### PR TITLE
Fix android_chrome_strings XTBs

### DIFF
--- a/android/java/strings/translations/android_chrome_strings_am.xtb
+++ b/android/java/strings/translations/android_chrome_strings_am.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="am">
-<translation id="1006017844123154345">መስመር ላይ ክፈት</translation>
-<translation id="1028699632127661925">ወደ <ph name="DEVICE_NAME" /> በመላክ ላይ...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" />ን በማከል ላይ...</translation>
-<translation id="1041308826830691739">ከድር ጣቢያዎች</translation>
-<translation id="1049743911850919806">ማንነት የማያሳውቅ</translation>
-<translation id="10614374240317010">በጭራሽ አልተቀመጠም</translation>
-<translation id="1067922213147265141">ሌሎች የGoogle አገልግሎቶች</translation>
-<translation id="1068672505746868501">በ<ph name="SOURCE_LANGUAGE" /> ውስጥ ገጾችን በጭራሽ አትተርጉም</translation>
-<translation id="107147699690128016">የፋይል ቅጥያውን ከቀየሩት ፋይሉ በተለየ መተግበሪያ ሊከፈት ይችላል፣ እና መሣሪያዎን ሊጎዳ ይችላል።</translation>
-<translation id="1100066534610197918">በቡድን ውስጥ አዲስ ትር ይክፈቱ</translation>
-<translation id="1105960400813249514">የማያ ገጽ ቀረጻ</translation>
-<translation id="1111673857033749125">በሌሎች መሣሪያዎችዎ ላይ የተቀመጡ ዕልባቶችዎ እዚህ ብቅ ይላሉ።</translation>
-<translation id="1113597929977215864">የተቃለለ እይታን አሳይ</translation>
-<translation id="1121094540300013208">የአጠቃቀም እና የብልሽት ሪፖርቶች</translation>
-<translation id="1124772482545689468">ተጠቃሚ</translation>
-<translation id="1129510026454351943">ዝርዝሮች፦ <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 ውርድን በመጠባበቅ ላይ}one{# ውርዶችን በመጠባበቅ ላይ}other{# ውርዶችን በመጠባበቅ ላይ}}</translation>
-<translation id="1145536944570833626">ነባሩን ውሂብ ይሰርዙ።</translation>
-<translation id="1146678959555564648">ምናባዊ ዕውነታ አስገባ</translation>
-<translation id="116280672541001035">ጥቅም ላይ የዋለው</translation>
-<translation id="1171770572613082465">የ«ከፍተኛ ጣቢያዎች» አዝራሩን መታ በማድረግ ታዋቂ ድር ጣቢያዎችን ይመልከቱ</translation>
-<translation id="1173894706177603556">ዳግም ሰይም</translation>
-<translation id="1178581264944972037">ለአፍታ አቁም</translation>
-<translation id="1181037720776840403">አስወግድ</translation>
-<translation id="1188239144602654184">AR ያስገቡ</translation>
-<translation id="1197267115302279827">ዕልባቶችን ውሰድ</translation>
-<translation id="119944043368869598">ሁሉንም አጽዳ</translation>
-<translation id="1201402288615127009">ቀጣይ</translation>
-<translation id="1204037785786432551">የማውረጃ አገናኝ</translation>
-<translation id="1206892813135768548">የአገናኝ ጽሑፍ ቅዳ</translation>
-<translation id="1208340532756947324">በመላ መሣሪያዎች ላይ ስምረትን ማብራት ለማስመር እና ግላዊነትን ለማላበስ</translation>
-<translation id="1209206284964581585">ለአሁን ደብቅ</translation>
-<translation id="1227058898775614466">የዳሰሳ ታሪክ</translation>
-<translation id="1231733316453485619">አስምር ይብራ?</translation>
-<translation id="123724288017357924">የተሸጎጠ ይዘትን ችላ በማለት የአሁኑን ገጽ ዳግም ጫን</translation>
-<translation id="124116460088058876">ተጨማሪ ቋንቋዎች</translation>
-<translation id="124678866338384709">የአሁኑን ትር ዝጋ</translation>
-<translation id="1258753120186372309">Google doodle፦ <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">ይፈልጉ እና ያስሱ</translation>
-<translation id="1264974993859112054">ሰፖርቶች</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> ን ማጋራት አልተቻለም።</translation>
-<translation id="1272079795634619415">አቁም</translation>
-<translation id="1283039547216852943">ለመዘርጋት መታ ያድርጉ</translation>
-<translation id="1285320974508926690">ይህን ጣቢያ በጭራሽ አትተርጉም</translation>
-<translation id="1291207594882862231">ታሪክ፣ ኩኪዎች፣ የጣቢያ ውሂብ፣ መሸጎጫን አጽዳ…</translation>
-<translation id="129382876167171263">በድር ጣቢያዎች የተቀመጡ ፋይሎች እዚህ ይታያሉ</translation>
-<translation id="129553762522093515">በቅርብ ጊዜ የተዘጉ</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - ከ<ph name="DEVICE_NAME" /> የተላከ</translation>
-<translation id="1310482092992808703">ትሮችን ይሰብስቡ</translation>
-<translation id="1327257854815634930">የዳሰሳ ታሪክ ተከፍቷል</translation>
-<translation id="1331212799747679585">Chrome መዘመን አይችልም። ተጨማሪ አማራጮች</translation>
-<translation id="1332501820983677155">የGoogle Chrome ባህሪ አቋራጮች</translation>
-<translation id="1360432990279830238">ዘግተው ወጥተው ስምረት ይጥፋ?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> ጣቢያ ተክሏል</translation>
-<translation id="1373696734384179344">የተመረጠውን ይዘት ለማውረድ በቂ ያልሆነ ማህደረ ትውስታ።</translation>
-<translation id="1376578503827013741">በማስላት ላይ…</translation>
-<translation id="1383876407941801731">ፍለጋ </translation>
-<translation id="1384959399684842514">የሚወርደው ላፍታ ቆሟል</translation>
-<translation id="1386674309198842382">ገባሪ ከ<ph name="LAST_UPDATED" /> ቀናት በፊት</translation>
-<translation id="1397811292916898096">በ<ph name="PRODUCT_NAME" /> ይፈልጉ</translation>
-<translation id="1404122904123200417">በ<ph name="WEBSITE_URL" /> ውስጥ ተካትቷል</translation>
-<translation id="1406000523432664303">«አትከታተል»</translation>
-<translation id="1407135791313364759">ሁሉንም ክፈት</translation>
-<translation id="1409426117486808224">ለክፍት ትሮች የተቃለለ እይታ</translation>
-<translation id="1409879593029778104">ፋይሉ አስቀድሞ ስላለ <ph name="FILE_NAME" />ን ማውረድ ታግዷል።</translation>
-<translation id="1414981605391750300">Googleን በማነጋገር ላይ።  ወደ አንድ ደቂቃ ሊወስድ ይችላል…</translation>
-<translation id="1416550906796893042">የመተግበሪያ ስሪት</translation>
-<translation id="1430915738399379752">አትም</translation>
-<translation id="1446450296470737166">ሙሉ የMIDI መሣሪያዎች መቆጣጠርን ያስችላል</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> ን ማጋራት አይቻልም</translation>
-<translation id="145097072038377568">በAndroid ቅንብሮች ውስጥ ጠፍቷል።</translation>
-<translation id="1477626028522505441">በአገልጋይ ችግሮች ምክንያት <ph name="FILE_NAME" />ን ማውረድ አልተሳካም።</translation>
-<translation id="1506061864768559482">የፍለጋ ፕሮግራም</translation>
-<translation id="1513352483775369820">ዕልባቶች እና የድር ታሪክ</translation>
-<translation id="1513858653616922153">የይለፍ ቃል ሰርዝ</translation>
-<translation id="1516229014686355813">ለመፈለግ መታ ያድርጉ የተመረጠውን ቃልን እና አሁን ያለውን ገጽ እንደ አውድ አድርጎ ወደ Google ፍለጋ ይልካቸዋል። በ<ph name="BEGIN_LINK" />ቅንብሮች<ph name="END_LINK" /> ውስጥ ሊያጠፉት ይችላሉ።</translation>
-<translation id="1521774566618522728">ገባሪ ዛሬ</translation>
-<translation id="1544826120773021464">የGoogle መለያዎን ለማቀናበር የ«መለያን አቀናብር» አዝራሩን መታ ያድርጉት</translation>
-<translation id="1549000191223877751">ወደ ሌላ መስኮት ውሰድ</translation>
-<translation id="1553358976309200471">Chromeን አዘምን</translation>
-<translation id="1569387923882100876">የተገናኘ መሣሪያ</translation>
-<translation id="1571304935088121812">የተጠቃሚ ስምን ቅዳ</translation>
-<translation id="1612196535745283361">Chrome መሣሪያዎችን መቃኘት እንዲችል የአካባቢ መዳረሻ ያስፈልገዋል። የአካባቢ መዳረሻ <ph name="BEGIN_LINK" />ለዚህ መሣሪያ ጠፍቷል<ph name="END_LINK" />።</translation>
-<translation id="1620510694547887537">ካሜራ</translation>
-<translation id="1623104350909869708">ይህ ገጽ ተጨማሪ መገናኛዎችን እንዳይፈጥር አግድ</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 የተመረጠ ንጥልን አስወግድ}one{# የተመረጡ ንጥሎችን አስወግድ}other{# የተመረጡ ንጥሎችን አስወግድ}}</translation>
-<translation id="164269334534774161"><ph name="CREATION_TIME" /> ላይ የነበረ የዚህን ገጽ የመስመር ውጪ ቅጂ በመመልከት ላይ ነዎት</translation>
-<translation id="1644574205037202324">ታሪክ</translation>
-<translation id="1647391597548383849">ካሜራዎን ይድረሱ</translation>
-<translation id="1660204651932907780">ጣቢያዎች ድምጽን እንዲያጫውቱ ፍቀድ (የሚመከር)</translation>
-<translation id="1670399744444387456">መሠረታዊ</translation>
-<translation id="1671236975893690980">ውርድ በመጠባበቅ ላይ...</translation>
-<translation id="1672586136351118594">ዳግም አታሳይ</translation>
-<translation id="1692118695553449118">አመሳስል በርቷል</translation>
-<translation id="169515064810179024">ጣቢያዎች የእንቅስቃሴ ዳሳሾችን እንዳይደርሱ ያግዱ</translation>
-<translation id="1717218214683051432">የእንቅስቃሴ ዳሳሾች</translation>
-<translation id="1718835860248848330">የመጨረሻው ሰዓት</translation>
-<translation id="1736419249208073774">አስስ</translation>
-<translation id="1743802530341753419">ጣቢያዎች ከአንድ መሣሪያ ጋር እንዲገናኙ ከመፍቀድ በፊት ጠይቅ (የሚመከር)</translation>
-<translation id="1749561566933687563">የእርስዎን ዕልባቶች ያስምሩ</translation>
-<translation id="17513872634828108">ትሮችን ክፈት</translation>
-<translation id="1779089405699405702">ስውር ምስል መፍቻ</translation>
-<translation id="1782483593938241562">ማብቂያ ቀን <ph name="DATE" /></translation>
-<translation id="1791662854739702043">የተጫነ</translation>
-<translation id="1792959175193046959">በማንኛውም ጊዜ ነባሪውን የማውረጃ ቦታ ይቀይሩ</translation>
-<translation id="1807246157184219062">ብርሃን</translation>
-<translation id="1810845389119482123">የመጀመሪያ የስምረት ማዋቀር አልተጠናቀቀም</translation>
-<translation id="1821253160463689938">የእርስዎን ምርጫዎች ለማስታወስ ኩኪዎችን ይጠቀማል፣ እነዚያን ገጾች ባይጎበኙም እንኳ</translation>
-<translation id="1829244130665387512">በዚህ ገጽ ውስጥ የተገኘ</translation>
-<translation id="1853692000353488670">አዲስ ማንነት የማያሳውቅ ትር</translation>
-<translation id="1856325424225101786">ቀላል ሁነታን ዳግም ያስጀምሩ?</translation>
-<translation id="1868024384445905608">Chrome አሁን ፋይሎችን በበለጠ ፍጥነት ያወርዳል</translation>
-<translation id="1883903952484604915">የእኔ ፋይሎች</translation>
-<translation id="1887786770086287077">የአካባቢ መዳረሻ ለዚህ መሣሪያ ጠፍቷል። በ<ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ያብሩት።</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> በChrome ውስጥ ይከፈታል። በመቀጠልዎ በChrome <ph name="BEGIN_LINK1" />አገልግሎት ውል<ph name="END_LINK1" /> እና <ph name="BEGIN_LINK2" />የግላዊነት ማስታወቂያ<ph name="END_LINK2" /> ተስማምተዋል።</translation>
-<translation id="1919345977826869612">ማስታወቂያዎች</translation>
-<translation id="1919950603503897840">ዕውቂያዎችን ምረጥ</translation>
-<translation id="1922076542920281912">Chrome የእርስዎን መገኛ አካባቢ እንዲደርስበት ለማድረግ፣ በተጨማሪ በ <ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ መገኛ አካባቢን ያብሩ።</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">ዝማኔዎች</translation>
-<translation id="19288952978244135">Chromeን ዳግም ክፈት።</translation>
-<translation id="1933845786846280168">የተመረጠው ትር</translation>
-<translation id="194341124344773587">በ<ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ፍቃዶችን ለChrome ያብሩ።</translation>
-<translation id="1943432128510653496">የይለፍ ቃላትን አስቀምጥ</translation>
-<translation id="1952172573699511566">ሲቻል፣ ድር ጣቢያዎች በእርስዎ ተመራጭ ቋንቋ ጽሑፍ ይታያሉ።</translation>
-<translation id="1960290143419248813">የChrome ዝማኔዎች ከአሁን በኋላ ለዚህ የAndroid ዝማኔዎች አይደገፉም</translation>
-<translation id="1966710179511230534">እባክዎ የመግቢያ ዝርዝሮችዎን ያዘምኑ።</translation>
-<translation id="1974060860693918893">የላቀ</translation>
-<translation id="1984705450038014246">የChrome ውሂብዎን ያስምሩ</translation>
-<translation id="1984937141057606926">የተፈቀደ፣ ከሶስተኛ ወገን በቀር</translation>
-<translation id="1986685561493779662">ስሙ አስቀድሞ አለ</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> አዝራር</translation>
-<translation id="1989112275319619282">አስስ</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> መጣመር ይፈልጋል</translation>
-<translation id="1994173015038366702">የጣቢያ ዩአርኤል</translation>
-<translation id="2000419248597011803">ፍለጋዎችን ከአድራሻ አሞሌው እና ከፍለጋ ሳጥኑ እና አንዳንድ ኩኪዎችን ወደ ነባሪው የፍለጋ ፕሮግራምዎ ይልካል</translation>
-<translation id="2002537628803770967">Google Payን የሚጠቀሙ ክሬዲት ካርዶች እና አድራሻዎች</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ፋይል}one{# ፋይሎች}other{# ፋይሎች}}</translation>
-<translation id="2017836877785168846">በአድራሻ አሞሌው ውስጥ ታሪክን እና ራስ-ሰር ማጠናቀቆችን ያጸዳል።</translation>
-<translation id="2021896219286479412">የሙሉ ማያ ገጽ ጣቢያ መቆጣጠሪያዎች</translation>
-<translation id="2038563949887743358">የዴስክቶፕ ጣቢያን ጠይቅን አብራ</translation>
-<translation id="2041019821020695769">Chrome ማሳወቂያዎችን እንዲልክልዎት ለማድረግ፣ በተጨማሪ በ <ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ማሳወቂያዎችን ያብሩ።</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> እንዲሁም በChrome ውስጥ ውሂብ አለው</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">ጣቢያ ባለበት ቆሟል</translation>
-<translation id="2063713494490388661">ለመፈለግ መታ ያድርጉ</translation>
-<translation id="2067805253194386918">ጽሑፍ</translation>
-<translation id="2079545284768500474">ቀልብስ</translation>
-<translation id="2082238445998314030">ውጤት <ph name="RESULT_NUMBER" /> ከ<ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">ድምፅ</translation>
-<translation id="2096012225669085171">በመላ መሣሪያዎች ላይ ያመሳስሉ እና ግላዊነት ያላብሱ</translation>
-<translation id="2100273922101894616">በራስ-ግባ</translation>
-<translation id="2100314319871056947">በትናንሽ ክፍሎች ጽሑፉን ለማጋራት ይሞክሩ</translation>
-<translation id="2107397443965016585">ጣቢያዎች የተጠበቀ ይዘትን እንዲያጫውቱ ከመፍቀድዎ በፊት ይጠይቁ (የሚመከር)</translation>
-<translation id="2111511281910874386">ወደዚህ ገጽ ይሂዱ</translation>
-<translation id="2122601567107267586">መተግበሪያውን መክፈት አልተቻለም</translation>
-<translation id="2126426811489709554">በChrome የጎለበተ</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> ተቀምጧል</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> ተዘግቷል</translation>
-<translation id="2139186145475833000">ወደ መነሻ ማያ ገጽ አክል</translation>
-<translation id="2146738493024040262">ቅጽበታዊ መተግበሪያን ክፈት</translation>
-<translation id="2148716181193084225">ዛሬ</translation>
-<translation id="2154484045852737596">ካርትን ያርትዑ</translation>
-<translation id="2154710561487035718">URL ቅዳ</translation>
-<translation id="2156074688469523661">ቀሪ ጣቢያዎች (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">የሆነ ነገር ከስልክዎ ወደ ሌላ መሣሪያ ለማጋራት በሁለቱም መሣሪያዎች ላይ በChrome ቅንብሮች ውስጥ ስምረትን ያብሩ</translation>
-<translation id="2170088579611075216">ቪአር ይፍቀዱ እና ያስገቡ</translation>
-<translation id="218608176142494674">ማጋራት</translation>
-<translation id="2227444325776770048">እንደ <ph name="USER_FULL_NAME" /> ሆነው ይቀጥሉ</translation>
-<translation id="2234876718134438132">ማመሳሰል እና የGoogle አገልግሎቶች</translation>
-<translation id="2259659629660284697">የይለፍ ቃላትን ወደ ውጭ ላክ...</translation>
-<translation id="2268044343513325586">አጽዳ</translation>
-<translation id="2286841657746966508">የመላኪያ አድራሻ</translation>
-<translation id="2289270750774289114">አንድ ጣቢያ በአቅራቢያ ያሉ ብሉቱዝ መሣሪያዎችን ፈልጎ ለማግኘት ሲፈልግ ጠይቅ (የሚመከር)</translation>
-<translation id="230115972905494466">ምንም ተኳሃኝ መሣሪያዎች አልተገኙም</translation>
-<translation id="2315043854645842844">የደንበኛ ወገን ዕውቅና ማረጋገጫ ምርጫ በስርዓተ-ክወናው አይደገፍም።</translation>
-<translation id="2318045970523081853">ጥሪ ለማድረግ መታ ያድርጉ</translation>
-<translation id="2321086116217818302">የይለፍ ቃላትን በማዘጋጀት ላይ…</translation>
-<translation id="2321958826496381788">ይህን በሚመች ሁኔታ ማንበብ እስኪችሉ ድረስ ተንሸራታቹን ይጎትቱት። በአንድ አንቀጽ ላይ ሁለቴ መታ ካደረጉ በኋላ ጽሑፍ ቢያንስ የዚህ ያህል ትልቀት ሊኖረው ይገባል።</translation>
-<translation id="2323763861024343754">የጣቢያ ማከማቻ</translation>
-<translation id="2328985652426384049">መግባት አልተቻለም</translation>
-<translation id="2330129964253841015">የእርስዎ የይለፍ ቃላት ከተነጠቁ ማስጠንቀቂያ ያግኙ</translation>
-<translation id="2349710944427398404">መለያዎች፣ ዕልባቶች እና የተቀመጡ ቅንብሮችን ጨምሮ Chrome የተጠቀመው ጠቅላላ ውሂብ</translation>
-<translation id="2353636109065292463">የበይነመረብ ግንኙነትዎን ይፈትሹ</translation>
-<translation id="2359808026110333948">ቀጥል</translation>
-<translation id="2369533728426058518">ክፍት ትሮች</translation>
-<translation id="2387895666653383613">የጽሑፍ ልኬት</translation>
-<translation id="2394602618534698961">የሚያወርዷቸው ፋይሎች እዚህ ይታያሉ</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> ሜባ</translation>
-<translation id="2407481962792080328">ወደ የእርስዎ የ Google መለያ ሲገቡ፣ ይህ ባህሪ ይበራል</translation>
-<translation id="2410754283952462441">አንድ መለያ ይምረጡ</translation>
-<translation id="2414886740292270097">ጨለማ</translation>
-<translation id="2416359993254398973">Chrome ለዚህ ጣቢያ የእርስዎን ካሜራ ለመድረስ ፈቃድ ይፈልጋል።</translation>
-<translation id="2426805022920575512">ሌላ መለያ ይምረጡ</translation>
-<translation id="2433507940547922241">ገጽታ</translation>
-<translation id="2434158240863470628">ማውረድ ተጠናቅቋል <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">የአካባቢ መዳረሻ</translation>
-<translation id="2450083983707403292"><ph name="FILE_NAME" />ን እንደገና ማውረድ መጀመር ይፈልጋሉ?</translation>
-<translation id="2482878487686419369">ማስታወቂያዎች</translation>
-<translation id="2490684707762498678">በ<ph name="APP_NAME" /> የሚተዳደር ነው</translation>
-<translation id="2494974097748878569">በChrome ውስጥ Google ረዳት</translation>
-<translation id="2496180316473517155">ታሪክ አሰሳ</translation>
-<translation id="2497852260688568942">ስምረት በእርስዎ አስተዳዳሪ ተሰናክሏል</translation>
-<translation id="2498359688066513246">እገዛ እና ግብረመልስ</translation>
-<translation id="2501278716633472235">ወደ ኋላ ተመለስ</translation>
-<translation id="2513403576141822879">ከግላዊነት፣ ደህንነት እና የውሂብ ስብስብ ጋር ለሚዛመዱ ተጨማሪ ቅንብሮች <ph name="BEGIN_LINK" />ስምረት እና የGoogle አገልግሎቶች<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">በቀላል ሁነታ ላይ Chrome ገጾችን በበለጠ ፍጥነት የሚጭን ሲሆን እስከ 60 በመቶ ያነሰ ውሂብ ይጠቀማል። የሚጎበኟቸው ገጾችን ለማትባት Chrome የድር ትራፊክዎን ወደ Google ይልካል። <ph name="BEGIN_LINK" />የበለጠ ለመረዳት<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">የሚጎበኙዋቸውን ገጾች ዩአርኤሎች ወደ Google ይልካል</translation>
-<translation id="2532336938189706096">የድር ዕይታ</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> ንጥሎች ተሰርዟል</translation>
-<translation id="2536728043171574184">የዚህን ገጽ የመስመር ውጭ ቅጂ በመመልከት ላይ</translation>
-<translation id="2546283357679194313">ኩኪዎች እና የጣቢያ ውሂብ</translation>
-<translation id="2567385386134582609">ምስል</translation>
-<translation id="257088987046510401">ገፅታዎች </translation>
-<translation id="2570922361219980984">የአካባቢ መዳረሻ እንዲሁም ለዚህ መሣሪያ ጠፍቷል። በ<ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ያብሩት።</translation>
-<translation id="257931822824936280">ተዘርግቷል - ለመሰብሰብ ጠቅ ያድርጉ</translation>
-<translation id="2581165646603367611">ይሄ Chrome አስፈላጊ ናቸው ብሎ የማያስባቸውን ኩኪዎች፣ መሸጎጫ እና ሌሎች ጣቢያዎች ያጸዳል።</translation>
-<translation id="2586657967955657006">የቅንጥብ ሰሌዳ</translation>
-<translation id="2587052924345400782">አዲስ ስሪት ይገኛል</translation>
-<translation id="2593272815202181319">ሞኖስፔስ</translation>
-<translation id="2612676031748830579">የካርድ ቁጥር</translation>
-<translation id="2621115761605608342">ጃቫስክሪፕትን ለአንድ የተወሰነ ጣቢያ ፍቀድ።</translation>
-<translation id="2625189173221582860">የይለፍ ቃል ተቀድቷል።</translation>
-<translation id="2631006050119455616">ተቀምጧል</translation>
-<translation id="2647434099613338025">ቋንቋ አክል</translation>
-<translation id="2650751991977523696">ፋይሉ እንደገና ይውረድ?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ኦዲዮ ፋይል}one{# ኦዲዮ ፋይሎች}other{# ኦዲዮ ፋይሎች}}</translation>
-<translation id="2653659639078652383">አስገባ</translation>
-<translation id="2677748264148917807">ለቅቀህ ውጣ</translation>
-<translation id="2704606927547763573">ተቀድቷል</translation>
-<translation id="2707726405694321444">ገጹን አድስ</translation>
-<translation id="2709516037105925701">ራስ-ሙላ</translation>
-<translation id="2717722538473713889">ኢሜይል አድራሻዎች</translation>
-<translation id="2728754400939377704">በጣቢያ ደርድር</translation>
-<translation id="2744248271121720757">አንድ ቃል በቅጽበት ለመፈለግ ወይም ተዛማጅ እርምጃዎችን ለመመልከት አንድ ቃል መታ ያድርጉ</translation>
-<translation id="2760989362628427051">የእርስዎ መሣሪያ በጨለማ ገጽታ ላይ ሲሆን ወይም ባትሪ ቆጣሪ ሲበራ የጨለማ ገጽታን አብራ</translation>
-<translation id="2762000892062317888">አሁን</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> ሰከንዶች ይቀራሉ</translation>
-<translation id="2779651927720337254">አልተሳካም</translation>
-<translation id="2781151931089541271">1 ሰከንድ ይቀራል</translation>
-<translation id="2801022321632964776">ቋንቋዎን በቅርብ ጊዜው የChrome ስሪት ለማግኘት ያዘምኑ</translation>
-<translation id="2810645512293415242">ውሂብን ለመቆጠብ እና በበለጠ ፍጥነት ለመጫን የተቃለለ ገጽ።</translation>
-<translation id="281504910091592009">የተቀመጡ የይለፍ ቃላትን በእርስዎ <ph name="BEGIN_LINK" />Google መለያ<ph name="END_LINK" /> ውስጥ ይመልከቱ እና ያስተዳድሩ</translation>
-<translation id="2818669890320396765">የእርስዎን ዕልባቶች በሁሉም መሣሪያዎችዎ ላይ ለማግኘት በመለያ መግባት እና ስምረትን ማብራት ለማግኘት</translation>
-<translation id="2822354292072154809">እርግጠኛ ነዎት ሁሉንም የ<ph name="CHOSEN_OBJECT_NAME" /> ጣቢያ ፈቃዶችን ዳግም ማስጀመር ይፈልጋሉ?</translation>
-<translation id="2836148919159985482">ከሙሉ ማያ ገጽ ለመውጣት የተመለስ አዝራሩን ይንኩ።</translation>
-<translation id="2842985007712546952">ወላጅ አቃፊ</translation>
-<translation id="2858138569776157458">ከፍተኛ ጣቢያዎች</translation>
-<translation id="2860954141821109167">በዚህ መሣሪያ ላይ የስልክ መተግበሪያ እንደነቃ ያረጋግጡ</translation>
-<translation id="2870560284913253234">ጣቢያ</translation>
-<translation id="2874939134665556319">ቀዳሚ ትራክ</translation>
-<translation id="2876369937070532032">የእርስዎ ደኅንነት አደጋ ላይ ሲወድቅ እርስዎ የሚጎበኙዋቸውን አንዳንድ ገጾች ዩአርኤሎች ወደ Google ይልካል።</translation>
-<translation id="2888126860611144412">ስለChrome</translation>
-<translation id="2891154217021530873">ገጹን መጫን አቁም</translation>
-<translation id="2893180576842394309">Google ፍለጋን እና ሌሎች የGoogle አገልግሎቶችን ግላዊነት ለማላበስ ሲል ታሪክዎን ሊጠቀም ይችላል።</translation>
-<translation id="2898264748040935573">የተከማቸ ይለፍ ቃል ያርትዑ</translation>
-<translation id="2900528713135656174">ክስተት ፍጠር</translation>
-<translation id="290376772003165898">ገጽ በ<ph name="LANGUAGE" /> አይደለም?</translation>
-<translation id="2904414404539560095">በሙሉ ቁመቱ ላይ የተከፈተ ትር የሚጋሩ የመሣሪያዎች ዝርዝር።</translation>
-<translation id="2910701580606108292">ጣቢያዎች ጥበቃ የሚደረግለትን ይዘትን እንዲያጫውቱ ከመፍቀድ በፊት ጠይቅ</translation>
-<translation id="2913331724188855103">ጣቢያዎች የኩኪ ውሂብ እንዲያስቀምጡ እና እንዲያነቡ ይፍቀዱ (የሚመከር)</translation>
-<translation id="2923908459366352541">ስም ልክ ያልሆነ ነው</translation>
-<translation id="2932150158123903946">የGoogle <ph name="APP_NAME" /> ማከማቻ</translation>
-<translation id="2942036813789421260">የቅድመ-እይታ ትር ተዘግቷል</translation>
-<translation id="2956410042958133412">ይህ መለያ የሚቀናበረው በ<ph name="PARENT_NAME_1" /> እና <ph name="PARENT_NAME_2" /> ነው።</translation>
-<translation id="2962095958535813455">ወደ ማንነት የማያሳውቁ ትሮች ተቀይሯል</translation>
-<translation id="2968755619301702150">የእውቅና ማረጋገጫ መመልከቻ</translation>
-<translation id="2979025552038692506">የተመረጠው ማንነት የማያሳውቅ ትር</translation>
-<translation id="2987620471460279764">ከሌሎች መሣሪያዎች የተጋራ ጽሑፍ</translation>
-<translation id="2989523299700148168">በቅርብ ጊዜ የተጎበኙ</translation>
-<translation id="2996291259634659425">የይለፍ ሐረግ ይፍጠሩ</translation>
-<translation id="2996809686854298943">ዩአርኤል ያስፈልጋል</translation>
-<translation id="300526633675317032">ይህ ሁሉንም <ph name="SIZE_IN_KB" /> የድር ጣቢያ ማከማቻ ያጸዳል።</translation>
-<translation id="3016635187733453316">ይህ መሣሪያ ወደ በይነ መረብ እንደተገናኘ እርግጠኛ ይሁኑ</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> ኪባ ወርዷል</translation>
-<translation id="3029704984691124060">የይለፍ ሐረጎቹ አይዛመዱም</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />እገዛ ያግኙ<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">አካባቢ ጠፍቷል፤ በ<ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ያብሩት።</translation>
-<translation id="3058498974290601450">ስምረትን በማንኛውም ጊዜ በቅንብሮች ውስጥ ማብራት ይችላሉ።</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> ዕልባት}one{<ph name="BOOKMARKS_COUNT_MANY" /> ዕልባቶች}other{<ph name="BOOKMARKS_COUNT_MANY" /> ዕልባቶች}}</translation>
-<translation id="3089395242580810162">ማንነትን በማያሳውቅ ትር ክፈት</translation>
-<translation id="3115898365077584848">መረጃ አሳይ</translation>
-<translation id="3123473560110926937">በአንዳንድ ጣቢያዎች ላይ ታግዷል</translation>
-<translation id="3137521801621304719">ከማንነት የማያሳውቅ ሁነታ ይውጡ</translation>
-<translation id="3143515551205905069">ስምረትን ሰርዝ</translation>
-<translation id="3157842584138209013">ከተጨማሪ አማራጮች አዝራር ላይ ምን ያህል ውሂብ እንዳስቀመጡ ይመልከቱ</translation>
-<translation id="3166827708714933426">የትር እና የመስኮት አቋራጮች</translation>
-<translation id="3181954750937456830">ደኅንነቱ የተጠበቀ አሰሳ (እርስዎን እና የእርስዎን መሣሪያ ከአደገኛ ጣቢያዎች ጥበቃ ያደርግላችኋል)</translation>
-<translation id="3190152372525844641">በ<ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ፍቃዶችን ለChrome ያብሩ።</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> የተከማቸ ውሂብ</translation>
-<translation id="3205824638308738187">በቃ ሊያልቅ ነው!</translation>
-<translation id="3207960819495026254">ዕልባት ተደርጎበታል</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> ተሰርዟል</translation>
-<translation id="321773570071367578">የእርስዎን የይለፍሐረግ ከረሱት ወይም ይህን ቅንብር መለወጥ ከፈለጉ <ph name="BEGIN_LINK" />ስምረትን ዳግም ያስጀምሩ<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">ማይክሮፎን</translation>
-<translation id="3232754137068452469">የድር መተግበሪያ</translation>
-<translation id="3236059992281584593">1 ደቂቃ ይቀራል</translation>
-<translation id="3244271242291266297">ወወ</translation>
-<translation id="3254409185687681395">ለእዚህ ገጽ ዕልባት አብጅ</translation>
-<translation id="3259831549858767975">በገጹ ላይ ያለውን ሁሉንም ነገር ይበልጥ አሳንስ</translation>
-<translation id="3269093882174072735">ምስል ጫን</translation>
-<translation id="3269956123044984603">ትሮችዎን ከሌሎች መሣሪያዎችዎ ለማግኘት በAndroid የመለያ ቅንብሮች ውስጥ «ውሂብን በራስ-አስምር»ን ያብሩ።</translation>
-<translation id="3277252321222022663">ጣቢያዎች ዳሳሾችን እንዲደርሱ ይፍቀዱላቸው (የሚመከር)</translation>
-<translation id="3282568296779691940">Chrome ውስጥ ይግቡ</translation>
-<translation id="3288003805934695103">ገጹን እንደገና መጫን</translation>
-<translation id="32895400574683172">ማሳወቂያዎች ይፈቀዳሉ</translation>
-<translation id="3295530008794733555">በበለጠ ፍጥነት ያስሱ። ያነሰ ውሂብን ይጠቀሙ።</translation>
-<translation id="3295602654194328831">መረጃ ደብቅ</translation>
-<translation id="3298243779924642547">ቀላል</translation>
-<translation id="3303414029551471755">ይዘቱን ማውረድ ይቀጥል?</translation>
-<translation id="3306398118552023113">ይህ መተግበሪያ በChrome ውስጥ እያሄደ ነው</translation>
-<translation id="3315103659806849044">እርስዎ በአሁኑ ጊዜ የእርስዎን የስምረት እና የGoogle አገልግሎት ቅንብሮችን እያበጁ ነው። ስምረትን ማብራቱን ለመጨረስ ከማያ ገጹ ታችኛው ክፍል አጠገብ ያለውን የአረጋግጥ አዝራር መታ ያድርጉ። ወደ ላይ ያስሱ</translation>
-<translation id="3328801116991980348">የጣቢያ መረጃ</translation>
-<translation id="3333961966071413176">ሁሉም እውቂያዎች</translation>
-<translation id="3334729583274622784">የፋይል ቅጥያ ይቀየር?</translation>
-<translation id="3341058695485821946">ምን ያህል ውሂብ እንዳስቀመጡ ይመልከቱ</translation>
-<translation id="3350687908700087792">ሁሉንም ማንነት የማያሳውቅ ትሮችን ይዝጉ</translation>
-<translation id="3353615205017136254">ቀላል ገጽ በGoogle ቀርቧል። ኦርጂናሉን ገጽ ለመጫን ኦርጂናል ጫን የሚለውን አዝራር መታ ያድርጉ።</translation>
-<translation id="3367813778245106622">ስምረትን ለመጀመር እንደገና ይግቡ</translation>
-<translation id="3374023511497244703">የእርስዎ እልባቶች፣ ታሪክ፣ የይለፍ ቃላት እና ሌላ የ Chrome ውሂብ ከእንግዲህ ወደ የእርስዎ Google መለያ ይሰምራል</translation>
-<translation id="3384347053049321195">ምስል አጋራ</translation>
-<translation id="3386292677130313581">ጣቢያዎች አካባቢዎን እንዲያውቁ ከመፍቀድዎ በፊት ይጠይቅ (የሚመከር)</translation>
-<translation id="3387650086002190359">በስርዓተ-ፋይል ስህተቶች ምክንያት <ph name="FILE_NAME" />ን ማውረድ አልተሳካም።</translation>
-<translation id="3389286852084373014">ጽሑፍ ከልክ በላይ ግዙፍ ነው</translation>
-<translation id="3398320232533725830">የዕልባቶች አስተዳዳሪን ክፈት</translation>
-<translation id="3414952576877147120">መጠን፦</translation>
-<translation id="3443221991560634068">የአሁኑን ገጽ ዳግም ጫን</translation>
-<translation id="3445014427084483498">ልክ አሁን</translation>
-<translation id="3478363558367712427">የፍለጋ ፕሮግራምዎን መምረጥ ይችላሉ</translation>
+<translation id="6910211073230771657">ተሰርዟል</translation>
+<translation id="6965382102122355670">እሺ</translation>
+<translation id="5301954838959518834">እሺ፣ ገባኝ</translation>
+<translation id="7658239707568436148">ይቅር</translation>
 <translation id="3479552764303398839">አሁን አይደለም</translation>
-<translation id="3492207499832628349">አዲስ ማንነት የማያሳውቅ ትር</translation>
-<translation id="3493531032208478708">ስለሚጠቆም ይዘት <ph name="BEGIN_LINK" />የበለጠ ለመረዳት<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">ትክክለኛ እውነታ</translation>
-<translation id="3518985090088779359">ተቀበል እና ቀጥል</translation>
-<translation id="3522247891732774234">ዝማኔ ይገኛል። ተጨማሪ አማራጮች</translation>
-<translation id="3524138585025253783">የገንቢ ዩአይ</translation>
-<translation id="3527085408025491307">አቃፊ</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> ኪባ ይገኛል</translation>
-<translation id="3549657413697417275">የራስዎን ታሪክ ይፈልጉ</translation>
-<translation id="3557336313807607643">ወደ እውቂያዎች አክል</translation>
-<translation id="3566923219790363270">Chrome አሁንም ድረስ ቪአር በማዘጋጀት ላይ ነው። Chromeን በኋላ ላይ ዳግም ያስጀምሩ።</translation>
-<translation id="3568688522516854065">ትሮችዎን ከሌሎች መሣሪያዎችዎ በመለያ መግባት እና ስምረትን ማብራት ለማግኘት</translation>
-<translation id="3587482841069643663">ሁሉም</translation>
-<translation id="358794129225322306">አንድ ጣቢያ በራስ-ሰር በርካታ ፋይሎችን እንዲያወርድ ይፍቀዱ።</translation>
-<translation id="3590487821116122040">Chrome አላስፈላጊ ነው የሚያስበው የጣቢያ ማከማቻ (ለምሳሌ፦ ምንም የተቀመጡ ቅንብሮች የሌላቸው ጣቢያዎች ወይም እርስዎ ብዙ ጊዜ የማይጎበኟቸው)</translation>
-<translation id="3599863153486145794">ታሪክን በመለያ ከገቡ ሁሉም መሣሪያዎች ላይ ያጸዳል። የእርስዎ Google መለያ <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" /> ላይ ሌሎች የአሰሳ ታሪክ ዓይነቶች ሊኖረው ይችላል</translation>
-<translation id="3600792891314830896">ድምጽን በሚያጫውቱ ጣቢያዎች ላይ ድምጸ-ከል አድርግ</translation>
-<translation id="3616113530831147358">ድምጽ</translation>
-<translation id="3631987586758005671">ለ <ph name="DEVICE_NAME" /> በማጋራት ላይ</translation>
-<translation id="3632295766818638029">የይለፍ ቃልን ግለጥ</translation>
-<translation id="363596933471559332">የተከማቹ ምስክርነቶችን በመጠቀም በራስ-ሰር ወደ የድር ጣቢያዎች መለያ ይግቡ። ባህሪው ሲጠፋ ወደ አንድ ድር ጣቢያ ከመግባትዎ በፊት ማረጋገጫ ይጠየቃሉ።</translation>
-<translation id="3658159451045945436">ዳግም ማስጀመር የተጎበኙ ጣቢያዎች ዝርዝር ጨምሮ የውሂብ ቁጠባዎን ታሪክ ይደመስሳል።</translation>
-<translation id="3692944402865947621">የማከማቻ ቦታው የማይገኝ ስለሆነ <ph name="FILE_NAME" />ን ማውረድ አልተሳካም።</translation>
-<translation id="3714981814255182093">የአግኝ አሞሌን ክፈት</translation>
-<translation id="3716182511346448902">ይህ ገጽ በጣም ብዙ ማህደረ ትውስታን ይጠቀማል፣ ስለዚህ Chrome ባለበት አቁሞታል።</translation>
-<translation id="3730075448226062617">Chrome የእርስዎን ማይክራፎን እንዲደርስ ለማድረግ፣ በ <ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ማይክራፎንን በተጨማሪ ያብሩ።</translation>
-<translation id="3739899004075612870">በ<ph name="PRODUCT_NAME" /> ውስጥ ዕልባት ተቀምጦለታል</translation>
-<translation id="3744111561329211289">የዳራ ስምረት</translation>
-<translation id="3771001275138982843">ዝማኔውን ማውረድ አልተቻለምም</translation>
-<translation id="3771033907050503522">ማንነት የማያሳውቁ ትሮች</translation>
-<translation id="3773755127849930740">ማጣመርን ለመፍቀድ <ph name="BEGIN_LINK" />ብሉቱዝን ያብሩ<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">ወደ መሣሪያዎችዎ ይላኩ</translation>
-<translation id="3778956594442850293">ወደ የመነሻ ገጽ ታክሏል</translation>
-<translation id="3789841737615482174">ጫን  </translation>
-<translation id="3810838688059735925">ቪዲዮ</translation>
-<translation id="3810973564298564668">አቀናብር</translation>
-<translation id="381841723434055211">ስልክ ቁጥሮች</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> የሚወርዱ ተሰርዘዋል</translation>
-<translation id="3822502789641063741">የጣቢያ ማከማቻ ይጽዳ?</translation>
-<translation id="385051799172605136">ተመለስ</translation>
-<translation id="3859306556332390985">ወደፊት ፈልግ</translation>
-<translation id="3894427358181296146">አቃፊ ያክሉ</translation>
-<translation id="3895926599014793903">ማጉላት አንቃን ያስገድዱ</translation>
-<translation id="3912508018559818924">ምርጡን ከድር ማግኘት…</translation>
-<translation id="3927692899758076493">ሳንስ ሰሪፍ</translation>
-<translation id="3928666092801078803">የእኔን ውሂብ አጣምር</translation>
-<translation id="393697183122708255">ምንም የነቃ የድምጽ ፍለጋ አይገኝም</translation>
-<translation id="395206256282351086">ፍለጋ እና የጣቢያ አስተያየት ጥቆማዎች ተሰናክለዋል</translation>
-<translation id="3955193568934677022">ጥበቃ የሚደረግበትን ይዘት እንዲያጫውቱ ለጣቢያዎች ፍቀድ (የሚመከር)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome ዝግጁ ሲሆን ገጽዎን ይጭነዋል}one{Chrome ዝግጁ ሲሆን ገጾችዎን ይጭነዋል}other{Chrome ዝግጁ ሲሆን ገጾችዎን ይጭነዋል}}</translation>
-<translation id="3963007978381181125">የእርስዎ የይለፍ ሐረግ ያለው ሰው ብቻ ነው የእርስዎን የተመሰጠረ ውሂብ ማንበብ የሚችለው። የይለፍ ሐረጉ ወደ Google አይላክም እንዲሁም አይከማችም። የእርስዎን የይለፍ ሐረግ ከረሱት ወይም ይህን ቅንብር መለወጥ ከፈለጉ ማሥመሩን ዳግም ማስጀመር ያስፈልገዎታል። <ph name="BEGIN_LINK" />የበለጠ ለመረዳት<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ማውረድ ተጠናቅቋል</translation>
-<translation id="397583555483684758">ስምረት መሥራት አቁሟል</translation>
-<translation id="3976396876660209797">ይህን አቋራጭ ያስወግዱትና እና ዳግም ይፍጠሩት</translation>
-<translation id="3985215325736559418"><ph name="FILE_NAME" />ን እንደገና ማውረድ ይፈእልጋሉ?</translation>
-<translation id="3987993985790029246">አገናኝ ቅዳ</translation>
-<translation id="3988213473815854515">መገኛ አካባቢ ተፈቅዷል</translation>
-<translation id="3988466920954086464">በዚህ ፓነል ውስጥ ቅጽበታዊ የፍለጋ ውጤቶችን ይመልከቱ</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">የማያስፈልግ ማከማቻ</translation>
-<translation id="4000212216660919741">ከመስመር ውጭ መነሻ</translation>
+<translation id="5317780077021120954">አስቀምጥ</translation>
+<translation id="4570913071927164677">ዝርዝሮች</translation>
+<translation id="8730621377337864115">ተከናውኗል</translation>
+<translation id="8261506727792406068">ሰርዝ</translation>
+<translation id="1181037720776840403">አስወግድ</translation>
+<translation id="5939518447894949180">ዳግም አስጀምር</translation>
 <translation id="4002066346123236978">ርዕስ</translation>
-<translation id="4008040567710660924">የተወሰነ ጣቢያ ኩኪዎችን ፍቀድ።</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ሰዓ}one{# ሰዓቶች}other{# ሰዓቶች}}</translation>
-<translation id="4046123991198612571">ቀጣይ ትራክ</translation>
-<translation id="4048707525896921369">ገጹን ትተው ሳይሄዱ በድር ጣቢያዎች ላይ ስላሉ ርዕሶች ይወቁ። ለመፈለግ መታ ያድርጉ አንድ ቃል እና በዙሪያው ያለውን አውድ ወደ Google ፍለጋ ይልክና ትርጓሜዎችን፣ ስዕሎችን፣ የፍለጋ ውጤቶችን እና ሌሎች ዝርዝሮችን ይመልሳል።
+<translation id="5916664084637901428">በርቷል</translation>
+<translation id="5860033963881614850">አጥፋ</translation>
+<translation id="6165508094623778733">የበለጠ ለመረዳት</translation>
+<translation id="6042308850641462728">ተጨማሪ</translation>
+<translation id="6040143037577758943">ዝጋ</translation>
+<translation id="780301667611848630">አይ፣ አመሰግናለሁ</translation>
+<translation id="1201402288615127009">ቀጣይ</translation>
+<translation id="2359808026110333948">ቀጥል</translation>
+<translation id="2653659639078652383">አስገባ</translation>
+<translation id="2079545284768500474">ቀልብስ</translation>
+<translation id="7649070708921625228">እገዛ</translation>
+<translation id="2148716181193084225">ዛሬ</translation>
+<translation id="7781829728241885113">ትናንት</translation>
+<translation id="6945221475159498467">ይምረጡ</translation>
+<translation id="7791543448312431591">አክል</translation>
+<translation id="6527303717912515753">አጋራ</translation>
+<translation id="1383876407941801731">ፍለጋ</translation>
+<translation id="3115898365077584848">መረጃ አሳይ</translation>
+<translation id="3295602654194328831">መረጃ ደብቅ</translation>
+<translation id="3987993985790029246">አገናኝ ቅዳ</translation>
+<translation id="2704606927547763573">ተቀድቷል</translation>
+<translation id="8725066075913043281">እንደገና ይሞክሩ</translation>
+<translation id="385051799172605136">ተመለስ</translation>
+<translation id="8131740175452115882">አረጋግጥ</translation>
+<translation id="5300589172476337783">አሳይ</translation>
+<translation id="1124772482545689468">ተጠቃሚ</translation>
+<translation id="8609465669617005112">ወደላይ አውጣ</translation>
+<translation id="6746124502594467657">ወደታች አውርድ</translation>
+<translation id="8249310407154411074">ወደ ላይ ውሰድ</translation>
+<translation id="8428213095426709021">ቅንብሮች</translation>
+<translation id="2498359688066513246">እገዛ እና ግብረመልስ</translation>
+<translation id="8378714024927312812">በእርስዎ ድርጅት የሚተዳደር</translation>
+<translation id="9019902583201351841">በእርስዎ ወላጆች የሚቀናበር</translation>
+<translation id="4645575059429386691">በእርስዎ ወላጅ የሚቀናበር</translation>
+<translation id="4883854917563148705">የሚተዳደሩ ቅንብሮች ዳግም ሊጀመሩ አይችሉም</translation>
+<translation id="4307992518367153382">መሠረታዊ</translation>
+<translation id="1974060860693918893">የላቀ</translation>
+<translation id="1146678959555564648">ምናባዊ ዕውነታ አስገባ</translation>
+<translation id="987264212798334818">አጠቃላይ</translation>
+<translation id="4275663329226226506">ማህደረ መረጃ</translation>
+<translation id="4759238208242260848">የወረዱ</translation>
+<translation id="218608176142494674">ማጋራት</translation>
+<translation id="8004582292198964060">አሳሽ</translation>
+<translation id="1105960400813249514">የማያ ገጽ ቀረጻ</translation>
+<translation id="4875775213178255010">የይዘት አስተያየት ጥቆማዎች</translation>
+<translation id="2021896219286479412">የሙሉ ማያ ገጽ ጣቢያ መቆጣጠሪያዎች</translation>
+<translation id="4587589328781138893">ጣቢያዎች</translation>
+<translation id="4943703118917034429">ምናባዊ እውነታ</translation>
+<translation id="1928696683969751773">ዝማኔዎች</translation>
+<translation id="6064125863973209585">የተጠናቀቁ ማውረዶች</translation>
+<translation id="5342314432463739672">የፈቃድ ጥያቄዎች</translation>
+<translation id="629730747756840877">መለያ</translation>
+<translation id="82609232232243542">Brave ውስጥ ይግቡ</translation>
+<translation id="7956662517480676674">ማመሳሰል እና የBrave Software አገልግሎቶች</translation>
+<translation id="5294439808117722387">እርስዎ በአሁኑ ጊዜ የእርስዎን የስምረት እና የBrave Software አገልግሎት ቅንብሮችን እያበጁ ነው። ስምረትን ማብራቱን ለመጨረስ ከማያ ገጹ ታችኛው ክፍል አጠገብ ያለውን የአረጋግጥ አዝራር መታ ያድርጉ። ወደ ላይ ያስሱ</translation>
+<translation id="2096012225669085171">በመላ መሣሪያዎች ላይ ያመሳስሉ እና ግላዊነት ያላብሱ</translation>
+<translation id="1692118695553449118">አመሳስል በርቷል</translation>
+<translation id="5514904542973294328">በዚህ መሣሪያ አስተዳዳሪ ተሰናክሏል</translation>
+<translation id="6447211988989208781">የBrave Software እንቅስቃሴ መቆጣጠሪያዎች</translation>
+<translation id="4882831918239250449">ፍለጋን፣ ማስታወቂያዎችን እና ተጨማሪ ነገሮችን ግላዊነት ለማላበስ የእርስዎ የአሰሳ ታሪክ እንዴት ጥቅም ላይ እንደሚውል ይቆጣጠሩ</translation>
+<translation id="7431991332293347422">ፍለጋን እና ተጨማሪ ነገሮችን ግላዊነት ለማላበስ የእርስዎ የአሰሳ ታሪክ እንዴት ጥቅም ላይ እንደሚውል ይቆጣጠሩ</translation>
+<translation id="6303969859164067831">ዘግተው ይውጡ እና ስምረትን ያጥፉ</translation>
+<translation id="1125261911132334651">የBrave Software መለያዎን ያቀናብሩ</translation>
+<translation id="6406506848690869874">አመሳስል</translation>
+<translation id="714362445477979774">የBrave ውሂብዎን ያስምሩ</translation>
+<translation id="4314815835985389558">ስምረትን ያቀናብሩ</translation>
+<translation id="5428209950370661546">ሌሎች የBrave Software አገልግሎቶች</translation>
+<translation id="7704317875155739195">ፍለጋዎችን እና ዩአርኤልዎችን በራስ-አጠናቅቅ</translation>
+<translation id="2000419248597011803">ፍለጋዎችን ከአድራሻ አሞሌው እና ከፍለጋ ሳጥኑ እና አንዳንድ ኩኪዎችን ወደ ነባሪው የፍለጋ ፕሮግራምዎ ይልካል</translation>
+<translation id="7981313251711023384">ይበልጥ ፈጣን ለሆነ አሰሳ እና ፍለጋ ገጾችን ቅድሚያ ይጫኑ</translation>
+<translation id="1821253160463689938">የእርስዎን ምርጫዎች ለማስታወስ ኩኪዎችን ይጠቀማል፣ እነዚያን ገጾች ባይጎበኙም እንኳ</translation>
+<translation id="6697492270171225480">አንድ ገጽ ሊገኝ ካልቻለ የተመሳሳይ ገጾች የአስተያየት ጥቆማዎችን አሳይ</translation>
+<translation id="8109318360573330108">ሊደርሱበት እየሞከሩ ያሉትን ገጽ ዩአርኤል ወደ Brave Software ይልካል</translation>
+<translation id="8438566539970814960">ፍለጋዎችን እና አሰሳን የተሻለ አድርግ</translation>
+<translation id="284843628681142937">የሚጎበኙዋቸውን ገጾች ዩአርኤሎች ወደ Brave Software ይልካል</translation>
+<translation id="7222718784508482526">ከግላዊነት፣ ደህንነት እና የውሂብ ስብስብ ጋር ለሚዛመዱ ተጨማሪ ቅንብሮች <ph name="BEGIN_LINK"/>ስምረት እና የBrave Software አገልግሎቶች<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">የBrave ባህሪያት እና አፈጻጸም እንዲሻሻል ያግዙ</translation>
+<translation id="9063160602596686558">የአጠቃቀም ስታስቲክስን እና የብልሽት ሪፖርቶችን በራስ-ሰር ወደ Brave Software ይልካል</translation>
+<translation id="4824958205181053313">ስምረት ይሰረዝ?</translation>
+<translation id="3058498974290601450">ስምረትን በማንኛውም ጊዜ በቅንብሮች ውስጥ ማብራት ይችላሉ።</translation>
+<translation id="3143515551205905069">ስምረትን ሰርዝ</translation>
+<translation id="1506061864768559482">የፍለጋ ፕሮግራም</translation>
+<translation id="55737423895878184">አካባቢ እና ማሳወቂያዎች ይፈቀዳሉ</translation>
+<translation id="3988213473815854515">መገኛ አካባቢ ተፈቅዷል</translation>
+<translation id="32895400574683172">ማሳወቂያዎች ይፈቀዳሉ</translation>
+<translation id="9040142327097499898">ማሳወቂያዎች ይፈቀዳሉ። አካባቢ ለዚህ መሣሪያ ጠፍቷል።</translation>
+<translation id="305593374596241526">አካባቢ ጠፍቷል፤ በ<ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ያብሩት።</translation>
+<translation id="2989523299700148168">በቅርብ ጊዜ የተጎበኙ</translation>
+<translation id="6433501201775827830">የእርስዎን የፍለጋ ፕሮግራም ይምረጡ</translation>
+<translation id="7177466738963138057">ይሄንን በኋላ ቅንብሮች ውስጥ ሊለውጡት ይችላሉ</translation>
+<translation id="3478363558367712427">የፍለጋ ፕሮግራምዎን መምረጥ ይችላሉ</translation>
+<translation id="4910889077668685004">የክፍያ መተግበሪያዎች</translation>
+<translation id="5152843274749979095">ምንም የሚደገፉ መተግበሪያዎች አልተጫኑም</translation>
+<translation id="8812260976093120287">በአንዳንድ ድር ጣቢያዎች ላይ ከላይ ባሉ የሚደገፉ የክፍያ መተግበሪያዎች በመሣሪያዎ ላይ መክፈል ይችላሉ።</translation>
+<translation id="7764225426217299476">አድራሻ አክል</translation>
+<translation id="5595485650161345191">አድራሻ አርትዕ</translation>
+<translation id="5087580092889165836">ካርድ አክል</translation>
+<translation id="2154484045852737596">ካርትን ያርትዑ</translation>
+<translation id="6140912465461743537">አገር/ክልል</translation>
+<translation id="5659593005791499971">ኢሜይል</translation>
+<translation id="4378154925671717803">ስልክ</translation>
+<translation id="4807098396393229769">በካርድ ላይ ያለ ስም</translation>
+<translation id="860043288473659153">የካርድ ያዢ ስም</translation>
+<translation id="2612676031748830579">የካርድ ቁጥር</translation>
+<translation id="869891660844655955">የሚያበቀበት ጊዜ</translation>
+<translation id="2286841657746966508">የመላኪያ አድራሻ</translation>
+<translation id="663059986967017181">ወደ Brave ተቀድቷል</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ተጨማሪ}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ተጨማሪ}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ተጨማሪ}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ተጨማሪ}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ተጨማሪ}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ተጨማሪ}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ተጨማሪ}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ተጨማሪ}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ተጨማሪ}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ተጨማሪ}one{<ph name="CONTACT_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ተጨማሪ}other{<ph name="CONTACT_PREVIEW"/>\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ተጨማሪ}}</translation>
+<translation id="7029809446516969842">የይለፍ ቃላት</translation>
+<translation id="1943432128510653496">የይለፍ ቃላትን አስቀምጥ</translation>
+<translation id="2100273922101894616">በራስ-ግባ</translation>
+<translation id="363596933471559332">የተከማቹ ምስክርነቶችን በመጠቀም በራስ-ሰር ወደ የድር ጣቢያዎች መለያ ይግቡ። ባህሪው ሲጠፋ ወደ አንድ ድር ጣቢያ ከመግባትዎ በፊት ማረጋገጫ ይጠየቃሉ።</translation>
+<translation id="6995899638241819463">የይለፍ ቃላት በውሂብ ደንብ ጥሰት ተጋላጭ ከሆነ ያስጠንቅቅዎት</translation>
+<translation id="1534287762301776620">ወደ የእርስዎ የ Brave Software መለያ ሲገቡ፣ ይህ ባህሪ ይበራል</translation>
+<translation id="10614374240317010">በጭራሽ አልተቀመጠም</translation>
+<translation id="3098842761938485917">የተቀመጡ የይለፍ ቃላትን በእርስዎ <ph name="BEGIN_LINK"/>Brave Software መለያ<ph name="END_LINK"/> ውስጥ ይመልከቱ እና ያስተዳድሩ</translation>
+<translation id="8562452229998620586">የተቀመጡ ይለፍ ቃላት እዚህ ይመጣሉ።</translation>
+<translation id="8084114998886531721">የተቀመጠ ይለፍ ቃል</translation>
+<translation id="2870560284913253234">ጣቢያ</translation>
+<translation id="8503813439785031346">የተጣቃሚ ስም</translation>
+<translation id="6657585470893396449">የይለፍ ቃል፦</translation>
+<translation id="2154710561487035718">URL ቅዳ</translation>
+<translation id="1571304935088121812">የተጠቃሚ ስምን ቅዳ</translation>
+<translation id="5005498671520578047">የይለፍ ቃል ቅዳ</translation>
+<translation id="3632295766818638029">የይለፍ ቃልን ግለጥ</translation>
+<translation id="1513858653616922153">የይለፍ ቃል ሰርዝ</translation>
+<translation id="543338862236136125">የይለፍ ቃል አርትዕ</translation>
+<translation id="4565377596337484307">የይለፍ ቃል ደብቅ</translation>
+<translation id="8523928698583292556">የተከማቸ የይለፍ ቃል ሰርዝ</translation>
+<translation id="2898264748040935573">የተከማቸ ይለፍ ቃል ያርትዑ</translation>
+<translation id="5433691172869980887">የተጠቃሚ ስም ተቀድቷል</translation>
+<translation id="5534640966246046842">ጣቢያ ተቀድቷል</translation>
+<translation id="2625189173221582860">የይለፍ ቃል ተቀድቷል።</translation>
+<translation id="4550003330909367850">የይለፍ ቃልዎን ቅጂ እዚህ ለመመልከት በዚህ መሣሪያ ላይ የማያ ገጽ ቁልፍን ያቀናብሩ።</translation>
+<translation id="6154478581116148741">የይለፍ ቃላትዎን ከዚህ መሣሪያ ወደ ውጭ ለመላክ በቅንብሮች ውስጥ የማያ ገጽ ቁልፍን ያብሩ</translation>
+<translation id="4842092870884894799">የይለፍ ቃል ማመንጨት ብቅ ይን በማሳየት ላይ</translation>
+<translation id="2259659629660284697">የይለፍ ቃላትን ወደ ውጭ ላክ...</translation>
+<translation id="133012818630824069">ከBrave ጋር የተከማቹ የይለፍ ቃሎችን ወደ ውጭ ላክ</translation>
+<translation id="6914783257214138813">የእርስዎ የይለፍ ቃላት ወደ ውጭ የተላከውን ፋይልን መመልከት ለሚችል ማንኛውም ሰው የሚታዩ ይሆናሉ።</translation>
+<translation id="2321086116217818302">የይለፍ ቃላትን በማዘጋጀት ላይ…</translation>
+<translation id="8445448999790540984">የይለፍ ቃላትን ወደ ውጭ መላክ አልተቻለም</translation>
+<translation id="3066461326500799725">እንዴት Brave Software Driveን መጠቀም እንደሚችሉ ይወቁ</translation>
+<translation id="729975465115245577">የእርስዎ መሣሪያ የይለፍ ቃላት ፋይሉን የሚያከማችበት መተግበሪያ የለውም።</translation>
+<translation id="7682724950699840886">የሚከተሉትን ጠቃሚ ምክሮች ይሞክሩ፦ በእርስዎ መሣሪያ ላይ በቂ ባዶ ቦታ መኖሩን ያረጋግጡ፣ ወይም እንደገና ወደ ውጭ ለመላክ ይሞክሩ።</translation>
+<translation id="1129510026454351943">ዝርዝሮች፦ <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">የይለፍ ቃልዎን ለመቅዳት ይክፈቱ</translation>
+<translation id="5515439363601853141">የይለፍ ቃልዎን ለመመልከት ይክፈቱ</translation>
+<translation id="6221633008163990886">የይለፍ ቃላትዎን ወደ ውጭ ለመላክ ይክፈቱ</translation>
+<translation id="230699814587342492">የBrave ይለፍ ቃላት</translation>
+<translation id="6075798973483050474">መነሻ ገጽን ያርትዑ</translation>
+<translation id="854522910157234410">ይህን ገጽ ክፈት</translation>
+<translation id="2482878487686419369">ማስታወቂያዎች</translation>
+<translation id="6255999984061454636">የይዘት አስተያየት ጥቆማዎች</translation>
+<translation id="805047784848435650">በእርስዎ የአሰሳ ታሪክ ላይ በመመስረት</translation>
+<translation id="1041308826830691739">ከድር ጣቢያዎች</translation>
+<translation id="395206256282351086">ፍለጋ እና የጣቢያ አስተያየት ጥቆማዎች ተሰናክለዋል</translation>
+<translation id="257088987046510401">ገፅታዎች</translation>
+<translation id="4650364565596261010">የሥርዓት ነባሪ</translation>
+<translation id="7588219262685291874">የመሣሪያዎ ባትሪ ቆጣቢ ሲበራ ጨለማ ገጽታን ያብሩ</translation>
+<translation id="2760989362628427051">የእርስዎ መሣሪያ በጨለማ ገጽታ ላይ ሲሆን ወይም ባትሪ ቆጣሪ ሲበራ የጨለማ ገጽታን አብራ</translation>
+<translation id="6381421346744604172">የጨለሙ የድር ጣቢያዎች</translation>
+<translation id="5040262127954254034">ግላዊነት</translation>
+<translation id="4991384657077828949">የBrave ደህንነት እንዲሻሻል ያግዙ</translation>
+<translation id="1943176487615318915">አደገኛ መተግበሪያዎችን እና ጣቢያዎችን ፈልጎ ለማግኘት፣ Brave እርስዎ የጎበኟቸውን አንዳንድ ገጾች ዩአርኤሎች፣ የተወሰነ የሥርዓት መረጃ እና አንዳንድ የገጽ ይዘት ወደ Brave Software ይልካል</translation>
+<translation id="3181954750937456830">ደኅንነቱ የተጠበቀ አሰሳ (እርስዎን እና የእርስዎን መሣሪያ ከአደገኛ ጣቢያዎች ጥበቃ ያደርግላችኋል)</translation>
+<translation id="7315322926489145388">የእርስዎ ደኅንነት አደጋ ላይ ሲወድቅ እርስዎ የሚጎበኙዋቸውን አንዳንድ ገጾች ዩአርኤሎች ወደ Brave Software ይልካል።</translation>
+<translation id="2063713494490388661">ለመፈለግ መታ ያድርጉ</translation>
+<translation id="2369463299479365221">ገጹን ትተው ሳይሄዱ በድር ጣቢያዎች ላይ ስላሉ ርዕሶች ይወቁ። ለመፈለግ መታ ያድርጉ አንድ ቃል እና በዙሪያው ያለውን አውድ ወደ Brave Software ፍለጋ ይልክና ትርጓሜዎችን፣ ስዕሎችን፣ የፍለጋ ውጤቶችን እና ሌሎች ዝርዝሮችን ይመልሳል።
 
 የፍለጋ ቃልዎን ለማስተካከል ለመምረጥ ተጭነው ይያዙ። ፍለጋዎን ይበልጥ ለማጥራት ፓነሉን እስከ ላይ ድረስ ያንሸራትቱትና የፍለጋ ሳጥኑን ይንኩ።</translation>
-<translation id="4056223980640387499">ቀይ ቡናማ</translation>
-<translation id="4060598801229743805">አማራጮች ከማያ ገጹ ግርጌ አጠገብ ይገኛሉ</translation>
-<translation id="4062305924942672200">የህግ መረጃ</translation>
-<translation id="4084682180776658562">ዕልባት</translation>
-<translation id="4084712963632273211">ከ<ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />በGoogle የተላከ<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">የመተግበሪያ ውሂብ ይሰረዝ?</translation>
-<translation id="4099578267706723511">የአጠቃቀም ስታቲክሶችን እና የብልሽት ሪፖርቶችን ወደ Google በመላክ Chromeን የተሻለ ለማድረግ እገዛ ያድርጉ።</translation>
-<translation id="410351446219883937">ራስ-አጫውት</translation>
-<translation id="4116038641877404294">ገጾችን ከመስመር ውጭ ለመጠቀም ያውርዷቸው</translation>
-<translation id="4135200667068010335">የተዘጋ ትር የሚጋሩ የመሣሪያዎች ዝርዝር።</translation>
-<translation id="4149994727733219643">ለድረ-ገጾች የተቃለለ እይታ</translation>
-<translation id="4165986682804962316">የጣቢያ ቅንብሮች</translation>
-<translation id="4169535189173047238">አትፍቀድ</translation>
-<translation id="4170011742729630528">አገልግሎቱ አይገኝም፤ ቆይተው እንደገና ይሞክሩ።</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> ጥቅም ላይ ውሏል</translation>
-<translation id="4181841719683918333">ቋንቋዎች</translation>
-<translation id="4183868528246477015">በGoogle Lens ይፈልጉ <ph name="BEGIN_NEW" />አዲስ<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">በአዲስ ትር ክፈት</translation>
-<translation id="4198423547019359126">ምንም የማውረጃ አካባቢዎች የሉም</translation>
-<translation id="4209895695669353772">በGoogle የተጠቆመ ግላዊነት የተላበሰ ይዘትን ስምረትን ማብራት ለማግኘት</translation>
-<translation id="4226663524361240545">ማሳወቂያዎች መሣሪያውን እንዲነዝር ሊያደርጉት ይችላሉ</translation>
-<translation id="423219824432660969">የተሳመረ ውሂብ <ph name="TIME" /> ላይ በነበረው የGoogle ይለፍ ቃል ያመስጥሩ</translation>
-<translation id="4242533952199664413">ቅንብሮችን ክፈት</translation>
-<translation id="4256782883801055595">የክፍት ምንጭ ፍቃዶች</translation>
-<translation id="4259722352634471385">ዳሰሳ ታግዷል፦ <ph name="URL" /></translation>
-<translation id="4269820728363426813">የአገናኝ አድራሻ ቅዳ</translation>
-<translation id="4275663329226226506">ማህደረ መረጃ</translation>
-<translation id="4278390842282768270">ተፈቅዷል</translation>
-<translation id="429312253194641664">አንድ ጣቢያ ሚዲያን በማጫወት ላይ ነው</translation>
-<translation id="4298388696830689168">የተገናኙ ጣቢያዎች</translation>
-<translation id="4307992518367153382">መሠረታዊ</translation>
-<translation id="4314815835985389558">ስምረትን ያቀናብሩ</translation>
-<translation id="4351244548802238354">መገናኛ ዝጋ</translation>
-<translation id="4378154925671717803">ስልክ</translation>
-<translation id="4384468725000734951">ለፍለጋ Sogouን መጠቀም</translation>
-<translation id="4404568932422911380">ምንም ዕልባቶች የሉም</translation>
-<translation id="4405224443901389797">ውሰድ ወደ…</translation>
-<translation id="4411535500181276704">ቀላል ሁነታ</translation>
-<translation id="4415276339145661267">የGoogle መለያዎን ያቀናብሩ</translation>
-<translation id="4432792777822557199">በ<ph name="SOURCE_LANGUAGE" /> ያሉ ገጾች ወደ <ph name="TARGET_LANGUAGE" /> ከአሁን በኋላ ይተረጎማሉ</translation>
-<translation id="4433925000917964731">ቀላል ገጹ በGoogle ቀርቧል።</translation>
-<translation id="4434045419905280838">ብቅ-ባዮች እና አቅጣጫ ማዞሮች</translation>
-<translation id="4440958355523780886">ቀላል ገጽ በGoogle ቀርቧል። ኦርጂናሉን ለመጫን መታ ያድርጉ።</translation>
-<translation id="4452411734226507615">የ<ph name="TAB_TITLE" /> ትር ዝጋ</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> ላይ ዕልባት ተደርጓል</translation>
-<translation id="445467742685312942">ጣቢያዎች የተጠበቀ ይዘትን እንዲያጫውት ይፍቀዱ</translation>
-<translation id="4468959413250150279">በአንድ የተወሰነ ጣቢያ ላይ ድምጸ-ከል አድርግ።</translation>
-<translation id="4472118726404937099">በመላ መሣሪያዎች ላይ በመለያ መግባት እና ስምረትን ማብራት ለማስመር እና ግላዊነትን ለማላበስ</translation>
-<translation id="447252321002412580">የChrome ባህሪያት እና አፈጻጸም እንዲሻሻል ያግዙ</translation>
-<translation id="4479647676395637221">ጣቢያዎች ካሜራዎን እንዲጠቀሙ ከመፍቀድዎ በፊት ይጠይቅ (የሚመከር)</translation>
-<translation id="4479972344484327217"><ph name="MODULE" /> ን ለChrome በመጫን ላይ…</translation>
-<translation id="4487967297491345095">ሁሉንም የChrome መተግበሪያ ውሂብ እስከመጨረሻው ይሰረዛል። ይሄ ሁሉንም ፋይሎች፣ ቅንብሮች፣ መለያዎች፣ የውሂብ ጎታዎች፣ ወዘተ. ያካትታል።</translation>
-<translation id="4493497663118223949">ቀላል ሁነታ በርቷል</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{ከ# ቀን በፊት}one{ከ# ቀኖች በፊት}other{ከ# ቀኖች በፊት}}</translation>
-<translation id="451872707440238414">ዕልባቶችዎን ይፈልጉ</translation>
-<translation id="4521489764227272523">የተመረጠው ውሂብ ከChrome እና የሰመሩ መሣሪያዎችዎ ተወግዷል።
-
-የእርስዎ Google መለያ በ<ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> ላይ እንደ ፍለጋዎች እና የሌሎች Google አገልግሎቶች እንቅስቃሴ ያሉ ሌሎች የአሰሳ ታሪክ ዓይነቶች ሊኖሩት ይችላል።</translation>
-<translation id="4532845899244822526">አቃፊ ይምረጡ</translation>
-<translation id="4538018662093857852">ቀላል ሁነታን አብራ</translation>
-<translation id="4550003330909367850">የይለፍ ቃልዎን ቅጂ እዚህ ለመመልከት በዚህ መሣሪያ ላይ የማያ ገጽ ቁልፍን ያቀናብሩ።</translation>
-<translation id="4558311620361989323">የድረ-ገጽ አቋራጮች</translation>
-<translation id="4561979708150884304">ግንኙነት የለም</translation>
-<translation id="4565377596337484307">የይለፍ ቃል ደብቅ</translation>
-<translation id="4570913071927164677">ዝርዝሮች</translation>
-<translation id="4572422548854449519">ወደ የሚተዳደር መለያ ይግቡ</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{ከ# ደቂቃ በፊት}one{ከ# ደቂቃዎች በፊት}other{ከ# ደቂቃዎች በፊት}}</translation>
-<translation id="4587589328781138893">ጣቢያዎች</translation>
-<translation id="4594952190837476234">ይህ የ<ph name="CREATION_TIME" />  የመስመር ውጭ ገጽ ከመስመር ላይ ስሪቱ የተለየ ሊሆን ይችላል።</translation>
-<translation id="4605958867780575332">ንጥል ተወግዷል፦ <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" />ን ይክፈቱ</translation>
-<translation id="4634124774493850572">የይለፍ ቃል ይጠቀሙ</translation>
-<translation id="4645575059429386691">በእርስዎ ወላጅ የሚቀናበር</translation>
-<translation id="4650364565596261010">የሥርዓት ነባሪ</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> ዕልባቶች ተሰርዘዋል</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> ወደ እርስዎ መነሻ ገፅ ታክሏል</translation>
-<translation id="4684427112815847243">ሁሉንም ያመሳስሉ</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ተጨማሪ}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ተጨማሪ}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ተጨማሪ}}</translation>
-<translation id="4696983787092045100">ጽሑፍ ወደ መሣሪያዎችዎ ይላኩ</translation>
-<translation id="4698034686595694889">በ<ph name="APP_NAME" /> ውስጥ ከመስመር ውጭ ይመልከቱ</translation>
-<translation id="4699172675775169585">የተሸጎጡ ምስሎች እና ፋይሎች</translation>
-<translation id="4714588616299687897">እስከ 60% የሚደርስ ውሂብዎን ይቆጥቡ</translation>
-<translation id="4719927025381752090">ለመተርጎም ጥያቄ አቅርብ</translation>
-<translation id="4720023427747327413">በ<ph name="PRODUCT_NAME" /> ውስጥ ክፈት</translation>
-<translation id="4720982865791209136">Chrome እንዲሻሻል ያግዙ። <ph name="BEGIN_LINK" />የዳሰሳ ጥናት ይወሰዱ<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">አዘምን</translation>
-<translation id="4738836084190194332">የተመሳሰለበት የመጨረሻው ጊዜ፦ <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">አዲስ ትር ክፈት</translation>
-<translation id="4751476147751820511">የእንቅስቃሴ ወይም የብርሃን ዳሳሾች</translation>
-<translation id="4759238208242260848">የወረዱ</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ውርድ ተጠናቅቋል}one{# ውርዶች ተጠናቅቀዋል}other{# ውርዶች ተጠናቅቀዋል}}</translation>
-<translation id="4797039098279997504">ወደ <ph name="URL_OF_THE_CURRENT_TAB" /> ለመመለስ ይንኩ</translation>
-<translation id="4802417911091824046">የይለፍ ሐረግ ምስጠራ ከGoogle Pay የመክፈያ ዘዴዎችን እና አድራሻዎችን አያካትትም።
-
-ይህን ቅንብር ለመቀየር <ph name="BEGIN_LINK" />ስምረትን ዳግም ያስጀምሩ<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">በካርድ ላይ ያለ ስም</translation>
-<translation id="4824958205181053313">ስምረት ይሰረዝ?</translation>
-<translation id="4837753911714442426">ገጽን ለማተም አማራጮችን ክፈት</translation>
-<translation id="4842092870884894799">የይለፍ ቃል ማመንጨት ብቅ ይን በማሳየት ላይ</translation>
-<translation id="4860895144060829044">ደውል</translation>
-<translation id="4866368707455379617"><ph name="MODULE" /> ን ለChrome ለመጫን አልተቻለም</translation>
-<translation id="4875775213178255010">የይዘት አስተያየት ጥቆማዎች</translation>
-<translation id="4878404682131129617">በተኪ አገልጋይ በኩል ዋሻን መመስረት አልተሳካም</translation>
-<translation id="4880127995492972015">ተርጉም…</translation>
-<translation id="4881695831933465202">ክፈት</translation>
-<translation id="488187801263602086">ፋይልን ዳግም ይሰይሙ</translation>
-<translation id="4882831918239250449">ፍለጋን፣ ማስታወቂያዎችን እና ተጨማሪ ነገሮችን ግላዊነት ለማላበስ የእርስዎ የአሰሳ ታሪክ እንዴት ጥቅም ላይ እንደሚውል ይቆጣጠሩ</translation>
-<translation id="4883854917563148705">የሚተዳደሩ ቅንብሮች ዳግም ሊጀመሩ አይችሉም</translation>
-<translation id="4885273946141277891">የማይደገፍ የChrome አብነቶች ብዛት።</translation>
-<translation id="4910889077668685004">የክፍያ መተግበሪያዎች</translation>
-<translation id="4913161338056004800">ስታትስቲክስ ዳግም አስጀምር</translation>
-<translation id="4913169188695071480">ማደስ አቁም</translation>
-<translation id="4915549754973153784">መሣሪያዎችን እየቃኙ ሳሉ <ph name="BEGIN_LINK" />እገዛን ያግኙ<ph name="END_LINK" />…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# ገጽ}one{# ገጾች}other{# ገጾች}}</translation>
-<translation id="4932247056774066048">በ<ph name="DOMAIN_NAME" /> ከሚተዳደር መለያ ዘግተው እየወጡ ስለሆነ የChrome ውሂብዎ ከዚህ መሣሪያ ይሰረዛል። በGoogle መለያዎ ውስጥ እንዳለ ይቆያል።</translation>
-<translation id="4943703118917034429">ምናባዊ እውነታ</translation>
-<translation id="4943872375798546930">ውጤቶች የሉም</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> ማያ ገጽዎን እያጋራ ነው</translation>
-<translation id="4961107849584082341">ይህን ገጽ ወደ ማንኛውም ቋንቋ ያስተርጉሙ</translation>
-<translation id="4962975101802056554">ሁሉንም የመሣሪያ ፈቃዶች ይሻሩ</translation>
-<translation id="4970824347203572753">በአካባቢዎ ውስጥ አይገኝም</translation>
-<translation id="497421865427891073">ወደ ፊት ሂድ</translation>
-<translation id="4988210275050210843">ፋይልን በማውረድ ላይ (<ph name="MEGABYTES" />)።</translation>
-<translation id="4988526792673242964">ገፆች</translation>
-<translation id="4994033804516042629">ምንም ዕውቂያዎች አልተገኙም</translation>
-<translation id="4996978546172906250">ያጋሩ በ</translation>
-<translation id="5004416275253351869">የGoogle እንቅስቃሴ መቆጣጠሪያዎች</translation>
-<translation id="5005498671520578047">የይለፍ ቃል ቅዳ</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> መገናኘት ይፈልጋል</translation>
-<translation id="5013696553129441713">ምንም አዲስ የአስተያየት ጥቆማዎች የሉም</translation>
-<translation id="5016205925109358554">ሰሪፍ</translation>
-<translation id="5033865233969348410">በቪአር ውስጥ ሳሉ ይህ ጣቢያ ስለእነዚህ ሊያውቅ ይችላል፦
-  -  እንደ ቁመት ያለ የእርስዎ አካላዊ ባህሪያት
-
-ወደ ቪአር ከመግባትዎ በፊት ይህን ጣቢያ የሚያምኑት መሆንዎን ያረጋግጡ።</translation>
+<translation id="2930742481329940825">ለመፈለግ መታ ያድርጉ የተመረጠውን ቃልን እና አሁን ያለውን ገጽ እንደ አውድ አድርጎ ወደ Brave Software ፍለጋ ይልካቸዋል። በ<ph name="BEGIN_LINK"/>ቅንብሮች<ph name="END_LINK"/> ውስጥ ሊያጠፉት ይችላሉ።</translation>
 <translation id="5039804452771397117">ፍቀድ</translation>
-<translation id="5040262127954254034">ግላዊነት</translation>
-<translation id="5048398596102334565">ጣቢያዎች የእንቅስቃሴ ዳሳሾችን እንዲደርሱባቸው ይፍቀዱ (የሚመከር)</translation>
-<translation id="5063480226653192405">አጠቃቀም</translation>
-<translation id="5087580092889165836">ካርድ አክል</translation>
-<translation id="5100237604440890931">ተሰብስቧል - ለመዘርጋት ጠቅ ያድርጉ</translation>
-<translation id="510275257476243843">1 ሰዓት ይቀራል</translation>
-<translation id="5123685120097942451">ማንነት የማያሳውቅ ትር</translation>
-<translation id="5127805178023152808">አመሳስል ጠፍቷል</translation>
-<translation id="5129038482087801250">የድር መተግበሪያን ጫን</translation>
-<translation id="5132942445612118989">የእርስዎን የይለፍ ቃላት፣ ታሪክ እና ተጨማሪ ነገሮች በሁሉም መሣሪያዎች ላይ ያስምሩ</translation>
-<translation id="5139940364318403933">እንዴት Google Driveን መጠቀም እንደሚችሉ ይወቁ</translation>
-<translation id="515227803646670480">የተከማቸ ውሂብን አጽዳ</translation>
-<translation id="5152843274749979095">ምንም የሚደገፉ መተግበሪያዎች አልተጫኑም</translation>
-<translation id="5161254044473106830">ርዕስ ያስፈልጋል</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ውርድ አልተሳካም።}one{# ውርዶች አልተሳኩም።}other{# ውርዶች አልተሳኩም።}}</translation>
-<translation id="5170568018924773124">በአቃፊ አሳይ</translation>
-<translation id="5184329579814168207">በChrome ውስጥ ክፈት</translation>
-<translation id="5193988420012215838">ወደ የእርስዎ ቅንጥብ ሰሌዳ ላይ ተቀድቷል</translation>
-<translation id="5197729504361054390">የመረጧቸው እውቂያዎች ለ<ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> ይጋራሉ።</translation>
-<translation id="5199929503336119739">የሥራ መገለጫ</translation>
-<translation id="5210286577605176222">ወደ ቀዳሚው ትር ዝለል</translation>
-<translation id="5210365745912300556">ትር ዝጋ</translation>
-<translation id="5224771365102442243">ከቪዲዮ ጋር</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> በአቅራቢያ የብሉቱዝ መሣሪያዎች ካሉ መቃኘት ይፈልጋል። የሚከተሉት መሣሪያዎች ተገኝተዋል፦</translation>
-<translation id="5233638681132016545">አዲስ ትር</translation>
-<translation id="526421993248218238">ይህን ገጽ መጫን አልተቻለም</translation>
-<translation id="5271967389191913893">መሣሪያ የሚወርደውን ይዘት መክፈት አይችልም።</translation>
-<translation id="528192093759286357">ከሙሉ ማያ ገጽ ለመውጣት ከላይ ይጎትቱ እና የተመለስ አዝራሩን ይንኩ።</translation>
-<translation id="5292796745632149097">ላክ ወደ</translation>
-<translation id="5300589172476337783">አሳይ</translation>
-<translation id="5301954838959518834">እሺ፣ ገባኝ</translation>
-<translation id="5304593522240415983">ይህ መስክ ባዶ ሊሆን አይችልም</translation>
-<translation id="5307446750509046227">የጣቢያ ማከማቻን አጽዳ</translation>
-<translation id="5308380583665731573">ይገናኙ</translation>
-<translation id="5313967007315987356">ጣቢያ አክል</translation>
-<translation id="5317780077021120954">አስቀምጥ</translation>
-<translation id="5324858694974489420">የወላጅ መቆጣጠሪያዎች</translation>
-<translation id="5327248766486351172">ስም</translation>
-<translation id="5335288049665977812">ጣቢያዎች ጃቫስክሪፕትን እንዲያሄዱ ፍቀድላቸው (የሚመከር)</translation>
-<translation id="5342314432463739672">የፈቃድ ጥያቄዎች</translation>
-<translation id="5357811892247919462">ትር ደርሷል</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> ትርን ይክፈቱ፣ ትሮችን ለመቀየር መታ ያድርጉ}one{<ph name="OPEN_TABS_MANY" /> ትሮችን ይክፈቱ፣ ትሮችን ለመቀየር መታ ያድርጉ}other{<ph name="OPEN_TABS_MANY" /> ትሮችን ይክፈቱ፣ ትሮችን ለመቀየር መታ ያድርጉ}}</translation>
-<translation id="5391532827096253100">ወደዚህ ጣቢያ ያልዎት ግንኙነት ደህንነቱ የተጠበቀ አይደለም። የጣቢያ መረጃ</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ተጨማሪ)}one{(+ # ተጨማሪ)}other{(+ # ተጨማሪ)}}</translation>
-<translation id="5400569084694353794">ይህን መተግበሪያ በመጠቀምዎ በChrome <ph name="BEGIN_LINK1" />አገልግሎት ውል<ph name="END_LINK1" /> እና <ph name="BEGIN_LINK2" />የግላዊነት ማስታወቂያ<ph name="END_LINK2" /> ተስማምተዋል።</translation>
-<translation id="5403592356182871684">ስሞች</translation>
-<translation id="5403644198645076998">የተወሰኑ ጣቢያዎችን ብቻ ፍቀድ</translation>
-<translation id="5414836363063783498">በማረጋገጥ ላይ…</translation>
-<translation id="5423934151118863508">በጣም በብዛት የተጎበኙ ገጾችዎ እዚህ ይመጣሉ</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> ጊባ ይገኛል</translation>
-<translation id="543338862236136125">የይለፍ ቃል አርትዕ</translation>
-<translation id="5433691172869980887">የተጠቃሚ ስም ተቀድቷል</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> ፋይሎችን በማውረድ ላይ (<ph name="MEGABYTES" />)።</translation>
-<translation id="5441522332038954058">ወደ የአድራሻው አሞሌ ዘልለህ ሂድ</translation>
-<translation id="5447201525962359567">ኩኪዎች እና ሌላ በአከባቢያዊ የተከማቸ ውሂብን ጨምሮ ሁሉም የጣቢያ ማከማቻ</translation>
-<translation id="5447765697759493033">ይህ ጣቢያ አይተረጎምም</translation>
-<translation id="545042621069398927">ውርድዎን በማፍጠን ላይ።</translation>
-<translation id="5456381639095306749">ገጽ አውርድ</translation>
-<translation id="5475862044948910901">የሚጨምር የእውነት ክፍለ ጊዜ ይጀመር?</translation>
-<translation id="548278423535722844">በካርታዎች መተግበሪያ ውስጥ ይክፈቱ</translation>
-<translation id="5487521232677179737">ውሂብን አጽዳ</translation>
-<translation id="5494752089476963479">ረባሽ ወይም አሳሳች ማስታወቂያዎችን ከሚያሳዩ ጣቢያዎች የሚመጡ ማስታወቂያዎችን አግድ</translation>
-<translation id="5500777121964041360">በአካባቢዎ ውስጥ ላይገኝ ይችላል</translation>
-<translation id="5512137114520586844">ይህ መለያ የሚቀናበረው በ<ph name="PARENT_NAME" /> ነው።</translation>
-<translation id="5514904542973294328">በዚህ መሣሪያ አስተዳዳሪ ተሰናክሏል</translation>
-<translation id="5515439363601853141">የይለፍ ቃልዎን ለመመልከት ይክፈቱ</translation>
-<translation id="5516455585884385570">የማሳወቂያ ቅንብሮችን ክፈት</translation>
-<translation id="5517095782334947753">ከ<ph name="FROM_ACCOUNT" /> የመጡ ዕልባቶች፣ ታሪክ፣ የይለፍ ቃላት  እና ሌሎች ቅንብሮች አለዎት።</translation>
-<translation id="5524843473235508879">አቅጣጫ ማዞር ታግዷል።</translation>
-<translation id="5527082711130173040">Chrome መሣሪያዎችን መቃኘት እንዲችል የአካባቢ መዳረሻ ያስፈልገዋል። <ph name="BEGIN_LINK1" />ፈቃዶችን ያዘምኑ<ph name="END_LINK1" />። የአካባቢ መዳረሻ እንዲሁም <ph name="BEGIN_LINK2" />ለዚህ መዳረሻ ጠፍቷል<ph name="END_LINK2" />።</translation>
-<translation id="5527111080432883924">ጣቢያዎች ከቅንጥብ ሰሌዳ ጽሑፍ እና ምስሎችን እንዲያነብቡ ከመፍቀድ በፊት ጠይቅ (የሚመከር)</translation>
-<translation id="5530766185686772672">ማንነት የማያሳውቁ ትሮችን ዝጋ</translation>
-<translation id="5534334044554683961">በቪአር ውስጥ ሳሉ ይህ ጣቢያ ስለእነዚህ ሊያውቅ ይችላል፦
-  -  እንደ ቁመት ያለ የእርስዎ አካላዊ ባህሪያት
-  -  የክፍልዎ አቀማመጥ
-
-ወደ ቪአር ከመግባትዎ በፊት ይህን ጣቢያ የሚያምኑት መሆንዎን ያረጋግጡ።</translation>
-<translation id="5534640966246046842">ጣቢያ ተቀድቷል</translation>
-<translation id="5556459405103347317">ዳግም ጫን</translation>
-<translation id="5561549206367097665">አውታረ መረብን በመጠበቅ ላይ…</translation>
-<translation id="557283862590186398">Chrome ለዚህ ጣቢያ የእርስዎን ማይክራፎን ለመድረስ ፈቃድ ይፈልጋል።</translation>
-<translation id="55737423895878184">አካባቢ እና ማሳወቂያዎች ይፈቀዳሉ</translation>
-<translation id="5578795271662203820">ይህንን ምስል <ph name="SEARCH_ENGINE" /> ላይ ይፈልጉት</translation>
-<translation id="5581519193887989363">በማንኛውም ጊዜ ምን እንደሚያሰምሩ በ<ph name="BEGIN_LINK1" />ቅንብሮች<ph name="END_LINK1" /> ውስጥ መምረጥ ይችላሉ።</translation>
-<translation id="5595485650161345191">አድራሻ አርትዕ</translation>
-<translation id="5596627076506792578">ተጨማሪ አማራጮች</translation>
-<translation id="5599455543593328020">ማንነት የማያሳውቅ ሁነታ</translation>
-<translation id="5620928963363755975">ከተጨማሪ አማራጮች አዝራር ሆነው የእርስዎን ፋይሎች እና ገጾች በውርዶች ውስጥ ያግኙ</translation>
-<translation id="5626134646977739690">ስም፦</translation>
-<translation id="5639724618331995626">ሁሉንም ጣቢያዎች ፍቀድ</translation>
-<translation id="5648166631817621825">ያለፉት 7 ቀኖች</translation>
-<translation id="5649053991847567735">ራስ-ሰር ውርዶች</translation>
-<translation id="5655963694829536461">የእርስዎን ውርዶች ይፈልጉ</translation>
-<translation id="5659593005791499971">ኢሜይል</translation>
-<translation id="5665379678064389456">በ<ph name="APP_NAME" /> ውስጥ ክስተት ይፍጠሩ</translation>
-<translation id="5668404140385795438">የአንድ ድር ጣቢያ ማጉላትን መከልከል ጥያቄ ሻር</translation>
-<translation id="5677928146339483299">ታግዷል</translation>
-<translation id="5684874026226664614">ውይ። ይህ ገጽ ሊተረጎም አይችልም።</translation>
-<translation id="5686790454216892815">የፋይሉ ስም በጣም ረጅም ነው</translation>
-<translation id="5689516760719285838">አካባቢ</translation>
-<translation id="569536719314091526">ከተጨማሪ አማራጮች አዝራርሩ ይህን ገጽ ወደ ማንኛውም ቋንቋ ያስተርጉሙ</translation>
-<translation id="572328651809341494">የቅርብ ጊዜ ትሮች</translation>
-<translation id="5726692708398506830">በገጹ ላይ ያለውን ሁሉንም ነገር ይበልጥ አተልቅ</translation>
-<translation id="5748802427693696783">ወደ መደበኛ ትሮች ቀይር</translation>
-<translation id="5749068826913805084">Chrome ፋይሎችን ለማውረድ የማከማቻ መዳረሻ ያስፈልገዋል።</translation>
-<translation id="5763382633136178763">ማንነት የማያሳውቁ ትሮች</translation>
-<translation id="5763514718066511291">የዚህ መተግበሪያ ዩአርኤል ለመቅዳት መታ ያድርጉ</translation>
-<translation id="5765780083710877561">መግለጫ</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> ከ<ph name="SPACE_AVAILABLE" /> በመጠቀም ላይ</translation>
-<translation id="5797070761912323120">Google ፍለጋን፣ ማስታወቂያዎችን እና ሌሎች የGoogle አገልግሎቶችን ግላዊነት ለማላበስ የእርስዎን ታሪክ ሊጠቀም ይችላል</translation>
-<translation id="5804241973901381774">ፍቃዶች</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{ከ# ሰዓት በፊት}one{ከ# ሰዓቶች በፊት}other{ከ# ሰዓቶች በፊት}}</translation>
-<translation id="5810288467834065221">የቅጂ መብት <ph name="YEAR" /> Google LLC. ሁሉም መብቶች በህግ የተጠበቁ ናቸው።</translation>
-<translation id="5817918615728894473">አጣምር</translation>
-<translation id="583281660410589416">ያልታወቀ </translation>
-<translation id="5833984609253377421">አገናኝ አጋራ</translation>
-<translation id="5836192821815272682">Chrome ዝማኔን በማውረድ ላይ…</translation>
-<translation id="5853623416121554550">ባለበት ቆሟል</translation>
-<translation id="5854790677617711513">ከ30 ቀናት በላይ የቆየ</translation>
-<translation id="5858741533101922242">Chrome የብሉቱዝ አስማሚውን ማብራት አልቻለም</translation>
-<translation id="5860033963881614850">አጥፋ</translation>
-<translation id="5862731021271217234">ትሮችዎን ከሌሎች መሣሪያዎችዎ ስምረትን ማብራት ለማግኘት</translation>
-<translation id="5864174910718532887">ዝርዝሮች፦ በጣቢያ ስም የተለየ</translation>
-<translation id="5864419784173784555">ሌላ ውርድን በመጠበቅ ላይ…</translation>
-<translation id="5865733239029070421">የአጠቃቀም ስታስቲክስን እና የብልሽት ሪፖርቶችን በራስ-ሰር ወደ Google ይልካል</translation>
-<translation id="5869522115854928033">የተቀመጡ የይለፍ ቃሎች</translation>
-<translation id="5902828464777634901">ኩኪዎችንም ጨምሮ በዚህ ድር ጣቢያ የተከማቸ ሁሉም አካባቢያዊ ውሂብ ይሰረዛል።</translation>
-<translation id="5916664084637901428">በርቷል</translation>
-<translation id="5919204609460789179">ስምረትን ለመጀመር <ph name="PRODUCT_NAME" />ን ያዘምኑ</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> ተቀምጧል</translation>
-<translation id="5939518447894949180">ዳግም አስጀምር</translation>
-<translation id="5942872142862698679">ለፍለጋ Googleን መጠቀም</translation>
-<translation id="5952764234151283551">ሊደርሱበት እየሞከሩ ያሉትን ገጽ ዩአርኤል ወደ Google ይልካል</translation>
-<translation id="5956665950594638604">የChrome እገዛ ማዕከልን በአዲስ ትር ውስጥ ክፈት</translation>
-<translation id="5958275228015807058">የእርስዎን ፋይሎች እና ገጾች በውርዶች ውስጥ ያግኙ</translation>
-<translation id="5962718611393537961">ለመሰብሰብ መታ ያድርጉ</translation>
-<translation id="6000066717592683814">Googleን አቆየው</translation>
-<translation id="6005538289190791541">የተጠቆመ የይለፍ ቃል</translation>
-<translation id="6036057147555329831">ተጨማሪ አይሲዩ</translation>
-<translation id="6039379616847168523">ወደ ቀጣዩ ትር ዝለል</translation>
-<translation id="6040143037577758943">ዝጋ</translation>
-<translation id="6042308850641462728">ተጨማሪ</translation>
-<translation id="604996488070107836"><ph name="FILE_NAME" />ን ማውረድ ባልታወቀ ስህተት ምክንያት አልተሳካም።</translation>
-<translation id="605721222689873409">ዓዓ</translation>
-<translation id="6064125863973209585">የተጠናቀቁ ማውረዶች</translation>
-<translation id="6075798973483050474">መነሻ ገጽን ያርትዑ</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> ሰዓቶች ይቀራሉ</translation>
-<translation id="6108923351542677676">ማዋቀር በሂደት ላይ…</translation>
-<translation id="6111020039983847643">ጥቅም ላይ የዋለው ውሂብ</translation>
-<translation id="6112702117600201073">ገጽ በማደስ ላይ</translation>
-<translation id="6127379762771434464">ንጥል ተወግዷል</translation>
-<translation id="6140912465461743537">አገር/ክልል</translation>
-<translation id="614940544461990577">ይሞክሩ፦</translation>
-<translation id="6154478581116148741">የይለፍ ቃላትዎን ከዚህ መሣሪያ ወደ ውጭ ለመላክ በቅንብሮች ውስጥ የማያ ገጽ ቁልፍን ያብሩ</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> የውሂብ ቁጠባዎች</translation>
-<translation id="6165508094623778733">የበለጠ ለመረዳት</translation>
-<translation id="6177111841848151710">ለአሁኑ የፍለጋ ፕሮግራም ታግዷል</translation>
-<translation id="6181444274883918285">ለየት ያለ ጣቢያን አክል</translation>
-<translation id="6192333916571137726">ፋይል ያውርዱ</translation>
-<translation id="6192792657125177640">የተለዩ</translation>
-<translation id="6194112207524046168">የእርስዎን ካሜራ Chrome እንዲደርስበት ለማድረግ፣ በ <ph name="BEGIN_LINK" />Android ቅንብሮች<ph name="END_LINK" /> ውስጥ ካሜራን በተጨማሪ ያብሩ።</translation>
-<translation id="6196640612572343990">የሦስተኛ ወገን ኩኪዎችን አግድ</translation>
-<translation id="6206551242102657620">ግንኙነት ደህንነቱ የተጠበቀ ነው። የጣቢያ መረጃ</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> አይደለም?</translation>
-<translation id="6221633008163990886">የይለፍ ቃላትዎን ወደ ውጭ ለመላክ ይክፈቱ</translation>
+<translation id="1406000523432664303">«አትከታተል»</translation>
 <translation id="6232535412751077445">«አትከታተል»ን ማንቃት ማለት አንድ ጥያቄ በአሰሳ ትራፊክዎ ላይ ይካተታል ማለት ነው። ማንኛውም ውጤት አንድ ድር ጣቢያ ለጥያቄው ምላሽ ከሰጠና ጥያቄውን በሚተረጎምበት መንገድ ላይ የሚወሰን ነው።
 
 ለምሳሌ፣ አንዳንድ ድር ጣቢያዎች ሌሎች በጎበኟቸው ድር ጣቢያዎች ላይ ያልተመሠረቱ ማስታወቂያዎችን በማሳየት ለዚህ ጥያቄ ምላሽ ሊሰጡ ይችላሉ። ብዙ ድር ጣቢያዎች አሁንም የአሰሳ ውሂብዎን ይሰበስቡና ይጠቀሙበታል — ለምሳሌ ደህንነትን ለማሻሻል፤ ይዘት፣ ማስታወቂያዎችና ምክሮች በድር ጣቢያዎች ላይ ለማቅረብ፤ እና የሪፖርት አደራረግ ስታቲስቲክስን ለማመንጨት።</translation>
-<translation id="624789221780392884">ማዘመኛ ዝግጁ ነው</translation>
-<translation id="6255999984061454636">የይዘት አስተያየት ጥቆማዎች</translation>
-<translation id="6277522088822131679">ገጹን ማተም ላይ ችግር ነበር። እባክዎ እንደገና ይሞክሩ።</translation>
-<translation id="6295158916970320988">ሁሉም ጣቢያዎች</translation>
-<translation id="629730747756840877">መለያ</translation>
-<translation id="6303969859164067831">ዘግተው ይውጡ እና ስምረትን ያጥፉ</translation>
-<translation id="6316139424528454185">የAndroid ስሪቱ አይደገፍም</translation>
-<translation id="6320088164292336938">ንዘር</translation>
-<translation id="6324034347079777476">የAndroid ሥርዓት ስምረት ተሰናክሏል</translation>
-<translation id="6333140779060797560">በ<ph name="APPLICATION" /> በኩል ያጋሩ</translation>
-<translation id="6337234675334993532">ምስጠራ</translation>
-<translation id="6341580099087024258">ፋይሎች የት እንደሚቀመጡ ይጠይቁ</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ተጨማሪ}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ተጨማሪ}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ተጨማሪ}}</translation>
-<translation id="6364438453358674297">ጥቆማው ከታሪክ ይወገድ?</translation>
-<translation id="6369229450655021117">ከዚህ ላይ ሆነው፣ ድሩን መፈለግ፣ ከጓደኞች ጋር መጋራት፣ እና ክፍት ገጾችን መመልከት ይችላሉ</translation>
-<translation id="6378173571450987352">ዝርዝሮች፦ ጥቅም ላይ በዋለው የውሂብ መጠን ተደርድረዋል</translation>
-<translation id="6381421346744604172">የጨለሙ የድር ጣቢያዎች</translation>
-<translation id="6388207532828177975">አጽዳ እና ዳግም አስጀምር</translation>
-<translation id="6393863479814692971">Chrome ለዚህ ጣቢያ የእርስዎን ካሜራ እና ማይክራፎን ለመድረስ ፈቃድ ይፈልጋል።</translation>
-<translation id="6395288395575013217">አገናኝ</translation>
-<translation id="6404511346730675251">ዕልባት አርትዕ</translation>
-<translation id="6406506848690869874">አመሳስል</translation>
-<translation id="641643625718530986">አትም…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> ሜባ ወርዷል</translation>
-<translation id="6427112570124116297">ድሩን ያስተርጉሙ</translation>
-<translation id="6433501201775827830">የእርስዎን የፍለጋ ፕሮግራም ይምረጡ</translation>
-<translation id="6437478888915024427">የገጽ መረጃ</translation>
-<translation id="6441734959916820584">ስም በጣም ረጅም ነው</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ምስል}one{# ምስሎች}other{# ምስሎች}}</translation>
-<translation id="6447842834002726250">ኩኪዎች</translation>
-<translation id="6461962085415701688">ፋይሉን መክፈት አይቻልም</translation>
-<translation id="6464977750820128603">በChrome ውስጥ የሚጎበኟቸውን ጣቢያዎች መመልከት እና ለእነሱ ሰዓት ቆጣሪዎችን ማቀናበር ይችላሉ።\n\nGoogle ሰዓት ቆጣሪዎች ስለሚያቀናብሩላቸው ጣቢያዎች እና ለምን ያህል ርዝመት እንደሚጎበኟቸው መረጃ ያገኛል። ይህ መረጃ ዲጂታል ብቁ መሆን የተሻለ ለማድረግ ስራ ላይ ይውላል።</translation>
-<translation id="6475951671322991020">ቪድዮ አውርድ</translation>
-<translation id="6482749332252372425">በማከማቻ ቦታ ጥበት ምክንያት <ph name="FILE_NAME" />ን ማውረድ አልተሳካም።</translation>
-<translation id="6496823230996795692"><ph name="APP_NAME" />ን ለመጀመሪያ ጊዜ ለመጠቀም እባክዎ ከበይነመረብ ጋር ይገናኙ።</translation>
-<translation id="6508722015517270189">Chromeን ዳግም ያስጀምሩት</translation>
-<translation id="6527303717912515753">አጋራ</translation>
-<translation id="6532866250404780454">በChrome ውስጥ የሚጎበኟቸው ጣቢያዎች አይታዩም። ሁሉም ሰዓት ቆጣሪዎች ይሰረዛሉ።</translation>
-<translation id="6534565668554028783">Google ምላሽ ለመስጠት ከልክ በላይ ረዥም ጊዜ ወስዷል</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> ጊባ ወርዷል</translation>
-<translation id="6539092367496845964">የሆነ ችግር ተፈጥሯል። ቆይተው እንደገና ይሞክሩ።</translation>
-<translation id="654446541061731451">በሞገድ የሚለቅቁት ትር ይምረጡ</translation>
-<translation id="6545017243486555795">ሁሉንም ውሂብ አጽዳ</translation>
-<translation id="6545864417968258051">የብሉቱዝ ቅኝት</translation>
-<translation id="6560414384669816528">ከSogou ጋር ይፈልጉ</translation>
-<translation id="6566259936974865419">Chrome <ph name="GIGABYTES" /> ጊባ ቆጥቦልዎታል</translation>
-<translation id="6573096386450695060">ሁልጊዜ ፍቀድ</translation>
-<translation id="6573431926118603307">በሌሎች መሣሪያዎችዎ ላይ ባለ Chrome ላይ የከፈቷቸው ትሮች እዚህ ይመጣሉ።</translation>
-<translation id="6583199322650523874">የአሁኑን ገጽ ዕልባት አድርግበት</translation>
-<translation id="6593061639179217415">የዴስክቶፕ ጣቢያ</translation>
-<translation id="6600954340915313787">ወደ Chrome ተቀድቷል</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> ጊባ</translation>
-<translation id="6612358246767739896">ጥበቃ የሚደረግለት ይዘት</translation>
-<translation id="6627583120233659107">አቃፊ አርትዕ</translation>
-<translation id="6643016212128521049">አጽዳ</translation>
-<translation id="6643649862576733715">በተቆጠበው የውሂብ መጠን ደርድር</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ተጨማሪ}one{<ph name="CONTACT_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ተጨማሪ}other{<ph name="CONTACT_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ተጨማሪ}}</translation>
-<translation id="6649642165559792194">ምስል <ph name="BEGIN_NEW" />አዲስ<ph name="END_NEW" />ን ቅድሚያ ይመልከቱ</translation>
-<translation id="6656545060687952787">Chrome መሣሪያዎችን ለመቃኘት የአካባቢ መዳረሻ ያስፈልገዋል። <ph name="BEGIN_LINK" />ፍቃዶችን ያዘምኑ<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">የይለፍ ቃል፦</translation>
-<translation id="6659594942844771486">ትር</translation>
-<translation id="666731172850799929">በ<ph name="APP_NAME" /> ውስጥ ክፈት</translation>
-<translation id="666981079809192359">የChrome ግላዊነት ማስታወቂያ</translation>
-<translation id="6676840375528380067">የChrome ውሂብዎ ከዚህ መሣሪያ ላይ ይጽዳ?</translation>
-<translation id="6697492270171225480">አንድ ገጽ ሊገኝ ካልቻለ የተመሳሳይ ገጾች የአስተያየት ጥቆማዎችን አሳይ</translation>
-<translation id="6697947395630195233">Chrome አካባቢዎን ለዚህ ጣቢያ ለማጋራት የአካባቢዎ መዳረሻ ይፈልጋል።</translation>
-<translation id="6698801883190606802">የተመሳሰለ ውሂብ ያስተዳድሩ</translation>
-<translation id="6699370405921460408">የGoogle አገልጋዮች እርስዎ የሚጎበኟቸውን ገጾች ያተባሉ።</translation>
-<translation id="6706288973712894588">በአሁኑ ጊዜ ከመስመር ውጪ ነዎት።\n<ph name="BEGIN_LINK" />የመስመር ውጭ ምግብዎን ያስሱ።<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">ዜና</translation>
-<translation id="6710213216561001401">ቀዳሚ</translation>
-<translation id="671481426037969117">የእርስዎ <ph name="FQDN" /> ሰዓት ቆጣሪ ጊዜ አልቋል። ነገ እንደገና ይጀመራል።</translation>
-<translation id="6738867403308150051">በማውረድ ላይ…</translation>
-<translation id="6746124502594467657">ወደታች አውርድ</translation>
-<translation id="6766622839693428701">ለመዝጋት ወደታች ያንሸራትቱ።</translation>
-<translation id="6766758767654711248">ወደ ጣቢያ ለመሄዴ መታ ያድርጉ</translation>
-<translation id="6767294960381293877">በግማሽ ቁመቱ ላይ የተከፈተ ትር የሚጋሩ የመሣሪያዎች ዝርዝር።</translation>
-<translation id="6782111308708962316">የሦስተኛ ወገን ድር ጣቢያዎች የኩኪ ውሂብን እንዳያስቀምጡ እና እንዳያነብቡ ከልክል</translation>
-<translation id="6790428901817661496">አጫውት</translation>
-<translation id="6811034713472274749">ገጽ ለመመልከት ዝግጁ ነው</translation>
-<translation id="6818926723028410516">ንጥሎችን ይምረጡ</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">መተርጎም</translation>
-<translation id="6845325883481699275">የChrome ደህንነት እንዲሻሻል ያግዙ</translation>
-<translation id="6846298663435243399">በመጫን ላይ…</translation>
-<translation id="6850409657436465440">የእርስዎ ውርድ አሁንም በሂደት ላይ ነው</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> ትሮች ተዘግተዋል</translation>
-<translation id="6864459304226931083">ምስል አውርድ</translation>
-<translation id="6865313869410766144">የራስ-ሙላ ቅጽ ውሂብ</translation>
-<translation id="688738109438487280">ነባሩን ውሂብ ወደ <ph name="TO_ACCOUNT" /> ያክሉ።</translation>
-<translation id="6891726759199484455">የይለፍ ቃልዎን ለመቅዳት ይክፈቱ</translation>
-<translation id="6896758677409633944">ቅዳ</translation>
-<translation id="6910211073230771657">ተሰርዟል</translation>
-<translation id="6912998170423641340">ጣቢያዎች ከቅንጥብ ሰሌዳ ጽሑፍን እና ምስሎችን እንዳያነብቡ አግድ</translation>
-<translation id="6914783257214138813">የእርስዎ የይለፍ ቃላት ወደ ውጭ የተላከውን ፋይልን መመልከት ለሚችል ማንኛውም ሰው የሚታዩ ይሆናሉ።</translation>
-<translation id="6942665639005891494">የቅንብሮች ምናሌ አማራጩን በመጠቀም ነባሪውን የማውረጃ ቦታ ይጠቀሙ</translation>
-<translation id="6945221475159498467">ይምረጡ</translation>
-<translation id="6963642900430330478">ይህ ገጽ አደገኛ ነው። የጣቢያ መረጃ</translation>
-<translation id="6963766334940102469">ዕልባቶችን ሰርዝ</translation>
-<translation id="6965382102122355670">እሺ</translation>
-<translation id="6979737339423435258">የምንጊዜም</translation>
-<translation id="6981982820502123353">ተደራሽነት</translation>
-<translation id="6989267951144302301">ማውረድ አልተቻለም</translation>
-<translation id="6990079615885386641">መተግበሪያውን ከGoogle Play መደብር ያግኙ፦ <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">ጣቢያዎች ማይክሮፎንዎን እንዲጠቀሙ ከመፍቀድዎ በፊት ይጠይቅ (የሚመከር)</translation>
-<translation id="7015203776128479407">የመጀመሪያው የስምረት ውቅረት አላለቀም። ስምረት ጠፍቷል።</translation>
-<translation id="7016516562562142042">ለአሁኑ የፍለጋ ፕሮግራም ተፈቅዷል</translation>
-<translation id="7022756207310403729">በአሳሽ ውስጥ ክፈት</translation>
-<translation id="702463548815491781">TalkBack ወይም መዳረሻ ቀይር ሲበሩ የሚመከር</translation>
-<translation id="7029809446516969842">የይለፍ ቃላት</translation>
-<translation id="7053983685419859001">አግድ</translation>
-<translation id="7055152154916055070">አቅጣጫ ማዞር ታግዷል፦</translation>
-<translation id="7063006564040364415">ከማመሳሰያ አገልጋዩ ጋር መገናኘት አልተቻለም።</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ተመርጧል}one{# ተመርጠዋል}other{# ተመርጠዋል}}</translation>
-<translation id="7071521146534760487">መለያን አቀናብር</translation>
-<translation id="7077143737582773186">ኤስዲ ካርድ</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> ተመርጠዋል።  አማራጮች ከማያ ገጹ አናት አጠገብ ይገኛሉ</translation>
-<translation id="7121362699166175603">በአድራሻ አሞሌው ላይ ታሪክን እና ራስ-ማጠናቀቆችን ያጸዳል። የእርስዎ Google መለያ <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> ላይ ሌሎች የአሰሳ ታሪክ አይነቶች ሊኖሩት ይችላል።</translation>
-<translation id="7128222689758636196">አሁን ላለው የፍለጋ ፕሮግራም ፍቀድ</translation>
-<translation id="7138678301420049075">ሌላ</translation>
-<translation id="7141896414559753902">ጣቢያዎች ብቅ-ባዮችን እንዳያሳዩ ያግዱ (የሚመከር)</translation>
-<translation id="7149158118503947153">ከ<ph name="DOMAIN_NAME" /> <ph name="BEGIN_LINK" />የመጀመሪያውን ገጽ ጫን<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">ባለፉት 24 ሰዓቶች</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> ኪባ</translation>
-<translation id="7177466738963138057">ይሄንን በኋላ ቅንብሮች ውስጥ ሊለውጡት ይችላሉ</translation>
-<translation id="7180611975245234373">አድስ</translation>
-<translation id="7189372733857464326">የGoogle Play አገልግሎቶች አዘምኖ እስኪጨርስ በመጠበቅ ላይ</translation>
-<translation id="7191430249889272776">ትር ጀርባ ላይ ተከፍቷል።</translation>
-<translation id="723171743924126238">ምስሎችን ይምረጡ</translation>
-<translation id="7233236755231902816">ድሩን በቋንቋዎ ለማየት የቅርብ ጊዜውን የChrome ስሪት ያግኙ</translation>
-<translation id="7243308994586599757">አማራጮች ከማያ ገጹ ግርጌ አጠገብ ይገኛሉ</translation>
-<translation id="7248069434667874558"><ph name="TARGET_DEVICE_NAME" /> በ Chrome ውስጥ ስምረት እንደበራለት ያረጋግጡ</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> ተመርጠዋል</translation>
-<translation id="7274013316676448362">የታገደ ጣቢያ</translation>
-<translation id="7290209999329137901">ዳግም መሰየም የለም</translation>
-<translation id="7291387454912369099">በረዳት የተቀሰቀሰ ተመዝግቦ መውጫ</translation>
-<translation id="7293171162284876153">ስምረትን ለመጀመር «የChrome ውሂብዎን ያስምሩ»ን ያብሩት።</translation>
-<translation id="729975465115245577">የእርስዎ መሣሪያ የይለፍ ቃላት ፋይሉን የሚያከማችበት መተግበሪያ የለውም።</translation>
-<translation id="7302081693174882195">ዝርዝሮች፦ በተቀመጠው የውሂብ መጠን ተደርድረዋል</translation>
-<translation id="7328017930301109123">በቀላል ሁነታ ላይ Chrome ገጾችን በበለጠ ፍጥነት የሚጭን ሲሆን እስከ 60 በመቶ ያነሰ ውሂብ ይጠቀማል።</translation>
-<translation id="7333031090786104871">አሁንም ቀዳሚ ጣቢያን በማከል ላይ</translation>
-<translation id="7352939065658542140">ቪድዮ</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 የተመረጠ ንጥል አጋራ}one{# የተመረጡ ንጥሎችን አጋራ}other{# የተመረጡ ንጥሎችን አጋራ}}</translation>
 <translation id="7359002509206457351">የመዳረሻ መክፈያ ዘዴዎች</translation>
+<translation id="8026334261755873520">የአሰሳ ውሂብ አጽዳ</translation>
+<translation id="1291207594882862231">ታሪክ፣ ኩኪዎች፣ የጣቢያ ውሂብ፣ መሸጎጫን አጽዳ…</translation>
+<translation id="7814200940910057384">የBrave ውሂብ ጸድቷል</translation>
+<translation id="1664855196866195614">የተመረጠው ውሂብ ከBrave እና የሰመሩ መሣሪያዎችዎ ተወግዷል።
+
+የእርስዎ Brave Software መለያ በ<ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> ላይ እንደ ፍለጋዎች እና የሌሎች Brave Software አገልግሎቶች እንቅስቃሴ ያሉ ሌሎች የአሰሳ ታሪክ ዓይነቶች ሊኖሩት ይችላል።</translation>
+<translation id="4699172675775169585">የተሸጎጡ ምስሎች እና ፋይሎች</translation>
+<translation id="2496180316473517155">ታሪክ አሰሳ</translation>
+<translation id="2546283357679194313">ኩኪዎች እና የጣቢያ ውሂብ</translation>
+<translation id="8662811608048051533">ከአብዛኛዎቹ ጣቢያዎች ዘግተው እንዲወጡ ያደርገዎታል።</translation>
+<translation id="8218628800671693884">ከአብዛኛዎቹ ጣቢያዎች ዘግተው ያስወጣዎታል። ከእርስዎ የBrave Software መለያ ዘግተው እንዲወጡ አይደረጉም።</translation>
+<translation id="2017836877785168846">በአድራሻ አሞሌው ውስጥ ታሪክን እና ራስ-ሰር ማጠናቀቆችን ያጸዳል።</translation>
+<translation id="8096327394278038498">በአድራሻ አሞሌው ላይ ታሪክን እና ራስ-ማጠናቀቆችን ያጸዳል። የእርስዎ Brave Software መለያ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> ላይ ሌሎች የአሰሳ ታሪክ አይነቶች ሊኖሩት ይችላል።</translation>
+<translation id="8122693181154564064">ታሪክን በመለያ ከገቡ ሁሉም መሣሪያዎች ላይ ያጸዳል። የእርስዎ Brave Software መለያ <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/> ላይ ሌሎች የአሰሳ ታሪክ ዓይነቶች ሊኖረው ይችላል</translation>
+<translation id="5869522115854928033">የተቀመጡ የይለፍ ቃሎች</translation>
+<translation id="6865313869410766144">የራስ-ሙላ ቅጽ ውሂብ</translation>
+<translation id="7562080006725997899">የአሰሳ ውሂብን በማጽዳት ላይ</translation>
+<translation id="5487521232677179737">ውሂብን አጽዳ</translation>
+<translation id="7498271377022651285">እባክዎ ይጠብቁ…</translation>
+<translation id="784934925303690534">የጊዜ ወሰን</translation>
+<translation id="1718835860248848330">የመጨረሻው ሰዓት</translation>
+<translation id="7149893636342594995">ባለፉት 24 ሰዓቶች</translation>
+<translation id="5648166631817621825">ያለፉት 7 ቀኖች</translation>
+<translation id="8571213806525832805">ባለፉት 4 ሳምንቶች</translation>
+<translation id="5854790677617711513">ከ30 ቀናት በላይ የቆየ</translation>
+<translation id="6979737339423435258">የምንጊዜም</translation>
+<translation id="982182592107339124">ይህ ለሁሉም ጣቢያዎች ውሂብን ያጸዳል፣ የሚከተሉትን ጨምሮ፦</translation>
+<translation id="6643016212128521049">አጽዳ</translation>
+<translation id="7641339528570811325">የአሰሳ ውሂብን አጽዳ…</translation>
+<translation id="1670399744444387456">መሠረታዊ</translation>
+<translation id="3245261285041759672">የእርስዎ Brave Software መለያ <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/> ላይ ሌሎች የአሰሳ ታሪክ ዓይነቶች ሊኖረው ይችላል።</translation>
+<translation id="7274013316676448362">የታገደ ጣቢያ</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> ንጥሎች ተሰርዟል</translation>
+<translation id="1121094540300013208">የአጠቃቀም እና የብልሽት ሪፖርቶች</translation>
+<translation id="9079153198295609735">የአጠቃቀም ስታስቲክስ እና የብልሽት ሪፖርቶች በራስ ሰር ወደ Brave Software ይላኩ።</translation>
+<translation id="6981982820502123353">ተደራሽነት</translation>
+<translation id="2387895666653383613">የጽሑፍ ልኬት</translation>
+<translation id="2321958826496381788">ይህን በሚመች ሁኔታ ማንበብ እስኪችሉ ድረስ ተንሸራታቹን ይጎትቱት። በአንድ አንቀጽ ላይ ሁለቴ መታ ካደረጉ በኋላ ጽሑፍ ቢያንስ የዚህ ያህል ትልቀት ሊኖረው ይገባል።</translation>
+<translation id="3895926599014793903">ማጉላት አንቃን ያስገድዱ</translation>
+<translation id="5668404140385795438">የአንድ ድር ጣቢያ ማጉላትን መከልከል ጥያቄ ሻር</translation>
+<translation id="4149994727733219643">ለድረ-ገጾች የተቃለለ እይታ</translation>
+<translation id="9100505651305367705">የሚደገፍ ሲሆን ጽሑፎችን በተቃለለ እይታ ለማሳየት ጠይቅ</translation>
+<translation id="1409426117486808224">ለክፍት ትሮች የተቃለለ እይታ</translation>
+<translation id="702463548815491781">TalkBack ወይም መዳረሻ ቀይር ሲበሩ የሚመከር</translation>
+<translation id="8284326494547611709">መግለጫ ጽሑፎች</translation>
+<translation id="4165986682804962316">የጣቢያ ቅንብሮች</translation>
+<translation id="6295158916970320988">ሁሉም ጣቢያዎች</translation>
+<translation id="8380167699614421159">ይህ ጣቢያ ረባሽ ወይም አሳሳች ማስታወቂያዎችን ያሳያል</translation>
+<translation id="1919345977826869612">ማስታወቂያዎች</translation>
+<translation id="410351446219883937">ራስ-አጫውት</translation>
+<translation id="6447842834002726250">ኩኪዎች</translation>
+<translation id="6196640612572343990">የሦስተኛ ወገን ኩኪዎችን አግድ</translation>
+<translation id="6782111308708962316">የሦስተኛ ወገን ድር ጣቢያዎች የኩኪ ውሂብን እንዳያስቀምጡ እና እንዳያነብቡ ከልክል</translation>
+<translation id="7521387064766892559">ጃቫስክሪፕት</translation>
+<translation id="4434045419905280838">ብቅ-ባዮች እና አቅጣጫ ማዞሮች</translation>
+<translation id="4751476147751820511">የእንቅስቃሴ ወይም የብርሃን ዳሳሾች</translation>
+<translation id="1717218214683051432">የእንቅስቃሴ ዳሳሾች</translation>
+<translation id="2091887806945687916">ድምፅ</translation>
+<translation id="2586657967955657006">የቅንጥብ ሰሌዳ</translation>
+<translation id="6320088164292336938">ንዘር</translation>
+<translation id="4226663524361240545">ማሳወቂያዎች መሣሪያውን እንዲነዝር ሊያደርጉት ይችላሉ</translation>
+<translation id="1446450296470737166">ሙሉ የMIDI መሣሪያዎች መቆጣጠርን ያስችላል</translation>
+<translation id="3744111561329211289">የዳራ ስምረት</translation>
+<translation id="5649053991847567735">ራስ-ሰር ውርዶች</translation>
+<translation id="6181444274883918285">ለየት ያለ ጣቢያን አክል</translation>
+<translation id="5313967007315987356">ጣቢያ አክል</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> ጣቢያ ተክሏል</translation>
+<translation id="7837721118676387834">ለአንድ የተወሰነ ጣቢያ ድምጸ-ከል የተደረጉ ቪዲዮዎችን በራስ-ሰር ማጫወትን ይፍቀዱ።</translation>
+<translation id="2621115761605608342">ጃቫስክሪፕትን ለአንድ የተወሰነ ጣቢያ ፍቀድ።</translation>
+<translation id="8801436777607969138">ጃቫስክሪፕትን ለአንድ የተወሰነ ጣቢያ አግድ።</translation>
+<translation id="8372893542064058268">ለአንድ የተወሰነ ጣቢያ የጀርባ ስምረትን ይፍቀዱ።</translation>
+<translation id="358794129225322306">አንድ ጣቢያ በራስ-ሰር በርካታ ፋይሎችን እንዲያወርድ ይፍቀዱ።</translation>
+<translation id="4008040567710660924">የተወሰነ ጣቢያ ኩኪዎችን ፍቀድ።</translation>
+<translation id="8958424370300090006">የአንድ የተወሰነ ጣቢያ ኩኪዎችን ያግዱ።</translation>
+<translation id="7882806643839505685">ለተወሰነ ጣቢያ ድምጽ ፍቀድ።</translation>
+<translation id="4468959413250150279">በአንድ የተወሰነ ጣቢያ ላይ ድምጸ-ከል አድርግ።</translation>
+<translation id="1994173015038366702">የጣቢያ ዩአርኤል</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">አጠቃቀም</translation>
+<translation id="5804241973901381774">ፍቃዶች</translation>
+<translation id="4278390842282768270">ተፈቅዷል</translation>
+<translation id="5677928146339483299">ታግዷል</translation>
+<translation id="1984937141057606926">የተፈቀደ፣ ከሶስተኛ ወገን በቀር</translation>
+<translation id="7423098979219808738">መጀመሪያ ጠይቅ</translation>
+<translation id="8116925261070264013">ድምፀ ከል ተደርጓል</translation>
+<translation id="8300705686683892304">በመተግበሪያ የሚተዳደር</translation>
+<translation id="6192792657125177640">የተለዩ</translation>
+<translation id="257931822824936280">ተዘርግቷል - ለመሰብሰብ ጠቅ ያድርጉ</translation>
+<translation id="5100237604440890931">ተሰብስቧል - ለመዘርጋት ጠቅ ያድርጉ</translation>
+<translation id="857943718398505171">ተፈቅዷል (የሚመከር)</translation>
+<translation id="2913331724188855103">ጣቢያዎች የኩኪ ውሂብ እንዲያስቀምጡ እና እንዲያነቡ ይፍቀዱ (የሚመከር)</translation>
+<translation id="7445411102860286510">ጣቢያዎች ድምፀ-ከል የተደረገባቸው ቪዲዮዎችን በራስ-ሰር እንዲያጫውቱ ይፍቀዱላቸው (የሚመከር)</translation>
+<translation id="5335288049665977812">ጣቢያዎች ጃቫስክሪፕትን እንዲያሄዱ ፍቀድላቸው (የሚመከር)</translation>
+<translation id="5527111080432883924">ጣቢያዎች ከቅንጥብ ሰሌዳ ጽሑፍ እና ምስሎችን እንዲያነብቡ ከመፍቀድ በፊት ጠይቅ (የሚመከር)</translation>
+<translation id="6912998170423641340">ጣቢያዎች ከቅንጥብ ሰሌዳ ጽሑፍን እና ምስሎችን እንዳያነብቡ አግድ</translation>
+<translation id="7423538860840206698">ቅንጥብ ሰሌዳን ከማንበብ ታግዷል</translation>
+<translation id="3955193568934677022">ጥበቃ የሚደረግበትን ይዘት እንዲያጫውቱ ለጣቢያዎች ፍቀድ (የሚመከር)</translation>
+<translation id="445467742685312942">ጣቢያዎች የተጠበቀ ይዘትን እንዲያጫውት ይፍቀዱ</translation>
+<translation id="2107397443965016585">ጣቢያዎች የተጠበቀ ይዘትን እንዲያጫውቱ ከመፍቀድዎ በፊት ይጠይቁ (የሚመከር)</translation>
+<translation id="2910701580606108292">ጣቢያዎች ጥበቃ የሚደረግለትን ይዘትን እንዲያጫውቱ ከመፍቀድ በፊት ጠይቅ</translation>
+<translation id="757524316907819857">ጣቢያዎች ጥበቃ የሚደረግለትን ይዘት እንዳያጫውቱ ያግዱ</translation>
+<translation id="3277252321222022663">ጣቢያዎች ዳሳሾችን እንዲደርሱ ይፍቀዱላቸው (የሚመከር)</translation>
+<translation id="5048398596102334565">ጣቢያዎች የእንቅስቃሴ ዳሳሾችን እንዲደርሱባቸው ይፍቀዱ (የሚመከር)</translation>
+<translation id="8816026460808729765">ጣቢያዎች ዳሳሾችን እንዳይደርሱ ያግዱ</translation>
+<translation id="169515064810179024">ጣቢያዎች የእንቅስቃሴ ዳሳሾችን እንዳይደርሱ ያግዱ</translation>
+<translation id="1660204651932907780">ጣቢያዎች ድምጽን እንዲያጫውቱ ፍቀድ (የሚመከር)</translation>
+<translation id="3600792891314830896">ድምጽን በሚያጫውቱ ጣቢያዎች ላይ ድምጸ-ከል አድርግ</translation>
+<translation id="1743802530341753419">ጣቢያዎች ከአንድ መሣሪያ ጋር እንዲገናኙ ከመፍቀድ በፊት ጠይቅ (የሚመከር)</translation>
+<translation id="851751545965956758">ጣቢያዎች ከመሣሪያዎች ጋር እንዳይገናኙ አግድ</translation>
+<translation id="7141896414559753902">ጣቢያዎች ብቅ-ባዮችን እንዳያሳዩ ያግዱ (የሚመከር)</translation>
+<translation id="5494752089476963479">ረባሽ ወይም አሳሳች ማስታወቂያዎችን ከሚያሳዩ ጣቢያዎች የሚመጡ ማስታወቂያዎችን አግድ</translation>
+<translation id="3123473560110926937">በአንዳንድ ጣቢያዎች ላይ ታግዷል</translation>
+<translation id="965817943346481315">ጣቢያው ረባሽ ወይም አሳሳች ማስታወቂያዎችን የሚያሳይ ከሆነ ማገድ (የሚመከር)</translation>
+<translation id="3386292677130313581">ጣቢያዎች አካባቢዎን እንዲያውቁ ከመፍቀድዎ በፊት ይጠይቅ (የሚመከር)</translation>
+<translation id="9139068048179869749">ጣቢያዎች ማሳወቂያዎችን እንዲልኩ ከመፍቀድ በፊት ይጠይቅ (የሚመከር)</translation>
+<translation id="4479647676395637221">ጣቢያዎች ካሜራዎን እንዲጠቀሙ ከመፍቀድዎ በፊት ይጠይቅ (የሚመከር)</translation>
+<translation id="6992289844737586249">ጣቢያዎች ማይክሮፎንዎን እንዲጠቀሙ ከመፍቀድዎ በፊት ይጠይቅ (የሚመከር)</translation>
+<translation id="2289270750774289114">አንድ ጣቢያ በአቅራቢያ ያሉ ብሉቱዝ መሣሪያዎችን ፈልጎ ለማግኘት ሲፈልግ ጠይቅ (የሚመከር)</translation>
+<translation id="7053983685419859001">አግድ</translation>
+<translation id="7128222689758636196">አሁን ላለው የፍለጋ ፕሮግራም ፍቀድ</translation>
+<translation id="7589445247086920869">አሁን ላለው የፍለጋ ፕሮግራም አግድ</translation>
+<translation id="6388207532828177975">አጽዳ እና ዳግም አስጀምር</translation>
+<translation id="7999064672810608036">እርግጠኛ ነዎት ለዚህ ጣቢያ ኩኪዎችንም ጨምሮ ሁሉንም አካባቢያዊ ውሂብ ማጽዳት እና ሁሉም ፍቃዶችን ዳግም ማስጀመር ይፈልጋሉ?</translation>
+<translation id="2822354292072154809">እርግጠኛ ነዎት ሁሉንም የ<ph name="CHOSEN_OBJECT_NAME"/> ጣቢያ ፈቃዶችን ዳግም ማስጀመር ይፈልጋሉ?</translation>
+<translation id="515227803646670480">የተከማቸ ውሂብን አጽዳ</translation>
+<translation id="5902828464777634901">ኩኪዎችንም ጨምሮ በዚህ ድር ጣቢያ የተከማቸ ሁሉም አካባቢያዊ ውሂብ ይሰረዛል።</translation>
+<translation id="119944043368869598">ሁሉንም አጽዳ</translation>
+<translation id="2490684707762498678">በ<ph name="APP_NAME"/> የሚተዳደር ነው</translation>
+<translation id="5516455585884385570">የማሳወቂያ ቅንብሮችን ክፈት</translation>
+<translation id="1404122904123200417">በ<ph name="WEBSITE_URL"/> ውስጥ ተካትቷል</translation>
+<translation id="129382876167171263">በድር ጣቢያዎች የተቀመጡ ፋይሎች እዚህ ይታያሉ</translation>
+<translation id="4181841719683918333">ቋንቋዎች</translation>
+<translation id="2647434099613338025">ቋንቋ አክል</translation>
+<translation id="1952172573699511566">ሲቻል፣ ድር ጣቢያዎች በእርስዎ ተመራጭ ቋንቋ ጽሑፍ ይታያሉ።</translation>
+<translation id="8559990750235505898">ገጾችን በሌሎች ቋንቋዎች ለመተርጎም ጥያቄ አቅርብ</translation>
+<translation id="4719927025381752090">ለመተርጎም ጥያቄ አቅርብ</translation>
+<translation id="8156139159503939589">ምን ቋንቋዎች ነው የሚያነብቡት?</translation>
+<translation id="5689516760719285838">አካባቢ</translation>
+<translation id="2440823041667407902">የአካባቢ መዳረሻ</translation>
+<translation id="2023546461831060654">በ<ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ፍቃዶችን ለBrave ያብሩ።</translation>
+<translation id="6665548517310046133">በ<ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ፍቃዶችን ለBrave ያብሩ።</translation>
+<translation id="2928908108430545745">Brave የእርስዎን መገኛ አካባቢ እንዲደርስበት ለማድረግ፣ በተጨማሪ በ <ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ መገኛ አካባቢን ያብሩ።</translation>
+<translation id="1028853271388022585">የእርስዎን ካሜራ Brave እንዲደርስበት ለማድረግ፣ በ <ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ካሜራን በተጨማሪ ያብሩ።</translation>
+<translation id="2913721282607281710">Brave ማሳወቂያዎችን እንዲልክልዎት ለማድረግ፣ በተጨማሪ በ <ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ማሳወቂያዎችን ያብሩ።</translation>
+<translation id="8753483718490035722">Brave የእርስዎን ማይክራፎን እንዲደርስ ለማድረግ፣ በ <ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ማይክራፎንን በተጨማሪ ያብሩ።</translation>
+<translation id="1887786770086287077">የአካባቢ መዳረሻ ለዚህ መሣሪያ ጠፍቷል። በ<ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ያብሩት።</translation>
+<translation id="2570922361219980984">የአካባቢ መዳረሻ እንዲሁም ለዚህ መሣሪያ ጠፍቷል። በ<ph name="BEGIN_LINK"/>Android ቅንብሮች<ph name="END_LINK"/> ውስጥ ያብሩት።</translation>
+<translation id="1620510694547887537">ካሜራ</translation>
+<translation id="3227137524299004712">ማይክሮፎን</translation>
+<translation id="1647391597548383849">ካሜራዎን ይድረሱ</translation>
+<translation id="945632385593298557">የእርስዎን ማይክሮፎን ይድረሱ</translation>
+<translation id="6612358246767739896">ጥበቃ የሚደረግለት ይዘት</translation>
+<translation id="885701979325669005">ማከማቻ</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> የተከማቸ ውሂብ</translation>
+<translation id="8847988622838149491">ዩ ኤስ ቢ</translation>
+<translation id="8447861592752582886">የመሣሪያ ፈቃድ ሻር</translation>
+<translation id="4962975101802056554">ሁሉንም የመሣሪያ ፈቃዶች ይሻሩ</translation>
+<translation id="6545864417968258051">የብሉቱዝ ቅኝት</translation>
+<translation id="4411535500181276704">ቀላል ሁነታ</translation>
+<translation id="7821588508402923572">የእርስዎ የውሂብ ቁጠባዎች እዚህ ይታያሉ</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> ተቀምጧል</translation>
+<translation id="8569404424186215731">ከ<ph name="DATE"/> ጀምሮ</translation>
+<translation id="3252158532344029638">በቀላል ሁነታ ላይ Brave ገጾችን በበለጠ ፍጥነት የሚጭን ሲሆን እስከ 60 በመቶ ያነሰ ውሂብ ይጠቀማል።</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> የውሂብ ቁጠባዎች</translation>
+<translation id="7494974237137038751">የተቆጠበው ውሂብ</translation>
+<translation id="6111020039983847643">ጥቅም ላይ የዋለው ውሂብ</translation>
+<translation id="7413229368719586778">መጀመሪያ ቀን <ph name="DATE"/></translation>
+<translation id="1782483593938241562">ማብቂያ ቀን <ph name="DATE"/></translation>
+<translation id="2728754400939377704">በጣቢያ ደርድር</translation>
+<translation id="5864174910718532887">ዝርዝሮች፦ በጣቢያ ስም የተለየ</translation>
+<translation id="116280672541001035">ጥቅም ላይ የዋለው</translation>
+<translation id="8349013245300336738">ጥቅም ላይ በዋለው የውሂብ መጠን ደርድር</translation>
+<translation id="6378173571450987352">ዝርዝሮች፦ ጥቅም ላይ በዋለው የውሂብ መጠን ተደርድረዋል</translation>
+<translation id="2631006050119455616">ተቀምጧል</translation>
+<translation id="6643649862576733715">በተቆጠበው የውሂብ መጠን ደርድር</translation>
+<translation id="7302081693174882195">ዝርዝሮች፦ በተቀመጠው የውሂብ መጠን ተደርድረዋል</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> ጥቅም ላይ ውሏል</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> ተቀምጧል</translation>
+<translation id="2156074688469523661">ቀሪ ጣቢያዎች (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">ሌላ</translation>
+<translation id="4913161338056004800">ስታትስቲክስ ዳግም አስጀምር</translation>
+<translation id="1856325424225101786">ቀላል ሁነታን ዳግም ያስጀምሩ?</translation>
+<translation id="3658159451045945436">ዳግም ማስጀመር የተጎበኙ ጣቢያዎች ዝርዝር ጨምሮ የውሂብ ቁጠባዎን ታሪክ ይደመስሳል።</translation>
+<translation id="3295530008794733555">በበለጠ ፍጥነት ያስሱ። ያነሰ ውሂብን ይጠቀሙ።</translation>
+<translation id="7340390500800578919">በቀላል ሁነታ ላይ Brave ገጾችን በበለጠ ፍጥነት የሚጭን ሲሆን እስከ 60 በመቶ ያነሰ ውሂብ ይጠቀማል። የሚጎበኟቸው ገጾችን ለማትባት Brave የድር ትራፊክዎን ወደ Brave Software ይልካል። <ph name="BEGIN_LINK"/>የበለጠ ለመረዳት<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">ቀላል ሁነታን አብራ</translation>
+<translation id="4493497663118223949">ቀላል ሁነታ በርቷል</translation>
+<translation id="7559975015014302720">ቀላል ሁነታ ጠፍቷል</translation>
+<translation id="7606077192958116810">ቀላል ሁነታ በርቷል። በቅንብሮች ውስጥ ያቀናብሩት።</translation>
+<translation id="4714588616299687897">እስከ 60% የሚደርስ ውሂብዎን ይቆጥቡ</translation>
+<translation id="1006927014032731288">የBrave Software አገልጋዮች እርስዎ የሚጎበኟቸውን ገጾች ያተባሉ።</translation>
+<translation id="3257320067425202300">Brave <ph name="MEGABYTES"/> ሜባ ቆጥቦልዎታል</translation>
+<translation id="5813223329348543512">Brave <ph name="GIGABYTES"/> ጊባ ቆጥቦልዎታል</translation>
+<translation id="8266862848225348053">የሚወርድበት ቦታ</translation>
+<translation id="7077143737582773186">ኤስዲ ካርድ</translation>
+<translation id="7762668264895820836">ኤስዲ ካርድ <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">ፋይሎች የት እንደሚቀመጡ ይጠይቁ</translation>
+<translation id="6192333916571137726">ፋይል ያውርዱ</translation>
+<translation id="1672586136351118594">ዳግም አታሳይ</translation>
+<translation id="2650751991977523696">ፋይሉ እንደገና ይውረድ?</translation>
+<translation id="8664979001105139458">የፋይል ስም አስቀድሞ አለ</translation>
+<translation id="488187801263602086">ፋይልን ዳግም ይሰይሙ</translation>
+<translation id="5686790454216892815">የፋይሉ ስም በጣም ረጅም ነው</translation>
+<translation id="7454641608352164238">በቂ ቦታ የለም</translation>
+<translation id="8972098258593396643">ወደ ነባሪው አቃፊ ይውረድ?</translation>
+<translation id="804335162455518893">ኤስዲ ካርድ አልተገኘም</translation>
+<translation id="7475688122056506577">ኤስዲ ካርድ አልተገኘም። አንዳንዶቹ ፋይሎችዎ ሊጎድሉ ይችላሉ።</translation>
+<translation id="4198423547019359126">ምንም የማውረጃ አካባቢዎች የሉም</translation>
+<translation id="8224471946457685718">በWi-Fi ላይ ለእርስዎ ጽሑፎችን ያውርዱ</translation>
+<translation id="4970824347203572753">በአካባቢዎ ውስጥ አይገኝም</translation>
+<translation id="5500777121964041360">በአካባቢዎ ውስጥ ላይገኝ ይችላል</translation>
+<translation id="1173894706177603556">ዳግም ሰይም</translation>
+<translation id="1986685561493779662">ስሙ አስቀድሞ አለ</translation>
+<translation id="6441734959916820584">ስም በጣም ረጅም ነው</translation>
+<translation id="2923908459366352541">ስም ልክ ያልሆነ ነው</translation>
+<translation id="7290209999329137901">ዳግም መሰየም የለም</translation>
+<translation id="3334729583274622784">የፋይል ቅጥያ ይቀየር?</translation>
+<translation id="107147699690128016">የፋይል ቅጥያውን ከቀየሩት ፋይሉ በተለየ መተግበሪያ ሊከፈት ይችላል፣ እና መሣሪያዎን ሊጎዳ ይችላል።</translation>
+<translation id="8541922081612557424">ስለBrave</translation>
+<translation id="5311273890481188673">የቅጂ መብት <ph name="YEAR"/> Brave Software LLC. ሁሉም መብቶች በህግ የተጠበቁ ናቸው።</translation>
+<translation id="1416550906796893042">የመተግበሪያ ስሪት</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (የተዘመነው በ<ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">ስርዓተ ክወና</translation>
+<translation id="3968054912784331254">የBrave ዝማኔዎች ከአሁን በኋላ ለዚህ የAndroid ዝማኔዎች አይደገፉም</translation>
+<translation id="7665369617277396874">መለያ ያክሉ</translation>
+<translation id="649070405679044769">እንደሚከተለው ሆነው ወደ Brave Software ይግቡ፦</translation>
+<translation id="6234515504547364178">ዘግተው ከBrave ይውጡ</translation>
+<translation id="5324858694974489420">የወላጅ መቆጣጠሪያዎች</translation>
+<translation id="8920114477895755567">የወላጆች ዝርዝሮችን በመጠበቅ ላይ።</translation>
+<translation id="5512137114520586844">ይህ መለያ የሚቀናበረው በ<ph name="PARENT_NAME"/> ነው።</translation>
+<translation id="2956410042958133412">ይህ መለያ የሚቀናበረው በ<ph name="PARENT_NAME_1"/> እና <ph name="PARENT_NAME_2"/> ነው።</translation>
+<translation id="8168435359814927499">ይዘት</translation>
+<translation id="5403644198645076998">የተወሰኑ ጣቢያዎችን ብቻ ፍቀድ</translation>
+<translation id="8641930654639604085">የአዋቂ ሰው ጣቢያዎችን ለማገድ ሞክር</translation>
+<translation id="5639724618331995626">ሁሉንም ጣቢያዎች ፍቀድ</translation>
+<translation id="796823723482603597">በBrave የጎለበተ</translation>
+<translation id="6324034347079777476">የAndroid ሥርዓት ስምረት ተሰናክሏል</translation>
+<translation id="5127805178023152808">አመሳስል ጠፍቷል</translation>
+<translation id="7015203776128479407">የመጀመሪያው የስምረት ውቅረት አላለቀም። ስምረት ጠፍቷል።</translation>
+<translation id="2497852260688568942">ስምረት በእርስዎ አስተዳዳሪ ተሰናክሏል</translation>
+<translation id="9100610230175265781">የይለፍ ሐረግ ያስፈልጋል</translation>
+<translation id="6108923351542677676">ማዋቀር በሂደት ላይ…</translation>
+<translation id="4062305924942672200">የህግ መረጃ</translation>
+<translation id="4256782883801055595">የክፍት ምንጭ ፍቃዶች</translation>
+<translation id="1138681184697033370">የBrave አገልግሎት ውል</translation>
+<translation id="7392539049993970338">የBrave ግላዊነት ማስታወቂያ</translation>
+<translation id="2677748264148917807">ለቅቀህ ውጣ</translation>
+<translation id="5556459405103347317">ዳግም ጫን</translation>
+<translation id="1623104350909869708">ይህ ገጽ ተጨማሪ መገናኛዎችን እንዳይፈጥር አግድ</translation>
+<translation id="2968755619301702150">የእውቅና ማረጋገጫ መመልከቻ</translation>
+<translation id="1360432990279830238">ዘግተው ወጥተው ስምረት ይጥፋ?</translation>
+<translation id="8581481290581777242">የBrave ውሂብዎ ከዚህ መሣሪያ ላይ ይጽዳ?</translation>
+<translation id="1318865768845061710">የእርስዎ እልባቶች፣ ታሪክ፣ የይለፍ ቃላት እና ሌላ የ Brave ውሂብ ከእንግዲህ ወደ የእርስዎ Brave Software መለያ ይሰምራል</translation>
+<translation id="3325020657155065477">በተጨማሪ ከዚህ መሣሪያ ላይ የእርስዎን Brave ውሂብ ያጽዱት</translation>
+<translation id="6136448902816743006">በ<ph name="DOMAIN_NAME"/> ከሚተዳደር መለያ ዘግተው እየወጡ ስለሆነ የBrave ውሂብዎ ከዚህ መሣሪያ ይሰረዛል። በBrave Software መለያዎ ውስጥ እንዳለ ይቆያል።</translation>
+<translation id="1853026300647876496">Brave Softwareን በማነጋገር ላይ።  ወደ አንድ ደቂቃ ሊወስድ ይችላል…</translation>
+<translation id="2328985652426384049">መግባት አልተቻለም</translation>
+<translation id="7723158744459952869">Brave Software ምላሽ ለመስጠት ከልክ በላይ ረዥም ጊዜ ወስዷል</translation>
+<translation id="4572422548854449519">ወደ የሚተዳደር መለያ ይግቡ</translation>
+<translation id="2689656545739939160">በ<ph name="MANAGED_DOMAIN"/> ወደሚተዳደር መለያ እየገቡና ሙሉውን የBrave ውሂብዎ ቁጥጥር ለአስተዳዳሪው እየሰጡ ነው። የእርስዎ ውሂብ እስከመጨረሻው ከዚህ መለያ ጋር ይተሳሰራል። ከBrave ዘግቶ መውጣት ውሂብዎን ከዚህ መሣሪያ ይሰርዘዋል፣ ነገር ግን በእርስዎ የBrave Software መለያ ላይ እንደተከማቸ ይቆያል።</translation>
+<translation id="1749561566933687563">የእርስዎን ዕልባቶች ያስምሩ</translation>
+<translation id="4242533952199664413">ቅንብሮችን ክፈት</translation>
+<translation id="1111673857033749125">በሌሎች መሣሪያዎችዎ ላይ የተቀመጡ ዕልባቶችዎ እዚህ ብቅ ይላሉ።</translation>
+<translation id="8636825310635137004">ትሮችዎን ከሌሎች መሣሪያዎችዎ ለማግኘት ስምረትን ያብሩ።</translation>
+<translation id="3269956123044984603">ትሮችዎን ከሌሎች መሣሪያዎችዎ ለማግኘት በAndroid የመለያ ቅንብሮች ውስጥ «ውሂብን በራስ-አስምር»ን ያብሩ።</translation>
+<translation id="5157964048453367290">በሌሎች መሣሪያዎችዎ ላይ ባለ Brave ላይ የከፈቷቸው ትሮች እዚህ ይመጣሉ።</translation>
+<translation id="4684427112815847243">ሁሉንም ያመሳስሉ</translation>
+<translation id="2709516037105925701">ራስ-ሙላ</translation>
+<translation id="8820817407110198400">ዕልባቶች</translation>
+<translation id="1644574205037202324">ታሪክ</translation>
+<translation id="17513872634828108">ትሮችን ክፈት</translation>
+<translation id="1320169905922104972">Brave Software Payን የሚጠቀሙ ክሬዲት ካርዶች እና አድራሻዎች</translation>
+<translation id="6337234675334993532">ምስጠራ</translation>
+<translation id="6698801883190606802">የተመሳሰለ ውሂብ ያስተዳድሩ</translation>
+<translation id="3598578758776312506">የይለፍ ቃላትን በBrave Software ምስክርነቶች መስጥር</translation>
+<translation id="7810580217418711046">የተሳመረ ውሂብ <ph name="TIME"/> ላይ በነበረው የBrave Software ይለፍ ቃል ያመስጥሩ</translation>
+<translation id="8461694314515752532">የሰመረ ውሂብ በራስዎ የስምረት ይለፍ ሐረግ ያመሣጥሩ</translation>
+<translation id="2996291259634659425">የይለፍ ሐረግ ይፍጠሩ</translation>
+<translation id="5713644099811900409">የBrave Software መለያ</translation>
+<translation id="8997474919031554666">የእርስዎ የይለፍ ሐረግ ያለው ሰው ብቻ ነው የእርስዎን የተመሰጠረ ውሂብ ማንበብ የሚችለው። የይለፍ ሐረጉ ወደ Brave Software አይላክም እንዲሁም አይከማችም። የእርስዎን የይለፍ ሐረግ ከረሱት ወይም ይህን ቅንብር መለወጥ ከፈለጉ ማሥመሩን ዳግም ማስጀመር ያስፈልገዎታል። <ph name="BEGIN_LINK"/>የበለጠ ለመረዳት<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">የይለፍ ሐረግ</translation>
+<translation id="7772032839648071052">የይለፍ ሐረግ ያረጋግጡ</translation>
+<translation id="5304593522240415983">ይህ መስክ ባዶ ሊሆን አይችልም</translation>
+<translation id="321773570071367578">የእርስዎን የይለፍሐረግ ከረሱት ወይም ይህን ቅንብር መለወጥ ከፈለጉ <ph name="BEGIN_LINK"/>ስምረትን ዳግም ያስጀምሩ<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">የይለፍ ሐረጎቹ አይዛመዱም</translation>
+<translation id="5149495116300586333">የይለፍ ሐረግ ምስጠራ ከBrave Software Pay የመክፈያ ዘዴዎችን እና አድራሻዎችን አያካትትም።
+
+ይህን ቅንብር ለመቀየር <ph name="BEGIN_LINK"/>ስምረትን ዳግም ያስጀምሩ<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">ትክክል ያልሆነ የይለፍ ሐረግ</translation>
+<translation id="5414836363063783498">በማረጋገጥ ላይ…</translation>
+<translation id="6846298663435243399">በመጫን ላይ…</translation>
+<translation id="5517095782334947753">ከ<ph name="FROM_ACCOUNT"/> የመጡ ዕልባቶች፣ ታሪክ፣ የይለፍ ቃላት  እና ሌሎች ቅንብሮች አለዎት።</translation>
+<translation id="3928666092801078803">የእኔን ውሂብ አጣምር</translation>
+<translation id="688738109438487280">ነባሩን ውሂብ ወደ <ph name="TO_ACCOUNT"/> ያክሉ።</translation>
+<translation id="806745655614357130">የእኔን ውሂብ ለብቻው አቆይ</translation>
+<translation id="1145536944570833626">ነባሩን ውሂብ ይሰርዙ።</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> መጣመር ይፈልጋል</translation>
+<translation id="4915549754973153784">መሣሪያዎችን እየቃኙ ሳሉ <ph name="BEGIN_LINK"/>እገዛን ያግኙ<ph name="END_LINK"/>…</translation>
+<translation id="5817918615728894473">አጣምር</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>እገዛን ያግኙ<ph name="END_LINK1"/> ወይም <ph name="BEGIN_LINK2"/>ዳግም ይቃኙ<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">ምንም ተኳሃኝ መሣሪያዎች አልተገኙም</translation>
+<translation id="3773755127849930740">ማጣመርን ለመፍቀድ <ph name="BEGIN_LINK"/>ብሉቱዝን ያብሩ<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave የብሉቱዝ አስማሚውን ማብራት አልቻለም</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>እገዛ ያግኙ<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave መሣሪያዎችን ለመቃኘት የአካባቢ መዳረሻ ያስፈልገዋል። <ph name="BEGIN_LINK"/>ፍቃዶችን ያዘምኑ<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave መሣሪያዎችን መቃኘት እንዲችል የአካባቢ መዳረሻ ያስፈልገዋል። የአካባቢ መዳረሻ <ph name="BEGIN_LINK"/>ለዚህ መሣሪያ ጠፍቷል<ph name="END_LINK"/>።</translation>
+<translation id="2367014990350929709">Brave መሣሪያዎችን መቃኘት እንዲችል የአካባቢ መዳረሻ ያስፈልገዋል። <ph name="BEGIN_LINK1"/>ፈቃዶችን ያዘምኑ<ph name="END_LINK1"/>። የአካባቢ መዳረሻ እንዲሁም <ph name="BEGIN_LINK2"/>ለዚህ መዳረሻ ጠፍቷል<ph name="END_LINK2"/>።</translation>
+<translation id="1569387923882100876">የተገናኘ መሣሪያ</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{የሲግናል ጥንካሬ ደረጃ፦ # አሞሌ}one{የሲግናል ጥንካሬ ደረጃ፦ # አሞሌዎች}other{የሲግናል ጥንካሬ ደረጃ፦ # አሞሌዎች}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> በአቅራቢያ የብሉቱዝ መሣሪያዎች ካሉ መቃኘት ይፈልጋል። የሚከተሉት መሣሪያዎች ተገኝተዋል፦</translation>
+<translation id="8368027906805972958">ያልታወቀ ወይም የማይደገፍ መሣሪያ (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">ስምረት እየሠራ አይደለም</translation>
+<translation id="1810845389119482123">የመጀመሪያ የስምረት ማዋቀር አልተጠናቀቀም</translation>
+<translation id="3235722914093408050">የBrave ስምረትን ለመጀመር የAndroid ቅንብሮችን ይክፈቱና የAndroid ስርዓት ስምረትን ዳግም ያንቁ</translation>
+<translation id="3367813778245106622">ስምረትን ለመጀመር እንደገና ይግቡ</translation>
+<translation id="974555521953189084">ስምረትን ለመጀመር የይለፍ ሐረግዎን ያስገቡ</translation>
+<translation id="2997266899014181325">ስምረትን ለመጀመር «የBrave ውሂብዎን ያስምሩ»ን ያብሩት።</translation>
+<translation id="8260126382462817229">እንደገና ለመግባት ይሞክሩ</translation>
+<translation id="5919204609460789179">ስምረትን ለመጀመር <ph name="PRODUCT_NAME"/>ን ያዘምኑ</translation>
+<translation id="397583555483684758">ስምረት መሥራት አቁሟል</translation>
+<translation id="1966710179511230534">እባክዎ የመግቢያ ዝርዝሮችዎን ያዘምኑ።</translation>
+<translation id="7063006564040364415">ከማመሳሰያ አገልጋዩ ጋር መገናኘት አልተቻለም።</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> ጊዜው ያለፈበት ነው።</translation>
+<translation id="4170011742729630528">አገልግሎቱ አይገኝም፤ ቆይተው እንደገና ይሞክሩ።</translation>
+<translation id="7947953824732555851">ተቀበል እና ግባ</translation>
+<translation id="8583805026567836021">የመለያ ውሂብን በማጽዳት ላይ</translation>
+<translation id="8310344678080805313">መደበኛ ትሮች</translation>
+<translation id="5748802427693696783">ወደ መደበኛ ትሮች ቀይር</translation>
+<translation id="7998918019931843664">የተዘጋውን ትር ዳግም ይክፈቱ</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>፣ ትር</translation>
+<translation id="4452411734226507615">የ<ph name="TAB_TITLE"/> ትር ዝጋ</translation>
+<translation id="7243308994586599757">አማራጮች ከማያ ገጹ ግርጌ አጠገብ ይገኛሉ</translation>
+<translation id="4060598801229743805">አማራጮች ከማያ ገጹ ግርጌ አጠገብ ይገኛሉ</translation>
+<translation id="2810645512293415242">ውሂብን ለመቆጠብ እና በበለጠ ፍጥነት ለመጫን የተቃለለ ገጽ።</translation>
+<translation id="3985215325736559418"><ph name="FILE_NAME"/>ን እንደገና ማውረድ ይፈእልጋሉ?</translation>
+<translation id="2450083983707403292"><ph name="FILE_NAME"/>ን እንደገና ማውረድ መጀመር ይፈልጋሉ?</translation>
+<translation id="7514365320538308">አውርድ</translation>
+<translation id="545042621069398927">ውርድዎን በማፍጠን ላይ።</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ፋይልን በማውረድ ላይ።}one{# ፋይሎች በማውረድ ላይ።}other{# ፋይሎች በማውረድ ላይ።}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> ፋይሎችን በማውረድ ላይ (<ph name="MEGABYTES"/>)።</translation>
+<translation id="4988210275050210843">ፋይልን በማውረድ ላይ (<ph name="MEGABYTES"/>)።</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ውርድ ተጠናቅቋል}one{# ውርዶች ተጠናቅቀዋል}other{# ውርዶች ተጠናቅቀዋል}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ውርድ አልተሳካም።}one{# ውርዶች አልተሳኩም።}other{# ውርዶች አልተሳኩም።}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 ውርድን በመጠባበቅ ላይ}one{# ውርዶችን በመጠባበቅ ላይ}other{# ውርዶችን በመጠባበቅ ላይ}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>።</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> አዝራር</translation>
+<translation id="3205824638308738187">በቃ ሊያልቅ ነው!</translation>
+<translation id="3960299545138990065">Braveን ዳግም ያስጀምሩት</translation>
+<translation id="3771001275138982843">ዝማኔውን ማውረድ አልተቻለምም</translation>
+<translation id="3888648114124182147">Brave ዝማኔን በማውረድ ላይ…</translation>
+<translation id="1705567146636171298">Braveን አዘምን</translation>
+<translation id="6195417478702700398">ለምርጥ የአሰሳ ተሞክሮ ለማግኘት Braveን ለማዘመን ይክፈቱ</translation>
+<translation id="3512968675351418494">ድሩን በቋንቋዎ ለማየት የቅርብ ጊዜውን የBrave ስሪት ያግኙ</translation>
+<translation id="6427112570124116297">ድሩን ያስተርጉሙ</translation>
+<translation id="1379423114029199501">ቋንቋዎን በቅርብ ጊዜው የBrave ስሪት ለማግኘት ያዘምኑ</translation>
+<translation id="5684874026226664614">ውይ። ይህ ገጽ ሊተረጎም አይችልም።</translation>
+<translation id="6831043979455480757">መተርጎም</translation>
+<translation id="1285320974508926690">ይህን ጣቢያ በጭራሽ አትተርጉም</translation>
+<translation id="773466115871691567">ገጾችን ሁልጊዜ በ<ph name="SOURCE_LANGUAGE"/> ተርጉም</translation>
+<translation id="1068672505746868501">በ<ph name="SOURCE_LANGUAGE"/> ውስጥ ገጾችን በጭራሽ አትተርጉም</translation>
+<translation id="124116460088058876">ተጨማሪ ቋንቋዎች</translation>
+<translation id="290376772003165898">ገጽ በ<ph name="LANGUAGE"/> አይደለም?</translation>
+<translation id="4432792777822557199">በ<ph name="SOURCE_LANGUAGE"/> ያሉ ገጾች ወደ <ph name="TARGET_LANGUAGE"/> ከአሁን በኋላ ይተረጎማሉ</translation>
+<translation id="8339163506404995330">በ<ph name="LANGUAGE"/> ያሉ ገጾች አይተረጎሙም</translation>
+<translation id="5447765697759493033">ይህ ጣቢያ አይተረጎምም</translation>
+<translation id="4880127995492972015">ተርጉም…</translation>
+<translation id="641643625718530986">አትም…</translation>
+<translation id="8909135823018751308">አጋራ…</translation>
+<translation id="4996978546172906250">ያጋሩ በ</translation>
+<translation id="6333140779060797560">በ<ph name="APPLICATION"/> በኩል ያጋሩ</translation>
+<translation id="6277522088822131679">ገጹን ማተም ላይ ችግር ነበር። እባክዎ እንደገና ይሞክሩ።</translation>
+<translation id="3254409185687681395">ለእዚህ ገጽ ዕልባት አብጅ</translation>
+<translation id="497421865427891073">ወደ ፊት ሂድ</translation>
+<translation id="813082847718468539">የጣቢያ መረጃን ይመልከቱ</translation>
+<translation id="2532336938189706096">የድር ዕይታ</translation>
+<translation id="6005538289190791541">የተጠቆመ የይለፍ ቃል</translation>
+<translation id="4634124774493850572">የይለፍ ቃል ይጠቀሙ</translation>
+<translation id="8285489906452138776">Brave ለዚህ ጣቢያ የእርስዎን ካሜራ ለመድረስ ፈቃድ ይፈልጋል።</translation>
+<translation id="320189792589364011">Brave ለዚህ ጣቢያ የእርስዎን ማይክራፎን ለመድረስ ፈቃድ ይፈልጋል።</translation>
+<translation id="7988136689212463100">Brave ለዚህ ጣቢያ የእርስዎን ካሜራ እና ማይክራፎን ለመድረስ ፈቃድ ይፈልጋል።</translation>
+<translation id="4931190655840828017">Brave አካባቢዎን ለዚህ ጣቢያ ለማጋራት የአካባቢዎ መዳረሻ ይፈልጋል።</translation>
+<translation id="3088191967551450609">Brave ፋይሎችን ለማውረድ የማከማቻ መዳረሻ ያስፈልገዋል።</translation>
+<translation id="8942627711005830162">በሌላ መስኮት ውስጥ ክፈት</translation>
+<translation id="4195643157523330669">በአዲስ ትር ክፈት</translation>
+<translation id="1100066534610197918">በቡድን ውስጥ አዲስ ትር ይክፈቱ</translation>
+<translation id="4860895144060829044">ደውል</translation>
+<translation id="6896758677409633944">ቅዳ</translation>
+<translation id="8393700583063109961">መልዕክት ይላኩ</translation>
+<translation id="3557336313807607643">ወደ እውቂያዎች አክል</translation>
+<translation id="4269820728363426813">የአገናኝ አድራሻ ቅዳ</translation>
+<translation id="1206892813135768548">የአገናኝ ጽሑፍ ቅዳ</translation>
+<translation id="1204037785786432551">የማውረጃ አገናኝ</translation>
+<translation id="6864459304226931083">ምስል አውርድ</translation>
+<translation id="8209050860603202033">ምስል ክፈት</translation>
+<translation id="8073388330009372546">ምስሉን በአዲስ ትር ውስጥ ክፈት</translation>
+<translation id="6649642165559792194">ምስል <ph name="BEGIN_NEW"/>አዲስ<ph name="END_NEW"/>ን ቅድሚያ ይመልከቱ</translation>
+<translation id="3269093882174072735">ምስል ጫን</translation>
+<translation id="3845332215609790146">በBrave Software Lens ይፈልጉ <ph name="BEGIN_NEW"/>አዲስ<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">ይህንን ምስል <ph name="SEARCH_ENGINE"/> ላይ ይፈልጉት</translation>
+<translation id="3384347053049321195">ምስል አጋራ</translation>
+<translation id="5833984609253377421">አገናኝ አጋራ</translation>
+<translation id="6475951671322991020">ቪድዮ አውርድ</translation>
+<translation id="2317945146070194624">በአዲስ የBrave ትር ውስጥ ክፈት</translation>
+<translation id="7975379999046275268">ገጽ <ph name="BEGIN_NEW"/>አዲስ<ph name="END_NEW"/> ቅድሚያ ይመልከቱ</translation>
+<translation id="6112702117600201073">ገጽ በማደስ ላይ</translation>
+<translation id="36525718899759834">መተግበሪያውን ከBrave Software Play መደብር ያግኙ፦ <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">ጨለማ</translation>
+<translation id="1807246157184219062">ብርሃን</translation>
+<translation id="4056223980640387499">ቀይ ቡናማ</translation>
+<translation id="3927692899758076493">ሳንስ ሰሪፍ</translation>
+<translation id="5016205925109358554">ሰሪፍ</translation>
+<translation id="2593272815202181319">ሞኖስፔስ</translation>
+<translation id="9206873250291191720">አ</translation>
+<translation id="654446541061731451">በሞገድ የሚለቅቁት ትር ይምረጡ</translation>
+<translation id="8719023831149562936">የአሁኑን ትር በሞገድ መላክ አልተቻለም</translation>
+<translation id="2139186145475833000">ወደ መነሻ ማያ ገጽ አክል</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/>ን ይክፈቱ</translation>
+<translation id="2122601567107267586">መተግበሪያውን መክፈት አልተቻለም</translation>
+<translation id="5129038482087801250">የድር መተግበሪያን ጫን</translation>
+<translation id="3789841737615482174">ጫን</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> ወደ እርስዎ መነሻ ገፅ ታክሏል</translation>
+<translation id="7333031090786104871">አሁንም ቀዳሚ ጣቢያን በማከል ላይ</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/>ን በማከል ላይ...</translation>
+<translation id="3778956594442850293">ወደ የመነሻ ገጽ ታክሏል</translation>
+<translation id="2146738493024040262">ቅጽበታዊ መተግበሪያን ክፈት</translation>
+<translation id="7016516562562142042">ለአሁኑ የፍለጋ ፕሮግራም ተፈቅዷል</translation>
+<translation id="6177111841848151710">ለአሁኑ የፍለጋ ፕሮግራም ታግዷል</translation>
+<translation id="145097072038377568">በAndroid ቅንብሮች ውስጥ ጠፍቷል።</translation>
+<translation id="8007176423574883786">ለዚህ መሣሪያ ጠፍቷል</translation>
+<translation id="164269334534774161"><ph name="CREATION_TIME"/> ላይ የነበረ የዚህን ገጽ የመስመር ውጪ ቅጂ በመመልከት ላይ ነዎት</translation>
+<translation id="4594952190837476234">ይህ የ<ph name="CREATION_TIME"/>  የመስመር ውጭ ገጽ ከመስመር ላይ ስሪቱ የተለየ ሊሆን ይችላል።</translation>
+<translation id="8840953339110955557">ይህ ገጽ ከመስመር ላይ ስሪቱ የተለየ ሊሆን ይችላል።</translation>
+<translation id="6405300764336705484">ይህ ይዘት ከ<ph name="DOMAIN_NAME"/> የመጣ ነው፣ የተላከው በBrave Software ነው።</translation>
+<translation id="1006017844123154345">መስመር ላይ ክፈት</translation>
+<translation id="3326636747541519688">ቀላል ገጹ በBrave Software ቀርቧል።</translation>
+<translation id="7149158118503947153">ከ<ph name="DOMAIN_NAME"/> <ph name="BEGIN_LINK"/>የመጀመሪያውን ገጽ ጫን<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">ይህን በተደጋጋሚነት እያዩት ከሆኑ እነዚህን <ph name="BEGIN_LINK"/>የአስተያየት ጥቆማዎች<ph name="END_LINK"/> ይሞክሩ።</translation>
+<translation id="8748850008226585750">ይዘቶች ተደብቀዋል</translation>
+<translation id="3810973564298564668">አቀናብር</translation>
+<translation id="5199929503336119739">የሥራ መገለጫ</translation>
+<translation id="528192093759286357">ከሙሉ ማያ ገጽ ለመውጣት ከላይ ይጎትቱ እና የተመለስ አዝራሩን ይንኩ።</translation>
+<translation id="2836148919159985482">ከሙሉ ማያ ገጽ ለመውጣት የተመለስ አዝራሩን ይንኩ።</translation>
+<translation id="3967822245660637423">ማውረድ ተጠናቅቋል</translation>
+<translation id="2434158240863470628">ማውረድ ተጠናቅቋል <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">ማውረድ አልተሳካም</translation>
+<translation id="1384959399684842514">የሚወርደው ላፍታ ቆሟል</translation>
+<translation id="1671236975893690980">ውርድ በመጠባበቅ ላይ...</translation>
+<translation id="5561549206367097665">አውታረ መረብን በመጠበቅ ላይ…</translation>
+<translation id="5864419784173784555">ሌላ ውርድን በመጠበቅ ላይ…</translation>
+<translation id="6461962085415701688">ፋይሉን መክፈት አይቻልም</translation>
+<translation id="1178581264944972037">ለአፍታ አቁም</translation>
+<translation id="8200772114523450471">ከቆመበት ቀጥል</translation>
+<translation id="1409879593029778104">ፋይሉ አስቀድሞ ስላለ <ph name="FILE_NAME"/>ን ማውረድ ታግዷል።</translation>
+<translation id="3387650086002190359">በስርዓተ-ፋይል ስህተቶች ምክንያት <ph name="FILE_NAME"/>ን ማውረድ አልተሳካም።</translation>
+<translation id="6482749332252372425">በማከማቻ ቦታ ጥበት ምክንያት <ph name="FILE_NAME"/>ን ማውረድ አልተሳካም።</translation>
+<translation id="7619072057915878432">በአውታረ መረብ ችግሮች ምክንያት <ph name="FILE_NAME"/>ን ማውረድ አልተሳካም።</translation>
+<translation id="1477626028522505441">በአገልጋይ ችግሮች ምክንያት <ph name="FILE_NAME"/>ን ማውረድ አልተሳካም።</translation>
+<translation id="3692944402865947621">የማከማቻ ቦታው የማይገኝ ስለሆነ <ph name="FILE_NAME"/>ን ማውረድ አልተሳካም።</translation>
+<translation id="604996488070107836"><ph name="FILE_NAME"/>ን ማውረድ ባልታወቀ ስህተት ምክንያት አልተሳካም።</translation>
+<translation id="6738867403308150051">በማውረድ ላይ…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> ኪባ</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> ሜባ</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> ጊባ</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> ኪባ ወርዷል</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> ሜባ ወርዷል</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> ጊባ ወርዷል</translation>
+<translation id="9204836675896933765">1 ፋይል ቀርቷል</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> ፋይሎች ይቀራሉ</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/>ፋይል ወርዷል}one{<ph name="FILES_DOWNLOADED_MANY"/> ፋይሎች ወርደዋል}other{<ph name="FILES_DOWNLOADED_MANY"/> ፋይሎች ወርደዋል}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> ቀኖች ይቀራሉ</translation>
+<translation id="8190358571722158785">1 ቀን ይቀራል</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> ሰዓቶች ይቀራሉ</translation>
+<translation id="510275257476243843">1 ሰዓት ይቀራል</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> ደቂቃዎች ይቀራሉ</translation>
+<translation id="3236059992281584593">1 ደቂቃ ይቀራል</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> ሰከንዶች ይቀራሉ</translation>
+<translation id="2781151931089541271">1 ሰከንድ ይቀራል</translation>
+<translation id="3303414029551471755">ይዘቱን ማውረድ ይቀጥል?</translation>
+<translation id="8617240290563765734">በወረደው ይዘት ላይ የተጠቆመው ዩአርኤል ይከፈት?</translation>
+<translation id="1373696734384179344">የተመረጠውን ይዘት ለማውረድ በቂ ያልሆነ ማህደረ ትውስታ።</translation>
+<translation id="5271967389191913893">መሣሪያ የሚወርደውን ይዘት መክፈት አይችልም።</translation>
+<translation id="883806473910249246">ይዘቱን በማውረድ ላይ ሳለ አንድ ስህተት ተከስቷል።</translation>
+<translation id="5626134646977739690">ስም፦</translation>
+<translation id="7963646190083259054">አቅራቢ፦</translation>
+<translation id="3414952576877147120">መጠን፦</translation>
+<translation id="7375125077091615385">ዓይነት፦</translation>
+<translation id="5765780083710877561">መግለጫ</translation>
+<translation id="4881695831933465202">ክፈት</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> ኪባ ይገኛል</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> ሜባ አለ</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> ጊባ ይገኛል</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> ከ<ph name="SPACE_AVAILABLE"/> በመጠቀም ላይ</translation>
+<translation id="3587482841069643663">ሁሉም</translation>
+<translation id="4988526792673242964">ገፆች</translation>
+<translation id="3810838688059735925">ቪዲዮ</translation>
+<translation id="3616113530831147358">ድምጽ</translation>
+<translation id="9219103736887031265">ምስሎች</translation>
+<translation id="8250920743982581267">ሰነዶች</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ፋይል}one{# ፋይሎች}other{# ፋይሎች}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ምስል}one{# ምስሎች}other{# ምስሎች}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# ቪዲዮ}one{# ቪዲዮዎች}other{# ቪዲዮዎች}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ኦዲዮ ፋይል}one{# ኦዲዮ ፋይሎች}other{# ኦዲዮ ፋይሎች}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# ገጽ}one{# ገጾች}other{# ገጾች}}</translation>
+<translation id="5456381639095306749">ገጽ አውርድ</translation>
+<translation id="2394602618534698961">የሚያወርዷቸው ፋይሎች እዚህ ይታያሉ</translation>
+<translation id="7810647596859435254">ክፈት በ…</translation>
+<translation id="5655963694829536461">የእርስዎን ውርዶች ይፈልጉ</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">የእኔ ፋይሎች</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">እርስዎ ከመስመር ውጭ ሆነውም እንኳ ሊያነብቧቸው የሚችሏቸውን ጽሑፎች እዚህ ይመጣሉ</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ሰዓ}one{# ሰዓቶች}other{# ሰዓቶች}}</translation>
+<translation id="5853623416121554550">ባለበት ቆሟል</translation>
+<translation id="8965591936373831584">በመጠበቅ ላይ</translation>
+<translation id="2779651927720337254">አልተሳካም</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">ልክ አሁን</translation>
+<translation id="4000212216660919741">ከመስመር ውጭ መነሻ</translation>
+<translation id="9133397713400217035">ከመስመር ውጭ ያስሱ</translation>
+<translation id="968900484120156207">እርስዎ የሚጎበኟቸው ገጾች እዚህ ላይ ብቅ ይላሉ</translation>
+<translation id="7882131421121961860">ምንም ታሪክ አልተገኘም</translation>
+<translation id="3549657413697417275">የራስዎን ታሪክ ይፈልጉ</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">ወወ</translation>
+<translation id="605721222689873409">ዓዓ</translation>
+<translation id="724102042129299115">Brave የመጀመሪያ አሂድ ተሞክሮ</translation>
+<translation id="2700285883409956633">ይህን መተግበሪያ በመጠቀምዎ በBrave <ph name="BEGIN_LINK1"/>አገልግሎት ውል<ph name="END_LINK1"/> እና <ph name="BEGIN_LINK2"/>የግላዊነት ማስታወቂያ<ph name="END_LINK2"/> ተስማምተዋል።</translation>
+<translation id="1640714894372474981">ይህን መተግበሪያ በመጠቀምዎ በBrave <ph name="BEGIN_LINK1"/>አገልግሎት ውል<ph name="END_LINK1"/> እና <ph name="BEGIN_LINK2"/>የግላዊነት ማሳወቂያ<ph name="END_LINK2"/> እንዲሁም <ph name="BEGIN_LINK3"/>በFamily Link ለሚተዳደሩ የBrave Software መለያዎች የግላዊነት ማሳወቂያ<ph name="END_LINK3"/> ይስማማሉ።</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> በBrave ውስጥ ይከፈታል። በመቀጠልዎ በBrave <ph name="BEGIN_LINK1"/>አገልግሎት ውል<ph name="END_LINK1"/> እና <ph name="BEGIN_LINK2"/>የግላዊነት ማስታወቂያ<ph name="END_LINK2"/> ተስማምተዋል።</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> በBrave ውስጥ ይከፈታል። በመቀጠልዎ በBrave <ph name="BEGIN_LINK1"/>አገልግሎት ውል<ph name="END_LINK1"/> እና <ph name="BEGIN_LINK2"/>የግላዊነት ማስታወቂያ<ph name="END_LINK2"/>፣ እና በ<ph name="BEGIN_LINK3"/>በFamily Link የሚተዳደሩ የBrave Software መለያዎች ግላዊነት ማስታወቂያ<ph name="END_LINK3"/> ተስማምተዋል።</translation>
+<translation id="673197144963363525">የአጠቃቀም ስታቲክሶችን እና የብልሽት ሪፖርቶችን ወደ Brave Software በመላክ Braveን የተሻለ ለማድረግ እገዛ ያድርጉ።</translation>
+<translation id="3518985090088779359">ተቀበል እና ቀጥል</translation>
+<translation id="7207456302801184289">ወደ Brave እንኳን ደህና መጡ</translation>
+<translation id="704822250101715322">የBrave Software Play አገልግሎቶች አዘምኖ እስኪጨርስ በመጠበቅ ላይ</translation>
+<translation id="1231733316453485619">አስምር ይብራ?</translation>
+<translation id="5132942445612118989">የእርስዎን የይለፍ ቃላት፣ ታሪክ እና ተጨማሪ ነገሮች በሁሉም መሣሪያዎች ላይ ያስምሩ</translation>
+<translation id="5736731321935944068">Brave Software ፍለጋን፣ ማስታወቂያዎችን እና ሌሎች የBrave Software አገልግሎቶችን ግላዊነት ለማላበስ የእርስዎን ታሪክ ሊጠቀም ይችላል</translation>
+<translation id="4013614219085422040">Brave Software ፍለጋን እና ሌሎች የBrave Software አገልግሎቶችን ግላዊነት ለማላበስ ሲል ታሪክዎን ሊጠቀም ይችላል።</translation>
+<translation id="5581519193887989363">በማንኛውም ጊዜ ምን እንደሚያሰምሩ በ<ph name="BEGIN_LINK1"/>ቅንብሮች<ph name="END_LINK1"/> ውስጥ መምረጥ ይችላሉ።</translation>
+<translation id="741204030948306876">አዎ፣ ገብቼያለሁ</translation>
+<translation id="2410754283952462441">አንድ መለያ ይምረጡ</translation>
+<translation id="2227444325776770048">እንደ <ph name="USER_FULL_NAME"/> ሆነው ይቀጥሉ</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> አይደለም?</translation>
+<translation id="8109613176066109935">የእርስዎን ዕልባቶች በሁሉም መሣሪያዎችዎ ላይ ስምረትን ማብራት ለማግኘት</translation>
+<translation id="2818669890320396765">የእርስዎን ዕልባቶች በሁሉም መሣሪያዎችዎ ላይ ለማግኘት በመለያ መግባት እና ስምረትን ማብራት ለማግኘት</translation>
+<translation id="6003646045106347985">በBrave Software የተጠቆመ ግላዊነት የተላበሰ ይዘትን ስምረትን ማብራት ለማግኘት</translation>
+<translation id="8494430740943879273">በBrave Software የተጠቆመ ግላዊነት የተላበሰ ይዘትን በመለያ መግባት እና ስምረትን ማብራት ለማግኘት</translation>
+<translation id="5862731021271217234">ትሮችዎን ከሌሎች መሣሪያዎችዎ ስምረትን ማብራት ለማግኘት</translation>
+<translation id="3568688522516854065">ትሮችዎን ከሌሎች መሣሪያዎችዎ በመለያ መግባት እና ስምረትን ማብራት ለማግኘት</translation>
+<translation id="1208340532756947324">በመላ መሣሪያዎች ላይ ስምረትን ማብራት ለማስመር እና ግላዊነትን ለማላበስ</translation>
+<translation id="4472118726404937099">በመላ መሣሪያዎች ላይ በመለያ መግባት እና ስምረትን ማብራት ለማስመር እና ግላዊነትን ለማላበስ</translation>
+<translation id="2426805022920575512">ሌላ መለያ ይምረጡ</translation>
+<translation id="6790428901817661496">አጫውት</translation>
+<translation id="1272079795634619415">አቁም</translation>
+<translation id="2874939134665556319">ቀዳሚ ትራክ</translation>
+<translation id="4046123991198612571">ቀጣይ ትራክ</translation>
+<translation id="3859306556332390985">ወደፊት ፈልግ</translation>
+<translation id="8441146129660941386">ወደኋላ ፈልግ</translation>
+<translation id="6706288973712894588">በአሁኑ ጊዜ ከመስመር ውጪ ነዎት።\n<ph name="BEGIN_LINK"/>የመስመር ውጭ ምግብዎን ያስሱ።<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">የቅርብ ጊዜ ትሮች</translation>
+<translation id="8497726226069778601">እዚህ ምንም የሚታይ ነገር የለም... ገና</translation>
+<translation id="5423934151118863508">በጣም በብዛት የተጎበኙ ገጾችዎ እዚህ ይመጣሉ</translation>
+<translation id="6127379762771434464">ንጥል ተወግዷል</translation>
+<translation id="4605958867780575332">ንጥል ተወግዷል፦ <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle፦ <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">ሌሎች መሣሪያዎች</translation>
+<translation id="4738836084190194332">የተመሳሰለበት የመጨረሻው ጊዜ፦ <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{ከ# ደቂቃ በፊት}one{ከ# ደቂቃዎች በፊት}other{ከ# ደቂቃዎች በፊት}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{ከ# ሰዓት በፊት}one{ከ# ሰዓቶች በፊት}other{ከ# ሰዓቶች በፊት}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{ከ# ቀን በፊት}one{ከ# ቀኖች በፊት}other{ከ# ቀኖች በፊት}}</translation>
+<translation id="2762000892062317888">አሁን</translation>
+<translation id="1407135791313364759">ሁሉንም ክፈት</translation>
+<translation id="1209206284964581585">ለአሁን ደብቅ</translation>
+<translation id="129553762522093515">በቅርብ ጊዜ የተዘጉ</translation>
+<translation id="8413126021676339697">ሙሉ ታሪክ አሳይ</translation>
+<translation id="7876243839304621966">ሁሉንም አስወግድ</translation>
+<translation id="8487700953926739672">ከመስመር ውጪ ይገኛል</translation>
+<translation id="5224771365102442243">ከቪዲዮ ጋር</translation>
+<translation id="3493531032208478708">ስለሚጠቆም ይዘት <ph name="BEGIN_LINK"/>የበለጠ ለመረዳት<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">የአስተያየት ጥቆማዎችን ማግኘት አልተቻለም</translation>
+<translation id="5013696553129441713">ምንም አዲስ የአስተያየት ጥቆማዎች የሉም</translation>
+<translation id="1736419249208073774">አስስ</translation>
+<translation id="7444811645081526538">ተጨማሪ ምድቦች</translation>
+<translation id="6709133671862442373">ዜና</translation>
+<translation id="1264974993859112054">ሰፖርቶች</translation>
+<translation id="9139318394846604261">ግዢ</translation>
+<translation id="3912508018559818924">ምርጡን ከድር ማግኘት…</translation>
+<translation id="526421993248218238">ይህን ገጽ መጫን አልተቻለም</translation>
+<translation id="614940544461990577">ይሞክሩ፦</translation>
+<translation id="3288003805934695103">ገጹን እንደገና መጫን</translation>
+<translation id="2353636109065292463">የበይነመረብ ግንኙነትዎን ይፈትሹ</translation>
+<translation id="2858138569776157458">ከፍተኛ ጣቢያዎች</translation>
+<translation id="8364299278605033898">ታዋቂ ድር ጣቢያዎችን ይመልከቱ</translation>
+<translation id="1171770572613082465">የ«ከፍተኛ ጣቢያዎች» አዝራሩን መታ በማድረግ ታዋቂ ድር ጣቢያዎችን ይመልከቱ</translation>
+<translation id="5233638681132016545">አዲስ ትር</translation>
+<translation id="4521874409998847950">ከ<ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>በBrave Software የተላከ<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">አዲስ ስሪት ይገኛል</translation>
+<translation id="4058091506841967397">Braveን ማዘመን አይቻልም</translation>
+<translation id="6316139424528454185">የAndroid ስሪቱ አይደገፍም</translation>
+<translation id="6989267951144302301">ማውረድ አልተቻለም</translation>
+<translation id="624789221780392884">ማዘመኛ ዝግጁ ነው</translation>
+<translation id="1549000191223877751">ወደ ሌላ መስኮት ውሰድ</translation>
+<translation id="7481312909269577407">ወደ ፊት</translation>
+<translation id="4084682180776658562">ዕልባት</translation>
+<translation id="6437478888915024427">የገጽ መረጃ</translation>
+<translation id="7180611975245234373">አድስ</translation>
+<translation id="4913169188695071480">ማደስ አቁም</translation>
+<translation id="1829244130665387512">በዚህ ገጽ ውስጥ የተገኘ</translation>
+<translation id="6593061639179217415">የዴስክቶፕ ጣቢያ</translation>
+<translation id="9063523880881406963">የዴስክቶፕ ጣቢያ ጠይቅን አጥፋ</translation>
+<translation id="2038563949887743358">የዴስክቶፕ ጣቢያን ጠይቅን አብራ</translation>
+<translation id="2433507940547922241">ገጽታ</translation>
+<translation id="983192555821071799">ሁሉንም ትሮች ይዝጉ</translation>
+<translation id="1310482092992808703">ትሮችን ይሰብስቡ</translation>
+<translation id="7725024127233776428">እርስዎ ዕልባት ያደረጉባቸው ገጾች እዚህ ላይ ብቅ ይላሉ</translation>
+<translation id="4404568932422911380">ምንም ዕልባቶች የሉም</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> ዕልባት}one{<ph name="BOOKMARKS_COUNT_MANY"/> ዕልባቶች}other{<ph name="BOOKMARKS_COUNT_MANY"/> ዕልባቶች}}</translation>
+<translation id="3739899004075612870">በ<ph name="PRODUCT_NAME"/> ውስጥ ዕልባት ተቀምጦለታል</translation>
+<translation id="3207960819495026254">ዕልባት ተደርጎበታል</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> ላይ ዕልባት ተደርጓል</translation>
+<translation id="8063895661287329888">ዕልባት ማከል አልተሳካም።</translation>
+<translation id="2842985007712546952">ወላጅ አቃፊ</translation>
+<translation id="9065203028668620118">አርትዕ</translation>
+<translation id="4405224443901389797">ውሰድ ወደ…</translation>
+<translation id="5170568018924773124">በአቃፊ አሳይ</translation>
+<translation id="8035133914807600019">አዲስ አቃፊ…</translation>
+<translation id="4532845899244822526">አቃፊ ይምረጡ</translation>
+<translation id="6627583120233659107">አቃፊ አርትዕ</translation>
+<translation id="1197267115302279827">ዕልባቶችን ውሰድ</translation>
+<translation id="6963766334940102469">ዕልባቶችን ሰርዝ</translation>
+<translation id="4351244548802238354">መገናኛ ዝጋ</translation>
+<translation id="451872707440238414">ዕልባቶችዎን ይፈልጉ</translation>
+<translation id="8901170036886848654">ምንም ዕልባቶች አልተገኙም</translation>
+<translation id="6404511346730675251">ዕልባት አርትዕ</translation>
+<translation id="3894427358181296146">አቃፊ ያክሉ</translation>
+<translation id="5327248766486351172">ስም</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">አቃፊ</translation>
+<translation id="5161254044473106830">ርዕስ ያስፈልጋል</translation>
+<translation id="2996809686854298943">ዩአርኤል ያስፈልጋል</translation>
+<translation id="2536728043171574184">የዚህን ገጽ የመስመር ውጭ ቅጂ በመመልከት ላይ</translation>
+<translation id="4698034686595694889">በ<ph name="APP_NAME"/> ውስጥ ከመስመር ውጭ ይመልከቱ</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> እና ተጨማሪ ጣቢያዎች</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave ዝግጁ ሲሆን ገጽዎን ይጭነዋል}one{Brave ዝግጁ ሲሆን ገጾችዎን ይጭነዋል}other{Brave ዝግጁ ሲሆን ገጾችዎን ይጭነዋል}}</translation>
+<translation id="6811034713472274749">ገጽ ለመመልከት ዝግጁ ነው</translation>
+<translation id="4561979708150884304">ግንኙነት የለም</translation>
+<translation id="8274165955039650276">ውርዶችን ይመልከቱ</translation>
+<translation id="2082238445998314030">ውጤት <ph name="RESULT_NUMBER"/> ከ<ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">ውጤቶች የሉም</translation>
+<translation id="981121421437150478">ከመስመር ውጪ</translation>
+<translation id="3298243779924642547">ቀላል</translation>
+<translation id="393697183122708255">ምንም የነቃ የድምጽ ፍለጋ አይገኝም</translation>
+<translation id="7191430249889272776">ትር ጀርባ ላይ ተከፍቷል።</translation>
+<translation id="8445059357334030806">በBrave ውስጥ ክፈት</translation>
+<translation id="4720023427747327413">በ<ph name="PRODUCT_NAME"/> ውስጥ ክፈት</translation>
+<translation id="7022756207310403729">በአሳሽ ውስጥ ክፈት</translation>
+<translation id="1113597929977215864">የተቃለለ እይታን አሳይ</translation>
+<translation id="1513352483775369820">ዕልባቶች እና የድር ታሪክ</translation>
+<translation id="4939482511480190003">Brave እንዲሻሻል ያግዙ። <ph name="BEGIN_LINK"/>የዳሰሳ ጥናት ይወሰዱ<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">ወደ ኋላ ተመለስ</translation>
+<translation id="5596627076506792578">ተጨማሪ አማራጮች</translation>
+<translation id="3522247891732774234">ዝማኔ ይገኛል። ተጨማሪ አማራጮች</translation>
+<translation id="6773423637732432200">Brave መዘመን አይችልም። ተጨማሪ አማራጮች</translation>
+<translation id="3328801116991980348">የጣቢያ መረጃ</translation>
+<translation id="5391532827096253100">ወደዚህ ጣቢያ ያልዎት ግንኙነት ደህንነቱ የተጠበቀ አይደለም። የጣቢያ መረጃ</translation>
+<translation id="6206551242102657620">ግንኙነት ደህንነቱ የተጠበቀ ነው። የጣቢያ መረጃ</translation>
+<translation id="6963642900430330478">ይህ ገጽ አደገኛ ነው። የጣቢያ መረጃ</translation>
+<translation id="9070377983101773829">የድምጽ ፍለጋን ጀምር</translation>
+<translation id="8676374126336081632">ግቤቱን አጽዳ</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> ትርን ይክፈቱ፣ ትሮችን ለመቀየር መታ ያድርጉ}one{<ph name="OPEN_TABS_MANY"/> ትሮችን ይክፈቱ፣ ትሮችን ለመቀየር መታ ያድርጉ}other{<ph name="OPEN_TABS_MANY"/> ትሮችን ይክፈቱ፣ ትሮችን ለመቀየር መታ ያድርጉ}}</translation>
+<translation id="2369533728426058518">ክፍት ትሮች</translation>
+<translation id="7071521146534760487">መለያን አቀናብር</translation>
+<translation id="932327136139879170">መነሻ</translation>
+<translation id="2707726405694321444">ገጹን አድስ</translation>
+<translation id="2891154217021530873">ገጹን መጫን አቁም</translation>
+<translation id="6710213216561001401">ቀዳሚ</translation>
+<translation id="6659594942844771486">ትር</translation>
+<translation id="1933845786846280168">የተመረጠው ትር</translation>
+<translation id="2268044343513325586">አጽዳ</translation>
+<translation id="7846076177841592234">ምርጫ ሰርዝ</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> ተመርጠዋል።  አማራጮች ከማያ ገጹ አናት አጠገብ ይገኛሉ</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> ተመርጠዋል</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 የተመረጠ ንጥል አጋራ}one{# የተመረጡ ንጥሎችን አጋራ}other{# የተመረጡ ንጥሎችን አጋራ}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 የተመረጠ ንጥልን አስወግድ}one{# የተመረጡ ንጥሎችን አስወግድ}other{# የተመረጡ ንጥሎችን አስወግድ}}</translation>
+<translation id="1283039547216852943">ለመዘርጋት መታ ያድርጉ</translation>
+<translation id="5962718611393537961">ለመሰብሰብ መታ ያድርጉ</translation>
+<translation id="8076492880354921740">ትሮች</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ተመርጧል}one{# ተመርጠዋል}other{# ተመርጠዋል}}</translation>
+<translation id="6818926723028410516">ንጥሎችን ይምረጡ</translation>
+<translation id="4797039098279997504">ወደ <ph name="URL_OF_THE_CURRENT_TAB"/> ለመመለስ ይንኩ</translation>
+<translation id="6766758767654711248">ወደ ጣቢያ ለመሄዴ መታ ያድርጉ</translation>
+<translation id="429312253194641664">አንድ ጣቢያ ሚዲያን በማጫወት ላይ ነው</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> ማያ ገጽዎን እያጋራ ነው</translation>
+<translation id="8833831881926404480">አንድ ጣቢያ ማያ ገጽዎን እያጋራ ነው</translation>
+<translation id="9086455579313502267">አውታረ መረቡን መድረስ አልተቻለም።</translation>
+<translation id="938850635132480979">ስህተት፦ <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">በ<ph name="APP_NAME"/> ውስጥ ክፈት</translation>
+<translation id="548278423535722844">በካርታዎች መተግበሪያ ውስጥ ይክፈቱ</translation>
+<translation id="7698359219371678927">በ<ph name="APP_NAME"/> ውስጥ ኢሜይል ይፍጠሩ</translation>
+<translation id="7875915731392087153">ኢሜይል ይፍጠሩ</translation>
+<translation id="5665379678064389456">በ<ph name="APP_NAME"/> ውስጥ ክስተት ይፍጠሩ</translation>
+<translation id="2900528713135656174">ክስተት ፍጠር</translation>
+<translation id="2111511281910874386">ወደዚህ ገጽ ይሂዱ</translation>
+<translation id="3988466920954086464">በዚህ ፓነል ውስጥ ቅጽበታዊ የፍለጋ ውጤቶችን ይመልከቱ</translation>
+<translation id="2744248271121720757">አንድ ቃል በቅጽበት ለመፈለግ ወይም ተዛማጅ እርምጃዎችን ለመመልከት አንድ ቃል መታ ያድርጉ</translation>
+<translation id="9155898266292537608">እንዲሁም አንድ ቃል ላይ በፍጥነት መታ በማድረግ ፍለጋ ማድረግ ይችላሉ</translation>
+<translation id="3232754137068452469">የድር መተግበሪያ</translation>
+<translation id="1430915738399379752">አትም</translation>
+<translation id="3775705724665058594">ወደ መሣሪያዎችዎ ይላኩ</translation>
+<translation id="6364438453358674297">ጥቆማው ከታሪክ ይወገድ?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> ተዘግቷል</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> ትሮች ተዘግተዋል</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> ተሰርዟል</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> ዕልባቶች ተሰርዘዋል</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> የሚወርዱ ተሰርዘዋል</translation>
+<translation id="1248710015876067820">የማይደገፍ የBrave አብነቶች ብዛት።</translation>
+<translation id="4259722352634471385">ዳሰሳ ታግዷል፦ <ph name="URL"/></translation>
+<translation id="8959122750345127698">ዳሰሳ ሊደረስበት አይችልም፦ <ph name="URL"/></translation>
+<translation id="5210365745912300556">ትር ዝጋ</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/>ን ዝጋ</translation>
+<translation id="1227058898775614466">የዳሰሳ ታሪክ</translation>
+<translation id="9169507124922466868">የዳሰሳ ታሪክ በግማሽ ተከፍቷል</translation>
+<translation id="1327257854815634930">የዳሰሳ ታሪክ ተከፍቷል</translation>
+<translation id="8788265440806329501">የዳሰሳ ታሪክ ተዘግቷል</translation>
+<translation id="7482656565088326534">የቅድመ-እይታ ትር</translation>
+<translation id="8427875596167638501">የቅድመ-እይታ ትር ግማሽ ተከፍቷል</translation>
+<translation id="9102803872260866941">የቅድመ-እይታ ትር ተከፍቷል</translation>
+<translation id="2942036813789421260">የቅድመ-እይታ ትር ተዘግቷል</translation>
+<translation id="6355102470683871794">የBrave Software <ph name="APP_NAME"/> ማከማቻ</translation>
+<translation id="3822502789641063741">የጣቢያ ማከማቻ ይጽዳ?</translation>
+<translation id="9205995714227143200">Brave አላስፈላጊ ነው የሚያስበው የጣቢያ ማከማቻ (ለምሳሌ፦ ምንም የተቀመጡ ቅንብሮች የሌላቸው ጣቢያዎች ወይም እርስዎ ብዙ ጊዜ የማይጎበኟቸው)</translation>
+<translation id="3997476611815694295">የማያስፈልግ ማከማቻ</translation>
+<translation id="8493948351860045254">ቦታ አስለቅቅ</translation>
+<translation id="2324920234469020158">ይሄ Brave አስፈላጊ ናቸው ብሎ የማያስባቸውን ኩኪዎች፣ መሸጎጫ እና ሌሎች ጣቢያዎች ያጸዳል።</translation>
+<translation id="5447201525962359567">ኩኪዎች እና ሌላ በአከባቢያዊ የተከማቸ ውሂብን ጨምሮ ሁሉም የጣቢያ ማከማቻ</translation>
+<translation id="1376578503827013741">በማስላት ላይ…</translation>
+<translation id="583281660410589416">ያልታወቀ</translation>
+<translation id="2323763861024343754">የጣቢያ ማከማቻ</translation>
+<translation id="3587672679800759167">መለያዎች፣ ዕልባቶች እና የተቀመጡ ቅንብሮችን ጨምሮ Brave የተጠቀመው ጠቅላላ ውሂብ</translation>
+<translation id="6545017243486555795">ሁሉንም ውሂብ አጽዳ</translation>
+<translation id="4095146165863963773">የመተግበሪያ ውሂብ ይሰረዝ?</translation>
+<translation id="53119194224775367">ሁሉንም የBrave መተግበሪያ ውሂብ እስከመጨረሻው ይሰረዛል። ይሄ ሁሉንም ፋይሎች፣ ቅንብሮች፣ መለያዎች፣ የውሂብ ጎታዎች፣ ወዘተ. ያካትታል።</translation>
+<translation id="5307446750509046227">የጣቢያ ማከማቻን አጽዳ</translation>
+<translation id="300526633675317032">ይህ ሁሉንም <ph name="SIZE_IN_KB"/> የድር ጣቢያ ማከማቻ ያጸዳል።</translation>
+<translation id="8068648041423924542">የዕውቅና ማረጋገጫን መምረጥ አልተቻለም።</translation>
+<translation id="2315043854645842844">የደንበኛ ወገን ዕውቅና ማረጋገጫ ምርጫ በስርዓተ-ክወናው አይደገፍም።</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> መገናኘት ይፈልጋል</translation>
+<translation id="5308380583665731573">ይገናኙ</translation>
+<translation id="868929229000858085">እውቂያዎችዎን ይፈልጉ</translation>
+<translation id="1919950603503897840">ዕውቂያዎችን ምረጥ</translation>
+<translation id="7986741934819883144">አንድ እውቂያ ይምረጡ</translation>
+<translation id="3333961966071413176">ሁሉም እውቂያዎች</translation>
+<translation id="4994033804516042629">ምንም ዕውቂያዎች አልተገኙም</translation>
+<translation id="5403592356182871684">ስሞች</translation>
+<translation id="2717722538473713889">ኢሜይል አድራሻዎች</translation>
+<translation id="381841723434055211">ስልክ ቁጥሮች</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ተጨማሪ)}one{(+ # ተጨማሪ)}other{(+ # ተጨማሪ)}}</translation>
+<translation id="5197729504361054390">የመረጧቸው እውቂያዎች ለ<ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> ይጋራሉ።</translation>
+<translation id="1779089405699405702">ስውር ምስል መፍቻ</translation>
+<translation id="8067883171444229417">ቪዲዮ አጫውት</translation>
+<translation id="6560414384669816528">ከSogou ጋር ይፈልጉ</translation>
+<translation id="5406914950576900927">Brave በቻይና ውስጥ <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>ን ለፍለጋ መጠቀም ይችላል። ይህን በ<ph name="BEGIN_LINK"/>ቅንብሮች<ph name="END_LINK"/> ውስጥ መጠቀም ይችላሉ።</translation>
+<translation id="6456271171669383967">Brave Softwareን አቆየው</translation>
+<translation id="4384468725000734951">ለፍለጋ Sogouን መጠቀም</translation>
+<translation id="6103327872225198548">ለፍለጋ Brave Softwareን መጠቀም</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">ይህ መተግበሪያ በBrave ውስጥ እያሄደ ነው</translation>
+<translation id="6143689084714664628">በBrave ውስጥ በማሄድ ላይ</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> እንዲሁም በBrave ውስጥ ውሂብ አለው</translation>
+<translation id="2734140769649165081">ውሂቡን በBrave ቅንብሮች ውስጥ ማጽዳት ይችላሉ</translation>
+<translation id="8232956427053453090">ውሂብን አቆይ</translation>
+<translation id="4298388696830689168">የተገናኙ ጣቢያዎች</translation>
+<translation id="5763514718066511291">የዚህ መተግበሪያ ዩአርኤል ለመቅዳት መታ ያድርጉ</translation>
+<translation id="6496823230996795692"><ph name="APP_NAME"/>ን ለመጀመሪያ ጊዜ ለመጠቀም እባክዎ ከበይነመረብ ጋር ይገናኙ።</translation>
+<translation id="751961395872307827">ከበይነመረቡ ጋር መገናኘት አልተቻለም</translation>
+<translation id="4878404682131129617">በተኪ አገልጋይ በኩል ዋሻን መመስረት አልተሳካም</translation>
+<translation id="4749960740855309258">አዲስ ትር ክፈት</translation>
+<translation id="8788968922598763114">መጨረሻ ላይ የተዘጋውን ትር ዳግም ክፈት</translation>
+<translation id="7929962904089429003">ምናሌውን ክፈት</translation>
+<translation id="6039379616847168523">ወደ ቀጣዩ ትር ዝለል</translation>
+<translation id="5210286577605176222">ወደ ቀዳሚው ትር ዝለል</translation>
+<translation id="124678866338384709">የአሁኑን ትር ዝጋ</translation>
+<translation id="3714981814255182093">የአግኝ አሞሌን ክፈት</translation>
+<translation id="5441522332038954058">ወደ የአድራሻው አሞሌ ዘልለህ ሂድ</translation>
+<translation id="3398320232533725830">የዕልባቶች አስተዳዳሪን ክፈት</translation>
+<translation id="6583199322650523874">የአሁኑን ገጽ ዕልባት አድርግበት</translation>
+<translation id="8489271220582375723">የታሪክ ገጹን ክፈት</translation>
+<translation id="4837753911714442426">ገጽን ለማተም አማራጮችን ክፈት</translation>
+<translation id="5726692708398506830">በገጹ ላይ ያለውን ሁሉንም ነገር ይበልጥ አተልቅ</translation>
+<translation id="3259831549858767975">በገጹ ላይ ያለውን ሁሉንም ነገር ይበልጥ አሳንስ</translation>
+<translation id="8015452622527143194">በገጹ ላይ ያለውን ሁሉንም ነገር ወደ ነባሪ መጠን መልስ</translation>
+<translation id="3443221991560634068">የአሁኑን ገጽ ዳግም ጫን</translation>
+<translation id="123724288017357924">የተሸጎጠ ይዘትን ችላ በማለት የአሁኑን ገጽ ዳግም ጫን</translation>
+<translation id="305870044889644984">የBrave እገዛ ማዕከልን በአዲስ ትር ውስጥ ክፈት</translation>
+<translation id="3166827708714933426">የትር እና የመስኮት አቋራጮች</translation>
+<translation id="3169981355900570544">የBrave Software Brave ባህሪ አቋራጮች</translation>
+<translation id="4558311620361989323">የድረ-ገጽ አቋራጮች</translation>
+<translation id="1908301351964700579">Brave አሁንም ድረስ ቪአር በማዘጋጀት ላይ ነው። Braveን በኋላ ላይ ዳግም ያስጀምሩ።</translation>
+<translation id="8970887620466824814">የሆነ ችግር ተፈጥሯል።</translation>
+<translation id="1875543012935658554">Braveን ዳግም ክፈት።</translation>
+<translation id="79859296434321399">የትክክለኛ እውነታ ይዘትን ለማየት ARCore ይጫኑ</translation>
+<translation id="8558485628462305855">የትክክለኛ እውነታ ይዘትን ለማየት ARCore ያዘምኑ</translation>
+<translation id="3513704683820682405">ትክክለኛ እውነታ</translation>
+<translation id="5475862044948910901">የሚጨምር የእውነት ክፍለ ጊዜ ይጀመር?</translation>
 <translation id="7365126855094612066">ለዚህ ወቅት ቆይታ ጊዜ ያህል፣ ጣቢያው የሚከተሉትን ማድረግ ይችላል፦
 • የእርስዎን አካባቢ የ 3D ካርታ መፍጠር
 • የካሜራን እንቅስቃሴ ዱካ መከታተል
 
 ይህ ጣቢያ ወደ ካሜራ መዳረሻ አያገኝም። የካሜራ ምስሎች ለእርስዎ ብቻ የሚታዩ ናቸው።</translation>
-<translation id="7375125077091615385">ዓይነት፦</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />።</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome የመጀመሪያ አሂድ ተሞክሮ</translation>
-<translation id="741204030948306876">አዎ፣ ገብቼያለሁ</translation>
-<translation id="7413229368719586778">መጀመሪያ ቀን <ph name="DATE" /></translation>
-<translation id="7423098979219808738">መጀመሪያ ጠይቅ</translation>
-<translation id="7423538860840206698">ቅንጥብ ሰሌዳን ከማንበብ ታግዷል</translation>
-<translation id="7431991332293347422">ፍለጋን እና ተጨማሪ ነገሮችን ግላዊነት ለማላበስ የእርስዎ የአሰሳ ታሪክ እንዴት ጥቅም ላይ እንደሚውል ይቆጣጠሩ</translation>
-<translation id="7437998757836447326">ዘግተው ከChrome ይውጡ</translation>
-<translation id="7438641746574390233">ቀላል ሁነታ ሲበራ Chrome ገጾች በበለጠ ፍጥነት እንዲጭኑ ለማድረግ የGoogle አገልጋዮችን ይጠቀማል። ቀላል ሁነታ በጣም ቀርፋፋ የሆኑ ገጾች መሠረታዊ ይዘትን ብቻ እንዲጭኑ አድርጎ ዳግም ይጽፋቸዋል። ቀላል ሁነታ ማንነት በማያሳውቁ ትሮች ላይ አይተገበርም።</translation>
-<translation id="7444811645081526538">ተጨማሪ ምድቦች</translation>
-<translation id="7445411102860286510">ጣቢያዎች ድምፀ-ከል የተደረገባቸው ቪዲዮዎችን በራስ-ሰር እንዲያጫውቱ ይፍቀዱላቸው (የሚመከር)</translation>
-<translation id="7453467225369441013">ከአብዛኛዎቹ ጣቢያዎች ዘግተው ያስወጣዎታል። ከእርስዎ የGoogle መለያ ዘግተው እንዲወጡ አይደረጉም።</translation>
-<translation id="7454641608352164238">በቂ ቦታ የለም</translation>
-<translation id="7475192538862203634">ይህን በተደጋጋሚነት እያዩት ከሆኑ እነዚህን <ph name="BEGIN_LINK" />የአስተያየት ጥቆማዎች<ph name="END_LINK" /> ይሞክሩ።</translation>
-<translation id="7475688122056506577">ኤስዲ ካርድ አልተገኘም። አንዳንዶቹ ፋይሎችዎ ሊጎድሉ ይችላሉ።</translation>
-<translation id="7479104141328977413">የትር አስተዳደር</translation>
-<translation id="7481312909269577407">ወደ ፊት</translation>
-<translation id="7482656565088326534">የቅድመ-እይታ ትር</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (የተዘመነው በ<ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">የተቆጠበው ውሂብ</translation>
-<translation id="7498271377022651285">እባክዎ ይጠብቁ…</translation>
-<translation id="7514365320538308">አውርድ</translation>
-<translation id="751961395872307827">ከበይነመረቡ ጋር መገናኘት አልተቻለም</translation>
-<translation id="7521387064766892559">ጃቫስክሪፕት</translation>
-<translation id="7542481630195938534">የአስተያየት ጥቆማዎችን ማግኘት አልተቻለም</translation>
-<translation id="7559975015014302720">ቀላል ሁነታ ጠፍቷል</translation>
-<translation id="7562080006725997899">የአሰሳ ውሂብን በማጽዳት ላይ</translation>
-<translation id="756809126120519699">የChrome ውሂብ ጸድቷል</translation>
-<translation id="757524316907819857">ጣቢያዎች ጥበቃ የሚደረግለትን ይዘት እንዳያጫውቱ ያግዱ</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" />ፋይል ወርዷል}one{<ph name="FILES_DOWNLOADED_MANY" /> ፋይሎች ወርደዋል}other{<ph name="FILES_DOWNLOADED_MANY" /> ፋይሎች ወርደዋል}}</translation>
-<translation id="7588219262685291874">የመሣሪያዎ ባትሪ ቆጣቢ ሲበራ ጨለማ ገጽታን ያብሩ</translation>
-<translation id="7589445247086920869">አሁን ላለው የፍለጋ ፕሮግራም አግድ</translation>
-<translation id="7593557518625677601">የChrome ስምረትን ለመጀመር የAndroid ቅንብሮችን ይክፈቱና የAndroid ስርዓት ስምረትን ዳግም ያንቁ</translation>
-<translation id="7596558890252710462">ስርዓተ ክወና</translation>
-<translation id="7605594153474022051">ስምረት እየሠራ አይደለም</translation>
-<translation id="7606077192958116810">ቀላል ሁነታ በርቷል። በቅንብሮች ውስጥ ያቀናብሩት።</translation>
-<translation id="7612619742409846846">እንደሚከተለው ሆነው ወደ Google ይግቡ፦</translation>
-<translation id="7619072057915878432">በአውታረ መረብ ችግሮች ምክንያት <ph name="FILE_NAME" />ን ማውረድ አልተሳካም።</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />እገዛን ያግኙ<ph name="END_LINK1" /> ወይም <ph name="BEGIN_LINK2" />ዳግም ይቃኙ<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">ወደ Chrome እንኳን ደህና መጡ</translation>
-<translation id="7638584964844754484">ትክክል ያልሆነ የይለፍ ሐረግ</translation>
-<translation id="7641339528570811325">የአሰሳ ውሂብን አጽዳ…</translation>
-<translation id="7648422057306047504">የይለፍ ቃላትን በGoogle ምስክርነቶች መስጥር</translation>
-<translation id="7649070708921625228">እገዛ</translation>
-<translation id="7658239707568436148">ይቅር</translation>
-<translation id="7665369617277396874">መለያ ያክሉ</translation>
-<translation id="766587987807204883">እርስዎ ከመስመር ውጭ ሆነውም እንኳ ሊያነብቧቸው የሚችሏቸውን ጽሑፎች እዚህ ይመጣሉ</translation>
-<translation id="7682724950699840886">የሚከተሉትን ጠቃሚ ምክሮች ይሞክሩ፦ በእርስዎ መሣሪያ ላይ በቂ ባዶ ቦታ መኖሩን ያረጋግጡ፣ ወይም እንደገና ወደ ውጭ ለመላክ ይሞክሩ።</translation>
-<translation id="7685301384041462804">ወደ ቪአር ከመግባትዎ በፊት ይህን ጣቢያ የሚያምኑ መሆንዎን ያረጋግጡ።</translation>
-<translation id="7698359219371678927">በ<ph name="APP_NAME" /> ውስጥ ኢሜይል ይፍጠሩ</translation>
-<translation id="7704317875155739195">ፍለጋዎችን እና ዩአርኤልዎችን በራስ-አጠናቅቅ</translation>
-<translation id="7725024127233776428">እርስዎ ዕልባት ያደረጉባቸው ገጾች እዚህ ላይ ብቅ ይላሉ</translation>
-<translation id="773466115871691567">ገጾችን ሁልጊዜ በ<ph name="SOURCE_LANGUAGE" /> ተርጉም</translation>
-<translation id="7746457520633464754">አደገኛ መተግበሪያዎችን እና ጣቢያዎችን ፈልጎ ለማግኘት፣ Chrome እርስዎ የጎበኟቸውን አንዳንድ ገጾች ዩአርኤሎች፣ የተወሰነ የሥርዓት መረጃ እና አንዳንድ የገጽ ይዘት ወደ Google ይልካል</translation>
-<translation id="7757787379047923882">ከ<ph name="DEVICE_NAME" /> የተጋራ ጽሑፍ</translation>
-<translation id="7762668264895820836">ኤስዲ ካርድ <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">አድራሻ አክል</translation>
-<translation id="7772032839648071052">የይለፍ ሐረግ ያረጋግጡ</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" />ን ዝጋ</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ተጨማሪ}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ተጨማሪ}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 እና <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ተጨማሪ}}</translation>
-<translation id="7781829728241885113">ትናንት</translation>
-<translation id="7791543448312431591">አክል</translation>
-<translation id="780301667611848630">አይ፣ አመሰግናለሁ</translation>
-<translation id="7810647596859435254">ክፈት በ…</translation>
-<translation id="7821588508402923572">የእርስዎ የውሂብ ቁጠባዎች እዚህ ይታያሉ</translation>
-<translation id="7837721118676387834">ለአንድ የተወሰነ ጣቢያ ድምጸ-ከል የተደረጉ ቪዲዮዎችን በራስ-ሰር ማጫወትን ይፍቀዱ።</translation>
-<translation id="7846076177841592234">ምርጫ ሰርዝ</translation>
-<translation id="784934925303690534">የጊዜ ወሰን</translation>
-<translation id="7851858861565204677">ሌሎች መሣሪያዎች</translation>
-<translation id="7875915731392087153">ኢሜይል ይፍጠሩ</translation>
-<translation id="7876243839304621966">ሁሉንም አስወግድ</translation>
-<translation id="7882131421121961860">ምንም ታሪክ አልተገኘም</translation>
-<translation id="7882806643839505685">ለተወሰነ ጣቢያ ድምጽ ፍቀድ።</translation>
-<translation id="7886917304091689118">በChrome ውስጥ በማሄድ ላይ</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ፋይልን በማውረድ ላይ።}one{# ፋይሎች በማውረድ ላይ።}other{# ፋይሎች በማውረድ ላይ።}}</translation>
-<translation id="7929962904089429003">ምናሌውን ክፈት</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> ጊዜው ያለፈበት ነው።</translation>
-<translation id="7947953824732555851">ተቀበል እና ግባ</translation>
-<translation id="7963646190083259054">አቅራቢ፦</translation>
-<translation id="7971136598759319605">1 ቀን በፊት ንቁ ነበር</translation>
-<translation id="7975379999046275268">ገጽ <ph name="BEGIN_NEW" />አዲስ<ph name="END_NEW" /> ቅድሚያ ይመልከቱ</translation>
-<translation id="7981313251711023384">ይበልጥ ፈጣን ለሆነ አሰሳ እና ፍለጋ ገጾችን ቅድሚያ ይጫኑ</translation>
-<translation id="79859296434321399">የትክክለኛ እውነታ ይዘትን ለማየት ARCore ይጫኑ</translation>
-<translation id="7986741934819883144">አንድ እውቂያ ይምረጡ</translation>
-<translation id="7987073022710626672">የChrome አገልግሎት ውል</translation>
-<translation id="7998918019931843664">የተዘጋውን ትር ዳግም ይክፈቱ</translation>
-<translation id="7999064672810608036">እርግጠኛ ነዎት ለዚህ ጣቢያ ኩኪዎችንም ጨምሮ ሁሉንም አካባቢያዊ ውሂብ ማጽዳት እና ሁሉም ፍቃዶችን ዳግም ማስጀመር ይፈልጋሉ?</translation>
-<translation id="8004582292198964060">አሳሽ</translation>
-<translation id="8007176423574883786">ለዚህ መሣሪያ ጠፍቷል</translation>
-<translation id="8013372441983637696">በተጨማሪ ከዚህ መሣሪያ ላይ የእርስዎን Chrome ውሂብ ያጽዱት</translation>
-<translation id="8015452622527143194">በገጹ ላይ ያለውን ሁሉንም ነገር ወደ ነባሪ መጠን መልስ</translation>
-<translation id="802154636333426148">ማውረድ አልተሳካም</translation>
-<translation id="8026334261755873520">የአሰሳ ውሂብ አጽዳ</translation>
-<translation id="8035133914807600019">አዲስ አቃፊ…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> ቀኖች ይቀራሉ</translation>
-<translation id="804335162455518893">ኤስዲ ካርድ አልተገኘም</translation>
-<translation id="805047784848435650">በእርስዎ የአሰሳ ታሪክ ላይ በመመስረት</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> ሜባ አለ</translation>
-<translation id="8058746566562539958">በአዲስ የChrome ትር ውስጥ ክፈት</translation>
-<translation id="8063895661287329888">ዕልባት ማከል አልተሳካም።</translation>
-<translation id="806745655614357130">የእኔን ውሂብ ለብቻው አቆይ</translation>
-<translation id="8067883171444229417">ቪዲዮ አጫውት</translation>
-<translation id="8068648041423924542">የዕውቅና ማረጋገጫን መምረጥ አልተቻለም።</translation>
-<translation id="8073388330009372546">ምስሉን በአዲስ ትር ውስጥ ክፈት</translation>
-<translation id="8076492880354921740">ትሮች</translation>
-<translation id="8084114998886531721">የተቀመጠ ይለፍ ቃል</translation>
-<translation id="8087000398470557479">ይህ ይዘት ከ<ph name="DOMAIN_NAME" /> የመጣ ነው፣ የተላከው በGoogle ነው።</translation>
-<translation id="8103578431304235997">ማንነት የማያሳውቅ ትር</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">የእርስዎን ዕልባቶች በሁሉም መሣሪያዎችዎ ላይ ስምረትን ማብራት ለማግኘት</translation>
-<translation id="8110087112193408731">በዲጂታል ብቁ መሆን ውስጥ የChrome እንቅስቃሴዎ ይታይ?</translation>
-<translation id="8116925261070264013">ድምፀ ከል ተደርጓል</translation>
-<translation id="813082847718468539">የጣቢያ መረጃን ይመልከቱ</translation>
-<translation id="8131740175452115882">አረጋግጥ</translation>
-<translation id="8156139159503939589">ምን ቋንቋዎች ነው የሚያነብቡት?</translation>
-<translation id="8168435359814927499">ይዘት</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> ፋይሎች ይቀራሉ</translation>
-<translation id="8190358571722158785">1 ቀን ይቀራል</translation>
-<translation id="8200772114523450471">ከቆመበት ቀጥል</translation>
-<translation id="8209050860603202033">ምስል ክፈት</translation>
-<translation id="8218622182176210845">መለያዎን ያቀናብሩ</translation>
-<translation id="8224471946457685718">በWi-Fi ላይ ለእርስዎ ጽሑፎችን ያውርዱ</translation>
-<translation id="8232956427053453090">ውሂብን አቆይ</translation>
-<translation id="8249310407154411074">ወደ ላይ ውሰድ</translation>
-<translation id="8250920743982581267">ሰነዶች</translation>
-<translation id="825412236959742607">ይህ ገጽ በጣም ብዙ ማህደረ ትውስታን ይጠቀማል፣ ስለዚህ Chrome አንዳንድ ይዘትን አስወግዷል።</translation>
-<translation id="8260126382462817229">እንደገና ለመግባት ይሞክሩ</translation>
-<translation id="8261506727792406068">ሰርዝ</translation>
-<translation id="8266862848225348053">የሚወርድበት ቦታ</translation>
-<translation id="8274165955039650276">ውርዶችን ይመልከቱ</translation>
-<translation id="8284326494547611709">መግለጫ ጽሑፎች</translation>
-<translation id="8300705686683892304">በመተግበሪያ የሚተዳደር</translation>
-<translation id="8310344678080805313">መደበኛ ትሮች</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> እና ተጨማሪ ጣቢያዎች</translation>
-<translation id="8327155640814342956">ለምርጥ የአሰሳ ተሞክሮ ለማግኘት Chromeን ለማዘመን ይክፈቱ</translation>
-<translation id="8339163506404995330">በ<ph name="LANGUAGE" /> ያሉ ገጾች አይተረጎሙም</translation>
-<translation id="8349013245300336738">ጥቅም ላይ በዋለው የውሂብ መጠን ደርድር</translation>
-<translation id="8364299278605033898">ታዋቂ ድር ጣቢያዎችን ይመልከቱ</translation>
-<translation id="8368027906805972958">ያልታወቀ ወይም የማይደገፍ መሣሪያ (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">ለአንድ የተወሰነ ጣቢያ የጀርባ ስምረትን ይፍቀዱ።</translation>
-<translation id="8378714024927312812">በእርስዎ ድርጅት የሚተዳደር</translation>
-<translation id="8380167699614421159">ይህ ጣቢያ ረባሽ ወይም አሳሳች ማስታወቂያዎችን ያሳያል</translation>
-<translation id="8393700583063109961">መልዕክት ይላኩ</translation>
-<translation id="8413126021676339697">ሙሉ ታሪክ አሳይ</translation>
-<translation id="8427875596167638501">የቅድመ-እይታ ትር ግማሽ ተከፍቷል</translation>
-<translation id="8428213095426709021">ቅንብሮች</translation>
-<translation id="8438566539970814960">ፍለጋዎችን እና አሰሳን የተሻለ አድርግ</translation>
-<translation id="8441146129660941386">ወደኋላ ፈልግ</translation>
-<translation id="8443209985646068659">Chromeን ማዘመን አይቻልም</translation>
-<translation id="8445448999790540984">የይለፍ ቃላትን ወደ ውጭ መላክ አልተቻለም</translation>
-<translation id="8447861592752582886">የመሣሪያ ፈቃድ ሻር</translation>
-<translation id="8461694314515752532">የሰመረ ውሂብ በራስዎ የስምረት ይለፍ ሐረግ ያመሣጥሩ</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> ከበይነ መረብ ጋር መገናኘቱን ያረጋግጡ</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ከመስመር ውጪ ይገኛል</translation>
-<translation id="8489271220582375723">የታሪክ ገጹን ክፈት</translation>
-<translation id="8493948351860045254">ቦታ አስለቅቅ</translation>
-<translation id="8497726226069778601">እዚህ ምንም የሚታይ ነገር የለም... ገና</translation>
-<translation id="8503559462189395349">የChrome ይለፍ ቃላት</translation>
-<translation id="8503813439785031346">የተጣቃሚ ስም</translation>
-<translation id="8514477925623180633">ከChrome ጋር የተከማቹ የይለፍ ቃሎችን ወደ ውጭ ላክ</translation>
-<translation id="8514577642972634246">ማንነት ወደ ማያሳውቅ ሁነታ ይግቡ</translation>
-<translation id="851751545965956758">ጣቢያዎች ከመሣሪያዎች ጋር እንዳይገናኙ አግድ</translation>
-<translation id="8523928698583292556">የተከማቸ የይለፍ ቃል ሰርዝ</translation>
-<translation id="854522910157234410">ይህን ገጽ ክፈት</translation>
-<translation id="8558485628462305855">የትክክለኛ እውነታ ይዘትን ለማየት ARCore ያዘምኑ</translation>
-<translation id="8559990750235505898">ገጾችን በሌሎች ቋንቋዎች ለመተርጎም ጥያቄ አቅርብ</translation>
-<translation id="8562452229998620586">የተቀመጡ ይለፍ ቃላት እዚህ ይመጣሉ።</translation>
-<translation id="8569404424186215731">ከ<ph name="DATE" /> ጀምሮ</translation>
-<translation id="8571213806525832805">ባለፉት 4 ሳምንቶች</translation>
-<translation id="857943718398505171">ተፈቅዷል (የሚመከር)</translation>
-<translation id="8583805026567836021">የመለያ ውሂብን በማጽዳት ላይ</translation>
-<translation id="860043288473659153">የካርድ ያዢ ስም</translation>
-<translation id="8609465669617005112">ወደላይ አውጣ</translation>
-<translation id="8616006591992756292">የእርስዎ Google መለያ <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" /> ላይ ሌሎች የአሰሳ ታሪክ ዓይነቶች ሊኖረው ይችላል።</translation>
-<translation id="8617240290563765734">በወረደው ይዘት ላይ የተጠቆመው ዩአርኤል ይከፈት?</translation>
-<translation id="8636825310635137004">ትሮችዎን ከሌሎች መሣሪያዎችዎ ለማግኘት ስምረትን ያብሩ።</translation>
-<translation id="8641930654639604085">የአዋቂ ሰው ጣቢያዎችን ለማገድ ሞክር</translation>
-<translation id="8655129584991699539">ውሂቡን በChrome ቅንብሮች ውስጥ ማጽዳት ይችላሉ</translation>
-<translation id="8662811608048051533">ከአብዛኛዎቹ ጣቢያዎች ዘግተው እንዲወጡ ያደርገዎታል።</translation>
-<translation id="8664979001105139458">የፋይል ስም አስቀድሞ አለ</translation>
-<translation id="8676374126336081632">ግቤቱን አጽዳ</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{የሲግናል ጥንካሬ ደረጃ፦ # አሞሌ}one{የሲግናል ጥንካሬ ደረጃ፦ # አሞሌዎች}other{የሲግናል ጥንካሬ ደረጃ፦ # አሞሌዎች}}</translation>
-<translation id="868929229000858085">እውቂያዎችዎን ይፈልጉ</translation>
-<translation id="869891660844655955">የሚያበቀበት ጊዜ</translation>
-<translation id="8719023831149562936">የአሁኑን ትር በሞገድ መላክ አልተቻለም</translation>
-<translation id="8725066075913043281">እንደገና ይሞክሩ</translation>
-<translation id="8728487861892616501">ይህን መተግበሪያ በመጠቀምዎ በChrome <ph name="BEGIN_LINK1" />አገልግሎት ውል<ph name="END_LINK1" /> እና <ph name="BEGIN_LINK2" />የግላዊነት ማሳወቂያ<ph name="END_LINK2" /> እንዲሁም <ph name="BEGIN_LINK3" />በFamily Link ለሚተዳደሩ የGoogle መለያዎች የግላዊነት ማሳወቂያ<ph name="END_LINK3" /> ይስማማሉ።</translation>
-<translation id="8730621377337864115">ተከናውኗል</translation>
-<translation id="8748850008226585750">ይዘቶች ተደብቀዋል</translation>
-<translation id="8751914237388039244">ምስል ይምረጡ</translation>
-<translation id="8788265440806329501">የዳሰሳ ታሪክ ተዘግቷል</translation>
-<translation id="8788968922598763114">መጨረሻ ላይ የተዘጋውን ትር ዳግም ክፈት</translation>
-<translation id="8801436777607969138">ጃቫስክሪፕትን ለአንድ የተወሰነ ጣቢያ አግድ።</translation>
-<translation id="8812260976093120287">በአንዳንድ ድር ጣቢያዎች ላይ ከላይ ባሉ የሚደገፉ የክፍያ መተግበሪያዎች በመሣሪያዎ ላይ መክፈል ይችላሉ።</translation>
-<translation id="8816026460808729765">ጣቢያዎች ዳሳሾችን እንዳይደርሱ ያግዱ</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> በChrome ውስጥ ይከፈታል። በመቀጠልዎ በChrome <ph name="BEGIN_LINK1" />አገልግሎት ውል<ph name="END_LINK1" /> እና <ph name="BEGIN_LINK2" />የግላዊነት ማስታወቂያ<ph name="END_LINK2" />፣ እና በ<ph name="BEGIN_LINK3" />በFamily Link የሚተዳደሩ የGoogle መለያዎች ግላዊነት ማስታወቂያ<ph name="END_LINK3" /> ተስማምተዋል።</translation>
-<translation id="8820817407110198400">ዕልባቶች</translation>
-<translation id="8833831881926404480">አንድ ጣቢያ ማያ ገጽዎን እያጋራ ነው</translation>
-<translation id="883806473910249246">ይዘቱን በማውረድ ላይ ሳለ አንድ ስህተት ተከስቷል።</translation>
-<translation id="8840953339110955557">ይህ ገጽ ከመስመር ላይ ስሪቱ የተለየ ሊሆን ይችላል።</translation>
-<translation id="8847988622838149491">ዩ ኤስ ቢ</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />፣ ትር</translation>
-<translation id="885701979325669005">ማከማቻ</translation>
-<translation id="889338405075704026">ወደ የChrome ቅንብሮች ይሂዱ</translation>
-<translation id="8901170036886848654">ምንም ዕልባቶች አልተገኙም</translation>
-<translation id="8909135823018751308">አጋራ…</translation>
-<translation id="8912362522468806198">የGoogle መለያ</translation>
-<translation id="8920114477895755567">የወላጆች ዝርዝሮችን በመጠበቅ ላይ።</translation>
+<translation id="1188239144602654184">AR ያስገቡ</translation>
+<translation id="473775607612524610">አዘምን</translation>
+<translation id="3133489217401741157"><ph name="MODULE"/> ን ለBrave በመጫን ላይ…</translation>
+<translation id="1791662854739702043">የተጫነ</translation>
+<translation id="5131234170665854056"><ph name="MODULE"/> ን ለBrave ለመጫን አልተቻለም</translation>
+<translation id="2567385386134582609">ምስል</translation>
+<translation id="6395288395575013217">አገናኝ</translation>
+<translation id="7352939065658542140">ቪድዮ</translation>
+<translation id="4116038641877404294">ገጾችን ከመስመር ውጭ ለመጠቀም ያውርዷቸው</translation>
 <translation id="8922289737868596582">ገጾችን ከመስመር ውጭ ለመጠቀም ከተጨማሪ አማራጮች አዝራሩ ላይ ያውርዱ</translation>
-<translation id="8937772741022875483">የChrome እንቅስቃሰዎ ከዲጂታል ብቁ መሆን ይወገድ?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">በሌላ መስኮት ውስጥ ክፈት</translation>
-<translation id="8951232171465285730">Chrome <ph name="MEGABYTES" /> ሜባ ቆጥቦልዎታል</translation>
-<translation id="8958424370300090006">የአንድ የተወሰነ ጣቢያ ኩኪዎችን ያግዱ።</translation>
-<translation id="8959122750345127698">ዳሰሳ ሊደረስበት አይችልም፦ <ph name="URL" /></translation>
-<translation id="8965591936373831584">በመጠበቅ ላይ</translation>
-<translation id="8970887620466824814">የሆነ ችግር ተፈጥሯል።</translation>
-<translation id="8972098258593396643">ወደ ነባሪው አቃፊ ይውረድ?</translation>
-<translation id="8986494364107987395">የአጠቃቀም ስታስቲክስ እና የብልሽት ሪፖርቶች በራስ ሰር ወደ Google ይላኩ።</translation>
-<translation id="8993760627012879038">አዲስ ትር በማንነት የማያሳውቅ ሁነታ ውስጥ ክፈት</translation>
-<translation id="8998729206196772491">በ<ph name="MANAGED_DOMAIN" /> ወደሚተዳደር መለያ እየገቡና ሙሉውን የChrome ውሂብዎ ቁጥጥር ለአስተዳዳሪው እየሰጡ ነው። የእርስዎ ውሂብ እስከመጨረሻው ከዚህ መለያ ጋር ይተሳሰራል። ከChrome ዘግቶ መውጣት ውሂብዎን ከዚህ መሣሪያ ይሰርዘዋል፣ ነገር ግን በእርስዎ የGoogle መለያ ላይ እንደተከማቸ ይቆያል።</translation>
-<translation id="9019902583201351841">በእርስዎ ወላጆች የሚቀናበር</translation>
-<translation id="9028914725102941583">በተለያዩ መሣሪያዎች ላይ ለማጋራት ስምረትን ያብሩ</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> ወደ ቪአር እንዲገባ ይፈቀድለት?</translation>
-<translation id="9040142327097499898">ማሳወቂያዎች ይፈቀዳሉ። አካባቢ ለዚህ መሣሪያ ጠፍቷል።</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# ቪዲዮ}one{# ቪዲዮዎች}other{# ቪዲዮዎች}}</translation>
-<translation id="9050666287014529139">የይለፍ ሐረግ</translation>
-<translation id="9063523880881406963">የዴስክቶፕ ጣቢያ ጠይቅን አጥፋ</translation>
-<translation id="9065203028668620118">አርትዕ</translation>
-<translation id="9070377983101773829">የድምጽ ፍለጋን ጀምር</translation>
-<translation id="9074336505530349563">በGoogle የተጠቆመ ግላዊነት የተላበሰ ይዘትን በመለያ መግባት እና ስምረትን ማብራት ለማግኘት</translation>
-<translation id="9086455579313502267">አውታረ መረቡን መድረስ አልተቻለም።</translation>
-<translation id="9100505651305367705">የሚደገፍ ሲሆን ጽሑፎችን በተቃለለ እይታ ለማሳየት ጠይቅ</translation>
-<translation id="9100610230175265781">የይለፍ ሐረግ ያስፈልጋል</translation>
-<translation id="9102803872260866941">የቅድመ-እይታ ትር ተከፍቷል</translation>
+<translation id="5958275228015807058">የእርስዎን ፋይሎች እና ገጾች በውርዶች ውስጥ ያግኙ</translation>
+<translation id="5620928963363755975">ከተጨማሪ አማራጮች አዝራር ሆነው የእርስዎን ፋይሎች እና ገጾች በውርዶች ውስጥ ያግኙ</translation>
+<translation id="3341058695485821946">ምን ያህል ውሂብ እንዳስቀመጡ ይመልከቱ</translation>
+<translation id="3157842584138209013">ከተጨማሪ አማራጮች አዝራር ላይ ምን ያህል ውሂብ እንዳስቀመጡ ይመልከቱ</translation>
+<translation id="8218622182176210845">መለያዎን ያቀናብሩ</translation>
+<translation id="8090895580117672212">የBrave Software መለያዎን ለማቀናበር የ«መለያን አቀናብር» አዝራሩን መታ ያድርጉት</translation>
+<translation id="8856898588039823173">ቀላል ገጽ በBrave Software ቀርቧል። ኦርጂናሉን ለመጫን መታ ያድርጉ።</translation>
+<translation id="8134317863207426198">ቀላል ገጽ በBrave Software ቀርቧል። ኦርጂናሉን ገጽ ለመጫን ኦርጂናል ጫን የሚለውን አዝራር መታ ያድርጉ።</translation>
+<translation id="4961107849584082341">ይህን ገጽ ወደ ማንኛውም ቋንቋ ያስተርጉሙ</translation>
+<translation id="569536719314091526">ከተጨማሪ አማራጮች አዝራርሩ ይህን ገጽ ወደ ማንኛውም ቋንቋ ያስተርጉሙ</translation>
+<translation id="1397811292916898096">በ<ph name="PRODUCT_NAME"/> ይፈልጉ</translation>
+<translation id="1792959175193046959">በማንኛውም ጊዜ ነባሪውን የማውረጃ ቦታ ይቀይሩ</translation>
+<translation id="6942665639005891494">የቅንብሮች ምናሌ አማራጩን በመጠቀም ነባሪውን የማውረጃ ቦታ ይጠቀሙ</translation>
+<translation id="6850409657436465440">የእርስዎ ውርድ አሁንም በሂደት ላይ ነው</translation>
+<translation id="5817715962196959877">Brave አሁን ፋይሎችን በበለጠ ፍጥነት ያወርዳል</translation>
+<translation id="3976396876660209797">ይህን አቋራጭ ያስወግዱትና እና ዳግም ይፍጠሩት</translation>
+<translation id="6766622839693428701">ለመዝጋት ወደታች ያንሸራትቱ።</translation>
+<translation id="1028699632127661925">ወደ <ph name="DEVICE_NAME"/> በመላክ ላይ...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - ከ<ph name="DEVICE_NAME"/> የተላከ</translation>
+<translation id="5357811892247919462">ትር ደርሷል</translation>
 <translation id="9104217018994036254">ትርን ለመጋራት የሚሆኑ የመሣሪያዎች ዝርዝር።</translation>
-<translation id="9133397713400217035">ከመስመር ውጭ ያስሱ</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">የመጀመሪያውን አሳይ</translation>
-<translation id="9139068048179869749">ጣቢያዎች ማሳወቂያዎችን እንዲልኩ ከመፍቀድ በፊት ይጠይቅ (የሚመከር)</translation>
-<translation id="9139318394846604261">ግዢ</translation>
-<translation id="9155898266292537608">እንዲሁም አንድ ቃል ላይ በፍጥነት መታ በማድረግ ፍለጋ ማድረግ ይችላሉ</translation>
-<translation id="9169507124922466868">የዳሰሳ ታሪክ በግማሽ ተከፍቷል</translation>
-<translation id="9204836675896933765">1 ፋይል ቀርቷል</translation>
-<translation id="9206873250291191720">አ</translation>
+<translation id="6767294960381293877">በግማሽ ቁመቱ ላይ የተከፈተ ትር የሚጋሩ የመሣሪያዎች ዝርዝር።</translation>
+<translation id="2904414404539560095">በሙሉ ቁመቱ ላይ የተከፈተ ትር የሚጋሩ የመሣሪያዎች ዝርዝር።</translation>
+<translation id="4135200667068010335">የተዘጋ ትር የሚጋሩ የመሣሪያዎች ዝርዝር።</translation>
+<translation id="5292796745632149097">ላክ ወደ</translation>
+<translation id="1386674309198842382">ገባሪ ከ<ph name="LAST_UPDATED"/> ቀናት በፊት</translation>
+<translation id="7971136598759319605">1 ቀን በፊት ንቁ ነበር</translation>
+<translation id="1521774566618522728">ገባሪ ዛሬ</translation>
+<translation id="3631987586758005671">ለ <ph name="DEVICE_NAME"/> በማጋራት ላይ</translation>
+<translation id="9028914725102941583">በተለያዩ መሣሪያዎች ላይ ለማጋራት ስምረትን ያብሩ</translation>
+<translation id="6162454065885854378">የሆነ ነገር ከስልክዎ ወደ ሌላ መሣሪያ ለማጋራት በሁለቱም መሣሪያዎች ላይ በBrave ቅንብሮች ውስጥ ስምረትን ያብሩ</translation>
+<translation id="6084271560289605378">ወደ የBrave ቅንብሮች ይሂዱ</translation>
+<translation id="2318045970523081853">ጥሪ ለማድረግ መታ ያድርጉ</translation>
 <translation id="9209888181064652401">ጥሪዎችን ማድረግ አይቻልም</translation>
-<translation id="9219103736887031265">ምስሎች</translation>
-<translation id="926205370408745186">የChrome እንቅስቃሴዎን ከዲጂታል ብቁ መሆን ያስወግዱ</translation>
-<translation id="932327136139879170">መነሻ</translation>
-<translation id="938850635132480979">ስህተት፦ <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">የእርስዎን ማይክሮፎን ይድረሱ</translation>
-<translation id="95817756606698420">Chrome በቻይና ውስጥ <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />ን ለፍለጋ መጠቀም ይችላል። ይህን በ<ph name="BEGIN_LINK" />ቅንብሮች<ph name="END_LINK" /> ውስጥ መጠቀም ይችላሉ።</translation>
-<translation id="965817943346481315">ጣቢያው ረባሽ ወይም አሳሳች ማስታወቂያዎችን የሚያሳይ ከሆነ ማገድ (የሚመከር)</translation>
-<translation id="968900484120156207">እርስዎ የሚጎበኟቸው ገጾች እዚህ ላይ ብቅ ይላሉ</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> ደቂቃዎች ይቀራሉ</translation>
-<translation id="974555521953189084">ስምረትን ለመጀመር የይለፍ ሐረግዎን ያስገቡ</translation>
-<translation id="981121421437150478">ከመስመር ውጪ</translation>
-<translation id="982182592107339124">ይህ ለሁሉም ጣቢያዎች ውሂብን ያጸዳል፣ የሚከተሉትን ጨምሮ፦</translation>
-<translation id="983192555821071799">ሁሉንም ትሮች ይዝጉ</translation>
-<translation id="987264212798334818">አጠቃላይ</translation>
+<translation id="2860954141821109167">በዚህ መሣሪያ ላይ የስልክ መተግበሪያ እንደነቃ ያረጋግጡ</translation>
+<translation id="2067805253194386918">ጽሑፍ</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> ን ማጋራት አይቻልም</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> ን ማጋራት አልተቻለም።</translation>
+<translation id="8287068819750208230"><ph name="TARGET_DEVICE_NAME"/> በ Brave ውስጥ ስምረት እንደበራለት ያረጋግጡ</translation>
+<translation id="3016635187733453316">ይህ መሣሪያ ወደ በይነ መረብ እንደተገናኘ እርግጠኛ ይሁኑ</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> ከበይነ መረብ ጋር መገናኘቱን ያረጋግጡ</translation>
+<translation id="6539092367496845964">የሆነ ችግር ተፈጥሯል። ቆይተው እንደገና ይሞክሩ።</translation>
+<translation id="3389286852084373014">ጽሑፍ ከልክ በላይ ግዙፍ ነው</translation>
+<translation id="2100314319871056947">በትናንሽ ክፍሎች ጽሑፉን ለማጋራት ይሞክሩ</translation>
+<translation id="2987620471460279764">ከሌሎች መሣሪያዎች የተጋራ ጽሑፍ</translation>
+<translation id="7757787379047923882">ከ<ph name="DEVICE_NAME"/> የተጋራ ጽሑፍ</translation>
+<translation id="5193988420012215838">ወደ የእርስዎ ቅንጥብ ሰሌዳ ላይ ተቀድቷል</translation>
+<translation id="4696983787092045100">ጽሑፍ ወደ መሣሪያዎችዎ ይላኩ</translation>
+<translation id="1260236875608242557">ይፈልጉ እና ያስሱ</translation>
+<translation id="6369229450655021117">ከዚህ ላይ ሆነው፣ ድሩን መፈለግ፣ ከጓደኞች ጋር መጋራት፣ እና ክፍት ገጾችን መመልከት ይችላሉ</translation>
+<translation id="723171743924126238">ምስሎችን ይምረጡ</translation>
+<translation id="8751914237388039244">ምስል ይምረጡ</translation>
+<translation id="1989112275319619282">አስስ</translation>
+<translation id="7055152154916055070">አቅጣጫ ማዞር ታግዷል፦</translation>
+<translation id="5524843473235508879">አቅጣጫ ማዞር ታግዷል።</translation>
+<translation id="6573096386450695060">ሁልጊዜ ፍቀድ</translation>
+<translation id="5805364706385912897">ይህ ገጽ በጣም ብዙ ማህደረ ትውስታን ይጠቀማል፣ ስለዚህ Brave ባለበት አቁሞታል።</translation>
+<translation id="5138664332909611586">ይህ ገጽ በጣም ብዙ ማህደረ ትውስታን ይጠቀማል፣ ስለዚህ Brave አንዳንድ ይዘትን አስወግዷል።</translation>
+<translation id="9137013805542155359">የመጀመሪያውን አሳይ</translation>
+<translation id="6361779936989026201">በBrave ውስጥ Brave Software ረዳት</translation>
+<translation id="7291387454912369099">በረዳት የተቀሰቀሰ ተመዝግቦ መውጫ</translation>
+<translation id="4565206163201411670">በዲጂታል ብቁ መሆን ውስጥ የBrave እንቅስቃሴዎ ይታይ?</translation>
+<translation id="9055113864158719823">በBrave ውስጥ የሚጎበኟቸውን ጣቢያዎች መመልከት እና ለእነሱ ሰዓት ቆጣሪዎችን ማቀናበር ይችላሉ።\n\nBrave Software ሰዓት ቆጣሪዎች ስለሚያቀናብሩላቸው ጣቢያዎች እና ለምን ያህል ርዝመት እንደሚጎበኟቸው መረጃ ያገኛል። ይህ መረጃ ዲጂታል ብቁ መሆን የተሻለ ለማድረግ ስራ ላይ ይውላል።</translation>
+<translation id="4596514158372210596">የBrave እንቅስቃሴዎን ከዲጂታል ብቁ መሆን ያስወግዱ</translation>
+<translation id="1174893863889683998">የBrave እንቅስቃሰዎ ከዲጂታል ብቁ መሆን ይወገድ?</translation>
+<translation id="708829030563435351">በBrave ውስጥ የሚጎበኟቸው ጣቢያዎች አይታዩም። ሁሉም ሰዓት ቆጣሪዎች ይሰረዛሉ።</translation>
+<translation id="2056878612599315956">ጣቢያ ባለበት ቆሟል</translation>
+<translation id="671481426037969117">የእርስዎ <ph name="FQDN"/> ሰዓት ቆጣሪ ጊዜ አልቋል። ነገ እንደገና ይጀመራል።</translation>
+<translation id="7479104141328977413">የትር አስተዳደር</translation>
+<translation id="3524138585025253783">የገንቢ ዩአይ</translation>
+<translation id="6036057147555329831">ተጨማሪ አይሲዩ</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> ወደ ቪአር እንዲገባ ይፈቀድለት?</translation>
+<translation id="7685301384041462804">ወደ ቪአር ከመግባትዎ በፊት ይህን ጣቢያ የሚያምኑ መሆንዎን ያረጋግጡ።</translation>
+<translation id="5033865233969348410">በቪአር ውስጥ ሳሉ ይህ ጣቢያ ስለእነዚህ ሊያውቅ ይችላል፦
+  -  እንደ ቁመት ያለ የእርስዎ አካላዊ ባህሪያት
+
+ወደ ቪአር ከመግባትዎ በፊት ይህን ጣቢያ የሚያምኑት መሆንዎን ያረጋግጡ።</translation>
+<translation id="5534334044554683961">በቪአር ውስጥ ሳሉ ይህ ጣቢያ ስለእነዚህ ሊያውቅ ይችላል፦
+  -  እንደ ቁመት ያለ የእርስዎ አካላዊ ባህሪያት
+  -  የክፍልዎ አቀማመጥ
+
+ወደ ቪአር ከመግባትዎ በፊት ይህን ጣቢያ የሚያምኑት መሆንዎን ያረጋግጡ።</translation>
+<translation id="4169535189173047238">አትፍቀድ</translation>
+<translation id="2170088579611075216">ቪአር ይፍቀዱ እና ያስገቡ</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ar.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ar.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ar">
-<translation id="1006017844123154345">فتح على الإنترنت</translation>
-<translation id="1028699632127661925">جارٍ الإرسال إلى <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">جارٍ إضافة <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">من المواقع الإلكترونية</translation>
-<translation id="1049743911850919806">التصفح المتخفي</translation>
-<translation id="10614374240317010">المواقع التي لن تحفظ كلمات المرور أبدًا</translation>
-<translation id="1067922213147265141">‏خدمات Google الأخرى</translation>
-<translation id="1068672505746868501">عدم ترجمة الصفحات باللغة <ph name="SOURCE_LANGUAGE" /> مُطلقًا</translation>
-<translation id="107147699690128016">في حال تغيير امتداد الملف، قد يفتح الملف في تطبيق مختلف ومن المحتمل أن يشكّل خطورة على جهازك.</translation>
-<translation id="1100066534610197918">فتح في علامة تبويب جديدة في مجموعة</translation>
-<translation id="1105960400813249514">التقاط الشاشة</translation>
-<translation id="1111673857033749125">ستظهر هنا الإشارات التي تم حفظها على أجهزتك الأخرى.</translation>
-<translation id="1113597929977215864">إظهار العرض المبسَّط</translation>
-<translation id="1121094540300013208">تقارير الاستخدام والأعطال</translation>
-<translation id="1124772482545689468">المستخدم</translation>
-<translation id="1129510026454351943">التفاصيل: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{هناك عملية تنزيل واحدة مُعلَّقة.}zero{هناك # عملية تنزيل مُعلَّقة.}two{هناك عمليتا تنزيل (#) مُعلَّقتان.}few{هناك # عمليات تنزيل مُعلَّقة.}many{هناك # عملية تنزيل مُعلَّقة.}other{هناك # عملية تنزيل مُعلَّقة.}}</translation>
-<translation id="1145536944570833626">يمكنك حذف البيانات الحالية.</translation>
-<translation id="1146678959555564648">‏إدخال VR</translation>
-<translation id="116280672541001035">المستخدَمة</translation>
-<translation id="1171770572613082465">عرض مواقع الويب الشائعة من خلال النقر على الزر "أهم المواقع"</translation>
-<translation id="1173894706177603556">إعادة تسمية</translation>
-<translation id="1178581264944972037">الإيقاف مؤقتًا</translation>
-<translation id="1181037720776840403">إزالة</translation>
-<translation id="1188239144602654184">إطلاق الواقع المعزّز</translation>
-<translation id="1197267115302279827">نقل الإشارات المرجعية</translation>
-<translation id="119944043368869598">محو الكل</translation>
-<translation id="1201402288615127009">التالي</translation>
-<translation id="1204037785786432551">تنزيل الرابط</translation>
-<translation id="1206892813135768548">نسخ نص الرابط</translation>
-<translation id="1208340532756947324">للمزامنة والتخصيص على جميع الأجهزة، يمكنك تفعيل المزامنة.</translation>
-<translation id="1209206284964581585">إخفاء الآن</translation>
-<translation id="1227058898775614466">سجلّ التنقُّل</translation>
-<translation id="1231733316453485619">هل تريد تفعيل المزامنة؟</translation>
-<translation id="123724288017357924">إعادة تحميل الصفحة الحالية مع تجاهل المحتوى المُخزَّن مؤقتًا</translation>
-<translation id="124116460088058876">مزيد من اللغات</translation>
-<translation id="124678866338384709">إغلاق علامة التبويب الحالية</translation>
-<translation id="1258753120186372309">‏رسم الشعار المبتكر من Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">البحث والاستكشاف</translation>
-<translation id="1264974993859112054">رياضة</translation>
-<translation id="1266864766717917324">تعذَّرت مشاركة <ph name="CONTENT_TYPE" />.</translation>
-<translation id="1272079795634619415">إيقاف</translation>
-<translation id="1283039547216852943">النقر للتوسيع</translation>
-<translation id="1285320974508926690">عدم ترجمة هذا الموقع مطلقًا</translation>
-<translation id="1291207594882862231">محو السجل وملفات تعريف الارتباط وبيانات المواقع وذاكرة التخزين المؤقت...</translation>
-<translation id="129382876167171263">تظهر هنا الملفات التي تحفظها المواقع الإلكترونية</translation>
-<translation id="129553762522093515">المغلقة حديثًا</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - تم الإرسال من <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">دمج علامات التبويب</translation>
-<translation id="1327257854815634930">يتم فتح سجلّ التنقُّل.</translation>
-<translation id="1331212799747679585">‏يتعذَّر تحديث Chrome. يُرجى الاطِّلاع على مزيد من الخيارات</translation>
-<translation id="1332501820983677155">‏اختصارات ميزات Google Chrome</translation>
-<translation id="1360432990279830238">هل تريد تسجيل الخروج وإيقاف المزامنة؟</translation>
-<translation id="1369915414381695676">تمت إضافة الموقع <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">لا توجد ذاكرة كافية لتنزيل المحتوى المحدد.</translation>
-<translation id="1376578503827013741">جارٍ الحوسبة...</translation>
-<translation id="1383876407941801731">البحث</translation>
-<translation id="1384959399684842514">تم إيقاف التنزيل مؤقتًا</translation>
-<translation id="1386674309198842382">نشط قبل <ph name="LAST_UPDATED" /> من الأيام</translation>
-<translation id="1397811292916898096">البحث باستخدام <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">متضمّن في <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"عدم التعقب"</translation>
-<translation id="1407135791313364759">فتح الكل</translation>
-<translation id="1409426117486808224">عرض مبسَّط لعلامات التبويب المفتوحة</translation>
-<translation id="1409879593029778104">مُنع تنزيل الملف <ph name="FILE_NAME" /> لأنه موجود بالفعل.</translation>
-<translation id="1414981605391750300">‏جارٍ الاتصال بـ Google. قد يستغرق ذلك دقيقة واحدة...</translation>
-<translation id="1416550906796893042">إصدار التطبيق</translation>
-<translation id="1430915738399379752">طباعة</translation>
-<translation id="1446450296470737166">‏السماح بالتحكم الكامل لأجهزة MIDI</translation>
-<translation id="1450753235335490080">تعذَّرت مشاركة <ph name="CONTENT_TYPE" />.</translation>
-<translation id="145097072038377568">‏تم إيقافه في إعدادات Android.</translation>
-<translation id="1477626028522505441">تعذّر تنزيل الملف <ph name="FILE_NAME" /> بسبب مشاكل بالخادم.</translation>
-<translation id="1506061864768559482">محرك البحث</translation>
-<translation id="1513352483775369820">الإشارات المرجعية وسجلّ الويب</translation>
-<translation id="1513858653616922153">حذف كلمة المرور</translation>
-<translation id="1516229014686355813">‏تعمل ميزة "البحث بالنقر" على إرسال الكلمة المُحدَّدة والصفحة الحالية كسياق إلى بحث Google. يمكنك إيقافها في <ph name="BEGIN_LINK" />الإعدادات<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">نشط اليوم</translation>
-<translation id="1544826120773021464">‏لإدارة إعدادات حسابك على Google، يُرجى النقر على الزر "إدارة الحساب".</translation>
-<translation id="1549000191223877751">الانتقال إلى نافذة أخرى</translation>
-<translation id="1553358976309200471">‏تحديث Chrome‏</translation>
-<translation id="1569387923882100876">جهاز متصل</translation>
-<translation id="1571304935088121812">نسخ اسم المستخدم</translation>
-<translation id="1612196535745283361">‏يحتاج Chrome للوصول إلى الموقع للبحث عن الأجهزة. الوصول إلى الموقع <ph name="BEGIN_LINK" />غير مفعّل لهذا الجهاز<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">الكاميرا</translation>
-<translation id="1623104350909869708">منع هذه الصفحة من إنشاء مربعات حوار إضافية.</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{إزالة عنصر واحد محدد}zero{إزالة # عنصر محدد}two{إزالة عنصرين (#) محددين}few{إزالة # عناصر محددة}many{إزالة # عنصرًا محددًا}other{إزالة # عنصر محدد}}</translation>
-<translation id="164269334534774161">أنت تعرض نسخة بلا اتصال لهذه الصفحة من <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">السجل</translation>
-<translation id="1647391597548383849">الدخول إلى الكاميرا</translation>
-<translation id="1660204651932907780">السماح لمواقع الويب بتشغيل الصوت (موصى به)</translation>
-<translation id="1670399744444387456">الإعدادات الأساسية</translation>
-<translation id="1671236975893690980">التنزيل معلّق...</translation>
-<translation id="1672586136351118594">عدم العرض مرة أخرى</translation>
-<translation id="1692118695553449118">المزامنة ممكنة</translation>
-<translation id="169515064810179024">حظر مواقع الويب من الوصول إلى مستشعرات الحركة</translation>
-<translation id="1717218214683051432">مستشعرات الحركة</translation>
-<translation id="1718835860248848330">آخر ساعة</translation>
-<translation id="1736419249208073774">استكشاف</translation>
-<translation id="1743802530341753419">السؤال قبل السماح لمواقع الويب بالاتصال بجهاز (موصى به)</translation>
-<translation id="1749561566933687563">مزامنة الإشارات المرجعية</translation>
-<translation id="17513872634828108">علامات التبويب المفتوحة</translation>
-<translation id="1779089405699405702">أداة فك تشفير الصور</translation>
-<translation id="1782483593938241562">تاريخ الانتهاء: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">تم التثبيت</translation>
-<translation id="1792959175193046959">تغيير موقع التنزيل التلقائي في أي وقت</translation>
-<translation id="1807246157184219062">فاتح</translation>
-<translation id="1810845389119482123">إعداد المزامنة الأولية لم يكتمل</translation>
-<translation id="1821253160463689938">يستخدم ملفات تعريف الارتباط لتذكّر الإعدادات المُفضّلة حتى إذا لم تزُر تلك الصفحات.</translation>
-<translation id="1829244130665387512">البحث في الصفحة</translation>
-<translation id="1853692000353488670">علامة تبويب جديدة للتصفح المتخفي</translation>
-<translation id="1856325424225101786">هل ترغب في إعادة ضبط الوضع البسيط؟</translation>
-<translation id="1868024384445905608">‏يُنزِّل Chrome الآن الملفات بشكلٍ أسرع.</translation>
-<translation id="1883903952484604915">ملفاتي</translation>
-<translation id="1887786770086287077">‏الوصول إلى الموقع الجغرافي متوقف لهذا الجهاز. يمكنك تفعليه في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">‏سيتم فتح <ph name="APP_NAME" /> في Chrome. بالمتابعة، أنت توافق على <ph name="BEGIN_LINK1" />بنود الخدمة<ph name="END_LINK1" /> و<ph name="BEGIN_LINK2" />إشعار الخصوصية<ph name="END_LINK2" /> في Chrome.</translation>
-<translation id="1919345977826869612">الإعلانات</translation>
-<translation id="1919950603503897840">اختيار جهات الاتصال</translation>
-<translation id="1922076542920281912">‏للسماح لمتصفِّح Chrome بالوصول إلى موقعك الجغرافي، يُرجى أيضًا تفعيل الموقع الجغرافي في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">التحديثات</translation>
-<translation id="19288952978244135">‏يُرجى إعادة فتح Chrome.</translation>
-<translation id="1933845786846280168">علامة تبويب محددة</translation>
-<translation id="194341124344773587">‏إتاحة الإذن لـ Chrome في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" /></translation>
-<translation id="1943432128510653496">حفظ كلمات المرور</translation>
-<translation id="1952172573699511566">ستعرض مواقع الويب النص بلغتك المفضّلة إن أمكن.</translation>
-<translation id="1960290143419248813">‏لم تعد تحديثات Chrome متاحة لهذا الإصدار من نظام التشغيل Android</translation>
-<translation id="1966710179511230534">يُرجى تحديث تفاصيل تسجيل الدخول.</translation>
-<translation id="1974060860693918893">الإعدادات المتقدّمة</translation>
-<translation id="1984705450038014246">‏مزامنة بيانات Chrome</translation>
-<translation id="1984937141057606926">مسموح باستثناء الجهات الخارجية</translation>
-<translation id="1986685561493779662">الاسم موجود من قبل</translation>
-<translation id="1987739130650180037">زر <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">تصفّح</translation>
-<translation id="1993768208584545658">يريد <ph name="SITE" /> الاقتران</translation>
-<translation id="1994173015038366702">‏عنوان URL للموقع</translation>
-<translation id="2000419248597011803">يُرسِل بعض ملفات تعريف الارتباط وعمليات البحث من شريط العناوين ومربّع البحث إلى محرِّك البحث التلقائي.</translation>
-<translation id="2002537628803770967">‏بطاقات الائتمان والعناوين باستخدام Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{ملف واحد (#)}zero{# ملف}two{ملفان (#)}few{# ملفات}many{# ملفًا}other{# ملف}}</translation>
-<translation id="2017836877785168846">محو السجلّ وعمليات الإكمال التلقائي في شريط العناوين.</translation>
-<translation id="2021896219286479412">عناصر التحكم لموقع في وضع ملء الشاشة</translation>
-<translation id="2038563949887743358">تشغيل طلب موقع الويب لسطح المكتب</translation>
-<translation id="2041019821020695769">‏للسماح لمتصفِّح Chrome بإرسال الإشعارات إليك، يمكنك أيضًا تفعيل الإشعارات في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">‏تتوفَّر بيانات<ph name="APP_NAME" /> أيضًا في Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">تم إيقاف الموقع الإلكتروني مؤقتًا</translation>
-<translation id="2063713494490388661">ميزة "البحث بالنقر"</translation>
-<translation id="2067805253194386918">نص</translation>
-<translation id="2079545284768500474">تراجع</translation>
-<translation id="2082238445998314030">النتيجة <ph name="RESULT_NUMBER" /> من <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">الصوت</translation>
-<translation id="2096012225669085171">المزامنة والتخصيص على الأجهزة</translation>
-<translation id="2100273922101894616">تسجيل الدخول تلقائيًا</translation>
-<translation id="2100314319871056947">يُرجى تجربة مشاركة النص في مجموعات أصغر.</translation>
-<translation id="2107397443965016585">السؤال أولاً قبل السماح لمواقع الويب بتشغيل المحتوى المَحمي (موصى به)</translation>
-<translation id="2111511281910874386">الانتقال إلى الصفحة</translation>
-<translation id="2122601567107267586">تعذر فتح التطبيق</translation>
-<translation id="2126426811489709554">‏يدعمها Chrome</translation>
-<translation id="2131665479022868825">تم توفير <ph name="DATA" /></translation>
-<translation id="213279576345780926">تم إغلاق <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">الإضافة إلى الشاشة الرئيسية</translation>
-<translation id="2146738493024040262">فتح تطبيق فوري</translation>
-<translation id="2148716181193084225">اليوم</translation>
-<translation id="2154484045852737596">تعديل البطاقة</translation>
-<translation id="2154710561487035718">‏نسخ عنوان URL</translation>
-<translation id="2156074688469523661">المواقع المتبقية (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">‏لمشاركة محتوى من هاتفك مع جهاز آخر، يُرجى تفعيل المزامنة في إعدادات Chrome على كلا الجهازين.</translation>
-<translation id="2170088579611075216">السماح بالواقع الافتراضي والدخول إليه</translation>
-<translation id="218608176142494674">المشاركة</translation>
-<translation id="2227444325776770048">المتابعة باسم <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">‏خدمات Google والمزامنة</translation>
-<translation id="2259659629660284697">تصدير كلمات المرور...</translation>
-<translation id="2268044343513325586">تحسين</translation>
-<translation id="2286841657746966508">عنوان الفاتورة</translation>
-<translation id="2289270750774289114">طلب الإذن عند محاولة موقع ويب العثور على أجهزة البلوتوث المجاورة (إجراء موصَى به)</translation>
-<translation id="230115972905494466">لم يتم العثور على أي أجهزة متوافقة</translation>
-<translation id="2315043854645842844">لا يدعم نظام التشغيل تحديد الشهادة من جانب العميل.</translation>
-<translation id="2318045970523081853">انقر لإجراء اتصال.</translation>
-<translation id="2321086116217818302">جارٍ تحضير كلمات المرور…</translation>
-<translation id="2321958826496381788">اسحب شريط التمرير إلى أن تتمكّن من قراءة هذا النص بسهولة. يجب أن يظهر النص بهذا الحجم على الأقل بعد النقر مرّتين على أي فقرة.</translation>
-<translation id="2323763861024343754">مساحة تخزين الموقع</translation>
-<translation id="2328985652426384049">تعذر تسجيل الدخول</translation>
-<translation id="2330129964253841015">التحذير إذا كانت كلمات المرور مخترقة</translation>
-<translation id="2349710944427398404">‏إجمالي البيانات المُستخدَمة من قِبل Chrome، بما في ذلك الحسابات والإشارات المرجعية والإعدادات المحفوظة</translation>
-<translation id="2353636109065292463">التحقُّق من اتصال الإنترنت</translation>
-<translation id="2359808026110333948">متابعة</translation>
-<translation id="2369533728426058518">علامات التبويب المفتوحة</translation>
-<translation id="2387895666653383613">تغيير حجم النص</translation>
-<translation id="2394602618534698961">تظهر الملفات التي نزَّلتها هنا.</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> ميغابايت</translation>
-<translation id="2407481962792080328">‏عند تسجيل الدخول إلى حسابك على Google، يتم تفعيل هذه الميزة.</translation>
-<translation id="2410754283952462441">اختيار حساب</translation>
-<translation id="2414886740292270097">داكن</translation>
-<translation id="2416359993254398973">‏يحتاج Chrome إلى إذن لاستخدام الكاميرا لموقع الويب هذا.</translation>
-<translation id="2426805022920575512">اختيار حساب آخر</translation>
-<translation id="2433507940547922241">المظهر</translation>
-<translation id="2434158240863470628">اكتمل التنزيل <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">تحديد الموقع الجغرافي</translation>
-<translation id="2450083983707403292">هل ترغب في بدء تنزيل <ph name="FILE_NAME" /> مرة أخرى؟</translation>
-<translation id="2482878487686419369">الإشعارات</translation>
-<translation id="2490684707762498678">تتم إدارتها من خلال <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">‏"مساعد Google" على Chrome</translation>
-<translation id="2496180316473517155">سجلّ التصفّح</translation>
-<translation id="2497852260688568942">تم إيقاف المزامنة من قِبل المشرف</translation>
-<translation id="2498359688066513246">المساعدة والتعليقات</translation>
-<translation id="2501278716633472235">الرجوع</translation>
-<translation id="2513403576141822879">‏لعرض مزيد من الإعدادات المتعلِّقة بالخصوصية والأمان وجمع البيانات، يُرجى الاطِّلاع على <ph name="BEGIN_LINK" />خدمات Google والمزامنة<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">‏في الوضع البسيط، يُحمِّل Chrome الصفحات بشكلٍ أسرع ويستخدم بيانات أقل بنسبة تصل إلى 60%. لتحسين مستوى أداء الصفحات التي تزورها، يرسل Chrome عدد زيارات الويب إلى Google. <ph name="BEGIN_LINK" />مزيد من المعلومات<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">‏يتم إرسال عناوين URL للصفحات التي تزورها إلى Google.</translation>
-<translation id="2532336938189706096">عرض الويب</translation>
-<translation id="2534155362429831547">تم حذف <ph name="NUMBER_OF_ITEMS" /> من العناصر</translation>
-<translation id="2536728043171574184">عرض نسخة بلا اتصال من هذه الصفحة</translation>
-<translation id="2546283357679194313">ملفات تعريف الارتباط وبيانات المواقع</translation>
-<translation id="2567385386134582609">صورة</translation>
-<translation id="257088987046510401">المظاهر</translation>
-<translation id="2570922361219980984">‏الوصول إلى الموقع الجغرافي متوقف لهذا الجهاز أيضًا. يمكنك تفعليه في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">تم التوسيع - انقر للتصغير.</translation>
-<translation id="2581165646603367611">‏سيؤدي هذا إلى مسح ملفات تعريف الارتباط وذاكرة التخزين المؤقت والبيانات الأخرى للمواقع التي لا يعتقد Chrome أنها مهمة.</translation>
-<translation id="2586657967955657006">الحافظة</translation>
-<translation id="2587052924345400782">يتوفر إصدار أحدث</translation>
-<translation id="2593272815202181319">أحادي المسافة</translation>
-<translation id="2612676031748830579">رقم البطاقة</translation>
-<translation id="2621115761605608342">السماح لموقع ويب معيّن بتشغيل جافا سكريبت</translation>
-<translation id="2625189173221582860">تم نسخ كلمة المرور</translation>
-<translation id="2631006050119455616">تم توفيرها</translation>
-<translation id="2647434099613338025">إضافة لغة</translation>
-<translation id="2650751991977523696">هل تريد تنزيل الملف مرة أخرى؟</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{ملف صوتي واحد (#)}zero{# ملف صوتي}two{ملفان صوتيان (#)}few{# ملفات صوتية}many{# ملفًا صوتيًا}other{# ملف صوتي}}</translation>
-<translation id="2653659639078652383">إرسال</translation>
-<translation id="2677748264148917807">الخروج</translation>
-<translation id="2704606927547763573">تم النسخ</translation>
-<translation id="2707726405694321444">تحديث الصفحة</translation>
-<translation id="2709516037105925701">الملء التلقائي</translation>
-<translation id="2717722538473713889">عنوان البريد الإلكتروني</translation>
-<translation id="2728754400939377704">الترتيب حسب الموقع</translation>
-<translation id="2744248271121720757">النقر على الكلمة للبحث عنها فورًا أو الاطلاع على الإجراءات ذات الصلة</translation>
-<translation id="2760989362628427051">تفعيل المظهر الداكن عند تفعيل المظهر الداكن للجهاز أو ميزة "توفير شحن البطارية"</translation>
-<translation id="2762000892062317888">الآن</translation>
-<translation id="2777555524387840389">عدد الثواني المتبقية: <ph name="SECONDS" /></translation>
-<translation id="2779651927720337254">تعذَّر التنزيل</translation>
-<translation id="2781151931089541271">يتبقى ثانية واحدة</translation>
-<translation id="2801022321632964776">‏يمكنك إجراء التحديث للحصول على لغتك في أحدث إصدار من Chrome.</translation>
-<translation id="2810645512293415242">صفحة مبسَّطة لحفظ البيانات والاستمتاع بتحميل أسرع.</translation>
-<translation id="281504910091592009">‏بإمكانك عرض كلمات المرور المحفوظة وإدارتها في <ph name="BEGIN_LINK" />حسابك على Google<ph name="END_LINK" />.</translation>
-<translation id="2818669890320396765">للحصول على الإشارات المرجعية على جميع أجهزتك، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
-<translation id="2822354292072154809">هل تريد فعلاً إعادة ضبط جميع أذونات الموقع الإلكتروني للكائن <ph name="CHOSEN_OBJECT_NAME" />؟</translation>
-<translation id="2836148919159985482">المس زر الرجوع للخروج من وضع ملء الشاشة.</translation>
-<translation id="2842985007712546952">المجلد الرئيسي</translation>
-<translation id="2858138569776157458">أهم المواقع</translation>
-<translation id="2860954141821109167">يُرجى التأكُّد من تفعيل تطبيق هاتف على هذا الجهاز.</translation>
-<translation id="2870560284913253234">الموقع</translation>
-<translation id="2874939134665556319">المقطع الصوتي السابق</translation>
-<translation id="2876369937070532032">‏يتم إرسال عناوين URL لبعض الصفحات التي تزورها إلى Google، عندما يكون أمانك في خطر</translation>
-<translation id="2888126860611144412">‏لمحة عن Chrome</translation>
-<translation id="2891154217021530873">إيقاف تحميل الصفحة</translation>
-<translation id="2893180576842394309">‏قد تستخدم Google سجلّك لتخصيص البحث وخدمات Google الأخرى.</translation>
-<translation id="2898264748040935573">تعديل كلمة المرور المخزنة</translation>
-<translation id="2900528713135656174">إنشاء حدث</translation>
-<translation id="290376772003165898">أليست الصفحة باللغة <ph name="LANGUAGE" />؟</translation>
-<translation id="2904414404539560095">قائمة بالأجهزة التي يمكن مشاركة علامة تبويب معها، مفتوحة على طول الشاشة.</translation>
-<translation id="2910701580606108292">السؤال قبل السماح لمواقع الويب بتشغيل المحتوى المحمي</translation>
-<translation id="2913331724188855103">السماح لمواقع الويب بحفظ بيانات ملفات تعريف الارتباط وقراءتها (موصى به)</translation>
-<translation id="2923908459366352541">الاسم غير صحيح</translation>
-<translation id="2932150158123903946">‏مساحة تخزين <ph name="APP_NAME" /> Google</translation>
-<translation id="2942036813789421260">علامة تبويب المعاينة مغلقة</translation>
-<translation id="2956410042958133412">تتم إدارة هذا الحساب بواسطة <ph name="PARENT_NAME_1" /> و <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">تم التبديل إلى علامات تبويب التصفح المتخفي</translation>
-<translation id="2968755619301702150">عارض الشهادات</translation>
-<translation id="2979025552038692506">علامة تبويب محددة للتصفح المتخفي</translation>
-<translation id="2987620471460279764">النصوص التي تمت مشاركتها من جهاز آخر</translation>
-<translation id="2989523299700148168">تم الانتقال إليها مؤخرًا</translation>
-<translation id="2996291259634659425">إنشاء عبارة المرور</translation>
-<translation id="2996809686854298943">‏عنوان URL المطلوب</translation>
-<translation id="300526633675317032">سيؤدي هذا إلى محو مساحة التخزين البالغة <ph name="SIZE_IN_KB" /> بأكملها من مساحة تخزين مواقع الويب.</translation>
-<translation id="3016635187733453316">يُرجى التأكُّد من اتصال هذا الجهاز بالإنترنت.</translation>
-<translation id="3029613699374795922">تم التنزيل بحجم <ph name="KBS" /> كيلوبايت</translation>
-<translation id="3029704984691124060">عبارات المرور غير متطابقة</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />الحصول على مساعدة<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">‏تحديد الموقع الجغرافي متوقف، يمكنك تفعيله من <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">يمكنك تفعيل المزامنة في أي وقت في الإعدادات.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{إشارة مرجعية <ph name="BOOKMARKS_COUNT_ONE" />}zero{<ph name="BOOKMARKS_COUNT_MANY" /> إشارات مرجعية}two{إشارتان مرجعيتان (<ph name="BOOKMARKS_COUNT_MANY" />)}few{<ph name="BOOKMARKS_COUNT_MANY" /> إشارات مرجعية}many{<ph name="BOOKMARKS_COUNT_MANY" /> إشارةً مرجعيةً}other{<ph name="BOOKMARKS_COUNT_MANY" /> إشارة مرجعية}}</translation>
-<translation id="3089395242580810162">الفتح في علامة تبويب تصفّح متخفي</translation>
-<translation id="3115898365077584848">عرض المعلومات</translation>
-<translation id="3123473560110926937">حظر الإعلانات في بعض المواقع</translation>
-<translation id="3137521801621304719">مغادرة وضع التصفح المتخفي</translation>
-<translation id="3143515551205905069">إلغاء المزامنة</translation>
-<translation id="3157842584138209013">الاطّلاع على مقدار البيانات التي وفّرتها بالنقر على "مزيد من الخيارات"</translation>
-<translation id="3166827708714933426">اختصارات علامات التبويب والنوافذ</translation>
-<translation id="3181954750937456830">التصفُّح الآمن (يحميك ويحمي جهازك من مواقع الويب الضارة)</translation>
-<translation id="3190152372525844641">‏تشغيل الأذونات لـ Chrome في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> من البيانات المخزّنة</translation>
-<translation id="3205824638308738187">أوشك التحديث على الانتهاء.</translation>
-<translation id="3207960819495026254">تمت إضافتها إلى الإشارات المرجعية.</translation>
-<translation id="3211426585530211793">تم حذف العنصر <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">إذا نسيت عبارة المرور أو رغبت في تغيير هذا الإعداد، يمكنك <ph name="BEGIN_LINK" />إعادة تعيين المزامنة<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">الميكروفون</translation>
-<translation id="3232754137068452469">تطبيق الويب</translation>
-<translation id="3236059992281584593">يتبقى دقيقة واحدة</translation>
-<translation id="3244271242291266297">الشهر</translation>
-<translation id="3254409185687681395">وضع إشارة على هذه الصفحة</translation>
-<translation id="3259831549858767975">تصغير كل محتويات الصفحة</translation>
-<translation id="3269093882174072735">تحميل الصورة</translation>
-<translation id="3269956123044984603">‏للحصول على علامات التبويب من أجهزتك الأخرى، شغِّل "المزامنة التلقائية للبيانات" في إعدادات حساب Android.</translation>
-<translation id="3277252321222022663">يمكنك السماح للمواقع بالوصول إلى أجهزة الاستشعار (مُقترَح).</translation>
-<translation id="3282568296779691940">‏تسجيل الدخول إلى Chrome</translation>
-<translation id="3288003805934695103">إعادة تحميل الصفحة</translation>
-<translation id="32895400574683172">مسموح بالإشعارات</translation>
-<translation id="3295530008794733555">تصفُّح أسرع. واستخدام بيانات أقل.</translation>
-<translation id="3295602654194328831">إخفاء المعلومات</translation>
-<translation id="3298243779924642547">نسخة خفيفة</translation>
-<translation id="3303414029551471755">هل ترغب في الاستمرار في تنزيل المحتوى؟</translation>
-<translation id="3306398118552023113">‏يتم تشغيل هذا التطبيق في Chrome</translation>
-<translation id="3315103659806849044">‏يتم حاليًا تخصيص إعدادات خدمة Google والمزامنة. لإنهاء تفعيل المزامنة، يُرجى الضغط على زر "التأكيد" بالقرب من أسفل الشاشة. الانتقال إلى أعلى</translation>
-<translation id="3328801116991980348">معلومات موقع الويب</translation>
-<translation id="3333961966071413176">جميع جهات الاتصال</translation>
-<translation id="3334729583274622784">هل تريد تغيير امتداد الملف؟</translation>
-<translation id="3341058695485821946">الاطّلاع على مقدار البيانات التي وفّرتها</translation>
-<translation id="3350687908700087792">إغلاق كافة علامات تبويب التصفح المتخفي</translation>
-<translation id="3353615205017136254">‏نسخة خفيفة تقدِّمها Google. انقر على زر "تحميل الصفحة الأصلية" لتحميلها.</translation>
-<translation id="3367813778245106622">تسجيل الدخول مرة أخرى لبدء المزامنة</translation>
-<translation id="3374023511497244703">‏لن تتم مزامنة الإشارات المرجعية والسجلّ وكلمات المرور وبيانات Chrome الأخرى مع حسابك على Google بعد ذلك.</translation>
-<translation id="3384347053049321195">مشاركة صورة</translation>
-<translation id="3386292677130313581">السؤال قبل السماح لمواقع الويب بمعرفة الموقع الجغرافي (موصى به)</translation>
-<translation id="3387650086002190359">تعذّر تنزيل الملف <ph name="FILE_NAME" /> بسبب أخطاء في نظام الملف.</translation>
-<translation id="3389286852084373014">النص كبير جدًا</translation>
-<translation id="3398320232533725830">فتح مدير الإشارات المرجعية</translation>
-<translation id="3414952576877147120">الحجم:</translation>
-<translation id="3443221991560634068">إعادة تحميل الصفحة الحالية</translation>
-<translation id="3445014427084483498">للتو</translation>
-<translation id="3478363558367712427">يمكنك استخدام محرّك بحث آخر.</translation>
+<translation id="6910211073230771657">تم الحذف</translation>
+<translation id="6965382102122355670">موافق</translation>
+<translation id="5301954838959518834">حسنًا</translation>
+<translation id="7658239707568436148">إلغاء</translation>
 <translation id="3479552764303398839">ليس الآن</translation>
-<translation id="3492207499832628349">علامة تبويب جديدة للتصفح المتخفي </translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />مزيد من المعلومات<ph name="END_LINK" /> حول المحتوى المقترح</translation>
-<translation id="3513704683820682405">الواقع المعزّز</translation>
-<translation id="3518985090088779359">القبول والمتابعة</translation>
-<translation id="3522247891732774234">التحديث متاح. مزيد من الخيارات</translation>
-<translation id="3524138585025253783">واجهة مستخدم مطوّر البرامج</translation>
-<translation id="3527085408025491307">المجلد</translation>
-<translation id="3542235761944717775">تتوفر مساحة <ph name="KILOBYTES" /> كيلوبايت</translation>
-<translation id="3549657413697417275">البحث في السجل</translation>
-<translation id="3557336313807607643">إضافة إلى جهات الاتصال</translation>
-<translation id="3566923219790363270">‏لا يزال Chrome يستعد للواقع الافتراضي. يُرجى إعادة تشغيل Chrome لاحقًا.</translation>
-<translation id="3568688522516854065">للحصول على علامات التبويب من أجهزتك الأخرى، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
-<translation id="3587482841069643663">الكل</translation>
-<translation id="358794129225322306">السماح لموقع ويب بتنزيل عدة ملفات تلقائيًا.</translation>
-<translation id="3590487821116122040">‏مساحة تخزين الموقع التي لا يعتقد Chrome أنها مهمة (مثل المواقع التي لا تتضمَّن إعدادات محفوظة أو تلك التي لا تزورها مرارًا)</translation>
-<translation id="3599863153486145794">‏يمسح السجل من كل الأجهزة التي تم تسجيل الدخول عليها. وقد يتضمن حسابك في Google نماذج أخرى من سجل التصفح في <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">كتم صوت مواقع الويب التي تشغّل الصوت</translation>
-<translation id="3616113530831147358">المقاطع الصوتية</translation>
-<translation id="3631987586758005671">جارٍ المشاركة مع <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">كشف كلمة المرور</translation>
-<translation id="363596933471559332">يمكنك تسجيل الدخول تلقائيًا إلى مواقع الويب باستخدام بيانات الاعتماد المخزّنة. وعندما تكون هذه الميزة غير مفعّلة، سيُطلب منك التحقّق من بيانات الاعتماد في كل مرة قبل تسجيل الدخول إلى موقع ويب.</translation>
-<translation id="3658159451045945436">تؤدي إعادة الضبط إلى محو سِجلّ البيانات المحفوظة، بما في ذلك قائمة المواقع الإلكترونية التي تمت زيارتها.</translation>
-<translation id="3692944402865947621">تعذّر تنزيل <ph name="FILE_NAME" /> نظرًا لعدم إمكانية الوصول إلى موقع مساحة التخزين.</translation>
-<translation id="3714981814255182093">فتح شريط البحث</translation>
-<translation id="3716182511346448902">‏تستهلك هذه الصفحة مساحة كبيرة من الذاكرة، لذلك أوقفها Chrome مؤقتًا.</translation>
-<translation id="3730075448226062617">‏للسماح لمتصفِّح Chrome بالوصول إلى الميكروفون، يُرجى أيضًا تشغيل الميكروفون في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">تمت إضافة إشارة مرجعية في <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">المزامنة في الخلفية</translation>
-<translation id="3771001275138982843">تعذُّر تنزيل التحديث</translation>
-<translation id="3771033907050503522">علامات تبويب التصفح المتخفي</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />تشغيل البلوتوث<ph name="END_LINK" /> للسماح بالإقران</translation>
-<translation id="3775705724665058594">إرسال إلى أجهزتك</translation>
-<translation id="3778956594442850293">تمت الإضافة إلى الشاشة الرئيسية</translation>
-<translation id="3789841737615482174">تثبيت</translation>
-<translation id="3810838688059735925">الفيديوهات</translation>
-<translation id="3810973564298564668">إدارة محرّكات البحث</translation>
-<translation id="381841723434055211">أرقام الهواتف</translation>
-<translation id="3819178904835489326">تم إلغاء <ph name="NUMBER_OF_DOWNLOADS" /> من التنزيلات</translation>
-<translation id="3822502789641063741">هل تريد محو مساحة تخزين المواقع؟</translation>
-<translation id="385051799172605136">الرجوع إلى الوراء</translation>
-<translation id="3859306556332390985">الانتقال للأمام</translation>
-<translation id="3894427358181296146">إضافة مجلد</translation>
-<translation id="3895926599014793903">فرض تفعيل التكبير/التصغير</translation>
-<translation id="3912508018559818924">جارٍ العثور على الأفضل من الويب...</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">جمع البيانات التابعة لي</translation>
-<translation id="393697183122708255">لا يتوفر بحث صوتي تم تمكينه</translation>
-<translation id="395206256282351086">اقتراحات البحث ومواقع الويب غير مفعّلة</translation>
-<translation id="3955193568934677022">السماح لمواقع الويب بتشغيل المحتوى المحمي (مُستحسَن)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{‏سيحمِّل Chrome الصفحة عندما تصبح جاهزة}zero{‏لن يحمِّل Chrome أي صفحات عندما تصبح جاهزة}two{‏سيحمِّل Chrome الصفحتين عندما تصبح جاهزتين}few{‏سيحمِّل Chrome الصفحات عندما تصبح جاهزة}many{‏سيحمِّل Chrome الصفحات عندما تصبح جاهزة}other{‏سيحمِّل Chrome الصفحات عندما تصبح جاهزة}}</translation>
-<translation id="3963007978381181125">‏لا يتضمّن التشفير باستخدام عبارة المرور طرق الدفع والعناوين من Google Pay. ولن يتمكّن أي شخص من الاطّلاع على بياناتك المشفرة إلا من يعرف عبارة مرورك. لا تُرسَل عبارة المرور إلى شركة Google ولا تُخزّن لديها. في حال نسيان عبارة المرور أو الرغبة في تغيير هذا الإعداد، ستحتاج إلى إعادة ضبط المزامنة. <ph name="BEGIN_LINK" />مزيد من المعلومات<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">اكتمل التنزيل</translation>
-<translation id="397583555483684758">توقفت المزامنة</translation>
-<translation id="3976396876660209797">إزالة هذا الاختصار وإعادة إنشائه</translation>
-<translation id="3985215325736559418">هل تريد تنزيل <ph name="FILE_NAME" /> مرة أخرى؟</translation>
-<translation id="3987993985790029246">نسخ الرابط</translation>
-<translation id="3988213473815854515">الموقع مسموح به</translation>
-<translation id="3988466920954086464">الاطلاع على نتائج البحث الفورية في هذه اللوحة</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">مساحة تخزين غير مهمة</translation>
-<translation id="4000212216660919741">الصفحة الرئيسية في وضع عدم الاتصال بالإنترنت</translation>
+<translation id="5317780077021120954">حفظ</translation>
+<translation id="4570913071927164677">التفاصيل</translation>
+<translation id="8730621377337864115">تم</translation>
+<translation id="8261506727792406068">حذف</translation>
+<translation id="1181037720776840403">إزالة</translation>
+<translation id="5939518447894949180">إعادة الضبط</translation>
 <translation id="4002066346123236978">العنوان</translation>
-<translation id="4008040567710660924">السماح لموقع ويب معيّن بتشغيل ملفات تعريف الارتباط</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{ساعة واحدة (#)}zero{# ساعة}two{ساعتان (#)}few{# ساعات}many{# ساعةً}other{# ساعة}}</translation>
-<translation id="4046123991198612571">المقطع الصوتي التالي</translation>
-<translation id="4048707525896921369">‏يمكنك معرفة معلومات عن مواضيع على المواقع الإلكترونية بدون مغادرة الصفحة. تُرسل ميزة "البحث بالنقر" الكلمة والسياق المحيط بها إلى "بحث Google" للحصول على تعريفات وصور ونتائج بحث وتفاصيل أخرى ذات الصلة بها.
+<translation id="5916664084637901428">مفعّل</translation>
+<translation id="5860033963881614850">غير مفعّل</translation>
+<translation id="6165508094623778733">مزيد من المعلومات</translation>
+<translation id="6042308850641462728">المزيد</translation>
+<translation id="6040143037577758943">إغلاق</translation>
+<translation id="780301667611848630">لا، شكرًا</translation>
+<translation id="1201402288615127009">التالي</translation>
+<translation id="2359808026110333948">متابعة</translation>
+<translation id="2653659639078652383">إرسال</translation>
+<translation id="2079545284768500474">تراجع</translation>
+<translation id="7649070708921625228">مساعدة</translation>
+<translation id="2148716181193084225">اليوم</translation>
+<translation id="7781829728241885113">أمس</translation>
+<translation id="6945221475159498467">تحديد</translation>
+<translation id="7791543448312431591">إضافة</translation>
+<translation id="6527303717912515753">مشاركة</translation>
+<translation id="1383876407941801731">البحث</translation>
+<translation id="3115898365077584848">عرض المعلومات</translation>
+<translation id="3295602654194328831">إخفاء المعلومات</translation>
+<translation id="3987993985790029246">نسخ الرابط</translation>
+<translation id="2704606927547763573">تم النسخ</translation>
+<translation id="8725066075913043281">أعد المحاولة</translation>
+<translation id="385051799172605136">الرجوع إلى الوراء</translation>
+<translation id="8131740175452115882">التأكيد</translation>
+<translation id="5300589172476337783">عرض</translation>
+<translation id="1124772482545689468">المستخدم</translation>
+<translation id="8609465669617005112">التحريك إلى أعلى</translation>
+<translation id="6746124502594467657">الانتقال إلى أسفل</translation>
+<translation id="8249310407154411074">نقل إلى الأعلى</translation>
+<translation id="8428213095426709021">الإعدادات</translation>
+<translation id="2498359688066513246">المساعدة والتعليقات</translation>
+<translation id="8378714024927312812">بإدارة مؤسستك</translation>
+<translation id="9019902583201351841">يديره والداك</translation>
+<translation id="4645575059429386691">يديره والداك</translation>
+<translation id="4883854917563148705">يتعذّر إعادة ضبط الإعدادات التي تمت إدارتها</translation>
+<translation id="4307992518367153382">الإعدادات الأساسية</translation>
+<translation id="1974060860693918893">الإعدادات المتقدّمة</translation>
+<translation id="1146678959555564648">‏إدخال VR</translation>
+<translation id="987264212798334818">عام</translation>
+<translation id="4275663329226226506">الوسائط</translation>
+<translation id="4759238208242260848">الملفات التي تم تنزيلها</translation>
+<translation id="218608176142494674">المشاركة</translation>
+<translation id="8004582292198964060">المتصفّح</translation>
+<translation id="1105960400813249514">التقاط الشاشة</translation>
+<translation id="4875775213178255010">اقتراحات المحتوى</translation>
+<translation id="2021896219286479412">عناصر التحكم لموقع في وضع ملء الشاشة</translation>
+<translation id="4587589328781138893">المواقع</translation>
+<translation id="4943703118917034429">الواقع الافتراضي</translation>
+<translation id="1928696683969751773">التحديثات</translation>
+<translation id="6064125863973209585">عمليات التنزيل المكتمِلة</translation>
+<translation id="5342314432463739672">طلبات الإذن</translation>
+<translation id="629730747756840877">الحساب</translation>
+<translation id="82609232232243542">‏تسجيل الدخول إلى Brave</translation>
+<translation id="7956662517480676674">‏خدمات Brave Software والمزامنة</translation>
+<translation id="5294439808117722387">‏يتم حاليًا تخصيص إعدادات خدمة Brave Software والمزامنة. لإنهاء تفعيل المزامنة، يُرجى الضغط على زر "التأكيد" بالقرب من أسفل الشاشة. الانتقال إلى أعلى</translation>
+<translation id="2096012225669085171">المزامنة والتخصيص على الأجهزة</translation>
+<translation id="1692118695553449118">المزامنة ممكنة</translation>
+<translation id="5514904542973294328">تم الإيقاف من قبل مشرف هذا الجهاز</translation>
+<translation id="6447211988989208781">‏عناصر التحكم بالنشاط على Brave Software</translation>
+<translation id="4882831918239250449">التحكُّم في كيفية استخدامنا لسِجل التصفُّح الخاص بك لتخصيص البحث والإعلانات والمزيد</translation>
+<translation id="7431991332293347422">التحكُّم في كيفية استخدامنا لسِجل التصفُّح لتخصيص البحث والمزيد</translation>
+<translation id="6303969859164067831">تسجيل الخروج وإيقاف المزامنة</translation>
+<translation id="1125261911132334651">‏إدارة حسابك على Brave Software</translation>
+<translation id="6406506848690869874">المزامنة</translation>
+<translation id="714362445477979774">‏مزامنة بيانات Brave</translation>
+<translation id="4314815835985389558">إدارة المزامنة</translation>
+<translation id="5428209950370661546">‏خدمات Brave Software الأخرى</translation>
+<translation id="7704317875155739195">‏الإكمال التلقائي لعناوين URL وعمليات البحث</translation>
+<translation id="2000419248597011803">يُرسِل بعض ملفات تعريف الارتباط وعمليات البحث من شريط العناوين ومربّع البحث إلى محرِّك البحث التلقائي.</translation>
+<translation id="7981313251711023384">التحميل المُسبق للصفحات للحصول على أداء أسرع أثناء التصفّح والبحث</translation>
+<translation id="1821253160463689938">يستخدم ملفات تعريف الارتباط لتذكّر الإعدادات المُفضّلة حتى إذا لم تزُر تلك الصفحات.</translation>
+<translation id="6697492270171225480">عرض اقتراحات للصفحات المشابهة عند تعذّر العثور على صفحة</translation>
+<translation id="8109318360573330108">‏يُرسِل عنوان URL لصفحة تحاول الوصول إليها إلى Brave Software.</translation>
+<translation id="8438566539970814960">تحسين عمليات البحث والتصفُّح</translation>
+<translation id="284843628681142937">‏يتم إرسال عناوين URL للصفحات التي تزورها إلى Brave Software.</translation>
+<translation id="7222718784508482526">‏لعرض مزيد من الإعدادات المتعلِّقة بالخصوصية والأمان وجمع البيانات، يُرجى الاطِّلاع على <ph name="BEGIN_LINK"/>خدمات Brave Software والمزامنة<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">‏المساعدة في تحسين ميزات Brave وأدائه</translation>
+<translation id="9063160602596686558">‏يُرسِل إحصاءات الاستخدام وتقارير الأعطال إلى Brave Software تلقائيًا.</translation>
+<translation id="4824958205181053313">هل تريد إلغاء المزامنة؟</translation>
+<translation id="3058498974290601450">يمكنك تفعيل المزامنة في أي وقت في الإعدادات.</translation>
+<translation id="3143515551205905069">إلغاء المزامنة</translation>
+<translation id="1506061864768559482">محرك البحث</translation>
+<translation id="55737423895878184">مسموح بالإشعارات وتحديد الموقع الجغرافي</translation>
+<translation id="3988213473815854515">الموقع مسموح به</translation>
+<translation id="32895400574683172">مسموح بالإشعارات</translation>
+<translation id="9040142327097499898">الإشعارات مسموح بها. وتحديد الموقع الجغرافي متوقف لهذا الجهاز.</translation>
+<translation id="305593374596241526">‏تحديد الموقع الجغرافي متوقف، يمكنك تفعيله من <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">تم الانتقال إليها مؤخرًا</translation>
+<translation id="6433501201775827830">اختيار محرك البحث</translation>
+<translation id="7177466738963138057">يمكنك تغيير ذلك لاحقًا من "الإعدادات"</translation>
+<translation id="3478363558367712427">يمكنك استخدام محرّك بحث آخر.</translation>
+<translation id="4910889077668685004">تطبيقات الدفع</translation>
+<translation id="5152843274749979095">ليس هناك أي تطبيق مثبّت متوافق</translation>
+<translation id="8812260976093120287">يمكنك على مواقع ويب معيّنة الدفع باستخدام تطبيقات الدفع المتوافقة أعلاه على جهازك.</translation>
+<translation id="7764225426217299476">إضافة عنوان</translation>
+<translation id="5595485650161345191">تعديل العنوان</translation>
+<translation id="5087580092889165836">إضافة بطاقة</translation>
+<translation id="2154484045852737596">تعديل البطاقة</translation>
+<translation id="6140912465461743537">الدولة/الإقليم</translation>
+<translation id="5659593005791499971">البريد الإلكتروني</translation>
+<translation id="4378154925671717803">هاتف</translation>
+<translation id="4807098396393229769">الاسم كما على البطاقة</translation>
+<translation id="860043288473659153">اسم حامل البطاقة</translation>
+<translation id="2612676031748830579">رقم البطاقة</translation>
+<translation id="869891660844655955">تاريخ انتهاء الصلاحية</translation>
+<translation id="2286841657746966508">عنوان الفاتورة</translation>
+<translation id="663059986967017181">‏تم النسخ إلى Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 وطريقة دفع إضافية واحدة (<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>)}zero{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> طريقة دفع إضافية}two{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 وطريقتا دفع إضافيتان (<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>)}few{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> طرق دفع إضافية}many{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> طريقة دفع إضافية}other{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> طريقة دفع إضافية}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 وعنوان إضافي واحد (<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>)}zero{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> عنوان إضافي}two{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 وعنوانان إضافيان (<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>)}few{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> عناوين إضافية}many{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> عنوانًا إضافيًا}other{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> عنوان إضافي}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 وخيار إضافي واحد (<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>)}zero{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> خيار إضافي}two{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 وخياران إضافيان (<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>)}few{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> خيارات إضافية}many{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> خيارًا إضافيًا}other{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> خيار إضافي}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{‏<ph name="CONTACT_PREVIEW"/>\u2026 وجهة اتصال إضافية واحدة <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}zero{‏<ph name="CONTACT_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> جهة اتصال إضافية}two{‏<ph name="CONTACT_PREVIEW"/>\u2026 وجهتا اتصال إضافيتان (<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>)}few{‏<ph name="CONTACT_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> جهات اتصال إضافية}many{‏<ph name="CONTACT_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> جهة اتصال إضافية}other{‏<ph name="CONTACT_PREVIEW"/>\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> جهة اتصال إضافية}}</translation>
+<translation id="7029809446516969842">كلمات المرور</translation>
+<translation id="1943432128510653496">حفظ كلمات المرور</translation>
+<translation id="2100273922101894616">تسجيل الدخول تلقائيًا</translation>
+<translation id="363596933471559332">يمكنك تسجيل الدخول تلقائيًا إلى مواقع الويب باستخدام بيانات الاعتماد المخزّنة. وعندما تكون هذه الميزة غير مفعّلة، سيُطلب منك التحقّق من بيانات الاعتماد في كل مرة قبل تسجيل الدخول إلى موقع ويب.</translation>
+<translation id="6995899638241819463">التحذير إذا تم الكشف عن كلمات المرور في عملية اختراق بيانات</translation>
+<translation id="1534287762301776620">‏عند تسجيل الدخول إلى حسابك على Brave Software، يتم تفعيل هذه الميزة.</translation>
+<translation id="10614374240317010">المواقع التي لن تحفظ كلمات المرور أبدًا</translation>
+<translation id="3098842761938485917">‏بإمكانك عرض كلمات المرور المحفوظة وإدارتها في <ph name="BEGIN_LINK"/>حسابك على Brave Software<ph name="END_LINK"/>.</translation>
+<translation id="8562452229998620586">ستظهر هنا كلمات المرور المحفوظة.</translation>
+<translation id="8084114998886531721">كلمة مرور محفوظة</translation>
+<translation id="2870560284913253234">الموقع</translation>
+<translation id="8503813439785031346">اسم المستخدم</translation>
+<translation id="6657585470893396449">كلمة المرور</translation>
+<translation id="2154710561487035718">‏نسخ عنوان URL</translation>
+<translation id="1571304935088121812">نسخ اسم المستخدم</translation>
+<translation id="5005498671520578047">نسخ كلمة المرور</translation>
+<translation id="3632295766818638029">كشف كلمة المرور</translation>
+<translation id="1513858653616922153">حذف كلمة المرور</translation>
+<translation id="543338862236136125">تعديل كلمة المرور</translation>
+<translation id="4565377596337484307">إخفاء كلمة المرور</translation>
+<translation id="8523928698583292556">حذف كلمة المرور المخزنة</translation>
+<translation id="2898264748040935573">تعديل كلمة المرور المخزنة</translation>
+<translation id="5433691172869980887">تم نسخ اسم المستخدم</translation>
+<translation id="5534640966246046842">تم نسخ الموقع</translation>
+<translation id="2625189173221582860">تم نسخ كلمة المرور</translation>
+<translation id="4550003330909367850">عيّن قفل الشاشة على هذا الجهاز لعرض كلمة المرور أو نسخها هنا.</translation>
+<translation id="6154478581116148741">تشغيل قفل الشاشة في الإعدادات لتصدير كلمات المرور من هذا الجهاز</translation>
+<translation id="4842092870884894799">عرض نافذة إنشاء كلمة المرور المنبثقة</translation>
+<translation id="2259659629660284697">تصدير كلمات المرور...</translation>
+<translation id="133012818630824069">‏تصدير كلمات المرور المخزنة من خلال Brave</translation>
+<translation id="6914783257214138813">ستكون كلمات مرورك مرئية لأي شخص يمكنه الاطلاع على الملف الذي تم تصديره.</translation>
+<translation id="2321086116217818302">جارٍ تحضير كلمات المرور…</translation>
+<translation id="8445448999790540984">يتعذّر تصدير كلمات المرور</translation>
+<translation id="3066461326500799725">‏التعرّف على كيفية استخدام Brave Software Drive</translation>
+<translation id="729975465115245577">لا يتضمن جهازك تطبيقًا لتخزين ملف كلمات المرور.</translation>
+<translation id="7682724950699840886">يمكنك تجربة النصائح التالية: تأكد من توفر مساحة كافية على جهازك وحاول التصدير مرة أخرى.</translation>
+<translation id="1129510026454351943">التفاصيل: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">إلغاء القفل لنسخ كلمة المرور</translation>
+<translation id="5515439363601853141">إلغاء القفل لعرض كلمة المرور</translation>
+<translation id="6221633008163990886">إلغاء القفل لتصدير كلمات المرور</translation>
+<translation id="230699814587342492">‏كلمات المرور في Brave</translation>
+<translation id="6075798973483050474">تعديل الصفحة الرئيسية</translation>
+<translation id="854522910157234410">فتح هذه الصفحة</translation>
+<translation id="2482878487686419369">الإشعارات</translation>
+<translation id="6255999984061454636">اقتراحات المحتوى</translation>
+<translation id="805047784848435650">استنادًا إلى سجلّ التصفُّح</translation>
+<translation id="1041308826830691739">من المواقع الإلكترونية</translation>
+<translation id="395206256282351086">اقتراحات البحث ومواقع الويب غير مفعّلة</translation>
+<translation id="257088987046510401">المظاهر</translation>
+<translation id="4650364565596261010">الإعداد التلقائي للنظام</translation>
+<translation id="7588219262685291874">تفعيل "المظهر الداكن" عند تفعيل ميزة "توفير شحن البطارية" للجهاز</translation>
+<translation id="2760989362628427051">تفعيل المظهر الداكن عند تفعيل المظهر الداكن للجهاز أو ميزة "توفير شحن البطارية"</translation>
+<translation id="6381421346744604172">تعتيم المواقع الإلكترونية</translation>
+<translation id="5040262127954254034">الخصوصية</translation>
+<translation id="4991384657077828949">‏المساعدة في تحسين أمان Brave</translation>
+<translation id="1943176487615318915">‏لرصد التطبيقات ومواقع الويب الضارة، يُرسل Brave عناوين URL لبعض الصفحات التي زرتها ومعلومات محدودة للنظام وبعض أنواع محتوى الصفحات إلى Brave Software.</translation>
+<translation id="3181954750937456830">التصفُّح الآمن (يحميك ويحمي جهازك من مواقع الويب الضارة)</translation>
+<translation id="7315322926489145388">‏يتم إرسال عناوين URL لبعض الصفحات التي تزورها إلى Brave Software، عندما يكون أمانك في خطر</translation>
+<translation id="2063713494490388661">ميزة "البحث بالنقر"</translation>
+<translation id="2369463299479365221">‏يمكنك معرفة معلومات عن مواضيع على المواقع الإلكترونية بدون مغادرة الصفحة. تُرسل ميزة "البحث بالنقر" الكلمة والسياق المحيط بها إلى "بحث Brave Software" للحصول على تعريفات وصور ونتائج بحث وتفاصيل أخرى ذات الصلة بها.
 
 لضبط عبارة البحث، ما عليك سوى النقر مع الاستمرار عليها لتحديدها. ولتحسين البحث، انتقل إلى أعلى اللوحة ثمّ انقر على مربّع البحث.</translation>
-<translation id="4056223980640387499">بني داكن</translation>
-<translation id="4060598801229743805">الخيارات متاحة بالقرب من أعلى الشاشة</translation>
-<translation id="4062305924942672200">المعلومات القانونية</translation>
-<translation id="4084682180776658562">إشارة</translation>
-<translation id="4084712963632273211">‏من <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />تعرضه Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">هل ترغب في حذف بيانات التطبيق؟</translation>
-<translation id="4099578267706723511">‏يمكنك المساعدة في تحسين Chrome عن طريق إرسال إحصاءات الاستخدام وتقارير الأعطال إلى Google.</translation>
-<translation id="410351446219883937">التشغيل التلقائي</translation>
-<translation id="4116038641877404294">تنزيل الصفحات لاستخدامها بلا اتصال بالإنترنت</translation>
-<translation id="4135200667068010335">قائمة الأجهزة التي يمكن مشاركة علامة تبويب معها مغلقة.</translation>
-<translation id="4149994727733219643">عرض مبسَّط لصفحات الويب</translation>
-<translation id="4165986682804962316">إعدادات المواقع</translation>
-<translation id="4169535189173047238">عدم السماح</translation>
-<translation id="4170011742729630528">الخدمة غير متاحة، أعد المحاولة لاحقًا.</translation>
-<translation id="4179980317383591987">تم استخدام <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">اللغات</translation>
-<translation id="4183868528246477015">‏البحث باستخدام "عدسة Google" <ph name="BEGIN_NEW" />جديد<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">الفتح في علامة تبويب جديدة</translation>
-<translation id="4198423547019359126">ما من مواقع تنزيل متاحة</translation>
-<translation id="4209895695669353772">‏للحصول على محتوى مُخصَّص اقترحته Google، يُرجى تفعيل المزامنة.</translation>
-<translation id="4226663524361240545">يمكن أن تؤدي الإشعارات إلى اهتزاز الجهاز</translation>
-<translation id="423219824432660969">‏تشفير البيانات المتزامنة باستخدام كلمة مرور Google اعتبارًا من <ph name="TIME" /></translation>
-<translation id="4242533952199664413">فتح الإعدادات</translation>
-<translation id="4256782883801055595">تراخيص البرامج المفتوحة المصدر</translation>
-<translation id="4259722352634471385">التنقل محظور: <ph name="URL" /></translation>
-<translation id="4269820728363426813">نسخ عنوان الرابط</translation>
-<translation id="4275663329226226506">الوسائط</translation>
-<translation id="4278390842282768270">مسموح</translation>
-<translation id="429312253194641664">تشغيل موقع ويب للوسائط</translation>
-<translation id="4298388696830689168">المواقع المرتبطة</translation>
-<translation id="4307992518367153382">الإعدادات الأساسية</translation>
-<translation id="4314815835985389558">إدارة المزامنة</translation>
-<translation id="4351244548802238354">إغلاق مربع الحوار</translation>
-<translation id="4378154925671717803">هاتف</translation>
-<translation id="4384468725000734951">‏استخدام محرك Sogou للبحث</translation>
-<translation id="4404568932422911380">ليست هناك إشارات مرجعية</translation>
-<translation id="4405224443901389797">نقل إلى...</translation>
-<translation id="4411535500181276704">الوضع البسيط</translation>
-<translation id="4415276339145661267">‏إدارة حسابك على Google</translation>
-<translation id="4432792777822557199">ستتم ترجمة الصفحات باللغة <ph name="SOURCE_LANGUAGE" /> إلى اللغة <ph name="TARGET_LANGUAGE" /> من الآن فصاعدًا</translation>
-<translation id="4433925000917964731">‏نسخة خفيفة تقدِّمها Google</translation>
-<translation id="4434045419905280838">النوافذ المنبثقة وإعادة التوجيه</translation>
-<translation id="4440958355523780886">‏صفحة بسيطة تقدِّمها Google. يُرجى النقر لتحميل الصفحة الأصلية.</translation>
-<translation id="4452411734226507615">إغلاق علامة التبويب <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">أُضيفَت إشارة مرجعية إلى <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">السماح لمواقع الويب بتشغيل المحتوى المَحمي</translation>
-<translation id="4468959413250150279">كتم صوت موقع ويب معين.</translation>
-<translation id="4472118726404937099">للمزامنة والتخصيص على جميع الأجهزة، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
-<translation id="447252321002412580">‏المساعدة في تحسين ميزات Chrome وأدائه</translation>
-<translation id="4479647676395637221">السؤال أولاً قبل السماح لمواقع الويب باستخدام الكاميرا (موصى به)</translation>
-<translation id="4479972344484327217">‏جارٍ تثبيت <ph name="MODULE" /> لمتصفِّح Chrome…</translation>
-<translation id="4487967297491345095">‏سيتم حذف جميع بيانات تطبيق Chrome نهائيًا. ويشمل ذلك جميع الملفات والإعدادات والحسابات وقواعد البيانات وما إلى ذلك.</translation>
-<translation id="4493497663118223949">الوضع البسيط مفعَّل</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{قبل يوم واحد (#)}zero{قبل # يوم}two{قبل يومين (#)}few{قبل # أيام}many{قبل # يومًا}other{قبل # يوم}}</translation>
-<translation id="451872707440238414">البحث في الإشارات المرجعية</translation>
-<translation id="4521489764227272523">‏تمت إزالة البيانات المُحددة من متصفح Chrome والأجهزة التي تمت مزامنتها.
-
-قد يحتوي حسابك على Google على نماذج أخرى لسجل التصفح، مثل عمليات البحث والأنشطة من خدمات Google الأخرى في <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">اختيار مجلد</translation>
-<translation id="4538018662093857852">تفعيل الوضع البسيط</translation>
-<translation id="4550003330909367850">عيّن قفل الشاشة على هذا الجهاز لعرض كلمة المرور أو نسخها هنا.</translation>
-<translation id="4558311620361989323">اختصارات صفحة الويب</translation>
-<translation id="4561979708150884304">لا يتوفّر اتصال بالإنترنت</translation>
-<translation id="4565377596337484307">إخفاء كلمة المرور</translation>
-<translation id="4570913071927164677">التفاصيل</translation>
-<translation id="4572422548854449519">تسجيل الدخول إلى الحساب المدار</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{قبل دقيقة واحدة (#)}zero{قبل # دقيقة}two{قبل دقيقتين (#)}few{قبل # دقائق}many{قبل # دقيقة}other{قبل # دقيقة}}</translation>
-<translation id="4587589328781138893">المواقع</translation>
-<translation id="4594952190837476234">تم إنشاء هذه الصفحة المتوفّرة بلا اتصال بالإنترنت في <ph name="CREATION_TIME" />، وقد تختلف عن النسخة المتوفِّرة على الإنترنت.</translation>
-<translation id="4605958867780575332">تمت إزالة العنصر: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">فتح <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">استخدام كلمة المرور</translation>
-<translation id="4645575059429386691">يديره والداك</translation>
-<translation id="4650364565596261010">الإعداد التلقائي للنظام</translation>
-<translation id="4663756553811254707">تم حذف <ph name="NUMBER_OF_BOOKMARKS" /> من الإشارات المرجعية</translation>
-<translation id="4665282149850138822">تمت إضافة <ph name="NAME" /> إلى صفحتك الرئيسية</translation>
-<translation id="4684427112815847243">مزامنة كل شيء</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 وخيار إضافي واحد (<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />)}zero{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> خيار إضافي}two{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 وخياران إضافيان (<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />)}few{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> خيارات إضافية}many{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> خيارًا إضافيًا}other{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> خيار إضافي}}</translation>
-<translation id="4696983787092045100">إرسال رسالة نصية إلى أجهزتك</translation>
-<translation id="4698034686595694889">العرض بلا اتصال بالإنترنت في تطبيق <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">الصور والملفات المخزنة مؤقتًا</translation>
-<translation id="4714588616299687897">توفير ما يصل إلى 60% من بياناتك</translation>
-<translation id="4719927025381752090">عرض ترجمة</translation>
-<translation id="4720023427747327413">الفتح في <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">‏المساعدة في تحسين Chrome. <ph name="BEGIN_LINK" />المشاركة في الاستطلاع<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">تحديث</translation>
-<translation id="4738836084190194332">آخر مزامنة: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">فتح علامة تبويب جديدة</translation>
-<translation id="4751476147751820511">أجهزة استشعار الإضاءة أو الحركة</translation>
-<translation id="4759238208242260848">الملفات التي تم تنزيلها</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{اكتملت عملية تنزيل واحدة.}zero{اكتملت # عملية تنزيل.}two{اكتملت عمليتا تنزيل (#).}few{اكتملت # عمليات تنزيل.}many{اكتملت # عملية تنزيل.}other{اكتملت # عملية تنزيل.}}</translation>
-<translation id="4797039098279997504">المس  للعودة إلى <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">‏لا يتضمّن التشفير باستخدام عبارة المرور طرق الدفع والعناوين من Google Pay.
-
-لتغيير هذا الإعداد، يُرجى <ph name="BEGIN_LINK" />إعادة ضبط المزامنة<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">الاسم كما على البطاقة</translation>
-<translation id="4824958205181053313">هل تريد إلغاء المزامنة؟</translation>
-<translation id="4837753911714442426">فتح الخيارات لطباعة الصفحة</translation>
-<translation id="4842092870884894799">عرض نافذة إنشاء كلمة المرور المنبثقة</translation>
-<translation id="4860895144060829044">اتصال</translation>
-<translation id="4866368707455379617">‏تعذر تثبيت <ph name="MODULE" /> لمتصفِّح Chrome</translation>
-<translation id="4875775213178255010">اقتراحات المحتوى</translation>
-<translation id="4878404682131129617">أخفق إنشاء نفق عبر الخادم الوكيل.</translation>
-<translation id="4880127995492972015">ترجمة…</translation>
-<translation id="4881695831933465202">فتح</translation>
-<translation id="488187801263602086">إعادة تسمية الملف</translation>
-<translation id="4882831918239250449">التحكُّم في كيفية استخدامنا لسِجل التصفُّح الخاص بك لتخصيص البحث والإعلانات والمزيد</translation>
-<translation id="4883854917563148705">يتعذّر إعادة ضبط الإعدادات التي تمت إدارتها</translation>
-<translation id="4885273946141277891">‏عدد نسخ Chrome غير متوافق.</translation>
-<translation id="4910889077668685004">تطبيقات الدفع</translation>
-<translation id="4913161338056004800">إعادة ضبط الإحصاءات</translation>
-<translation id="4913169188695071480">إيقاف التحديث</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />الحصول على مساعدة<ph name="END_LINK" /> أثناء البحث عن الأجهزة…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{صفحة واحدة (#)}zero{# صفحة}two{صفحتان (#)}few{# صفحات}many{# صفحةً}other{# صفحة}}</translation>
-<translation id="4932247056774066048">‏لأنك بصدد الخروج من حساب تتم إدارته من خلال <ph name="DOMAIN_NAME" />، سيتم حذف بيانات Chrome من هذا الجهاز. وستظل البيانات في حسابك على Google.</translation>
-<translation id="4943703118917034429">الواقع الافتراضي</translation>
-<translation id="4943872375798546930">لا نتائج</translation>
-<translation id="4958708863221495346">يشارك <ph name="URL_OF_THE_CURRENT_TAB" /> شاشتك</translation>
-<translation id="4961107849584082341">ترجمة هذه الصفحة إلى أي لغة</translation>
-<translation id="4962975101802056554">إبطال جميع الأذونات للجهاز</translation>
-<translation id="4970824347203572753">لا تتوفر هذه الميزة في موقعك الجغرافي</translation>
-<translation id="497421865427891073">انتقال للأمام</translation>
-<translation id="4988210275050210843">جارٍ تنزيل الملف (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">الصفحات</translation>
-<translation id="4994033804516042629">لم يتم العثور على أي جهات اتصال</translation>
-<translation id="4996978546172906250">المشاركة عن طريق</translation>
-<translation id="5004416275253351869">‏عناصر التحكم بالنشاط على Google</translation>
-<translation id="5005498671520578047">نسخ كلمة المرور</translation>
-<translation id="5011311129201317034">يريد <ph name="SITE" /> الاتصال</translation>
-<translation id="5013696553129441713">ما من اقتراحات جديدة</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">عندما تكون في وضع "الواقع الافتراضي"، قد يتمكن هذا الموقع الإلكتروني من معرفة:
-  -  سماتك البدنية، مثل الطول
-
-يُرجى التأكد من أنك تثق بهذا الموقع الإلكتروني قبل الانتقال إلى وضع "الواقع الإفتراضي".</translation>
+<translation id="2930742481329940825">‏تعمل ميزة "البحث بالنقر" على إرسال الكلمة المُحدَّدة والصفحة الحالية كسياق إلى بحث Brave Software. يمكنك إيقافها في <ph name="BEGIN_LINK"/>الإعدادات<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">سماح</translation>
-<translation id="5040262127954254034">الخصوصية</translation>
-<translation id="5048398596102334565">السماح لمواقع الويب بالوصول إلى مستشعرات الحركة (مُقترَح)</translation>
-<translation id="5063480226653192405">الاستخدام</translation>
-<translation id="5087580092889165836">إضافة بطاقة</translation>
-<translation id="5100237604440890931">تم التصغير - انقر للتوسيع.</translation>
-<translation id="510275257476243843">يتبقى ساعة واحدة</translation>
-<translation id="5123685120097942451">علامة تبويب "التصفُّح المتخفي"</translation>
-<translation id="5127805178023152808">المزامنة غير مفعّلة</translation>
-<translation id="5129038482087801250">تثبيت تطبيق الويب</translation>
-<translation id="5132942445612118989">مزامنة كلمات المرور والسجلّ والمزيد على جميع الأجهزة</translation>
-<translation id="5139940364318403933">‏التعرّف على كيفية استخدام Google Drive</translation>
-<translation id="515227803646670480">محو البيانات المخزّنة</translation>
-<translation id="5152843274749979095">ليس هناك أي تطبيق مثبّت متوافق</translation>
-<translation id="5161254044473106830">العنوان مطلوب</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{تعذَّر إتمام عملية تنزيل واحدة.}zero{تعذَّر إتمام # عملية تنزيل.}two{تعذَّر إتمام عمليتي تنزيل (#).}few{تعذَّر إتمام # عمليات تنزيل.}many{تعذَّر إتمام # عملية تنزيل.}other{تعذَّر إتمام # عملية تنزيل.}}</translation>
-<translation id="5170568018924773124">العرض في المجلد</translation>
-<translation id="5184329579814168207">‏فتح في Chrome</translation>
-<translation id="5193988420012215838">تم النسخ إلى الحافظة</translation>
-<translation id="5197729504361054390">ستتم مشاركة جهات الاتصال التي تختارها مع الموقع الإلكتروني <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">الملف الشخصي للعمل</translation>
-<translation id="5210286577605176222">الانتقال السريع إلى علامة التبويب السابقة</translation>
-<translation id="5210365745912300556">إغلاق علامة التبويب</translation>
-<translation id="5224771365102442243">يتضمن فيديو</translation>
-<translation id="5230560987958996918">يريد <ph name="SITE" /> البحث عن أجهزة البلوتوث المجاورة. وتم العثور على الأجهزة التالية:</translation>
-<translation id="5233638681132016545">علامة تبويب جديدة</translation>
-<translation id="526421993248218238">يتعذَّر تحميل هذه الصفحة</translation>
-<translation id="5271967389191913893">لا يمكن للجهاز فتح المحتوى لتنزيله</translation>
-<translation id="528192093759286357">اسحب من الجزء العلوي والمس زر الرجوع للخروج من وضع ملء الشاشة.</translation>
-<translation id="5292796745632149097">إرسال إلى</translation>
-<translation id="5300589172476337783">عرض</translation>
-<translation id="5301954838959518834">حسنًا</translation>
-<translation id="5304593522240415983">لا يمكن ترك هذا الحقل فارغًا</translation>
-<translation id="5307446750509046227">محو مساحة تخزين المواقع</translation>
-<translation id="5308380583665731573">اتصال</translation>
-<translation id="5313967007315987356">إضافة موقع ويب</translation>
-<translation id="5317780077021120954">حفظ</translation>
-<translation id="5324858694974489420">الإعدادات الأبوية</translation>
-<translation id="5327248766486351172">الاسم</translation>
-<translation id="5335288049665977812">السماح لمواقع الويب بتشغيل جافا سكريبت (موصى به)</translation>
-<translation id="5342314432463739672">طلبات الإذن</translation>
-<translation id="5357811892247919462">تم تلقي علامة تبويب</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> علامة تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}zero{<ph name="OPEN_TABS_MANY" /> علامات تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}two{علامتا تبويب مفتوحتان<ph name="OPEN_TABS_MANY" />، يُرجى النقر لتبديل علامات التبويب}few{<ph name="OPEN_TABS_MANY" /> علامات تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}many{<ph name="OPEN_TABS_MANY" /> علامة تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}other{<ph name="OPEN_TABS_MANY" /> علامة تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}}</translation>
-<translation id="5391532827096253100">إن اتصالك بهذا الموقع الإلكتروني غير آمن. معلومات موقع الويب</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 آخر)}zero{(+ # آخر)}two{(+ اثنين (#) آخرين)}few{(+ # أخرى)}many{(+ # آخر)}other{(+ # آخر)}}</translation>
-<translation id="5400569084694353794">باستخدام هذا التطبيق، أنت توافق على <ph name="BEGIN_LINK1" />بنود الخدمة<ph name="END_LINK1" /> و<ph name="BEGIN_LINK2" />إشعار الخصوصية<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">الأسماء</translation>
-<translation id="5403644198645076998">السماح بمواقع ويب معيّنة فقط</translation>
-<translation id="5414836363063783498">جارٍ التحقق...</translation>
-<translation id="5423934151118863508">ستظهر صفحاتك الأكثر زيارة هنا</translation>
-<translation id="5424588387303617268">يتوفر <ph name="GIGABYTES" /> غيغابايت</translation>
-<translation id="543338862236136125">تعديل كلمة المرور</translation>
-<translation id="5433691172869980887">تم نسخ اسم المستخدم</translation>
-<translation id="543509235395288790">جارٍ تنزيل <ph name="COUNT" /> من الملفات (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">الانتقال السريع إلى شريط العناوين</translation>
-<translation id="5447201525962359567">مساحة التخزين في الموقع كاملة، بما في ذلك ملفات تعريف الارتباط وغيرها من البيانات المُخزَّنَة محليًا</translation>
-<translation id="5447765697759493033">لن تتم ترجمة هذا الموقع</translation>
-<translation id="545042621069398927">جارٍ تسريع التنزيل.</translation>
-<translation id="5456381639095306749">تنزيل الصفحة</translation>
-<translation id="5475862044948910901">هل تريد بدء جلسة الواقع المعزّز؟</translation>
-<translation id="548278423535722844">فتح في تطبيق الخرائط</translation>
-<translation id="5487521232677179737">محو البيانات</translation>
-<translation id="5494752089476963479">حظر الإعلانات في المواقع الإلكترونية التي تعرض إعلانات مضلِّلة أو غير مرغوب فيها</translation>
-<translation id="5500777121964041360">قد لا تتوفَّر هذه الميزة في موقعك الجغرافي</translation>
-<translation id="5512137114520586844">تتم إدارة هذا الحساب بواسطة <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">تم الإيقاف من قبل مشرف هذا الجهاز</translation>
-<translation id="5515439363601853141">إلغاء القفل لعرض كلمة المرور</translation>
-<translation id="5516455585884385570">فتح إعدادات الإشعارات</translation>
-<translation id="5517095782334947753">تتوفر لديك الإشارات المرجعية، والسجل، وكلمات المرور، والإعدادات الأخرى من <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">تم حظر إعادة التوجيه.</translation>
-<translation id="5527082711130173040">‏يحتاج Chrome للوصول إلى الموقع للبحث عن الأجهزة. <ph name="BEGIN_LINK1" />تحديث الأذونات<ph name="END_LINK1" />. الوصول إلى الموقع <ph name="BEGIN_LINK2" />غير مفعّل لهذا الجهاز<ph name="END_LINK2" /> أيضًا.</translation>
-<translation id="5527111080432883924">السؤال أولاً قبل السماح لمواقع الويب بقراءة النصوص والصور من الحافظة (موصى به)</translation>
-<translation id="5530766185686772672">إغلاق علامات تبويب التصفح المتخفي</translation>
-<translation id="5534334044554683961">عندما تكون في وضع "الواقع الافتراضي"، قد يتمكن هذا الموقع الإلكتروني من معرفة:
-  -   سماتك البدنية، مثل الطول
-  -   تنسيق غرفتك
-
-يُرجى التأكد من أنك تثق بهذا الموقع الإلكتروني قبل الانتقال إلى وضع "الواقع الافتراضي".</translation>
-<translation id="5534640966246046842">تم نسخ الموقع</translation>
-<translation id="5556459405103347317">إعادة التحميل</translation>
-<translation id="5561549206367097665">في انتظار الشبكة...</translation>
-<translation id="557283862590186398">‏يحتاج Chrome إلى إذن لاستخدام الميكروفون لموقع الويب هذا.</translation>
-<translation id="55737423895878184">مسموح بالإشعارات وتحديد الموقع الجغرافي</translation>
-<translation id="5578795271662203820">البحث في <ph name="SEARCH_ENGINE" /> عن هذه الصورة</translation>
-<translation id="5581519193887989363">يمكنك دائمًا اختيار ما تريد مزامنته في <ph name="BEGIN_LINK1" />الإعدادات<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">تعديل العنوان</translation>
-<translation id="5596627076506792578">خيارات إضافية</translation>
-<translation id="5599455543593328020">وضع "التصفّح المتخفي"</translation>
-<translation id="5620928963363755975">العثور على الملفات والصفحات في التنزيلات من الزر "مزيد من الخيارات"</translation>
-<translation id="5626134646977739690">الاسم:</translation>
-<translation id="5639724618331995626">السماح بجميع المواقع</translation>
-<translation id="5648166631817621825">آخر 7 أيام</translation>
-<translation id="5649053991847567735">التنزيلات التلقائية</translation>
-<translation id="5655963694829536461">البحث في التنزيلات</translation>
-<translation id="5659593005791499971">البريد الإلكتروني</translation>
-<translation id="5665379678064389456">إنشاء حدث في <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">تجاوز طلب موقع الويب لمنع التكبير</translation>
-<translation id="5677928146339483299">محظور </translation>
-<translation id="5684874026226664614">عفوًا. تعذرت ترجمة هذه الصفحة.</translation>
-<translation id="5686790454216892815">اسم الملف طويل جدًا</translation>
-<translation id="5689516760719285838">الموقع الجغرافي</translation>
-<translation id="569536719314091526">ترجمة هذه الصفحة إلى أي لغة من خلال الزر "مزيد من الخيارات"</translation>
-<translation id="572328651809341494">علامات التبويب الأخيرة</translation>
-<translation id="5726692708398506830">تكبير كل محتويات الصفحة</translation>
-<translation id="5748802427693696783">تم التبديل إلى علامات التبويب القياسية</translation>
-<translation id="5749068826913805084">‏يحتاج Chrome للوصول إلى مساحة التخزين لتنزيل الملفات.</translation>
-<translation id="5763382633136178763">علامات تبويب التصفح المتخفي</translation>
-<translation id="5763514718066511291">‏النقر لنسخ عنوان URL لهذا التطبيق</translation>
-<translation id="5765780083710877561">الوصف:</translation>
-<translation id="5793665092639000975">يتم استخدام <ph name="SPACE_USED" /> من أصل <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">‏قد تستخدم Google سجلّك لتخصيص البحث والإعلانات وخدمات Google الأخرى.</translation>
-<translation id="5804241973901381774">الأذونات</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{قبل ساعة واحدة (#)}zero{قبل # ساعة}two{قبل ساعتين (#)}few{قبل # ساعات}many{قبل # ساعة}other{قبل # ساعة}}</translation>
-<translation id="5810288467834065221">‏حقوق الطبع والنشر لعام <ph name="YEAR" /> لشركة Google LLC. جميع الحقوق محفوظة.</translation>
-<translation id="5817918615728894473">إقران</translation>
-<translation id="583281660410589416">غير معروف</translation>
-<translation id="5833984609253377421">مشاركة الرابط</translation>
-<translation id="5836192821815272682">‏جارٍ تنزيل تحديث Chrome…</translation>
-<translation id="5853623416121554550">متوقف مؤقتًا</translation>
-<translation id="5854790677617711513">مرّ عليها أكثر من 30 يومًا</translation>
-<translation id="5858741533101922242">‏يتعذر على Chrome تشغيل محوّل البلوتوث</translation>
-<translation id="5860033963881614850">غير مفعّل</translation>
-<translation id="5862731021271217234">للحصول على علامات التبويب من أجهزتك الأخرى، يُرجى تفعيل المزامنة.</translation>
-<translation id="5864174910718532887">التفاصيل: تم الترتيب بحسب اسم موقع الويب</translation>
-<translation id="5864419784173784555">في انتظار تنزيل آخر…</translation>
-<translation id="5865733239029070421">‏يُرسِل إحصاءات الاستخدام وتقارير الأعطال إلى Google تلقائيًا.</translation>
-<translation id="5869522115854928033">كلمات المرور المحفوظة</translation>
-<translation id="5902828464777634901">سيتم حذف كل البيانات المحلية التي يخزّنها هذا الموقع الإلكتروني، بما في ذلك ملفات تعريف الارتباط.</translation>
-<translation id="5916664084637901428">مفعّل</translation>
-<translation id="5919204609460789179">تحديث <ph name="PRODUCT_NAME" /> لبدء المزامنة</translation>
-<translation id="5937580074298050696">تم توفير <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">إعادة الضبط</translation>
-<translation id="5942872142862698679">‏استخدام محرك Google للبحث</translation>
-<translation id="5952764234151283551">‏يُرسِل عنوان URL لصفحة تحاول الوصول إليها إلى Google.</translation>
-<translation id="5956665950594638604">‏فتح مركز مساعدة Chrome في علامة تبويب جديدة</translation>
-<translation id="5958275228015807058">العثور على الملفات والصفحات في التنزيلات</translation>
-<translation id="5962718611393537961">النقر للتصغير</translation>
-<translation id="6000066717592683814">‏الاستمرار في استخدام محرك Google</translation>
-<translation id="6005538289190791541">كلمة المرور المُقترحَة</translation>
-<translation id="6036057147555329831">وحدة الرعاية المركزية الإضافية</translation>
-<translation id="6039379616847168523">الانتقال السريع إلى علامة التبويب التالية</translation>
-<translation id="6040143037577758943">إغلاق</translation>
-<translation id="6042308850641462728">المزيد</translation>
-<translation id="604996488070107836">تعذّر تنزيل الملف <ph name="FILE_NAME" /> بسبب خطأ غير معلوم.</translation>
-<translation id="605721222689873409">العام</translation>
-<translation id="6064125863973209585">عمليات التنزيل المكتمِلة</translation>
-<translation id="6075798973483050474">تعديل الصفحة الرئيسية</translation>
-<translation id="60923314841986378">عدد الساعات المتبقية: <ph name="HOURS" /></translation>
-<translation id="6108923351542677676">الإعداد قيد التقدّم…</translation>
-<translation id="6111020039983847643">حجم البيانات المستخدَمة</translation>
-<translation id="6112702117600201073">يتم الآن تحديث الصفحة</translation>
-<translation id="6127379762771434464">أُزيلَ عنصر</translation>
-<translation id="6140912465461743537">الدولة/الإقليم</translation>
-<translation id="614940544461990577">يمكنك محاولة:</translation>
-<translation id="6154478581116148741">تشغيل قفل الشاشة في الإعدادات لتصدير كلمات المرور من هذا الجهاز</translation>
-<translation id="6159335304067198720">توفير البيانات بنسبة <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">مزيد من المعلومات</translation>
-<translation id="6177111841848151710">تم حظره لمحرك البحث الحالي</translation>
-<translation id="6181444274883918285">إضافة موقع ويب إلى قائمة الاستثناءات</translation>
-<translation id="6192333916571137726">ملف تحميل</translation>
-<translation id="6192792657125177640">الاستثناءات</translation>
-<translation id="6194112207524046168">‏للسماح لمتصفِّح Chrome بالوصول إلى الكاميرا، يُرجى أيضًا تشغيل الكاميرا في <ph name="BEGIN_LINK" />إعدادات Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">حظر ملفات تعريف الارتباط للجهات الخارجية</translation>
-<translation id="6206551242102657620">يُعدُّ اتصالك آمنًا. معلومات موقع الويب</translation>
-<translation id="6210748933810148297">ليس <ph name="EMAIL" />؟</translation>
-<translation id="6221633008163990886">إلغاء القفل لتصدير كلمات المرور</translation>
+<translation id="1406000523432664303">"عدم التعقب"</translation>
 <translation id="6232535412751077445">إن تفعيل ميزة "عدم التعقب" يعني أنه سيتم تضمين طلب في حركة بيانات التصفّح. ويعتمد أي تأثير يحدث على ما إذا كان موقع الويب سيستجيب للطلب، وعلى كيفية تفسير الطلب.
 
 على سبيل المثال، قد تستجيب بعض مواقع الويب لهذا الطلب عبر عرض إعلانات لا تستند إلى مواقع الويب الأخرى التي زرتها، بينما ستظل العديد من مواقع الويب تجمع بيانات تصفّحك وتستخدمها - مثلاً لتحسين الأمان وتقديم محتوى وخدمات وإعلانات واقتراحات وإعداد تقارير بالإحصاءات.</translation>
-<translation id="624789221780392884">التحديث جاهز</translation>
-<translation id="6255999984061454636">اقتراحات المحتوى</translation>
-<translation id="6277522088822131679">حدثت مشكلة أثناء طباعة الصفحة. يُرجى إعادة المحاولة.</translation>
-<translation id="6295158916970320988">جميع المواقع</translation>
-<translation id="629730747756840877">الحساب</translation>
-<translation id="6303969859164067831">تسجيل الخروج وإيقاف المزامنة</translation>
-<translation id="6316139424528454185">‏إصدار Android غير متوافق</translation>
-<translation id="6320088164292336938">اهتزاز</translation>
-<translation id="6324034347079777476">‏تمّ إيقاف مزامنة نظام Android</translation>
-<translation id="6333140779060797560">المشاركة عن طريق <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">تشفير</translation>
-<translation id="6341580099087024258">السؤال عن مكان حفظ الملفات</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 وعنوان إضافي واحد (<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />)}zero{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> عنوان إضافي}two{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 وعنوانان إضافيان (<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />)}few{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> عناوين إضافية}many{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> عنوانًا إضافيًا}other{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> عنوان إضافي}}</translation>
-<translation id="6364438453358674297">هل تريد إزالة اقتراح من السجل؟</translation>
-<translation id="6369229450655021117">يمكنك "من هنا" البحث في الويب والمشاركة مع أصدقائك وعرض الصفحات المفتوحة</translation>
-<translation id="6378173571450987352">التفاصيل: تم الترتيب بحسب مقدار البيانات المُستخدَمة</translation>
-<translation id="6381421346744604172">تعتيم المواقع الإلكترونية</translation>
-<translation id="6388207532828177975">المحو وإعادة الضبط</translation>
-<translation id="6393863479814692971">‏يحتاج Chrome إلى إذن لاستخدام الكاميرا والميكروفون لموقع الويب هذا.</translation>
-<translation id="6395288395575013217">رابط</translation>
-<translation id="6404511346730675251">تعديل الإشارة المرجعية</translation>
-<translation id="6406506848690869874">المزامنة</translation>
-<translation id="641643625718530986">طباعة…</translation>
-<translation id="6416782512398055893">تم التنزيل بحجم <ph name="MBS" /> ميغابايت</translation>
-<translation id="6427112570124116297">ترجمة موقع الويب</translation>
-<translation id="6433501201775827830">اختيار محرك البحث</translation>
-<translation id="6437478888915024427">معلومات الصفحة</translation>
-<translation id="6441734959916820584">الاسم طويل جدًا</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{صورة واحدة (#)}zero{# صورة}two{صورتان (#)}few{# صور}many{# صورةً}other{# صورة}}</translation>
-<translation id="6447842834002726250">ملفّات تعريف الارتباط</translation>
-<translation id="6461962085415701688">يتعذر فتح الملف</translation>
-<translation id="6464977750820128603">‏يمكنك الاطِّلاع على مواقع الويب التي تزورها في Chrome وتحديد موقِّتات لها.\n\nتحصل Google على معلومات عن مواقع الويب التي ضبطت موقِّتات لها ومدة زيارتك لها. تُستخدم هذه المعلومات لتحسين الرفاهية الرقمية.</translation>
-<translation id="6475951671322991020">تنزيل الفيديو</translation>
-<translation id="6482749332252372425">تعذّر تنزيل الملف <ph name="FILE_NAME" /> لعدم توفر مساحة لتخزين.</translation>
-<translation id="6496823230996795692">لاستخدام <ph name="APP_NAME" /> للمرة الأولى، يُرجى الاتصال بالإنترنت.</translation>
-<translation id="6508722015517270189">‏إعادة تشغيل Chrome</translation>
-<translation id="6527303717912515753">مشاركة</translation>
-<translation id="6532866250404780454">‏لن يتم عرض مواقع الويب التي تزورها في Chrome. سيتم حذف جميع موقِّتات موقع الويب.</translation>
-<translation id="6534565668554028783">‏استغرقت Google وقتًا أطول مما يجب للاستجابة</translation>
-<translation id="6538442820324228105">تم التنزيل بحجم <ph name="GBS" /> غيغابايت</translation>
-<translation id="6539092367496845964">حدث خطأ. يُرجى إعادة المحاولة لاحقًا.</translation>
-<translation id="654446541061731451">حدد علامة تبويب لإرسالها باستخدام الشعاع</translation>
-<translation id="6545017243486555795">مسح جميع البيانات</translation>
-<translation id="6545864417968258051">البحث عن بلوتوث</translation>
-<translation id="6560414384669816528">‏البحث باستخدام Sogou</translation>
-<translation id="6566259936974865419">‏لقد وفر Chrome لك <ph name="GIGABYTES" /> غيغابايت</translation>
-<translation id="6573096386450695060">السماح دومًا</translation>
-<translation id="6573431926118603307">‏ستظهر هنا علامات التبويب التي فتحتها في Chrome من أجهزتك الأخرى.</translation>
-<translation id="6583199322650523874">وضع إشارة مرجعية على الصفحة الحالية</translation>
-<translation id="6593061639179217415">العرض بإصدار سطح المكتب</translation>
-<translation id="6600954340915313787">‏تم النسخ إلى Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> غيغابايت</translation>
-<translation id="6612358246767739896">المحتوى المحمي</translation>
-<translation id="6627583120233659107">تعديل مجلد</translation>
-<translation id="6643016212128521049">محو</translation>
-<translation id="6643649862576733715">الترتيب حسب مقدار البيانات التي تم توفيرها</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{‏<ph name="CONTACT_PREVIEW" />\u2026 وجهة اتصال إضافية واحدة <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}zero{‏<ph name="CONTACT_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> جهة اتصال إضافية}two{‏<ph name="CONTACT_PREVIEW" />\u2026 وجهتا اتصال إضافيتان (<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />)}few{‏<ph name="CONTACT_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> جهات اتصال إضافية}many{‏<ph name="CONTACT_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> جهة اتصال إضافية}other{‏<ph name="CONTACT_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> جهة اتصال إضافية}}</translation>
-<translation id="6649642165559792194">معاينة صورة <ph name="BEGIN_NEW" />ميزة جديدة<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">‏يحتاج Chrome للوصول إلى المواقع للبحث عن الأجهزة. <ph name="BEGIN_LINK" />تحديث الأذونات<ph name="END_LINK" />.</translation>
-<translation id="6657585470893396449">كلمة المرور</translation>
-<translation id="6659594942844771486">علامة تبويب</translation>
-<translation id="666731172850799929">الفتح في <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">‏إشعار خصوصية Chrome</translation>
-<translation id="6676840375528380067">‏هل تريد محو بيانات Chrome من هذا الجهاز؟</translation>
-<translation id="6697492270171225480">عرض اقتراحات للصفحات المشابهة عند تعذّر العثور على صفحة</translation>
-<translation id="6697947395630195233">‏يحتاج Chrome إلى الوصول إلى موقعك الجغرافي لمشاركة موقعك الجغرافي مع موقع الويب هذا.</translation>
-<translation id="6698801883190606802">إدارة البيانات المتزامنة</translation>
-<translation id="6699370405921460408">‏ستعمل خوادم Google على تحسين الصفحات التي تزورها.</translation>
-<translation id="6706288973712894588">‏أنت غير متصل بالإنترنت حاليًا.\n<ph name="BEGIN_LINK" />تعرّف على الخلاصة بلا إنترنت.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">الأخبار</translation>
-<translation id="6710213216561001401">السابق</translation>
-<translation id="671481426037969117">انقضى وقت موقّت <ph name="FQDN" />، وسيبدأ عمله مرّةً أخرى غدًا.</translation>
-<translation id="6738867403308150051">جارٍ التنزيل…</translation>
-<translation id="6746124502594467657">الانتقال إلى أسفل</translation>
-<translation id="6766622839693428701">يمكنك التمرير السريع للأسفل للإغلاق.</translation>
-<translation id="6766758767654711248">انقر للانتقال إلى موقع الويب</translation>
-<translation id="6767294960381293877">قائمة الأجهزة التي يمكن مشاركة علامة تبويب معها، مفتوحة على طول النصف السفلي من الشاشة.</translation>
-<translation id="6782111308708962316">منع مواقع الويب التابعة لجهات خارجية من حفظ بيانات ملفات تعريف الارتباط وقراءتها</translation>
-<translation id="6790428901817661496">التشغيل</translation>
-<translation id="6811034713472274749">الصفحة جاهزة للعرض</translation>
-<translation id="6818926723028410516">اختيار عناصر</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">ترجمة</translation>
-<translation id="6845325883481699275">‏المساعدة في تحسين أمان Chrome</translation>
-<translation id="6846298663435243399">جارٍ التحميل…</translation>
-<translation id="6850409657436465440">لا يزال التنزيل قيد التقدُّم</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> من علامات التبويب المغلقة</translation>
-<translation id="6864459304226931083">تنزيل الصورة</translation>
-<translation id="6865313869410766144">الملء التلقائي للبيانات</translation>
-<translation id="688738109438487280">يمكنك إضافة البيانات الحالية إلى <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">إلغاء القفل لنسخ كلمة المرور</translation>
-<translation id="6896758677409633944">نسخ</translation>
-<translation id="6910211073230771657">تم الحذف</translation>
-<translation id="6912998170423641340">حظر مواقع الويب من قراءة الصور والنصوص من الحافظة</translation>
-<translation id="6914783257214138813">ستكون كلمات مرورك مرئية لأي شخص يمكنه الاطلاع على الملف الذي تم تصديره.</translation>
-<translation id="6942665639005891494">تغيير موقع التنزيل التلقائي في أي وقت باستخدام خيار قائمة "الإعدادات"</translation>
-<translation id="6945221475159498467">تحديد</translation>
-<translation id="6963642900430330478">تُعدُّ هذه الصفحة خطيرة. معلومات موقع الويب</translation>
-<translation id="6963766334940102469">حذف الإشارات المرجعية</translation>
-<translation id="6965382102122355670">موافق</translation>
-<translation id="6979737339423435258">جميع الأوقات</translation>
-<translation id="6981982820502123353">إمكانية الوصول</translation>
-<translation id="6989267951144302301">تعذّر التنزيل</translation>
-<translation id="6990079615885386641">‏الحصول على التطبيق من متجر Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">السؤال أولاً قبل السماح لمواقع الويب باستخدام الميكروفون (موصى به)</translation>
-<translation id="7015203776128479407">لم ينتهِ إعداد المزامنة الأولية. تم إيقاف المزامنة.</translation>
-<translation id="7016516562562142042">تم منح الإذن لمحرّك البحث الحالي</translation>
-<translation id="7022756207310403729">فتح في المتصفح</translation>
-<translation id="702463548815491781">‏يُوصى به عند تفعيل TalkBack أو الوصول عبر مفتاح التحويل</translation>
-<translation id="7029809446516969842">كلمات المرور</translation>
-<translation id="7053983685419859001">حظر</translation>
-<translation id="7055152154916055070">تم حظر إعادة توجيه:</translation>
-<translation id="7063006564040364415">تعذر الاتصال بخادم المزامنة.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{تم تحديد عنصر واحد}zero{تم تحديد # عنصر}two{تم تحديد عنصرين (#)}few{تم تحديد # عناصر}many{تم تحديد # عنصرًا}other{تم تحديد # عنصر}}</translation>
-<translation id="7071521146534760487">إدارة الحساب</translation>
-<translation id="7077143737582773186">‏بطاقة SD</translation>
-<translation id="7087918508125750058">تم تحديد <ph name="ITEM_COUNT" /> عنصر، ويمكنك الاطّلاع على الخيارات في الجزء العلوي من الشاشة.</translation>
-<translation id="7121362699166175603">‏يتم محو السجلّ وعمليات الإكمال التلقائي في شريط العناوين. وقد يتضمّن حسابك على Google نماذج أخرى من سجلّ التصفّح في <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">السماح لمحرّك البحث الحالي</translation>
-<translation id="7138678301420049075">أخرى</translation>
-<translation id="7141896414559753902">منع مواقع الويب من عرض النوافذ المنبثقة وعمليات إعادة التوجيه (مُوصى به)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />تحميل الصفحة الأصلية<ph name="END_LINK" /> من <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">آخر 24 ساعة</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> كيلوبايت</translation>
-<translation id="7177466738963138057">يمكنك تغيير ذلك لاحقًا من "الإعدادات"</translation>
-<translation id="7180611975245234373">إعادة التحميل</translation>
-<translation id="7189372733857464326">‏انتظار انتهاء تحديث خدمات Google Play</translation>
-<translation id="7191430249889272776">تم فتح علامة التبويب في الخلفية.</translation>
-<translation id="723171743924126238">تحديد الصور</translation>
-<translation id="7233236755231902816">‏للاطّلاع على الويب بلغتك، يمكنك الحصول على أحدث إصدار من Chrome.</translation>
-<translation id="7243308994586599757">الخيارات المتاحة بالقرب من الجزء السفلي من الشاشة</translation>
-<translation id="7248069434667874558">‏يُرجى التأكّد من تفعيل مزامنة <ph name="TARGET_DEVICE_NAME" /> في Chrome.</translation>
-<translation id="7250468141469952378">تم اختيار <ph name="ITEM_COUNT" /> عنصراً</translation>
-<translation id="7274013316676448362">الموقع المحظور</translation>
-<translation id="7290209999329137901">إعادة التسمية غير متوفرة</translation>
-<translation id="7291387454912369099">‏الملء التلقائي باستخدام "مساعد Google"</translation>
-<translation id="7293171162284876153">‏لبدء المزامنة، يُرجى تفعيل "مزامنة بيانات Chrome".</translation>
-<translation id="729975465115245577">لا يتضمن جهازك تطبيقًا لتخزين ملف كلمات المرور.</translation>
-<translation id="7302081693174882195">التفاصيل: تم الترتيب بحسب مقدار البيانات المحفوظة</translation>
-<translation id="7328017930301109123">‏في الوضع البسيط، يُحمِّل Chrome الصفحات بشكلٍ أسرع ويستخدم بيانات أقل بنسبة تصل إلى 60 بالمائة.</translation>
-<translation id="7333031090786104871">لا تزال عملية إضافة موقع الويب السابق جارية</translation>
-<translation id="7352939065658542140">فيديو</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{مشاركة عنصر واحد محدد}zero{مشاركة # عنصر محدد}two{مشاركة عنصرين (#) محددين}few{مشاركة # عناصر محددة}many{مشاركة # عنصرًا محددًا}other{مشاركة # عنصر محدد}}</translation>
 <translation id="7359002509206457351">الوصول إلى طرق الدفع</translation>
+<translation id="8026334261755873520">محو بيانات التصفُّح</translation>
+<translation id="1291207594882862231">محو السجل وملفات تعريف الارتباط وبيانات المواقع وذاكرة التخزين المؤقت...</translation>
+<translation id="7814200940910057384">‏بيانات Brave التي تم محوها</translation>
+<translation id="1664855196866195614">‏تمت إزالة البيانات المُحددة من متصفح Brave والأجهزة التي تمت مزامنتها.
+
+قد يحتوي حسابك على Brave Software على نماذج أخرى لسجل التصفح، مثل عمليات البحث والأنشطة من خدمات Brave Software الأخرى في <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">الصور والملفات المخزنة مؤقتًا</translation>
+<translation id="2496180316473517155">سجلّ التصفّح</translation>
+<translation id="2546283357679194313">ملفات تعريف الارتباط وبيانات المواقع</translation>
+<translation id="8662811608048051533">يخرجك من معظم مواقع الويب.</translation>
+<translation id="8218628800671693884">‏سيتم تسجيل الخروج من معظم مواقع الويب، لكن لن يتم تسجيل الخروج من حسابك على Brave Software.</translation>
+<translation id="2017836877785168846">محو السجلّ وعمليات الإكمال التلقائي في شريط العناوين.</translation>
+<translation id="8096327394278038498">‏يتم محو السجلّ وعمليات الإكمال التلقائي في شريط العناوين. وقد يتضمّن حسابك على Brave Software نماذج أخرى من سجلّ التصفّح في <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">‏يمسح السجل من كل الأجهزة التي تم تسجيل الدخول عليها. وقد يتضمن حسابك في Brave Software نماذج أخرى من سجل التصفح في <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">كلمات المرور المحفوظة</translation>
+<translation id="6865313869410766144">الملء التلقائي للبيانات</translation>
+<translation id="7562080006725997899">جارٍ محو بيانات التصفح</translation>
+<translation id="5487521232677179737">محو البيانات</translation>
+<translation id="7498271377022651285">يُرجى الانتظار...</translation>
+<translation id="784934925303690534">النطاق الزمني</translation>
+<translation id="1718835860248848330">آخر ساعة</translation>
+<translation id="7149893636342594995">آخر 24 ساعة</translation>
+<translation id="5648166631817621825">آخر 7 أيام</translation>
+<translation id="8571213806525832805">الأسابيع الـ4 الأخيرة</translation>
+<translation id="5854790677617711513">مرّ عليها أكثر من 30 يومًا</translation>
+<translation id="6979737339423435258">جميع الأوقات</translation>
+<translation id="982182592107339124">سيؤدي هذا إلى محو بيانات جميع المواقع، بما في ذلك:</translation>
+<translation id="6643016212128521049">محو</translation>
+<translation id="7641339528570811325">محو بيانات التصفّح...</translation>
+<translation id="1670399744444387456">الإعدادات الأساسية</translation>
+<translation id="3245261285041759672">‏قد يتضمّن حسابك على Brave Software نماذج أخرى من سجلّ التصفّح في <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">الموقع المحظور</translation>
+<translation id="2534155362429831547">تم حذف <ph name="NUMBER_OF_ITEMS"/> من العناصر</translation>
+<translation id="1121094540300013208">تقارير الاستخدام والأعطال</translation>
+<translation id="9079153198295609735">‏إرسال إحصاءات الاستخدام وتقارير الأعطال إلى Brave Software تلقائيًا</translation>
+<translation id="6981982820502123353">إمكانية الوصول</translation>
+<translation id="2387895666653383613">تغيير حجم النص</translation>
+<translation id="2321958826496381788">اسحب شريط التمرير إلى أن تتمكّن من قراءة هذا النص بسهولة. يجب أن يظهر النص بهذا الحجم على الأقل بعد النقر مرّتين على أي فقرة.</translation>
+<translation id="3895926599014793903">فرض تفعيل التكبير/التصغير</translation>
+<translation id="5668404140385795438">تجاوز طلب موقع الويب لمنع التكبير</translation>
+<translation id="4149994727733219643">عرض مبسَّط لصفحات الويب</translation>
+<translation id="9100505651305367705">اقتراح مشاهدة المقالات في العرض المبسَّط إذا كان ذلك متاحًا</translation>
+<translation id="1409426117486808224">عرض مبسَّط لعلامات التبويب المفتوحة</translation>
+<translation id="702463548815491781">‏يُوصى به عند تفعيل TalkBack أو الوصول عبر مفتاح التحويل</translation>
+<translation id="8284326494547611709">الترجمة والشرح</translation>
+<translation id="4165986682804962316">إعدادات المواقع</translation>
+<translation id="6295158916970320988">جميع المواقع</translation>
+<translation id="8380167699614421159">يعرض هذا الموقع الإلكتروني إعلانات مضلِّلة أو غير مرغوب فيها</translation>
+<translation id="1919345977826869612">الإعلانات</translation>
+<translation id="410351446219883937">التشغيل التلقائي</translation>
+<translation id="6447842834002726250">ملفّات تعريف الارتباط</translation>
+<translation id="6196640612572343990">حظر ملفات تعريف الارتباط للجهات الخارجية</translation>
+<translation id="6782111308708962316">منع مواقع الويب التابعة لجهات خارجية من حفظ بيانات ملفات تعريف الارتباط وقراءتها</translation>
+<translation id="7521387064766892559">جافا سكريبت</translation>
+<translation id="4434045419905280838">النوافذ المنبثقة وإعادة التوجيه</translation>
+<translation id="4751476147751820511">أجهزة استشعار الإضاءة أو الحركة</translation>
+<translation id="1717218214683051432">مستشعرات الحركة</translation>
+<translation id="2091887806945687916">الصوت</translation>
+<translation id="2586657967955657006">الحافظة</translation>
+<translation id="6320088164292336938">اهتزاز</translation>
+<translation id="4226663524361240545">يمكن أن تؤدي الإشعارات إلى اهتزاز الجهاز</translation>
+<translation id="1446450296470737166">‏السماح بالتحكم الكامل لأجهزة MIDI</translation>
+<translation id="3744111561329211289">المزامنة في الخلفية</translation>
+<translation id="5649053991847567735">التنزيلات التلقائية</translation>
+<translation id="6181444274883918285">إضافة موقع ويب إلى قائمة الاستثناءات</translation>
+<translation id="5313967007315987356">إضافة موقع ويب</translation>
+<translation id="1369915414381695676">تمت إضافة الموقع <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">السماح لموقع ويب معيّن بالتشغيل التلقائي للفيديوهات المكتومة الصوت</translation>
+<translation id="2621115761605608342">السماح لموقع ويب معيّن بتشغيل جافا سكريبت</translation>
+<translation id="8801436777607969138">حظر جافا سكريبت لموقع ويب مُعيَّن.</translation>
+<translation id="8372893542064058268">السماح لموقع ويب معيّن بتشغيل "المزامنة في الخلفية"</translation>
+<translation id="358794129225322306">السماح لموقع ويب بتنزيل عدة ملفات تلقائيًا.</translation>
+<translation id="4008040567710660924">السماح لموقع ويب معيّن بتشغيل ملفات تعريف الارتباط</translation>
+<translation id="8958424370300090006">حظر ملفات تعريف الارتباط لموقع إلكتروني مُحدَّد.</translation>
+<translation id="7882806643839505685">السماح بتشغيل الصوت لموقع معين.</translation>
+<translation id="4468959413250150279">كتم صوت موقع ويب معين.</translation>
+<translation id="1994173015038366702">‏عنوان URL للموقع</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">الاستخدام</translation>
+<translation id="5804241973901381774">الأذونات</translation>
+<translation id="4278390842282768270">مسموح</translation>
+<translation id="5677928146339483299">محظور</translation>
+<translation id="1984937141057606926">مسموح باستثناء الجهات الخارجية</translation>
+<translation id="7423098979219808738">السؤال أولاً</translation>
+<translation id="8116925261070264013">مواقع الويب التي تم كتم الصوت فيها</translation>
+<translation id="8300705686683892304">تتم الإدارة من خلال التطبيق</translation>
+<translation id="6192792657125177640">الاستثناءات</translation>
+<translation id="257931822824936280">تم التوسيع - انقر للتصغير.</translation>
+<translation id="5100237604440890931">تم التصغير - انقر للتوسيع.</translation>
+<translation id="857943718398505171">مسموح بها (موصى بها)</translation>
+<translation id="2913331724188855103">السماح لمواقع الويب بحفظ بيانات ملفات تعريف الارتباط وقراءتها (موصى به)</translation>
+<translation id="7445411102860286510">السماح لمواقع الويب بتشغيل الفيديوهات المكتومة الصوت تلقائيًا (مُستحسن)</translation>
+<translation id="5335288049665977812">السماح لمواقع الويب بتشغيل جافا سكريبت (موصى به)</translation>
+<translation id="5527111080432883924">السؤال أولاً قبل السماح لمواقع الويب بقراءة النصوص والصور من الحافظة (موصى به)</translation>
+<translation id="6912998170423641340">حظر مواقع الويب من قراءة الصور والنصوص من الحافظة</translation>
+<translation id="7423538860840206698">تم الحظر من قراءة الحافظة</translation>
+<translation id="3955193568934677022">السماح لمواقع الويب بتشغيل المحتوى المحمي (مُستحسَن)</translation>
+<translation id="445467742685312942">السماح لمواقع الويب بتشغيل المحتوى المَحمي</translation>
+<translation id="2107397443965016585">السؤال أولاً قبل السماح لمواقع الويب بتشغيل المحتوى المَحمي (موصى به)</translation>
+<translation id="2910701580606108292">السؤال قبل السماح لمواقع الويب بتشغيل المحتوى المحمي</translation>
+<translation id="757524316907819857">منع مواقع الويب من تشغيل المحتوى المحمي</translation>
+<translation id="3277252321222022663">يمكنك السماح للمواقع بالوصول إلى أجهزة الاستشعار (مُقترَح).</translation>
+<translation id="5048398596102334565">السماح لمواقع الويب بالوصول إلى مستشعرات الحركة (مُقترَح)</translation>
+<translation id="8816026460808729765">يمكنك حظر مواقع الويب من الوصول إلى أجهزة الاستشعار.</translation>
+<translation id="169515064810179024">حظر مواقع الويب من الوصول إلى مستشعرات الحركة</translation>
+<translation id="1660204651932907780">السماح لمواقع الويب بتشغيل الصوت (موصى به)</translation>
+<translation id="3600792891314830896">كتم صوت مواقع الويب التي تشغّل الصوت</translation>
+<translation id="1743802530341753419">السؤال قبل السماح لمواقع الويب بالاتصال بجهاز (موصى به)</translation>
+<translation id="851751545965956758">حظر مواقع الويب من الاتصال بأجهزة</translation>
+<translation id="7141896414559753902">منع مواقع الويب من عرض النوافذ المنبثقة وعمليات إعادة التوجيه (مُوصى به)</translation>
+<translation id="5494752089476963479">حظر الإعلانات في المواقع الإلكترونية التي تعرض إعلانات مضلِّلة أو غير مرغوب فيها</translation>
+<translation id="3123473560110926937">حظر الإعلانات في بعض المواقع</translation>
+<translation id="965817943346481315">الحظر في حال كان موقع الويب يعرض إعلانات مضلِّلة أو غير مرغوب فيها (مُستحسَن)</translation>
+<translation id="3386292677130313581">السؤال قبل السماح لمواقع الويب بمعرفة الموقع الجغرافي (موصى به)</translation>
+<translation id="9139068048179869749">السؤال قبل السماح لمواقع الويب بإرسال الإشعارات (موصى به)</translation>
+<translation id="4479647676395637221">السؤال أولاً قبل السماح لمواقع الويب باستخدام الكاميرا (موصى به)</translation>
+<translation id="6992289844737586249">السؤال أولاً قبل السماح لمواقع الويب باستخدام الميكروفون (موصى به)</translation>
+<translation id="2289270750774289114">طلب الإذن عند محاولة موقع ويب العثور على أجهزة البلوتوث المجاورة (إجراء موصَى به)</translation>
+<translation id="7053983685419859001">حظر</translation>
+<translation id="7128222689758636196">السماح لمحرّك البحث الحالي</translation>
+<translation id="7589445247086920869">حظر محرّك البحث الحالي</translation>
+<translation id="6388207532828177975">المحو وإعادة الضبط</translation>
+<translation id="7999064672810608036">هل أنت متأكّد أنك تريد محو كل البيانات المحلية، بما في ذلك ملفات تعريف الارتباط، وإعادة ضبط كافة الأذونات لهذا الموقع الإلكتروني؟</translation>
+<translation id="2822354292072154809">هل تريد فعلاً إعادة ضبط جميع أذونات الموقع الإلكتروني للكائن <ph name="CHOSEN_OBJECT_NAME"/>؟</translation>
+<translation id="515227803646670480">محو البيانات المخزّنة</translation>
+<translation id="5902828464777634901">سيتم حذف كل البيانات المحلية التي يخزّنها هذا الموقع الإلكتروني، بما في ذلك ملفات تعريف الارتباط.</translation>
+<translation id="119944043368869598">محو الكل</translation>
+<translation id="2490684707762498678">تتم إدارتها من خلال <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">فتح إعدادات الإشعارات</translation>
+<translation id="1404122904123200417">متضمّن في <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">تظهر هنا الملفات التي تحفظها المواقع الإلكترونية</translation>
+<translation id="4181841719683918333">اللغات</translation>
+<translation id="2647434099613338025">إضافة لغة</translation>
+<translation id="1952172573699511566">ستعرض مواقع الويب النص بلغتك المفضّلة إن أمكن.</translation>
+<translation id="8559990750235505898">اقتراح ترجمة الصفحات المكتوبة بلغات أخرى</translation>
+<translation id="4719927025381752090">عرض ترجمة</translation>
+<translation id="8156139159503939589">ما هي اللغات التي تقرؤها؟</translation>
+<translation id="5689516760719285838">الموقع الجغرافي</translation>
+<translation id="2440823041667407902">تحديد الموقع الجغرافي</translation>
+<translation id="2023546461831060654">‏تشغيل الأذونات لـ Brave في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">‏إتاحة الإذن لـ Brave في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/></translation>
+<translation id="2928908108430545745">‏للسماح لمتصفِّح Brave بالوصول إلى موقعك الجغرافي، يُرجى أيضًا تفعيل الموقع الجغرافي في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">‏للسماح لمتصفِّح Brave بالوصول إلى الكاميرا، يُرجى أيضًا تشغيل الكاميرا في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">‏للسماح لمتصفِّح Brave بإرسال الإشعارات إليك، يمكنك أيضًا تفعيل الإشعارات في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">‏للسماح لمتصفِّح Brave بالوصول إلى الميكروفون، يُرجى أيضًا تشغيل الميكروفون في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">‏الوصول إلى الموقع الجغرافي متوقف لهذا الجهاز. يمكنك تفعليه في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">‏الوصول إلى الموقع الجغرافي متوقف لهذا الجهاز أيضًا. يمكنك تفعليه في <ph name="BEGIN_LINK"/>إعدادات Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">الكاميرا</translation>
+<translation id="3227137524299004712">الميكروفون</translation>
+<translation id="1647391597548383849">الدخول إلى الكاميرا</translation>
+<translation id="945632385593298557">الدخول إلى الميكروفون</translation>
+<translation id="6612358246767739896">المحتوى المحمي</translation>
+<translation id="885701979325669005">التخزين</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> من البيانات المخزّنة</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">إبطال إذن الجهاز</translation>
+<translation id="4962975101802056554">إبطال جميع الأذونات للجهاز</translation>
+<translation id="6545864417968258051">البحث عن بلوتوث</translation>
+<translation id="4411535500181276704">الوضع البسيط</translation>
+<translation id="7821588508402923572">سيظهر توفير البيانات هنا</translation>
+<translation id="2131665479022868825">تم توفير <ph name="DATA"/></translation>
+<translation id="8569404424186215731">منذ <ph name="DATE"/></translation>
+<translation id="3252158532344029638">‏في الوضع البسيط، يُحمِّل Brave الصفحات بشكلٍ أسرع ويستخدم بيانات أقل بنسبة تصل إلى 60 بالمائة.</translation>
+<translation id="6159335304067198720">توفير البيانات بنسبة <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">حجم البيانات التي تم توفيرها</translation>
+<translation id="6111020039983847643">حجم البيانات المستخدَمة</translation>
+<translation id="7413229368719586778">تاريخ البدء: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">تاريخ الانتهاء: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">الترتيب حسب الموقع</translation>
+<translation id="5864174910718532887">التفاصيل: تم الترتيب بحسب اسم موقع الويب</translation>
+<translation id="116280672541001035">المستخدَمة</translation>
+<translation id="8349013245300336738">الترتيب حسب مقدار البيانات المُستخدَمة</translation>
+<translation id="6378173571450987352">التفاصيل: تم الترتيب بحسب مقدار البيانات المُستخدَمة</translation>
+<translation id="2631006050119455616">تم توفيرها</translation>
+<translation id="6643649862576733715">الترتيب حسب مقدار البيانات التي تم توفيرها</translation>
+<translation id="7302081693174882195">التفاصيل: تم الترتيب بحسب مقدار البيانات المحفوظة</translation>
+<translation id="4179980317383591987">تم استخدام <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">تم توفير <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">المواقع المتبقية (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">أخرى</translation>
+<translation id="4913161338056004800">إعادة ضبط الإحصاءات</translation>
+<translation id="1856325424225101786">هل ترغب في إعادة ضبط الوضع البسيط؟</translation>
+<translation id="3658159451045945436">تؤدي إعادة الضبط إلى محو سِجلّ البيانات المحفوظة، بما في ذلك قائمة المواقع الإلكترونية التي تمت زيارتها.</translation>
+<translation id="3295530008794733555">تصفُّح أسرع. واستخدام بيانات أقل.</translation>
+<translation id="7340390500800578919">‏في الوضع البسيط، يُحمِّل Brave الصفحات بشكلٍ أسرع ويستخدم بيانات أقل بنسبة تصل إلى 60%. لتحسين مستوى أداء الصفحات التي تزورها، يرسل Brave عدد زيارات الويب إلى Brave Software. <ph name="BEGIN_LINK"/>مزيد من المعلومات<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">تفعيل الوضع البسيط</translation>
+<translation id="4493497663118223949">الوضع البسيط مفعَّل</translation>
+<translation id="7559975015014302720">تم إيقاف الوضع البسيط</translation>
+<translation id="7606077192958116810">تم تفعيل الوضع البسيط. يمكنك إدارته في الإعدادات.</translation>
+<translation id="4714588616299687897">توفير ما يصل إلى 60% من بياناتك</translation>
+<translation id="1006927014032731288">‏ستعمل خوادم Brave Software على تحسين الصفحات التي تزورها.</translation>
+<translation id="3257320067425202300">‏لقد وفر Brave لك <ph name="MEGABYTES"/> ميغابايت</translation>
+<translation id="5813223329348543512">‏لقد وفر Brave لك <ph name="GIGABYTES"/> غيغابايت</translation>
+<translation id="8266862848225348053">موقع التنزيل</translation>
+<translation id="7077143737582773186">‏بطاقة SD</translation>
+<translation id="7762668264895820836">‏بطاقة SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">السؤال عن مكان حفظ الملفات</translation>
+<translation id="6192333916571137726">ملف تحميل</translation>
+<translation id="1672586136351118594">عدم العرض مرة أخرى</translation>
+<translation id="2650751991977523696">هل تريد تنزيل الملف مرة أخرى؟</translation>
+<translation id="8664979001105139458">اسم الملف موجود</translation>
+<translation id="488187801263602086">إعادة تسمية الملف</translation>
+<translation id="5686790454216892815">اسم الملف طويل جدًا</translation>
+<translation id="7454641608352164238">مساحة التخزين غير كافية</translation>
+<translation id="8972098258593396643">هل تريد التنزيل إلى المجلد التلقائي؟</translation>
+<translation id="804335162455518893">‏لم يتم العثور على بطاقة SD.</translation>
+<translation id="7475688122056506577">‏لم يتم العثور على بطاقة SD. قد يكون بعض الملفات مفقودًا.</translation>
+<translation id="4198423547019359126">ما من مواقع تنزيل متاحة</translation>
+<translation id="8224471946457685718">‏تنزيل مقالات لك عند الاتصال بشبكة Wi-Fi</translation>
+<translation id="4970824347203572753">لا تتوفر هذه الميزة في موقعك الجغرافي</translation>
+<translation id="5500777121964041360">قد لا تتوفَّر هذه الميزة في موقعك الجغرافي</translation>
+<translation id="1173894706177603556">إعادة تسمية</translation>
+<translation id="1986685561493779662">الاسم موجود من قبل</translation>
+<translation id="6441734959916820584">الاسم طويل جدًا</translation>
+<translation id="2923908459366352541">الاسم غير صحيح</translation>
+<translation id="7290209999329137901">إعادة التسمية غير متوفرة</translation>
+<translation id="3334729583274622784">هل تريد تغيير امتداد الملف؟</translation>
+<translation id="107147699690128016">في حال تغيير امتداد الملف، قد يفتح الملف في تطبيق مختلف ومن المحتمل أن يشكّل خطورة على جهازك.</translation>
+<translation id="8541922081612557424">‏لمحة عن Brave</translation>
+<translation id="5311273890481188673">‏حقوق الطبع والنشر لعام <ph name="YEAR"/> لشركة Brave Software LLC. جميع الحقوق محفوظة.</translation>
+<translation id="1416550906796893042">إصدار التطبيق</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (تم التحديث منذ <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">نظام التشغيل</translation>
+<translation id="3968054912784331254">‏لم تعد تحديثات Brave متاحة لهذا الإصدار من نظام التشغيل Android</translation>
+<translation id="7665369617277396874">إضافة حساب</translation>
+<translation id="649070405679044769">‏أنت مسجّل الدخول إلى Brave Software باستخدام</translation>
+<translation id="6234515504547364178">‏تسجيل الخروج من Brave</translation>
+<translation id="5324858694974489420">الإعدادات الأبوية</translation>
+<translation id="8920114477895755567">الانتظار للحصول على تفاصيل الآباء</translation>
+<translation id="5512137114520586844">تتم إدارة هذا الحساب بواسطة <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">تتم إدارة هذا الحساب بواسطة <ph name="PARENT_NAME_1"/> و <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">المحتوى</translation>
+<translation id="5403644198645076998">السماح بمواقع ويب معيّنة فقط</translation>
+<translation id="8641930654639604085">محاولة حظر مواقع الويب التي تتضمن محتوى للبالغين</translation>
+<translation id="5639724618331995626">السماح بجميع المواقع</translation>
+<translation id="796823723482603597">‏يدعمها Brave</translation>
+<translation id="6324034347079777476">‏تمّ إيقاف مزامنة نظام Android</translation>
+<translation id="5127805178023152808">المزامنة غير مفعّلة</translation>
+<translation id="7015203776128479407">لم ينتهِ إعداد المزامنة الأولية. تم إيقاف المزامنة.</translation>
+<translation id="2497852260688568942">تم إيقاف المزامنة من قِبل المشرف</translation>
+<translation id="9100610230175265781">عبارة المرور مطلوبة</translation>
+<translation id="6108923351542677676">الإعداد قيد التقدّم…</translation>
+<translation id="4062305924942672200">المعلومات القانونية</translation>
+<translation id="4256782883801055595">تراخيص البرامج المفتوحة المصدر</translation>
+<translation id="1138681184697033370">‏بنود خدمة Brave</translation>
+<translation id="7392539049993970338">‏إشعار خصوصية Brave</translation>
+<translation id="2677748264148917807">الخروج</translation>
+<translation id="5556459405103347317">إعادة التحميل</translation>
+<translation id="1623104350909869708">منع هذه الصفحة من إنشاء مربعات حوار إضافية.</translation>
+<translation id="2968755619301702150">عارض الشهادات</translation>
+<translation id="1360432990279830238">هل تريد تسجيل الخروج وإيقاف المزامنة؟</translation>
+<translation id="8581481290581777242">‏هل تريد محو بيانات Brave من هذا الجهاز؟</translation>
+<translation id="1318865768845061710">‏لن تتم مزامنة الإشارات المرجعية والسجلّ وكلمات المرور وبيانات Brave الأخرى مع حسابك على Brave Software بعد ذلك.</translation>
+<translation id="3325020657155065477">‏محو بيانات Brave من هذا الجهاز أيضًا</translation>
+<translation id="6136448902816743006">‏لأنك بصدد الخروج من حساب تتم إدارته من خلال <ph name="DOMAIN_NAME"/>، سيتم حذف بيانات Brave من هذا الجهاز. وستظل البيانات في حسابك على Brave Software.</translation>
+<translation id="1853026300647876496">‏جارٍ الاتصال بـ Brave Software. قد يستغرق ذلك دقيقة واحدة...</translation>
+<translation id="2328985652426384049">تعذر تسجيل الدخول</translation>
+<translation id="7723158744459952869">‏استغرقت Brave Software وقتًا أطول مما يجب للاستجابة</translation>
+<translation id="4572422548854449519">تسجيل الدخول إلى الحساب المدار</translation>
+<translation id="2689656545739939160">‏يتم تسجيل دخولك باستخدام حساب تتم إدارته من خلال <ph name="MANAGED_DOMAIN"/> ومنح مشرفه الحق في التحكم في بياناتك على Brave. سيؤدي ذلك إلى جعل بياناتك مرتبطة دائمًا بهذا الحساب. كما سيؤدي الخروج من Brave إلى حذف بياناتك من هذا الجهاز، ولكن ستظل هذه البيانات مخزَّنة على حسابك في Brave Software.</translation>
+<translation id="1749561566933687563">مزامنة الإشارات المرجعية</translation>
+<translation id="4242533952199664413">فتح الإعدادات</translation>
+<translation id="1111673857033749125">ستظهر هنا الإشارات التي تم حفظها على أجهزتك الأخرى.</translation>
+<translation id="8636825310635137004">للحصول على علامات التبويب من أجهزتك الأخرى، شغِّل المزامنة.</translation>
+<translation id="3269956123044984603">‏للحصول على علامات التبويب من أجهزتك الأخرى، شغِّل "المزامنة التلقائية للبيانات" في إعدادات حساب Android.</translation>
+<translation id="5157964048453367290">‏ستظهر هنا علامات التبويب التي فتحتها في Brave من أجهزتك الأخرى.</translation>
+<translation id="4684427112815847243">مزامنة كل شيء</translation>
+<translation id="2709516037105925701">الملء التلقائي</translation>
+<translation id="8820817407110198400">الإشارات المرجعية</translation>
+<translation id="1644574205037202324">السجل</translation>
+<translation id="17513872634828108">علامات التبويب المفتوحة</translation>
+<translation id="1320169905922104972">‏بطاقات الائتمان والعناوين باستخدام Brave Software Pay</translation>
+<translation id="6337234675334993532">تشفير</translation>
+<translation id="6698801883190606802">إدارة البيانات المتزامنة</translation>
+<translation id="3598578758776312506">‏تشفير كلمات المرور باستخدام بيانات اعتماد Brave Software</translation>
+<translation id="7810580217418711046">‏تشفير البيانات المتزامنة باستخدام كلمة مرور Brave Software اعتبارًا من <ph name="TIME"/></translation>
+<translation id="8461694314515752532">تشفير البيانات المتزامنة باستخدام عبارة مرور المزامنة الخاصة بك</translation>
+<translation id="2996291259634659425">إنشاء عبارة المرور</translation>
+<translation id="5713644099811900409">‏حساب Brave Software‏</translation>
+<translation id="8997474919031554666">‏لا يتضمّن التشفير باستخدام عبارة المرور طرق الدفع والعناوين من Brave Software Pay. ولن يتمكّن أي شخص من الاطّلاع على بياناتك المشفرة إلا من يعرف عبارة مرورك. لا تُرسَل عبارة المرور إلى شركة Brave Software ولا تُخزّن لديها. في حال نسيان عبارة المرور أو الرغبة في تغيير هذا الإعداد، ستحتاج إلى إعادة ضبط المزامنة. <ph name="BEGIN_LINK"/>مزيد من المعلومات<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">عبارة المرور</translation>
+<translation id="7772032839648071052">تأكيد عبارة المرور</translation>
+<translation id="5304593522240415983">لا يمكن ترك هذا الحقل فارغًا</translation>
+<translation id="321773570071367578">إذا نسيت عبارة المرور أو رغبت في تغيير هذا الإعداد، يمكنك <ph name="BEGIN_LINK"/>إعادة تعيين المزامنة<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">عبارات المرور غير متطابقة</translation>
+<translation id="5149495116300586333">‏لا يتضمّن التشفير باستخدام عبارة المرور طرق الدفع والعناوين من Brave Software Pay.
+
+لتغيير هذا الإعداد، يُرجى <ph name="BEGIN_LINK"/>إعادة ضبط المزامنة<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">عبارة مرور غير صحيحة</translation>
+<translation id="5414836363063783498">جارٍ التحقق...</translation>
+<translation id="6846298663435243399">جارٍ التحميل…</translation>
+<translation id="5517095782334947753">تتوفر لديك الإشارات المرجعية، والسجل، وكلمات المرور، والإعدادات الأخرى من <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">جمع البيانات التابعة لي</translation>
+<translation id="688738109438487280">يمكنك إضافة البيانات الحالية إلى <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">الحفاظ على البيانات التابعة لي منفصلة</translation>
+<translation id="1145536944570833626">يمكنك حذف البيانات الحالية.</translation>
+<translation id="1993768208584545658">يريد <ph name="SITE"/> الاقتران</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>الحصول على مساعدة<ph name="END_LINK"/> أثناء البحث عن الأجهزة…</translation>
+<translation id="5817918615728894473">إقران</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>الحصول على مساعدة<ph name="END_LINK1"/> أو <ph name="BEGIN_LINK2"/>إعادة الفحص<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">لم يتم العثور على أي أجهزة متوافقة</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>تشغيل البلوتوث<ph name="END_LINK"/> للسماح بالإقران</translation>
+<translation id="998321811308652668">‏يتعذر على Brave تشغيل محوّل البلوتوث</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>الحصول على مساعدة<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">‏يحتاج Brave للوصول إلى المواقع للبحث عن الأجهزة. <ph name="BEGIN_LINK"/>تحديث الأذونات<ph name="END_LINK"/>.</translation>
+<translation id="852740676285943527">‏يحتاج Brave للوصول إلى الموقع للبحث عن الأجهزة. الوصول إلى الموقع <ph name="BEGIN_LINK"/>غير مفعّل لهذا الجهاز<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">‏يحتاج Brave للوصول إلى الموقع للبحث عن الأجهزة. <ph name="BEGIN_LINK1"/>تحديث الأذونات<ph name="END_LINK1"/>. الوصول إلى الموقع <ph name="BEGIN_LINK2"/>غير مفعّل لهذا الجهاز<ph name="END_LINK2"/> أيضًا.</translation>
+<translation id="1569387923882100876">جهاز متصل</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{مستوى قوة الإشارة: شريط واحد (#)}zero{مستوى قوة الإشارة: # شريط}two{مستوى قوة الإشارة: شريطان (#)}few{مستوى قوة الإشارة: # أشرطة}many{مستوى قوة الإشارة: # شريطًا}other{مستوى قوة الإشارة: # شريط}}</translation>
+<translation id="5230560987958996918">يريد <ph name="SITE"/> البحث عن أجهزة البلوتوث المجاورة. وتم العثور على الأجهزة التالية:</translation>
+<translation id="8368027906805972958">جهاز غير معروف أو غير متوافق (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">المزامنة لا تعمل</translation>
+<translation id="1810845389119482123">إعداد المزامنة الأولية لم يكتمل</translation>
+<translation id="3235722914093408050">‏فتح إعدادات Android وإعادة تفعيل مزامنة نظام Android لبدء مزامنة Brave</translation>
+<translation id="3367813778245106622">تسجيل الدخول مرة أخرى لبدء المزامنة</translation>
+<translation id="974555521953189084">إدخال عبارة المرور لبدء المزامنة</translation>
+<translation id="2997266899014181325">‏لبدء المزامنة، يُرجى تفعيل "مزامنة بيانات Brave".</translation>
+<translation id="8260126382462817229">محاولة تسجيل الدخول مرة أخرى</translation>
+<translation id="5919204609460789179">تحديث <ph name="PRODUCT_NAME"/> لبدء المزامنة</translation>
+<translation id="397583555483684758">توقفت المزامنة</translation>
+<translation id="1966710179511230534">يُرجى تحديث تفاصيل تسجيل الدخول.</translation>
+<translation id="7063006564040364415">تعذر الاتصال بخادم المزامنة.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> قديم.</translation>
+<translation id="4170011742729630528">الخدمة غير متاحة، أعد المحاولة لاحقًا.</translation>
+<translation id="7947953824732555851">قبول وتسجيل الدخول</translation>
+<translation id="8583805026567836021">محو بيانات الحساب</translation>
+<translation id="8310344678080805313">علامات التبويب القياسية</translation>
+<translation id="5748802427693696783">تم التبديل إلى علامات التبويب القياسية</translation>
+<translation id="7998918019931843664">إعادة فتح علامة التبويب المغلقة</translation>
+<translation id="8853345339104747198">علامة التبويب <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">إغلاق علامة التبويب <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">الخيارات المتاحة بالقرب من الجزء السفلي من الشاشة</translation>
+<translation id="4060598801229743805">الخيارات متاحة بالقرب من أعلى الشاشة</translation>
+<translation id="2810645512293415242">صفحة مبسَّطة لحفظ البيانات والاستمتاع بتحميل أسرع.</translation>
+<translation id="3985215325736559418">هل تريد تنزيل <ph name="FILE_NAME"/> مرة أخرى؟</translation>
+<translation id="2450083983707403292">هل ترغب في بدء تنزيل <ph name="FILE_NAME"/> مرة أخرى؟</translation>
+<translation id="7514365320538308">تنزيل</translation>
+<translation id="545042621069398927">جارٍ تسريع التنزيل.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{جارٍ تنزيل ملف واحد.}zero{جارٍ تنزيل # ملف}two{جارٍ تنزيل ملفين (#).}few{جارٍ تنزيل # ملفات.}many{جارٍ تنزيل # ملفًا.}other{جارٍ تنزيل # ملف.}}</translation>
+<translation id="543509235395288790">جارٍ تنزيل <ph name="COUNT"/> من الملفات (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">جارٍ تنزيل الملف (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{اكتملت عملية تنزيل واحدة.}zero{اكتملت # عملية تنزيل.}two{اكتملت عمليتا تنزيل (#).}few{اكتملت # عمليات تنزيل.}many{اكتملت # عملية تنزيل.}other{اكتملت # عملية تنزيل.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{تعذَّر إتمام عملية تنزيل واحدة.}zero{تعذَّر إتمام # عملية تنزيل.}two{تعذَّر إتمام عمليتي تنزيل (#).}few{تعذَّر إتمام # عمليات تنزيل.}many{تعذَّر إتمام # عملية تنزيل.}other{تعذَّر إتمام # عملية تنزيل.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{هناك عملية تنزيل واحدة مُعلَّقة.}zero{هناك # عملية تنزيل مُعلَّقة.}two{هناك عمليتا تنزيل (#) مُعلَّقتان.}few{هناك # عمليات تنزيل مُعلَّقة.}many{هناك # عملية تنزيل مُعلَّقة.}other{هناك # عملية تنزيل مُعلَّقة.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/></translation>
+<translation id="1987739130650180037">زر <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">أوشك التحديث على الانتهاء.</translation>
+<translation id="3960299545138990065">‏إعادة تشغيل Brave</translation>
+<translation id="3771001275138982843">تعذُّر تنزيل التحديث</translation>
+<translation id="3888648114124182147">‏جارٍ تنزيل تحديث Brave…</translation>
+<translation id="1705567146636171298">‏تحديث Brave‏</translation>
+<translation id="6195417478702700398">‏للحصول على أفضل تجربة للتصفّح، يُرجى الفتح لتحديث Brave.</translation>
+<translation id="3512968675351418494">‏للاطّلاع على الويب بلغتك، يمكنك الحصول على أحدث إصدار من Brave.</translation>
+<translation id="6427112570124116297">ترجمة موقع الويب</translation>
+<translation id="1379423114029199501">‏يمكنك إجراء التحديث للحصول على لغتك في أحدث إصدار من Brave.</translation>
+<translation id="5684874026226664614">عفوًا. تعذرت ترجمة هذه الصفحة.</translation>
+<translation id="6831043979455480757">ترجمة</translation>
+<translation id="1285320974508926690">عدم ترجمة هذا الموقع مطلقًا</translation>
+<translation id="773466115871691567">ترجمة الصفحات باللغة <ph name="SOURCE_LANGUAGE"/> دائمًا</translation>
+<translation id="1068672505746868501">عدم ترجمة الصفحات باللغة <ph name="SOURCE_LANGUAGE"/> مُطلقًا</translation>
+<translation id="124116460088058876">مزيد من اللغات</translation>
+<translation id="290376772003165898">أليست الصفحة باللغة <ph name="LANGUAGE"/>؟</translation>
+<translation id="4432792777822557199">ستتم ترجمة الصفحات باللغة <ph name="SOURCE_LANGUAGE"/> إلى اللغة <ph name="TARGET_LANGUAGE"/> من الآن فصاعدًا</translation>
+<translation id="8339163506404995330">لن تتم ترجمة الصفحات باللغة <ph name="LANGUAGE"/></translation>
+<translation id="5447765697759493033">لن تتم ترجمة هذا الموقع</translation>
+<translation id="4880127995492972015">ترجمة…</translation>
+<translation id="641643625718530986">طباعة…</translation>
+<translation id="8909135823018751308">مشاركة…</translation>
+<translation id="4996978546172906250">المشاركة عن طريق</translation>
+<translation id="6333140779060797560">المشاركة عن طريق <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">حدثت مشكلة أثناء طباعة الصفحة. يُرجى إعادة المحاولة.</translation>
+<translation id="3254409185687681395">وضع إشارة على هذه الصفحة</translation>
+<translation id="497421865427891073">انتقال للأمام</translation>
+<translation id="813082847718468539">عرض معلومات الموقع</translation>
+<translation id="2532336938189706096">عرض الويب</translation>
+<translation id="6005538289190791541">كلمة المرور المُقترحَة</translation>
+<translation id="4634124774493850572">استخدام كلمة المرور</translation>
+<translation id="8285489906452138776">‏يحتاج Brave إلى إذن لاستخدام الكاميرا لموقع الويب هذا.</translation>
+<translation id="320189792589364011">‏يحتاج Brave إلى إذن لاستخدام الميكروفون لموقع الويب هذا.</translation>
+<translation id="7988136689212463100">‏يحتاج Brave إلى إذن لاستخدام الكاميرا والميكروفون لموقع الويب هذا.</translation>
+<translation id="4931190655840828017">‏يحتاج Brave إلى الوصول إلى موقعك الجغرافي لمشاركة موقعك الجغرافي مع موقع الويب هذا.</translation>
+<translation id="3088191967551450609">‏يحتاج Brave للوصول إلى مساحة التخزين لتنزيل الملفات.</translation>
+<translation id="8942627711005830162">فتح في نافذة أخرى</translation>
+<translation id="4195643157523330669">الفتح في علامة تبويب جديدة</translation>
+<translation id="1100066534610197918">فتح في علامة تبويب جديدة في مجموعة</translation>
+<translation id="4860895144060829044">اتصال</translation>
+<translation id="6896758677409633944">نسخ</translation>
+<translation id="8393700583063109961">إرسال رسالة</translation>
+<translation id="3557336313807607643">إضافة إلى جهات الاتصال</translation>
+<translation id="4269820728363426813">نسخ عنوان الرابط</translation>
+<translation id="1206892813135768548">نسخ نص الرابط</translation>
+<translation id="1204037785786432551">تنزيل الرابط</translation>
+<translation id="6864459304226931083">تنزيل الصورة</translation>
+<translation id="8209050860603202033">فتح الصورة</translation>
+<translation id="8073388330009372546">فتح الصورة بعلامة تبويب جديدة</translation>
+<translation id="6649642165559792194">معاينة صورة <ph name="BEGIN_NEW"/>ميزة جديدة<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">تحميل الصورة</translation>
+<translation id="3845332215609790146">‏البحث باستخدام "عدسة Brave Software" <ph name="BEGIN_NEW"/>جديد<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">البحث في <ph name="SEARCH_ENGINE"/> عن هذه الصورة</translation>
+<translation id="3384347053049321195">مشاركة صورة</translation>
+<translation id="5833984609253377421">مشاركة الرابط</translation>
+<translation id="6475951671322991020">تنزيل الفيديو</translation>
+<translation id="2317945146070194624">‏فتح بعلامة تبويب Brave جديدة</translation>
+<translation id="7975379999046275268">معاينة صفحة <ph name="BEGIN_NEW"/>ميزة جديدة<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">يتم الآن تحديث الصفحة</translation>
+<translation id="36525718899759834">‏الحصول على التطبيق من متجر Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">داكن</translation>
+<translation id="1807246157184219062">فاتح</translation>
+<translation id="4056223980640387499">بني داكن</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">أحادي المسافة</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">حدد علامة تبويب لإرسالها باستخدام الشعاع</translation>
+<translation id="8719023831149562936">تعذر إرسال علامة التبويب الحالية باستخدام الشعاع</translation>
+<translation id="2139186145475833000">الإضافة إلى الشاشة الرئيسية</translation>
+<translation id="4616150815774728855">فتح <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">تعذر فتح التطبيق</translation>
+<translation id="5129038482087801250">تثبيت تطبيق الويب</translation>
+<translation id="3789841737615482174">تثبيت</translation>
+<translation id="4665282149850138822">تمت إضافة <ph name="NAME"/> إلى صفحتك الرئيسية</translation>
+<translation id="7333031090786104871">لا تزال عملية إضافة موقع الويب السابق جارية</translation>
+<translation id="1036727731225946849">جارٍ إضافة <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">تمت الإضافة إلى الشاشة الرئيسية</translation>
+<translation id="2146738493024040262">فتح تطبيق فوري</translation>
+<translation id="7016516562562142042">تم منح الإذن لمحرّك البحث الحالي</translation>
+<translation id="6177111841848151710">تم حظره لمحرك البحث الحالي</translation>
+<translation id="145097072038377568">‏تم إيقافه في إعدادات Android.</translation>
+<translation id="8007176423574883786">تم إيقافه لهذا الجهاز</translation>
+<translation id="164269334534774161">أنت تعرض نسخة بلا اتصال لهذه الصفحة من <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">تم إنشاء هذه الصفحة المتوفّرة بلا اتصال بالإنترنت في <ph name="CREATION_TIME"/>، وقد تختلف عن النسخة المتوفِّرة على الإنترنت.</translation>
+<translation id="8840953339110955557">قد تختلف هذه الصفحة عن الإصدار الوارد على الإنترنت.</translation>
+<translation id="6405300764336705484">‏هذا المحتوى من <ph name="DOMAIN_NAME"/>، وتم عرضه من قبل Brave Software.</translation>
+<translation id="1006017844123154345">فتح على الإنترنت</translation>
+<translation id="3326636747541519688">‏نسخة خفيفة تقدِّمها Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>تحميل الصفحة الأصلية<ph name="END_LINK"/> من <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">إذا تكرّر هذا الخطأ، ننصحك بالاطّلاع على هذه <ph name="BEGIN_LINK"/>الاقتراحات<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">المحتويات مخفية</translation>
+<translation id="3810973564298564668">إدارة محرّكات البحث</translation>
+<translation id="5199929503336119739">الملف الشخصي للعمل</translation>
+<translation id="528192093759286357">اسحب من الجزء العلوي والمس زر الرجوع للخروج من وضع ملء الشاشة.</translation>
+<translation id="2836148919159985482">المس زر الرجوع للخروج من وضع ملء الشاشة.</translation>
+<translation id="3967822245660637423">اكتمل التنزيل</translation>
+<translation id="2434158240863470628">اكتمل التنزيل <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">تعذّر التنزيل</translation>
+<translation id="1384959399684842514">تم إيقاف التنزيل مؤقتًا</translation>
+<translation id="1671236975893690980">التنزيل معلّق...</translation>
+<translation id="5561549206367097665">في انتظار الشبكة...</translation>
+<translation id="5864419784173784555">في انتظار تنزيل آخر…</translation>
+<translation id="6461962085415701688">يتعذر فتح الملف</translation>
+<translation id="1178581264944972037">الإيقاف مؤقتًا</translation>
+<translation id="8200772114523450471">استئناف</translation>
+<translation id="1409879593029778104">مُنع تنزيل الملف <ph name="FILE_NAME"/> لأنه موجود بالفعل.</translation>
+<translation id="3387650086002190359">تعذّر تنزيل الملف <ph name="FILE_NAME"/> بسبب أخطاء في نظام الملف.</translation>
+<translation id="6482749332252372425">تعذّر تنزيل الملف <ph name="FILE_NAME"/> لعدم توفر مساحة لتخزين.</translation>
+<translation id="7619072057915878432">تعذّر تنزيل الملف <ph name="FILE_NAME"/> بسبب إخفاقات الشبكة.</translation>
+<translation id="1477626028522505441">تعذّر تنزيل الملف <ph name="FILE_NAME"/> بسبب مشاكل بالخادم.</translation>
+<translation id="3692944402865947621">تعذّر تنزيل <ph name="FILE_NAME"/> نظرًا لعدم إمكانية الوصول إلى موقع مساحة التخزين.</translation>
+<translation id="604996488070107836">تعذّر تنزيل الملف <ph name="FILE_NAME"/> بسبب خطأ غير معلوم.</translation>
+<translation id="6738867403308150051">جارٍ التنزيل…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> كيلوبايت</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> ميغابايت</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> غيغابايت</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">تم التنزيل بحجم <ph name="KBS"/> كيلوبايت</translation>
+<translation id="6416782512398055893">تم التنزيل بحجم <ph name="MBS"/> ميغابايت</translation>
+<translation id="6538442820324228105">تم التنزيل بحجم <ph name="GBS"/> غيغابايت</translation>
+<translation id="9204836675896933765">ملف واحد متبقٍ</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> من الملفات المتبقية</translation>
+<translation id="757855969265046257">{FILES,plural, =1{تم تنزيل ملف <ph name="FILES_DOWNLOADED_ONE"/>}zero{تم تنزيل <ph name="FILES_DOWNLOADED_MANY"/> ملفات}two{تم تنزيل ملفين (<ph name="FILES_DOWNLOADED_MANY"/>)}few{تم تنزيل <ph name="FILES_DOWNLOADED_MANY"/> ملفات}many{تم تنزيل <ph name="FILES_DOWNLOADED_MANY"/> ملفًا}other{تم تنزيل <ph name="FILES_DOWNLOADED_MANY"/> ملف}}</translation>
+<translation id="8037750541064988519">عدد الأيام المتبقية: <ph name="DAYS"/></translation>
+<translation id="8190358571722158785">يتبقى يوم واحد</translation>
+<translation id="60923314841986378">عدد الساعات المتبقية: <ph name="HOURS"/></translation>
+<translation id="510275257476243843">يتبقى ساعة واحدة</translation>
+<translation id="970715775301869095">عدد الدقائق المتبقية: <ph name="MINUTES"/></translation>
+<translation id="3236059992281584593">يتبقى دقيقة واحدة</translation>
+<translation id="2777555524387840389">عدد الثواني المتبقية: <ph name="SECONDS"/></translation>
+<translation id="2781151931089541271">يتبقى ثانية واحدة</translation>
+<translation id="3303414029551471755">هل ترغب في الاستمرار في تنزيل المحتوى؟</translation>
+<translation id="8617240290563765734">‏هل تريد فتح عنوان URL المقترح والمحدد في المحتوى الذي تم تنزيله؟</translation>
+<translation id="1373696734384179344">لا توجد ذاكرة كافية لتنزيل المحتوى المحدد.</translation>
+<translation id="5271967389191913893">لا يمكن للجهاز فتح المحتوى لتنزيله</translation>
+<translation id="883806473910249246">حدث خطأ أثناء تنزيل المحتوى.</translation>
+<translation id="5626134646977739690">الاسم:</translation>
+<translation id="7963646190083259054">المورّد:</translation>
+<translation id="3414952576877147120">الحجم:</translation>
+<translation id="7375125077091615385">النوع:</translation>
+<translation id="5765780083710877561">الوصف:</translation>
+<translation id="4881695831933465202">فتح</translation>
+<translation id="3542235761944717775">تتوفر مساحة <ph name="KILOBYTES"/> كيلوبايت</translation>
+<translation id="8051695050440594747">هناك <ph name="MEGABYTES"/> ميغابايت متوفرة</translation>
+<translation id="5424588387303617268">يتوفر <ph name="GIGABYTES"/> غيغابايت</translation>
+<translation id="5793665092639000975">يتم استخدام <ph name="SPACE_USED"/> من أصل <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">الكل</translation>
+<translation id="4988526792673242964">الصفحات</translation>
+<translation id="3810838688059735925">الفيديوهات</translation>
+<translation id="3616113530831147358">المقاطع الصوتية</translation>
+<translation id="9219103736887031265">الصور</translation>
+<translation id="8250920743982581267">المستندات</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{ملف واحد (#)}zero{# ملف}two{ملفان (#)}few{# ملفات}many{# ملفًا}other{# ملف}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{صورة واحدة (#)}zero{# صورة}two{صورتان (#)}few{# صور}many{# صورةً}other{# صورة}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{فيديو واحد (#)}zero{# فيديو}two{فيديوهان (#)}few{# فيديوهات}many{# فيديو}other{# فيديو}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{ملف صوتي واحد (#)}zero{# ملف صوتي}two{ملفان صوتيان (#)}few{# ملفات صوتية}many{# ملفًا صوتيًا}other{# ملف صوتي}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{صفحة واحدة (#)}zero{# صفحة}two{صفحتان (#)}few{# صفحات}many{# صفحةً}other{# صفحة}}</translation>
+<translation id="5456381639095306749">تنزيل الصفحة</translation>
+<translation id="2394602618534698961">تظهر الملفات التي نزَّلتها هنا.</translation>
+<translation id="7810647596859435254">فتح باستخدام...</translation>
+<translation id="5655963694829536461">البحث في التنزيلات</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">ملفاتي</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">تظهر المقالات هنا، ويمكنك الاطّلاع عليها حتى عندما لا يكون الجهاز متّصلًا بالإنترنت.</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{ساعة واحدة (#)}zero{# ساعة}two{ساعتان (#)}few{# ساعات}many{# ساعةً}other{# ساعة}}</translation>
+<translation id="5853623416121554550">متوقف مؤقتًا</translation>
+<translation id="8965591936373831584">في الانتظار</translation>
+<translation id="2779651927720337254">تعذَّر التنزيل</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">للتو</translation>
+<translation id="4000212216660919741">الصفحة الرئيسية في وضع عدم الاتصال بالإنترنت</translation>
+<translation id="9133397713400217035">الاطّلاع في وضع عدم الاتصال بالإنترنت</translation>
+<translation id="968900484120156207">يتم عرض الصفحات التي تزورها هنا.</translation>
+<translation id="7882131421121961860">لم يتم العثور على أي سجلّ</translation>
+<translation id="3549657413697417275">البحث في السجل</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">الشهر</translation>
+<translation id="605721222689873409">العام</translation>
+<translation id="724102042129299115">‏أول تجربة تشغيل لمتصفح Brave</translation>
+<translation id="2700285883409956633">باستخدام هذا التطبيق، أنت توافق على <ph name="BEGIN_LINK1"/>بنود الخدمة<ph name="END_LINK1"/> و<ph name="BEGIN_LINK2"/>إشعار الخصوصية<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">‏باستخدامك لهذا التطبيق، أنت توافق على <ph name="BEGIN_LINK1"/>بنود الخدمة في Brave<ph name="END_LINK1"/> و<ph name="BEGIN_LINK2"/>إشعار الخصوصية<ph name="END_LINK2"/> و<ph name="BEGIN_LINK3"/>إشعار الخصوصية لحسابات Brave Software المُدارة من خلال Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">‏سيتم فتح <ph name="APP_NAME"/> في Brave. بالمتابعة، أنت توافق على <ph name="BEGIN_LINK1"/>بنود الخدمة<ph name="END_LINK1"/> و<ph name="BEGIN_LINK2"/>إشعار الخصوصية<ph name="END_LINK2"/> في Brave.</translation>
+<translation id="5071615083211946659">‏سيتم فتح <ph name="APP_NAME"/> في Brave. بالمتابعة، أنت توافق على <ph name="BEGIN_LINK1"/>بنود الخدمة<ph name="END_LINK1"/> و<ph name="BEGIN_LINK2"/>إشعار الخصوصية<ph name="END_LINK2"/> في Brave، و<ph name="BEGIN_LINK3"/>إشعار الخصوصية لحسابات Brave Software المُدارة من خلال Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">‏يمكنك المساعدة في تحسين Brave عن طريق إرسال إحصاءات الاستخدام وتقارير الأعطال إلى Brave Software.</translation>
+<translation id="3518985090088779359">القبول والمتابعة</translation>
+<translation id="7207456302801184289">‏مرحبًا بك في Brave‏</translation>
+<translation id="704822250101715322">‏انتظار انتهاء تحديث خدمات Brave Software Play</translation>
+<translation id="1231733316453485619">هل تريد تفعيل المزامنة؟</translation>
+<translation id="5132942445612118989">مزامنة كلمات المرور والسجلّ والمزيد على جميع الأجهزة</translation>
+<translation id="5736731321935944068">‏قد تستخدم Brave Software سجلّك لتخصيص البحث والإعلانات وخدمات Brave Software الأخرى.</translation>
+<translation id="4013614219085422040">‏قد تستخدم Brave Software سجلّك لتخصيص البحث وخدمات Brave Software الأخرى.</translation>
+<translation id="5581519193887989363">يمكنك دائمًا اختيار ما تريد مزامنته في <ph name="BEGIN_LINK1"/>الإعدادات<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">نعم، موافق</translation>
+<translation id="2410754283952462441">اختيار حساب</translation>
+<translation id="2227444325776770048">المتابعة باسم <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">ليس <ph name="EMAIL"/>؟</translation>
+<translation id="8109613176066109935">للحصول على الإشارات المرجعية على جميع أجهزتك، يُرجى تفعيل المزامنة.</translation>
+<translation id="2818669890320396765">للحصول على الإشارات المرجعية على جميع أجهزتك، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
+<translation id="6003646045106347985">‏للحصول على محتوى مُخصَّص اقترحته Brave Software، يُرجى تفعيل المزامنة.</translation>
+<translation id="8494430740943879273">‏للحصول على محتوى مُخصَّص اقترحته Brave Software، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
+<translation id="5862731021271217234">للحصول على علامات التبويب من أجهزتك الأخرى، يُرجى تفعيل المزامنة.</translation>
+<translation id="3568688522516854065">للحصول على علامات التبويب من أجهزتك الأخرى، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
+<translation id="1208340532756947324">للمزامنة والتخصيص على جميع الأجهزة، يمكنك تفعيل المزامنة.</translation>
+<translation id="4472118726404937099">للمزامنة والتخصيص على جميع الأجهزة، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
+<translation id="2426805022920575512">اختيار حساب آخر</translation>
+<translation id="6790428901817661496">التشغيل</translation>
+<translation id="1272079795634619415">إيقاف</translation>
+<translation id="2874939134665556319">المقطع الصوتي السابق</translation>
+<translation id="4046123991198612571">المقطع الصوتي التالي</translation>
+<translation id="3859306556332390985">الانتقال للأمام</translation>
+<translation id="8441146129660941386">الرجوع للوراء</translation>
+<translation id="6706288973712894588">‏أنت غير متصل بالإنترنت حاليًا.\n<ph name="BEGIN_LINK"/>تعرّف على الخلاصة بلا إنترنت.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">علامات التبويب الأخيرة</translation>
+<translation id="8497726226069778601">لا يوجد شيء هنا... حتى الآن</translation>
+<translation id="5423934151118863508">ستظهر صفحاتك الأكثر زيارة هنا</translation>
+<translation id="6127379762771434464">أُزيلَ عنصر</translation>
+<translation id="4605958867780575332">تمت إزالة العنصر: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">‏رسم الشعار المبتكر من Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">أجهزة أخرى</translation>
+<translation id="4738836084190194332">آخر مزامنة: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{قبل دقيقة واحدة (#)}zero{قبل # دقيقة}two{قبل دقيقتين (#)}few{قبل # دقائق}many{قبل # دقيقة}other{قبل # دقيقة}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{قبل ساعة واحدة (#)}zero{قبل # ساعة}two{قبل ساعتين (#)}few{قبل # ساعات}many{قبل # ساعة}other{قبل # ساعة}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{قبل يوم واحد (#)}zero{قبل # يوم}two{قبل يومين (#)}few{قبل # أيام}many{قبل # يومًا}other{قبل # يوم}}</translation>
+<translation id="2762000892062317888">الآن</translation>
+<translation id="1407135791313364759">فتح الكل</translation>
+<translation id="1209206284964581585">إخفاء الآن</translation>
+<translation id="129553762522093515">المغلقة حديثًا</translation>
+<translation id="8413126021676339697">عرض السجلّ بكامله</translation>
+<translation id="7876243839304621966">إزالة الكل</translation>
+<translation id="8487700953926739672">التوفر بلا إنترنت</translation>
+<translation id="5224771365102442243">يتضمن فيديو</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>مزيد من المعلومات<ph name="END_LINK"/> حول المحتوى المقترح</translation>
+<translation id="7542481630195938534">يتعذر الحصول على الاقتراحات</translation>
+<translation id="5013696553129441713">ما من اقتراحات جديدة</translation>
+<translation id="1736419249208073774">استكشاف</translation>
+<translation id="7444811645081526538">مزيد من الفئات</translation>
+<translation id="6709133671862442373">الأخبار</translation>
+<translation id="1264974993859112054">رياضة</translation>
+<translation id="9139318394846604261">التسوّق</translation>
+<translation id="3912508018559818924">جارٍ العثور على الأفضل من الويب...</translation>
+<translation id="526421993248218238">يتعذَّر تحميل هذه الصفحة</translation>
+<translation id="614940544461990577">يمكنك محاولة:</translation>
+<translation id="3288003805934695103">إعادة تحميل الصفحة</translation>
+<translation id="2353636109065292463">التحقُّق من اتصال الإنترنت</translation>
+<translation id="2858138569776157458">أهم المواقع</translation>
+<translation id="8364299278605033898">عرض مواقع الويب الشائعة</translation>
+<translation id="1171770572613082465">عرض مواقع الويب الشائعة من خلال النقر على الزر "أهم المواقع"</translation>
+<translation id="5233638681132016545">علامة تبويب جديدة</translation>
+<translation id="4521874409998847950">‏من <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>تعرضه Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">يتوفر إصدار أحدث</translation>
+<translation id="4058091506841967397">‏يتعذَّر تحديث Brave</translation>
+<translation id="6316139424528454185">‏إصدار Android غير متوافق</translation>
+<translation id="6989267951144302301">تعذّر التنزيل</translation>
+<translation id="624789221780392884">التحديث جاهز</translation>
+<translation id="1549000191223877751">الانتقال إلى نافذة أخرى</translation>
+<translation id="7481312909269577407">إلى الأمام</translation>
+<translation id="4084682180776658562">إشارة</translation>
+<translation id="6437478888915024427">معلومات الصفحة</translation>
+<translation id="7180611975245234373">إعادة التحميل</translation>
+<translation id="4913169188695071480">إيقاف التحديث</translation>
+<translation id="1829244130665387512">البحث في الصفحة</translation>
+<translation id="6593061639179217415">العرض بإصدار سطح المكتب</translation>
+<translation id="9063523880881406963">إيقاف طلب موقع الويب لسطح المكتب</translation>
+<translation id="2038563949887743358">تشغيل طلب موقع الويب لسطح المكتب</translation>
+<translation id="2433507940547922241">المظهر</translation>
+<translation id="983192555821071799">إغلاق جميع علامات التبويب</translation>
+<translation id="1310482092992808703">دمج علامات التبويب</translation>
+<translation id="7725024127233776428">يتم عرض الصفحات التي يتم وضع إشارة عليها هنا.</translation>
+<translation id="4404568932422911380">ليست هناك إشارات مرجعية</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{إشارة مرجعية <ph name="BOOKMARKS_COUNT_ONE"/>}zero{<ph name="BOOKMARKS_COUNT_MANY"/> إشارات مرجعية}two{إشارتان مرجعيتان (<ph name="BOOKMARKS_COUNT_MANY"/>)}few{<ph name="BOOKMARKS_COUNT_MANY"/> إشارات مرجعية}many{<ph name="BOOKMARKS_COUNT_MANY"/> إشارةً مرجعيةً}other{<ph name="BOOKMARKS_COUNT_MANY"/> إشارة مرجعية}}</translation>
+<translation id="3739899004075612870">تمت إضافة إشارة مرجعية في <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">تمت إضافتها إلى الإشارات المرجعية.</translation>
+<translation id="4452548195519783679">أُضيفَت إشارة مرجعية إلى <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">تعذّرت إضافة الإشارة المرجعية.</translation>
+<translation id="2842985007712546952">المجلد الرئيسي</translation>
+<translation id="9065203028668620118">تعديل</translation>
+<translation id="4405224443901389797">نقل إلى...</translation>
+<translation id="5170568018924773124">العرض في المجلد</translation>
+<translation id="8035133914807600019">مجلد جديد...</translation>
+<translation id="4532845899244822526">اختيار مجلد</translation>
+<translation id="6627583120233659107">تعديل مجلد</translation>
+<translation id="1197267115302279827">نقل الإشارات المرجعية</translation>
+<translation id="6963766334940102469">حذف الإشارات المرجعية</translation>
+<translation id="4351244548802238354">إغلاق مربع الحوار</translation>
+<translation id="451872707440238414">البحث في الإشارات المرجعية</translation>
+<translation id="8901170036886848654">ما مِن إشارات مرجعية مطابقة</translation>
+<translation id="6404511346730675251">تعديل الإشارة المرجعية</translation>
+<translation id="3894427358181296146">إضافة مجلد</translation>
+<translation id="5327248766486351172">الاسم</translation>
+<translation id="7400418766976504921">‏عنوان URL</translation>
+<translation id="3527085408025491307">المجلد</translation>
+<translation id="5161254044473106830">العنوان مطلوب</translation>
+<translation id="2996809686854298943">‏عنوان URL المطلوب</translation>
+<translation id="2536728043171574184">عرض نسخة بلا اتصال من هذه الصفحة</translation>
+<translation id="4698034686595694889">العرض بلا اتصال بالإنترنت في تطبيق <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ومواقع أخرى</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{‏سيحمِّل Brave الصفحة عندما تصبح جاهزة}zero{‏لن يحمِّل Brave أي صفحات عندما تصبح جاهزة}two{‏سيحمِّل Brave الصفحتين عندما تصبح جاهزتين}few{‏سيحمِّل Brave الصفحات عندما تصبح جاهزة}many{‏سيحمِّل Brave الصفحات عندما تصبح جاهزة}other{‏سيحمِّل Brave الصفحات عندما تصبح جاهزة}}</translation>
+<translation id="6811034713472274749">الصفحة جاهزة للعرض</translation>
+<translation id="4561979708150884304">لا يتوفّر اتصال بالإنترنت</translation>
+<translation id="8274165955039650276">الاطِّلاع على التنزيلات</translation>
+<translation id="2082238445998314030">النتيجة <ph name="RESULT_NUMBER"/> من <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">لا نتائج</translation>
+<translation id="981121421437150478">بلا اتصال</translation>
+<translation id="3298243779924642547">نسخة خفيفة</translation>
+<translation id="393697183122708255">لا يتوفر بحث صوتي تم تمكينه</translation>
+<translation id="7191430249889272776">تم فتح علامة التبويب في الخلفية.</translation>
+<translation id="8445059357334030806">‏فتح في Brave</translation>
+<translation id="4720023427747327413">الفتح في <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">فتح في المتصفح</translation>
+<translation id="1113597929977215864">إظهار العرض المبسَّط</translation>
+<translation id="1513352483775369820">الإشارات المرجعية وسجلّ الويب</translation>
+<translation id="4939482511480190003">‏المساعدة في تحسين Brave. <ph name="BEGIN_LINK"/>المشاركة في الاستطلاع<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">الرجوع</translation>
+<translation id="5596627076506792578">خيارات إضافية</translation>
+<translation id="3522247891732774234">التحديث متاح. مزيد من الخيارات</translation>
+<translation id="6773423637732432200">‏يتعذَّر تحديث Brave. يُرجى الاطِّلاع على مزيد من الخيارات</translation>
+<translation id="3328801116991980348">معلومات موقع الويب</translation>
+<translation id="5391532827096253100">إن اتصالك بهذا الموقع الإلكتروني غير آمن. معلومات موقع الويب</translation>
+<translation id="6206551242102657620">يُعدُّ اتصالك آمنًا. معلومات موقع الويب</translation>
+<translation id="6963642900430330478">تُعدُّ هذه الصفحة خطيرة. معلومات موقع الويب</translation>
+<translation id="9070377983101773829">بدء البحث الصوتي</translation>
+<translation id="8676374126336081632">محو الإرسال</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> علامة تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}zero{<ph name="OPEN_TABS_MANY"/> علامات تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}two{علامتا تبويب مفتوحتان<ph name="OPEN_TABS_MANY"/>، يُرجى النقر لتبديل علامات التبويب}few{<ph name="OPEN_TABS_MANY"/> علامات تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}many{<ph name="OPEN_TABS_MANY"/> علامة تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}other{<ph name="OPEN_TABS_MANY"/> علامة تبويب مفتوحة، يُرجى النقر لتبديل علامات التبويب}}</translation>
+<translation id="2369533728426058518">علامات التبويب المفتوحة</translation>
+<translation id="7071521146534760487">إدارة الحساب</translation>
+<translation id="932327136139879170">الصفحة الرئيسية</translation>
+<translation id="2707726405694321444">تحديث الصفحة</translation>
+<translation id="2891154217021530873">إيقاف تحميل الصفحة</translation>
+<translation id="6710213216561001401">السابق</translation>
+<translation id="6659594942844771486">علامة تبويب</translation>
+<translation id="1933845786846280168">علامة تبويب محددة</translation>
+<translation id="2268044343513325586">تحسين</translation>
+<translation id="7846076177841592234">إلغاء التحديد</translation>
+<translation id="7087918508125750058">تم تحديد <ph name="ITEM_COUNT"/> عنصر، ويمكنك الاطّلاع على الخيارات في الجزء العلوي من الشاشة.</translation>
+<translation id="7250468141469952378">تم اختيار <ph name="ITEM_COUNT"/> عنصراً</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{مشاركة عنصر واحد محدد}zero{مشاركة # عنصر محدد}two{مشاركة عنصرين (#) محددين}few{مشاركة # عناصر محددة}many{مشاركة # عنصرًا محددًا}other{مشاركة # عنصر محدد}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{إزالة عنصر واحد محدد}zero{إزالة # عنصر محدد}two{إزالة عنصرين (#) محددين}few{إزالة # عناصر محددة}many{إزالة # عنصرًا محددًا}other{إزالة # عنصر محدد}}</translation>
+<translation id="1283039547216852943">النقر للتوسيع</translation>
+<translation id="5962718611393537961">النقر للتصغير</translation>
+<translation id="8076492880354921740">علامات التبويب</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{تم تحديد عنصر واحد}zero{تم تحديد # عنصر}two{تم تحديد عنصرين (#)}few{تم تحديد # عناصر}many{تم تحديد # عنصرًا}other{تم تحديد # عنصر}}</translation>
+<translation id="6818926723028410516">اختيار عناصر</translation>
+<translation id="4797039098279997504">المس  للعودة إلى <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">انقر للانتقال إلى موقع الويب</translation>
+<translation id="429312253194641664">تشغيل موقع ويب للوسائط</translation>
+<translation id="4958708863221495346">يشارك <ph name="URL_OF_THE_CURRENT_TAB"/> شاشتك</translation>
+<translation id="8833831881926404480">يشارك موقع ويب شاشتك</translation>
+<translation id="9086455579313502267">تعذر الدخول إلى الشبكة</translation>
+<translation id="938850635132480979">الخطأ: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">الفتح في <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">فتح في تطبيق الخرائط</translation>
+<translation id="7698359219371678927">إنشاء بريد إلكتروني في <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">إنشاء بريد إلكتروني</translation>
+<translation id="5665379678064389456">إنشاء حدث في <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">إنشاء حدث</translation>
+<translation id="2111511281910874386">الانتقال إلى الصفحة</translation>
+<translation id="3988466920954086464">الاطلاع على نتائج البحث الفورية في هذه اللوحة</translation>
+<translation id="2744248271121720757">النقر على الكلمة للبحث عنها فورًا أو الاطلاع على الإجراءات ذات الصلة</translation>
+<translation id="9155898266292537608">يمكنك أيضًا البحث بنقرة سريعة على كلمة</translation>
+<translation id="3232754137068452469">تطبيق الويب</translation>
+<translation id="1430915738399379752">طباعة</translation>
+<translation id="3775705724665058594">إرسال إلى أجهزتك</translation>
+<translation id="6364438453358674297">هل تريد إزالة اقتراح من السجل؟</translation>
+<translation id="213279576345780926">تم إغلاق <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> من علامات التبويب المغلقة</translation>
+<translation id="3211426585530211793">تم حذف العنصر <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">تم حذف <ph name="NUMBER_OF_BOOKMARKS"/> من الإشارات المرجعية</translation>
+<translation id="3819178904835489326">تم إلغاء <ph name="NUMBER_OF_DOWNLOADS"/> من التنزيلات</translation>
+<translation id="1248710015876067820">‏عدد نسخ Brave غير متوافق.</translation>
+<translation id="4259722352634471385">التنقل محظور: <ph name="URL"/></translation>
+<translation id="8959122750345127698">التنقل غير قابل للوصول: <ph name="URL"/></translation>
+<translation id="5210365745912300556">إغلاق علامة التبويب</translation>
+<translation id="7772375229873196092">إغلاق <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">سجلّ التنقُّل</translation>
+<translation id="9169507124922466868">سجلّ التنقل مفتوح جزئيًا</translation>
+<translation id="1327257854815634930">يتم فتح سجلّ التنقُّل.</translation>
+<translation id="8788265440806329501">يتم إغلاق سجلّ التنقُّل.</translation>
+<translation id="7482656565088326534">علامة تبويب المعاينة</translation>
+<translation id="8427875596167638501">علامة تبويب المعاينة مفتوحة جزئيًا</translation>
+<translation id="9102803872260866941">علامة تبويب المعاينة مفتوحة</translation>
+<translation id="2942036813789421260">علامة تبويب المعاينة مغلقة</translation>
+<translation id="6355102470683871794">‏مساحة تخزين <ph name="APP_NAME"/> Brave Software</translation>
+<translation id="3822502789641063741">هل تريد محو مساحة تخزين المواقع؟</translation>
+<translation id="9205995714227143200">‏مساحة تخزين الموقع التي لا يعتقد Brave أنها مهمة (مثل المواقع التي لا تتضمَّن إعدادات محفوظة أو تلك التي لا تزورها مرارًا)</translation>
+<translation id="3997476611815694295">مساحة تخزين غير مهمة</translation>
+<translation id="8493948351860045254">تفريغ بعض المساحة</translation>
+<translation id="2324920234469020158">‏سيؤدي هذا إلى مسح ملفات تعريف الارتباط وذاكرة التخزين المؤقت والبيانات الأخرى للمواقع التي لا يعتقد Brave أنها مهمة.</translation>
+<translation id="5447201525962359567">مساحة التخزين في الموقع كاملة، بما في ذلك ملفات تعريف الارتباط وغيرها من البيانات المُخزَّنَة محليًا</translation>
+<translation id="1376578503827013741">جارٍ الحوسبة...</translation>
+<translation id="583281660410589416">غير معروف</translation>
+<translation id="2323763861024343754">مساحة تخزين الموقع</translation>
+<translation id="3587672679800759167">‏إجمالي البيانات المُستخدَمة من قِبل Brave، بما في ذلك الحسابات والإشارات المرجعية والإعدادات المحفوظة</translation>
+<translation id="6545017243486555795">مسح جميع البيانات</translation>
+<translation id="4095146165863963773">هل ترغب في حذف بيانات التطبيق؟</translation>
+<translation id="53119194224775367">‏سيتم حذف جميع بيانات تطبيق Brave نهائيًا. ويشمل ذلك جميع الملفات والإعدادات والحسابات وقواعد البيانات وما إلى ذلك.</translation>
+<translation id="5307446750509046227">محو مساحة تخزين المواقع</translation>
+<translation id="300526633675317032">سيؤدي هذا إلى محو مساحة التخزين البالغة <ph name="SIZE_IN_KB"/> بأكملها من مساحة تخزين مواقع الويب.</translation>
+<translation id="8068648041423924542">يتعذر تحديد الشهادة.</translation>
+<translation id="2315043854645842844">لا يدعم نظام التشغيل تحديد الشهادة من جانب العميل.</translation>
+<translation id="5011311129201317034">يريد <ph name="SITE"/> الاتصال</translation>
+<translation id="5308380583665731573">اتصال</translation>
+<translation id="868929229000858085">البحث في جهات الاتصال</translation>
+<translation id="1919950603503897840">اختيار جهات الاتصال</translation>
+<translation id="7986741934819883144">اختيار جهة اتصال</translation>
+<translation id="3333961966071413176">جميع جهات الاتصال</translation>
+<translation id="4994033804516042629">لم يتم العثور على أي جهات اتصال</translation>
+<translation id="5403592356182871684">الأسماء</translation>
+<translation id="2717722538473713889">عنوان البريد الإلكتروني</translation>
+<translation id="381841723434055211">أرقام الهواتف</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 آخر)}zero{(+ # آخر)}two{(+ اثنين (#) آخرين)}few{(+ # أخرى)}many{(+ # آخر)}other{(+ # آخر)}}</translation>
+<translation id="5197729504361054390">ستتم مشاركة جهات الاتصال التي تختارها مع الموقع الإلكتروني <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">أداة فك تشفير الصور</translation>
+<translation id="8067883171444229417">تشغيل الفيديو</translation>
+<translation id="6560414384669816528">‏البحث باستخدام Sogou</translation>
+<translation id="5406914950576900927">‏يمكن لـ Brave استخدام <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> للبحث في الصين. ويمكنك تغيير هذا في <ph name="BEGIN_LINK"/>الإعدادات<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">‏الاستمرار في استخدام محرك Brave Software</translation>
+<translation id="4384468725000734951">‏استخدام محرك Sogou للبحث</translation>
+<translation id="6103327872225198548">‏استخدام محرك Brave Software للبحث</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">‏يتم تشغيل هذا التطبيق في Brave</translation>
+<translation id="6143689084714664628">‏قيد التشغيل في Brave</translation>
+<translation id="7675869148432102528">‏تتوفَّر بيانات<ph name="APP_NAME"/> أيضًا في Brave</translation>
+<translation id="2734140769649165081">‏يمكنك محو البيانات في إعدادات Brave.</translation>
+<translation id="8232956427053453090">حفظ البيانات</translation>
+<translation id="4298388696830689168">المواقع المرتبطة</translation>
+<translation id="5763514718066511291">‏النقر لنسخ عنوان URL لهذا التطبيق</translation>
+<translation id="6496823230996795692">لاستخدام <ph name="APP_NAME"/> للمرة الأولى، يُرجى الاتصال بالإنترنت.</translation>
+<translation id="751961395872307827">يتعذّر الاتصال بالموقع</translation>
+<translation id="4878404682131129617">أخفق إنشاء نفق عبر الخادم الوكيل.</translation>
+<translation id="4749960740855309258">فتح علامة تبويب جديدة</translation>
+<translation id="8788968922598763114">إعادة فتح آخر علامة تبويب تم إغلاقها</translation>
+<translation id="7929962904089429003">فتح القائمة</translation>
+<translation id="6039379616847168523">الانتقال السريع إلى علامة التبويب التالية</translation>
+<translation id="5210286577605176222">الانتقال السريع إلى علامة التبويب السابقة</translation>
+<translation id="124678866338384709">إغلاق علامة التبويب الحالية</translation>
+<translation id="3714981814255182093">فتح شريط البحث</translation>
+<translation id="5441522332038954058">الانتقال السريع إلى شريط العناوين</translation>
+<translation id="3398320232533725830">فتح مدير الإشارات المرجعية</translation>
+<translation id="6583199322650523874">وضع إشارة مرجعية على الصفحة الحالية</translation>
+<translation id="8489271220582375723">فتح صفحة السجل</translation>
+<translation id="4837753911714442426">فتح الخيارات لطباعة الصفحة</translation>
+<translation id="5726692708398506830">تكبير كل محتويات الصفحة</translation>
+<translation id="3259831549858767975">تصغير كل محتويات الصفحة</translation>
+<translation id="8015452622527143194">إعادة كل محتويات الصفحة إلى الحجم التلقائي</translation>
+<translation id="3443221991560634068">إعادة تحميل الصفحة الحالية</translation>
+<translation id="123724288017357924">إعادة تحميل الصفحة الحالية مع تجاهل المحتوى المُخزَّن مؤقتًا</translation>
+<translation id="305870044889644984">‏فتح مركز مساعدة Brave في علامة تبويب جديدة</translation>
+<translation id="3166827708714933426">اختصارات علامات التبويب والنوافذ</translation>
+<translation id="3169981355900570544">‏اختصارات ميزات Brave Software Brave</translation>
+<translation id="4558311620361989323">اختصارات صفحة الويب</translation>
+<translation id="1908301351964700579">‏لا يزال Brave يستعد للواقع الافتراضي. يُرجى إعادة تشغيل Brave لاحقًا.</translation>
+<translation id="8970887620466824814">حدث خطأ.</translation>
+<translation id="1875543012935658554">‏يُرجى إعادة فتح Brave.</translation>
+<translation id="79859296434321399">‏لعرض محتوى الواقع المُعزَّز، يُرجى تثبيت ARCore</translation>
+<translation id="8558485628462305855">‏لعرض محتوى الواقع المُعزَّز، يُرجى تحديث ARCore</translation>
+<translation id="3513704683820682405">الواقع المعزّز</translation>
+<translation id="5475862044948910901">هل تريد بدء جلسة الواقع المعزّز؟</translation>
 <translation id="7365126855094612066">طوال مدة هذه الجلسة، سيتمكَّن موقع الويب من تنفيذ ما يلي:
 • إنشاء خريطة ثلاثية الأبعاد لبيئتك
 • تتبّع حركة الكاميرا
 
 لا يمكن لموقع الويب الحصول على إذن بالوصول إلى الكاميرا. لا تكون الصور المُلتقطة بالكاميرا مرئية إلا لك.</translation>
-<translation id="7375125077091615385">النوع:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" /></translation>
-<translation id="7400418766976504921">‏عنوان URL</translation>
-<translation id="7403691278183511381">‏أول تجربة تشغيل لمتصفح Chrome</translation>
-<translation id="741204030948306876">نعم، موافق</translation>
-<translation id="7413229368719586778">تاريخ البدء: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">السؤال أولاً</translation>
-<translation id="7423538860840206698">تم الحظر من قراءة الحافظة</translation>
-<translation id="7431991332293347422">التحكُّم في كيفية استخدامنا لسِجل التصفُّح لتخصيص البحث والمزيد</translation>
-<translation id="7437998757836447326">‏تسجيل الخروج من Chrome</translation>
-<translation id="7438641746574390233">‏عند تفعيل الوضع البسيط، يستخدم Chrome خدمات Google لتحميل الصفحات بشكلٍ أسرع. يعيد الوضع البسيط كتابة الصفحات البطيئة للغاية من أجل تحميل المحتوى الأساسي فقط. لا ينطبق الوضع البسيط على علامات تبويب التصفُّح المتخفي.</translation>
-<translation id="7444811645081526538">مزيد من الفئات</translation>
-<translation id="7445411102860286510">السماح لمواقع الويب بتشغيل الفيديوهات المكتومة الصوت تلقائيًا (مُستحسن)</translation>
-<translation id="7453467225369441013">‏سيتم تسجيل الخروج من معظم مواقع الويب، لكن لن يتم تسجيل الخروج من حسابك على Google.</translation>
-<translation id="7454641608352164238">مساحة التخزين غير كافية</translation>
-<translation id="7475192538862203634">إذا تكرّر هذا الخطأ، ننصحك بالاطّلاع على هذه <ph name="BEGIN_LINK" />الاقتراحات<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">‏لم يتم العثور على بطاقة SD. قد يكون بعض الملفات مفقودًا.</translation>
-<translation id="7479104141328977413">إدارة علامات التبويب</translation>
-<translation id="7481312909269577407">إلى الأمام</translation>
-<translation id="7482656565088326534">علامة تبويب المعاينة</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (تم التحديث منذ <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">حجم البيانات التي تم توفيرها</translation>
-<translation id="7498271377022651285">يُرجى الانتظار...</translation>
-<translation id="7514365320538308">تنزيل</translation>
-<translation id="751961395872307827">يتعذّر الاتصال بالموقع</translation>
-<translation id="7521387064766892559">جافا سكريبت</translation>
-<translation id="7542481630195938534">يتعذر الحصول على الاقتراحات</translation>
-<translation id="7559975015014302720">تم إيقاف الوضع البسيط</translation>
-<translation id="7562080006725997899">جارٍ محو بيانات التصفح</translation>
-<translation id="756809126120519699">‏بيانات Chrome التي تم محوها</translation>
-<translation id="757524316907819857">منع مواقع الويب من تشغيل المحتوى المحمي</translation>
-<translation id="757855969265046257">{FILES,plural, =1{تم تنزيل ملف <ph name="FILES_DOWNLOADED_ONE" />}zero{تم تنزيل <ph name="FILES_DOWNLOADED_MANY" /> ملفات}two{تم تنزيل ملفين (<ph name="FILES_DOWNLOADED_MANY" />)}few{تم تنزيل <ph name="FILES_DOWNLOADED_MANY" /> ملفات}many{تم تنزيل <ph name="FILES_DOWNLOADED_MANY" /> ملفًا}other{تم تنزيل <ph name="FILES_DOWNLOADED_MANY" /> ملف}}</translation>
-<translation id="7588219262685291874">تفعيل "المظهر الداكن" عند تفعيل ميزة "توفير شحن البطارية" للجهاز</translation>
-<translation id="7589445247086920869">حظر محرّك البحث الحالي</translation>
-<translation id="7593557518625677601">‏فتح إعدادات Android وإعادة تفعيل مزامنة نظام Android لبدء مزامنة Chrome</translation>
-<translation id="7596558890252710462">نظام التشغيل</translation>
-<translation id="7605594153474022051">المزامنة لا تعمل</translation>
-<translation id="7606077192958116810">تم تفعيل الوضع البسيط. يمكنك إدارته في الإعدادات.</translation>
-<translation id="7612619742409846846">‏أنت مسجّل الدخول إلى Google باستخدام</translation>
-<translation id="7619072057915878432">تعذّر تنزيل الملف <ph name="FILE_NAME" /> بسبب إخفاقات الشبكة.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />الحصول على مساعدة<ph name="END_LINK1" /> أو <ph name="BEGIN_LINK2" />إعادة الفحص<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">‏مرحبًا بك في Chrome‏</translation>
-<translation id="7638584964844754484">عبارة مرور غير صحيحة</translation>
-<translation id="7641339528570811325">محو بيانات التصفّح...</translation>
-<translation id="7648422057306047504">‏تشفير كلمات المرور باستخدام بيانات اعتماد Google</translation>
-<translation id="7649070708921625228">مساعدة</translation>
-<translation id="7658239707568436148">إلغاء</translation>
-<translation id="7665369617277396874">إضافة حساب</translation>
-<translation id="766587987807204883">تظهر المقالات هنا، ويمكنك الاطّلاع عليها حتى عندما لا يكون الجهاز متّصلًا بالإنترنت.</translation>
-<translation id="7682724950699840886">يمكنك تجربة النصائح التالية: تأكد من توفر مساحة كافية على جهازك وحاول التصدير مرة أخرى.</translation>
-<translation id="7685301384041462804">تأكّد من أنك تثق في هذا الموقع الإلكتروني قبل الانتقال إلى وضع "الواقع الافتراضي".</translation>
-<translation id="7698359219371678927">إنشاء بريد إلكتروني في <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">‏الإكمال التلقائي لعناوين URL وعمليات البحث</translation>
-<translation id="7725024127233776428">يتم عرض الصفحات التي يتم وضع إشارة عليها هنا.</translation>
-<translation id="773466115871691567">ترجمة الصفحات باللغة <ph name="SOURCE_LANGUAGE" /> دائمًا</translation>
-<translation id="7746457520633464754">‏لرصد التطبيقات ومواقع الويب الضارة، يُرسل Chrome عناوين URL لبعض الصفحات التي زرتها ومعلومات محدودة للنظام وبعض أنواع محتوى الصفحات إلى Google.</translation>
-<translation id="7757787379047923882">تمت مشاركة النص من <ph name="DEVICE_NAME" />.</translation>
-<translation id="7762668264895820836">‏بطاقة SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">إضافة عنوان</translation>
-<translation id="7772032839648071052">تأكيد عبارة المرور</translation>
-<translation id="7772375229873196092">إغلاق <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 وطريقة دفع إضافية واحدة (<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />)}zero{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> طريقة دفع إضافية}two{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 وطريقتا دفع إضافيتان (<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />)}few{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> طرق دفع إضافية}many{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> طريقة دفع إضافية}other{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 و<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> طريقة دفع إضافية}}</translation>
-<translation id="7781829728241885113">أمس</translation>
-<translation id="7791543448312431591">إضافة</translation>
-<translation id="780301667611848630">لا، شكرًا</translation>
-<translation id="7810647596859435254">فتح باستخدام...</translation>
-<translation id="7821588508402923572">سيظهر توفير البيانات هنا</translation>
-<translation id="7837721118676387834">السماح لموقع ويب معيّن بالتشغيل التلقائي للفيديوهات المكتومة الصوت</translation>
-<translation id="7846076177841592234">إلغاء التحديد</translation>
-<translation id="784934925303690534">النطاق الزمني</translation>
-<translation id="7851858861565204677">أجهزة أخرى</translation>
-<translation id="7875915731392087153">إنشاء بريد إلكتروني</translation>
-<translation id="7876243839304621966">إزالة الكل</translation>
-<translation id="7882131421121961860">لم يتم العثور على أي سجلّ</translation>
-<translation id="7882806643839505685">السماح بتشغيل الصوت لموقع معين.</translation>
-<translation id="7886917304091689118">‏قيد التشغيل في Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{جارٍ تنزيل ملف واحد.}zero{جارٍ تنزيل # ملف}two{جارٍ تنزيل ملفين (#).}few{جارٍ تنزيل # ملفات.}many{جارٍ تنزيل # ملفًا.}other{جارٍ تنزيل # ملف.}}</translation>
-<translation id="7929962904089429003">فتح القائمة</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> قديم.</translation>
-<translation id="7947953824732555851">قبول وتسجيل الدخول</translation>
-<translation id="7963646190083259054">المورّد:</translation>
-<translation id="7971136598759319605">نشط قبل يوم واحد</translation>
-<translation id="7975379999046275268">معاينة صفحة <ph name="BEGIN_NEW" />ميزة جديدة<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">التحميل المُسبق للصفحات للحصول على أداء أسرع أثناء التصفّح والبحث</translation>
-<translation id="79859296434321399">‏لعرض محتوى الواقع المُعزَّز، يُرجى تثبيت ARCore</translation>
-<translation id="7986741934819883144">اختيار جهة اتصال</translation>
-<translation id="7987073022710626672">‏بنود خدمة Chrome</translation>
-<translation id="7998918019931843664">إعادة فتح علامة التبويب المغلقة</translation>
-<translation id="7999064672810608036">هل أنت متأكّد أنك تريد محو كل البيانات المحلية، بما في ذلك ملفات تعريف الارتباط، وإعادة ضبط كافة الأذونات لهذا الموقع الإلكتروني؟</translation>
-<translation id="8004582292198964060">المتصفّح</translation>
-<translation id="8007176423574883786">تم إيقافه لهذا الجهاز</translation>
-<translation id="8013372441983637696">‏محو بيانات Chrome من هذا الجهاز أيضًا</translation>
-<translation id="8015452622527143194">إعادة كل محتويات الصفحة إلى الحجم التلقائي</translation>
-<translation id="802154636333426148">تعذّر التنزيل</translation>
-<translation id="8026334261755873520">محو بيانات التصفُّح</translation>
-<translation id="8035133914807600019">مجلد جديد...</translation>
-<translation id="8037750541064988519">عدد الأيام المتبقية: <ph name="DAYS" /></translation>
-<translation id="804335162455518893">‏لم يتم العثور على بطاقة SD.</translation>
-<translation id="805047784848435650">استنادًا إلى سجلّ التصفُّح</translation>
-<translation id="8051695050440594747">هناك <ph name="MEGABYTES" /> ميغابايت متوفرة</translation>
-<translation id="8058746566562539958">‏فتح بعلامة تبويب Chrome جديدة</translation>
-<translation id="8063895661287329888">تعذّرت إضافة الإشارة المرجعية.</translation>
-<translation id="806745655614357130">الحفاظ على البيانات التابعة لي منفصلة</translation>
-<translation id="8067883171444229417">تشغيل الفيديو</translation>
-<translation id="8068648041423924542">يتعذر تحديد الشهادة.</translation>
-<translation id="8073388330009372546">فتح الصورة بعلامة تبويب جديدة</translation>
-<translation id="8076492880354921740">علامات التبويب</translation>
-<translation id="8084114998886531721">كلمة مرور محفوظة</translation>
-<translation id="8087000398470557479">‏هذا المحتوى من <ph name="DOMAIN_NAME" />، وتم عرضه من قبل Google.</translation>
-<translation id="8103578431304235997">علامة تبويب للتصفح المتخفي</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">للحصول على الإشارات المرجعية على جميع أجهزتك، يُرجى تفعيل المزامنة.</translation>
-<translation id="8110087112193408731">‏هل تريد عرض نشاط Chrome في الرفاهية الرقمية؟</translation>
-<translation id="8116925261070264013">مواقع الويب التي تم كتم الصوت فيها</translation>
-<translation id="813082847718468539">عرض معلومات الموقع</translation>
-<translation id="8131740175452115882">التأكيد</translation>
-<translation id="8156139159503939589">ما هي اللغات التي تقرؤها؟</translation>
-<translation id="8168435359814927499">المحتوى</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> من الملفات المتبقية</translation>
-<translation id="8190358571722158785">يتبقى يوم واحد</translation>
-<translation id="8200772114523450471">استئناف</translation>
-<translation id="8209050860603202033">فتح الصورة</translation>
-<translation id="8218622182176210845">إدارة حسابك</translation>
-<translation id="8224471946457685718">‏تنزيل مقالات لك عند الاتصال بشبكة Wi-Fi</translation>
-<translation id="8232956427053453090">حفظ البيانات</translation>
-<translation id="8249310407154411074">نقل إلى الأعلى</translation>
-<translation id="8250920743982581267">المستندات</translation>
-<translation id="825412236959742607">‏تستهلك هذه الصفحة مساحة كبيرة من الذاكرة، لذلك أزال Chrome بعض محتواها.</translation>
-<translation id="8260126382462817229">محاولة تسجيل الدخول مرة أخرى</translation>
-<translation id="8261506727792406068">حذف</translation>
-<translation id="8266862848225348053">موقع التنزيل</translation>
-<translation id="8274165955039650276">الاطِّلاع على التنزيلات</translation>
-<translation id="8284326494547611709">الترجمة والشرح</translation>
-<translation id="8300705686683892304">تتم الإدارة من خلال التطبيق</translation>
-<translation id="8310344678080805313">علامات التبويب القياسية</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ومواقع أخرى</translation>
-<translation id="8327155640814342956">‏للحصول على أفضل تجربة للتصفّح، يُرجى الفتح لتحديث Chrome.</translation>
-<translation id="8339163506404995330">لن تتم ترجمة الصفحات باللغة <ph name="LANGUAGE" /></translation>
-<translation id="8349013245300336738">الترتيب حسب مقدار البيانات المُستخدَمة</translation>
-<translation id="8364299278605033898">عرض مواقع الويب الشائعة</translation>
-<translation id="8368027906805972958">جهاز غير معروف أو غير متوافق (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">السماح لموقع ويب معيّن بتشغيل "المزامنة في الخلفية"</translation>
-<translation id="8378714024927312812">بإدارة مؤسستك</translation>
-<translation id="8380167699614421159">يعرض هذا الموقع الإلكتروني إعلانات مضلِّلة أو غير مرغوب فيها</translation>
-<translation id="8393700583063109961">إرسال رسالة</translation>
-<translation id="8413126021676339697">عرض السجلّ بكامله</translation>
-<translation id="8427875596167638501">علامة تبويب المعاينة مفتوحة جزئيًا</translation>
-<translation id="8428213095426709021">الإعدادات</translation>
-<translation id="8438566539970814960">تحسين عمليات البحث والتصفُّح</translation>
-<translation id="8441146129660941386">الرجوع للوراء</translation>
-<translation id="8443209985646068659">‏يتعذَّر تحديث Chrome</translation>
-<translation id="8445448999790540984">يتعذّر تصدير كلمات المرور</translation>
-<translation id="8447861592752582886">إبطال إذن الجهاز</translation>
-<translation id="8461694314515752532">تشفير البيانات المتزامنة باستخدام عبارة مرور المزامنة الخاصة بك</translation>
-<translation id="8466613982764129868">يُرجى التأكُّد من اتصال الجهاز <ph name="TARGET_DEVICE_NAME" /> بالإنترنت.</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">التوفر بلا إنترنت</translation>
-<translation id="8489271220582375723">فتح صفحة السجل</translation>
-<translation id="8493948351860045254">تفريغ بعض المساحة</translation>
-<translation id="8497726226069778601">لا يوجد شيء هنا... حتى الآن</translation>
-<translation id="8503559462189395349">‏كلمات المرور في Chrome</translation>
-<translation id="8503813439785031346">اسم المستخدم</translation>
-<translation id="8514477925623180633">‏تصدير كلمات المرور المخزنة من خلال Chrome</translation>
-<translation id="8514577642972634246">الدخول إلى وضع التصفح المتخفي</translation>
-<translation id="851751545965956758">حظر مواقع الويب من الاتصال بأجهزة</translation>
-<translation id="8523928698583292556">حذف كلمة المرور المخزنة</translation>
-<translation id="854522910157234410">فتح هذه الصفحة</translation>
-<translation id="8558485628462305855">‏لعرض محتوى الواقع المُعزَّز، يُرجى تحديث ARCore</translation>
-<translation id="8559990750235505898">اقتراح ترجمة الصفحات المكتوبة بلغات أخرى</translation>
-<translation id="8562452229998620586">ستظهر هنا كلمات المرور المحفوظة.</translation>
-<translation id="8569404424186215731">منذ <ph name="DATE" /></translation>
-<translation id="8571213806525832805">الأسابيع الـ4 الأخيرة</translation>
-<translation id="857943718398505171">مسموح بها (موصى بها)</translation>
-<translation id="8583805026567836021">محو بيانات الحساب</translation>
-<translation id="860043288473659153">اسم حامل البطاقة</translation>
-<translation id="8609465669617005112">التحريك إلى أعلى</translation>
-<translation id="8616006591992756292">‏قد يتضمّن حسابك على Google نماذج أخرى من سجلّ التصفّح في <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">‏هل تريد فتح عنوان URL المقترح والمحدد في المحتوى الذي تم تنزيله؟</translation>
-<translation id="8636825310635137004">للحصول على علامات التبويب من أجهزتك الأخرى، شغِّل المزامنة.</translation>
-<translation id="8641930654639604085">محاولة حظر مواقع الويب التي تتضمن محتوى للبالغين</translation>
-<translation id="8655129584991699539">‏يمكنك محو البيانات في إعدادات Chrome.</translation>
-<translation id="8662811608048051533">يخرجك من معظم مواقع الويب.</translation>
-<translation id="8664979001105139458">اسم الملف موجود</translation>
-<translation id="8676374126336081632">محو الإرسال</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{مستوى قوة الإشارة: شريط واحد (#)}zero{مستوى قوة الإشارة: # شريط}two{مستوى قوة الإشارة: شريطان (#)}few{مستوى قوة الإشارة: # أشرطة}many{مستوى قوة الإشارة: # شريطًا}other{مستوى قوة الإشارة: # شريط}}</translation>
-<translation id="868929229000858085">البحث في جهات الاتصال</translation>
-<translation id="869891660844655955">تاريخ انتهاء الصلاحية</translation>
-<translation id="8719023831149562936">تعذر إرسال علامة التبويب الحالية باستخدام الشعاع</translation>
-<translation id="8725066075913043281">أعد المحاولة</translation>
-<translation id="8728487861892616501">‏باستخدامك لهذا التطبيق، أنت توافق على <ph name="BEGIN_LINK1" />بنود الخدمة في Chrome<ph name="END_LINK1" /> و<ph name="BEGIN_LINK2" />إشعار الخصوصية<ph name="END_LINK2" /> و<ph name="BEGIN_LINK3" />إشعار الخصوصية لحسابات Google المُدارة من خلال Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">تم</translation>
-<translation id="8748850008226585750">المحتويات مخفية</translation>
-<translation id="8751914237388039244">اختيار صورة</translation>
-<translation id="8788265440806329501">يتم إغلاق سجلّ التنقُّل.</translation>
-<translation id="8788968922598763114">إعادة فتح آخر علامة تبويب تم إغلاقها</translation>
-<translation id="8801436777607969138">حظر جافا سكريبت لموقع ويب مُعيَّن.</translation>
-<translation id="8812260976093120287">يمكنك على مواقع ويب معيّنة الدفع باستخدام تطبيقات الدفع المتوافقة أعلاه على جهازك.</translation>
-<translation id="8816026460808729765">يمكنك حظر مواقع الويب من الوصول إلى أجهزة الاستشعار.</translation>
-<translation id="8816439037877937734">‏سيتم فتح <ph name="APP_NAME" /> في Chrome. بالمتابعة، أنت توافق على <ph name="BEGIN_LINK1" />بنود الخدمة<ph name="END_LINK1" /> و<ph name="BEGIN_LINK2" />إشعار الخصوصية<ph name="END_LINK2" /> في Chrome، و<ph name="BEGIN_LINK3" />إشعار الخصوصية لحسابات Google المُدارة من خلال Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">الإشارات المرجعية</translation>
-<translation id="8833831881926404480">يشارك موقع ويب شاشتك</translation>
-<translation id="883806473910249246">حدث خطأ أثناء تنزيل المحتوى.</translation>
-<translation id="8840953339110955557">قد تختلف هذه الصفحة عن الإصدار الوارد على الإنترنت.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">علامة التبويب <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">التخزين</translation>
-<translation id="889338405075704026">‏الانتقال إلى إعدادات Chrome</translation>
-<translation id="8901170036886848654">ما مِن إشارات مرجعية مطابقة</translation>
-<translation id="8909135823018751308">مشاركة…</translation>
-<translation id="8912362522468806198">‏حساب Google‏</translation>
-<translation id="8920114477895755567">الانتظار للحصول على تفاصيل الآباء</translation>
+<translation id="1188239144602654184">إطلاق الواقع المعزّز</translation>
+<translation id="473775607612524610">تحديث</translation>
+<translation id="3133489217401741157">‏جارٍ تثبيت <ph name="MODULE"/> لمتصفِّح Brave…</translation>
+<translation id="1791662854739702043">تم التثبيت</translation>
+<translation id="5131234170665854056">‏تعذر تثبيت <ph name="MODULE"/> لمتصفِّح Brave</translation>
+<translation id="2567385386134582609">صورة</translation>
+<translation id="6395288395575013217">رابط</translation>
+<translation id="7352939065658542140">فيديو</translation>
+<translation id="4116038641877404294">تنزيل الصفحات لاستخدامها بلا اتصال بالإنترنت</translation>
 <translation id="8922289737868596582">تنزيل الصفحات من الزر "مزيد من الخيارات" لاستخدامها بلا اتصال بالإنترنت</translation>
-<translation id="8937772741022875483">‏هل تريد إزالة نشاط Chrome من الرفاهية الرقمية؟</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">فتح في نافذة أخرى</translation>
-<translation id="8951232171465285730">‏لقد وفر Chrome لك <ph name="MEGABYTES" /> ميغابايت</translation>
-<translation id="8958424370300090006">حظر ملفات تعريف الارتباط لموقع إلكتروني مُحدَّد.</translation>
-<translation id="8959122750345127698">التنقل غير قابل للوصول: <ph name="URL" /></translation>
-<translation id="8965591936373831584">في الانتظار</translation>
-<translation id="8970887620466824814">حدث خطأ.</translation>
-<translation id="8972098258593396643">هل تريد التنزيل إلى المجلد التلقائي؟</translation>
-<translation id="8986494364107987395">‏إرسال إحصاءات الاستخدام وتقارير الأعطال إلى Google تلقائيًا</translation>
-<translation id="8993760627012879038">فتح علامة تبويب جديدة في وضع التصفّح المتخفّي</translation>
-<translation id="8998729206196772491">‏يتم تسجيل دخولك باستخدام حساب تتم إدارته من خلال <ph name="MANAGED_DOMAIN" /> ومنح مشرفه الحق في التحكم في بياناتك على Chrome. سيؤدي ذلك إلى جعل بياناتك مرتبطة دائمًا بهذا الحساب. كما سيؤدي الخروج من Chrome إلى حذف بياناتك من هذا الجهاز، ولكن ستظل هذه البيانات مخزَّنة على حسابك في Google.</translation>
-<translation id="9019902583201351841">يديره والداك</translation>
-<translation id="9028914725102941583">تفعيل المزامنة لمشاركة المحتوى مع جهاز آخر</translation>
-<translation id="9029323097866369874">هل تريد السماح للموقع الإلكتروني <ph name="DOMAIN" /> بالانتقال إلى وضع "الواقع الافتراضي"؟</translation>
-<translation id="9040142327097499898">الإشعارات مسموح بها. وتحديد الموقع الجغرافي متوقف لهذا الجهاز.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{فيديو واحد (#)}zero{# فيديو}two{فيديوهان (#)}few{# فيديوهات}many{# فيديو}other{# فيديو}}</translation>
-<translation id="9050666287014529139">عبارة المرور</translation>
-<translation id="9063523880881406963">إيقاف طلب موقع الويب لسطح المكتب</translation>
-<translation id="9065203028668620118">تعديل</translation>
-<translation id="9070377983101773829">بدء البحث الصوتي</translation>
-<translation id="9074336505530349563">‏للحصول على محتوى مُخصَّص اقترحته Google، يُرجى تسجيل الدخول وتفعيل المزامنة.</translation>
-<translation id="9086455579313502267">تعذر الدخول إلى الشبكة</translation>
-<translation id="9100505651305367705">اقتراح مشاهدة المقالات في العرض المبسَّط إذا كان ذلك متاحًا</translation>
-<translation id="9100610230175265781">عبارة المرور مطلوبة</translation>
-<translation id="9102803872260866941">علامة تبويب المعاينة مفتوحة</translation>
+<translation id="5958275228015807058">العثور على الملفات والصفحات في التنزيلات</translation>
+<translation id="5620928963363755975">العثور على الملفات والصفحات في التنزيلات من الزر "مزيد من الخيارات"</translation>
+<translation id="3341058695485821946">الاطّلاع على مقدار البيانات التي وفّرتها</translation>
+<translation id="3157842584138209013">الاطّلاع على مقدار البيانات التي وفّرتها بالنقر على "مزيد من الخيارات"</translation>
+<translation id="8218622182176210845">إدارة حسابك</translation>
+<translation id="8090895580117672212">‏لإدارة إعدادات حسابك على Brave Software، يُرجى النقر على الزر "إدارة الحساب".</translation>
+<translation id="8856898588039823173">‏صفحة بسيطة تقدِّمها Brave Software. يُرجى النقر لتحميل الصفحة الأصلية.</translation>
+<translation id="8134317863207426198">‏نسخة خفيفة تقدِّمها Brave Software. انقر على زر "تحميل الصفحة الأصلية" لتحميلها.</translation>
+<translation id="4961107849584082341">ترجمة هذه الصفحة إلى أي لغة</translation>
+<translation id="569536719314091526">ترجمة هذه الصفحة إلى أي لغة من خلال الزر "مزيد من الخيارات"</translation>
+<translation id="1397811292916898096">البحث باستخدام <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">تغيير موقع التنزيل التلقائي في أي وقت</translation>
+<translation id="6942665639005891494">تغيير موقع التنزيل التلقائي في أي وقت باستخدام خيار قائمة "الإعدادات"</translation>
+<translation id="6850409657436465440">لا يزال التنزيل قيد التقدُّم</translation>
+<translation id="5817715962196959877">‏يُنزِّل Brave الآن الملفات بشكلٍ أسرع.</translation>
+<translation id="3976396876660209797">إزالة هذا الاختصار وإعادة إنشائه</translation>
+<translation id="6766622839693428701">يمكنك التمرير السريع للأسفل للإغلاق.</translation>
+<translation id="1028699632127661925">جارٍ الإرسال إلى <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - تم الإرسال من <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">تم تلقي علامة تبويب</translation>
 <translation id="9104217018994036254">قائمة الأجهزة التي يمكن مشاركة علامة تبويب معها.</translation>
-<translation id="9133397713400217035">الاطّلاع في وضع عدم الاتصال بالإنترنت</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">إظهار الصفحة الأصلية</translation>
-<translation id="9139068048179869749">السؤال قبل السماح لمواقع الويب بإرسال الإشعارات (موصى به)</translation>
-<translation id="9139318394846604261">التسوّق</translation>
-<translation id="9155898266292537608">يمكنك أيضًا البحث بنقرة سريعة على كلمة</translation>
-<translation id="9169507124922466868">سجلّ التنقل مفتوح جزئيًا</translation>
-<translation id="9204836675896933765">ملف واحد متبقٍ</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">قائمة الأجهزة التي يمكن مشاركة علامة تبويب معها، مفتوحة على طول النصف السفلي من الشاشة.</translation>
+<translation id="2904414404539560095">قائمة بالأجهزة التي يمكن مشاركة علامة تبويب معها، مفتوحة على طول الشاشة.</translation>
+<translation id="4135200667068010335">قائمة الأجهزة التي يمكن مشاركة علامة تبويب معها مغلقة.</translation>
+<translation id="5292796745632149097">إرسال إلى</translation>
+<translation id="1386674309198842382">نشط قبل <ph name="LAST_UPDATED"/> من الأيام</translation>
+<translation id="7971136598759319605">نشط قبل يوم واحد</translation>
+<translation id="1521774566618522728">نشط اليوم</translation>
+<translation id="3631987586758005671">جارٍ المشاركة مع <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">تفعيل المزامنة لمشاركة المحتوى مع جهاز آخر</translation>
+<translation id="6162454065885854378">‏لمشاركة محتوى من هاتفك مع جهاز آخر، يُرجى تفعيل المزامنة في إعدادات Brave على كلا الجهازين.</translation>
+<translation id="6084271560289605378">‏الانتقال إلى إعدادات Brave</translation>
+<translation id="2318045970523081853">انقر لإجراء اتصال.</translation>
 <translation id="9209888181064652401">لا يمكن إجراء المكالمات</translation>
-<translation id="9219103736887031265">الصور</translation>
-<translation id="926205370408745186">‏إزالة نشاط Chrome من الرفاهية الرقمية</translation>
-<translation id="932327136139879170">الصفحة الرئيسية</translation>
-<translation id="938850635132480979">الخطأ: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">الدخول إلى الميكروفون</translation>
-<translation id="95817756606698420">‏يمكن لـ Chrome استخدام <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> للبحث في الصين. ويمكنك تغيير هذا في <ph name="BEGIN_LINK" />الإعدادات<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">الحظر في حال كان موقع الويب يعرض إعلانات مضلِّلة أو غير مرغوب فيها (مُستحسَن)</translation>
-<translation id="968900484120156207">يتم عرض الصفحات التي تزورها هنا.</translation>
-<translation id="970715775301869095">عدد الدقائق المتبقية: <ph name="MINUTES" /></translation>
-<translation id="974555521953189084">إدخال عبارة المرور لبدء المزامنة</translation>
-<translation id="981121421437150478">بلا اتصال</translation>
-<translation id="982182592107339124">سيؤدي هذا إلى محو بيانات جميع المواقع، بما في ذلك:</translation>
-<translation id="983192555821071799">إغلاق جميع علامات التبويب</translation>
-<translation id="987264212798334818">عام</translation>
+<translation id="2860954141821109167">يُرجى التأكُّد من تفعيل تطبيق هاتف على هذا الجهاز.</translation>
+<translation id="2067805253194386918">نص</translation>
+<translation id="1450753235335490080">تعذَّرت مشاركة <ph name="CONTENT_TYPE"/>.</translation>
+<translation id="1266864766717917324">تعذَّرت مشاركة <ph name="CONTENT_TYPE"/>.</translation>
+<translation id="8287068819750208230">‏يُرجى التأكّد من تفعيل مزامنة <ph name="TARGET_DEVICE_NAME"/> في Brave.</translation>
+<translation id="3016635187733453316">يُرجى التأكُّد من اتصال هذا الجهاز بالإنترنت.</translation>
+<translation id="8466613982764129868">يُرجى التأكُّد من اتصال الجهاز <ph name="TARGET_DEVICE_NAME"/> بالإنترنت.</translation>
+<translation id="6539092367496845964">حدث خطأ. يُرجى إعادة المحاولة لاحقًا.</translation>
+<translation id="3389286852084373014">النص كبير جدًا</translation>
+<translation id="2100314319871056947">يُرجى تجربة مشاركة النص في مجموعات أصغر.</translation>
+<translation id="2987620471460279764">النصوص التي تمت مشاركتها من جهاز آخر</translation>
+<translation id="7757787379047923882">تمت مشاركة النص من <ph name="DEVICE_NAME"/>.</translation>
+<translation id="5193988420012215838">تم النسخ إلى الحافظة</translation>
+<translation id="4696983787092045100">إرسال رسالة نصية إلى أجهزتك</translation>
+<translation id="1260236875608242557">البحث والاستكشاف</translation>
+<translation id="6369229450655021117">يمكنك "من هنا" البحث في الويب والمشاركة مع أصدقائك وعرض الصفحات المفتوحة</translation>
+<translation id="723171743924126238">تحديد الصور</translation>
+<translation id="8751914237388039244">اختيار صورة</translation>
+<translation id="1989112275319619282">تصفّح</translation>
+<translation id="7055152154916055070">تم حظر إعادة توجيه:</translation>
+<translation id="5524843473235508879">تم حظر إعادة التوجيه.</translation>
+<translation id="6573096386450695060">السماح دومًا</translation>
+<translation id="5805364706385912897">‏تستهلك هذه الصفحة مساحة كبيرة من الذاكرة، لذلك أوقفها Brave مؤقتًا.</translation>
+<translation id="5138664332909611586">‏تستهلك هذه الصفحة مساحة كبيرة من الذاكرة، لذلك أزال Brave بعض محتواها.</translation>
+<translation id="9137013805542155359">إظهار الصفحة الأصلية</translation>
+<translation id="6361779936989026201">‏"مساعد Brave Software" على Brave</translation>
+<translation id="7291387454912369099">‏الملء التلقائي باستخدام "مساعد Brave Software"</translation>
+<translation id="4565206163201411670">‏هل تريد عرض نشاط Brave في الرفاهية الرقمية؟</translation>
+<translation id="9055113864158719823">‏يمكنك الاطِّلاع على مواقع الويب التي تزورها في Brave وتحديد موقِّتات لها.\n\nتحصل Brave Software على معلومات عن مواقع الويب التي ضبطت موقِّتات لها ومدة زيارتك لها. تُستخدم هذه المعلومات لتحسين الرفاهية الرقمية.</translation>
+<translation id="4596514158372210596">‏إزالة نشاط Brave من الرفاهية الرقمية</translation>
+<translation id="1174893863889683998">‏هل تريد إزالة نشاط Brave من الرفاهية الرقمية؟</translation>
+<translation id="708829030563435351">‏لن يتم عرض مواقع الويب التي تزورها في Brave. سيتم حذف جميع موقِّتات موقع الويب.</translation>
+<translation id="2056878612599315956">تم إيقاف الموقع الإلكتروني مؤقتًا</translation>
+<translation id="671481426037969117">انقضى وقت موقّت <ph name="FQDN"/>، وسيبدأ عمله مرّةً أخرى غدًا.</translation>
+<translation id="7479104141328977413">إدارة علامات التبويب</translation>
+<translation id="3524138585025253783">واجهة مستخدم مطوّر البرامج</translation>
+<translation id="6036057147555329831">وحدة الرعاية المركزية الإضافية</translation>
+<translation id="9029323097866369874">هل تريد السماح للموقع الإلكتروني <ph name="DOMAIN"/> بالانتقال إلى وضع "الواقع الافتراضي"؟</translation>
+<translation id="7685301384041462804">تأكّد من أنك تثق في هذا الموقع الإلكتروني قبل الانتقال إلى وضع "الواقع الافتراضي".</translation>
+<translation id="5033865233969348410">عندما تكون في وضع "الواقع الافتراضي"، قد يتمكن هذا الموقع الإلكتروني من معرفة:
+  -  سماتك البدنية، مثل الطول
+
+يُرجى التأكد من أنك تثق بهذا الموقع الإلكتروني قبل الانتقال إلى وضع "الواقع الإفتراضي".</translation>
+<translation id="5534334044554683961">عندما تكون في وضع "الواقع الافتراضي"، قد يتمكن هذا الموقع الإلكتروني من معرفة:
+  -   سماتك البدنية، مثل الطول
+  -   تنسيق غرفتك
+
+يُرجى التأكد من أنك تثق بهذا الموقع الإلكتروني قبل الانتقال إلى وضع "الواقع الافتراضي".</translation>
+<translation id="4169535189173047238">عدم السماح</translation>
+<translation id="2170088579611075216">السماح بالواقع الافتراضي والدخول إليه</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_bg.xtb
+++ b/android/java/strings/translations/android_chrome_strings_bg.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="bg">
-<translation id="1006017844123154345">Отваряне онлайн</translation>
-<translation id="1028699632127661925">Изпраща се до <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> се добавя...</translation>
-<translation id="1041308826830691739">От уебсайтове</translation>
-<translation id="1049743911850919806">„Инкогнито“</translation>
-<translation id="10614374240317010">Незапазвани никога</translation>
-<translation id="1067922213147265141">Други услуги на Google</translation>
-<translation id="1068672505746868501">Страниците на <ph name="SOURCE_LANGUAGE" /> да не се превеждат</translation>
-<translation id="107147699690128016">Ако промените файловото разширение, файлът може да се отвори в друго приложение и потенциално да навреди на устройството ви.</translation>
-<translation id="1100066534610197918">Отваряне в нов раздел в група</translation>
-<translation id="1105960400813249514">Заснемане на екрана</translation>
-<translation id="1111673857033749125">Тук ще се показват отметките, които сте запазили на другите си устройства.</translation>
-<translation id="1113597929977215864">Показване на опростения изглед</translation>
-<translation id="1121094540300013208">Отчети за употребата и сигнали за сривове</translation>
-<translation id="1124772482545689468">Потребител</translation>
-<translation id="1129510026454351943">Подробности: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Предстои 1 изтегляне.}other{Предстоят # изтегляния.}}</translation>
-<translation id="1145536944570833626">Изтриване на съществуващите данни.</translation>
-<translation id="1146678959555564648">Вход във VR</translation>
-<translation id="116280672541001035">Използвани</translation>
-<translation id="1171770572613082465">Вижте популярните уебсайтове, като докоснете бутона „Водещи сайтове“</translation>
-<translation id="1173894706177603556">Преименуване</translation>
-<translation id="1178581264944972037">Пауза</translation>
-<translation id="1181037720776840403">Премахване</translation>
-<translation id="1188239144602654184">Стартиране на AR</translation>
-<translation id="1197267115302279827">Преместване на отметки</translation>
-<translation id="119944043368869598">Изчистване на всички</translation>
-<translation id="1201402288615127009">Напред</translation>
-<translation id="1204037785786432551">Изтегляне на връзката</translation>
-<translation id="1206892813135768548">Копиране на текста на връзката</translation>
-<translation id="1208340532756947324">Включете синхронизирането, за да се възползвате от синхронизиране и персонализиране на всички устройства</translation>
-<translation id="1209206284964581585">Скриване засега</translation>
-<translation id="1227058898775614466">История на навигацията</translation>
-<translation id="1231733316453485619">Да се включи ли синхронизирането?</translation>
-<translation id="123724288017357924">Презареждане на страницата (кешът се пренебрегва)</translation>
-<translation id="124116460088058876">Още езици</translation>
-<translation id="124678866338384709">Затваряне на текущия раздел</translation>
-<translation id="1258753120186372309">Драскулка на Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Търсене и разглеждане</translation>
-<translation id="1264974993859112054">Спорт</translation>
-<translation id="1266864766717917324">Споделянето на <ph name="CONTENT_TYPE" /> не бе възможно</translation>
-<translation id="1272079795634619415">Стоп</translation>
-<translation id="1283039547216852943">Докоснете за разгъване</translation>
-<translation id="1285320974508926690">Този сайт да не се превежда никога</translation>
-<translation id="1291207594882862231">Изчистване на историята, „бисквитките“, данните за сайтове и кеша…</translation>
-<translation id="129382876167171263">Тук се показват файловете, запазени от уебсайтове</translation>
-<translation id="129553762522093515">Наскоро затворени</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Изпратено от <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Групиране на раздели</translation>
-<translation id="1327257854815634930">Историята на навигацията е отворена</translation>
-<translation id="1331212799747679585">Chrome не може да се актуализира. Още опции</translation>
-<translation id="1332501820983677155">Комбинации за функции на Google Chrome</translation>
-<translation id="1360432990279830238">Изход и изключване на синхронизирането?</translation>
-<translation id="1369915414381695676">Сайтът <ph name="SITE_NAME" /> е добавен</translation>
-<translation id="1373696734384179344">Недостатъчно памет за изтегляне на избраното съдържание.</translation>
-<translation id="1376578503827013741">Изчислява се…</translation>
-<translation id="1383876407941801731">Търсене</translation>
-<translation id="1384959399684842514">Изтеглянето е на пауза</translation>
-<translation id="1386674309198842382">Активно преди <ph name="LAST_UPDATED" /> дни</translation>
-<translation id="1397811292916898096">Търсене чрез <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Вградено в(ъв) <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Заявка „Do Not Track“</translation>
-<translation id="1407135791313364759">Отваряне на всички</translation>
-<translation id="1409426117486808224">Опростен изглед на отворените раздели</translation>
-<translation id="1409879593029778104">Изтеглянето на „<ph name="FILE_NAME" />“ е предотвратено, защото файлът вече съществува.</translation>
-<translation id="1414981605391750300">Установява се връзка с Google. Това може да отнеме известно време…</translation>
-<translation id="1416550906796893042">Версия на приложението</translation>
-<translation id="1430915738399379752">Печат</translation>
-<translation id="1446450296470737166">Разр. на пълния контрол над MIDI</translation>
-<translation id="1450753235335490080">Споделянето на <ph name="CONTENT_TYPE" /> не е възможно</translation>
-<translation id="145097072038377568">Изключено от настройките на Android</translation>
-<translation id="1477626028522505441">Изтеглянето на „<ph name="FILE_NAME" />“ не бе успешно поради проблеми в сървъра.</translation>
-<translation id="1506061864768559482">Търсеща машина</translation>
-<translation id="1513352483775369820">Отметки и посетени сайтове</translation>
-<translation id="1513858653616922153">Изтриване на паролата</translation>
-<translation id="1516229014686355813">При търсене с докосване избраната дума и текущата страница се изпращат като контекст до Google Търсене. Можете да изключите функцията от <ph name="BEGIN_LINK" />Настройки<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Активно днес</translation>
-<translation id="1544826120773021464">За да управлявате профила си в Google, докоснете бутона „Управление на профила“</translation>
-<translation id="1549000191223877751">Преместв. в другия прозорец</translation>
-<translation id="1553358976309200471">Актуализиране на Chrome</translation>
-<translation id="1569387923882100876">Свързано устройство</translation>
-<translation id="1571304935088121812">Копиране на потребителското име</translation>
-<translation id="1612196535745283361">Chrome се нуждае от достъп до местоположението, за да сканира за устройства, но съответните услуги са <ph name="BEGIN_LINK" />изключени за това устройство<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Камера</translation>
-<translation id="1623104350909869708">Да не се създават допълнителни диалогови прозорци от тази страница</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Премахване на 1 избран елемент}other{Премахване на # избрани елемента}}</translation>
-<translation id="164269334534774161">Преглеждате офлайн копие на тази страница, създадено на <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">История</translation>
-<translation id="1647391597548383849">Достъп до камерата</translation>
-<translation id="1660204651932907780">Разрешаване на сайтовете да възпроизвеждат звук (препоръчително)</translation>
-<translation id="1670399744444387456">Основни</translation>
-<translation id="1671236975893690980">Предстои изтегляне…</translation>
-<translation id="1672586136351118594">Да не се показва отново</translation>
-<translation id="1692118695553449118">Синхронизирането е включено</translation>
-<translation id="169515064810179024">Блокиране на достъпа на сайтовете до сензорите за движение</translation>
-<translation id="1717218214683051432">Сензори за движение</translation>
-<translation id="1718835860248848330">Последния час</translation>
-<translation id="1736419249208073774">Разглеждане</translation>
-<translation id="1743802530341753419">Извеждане на запитване, преди да се разреши на сайтовете да се свържат с устройство (препоръчително)</translation>
-<translation id="1749561566933687563">Синхронизирайте отметките си</translation>
-<translation id="17513872634828108">Отворени раздели</translation>
-<translation id="1779089405699405702">Декодиране на изображения</translation>
-<translation id="1782483593938241562">Крайна дата: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Инсталиран</translation>
-<translation id="1792959175193046959">Променете стандартното местоположение за изтегляне по всяко време</translation>
-<translation id="1807246157184219062">Светло</translation>
-<translation id="1810845389119482123">Първоначалното настройване на синхронизирането не завърши</translation>
-<translation id="1821253160463689938">Използва „бисквитки“ за запомняне на предпочитанията ви дори ако не посещавате тези страници</translation>
-<translation id="1829244130665387512">Търсене в страницата</translation>
-<translation id="1853692000353488670">Нов раздел „инкогнито“</translation>
-<translation id="1856325424225101786">Да се нулира ли олекотеният режим?</translation>
-<translation id="1868024384445905608">Изтеглянето на файлове в Chrome вече е по-бързо</translation>
-<translation id="1883903952484604915">Моите файлове</translation>
-<translation id="1887786770086287077">Достъпът до местоположението е изключен за това устройство. Включете го от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> ще се отвори в Chrome. С продължаването си приемате <ph name="BEGIN_LINK1" />Общите условия<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Съобщението за поверителност<ph name="END_LINK2" /> на браузъра.</translation>
-<translation id="1919345977826869612">Реклами</translation>
-<translation id="1919950603503897840">Избор на контакти</translation>
-<translation id="1922076542920281912">За да разрешите на Chrome да осъществява достъп до местоположението ви, то трябва да бъде включено и от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> от <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Актуализации</translation>
-<translation id="19288952978244135">Отворете отново Chrome.</translation>
-<translation id="1933845786846280168">Избран раздел</translation>
-<translation id="194341124344773587">Включете разрешението за Chrome от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Запазени пароли</translation>
-<translation id="1952172573699511566">Когато е възможно, текстът на уебсайтовете ще се показва на предпочитания от вас език.</translation>
-<translation id="1960290143419248813">Актуализациите на Chrome вече не се поддържат за тази версия на Android</translation>
-<translation id="1966710179511230534">Моля, актуализирайте данните си за вход.</translation>
-<translation id="1974060860693918893">Разширени</translation>
-<translation id="1984705450038014246">Синхронизиране на данните ви в Chrome</translation>
-<translation id="1984937141057606926">Разрешено, но не и за трети страни</translation>
-<translation id="1986685561493779662">Името вече съществува</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> бутон „<ph name="LINK_NAME" />“</translation>
-<translation id="1989112275319619282">Сърфиране</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> иска да се сдвои</translation>
-<translation id="1994173015038366702">URL адрес на сайт</translation>
-<translation id="2000419248597011803">Изпраща някои „бисквитки“ и заявките за търсене от адресната лента и полето за търсене до стандартната ви търсеща машина</translation>
-<translation id="2002537628803770967">Кредитни карти и адреси посредством Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# файл}other{# файла}}</translation>
-<translation id="2017836877785168846">Изчиства историята и автоматичните довършвания в адресната лента.</translation>
-<translation id="2021896219286479412">Контроли за сайтове на цял екран</translation>
-<translation id="2038563949887743358">Включване на функцията за заявяване на настолни сайтове</translation>
-<translation id="2041019821020695769">За да разрешите на Chrome да ви изпраща известия, те трябва да бъдат включени и от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> също има данни в Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /><ph name="SEPARATOR" /><ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Сайтът е на пауза</translation>
-<translation id="2063713494490388661">Търсене с докосване</translation>
-<translation id="2067805253194386918">текст</translation>
-<translation id="2079545284768500474">Отмяна</translation>
-<translation id="2082238445998314030">Резултат <ph name="RESULT_NUMBER" /> от <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Звук</translation>
-<translation id="2096012225669085171">Синхронизиране и персонализиране на всички устройства</translation>
-<translation id="2100273922101894616">Автоматичен вход</translation>
-<translation id="2100314319871056947">Опитайте да споделите текста на по-малки части</translation>
-<translation id="2107397443965016585">Запитване преди разрешаване на сайтовете да възпроизвеждат защитено съдържание (препоръчително)</translation>
-<translation id="2111511281910874386">Към страницата</translation>
-<translation id="2122601567107267586">Приложението не можа да бъде отворено</translation>
-<translation id="2126426811489709554">Предоставено от Chrome</translation>
-<translation id="2131665479022868825">Спестихте <ph name="DATA" /></translation>
-<translation id="213279576345780926">Затворихте „<ph name="TAB_TITLE" />“</translation>
-<translation id="2139186145475833000">Добавяне към началния екран</translation>
-<translation id="2146738493024040262">Отваряне на мигновеното приложение</translation>
-<translation id="2148716181193084225">Днес</translation>
-<translation id="2154484045852737596">Редактиране на картата</translation>
-<translation id="2154710561487035718">Копиране на URL адреса</translation>
-<translation id="2156074688469523661">Останали сайтове (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">За да споделите нещо от телефона си на друго устройство, включете синхронизирането от настройките за Chrome и на двете устройства</translation>
-<translation id="2170088579611075216">Разрешаване и стартиране на VR</translation>
-<translation id="218608176142494674">Споделяне</translation>
-<translation id="2227444325776770048">Продължаване като <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Синхронизиране и услуги на Google</translation>
-<translation id="2259659629660284697">Експортиране на паролите…</translation>
-<translation id="2268044343513325586">Прецизиране</translation>
-<translation id="2286841657746966508">Адрес за фактуриране</translation>
-<translation id="2289270750774289114">Извеждане на запитване, когато сайт иска да открива устройства с Bluetooth в близост (препоръчително)</translation>
-<translation id="230115972905494466">Няма намерени съвместими устройства</translation>
-<translation id="2315043854645842844">Избраният сертификат от страната на клиента не се поддържа от операционната система.</translation>
-<translation id="2318045970523081853">Докоснете за извършване на обаждане</translation>
-<translation id="2321086116217818302">Паролите се подготвят…</translation>
-<translation id="2321958826496381788">Преместете плъзгача, докато можете да четете удобно това. Текстът трябва да изглежда поне толкова голям след двукратно докосване на абзац.</translation>
-<translation id="2323763861024343754">Данни от сайтове</translation>
-<translation id="2328985652426384049">Влизането в профила не е възможно</translation>
-<translation id="2330129964253841015">Предупреждение при компрометирани пароли</translation>
-<translation id="2349710944427398404">Общо място в хранилището, което се използва от Chrome, включително за профили, отметки и запазени настройки</translation>
-<translation id="2353636109065292463">Връзката с интернет се проверява</translation>
-<translation id="2359808026110333948">Напред</translation>
-<translation id="2369533728426058518">отваряне на раздели</translation>
-<translation id="2387895666653383613">Мащабиране на текста</translation>
-<translation id="2394602618534698961">Изтеглените от вас файлове се показват тук</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> МБ</translation>
-<translation id="2407481962792080328">Когато влезете в профила си в Google, тази функция се включва</translation>
-<translation id="2410754283952462441">Изберете профил</translation>
-<translation id="2414886740292270097">Тъмно</translation>
-<translation id="2416359993254398973">Chrome се нуждае от разрешение за достъп до камерата ви за този сайт.</translation>
-<translation id="2426805022920575512">Избиране на друг профил</translation>
-<translation id="2433507940547922241">Облик</translation>
-<translation id="2434158240863470628">Изтеглянето завърши <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Достъп до местоположението</translation>
-<translation id="2450083983707403292">Искате ли да започнете да изтегляте „<ph name="FILE_NAME" />“ още веднъж?</translation>
-<translation id="2482878487686419369">Известия</translation>
-<translation id="2490684707762498678">Управляват се от <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Асистент в Chrome</translation>
-<translation id="2496180316473517155">История на сърфирането</translation>
-<translation id="2497852260688568942">Синхронизирането е деактивирано от администратора ви</translation>
-<translation id="2498359688066513246">Помощ и отзиви</translation>
-<translation id="2501278716633472235">Назад</translation>
-<translation id="2513403576141822879">За още настройки за поверителността, сигурността и събирането на данни вижте <ph name="BEGIN_LINK" />Синхронизиране и услуги на Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">В олекотения режим на Chrome страниците се зареждат по-бързо и се използват до 60 процента по-малко данни. С цел оптимизиране на посещаваните от вас страници Chrome изпраща до Google уеб трафика ви. <ph name="BEGIN_LINK" />Научете повече<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Изпраща до Google URL адресите на страниците, които посещавате</translation>
-<translation id="2532336938189706096">Изглед в мрежата</translation>
-<translation id="2534155362429831547">Изтрихте <ph name="NUMBER_OF_ITEMS" /> елемента</translation>
-<translation id="2536728043171574184">Преглеждате офлайн копие на страницата</translation>
-<translation id="2546283357679194313">„Бисквитки“ и данни за сайтове</translation>
-<translation id="2567385386134582609">ИЗОБРАЖЕНИЕ</translation>
-<translation id="257088987046510401">Теми</translation>
-<translation id="2570922361219980984">Достъпът до местоположението е изключен и за това устройство. Включете го от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Разгънато – кликнете за свиване.</translation>
-<translation id="2581165646603367611">Така ще се изчистят „бисквитките“, кешът и другата информация от сайтове, която не е важна за Chrome.</translation>
-<translation id="2586657967955657006">Буферна памет</translation>
-<translation id="2587052924345400782">Налице е по-нова версия</translation>
-<translation id="2593272815202181319">Непропорционален</translation>
-<translation id="2612676031748830579">Номер на картата</translation>
-<translation id="2621115761605608342">Разрешаване на JavaScript за конкретен сайт.</translation>
-<translation id="2625189173221582860">Паролата е копирана</translation>
-<translation id="2631006050119455616">Спестени</translation>
-<translation id="2647434099613338025">Добавяне на език</translation>
-<translation id="2650751991977523696">Да се изтегли ли отново файлът?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудиофайл}other{# аудиофайла}}</translation>
-<translation id="2653659639078652383">Изпращане</translation>
-<translation id="2677748264148917807">Излизане</translation>
-<translation id="2704606927547763573">Копирано</translation>
-<translation id="2707726405694321444">Опресняване на страницата</translation>
-<translation id="2709516037105925701">Автоматично попълване</translation>
-<translation id="2717722538473713889">Имейл адреси</translation>
-<translation id="2728754400939377704">Сортиране по сайт</translation>
-<translation id="2744248271121720757">Докоснете дума, за да извършите незабавно търсене, или вижте свързаните действия</translation>
-<translation id="2760989362628427051">Включване на тъмната тема, когато тъмната тема на устройството или режимът за запазване на батерията в него са включени</translation>
-<translation id="2762000892062317888">току-що</translation>
-<translation id="2777555524387840389">Остават <ph name="SECONDS" /> сек</translation>
-<translation id="2779651927720337254">неуспешно</translation>
-<translation id="2781151931089541271">Остава 1 сек</translation>
-<translation id="2801022321632964776">Актуализирайте, за да получите своя език в най-новата версия на Chrome</translation>
-<translation id="2810645512293415242">Страницата е опростена с цел пестене на данни и по-бързо зареждане.</translation>
-<translation id="281504910091592009">Преглеждайте и управлявайте запазените пароли в <ph name="BEGIN_LINK" />профила си в Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Влезте в профила си и включете синхронизирането, за да получите отметките си на всичките си устройства</translation>
-<translation id="2822354292072154809">Наистина ли искате да зададете повторно всички разрешения за сайта за <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Докоснете бутона за връщане назад, за да излезете от режима на цял екран.</translation>
-<translation id="2842985007712546952">Основна папка</translation>
-<translation id="2858138569776157458">Водещи сайтове</translation>
-<translation id="2860954141821109167">Трябва да има активирано приложение за телефон на устройството</translation>
-<translation id="2870560284913253234">Сайт</translation>
-<translation id="2874939134665556319">Предишен запис</translation>
-<translation id="2876369937070532032">Когато сигурността ви е застрашена, изпраща до Google URL адресите на някои от страниците, които посещавате.</translation>
-<translation id="2888126860611144412">Всичко за Chrome</translation>
-<translation id="2891154217021530873">Спиране на зареждането на страницата</translation>
-<translation id="2893180576842394309">Възможно е да използваме историята ви, за да персонализираме търсенето и други услуги на Google</translation>
-<translation id="2898264748040935573">Редактиране на съхранената парола</translation>
-<translation id="2900528713135656174">Създайте събитие</translation>
-<translation id="290376772003165898">Страницата не е на <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Списъкът с устройства, с които да се сподели даден раздел, е отворен на пълната височина.</translation>
-<translation id="2910701580606108292">Запитване преди разрешаване на сайтовете да възпроизвеждат защитено съдържание</translation>
-<translation id="2913331724188855103">Разрешаване на сайтовете да запазват „бисквитки“ и да четат данни от такива (препоръчително)</translation>
-<translation id="2923908459366352541">Името е невалидно</translation>
-<translation id="2932150158123903946">Хранилище на Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Разделът за визуализация е затворен</translation>
-<translation id="2956410042958133412">Този профил се управлява от <ph name="PARENT_NAME_1" /> и <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Превключихте към разделите в режим „инкогнито“</translation>
-<translation id="2968755619301702150">Визуализатор на сертификатите</translation>
-<translation id="2979025552038692506">Избран раздел в режим „инкогнито“</translation>
-<translation id="2987620471460279764">Текст, споделен от друго устройство</translation>
-<translation id="2989523299700148168">Наскоро посетени</translation>
-<translation id="2996291259634659425">Създаване на пропуск</translation>
-<translation id="2996809686854298943">Изисква се URL адрес</translation>
-<translation id="300526633675317032">Така ще се изчистят всички съхранявани данни от уебсайтове (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">Уверете се, че това устройство е свързано с интернет</translation>
-<translation id="3029613699374795922">Изтеглено: <ph name="KBS" /> КБ</translation>
-<translation id="3029704984691124060">Пропуските не са идентични</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Получете помощ<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Местоположението е изключено. Включете го от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Можете по всяко време да включите синхронизирането в настройките</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> отметка}other{<ph name="BOOKMARKS_COUNT_MANY" /> отметки}}</translation>
-<translation id="3089395242580810162">Отваряне в раздел „инкогнито“</translation>
-<translation id="3115898365077584848">Показване на информацията</translation>
-<translation id="3123473560110926937">Блокиране на някои сайтове</translation>
-<translation id="3137521801621304719">Напускане на режима „инкогнито“</translation>
-<translation id="3143515551205905069">Анулиране на синхронизирането</translation>
-<translation id="3157842584138209013">Използвайте бутона „Още опции“, за да видите колко данни сте спестили</translation>
-<translation id="3166827708714933426">Комбинации за раздели и прозорци</translation>
-<translation id="3181954750937456830">„Безопасно сърфиране“ (защитава вас и устройството ви от опасни сайтове)</translation>
-<translation id="3190152372525844641">Включете разрешенията за Chrome от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">Съхранявани данни: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Още съвсем малко!</translation>
-<translation id="3207960819495026254">С отметка</translation>
-<translation id="3211426585530211793">Изтрихте „<ph name="ITEM_TITLE" />“</translation>
-<translation id="321773570071367578">Ако забравите пропуска си или искате да промените тази настройка, <ph name="BEGIN_LINK" />нулирайте синхронизирането<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Микрофон</translation>
-<translation id="3232754137068452469">Уеб приложение</translation>
-<translation id="3236059992281584593">Остава 1 мин</translation>
-<translation id="3244271242291266297">ММ</translation>
-<translation id="3254409185687681395">Запазване на отметка към тази страница</translation>
-<translation id="3259831549858767975">Смаляване на всички елементи на страницата</translation>
-<translation id="3269093882174072735">Зареждане на изображението</translation>
-<translation id="3269956123044984603">Включете „Авт. синхронизиране на данните“ от „Профили“ в настройките на Android, за да получите разделите си от другите си устройства.</translation>
-<translation id="3277252321222022663">Разрешаване на достъпа на сайтовете до сензорите (препоръчително)</translation>
-<translation id="3282568296779691940">Вход в Chrome</translation>
-<translation id="3288003805934695103">Презаредете страницата.</translation>
-<translation id="32895400574683172">Известията са разрешени</translation>
-<translation id="3295530008794733555">Сърфирайте по-бързо. Използвайте по-малко данни.</translation>
-<translation id="3295602654194328831">Скриване на информацията</translation>
-<translation id="3298243779924642547">Олекотена</translation>
-<translation id="3303414029551471755">Искате ли да продължите с изтеглянето на съдържанието?</translation>
-<translation id="3306398118552023113">Това приложение се изпълнява в Chrome</translation>
-<translation id="3315103659806849044">Понастоящем персонализирате настройките си за синхронизиране и за услугите на Google. За да включите синхронизирането, докоснете бутона „Потвърждаване“ в долната част на екрана. Навигиране нагоре</translation>
-<translation id="3328801116991980348">Информация за сайта</translation>
-<translation id="3333961966071413176">Всички контакти</translation>
-<translation id="3334729583274622784">Да се промени ли файловото разширение?</translation>
-<translation id="3341058695485821946">Вижте колко данни сте спестили</translation>
-<translation id="3350687908700087792">Затваряне на всички раздели в режим „инкогнито“</translation>
-<translation id="3353615205017136254">Олекотена страница, предоставена от Google. Докоснете съответния бутон за зареждане на оригиналната.</translation>
-<translation id="3367813778245106622">Влезте в профила си отново, за да започне синхронизирането</translation>
-<translation id="3374023511497244703">Вашите отметки, история, пароли и други данни в Chrome повече няма да се синхронизират с профила ви в Google</translation>
-<translation id="3384347053049321195">Споделяне на изображението</translation>
-<translation id="3386292677130313581">Извеждане на запитване, преди на сайтовете да се разреши достъп до местоположението ви (препоръчително)</translation>
-<translation id="3387650086002190359">Изтеглянето на „<ph name="FILE_NAME" />“ не бе успешно поради грешки във файловата система.</translation>
-<translation id="3389286852084373014">Текстът е твърде голям</translation>
-<translation id="3398320232533725830">Отваряне на диспечера на отметките</translation>
-<translation id="3414952576877147120">Размер:</translation>
-<translation id="3443221991560634068">Презареждане на текущата страница</translation>
-<translation id="3445014427084483498">Току-що</translation>
-<translation id="3478363558367712427">Можете да изберете търсещата си машина</translation>
+<translation id="6910211073230771657">Изтрито</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Добре, разбрах</translation>
+<translation id="7658239707568436148">Отказ</translation>
 <translation id="3479552764303398839">Не сега</translation>
-<translation id="3492207499832628349">Нов раздел „инкогнито“</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Научете повече<ph name="END_LINK" /> за предложеното съдържание</translation>
-<translation id="3513704683820682405">Обогатена реалност</translation>
-<translation id="3518985090088779359">Приемам и напред</translation>
-<translation id="3522247891732774234">Налице е актуализация. Още опции</translation>
-<translation id="3524138585025253783">ПИ за програмисти</translation>
-<translation id="3527085408025491307">Папка</translation>
-<translation id="3542235761944717775">Свободно място: <ph name="KILOBYTES" /> КБ</translation>
-<translation id="3549657413697417275">Търсене в историята ви</translation>
-<translation id="3557336313807607643">Добавяне към контактите</translation>
-<translation id="3566923219790363270">Chrome все още се подготвя за VR. Рестартирайте браузъра по-късно.</translation>
-<translation id="3568688522516854065">Влезте в профила си и включете синхронизирането, за да получите разделите си от другите си устройства</translation>
-<translation id="3587482841069643663">Всички</translation>
-<translation id="358794129225322306">Разрешаване на сайт автоматично да изтегля няколко файла.</translation>
-<translation id="3590487821116122040">Съхранявани данни от сайтове, които Chrome не счита за важни (напр. рядко посещавани или сайтове без запазени настройки)</translation>
-<translation id="3599863153486145794">Изчиства историята от всички устройства, на които сте влезли в профила си в Google. В него може да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Спиране на звука, възпроизвеждан от сайтовете</translation>
-<translation id="3616113530831147358">Аудио</translation>
-<translation id="3631987586758005671">Споделя се с(ъс) <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Показване на паролата</translation>
-<translation id="363596933471559332">Автоматично влизане в уебсайтове посредством съхранявани идентификационни данни. Когато функцията е изключена, ще трябва да потвърждавате всяко влизане в профил в уебсайт.</translation>
-<translation id="3658159451045945436">Така ще изтриете историята на спестените данни, включително списъка с посетени сайтове.</translation>
-<translation id="3692944402865947621">Изтеглянето на <ph name="FILE_NAME" /> не бе успешно, тъй като няма достъп до местоположението за съхранение.</translation>
-<translation id="3714981814255182093">Отваряне на лентата за търсене</translation>
-<translation id="3716182511346448902">Тази страница използва твърде много памет, така че Chrome я постави на пауза.</translation>
-<translation id="3730075448226062617">За да разрешите на Chrome да осъществява достъп до микрофона ви, той трябва да бъде включен и от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Отметката бе запазена в/ъв <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Синхронизиране на заден план</translation>
-<translation id="3771001275138982843">Актуализацията не можа да бъде изтеглена</translation>
-<translation id="3771033907050503522">Раздели „инкогнито“</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Включете Bluetooth<ph name="END_LINK" />, за да разрешите сдвояването</translation>
-<translation id="3775705724665058594">Изпращане до устройствата ви</translation>
-<translation id="3778956594442850293">Добавено към началния екран</translation>
-<translation id="3789841737615482174">Инсталиране</translation>
-<translation id="3810838688059735925">Видео</translation>
-<translation id="3810973564298564668">Управление</translation>
-<translation id="381841723434055211">Телефонни номера</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> изтегляния бяха изтрити</translation>
-<translation id="3822502789641063741">Изчистване на данните?</translation>
-<translation id="385051799172605136">Назад</translation>
-<translation id="3859306556332390985">Придвижване напред</translation>
-<translation id="3894427358181296146">Добавяне на папка</translation>
-<translation id="3895926599014793903">Принудително активиране на промяната на мащаба</translation>
-<translation id="3912508018559818924">Намираме най-доброто от мрежата…</translation>
-<translation id="3927692899758076493">Безсерифен</translation>
-<translation id="3928666092801078803">Комбиниране на данните ми</translation>
-<translation id="393697183122708255">Не е налице активирано гласово търсене</translation>
-<translation id="395206256282351086">Предложенията за търсене и сайтове са деактивирани</translation>
-<translation id="3955193568934677022">Разрешаване на сайтовете да възпроизвеждат защитено съдържание (препоръчително)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome ще зареди страницата при готовност}other{Chrome ще зареди страниците при готовност}}</translation>
-<translation id="3963007978381181125">Шифроването с пропуск не включва начините на плащане и адресите от Google Pay. Само някой с пропуска ви може да прочете шифрованите ви данни – той не се изпраща до Google, нито се съхранява от нас. Ако го забравите или искате да промените тази настройка, ще се наложи да нулирате синхронизирането. <ph name="BEGIN_LINK" />Научете повече<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Изтеглянето завърши</translation>
-<translation id="397583555483684758">Синхронизирането спря да работи</translation>
-<translation id="3976396876660209797">Премахнете и създайте отново този пряк път</translation>
-<translation id="3985215325736559418">Искате ли отново да изтеглите „<ph name="FILE_NAME" />“?</translation>
-<translation id="3987993985790029246">Връзка: Коп.</translation>
-<translation id="3988213473815854515">Местоположението е разрешено</translation>
-<translation id="3988466920954086464">Отворете този панел, за да видите динамичните резултати от търсенето</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> от ?</translation>
-<translation id="3997476611815694295">Маловажни данни в хранилището</translation>
-<translation id="4000212216660919741">Начална страница в офлайн режим</translation>
+<translation id="5317780077021120954">Запазване</translation>
+<translation id="4570913071927164677">Подробности</translation>
+<translation id="8730621377337864115">Готово</translation>
+<translation id="8261506727792406068">Изтриване</translation>
+<translation id="1181037720776840403">Премахване</translation>
+<translation id="5939518447894949180">Нулиране</translation>
 <translation id="4002066346123236978">Заглавие</translation>
-<translation id="4008040567710660924">Разрешаване на „бисквитките“ за конкретен сайт.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ч}other{# ч}}</translation>
-<translation id="4046123991198612571">Следващ запис</translation>
-<translation id="4048707525896921369">Научавайте за темите в уебсайтовете, без да напускате страницата. Функцията за търсене с докосване изпраща до Google Търсене определени думи и заобикалящия ги текст и така извежда определения, снимки, резултати и други подробности.
+<translation id="5916664084637901428">Включено</translation>
+<translation id="5860033963881614850">Изключено</translation>
+<translation id="6165508094623778733">Научете повече</translation>
+<translation id="6042308850641462728">Още</translation>
+<translation id="6040143037577758943">Затваряне</translation>
+<translation id="780301667611848630">Не, благодаря</translation>
+<translation id="1201402288615127009">Напред</translation>
+<translation id="2359808026110333948">Напред</translation>
+<translation id="2653659639078652383">Изпращане</translation>
+<translation id="2079545284768500474">Отмяна</translation>
+<translation id="7649070708921625228">Помощ</translation>
+<translation id="2148716181193084225">Днес</translation>
+<translation id="7781829728241885113">Вчера</translation>
+<translation id="6945221475159498467">Избиране</translation>
+<translation id="7791543448312431591">Добавяне</translation>
+<translation id="6527303717912515753">Споделяне</translation>
+<translation id="1383876407941801731">Търсене</translation>
+<translation id="3115898365077584848">Показване на информацията</translation>
+<translation id="3295602654194328831">Скриване на информацията</translation>
+<translation id="3987993985790029246">Връзка: Коп.</translation>
+<translation id="2704606927547763573">Копирано</translation>
+<translation id="8725066075913043281">Опитайте отново</translation>
+<translation id="385051799172605136">Назад</translation>
+<translation id="8131740175452115882">Потвърждаване</translation>
+<translation id="5300589172476337783">Показване</translation>
+<translation id="1124772482545689468">Потребител</translation>
+<translation id="8609465669617005112">Придвижване нагоре</translation>
+<translation id="6746124502594467657">Придвижване надолу</translation>
+<translation id="8249310407154411074">Преместване най-горе</translation>
+<translation id="8428213095426709021">Настройки</translation>
+<translation id="2498359688066513246">Помощ и отзиви</translation>
+<translation id="8378714024927312812">Управлява се от организацията ви</translation>
+<translation id="9019902583201351841">Управлява се от родителите ви</translation>
+<translation id="4645575059429386691">Управлява се от ваш родител</translation>
+<translation id="4883854917563148705">Управляваните настройки не могат да се зададат отново</translation>
+<translation id="4307992518367153382">Основни положения</translation>
+<translation id="1974060860693918893">Разширени</translation>
+<translation id="1146678959555564648">Вход във VR</translation>
+<translation id="987264212798334818">Общи</translation>
+<translation id="4275663329226226506">Медия</translation>
+<translation id="4759238208242260848">Изтегляния</translation>
+<translation id="218608176142494674">Споделяне</translation>
+<translation id="8004582292198964060">Браузър</translation>
+<translation id="1105960400813249514">Заснемане на екрана</translation>
+<translation id="4875775213178255010">Предложения за съдържание</translation>
+<translation id="2021896219286479412">Контроли за сайтове на цял екран</translation>
+<translation id="4587589328781138893">Сайтове</translation>
+<translation id="4943703118917034429">Виртуална реалност</translation>
+<translation id="1928696683969751773">Актуализации</translation>
+<translation id="6064125863973209585">Завършени изтегляния</translation>
+<translation id="5342314432463739672">Искания за разрешение</translation>
+<translation id="629730747756840877">Профил</translation>
+<translation id="82609232232243542">Вход в Brave</translation>
+<translation id="7956662517480676674">Синхронизиране и услуги на Brave Software</translation>
+<translation id="5294439808117722387">Понастоящем персонализирате настройките си за синхронизиране и за услугите на Brave Software. За да включите синхронизирането, докоснете бутона „Потвърждаване“ в долната част на екрана. Навигиране нагоре</translation>
+<translation id="2096012225669085171">Синхронизиране и персонализиране на всички устройства</translation>
+<translation id="1692118695553449118">Синхронизирането е включено</translation>
+<translation id="5514904542973294328">Деактивирано от администратора на това устройство</translation>
+<translation id="6447211988989208781">Контроли за активността в Brave Software</translation>
+<translation id="4882831918239250449">Контролирайте начина, по който историята ви на сърфиране се използва за персонализиране на търсенето, рекламите и др.</translation>
+<translation id="7431991332293347422">Контролирайте начина, по който историята ви на сърфиране се използва за персонализиране на търсенето и др.</translation>
+<translation id="6303969859164067831">Изход от профила и изключване на синхронизирането</translation>
+<translation id="1125261911132334651">Управление на профила ви в Brave Software</translation>
+<translation id="6406506848690869874">Синхронизиранe</translation>
+<translation id="714362445477979774">Синхронизиране на данните ви в Brave</translation>
+<translation id="4314815835985389558">Управление на синхронизирането</translation>
+<translation id="5428209950370661546">Други услуги на Brave Software</translation>
+<translation id="7704317875155739195">Автоматично довършване на заявки за търсене и URL адреси</translation>
+<translation id="2000419248597011803">Изпраща някои „бисквитки“ и заявките за търсене от адресната лента и полето за търсене до стандартната ви търсеща машина</translation>
+<translation id="7981313251711023384">Предварително зареждане на страниците с цел по-бързо сърфиране и търсене</translation>
+<translation id="1821253160463689938">Използва „бисквитки“ за запомняне на предпочитанията ви дори ако не посещавате тези страници</translation>
+<translation id="6697492270171225480">Показване на предложения за подобни страници, когато дадена страница не може да бъде намерена</translation>
+<translation id="8109318360573330108">Изпраща до Brave Software URL адреса на страницата, която искате да посетите</translation>
+<translation id="8438566539970814960">Подобряване на търсенията и сърфирането</translation>
+<translation id="284843628681142937">Изпраща до Brave Software URL адресите на страниците, които посещавате</translation>
+<translation id="7222718784508482526">За още настройки за поверителността, сигурността и събирането на данни вижте <ph name="BEGIN_LINK"/>Синхронизиране и услуги на Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Помощ за подобряването на функциите и ефективността на Brave</translation>
+<translation id="9063160602596686558">Автоматично изпраща до Brave Software статистически данни за използването на Brave и сигнали за сривове</translation>
+<translation id="4824958205181053313">Да се анулира ли синхронизирането?</translation>
+<translation id="3058498974290601450">Можете по всяко време да включите синхронизирането в настройките</translation>
+<translation id="3143515551205905069">Анулиране на синхронизирането</translation>
+<translation id="1506061864768559482">Търсеща машина</translation>
+<translation id="55737423895878184">Достъпът до местоположението и известията са разрешени</translation>
+<translation id="3988213473815854515">Местоположението е разрешено</translation>
+<translation id="32895400574683172">Известията са разрешени</translation>
+<translation id="9040142327097499898">Известията са разрешени. Местоположението е изключено за това устройство.</translation>
+<translation id="305593374596241526">Местоположението е изключено. Включете го от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Наскоро посетени</translation>
+<translation id="6433501201775827830">Изберете машина за търсене</translation>
+<translation id="7177466738963138057">Можете да промените това по-късно от настройките</translation>
+<translation id="3478363558367712427">Можете да изберете търсещата си машина</translation>
+<translation id="4910889077668685004">Приложения за плащане</translation>
+<translation id="5152843274749979095">Никое от поддържаните приложения не е инсталирано</translation>
+<translation id="8812260976093120287">На някои уебсайтове можете да извършвате плащания чрез посочените по-горе поддържани приложения за плащане на устройството ви.</translation>
+<translation id="7764225426217299476">Добавяне на адрес</translation>
+<translation id="5595485650161345191">Редактиране на адреса</translation>
+<translation id="5087580092889165836">Добавяне на карта</translation>
+<translation id="2154484045852737596">Редактиране на картата</translation>
+<translation id="6140912465461743537">Държава/регион</translation>
+<translation id="5659593005791499971">Имейл</translation>
+<translation id="4378154925671717803">Телефон</translation>
+<translation id="4807098396393229769">Име върху картата</translation>
+<translation id="860043288473659153">Име на титуляря на картата</translation>
+<translation id="2612676031748830579">Номер на картата</translation>
+<translation id="869891660844655955">Дата на валидност</translation>
+<translation id="2286841657746966508">Адрес за фактуриране</translation>
+<translation id="663059986967017181">Копирано в Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Пароли</translation>
+<translation id="1943432128510653496">Запазени пароли</translation>
+<translation id="2100273922101894616">Автоматичен вход</translation>
+<translation id="363596933471559332">Автоматично влизане в уебсайтове посредством съхранявани идентификационни данни. Когато функцията е изключена, ще трябва да потвърждавате всяко влизане в профил в уебсайт.</translation>
+<translation id="6995899638241819463">Предупреждение за разкрити пароли при нарушение на сигурността на данните</translation>
+<translation id="1534287762301776620">Когато влезете в профила си в Brave Software, тази функция се включва</translation>
+<translation id="10614374240317010">Незапазвани никога</translation>
+<translation id="3098842761938485917">Преглеждайте и управлявайте запазените пароли в <ph name="BEGIN_LINK"/>профила си в Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Запазените пароли ще се покажат тук.</translation>
+<translation id="8084114998886531721">Запазена парола</translation>
+<translation id="2870560284913253234">Сайт</translation>
+<translation id="8503813439785031346">Потребителско име</translation>
+<translation id="6657585470893396449">Парола</translation>
+<translation id="2154710561487035718">Копиране на URL адреса</translation>
+<translation id="1571304935088121812">Копиране на потребителското име</translation>
+<translation id="5005498671520578047">Копиране на паролата</translation>
+<translation id="3632295766818638029">Показване на паролата</translation>
+<translation id="1513858653616922153">Изтриване на паролата</translation>
+<translation id="543338862236136125">Редактиране на паролата</translation>
+<translation id="4565377596337484307">Скриване на паролата</translation>
+<translation id="8523928698583292556">Изтриване на съхранената парола</translation>
+<translation id="2898264748040935573">Редактиране на съхранената парола</translation>
+<translation id="5433691172869980887">Потребителското име е копирано</translation>
+<translation id="5534640966246046842">Сайтът е копиран</translation>
+<translation id="2625189173221582860">Паролата е копирана</translation>
+<translation id="4550003330909367850">За да видите или копирате паролата си тук, задайте опция за заключване на екрана на това устройство.</translation>
+<translation id="6154478581116148741">Включете функцията за заключване на екрана от настройките, за да експортирате паролите си от това устройство</translation>
+<translation id="4842092870884894799">Изскачащият прозорец за генериране на пароли е показан</translation>
+<translation id="2259659629660284697">Експортиране на паролите…</translation>
+<translation id="133012818630824069">Експортиране на паролите, съхранявани в Brave</translation>
+<translation id="6914783257214138813">Паролите ви ще бъдат видими за всички, които могат да видят експортирания файл.</translation>
+<translation id="2321086116217818302">Паролите се подготвят…</translation>
+<translation id="8445448999790540984">Паролите не могат да бъдат експортирани</translation>
+<translation id="3066461326500799725">Научете как да използвате Brave Software Диск</translation>
+<translation id="729975465115245577">На устройството ви няма приложение за съхраняване на файла с паролите.</translation>
+<translation id="7682724950699840886">Изпробвайте следните съвети: Уверете се, че има достатъчно място на устройството ви. Опитайте отново да експортирате.</translation>
+<translation id="1129510026454351943">Подробности: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Отключете, за да копирате паролата си</translation>
+<translation id="5515439363601853141">Отключете, за да видите паролата си</translation>
+<translation id="6221633008163990886">Отключете, за да експортирате паролите си</translation>
+<translation id="230699814587342492">Пароли в Brave</translation>
+<translation id="6075798973483050474">Редактиране на началната страница</translation>
+<translation id="854522910157234410">Отваряне на тази страница</translation>
+<translation id="2482878487686419369">Известия</translation>
+<translation id="6255999984061454636">Предложения за съдържание</translation>
+<translation id="805047784848435650">Въз основа на историята ви на сърфиране</translation>
+<translation id="1041308826830691739">От уебсайтове</translation>
+<translation id="395206256282351086">Предложенията за търсене и сайтове са деактивирани</translation>
+<translation id="257088987046510401">Теми</translation>
+<translation id="4650364565596261010">Стандартно за системата</translation>
+<translation id="7588219262685291874">Включване на тъмната тема, когато режимът за запазване на батерията на устройството ви е включен</translation>
+<translation id="2760989362628427051">Включване на тъмната тема, когато тъмната тема на устройството или режимът за запазване на батерията в него са включени</translation>
+<translation id="6381421346744604172">Потъмняване на уебсайтовете</translation>
+<translation id="5040262127954254034">Поверителност</translation>
+<translation id="4991384657077828949">Помощ за подобряването на сигурността на Brave</translation>
+<translation id="1943176487615318915">За да открива опасни приложения и сайтове, Brave изпраща до Brave Software URL адресите на някои от страниците, които посещавате, ограничена системна информация и част от съдържанието на страниците</translation>
+<translation id="3181954750937456830">„Безопасно сърфиране“ (защитава вас и устройството ви от опасни сайтове)</translation>
+<translation id="7315322926489145388">Когато сигурността ви е застрашена, изпраща до Brave Software URL адресите на някои от страниците, които посещавате.</translation>
+<translation id="2063713494490388661">Търсене с докосване</translation>
+<translation id="2369463299479365221">Научавайте за темите в уебсайтовете, без да напускате страницата. Функцията за търсене с докосване изпраща до Brave Software Търсене определени думи и заобикалящия ги текст и така извежда определения, снимки, резултати и други подробности.
 
 За да коригирате думата си за търсене, натиснете продължително за избор. За да прецизирате заявката, плъзнете панела нагоре докрай и докоснете полето за търсене.</translation>
-<translation id="4056223980640387499">Сепия</translation>
-<translation id="4060598801229743805">Опциите са в горната част на екрана</translation>
-<translation id="4062305924942672200">Правна информация</translation>
-<translation id="4084682180776658562">Отметка</translation>
-<translation id="4084712963632273211">От <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />показва се от Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Да се изтрият ли данните на приложенията?</translation>
-<translation id="4099578267706723511">Помогнете за подобряването на Chrome, като изпращате до Google статистически данни за употребата и сигнали за сривове.</translation>
-<translation id="410351446219883937">Автоматично възпроизвеждане</translation>
-<translation id="4116038641877404294">Изтеглете страниците, за да ги използвате офлайн</translation>
-<translation id="4135200667068010335">Списъкът с устройства, с които да се сподели даден раздел, е затворен.</translation>
-<translation id="4149994727733219643">Опростен изглед на уеб страниците</translation>
-<translation id="4165986682804962316">Настройки за сайта</translation>
-<translation id="4169535189173047238">Забраняване</translation>
-<translation id="4170011742729630528">Няма достъп до услугата. Опитайте отново по-късно.</translation>
-<translation id="4179980317383591987">Използвани: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Езици</translation>
-<translation id="4183868528246477015">Търсене с Google Обектив <ph name="BEGIN_NEW" />Ново<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Отваряне в нов раздел</translation>
-<translation id="4198423547019359126">Няма местоположения за изтегляне</translation>
-<translation id="4209895695669353772">Включете синхронизирането, за да получавате персонализирано съдържание, предлагано от Google</translation>
-<translation id="4226663524361240545">Възможно е устройството да вибрира при известия</translation>
-<translation id="423219824432660969">Шифроване на синхронизираните данни с паролата за Google от <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Отваряне на настройките</translation>
-<translation id="4256782883801055595">Лицензи за отворен код</translation>
-<translation id="4259722352634471385">Навигирането е блокирано: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Копиране на адреса на връзката</translation>
-<translation id="4275663329226226506">Медия</translation>
-<translation id="4278390842282768270">Разрешено</translation>
-<translation id="429312253194641664">Сайт възпроизвежда мултимедийно съдържание</translation>
-<translation id="4298388696830689168">Свързани сайтове</translation>
-<translation id="4307992518367153382">Основни положения</translation>
-<translation id="4314815835985389558">Управление на синхронизирането</translation>
-<translation id="4351244548802238354">Затваряне на диалоговия прозорец</translation>
-<translation id="4378154925671717803">Телефон</translation>
-<translation id="4384468725000734951">За търсене ще се използва Sogou</translation>
-<translation id="4404568932422911380">Няма отметки</translation>
-<translation id="4405224443901389797">Преместване във…</translation>
-<translation id="4411535500181276704">Олекотен режим</translation>
-<translation id="4415276339145661267">Управление на профила ви в Google</translation>
-<translation id="4432792777822557199">От сега нататък страниците на <ph name="SOURCE_LANGUAGE" /> ще се превеждат на <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Олекотена страница, предоставена от Google</translation>
-<translation id="4434045419905280838">Изскач. прозорци и пренасочвания</translation>
-<translation id="4440958355523780886">Олекотена страница, предоставена от Google. Докоснете за зареждане на оригиналната.</translation>
-<translation id="4452411734226507615">Затваряне на раздела „<ph name="TAB_TITLE" />“</translation>
-<translation id="4452548195519783679">Отметката бе запазена в/ъв „<ph name="FOLDER_NAME" />“</translation>
-<translation id="445467742685312942">Разрешаване на сайтовете да възпроизвеждат защитено съдържание</translation>
-<translation id="4468959413250150279">Спиране на звука за конкретен сайт.</translation>
-<translation id="4472118726404937099">Влезте в профила си и включете синхронизирането, за да се възползвате от синхронизиране и персонализиране на всички устройства</translation>
-<translation id="447252321002412580">Помощ за подобряването на функциите и ефективността на Chrome</translation>
-<translation id="4479647676395637221">Извеждане на запитване, преди да се разреши на сайтовете да използват камерата (препоръчително)</translation>
-<translation id="4479972344484327217">Модулът „<ph name="MODULE" />“ за Chrome се инсталира…</translation>
-<translation id="4487967297491345095">Всички данни на приложението Chrome ще се изтрият за постоянно. Това включва всички файлове, настройки, профили, бази от данни и др.</translation>
-<translation id="4493497663118223949">Олекотеният режим е включен</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{преди # ден}other{преди # дни}}</translation>
-<translation id="451872707440238414">Търсене в отметките ви</translation>
-<translation id="4521489764227272523">Избраните данни са премахнати от Chrome и синхронизираните ви устройства.
-
-Възможно е в профила ви в Google да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> – например търсения и активност от други наши услуги.</translation>
-<translation id="4532845899244822526">Избиране на папка</translation>
-<translation id="4538018662093857852">Включване на олекотения режим</translation>
-<translation id="4550003330909367850">За да видите или копирате паролата си тук, задайте опция за заключване на екрана на това устройство.</translation>
-<translation id="4558311620361989323">Комбинации за уеб страници</translation>
-<translation id="4561979708150884304">Няма връзка</translation>
-<translation id="4565377596337484307">Скриване на паролата</translation>
-<translation id="4570913071927164677">Подробности</translation>
-<translation id="4572422548854449519">Вход в управляван профил</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{преди # минута}other{преди # минути}}</translation>
-<translation id="4587589328781138893">Сайтове</translation>
-<translation id="4594952190837476234">Тази офлайн страница е от <ph name="CREATION_TIME" /> и може да се различава от онлайн версията.</translation>
-<translation id="4605958867780575332">Елементът бе премахнат: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Отваряне на <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Използване на паролата</translation>
-<translation id="4645575059429386691">Управлява се от ваш родител</translation>
-<translation id="4650364565596261010">Стандартно за системата</translation>
-<translation id="4663756553811254707">Изтрихте <ph name="NUMBER_OF_BOOKMARKS" /> отметки</translation>
-<translation id="4665282149850138822">Добавихте <ph name="NAME" /> към началния екран</translation>
-<translation id="4684427112815847243">Синхронизиране на всичко</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Изпращане на текст до устройствата ви</translation>
-<translation id="4698034686595694889">Офлайн преглед в <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Кеширани изображения и файлове</translation>
-<translation id="4714588616299687897">Икономисвайте до 60% от данните</translation>
-<translation id="4719927025381752090">Предложения за превод</translation>
-<translation id="4720023427747327413">Отваряне в <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Помогнете за подобряването на Chrome. <ph name="BEGIN_LINK" />Участвайте в анкетата<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Актуализиране</translation>
-<translation id="4738836084190194332">Последно синхронизиране: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Отваряне на нов раздел</translation>
-<translation id="4751476147751820511">Сензори за движение или светлина</translation>
-<translation id="4759238208242260848">Изтегляния</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 изтегляне завърши.}other{# изтегляния завършиха.}}</translation>
-<translation id="4797039098279997504">Докоснете, за да се върнете към <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Шифроването с пропуск не включва начините на плащане и адресите от Google Pay.
-
-За да промените тази настройка, <ph name="BEGIN_LINK" />нулирайте синхронизирането<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Име върху картата</translation>
-<translation id="4824958205181053313">Да се анулира ли синхронизирането?</translation>
-<translation id="4837753911714442426">Отваряне на опциите за отпечатване на страницата</translation>
-<translation id="4842092870884894799">Изскачащият прозорец за генериране на пароли е показан</translation>
-<translation id="4860895144060829044">Обаждане</translation>
-<translation id="4866368707455379617">Модулът „<ph name="MODULE" />“ за Chrome не може да се инсталира</translation>
-<translation id="4875775213178255010">Предложения за съдържание</translation>
-<translation id="4878404682131129617">Създаването на тунел през прокси сървъра не бе успешно</translation>
-<translation id="4880127995492972015">Превод…</translation>
-<translation id="4881695831933465202">Отваряне</translation>
-<translation id="488187801263602086">Преименуване на файла</translation>
-<translation id="4882831918239250449">Контролирайте начина, по който историята ви на сърфиране се използва за персонализиране на търсенето, рекламите и др.</translation>
-<translation id="4883854917563148705">Управляваните настройки не могат да се зададат отново</translation>
-<translation id="4885273946141277891">Неподдържан брой екземпляри на Chrome.</translation>
-<translation id="4910889077668685004">Приложения за плащане</translation>
-<translation id="4913161338056004800">Нулиране на статистическите данни</translation>
-<translation id="4913169188695071480">Спиране на опресняването</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Получете помощ<ph name="END_LINK" />, докато се сканира за устройства…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# страница}other{# страници}}</translation>
-<translation id="4932247056774066048">Тъй като излизате от профил, управляван от <ph name="DOMAIN_NAME" />, данните ви в Chrome ще бъдат изтрити от това устройство. Те ще останат в профила ви в Google.</translation>
-<translation id="4943703118917034429">Виртуална реалност</translation>
-<translation id="4943872375798546930">Няма резултати</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> споделя екрана ви</translation>
-<translation id="4961107849584082341">Превод на тази страница на който и да е език</translation>
-<translation id="4962975101802056554">Отмяна на всички разрешения за устройството</translation>
-<translation id="4970824347203572753">Не се предлага за местоположението ви</translation>
-<translation id="497421865427891073">Преминаване напред</translation>
-<translation id="4988210275050210843">Изтегля се файл (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Страници</translation>
-<translation id="4994033804516042629">Няма намерени контакти</translation>
-<translation id="4996978546172906250">Споделяне чрез</translation>
-<translation id="5004416275253351869">Контроли за активността в Google</translation>
-<translation id="5005498671520578047">Копиране на паролата</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> иска да се свърже</translation>
-<translation id="5013696553129441713">Няма нови предложения</translation>
-<translation id="5016205925109358554">Серифен</translation>
-<translation id="5033865233969348410">Когато стартирате VR, този сайт може да научи за:
-  – физическите ви черти, напр. височина.
-
-Проверете дали имате доверие на този сайт, преди да стартирате VR.</translation>
+<translation id="2930742481329940825">При търсене с докосване избраната дума и текущата страница се изпращат като контекст до Brave Software Търсене. Можете да изключите функцията от <ph name="BEGIN_LINK"/>Настройки<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Разрешаване</translation>
-<translation id="5040262127954254034">Поверителност</translation>
-<translation id="5048398596102334565">Разрешаване на достъпа на сайтовете до сензорите за движение (препоръчително)</translation>
-<translation id="5063480226653192405">Употреба</translation>
-<translation id="5087580092889165836">Добавяне на карта</translation>
-<translation id="5100237604440890931">Свито – кликнете за разгъване.</translation>
-<translation id="510275257476243843">Остава 1 час</translation>
-<translation id="5123685120097942451">Раздел в режим „инкогнито“</translation>
-<translation id="5127805178023152808">Синхронизирането е изключено</translation>
-<translation id="5129038482087801250">Инстал. на уеб приложението</translation>
-<translation id="5132942445612118989">Синхронизиране на паролите, историята ви и др. на всички устройства</translation>
-<translation id="5139940364318403933">Научете как да използвате Google Диск</translation>
-<translation id="515227803646670480">Изчистване на съхраняваните данни</translation>
-<translation id="5152843274749979095">Никое от поддържаните приложения не е инсталирано</translation>
-<translation id="5161254044473106830">Изисква се заглавие</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 изтегляне не бе успешно.}other{# изтегляния не бяха успешни.}}</translation>
-<translation id="5170568018924773124">Показване в папката</translation>
-<translation id="5184329579814168207">Отваряне в Chrome</translation>
-<translation id="5193988420012215838">Копирано в буферната памет</translation>
-<translation id="5197729504361054390">Избраните от вас контакти ще бъдат споделени със сайта <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Служебен потребителски профил</translation>
-<translation id="5210286577605176222">Преминаване към предишния раздел</translation>
-<translation id="5210365745912300556">Затваряне на раздела</translation>
-<translation id="5224771365102442243">С видеоклип</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> иска да сканира за устройства с Bluetooth в близост. Намерени са следните:</translation>
-<translation id="5233638681132016545">Нов раздел</translation>
-<translation id="526421993248218238">Тази страница не може да се зареди</translation>
-<translation id="5271967389191913893">Устройството не може да отвори съдържанието за изтегляне.</translation>
-<translation id="528192093759286357">Плъзнете пръст от горната част на екрана и докоснете бутона за връщане назад, за да излезете от режима на цял екран.</translation>
-<translation id="5292796745632149097">Изпращане до</translation>
-<translation id="5300589172476337783">Показване</translation>
-<translation id="5301954838959518834">Добре, разбрах</translation>
-<translation id="5304593522240415983">Това поле трябва да се попълни</translation>
-<translation id="5307446750509046227">Изчистване на данните</translation>
-<translation id="5308380583665731573">Свързване</translation>
-<translation id="5313967007315987356">Добавяне на сайт</translation>
-<translation id="5317780077021120954">Запазване</translation>
-<translation id="5324858694974489420">Родителски настройки</translation>
-<translation id="5327248766486351172">Име</translation>
-<translation id="5335288049665977812">Разрешаване на сайтовете да изпълняват JavaScript (препоръчително)</translation>
-<translation id="5342314432463739672">Искания за разрешение</translation>
-<translation id="5357811892247919462">Получихте раздел</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> отворен раздел. Докоснете за превключване между разделите}other{<ph name="OPEN_TABS_MANY" /> отворени раздела. Докоснете за превключване между тях}}</translation>
-<translation id="5391532827096253100">Връзката ви с този сайт не е защитена. Информация за сайта</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(и още 1)}other{(и още #)}}</translation>
-<translation id="5400569084694353794">С използването на това приложение приемате <ph name="BEGIN_LINK1" />Общите условия<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Съобщението за поверителност<ph name="END_LINK2" /> на Chrome.</translation>
-<translation id="5403592356182871684">Имена</translation>
-<translation id="5403644198645076998">Разрешаване само на конкретни сайтове</translation>
-<translation id="5414836363063783498">Потвърждава се…</translation>
-<translation id="5423934151118863508">Най-посещаваните от вас страници ще се показват тук</translation>
-<translation id="5424588387303617268">Налични: <ph name="GIGABYTES" /> ГБ</translation>
-<translation id="543338862236136125">Редактиране на паролата</translation>
-<translation id="5433691172869980887">Потребителското име е копирано</translation>
-<translation id="543509235395288790">Изтеглят се <ph name="COUNT" /> файла (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Преминаване към адресната лента</translation>
-<translation id="5447201525962359567">Всички данни от сайтове, включително „бисквитки“ и друга локално съхранявана информация</translation>
-<translation id="5447765697759493033">Този сайт няма да се превежда</translation>
-<translation id="545042621069398927">Изтеглянето се ускорява.</translation>
-<translation id="5456381639095306749">Изтегляне на страницата</translation>
-<translation id="5475862044948910901">Искате ли да стартирате сесия с обогатена реалност?</translation>
-<translation id="548278423535722844">Отваряне в приложение за карти</translation>
-<translation id="5487521232677179737">Изчиств. на данните</translation>
-<translation id="5494752089476963479">Блокиране на рекламите от сайтове, на които се показват натрапчиви или подвеждащи реклами</translation>
-<translation id="5500777121964041360">Може да не се предлага за местоположението ви</translation>
-<translation id="5512137114520586844">Този профил се управлява от <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Деактивирано от администратора на това устройство</translation>
-<translation id="5515439363601853141">Отключете, за да видите паролата си</translation>
-<translation id="5516455585884385570">Отваряне на настройките за известия</translation>
-<translation id="5517095782334947753">Имате отметки, история, пароли и други настройки от <ph name="FROM_ACCOUNT" /></translation>
-<translation id="5524843473235508879">Блокирано бе пренасочване.</translation>
-<translation id="5527082711130173040">Chrome се нуждае от достъп до местоположението, за да сканира за устройства. <ph name="BEGIN_LINK1" />Актуализирайте разрешенията<ph name="END_LINK1" />. Също така услугите за местоположение са <ph name="BEGIN_LINK2" />изключени за това устройство<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Извеждане на запитване, преди да се разреши на сайтовете да четат текста и изображенията от буферната памет (препоръчително)</translation>
-<translation id="5530766185686772672">Раздели „инкогнито“: Затв.</translation>
-<translation id="5534334044554683961">Когато стартирате VR, този сайт може да научи за:
-  – физическите ви черти, като височина;
-  – плана на стаята ви.
-
-Проверете дали имате доверие на този сайт, преди да стартирате VR.</translation>
-<translation id="5534640966246046842">Сайтът е копиран</translation>
-<translation id="5556459405103347317">Повторно зареждане</translation>
-<translation id="5561549206367097665">Изчаква се връзка с мрежата…</translation>
-<translation id="557283862590186398">Chrome се нуждае от разрешение за достъп до микрофона ви за този сайт.</translation>
-<translation id="55737423895878184">Достъпът до местоположението и известията са разрешени</translation>
-<translation id="5578795271662203820">Търсене на изображението със: <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Винаги можете да изберете какво да се синхронизира от <ph name="BEGIN_LINK1" />настройките<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Редактиране на адреса</translation>
-<translation id="5596627076506792578">Още опции</translation>
-<translation id="5599455543593328020">Режим „инкогнито“</translation>
-<translation id="5620928963363755975">Използвайте бутона „Още опции“, за да намерите файловете и страниците си в „Изтегляния“</translation>
-<translation id="5626134646977739690">Име:</translation>
-<translation id="5639724618331995626">Разрешаване на всички сайтове</translation>
-<translation id="5648166631817621825">Последните 7 дни</translation>
-<translation id="5649053991847567735">Автоматични изтегляния</translation>
-<translation id="5655963694829536461">Търсете в изтеглянията</translation>
-<translation id="5659593005791499971">Имейл</translation>
-<translation id="5665379678064389456">Създайте събитие в <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Отмяна на искането на уебсайта да не се допуска увеличаване на мащаба</translation>
-<translation id="5677928146339483299">Блокирано</translation>
-<translation id="5684874026226664614">Ами сега! Тази страница не можа да се преведе.</translation>
-<translation id="5686790454216892815">Името на файла е твърде дълго</translation>
-<translation id="5689516760719285838">Местоположение</translation>
-<translation id="569536719314091526">Страницата може да бъде преведена на който и да е език чрез бутона за още опции</translation>
-<translation id="572328651809341494">Скорошни раздели</translation>
-<translation id="5726692708398506830">Уголемяване на всички елементи на страницата</translation>
-<translation id="5748802427693696783">Превключихте към стандартните раздели</translation>
-<translation id="5749068826913805084">Chrome се нуждае от достъп до хранилището, за да изтегля файлове.</translation>
-<translation id="5763382633136178763">Раздели в режим „инкогнито“</translation>
-<translation id="5763514718066511291">Докоснете, за да копирате URL адреса за това приложение</translation>
-<translation id="5765780083710877561">Описание:</translation>
-<translation id="5793665092639000975">Използвано място: <ph name="SPACE_USED" /> от <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Възможно е да използваме историята ви, за да персонализираме търсенето, рекламите и други услуги на Google</translation>
-<translation id="5804241973901381774">Разрешения</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{преди # час}other{преди # часа}}</translation>
-<translation id="5810288467834065221">Авторски права <ph name="YEAR" /> г. Google LLC. Всички права запазени.</translation>
-<translation id="5817918615728894473">Сдвояване</translation>
-<translation id="583281660410589416">Неизвестно</translation>
-<translation id="5833984609253377421">Споделяне на връзката</translation>
-<translation id="5836192821815272682">Актуализацията на Chrome се изтегля…</translation>
-<translation id="5853623416121554550">на пауза</translation>
-<translation id="5854790677617711513">По-стари от 30 дни</translation>
-<translation id="5858741533101922242">Chrome не може да включи адаптера за Bluetooth</translation>
-<translation id="5860033963881614850">Изключено</translation>
-<translation id="5862731021271217234">Включете синхронизирането, за да получите разделите си от другите си устройства</translation>
-<translation id="5864174910718532887">Подробности: сортирани по име на сайта</translation>
-<translation id="5864419784173784555">Изчаква се друго изтегляне…</translation>
-<translation id="5865733239029070421">Автоматично изпраща до Google статистически данни за използването на Chrome и сигнали за сривове</translation>
-<translation id="5869522115854928033">Запазени пароли</translation>
-<translation id="5902828464777634901">Ще се изтрият всички локални данни, съхранявани от този уебсайт, включително „бисквитките“.</translation>
-<translation id="5916664084637901428">Включено</translation>
-<translation id="5919204609460789179">Актуализирайте <ph name="PRODUCT_NAME" />, за да стартира синхронизирането</translation>
-<translation id="5937580074298050696">Спестени: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Нулиране</translation>
-<translation id="5942872142862698679">За търсене ще се използва Google</translation>
-<translation id="5952764234151283551">Изпраща до Google URL адреса на страницата, която искате да посетите</translation>
-<translation id="5956665950594638604">Отваряне на Помощния център на Chrome в нов раздел</translation>
-<translation id="5958275228015807058">Намерете файловете и страниците си в „Изтегляния“</translation>
-<translation id="5962718611393537961">Докоснете за свиване</translation>
-<translation id="6000066717592683814">Запазване на Google</translation>
-<translation id="6005538289190791541">Предложена парола</translation>
-<translation id="6036057147555329831">допълнителният ICU модул</translation>
-<translation id="6039379616847168523">Преминаване към следващия раздел</translation>
-<translation id="6040143037577758943">Затваряне</translation>
-<translation id="6042308850641462728">Още</translation>
-<translation id="604996488070107836">Изтеглянето на „<ph name="FILE_NAME" />“ не бе успешно поради неизвестна грешка.</translation>
-<translation id="605721222689873409">ГГ</translation>
-<translation id="6064125863973209585">Завършени изтегляния</translation>
-<translation id="6075798973483050474">Редактиране на началната страница</translation>
-<translation id="60923314841986378">Остават <ph name="HOURS" /> часа</translation>
-<translation id="6108923351542677676">Извършва се настройване…</translation>
-<translation id="6111020039983847643">използвани данни</translation>
-<translation id="6112702117600201073">Опресняване на страницата</translation>
-<translation id="6127379762771434464">Елементът бе премахнат</translation>
-<translation id="6140912465461743537">Държава/регион</translation>
-<translation id="614940544461990577">Изпробвайте следното:</translation>
-<translation id="6154478581116148741">Включете функцията за заключване на екрана от настройките, за да експортирате паролите си от това устройство</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> икономия на данни</translation>
-<translation id="6165508094623778733">Научете повече</translation>
-<translation id="6177111841848151710">Блокирано за текущата търсеща машина</translation>
-<translation id="6181444274883918285">Добавяне на изключение за сайт</translation>
-<translation id="6192333916571137726">Изтегляне на файл</translation>
-<translation id="6192792657125177640">Изключения</translation>
-<translation id="6194112207524046168">За да разрешите на Chrome да осъществява достъп до камерата ви, тя трябва да бъде включена и от <ph name="BEGIN_LINK" />настройките на Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Блокиране на „бисквитките“ на трети страни</translation>
-<translation id="6206551242102657620">Връзката е защитена. Информация за сайта</translation>
-<translation id="6210748933810148297">Не сте <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Отключете, за да експортирате паролите си</translation>
+<translation id="1406000523432664303">Заявка „Do Not Track“</translation>
 <translation id="6232535412751077445">Активирането на „Do Not Track“ означава, че с трафика ви на сърфиране ще се подава заявка. Ефектите зависят от това, дали уебсайтът ще отговори на нея и как ще я изтълкува.
 
 Някои уебсайтове например може да отговорят на тази заявка, като ви покажат реклами, които не се базират на други посетени от вас сайтове. Много уебсайтове ще продължат да събират и използват данните ви за сърфиране – например с цел подобряване на сигурността, предоставяне на съдържание, реклами и препоръки и генериране на статистически данни за отчитане.</translation>
-<translation id="624789221780392884">Актуализацията е готова</translation>
-<translation id="6255999984061454636">Предложения за съдържание</translation>
-<translation id="6277522088822131679">При отпечатването на страницата възникна проблем. Моля, опитайте отново.</translation>
-<translation id="6295158916970320988">Всички сайтове</translation>
-<translation id="629730747756840877">Профил</translation>
-<translation id="6303969859164067831">Изход от профила и изключване на синхронизирането</translation>
-<translation id="6316139424528454185">Неподдържана версия на Android</translation>
-<translation id="6320088164292336938">Вибриране</translation>
-<translation id="6324034347079777476">Системното синхронизиране под Android е деактивирано</translation>
-<translation id="6333140779060797560">Споделяне чрез <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Шифроване</translation>
-<translation id="6341580099087024258">Извеждане на запитване къде да се запазват файловете</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Предложението да се премахне ли от историята?</translation>
-<translation id="6369229450655021117">Оттук можете да търсите в мрежата, да споделяте с приятели и да преглеждате отворените страници</translation>
-<translation id="6378173571450987352">Подробности: сортирани по количество използвани данни</translation>
-<translation id="6381421346744604172">Потъмняване на уебсайтовете</translation>
-<translation id="6388207532828177975">Изчистване и нулиране</translation>
-<translation id="6393863479814692971">Chrome се нуждае от разрешение за достъп до камерата и микрофона ви за този сайт.</translation>
-<translation id="6395288395575013217">ВРЪЗКА</translation>
-<translation id="6404511346730675251">Редактиране на отметката</translation>
-<translation id="6406506848690869874">Синхронизиранe</translation>
-<translation id="641643625718530986">Печат…</translation>
-<translation id="6416782512398055893">Изтеглено: <ph name="MBS" /> МБ</translation>
-<translation id="6427112570124116297">Превод на всичко в мрежата</translation>
-<translation id="6433501201775827830">Изберете машина за търсене</translation>
-<translation id="6437478888915024427">Информация за страницата</translation>
-<translation id="6441734959916820584">Името е твърде дълго</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# изображение}other{# изображения}}</translation>
-<translation id="6447842834002726250">„Бисквитки“</translation>
-<translation id="6461962085415701688">Файлът не може да бъде отворен</translation>
-<translation id="6464977750820128603">Можете да преглеждате сайтовете, които посещавате в Chrome, и да задавате таймери за тях.\n\nGoogle получава информация относно сайтовете, за които задавате таймери, и продължителността на посещенията ви. Тези данни се използват за подобряването на „Дигитално благополучие“.</translation>
-<translation id="6475951671322991020">Изтегляне на видеоклипа</translation>
-<translation id="6482749332252372425">Изтеглянето на „<ph name="FILE_NAME" />“ не бе успешно поради липса на място в хранилището.</translation>
-<translation id="6496823230996795692">За да използвате <ph name="APP_NAME" /> за първи път, моля, свържете се с интернет.</translation>
-<translation id="6508722015517270189">Рестартирайте Chrome.</translation>
-<translation id="6527303717912515753">Споделяне</translation>
-<translation id="6532866250404780454">Посетените от вас сайтове в Chrome няма да се показват. Всички таймери за сайтове ще бъдат изтрити.</translation>
-<translation id="6534565668554028783">Google не отговаря твърде дълго време</translation>
-<translation id="6538442820324228105">Изтеглено: <ph name="GBS" /> ГБ</translation>
-<translation id="6539092367496845964">Нещо се обърка. Опитайте пак по-късно.</translation>
-<translation id="654446541061731451">Изберете раздел за излъчване</translation>
-<translation id="6545017243486555795">Изчистване на всички данни</translation>
-<translation id="6545864417968258051">Сканиране за устройства с Bluetooth</translation>
-<translation id="6560414384669816528">Търсене със Sogou</translation>
-<translation id="6566259936974865419">Chrome ви спести <ph name="GIGABYTES" /> ГБ</translation>
-<translation id="6573096386450695060">Разрешаване винаги</translation>
-<translation id="6573431926118603307">Тук ще се показват разделите, които сте отворили в Chrome на другите си устройства.</translation>
-<translation id="6583199322650523874">Запазване на отметка към текущата страница</translation>
-<translation id="6593061639179217415">Настолен сайт</translation>
-<translation id="6600954340915313787">Копирано в Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> ГБ</translation>
-<translation id="6612358246767739896">Защитено съдържание</translation>
-<translation id="6627583120233659107">Редактиране на папката</translation>
-<translation id="6643016212128521049">Изчистване</translation>
-<translation id="6643649862576733715">Сортирайте по количество спестени данни</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Визуализация <ph name="BEGIN_NEW" />Ново<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome се нуждае от достъп до местоположението, за да сканира за устройства. <ph name="BEGIN_LINK" />Актуализиране на разрешенията<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Парола</translation>
-<translation id="6659594942844771486">Раздел</translation>
-<translation id="666731172850799929">Отваряне в <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Съобщение за поверителност на Chrome</translation>
-<translation id="6676840375528380067">Искате ли данните ви в Chrome да бъдат изчистени от устройството?</translation>
-<translation id="6697492270171225480">Показване на предложения за подобни страници, когато дадена страница не може да бъде намерена</translation>
-<translation id="6697947395630195233">Chrome се нуждае от достъп до данните за местоположението ви, за да ги сподели с този сайт.</translation>
-<translation id="6698801883190606802">Управление на синхронизираните данни</translation>
-<translation id="6699370405921460408">Сървърите на Google ще оптимизират посещаваните от вас страници.</translation>
-<translation id="6706288973712894588">Понастоящем сте офлайн.\n<ph name="BEGIN_LINK" />Разгледайте емисията си в офлайн режим.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Новини</translation>
-<translation id="6710213216561001401">Предишна</translation>
-<translation id="671481426037969117">Таймерът ви за <ph name="FQDN" /> изтече и ще се стартира отново утре.</translation>
-<translation id="6738867403308150051">Изтегля се…</translation>
-<translation id="6746124502594467657">Придвижване надолу</translation>
-<translation id="6766622839693428701">Прекарайте пръст надолу, за да затворите.</translation>
-<translation id="6766758767654711248">Докоснете, за да посетите сайта</translation>
-<translation id="6767294960381293877">Списъкът с устройства, с които да се сподели даден раздел, е отворен на половин височина.</translation>
-<translation id="6782111308708962316">Забраняване на уебсайтовете на трети страни да запазват и четат данни в „бисквитки“</translation>
-<translation id="6790428901817661496">Пускане</translation>
-<translation id="6811034713472274749">Страницата е готова за преглед</translation>
-<translation id="6818926723028410516">Избор на елементи</translation>
-<translation id="6820686453637990663">Код за сигурност</translation>
-<translation id="6831043979455480757">Превод</translation>
-<translation id="6845325883481699275">Помощ за подобряването на сигурността на Chrome</translation>
-<translation id="6846298663435243399">Зарежда се…</translation>
-<translation id="6850409657436465440">Изтеглянето продължава</translation>
-<translation id="6850830437481525139">Затворихте <ph name="TAB_COUNT" /> раздела</translation>
-<translation id="6864459304226931083">Изтегляне на изображението</translation>
-<translation id="6865313869410766144">Данни за автоматично попълване на формуляри</translation>
-<translation id="688738109438487280">Добавяне на съществуващите данни към <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Отключете, за да копирате паролата си</translation>
-<translation id="6896758677409633944">Копиране</translation>
-<translation id="6910211073230771657">Изтрито</translation>
-<translation id="6912998170423641340">Забраняване на сайтовете да четат текста и изображенията от буферната памет</translation>
-<translation id="6914783257214138813">Паролите ви ще бъдат видими за всички, които могат да видят експортирания файл.</translation>
-<translation id="6942665639005891494">Променете стандартното местоположение за изтегляне по всяко време чрез опцията в менюто „Настройки“</translation>
-<translation id="6945221475159498467">Избиране</translation>
-<translation id="6963642900430330478">Тази страница е опасна. Информация за сайта</translation>
-<translation id="6963766334940102469">Изтриване на отметките</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">За цялото време</translation>
-<translation id="6981982820502123353">Достъпност</translation>
-<translation id="6989267951144302301">Неуспешно изтегляне</translation>
-<translation id="6990079615885386641">Изтегляне на приложението от Google Play Магазин: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Извеждане на запитване, преди да се разреши на сайтовете да използват микрофона (препоръчително)</translation>
-<translation id="7015203776128479407">Първоначалното настройване на синхронизирането не бе завършено. Синхронизирането е изключено.</translation>
-<translation id="7016516562562142042">Разрешено за текущата търсеща машина</translation>
-<translation id="7022756207310403729">Отваряне в браузъра</translation>
-<translation id="702463548815491781">Препоръчва се, когато TalkBack или достъпът с превключване са задействани</translation>
-<translation id="7029809446516969842">Пароли</translation>
-<translation id="7053983685419859001">Блокиране</translation>
-<translation id="7055152154916055070">Блокирано бе пренасочване:</translation>
-<translation id="7063006564040364415">Не можа да се установи връзка със синхронизиращия сървър.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Избрана е 1}other{Избрани са #}}</translation>
-<translation id="7071521146534760487">Управление на профила</translation>
-<translation id="7077143737582773186">SD карта</translation>
-<translation id="7087918508125750058">Избрани: <ph name="ITEM_COUNT" />. Налице са опции близо до горната част на екрана</translation>
-<translation id="7121362699166175603">Изчиства историята и автоматичните довършвания в адресната лента. В профила ви в Google може да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Разрешаване за текущата търсеща машина</translation>
-<translation id="7138678301420049075">Друго</translation>
-<translation id="7141896414559753902">Блокиране на показването на изскачащи прозорци и пренасочвания от сайтовете (препоръчително)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Зареждане на оригиналната страница<ph name="END_LINK" /> от <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Последните 24 часа</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> КБ</translation>
-<translation id="7177466738963138057">Можете да промените това по-късно от настройките</translation>
-<translation id="7180611975245234373">Опресняване</translation>
-<translation id="7189372733857464326">Изчаква се актуализирането на услугите за Google Play да приключи</translation>
-<translation id="7191430249889272776">Разделът е отворен на заден план.</translation>
-<translation id="723171743924126238">Избиране на изображения</translation>
-<translation id="7233236755231902816">За да виждате съдържанието в мрежата на своя език, изтеглете най-новата версия на Chrome</translation>
-<translation id="7243308994586599757">Опциите са в долната част на екрана</translation>
-<translation id="7248069434667874558">Уверете се, че синхронизирането в Chrome е включено за <ph name="TARGET_DEVICE_NAME" /></translation>
-<translation id="7250468141469952378">Избрани: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Блокиран сайт</translation>
-<translation id="7290209999329137901">Преименуването не е възможно</translation>
-<translation id="7291387454912369099">Плащане с помощта на Асистент</translation>
-<translation id="7293171162284876153">За да стартирате синхронизирането, включете „Синхронизиране на данните ви в Chrome“.</translation>
-<translation id="729975465115245577">На устройството ви няма приложение за съхраняване на файла с паролите.</translation>
-<translation id="7302081693174882195">Подробности: сортирани по количество спестени данни</translation>
-<translation id="7328017930301109123">В олекотения режим на Chrome страниците се зареждат по-бързо и се използват до 60 процента по-малко данни.</translation>
-<translation id="7333031090786104871">Още се добавя предишният сайт</translation>
-<translation id="7352939065658542140">ВИДЕОКЛИП</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Споделяне на 1 избран елемент}other{Споделяне на # избрани елемента}}</translation>
 <translation id="7359002509206457351">Достъп до начините на плащане</translation>
+<translation id="8026334261755873520">Изчистване на данните за сърфирането</translation>
+<translation id="1291207594882862231">Изчистване на историята, „бисквитките“, данните за сайтове и кеша…</translation>
+<translation id="7814200940910057384">Данните в Brave са изчистени</translation>
+<translation id="1664855196866195614">Избраните данни са премахнати от Brave и синхронизираните ви устройства.
+
+Възможно е в профила ви в Brave Software да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> – например търсения и активност от други наши услуги.</translation>
+<translation id="4699172675775169585">Кеширани изображения и файлове</translation>
+<translation id="2496180316473517155">История на сърфирането</translation>
+<translation id="2546283357679194313">„Бисквитки“ и данни за сайтове</translation>
+<translation id="8662811608048051533">Ще излезете от повечето сайтове.</translation>
+<translation id="8218628800671693884">Ще излезете от повечето сайтове, но не и от профила си в Brave Software.</translation>
+<translation id="2017836877785168846">Изчиства историята и автоматичните довършвания в адресната лента.</translation>
+<translation id="8096327394278038498">Изчиства историята и автоматичните довършвания в адресната лента. В профила ви в Brave Software може да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Изчиства историята от всички устройства, на които сте влезли в профила си в Brave Software. В него може да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Запазени пароли</translation>
+<translation id="6865313869410766144">Данни за автоматично попълване на формуляри</translation>
+<translation id="7562080006725997899">Данните за сърфирането се изчистват</translation>
+<translation id="5487521232677179737">Изчиств. на данните</translation>
+<translation id="7498271377022651285">Моля, изчакайте...</translation>
+<translation id="784934925303690534">Период от време</translation>
+<translation id="1718835860248848330">Последния час</translation>
+<translation id="7149893636342594995">Последните 24 часа</translation>
+<translation id="5648166631817621825">Последните 7 дни</translation>
+<translation id="8571213806525832805">Последните 4 седмици</translation>
+<translation id="5854790677617711513">По-стари от 30 дни</translation>
+<translation id="6979737339423435258">За цялото време</translation>
+<translation id="982182592107339124">Това действие ще изчисти данните за всички сайтове, включително:</translation>
+<translation id="6643016212128521049">Изчистване</translation>
+<translation id="7641339528570811325">Изчистване на данните за сърфирането…</translation>
+<translation id="1670399744444387456">Основни</translation>
+<translation id="3245261285041759672">В профила ви в Brave Software може да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Блокиран сайт</translation>
+<translation id="2534155362429831547">Изтрихте <ph name="NUMBER_OF_ITEMS"/> елемента</translation>
+<translation id="1121094540300013208">Отчети за употребата и сигнали за сривове</translation>
+<translation id="9079153198295609735">Автоматично изпращане до Brave Software на статистически данни за използването на Brave и сигнали за сривове</translation>
+<translation id="6981982820502123353">Достъпност</translation>
+<translation id="2387895666653383613">Мащабиране на текста</translation>
+<translation id="2321958826496381788">Преместете плъзгача, докато можете да четете удобно това. Текстът трябва да изглежда поне толкова голям след двукратно докосване на абзац.</translation>
+<translation id="3895926599014793903">Принудително активиране на промяната на мащаба</translation>
+<translation id="5668404140385795438">Отмяна на искането на уебсайта да не се допуска увеличаване на мащаба</translation>
+<translation id="4149994727733219643">Опростен изглед на уеб страниците</translation>
+<translation id="9100505651305367705">Извеждане на предложение статиите да се показват в опростен изглед, когато се поддържа</translation>
+<translation id="1409426117486808224">Опростен изглед на отворените раздели</translation>
+<translation id="702463548815491781">Препоръчва се, когато TalkBack или достъпът с превключване са задействани</translation>
+<translation id="8284326494547611709">Надписи</translation>
+<translation id="4165986682804962316">Настройки за сайта</translation>
+<translation id="6295158916970320988">Всички сайтове</translation>
+<translation id="8380167699614421159">На този сайт се показват натрапчиви или подвеждащи реклами</translation>
+<translation id="1919345977826869612">Реклами</translation>
+<translation id="410351446219883937">Автоматично възпроизвеждане</translation>
+<translation id="6447842834002726250">„Бисквитки“</translation>
+<translation id="6196640612572343990">Блокиране на „бисквитките“ на трети страни</translation>
+<translation id="6782111308708962316">Забраняване на уебсайтовете на трети страни да запазват и четат данни в „бисквитки“</translation>
+<translation id="7521387064766892559">Javascript</translation>
+<translation id="4434045419905280838">Изскач. прозорци и пренасочвания</translation>
+<translation id="4751476147751820511">Сензори за движение или светлина</translation>
+<translation id="1717218214683051432">Сензори за движение</translation>
+<translation id="2091887806945687916">Звук</translation>
+<translation id="2586657967955657006">Буферна памет</translation>
+<translation id="6320088164292336938">Вибриране</translation>
+<translation id="4226663524361240545">Възможно е устройството да вибрира при известия</translation>
+<translation id="1446450296470737166">Разр. на пълния контрол над MIDI</translation>
+<translation id="3744111561329211289">Синхронизиране на заден план</translation>
+<translation id="5649053991847567735">Автоматични изтегляния</translation>
+<translation id="6181444274883918285">Добавяне на изключение за сайт</translation>
+<translation id="5313967007315987356">Добавяне на сайт</translation>
+<translation id="1369915414381695676">Сайтът <ph name="SITE_NAME"/> е добавен</translation>
+<translation id="7837721118676387834">Разрешаване на автоматичното възпроизвеждане на видеоклипове със заглушен звук за конкретен сайт.</translation>
+<translation id="2621115761605608342">Разрешаване на JavaScript за конкретен сайт.</translation>
+<translation id="8801436777607969138">Блокиране на JavaScript за конкретен сайт.</translation>
+<translation id="8372893542064058268">Разрешаване на синхронизирането на заден план за конкретен сайт.</translation>
+<translation id="358794129225322306">Разрешаване на сайт автоматично да изтегля няколко файла.</translation>
+<translation id="4008040567710660924">Разрешаване на „бисквитките“ за конкретен сайт.</translation>
+<translation id="8958424370300090006">Блокиране на „бисквитките“ за конкретен сайт.</translation>
+<translation id="7882806643839505685">Разрешаване на звука за конкретен сайт.</translation>
+<translation id="4468959413250150279">Спиране на звука за конкретен сайт.</translation>
+<translation id="1994173015038366702">URL адрес на сайт</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Употреба</translation>
+<translation id="5804241973901381774">Разрешения</translation>
+<translation id="4278390842282768270">Разрешено</translation>
+<translation id="5677928146339483299">Блокирано</translation>
+<translation id="1984937141057606926">Разрешено, но не и за трети страни</translation>
+<translation id="7423098979219808738">Първо ще се извежда запитване</translation>
+<translation id="8116925261070264013">Заглушени</translation>
+<translation id="8300705686683892304">Управлявани от приложение</translation>
+<translation id="6192792657125177640">Изключения</translation>
+<translation id="257931822824936280">Разгънато – кликнете за свиване.</translation>
+<translation id="5100237604440890931">Свито – кликнете за разгъване.</translation>
+<translation id="857943718398505171">Разрешено (препоръчително)</translation>
+<translation id="2913331724188855103">Разрешаване на сайтовете да запазват „бисквитки“ и да четат данни от такива (препоръчително)</translation>
+<translation id="7445411102860286510">Разрешаване на сайтовете автоматично да възпроизвеждат видеоклипове със заглушен звук (препоръчително)</translation>
+<translation id="5335288049665977812">Разрешаване на сайтовете да изпълняват JavaScript (препоръчително)</translation>
+<translation id="5527111080432883924">Извеждане на запитване, преди да се разреши на сайтовете да четат текста и изображенията от буферната памет (препоръчително)</translation>
+<translation id="6912998170423641340">Забраняване на сайтовете да четат текста и изображенията от буферната памет</translation>
+<translation id="7423538860840206698">Достъпът за четене до буферната памет е блокиран</translation>
+<translation id="3955193568934677022">Разрешаване на сайтовете да възпроизвеждат защитено съдържание (препоръчително)</translation>
+<translation id="445467742685312942">Разрешаване на сайтовете да възпроизвеждат защитено съдържание</translation>
+<translation id="2107397443965016585">Запитване преди разрешаване на сайтовете да възпроизвеждат защитено съдържание (препоръчително)</translation>
+<translation id="2910701580606108292">Запитване преди разрешаване на сайтовете да възпроизвеждат защитено съдържание</translation>
+<translation id="757524316907819857">Блокиране на възможността на сайтовете да възпроизвеждат защитено съдържание</translation>
+<translation id="3277252321222022663">Разрешаване на достъпа на сайтовете до сензорите (препоръчително)</translation>
+<translation id="5048398596102334565">Разрешаване на достъпа на сайтовете до сензорите за движение (препоръчително)</translation>
+<translation id="8816026460808729765">Блокиране на достъпа на сайтовете до сензорите</translation>
+<translation id="169515064810179024">Блокиране на достъпа на сайтовете до сензорите за движение</translation>
+<translation id="1660204651932907780">Разрешаване на сайтовете да възпроизвеждат звук (препоръчително)</translation>
+<translation id="3600792891314830896">Спиране на звука, възпроизвеждан от сайтовете</translation>
+<translation id="1743802530341753419">Извеждане на запитване, преди да се разреши на сайтовете да се свържат с устройство (препоръчително)</translation>
+<translation id="851751545965956758">Блокиране на сайтовете, така че да не се свързват с устройства</translation>
+<translation id="7141896414559753902">Блокиране на показването на изскачащи прозорци и пренасочвания от сайтовете (препоръчително)</translation>
+<translation id="5494752089476963479">Блокиране на рекламите от сайтове, на които се показват натрапчиви или подвеждащи реклами</translation>
+<translation id="3123473560110926937">Блокиране на някои сайтове</translation>
+<translation id="965817943346481315">Блокиране, ако на сайта се показват натрапчиви или подвеждащи реклами (препоръчително)</translation>
+<translation id="3386292677130313581">Извеждане на запитване, преди на сайтовете да се разреши достъп до местоположението ви (препоръчително)</translation>
+<translation id="9139068048179869749">Извеждане на запитване, преди да се разреши на сайтовете да изпращат известия (препоръчително)</translation>
+<translation id="4479647676395637221">Извеждане на запитване, преди да се разреши на сайтовете да използват камерата (препоръчително)</translation>
+<translation id="6992289844737586249">Извеждане на запитване, преди да се разреши на сайтовете да използват микрофона (препоръчително)</translation>
+<translation id="2289270750774289114">Извеждане на запитване, когато сайт иска да открива устройства с Bluetooth в близост (препоръчително)</translation>
+<translation id="7053983685419859001">Блокиране</translation>
+<translation id="7128222689758636196">Разрешаване за текущата търсеща машина</translation>
+<translation id="7589445247086920869">Блокиране за текущата търсеща машина</translation>
+<translation id="6388207532828177975">Изчистване и нулиране</translation>
+<translation id="7999064672810608036">Наистина ли искате да изчистите всички локални данни, включително „бисквитките“, и да нулирате всички разрешения за този уебсайт?</translation>
+<translation id="2822354292072154809">Наистина ли искате да зададете повторно всички разрешения за сайта за <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Изчистване на съхраняваните данни</translation>
+<translation id="5902828464777634901">Ще се изтрият всички локални данни, съхранявани от този уебсайт, включително „бисквитките“.</translation>
+<translation id="119944043368869598">Изчистване на всички</translation>
+<translation id="2490684707762498678">Управляват се от <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Отваряне на настройките за известия</translation>
+<translation id="1404122904123200417">Вградено в(ъв) <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Тук се показват файловете, запазени от уебсайтове</translation>
+<translation id="4181841719683918333">Езици</translation>
+<translation id="2647434099613338025">Добавяне на език</translation>
+<translation id="1952172573699511566">Когато е възможно, текстът на уебсайтовете ще се показва на предпочитания от вас език.</translation>
+<translation id="8559990750235505898">Извеждане на предложения за превод на страниците, написани на други езици</translation>
+<translation id="4719927025381752090">Предложения за превод</translation>
+<translation id="8156139159503939589">Какви езици четете?</translation>
+<translation id="5689516760719285838">Местоположение</translation>
+<translation id="2440823041667407902">Достъп до местоположението</translation>
+<translation id="2023546461831060654">Включете разрешенията за Brave от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Включете разрешението за Brave от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">За да разрешите на Brave да осъществява достъп до местоположението ви, то трябва да бъде включено и от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">За да разрешите на Brave да осъществява достъп до камерата ви, тя трябва да бъде включена и от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">За да разрешите на Brave да ви изпраща известия, те трябва да бъдат включени и от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">За да разрешите на Brave да осъществява достъп до микрофона ви, той трябва да бъде включен и от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Достъпът до местоположението е изключен за това устройство. Включете го от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Достъпът до местоположението е изключен и за това устройство. Включете го от <ph name="BEGIN_LINK"/>настройките на Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Камера</translation>
+<translation id="3227137524299004712">Микрофон</translation>
+<translation id="1647391597548383849">Достъп до камерата</translation>
+<translation id="945632385593298557">Достъп до микрофона</translation>
+<translation id="6612358246767739896">Защитено съдържание</translation>
+<translation id="885701979325669005">Хранилище</translation>
+<translation id="3198916472715691905">Съхранявани данни: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Отмяна на разрешението за достъп до устройството</translation>
+<translation id="4962975101802056554">Отмяна на всички разрешения за устройството</translation>
+<translation id="6545864417968258051">Сканиране за устройства с Bluetooth</translation>
+<translation id="4411535500181276704">Олекотен режим</translation>
+<translation id="7821588508402923572">Тук ще се показва количеството икономисани данни</translation>
+<translation id="2131665479022868825">Спестихте <ph name="DATA"/></translation>
+<translation id="8569404424186215731">от <ph name="DATE"/></translation>
+<translation id="3252158532344029638">В олекотения режим на Brave страниците се зареждат по-бързо и се използват до 60 процента по-малко данни.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> икономия на данни</translation>
+<translation id="7494974237137038751">спестени данни</translation>
+<translation id="6111020039983847643">използвани данни</translation>
+<translation id="7413229368719586778">Начална дата: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Крайна дата: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Сортиране по сайт</translation>
+<translation id="5864174910718532887">Подробности: сортирани по име на сайта</translation>
+<translation id="116280672541001035">Използвани</translation>
+<translation id="8349013245300336738">Сортиране по количеството използвани данни</translation>
+<translation id="6378173571450987352">Подробности: сортирани по количество използвани данни</translation>
+<translation id="2631006050119455616">Спестени</translation>
+<translation id="6643649862576733715">Сортирайте по количество спестени данни</translation>
+<translation id="7302081693174882195">Подробности: сортирани по количество спестени данни</translation>
+<translation id="4179980317383591987">Използвани: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Спестени: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Останали сайтове (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Друго</translation>
+<translation id="4913161338056004800">Нулиране на статистическите данни</translation>
+<translation id="1856325424225101786">Да се нулира ли олекотеният режим?</translation>
+<translation id="3658159451045945436">Така ще изтриете историята на спестените данни, включително списъка с посетени сайтове.</translation>
+<translation id="3295530008794733555">Сърфирайте по-бързо. Използвайте по-малко данни.</translation>
+<translation id="7340390500800578919">В олекотения режим на Brave страниците се зареждат по-бързо и се използват до 60 процента по-малко данни. С цел оптимизиране на посещаваните от вас страници Brave изпраща до Brave Software уеб трафика ви. <ph name="BEGIN_LINK"/>Научете повече<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Включване на олекотения режим</translation>
+<translation id="4493497663118223949">Олекотеният режим е включен</translation>
+<translation id="7559975015014302720">Олекотеният режим е изключен</translation>
+<translation id="7606077192958116810">Олекотеният режим е включен. Можете да го управлявате от настройките.</translation>
+<translation id="4714588616299687897">Икономисвайте до 60% от данните</translation>
+<translation id="1006927014032731288">Сървърите на Brave Software ще оптимизират посещаваните от вас страници.</translation>
+<translation id="3257320067425202300">Brave ви спести <ph name="MEGABYTES"/> МБ</translation>
+<translation id="5813223329348543512">Brave ви спести <ph name="GIGABYTES"/> ГБ</translation>
+<translation id="8266862848225348053">Местоположение за изтеглянията</translation>
+<translation id="7077143737582773186">SD карта</translation>
+<translation id="7762668264895820836">SD карта <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Извеждане на запитване къде да се запазват файловете</translation>
+<translation id="6192333916571137726">Изтегляне на файл</translation>
+<translation id="1672586136351118594">Да не се показва отново</translation>
+<translation id="2650751991977523696">Да се изтегли ли отново файлът?</translation>
+<translation id="8664979001105139458">Името на файла вече съществува</translation>
+<translation id="488187801263602086">Преименуване на файла</translation>
+<translation id="5686790454216892815">Името на файла е твърде дълго</translation>
+<translation id="7454641608352164238">Няма достатъчно място</translation>
+<translation id="8972098258593396643">Да се изтегли ли файлът в стандартната папка?</translation>
+<translation id="804335162455518893">SD картата не е намерена</translation>
+<translation id="7475688122056506577">SD картата не е намерена. Някои файлове може да липсват.</translation>
+<translation id="4198423547019359126">Няма местоположения за изтегляне</translation>
+<translation id="8224471946457685718">Изтегляне на статиите за вас през Wi-Fi</translation>
+<translation id="4970824347203572753">Не се предлага за местоположението ви</translation>
+<translation id="5500777121964041360">Може да не се предлага за местоположението ви</translation>
+<translation id="1173894706177603556">Преименуване</translation>
+<translation id="1986685561493779662">Името вече съществува</translation>
+<translation id="6441734959916820584">Името е твърде дълго</translation>
+<translation id="2923908459366352541">Името е невалидно</translation>
+<translation id="7290209999329137901">Преименуването не е възможно</translation>
+<translation id="3334729583274622784">Да се промени ли файловото разширение?</translation>
+<translation id="107147699690128016">Ако промените файловото разширение, файлът може да се отвори в друго приложение и потенциално да навреди на устройството ви.</translation>
+<translation id="8541922081612557424">Всичко за Brave</translation>
+<translation id="5311273890481188673">Авторски права <ph name="YEAR"/> г. Brave Software LLC. Всички права запазени.</translation>
+<translation id="1416550906796893042">Версия на приложението</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Актуализирано: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Операционна система</translation>
+<translation id="3968054912784331254">Актуализациите на Brave вече не се поддържат за тази версия на Android</translation>
+<translation id="7665369617277396874">Добавяне на профил</translation>
+<translation id="649070405679044769">Влезли сте в Brave Software като</translation>
+<translation id="6234515504547364178">Изход от Brave</translation>
+<translation id="5324858694974489420">Родителски настройки</translation>
+<translation id="8920114477895755567">Изчакват се подробности за родителите.</translation>
+<translation id="5512137114520586844">Този профил се управлява от <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Този профил се управлява от <ph name="PARENT_NAME_1"/> и <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Съдържание</translation>
+<translation id="5403644198645076998">Разрешаване само на конкретни сайтове</translation>
+<translation id="8641930654639604085">Опит за блокиране на сайтовете за пълнолетни</translation>
+<translation id="5639724618331995626">Разрешаване на всички сайтове</translation>
+<translation id="796823723482603597">Предоставено от Brave</translation>
+<translation id="6324034347079777476">Системното синхронизиране под Android е деактивирано</translation>
+<translation id="5127805178023152808">Синхронизирането е изключено</translation>
+<translation id="7015203776128479407">Първоначалното настройване на синхронизирането не бе завършено. Синхронизирането е изключено.</translation>
+<translation id="2497852260688568942">Синхронизирането е деактивирано от администратора ви</translation>
+<translation id="9100610230175265781">Изисква се пропуск</translation>
+<translation id="6108923351542677676">Извършва се настройване…</translation>
+<translation id="4062305924942672200">Правна информация</translation>
+<translation id="4256782883801055595">Лицензи за отворен код</translation>
+<translation id="1138681184697033370">Общи условия на Brave</translation>
+<translation id="7392539049993970338">Съобщение за поверителност на Brave</translation>
+<translation id="2677748264148917807">Излизане</translation>
+<translation id="5556459405103347317">Повторно зареждане</translation>
+<translation id="1623104350909869708">Да не се създават допълнителни диалогови прозорци от тази страница</translation>
+<translation id="2968755619301702150">Визуализатор на сертификатите</translation>
+<translation id="1360432990279830238">Изход и изключване на синхронизирането?</translation>
+<translation id="8581481290581777242">Искате ли данните ви в Brave да бъдат изчистени от устройството?</translation>
+<translation id="1318865768845061710">Вашите отметки, история, пароли и други данни в Brave повече няма да се синхронизират с профила ви в Brave Software</translation>
+<translation id="3325020657155065477">Изчистване на данните ви в Brave и от това устройство</translation>
+<translation id="6136448902816743006">Тъй като излизате от профил, управляван от <ph name="DOMAIN_NAME"/>, данните ви в Brave ще бъдат изтрити от това устройство. Те ще останат в профила ви в Brave Software.</translation>
+<translation id="1853026300647876496">Установява се връзка с Brave Software. Това може да отнеме известно време…</translation>
+<translation id="2328985652426384049">Влизането в профила не е възможно</translation>
+<translation id="7723158744459952869">Brave Software не отговаря твърде дълго време</translation>
+<translation id="4572422548854449519">Вход в управляван профил</translation>
+<translation id="2689656545739939160">Влизате с профил, управляван от <ph name="MANAGED_DOMAIN"/>, и предоставяте на администратора му контрол върху данните си в Brave. Те ще се свържат за постоянно с този профил. При излизане от профила в браузъра информацията ви ще се изтрие от устройството, но ще продължи да се съхранява в профила ви в Brave Software.</translation>
+<translation id="1749561566933687563">Синхронизирайте отметките си</translation>
+<translation id="4242533952199664413">Отваряне на настройките</translation>
+<translation id="1111673857033749125">Тук ще се показват отметките, които сте запазили на другите си устройства.</translation>
+<translation id="8636825310635137004">Включете синхронизирането, за да получите разделите си от другите си устройства.</translation>
+<translation id="3269956123044984603">Включете „Авт. синхронизиране на данните“ от „Профили“ в настройките на Android, за да получите разделите си от другите си устройства.</translation>
+<translation id="5157964048453367290">Тук ще се показват разделите, които сте отворили в Brave на другите си устройства.</translation>
+<translation id="4684427112815847243">Синхронизиране на всичко</translation>
+<translation id="2709516037105925701">Автоматично попълване</translation>
+<translation id="8820817407110198400">Отметки</translation>
+<translation id="1644574205037202324">История</translation>
+<translation id="17513872634828108">Отворени раздели</translation>
+<translation id="1320169905922104972">Кредитни карти и адреси посредством Brave Software Pay</translation>
+<translation id="6337234675334993532">Шифроване</translation>
+<translation id="6698801883190606802">Управление на синхронизираните данни</translation>
+<translation id="3598578758776312506">Шифроване на паролите с идентификационните данни за Brave Software</translation>
+<translation id="7810580217418711046">Шифроване на синхронизираните данни с паролата за Brave Software от <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Шифроване на синхронизираните данни със собствения ви пропуск за синхронизиране</translation>
+<translation id="2996291259634659425">Създаване на пропуск</translation>
+<translation id="5713644099811900409">Профил в Brave Software</translation>
+<translation id="8997474919031554666">Шифроването с пропуск не включва начините на плащане и адресите от Brave Software Pay. Само някой с пропуска ви може да прочете шифрованите ви данни – той не се изпраща до Brave Software, нито се съхранява от нас. Ако го забравите или искате да промените тази настройка, ще се наложи да нулирате синхронизирането. <ph name="BEGIN_LINK"/>Научете повече<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Парола</translation>
+<translation id="7772032839648071052">Потвърдете пропуска</translation>
+<translation id="5304593522240415983">Това поле трябва да се попълни</translation>
+<translation id="321773570071367578">Ако забравите пропуска си или искате да промените тази настройка, <ph name="BEGIN_LINK"/>нулирайте синхронизирането<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Пропуските не са идентични</translation>
+<translation id="5149495116300586333">Шифроването с пропуск не включва начините на плащане и адресите от Brave Software Pay.
+
+За да промените тази настройка, <ph name="BEGIN_LINK"/>нулирайте синхронизирането<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Неправилен пропуск</translation>
+<translation id="5414836363063783498">Потвърждава се…</translation>
+<translation id="6846298663435243399">Зарежда се…</translation>
+<translation id="5517095782334947753">Имате отметки, история, пароли и други настройки от <ph name="FROM_ACCOUNT"/></translation>
+<translation id="3928666092801078803">Комбиниране на данните ми</translation>
+<translation id="688738109438487280">Добавяне на съществуващите данни към <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Оставяне на данните отделно</translation>
+<translation id="1145536944570833626">Изтриване на съществуващите данни.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> иска да се сдвои</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Получете помощ<ph name="END_LINK"/>, докато се сканира за устройства…</translation>
+<translation id="5817918615728894473">Сдвояване</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Получете помощ<ph name="END_LINK1"/> или <ph name="BEGIN_LINK2"/>сканирайте отново<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Няма намерени съвместими устройства</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Включете Bluetooth<ph name="END_LINK"/>, за да разрешите сдвояването</translation>
+<translation id="998321811308652668">Brave не може да включи адаптера за Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Получете помощ<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave се нуждае от достъп до местоположението, за да сканира за устройства. <ph name="BEGIN_LINK"/>Актуализиране на разрешенията<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave се нуждае от достъп до местоположението, за да сканира за устройства, но съответните услуги са <ph name="BEGIN_LINK"/>изключени за това устройство<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave се нуждае от достъп до местоположението, за да сканира за устройства. <ph name="BEGIN_LINK1"/>Актуализирайте разрешенията<ph name="END_LINK1"/>. Също така услугите за местоположение са <ph name="BEGIN_LINK2"/>изключени за това устройство<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Свързано устройство</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Сила на сигнала: # чертичка}other{Сила на сигнала: # чертички}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> иска да сканира за устройства с Bluetooth в близост. Намерени са следните:</translation>
+<translation id="8368027906805972958">Неизвестно или неподдържано устройство (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Синхронизирането не работи</translation>
+<translation id="1810845389119482123">Първоначалното настройване на синхронизирането не завърши</translation>
+<translation id="3235722914093408050">За старт на синхронизирането активирайте системното синхронизиране на Android</translation>
+<translation id="3367813778245106622">Влезте в профила си отново, за да започне синхронизирането</translation>
+<translation id="974555521953189084">Въведете своя пропуск, за да започне синхронизирането</translation>
+<translation id="2997266899014181325">За да стартирате синхронизирането, включете „Синхронизиране на данните ви в Brave“.</translation>
+<translation id="8260126382462817229">Опитайте да влезете отново</translation>
+<translation id="5919204609460789179">Актуализирайте <ph name="PRODUCT_NAME"/>, за да стартира синхронизирането</translation>
+<translation id="397583555483684758">Синхронизирането спря да работи</translation>
+<translation id="1966710179511230534">Моля, актуализирайте данните си за вход.</translation>
+<translation id="7063006564040364415">Не можа да се установи връзка със синхронизиращия сървър.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> не е актуален.</translation>
+<translation id="4170011742729630528">Няма достъп до услугата. Опитайте отново по-късно.</translation>
+<translation id="7947953824732555851">Приемам и влизам</translation>
+<translation id="8583805026567836021">Данните от профила се изчистват</translation>
+<translation id="8310344678080805313">Стандартни раздели</translation>
+<translation id="5748802427693696783">Превключихте към стандартните раздели</translation>
+<translation id="7998918019931843664">Повторно отваряне на затворения раздел</translation>
+<translation id="8853345339104747198">„<ph name="TAB_TITLE"/>“ – раздел</translation>
+<translation id="4452411734226507615">Затваряне на раздела „<ph name="TAB_TITLE"/>“</translation>
+<translation id="7243308994586599757">Опциите са в долната част на екрана</translation>
+<translation id="4060598801229743805">Опциите са в горната част на екрана</translation>
+<translation id="2810645512293415242">Страницата е опростена с цел пестене на данни и по-бързо зареждане.</translation>
+<translation id="3985215325736559418">Искате ли отново да изтеглите „<ph name="FILE_NAME"/>“?</translation>
+<translation id="2450083983707403292">Искате ли да започнете да изтегляте „<ph name="FILE_NAME"/>“ още веднъж?</translation>
+<translation id="7514365320538308">Изтегляне</translation>
+<translation id="545042621069398927">Изтеглянето се ускорява.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Изтегля се файл.}other{Изтеглят се # файла.}}</translation>
+<translation id="543509235395288790">Изтеглят се <ph name="COUNT"/> файла (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Изтегля се файл (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 изтегляне завърши.}other{# изтегляния завършиха.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 изтегляне не бе успешно.}other{# изтегляния не бяха успешни.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Предстои 1 изтегляне.}other{Предстоят # изтегляния.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> бутон „<ph name="LINK_NAME"/>“</translation>
+<translation id="3205824638308738187">Още съвсем малко!</translation>
+<translation id="3960299545138990065">Рестартирайте Brave.</translation>
+<translation id="3771001275138982843">Актуализацията не можа да бъде изтеглена</translation>
+<translation id="3888648114124182147">Актуализацията на Brave се изтегля…</translation>
+<translation id="1705567146636171298">Актуализиране на Brave</translation>
+<translation id="6195417478702700398">За оптимално сърфиране отворете, за да актуализирате Brave</translation>
+<translation id="3512968675351418494">За да виждате съдържанието в мрежата на своя език, изтеглете най-новата версия на Brave</translation>
+<translation id="6427112570124116297">Превод на всичко в мрежата</translation>
+<translation id="1379423114029199501">Актуализирайте, за да получите своя език в най-новата версия на Brave</translation>
+<translation id="5684874026226664614">Ами сега! Тази страница не можа да се преведе.</translation>
+<translation id="6831043979455480757">Превод</translation>
+<translation id="1285320974508926690">Този сайт да не се превежда никога</translation>
+<translation id="773466115871691567">Страниците на <ph name="SOURCE_LANGUAGE"/> да се превеждат винаги</translation>
+<translation id="1068672505746868501">Страниците на <ph name="SOURCE_LANGUAGE"/> да не се превеждат</translation>
+<translation id="124116460088058876">Още езици</translation>
+<translation id="290376772003165898">Страницата не е на <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">От сега нататък страниците на <ph name="SOURCE_LANGUAGE"/> ще се превеждат на <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Страниците на <ph name="LANGUAGE"/> няма да се превеждат</translation>
+<translation id="5447765697759493033">Този сайт няма да се превежда</translation>
+<translation id="4880127995492972015">Превод…</translation>
+<translation id="641643625718530986">Печат…</translation>
+<translation id="8909135823018751308">Споделяне…</translation>
+<translation id="4996978546172906250">Споделяне чрез</translation>
+<translation id="6333140779060797560">Споделяне чрез <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">При отпечатването на страницата възникна проблем. Моля, опитайте отново.</translation>
+<translation id="3254409185687681395">Запазване на отметка към тази страница</translation>
+<translation id="497421865427891073">Преминаване напред</translation>
+<translation id="813082847718468539">Преглед на информацията за сайта</translation>
+<translation id="2532336938189706096">Изглед в мрежата</translation>
+<translation id="6005538289190791541">Предложена парола</translation>
+<translation id="4634124774493850572">Използване на паролата</translation>
+<translation id="8285489906452138776">Brave се нуждае от разрешение за достъп до камерата ви за този сайт.</translation>
+<translation id="320189792589364011">Brave се нуждае от разрешение за достъп до микрофона ви за този сайт.</translation>
+<translation id="7988136689212463100">Brave се нуждае от разрешение за достъп до камерата и микрофона ви за този сайт.</translation>
+<translation id="4931190655840828017">Brave се нуждае от достъп до данните за местоположението ви, за да ги сподели с този сайт.</translation>
+<translation id="3088191967551450609">Brave се нуждае от достъп до хранилището, за да изтегля файлове.</translation>
+<translation id="8942627711005830162">Отваряне в другия прозорец</translation>
+<translation id="4195643157523330669">Отваряне в нов раздел</translation>
+<translation id="1100066534610197918">Отваряне в нов раздел в група</translation>
+<translation id="4860895144060829044">Обаждане</translation>
+<translation id="6896758677409633944">Копиране</translation>
+<translation id="8393700583063109961">Изпратете съобщение</translation>
+<translation id="3557336313807607643">Добавяне към контактите</translation>
+<translation id="4269820728363426813">Копиране на адреса на връзката</translation>
+<translation id="1206892813135768548">Копиране на текста на връзката</translation>
+<translation id="1204037785786432551">Изтегляне на връзката</translation>
+<translation id="6864459304226931083">Изтегляне на изображението</translation>
+<translation id="8209050860603202033">Отваряне на изображението</translation>
+<translation id="8073388330009372546">Отваряне в нов раздел</translation>
+<translation id="6649642165559792194">Визуализация <ph name="BEGIN_NEW"/>Ново<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Зареждане на изображението</translation>
+<translation id="3845332215609790146">Търсене с Brave Software Обектив <ph name="BEGIN_NEW"/>Ново<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Търсене на изображението със: <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Споделяне на изображението</translation>
+<translation id="5833984609253377421">Споделяне на връзката</translation>
+<translation id="6475951671322991020">Изтегляне на видеоклипа</translation>
+<translation id="2317945146070194624">Отваряне в нов раздел в Brave</translation>
+<translation id="7975379999046275268">Визуализация <ph name="BEGIN_NEW"/>Ново<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Опресняване на страницата</translation>
+<translation id="36525718899759834">Изтегляне на приложението от Brave Software Play Магазин: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Тъмно</translation>
+<translation id="1807246157184219062">Светло</translation>
+<translation id="4056223980640387499">Сепия</translation>
+<translation id="3927692899758076493">Безсерифен</translation>
+<translation id="5016205925109358554">Серифен</translation>
+<translation id="2593272815202181319">Непропорционален</translation>
+<translation id="9206873250291191720">А</translation>
+<translation id="654446541061731451">Изберете раздел за излъчване</translation>
+<translation id="8719023831149562936">Текущият раздел не може да се излъчи</translation>
+<translation id="2139186145475833000">Добавяне към началния екран</translation>
+<translation id="4616150815774728855">Отваряне на <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Приложението не можа да бъде отворено</translation>
+<translation id="5129038482087801250">Инстал. на уеб приложението</translation>
+<translation id="3789841737615482174">Инсталиране</translation>
+<translation id="4665282149850138822">Добавихте <ph name="NAME"/> към началния екран</translation>
+<translation id="7333031090786104871">Още се добавя предишният сайт</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> се добавя...</translation>
+<translation id="3778956594442850293">Добавено към началния екран</translation>
+<translation id="2146738493024040262">Отваряне на мигновеното приложение</translation>
+<translation id="7016516562562142042">Разрешено за текущата търсеща машина</translation>
+<translation id="6177111841848151710">Блокирано за текущата търсеща машина</translation>
+<translation id="145097072038377568">Изключено от настройките на Android</translation>
+<translation id="8007176423574883786">Изключено за това устройство</translation>
+<translation id="164269334534774161">Преглеждате офлайн копие на тази страница, създадено на <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Тази офлайн страница е от <ph name="CREATION_TIME"/> и може да се различава от онлайн версията.</translation>
+<translation id="8840953339110955557">Тази страница може да се различава от онлайн версията.</translation>
+<translation id="6405300764336705484">Това съдържание се показва от Brave Software, а източникът му е <ph name="DOMAIN_NAME"/>.</translation>
+<translation id="1006017844123154345">Отваряне онлайн</translation>
+<translation id="3326636747541519688">Олекотена страница, предоставена от Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Зареждане на оригиналната страница<ph name="END_LINK"/> от <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Ако виждате това често, изпробвайте тези <ph name="BEGIN_LINK"/>предложения<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Съдържанието е скрито</translation>
+<translation id="3810973564298564668">Управление</translation>
+<translation id="5199929503336119739">Служебен потребителски профил</translation>
+<translation id="528192093759286357">Плъзнете пръст от горната част на екрана и докоснете бутона за връщане назад, за да излезете от режима на цял екран.</translation>
+<translation id="2836148919159985482">Докоснете бутона за връщане назад, за да излезете от режима на цял екран.</translation>
+<translation id="3967822245660637423">Изтеглянето завърши</translation>
+<translation id="2434158240863470628">Изтеглянето завърши <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Изтеглянето не бе успешно</translation>
+<translation id="1384959399684842514">Изтеглянето е на пауза</translation>
+<translation id="1671236975893690980">Предстои изтегляне…</translation>
+<translation id="5561549206367097665">Изчаква се връзка с мрежата…</translation>
+<translation id="5864419784173784555">Изчаква се друго изтегляне…</translation>
+<translation id="6461962085415701688">Файлът не може да бъде отворен</translation>
+<translation id="1178581264944972037">Пауза</translation>
+<translation id="8200772114523450471">Възобновяване</translation>
+<translation id="1409879593029778104">Изтеглянето на „<ph name="FILE_NAME"/>“ е предотвратено, защото файлът вече съществува.</translation>
+<translation id="3387650086002190359">Изтеглянето на „<ph name="FILE_NAME"/>“ не бе успешно поради грешки във файловата система.</translation>
+<translation id="6482749332252372425">Изтеглянето на „<ph name="FILE_NAME"/>“ не бе успешно поради липса на място в хранилището.</translation>
+<translation id="7619072057915878432">Изтеглянето на „<ph name="FILE_NAME"/>“ не бе успешно поради грешки в мрежата.</translation>
+<translation id="1477626028522505441">Изтеглянето на „<ph name="FILE_NAME"/>“ не бе успешно поради проблеми в сървъра.</translation>
+<translation id="3692944402865947621">Изтеглянето на <ph name="FILE_NAME"/> не бе успешно, тъй като няма достъп до местоположението за съхранение.</translation>
+<translation id="604996488070107836">Изтеглянето на „<ph name="FILE_NAME"/>“ не бе успешно поради неизвестна грешка.</translation>
+<translation id="6738867403308150051">Изтегля се…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> КБ</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> МБ</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> ГБ</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> от ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> от <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Изтеглено: <ph name="KBS"/> КБ</translation>
+<translation id="6416782512398055893">Изтеглено: <ph name="MBS"/> МБ</translation>
+<translation id="6538442820324228105">Изтеглено: <ph name="GBS"/> ГБ</translation>
+<translation id="9204836675896933765">Остава 1 файл</translation>
+<translation id="8186512483418048923">Остават <ph name="FILES"/> файла</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> файл бе изтеглен}other{<ph name="FILES_DOWNLOADED_MANY"/> файла бяха изтеглени}}</translation>
+<translation id="8037750541064988519">Остават <ph name="DAYS"/> дни</translation>
+<translation id="8190358571722158785">Остава 1 ден</translation>
+<translation id="60923314841986378">Остават <ph name="HOURS"/> часа</translation>
+<translation id="510275257476243843">Остава 1 час</translation>
+<translation id="970715775301869095">Остават <ph name="MINUTES"/> мин</translation>
+<translation id="3236059992281584593">Остава 1 мин</translation>
+<translation id="2777555524387840389">Остават <ph name="SECONDS"/> сек</translation>
+<translation id="2781151931089541271">Остава 1 сек</translation>
+<translation id="3303414029551471755">Искате ли да продължите с изтеглянето на съдържанието?</translation>
+<translation id="8617240290563765734">Да се отвори ли предложеният URL адрес, посочен в изтегленото съдържание?</translation>
+<translation id="1373696734384179344">Недостатъчно памет за изтегляне на избраното съдържание.</translation>
+<translation id="5271967389191913893">Устройството не може да отвори съдържанието за изтегляне.</translation>
+<translation id="883806473910249246">При изтеглянето на съдържанието възникна грешка.</translation>
+<translation id="5626134646977739690">Име:</translation>
+<translation id="7963646190083259054">Доставчик:</translation>
+<translation id="3414952576877147120">Размер:</translation>
+<translation id="7375125077091615385">Тип:</translation>
+<translation id="5765780083710877561">Описание:</translation>
+<translation id="4881695831933465202">Отваряне</translation>
+<translation id="3542235761944717775">Свободно място: <ph name="KILOBYTES"/> КБ</translation>
+<translation id="8051695050440594747">Налице: <ph name="MEGABYTES"/> МБ</translation>
+<translation id="5424588387303617268">Налични: <ph name="GIGABYTES"/> ГБ</translation>
+<translation id="5793665092639000975">Използвано място: <ph name="SPACE_USED"/> от <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Всички</translation>
+<translation id="4988526792673242964">Страници</translation>
+<translation id="3810838688059735925">Видео</translation>
+<translation id="3616113530831147358">Аудио</translation>
+<translation id="9219103736887031265">Изображения</translation>
+<translation id="8250920743982581267">Документи</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# файл}other{# файла}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# изображение}other{# изображения}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# видеоклип}other{# видеоклипа}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудиофайл}other{# аудиофайла}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# страница}other{# страници}}</translation>
+<translation id="5456381639095306749">Изтегляне на страницата</translation>
+<translation id="2394602618534698961">Изтеглените от вас файлове се показват тук</translation>
+<translation id="7810647596859435254">Отваряне със…</translation>
+<translation id="5655963694829536461">Търсете в изтеглянията</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/><ph name="SEPARATOR"/><ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Моите файлове</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/><ph name="SEPARATOR"/><ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Тук се показват статии, които можете да четете дори когато сте офлайн</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ч}other{# ч}}</translation>
+<translation id="5853623416121554550">на пауза</translation>
+<translation id="8965591936373831584">изчаква</translation>
+<translation id="2779651927720337254">неуспешно</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/><ph name="SEPARATOR"/><ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Току-що</translation>
+<translation id="4000212216660919741">Начална страница в офлайн режим</translation>
+<translation id="9133397713400217035">Разглеждане в офлайн режим</translation>
+<translation id="968900484120156207">Посетените от вас страници се показват тук</translation>
+<translation id="7882131421121961860">Няма намерена история</translation>
+<translation id="3549657413697417275">Търсене в историята ви</translation>
+<translation id="6820686453637990663">Код за сигурност</translation>
+<translation id="3244271242291266297">ММ</translation>
+<translation id="605721222689873409">ГГ</translation>
+<translation id="724102042129299115">Представяне при първо стартиране на Brave</translation>
+<translation id="2700285883409956633">С използването на това приложение приемате <ph name="BEGIN_LINK1"/>Общите условия<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Съобщението за поверителност<ph name="END_LINK2"/> на Brave.</translation>
+<translation id="1640714894372474981">С използването на това приложение приемате <ph name="BEGIN_LINK1"/>Общите условия<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Съобщението за поверителност<ph name="END_LINK2"/> на Brave, както и <ph name="BEGIN_LINK3"/>Съобщението за поверителност за профили в Brave Software, управлявани чрез Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> ще се отвори в Brave. С продължаването си приемате <ph name="BEGIN_LINK1"/>Общите условия<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Съобщението за поверителност<ph name="END_LINK2"/> на браузъра.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> ще се отвори в Brave. С продължаването си приемате <ph name="BEGIN_LINK1"/>Общите условия<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Съобщението за поверителност<ph name="END_LINK2"/> на браузъра, както и <ph name="BEGIN_LINK3"/>Съобщението за поверителност за профили в Brave Software, управлявани чрез Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Помогнете за подобряването на Brave, като изпращате до Brave Software статистически данни за употребата и сигнали за сривове.</translation>
+<translation id="3518985090088779359">Приемам и напред</translation>
+<translation id="7207456302801184289">Добре дошли в Brave</translation>
+<translation id="704822250101715322">Изчаква се актуализирането на услугите за Brave Software Play да приключи</translation>
+<translation id="1231733316453485619">Да се включи ли синхронизирането?</translation>
+<translation id="5132942445612118989">Синхронизиране на паролите, историята ви и др. на всички устройства</translation>
+<translation id="5736731321935944068">Възможно е да използваме историята ви, за да персонализираме търсенето, рекламите и други услуги на Brave Software</translation>
+<translation id="4013614219085422040">Възможно е да използваме историята ви, за да персонализираме търсенето и други услуги на Brave Software</translation>
+<translation id="5581519193887989363">Винаги можете да изберете какво да се синхронизира от <ph name="BEGIN_LINK1"/>настройките<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Да, ще участвам</translation>
+<translation id="2410754283952462441">Изберете профил</translation>
+<translation id="2227444325776770048">Продължаване като <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Не сте <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Включете синхронизирането, за да получите отметките си на всичките си устройства</translation>
+<translation id="2818669890320396765">Влезте в профила си и включете синхронизирането, за да получите отметките си на всичките си устройства</translation>
+<translation id="6003646045106347985">Включете синхронизирането, за да получавате персонализирано съдържание, предлагано от Brave Software</translation>
+<translation id="8494430740943879273">Влезте в профила си и включете синхронизирането, за да получавате персонализирано съдържание, предлагано от Brave Software</translation>
+<translation id="5862731021271217234">Включете синхронизирането, за да получите разделите си от другите си устройства</translation>
+<translation id="3568688522516854065">Влезте в профила си и включете синхронизирането, за да получите разделите си от другите си устройства</translation>
+<translation id="1208340532756947324">Включете синхронизирането, за да се възползвате от синхронизиране и персонализиране на всички устройства</translation>
+<translation id="4472118726404937099">Влезте в профила си и включете синхронизирането, за да се възползвате от синхронизиране и персонализиране на всички устройства</translation>
+<translation id="2426805022920575512">Избиране на друг профил</translation>
+<translation id="6790428901817661496">Пускане</translation>
+<translation id="1272079795634619415">Стоп</translation>
+<translation id="2874939134665556319">Предишен запис</translation>
+<translation id="4046123991198612571">Следващ запис</translation>
+<translation id="3859306556332390985">Придвижване напред</translation>
+<translation id="8441146129660941386">Придвижване назад</translation>
+<translation id="6706288973712894588">Понастоящем сте офлайн.\n<ph name="BEGIN_LINK"/>Разгледайте емисията си в офлайн режим.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Скорошни раздели</translation>
+<translation id="8497726226069778601">Тук няма нищо… засега</translation>
+<translation id="5423934151118863508">Най-посещаваните от вас страници ще се показват тук</translation>
+<translation id="6127379762771434464">Елементът бе премахнат</translation>
+<translation id="4605958867780575332">Елементът бе премахнат: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Драскулка на Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Други устройства</translation>
+<translation id="4738836084190194332">Последно синхронизиране: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{преди # минута}other{преди # минути}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{преди # час}other{преди # часа}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{преди # ден}other{преди # дни}}</translation>
+<translation id="2762000892062317888">току-що</translation>
+<translation id="1407135791313364759">Отваряне на всички</translation>
+<translation id="1209206284964581585">Скриване засега</translation>
+<translation id="129553762522093515">Наскоро затворени</translation>
+<translation id="8413126021676339697">Цялата история</translation>
+<translation id="7876243839304621966">Премахване на всички</translation>
+<translation id="8487700953926739672">Налице офлайн</translation>
+<translation id="5224771365102442243">С видеоклип</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Научете повече<ph name="END_LINK"/> за предложеното съдържание</translation>
+<translation id="7542481630195938534">Предложенията не могат да бъдат показани</translation>
+<translation id="5013696553129441713">Няма нови предложения</translation>
+<translation id="1736419249208073774">Разглеждане</translation>
+<translation id="7444811645081526538">Още категории</translation>
+<translation id="6709133671862442373">Новини</translation>
+<translation id="1264974993859112054">Спорт</translation>
+<translation id="9139318394846604261">Пазаруване</translation>
+<translation id="3912508018559818924">Намираме най-доброто от мрежата…</translation>
+<translation id="526421993248218238">Тази страница не може да се зареди</translation>
+<translation id="614940544461990577">Изпробвайте следното:</translation>
+<translation id="3288003805934695103">Презаредете страницата.</translation>
+<translation id="2353636109065292463">Връзката с интернет се проверява</translation>
+<translation id="2858138569776157458">Водещи сайтове</translation>
+<translation id="8364299278605033898">Вижте популярните уебсайтове</translation>
+<translation id="1171770572613082465">Вижте популярните уебсайтове, като докоснете бутона „Водещи сайтове“</translation>
+<translation id="5233638681132016545">Нов раздел</translation>
+<translation id="4521874409998847950">От <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>показва се от Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Налице е по-нова версия</translation>
+<translation id="4058091506841967397">Не може да се актуализира</translation>
+<translation id="6316139424528454185">Неподдържана версия на Android</translation>
+<translation id="6989267951144302301">Неуспешно изтегляне</translation>
+<translation id="624789221780392884">Актуализацията е готова</translation>
+<translation id="1549000191223877751">Преместв. в другия прозорец</translation>
+<translation id="7481312909269577407">Препращане</translation>
+<translation id="4084682180776658562">Отметка</translation>
+<translation id="6437478888915024427">Информация за страницата</translation>
+<translation id="7180611975245234373">Опресняване</translation>
+<translation id="4913169188695071480">Спиране на опресняването</translation>
+<translation id="1829244130665387512">Търсене в страницата</translation>
+<translation id="6593061639179217415">Настолен сайт</translation>
+<translation id="9063523880881406963">Изключване на функцията за заявяване на настолни сайтове</translation>
+<translation id="2038563949887743358">Включване на функцията за заявяване на настолни сайтове</translation>
+<translation id="2433507940547922241">Облик</translation>
+<translation id="983192555821071799">Затваряне на всички раздели</translation>
+<translation id="1310482092992808703">Групиране на раздели</translation>
+<translation id="7725024127233776428">Запазените от вас отметки към страници се показват тук</translation>
+<translation id="4404568932422911380">Няма отметки</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> отметка}other{<ph name="BOOKMARKS_COUNT_MANY"/> отметки}}</translation>
+<translation id="3739899004075612870">Отметката бе запазена в/ъв <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">С отметка</translation>
+<translation id="4452548195519783679">Отметката бе запазена в/ъв „<ph name="FOLDER_NAME"/>“</translation>
+<translation id="8063895661287329888">Добавянето на отметката не бе успешно.</translation>
+<translation id="2842985007712546952">Основна папка</translation>
+<translation id="9065203028668620118">Редактиране</translation>
+<translation id="4405224443901389797">Преместване във…</translation>
+<translation id="5170568018924773124">Показване в папката</translation>
+<translation id="8035133914807600019">Нова папка…</translation>
+<translation id="4532845899244822526">Избиране на папка</translation>
+<translation id="6627583120233659107">Редактиране на папката</translation>
+<translation id="1197267115302279827">Преместване на отметки</translation>
+<translation id="6963766334940102469">Изтриване на отметките</translation>
+<translation id="4351244548802238354">Затваряне на диалоговия прозорец</translation>
+<translation id="451872707440238414">Търсене в отметките ви</translation>
+<translation id="8901170036886848654">Няма намерени отметки</translation>
+<translation id="6404511346730675251">Редактиране на отметката</translation>
+<translation id="3894427358181296146">Добавяне на папка</translation>
+<translation id="5327248766486351172">Име</translation>
+<translation id="7400418766976504921">URL адрес</translation>
+<translation id="3527085408025491307">Папка</translation>
+<translation id="5161254044473106830">Изисква се заглавие</translation>
+<translation id="2996809686854298943">Изисква се URL адрес</translation>
+<translation id="2536728043171574184">Преглеждате офлайн копие на страницата</translation>
+<translation id="4698034686595694889">Офлайн преглед в <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> и още сайтове</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave ще зареди страницата при готовност}other{Brave ще зареди страниците при готовност}}</translation>
+<translation id="6811034713472274749">Страницата е готова за преглед</translation>
+<translation id="4561979708150884304">Няма връзка</translation>
+<translation id="8274165955039650276">Преглед на изтеглянията</translation>
+<translation id="2082238445998314030">Резултат <ph name="RESULT_NUMBER"/> от <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Няма резултати</translation>
+<translation id="981121421437150478">Офлайн</translation>
+<translation id="3298243779924642547">Олекотена</translation>
+<translation id="393697183122708255">Не е налице активирано гласово търсене</translation>
+<translation id="7191430249889272776">Разделът е отворен на заден план.</translation>
+<translation id="8445059357334030806">Отваряне в Brave</translation>
+<translation id="4720023427747327413">Отваряне в <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Отваряне в браузъра</translation>
+<translation id="1113597929977215864">Показване на опростения изглед</translation>
+<translation id="1513352483775369820">Отметки и посетени сайтове</translation>
+<translation id="4939482511480190003">Помогнете за подобряването на Brave. <ph name="BEGIN_LINK"/>Участвайте в анкетата<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Назад</translation>
+<translation id="5596627076506792578">Още опции</translation>
+<translation id="3522247891732774234">Налице е актуализация. Още опции</translation>
+<translation id="6773423637732432200">Brave не може да се актуализира. Още опции</translation>
+<translation id="3328801116991980348">Информация за сайта</translation>
+<translation id="5391532827096253100">Връзката ви с този сайт не е защитена. Информация за сайта</translation>
+<translation id="6206551242102657620">Връзката е защитена. Информация за сайта</translation>
+<translation id="6963642900430330478">Тази страница е опасна. Информация за сайта</translation>
+<translation id="9070377983101773829">Стартиране на гласово търсене</translation>
+<translation id="8676374126336081632">Изчистване на въведеното</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> отворен раздел. Докоснете за превключване между разделите}other{<ph name="OPEN_TABS_MANY"/> отворени раздела. Докоснете за превключване между тях}}</translation>
+<translation id="2369533728426058518">отваряне на раздели</translation>
+<translation id="7071521146534760487">Управление на профила</translation>
+<translation id="932327136139879170">Начална страница</translation>
+<translation id="2707726405694321444">Опресняване на страницата</translation>
+<translation id="2891154217021530873">Спиране на зареждането на страницата</translation>
+<translation id="6710213216561001401">Предишна</translation>
+<translation id="6659594942844771486">Раздел</translation>
+<translation id="1933845786846280168">Избран раздел</translation>
+<translation id="2268044343513325586">Прецизиране</translation>
+<translation id="7846076177841592234">Анулиране на избора</translation>
+<translation id="7087918508125750058">Избрани: <ph name="ITEM_COUNT"/>. Налице са опции близо до горната част на екрана</translation>
+<translation id="7250468141469952378">Избрани: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Споделяне на 1 избран елемент}other{Споделяне на # избрани елемента}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Премахване на 1 избран елемент}other{Премахване на # избрани елемента}}</translation>
+<translation id="1283039547216852943">Докоснете за разгъване</translation>
+<translation id="5962718611393537961">Докоснете за свиване</translation>
+<translation id="8076492880354921740">Раздели</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Избрана е 1}other{Избрани са #}}</translation>
+<translation id="6818926723028410516">Избор на елементи</translation>
+<translation id="4797039098279997504">Докоснете, за да се върнете към <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Докоснете, за да посетите сайта</translation>
+<translation id="429312253194641664">Сайт възпроизвежда мултимедийно съдържание</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> споделя екрана ви</translation>
+<translation id="8833831881926404480">Сайт споделя екрана ви</translation>
+<translation id="9086455579313502267">Няма достъп до мрежата</translation>
+<translation id="938850635132480979">Грешка: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Отваряне в <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Отваряне в приложение за карти</translation>
+<translation id="7698359219371678927">Създайте имейл в <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Създайте имейл</translation>
+<translation id="5665379678064389456">Създайте събитие в <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Създайте събитие</translation>
+<translation id="2111511281910874386">Към страницата</translation>
+<translation id="3988466920954086464">Отворете този панел, за да видите динамичните резултати от търсенето</translation>
+<translation id="2744248271121720757">Докоснете дума, за да извършите незабавно търсене, или вижте свързаните действия</translation>
+<translation id="9155898266292537608">Можете също да извършите търсене с бързо докосване на дума</translation>
+<translation id="3232754137068452469">Уеб приложение</translation>
+<translation id="1430915738399379752">Печат</translation>
+<translation id="3775705724665058594">Изпращане до устройствата ви</translation>
+<translation id="6364438453358674297">Предложението да се премахне ли от историята?</translation>
+<translation id="213279576345780926">Затворихте „<ph name="TAB_TITLE"/>“</translation>
+<translation id="6850830437481525139">Затворихте <ph name="TAB_COUNT"/> раздела</translation>
+<translation id="3211426585530211793">Изтрихте „<ph name="ITEM_TITLE"/>“</translation>
+<translation id="4663756553811254707">Изтрихте <ph name="NUMBER_OF_BOOKMARKS"/> отметки</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> изтегляния бяха изтрити</translation>
+<translation id="1248710015876067820">Неподдържан брой екземпляри на Brave.</translation>
+<translation id="4259722352634471385">Навигирането е блокирано: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Навигирането не е възможно: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Затваряне на раздела</translation>
+<translation id="7772375229873196092">Затваряне на <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">История на навигацията</translation>
+<translation id="9169507124922466868">Историята на навигацията е наполовина отворена</translation>
+<translation id="1327257854815634930">Историята на навигацията е отворена</translation>
+<translation id="8788265440806329501">Историята на навигацията е затворена</translation>
+<translation id="7482656565088326534">Раздел за визуализация</translation>
+<translation id="8427875596167638501">Разделът за визуализация е наполовина отворен</translation>
+<translation id="9102803872260866941">Разделът за визуализация е отворен</translation>
+<translation id="2942036813789421260">Разделът за визуализация е затворен</translation>
+<translation id="6355102470683871794">Хранилище на Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Изчистване на данните?</translation>
+<translation id="9205995714227143200">Съхранявани данни от сайтове, които Brave не счита за важни (напр. рядко посещавани или сайтове без запазени настройки)</translation>
+<translation id="3997476611815694295">Маловажни данни в хранилището</translation>
+<translation id="8493948351860045254">Освобождаване на място</translation>
+<translation id="2324920234469020158">Така ще се изчистят „бисквитките“, кешът и другата информация от сайтове, която не е важна за Brave.</translation>
+<translation id="5447201525962359567">Всички данни от сайтове, включително „бисквитки“ и друга локално съхранявана информация</translation>
+<translation id="1376578503827013741">Изчислява се…</translation>
+<translation id="583281660410589416">Неизвестно</translation>
+<translation id="2323763861024343754">Данни от сайтове</translation>
+<translation id="3587672679800759167">Общо място в хранилището, което се използва от Brave, включително за профили, отметки и запазени настройки</translation>
+<translation id="6545017243486555795">Изчистване на всички данни</translation>
+<translation id="4095146165863963773">Да се изтрият ли данните на приложенията?</translation>
+<translation id="53119194224775367">Всички данни на приложението Brave ще се изтрият за постоянно. Това включва всички файлове, настройки, профили, бази от данни и др.</translation>
+<translation id="5307446750509046227">Изчистване на данните</translation>
+<translation id="300526633675317032">Така ще се изчистят всички съхранявани данни от уебсайтове (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">Сертификатът не може да бъде избран.</translation>
+<translation id="2315043854645842844">Избраният сертификат от страната на клиента не се поддържа от операционната система.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> иска да се свърже</translation>
+<translation id="5308380583665731573">Свързване</translation>
+<translation id="868929229000858085">Търсене в контактите ви</translation>
+<translation id="1919950603503897840">Избор на контакти</translation>
+<translation id="7986741934819883144">Изберете контакт</translation>
+<translation id="3333961966071413176">Всички контакти</translation>
+<translation id="4994033804516042629">Няма намерени контакти</translation>
+<translation id="5403592356182871684">Имена</translation>
+<translation id="2717722538473713889">Имейл адреси</translation>
+<translation id="381841723434055211">Телефонни номера</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(и още 1)}other{(и още #)}}</translation>
+<translation id="5197729504361054390">Избраните от вас контакти ще бъдат споделени със сайта <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Декодиране на изображения</translation>
+<translation id="8067883171444229417">Възпроизвеждане на видеоклипа</translation>
+<translation id="6560414384669816528">Търсене със Sogou</translation>
+<translation id="5406914950576900927">Brave може да използва <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> за търсене в Китай. Можете да промените това от <ph name="BEGIN_LINK"/>Настройки<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Запазване на Brave Software</translation>
+<translation id="4384468725000734951">За търсене ще се използва Sogou</translation>
+<translation id="6103327872225198548">За търсене ще се използва Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Това приложение се изпълнява в Brave</translation>
+<translation id="6143689084714664628">Изпълнява се в Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> също има данни в Brave</translation>
+<translation id="2734140769649165081">Можете да изчистите данните в настройките на Brave</translation>
+<translation id="8232956427053453090">Запазване на данните</translation>
+<translation id="4298388696830689168">Свързани сайтове</translation>
+<translation id="5763514718066511291">Докоснете, за да копирате URL адреса за това приложение</translation>
+<translation id="6496823230996795692">За да използвате <ph name="APP_NAME"/> за първи път, моля, свържете се с интернет.</translation>
+<translation id="751961395872307827">Не може да се установи връзка със сайта</translation>
+<translation id="4878404682131129617">Създаването на тунел през прокси сървъра не бе успешно</translation>
+<translation id="4749960740855309258">Отваряне на нов раздел</translation>
+<translation id="8788968922598763114">Повторно отваряне на последно затворения раздел</translation>
+<translation id="7929962904089429003">Отваряне на менюто</translation>
+<translation id="6039379616847168523">Преминаване към следващия раздел</translation>
+<translation id="5210286577605176222">Преминаване към предишния раздел</translation>
+<translation id="124678866338384709">Затваряне на текущия раздел</translation>
+<translation id="3714981814255182093">Отваряне на лентата за търсене</translation>
+<translation id="5441522332038954058">Преминаване към адресната лента</translation>
+<translation id="3398320232533725830">Отваряне на диспечера на отметките</translation>
+<translation id="6583199322650523874">Запазване на отметка към текущата страница</translation>
+<translation id="8489271220582375723">Отваряне на страницата „История“</translation>
+<translation id="4837753911714442426">Отваряне на опциите за отпечатване на страницата</translation>
+<translation id="5726692708398506830">Уголемяване на всички елементи на страницата</translation>
+<translation id="3259831549858767975">Смаляване на всички елементи на страницата</translation>
+<translation id="8015452622527143194">Стандартен размер на всички елементи на страницата</translation>
+<translation id="3443221991560634068">Презареждане на текущата страница</translation>
+<translation id="123724288017357924">Презареждане на страницата (кешът се пренебрегва)</translation>
+<translation id="305870044889644984">Отваряне на Помощния център на Brave в нов раздел</translation>
+<translation id="3166827708714933426">Комбинации за раздели и прозорци</translation>
+<translation id="3169981355900570544">Комбинации за функции на Brave Software Brave</translation>
+<translation id="4558311620361989323">Комбинации за уеб страници</translation>
+<translation id="1908301351964700579">Brave все още се подготвя за VR. Рестартирайте браузъра по-късно.</translation>
+<translation id="8970887620466824814">Нещо се обърка.</translation>
+<translation id="1875543012935658554">Отворете отново Brave.</translation>
+<translation id="79859296434321399">За да гледате съдържание с обогатена реалност, инсталирайте ARCore</translation>
+<translation id="8558485628462305855">За да гледате съдържание с обогатена реалност, актуализирайте ARCore</translation>
+<translation id="3513704683820682405">Обогатена реалност</translation>
+<translation id="5475862044948910901">Искате ли да стартирате сесия с обогатена реалност?</translation>
 <translation id="7365126855094612066">По време на тази сесия сайтът ще може:
 • да създаде триизмерна карта на заобикалящата ви среда;
 • да проследява движенията на камерата.
 
 Сайтът НЕ получава достъп до камерата. Изображенията от нея са видими само за вас.</translation>
-<translation id="7375125077091615385">Тип:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL адрес</translation>
-<translation id="7403691278183511381">Представяне при първо стартиране на Chrome</translation>
-<translation id="741204030948306876">Да, ще участвам</translation>
-<translation id="7413229368719586778">Начална дата: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Първо ще се извежда запитване</translation>
-<translation id="7423538860840206698">Достъпът за четене до буферната памет е блокиран</translation>
-<translation id="7431991332293347422">Контролирайте начина, по който историята ви на сърфиране се използва за персонализиране на търсенето и др.</translation>
-<translation id="7437998757836447326">Изход от Chrome</translation>
-<translation id="7438641746574390233">Когато олекотеният режим е включен, Chrome използва сървърите на Google, за да ускорява зареждането на страниците. Бавните страници се пренаписват, за да се зареди само основното съдържание. Олекотеният режим не се поддържа за раздели в режим „инкогнито“.</translation>
-<translation id="7444811645081526538">Още категории</translation>
-<translation id="7445411102860286510">Разрешаване на сайтовете автоматично да възпроизвеждат видеоклипове със заглушен звук (препоръчително)</translation>
-<translation id="7453467225369441013">Ще излезете от повечето сайтове, но не и от профила си в Google.</translation>
-<translation id="7454641608352164238">Няма достатъчно място</translation>
-<translation id="7475192538862203634">Ако виждате това често, изпробвайте тези <ph name="BEGIN_LINK" />предложения<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD картата не е намерена. Някои файлове може да липсват.</translation>
-<translation id="7479104141328977413">Управление на разделите</translation>
-<translation id="7481312909269577407">Препращане</translation>
-<translation id="7482656565088326534">Раздел за визуализация</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Актуализирано: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">спестени данни</translation>
-<translation id="7498271377022651285">Моля, изчакайте...</translation>
-<translation id="7514365320538308">Изтегляне</translation>
-<translation id="751961395872307827">Не може да се установи връзка със сайта</translation>
-<translation id="7521387064766892559">Javascript</translation>
-<translation id="7542481630195938534">Предложенията не могат да бъдат показани</translation>
-<translation id="7559975015014302720">Олекотеният режим е изключен</translation>
-<translation id="7562080006725997899">Данните за сърфирането се изчистват</translation>
-<translation id="756809126120519699">Данните в Chrome са изчистени</translation>
-<translation id="757524316907819857">Блокиране на възможността на сайтовете да възпроизвеждат защитено съдържание</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> файл бе изтеглен}other{<ph name="FILES_DOWNLOADED_MANY" /> файла бяха изтеглени}}</translation>
-<translation id="7588219262685291874">Включване на тъмната тема, когато режимът за запазване на батерията на устройството ви е включен</translation>
-<translation id="7589445247086920869">Блокиране за текущата търсеща машина</translation>
-<translation id="7593557518625677601">За старт на синхронизирането активирайте системното синхронизиране на Android</translation>
-<translation id="7596558890252710462">Операционна система</translation>
-<translation id="7605594153474022051">Синхронизирането не работи</translation>
-<translation id="7606077192958116810">Олекотеният режим е включен. Можете да го управлявате от настройките.</translation>
-<translation id="7612619742409846846">Влезли сте в Google като</translation>
-<translation id="7619072057915878432">Изтеглянето на „<ph name="FILE_NAME" />“ не бе успешно поради грешки в мрежата.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Получете помощ<ph name="END_LINK1" /> или <ph name="BEGIN_LINK2" />сканирайте отново<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Добре дошли в Chrome</translation>
-<translation id="7638584964844754484">Неправилен пропуск</translation>
-<translation id="7641339528570811325">Изчистване на данните за сърфирането…</translation>
-<translation id="7648422057306047504">Шифроване на паролите с идентификационните данни за Google</translation>
-<translation id="7649070708921625228">Помощ</translation>
-<translation id="7658239707568436148">Отказ</translation>
-<translation id="7665369617277396874">Добавяне на профил</translation>
-<translation id="766587987807204883">Тук се показват статии, които можете да четете дори когато сте офлайн</translation>
-<translation id="7682724950699840886">Изпробвайте следните съвети: Уверете се, че има достатъчно място на устройството ви. Опитайте отново да експортирате.</translation>
-<translation id="7685301384041462804">Проверете дали имате доверие на този сайт, преди да стартирате VR.</translation>
-<translation id="7698359219371678927">Създайте имейл в <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Автоматично довършване на заявки за търсене и URL адреси</translation>
-<translation id="7725024127233776428">Запазените от вас отметки към страници се показват тук</translation>
-<translation id="773466115871691567">Страниците на <ph name="SOURCE_LANGUAGE" /> да се превеждат винаги</translation>
-<translation id="7746457520633464754">За да открива опасни приложения и сайтове, Chrome изпраща до Google URL адресите на някои от страниците, които посещавате, ограничена системна информация и част от съдържанието на страниците</translation>
-<translation id="7757787379047923882">Текст, споделен от <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD карта <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Добавяне на адрес</translation>
-<translation id="7772032839648071052">Потвърдете пропуска</translation>
-<translation id="7772375229873196092">Затваряне на <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 и още <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Вчера</translation>
-<translation id="7791543448312431591">Добавяне</translation>
-<translation id="780301667611848630">Не, благодаря</translation>
-<translation id="7810647596859435254">Отваряне със…</translation>
-<translation id="7821588508402923572">Тук ще се показва количеството икономисани данни</translation>
-<translation id="7837721118676387834">Разрешаване на автоматичното възпроизвеждане на видеоклипове със заглушен звук за конкретен сайт.</translation>
-<translation id="7846076177841592234">Анулиране на избора</translation>
-<translation id="784934925303690534">Период от време</translation>
-<translation id="7851858861565204677">Други устройства</translation>
-<translation id="7875915731392087153">Създайте имейл</translation>
-<translation id="7876243839304621966">Премахване на всички</translation>
-<translation id="7882131421121961860">Няма намерена история</translation>
-<translation id="7882806643839505685">Разрешаване на звука за конкретен сайт.</translation>
-<translation id="7886917304091689118">Изпълнява се в Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Изтегля се файл.}other{Изтеглят се # файла.}}</translation>
-<translation id="7929962904089429003">Отваряне на менюто</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> не е актуален.</translation>
-<translation id="7947953824732555851">Приемам и влизам</translation>
-<translation id="7963646190083259054">Доставчик:</translation>
-<translation id="7971136598759319605">Активно преди 1 ден</translation>
-<translation id="7975379999046275268">Визуализация <ph name="BEGIN_NEW" />Ново<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Предварително зареждане на страниците с цел по-бързо сърфиране и търсене</translation>
-<translation id="79859296434321399">За да гледате съдържание с обогатена реалност, инсталирайте ARCore</translation>
-<translation id="7986741934819883144">Изберете контакт</translation>
-<translation id="7987073022710626672">Общи условия на Chrome</translation>
-<translation id="7998918019931843664">Повторно отваряне на затворения раздел</translation>
-<translation id="7999064672810608036">Наистина ли искате да изчистите всички локални данни, включително „бисквитките“, и да нулирате всички разрешения за този уебсайт?</translation>
-<translation id="8004582292198964060">Браузър</translation>
-<translation id="8007176423574883786">Изключено за това устройство</translation>
-<translation id="8013372441983637696">Изчистване на данните ви в Chrome и от това устройство</translation>
-<translation id="8015452622527143194">Стандартен размер на всички елементи на страницата</translation>
-<translation id="802154636333426148">Изтеглянето не бе успешно</translation>
-<translation id="8026334261755873520">Изчистване на данните за сърфирането</translation>
-<translation id="8035133914807600019">Нова папка…</translation>
-<translation id="8037750541064988519">Остават <ph name="DAYS" /> дни</translation>
-<translation id="804335162455518893">SD картата не е намерена</translation>
-<translation id="805047784848435650">Въз основа на историята ви на сърфиране</translation>
-<translation id="8051695050440594747">Налице: <ph name="MEGABYTES" /> МБ</translation>
-<translation id="8058746566562539958">Отваряне в нов раздел в Chrome</translation>
-<translation id="8063895661287329888">Добавянето на отметката не бе успешно.</translation>
-<translation id="806745655614357130">Оставяне на данните отделно</translation>
-<translation id="8067883171444229417">Възпроизвеждане на видеоклипа</translation>
-<translation id="8068648041423924542">Сертификатът не може да бъде избран.</translation>
-<translation id="8073388330009372546">Отваряне в нов раздел</translation>
-<translation id="8076492880354921740">Раздели</translation>
-<translation id="8084114998886531721">Запазена парола</translation>
-<translation id="8087000398470557479">Това съдържание се показва от Google, а източникът му е <ph name="DOMAIN_NAME" />.</translation>
-<translation id="8103578431304235997">Раздел в режим „инкогнито“</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /><ph name="SEPARATOR" /><ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Включете синхронизирането, за да получите отметките си на всичките си устройства</translation>
-<translation id="8110087112193408731">Искате ли активността ви в Chrome да се показва в „Дигитално благополучие“?</translation>
-<translation id="8116925261070264013">Заглушени</translation>
-<translation id="813082847718468539">Преглед на информацията за сайта</translation>
-<translation id="8131740175452115882">Потвърждаване</translation>
-<translation id="8156139159503939589">Какви езици четете?</translation>
-<translation id="8168435359814927499">Съдържание</translation>
-<translation id="8186512483418048923">Остават <ph name="FILES" /> файла</translation>
-<translation id="8190358571722158785">Остава 1 ден</translation>
-<translation id="8200772114523450471">Възобновяване</translation>
-<translation id="8209050860603202033">Отваряне на изображението</translation>
-<translation id="8218622182176210845">Управление на профила ви</translation>
-<translation id="8224471946457685718">Изтегляне на статиите за вас през Wi-Fi</translation>
-<translation id="8232956427053453090">Запазване на данните</translation>
-<translation id="8249310407154411074">Преместване най-горе</translation>
-<translation id="8250920743982581267">Документи</translation>
-<translation id="825412236959742607">Тази страница използва твърде много памет, така че Chrome премахна част от съдържанието.</translation>
-<translation id="8260126382462817229">Опитайте да влезете отново</translation>
-<translation id="8261506727792406068">Изтриване</translation>
-<translation id="8266862848225348053">Местоположение за изтеглянията</translation>
-<translation id="8274165955039650276">Преглед на изтеглянията</translation>
-<translation id="8284326494547611709">Надписи</translation>
-<translation id="8300705686683892304">Управлявани от приложение</translation>
-<translation id="8310344678080805313">Стандартни раздели</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> и още сайтове</translation>
-<translation id="8327155640814342956">За оптимално сърфиране отворете, за да актуализирате Chrome</translation>
-<translation id="8339163506404995330">Страниците на <ph name="LANGUAGE" /> няма да се превеждат</translation>
-<translation id="8349013245300336738">Сортиране по количеството използвани данни</translation>
-<translation id="8364299278605033898">Вижте популярните уебсайтове</translation>
-<translation id="8368027906805972958">Неизвестно или неподдържано устройство (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Разрешаване на синхронизирането на заден план за конкретен сайт.</translation>
-<translation id="8378714024927312812">Управлява се от организацията ви</translation>
-<translation id="8380167699614421159">На този сайт се показват натрапчиви или подвеждащи реклами</translation>
-<translation id="8393700583063109961">Изпратете съобщение</translation>
-<translation id="8413126021676339697">Цялата история</translation>
-<translation id="8427875596167638501">Разделът за визуализация е наполовина отворен</translation>
-<translation id="8428213095426709021">Настройки</translation>
-<translation id="8438566539970814960">Подобряване на търсенията и сърфирането</translation>
-<translation id="8441146129660941386">Придвижване назад</translation>
-<translation id="8443209985646068659">Не може да се актуализира</translation>
-<translation id="8445448999790540984">Паролите не могат да бъдат експортирани</translation>
-<translation id="8447861592752582886">Отмяна на разрешението за достъп до устройството</translation>
-<translation id="8461694314515752532">Шифроване на синхронизираните данни със собствения ви пропуск за синхронизиране</translation>
-<translation id="8466613982764129868">Уверете се, че устройството <ph name="TARGET_DEVICE_NAME" /> е свързано с интернет</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /><ph name="SEPARATOR" /><ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Налице офлайн</translation>
-<translation id="8489271220582375723">Отваряне на страницата „История“</translation>
-<translation id="8493948351860045254">Освобождаване на място</translation>
-<translation id="8497726226069778601">Тук няма нищо… засега</translation>
-<translation id="8503559462189395349">Пароли в Chrome</translation>
-<translation id="8503813439785031346">Потребителско име</translation>
-<translation id="8514477925623180633">Експортиране на паролите, съхранявани в Chrome</translation>
-<translation id="8514577642972634246">Влизане в режим „инкогнито“</translation>
-<translation id="851751545965956758">Блокиране на сайтовете, така че да не се свързват с устройства</translation>
-<translation id="8523928698583292556">Изтриване на съхранената парола</translation>
-<translation id="854522910157234410">Отваряне на тази страница</translation>
-<translation id="8558485628462305855">За да гледате съдържание с обогатена реалност, актуализирайте ARCore</translation>
-<translation id="8559990750235505898">Извеждане на предложения за превод на страниците, написани на други езици</translation>
-<translation id="8562452229998620586">Запазените пароли ще се покажат тук.</translation>
-<translation id="8569404424186215731">от <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Последните 4 седмици</translation>
-<translation id="857943718398505171">Разрешено (препоръчително)</translation>
-<translation id="8583805026567836021">Данните от профила се изчистват</translation>
-<translation id="860043288473659153">Име на титуляря на картата</translation>
-<translation id="8609465669617005112">Придвижване нагоре</translation>
-<translation id="8616006591992756292">В профила ви в Google може да има други видове история на сърфиране, съхранявани на адрес <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Да се отвори ли предложеният URL адрес, посочен в изтегленото съдържание?</translation>
-<translation id="8636825310635137004">Включете синхронизирането, за да получите разделите си от другите си устройства.</translation>
-<translation id="8641930654639604085">Опит за блокиране на сайтовете за пълнолетни</translation>
-<translation id="8655129584991699539">Можете да изчистите данните в настройките на Chrome</translation>
-<translation id="8662811608048051533">Ще излезете от повечето сайтове.</translation>
-<translation id="8664979001105139458">Името на файла вече съществува</translation>
-<translation id="8676374126336081632">Изчистване на въведеното</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Сила на сигнала: # чертичка}other{Сила на сигнала: # чертички}}</translation>
-<translation id="868929229000858085">Търсене в контактите ви</translation>
-<translation id="869891660844655955">Дата на валидност</translation>
-<translation id="8719023831149562936">Текущият раздел не може да се излъчи</translation>
-<translation id="8725066075913043281">Опитайте отново</translation>
-<translation id="8728487861892616501">С използването на това приложение приемате <ph name="BEGIN_LINK1" />Общите условия<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Съобщението за поверителност<ph name="END_LINK2" /> на Chrome, както и <ph name="BEGIN_LINK3" />Съобщението за поверителност за профили в Google, управлявани чрез Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Готово</translation>
-<translation id="8748850008226585750">Съдържанието е скрито</translation>
-<translation id="8751914237388039244">Изберете изображение</translation>
-<translation id="8788265440806329501">Историята на навигацията е затворена</translation>
-<translation id="8788968922598763114">Повторно отваряне на последно затворения раздел</translation>
-<translation id="8801436777607969138">Блокиране на JavaScript за конкретен сайт.</translation>
-<translation id="8812260976093120287">На някои уебсайтове можете да извършвате плащания чрез посочените по-горе поддържани приложения за плащане на устройството ви.</translation>
-<translation id="8816026460808729765">Блокиране на достъпа на сайтовете до сензорите</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> ще се отвори в Chrome. С продължаването си приемате <ph name="BEGIN_LINK1" />Общите условия<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Съобщението за поверителност<ph name="END_LINK2" /> на браузъра, както и <ph name="BEGIN_LINK3" />Съобщението за поверителност за профили в Google, управлявани чрез Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Отметки</translation>
-<translation id="8833831881926404480">Сайт споделя екрана ви</translation>
-<translation id="883806473910249246">При изтеглянето на съдържанието възникна грешка.</translation>
-<translation id="8840953339110955557">Тази страница може да се различава от онлайн версията.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">„<ph name="TAB_TITLE" />“ – раздел</translation>
-<translation id="885701979325669005">Хранилище</translation>
-<translation id="889338405075704026">Към настройките за Chrome</translation>
-<translation id="8901170036886848654">Няма намерени отметки</translation>
-<translation id="8909135823018751308">Споделяне…</translation>
-<translation id="8912362522468806198">Профил в Google</translation>
-<translation id="8920114477895755567">Изчакват се подробности за родителите.</translation>
+<translation id="1188239144602654184">Стартиране на AR</translation>
+<translation id="473775607612524610">Актуализиране</translation>
+<translation id="3133489217401741157">Модулът „<ph name="MODULE"/>“ за Brave се инсталира…</translation>
+<translation id="1791662854739702043">Инсталиран</translation>
+<translation id="5131234170665854056">Модулът „<ph name="MODULE"/>“ за Brave не може да се инсталира</translation>
+<translation id="2567385386134582609">ИЗОБРАЖЕНИЕ</translation>
+<translation id="6395288395575013217">ВРЪЗКА</translation>
+<translation id="7352939065658542140">ВИДЕОКЛИП</translation>
+<translation id="4116038641877404294">Изтеглете страниците, за да ги използвате офлайн</translation>
 <translation id="8922289737868596582">Изтеглете страниците чрез бутона „Още опции“, за да ги използвате офлайн</translation>
-<translation id="8937772741022875483">Искате ли активността ви в Chrome да се премахне от „Дигитално благополучие“?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Отваряне в другия прозорец</translation>
-<translation id="8951232171465285730">Chrome ви спести <ph name="MEGABYTES" /> МБ</translation>
-<translation id="8958424370300090006">Блокиране на „бисквитките“ за конкретен сайт.</translation>
-<translation id="8959122750345127698">Навигирането не е възможно: <ph name="URL" /></translation>
-<translation id="8965591936373831584">изчаква</translation>
-<translation id="8970887620466824814">Нещо се обърка.</translation>
-<translation id="8972098258593396643">Да се изтегли ли файлът в стандартната папка?</translation>
-<translation id="8986494364107987395">Автоматично изпращане до Google на статистически данни за използването на Chrome и сигнали за сривове</translation>
-<translation id="8993760627012879038">Отваряне на нов раздел в режим „инкогнито“</translation>
-<translation id="8998729206196772491">Влизате с профил, управляван от <ph name="MANAGED_DOMAIN" />, и предоставяте на администратора му контрол върху данните си в Chrome. Те ще се свържат за постоянно с този профил. При излизане от профила в браузъра информацията ви ще се изтрие от устройството, но ще продължи да се съхранява в профила ви в Google.</translation>
-<translation id="9019902583201351841">Управлява се от родителите ви</translation>
-<translation id="9028914725102941583">Включете синхронизирането, за да споделяте на всички устройства</translation>
-<translation id="9029323097866369874">Да се разреши ли на <ph name="DOMAIN" /> да стартира VR?</translation>
-<translation id="9040142327097499898">Известията са разрешени. Местоположението е изключено за това устройство.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# видеоклип}other{# видеоклипа}}</translation>
-<translation id="9050666287014529139">Парола</translation>
-<translation id="9063523880881406963">Изключване на функцията за заявяване на настолни сайтове</translation>
-<translation id="9065203028668620118">Редактиране</translation>
-<translation id="9070377983101773829">Стартиране на гласово търсене</translation>
-<translation id="9074336505530349563">Влезте в профила си и включете синхронизирането, за да получавате персонализирано съдържание, предлагано от Google</translation>
-<translation id="9086455579313502267">Няма достъп до мрежата</translation>
-<translation id="9100505651305367705">Извеждане на предложение статиите да се показват в опростен изглед, когато се поддържа</translation>
-<translation id="9100610230175265781">Изисква се пропуск</translation>
-<translation id="9102803872260866941">Разделът за визуализация е отворен</translation>
+<translation id="5958275228015807058">Намерете файловете и страниците си в „Изтегляния“</translation>
+<translation id="5620928963363755975">Използвайте бутона „Още опции“, за да намерите файловете и страниците си в „Изтегляния“</translation>
+<translation id="3341058695485821946">Вижте колко данни сте спестили</translation>
+<translation id="3157842584138209013">Използвайте бутона „Още опции“, за да видите колко данни сте спестили</translation>
+<translation id="8218622182176210845">Управление на профила ви</translation>
+<translation id="8090895580117672212">За да управлявате профила си в Brave Software, докоснете бутона „Управление на профила“</translation>
+<translation id="8856898588039823173">Олекотена страница, предоставена от Brave Software. Докоснете за зареждане на оригиналната.</translation>
+<translation id="8134317863207426198">Олекотена страница, предоставена от Brave Software. Докоснете съответния бутон за зареждане на оригиналната.</translation>
+<translation id="4961107849584082341">Превод на тази страница на който и да е език</translation>
+<translation id="569536719314091526">Страницата може да бъде преведена на който и да е език чрез бутона за още опции</translation>
+<translation id="1397811292916898096">Търсене чрез <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Променете стандартното местоположение за изтегляне по всяко време</translation>
+<translation id="6942665639005891494">Променете стандартното местоположение за изтегляне по всяко време чрез опцията в менюто „Настройки“</translation>
+<translation id="6850409657436465440">Изтеглянето продължава</translation>
+<translation id="5817715962196959877">Изтеглянето на файлове в Brave вече е по-бързо</translation>
+<translation id="3976396876660209797">Премахнете и създайте отново този пряк път</translation>
+<translation id="6766622839693428701">Прекарайте пръст надолу, за да затворите.</translation>
+<translation id="1028699632127661925">Изпраща се до <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Изпратено от <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Получихте раздел</translation>
 <translation id="9104217018994036254">Списъкът с устройства, с които да се сподели даден раздел.</translation>
-<translation id="9133397713400217035">Разглеждане в офлайн режим</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Показване на оригинала</translation>
-<translation id="9139068048179869749">Извеждане на запитване, преди да се разреши на сайтовете да изпращат известия (препоръчително)</translation>
-<translation id="9139318394846604261">Пазаруване</translation>
-<translation id="9155898266292537608">Можете също да извършите търсене с бързо докосване на дума</translation>
-<translation id="9169507124922466868">Историята на навигацията е наполовина отворена</translation>
-<translation id="9204836675896933765">Остава 1 файл</translation>
-<translation id="9206873250291191720">А</translation>
+<translation id="6767294960381293877">Списъкът с устройства, с които да се сподели даден раздел, е отворен на половин височина.</translation>
+<translation id="2904414404539560095">Списъкът с устройства, с които да се сподели даден раздел, е отворен на пълната височина.</translation>
+<translation id="4135200667068010335">Списъкът с устройства, с които да се сподели даден раздел, е затворен.</translation>
+<translation id="5292796745632149097">Изпращане до</translation>
+<translation id="1386674309198842382">Активно преди <ph name="LAST_UPDATED"/> дни</translation>
+<translation id="7971136598759319605">Активно преди 1 ден</translation>
+<translation id="1521774566618522728">Активно днес</translation>
+<translation id="3631987586758005671">Споделя се с(ъс) <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Включете синхронизирането, за да споделяте на всички устройства</translation>
+<translation id="6162454065885854378">За да споделите нещо от телефона си на друго устройство, включете синхронизирането от настройките за Brave и на двете устройства</translation>
+<translation id="6084271560289605378">Към настройките за Brave</translation>
+<translation id="2318045970523081853">Докоснете за извършване на обаждане</translation>
 <translation id="9209888181064652401">Не могат да се извършват обаждания</translation>
-<translation id="9219103736887031265">Изображения</translation>
-<translation id="926205370408745186">Премахване на активността ви в Chrome от „Дигитално благополучие“</translation>
-<translation id="932327136139879170">Начална страница</translation>
-<translation id="938850635132480979">Грешка: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Достъп до микрофона</translation>
-<translation id="95817756606698420">Chrome може да използва <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> за търсене в Китай. Можете да промените това от <ph name="BEGIN_LINK" />Настройки<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Блокиране, ако на сайта се показват натрапчиви или подвеждащи реклами (препоръчително)</translation>
-<translation id="968900484120156207">Посетените от вас страници се показват тук</translation>
-<translation id="970715775301869095">Остават <ph name="MINUTES" /> мин</translation>
-<translation id="974555521953189084">Въведете своя пропуск, за да започне синхронизирането</translation>
-<translation id="981121421437150478">Офлайн</translation>
-<translation id="982182592107339124">Това действие ще изчисти данните за всички сайтове, включително:</translation>
-<translation id="983192555821071799">Затваряне на всички раздели</translation>
-<translation id="987264212798334818">Общи</translation>
+<translation id="2860954141821109167">Трябва да има активирано приложение за телефон на устройството</translation>
+<translation id="2067805253194386918">текст</translation>
+<translation id="1450753235335490080">Споделянето на <ph name="CONTENT_TYPE"/> не е възможно</translation>
+<translation id="1266864766717917324">Споделянето на <ph name="CONTENT_TYPE"/> не бе възможно</translation>
+<translation id="8287068819750208230">Уверете се, че синхронизирането в Brave е включено за <ph name="TARGET_DEVICE_NAME"/></translation>
+<translation id="3016635187733453316">Уверете се, че това устройство е свързано с интернет</translation>
+<translation id="8466613982764129868">Уверете се, че устройството <ph name="TARGET_DEVICE_NAME"/> е свързано с интернет</translation>
+<translation id="6539092367496845964">Нещо се обърка. Опитайте пак по-късно.</translation>
+<translation id="3389286852084373014">Текстът е твърде голям</translation>
+<translation id="2100314319871056947">Опитайте да споделите текста на по-малки части</translation>
+<translation id="2987620471460279764">Текст, споделен от друго устройство</translation>
+<translation id="7757787379047923882">Текст, споделен от <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Копирано в буферната памет</translation>
+<translation id="4696983787092045100">Изпращане на текст до устройствата ви</translation>
+<translation id="1260236875608242557">Търсене и разглеждане</translation>
+<translation id="6369229450655021117">Оттук можете да търсите в мрежата, да споделяте с приятели и да преглеждате отворените страници</translation>
+<translation id="723171743924126238">Избиране на изображения</translation>
+<translation id="8751914237388039244">Изберете изображение</translation>
+<translation id="1989112275319619282">Сърфиране</translation>
+<translation id="7055152154916055070">Блокирано бе пренасочване:</translation>
+<translation id="5524843473235508879">Блокирано бе пренасочване.</translation>
+<translation id="6573096386450695060">Разрешаване винаги</translation>
+<translation id="5805364706385912897">Тази страница използва твърде много памет, така че Brave я постави на пауза.</translation>
+<translation id="5138664332909611586">Тази страница използва твърде много памет, така че Brave премахна част от съдържанието.</translation>
+<translation id="9137013805542155359">Показване на оригинала</translation>
+<translation id="6361779936989026201">Brave Software Асистент в Brave</translation>
+<translation id="7291387454912369099">Плащане с помощта на Асистент</translation>
+<translation id="4565206163201411670">Искате ли активността ви в Brave да се показва в „Дигитално благополучие“?</translation>
+<translation id="9055113864158719823">Можете да преглеждате сайтовете, които посещавате в Brave, и да задавате таймери за тях.\n\nBrave Software получава информация относно сайтовете, за които задавате таймери, и продължителността на посещенията ви. Тези данни се използват за подобряването на „Дигитално благополучие“.</translation>
+<translation id="4596514158372210596">Премахване на активността ви в Brave от „Дигитално благополучие“</translation>
+<translation id="1174893863889683998">Искате ли активността ви в Brave да се премахне от „Дигитално благополучие“?</translation>
+<translation id="708829030563435351">Посетените от вас сайтове в Brave няма да се показват. Всички таймери за сайтове ще бъдат изтрити.</translation>
+<translation id="2056878612599315956">Сайтът е на пауза</translation>
+<translation id="671481426037969117">Таймерът ви за <ph name="FQDN"/> изтече и ще се стартира отново утре.</translation>
+<translation id="7479104141328977413">Управление на разделите</translation>
+<translation id="3524138585025253783">ПИ за програмисти</translation>
+<translation id="6036057147555329831">допълнителният ICU модул</translation>
+<translation id="9029323097866369874">Да се разреши ли на <ph name="DOMAIN"/> да стартира VR?</translation>
+<translation id="7685301384041462804">Проверете дали имате доверие на този сайт, преди да стартирате VR.</translation>
+<translation id="5033865233969348410">Когато стартирате VR, този сайт може да научи за:
+  – физическите ви черти, напр. височина.
+
+Проверете дали имате доверие на този сайт, преди да стартирате VR.</translation>
+<translation id="5534334044554683961">Когато стартирате VR, този сайт може да научи за:
+  – физическите ви черти, като височина;
+  – плана на стаята ви.
+
+Проверете дали имате доверие на този сайт, преди да стартирате VR.</translation>
+<translation id="4169535189173047238">Забраняване</translation>
+<translation id="2170088579611075216">Разрешаване и стартиране на VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_bn.xtb
+++ b/android/java/strings/translations/android_chrome_strings_bn.xtb
@@ -1,1120 +1,1103 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="bn">
-<translation id="1006017844123154345">অনলাইনে খুলুন</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" />-এ পাঠানো হচ্ছে...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> যোগ করা হচ্ছে...</translation>
-<translation id="1041308826830691739">ওয়েবসাইট থেকে</translation>
-<translation id="1049743911850919806">ছদ্মবেশী</translation>
-<translation id="10614374240317010">কখনও সংরক্ষিত হয়নি</translation>
-<translation id="1067922213147265141">Google-এর অন্যান্য পরিষেবা</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" /> ভাষার পৃষ্ঠার অনুবাদ কখনও দেখতে চাই না</translation>
-<translation id="107147699690128016">আপনি ফাইলের এক্সটেনশন পরিবর্তন করলে, সেটি অন্য অ্যাপ্লিকেশনে খুলতে পারে এবং আপনার ডিভাইসে সমস্যার সৃষ্টি করতে পারে।</translation>
-<translation id="1100066534610197918">গ্রুপে একটি নতুন ট্যাব খুলুন</translation>
-<translation id="1105960400813249514">স্ক্রিন ক্যাপচার</translation>
-<translation id="1111673857033749125">আপনার অন্যান্য ডিভাইসে সেভ করা বুকমার্কগুলি এখানে দেখা যাবে।</translation>
-<translation id="1113597929977215864">সরলীকৃত ভিউ দেখান</translation>
-<translation id="1121094540300013208">ব্যবহার এবং ক্র্যাশ প্রতিবেদনগুলি</translation>
-<translation id="1124772482545689468">ব্যবহারকারী</translation>
-<translation id="1129510026454351943">বিবরণ: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{১টি ডাউনলোড বাকি আছে।}one{#টি ডাউনলোড বাকি আছে।}other{#টি ডাউনলোড বাকি আছে।}}</translation>
-<translation id="1145536944570833626">বিদ্যমান ডেটা মুছুন।</translation>
-<translation id="1146678959555564648">(ভিআর)VR লিখুন</translation>
-<translation id="116280672541001035">ব্যবহৃত</translation>
-<translation id="1171770572613082465">"সেরা সাইট" বোতামে ট্যাপ করে জনপ্রিয় ওয়েবসাইটগুলি দেখুন</translation>
-<translation id="1173894706177603556">পুনঃনামকরণ</translation>
-<translation id="1178581264944972037">বিরতি</translation>
-<translation id="1181037720776840403">সরান</translation>
-<translation id="1188239144602654184">এ আর সেশন শুরু করুন</translation>
-<translation id="1197267115302279827">বুকমার্কগুলি সরান</translation>
-<translation id="119944043368869598">সব পরিষ্কার করুন</translation>
-<translation id="1201402288615127009">পরবর্তী</translation>
-<translation id="1204037785786432551">লিঙ্ক ডাউনলোড করুন</translation>
-<translation id="1206892813135768548">লিঙ্ক টেক্সট কপি করুন</translation>
-<translation id="1208340532756947324">সমগ্র ডিভাইস জুড়ে সিঙ্ক এবং ব্যক্তিগতকৃত করতে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="1209206284964581585">এখনকার মতো লুকান</translation>
-<translation id="1227058898775614466">নেভিগেশনের ইতিহাস</translation>
-<translation id="1231733316453485619">সিঙ্ক চালু করবেন?</translation>
-<translation id="123724288017357924">ক্যাশে করা কন্টেন্ট এড়িয়ে বর্তমান পৃষ্ঠা আবার লোড করুন</translation>
-<translation id="124116460088058876">আরও ভাষা</translation>
-<translation id="124678866338384709">বর্তমান ট্যাব বন্ধ করুন</translation>
-<translation id="1258753120186372309">Google ডুডল: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">সার্চ করুন, ঘুরে দেখুন</translation>
-<translation id="1264974993859112054">খেলাধূলা</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> শেয়ার করা যায়নি</translation>
-<translation id="1272079795634619415">বন্ধ</translation>
-<translation id="1283039547216852943">প্রসারিত করতে আলতো চাপুন</translation>
-<translation id="1285320974508926690">কখনই এই সাইটটিকে অনুবাদ করবেন না</translation>
-<translation id="1291207594882862231">ইতিহাস, কুকিজ, সাইট ডেটা, ক্যাশে সাফ করে...</translation>
-<translation id="129382876167171263">ওয়েবসাইট যেসব ফাইল সেভ করে সেগুলি এখানে দেখা যায়</translation>
-<translation id="129553762522093515">সম্প্রতি বন্ধ হয়েছে</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> থেকে পাঠানো হয়েছে</translation>
-<translation id="1310482092992808703">ট্যাবগুলি গ্রুপ করুন</translation>
-<translation id="1327257854815634930">নেভিগেশনের ইতিহাস খোলা হয়েছে</translation>
-<translation id="1331212799747679585">Chrome আপডেট হচ্ছে না। আরও বিকল্প</translation>
-<translation id="1332501820983677155">Google Chrome এর বাছাই করা শর্টকাটগুলি</translation>
-<translation id="1360432990279830238">সাইন-আউট করে সিঙ্ক বন্ধ করবেন?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> সাইট যোগ করা হয়েছে</translation>
-<translation id="1373696734384179344">নির্বাচিত কন্টেন্ট ডাউনলোড করার জন্য যথেষ্ট মেমরি নেই৷</translation>
-<translation id="1376578503827013741">গণনা করছে...</translation>
-<translation id="1383876407941801731">সার্চ করুন</translation>
-<translation id="1384959399684842514">ডাউনলোড পজ করা আছে</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> দিন আগে ব্যবহার করা হয়েছে</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> এর সাহায্যে খুঁজুন</translation>
-<translation id="1404122904123200417">এর মধ্যে এম্বেড করা হয়েছে <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"ট্র্যাক করবেন না"</translation>
-<translation id="1407135791313364759">সব খুলুন</translation>
-<translation id="1409426117486808224">খোলা ট্যাবের জন্য সরলীকৃত ভিউ</translation>
-<translation id="1409879593029778104">ফাইল ইতিমধ্যেই থাকায় <ph name="FILE_NAME" /> ডাউনলোড আটকানো হয়েছে।</translation>
-<translation id="1414981605391750300">Google এর সাথে যোগাযোগ করা হচ্ছে। এতে একটু সময় লাগবে…</translation>
-<translation id="1416550906796893042">অ্যাপ্লিকেশন ভার্সন</translation>
-<translation id="1430915738399379752">প্রিন্ট</translation>
-<translation id="1446450296470737166">MIDI ডিভাইসগুলির পূর্ণ নিয়ন্ত্রণের অনুমতি দিন</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> শেয়ার করা যাচ্ছে না</translation>
-<translation id="145097072038377568">Android সেটিংসে বন্ধ করা অাছে</translation>
-<translation id="1477626028522505441">সার্ভার সমস্যার কারণে <ph name="FILE_NAME" /> ডাউনলোড করা যায়নি।</translation>
-<translation id="1506061864768559482">সার্চ ইঞ্জিন</translation>
-<translation id="1513352483775369820">বুকমার্কগুলি এবং ওয়েব ইতিহাস</translation>
-<translation id="1513858653616922153">পাসওয়ার্ড মুছুন</translation>
-<translation id="1516229014686355813">'সার্চ করতে ট্যাপ করুন' বৈশিষ্ট্যটি Google সার্চের রেফারেন্স হিসেবে বেছে নেওয়া শব্দ এবং বর্তমান পৃষ্ঠাটি পাঠায়। আপনি <ph name="BEGIN_LINK" />সেটিংস<ph name="END_LINK" /> থেকে এটি বন্ধ করতে পারেন।</translation>
-<translation id="1521774566618522728">আজ ব্যবহার করা হয়েছে</translation>
-<translation id="1544826120773021464">আপনার Google অ্যাকাউন্ট ম্যানেজ করতে, "অ্যাকাউন্ট ম্যানেজ করুন" বোতামে ট্যাপ করুন</translation>
-<translation id="1549000191223877751">অন্য উইন্ডোতে সরান</translation>
-<translation id="1553358976309200471">Chrome আপডেট করুন</translation>
-<translation id="1569387923882100876">সংযুক্ত ডিভাইস</translation>
-<translation id="1571304935088121812">ইউজারনেম কপি করুন</translation>
-<translation id="1612196535745283361">ডিভাইস স্ক্যান করার জন্য Chrome এর অবস্থানের অ্যাক্সেস প্রয়োজন। অবস্থানের অ্যাক্সেস <ph name="BEGIN_LINK" />এই ডিভাইসের জন্য বন্ধ করা হয়েছে<ph name="END_LINK" />।</translation>
-<translation id="1620510694547887537">ক্যামেরা</translation>
-<translation id="1623104350909869708">এই পৃষ্ঠাটিকে অতিরিক্ত কথোপকথন তৈরি করা থেকে বাধা দিন</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{১ টি নির্বাচিত আইটেম সরান}one{#টি নির্বাচিত আইটেম সরান}other{#টি নির্বাচিত আইটেম সরান}}</translation>
-<translation id="164269334534774161">আপনি <ph name="CREATION_TIME" /> তারিখের এই পৃষ্ঠার একটি অফলাইন কপি দেখছেন</translation>
-<translation id="1644574205037202324">ইতিহাস</translation>
-<translation id="1647391597548383849">আপনার ক্যামেরা অ্যাক্সেস করুন</translation>
-<translation id="1660204651932907780">সাউন্ডটি প্লে করার জন্য সাইটটিতে অনুমতি দিন (প্রস্তাবিত)</translation>
-<translation id="1670399744444387456">প্রাথমিক</translation>
-<translation id="1671236975893690980">ডাউনলোড মুলতবি হয়ে আছে...</translation>
-<translation id="1672586136351118594">আর দেখতে চাই না</translation>
-<translation id="1692118695553449118">সিঙ্ক চালু রয়েছে</translation>
-<translation id="169515064810179024">মোশন সেন্সর অ্যাক্সেস করা থেকে সাইটকে ব্লক করুন</translation>
-<translation id="1717218214683051432">মোশন সেন্সর</translation>
-<translation id="1718835860248848330">শেষ ঘণ্টা</translation>
-<translation id="1736419249208073774">ঘুরে দেখুন</translation>
-<translation id="1743802530341753419">কোনও সাইটকে ডিভাইসের সাথে কানেক্ট করার আগে অনুমতি দেওয়ার ব্যবস্থা রাখুন (প্রস্তাবিত)</translation>
-<translation id="1749561566933687563">আপনার বুকমার্কগুলি সিঙ্ক করুন</translation>
-<translation id="17513872634828108">খোলা ট্যাব</translation>
-<translation id="1779089405699405702">ইমেজ ডিকোডার</translation>
-<translation id="1782483593938241562">শেষ হওয়ার তারিখ <ph name="DATE" /></translation>
-<translation id="1791662854739702043">ইনস্টল হয়েছে</translation>
-<translation id="1792959175193046959">যেকোনও সময় ডাউনলোডের ডিফল্ট লোকেশন পরিবর্তন করুন</translation>
-<translation id="1807246157184219062">আলো</translation>
-<translation id="1810845389119482123">প্রারম্ভিক সিঙ্ক সেট-আপ করা সম্পূর্ণ হয়নি</translation>
-<translation id="1821253160463689938">আপনার পছন্দগুলি মনে রাখার জন্য কুকি ব্যবহার করে। আপনি সেই সমস্ত পৃষ্ঠায় না গেলেও তা করে থাকে</translation>
-<translation id="1829244130665387512">পৃষ্ঠাতে খুঁজুন</translation>
-<translation id="1853692000353488670">নতুন ছদ্মবেশী ট্যাব</translation>
-<translation id="1856325424225101786">লাইট মোড রিসেট করবেন?</translation>
-<translation id="1868024384445905608">Chrome এখন আরও দ্রুত ফাইল ডাউনলোড করে</translation>
-<translation id="1883903952484604915">আমার ফাইল</translation>
-<translation id="1887786770086287077">এই ডিভাইসে লোকেশন অ্যাক্সেস বন্ধ আছে। চালু করতে <ph name="BEGIN_LINK" />Android সেটিংসে<ph name="END_LINK" /> যান।</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" />Chrome এ খুলবে। চালিয়ে যাওয়ার অর্থ আপনি Chrome এর <ph name="BEGIN_LINK1" />পরিষেবার শর্তাবলী<ph name="END_LINK1" />  এবং <ph name="BEGIN_LINK2" />গোপনীয়তা বিজ্ঞপ্তি<ph name="END_LINK2" />র সাথে সম্মত হচ্ছেন।</translation>
-<translation id="1919345977826869612">বিজ্ঞাপন</translation>
-<translation id="1919950603503897840">পরিচিতিগুলি বেছে নিন</translation>
-<translation id="1922076542920281912">Chrome যাতে আপনার লোকেশন অ্যাক্সেস করতে পারে তার জন্য <ph name="BEGIN_LINK" />Android সেটিংস<ph name="END_LINK" />-এ গিয়ে লোকেশন চালু করুন।</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">আপডেটগুলি</translation>
-<translation id="19288952978244135">Chrome আবার খুলুন।</translation>
-<translation id="1933845786846280168">নির্বাচিত ট্যাবগুলি</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android সেটিংসে<ph name="END_LINK" /> Chrome এর জন্য অনুমতি চালু করুন।</translation>
-<translation id="1943432128510653496">পাসওয়ার্ডগুলি সেভ করুন</translation>
-<translation id="1952172573699511566">যখন সম্ভব হবে ওয়েবসাইট আপনার পছন্দের ভাষায় টেক্সট দেখাবে।</translation>
-<translation id="1960290143419248813">Android-এর এই ভার্সনে Chrome আপডেট করা আর সম্ভব নয়</translation>
-<translation id="1966710179511230534">অনুগ্রহ করে আমার সাইন-ইন বিবরণ আপডেট করুন।</translation>
-<translation id="1974060860693918893">উন্নত</translation>
-<translation id="1984705450038014246">আপনার Chrome ডেটা সিঙ্ক করুন</translation>
-<translation id="1984937141057606926">মঞ্জুরিপ্রাপ্ত, তৃতীয় পক্ষ ব্যাতীত</translation>
-<translation id="1986685561493779662">নামটি আগে থেকেই আছে</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> বোতাম</translation>
-<translation id="1989112275319619282">ব্রাউজ করুন</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> এদের সঙ্গে যুক্ত হতে চাচ্ছে</translation>
-<translation id="1994173015038366702">সাইট URL</translation>
-<translation id="2000419248597011803">অ্যাড্রেস বার এবং সার্চ বক্স থেকে সার্চের তথ্য এবং কিছু কুকি আপনার ডিফল্ট সার্চ ইঞ্জিনে পাঠায়</translation>
-<translation id="2002537628803770967">Google Pay ব্যবহার করে ক্রেডিট কার্ড এবং ঠিকানা</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{#টি ফাইল}one{#টি ফাইল}other{#টি ফাইল}}</translation>
-<translation id="2017836877785168846">অ্যাড্রেস বার থেকে ইতিহাস ও অটোকমপ্লিট মুছে ফেলে।</translation>
-<translation id="2021896219286479412">পূর্ণ স্ক্রিন সাইট নিয়ন্ত্রণ</translation>
-<translation id="2038563949887743358">ডেস্কটপ সাইটের অনুরোধ চালু করুন</translation>
-<translation id="2041019821020695769">Chrome যাতে আপনাকে বিজ্ঞপ্তি পাঠাতে পারে তার জন্য আপনি <ph name="BEGIN_LINK" />Android সেটিংস<ph name="END_LINK" />-এ গিয়ে বিজ্ঞপ্তি চালু করুন।</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> অ্যাপের ডেটা Chrome ব্রাউজারেও আছে</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">সাইট পজ করা আছে</translation>
-<translation id="2063713494490388661">সার্চ করতে আলতো চাপুন</translation>
-<translation id="2067805253194386918">টেক্সট</translation>
-<translation id="2079545284768500474">আগের অবস্থায় ফিরুন</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" /> এর মধ্যে <ph name="RESULT_NUMBER" /> টি ফলাফল</translation>
-<translation id="2091887806945687916">আওয়াজ</translation>
-<translation id="2096012225669085171">বিভিন্ন ডিভাইস জুড়ে সিঙ্ক এবং ব্যক্তিগতকৃত করুন</translation>
-<translation id="2100273922101894616">অটো সাইন-ইন</translation>
-<translation id="2100314319871056947">টেক্সটটি ছোট ছোট ভাগে ভাগ করে পাঠানোর চেষ্টা করুন</translation>
-<translation id="2107397443965016585">সাইটকে সুরক্ষিত কন্টেন্ট চালানোর অনুমতি দেওয়ার আগে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
-<translation id="2111511281910874386">এই পৃষ্ঠাতে যান</translation>
-<translation id="2122601567107267586">অ্যাপটি খোলা যায়নি</translation>
-<translation id="2126426811489709554">Chrome দ্বারা চালিত</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> সংরক্ষণ করা হয়েছে</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> বন্ধ করা হয়েছে</translation>
-<translation id="2139186145475833000">হোম স্ক্রীনে যোগ করুন</translation>
-<translation id="2146738493024040262">ইনস্ট্যান্ট অ্যাপ খুলুন</translation>
-<translation id="2148716181193084225">আজ</translation>
-<translation id="2154484045852737596">কার্ড সম্পাদনা করুন</translation>
-<translation id="2154710561487035718">ইউআরএল কপি করুন</translation>
-<translation id="2156074688469523661">(<ph name="NUMBER_OF_SITES" />)টি সাইট বাকি আছে</translation>
-<translation id="2157851137955077194">আপনার ফোন থেকে অন্য কোনও ডিভাইসে কিছু শেয়ার করতে হলে, দুটি ডিভাইসের Chrome সেটিংস থেকে সিঙ্ক ফিচার চালু করুন</translation>
-<translation id="2170088579611075216">ভিআর প্রেজেন্টেশন শুরু করার অনুমতি দিন</translation>
-<translation id="218608176142494674">শেয়ার করা সংক্রান্ত বিজ্ঞপ্তি</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> হিসেবে চালিয়ে যান</translation>
-<translation id="2234876718134438132">সিঙ্ক এবং Google পরিষেবাগুলি</translation>
-<translation id="2259659629660284697">পাসওয়ার্ড এক্সপোর্ট করুন...</translation>
-<translation id="2268044343513325586">রিফাইন করুন</translation>
-<translation id="2286841657746966508">বিলিং ঠিকানা</translation>
-<translation id="2289270750774289114">কাছাকাছি ব্লুটুথ ডিভাইস আছে কিনা তা কোনও সাইট খুঁজতে চাইলে আমাকে জিজ্ঞাসা করুন (সাজেস্ট করা হচ্ছে)</translation>
-<translation id="230115972905494466">উপযুক্ত ডিভাইস খুঁজে পাওয়া যায়নি</translation>
-<translation id="2315043854645842844">ক্লায়েন্ট সাইড সার্টিফিকেট নির্বাচন অপারেটিং সিসটেম দ্বারা সমর্থিত নয়।</translation>
-<translation id="2318045970523081853">কল করতে ট্যাপ করুন</translation>
-<translation id="2321086116217818302">পাসওয়ার্ড তৈরি করা হচ্ছে…</translation>
-<translation id="2321958826496381788">আপনি এটি স্বচ্ছন্দে পড়তে না পারা পর্যন্ত স্লাইডারটি টেনে আনুন৷ কোনো অনুচ্ছেদে দুবার-আলতো চাপার পরে পাঠ্যটিকে দেখতে অন্ততপক্ষে এইরকম বড় লাগা উচিত৷</translation>
-<translation id="2323763861024343754">সাইটের স্টোরেজ</translation>
-<translation id="2328985652426384049">সাইন ইন করতে পারছেন না</translation>
-<translation id="2330129964253841015">পাসওয়ার্ড হ্যাক করার চেষ্টা করা হলে আপনাকে জানানো হবে</translation>
-<translation id="2349710944427398404">অ্যাকাউন্ট, ​​বুকমার্ক এবং স্টোর করা সেটিংসসহ Chrome-এর ব্যবহার করা মোট ডেটা</translation>
-<translation id="2353636109065292463">আপনার ইন্টারনেট কানেকশন ঠিক আছে কিনা সেটি দেখা হচ্ছে</translation>
-<translation id="2359808026110333948">চালিয়ে যান</translation>
-<translation id="2369533728426058518">খোলা ট্যাবগুলি</translation>
-<translation id="2387895666653383613">পাঠ্য স্কেলিং</translation>
-<translation id="2394602618534698961">আপনার ডাউনলোড করা ফাইল এখানে দেখানো হয়</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> এমবি</translation>
-<translation id="2407481962792080328">আপনার Google অ্যাকাউন্টে সাইন-ইন করলে এই ফিচারটি চালু হয়ে যাবে</translation>
-<translation id="2410754283952462441">একটি অ্যাকাউন্ট বেছে নিন</translation>
-<translation id="2414886740292270097">অন্ধকার</translation>
-<translation id="2416359993254398973">এই সাইটটির জন্য Chrome কে আপনার ক্যামেরায় অ্যাক্সেস দিতে হবে।</translation>
-<translation id="2426805022920575512">অন্য একটি অ্যাকাউন্ট বেছে নিন</translation>
-<translation id="2433507940547922241">উপস্থিতি</translation>
-<translation id="2434158240863470628"><ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /> ডাউনলোড সম্পূর্ণ হয়েছে</translation>
-<translation id="2440823041667407902">লোকেশন অ্যাক্সেস</translation>
-<translation id="2450083983707403292">আপনি কি আবার <ph name="FILE_NAME" /> ডাউনলোড করা শুরু করতে চান?</translation>
-<translation id="2482878487686419369">বিজ্ঞপ্তিগুলি</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> ম্যানেজ করে</translation>
-<translation id="2494974097748878569">Chrome-এ Google অ্যাসিস্ট্যান্ট</translation>
-<translation id="2496180316473517155">ব্রাউজিং ইতিহাস</translation>
-<translation id="2497852260688568942">আপনার প্রশাসকের দ্বারা সিঙ্ক অক্ষম করা হয়েছে</translation>
-<translation id="2498359688066513246">সহায়তা ও প্রতিবার্তা</translation>
-<translation id="2501278716633472235">ফিরে যান</translation>
-<translation id="2513403576141822879">আপনার গোপনীয়তা, নিরাপত্তা এবং ডেটা সংগ্রহের সাথে সম্পর্কযুক্ত আরও সেটিংসের জন্য <ph name="BEGIN_LINK" />সিঙ্ক এবং Google পরিষেবাগুলি<ph name="END_LINK" /> দেখুন</translation>
-<translation id="2518590038762162553">লাইট মোডে, Chrome আরও দ্রুত পৃষ্ঠা লোড করে এবং ৬০ শতাংশ পর্যন্ত কম ডেটা ব্যবহার করে। আপনার ভিজিট করা পৃষ্ঠাকে অপ্টিমাইজ করার জন্য Chrome আপনার ওয়েব ট্রাফিককে Google-এ পাঠায়। <ph name="BEGIN_LINK" />আরও জানুন<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">আপনার দেখা পৃষ্ঠাগুলির ইউআরএল Google-এ পাঠায়</translation>
-<translation id="2532336938189706096">ওয়েব দর্শন</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" />টি আইটেম মোছা হয়েছে</translation>
-<translation id="2536728043171574184">এই পৃষ্ঠার একটি অফলাইন কপি দেখছেন</translation>
-<translation id="2546283357679194313">কুকিজ ও সাইট ডেটা</translation>
-<translation id="2567385386134582609">ইমেজ</translation>
-<translation id="257088987046510401">থিমসমূহ</translation>
-<translation id="2570922361219980984">এই ডিভাইসেও লোকেশন অ্যাক্সেস বন্ধ আছে। চালু করতে <ph name="BEGIN_LINK" />Android সেটিংসে<ph name="END_LINK" /> যান।</translation>
-<translation id="257931822824936280">প্রসারিত - সঙ্কুচিত করতে ক্লিক করুন৷</translation>
-<translation id="2581165646603367611">এটা কুকিজ, ক্যাশে, এবং সাইটের সেই সব ডেটা যা Chrome গুরুত্বপূর্ণ মনে করে না সেগুলিকে সাফ করবে।</translation>
-<translation id="2586657967955657006">ক্লিপবোর্ড</translation>
-<translation id="2587052924345400782">নতুন ভার্সন উপলভ্য</translation>
-<translation id="2593272815202181319">মোনোস্পেস</translation>
-<translation id="2612676031748830579">কার্ড নম্বর</translation>
-<translation id="2621115761605608342">একটি নির্দিষ্ট সাইটের জন্য জাভাস্ক্রিপ্ট মঞ্জুর করুন।</translation>
-<translation id="2625189173221582860">পাসওয়ার্ড কপি করা হয়েছে</translation>
-<translation id="2631006050119455616">সংরক্ষিত হয়েছে</translation>
-<translation id="2647434099613338025">ভাষা যুক্ত করুন</translation>
-<translation id="2650751991977523696">আবার ফাইল ডাউনলোড করবেন?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{#টি অডিও ফাইল}one{#টি অডিও ফাইল}other{#টি অডিও ফাইল}}</translation>
-<translation id="2653659639078652383">জমা দিন</translation>
-<translation id="2677748264148917807">ছেড়ে চলে যান</translation>
-<translation id="2704606927547763573">প্রতিলিপি করা হয়েছে</translation>
-<translation id="2707726405694321444">পৃষ্ঠা রিফ্রেশ করুন</translation>
-<translation id="2709516037105925701">স্বয়ংপূরণ</translation>
-<translation id="2717722538473713889">ইমেল আইডি</translation>
-<translation id="2728754400939377704">সাইট অনুযায়ী সাজান</translation>
-<translation id="2744248271121720757">ঝটপট সার্চ এবং সম্পর্কিত অ্যাকশন দেখতে একটি শব্দ ট্যাপ করুন</translation>
-<translation id="2760989362628427051">আপনার ডিভাইসে গাঢ় থিম বা ব্যাটারি সেভার চালু থাকলে, গাঢ় থিম চালু করুন</translation>
-<translation id="2762000892062317888">এখনই</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> সেকেন্ড বাকি আছে</translation>
-<translation id="2779651927720337254">করা যায়নি</translation>
-<translation id="2781151931089541271">১ সেকেন্ড বাকি আছে</translation>
-<translation id="2801022321632964776">নিজের ভাষায় ব্রাউজ করতে, Chrome-কে লেটেস্ট ভার্সনে আপডেট করুন</translation>
-<translation id="2810645512293415242">পৃষ্ঠায় সহজে ডেটা সংরক্ষণ করে এবং দ্রুত লোড করুন।</translation>
-<translation id="281504910091592009">আপনার <ph name="BEGIN_LINK" />Google অ্যাকাউন্ট<ph name="END_LINK" />-এ সেভ করা পাসওয়ার্ড দেখুন এবং পরিচালনা করুন</translation>
-<translation id="2818669890320396765">আপনার সমস্ত ডিভাইসে বুকমার্কগুলি পেতে সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="2822354292072154809">আপনি কি <ph name="CHOSEN_OBJECT_NAME" />-এর জন্য সাইটের সব অনুমতি রিসেট করার ব্যাপারে নিশ্চিত?</translation>
-<translation id="2836148919159985482">পূর্ণ স্ক্রিন থেকে বেরিয়ে যেতে পিছনে ফেরার বোতাম স্পর্শ করুন।</translation>
-<translation id="2842985007712546952">অভিভাবক ফোল্ডার</translation>
-<translation id="2858138569776157458">সেরা সাইট</translation>
-<translation id="2860954141821109167">এই ডিভাইসে ফোন অ্যাপ চালু করা আছে কিনা দেখে নিন</translation>
-<translation id="2870560284913253234">সাইট</translation>
-<translation id="2874939134665556319">পূর্ববর্তী ট্র্যাক</translation>
-<translation id="2876369937070532032">নিরাপত্তা সংক্রান্ত কোনও ঝুঁকি থাকলে, আপনার দেখা কিছু পৃষ্ঠার ইউআরএল Google-কে পাঠায়</translation>
-<translation id="2888126860611144412">Chrome সম্বন্ধে</translation>
-<translation id="2891154217021530873">পৃষ্ঠা লোড করা বন্ধ করুন</translation>
-<translation id="2893180576842394309">সার্চ এবং অন্যান্য Google পরিষেবাকে আপনার মতো করে সাজিয়ে নিতে Google আপনার ইতিহাস ব্যবহার করতে পারে</translation>
-<translation id="2898264748040935573">স্টোর করা পাসওয়ার্ড এডিট করুন</translation>
-<translation id="2900528713135656174">ইভেন্ট তৈরি করুন</translation>
-<translation id="290376772003165898">পৃষ্ঠাটি <ph name="LANGUAGE" /> ভাষায় নয়?</translation>
-<translation id="2904414404539560095">ট্যাব শেয়ার করা যাবে এমন ডিভাইসের সূচি সম্পূর্ণ স্ক্রিন জুড়ে খোলা হয়েছে।</translation>
-<translation id="2910701580606108292">কোনও সাইটে সুরক্ষিত কন্টেন্ট চালু হওয়ার আগে আমায় জিজ্ঞেস করা হোক</translation>
-<translation id="2913331724188855103">সাইটগুলিকে কুকি ডেটা পড়ার এবং সংরক্ষণ করার অনুমতি দিন (প্রস্তাবিত)</translation>
-<translation id="2923908459366352541">নাম সঠিক নয়</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> স্টোরেজ</translation>
-<translation id="2942036813789421260">প্রিভিউ ট্যাব বন্ধ করা আছে</translation>
-<translation id="2956410042958133412">এই অ্যাকাউন্টটি <ph name="PARENT_NAME_1" /> এবং <ph name="PARENT_NAME_2" /> দ্বারা পরিচালিত হয়৷</translation>
-<translation id="2962095958535813455">ছদ্মবেশী ট্যাবে পাল্টানো হয়েছে</translation>
-<translation id="2968755619301702150">সার্টিফিকেট প্রদর্শনকারী</translation>
-<translation id="2979025552038692506">নির্বাচিত ছদ্মবেশী ট্যাবগুলি</translation>
-<translation id="2987620471460279764">অন্য ডিভাইস থেকে টেক্সট শেয়ার করা হয়েছে</translation>
-<translation id="2989523299700148168">সাম্প্রতিক দেখা হয়েছে</translation>
-<translation id="2996291259634659425">পাসফ্রেজ তৈরি করুন</translation>
-<translation id="2996809686854298943">URL প্রয়োজন</translation>
-<translation id="300526633675317032">এটা ওয়েবসাইট স্টোরেজের <ph name="SIZE_IN_KB" />-এর পুরোটা সাফ করবে।</translation>
-<translation id="3016635187733453316">এই ডিভাইসটি ইন্টারনেটে কানেক্ট করা আছে কিনা দেখে নিন</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB ডাউনলোড হয়েছে</translation>
-<translation id="3029704984691124060">পাসফ্রেজসমূহ মেলে না</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />সহায়তা পান<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">লোকেশনটি বন্ধ, <ph name="BEGIN_LINK" />Android সেটিংস<ph name="END_LINK" /> থেকে এটি চালু করুন।</translation>
-<translation id="3058498974290601450">যেকোনও সময় সেটিংস থেকে আপনি সিঙ্ক চালু করতে পারেন</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" />টি বুকমার্ক}one{<ph name="BOOKMARKS_COUNT_MANY" />টি বুকমার্ক}other{<ph name="BOOKMARKS_COUNT_MANY" />টি বুকমার্ক}}</translation>
-<translation id="3089395242580810162">ছদ্মবেশী ট্যাবে খুলুন</translation>
-<translation id="3115898365077584848">তথ্য দেখুন</translation>
-<translation id="3123473560110926937">কিছু সাইটে ব্লক করা হয়েছে</translation>
-<translation id="3137521801621304719">ছদ্মবেশী মোড ছেড়ে যান</translation>
-<translation id="3143515551205905069">সিঙ্ক বাতিল করুন</translation>
-<translation id="3157842584138209013">আরও বিকল্প বোতাম দিয়ে দেখুন আপনি কত ডেটা সাশ্রয় করেছেন</translation>
-<translation id="3166827708714933426">ট্যাব এবং উইন্ডোর শর্টকাটগুলি</translation>
-<translation id="3181954750937456830">নিরাপদ ব্রাউজিং (বিপজ্জনক সাইট থেকে আপনাকে এবং আপনার ডিভাইসকে রক্ষা করে)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android সেটিংসে<ph name="END_LINK" /> Chrome এর জন্য অনুমতিগুলি চালু করুন।</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> সংরক্ষিত ডেটা</translation>
-<translation id="3205824638308738187">প্রায় শেষ হয়ে গেছে!</translation>
-<translation id="3207960819495026254">বুকমার্ক করা হয়েছে</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> মুছে ফেলা হয়েছে</translation>
-<translation id="321773570071367578">আপনি যদি আপনার পাসফ্রেজ ভুলে যান বা এই সেটিং পরিবর্তন করতে চান, তাহলে <ph name="BEGIN_LINK" />সিঙ্ক পুনরায় সেট করুন<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">মাইক্রোফোন</translation>
-<translation id="3232754137068452469">ওয়েব অ্যাপ</translation>
-<translation id="3236059992281584593">১ মিনিট বাকি আছে</translation>
-<translation id="3244271242291266297">মিমি</translation>
-<translation id="3254409185687681395">এই পৃষ্ঠাটি বুকমার্ক করুন</translation>
-<translation id="3259831549858767975">পৃষ্ঠাতে থাকা সবকিছুকে ছোট করুন</translation>
-<translation id="3269093882174072735">ইমেজ লোড করুন</translation>
-<translation id="3269956123044984603">আপনার অন্য ডিভাইসগুলি থেকে আপনার ট্যাবগুলি পেতে, Android অ্যাকাউন্ট সেটিংসে "ডেটা অটো-সিঙ্ক" চালু করুন।</translation>
-<translation id="3277252321222022663">সাইটকে সেন্সর অ্যাক্সেস করার অনুমতি দিন (সাজেস্ট করা হয়)</translation>
-<translation id="3282568296779691940">Chrome-এ সাইন-ইন করুন</translation>
-<translation id="3288003805934695103">পৃষ্ঠাটি আবার লোড করে দেখুন</translation>
-<translation id="32895400574683172">বিজ্ঞপ্তিগুলি অনুমোদিত</translation>
-<translation id="3295530008794733555">চটপট ব্রাউজ করুন। আরও কম ডেটা ব্যবহার করুন।</translation>
-<translation id="3295602654194328831">তথ্য লুকান</translation>
-<translation id="3298243779924642547">লাইট</translation>
-<translation id="3303414029551471755">কন্টেন্ট ডাউনলোড করার জন্য এগোতে চান?</translation>
-<translation id="3306398118552023113">Chrome-এ এই অ্যাপটি চলছে</translation>
-<translation id="3315103659806849044">আপনি এখন আপনার সিঙ্ক এবং Google পরিষেবার সেটিংস কাস্টমাইজ করছেন। স্ক্রিনের নিচের দিকে থাকা 'কনফার্ম করুন' বোতামে ট্যাপ করে সিঙ্ক চালু দিন। উপরে নেভিগেট করুন</translation>
-<translation id="3328801116991980348">সাইট তথ্য</translation>
-<translation id="3333961966071413176">সব পরিচিতি</translation>
-<translation id="3334729583274622784">ফাইলের এক্সটেনশন পরিবর্তন করতে চান?</translation>
-<translation id="3341058695485821946">দেখুন আপনি কত ডেটা সাশ্রয় করেছেন</translation>
-<translation id="3350687908700087792">সমস্ত ছদ্মবেশী ট্যাব বন্ধ করুন</translation>
-<translation id="3353615205017136254">Google লাইট পৃষ্ঠা পাঠিয়েছে। আসল পৃষ্ঠাটি লোড করতে "আসলটি লোড করুন" বোতামে ট্যাপ করুন।</translation>
-<translation id="3367813778245106622">সিঙ্ক করা শুরু করতে আবার সাইন-ইন করুন</translation>
-<translation id="3374023511497244703">আপনার বুকমার্ক, ইতিহাস, পাসওয়ার্ড ও অন্যান্য Chrome ডেটা আর আপনার Google অ্যাকাউন্টের সাথে সিঙ্ক করা হবে না</translation>
-<translation id="3384347053049321195">ইমেজ শেয়ার করুন</translation>
-<translation id="3386292677130313581">সাইটগুলিকে আপনার লোকেশন জানতে দিতে মঞ্জুরি দেওয়ার আগে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
-<translation id="3387650086002190359">ফাইল সিস্টেম ত্রুটির কারণে <ph name="FILE_NAME" /> ডাউনলোড করা যায়নি।</translation>
-<translation id="3389286852084373014">টেক্সটটি অনেক বড়</translation>
-<translation id="3398320232533725830">বুকমার্কস ম্যানেজার খুলুন</translation>
-<translation id="3414952576877147120">মাপ:</translation>
-<translation id="3443221991560634068">বর্তমান পৃষ্ঠাটি রিলোড করুন</translation>
-<translation id="3445014427084483498">এইমাত্র</translation>
-<translation id="3478363558367712427">আপনার সার্চ ইঞ্জিন বেছে নিতে পারেন</translation>
+<translation id="6910211073230771657">মোছা হয়েছে</translation>
+<translation id="6965382102122355670">ঠিক আছে</translation>
+<translation id="5301954838959518834">ঠিক আছে, বুঝেছি</translation>
+<translation id="7658239707568436148">বাতিল</translation>
 <translation id="3479552764303398839">এখনই নয়</translation>
-<translation id="3492207499832628349">নতুন ছদ্মবেশী ট্যাব</translation>
-<translation id="3493531032208478708">প্রস্তাবিত কন্টেন্ট সম্পর্কে <ph name="BEGIN_LINK" />আরও জানুন<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">অগমেন্টেড রিয়েলিটি</translation>
-<translation id="3518985090088779359">স্বীকার করুন ও অবিরত রাখুন</translation>
-<translation id="3522247891732774234">আপডেট উপলব্ধ। আরও বিকল্প</translation>
-<translation id="3524138585025253783">ডেভেলপার UI</translation>
-<translation id="3527085408025491307">ফোল্ডার</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> কেবি available</translation>
-<translation id="3549657413697417275">আপনার ইতিহাস খুঁজুন</translation>
-<translation id="3557336313807607643">পরিচিতিতে যোগ করুন</translation>
-<translation id="3566923219790363270">ভি আর সমর্থনের জন্য Chrome-এ এখনও কাজ চলছে। পরে Chrome রিস্টার্ট করুন।</translation>
-<translation id="3568688522516854065">আপনার অন্যান্য ডিভাইস থেকে ট্যাবগুলি পেতে সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="3587482841069643663">সকল</translation>
-<translation id="358794129225322306">একটি সাইটকে একাধিক ফাইল অটোমেটিক ডাউনলোড করার অনুমতি দিন।</translation>
-<translation id="3590487821116122040">যে সাইট স্টোরেজকে Chrome গুরুত্বপূর্ণ মনে করে না (উদাঃ সেভকরা সেটিংস বিহীন সাইটগুলি বা আপনি প্রায়শই ঘুরে দেখেন না এমন সাইটগুলি)</translation>
-<translation id="3599863153486145794">সমস্ত সাইন-ইন করা ডিভাইসগুলি থেকে ইতিহাস মুছে ফেলে। <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />-এ আপনার Google অ্যাকাউন্টের অন্যান্য ধরনের ব্রাউজিংয়ের ইতিহাস থাকতে পারে।</translation>
-<translation id="3600792891314830896">সাউন্ড প্লে করা হয় যে সাইটগুলিতে সেগুলি মিউট করুন</translation>
-<translation id="3616113530831147358">অডিও</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" />-এর সাথে শেয়ার করা হচ্ছে</translation>
-<translation id="3632295766818638029">পাসওয়ার্ড উম্মোচন করুন</translation>
-<translation id="363596933471559332">সঞ্চিত ক্রেডেনশিয়াল ব্যবহার করে ওয়েবসাইটগুলিতে অটোমেটিক সাইন-ইন। যখন বৈশিষ্ট্যটি বন্ধ করা থাকে, তখন প্রতিবারই একটি ওয়েবসাইটে সাইন-ইন করার সময় আপনাকে যাচাইকরণের জন্য বলা হবে।</translation>
-<translation id="3658159451045945436">রিসেট করলে আপনার ঘুরে দেখা সাইট সহ আপনার ডেটা সেভিংয়ের ইতিহাস মুছে দেয়।</translation>
-<translation id="3692944402865947621">স্টোর করার জায়গা খুঁজে না পাওয়ায় <ph name="FILE_NAME" /> ডাউনলোড করা যায়নি।</translation>
-<translation id="3714981814255182093">খুঁজুন দণ্ডটি খুলুন</translation>
-<translation id="3716182511346448902">এই পৃষ্ঠাটি খুব বেশি মেমরি ব্যবহার করছে তাই Chrome এটি বিরত রেখেছে।</translation>
-<translation id="3730075448226062617">Chrome যাতে আপনার মাইক্রোফোন অ্যাক্সেস করতে পারে তার জন্য <ph name="BEGIN_LINK" />Android সেটিংস<ph name="END_LINK" />-এ গিয়ে মাইক্রোফোন চালু করুন।</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> এ বুকমার্ক করা হয়েছে</translation>
-<translation id="3744111561329211289">পটভূমি সিঙ্ক</translation>
-<translation id="3771001275138982843">আপডেট ডাউনলোড করা যায়নি</translation>
-<translation id="3771033907050503522">ছদ্মবেশী ট্যাবগুলি</translation>
-<translation id="3773755127849930740">যুক্ত করার মঞ্জুরি দিতে <ph name="BEGIN_LINK" />ব্লুটুথ চালু করুন<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">আপনার ডিভাইসে পাঠান</translation>
-<translation id="3778956594442850293">হোম স্ক্রিনে যোগ করা হয়েছে</translation>
-<translation id="3789841737615482174">ইনস্টল করুন</translation>
-<translation id="3810838688059735925">ভিডিও</translation>
-<translation id="3810973564298564668">পরিচালনা</translation>
-<translation id="381841723434055211">ফোন নম্বর</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" />টি ডাউনলোড মোছা হয়েছে</translation>
-<translation id="3822502789641063741">সাইটের সঞ্চয়স্থান সাফ করবেন?</translation>
-<translation id="385051799172605136">ফিরুন</translation>
-<translation id="3859306556332390985">সামনে এগোন</translation>
-<translation id="3894427358181296146">ফোল্ডার যোগ করুন</translation>
-<translation id="3895926599014793903">ফোর্স জুম চালু করুন</translation>
-<translation id="3912508018559818924">ওয়েব থেকে সেরা ফলাফল লোড করা হচ্ছে…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">আমার ডেটা একত্রিত করুন</translation>
-<translation id="393697183122708255">কোনো সক্ষম ভয়েস সার্চ উপলব্ধ নেই</translation>
-<translation id="395206256282351086">সার্চ এবং সাইটের প্রস্তাবনা অক্ষম করা আছে</translation>
-<translation id="3955193568934677022">সুরক্ষিত কন্টেন্ট প্লে করতে সাইটগুলিকে মঞ্জুরি দিন (প্রস্তাবিত)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{রেডি হলেই Chrome আপনার পৃষ্ঠা লোড করবে}one{রেডি হলেই Chrome আপনার পৃষ্ঠা লোড করবে}other{রেডি হলেই Chrome আপনার পৃষ্ঠা লোড করবে}}</translation>
-<translation id="3963007978381181125">পাসফ্রেজ এনক্রিপশনে Google Pay-এর পেমেন্ট পদ্ধতি ও ঠিকানা অন্তর্ভুক্ত থাকে না। 
-আপনার পাসফ্রেজ আছে এমন কেউই শুধু আপনার এনক্রিপ্ট করা ডেটা পড়তে পারবেন। 
-পাসফ্রেজ Google-এ পাঠানো হয় না বা Google তা সংরক্ষণ করে না। পাসফ্রেজ ভুলে গেলে বা এই সেটিং পরিবর্তন করতে চাইলে, আপনাকে সিঙ্ক রিসেট করতে হবে। <ph name="BEGIN_LINK" />আরও জানুন<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ডাউনলোড সম্পূর্ণ</translation>
-<translation id="397583555483684758">সিঙ্ক কাজ করা বন্ধ করে দিয়েছে</translation>
-<translation id="3976396876660209797">এই শর্টকাটটি সরিয়ে নতুন করে তৈরি করুন</translation>
-<translation id="3985215325736559418">আপনি কি আবার <ph name="FILE_NAME" /> ডাউনলোড করতে চান?</translation>
-<translation id="3987993985790029246">লিঙ্ক কপি করুন</translation>
-<translation id="3988213473815854515">লোকেশন অনুমোদিত হয়েছে</translation>
-<translation id="3988466920954086464">সার্চের ফলাফল ঝটপট এই প্যানেলে দেখুন</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">গুরুত্বহীন সঞ্চয়স্থান</translation>
-<translation id="4000212216660919741">অফলাইন হোম</translation>
+<translation id="5317780077021120954">সেভ করুন</translation>
+<translation id="4570913071927164677">বিবরণ</translation>
+<translation id="8730621377337864115">হয়ে গেছে</translation>
+<translation id="8261506727792406068">মুছুন</translation>
+<translation id="1181037720776840403">সরান</translation>
+<translation id="5939518447894949180">রিসেট করুন</translation>
 <translation id="4002066346123236978">শিরোনাম</translation>
-<translation id="4008040567710660924">কোনও নির্দিষ্ট সাইটের জন্য কুকিকে অনুমতি দিন।</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ঘণ্টা}one{# ঘণ্টা}other{# ঘণ্টা}}</translation>
-<translation id="4046123991198612571">পরবর্তী ট্র্যাক</translation>
-<translation id="4048707525896921369">পৃষ্ঠাতে থাকাকালীন ওয়েবসাইটে গিয়ে বিষয়গুলি সম্পর্কে জানুন। 'সার্চ করতে ট্যাপ করা' বৈশিষ্ট্যটি একটি শব্দ এবং এটির সাথে সম্পর্কযুক্ত প্রসঙ্গ Google সার্চে পাঠায়, তার সাথে সংজ্ঞা, ছবি, সার্চ ফলাফল এবং আরও অনেক কিছু দেখায়৷
+<translation id="5916664084637901428">চালু</translation>
+<translation id="5860033963881614850">বন্ধ করুন</translation>
+<translation id="6165508094623778733">আরও জানুন</translation>
+<translation id="6042308850641462728">আরও</translation>
+<translation id="6040143037577758943">বন্ধ</translation>
+<translation id="780301667611848630">না থাক</translation>
+<translation id="1201402288615127009">পরবর্তী</translation>
+<translation id="2359808026110333948">চালিয়ে যান</translation>
+<translation id="2653659639078652383">জমা দিন</translation>
+<translation id="2079545284768500474">আগের অবস্থায় ফিরুন</translation>
+<translation id="7649070708921625228">সহায়তা</translation>
+<translation id="2148716181193084225">আজ</translation>
+<translation id="7781829728241885113">গতকাল</translation>
+<translation id="6945221475159498467">নির্বাচন</translation>
+<translation id="7791543448312431591">জুড়ুন</translation>
+<translation id="6527303717912515753">শেয়ার করুন</translation>
+<translation id="1383876407941801731">সার্চ করুন</translation>
+<translation id="3115898365077584848">তথ্য দেখুন</translation>
+<translation id="3295602654194328831">তথ্য লুকান</translation>
+<translation id="3987993985790029246">লিঙ্ক কপি করুন</translation>
+<translation id="2704606927547763573">প্রতিলিপি করা হয়েছে</translation>
+<translation id="8725066075913043281">আবার চেষ্টা করুন</translation>
+<translation id="385051799172605136">ফিরুন</translation>
+<translation id="8131740175452115882">নিশ্চিত হন</translation>
+<translation id="5300589172476337783">দেখান</translation>
+<translation id="1124772482545689468">ব্যবহারকারী</translation>
+<translation id="8609465669617005112">উপরে যান</translation>
+<translation id="6746124502594467657">নিচে যান</translation>
+<translation id="8249310407154411074">শীর্ষে সরান</translation>
+<translation id="8428213095426709021">সেটিংস</translation>
+<translation id="2498359688066513246">সহায়তা ও প্রতিবার্তা</translation>
+<translation id="8378714024927312812">আপনার প্রতিষ্ঠানের দ্বারা ম্যানেজ করা</translation>
+<translation id="9019902583201351841">আপনার পিতামাতার দ্বারা পরিচালিত</translation>
+<translation id="4645575059429386691">আপনার পিতামাতার দ্বারা পরিচালিত</translation>
+<translation id="4883854917563148705">ম্যানেজ করা সেটিংস রিসেট করা যায় না</translation>
+<translation id="4307992518367153382">বুনিয়াদি</translation>
+<translation id="1974060860693918893">উন্নত</translation>
+<translation id="1146678959555564648">(ভিআর)VR লিখুন</translation>
+<translation id="987264212798334818">সাধারণ</translation>
+<translation id="4275663329226226506">মাধ্যম</translation>
+<translation id="4759238208242260848">ডাউনলোডগুলি</translation>
+<translation id="218608176142494674">শেয়ার করা সংক্রান্ত বিজ্ঞপ্তি</translation>
+<translation id="8004582292198964060">ব্রাউজার</translation>
+<translation id="1105960400813249514">স্ক্রিন ক্যাপচার</translation>
+<translation id="4875775213178255010">কন্টেন্টের প্রস্তাবনা</translation>
+<translation id="2021896219286479412">পূর্ণ স্ক্রিন সাইট নিয়ন্ত্রণ</translation>
+<translation id="4587589328781138893">সাইটগুলি</translation>
+<translation id="4943703118917034429">ভার্চুয়াল রিয়ালিটি</translation>
+<translation id="1928696683969751773">আপডেটগুলি</translation>
+<translation id="6064125863973209585">সম্পূর্ণ হয়ে যাওয়া ডাউনলোড</translation>
+<translation id="5342314432463739672">অনুমতি দেওয়ার অনুরোধ</translation>
+<translation id="629730747756840877">অ্যাকাউন্ট</translation>
+<translation id="82609232232243542">Brave-এ সাইন-ইন করুন</translation>
+<translation id="7956662517480676674">সিঙ্ক এবং Brave Software পরিষেবাগুলি</translation>
+<translation id="5294439808117722387">আপনি এখন আপনার সিঙ্ক এবং Brave Software পরিষেবার সেটিংস কাস্টমাইজ করছেন। স্ক্রিনের নিচের দিকে থাকা 'কনফার্ম করুন' বোতামে ট্যাপ করে সিঙ্ক চালু দিন। উপরে নেভিগেট করুন</translation>
+<translation id="2096012225669085171">বিভিন্ন ডিভাইস জুড়ে সিঙ্ক এবং ব্যক্তিগতকৃত করুন</translation>
+<translation id="1692118695553449118">সিঙ্ক চালু রয়েছে</translation>
+<translation id="5514904542973294328">এই ডিভাইসের প্রশাসক অক্ষম করেছে</translation>
+<translation id="6447211988989208781">Brave Software অ্যাক্টিভিটির নিয়ন্ত্রণ</translation>
+<translation id="4882831918239250449">সার্চ, বিজ্ঞাপনসহ আরও অনেক কিছু ব্যক্তিগতকৃত করার জন্য আপনার ব্রাউজিং ইতিহাস কীভাবে ব্যবহার হবে তা নিয়ন্ত্রণ করুন</translation>
+<translation id="7431991332293347422">সার্চ এবং আরও অনেক কিছু নিজের মত করে সাজিয়ে নেওয়ার জন্য আপনার ব্রাউজিং ইতিহাস কীভাবে ব্যবহার হবে তা নিয়ন্ত্রণ করুন</translation>
+<translation id="6303969859164067831">সাইন-আউট করুন এবং সিঙ্ক করা বন্ধ করুন</translation>
+<translation id="1125261911132334651">আপনার Brave Software অ্যাকাউন্ট ম্যানেজ করুন</translation>
+<translation id="6406506848690869874">সিঙ্ক</translation>
+<translation id="714362445477979774">আপনার Brave ডেটা সিঙ্ক করুন</translation>
+<translation id="4314815835985389558">সিঙ্ক ম্যানেজ করুন</translation>
+<translation id="5428209950370661546">Brave Software-এর অন্যান্য পরিষেবা</translation>
+<translation id="7704317875155739195">সার্চ এবং ইউআরএলগুলি নিজে থেকে সম্পূর্ণ হতে দিন</translation>
+<translation id="2000419248597011803">অ্যাড্রেস বার এবং সার্চ বক্স থেকে সার্চের তথ্য এবং কিছু কুকি আপনার ডিফল্ট সার্চ ইঞ্জিনে পাঠায়</translation>
+<translation id="7981313251711023384">আরও দ্রুত ব্রাউজ করা এবং খোঁজার জন্য পৃষ্ঠা আগে লোড করুন</translation>
+<translation id="1821253160463689938">আপনার পছন্দগুলি মনে রাখার জন্য কুকি ব্যবহার করে। আপনি সেই সমস্ত পৃষ্ঠায় না গেলেও তা করে থাকে</translation>
+<translation id="6697492270171225480">কোনও একটি পৃষ্ঠা খুঁজে পাওয়া না গেলে একইরকম আরও পৃষ্ঠার সাজেশন দেখুন</translation>
+<translation id="8109318360573330108">যে পৃষ্ঠাটি দেখার চেষ্টা করছেন Brave Software-কে সেটির ইউআরএল পাঠায়</translation>
+<translation id="8438566539970814960">সার্চ এবং ব্রাউজিং অভিজ্ঞতা আরও উন্নত করুন</translation>
+<translation id="284843628681142937">আপনার দেখা পৃষ্ঠাগুলির ইউআরএল Brave Software-এ পাঠায়</translation>
+<translation id="7222718784508482526">আপনার গোপনীয়তা, নিরাপত্তা এবং ডেটা সংগ্রহের সাথে সম্পর্কযুক্ত আরও সেটিংসের জন্য <ph name="BEGIN_LINK"/>সিঙ্ক এবং Brave Software পরিষেবাগুলি<ph name="END_LINK"/> দেখুন</translation>
+<translation id="918192811481327695">Brave-এর বৈশিষ্ট্য এবং পারফরম্যান্স আরও ভালো করতে সাহায্য করুন</translation>
+<translation id="9063160602596686558">ব্যবহারের পরিসংখ্যান এবং ক্র্যাশ রিপোর্ট নিজে থেকেই Brave Software-কে পাঠায়</translation>
+<translation id="4824958205181053313">সিঙ্ক বাতিল করতে চান?</translation>
+<translation id="3058498974290601450">যেকোনও সময় সেটিংস থেকে আপনি সিঙ্ক চালু করতে পারেন</translation>
+<translation id="3143515551205905069">সিঙ্ক বাতিল করুন</translation>
+<translation id="1506061864768559482">সার্চ ইঞ্জিন</translation>
+<translation id="55737423895878184">লোকেশন এবং বিজ্ঞপ্তিগুলি অনুমোদিত</translation>
+<translation id="3988213473815854515">লোকেশন অনুমোদিত হয়েছে</translation>
+<translation id="32895400574683172">বিজ্ঞপ্তিগুলি অনুমোদিত</translation>
+<translation id="9040142327097499898">বিজ্ঞপ্তির অনুমতি দেওয়া আছে। এই ডিভাইসে লোকেশন বন্ধ করা আছে।</translation>
+<translation id="305593374596241526">লোকেশনটি বন্ধ, <ph name="BEGIN_LINK"/>Android সেটিংস<ph name="END_LINK"/> থেকে এটি চালু করুন।</translation>
+<translation id="2989523299700148168">সাম্প্রতিক দেখা হয়েছে</translation>
+<translation id="6433501201775827830">আপনার সার্চ ইঞ্জিন বেছে নিন</translation>
+<translation id="7177466738963138057">আপনি পরে সেটিংসে এই পরিবর্তন করতে পারবেন</translation>
+<translation id="3478363558367712427">আপনার সার্চ ইঞ্জিন বেছে নিতে পারেন</translation>
+<translation id="4910889077668685004">পেমেন্ট অ্যাপ্লিকেশান</translation>
+<translation id="5152843274749979095">কোনো সমর্থিত অ্যাপ্লিকেশান ইনস্টল করা নেই</translation>
+<translation id="8812260976093120287">কিছু ওয়েবসাইটে আপনি উপরের সমর্থিত পেমেন্ট অ্যাপ্লিকেশান দিয়ে অর্থপ্রদান করতে পারেন।</translation>
+<translation id="7764225426217299476">ঠিকানা যোগ করুন</translation>
+<translation id="5595485650161345191">ঠিকানা সম্পাদনা করুন</translation>
+<translation id="5087580092889165836">কার্ড জুড়ুন</translation>
+<translation id="2154484045852737596">কার্ড সম্পাদনা করুন</translation>
+<translation id="6140912465461743537">দেশ/অঞ্চল</translation>
+<translation id="5659593005791499971">ইমেল আইডি</translation>
+<translation id="4378154925671717803">ফোন</translation>
+<translation id="4807098396393229769">কার্ডে থাকা নাম</translation>
+<translation id="860043288473659153">কার্ডধারকের নাম</translation>
+<translation id="2612676031748830579">কার্ড নম্বর</translation>
+<translation id="869891660844655955">মেয়াদকাল সমাপ্তির তারিখ</translation>
+<translation id="2286841657746966508">বিলিং ঠিকানা</translation>
+<translation id="663059986967017181">Brave-এ প্রতিলিপি করা হয়েছে</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> আরও অনেক}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> আরও অনেক}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> আরও অনেক}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> আরও অনেক}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> আরও অনেক}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> আরও অনেক}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> আরও অনেক}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> আরও অনেক}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> আরও অনেক}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> আরও অনেক}one{<ph name="CONTACT_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> আরও অনেক}other{<ph name="CONTACT_PREVIEW"/>\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> আরও অনেক}}</translation>
+<translation id="7029809446516969842">পাসওয়ার্ড</translation>
+<translation id="1943432128510653496">পাসওয়ার্ডগুলি সেভ করুন</translation>
+<translation id="2100273922101894616">অটো সাইন-ইন</translation>
+<translation id="363596933471559332">সঞ্চিত ক্রেডেনশিয়াল ব্যবহার করে ওয়েবসাইটগুলিতে অটোমেটিক সাইন-ইন। যখন বৈশিষ্ট্যটি বন্ধ করা থাকে, তখন প্রতিবারই একটি ওয়েবসাইটে সাইন-ইন করার সময় আপনাকে যাচাইকরণের জন্য বলা হবে।</translation>
+<translation id="6995899638241819463">আপনার পাসওয়ার্ড কোনও ডেটা নিরাপত্তা লঙ্ঘনের কারণে সর্বজনীনভাবে প্রকাশ হলে তা আপনাকে জানানো হবে</translation>
+<translation id="1534287762301776620">আপনার Brave Software অ্যাকাউন্টে সাইন-ইন করলে এই ফিচারটি চালু হয়ে যাবে</translation>
+<translation id="10614374240317010">কখনও সংরক্ষিত হয়নি</translation>
+<translation id="3098842761938485917">আপনার <ph name="BEGIN_LINK"/>Brave Software অ্যাকাউন্ট<ph name="END_LINK"/>-এ সেভ করা পাসওয়ার্ড দেখুন এবং পরিচালনা করুন</translation>
+<translation id="8562452229998620586">আপনার সংরক্ষিত পাসওয়ার্ডগুলি এখানে উপস্থিত হবে৷</translation>
+<translation id="8084114998886531721">সংরক্ষিত পাসওয়ার্ড</translation>
+<translation id="2870560284913253234">সাইট</translation>
+<translation id="8503813439785031346">ইউজারনেম</translation>
+<translation id="6657585470893396449">পাসওয়ার্ড</translation>
+<translation id="2154710561487035718">ইউআরএল কপি করুন</translation>
+<translation id="1571304935088121812">ইউজারনেম কপি করুন</translation>
+<translation id="5005498671520578047">পাসওয়ার্ড কপি করুন</translation>
+<translation id="3632295766818638029">পাসওয়ার্ড উম্মোচন করুন</translation>
+<translation id="1513858653616922153">পাসওয়ার্ড মুছুন</translation>
+<translation id="543338862236136125">পাসওয়ার্ড এডিট করুন</translation>
+<translation id="4565377596337484307">পাসওয়ার্ড লুকান</translation>
+<translation id="8523928698583292556">সংরক্ষিত পাসওয়ার্ড মুছুন</translation>
+<translation id="2898264748040935573">স্টোর করা পাসওয়ার্ড এডিট করুন</translation>
+<translation id="5433691172869980887">ইউজারনেম কপি করা হয়েছে</translation>
+<translation id="5534640966246046842">সাইট কপি করা হয়েছে</translation>
+<translation id="2625189173221582860">পাসওয়ার্ড কপি করা হয়েছে</translation>
+<translation id="4550003330909367850">এখানে আপনার পাসওয়ার্ডটি দেখতে অথবা কপি করতে এই ডিভাইসে স্ক্রিন লক সেট করুন।</translation>
+<translation id="6154478581116148741">এই ডিভাইস থেকে আপনার পাসওয়ার্ড এক্সপোর্ট করতে সেটিংসে স্ক্রিন লক চালু করুন</translation>
+<translation id="4842092870884894799">পাসওয়ার্ড প্রজন্মের পপআপ দেখানো হচ্ছে</translation>
+<translation id="2259659629660284697">পাসওয়ার্ড এক্সপোর্ট করুন...</translation>
+<translation id="133012818630824069">Brave এ সেভ করা পাসওয়ার্ড এক্সপোর্ট করুন</translation>
+<translation id="6914783257214138813">এক্সপোর্ট করা ফাইল যারা দেখতে পান তারা আপনার পাসওয়ার্ডগুলিও দেখতে পাবেন।</translation>
+<translation id="2321086116217818302">পাসওয়ার্ড তৈরি করা হচ্ছে…</translation>
+<translation id="8445448999790540984">পাসওয়ার্ড এক্সপোর্ট করা যাচ্ছে না</translation>
+<translation id="3066461326500799725">Brave Software ড্রাইভ কীভাবে ব্যবহার করবেন জানুন</translation>
+<translation id="729975465115245577">পাসওয়ার্ড ফাইল সেভ করার জন্য আপনার ডিভাইসে কোনও অ্যাপ নেই।</translation>
+<translation id="7682724950699840886">নিম্নলিখিত টিপ্স ব্যবহার করার চেষ্টা করুন: আপনার ডিভাইসে পর্যাপ্ত জায়গা আছে কিনা দেখে নিয়ে আবার এক্সপোর্ট করার চেষ্টা করুন।</translation>
+<translation id="1129510026454351943">বিবরণ: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">আপনার পাসওয়ার্ড কপি করতে আনলক করুন</translation>
+<translation id="5515439363601853141">আপনার পাসওয়ার্ড দেখতে আনলক করুন</translation>
+<translation id="6221633008163990886">আপনার পাসওয়ার্ড এক্সপোর্ট করতে আনলক করুন</translation>
+<translation id="230699814587342492">Brave পাসওয়ার্ডগুলি</translation>
+<translation id="6075798973483050474">হোম পৃষ্ঠা সম্পাদনা করুন</translation>
+<translation id="854522910157234410">এই পৃষ্ঠাটি খুলুন</translation>
+<translation id="2482878487686419369">বিজ্ঞপ্তিগুলি</translation>
+<translation id="6255999984061454636">কন্টেন্টের প্রস্তাবনা</translation>
+<translation id="805047784848435650">আপনার ব্রাউজিং ইতিহাসের উপর ভিত্তি করে</translation>
+<translation id="1041308826830691739">ওয়েবসাইট থেকে</translation>
+<translation id="395206256282351086">সার্চ এবং সাইটের প্রস্তাবনা অক্ষম করা আছে</translation>
+<translation id="257088987046510401">থিমসমূহ</translation>
+<translation id="4650364565596261010">সিস্টেম ডিফল্ট</translation>
+<translation id="7588219262685291874">আপনার ডিভাইস ব্যাটারি সেভারে চললে গাঢ় থিম চালু করুন</translation>
+<translation id="2760989362628427051">আপনার ডিভাইসে গাঢ় থিম বা ব্যাটারি সেভার চালু থাকলে, গাঢ় থিম চালু করুন</translation>
+<translation id="6381421346744604172">ওয়েবসাইট কালো করুন</translation>
+<translation id="5040262127954254034">গোপনীয়তা</translation>
+<translation id="4991384657077828949">Brave-এর নিরাপত্তা উন্নত করতে সাহায্য করুন</translation>
+<translation id="1943176487615318915">বিপজ্জনক অ্যাপ ও সাইট শনাক্ত করতে Brave আপনার দেখা পৃষ্ঠাগুলির ইউআরএল, সিস্টেমের কিছু তথ্য ও কিছু পৃষ্ঠার কন্টেন্ট Brave Software-কে পাঠায়</translation>
+<translation id="3181954750937456830">নিরাপদ ব্রাউজিং (বিপজ্জনক সাইট থেকে আপনাকে এবং আপনার ডিভাইসকে রক্ষা করে)</translation>
+<translation id="7315322926489145388">নিরাপত্তা সংক্রান্ত কোনও ঝুঁকি থাকলে, আপনার দেখা কিছু পৃষ্ঠার ইউআরএল Brave Software-কে পাঠায়</translation>
+<translation id="2063713494490388661">সার্চ করতে আলতো চাপুন</translation>
+<translation id="2369463299479365221">পৃষ্ঠাতে থাকাকালীন ওয়েবসাইটে গিয়ে বিষয়গুলি সম্পর্কে জানুন। 'সার্চ করতে ট্যাপ করা' বৈশিষ্ট্যটি একটি শব্দ এবং এটির সাথে সম্পর্কযুক্ত প্রসঙ্গ Brave Software সার্চে পাঠায়, তার সাথে সংজ্ঞা, ছবি, সার্চ ফলাফল এবং আরও অনেক কিছু দেখায়৷
 
 সার্চের শব্দটি অ্যাডজাস্ট করতে, বেছে নেওয়ার জন্য দীর্ঘক্ষণ প্রেস করুন। আপনার সার্চটি রিফাইন করতে, প্যানেলটিকে সোজা উপরের দিকে স্লাইড করুন এবং সার্চ বক্সে ট্যাপ করুন।</translation>
-<translation id="4056223980640387499">সেপিয়া</translation>
-<translation id="4060598801229743805">স্ক্রীনের প্রায় উপরের দিকে বিকল্পগুলি উপলব্ধ</translation>
-<translation id="4062305924942672200">আইনী তথ্য</translation>
-<translation id="4084682180776658562">বুকমার্ক</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" /> থেকে – <ph name="BEGIN_DEEMPHASIZED" />Google এর মাধ্যমে ডেলিভারি দেওয়া হয়েছে<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">অ্যাপ্লিকেশান ডেটা মুছবেন?</translation>
-<translation id="4099578267706723511">Google-এ ব্যবহারের পরিসংখ্যান এবং ক্র্যাশ রিপোর্টগুলি পাঠিয়ে Chrome-কে আরও ভাল করে তুলতে সহায়তা করুন৷</translation>
-<translation id="410351446219883937">স্বতঃচালানো</translation>
-<translation id="4116038641877404294">পৃষ্ঠাগুলি অফলাইনে ব্যবহার করতে সেগুলি ডাউনলোড করুন</translation>
-<translation id="4135200667068010335">ট্যাব শেয়ার করা যাবে এমন ডিভাইসের সূচি বন্ধ আছে।</translation>
-<translation id="4149994727733219643">ওয়েব পৃষ্ঠার জন্য সরলীকৃত ভিউ</translation>
-<translation id="4165986682804962316">সাইটের সেটিংস</translation>
-<translation id="4169535189173047238">অনুমতি দেবেন না</translation>
-<translation id="4170011742729630528">পরিষেবাটি উপলব্ধ নেই, পরে আবার চেষ্টা করুন৷</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> ব্যবহার করা হয়েছে</translation>
-<translation id="4181841719683918333">ভাষাসমূহ</translation>
-<translation id="4183868528246477015">Google Lens-এর <ph name="BEGIN_NEW" />নতুন<ph name="END_NEW" /> ভার্সন দিয়ে খুুঁজুন</translation>
-<translation id="4195643157523330669">নতুন ট্যাবে খুলুন</translation>
-<translation id="4198423547019359126">ডাউনলোড করার জন্য লোকেশন উপলভ্য নেই</translation>
-<translation id="4209895695669353772">Google-এর প্রস্তাবিত ব্যক্তিগতকৃত কন্টেন্ট পেতে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="4226663524361240545">বিজ্ঞপ্তি আসলে ডিভাইস ভাইব্রেট হতে পারে</translation>
-<translation id="423219824432660969">Google পাসওয়ার্ড দিয়ে <ph name="TIME" />-এ সিঙ্ক করা ডেটা এনক্রিপ্ট করুন</translation>
-<translation id="4242533952199664413">সেটিংস খুলুন</translation>
-<translation id="4256782883801055595">ওপেন সোর্স লাইসেন্স</translation>
-<translation id="4259722352634471385">নেভিগেশন অবরুদ্ধ করা হয়েছে: <ph name="URL" /></translation>
-<translation id="4269820728363426813">লিঙ্ক অ্যাড্রেস কপি করুন</translation>
-<translation id="4275663329226226506">মাধ্যম</translation>
-<translation id="4278390842282768270">মঞ্জুরিপ্রাপ্ত</translation>
-<translation id="429312253194641664">একটি সাইট মিডিয়া চালাচ্ছে</translation>
-<translation id="4298388696830689168">লিঙ্ক করা সাইট</translation>
-<translation id="4307992518367153382">বুনিয়াদি</translation>
-<translation id="4314815835985389558">সিঙ্ক ম্যানেজ করুন</translation>
-<translation id="4351244548802238354">ডায়ালগ বন্ধ করুন</translation>
-<translation id="4378154925671717803">ফোন</translation>
-<translation id="4384468725000734951">সার্চের জন্য Sogou কে ব্যবহার করছে</translation>
-<translation id="4404568932422911380">কোনও বুকমার্ক নেই</translation>
-<translation id="4405224443901389797">এই ফোল্ডারে সরান…</translation>
-<translation id="4411535500181276704">লাইট মোড</translation>
-<translation id="4415276339145661267">আপনার Google অ্যাকাউন্ট ম্যানেজ করুন</translation>
-<translation id="4432792777822557199">এখন থেকে <ph name="SOURCE_LANGUAGE" /> ভাষার পৃষ্ঠাগুলিকে <ph name="TARGET_LANGUAGE" /> ভাষায় অনুবাদ করা হবে</translation>
-<translation id="4433925000917964731">Google লাইট পৃষ্ঠা পাঠিয়েছে</translation>
-<translation id="4434045419905280838">পপ-আপ এবং রিডাইরেক্ট</translation>
-<translation id="4440958355523780886">Google লাইট পৃষ্ঠা পাঠিয়েছে। আসল পৃষ্ঠাটি লোড করতে ট্যাপ করুন।</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> ট্যাবটি বন্ধ করুন</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> এ বুকমার্ক করা হয়েছে</translation>
-<translation id="445467742685312942">সাইটকে সুরক্ষিত কন্টেন্ট চালানোর জন্য অনুমতি দিন</translation>
-<translation id="4468959413250150279">নির্দিষ্ট কোনও সাইটের জন্য সাউন্ড মিউট করুন।</translation>
-<translation id="4472118726404937099">ডিভাইস জুড়ে সিঙ্ক এবং ব্যক্তিগতকৃত করতে সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="447252321002412580">Chrome-এর বৈশিষ্ট্য এবং পারফরম্যান্স আরও ভালো করতে সাহায্য করুন</translation>
-<translation id="4479647676395637221">সাইটগুলিকে আপনার ক্যামেরা ব্যবহার করতে দিতে মঞ্জুরি দেওয়ার আগে প্রথমে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
-<translation id="4479972344484327217">Chrome-এর জন্য <ph name="MODULE" /> ইনস্টল করা হচ্ছে…</translation>
-<translation id="4487967297491345095">Chrome-এর সকল অ্যাপ ডেটা স্থায়ীভাবে মুছে ফেলা হবে। এর মধ্যে সব ফাইল, সেটিংস, অ্যাকাউন্ট, ডেটাবেস ইত্যাদি অন্তর্ভুক্ত।</translation>
-<translation id="4493497663118223949">লাইট মোড চালু আছে</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# দিন আগে}one{# দিন আগে}other{# দিন আগে}}</translation>
-<translation id="451872707440238414">আপনার বুকমার্কস খুঁজুন</translation>
-<translation id="4521489764227272523">বেছে নেওয়া ডেটা Chrome ও সিঙ্ক করা ডিভাইস থেকে সরিয়ে দেওয়া হয়েছে।
-
-আপনার Google অ্যাকাউন্টের সার্চ এবং অন্যান্য Google পরিষেবায় বিভিন্ন অ্যাক্টিভিটির মতো অন্যান্য ধরনের ব্রাউজিং ইতিহাস <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" />-এ সেভ করা থাকতে পারে।</translation>
-<translation id="4532845899244822526">ফোল্ডার বেছে নিন</translation>
-<translation id="4538018662093857852">লাইট মোড চালু করুন</translation>
-<translation id="4550003330909367850">এখানে আপনার পাসওয়ার্ডটি দেখতে অথবা কপি করতে এই ডিভাইসে স্ক্রিন লক সেট করুন।</translation>
-<translation id="4558311620361989323">ওয়েবপৃষ্ঠার শর্টকাটগুলি</translation>
-<translation id="4561979708150884304">কোনও কানেকশন নেই</translation>
-<translation id="4565377596337484307">পাসওয়ার্ড লুকান</translation>
-<translation id="4570913071927164677">বিবরণ</translation>
-<translation id="4572422548854449519">ম্যানেজ করা অ্যাকাউন্টে সাইন-ইন করুন</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# মিনিট আগে}one{# মিনিট আগে}other{# মিনিট আগে}}</translation>
-<translation id="4587589328781138893">সাইটগুলি</translation>
-<translation id="4594952190837476234">এই অফলাইন পৃষ্ঠাটি <ph name="CREATION_TIME" />-এ তৈরি করা হয়েছিল এবং এটি অনলাইন ভার্সনের থেকে আলাদা হতে পারে।</translation>
-<translation id="4605958867780575332">আইটেম সরানো হয়েছে: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> খুলুন</translation>
-<translation id="4634124774493850572">পাসওয়ার্ড ব্যবহার করুন</translation>
-<translation id="4645575059429386691">আপনার পিতামাতার দ্বারা পরিচালিত</translation>
-<translation id="4650364565596261010">সিস্টেম ডিফল্ট</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" />টি বুকমার্ক মোছা হয়েছে</translation>
-<translation id="4665282149850138822">আপনার হোম স্ক্রীনে <ph name="NAME" /> কে যোগ করা হয়েছে</translation>
-<translation id="4684427112815847243">সবকিছু সিঙ্ক করুন</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> আরও অনেক}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> আরও অনেক}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> আরও অনেক}}</translation>
-<translation id="4696983787092045100">আপনার ডিভাইসে টেক্সট পাঠান</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> এ অফলাইনে দেখুন</translation>
-<translation id="4699172675775169585">ক্যাশে করা ছবি এবং ফাইলগুলি</translation>
-<translation id="4714588616299687897">আপনার ডেটা ৬০% পর্যন্ত সেভ করুন</translation>
-<translation id="4719927025381752090">অনুবাদ করুন</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" /> এ খুলুন</translation>
-<translation id="4720982865791209136">Chrome উন্নত করতে সাহায্য করুন। <ph name="BEGIN_LINK" />সমীক্ষায় অংশ নিন।<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">আপডেট করুন</translation>
-<translation id="4738836084190194332">সর্বশেষ সিঙ্ক হয়েছে: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">একটি নতুন ট্যাব খুলুন</translation>
-<translation id="4751476147751820511">মোশন বা হালকা সেন্সর</translation>
-<translation id="4759238208242260848">ডাউনলোডগুলি</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{১টি ডাউনলোড হয়ে গেছে।}one{#টি ডাউনলোড হয়ে গেছে।}other{#টি ডাউনলোড হয়ে গেছে।}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" />-এ ফিরে যেতে স্পর্শ করুন</translation>
-<translation id="4802417911091824046">পাসফ্রেজ এনক্রিপশনে Google Pay-এর পেমেন্ট পদ্ধতি ও ঠিকানা অন্তর্ভুক্ত থাকে না।
-
-<ph name="BEGIN_LINK" />রিসেট সিঙ্ক<ph name="END_LINK" /> থেকে এই সেটিং পরিবর্তন করুন</translation>
-<translation id="4807098396393229769">কার্ডে থাকা নাম</translation>
-<translation id="4824958205181053313">সিঙ্ক বাতিল করতে চান?</translation>
-<translation id="4837753911714442426">‘পৃষ্ঠা প্রিন্ট করুন’-এর বিকল্পগুলি খুলুন</translation>
-<translation id="4842092870884894799">পাসওয়ার্ড প্রজন্মের পপআপ দেখানো হচ্ছে</translation>
-<translation id="4860895144060829044">কল করুন</translation>
-<translation id="4866368707455379617">Chrome-এর জন্য <ph name="MODULE" /> ইনস্টল করা যাচ্ছে না</translation>
-<translation id="4875775213178255010">কন্টেন্টের প্রস্তাবনা</translation>
-<translation id="4878404682131129617">প্রক্সি সার্ভারের মাধ্যমে টানেল তৈরি করা যায়নি</translation>
-<translation id="4880127995492972015">অনুবাদ করুন…</translation>
-<translation id="4881695831933465202">খুলুন</translation>
-<translation id="488187801263602086">ফাইলটির আবার নাম দিন</translation>
-<translation id="4882831918239250449">সার্চ, বিজ্ঞাপনসহ আরও অনেক কিছু ব্যক্তিগতকৃত করার জন্য আপনার ব্রাউজিং ইতিহাস কীভাবে ব্যবহার হবে তা নিয়ন্ত্রণ করুন</translation>
-<translation id="4883854917563148705">ম্যানেজ করা সেটিংস রিসেট করা যায় না</translation>
-<translation id="4885273946141277891">অসমর্থিত সংখ্যার Chrome দৃষ্টান্তগুলি</translation>
-<translation id="4910889077668685004">পেমেন্ট অ্যাপ্লিকেশান</translation>
-<translation id="4913161338056004800">পরিসংখ্যান রিসেট করুন</translation>
-<translation id="4913169188695071480">রিফ্রেশ করা বন্ধ করুন</translation>
-<translation id="4915549754973153784">ডিভাইসের জন্য স্ক্যান করার সময় <ph name="BEGIN_LINK" />সহায়তা পান<ph name="END_LINK" />...</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{#টি পৃষ্ঠা}one{#টি পৃষ্ঠা}other{#টি পৃষ্ঠা}}</translation>
-<translation id="4932247056774066048">যেহেতু আপনি <ph name="DOMAIN_NAME" />-এর ম্যানেজ করা অ্যাকাউন্ট থেকে সাইন-আউট করছেন তাই এই ডিভাইস থেকে আপনার Chrome ডেটা মুছে ফেলা হবে। এটি আপনার Google অ্যাকাউন্টে থাকবে।</translation>
-<translation id="4943703118917034429">ভার্চুয়াল রিয়ালিটি</translation>
-<translation id="4943872375798546930">কোন ফলাফল নেই</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> আপনার স্ক্রিন শেয়ার করছে</translation>
-<translation id="4961107849584082341">এই পৃষ্ঠাটি যেকোনও ভাষায় অনুবাদ করুন</translation>
-<translation id="4962975101802056554">ডিভাইসের ক্ষেত্রে সমস্ত অনুমতি সরিয়ে দিন</translation>
-<translation id="4970824347203572753">আপনার লোকেশনে উপলভ্য নেই</translation>
-<translation id="497421865427891073">অগ্রবর্তী করুন</translation>
-<translation id="4988210275050210843">ফাইল ডাউনলোড হচ্ছে (<ph name="MEGABYTES" />)।</translation>
-<translation id="4988526792673242964">পৃষ্ঠাসমূহ</translation>
-<translation id="4994033804516042629">কোনও পরিচিতি পাওয়া যায়নি</translation>
-<translation id="4996978546172906250">এর মাধ্যমে শেয়ার করুন</translation>
-<translation id="5004416275253351869">Google অ্যাক্টিভিটির নিয়ন্ত্রণ</translation>
-<translation id="5005498671520578047">পাসওয়ার্ড কপি করুন</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> এদের সঙ্গে সংযুক্ত হতে চায়</translation>
-<translation id="5013696553129441713">নতুন কোনও প্রস্তাবনা নেই</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">আপনি ভিআর (VR) মোডে থাকলে এই সাইট যে বিষয় সম্পর্কে জানতে পারে তা হল:
-  -  আপনার শারীরিক বৈশিষ্ট্য, যেমন উচ্চতা
-
-ভিআর (VR) ব্যবহার করার আগে সাইটটি বিশ্বস্ত কিনা ভাল করে দেখে নিন।</translation>
+<translation id="2930742481329940825">'সার্চ করতে ট্যাপ করুন' বৈশিষ্ট্যটি Brave Software সার্চের রেফারেন্স হিসেবে বেছে নেওয়া শব্দ এবং বর্তমান পৃষ্ঠাটি পাঠায়। আপনি <ph name="BEGIN_LINK"/>সেটিংস<ph name="END_LINK"/> থেকে এটি বন্ধ করতে পারেন।</translation>
 <translation id="5039804452771397117">অনুমতি দিন</translation>
-<translation id="5040262127954254034">গোপনীয়তা</translation>
-<translation id="5048398596102334565">সাইটকে মোশন সেন্সর অ্যাক্সেস করার অনুমতি দিন (সাজেস্ট করা হয়)</translation>
-<translation id="5063480226653192405">ব্যবহার</translation>
-<translation id="5087580092889165836">কার্ড জুড়ুন</translation>
-<translation id="5100237604440890931">সঙ্কুচিত - প্রসারিত করতে ক্লিক করুন৷</translation>
-<translation id="510275257476243843">১ ঘণ্টা বাকি আছে</translation>
-<translation id="5123685120097942451">ছদ্মবেশী ট্যাব</translation>
-<translation id="5127805178023152808">সিঙ্ক বন্ধ রয়েছে</translation>
-<translation id="5129038482087801250">ওয়েব অ্যাপ ইনস্টল করুন</translation>
-<translation id="5132942445612118989">সমস্ত ডিভাইসে আপনার পাসওয়ার্ড, ইতিহাস ও আরও অনেক কিছু সিঙ্ক করুন</translation>
-<translation id="5139940364318403933">Google ড্রাইভ কীভাবে ব্যবহার করবেন জানুন</translation>
-<translation id="515227803646670480">সঞ্চিত ডেটা সাফ করুন</translation>
-<translation id="5152843274749979095">কোনো সমর্থিত অ্যাপ্লিকেশান ইনস্টল করা নেই</translation>
-<translation id="5161254044473106830">শিরোনাম প্রয়োজন</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{১টি ডাউনলোড করা যায়নি।}one{#টি ডাউনলোড করা যায়নি।}other{#টি ডাউনলোড করা যায়নি।}}</translation>
-<translation id="5170568018924773124">ফোল্ডারে দেখান</translation>
-<translation id="5184329579814168207">Chrome এ খুলুন</translation>
-<translation id="5193988420012215838">আপনার ক্লিপবোর্ডে কপি করা হয়েছে</translation>
-<translation id="5197729504361054390">আপনার বেছে নেওয়া পরিচিতি <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />-এর সাথে শেয়ার করা হবে।</translation>
-<translation id="5199929503336119739">কর্মস্থলের প্রোফাইল</translation>
-<translation id="5210286577605176222">পূর্ববর্তী ট্যাবে চলে যান</translation>
-<translation id="5210365745912300556">ট্যাব বন্ধ করুন</translation>
-<translation id="5224771365102442243">ভিডিও এর সাথে</translation>
-<translation id="5230560987958996918">কাছাকাছি থাকা ব্লুটুথ ডিভাইসগুলিকে <ph name="SITE" /> স্ক্যান করতে চায়, এই ডিভাইসগুলি পাওয়া গেছে:</translation>
-<translation id="5233638681132016545">নতুন ট্যাব</translation>
-<translation id="526421993248218238">পৃষ্ঠাটি লোড করা যাচ্ছে না</translation>
-<translation id="5271967389191913893">ডাউনলোড করা কন্টেন্ট ডিভাইস খুলতে পারবে না৷</translation>
-<translation id="528192093759286357">উপর থেকে টেনে আনুন এবং পূর্ণ স্ক্রিন থেকে বেরিয়ে যেতে পিছনে ফেরার বোতাম স্পর্শ করুন।</translation>
-<translation id="5292796745632149097">এতে পাঠান:</translation>
-<translation id="5300589172476337783">দেখান</translation>
-<translation id="5301954838959518834">ঠিক আছে, বুঝেছি</translation>
-<translation id="5304593522240415983">এই ক্ষেত্রটি খালি রাখা যাবে না</translation>
-<translation id="5307446750509046227">সাইটের সেভ করা ডেটা মুছুন</translation>
-<translation id="5308380583665731573">সংযুক্ত করুন</translation>
-<translation id="5313967007315987356">সাইট যোগ করুন</translation>
-<translation id="5317780077021120954">সেভ করুন</translation>
-<translation id="5324858694974489420">অভিভাবকীয় সেটিংস</translation>
-<translation id="5327248766486351172">নাম</translation>
-<translation id="5335288049665977812">সাইটগুলিকে JavaScript চালানোর অনুমতি দিন (প্রস্তাবিত)</translation>
-<translation id="5342314432463739672">অনুমতি দেওয়ার অনুরোধ</translation>
-<translation id="5357811892247919462">ট্যাব পাওয়া গেছে</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" />টি খোলা ট্যাব, এক ট্যাব থেকে অন্য ট্যাবে যেতে ট্যাপ করুন}one{<ph name="OPEN_TABS_MANY" />টি খোলা ট্যাব, এক ট্যাব থেকে অন্য ট্যাবে যেতে ট্যাপ করুন}other{<ph name="OPEN_TABS_MANY" />টি খোলা ট্যাব, এক ট্যাব থেকে অন্য ট্যাবে যেতে ট্যাপ করুন}}</translation>
-<translation id="5391532827096253100">এই সাইটে আপনার কানেকশন নিরাপদ নয়। সাইটের তথ্য</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(এছাড়া আরও ১টি)}one{(এছাড়া আরও #টি)}other{(এছাড়া আরও #টি)}}</translation>
-<translation id="5400569084694353794">এই অ্যাপ্লিকেশানটি ব্যবহার করার মাধ্যমে আপনি Chrome এর <ph name="BEGIN_LINK1" />পরিষেবার শর্তাবলি<ph name="END_LINK1" /> এবং <ph name="BEGIN_LINK2" />গোপনীয়তা বিজ্ঞপ্তিতে<ph name="END_LINK2" /> সম্মত হচ্ছেন৷</translation>
-<translation id="5403592356182871684">নাম</translation>
-<translation id="5403644198645076998">শুধুমাত্র নির্দিষ্ট কিছু সাইটকে অনুমতি দিন</translation>
-<translation id="5414836363063783498">যাচাই করা হচ্ছে...</translation>
-<translation id="5423934151118863508">আপনার সর্বাধিক দেখা পৃষ্ঠাগুলি এখানে দেখা যাবে</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> জিবি উপলব্ধ</translation>
-<translation id="543338862236136125">পাসওয়ার্ড এডিট করুন</translation>
-<translation id="5433691172869980887">ইউজারনেম কপি করা হয়েছে</translation>
-<translation id="543509235395288790"><ph name="COUNT" />টি ফাইল ডাউনলোড হচ্ছে (<ph name="MEGABYTES" />)।</translation>
-<translation id="5441522332038954058">অ্যাড্রেস বারে চলে যান</translation>
-<translation id="5447201525962359567">কুকিজ ও অন্যান্য স্থানীয়ভাবে সংরক্ষণ করা তথ্য সহ সাইটের সকল সঞ্চয়স্থান</translation>
-<translation id="5447765697759493033">এই সাইটটি অনুবাদ করা হবে না</translation>
-<translation id="545042621069398927">আপনার ডাউনলোডের স্পিড বাড়ানো হচ্ছে।</translation>
-<translation id="5456381639095306749">পৃষ্ঠা ডাউনলোড করুন</translation>
-<translation id="5475862044948910901">অগমেন্টেড রিয়েলিটি সেশন শুরু করতে চান?</translation>
-<translation id="548278423535722844">ম্যাপ অ্যাপ্লিকেশানে খুলুন</translation>
-<translation id="5487521232677179737">ডেটা সাফ করুন</translation>
-<translation id="5494752089476963479">সাইটে থাকা ব্যাঘাত সৃষ্টিকারী বা বিভ্রান্তিকর বিজ্ঞাপন ব্লক করুন</translation>
-<translation id="5500777121964041360">আপনার লোকেশনে উপলভ্য নাও থাকতে পারে</translation>
-<translation id="5512137114520586844">এই অ্যাকাউন্টটি <ph name="PARENT_NAME" />-এর দ্বারা পরিচালিত হয়৷</translation>
-<translation id="5514904542973294328">এই ডিভাইসের প্রশাসক অক্ষম করেছে</translation>
-<translation id="5515439363601853141">আপনার পাসওয়ার্ড দেখতে আনলক করুন</translation>
-<translation id="5516455585884385570">বিজ্ঞপ্তির সেটিংস খুলুন</translation>
-<translation id="5517095782334947753">আপনার জন্য <ph name="FROM_ACCOUNT" /> থেকে বুকমার্কস, ইতিহাস, পাসওয়ার্ড এবং অন্যান্য সেটিংস আছে।</translation>
-<translation id="5524843473235508879">রিডাইরেক্ট ব্লক করা হয়েছে।</translation>
-<translation id="5527082711130173040">ডিভাইস স্ক্যান করার জন্য Chrome এর অবস্থানের অ্যাক্সেস প্রয়োজন।  <ph name="BEGIN_LINK1" />অনুমতিগুলির আপডেট করুন<ph name="END_LINK1" />। অবস্থানের অ্যাক্সেস <ph name="BEGIN_LINK2" />এই ডিভাইসের জন্যও বন্ধ করা হয়েছে<ph name="END_LINK2" />।</translation>
-<translation id="5527111080432883924">ক্লিপবোর্ডের টেক্সট এবং ছবি পড়ার জন্য অনুমতি দেওয়ার আগে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
-<translation id="5530766185686772672">ছদ্মবেশী ট্যাবগুলি বন্ধ করুন</translation>
-<translation id="5534334044554683961">আপনি ভিআর (VR) মোডে থাকলে এই সাইট যে বিষয় সম্পর্কে হয়ত জানতে পারে, তা হল:
-  -  আপনার শারীরিক বৈশিষ্ট্য, যেমন উচ্চতার
-  -   আপনার রুমের লেআউট
-
-ভিআর (VR) ব্যবহার করার আগে সাইটটি বিশ্বস্ত কিনা ভাল করে দেখে নিন।</translation>
-<translation id="5534640966246046842">সাইট কপি করা হয়েছে</translation>
-<translation id="5556459405103347317">রিলোড করুন</translation>
-<translation id="5561549206367097665">নেটওয়ার্কের জন্য অপেক্ষা করা হচ্ছে...</translation>
-<translation id="557283862590186398">এই সাইটটির জন্য Chrome কে আপনার মাইক্রোফোনে অ্যাক্সেস দিতে হবে।</translation>
-<translation id="55737423895878184">লোকেশন এবং বিজ্ঞপ্তিগুলি অনুমোদিত</translation>
-<translation id="5578795271662203820">এই ইমেজটির জন্য <ph name="SEARCH_ENGINE" /> খুঁজুন</translation>
-<translation id="5581519193887989363"><ph name="BEGIN_LINK1" />সেটিংসে<ph name="END_LINK1" /> কী সিঙ্ক করা হবে তা আপনি সবসময় বেছে নিতে পারেন।</translation>
-<translation id="5595485650161345191">ঠিকানা সম্পাদনা করুন</translation>
-<translation id="5596627076506792578">আরও বিকল্পগুলি</translation>
-<translation id="5599455543593328020">ছদ্মবেশী মোড</translation>
-<translation id="5620928963363755975">আরও বিকল্প বোতামের ডাউনলোড বিকল্প থেকে আপনার সমস্ত ফাইল ও পৃষ্ঠাগুলি খুঁজে পান</translation>
-<translation id="5626134646977739690">নাম:</translation>
-<translation id="5639724618331995626">সমস্ত সাইটকে অনুমতি দিন</translation>
-<translation id="5648166631817621825">গত ৭ দিন</translation>
-<translation id="5649053991847567735">অটোমেটিক ডাউনলোডগুলি</translation>
-<translation id="5655963694829536461">আপনার ডাউনলোডগুলি খুঁজুন</translation>
-<translation id="5659593005791499971">ইমেল আইডি</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> এ ইভেন্ট তৈরি করুন</translation>
-<translation id="5668404140385795438">কোনো ওয়েবসাইটের জুম ইন প্রতিরোধ করার অনুরোধ উপেক্ষা করুন</translation>
-<translation id="5677928146339483299">অবরুদ্ধ</translation>
-<translation id="5684874026226664614">ওহো৷ এই পৃষ্ঠাটির অনুবাদ করা যাবে না৷</translation>
-<translation id="5686790454216892815">ফাইলের নামটি খুব বড়</translation>
-<translation id="5689516760719285838">লোকেশন</translation>
-<translation id="569536719314091526">আরও বিকল্প বোতাম থেকে এই পৃষ্ঠাটিকে যেকোনও ভাষায় অনুবাদ করুন</translation>
-<translation id="572328651809341494">সাম্প্রতিক ট্যাবগুলি</translation>
-<translation id="5726692708398506830">পৃষ্ঠাতে থাকা সবকিছুকে বড় করুন</translation>
-<translation id="5748802427693696783">স্ট্যান্ডার্ড ট্যাবে পাল্টানো হয়েছে</translation>
-<translation id="5749068826913805084">ফাইল ডাউনলোড করতে Chrome-এর জন্য স্টোরেজ অ্যাক্সেস প্রয়োজন।</translation>
-<translation id="5763382633136178763">ছদ্মবেশী ট্যাব</translation>
-<translation id="5763514718066511291">এই অ্যাপের ইউআরএল কপি করতে ট্যাপ করুন</translation>
-<translation id="5765780083710877561">বর্ণনা:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" /> এর <ph name="SPACE_USED" /> ব্যবহার করা হচ্ছে</translation>
-<translation id="5797070761912323120">সার্চ, বিজ্ঞাপন এবং অন্যান্য Google পরিষেবাকে আপনার মতো করে সাজিয়ে নিতে Google আপনার ইতিহাস ব্যবহার করতে পারে</translation>
-<translation id="5804241973901381774">অনুমতিগুলি</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# ঘণ্টা আগে}one{# ঘণ্টা আগে}other{# ঘণ্টা আগে}}</translation>
-<translation id="5810288467834065221">কপিরাইট <ph name="YEAR" /> Google LLC সব স্বত্ব সংরক্ষিত আছে।</translation>
-<translation id="5817918615728894473">যুক্ত করুন</translation>
-<translation id="583281660410589416">অজানা</translation>
-<translation id="5833984609253377421">লিঙ্ক শেয়ার করুন</translation>
-<translation id="5836192821815272682">Chrome-এর আপডেট ডাউনলোড করা হচ্ছে…</translation>
-<translation id="5853623416121554550">পজ করা হয়েছে</translation>
-<translation id="5854790677617711513">৩০ দিনের বেশি পুরনো</translation>
-<translation id="5858741533101922242">Chrome ব্লুটুথ অ্যাডাপ্টার চালু করতে পারছে না</translation>
-<translation id="5860033963881614850">বন্ধ করুন</translation>
-<translation id="5862731021271217234">আপনার অন্যান্য ডিভাইস থেকে ট্যাবগুলি পেতে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="5864174910718532887">বিবরণ: সাইটের নাম অনুযায়ী সাজানো হয়েছে</translation>
-<translation id="5864419784173784555">অন্য ডাউনলোডের জন্য অপেক্ষা করা হচ্ছে…</translation>
-<translation id="5865733239029070421">ব্যবহারের পরিসংখ্যান এবং ক্র্যাশ রিপোর্ট নিজে থেকেই Google-কে পাঠায়</translation>
-<translation id="5869522115854928033">সংরক্ষিত পাসওয়ার্ড</translation>
-<translation id="5902828464777634901">কুকি সহ এই ওয়েবসাইটের সঞ্চিত সমস্ত ডেটা মোছা হবে।</translation>
-<translation id="5916664084637901428">চালু</translation>
-<translation id="5919204609460789179">সিঙ্ক শুরু করতে <ph name="PRODUCT_NAME" /> আপডেট করুন</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> সেভ করা হয়েছে</translation>
-<translation id="5939518447894949180">রিসেট করুন</translation>
-<translation id="5942872142862698679">সার্চের জন্য Google কে ব্যবহার করছে</translation>
-<translation id="5952764234151283551">যে পৃষ্ঠাটি দেখার চেষ্টা করছেন Google-কে সেটির ইউআরএল পাঠায়</translation>
-<translation id="5956665950594638604">Chrome সহায়তা কেন্দ্রকে একটি নতুন ট্যাবে খুলুন</translation>
-<translation id="5958275228015807058">ডাউনলোড ফোল্ডার থেকে আপনার সমস্ত ফাইল ও পৃষ্ঠাগুলি খুঁজে নিন</translation>
-<translation id="5962718611393537961">সঙ্কুচিত করতে আলতো চাপুন</translation>
-<translation id="6000066717592683814">Google কে রাখুন</translation>
-<translation id="6005538289190791541">প্রস্তাবিত পাসওয়ার্ড</translation>
-<translation id="6036057147555329831">অতিরিক্ত ICU</translation>
-<translation id="6039379616847168523">পরবর্তী ট্যাবে চলে যান</translation>
-<translation id="6040143037577758943">বন্ধ</translation>
-<translation id="6042308850641462728">আরও</translation>
-<translation id="604996488070107836">একটি অজানা ত্রুটির কারনে <ph name="FILE_NAME" /> ডাউনলোড করা যায়নি।</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">সম্পূর্ণ হয়ে যাওয়া ডাউনলোড</translation>
-<translation id="6075798973483050474">হোম পৃষ্ঠা সম্পাদনা করুন</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> ঘণ্টা বাকি আছে</translation>
-<translation id="6108923351542677676">সেটআপ চলছে...</translation>
-<translation id="6111020039983847643">ব্যবহৃত ডেটা</translation>
-<translation id="6112702117600201073">রিফ্রেশ পৃষ্ঠা</translation>
-<translation id="6127379762771434464">আইটেম সরানো হয়েছে</translation>
-<translation id="6140912465461743537">দেশ/অঞ্চল</translation>
-<translation id="614940544461990577">এটি করে দেখুন:</translation>
-<translation id="6154478581116148741">এই ডিভাইস থেকে আপনার পাসওয়ার্ড এক্সপোর্ট করতে সেটিংসে স্ক্রিন লক চালু করুন</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> ডেটা সঞ্চয়</translation>
-<translation id="6165508094623778733">আরও জানুন</translation>
-<translation id="6177111841848151710">বর্তমান সার্চ ইঞ্জিনের জন্য অবরুদ্ধ করা হয়েছে</translation>
-<translation id="6181444274883918285">ব্যতিক্রমী সাইট যোগ করুন</translation>
-<translation id="6192333916571137726">ফাইল ডাউনলোড করুন</translation>
-<translation id="6192792657125177640">ব্যতিক্রমগুলি</translation>
-<translation id="6194112207524046168">Chrome যাতে আপনার ক্যামেরা অ্যাক্সেস করতে পারে তার জন্য <ph name="BEGIN_LINK" />Android সেটিংস<ph name="END_LINK" />-এ গিয়ে ক্যামেরা চালু করুন।</translation>
-<translation id="6196640612572343990">তৃতীয় পক্ষের কুকিজ অবরুদ্ধ করুন</translation>
-<translation id="6206551242102657620">কানেকশনটি নিরাপদ। সাইট তথ্য</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> না?</translation>
-<translation id="6221633008163990886">আপনার পাসওয়ার্ড এক্সপোর্ট করতে আনলক করুন</translation>
+<translation id="1406000523432664303">"ট্র্যাক করবেন না"</translation>
 <translation id="6232535412751077445">"ট্র্যাক করবেন না" চালু করার অর্থ হল আপনার ব্রাউজিং ট্র্যাফিকের সাথে একটি অনুরোধ অন্তর্ভুক্ত হবে৷ অনুরোধটিতে কোনো ওয়েবসাইট প্রতিক্রিয়া করে কি না এবং অনুরোধটিকে কীভাবে ব্যাখ্যা করা হয় তার উপর যেকোনো প্রভাব নির্ভর করে৷
 
 উদাহরণস্বরূপ, কিছু ওয়েবসাইট আপনার দেখা অন্য ওয়েবসাইট ভিত্তিক নয় এমন বিজ্ঞাপন দেখিয়ে এই অনুরোধে প্রতিক্রিয়া জানাতে পারে৷ অনেক ওয়েবসাইট তারপরও আপনার ব্রাউজিং ডেটা সংগ্রহ এবং ব্যবহার করবে - উদাহরণস্বরূপ, আপনার নিরাপত্তা বাড়াতে, সামগ্রী, বিজ্ঞাপন এবং প্রস্তাবনা প্রদান করতে এবং রিপোর্ট পরিসংখ্যান তৈরি করতে৷</translation>
-<translation id="624789221780392884">আপডেট প্রস্তুত</translation>
-<translation id="6255999984061454636">কন্টেন্টের প্রস্তাবনা</translation>
-<translation id="6277522088822131679">পৃষ্ঠাটি প্রিন্ট করার সময় একটি সমস্যা হয়েছিল৷ দয়া করে আবার চেষ্টা করুন৷</translation>
-<translation id="6295158916970320988">সমস্ত সাইট</translation>
-<translation id="629730747756840877">অ্যাকাউন্ট</translation>
-<translation id="6303969859164067831">সাইন-আউট করুন এবং সিঙ্ক করা বন্ধ করুন</translation>
-<translation id="6316139424528454185">এই Android ভার্সন সমর্থিত নয়</translation>
-<translation id="6320088164292336938">কম্পন</translation>
-<translation id="6324034347079777476">Android সিস্টেম সিঙ্ক অক্ষম করা হয়েছে</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> এর মাধ্যমে শেয়ার করুন</translation>
-<translation id="6337234675334993532">এনক্রিপশন</translation>
-<translation id="6341580099087024258">কোথায় ফাইল সেভ করতে চান</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> আরও অনেক}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> আরও অনেক}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> আরও অনেক}}</translation>
-<translation id="6364438453358674297">ইতিহাস থেকে প্রস্তাবনা সরাবেন?</translation>
-<translation id="6369229450655021117">এখান থেকে আপনি ওয়েবে সার্চ করতে, বন্ধুদের সাথে শেয়ার করতে এবং খোলা পৃষ্ঠাগুলি দেখতে পারেন</translation>
-<translation id="6378173571450987352">বিবরণ: ব্যবহার করা ডেটার পরিমাণ অনুযায়ী সাজানো হয়েছে</translation>
-<translation id="6381421346744604172">ওয়েবসাইট কালো করুন</translation>
-<translation id="6388207532828177975">পরিষ্কার এবং রিসেট করুন</translation>
-<translation id="6393863479814692971">এই সাইটটির জন্য Chrome কে আপনার ক্যামেরা এবং মাইক্রোফোনে অ্যাক্সেস দিতে হবে।</translation>
-<translation id="6395288395575013217">লিঙ্ক</translation>
-<translation id="6404511346730675251">বুকমার্ক সম্পাদনা করুন</translation>
-<translation id="6406506848690869874">সিঙ্ক</translation>
-<translation id="641643625718530986">প্রিন্ট...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB ডাউনলোড হয়েছে</translation>
-<translation id="6427112570124116297">ওয়েবের কন্টেন্ট অনুবাদ করুন</translation>
-<translation id="6433501201775827830">আপনার সার্চ ইঞ্জিন বেছে নিন</translation>
-<translation id="6437478888915024427">পৃষ্ঠার তথ্য</translation>
-<translation id="6441734959916820584">নামটি অত্যন্ত দীর্ঘ</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{#টি ছবি}one{#টি ছবি}other{#টি ছবি}}</translation>
-<translation id="6447842834002726250">কুকিজ</translation>
-<translation id="6461962085415701688">ফাইল খোলা যাচ্ছে না</translation>
-<translation id="6464977750820128603">Chrome-এ দেখা সাইটগুলি আপনি দেখতে পাবেন এবং সাইটগুলিতে টাইমার সেট করতে পারবেন।\n\nযে সমস্ত সাইটে টাইমার সেট করেছেন বা কত সময় ধরে সাইটটি দেখেছেন তার সমস্ত তথ্য Google-এর কাছে যায়। ডিজিটাল ওয়েলবিং-কে আরও উন্নত করতে এই তথ্য ব্যবহার করা হয়।</translation>
-<translation id="6475951671322991020">ভিডিও ডাউনলোড করুন</translation>
-<translation id="6482749332252372425">স্টোরেজে জায়গার ঘাটতির কারণে <ph name="FILE_NAME" /> ডাউনলোড করা যায়নি।</translation>
-<translation id="6496823230996795692"><ph name="APP_NAME" /> প্রথমবার ব্যবহার করার জন্য অনুগ্রহ করে ইন্টারনেটে সংযুক্ত হন।</translation>
-<translation id="6508722015517270189">Chrome পুনরায় চালু করুন</translation>
-<translation id="6527303717912515753">শেয়ার করুন</translation>
-<translation id="6532866250404780454">আপনি কোন কোন সাইটে গেছেন তা Chrome-এ দেখা যাবে না। সমস্ত সাইটের টাইমার মুছে দেওয়া হবে।</translation>
-<translation id="6534565668554028783">Google সাড়া দিতে দেরী করছে</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB ডাউনলোড হয়েছে</translation>
-<translation id="6539092367496845964">কোনও সমস্যা হয়েছে। পরে আবার চেষ্টা করুন।</translation>
-<translation id="654446541061731451">বিম করার জন্য একটি ট্যাব বেছে নিন</translation>
-<translation id="6545017243486555795">সমস্ত ডেটা সাফ করুন</translation>
-<translation id="6545864417968258051">ব্লুটুথ স্ক্যানিং</translation>
-<translation id="6560414384669816528">Sogou দিয়ে খুঁজুন</translation>
-<translation id="6566259936974865419">Chrome আপনার জন্য <ph name="GIGABYTES" /> জিবি বাঁচিয়ে দিয়েছে</translation>
-<translation id="6573096386450695060">সর্বদা অনুমতি দিন</translation>
-<translation id="6573431926118603307">আপনার অন্য ডিভাইসগুলিতে Chrome এ আপনি যে ট্যাবগুলি খুলেছেন সেগুলি এখানে দেখা যাবে।</translation>
-<translation id="6583199322650523874">বর্তমান পৃষ্ঠাটি বুকমার্ক করুন</translation>
-<translation id="6593061639179217415">ডেস্কটপ সাইট</translation>
-<translation id="6600954340915313787">Chrome-এ প্রতিলিপি করা হয়েছে</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> জিবি</translation>
-<translation id="6612358246767739896">সুরক্ষিত কন্টেন্ট</translation>
-<translation id="6627583120233659107">ফোল্ডার সম্পাদনা করুন</translation>
-<translation id="6643016212128521049">সাফ করুন</translation>
-<translation id="6643649862576733715">সেভ করা ডেটার পরিমাণ অনুযায়ী সাজান</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> আরও অনেক}one{<ph name="CONTACT_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> আরও অনেক}other{<ph name="CONTACT_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> আরও অনেক}}</translation>
-<translation id="6649642165559792194"><ph name="BEGIN_NEW" />নতুন<ph name="END_NEW" /> ছবির প্রিভিউ দেখুন</translation>
-<translation id="6656545060687952787">ডিভাইস স্ক্যান করার জন্য Chrome এর স্থান এক্সেস প্রয়োজন। <ph name="BEGIN_LINK" />অনুমতি আপডেট করুন<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">পাসওয়ার্ড</translation>
-<translation id="6659594942844771486">ট্যাব</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" /> এ খুলুন</translation>
-<translation id="666981079809192359">Chrome এর গোপনীয়তা বিজ্ঞপ্তি</translation>
-<translation id="6676840375528380067">এই ডিভাইস থেকে Chrome ডেটা সরিয়ে ফেলবেন?</translation>
-<translation id="6697492270171225480">কোনও একটি পৃষ্ঠা খুঁজে পাওয়া না গেলে একইরকম আরও পৃষ্ঠার সাজেশন দেখুন</translation>
-<translation id="6697947395630195233">এই সাইটটির সাথে আপনার লোকেশন শেয়ার করার জন্য Chrome কে আপনার লোকেশনের তথ্যে অ্যাক্সেস দিতে হবে।</translation>
-<translation id="6698801883190606802">সিঙ্ক হওয়া ডেটা পরিচালনা করুন</translation>
-<translation id="6699370405921460408">আপনি যে পৃষ্ঠাগুলিতে যান সেগুলি Google সার্ভার অপ্টিমাইজ করবে।</translation>
-<translation id="6706288973712894588">আপনি এখন অফলাইন আছেন।\n<ph name="BEGIN_LINK" />আপনার অফলাইন ফিড ঘুরে দেখুন।<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">সংবাদ</translation>
-<translation id="6710213216561001401">পূর্ববর্তী</translation>
-<translation id="671481426037969117">আপনার <ph name="FQDN" /> টাইমারের মেয়াদ পেরিয়ে গেছে। আগামীকাল আবার এটি শুরু হবে।</translation>
-<translation id="6738867403308150051">ডাউনলোড হচ্ছে...</translation>
-<translation id="6746124502594467657">নিচে যান</translation>
-<translation id="6766622839693428701">বন্ধ করতে নিচের দিকে সোয়াইপ করুন।</translation>
-<translation id="6766758767654711248">সাইটে যেতে ট্যাপ করুন</translation>
-<translation id="6767294960381293877">ট্যাব শেয়ার করা যাবে এমন ডিভাইসের সূচি অর্ধেক স্ক্রিন জুড়ে খোলা হয়েছে।</translation>
-<translation id="6782111308708962316">কুকি ডেটা সংরক্ষণ করা এবং পড়া থেকে তৃতীয় পক্ষের ওয়েবসাইটগুলিকে আটকান</translation>
-<translation id="6790428901817661496">চালু করুন</translation>
-<translation id="6811034713472274749">পৃষ্ঠাটি এখন দেখতে পাবেন</translation>
-<translation id="6818926723028410516">আইটেম বেছে নিন</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">অনুবাদ</translation>
-<translation id="6845325883481699275">Chrome-এর নিরাপত্তা উন্নত করতে সাহায্য করুন</translation>
-<translation id="6846298663435243399">লোড হচ্ছে...</translation>
-<translation id="6850409657436465440">ডাউনলোডটি এখনও চলছে</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" />টি ট্যাব বন্ধ হয়েছে</translation>
-<translation id="6864459304226931083">ইমেজ ডাউনলোড করুন</translation>
-<translation id="6865313869410766144">স্বতঃপূর্ণ ফর্ম ডেটা</translation>
-<translation id="688738109438487280">বিদ্যমান ডেটা <ph name="TO_ACCOUNT" /> এ যোগ করুন।</translation>
-<translation id="6891726759199484455">আপনার পাসওয়ার্ড কপি করতে আনলক করুন</translation>
-<translation id="6896758677409633944">কপি</translation>
-<translation id="6910211073230771657">মোছা হয়েছে</translation>
-<translation id="6912998170423641340">ক্লিপবোর্ডের টেক্সট এবং ছবি পড়ার থেকে সাইটগুলিকে ব্লক করুন</translation>
-<translation id="6914783257214138813">এক্সপোর্ট করা ফাইল যারা দেখতে পান তারা আপনার পাসওয়ার্ডগুলিও দেখতে পাবেন।</translation>
-<translation id="6942665639005891494">সেটিংস মেনুর বিকল্পে গিয়ে যেকোনও সময় ডাউনলোডের ডিফল্ট লোকেশন পরিবর্তন করুন</translation>
-<translation id="6945221475159498467">নির্বাচন</translation>
-<translation id="6963642900430330478">এই পৃষ্ঠাটি বিপজ্জনক। সাইটের তথ্য</translation>
-<translation id="6963766334940102469">বুকমার্কগুলি মুছুন</translation>
-<translation id="6965382102122355670">ঠিক আছে</translation>
-<translation id="6979737339423435258">শুরু থেকে</translation>
-<translation id="6981982820502123353">ব্যবহারযোগ্যতা</translation>
-<translation id="6989267951144302301">ডাউনলোড করা যায়নি</translation>
-<translation id="6990079615885386641">Google Play Store-এর থেকে অ্যাপ্লিকেশানটি পান: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">সাইটগুলিকে আপনার মাইক্রোফোন ব্যবহার করতে দিতে মঞ্জুরি দেওয়ার আগে প্রথমে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
-<translation id="7015203776128479407">সিঙ্কের প্রাথমিক সেট-আপ সম্পূর্ণ হয়নি। সিঙ্ক বন্ধ আছে।</translation>
-<translation id="7016516562562142042">বর্তমান সার্চ ইঞ্জিনের জন্য অনুমোদন দেওয়া হয়েছে</translation>
-<translation id="7022756207310403729">ব্রাউজারে খুলুন</translation>
-<translation id="702463548815491781">'টকব্যাক' অথবা 'অ্যাক্সেস পরিবর্তন করুন' চালু করা থাকলে এটি করার সাজেশন পাবেন</translation>
-<translation id="7029809446516969842">পাসওয়ার্ড</translation>
-<translation id="7053983685419859001">ব্লক করুন</translation>
-<translation id="7055152154916055070">রিডাইরেক্ট ব্লক করা হয়েছে:</translation>
-<translation id="7063006564040364415">সিঙ্ক সার্ভারে সংযোগ করতে পারেনি৷</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{১টি বেছে নেওয়া হয়েছে}one{#টি বেছে নেওয়া হয়েছে}other{#টি বেছে নেওয়া হয়েছে}}</translation>
-<translation id="7071521146534760487">অ্যাকাউন্ট ম্যানেজ করুন</translation>
-<translation id="7077143737582773186">এসডি কার্ড</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> বেছে নেওয়া হয়েছে।  স্ক্রিনের উপরে বিকল্পগুলি পাওয়া যাবে</translation>
-<translation id="7121362699166175603">অ্যাড্রেস বারের ইতিহাস এবং অটোকমপ্লিট তথ্য মুছে ফেলে। <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />-এ আপনার Google অ্যাকাউন্টের অন্যান্য ধরনের ব্রাউজিংয়ের ইতিহাস থাকতে পারে।</translation>
-<translation id="7128222689758636196">বর্তমান সার্চ ইঞ্জিনের জন্য অনুমোদন দিন</translation>
-<translation id="7138678301420049075">অন্যান্য</translation>
-<translation id="7141896414559753902">সাইটগুলিকে পপ-আপ দেখাতে এবং রিডাইরেক্ট করা থেকে বাধা দিন (প্রস্তাবিত)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> থেকে <ph name="BEGIN_LINK" />মূল পৃষ্ঠাটি লোড করুন<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">গত ২৪ ঘণ্টা</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> কেবি</translation>
-<translation id="7177466738963138057">আপনি পরে সেটিংসে এই পরিবর্তন করতে পারবেন</translation>
-<translation id="7180611975245234373">রিফ্রেশ করুন</translation>
-<translation id="7189372733857464326">Google Play পরিষেবাগুলির আপডেট শেষ হওয়ার জন্য অপেক্ষা করছে</translation>
-<translation id="7191430249889272776">পটভূমিতে ট্যাব খোলা হয়েছে।</translation>
-<translation id="723171743924126238">ছবি বেছে নিন</translation>
-<translation id="7233236755231902816">ওয়েবের কন্টেন্ট নিজের ভাষায় পড়তে, Chrome-এর লেটেস্ট ভার্সন ইনস্টল করুন</translation>
-<translation id="7243308994586599757">স্ক্রীনের প্রায় নীচের দিকে বিকল্পগুলি উপলব্ধ</translation>
-<translation id="7248069434667874558">Chrome-এ <ph name="TARGET_DEVICE_NAME" /> সিঙ্ক করার ফিচার চালু করে রেখেছেন কিনা দেখে নিন।</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" />টি বেছে নেওয়া হয়েছে</translation>
-<translation id="7274013316676448362">অবরুদ্ধ সাইট</translation>
-<translation id="7290209999329137901">আবার নামকরণের বিকল্পটি উপলভ্য নেই</translation>
-<translation id="7291387454912369099">অ্যাসিস্ট্যান্টের মাধ্যমে চেকআউট</translation>
-<translation id="7293171162284876153">সিঙ্ক চালু করতে "আপনার Chrome ডেটা সিঙ্ক করুন" বিকল্পটি চালু করুন।</translation>
-<translation id="729975465115245577">পাসওয়ার্ড ফাইল সেভ করার জন্য আপনার ডিভাইসে কোনও অ্যাপ নেই।</translation>
-<translation id="7302081693174882195">বিবরণ: সেভ করা ডেটার পরিমাণ অনুযায়ী সাজানো হয়েছে</translation>
-<translation id="7328017930301109123">লাইট মোডে, Chrome আরও দ্রুত পৃষ্ঠা লোড করে এবং ৬০ শতাংশ পর্যন্ত কম ডেটা ব্যবহার করে।</translation>
-<translation id="7333031090786104871">এখনও পূর্বের সাইট যোগ করছে</translation>
-<translation id="7352939065658542140">ভিডিও</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{১টি নির্বাচিত আইটেম শেয়ার করুন}one{#টি নির্বাচিত আইটেম শেয়ার করুন}other{#টি নির্বাচিত আইটেম শেয়ার করুন}}</translation>
 <translation id="7359002509206457351">পেমেন্টের পদ্ধতি অ্যাক্সেস করুন</translation>
+<translation id="8026334261755873520">ব্রাউজ করা ডেটা সাফ করুন</translation>
+<translation id="1291207594882862231">ইতিহাস, কুকিজ, সাইট ডেটা, ক্যাশে সাফ করে...</translation>
+<translation id="7814200940910057384">Brave ডেটা সাফ হয়েছে</translation>
+<translation id="1664855196866195614">বেছে নেওয়া ডেটা Brave ও সিঙ্ক করা ডিভাইস থেকে সরিয়ে দেওয়া হয়েছে।
+
+আপনার Brave Software অ্যাকাউন্টের সার্চ এবং অন্যান্য Brave Software পরিষেবায় বিভিন্ন অ্যাক্টিভিটির মতো অন্যান্য ধরনের ব্রাউজিং ইতিহাস <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/>-এ সেভ করা থাকতে পারে।</translation>
+<translation id="4699172675775169585">ক্যাশে করা ছবি এবং ফাইলগুলি</translation>
+<translation id="2496180316473517155">ব্রাউজিং ইতিহাস</translation>
+<translation id="2546283357679194313">কুকিজ ও সাইট ডেটা</translation>
+<translation id="8662811608048051533">বেশিরভাগ সাইট থেকে আপনাকে সাইন-আউট করিয়ে দেয়।</translation>
+<translation id="8218628800671693884">বেশিরভাগ সাইট থেকে আপনাকে সাইন-আউট করিয়ে দেয়। তবে আপনার Brave Software অ্যাকাউন্ট থেকে আপনাকে সাইন-আউট করানো হবে না।</translation>
+<translation id="2017836877785168846">অ্যাড্রেস বার থেকে ইতিহাস ও অটোকমপ্লিট মুছে ফেলে।</translation>
+<translation id="8096327394278038498">অ্যাড্রেস বারের ইতিহাস এবং অটোকমপ্লিট তথ্য মুছে ফেলে। <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>-এ আপনার Brave Software অ্যাকাউন্টের অন্যান্য ধরনের ব্রাউজিংয়ের ইতিহাস থাকতে পারে।</translation>
+<translation id="8122693181154564064">সমস্ত সাইন-ইন করা ডিভাইসগুলি থেকে ইতিহাস মুছে ফেলে। <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>-এ আপনার Brave Software অ্যাকাউন্টের অন্যান্য ধরনের ব্রাউজিংয়ের ইতিহাস থাকতে পারে।</translation>
+<translation id="5869522115854928033">সংরক্ষিত পাসওয়ার্ড</translation>
+<translation id="6865313869410766144">স্বতঃপূর্ণ ফর্ম ডেটা</translation>
+<translation id="7562080006725997899">ব্রাউজিং ইতিহাস সাফ করা হচ্ছে</translation>
+<translation id="5487521232677179737">ডেটা সাফ করুন</translation>
+<translation id="7498271377022651285">দয়া করে অপেক্ষা করুন...</translation>
+<translation id="784934925303690534">সময় সীমা</translation>
+<translation id="1718835860248848330">শেষ ঘণ্টা</translation>
+<translation id="7149893636342594995">গত ২৪ ঘণ্টা</translation>
+<translation id="5648166631817621825">গত ৭ দিন</translation>
+<translation id="8571213806525832805">গত ৪ সপ্তাহ</translation>
+<translation id="5854790677617711513">৩০ দিনের বেশি পুরনো</translation>
+<translation id="6979737339423435258">শুরু থেকে</translation>
+<translation id="982182592107339124">এটা সব সাইটের জন্য ডেটা সাফ করবে, এতে অন্তর্ভুক্ত আছে:</translation>
+<translation id="6643016212128521049">সাফ করুন</translation>
+<translation id="7641339528570811325">ব্রাউজিং ডেটা সাফ করুন...</translation>
+<translation id="1670399744444387456">প্রাথমিক</translation>
+<translation id="3245261285041759672"><ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>-এ আপনার Brave Software অ্যাকাউন্টের অন্যান্য ধরনের ব্রাউজিংয়ের ইতিহাস থাকতে পারে।</translation>
+<translation id="7274013316676448362">অবরুদ্ধ সাইট</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/>টি আইটেম মোছা হয়েছে</translation>
+<translation id="1121094540300013208">ব্যবহার এবং ক্র্যাশ প্রতিবেদনগুলি</translation>
+<translation id="9079153198295609735">ব্যবহারের পরিসংখ্যান এবং ক্র্যাশ প্রতিবেদনগুলি স্বয়ংক্রিয়ভাবে Brave Software-এ পাঠান</translation>
+<translation id="6981982820502123353">ব্যবহারযোগ্যতা</translation>
+<translation id="2387895666653383613">পাঠ্য স্কেলিং</translation>
+<translation id="2321958826496381788">আপনি এটি স্বচ্ছন্দে পড়তে না পারা পর্যন্ত স্লাইডারটি টেনে আনুন৷ কোনো অনুচ্ছেদে দুবার-আলতো চাপার পরে পাঠ্যটিকে দেখতে অন্ততপক্ষে এইরকম বড় লাগা উচিত৷</translation>
+<translation id="3895926599014793903">ফোর্স জুম চালু করুন</translation>
+<translation id="5668404140385795438">কোনো ওয়েবসাইটের জুম ইন প্রতিরোধ করার অনুরোধ উপেক্ষা করুন</translation>
+<translation id="4149994727733219643">ওয়েব পৃষ্ঠার জন্য সরলীকৃত ভিউ</translation>
+<translation id="9100505651305367705">সমর্থিত হলে সরলীকৃত ভিউতে নিবন্ধগুলি দেখানোর প্রস্তাব দিন</translation>
+<translation id="1409426117486808224">খোলা ট্যাবের জন্য সরলীকৃত ভিউ</translation>
+<translation id="702463548815491781">'টকব্যাক' অথবা 'অ্যাক্সেস পরিবর্তন করুন' চালু করা থাকলে এটি করার সাজেশন পাবেন</translation>
+<translation id="8284326494547611709">পরিচয়লিপিগুলি</translation>
+<translation id="4165986682804962316">সাইটের সেটিংস</translation>
+<translation id="6295158916970320988">সমস্ত সাইট</translation>
+<translation id="8380167699614421159">এই সাইট ব্যাঘাত সৃষ্টিকারী বা বিভ্রান্তিকর বিজ্ঞাপন দেখায়</translation>
+<translation id="1919345977826869612">বিজ্ঞাপন</translation>
+<translation id="410351446219883937">স্বতঃচালানো</translation>
+<translation id="6447842834002726250">কুকিজ</translation>
+<translation id="6196640612572343990">তৃতীয় পক্ষের কুকিজ অবরুদ্ধ করুন</translation>
+<translation id="6782111308708962316">কুকি ডেটা সংরক্ষণ করা এবং পড়া থেকে তৃতীয় পক্ষের ওয়েবসাইটগুলিকে আটকান</translation>
+<translation id="7521387064766892559">জাভাস্ক্রিপ্ট</translation>
+<translation id="4434045419905280838">পপ-আপ এবং রিডাইরেক্ট</translation>
+<translation id="4751476147751820511">মোশন বা হালকা সেন্সর</translation>
+<translation id="1717218214683051432">মোশন সেন্সর</translation>
+<translation id="2091887806945687916">আওয়াজ</translation>
+<translation id="2586657967955657006">ক্লিপবোর্ড</translation>
+<translation id="6320088164292336938">কম্পন</translation>
+<translation id="4226663524361240545">বিজ্ঞপ্তি আসলে ডিভাইস ভাইব্রেট হতে পারে</translation>
+<translation id="1446450296470737166">MIDI ডিভাইসগুলির পূর্ণ নিয়ন্ত্রণের অনুমতি দিন</translation>
+<translation id="3744111561329211289">পটভূমি সিঙ্ক</translation>
+<translation id="5649053991847567735">অটোমেটিক ডাউনলোডগুলি</translation>
+<translation id="6181444274883918285">ব্যতিক্রমী সাইট যোগ করুন</translation>
+<translation id="5313967007315987356">সাইট যোগ করুন</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> সাইট যোগ করা হয়েছে</translation>
+<translation id="7837721118676387834">একটি নির্দিষ্ট সাইটের জন্য মিউট করে রাখা ভিডিওগুলি স্বতঃবাজানোর অনুমতি দেয়।</translation>
+<translation id="2621115761605608342">একটি নির্দিষ্ট সাইটের জন্য জাভাস্ক্রিপ্ট মঞ্জুর করুন।</translation>
+<translation id="8801436777607969138">একটি নির্দিষ্ট সাইটের জন্য জাভাস্ক্রিপ্ট ব্লক করুন।</translation>
+<translation id="8372893542064058268">একটি নির্দিষ্ট সাইটের জন্য পটভূমি সিঙ্কের অনুমতি দিন।</translation>
+<translation id="358794129225322306">একটি সাইটকে একাধিক ফাইল অটোমেটিক ডাউনলোড করার অনুমতি দিন।</translation>
+<translation id="4008040567710660924">কোনও নির্দিষ্ট সাইটের জন্য কুকিকে অনুমতি দিন।</translation>
+<translation id="8958424370300090006">কোনও নির্দিষ্ট সাইটের জন্য কুকি ব্লক করুন।</translation>
+<translation id="7882806643839505685">একটি নির্দিষ্ট সাইটের জন্য সাউন্ড প্লে করার অনুমতি দিন।</translation>
+<translation id="4468959413250150279">নির্দিষ্ট কোনও সাইটের জন্য সাউন্ড মিউট করুন।</translation>
+<translation id="1994173015038366702">সাইট URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">ব্যবহার</translation>
+<translation id="5804241973901381774">অনুমতিগুলি</translation>
+<translation id="4278390842282768270">মঞ্জুরিপ্রাপ্ত</translation>
+<translation id="5677928146339483299">অবরুদ্ধ</translation>
+<translation id="1984937141057606926">মঞ্জুরিপ্রাপ্ত, তৃতীয় পক্ষ ব্যাতীত</translation>
+<translation id="7423098979219808738">প্রথমে জিজ্ঞাসা করুন</translation>
+<translation id="8116925261070264013">মিউট করা আছে</translation>
+<translation id="8300705686683892304">অ্যাপ ম্যানেজ করে</translation>
+<translation id="6192792657125177640">ব্যতিক্রমগুলি</translation>
+<translation id="257931822824936280">প্রসারিত - সঙ্কুচিত করতে ক্লিক করুন৷</translation>
+<translation id="5100237604440890931">সঙ্কুচিত - প্রসারিত করতে ক্লিক করুন৷</translation>
+<translation id="857943718398505171">অনুমোদিত (প্রস্তাবিত)</translation>
+<translation id="2913331724188855103">সাইটগুলিকে কুকি ডেটা পড়ার এবং সংরক্ষণ করার অনুমতি দিন (প্রস্তাবিত)</translation>
+<translation id="7445411102860286510">সাইটগুলিকে মিউট করে রাখা ভিডিও স্বতঃবাজানোর মঞ্জুরি দেয় (প্রস্তাবিত)</translation>
+<translation id="5335288049665977812">সাইটগুলিকে JavaScript চালানোর অনুমতি দিন (প্রস্তাবিত)</translation>
+<translation id="5527111080432883924">ক্লিপবোর্ডের টেক্সট এবং ছবি পড়ার জন্য অনুমতি দেওয়ার আগে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
+<translation id="6912998170423641340">ক্লিপবোর্ডের টেক্সট এবং ছবি পড়ার থেকে সাইটগুলিকে ব্লক করুন</translation>
+<translation id="7423538860840206698">ক্লিপবোর্ড পড়া ব্লক করা হয়েছে</translation>
+<translation id="3955193568934677022">সুরক্ষিত কন্টেন্ট প্লে করতে সাইটগুলিকে মঞ্জুরি দিন (প্রস্তাবিত)</translation>
+<translation id="445467742685312942">সাইটকে সুরক্ষিত কন্টেন্ট চালানোর জন্য অনুমতি দিন</translation>
+<translation id="2107397443965016585">সাইটকে সুরক্ষিত কন্টেন্ট চালানোর অনুমতি দেওয়ার আগে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
+<translation id="2910701580606108292">কোনও সাইটে সুরক্ষিত কন্টেন্ট চালু হওয়ার আগে আমায় জিজ্ঞেস করা হোক</translation>
+<translation id="757524316907819857">সুরক্ষিত কন্টেন্ট চালানো থেকে সাইটকে ব্লক করুন</translation>
+<translation id="3277252321222022663">সাইটকে সেন্সর অ্যাক্সেস করার অনুমতি দিন (সাজেস্ট করা হয়)</translation>
+<translation id="5048398596102334565">সাইটকে মোশন সেন্সর অ্যাক্সেস করার অনুমতি দিন (সাজেস্ট করা হয়)</translation>
+<translation id="8816026460808729765">সেন্সর অ্যাক্সেস করা থেকে সাইটকে ব্লক করুন</translation>
+<translation id="169515064810179024">মোশন সেন্সর অ্যাক্সেস করা থেকে সাইটকে ব্লক করুন</translation>
+<translation id="1660204651932907780">সাউন্ডটি প্লে করার জন্য সাইটটিতে অনুমতি দিন (প্রস্তাবিত)</translation>
+<translation id="3600792891314830896">সাউন্ড প্লে করা হয় যে সাইটগুলিতে সেগুলি মিউট করুন</translation>
+<translation id="1743802530341753419">কোনও সাইটকে ডিভাইসের সাথে কানেক্ট করার আগে অনুমতি দেওয়ার ব্যবস্থা রাখুন (প্রস্তাবিত)</translation>
+<translation id="851751545965956758">সাইটকে ডিভাইসের সাথে কানেক্ট করা থেকে ব্লক করুন</translation>
+<translation id="7141896414559753902">সাইটগুলিকে পপ-আপ দেখাতে এবং রিডাইরেক্ট করা থেকে বাধা দিন (প্রস্তাবিত)</translation>
+<translation id="5494752089476963479">সাইটে থাকা ব্যাঘাত সৃষ্টিকারী বা বিভ্রান্তিকর বিজ্ঞাপন ব্লক করুন</translation>
+<translation id="3123473560110926937">কিছু সাইটে ব্লক করা হয়েছে</translation>
+<translation id="965817943346481315">সাইটে থাকা ব্যাঘাত সৃষ্টিকারী বা বিভ্রান্তিকর বিজ্ঞাপন ব্লক করুন (প্রস্তাবিত)</translation>
+<translation id="3386292677130313581">সাইটগুলিকে আপনার লোকেশন জানতে দিতে মঞ্জুরি দেওয়ার আগে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
+<translation id="9139068048179869749">কোনও সাইটকে বিজ্ঞপ্তি পাঠানোর অনুমতি দেওয়ার আগে আমাকে জিজ্ঞেস করা হবে (প্রস্তাবিত)</translation>
+<translation id="4479647676395637221">সাইটগুলিকে আপনার ক্যামেরা ব্যবহার করতে দিতে মঞ্জুরি দেওয়ার আগে প্রথমে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
+<translation id="6992289844737586249">সাইটগুলিকে আপনার মাইক্রোফোন ব্যবহার করতে দিতে মঞ্জুরি দেওয়ার আগে প্রথমে জিজ্ঞাসা করুন (প্রস্তাবিত)</translation>
+<translation id="2289270750774289114">কাছাকাছি ব্লুটুথ ডিভাইস আছে কিনা তা কোনও সাইট খুঁজতে চাইলে আমাকে জিজ্ঞাসা করুন (সাজেস্ট করা হচ্ছে)</translation>
+<translation id="7053983685419859001">ব্লক করুন</translation>
+<translation id="7128222689758636196">বর্তমান সার্চ ইঞ্জিনের জন্য অনুমোদন দিন</translation>
+<translation id="7589445247086920869">বর্তমান সার্চ ইঞ্জিনের জন্য অবরুদ্ধ করুন</translation>
+<translation id="6388207532828177975">পরিষ্কার এবং রিসেট করুন</translation>
+<translation id="7999064672810608036">আপনি কি এই ওয়েবসাইটের কুকি সহ সমস্ত ডেটা পরিষ্কার করার এবং এটির সমস্ত অনুমতি রিসেট করার বিষয়ে নিশ্চিত?</translation>
+<translation id="2822354292072154809">আপনি কি <ph name="CHOSEN_OBJECT_NAME"/>-এর জন্য সাইটের সব অনুমতি রিসেট করার ব্যাপারে নিশ্চিত?</translation>
+<translation id="515227803646670480">সঞ্চিত ডেটা সাফ করুন</translation>
+<translation id="5902828464777634901">কুকি সহ এই ওয়েবসাইটের সঞ্চিত সমস্ত ডেটা মোছা হবে।</translation>
+<translation id="119944043368869598">সব পরিষ্কার করুন</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> ম্যানেজ করে</translation>
+<translation id="5516455585884385570">বিজ্ঞপ্তির সেটিংস খুলুন</translation>
+<translation id="1404122904123200417">এর মধ্যে এম্বেড করা হয়েছে <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">ওয়েবসাইট যেসব ফাইল সেভ করে সেগুলি এখানে দেখা যায়</translation>
+<translation id="4181841719683918333">ভাষাসমূহ</translation>
+<translation id="2647434099613338025">ভাষা যুক্ত করুন</translation>
+<translation id="1952172573699511566">যখন সম্ভব হবে ওয়েবসাইট আপনার পছন্দের ভাষায় টেক্সট দেখাবে।</translation>
+<translation id="8559990750235505898">অন্য ভাষাতে পৃষ্ঠা অনুবাদ করার প্রস্তাব দিন</translation>
+<translation id="4719927025381752090">অনুবাদ করুন</translation>
+<translation id="8156139159503939589">আপনি কোন কোন ভাষা পড়তে পারেন?</translation>
+<translation id="5689516760719285838">লোকেশন</translation>
+<translation id="2440823041667407902">লোকেশন অ্যাক্সেস</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android সেটিংসে<ph name="END_LINK"/> Brave এর জন্য অনুমতিগুলি চালু করুন।</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android সেটিংসে<ph name="END_LINK"/> Brave এর জন্য অনুমতি চালু করুন।</translation>
+<translation id="2928908108430545745">Brave যাতে আপনার লোকেশন অ্যাক্সেস করতে পারে তার জন্য <ph name="BEGIN_LINK"/>Android সেটিংস<ph name="END_LINK"/>-এ গিয়ে লোকেশন চালু করুন।</translation>
+<translation id="1028853271388022585">Brave যাতে আপনার ক্যামেরা অ্যাক্সেস করতে পারে তার জন্য <ph name="BEGIN_LINK"/>Android সেটিংস<ph name="END_LINK"/>-এ গিয়ে ক্যামেরা চালু করুন।</translation>
+<translation id="2913721282607281710">Brave যাতে আপনাকে বিজ্ঞপ্তি পাঠাতে পারে তার জন্য আপনি <ph name="BEGIN_LINK"/>Android সেটিংস<ph name="END_LINK"/>-এ গিয়ে বিজ্ঞপ্তি চালু করুন।</translation>
+<translation id="8753483718490035722">Brave যাতে আপনার মাইক্রোফোন অ্যাক্সেস করতে পারে তার জন্য <ph name="BEGIN_LINK"/>Android সেটিংস<ph name="END_LINK"/>-এ গিয়ে মাইক্রোফোন চালু করুন।</translation>
+<translation id="1887786770086287077">এই ডিভাইসে লোকেশন অ্যাক্সেস বন্ধ আছে। চালু করতে <ph name="BEGIN_LINK"/>Android সেটিংসে<ph name="END_LINK"/> যান।</translation>
+<translation id="2570922361219980984">এই ডিভাইসেও লোকেশন অ্যাক্সেস বন্ধ আছে। চালু করতে <ph name="BEGIN_LINK"/>Android সেটিংসে<ph name="END_LINK"/> যান।</translation>
+<translation id="1620510694547887537">ক্যামেরা</translation>
+<translation id="3227137524299004712">মাইক্রোফোন</translation>
+<translation id="1647391597548383849">আপনার ক্যামেরা অ্যাক্সেস করুন</translation>
+<translation id="945632385593298557">আপনার মাইক্রোফোন অ্যাক্সেস করুন</translation>
+<translation id="6612358246767739896">সুরক্ষিত কন্টেন্ট</translation>
+<translation id="885701979325669005">স্টোরেজ</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> সংরক্ষিত ডেটা</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">ডিভাইসের অনুমতি প্রত্যাহার করুন</translation>
+<translation id="4962975101802056554">ডিভাইসের ক্ষেত্রে সমস্ত অনুমতি সরিয়ে দিন</translation>
+<translation id="6545864417968258051">ব্লুটুথ স্ক্যানিং</translation>
+<translation id="4411535500181276704">লাইট মোড</translation>
+<translation id="7821588508402923572">আপনি কত ডেটা সেভ করেছেন তা এখানে দেখা যাবে</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> সংরক্ষণ করা হয়েছে</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> তারিখ থেকে</translation>
+<translation id="3252158532344029638">লাইট মোডে, Brave আরও দ্রুত পৃষ্ঠা লোড করে এবং ৬০ শতাংশ পর্যন্ত কম ডেটা ব্যবহার করে।</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> ডেটা সঞ্চয়</translation>
+<translation id="7494974237137038751">সেভ করা ডেটা</translation>
+<translation id="6111020039983847643">ব্যবহৃত ডেটা</translation>
+<translation id="7413229368719586778">শুরুর তারিখ <ph name="DATE"/></translation>
+<translation id="1782483593938241562">শেষ হওয়ার তারিখ <ph name="DATE"/></translation>
+<translation id="2728754400939377704">সাইট অনুযায়ী সাজান</translation>
+<translation id="5864174910718532887">বিবরণ: সাইটের নাম অনুযায়ী সাজানো হয়েছে</translation>
+<translation id="116280672541001035">ব্যবহৃত</translation>
+<translation id="8349013245300336738">ব্যবহার করা ডেটার পরিমাণ অনুযায়ী সাজান</translation>
+<translation id="6378173571450987352">বিবরণ: ব্যবহার করা ডেটার পরিমাণ অনুযায়ী সাজানো হয়েছে</translation>
+<translation id="2631006050119455616">সংরক্ষিত হয়েছে</translation>
+<translation id="6643649862576733715">সেভ করা ডেটার পরিমাণ অনুযায়ী সাজান</translation>
+<translation id="7302081693174882195">বিবরণ: সেভ করা ডেটার পরিমাণ অনুযায়ী সাজানো হয়েছে</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> ব্যবহার করা হয়েছে</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> সেভ করা হয়েছে</translation>
+<translation id="2156074688469523661">(<ph name="NUMBER_OF_SITES"/>)টি সাইট বাকি আছে</translation>
+<translation id="7138678301420049075">অন্যান্য</translation>
+<translation id="4913161338056004800">পরিসংখ্যান রিসেট করুন</translation>
+<translation id="1856325424225101786">লাইট মোড রিসেট করবেন?</translation>
+<translation id="3658159451045945436">রিসেট করলে আপনার ঘুরে দেখা সাইট সহ আপনার ডেটা সেভিংয়ের ইতিহাস মুছে দেয়।</translation>
+<translation id="3295530008794733555">চটপট ব্রাউজ করুন। আরও কম ডেটা ব্যবহার করুন।</translation>
+<translation id="7340390500800578919">লাইট মোডে, Brave আরও দ্রুত পৃষ্ঠা লোড করে এবং ৬০ শতাংশ পর্যন্ত কম ডেটা ব্যবহার করে। আপনার ভিজিট করা পৃষ্ঠাকে অপ্টিমাইজ করার জন্য Brave আপনার ওয়েব ট্রাফিককে Brave Software-এ পাঠায়। <ph name="BEGIN_LINK"/>আরও জানুন<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">লাইট মোড চালু করুন</translation>
+<translation id="4493497663118223949">লাইট মোড চালু আছে</translation>
+<translation id="7559975015014302720">লাইট মোড বন্ধ আছে</translation>
+<translation id="7606077192958116810">লাইট মোড চালু আছে। সেটিংসে এটি ম্যানেজ করুন।</translation>
+<translation id="4714588616299687897">আপনার ডেটা ৬০% পর্যন্ত সেভ করুন</translation>
+<translation id="1006927014032731288">আপনি যে পৃষ্ঠাগুলিতে যান সেগুলি Brave Software সার্ভার অপ্টিমাইজ করবে।</translation>
+<translation id="3257320067425202300">Brave আপনার জন্য <ph name="MEGABYTES"/> এমবি বাঁচিয়ে দিয়েছে</translation>
+<translation id="5813223329348543512">Brave আপনার জন্য <ph name="GIGABYTES"/> জিবি বাঁচিয়ে দিয়েছে</translation>
+<translation id="8266862848225348053">যেখানে ডাউনলোড হবে</translation>
+<translation id="7077143737582773186">এসডি কার্ড</translation>
+<translation id="7762668264895820836"><ph name="SD_CARD_NUMBER"/> টি এসডি কার্ড</translation>
+<translation id="6341580099087024258">কোথায় ফাইল সেভ করতে চান</translation>
+<translation id="6192333916571137726">ফাইল ডাউনলোড করুন</translation>
+<translation id="1672586136351118594">আর দেখতে চাই না</translation>
+<translation id="2650751991977523696">আবার ফাইল ডাউনলোড করবেন?</translation>
+<translation id="8664979001105139458">ফাইলের নামটি আগে থেকেই আছে</translation>
+<translation id="488187801263602086">ফাইলটির আবার নাম দিন</translation>
+<translation id="5686790454216892815">ফাইলের নামটি খুব বড়</translation>
+<translation id="7454641608352164238">পর্যাপ্ত জায়গা নেই</translation>
+<translation id="8972098258593396643">ডিফল্ট ফোল্ডারে ডাউনলোড করবেন?</translation>
+<translation id="804335162455518893">এসডি কার্ড পাওয়া যায়নি</translation>
+<translation id="7475688122056506577">এসডি কার্ড পাওয়া যায়নি। আপনার কিছু ফাইল নাও থাকতে পারে।</translation>
+<translation id="4198423547019359126">ডাউনলোড করার জন্য লোকেশন উপলভ্য নেই</translation>
+<translation id="8224471946457685718">ওয়াই-ফাই ব্যবহার করে আপনার জন্য নিবন্ধ ডাউনলোড করুন</translation>
+<translation id="4970824347203572753">আপনার লোকেশনে উপলভ্য নেই</translation>
+<translation id="5500777121964041360">আপনার লোকেশনে উপলভ্য নাও থাকতে পারে</translation>
+<translation id="1173894706177603556">পুনঃনামকরণ</translation>
+<translation id="1986685561493779662">নামটি আগে থেকেই আছে</translation>
+<translation id="6441734959916820584">নামটি অত্যন্ত দীর্ঘ</translation>
+<translation id="2923908459366352541">নাম সঠিক নয়</translation>
+<translation id="7290209999329137901">আবার নামকরণের বিকল্পটি উপলভ্য নেই</translation>
+<translation id="3334729583274622784">ফাইলের এক্সটেনশন পরিবর্তন করতে চান?</translation>
+<translation id="107147699690128016">আপনি ফাইলের এক্সটেনশন পরিবর্তন করলে, সেটি অন্য অ্যাপ্লিকেশনে খুলতে পারে এবং আপনার ডিভাইসে সমস্যার সৃষ্টি করতে পারে।</translation>
+<translation id="8541922081612557424">Brave সম্বন্ধে</translation>
+<translation id="5311273890481188673">কপিরাইট <ph name="YEAR"/> Brave Software LLC সব স্বত্ব সংরক্ষিত আছে।</translation>
+<translation id="1416550906796893042">অ্যাপ্লিকেশন ভার্সন</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (আপডেট করা হয়েছে <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">অপারেটিং সিস্টেম</translation>
+<translation id="3968054912784331254">Android-এর এই ভার্সনে Brave আপডেট করা আর সম্ভব নয়</translation>
+<translation id="7665369617277396874">অ্যাকাউন্ট যোগ করুন</translation>
+<translation id="649070405679044769">এই হিসাবে Brave Software এ প্রবেশ করেছেন</translation>
+<translation id="6234515504547364178">Brave থেকে সাইন-আউট করুন</translation>
+<translation id="5324858694974489420">অভিভাবকীয় সেটিংস</translation>
+<translation id="8920114477895755567">অভিভাবকের বিশদ বিবরণের জন্য অপেক্ষা করা হচ্ছে৷</translation>
+<translation id="5512137114520586844">এই অ্যাকাউন্টটি <ph name="PARENT_NAME"/>-এর দ্বারা পরিচালিত হয়৷</translation>
+<translation id="2956410042958133412">এই অ্যাকাউন্টটি <ph name="PARENT_NAME_1"/> এবং <ph name="PARENT_NAME_2"/> দ্বারা পরিচালিত হয়৷</translation>
+<translation id="8168435359814927499">কন্টেন্ট</translation>
+<translation id="5403644198645076998">শুধুমাত্র নির্দিষ্ট কিছু সাইটকে অনুমতি দিন</translation>
+<translation id="8641930654639604085">প্রাপ্তবয়স্কদের সাইটগুলি অবরুদ্ধ করার চেষ্টা করুন</translation>
+<translation id="5639724618331995626">সমস্ত সাইটকে অনুমতি দিন</translation>
+<translation id="796823723482603597">Brave দ্বারা চালিত</translation>
+<translation id="6324034347079777476">Android সিস্টেম সিঙ্ক অক্ষম করা হয়েছে</translation>
+<translation id="5127805178023152808">সিঙ্ক বন্ধ রয়েছে</translation>
+<translation id="7015203776128479407">সিঙ্কের প্রাথমিক সেট-আপ সম্পূর্ণ হয়নি। সিঙ্ক বন্ধ আছে।</translation>
+<translation id="2497852260688568942">আপনার প্রশাসকের দ্বারা সিঙ্ক অক্ষম করা হয়েছে</translation>
+<translation id="9100610230175265781">পাসফ্রেজের প্রয়োজন</translation>
+<translation id="6108923351542677676">সেটআপ চলছে...</translation>
+<translation id="4062305924942672200">আইনী তথ্য</translation>
+<translation id="4256782883801055595">ওপেন সোর্স লাইসেন্স</translation>
+<translation id="1138681184697033370">Brave পরিষেবার শর্তাবলি</translation>
+<translation id="7392539049993970338">Brave এর গোপনীয়তা বিজ্ঞপ্তি</translation>
+<translation id="2677748264148917807">ছেড়ে চলে যান</translation>
+<translation id="5556459405103347317">রিলোড করুন</translation>
+<translation id="1623104350909869708">এই পৃষ্ঠাটিকে অতিরিক্ত কথোপকথন তৈরি করা থেকে বাধা দিন</translation>
+<translation id="2968755619301702150">সার্টিফিকেট প্রদর্শনকারী</translation>
+<translation id="1360432990279830238">সাইন-আউট করে সিঙ্ক বন্ধ করবেন?</translation>
+<translation id="8581481290581777242">এই ডিভাইস থেকে Brave ডেটা সরিয়ে ফেলবেন?</translation>
+<translation id="1318865768845061710">আপনার বুকমার্ক, ইতিহাস, পাসওয়ার্ড ও অন্যান্য Brave ডেটা আর আপনার Brave Software অ্যাকাউন্টের সাথে সিঙ্ক করা হবে না</translation>
+<translation id="3325020657155065477">এছাড়া এই ডিভাইস থেকে Brave ডেটা সরিয়ে ফেলুন</translation>
+<translation id="6136448902816743006">যেহেতু আপনি <ph name="DOMAIN_NAME"/>-এর ম্যানেজ করা অ্যাকাউন্ট থেকে সাইন-আউট করছেন তাই এই ডিভাইস থেকে আপনার Brave ডেটা মুছে ফেলা হবে। এটি আপনার Brave Software অ্যাকাউন্টে থাকবে।</translation>
+<translation id="1853026300647876496">Brave Software এর সাথে যোগাযোগ করা হচ্ছে। এতে একটু সময় লাগবে…</translation>
+<translation id="2328985652426384049">সাইন ইন করতে পারছেন না</translation>
+<translation id="7723158744459952869">Brave Software সাড়া দিতে দেরী করছে</translation>
+<translation id="4572422548854449519">ম্যানেজ করা অ্যাকাউন্টে সাইন-ইন করুন</translation>
+<translation id="2689656545739939160">আপনি <ph name="MANAGED_DOMAIN"/> দ্বারা পরিচালিত একটি অ্যাকাউন্টের মাধ্যমে সাইন-ইন করছেন এবং এর অ্যাডমিনিস্ট্রেটরকে আপনার Brave ডেটা নিয়ন্ত্রণ করতে দিচ্ছেন৷ আপনার ডেটা এই অ্যাকাউন্টের সাথে স্থায়ীভাবে আবদ্ধ হবে৷ Brave থেকে সাইন-আউট করলে এই ডিভাইস থেকে আপনার ডেটা মুছে ফেলা হবে, কিন্তু এটা আপনার Brave Software অ্যাকাউন্টে সঞ্চিত থাকবে।</translation>
+<translation id="1749561566933687563">আপনার বুকমার্কগুলি সিঙ্ক করুন</translation>
+<translation id="4242533952199664413">সেটিংস খুলুন</translation>
+<translation id="1111673857033749125">আপনার অন্যান্য ডিভাইসে সেভ করা বুকমার্কগুলি এখানে দেখা যাবে।</translation>
+<translation id="8636825310635137004">আপনার অন্য ডিভাইসগুলি থেকে আপনার ট্যাবগুলি পেতে, সিঙ্ক চালু করুন।</translation>
+<translation id="3269956123044984603">আপনার অন্য ডিভাইসগুলি থেকে আপনার ট্যাবগুলি পেতে, Android অ্যাকাউন্ট সেটিংসে "ডেটা অটো-সিঙ্ক" চালু করুন।</translation>
+<translation id="5157964048453367290">আপনার অন্য ডিভাইসগুলিতে Brave এ আপনি যে ট্যাবগুলি খুলেছেন সেগুলি এখানে দেখা যাবে।</translation>
+<translation id="4684427112815847243">সবকিছু সিঙ্ক করুন</translation>
+<translation id="2709516037105925701">স্বয়ংপূরণ</translation>
+<translation id="8820817407110198400">বুকমার্কস</translation>
+<translation id="1644574205037202324">ইতিহাস</translation>
+<translation id="17513872634828108">খোলা ট্যাব</translation>
+<translation id="1320169905922104972">Brave Software Pay ব্যবহার করে ক্রেডিট কার্ড এবং ঠিকানা</translation>
+<translation id="6337234675334993532">এনক্রিপশন</translation>
+<translation id="6698801883190606802">সিঙ্ক হওয়া ডেটা পরিচালনা করুন</translation>
+<translation id="3598578758776312506">Brave Software সার্টিফিকেটসমূহের সাথে পাসওয়ার্ডগুলি এনক্রিপ্ট করুন</translation>
+<translation id="7810580217418711046">Brave Software পাসওয়ার্ড দিয়ে <ph name="TIME"/>-এ সিঙ্ক করা ডেটা এনক্রিপ্ট করুন</translation>
+<translation id="8461694314515752532">আপনার নিজস্ব সিঙ্ক পাসফ্রেজ দিয়ে সিঙ্ক করা ডেটা এনক্রিপ্ট করুন</translation>
+<translation id="2996291259634659425">পাসফ্রেজ তৈরি করুন</translation>
+<translation id="5713644099811900409">Brave Software অ্যাকাউন্ট</translation>
+<translation id="8997474919031554666">পাসফ্রেজ এনক্রিপশনে Brave Software Pay-এর পেমেন্ট পদ্ধতি ও ঠিকানা অন্তর্ভুক্ত থাকে না। 
+আপনার পাসফ্রেজ আছে এমন কেউই শুধু আপনার এনক্রিপ্ট করা ডেটা পড়তে পারবেন। 
+পাসফ্রেজ Brave Software-এ পাঠানো হয় না বা Brave Software তা সংরক্ষণ করে না। পাসফ্রেজ ভুলে গেলে বা এই সেটিং পরিবর্তন করতে চাইলে, আপনাকে সিঙ্ক রিসেট করতে হবে। <ph name="BEGIN_LINK"/>আরও জানুন<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">পাসফ্রেজ</translation>
+<translation id="7772032839648071052">পাসফ্রেজ নিশ্চিত করুন</translation>
+<translation id="5304593522240415983">এই ক্ষেত্রটি খালি রাখা যাবে না</translation>
+<translation id="321773570071367578">আপনি যদি আপনার পাসফ্রেজ ভুলে যান বা এই সেটিং পরিবর্তন করতে চান, তাহলে <ph name="BEGIN_LINK"/>সিঙ্ক পুনরায় সেট করুন<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">পাসফ্রেজসমূহ মেলে না</translation>
+<translation id="5149495116300586333">পাসফ্রেজ এনক্রিপশনে Brave Software Pay-এর পেমেন্ট পদ্ধতি ও ঠিকানা অন্তর্ভুক্ত থাকে না।
+
+<ph name="BEGIN_LINK"/>রিসেট সিঙ্ক<ph name="END_LINK"/> থেকে এই সেটিং পরিবর্তন করুন</translation>
+<translation id="7638584964844754484">ত্রুটিপূর্ণ পাসফ্রেজ</translation>
+<translation id="5414836363063783498">যাচাই করা হচ্ছে...</translation>
+<translation id="6846298663435243399">লোড হচ্ছে...</translation>
+<translation id="5517095782334947753">আপনার জন্য <ph name="FROM_ACCOUNT"/> থেকে বুকমার্কস, ইতিহাস, পাসওয়ার্ড এবং অন্যান্য সেটিংস আছে।</translation>
+<translation id="3928666092801078803">আমার ডেটা একত্রিত করুন</translation>
+<translation id="688738109438487280">বিদ্যমান ডেটা <ph name="TO_ACCOUNT"/> এ যোগ করুন।</translation>
+<translation id="806745655614357130">আমার ডেটা আলাদা রাখুন</translation>
+<translation id="1145536944570833626">বিদ্যমান ডেটা মুছুন।</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> এদের সঙ্গে যুক্ত হতে চাচ্ছে</translation>
+<translation id="4915549754973153784">ডিভাইসের জন্য স্ক্যান করার সময় <ph name="BEGIN_LINK"/>সহায়তা পান<ph name="END_LINK"/>...</translation>
+<translation id="5817918615728894473">যুক্ত করুন</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>সহায়তা পান<ph name="END_LINK1"/> বা <ph name="BEGIN_LINK2"/>আবার স্ক্যান করুন<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">উপযুক্ত ডিভাইস খুঁজে পাওয়া যায়নি</translation>
+<translation id="3773755127849930740">যুক্ত করার মঞ্জুরি দিতে <ph name="BEGIN_LINK"/>ব্লুটুথ চালু করুন<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave ব্লুটুথ অ্যাডাপ্টার চালু করতে পারছে না</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>সহায়তা পান<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">ডিভাইস স্ক্যান করার জন্য Brave এর স্থান এক্সেস প্রয়োজন। <ph name="BEGIN_LINK"/>অনুমতি আপডেট করুন<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">ডিভাইস স্ক্যান করার জন্য Brave এর অবস্থানের অ্যাক্সেস প্রয়োজন। অবস্থানের অ্যাক্সেস <ph name="BEGIN_LINK"/>এই ডিভাইসের জন্য বন্ধ করা হয়েছে<ph name="END_LINK"/>।</translation>
+<translation id="2367014990350929709">ডিভাইস স্ক্যান করার জন্য Brave এর অবস্থানের অ্যাক্সেস প্রয়োজন।  <ph name="BEGIN_LINK1"/>অনুমতিগুলির আপডেট করুন<ph name="END_LINK1"/>। অবস্থানের অ্যাক্সেস <ph name="BEGIN_LINK2"/>এই ডিভাইসের জন্যও বন্ধ করা হয়েছে<ph name="END_LINK2"/>।</translation>
+<translation id="1569387923882100876">সংযুক্ত ডিভাইস</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{সিগনালের স্তর: #টি দণ্ড}one{সিগনালের স্তর: #টি দণ্ড}other{সিগনালের স্তর: #টি দণ্ড}}</translation>
+<translation id="5230560987958996918">কাছাকাছি থাকা ব্লুটুথ ডিভাইসগুলিকে <ph name="SITE"/> স্ক্যান করতে চায়, এই ডিভাইসগুলি পাওয়া গেছে:</translation>
+<translation id="8368027906805972958">অপরিচিত বা কাজ করে না এমন ডিভাইস (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">সিঙ্ক কাজ করছে না</translation>
+<translation id="1810845389119482123">প্রারম্ভিক সিঙ্ক সেট-আপ করা সম্পূর্ণ হয়নি</translation>
+<translation id="3235722914093408050">Android সেটিংস খুলে Brave সিঙ্ক শুরু করতে Android সিস্টেমকে পুনরায় সক্ষম করুন</translation>
+<translation id="3367813778245106622">সিঙ্ক করা শুরু করতে আবার সাইন-ইন করুন</translation>
+<translation id="974555521953189084">সিঙ্ক শুরু করার জন্য আপনার পাসফ্রেজ লিখুন</translation>
+<translation id="2997266899014181325">সিঙ্ক চালু করতে "আপনার Brave ডেটা সিঙ্ক করুন" বিকল্পটি চালু করুন।</translation>
+<translation id="8260126382462817229">আবার সাইন ইন করার চেষ্টা করুন</translation>
+<translation id="5919204609460789179">সিঙ্ক শুরু করতে <ph name="PRODUCT_NAME"/> আপডেট করুন</translation>
+<translation id="397583555483684758">সিঙ্ক কাজ করা বন্ধ করে দিয়েছে</translation>
+<translation id="1966710179511230534">অনুগ্রহ করে আমার সাইন-ইন বিবরণ আপডেট করুন।</translation>
+<translation id="7063006564040364415">সিঙ্ক সার্ভারে সংযোগ করতে পারেনি৷</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> পুরনো হয়ে গেছে।</translation>
+<translation id="4170011742729630528">পরিষেবাটি উপলব্ধ নেই, পরে আবার চেষ্টা করুন৷</translation>
+<translation id="7947953824732555851">সম্মত হয়ে সাইন-ইন করুন</translation>
+<translation id="8583805026567836021">অ্যাকাউন্টের ডেটা সাফ করা হচ্ছে</translation>
+<translation id="8310344678080805313">স্ট্যান্ডার্ড ট্যাব</translation>
+<translation id="5748802427693696783">স্ট্যান্ডার্ড ট্যাবে পাল্টানো হয়েছে</translation>
+<translation id="7998918019931843664">বন্ধ হওয়া ট্যাব আবার খুলুন</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, ট্যাব</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> ট্যাবটি বন্ধ করুন</translation>
+<translation id="7243308994586599757">স্ক্রীনের প্রায় নীচের দিকে বিকল্পগুলি উপলব্ধ</translation>
+<translation id="4060598801229743805">স্ক্রীনের প্রায় উপরের দিকে বিকল্পগুলি উপলব্ধ</translation>
+<translation id="2810645512293415242">পৃষ্ঠায় সহজে ডেটা সংরক্ষণ করে এবং দ্রুত লোড করুন।</translation>
+<translation id="3985215325736559418">আপনি কি আবার <ph name="FILE_NAME"/> ডাউনলোড করতে চান?</translation>
+<translation id="2450083983707403292">আপনি কি আবার <ph name="FILE_NAME"/> ডাউনলোড করা শুরু করতে চান?</translation>
+<translation id="7514365320538308">ডাউনলোড করুন</translation>
+<translation id="545042621069398927">আপনার ডাউনলোডের স্পিড বাড়ানো হচ্ছে।</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ফাইলটি ডাউনলোড হচ্ছে।}one{#টি ফাইল ডাউনলোড হচ্ছে।}other{#টি ফাইল ডাউনলোড হচ্ছে।}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/>টি ফাইল ডাউনলোড হচ্ছে (<ph name="MEGABYTES"/>)।</translation>
+<translation id="4988210275050210843">ফাইল ডাউনলোড হচ্ছে (<ph name="MEGABYTES"/>)।</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{১টি ডাউনলোড হয়ে গেছে।}one{#টি ডাউনলোড হয়ে গেছে।}other{#টি ডাউনলোড হয়ে গেছে।}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{১টি ডাউনলোড করা যায়নি।}one{#টি ডাউনলোড করা যায়নি।}other{#টি ডাউনলোড করা যায়নি।}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{১টি ডাউনলোড বাকি আছে।}one{#টি ডাউনলোড বাকি আছে।}other{#টি ডাউনলোড বাকি আছে।}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>।</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> বোতাম</translation>
+<translation id="3205824638308738187">প্রায় শেষ হয়ে গেছে!</translation>
+<translation id="3960299545138990065">Brave পুনরায় চালু করুন</translation>
+<translation id="3771001275138982843">আপডেট ডাউনলোড করা যায়নি</translation>
+<translation id="3888648114124182147">Brave-এর আপডেট ডাউনলোড করা হচ্ছে…</translation>
+<translation id="1705567146636171298">Brave আপডেট করুন</translation>
+<translation id="6195417478702700398">সবচেয়ে ভাল ব্রাউজিং অভিজ্ঞতা পেতে, Brave আপডেট করুন</translation>
+<translation id="3512968675351418494">ওয়েবের কন্টেন্ট নিজের ভাষায় পড়তে, Brave-এর লেটেস্ট ভার্সন ইনস্টল করুন</translation>
+<translation id="6427112570124116297">ওয়েবের কন্টেন্ট অনুবাদ করুন</translation>
+<translation id="1379423114029199501">নিজের ভাষায় ব্রাউজ করতে, Brave-কে লেটেস্ট ভার্সনে আপডেট করুন</translation>
+<translation id="5684874026226664614">ওহো৷ এই পৃষ্ঠাটির অনুবাদ করা যাবে না৷</translation>
+<translation id="6831043979455480757">অনুবাদ</translation>
+<translation id="1285320974508926690">কখনই এই সাইটটিকে অনুবাদ করবেন না</translation>
+<translation id="773466115871691567">সব সময় <ph name="SOURCE_LANGUAGE"/> ভাষার পৃষ্ঠার অনুবাদ দেখতে চাই</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/> ভাষার পৃষ্ঠার অনুবাদ কখনও দেখতে চাই না</translation>
+<translation id="124116460088058876">আরও ভাষা</translation>
+<translation id="290376772003165898">পৃষ্ঠাটি <ph name="LANGUAGE"/> ভাষায় নয়?</translation>
+<translation id="4432792777822557199">এখন থেকে <ph name="SOURCE_LANGUAGE"/> ভাষার পৃষ্ঠাগুলিকে <ph name="TARGET_LANGUAGE"/> ভাষায় অনুবাদ করা হবে</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/> ভাষার পৃষ্ঠার অনুবাদ করা হবে না</translation>
+<translation id="5447765697759493033">এই সাইটটি অনুবাদ করা হবে না</translation>
+<translation id="4880127995492972015">অনুবাদ করুন…</translation>
+<translation id="641643625718530986">প্রিন্ট...</translation>
+<translation id="8909135823018751308">শেয়ার করুন...</translation>
+<translation id="4996978546172906250">এর মাধ্যমে শেয়ার করুন</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> এর মাধ্যমে শেয়ার করুন</translation>
+<translation id="6277522088822131679">পৃষ্ঠাটি প্রিন্ট করার সময় একটি সমস্যা হয়েছিল৷ দয়া করে আবার চেষ্টা করুন৷</translation>
+<translation id="3254409185687681395">এই পৃষ্ঠাটি বুকমার্ক করুন</translation>
+<translation id="497421865427891073">অগ্রবর্তী করুন</translation>
+<translation id="813082847718468539">সাইটের তথ্য দর্শন করুন</translation>
+<translation id="2532336938189706096">ওয়েব দর্শন</translation>
+<translation id="6005538289190791541">প্রস্তাবিত পাসওয়ার্ড</translation>
+<translation id="4634124774493850572">পাসওয়ার্ড ব্যবহার করুন</translation>
+<translation id="8285489906452138776">এই সাইটটির জন্য Brave কে আপনার ক্যামেরায় অ্যাক্সেস দিতে হবে।</translation>
+<translation id="320189792589364011">এই সাইটটির জন্য Brave কে আপনার মাইক্রোফোনে অ্যাক্সেস দিতে হবে।</translation>
+<translation id="7988136689212463100">এই সাইটটির জন্য Brave কে আপনার ক্যামেরা এবং মাইক্রোফোনে অ্যাক্সেস দিতে হবে।</translation>
+<translation id="4931190655840828017">এই সাইটটির সাথে আপনার লোকেশন শেয়ার করার জন্য Brave কে আপনার লোকেশনের তথ্যে অ্যাক্সেস দিতে হবে।</translation>
+<translation id="3088191967551450609">ফাইল ডাউনলোড করতে Brave-এর জন্য স্টোরেজ অ্যাক্সেস প্রয়োজন।</translation>
+<translation id="8942627711005830162">অন্য উইন্ডোতে খুলুন</translation>
+<translation id="4195643157523330669">নতুন ট্যাবে খুলুন</translation>
+<translation id="1100066534610197918">গ্রুপে একটি নতুন ট্যাব খুলুন</translation>
+<translation id="4860895144060829044">কল করুন</translation>
+<translation id="6896758677409633944">কপি</translation>
+<translation id="8393700583063109961">বার্তা পাঠান</translation>
+<translation id="3557336313807607643">পরিচিতিতে যোগ করুন</translation>
+<translation id="4269820728363426813">লিঙ্ক অ্যাড্রেস কপি করুন</translation>
+<translation id="1206892813135768548">লিঙ্ক টেক্সট কপি করুন</translation>
+<translation id="1204037785786432551">লিঙ্ক ডাউনলোড করুন</translation>
+<translation id="6864459304226931083">ইমেজ ডাউনলোড করুন</translation>
+<translation id="8209050860603202033">ইমেজ খুলুন</translation>
+<translation id="8073388330009372546">নতুন ট্যাবে ইমেজ খুলুন</translation>
+<translation id="6649642165559792194"><ph name="BEGIN_NEW"/>নতুন<ph name="END_NEW"/> ছবির প্রিভিউ দেখুন</translation>
+<translation id="3269093882174072735">ইমেজ লোড করুন</translation>
+<translation id="3845332215609790146">Brave Software Lens-এর <ph name="BEGIN_NEW"/>নতুন<ph name="END_NEW"/> ভার্সন দিয়ে খুুঁজুন</translation>
+<translation id="5578795271662203820">এই ইমেজটির জন্য <ph name="SEARCH_ENGINE"/> খুঁজুন</translation>
+<translation id="3384347053049321195">ইমেজ শেয়ার করুন</translation>
+<translation id="5833984609253377421">লিঙ্ক শেয়ার করুন</translation>
+<translation id="6475951671322991020">ভিডিও ডাউনলোড করুন</translation>
+<translation id="2317945146070194624">নতুন Brave ট্যাবে খুলুন</translation>
+<translation id="7975379999046275268"><ph name="BEGIN_NEW"/>নতুন<ph name="END_NEW"/> পৃষ্ঠার প্রিভিউ দেখুন</translation>
+<translation id="6112702117600201073">রিফ্রেশ পৃষ্ঠা</translation>
+<translation id="36525718899759834">Brave Software Play Store-এর থেকে অ্যাপ্লিকেশানটি পান: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">অন্ধকার</translation>
+<translation id="1807246157184219062">আলো</translation>
+<translation id="4056223980640387499">সেপিয়া</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">মোনোস্পেস</translation>
+<translation id="9206873250291191720">আ</translation>
+<translation id="654446541061731451">বিম করার জন্য একটি ট্যাব বেছে নিন</translation>
+<translation id="8719023831149562936">বর্তমান ট্যাবকে বীম করা যাবে না</translation>
+<translation id="2139186145475833000">হোম স্ক্রীনে যোগ করুন</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> খুলুন</translation>
+<translation id="2122601567107267586">অ্যাপটি খোলা যায়নি</translation>
+<translation id="5129038482087801250">ওয়েব অ্যাপ ইনস্টল করুন</translation>
+<translation id="3789841737615482174">ইনস্টল করুন</translation>
+<translation id="4665282149850138822">আপনার হোম স্ক্রীনে <ph name="NAME"/> কে যোগ করা হয়েছে</translation>
+<translation id="7333031090786104871">এখনও পূর্বের সাইট যোগ করছে</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> যোগ করা হচ্ছে...</translation>
+<translation id="3778956594442850293">হোম স্ক্রিনে যোগ করা হয়েছে</translation>
+<translation id="2146738493024040262">ইনস্ট্যান্ট অ্যাপ খুলুন</translation>
+<translation id="7016516562562142042">বর্তমান সার্চ ইঞ্জিনের জন্য অনুমোদন দেওয়া হয়েছে</translation>
+<translation id="6177111841848151710">বর্তমান সার্চ ইঞ্জিনের জন্য অবরুদ্ধ করা হয়েছে</translation>
+<translation id="145097072038377568">Android সেটিংসে বন্ধ করা অাছে</translation>
+<translation id="8007176423574883786">এই ডিভাইসের জন্য বন্ধ করা আছে</translation>
+<translation id="164269334534774161">আপনি <ph name="CREATION_TIME"/> তারিখের এই পৃষ্ঠার একটি অফলাইন কপি দেখছেন</translation>
+<translation id="4594952190837476234">এই অফলাইন পৃষ্ঠাটি <ph name="CREATION_TIME"/>-এ তৈরি করা হয়েছিল এবং এটি অনলাইন ভার্সনের থেকে আলাদা হতে পারে।</translation>
+<translation id="8840953339110955557">এই পৃষ্ঠাটি হয়ত অনলাইন ভার্সনের থেকে আলাদা হতে পারে।</translation>
+<translation id="6405300764336705484">এই কন্টেন্ট Brave Software দ্বারা বিতরণ করা <ph name="DOMAIN_NAME"/> থেকে এসেছে।</translation>
+<translation id="1006017844123154345">অনলাইনে খুলুন</translation>
+<translation id="3326636747541519688">Brave Software লাইট পৃষ্ঠা পাঠিয়েছে</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> থেকে <ph name="BEGIN_LINK"/>মূল পৃষ্ঠাটি লোড করুন<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">আপনি যদি এটি প্রায়ই দেখতে পান, তাহলে <ph name="BEGIN_LINK"/>প্রস্তাবনাগুলি<ph name="END_LINK"/> চেষ্টা করে দেখুন৷</translation>
+<translation id="8748850008226585750">সামগ্রী লুকানো আছে</translation>
+<translation id="3810973564298564668">পরিচালনা</translation>
+<translation id="5199929503336119739">কর্মস্থলের প্রোফাইল</translation>
+<translation id="528192093759286357">উপর থেকে টেনে আনুন এবং পূর্ণ স্ক্রিন থেকে বেরিয়ে যেতে পিছনে ফেরার বোতাম স্পর্শ করুন।</translation>
+<translation id="2836148919159985482">পূর্ণ স্ক্রিন থেকে বেরিয়ে যেতে পিছনে ফেরার বোতাম স্পর্শ করুন।</translation>
+<translation id="3967822245660637423">ডাউনলোড সম্পূর্ণ</translation>
+<translation id="2434158240863470628"><ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/> ডাউনলোড সম্পূর্ণ হয়েছে</translation>
+<translation id="802154636333426148">ডাউনলোড করা যায়নি</translation>
+<translation id="1384959399684842514">ডাউনলোড পজ করা আছে</translation>
+<translation id="1671236975893690980">ডাউনলোড মুলতবি হয়ে আছে...</translation>
+<translation id="5561549206367097665">নেটওয়ার্কের জন্য অপেক্ষা করা হচ্ছে...</translation>
+<translation id="5864419784173784555">অন্য ডাউনলোডের জন্য অপেক্ষা করা হচ্ছে…</translation>
+<translation id="6461962085415701688">ফাইল খোলা যাচ্ছে না</translation>
+<translation id="1178581264944972037">বিরতি</translation>
+<translation id="8200772114523450471">আবার চালু করা</translation>
+<translation id="1409879593029778104">ফাইল ইতিমধ্যেই থাকায় <ph name="FILE_NAME"/> ডাউনলোড আটকানো হয়েছে।</translation>
+<translation id="3387650086002190359">ফাইল সিস্টেম ত্রুটির কারণে <ph name="FILE_NAME"/> ডাউনলোড করা যায়নি।</translation>
+<translation id="6482749332252372425">স্টোরেজে জায়গার ঘাটতির কারণে <ph name="FILE_NAME"/> ডাউনলোড করা যায়নি।</translation>
+<translation id="7619072057915878432">নেটওয়ার্ক কানেক্ট হয়নি বলে <ph name="FILE_NAME"/> ডাউনলোড করা যায়নি।</translation>
+<translation id="1477626028522505441">সার্ভার সমস্যার কারণে <ph name="FILE_NAME"/> ডাউনলোড করা যায়নি।</translation>
+<translation id="3692944402865947621">স্টোর করার জায়গা খুঁজে না পাওয়ায় <ph name="FILE_NAME"/> ডাউনলোড করা যায়নি।</translation>
+<translation id="604996488070107836">একটি অজানা ত্রুটির কারনে <ph name="FILE_NAME"/> ডাউনলোড করা যায়নি।</translation>
+<translation id="6738867403308150051">ডাউনলোড হচ্ছে...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> কেবি</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> এমবি</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> জিবি</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB ডাউনলোড হয়েছে</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB ডাউনলোড হয়েছে</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB ডাউনলোড হয়েছে</translation>
+<translation id="9204836675896933765">১টি ফাইল বাকি</translation>
+<translation id="8186512483418048923"><ph name="FILES"/>টি ফাইল বাকি</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/>টি ফাইল ডাউনলোড হয়েছে}one{<ph name="FILES_DOWNLOADED_MANY"/>টি ফাইল ডাউনলোড হয়েছে}other{<ph name="FILES_DOWNLOADED_MANY"/>টি ফাইল ডাউনলোড হয়েছে}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> দিন বাকি আছে</translation>
+<translation id="8190358571722158785">১ দিন বাকি আছে</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> ঘণ্টা বাকি আছে</translation>
+<translation id="510275257476243843">১ ঘণ্টা বাকি আছে</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> মিনিট বাকি আছে</translation>
+<translation id="3236059992281584593">১ মিনিট বাকি আছে</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> সেকেন্ড বাকি আছে</translation>
+<translation id="2781151931089541271">১ সেকেন্ড বাকি আছে</translation>
+<translation id="3303414029551471755">কন্টেন্ট ডাউনলোড করার জন্য এগোতে চান?</translation>
+<translation id="8617240290563765734">ডাউনলোড হওয়া কন্টেন্টতে নির্দিষ্ট করা প্রস্তাবিত URLটি খুলবেন?</translation>
+<translation id="1373696734384179344">নির্বাচিত কন্টেন্ট ডাউনলোড করার জন্য যথেষ্ট মেমরি নেই৷</translation>
+<translation id="5271967389191913893">ডাউনলোড করা কন্টেন্ট ডিভাইস খুলতে পারবে না৷</translation>
+<translation id="883806473910249246">কন্টেন্ট ডাউনলোড করার সময় একটি ত্রুটি ঘটেছে৷</translation>
+<translation id="5626134646977739690">নাম:</translation>
+<translation id="7963646190083259054">বিক্রেতা:</translation>
+<translation id="3414952576877147120">মাপ:</translation>
+<translation id="7375125077091615385">প্রকার:</translation>
+<translation id="5765780083710877561">বর্ণনা:</translation>
+<translation id="4881695831933465202">খুলুন</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> কেবি available</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> এমবি উপলভ্য</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> জিবি উপলব্ধ</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/> এর <ph name="SPACE_USED"/> ব্যবহার করা হচ্ছে</translation>
+<translation id="3587482841069643663">সকল</translation>
+<translation id="4988526792673242964">পৃষ্ঠাসমূহ</translation>
+<translation id="3810838688059735925">ভিডিও</translation>
+<translation id="3616113530831147358">অডিও</translation>
+<translation id="9219103736887031265">ছবিগুলি</translation>
+<translation id="8250920743982581267">দস্তাবেজগুলি</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{#টি ফাইল}one{#টি ফাইল}other{#টি ফাইল}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{#টি ছবি}one{#টি ছবি}other{#টি ছবি}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{#টি ভিডিও}one{#টি ভিডিও}other{#টি ভিডিও}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{#টি অডিও ফাইল}one{#টি অডিও ফাইল}other{#টি অডিও ফাইল}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{#টি পৃষ্ঠা}one{#টি পৃষ্ঠা}other{#টি পৃষ্ঠা}}</translation>
+<translation id="5456381639095306749">পৃষ্ঠা ডাউনলোড করুন</translation>
+<translation id="2394602618534698961">আপনার ডাউনলোড করা ফাইল এখানে দেখানো হয়</translation>
+<translation id="7810647596859435254">এর মাধ্যমে খুলুন...</translation>
+<translation id="5655963694829536461">আপনার ডাউনলোডগুলি খুঁজুন</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">আমার ফাইল</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">নিবন্ধগুলি এখানে দেখানো হয় এবং আপনি সেগুলি অফলাইনেও পড়তে পারেন</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ঘণ্টা}one{# ঘণ্টা}other{# ঘণ্টা}}</translation>
+<translation id="5853623416121554550">পজ করা হয়েছে</translation>
+<translation id="8965591936373831584">বাকি আছে</translation>
+<translation id="2779651927720337254">করা যায়নি</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">এইমাত্র</translation>
+<translation id="4000212216660919741">অফলাইন হোম</translation>
+<translation id="9133397713400217035">অফলাইন কন্টেন্ট দেখুন</translation>
+<translation id="968900484120156207">আপনি যে পৃষ্ঠাগুলিতে যান সেগুলি এখানে দেখানো হয়</translation>
+<translation id="7882131421121961860">কোনো ইতিহাস পাওয়া যায়নি</translation>
+<translation id="3549657413697417275">আপনার ইতিহাস খুঁজুন</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">মিমি</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave প্রথম চালানোর অভিজ্ঞতা</translation>
+<translation id="2700285883409956633">এই অ্যাপ্লিকেশানটি ব্যবহার করার মাধ্যমে আপনি Brave এর <ph name="BEGIN_LINK1"/>পরিষেবার শর্তাবলি<ph name="END_LINK1"/> এবং <ph name="BEGIN_LINK2"/>গোপনীয়তা বিজ্ঞপ্তিতে<ph name="END_LINK2"/> সম্মত হচ্ছেন৷</translation>
+<translation id="1640714894372474981">এই অ্য়াপটি ব্যবহার করার মাধ্যমে আপনি Brave-এর <ph name="BEGIN_LINK1"/>পরিষেবার শর্তাবলি<ph name="END_LINK1"/> এবং <ph name="BEGIN_LINK2"/>গোপনীয়তা নীতি<ph name="END_LINK2"/> এবং <ph name="BEGIN_LINK3"/>Family Link-এ তৈরি করা Brave Software অ্যাকাউন্টগুলির জন্য গোপনীয়তার বিজ্ঞপ্তি<ph name="END_LINK3"/>-এর সাথে সম্মত হন।</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/>Brave এ খুলবে। চালিয়ে যাওয়ার অর্থ আপনি Brave এর <ph name="BEGIN_LINK1"/>পরিষেবার শর্তাবলী<ph name="END_LINK1"/>  এবং <ph name="BEGIN_LINK2"/>গোপনীয়তা বিজ্ঞপ্তি<ph name="END_LINK2"/>র সাথে সম্মত হচ্ছেন।</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Brave-এ খুলবে। চালিয়ে যাওয়ার মাধ্যমে আপনি Brave-এর <ph name="BEGIN_LINK1"/>পরিষেবার শর্তাবলী<ph name="END_LINK1"/> ও <ph name="BEGIN_LINK2"/>গোপনীয়তা বিজ্ঞপ্তি<ph name="END_LINK2"/> এবং <ph name="BEGIN_LINK3"/>Family Link-এর মাধ্যমে পরিচালিত Brave Software অ্যাকাউন্টের গোপনীয়তা বিজ্ঞপ্তি<ph name="END_LINK3"/>র সাথে সম্মত হচ্ছেন।</translation>
+<translation id="673197144963363525">Brave Software-এ ব্যবহারের পরিসংখ্যান এবং ক্র্যাশ রিপোর্টগুলি পাঠিয়ে Brave-কে আরও ভাল করে তুলতে সহায়তা করুন৷</translation>
+<translation id="3518985090088779359">স্বীকার করুন ও অবিরত রাখুন</translation>
+<translation id="7207456302801184289">Brave এ স্বাগতম</translation>
+<translation id="704822250101715322">Brave Software Play পরিষেবাগুলির আপডেট শেষ হওয়ার জন্য অপেক্ষা করছে</translation>
+<translation id="1231733316453485619">সিঙ্ক চালু করবেন?</translation>
+<translation id="5132942445612118989">সমস্ত ডিভাইসে আপনার পাসওয়ার্ড, ইতিহাস ও আরও অনেক কিছু সিঙ্ক করুন</translation>
+<translation id="5736731321935944068">সার্চ, বিজ্ঞাপন এবং অন্যান্য Brave Software পরিষেবাকে আপনার মতো করে সাজিয়ে নিতে Brave Software আপনার ইতিহাস ব্যবহার করতে পারে</translation>
+<translation id="4013614219085422040">সার্চ এবং অন্যান্য Brave Software পরিষেবাকে আপনার মতো করে সাজিয়ে নিতে Brave Software আপনার ইতিহাস ব্যবহার করতে পারে</translation>
+<translation id="5581519193887989363"><ph name="BEGIN_LINK1"/>সেটিংসে<ph name="END_LINK1"/> কী সিঙ্ক করা হবে তা আপনি সবসময় বেছে নিতে পারেন।</translation>
+<translation id="741204030948306876">হ্যাঁ, আমি রাজি</translation>
+<translation id="2410754283952462441">একটি অ্যাকাউন্ট বেছে নিন</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> হিসেবে চালিয়ে যান</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> না?</translation>
+<translation id="8109613176066109935">আপনার সমস্ত ডিভাইসে বুকমার্কগুলি পেতে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="2818669890320396765">আপনার সমস্ত ডিভাইসে বুকমার্কগুলি পেতে সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="6003646045106347985">Brave Software-এর প্রস্তাবিত ব্যক্তিগতকৃত কন্টেন্ট পেতে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="8494430740943879273">Brave Software-এর প্রস্তাবিত ব্যক্তিগতকৃত কন্টেন্ট পাওয়ার জন্য সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="5862731021271217234">আপনার অন্যান্য ডিভাইস থেকে ট্যাবগুলি পেতে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="3568688522516854065">আপনার অন্যান্য ডিভাইস থেকে ট্যাবগুলি পেতে সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="1208340532756947324">সমগ্র ডিভাইস জুড়ে সিঙ্ক এবং ব্যক্তিগতকৃত করতে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="4472118726404937099">ডিভাইস জুড়ে সিঙ্ক এবং ব্যক্তিগতকৃত করতে সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
+<translation id="2426805022920575512">অন্য একটি অ্যাকাউন্ট বেছে নিন</translation>
+<translation id="6790428901817661496">চালু করুন</translation>
+<translation id="1272079795634619415">বন্ধ</translation>
+<translation id="2874939134665556319">পূর্ববর্তী ট্র্যাক</translation>
+<translation id="4046123991198612571">পরবর্তী ট্র্যাক</translation>
+<translation id="3859306556332390985">সামনে এগোন</translation>
+<translation id="8441146129660941386">পেছনে যান</translation>
+<translation id="6706288973712894588">আপনি এখন অফলাইন আছেন।\n<ph name="BEGIN_LINK"/>আপনার অফলাইন ফিড ঘুরে দেখুন।<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">সাম্প্রতিক ট্যাবগুলি</translation>
+<translation id="8497726226069778601">এখানে... দেখার মতো এখনো কিছু নেই</translation>
+<translation id="5423934151118863508">আপনার সর্বাধিক দেখা পৃষ্ঠাগুলি এখানে দেখা যাবে</translation>
+<translation id="6127379762771434464">আইটেম সরানো হয়েছে</translation>
+<translation id="4605958867780575332">আইটেম সরানো হয়েছে: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software ডুডল: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">অন্যান্য ডিভাইস</translation>
+<translation id="4738836084190194332">সর্বশেষ সিঙ্ক হয়েছে: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# মিনিট আগে}one{# মিনিট আগে}other{# মিনিট আগে}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# ঘণ্টা আগে}one{# ঘণ্টা আগে}other{# ঘণ্টা আগে}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# দিন আগে}one{# দিন আগে}other{# দিন আগে}}</translation>
+<translation id="2762000892062317888">এখনই</translation>
+<translation id="1407135791313364759">সব খুলুন</translation>
+<translation id="1209206284964581585">এখনকার মতো লুকান</translation>
+<translation id="129553762522093515">সম্প্রতি বন্ধ হয়েছে</translation>
+<translation id="8413126021676339697">সম্পূর্ণ ইতিহাস দেখান</translation>
+<translation id="7876243839304621966">সকল সরান</translation>
+<translation id="8487700953926739672">অফলাইনে উপলব্ধ</translation>
+<translation id="5224771365102442243">ভিডিও এর সাথে</translation>
+<translation id="3493531032208478708">প্রস্তাবিত কন্টেন্ট সম্পর্কে <ph name="BEGIN_LINK"/>আরও জানুন<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">প্রস্তাবনা পাওয়া যাচ্ছে না</translation>
+<translation id="5013696553129441713">নতুন কোনও প্রস্তাবনা নেই</translation>
+<translation id="1736419249208073774">ঘুরে দেখুন</translation>
+<translation id="7444811645081526538">আরও বিভাগ</translation>
+<translation id="6709133671862442373">সংবাদ</translation>
+<translation id="1264974993859112054">খেলাধূলা</translation>
+<translation id="9139318394846604261">কেনাকাটা</translation>
+<translation id="3912508018559818924">ওয়েব থেকে সেরা ফলাফল লোড করা হচ্ছে…</translation>
+<translation id="526421993248218238">পৃষ্ঠাটি লোড করা যাচ্ছে না</translation>
+<translation id="614940544461990577">এটি করে দেখুন:</translation>
+<translation id="3288003805934695103">পৃষ্ঠাটি আবার লোড করে দেখুন</translation>
+<translation id="2353636109065292463">আপনার ইন্টারনেট কানেকশন ঠিক আছে কিনা সেটি দেখা হচ্ছে</translation>
+<translation id="2858138569776157458">সেরা সাইট</translation>
+<translation id="8364299278605033898">জনপ্রিয় ওয়েবসাইট দেখুন</translation>
+<translation id="1171770572613082465">"সেরা সাইট" বোতামে ট্যাপ করে জনপ্রিয় ওয়েবসাইটগুলি দেখুন</translation>
+<translation id="5233638681132016545">নতুন ট্যাব</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/> থেকে – <ph name="BEGIN_DEEMPHASIZED"/>Brave Software এর মাধ্যমে ডেলিভারি দেওয়া হয়েছে<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">নতুন ভার্সন উপলভ্য</translation>
+<translation id="4058091506841967397">Brave আপডেট হচ্ছে না</translation>
+<translation id="6316139424528454185">এই Android ভার্সন সমর্থিত নয়</translation>
+<translation id="6989267951144302301">ডাউনলোড করা যায়নি</translation>
+<translation id="624789221780392884">আপডেট প্রস্তুত</translation>
+<translation id="1549000191223877751">অন্য উইন্ডোতে সরান</translation>
+<translation id="7481312909269577407">ফরওয়ার্ড</translation>
+<translation id="4084682180776658562">বুকমার্ক</translation>
+<translation id="6437478888915024427">পৃষ্ঠার তথ্য</translation>
+<translation id="7180611975245234373">রিফ্রেশ করুন</translation>
+<translation id="4913169188695071480">রিফ্রেশ করা বন্ধ করুন</translation>
+<translation id="1829244130665387512">পৃষ্ঠাতে খুঁজুন</translation>
+<translation id="6593061639179217415">ডেস্কটপ সাইট</translation>
+<translation id="9063523880881406963">ডেস্কটপ সাইটের অনুরোধ বন্ধ করুন</translation>
+<translation id="2038563949887743358">ডেস্কটপ সাইটের অনুরোধ চালু করুন</translation>
+<translation id="2433507940547922241">উপস্থিতি</translation>
+<translation id="983192555821071799">সমস্ত ট্যাবগুলি বন্ধ করুন</translation>
+<translation id="1310482092992808703">ট্যাবগুলি গ্রুপ করুন</translation>
+<translation id="7725024127233776428">আপনার বুকমার্ক করা পৃষ্ঠা এখানে দেখানো হয়</translation>
+<translation id="4404568932422911380">কোনও বুকমার্ক নেই</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/>টি বুকমার্ক}one{<ph name="BOOKMARKS_COUNT_MANY"/>টি বুকমার্ক}other{<ph name="BOOKMARKS_COUNT_MANY"/>টি বুকমার্ক}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> এ বুকমার্ক করা হয়েছে</translation>
+<translation id="3207960819495026254">বুকমার্ক করা হয়েছে</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> এ বুকমার্ক করা হয়েছে</translation>
+<translation id="8063895661287329888">বুকমার্ক যোগ করতে ব্যর্থ হয়েছে।</translation>
+<translation id="2842985007712546952">অভিভাবক ফোল্ডার</translation>
+<translation id="9065203028668620118">সম্পাদনা</translation>
+<translation id="4405224443901389797">এই ফোল্ডারে সরান…</translation>
+<translation id="5170568018924773124">ফোল্ডারে দেখান</translation>
+<translation id="8035133914807600019">নতুন ফোল্ডার...</translation>
+<translation id="4532845899244822526">ফোল্ডার বেছে নিন</translation>
+<translation id="6627583120233659107">ফোল্ডার সম্পাদনা করুন</translation>
+<translation id="1197267115302279827">বুকমার্কগুলি সরান</translation>
+<translation id="6963766334940102469">বুকমার্কগুলি মুছুন</translation>
+<translation id="4351244548802238354">ডায়ালগ বন্ধ করুন</translation>
+<translation id="451872707440238414">আপনার বুকমার্কস খুঁজুন</translation>
+<translation id="8901170036886848654">কোনো বুকমার্ক পাওয়া যায়নি</translation>
+<translation id="6404511346730675251">বুকমার্ক সম্পাদনা করুন</translation>
+<translation id="3894427358181296146">ফোল্ডার যোগ করুন</translation>
+<translation id="5327248766486351172">নাম</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">ফোল্ডার</translation>
+<translation id="5161254044473106830">শিরোনাম প্রয়োজন</translation>
+<translation id="2996809686854298943">URL প্রয়োজন</translation>
+<translation id="2536728043171574184">এই পৃষ্ঠার একটি অফলাইন কপি দেখছেন</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> এ অফলাইনে দেখুন</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> এবং আরও অনেক সাইট</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{রেডি হলেই Brave আপনার পৃষ্ঠা লোড করবে}one{রেডি হলেই Brave আপনার পৃষ্ঠা লোড করবে}other{রেডি হলেই Brave আপনার পৃষ্ঠা লোড করবে}}</translation>
+<translation id="6811034713472274749">পৃষ্ঠাটি এখন দেখতে পাবেন</translation>
+<translation id="4561979708150884304">কোনও কানেকশন নেই</translation>
+<translation id="8274165955039650276">ডাউনলোড দেখুন</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/> এর মধ্যে <ph name="RESULT_NUMBER"/> টি ফলাফল</translation>
+<translation id="4943872375798546930">কোন ফলাফল নেই</translation>
+<translation id="981121421437150478">অফলাইন</translation>
+<translation id="3298243779924642547">লাইট</translation>
+<translation id="393697183122708255">কোনো সক্ষম ভয়েস সার্চ উপলব্ধ নেই</translation>
+<translation id="7191430249889272776">পটভূমিতে ট্যাব খোলা হয়েছে।</translation>
+<translation id="8445059357334030806">Brave এ খুলুন</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/> এ খুলুন</translation>
+<translation id="7022756207310403729">ব্রাউজারে খুলুন</translation>
+<translation id="1113597929977215864">সরলীকৃত ভিউ দেখান</translation>
+<translation id="1513352483775369820">বুকমার্কগুলি এবং ওয়েব ইতিহাস</translation>
+<translation id="4939482511480190003">Brave উন্নত করতে সাহায্য করুন। <ph name="BEGIN_LINK"/>সমীক্ষায় অংশ নিন।<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">ফিরে যান</translation>
+<translation id="5596627076506792578">আরও বিকল্পগুলি</translation>
+<translation id="3522247891732774234">আপডেট উপলব্ধ। আরও বিকল্প</translation>
+<translation id="6773423637732432200">Brave আপডেট হচ্ছে না। আরও বিকল্প</translation>
+<translation id="3328801116991980348">সাইট তথ্য</translation>
+<translation id="5391532827096253100">এই সাইটে আপনার কানেকশন নিরাপদ নয়। সাইটের তথ্য</translation>
+<translation id="6206551242102657620">কানেকশনটি নিরাপদ। সাইট তথ্য</translation>
+<translation id="6963642900430330478">এই পৃষ্ঠাটি বিপজ্জনক। সাইটের তথ্য</translation>
+<translation id="9070377983101773829">ভয়েস সার্চ শুরু করুন</translation>
+<translation id="8676374126336081632">ইনপুট সাফ করুন</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/>টি খোলা ট্যাব, এক ট্যাব থেকে অন্য ট্যাবে যেতে ট্যাপ করুন}one{<ph name="OPEN_TABS_MANY"/>টি খোলা ট্যাব, এক ট্যাব থেকে অন্য ট্যাবে যেতে ট্যাপ করুন}other{<ph name="OPEN_TABS_MANY"/>টি খোলা ট্যাব, এক ট্যাব থেকে অন্য ট্যাবে যেতে ট্যাপ করুন}}</translation>
+<translation id="2369533728426058518">খোলা ট্যাবগুলি</translation>
+<translation id="7071521146534760487">অ্যাকাউন্ট ম্যানেজ করুন</translation>
+<translation id="932327136139879170">হোম</translation>
+<translation id="2707726405694321444">পৃষ্ঠা রিফ্রেশ করুন</translation>
+<translation id="2891154217021530873">পৃষ্ঠা লোড করা বন্ধ করুন</translation>
+<translation id="6710213216561001401">পূর্ববর্তী</translation>
+<translation id="6659594942844771486">ট্যাব</translation>
+<translation id="1933845786846280168">নির্বাচিত ট্যাবগুলি</translation>
+<translation id="2268044343513325586">রিফাইন করুন</translation>
+<translation id="7846076177841592234">নির্বাচন বাতিল করুন</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> বেছে নেওয়া হয়েছে।  স্ক্রিনের উপরে বিকল্পগুলি পাওয়া যাবে</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/>টি বেছে নেওয়া হয়েছে</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{১টি নির্বাচিত আইটেম শেয়ার করুন}one{#টি নির্বাচিত আইটেম শেয়ার করুন}other{#টি নির্বাচিত আইটেম শেয়ার করুন}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{১ টি নির্বাচিত আইটেম সরান}one{#টি নির্বাচিত আইটেম সরান}other{#টি নির্বাচিত আইটেম সরান}}</translation>
+<translation id="1283039547216852943">প্রসারিত করতে আলতো চাপুন</translation>
+<translation id="5962718611393537961">সঙ্কুচিত করতে আলতো চাপুন</translation>
+<translation id="8076492880354921740">ট্যাবগুলি</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{১টি বেছে নেওয়া হয়েছে}one{#টি বেছে নেওয়া হয়েছে}other{#টি বেছে নেওয়া হয়েছে}}</translation>
+<translation id="6818926723028410516">আইটেম বেছে নিন</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/>-এ ফিরে যেতে স্পর্শ করুন</translation>
+<translation id="6766758767654711248">সাইটে যেতে ট্যাপ করুন</translation>
+<translation id="429312253194641664">একটি সাইট মিডিয়া চালাচ্ছে</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> আপনার স্ক্রিন শেয়ার করছে</translation>
+<translation id="8833831881926404480">একটি সাইট আপনার স্ক্রিন শেয়ার করছে</translation>
+<translation id="9086455579313502267">নেটওয়ার্কটি অ্যাক্সেস করতে অক্ষম</translation>
+<translation id="938850635132480979">ত্রুটি: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/> এ খুলুন</translation>
+<translation id="548278423535722844">ম্যাপ অ্যাপ্লিকেশানে খুলুন</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/>-এ ইমেল আইডি তৈরি করুন</translation>
+<translation id="7875915731392087153">ইমেল আইডি তৈরি করুন</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> এ ইভেন্ট তৈরি করুন</translation>
+<translation id="2900528713135656174">ইভেন্ট তৈরি করুন</translation>
+<translation id="2111511281910874386">এই পৃষ্ঠাতে যান</translation>
+<translation id="3988466920954086464">সার্চের ফলাফল ঝটপট এই প্যানেলে দেখুন</translation>
+<translation id="2744248271121720757">ঝটপট সার্চ এবং সম্পর্কিত অ্যাকশন দেখতে একটি শব্দ ট্যাপ করুন</translation>
+<translation id="9155898266292537608">এছাড়াও কোনও শব্দের উপরে ট্যাপ করেও খুঁজতে পারেন</translation>
+<translation id="3232754137068452469">ওয়েব অ্যাপ</translation>
+<translation id="1430915738399379752">প্রিন্ট</translation>
+<translation id="3775705724665058594">আপনার ডিভাইসে পাঠান</translation>
+<translation id="6364438453358674297">ইতিহাস থেকে প্রস্তাবনা সরাবেন?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> বন্ধ করা হয়েছে</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/>টি ট্যাব বন্ধ হয়েছে</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> মুছে ফেলা হয়েছে</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/>টি বুকমার্ক মোছা হয়েছে</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/>টি ডাউনলোড মোছা হয়েছে</translation>
+<translation id="1248710015876067820">অসমর্থিত সংখ্যার Brave দৃষ্টান্তগুলি</translation>
+<translation id="4259722352634471385">নেভিগেশন অবরুদ্ধ করা হয়েছে: <ph name="URL"/></translation>
+<translation id="8959122750345127698">নেভিগেশানে পৌছানো যাচ্ছে না: <ph name="URL"/></translation>
+<translation id="5210365745912300556">ট্যাব বন্ধ করুন</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> বন্ধ করুন</translation>
+<translation id="1227058898775614466">নেভিগেশনের ইতিহাস</translation>
+<translation id="9169507124922466868">নেভিগেশনের ইতিহাস অর্ধেক খোলা রয়েছে</translation>
+<translation id="1327257854815634930">নেভিগেশনের ইতিহাস খোলা হয়েছে</translation>
+<translation id="8788265440806329501">নেভিগেশনের ইতিহাস বন্ধ করা হয়েছে</translation>
+<translation id="7482656565088326534">প্রিভিউ ট্যাব</translation>
+<translation id="8427875596167638501">প্রিভিউ ট্যাব অর্ধেক খোলা আছে</translation>
+<translation id="9102803872260866941">প্রিভিউ ট্যাব খোলা হয়েছে</translation>
+<translation id="2942036813789421260">প্রিভিউ ট্যাব বন্ধ করা আছে</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> স্টোরেজ</translation>
+<translation id="3822502789641063741">সাইটের সঞ্চয়স্থান সাফ করবেন?</translation>
+<translation id="9205995714227143200">যে সাইট স্টোরেজকে Brave গুরুত্বপূর্ণ মনে করে না (উদাঃ সেভকরা সেটিংস বিহীন সাইটগুলি বা আপনি প্রায়শই ঘুরে দেখেন না এমন সাইটগুলি)</translation>
+<translation id="3997476611815694295">গুরুত্বহীন সঞ্চয়স্থান</translation>
+<translation id="8493948351860045254">জায়গা ফাঁকা করুন</translation>
+<translation id="2324920234469020158">এটা কুকিজ, ক্যাশে, এবং সাইটের সেই সব ডেটা যা Brave গুরুত্বপূর্ণ মনে করে না সেগুলিকে সাফ করবে।</translation>
+<translation id="5447201525962359567">কুকিজ ও অন্যান্য স্থানীয়ভাবে সংরক্ষণ করা তথ্য সহ সাইটের সকল সঞ্চয়স্থান</translation>
+<translation id="1376578503827013741">গণনা করছে...</translation>
+<translation id="583281660410589416">অজানা</translation>
+<translation id="2323763861024343754">সাইটের স্টোরেজ</translation>
+<translation id="3587672679800759167">অ্যাকাউন্ট, ​​বুকমার্ক এবং স্টোর করা সেটিংসসহ Brave-এর ব্যবহার করা মোট ডেটা</translation>
+<translation id="6545017243486555795">সমস্ত ডেটা সাফ করুন</translation>
+<translation id="4095146165863963773">অ্যাপ্লিকেশান ডেটা মুছবেন?</translation>
+<translation id="53119194224775367">Brave-এর সকল অ্যাপ ডেটা স্থায়ীভাবে মুছে ফেলা হবে। এর মধ্যে সব ফাইল, সেটিংস, অ্যাকাউন্ট, ডেটাবেস ইত্যাদি অন্তর্ভুক্ত।</translation>
+<translation id="5307446750509046227">সাইটের সেভ করা ডেটা মুছুন</translation>
+<translation id="300526633675317032">এটা ওয়েবসাইট স্টোরেজের <ph name="SIZE_IN_KB"/>-এর পুরোটা সাফ করবে।</translation>
+<translation id="8068648041423924542">সার্টিফিকেট বেছে নিতে পারেনি।</translation>
+<translation id="2315043854645842844">ক্লায়েন্ট সাইড সার্টিফিকেট নির্বাচন অপারেটিং সিসটেম দ্বারা সমর্থিত নয়।</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> এদের সঙ্গে সংযুক্ত হতে চায়</translation>
+<translation id="5308380583665731573">সংযুক্ত করুন</translation>
+<translation id="868929229000858085">আপনার পরিচিতি সার্চ করুন</translation>
+<translation id="1919950603503897840">পরিচিতিগুলি বেছে নিন</translation>
+<translation id="7986741934819883144">একটি পরিচিতি বেছে নিন</translation>
+<translation id="3333961966071413176">সব পরিচিতি</translation>
+<translation id="4994033804516042629">কোনও পরিচিতি পাওয়া যায়নি</translation>
+<translation id="5403592356182871684">নাম</translation>
+<translation id="2717722538473713889">ইমেল আইডি</translation>
+<translation id="381841723434055211">ফোন নম্বর</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(এছাড়া আরও ১টি)}one{(এছাড়া আরও #টি)}other{(এছাড়া আরও #টি)}}</translation>
+<translation id="5197729504361054390">আপনার বেছে নেওয়া পরিচিতি <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>-এর সাথে শেয়ার করা হবে।</translation>
+<translation id="1779089405699405702">ইমেজ ডিকোডার</translation>
+<translation id="8067883171444229417">ভিডিও চালানোর বোতাম</translation>
+<translation id="6560414384669816528">Sogou দিয়ে খুঁজুন</translation>
+<translation id="5406914950576900927">Brave, চীনে সার্চের জন্য <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> কে ব্যবহার করতে পারে। আপনি <ph name="BEGIN_LINK"/>সেটিংস<ph name="END_LINK"/> থেকে এটি পরিবর্তন করতে পারেন।</translation>
+<translation id="6456271171669383967">Brave Software কে রাখুন</translation>
+<translation id="4384468725000734951">সার্চের জন্য Sogou কে ব্যবহার করছে</translation>
+<translation id="6103327872225198548">সার্চের জন্য Brave Software কে ব্যবহার করছে</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Brave-এ এই অ্যাপটি চলছে</translation>
+<translation id="6143689084714664628">Brave এ চালানো হচ্ছে</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> অ্যাপের ডেটা Brave ব্রাউজারেও আছে</translation>
+<translation id="2734140769649165081">Brave সেটিংসে গিয়ে আপনি ডেটা মুছে ফেলতে পারেন</translation>
+<translation id="8232956427053453090">ডেটা রাখুন</translation>
+<translation id="4298388696830689168">লিঙ্ক করা সাইট</translation>
+<translation id="5763514718066511291">এই অ্যাপের ইউআরএল কপি করতে ট্যাপ করুন</translation>
+<translation id="6496823230996795692"><ph name="APP_NAME"/> প্রথমবার ব্যবহার করার জন্য অনুগ্রহ করে ইন্টারনেটে সংযুক্ত হন।</translation>
+<translation id="751961395872307827">সাইটের সাথে সংযোগ করা যাচ্ছে না</translation>
+<translation id="4878404682131129617">প্রক্সি সার্ভারের মাধ্যমে টানেল তৈরি করা যায়নি</translation>
+<translation id="4749960740855309258">একটি নতুন ট্যাব খুলুন</translation>
+<translation id="8788968922598763114">সব শেষে বন্ধ করা ট্যাবটি পুনরায় খুলুন</translation>
+<translation id="7929962904089429003">মেনুটি খুলুন</translation>
+<translation id="6039379616847168523">পরবর্তী ট্যাবে চলে যান</translation>
+<translation id="5210286577605176222">পূর্ববর্তী ট্যাবে চলে যান</translation>
+<translation id="124678866338384709">বর্তমান ট্যাব বন্ধ করুন</translation>
+<translation id="3714981814255182093">খুঁজুন দণ্ডটি খুলুন</translation>
+<translation id="5441522332038954058">অ্যাড্রেস বারে চলে যান</translation>
+<translation id="3398320232533725830">বুকমার্কস ম্যানেজার খুলুন</translation>
+<translation id="6583199322650523874">বর্তমান পৃষ্ঠাটি বুকমার্ক করুন</translation>
+<translation id="8489271220582375723">ইতিহাস পৃষ্ঠাটি খুলুন</translation>
+<translation id="4837753911714442426">‘পৃষ্ঠা প্রিন্ট করুন’-এর বিকল্পগুলি খুলুন</translation>
+<translation id="5726692708398506830">পৃষ্ঠাতে থাকা সবকিছুকে বড় করুন</translation>
+<translation id="3259831549858767975">পৃষ্ঠাতে থাকা সবকিছুকে ছোট করুন</translation>
+<translation id="8015452622527143194">পৃষ্ঠার সবকিছুকে ডিফল্ট আকারে ফিরিয়ে আনুন</translation>
+<translation id="3443221991560634068">বর্তমান পৃষ্ঠাটি রিলোড করুন</translation>
+<translation id="123724288017357924">ক্যাশে করা কন্টেন্ট এড়িয়ে বর্তমান পৃষ্ঠা আবার লোড করুন</translation>
+<translation id="305870044889644984">Brave সহায়তা কেন্দ্রকে একটি নতুন ট্যাবে খুলুন</translation>
+<translation id="3166827708714933426">ট্যাব এবং উইন্ডোর শর্টকাটগুলি</translation>
+<translation id="3169981355900570544">Brave Software Brave এর বাছাই করা শর্টকাটগুলি</translation>
+<translation id="4558311620361989323">ওয়েবপৃষ্ঠার শর্টকাটগুলি</translation>
+<translation id="1908301351964700579">ভি আর সমর্থনের জন্য Brave-এ এখনও কাজ চলছে। পরে Brave রিস্টার্ট করুন।</translation>
+<translation id="8970887620466824814">কিছু সমস্যা হয়েছে।</translation>
+<translation id="1875543012935658554">Brave আবার খুলুন।</translation>
+<translation id="79859296434321399">অগমেন্টেড রিয়েলিটি কন্টেন্ট দেখার জন্য ARCore ইনস্টল করুন</translation>
+<translation id="8558485628462305855">অগমেন্টেড রিয়েলিটি কন্টেন্ট দেখার জন্য ARCore আপডেট করুন</translation>
+<translation id="3513704683820682405">অগমেন্টেড রিয়েলিটি</translation>
+<translation id="5475862044948910901">অগমেন্টেড রিয়েলিটি সেশন শুরু করতে চান?</translation>
 <translation id="7365126855094612066">এই সেশন চলাকালীন, সাইটটি এগুলি করতে পারবে:
 • আপনার পরিবেশের একটি 3D ম্যাপ তৈরি করা
 • ক্যামেরার মোশন ট্র্যাক করা
 
 সাইটকে ক্যামেরা অ্যাক্সেস করতে দেওয়া হয় না। ক্যামেরার ছবি শুধুমাত্র আপনিই দেখতে পান।</translation>
-<translation id="7375125077091615385">প্রকার:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />।</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome প্রথম চালানোর অভিজ্ঞতা</translation>
-<translation id="741204030948306876">হ্যাঁ, আমি রাজি</translation>
-<translation id="7413229368719586778">শুরুর তারিখ <ph name="DATE" /></translation>
-<translation id="7423098979219808738">প্রথমে জিজ্ঞাসা করুন</translation>
-<translation id="7423538860840206698">ক্লিপবোর্ড পড়া ব্লক করা হয়েছে</translation>
-<translation id="7431991332293347422">সার্চ এবং আরও অনেক কিছু নিজের মত করে সাজিয়ে নেওয়ার জন্য আপনার ব্রাউজিং ইতিহাস কীভাবে ব্যবহার হবে তা নিয়ন্ত্রণ করুন</translation>
-<translation id="7437998757836447326">Chrome থেকে সাইন-আউট করুন</translation>
-<translation id="7438641746574390233">লাইট মোড চালু থাকলে Chrome দ্রুত পৃষ্ঠা লোড করার জন্য Google সার্ভার ব্যবহার করে। লাইট মোড ধীরে ধীরে লোড হওয়া পৃষ্ঠাগুলিকে রিরাইট করে শুধু প্রয়োজনীয় কন্টেন্ট লোড করে। লাইট মোড ছদ্মবেশী ট্যাবে প্রযোজ্য হবে না।</translation>
-<translation id="7444811645081526538">আরও বিভাগ</translation>
-<translation id="7445411102860286510">সাইটগুলিকে মিউট করে রাখা ভিডিও স্বতঃবাজানোর মঞ্জুরি দেয় (প্রস্তাবিত)</translation>
-<translation id="7453467225369441013">বেশিরভাগ সাইট থেকে আপনাকে সাইন-আউট করিয়ে দেয়। তবে আপনার Google অ্যাকাউন্ট থেকে আপনাকে সাইন-আউট করানো হবে না।</translation>
-<translation id="7454641608352164238">পর্যাপ্ত জায়গা নেই</translation>
-<translation id="7475192538862203634">আপনি যদি এটি প্রায়ই দেখতে পান, তাহলে <ph name="BEGIN_LINK" />প্রস্তাবনাগুলি<ph name="END_LINK" /> চেষ্টা করে দেখুন৷</translation>
-<translation id="7475688122056506577">এসডি কার্ড পাওয়া যায়নি। আপনার কিছু ফাইল নাও থাকতে পারে।</translation>
-<translation id="7479104141328977413">ট্যাব ম্যানেজমেন্ট</translation>
-<translation id="7481312909269577407">ফরওয়ার্ড</translation>
-<translation id="7482656565088326534">প্রিভিউ ট্যাব</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (আপডেট করা হয়েছে <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">সেভ করা ডেটা</translation>
-<translation id="7498271377022651285">দয়া করে অপেক্ষা করুন...</translation>
-<translation id="7514365320538308">ডাউনলোড করুন</translation>
-<translation id="751961395872307827">সাইটের সাথে সংযোগ করা যাচ্ছে না</translation>
-<translation id="7521387064766892559">জাভাস্ক্রিপ্ট</translation>
-<translation id="7542481630195938534">প্রস্তাবনা পাওয়া যাচ্ছে না</translation>
-<translation id="7559975015014302720">লাইট মোড বন্ধ আছে</translation>
-<translation id="7562080006725997899">ব্রাউজিং ইতিহাস সাফ করা হচ্ছে</translation>
-<translation id="756809126120519699">Chrome ডেটা সাফ হয়েছে</translation>
-<translation id="757524316907819857">সুরক্ষিত কন্টেন্ট চালানো থেকে সাইটকে ব্লক করুন</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" />টি ফাইল ডাউনলোড হয়েছে}one{<ph name="FILES_DOWNLOADED_MANY" />টি ফাইল ডাউনলোড হয়েছে}other{<ph name="FILES_DOWNLOADED_MANY" />টি ফাইল ডাউনলোড হয়েছে}}</translation>
-<translation id="7588219262685291874">আপনার ডিভাইস ব্যাটারি সেভারে চললে গাঢ় থিম চালু করুন</translation>
-<translation id="7589445247086920869">বর্তমান সার্চ ইঞ্জিনের জন্য অবরুদ্ধ করুন</translation>
-<translation id="7593557518625677601">Android সেটিংস খুলে Chrome সিঙ্ক শুরু করতে Android সিস্টেমকে পুনরায় সক্ষম করুন</translation>
-<translation id="7596558890252710462">অপারেটিং সিস্টেম</translation>
-<translation id="7605594153474022051">সিঙ্ক কাজ করছে না</translation>
-<translation id="7606077192958116810">লাইট মোড চালু আছে। সেটিংসে এটি ম্যানেজ করুন।</translation>
-<translation id="7612619742409846846">এই হিসাবে Google এ প্রবেশ করেছেন</translation>
-<translation id="7619072057915878432">নেটওয়ার্ক কানেক্ট হয়নি বলে <ph name="FILE_NAME" /> ডাউনলোড করা যায়নি।</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />সহায়তা পান<ph name="END_LINK1" /> বা <ph name="BEGIN_LINK2" />আবার স্ক্যান করুন<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome এ স্বাগতম</translation>
-<translation id="7638584964844754484">ত্রুটিপূর্ণ পাসফ্রেজ</translation>
-<translation id="7641339528570811325">ব্রাউজিং ডেটা সাফ করুন...</translation>
-<translation id="7648422057306047504">Google সার্টিফিকেটসমূহের সাথে পাসওয়ার্ডগুলি এনক্রিপ্ট করুন</translation>
-<translation id="7649070708921625228">সহায়তা</translation>
-<translation id="7658239707568436148">বাতিল</translation>
-<translation id="7665369617277396874">অ্যাকাউন্ট যোগ করুন</translation>
-<translation id="766587987807204883">নিবন্ধগুলি এখানে দেখানো হয় এবং আপনি সেগুলি অফলাইনেও পড়তে পারেন</translation>
-<translation id="7682724950699840886">নিম্নলিখিত টিপ্স ব্যবহার করার চেষ্টা করুন: আপনার ডিভাইসে পর্যাপ্ত জায়গা আছে কিনা দেখে নিয়ে আবার এক্সপোর্ট করার চেষ্টা করুন।</translation>
-<translation id="7685301384041462804">ভিআর (VR) কন্টেন্ট দেখার আগে সাইটটি বিশ্বস্ত কিনা তা ভাল করে দেখে নিন।</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" />-এ ইমেল আইডি তৈরি করুন</translation>
-<translation id="7704317875155739195">সার্চ এবং ইউআরএলগুলি নিজে থেকে সম্পূর্ণ হতে দিন</translation>
-<translation id="7725024127233776428">আপনার বুকমার্ক করা পৃষ্ঠা এখানে দেখানো হয়</translation>
-<translation id="773466115871691567">সব সময় <ph name="SOURCE_LANGUAGE" /> ভাষার পৃষ্ঠার অনুবাদ দেখতে চাই</translation>
-<translation id="7746457520633464754">বিপজ্জনক অ্যাপ ও সাইট শনাক্ত করতে Chrome আপনার দেখা পৃষ্ঠাগুলির ইউআরএল, সিস্টেমের কিছু তথ্য ও কিছু পৃষ্ঠার কন্টেন্ট Google-কে পাঠায়</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> থেকে টেক্সট শেয়ার করা হয়েছে</translation>
-<translation id="7762668264895820836"><ph name="SD_CARD_NUMBER" /> টি এসডি কার্ড</translation>
-<translation id="7764225426217299476">ঠিকানা যোগ করুন</translation>
-<translation id="7772032839648071052">পাসফ্রেজ নিশ্চিত করুন</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> বন্ধ করুন</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> আরও অনেক}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> আরও অনেক}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 এবং <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> আরও অনেক}}</translation>
-<translation id="7781829728241885113">গতকাল</translation>
-<translation id="7791543448312431591">জুড়ুন</translation>
-<translation id="780301667611848630">না থাক</translation>
-<translation id="7810647596859435254">এর মাধ্যমে খুলুন...</translation>
-<translation id="7821588508402923572">আপনি কত ডেটা সেভ করেছেন তা এখানে দেখা যাবে</translation>
-<translation id="7837721118676387834">একটি নির্দিষ্ট সাইটের জন্য মিউট করে রাখা ভিডিওগুলি স্বতঃবাজানোর অনুমতি দেয়।</translation>
-<translation id="7846076177841592234">নির্বাচন বাতিল করুন</translation>
-<translation id="784934925303690534">সময় সীমা</translation>
-<translation id="7851858861565204677">অন্যান্য ডিভাইস</translation>
-<translation id="7875915731392087153">ইমেল আইডি তৈরি করুন</translation>
-<translation id="7876243839304621966">সকল সরান</translation>
-<translation id="7882131421121961860">কোনো ইতিহাস পাওয়া যায়নি</translation>
-<translation id="7882806643839505685">একটি নির্দিষ্ট সাইটের জন্য সাউন্ড প্লে করার অনুমতি দিন।</translation>
-<translation id="7886917304091689118">Chrome এ চালানো হচ্ছে</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ফাইলটি ডাউনলোড হচ্ছে।}one{#টি ফাইল ডাউনলোড হচ্ছে।}other{#টি ফাইল ডাউনলোড হচ্ছে।}}</translation>
-<translation id="7929962904089429003">মেনুটি খুলুন</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> পুরনো হয়ে গেছে।</translation>
-<translation id="7947953824732555851">সম্মত হয়ে সাইন-ইন করুন</translation>
-<translation id="7963646190083259054">বিক্রেতা:</translation>
-<translation id="7971136598759319605">১ দিন আগে ব্যবহার করা হয়েছে</translation>
-<translation id="7975379999046275268"><ph name="BEGIN_NEW" />নতুন<ph name="END_NEW" /> পৃষ্ঠার প্রিভিউ দেখুন</translation>
-<translation id="7981313251711023384">আরও দ্রুত ব্রাউজ করা এবং খোঁজার জন্য পৃষ্ঠা আগে লোড করুন</translation>
-<translation id="79859296434321399">অগমেন্টেড রিয়েলিটি কন্টেন্ট দেখার জন্য ARCore ইনস্টল করুন</translation>
-<translation id="7986741934819883144">একটি পরিচিতি বেছে নিন</translation>
-<translation id="7987073022710626672">Chrome পরিষেবার শর্তাবলি</translation>
-<translation id="7998918019931843664">বন্ধ হওয়া ট্যাব আবার খুলুন</translation>
-<translation id="7999064672810608036">আপনি কি এই ওয়েবসাইটের কুকি সহ সমস্ত ডেটা পরিষ্কার করার এবং এটির সমস্ত অনুমতি রিসেট করার বিষয়ে নিশ্চিত?</translation>
-<translation id="8004582292198964060">ব্রাউজার</translation>
-<translation id="8007176423574883786">এই ডিভাইসের জন্য বন্ধ করা আছে</translation>
-<translation id="8013372441983637696">এছাড়া এই ডিভাইস থেকে Chrome ডেটা সরিয়ে ফেলুন</translation>
-<translation id="8015452622527143194">পৃষ্ঠার সবকিছুকে ডিফল্ট আকারে ফিরিয়ে আনুন</translation>
-<translation id="802154636333426148">ডাউনলোড করা যায়নি</translation>
-<translation id="8026334261755873520">ব্রাউজ করা ডেটা সাফ করুন</translation>
-<translation id="8035133914807600019">নতুন ফোল্ডার...</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> দিন বাকি আছে</translation>
-<translation id="804335162455518893">এসডি কার্ড পাওয়া যায়নি</translation>
-<translation id="805047784848435650">আপনার ব্রাউজিং ইতিহাসের উপর ভিত্তি করে</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> এমবি উপলভ্য</translation>
-<translation id="8058746566562539958">নতুন Chrome ট্যাবে খুলুন</translation>
-<translation id="8063895661287329888">বুকমার্ক যোগ করতে ব্যর্থ হয়েছে।</translation>
-<translation id="806745655614357130">আমার ডেটা আলাদা রাখুন</translation>
-<translation id="8067883171444229417">ভিডিও চালানোর বোতাম</translation>
-<translation id="8068648041423924542">সার্টিফিকেট বেছে নিতে পারেনি।</translation>
-<translation id="8073388330009372546">নতুন ট্যাবে ইমেজ খুলুন</translation>
-<translation id="8076492880354921740">ট্যাবগুলি</translation>
-<translation id="8084114998886531721">সংরক্ষিত পাসওয়ার্ড</translation>
-<translation id="8087000398470557479">এই কন্টেন্ট Google দ্বারা বিতরণ করা <ph name="DOMAIN_NAME" /> থেকে এসেছে।</translation>
-<translation id="8103578431304235997">ছদ্মবেশী ট্যাব</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">আপনার সমস্ত ডিভাইসে বুকমার্কগুলি পেতে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="8110087112193408731">ডিজিটাল ওয়েলবিং-এ আপনার Chrome অ্যাক্টিভিটি দেখতে চান?</translation>
-<translation id="8116925261070264013">মিউট করা আছে</translation>
-<translation id="813082847718468539">সাইটের তথ্য দর্শন করুন</translation>
-<translation id="8131740175452115882">নিশ্চিত হন</translation>
-<translation id="8156139159503939589">আপনি কোন কোন ভাষা পড়তে পারেন?</translation>
-<translation id="8168435359814927499">কন্টেন্ট</translation>
-<translation id="8186512483418048923"><ph name="FILES" />টি ফাইল বাকি</translation>
-<translation id="8190358571722158785">১ দিন বাকি আছে</translation>
-<translation id="8200772114523450471">আবার চালু করা</translation>
-<translation id="8209050860603202033">ইমেজ খুলুন</translation>
-<translation id="8218622182176210845">আপনার অ্যাকাউন্ট ম্যানেজ করুন</translation>
-<translation id="8224471946457685718">ওয়াই-ফাই ব্যবহার করে আপনার জন্য নিবন্ধ ডাউনলোড করুন</translation>
-<translation id="8232956427053453090">ডেটা রাখুন</translation>
-<translation id="8249310407154411074">শীর্ষে সরান</translation>
-<translation id="8250920743982581267">দস্তাবেজগুলি</translation>
-<translation id="825412236959742607">এই পৃষ্ঠাটি খুব বেশি মেমরি ব্যবহার করছে তাই Chrome কিছু কন্টেন্ট সরিয়ে দিয়েছে।</translation>
-<translation id="8260126382462817229">আবার সাইন ইন করার চেষ্টা করুন</translation>
-<translation id="8261506727792406068">মুছুন</translation>
-<translation id="8266862848225348053">যেখানে ডাউনলোড হবে</translation>
-<translation id="8274165955039650276">ডাউনলোড দেখুন</translation>
-<translation id="8284326494547611709">পরিচয়লিপিগুলি</translation>
-<translation id="8300705686683892304">অ্যাপ ম্যানেজ করে</translation>
-<translation id="8310344678080805313">স্ট্যান্ডার্ড ট্যাব</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> এবং আরও অনেক সাইট</translation>
-<translation id="8327155640814342956">সবচেয়ে ভাল ব্রাউজিং অভিজ্ঞতা পেতে, Chrome আপডেট করুন</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" /> ভাষার পৃষ্ঠার অনুবাদ করা হবে না</translation>
-<translation id="8349013245300336738">ব্যবহার করা ডেটার পরিমাণ অনুযায়ী সাজান</translation>
-<translation id="8364299278605033898">জনপ্রিয় ওয়েবসাইট দেখুন</translation>
-<translation id="8368027906805972958">অপরিচিত বা কাজ করে না এমন ডিভাইস (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">একটি নির্দিষ্ট সাইটের জন্য পটভূমি সিঙ্কের অনুমতি দিন।</translation>
-<translation id="8378714024927312812">আপনার প্রতিষ্ঠানের দ্বারা ম্যানেজ করা</translation>
-<translation id="8380167699614421159">এই সাইট ব্যাঘাত সৃষ্টিকারী বা বিভ্রান্তিকর বিজ্ঞাপন দেখায়</translation>
-<translation id="8393700583063109961">বার্তা পাঠান</translation>
-<translation id="8413126021676339697">সম্পূর্ণ ইতিহাস দেখান</translation>
-<translation id="8427875596167638501">প্রিভিউ ট্যাব অর্ধেক খোলা আছে</translation>
-<translation id="8428213095426709021">সেটিংস</translation>
-<translation id="8438566539970814960">সার্চ এবং ব্রাউজিং অভিজ্ঞতা আরও উন্নত করুন</translation>
-<translation id="8441146129660941386">পেছনে যান</translation>
-<translation id="8443209985646068659">Chrome আপডেট হচ্ছে না</translation>
-<translation id="8445448999790540984">পাসওয়ার্ড এক্সপোর্ট করা যাচ্ছে না</translation>
-<translation id="8447861592752582886">ডিভাইসের অনুমতি প্রত্যাহার করুন</translation>
-<translation id="8461694314515752532">আপনার নিজস্ব সিঙ্ক পাসফ্রেজ দিয়ে সিঙ্ক করা ডেটা এনক্রিপ্ট করুন</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> ডিভাইসটি ইন্টারনেটের সাথে কানেক্ট করা আছে কিনা দেখে নিন</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">অফলাইনে উপলব্ধ</translation>
-<translation id="8489271220582375723">ইতিহাস পৃষ্ঠাটি খুলুন</translation>
-<translation id="8493948351860045254">জায়গা ফাঁকা করুন</translation>
-<translation id="8497726226069778601">এখানে... দেখার মতো এখনো কিছু নেই</translation>
-<translation id="8503559462189395349">Chrome পাসওয়ার্ডগুলি</translation>
-<translation id="8503813439785031346">ইউজারনেম</translation>
-<translation id="8514477925623180633">Chrome এ সেভ করা পাসওয়ার্ড এক্সপোর্ট করুন</translation>
-<translation id="8514577642972634246">ছদ্মবেশী মোডে সাইন-ইন</translation>
-<translation id="851751545965956758">সাইটকে ডিভাইসের সাথে কানেক্ট করা থেকে ব্লক করুন</translation>
-<translation id="8523928698583292556">সংরক্ষিত পাসওয়ার্ড মুছুন</translation>
-<translation id="854522910157234410">এই পৃষ্ঠাটি খুলুন</translation>
-<translation id="8558485628462305855">অগমেন্টেড রিয়েলিটি কন্টেন্ট দেখার জন্য ARCore আপডেট করুন</translation>
-<translation id="8559990750235505898">অন্য ভাষাতে পৃষ্ঠা অনুবাদ করার প্রস্তাব দিন</translation>
-<translation id="8562452229998620586">আপনার সংরক্ষিত পাসওয়ার্ডগুলি এখানে উপস্থিত হবে৷</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> তারিখ থেকে</translation>
-<translation id="8571213806525832805">গত ৪ সপ্তাহ</translation>
-<translation id="857943718398505171">অনুমোদিত (প্রস্তাবিত)</translation>
-<translation id="8583805026567836021">অ্যাকাউন্টের ডেটা সাফ করা হচ্ছে</translation>
-<translation id="860043288473659153">কার্ডধারকের নাম</translation>
-<translation id="8609465669617005112">উপরে যান</translation>
-<translation id="8616006591992756292"><ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />-এ আপনার Google অ্যাকাউন্টের অন্যান্য ধরনের ব্রাউজিংয়ের ইতিহাস থাকতে পারে।</translation>
-<translation id="8617240290563765734">ডাউনলোড হওয়া কন্টেন্টতে নির্দিষ্ট করা প্রস্তাবিত URLটি খুলবেন?</translation>
-<translation id="8636825310635137004">আপনার অন্য ডিভাইসগুলি থেকে আপনার ট্যাবগুলি পেতে, সিঙ্ক চালু করুন।</translation>
-<translation id="8641930654639604085">প্রাপ্তবয়স্কদের সাইটগুলি অবরুদ্ধ করার চেষ্টা করুন</translation>
-<translation id="8655129584991699539">Chrome সেটিংসে গিয়ে আপনি ডেটা মুছে ফেলতে পারেন</translation>
-<translation id="8662811608048051533">বেশিরভাগ সাইট থেকে আপনাকে সাইন-আউট করিয়ে দেয়।</translation>
-<translation id="8664979001105139458">ফাইলের নামটি আগে থেকেই আছে</translation>
-<translation id="8676374126336081632">ইনপুট সাফ করুন</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{সিগনালের স্তর: #টি দণ্ড}one{সিগনালের স্তর: #টি দণ্ড}other{সিগনালের স্তর: #টি দণ্ড}}</translation>
-<translation id="868929229000858085">আপনার পরিচিতি সার্চ করুন</translation>
-<translation id="869891660844655955">মেয়াদকাল সমাপ্তির তারিখ</translation>
-<translation id="8719023831149562936">বর্তমান ট্যাবকে বীম করা যাবে না</translation>
-<translation id="8725066075913043281">আবার চেষ্টা করুন</translation>
-<translation id="8728487861892616501">এই অ্য়াপটি ব্যবহার করার মাধ্যমে আপনি Chrome-এর <ph name="BEGIN_LINK1" />পরিষেবার শর্তাবলি<ph name="END_LINK1" /> এবং <ph name="BEGIN_LINK2" />গোপনীয়তা নীতি<ph name="END_LINK2" /> এবং <ph name="BEGIN_LINK3" />Family Link-এ তৈরি করা Google অ্যাকাউন্টগুলির জন্য গোপনীয়তার বিজ্ঞপ্তি<ph name="END_LINK3" />-এর সাথে সম্মত হন।</translation>
-<translation id="8730621377337864115">হয়ে গেছে</translation>
-<translation id="8748850008226585750">সামগ্রী লুকানো আছে</translation>
-<translation id="8751914237388039244">একটি ছবি বেছে নিন</translation>
-<translation id="8788265440806329501">নেভিগেশনের ইতিহাস বন্ধ করা হয়েছে</translation>
-<translation id="8788968922598763114">সব শেষে বন্ধ করা ট্যাবটি পুনরায় খুলুন</translation>
-<translation id="8801436777607969138">একটি নির্দিষ্ট সাইটের জন্য জাভাস্ক্রিপ্ট ব্লক করুন।</translation>
-<translation id="8812260976093120287">কিছু ওয়েবসাইটে আপনি উপরের সমর্থিত পেমেন্ট অ্যাপ্লিকেশান দিয়ে অর্থপ্রদান করতে পারেন।</translation>
-<translation id="8816026460808729765">সেন্সর অ্যাক্সেস করা থেকে সাইটকে ব্লক করুন</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chrome-এ খুলবে। চালিয়ে যাওয়ার মাধ্যমে আপনি Chrome-এর <ph name="BEGIN_LINK1" />পরিষেবার শর্তাবলী<ph name="END_LINK1" /> ও <ph name="BEGIN_LINK2" />গোপনীয়তা বিজ্ঞপ্তি<ph name="END_LINK2" /> এবং <ph name="BEGIN_LINK3" />Family Link-এর মাধ্যমে পরিচালিত Google অ্যাকাউন্টের গোপনীয়তা বিজ্ঞপ্তি<ph name="END_LINK3" />র সাথে সম্মত হচ্ছেন।</translation>
-<translation id="8820817407110198400">বুকমার্কস</translation>
-<translation id="8833831881926404480">একটি সাইট আপনার স্ক্রিন শেয়ার করছে</translation>
-<translation id="883806473910249246">কন্টেন্ট ডাউনলোড করার সময় একটি ত্রুটি ঘটেছে৷</translation>
-<translation id="8840953339110955557">এই পৃষ্ঠাটি হয়ত অনলাইন ভার্সনের থেকে আলাদা হতে পারে।</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, ট্যাব</translation>
-<translation id="885701979325669005">স্টোরেজ</translation>
-<translation id="889338405075704026">Chrome সেটিংসে যান</translation>
-<translation id="8901170036886848654">কোনো বুকমার্ক পাওয়া যায়নি</translation>
-<translation id="8909135823018751308">শেয়ার করুন...</translation>
-<translation id="8912362522468806198">Google অ্যাকাউন্ট</translation>
-<translation id="8920114477895755567">অভিভাবকের বিশদ বিবরণের জন্য অপেক্ষা করা হচ্ছে৷</translation>
+<translation id="1188239144602654184">এ আর সেশন শুরু করুন</translation>
+<translation id="473775607612524610">আপডেট করুন</translation>
+<translation id="3133489217401741157">Brave-এর জন্য <ph name="MODULE"/> ইনস্টল করা হচ্ছে…</translation>
+<translation id="1791662854739702043">ইনস্টল হয়েছে</translation>
+<translation id="5131234170665854056">Brave-এর জন্য <ph name="MODULE"/> ইনস্টল করা যাচ্ছে না</translation>
+<translation id="2567385386134582609">ইমেজ</translation>
+<translation id="6395288395575013217">লিঙ্ক</translation>
+<translation id="7352939065658542140">ভিডিও</translation>
+<translation id="4116038641877404294">পৃষ্ঠাগুলি অফলাইনে ব্যবহার করতে সেগুলি ডাউনলোড করুন</translation>
 <translation id="8922289737868596582">পৃষ্ঠাগুলি অফলাইনে ব্যবহার করতে সেগুলি আরও বিকল্প বোতাম থেকে ডাউনলোড করুন</translation>
-<translation id="8937772741022875483">ডিজিটাল ওয়েলবিয়িং থেকে আপনার Chrome অ্যাক্টিভিটি সরিয়ে দিতে চান?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">অন্য উইন্ডোতে খুলুন</translation>
-<translation id="8951232171465285730">Chrome আপনার জন্য <ph name="MEGABYTES" /> এমবি বাঁচিয়ে দিয়েছে</translation>
-<translation id="8958424370300090006">কোনও নির্দিষ্ট সাইটের জন্য কুকি ব্লক করুন।</translation>
-<translation id="8959122750345127698">নেভিগেশানে পৌছানো যাচ্ছে না: <ph name="URL" /></translation>
-<translation id="8965591936373831584">বাকি আছে</translation>
-<translation id="8970887620466824814">কিছু সমস্যা হয়েছে।</translation>
-<translation id="8972098258593396643">ডিফল্ট ফোল্ডারে ডাউনলোড করবেন?</translation>
-<translation id="8986494364107987395">ব্যবহারের পরিসংখ্যান এবং ক্র্যাশ প্রতিবেদনগুলি স্বয়ংক্রিয়ভাবে Google-এ পাঠান</translation>
-<translation id="8993760627012879038">ছদ্মবেশী মোডে একটি নতুন ট্যাব খুলুন</translation>
-<translation id="8998729206196772491">আপনি <ph name="MANAGED_DOMAIN" /> দ্বারা পরিচালিত একটি অ্যাকাউন্টের মাধ্যমে সাইন-ইন করছেন এবং এর অ্যাডমিনিস্ট্রেটরকে আপনার Chrome ডেটা নিয়ন্ত্রণ করতে দিচ্ছেন৷ আপনার ডেটা এই অ্যাকাউন্টের সাথে স্থায়ীভাবে আবদ্ধ হবে৷ Chrome থেকে সাইন-আউট করলে এই ডিভাইস থেকে আপনার ডেটা মুছে ফেলা হবে, কিন্তু এটা আপনার Google অ্যাকাউন্টে সঞ্চিত থাকবে।</translation>
-<translation id="9019902583201351841">আপনার পিতামাতার দ্বারা পরিচালিত</translation>
-<translation id="9028914725102941583">বিভিন্ন ডিভাইসের জুড়ে শেয়ার করার জন্য সিঙ্ক ফিচার চালু করুন</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> সাইটকে ভিআর (VR) মোড ব্যবহার করার অনুমতি দেবেন?</translation>
-<translation id="9040142327097499898">বিজ্ঞপ্তির অনুমতি দেওয়া আছে। এই ডিভাইসে লোকেশন বন্ধ করা আছে।</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{#টি ভিডিও}one{#টি ভিডিও}other{#টি ভিডিও}}</translation>
-<translation id="9050666287014529139">পাসফ্রেজ</translation>
-<translation id="9063523880881406963">ডেস্কটপ সাইটের অনুরোধ বন্ধ করুন</translation>
-<translation id="9065203028668620118">সম্পাদনা</translation>
-<translation id="9070377983101773829">ভয়েস সার্চ শুরু করুন</translation>
-<translation id="9074336505530349563">Google-এর প্রস্তাবিত ব্যক্তিগতকৃত কন্টেন্ট পাওয়ার জন্য সাইন-ইন করে সিঙ্ক বিকল্প চালু করুন</translation>
-<translation id="9086455579313502267">নেটওয়ার্কটি অ্যাক্সেস করতে অক্ষম</translation>
-<translation id="9100505651305367705">সমর্থিত হলে সরলীকৃত ভিউতে নিবন্ধগুলি দেখানোর প্রস্তাব দিন</translation>
-<translation id="9100610230175265781">পাসফ্রেজের প্রয়োজন</translation>
-<translation id="9102803872260866941">প্রিভিউ ট্যাব খোলা হয়েছে</translation>
+<translation id="5958275228015807058">ডাউনলোড ফোল্ডার থেকে আপনার সমস্ত ফাইল ও পৃষ্ঠাগুলি খুঁজে নিন</translation>
+<translation id="5620928963363755975">আরও বিকল্প বোতামের ডাউনলোড বিকল্প থেকে আপনার সমস্ত ফাইল ও পৃষ্ঠাগুলি খুঁজে পান</translation>
+<translation id="3341058695485821946">দেখুন আপনি কত ডেটা সাশ্রয় করেছেন</translation>
+<translation id="3157842584138209013">আরও বিকল্প বোতাম দিয়ে দেখুন আপনি কত ডেটা সাশ্রয় করেছেন</translation>
+<translation id="8218622182176210845">আপনার অ্যাকাউন্ট ম্যানেজ করুন</translation>
+<translation id="8090895580117672212">আপনার Brave Software অ্যাকাউন্ট ম্যানেজ করতে, "অ্যাকাউন্ট ম্যানেজ করুন" বোতামে ট্যাপ করুন</translation>
+<translation id="8856898588039823173">Brave Software লাইট পৃষ্ঠা পাঠিয়েছে। আসল পৃষ্ঠাটি লোড করতে ট্যাপ করুন।</translation>
+<translation id="8134317863207426198">Brave Software লাইট পৃষ্ঠা পাঠিয়েছে। আসল পৃষ্ঠাটি লোড করতে "আসলটি লোড করুন" বোতামে ট্যাপ করুন।</translation>
+<translation id="4961107849584082341">এই পৃষ্ঠাটি যেকোনও ভাষায় অনুবাদ করুন</translation>
+<translation id="569536719314091526">আরও বিকল্প বোতাম থেকে এই পৃষ্ঠাটিকে যেকোনও ভাষায় অনুবাদ করুন</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> এর সাহায্যে খুঁজুন</translation>
+<translation id="1792959175193046959">যেকোনও সময় ডাউনলোডের ডিফল্ট লোকেশন পরিবর্তন করুন</translation>
+<translation id="6942665639005891494">সেটিংস মেনুর বিকল্পে গিয়ে যেকোনও সময় ডাউনলোডের ডিফল্ট লোকেশন পরিবর্তন করুন</translation>
+<translation id="6850409657436465440">ডাউনলোডটি এখনও চলছে</translation>
+<translation id="5817715962196959877">Brave এখন আরও দ্রুত ফাইল ডাউনলোড করে</translation>
+<translation id="3976396876660209797">এই শর্টকাটটি সরিয়ে নতুন করে তৈরি করুন</translation>
+<translation id="6766622839693428701">বন্ধ করতে নিচের দিকে সোয়াইপ করুন।</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/>-এ পাঠানো হচ্ছে...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> থেকে পাঠানো হয়েছে</translation>
+<translation id="5357811892247919462">ট্যাব পাওয়া গেছে</translation>
 <translation id="9104217018994036254">ট্যাব শেয়ার করা যাবে এমন ডিভাইসের সূচি।</translation>
-<translation id="9133397713400217035">অফলাইন কন্টেন্ট দেখুন</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">প্রকৃত রূপ দেখান</translation>
-<translation id="9139068048179869749">কোনও সাইটকে বিজ্ঞপ্তি পাঠানোর অনুমতি দেওয়ার আগে আমাকে জিজ্ঞেস করা হবে (প্রস্তাবিত)</translation>
-<translation id="9139318394846604261">কেনাকাটা</translation>
-<translation id="9155898266292537608">এছাড়াও কোনও শব্দের উপরে ট্যাপ করেও খুঁজতে পারেন</translation>
-<translation id="9169507124922466868">নেভিগেশনের ইতিহাস অর্ধেক খোলা রয়েছে</translation>
-<translation id="9204836675896933765">১টি ফাইল বাকি</translation>
-<translation id="9206873250291191720">আ</translation>
+<translation id="6767294960381293877">ট্যাব শেয়ার করা যাবে এমন ডিভাইসের সূচি অর্ধেক স্ক্রিন জুড়ে খোলা হয়েছে।</translation>
+<translation id="2904414404539560095">ট্যাব শেয়ার করা যাবে এমন ডিভাইসের সূচি সম্পূর্ণ স্ক্রিন জুড়ে খোলা হয়েছে।</translation>
+<translation id="4135200667068010335">ট্যাব শেয়ার করা যাবে এমন ডিভাইসের সূচি বন্ধ আছে।</translation>
+<translation id="5292796745632149097">এতে পাঠান:</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> দিন আগে ব্যবহার করা হয়েছে</translation>
+<translation id="7971136598759319605">১ দিন আগে ব্যবহার করা হয়েছে</translation>
+<translation id="1521774566618522728">আজ ব্যবহার করা হয়েছে</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/>-এর সাথে শেয়ার করা হচ্ছে</translation>
+<translation id="9028914725102941583">বিভিন্ন ডিভাইসের জুড়ে শেয়ার করার জন্য সিঙ্ক ফিচার চালু করুন</translation>
+<translation id="6162454065885854378">আপনার ফোন থেকে অন্য কোনও ডিভাইসে কিছু শেয়ার করতে হলে, দুটি ডিভাইসের Brave সেটিংস থেকে সিঙ্ক ফিচার চালু করুন</translation>
+<translation id="6084271560289605378">Brave সেটিংসে যান</translation>
+<translation id="2318045970523081853">কল করতে ট্যাপ করুন</translation>
 <translation id="9209888181064652401">কল করা যাচ্ছে না</translation>
-<translation id="9219103736887031265">ছবিগুলি</translation>
-<translation id="926205370408745186">ডিজিটাল ওয়েলবিং থেকে আপনার Chrome অ্যাক্টিভিটি সরিয়ে দিন</translation>
-<translation id="932327136139879170">হোম</translation>
-<translation id="938850635132480979">ত্রুটি: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">আপনার মাইক্রোফোন অ্যাক্সেস করুন</translation>
-<translation id="95817756606698420">Chrome, চীনে সার্চের জন্য <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> কে ব্যবহার করতে পারে। আপনি <ph name="BEGIN_LINK" />সেটিংস<ph name="END_LINK" /> থেকে এটি পরিবর্তন করতে পারেন।</translation>
-<translation id="965817943346481315">সাইটে থাকা ব্যাঘাত সৃষ্টিকারী বা বিভ্রান্তিকর বিজ্ঞাপন ব্লক করুন (প্রস্তাবিত)</translation>
-<translation id="968900484120156207">আপনি যে পৃষ্ঠাগুলিতে যান সেগুলি এখানে দেখানো হয়</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> মিনিট বাকি আছে</translation>
-<translation id="974555521953189084">সিঙ্ক শুরু করার জন্য আপনার পাসফ্রেজ লিখুন</translation>
-<translation id="981121421437150478">অফলাইন</translation>
-<translation id="982182592107339124">এটা সব সাইটের জন্য ডেটা সাফ করবে, এতে অন্তর্ভুক্ত আছে:</translation>
-<translation id="983192555821071799">সমস্ত ট্যাবগুলি বন্ধ করুন</translation>
-<translation id="987264212798334818">সাধারণ</translation>
+<translation id="2860954141821109167">এই ডিভাইসে ফোন অ্যাপ চালু করা আছে কিনা দেখে নিন</translation>
+<translation id="2067805253194386918">টেক্সট</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> শেয়ার করা যাচ্ছে না</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> শেয়ার করা যায়নি</translation>
+<translation id="8287068819750208230">Brave-এ <ph name="TARGET_DEVICE_NAME"/> সিঙ্ক করার ফিচার চালু করে রেখেছেন কিনা দেখে নিন।</translation>
+<translation id="3016635187733453316">এই ডিভাইসটি ইন্টারনেটে কানেক্ট করা আছে কিনা দেখে নিন</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> ডিভাইসটি ইন্টারনেটের সাথে কানেক্ট করা আছে কিনা দেখে নিন</translation>
+<translation id="6539092367496845964">কোনও সমস্যা হয়েছে। পরে আবার চেষ্টা করুন।</translation>
+<translation id="3389286852084373014">টেক্সটটি অনেক বড়</translation>
+<translation id="2100314319871056947">টেক্সটটি ছোট ছোট ভাগে ভাগ করে পাঠানোর চেষ্টা করুন</translation>
+<translation id="2987620471460279764">অন্য ডিভাইস থেকে টেক্সট শেয়ার করা হয়েছে</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> থেকে টেক্সট শেয়ার করা হয়েছে</translation>
+<translation id="5193988420012215838">আপনার ক্লিপবোর্ডে কপি করা হয়েছে</translation>
+<translation id="4696983787092045100">আপনার ডিভাইসে টেক্সট পাঠান</translation>
+<translation id="1260236875608242557">সার্চ করুন, ঘুরে দেখুন</translation>
+<translation id="6369229450655021117">এখান থেকে আপনি ওয়েবে সার্চ করতে, বন্ধুদের সাথে শেয়ার করতে এবং খোলা পৃষ্ঠাগুলি দেখতে পারেন</translation>
+<translation id="723171743924126238">ছবি বেছে নিন</translation>
+<translation id="8751914237388039244">একটি ছবি বেছে নিন</translation>
+<translation id="1989112275319619282">ব্রাউজ করুন</translation>
+<translation id="7055152154916055070">রিডাইরেক্ট ব্লক করা হয়েছে:</translation>
+<translation id="5524843473235508879">রিডাইরেক্ট ব্লক করা হয়েছে।</translation>
+<translation id="6573096386450695060">সর্বদা অনুমতি দিন</translation>
+<translation id="5805364706385912897">এই পৃষ্ঠাটি খুব বেশি মেমরি ব্যবহার করছে তাই Brave এটি বিরত রেখেছে।</translation>
+<translation id="5138664332909611586">এই পৃষ্ঠাটি খুব বেশি মেমরি ব্যবহার করছে তাই Brave কিছু কন্টেন্ট সরিয়ে দিয়েছে।</translation>
+<translation id="9137013805542155359">প্রকৃত রূপ দেখান</translation>
+<translation id="6361779936989026201">Brave-এ Brave Software অ্যাসিস্ট্যান্ট</translation>
+<translation id="7291387454912369099">অ্যাসিস্ট্যান্টের মাধ্যমে চেকআউট</translation>
+<translation id="4565206163201411670">ডিজিটাল ওয়েলবিং-এ আপনার Brave অ্যাক্টিভিটি দেখতে চান?</translation>
+<translation id="9055113864158719823">Brave-এ দেখা সাইটগুলি আপনি দেখতে পাবেন এবং সাইটগুলিতে টাইমার সেট করতে পারবেন।\n\nযে সমস্ত সাইটে টাইমার সেট করেছেন বা কত সময় ধরে সাইটটি দেখেছেন তার সমস্ত তথ্য Brave Software-এর কাছে যায়। ডিজিটাল ওয়েলবিং-কে আরও উন্নত করতে এই তথ্য ব্যবহার করা হয়।</translation>
+<translation id="4596514158372210596">ডিজিটাল ওয়েলবিং থেকে আপনার Brave অ্যাক্টিভিটি সরিয়ে দিন</translation>
+<translation id="1174893863889683998">ডিজিটাল ওয়েলবিয়িং থেকে আপনার Brave অ্যাক্টিভিটি সরিয়ে দিতে চান?</translation>
+<translation id="708829030563435351">আপনি কোন কোন সাইটে গেছেন তা Brave-এ দেখা যাবে না। সমস্ত সাইটের টাইমার মুছে দেওয়া হবে।</translation>
+<translation id="2056878612599315956">সাইট পজ করা আছে</translation>
+<translation id="671481426037969117">আপনার <ph name="FQDN"/> টাইমারের মেয়াদ পেরিয়ে গেছে। আগামীকাল আবার এটি শুরু হবে।</translation>
+<translation id="7479104141328977413">ট্যাব ম্যানেজমেন্ট</translation>
+<translation id="3524138585025253783">ডেভেলপার UI</translation>
+<translation id="6036057147555329831">অতিরিক্ত ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> সাইটকে ভিআর (VR) মোড ব্যবহার করার অনুমতি দেবেন?</translation>
+<translation id="7685301384041462804">ভিআর (VR) কন্টেন্ট দেখার আগে সাইটটি বিশ্বস্ত কিনা তা ভাল করে দেখে নিন।</translation>
+<translation id="5033865233969348410">আপনি ভিআর (VR) মোডে থাকলে এই সাইট যে বিষয় সম্পর্কে জানতে পারে তা হল:
+  -  আপনার শারীরিক বৈশিষ্ট্য, যেমন উচ্চতা
+
+ভিআর (VR) ব্যবহার করার আগে সাইটটি বিশ্বস্ত কিনা ভাল করে দেখে নিন।</translation>
+<translation id="5534334044554683961">আপনি ভিআর (VR) মোডে থাকলে এই সাইট যে বিষয় সম্পর্কে হয়ত জানতে পারে, তা হল:
+  -  আপনার শারীরিক বৈশিষ্ট্য, যেমন উচ্চতার
+  -   আপনার রুমের লেআউট
+
+ভিআর (VR) ব্যবহার করার আগে সাইটটি বিশ্বস্ত কিনা ভাল করে দেখে নিন।</translation>
+<translation id="4169535189173047238">অনুমতি দেবেন না</translation>
+<translation id="2170088579611075216">ভিআর প্রেজেন্টেশন শুরু করার অনুমতি দিন</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ca.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ca.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ca">
-<translation id="1006017844123154345">Obre en línia</translation>
-<translation id="1028699632127661925">S'està enviant a <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">S'està afegint <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">De llocs web</translation>
-<translation id="1049743911850919806">Incògnit</translation>
-<translation id="10614374240317010">Contrasenyes que no es desen mai</translation>
-<translation id="1067922213147265141">Altres serveis de Google</translation>
-<translation id="1068672505746868501">No tradueixis mai les pàgines en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Si canvies l'extensió del fitxer, pot ser que el fitxer s'obri en una altra aplicació i pot arribar a ser perillós per al dispositiu.</translation>
-<translation id="1100066534610197918">Obre en una pestanya d'un grup</translation>
-<translation id="1105960400813249514">Captura de pantalla</translation>
-<translation id="1111673857033749125">Les adreces d'interès desades als altres dispositius es mostraran aquí.</translation>
-<translation id="1113597929977215864">Mostra la visualització simplificada</translation>
-<translation id="1121094540300013208">Informes d'ús i d'error</translation>
-<translation id="1124772482545689468">Usuari</translation>
-<translation id="1129510026454351943">Detalls: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Hi ha 1 baixada pendent.}other{Hi ha # baixades pendents.}}</translation>
-<translation id="1145536944570833626">Suprimeix les dades existents.</translation>
-<translation id="1146678959555564648">Activa el mode RV</translation>
-<translation id="116280672541001035">Dades utilitzades</translation>
-<translation id="1171770572613082465">Toca el botó Llocs populars per veure les tendències en llocs web</translation>
-<translation id="1173894706177603556">Canvia el nom</translation>
-<translation id="1178581264944972037">Posa en pausa</translation>
-<translation id="1181037720776840403">Suprimeix</translation>
-<translation id="1188239144602654184">Entra a la realitat augmentada</translation>
-<translation id="1197267115302279827">Mou les adreces d'interès</translation>
-<translation id="119944043368869598">Esborra-ho tot</translation>
-<translation id="1201402288615127009">Següent</translation>
-<translation id="1204037785786432551">Baixa l'enllaç</translation>
-<translation id="1206892813135768548">Copia el text de l'enllaç</translation>
-<translation id="1208340532756947324">Per sincronitzar i personalitzar el contingut en tots els dispositius, activa la sincronització</translation>
-<translation id="1209206284964581585">Amaga per ara</translation>
-<translation id="1227058898775614466">Historial de navegació</translation>
-<translation id="1231733316453485619">Vols activar la sincronització?</translation>
-<translation id="123724288017357924">Carrega pàgina actual; ignora contingut en memòria</translation>
-<translation id="124116460088058876">Més idiomes</translation>
-<translation id="124678866338384709">Tanca la pestanya actual</translation>
-<translation id="1258753120186372309">Doodle de Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Fes cerques i explora contingut</translation>
-<translation id="1264974993859112054">Esports</translation>
-<translation id="1266864766717917324">No s'ha pogut compartir <ph name="CONTENT_TYPE" />.</translation>
-<translation id="1272079795634619415">Atura</translation>
-<translation id="1283039547216852943">Toca per desplegar</translation>
-<translation id="1285320974508926690">No tradueixis mai aquest lloc</translation>
-<translation id="1291207594882862231">Esborra l'historial, les galetes, les dades dels llocs web, la memòria cau, etc.</translation>
-<translation id="129382876167171263">Els fitxers desats pels llocs web es mostren aquí</translation>
-<translation id="129553762522093515">Tancades recentment</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" />: s'ha enviat des del dispositiu <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Agrupa les pestanyes</translation>
-<translation id="1327257854815634930">L'historial de navegació està obert</translation>
-<translation id="1331212799747679585">No es pot actualitzar Chrome. Més opcions</translation>
-<translation id="1332501820983677155">Dreceres per a funcions de Google Chrome</translation>
-<translation id="1360432990279830238">Vols tancar la sessió i desactivar la sincronització?</translation>
-<translation id="1369915414381695676">El lloc <ph name="SITE_NAME" /> s'ha afegit</translation>
-<translation id="1373696734384179344">No hi ha prou memòria per baixar el contingut seleccionat.</translation>
-<translation id="1376578503827013741">S'està calculant…</translation>
-<translation id="1383876407941801731">Cerca</translation>
-<translation id="1384959399684842514">La baixada s'ha posat en pausa</translation>
-<translation id="1386674309198842382">Actiu fa <ph name="LAST_UPDATED" /> dies</translation>
-<translation id="1397811292916898096">Cerca amb <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Inserit a <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">No segueixis</translation>
-<translation id="1407135791313364759">Obre-les totes</translation>
-<translation id="1409426117486808224">Visualització simplificada de les pestanyes obertes</translation>
-<translation id="1409879593029778104">No s'ha baixat el fitxer <ph name="FILE_NAME" /> perquè ja existeix.</translation>
-<translation id="1414981605391750300">S'està contactant amb Google. Aquest procés pot trigar una estona…</translation>
-<translation id="1416550906796893042">Versió de l'aplicació</translation>
-<translation id="1430915738399379752">Imprimeix</translation>
-<translation id="1446450296470737166">Permet control total disp. MIDI</translation>
-<translation id="1450753235335490080">No es pot compartir <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Aquest permís està desactivat a la configuració d'Android</translation>
-<translation id="1477626028522505441">No s'ha pogut baixar <ph name="FILE_NAME" /> a causa de problemes amb el servidor.</translation>
-<translation id="1506061864768559482">Motor de cerca</translation>
-<translation id="1513352483775369820">Adreces interès i historial web</translation>
-<translation id="1513858653616922153">Suprimeix la contrasenya</translation>
-<translation id="1516229014686355813">La funció Toca per cercar envia la paraula seleccionada i la pàgina actual com a context a la Cerca de Google. La pots desactivar a <ph name="BEGIN_LINK" />Configuració<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Actiu avui</translation>
-<translation id="1544826120773021464">Per gestionar el teu Compte de Google, toca el botó Gestiona el compte</translation>
-<translation id="1549000191223877751">Mou a l'altra finestra</translation>
-<translation id="1553358976309200471">Actualitza Chrome</translation>
-<translation id="1569387923882100876">Dispositiu connectat</translation>
-<translation id="1571304935088121812">Copia el nom d'usuari</translation>
-<translation id="1612196535745283361">Chrome necessita accedir a la ubicació per poder cercar dispositius, però aquesta funció està <ph name="BEGIN_LINK" />desactivada en aquest dispositiu<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Càmera</translation>
-<translation id="1623104350909869708">Impedeix que aquesta pàgina creï quadres de diàleg addicionals</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Suprimeix 1 element seleccionat}other{Suprimeix # elements seleccionats}}</translation>
-<translation id="164269334534774161">Es mostra una còpia sense connexió d'aquesta pàgina creada el dia <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historial</translation>
-<translation id="1647391597548383849">Accés a la càmera</translation>
-<translation id="1660204651932907780">Permet que els llocs web reprodueixin so (opció recomanada)</translation>
-<translation id="1670399744444387456">Configuració bàsica</translation>
-<translation id="1671236975893690980">Baixada pendent…</translation>
-<translation id="1672586136351118594">No m'ho tornis a mostrar</translation>
-<translation id="1692118695553449118">La sincronització està activada</translation>
-<translation id="169515064810179024">Impedeix que els llocs web accedeixin als sensors de moviment</translation>
-<translation id="1717218214683051432">Sensors de moviment</translation>
-<translation id="1718835860248848330">Darrera hora</translation>
-<translation id="1736419249208073774">Explora</translation>
-<translation id="1743802530341753419">Pregunta'm abans de permetre que els llocs web es connectin a un dispositiu (opció recomanada)</translation>
-<translation id="1749561566933687563">Sincronitzeu les adreces d'interès</translation>
-<translation id="17513872634828108">Pestanyes obertes</translation>
-<translation id="1779089405699405702">Descodificador d'imatges</translation>
-<translation id="1782483593938241562">Data de finalització: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Instal·lat</translation>
-<translation id="1792959175193046959">Canvia la ubicació predeterminada de baixada en qualsevol moment</translation>
-<translation id="1807246157184219062">Clar</translation>
-<translation id="1810845389119482123">La configuració de la sincronització inicial no ha finalitzat</translation>
-<translation id="1821253160463689938">Utilitza galetes per recordar les teves preferències, fins i tot si no visites aquestes pàgines</translation>
-<translation id="1829244130665387512">Cerca a la pàgina</translation>
-<translation id="1853692000353488670">Pestanya d'incògnit nova</translation>
-<translation id="1856325424225101786">Vols restablir el mode bàsic?</translation>
-<translation id="1868024384445905608">Ara Chrome baixa els fitxers més ràpid</translation>
-<translation id="1883903952484604915">Els meus fitxers</translation>
-<translation id="1887786770086287077">L'accés a la ubicació està desactivat en aquest dispositiu. Activa'l a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> s'obrirà a Chrome. En continuar, acceptes les <ph name="BEGIN_LINK1" />condicions del servei<ph name="END_LINK1" /> i l'<ph name="BEGIN_LINK2" />avís de privadesa<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="1919345977826869612">Anuncis</translation>
-<translation id="1919950603503897840">Selecciona contactes</translation>
-<translation id="1922076542920281912">Perquè Chrome pugui accedir a la teva ubicació, també l'has d'activar a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Actualitzacions</translation>
-<translation id="19288952978244135">Torna a obrir Chrome.</translation>
-<translation id="1933845786846280168">Pestanya seleccionada</translation>
-<translation id="194341124344773587">Activa el permís per a Chrome a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Desa les contrasenyes</translation>
-<translation id="1952172573699511566">Quan sigui possible, els llocs web mostraran el text en el teu idioma preferit.</translation>
-<translation id="1960290143419248813">Aquesta versió d'Android ja no admet les actualitzacions de Chrome</translation>
-<translation id="1966710179511230534">Actualitzeu les dades d'inici de sessió.</translation>
-<translation id="1974060860693918893">Configuració avançada</translation>
-<translation id="1984705450038014246">Sincronitza les dades de Chrome</translation>
-<translation id="1984937141057606926">Permeses, excepte les de tercers</translation>
-<translation id="1986685561493779662">El nom ja existeix</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> (botó <ph name="LINK_NAME" />)</translation>
-<translation id="1989112275319619282">Examina</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> es vol vincular</translation>
-<translation id="1994173015038366702">URL del lloc web</translation>
-<translation id="2000419248597011803">Envia al motor de cerca predeterminat algunes galetes i cerques de la barra d'adreces i del quadre de cerca</translation>
-<translation id="2002537628803770967">Targetes de crèdit i adreces que fan servir Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fitxer}other{# fitxers}}</translation>
-<translation id="2017836877785168846">Esborra l'historial i les complecions automàtiques a la barra d'adreces.</translation>
-<translation id="2021896219286479412">Controls de pantalla completa</translation>
-<translation id="2038563949887743358">Activa Mostra com a ordinador</translation>
-<translation id="2041019821020695769">Perquè Chrome et pugui enviar notificacions, també has d'activar-les a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> també té dades a Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">El lloc web s'ha posat en pausa</translation>
-<translation id="2063713494490388661">Toca per cercar</translation>
-<translation id="2067805253194386918">text</translation>
-<translation id="2079545284768500474">Desfés</translation>
-<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER" /> de <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">So</translation>
-<translation id="2096012225669085171">Sincronitza i personalitza el contingut en tots els dispositius</translation>
-<translation id="2100273922101894616">Inici de sessió automàtic</translation>
-<translation id="2100314319871056947">Prova de compartir el text en fragments més petits</translation>
-<translation id="2107397443965016585">Pregunta'm abans de permetre que els llocs web reprodueixin contingut protegit (opció recomanada)</translation>
-<translation id="2111511281910874386">Ves a la pàgina</translation>
-<translation id="2122601567107267586">L'aplicació no s'ha pogut obrir</translation>
-<translation id="2126426811489709554">Amb la tecnologia de Chrome</translation>
-<translation id="2131665479022868825">Dades estalviades: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Pestanya <ph name="TAB_TITLE" /> tancada</translation>
-<translation id="2139186145475833000">Afegeix a pantalla d'inici</translation>
-<translation id="2146738493024040262">Obre l'aplicació instantània</translation>
-<translation id="2148716181193084225">Avui</translation>
-<translation id="2154484045852737596">Edita la targeta</translation>
-<translation id="2154710561487035718">Copia l'URL</translation>
-<translation id="2156074688469523661">Llocs restants (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Per compartir elements del telèfon amb un altre dispositiu, activa la sincronització a la configuració de Chrome en tots dos dispositius</translation>
-<translation id="2170088579611075216">Permet i activa el mode RV</translation>
-<translation id="218608176142494674">S'estan compartint</translation>
-<translation id="2227444325776770048">Continua com a <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sincronització i serveis de Google</translation>
-<translation id="2259659629660284697">Exporta les contrasenyes…</translation>
-<translation id="2268044343513325586">Restringeix</translation>
-<translation id="2286841657746966508">Adreça de facturació</translation>
-<translation id="2289270750774289114">Pregunta'm quan un lloc web vulgui descobrir dispositius Bluetooth propers (opció recomanada)</translation>
-<translation id="230115972905494466">No s'ha trobat cap dispositiu compatible</translation>
-<translation id="2315043854645842844">El sistema operatiu no permet seleccionar el certificat del client.</translation>
-<translation id="2318045970523081853">Toca per fer una trucada</translation>
-<translation id="2321086116217818302">S'estan preparant les contrasenyes…</translation>
-<translation id="2321958826496381788">Arrossega el control lliscant fins que puguis llegir aquest text còmodament. El text ha de ser almenys així de gran després de tocar dos cops un paràgraf.</translation>
-<translation id="2323763861024343754">Emmagatzematge del lloc web</translation>
-<translation id="2328985652426384049">No es pot iniciar la sessió</translation>
-<translation id="2330129964253841015">T'avisa si les contrasenyes es posen en perill</translation>
-<translation id="2349710944427398404">Dades totals utilitzades per Chrome, com ara comptes, adreces d'interès i opcions de configuració desades</translation>
-<translation id="2353636109065292463">S'està comprovant la connexió a Internet</translation>
-<translation id="2359808026110333948">Continua</translation>
-<translation id="2369533728426058518">pestanyes obertes</translation>
-<translation id="2387895666653383613">Canvia la mida del text</translation>
-<translation id="2394602618534698961">Els fitxers que baixes es mostren aquí</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">En iniciar la sessió al Compte de Google, aquesta funció està sempre activada</translation>
-<translation id="2410754283952462441">Tria un compte</translation>
-<translation id="2414886740292270097">Fosc</translation>
-<translation id="2416359993254398973">Per visitar aquest lloc web, Chrome necessita permís per accedir a la teva càmera.</translation>
-<translation id="2426805022920575512">Tria un altre compte</translation>
-<translation id="2433507940547922241">Aparença</translation>
-<translation id="2434158240863470628">S'ha completat la baixada <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Accés a la ubicació</translation>
-<translation id="2450083983707403292">Vols tornar a baixar el fitxer <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Notificacions</translation>
-<translation id="2490684707762498678">Gestionades per <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Assistent de Google a Chrome</translation>
-<translation id="2496180316473517155">Historial de navegació</translation>
-<translation id="2497852260688568942">L'administrador ha desactivat la sincronització</translation>
-<translation id="2498359688066513246">Ajuda i suggeriments </translation>
-<translation id="2501278716633472235">Torna</translation>
-<translation id="2513403576141822879">Per trobar més opcions de configuració relacionades amb la privadesa, la seguretat i la recollida de dades, consulta <ph name="BEGIN_LINK" />Sincronització i serveis de Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">En el mode bàsic, Chrome carrega les pàgines més ràpidament i utilitza fins a un 60 per cent menys de dades. Per optimitzar les pàgines que visites, Chrome envia el teu trànsit web a Google. <ph name="BEGIN_LINK" />Més informació<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Envia a Google els URL de les pàgines que visites</translation>
-<translation id="2532336938189706096">Visualització web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> elements suprimits</translation>
-<translation id="2536728043171574184">S'està mostrant una còpia sense connexió d'aquesta pàgina</translation>
-<translation id="2546283357679194313">Dades de llocs web i galetes</translation>
-<translation id="2567385386134582609">IMATGE</translation>
-<translation id="257088987046510401">Temes</translation>
-<translation id="2570922361219980984">L'accés a la ubicació també està desactivat en aquest dispositiu. Activa'l a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Vista desplegada (feu clic per replegar-la)</translation>
-<translation id="2581165646603367611">Amb aquesta acció, se suprimiran les galetes, la memòria cau i altres dades de llocs que Chrome no consideri importants.</translation>
-<translation id="2586657967955657006">Porta-retalls</translation>
-<translation id="2587052924345400782">Versió nova disponible</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Número de targeta</translation>
-<translation id="2621115761605608342">Permet JavaScript en un lloc web concret.</translation>
-<translation id="2625189173221582860">S'ha copiat la contrasenya</translation>
-<translation id="2631006050119455616">Dades estalviades</translation>
-<translation id="2647434099613338025">Afegeix un idioma</translation>
-<translation id="2650751991977523696">Vols tornar a baixar el fitxer?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# fitxer d'àudio}other{# fitxers d'àudio}}</translation>
-<translation id="2653659639078652383">Envia</translation>
-<translation id="2677748264148917807">Surt</translation>
-<translation id="2704606927547763573">Copiada</translation>
-<translation id="2707726405694321444">Actualitza la pàgina</translation>
-<translation id="2709516037105925701">Emplenament automàtic</translation>
-<translation id="2717722538473713889">Adreces electròniques</translation>
-<translation id="2728754400939377704">Ordena per lloc web</translation>
-<translation id="2744248271121720757">Toca una paraula per fer una cerca a l'instant o per veure accions relacionades</translation>
-<translation id="2760989362628427051">Activa el tema fosc quan el teu dispositiu tingui activat aquest tema o el mode d'estalvi de bateria</translation>
-<translation id="2762000892062317888">ara mateix</translation>
-<translation id="2777555524387840389">Queden <ph name="SECONDS" /> segons</translation>
-<translation id="2779651927720337254">ha fallat</translation>
-<translation id="2781151931089541271">Queda 1 segon</translation>
-<translation id="2801022321632964776">Fes l'actualització per veure la darrera versió de Chrome en el teu idioma</translation>
-<translation id="2810645512293415242">La pàgina s'ha simplificat per estalviar dades i carregar-se més ràpidament.</translation>
-<translation id="281504910091592009">Consulta i gestiona les contrasenyes desades al <ph name="BEGIN_LINK" />Compte de Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Per accedir a les adreces d'interès des de tots els dispositius, inicia la sessió i activa la sincronització</translation>
-<translation id="2822354292072154809">Confirmes que vols restablir tots els permisos del lloc web concedits a <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Toqueu el botó Enrere per sortir de la pantalla completa.</translation>
-<translation id="2842985007712546952">Carpeta principal</translation>
-<translation id="2858138569776157458">Llocs populars</translation>
-<translation id="2860954141821109167">Comprova que hi hagi una aplicació de telèfon activada en aquest dispositiu</translation>
-<translation id="2870560284913253234">Lloc web</translation>
-<translation id="2874939134665556319">Pista anterior</translation>
-<translation id="2876369937070532032">Envia a Google els URL d'algunes de les pàgines que visites quan la teva seguretat està en risc</translation>
-<translation id="2888126860611144412">Sobre Chrome</translation>
-<translation id="2891154217021530873">Atura la càrrega de la pàgina</translation>
-<translation id="2893180576842394309">És possible que Google utilitzi el teu historial per personalitzar la Cerca i altres serveis de Google</translation>
-<translation id="2898264748040935573">Edita la contrasenya emmagatzemada</translation>
-<translation id="2900528713135656174">Crea un esdeveniment</translation>
-<translation id="290376772003165898">La pàgina no està en <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">La llista de dispositius amb què es compartirà una pestanya ocupa tota la pantalla.</translation>
-<translation id="2910701580606108292">Pregunta'm abans de permetre que els llocs web reprodueixin contingut protegit</translation>
-<translation id="2913331724188855103">Permet que els llocs web desin i llegeixin les dades de les galetes (opció recomanada)</translation>
-<translation id="2923908459366352541">El nom no és vàlid</translation>
-<translation id="2932150158123903946">Emmagatzematge de Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">La pestanya de previsualització està tancada</translation>
-<translation id="2956410042958133412"><ph name="PARENT_NAME_1" /> i <ph name="PARENT_NAME_2" /> gestionen aquest compte.</translation>
-<translation id="2962095958535813455">S'ha canviat a les pestanyes d'incògnit</translation>
-<translation id="2968755619301702150">Lector de certificats</translation>
-<translation id="2979025552038692506">Pestanya d'incògnit seleccionada</translation>
-<translation id="2987620471460279764">Text compartit d'un altre dispositiu</translation>
-<translation id="2989523299700148168">Visitats últimament</translation>
-<translation id="2996291259634659425">Creeu una frase de contrasenya</translation>
-<translation id="2996809686854298943">Es necessita un URL</translation>
-<translation id="300526633675317032">Amb aquesta acció s'esborraran <ph name="SIZE_IN_KB" /> d'emmagatzematge del lloc web.</translation>
-<translation id="3016635187733453316">Comprova que el dispositiu estigui connectat a Internet</translation>
-<translation id="3029613699374795922">S'han baixat <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Les frases de contrasenya no coincideixen</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Obteniu ajuda<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">La ubicació està desactivada; activa-la a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Pots activar la sincronització en qualsevol moment des de la configuració</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> adreça d'interès}other{<ph name="BOOKMARKS_COUNT_MANY" /> adreces d'interès}}</translation>
-<translation id="3089395242580810162">Obre en pestanya d'incògnit</translation>
-<translation id="3115898365077584848">Mostra la informació</translation>
-<translation id="3123473560110926937">Bloquejat en alguns llocs web</translation>
-<translation id="3137521801621304719">Surt del mode d'incògnit</translation>
-<translation id="3143515551205905069">Cancel·la la sincronització</translation>
-<translation id="3157842584138209013">Consulta la quantitat de dades que has estalviat des del botó Més opcions</translation>
-<translation id="3166827708714933426">Dreceres per a pestanyes i finestres</translation>
-<translation id="3181954750937456830">Navegació segura (et protegeix a tu i al teu dispositiu de llocs web perillosos)</translation>
-<translation id="3190152372525844641">Activeu els permisos per a Chrome a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> de dades desades</translation>
-<translation id="3205824638308738187">Falta poc per acabar.</translation>
-<translation id="3207960819495026254">S'ha afegit a les adreces d'interès.</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> s'ha suprimit</translation>
-<translation id="321773570071367578">Si oblideu la frase de contrasenya o voleu canviar aquesta configuració, <ph name="BEGIN_LINK" />restabliu la sincronització<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Micròfon</translation>
-<translation id="3232754137068452469">Aplicació web</translation>
-<translation id="3236059992281584593">Queda 1 minut</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Afegeix aquesta pàgina a les adreces d'interès</translation>
-<translation id="3259831549858767975">Redueix la mida de tots els elements de la pàgina</translation>
-<translation id="3269093882174072735">Carrega la imatge</translation>
-<translation id="3269956123044984603">Per accedir a les pestanyes dels altres dispositius que tinguis, activa Sincronitza dades automàticament a la configuració del compte a Android.</translation>
-<translation id="3277252321222022663">Permet que els llocs web accedeixin als sensors (opció recomanada)</translation>
-<translation id="3282568296779691940">Inicia la sessió a Chrome</translation>
-<translation id="3288003805934695103">Torneu a carregar la pàgina</translation>
-<translation id="32895400574683172">Es permeten les notificacions</translation>
-<translation id="3295530008794733555">Navega més de pressa. Utilitza menys dades.</translation>
-<translation id="3295602654194328831">Amaga la informació</translation>
-<translation id="3298243779924642547">Mode bàsic</translation>
-<translation id="3303414029551471755">Voleu baixar el contingut?</translation>
-<translation id="3306398118552023113">Aquesta aplicació s'està executant a Chrome</translation>
-<translation id="3315103659806849044">Estàs personalitzant la configuració de la sincronització i del servei de Google. Per acabar d'activar la sincronització, toca el botó Confirma que hi ha cap a la part inferior de la pantalla. Navega cap amunt</translation>
-<translation id="3328801116991980348">Informació del lloc web</translation>
-<translation id="3333961966071413176">Tots els contactes</translation>
-<translation id="3334729583274622784">Vols canviar l'extensió del fitxer?</translation>
-<translation id="3341058695485821946">Consulta la quantitat de dades que has estalviat</translation>
-<translation id="3350687908700087792">Tanca totes les pestanyes d'incògnit</translation>
-<translation id="3353615205017136254">Pàgina en mode bàsic oferida per Google. Toca el botó Carrega la versió original per carregar la pàgina original.</translation>
-<translation id="3367813778245106622">Torna a iniciar la sessió per començar la sincronització</translation>
-<translation id="3374023511497244703">Les adreces d'interès, l'historial, les contrasenyes i altres dades de Chrome ja no se sincronitzaran amb el teu Compte de Google</translation>
-<translation id="3384347053049321195">Comparteix la imatge</translation>
-<translation id="3386292677130313581">Pregunta'm abans de permetre que els llocs web sàpiguen la meva ubicació (opció recomanada)</translation>
-<translation id="3387650086002190359">No s'ha pogut baixar <ph name="FILE_NAME" /> a causa d'errors amb el sistema de fitxers.</translation>
-<translation id="3389286852084373014">El text és massa llarg</translation>
-<translation id="3398320232533725830">Obre el gestor d'adreces d'interès</translation>
-<translation id="3414952576877147120">Mida:</translation>
-<translation id="3443221991560634068">Torna a carregar la pàgina actual</translation>
-<translation id="3445014427084483498">Ara mateix</translation>
-<translation id="3478363558367712427">Pots triar el motor de cerca que prefereixis</translation>
+<translation id="6910211073230771657">Suprimit</translation>
+<translation id="6965382102122355670">D'acord</translation>
+<translation id="5301954838959518834">D'acord</translation>
+<translation id="7658239707568436148">Cancel·la</translation>
 <translation id="3479552764303398839">Ara no</translation>
-<translation id="3492207499832628349">Pestanya d'incògnit nova</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Més informació<ph name="END_LINK" /> sobre el contingut suggerit</translation>
-<translation id="3513704683820682405">Realitat augmentada</translation>
-<translation id="3518985090088779359">Accepta i continua</translation>
-<translation id="3522247891732774234">Hi ha una actualització disponible. Més opcions</translation>
-<translation id="3524138585025253783">Interfície d'usuari per a desenvolupadors</translation>
-<translation id="3527085408025491307">Carpeta</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> kB disponibles</translation>
-<translation id="3549657413697417275">Cerca a l'historial</translation>
-<translation id="3557336313807607643">Afegeix als contactes</translation>
-<translation id="3566923219790363270">Encara s'està preparant Chrome per a la RV. Reinicia'l més tard.</translation>
-<translation id="3568688522516854065">Inicia la sessió i activa la sincronització per accedir a les pestanyes dels altres dispositius que tinguis</translation>
-<translation id="3587482841069643663">Tots</translation>
-<translation id="358794129225322306">Permet que un lloc web baixi diversos fitxers automàticament.</translation>
-<translation id="3590487821116122040">Emmagatzematge de llocs web que Chrome no considera important (com ara llocs web sense configuració desada o aquells que no visites sovint)</translation>
-<translation id="3599863153486145794">Esborra l'historial de tots els dispositius en què tinguis iniciada la sessió. A <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> trobaràs altres maneres d'explorar l'historial de navegació del Compte de Google.</translation>
-<translation id="3600792891314830896">Silencia els llocs web que reprodueixen so</translation>
-<translation id="3616113530831147358">Àudio</translation>
-<translation id="3631987586758005671">S'està compartint amb <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Mostra la contrasenya</translation>
-<translation id="363596933471559332">Inicia la sessió automàticament als llocs web amb les credencials emmagatzemades. Si la funció està desactivada, se us demana sempre que les verifiqueu per iniciar la sessió en un lloc web.</translation>
-<translation id="3658159451045945436">Si el restableixes, s'esborrarà l'historial de l'estalvi de dades, inclosa la llista de llocs web visitats.</translation>
-<translation id="3692944402865947621">No s'ha pogut baixar <ph name="FILE_NAME" /> perquè no es pot trobar la ubicació d'emmagatzematge.</translation>
-<translation id="3714981814255182093">Obre la barra de cerca</translation>
-<translation id="3716182511346448902">Com que aquesta pàgina fa servir massa memòria, Chrome l'ha posat en pausa.</translation>
-<translation id="3730075448226062617">Perquè Chrome pugui accedir al micròfon, també has d'activar el micròfon a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Afegit a les adreces de: <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sincronització en segon pla</translation>
-<translation id="3771001275138982843">No s'ha pogut baixar l'actualització</translation>
-<translation id="3771033907050503522">Pestanyes d'incògnit</translation>
-<translation id="3773755127849930740">Per permetre la vinculació, <ph name="BEGIN_LINK" />activa el Bluetooth<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">Envia als teus dispositius</translation>
-<translation id="3778956594442850293">S'ha afegit a la pantalla d'inici</translation>
-<translation id="3789841737615482174">Instal·la</translation>
-<translation id="3810838688059735925">Vídeo</translation>
-<translation id="3810973564298564668">Gestiona</translation>
-<translation id="381841723434055211">Números de telèfon</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> baixades suprimides</translation>
-<translation id="3822502789641063741">Esborrem emmagatz. lloc web?</translation>
-<translation id="385051799172605136">Enrere</translation>
-<translation id="3859306556332390985">Avança</translation>
-<translation id="3894427358181296146">Afegeix una carpeta</translation>
-<translation id="3895926599014793903">Força l'activació del zoom</translation>
-<translation id="3912508018559818924">Estem cercant el millor contingut del web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combina les meves dades</translation>
-<translation id="393697183122708255">La cerca per veu no està disponible</translation>
-<translation id="395206256282351086">S'han desactivat els suggeriments de cerques i llocs web</translation>
-<translation id="3955193568934677022">Permet que els llocs web reprodueixin contingut protegit (opció recomanada)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome carregarà la pàgina quan estigui a punt}other{Chrome carregarà les pàgines quan estiguin a punt}}</translation>
-<translation id="3963007978381181125">L'encriptació de frases de contrasenya no inclou les formes de pagament ni les adreces de Google Pay. Només els usuaris que sàpiguen la teva frase de contrasenya poden llegir les dades que encriptes. La frase de contrasenya no s'envia a Google, i Google tampoc no l'emmagatzema. Si l'oblides o vols canviar aquesta opció, has de restablir la sincronització. <ph name="BEGIN_LINK" />Més informació<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">S'ha completat la baixada</translation>
-<translation id="397583555483684758">La sincronització ha deixat de funcionar</translation>
-<translation id="3976396876660209797">Suprimeix aquesta drecera i torna-la a crear</translation>
-<translation id="3985215325736559418">Vols tornar a baixar <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Copia l'enllaç</translation>
-<translation id="3988213473815854515">La ubicació es permet</translation>
-<translation id="3988466920954086464">Consulta els resultats de la cerca instantània en aquest tauler</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Emmagatzematge no important</translation>
-<translation id="4000212216660919741">Pàgina d'inici sense connexió</translation>
+<translation id="5317780077021120954">Desa</translation>
+<translation id="4570913071927164677">Detalls</translation>
+<translation id="8730621377337864115">Fet</translation>
+<translation id="8261506727792406068">Suprimeix</translation>
+<translation id="1181037720776840403">Suprimeix</translation>
+<translation id="5939518447894949180">Restableix</translation>
 <translation id="4002066346123236978">Títol</translation>
-<translation id="4008040567710660924">Permet les galetes d'un lloc web concret.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Pista següent</translation>
-<translation id="4048707525896921369">Obtén informació sobre temes dels llocs web sense sortir de la pàgina. La funció Toca per cercar envia una paraula i el context que l'envolta a la Cerca de Google i torna definicions, imatges, resultats de la cerca i altres detalls.
+<translation id="5916664084637901428">Activat</translation>
+<translation id="5860033963881614850">Desactivat</translation>
+<translation id="6165508094623778733">Més informació</translation>
+<translation id="6042308850641462728">Més</translation>
+<translation id="6040143037577758943">Tanca</translation>
+<translation id="780301667611848630">No, gràcies</translation>
+<translation id="1201402288615127009">Següent</translation>
+<translation id="2359808026110333948">Continua</translation>
+<translation id="2653659639078652383">Envia</translation>
+<translation id="2079545284768500474">Desfés</translation>
+<translation id="7649070708921625228">Ajuda</translation>
+<translation id="2148716181193084225">Avui</translation>
+<translation id="7781829728241885113">Ahir</translation>
+<translation id="6945221475159498467">Selecciona</translation>
+<translation id="7791543448312431591">Afegeix</translation>
+<translation id="6527303717912515753">Comparteix</translation>
+<translation id="1383876407941801731">Cerca</translation>
+<translation id="3115898365077584848">Mostra la informació</translation>
+<translation id="3295602654194328831">Amaga la informació</translation>
+<translation id="3987993985790029246">Copia l'enllaç</translation>
+<translation id="2704606927547763573">Copiada</translation>
+<translation id="8725066075913043281">Torna-ho a provar</translation>
+<translation id="385051799172605136">Enrere</translation>
+<translation id="8131740175452115882">Confirma</translation>
+<translation id="5300589172476337783">Mostra</translation>
+<translation id="1124772482545689468">Usuari</translation>
+<translation id="8609465669617005112">Desplaça cap amunt</translation>
+<translation id="6746124502594467657">Mou avall</translation>
+<translation id="8249310407154411074">Mou a la part superior</translation>
+<translation id="8428213095426709021">Configuració</translation>
+<translation id="2498359688066513246">Ajuda i suggeriments</translation>
+<translation id="8378714024927312812">Gestionat per la teva organització</translation>
+<translation id="9019902583201351841">Gestionat pels pares</translation>
+<translation id="4645575059429386691">Gestionat pels pares</translation>
+<translation id="4883854917563148705">Les opcions de configuració gestionades no es poden restablir</translation>
+<translation id="4307992518367153382">Configuració bàsica</translation>
+<translation id="1974060860693918893">Configuració avançada</translation>
+<translation id="1146678959555564648">Activa el mode RV</translation>
+<translation id="987264212798334818">General</translation>
+<translation id="4275663329226226506">Multimèdia</translation>
+<translation id="4759238208242260848">Baixades</translation>
+<translation id="218608176142494674">S'estan compartint</translation>
+<translation id="8004582292198964060">Navegador</translation>
+<translation id="1105960400813249514">Captura de pantalla</translation>
+<translation id="4875775213178255010">Suggeriments de contingut</translation>
+<translation id="2021896219286479412">Controls de pantalla completa</translation>
+<translation id="4587589328781138893">Llocs web</translation>
+<translation id="4943703118917034429">Realitat virtual</translation>
+<translation id="1928696683969751773">Actualitzacions</translation>
+<translation id="6064125863973209585">Baixades completades</translation>
+<translation id="5342314432463739672">Sol·licituds de permís</translation>
+<translation id="629730747756840877">Compte</translation>
+<translation id="82609232232243542">Inicia la sessió a Brave</translation>
+<translation id="7956662517480676674">Sincronització i serveis de Brave Software</translation>
+<translation id="5294439808117722387">Estàs personalitzant la configuració de la sincronització i del servei de Brave Software. Per acabar d'activar la sincronització, toca el botó Confirma que hi ha cap a la part inferior de la pantalla. Navega cap amunt</translation>
+<translation id="2096012225669085171">Sincronitza i personalitza el contingut en tots els dispositius</translation>
+<translation id="1692118695553449118">La sincronització està activada</translation>
+<translation id="5514904542973294328">Opció desactivada per l'administrador d'aquest dispositiu</translation>
+<translation id="6447211988989208781">Controls d'activitat de Brave Software</translation>
+<translation id="4882831918239250449">Controla com s'utilitza l'historial de navegació per personalitzar la Cerca, els anuncis i molt més</translation>
+<translation id="7431991332293347422">Controla com s'utilitza l'historial de navegació per personalitzar la Cerca i més</translation>
+<translation id="6303969859164067831">Tanca la sessió i desactiva la sincronització</translation>
+<translation id="1125261911132334651">Gestiona el teu Compte de Brave Software</translation>
+<translation id="6406506848690869874">Sincronització</translation>
+<translation id="714362445477979774">Sincronitza les dades de Brave</translation>
+<translation id="4314815835985389558">Gestiona la sincronització</translation>
+<translation id="5428209950370661546">Altres serveis de Brave Software</translation>
+<translation id="7704317875155739195">Completa automàticament les cerques i els URL</translation>
+<translation id="2000419248597011803">Envia al motor de cerca predeterminat algunes galetes i cerques de la barra d'adreces i del quadre de cerca</translation>
+<translation id="7981313251711023384">Carrega les pàgines prèviament per poder-hi navegar i fer cerques més de pressa</translation>
+<translation id="1821253160463689938">Utilitza galetes per recordar les teves preferències, fins i tot si no visites aquestes pàgines</translation>
+<translation id="6697492270171225480">Mostra suggeriments de pàgines similars quan no se'n trobi una</translation>
+<translation id="8109318360573330108">Envia a Brave Software l'URL d'una pàgina que estàs provant de visitar</translation>
+<translation id="8438566539970814960">Millora les cerques i la navegació</translation>
+<translation id="284843628681142937">Envia a Brave Software els URL de les pàgines que visites</translation>
+<translation id="7222718784508482526">Per trobar més opcions de configuració relacionades amb la privadesa, la seguretat i la recollida de dades, consulta <ph name="BEGIN_LINK"/>Sincronització i serveis de Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Ajuda a millorar les funcions i el rendiment de Brave</translation>
+<translation id="9063160602596686558">Envia automàticament a Brave Software estadístiques d'ús i informes d'error</translation>
+<translation id="4824958205181053313">Vols cancel·lar la sincronització?</translation>
+<translation id="3058498974290601450">Pots activar la sincronització en qualsevol moment des de la configuració</translation>
+<translation id="3143515551205905069">Cancel·la la sincronització</translation>
+<translation id="1506061864768559482">Motor de cerca</translation>
+<translation id="55737423895878184">Es permeten la ubicació i les notificacions</translation>
+<translation id="3988213473815854515">La ubicació es permet</translation>
+<translation id="32895400574683172">Es permeten les notificacions</translation>
+<translation id="9040142327097499898">Es permeten les notificacions. La ubicació està desactivada en aquest dispositiu.</translation>
+<translation id="305593374596241526">La ubicació està desactivada; activa-la a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Visitats últimament</translation>
+<translation id="6433501201775827830">Tria el motor de cerca</translation>
+<translation id="7177466738963138057">Pots canviar aquesta opció més endavant a Configuració</translation>
+<translation id="3478363558367712427">Pots triar el motor de cerca que prefereixis</translation>
+<translation id="4910889077668685004">Aplicacions de pagament</translation>
+<translation id="5152843274749979095">No hi ha cap aplicació admesa instal·lada</translation>
+<translation id="8812260976093120287">En alguns llocs web, pots fer servir el teu dispositiu per pagar amb les aplicacions de pagament anteriors admeses.</translation>
+<translation id="7764225426217299476">Afegeix una adreça</translation>
+<translation id="5595485650161345191">Edita l'adreça</translation>
+<translation id="5087580092889165836">Afegeix una targeta</translation>
+<translation id="2154484045852737596">Edita la targeta</translation>
+<translation id="6140912465461743537">País/regió</translation>
+<translation id="5659593005791499971">Correu electrònic</translation>
+<translation id="4378154925671717803">Telèfon</translation>
+<translation id="4807098396393229769">Titular de la targeta</translation>
+<translation id="860043288473659153">Nom del titular de la targeta</translation>
+<translation id="2612676031748830579">Número de targeta</translation>
+<translation id="869891660844655955">Data de caducitat</translation>
+<translation id="2286841657746966508">Adreça de facturació</translation>
+<translation id="663059986967017181">Copiada de Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> més}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> més}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> més}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> més}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> més}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> més}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> més}other{<ph name="CONTACT_PREVIEW"/>\u2026 i <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> més}}</translation>
+<translation id="7029809446516969842">Contrasenyes</translation>
+<translation id="1943432128510653496">Desa les contrasenyes</translation>
+<translation id="2100273922101894616">Inici de sessió automàtic</translation>
+<translation id="363596933471559332">Inicia la sessió automàticament als llocs web amb les credencials emmagatzemades. Si la funció està desactivada, se us demana sempre que les verifiqueu per iniciar la sessió en un lloc web.</translation>
+<translation id="6995899638241819463">Rep un advertiment si les contrasenyes queden exposades en l'àmbit d'una violació de les dades</translation>
+<translation id="1534287762301776620">En iniciar la sessió al Compte de Brave Software, aquesta funció està sempre activada</translation>
+<translation id="10614374240317010">Contrasenyes que no es desen mai</translation>
+<translation id="3098842761938485917">Consulta i gestiona les contrasenyes desades al <ph name="BEGIN_LINK"/>Compte de Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Les contrasenyes desades apareixeran aquí.</translation>
+<translation id="8084114998886531721">Contrasenya desada</translation>
+<translation id="2870560284913253234">Lloc web</translation>
+<translation id="8503813439785031346">Nom d'usuari</translation>
+<translation id="6657585470893396449">Contrasenya</translation>
+<translation id="2154710561487035718">Copia l'URL</translation>
+<translation id="1571304935088121812">Copia el nom d'usuari</translation>
+<translation id="5005498671520578047">Copia la contrasenya</translation>
+<translation id="3632295766818638029">Mostra la contrasenya</translation>
+<translation id="1513858653616922153">Suprimeix la contrasenya</translation>
+<translation id="543338862236136125">Edita la contrasenya</translation>
+<translation id="4565377596337484307">Oculta la contrasenya</translation>
+<translation id="8523928698583292556">Suprimeix la contrasenya emmagatzemada</translation>
+<translation id="2898264748040935573">Edita la contrasenya emmagatzemada</translation>
+<translation id="5433691172869980887">S'ha copiat el nom d'usuari</translation>
+<translation id="5534640966246046842">S'ha copiat el lloc web</translation>
+<translation id="2625189173221582860">S'ha copiat la contrasenya</translation>
+<translation id="4550003330909367850">Per veure o copiar la contrasenya aquí, configura el bloqueig de pantalla en aquest dispositiu.</translation>
+<translation id="6154478581116148741">Activa el bloqueig de pantalla a Configuració per exportar les teves contrasenyes d'aquest dispositiu</translation>
+<translation id="4842092870884894799">Es mostra la finestra emergent de generació de contrasenyes</translation>
+<translation id="2259659629660284697">Exporta les contrasenyes…</translation>
+<translation id="133012818630824069">Exporta les contrasenyes emmagatzemades a Brave</translation>
+<translation id="6914783257214138813">Tothom que pugui veure el fitxer exportat podrà veure també les teves contrasenyes.</translation>
+<translation id="2321086116217818302">S'estan preparant les contrasenyes…</translation>
+<translation id="8445448999790540984">No es poden exportar les contrasenyes</translation>
+<translation id="3066461326500799725">Obtén informació sobre com pots utilitzar Brave Software Drive</translation>
+<translation id="729975465115245577">El dispositiu no té cap aplicació per emmagatzemar el fitxer de contrasenyes.</translation>
+<translation id="7682724950699840886">Segueix aquests consells: comprova que hi hagi prou espai al dispositiu i prova d'exportar les contrasenyes de nou.</translation>
+<translation id="1129510026454351943">Detalls: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Desbloqueja la pantalla per copiar la contrasenya</translation>
+<translation id="5515439363601853141">Desbloqueja la pantalla per veure la contrasenya</translation>
+<translation id="6221633008163990886">Desbloqueja per exportar les contrasenyes</translation>
+<translation id="230699814587342492">Contrasenyes de Brave</translation>
+<translation id="6075798973483050474">Editar la pàgina d'inici</translation>
+<translation id="854522910157234410">Obre aquesta pàgina</translation>
+<translation id="2482878487686419369">Notificacions</translation>
+<translation id="6255999984061454636">Suggeriments de contingut</translation>
+<translation id="805047784848435650">Segons l'historial de navegació</translation>
+<translation id="1041308826830691739">De llocs web</translation>
+<translation id="395206256282351086">S'han desactivat els suggeriments de cerques i llocs web</translation>
+<translation id="257088987046510401">Temes</translation>
+<translation id="4650364565596261010">Opció predeterminada del sistema</translation>
+<translation id="7588219262685291874">Activa el tema fosc quan l'estalvi de bateria del dispositiu estigui activat</translation>
+<translation id="2760989362628427051">Activa el tema fosc quan el teu dispositiu tingui activat aquest tema o el mode d'estalvi de bateria</translation>
+<translation id="6381421346744604172">Enfosqueix els llocs web</translation>
+<translation id="5040262127954254034">Privadesa</translation>
+<translation id="4991384657077828949">Ajuda a millorar la seguretat de Brave</translation>
+<translation id="1943176487615318915">Per detectar aplicacions i llocs web perillosos, Brave envia a Brave Software els URL d'algunes de les pàgines que visites, informació limitada del sistema i part del contingut de les pàgines</translation>
+<translation id="3181954750937456830">Navegació segura (et protegeix a tu i al teu dispositiu de llocs web perillosos)</translation>
+<translation id="7315322926489145388">Envia a Brave Software els URL d'algunes de les pàgines que visites quan la teva seguretat està en risc</translation>
+<translation id="2063713494490388661">Toca per cercar</translation>
+<translation id="2369463299479365221">Obtén informació sobre temes dels llocs web sense sortir de la pàgina. La funció Toca per cercar envia una paraula i el context que l'envolta a la Cerca de Brave Software i torna definicions, imatges, resultats de la cerca i altres detalls.
 
 Per ajustar el terme de cerca, mantén-lo premut per seleccionar-lo. Per definir millor la cerca, fes lliscar el tauler cap amunt tot el que puguis i toca el quadre de cerca.</translation>
-<translation id="4056223980640387499">Sèpia</translation>
-<translation id="4060598801229743805">Hi ha opcions disponibles a prop de la part superior de la pantalla</translation>
-<translation id="4062305924942672200">Informació legal</translation>
-<translation id="4084682180776658562">Adreça d'interès</translation>
-<translation id="4084712963632273211">Publicada originalment per <ph name="PUBLISHER_ORIGIN" />, <ph name="BEGIN_DEEMPHASIZED" />oferida per Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Vols suprimir les dades de l'aplicació?</translation>
-<translation id="4099578267706723511">Ajuda a millorar Chrome enviant estadístiques d'ús i informes d'error a Google.</translation>
-<translation id="410351446219883937">Reproducció automàtica</translation>
-<translation id="4116038641877404294">Baixa pàgines per utilitzar-les sense connexió</translation>
-<translation id="4135200667068010335">La llista de dispositius amb què es compartirà una pestanya està tancada.</translation>
-<translation id="4149994727733219643">Visualització simplificada de pàgines web</translation>
-<translation id="4165986682804962316">Configuració del lloc web</translation>
-<translation id="4169535189173047238">No permetis</translation>
-<translation id="4170011742729630528">El servei no està disponible. Torneu-ho a provar més tard.</translation>
-<translation id="4179980317383591987">Dades utilitzades: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Idiomes</translation>
-<translation id="4183868528246477015">Cerca amb Google Lens <ph name="BEGIN_NEW" />Novetat<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Obre en una pestanya nova</translation>
-<translation id="4198423547019359126">No hi ha cap ubicació de baixada disponible</translation>
-<translation id="4209895695669353772">Perquè Google et suggereixi contingut personalitzat, activa la sincronització</translation>
-<translation id="4226663524361240545">És possible que les notificacions facin vibrar el dispositiu</translation>
-<translation id="423219824432660969">Encripta les dades sincronitzades amb la contrasenya de Google del dia <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Obre la configuració</translation>
-<translation id="4256782883801055595">Llicències de programari lliure</translation>
-<translation id="4259722352634471385">S'ha bloquejat la navegació: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copia l'adreça de l'enllaç</translation>
-<translation id="4275663329226226506">Multimèdia</translation>
-<translation id="4278390842282768270">Permès</translation>
-<translation id="429312253194641664">Un lloc web està reproduint contingut multimèdia</translation>
-<translation id="4298388696830689168">Llocs web enllaçats</translation>
-<translation id="4307992518367153382">Configuració bàsica</translation>
-<translation id="4314815835985389558">Gestiona la sincronització</translation>
-<translation id="4351244548802238354">Tanca el quadre de diàleg</translation>
-<translation id="4378154925671717803">Telèfon</translation>
-<translation id="4384468725000734951">S'utilitza Sogou per a la cerca</translation>
-<translation id="4404568932422911380">Cap adreça d'interès</translation>
-<translation id="4405224443901389797">Mou a…</translation>
-<translation id="4411535500181276704">Mode bàsic</translation>
-<translation id="4415276339145661267">Gestiona el teu Compte de Google</translation>
-<translation id="4432792777822557199">A partir d'ara, les pàgines en <ph name="SOURCE_LANGUAGE" /> es traduiran a <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Pàgina en mode bàsic oferida per Google</translation>
-<translation id="4434045419905280838">Finestres emergents i redireccions</translation>
-<translation id="4440958355523780886">Pàgina en mode bàsic oferta per Google. Toca per carregar l'original.</translation>
-<translation id="4452411734226507615">Tanca la pestanya <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Adreça d'interès afegida a <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Permet que els llocs web reprodueixin contingut protegit</translation>
-<translation id="4468959413250150279">Silencia el so d'un lloc web concret.</translation>
-<translation id="4472118726404937099">Per sincronitzar i personalitzar el contingut en tots els dispositius, inicia la sessió i activa la sincronització</translation>
-<translation id="447252321002412580">Ajuda a millorar les funcions i el rendiment de Chrome</translation>
-<translation id="4479647676395637221">Pregunta'm abans de permetre que els llocs web utilitzin la càmera (opció recomanada)</translation>
-<translation id="4479972344484327217">S'està instal·lant <ph name="MODULE" /> per a Chrome…</translation>
-<translation id="4487967297491345095">Totes les dades de les aplicacions de Chrome, com ara els fitxers, la configuració, els comptes o les bases de dades, entre d'altres, se suprimiran permanentment.</translation>
-<translation id="4493497663118223949">El mode bàsic està activat</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{fa # dia}other{fa # dies}}</translation>
-<translation id="451872707440238414">Cerca a les adreces d'interès</translation>
-<translation id="4521489764227272523">Les dades seleccionades s'han suprimit de Chrome i dels dispositius sincronitzats.
-
-És possible que el teu compte de Google tingui altres formes de l'historial de navegació, com ara les cerques i l'activitat d'altres serveis de Google a <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Tria la carpeta</translation>
-<translation id="4538018662093857852">Activa el mode bàsic</translation>
-<translation id="4550003330909367850">Per veure o copiar la contrasenya aquí, configura el bloqueig de pantalla en aquest dispositiu.</translation>
-<translation id="4558311620361989323">Dreceres per a pàgines web</translation>
-<translation id="4561979708150884304">No hi ha connexió</translation>
-<translation id="4565377596337484307">Oculta la contrasenya</translation>
-<translation id="4570913071927164677">Detalls</translation>
-<translation id="4572422548854449519">Inicia la sessió al compte gestionat</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{fa # minut}other{fa # minuts}}</translation>
-<translation id="4587589328781138893">Llocs web</translation>
-<translation id="4594952190837476234">Aquesta pàgina sense connexió és del dia <ph name="CREATION_TIME" /> i pot ser diferent de la versió en línia.</translation>
-<translation id="4605958867780575332">S'ha suprimit l'element: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Obre <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Fes servir la contrasenya</translation>
-<translation id="4645575059429386691">Gestionat pels pares</translation>
-<translation id="4650364565596261010">Opció predeterminada del sistema</translation>
-<translation id="4663756553811254707">S'han suprimit <ph name="NUMBER_OF_BOOKMARKS" /> adreces d'interès</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> s'ha afegit a la pantalla d'inici</translation>
-<translation id="4684427112815847243">Sincronitza-ho tot</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> més}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> més}}</translation>
-<translation id="4696983787092045100">Envia text als teus dispositius</translation>
-<translation id="4698034686595694889">Mostra sense connexió a <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Imatges i fitxers desats a la memòria cau</translation>
-<translation id="4714588616299687897">Estalvia fins a un 60% de les dades</translation>
-<translation id="4719927025381752090">Proposa traduir aquest idioma</translation>
-<translation id="4720023427747327413">Obre a <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Ajuda a millorar Chrome. <ph name="BEGIN_LINK" />Respon a l'enquesta<ph name="END_LINK" />.</translation>
-<translation id="473775607612524610">Actualitza</translation>
-<translation id="4738836084190194332">Última sincronització: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Obre una pestanya nova</translation>
-<translation id="4751476147751820511">Sensors de moviment o de llum</translation>
-<translation id="4759238208242260848">Baixades</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{S'ha completat 1 baixada.}other{S'han completat # baixades.}}</translation>
-<translation id="4797039098279997504">Toqueu per tornar a <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">L'encriptació de frases de contrasenya no inclou les formes de pagament ni les adreces de Google Pay.
-
-Per canviar aquesta opció, <ph name="BEGIN_LINK" />restableix la sincronització<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Titular de la targeta</translation>
-<translation id="4824958205181053313">Vols cancel·lar la sincronització?</translation>
-<translation id="4837753911714442426">Obre les opcions per imprimir la pàgina</translation>
-<translation id="4842092870884894799">Es mostra la finestra emergent de generació de contrasenyes</translation>
-<translation id="4860895144060829044">Truca</translation>
-<translation id="4866368707455379617">No es pot instal·lar <ph name="MODULE" /> per a Chrome</translation>
-<translation id="4875775213178255010">Suggeriments de contingut</translation>
-<translation id="4878404682131129617">S'ha produït un error en establir un túnel mitjançant el servidor intermediari</translation>
-<translation id="4880127995492972015">Tradueix…</translation>
-<translation id="4881695831933465202">Obre</translation>
-<translation id="488187801263602086">Canvia el nom del fitxer</translation>
-<translation id="4882831918239250449">Controla com s'utilitza l'historial de navegació per personalitzar la Cerca, els anuncis i molt més</translation>
-<translation id="4883854917563148705">Les opcions de configuració gestionades no es poden restablir</translation>
-<translation id="4885273946141277891">No s'admet aquest nombre d'instàncies de Chrome.</translation>
-<translation id="4910889077668685004">Aplicacions de pagament</translation>
-<translation id="4913161338056004800">Restableix les estadístiques</translation>
-<translation id="4913169188695071480">Deixa d'actualitzar</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Obtén ajuda<ph name="END_LINK" /> mentre se cerquen dispositius…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# pàgina}other{# pàgines}}</translation>
-<translation id="4932247056774066048">Com que estàs tancant la sessió d'un compte gestionat per <ph name="DOMAIN_NAME" />, les teves dades de Chrome se suprimiran d'aquest dispositiu. Tanmateix, es conservaran al teu Compte de Google.</translation>
-<translation id="4943703118917034429">Realitat virtual</translation>
-<translation id="4943872375798546930">No hi ha cap resultat</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> comparteix la teva pantalla</translation>
-<translation id="4961107849584082341">Tradueix aquesta pàgina a qualsevol idioma</translation>
-<translation id="4962975101802056554">Revoca tots els permisos del dispositiu</translation>
-<translation id="4970824347203572753">No està disponible a la teva ubicació</translation>
-<translation id="497421865427891073">Ves endavant</translation>
-<translation id="4988210275050210843">S'està baixant el fitxer (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Pàgines</translation>
-<translation id="4994033804516042629">No s'ha trobat cap contacte</translation>
-<translation id="4996978546172906250">Comparteix mitjançant</translation>
-<translation id="5004416275253351869">Controls d'activitat de Google</translation>
-<translation id="5005498671520578047">Copia la contrasenya</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> es vol connectar</translation>
-<translation id="5013696553129441713">No hi ha cap suggeriment nou</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Mentre estiguis en el mode RV, pot ser que aquest lloc web pugui obtenir la informació següent:
-- els teus trets físics, com ara l'alçada
-
-Assegura't que confies en aquest lloc web abans d'entrar al mode RV.</translation>
+<translation id="2930742481329940825">La funció Toca per cercar envia la paraula seleccionada i la pàgina actual com a context a la Cerca de Brave Software. La pots desactivar a <ph name="BEGIN_LINK"/>Configuració<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Permet</translation>
-<translation id="5040262127954254034">Privadesa</translation>
-<translation id="5048398596102334565">Permet que els llocs web accedeixin als sensors de moviment (opció recomanada)</translation>
-<translation id="5063480226653192405">Ús</translation>
-<translation id="5087580092889165836">Afegeix una targeta</translation>
-<translation id="5100237604440890931">Vista replegada (feu clic per desplegar-la)</translation>
-<translation id="510275257476243843">Queda 1 hora</translation>
-<translation id="5123685120097942451">Pestanya d'incògnit</translation>
-<translation id="5127805178023152808">Sincronització desactivada</translation>
-<translation id="5129038482087801250">Instal·la l'aplicació web</translation>
-<translation id="5132942445612118989">Sincronitza les contrasenyes, l'historial i altres elements en tots els dispositius</translation>
-<translation id="5139940364318403933">Obtén informació sobre com pots utilitzar Google Drive</translation>
-<translation id="515227803646670480">Esborra les dades emmagatzemades</translation>
-<translation id="5152843274749979095">No hi ha cap aplicació admesa instal·lada</translation>
-<translation id="5161254044473106830">Cal indicar un títol</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{No s'ha pogut completar 1 baixada.}other{No s'han pogut completar # baixades.}}</translation>
-<translation id="5170568018924773124">Mostra a la carpeta</translation>
-<translation id="5184329579814168207">Obre a Chrome</translation>
-<translation id="5193988420012215838">S'ha copiat al porta-retalls</translation>
-<translation id="5197729504361054390">Els contactes que seleccionis es compartiran amb <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Perfil professional</translation>
-<translation id="5210286577605176222">Ves a la pestanya anterior</translation>
-<translation id="5210365745912300556">Tanca la pestanya</translation>
-<translation id="5224771365102442243">Amb vídeo</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> vol cercar dispositius Bluetooth propers. S'han trobat els dispositius següents:</translation>
-<translation id="5233638681132016545">Pestanya nova</translation>
-<translation id="526421993248218238">No es pot carregar aquesta pàgina</translation>
-<translation id="5271967389191913893">El dispositiu no pot obrir el contingut que s'ha de baixar.</translation>
-<translation id="528192093759286357">Arrossegueu la pantalla des de la part superior i toqueu el botó Enrere per sortir de la pantalla completa.</translation>
-<translation id="5292796745632149097">Envia a</translation>
-<translation id="5300589172476337783">Mostra</translation>
-<translation id="5301954838959518834">D'acord</translation>
-<translation id="5304593522240415983">Aquest camp no pot estar en blanc</translation>
-<translation id="5307446750509046227">Esborra emmagatz. lloc</translation>
-<translation id="5308380583665731573">Connecta</translation>
-<translation id="5313967007315987356">Afegeix un lloc web</translation>
-<translation id="5317780077021120954">Desa</translation>
-<translation id="5324858694974489420">Configuració parental</translation>
-<translation id="5327248766486351172">Nom</translation>
-<translation id="5335288049665977812">Permet que els llocs web executin JavaScript (opció recomanada)</translation>
-<translation id="5342314432463739672">Sol·licituds de permís</translation>
-<translation id="5357811892247919462">S'ha rebut una pestanya</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> pestanya oberta; toca per canviar de pestanya}other{<ph name="OPEN_TABS_MANY" /> pestanyes obertes; toca per canviar de pestanya}}</translation>
-<translation id="5391532827096253100">La connexió amb aquest lloc web no és segura. Informació del lloc web</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(i 1 més)}other{(i # més)}}</translation>
-<translation id="5400569084694353794">En fer servir aquesta aplicació, acceptes les <ph name="BEGIN_LINK1" />condicions del servei<ph name="END_LINK1" /> i l'<ph name="BEGIN_LINK2" />avís de privadesa<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="5403592356182871684">Noms</translation>
-<translation id="5403644198645076998">Permet només certs llocs web</translation>
-<translation id="5414836363063783498">S'està verificant...</translation>
-<translation id="5423934151118863508">Les pàgines més visitades es mostraran aquí</translation>
-<translation id="5424588387303617268">GB disponibles: <ph name="GIGABYTES" /></translation>
-<translation id="543338862236136125">Edita la contrasenya</translation>
-<translation id="5433691172869980887">S'ha copiat el nom d'usuari</translation>
-<translation id="543509235395288790">S'estan baixant <ph name="COUNT" /> fitxers (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Ves a la barra d'adreces</translation>
-<translation id="5447201525962359567">Tot l'emmagatzematge del lloc web, com ara les galetes i altres dades emmagatzemades localment</translation>
-<translation id="5447765697759493033">Aquest lloc web no es traduirà</translation>
-<translation id="545042621069398927">S'està accelerant la baixada.</translation>
-<translation id="5456381639095306749">Baixa la pàgina</translation>
-<translation id="5475862044948910901">Vols iniciar la sessió de realitat augmentada?</translation>
-<translation id="548278423535722844">Obre en una aplicació de mapes</translation>
-<translation id="5487521232677179737">Esborra les dades</translation>
-<translation id="5494752089476963479">Bloqueja els anuncis als llocs web que mostren publicitat intrusiva o enganyosa</translation>
-<translation id="5500777121964041360">Pot ser que no estigui disponible a la teva ubicació</translation>
-<translation id="5512137114520586844"><ph name="PARENT_NAME" /> gestiona aquest compte.</translation>
-<translation id="5514904542973294328">Opció desactivada per l'administrador d'aquest dispositiu</translation>
-<translation id="5515439363601853141">Desbloqueja la pantalla per veure la contrasenya</translation>
-<translation id="5516455585884385570">Obre la configuració de notificacions</translation>
-<translation id="5517095782334947753">Tens les adreces d'interès, l'historial, les contrasenyes i altres opcions de configuració de l'adreça <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">S'ha bloquejat la redirecció.</translation>
-<translation id="5527082711130173040">Chrome necessita accedir a la ubicació per poder cercar dispositius. <ph name="BEGIN_LINK1" />Actualitza els permisos<ph name="END_LINK1" />. L'accés a la ubicació també està <ph name="BEGIN_LINK2" />desactivat en aquest dispositiu<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Pregunta'm abans de permetre que els llocs web llegeixin el text i les imatges del porta-retalls (opció recomanada)</translation>
-<translation id="5530766185686772672">Tanca pestanyes d'incògnit</translation>
-<translation id="5534334044554683961">Mentre estiguis en el mode RV, pot ser que aquest lloc web pugui obtenir la informació següent:
-- els teus trets físics, com ara l'alçada
-- la distribució de la teva habitació
-
-Assegura't que confies en aquest lloc web abans d'entrar al mode RV.</translation>
-<translation id="5534640966246046842">S'ha copiat el lloc web</translation>
-<translation id="5556459405103347317">Torna a carregar</translation>
-<translation id="5561549206367097665">S'està esperant la xarxa…</translation>
-<translation id="557283862590186398">Per visitar aquest lloc web, Chrome necessita permís per accedir al teu micròfon.</translation>
-<translation id="55737423895878184">Es permeten la ubicació i les notificacions</translation>
-<translation id="5578795271662203820">Cerca aquesta imatge a <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Sempre pots anar a la <ph name="BEGIN_LINK1" />configuració<ph name="END_LINK1" /> per decidir què vols sincronitzar.</translation>
-<translation id="5595485650161345191">Edita l'adreça</translation>
-<translation id="5596627076506792578">Més opcions</translation>
-<translation id="5599455543593328020">Mode d'incògnit</translation>
-<translation id="5620928963363755975">Per veure els teus fitxers i les teves pàgines, toca el botó Més opcions i ves a la secció Baixades</translation>
-<translation id="5626134646977739690">Nom:</translation>
-<translation id="5639724618331995626">Permet tots els llocs</translation>
-<translation id="5648166631817621825">7 darrers dies</translation>
-<translation id="5649053991847567735">Baixades automàtiques</translation>
-<translation id="5655963694829536461">Cerca a les baixades</translation>
-<translation id="5659593005791499971">Correu electrònic</translation>
-<translation id="5665379678064389456">Crea un esdeveniment a <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ignora la sol·licitud d'un lloc web per evitar que s'apropi la imatge</translation>
-<translation id="5677928146339483299">Bloquejat</translation>
-<translation id="5684874026226664614">Aquesta pàgina no s'ha pogut traduir.</translation>
-<translation id="5686790454216892815">El nom del fitxer és massa llarg</translation>
-<translation id="5689516760719285838">Ubicació</translation>
-<translation id="569536719314091526">Tradueix aquesta pàgina a qualsevol idioma des del botó Més opcions</translation>
-<translation id="572328651809341494">Pestanyes recents</translation>
-<translation id="5726692708398506830">Augmenta la mida de tots els elements de la pàgina</translation>
-<translation id="5748802427693696783">S'ha canviat a les pestanyes estàndard</translation>
-<translation id="5749068826913805084">Chrome necessita accedir a l'emmagatzematge per poder baixar fitxers.</translation>
-<translation id="5763382633136178763">Pestanyes d'incògnit</translation>
-<translation id="5763514718066511291">Toca per copiar l'URL d'aquesta aplicació</translation>
-<translation id="5765780083710877561">Descripció:</translation>
-<translation id="5793665092639000975">S'estan utilitzant <ph name="SPACE_USED" /> de <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">És possible que Google utilitzi el teu historial per personalitzar la Cerca, els anuncis i altres serveis de Google</translation>
-<translation id="5804241973901381774">Permisos</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{fa # hora}other{fa # hores}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Tots els drets reservats.</translation>
-<translation id="5817918615728894473">Vincula</translation>
-<translation id="583281660410589416">Desconegut</translation>
-<translation id="5833984609253377421">Comparteix l'enllaç</translation>
-<translation id="5836192821815272682">S'està baixant l'actualització de Chrome…</translation>
-<translation id="5853623416121554550">en pausa</translation>
-<translation id="5854790677617711513">Anterior a 30 dies</translation>
-<translation id="5858741533101922242">Chrome no pot activar l'adaptador Bluetooth</translation>
-<translation id="5860033963881614850">Desactivat</translation>
-<translation id="5862731021271217234">Activa la sincronització per accedir a les pestanyes dels altres dispositius que tinguis</translation>
-<translation id="5864174910718532887">Detalls: files ordenades per nom del lloc web</translation>
-<translation id="5864419784173784555">S'està esperant que finalitzi una altra baixada…</translation>
-<translation id="5865733239029070421">Envia automàticament a Google estadístiques d'ús i informes d'error</translation>
-<translation id="5869522115854928033">Contrasenyes desades</translation>
-<translation id="5902828464777634901">Se suprimiran totes les dades que aquest lloc web hagi emmagatzemat, incloses les galetes.</translation>
-<translation id="5916664084637901428">Activat</translation>
-<translation id="5919204609460789179">Actualitza <ph name="PRODUCT_NAME" /> per iniciar la sincronització</translation>
-<translation id="5937580074298050696">Dades estalviades: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Restableix</translation>
-<translation id="5942872142862698679">S'utilitza Google per a la cerca</translation>
-<translation id="5952764234151283551">Envia a Google l'URL d'una pàgina que estàs provant de visitar</translation>
-<translation id="5956665950594638604">Obre Centre d'ajuda de Chrome en una pestanya nova</translation>
-<translation id="5958275228015807058">Trobaràs els teus fitxers i les teves pàgines a Baixades</translation>
-<translation id="5962718611393537961">Toca per replegar</translation>
-<translation id="6000066717592683814">Continua amb Google</translation>
-<translation id="6005538289190791541">Contrasenya suggerida</translation>
-<translation id="6036057147555329831">ICU addicional</translation>
-<translation id="6039379616847168523">Ves a la pestanya següent</translation>
-<translation id="6040143037577758943">Tanca</translation>
-<translation id="6042308850641462728">Més</translation>
-<translation id="604996488070107836">No s'ha pogut baixar <ph name="FILE_NAME" /> a causa d'un error desconegut.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Baixades completades</translation>
-<translation id="6075798973483050474">Editar la pàgina d'inici</translation>
-<translation id="60923314841986378">Queden <ph name="HOURS" /> hores</translation>
-<translation id="6108923351542677676">Configuració en curs...</translation>
-<translation id="6111020039983847643">dades utilitzades</translation>
-<translation id="6112702117600201073">S'està actualitzant la pàgina</translation>
-<translation id="6127379762771434464">S'ha suprimit l'element</translation>
-<translation id="6140912465461743537">País/regió</translation>
-<translation id="614940544461990577">Prova el següent:</translation>
-<translation id="6154478581116148741">Activa el bloqueig de pantalla a Configuració per exportar les teves contrasenyes d'aquest dispositiu</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> de reducció de dades</translation>
-<translation id="6165508094623778733">Més informació</translation>
-<translation id="6177111841848151710">S'ha bloquejat per al motor de cerca actual</translation>
-<translation id="6181444274883918285">Afegeix excepció per a un lloc web</translation>
-<translation id="6192333916571137726">Baixa el fitxer</translation>
-<translation id="6192792657125177640">Excepcions</translation>
-<translation id="6194112207524046168">Perquè Chrome pugui accedir a la càmera, també has d'activar-la a la <ph name="BEGIN_LINK" />configuració d'Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Bloqueja les galetes de tercers</translation>
-<translation id="6206551242102657620">La connexió és segura. Informació del lloc web</translation>
-<translation id="6210748933810148297">No ets <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Desbloqueja per exportar les contrasenyes</translation>
+<translation id="1406000523432664303">No segueixis</translation>
 <translation id="6232535412751077445">Si actives l'opció No segueixis, s'inclourà una sol·licitud al trànsit de navegació. Que s'apliqui o no dependrà de si algun lloc web respon a la sol·licitud i de com s'interpreta.
 
 Per exemple, és possible que alguns llocs web responguin a aquesta sol·licitud mostrant-te anuncis que no estiguin basats en altres llocs web que hagis visitat. Molts llocs web continuaran recopilant i utilitzant les teves dades de navegació (per exemple, per millorar la seguretat, per proporcionar contingut, anuncis i recomanacions i per generar estadístiques).</translation>
-<translation id="624789221780392884">Actualització a punt.</translation>
-<translation id="6255999984061454636">Suggeriments de contingut</translation>
-<translation id="6277522088822131679">S'ha produït un problema en imprimir la pàgina. Torneu-ho a provar.</translation>
-<translation id="6295158916970320988">Tots els llocs web</translation>
-<translation id="629730747756840877">Compte</translation>
-<translation id="6303969859164067831">Tanca la sessió i desactiva la sincronització</translation>
-<translation id="6316139424528454185">Versió d'Android no admesa</translation>
-<translation id="6320088164292336938">Vibració</translation>
-<translation id="6324034347079777476">La sincronització del sistema Android està desactivada</translation>
-<translation id="6333140779060797560">Comparteix mitjançant <ph name="APPLICATION" />.</translation>
-<translation id="6337234675334993532">Encriptació</translation>
-<translation id="6341580099087024258">Pregunta on es desen els fitxers</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> més}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> més}}</translation>
-<translation id="6364438453358674297">Voleu suprimir el suggeriment de l'historial?</translation>
-<translation id="6369229450655021117">Des d'aquí, pots fer cerques al web, compartir contingut amb els amics i veure les pàgines obertes</translation>
-<translation id="6378173571450987352">Detalls: files ordenades per quantitat de dades utilitzades</translation>
-<translation id="6381421346744604172">Enfosqueix els llocs web</translation>
-<translation id="6388207532828177975">Esborra i restableix</translation>
-<translation id="6393863479814692971">Per visitar aquest lloc web, Chrome necessita permís per accedir a la teva càmera i al teu micròfon.</translation>
-<translation id="6395288395575013217">ENLLAÇ</translation>
-<translation id="6404511346730675251">Edita l'adreça d'interès</translation>
-<translation id="6406506848690869874">Sincronització</translation>
-<translation id="641643625718530986">Imprimeix…</translation>
-<translation id="6416782512398055893">S'han baixat <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Tradueix el web</translation>
-<translation id="6433501201775827830">Tria el motor de cerca</translation>
-<translation id="6437478888915024427">Informació de la pàgina</translation>
-<translation id="6441734959916820584">El nom és massa llarg</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imatge}other{# imatges}}</translation>
-<translation id="6447842834002726250">Galetes</translation>
-<translation id="6461962085415701688">El fitxer no es pot obrir</translation>
-<translation id="6464977750820128603">Pots veure els llocs web que visites a Chrome i establir-hi temporitzadors.\n\nGoogle obté informació sobre els llocs web en què estableixes temporitzadors i sobre el temps que hi passes. Aquesta informació s'utilitza per millorar Benestar digital.</translation>
-<translation id="6475951671322991020">Baixa el vídeo</translation>
-<translation id="6482749332252372425">No s'ha pogut baixar <ph name="FILE_NAME" /> perquè falta espai d'emmagatzematge.</translation>
-<translation id="6496823230996795692">Per utilitzar <ph name="APP_NAME" /> per primera vegada, connecta't a Internet.</translation>
-<translation id="6508722015517270189">Reinicia Chrome</translation>
-<translation id="6527303717912515753">Comparteix</translation>
-<translation id="6532866250404780454">Els llocs web que visitis a Chrome no es mostraran. Se suprimiran tots els temporitzadors del lloc web.</translation>
-<translation id="6534565668554028783">Google ha tardat massa a respondre</translation>
-<translation id="6538442820324228105">S'han baixat <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">S'ha produït un error. Torna-ho a provar més tard.</translation>
-<translation id="654446541061731451">Trieu una pestanya per compartir-la.</translation>
-<translation id="6545017243486555795">Esborra totes les dades</translation>
-<translation id="6545864417968258051">Cerca de dispositius Bluetooth</translation>
-<translation id="6560414384669816528">Cerca amb Sogou</translation>
-<translation id="6566259936974865419">Chrome t'ha estalviat <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Permet sempre</translation>
-<translation id="6573431926118603307">Les pestanyes que tingueu obertes a Chrome als altres dispositius es mostraran aquí.</translation>
-<translation id="6583199322650523874">Afegeix la pàgina actual a les adreces d'interès</translation>
-<translation id="6593061639179217415">Lloc web per a ordinador</translation>
-<translation id="6600954340915313787">Copiada de Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Contingut protegit</translation>
-<translation id="6627583120233659107">Edita la carpeta</translation>
-<translation id="6643016212128521049">Esborra</translation>
-<translation id="6643649862576733715">Ordena per quantitat de dades estalviades</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> més}other{<ph name="CONTACT_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> més}}</translation>
-<translation id="6649642165559792194">Previsualitza la imatge <ph name="BEGIN_NEW" />Novetat<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome necessita accedir a la ubicació per poder cercar dispositius. <ph name="BEGIN_LINK" />Actualitza els permisos<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Contrasenya</translation>
-<translation id="6659594942844771486">Pestanya</translation>
-<translation id="666731172850799929">Obre a <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Avís de privadesa de Chrome</translation>
-<translation id="6676840375528380067">Vols esborrar les dades de Chrome del dispositiu?</translation>
-<translation id="6697492270171225480">Mostra suggeriments de pàgines similars quan no se'n trobi una</translation>
-<translation id="6697947395630195233">Chrome necessita accedir a la teva ubicació per compartir-la amb aquest lloc web.</translation>
-<translation id="6698801883190606802">Gestiona les dades sincronitzades</translation>
-<translation id="6699370405921460408">Els servidors de Google optimitzaran les pàgines que visitis.</translation>
-<translation id="6706288973712894588">En aquests moments no tens connexió.\n<ph name="BEGIN_LINK" />Explora el feed sense connexió<ph name="END_LINK" />.</translation>
-<translation id="6709133671862442373">Notícies</translation>
-<translation id="6710213216561001401">Anterior</translation>
-<translation id="671481426037969117">S'ha esgotat el temps definit al temporitzador per a <ph name="FQDN" />. Es tornarà a iniciar demà.</translation>
-<translation id="6738867403308150051">S'està baixant...</translation>
-<translation id="6746124502594467657">Mou avall</translation>
-<translation id="6766622839693428701">Llisca cap avall per tancar el full.</translation>
-<translation id="6766758767654711248">Toca per anar al lloc web</translation>
-<translation id="6767294960381293877">La llista de dispositius amb què es compartirà una pestanya ocupa la meitat inferior de la pantalla.</translation>
-<translation id="6782111308708962316">Impedeix que els llocs web de tercers desin i llegeixin les dades de les galetes</translation>
-<translation id="6790428901817661496">Reprodueix</translation>
-<translation id="6811034713472274749">Ja es pot veure la pàgina</translation>
-<translation id="6818926723028410516">Selecciona elements</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Tradueix</translation>
-<translation id="6845325883481699275">Ajuda a millorar la seguretat de Chrome</translation>
-<translation id="6846298663435243399">S'està carregant…</translation>
-<translation id="6850409657436465440">La baixada encara està en curs</translation>
-<translation id="6850830437481525139">S'han tancat <ph name="TAB_COUNT" /> pestanyes</translation>
-<translation id="6864459304226931083">Baixa la imatge</translation>
-<translation id="6865313869410766144">Dades d'Emplenament automàtic de formularis</translation>
-<translation id="688738109438487280">Afegeix les dades existents a <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Desbloqueja la pantalla per copiar la contrasenya</translation>
-<translation id="6896758677409633944">Copia</translation>
-<translation id="6910211073230771657">Suprimit</translation>
-<translation id="6912998170423641340">Impedeix que els llocs web llegeixin el text i les imatges del porta-retalls</translation>
-<translation id="6914783257214138813">Tothom que pugui veure el fitxer exportat podrà veure també les teves contrasenyes.</translation>
-<translation id="6942665639005891494">Canvia la ubicació predeterminada de baixada en qualsevol moment amb l'opció del menú Configuració</translation>
-<translation id="6945221475159498467">Selecciona</translation>
-<translation id="6963642900430330478">Aquesta pàgina és perillosa. Informació del lloc web</translation>
-<translation id="6963766334940102469">Suprimeix les adreces d'interès</translation>
-<translation id="6965382102122355670">D'acord</translation>
-<translation id="6979737339423435258">Tot el període</translation>
-<translation id="6981982820502123353">Accessibilitat</translation>
-<translation id="6989267951144302301">No s'ha pogut baixar</translation>
-<translation id="6990079615885386641">Baixeu l'aplicació des de Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Pregunta'm abans de permetre que els llocs web utilitzin el micròfon (opció recomanada)</translation>
-<translation id="7015203776128479407">La configuració de la sincronització inicial no ha finalitzat. La sincronització està desactivada.</translation>
-<translation id="7016516562562142042">Es permet al motor de cerca actual</translation>
-<translation id="7022756207310403729">Obre al navegador</translation>
-<translation id="702463548815491781">Es recomana quan TalkBack o l'accés amb interruptors estan activats</translation>
-<translation id="7029809446516969842">Contrasenyes</translation>
-<translation id="7053983685419859001">Bloqueja</translation>
-<translation id="7055152154916055070">S'ha bloquejat la redirecció:</translation>
-<translation id="7063006564040364415">No s'ha pogut connectar amb el servidor de sincronització.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 seleccionat}other{# seleccionats}}</translation>
-<translation id="7071521146534760487">Gestiona el compte</translation>
-<translation id="7077143737582773186">Targeta Secure Digital</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> elements seleccionats. Hi ha opcions disponibles a prop de la part superior de la pantalla.</translation>
-<translation id="7121362699166175603">Esborra l'historial i les complecions automàtiques a la barra d'adreces. A <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> trobaràs altres maneres d'explorar l'historial de navegació del Compte de Google.</translation>
-<translation id="7128222689758636196">Permet al motor de cerca actual</translation>
-<translation id="7138678301420049075">Altres</translation>
-<translation id="7141896414559753902">Bloqueja les finestres emergents i les redireccions als llocs web (opció recomanada)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Carrega la pàgina original<ph name="END_LINK" /> del domini <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">24 darreres hores</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Pots canviar aquesta opció més endavant a Configuració</translation>
-<translation id="7180611975245234373">Actualitza</translation>
-<translation id="7189372733857464326">S'està esperant que Serveis de Google Play s'acabi d'actualitzar</translation>
-<translation id="7191430249889272776">Pestanya oberta en segon pla</translation>
-<translation id="723171743924126238">Selecciona imatges</translation>
-<translation id="7233236755231902816">Per veure el web en el teu idioma, actualitza Chrome a la versió més recent.</translation>
-<translation id="7243308994586599757">Opcions disponibles a la part inferior de la pantalla</translation>
-<translation id="7248069434667874558">Comprova que <ph name="TARGET_DEVICE_NAME" /> tingui la sincronització activada a Chrome</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> elements seleccionats</translation>
-<translation id="7274013316676448362">Lloc bloquejat</translation>
-<translation id="7290209999329137901">No es pot canviar el nom</translation>
-<translation id="7291387454912369099">Pagament activat per l'Assistent</translation>
-<translation id="7293171162284876153">Per iniciar la sincronització, activa l'opció Sincronitza les dades de Chrome.</translation>
-<translation id="729975465115245577">El dispositiu no té cap aplicació per emmagatzemar el fitxer de contrasenyes.</translation>
-<translation id="7302081693174882195">Detalls: files ordenades per quantitat de dades estalviades</translation>
-<translation id="7328017930301109123">En el mode bàsic, Chrome carrega les pàgines més ràpidament i utilitza fins a un 60 per cent menys de dades.</translation>
-<translation id="7333031090786104871">Encara s'hi està afegint el lloc anterior</translation>
-<translation id="7352939065658542140">VÍDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Comparteix 1 element seleccionat}other{Comparteix # elements seleccionats}}</translation>
 <translation id="7359002509206457351">Accedeix a les formes de pagament</translation>
+<translation id="8026334261755873520">Esborra les dades de navegació</translation>
+<translation id="1291207594882862231">Esborra l'historial, les galetes, les dades dels llocs web, la memòria cau, etc.</translation>
+<translation id="7814200940910057384">S'han esborrat les dades de Brave</translation>
+<translation id="1664855196866195614">Les dades seleccionades s'han suprimit de Brave i dels dispositius sincronitzats.
+
+És possible que el teu compte de Brave Software tingui altres formes de l'historial de navegació, com ara les cerques i l'activitat d'altres serveis de Brave Software a <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Imatges i fitxers desats a la memòria cau</translation>
+<translation id="2496180316473517155">Historial de navegació</translation>
+<translation id="2546283357679194313">Dades de llocs web i galetes</translation>
+<translation id="8662811608048051533">Et tanca la sessió de la majoria de llocs.</translation>
+<translation id="8218628800671693884">Et tanca la sessió de la majoria de llocs web, però no la del Compte de Brave Software.</translation>
+<translation id="2017836877785168846">Esborra l'historial i les complecions automàtiques a la barra d'adreces.</translation>
+<translation id="8096327394278038498">Esborra l'historial i les complecions automàtiques a la barra d'adreces. A <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> trobaràs altres maneres d'explorar l'historial de navegació del Compte de Brave Software.</translation>
+<translation id="8122693181154564064">Esborra l'historial de tots els dispositius en què tinguis iniciada la sessió. A <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> trobaràs altres maneres d'explorar l'historial de navegació del Compte de Brave Software.</translation>
+<translation id="5869522115854928033">Contrasenyes desades</translation>
+<translation id="6865313869410766144">Dades d'Emplenament automàtic de formularis</translation>
+<translation id="7562080006725997899">S'estan esborrant les dades de navegació</translation>
+<translation id="5487521232677179737">Esborra les dades</translation>
+<translation id="7498271377022651285">Espereu...</translation>
+<translation id="784934925303690534">Interval de temps</translation>
+<translation id="1718835860248848330">Darrera hora</translation>
+<translation id="7149893636342594995">24 darreres hores</translation>
+<translation id="5648166631817621825">7 darrers dies</translation>
+<translation id="8571213806525832805">4 darreres setmanes</translation>
+<translation id="5854790677617711513">Anterior a 30 dies</translation>
+<translation id="6979737339423435258">Tot el període</translation>
+<translation id="982182592107339124">S'esborraran les dades de tots els llocs web, com ara:</translation>
+<translation id="6643016212128521049">Esborra</translation>
+<translation id="7641339528570811325">Esborra les dades de navegació…</translation>
+<translation id="1670399744444387456">Configuració bàsica</translation>
+<translation id="3245261285041759672">A <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> trobaràs altres maneres d'explorar l'historial de navegació del teu Compte de Brave Software.</translation>
+<translation id="7274013316676448362">Lloc bloquejat</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> elements suprimits</translation>
+<translation id="1121094540300013208">Informes d'ús i d'error</translation>
+<translation id="9079153198295609735">Envia automàticament estadístiques d'ús i informes d'error a Brave Software</translation>
+<translation id="6981982820502123353">Accessibilitat</translation>
+<translation id="2387895666653383613">Canvia la mida del text</translation>
+<translation id="2321958826496381788">Arrossega el control lliscant fins que puguis llegir aquest text còmodament. El text ha de ser almenys així de gran després de tocar dos cops un paràgraf.</translation>
+<translation id="3895926599014793903">Força l'activació del zoom</translation>
+<translation id="5668404140385795438">Ignora la sol·licitud d'un lloc web per evitar que s'apropi la imatge</translation>
+<translation id="4149994727733219643">Visualització simplificada de pàgines web</translation>
+<translation id="9100505651305367705">Proposa mostrar articles en visualització simplificada, quan s'admeti</translation>
+<translation id="1409426117486808224">Visualització simplificada de les pestanyes obertes</translation>
+<translation id="702463548815491781">Es recomana quan TalkBack o l'accés amb interruptors estan activats</translation>
+<translation id="8284326494547611709">Subtítols</translation>
+<translation id="4165986682804962316">Configuració del lloc web</translation>
+<translation id="6295158916970320988">Tots els llocs web</translation>
+<translation id="8380167699614421159">Aquest lloc web mostra anuncis intrusius o enganyosos</translation>
+<translation id="1919345977826869612">Anuncis</translation>
+<translation id="410351446219883937">Reproducció automàtica</translation>
+<translation id="6447842834002726250">Galetes</translation>
+<translation id="6196640612572343990">Bloqueja les galetes de tercers</translation>
+<translation id="6782111308708962316">Impedeix que els llocs web de tercers desin i llegeixin les dades de les galetes</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Finestres emergents i redireccions</translation>
+<translation id="4751476147751820511">Sensors de moviment o de llum</translation>
+<translation id="1717218214683051432">Sensors de moviment</translation>
+<translation id="2091887806945687916">So</translation>
+<translation id="2586657967955657006">Porta-retalls</translation>
+<translation id="6320088164292336938">Vibració</translation>
+<translation id="4226663524361240545">És possible que les notificacions facin vibrar el dispositiu</translation>
+<translation id="1446450296470737166">Permet control total disp. MIDI</translation>
+<translation id="3744111561329211289">Sincronització en segon pla</translation>
+<translation id="5649053991847567735">Baixades automàtiques</translation>
+<translation id="6181444274883918285">Afegeix excepció per a un lloc web</translation>
+<translation id="5313967007315987356">Afegeix un lloc web</translation>
+<translation id="1369915414381695676">El lloc <ph name="SITE_NAME"/> s'ha afegit</translation>
+<translation id="7837721118676387834">Permet la reproducció automàtica de vídeos silenciats d'un lloc web concret.</translation>
+<translation id="2621115761605608342">Permet JavaScript en un lloc web concret.</translation>
+<translation id="8801436777607969138">Bloqueja JavaScript en un lloc web concret.</translation>
+<translation id="8372893542064058268">Permet la sincronització en segon pla en un lloc concret.</translation>
+<translation id="358794129225322306">Permet que un lloc web baixi diversos fitxers automàticament.</translation>
+<translation id="4008040567710660924">Permet les galetes d'un lloc web concret.</translation>
+<translation id="8958424370300090006">Bloqueja les galetes d'un lloc web concret.</translation>
+<translation id="7882806643839505685">Permet el so d'un lloc web concret.</translation>
+<translation id="4468959413250150279">Silencia el so d'un lloc web concret.</translation>
+<translation id="1994173015038366702">URL del lloc web</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Ús</translation>
+<translation id="5804241973901381774">Permisos</translation>
+<translation id="4278390842282768270">Permès</translation>
+<translation id="5677928146339483299">Bloquejat</translation>
+<translation id="1984937141057606926">Permeses, excepte les de tercers</translation>
+<translation id="7423098979219808738">Pregunta-m'ho abans</translation>
+<translation id="8116925261070264013">Silenciats</translation>
+<translation id="8300705686683892304">Gestionats per aplicacions</translation>
+<translation id="6192792657125177640">Excepcions</translation>
+<translation id="257931822824936280">Vista desplegada (feu clic per replegar-la)</translation>
+<translation id="5100237604440890931">Vista replegada (feu clic per desplegar-la)</translation>
+<translation id="857943718398505171">Permès (opció recomanada)</translation>
+<translation id="2913331724188855103">Permet que els llocs web desin i llegeixin les dades de les galetes (opció recomanada)</translation>
+<translation id="7445411102860286510">Permet que els llocs web reprodueixin automàticament vídeos silenciats (opció recomanada)</translation>
+<translation id="5335288049665977812">Permet que els llocs web executin JavaScript (opció recomanada)</translation>
+<translation id="5527111080432883924">Pregunta'm abans de permetre que els llocs web llegeixin el text i les imatges del porta-retalls (opció recomanada)</translation>
+<translation id="6912998170423641340">Impedeix que els llocs web llegeixin el text i les imatges del porta-retalls</translation>
+<translation id="7423538860840206698">L'accés de lectura al porta-retalls està bloquejat</translation>
+<translation id="3955193568934677022">Permet que els llocs web reprodueixin contingut protegit (opció recomanada)</translation>
+<translation id="445467742685312942">Permet que els llocs web reprodueixin contingut protegit</translation>
+<translation id="2107397443965016585">Pregunta'm abans de permetre que els llocs web reprodueixin contingut protegit (opció recomanada)</translation>
+<translation id="2910701580606108292">Pregunta'm abans de permetre que els llocs web reprodueixin contingut protegit</translation>
+<translation id="757524316907819857">Impedeix que els llocs web reprodueixin contingut protegit</translation>
+<translation id="3277252321222022663">Permet que els llocs web accedeixin als sensors (opció recomanada)</translation>
+<translation id="5048398596102334565">Permet que els llocs web accedeixin als sensors de moviment (opció recomanada)</translation>
+<translation id="8816026460808729765">Impedeix que els llocs web accedeixin als sensors</translation>
+<translation id="169515064810179024">Impedeix que els llocs web accedeixin als sensors de moviment</translation>
+<translation id="1660204651932907780">Permet que els llocs web reprodueixin so (opció recomanada)</translation>
+<translation id="3600792891314830896">Silencia els llocs web que reprodueixen so</translation>
+<translation id="1743802530341753419">Pregunta'm abans de permetre que els llocs web es connectin a un dispositiu (opció recomanada)</translation>
+<translation id="851751545965956758">Impedeix que els llocs web es connectin a dispositius</translation>
+<translation id="7141896414559753902">Bloqueja les finestres emergents i les redireccions als llocs web (opció recomanada)</translation>
+<translation id="5494752089476963479">Bloqueja els anuncis als llocs web que mostren publicitat intrusiva o enganyosa</translation>
+<translation id="3123473560110926937">Bloquejat en alguns llocs web</translation>
+<translation id="965817943346481315">Bloqueja els anuncis si el lloc web mostra publicitat intrusiva o enganyosa (opció recomanada)</translation>
+<translation id="3386292677130313581">Pregunta'm abans de permetre que els llocs web sàpiguen la meva ubicació (opció recomanada)</translation>
+<translation id="9139068048179869749">Pregunta'm abans de permetre que els llocs web enviïn notificacions (opció recomanada)</translation>
+<translation id="4479647676395637221">Pregunta'm abans de permetre que els llocs web utilitzin la càmera (opció recomanada)</translation>
+<translation id="6992289844737586249">Pregunta'm abans de permetre que els llocs web utilitzin el micròfon (opció recomanada)</translation>
+<translation id="2289270750774289114">Pregunta'm quan un lloc web vulgui descobrir dispositius Bluetooth propers (opció recomanada)</translation>
+<translation id="7053983685419859001">Bloqueja</translation>
+<translation id="7128222689758636196">Permet al motor de cerca actual</translation>
+<translation id="7589445247086920869">Bloqueja al motor de cerca actual</translation>
+<translation id="6388207532828177975">Esborra i restableix</translation>
+<translation id="7999064672810608036">Confirmes que vols esborrar d'aquest lloc web totes les dades locals, incloses les galetes, i restablir-ne tots els permisos?</translation>
+<translation id="2822354292072154809">Confirmes que vols restablir tots els permisos del lloc web concedits a <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Esborra les dades emmagatzemades</translation>
+<translation id="5902828464777634901">Se suprimiran totes les dades que aquest lloc web hagi emmagatzemat, incloses les galetes.</translation>
+<translation id="119944043368869598">Esborra-ho tot</translation>
+<translation id="2490684707762498678">Gestionades per <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Obre la configuració de notificacions</translation>
+<translation id="1404122904123200417">Inserit a <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Els fitxers desats pels llocs web es mostren aquí</translation>
+<translation id="4181841719683918333">Idiomes</translation>
+<translation id="2647434099613338025">Afegeix un idioma</translation>
+<translation id="1952172573699511566">Quan sigui possible, els llocs web mostraran el text en el teu idioma preferit.</translation>
+<translation id="8559990750235505898">Proposa traduir les pàgines en altres idiomes</translation>
+<translation id="4719927025381752090">Proposa traduir aquest idioma</translation>
+<translation id="8156139159503939589">En quins idiomes pots llegir?</translation>
+<translation id="5689516760719285838">Ubicació</translation>
+<translation id="2440823041667407902">Accés a la ubicació</translation>
+<translation id="2023546461831060654">Activeu els permisos per a Brave a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Activa el permís per a Brave a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Perquè Brave pugui accedir a la teva ubicació, també l'has d'activar a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Perquè Brave pugui accedir a la càmera, també has d'activar-la a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Perquè Brave et pugui enviar notificacions, també has d'activar-les a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Perquè Brave pugui accedir al micròfon, també has d'activar el micròfon a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">L'accés a la ubicació està desactivat en aquest dispositiu. Activa'l a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">L'accés a la ubicació també està desactivat en aquest dispositiu. Activa'l a la <ph name="BEGIN_LINK"/>configuració d'Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Càmera</translation>
+<translation id="3227137524299004712">Micròfon</translation>
+<translation id="1647391597548383849">Accés a la càmera</translation>
+<translation id="945632385593298557">Accés al micròfon</translation>
+<translation id="6612358246767739896">Contingut protegit</translation>
+<translation id="885701979325669005">Emmagatzematge</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> de dades desades</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revoca el permís d'accés al dispositiu</translation>
+<translation id="4962975101802056554">Revoca tots els permisos del dispositiu</translation>
+<translation id="6545864417968258051">Cerca de dispositius Bluetooth</translation>
+<translation id="4411535500181276704">Mode bàsic</translation>
+<translation id="7821588508402923572">Les dades que estalviïs es mostraran aquí</translation>
+<translation id="2131665479022868825">Dades estalviades: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">des del dia <ph name="DATE"/></translation>
+<translation id="3252158532344029638">En el mode bàsic, Brave carrega les pàgines més ràpidament i utilitza fins a un 60 per cent menys de dades.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> de reducció de dades</translation>
+<translation id="7494974237137038751">dades estalviades</translation>
+<translation id="6111020039983847643">dades utilitzades</translation>
+<translation id="7413229368719586778">Data d'inici: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Data de finalització: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Ordena per lloc web</translation>
+<translation id="5864174910718532887">Detalls: files ordenades per nom del lloc web</translation>
+<translation id="116280672541001035">Dades utilitzades</translation>
+<translation id="8349013245300336738">Ordena per quantitat de dades utilitzades</translation>
+<translation id="6378173571450987352">Detalls: files ordenades per quantitat de dades utilitzades</translation>
+<translation id="2631006050119455616">Dades estalviades</translation>
+<translation id="6643649862576733715">Ordena per quantitat de dades estalviades</translation>
+<translation id="7302081693174882195">Detalls: files ordenades per quantitat de dades estalviades</translation>
+<translation id="4179980317383591987">Dades utilitzades: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Dades estalviades: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Llocs restants (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Altres</translation>
+<translation id="4913161338056004800">Restableix les estadístiques</translation>
+<translation id="1856325424225101786">Vols restablir el mode bàsic?</translation>
+<translation id="3658159451045945436">Si el restableixes, s'esborrarà l'historial de l'estalvi de dades, inclosa la llista de llocs web visitats.</translation>
+<translation id="3295530008794733555">Navega més de pressa. Utilitza menys dades.</translation>
+<translation id="7340390500800578919">En el mode bàsic, Brave carrega les pàgines més ràpidament i utilitza fins a un 60 per cent menys de dades. Per optimitzar les pàgines que visites, Brave envia el teu trànsit web a Brave Software. <ph name="BEGIN_LINK"/>Més informació<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Activa el mode bàsic</translation>
+<translation id="4493497663118223949">El mode bàsic està activat</translation>
+<translation id="7559975015014302720">El mode bàsic està desactivat</translation>
+<translation id="7606077192958116810">El mode bàsic està activat. Gestiona'l a Configuració.</translation>
+<translation id="4714588616299687897">Estalvia fins a un 60% de les dades</translation>
+<translation id="1006927014032731288">Els servidors de Brave Software optimitzaran les pàgines que visitis.</translation>
+<translation id="3257320067425202300">Brave t'ha estalviat <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave t'ha estalviat <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Ubicació de baixada</translation>
+<translation id="7077143737582773186">Targeta Secure Digital</translation>
+<translation id="7762668264895820836">Targeta SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Pregunta on es desen els fitxers</translation>
+<translation id="6192333916571137726">Baixa el fitxer</translation>
+<translation id="1672586136351118594">No m'ho tornis a mostrar</translation>
+<translation id="2650751991977523696">Vols tornar a baixar el fitxer?</translation>
+<translation id="8664979001105139458">El nom del fitxer ja existeix</translation>
+<translation id="488187801263602086">Canvia el nom del fitxer</translation>
+<translation id="5686790454216892815">El nom del fitxer és massa llarg</translation>
+<translation id="7454641608352164238">No hi ha prou espai</translation>
+<translation id="8972098258593396643">Vols baixar el fitxer a la carpeta predeterminada?</translation>
+<translation id="804335162455518893">La targeta SD no s'ha trobat</translation>
+<translation id="7475688122056506577">La targeta SD no s'ha trobat. Pot ser que faltin alguns fitxers.</translation>
+<translation id="4198423547019359126">No hi ha cap ubicació de baixada disponible</translation>
+<translation id="8224471946457685718">Baixa articles que et poden interessar quan tinguis connexió a la Wi-Fi</translation>
+<translation id="4970824347203572753">No està disponible a la teva ubicació</translation>
+<translation id="5500777121964041360">Pot ser que no estigui disponible a la teva ubicació</translation>
+<translation id="1173894706177603556">Canvia el nom</translation>
+<translation id="1986685561493779662">El nom ja existeix</translation>
+<translation id="6441734959916820584">El nom és massa llarg</translation>
+<translation id="2923908459366352541">El nom no és vàlid</translation>
+<translation id="7290209999329137901">No es pot canviar el nom</translation>
+<translation id="3334729583274622784">Vols canviar l'extensió del fitxer?</translation>
+<translation id="107147699690128016">Si canvies l'extensió del fitxer, pot ser que el fitxer s'obri en una altra aplicació i pot arribar a ser perillós per al dispositiu.</translation>
+<translation id="8541922081612557424">Sobre Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Tots els drets reservats.</translation>
+<translation id="1416550906796893042">Versió de l'aplicació</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (última actualització: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistema operatiu</translation>
+<translation id="3968054912784331254">Aquesta versió d'Android ja no admet les actualitzacions de Brave</translation>
+<translation id="7665369617277396874">Afegeix un compte</translation>
+<translation id="649070405679044769">Has iniciat la sessió a Brave Software com a</translation>
+<translation id="6234515504547364178">Tanca la sessió de Brave</translation>
+<translation id="5324858694974489420">Configuració parental</translation>
+<translation id="8920114477895755567">S'està esperant la informació parental.</translation>
+<translation id="5512137114520586844"><ph name="PARENT_NAME"/> gestiona aquest compte.</translation>
+<translation id="2956410042958133412"><ph name="PARENT_NAME_1"/> i <ph name="PARENT_NAME_2"/> gestionen aquest compte.</translation>
+<translation id="8168435359814927499">Contingut</translation>
+<translation id="5403644198645076998">Permet només certs llocs web</translation>
+<translation id="8641930654639604085">Prova de bloquejar els llocs web per a adults</translation>
+<translation id="5639724618331995626">Permet tots els llocs</translation>
+<translation id="796823723482603597">Amb la tecnologia de Brave</translation>
+<translation id="6324034347079777476">La sincronització del sistema Android està desactivada</translation>
+<translation id="5127805178023152808">Sincronització desactivada</translation>
+<translation id="7015203776128479407">La configuració de la sincronització inicial no ha finalitzat. La sincronització està desactivada.</translation>
+<translation id="2497852260688568942">L'administrador ha desactivat la sincronització</translation>
+<translation id="9100610230175265781">S'ha d'introduir una frase de contrasenya</translation>
+<translation id="6108923351542677676">Configuració en curs...</translation>
+<translation id="4062305924942672200">Informació legal</translation>
+<translation id="4256782883801055595">Llicències de programari lliure</translation>
+<translation id="1138681184697033370">Condicions del servei de Brave</translation>
+<translation id="7392539049993970338">Avís de privadesa de Brave</translation>
+<translation id="2677748264148917807">Surt</translation>
+<translation id="5556459405103347317">Torna a carregar</translation>
+<translation id="1623104350909869708">Impedeix que aquesta pàgina creï quadres de diàleg addicionals</translation>
+<translation id="2968755619301702150">Lector de certificats</translation>
+<translation id="1360432990279830238">Vols tancar la sessió i desactivar la sincronització?</translation>
+<translation id="8581481290581777242">Vols esborrar les dades de Brave del dispositiu?</translation>
+<translation id="1318865768845061710">Les adreces d'interès, l'historial, les contrasenyes i altres dades de Brave ja no se sincronitzaran amb el teu Compte de Brave Software</translation>
+<translation id="3325020657155065477">Esborra també les teves dades de Brave d'aquest dispositiu</translation>
+<translation id="6136448902816743006">Com que estàs tancant la sessió d'un compte gestionat per <ph name="DOMAIN_NAME"/>, les teves dades de Brave se suprimiran d'aquest dispositiu. Tanmateix, es conservaran al teu Compte de Brave Software.</translation>
+<translation id="1853026300647876496">S'està contactant amb Brave Software. Aquest procés pot trigar una estona…</translation>
+<translation id="2328985652426384049">No es pot iniciar la sessió</translation>
+<translation id="7723158744459952869">Brave Software ha tardat massa a respondre</translation>
+<translation id="4572422548854449519">Inicia la sessió al compte gestionat</translation>
+<translation id="2689656545739939160">Estàs iniciant la sessió amb un compte gestionat per <ph name="MANAGED_DOMAIN"/> i estàs donant a l'administrador el control de les teves dades de Brave. Les dades passaran a estar vinculades a aquest compte permanentment. Si tanques la sessió de Brave, se suprimiran les teves dades d'aquest dispositiu, però continuaran emmagatzemades al teu compte de Brave Software.</translation>
+<translation id="1749561566933687563">Sincronitzeu les adreces d'interès</translation>
+<translation id="4242533952199664413">Obre la configuració</translation>
+<translation id="1111673857033749125">Les adreces d'interès desades als altres dispositius es mostraran aquí.</translation>
+<translation id="8636825310635137004">Activa la sincronització per accedir a les pestanyes dels altres dispositius que tinguis.</translation>
+<translation id="3269956123044984603">Per accedir a les pestanyes dels altres dispositius que tinguis, activa Sincronitza dades automàticament a la configuració del compte a Android.</translation>
+<translation id="5157964048453367290">Les pestanyes que tingueu obertes a Brave als altres dispositius es mostraran aquí.</translation>
+<translation id="4684427112815847243">Sincronitza-ho tot</translation>
+<translation id="2709516037105925701">Emplenament automàtic</translation>
+<translation id="8820817407110198400">Adreces d'interès</translation>
+<translation id="1644574205037202324">Historial</translation>
+<translation id="17513872634828108">Pestanyes obertes</translation>
+<translation id="1320169905922104972">Targetes de crèdit i adreces que fan servir Brave Software Pay</translation>
+<translation id="6337234675334993532">Encriptació</translation>
+<translation id="6698801883190606802">Gestiona les dades sincronitzades</translation>
+<translation id="3598578758776312506">Encripta les contrasenyes amb credencials de Brave Software</translation>
+<translation id="7810580217418711046">Encripta les dades sincronitzades amb la contrasenya de Brave Software del dia <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Encripta les dades sincronitzades amb la teva frase de contrasenya de sincronització</translation>
+<translation id="2996291259634659425">Creeu una frase de contrasenya</translation>
+<translation id="5713644099811900409">Compte de Brave Software</translation>
+<translation id="8997474919031554666">L'encriptació de frases de contrasenya no inclou les formes de pagament ni les adreces de Brave Software Pay. Només els usuaris que sàpiguen la teva frase de contrasenya poden llegir les dades que encriptes. La frase de contrasenya no s'envia a Brave Software, i Brave Software tampoc no l'emmagatzema. Si l'oblides o vols canviar aquesta opció, has de restablir la sincronització. <ph name="BEGIN_LINK"/>Més informació<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Frase de contrasenya</translation>
+<translation id="7772032839648071052">Confirmeu la frase de contrasenya</translation>
+<translation id="5304593522240415983">Aquest camp no pot estar en blanc</translation>
+<translation id="321773570071367578">Si oblideu la frase de contrasenya o voleu canviar aquesta configuració, <ph name="BEGIN_LINK"/>restabliu la sincronització<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Les frases de contrasenya no coincideixen</translation>
+<translation id="5149495116300586333">L'encriptació de frases de contrasenya no inclou les formes de pagament ni les adreces de Brave Software Pay.
+
+Per canviar aquesta opció, <ph name="BEGIN_LINK"/>restableix la sincronització<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">La frase de contrasenya és incorrecta</translation>
+<translation id="5414836363063783498">S'està verificant...</translation>
+<translation id="6846298663435243399">S'està carregant…</translation>
+<translation id="5517095782334947753">Tens les adreces d'interès, l'historial, les contrasenyes i altres opcions de configuració de l'adreça <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combina les meves dades</translation>
+<translation id="688738109438487280">Afegeix les dades existents a <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Mantén les meves dades separades</translation>
+<translation id="1145536944570833626">Suprimeix les dades existents.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> es vol vincular</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Obtén ajuda<ph name="END_LINK"/> mentre se cerquen dispositius…</translation>
+<translation id="5817918615728894473">Vincula</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Obtén ajuda<ph name="END_LINK1"/> o <ph name="BEGIN_LINK2"/>torna a fer la cerca<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">No s'ha trobat cap dispositiu compatible</translation>
+<translation id="3773755127849930740">Per permetre la vinculació, <ph name="BEGIN_LINK"/>activa el Bluetooth<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave no pot activar l'adaptador Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Obteniu ajuda<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave necessita accedir a la ubicació per poder cercar dispositius. <ph name="BEGIN_LINK"/>Actualitza els permisos<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave necessita accedir a la ubicació per poder cercar dispositius, però aquesta funció està <ph name="BEGIN_LINK"/>desactivada en aquest dispositiu<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave necessita accedir a la ubicació per poder cercar dispositius. <ph name="BEGIN_LINK1"/>Actualitza els permisos<ph name="END_LINK1"/>. L'accés a la ubicació també està <ph name="BEGIN_LINK2"/>desactivat en aquest dispositiu<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Dispositiu connectat</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Intensitat del senyal: # barra}other{Intensitat del senyal: # barres}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> vol cercar dispositius Bluetooth propers. S'han trobat els dispositius següents:</translation>
+<translation id="8368027906805972958">Dispositiu desconegut o no admès (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">La sincronització no funciona</translation>
+<translation id="1810845389119482123">La configuració de la sincronització inicial no ha finalitzat</translation>
+<translation id="3235722914093408050">Obre la configuració d'Android i torna a activar la sincronització del sistema Android per començar la sincronització de Brave</translation>
+<translation id="3367813778245106622">Torna a iniciar la sessió per començar la sincronització</translation>
+<translation id="974555521953189084">Introdueix la teva frase de contrasenya per iniciar la sincronització</translation>
+<translation id="2997266899014181325">Per iniciar la sincronització, activa l'opció Sincronitza les dades de Brave.</translation>
+<translation id="8260126382462817229">Torna a iniciar la sessió</translation>
+<translation id="5919204609460789179">Actualitza <ph name="PRODUCT_NAME"/> per iniciar la sincronització</translation>
+<translation id="397583555483684758">La sincronització ha deixat de funcionar</translation>
+<translation id="1966710179511230534">Actualitzeu les dades d'inici de sessió.</translation>
+<translation id="7063006564040364415">No s'ha pogut connectar amb el servidor de sincronització.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> no està actualitzat.</translation>
+<translation id="4170011742729630528">El servei no està disponible. Torneu-ho a provar més tard.</translation>
+<translation id="7947953824732555851">Acc. i inicia sessió</translation>
+<translation id="8583805026567836021">S'estan esborrant les dades del compte</translation>
+<translation id="8310344678080805313">Pestanyes estàndard</translation>
+<translation id="5748802427693696783">S'ha canviat a les pestanyes estàndard</translation>
+<translation id="7998918019931843664">Torna a obrir la pestanya tancada</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, pestanya</translation>
+<translation id="4452411734226507615">Tanca la pestanya <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opcions disponibles a la part inferior de la pantalla</translation>
+<translation id="4060598801229743805">Hi ha opcions disponibles a prop de la part superior de la pantalla</translation>
+<translation id="2810645512293415242">La pàgina s'ha simplificat per estalviar dades i carregar-se més ràpidament.</translation>
+<translation id="3985215325736559418">Vols tornar a baixar <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Vols tornar a baixar el fitxer <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Baixa</translation>
+<translation id="545042621069398927">S'està accelerant la baixada.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{S'està baixant el fitxer.}other{S'estan baixant # fitxers.}}</translation>
+<translation id="543509235395288790">S'estan baixant <ph name="COUNT"/> fitxers (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">S'està baixant el fitxer (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{S'ha completat 1 baixada.}other{S'han completat # baixades.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{No s'ha pogut completar 1 baixada.}other{No s'han pogut completar # baixades.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Hi ha 1 baixada pendent.}other{Hi ha # baixades pendents.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/></translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> (botó <ph name="LINK_NAME"/>)</translation>
+<translation id="3205824638308738187">Falta poc per acabar.</translation>
+<translation id="3960299545138990065">Reinicia Brave</translation>
+<translation id="3771001275138982843">No s'ha pogut baixar l'actualització</translation>
+<translation id="3888648114124182147">S'està baixant l'actualització de Brave…</translation>
+<translation id="1705567146636171298">Actualitza Brave</translation>
+<translation id="6195417478702700398">Per gaudir de la millor experiència de navegació, obre Brave per actualitzar-lo</translation>
+<translation id="3512968675351418494">Per veure el web en el teu idioma, actualitza Brave a la versió més recent.</translation>
+<translation id="6427112570124116297">Tradueix el web</translation>
+<translation id="1379423114029199501">Fes l'actualització per veure la darrera versió de Brave en el teu idioma</translation>
+<translation id="5684874026226664614">Aquesta pàgina no s'ha pogut traduir.</translation>
+<translation id="6831043979455480757">Tradueix</translation>
+<translation id="1285320974508926690">No tradueixis mai aquest lloc</translation>
+<translation id="773466115871691567">Tradueix sempre les pàgines en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">No tradueixis mai les pàgines en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Més idiomes</translation>
+<translation id="290376772003165898">La pàgina no està en <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">A partir d'ara, les pàgines en <ph name="SOURCE_LANGUAGE"/> es traduiran a <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Les pàgines en <ph name="LANGUAGE"/> no es traduiran</translation>
+<translation id="5447765697759493033">Aquest lloc web no es traduirà</translation>
+<translation id="4880127995492972015">Tradueix…</translation>
+<translation id="641643625718530986">Imprimeix…</translation>
+<translation id="8909135823018751308">Comparteix...</translation>
+<translation id="4996978546172906250">Comparteix mitjançant</translation>
+<translation id="6333140779060797560">Comparteix mitjançant <ph name="APPLICATION"/>.</translation>
+<translation id="6277522088822131679">S'ha produït un problema en imprimir la pàgina. Torneu-ho a provar.</translation>
+<translation id="3254409185687681395">Afegeix aquesta pàgina a les adreces d'interès</translation>
+<translation id="497421865427891073">Ves endavant</translation>
+<translation id="813082847718468539">Mostra la informació del lloc</translation>
+<translation id="2532336938189706096">Visualització web</translation>
+<translation id="6005538289190791541">Contrasenya suggerida</translation>
+<translation id="4634124774493850572">Fes servir la contrasenya</translation>
+<translation id="8285489906452138776">Per visitar aquest lloc web, Brave necessita permís per accedir a la teva càmera.</translation>
+<translation id="320189792589364011">Per visitar aquest lloc web, Brave necessita permís per accedir al teu micròfon.</translation>
+<translation id="7988136689212463100">Per visitar aquest lloc web, Brave necessita permís per accedir a la teva càmera i al teu micròfon.</translation>
+<translation id="4931190655840828017">Brave necessita accedir a la teva ubicació per compartir-la amb aquest lloc web.</translation>
+<translation id="3088191967551450609">Brave necessita accedir a l'emmagatzematge per poder baixar fitxers.</translation>
+<translation id="8942627711005830162">Obre en una altra finestra</translation>
+<translation id="4195643157523330669">Obre en una pestanya nova</translation>
+<translation id="1100066534610197918">Obre en una pestanya d'un grup</translation>
+<translation id="4860895144060829044">Truca</translation>
+<translation id="6896758677409633944">Copia</translation>
+<translation id="8393700583063109961">Envia el missatge</translation>
+<translation id="3557336313807607643">Afegeix als contactes</translation>
+<translation id="4269820728363426813">Copia l'adreça de l'enllaç</translation>
+<translation id="1206892813135768548">Copia el text de l'enllaç</translation>
+<translation id="1204037785786432551">Baixa l'enllaç</translation>
+<translation id="6864459304226931083">Baixa la imatge</translation>
+<translation id="8209050860603202033">Obre la imatge</translation>
+<translation id="8073388330009372546">Obre en una pestanya nova</translation>
+<translation id="6649642165559792194">Previsualitza la imatge <ph name="BEGIN_NEW"/>Novetat<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Carrega la imatge</translation>
+<translation id="3845332215609790146">Cerca amb Brave Software Lens <ph name="BEGIN_NEW"/>Novetat<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Cerca aquesta imatge a <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Comparteix la imatge</translation>
+<translation id="5833984609253377421">Comparteix l'enllaç</translation>
+<translation id="6475951671322991020">Baixa el vídeo</translation>
+<translation id="2317945146070194624">Obre en pestanya nova a Brave</translation>
+<translation id="7975379999046275268">Previsualitza la pàgina <ph name="BEGIN_NEW"/>Novetat<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">S'està actualitzant la pàgina</translation>
+<translation id="36525718899759834">Baixeu l'aplicació des de Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Fosc</translation>
+<translation id="1807246157184219062">Clar</translation>
+<translation id="4056223980640387499">Sèpia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Trieu una pestanya per compartir-la.</translation>
+<translation id="8719023831149562936">La pestanya actual no es pot compartir.</translation>
+<translation id="2139186145475833000">Afegeix a pantalla d'inici</translation>
+<translation id="4616150815774728855">Obre <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">L'aplicació no s'ha pogut obrir</translation>
+<translation id="5129038482087801250">Instal·la l'aplicació web</translation>
+<translation id="3789841737615482174">Instal·la</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> s'ha afegit a la pantalla d'inici</translation>
+<translation id="7333031090786104871">Encara s'hi està afegint el lloc anterior</translation>
+<translation id="1036727731225946849">S'està afegint <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">S'ha afegit a la pantalla d'inici</translation>
+<translation id="2146738493024040262">Obre l'aplicació instantània</translation>
+<translation id="7016516562562142042">Es permet al motor de cerca actual</translation>
+<translation id="6177111841848151710">S'ha bloquejat per al motor de cerca actual</translation>
+<translation id="145097072038377568">Aquest permís està desactivat a la configuració d'Android</translation>
+<translation id="8007176423574883786">Aquesta ubicació està desactivada per a aquest dispositiu</translation>
+<translation id="164269334534774161">Es mostra una còpia sense connexió d'aquesta pàgina creada el dia <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Aquesta pàgina sense connexió és del dia <ph name="CREATION_TIME"/> i pot ser diferent de la versió en línia.</translation>
+<translation id="8840953339110955557">Aquesta pàgina pot ser diferent de la versió en línia.</translation>
+<translation id="6405300764336705484">Aquest contingut és del domini <ph name="DOMAIN_NAME"/>, oferit per Brave Software.</translation>
+<translation id="1006017844123154345">Obre en línia</translation>
+<translation id="3326636747541519688">Pàgina en mode bàsic oferida per Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Carrega la pàgina original<ph name="END_LINK"/> del domini <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Si això passa sovint, prova aquests <ph name="BEGIN_LINK"/>suggeriments<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Contingut amagat</translation>
+<translation id="3810973564298564668">Gestiona</translation>
+<translation id="5199929503336119739">Perfil professional</translation>
+<translation id="528192093759286357">Arrossegueu la pantalla des de la part superior i toqueu el botó Enrere per sortir de la pantalla completa.</translation>
+<translation id="2836148919159985482">Toqueu el botó Enrere per sortir de la pantalla completa.</translation>
+<translation id="3967822245660637423">S'ha completat la baixada</translation>
+<translation id="2434158240863470628">S'ha completat la baixada <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Error de baixada</translation>
+<translation id="1384959399684842514">La baixada s'ha posat en pausa</translation>
+<translation id="1671236975893690980">Baixada pendent…</translation>
+<translation id="5561549206367097665">S'està esperant la xarxa…</translation>
+<translation id="5864419784173784555">S'està esperant que finalitzi una altra baixada…</translation>
+<translation id="6461962085415701688">El fitxer no es pot obrir</translation>
+<translation id="1178581264944972037">Posa en pausa</translation>
+<translation id="8200772114523450471">Reprèn</translation>
+<translation id="1409879593029778104">No s'ha baixat el fitxer <ph name="FILE_NAME"/> perquè ja existeix.</translation>
+<translation id="3387650086002190359">No s'ha pogut baixar <ph name="FILE_NAME"/> a causa d'errors amb el sistema de fitxers.</translation>
+<translation id="6482749332252372425">No s'ha pogut baixar <ph name="FILE_NAME"/> perquè falta espai d'emmagatzematge.</translation>
+<translation id="7619072057915878432">No s'ha pogut baixar <ph name="FILE_NAME"/> a causa d'errors a la xarxa.</translation>
+<translation id="1477626028522505441">No s'ha pogut baixar <ph name="FILE_NAME"/> a causa de problemes amb el servidor.</translation>
+<translation id="3692944402865947621">No s'ha pogut baixar <ph name="FILE_NAME"/> perquè no es pot trobar la ubicació d'emmagatzematge.</translation>
+<translation id="604996488070107836">No s'ha pogut baixar <ph name="FILE_NAME"/> a causa d'un error desconegut.</translation>
+<translation id="6738867403308150051">S'està baixant...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">S'han baixat <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">S'han baixat <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">S'han baixat <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Queda 1 fitxer</translation>
+<translation id="8186512483418048923">Queden <ph name="FILES"/> fitxers</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fitxer baixat}other{<ph name="FILES_DOWNLOADED_MANY"/> fitxers baixats}}</translation>
+<translation id="8037750541064988519">Queden <ph name="DAYS"/> dies</translation>
+<translation id="8190358571722158785">Queda 1 dia</translation>
+<translation id="60923314841986378">Queden <ph name="HOURS"/> hores</translation>
+<translation id="510275257476243843">Queda 1 hora</translation>
+<translation id="970715775301869095">Queden <ph name="MINUTES"/> minuts</translation>
+<translation id="3236059992281584593">Queda 1 minut</translation>
+<translation id="2777555524387840389">Queden <ph name="SECONDS"/> segons</translation>
+<translation id="2781151931089541271">Queda 1 segon</translation>
+<translation id="3303414029551471755">Voleu baixar el contingut?</translation>
+<translation id="8617240290563765734">Voleu obrir l'URL suggerit que s'especifica al contingut que s'ha baixat?</translation>
+<translation id="1373696734384179344">No hi ha prou memòria per baixar el contingut seleccionat.</translation>
+<translation id="5271967389191913893">El dispositiu no pot obrir el contingut que s'ha de baixar.</translation>
+<translation id="883806473910249246">S'ha produït un error en baixar el contingut.</translation>
+<translation id="5626134646977739690">Nom:</translation>
+<translation id="7963646190083259054">Proveïdor:</translation>
+<translation id="3414952576877147120">Mida:</translation>
+<translation id="7375125077091615385">Tipus:</translation>
+<translation id="5765780083710877561">Descripció:</translation>
+<translation id="4881695831933465202">Obre</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> kB disponibles</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB disponibles</translation>
+<translation id="5424588387303617268">GB disponibles: <ph name="GIGABYTES"/></translation>
+<translation id="5793665092639000975">S'estan utilitzant <ph name="SPACE_USED"/> de <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Tots</translation>
+<translation id="4988526792673242964">Pàgines</translation>
+<translation id="3810838688059735925">Vídeo</translation>
+<translation id="3616113530831147358">Àudio</translation>
+<translation id="9219103736887031265">Imatges</translation>
+<translation id="8250920743982581267">Documents</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fitxer}other{# fitxers}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imatge}other{# imatges}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}other{# vídeos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# fitxer d'àudio}other{# fitxers d'àudio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# pàgina}other{# pàgines}}</translation>
+<translation id="5456381639095306749">Baixa la pàgina</translation>
+<translation id="2394602618534698961">Els fitxers que baixes es mostren aquí</translation>
+<translation id="7810647596859435254">Obre amb…</translation>
+<translation id="5655963694829536461">Cerca a les baixades</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Els meus fitxers</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Els articles es mostren aquí i els pots llegir fins i tot sense connexió</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
+<translation id="5853623416121554550">en pausa</translation>
+<translation id="8965591936373831584">pendent</translation>
+<translation id="2779651927720337254">ha fallat</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Ara mateix</translation>
+<translation id="4000212216660919741">Pàgina d'inici sense connexió</translation>
+<translation id="9133397713400217035">Explora sense connexió</translation>
+<translation id="968900484120156207">Les pàgines que visitis es mostraran aquí</translation>
+<translation id="7882131421121961860">No s'ha trobat l'element que cerques a l'historial</translation>
+<translation id="3549657413697417275">Cerca a l'historial</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Experiència de primera execució de Brave</translation>
+<translation id="2700285883409956633">En fer servir aquesta aplicació, acceptes les <ph name="BEGIN_LINK1"/>condicions del servei<ph name="END_LINK1"/> i l'<ph name="BEGIN_LINK2"/>avís de privadesa<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="1640714894372474981">En utilitzar aquesta aplicació, acceptes les <ph name="BEGIN_LINK1"/>condicions del servei<ph name="END_LINK1"/> i l'<ph name="BEGIN_LINK2"/>avís de privadesa<ph name="END_LINK2"/> de Brave, així com l'<ph name="BEGIN_LINK3"/>avís de privadesa per a comptes de Brave Software gestionats amb Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> s'obrirà a Brave. En continuar, acceptes les <ph name="BEGIN_LINK1"/>condicions del servei<ph name="END_LINK1"/> i l'<ph name="BEGIN_LINK2"/>avís de privadesa<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> s'obrirà a Brave. En continuar, acceptes les <ph name="BEGIN_LINK1"/>condicions del servei<ph name="END_LINK1"/> i l'<ph name="BEGIN_LINK2"/>avís de privadesa<ph name="END_LINK2"/> de Brave, així com l'<ph name="BEGIN_LINK3"/>avís de privadesa per als comptes de Brave Software gestionats amb Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Ajuda a millorar Brave enviant estadístiques d'ús i informes d'error a Brave Software.</translation>
+<translation id="3518985090088779359">Accepta i continua</translation>
+<translation id="7207456302801184289">Et donem la benvinguda a Brave</translation>
+<translation id="704822250101715322">S'està esperant que Serveis de Brave Software Play s'acabi d'actualitzar</translation>
+<translation id="1231733316453485619">Vols activar la sincronització?</translation>
+<translation id="5132942445612118989">Sincronitza les contrasenyes, l'historial i altres elements en tots els dispositius</translation>
+<translation id="5736731321935944068">És possible que Brave Software utilitzi el teu historial per personalitzar la Cerca, els anuncis i altres serveis de Brave Software</translation>
+<translation id="4013614219085422040">És possible que Brave Software utilitzi el teu historial per personalitzar la Cerca i altres serveis de Brave Software</translation>
+<translation id="5581519193887989363">Sempre pots anar a la <ph name="BEGIN_LINK1"/>configuració<ph name="END_LINK1"/> per decidir què vols sincronitzar.</translation>
+<translation id="741204030948306876">Sí, ho accepto</translation>
+<translation id="2410754283952462441">Tria un compte</translation>
+<translation id="2227444325776770048">Continua com a <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">No ets <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Per accedir a les adreces d'interès des de tots els dispositius, activa la sincronització</translation>
+<translation id="2818669890320396765">Per accedir a les adreces d'interès des de tots els dispositius, inicia la sessió i activa la sincronització</translation>
+<translation id="6003646045106347985">Perquè Brave Software et suggereixi contingut personalitzat, activa la sincronització</translation>
+<translation id="8494430740943879273">Perquè Brave Software et suggereixi contingut personalitzat, inicia la sessió i activa la sincronització</translation>
+<translation id="5862731021271217234">Activa la sincronització per accedir a les pestanyes dels altres dispositius que tinguis</translation>
+<translation id="3568688522516854065">Inicia la sessió i activa la sincronització per accedir a les pestanyes dels altres dispositius que tinguis</translation>
+<translation id="1208340532756947324">Per sincronitzar i personalitzar el contingut en tots els dispositius, activa la sincronització</translation>
+<translation id="4472118726404937099">Per sincronitzar i personalitzar el contingut en tots els dispositius, inicia la sessió i activa la sincronització</translation>
+<translation id="2426805022920575512">Tria un altre compte</translation>
+<translation id="6790428901817661496">Reprodueix</translation>
+<translation id="1272079795634619415">Atura</translation>
+<translation id="2874939134665556319">Pista anterior</translation>
+<translation id="4046123991198612571">Pista següent</translation>
+<translation id="3859306556332390985">Avança</translation>
+<translation id="8441146129660941386">Retrocedeix</translation>
+<translation id="6706288973712894588">En aquests moments no tens connexió.\n<ph name="BEGIN_LINK"/>Explora el feed sense connexió<ph name="END_LINK"/>.</translation>
+<translation id="572328651809341494">Pestanyes recents</translation>
+<translation id="8497726226069778601">Aquí encara no hi ha contingut per mostrar</translation>
+<translation id="5423934151118863508">Les pàgines més visitades es mostraran aquí</translation>
+<translation id="6127379762771434464">S'ha suprimit l'element</translation>
+<translation id="4605958867780575332">S'ha suprimit l'element: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle de Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Altres dispositius</translation>
+<translation id="4738836084190194332">Última sincronització: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{fa # minut}other{fa # minuts}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{fa # hora}other{fa # hores}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{fa # dia}other{fa # dies}}</translation>
+<translation id="2762000892062317888">ara mateix</translation>
+<translation id="1407135791313364759">Obre-les totes</translation>
+<translation id="1209206284964581585">Amaga per ara</translation>
+<translation id="129553762522093515">Tancades recentment</translation>
+<translation id="8413126021676339697">Mostra l'historial complet</translation>
+<translation id="7876243839304621966">Suprimeix-ho tot</translation>
+<translation id="8487700953926739672">Disponible sense connexió</translation>
+<translation id="5224771365102442243">Amb vídeo</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Més informació<ph name="END_LINK"/> sobre el contingut suggerit</translation>
+<translation id="7542481630195938534">No es poden obtenir suggeriments</translation>
+<translation id="5013696553129441713">No hi ha cap suggeriment nou</translation>
+<translation id="1736419249208073774">Explora</translation>
+<translation id="7444811645081526538">Més categories</translation>
+<translation id="6709133671862442373">Notícies</translation>
+<translation id="1264974993859112054">Esports</translation>
+<translation id="9139318394846604261">Compres</translation>
+<translation id="3912508018559818924">Estem cercant el millor contingut del web…</translation>
+<translation id="526421993248218238">No es pot carregar aquesta pàgina</translation>
+<translation id="614940544461990577">Prova el següent:</translation>
+<translation id="3288003805934695103">Torneu a carregar la pàgina</translation>
+<translation id="2353636109065292463">S'està comprovant la connexió a Internet</translation>
+<translation id="2858138569776157458">Llocs populars</translation>
+<translation id="8364299278605033898">Mostra llocs web populars</translation>
+<translation id="1171770572613082465">Toca el botó Llocs populars per veure les tendències en llocs web</translation>
+<translation id="5233638681132016545">Pestanya nova</translation>
+<translation id="4521874409998847950">Publicada originalment per <ph name="PUBLISHER_ORIGIN"/>, <ph name="BEGIN_DEEMPHASIZED"/>oferida per Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Versió nova disponible</translation>
+<translation id="4058091506841967397">Brave no actualitzable</translation>
+<translation id="6316139424528454185">Versió d'Android no admesa</translation>
+<translation id="6989267951144302301">No s'ha pogut baixar</translation>
+<translation id="624789221780392884">Actualització a punt.</translation>
+<translation id="1549000191223877751">Mou a l'altra finestra</translation>
+<translation id="7481312909269577407">Endavant</translation>
+<translation id="4084682180776658562">Adreça d'interès</translation>
+<translation id="6437478888915024427">Informació de la pàgina</translation>
+<translation id="7180611975245234373">Actualitza</translation>
+<translation id="4913169188695071480">Deixa d'actualitzar</translation>
+<translation id="1829244130665387512">Cerca a la pàgina</translation>
+<translation id="6593061639179217415">Lloc web per a ordinador</translation>
+<translation id="9063523880881406963">Desactiva Mostra com a ordinador</translation>
+<translation id="2038563949887743358">Activa Mostra com a ordinador</translation>
+<translation id="2433507940547922241">Aparença</translation>
+<translation id="983192555821071799">Tanca totes les pestanyes</translation>
+<translation id="1310482092992808703">Agrupa les pestanyes</translation>
+<translation id="7725024127233776428">Les pàgines que afegeixis a les adreces d'interès es mostraran aquí</translation>
+<translation id="4404568932422911380">Cap adreça d'interès</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> adreça d'interès}other{<ph name="BOOKMARKS_COUNT_MANY"/> adreces d'interès}}</translation>
+<translation id="3739899004075612870">Afegit a les adreces de: <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">S'ha afegit a les adreces d'interès.</translation>
+<translation id="4452548195519783679">Adreça d'interès afegida a <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">L'adreça d'interès no s'ha pogut afegir.</translation>
+<translation id="2842985007712546952">Carpeta principal</translation>
+<translation id="9065203028668620118">Edita</translation>
+<translation id="4405224443901389797">Mou a…</translation>
+<translation id="5170568018924773124">Mostra a la carpeta</translation>
+<translation id="8035133914807600019">Carpeta nova…</translation>
+<translation id="4532845899244822526">Tria la carpeta</translation>
+<translation id="6627583120233659107">Edita la carpeta</translation>
+<translation id="1197267115302279827">Mou les adreces d'interès</translation>
+<translation id="6963766334940102469">Suprimeix les adreces d'interès</translation>
+<translation id="4351244548802238354">Tanca el quadre de diàleg</translation>
+<translation id="451872707440238414">Cerca a les adreces d'interès</translation>
+<translation id="8901170036886848654">No s'ha trobat cap adreça d'interès</translation>
+<translation id="6404511346730675251">Edita l'adreça d'interès</translation>
+<translation id="3894427358181296146">Afegeix una carpeta</translation>
+<translation id="5327248766486351172">Nom</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Carpeta</translation>
+<translation id="5161254044473106830">Cal indicar un títol</translation>
+<translation id="2996809686854298943">Es necessita un URL</translation>
+<translation id="2536728043171574184">S'està mostrant una còpia sense connexió d'aquesta pàgina</translation>
+<translation id="4698034686595694889">Mostra sense connexió a <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> i més llocs web</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave carregarà la pàgina quan estigui a punt}other{Brave carregarà les pàgines quan estiguin a punt}}</translation>
+<translation id="6811034713472274749">Ja es pot veure la pàgina</translation>
+<translation id="4561979708150884304">No hi ha connexió</translation>
+<translation id="8274165955039650276">Mostra les baixades</translation>
+<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER"/> de <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">No hi ha cap resultat</translation>
+<translation id="981121421437150478">Sense connexió</translation>
+<translation id="3298243779924642547">Mode bàsic</translation>
+<translation id="393697183122708255">La cerca per veu no està disponible</translation>
+<translation id="7191430249889272776">Pestanya oberta en segon pla</translation>
+<translation id="8445059357334030806">Obre a Brave</translation>
+<translation id="4720023427747327413">Obre a <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Obre al navegador</translation>
+<translation id="1113597929977215864">Mostra la visualització simplificada</translation>
+<translation id="1513352483775369820">Adreces interès i historial web</translation>
+<translation id="4939482511480190003">Ajuda a millorar Brave. <ph name="BEGIN_LINK"/>Respon a l'enquesta<ph name="END_LINK"/>.</translation>
+<translation id="2501278716633472235">Torna</translation>
+<translation id="5596627076506792578">Més opcions</translation>
+<translation id="3522247891732774234">Hi ha una actualització disponible. Més opcions</translation>
+<translation id="6773423637732432200">No es pot actualitzar Brave. Més opcions</translation>
+<translation id="3328801116991980348">Informació del lloc web</translation>
+<translation id="5391532827096253100">La connexió amb aquest lloc web no és segura. Informació del lloc web</translation>
+<translation id="6206551242102657620">La connexió és segura. Informació del lloc web</translation>
+<translation id="6963642900430330478">Aquesta pàgina és perillosa. Informació del lloc web</translation>
+<translation id="9070377983101773829">Inicia la cerca per veu</translation>
+<translation id="8676374126336081632">Esborra l'entrada</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> pestanya oberta; toca per canviar de pestanya}other{<ph name="OPEN_TABS_MANY"/> pestanyes obertes; toca per canviar de pestanya}}</translation>
+<translation id="2369533728426058518">pestanyes obertes</translation>
+<translation id="7071521146534760487">Gestiona el compte</translation>
+<translation id="932327136139879170">Inici</translation>
+<translation id="2707726405694321444">Actualitza la pàgina</translation>
+<translation id="2891154217021530873">Atura la càrrega de la pàgina</translation>
+<translation id="6710213216561001401">Anterior</translation>
+<translation id="6659594942844771486">Pestanya</translation>
+<translation id="1933845786846280168">Pestanya seleccionada</translation>
+<translation id="2268044343513325586">Restringeix</translation>
+<translation id="7846076177841592234">Cancel·la la selecció</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> elements seleccionats. Hi ha opcions disponibles a prop de la part superior de la pantalla.</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> elements seleccionats</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Comparteix 1 element seleccionat}other{Comparteix # elements seleccionats}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Suprimeix 1 element seleccionat}other{Suprimeix # elements seleccionats}}</translation>
+<translation id="1283039547216852943">Toca per desplegar</translation>
+<translation id="5962718611393537961">Toca per replegar</translation>
+<translation id="8076492880354921740">Pestanyes</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 seleccionat}other{# seleccionats}}</translation>
+<translation id="6818926723028410516">Selecciona elements</translation>
+<translation id="4797039098279997504">Toqueu per tornar a <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Toca per anar al lloc web</translation>
+<translation id="429312253194641664">Un lloc web està reproduint contingut multimèdia</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> comparteix la teva pantalla</translation>
+<translation id="8833831881926404480">Un lloc web està compartint la teva pantalla</translation>
+<translation id="9086455579313502267">No es pot accedir a la xarxa</translation>
+<translation id="938850635132480979">Error: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Obre a <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Obre en una aplicació de mapes</translation>
+<translation id="7698359219371678927">Crea una adreça electrònica a <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Crea una adreça electrònica</translation>
+<translation id="5665379678064389456">Crea un esdeveniment a <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Crea un esdeveniment</translation>
+<translation id="2111511281910874386">Ves a la pàgina</translation>
+<translation id="3988466920954086464">Consulta els resultats de la cerca instantània en aquest tauler</translation>
+<translation id="2744248271121720757">Toca una paraula per fer una cerca a l'instant o per veure accions relacionades</translation>
+<translation id="9155898266292537608">També pots fer un toc ràpid en una paraula per fer cerques</translation>
+<translation id="3232754137068452469">Aplicació web</translation>
+<translation id="1430915738399379752">Imprimeix</translation>
+<translation id="3775705724665058594">Envia als teus dispositius</translation>
+<translation id="6364438453358674297">Voleu suprimir el suggeriment de l'historial?</translation>
+<translation id="213279576345780926">Pestanya <ph name="TAB_TITLE"/> tancada</translation>
+<translation id="6850830437481525139">S'han tancat <ph name="TAB_COUNT"/> pestanyes</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> s'ha suprimit</translation>
+<translation id="4663756553811254707">S'han suprimit <ph name="NUMBER_OF_BOOKMARKS"/> adreces d'interès</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> baixades suprimides</translation>
+<translation id="1248710015876067820">No s'admet aquest nombre d'instàncies de Brave.</translation>
+<translation id="4259722352634471385">S'ha bloquejat la navegació: <ph name="URL"/></translation>
+<translation id="8959122750345127698">No es pot accedir a la navegació: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Tanca la pestanya</translation>
+<translation id="7772375229873196092">Tanca <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Historial de navegació</translation>
+<translation id="9169507124922466868">L'historial de navegació està obert fins a la meitat</translation>
+<translation id="1327257854815634930">L'historial de navegació està obert</translation>
+<translation id="8788265440806329501">L'historial de navegació està tancat</translation>
+<translation id="7482656565088326534">Pestanya de previsualització</translation>
+<translation id="8427875596167638501">La pestanya de previsualització està oberta fins a la meitat</translation>
+<translation id="9102803872260866941">La pestanya de previsualització està oberta</translation>
+<translation id="2942036813789421260">La pestanya de previsualització està tancada</translation>
+<translation id="6355102470683871794">Emmagatzematge de Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Esborrem emmagatz. lloc web?</translation>
+<translation id="9205995714227143200">Emmagatzematge de llocs web que Brave no considera important (com ara llocs web sense configuració desada o aquells que no visites sovint)</translation>
+<translation id="3997476611815694295">Emmagatzematge no important</translation>
+<translation id="8493948351860045254">Allibera espai</translation>
+<translation id="2324920234469020158">Amb aquesta acció, se suprimiran les galetes, la memòria cau i altres dades de llocs que Brave no consideri importants.</translation>
+<translation id="5447201525962359567">Tot l'emmagatzematge del lloc web, com ara les galetes i altres dades emmagatzemades localment</translation>
+<translation id="1376578503827013741">S'està calculant…</translation>
+<translation id="583281660410589416">Desconegut</translation>
+<translation id="2323763861024343754">Emmagatzematge del lloc web</translation>
+<translation id="3587672679800759167">Dades totals utilitzades per Brave, com ara comptes, adreces d'interès i opcions de configuració desades</translation>
+<translation id="6545017243486555795">Esborra totes les dades</translation>
+<translation id="4095146165863963773">Vols suprimir les dades de l'aplicació?</translation>
+<translation id="53119194224775367">Totes les dades de les aplicacions de Brave, com ara els fitxers, la configuració, els comptes o les bases de dades, entre d'altres, se suprimiran permanentment.</translation>
+<translation id="5307446750509046227">Esborra emmagatz. lloc</translation>
+<translation id="300526633675317032">Amb aquesta acció s'esborraran <ph name="SIZE_IN_KB"/> d'emmagatzematge del lloc web.</translation>
+<translation id="8068648041423924542">No es pot seleccionar el certificat.</translation>
+<translation id="2315043854645842844">El sistema operatiu no permet seleccionar el certificat del client.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> es vol connectar</translation>
+<translation id="5308380583665731573">Connecta</translation>
+<translation id="868929229000858085">Cerca als contactes</translation>
+<translation id="1919950603503897840">Selecciona contactes</translation>
+<translation id="7986741934819883144">Selecciona un contacte</translation>
+<translation id="3333961966071413176">Tots els contactes</translation>
+<translation id="4994033804516042629">No s'ha trobat cap contacte</translation>
+<translation id="5403592356182871684">Noms</translation>
+<translation id="2717722538473713889">Adreces electròniques</translation>
+<translation id="381841723434055211">Números de telèfon</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(i 1 més)}other{(i # més)}}</translation>
+<translation id="5197729504361054390">Els contactes que seleccionis es compartiran amb <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Descodificador d'imatges</translation>
+<translation id="8067883171444229417">Reprodueix el vídeo</translation>
+<translation id="6560414384669816528">Cerca amb Sogou</translation>
+<translation id="5406914950576900927">Brave pot utilitzar <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> per fer cerques a la Xina. Per canviar-ho, ves a <ph name="BEGIN_LINK"/>Configuració<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Continua amb Brave Software</translation>
+<translation id="4384468725000734951">S'utilitza Sogou per a la cerca</translation>
+<translation id="6103327872225198548">S'utilitza Brave Software per a la cerca</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Aquesta aplicació s'està executant a Brave</translation>
+<translation id="6143689084714664628">S'està executant a Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> també té dades a Brave</translation>
+<translation id="2734140769649165081">Pots esborrar les dades a la configuració de Brave</translation>
+<translation id="8232956427053453090">Conserva les dades</translation>
+<translation id="4298388696830689168">Llocs web enllaçats</translation>
+<translation id="5763514718066511291">Toca per copiar l'URL d'aquesta aplicació</translation>
+<translation id="6496823230996795692">Per utilitzar <ph name="APP_NAME"/> per primera vegada, connecta't a Internet.</translation>
+<translation id="751961395872307827">No es pot connectar amb el lloc web</translation>
+<translation id="4878404682131129617">S'ha produït un error en establir un túnel mitjançant el servidor intermediari</translation>
+<translation id="4749960740855309258">Obre una pestanya nova</translation>
+<translation id="8788968922598763114">Torna a obrir l'última pestanya tancada</translation>
+<translation id="7929962904089429003">Obre el menú</translation>
+<translation id="6039379616847168523">Ves a la pestanya següent</translation>
+<translation id="5210286577605176222">Ves a la pestanya anterior</translation>
+<translation id="124678866338384709">Tanca la pestanya actual</translation>
+<translation id="3714981814255182093">Obre la barra de cerca</translation>
+<translation id="5441522332038954058">Ves a la barra d'adreces</translation>
+<translation id="3398320232533725830">Obre el gestor d'adreces d'interès</translation>
+<translation id="6583199322650523874">Afegeix la pàgina actual a les adreces d'interès</translation>
+<translation id="8489271220582375723">Obre la pàgina de l'historial</translation>
+<translation id="4837753911714442426">Obre les opcions per imprimir la pàgina</translation>
+<translation id="5726692708398506830">Augmenta la mida de tots els elements de la pàgina</translation>
+<translation id="3259831549858767975">Redueix la mida de tots els elements de la pàgina</translation>
+<translation id="8015452622527143194">Restableix la mida de tots els elements de la pàgina</translation>
+<translation id="3443221991560634068">Torna a carregar la pàgina actual</translation>
+<translation id="123724288017357924">Carrega pàgina actual; ignora contingut en memòria</translation>
+<translation id="305870044889644984">Obre Centre d'ajuda de Brave en una pestanya nova</translation>
+<translation id="3166827708714933426">Dreceres per a pestanyes i finestres</translation>
+<translation id="3169981355900570544">Dreceres per a funcions de Brave Software Brave</translation>
+<translation id="4558311620361989323">Dreceres per a pàgines web</translation>
+<translation id="1908301351964700579">Encara s'està preparant Brave per a la RV. Reinicia'l més tard.</translation>
+<translation id="8970887620466824814">S'ha produït un error.</translation>
+<translation id="1875543012935658554">Torna a obrir Brave.</translation>
+<translation id="79859296434321399">Per veure contingut en realitat augmentada, instal·la ARCore</translation>
+<translation id="8558485628462305855">Per veure contingut en realitat augmentada, actualitza ARCore</translation>
+<translation id="3513704683820682405">Realitat augmentada</translation>
+<translation id="5475862044948910901">Vols iniciar la sessió de realitat augmentada?</translation>
 <translation id="7365126855094612066">Mentre duri aquesta sessió, el lloc web podrà fer el següent:
 • Crear un mapa en 3D del teu entorn.
 • Fer el seguiment del moviment de la càmera.
 
 El lloc web NO obté accés a la càmera. Només tu pots veure les imatges de la càmera.</translation>
-<translation id="7375125077091615385">Tipus:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" /></translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Experiència de primera execució de Chrome</translation>
-<translation id="741204030948306876">Sí, ho accepto</translation>
-<translation id="7413229368719586778">Data d'inici: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Pregunta-m'ho abans</translation>
-<translation id="7423538860840206698">L'accés de lectura al porta-retalls està bloquejat</translation>
-<translation id="7431991332293347422">Controla com s'utilitza l'historial de navegació per personalitzar la Cerca i més</translation>
-<translation id="7437998757836447326">Tanca la sessió de Chrome</translation>
-<translation id="7438641746574390233">Quan el mode bàsic estigui activat, Chrome utilitzarà els servidors de Google perquè les pàgines es carreguin més de pressa. El mode bàsic reescriu les pàgines molt lentes per carregar només el contingut essencial. El mode bàsic no s'aplica a les pestanyes d'incògnit.</translation>
-<translation id="7444811645081526538">Més categories</translation>
-<translation id="7445411102860286510">Permet que els llocs web reprodueixin automàticament vídeos silenciats (opció recomanada)</translation>
-<translation id="7453467225369441013">Et tanca la sessió de la majoria de llocs web, però no la del Compte de Google.</translation>
-<translation id="7454641608352164238">No hi ha prou espai</translation>
-<translation id="7475192538862203634">Si això passa sovint, prova aquests <ph name="BEGIN_LINK" />suggeriments<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">La targeta SD no s'ha trobat. Pot ser que faltin alguns fitxers.</translation>
-<translation id="7479104141328977413">Gestió de pestanyes</translation>
-<translation id="7481312909269577407">Endavant</translation>
-<translation id="7482656565088326534">Pestanya de previsualització</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (última actualització: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">dades estalviades</translation>
-<translation id="7498271377022651285">Espereu...</translation>
-<translation id="7514365320538308">Baixa</translation>
-<translation id="751961395872307827">No es pot connectar amb el lloc web</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">No es poden obtenir suggeriments</translation>
-<translation id="7559975015014302720">El mode bàsic està desactivat</translation>
-<translation id="7562080006725997899">S'estan esborrant les dades de navegació</translation>
-<translation id="756809126120519699">S'han esborrat les dades de Chrome</translation>
-<translation id="757524316907819857">Impedeix que els llocs web reprodueixin contingut protegit</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fitxer baixat}other{<ph name="FILES_DOWNLOADED_MANY" /> fitxers baixats}}</translation>
-<translation id="7588219262685291874">Activa el tema fosc quan l'estalvi de bateria del dispositiu estigui activat</translation>
-<translation id="7589445247086920869">Bloqueja al motor de cerca actual</translation>
-<translation id="7593557518625677601">Obre la configuració d'Android i torna a activar la sincronització del sistema Android per començar la sincronització de Chrome</translation>
-<translation id="7596558890252710462">Sistema operatiu</translation>
-<translation id="7605594153474022051">La sincronització no funciona</translation>
-<translation id="7606077192958116810">El mode bàsic està activat. Gestiona'l a Configuració.</translation>
-<translation id="7612619742409846846">Has iniciat la sessió a Google com a</translation>
-<translation id="7619072057915878432">No s'ha pogut baixar <ph name="FILE_NAME" /> a causa d'errors a la xarxa.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Obtén ajuda<ph name="END_LINK1" /> o <ph name="BEGIN_LINK2" />torna a fer la cerca<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Et donem la benvinguda a Chrome</translation>
-<translation id="7638584964844754484">La frase de contrasenya és incorrecta</translation>
-<translation id="7641339528570811325">Esborra les dades de navegació…</translation>
-<translation id="7648422057306047504">Encripta les contrasenyes amb credencials de Google</translation>
-<translation id="7649070708921625228">Ajuda</translation>
-<translation id="7658239707568436148">Cancel·la</translation>
-<translation id="7665369617277396874">Afegeix un compte</translation>
-<translation id="766587987807204883">Els articles es mostren aquí i els pots llegir fins i tot sense connexió</translation>
-<translation id="7682724950699840886">Segueix aquests consells: comprova que hi hagi prou espai al dispositiu i prova d'exportar les contrasenyes de nou.</translation>
-<translation id="7685301384041462804">Assegura't que confies en aquest lloc web abans d'entrar al mode RV.</translation>
-<translation id="7698359219371678927">Crea una adreça electrònica a <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Completa automàticament les cerques i els URL</translation>
-<translation id="7725024127233776428">Les pàgines que afegeixis a les adreces d'interès es mostraran aquí</translation>
-<translation id="773466115871691567">Tradueix sempre les pàgines en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Per detectar aplicacions i llocs web perillosos, Chrome envia a Google els URL d'algunes de les pàgines que visites, informació limitada del sistema i part del contingut de les pàgines</translation>
-<translation id="7757787379047923882">Text compartit des del dispositiu <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Targeta SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Afegeix una adreça</translation>
-<translation id="7772032839648071052">Confirmeu la frase de contrasenya</translation>
-<translation id="7772375229873196092">Tanca <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> més}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> més}}</translation>
-<translation id="7781829728241885113">Ahir</translation>
-<translation id="7791543448312431591">Afegeix</translation>
-<translation id="780301667611848630">No, gràcies</translation>
-<translation id="7810647596859435254">Obre amb…</translation>
-<translation id="7821588508402923572">Les dades que estalviïs es mostraran aquí</translation>
-<translation id="7837721118676387834">Permet la reproducció automàtica de vídeos silenciats d'un lloc web concret.</translation>
-<translation id="7846076177841592234">Cancel·la la selecció</translation>
-<translation id="784934925303690534">Interval de temps</translation>
-<translation id="7851858861565204677">Altres dispositius</translation>
-<translation id="7875915731392087153">Crea una adreça electrònica</translation>
-<translation id="7876243839304621966">Suprimeix-ho tot</translation>
-<translation id="7882131421121961860">No s'ha trobat l'element que cerques a l'historial</translation>
-<translation id="7882806643839505685">Permet el so d'un lloc web concret.</translation>
-<translation id="7886917304091689118">S'està executant a Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{S'està baixant el fitxer.}other{S'estan baixant # fitxers.}}</translation>
-<translation id="7929962904089429003">Obre el menú</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> no està actualitzat.</translation>
-<translation id="7947953824732555851">Acc. i inicia sessió</translation>
-<translation id="7963646190083259054">Proveïdor:</translation>
-<translation id="7971136598759319605">Actiu fa 1 dia</translation>
-<translation id="7975379999046275268">Previsualitza la pàgina <ph name="BEGIN_NEW" />Novetat<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Carrega les pàgines prèviament per poder-hi navegar i fer cerques més de pressa</translation>
-<translation id="79859296434321399">Per veure contingut en realitat augmentada, instal·la ARCore</translation>
-<translation id="7986741934819883144">Selecciona un contacte</translation>
-<translation id="7987073022710626672">Condicions del servei de Chrome</translation>
-<translation id="7998918019931843664">Torna a obrir la pestanya tancada</translation>
-<translation id="7999064672810608036">Confirmes que vols esborrar d'aquest lloc web totes les dades locals, incloses les galetes, i restablir-ne tots els permisos?</translation>
-<translation id="8004582292198964060">Navegador</translation>
-<translation id="8007176423574883786">Aquesta ubicació està desactivada per a aquest dispositiu</translation>
-<translation id="8013372441983637696">Esborra també les teves dades de Chrome d'aquest dispositiu</translation>
-<translation id="8015452622527143194">Restableix la mida de tots els elements de la pàgina</translation>
-<translation id="802154636333426148">Error de baixada</translation>
-<translation id="8026334261755873520">Esborra les dades de navegació</translation>
-<translation id="8035133914807600019">Carpeta nova…</translation>
-<translation id="8037750541064988519">Queden <ph name="DAYS" /> dies</translation>
-<translation id="804335162455518893">La targeta SD no s'ha trobat</translation>
-<translation id="805047784848435650">Segons l'historial de navegació</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB disponibles</translation>
-<translation id="8058746566562539958">Obre en pestanya nova a Chrome</translation>
-<translation id="8063895661287329888">L'adreça d'interès no s'ha pogut afegir.</translation>
-<translation id="806745655614357130">Mantén les meves dades separades</translation>
-<translation id="8067883171444229417">Reprodueix el vídeo</translation>
-<translation id="8068648041423924542">No es pot seleccionar el certificat.</translation>
-<translation id="8073388330009372546">Obre en una pestanya nova</translation>
-<translation id="8076492880354921740">Pestanyes</translation>
-<translation id="8084114998886531721">Contrasenya desada</translation>
-<translation id="8087000398470557479">Aquest contingut és del domini <ph name="DOMAIN_NAME" />, oferit per Google.</translation>
-<translation id="8103578431304235997">Pestanya d'incògnit</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Per accedir a les adreces d'interès des de tots els dispositius, activa la sincronització</translation>
-<translation id="8110087112193408731">Vols veure l'activitat de Chrome a Benestar digital?</translation>
-<translation id="8116925261070264013">Silenciats</translation>
-<translation id="813082847718468539">Mostra la informació del lloc</translation>
-<translation id="8131740175452115882">Confirma</translation>
-<translation id="8156139159503939589">En quins idiomes pots llegir?</translation>
-<translation id="8168435359814927499">Contingut</translation>
-<translation id="8186512483418048923">Queden <ph name="FILES" /> fitxers</translation>
-<translation id="8190358571722158785">Queda 1 dia</translation>
-<translation id="8200772114523450471">Reprèn</translation>
-<translation id="8209050860603202033">Obre la imatge</translation>
-<translation id="8218622182176210845">Gestiona el compte</translation>
-<translation id="8224471946457685718">Baixa articles que et poden interessar quan tinguis connexió a la Wi-Fi</translation>
-<translation id="8232956427053453090">Conserva les dades</translation>
-<translation id="8249310407154411074">Mou a la part superior</translation>
-<translation id="8250920743982581267">Documents</translation>
-<translation id="825412236959742607">Com que aquesta pàgina fa servir massa memòria, Chrome n'ha suprimit contingut.</translation>
-<translation id="8260126382462817229">Torna a iniciar la sessió</translation>
-<translation id="8261506727792406068">Suprimeix</translation>
-<translation id="8266862848225348053">Ubicació de baixada</translation>
-<translation id="8274165955039650276">Mostra les baixades</translation>
-<translation id="8284326494547611709">Subtítols</translation>
-<translation id="8300705686683892304">Gestionats per aplicacions</translation>
-<translation id="8310344678080805313">Pestanyes estàndard</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> i més llocs web</translation>
-<translation id="8327155640814342956">Per gaudir de la millor experiència de navegació, obre Chrome per actualitzar-lo</translation>
-<translation id="8339163506404995330">Les pàgines en <ph name="LANGUAGE" /> no es traduiran</translation>
-<translation id="8349013245300336738">Ordena per quantitat de dades utilitzades</translation>
-<translation id="8364299278605033898">Mostra llocs web populars</translation>
-<translation id="8368027906805972958">Dispositiu desconegut o no admès (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Permet la sincronització en segon pla en un lloc concret.</translation>
-<translation id="8378714024927312812">Gestionat per la teva organització</translation>
-<translation id="8380167699614421159">Aquest lloc web mostra anuncis intrusius o enganyosos</translation>
-<translation id="8393700583063109961">Envia el missatge</translation>
-<translation id="8413126021676339697">Mostra l'historial complet</translation>
-<translation id="8427875596167638501">La pestanya de previsualització està oberta fins a la meitat</translation>
-<translation id="8428213095426709021">Configuració</translation>
-<translation id="8438566539970814960">Millora les cerques i la navegació</translation>
-<translation id="8441146129660941386">Retrocedeix</translation>
-<translation id="8443209985646068659">Chrome no actualitzable</translation>
-<translation id="8445448999790540984">No es poden exportar les contrasenyes</translation>
-<translation id="8447861592752582886">Revoca el permís d'accés al dispositiu</translation>
-<translation id="8461694314515752532">Encripta les dades sincronitzades amb la teva frase de contrasenya de sincronització</translation>
-<translation id="8466613982764129868">Comprova que el dispositiu <ph name="TARGET_DEVICE_NAME" /> estigui connectat a Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponible sense connexió</translation>
-<translation id="8489271220582375723">Obre la pàgina de l'historial</translation>
-<translation id="8493948351860045254">Allibera espai</translation>
-<translation id="8497726226069778601">Aquí encara no hi ha contingut per mostrar</translation>
-<translation id="8503559462189395349">Contrasenyes de Chrome</translation>
-<translation id="8503813439785031346">Nom d'usuari</translation>
-<translation id="8514477925623180633">Exporta les contrasenyes emmagatzemades a Chrome</translation>
-<translation id="8514577642972634246">Entra al mode d'incògnit</translation>
-<translation id="851751545965956758">Impedeix que els llocs web es connectin a dispositius</translation>
-<translation id="8523928698583292556">Suprimeix la contrasenya emmagatzemada</translation>
-<translation id="854522910157234410">Obre aquesta pàgina</translation>
-<translation id="8558485628462305855">Per veure contingut en realitat augmentada, actualitza ARCore</translation>
-<translation id="8559990750235505898">Proposa traduir les pàgines en altres idiomes</translation>
-<translation id="8562452229998620586">Les contrasenyes desades apareixeran aquí.</translation>
-<translation id="8569404424186215731">des del dia <ph name="DATE" /></translation>
-<translation id="8571213806525832805">4 darreres setmanes</translation>
-<translation id="857943718398505171">Permès (opció recomanada)</translation>
-<translation id="8583805026567836021">S'estan esborrant les dades del compte</translation>
-<translation id="860043288473659153">Nom del titular de la targeta</translation>
-<translation id="8609465669617005112">Desplaça cap amunt</translation>
-<translation id="8616006591992756292">A <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> trobaràs altres maneres d'explorar l'historial de navegació del teu Compte de Google.</translation>
-<translation id="8617240290563765734">Voleu obrir l'URL suggerit que s'especifica al contingut que s'ha baixat?</translation>
-<translation id="8636825310635137004">Activa la sincronització per accedir a les pestanyes dels altres dispositius que tinguis.</translation>
-<translation id="8641930654639604085">Prova de bloquejar els llocs web per a adults</translation>
-<translation id="8655129584991699539">Pots esborrar les dades a la configuració de Chrome</translation>
-<translation id="8662811608048051533">Et tanca la sessió de la majoria de llocs.</translation>
-<translation id="8664979001105139458">El nom del fitxer ja existeix</translation>
-<translation id="8676374126336081632">Esborra l'entrada</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Intensitat del senyal: # barra}other{Intensitat del senyal: # barres}}</translation>
-<translation id="868929229000858085">Cerca als contactes</translation>
-<translation id="869891660844655955">Data de caducitat</translation>
-<translation id="8719023831149562936">La pestanya actual no es pot compartir.</translation>
-<translation id="8725066075913043281">Torna-ho a provar</translation>
-<translation id="8728487861892616501">En utilitzar aquesta aplicació, acceptes les <ph name="BEGIN_LINK1" />condicions del servei<ph name="END_LINK1" /> i l'<ph name="BEGIN_LINK2" />avís de privadesa<ph name="END_LINK2" /> de Chrome, així com l'<ph name="BEGIN_LINK3" />avís de privadesa per a comptes de Google gestionats amb Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Fet</translation>
-<translation id="8748850008226585750">Contingut amagat</translation>
-<translation id="8751914237388039244">Selecciona una imatge</translation>
-<translation id="8788265440806329501">L'historial de navegació està tancat</translation>
-<translation id="8788968922598763114">Torna a obrir l'última pestanya tancada</translation>
-<translation id="8801436777607969138">Bloqueja JavaScript en un lloc web concret.</translation>
-<translation id="8812260976093120287">En alguns llocs web, pots fer servir el teu dispositiu per pagar amb les aplicacions de pagament anteriors admeses.</translation>
-<translation id="8816026460808729765">Impedeix que els llocs web accedeixin als sensors</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> s'obrirà a Chrome. En continuar, acceptes les <ph name="BEGIN_LINK1" />condicions del servei<ph name="END_LINK1" /> i l'<ph name="BEGIN_LINK2" />avís de privadesa<ph name="END_LINK2" /> de Chrome, així com l'<ph name="BEGIN_LINK3" />avís de privadesa per als comptes de Google gestionats amb Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Adreces d'interès</translation>
-<translation id="8833831881926404480">Un lloc web està compartint la teva pantalla</translation>
-<translation id="883806473910249246">S'ha produït un error en baixar el contingut.</translation>
-<translation id="8840953339110955557">Aquesta pàgina pot ser diferent de la versió en línia.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, pestanya</translation>
-<translation id="885701979325669005">Emmagatzematge</translation>
-<translation id="889338405075704026">Ves a la configuració de Chrome</translation>
-<translation id="8901170036886848654">No s'ha trobat cap adreça d'interès</translation>
-<translation id="8909135823018751308">Comparteix...</translation>
-<translation id="8912362522468806198">Compte de Google</translation>
-<translation id="8920114477895755567">S'està esperant la informació parental.</translation>
+<translation id="1188239144602654184">Entra a la realitat augmentada</translation>
+<translation id="473775607612524610">Actualitza</translation>
+<translation id="3133489217401741157">S'està instal·lant <ph name="MODULE"/> per a Brave…</translation>
+<translation id="1791662854739702043">Instal·lat</translation>
+<translation id="5131234170665854056">No es pot instal·lar <ph name="MODULE"/> per a Brave</translation>
+<translation id="2567385386134582609">IMATGE</translation>
+<translation id="6395288395575013217">ENLLAÇ</translation>
+<translation id="7352939065658542140">VÍDEO</translation>
+<translation id="4116038641877404294">Baixa pàgines per utilitzar-les sense connexió</translation>
 <translation id="8922289737868596582">Baixa pàgines amb el botó Més opcions per utilitzar-les sense connexió</translation>
-<translation id="8937772741022875483">Vols suprimir l'activitat de Chrome a Benestar digital?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Obre en una altra finestra</translation>
-<translation id="8951232171465285730">Chrome t'ha estalviat <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Bloqueja les galetes d'un lloc web concret.</translation>
-<translation id="8959122750345127698">No es pot accedir a la navegació: <ph name="URL" /></translation>
-<translation id="8965591936373831584">pendent</translation>
-<translation id="8970887620466824814">S'ha produït un error.</translation>
-<translation id="8972098258593396643">Vols baixar el fitxer a la carpeta predeterminada?</translation>
-<translation id="8986494364107987395">Envia automàticament estadístiques d'ús i informes d'error a Google</translation>
-<translation id="8993760627012879038">Obre una pestanya nova en mode d'incògnit</translation>
-<translation id="8998729206196772491">Estàs iniciant la sessió amb un compte gestionat per <ph name="MANAGED_DOMAIN" /> i estàs donant a l'administrador el control de les teves dades de Chrome. Les dades passaran a estar vinculades a aquest compte permanentment. Si tanques la sessió de Chrome, se suprimiran les teves dades d'aquest dispositiu, però continuaran emmagatzemades al teu compte de Google.</translation>
-<translation id="9019902583201351841">Gestionat pels pares</translation>
-<translation id="9028914725102941583">Activa la sincronització per compartir elements entre dispositius</translation>
-<translation id="9029323097866369874">Vols permetre que <ph name="DOMAIN" /> entri al mode RV?</translation>
-<translation id="9040142327097499898">Es permeten les notificacions. La ubicació està desactivada en aquest dispositiu.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}other{# vídeos}}</translation>
-<translation id="9050666287014529139">Frase de contrasenya</translation>
-<translation id="9063523880881406963">Desactiva Mostra com a ordinador</translation>
-<translation id="9065203028668620118">Edita</translation>
-<translation id="9070377983101773829">Inicia la cerca per veu</translation>
-<translation id="9074336505530349563">Perquè Google et suggereixi contingut personalitzat, inicia la sessió i activa la sincronització</translation>
-<translation id="9086455579313502267">No es pot accedir a la xarxa</translation>
-<translation id="9100505651305367705">Proposa mostrar articles en visualització simplificada, quan s'admeti</translation>
-<translation id="9100610230175265781">S'ha d'introduir una frase de contrasenya </translation>
-<translation id="9102803872260866941">La pestanya de previsualització està oberta</translation>
+<translation id="5958275228015807058">Trobaràs els teus fitxers i les teves pàgines a Baixades</translation>
+<translation id="5620928963363755975">Per veure els teus fitxers i les teves pàgines, toca el botó Més opcions i ves a la secció Baixades</translation>
+<translation id="3341058695485821946">Consulta la quantitat de dades que has estalviat</translation>
+<translation id="3157842584138209013">Consulta la quantitat de dades que has estalviat des del botó Més opcions</translation>
+<translation id="8218622182176210845">Gestiona el compte</translation>
+<translation id="8090895580117672212">Per gestionar el teu Compte de Brave Software, toca el botó Gestiona el compte</translation>
+<translation id="8856898588039823173">Pàgina en mode bàsic oferta per Brave Software. Toca per carregar l'original.</translation>
+<translation id="8134317863207426198">Pàgina en mode bàsic oferida per Brave Software. Toca el botó Carrega la versió original per carregar la pàgina original.</translation>
+<translation id="4961107849584082341">Tradueix aquesta pàgina a qualsevol idioma</translation>
+<translation id="569536719314091526">Tradueix aquesta pàgina a qualsevol idioma des del botó Més opcions</translation>
+<translation id="1397811292916898096">Cerca amb <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Canvia la ubicació predeterminada de baixada en qualsevol moment</translation>
+<translation id="6942665639005891494">Canvia la ubicació predeterminada de baixada en qualsevol moment amb l'opció del menú Configuració</translation>
+<translation id="6850409657436465440">La baixada encara està en curs</translation>
+<translation id="5817715962196959877">Ara Brave baixa els fitxers més ràpid</translation>
+<translation id="3976396876660209797">Suprimeix aquesta drecera i torna-la a crear</translation>
+<translation id="6766622839693428701">Llisca cap avall per tancar el full.</translation>
+<translation id="1028699632127661925">S'està enviant a <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/>: s'ha enviat des del dispositiu <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">S'ha rebut una pestanya</translation>
 <translation id="9104217018994036254">Llista de dispositius amb què es compartirà una pestanya.</translation>
-<translation id="9133397713400217035">Explora sense connexió</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Mostra l'original</translation>
-<translation id="9139068048179869749">Pregunta'm abans de permetre que els llocs web enviïn notificacions (opció recomanada)</translation>
-<translation id="9139318394846604261">Compres</translation>
-<translation id="9155898266292537608">També pots fer un toc ràpid en una paraula per fer cerques</translation>
-<translation id="9169507124922466868">L'historial de navegació està obert fins a la meitat</translation>
-<translation id="9204836675896933765">Queda 1 fitxer</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">La llista de dispositius amb què es compartirà una pestanya ocupa la meitat inferior de la pantalla.</translation>
+<translation id="2904414404539560095">La llista de dispositius amb què es compartirà una pestanya ocupa tota la pantalla.</translation>
+<translation id="4135200667068010335">La llista de dispositius amb què es compartirà una pestanya està tancada.</translation>
+<translation id="5292796745632149097">Envia a</translation>
+<translation id="1386674309198842382">Actiu fa <ph name="LAST_UPDATED"/> dies</translation>
+<translation id="7971136598759319605">Actiu fa 1 dia</translation>
+<translation id="1521774566618522728">Actiu avui</translation>
+<translation id="3631987586758005671">S'està compartint amb <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Activa la sincronització per compartir elements entre dispositius</translation>
+<translation id="6162454065885854378">Per compartir elements del telèfon amb un altre dispositiu, activa la sincronització a la configuració de Brave en tots dos dispositius</translation>
+<translation id="6084271560289605378">Ves a la configuració de Brave</translation>
+<translation id="2318045970523081853">Toca per fer una trucada</translation>
 <translation id="9209888181064652401">No es poden fer trucades</translation>
-<translation id="9219103736887031265">Imatges</translation>
-<translation id="926205370408745186">Suprimeix l'activitat de Chrome de l'aplicació Benestar digital</translation>
-<translation id="932327136139879170">Inici</translation>
-<translation id="938850635132480979">Error: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Accés al micròfon</translation>
-<translation id="95817756606698420">Chrome pot utilitzar <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> per fer cerques a la Xina. Per canviar-ho, ves a <ph name="BEGIN_LINK" />Configuració<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloqueja els anuncis si el lloc web mostra publicitat intrusiva o enganyosa (opció recomanada)</translation>
-<translation id="968900484120156207">Les pàgines que visitis es mostraran aquí</translation>
-<translation id="970715775301869095">Queden <ph name="MINUTES" /> minuts</translation>
-<translation id="974555521953189084">Introdueix la teva frase de contrasenya per iniciar la sincronització</translation>
-<translation id="981121421437150478">Sense connexió</translation>
-<translation id="982182592107339124">S'esborraran les dades de tots els llocs web, com ara:</translation>
-<translation id="983192555821071799">Tanca totes les pestanyes</translation>
-<translation id="987264212798334818">General</translation>
+<translation id="2860954141821109167">Comprova que hi hagi una aplicació de telèfon activada en aquest dispositiu</translation>
+<translation id="2067805253194386918">text</translation>
+<translation id="1450753235335490080">No es pot compartir <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">No s'ha pogut compartir <ph name="CONTENT_TYPE"/>.</translation>
+<translation id="8287068819750208230">Comprova que <ph name="TARGET_DEVICE_NAME"/> tingui la sincronització activada a Brave</translation>
+<translation id="3016635187733453316">Comprova que el dispositiu estigui connectat a Internet</translation>
+<translation id="8466613982764129868">Comprova que el dispositiu <ph name="TARGET_DEVICE_NAME"/> estigui connectat a Internet</translation>
+<translation id="6539092367496845964">S'ha produït un error. Torna-ho a provar més tard.</translation>
+<translation id="3389286852084373014">El text és massa llarg</translation>
+<translation id="2100314319871056947">Prova de compartir el text en fragments més petits</translation>
+<translation id="2987620471460279764">Text compartit d'un altre dispositiu</translation>
+<translation id="7757787379047923882">Text compartit des del dispositiu <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">S'ha copiat al porta-retalls</translation>
+<translation id="4696983787092045100">Envia text als teus dispositius</translation>
+<translation id="1260236875608242557">Fes cerques i explora contingut</translation>
+<translation id="6369229450655021117">Des d'aquí, pots fer cerques al web, compartir contingut amb els amics i veure les pàgines obertes</translation>
+<translation id="723171743924126238">Selecciona imatges</translation>
+<translation id="8751914237388039244">Selecciona una imatge</translation>
+<translation id="1989112275319619282">Examina</translation>
+<translation id="7055152154916055070">S'ha bloquejat la redirecció:</translation>
+<translation id="5524843473235508879">S'ha bloquejat la redirecció.</translation>
+<translation id="6573096386450695060">Permet sempre</translation>
+<translation id="5805364706385912897">Com que aquesta pàgina fa servir massa memòria, Brave l'ha posat en pausa.</translation>
+<translation id="5138664332909611586">Com que aquesta pàgina fa servir massa memòria, Brave n'ha suprimit contingut.</translation>
+<translation id="9137013805542155359">Mostra l'original</translation>
+<translation id="6361779936989026201">Assistent de Brave Software a Brave</translation>
+<translation id="7291387454912369099">Pagament activat per l'Assistent</translation>
+<translation id="4565206163201411670">Vols veure l'activitat de Brave a Benestar digital?</translation>
+<translation id="9055113864158719823">Pots veure els llocs web que visites a Brave i establir-hi temporitzadors.\n\nBrave Software obté informació sobre els llocs web en què estableixes temporitzadors i sobre el temps que hi passes. Aquesta informació s'utilitza per millorar Benestar digital.</translation>
+<translation id="4596514158372210596">Suprimeix l'activitat de Brave de l'aplicació Benestar digital</translation>
+<translation id="1174893863889683998">Vols suprimir l'activitat de Brave a Benestar digital?</translation>
+<translation id="708829030563435351">Els llocs web que visitis a Brave no es mostraran. Se suprimiran tots els temporitzadors del lloc web.</translation>
+<translation id="2056878612599315956">El lloc web s'ha posat en pausa</translation>
+<translation id="671481426037969117">S'ha esgotat el temps definit al temporitzador per a <ph name="FQDN"/>. Es tornarà a iniciar demà.</translation>
+<translation id="7479104141328977413">Gestió de pestanyes</translation>
+<translation id="3524138585025253783">Interfície d'usuari per a desenvolupadors</translation>
+<translation id="6036057147555329831">ICU addicional</translation>
+<translation id="9029323097866369874">Vols permetre que <ph name="DOMAIN"/> entri al mode RV?</translation>
+<translation id="7685301384041462804">Assegura't que confies en aquest lloc web abans d'entrar al mode RV.</translation>
+<translation id="5033865233969348410">Mentre estiguis en el mode RV, pot ser que aquest lloc web pugui obtenir la informació següent:
+- els teus trets físics, com ara l'alçada
+
+Assegura't que confies en aquest lloc web abans d'entrar al mode RV.</translation>
+<translation id="5534334044554683961">Mentre estiguis en el mode RV, pot ser que aquest lloc web pugui obtenir la informació següent:
+- els teus trets físics, com ara l'alçada
+- la distribució de la teva habitació
+
+Assegura't que confies en aquest lloc web abans d'entrar al mode RV.</translation>
+<translation id="4169535189173047238">No permetis</translation>
+<translation id="2170088579611075216">Permet i activa el mode RV</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_cs.xtb
+++ b/android/java/strings/translations/android_chrome_strings_cs.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="cs">
-<translation id="1006017844123154345">Otevřít online</translation>
-<translation id="1028699632127661925">Odesílání na zařízení <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Přidávání aplikace <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Z webů</translation>
-<translation id="1049743911850919806">Anonymní režim</translation>
-<translation id="10614374240317010">Nikdy se neukládají</translation>
-<translation id="1067922213147265141">Další služby Google</translation>
-<translation id="1068672505746868501">Stránky v jazyce <ph name="SOURCE_LANGUAGE" /> nikdy nepřekládat</translation>
-<translation id="107147699690128016">Pokud změníte příponu souboru, může se soubor otevřít v jiné aplikaci a potenciálně může být rizikem pro vaše zařízení.</translation>
-<translation id="1100066534610197918">Otevřít na nové kartě ve skup.</translation>
-<translation id="1105960400813249514">Snímky obrazovky</translation>
-<translation id="1111673857033749125">Zde se objeví záložky, které jste si uložili v ostatních zařízeních.</translation>
-<translation id="1113597929977215864">Zapnout zjednodušené zobrazení</translation>
-<translation id="1121094540300013208">Zprávy o využití a selhání</translation>
-<translation id="1124772482545689468">Uživatel</translation>
-<translation id="1129510026454351943">Podrobnosti: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 nevyřízené stahování.}few{# nevyřízená stahování.}many{# nevyřízeného stahování.}other{# nevyřízených stahování.}}</translation>
-<translation id="1145536944570833626">Smazat existující data.</translation>
-<translation id="1146678959555564648">Zapnout VR</translation>
-<translation id="116280672541001035">Využito</translation>
-<translation id="1171770572613082465">Populární weby zobrazíte klepnutím na tlačítko Top weby</translation>
-<translation id="1173894706177603556">Přejmenovat</translation>
-<translation id="1178581264944972037">Pozastavit</translation>
-<translation id="1181037720776840403">Odebrat</translation>
-<translation id="1188239144602654184">Spustit rozšířenou realitu</translation>
-<translation id="1197267115302279827">Přesunutí záložek</translation>
-<translation id="119944043368869598">Vymazat vše</translation>
-<translation id="1201402288615127009">Další</translation>
-<translation id="1204037785786432551">Stáhnout odkaz</translation>
-<translation id="1206892813135768548">Zkopírovat text odkazu</translation>
-<translation id="1208340532756947324">Chcete-li synchronizovat a přizpůsobit různá zařízení, zapněte synchronizaci</translation>
-<translation id="1209206284964581585">Prozatím skrýt</translation>
-<translation id="1227058898775614466">Historie navigace</translation>
-<translation id="1231733316453485619">Zapnout synchronizaci?</translation>
-<translation id="123724288017357924">Obnovit stránku a ignorovat obsah v mezipaměti</translation>
-<translation id="124116460088058876">Další jazyky</translation>
-<translation id="124678866338384709">Zavřít aktuální kartu</translation>
-<translation id="1258753120186372309">Sváteční logo Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Vyhledávání a prozkoumávání</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Sdílení obsahu typu <ph name="CONTENT_TYPE" /> se nezdařilo</translation>
-<translation id="1272079795634619415">Zastavit</translation>
-<translation id="1283039547216852943">Klepnutím rozbalíte</translation>
-<translation id="1285320974508926690">Tento web nikdy nepřekládat</translation>
-<translation id="1291207594882862231">Vymazat historii, soubory cookie, data webů, mezipaměť…</translation>
-<translation id="129382876167171263">Zde se budou zobrazovat soubory uložené webovými stránkami</translation>
-<translation id="129553762522093515">Nedávno zavřené</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – odesláno ze zařízení <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Seskupit karty</translation>
-<translation id="1327257854815634930">Historie navigace je otevřená</translation>
-<translation id="1331212799747679585">Chrome nelze aktualizovat. Další možnosti</translation>
-<translation id="1332501820983677155">Zkratky funkcí prohlížeče Google Chrome</translation>
-<translation id="1360432990279830238">Odhlásit se a vypnout synchronizaci?</translation>
-<translation id="1369915414381695676">Byl přidán web <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Ke stažení vybraného obsahu není k dispozici dostatek paměti.</translation>
-<translation id="1376578503827013741">Probíhá výpočet…</translation>
-<translation id="1383876407941801731">Vyhledávání</translation>
-<translation id="1384959399684842514">Stahování pozastaveno</translation>
-<translation id="1386674309198842382">Aktivní před tímto počtem dní: <ph name="LAST_UPDATED" /></translation>
-<translation id="1397811292916898096">Hledat pomocí vyhledávače <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Vloženo do <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Do Not Track (Nesledovat)</translation>
-<translation id="1407135791313364759">Otevřít vše</translation>
-<translation id="1409426117486808224">Zjednodušené zobrazení otevřených karet</translation>
-<translation id="1409879593029778104">Stažení souboru <ph name="FILE_NAME" /> bylo zabráněno, protože soubor již existuje.</translation>
-<translation id="1414981605391750300">Kontaktování Googlu. Může to chvíli trvat…</translation>
-<translation id="1416550906796893042">Verze aplikace</translation>
-<translation id="1430915738399379752">Tisk</translation>
-<translation id="1446450296470737166">Povolit úplné ovládání zařízení MIDI</translation>
-<translation id="1450753235335490080">Sdílení obsahu typu <ph name="CONTENT_TYPE" /> se nezdařilo</translation>
-<translation id="145097072038377568">Vypnuto v Nastavení pro Android</translation>
-<translation id="1477626028522505441">Stažení souboru <ph name="FILE_NAME" /> se nezdařilo z důvodu problémů se serverem.</translation>
-<translation id="1506061864768559482">Vyhledávač</translation>
-<translation id="1513352483775369820">Záložky a webová historie</translation>
-<translation id="1513858653616922153">Vymazat heslo</translation>
-<translation id="1516229014686355813">Vyhledání klepnutím odešle vybrané slovo a aktuální stránku jako kontext do Vyhledávání Google. Tuto funkci můžete vypnout v <ph name="BEGIN_LINK" />Nastavení<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktivní dnes</translation>
-<translation id="1544826120773021464">Chcete-li spravovat svůj účet Google, klepněte na tlačítko Spravovat účet</translation>
-<translation id="1549000191223877751">Přejít do jiného okna</translation>
-<translation id="1553358976309200471">Aktualizovat Chrome</translation>
-<translation id="1569387923882100876">Připojené zařízení</translation>
-<translation id="1571304935088121812">Kopírovat uživatelské jméno</translation>
-<translation id="1612196535745283361">K vyhledání zařízení potřebuje Chrome přístup k informacím o poloze. Přístup k poloze je v tomto zařízení <ph name="BEGIN_LINK" />vypnut<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Bránit této stránce ve vytváření dalších dialogových oken</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Odstranit jednu vybranou položku}few{Odstranit # vybrané položky}many{Odstranit # vybrané položky}other{Odstranit # vybraných položek}}</translation>
-<translation id="164269334534774161">Prohlížíte si offline kopii této stránky z <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historie</translation>
-<translation id="1647391597548383849">Přístup k fotoaparátu</translation>
-<translation id="1660204651932907780">Povolit webům přehrávat zvuky (doporučeno)</translation>
-<translation id="1670399744444387456">Základní</translation>
-<translation id="1671236975893690980">Nevyřízené stahování…</translation>
-<translation id="1672586136351118594">Tuto zprávu již nezobrazovat</translation>
-<translation id="1692118695553449118">Synchronizace je zapnuta</translation>
-<translation id="169515064810179024">Blokovat webům přístup k senzorům pohybu</translation>
-<translation id="1717218214683051432">Pohybová čidla</translation>
-<translation id="1718835860248848330">Poslední hodina</translation>
-<translation id="1736419249208073774">Prozkoumat</translation>
-<translation id="1743802530341753419">Pokud se web bude chtít připojit k zařízení, zobrazit dotaz (doporučeno)</translation>
-<translation id="1749561566933687563">Synchronizace záložek</translation>
-<translation id="17513872634828108">Otevřené karty</translation>
-<translation id="1779089405699405702">Dekodér obrázků</translation>
-<translation id="1782483593938241562">Datum ukončení: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Nainstalováno</translation>
-<translation id="1792959175193046959">Výchozí umístění pro stažené soubory můžete kdykoliv změnit.</translation>
-<translation id="1807246157184219062">Světlé</translation>
-<translation id="1810845389119482123">Počáteční nastavení synchronizace nebylo dokončeno</translation>
-<translation id="1821253160463689938">Používá soubory cookie k uložení vašeho nastavení i v případě, že stránky nenavštívíte</translation>
-<translation id="1829244130665387512">Najít na stránce</translation>
-<translation id="1853692000353488670">Nová anonymní karta</translation>
-<translation id="1856325424225101786">Resetovat zjednodušený režim?</translation>
-<translation id="1868024384445905608">Chrome teď stahuje soubory rychleji</translation>
-<translation id="1883903952484604915">Moje soubory</translation>
-<translation id="1887786770086287077">Přístup k poloze je v tomto zařízení vypnut. Zapnete jej v <ph name="BEGIN_LINK" />Nastavení Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Aplikace <ph name="APP_NAME" /> se otevře v Chromu. Pokračováním vyjadřujete souhlas se <ph name="BEGIN_LINK1" />smluvními podmínkami<ph name="END_LINK1" /> a <ph name="BEGIN_LINK2" />upozorněním ve věci ochrany soukromí<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Reklamy</translation>
-<translation id="1919950603503897840">Vyberte kontakty</translation>
-<translation id="1922076542920281912">Chcete-li Chromu povolit přístup k vaší poloze, zapněte ji také v <ph name="BEGIN_LINK" />Nastavení Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Aktualizace</translation>
-<translation id="19288952978244135">Znovu spusťte Chrome.</translation>
-<translation id="1933845786846280168">Vybraná karta</translation>
-<translation id="194341124344773587">Oprávnění pro Chrome zapnete v <ph name="BEGIN_LINK" />Nastavení pro Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Ukládání hesel</translation>
-<translation id="1952172573699511566">Pokud to bude možné, budou weby zobrazovat text ve vašem preferovaném jazyce.</translation>
-<translation id="1960290143419248813">V této verzi platformy Android již aktualizace prohlížeče Chrome nejsou podporovány</translation>
-<translation id="1966710179511230534">Aktualizujte prosím své přihlašovací údaje.</translation>
-<translation id="1974060860693918893">Rozšířená nastavení</translation>
-<translation id="1984705450038014246">Synchronizovat data prohlížeče Chrome</translation>
-<translation id="1984937141057606926">Povoleno, s výjimkou souborů cookie třetí strany</translation>
-<translation id="1986685561493779662">Název již existuje</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> tlačítko <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Procházet</translation>
-<translation id="1993768208584545658">Web <ph name="SITE" /> žádá o spárování</translation>
-<translation id="1994173015038366702">Adresa URL webu</translation>
-<translation id="2000419248597011803">Odesílá soubory cookie a vyhledávací dotazy z adresního řádku a vyhledávacího pole a několik souborů cookie vašemu výchozímu vyhledávači</translation>
-<translation id="2002537628803770967">Platební karty a adresy pomocí služby Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# soubor}few{# soubory}many{# souboru}other{# souborů}}</translation>
-<translation id="2017836877785168846">Vymaže historii a automatická dokončení v adresním řádku.</translation>
-<translation id="2021896219286479412">Ovládání webu na celé obrazovce</translation>
-<translation id="2038563949887743358">Zapnout funkci Verze webu pro PC</translation>
-<translation id="2041019821020695769">Chcete-li Chromu umožnit zasílat vám oznámení, zapněte oznámení také v <ph name="BEGIN_LINK" />Natavení Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Aplikace <ph name="APP_NAME" /> má také data v Chromu</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Web je pozastaven</translation>
-<translation id="2063713494490388661">Vyhledání klepnutím</translation>
-<translation id="2067805253194386918">text</translation>
-<translation id="2079545284768500474">Vrátit zpět</translation>
-<translation id="2082238445998314030">Výsledek <ph name="RESULT_NUMBER" /> z <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Zvuk</translation>
-<translation id="2096012225669085171">Synchronizovat a přizpůsobit na různých zařízeních</translation>
-<translation id="2100273922101894616">Přihlásit se automaticky</translation>
-<translation id="2100314319871056947">Zkuste text sdílet po menších částech</translation>
-<translation id="2107397443965016585">Před povolením spuštění chráněného obsahu na webu se zeptat (doporučeno)</translation>
-<translation id="2111511281910874386">Přejít na stránku</translation>
-<translation id="2122601567107267586">Aplikaci nelze otevřít</translation>
-<translation id="2126426811489709554">Používá technologii Chrome</translation>
-<translation id="2131665479022868825">Uspořeno: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Karta <ph name="TAB_TITLE" /> byla zavřena.</translation>
-<translation id="2139186145475833000">Přidat na plochu</translation>
-<translation id="2146738493024040262">Otevřít okamžitou aplikaci</translation>
-<translation id="2148716181193084225">Dnes</translation>
-<translation id="2154484045852737596">Úprava karty</translation>
-<translation id="2154710561487035718">Kopírovat adresu URL</translation>
-<translation id="2156074688469523661">Zbývající weby (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Chcete-li něco z telefonu sdílet do jiného zařízení, zapněte v nastavení Chromu na obou zařízeních synchronizaci</translation>
-<translation id="2170088579611075216">Povolit a spustit virtuální realitu</translation>
-<translation id="218608176142494674">Sdílení</translation>
-<translation id="2227444325776770048">Pokračovat jako uživatel <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synchronizace a služby Google</translation>
-<translation id="2259659629660284697">Exportovat hesla…</translation>
-<translation id="2268044343513325586">Upřesnit</translation>
-<translation id="2286841657746966508">Fakturační adresa</translation>
-<translation id="2289270750774289114">Zeptat se, když chce web objevit zařízení Bluetooth v okolí (doporučeno)</translation>
-<translation id="230115972905494466">Nebyla nalezena žádná kompatibilní zařízení</translation>
-<translation id="2315043854645842844">Volbu certifikátu na straně klienta operační systém nepodporuje.</translation>
-<translation id="2318045970523081853">Klepnutím zahájíte hovor</translation>
-<translation id="2321086116217818302">Příprava hesel…</translation>
-<translation id="2321958826496381788">Přetahujte posuvník tak dlouho, dokud nebudete moci pohodlně přečíst tento text. Po dvojitém klepnutí na odstavec by měl být text alespoň takto velký.</translation>
-<translation id="2323763861024343754">Úložiště webů</translation>
-<translation id="2328985652426384049">Přihlášení se nezdařilo</translation>
-<translation id="2330129964253841015">Upozorňovat v případě ohrožení hesel</translation>
-<translation id="2349710944427398404">Celkové množství dat využívané prohlížečem Chrome, včetně účtů, záložek a uložených nastavení</translation>
-<translation id="2353636109065292463">Kontrola připojení k internetu</translation>
-<translation id="2359808026110333948">Pokračovat</translation>
-<translation id="2369533728426058518">otevřené karty</translation>
-<translation id="2387895666653383613">Zvětšení/zmenšení textu</translation>
-<translation id="2394602618534698961">Zde se zobrazují stažené soubory</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Když se přihlásíte k účtu Google, je tato funkce zapnutá</translation>
-<translation id="2410754283952462441">Vyberte účet</translation>
-<translation id="2414886740292270097">Tmavé</translation>
-<translation id="2416359993254398973">Chrome pro tento web potřebuje oprávnění k přístupu k fotoaparátu.</translation>
-<translation id="2426805022920575512">Vybrat jiný účet</translation>
-<translation id="2433507940547922241">Vzhled</translation>
-<translation id="2434158240863470628">Stažení bylo dokončeno <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Přístup k poloze</translation>
-<translation id="2450083983707403292">Chcete soubor <ph name="FILE_NAME" /> začít stahovat znovu?</translation>
-<translation id="2482878487686419369">Oznámení</translation>
-<translation id="2490684707762498678">Spravováno aplikací <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Asistent Google v Chromu</translation>
-<translation id="2496180316473517155">Historie procházení</translation>
-<translation id="2497852260688568942">Synchronizace je administrátorem zakázána.</translation>
-<translation id="2498359688066513246">Nápověda a zpětná vazba</translation>
-<translation id="2501278716633472235">Zpět</translation>
-<translation id="2513403576141822879">Další nastavení související s ochranou soukromí, zabezpečením a shromažďováním dat naleznete v části <ph name="BEGIN_LINK" />Synchronizace a služby Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Ve zjednodušeném režimu načítá Chrome stránky rychleji a používá až o 60 procent méně dat. Kvůli optimalizaci navštěvovaných stránek přijímá Chrome váš webový provoz přes Google. <ph name="BEGIN_LINK" />Další informace<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Odesílá do Googlu adresy URL stránek, které navštěvujete</translation>
-<translation id="2532336938189706096">Webové zobrazení</translation>
-<translation id="2534155362429831547">Byly smazány položky (celkem <ph name="NUMBER_OF_ITEMS" />)</translation>
-<translation id="2536728043171574184">Prohlížíte offline kopii stránky</translation>
-<translation id="2546283357679194313">Soubory cookie a data webových stránek</translation>
-<translation id="2567385386134582609">OBRÁZEK</translation>
-<translation id="257088987046510401">Motivy</translation>
-<translation id="2570922361219980984">Přístup k poloze je vypnut také v tomto zařízení. Zapnete jej v <ph name="BEGIN_LINK" />Nastavení Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Rozbaleno – kliknutím sbalíte</translation>
-<translation id="2581165646603367611">Tímto vymažete soubory cookie, mezipaměť a další data webů, která Chrome považuje za nedůležitá.</translation>
-<translation id="2586657967955657006">Schránka</translation>
-<translation id="2587052924345400782">Je dostupná novější verze</translation>
-<translation id="2593272815202181319">Neproporcionální</translation>
-<translation id="2612676031748830579">Číslo karty</translation>
-<translation id="2621115761605608342">Povolit JavaScript pro konkrétní web.</translation>
-<translation id="2625189173221582860">Heslo bylo zkopírováno</translation>
-<translation id="2631006050119455616">Uloženo</translation>
-<translation id="2647434099613338025">Přidat jazyk</translation>
-<translation id="2650751991977523696">Stáhnout soubor znovu?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# zvukový soubor}few{# zvukové soubory}many{# zvukového souboru}other{# zvukových souborů}}</translation>
-<translation id="2653659639078652383">Odeslat</translation>
-<translation id="2677748264148917807">Odejít</translation>
-<translation id="2704606927547763573">Zkopírováno</translation>
-<translation id="2707726405694321444">Obnovit stránku</translation>
-<translation id="2709516037105925701">Automatické vyplňování</translation>
-<translation id="2717722538473713889">E‑mailové adresy</translation>
-<translation id="2728754400939377704">Seřadit podle webu</translation>
-<translation id="2744248271121720757">Klepnutím na slovo můžete okamžitě vyhledávat nebo zobrazit související akce</translation>
-<translation id="2760989362628427051">Zapnout tmavý motiv, když je na zařízení zapnutý tmavý motiv nebo spořič baterie</translation>
-<translation id="2762000892062317888">právě teď</translation>
-<translation id="2777555524387840389">Zbývá: <ph name="SECONDS" /> s</translation>
-<translation id="2779651927720337254">nezdařilo se</translation>
-<translation id="2781151931089541271">Zbývá: 1 s</translation>
-<translation id="2801022321632964776">Chcete-li si obsah prohlížet ve svém jazyce, aktualizujte na nejnovější verzi Chromu</translation>
-<translation id="2810645512293415242">Stránka byla zjednodušena s cílem ušetřit data a zrychlit načtení.</translation>
-<translation id="281504910091592009">Zobrazit a spravovat uložená hesla v <ph name="BEGIN_LINK" />účtu Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Chcete-li mít záložky ve všech zařízeních, přihlaste se a zapněte synchronizaci</translation>
-<translation id="2822354292072154809">Opravdu chcete resetovat všechna oprávnění webů pro objekt <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Režim celé obrazovky ukončíte klepnutím na tlačítko Zpět.</translation>
-<translation id="2842985007712546952">Nadřazená složka</translation>
-<translation id="2858138569776157458">Top weby</translation>
-<translation id="2860954141821109167">Zkontrolujte zda je na tomto zařízení povolená aplikace k telefonování</translation>
-<translation id="2870560284913253234">Stránky</translation>
-<translation id="2874939134665556319">Předchozí skladba</translation>
-<translation id="2876369937070532032">Když je ohrožena vaše bezpečnost, odesílá adresy URL některých navštívených stránek do Googlu</translation>
-<translation id="2888126860611144412">O aplikaci Chrome</translation>
-<translation id="2891154217021530873">Zastavit načítání stránky</translation>
-<translation id="2893180576842394309">Google vaši historii může používat k personalizaci Vyhledávání a dalších služeb Google</translation>
-<translation id="2898264748040935573">Upravit uložené heslo</translation>
-<translation id="2900528713135656174">Vytvořit událost</translation>
-<translation id="290376772003165898">Stránka není v jazyce <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Seznam zařízení, se kterými se má karta sdílet, otevřený na plnou výšku.</translation>
-<translation id="2910701580606108292">Před povolením spuštění chráněného obsahu na webu se zeptat</translation>
-<translation id="2913331724188855103">Povolit webům ukládat a číst data souborů cookie (doporučeno)</translation>
-<translation id="2923908459366352541">Název je neplatný</translation>
-<translation id="2932150158123903946">Úložiště aplikace Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Karta náhledu byla zavřena</translation>
-<translation id="2956410042958133412">Tento účet spravují uživatelé <ph name="PARENT_NAME_1" /> a <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Přepnuto na anonymní karty</translation>
-<translation id="2968755619301702150">Prohlížeč certifikátů</translation>
-<translation id="2979025552038692506">Vybraná anonymní karta</translation>
-<translation id="2987620471460279764">Text sdílený z jiného zařízení</translation>
-<translation id="2989523299700148168">Nedávno navštívené</translation>
-<translation id="2996291259634659425">Vytvoření heslové fráze</translation>
-<translation id="2996809686854298943">Je požadována adresa URL</translation>
-<translation id="300526633675317032">Tímto vymažete celé úložiště webů (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">Zkontrolujte, zda je toto zařízení připojeno k internetu</translation>
-<translation id="3029613699374795922">Staženo: <ph name="KBS" /> kB</translation>
-<translation id="3029704984691124060">Heslové fráze se neshodují</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Zobrazit nápovědu<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Určování polohy je vypnuté, zapnete jej v <ph name="BEGIN_LINK" />nastavení zařízení Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Synchronizaci můžete kdykoliv zapnout v nastavení</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> záložka}few{<ph name="BOOKMARKS_COUNT_MANY" /> záložky}many{<ph name="BOOKMARKS_COUNT_MANY" /> záložky}other{<ph name="BOOKMARKS_COUNT_MANY" /> záložek}}</translation>
-<translation id="3089395242580810162">Otevřít na anonymní kartě</translation>
-<translation id="3115898365077584848">Zobrazit informace</translation>
-<translation id="3123473560110926937">Na některých webech blokováno</translation>
-<translation id="3137521801621304719">Ukončit anonymní režim</translation>
-<translation id="3143515551205905069">Zrušit synchronizaci</translation>
-<translation id="3157842584138209013">Informace o množství uspořených dat zobrazíte pomocí tlačítka Další možnosti</translation>
-<translation id="3166827708714933426">Zkratky pro okna a karty</translation>
-<translation id="3181954750937456830">Bezpečné prohlížení (chrání vás a vaše zařízení před nebezpečnými weby)</translation>
-<translation id="3190152372525844641">Oprávnění pro Chrome zapnete v <ph name="BEGIN_LINK" />Nastavení pro Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">Uložená data: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Skoro hotovo.</translation>
-<translation id="3207960819495026254">Přidáno do záložek</translation>
-<translation id="3211426585530211793">Položka <ph name="ITEM_TITLE" /> byla smazána</translation>
-<translation id="321773570071367578">Pokud jste heslovou frázi zapomněli nebo toto nastavení chcete změnit, <ph name="BEGIN_LINK" />resetujte synchronizaci<ph name="END_LINK" />.</translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Webová aplikace</translation>
-<translation id="3236059992281584593">Zbývá: 1 min</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Přidat stránku do záložek</translation>
-<translation id="3259831549858767975">Zmenšit veškerý obsah stránky</translation>
-<translation id="3269093882174072735">Načíst obrázek</translation>
-<translation id="3269956123044984603">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte v nastavení účtu Android možnost Automatická synchronizace dat.</translation>
-<translation id="3277252321222022663">Povolit webům přístup k senzorům (doporučeno)</translation>
-<translation id="3282568296779691940">Přihlásit se do Chromu</translation>
-<translation id="3288003805934695103">Načíst stránku znovu</translation>
-<translation id="32895400574683172">Oznámení jsou povolena</translation>
-<translation id="3295530008794733555">Prohlížejte si internet rychleji. Využívejte méně dat.</translation>
-<translation id="3295602654194328831">Skrýt informace</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Chcete pokračovat ke stažení obsahu?</translation>
-<translation id="3306398118552023113">Tato aplikace je spuštěna v Chromu</translation>
-<translation id="3315103659806849044">Aktuálně upravujete své nastavení synchronizace a služeb Google. Zapnutí synchronizace dokončíte klepnutím na tlačítko Potvrdit, které se nachází u dolního okraje obrazovky. Přejít nahoru</translation>
-<translation id="3328801116991980348">Informace o stránkách</translation>
-<translation id="3333961966071413176">Všechny kontakty</translation>
-<translation id="3334729583274622784">Změnit příponu souboru?</translation>
-<translation id="3341058695485821946">Podívejte se, kolik dat jste ušetřili</translation>
-<translation id="3350687908700087792">Zavřít všechny anonymní karty</translation>
-<translation id="3353615205017136254">Zjednodušenou stránku poskytuje Google. Klepnutím na tlačítko k načtení originálu zobrazíte původní verzi.</translation>
-<translation id="3367813778245106622">Chcete-li zahájit synchronizaci, znovu se přihlaste.</translation>
-<translation id="3374023511497244703">Vaše záložky, historie, hesla a další data v Chromu se již nebudou synchronizovat do vašeho účtu Google</translation>
-<translation id="3384347053049321195">Sdílet obrázek</translation>
-<translation id="3386292677130313581">Pokud web bude chtít znát vaši polohu, zobrazit dotaz (doporučeno)</translation>
-<translation id="3387650086002190359">Stažení souboru <ph name="FILE_NAME" /> se nezdařilo z důvodu chyb systému souborů.</translation>
-<translation id="3389286852084373014">Text je příliš dlouhý</translation>
-<translation id="3398320232533725830">Otevřít správce záložek</translation>
-<translation id="3414952576877147120">Velikost:</translation>
-<translation id="3443221991560634068">Znovu načíst aktuální stránku</translation>
-<translation id="3445014427084483498">Právě teď</translation>
-<translation id="3478363558367712427">Můžete si vybrat vyhledávač</translation>
+<translation id="6910211073230771657">Smazáno</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Dobře, rozumím</translation>
+<translation id="7658239707568436148">Zrušit</translation>
 <translation id="3479552764303398839">Teď ne</translation>
-<translation id="3492207499832628349">Nová anonymní karta</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Další informace<ph name="END_LINK" /> o navrhovaném obsahu</translation>
-<translation id="3513704683820682405">Rozšířená realita</translation>
-<translation id="3518985090088779359">PŘIJMOUT A POKRAČOVAT</translation>
-<translation id="3522247891732774234">K dispozici je aktualizace. Další možnosti</translation>
-<translation id="3524138585025253783">Uživatelské rozhraní pro vývojáře</translation>
-<translation id="3527085408025491307">Složka</translation>
-<translation id="3542235761944717775">Dostupné místo: <ph name="KILOBYTES" /> kB</translation>
-<translation id="3549657413697417275">Prohledávat historii</translation>
-<translation id="3557336313807607643">Přidat do kontaktů</translation>
-<translation id="3566923219790363270">Chrome se na virtuální realitu stále připravuje. Restartujte Chrome později.</translation>
-<translation id="3568688522516854065">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte synchronizaci</translation>
-<translation id="3587482841069643663">Vše</translation>
-<translation id="358794129225322306">Povolit webu automaticky stáhnout několik souborů.</translation>
-<translation id="3590487821116122040">Úložiště webů, které Chrome považuje za nedůležité (např. weby bez uložených nastavení nebo weby, které nenavštěvujete často)</translation>
-<translation id="3599863153486145794">Vymaže historii ze všech zařízení, na kterých jste přihlášeni. Na stránce <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Google.</translation>
-<translation id="3600792891314830896">Ztlumit weby, které přehrávají zvuky</translation>
-<translation id="3616113530831147358">Zvuk</translation>
-<translation id="3631987586758005671">Sdílení se zařízením <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Zrušit maskování hesla</translation>
-<translation id="363596933471559332">Přihlašovat se na weby automaticky pomocí uložených identifikačních údajů. Když je tato funkce vypnutá, budete před každým přihlášením na web požádáni o ověření.</translation>
-<translation id="3658159451045945436">Resetováním vymažete historii úspory dat, včetně seznamu navštívených webů.</translation>
-<translation id="3692944402865947621">Stažení souboru <ph name="FILE_NAME" /> se nezdařilo, protože umístění úložiště není dostupné.</translation>
-<translation id="3714981814255182093">Otevřít lištu Najít</translation>
-<translation id="3716182511346448902">Tato stránka využívá příliš mnoho paměti, proto ji Chrome pozastavil.</translation>
-<translation id="3730075448226062617">Chcete-li Chromu umožnit přístup k mikrofonu, zapněte mikrofon také v <ph name="BEGIN_LINK" />Nastavení Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Přidáno do záložek (<ph name="PRODUCT_NAME" />)</translation>
-<translation id="3744111561329211289">Synchronizace na pozadí</translation>
-<translation id="3771001275138982843">Aktualizaci nelze stáhnout</translation>
-<translation id="3771033907050503522">Anonymní karty</translation>
-<translation id="3773755127849930740">Chcete-li povolit párování, <ph name="BEGIN_LINK" />zapněte Bluetooth<ph name="END_LINK" />.</translation>
-<translation id="3775705724665058594">Odeslat na vaše zařízení</translation>
-<translation id="3778956594442850293">Přidáno na domovskou obrazovku</translation>
-<translation id="3789841737615482174">Instalovat</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Spravovat</translation>
-<translation id="381841723434055211">Telefonní čísla</translation>
-<translation id="3819178904835489326">Počet smazaných stažených souborů: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Vymazat úložiště webů?</translation>
-<translation id="385051799172605136">Zpět</translation>
-<translation id="3859306556332390985">Přetočit dopředu</translation>
-<translation id="3894427358181296146">Přidat složku</translation>
-<translation id="3895926599014793903">Vynutit aktivaci přiblížení</translation>
-<translation id="3912508018559818924">Hledáme to nejlepší z webu…</translation>
-<translation id="3927692899758076493">Bezpatková</translation>
-<translation id="3928666092801078803">Sloučit má data</translation>
-<translation id="393697183122708255">Hlasové vyhledávání není k dispozici</translation>
-<translation id="395206256282351086">Návrhy vyhledávacích dotazů a webů jsou vypnuty</translation>
-<translation id="3955193568934677022">Povolit webům přehrávat chráněný obsah (doporučeno)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome stránku načte, až bude připraven}few{Chrome stránky načte, až bude připraven}many{Chrome stránky načte, až bude připraven}other{Chrome stránky načte, až bude připraven}}</translation>
-<translation id="3963007978381181125">Šifrování pomocí heslové fráze se nevztahuje na platební metody a adresy ze služby Google Pay. Vaše šifrovaná data mohou číst pouze uživatelé, kteří mají vaši heslovou frázi. Heslová fráze se neodesílá do Googlu a není na Googlu uložena. Pokud ji zapomenete nebo toto nastavení budete chtít změnit, bude nutné synchronizaci resetovat. <ph name="BEGIN_LINK" />Další informace<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Stahování bylo dokončeno</translation>
-<translation id="397583555483684758">Synchronizace přestala fungovat</translation>
-<translation id="3976396876660209797">Odstraňte tuto zkratku a znovu ji vytvořte</translation>
-<translation id="3985215325736559418">Opravdu soubor <ph name="FILE_NAME" /> chcete stáhnout znovu?</translation>
-<translation id="3987993985790029246">Kopírovat odkaz</translation>
-<translation id="3988213473815854515">Přístup k poloze je povolen</translation>
-<translation id="3988466920954086464">Na tomto panelu naleznete výsledky dynamického vyhledávání</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Nedůležité úložiště</translation>
-<translation id="4000212216660919741">Offline domovská stránka</translation>
+<translation id="5317780077021120954">Uložit</translation>
+<translation id="4570913071927164677">Podrobnosti</translation>
+<translation id="8730621377337864115">Hotovo</translation>
+<translation id="8261506727792406068">Smazat</translation>
+<translation id="1181037720776840403">Odebrat</translation>
+<translation id="5939518447894949180">Resetovat</translation>
 <translation id="4002066346123236978">Název</translation>
-<translation id="4008040567710660924">Povolit soubory cookie pro konkrétní web.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}few{# h}many{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Další skladba</translation>
-<translation id="4048707525896921369">Vyhledávejte informace o tématech zmíněných na stránce, aniž byste stránku museli opustit. Funkce Vyhledání klepnutím odešle slovo a okolní kontext do Vyhledávání Google, které vrátí definice, obrázky, výsledky vyhledávání a další podrobnosti.
+<translation id="5916664084637901428">Zapnuto</translation>
+<translation id="5860033963881614850">Vypnuto</translation>
+<translation id="6165508094623778733">Další informace</translation>
+<translation id="6042308850641462728">Více</translation>
+<translation id="6040143037577758943">Zavřít</translation>
+<translation id="780301667611848630">Ne, děkuji</translation>
+<translation id="1201402288615127009">Další</translation>
+<translation id="2359808026110333948">Pokračovat</translation>
+<translation id="2653659639078652383">Odeslat</translation>
+<translation id="2079545284768500474">Vrátit zpět</translation>
+<translation id="7649070708921625228">Nápověda</translation>
+<translation id="2148716181193084225">Dnes</translation>
+<translation id="7781829728241885113">Včera</translation>
+<translation id="6945221475159498467">Vybrat</translation>
+<translation id="7791543448312431591">Přidat</translation>
+<translation id="6527303717912515753">Sdílet</translation>
+<translation id="1383876407941801731">Vyhledávání</translation>
+<translation id="3115898365077584848">Zobrazit informace</translation>
+<translation id="3295602654194328831">Skrýt informace</translation>
+<translation id="3987993985790029246">Kopírovat odkaz</translation>
+<translation id="2704606927547763573">Zkopírováno</translation>
+<translation id="8725066075913043281">Zkusit znovu</translation>
+<translation id="385051799172605136">Zpět</translation>
+<translation id="8131740175452115882">Potvrdit</translation>
+<translation id="5300589172476337783">Zobrazit</translation>
+<translation id="1124772482545689468">Uživatel</translation>
+<translation id="8609465669617005112">Posunout nahoru</translation>
+<translation id="6746124502594467657">Posunout dolů</translation>
+<translation id="8249310407154411074">Přesunout na začátek</translation>
+<translation id="8428213095426709021">Nastavení</translation>
+<translation id="2498359688066513246">Nápověda a zpětná vazba</translation>
+<translation id="8378714024927312812">Spravováno vaší organizací</translation>
+<translation id="9019902583201351841">Spravováno vašimi rodiči</translation>
+<translation id="4645575059429386691">Spravováno vaším rodičem</translation>
+<translation id="4883854917563148705">Spravovaná nastavení nelze resetovat</translation>
+<translation id="4307992518367153382">Základy</translation>
+<translation id="1974060860693918893">Rozšířená nastavení</translation>
+<translation id="1146678959555564648">Zapnout VR</translation>
+<translation id="987264212798334818">Všeobecné</translation>
+<translation id="4275663329226226506">Média</translation>
+<translation id="4759238208242260848">Stažené soubory</translation>
+<translation id="218608176142494674">Sdílení</translation>
+<translation id="8004582292198964060">Prohlížeč</translation>
+<translation id="1105960400813249514">Snímky obrazovky</translation>
+<translation id="4875775213178255010">Návrhy obsahu</translation>
+<translation id="2021896219286479412">Ovládání webu na celé obrazovce</translation>
+<translation id="4587589328781138893">Weby</translation>
+<translation id="4943703118917034429">Virtuální realita</translation>
+<translation id="1928696683969751773">Aktualizace</translation>
+<translation id="6064125863973209585">Dokončená stahování</translation>
+<translation id="5342314432463739672">Žádosti o oprávnění</translation>
+<translation id="629730747756840877">Účet</translation>
+<translation id="82609232232243542">Přihlásit se do Chromu</translation>
+<translation id="7956662517480676674">Synchronizace a služby Brave Software</translation>
+<translation id="5294439808117722387">Aktuálně upravujete své nastavení synchronizace a služeb Brave Software. Zapnutí synchronizace dokončíte klepnutím na tlačítko Potvrdit, které se nachází u dolního okraje obrazovky. Přejít nahoru</translation>
+<translation id="2096012225669085171">Synchronizovat a přizpůsobit na různých zařízeních</translation>
+<translation id="1692118695553449118">Synchronizace je zapnuta</translation>
+<translation id="5514904542973294328">Zakázáno administrátorem tohoto zařízení</translation>
+<translation id="6447211988989208781">Ovládací prvky aktivity Brave Software</translation>
+<translation id="4882831918239250449">Nastavte, jak se má vaše historie procházení používat k personalizaci Vyhledávání, reklam a dalších služeb</translation>
+<translation id="7431991332293347422">Nastavte, jak se má vaše historie prohlížení používat k personalizaci Vyhledávání a dalších služeb</translation>
+<translation id="6303969859164067831">Odhlásit a vypnout synchronizaci</translation>
+<translation id="1125261911132334651">Spravovat váš účet Brave Software</translation>
+<translation id="6406506848690869874">Synchronizace</translation>
+<translation id="714362445477979774">Synchronizovat data prohlížeče Brave</translation>
+<translation id="4314815835985389558">Správa synchronizace</translation>
+<translation id="5428209950370661546">Další služby Brave Software</translation>
+<translation id="7704317875155739195">Automaticky doplňovat vyhledávací dotazy a adresy URL</translation>
+<translation id="2000419248597011803">Odesílá soubory cookie a vyhledávací dotazy z adresního řádku a vyhledávacího pole a několik souborů cookie vašemu výchozímu vyhledávači</translation>
+<translation id="7981313251711023384">Předběžně načítat stránky pro rychlejší procházení a vyhledávání</translation>
+<translation id="1821253160463689938">Používá soubory cookie k uložení vašeho nastavení i v případě, že stránky nenavštívíte</translation>
+<translation id="6697492270171225480">Zobrazovat návrhy podobných stránek, když stránku nelze najít</translation>
+<translation id="8109318360573330108">Odesílá do Googlu adresu URL stránky, na kterou se pokoušíte přejít</translation>
+<translation id="8438566539970814960">Vylepšit vyhledávání a procházení</translation>
+<translation id="284843628681142937">Odesílá do Googlu adresy URL stránek, které navštěvujete</translation>
+<translation id="7222718784508482526">Další nastavení související s ochranou soukromí, zabezpečením a shromažďováním dat naleznete v části <ph name="BEGIN_LINK"/>Synchronizace a služby Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Pomoci s vylepšováním funkcí a výkonu prohlížeče Brave</translation>
+<translation id="9063160602596686558">Automaticky odesílá statistiky o využívání a zprávy o selhání do Googlu</translation>
+<translation id="4824958205181053313">Zrušit synchronizaci?</translation>
+<translation id="3058498974290601450">Synchronizaci můžete kdykoliv zapnout v nastavení</translation>
+<translation id="3143515551205905069">Zrušit synchronizaci</translation>
+<translation id="1506061864768559482">Vyhledávač</translation>
+<translation id="55737423895878184">Určování polohy a oznámení jsou povoleny</translation>
+<translation id="3988213473815854515">Přístup k poloze je povolen</translation>
+<translation id="32895400574683172">Oznámení jsou povolena</translation>
+<translation id="9040142327097499898">Oznámení jsou povolena. Poloha je v tomto zařízení vypnutá.</translation>
+<translation id="305593374596241526">Určování polohy je vypnuté, zapnete jej v <ph name="BEGIN_LINK"/>nastavení zařízení Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Nedávno navštívené</translation>
+<translation id="6433501201775827830">Vyberte vyhledávač</translation>
+<translation id="7177466738963138057">Svoji volbu můžete později změnit v nabídce Nastavení</translation>
+<translation id="3478363558367712427">Můžete si vybrat vyhledávač</translation>
+<translation id="4910889077668685004">Platební aplikace</translation>
+<translation id="5152843274749979095">Nejsou nainstalovány žádné podporované aplikace</translation>
+<translation id="8812260976093120287">Na některých webech můžete platit pomocí výše uvedených podporovaných platebních aplikací v zařízení.</translation>
+<translation id="7764225426217299476">Přidat adresu</translation>
+<translation id="5595485650161345191">Upravit adresu</translation>
+<translation id="5087580092889165836">Přidat kartu</translation>
+<translation id="2154484045852737596">Úprava karty</translation>
+<translation id="6140912465461743537">Země/Region</translation>
+<translation id="5659593005791499971">E-mail</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Jméno na kartě</translation>
+<translation id="860043288473659153">Jméno držitele karty</translation>
+<translation id="2612676031748830579">Číslo karty</translation>
+<translation id="869891660844655955">Datum vypršení platnosti</translation>
+<translation id="2286841657746966508">Fakturační adresa</translation>
+<translation id="663059986967017181">Zkopírováno do Chromu</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> další}few{<ph name="PAYMENT_METHOD_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> další}many{<ph name="PAYMENT_METHOD_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> další}other{<ph name="PAYMENT_METHOD_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> dalších}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> další}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> další}many{<ph name="SHIPPING_ADDRESS_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> další}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> dalších}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> další}few{<ph name="SHIPPING_OPTION_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> další}many{<ph name="SHIPPING_OPTION_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> další}other{<ph name="SHIPPING_OPTION_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> dalších}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> další}few{<ph name="CONTACT_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> další}many{<ph name="CONTACT_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> dalšího}other{<ph name="CONTACT_PREVIEW"/> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> dalších}}</translation>
+<translation id="7029809446516969842">Hesla</translation>
+<translation id="1943432128510653496">Ukládání hesel</translation>
+<translation id="2100273922101894616">Přihlásit se automaticky</translation>
+<translation id="363596933471559332">Přihlašovat se na weby automaticky pomocí uložených identifikačních údajů. Když je tato funkce vypnutá, budete před každým přihlášením na web požádáni o ověření.</translation>
+<translation id="6995899638241819463">Upozorňovat v případě vyzrazení hesel při porušení zabezpečení</translation>
+<translation id="1534287762301776620">Když se přihlásíte k účtu Brave Software, je tato funkce zapnutá</translation>
+<translation id="10614374240317010">Nikdy se neukládají</translation>
+<translation id="3098842761938485917">Zobrazit a spravovat uložená hesla v <ph name="BEGIN_LINK"/>účtu Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Zde se zobrazí uložená hesla.</translation>
+<translation id="8084114998886531721">Uložené heslo</translation>
+<translation id="2870560284913253234">Stránky</translation>
+<translation id="8503813439785031346">Uživatelské jméno</translation>
+<translation id="6657585470893396449">Heslo</translation>
+<translation id="2154710561487035718">Kopírovat adresu URL</translation>
+<translation id="1571304935088121812">Kopírovat uživatelské jméno</translation>
+<translation id="5005498671520578047">Kopírování hesla</translation>
+<translation id="3632295766818638029">Zrušit maskování hesla</translation>
+<translation id="1513858653616922153">Vymazat heslo</translation>
+<translation id="543338862236136125">Upravit heslo</translation>
+<translation id="4565377596337484307">Skrýt heslo</translation>
+<translation id="8523928698583292556">Vymazat uložené heslo</translation>
+<translation id="2898264748040935573">Upravit uložené heslo</translation>
+<translation id="5433691172869980887">Uživatelské jméno bylo zkopírováno</translation>
+<translation id="5534640966246046842">Web byl zkopírován</translation>
+<translation id="2625189173221582860">Heslo bylo zkopírováno</translation>
+<translation id="4550003330909367850">Chcete-li zde zobrazovat či kopírovat hesla, nastavte v tomto zařízení zámek obrazovky.</translation>
+<translation id="6154478581116148741">Chcete-li z tohoto zařízení exportovat svá hesla, zapněte v Nastavení zámek obrazovky</translation>
+<translation id="4842092870884894799">Je zobrazeno vyskakovací okno generování hesla</translation>
+<translation id="2259659629660284697">Exportovat hesla…</translation>
+<translation id="133012818630824069">Exportovat hesla uložená v Chromu</translation>
+<translation id="6914783257214138813">Vaše hesla uvidí každý, kdo může zobrazit exportovaný soubor.</translation>
+<translation id="2321086116217818302">Příprava hesel…</translation>
+<translation id="8445448999790540984">Hesla se nepodařilo exportovat</translation>
+<translation id="3066461326500799725">Naučte se používat Disk Brave Software</translation>
+<translation id="729975465115245577">V zařízení není žádná aplikace, pomocí které by soubor s hesly bylo možné uložit.</translation>
+<translation id="7682724950699840886">Vyzkoušejte tyto tipy: Zajistěte, aby v zařízení byl dostatek místa a zkuste export zopakovat.</translation>
+<translation id="1129510026454351943">Podrobnosti: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Chcete-li zkopírovat heslo, odemkněte zařízení</translation>
+<translation id="5515439363601853141">Chcete-li zobrazit heslo, odemkněte zařízení</translation>
+<translation id="6221633008163990886">Chcete-li exportovat hesla, odemkněte zařízení</translation>
+<translation id="230699814587342492">Hesla Brave</translation>
+<translation id="6075798973483050474">Upravit domovskou stránku</translation>
+<translation id="854522910157234410">Otevřít tuto stránku</translation>
+<translation id="2482878487686419369">Oznámení</translation>
+<translation id="6255999984061454636">Návrhy obsahu</translation>
+<translation id="805047784848435650">Na základě vaší historie prohlížení</translation>
+<translation id="1041308826830691739">Z webů</translation>
+<translation id="395206256282351086">Návrhy vyhledávacích dotazů a webů jsou vypnuty</translation>
+<translation id="257088987046510401">Motivy</translation>
+<translation id="4650364565596261010">Výchozí nastavení systému</translation>
+<translation id="7588219262685291874">Když je na zařízení zapnutý spořič baterie, zapnout tmavý motiv</translation>
+<translation id="2760989362628427051">Zapnout tmavý motiv, když je na zařízení zapnutý tmavý motiv nebo spořič baterie</translation>
+<translation id="6381421346744604172">Ztmavit webové stránky</translation>
+<translation id="5040262127954254034">Ochrana soukromí</translation>
+<translation id="4991384657077828949">Pomoci zlepšovat zabezpečení Chromu</translation>
+<translation id="1943176487615318915">Kvůli detekci nebezpečných aplikací a webů odesílá Brave do Googlu adresy URL některých navštívených stránek, omezené informace o systému a část obsahu stránek</translation>
+<translation id="3181954750937456830">Bezpečné prohlížení (chrání vás a vaše zařízení před nebezpečnými weby)</translation>
+<translation id="7315322926489145388">Když je ohrožena vaše bezpečnost, odesílá adresy URL některých navštívených stránek do Googlu</translation>
+<translation id="2063713494490388661">Vyhledání klepnutím</translation>
+<translation id="2369463299479365221">Vyhledávejte informace o tématech zmíněných na stránce, aniž byste stránku museli opustit. Funkce Vyhledání klepnutím odešle slovo a okolní kontext do Vyhledávání Brave Software, které vrátí definice, obrázky, výsledky vyhledávání a další podrobnosti.
 
 Chcete-li vyhledávací dotaz upravit, proveďte výběr dlouhým stisknutím. Chcete-li upřesnit vyhledávací dotaz, přejeďte po panelu až nahoru a klepněte na vyhledávací pole.</translation>
-<translation id="4056223980640387499">Sépie</translation>
-<translation id="4060598801229743805">Možnosti jsou k dispozici u horního okraje obrazovky</translation>
-<translation id="4062305924942672200">Právní informace</translation>
-<translation id="4084682180776658562">Záložka</translation>
-<translation id="4084712963632273211">Zdroj: <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />poskytováno společností Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Vymazat data aplikace?</translation>
-<translation id="4099578267706723511">Pomozte Chrome zlepšovat – posílejte Googlu statistiky o využívání a zprávy o selhání.</translation>
-<translation id="410351446219883937">Automatické přehrávání</translation>
-<translation id="4116038641877404294">Stáhněte si stránky k použití offline</translation>
-<translation id="4135200667068010335">Seznam zařízení, se kterými se má karta sdílet, je zavřený.</translation>
-<translation id="4149994727733219643">Zjednodušené zobrazení webových stránek</translation>
-<translation id="4165986682804962316">Nastavení webu</translation>
-<translation id="4169535189173047238">Nepovolovat</translation>
-<translation id="4170011742729630528">Služba není k dispozici, zkuste to později.</translation>
-<translation id="4179980317383591987">Využito: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Jazyky</translation>
-<translation id="4183868528246477015">Hledat pomocí Google Lens <ph name="BEGIN_NEW" />Nové<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Otevřít na nové kartě</translation>
-<translation id="4198423547019359126">Nejsou k dispozici žádná umístění stažených souborů</translation>
-<translation id="4209895695669353772">Chcete-li od Googlu získat personalizované návrhy obsahu, zapněte synchronizaci</translation>
-<translation id="4226663524361240545">Oznámení mohou aktivovat vibraci</translation>
-<translation id="423219824432660969">Zašifrovat synchronizovaná data pomocí hesla Google z <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Otevřít Nastavení</translation>
-<translation id="4256782883801055595">Licence open source</translation>
-<translation id="4259722352634471385">Navigace je blokována: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Zkopírovat adresu odkazu</translation>
-<translation id="4275663329226226506">Média</translation>
-<translation id="4278390842282768270">Povoleno</translation>
-<translation id="429312253194641664">Web přehrává média</translation>
-<translation id="4298388696830689168">Propojené weby</translation>
-<translation id="4307992518367153382">Základy</translation>
-<translation id="4314815835985389558">Správa synchronizace</translation>
-<translation id="4351244548802238354">Zavřít dialogové okno</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">K vyhledávání se používá služba Sogou</translation>
-<translation id="4404568932422911380">Žádné záložky</translation>
-<translation id="4405224443901389797">Přesunout do…</translation>
-<translation id="4411535500181276704">Zjednodušený režim</translation>
-<translation id="4415276339145661267">Spravovat váš účet Google</translation>
-<translation id="4432792777822557199">Stránky v jazyce <ph name="SOURCE_LANGUAGE" /> od teď budou překládány do jazyka <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Zjednodušenou stránku poskytuje Google</translation>
-<translation id="4434045419905280838">Vyskakovací okna a přesměrování</translation>
-<translation id="4440958355523780886">Zjednodušenou stránku poskytuje Google. Klepnutím načtete originál.</translation>
-<translation id="4452411734226507615">Zavřít kartu <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Záložka přidána do složky <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Povolit webům přehrávat chráněný obsah</translation>
-<translation id="4468959413250150279">Vypne zvuk na konkrétním webu.</translation>
-<translation id="4472118726404937099">Chcete-li synchronizovat a přizpůsobit různá zařízení, přihlaste se a zapněte synchronizaci</translation>
-<translation id="447252321002412580">Pomoci s vylepšováním funkcí a výkonu prohlížeče Chrome</translation>
-<translation id="4479647676395637221">Pokud web bude chtít použít vaši kameru, zobrazit dotaz (doporučeno)</translation>
-<translation id="4479972344484327217">Instalace modulu <ph name="MODULE" /> pro Chrome…</translation>
-<translation id="4487967297491345095">Všechna data aplikace Chrome budou trvale smazána. Zahrnuje to soubory, nastavení, účty, databáze apod.</translation>
-<translation id="4493497663118223949">Zjednodušený režim je zapnutý</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{před # dnem}few{před # dny}many{před # dne}other{před # dny}}</translation>
-<translation id="451872707440238414">Prohledat záložky</translation>
-<translation id="4521489764227272523">Vybraná data byla z Chromu a synchronizovaných zařízení odstraněna.
-
-Na stránce <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" /> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Google, například vyhledávací dotazy a aktivita z ostatních služeb Google.</translation>
-<translation id="4532845899244822526">Výběr složky</translation>
-<translation id="4538018662093857852">Zapnout zjednodušený režim</translation>
-<translation id="4550003330909367850">Chcete-li zde zobrazovat či kopírovat hesla, nastavte v tomto zařízení zámek obrazovky.</translation>
-<translation id="4558311620361989323">Zkratky webových stránek</translation>
-<translation id="4561979708150884304">Žádné připojení</translation>
-<translation id="4565377596337484307">Skrýt heslo</translation>
-<translation id="4570913071927164677">Podrobnosti</translation>
-<translation id="4572422548854449519">Přihlaste se ke spravovanému účtu</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{před # minutou}few{před # minutami}many{před # minuty}other{před # minutami}}</translation>
-<translation id="4587589328781138893">Weby</translation>
-<translation id="4594952190837476234">Tato offline stránka je z <ph name="CREATION_TIME" /> a může se od online verze lišit.</translation>
-<translation id="4605958867780575332">Tato položka byla odstraněna: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Do aplikace <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Použít heslo</translation>
-<translation id="4645575059429386691">Spravováno vaším rodičem</translation>
-<translation id="4650364565596261010">Výchozí nastavení systému</translation>
-<translation id="4663756553811254707">Smazané záložky: <ph name="NUMBER_OF_BOOKMARKS" /></translation>
-<translation id="4665282149850138822">Na plochu byl přidán web <ph name="NAME" /></translation>
-<translation id="4684427112815847243">Synchronizovat vše</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> další}few{<ph name="SHIPPING_OPTION_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> další}many{<ph name="SHIPPING_OPTION_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> další}other{<ph name="SHIPPING_OPTION_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> dalších}}</translation>
-<translation id="4696983787092045100">Odeslat text do vašich zařízení</translation>
-<translation id="4698034686595694889">Zobrazit offline v aplikaci <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Obrázky a soubory v mezipaměti</translation>
-<translation id="4714588616299687897">Uspořte až 60 % svých dat</translation>
-<translation id="4719927025381752090">Nabízet překlad</translation>
-<translation id="4720023427747327413">Otevřít v aplikaci <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Pomozte Chrome zlepšit. <ph name="BEGIN_LINK" />Zúčastněte se průzkumu<ph name="END_LINK" />.</translation>
-<translation id="473775607612524610">Aktualizovat</translation>
-<translation id="4738836084190194332">Poslední synchronizace: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Otevření nové karty</translation>
-<translation id="4751476147751820511">Senzory pohybu nebo světla</translation>
-<translation id="4759238208242260848">Stažené soubory</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Stažení 1 souboru bylo dokončeno.}few{Stažení # souborů bylo dokončeno.}many{Stažení # souboru bylo dokončeno.}other{Stažení # souborů bylo dokončeno.}}</translation>
-<translation id="4797039098279997504">Klepnutím se vrátíte na kartu <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Šifrování pomocí heslové fráze se nevztahuje na platební metody a adresy ze služby Google Pay.
-
-Chcete-toto nastavení změnit, <ph name="BEGIN_LINK" />resetujte synchronizaci<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Jméno na kartě</translation>
-<translation id="4824958205181053313">Zrušit synchronizaci?</translation>
-<translation id="4837753911714442426">Otevřít možnosti tisku stránky</translation>
-<translation id="4842092870884894799">Je zobrazeno vyskakovací okno generování hesla</translation>
-<translation id="4860895144060829044">Volat</translation>
-<translation id="4866368707455379617">Modul <ph name="MODULE" /> pro Chrome se nepodařilo nainstalovat</translation>
-<translation id="4875775213178255010">Návrhy obsahu</translation>
-<translation id="4878404682131129617">Vytvoření tunelu prostřednictvím proxy serveru se nezdařilo</translation>
-<translation id="4880127995492972015">Přeložit…</translation>
-<translation id="4881695831933465202">Otevřít</translation>
-<translation id="488187801263602086">Přejmenovat soubor</translation>
-<translation id="4882831918239250449">Nastavte, jak se má vaše historie procházení používat k personalizaci Vyhledávání, reklam a dalších služeb</translation>
-<translation id="4883854917563148705">Spravovaná nastavení nelze resetovat</translation>
-<translation id="4885273946141277891">Nepodporovaný počet instancí Chromu.</translation>
-<translation id="4910889077668685004">Platební aplikace</translation>
-<translation id="4913161338056004800">Obnovit statistiky</translation>
-<translation id="4913169188695071480">Zastavit obnovování</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Nápověda<ph name="END_LINK" /> k vyhledávání zařízení…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stránka}few{# stránky}many{# stránky}other{# stránek}}</translation>
-<translation id="4932247056774066048">Protože se odhlašujete z účtu spravovaného doménou <ph name="DOMAIN_NAME" />, vaše data prohlížeče Chrome z tohoto zařízení budou smazána. Ve vašem účtu Google zůstanou.</translation>
-<translation id="4943703118917034429">Virtuální realita</translation>
-<translation id="4943872375798546930">Žádné výsledky</translation>
-<translation id="4958708863221495346">Stránka <ph name="URL_OF_THE_CURRENT_TAB" /> sdílí vaši obrazovku</translation>
-<translation id="4961107849584082341">Nechte si tuto stránku přeložit do libovolného jazyka</translation>
-<translation id="4962975101802056554">Zrušit všechna oprávnění pro zařízení</translation>
-<translation id="4970824347203572753">Ve vaší lokalitě není k dispozici</translation>
-<translation id="497421865427891073">Vpřed</translation>
-<translation id="4988210275050210843">Stahování souboru (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Stránky</translation>
-<translation id="4994033804516042629">Nebyly nalezeny žádné kontakty</translation>
-<translation id="4996978546172906250">Sdílet prostřednictvím</translation>
-<translation id="5004416275253351869">Ovládací prvky aktivity Google</translation>
-<translation id="5005498671520578047">Kopírování hesla</translation>
-<translation id="5011311129201317034">Web <ph name="SITE" /> žádá o připojení</translation>
-<translation id="5013696553129441713">Žádné nové návrhy</translation>
-<translation id="5016205925109358554">Patková</translation>
-<translation id="5033865233969348410">V režimu virtuální reality tento web může získat následující informace:
-– vaše fyzické vlastnosti, jako je výška
-
-Před přechodem do režimu virtuální reality zkontrolujte, zda tomuto webu důvěřujete.</translation>
+<translation id="2930742481329940825">Vyhledání klepnutím odešle vybrané slovo a aktuální stránku jako kontext do Vyhledávání Brave Software. Tuto funkci můžete vypnout v <ph name="BEGIN_LINK"/>Nastavení<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Povolit</translation>
-<translation id="5040262127954254034">Ochrana soukromí</translation>
-<translation id="5048398596102334565">Povolit webům přístup k senzorům pohybu (doporučeno)</translation>
-<translation id="5063480226653192405">Použití</translation>
-<translation id="5087580092889165836">Přidat kartu</translation>
-<translation id="5100237604440890931">Sbaleno – kliknutím rozbalíte</translation>
-<translation id="510275257476243843">Zbývá: 1 h</translation>
-<translation id="5123685120097942451">Anonymní karta</translation>
-<translation id="5127805178023152808">Synchronizace je vypnuta</translation>
-<translation id="5129038482087801250">Instalovat webovou aplikaci</translation>
-<translation id="5132942445612118989">Vaše hesla, historie a další údaje na všech zařízeních</translation>
-<translation id="5139940364318403933">Naučte se používat Disk Google</translation>
-<translation id="515227803646670480">Vymazat uložená data</translation>
-<translation id="5152843274749979095">Nejsou nainstalovány žádné podporované aplikace</translation>
-<translation id="5161254044473106830">Je požadován název</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Stažení 1 souboru se nezdařilo.}few{Stažení # souborů se nezdařilo.}many{Stažení # souboru se nezdařilo.}other{Stažení # souborů se nezdařilo.}}</translation>
-<translation id="5170568018924773124">Zobrazit ve složce</translation>
-<translation id="5184329579814168207">Otevřít v Chromu</translation>
-<translation id="5193988420012215838">Zkopírováno do schránky</translation>
-<translation id="5197729504361054390">Vybrané kontakty budou sdíleny s webem <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Pracovní profil</translation>
-<translation id="5210286577605176222">Přejít na předchozí kartu</translation>
-<translation id="5210365745912300556">Zavřít kartu</translation>
-<translation id="5224771365102442243">S videem</translation>
-<translation id="5230560987958996918">Web <ph name="SITE" /> chce vyhledat zařízení Bluetooth v okolí. Byla nalezena následující zařízení:</translation>
-<translation id="5233638681132016545">Nová karta</translation>
-<translation id="526421993248218238">Stránku nelze načíst</translation>
-<translation id="5271967389191913893">Zařízení obsah ke stažení nemůže otevřít.</translation>
-<translation id="528192093759286357">Režim celé obrazovky ukončíte přetažením z horního okraje obrazovky a klepnutím na tlačítko Zpět.</translation>
-<translation id="5292796745632149097">Odeslat do zařízení</translation>
-<translation id="5300589172476337783">Zobrazit</translation>
-<translation id="5301954838959518834">Dobře, rozumím</translation>
-<translation id="5304593522240415983">Toto pole nesmí být prázdné</translation>
-<translation id="5307446750509046227">Vymazat úložiště webů</translation>
-<translation id="5308380583665731573">Připojení</translation>
-<translation id="5313967007315987356">Přidat web</translation>
-<translation id="5317780077021120954">Uložit</translation>
-<translation id="5324858694974489420">Rodičovská nastavení</translation>
-<translation id="5327248766486351172">Jméno</translation>
-<translation id="5335288049665977812">Povolit webům spouštět JavaScript (doporučeno)</translation>
-<translation id="5342314432463739672">Žádosti o oprávnění</translation>
-<translation id="5357811892247919462">Byla přijata karta</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{Je otevřená <ph name="OPEN_TABS_ONE" /> karta, můžete mezi nimi přepínat klepnutím}few{Je otevřených <ph name="OPEN_TABS_MANY" /> karet, můžete mezi nimi přepínat klepnutím}many{Je otevřených <ph name="OPEN_TABS_MANY" /> karty, můžete mezi nimi přepínat klepnutím}other{Je otevřených <ph name="OPEN_TABS_MANY" /> karet, můžete mezi nimi přepínat klepnutím}}</translation>
-<translation id="5391532827096253100">Spojení s tímto webem není zabezpečené. Informace o webu</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 další)}few{(+ # další)}many{(+ # další)}other{(+ # dalších)}}</translation>
-<translation id="5400569084694353794">Používáním této aplikace vyjadřujete souhlas se <ph name="BEGIN_LINK1" />smluvními podmínkami<ph name="END_LINK1" /> a <ph name="BEGIN_LINK2" />zásadami ochrany soukromí<ph name="END_LINK2" /> prohlížeče Chrome.</translation>
-<translation id="5403592356182871684">Názvy</translation>
-<translation id="5403644198645076998">Povolit pouze určité weby</translation>
-<translation id="5414836363063783498">Ověřování…</translation>
-<translation id="5423934151118863508">Zde se zobrazí vaše nejnavštěvovanější stránky.</translation>
-<translation id="5424588387303617268">K dispozici: <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Upravit heslo</translation>
-<translation id="5433691172869980887">Uživatelské jméno bylo zkopírováno</translation>
-<translation id="543509235395288790">Stahování <ph name="COUNT" /> souborů (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Přejít na adresní řádek</translation>
-<translation id="5447201525962359567">Veškerá data webů, včetně souborů cookie a dalších místně uložených dat</translation>
-<translation id="5447765697759493033">Tento web nebude přeložen</translation>
-<translation id="545042621069398927">Zrychlování stahování.</translation>
-<translation id="5456381639095306749">Stáhnout stránku</translation>
-<translation id="5475862044948910901">Spustit relaci rozšířené reality?</translation>
-<translation id="548278423535722844">Otevřít v mapové aplikaci</translation>
-<translation id="5487521232677179737">Vymazat data</translation>
-<translation id="5494752089476963479">Blokovat reklamy na webech, které zobrazují obtěžující nebo zavádějící reklamy</translation>
-<translation id="5500777121964041360">Ve vaší lokalitě nemusí být k dispozici</translation>
-<translation id="5512137114520586844">Tento účet je spravován uživatelem <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Zakázáno administrátorem tohoto zařízení</translation>
-<translation id="5515439363601853141">Chcete-li zobrazit heslo, odemkněte zařízení</translation>
-<translation id="5516455585884385570">Otevřít nastavení oznámení</translation>
-<translation id="5517095782334947753">Máte záložky, historii, hesla a další nastavení z účtu <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Bylo zablokováno přesměrování.</translation>
-<translation id="5527082711130173040">K vyhledání zařízení potřebuje Chrome přístup k informacím o poloze. <ph name="BEGIN_LINK1" />Aktualizujte oprávnění<ph name="END_LINK1" />. V tomto zařízení je také <ph name="BEGIN_LINK2" />vypnut přístup k poloze<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Zeptat se, než bude webům povolen přístup k textu a obrázkům zkopírovaným do schránky (doporučeno)</translation>
-<translation id="5530766185686772672">Zavřít anonymní karty</translation>
-<translation id="5534334044554683961">V režimu virtuální reality tento web může získat následující informace:
-– vaše fyzické vlastnosti, jako je výška,
-– rozvržení vaší místnosti.
-
-Před přechodem do režimu virtuální reality zkontrolujte, zda tomuto webu důvěřujete.</translation>
-<translation id="5534640966246046842">Web byl zkopírován</translation>
-<translation id="5556459405103347317">Načíst znovu</translation>
-<translation id="5561549206367097665">Čekání na síť…</translation>
-<translation id="557283862590186398">Chrome pro tento web potřebuje oprávnění k přístupu k mikrofonu.</translation>
-<translation id="55737423895878184">Určování polohy a oznámení jsou povoleny</translation>
-<translation id="5578795271662203820">Hledat obrázek pomocí <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Synchronizované položky můžete kdykoliv vybrat v <ph name="BEGIN_LINK1" />nastavení<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Upravit adresu</translation>
-<translation id="5596627076506792578">Další možnosti</translation>
-<translation id="5599455543593328020">Anonymní režim</translation>
-<translation id="5620928963363755975">Stažené soubory a stránky můžete najít pomocí tlačítka Další možnosti</translation>
-<translation id="5626134646977739690">Jméno:</translation>
-<translation id="5639724618331995626">Povolit všechny weby</translation>
-<translation id="5648166631817621825">Posledních 7 dní</translation>
-<translation id="5649053991847567735">Automatické stahování</translation>
-<translation id="5655963694829536461">Hledat ve stažených souborech</translation>
-<translation id="5659593005791499971">E-mail</translation>
-<translation id="5665379678064389456">Vytvořit událost v aplikaci <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Přepsat požadavek webu na zákaz přiblížení</translation>
-<translation id="5677928146339483299">Zablokováno</translation>
-<translation id="5684874026226664614">Jejda. Tuto stránku se nepodařilo přeložit.</translation>
-<translation id="5686790454216892815">Název souboru je příliš dlouhý</translation>
-<translation id="5689516760719285838">Poloha</translation>
-<translation id="569536719314091526">Pomocí tlačítka Další možnosti můžete tuto stránku přeložit do libovolného jazyka.</translation>
-<translation id="572328651809341494">Nedávno použité karty</translation>
-<translation id="5726692708398506830">Zvětšit veškerý obsah stránky</translation>
-<translation id="5748802427693696783">Přepnuto na standardní karty</translation>
-<translation id="5749068826913805084">Aby bylo možné stahovat soubory, Chrome potřebuje přístup k úložišti.</translation>
-<translation id="5763382633136178763">Anonymní karty</translation>
-<translation id="5763514718066511291">Klepnutím zkopírujete adresu URL této aplikace</translation>
-<translation id="5765780083710877561">Popis:</translation>
-<translation id="5793665092639000975">Je využito <ph name="SPACE_USED" /> z <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google vaši historii může používat k personalizaci Vyhledávání, reklam a dalších služeb Google</translation>
-<translation id="5804241973901381774">Oprávnění</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{před # hodinou}few{před # hodinami}many{před # hodiny}other{před # hodinami}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Všechna práva vyhrazena.</translation>
-<translation id="5817918615728894473">Spárovat</translation>
-<translation id="583281660410589416">Neznámé</translation>
-<translation id="5833984609253377421">Sdílet odkaz</translation>
-<translation id="5836192821815272682">Stahování aktualizace Chromu…</translation>
-<translation id="5853623416121554550">pozastaveno</translation>
-<translation id="5854790677617711513">Starší než 30 dnů</translation>
-<translation id="5858741533101922242">Chrome nemůže zapnout adaptér Bluetooth</translation>
-<translation id="5860033963881614850">Vypnuto</translation>
-<translation id="5862731021271217234">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte synchronizaci</translation>
-<translation id="5864174910718532887">Podrobnosti: Seřazeno podle názvu webu</translation>
-<translation id="5864419784173784555">Čekání na další stahování…</translation>
-<translation id="5865733239029070421">Automaticky odesílá statistiky o využívání a zprávy o selhání do Googlu</translation>
-<translation id="5869522115854928033">Uložená hesla</translation>
-<translation id="5902828464777634901">Všechna místní data uložená tímto webem, včetně souborů cookie, budou smazána.</translation>
-<translation id="5916664084637901428">Zapnuto</translation>
-<translation id="5919204609460789179">Chcete-li zahájit synchronizaci, aktualizujte aplikaci <ph name="PRODUCT_NAME" /></translation>
-<translation id="5937580074298050696">Uspořeno: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Resetovat</translation>
-<translation id="5942872142862698679">K vyhledávání se používá Google</translation>
-<translation id="5952764234151283551">Odesílá do Googlu adresu URL stránky, na kterou se pokoušíte přejít</translation>
-<translation id="5956665950594638604">Otevřít centrum nápovědy Chrome na nové kartě</translation>
-<translation id="5958275228015807058">Najděte stažené soubory a stránky</translation>
-<translation id="5962718611393537961">Klepnutím sbalíte</translation>
-<translation id="6000066717592683814">Ponechat Google</translation>
-<translation id="6005538289190791541">Navrhované heslo</translation>
-<translation id="6036057147555329831">Extra ICU</translation>
-<translation id="6039379616847168523">Přejít na další kartu</translation>
-<translation id="6040143037577758943">Zavřít</translation>
-<translation id="6042308850641462728">Více</translation>
-<translation id="604996488070107836">Stažení souboru <ph name="FILE_NAME" /> se nezdařilo z důvodu neznámé chyby.</translation>
-<translation id="605721222689873409">RR</translation>
-<translation id="6064125863973209585">Dokončená stahování</translation>
-<translation id="6075798973483050474">Upravit domovskou stránku</translation>
-<translation id="60923314841986378">Zbývá: <ph name="HOURS" /> h</translation>
-<translation id="6108923351542677676">Probíhá nastavování…</translation>
-<translation id="6111020039983847643">využitá data</translation>
-<translation id="6112702117600201073">Obnovování stránky</translation>
-<translation id="6127379762771434464">Položka byla odstraněna</translation>
-<translation id="6140912465461743537">Země/Region</translation>
-<translation id="614940544461990577">Zkuste:</translation>
-<translation id="6154478581116148741">Chcete-li z tohoto zařízení exportovat svá hesla, zapněte v Nastavení zámek obrazovky</translation>
-<translation id="6159335304067198720">Úspora dat: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Další informace</translation>
-<translation id="6177111841848151710">Pro aktuální vyhledávač blokováno</translation>
-<translation id="6181444274883918285">Přidat výjimku pro konkrétní web</translation>
-<translation id="6192333916571137726">Stáhnout soubor</translation>
-<translation id="6192792657125177640">Výjimky</translation>
-<translation id="6194112207524046168">Chcete-li Chromu umožnit přístup k fotoaparátu, zapněte fotoaparát také v <ph name="BEGIN_LINK" />Nastavení Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokovat soubory cookie třetích stran</translation>
-<translation id="6206551242102657620">Připojení je zabezpečené. Informace o webu</translation>
-<translation id="6210748933810148297">Nejste <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Chcete-li exportovat hesla, odemkněte zařízení</translation>
+<translation id="1406000523432664303">Do Not Track (Nesledovat)</translation>
 <translation id="6232535412751077445">Pokud povolíte požadavek Do Not Track, bude připojován k datům provozu prohlížení. Účinek tohoto požadavku závisí na tom, zda na něj budou webové stránky reagovat a jak jej budou interpretovat.
 
 Některé weby mohou například na tento požadavek reagovat tak, že vám zobrazí reklamy, které nejsou založeny na ostatních navštívených webových stránkách. Řada webů bude i nadále shromažďovat vaše údaje o prohlížení a používat je například ke zlepšení zabezpečení, poskytování obsahu, reklam a doporučení a ke generování statistik pro přehledy.</translation>
-<translation id="624789221780392884">Je připravena aktualizace</translation>
-<translation id="6255999984061454636">Návrhy obsahu</translation>
-<translation id="6277522088822131679">Při tištění stránky došlo k problému. Zkuste to prosím znovu.</translation>
-<translation id="6295158916970320988">Všechny weby</translation>
-<translation id="629730747756840877">Účet</translation>
-<translation id="6303969859164067831">Odhlásit a vypnout synchronizaci</translation>
-<translation id="6316139424528454185">Nepodporovaná verze Androidu</translation>
-<translation id="6320088164292336938">Vibrovat</translation>
-<translation id="6324034347079777476">Synchronizace systému Android je vypnuta.</translation>
-<translation id="6333140779060797560">Sdílet prostřednictvím aplikace <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Šifrování</translation>
-<translation id="6341580099087024258">Zeptat se, kam se soubory mají uložit</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> další}few{<ph name="SHIPPING_ADDRESS_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> další}many{<ph name="SHIPPING_ADDRESS_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> další}other{<ph name="SHIPPING_ADDRESS_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> dalších}}</translation>
-<translation id="6364438453358674297">Odstranit návrh z historie?</translation>
-<translation id="6369229450655021117">Odsud můžete vyhledávat na webu, sdílet obsah s přáteli a zobrazovat otevřené stránky.</translation>
-<translation id="6378173571450987352">Podrobnosti: Seřazeno podle množství využitých dat</translation>
-<translation id="6381421346744604172">Ztmavit webové stránky</translation>
-<translation id="6388207532828177975">Vymazat a resetovat</translation>
-<translation id="6393863479814692971">Chrome pro tento web potřebuje oprávnění k přístupu k fotoaparátu a mikrofonu.</translation>
-<translation id="6395288395575013217">ODKAZ</translation>
-<translation id="6404511346730675251">Upravit záložku</translation>
-<translation id="6406506848690869874">Synchronizace</translation>
-<translation id="641643625718530986">Tisk…</translation>
-<translation id="6416782512398055893">Staženo: <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Přeložte si web</translation>
-<translation id="6433501201775827830">Vyberte vyhledávač</translation>
-<translation id="6437478888915024427">Informace o stránce</translation>
-<translation id="6441734959916820584">Název je příliš dlouhý</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# obrázek}few{# obrázky}many{# obrázku}other{# obrázků}}</translation>
-<translation id="6447842834002726250">Soubory cookie</translation>
-<translation id="6461962085415701688">Soubor nelze otevřít</translation>
-<translation id="6464977750820128603">Můžete se podívat, které stránky v Chromu navštěvujete, a nastavit pro ně časovače.\n\nGoogle obdrží informace o webech, pro které nastavíte časovače, a o tom, jak dlouho jste na nich byli. Tyto informace slouží ke zlepšování digitální rovnováhy.</translation>
-<translation id="6475951671322991020">Stáhnout video</translation>
-<translation id="6482749332252372425">Stažení souboru <ph name="FILE_NAME" /> se nezdařilo z důvodu nedostatku místa v úložišti.</translation>
-<translation id="6496823230996795692">Chcete-li poprvé použít aplikaci <ph name="APP_NAME" />, připojte se k internetu.</translation>
-<translation id="6508722015517270189">Restartujte Chrome</translation>
-<translation id="6527303717912515753">Sdílet</translation>
-<translation id="6532866250404780454">Weby navštívené v Chromu se nebudou zobrazovat. Všechny časovače webů budou smazány.</translation>
-<translation id="6534565668554028783">Odpověď Googlu trvala příliš dlouho</translation>
-<translation id="6538442820324228105">Staženo: <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Něco se pokazilo. Zkuste to později.</translation>
-<translation id="654446541061731451">Vyberte kartu, kterou chcete přenést</translation>
-<translation id="6545017243486555795">Vymazat všechna data</translation>
-<translation id="6545864417968258051">Vyhledávání Bluetooth</translation>
-<translation id="6560414384669816528">Vyhledávat pomocí Sogou</translation>
-<translation id="6566259936974865419">Chrome vám ušetřil <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Vždy povolit</translation>
-<translation id="6573431926118603307">Zde se objeví karty, které jste otevřeli v Chromu ve svých ostatních zařízeních.</translation>
-<translation id="6583199322650523874">Přidat aktuální stránku do záložek</translation>
-<translation id="6593061639179217415">Stránky pro počítač</translation>
-<translation id="6600954340915313787">Zkopírováno do Chromu</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Chráněný obsah</translation>
-<translation id="6627583120233659107">Upravit složku</translation>
-<translation id="6643016212128521049">Vymazat</translation>
-<translation id="6643649862576733715">Seřadit podle množství uspořených dat</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> další}few{<ph name="CONTACT_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> další}many{<ph name="CONTACT_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> dalšího}other{<ph name="CONTACT_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> dalších}}</translation>
-<translation id="6649642165559792194">Zobrazit náhled obrázku <ph name="BEGIN_NEW" />Nové<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">K vyhledání zařízení Chrome potřebuje přístup k informacím o poloze. <ph name="BEGIN_LINK" />Aktualizovat oprávnění<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Heslo</translation>
-<translation id="6659594942844771486">Karta</translation>
-<translation id="666731172850799929">Otevřít v aplikaci <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Ochrana soukromí v Chromu</translation>
-<translation id="6676840375528380067">Vymazat z tohoto zařízení data prohlížeče Chrome?</translation>
-<translation id="6697492270171225480">Zobrazovat návrhy podobných stránek, když stránku nelze najít</translation>
-<translation id="6697947395630195233">Chrome potřebuje přístup k vaší poloze, aby ji mohl sdílet s tímto webem.</translation>
-<translation id="6698801883190606802">Správa synchronizovaných dat</translation>
-<translation id="6699370405921460408">Servery Google budou navštěvované stránky optimalizovat.</translation>
-<translation id="6706288973712894588">Momentálně jste v režimu offline.\n<ph name="BEGIN_LINK" />Prozkoumejte svůj offline informační kanál.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Zprávy</translation>
-<translation id="6710213216561001401">Předchozí</translation>
-<translation id="671481426037969117">Časovač <ph name="FQDN" /> vypršel. Spustí se zase zítra.</translation>
-<translation id="6738867403308150051">Stahování…</translation>
-<translation id="6746124502594467657">Posunout dolů</translation>
-<translation id="6766622839693428701">Zavřete přejetím prstem dolů.</translation>
-<translation id="6766758767654711248">Klepnutím přejdete na web</translation>
-<translation id="6767294960381293877">Seznam zařízení, se kterými se má karta sdílet, otevřený na poloviční výšku.</translation>
-<translation id="6782111308708962316">Zabránit webům třetích stran v ukládání a čtení dat souborů cookie</translation>
-<translation id="6790428901817661496">Přehrát</translation>
-<translation id="6811034713472274749">Stránka je připravená k zobrazení</translation>
-<translation id="6818926723028410516">Výběr položek</translation>
-<translation id="6820686453637990663">Bezpečnostní kód platební karty (CVC)</translation>
-<translation id="6831043979455480757">Přeložit</translation>
-<translation id="6845325883481699275">Pomoci zlepšovat zabezpečení Chromu</translation>
-<translation id="6846298663435243399">Načítání…</translation>
-<translation id="6850409657436465440">Stahování stále probíhá</translation>
-<translation id="6850830437481525139">Zavřené karty: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Stáhnout obrázek</translation>
-<translation id="6865313869410766144">Automatické vyplňování formulářů</translation>
-<translation id="688738109438487280">Přidat existující data do účtu <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Chcete-li zkopírovat heslo, odemkněte zařízení</translation>
-<translation id="6896758677409633944">Kopírovat</translation>
-<translation id="6910211073230771657">Smazáno</translation>
-<translation id="6912998170423641340">Blokovat webům přístup k textu a obrázkům zkopírovaným do schránky</translation>
-<translation id="6914783257214138813">Vaše hesla uvidí každý, kdo může zobrazit exportovaný soubor.</translation>
-<translation id="6942665639005891494">Výchozí umístění pro stažené soubory můžete kdykoliv změnit pomocí možnosti v nabídce Nastavení.</translation>
-<translation id="6945221475159498467">Vybrat</translation>
-<translation id="6963642900430330478">Tato stránka je nebezpečná. Informace o webu</translation>
-<translation id="6963766334940102469">Smazat záložky</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Od počátku věků</translation>
-<translation id="6981982820502123353">Usnadnění</translation>
-<translation id="6989267951144302301">Stažení se nezdařilo</translation>
-<translation id="6990079615885386641">Získat aplikaci z Obchodu Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Pokud web bude chtít použít váš mikrofon, zobrazit dotaz (doporučeno)</translation>
-<translation id="7015203776128479407">Počáteční nastavení synchronizace nebylo dokončeno. Synchronizace je vypnutá.</translation>
-<translation id="7016516562562142042">Pro aktuální vyhledávač povoleno</translation>
-<translation id="7022756207310403729">Otevřít v prohlížeči</translation>
-<translation id="702463548815491781">Doporučeno, když je zapnuta funkce TalkBack nebo přístup pomocí přepínačů</translation>
-<translation id="7029809446516969842">Hesla</translation>
-<translation id="7053983685419859001">Blokovat</translation>
-<translation id="7055152154916055070">Bylo zablokováno přesměrování:</translation>
-<translation id="7063006564040364415">K synchronizačnímu serveru se nelze připojit.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Vybráno: 1}few{Vybráno: #}many{Vybráno: #}other{Vybráno: #}}</translation>
-<translation id="7071521146534760487">Spravovat účet</translation>
-<translation id="7077143737582773186">SD karta</translation>
-<translation id="7087918508125750058">Vybrané položky: <ph name="ITEM_COUNT" />. Možnosti jsou k dispozici u horního okraje obrazovky</translation>
-<translation id="7121362699166175603">Vymaže historii a automatická dokončení v adresním řádku. Na stránce <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Google.</translation>
-<translation id="7128222689758636196">Povolit pro aktuální vyhledávač</translation>
-<translation id="7138678301420049075">Ostatní</translation>
-<translation id="7141896414559753902">Bránit webům v zobrazování vyskakovacích oken a v přesměrování (doporučeno)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Načíst původní stránku<ph name="END_LINK" /> z domény <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Posledních 24 hodin</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Svoji volbu můžete později změnit v nabídce Nastavení</translation>
-<translation id="7180611975245234373">Obnovit</translation>
-<translation id="7189372733857464326">Počkejte prosím, než služby Google Play dokončí aktualizaci</translation>
-<translation id="7191430249889272776">Karta je otevřena na pozadí.</translation>
-<translation id="723171743924126238">Vyberte fotky</translation>
-<translation id="7233236755231902816">Chcete-li si web prohlížet ve svém jazyce, stáhněte si nejnovější verzi Chromu</translation>
-<translation id="7243308994586599757">Možnosti jsou k dispozici ve spodní části obrazovky</translation>
-<translation id="7248069434667874558">Zkontrolujte, zda je v Chromu na zařízení <ph name="TARGET_DEVICE_NAME" /> zapnutá synchronizace</translation>
-<translation id="7250468141469952378">Vybráno: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Blokovaný web</translation>
-<translation id="7290209999329137901">Přejmenování není k dispozici</translation>
-<translation id="7291387454912369099">Platba aktivovaná Asistentem</translation>
-<translation id="7293171162284876153">Chcete-li synchronizaci spustit, zapněte přepínač Synchronizovat data prohlížeče Chrome.</translation>
-<translation id="729975465115245577">V zařízení není žádná aplikace, pomocí které by soubor s hesly bylo možné uložit.</translation>
-<translation id="7302081693174882195">Podrobnosti: Seřazeno podle množství uspořených dat</translation>
-<translation id="7328017930301109123">Ve zjednodušeném režimu načítá Chrome stránky rychleji a používá až o 60 procent méně dat.</translation>
-<translation id="7333031090786104871">Předchozí web se stále přidává</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Sdílet 1 vybranou položku}few{Sdílet # vybrané položky}many{Sdílet # vybrané položky}other{Sdílet # vybraných položek}}</translation>
 <translation id="7359002509206457351">Poskytnout přístup k platební metodám</translation>
+<translation id="8026334261755873520">Vymazat údaje o prohlížení</translation>
+<translation id="1291207594882862231">Vymazat historii, soubory cookie, data webů, mezipaměť…</translation>
+<translation id="7814200940910057384">Vymazání údajů Chromu</translation>
+<translation id="1664855196866195614">Vybraná data byla z Chromu a synchronizovaných zařízení odstraněna.
+
+Na stránce <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Brave Software, například vyhledávací dotazy a aktivita z ostatních služeb Brave Software.</translation>
+<translation id="4699172675775169585">Obrázky a soubory v mezipaměti</translation>
+<translation id="2496180316473517155">Historie procházení</translation>
+<translation id="2546283357679194313">Soubory cookie a data webových stránek</translation>
+<translation id="8662811608048051533">Odhlásí vás z většiny webů.</translation>
+<translation id="8218628800671693884">Odhlásí vás z většiny webů. Z účtu Brave Software odhlášeni nebudete.</translation>
+<translation id="2017836877785168846">Vymaže historii a automatická dokončení v adresním řádku.</translation>
+<translation id="8096327394278038498">Vymaže historii a automatická dokončení v adresním řádku. Na stránce <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Brave Software.</translation>
+<translation id="8122693181154564064">Vymaže historii ze všech zařízení, na kterých jste přihlášeni. Na stránce <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Brave Software.</translation>
+<translation id="5869522115854928033">Uložená hesla</translation>
+<translation id="6865313869410766144">Automatické vyplňování formulářů</translation>
+<translation id="7562080006725997899">Mazání údajů o prohlížení</translation>
+<translation id="5487521232677179737">Vymazat data</translation>
+<translation id="7498271377022651285">Čekejte prosím…</translation>
+<translation id="784934925303690534">Časové období</translation>
+<translation id="1718835860248848330">Poslední hodina</translation>
+<translation id="7149893636342594995">Posledních 24 hodin</translation>
+<translation id="5648166631817621825">Posledních 7 dní</translation>
+<translation id="8571213806525832805">Poslední 4 týdny</translation>
+<translation id="5854790677617711513">Starší než 30 dnů</translation>
+<translation id="6979737339423435258">Od počátku věků</translation>
+<translation id="982182592107339124">Tímto vymažete data všech webů včetně těchto:</translation>
+<translation id="6643016212128521049">Vymazat</translation>
+<translation id="7641339528570811325">Vymazat údaje o prohlížení…</translation>
+<translation id="1670399744444387456">Základní</translation>
+<translation id="3245261285041759672">Na stránce <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Brave Software.</translation>
+<translation id="7274013316676448362">Blokovaný web</translation>
+<translation id="2534155362429831547">Byly smazány položky (celkem <ph name="NUMBER_OF_ITEMS"/>)</translation>
+<translation id="1121094540300013208">Zprávy o využití a selhání</translation>
+<translation id="9079153198295609735">Automaticky posílat společnosti Brave Software statistiky používání a zprávy o selhání</translation>
+<translation id="6981982820502123353">Usnadnění</translation>
+<translation id="2387895666653383613">Zvětšení/zmenšení textu</translation>
+<translation id="2321958826496381788">Přetahujte posuvník tak dlouho, dokud nebudete moci pohodlně přečíst tento text. Po dvojitém klepnutí na odstavec by měl být text alespoň takto velký.</translation>
+<translation id="3895926599014793903">Vynutit aktivaci přiblížení</translation>
+<translation id="5668404140385795438">Přepsat požadavek webu na zákaz přiblížení</translation>
+<translation id="4149994727733219643">Zjednodušené zobrazení webových stránek</translation>
+<translation id="9100505651305367705">Nabízet zjednodušené zobrazení článků (pokud je podporováno)</translation>
+<translation id="1409426117486808224">Zjednodušené zobrazení otevřených karet</translation>
+<translation id="702463548815491781">Doporučeno, když je zapnuta funkce TalkBack nebo přístup pomocí přepínačů</translation>
+<translation id="8284326494547611709">Titulky</translation>
+<translation id="4165986682804962316">Nastavení webu</translation>
+<translation id="6295158916970320988">Všechny weby</translation>
+<translation id="8380167699614421159">Tento web zobrazuje rušivé nebo zavádějící reklamy</translation>
+<translation id="1919345977826869612">Reklamy</translation>
+<translation id="410351446219883937">Automatické přehrávání</translation>
+<translation id="6447842834002726250">Soubory cookie</translation>
+<translation id="6196640612572343990">Blokovat soubory cookie třetích stran</translation>
+<translation id="6782111308708962316">Zabránit webům třetích stran v ukládání a čtení dat souborů cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Vyskakovací okna a přesměrování</translation>
+<translation id="4751476147751820511">Senzory pohybu nebo světla</translation>
+<translation id="1717218214683051432">Pohybová čidla</translation>
+<translation id="2091887806945687916">Zvuk</translation>
+<translation id="2586657967955657006">Schránka</translation>
+<translation id="6320088164292336938">Vibrovat</translation>
+<translation id="4226663524361240545">Oznámení mohou aktivovat vibraci</translation>
+<translation id="1446450296470737166">Povolit úplné ovládání zařízení MIDI</translation>
+<translation id="3744111561329211289">Synchronizace na pozadí</translation>
+<translation id="5649053991847567735">Automatické stahování</translation>
+<translation id="6181444274883918285">Přidat výjimku pro konkrétní web</translation>
+<translation id="5313967007315987356">Přidat web</translation>
+<translation id="1369915414381695676">Byl přidán web <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Povolit automatické přehrávání ztlumených videí na konkrétním webu.</translation>
+<translation id="2621115761605608342">Povolit JavaScript pro konkrétní web.</translation>
+<translation id="8801436777607969138">Blokovat JavaScript na konkrétním webu.</translation>
+<translation id="8372893542064058268">Povolit synchronizaci na pozadí konkrétnímu webu.</translation>
+<translation id="358794129225322306">Povolit webu automaticky stáhnout několik souborů.</translation>
+<translation id="4008040567710660924">Povolit soubory cookie pro konkrétní web.</translation>
+<translation id="8958424370300090006">Blokovat soubory cookie pro konkrétní web.</translation>
+<translation id="7882806643839505685">Zapne zvuk na konkrétním webu.</translation>
+<translation id="4468959413250150279">Vypne zvuk na konkrétním webu.</translation>
+<translation id="1994173015038366702">Adresa URL webu</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Použití</translation>
+<translation id="5804241973901381774">Oprávnění</translation>
+<translation id="4278390842282768270">Povoleno</translation>
+<translation id="5677928146339483299">Zablokováno</translation>
+<translation id="1984937141057606926">Povoleno, s výjimkou souborů cookie třetí strany</translation>
+<translation id="7423098979219808738">Nejprve se dotázat</translation>
+<translation id="8116925261070264013">Ztlumeno</translation>
+<translation id="8300705686683892304">Spravováno aplikací</translation>
+<translation id="6192792657125177640">Výjimky</translation>
+<translation id="257931822824936280">Rozbaleno – kliknutím sbalíte</translation>
+<translation id="5100237604440890931">Sbaleno – kliknutím rozbalíte</translation>
+<translation id="857943718398505171">Povoleno (doporučeno)</translation>
+<translation id="2913331724188855103">Povolit webům ukládat a číst data souborů cookie (doporučeno)</translation>
+<translation id="7445411102860286510">Povolit webům automaticky přehrávat ztlumená videa (doporučeno)</translation>
+<translation id="5335288049665977812">Povolit webům spouštět JavaScript (doporučeno)</translation>
+<translation id="5527111080432883924">Zeptat se, než bude webům povolen přístup k textu a obrázkům zkopírovaným do schránky (doporučeno)</translation>
+<translation id="6912998170423641340">Blokovat webům přístup k textu a obrázkům zkopírovaným do schránky</translation>
+<translation id="7423538860840206698">Čtení schránky je blokováno</translation>
+<translation id="3955193568934677022">Povolit webům přehrávat chráněný obsah (doporučeno)</translation>
+<translation id="445467742685312942">Povolit webům přehrávat chráněný obsah</translation>
+<translation id="2107397443965016585">Před povolením spuštění chráněného obsahu na webu se zeptat (doporučeno)</translation>
+<translation id="2910701580606108292">Před povolením spuštění chráněného obsahu na webu se zeptat</translation>
+<translation id="757524316907819857">Bránit webům v přehrávání chráněného obsahu</translation>
+<translation id="3277252321222022663">Povolit webům přístup k senzorům (doporučeno)</translation>
+<translation id="5048398596102334565">Povolit webům přístup k senzorům pohybu (doporučeno)</translation>
+<translation id="8816026460808729765">Blokovat webům přístup k senzorům</translation>
+<translation id="169515064810179024">Blokovat webům přístup k senzorům pohybu</translation>
+<translation id="1660204651932907780">Povolit webům přehrávat zvuky (doporučeno)</translation>
+<translation id="3600792891314830896">Ztlumit weby, které přehrávají zvuky</translation>
+<translation id="1743802530341753419">Pokud se web bude chtít připojit k zařízení, zobrazit dotaz (doporučeno)</translation>
+<translation id="851751545965956758">Bránit webům v připojení k zařízením</translation>
+<translation id="7141896414559753902">Bránit webům v zobrazování vyskakovacích oken a v přesměrování (doporučeno)</translation>
+<translation id="5494752089476963479">Blokovat reklamy na webech, které zobrazují obtěžující nebo zavádějící reklamy</translation>
+<translation id="3123473560110926937">Na některých webech blokováno</translation>
+<translation id="965817943346481315">Blokovat, pokud web zobrazuje rušivé nebo zavádějící reklamy (doporučeno)</translation>
+<translation id="3386292677130313581">Pokud web bude chtít znát vaši polohu, zobrazit dotaz (doporučeno)</translation>
+<translation id="9139068048179869749">Pokud web bude chtít odesílat oznámení, zobrazit dotaz (doporučeno)</translation>
+<translation id="4479647676395637221">Pokud web bude chtít použít vaši kameru, zobrazit dotaz (doporučeno)</translation>
+<translation id="6992289844737586249">Pokud web bude chtít použít váš mikrofon, zobrazit dotaz (doporučeno)</translation>
+<translation id="2289270750774289114">Zeptat se, když chce web objevit zařízení Bluetooth v okolí (doporučeno)</translation>
+<translation id="7053983685419859001">Blokovat</translation>
+<translation id="7128222689758636196">Povolit pro aktuální vyhledávač</translation>
+<translation id="7589445247086920869">Blokovat pro aktuální vyhledávač</translation>
+<translation id="6388207532828177975">Vymazat a resetovat</translation>
+<translation id="7999064672810608036">Opravdu chcete vymazat všechna místní data tohoto webu, včetně souborů cookie, a resetovat všechna jeho oprávnění?</translation>
+<translation id="2822354292072154809">Opravdu chcete resetovat všechna oprávnění webů pro objekt <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Vymazat uložená data</translation>
+<translation id="5902828464777634901">Všechna místní data uložená tímto webem, včetně souborů cookie, budou smazána.</translation>
+<translation id="119944043368869598">Vymazat vše</translation>
+<translation id="2490684707762498678">Spravováno aplikací <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Otevřít nastavení oznámení</translation>
+<translation id="1404122904123200417">Vloženo do <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Zde se budou zobrazovat soubory uložené webovými stránkami</translation>
+<translation id="4181841719683918333">Jazyky</translation>
+<translation id="2647434099613338025">Přidat jazyk</translation>
+<translation id="1952172573699511566">Pokud to bude možné, budou weby zobrazovat text ve vašem preferovaném jazyce.</translation>
+<translation id="8559990750235505898">Nabízet překlad stránek v jiných jazycích</translation>
+<translation id="4719927025381752090">Nabízet překlad</translation>
+<translation id="8156139159503939589">Jaké jazyky ovládáte?</translation>
+<translation id="5689516760719285838">Poloha</translation>
+<translation id="2440823041667407902">Přístup k poloze</translation>
+<translation id="2023546461831060654">Oprávnění pro Brave zapnete v <ph name="BEGIN_LINK"/>Nastavení pro Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Oprávnění pro Brave zapnete v <ph name="BEGIN_LINK"/>Nastavení pro Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Chcete-li Chromu povolit přístup k vaší poloze, zapněte ji také v <ph name="BEGIN_LINK"/>Nastavení Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Chcete-li Chromu umožnit přístup k fotoaparátu, zapněte fotoaparát také v <ph name="BEGIN_LINK"/>Nastavení Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Chcete-li Chromu umožnit zasílat vám oznámení, zapněte oznámení také v <ph name="BEGIN_LINK"/>Natavení Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Chcete-li Chromu umožnit přístup k mikrofonu, zapněte mikrofon také v <ph name="BEGIN_LINK"/>Nastavení Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Přístup k poloze je v tomto zařízení vypnut. Zapnete jej v <ph name="BEGIN_LINK"/>Nastavení Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Přístup k poloze je vypnut také v tomto zařízení. Zapnete jej v <ph name="BEGIN_LINK"/>Nastavení Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Přístup k fotoaparátu</translation>
+<translation id="945632385593298557">Přístup k mikrofonu</translation>
+<translation id="6612358246767739896">Chráněný obsah</translation>
+<translation id="885701979325669005">Úložiště</translation>
+<translation id="3198916472715691905">Uložená data: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Zrušit oprávnění zařízení</translation>
+<translation id="4962975101802056554">Zrušit všechna oprávnění pro zařízení</translation>
+<translation id="6545864417968258051">Vyhledávání Bluetooth</translation>
+<translation id="4411535500181276704">Zjednodušený režim</translation>
+<translation id="7821588508402923572">Zde se budou zobrazovat vaše úspory dat</translation>
+<translation id="2131665479022868825">Uspořeno: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">od <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Ve zjednodušeném režimu načítá Brave stránky rychleji a používá až o 60 procent méně dat.</translation>
+<translation id="6159335304067198720">Úspora dat: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">uspořená data</translation>
+<translation id="6111020039983847643">využitá data</translation>
+<translation id="7413229368719586778">Datum zahájení <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Datum ukončení: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Seřadit podle webu</translation>
+<translation id="5864174910718532887">Podrobnosti: Seřazeno podle názvu webu</translation>
+<translation id="116280672541001035">Využito</translation>
+<translation id="8349013245300336738">Seřadit podle množství využitých dat</translation>
+<translation id="6378173571450987352">Podrobnosti: Seřazeno podle množství využitých dat</translation>
+<translation id="2631006050119455616">Uloženo</translation>
+<translation id="6643649862576733715">Seřadit podle množství uspořených dat</translation>
+<translation id="7302081693174882195">Podrobnosti: Seřazeno podle množství uspořených dat</translation>
+<translation id="4179980317383591987">Využito: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Uspořeno: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Zbývající weby (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Ostatní</translation>
+<translation id="4913161338056004800">Obnovit statistiky</translation>
+<translation id="1856325424225101786">Resetovat zjednodušený režim?</translation>
+<translation id="3658159451045945436">Resetováním vymažete historii úspory dat, včetně seznamu navštívených webů.</translation>
+<translation id="3295530008794733555">Prohlížejte si internet rychleji. Využívejte méně dat.</translation>
+<translation id="7340390500800578919">Ve zjednodušeném režimu načítá Brave stránky rychleji a používá až o 60 procent méně dat. Kvůli optimalizaci navštěvovaných stránek přijímá Brave váš webový provoz přes Brave Software. <ph name="BEGIN_LINK"/>Další informace<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Zapnout zjednodušený režim</translation>
+<translation id="4493497663118223949">Zjednodušený režim je zapnutý</translation>
+<translation id="7559975015014302720">Zjednodušený režim je vypnutý</translation>
+<translation id="7606077192958116810">Zjednodušený režim je zapnutý. Spravovat ho můžete v Nastavení.</translation>
+<translation id="4714588616299687897">Uspořte až 60 % svých dat</translation>
+<translation id="1006927014032731288">Servery Brave Software budou navštěvované stránky optimalizovat.</translation>
+<translation id="3257320067425202300">Brave vám ušetřil <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave vám ušetřil <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Umístění stažených souborů</translation>
+<translation id="7077143737582773186">SD karta</translation>
+<translation id="7762668264895820836">SD karta <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Zeptat se, kam se soubory mají uložit</translation>
+<translation id="6192333916571137726">Stáhnout soubor</translation>
+<translation id="1672586136351118594">Tuto zprávu již nezobrazovat</translation>
+<translation id="2650751991977523696">Stáhnout soubor znovu?</translation>
+<translation id="8664979001105139458">Název souboru již existuje</translation>
+<translation id="488187801263602086">Přejmenovat soubor</translation>
+<translation id="5686790454216892815">Název souboru je příliš dlouhý</translation>
+<translation id="7454641608352164238">Nedostatek místa</translation>
+<translation id="8972098258593396643">Stáhnout do výchozí složky?</translation>
+<translation id="804335162455518893">SD karta nenalezena</translation>
+<translation id="7475688122056506577">SD karta nebyla nalezena. Některé vaše soubory mohou chybět.</translation>
+<translation id="4198423547019359126">Nejsou k dispozici žádná umístění stažených souborů</translation>
+<translation id="8224471946457685718">Stahovat články pro vás přes Wi-Fi</translation>
+<translation id="4970824347203572753">Ve vaší lokalitě není k dispozici</translation>
+<translation id="5500777121964041360">Ve vaší lokalitě nemusí být k dispozici</translation>
+<translation id="1173894706177603556">Přejmenovat</translation>
+<translation id="1986685561493779662">Název již existuje</translation>
+<translation id="6441734959916820584">Název je příliš dlouhý</translation>
+<translation id="2923908459366352541">Název je neplatný</translation>
+<translation id="7290209999329137901">Přejmenování není k dispozici</translation>
+<translation id="3334729583274622784">Změnit příponu souboru?</translation>
+<translation id="107147699690128016">Pokud změníte příponu souboru, může se soubor otevřít v jiné aplikaci a potenciálně může být rizikem pro vaše zařízení.</translation>
+<translation id="8541922081612557424">O aplikaci Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Všechna práva vyhrazena.</translation>
+<translation id="1416550906796893042">Verze aplikace</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (aktualizováno <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operační systém</translation>
+<translation id="3968054912784331254">V této verzi platformy Android již aktualizace prohlížeče Brave nejsou podporovány</translation>
+<translation id="7665369617277396874">Přidat účet</translation>
+<translation id="649070405679044769">Jste přihlášeni do Googlu jako</translation>
+<translation id="6234515504547364178">Odhlášení z Chromu</translation>
+<translation id="5324858694974489420">Rodičovská nastavení</translation>
+<translation id="8920114477895755567">Čekáme na podrobnosti o rodičích.</translation>
+<translation id="5512137114520586844">Tento účet je spravován uživatelem <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Tento účet spravují uživatelé <ph name="PARENT_NAME_1"/> a <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Obsah</translation>
+<translation id="5403644198645076998">Povolit pouze určité weby</translation>
+<translation id="8641930654639604085">Pokusit se blokovat weby pouze pro dospělé</translation>
+<translation id="5639724618331995626">Povolit všechny weby</translation>
+<translation id="796823723482603597">Používá technologii Brave</translation>
+<translation id="6324034347079777476">Synchronizace systému Android je vypnuta.</translation>
+<translation id="5127805178023152808">Synchronizace je vypnuta</translation>
+<translation id="7015203776128479407">Počáteční nastavení synchronizace nebylo dokončeno. Synchronizace je vypnutá.</translation>
+<translation id="2497852260688568942">Synchronizace je administrátorem zakázána.</translation>
+<translation id="9100610230175265781">Je vyžadována heslová fráze</translation>
+<translation id="6108923351542677676">Probíhá nastavování…</translation>
+<translation id="4062305924942672200">Právní informace</translation>
+<translation id="4256782883801055595">Licence open source</translation>
+<translation id="1138681184697033370">Smluvní podmínky Brave</translation>
+<translation id="7392539049993970338">Ochrana soukromí v Chromu</translation>
+<translation id="2677748264148917807">Odejít</translation>
+<translation id="5556459405103347317">Načíst znovu</translation>
+<translation id="1623104350909869708">Bránit této stránce ve vytváření dalších dialogových oken</translation>
+<translation id="2968755619301702150">Prohlížeč certifikátů</translation>
+<translation id="1360432990279830238">Odhlásit se a vypnout synchronizaci?</translation>
+<translation id="8581481290581777242">Vymazat z tohoto zařízení data prohlížeče Brave?</translation>
+<translation id="1318865768845061710">Vaše záložky, historie, hesla a další data v Chromu se již nebudou synchronizovat do vašeho účtu Brave Software</translation>
+<translation id="3325020657155065477">Vymazat data prohlížeče Brave také z tohoto zařízení</translation>
+<translation id="6136448902816743006">Protože se odhlašujete z účtu spravovaného doménou <ph name="DOMAIN_NAME"/>, vaše data prohlížeče Brave z tohoto zařízení budou smazána. Ve vašem účtu Brave Software zůstanou.</translation>
+<translation id="1853026300647876496">Kontaktování Googlu. Může to chvíli trvat…</translation>
+<translation id="2328985652426384049">Přihlášení se nezdařilo</translation>
+<translation id="7723158744459952869">Odpověď Googlu trvala příliš dlouho</translation>
+<translation id="4572422548854449519">Přihlaste se ke spravovanému účtu</translation>
+<translation id="2689656545739939160">Přihlašujete se pomocí účtu spravovaného doménou <ph name="MANAGED_DOMAIN"/> a poskytujete jeho správci kontrolu nad svými daty prohlížeče Brave. Vaše data budou trvale přidružena k tomuto účtu. Odhlášením z Chromu svá data smažete z tohoto zařízení, ve vašem účtu Brave Software však uložena zůstanou.</translation>
+<translation id="1749561566933687563">Synchronizace záložek</translation>
+<translation id="4242533952199664413">Otevřít Nastavení</translation>
+<translation id="1111673857033749125">Zde se objeví záložky, které jste si uložili v ostatních zařízeních.</translation>
+<translation id="8636825310635137004">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte synchronizaci.</translation>
+<translation id="3269956123044984603">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte v nastavení účtu Android možnost Automatická synchronizace dat.</translation>
+<translation id="5157964048453367290">Zde se objeví karty, které jste otevřeli v Chromu ve svých ostatních zařízeních.</translation>
+<translation id="4684427112815847243">Synchronizovat vše</translation>
+<translation id="2709516037105925701">Automatické vyplňování</translation>
+<translation id="8820817407110198400">Záložky</translation>
+<translation id="1644574205037202324">Historie</translation>
+<translation id="17513872634828108">Otevřené karty</translation>
+<translation id="1320169905922104972">Platební karty a adresy pomocí služby Brave Software Pay</translation>
+<translation id="6337234675334993532">Šifrování</translation>
+<translation id="6698801883190606802">Správa synchronizovaných dat</translation>
+<translation id="3598578758776312506">Šifrovat hesla pomocí identifikačních údajů Brave Software</translation>
+<translation id="7810580217418711046">Zašifrovat synchronizovaná data pomocí hesla Brave Software z <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Šifrovat synchronizovaná data pomocí vlastní heslové fráze pro synchronizaci</translation>
+<translation id="2996291259634659425">Vytvoření heslové fráze</translation>
+<translation id="5713644099811900409">Účet Brave Software</translation>
+<translation id="8997474919031554666">Šifrování pomocí heslové fráze se nevztahuje na platební metody a adresy ze služby Brave Software Pay. Vaše šifrovaná data mohou číst pouze uživatelé, kteří mají vaši heslovou frázi. Heslová fráze se neodesílá do Googlu a není na Googlu uložena. Pokud ji zapomenete nebo toto nastavení budete chtít změnit, bude nutné synchronizaci resetovat. <ph name="BEGIN_LINK"/>Další informace<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Heslová fráze</translation>
+<translation id="7772032839648071052">Potvrďte heslovou frázi</translation>
+<translation id="5304593522240415983">Toto pole nesmí být prázdné</translation>
+<translation id="321773570071367578">Pokud jste heslovou frázi zapomněli nebo toto nastavení chcete změnit, <ph name="BEGIN_LINK"/>resetujte synchronizaci<ph name="END_LINK"/>.</translation>
+<translation id="3029704984691124060">Heslové fráze se neshodují</translation>
+<translation id="5149495116300586333">Šifrování pomocí heslové fráze se nevztahuje na platební metody a adresy ze služby Brave Software Pay.
+
+Chcete-toto nastavení změnit, <ph name="BEGIN_LINK"/>resetujte synchronizaci<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">Nesprávná heslová fráze</translation>
+<translation id="5414836363063783498">Ověřování…</translation>
+<translation id="6846298663435243399">Načítání…</translation>
+<translation id="5517095782334947753">Máte záložky, historii, hesla a další nastavení z účtu <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Sloučit má data</translation>
+<translation id="688738109438487280">Přidat existující data do účtu <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Uchovat má data samostatně.</translation>
+<translation id="1145536944570833626">Smazat existující data.</translation>
+<translation id="1993768208584545658">Web <ph name="SITE"/> žádá o spárování</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Nápověda<ph name="END_LINK"/> k vyhledávání zařízení…</translation>
+<translation id="5817918615728894473">Spárovat</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Prohlédněte si nápovědu<ph name="END_LINK1"/> nebo zařízení <ph name="BEGIN_LINK2"/>vyhledejte znovu<ph name="END_LINK2"/>.</translation>
+<translation id="230115972905494466">Nebyla nalezena žádná kompatibilní zařízení</translation>
+<translation id="3773755127849930740">Chcete-li povolit párování, <ph name="BEGIN_LINK"/>zapněte Bluetooth<ph name="END_LINK"/>.</translation>
+<translation id="998321811308652668">Brave nemůže zapnout adaptér Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Zobrazit nápovědu<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">K vyhledání zařízení Brave potřebuje přístup k informacím o poloze. <ph name="BEGIN_LINK"/>Aktualizovat oprávnění<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">K vyhledání zařízení potřebuje Brave přístup k informacím o poloze. Přístup k poloze je v tomto zařízení <ph name="BEGIN_LINK"/>vypnut<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">K vyhledání zařízení potřebuje Brave přístup k informacím o poloze. <ph name="BEGIN_LINK1"/>Aktualizujte oprávnění<ph name="END_LINK1"/>. V tomto zařízení je také <ph name="BEGIN_LINK2"/>vypnut přístup k poloze<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Připojené zařízení</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Síla signálu: # čárka}few{Síla signálu: # čárky}many{Síla signálu: # čárky}other{Síla signálu: # čárek}}</translation>
+<translation id="5230560987958996918">Web <ph name="SITE"/> chce vyhledat zařízení Bluetooth v okolí. Byla nalezena následující zařízení:</translation>
+<translation id="8368027906805972958">Neznámé nebo nepodporované zařízení (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synchronizace nefunguje</translation>
+<translation id="1810845389119482123">Počáteční nastavení synchronizace nebylo dokončeno</translation>
+<translation id="3235722914093408050">Chcete-li spustit synchronizaci Chromu, povolte synchronizaci systému Android.</translation>
+<translation id="3367813778245106622">Chcete-li zahájit synchronizaci, znovu se přihlaste.</translation>
+<translation id="974555521953189084">Chcete-li spustit synchronizaci zadejte heslovou frázi.</translation>
+<translation id="2997266899014181325">Chcete-li synchronizaci spustit, zapněte přepínač Synchronizovat data prohlížeče Brave.</translation>
+<translation id="8260126382462817229">Zkuste se přihlásit znovu.</translation>
+<translation id="5919204609460789179">Chcete-li zahájit synchronizaci, aktualizujte aplikaci <ph name="PRODUCT_NAME"/></translation>
+<translation id="397583555483684758">Synchronizace přestala fungovat</translation>
+<translation id="1966710179511230534">Aktualizujte prosím své přihlašovací údaje.</translation>
+<translation id="7063006564040364415">K synchronizačnímu serveru se nelze připojit.</translation>
+<translation id="7942131818088350342">Aplikace <ph name="PRODUCT_NAME"/> je zastaralá.</translation>
+<translation id="4170011742729630528">Služba není k dispozici, zkuste to později.</translation>
+<translation id="7947953824732555851">Přijmout a přihlásit</translation>
+<translation id="8583805026567836021">Mazání dat účtu</translation>
+<translation id="8310344678080805313">Standardní karty</translation>
+<translation id="5748802427693696783">Přepnuto na standardní karty</translation>
+<translation id="7998918019931843664">Znovu otevřít zavřenou kartu</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, karta</translation>
+<translation id="4452411734226507615">Zavřít kartu <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Možnosti jsou k dispozici ve spodní části obrazovky</translation>
+<translation id="4060598801229743805">Možnosti jsou k dispozici u horního okraje obrazovky</translation>
+<translation id="2810645512293415242">Stránka byla zjednodušena s cílem ušetřit data a zrychlit načtení.</translation>
+<translation id="3985215325736559418">Opravdu soubor <ph name="FILE_NAME"/> chcete stáhnout znovu?</translation>
+<translation id="2450083983707403292">Chcete soubor <ph name="FILE_NAME"/> začít stahovat znovu?</translation>
+<translation id="7514365320538308">Stáhnout</translation>
+<translation id="545042621069398927">Zrychlování stahování.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Stahování souboru.}few{Stahování # souborů.}many{Stahování # souboru.}other{Stahování # souborů.}}</translation>
+<translation id="543509235395288790">Stahování <ph name="COUNT"/> souborů (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Stahování souboru (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Stažení 1 souboru bylo dokončeno.}few{Stažení # souborů bylo dokončeno.}many{Stažení # souboru bylo dokončeno.}other{Stažení # souborů bylo dokončeno.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Stažení 1 souboru se nezdařilo.}few{Stažení # souborů se nezdařilo.}many{Stažení # souboru se nezdařilo.}other{Stažení # souborů se nezdařilo.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 nevyřízené stahování.}few{# nevyřízená stahování.}many{# nevyřízeného stahování.}other{# nevyřízených stahování.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> tlačítko <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Skoro hotovo.</translation>
+<translation id="3960299545138990065">Restartujte Brave</translation>
+<translation id="3771001275138982843">Aktualizaci nelze stáhnout</translation>
+<translation id="3888648114124182147">Stahování aktualizace Chromu…</translation>
+<translation id="1705567146636171298">Aktualizovat Brave</translation>
+<translation id="6195417478702700398">Chcete-li mít při procházení nejlepší prostředí a funkce, aktualizujte Brave</translation>
+<translation id="3512968675351418494">Chcete-li si web prohlížet ve svém jazyce, stáhněte si nejnovější verzi Chromu</translation>
+<translation id="6427112570124116297">Přeložte si web</translation>
+<translation id="1379423114029199501">Chcete-li si obsah prohlížet ve svém jazyce, aktualizujte na nejnovější verzi Chromu</translation>
+<translation id="5684874026226664614">Jejda. Tuto stránku se nepodařilo přeložit.</translation>
+<translation id="6831043979455480757">Přeložit</translation>
+<translation id="1285320974508926690">Tento web nikdy nepřekládat</translation>
+<translation id="773466115871691567">Stránky v jazyce <ph name="SOURCE_LANGUAGE"/> vždy překládat</translation>
+<translation id="1068672505746868501">Stránky v jazyce <ph name="SOURCE_LANGUAGE"/> nikdy nepřekládat</translation>
+<translation id="124116460088058876">Další jazyky</translation>
+<translation id="290376772003165898">Stránka není v jazyce <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Stránky v jazyce <ph name="SOURCE_LANGUAGE"/> od teď budou překládány do jazyka <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Stránky v jazyce <ph name="LANGUAGE"/> nebudou překládány</translation>
+<translation id="5447765697759493033">Tento web nebude přeložen</translation>
+<translation id="4880127995492972015">Přeložit…</translation>
+<translation id="641643625718530986">Tisk…</translation>
+<translation id="8909135823018751308">Sdílet…</translation>
+<translation id="4996978546172906250">Sdílet prostřednictvím</translation>
+<translation id="6333140779060797560">Sdílet prostřednictvím aplikace <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Při tištění stránky došlo k problému. Zkuste to prosím znovu.</translation>
+<translation id="3254409185687681395">Přidat stránku do záložek</translation>
+<translation id="497421865427891073">Vpřed</translation>
+<translation id="813082847718468539">Zobrazit informace o stránkách</translation>
+<translation id="2532336938189706096">Webové zobrazení</translation>
+<translation id="6005538289190791541">Navrhované heslo</translation>
+<translation id="4634124774493850572">Použít heslo</translation>
+<translation id="8285489906452138776">Brave pro tento web potřebuje oprávnění k přístupu k fotoaparátu.</translation>
+<translation id="320189792589364011">Brave pro tento web potřebuje oprávnění k přístupu k mikrofonu.</translation>
+<translation id="7988136689212463100">Brave pro tento web potřebuje oprávnění k přístupu k fotoaparátu a mikrofonu.</translation>
+<translation id="4931190655840828017">Brave potřebuje přístup k vaší poloze, aby ji mohl sdílet s tímto webem.</translation>
+<translation id="3088191967551450609">Aby bylo možné stahovat soubory, Brave potřebuje přístup k úložišti.</translation>
+<translation id="8942627711005830162">Otevřít v jiném okně</translation>
+<translation id="4195643157523330669">Otevřít na nové kartě</translation>
+<translation id="1100066534610197918">Otevřít na nové kartě ve skup.</translation>
+<translation id="4860895144060829044">Volat</translation>
+<translation id="6896758677409633944">Kopírovat</translation>
+<translation id="8393700583063109961">Odeslat zprávu</translation>
+<translation id="3557336313807607643">Přidat do kontaktů</translation>
+<translation id="4269820728363426813">Zkopírovat adresu odkazu</translation>
+<translation id="1206892813135768548">Zkopírovat text odkazu</translation>
+<translation id="1204037785786432551">Stáhnout odkaz</translation>
+<translation id="6864459304226931083">Stáhnout obrázek</translation>
+<translation id="8209050860603202033">Otevřít obrázek</translation>
+<translation id="8073388330009372546">Otevřít na nové kartě</translation>
+<translation id="6649642165559792194">Zobrazit náhled obrázku <ph name="BEGIN_NEW"/>Nové<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Načíst obrázek</translation>
+<translation id="3845332215609790146">Hledat pomocí Brave Software Lens <ph name="BEGIN_NEW"/>Nové<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Hledat obrázek pomocí <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Sdílet obrázek</translation>
+<translation id="5833984609253377421">Sdílet odkaz</translation>
+<translation id="6475951671322991020">Stáhnout video</translation>
+<translation id="2317945146070194624">Otevřít na nové kartě v Chromu</translation>
+<translation id="7975379999046275268">Zobrazit náhled stránky <ph name="BEGIN_NEW"/>Nové<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Obnovování stránky</translation>
+<translation id="36525718899759834">Získat aplikaci z Obchodu Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tmavé</translation>
+<translation id="1807246157184219062">Světlé</translation>
+<translation id="4056223980640387499">Sépie</translation>
+<translation id="3927692899758076493">Bezpatková</translation>
+<translation id="5016205925109358554">Patková</translation>
+<translation id="2593272815202181319">Neproporcionální</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Vyberte kartu, kterou chcete přenést</translation>
+<translation id="8719023831149562936">Aktuální kartu nelze přenést</translation>
+<translation id="2139186145475833000">Přidat na plochu</translation>
+<translation id="4616150815774728855">Do aplikace <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Aplikaci nelze otevřít</translation>
+<translation id="5129038482087801250">Instalovat webovou aplikaci</translation>
+<translation id="3789841737615482174">Instalovat</translation>
+<translation id="4665282149850138822">Na plochu byl přidán web <ph name="NAME"/></translation>
+<translation id="7333031090786104871">Předchozí web se stále přidává</translation>
+<translation id="1036727731225946849">Přidávání aplikace <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Přidáno na domovskou obrazovku</translation>
+<translation id="2146738493024040262">Otevřít okamžitou aplikaci</translation>
+<translation id="7016516562562142042">Pro aktuální vyhledávač povoleno</translation>
+<translation id="6177111841848151710">Pro aktuální vyhledávač blokováno</translation>
+<translation id="145097072038377568">Vypnuto v Nastavení pro Android</translation>
+<translation id="8007176423574883786">Vypnuto v tomto zařízení</translation>
+<translation id="164269334534774161">Prohlížíte si offline kopii této stránky z <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Tato offline stránka je z <ph name="CREATION_TIME"/> a může se od online verze lišit.</translation>
+<translation id="8840953339110955557">Tato stránka se může od online verze lišit.</translation>
+<translation id="6405300764336705484">Tento obsah pochází z domény <ph name="DOMAIN_NAME"/>. Poskytováno společností Brave Software.</translation>
+<translation id="1006017844123154345">Otevřít online</translation>
+<translation id="3326636747541519688">Zjednodušenou stránku poskytuje Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Načíst původní stránku<ph name="END_LINK"/> z domény <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Pokud se vám tato stránka zobrazuje často, vyzkoušejte tyto <ph name="BEGIN_LINK"/>návrhy<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Skrytý obsah</translation>
+<translation id="3810973564298564668">Spravovat</translation>
+<translation id="5199929503336119739">Pracovní profil</translation>
+<translation id="528192093759286357">Režim celé obrazovky ukončíte přetažením z horního okraje obrazovky a klepnutím na tlačítko Zpět.</translation>
+<translation id="2836148919159985482">Režim celé obrazovky ukončíte klepnutím na tlačítko Zpět.</translation>
+<translation id="3967822245660637423">Stahování bylo dokončeno</translation>
+<translation id="2434158240863470628">Stažení bylo dokončeno <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Stažení se nezdařilo</translation>
+<translation id="1384959399684842514">Stahování pozastaveno</translation>
+<translation id="1671236975893690980">Nevyřízené stahování…</translation>
+<translation id="5561549206367097665">Čekání na síť…</translation>
+<translation id="5864419784173784555">Čekání na další stahování…</translation>
+<translation id="6461962085415701688">Soubor nelze otevřít</translation>
+<translation id="1178581264944972037">Pozastavit</translation>
+<translation id="8200772114523450471">Pokračovat</translation>
+<translation id="1409879593029778104">Stažení souboru <ph name="FILE_NAME"/> bylo zabráněno, protože soubor již existuje.</translation>
+<translation id="3387650086002190359">Stažení souboru <ph name="FILE_NAME"/> se nezdařilo z důvodu chyb systému souborů.</translation>
+<translation id="6482749332252372425">Stažení souboru <ph name="FILE_NAME"/> se nezdařilo z důvodu nedostatku místa v úložišti.</translation>
+<translation id="7619072057915878432">Stahování souboru <ph name="FILE_NAME"/> se nezdařilo z důvodu selhání sítě.</translation>
+<translation id="1477626028522505441">Stažení souboru <ph name="FILE_NAME"/> se nezdařilo z důvodu problémů se serverem.</translation>
+<translation id="3692944402865947621">Stažení souboru <ph name="FILE_NAME"/> se nezdařilo, protože umístění úložiště není dostupné.</translation>
+<translation id="604996488070107836">Stažení souboru <ph name="FILE_NAME"/> se nezdařilo z důvodu neznámé chyby.</translation>
+<translation id="6738867403308150051">Stahování…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Staženo: <ph name="KBS"/> kB</translation>
+<translation id="6416782512398055893">Staženo: <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Staženo: <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Zbývá 1 soubor</translation>
+<translation id="8186512483418048923">Zbývající soubory: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Byl stažen <ph name="FILES_DOWNLOADED_ONE"/> soubor}few{Byly staženy <ph name="FILES_DOWNLOADED_MANY"/> soubory}many{Bylo staženo <ph name="FILES_DOWNLOADED_MANY"/> souboru}other{Bylo staženo <ph name="FILES_DOWNLOADED_MANY"/> souborů}}</translation>
+<translation id="8037750541064988519">Zbývá: <ph name="DAYS"/> d</translation>
+<translation id="8190358571722158785">Zbývá: 1 d</translation>
+<translation id="60923314841986378">Zbývá: <ph name="HOURS"/> h</translation>
+<translation id="510275257476243843">Zbývá: 1 h</translation>
+<translation id="970715775301869095">Zbývá: <ph name="MINUTES"/> min</translation>
+<translation id="3236059992281584593">Zbývá: 1 min</translation>
+<translation id="2777555524387840389">Zbývá: <ph name="SECONDS"/> s</translation>
+<translation id="2781151931089541271">Zbývá: 1 s</translation>
+<translation id="3303414029551471755">Chcete pokračovat ke stažení obsahu?</translation>
+<translation id="8617240290563765734">Otevřít navrhovanou adresu URL uvedenou ve staženém obsahu?</translation>
+<translation id="1373696734384179344">Ke stažení vybraného obsahu není k dispozici dostatek paměti.</translation>
+<translation id="5271967389191913893">Zařízení obsah ke stažení nemůže otevřít.</translation>
+<translation id="883806473910249246">Při stahování obsahu došlo k chybě.</translation>
+<translation id="5626134646977739690">Jméno:</translation>
+<translation id="7963646190083259054">Dodavatel:</translation>
+<translation id="3414952576877147120">Velikost:</translation>
+<translation id="7375125077091615385">Typ:</translation>
+<translation id="5765780083710877561">Popis:</translation>
+<translation id="4881695831933465202">Otevřít</translation>
+<translation id="3542235761944717775">Dostupné místo: <ph name="KILOBYTES"/> kB</translation>
+<translation id="8051695050440594747">K dispozici: <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268">K dispozici: <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Je využito <ph name="SPACE_USED"/> z <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Vše</translation>
+<translation id="4988526792673242964">Stránky</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Zvuk</translation>
+<translation id="9219103736887031265">Obrázky</translation>
+<translation id="8250920743982581267">Dokumenty</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# soubor}few{# soubory}many{# souboru}other{# souborů}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# obrázek}few{# obrázky}many{# obrázku}other{# obrázků}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}few{# videa}many{# videa}other{# videí}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# zvukový soubor}few{# zvukové soubory}many{# zvukového souboru}other{# zvukových souborů}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stránka}few{# stránky}many{# stránky}other{# stránek}}</translation>
+<translation id="5456381639095306749">Stáhnout stránku</translation>
+<translation id="2394602618534698961">Zde se zobrazují stažené soubory</translation>
+<translation id="7810647596859435254">Otevřít v aplikaci…</translation>
+<translation id="5655963694829536461">Hledat ve stažených souborech</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Moje soubory</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Zde se zobrazují články, které si můžete číst i offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}few{# h}many{# h}other{# h}}</translation>
+<translation id="5853623416121554550">pozastaveno</translation>
+<translation id="8965591936373831584">nevyřízeno</translation>
+<translation id="2779651927720337254">nezdařilo se</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Právě teď</translation>
+<translation id="4000212216660919741">Offline domovská stránka</translation>
+<translation id="9133397713400217035">Prozkoumat offline</translation>
+<translation id="968900484120156207">Zde se zobrazují navštívené stránky</translation>
+<translation id="7882131421121961860">Nebyla nalezena žádná historie</translation>
+<translation id="3549657413697417275">Prohledávat historii</translation>
+<translation id="6820686453637990663">Bezpečnostní kód platební karty (CVC)</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">RR</translation>
+<translation id="724102042129299115">První spuštění Chromu</translation>
+<translation id="2700285883409956633">Používáním této aplikace vyjadřujete souhlas se <ph name="BEGIN_LINK1"/>smluvními podmínkami<ph name="END_LINK1"/> a <ph name="BEGIN_LINK2"/>zásadami ochrany soukromí<ph name="END_LINK2"/> prohlížeče Brave.</translation>
+<translation id="1640714894372474981">Používáním této aplikace vyjadřujete souhlas se <ph name="BEGIN_LINK1"/>smluvními podmínkami<ph name="END_LINK1"/> a <ph name="BEGIN_LINK2"/>upozorněním ve věci ochrany soukromí<ph name="END_LINK2"/> prohlížeče Brave a <ph name="BEGIN_LINK3"/>upozorněním ve věci ochrany soukromí pro účty Brave Software spravované prostřednictvím služby Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Aplikace <ph name="APP_NAME"/> se otevře v Chromu. Pokračováním vyjadřujete souhlas se <ph name="BEGIN_LINK1"/>smluvními podmínkami<ph name="END_LINK1"/> a <ph name="BEGIN_LINK2"/>upozorněním ve věci ochrany soukromí<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659">Aplikace <ph name="APP_NAME"/> se otevře v Chromu. Pokračováním vyjadřujete souhlas se <ph name="BEGIN_LINK1"/>smluvními podmínkami<ph name="END_LINK1"/> a <ph name="BEGIN_LINK2"/>upozorněním ve věci ochrany soukromí<ph name="END_LINK2"/> prohlížeče Brave a <ph name="BEGIN_LINK3"/>upozorněním ve věci ochrany soukromí pro účty Brave Software spravované prostřednictvím služby Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Pomozte Brave zlepšovat – posílejte Googlu statistiky o využívání a zprávy o selhání.</translation>
+<translation id="3518985090088779359">PŘIJMOUT A POKRAČOVAT</translation>
+<translation id="7207456302801184289">Vítá vás Brave</translation>
+<translation id="704822250101715322">Počkejte prosím, než služby Brave Software Play dokončí aktualizaci</translation>
+<translation id="1231733316453485619">Zapnout synchronizaci?</translation>
+<translation id="5132942445612118989">Vaše hesla, historie a další údaje na všech zařízeních</translation>
+<translation id="5736731321935944068">Brave Software vaši historii může používat k personalizaci Vyhledávání, reklam a dalších služeb Brave Software</translation>
+<translation id="4013614219085422040">Brave Software vaši historii může používat k personalizaci Vyhledávání a dalších služeb Brave Software</translation>
+<translation id="5581519193887989363">Synchronizované položky můžete kdykoliv vybrat v <ph name="BEGIN_LINK1"/>nastavení<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Ano</translation>
+<translation id="2410754283952462441">Vyberte účet</translation>
+<translation id="2227444325776770048">Pokračovat jako uživatel <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Nejste <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Chcete-li mít záložky ve všech zařízeních, zapněte synchronizaci</translation>
+<translation id="2818669890320396765">Chcete-li mít záložky ve všech zařízeních, přihlaste se a zapněte synchronizaci</translation>
+<translation id="6003646045106347985">Chcete-li od Googlu získat personalizované návrhy obsahu, zapněte synchronizaci</translation>
+<translation id="8494430740943879273">Chcete-li od Googlu získat personalizované návrhy obsahu, zapněte synchronizaci</translation>
+<translation id="5862731021271217234">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte synchronizaci</translation>
+<translation id="3568688522516854065">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte synchronizaci</translation>
+<translation id="1208340532756947324">Chcete-li synchronizovat a přizpůsobit různá zařízení, zapněte synchronizaci</translation>
+<translation id="4472118726404937099">Chcete-li synchronizovat a přizpůsobit různá zařízení, přihlaste se a zapněte synchronizaci</translation>
+<translation id="2426805022920575512">Vybrat jiný účet</translation>
+<translation id="6790428901817661496">Přehrát</translation>
+<translation id="1272079795634619415">Zastavit</translation>
+<translation id="2874939134665556319">Předchozí skladba</translation>
+<translation id="4046123991198612571">Další skladba</translation>
+<translation id="3859306556332390985">Přetočit dopředu</translation>
+<translation id="8441146129660941386">Přetočit dozadu</translation>
+<translation id="6706288973712894588">Momentálně jste v režimu offline.\n<ph name="BEGIN_LINK"/>Prozkoumejte svůj offline informační kanál.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Nedávno použité karty</translation>
+<translation id="8497726226069778601">Zatím tu nic není...</translation>
+<translation id="5423934151118863508">Zde se zobrazí vaše nejnavštěvovanější stránky.</translation>
+<translation id="6127379762771434464">Položka byla odstraněna</translation>
+<translation id="4605958867780575332">Tato položka byla odstraněna: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Sváteční logo Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Jiná zařízení</translation>
+<translation id="4738836084190194332">Poslední synchronizace: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{před # minutou}few{před # minutami}many{před # minuty}other{před # minutami}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{před # hodinou}few{před # hodinami}many{před # hodiny}other{před # hodinami}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{před # dnem}few{před # dny}many{před # dne}other{před # dny}}</translation>
+<translation id="2762000892062317888">právě teď</translation>
+<translation id="1407135791313364759">Otevřít vše</translation>
+<translation id="1209206284964581585">Prozatím skrýt</translation>
+<translation id="129553762522093515">Nedávno zavřené</translation>
+<translation id="8413126021676339697">Zobrazit celou historii</translation>
+<translation id="7876243839304621966">Odstranit vše</translation>
+<translation id="8487700953926739672">Dostupné offline</translation>
+<translation id="5224771365102442243">S videem</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Další informace<ph name="END_LINK"/> o navrhovaném obsahu</translation>
+<translation id="7542481630195938534">Návrhy nelze načíst</translation>
+<translation id="5013696553129441713">Žádné nové návrhy</translation>
+<translation id="1736419249208073774">Prozkoumat</translation>
+<translation id="7444811645081526538">Další kategorie</translation>
+<translation id="6709133671862442373">Zprávy</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Nákupy</translation>
+<translation id="3912508018559818924">Hledáme to nejlepší z webu…</translation>
+<translation id="526421993248218238">Stránku nelze načíst</translation>
+<translation id="614940544461990577">Zkuste:</translation>
+<translation id="3288003805934695103">Načíst stránku znovu</translation>
+<translation id="2353636109065292463">Kontrola připojení k internetu</translation>
+<translation id="2858138569776157458">Top weby</translation>
+<translation id="8364299278605033898">Zobrazit populární weby</translation>
+<translation id="1171770572613082465">Populární weby zobrazíte klepnutím na tlačítko Top weby</translation>
+<translation id="5233638681132016545">Nová karta</translation>
+<translation id="4521874409998847950">Zdroj: <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>poskytováno společností Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Je dostupná novější verze</translation>
+<translation id="4058091506841967397">Brave nelze aktualizovat</translation>
+<translation id="6316139424528454185">Nepodporovaná verze Androidu</translation>
+<translation id="6989267951144302301">Stažení se nezdařilo</translation>
+<translation id="624789221780392884">Je připravena aktualizace</translation>
+<translation id="1549000191223877751">Přejít do jiného okna</translation>
+<translation id="7481312909269577407">Vpřed</translation>
+<translation id="4084682180776658562">Záložka</translation>
+<translation id="6437478888915024427">Informace o stránce</translation>
+<translation id="7180611975245234373">Obnovit</translation>
+<translation id="4913169188695071480">Zastavit obnovování</translation>
+<translation id="1829244130665387512">Najít na stránce</translation>
+<translation id="6593061639179217415">Stránky pro počítač</translation>
+<translation id="9063523880881406963">Vypnout funkci Verzi webu pro PC</translation>
+<translation id="2038563949887743358">Zapnout funkci Verze webu pro PC</translation>
+<translation id="2433507940547922241">Vzhled</translation>
+<translation id="983192555821071799">Zavřít všechny karty</translation>
+<translation id="1310482092992808703">Seskupit karty</translation>
+<translation id="7725024127233776428">Zde se zobrazují stránky přidané do záložek</translation>
+<translation id="4404568932422911380">Žádné záložky</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> záložka}few{<ph name="BOOKMARKS_COUNT_MANY"/> záložky}many{<ph name="BOOKMARKS_COUNT_MANY"/> záložky}other{<ph name="BOOKMARKS_COUNT_MANY"/> záložek}}</translation>
+<translation id="3739899004075612870">Přidáno do záložek (<ph name="PRODUCT_NAME"/>)</translation>
+<translation id="3207960819495026254">Přidáno do záložek</translation>
+<translation id="4452548195519783679">Záložka přidána do složky <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Přidání záložky se nezdařilo.</translation>
+<translation id="2842985007712546952">Nadřazená složka</translation>
+<translation id="9065203028668620118">Upravit</translation>
+<translation id="4405224443901389797">Přesunout do…</translation>
+<translation id="5170568018924773124">Zobrazit ve složce</translation>
+<translation id="8035133914807600019">Nová složka…</translation>
+<translation id="4532845899244822526">Výběr složky</translation>
+<translation id="6627583120233659107">Upravit složku</translation>
+<translation id="1197267115302279827">Přesunutí záložek</translation>
+<translation id="6963766334940102469">Smazat záložky</translation>
+<translation id="4351244548802238354">Zavřít dialogové okno</translation>
+<translation id="451872707440238414">Prohledat záložky</translation>
+<translation id="8901170036886848654">Nebyly nalezeny žádné záložky</translation>
+<translation id="6404511346730675251">Upravit záložku</translation>
+<translation id="3894427358181296146">Přidat složku</translation>
+<translation id="5327248766486351172">Jméno</translation>
+<translation id="7400418766976504921">Adresa URL</translation>
+<translation id="3527085408025491307">Složka</translation>
+<translation id="5161254044473106830">Je požadován název</translation>
+<translation id="2996809686854298943">Je požadována adresa URL</translation>
+<translation id="2536728043171574184">Prohlížíte offline kopii stránky</translation>
+<translation id="4698034686595694889">Zobrazit offline v aplikaci <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> a další weby</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave stránku načte, až bude připraven}few{Brave stránky načte, až bude připraven}many{Brave stránky načte, až bude připraven}other{Brave stránky načte, až bude připraven}}</translation>
+<translation id="6811034713472274749">Stránka je připravená k zobrazení</translation>
+<translation id="4561979708150884304">Žádné připojení</translation>
+<translation id="8274165955039650276">Zobrazit stažený obsah</translation>
+<translation id="2082238445998314030">Výsledek <ph name="RESULT_NUMBER"/> z <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Žádné výsledky</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Hlasové vyhledávání není k dispozici</translation>
+<translation id="7191430249889272776">Karta je otevřena na pozadí.</translation>
+<translation id="8445059357334030806">Otevřít v Chromu</translation>
+<translation id="4720023427747327413">Otevřít v aplikaci <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Otevřít v prohlížeči</translation>
+<translation id="1113597929977215864">Zapnout zjednodušené zobrazení</translation>
+<translation id="1513352483775369820">Záložky a webová historie</translation>
+<translation id="4939482511480190003">Pomozte Brave zlepšit. <ph name="BEGIN_LINK"/>Zúčastněte se průzkumu<ph name="END_LINK"/>.</translation>
+<translation id="2501278716633472235">Zpět</translation>
+<translation id="5596627076506792578">Další možnosti</translation>
+<translation id="3522247891732774234">K dispozici je aktualizace. Další možnosti</translation>
+<translation id="6773423637732432200">Brave nelze aktualizovat. Další možnosti</translation>
+<translation id="3328801116991980348">Informace o stránkách</translation>
+<translation id="5391532827096253100">Spojení s tímto webem není zabezpečené. Informace o webu</translation>
+<translation id="6206551242102657620">Připojení je zabezpečené. Informace o webu</translation>
+<translation id="6963642900430330478">Tato stránka je nebezpečná. Informace o webu</translation>
+<translation id="9070377983101773829">Spustit hlasové vyhledávání</translation>
+<translation id="8676374126336081632">Vymazat vstup</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{Je otevřená <ph name="OPEN_TABS_ONE"/> karta, můžete mezi nimi přepínat klepnutím}few{Je otevřených <ph name="OPEN_TABS_MANY"/> karet, můžete mezi nimi přepínat klepnutím}many{Je otevřených <ph name="OPEN_TABS_MANY"/> karty, můžete mezi nimi přepínat klepnutím}other{Je otevřených <ph name="OPEN_TABS_MANY"/> karet, můžete mezi nimi přepínat klepnutím}}</translation>
+<translation id="2369533728426058518">otevřené karty</translation>
+<translation id="7071521146534760487">Spravovat účet</translation>
+<translation id="932327136139879170">Domovská stránka</translation>
+<translation id="2707726405694321444">Obnovit stránku</translation>
+<translation id="2891154217021530873">Zastavit načítání stránky</translation>
+<translation id="6710213216561001401">Předchozí</translation>
+<translation id="6659594942844771486">Karta</translation>
+<translation id="1933845786846280168">Vybraná karta</translation>
+<translation id="2268044343513325586">Upřesnit</translation>
+<translation id="7846076177841592234">Zrušit výběr</translation>
+<translation id="7087918508125750058">Vybrané položky: <ph name="ITEM_COUNT"/>. Možnosti jsou k dispozici u horního okraje obrazovky</translation>
+<translation id="7250468141469952378">Vybráno: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Sdílet 1 vybranou položku}few{Sdílet # vybrané položky}many{Sdílet # vybrané položky}other{Sdílet # vybraných položek}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Odstranit jednu vybranou položku}few{Odstranit # vybrané položky}many{Odstranit # vybrané položky}other{Odstranit # vybraných položek}}</translation>
+<translation id="1283039547216852943">Klepnutím rozbalíte</translation>
+<translation id="5962718611393537961">Klepnutím sbalíte</translation>
+<translation id="8076492880354921740">Karty</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Vybráno: 1}few{Vybráno: #}many{Vybráno: #}other{Vybráno: #}}</translation>
+<translation id="6818926723028410516">Výběr položek</translation>
+<translation id="4797039098279997504">Klepnutím se vrátíte na kartu <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Klepnutím přejdete na web</translation>
+<translation id="429312253194641664">Web přehrává média</translation>
+<translation id="4958708863221495346">Stránka <ph name="URL_OF_THE_CURRENT_TAB"/> sdílí vaši obrazovku</translation>
+<translation id="8833831881926404480">Web sdílí vaši obrazovku</translation>
+<translation id="9086455579313502267">Nelze získat přístup k síti.</translation>
+<translation id="938850635132480979">Chyba: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Otevřít v aplikaci <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Otevřít v mapové aplikaci</translation>
+<translation id="7698359219371678927">Vytvořit e-mail v aplikaci <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Vytvořit e-mail</translation>
+<translation id="5665379678064389456">Vytvořit událost v aplikaci <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Vytvořit událost</translation>
+<translation id="2111511281910874386">Přejít na stránku</translation>
+<translation id="3988466920954086464">Na tomto panelu naleznete výsledky dynamického vyhledávání</translation>
+<translation id="2744248271121720757">Klepnutím na slovo můžete okamžitě vyhledávat nebo zobrazit související akce</translation>
+<translation id="9155898266292537608">Hledat můžete také rychlým klepnutím na slovo</translation>
+<translation id="3232754137068452469">Webová aplikace</translation>
+<translation id="1430915738399379752">Tisk</translation>
+<translation id="3775705724665058594">Odeslat na vaše zařízení</translation>
+<translation id="6364438453358674297">Odstranit návrh z historie?</translation>
+<translation id="213279576345780926">Karta <ph name="TAB_TITLE"/> byla zavřena.</translation>
+<translation id="6850830437481525139">Zavřené karty: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Položka <ph name="ITEM_TITLE"/> byla smazána</translation>
+<translation id="4663756553811254707">Smazané záložky: <ph name="NUMBER_OF_BOOKMARKS"/></translation>
+<translation id="3819178904835489326">Počet smazaných stažených souborů: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Nepodporovaný počet instancí Chromu.</translation>
+<translation id="4259722352634471385">Navigace je blokována: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigace není dosažitelná: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Zavřít kartu</translation>
+<translation id="7772375229873196092">Zavřít aplikaci <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Historie navigace</translation>
+<translation id="9169507124922466868">Historie navigace je otevřená na půlce</translation>
+<translation id="1327257854815634930">Historie navigace je otevřená</translation>
+<translation id="8788265440806329501">Historie navigace je zavřená</translation>
+<translation id="7482656565088326534">Karta náhledu</translation>
+<translation id="8427875596167638501">Karta náhledu je otevřená na půlce</translation>
+<translation id="9102803872260866941">Je otevřená karta náhledu</translation>
+<translation id="2942036813789421260">Karta náhledu byla zavřena</translation>
+<translation id="6355102470683871794">Úložiště aplikace Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Vymazat úložiště webů?</translation>
+<translation id="9205995714227143200">Úložiště webů, které Brave považuje za nedůležité (např. weby bez uložených nastavení nebo weby, které nenavštěvujete často)</translation>
+<translation id="3997476611815694295">Nedůležité úložiště</translation>
+<translation id="8493948351860045254">Uvolnit místo</translation>
+<translation id="2324920234469020158">Tímto vymažete soubory cookie, mezipaměť a další data webů, která Brave považuje za nedůležitá.</translation>
+<translation id="5447201525962359567">Veškerá data webů, včetně souborů cookie a dalších místně uložených dat</translation>
+<translation id="1376578503827013741">Probíhá výpočet…</translation>
+<translation id="583281660410589416">Neznámé</translation>
+<translation id="2323763861024343754">Úložiště webů</translation>
+<translation id="3587672679800759167">Celkové množství dat využívané prohlížečem Brave, včetně účtů, záložek a uložených nastavení</translation>
+<translation id="6545017243486555795">Vymazat všechna data</translation>
+<translation id="4095146165863963773">Vymazat data aplikace?</translation>
+<translation id="53119194224775367">Všechna data aplikace Brave budou trvale smazána. Zahrnuje to soubory, nastavení, účty, databáze apod.</translation>
+<translation id="5307446750509046227">Vymazat úložiště webů</translation>
+<translation id="300526633675317032">Tímto vymažete celé úložiště webů (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">Certifikát nelze vybrat.</translation>
+<translation id="2315043854645842844">Volbu certifikátu na straně klienta operační systém nepodporuje.</translation>
+<translation id="5011311129201317034">Web <ph name="SITE"/> žádá o připojení</translation>
+<translation id="5308380583665731573">Připojení</translation>
+<translation id="868929229000858085">Vyhledat v kontaktech</translation>
+<translation id="1919950603503897840">Vyberte kontakty</translation>
+<translation id="7986741934819883144">Výběr kontaktu</translation>
+<translation id="3333961966071413176">Všechny kontakty</translation>
+<translation id="4994033804516042629">Nebyly nalezeny žádné kontakty</translation>
+<translation id="5403592356182871684">Názvy</translation>
+<translation id="2717722538473713889">E‑mailové adresy</translation>
+<translation id="381841723434055211">Telefonní čísla</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 další)}few{(+ # další)}many{(+ # další)}other{(+ # dalších)}}</translation>
+<translation id="5197729504361054390">Vybrané kontakty budou sdíleny s webem <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Dekodér obrázků</translation>
+<translation id="8067883171444229417">Přehrát video</translation>
+<translation id="6560414384669816528">Vyhledávat pomocí Sogou</translation>
+<translation id="5406914950576900927">Brave může v Číně k vyhledávání používat službu <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>. Tuto volbu můžete změnit v <ph name="BEGIN_LINK"/>Nastavení<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Ponechat Brave Software</translation>
+<translation id="4384468725000734951">K vyhledávání se používá služba Sogou</translation>
+<translation id="6103327872225198548">K vyhledávání se používá Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Tato aplikace je spuštěna v Chromu</translation>
+<translation id="6143689084714664628">Spuštěno v Chromu</translation>
+<translation id="7675869148432102528">Aplikace <ph name="APP_NAME"/> má také data v Chromu</translation>
+<translation id="2734140769649165081">Data můžete vymazat v nastavení Chromu</translation>
+<translation id="8232956427053453090">Zachovat data</translation>
+<translation id="4298388696830689168">Propojené weby</translation>
+<translation id="5763514718066511291">Klepnutím zkopírujete adresu URL této aplikace</translation>
+<translation id="6496823230996795692">Chcete-li poprvé použít aplikaci <ph name="APP_NAME"/>, připojte se k internetu.</translation>
+<translation id="751961395872307827">K webu se nelze připojit</translation>
+<translation id="4878404682131129617">Vytvoření tunelu prostřednictvím proxy serveru se nezdařilo</translation>
+<translation id="4749960740855309258">Otevření nové karty</translation>
+<translation id="8788968922598763114">Znovu otevřít naposledy zavřenou kartu</translation>
+<translation id="7929962904089429003">Otevřít nabídku</translation>
+<translation id="6039379616847168523">Přejít na další kartu</translation>
+<translation id="5210286577605176222">Přejít na předchozí kartu</translation>
+<translation id="124678866338384709">Zavřít aktuální kartu</translation>
+<translation id="3714981814255182093">Otevřít lištu Najít</translation>
+<translation id="5441522332038954058">Přejít na adresní řádek</translation>
+<translation id="3398320232533725830">Otevřít správce záložek</translation>
+<translation id="6583199322650523874">Přidat aktuální stránku do záložek</translation>
+<translation id="8489271220582375723">Otevřít stránku historie</translation>
+<translation id="4837753911714442426">Otevřít možnosti tisku stránky</translation>
+<translation id="5726692708398506830">Zvětšit veškerý obsah stránky</translation>
+<translation id="3259831549858767975">Zmenšit veškerý obsah stránky</translation>
+<translation id="8015452622527143194">Vrátit veškerý obsah stránky na původní velikost</translation>
+<translation id="3443221991560634068">Znovu načíst aktuální stránku</translation>
+<translation id="123724288017357924">Obnovit stránku a ignorovat obsah v mezipaměti</translation>
+<translation id="305870044889644984">Otevřít centrum nápovědy Brave na nové kartě</translation>
+<translation id="3166827708714933426">Zkratky pro okna a karty</translation>
+<translation id="3169981355900570544">Zkratky funkcí prohlížeče Brave Software Brave</translation>
+<translation id="4558311620361989323">Zkratky webových stránek</translation>
+<translation id="1908301351964700579">Brave se na virtuální realitu stále připravuje. Restartujte Brave později.</translation>
+<translation id="8970887620466824814">Došlo k chybě.</translation>
+<translation id="1875543012935658554">Znovu spusťte Brave.</translation>
+<translation id="79859296434321399">Chcete-li zobrazit obsah pro rozšířenou realitu, nainstalujte ARCore</translation>
+<translation id="8558485628462305855">Chcete-li zobrazit obsah pro rozšířenou realitu, aktualizujte ARCore</translation>
+<translation id="3513704683820682405">Rozšířená realita</translation>
+<translation id="5475862044948910901">Spustit relaci rozšířené reality?</translation>
 <translation id="7365126855094612066">Po dobu trvání této relace bude web moci:
 • vytvářet 3D mapu vašeho prostředí,
 • sledovat pohyb fotoaparátu.
 
 Web NEZÍSKÁ přístup k fotoaparátu. Fotky z fotoaparátu uvidíte pouze vy.</translation>
-<translation id="7375125077091615385">Typ:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">Adresa URL</translation>
-<translation id="7403691278183511381">První spuštění Chromu</translation>
-<translation id="741204030948306876">Ano</translation>
-<translation id="7413229368719586778">Datum zahájení <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Nejprve se dotázat</translation>
-<translation id="7423538860840206698">Čtení schránky je blokováno</translation>
-<translation id="7431991332293347422">Nastavte, jak se má vaše historie prohlížení používat k personalizaci Vyhledávání a dalších služeb</translation>
-<translation id="7437998757836447326">Odhlášení z Chromu</translation>
-<translation id="7438641746574390233">Když je zapnutý zjednodušený režim, Chrome načítání stránek urychluje pomocí serverů Google. Ve zjednodušeném režimu se velmi pomalé stránky přepisují tak, aby se načítal jen nezbytný obsah. Zjednodušený režim se nepoužívá pro anonymní karty.</translation>
-<translation id="7444811645081526538">Další kategorie</translation>
-<translation id="7445411102860286510">Povolit webům automaticky přehrávat ztlumená videa (doporučeno)</translation>
-<translation id="7453467225369441013">Odhlásí vás z většiny webů. Z účtu Google odhlášeni nebudete.</translation>
-<translation id="7454641608352164238">Nedostatek místa</translation>
-<translation id="7475192538862203634">Pokud se vám tato stránka zobrazuje často, vyzkoušejte tyto <ph name="BEGIN_LINK" />návrhy<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD karta nebyla nalezena. Některé vaše soubory mohou chybět.</translation>
-<translation id="7479104141328977413">Správa karet</translation>
-<translation id="7481312909269577407">Vpřed</translation>
-<translation id="7482656565088326534">Karta náhledu</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (aktualizováno <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">uspořená data</translation>
-<translation id="7498271377022651285">Čekejte prosím…</translation>
-<translation id="7514365320538308">Stáhnout</translation>
-<translation id="751961395872307827">K webu se nelze připojit</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Návrhy nelze načíst</translation>
-<translation id="7559975015014302720">Zjednodušený režim je vypnutý</translation>
-<translation id="7562080006725997899">Mazání údajů o prohlížení</translation>
-<translation id="756809126120519699">Vymazání údajů Chromu</translation>
-<translation id="757524316907819857">Bránit webům v přehrávání chráněného obsahu</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Byl stažen <ph name="FILES_DOWNLOADED_ONE" /> soubor}few{Byly staženy <ph name="FILES_DOWNLOADED_MANY" /> soubory}many{Bylo staženo <ph name="FILES_DOWNLOADED_MANY" /> souboru}other{Bylo staženo <ph name="FILES_DOWNLOADED_MANY" /> souborů}}</translation>
-<translation id="7588219262685291874">Když je na zařízení zapnutý spořič baterie, zapnout tmavý motiv</translation>
-<translation id="7589445247086920869">Blokovat pro aktuální vyhledávač</translation>
-<translation id="7593557518625677601">Chcete-li spustit synchronizaci Chromu, povolte synchronizaci systému Android.</translation>
-<translation id="7596558890252710462">Operační systém</translation>
-<translation id="7605594153474022051">Synchronizace nefunguje</translation>
-<translation id="7606077192958116810">Zjednodušený režim je zapnutý. Spravovat ho můžete v Nastavení.</translation>
-<translation id="7612619742409846846">Jste přihlášeni do Googlu jako</translation>
-<translation id="7619072057915878432">Stahování souboru <ph name="FILE_NAME" /> se nezdařilo z důvodu selhání sítě.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Prohlédněte si nápovědu<ph name="END_LINK1" /> nebo zařízení <ph name="BEGIN_LINK2" />vyhledejte znovu<ph name="END_LINK2" />.</translation>
-<translation id="7626032353295482388">Vítá vás Chrome</translation>
-<translation id="7638584964844754484">Nesprávná heslová fráze</translation>
-<translation id="7641339528570811325">Vymazat údaje o prohlížení…</translation>
-<translation id="7648422057306047504">Šifrovat hesla pomocí identifikačních údajů Google</translation>
-<translation id="7649070708921625228">Nápověda</translation>
-<translation id="7658239707568436148">Zrušit</translation>
-<translation id="7665369617277396874">Přidat účet</translation>
-<translation id="766587987807204883">Zde se zobrazují články, které si můžete číst i offline</translation>
-<translation id="7682724950699840886">Vyzkoušejte tyto tipy: Zajistěte, aby v zařízení byl dostatek místa a zkuste export zopakovat.</translation>
-<translation id="7685301384041462804">Před přechodem do režimu virtuální reality zkontrolujte, zda tomuto webu důvěřujete</translation>
-<translation id="7698359219371678927">Vytvořit e-mail v aplikaci <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Automaticky doplňovat vyhledávací dotazy a adresy URL</translation>
-<translation id="7725024127233776428">Zde se zobrazují stránky přidané do záložek</translation>
-<translation id="773466115871691567">Stránky v jazyce <ph name="SOURCE_LANGUAGE" /> vždy překládat</translation>
-<translation id="7746457520633464754">Kvůli detekci nebezpečných aplikací a webů odesílá Chrome do Googlu adresy URL některých navštívených stránek, omezené informace o systému a část obsahu stránek</translation>
-<translation id="7757787379047923882">Text sdílený ze zařízení <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD karta <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Přidat adresu</translation>
-<translation id="7772032839648071052">Potvrďte heslovou frázi</translation>
-<translation id="7772375229873196092">Zavřít aplikaci <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> další}few{<ph name="PAYMENT_METHOD_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> další}many{<ph name="PAYMENT_METHOD_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> další}other{<ph name="PAYMENT_METHOD_PREVIEW" /> a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> dalších}}</translation>
-<translation id="7781829728241885113">Včera</translation>
-<translation id="7791543448312431591">Přidat</translation>
-<translation id="780301667611848630">Ne, děkuji</translation>
-<translation id="7810647596859435254">Otevřít v aplikaci…</translation>
-<translation id="7821588508402923572">Zde se budou zobrazovat vaše úspory dat</translation>
-<translation id="7837721118676387834">Povolit automatické přehrávání ztlumených videí na konkrétním webu.</translation>
-<translation id="7846076177841592234">Zrušit výběr</translation>
-<translation id="784934925303690534">Časové období</translation>
-<translation id="7851858861565204677">Jiná zařízení</translation>
-<translation id="7875915731392087153">Vytvořit e-mail</translation>
-<translation id="7876243839304621966">Odstranit vše</translation>
-<translation id="7882131421121961860">Nebyla nalezena žádná historie</translation>
-<translation id="7882806643839505685">Zapne zvuk na konkrétním webu.</translation>
-<translation id="7886917304091689118">Spuštěno v Chromu</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Stahování souboru.}few{Stahování # souborů.}many{Stahování # souboru.}other{Stahování # souborů.}}</translation>
-<translation id="7929962904089429003">Otevřít nabídku</translation>
-<translation id="7942131818088350342">Aplikace <ph name="PRODUCT_NAME" /> je zastaralá.</translation>
-<translation id="7947953824732555851">Přijmout a přihlásit</translation>
-<translation id="7963646190083259054">Dodavatel:</translation>
-<translation id="7971136598759319605">Aktivní včera</translation>
-<translation id="7975379999046275268">Zobrazit náhled stránky <ph name="BEGIN_NEW" />Nové<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Předběžně načítat stránky pro rychlejší procházení a vyhledávání</translation>
-<translation id="79859296434321399">Chcete-li zobrazit obsah pro rozšířenou realitu, nainstalujte ARCore</translation>
-<translation id="7986741934819883144">Výběr kontaktu</translation>
-<translation id="7987073022710626672">Smluvní podmínky Chrome</translation>
-<translation id="7998918019931843664">Znovu otevřít zavřenou kartu</translation>
-<translation id="7999064672810608036">Opravdu chcete vymazat všechna místní data tohoto webu, včetně souborů cookie, a resetovat všechna jeho oprávnění?</translation>
-<translation id="8004582292198964060">Prohlížeč</translation>
-<translation id="8007176423574883786">Vypnuto v tomto zařízení</translation>
-<translation id="8013372441983637696">Vymazat data prohlížeče Chrome také z tohoto zařízení</translation>
-<translation id="8015452622527143194">Vrátit veškerý obsah stránky na původní velikost</translation>
-<translation id="802154636333426148">Stažení se nezdařilo</translation>
-<translation id="8026334261755873520">Vymazat údaje o prohlížení</translation>
-<translation id="8035133914807600019">Nová složka…</translation>
-<translation id="8037750541064988519">Zbývá: <ph name="DAYS" /> d</translation>
-<translation id="804335162455518893">SD karta nenalezena</translation>
-<translation id="805047784848435650">Na základě vaší historie prohlížení</translation>
-<translation id="8051695050440594747">K dispozici: <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">Otevřít na nové kartě v Chromu</translation>
-<translation id="8063895661287329888">Přidání záložky se nezdařilo.</translation>
-<translation id="806745655614357130">Uchovat má data samostatně.</translation>
-<translation id="8067883171444229417">Přehrát video</translation>
-<translation id="8068648041423924542">Certifikát nelze vybrat.</translation>
-<translation id="8073388330009372546">Otevřít na nové kartě</translation>
-<translation id="8076492880354921740">Karty</translation>
-<translation id="8084114998886531721">Uložené heslo</translation>
-<translation id="8087000398470557479">Tento obsah pochází z domény <ph name="DOMAIN_NAME" />. Poskytováno společností Google.</translation>
-<translation id="8103578431304235997">Anonymní karta</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Chcete-li mít záložky ve všech zařízeních, zapněte synchronizaci</translation>
-<translation id="8110087112193408731">Zobrazovat vaši aktivitu v Chromu v digitální rovnováze?</translation>
-<translation id="8116925261070264013">Ztlumeno</translation>
-<translation id="813082847718468539">Zobrazit informace o stránkách</translation>
-<translation id="8131740175452115882">Potvrdit</translation>
-<translation id="8156139159503939589">Jaké jazyky ovládáte?</translation>
-<translation id="8168435359814927499">Obsah</translation>
-<translation id="8186512483418048923">Zbývající soubory: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Zbývá: 1 d</translation>
-<translation id="8200772114523450471">Pokračovat</translation>
-<translation id="8209050860603202033">Otevřít obrázek</translation>
-<translation id="8218622182176210845">Správa účtu</translation>
-<translation id="8224471946457685718">Stahovat články pro vás přes Wi-Fi</translation>
-<translation id="8232956427053453090">Zachovat data</translation>
-<translation id="8249310407154411074">Přesunout na začátek</translation>
-<translation id="8250920743982581267">Dokumenty</translation>
-<translation id="825412236959742607">Tato stránka využívá příliš mnoho paměti, Chrome proto odstranil část obsahu.</translation>
-<translation id="8260126382462817229">Zkuste se přihlásit znovu.</translation>
-<translation id="8261506727792406068">Smazat</translation>
-<translation id="8266862848225348053">Umístění stažených souborů</translation>
-<translation id="8274165955039650276">Zobrazit stažený obsah</translation>
-<translation id="8284326494547611709">Titulky</translation>
-<translation id="8300705686683892304">Spravováno aplikací</translation>
-<translation id="8310344678080805313">Standardní karty</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> a další weby</translation>
-<translation id="8327155640814342956">Chcete-li mít při procházení nejlepší prostředí a funkce, aktualizujte Chrome</translation>
-<translation id="8339163506404995330">Stránky v jazyce <ph name="LANGUAGE" /> nebudou překládány</translation>
-<translation id="8349013245300336738">Seřadit podle množství využitých dat</translation>
-<translation id="8364299278605033898">Zobrazit populární weby</translation>
-<translation id="8368027906805972958">Neznámé nebo nepodporované zařízení (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Povolit synchronizaci na pozadí konkrétnímu webu.</translation>
-<translation id="8378714024927312812">Spravováno vaší organizací</translation>
-<translation id="8380167699614421159">Tento web zobrazuje rušivé nebo zavádějící reklamy</translation>
-<translation id="8393700583063109961">Odeslat zprávu</translation>
-<translation id="8413126021676339697">Zobrazit celou historii</translation>
-<translation id="8427875596167638501">Karta náhledu je otevřená na půlce</translation>
-<translation id="8428213095426709021">Nastavení</translation>
-<translation id="8438566539970814960">Vylepšit vyhledávání a procházení</translation>
-<translation id="8441146129660941386">Přetočit dozadu</translation>
-<translation id="8443209985646068659">Chrome nelze aktualizovat</translation>
-<translation id="8445448999790540984">Hesla se nepodařilo exportovat</translation>
-<translation id="8447861592752582886">Zrušit oprávnění zařízení</translation>
-<translation id="8461694314515752532">Šifrovat synchronizovaná data pomocí vlastní heslové fráze pro synchronizaci</translation>
-<translation id="8466613982764129868">Zkontrolujte, zda je zařízení <ph name="TARGET_DEVICE_NAME" /> připojené k internetu</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Dostupné offline</translation>
-<translation id="8489271220582375723">Otevřít stránku historie</translation>
-<translation id="8493948351860045254">Uvolnit místo</translation>
-<translation id="8497726226069778601">Zatím tu nic není...</translation>
-<translation id="8503559462189395349">Hesla Chrome</translation>
-<translation id="8503813439785031346">Uživatelské jméno</translation>
-<translation id="8514477925623180633">Exportovat hesla uložená v Chromu</translation>
-<translation id="8514577642972634246">Přejít do anonymního režimu</translation>
-<translation id="851751545965956758">Bránit webům v připojení k zařízením</translation>
-<translation id="8523928698583292556">Vymazat uložené heslo</translation>
-<translation id="854522910157234410">Otevřít tuto stránku</translation>
-<translation id="8558485628462305855">Chcete-li zobrazit obsah pro rozšířenou realitu, aktualizujte ARCore</translation>
-<translation id="8559990750235505898">Nabízet překlad stránek v jiných jazycích</translation>
-<translation id="8562452229998620586">Zde se zobrazí uložená hesla.</translation>
-<translation id="8569404424186215731">od <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Poslední 4 týdny</translation>
-<translation id="857943718398505171">Povoleno (doporučeno)</translation>
-<translation id="8583805026567836021">Mazání dat účtu</translation>
-<translation id="860043288473659153">Jméno držitele karty</translation>
-<translation id="8609465669617005112">Posunout nahoru</translation>
-<translation id="8616006591992756292">Na stránce <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> mohou být k dispozici další druhy historie prohlížení zaznamenané ve vašem účtu Google.</translation>
-<translation id="8617240290563765734">Otevřít navrhovanou adresu URL uvedenou ve staženém obsahu?</translation>
-<translation id="8636825310635137004">Chcete-li získat přístup ke kartám ze svých ostatních zařízení, zapněte synchronizaci.</translation>
-<translation id="8641930654639604085">Pokusit se blokovat weby pouze pro dospělé</translation>
-<translation id="8655129584991699539">Data můžete vymazat v nastavení Chromu</translation>
-<translation id="8662811608048051533">Odhlásí vás z většiny webů.</translation>
-<translation id="8664979001105139458">Název souboru již existuje</translation>
-<translation id="8676374126336081632">Vymazat vstup</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Síla signálu: # čárka}few{Síla signálu: # čárky}many{Síla signálu: # čárky}other{Síla signálu: # čárek}}</translation>
-<translation id="868929229000858085">Vyhledat v kontaktech</translation>
-<translation id="869891660844655955">Datum vypršení platnosti</translation>
-<translation id="8719023831149562936">Aktuální kartu nelze přenést</translation>
-<translation id="8725066075913043281">Zkusit znovu</translation>
-<translation id="8728487861892616501">Používáním této aplikace vyjadřujete souhlas se <ph name="BEGIN_LINK1" />smluvními podmínkami<ph name="END_LINK1" /> a <ph name="BEGIN_LINK2" />upozorněním ve věci ochrany soukromí<ph name="END_LINK2" /> prohlížeče Chrome a <ph name="BEGIN_LINK3" />upozorněním ve věci ochrany soukromí pro účty Google spravované prostřednictvím služby Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Hotovo</translation>
-<translation id="8748850008226585750">Skrytý obsah</translation>
-<translation id="8751914237388039244">Vybrat obrázek</translation>
-<translation id="8788265440806329501">Historie navigace je zavřená</translation>
-<translation id="8788968922598763114">Znovu otevřít naposledy zavřenou kartu</translation>
-<translation id="8801436777607969138">Blokovat JavaScript na konkrétním webu.</translation>
-<translation id="8812260976093120287">Na některých webech můžete platit pomocí výše uvedených podporovaných platebních aplikací v zařízení.</translation>
-<translation id="8816026460808729765">Blokovat webům přístup k senzorům</translation>
-<translation id="8816439037877937734">Aplikace <ph name="APP_NAME" /> se otevře v Chromu. Pokračováním vyjadřujete souhlas se <ph name="BEGIN_LINK1" />smluvními podmínkami<ph name="END_LINK1" /> a <ph name="BEGIN_LINK2" />upozorněním ve věci ochrany soukromí<ph name="END_LINK2" /> prohlížeče Chrome a <ph name="BEGIN_LINK3" />upozorněním ve věci ochrany soukromí pro účty Google spravované prostřednictvím služby Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Záložky</translation>
-<translation id="8833831881926404480">Web sdílí vaši obrazovku</translation>
-<translation id="883806473910249246">Při stahování obsahu došlo k chybě.</translation>
-<translation id="8840953339110955557">Tato stránka se může od online verze lišit.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, karta</translation>
-<translation id="885701979325669005">Úložiště</translation>
-<translation id="889338405075704026">Přejít do nastavení Chromu</translation>
-<translation id="8901170036886848654">Nebyly nalezeny žádné záložky</translation>
-<translation id="8909135823018751308">Sdílet…</translation>
-<translation id="8912362522468806198">Účet Google</translation>
-<translation id="8920114477895755567">Čekáme na podrobnosti o rodičích.</translation>
+<translation id="1188239144602654184">Spustit rozšířenou realitu</translation>
+<translation id="473775607612524610">Aktualizovat</translation>
+<translation id="3133489217401741157">Instalace modulu <ph name="MODULE"/> pro Brave…</translation>
+<translation id="1791662854739702043">Nainstalováno</translation>
+<translation id="5131234170665854056">Modul <ph name="MODULE"/> pro Brave se nepodařilo nainstalovat</translation>
+<translation id="2567385386134582609">OBRÁZEK</translation>
+<translation id="6395288395575013217">ODKAZ</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Stáhněte si stránky k použití offline</translation>
 <translation id="8922289737868596582">Stáhněte si stránky k použití offline pomocí tlačítka Další možnosti</translation>
-<translation id="8937772741022875483">Odstranit vaši aktivitu v Chromu z digitální rovnováhy?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Otevřít v jiném okně</translation>
-<translation id="8951232171465285730">Chrome vám ušetřil <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokovat soubory cookie pro konkrétní web.</translation>
-<translation id="8959122750345127698">Navigace není dosažitelná: <ph name="URL" /></translation>
-<translation id="8965591936373831584">nevyřízeno</translation>
-<translation id="8970887620466824814">Došlo k chybě.</translation>
-<translation id="8972098258593396643">Stáhnout do výchozí složky?</translation>
-<translation id="8986494364107987395">Automaticky posílat společnosti Google statistiky používání a zprávy o selhání</translation>
-<translation id="8993760627012879038">Otevřít novou kartu v anonymním režimu</translation>
-<translation id="8998729206196772491">Přihlašujete se pomocí účtu spravovaného doménou <ph name="MANAGED_DOMAIN" /> a poskytujete jeho správci kontrolu nad svými daty prohlížeče Chrome. Vaše data budou trvale přidružena k tomuto účtu. Odhlášením z Chromu svá data smažete z tohoto zařízení, ve vašem účtu Google však uložena zůstanou.</translation>
-<translation id="9019902583201351841">Spravováno vašimi rodiči</translation>
-<translation id="9028914725102941583">Chcete-li umožnit sdílení mezi zařízeními, zapněte synchronizaci</translation>
-<translation id="9029323097866369874">Povolit webu <ph name="DOMAIN" /> přejít do režimu virtuální reality?</translation>
-<translation id="9040142327097499898">Oznámení jsou povolena. Poloha je v tomto zařízení vypnutá.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}few{# videa}many{# videa}other{# videí}}</translation>
-<translation id="9050666287014529139">Heslová fráze</translation>
-<translation id="9063523880881406963">Vypnout funkci Verzi webu pro PC</translation>
-<translation id="9065203028668620118">Upravit</translation>
-<translation id="9070377983101773829">Spustit hlasové vyhledávání</translation>
-<translation id="9074336505530349563">Chcete-li od Googlu získat personalizované návrhy obsahu, zapněte synchronizaci</translation>
-<translation id="9086455579313502267">Nelze získat přístup k síti.</translation>
-<translation id="9100505651305367705">Nabízet zjednodušené zobrazení článků (pokud je podporováno)</translation>
-<translation id="9100610230175265781">Je vyžadována heslová fráze</translation>
-<translation id="9102803872260866941">Je otevřená karta náhledu</translation>
+<translation id="5958275228015807058">Najděte stažené soubory a stránky</translation>
+<translation id="5620928963363755975">Stažené soubory a stránky můžete najít pomocí tlačítka Další možnosti</translation>
+<translation id="3341058695485821946">Podívejte se, kolik dat jste ušetřili</translation>
+<translation id="3157842584138209013">Informace o množství uspořených dat zobrazíte pomocí tlačítka Další možnosti</translation>
+<translation id="8218622182176210845">Správa účtu</translation>
+<translation id="8090895580117672212">Chcete-li spravovat svůj účet Brave Software, klepněte na tlačítko Spravovat účet</translation>
+<translation id="8856898588039823173">Zjednodušenou stránku poskytuje Brave Software. Klepnutím načtete originál.</translation>
+<translation id="8134317863207426198">Zjednodušenou stránku poskytuje Brave Software. Klepnutím na tlačítko k načtení originálu zobrazíte původní verzi.</translation>
+<translation id="4961107849584082341">Nechte si tuto stránku přeložit do libovolného jazyka</translation>
+<translation id="569536719314091526">Pomocí tlačítka Další možnosti můžete tuto stránku přeložit do libovolného jazyka.</translation>
+<translation id="1397811292916898096">Hledat pomocí vyhledávače <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Výchozí umístění pro stažené soubory můžete kdykoliv změnit.</translation>
+<translation id="6942665639005891494">Výchozí umístění pro stažené soubory můžete kdykoliv změnit pomocí možnosti v nabídce Nastavení.</translation>
+<translation id="6850409657436465440">Stahování stále probíhá</translation>
+<translation id="5817715962196959877">Brave teď stahuje soubory rychleji</translation>
+<translation id="3976396876660209797">Odstraňte tuto zkratku a znovu ji vytvořte</translation>
+<translation id="6766622839693428701">Zavřete přejetím prstem dolů.</translation>
+<translation id="1028699632127661925">Odesílání na zařízení <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – odesláno ze zařízení <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Byla přijata karta</translation>
 <translation id="9104217018994036254">Seznam zařízení, se kterými se má karta sdílet.</translation>
-<translation id="9133397713400217035">Prozkoumat offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Zobrazit originál</translation>
-<translation id="9139068048179869749">Pokud web bude chtít odesílat oznámení, zobrazit dotaz (doporučeno)</translation>
-<translation id="9139318394846604261">Nákupy</translation>
-<translation id="9155898266292537608">Hledat můžete také rychlým klepnutím na slovo</translation>
-<translation id="9169507124922466868">Historie navigace je otevřená na půlce</translation>
-<translation id="9204836675896933765">Zbývá 1 soubor</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Seznam zařízení, se kterými se má karta sdílet, otevřený na poloviční výšku.</translation>
+<translation id="2904414404539560095">Seznam zařízení, se kterými se má karta sdílet, otevřený na plnou výšku.</translation>
+<translation id="4135200667068010335">Seznam zařízení, se kterými se má karta sdílet, je zavřený.</translation>
+<translation id="5292796745632149097">Odeslat do zařízení</translation>
+<translation id="1386674309198842382">Aktivní před tímto počtem dní: <ph name="LAST_UPDATED"/></translation>
+<translation id="7971136598759319605">Aktivní včera</translation>
+<translation id="1521774566618522728">Aktivní dnes</translation>
+<translation id="3631987586758005671">Sdílení se zařízením <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Chcete-li umožnit sdílení mezi zařízeními, zapněte synchronizaci</translation>
+<translation id="6162454065885854378">Chcete-li něco z telefonu sdílet do jiného zařízení, zapněte v nastavení Chromu na obou zařízeních synchronizaci</translation>
+<translation id="6084271560289605378">Přejít do nastavení Chromu</translation>
+<translation id="2318045970523081853">Klepnutím zahájíte hovor</translation>
 <translation id="9209888181064652401">Nelze uskutečňovat hovory</translation>
-<translation id="9219103736887031265">Obrázky</translation>
-<translation id="926205370408745186">Odstranit vaši aktivitu v Chromu z digitální rovnováhy</translation>
-<translation id="932327136139879170">Domovská stránka</translation>
-<translation id="938850635132480979">Chyba: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Přístup k mikrofonu</translation>
-<translation id="95817756606698420">Chrome může v Číně k vyhledávání používat službu <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />. Tuto volbu můžete změnit v <ph name="BEGIN_LINK" />Nastavení<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokovat, pokud web zobrazuje rušivé nebo zavádějící reklamy (doporučeno)</translation>
-<translation id="968900484120156207">Zde se zobrazují navštívené stránky</translation>
-<translation id="970715775301869095">Zbývá: <ph name="MINUTES" /> min</translation>
-<translation id="974555521953189084">Chcete-li spustit synchronizaci zadejte heslovou frázi.</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Tímto vymažete data všech webů včetně těchto:</translation>
-<translation id="983192555821071799">Zavřít všechny karty</translation>
-<translation id="987264212798334818">Všeobecné</translation>
+<translation id="2860954141821109167">Zkontrolujte zda je na tomto zařízení povolená aplikace k telefonování</translation>
+<translation id="2067805253194386918">text</translation>
+<translation id="1450753235335490080">Sdílení obsahu typu <ph name="CONTENT_TYPE"/> se nezdařilo</translation>
+<translation id="1266864766717917324">Sdílení obsahu typu <ph name="CONTENT_TYPE"/> se nezdařilo</translation>
+<translation id="8287068819750208230">Zkontrolujte, zda je v Chromu na zařízení <ph name="TARGET_DEVICE_NAME"/> zapnutá synchronizace</translation>
+<translation id="3016635187733453316">Zkontrolujte, zda je toto zařízení připojeno k internetu</translation>
+<translation id="8466613982764129868">Zkontrolujte, zda je zařízení <ph name="TARGET_DEVICE_NAME"/> připojené k internetu</translation>
+<translation id="6539092367496845964">Něco se pokazilo. Zkuste to později.</translation>
+<translation id="3389286852084373014">Text je příliš dlouhý</translation>
+<translation id="2100314319871056947">Zkuste text sdílet po menších částech</translation>
+<translation id="2987620471460279764">Text sdílený z jiného zařízení</translation>
+<translation id="7757787379047923882">Text sdílený ze zařízení <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Zkopírováno do schránky</translation>
+<translation id="4696983787092045100">Odeslat text do vašich zařízení</translation>
+<translation id="1260236875608242557">Vyhledávání a prozkoumávání</translation>
+<translation id="6369229450655021117">Odsud můžete vyhledávat na webu, sdílet obsah s přáteli a zobrazovat otevřené stránky.</translation>
+<translation id="723171743924126238">Vyberte fotky</translation>
+<translation id="8751914237388039244">Vybrat obrázek</translation>
+<translation id="1989112275319619282">Procházet</translation>
+<translation id="7055152154916055070">Bylo zablokováno přesměrování:</translation>
+<translation id="5524843473235508879">Bylo zablokováno přesměrování.</translation>
+<translation id="6573096386450695060">Vždy povolit</translation>
+<translation id="5805364706385912897">Tato stránka využívá příliš mnoho paměti, proto ji Brave pozastavil.</translation>
+<translation id="5138664332909611586">Tato stránka využívá příliš mnoho paměti, Brave proto odstranil část obsahu.</translation>
+<translation id="9137013805542155359">Zobrazit originál</translation>
+<translation id="6361779936989026201">Asistent Brave Software v Chromu</translation>
+<translation id="7291387454912369099">Platba aktivovaná Asistentem</translation>
+<translation id="4565206163201411670">Zobrazovat vaši aktivitu v Chromu v digitální rovnováze?</translation>
+<translation id="9055113864158719823">Můžete se podívat, které stránky v Chromu navštěvujete, a nastavit pro ně časovače.\n\nBrave Software obdrží informace o webech, pro které nastavíte časovače, a o tom, jak dlouho jste na nich byli. Tyto informace slouží ke zlepšování digitální rovnováhy.</translation>
+<translation id="4596514158372210596">Odstranit vaši aktivitu v Chromu z digitální rovnováhy</translation>
+<translation id="1174893863889683998">Odstranit vaši aktivitu v Chromu z digitální rovnováhy?</translation>
+<translation id="708829030563435351">Weby navštívené v Chromu se nebudou zobrazovat. Všechny časovače webů budou smazány.</translation>
+<translation id="2056878612599315956">Web je pozastaven</translation>
+<translation id="671481426037969117">Časovač <ph name="FQDN"/> vypršel. Spustí se zase zítra.</translation>
+<translation id="7479104141328977413">Správa karet</translation>
+<translation id="3524138585025253783">Uživatelské rozhraní pro vývojáře</translation>
+<translation id="6036057147555329831">Extra ICU</translation>
+<translation id="9029323097866369874">Povolit webu <ph name="DOMAIN"/> přejít do režimu virtuální reality?</translation>
+<translation id="7685301384041462804">Před přechodem do režimu virtuální reality zkontrolujte, zda tomuto webu důvěřujete</translation>
+<translation id="5033865233969348410">V režimu virtuální reality tento web může získat následující informace:
+– vaše fyzické vlastnosti, jako je výška
+
+Před přechodem do režimu virtuální reality zkontrolujte, zda tomuto webu důvěřujete.</translation>
+<translation id="5534334044554683961">V režimu virtuální reality tento web může získat následující informace:
+– vaše fyzické vlastnosti, jako je výška,
+– rozvržení vaší místnosti.
+
+Před přechodem do režimu virtuální reality zkontrolujte, zda tomuto webu důvěřujete.</translation>
+<translation id="4169535189173047238">Nepovolovat</translation>
+<translation id="2170088579611075216">Povolit a spustit virtuální realitu</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_da.xtb
+++ b/android/java/strings/translations/android_chrome_strings_da.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="da">
-<translation id="1006017844123154345">Åbn på nettet</translation>
-<translation id="1028699632127661925">Sender til <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Tilføjer <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Fra websites</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Gemmes aldrig</translation>
-<translation id="1067922213147265141">Andre Google-tjenester</translation>
-<translation id="1068672505746868501">Oversæt aldrig sider på <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Hvis du ændrer filtypen, åbnes filen muligvis i en anden app og kan være skadelig for din enhed.</translation>
-<translation id="1100066534610197918">Åbn i en ny fane i en gruppe</translation>
-<translation id="1105960400813249514">Screenshot</translation>
-<translation id="1111673857033749125">Bogmærker, der er gemt på dine andre enheder, vises her.</translation>
-<translation id="1113597929977215864">Se enkel visning</translation>
-<translation id="1121094540300013208">Brugs- og nedbrudsrapporter</translation>
-<translation id="1124772482545689468">Bruger</translation>
-<translation id="1129510026454351943">Info: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download afventer.}one{# download afventer.}other{# downloads afventer.}}</translation>
-<translation id="1145536944570833626">Slet eksisterende data.</translation>
-<translation id="1146678959555564648">Angiv VR</translation>
-<translation id="116280672541001035">Brugt</translation>
-<translation id="1171770572613082465">Se populære websites ved at trykke på knappen "Topwebsites"</translation>
-<translation id="1173894706177603556">Omdøb</translation>
-<translation id="1178581264944972037">Pause</translation>
-<translation id="1181037720776840403">Fjern</translation>
-<translation id="1188239144602654184">Start AR</translation>
-<translation id="1197267115302279827">Flyt bogmærker</translation>
-<translation id="119944043368869598">Ryd alle</translation>
-<translation id="1201402288615127009">Næste</translation>
-<translation id="1204037785786432551">Download link</translation>
-<translation id="1206892813135768548">Kopiér linktekst</translation>
-<translation id="1208340532756947324">Aktivér synkronisering for at synkronisere og tilpasse på alle dine enheder</translation>
-<translation id="1209206284964581585">Skjul indtil videre</translation>
-<translation id="1227058898775614466">Navigationsoversigt</translation>
-<translation id="1231733316453485619">Vil du aktivere synkronisering?</translation>
-<translation id="123724288017357924">Genindlæs aktuel side, og ignorer indhold gemt i cache</translation>
-<translation id="124116460088058876">Flere sprog</translation>
-<translation id="124678866338384709">Luk aktuel fane</translation>
-<translation id="1258753120186372309">Google-doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Søg, og udforsk</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Det var ikke muligt at dele <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Stop</translation>
-<translation id="1283039547216852943">Tryk for at udvide</translation>
-<translation id="1285320974508926690">Oversæt aldrig dette website</translation>
-<translation id="1291207594882862231">Ryd historik, cookies, websitedata, cache...</translation>
-<translation id="129382876167171263">Filer, der gemmes af websites, vises her</translation>
-<translation id="129553762522093515">Senest lukkede</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – sendt fra <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Gruppér faner</translation>
-<translation id="1327257854815634930">Navigationsoversigt er åbnet</translation>
-<translation id="1331212799747679585">Chrome kan ikke opdateres. Flere valgmuligheder</translation>
-<translation id="1332501820983677155">Funktionsgenveje i Google Chrome</translation>
-<translation id="1360432990279830238">Log ud, og deaktiver synkronisering?</translation>
-<translation id="1369915414381695676">Websitet <ph name="SITE_NAME" /> blev tilføjet</translation>
-<translation id="1373696734384179344">Der er ikke nok hukommelse til at downloade det valgte indhold.</translation>
-<translation id="1376578503827013741">Beregner…</translation>
-<translation id="1383876407941801731">Søg</translation>
-<translation id="1384959399684842514">Download er sat på pause</translation>
-<translation id="1386674309198842382">Aktiv for <ph name="LAST_UPDATED" /> dage siden</translation>
-<translation id="1397811292916898096">Søg med <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Integreret i <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"Do Not Track"</translation>
-<translation id="1407135791313364759">Åbn alle</translation>
-<translation id="1409426117486808224">Enkel visning af åbne faner</translation>
-<translation id="1409879593029778104">Download af <ph name="FILE_NAME" /> blev forhindret, fordi filen allerede findes.</translation>
-<translation id="1414981605391750300">Kontakter Google. Dette kan tage et øjeblik…</translation>
-<translation id="1416550906796893042">Appversion</translation>
-<translation id="1430915738399379752">Udskriv</translation>
-<translation id="1446450296470737166">Tillad fuld kontrol over MIDI-enheder</translation>
-<translation id="1450753235335490080">Delingen af <ph name="CONTENT_TYPE" /> mislykkedes</translation>
-<translation id="145097072038377568">Deaktiveret i indstillingerne for Android</translation>
-<translation id="1477626028522505441">Download af <ph name="FILE_NAME" /> mislykkedes på grund af serverproblemer.</translation>
-<translation id="1506061864768559482">Søgemaskine</translation>
-<translation id="1513352483775369820">Bogmærker og webhistorik</translation>
-<translation id="1513858653616922153">Slet adgangskoden</translation>
-<translation id="1516229014686355813">Funktionen "Tryk for at søge" sender det markerede ord og den aktuelle side som kontekst til Google Søgning. Du kan deaktivere funktionen i <ph name="BEGIN_LINK" />Indstillinger<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktiv i dag</translation>
-<translation id="1544826120773021464">Tryk på knappen "Administrer konto" for at administrere din Google-konto</translation>
-<translation id="1549000191223877751">Flyt til et andet vindue</translation>
-<translation id="1553358976309200471">Opdater Chrome</translation>
-<translation id="1569387923882100876">Tilsluttet enhed</translation>
-<translation id="1571304935088121812">Kopiér brugernavnet</translation>
-<translation id="1612196535745283361">Chrome skal have placeringsadgang for at kunne scanne efter enheder. Placeringsadgang er <ph name="BEGIN_LINK" />slået fra på denne enhed<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Undgå, at denne side opretter yderligere dialogbokse</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Fjern 1 valgt element}one{Fjern # valgt element}other{Fjern # valgte elementer}}</translation>
-<translation id="164269334534774161">Du ser en offlinekopi af denne side fra <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historik</translation>
-<translation id="1647391597548383849">Adgang til dit kamera</translation>
-<translation id="1660204651932907780">Tillad, at websites afspiller lyd (anbefales)</translation>
-<translation id="1670399744444387456">Grundlæggende</translation>
-<translation id="1671236975893690980">Download afventer…</translation>
-<translation id="1672586136351118594">Vis ikke igen</translation>
-<translation id="1692118695553449118">Synkronisering er slået til</translation>
-<translation id="169515064810179024">Bloker adgang til bevægelsessensorer på websites</translation>
-<translation id="1717218214683051432">Bevægelsessensorer</translation>
-<translation id="1718835860248848330">Den seneste time</translation>
-<translation id="1736419249208073774">Mere</translation>
-<translation id="1743802530341753419">Spørg, før websites opretter forbindelse til en enhed (anbefales)</translation>
-<translation id="1749561566933687563">Synkroniser dine bogmærker</translation>
-<translation id="17513872634828108">Åbne faner</translation>
-<translation id="1779089405699405702">Værktøj til afkodning af billeder</translation>
-<translation id="1782483593938241562">Slutdato <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installeret</translation>
-<translation id="1792959175193046959">Du kan til enhver tid skifte standardplaceringen for downloads</translation>
-<translation id="1807246157184219062">Lys</translation>
-<translation id="1810845389119482123">Indledende konfiguration af synkronisering er ikke afsluttet</translation>
-<translation id="1821253160463689938">Anvender cookies til at huske dine præferencer, også selvom du ikke besøger siderne</translation>
-<translation id="1829244130665387512">Find på siden</translation>
-<translation id="1853692000353488670">Ny inkognitofane</translation>
-<translation id="1856325424225101786">Vil du nulstille Lite-tilstand?</translation>
-<translation id="1868024384445905608">Chrome downloader nu filer endnu hurtigere</translation>
-<translation id="1883903952484604915">Mine filer</translation>
-<translation id="1887786770086287077">Placeringsadgang er deaktiveret for denne enhed. Aktivér det under <ph name="BEGIN_LINK" />indstillinger for Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> åbnes i Chrome. Når du fortsætter, accepterer du Chromes <ph name="BEGIN_LINK1" />servicevilkår<ph name="END_LINK1" /> og <ph name="BEGIN_LINK2" />erklæring om privatliv<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Annoncer</translation>
-<translation id="1919950603503897840">Vælg kontakter</translation>
-<translation id="1922076542920281912">Aktivér også placering i <ph name="BEGIN_LINK" />Android-indstillingerne<ph name="END_LINK" /> for at give Chrome adgang til din placering.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Opdateringer</translation>
-<translation id="19288952978244135">Åbn Chrome igen.</translation>
-<translation id="1933845786846280168">Valgt fane</translation>
-<translation id="194341124344773587">Aktivér tilladelse for Chrome i <ph name="BEGIN_LINK" />Android-indstillingerne<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Gem adgangskoder</translation>
-<translation id="1952172573699511566">Websites viser tekst på dit foretrukne sprog, når det er muligt.</translation>
-<translation id="1960290143419248813">Chrome understøtter ikke længere denne version af Android</translation>
-<translation id="1966710179511230534">Opdater dine loginoplysninger.</translation>
-<translation id="1974060860693918893">Avanceret</translation>
-<translation id="1984705450038014246">Synkroniser dine Chrome-data</translation>
-<translation id="1984937141057606926">Tilladt, undtagen tredjepartscookies</translation>
-<translation id="1986685561493779662">Navnet findes allerede</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" />-knap</translation>
-<translation id="1989112275319619282">Gennemse</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> vil gerne parre</translation>
-<translation id="1994173015038366702">Webadresse</translation>
-<translation id="2000419248597011803">Sender visse cookies og søgninger fra adresselinjen og søgefeltet til din standardsøgemaskine</translation>
-<translation id="2002537628803770967">Kreditkort og adresser fra Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fil}one{# fil}other{# filer}}</translation>
-<translation id="2017836877785168846">Nulstiller historikken og autofuldførelser i adresselinjen.</translation>
-<translation id="2021896219286479412">Kontrolelementer på website i fuld skærm</translation>
-<translation id="2038563949887743358">Slå computerversionen af websitet til</translation>
-<translation id="2041019821020695769">Aktivér også notifikationer i <ph name="BEGIN_LINK" />Android-indstillingerne<ph name="END_LINK" /> for at give Chrome tilladelse til at sende dig notifikationer.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> har også data i Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Websitet er sat på pause</translation>
-<translation id="2063713494490388661">Tryk for at søge</translation>
-<translation id="2067805253194386918">tekst</translation>
-<translation id="2079545284768500474">Fortryd</translation>
-<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER" /> af <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Lyd</translation>
-<translation id="2096012225669085171">Synkroniser og tilpas på flere enheder</translation>
-<translation id="2100273922101894616">Automatisk login</translation>
-<translation id="2100314319871056947">Prøv at opdele teksten i mindre stykker</translation>
-<translation id="2107397443965016585">Spørg, før websites får tilladelse til at afspille beskyttet indhold (anbefales)</translation>
-<translation id="2111511281910874386">Gå til side</translation>
-<translation id="2122601567107267586">Appen kunne ikke åbnes</translation>
-<translation id="2126426811489709554">Leveret af Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> sparet</translation>
-<translation id="213279576345780926">Lukkede <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Føj til startskærm</translation>
-<translation id="2146738493024040262">Åbn instant app</translation>
-<translation id="2148716181193084225">I dag</translation>
-<translation id="2154484045852737596">Rediger kort</translation>
-<translation id="2154710561487035718">Kopier webadresse</translation>
-<translation id="2156074688469523661">Tilbageværende websites (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Hvis du vil dele noget på din telefon med en anden enhed, kan du aktivere synkronisering i Chrome-indstillingerne på begge enheder</translation>
-<translation id="2170088579611075216">Tillad og start VR</translation>
-<translation id="218608176142494674">Deling</translation>
-<translation id="2227444325776770048">Fortsæt som <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synkronisering og Google-tjenester</translation>
-<translation id="2259659629660284697">Eksportér adgangskoder…</translation>
-<translation id="2268044343513325586">Juster</translation>
-<translation id="2286841657746966508">Faktureringsadresse</translation>
-<translation id="2289270750774289114">Spørg, når et website vil søge efter Bluetooth-enheder i nærheden (anbefalet)</translation>
-<translation id="230115972905494466">Der blev ikke fundet nogen kompatible enheder</translation>
-<translation id="2315043854645842844">Klientens certifikatvalg understøttes ikke af operativsystemet.</translation>
-<translation id="2318045970523081853">Tryk for at ringe op</translation>
-<translation id="2321086116217818302">Forbereder adgangskoder…</translation>
-<translation id="2321958826496381788">Træk i skyderen, indtil du kan nemt læse dette. Teksten som minimum have denne størrelse, når du har trykket to gange på et afsnit.</translation>
-<translation id="2323763861024343754">Websitelagerplads</translation>
-<translation id="2328985652426384049">Det er ikke muligt at logge ind</translation>
-<translation id="2330129964253841015">Få en underretning, hvis adgangskoder kompromitteres</translation>
-<translation id="2349710944427398404">Samlet mængde data, som Chrome anvender, herunder konti, bogmærker og gemte indstillinger</translation>
-<translation id="2353636109065292463">Tjekker din internetforbindelse</translation>
-<translation id="2359808026110333948">Fortsæt</translation>
-<translation id="2369533728426058518">åbne faner</translation>
-<translation id="2387895666653383613">Tekststørrelse</translation>
-<translation id="2394602618534698961">Her vises de filer, du downloader</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Når du logger ind på din Google-konto, er denne funktion aktiveret</translation>
-<translation id="2410754283952462441">Vælg en konto</translation>
-<translation id="2414886740292270097">Mørk</translation>
-<translation id="2416359993254398973">Chrome skal have tilladelse til at bruge dit kamera på dette website.</translation>
-<translation id="2426805022920575512">Vælg en anden konto</translation>
-<translation id="2433507940547922241">Udseende</translation>
-<translation id="2434158240863470628">Downloaden er fuldført <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Placeringsadgang</translation>
-<translation id="2450083983707403292">Vil du begynde at downloade <ph name="FILE_NAME" /> igen?</translation>
-<translation id="2482878487686419369">Notifikationer</translation>
-<translation id="2490684707762498678">Administreret af <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Assistent i Chrome</translation>
-<translation id="2496180316473517155">Browserhistorik</translation>
-<translation id="2497852260688568942">Synkronisering er deaktiveret af din administrator.</translation>
-<translation id="2498359688066513246">Hjælp og feedback</translation>
-<translation id="2501278716633472235">Gå tilbage</translation>
-<translation id="2513403576141822879">Du kan finde flere indstillinger vedrørende privatliv, sikkerhed og dataindsamling ved at gå til <ph name="BEGIN_LINK" />Synkronisering og Google-tjenester<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Chrome indlæser sider hurtigere og bruger op til 60 procent mindre data i Lite-tilstand. Chrome sender din webtrafik til Google for at optimere de sider, du besøger. <ph name="BEGIN_LINK" />Få flere oplysninger<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Sender webadresser på de sider, du besøger, til Google</translation>
-<translation id="2532336938189706096">Webvisning</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> elementer blev slettet</translation>
-<translation id="2536728043171574184">Du ser en offlinekopi af denne side</translation>
-<translation id="2546283357679194313">Cookies og websitedata</translation>
-<translation id="2567385386134582609">BILLEDE</translation>
-<translation id="257088987046510401">Temaer</translation>
-<translation id="2570922361219980984">Placeringsadgang er også deaktiveret for denne enhed. Aktivér det under <ph name="BEGIN_LINK" />indstillinger for Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Udvidet – klik for at skjule.</translation>
-<translation id="2581165646603367611">Dette rydder cookies, cache og andre data fra websites, som ikke er vigtige ifølge Chrome.</translation>
-<translation id="2586657967955657006">Udklipsholder</translation>
-<translation id="2587052924345400782">Der findes en nyere version</translation>
-<translation id="2593272815202181319">Enkelt tegnafstand</translation>
-<translation id="2612676031748830579">Kortnummer</translation>
-<translation id="2621115761605608342">Tillad JavaScript for et bestemt website.</translation>
-<translation id="2625189173221582860">Adgangskoden er kopieret</translation>
-<translation id="2631006050119455616">Sparet</translation>
-<translation id="2647434099613338025">Tilføj sprog</translation>
-<translation id="2650751991977523696">Vil du downloade filen igen?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# lydfil}one{# lydfil}other{# lydfiler}}</translation>
-<translation id="2653659639078652383">Indsend</translation>
-<translation id="2677748264148917807">Forlad</translation>
-<translation id="2704606927547763573">Kopieret</translation>
-<translation id="2707726405694321444">Opdater siden</translation>
-<translation id="2709516037105925701">AutoFyld</translation>
-<translation id="2717722538473713889">Mailadresser</translation>
-<translation id="2728754400939377704">Sortér efter website</translation>
-<translation id="2744248271121720757">Tryk på et ord for at søge øjeblikkeligt eller se relaterede handlinger</translation>
-<translation id="2760989362628427051">Aktivér mørkt tema, når enhedens mørke tema eller batterisparefunktion er aktiveret</translation>
-<translation id="2762000892062317888">lige nu</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> sekunder tilbage</translation>
-<translation id="2779651927720337254">mislykkedes</translation>
-<translation id="2781151931089541271">1 sekund tilbage</translation>
-<translation id="2801022321632964776">Opdater til den nyeste version af Chrome for at bruge dit eget sprog</translation>
-<translation id="2810645512293415242">Forenklet side, der sparer data og indlæses hurtigere.</translation>
-<translation id="281504910091592009">Se og administrer gemte adgangskoder på din <ph name="BEGIN_LINK" />Google-konto<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Log ind, og aktivér synkronisering for at få vist dine bogmærker på alle dine enheder</translation>
-<translation id="2822354292072154809">Er du sikker på, at du vil nulstille alle websitetilladelser for <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Tryk på tilbageknappen for at afslutte fuld skærm.</translation>
-<translation id="2842985007712546952">Overordnet mappe</translation>
-<translation id="2858138569776157458">Topwebsites</translation>
-<translation id="2860954141821109167">Sørg for, at opkaldsappen er aktiveret på denne enhed</translation>
-<translation id="2870560284913253234">Website</translation>
-<translation id="2874939134665556319">Forrige nummer</translation>
-<translation id="2876369937070532032">Sender webadresser på nogle sider, som du besøger, til Google, når din sikkerhed er truet</translation>
-<translation id="2888126860611144412">Om Chrome</translation>
-<translation id="2891154217021530873">Stop sideindlæsning</translation>
-<translation id="2893180576842394309">Google kan bruge din historik til at tilpasse Søgning og andre Google-tjenester</translation>
-<translation id="2898264748040935573">Rediger gemt adgangskode</translation>
-<translation id="2900528713135656174">Opret begivenhed</translation>
-<translation id="290376772003165898">Er siden ikke på <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Åben liste i fuld højde over enheder, der skal deles en fane med.</translation>
-<translation id="2910701580606108292">Spørg, før websites begynder at afspille beskyttet indhold</translation>
-<translation id="2913331724188855103">Tillad, at websites gemmer og læser cookiedata (anbefales)</translation>
-<translation id="2923908459366352541">Navnet er ugyldigt</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" />-lagerplads</translation>
-<translation id="2942036813789421260">Fanen forhåndsvisning er lukket</translation>
-<translation id="2956410042958133412">Denne konto administreres af <ph name="PARENT_NAME_1" /> og <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Skiftet til inkognitofaner</translation>
-<translation id="2968755619301702150">Certifikatfremviser</translation>
-<translation id="2979025552038692506">Valgt inkognitofane</translation>
-<translation id="2987620471460279764">Tekst, der er delt fra en anden enhed</translation>
-<translation id="2989523299700148168">Besøgt for nylig</translation>
-<translation id="2996291259634659425">Opret adgangssætning</translation>
-<translation id="2996809686854298943">En webadresse er påkrævet</translation>
-<translation id="300526633675317032">Dette rydder alle <ph name="SIZE_IN_KB" /> i websitelagerpladsen.</translation>
-<translation id="3016635187733453316">Sørg for, at din enhed har forbindelse til internettet</translation>
-<translation id="3029613699374795922">Der er downloadet <ph name="KBS" /> kB</translation>
-<translation id="3029704984691124060">Adgangssætningerne stemmer ikke overens</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Få hjælp<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Placering er slået fra. Du kan aktivere den i <ph name="BEGIN_LINK" />Android-indstillingerne<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Du kan til enhver tid aktivere synkronisering i indstillingerne</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> bogmærke}one{<ph name="BOOKMARKS_COUNT_MANY" />bogmærke}other{<ph name="BOOKMARKS_COUNT_MANY" />bogmærker}}</translation>
-<translation id="3089395242580810162">Åbn på inkognitofane</translation>
-<translation id="3115898365077584848">Vis info</translation>
-<translation id="3123473560110926937">Blokeret på visse websites</translation>
-<translation id="3137521801621304719">Slå inkognitotilstand fra</translation>
-<translation id="3143515551205905069">Annuller synkronisering</translation>
-<translation id="3157842584138209013">Se, hvor meget data du har sparet via knappen Flere valgmuligheder</translation>
-<translation id="3166827708714933426">Genveje på faner og i vinduer</translation>
-<translation id="3181954750937456830">Beskyttet browsing (beskytter dig og din enhed mod farlige websites)</translation>
-<translation id="3190152372525844641">Aktivér tilladelser for Chrome i <ph name="BEGIN_LINK" />Android-indstillingerne<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> gemte data</translation>
-<translation id="3205824638308738187">Du er næsten færdig.</translation>
-<translation id="3207960819495026254">Gemt som bogmærke</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> blev slettet</translation>
-<translation id="321773570071367578">Hvis du har glemt din adgangssætning eller vil ændre denne indstilling, skal du <ph name="BEGIN_LINK" />nulstille synkroniseringen<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Webapp</translation>
-<translation id="3236059992281584593">1 minut tilbage</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Tilføj denne side som bogmærke</translation>
-<translation id="3259831549858767975">Gør alting på siden mindre</translation>
-<translation id="3269093882174072735">Indlæs billede</translation>
-<translation id="3269956123044984603">Aktivér "Automatisk synkronisering af data" i kontoindstillingerne for Android for at få adgang til dine faner på dine andre enheder.</translation>
-<translation id="3277252321222022663">Tillad, at websites kan få adgang til sensorer (anbefales)</translation>
-<translation id="3282568296779691940">Log ind i Chrome</translation>
-<translation id="3288003805934695103">Genindlæse siden</translation>
-<translation id="32895400574683172">Notifikationer er tilladt</translation>
-<translation id="3295530008794733555">Få hurtigere browsing. Brug mindre data.</translation>
-<translation id="3295602654194328831">Skjul oplysninger</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Vil du fortsætte og downloade indholdet?</translation>
-<translation id="3306398118552023113">Denne app kører i Chrome</translation>
-<translation id="3315103659806849044">Du tilpasser i øjeblikket dine indstillinger for Synkronisering og Google-tjenester. Afslut aktiveringen af synkronisering ved at trykke på knappen Bekræft nederst på skærmen. Gå op</translation>
-<translation id="3328801116991980348">Webstedoplysninger</translation>
-<translation id="3333961966071413176">Alle kontakter</translation>
-<translation id="3334729583274622784">Vil du ændre filtypen?</translation>
-<translation id="3341058695485821946">Se, hvor meget data du har sparet</translation>
-<translation id="3350687908700087792">Luk alle inkognitofaner</translation>
-<translation id="3353615205017136254">Lite-side leveret af Google. Tryk på knappen Indlæs original for at indlæse den originale side.</translation>
-<translation id="3367813778245106622">Log ind igen for at starte synkroniseringen</translation>
-<translation id="3374023511497244703">Din historik samt dine bogmærker, adgangskoder og andre Chrome-data synkroniseres ikke længere med din Google-konto</translation>
-<translation id="3384347053049321195">Del billede</translation>
-<translation id="3386292677130313581">Spørg, om websites må få adgang til din placering (anbefales)</translation>
-<translation id="3387650086002190359">Download af <ph name="FILE_NAME" /> mislykkedes på grund af fejl i filsystemet.</translation>
-<translation id="3389286852084373014">Teksten er for lang</translation>
-<translation id="3398320232533725830">Åbn bogmærkeadministratoren</translation>
-<translation id="3414952576877147120">Størrelse:</translation>
-<translation id="3443221991560634068">Genindlæs den aktuelle side</translation>
-<translation id="3445014427084483498">Lige nu</translation>
-<translation id="3478363558367712427">Du kan vælge din søgemaskine</translation>
+<translation id="6910211073230771657">Slettet</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, det er forstået</translation>
+<translation id="7658239707568436148">Annuller</translation>
 <translation id="3479552764303398839">Ikke nu</translation>
-<translation id="3492207499832628349">Ny inkognitofane</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Få flere oplysninger<ph name="END_LINK" /> om anbefalet indhold</translation>
-<translation id="3513704683820682405">Augmented reality</translation>
-<translation id="3518985090088779359">Acceptér og fortsæt</translation>
-<translation id="3522247891732774234">Tilgængelig opdatering. Flere muligheder</translation>
-<translation id="3524138585025253783">Brugerflade for udviklere</translation>
-<translation id="3527085408025491307">Mappe</translation>
-<translation id="3542235761944717775">Der er <ph name="KILOBYTES" /> kB til rådighed</translation>
-<translation id="3549657413697417275">Søg i din historik</translation>
-<translation id="3557336313807607643">Føj til kontakter</translation>
-<translation id="3566923219790363270">Chrome er stadig i gang med at forberede VR. Genstart Chrome senere.</translation>
-<translation id="3568688522516854065">Log ind, og aktivér synkronisering for at få adgang til dine faner på dine andre enheder</translation>
-<translation id="3587482841069643663">Alle</translation>
-<translation id="358794129225322306">Tillad, at et website kan downloade flere filer automatisk.</translation>
-<translation id="3590487821116122040">Websitelagerplads, som ikke er vigtig ifølge Chrome (f.eks. websites uden gemte indstillinger eller websites, du ikke besøger så ofte)</translation>
-<translation id="3599863153486145794">Rydder historikken på alle enheder, hvor du er logget ind. Din Google-konto kan have andre former for browserhistorik på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Lyden slås fra for websites, der afspiller lyd</translation>
-<translation id="3616113530831147358">Lyd</translation>
-<translation id="3631987586758005671">Deler med <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Vis adgangskoden</translation>
-<translation id="363596933471559332">Log automatisk ind på websites med gemte loginoplysninger. Når funktionen er slået fra, bliver du bedt om at bekræfte, hver gang du vil logge ind på et website.</translation>
-<translation id="3658159451045945436">En nulstilling sletter din historik for databesparelser, herunder listen over de websites, du har besøgt.</translation>
-<translation id="3692944402865947621"><ph name="FILE_NAME" /> blev ikke downloadet, da lagerplaceringen ikke er tilgængelig.</translation>
-<translation id="3714981814255182093">Åbn søgefeltet</translation>
-<translation id="3716182511346448902">Denne side anvender for meget hukommelse, så Chrome har sat den på pause.</translation>
-<translation id="3730075448226062617">Aktivér også din mikrofon i <ph name="BEGIN_LINK" />Android-indstillingerne<ph name="END_LINK" /> for at give Chrome adgang til mikrofonen.</translation>
-<translation id="3739899004075612870">Tilføjet som bogmærke i <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Synkronisering i baggrunden</translation>
-<translation id="3771001275138982843">Opdateringen kunne ikke downloades</translation>
-<translation id="3771033907050503522">Inkognitofaner</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Slå Bluetooth til<ph name="END_LINK" /> for at tillade parring</translation>
-<translation id="3775705724665058594">Send til dine enheder</translation>
-<translation id="3778956594442850293">Føjet til startskærmen</translation>
-<translation id="3789841737615482174">Installer</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Valgmuligheder</translation>
-<translation id="381841723434055211">Telefonnumre</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> downloads blev slettet</translation>
-<translation id="3822502789641063741">Vil du rydde websitelagerpladsen?</translation>
-<translation id="385051799172605136">Tilbage</translation>
-<translation id="3859306556332390985">Spol fremad</translation>
-<translation id="3894427358181296146">Tilføj mappe</translation>
-<translation id="3895926599014793903">Tving aktivering af zoom</translation>
-<translation id="3912508018559818924">Finder det bedste fra nettet…</translation>
-<translation id="3927692899758076493">Sans serif</translation>
-<translation id="3928666092801078803">Kombiner mine data</translation>
-<translation id="393697183122708255">Aktiveret talesøgning ikke tilgængelig</translation>
-<translation id="395206256282351086">Søge- og websiteforslag er deaktiveret</translation>
-<translation id="3955193568934677022">Tillad, at websites afspiller beskyttet indhold (anbefales)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome indlæser din side, når det er muligt}one{Chrome indlæser din side, når det er muligt}other{Chrome indlæser dine sider, når det er muligt}}</translation>
-<translation id="3963007978381181125">Kryptering med adgangssætning omfatter ikke betalingsmetoder og adresser fra Google Pay. Det er kun personer med din adgangssætning, der kan læse dine krypterede data. Adgangssætningen sendes ikke til eller gemmes af Google. Hvis du glemmer din adgangssætning eller vil ændre denne indstilling, skal du nulstille synkronisering. <ph name="BEGIN_LINK" />Få flere oplysninger<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Download fuldført</translation>
-<translation id="397583555483684758">Synkroniseringen fungerer ikke mere</translation>
-<translation id="3976396876660209797">Fjern og genskab denne genvej</translation>
-<translation id="3985215325736559418">Vil du downloade <ph name="FILE_NAME" /> igen?</translation>
-<translation id="3987993985790029246">Kopiér linket</translation>
-<translation id="3988213473815854515">Placeringen er tilladt</translation>
-<translation id="3988466920954086464">Se direkte søgeresultater i dette panel</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Lagerplads, der ikke er vigtig</translation>
-<translation id="4000212216660919741">Hjemmet er offline</translation>
+<translation id="5317780077021120954">Gem</translation>
+<translation id="4570913071927164677">Info</translation>
+<translation id="8730621377337864115">Udfør</translation>
+<translation id="8261506727792406068">Slet</translation>
+<translation id="1181037720776840403">Fjern</translation>
+<translation id="5939518447894949180">Nulstil</translation>
 <translation id="4002066346123236978">Titel</translation>
-<translation id="4008040567710660924">Tillad cookies for et bestemt website.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# t.}one{# t.}other{# t.}}</translation>
-<translation id="4046123991198612571">Næste nummer</translation>
-<translation id="4048707525896921369">Få oplysninger om emner på websites uden at forlade siden. "Tryk for at søge" sender et ord og ordets kontekst til Google Søgning og giver dig definitioner, billeder, søgeresultater og andre oplysninger.
+<translation id="5916664084637901428">Til</translation>
+<translation id="5860033963881614850">Fra</translation>
+<translation id="6165508094623778733">Flere oplysninger</translation>
+<translation id="6042308850641462728">Mere</translation>
+<translation id="6040143037577758943">Luk</translation>
+<translation id="780301667611848630">Nej tak</translation>
+<translation id="1201402288615127009">Næste</translation>
+<translation id="2359808026110333948">Fortsæt</translation>
+<translation id="2653659639078652383">Indsend</translation>
+<translation id="2079545284768500474">Fortryd</translation>
+<translation id="7649070708921625228">Hjælp</translation>
+<translation id="2148716181193084225">I dag</translation>
+<translation id="7781829728241885113">I går</translation>
+<translation id="6945221475159498467">Vælg</translation>
+<translation id="7791543448312431591">Tilføj</translation>
+<translation id="6527303717912515753">Del</translation>
+<translation id="1383876407941801731">Søg</translation>
+<translation id="3115898365077584848">Vis info</translation>
+<translation id="3295602654194328831">Skjul oplysninger</translation>
+<translation id="3987993985790029246">Kopiér linket</translation>
+<translation id="2704606927547763573">Kopieret</translation>
+<translation id="8725066075913043281">Forsøg igen</translation>
+<translation id="385051799172605136">Tilbage</translation>
+<translation id="8131740175452115882">Bekræft</translation>
+<translation id="5300589172476337783">Vis</translation>
+<translation id="1124772482545689468">Bruger</translation>
+<translation id="8609465669617005112">Flyt op</translation>
+<translation id="6746124502594467657">Flyt ned</translation>
+<translation id="8249310407154411074">Flyt til toppen</translation>
+<translation id="8428213095426709021">Indstillinger</translation>
+<translation id="2498359688066513246">Hjælp og feedback</translation>
+<translation id="8378714024927312812">Administreret af din organisation</translation>
+<translation id="9019902583201351841">Administreret af dine forældre</translation>
+<translation id="4645575059429386691">Administreret af en af dine forældre</translation>
+<translation id="4883854917563148705">Administrerede indstillinger kan ikke nulstilles</translation>
+<translation id="4307992518367153382">Grundlæggende valgmuligheder</translation>
+<translation id="1974060860693918893">Avanceret</translation>
+<translation id="1146678959555564648">Angiv VR</translation>
+<translation id="987264212798334818">Generelt</translation>
+<translation id="4275663329226226506">Medier</translation>
+<translation id="4759238208242260848">Downloads</translation>
+<translation id="218608176142494674">Deling</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Screenshot</translation>
+<translation id="4875775213178255010">Indholdsforslag</translation>
+<translation id="2021896219286479412">Kontrolelementer på website i fuld skærm</translation>
+<translation id="4587589328781138893">Websites</translation>
+<translation id="4943703118917034429">Virtual reality</translation>
+<translation id="1928696683969751773">Opdateringer</translation>
+<translation id="6064125863973209585">Gennemførte downloads</translation>
+<translation id="5342314432463739672">Anmodninger om tilladelse</translation>
+<translation id="629730747756840877">Konto</translation>
+<translation id="82609232232243542">Log ind i Brave</translation>
+<translation id="7956662517480676674">Synkronisering og Brave Software-tjenester</translation>
+<translation id="5294439808117722387">Du tilpasser i øjeblikket dine indstillinger for Synkronisering og Brave Software-tjenester. Afslut aktiveringen af synkronisering ved at trykke på knappen Bekræft nederst på skærmen. Gå op</translation>
+<translation id="2096012225669085171">Synkroniser og tilpas på flere enheder</translation>
+<translation id="1692118695553449118">Synkronisering er slået til</translation>
+<translation id="5514904542973294328">Deaktiveret af administratoren af denne enhed</translation>
+<translation id="6447211988989208781">Aktivitetsadministration på Brave Software</translation>
+<translation id="4882831918239250449">Styr, hvordan din browserhistorik anvendes til at tilpasse søgeresultater, annoncer og meget mere</translation>
+<translation id="7431991332293347422">Bestem selv, hvordan din browserhistorik skal bruges til at tilpasse søgeresultater m.m.</translation>
+<translation id="6303969859164067831">Log ud, og deaktiver synkronisering</translation>
+<translation id="1125261911132334651">Administrer din Brave Software-konto</translation>
+<translation id="6406506848690869874">Synkronisering</translation>
+<translation id="714362445477979774">Synkroniser dine Brave-data</translation>
+<translation id="4314815835985389558">Administrer synkronisering</translation>
+<translation id="5428209950370661546">Andre Brave Software-tjenester</translation>
+<translation id="7704317875155739195">Autofuldfør søgninger og webadresser</translation>
+<translation id="2000419248597011803">Sender visse cookies og søgninger fra adresselinjen og søgefeltet til din standardsøgemaskine</translation>
+<translation id="7981313251711023384">Forudindlæs sider, så du kan browse og søge hurtigere</translation>
+<translation id="1821253160463689938">Anvender cookies til at huske dine præferencer, også selvom du ikke besøger siderne</translation>
+<translation id="6697492270171225480">Se forslag til lignende sider, når en side ikke kan findes</translation>
+<translation id="8109318360573330108">Sender webadressen på en side, du forsøger at åbne, til Brave Software</translation>
+<translation id="8438566539970814960">Gør søgninger og browsing endnu bedre</translation>
+<translation id="284843628681142937">Sender webadresser på de sider, du besøger, til Brave Software</translation>
+<translation id="7222718784508482526">Du kan finde flere indstillinger vedrørende privatliv, sikkerhed og dataindsamling ved at gå til <ph name="BEGIN_LINK"/>Synkronisering og Brave Software-tjenester<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Vær med til at forbedre Braves funktioner og ydeevne</translation>
+<translation id="9063160602596686558">Sender automatisk brugsstatistikker og nedbrudsrapporter til Brave Software</translation>
+<translation id="4824958205181053313">Vil du annullere synkroniseringen?</translation>
+<translation id="3058498974290601450">Du kan til enhver tid aktivere synkronisering i indstillingerne</translation>
+<translation id="3143515551205905069">Annuller synkronisering</translation>
+<translation id="1506061864768559482">Søgemaskine</translation>
+<translation id="55737423895878184">Placering og notifikationer er tilladt</translation>
+<translation id="3988213473815854515">Placeringen er tilladt</translation>
+<translation id="32895400574683172">Notifikationer er tilladt</translation>
+<translation id="9040142327097499898">Notifikationer er tilladt. Placering er deaktiveret for denne enhed.</translation>
+<translation id="305593374596241526">Placering er slået fra. Du kan aktivere den i <ph name="BEGIN_LINK"/>Android-indstillingerne<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Besøgt for nylig</translation>
+<translation id="6433501201775827830">Vælg en søgemaskine</translation>
+<translation id="7177466738963138057">Du kan ændre dette senere i Indstillinger</translation>
+<translation id="3478363558367712427">Du kan vælge din søgemaskine</translation>
+<translation id="4910889077668685004">Betalingsapps</translation>
+<translation id="5152843274749979095">Der er ikke installeret nogen understøttede apps</translation>
+<translation id="8812260976093120287">På nogle websites kan du betale med ovenstående understøttede betalingsapps på din enhed.</translation>
+<translation id="7764225426217299476">Tilføj adresse</translation>
+<translation id="5595485650161345191">Rediger adresse</translation>
+<translation id="5087580092889165836">Tilføj kort</translation>
+<translation id="2154484045852737596">Rediger kort</translation>
+<translation id="6140912465461743537">Land/region</translation>
+<translation id="5659593005791499971">Mail</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Navn på kort</translation>
+<translation id="860043288473659153">Kortholderens navn</translation>
+<translation id="2612676031748830579">Kortnummer</translation>
+<translation id="869891660844655955">Udløbsdato</translation>
+<translation id="2286841657746966508">Faktureringsadresse</translation>
+<translation id="663059986967017181">Kopieret til Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> mere}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> mere}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> mere}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> mere}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> mere}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> mere}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> mere}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> mere}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> mere}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> mere}one{<ph name="CONTACT_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> mere}other{<ph name="CONTACT_PREVIEW"/>\u2026 og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> mere}}</translation>
+<translation id="7029809446516969842">Adgangskoder</translation>
+<translation id="1943432128510653496">Gem adgangskoder</translation>
+<translation id="2100273922101894616">Automatisk login</translation>
+<translation id="363596933471559332">Log automatisk ind på websites med gemte loginoplysninger. Når funktionen er slået fra, bliver du bedt om at bekræfte, hver gang du vil logge ind på et website.</translation>
+<translation id="6995899638241819463">Få en underretning, hvis adgangskoder afsløres i forbindelse med et brud på datasikkerheden</translation>
+<translation id="1534287762301776620">Når du logger ind på din Brave Software-konto, er denne funktion aktiveret</translation>
+<translation id="10614374240317010">Gemmes aldrig</translation>
+<translation id="3098842761938485917">Se og administrer gemte adgangskoder på din <ph name="BEGIN_LINK"/>Brave Software-konto<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Dine gemte adgangskoder vises her.</translation>
+<translation id="8084114998886531721">Gemt adgangskode</translation>
+<translation id="2870560284913253234">Website</translation>
+<translation id="8503813439785031346">Brugernavn</translation>
+<translation id="6657585470893396449">Adgangskode</translation>
+<translation id="2154710561487035718">Kopier webadresse</translation>
+<translation id="1571304935088121812">Kopiér brugernavnet</translation>
+<translation id="5005498671520578047">Kopiér adgangskode</translation>
+<translation id="3632295766818638029">Vis adgangskoden</translation>
+<translation id="1513858653616922153">Slet adgangskoden</translation>
+<translation id="543338862236136125">Rediger adgangskode</translation>
+<translation id="4565377596337484307">Skjul adgangskode</translation>
+<translation id="8523928698583292556">Slet den gemte adgangskode</translation>
+<translation id="2898264748040935573">Rediger gemt adgangskode</translation>
+<translation id="5433691172869980887">Brugernavnet er kopieret</translation>
+<translation id="5534640966246046842">Websitet er kopieret</translation>
+<translation id="2625189173221582860">Adgangskoden er kopieret</translation>
+<translation id="4550003330909367850">Indstil en skærmlås på denne enhed for at se eller kopiere din adgangkode her.</translation>
+<translation id="6154478581116148741">Aktivér skærmlåsen i Indstillinger for at eksportere dine adgangskoder fra denne enhed</translation>
+<translation id="4842092870884894799">Viser pop op for generering af adgangskoder</translation>
+<translation id="2259659629660284697">Eksportér adgangskoder…</translation>
+<translation id="133012818630824069">Eksportér adgangskoder, der er gemt med Brave</translation>
+<translation id="6914783257214138813">Dine adgangskoder vil være synlige for alle, der kan se den eksporterede fil.</translation>
+<translation id="2321086116217818302">Forbereder adgangskoder…</translation>
+<translation id="8445448999790540984">Der kan ikke eksporteres adgangskoder</translation>
+<translation id="3066461326500799725">Få oplysninger om, hvordan du bruger Brave Software Drev</translation>
+<translation id="729975465115245577">Der er ikke nogen app på din enhed, hvor filen med adgangskoder kan gemmes.</translation>
+<translation id="7682724950699840886">Prøv følgende tips: Sørg for, at der er nok ledig plads på din enhed, og prøv at eksportere igen.</translation>
+<translation id="1129510026454351943">Info: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Lås op for at kopiere din adgangskode</translation>
+<translation id="5515439363601853141">Lås op for at se din adgangskode</translation>
+<translation id="6221633008163990886">Lås op for at eksportere dine adgangskoder</translation>
+<translation id="230699814587342492">Brave-adgangskoder</translation>
+<translation id="6075798973483050474">Rediger startside</translation>
+<translation id="854522910157234410">Åbn denne side</translation>
+<translation id="2482878487686419369">Notifikationer</translation>
+<translation id="6255999984061454636">Indholdsforslag</translation>
+<translation id="805047784848435650">Baseret på din browserhistorik</translation>
+<translation id="1041308826830691739">Fra websites</translation>
+<translation id="395206256282351086">Søge- og websiteforslag er deaktiveret</translation>
+<translation id="257088987046510401">Temaer</translation>
+<translation id="4650364565596261010">Systemstandard</translation>
+<translation id="7588219262685291874">Aktivér mørkt tema, når enhedens batterisparefunktion er aktiveret</translation>
+<translation id="2760989362628427051">Aktivér mørkt tema, når enhedens mørke tema eller batterisparefunktion er aktiveret</translation>
+<translation id="6381421346744604172">Gør websites mørkere</translation>
+<translation id="5040262127954254034">Privatliv</translation>
+<translation id="4991384657077828949">Hjælp med at forbedre sikkerheden i Brave</translation>
+<translation id="1943176487615318915">Brave sender webadresser på nogle sider, du besøger, begrænsede systemoplysninger og noget sideindhold til Brave Software med henblik på at registrere farlige apps og websites.</translation>
+<translation id="3181954750937456830">Beskyttet browsing (beskytter dig og din enhed mod farlige websites)</translation>
+<translation id="7315322926489145388">Sender webadresser på nogle sider, som du besøger, til Brave Software, når din sikkerhed er truet</translation>
+<translation id="2063713494490388661">Tryk for at søge</translation>
+<translation id="2369463299479365221">Få oplysninger om emner på websites uden at forlade siden. "Tryk for at søge" sender et ord og ordets kontekst til Brave Software Søgning og giver dig definitioner, billeder, søgeresultater og andre oplysninger.
 
 Tryk længe på din søgeterm for at vælge den og tilpasse den. Du kan afgrænse din søgning ved at trække panelet helt op og trykke i søgefeltet.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Du finder de tilgængelige valgmuligheder øverst på skærmen</translation>
-<translation id="4062305924942672200">Juridiske oplysninger</translation>
-<translation id="4084682180776658562">Bogmærke</translation>
-<translation id="4084712963632273211">Fra <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />leveret af Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Vil du slette appdata?</translation>
-<translation id="4099578267706723511">Vær med til at gøre Chrome bedre ved at sende brugsstatistik og nedbrudsrapporter til Google.</translation>
-<translation id="410351446219883937">Autoplay</translation>
-<translation id="4116038641877404294">Download sider for at bruge dem, når du er offline</translation>
-<translation id="4135200667068010335">Lukket liste over enheder, der skal deles en fane med.</translation>
-<translation id="4149994727733219643">Enkel visning af websider</translation>
-<translation id="4165986682804962316">Indstillinger for websites</translation>
-<translation id="4169535189173047238">Tillad ikke</translation>
-<translation id="4170011742729630528">Tjenesten er ikke tilgængelig. Prøv igen senere.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> er brugt</translation>
-<translation id="4181841719683918333">Sprog</translation>
-<translation id="4183868528246477015">Søg med Google Lens <ph name="BEGIN_NEW" />Nyhed<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Åbn på ny fane</translation>
-<translation id="4198423547019359126">Der er ingen tilgængelige downloadplaceringer</translation>
-<translation id="4209895695669353772">Aktivér synkronisering for at hente brugertilpasset indhold, som er foreslået af Google</translation>
-<translation id="4226663524361240545">Notifikationer kan få enheden til at vibrere</translation>
-<translation id="423219824432660969">Kryptér synkroniserede data med Google-adgangskoden fra <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Åbn Indstillinger</translation>
-<translation id="4256782883801055595">Open source-licenser</translation>
-<translation id="4259722352634471385">Navigationen er blokeret: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopiér linkadresse</translation>
-<translation id="4275663329226226506">Medier</translation>
-<translation id="4278390842282768270">Tilladt</translation>
-<translation id="429312253194641664">Et website afspiller medier</translation>
-<translation id="4298388696830689168">Tilknyttede websites</translation>
-<translation id="4307992518367153382">Grundlæggende valgmuligheder</translation>
-<translation id="4314815835985389558">Administrer synkronisering</translation>
-<translation id="4351244548802238354">Luk dialogboksen</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Søgning via Sogou</translation>
-<translation id="4404568932422911380">Der er ingen bogmærker</translation>
-<translation id="4405224443901389797">Flyt til…</translation>
-<translation id="4411535500181276704">Lite-tilstand</translation>
-<translation id="4415276339145661267">Administrer din Google-konto</translation>
-<translation id="4432792777822557199">Sider på <ph name="SOURCE_LANGUAGE" /> oversættes fremover til <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Lite-side leveret af Google</translation>
-<translation id="4434045419905280838">Pop op-vinduer og omdirigeringer</translation>
-<translation id="4440958355523780886">Lite-side leveret af Google. Tryk for at indlæse originalen.</translation>
-<translation id="4452411734226507615">Luk fanen <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Bogmærket er gemt i <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Tillad, at websites afspiller beskyttet indhold</translation>
-<translation id="4468959413250150279">Slå lyden fra for et bestemt website.</translation>
-<translation id="4472118726404937099">Log ind, og aktivér synkronisering for at synkronisere og tilpasse på alle dine enheder</translation>
-<translation id="447252321002412580">Vær med til at forbedre Chromes funktioner og ydeevne</translation>
-<translation id="4479647676395637221">Spørg, før websites bruger dit kamera (anbefales)</translation>
-<translation id="4479972344484327217">Installerer <ph name="MODULE" /> til Chrome…</translation>
-<translation id="4487967297491345095">Alle Chromes appdata slettes permanent. Dette omfatter alle filer, indstillinger, konti, databaser osv.</translation>
-<translation id="4493497663118223949">Lite-tilstand er aktiveret</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{For 1 dag siden}one{For # dag siden}other{For # dage siden}}</translation>
-<translation id="451872707440238414">Søg i dine bogmærker</translation>
-<translation id="4521489764227272523">De valgte data er fjernet fra Chrome og synkroniserede enheder.
-
-Din Google-konto kan have andre former for browserhistorik, f.eks. søgninger og aktivitet fra andre Google-tjenester, på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Vælg mappe</translation>
-<translation id="4538018662093857852">Aktivér Lite-tilstand</translation>
-<translation id="4550003330909367850">Indstil en skærmlås på denne enhed for at se eller kopiere din adgangkode her.</translation>
-<translation id="4558311620361989323">Genveje på websider</translation>
-<translation id="4561979708150884304">Der er ingen forbindelse</translation>
-<translation id="4565377596337484307">Skjul adgangskode</translation>
-<translation id="4570913071927164677">Info</translation>
-<translation id="4572422548854449519">Log ind på mangerstyret konto</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{For # minut siden}one{For # minut siden}other{For # minutter siden}}</translation>
-<translation id="4587589328781138893">Websites</translation>
-<translation id="4594952190837476234">Denne offlineside er fra <ph name="CREATION_TIME" /> og kan afvige fra onlineversionen.</translation>
-<translation id="4605958867780575332">Element fjernet: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Åbn <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Brug adgangskode</translation>
-<translation id="4645575059429386691">Administreret af en af dine forældre</translation>
-<translation id="4650364565596261010">Systemstandard</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> bogmærker blev slettet</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> blev føjet til din startskærm</translation>
-<translation id="4684427112815847243">Synkroniser alt</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> mere}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> mere}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> mere}}</translation>
-<translation id="4696983787092045100">Send sms til dine enheder</translation>
-<translation id="4698034686595694889">Se offline i <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Billeder og filer, der er gemt i cache</translation>
-<translation id="4714588616299687897">Spar op til 60 % af dine data</translation>
-<translation id="4719927025381752090">Tilbyd at oversætte</translation>
-<translation id="4720023427747327413">Åbn i <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Vær med til at forbedre Chrome. <ph name="BEGIN_LINK" />Deltag i undersøgelsen<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Opdater</translation>
-<translation id="4738836084190194332">Seneste synkronisering: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Åbn en ny fane</translation>
-<translation id="4751476147751820511">Bevægelses- eller lyssensorer</translation>
-<translation id="4759238208242260848">Downloads</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download er fuldført.}one{# download er fuldført.}other{# downloads er fuldført.}}</translation>
-<translation id="4797039098279997504">Tryk for at gå tilbage til <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Kryptering med adgangssætning omfatter ikke betalingsmetoder og adresser fra Google Pay.
-
-Hvis du vil ændre denne indstilling, skal du <ph name="BEGIN_LINK" />nulstille synkronisering<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Navn på kort</translation>
-<translation id="4824958205181053313">Vil du annullere synkroniseringen?</translation>
-<translation id="4837753911714442426">Åbn valgmuligheder for udskrivning af siden</translation>
-<translation id="4842092870884894799">Viser pop op for generering af adgangskoder</translation>
-<translation id="4860895144060829044">Ring op</translation>
-<translation id="4866368707455379617"><ph name="MODULE" /> kunne ikke installeres til Chrome</translation>
-<translation id="4875775213178255010">Indholdsforslag</translation>
-<translation id="4878404682131129617">Der kunne ikke etableres en tunnel via proxyserver</translation>
-<translation id="4880127995492972015">Oversæt…</translation>
-<translation id="4881695831933465202">Åbn</translation>
-<translation id="488187801263602086">Omdøb fil</translation>
-<translation id="4882831918239250449">Styr, hvordan din browserhistorik anvendes til at tilpasse søgeresultater, annoncer og meget mere</translation>
-<translation id="4883854917563148705">Administrerede indstillinger kan ikke nulstilles</translation>
-<translation id="4885273946141277891">Der er flere forekomster af Chrome, end der understøttes.</translation>
-<translation id="4910889077668685004">Betalingsapps</translation>
-<translation id="4913161338056004800">Nulstil statistik</translation>
-<translation id="4913169188695071480">Stop med at opdatere</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Få hjælp<ph name="END_LINK" />, mens der scannes efter enheder…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# side}one{# side}other{# sider}}</translation>
-<translation id="4932247056774066048">Da du er ved at logge ud af en konto, der administreres af <ph name="DOMAIN_NAME" />, slettes dine Chrome-data fra denne enhed. Dataene vil stadig være at finde på din Google-konto.</translation>
-<translation id="4943703118917034429">Virtual reality</translation>
-<translation id="4943872375798546930">Ingen resultater</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> deler din skærm</translation>
-<translation id="4961107849584082341">Oversæt denne side til et hvilket som helst sprog</translation>
-<translation id="4962975101802056554">Tilbagekald alle tilladelser for enheden</translation>
-<translation id="4970824347203572753">Ikke tilgængelig på din placering</translation>
-<translation id="497421865427891073">Gå fremad</translation>
-<translation id="4988210275050210843">Downloader fil (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Sider</translation>
-<translation id="4994033804516042629">Der blev ikke fundet nogen kontakter</translation>
-<translation id="4996978546172906250">Del via</translation>
-<translation id="5004416275253351869">Aktivitetsadministration på Google</translation>
-<translation id="5005498671520578047">Kopiér adgangskode</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> vil gerne oprette forbindelse</translation>
-<translation id="5013696553129441713">Der er ingen nye forslag</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Mens du er i VR, kan dette website muligvis få oplysninger om:
-  –  Dine fysiske træk som f.eks. højde
-
-Sørg for, at du har tillid til dette website, før du starter VR.</translation>
+<translation id="2930742481329940825">Funktionen "Tryk for at søge" sender det markerede ord og den aktuelle side som kontekst til Brave Software Søgning. Du kan deaktivere funktionen i <ph name="BEGIN_LINK"/>Indstillinger<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Tillad</translation>
-<translation id="5040262127954254034">Privatliv</translation>
-<translation id="5048398596102334565">Tillad, at websites kan få adgang til bevægelsessensorer (anbefales)</translation>
-<translation id="5063480226653192405">Databrug</translation>
-<translation id="5087580092889165836">Tilføj kort</translation>
-<translation id="5100237604440890931">Skjult – klik for at udvide.</translation>
-<translation id="510275257476243843">1 time tilbage</translation>
-<translation id="5123685120097942451">Inkognitofane</translation>
-<translation id="5127805178023152808">Synkronisering er slået fra</translation>
-<translation id="5129038482087801250">Installer webapp</translation>
-<translation id="5132942445612118989">Synkroniser dine adgangskoder, din historik og meget mere på alle enheder</translation>
-<translation id="5139940364318403933">Få oplysninger om, hvordan du bruger Google Drev</translation>
-<translation id="515227803646670480">Ryd lagrede data</translation>
-<translation id="5152843274749979095">Der er ikke installeret nogen understøttede apps</translation>
-<translation id="5161254044473106830">Der skal angives en titel</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download mislykkedes.}one{# download mislykkedes.}other{# downloads mislykkedes.}}</translation>
-<translation id="5170568018924773124">Vis i mappe</translation>
-<translation id="5184329579814168207">Åbn i Chrome</translation>
-<translation id="5193988420012215838">Kopieret til din udklipsholder</translation>
-<translation id="5197729504361054390">De kontakter, du vælger, deles med <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Arbejdsprofil</translation>
-<translation id="5210286577605176222">Gå til den forrige fane</translation>
-<translation id="5210365745912300556">Luk fanen</translation>
-<translation id="5224771365102442243">Med video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> vil gerne søge efter Bluetooth-enheder i nærheden. Følgende enheder blev fundet:</translation>
-<translation id="5233638681132016545">Ny fane</translation>
-<translation id="526421993248218238">Siden kunne ikke indlæses</translation>
-<translation id="5271967389191913893">Enheden kan ikke åbne det indhold, der skal downloades.</translation>
-<translation id="528192093759286357">Træk fra toppen, og tryk på tilbageknappen igen for at afslutte fuld skærm.</translation>
-<translation id="5292796745632149097">Send til</translation>
-<translation id="5300589172476337783">Vis</translation>
-<translation id="5301954838959518834">OK, det er forstået</translation>
-<translation id="5304593522240415983">Dette felt må ikke være tomt</translation>
-<translation id="5307446750509046227">Ryd websitelagerplads</translation>
-<translation id="5308380583665731573">Få forbindelse</translation>
-<translation id="5313967007315987356">Tilføj website</translation>
-<translation id="5317780077021120954">Gem</translation>
-<translation id="5324858694974489420">Indstillinger for børnesikring</translation>
-<translation id="5327248766486351172">Navn</translation>
-<translation id="5335288049665977812">Tillad, at websites kører JavaScript (anbefales)</translation>
-<translation id="5342314432463739672">Anmodninger om tilladelse</translation>
-<translation id="5357811892247919462">Du har modtaget en fane</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> åben fane – tryk for at skifte fane}one{<ph name="OPEN_TABS_MANY" /> åben fane – tryk for at skifte fane}other{<ph name="OPEN_TABS_MANY" /> åbne faner – tryk for at skifte fane}}</translation>
-<translation id="5391532827096253100">Din forbindelse til dette website er ikke sikker. Websiteoplysninger</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 anden)}one{(+ # anden)}other{(+ # andre)}}</translation>
-<translation id="5400569084694353794">Ved at bruge denne app accepterer du Chromes <ph name="BEGIN_LINK1" />servicevilkår<ph name="END_LINK1" /> og <ph name="BEGIN_LINK2" />erklæring om privatliv<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Navne</translation>
-<translation id="5403644198645076998">Tillad kun bestemte websites</translation>
-<translation id="5414836363063783498">Bekræfter...</translation>
-<translation id="5423934151118863508">Dine mest besøgte sider vises her</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB ledig plads</translation>
-<translation id="543338862236136125">Rediger adgangskode</translation>
-<translation id="5433691172869980887">Brugernavnet er kopieret</translation>
-<translation id="543509235395288790">Downloader <ph name="COUNT" /> filer (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Gå til adresselinjen</translation>
-<translation id="5447201525962359567">Al websitelagerplads, herunder cookies og andre data, der er gemt lokalt</translation>
-<translation id="5447765697759493033">Dette website kan ikke oversættes</translation>
-<translation id="545042621069398927">Øger hastigheden på din download.</translation>
-<translation id="5456381639095306749">Download siden</translation>
-<translation id="5475862044948910901">Vil du starte en session med augmented reality?</translation>
-<translation id="548278423535722844">Åbn i kortapp</translation>
-<translation id="5487521232677179737">Ryd data</translation>
-<translation id="5494752089476963479">Bloker annoncer på websites, der viser påtrængende eller vildledende annoncer</translation>
-<translation id="5500777121964041360">Funktionen er muligvis ikke tilgængelig på din placering</translation>
-<translation id="5512137114520586844">Denne konto administreres af <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Deaktiveret af administratoren af denne enhed</translation>
-<translation id="5515439363601853141">Lås op for at se din adgangskode</translation>
-<translation id="5516455585884385570">Åbn indstillinger for notifikationer</translation>
-<translation id="5517095782334947753">Du har bogmærker, historik, adgangskoder og andre indstillinger fra <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Omdirigeringen blev blokeret.</translation>
-<translation id="5527082711130173040">Chrome skal have placeringsadgang for at kunne scanne efter enheder. <ph name="BEGIN_LINK1" />Opdater tilladelser<ph name="END_LINK1" />. Placeringsadgang er også <ph name="BEGIN_LINK2" />slået fra på denne enhed<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Spørg, før websites får adgang til at læse tekst og billeder fra udklipsholderen (anbefales)</translation>
-<translation id="5530766185686772672">Luk inkognitofaner</translation>
-<translation id="5534334044554683961">Mens du er i VR, kan dette website muligvis få oplysninger om:
-  –   Dine fysiske træk som f.eks. højde
-  –   Layoutet i det rum, du befinder dig i
-
-Sørg for, at du har tillid til dette website, før du starter VR.</translation>
-<translation id="5534640966246046842">Websitet er kopieret</translation>
-<translation id="5556459405103347317">Genindlæs</translation>
-<translation id="5561549206367097665">Venter på netværk…</translation>
-<translation id="557283862590186398">Chrome skal have tilladelse til at bruge din mikrofon på dette website.</translation>
-<translation id="55737423895878184">Placering og notifikationer er tilladt</translation>
-<translation id="5578795271662203820">Søg efter billedet på <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Du kan altid vælge, hvad der skal synkroniseres, i <ph name="BEGIN_LINK1" />indstillingerne<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Rediger adresse</translation>
-<translation id="5596627076506792578">Flere valgmuligheder</translation>
-<translation id="5599455543593328020">Inkognitotilstand</translation>
-<translation id="5620928963363755975">Find dine filer og sider i Downloads via knappen Flere valgmuligheder</translation>
-<translation id="5626134646977739690">Navn:</translation>
-<translation id="5639724618331995626">Tillad alle websites</translation>
-<translation id="5648166631817621825">De seneste syv dage</translation>
-<translation id="5649053991847567735">Automatiske downloads</translation>
-<translation id="5655963694829536461">Søg i dine downloads</translation>
-<translation id="5659593005791499971">Mail</translation>
-<translation id="5665379678064389456">Opret begivenhed i <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Tilsidesæt en anmodning fra et website om at undgå at zoome ind</translation>
-<translation id="5677928146339483299">Blokeret</translation>
-<translation id="5684874026226664614">Ups! Denne side kunne ikke oversættes.</translation>
-<translation id="5686790454216892815">Filnavnet er for langt</translation>
-<translation id="5689516760719285838">Placering</translation>
-<translation id="569536719314091526">Oversæt denne side til et hvilket som helst sprog via knappen Flere valgmuligheder</translation>
-<translation id="572328651809341494">Seneste faner</translation>
-<translation id="5726692708398506830">Gør alting på siden større</translation>
-<translation id="5748802427693696783">Skiftet til standardfaner</translation>
-<translation id="5749068826913805084">Chrome skal have lageradgang for at kunne downloade filer.</translation>
-<translation id="5763382633136178763">Inkognitofaner</translation>
-<translation id="5763514718066511291">Tryk for at kopiere webadressen til denne app</translation>
-<translation id="5765780083710877561">Beskrivelse:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> af <ph name="SPACE_AVAILABLE" /> i brug</translation>
-<translation id="5797070761912323120">Google kan bruge din historik til at tilpasse Søgning, annoncer og andre Google-tjenester</translation>
-<translation id="5804241973901381774">Tilladelser</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{For 1 time siden}one{For # time siden}other{For # timer siden}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Alle rettigheder forbeholdes.</translation>
-<translation id="5817918615728894473">Start parring</translation>
-<translation id="583281660410589416">Ukendt</translation>
-<translation id="5833984609253377421">Del link</translation>
-<translation id="5836192821815272682">Downloader Chrome-opdateringen…</translation>
-<translation id="5853623416121554550">sat på pause</translation>
-<translation id="5854790677617711513">Ældre end 30 dage</translation>
-<translation id="5858741533101922242">Chrome kan ikke slå Bluetooth-adapteren til</translation>
-<translation id="5860033963881614850">Fra</translation>
-<translation id="5862731021271217234">Aktivér synkronisering for at få adgang til dine faner på dine andre enheder</translation>
-<translation id="5864174910718532887">Info: Sorteret efter navn på website</translation>
-<translation id="5864419784173784555">Venter på en anden download…</translation>
-<translation id="5865733239029070421">Sender automatisk brugsstatistikker og nedbrudsrapporter til Google</translation>
-<translation id="5869522115854928033">Gemte adgangskoder</translation>
-<translation id="5902828464777634901">Alle lokale data, der gemmes af websitet, herunder cookies, slettes</translation>
-<translation id="5916664084637901428">Til</translation>
-<translation id="5919204609460789179">Opdater <ph name="PRODUCT_NAME" /> for at starte synkroniseringen</translation>
-<translation id="5937580074298050696">Du har sparet <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Nulstil</translation>
-<translation id="5942872142862698679">Søgning via Google</translation>
-<translation id="5952764234151283551">Sender webadressen på en side, du forsøger at åbne, til Google</translation>
-<translation id="5956665950594638604">Åbn Hjælp til Chrome i en ny fane</translation>
-<translation id="5958275228015807058">Find dine filer og sider i Downloads</translation>
-<translation id="5962718611393537961">Tryk for at skjule</translation>
-<translation id="6000066717592683814">Behold Google</translation>
-<translation id="6005538289190791541">Foreslået adgangskode</translation>
-<translation id="6036057147555329831">Ekstra ICU</translation>
-<translation id="6039379616847168523">Gå til den næste fane</translation>
-<translation id="6040143037577758943">Luk</translation>
-<translation id="6042308850641462728">Mere</translation>
-<translation id="604996488070107836"><ph name="FILE_NAME" /> kunne ikke downloades, da der opstod en ukendt fejl.</translation>
-<translation id="605721222689873409">ÅÅ</translation>
-<translation id="6064125863973209585">Gennemførte downloads</translation>
-<translation id="6075798973483050474">Rediger startside</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> timer tilbage</translation>
-<translation id="6108923351542677676">Konfigurationen er i gang...</translation>
-<translation id="6111020039983847643">dataforbrug</translation>
-<translation id="6112702117600201073">Opdaterer siden</translation>
-<translation id="6127379762771434464">Elementet blev fjernet</translation>
-<translation id="6140912465461743537">Land/region</translation>
-<translation id="614940544461990577">Prøv at:</translation>
-<translation id="6154478581116148741">Aktivér skærmlåsen i Indstillinger for at eksportere dine adgangskoder fra denne enhed</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> sparet data</translation>
-<translation id="6165508094623778733">Flere oplysninger</translation>
-<translation id="6177111841848151710">Blokeret for den nuværende søgemaskine</translation>
-<translation id="6181444274883918285">Tilføj en undtagelse for et website</translation>
-<translation id="6192333916571137726">Download fil</translation>
-<translation id="6192792657125177640">Undtagelser</translation>
-<translation id="6194112207524046168">Aktivér også dit kamera i <ph name="BEGIN_LINK" />Android-indstillingerne<ph name="END_LINK" /> for at give Chrome adgang til kameraet.</translation>
-<translation id="6196640612572343990">Bloker cookies fra tredjeparter</translation>
-<translation id="6206551242102657620">Forbindelsen er sikker. Websiteoplysninger</translation>
-<translation id="6210748933810148297">Ikke <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Lås op for at eksportere dine adgangskoder</translation>
+<translation id="1406000523432664303">"Do Not Track"</translation>
 <translation id="6232535412751077445">Aktivering af "Do Not Track" betyder, at en anmodning medtages i din browsertrafik. Effekten afhænger af, om et website reagerer på anmodningen, og hvordan anmodningen fortolkes.
 
 Nogle websites kan f.eks. reagere på denne anmodning ved at vise dig annoncer, som ikke er baseret på andre websites, du har besøgt. Mange websites vil fortsat indsamle og bruge browserdata til f.eks. at forbedre sikkerheden, til at levere indhold, annoncer og anbefalinger og til at generere rapporteringsstatistik.</translation>
-<translation id="624789221780392884">Opdateringen er klar</translation>
-<translation id="6255999984061454636">Indholdsforslag</translation>
-<translation id="6277522088822131679">Der opstod et problem med udskrivning af siden. Prøv igen.</translation>
-<translation id="6295158916970320988">Alle websites</translation>
-<translation id="629730747756840877">Konto</translation>
-<translation id="6303969859164067831">Log ud, og deaktiver synkronisering</translation>
-<translation id="6316139424528454185">Android-versionen understøttes ikke</translation>
-<translation id="6320088164292336938">Vibrer</translation>
-<translation id="6324034347079777476">Synkronisering af Android-systemet blev deaktiveret</translation>
-<translation id="6333140779060797560">Del via <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Kryptering</translation>
-<translation id="6341580099087024258">Spørg, hvor filer skal gemmes</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> mere}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> mere}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> mere}}</translation>
-<translation id="6364438453358674297">Vil du fjerne forslaget fra historikken?</translation>
-<translation id="6369229450655021117">Herfra kan du søge på nettet, dele indhold med venner og se åbne sider</translation>
-<translation id="6378173571450987352">Info: Sorteret efter mængden af brugte data</translation>
-<translation id="6381421346744604172">Gør websites mørkere</translation>
-<translation id="6388207532828177975">Ryd og nulstil</translation>
-<translation id="6393863479814692971">Chrome skal have tilladelse til at bruge dit kamera og din mikrofon på dette website.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Rediger bogmærke</translation>
-<translation id="6406506848690869874">Synkronisering</translation>
-<translation id="641643625718530986">Udskriv…</translation>
-<translation id="6416782512398055893">Der er downloadet <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Oversæt på nettet</translation>
-<translation id="6433501201775827830">Vælg en søgemaskine</translation>
-<translation id="6437478888915024427">Sideoplysninger</translation>
-<translation id="6441734959916820584">Navnet er for langt</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# billede}one{# billede}other{# billeder}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Filen kan ikke åbnes</translation>
-<translation id="6464977750820128603">Du kan se websites, du har besøgt i Chrome, og indstille timere for dem.\n\nGoogle får oplysninger om de websites, du indstiller timere for, og hvor længe du er på dem. Disse oplysninger bruges til at forbedre Digital balance.</translation>
-<translation id="6475951671322991020">Download video</translation>
-<translation id="6482749332252372425">Download af <ph name="FILE_NAME" /> mislykkedes, fordi der ikke er nok lagerplads.</translation>
-<translation id="6496823230996795692">Opret forbindelse til internettet, første gang du bruger <ph name="APP_NAME" />.</translation>
-<translation id="6508722015517270189">Genstart Chrome</translation>
-<translation id="6527303717912515753">Del</translation>
-<translation id="6532866250404780454">Websites, du besøger i Chrome, vises ikke. Alle timere for websites slettes.</translation>
-<translation id="6534565668554028783">Google var for lang tid om at svare</translation>
-<translation id="6538442820324228105">Der er downloadet <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Der opstod en fejl. Prøv igen senere.</translation>
-<translation id="654446541061731451">Vælg en fane, der skal overføres</translation>
-<translation id="6545017243486555795">Ryd alle data</translation>
-<translation id="6545864417968258051">Bluetooth-scanning</translation>
-<translation id="6560414384669816528">Søg via Sogou</translation>
-<translation id="6566259936974865419">Chrome har sparet dig <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Tillad altid</translation>
-<translation id="6573431926118603307">Faner, du har åbnet i Chrome på dine andre enheder, vises her.</translation>
-<translation id="6583199322650523874">Føj et bogmærke til den aktuelle side</translation>
-<translation id="6593061639179217415">Standardwebsite</translation>
-<translation id="6600954340915313787">Kopieret til Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Beskyttet indhold</translation>
-<translation id="6627583120233659107">Rediger mappen</translation>
-<translation id="6643016212128521049">Ryd</translation>
-<translation id="6643649862576733715">Sortér efter mængden af data, der blev sparet</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> mere}one{<ph name="CONTACT_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> mere}other{<ph name="CONTACT_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> mere}}</translation>
-<translation id="6649642165559792194">Se forhåndsvisning af <ph name="BEGIN_NEW" />Ny<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome skal bruge placeringsadgang for at kunne scanne efter enheder. <ph name="BEGIN_LINK" />Opdater tilladelser<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Adgangskode</translation>
-<translation id="6659594942844771486">Fane</translation>
-<translation id="666731172850799929">Åbn i <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Erklæring om privatliv for Google Chrome</translation>
-<translation id="6676840375528380067">Vil du rydde dine Chrome-data på denne enhed?</translation>
-<translation id="6697492270171225480">Se forslag til lignende sider, når en side ikke kan findes</translation>
-<translation id="6697947395630195233">Chrome skal have adgang til din placering for at dele din placering med dette website.</translation>
-<translation id="6698801883190606802">Administrer synkroniserede data</translation>
-<translation id="6699370405921460408">Google-serverne optimerer de sider, du besøger.</translation>
-<translation id="6706288973712894588">Du er i øjeblikket offline.\n<ph name="BEGIN_LINK" />Gå på opdagelse i dit offlinefeed<ph name="END_LINK" />.</translation>
-<translation id="6709133671862442373">Nyheder</translation>
-<translation id="6710213216561001401">Forrige</translation>
-<translation id="671481426037969117">Din timer for <ph name="FQDN" /> udløb. Den starter igen i morgen.</translation>
-<translation id="6738867403308150051">Downloader…</translation>
-<translation id="6746124502594467657">Flyt ned</translation>
-<translation id="6766622839693428701">Stryg ned for at lukke.</translation>
-<translation id="6766758767654711248">Tryk for at gå til websitet</translation>
-<translation id="6767294960381293877">Åben liste i halv højde over enheder, der skal deles en fane med.</translation>
-<translation id="6782111308708962316">Undgå, at tredjepartswebsites gemmer og læser cookiedata</translation>
-<translation id="6790428901817661496">Afspil</translation>
-<translation id="6811034713472274749">Siden kan nu ses</translation>
-<translation id="6818926723028410516">Vælg elementer</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Oversæt</translation>
-<translation id="6845325883481699275">Hjælp med at forbedre sikkerheden i Chrome</translation>
-<translation id="6846298663435243399">Indlæser…</translation>
-<translation id="6850409657436465440">Der downloades stadig</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> faner blev lukket</translation>
-<translation id="6864459304226931083">Download billede</translation>
-<translation id="6865313869410766144">Formulardata for AutoFyld</translation>
-<translation id="688738109438487280">Føj eksisterende data til <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Lås op for at kopiere din adgangskode</translation>
-<translation id="6896758677409633944">Kopiér</translation>
-<translation id="6910211073230771657">Slettet</translation>
-<translation id="6912998170423641340">Bloker websites, så de ikke kan læse tekst og billeder fra udklipsholderen</translation>
-<translation id="6914783257214138813">Dine adgangskoder vil være synlige for alle, der kan se den eksporterede fil.</translation>
-<translation id="6942665639005891494">Du kan til enhver tid ændre standardplaceringen for downloads via menuen Indstillinger</translation>
-<translation id="6945221475159498467">Vælg</translation>
-<translation id="6963642900430330478">Denne side er farlig. Websiteoplysninger</translation>
-<translation id="6963766334940102469">Slet bogmærker</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Altid</translation>
-<translation id="6981982820502123353">Hjælpefunktioner</translation>
-<translation id="6989267951144302301">Der kan ikke downloades</translation>
-<translation id="6990079615885386641">Hent appen i Google Play Butik: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Spørg, før websites bruger din mikrofon (anbefales)</translation>
-<translation id="7015203776128479407">Den indledende konfiguration af synkronisering blev ikke afsluttet. Synkronisering er deaktiveret.</translation>
-<translation id="7016516562562142042">Tilladt for den nuværende søgemaskine</translation>
-<translation id="7022756207310403729">Åbn i browser</translation>
-<translation id="702463548815491781">Anbefales, når TalkBack eller Kontaktadgang er aktiveret</translation>
-<translation id="7029809446516969842">Adgangskoder</translation>
-<translation id="7053983685419859001">Bloker</translation>
-<translation id="7055152154916055070">Omdirigeringen blev blokeret:</translation>
-<translation id="7063006564040364415">Der kunne ikke oprettes forbindelse til synkroniseringsserveren.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 er valgt}one{# er valgt}other{# er valgt}}</translation>
-<translation id="7071521146534760487">Administrer konto</translation>
-<translation id="7077143737582773186">SD-kort</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> er markeret. De tilgængelige valgmuligheder er øverst på skærmen</translation>
-<translation id="7121362699166175603">Rydder historikken og autofuldførelser i adresselinjen. Din Google-konto kan have andre former for browserhistorik på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Tillad for den aktuelle søgemaskine</translation>
-<translation id="7138678301420049075">Andet</translation>
-<translation id="7141896414559753902">Bloker visning af pop up-vinduer på websites og omdirigeringer (anbefales)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Indlæs den oprindelige side<ph name="END_LINK" /> fra <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">De seneste 24 timer</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Du kan ændre dette senere i Indstillinger</translation>
-<translation id="7180611975245234373">Opdater</translation>
-<translation id="7189372733857464326">Venter på, at Google Play-tjenester er opdateret</translation>
-<translation id="7191430249889272776">Fanen blev åbnet i baggrunden.</translation>
-<translation id="723171743924126238">Vælg billeder</translation>
-<translation id="7233236755231902816">Hent den nyeste version af Chrome for at bruge browseren på dit eget sprog</translation>
-<translation id="7243308994586599757">Du finder indstillingerne nederst på skærmen</translation>
-<translation id="7248069434667874558">Sørg for, at synkronisering er aktiveret i Chrome på <ph name="TARGET_DEVICE_NAME" /></translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> er markeret</translation>
-<translation id="7274013316676448362">Blokeret website</translation>
-<translation id="7290209999329137901">Elementet kan ikke omdøbes.</translation>
-<translation id="7291387454912369099">Betaling udløst af Assistent</translation>
-<translation id="7293171162284876153">Aktivér "Synkroniser dine Chrome-data" for starte synkroniseringen.</translation>
-<translation id="729975465115245577">Der er ikke nogen app på din enhed, hvor filen med adgangskoder kan gemmes.</translation>
-<translation id="7302081693174882195">Info: Sorteret efter mængden af sparede data</translation>
-<translation id="7328017930301109123">Chrome indlæser sider hurtigere og bruger op til 60 procent mindre data i Lite-tilstand.</translation>
-<translation id="7333031090786104871">Det forrige website er stadig ved at blive tilføjet</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Del 1 valgt element}one{Del # valgt element}other{Del # valgte elementer}}</translation>
 <translation id="7359002509206457351">Adgang til betalingsmetoder</translation>
+<translation id="8026334261755873520">Ryd browserdata</translation>
+<translation id="1291207594882862231">Ryd historik, cookies, websitedata, cache...</translation>
+<translation id="7814200940910057384">Brave-dataene blev ryddet</translation>
+<translation id="1664855196866195614">De valgte data er fjernet fra Brave og synkroniserede enheder.
+
+Din Brave Software-konto kan have andre former for browserhistorik, f.eks. søgninger og aktivitet fra andre Brave Software-tjenester, på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Billeder og filer, der er gemt i cache</translation>
+<translation id="2496180316473517155">Browserhistorik</translation>
+<translation id="2546283357679194313">Cookies og websitedata</translation>
+<translation id="8662811608048051533">Logger dig ud af de fleste websites.</translation>
+<translation id="8218628800671693884">Logger dig ud af de fleste websites. Du bliver ikke logget ud af din Brave Software-konto.</translation>
+<translation id="2017836877785168846">Nulstiller historikken og autofuldførelser i adresselinjen.</translation>
+<translation id="8096327394278038498">Rydder historikken og autofuldførelser i adresselinjen. Din Brave Software-konto kan have andre former for browserhistorik på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Rydder historikken på alle enheder, hvor du er logget ind. Din Brave Software-konto kan have andre former for browserhistorik på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Gemte adgangskoder</translation>
+<translation id="6865313869410766144">Formulardata for AutoFyld</translation>
+<translation id="7562080006725997899">Browserdata ryddes</translation>
+<translation id="5487521232677179737">Ryd data</translation>
+<translation id="7498271377022651285">Vent…</translation>
+<translation id="784934925303690534">Tidsinterval</translation>
+<translation id="1718835860248848330">Den seneste time</translation>
+<translation id="7149893636342594995">De seneste 24 timer</translation>
+<translation id="5648166631817621825">De seneste syv dage</translation>
+<translation id="8571213806525832805">Seneste 4 uger</translation>
+<translation id="5854790677617711513">Ældre end 30 dage</translation>
+<translation id="6979737339423435258">Altid</translation>
+<translation id="982182592107339124">Denne handling rydder dataene for alle websites, herunder:</translation>
+<translation id="6643016212128521049">Ryd</translation>
+<translation id="7641339528570811325">Ryd browserdata…</translation>
+<translation id="1670399744444387456">Grundlæggende</translation>
+<translation id="3245261285041759672">Din Brave Software-konto kan have andre former for browserhistorik på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Blokeret website</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> elementer blev slettet</translation>
+<translation id="1121094540300013208">Brugs- og nedbrudsrapporter</translation>
+<translation id="9079153198295609735">Send automatisk brugsstatistikker og nedbrudsrapporter til Brave Software</translation>
+<translation id="6981982820502123353">Hjælpefunktioner</translation>
+<translation id="2387895666653383613">Tekststørrelse</translation>
+<translation id="2321958826496381788">Træk i skyderen, indtil du kan nemt læse dette. Teksten som minimum have denne størrelse, når du har trykket to gange på et afsnit.</translation>
+<translation id="3895926599014793903">Tving aktivering af zoom</translation>
+<translation id="5668404140385795438">Tilsidesæt en anmodning fra et website om at undgå at zoome ind</translation>
+<translation id="4149994727733219643">Enkel visning af websider</translation>
+<translation id="9100505651305367705">Tilbyd enkel visning af artikler, når det understøttes</translation>
+<translation id="1409426117486808224">Enkel visning af åbne faner</translation>
+<translation id="702463548815491781">Anbefales, når TalkBack eller Kontaktadgang er aktiveret</translation>
+<translation id="8284326494547611709">Undertekster</translation>
+<translation id="4165986682804962316">Indstillinger for websites</translation>
+<translation id="6295158916970320988">Alle websites</translation>
+<translation id="8380167699614421159">Dette website viser påtrængende eller vildledende annoncer</translation>
+<translation id="1919345977826869612">Annoncer</translation>
+<translation id="410351446219883937">Autoplay</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Bloker cookies fra tredjeparter</translation>
+<translation id="6782111308708962316">Undgå, at tredjepartswebsites gemmer og læser cookiedata</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop op-vinduer og omdirigeringer</translation>
+<translation id="4751476147751820511">Bevægelses- eller lyssensorer</translation>
+<translation id="1717218214683051432">Bevægelsessensorer</translation>
+<translation id="2091887806945687916">Lyd</translation>
+<translation id="2586657967955657006">Udklipsholder</translation>
+<translation id="6320088164292336938">Vibrer</translation>
+<translation id="4226663524361240545">Notifikationer kan få enheden til at vibrere</translation>
+<translation id="1446450296470737166">Tillad fuld kontrol over MIDI-enheder</translation>
+<translation id="3744111561329211289">Synkronisering i baggrunden</translation>
+<translation id="5649053991847567735">Automatiske downloads</translation>
+<translation id="6181444274883918285">Tilføj en undtagelse for et website</translation>
+<translation id="5313967007315987356">Tilføj website</translation>
+<translation id="1369915414381695676">Websitet <ph name="SITE_NAME"/> blev tilføjet</translation>
+<translation id="7837721118676387834">Tillad automatisk afspilning af videoer, hvor lyden er slået fra, for et bestemt website.</translation>
+<translation id="2621115761605608342">Tillad JavaScript for et bestemt website.</translation>
+<translation id="8801436777607969138">Bloker JavaScript for et bestemt website.</translation>
+<translation id="8372893542064058268">Tillad synkronisering i baggrunden for et bestemt website.</translation>
+<translation id="358794129225322306">Tillad, at et website kan downloade flere filer automatisk.</translation>
+<translation id="4008040567710660924">Tillad cookies for et bestemt website.</translation>
+<translation id="8958424370300090006">Bloker cookies for et bestemt website.</translation>
+<translation id="7882806643839505685">Tillad, at et bestemt website afspiller lyd.</translation>
+<translation id="4468959413250150279">Slå lyden fra for et bestemt website.</translation>
+<translation id="1994173015038366702">Webadresse</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Databrug</translation>
+<translation id="5804241973901381774">Tilladelser</translation>
+<translation id="4278390842282768270">Tilladt</translation>
+<translation id="5677928146339483299">Blokeret</translation>
+<translation id="1984937141057606926">Tilladt, undtagen tredjepartscookies</translation>
+<translation id="7423098979219808738">Spørg først</translation>
+<translation id="8116925261070264013">Websites, hvor lyden er slået fra</translation>
+<translation id="8300705686683892304">Administreres af en app</translation>
+<translation id="6192792657125177640">Undtagelser</translation>
+<translation id="257931822824936280">Udvidet – klik for at skjule.</translation>
+<translation id="5100237604440890931">Skjult – klik for at udvide.</translation>
+<translation id="857943718398505171">Tilladt (anbefales)</translation>
+<translation id="2913331724188855103">Tillad, at websites gemmer og læser cookiedata (anbefales)</translation>
+<translation id="7445411102860286510">Tillad, at websites automatisk afspiller videoer med lyden slået fra (anbefales)</translation>
+<translation id="5335288049665977812">Tillad, at websites kører JavaScript (anbefales)</translation>
+<translation id="5527111080432883924">Spørg, før websites får adgang til at læse tekst og billeder fra udklipsholderen (anbefales)</translation>
+<translation id="6912998170423641340">Bloker websites, så de ikke kan læse tekst og billeder fra udklipsholderen</translation>
+<translation id="7423538860840206698">Blokeret fra at læse udklipsholderen</translation>
+<translation id="3955193568934677022">Tillad, at websites afspiller beskyttet indhold (anbefales)</translation>
+<translation id="445467742685312942">Tillad, at websites afspiller beskyttet indhold</translation>
+<translation id="2107397443965016585">Spørg, før websites får tilladelse til at afspille beskyttet indhold (anbefales)</translation>
+<translation id="2910701580606108292">Spørg, før websites begynder at afspille beskyttet indhold</translation>
+<translation id="757524316907819857">Bloker afspilning af beskyttet indhold på websites</translation>
+<translation id="3277252321222022663">Tillad, at websites kan få adgang til sensorer (anbefales)</translation>
+<translation id="5048398596102334565">Tillad, at websites kan få adgang til bevægelsessensorer (anbefales)</translation>
+<translation id="8816026460808729765">Bloker adgang til sensorer på websites</translation>
+<translation id="169515064810179024">Bloker adgang til bevægelsessensorer på websites</translation>
+<translation id="1660204651932907780">Tillad, at websites afspiller lyd (anbefales)</translation>
+<translation id="3600792891314830896">Lyden slås fra for websites, der afspiller lyd</translation>
+<translation id="1743802530341753419">Spørg, før websites opretter forbindelse til en enhed (anbefales)</translation>
+<translation id="851751545965956758">Bloker websites fra at oprette forbindelse til enheder</translation>
+<translation id="7141896414559753902">Bloker visning af pop up-vinduer på websites og omdirigeringer (anbefales)</translation>
+<translation id="5494752089476963479">Bloker annoncer på websites, der viser påtrængende eller vildledende annoncer</translation>
+<translation id="3123473560110926937">Blokeret på visse websites</translation>
+<translation id="965817943346481315">Bloker, hvis websitet viser påtrængende eller vildledende annoncer (anbefales)</translation>
+<translation id="3386292677130313581">Spørg, om websites må få adgang til din placering (anbefales)</translation>
+<translation id="9139068048179869749">Spørg, før websites sender notifikationer (anbefales)</translation>
+<translation id="4479647676395637221">Spørg, før websites bruger dit kamera (anbefales)</translation>
+<translation id="6992289844737586249">Spørg, før websites bruger din mikrofon (anbefales)</translation>
+<translation id="2289270750774289114">Spørg, når et website vil søge efter Bluetooth-enheder i nærheden (anbefalet)</translation>
+<translation id="7053983685419859001">Bloker</translation>
+<translation id="7128222689758636196">Tillad for den aktuelle søgemaskine</translation>
+<translation id="7589445247086920869">Bloker for den aktuelle søgemaskine</translation>
+<translation id="6388207532828177975">Ryd og nulstil</translation>
+<translation id="7999064672810608036">Er du sikker på, at du vil slette alle lokale data, herunder cookies, og nulstille alle tilladelser for dette website?</translation>
+<translation id="2822354292072154809">Er du sikker på, at du vil nulstille alle websitetilladelser for <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Ryd lagrede data</translation>
+<translation id="5902828464777634901">Alle lokale data, der gemmes af websitet, herunder cookies, slettes</translation>
+<translation id="119944043368869598">Ryd alle</translation>
+<translation id="2490684707762498678">Administreret af <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Åbn indstillinger for notifikationer</translation>
+<translation id="1404122904123200417">Integreret i <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Filer, der gemmes af websites, vises her</translation>
+<translation id="4181841719683918333">Sprog</translation>
+<translation id="2647434099613338025">Tilføj sprog</translation>
+<translation id="1952172573699511566">Websites viser tekst på dit foretrukne sprog, når det er muligt.</translation>
+<translation id="8559990750235505898">Tilbyd at oversætte sider på andre sprog</translation>
+<translation id="4719927025381752090">Tilbyd at oversætte</translation>
+<translation id="8156139159503939589">Hvilke sprog læser du?</translation>
+<translation id="5689516760719285838">Placering</translation>
+<translation id="2440823041667407902">Placeringsadgang</translation>
+<translation id="2023546461831060654">Aktivér tilladelser for Brave i <ph name="BEGIN_LINK"/>Android-indstillingerne<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Aktivér tilladelse for Brave i <ph name="BEGIN_LINK"/>Android-indstillingerne<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Aktivér også placering i <ph name="BEGIN_LINK"/>Android-indstillingerne<ph name="END_LINK"/> for at give Brave adgang til din placering.</translation>
+<translation id="1028853271388022585">Aktivér også dit kamera i <ph name="BEGIN_LINK"/>Android-indstillingerne<ph name="END_LINK"/> for at give Brave adgang til kameraet.</translation>
+<translation id="2913721282607281710">Aktivér også notifikationer i <ph name="BEGIN_LINK"/>Android-indstillingerne<ph name="END_LINK"/> for at give Brave tilladelse til at sende dig notifikationer.</translation>
+<translation id="8753483718490035722">Aktivér også din mikrofon i <ph name="BEGIN_LINK"/>Android-indstillingerne<ph name="END_LINK"/> for at give Brave adgang til mikrofonen.</translation>
+<translation id="1887786770086287077">Placeringsadgang er deaktiveret for denne enhed. Aktivér det under <ph name="BEGIN_LINK"/>indstillinger for Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Placeringsadgang er også deaktiveret for denne enhed. Aktivér det under <ph name="BEGIN_LINK"/>indstillinger for Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Adgang til dit kamera</translation>
+<translation id="945632385593298557">Adgang til din mikrofon</translation>
+<translation id="6612358246767739896">Beskyttet indhold</translation>
+<translation id="885701979325669005">Lagerplads</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> gemte data</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Tilbagekald adgangstilladelsen til enheden</translation>
+<translation id="4962975101802056554">Tilbagekald alle tilladelser for enheden</translation>
+<translation id="6545864417968258051">Bluetooth-scanning</translation>
+<translation id="4411535500181276704">Lite-tilstand</translation>
+<translation id="7821588508402923572">Din databesparelse vises her</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> sparet</translation>
+<translation id="8569404424186215731">siden den <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Brave indlæser sider hurtigere og bruger op til 60 procent mindre data i Lite-tilstand.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> sparet data</translation>
+<translation id="7494974237137038751">databesparelse</translation>
+<translation id="6111020039983847643">dataforbrug</translation>
+<translation id="7413229368719586778">Startdato <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Slutdato <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sortér efter website</translation>
+<translation id="5864174910718532887">Info: Sorteret efter navn på website</translation>
+<translation id="116280672541001035">Brugt</translation>
+<translation id="8349013245300336738">Sortér efter mængden af data, der er brugt</translation>
+<translation id="6378173571450987352">Info: Sorteret efter mængden af brugte data</translation>
+<translation id="2631006050119455616">Sparet</translation>
+<translation id="6643649862576733715">Sortér efter mængden af data, der blev sparet</translation>
+<translation id="7302081693174882195">Info: Sorteret efter mængden af sparede data</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> er brugt</translation>
+<translation id="5937580074298050696">Du har sparet <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Tilbageværende websites (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Andet</translation>
+<translation id="4913161338056004800">Nulstil statistik</translation>
+<translation id="1856325424225101786">Vil du nulstille Lite-tilstand?</translation>
+<translation id="3658159451045945436">En nulstilling sletter din historik for databesparelser, herunder listen over de websites, du har besøgt.</translation>
+<translation id="3295530008794733555">Få hurtigere browsing. Brug mindre data.</translation>
+<translation id="7340390500800578919">Brave indlæser sider hurtigere og bruger op til 60 procent mindre data i Lite-tilstand. Brave sender din webtrafik til Brave Software for at optimere de sider, du besøger. <ph name="BEGIN_LINK"/>Få flere oplysninger<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Aktivér Lite-tilstand</translation>
+<translation id="4493497663118223949">Lite-tilstand er aktiveret</translation>
+<translation id="7559975015014302720">Lite-tilstand er deaktiveret</translation>
+<translation id="7606077192958116810">Lite-tilstand er aktiveret. Administrer tilstanden i Indstillinger.</translation>
+<translation id="4714588616299687897">Spar op til 60 % af dine data</translation>
+<translation id="1006927014032731288">Brave Software-serverne optimerer de sider, du besøger.</translation>
+<translation id="3257320067425202300">Brave har sparet dig <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave har sparet dig <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Downloadplacering</translation>
+<translation id="7077143737582773186">SD-kort</translation>
+<translation id="7762668264895820836">SD-kort <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Spørg, hvor filer skal gemmes</translation>
+<translation id="6192333916571137726">Download fil</translation>
+<translation id="1672586136351118594">Vis ikke igen</translation>
+<translation id="2650751991977523696">Vil du downloade filen igen?</translation>
+<translation id="8664979001105139458">Filnavnet findes allerede</translation>
+<translation id="488187801263602086">Omdøb fil</translation>
+<translation id="5686790454216892815">Filnavnet er for langt</translation>
+<translation id="7454641608352164238">Der er ikke nok plads</translation>
+<translation id="8972098258593396643">Vil du downloade til standardmappen?</translation>
+<translation id="804335162455518893">SD-kortet blev ikke fundet</translation>
+<translation id="7475688122056506577">SD-kortet blev fundet. Nogle af dine filer mangler muligvis.</translation>
+<translation id="4198423547019359126">Der er ingen tilgængelige downloadplaceringer</translation>
+<translation id="8224471946457685718">Download artikler til dig via Wi-Fi</translation>
+<translation id="4970824347203572753">Ikke tilgængelig på din placering</translation>
+<translation id="5500777121964041360">Funktionen er muligvis ikke tilgængelig på din placering</translation>
+<translation id="1173894706177603556">Omdøb</translation>
+<translation id="1986685561493779662">Navnet findes allerede</translation>
+<translation id="6441734959916820584">Navnet er for langt</translation>
+<translation id="2923908459366352541">Navnet er ugyldigt</translation>
+<translation id="7290209999329137901">Elementet kan ikke omdøbes.</translation>
+<translation id="3334729583274622784">Vil du ændre filtypen?</translation>
+<translation id="107147699690128016">Hvis du ændrer filtypen, åbnes filen muligvis i en anden app og kan være skadelig for din enhed.</translation>
+<translation id="8541922081612557424">Om Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Alle rettigheder forbeholdes.</translation>
+<translation id="1416550906796893042">Appversion</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Opdateret <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operativsystem</translation>
+<translation id="3968054912784331254">Brave understøtter ikke længere denne version af Android</translation>
+<translation id="7665369617277396874">Tilføj konto</translation>
+<translation id="649070405679044769">Du er logget ind på Brave Software som</translation>
+<translation id="6234515504547364178">Log ud af Brave</translation>
+<translation id="5324858694974489420">Indstillinger for børnesikring</translation>
+<translation id="8920114477895755567">Venter på oplysninger om forældre.</translation>
+<translation id="5512137114520586844">Denne konto administreres af <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Denne konto administreres af <ph name="PARENT_NAME_1"/> og <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Indhold</translation>
+<translation id="5403644198645076998">Tillad kun bestemte websites</translation>
+<translation id="8641930654639604085">Prøv at blokere websites med indhold for voksne</translation>
+<translation id="5639724618331995626">Tillad alle websites</translation>
+<translation id="796823723482603597">Leveret af Brave</translation>
+<translation id="6324034347079777476">Synkronisering af Android-systemet blev deaktiveret</translation>
+<translation id="5127805178023152808">Synkronisering er slået fra</translation>
+<translation id="7015203776128479407">Den indledende konfiguration af synkronisering blev ikke afsluttet. Synkronisering er deaktiveret.</translation>
+<translation id="2497852260688568942">Synkronisering er deaktiveret af din administrator.</translation>
+<translation id="9100610230175265781">Adgangssætning kræves</translation>
+<translation id="6108923351542677676">Konfigurationen er i gang...</translation>
+<translation id="4062305924942672200">Juridiske oplysninger</translation>
+<translation id="4256782883801055595">Open source-licenser</translation>
+<translation id="1138681184697033370">Braves servicevilkår</translation>
+<translation id="7392539049993970338">Erklæring om privatliv for Brave Software Brave</translation>
+<translation id="2677748264148917807">Forlad</translation>
+<translation id="5556459405103347317">Genindlæs</translation>
+<translation id="1623104350909869708">Undgå, at denne side opretter yderligere dialogbokse</translation>
+<translation id="2968755619301702150">Certifikatfremviser</translation>
+<translation id="1360432990279830238">Log ud, og deaktiver synkronisering?</translation>
+<translation id="8581481290581777242">Vil du rydde dine Brave-data på denne enhed?</translation>
+<translation id="1318865768845061710">Din historik samt dine bogmærker, adgangskoder og andre Brave-data synkroniseres ikke længere med din Brave Software-konto</translation>
+<translation id="3325020657155065477">Ryd også dine Brave-data fra enheden</translation>
+<translation id="6136448902816743006">Da du er ved at logge ud af en konto, der administreres af <ph name="DOMAIN_NAME"/>, slettes dine Brave-data fra denne enhed. Dataene vil stadig være at finde på din Brave Software-konto.</translation>
+<translation id="1853026300647876496">Kontakter Brave Software. Dette kan tage et øjeblik…</translation>
+<translation id="2328985652426384049">Det er ikke muligt at logge ind</translation>
+<translation id="7723158744459952869">Brave Software var for lang tid om at svare</translation>
+<translation id="4572422548854449519">Log ind på mangerstyret konto</translation>
+<translation id="2689656545739939160">Du er ved at logge ind med en konto, der administreres af <ph name="MANAGED_DOMAIN"/>, hvilket giver administratoren kontrol over dine Brave-data. Dine data tilknyttes denne konto permanent. Hvis du logger ud af Brave, slettes dine data fra denne enhed, men de forbliver gemt på din Brave Software-konto.</translation>
+<translation id="1749561566933687563">Synkroniser dine bogmærker</translation>
+<translation id="4242533952199664413">Åbn Indstillinger</translation>
+<translation id="1111673857033749125">Bogmærker, der er gemt på dine andre enheder, vises her.</translation>
+<translation id="8636825310635137004">Aktivér synkronisering for at få adgang til dine faner på dine andre enheder.</translation>
+<translation id="3269956123044984603">Aktivér "Automatisk synkronisering af data" i kontoindstillingerne for Android for at få adgang til dine faner på dine andre enheder.</translation>
+<translation id="5157964048453367290">Faner, du har åbnet i Brave på dine andre enheder, vises her.</translation>
+<translation id="4684427112815847243">Synkroniser alt</translation>
+<translation id="2709516037105925701">AutoFyld</translation>
+<translation id="8820817407110198400">Bogmærker</translation>
+<translation id="1644574205037202324">Historik</translation>
+<translation id="17513872634828108">Åbne faner</translation>
+<translation id="1320169905922104972">Kreditkort og adresser fra Brave Software Pay</translation>
+<translation id="6337234675334993532">Kryptering</translation>
+<translation id="6698801883190606802">Administrer synkroniserede data</translation>
+<translation id="3598578758776312506">Kryptér adgangskoder med Brave Software-loginoplysninger</translation>
+<translation id="7810580217418711046">Kryptér synkroniserede data med Brave Software-adgangskoden fra <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Kryptér synkroniserede data med din egen adgangssætning til synkronisering</translation>
+<translation id="2996291259634659425">Opret adgangssætning</translation>
+<translation id="5713644099811900409">Brave Software-konto</translation>
+<translation id="8997474919031554666">Kryptering med adgangssætning omfatter ikke betalingsmetoder og adresser fra Brave Software Pay. Det er kun personer med din adgangssætning, der kan læse dine krypterede data. Adgangssætningen sendes ikke til eller gemmes af Brave Software. Hvis du glemmer din adgangssætning eller vil ændre denne indstilling, skal du nulstille synkronisering. <ph name="BEGIN_LINK"/>Få flere oplysninger<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Adgangssætning</translation>
+<translation id="7772032839648071052">Bekræft adgangssætning</translation>
+<translation id="5304593522240415983">Dette felt må ikke være tomt</translation>
+<translation id="321773570071367578">Hvis du har glemt din adgangssætning eller vil ændre denne indstilling, skal du <ph name="BEGIN_LINK"/>nulstille synkroniseringen<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Adgangssætningerne stemmer ikke overens</translation>
+<translation id="5149495116300586333">Kryptering med adgangssætning omfatter ikke betalingsmetoder og adresser fra Brave Software Pay.
+
+Hvis du vil ændre denne indstilling, skal du <ph name="BEGIN_LINK"/>nulstille synkronisering<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Forkert adgangssætning</translation>
+<translation id="5414836363063783498">Bekræfter...</translation>
+<translation id="6846298663435243399">Indlæser…</translation>
+<translation id="5517095782334947753">Du har bogmærker, historik, adgangskoder og andre indstillinger fra <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Kombiner mine data</translation>
+<translation id="688738109438487280">Føj eksisterende data til <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Hold mine data adskilt</translation>
+<translation id="1145536944570833626">Slet eksisterende data.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> vil gerne parre</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Få hjælp<ph name="END_LINK"/>, mens der scannes efter enheder…</translation>
+<translation id="5817918615728894473">Start parring</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Få hjælp<ph name="END_LINK1"/>, eller <ph name="BEGIN_LINK2"/>scan igen<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Der blev ikke fundet nogen kompatible enheder</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Slå Bluetooth til<ph name="END_LINK"/> for at tillade parring</translation>
+<translation id="998321811308652668">Brave kan ikke slå Bluetooth-adapteren til</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Få hjælp<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave skal bruge placeringsadgang for at kunne scanne efter enheder. <ph name="BEGIN_LINK"/>Opdater tilladelser<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave skal have placeringsadgang for at kunne scanne efter enheder. Placeringsadgang er <ph name="BEGIN_LINK"/>slået fra på denne enhed<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave skal have placeringsadgang for at kunne scanne efter enheder. <ph name="BEGIN_LINK1"/>Opdater tilladelser<ph name="END_LINK1"/>. Placeringsadgang er også <ph name="BEGIN_LINK2"/>slået fra på denne enhed<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Tilsluttet enhed</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstyrkeniveau: # søjle}one{Signalstyrkeniveau: # søjle}other{Signalstyrkeniveau: # søjler}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> vil gerne søge efter Bluetooth-enheder i nærheden. Følgende enheder blev fundet:</translation>
+<translation id="8368027906805972958">Ukendt eller ikke-understøttet enhed (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synkronisering fungerer ikke</translation>
+<translation id="1810845389119482123">Indledende konfiguration af synkronisering er ikke afsluttet</translation>
+<translation id="3235722914093408050">Åbn Android-indstillinger, og genaktiver synkronisering af Android-systemet for at starte Brave-synkroniseringen</translation>
+<translation id="3367813778245106622">Log ind igen for at starte synkroniseringen</translation>
+<translation id="974555521953189084">Angiv din adgangssætning for at starte synkroniseringen</translation>
+<translation id="2997266899014181325">Aktivér "Synkroniser dine Brave-data" for starte synkroniseringen.</translation>
+<translation id="8260126382462817229">Prøv at logge ind igen</translation>
+<translation id="5919204609460789179">Opdater <ph name="PRODUCT_NAME"/> for at starte synkroniseringen</translation>
+<translation id="397583555483684758">Synkroniseringen fungerer ikke mere</translation>
+<translation id="1966710179511230534">Opdater dine loginoplysninger.</translation>
+<translation id="7063006564040364415">Der kunne ikke oprettes forbindelse til synkroniseringsserveren.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> er forældet.</translation>
+<translation id="4170011742729630528">Tjenesten er ikke tilgængelig. Prøv igen senere.</translation>
+<translation id="7947953824732555851">Acceptér og log ind</translation>
+<translation id="8583805026567836021">Kontodataene ryddes</translation>
+<translation id="8310344678080805313">Standardfaner</translation>
+<translation id="5748802427693696783">Skiftet til standardfaner</translation>
+<translation id="7998918019931843664">Åbn lukket fane igen</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, fane</translation>
+<translation id="4452411734226507615">Luk fanen <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Du finder indstillingerne nederst på skærmen</translation>
+<translation id="4060598801229743805">Du finder de tilgængelige valgmuligheder øverst på skærmen</translation>
+<translation id="2810645512293415242">Forenklet side, der sparer data og indlæses hurtigere.</translation>
+<translation id="3985215325736559418">Vil du downloade <ph name="FILE_NAME"/> igen?</translation>
+<translation id="2450083983707403292">Vil du begynde at downloade <ph name="FILE_NAME"/> igen?</translation>
+<translation id="7514365320538308">Download</translation>
+<translation id="545042621069398927">Øger hastigheden på din download.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Downloader fil.}one{Downloader # fil.}other{Downloader # filer.}}</translation>
+<translation id="543509235395288790">Downloader <ph name="COUNT"/> filer (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Downloader fil (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download er fuldført.}one{# download er fuldført.}other{# downloads er fuldført.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download mislykkedes.}one{# download mislykkedes.}other{# downloads mislykkedes.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download afventer.}one{# download afventer.}other{# downloads afventer.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/>-knap</translation>
+<translation id="3205824638308738187">Du er næsten færdig.</translation>
+<translation id="3960299545138990065">Genstart Brave</translation>
+<translation id="3771001275138982843">Opdateringen kunne ikke downloades</translation>
+<translation id="3888648114124182147">Downloader Brave-opdateringen…</translation>
+<translation id="1705567146636171298">Opdater Brave</translation>
+<translation id="6195417478702700398">Opdater Brave for at få den bedste browseroplevelse</translation>
+<translation id="3512968675351418494">Hent den nyeste version af Brave for at bruge browseren på dit eget sprog</translation>
+<translation id="6427112570124116297">Oversæt på nettet</translation>
+<translation id="1379423114029199501">Opdater til den nyeste version af Brave for at bruge dit eget sprog</translation>
+<translation id="5684874026226664614">Ups! Denne side kunne ikke oversættes.</translation>
+<translation id="6831043979455480757">Oversæt</translation>
+<translation id="1285320974508926690">Oversæt aldrig dette website</translation>
+<translation id="773466115871691567">Oversæt altid sider på <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Oversæt aldrig sider på <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Flere sprog</translation>
+<translation id="290376772003165898">Er siden ikke på <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Sider på <ph name="SOURCE_LANGUAGE"/> oversættes fremover til <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Sider på <ph name="LANGUAGE"/> oversættes ikke</translation>
+<translation id="5447765697759493033">Dette website kan ikke oversættes</translation>
+<translation id="4880127995492972015">Oversæt…</translation>
+<translation id="641643625718530986">Udskriv…</translation>
+<translation id="8909135823018751308">Del…</translation>
+<translation id="4996978546172906250">Del via</translation>
+<translation id="6333140779060797560">Del via <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Der opstod et problem med udskrivning af siden. Prøv igen.</translation>
+<translation id="3254409185687681395">Tilføj denne side som bogmærke</translation>
+<translation id="497421865427891073">Gå fremad</translation>
+<translation id="813082847718468539">Se websiteoplysninger</translation>
+<translation id="2532336938189706096">Webvisning</translation>
+<translation id="6005538289190791541">Foreslået adgangskode</translation>
+<translation id="4634124774493850572">Brug adgangskode</translation>
+<translation id="8285489906452138776">Brave skal have tilladelse til at bruge dit kamera på dette website.</translation>
+<translation id="320189792589364011">Brave skal have tilladelse til at bruge din mikrofon på dette website.</translation>
+<translation id="7988136689212463100">Brave skal have tilladelse til at bruge dit kamera og din mikrofon på dette website.</translation>
+<translation id="4931190655840828017">Brave skal have adgang til din placering for at dele din placering med dette website.</translation>
+<translation id="3088191967551450609">Brave skal have lageradgang for at kunne downloade filer.</translation>
+<translation id="8942627711005830162">Åbn i et andet vindue</translation>
+<translation id="4195643157523330669">Åbn på ny fane</translation>
+<translation id="1100066534610197918">Åbn i en ny fane i en gruppe</translation>
+<translation id="4860895144060829044">Ring op</translation>
+<translation id="6896758677409633944">Kopiér</translation>
+<translation id="8393700583063109961">Send en besked</translation>
+<translation id="3557336313807607643">Føj til kontakter</translation>
+<translation id="4269820728363426813">Kopiér linkadresse</translation>
+<translation id="1206892813135768548">Kopiér linktekst</translation>
+<translation id="1204037785786432551">Download link</translation>
+<translation id="6864459304226931083">Download billede</translation>
+<translation id="8209050860603202033">Åbn billede</translation>
+<translation id="8073388330009372546">Åbn billede på ny fane</translation>
+<translation id="6649642165559792194">Se forhåndsvisning af <ph name="BEGIN_NEW"/>Ny<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Indlæs billede</translation>
+<translation id="3845332215609790146">Søg med Brave Software Lens <ph name="BEGIN_NEW"/>Nyhed<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Søg efter billedet på <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Del billede</translation>
+<translation id="5833984609253377421">Del link</translation>
+<translation id="6475951671322991020">Download video</translation>
+<translation id="2317945146070194624">Åbn på ny fane i Brave</translation>
+<translation id="7975379999046275268">Se forhåndsvisning af siden <ph name="BEGIN_NEW"/>Ny<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Opdaterer siden</translation>
+<translation id="36525718899759834">Hent appen i Brave Software Play Butik: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Mørk</translation>
+<translation id="1807246157184219062">Lys</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Enkelt tegnafstand</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Vælg en fane, der skal overføres</translation>
+<translation id="8719023831149562936">Den aktuelle fane kan ikke overføres</translation>
+<translation id="2139186145475833000">Føj til startskærm</translation>
+<translation id="4616150815774728855">Åbn <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Appen kunne ikke åbnes</translation>
+<translation id="5129038482087801250">Installer webapp</translation>
+<translation id="3789841737615482174">Installer</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> blev føjet til din startskærm</translation>
+<translation id="7333031090786104871">Det forrige website er stadig ved at blive tilføjet</translation>
+<translation id="1036727731225946849">Tilføjer <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Føjet til startskærmen</translation>
+<translation id="2146738493024040262">Åbn instant app</translation>
+<translation id="7016516562562142042">Tilladt for den nuværende søgemaskine</translation>
+<translation id="6177111841848151710">Blokeret for den nuværende søgemaskine</translation>
+<translation id="145097072038377568">Deaktiveret i indstillingerne for Android</translation>
+<translation id="8007176423574883786">Deaktiveret på denne enhed</translation>
+<translation id="164269334534774161">Du ser en offlinekopi af denne side fra <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Denne offlineside er fra <ph name="CREATION_TIME"/> og kan afvige fra onlineversionen.</translation>
+<translation id="8840953339110955557">Denne side kan afvige fra onlineversionen.</translation>
+<translation id="6405300764336705484">Dette indhold er fra <ph name="DOMAIN_NAME"/>, som leveres af Brave Software.</translation>
+<translation id="1006017844123154345">Åbn på nettet</translation>
+<translation id="3326636747541519688">Lite-side leveret af Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Indlæs den oprindelige side<ph name="END_LINK"/> fra <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Hvis du ser dette jævnligt, kan du prøve disse <ph name="BEGIN_LINK"/>forslag<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Indholdet er skjult</translation>
+<translation id="3810973564298564668">Valgmuligheder</translation>
+<translation id="5199929503336119739">Arbejdsprofil</translation>
+<translation id="528192093759286357">Træk fra toppen, og tryk på tilbageknappen igen for at afslutte fuld skærm.</translation>
+<translation id="2836148919159985482">Tryk på tilbageknappen for at afslutte fuld skærm.</translation>
+<translation id="3967822245660637423">Download fuldført</translation>
+<translation id="2434158240863470628">Downloaden er fuldført <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Download mislykkedes</translation>
+<translation id="1384959399684842514">Download er sat på pause</translation>
+<translation id="1671236975893690980">Download afventer…</translation>
+<translation id="5561549206367097665">Venter på netværk…</translation>
+<translation id="5864419784173784555">Venter på en anden download…</translation>
+<translation id="6461962085415701688">Filen kan ikke åbnes</translation>
+<translation id="1178581264944972037">Pause</translation>
+<translation id="8200772114523450471">Genoptag</translation>
+<translation id="1409879593029778104">Download af <ph name="FILE_NAME"/> blev forhindret, fordi filen allerede findes.</translation>
+<translation id="3387650086002190359">Download af <ph name="FILE_NAME"/> mislykkedes på grund af fejl i filsystemet.</translation>
+<translation id="6482749332252372425">Download af <ph name="FILE_NAME"/> mislykkedes, fordi der ikke er nok lagerplads.</translation>
+<translation id="7619072057915878432">Download af <ph name="FILE_NAME"/> mislykkedes på grund af netværksfejl.</translation>
+<translation id="1477626028522505441">Download af <ph name="FILE_NAME"/> mislykkedes på grund af serverproblemer.</translation>
+<translation id="3692944402865947621"><ph name="FILE_NAME"/> blev ikke downloadet, da lagerplaceringen ikke er tilgængelig.</translation>
+<translation id="604996488070107836"><ph name="FILE_NAME"/> kunne ikke downloades, da der opstod en ukendt fejl.</translation>
+<translation id="6738867403308150051">Downloader…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Der er downloadet <ph name="KBS"/> kB</translation>
+<translation id="6416782512398055893">Der er downloadet <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Der er downloadet <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">1 fil tilbage</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> filer tilbage</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fil blev downloadet}one{<ph name="FILES_DOWNLOADED_MANY"/> fil blev downloadet}other{<ph name="FILES_DOWNLOADED_MANY"/> filer blev downloadet}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> dage tilbage</translation>
+<translation id="8190358571722158785">1 dag tilbage</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> timer tilbage</translation>
+<translation id="510275257476243843">1 time tilbage</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minutter tilbage</translation>
+<translation id="3236059992281584593">1 minut tilbage</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> sekunder tilbage</translation>
+<translation id="2781151931089541271">1 sekund tilbage</translation>
+<translation id="3303414029551471755">Vil du fortsætte og downloade indholdet?</translation>
+<translation id="8617240290563765734">Vil du åbne den foreslåede webadresse, som er angivet i det downloadede indhold?</translation>
+<translation id="1373696734384179344">Der er ikke nok hukommelse til at downloade det valgte indhold.</translation>
+<translation id="5271967389191913893">Enheden kan ikke åbne det indhold, der skal downloades.</translation>
+<translation id="883806473910249246">Der opstod en fejl under download af indholdet.</translation>
+<translation id="5626134646977739690">Navn:</translation>
+<translation id="7963646190083259054">Leverandør:</translation>
+<translation id="3414952576877147120">Størrelse:</translation>
+<translation id="7375125077091615385">Type:</translation>
+<translation id="5765780083710877561">Beskrivelse:</translation>
+<translation id="4881695831933465202">Åbn</translation>
+<translation id="3542235761944717775">Der er <ph name="KILOBYTES"/> kB til rådighed</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB er ledig</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB ledig plads</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> af <ph name="SPACE_AVAILABLE"/> i brug</translation>
+<translation id="3587482841069643663">Alle</translation>
+<translation id="4988526792673242964">Sider</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Lyd</translation>
+<translation id="9219103736887031265">Billeder</translation>
+<translation id="8250920743982581267">Dokumenter</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fil}one{# fil}other{# filer}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# billede}one{# billede}other{# billeder}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}one{# video}other{# videoer}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# lydfil}one{# lydfil}other{# lydfiler}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# side}one{# side}other{# sider}}</translation>
+<translation id="5456381639095306749">Download siden</translation>
+<translation id="2394602618534698961">Her vises de filer, du downloader</translation>
+<translation id="7810647596859435254">Åbn med…</translation>
+<translation id="5655963694829536461">Søg i dine downloads</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mine filer</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Her vises artikler, som du kan læse, selv når du er offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# t.}one{# t.}other{# t.}}</translation>
+<translation id="5853623416121554550">sat på pause</translation>
+<translation id="8965591936373831584">afventer</translation>
+<translation id="2779651927720337254">mislykkedes</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Lige nu</translation>
+<translation id="4000212216660919741">Hjemmet er offline</translation>
+<translation id="9133397713400217035">Udforsk offline</translation>
+<translation id="968900484120156207">De sider, du besøger, vises her</translation>
+<translation id="7882131421121961860">Der blev ikke fundet nogen historik</translation>
+<translation id="3549657413697417275">Søg i din historik</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">ÅÅ</translation>
+<translation id="724102042129299115">Førstegangsoplevelse af Brave</translation>
+<translation id="2700285883409956633">Ved at bruge denne app accepterer du Braves <ph name="BEGIN_LINK1"/>servicevilkår<ph name="END_LINK1"/> og <ph name="BEGIN_LINK2"/>erklæring om privatliv<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Når du bruger denne app, accepterer du Braves <ph name="BEGIN_LINK1"/>servicevilkår<ph name="END_LINK1"/> og <ph name="BEGIN_LINK2"/>erklæring om privatliv<ph name="END_LINK2"/> samt <ph name="BEGIN_LINK3"/>erklæringen om privatliv for Brave Software-konti, der administreres med Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> åbnes i Brave. Når du fortsætter, accepterer du Braves <ph name="BEGIN_LINK1"/>servicevilkår<ph name="END_LINK1"/> og <ph name="BEGIN_LINK2"/>erklæring om privatliv<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> åbnes i Brave. Når du fortsætter, accepterer du Braves <ph name="BEGIN_LINK1"/>servicevilkår<ph name="END_LINK1"/> og <ph name="BEGIN_LINK2"/>erklæring om privatliv<ph name="END_LINK2"/> samt <ph name="BEGIN_LINK3"/>erklæringen om privatliv for Brave Software-konti, der administreres med Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Vær med til at gøre Brave bedre ved at sende brugsstatistik og nedbrudsrapporter til Brave Software.</translation>
+<translation id="3518985090088779359">Acceptér og fortsæt</translation>
+<translation id="7207456302801184289">Velkommen til Brave</translation>
+<translation id="704822250101715322">Venter på, at Brave Software Play-tjenester er opdateret</translation>
+<translation id="1231733316453485619">Vil du aktivere synkronisering?</translation>
+<translation id="5132942445612118989">Synkroniser dine adgangskoder, din historik og meget mere på alle enheder</translation>
+<translation id="5736731321935944068">Brave Software kan bruge din historik til at tilpasse Søgning, annoncer og andre Brave Software-tjenester</translation>
+<translation id="4013614219085422040">Brave Software kan bruge din historik til at tilpasse Søgning og andre Brave Software-tjenester</translation>
+<translation id="5581519193887989363">Du kan altid vælge, hvad der skal synkroniseres, i <ph name="BEGIN_LINK1"/>indstillingerne<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Ja tak</translation>
+<translation id="2410754283952462441">Vælg en konto</translation>
+<translation id="2227444325776770048">Fortsæt som <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Ikke <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Aktivér synkronisering for at få vist dine bogmærker på alle dine enheder</translation>
+<translation id="2818669890320396765">Log ind, og aktivér synkronisering for at få vist dine bogmærker på alle dine enheder</translation>
+<translation id="6003646045106347985">Aktivér synkronisering for at hente brugertilpasset indhold, som er foreslået af Brave Software</translation>
+<translation id="8494430740943879273">Log ind, og aktivér synkronisering for at hente brugertilpasset indhold, som er foreslået af Brave Software</translation>
+<translation id="5862731021271217234">Aktivér synkronisering for at få adgang til dine faner på dine andre enheder</translation>
+<translation id="3568688522516854065">Log ind, og aktivér synkronisering for at få adgang til dine faner på dine andre enheder</translation>
+<translation id="1208340532756947324">Aktivér synkronisering for at synkronisere og tilpasse på alle dine enheder</translation>
+<translation id="4472118726404937099">Log ind, og aktivér synkronisering for at synkronisere og tilpasse på alle dine enheder</translation>
+<translation id="2426805022920575512">Vælg en anden konto</translation>
+<translation id="6790428901817661496">Afspil</translation>
+<translation id="1272079795634619415">Stop</translation>
+<translation id="2874939134665556319">Forrige nummer</translation>
+<translation id="4046123991198612571">Næste nummer</translation>
+<translation id="3859306556332390985">Spol fremad</translation>
+<translation id="8441146129660941386">Spol tilbage</translation>
+<translation id="6706288973712894588">Du er i øjeblikket offline.\n<ph name="BEGIN_LINK"/>Gå på opdagelse i dit offlinefeed<ph name="END_LINK"/>.</translation>
+<translation id="572328651809341494">Seneste faner</translation>
+<translation id="8497726226069778601">Her er ikke noget at se… endnu</translation>
+<translation id="5423934151118863508">Dine mest besøgte sider vises her</translation>
+<translation id="6127379762771434464">Elementet blev fjernet</translation>
+<translation id="4605958867780575332">Element fjernet: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software-doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Andre enheder</translation>
+<translation id="4738836084190194332">Seneste synkronisering: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{For # minut siden}one{For # minut siden}other{For # minutter siden}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{For 1 time siden}one{For # time siden}other{For # timer siden}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{For 1 dag siden}one{For # dag siden}other{For # dage siden}}</translation>
+<translation id="2762000892062317888">lige nu</translation>
+<translation id="1407135791313364759">Åbn alle</translation>
+<translation id="1209206284964581585">Skjul indtil videre</translation>
+<translation id="129553762522093515">Senest lukkede</translation>
+<translation id="8413126021676339697">Vis hele historikken</translation>
+<translation id="7876243839304621966">Fjern alt</translation>
+<translation id="8487700953926739672">Tilgængelig offline</translation>
+<translation id="5224771365102442243">Med video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Få flere oplysninger<ph name="END_LINK"/> om anbefalet indhold</translation>
+<translation id="7542481630195938534">Forslagene kan ikke hentes</translation>
+<translation id="5013696553129441713">Der er ingen nye forslag</translation>
+<translation id="1736419249208073774">Mere</translation>
+<translation id="7444811645081526538">Flere kategorier</translation>
+<translation id="6709133671862442373">Nyheder</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Shopping</translation>
+<translation id="3912508018559818924">Finder det bedste fra nettet…</translation>
+<translation id="526421993248218238">Siden kunne ikke indlæses</translation>
+<translation id="614940544461990577">Prøv at:</translation>
+<translation id="3288003805934695103">Genindlæse siden</translation>
+<translation id="2353636109065292463">Tjekker din internetforbindelse</translation>
+<translation id="2858138569776157458">Topwebsites</translation>
+<translation id="8364299278605033898">Se populære websites</translation>
+<translation id="1171770572613082465">Se populære websites ved at trykke på knappen "Topwebsites"</translation>
+<translation id="5233638681132016545">Ny fane</translation>
+<translation id="4521874409998847950">Fra <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>leveret af Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Der findes en nyere version</translation>
+<translation id="4058091506841967397">Brave kan ikke opdateres</translation>
+<translation id="6316139424528454185">Android-versionen understøttes ikke</translation>
+<translation id="6989267951144302301">Der kan ikke downloades</translation>
+<translation id="624789221780392884">Opdateringen er klar</translation>
+<translation id="1549000191223877751">Flyt til et andet vindue</translation>
+<translation id="7481312909269577407">Frem</translation>
+<translation id="4084682180776658562">Bogmærke</translation>
+<translation id="6437478888915024427">Sideoplysninger</translation>
+<translation id="7180611975245234373">Opdater</translation>
+<translation id="4913169188695071480">Stop med at opdatere</translation>
+<translation id="1829244130665387512">Find på siden</translation>
+<translation id="6593061639179217415">Standardwebsite</translation>
+<translation id="9063523880881406963">Slå anmodning om computerversionen af websitet fra</translation>
+<translation id="2038563949887743358">Slå computerversionen af websitet til</translation>
+<translation id="2433507940547922241">Udseende</translation>
+<translation id="983192555821071799">Luk alle faner</translation>
+<translation id="1310482092992808703">Gruppér faner</translation>
+<translation id="7725024127233776428">De sider, du føjer et bogmærke til, vises her</translation>
+<translation id="4404568932422911380">Der er ingen bogmærker</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> bogmærke}one{<ph name="BOOKMARKS_COUNT_MANY"/>bogmærke}other{<ph name="BOOKMARKS_COUNT_MANY"/>bogmærker}}</translation>
+<translation id="3739899004075612870">Tilføjet som bogmærke i <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Gemt som bogmærke</translation>
+<translation id="4452548195519783679">Bogmærket er gemt i <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Bogmærket kunne ikke tilføjes.</translation>
+<translation id="2842985007712546952">Overordnet mappe</translation>
+<translation id="9065203028668620118">Rediger</translation>
+<translation id="4405224443901389797">Flyt til…</translation>
+<translation id="5170568018924773124">Vis i mappe</translation>
+<translation id="8035133914807600019">Ny mappe…</translation>
+<translation id="4532845899244822526">Vælg mappe</translation>
+<translation id="6627583120233659107">Rediger mappen</translation>
+<translation id="1197267115302279827">Flyt bogmærker</translation>
+<translation id="6963766334940102469">Slet bogmærker</translation>
+<translation id="4351244548802238354">Luk dialogboksen</translation>
+<translation id="451872707440238414">Søg i dine bogmærker</translation>
+<translation id="8901170036886848654">Der blev ikke fundet nogen bogmærker</translation>
+<translation id="6404511346730675251">Rediger bogmærke</translation>
+<translation id="3894427358181296146">Tilføj mappe</translation>
+<translation id="5327248766486351172">Navn</translation>
+<translation id="7400418766976504921">Webadresse</translation>
+<translation id="3527085408025491307">Mappe</translation>
+<translation id="5161254044473106830">Der skal angives en titel</translation>
+<translation id="2996809686854298943">En webadresse er påkrævet</translation>
+<translation id="2536728043171574184">Du ser en offlinekopi af denne side</translation>
+<translation id="4698034686595694889">Se offline i <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> og andre websites</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave indlæser din side, når det er muligt}one{Brave indlæser din side, når det er muligt}other{Brave indlæser dine sider, når det er muligt}}</translation>
+<translation id="6811034713472274749">Siden kan nu ses</translation>
+<translation id="4561979708150884304">Der er ingen forbindelse</translation>
+<translation id="8274165955039650276">Se downloads</translation>
+<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER"/> af <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Ingen resultater</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Aktiveret talesøgning ikke tilgængelig</translation>
+<translation id="7191430249889272776">Fanen blev åbnet i baggrunden.</translation>
+<translation id="8445059357334030806">Åbn i Brave</translation>
+<translation id="4720023427747327413">Åbn i <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Åbn i browser</translation>
+<translation id="1113597929977215864">Se enkel visning</translation>
+<translation id="1513352483775369820">Bogmærker og webhistorik</translation>
+<translation id="4939482511480190003">Vær med til at forbedre Brave. <ph name="BEGIN_LINK"/>Deltag i undersøgelsen<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Gå tilbage</translation>
+<translation id="5596627076506792578">Flere valgmuligheder</translation>
+<translation id="3522247891732774234">Tilgængelig opdatering. Flere muligheder</translation>
+<translation id="6773423637732432200">Brave kan ikke opdateres. Flere valgmuligheder</translation>
+<translation id="3328801116991980348">Webstedoplysninger</translation>
+<translation id="5391532827096253100">Din forbindelse til dette website er ikke sikker. Websiteoplysninger</translation>
+<translation id="6206551242102657620">Forbindelsen er sikker. Websiteoplysninger</translation>
+<translation id="6963642900430330478">Denne side er farlig. Websiteoplysninger</translation>
+<translation id="9070377983101773829">Start talesøgning</translation>
+<translation id="8676374126336081632">Ryd indtastning</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> åben fane – tryk for at skifte fane}one{<ph name="OPEN_TABS_MANY"/> åben fane – tryk for at skifte fane}other{<ph name="OPEN_TABS_MANY"/> åbne faner – tryk for at skifte fane}}</translation>
+<translation id="2369533728426058518">åbne faner</translation>
+<translation id="7071521146534760487">Administrer konto</translation>
+<translation id="932327136139879170">Start</translation>
+<translation id="2707726405694321444">Opdater siden</translation>
+<translation id="2891154217021530873">Stop sideindlæsning</translation>
+<translation id="6710213216561001401">Forrige</translation>
+<translation id="6659594942844771486">Fane</translation>
+<translation id="1933845786846280168">Valgt fane</translation>
+<translation id="2268044343513325586">Juster</translation>
+<translation id="7846076177841592234">Annuller valg</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> er markeret. De tilgængelige valgmuligheder er øverst på skærmen</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> er markeret</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Del 1 valgt element}one{Del # valgt element}other{Del # valgte elementer}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Fjern 1 valgt element}one{Fjern # valgt element}other{Fjern # valgte elementer}}</translation>
+<translation id="1283039547216852943">Tryk for at udvide</translation>
+<translation id="5962718611393537961">Tryk for at skjule</translation>
+<translation id="8076492880354921740">Faner</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 er valgt}one{# er valgt}other{# er valgt}}</translation>
+<translation id="6818926723028410516">Vælg elementer</translation>
+<translation id="4797039098279997504">Tryk for at gå tilbage til <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Tryk for at gå til websitet</translation>
+<translation id="429312253194641664">Et website afspiller medier</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> deler din skærm</translation>
+<translation id="8833831881926404480">Et website deler din skærm</translation>
+<translation id="9086455579313502267">Der kunne ikke opnås adgang til netværket</translation>
+<translation id="938850635132480979">Fejl: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Åbn i <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Åbn i kortapp</translation>
+<translation id="7698359219371678927">Opret mail i <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Opret mail</translation>
+<translation id="5665379678064389456">Opret begivenhed i <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Opret begivenhed</translation>
+<translation id="2111511281910874386">Gå til side</translation>
+<translation id="3988466920954086464">Se direkte søgeresultater i dette panel</translation>
+<translation id="2744248271121720757">Tryk på et ord for at søge øjeblikkeligt eller se relaterede handlinger</translation>
+<translation id="9155898266292537608">Du kan også søge med et hurtigt tryk på et ord</translation>
+<translation id="3232754137068452469">Webapp</translation>
+<translation id="1430915738399379752">Udskriv</translation>
+<translation id="3775705724665058594">Send til dine enheder</translation>
+<translation id="6364438453358674297">Vil du fjerne forslaget fra historikken?</translation>
+<translation id="213279576345780926">Lukkede <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> faner blev lukket</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> blev slettet</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> bogmærker blev slettet</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> downloads blev slettet</translation>
+<translation id="1248710015876067820">Der er flere forekomster af Brave, end der understøttes.</translation>
+<translation id="4259722352634471385">Navigationen er blokeret: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigationen er ikke mulig: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Luk fanen</translation>
+<translation id="7772375229873196092">Luk <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Navigationsoversigt</translation>
+<translation id="9169507124922466868">Navigationshistorikken er åbnet halvt</translation>
+<translation id="1327257854815634930">Navigationsoversigt er åbnet</translation>
+<translation id="8788265440806329501">Navigationsoversigt er lukket</translation>
+<translation id="7482656565088326534">Fanen forhåndsvisning</translation>
+<translation id="8427875596167638501">Fanen forhåndsvisning er åbnet halvt</translation>
+<translation id="9102803872260866941">Fanen forhåndsvisning er åben</translation>
+<translation id="2942036813789421260">Fanen forhåndsvisning er lukket</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/>-lagerplads</translation>
+<translation id="3822502789641063741">Vil du rydde websitelagerpladsen?</translation>
+<translation id="9205995714227143200">Websitelagerplads, som ikke er vigtig ifølge Brave (f.eks. websites uden gemte indstillinger eller websites, du ikke besøger så ofte)</translation>
+<translation id="3997476611815694295">Lagerplads, der ikke er vigtig</translation>
+<translation id="8493948351860045254">Frigør plads</translation>
+<translation id="2324920234469020158">Dette rydder cookies, cache og andre data fra websites, som ikke er vigtige ifølge Brave.</translation>
+<translation id="5447201525962359567">Al websitelagerplads, herunder cookies og andre data, der er gemt lokalt</translation>
+<translation id="1376578503827013741">Beregner…</translation>
+<translation id="583281660410589416">Ukendt</translation>
+<translation id="2323763861024343754">Websitelagerplads</translation>
+<translation id="3587672679800759167">Samlet mængde data, som Brave anvender, herunder konti, bogmærker og gemte indstillinger</translation>
+<translation id="6545017243486555795">Ryd alle data</translation>
+<translation id="4095146165863963773">Vil du slette appdata?</translation>
+<translation id="53119194224775367">Alle Braves appdata slettes permanent. Dette omfatter alle filer, indstillinger, konti, databaser osv.</translation>
+<translation id="5307446750509046227">Ryd websitelagerplads</translation>
+<translation id="300526633675317032">Dette rydder alle <ph name="SIZE_IN_KB"/> i websitelagerpladsen.</translation>
+<translation id="8068648041423924542">Certifikatet kunne ikke vælges.</translation>
+<translation id="2315043854645842844">Klientens certifikatvalg understøttes ikke af operativsystemet.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> vil gerne oprette forbindelse</translation>
+<translation id="5308380583665731573">Få forbindelse</translation>
+<translation id="868929229000858085">Søg blandt dine kontakter</translation>
+<translation id="1919950603503897840">Vælg kontakter</translation>
+<translation id="7986741934819883144">Vælg en kontakt</translation>
+<translation id="3333961966071413176">Alle kontakter</translation>
+<translation id="4994033804516042629">Der blev ikke fundet nogen kontakter</translation>
+<translation id="5403592356182871684">Navne</translation>
+<translation id="2717722538473713889">Mailadresser</translation>
+<translation id="381841723434055211">Telefonnumre</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 anden)}one{(+ # anden)}other{(+ # andre)}}</translation>
+<translation id="5197729504361054390">De kontakter, du vælger, deles med <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Værktøj til afkodning af billeder</translation>
+<translation id="8067883171444229417">Afspil video</translation>
+<translation id="6560414384669816528">Søg via Sogou</translation>
+<translation id="5406914950576900927">Brave kan bruge <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> til søgninger i Kina. Du kan ændre dette i <ph name="BEGIN_LINK"/>Indstillinger<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Behold Brave Software</translation>
+<translation id="4384468725000734951">Søgning via Sogou</translation>
+<translation id="6103327872225198548">Søgning via Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Denne app kører i Brave</translation>
+<translation id="6143689084714664628">Kører i Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> har også data i Brave</translation>
+<translation id="2734140769649165081">Du kan rydde dataene i Brave-indstillingerne</translation>
+<translation id="8232956427053453090">Behold data</translation>
+<translation id="4298388696830689168">Tilknyttede websites</translation>
+<translation id="5763514718066511291">Tryk for at kopiere webadressen til denne app</translation>
+<translation id="6496823230996795692">Opret forbindelse til internettet, første gang du bruger <ph name="APP_NAME"/>.</translation>
+<translation id="751961395872307827">Der kunne ikke oprettes forbindelse til websitet</translation>
+<translation id="4878404682131129617">Der kunne ikke etableres en tunnel via proxyserver</translation>
+<translation id="4749960740855309258">Åbn en ny fane</translation>
+<translation id="8788968922598763114">Åbn den senest lukkede fane igen</translation>
+<translation id="7929962904089429003">Åbn menuen</translation>
+<translation id="6039379616847168523">Gå til den næste fane</translation>
+<translation id="5210286577605176222">Gå til den forrige fane</translation>
+<translation id="124678866338384709">Luk aktuel fane</translation>
+<translation id="3714981814255182093">Åbn søgefeltet</translation>
+<translation id="5441522332038954058">Gå til adresselinjen</translation>
+<translation id="3398320232533725830">Åbn bogmærkeadministratoren</translation>
+<translation id="6583199322650523874">Føj et bogmærke til den aktuelle side</translation>
+<translation id="8489271220582375723">Åbn siden med historik</translation>
+<translation id="4837753911714442426">Åbn valgmuligheder for udskrivning af siden</translation>
+<translation id="5726692708398506830">Gør alting på siden større</translation>
+<translation id="3259831549858767975">Gør alting på siden mindre</translation>
+<translation id="8015452622527143194">Nulstil alt på siden til standardstørrelsen</translation>
+<translation id="3443221991560634068">Genindlæs den aktuelle side</translation>
+<translation id="123724288017357924">Genindlæs aktuel side, og ignorer indhold gemt i cache</translation>
+<translation id="305870044889644984">Åbn Hjælp til Brave i en ny fane</translation>
+<translation id="3166827708714933426">Genveje på faner og i vinduer</translation>
+<translation id="3169981355900570544">Funktionsgenveje i Brave Software Brave</translation>
+<translation id="4558311620361989323">Genveje på websider</translation>
+<translation id="1908301351964700579">Brave er stadig i gang med at forberede VR. Genstart Brave senere.</translation>
+<translation id="8970887620466824814">Der opstod en fejl.</translation>
+<translation id="1875543012935658554">Åbn Brave igen.</translation>
+<translation id="79859296434321399">Installer ARCore for at se augmented reality-indhold</translation>
+<translation id="8558485628462305855">Opdater ARCore for at se augmented reality-indhold</translation>
+<translation id="3513704683820682405">Augmented reality</translation>
+<translation id="5475862044948910901">Vil du starte en session med augmented reality?</translation>
 <translation id="7365126855094612066">Under denne session kan websitet:
 • Oprette et 3D-kort over dine omgivelser
 • Spore kamerabevægelser
 
 Websitet får IKKE adgang til kameraet. Kameraets billeder kan kun ses af dig.</translation>
-<translation id="7375125077091615385">Type:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">Webadresse</translation>
-<translation id="7403691278183511381">Førstegangsoplevelse af Chrome</translation>
-<translation id="741204030948306876">Ja tak</translation>
-<translation id="7413229368719586778">Startdato <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Spørg først</translation>
-<translation id="7423538860840206698">Blokeret fra at læse udklipsholderen</translation>
-<translation id="7431991332293347422">Bestem selv, hvordan din browserhistorik skal bruges til at tilpasse søgeresultater m.m.</translation>
-<translation id="7437998757836447326">Log ud af Chrome</translation>
-<translation id="7438641746574390233">Når Lite-tilstand er aktiveret, bruger Chrome Googles servere til at gøre sideindlæsningen hurtigere. Lite-tilstanden omskriver meget langsomme sider til kun at indlæse væsentligt indhold. Lite-tilstand kan ikke bruges i inkognitotilstand.</translation>
-<translation id="7444811645081526538">Flere kategorier</translation>
-<translation id="7445411102860286510">Tillad, at websites automatisk afspiller videoer med lyden slået fra (anbefales)</translation>
-<translation id="7453467225369441013">Logger dig ud af de fleste websites. Du bliver ikke logget ud af din Google-konto.</translation>
-<translation id="7454641608352164238">Der er ikke nok plads</translation>
-<translation id="7475192538862203634">Hvis du ser dette jævnligt, kan du prøve disse <ph name="BEGIN_LINK" />forslag<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD-kortet blev fundet. Nogle af dine filer mangler muligvis.</translation>
-<translation id="7479104141328977413">Faneadministration</translation>
-<translation id="7481312909269577407">Frem</translation>
-<translation id="7482656565088326534">Fanen forhåndsvisning</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Opdateret <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">databesparelse</translation>
-<translation id="7498271377022651285">Vent…</translation>
-<translation id="7514365320538308">Download</translation>
-<translation id="751961395872307827">Der kunne ikke oprettes forbindelse til websitet</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Forslagene kan ikke hentes</translation>
-<translation id="7559975015014302720">Lite-tilstand er deaktiveret</translation>
-<translation id="7562080006725997899">Browserdata ryddes</translation>
-<translation id="756809126120519699">Chrome-dataene blev ryddet</translation>
-<translation id="757524316907819857">Bloker afspilning af beskyttet indhold på websites</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fil blev downloadet}one{<ph name="FILES_DOWNLOADED_MANY" /> fil blev downloadet}other{<ph name="FILES_DOWNLOADED_MANY" /> filer blev downloadet}}</translation>
-<translation id="7588219262685291874">Aktivér mørkt tema, når enhedens batterisparefunktion er aktiveret</translation>
-<translation id="7589445247086920869">Bloker for den aktuelle søgemaskine</translation>
-<translation id="7593557518625677601">Åbn Android-indstillinger, og genaktiver synkronisering af Android-systemet for at starte Chrome-synkroniseringen</translation>
-<translation id="7596558890252710462">Operativsystem</translation>
-<translation id="7605594153474022051">Synkronisering fungerer ikke</translation>
-<translation id="7606077192958116810">Lite-tilstand er aktiveret. Administrer tilstanden i Indstillinger.</translation>
-<translation id="7612619742409846846">Du er logget ind på Google som</translation>
-<translation id="7619072057915878432">Download af <ph name="FILE_NAME" /> mislykkedes på grund af netværksfejl.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Få hjælp<ph name="END_LINK1" />, eller <ph name="BEGIN_LINK2" />scan igen<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Velkommen til Chrome</translation>
-<translation id="7638584964844754484">Forkert adgangssætning</translation>
-<translation id="7641339528570811325">Ryd browserdata…</translation>
-<translation id="7648422057306047504">Kryptér adgangskoder med Google-loginoplysninger</translation>
-<translation id="7649070708921625228">Hjælp</translation>
-<translation id="7658239707568436148">Annuller</translation>
-<translation id="7665369617277396874">Tilføj konto</translation>
-<translation id="766587987807204883">Her vises artikler, som du kan læse, selv når du er offline</translation>
-<translation id="7682724950699840886">Prøv følgende tips: Sørg for, at der er nok ledig plads på din enhed, og prøv at eksportere igen.</translation>
-<translation id="7685301384041462804">Sørg for, at du har tillid til dette website, før du starter VR.</translation>
-<translation id="7698359219371678927">Opret mail i <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Autofuldfør søgninger og webadresser</translation>
-<translation id="7725024127233776428">De sider, du føjer et bogmærke til, vises her</translation>
-<translation id="773466115871691567">Oversæt altid sider på <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Chrome sender webadresser på nogle sider, du besøger, begrænsede systemoplysninger og noget sideindhold til Google med henblik på at registrere farlige apps og websites.</translation>
-<translation id="7757787379047923882">Tekst, der deles fra <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-kort <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Tilføj adresse</translation>
-<translation id="7772032839648071052">Bekræft adgangssætning</translation>
-<translation id="7772375229873196092">Luk <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> mere}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> mere}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> mere}}</translation>
-<translation id="7781829728241885113">I går</translation>
-<translation id="7791543448312431591">Tilføj</translation>
-<translation id="780301667611848630">Nej tak</translation>
-<translation id="7810647596859435254">Åbn med…</translation>
-<translation id="7821588508402923572">Din databesparelse vises her</translation>
-<translation id="7837721118676387834">Tillad automatisk afspilning af videoer, hvor lyden er slået fra, for et bestemt website.</translation>
-<translation id="7846076177841592234">Annuller valg</translation>
-<translation id="784934925303690534">Tidsinterval</translation>
-<translation id="7851858861565204677">Andre enheder</translation>
-<translation id="7875915731392087153">Opret mail</translation>
-<translation id="7876243839304621966">Fjern alt</translation>
-<translation id="7882131421121961860">Der blev ikke fundet nogen historik</translation>
-<translation id="7882806643839505685">Tillad, at et bestemt website afspiller lyd.</translation>
-<translation id="7886917304091689118">Kører i Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Downloader fil.}one{Downloader # fil.}other{Downloader # filer.}}</translation>
-<translation id="7929962904089429003">Åbn menuen</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> er forældet.</translation>
-<translation id="7947953824732555851">Acceptér og log ind</translation>
-<translation id="7963646190083259054">Leverandør:</translation>
-<translation id="7971136598759319605">Aktiv for 1 dag siden</translation>
-<translation id="7975379999046275268">Se forhåndsvisning af siden <ph name="BEGIN_NEW" />Ny<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Forudindlæs sider, så du kan browse og søge hurtigere</translation>
-<translation id="79859296434321399">Installer ARCore for at se augmented reality-indhold</translation>
-<translation id="7986741934819883144">Vælg en kontakt</translation>
-<translation id="7987073022710626672">Chromes servicevilkår</translation>
-<translation id="7998918019931843664">Åbn lukket fane igen</translation>
-<translation id="7999064672810608036">Er du sikker på, at du vil slette alle lokale data, herunder cookies, og nulstille alle tilladelser for dette website?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Deaktiveret på denne enhed</translation>
-<translation id="8013372441983637696">Ryd også dine Chrome-data fra enheden</translation>
-<translation id="8015452622527143194">Nulstil alt på siden til standardstørrelsen</translation>
-<translation id="802154636333426148">Download mislykkedes</translation>
-<translation id="8026334261755873520">Ryd browserdata</translation>
-<translation id="8035133914807600019">Ny mappe…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> dage tilbage</translation>
-<translation id="804335162455518893">SD-kortet blev ikke fundet</translation>
-<translation id="805047784848435650">Baseret på din browserhistorik</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB er ledig</translation>
-<translation id="8058746566562539958">Åbn på ny fane i Chrome</translation>
-<translation id="8063895661287329888">Bogmærket kunne ikke tilføjes.</translation>
-<translation id="806745655614357130">Hold mine data adskilt</translation>
-<translation id="8067883171444229417">Afspil video</translation>
-<translation id="8068648041423924542">Certifikatet kunne ikke vælges.</translation>
-<translation id="8073388330009372546">Åbn billede på ny fane</translation>
-<translation id="8076492880354921740">Faner</translation>
-<translation id="8084114998886531721">Gemt adgangskode</translation>
-<translation id="8087000398470557479">Dette indhold er fra <ph name="DOMAIN_NAME" />, som leveres af Google.</translation>
-<translation id="8103578431304235997">Inkognitofane</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Aktivér synkronisering for at få vist dine bogmærker på alle dine enheder</translation>
-<translation id="8110087112193408731">Vil du se din Chrome-aktivitet i Digital balance?</translation>
-<translation id="8116925261070264013">Websites, hvor lyden er slået fra</translation>
-<translation id="813082847718468539">Se websiteoplysninger</translation>
-<translation id="8131740175452115882">Bekræft</translation>
-<translation id="8156139159503939589">Hvilke sprog læser du?</translation>
-<translation id="8168435359814927499">Indhold</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> filer tilbage</translation>
-<translation id="8190358571722158785">1 dag tilbage</translation>
-<translation id="8200772114523450471">Genoptag</translation>
-<translation id="8209050860603202033">Åbn billede</translation>
-<translation id="8218622182176210845">Administrer din konto</translation>
-<translation id="8224471946457685718">Download artikler til dig via Wi-Fi</translation>
-<translation id="8232956427053453090">Behold data</translation>
-<translation id="8249310407154411074">Flyt til toppen</translation>
-<translation id="8250920743982581267">Dokumenter</translation>
-<translation id="825412236959742607">Denne side anvender for meget hukommelse, så Chrome har fjernet noget indhold.</translation>
-<translation id="8260126382462817229">Prøv at logge ind igen</translation>
-<translation id="8261506727792406068">Slet</translation>
-<translation id="8266862848225348053">Downloadplacering</translation>
-<translation id="8274165955039650276">Se downloads</translation>
-<translation id="8284326494547611709">Undertekster</translation>
-<translation id="8300705686683892304">Administreres af en app</translation>
-<translation id="8310344678080805313">Standardfaner</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> og andre websites</translation>
-<translation id="8327155640814342956">Opdater Chrome for at få den bedste browseroplevelse</translation>
-<translation id="8339163506404995330">Sider på <ph name="LANGUAGE" /> oversættes ikke</translation>
-<translation id="8349013245300336738">Sortér efter mængden af data, der er brugt</translation>
-<translation id="8364299278605033898">Se populære websites</translation>
-<translation id="8368027906805972958">Ukendt eller ikke-understøttet enhed (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Tillad synkronisering i baggrunden for et bestemt website.</translation>
-<translation id="8378714024927312812">Administreret af din organisation</translation>
-<translation id="8380167699614421159">Dette website viser påtrængende eller vildledende annoncer</translation>
-<translation id="8393700583063109961">Send en besked</translation>
-<translation id="8413126021676339697">Vis hele historikken</translation>
-<translation id="8427875596167638501">Fanen forhåndsvisning er åbnet halvt</translation>
-<translation id="8428213095426709021">Indstillinger</translation>
-<translation id="8438566539970814960">Gør søgninger og browsing endnu bedre</translation>
-<translation id="8441146129660941386">Spol tilbage</translation>
-<translation id="8443209985646068659">Chrome kan ikke opdateres</translation>
-<translation id="8445448999790540984">Der kan ikke eksporteres adgangskoder</translation>
-<translation id="8447861592752582886">Tilbagekald adgangstilladelsen til enheden</translation>
-<translation id="8461694314515752532">Kryptér synkroniserede data med din egen adgangssætning til synkronisering</translation>
-<translation id="8466613982764129868">Sørg for, at <ph name="TARGET_DEVICE_NAME" /> har forbindelse til internettet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Tilgængelig offline</translation>
-<translation id="8489271220582375723">Åbn siden med historik</translation>
-<translation id="8493948351860045254">Frigør plads</translation>
-<translation id="8497726226069778601">Her er ikke noget at se… endnu</translation>
-<translation id="8503559462189395349">Chrome-adgangskoder</translation>
-<translation id="8503813439785031346">Brugernavn</translation>
-<translation id="8514477925623180633">Eksportér adgangskoder, der er gemt med Chrome</translation>
-<translation id="8514577642972634246">Slå inkognitotilstand til</translation>
-<translation id="851751545965956758">Bloker websites fra at oprette forbindelse til enheder</translation>
-<translation id="8523928698583292556">Slet den gemte adgangskode</translation>
-<translation id="854522910157234410">Åbn denne side</translation>
-<translation id="8558485628462305855">Opdater ARCore for at se augmented reality-indhold</translation>
-<translation id="8559990750235505898">Tilbyd at oversætte sider på andre sprog</translation>
-<translation id="8562452229998620586">Dine gemte adgangskoder vises her.</translation>
-<translation id="8569404424186215731">siden den <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Seneste 4 uger</translation>
-<translation id="857943718398505171">Tilladt (anbefales)</translation>
-<translation id="8583805026567836021">Kontodataene ryddes</translation>
-<translation id="860043288473659153">Kortholderens navn</translation>
-<translation id="8609465669617005112">Flyt op</translation>
-<translation id="8616006591992756292">Din Google-konto kan have andre former for browserhistorik på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Vil du åbne den foreslåede webadresse, som er angivet i det downloadede indhold?</translation>
-<translation id="8636825310635137004">Aktivér synkronisering for at få adgang til dine faner på dine andre enheder.</translation>
-<translation id="8641930654639604085">Prøv at blokere websites med indhold for voksne</translation>
-<translation id="8655129584991699539">Du kan rydde dataene i Chrome-indstillingerne</translation>
-<translation id="8662811608048051533">Logger dig ud af de fleste websites.</translation>
-<translation id="8664979001105139458">Filnavnet findes allerede</translation>
-<translation id="8676374126336081632">Ryd indtastning</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstyrkeniveau: # søjle}one{Signalstyrkeniveau: # søjle}other{Signalstyrkeniveau: # søjler}}</translation>
-<translation id="868929229000858085">Søg blandt dine kontakter</translation>
-<translation id="869891660844655955">Udløbsdato</translation>
-<translation id="8719023831149562936">Den aktuelle fane kan ikke overføres</translation>
-<translation id="8725066075913043281">Forsøg igen</translation>
-<translation id="8728487861892616501">Når du bruger denne app, accepterer du Chromes <ph name="BEGIN_LINK1" />servicevilkår<ph name="END_LINK1" /> og <ph name="BEGIN_LINK2" />erklæring om privatliv<ph name="END_LINK2" /> samt <ph name="BEGIN_LINK3" />erklæringen om privatliv for Google-konti, der administreres med Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Udfør</translation>
-<translation id="8748850008226585750">Indholdet er skjult</translation>
-<translation id="8751914237388039244">Vælg et billede</translation>
-<translation id="8788265440806329501">Navigationsoversigt er lukket</translation>
-<translation id="8788968922598763114">Åbn den senest lukkede fane igen</translation>
-<translation id="8801436777607969138">Bloker JavaScript for et bestemt website.</translation>
-<translation id="8812260976093120287">På nogle websites kan du betale med ovenstående understøttede betalingsapps på din enhed.</translation>
-<translation id="8816026460808729765">Bloker adgang til sensorer på websites</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> åbnes i Chrome. Når du fortsætter, accepterer du Chromes <ph name="BEGIN_LINK1" />servicevilkår<ph name="END_LINK1" /> og <ph name="BEGIN_LINK2" />erklæring om privatliv<ph name="END_LINK2" /> samt <ph name="BEGIN_LINK3" />erklæringen om privatliv for Google-konti, der administreres med Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Bogmærker</translation>
-<translation id="8833831881926404480">Et website deler din skærm</translation>
-<translation id="883806473910249246">Der opstod en fejl under download af indholdet.</translation>
-<translation id="8840953339110955557">Denne side kan afvige fra onlineversionen.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, fane</translation>
-<translation id="885701979325669005">Lagerplads</translation>
-<translation id="889338405075704026">Gå til Chrome-indstillinger</translation>
-<translation id="8901170036886848654">Der blev ikke fundet nogen bogmærker</translation>
-<translation id="8909135823018751308">Del…</translation>
-<translation id="8912362522468806198">Google-konto</translation>
-<translation id="8920114477895755567">Venter på oplysninger om forældre.</translation>
+<translation id="1188239144602654184">Start AR</translation>
+<translation id="473775607612524610">Opdater</translation>
+<translation id="3133489217401741157">Installerer <ph name="MODULE"/> til Brave…</translation>
+<translation id="1791662854739702043">Installeret</translation>
+<translation id="5131234170665854056"><ph name="MODULE"/> kunne ikke installeres til Brave</translation>
+<translation id="2567385386134582609">BILLEDE</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Download sider for at bruge dem, når du er offline</translation>
 <translation id="8922289737868596582">Download sider via knappen Flere valgmuligheder for at bruge dem, når du er offline</translation>
-<translation id="8937772741022875483">Vil du fjerne din Chrome-aktivitet fra Digital balance?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Åbn i et andet vindue</translation>
-<translation id="8951232171465285730">Chrome har sparet dig <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Bloker cookies for et bestemt website.</translation>
-<translation id="8959122750345127698">Navigationen er ikke mulig: <ph name="URL" /></translation>
-<translation id="8965591936373831584">afventer</translation>
-<translation id="8970887620466824814">Der opstod en fejl.</translation>
-<translation id="8972098258593396643">Vil du downloade til standardmappen?</translation>
-<translation id="8986494364107987395">Send automatisk brugsstatistikker og nedbrudsrapporter til Google</translation>
-<translation id="8993760627012879038">Åbn en ny fane i inkognitotilstand</translation>
-<translation id="8998729206196772491">Du er ved at logge ind med en konto, der administreres af <ph name="MANAGED_DOMAIN" />, hvilket giver administratoren kontrol over dine Chrome-data. Dine data tilknyttes denne konto permanent. Hvis du logger ud af Chrome, slettes dine data fra denne enhed, men de forbliver gemt på din Google-konto.</translation>
-<translation id="9019902583201351841">Administreret af dine forældre</translation>
-<translation id="9028914725102941583">Aktivér synkronisering for at dele mellem enheder</translation>
-<translation id="9029323097866369874">Vil du tillade, at <ph name="DOMAIN" /> starter VR?</translation>
-<translation id="9040142327097499898">Notifikationer er tilladt. Placering er deaktiveret for denne enhed.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}one{# video}other{# videoer}}</translation>
-<translation id="9050666287014529139">Adgangssætning</translation>
-<translation id="9063523880881406963">Slå anmodning om computerversionen af websitet fra</translation>
-<translation id="9065203028668620118">Rediger</translation>
-<translation id="9070377983101773829">Start talesøgning</translation>
-<translation id="9074336505530349563">Log ind, og aktivér synkronisering for at hente brugertilpasset indhold, som er foreslået af Google</translation>
-<translation id="9086455579313502267">Der kunne ikke opnås adgang til netværket</translation>
-<translation id="9100505651305367705">Tilbyd enkel visning af artikler, når det understøttes</translation>
-<translation id="9100610230175265781">Adgangssætning kræves</translation>
-<translation id="9102803872260866941">Fanen forhåndsvisning er åben</translation>
+<translation id="5958275228015807058">Find dine filer og sider i Downloads</translation>
+<translation id="5620928963363755975">Find dine filer og sider i Downloads via knappen Flere valgmuligheder</translation>
+<translation id="3341058695485821946">Se, hvor meget data du har sparet</translation>
+<translation id="3157842584138209013">Se, hvor meget data du har sparet via knappen Flere valgmuligheder</translation>
+<translation id="8218622182176210845">Administrer din konto</translation>
+<translation id="8090895580117672212">Tryk på knappen "Administrer konto" for at administrere din Brave Software-konto</translation>
+<translation id="8856898588039823173">Lite-side leveret af Brave Software. Tryk for at indlæse originalen.</translation>
+<translation id="8134317863207426198">Lite-side leveret af Brave Software. Tryk på knappen Indlæs original for at indlæse den originale side.</translation>
+<translation id="4961107849584082341">Oversæt denne side til et hvilket som helst sprog</translation>
+<translation id="569536719314091526">Oversæt denne side til et hvilket som helst sprog via knappen Flere valgmuligheder</translation>
+<translation id="1397811292916898096">Søg med <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Du kan til enhver tid skifte standardplaceringen for downloads</translation>
+<translation id="6942665639005891494">Du kan til enhver tid ændre standardplaceringen for downloads via menuen Indstillinger</translation>
+<translation id="6850409657436465440">Der downloades stadig</translation>
+<translation id="5817715962196959877">Brave downloader nu filer endnu hurtigere</translation>
+<translation id="3976396876660209797">Fjern og genskab denne genvej</translation>
+<translation id="6766622839693428701">Stryg ned for at lukke.</translation>
+<translation id="1028699632127661925">Sender til <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – sendt fra <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Du har modtaget en fane</translation>
 <translation id="9104217018994036254">Liste over enheder, der skal deles en fane med.</translation>
-<translation id="9133397713400217035">Udforsk offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Vis oprindelig</translation>
-<translation id="9139068048179869749">Spørg, før websites sender notifikationer (anbefales)</translation>
-<translation id="9139318394846604261">Shopping</translation>
-<translation id="9155898266292537608">Du kan også søge med et hurtigt tryk på et ord</translation>
-<translation id="9169507124922466868">Navigationshistorikken er åbnet halvt</translation>
-<translation id="9204836675896933765">1 fil tilbage</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Åben liste i halv højde over enheder, der skal deles en fane med.</translation>
+<translation id="2904414404539560095">Åben liste i fuld højde over enheder, der skal deles en fane med.</translation>
+<translation id="4135200667068010335">Lukket liste over enheder, der skal deles en fane med.</translation>
+<translation id="5292796745632149097">Send til</translation>
+<translation id="1386674309198842382">Aktiv for <ph name="LAST_UPDATED"/> dage siden</translation>
+<translation id="7971136598759319605">Aktiv for 1 dag siden</translation>
+<translation id="1521774566618522728">Aktiv i dag</translation>
+<translation id="3631987586758005671">Deler med <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Aktivér synkronisering for at dele mellem enheder</translation>
+<translation id="6162454065885854378">Hvis du vil dele noget på din telefon med en anden enhed, kan du aktivere synkronisering i Brave-indstillingerne på begge enheder</translation>
+<translation id="6084271560289605378">Gå til Brave-indstillinger</translation>
+<translation id="2318045970523081853">Tryk for at ringe op</translation>
 <translation id="9209888181064652401">Det er ikke muligt at foretage opkald</translation>
-<translation id="9219103736887031265">Billeder</translation>
-<translation id="926205370408745186">Fjern din Chrome-aktivitet fra Digital balance</translation>
-<translation id="932327136139879170">Start</translation>
-<translation id="938850635132480979">Fejl: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Adgang til din mikrofon</translation>
-<translation id="95817756606698420">Chrome kan bruge <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> til søgninger i Kina. Du kan ændre dette i <ph name="BEGIN_LINK" />Indstillinger<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloker, hvis websitet viser påtrængende eller vildledende annoncer (anbefales)</translation>
-<translation id="968900484120156207">De sider, du besøger, vises her</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minutter tilbage</translation>
-<translation id="974555521953189084">Angiv din adgangssætning for at starte synkroniseringen</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Denne handling rydder dataene for alle websites, herunder:</translation>
-<translation id="983192555821071799">Luk alle faner</translation>
-<translation id="987264212798334818">Generelt</translation>
+<translation id="2860954141821109167">Sørg for, at opkaldsappen er aktiveret på denne enhed</translation>
+<translation id="2067805253194386918">tekst</translation>
+<translation id="1450753235335490080">Delingen af <ph name="CONTENT_TYPE"/> mislykkedes</translation>
+<translation id="1266864766717917324">Det var ikke muligt at dele <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Sørg for, at synkronisering er aktiveret i Brave på <ph name="TARGET_DEVICE_NAME"/></translation>
+<translation id="3016635187733453316">Sørg for, at din enhed har forbindelse til internettet</translation>
+<translation id="8466613982764129868">Sørg for, at <ph name="TARGET_DEVICE_NAME"/> har forbindelse til internettet</translation>
+<translation id="6539092367496845964">Der opstod en fejl. Prøv igen senere.</translation>
+<translation id="3389286852084373014">Teksten er for lang</translation>
+<translation id="2100314319871056947">Prøv at opdele teksten i mindre stykker</translation>
+<translation id="2987620471460279764">Tekst, der er delt fra en anden enhed</translation>
+<translation id="7757787379047923882">Tekst, der deles fra <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kopieret til din udklipsholder</translation>
+<translation id="4696983787092045100">Send sms til dine enheder</translation>
+<translation id="1260236875608242557">Søg, og udforsk</translation>
+<translation id="6369229450655021117">Herfra kan du søge på nettet, dele indhold med venner og se åbne sider</translation>
+<translation id="723171743924126238">Vælg billeder</translation>
+<translation id="8751914237388039244">Vælg et billede</translation>
+<translation id="1989112275319619282">Gennemse</translation>
+<translation id="7055152154916055070">Omdirigeringen blev blokeret:</translation>
+<translation id="5524843473235508879">Omdirigeringen blev blokeret.</translation>
+<translation id="6573096386450695060">Tillad altid</translation>
+<translation id="5805364706385912897">Denne side anvender for meget hukommelse, så Brave har sat den på pause.</translation>
+<translation id="5138664332909611586">Denne side anvender for meget hukommelse, så Brave har fjernet noget indhold.</translation>
+<translation id="9137013805542155359">Vis oprindelig</translation>
+<translation id="6361779936989026201">Brave Software Assistent i Brave</translation>
+<translation id="7291387454912369099">Betaling udløst af Assistent</translation>
+<translation id="4565206163201411670">Vil du se din Brave-aktivitet i Digital balance?</translation>
+<translation id="9055113864158719823">Du kan se websites, du har besøgt i Brave, og indstille timere for dem.\n\nBrave Software får oplysninger om de websites, du indstiller timere for, og hvor længe du er på dem. Disse oplysninger bruges til at forbedre Digital balance.</translation>
+<translation id="4596514158372210596">Fjern din Brave-aktivitet fra Digital balance</translation>
+<translation id="1174893863889683998">Vil du fjerne din Brave-aktivitet fra Digital balance?</translation>
+<translation id="708829030563435351">Websites, du besøger i Brave, vises ikke. Alle timere for websites slettes.</translation>
+<translation id="2056878612599315956">Websitet er sat på pause</translation>
+<translation id="671481426037969117">Din timer for <ph name="FQDN"/> udløb. Den starter igen i morgen.</translation>
+<translation id="7479104141328977413">Faneadministration</translation>
+<translation id="3524138585025253783">Brugerflade for udviklere</translation>
+<translation id="6036057147555329831">Ekstra ICU</translation>
+<translation id="9029323097866369874">Vil du tillade, at <ph name="DOMAIN"/> starter VR?</translation>
+<translation id="7685301384041462804">Sørg for, at du har tillid til dette website, før du starter VR.</translation>
+<translation id="5033865233969348410">Mens du er i VR, kan dette website muligvis få oplysninger om:
+  –  Dine fysiske træk som f.eks. højde
+
+Sørg for, at du har tillid til dette website, før du starter VR.</translation>
+<translation id="5534334044554683961">Mens du er i VR, kan dette website muligvis få oplysninger om:
+  –   Dine fysiske træk som f.eks. højde
+  –   Layoutet i det rum, du befinder dig i
+
+Sørg for, at du har tillid til dette website, før du starter VR.</translation>
+<translation id="4169535189173047238">Tillad ikke</translation>
+<translation id="2170088579611075216">Tillad og start VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_de.xtb
+++ b/android/java/strings/translations/android_chrome_strings_de.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="de">
-<translation id="1006017844123154345">Online öffnen</translation>
-<translation id="1028699632127661925">Wird an <ph name="DEVICE_NAME" /> gesendet…</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> wird hinzugefügt...</translation>
-<translation id="1041308826830691739">Von Websites</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Nie speichern für…</translation>
-<translation id="1067922213147265141">Weitere Google-Dienste</translation>
-<translation id="1068672505746868501">Seiten auf <ph name="SOURCE_LANGUAGE" /> nie übersetzen</translation>
-<translation id="107147699690128016">Eine Änderung der Dateiendung kann zum Öffnen der Datei in einer anderen Anwendung führen und Schäden an Ihrem Gerät verursachen.</translation>
-<translation id="1100066534610197918">In neuem Tab in Gruppe öffnen</translation>
-<translation id="1105960400813249514">Bildschirmaufnahme</translation>
-<translation id="1111673857033749125">Hier werden die Lesezeichen angezeigt, die auf Ihren anderen Geräten gespeichert sind.</translation>
-<translation id="1113597929977215864">Vereinfachte Ansicht anzeigen</translation>
-<translation id="1121094540300013208">Nutzungs- und Absturzberichte</translation>
-<translation id="1124772482545689468">Nutzer</translation>
-<translation id="1129510026454351943">Details: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 Download ausstehend.}other{# Downloads ausstehend.}}</translation>
-<translation id="1145536944570833626">Vorhandene Daten löschen</translation>
-<translation id="1146678959555564648">VR aktivieren</translation>
-<translation id="116280672541001035">Genutzt</translation>
-<translation id="1171770572613082465">Tippen Sie auf die Schaltfläche "Top-Websites", um beliebte Websites zu sehen</translation>
-<translation id="1173894706177603556">Umbenennen</translation>
-<translation id="1178581264944972037">Anhalten</translation>
-<translation id="1181037720776840403">Entfernen</translation>
-<translation id="1188239144602654184">AR-Sitzung starten</translation>
-<translation id="1197267115302279827">Lesezeichen verschieben</translation>
-<translation id="119944043368869598">Alle löschen</translation>
-<translation id="1201402288615127009">Weiter</translation>
-<translation id="1204037785786432551">Link herunterladen</translation>
-<translation id="1206892813135768548">Linktext kopieren</translation>
-<translation id="1208340532756947324">Aktivieren Sie die Synchronisierung, um geräteübergreifend zu synchronisieren und zu personalisieren</translation>
-<translation id="1209206284964581585">Vorerst ausblenden</translation>
-<translation id="1227058898775614466">Navigationsverlauf</translation>
-<translation id="1231733316453485619">Synchronisierung aktivieren?</translation>
-<translation id="123724288017357924">Aktuelle Seite neu laden, Cache-Inhalte ignorieren</translation>
-<translation id="124116460088058876">Weitere Sprachen</translation>
-<translation id="124678866338384709">Aktuellen Tab schließen</translation>
-<translation id="1258753120186372309">Google-Doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Suchen und entdecken</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> konnte nicht geteilt werden</translation>
-<translation id="1272079795634619415">Stopp</translation>
-<translation id="1283039547216852943">Zum Maximieren tippen</translation>
-<translation id="1285320974508926690">Diese Website nie übersetzen</translation>
-<translation id="1291207594882862231">Verlauf, Cookies, Websitedaten, Cache leeren…</translation>
-<translation id="129382876167171263">Hier werden von Websites gespeicherte Dateien angezeigt</translation>
-<translation id="129553762522093515">Kürzlich geschlossen</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" />: gesendet von <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Tabs gruppieren</translation>
-<translation id="1327257854815634930">Der Navigationsverlauf ist geöffnet</translation>
-<translation id="1331212799747679585">Chrome kann nicht aktualisiert werden. Weitere Optionen</translation>
-<translation id="1332501820983677155">Tastenkombinationen für Google Chrome-Funktionen</translation>
-<translation id="1360432990279830238">Abmelden &amp; Synchronisierung deaktivieren?</translation>
-<translation id="1369915414381695676">Website "<ph name="SITE_NAME" />" hinzugefügt</translation>
-<translation id="1373696734384179344">Der Speicher reicht nicht aus, um den ausgewählten Inhalt herunterzuladen.</translation>
-<translation id="1376578503827013741">Berechnung läuft...</translation>
-<translation id="1383876407941801731">Suchen</translation>
-<translation id="1384959399684842514">Download angehalten</translation>
-<translation id="1386674309198842382">Vor <ph name="LAST_UPDATED" /> Tagen aktiv</translation>
-<translation id="1397811292916898096">Mit <ph name="PRODUCT_NAME" /> suchen</translation>
-<translation id="1404122904123200417">Eingebettet in <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"Do Not Track"</translation>
-<translation id="1407135791313364759">Alle öffnen</translation>
-<translation id="1409426117486808224">Vereinfachte Ansicht für geöffnete Tabs</translation>
-<translation id="1409879593029778104"><ph name="FILE_NAME" /> konnte nicht heruntergeladen werden, da die Datei bereits vorhanden ist.</translation>
-<translation id="1414981605391750300">Google wird kontaktiert. Das kann einen Moment dauern.</translation>
-<translation id="1416550906796893042">Anwendungsversion</translation>
-<translation id="1430915738399379752">Drucken</translation>
-<translation id="1446450296470737166">Volle Kontr. über MIDI-Ger. erl.</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> kann nicht geteilt werden</translation>
-<translation id="145097072038377568">In den Android-Einstellungen deaktiviert</translation>
-<translation id="1477626028522505441"><ph name="FILE_NAME" /> konnte aufgrund von Serverproblemen nicht heruntergeladen werden.</translation>
-<translation id="1506061864768559482">Suchmaschine</translation>
-<translation id="1513352483775369820">Lesezeichen und Webprotokoll</translation>
-<translation id="1513858653616922153">Passwort löschen</translation>
-<translation id="1516229014686355813">Mit "Zum Suchen tippen" werden das ausgewählte Wort und die aktuelle Seite als Kontext an die Google-Suche gesendet. Sie können die Funktion in den <ph name="BEGIN_LINK" />Einstellungen<ph name="END_LINK" /> deaktivieren.</translation>
-<translation id="1521774566618522728">Heute aktiv</translation>
-<translation id="1544826120773021464">Wenn Sie Ihr Google-Konto verwalten möchten, tippen Sie auf die Schaltfläche "Konto verwalten"</translation>
-<translation id="1549000191223877751">Zu anderem Fenster wechseln</translation>
-<translation id="1553358976309200471">Chrome aktualisieren</translation>
-<translation id="1569387923882100876">Verbundenes Gerät</translation>
-<translation id="1571304935088121812">Nutzernamen kopieren</translation>
-<translation id="1612196535745283361">Chrome benötigt Zugriff auf den Standort, um nach Geräten suchen zu können. Der Standortzugriff ist <ph name="BEGIN_LINK" />für dieses Gerät deaktiviert<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Keine weiteren Dialogfelder auf dieser Seite zulassen</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 ausgewähltes Element entfernen}other{# ausgewählte Elemente entfernen}}</translation>
-<translation id="164269334534774161">Sie sehen sich momentan eine Offlinekopie dieser Seite vom <ph name="CREATION_TIME" /> an</translation>
-<translation id="1644574205037202324">Verlauf</translation>
-<translation id="1647391597548383849">Kamerazugriff</translation>
-<translation id="1660204651932907780">Wiedergabe von Ton auf Websites zulassen (empfohlen)</translation>
-<translation id="1670399744444387456">Grundlegend</translation>
-<translation id="1671236975893690980">Download ausstehend...</translation>
-<translation id="1672586136351118594">Nicht mehr anzeigen</translation>
-<translation id="1692118695553449118">Synchronisierung ist aktiviert</translation>
-<translation id="169515064810179024">Zugriff auf Bewegungssensoren für Websites blockieren</translation>
-<translation id="1717218214683051432">Bewegungssensoren</translation>
-<translation id="1718835860248848330">Letzte Stunde</translation>
-<translation id="1736419249208073774">Entdecken</translation>
-<translation id="1743802530341753419">Nachfragen, bevor Websites eine Verbindung zu einem Gerät herstellen (empfohlen)</translation>
-<translation id="1749561566933687563">Lesezeichen synchronisieren</translation>
-<translation id="17513872634828108">Geöffnete Tabs</translation>
-<translation id="1779089405699405702">Bild-Decodierer</translation>
-<translation id="1782483593938241562">Enddatum: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installiert</translation>
-<translation id="1792959175193046959">Sie können den Standard-Downloadpfad jederzeit ändern</translation>
-<translation id="1807246157184219062">Hell</translation>
-<translation id="1810845389119482123">Erste Einrichtung der Synchronisierung nicht abgeschlossen</translation>
-<translation id="1821253160463689938">Zum Speichern Ihrer Einstellungen werden Cookies verwendet, auch wenn Sie diese Seiten nicht besuchen</translation>
-<translation id="1829244130665387512">Auf Seite suchen</translation>
-<translation id="1853692000353488670">Neuer Inkognito-Tab</translation>
-<translation id="1856325424225101786">Lite-Modus zurücksetzen?</translation>
-<translation id="1868024384445905608">In Chrome sind Downloads jetzt noch schneller</translation>
-<translation id="1883903952484604915">Meine Dateien</translation>
-<translation id="1887786770086287077">Der Standortzugriff ist für dieses Gerät deaktiviert. Sie können ihn in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" /> aktivieren.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> wird in Chrome geöffnet. Wenn Sie fortfahren, stimmen Sie den <ph name="BEGIN_LINK1" />Nutzungsbedingungen<ph name="END_LINK1" /> und <ph name="BEGIN_LINK2" />Datenschutzhinweisen<ph name="END_LINK2" /> von Chrome zu.</translation>
-<translation id="1919345977826869612">Werbung</translation>
-<translation id="1919950603503897840">Kontakte auswählen</translation>
-<translation id="1922076542920281912">Aktivieren Sie die Standortermittlung auch in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" />, damit Chrome auf Ihren Standort zugreifen kann.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> von <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Aktualisierungen</translation>
-<translation id="19288952978244135">Öffnen Sie Chrome noch einmal.</translation>
-<translation id="1933845786846280168">Ausgewählter Tab</translation>
-<translation id="194341124344773587">Berechtigung für Chrome in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" /> aktivieren</translation>
-<translation id="1943432128510653496">Passwörter speichern</translation>
-<translation id="1952172573699511566">Sofern dies möglich ist, wird Text auf Websites in Ihrer bevorzugten Sprache angezeigt.</translation>
-<translation id="1960290143419248813">Chrome-Updates werden für diese Version von Android nicht mehr unterstützt</translation>
-<translation id="1966710179511230534">Bitte aktualisieren Sie Ihre Anmeldeinformationen.</translation>
-<translation id="1974060860693918893">Erweitert</translation>
-<translation id="1984705450038014246">Chrome-Daten synchronisieren</translation>
-<translation id="1984937141057606926">Zugelassen, außer Cookies Dritter</translation>
-<translation id="1986685561493779662">Name ist bereits vorhanden</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> – Schaltfläche "<ph name="LINK_NAME" />"</translation>
-<translation id="1989112275319619282">Durchsuchen</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> möchte eine Kopplung durchführen</translation>
-<translation id="1994173015038366702">Website-URL</translation>
-<translation id="2000419248597011803">Suchanfragen, die in die Adressleiste und das Suchfeld eingegeben wurden, sowie einige Cookies werden an Ihre Standardsuchmaschine gesendet</translation>
-<translation id="2002537628803770967">Kreditkarten und Adressen aus Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Datei}other{# Dateien}}</translation>
-<translation id="2017836877785168846">Löscht den Verlauf sowie Autovervollständigungen in der Adressleiste.</translation>
-<translation id="2021896219286479412">Vollbild-Steuerelemente</translation>
-<translation id="2038563949887743358">"Desktopversion ansehen" aktivieren</translation>
-<translation id="2041019821020695769">Aktivieren Sie Benachrichtigungen auch in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" />, damit Chrome Ihnen Benachrichtigungen senden kann.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> hat auch Daten in Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Website pausiert</translation>
-<translation id="2063713494490388661">Zum Suchen tippen</translation>
-<translation id="2067805253194386918">Text</translation>
-<translation id="2079545284768500474">Rückgängig machen</translation>
-<translation id="2082238445998314030">Ergebnis <ph name="RESULT_NUMBER" /> von <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Ton</translation>
-<translation id="2096012225669085171">Geräteübergreifend synchronisieren und personalisieren</translation>
-<translation id="2100273922101894616">Automatisch anmelden</translation>
-<translation id="2100314319871056947">Teilen Sie den Text am besten in mehreren Abschnitten</translation>
-<translation id="2107397443965016585">Fragen, bevor Websites erlaubt wird, geschützten Inhalt wiederzugeben (empfohlen)</translation>
-<translation id="2111511281910874386">Seite aufrufen</translation>
-<translation id="2122601567107267586">App konnte nicht geöffnet werden</translation>
-<translation id="2126426811489709554">Powered by Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> eingespart</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> geschlossen</translation>
-<translation id="2139186145475833000">Zum Startbildschirm zufügen</translation>
-<translation id="2146738493024040262">Instant-App öffnen</translation>
-<translation id="2148716181193084225">Heute</translation>
-<translation id="2154484045852737596">Karte bearbeiten</translation>
-<translation id="2154710561487035718">URL kopieren</translation>
-<translation id="2156074688469523661">Restliche Websites (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Wenn Sie Inhalte auf Ihrem Smartphone mit einem anderen Gerät teilen möchten, aktivieren Sie auf beiden Geräten in den Chrome-Einstellungen die Synchronisierung</translation>
-<translation id="2170088579611075216">Zulassen und VR starten</translation>
-<translation id="218608176142494674">Freigabe</translation>
-<translation id="2227444325776770048">Als <ph name="USER_FULL_NAME" /> fortfahren</translation>
-<translation id="2234876718134438132">Synchronisierung und Google-Dienste</translation>
-<translation id="2259659629660284697">Passwörter exportieren…</translation>
-<translation id="2268044343513325586">Verfeinern</translation>
-<translation id="2286841657746966508">Rechnungsadresse</translation>
-<translation id="2289270750774289114">Nachfragen, wenn eine Website nach Bluetooth-Geräten in der Nähe suchen möchte (empfohlen)</translation>
-<translation id="230115972905494466">Keine kompatiblen Geräte gefunden</translation>
-<translation id="2315043854645842844">Die clientseitige Zertifikatauswahl wird vom Betriebssystem nicht unterstützt.</translation>
-<translation id="2318045970523081853">Zum Anrufen tippen</translation>
-<translation id="2321086116217818302">Passwörter werden zum Exportieren vorbereitet…</translation>
-<translation id="2321958826496381788">Ziehen Sie den Schieberegler, bis Sie diesen Text problemlos lesen können. Nach dem Doppeltippen auf einen Abschnitt sollte der Text mindestens so groß sein.</translation>
-<translation id="2323763861024343754">Websitespeicher</translation>
-<translation id="2328985652426384049">Anmeldung nicht möglich</translation>
-<translation id="2330129964253841015">Warnen, wenn Passwörter nicht mehr sicher sind</translation>
-<translation id="2349710944427398404">Gesamtdaten, die von Chrome verwendet werden, wie Konten, Lesezeichen und gespeicherte Einstellungen</translation>
-<translation id="2353636109065292463">Internetverbindung überprüfen</translation>
-<translation id="2359808026110333948">Weiter</translation>
-<translation id="2369533728426058518">Tabs öffnen</translation>
-<translation id="2387895666653383613">Text-Skalierung</translation>
-<translation id="2394602618534698961">Dateien, die Sie herunterladen, werden hier angezeigt</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Wenn Sie sich in Ihrem Google-Konto anmelden, ist diese Funktion eingeschaltet</translation>
-<translation id="2410754283952462441">Konto auswählen</translation>
-<translation id="2414886740292270097">Dunkel</translation>
-<translation id="2416359993254398973">Chrome benötigt für diese Website die Berechtigung, auf Ihre Kamera zuzugreifen.</translation>
-<translation id="2426805022920575512">Anderes Konto auswählen</translation>
-<translation id="2433507940547922241">Darstellung</translation>
-<translation id="2434158240863470628">Download abgeschlossen <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Standortzugriff</translation>
-<translation id="2450083983707403292">Möchten Sie den Download von <ph name="FILE_NAME" /> noch einmal starten?</translation>
-<translation id="2482878487686419369">Benachrichtigungen</translation>
-<translation id="2490684707762498678">Verwaltet von <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Assistant für Chrome</translation>
-<translation id="2496180316473517155">Browserverlauf</translation>
-<translation id="2497852260688568942">Die Synchronisierung wurde von Ihrem Administrator deaktiviert</translation>
-<translation id="2498359688066513246">Hilfe &amp; Feedback</translation>
-<translation id="2501278716633472235">Zurück</translation>
-<translation id="2513403576141822879">Weitere Einstellungen in Verbindung mit Datenschutz, Sicherheit und der Erhebung von Daten finden Sie unter <ph name="BEGIN_LINK" />Synchronisierung und Google-Dienste<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Im Lite-Modus werden Seiten schneller in Chrome geladen und es werden bis zu 60 % weniger Daten verbraucht. Zum Optimieren der von Ihnen besuchten Seiten sendet Chrome Ihren Datenverkehr an Google. <ph name="BEGIN_LINK" />Weitere Informationen<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">URLs der von Ihnen besuchten Seiten werden an Google gesendet</translation>
-<translation id="2532336938189706096">Web-Ansicht</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> Einträge gelöscht</translation>
-<translation id="2536728043171574184">Eine Offline-Kopie dieser Seite wird angezeigt.</translation>
-<translation id="2546283357679194313">Cookies und Websitedaten</translation>
-<translation id="2567385386134582609">BILD</translation>
-<translation id="257088987046510401">Designs</translation>
-<translation id="2570922361219980984">Der Standortzugriff ist für dieses Gerät ebenfalls deaktiviert. Sie können ihn in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" /> aktivieren.</translation>
-<translation id="257931822824936280">Maximiert – zum Minimieren klicken</translation>
-<translation id="2581165646603367611">Alle Cookies, der Cache und andere Daten von Websites, die Chrome nicht für wichtig hält, werden gelöscht.</translation>
-<translation id="2586657967955657006">Zwischenablage</translation>
-<translation id="2587052924345400782">Neuere Version verfügbar</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Kartennummer</translation>
-<translation id="2621115761605608342">JavaScript für eine bestimmte Website zulassen.</translation>
-<translation id="2625189173221582860">Passwort kopiert</translation>
-<translation id="2631006050119455616">Eingespart</translation>
-<translation id="2647434099613338025">Sprache hinzufügen</translation>
-<translation id="2650751991977523696">Datei noch einmal herunterladen?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Audiodatei}other{# Audiodateien}}</translation>
-<translation id="2653659639078652383">Senden</translation>
-<translation id="2677748264148917807">Verlassen</translation>
-<translation id="2704606927547763573">Kopiert</translation>
-<translation id="2707726405694321444">Seite aktualisieren</translation>
-<translation id="2709516037105925701">AutoFill</translation>
-<translation id="2717722538473713889">E-Mail-Adressen</translation>
-<translation id="2728754400939377704">Nach Website sortieren</translation>
-<translation id="2744248271121720757">Tippen Sie auf ein Wort, um eine Sofortsuche zu starten oder weitere Aktionen anzuzeigen</translation>
-<translation id="2760989362628427051">Dunkles Design verwenden, wenn beim Gerät der Energiesparmodus oder das dunkle Design aktiviert ist</translation>
-<translation id="2762000892062317888">gerade eben</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> Sekunden übrig</translation>
-<translation id="2779651927720337254">fehlgeschlagen</translation>
-<translation id="2781151931089541271">1 Sekunde übrig</translation>
-<translation id="2801022321632964776">Chrome jetzt aktualisieren und das Internet in Ihrer Sprache entdecken</translation>
-<translation id="2810645512293415242">Vereinfachte Seite für einen geringeren Datenverbrauch und schnelleres Laden.</translation>
-<translation id="281504910091592009">Gespeicherte Passwörter in Ihrem <ph name="BEGIN_LINK" />Google-Konto<ph name="END_LINK" /> ansehen und verwalten</translation>
-<translation id="2818669890320396765">Melden Sie sich an und aktivieren Sie die Synchronisierung, um Ihre Lesezeichen auf allen Ihren Geräten zu sehen</translation>
-<translation id="2822354292072154809">Möchten Sie wirklich alle Websiteberechtigungen für <ph name="CHOSEN_OBJECT_NAME" /> zurücksetzen?</translation>
-<translation id="2836148919159985482">Tippen Sie zum Beenden des Vollbildmodus auf die Zurück-Taste.</translation>
-<translation id="2842985007712546952">Übergeordneter Ordner</translation>
-<translation id="2858138569776157458">Top-Websites</translation>
-<translation id="2860954141821109167">Prüfen Sie, ob auf diesem Gerät eine Telefon-App aktiviert ist</translation>
-<translation id="2870560284913253234">Website</translation>
-<translation id="2874939134665556319">Vorheriger Titel</translation>
-<translation id="2876369937070532032">URLs einiger von mir besuchter Seiten an Google senden, wenn meine Sicherheit gefährdet ist</translation>
-<translation id="2888126860611144412">Über Google Chrome</translation>
-<translation id="2891154217021530873">Laden der Seite anhalten</translation>
-<translation id="2893180576842394309">Anhand Ihres Verlaufs kann Google die Google-Suche und andere Google-Dienste personalisieren</translation>
-<translation id="2898264748040935573">Gespeichertes Passwort bearbeiten</translation>
-<translation id="2900528713135656174">Termin erstellen</translation>
-<translation id="290376772003165898">Diese Seite ist nicht auf <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Die Liste von Geräten, mit denen ein Tab geteilt werden kann, ist ganz geöffnet.</translation>
-<translation id="2910701580606108292">Fragen, bevor die Wiedergabe geschützter Inhalte auf Websites zugelassen wird</translation>
-<translation id="2913331724188855103">Websites dürfen Cookiedaten speichern und lesen (empfohlen)</translation>
-<translation id="2923908459366352541">Der Name ist ungültig</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" />-Speicher</translation>
-<translation id="2942036813789421260">Vorschau-Tab ist geschlossen</translation>
-<translation id="2956410042958133412">Dieses Konto wird von <ph name="PARENT_NAME_1" /> und <ph name="PARENT_NAME_2" /> verwaltet.</translation>
-<translation id="2962095958535813455">Zu Inkognito-Tabs gewechselt</translation>
-<translation id="2968755619301702150">Zertifikats-Viewer</translation>
-<translation id="2979025552038692506">Ausgewählter Inkognito-Tab</translation>
-<translation id="2987620471460279764">Text, der über ein anderes Gerät geteilt wurde</translation>
-<translation id="2989523299700148168">Kürzlich besucht</translation>
-<translation id="2996291259634659425">Passphrase erstellen</translation>
-<translation id="2996809686854298943">URL erforderlich</translation>
-<translation id="300526633675317032">Der gesamte Websitespeicher (<ph name="SIZE_IN_KB" />) wird gelöscht.</translation>
-<translation id="3016635187733453316">Prüfen Sie, ob das Gerät mit dem Internet verbunden ist</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB heruntergeladen</translation>
-<translation id="3029704984691124060">Passphrasen stimmen nicht überein.</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Hilfe aufrufen<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Die Standortermittlung ist deaktiviert. Sie können sie in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" /> aktivieren.</translation>
-<translation id="3058498974290601450">Sie können die Synchronisierung jederzeit in den Einstellungen aktivieren</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> Lesezeichen}other{<ph name="BOOKMARKS_COUNT_MANY" /> Lesezeichen}}</translation>
-<translation id="3089395242580810162">In Inkognito-Tab öffnen</translation>
-<translation id="3115898365077584848">Informationen anzeigen</translation>
-<translation id="3123473560110926937">Auf einigen Websites blockiert</translation>
-<translation id="3137521801621304719">Inkognitomodus deaktivieren</translation>
-<translation id="3143515551205905069">Synchronisierung abbrechen</translation>
-<translation id="3157842584138209013">Über die Schaltfläche "Weitere Optionen" können Sie sich ansehen, wie viel Datenvolumen Sie einsparen</translation>
-<translation id="3166827708714933426">Tastenkombinationen für Tabs und Fenster</translation>
-<translation id="3181954750937456830">Safe Browsing (mich und mein Gerät vor schädlichen Websites schützen)</translation>
-<translation id="3190152372525844641">Berechtigungen für Chrome in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" /> aktivieren</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> gespeicherte Daten</translation>
-<translation id="3205824638308738187">Fast fertig.</translation>
-<translation id="3207960819495026254">Mit einem Lesezeichen versehen</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> gelöscht</translation>
-<translation id="321773570071367578">Wenn Sie Ihre Passphrase vergessen oder diese Einstellung ändern möchten, <ph name="BEGIN_LINK" />setzen Sie die Synchronisierung zurück<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Web-App</translation>
-<translation id="3236059992281584593">1 Minute übrig</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Lesezeichen für diese Seite erstellen</translation>
-<translation id="3259831549858767975">Gesamten Seiteninhalt verkleinern</translation>
-<translation id="3269093882174072735">Bild laden</translation>
-<translation id="3269956123044984603">Aktivieren Sie "Daten automatisch synchronisieren" in den Android-Kontoeinstellungen, um Tabs von Ihren anderen Geräten abzurufen.</translation>
-<translation id="3277252321222022663">Websites den Zugriff auf Sensoren erlauben (empfohlen)</translation>
-<translation id="3282568296779691940">In Chrome anmelden</translation>
-<translation id="3288003805934695103">Seite aktualisieren</translation>
-<translation id="32895400574683172">Benachrichtigungen sind erlaubt</translation>
-<translation id="3295530008794733555">Schneller surfen. Weniger Daten verbrauchen.</translation>
-<translation id="3295602654194328831">Informationen ausblenden</translation>
-<translation id="3298243779924642547">Lite-Modus</translation>
-<translation id="3303414029551471755">Inhalt herunterladen?</translation>
-<translation id="3306398118552023113">Diese App wird in Chrome ausgeführt</translation>
-<translation id="3315103659806849044">Sie passen gerade die Einstellungen für "Synchronisierung und Google-Dienste" an Wenn Sie die Aktivierung der Synchronisierung abschließen möchten, tippen Sie unten auf dem Bildschirm auf "Bestätigen". Nach oben</translation>
-<translation id="3328801116991980348">Websiteinformationen</translation>
-<translation id="3333961966071413176">Alle Kontakte</translation>
-<translation id="3334729583274622784">Dateiendung ändern?</translation>
-<translation id="3341058695485821946">Erfahren Sie, wie viel Datenvolumen Sie eingespart haben</translation>
-<translation id="3350687908700087792">Alle Inkognito-Tabs schließen</translation>
-<translation id="3353615205017136254">Lite-Modus-Seite von Google bereitgestellt. Zum Laden der Originalseite auf die Schaltfläche "Original laden" tippen.</translation>
-<translation id="3367813778245106622">Melden Sie sich nochmals an, um die Synchronisierung zu starten</translation>
-<translation id="3374023511497244703">Ihre Lesezeichen, Ihr Verlauf, Ihre Passwörter und andere Chrome-Daten werden nicht mehr mit Ihrem Google-Konto synchronisiert.</translation>
-<translation id="3384347053049321195">Bild teilen</translation>
-<translation id="3386292677130313581">Nachfragen, bevor Websites Ihr Standort angezeigt wird (empfohlen)</translation>
-<translation id="3387650086002190359"><ph name="FILE_NAME" /> konnte aufgrund von Dateisystemfehlern nicht heruntergeladen werden.</translation>
-<translation id="3389286852084373014">SMS zu lang</translation>
-<translation id="3398320232533725830">Lesezeichen-Manager öffnen</translation>
-<translation id="3414952576877147120">Größe:</translation>
-<translation id="3443221991560634068">Aktuelle Seite neu laden</translation>
-<translation id="3445014427084483498">Gerade eben</translation>
-<translation id="3478363558367712427">Sie können Ihre Suchmaschine auswählen</translation>
+<translation id="6910211073230771657">Gelöscht</translation>
+<translation id="6965382102122355670">Ok</translation>
+<translation id="5301954838959518834">Ok</translation>
+<translation id="7658239707568436148">Abbrechen</translation>
 <translation id="3479552764303398839">Jetzt nicht</translation>
-<translation id="3492207499832628349">Neuer Inkognito-Tab</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Weitere Informationen<ph name="END_LINK" /> zu vorgeschlagenen Inhalten</translation>
-<translation id="3513704683820682405">Augmented Reality</translation>
-<translation id="3518985090088779359">Akzeptieren &amp; weiter</translation>
-<translation id="3522247891732774234">Update verfügbar. Weitere Optionen</translation>
-<translation id="3524138585025253783">Benutzeroberfläche für Entwickler</translation>
-<translation id="3527085408025491307">Ordner</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB verfügbar</translation>
-<translation id="3549657413697417275">Im Verlauf suchen</translation>
-<translation id="3557336313807607643">Zu Kontakten hinzufügen</translation>
-<translation id="3566923219790363270">VR ist noch nicht bereit. Starten Sie Chrome später neu.</translation>
-<translation id="3568688522516854065">Melden Sie sich an und aktivieren Sie die Synchronisierung, um Ihre Tabs von Ihren anderen Geräten abzurufen</translation>
-<translation id="3587482841069643663">Alle</translation>
-<translation id="358794129225322306">Einer Website erlauben, automatisch mehrere Dateien herunterzuladen.</translation>
-<translation id="3590487821116122040">Websitespeicher, den Chrome nicht für wichtig hält, wie etwa Websites ohne gespeicherte Einstellungen oder solche, die nicht oft besucht werden</translation>
-<translation id="3599863153486145794">Löscht den Verlauf bei allen angemeldeten Geräten. Unter <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> sind möglicherweise weitere Arten von Browserverlaufsdaten für Ihr Google-Konto gespeichert.</translation>
-<translation id="3600792891314830896">Websites stummschalten, die Ton wiedergeben</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Wird mit "<ph name="DEVICE_NAME" />" geteilt</translation>
-<translation id="3632295766818638029">Passwort anzeigen</translation>
-<translation id="363596933471559332">Sie werden mit gespeicherten Anmeldedaten automatisch auf Websites angemeldet. Wenn das Kästchen nicht angeklickt ist, werden Sie jedes Mal aufgefordert, sich manuell auf einer Website anzumelden.</translation>
-<translation id="3658159451045945436">Durch das Zurücksetzen wird der Verlauf gelöscht. Dazu gehört auch die Liste der besuchten Websites.</translation>
-<translation id="3692944402865947621">Download von <ph name="FILE_NAME" /> fehlgeschlagen, weil der Speicherort nicht erreichbar ist.</translation>
-<translation id="3714981814255182093">Suchleiste öffnen</translation>
-<translation id="3716182511346448902">Diese Seite benötigt zu viel Arbeitsspeicher und wurde daher von Chrome angehalten.</translation>
-<translation id="3730075448226062617">Aktivieren Sie das Mikrofon auch in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" />, damit Chrome auf es zugreifen kann.</translation>
-<translation id="3739899004075612870">Als Lesezeichen in <ph name="PRODUCT_NAME" /> gespeichert</translation>
-<translation id="3744111561329211289">Hintergrundsynchronisierung</translation>
-<translation id="3771001275138982843">Update konnte nicht heruntergeladen werden</translation>
-<translation id="3771033907050503522">Inkognito-Tabs</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Aktivieren Sie Bluetooth<ph name="END_LINK" />, um die Kopplung zu ermöglichen</translation>
-<translation id="3775705724665058594">An meine Geräte senden</translation>
-<translation id="3778956594442850293">Zum Startbildschirm hinzugefügt</translation>
-<translation id="3789841737615482174">Installieren</translation>
-<translation id="3810838688059735925">Videos</translation>
-<translation id="3810973564298564668">Verwalten</translation>
-<translation id="381841723434055211">Telefonnummern</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> Downloads gelöscht</translation>
-<translation id="3822502789641063741">Websitespeicher löschen?</translation>
-<translation id="385051799172605136">Zurück</translation>
-<translation id="3859306556332390985">Nach vorne navigieren</translation>
-<translation id="3894427358181296146">Ordner hinzufügen</translation>
-<translation id="3895926599014793903">Zoom zwingend aktivieren</translation>
-<translation id="3912508018559818924">Das Beste aus dem Web wird gesucht…</translation>
-<translation id="3927692899758076493">Serifenlose Schrift</translation>
-<translation id="3928666092801078803">Daten zusammenführen</translation>
-<translation id="393697183122708255">Keine aktivierte Sprachsuche verfügbar</translation>
-<translation id="395206256282351086">Vorschläge für Suchbegriffe und Websites deaktiviert</translation>
-<translation id="3955193568934677022">Wiedergabe geschützter Inhalte auf Websites zulassen (empfohlen)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome lädt Ihre Seite, sobald diese bereit ist}other{Chrome lädt Ihre Seiten, sobald diese bereit sind}}</translation>
-<translation id="3963007978381181125">Die Passphrasenverschlüsselung enthält keine Zahlungsmethoden oder Adressen von Google Pay. Nur Personen mit Ihrer Passphrase können Ihre verschlüsselten Daten lesen. Die Passphrase wird nicht an Google gesendet oder von Google gespeichert. Falls Sie sie vergessen oder diese Einstellung ändern möchten, müssen Sie die Synchronisierung zurücksetzen. <ph name="BEGIN_LINK" />Weitere Informationen<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Download abgeschlossen</translation>
-<translation id="397583555483684758">Die Synchronisierung funktioniert nicht mehr</translation>
-<translation id="3976396876660209797">Verknüpfung entfernen und neu erstellen</translation>
-<translation id="3985215325736559418">Soll <ph name="FILE_NAME" /> erneut heruntergeladen werden?</translation>
-<translation id="3987993985790029246">Link kopieren</translation>
-<translation id="3988213473815854515">Standort freigegeben</translation>
-<translation id="3988466920954086464">Instant-Suchergebnisse in diesem Feld ansehen</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> von ?</translation>
-<translation id="3997476611815694295">Speicher für unwichtige Websites</translation>
-<translation id="4000212216660919741">Offline-Startseite</translation>
+<translation id="5317780077021120954">Speichern</translation>
+<translation id="4570913071927164677">Details</translation>
+<translation id="8730621377337864115">Fertig</translation>
+<translation id="8261506727792406068">Löschen</translation>
+<translation id="1181037720776840403">Entfernen</translation>
+<translation id="5939518447894949180">Zurücksetzen</translation>
 <translation id="4002066346123236978">Titel</translation>
-<translation id="4008040567710660924">Cookies für eine bestimmte Website werden zugelassen.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Nächster Titel</translation>
-<translation id="4048707525896921369">Erfahren Sie mehr zu Themen auf einer Website, ohne die Seite verlassen zu müssen. Mit der Option "Zum Suchen tippen" wird ein Wort sowie dessen Kontext an die Google-Suche gesendet. Daraufhin erhalten Sie Definitionen, Bilder, Suchergebnisse und andere Details.
+<translation id="5916664084637901428">An</translation>
+<translation id="5860033963881614850">Aus</translation>
+<translation id="6165508094623778733">Weitere Informationen</translation>
+<translation id="6042308850641462728">Mehr</translation>
+<translation id="6040143037577758943">Schließen</translation>
+<translation id="780301667611848630">Kein Interesse</translation>
+<translation id="1201402288615127009">Weiter</translation>
+<translation id="2359808026110333948">Weiter</translation>
+<translation id="2653659639078652383">Senden</translation>
+<translation id="2079545284768500474">Rückgängig machen</translation>
+<translation id="7649070708921625228">Hilfe</translation>
+<translation id="2148716181193084225">Heute</translation>
+<translation id="7781829728241885113">Gestern</translation>
+<translation id="6945221475159498467">Auswählen</translation>
+<translation id="7791543448312431591">Hinzufügen</translation>
+<translation id="6527303717912515753">Teilen</translation>
+<translation id="1383876407941801731">Suchen</translation>
+<translation id="3115898365077584848">Informationen anzeigen</translation>
+<translation id="3295602654194328831">Informationen ausblenden</translation>
+<translation id="3987993985790029246">Link kopieren</translation>
+<translation id="2704606927547763573">Kopiert</translation>
+<translation id="8725066075913043281">Erneut versuchen</translation>
+<translation id="385051799172605136">Zurück</translation>
+<translation id="8131740175452115882">Bestätigen</translation>
+<translation id="5300589172476337783">Anzeigen</translation>
+<translation id="1124772482545689468">Nutzer</translation>
+<translation id="8609465669617005112">Nach oben</translation>
+<translation id="6746124502594467657">Nach unten</translation>
+<translation id="8249310407154411074">Ganz nach oben</translation>
+<translation id="8428213095426709021">Einstellungen</translation>
+<translation id="2498359688066513246">Hilfe &amp; Feedback</translation>
+<translation id="8378714024927312812">Von Ihrer Organisation verwaltet</translation>
+<translation id="9019902583201351841">Von deinen Eltern verwaltet</translation>
+<translation id="4645575059429386691">Von deinen Eltern verwaltet</translation>
+<translation id="4883854917563148705">Verwaltete Einstellungen können nicht zurückgesetzt werden</translation>
+<translation id="4307992518367153382">Grundeinstellungen</translation>
+<translation id="1974060860693918893">Erweitert</translation>
+<translation id="1146678959555564648">VR aktivieren</translation>
+<translation id="987264212798334818">Allgemein</translation>
+<translation id="4275663329226226506">Medien</translation>
+<translation id="4759238208242260848">Downloads</translation>
+<translation id="218608176142494674">Freigabe</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Bildschirmaufnahme</translation>
+<translation id="4875775213178255010">Inhaltsvorschläge</translation>
+<translation id="2021896219286479412">Vollbild-Steuerelemente</translation>
+<translation id="4587589328781138893">Websites</translation>
+<translation id="4943703118917034429">Virtual Reality</translation>
+<translation id="1928696683969751773">Aktualisierungen</translation>
+<translation id="6064125863973209585">Abgeschlossene Downloads</translation>
+<translation id="5342314432463739672">Berechtigungsanfragen</translation>
+<translation id="629730747756840877">Konto</translation>
+<translation id="82609232232243542">In Brave anmelden</translation>
+<translation id="7956662517480676674">Synchronisierung und Brave Software-Dienste</translation>
+<translation id="5294439808117722387">Sie passen gerade die Einstellungen für "Synchronisierung und Brave Software-Dienste" an Wenn Sie die Aktivierung der Synchronisierung abschließen möchten, tippen Sie unten auf dem Bildschirm auf "Bestätigen". Nach oben</translation>
+<translation id="2096012225669085171">Geräteübergreifend synchronisieren und personalisieren</translation>
+<translation id="1692118695553449118">Synchronisierung ist aktiviert</translation>
+<translation id="5514904542973294328">Vom Administrator dieses Geräts deaktiviert</translation>
+<translation id="6447211988989208781">Brave Software-Aktivitätseinstellungen</translation>
+<translation id="4882831918239250449">Legen Sie fest, wie Ihr Browserverlauf zur Personalisierung verwendet wird, z. B. bei der Suche und bei Werbung</translation>
+<translation id="7431991332293347422">Legen Sie fest, wie Ihr Browserverlauf zur Personalisierung der Brave Software-Suche verwendet wird</translation>
+<translation id="6303969859164067831">Abmelden und die Synchronisierung ausschalten</translation>
+<translation id="1125261911132334651">Brave Software-Konto verwalten</translation>
+<translation id="6406506848690869874">Synchronisierung</translation>
+<translation id="714362445477979774">Brave-Daten synchronisieren</translation>
+<translation id="4314815835985389558">Synchronisierung verwalten</translation>
+<translation id="5428209950370661546">Weitere Brave Software-Dienste</translation>
+<translation id="7704317875155739195">Suchanfragen und URLs automatisch vervollständigen</translation>
+<translation id="2000419248597011803">Suchanfragen, die in die Adressleiste und das Suchfeld eingegeben wurden, sowie einige Cookies werden an Ihre Standardsuchmaschine gesendet</translation>
+<translation id="7981313251711023384">Seiten vorab laden, um das Surfen und die Suche zu beschleunigen</translation>
+<translation id="1821253160463689938">Zum Speichern Ihrer Einstellungen werden Cookies verwendet, auch wenn Sie diese Seiten nicht besuchen</translation>
+<translation id="6697492270171225480">Vorschläge für ähnliche Seiten anzeigen, wenn eine Seite nicht gefunden werden kann</translation>
+<translation id="8109318360573330108">Die URL einer Seite, die Sie aufrufen möchten, wird an Brave Software gesendet</translation>
+<translation id="8438566539970814960">Suchanfragen und das Surfen verbessern</translation>
+<translation id="284843628681142937">URLs der von Ihnen besuchten Seiten werden an Brave Software gesendet</translation>
+<translation id="7222718784508482526">Weitere Einstellungen in Verbindung mit Datenschutz, Sicherheit und der Erhebung von Daten finden Sie unter <ph name="BEGIN_LINK"/>Synchronisierung und Brave Software-Dienste<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Helfen, die Funktionen und die Leistung von Brave zu verbessern</translation>
+<translation id="9063160602596686558">Nutzungsstatistiken und Absturzberichte automatisch an Brave Software senden</translation>
+<translation id="4824958205181053313">Synchronisierung abbrechen?</translation>
+<translation id="3058498974290601450">Sie können die Synchronisierung jederzeit in den Einstellungen aktivieren</translation>
+<translation id="3143515551205905069">Synchronisierung abbrechen</translation>
+<translation id="1506061864768559482">Suchmaschine</translation>
+<translation id="55737423895878184">Standortermittlung und Benachrichtigungen sind erlaubt</translation>
+<translation id="3988213473815854515">Standort freigegeben</translation>
+<translation id="32895400574683172">Benachrichtigungen sind erlaubt</translation>
+<translation id="9040142327097499898">Benachrichtigungen sind erlaubt. Der Standortzugriff ist für dieses Gerät deaktiviert.</translation>
+<translation id="305593374596241526">Die Standortermittlung ist deaktiviert. Sie können sie in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/> aktivieren.</translation>
+<translation id="2989523299700148168">Kürzlich besucht</translation>
+<translation id="6433501201775827830">Suchmaschine auswählen</translation>
+<translation id="7177466738963138057">Dies kann später in den Einstellungen geändert werden</translation>
+<translation id="3478363558367712427">Sie können Ihre Suchmaschine auswählen</translation>
+<translation id="4910889077668685004">Zahlungs-Apps</translation>
+<translation id="5152843274749979095">Keine unterstützten Apps installiert</translation>
+<translation id="8812260976093120287">Auf manchen Websites können Sie über Ihr Gerät mit den obigen unterstützten Zahlungs-Apps bezahlen.</translation>
+<translation id="7764225426217299476">Adresse hinzufügen</translation>
+<translation id="5595485650161345191">Adresse bearbeiten</translation>
+<translation id="5087580092889165836">Karte hinzufügen</translation>
+<translation id="2154484045852737596">Karte bearbeiten</translation>
+<translation id="6140912465461743537">Land/Region</translation>
+<translation id="5659593005791499971">E-Mail-Adresse</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Name auf Karte</translation>
+<translation id="860043288473659153">Name des Karteninhabers</translation>
+<translation id="2612676031748830579">Kartennummer</translation>
+<translation id="869891660844655955">Ablaufdatum</translation>
+<translation id="2286841657746966508">Rechnungsadresse</translation>
+<translation id="663059986967017181">In Brave kopiert</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> weitere}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> weitere}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> weitere}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> weitere}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> weitere}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> weitere}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> weitere}other{<ph name="CONTACT_PREVIEW"/>\u2026 und <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> weitere}}</translation>
+<translation id="7029809446516969842">Passwörter</translation>
+<translation id="1943432128510653496">Passwörter speichern</translation>
+<translation id="2100273922101894616">Automatisch anmelden</translation>
+<translation id="363596933471559332">Sie werden mit gespeicherten Anmeldedaten automatisch auf Websites angemeldet. Wenn das Kästchen nicht angeklickt ist, werden Sie jedes Mal aufgefordert, sich manuell auf einer Website anzumelden.</translation>
+<translation id="6995899638241819463">Warnen, wenn Passwörter durch eine Datenpanne preisgegeben werden</translation>
+<translation id="1534287762301776620">Wenn Sie sich in Ihrem Brave Software-Konto anmelden, ist diese Funktion eingeschaltet</translation>
+<translation id="10614374240317010">Nie speichern für…</translation>
+<translation id="3098842761938485917">Gespeicherte Passwörter in Ihrem <ph name="BEGIN_LINK"/>Brave Software-Konto<ph name="END_LINK"/> ansehen und verwalten</translation>
+<translation id="8562452229998620586">Gespeicherte Passwörter erscheinen hier.</translation>
+<translation id="8084114998886531721">Gespeichertes Passwort</translation>
+<translation id="2870560284913253234">Website</translation>
+<translation id="8503813439785031346">Nutzername</translation>
+<translation id="6657585470893396449">Passwort</translation>
+<translation id="2154710561487035718">URL kopieren</translation>
+<translation id="1571304935088121812">Nutzernamen kopieren</translation>
+<translation id="5005498671520578047">Passwort kopieren</translation>
+<translation id="3632295766818638029">Passwort anzeigen</translation>
+<translation id="1513858653616922153">Passwort löschen</translation>
+<translation id="543338862236136125">Passwort ändern</translation>
+<translation id="4565377596337484307">Passwort ausblenden</translation>
+<translation id="8523928698583292556">Gespeichertes Passwort löschen</translation>
+<translation id="2898264748040935573">Gespeichertes Passwort bearbeiten</translation>
+<translation id="5433691172869980887">Nutzername kopiert</translation>
+<translation id="5534640966246046842">Website kopiert</translation>
+<translation id="2625189173221582860">Passwort kopiert</translation>
+<translation id="4550003330909367850">Um Ihr Passwort hier anzeigen zu lassen oder zu kopieren, legen Sie eine Displaysperre für dieses Gerät fest.</translation>
+<translation id="6154478581116148741">Aktivieren Sie die Displaysperre unter "Einstellungen", um Ihre Passwörter aus dem Gerät zu exportieren</translation>
+<translation id="4842092870884894799">Pop-up-Fenster zur Passwortgenerierung wird angezeigt.</translation>
+<translation id="2259659629660284697">Passwörter exportieren…</translation>
+<translation id="133012818630824069">In Brave gespeicherte Passwörter exportieren</translation>
+<translation id="6914783257214138813">Ihre Passwörter sind für jeden zugänglich, der die exportierte Passwortdatei aufrufen kann.</translation>
+<translation id="2321086116217818302">Passwörter werden zum Exportieren vorbereitet…</translation>
+<translation id="8445448999790540984">Passwörter können nicht exportiert werden</translation>
+<translation id="3066461326500799725">So nutzen Sie Brave Software Drive</translation>
+<translation id="729975465115245577">Auf Ihrem Gerät befindet sich keine App zum Speichern der Passwortdatei.</translation>
+<translation id="7682724950699840886">Probieren Sie folgende Tipps aus: Sorgen Sie dafür, dass auf Ihrem Gerät ausreichend Speicherplatz vorhanden ist, und wiederholen Sie den Export.</translation>
+<translation id="1129510026454351943">Details: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Entsperren, um Ihr Passwort zu kopieren</translation>
+<translation id="5515439363601853141">Entsperren, um Ihr Passwort zu sehen</translation>
+<translation id="6221633008163990886">Zum Exportieren Ihrer Passwörter entsperren</translation>
+<translation id="230699814587342492">Brave-Passwörter</translation>
+<translation id="6075798973483050474">Startseite bearbeiten</translation>
+<translation id="854522910157234410">Diese Seite öffnen</translation>
+<translation id="2482878487686419369">Benachrichtigungen</translation>
+<translation id="6255999984061454636">Inhaltsvorschläge</translation>
+<translation id="805047784848435650">Basierend auf Ihrem Browserverlauf</translation>
+<translation id="1041308826830691739">Von Websites</translation>
+<translation id="395206256282351086">Vorschläge für Suchbegriffe und Websites deaktiviert</translation>
+<translation id="257088987046510401">Designs</translation>
+<translation id="4650364565596261010">Systemstandardeinstellung</translation>
+<translation id="7588219262685291874">Dunkles Design verwenden, wenn Energiesparmodus des Geräts aktiviert ist</translation>
+<translation id="2760989362628427051">Dunkles Design verwenden, wenn beim Gerät der Energiesparmodus oder das dunkle Design aktiviert ist</translation>
+<translation id="6381421346744604172">Websites verdunkeln</translation>
+<translation id="5040262127954254034">Datenschutz</translation>
+<translation id="4991384657077828949">Zur Verbesserung der Sicherheit von Brave beitragen</translation>
+<translation id="1943176487615318915">Brave sendet die URLs einiger von Ihnen besuchter Seiten, bestimmte Systeminformationen und einige Seiteninhalte an Brave Software, um gefährliche Apps und Websites zu erkennen</translation>
+<translation id="3181954750937456830">Safe Browsing (mich und mein Gerät vor schädlichen Websites schützen)</translation>
+<translation id="7315322926489145388">URLs einiger von mir besuchter Seiten an Brave Software senden, wenn meine Sicherheit gefährdet ist</translation>
+<translation id="2063713494490388661">Zum Suchen tippen</translation>
+<translation id="2369463299479365221">Erfahren Sie mehr zu Themen auf einer Website, ohne die Seite verlassen zu müssen. Mit der Option "Zum Suchen tippen" wird ein Wort sowie dessen Kontext an die Brave Software-Suche gesendet. Daraufhin erhalten Sie Definitionen, Bilder, Suchergebnisse und andere Details.
 
 Wenn Sie den Suchbegriff anpassen möchten, halten Sie den entsprechenden Begriff etwas länger gedrückt. Sie können Ihre Suche auch verfeinern, indem Sie das Feld ganz nach oben schieben und auf das Suchfeld tippen.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Optionen sind oben auf dem Bildschirm verfügbar</translation>
-<translation id="4062305924942672200">Rechtliche Hinweise</translation>
-<translation id="4084682180776658562">Lesezeichen</translation>
-<translation id="4084712963632273211">Von <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />bereitgestellt durch Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">App-Daten löschen?</translation>
-<translation id="4099578267706723511">Nutzungsstatistiken und Absturzberichte zur Verbesserung von Chrome an Google senden</translation>
-<translation id="410351446219883937">Autoplay</translation>
-<translation id="4116038641877404294">Seiten zur Offline-Ansicht herunterladen</translation>
-<translation id="4135200667068010335">Die Liste von Geräten, mit denen ein Tab geteilt werden kann, ist geschlossen.</translation>
-<translation id="4149994727733219643">Vereinfachte Ansicht für Webseiten</translation>
-<translation id="4165986682804962316">Website-Einstellungen</translation>
-<translation id="4169535189173047238">Nicht zulassen</translation>
-<translation id="4170011742729630528">Der Dienst ist momentan nicht verfügbar. Bitte versuchen Sie es später erneut.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> verwendet</translation>
-<translation id="4181841719683918333">Sprachen</translation>
-<translation id="4183868528246477015">Mit Google Lens suchen <ph name="BEGIN_NEW" />Neu<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">In neuem Tab öffnen</translation>
-<translation id="4198423547019359126">Keine verfügbaren Speicherorte für Downloads</translation>
-<translation id="4209895695669353772">Aktivieren Sie die Synchronisierung, um personalisierte, von Google vorgeschlagene Inhalte zu erhalten</translation>
-<translation id="4226663524361240545">Bei Benachrichtigungen kann das Gerät vibrieren</translation>
-<translation id="423219824432660969">Synchronisierte Daten mit dem Google-Passwort vom <ph name="TIME" /> verschlüsseln</translation>
-<translation id="4242533952199664413">Einstellungen öffnen</translation>
-<translation id="4256782883801055595">Open Source-Lizenzen</translation>
-<translation id="4259722352634471385">Die Navigation zu <ph name="URL" /> ist blockiert.</translation>
-<translation id="4269820728363426813">URL kopieren</translation>
-<translation id="4275663329226226506">Medien</translation>
-<translation id="4278390842282768270">Zugelassen</translation>
-<translation id="429312253194641664">Eine Website gibt Medien wieder</translation>
-<translation id="4298388696830689168">Verknüpfte Websites</translation>
-<translation id="4307992518367153382">Grundeinstellungen</translation>
-<translation id="4314815835985389558">Synchronisierung verwalten</translation>
-<translation id="4351244548802238354">Dialogfeld schließen</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Suche erfolgt mit Sogou</translation>
-<translation id="4404568932422911380">Keine Lesezeichen</translation>
-<translation id="4405224443901389797">Verschieben nach…</translation>
-<translation id="4411535500181276704">Lite-Modus</translation>
-<translation id="4415276339145661267">Google-Konto verwalten</translation>
-<translation id="4432792777822557199">Seiten auf <ph name="SOURCE_LANGUAGE" /> werden ab jetzt auf <ph name="TARGET_LANGUAGE" /> übersetzt</translation>
-<translation id="4433925000917964731">Lite-Modus-Seite von Google bereitgestellt</translation>
-<translation id="4434045419905280838">Pop-ups und Weiterleitungen</translation>
-<translation id="4440958355523780886">Lite-Modus-Seite von Google bereitgestellt. Zum Laden der Originalseite tippen.</translation>
-<translation id="4452411734226507615">Tab "<ph name="TAB_TITLE" />" schließen</translation>
-<translation id="4452548195519783679">Als Lesezeichen in "<ph name="FOLDER_NAME" />" gespeichert</translation>
-<translation id="445467742685312942">Websites erlauben, geschützte Inhalte wiederzugeben</translation>
-<translation id="4468959413250150279">Eine bestimmte Website stummschalten.</translation>
-<translation id="4472118726404937099">Melden Sie sich an und aktivieren Sie die Synchronisierung, um geräteübergreifend zu synchronisieren und zu personalisieren</translation>
-<translation id="447252321002412580">Helfen, die Funktionen und die Leistung von Chrome zu verbessern</translation>
-<translation id="4479647676395637221">Nachfragen, bevor Websites Zugriff auf Ihre Kamera erhalten (empfohlen)</translation>
-<translation id="4479972344484327217"><ph name="MODULE" /> für Chrome wird installiert…</translation>
-<translation id="4487967297491345095">Alle App-Daten in Chrome werden dauerhaft gelöscht. Hierzu gehören alle Dateien, Einstellungen, Konten, Datenbanken.</translation>
-<translation id="4493497663118223949">Lite-Modus ist aktiviert</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Vor # Tag}other{Vor # Tagen}}</translation>
-<translation id="451872707440238414">Lesezeichen durchsuchen</translation>
-<translation id="4521489764227272523">Die ausgewählten Daten wurden aus Chrome und von allen Ihren synchronisierten Geräten entfernt.
-
-Eventuell finden Sie unter <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" /> weitere Formen des Browserverlaufs wie Suchanfragen oder Aktivitäten anderer Google-Dienste für Ihr Google-Konto.</translation>
-<translation id="4532845899244822526">Ordner auswählen</translation>
-<translation id="4538018662093857852">Lite-Modus aktivieren</translation>
-<translation id="4550003330909367850">Um Ihr Passwort hier anzeigen zu lassen oder zu kopieren, legen Sie eine Displaysperre für dieses Gerät fest.</translation>
-<translation id="4558311620361989323">Tastenkombinationen für Webseiten</translation>
-<translation id="4561979708150884304">Keine Verbindung</translation>
-<translation id="4565377596337484307">Passwort ausblenden</translation>
-<translation id="4570913071927164677">Details</translation>
-<translation id="4572422548854449519">In verwaltetem Konto anmelden</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{vor # Minute}other{vor # Minuten}}</translation>
-<translation id="4587589328781138893">Websites</translation>
-<translation id="4594952190837476234">Diese Offlineseite ist vom <ph name="CREATION_TIME" /> und unterscheidet sich gegebenenfalls von der Onlineversion.</translation>
-<translation id="4605958867780575332">Element entfernt: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> öffnen</translation>
-<translation id="4634124774493850572">Passwort verwenden</translation>
-<translation id="4645575059429386691">Von deinen Eltern verwaltet</translation>
-<translation id="4650364565596261010">Systemstandardeinstellung</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> Lesezeichen gelöscht</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> wurde Ihrem Startbildschirm hinzugefügt.</translation>
-<translation id="4684427112815847243">Alles synchronisieren</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> weitere}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> weitere}}</translation>
-<translation id="4696983787092045100">SMS an meine Geräte senden</translation>
-<translation id="4698034686595694889">Offline in <ph name="APP_NAME" /> ansehen</translation>
-<translation id="4699172675775169585">Bilder und Dateien im Cache</translation>
-<translation id="4714588616299687897">Reduzieren Sie Ihre Daten um bis zu 60 %</translation>
-<translation id="4719927025381752090">Übersetzung anbieten</translation>
-<translation id="4720023427747327413">In <ph name="PRODUCT_NAME" /> öffnen</translation>
-<translation id="4720982865791209136">Helfen Sie uns, Chrome zu verbessern. <ph name="BEGIN_LINK" />An Umfrage teilnehmen<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Aktualisieren</translation>
-<translation id="4738836084190194332">Letzte Synchronisierung: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Neuen Tab öffnen</translation>
-<translation id="4751476147751820511">Bewegungs- oder Lichtsensoren</translation>
-<translation id="4759238208242260848">Downloads</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 Download abgeschlossen.}other{# Downloads abgeschlossen.}}</translation>
-<translation id="4797039098279997504">Tippen, um zu <ph name="URL_OF_THE_CURRENT_TAB" /> zurückzukehren</translation>
-<translation id="4802417911091824046">Die Passphrasenverschlüsselung enthält keine Zahlungsmethoden oder Adressen von Google Pay.
-
-Wenn Sie diese Einstellung ändern möchten, <ph name="BEGIN_LINK" />setzen Sie die Synchronisierung zurück<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Name auf Karte</translation>
-<translation id="4824958205181053313">Synchronisierung abbrechen?</translation>
-<translation id="4837753911714442426">Optionen zum Drucken einer Seite öffnen</translation>
-<translation id="4842092870884894799">Pop-up-Fenster zur Passwortgenerierung wird angezeigt.</translation>
-<translation id="4860895144060829044">Anrufen</translation>
-<translation id="4866368707455379617"><ph name="MODULE" /> kann nicht für Chrome installiert werden</translation>
-<translation id="4875775213178255010">Inhaltsvorschläge</translation>
-<translation id="4878404682131129617">Tunnelerstellung via Proxyserver ist fehlgeschlagen</translation>
-<translation id="4880127995492972015">Übersetzen…</translation>
-<translation id="4881695831933465202">Öffnen</translation>
-<translation id="488187801263602086">Datei umbenennen</translation>
-<translation id="4882831918239250449">Legen Sie fest, wie Ihr Browserverlauf zur Personalisierung verwendet wird, z. B. bei der Suche und bei Werbung</translation>
-<translation id="4883854917563148705">Verwaltete Einstellungen können nicht zurückgesetzt werden</translation>
-<translation id="4885273946141277891">Nicht unterstützte Anzahl von Chrome-Instanzen</translation>
-<translation id="4910889077668685004">Zahlungs-Apps</translation>
-<translation id="4913161338056004800">Statistiken zurücksetzen</translation>
-<translation id="4913169188695071480">Aktualisierung anhalten</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Hilfe aufrufen<ph name="END_LINK" />, während nach Geräten gesucht wird…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Seite}other{# Seiten}}</translation>
-<translation id="4932247056774066048">Da Sie sich von einem Konto abmelden, das von <ph name="DOMAIN_NAME" /> verwaltet wird, werden Ihre Chrome-Daten auf diesem Gerät gelöscht. Die Daten bleiben jedoch in Ihrem Google-Konto.</translation>
-<translation id="4943703118917034429">Virtual Reality</translation>
-<translation id="4943872375798546930">Keine Ergebnisse</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> hat Ihren Bildschirm freigegeben</translation>
-<translation id="4961107849584082341">Lassen Sie sich diese Seite in eine beliebige Sprache übersetzen</translation>
-<translation id="4962975101802056554">Alle Berechtigungen für Gerät entziehen</translation>
-<translation id="4970824347203572753">In Ihrem Land nicht verfügbar</translation>
-<translation id="497421865427891073">Weiter</translation>
-<translation id="4988210275050210843">Datei wird heruntergeladen (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Seiten</translation>
-<translation id="4994033804516042629">Keine Kontakte gefunden</translation>
-<translation id="4996978546172906250">Teilen über</translation>
-<translation id="5004416275253351869">Google-Aktivitätseinstellungen</translation>
-<translation id="5005498671520578047">Passwort kopieren</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> möchte eine Verbindung herstellen</translation>
-<translation id="5013696553129441713">Keine neuen Vorschläge</translation>
-<translation id="5016205925109358554">Serifenschrift</translation>
-<translation id="5033865233969348410">Während Sie sich im VR-Modus befinden, erhält die Website möglicherweise bestimmte Informationen über Sie. Dazu gehören:
-– physische Merkmale wie Ihre Größe
-
-Starten Sie den VR-Modus nur dann, wenn Sie dieser Website vertrauen.</translation>
+<translation id="2930742481329940825">Mit "Zum Suchen tippen" werden das ausgewählte Wort und die aktuelle Seite als Kontext an die Brave Software-Suche gesendet. Sie können die Funktion in den <ph name="BEGIN_LINK"/>Einstellungen<ph name="END_LINK"/> deaktivieren.</translation>
 <translation id="5039804452771397117">Zulassen</translation>
-<translation id="5040262127954254034">Datenschutz</translation>
-<translation id="5048398596102334565">Websites den Zugriff auf Bewegungssensoren erlauben (empfohlen)</translation>
-<translation id="5063480226653192405">Verwendung</translation>
-<translation id="5087580092889165836">Karte hinzufügen</translation>
-<translation id="5100237604440890931">Minimiert – zum Maximieren klicken</translation>
-<translation id="510275257476243843">1 Stunde übrig</translation>
-<translation id="5123685120097942451">Inkognito-Tab</translation>
-<translation id="5127805178023152808">Synchronisierung ist deaktiviert</translation>
-<translation id="5129038482087801250">Web-App installieren</translation>
-<translation id="5132942445612118989">Passwörter, Verlauf und mehr auf allen Geräten synchronisieren</translation>
-<translation id="5139940364318403933">So nutzen Sie Google Drive</translation>
-<translation id="515227803646670480">Gespeich. Daten löschen</translation>
-<translation id="5152843274749979095">Keine unterstützten Apps installiert</translation>
-<translation id="5161254044473106830">Titel erforderlich</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 Download fehlgeschlagen.}other{# Downloads fehlgeschlagen.}}</translation>
-<translation id="5170568018924773124">In Ordner anzeigen</translation>
-<translation id="5184329579814168207">In Chrome öffnen</translation>
-<translation id="5193988420012215838">In die Zwischenablage kopiert</translation>
-<translation id="5197729504361054390">Die von Ihnen ausgewählten Kontakte werden mit <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> geteilt.</translation>
-<translation id="5199929503336119739">Arbeitsprofil</translation>
-<translation id="5210286577605176222">Zum vorherigen Tab wechseln</translation>
-<translation id="5210365745912300556">Schließen</translation>
-<translation id="5224771365102442243">Mit Video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> möchte nach Bluetooth-Geräten in der Nähe suchen. Die folgenden Geräte wurden gefunden:</translation>
-<translation id="5233638681132016545">Neuer Tab</translation>
-<translation id="526421993248218238">Fehler beim Laden der Seite</translation>
-<translation id="5271967389191913893">Das Gerät kann den Inhalt, der heruntergeladen werden soll, nicht öffnen.</translation>
-<translation id="528192093759286357">Ziehen Sie zum Beenden des Vollbildmodus von oben und tippen Sie auf die Zurück-Taste.</translation>
-<translation id="5292796745632149097">Senden an</translation>
-<translation id="5300589172476337783">Anzeigen</translation>
-<translation id="5301954838959518834">Ok</translation>
-<translation id="5304593522240415983">Dieses Feld darf nicht leer sein.</translation>
-<translation id="5307446750509046227">Websitespeicher löschen</translation>
-<translation id="5308380583665731573">Verbinden</translation>
-<translation id="5313967007315987356">Website hinzufügen</translation>
-<translation id="5317780077021120954">Speichern</translation>
-<translation id="5324858694974489420">Jugendschutzeinstellungen</translation>
-<translation id="5327248766486351172">Name</translation>
-<translation id="5335288049665977812">Ausführung von JavaScript durch Websites zulassen (empfohlen)</translation>
-<translation id="5342314432463739672">Berechtigungsanfragen</translation>
-<translation id="5357811892247919462">Tab erhalten</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> geöffneter Tab, zum Wechseln der Tabs tippen}other{<ph name="OPEN_TABS_MANY" /> geöffnete Tabs, zum Wechseln der Tabs tippen}}</translation>
-<translation id="5391532827096253100">Die Verbindung zu dieser Website ist nicht sicher. Websiteinformationen</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 weitere)}other{(+ # weitere)}}</translation>
-<translation id="5400569084694353794">Durch die Verwendung dieser App stimmen Sie den <ph name="BEGIN_LINK1" />Nutzungsbedingungen<ph name="END_LINK1" /> und <ph name="BEGIN_LINK2" />Datenschutzhinweisen<ph name="END_LINK2" /> von Chrome zu.</translation>
-<translation id="5403592356182871684">Namen</translation>
-<translation id="5403644198645076998">Nur bestimmte Websites zulassen</translation>
-<translation id="5414836363063783498">Überprüfung...</translation>
-<translation id="5423934151118863508">Hier werden Ihre am meisten aufgerufenen Seiten angezeigt.</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB verfügbar</translation>
-<translation id="543338862236136125">Passwort ändern</translation>
-<translation id="5433691172869980887">Nutzername kopiert</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> Dateien (<ph name="MEGABYTES" /> MB) werden heruntergeladen.</translation>
-<translation id="5441522332038954058">Zur Adressleiste wechseln</translation>
-<translation id="5447201525962359567">Gesamter Websitespeicher einschließlich Cookies und anderer lokal gespeicherter Daten</translation>
-<translation id="5447765697759493033">Diese Website wird nicht übersetzt</translation>
-<translation id="545042621069398927">Download wird beschleunigt.</translation>
-<translation id="5456381639095306749">Seite herunterladen</translation>
-<translation id="5475862044948910901">Augmented-Reality-Sitzung starten?</translation>
-<translation id="548278423535722844">In einer Karten-App öffnen</translation>
-<translation id="5487521232677179737">Daten löschen</translation>
-<translation id="5494752089476963479">Werbung auf Websites blockieren, auf denen aufdringliche oder irreführende Werbung angezeigt wird</translation>
-<translation id="5500777121964041360">In Ihrem Land möglicherweise nicht verfügbar</translation>
-<translation id="5512137114520586844">Dieses Konto wird von <ph name="PARENT_NAME" /> verwaltet.</translation>
-<translation id="5514904542973294328">Vom Administrator dieses Geräts deaktiviert</translation>
-<translation id="5515439363601853141">Entsperren, um Ihr Passwort zu sehen</translation>
-<translation id="5516455585884385570">Benachrichtigungseinstellungen öffnen</translation>
-<translation id="5517095782334947753">Sie haben Lesezeichen, den Verlauf, Passwörter und andere Einstellungen von <ph name="FROM_ACCOUNT" /> übernommen.</translation>
-<translation id="5524843473235508879">Weiterleitung blockiert.</translation>
-<translation id="5527082711130173040">Chrome benötigt Zugriff auf den Standort, um nach Geräten suchen zu können. <ph name="BEGIN_LINK1" />Berechtigungen aktualisieren.<ph name="END_LINK1" /> Außerdem ist der Standortzugriff <ph name="BEGIN_LINK2" />für dieses Gerät deaktiviert<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Nachfragen, bevor einer Website erlaubt wird, Texte und Bilder aus der Zwischenablage abzurufen (empfohlen)</translation>
-<translation id="5530766185686772672">Inkognito-Tabs schließen</translation>
-<translation id="5534334044554683961">Während Sie sich im VR-Modus befinden, erhält die Website möglicherweise bestimmte Informationen über Sie. Dazu gehören:
-– physische Merkmale wie Ihre Größe und
-– der Grundriss Ihres Zimmers
-
-Starten Sie den VR-Modus nur dann, wenn Sie dieser Website vertrauen.</translation>
-<translation id="5534640966246046842">Website kopiert</translation>
-<translation id="5556459405103347317">Neu laden</translation>
-<translation id="5561549206367097665">Warten auf Netzwerk…</translation>
-<translation id="557283862590186398">Chrome benötigt für diese Website die Berechtigung, auf Ihr Mikrofon zuzugreifen.</translation>
-<translation id="55737423895878184">Standortermittlung und Benachrichtigungen sind erlaubt</translation>
-<translation id="5578795271662203820">In <ph name="SEARCH_ENGINE" /> nach dem Bild suchen</translation>
-<translation id="5581519193887989363">Sie können in den <ph name="BEGIN_LINK1" />Einstellungen<ph name="END_LINK1" /> auswählen, was Sie synchronisieren möchten.</translation>
-<translation id="5595485650161345191">Adresse bearbeiten</translation>
-<translation id="5596627076506792578">Weitere Optionen</translation>
-<translation id="5599455543593328020">Inkognitomodus</translation>
-<translation id="5620928963363755975">Ihre Dateien und Seiten finden Sie durch Auswahl der Schaltfläche "Weitere Optionen" unter "Downloads"</translation>
-<translation id="5626134646977739690">Name:</translation>
-<translation id="5639724618331995626">Alle Websites zulassen</translation>
-<translation id="5648166631817621825">Letzte 7 Tage</translation>
-<translation id="5649053991847567735">Auto-Downloads</translation>
-<translation id="5655963694829536461">In Downloads suchen</translation>
-<translation id="5659593005791499971">E-Mail-Adresse</translation>
-<translation id="5665379678064389456">Termin in <ph name="APP_NAME" /> erstellen</translation>
-<translation id="5668404140385795438">Website-Anfrage zum Verhindern des Vergrößerns übergehen</translation>
-<translation id="5677928146339483299">Blockiert</translation>
-<translation id="5684874026226664614">Hoppla! Diese Seite konnte nicht übersetzt werden.</translation>
-<translation id="5686790454216892815">Dateiname zu lang</translation>
-<translation id="5689516760719285838">Ort</translation>
-<translation id="569536719314091526">Über die Schaltfläche "Weitere Optionen" können Sie sich diese Seite in eine beliebige Sprache übersetzen lassen</translation>
-<translation id="572328651809341494">Zuletzt geöffnete Tabs</translation>
-<translation id="5726692708398506830">Gesamten Seiteninhalt vergrößern</translation>
-<translation id="5748802427693696783">Zu Standard-Tabs gewechselt</translation>
-<translation id="5749068826913805084">Chrome benötigt Speicherzugriff, um Dateien herunterladen zu können.</translation>
-<translation id="5763382633136178763">Inkognito-Tabs</translation>
-<translation id="5763514718066511291">Tippen, um die URL für diese App zu kopieren</translation>
-<translation id="5765780083710877561">Beschreibung:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> von <ph name="SPACE_AVAILABLE" /> werden verwendet</translation>
-<translation id="5797070761912323120">Anhand Ihres Verlaufs kann Google die Google-Suche, Werbung und andere Google-Dienste personalisieren</translation>
-<translation id="5804241973901381774">Berechtigungen</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Vor # Stunde}other{Vor # Stunden}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC Alle Rechte vorbehalten.</translation>
-<translation id="5817918615728894473">Koppeln</translation>
-<translation id="583281660410589416">Unbekannt</translation>
-<translation id="5833984609253377421">Link teilen</translation>
-<translation id="5836192821815272682">Chrome-Update wird heruntergeladen…</translation>
-<translation id="5853623416121554550">pausiert</translation>
-<translation id="5854790677617711513">Älter als 30 Tage</translation>
-<translation id="5858741533101922242">Chrome kann den Bluetooth-Adapter nicht aktivieren</translation>
-<translation id="5860033963881614850">Aus</translation>
-<translation id="5862731021271217234">Aktivieren Sie die Synchronisierung, um Ihre Tabs von Ihren anderen Geräten abzurufen</translation>
-<translation id="5864174910718532887">Details: Nach Websitename sortiert</translation>
-<translation id="5864419784173784555">Warten auf weiteren Download…</translation>
-<translation id="5865733239029070421">Nutzungsstatistiken und Absturzberichte automatisch an Google senden</translation>
-<translation id="5869522115854928033">Gespeicherte Passwörter</translation>
-<translation id="5902828464777634901">Alle von dieser Website gespeicherten lokalen Daten, einschließlich Cookies, werden gelöscht.</translation>
-<translation id="5916664084637901428">An</translation>
-<translation id="5919204609460789179">Zur Synchronisierung müssen Sie <ph name="PRODUCT_NAME" /> aktualisieren</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> gespeichert</translation>
-<translation id="5939518447894949180">Zurücksetzen</translation>
-<translation id="5942872142862698679">Suche erfolgt mit Google</translation>
-<translation id="5952764234151283551">Die URL einer Seite, die Sie aufrufen möchten, wird an Google gesendet</translation>
-<translation id="5956665950594638604">Chrome-Hilfe in einem neuen Tab öffnen</translation>
-<translation id="5958275228015807058">Ihre Dateien und Seiten finden Sie unter "Downloads"</translation>
-<translation id="5962718611393537961">Zum Minimieren tippen</translation>
-<translation id="6000066717592683814">Google beibehalten</translation>
-<translation id="6005538289190791541">Vorgeschlagenes Passwort</translation>
-<translation id="6036057147555329831">Extra ICU</translation>
-<translation id="6039379616847168523">Zum nächsten Tab wechseln</translation>
-<translation id="6040143037577758943">Schließen</translation>
-<translation id="6042308850641462728">Mehr</translation>
-<translation id="604996488070107836"><ph name="FILE_NAME" /> konnte aufgrund eines unbekannten Fehlers nicht heruntergeladen werden.</translation>
-<translation id="605721222689873409">JJ</translation>
-<translation id="6064125863973209585">Abgeschlossene Downloads</translation>
-<translation id="6075798973483050474">Startseite bearbeiten</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> Stunden übrig</translation>
-<translation id="6108923351542677676">Einrichtung läuft...</translation>
-<translation id="6111020039983847643">genutzte Datenmenge</translation>
-<translation id="6112702117600201073">Aktualisierung der Seite</translation>
-<translation id="6127379762771434464">Eintrag entfernt</translation>
-<translation id="6140912465461743537">Land/Region</translation>
-<translation id="614940544461990577">Versuchen Sie Folgendes:</translation>
-<translation id="6154478581116148741">Aktivieren Sie die Displaysperre unter "Einstellungen", um Ihre Passwörter aus dem Gerät zu exportieren</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> Einsparungen bei der Datennutzung</translation>
-<translation id="6165508094623778733">Weitere Informationen</translation>
-<translation id="6177111841848151710">Für die aktuelle Suchmaschine blockiert</translation>
-<translation id="6181444274883918285">Ausnahme für Website hinzufügen</translation>
-<translation id="6192333916571137726">Download-Datei</translation>
-<translation id="6192792657125177640">Ausnahmen</translation>
-<translation id="6194112207524046168">Aktivieren Sie die Kamera auch in den <ph name="BEGIN_LINK" />Android-Einstellungen<ph name="END_LINK" />, damit Chrome auf sie zugreifen kann.</translation>
-<translation id="6196640612572343990">Drittanbieter-Cookies blockieren</translation>
-<translation id="6206551242102657620">Die Verbindung ist sicher. Websiteinformationen</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> ist nicht Ihre E-Mail-Adresse?</translation>
-<translation id="6221633008163990886">Zum Exportieren Ihrer Passwörter entsperren</translation>
+<translation id="1406000523432664303">"Do Not Track"</translation>
 <translation id="6232535412751077445">Wenn Sie das Kästchen "Do Not Track" anklicken, wird mit Ihren Browserzugriffen eine Anforderung gesendet. Wie sich diese Anforderung auswirkt, hängt davon ab, ob eine Website darauf reagiert und wie die Anforderung interpretiert wird.
 
 Einige Websites schalten möglicherweise Werbeanzeigen, deren Auswahl nicht darauf basiert, welche Websites Sie zuvor besucht haben. Viele Websites erfassen weiterhin Ihre Browserdaten und verwenden sie, um beispielsweise die Sicherheit zu verbessern oder Inhalte, Werbeanzeigen und Empfehlungen bereitzustellen und Statistiken für Berichte zu erstellen.</translation>
-<translation id="624789221780392884">Update bereit</translation>
-<translation id="6255999984061454636">Inhaltsvorschläge</translation>
-<translation id="6277522088822131679">Beim Drucken der Seite ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.</translation>
-<translation id="6295158916970320988">Alle Websites</translation>
-<translation id="629730747756840877">Konto</translation>
-<translation id="6303969859164067831">Abmelden und die Synchronisierung ausschalten</translation>
-<translation id="6316139424528454185">Android-Version nicht unterstützt</translation>
-<translation id="6320088164292336938">Vibrieren</translation>
-<translation id="6324034347079777476">Android-Systemsynchronisierung deaktiviert</translation>
-<translation id="6333140779060797560">Über <ph name="APPLICATION" /> teilen</translation>
-<translation id="6337234675334993532">Verschlüsselung</translation>
-<translation id="6341580099087024258">Fragen, wo Dateien gespeichert werden sollen</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> weitere}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> weitere}}</translation>
-<translation id="6364438453358674297">Vorschlag aus Verlauf entfernen?</translation>
-<translation id="6369229450655021117">Von hier aus können Sie im Web suchen, Inhalte mit Freunden teilen und sich geöffnete Seiten ansehen.</translation>
-<translation id="6378173571450987352">Details: Nach der Menge der verwendeten Daten sortiert</translation>
-<translation id="6381421346744604172">Websites verdunkeln</translation>
-<translation id="6388207532828177975">Löschen &amp; zurücksetzen</translation>
-<translation id="6393863479814692971">Chrome benötigt für diese Website die Berechtigung, auf Ihre Kamera und Ihr Mikrofon zuzugreifen.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Lesezeichen bearbeiten</translation>
-<translation id="6406506848690869874">Synchronisierung</translation>
-<translation id="641643625718530986">Drucken...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB heruntergeladen</translation>
-<translation id="6427112570124116297">Das Web übersetzen</translation>
-<translation id="6433501201775827830">Suchmaschine auswählen</translation>
-<translation id="6437478888915024427">Seiteninfo</translation>
-<translation id="6441734959916820584">Name ist zu lang</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Bild}other{# Bilder}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Datei kann nicht geöffnet werden</translation>
-<translation id="6464977750820128603">Sie sehen in Chrome besuchte Websites und können Timer einstellen.\n\nGoogle erhält Informationen zu den Websites, für die Sie Timer einstellen, sowie zur Dauer des Besuchs. Anhand dieser Informationen wird Digital Wellbeing optimiert.</translation>
-<translation id="6475951671322991020">Video herunterladen</translation>
-<translation id="6482749332252372425"><ph name="FILE_NAME" /> konnte nicht heruntergeladen werden, weil nicht genügend Speicherplatz vorhanden ist.</translation>
-<translation id="6496823230996795692">Wenn Sie <ph name="APP_NAME" /> zum ersten Mal nutzen, stellen Sie bitte eine Verbindung zum Internet her.</translation>
-<translation id="6508722015517270189">Chrome neu starten</translation>
-<translation id="6527303717912515753">Teilen</translation>
-<translation id="6532866250404780454">In Chrome aufgerufene Websites werden nicht angezeigt. Alle Timer für Websites werden gelöscht.</translation>
-<translation id="6534565668554028783">Die Antwort von Google hat zu lange gedauert</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB heruntergeladen</translation>
-<translation id="6539092367496845964">Ein Fehler ist aufgetreten. Versuchen Sie es später noch einmal.</translation>
-<translation id="654446541061731451">Tab zum Beamen auswählen</translation>
-<translation id="6545017243486555795">Alle Daten löschen</translation>
-<translation id="6545864417968258051">Bluetooth-Suche</translation>
-<translation id="6560414384669816528">Suche mit Sogou</translation>
-<translation id="6566259936974865419">Dank Chrome haben Sie <ph name="GIGABYTES" /> GB eingespart</translation>
-<translation id="6573096386450695060">Immer zulassen</translation>
-<translation id="6573431926118603307">Hier werden Tabs angezeigt, die Sie auf Ihren anderen Geräten in Chrome geöffnet haben.</translation>
-<translation id="6583199322650523874">Aktuelle Seite als Lesezeichen speichern</translation>
-<translation id="6593061639179217415">Desktopwebsite</translation>
-<translation id="6600954340915313787">In Chrome kopiert</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Geschützte Inhalte</translation>
-<translation id="6627583120233659107">Ordner bearbeiten</translation>
-<translation id="6643016212128521049">Löschen</translation>
-<translation id="6643649862576733715">Nach Menge der gespeicherten Daten sortieren</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> weitere}other{<ph name="CONTACT_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> weitere}}</translation>
-<translation id="6649642165559792194">Bildvorschau <ph name="BEGIN_NEW" />Neu<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome benötigt Zugriff auf den Standort, um nach Geräten suchen zu können. <ph name="BEGIN_LINK" />Berechtigungen aktualisieren<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Passwort</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">In <ph name="APP_NAME" /> öffnen</translation>
-<translation id="666981079809192359">Chrome-Datenschutzhinweise</translation>
-<translation id="6676840375528380067">Ihre Chrome-Daten von diesem Gerät löschen?</translation>
-<translation id="6697492270171225480">Vorschläge für ähnliche Seiten anzeigen, wenn eine Seite nicht gefunden werden kann</translation>
-<translation id="6697947395630195233">Chrome benötigt Zugriff auf Ihren Standort, um ihn mit dieser Website zu teilen.</translation>
-<translation id="6698801883190606802">Synchronisierte Daten verwalten</translation>
-<translation id="6699370405921460408">Google-Server optimieren die Seiten, die Sie besuchen.</translation>
-<translation id="6706288973712894588">Sie sind gerade offline.\n<ph name="BEGIN_LINK" />Sehen Sie sich Ihren Offline-Feed an.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Nachrichten</translation>
-<translation id="6710213216561001401">Zurück</translation>
-<translation id="671481426037969117">Ihr <ph name="FQDN" />-Timer ist abgelaufen. Morgen startet er neu.</translation>
-<translation id="6738867403308150051">Wird heruntergeladen...</translation>
-<translation id="6746124502594467657">Nach unten</translation>
-<translation id="6766622839693428701">Zum Schließen nach unten wischen.</translation>
-<translation id="6766758767654711248">Tippen, um zur Website zu wechseln</translation>
-<translation id="6767294960381293877">Die Liste von Geräten, mit denen ein Tab geteilt werden kann, ist halb geöffnet.</translation>
-<translation id="6782111308708962316">Websites von Drittanbietern am Speichern und Lesen von Cookiedaten hindern</translation>
-<translation id="6790428901817661496">Wiedergabe</translation>
-<translation id="6811034713472274749">Seitenansicht bereit</translation>
-<translation id="6818926723028410516">Einträge auswählen</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Übersetzen</translation>
-<translation id="6845325883481699275">Zur Verbesserung der Sicherheit von Chrome beitragen</translation>
-<translation id="6846298663435243399">Wird geladen…</translation>
-<translation id="6850409657436465440">Download noch in Bearbeitung</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> Tabs geschlossen</translation>
-<translation id="6864459304226931083">Bild herunterladen</translation>
-<translation id="6865313869410766144">AutoFill-Formulardaten</translation>
-<translation id="688738109438487280">Vorhandene Daten werden zu <ph name="TO_ACCOUNT" /> hinzugefügt.</translation>
-<translation id="6891726759199484455">Entsperren, um Ihr Passwort zu kopieren</translation>
-<translation id="6896758677409633944">Kopieren</translation>
-<translation id="6910211073230771657">Gelöscht</translation>
-<translation id="6912998170423641340">Websites dürfen keine Texte oder Bilder aus der Zwischenablage abrufen</translation>
-<translation id="6914783257214138813">Ihre Passwörter sind für jeden zugänglich, der die exportierte Passwortdatei aufrufen kann.</translation>
-<translation id="6942665639005891494">Sie können den Standard-Downloadpfad jederzeit über die Option im Menü "Einstellungen" ändern</translation>
-<translation id="6945221475159498467">Auswählen</translation>
-<translation id="6963642900430330478">Diese Seite ist gefährlich. Websiteinformationen</translation>
-<translation id="6963766334940102469">Lesezeichen löschen</translation>
-<translation id="6965382102122355670">Ok</translation>
-<translation id="6979737339423435258">Gesamte Zeit</translation>
-<translation id="6981982820502123353">Bedienungshilfen</translation>
-<translation id="6989267951144302301">Fehler beim Download</translation>
-<translation id="6990079615885386641">App aus dem Play Store abrufen: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Nachfragen, bevor Websites auf Ihr Mikrofon zugreifen dürfen (empfohlen)</translation>
-<translation id="7015203776128479407">Die erstmalige Einrichtung der Synchronisierung wurde nicht abgeschlossen. Synchronisierung ist deaktiviert.</translation>
-<translation id="7016516562562142042">Für die aktuelle Suchmaschine zugelassen</translation>
-<translation id="7022756207310403729">Im Browser öffnen</translation>
-<translation id="702463548815491781">Empfohlen, wenn TalkBack oder der Schalterzugriff aktiviert ist</translation>
-<translation id="7029809446516969842">Passwörter</translation>
-<translation id="7053983685419859001">Blockieren</translation>
-<translation id="7055152154916055070">Weiterleitung blockiert:</translation>
-<translation id="7063006564040364415">Verbindung zum Synchronisierungsserver konnte nicht hergestellt werden.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ausgewählt}other{# ausgewählt}}</translation>
-<translation id="7071521146534760487">Konto verwalten</translation>
-<translation id="7077143737582773186">SD-Karte</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> ausgewählt. Optionen sind oben auf dem Bildschirm verfügbar</translation>
-<translation id="7121362699166175603">Löscht den Verlauf und Autovervollständigungen in der Adressleiste. Unter <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> sind möglicherweise weitere Arten von Browserverlaufsdaten für Ihr Google-Konto gespeichert.</translation>
-<translation id="7128222689758636196">Für die aktuelle Suchmaschine zulassen</translation>
-<translation id="7138678301420049075">Sonstiges</translation>
-<translation id="7141896414559753902">Anzeige von Pop-ups und Weiterleitungen für Websites blockieren (empfohlen)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Originalseite<ph name="END_LINK" /> aus <ph name="DOMAIN_NAME" /> laden</translation>
-<translation id="7149893636342594995">Letzte 24 Stunden</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Dies kann später in den Einstellungen geändert werden</translation>
-<translation id="7180611975245234373">Aktualisieren</translation>
-<translation id="7189372733857464326">Warten auf Abschluss der Google Play-Dienste-Aktualisierung</translation>
-<translation id="7191430249889272776">Tab im Hintergrund geöffnet</translation>
-<translation id="723171743924126238">Bilder auswählen</translation>
-<translation id="7233236755231902816">Das Web in Ihrer Sprache – mit der aktuellen Version von Chrome</translation>
-<translation id="7243308994586599757">Optionen unten auf dem Bildschirm verfügbar</translation>
-<translation id="7248069434667874558">Prüfen Sie, ob auf <ph name="TARGET_DEVICE_NAME" /> die Synchronisierung in Chrome aktiviert ist</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> ausgewählt</translation>
-<translation id="7274013316676448362">Blockierte Website</translation>
-<translation id="7290209999329137901">Umbenennen nicht verfügbar</translation>
-<translation id="7291387454912369099">Assistant für AutoFill</translation>
-<translation id="7293171162284876153">Aktivieren Sie "Chrome-Daten synchronisieren", um die Synchronisierung zu starten.</translation>
-<translation id="729975465115245577">Auf Ihrem Gerät befindet sich keine App zum Speichern der Passwortdatei.</translation>
-<translation id="7302081693174882195">Details: Nach der Menge der gespeicherten Daten sortiert</translation>
-<translation id="7328017930301109123">Im Lite-Modus werden Seiten schneller in Chrome geladen und es werden bis zu 60 Prozent weniger Daten verbraucht.</translation>
-<translation id="7333031090786104871">Vorherige Website wird noch hinzugefügt</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 ausgewähltes Element teilen}other{# ausgewählte Elemente teilen}}</translation>
 <translation id="7359002509206457351">Auf Zahlungsmethoden zugreifen</translation>
+<translation id="8026334261755873520">Browserdaten löschen</translation>
+<translation id="1291207594882862231">Verlauf, Cookies, Websitedaten, Cache leeren…</translation>
+<translation id="7814200940910057384">Gelöschte Brave-Daten</translation>
+<translation id="1664855196866195614">Die ausgewählten Daten wurden aus Brave und von allen Ihren synchronisierten Geräten entfernt.
+
+Eventuell finden Sie unter <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/> weitere Formen des Browserverlaufs wie Suchanfragen oder Aktivitäten anderer Brave Software-Dienste für Ihr Brave Software-Konto.</translation>
+<translation id="4699172675775169585">Bilder und Dateien im Cache</translation>
+<translation id="2496180316473517155">Browserverlauf</translation>
+<translation id="2546283357679194313">Cookies und Websitedaten</translation>
+<translation id="8662811608048051533">Sie werden von den meisten Websites abgemeldet.</translation>
+<translation id="8218628800671693884">Sie werden von den meisten Websites, aber nicht aus Ihrem Brave Software-Konto abgemeldet.</translation>
+<translation id="2017836877785168846">Löscht den Verlauf sowie Autovervollständigungen in der Adressleiste.</translation>
+<translation id="8096327394278038498">Löscht den Verlauf und Autovervollständigungen in der Adressleiste. Unter <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> sind möglicherweise weitere Arten von Browserverlaufsdaten für Ihr Brave Software-Konto gespeichert.</translation>
+<translation id="8122693181154564064">Löscht den Verlauf bei allen angemeldeten Geräten. Unter <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> sind möglicherweise weitere Arten von Browserverlaufsdaten für Ihr Brave Software-Konto gespeichert.</translation>
+<translation id="5869522115854928033">Gespeicherte Passwörter</translation>
+<translation id="6865313869410766144">AutoFill-Formulardaten</translation>
+<translation id="7562080006725997899">Browserdaten werden gelöscht</translation>
+<translation id="5487521232677179737">Daten löschen</translation>
+<translation id="7498271377022651285">Bitte warten...</translation>
+<translation id="784934925303690534">Zeitraum</translation>
+<translation id="1718835860248848330">Letzte Stunde</translation>
+<translation id="7149893636342594995">Letzte 24 Stunden</translation>
+<translation id="5648166631817621825">Letzte 7 Tage</translation>
+<translation id="8571213806525832805">Letzte 4 Wochen</translation>
+<translation id="5854790677617711513">Älter als 30 Tage</translation>
+<translation id="6979737339423435258">Gesamte Zeit</translation>
+<translation id="982182592107339124">Alle Daten für alle Websites werden gelöscht, darunter:</translation>
+<translation id="6643016212128521049">Löschen</translation>
+<translation id="7641339528570811325">Browserdaten löschen…</translation>
+<translation id="1670399744444387456">Grundlegend</translation>
+<translation id="3245261285041759672">Unter <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> sind möglicherweise weitere Arten von Browserverlaufsdaten für Ihr Brave Software-Konto gespeichert.</translation>
+<translation id="7274013316676448362">Blockierte Website</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> Einträge gelöscht</translation>
+<translation id="1121094540300013208">Nutzungs- und Absturzberichte</translation>
+<translation id="9079153198295609735">Nutzungsstatistiken und Absturzberichte automatisch an Brave Software senden</translation>
+<translation id="6981982820502123353">Bedienungshilfen</translation>
+<translation id="2387895666653383613">Text-Skalierung</translation>
+<translation id="2321958826496381788">Ziehen Sie den Schieberegler, bis Sie diesen Text problemlos lesen können. Nach dem Doppeltippen auf einen Abschnitt sollte der Text mindestens so groß sein.</translation>
+<translation id="3895926599014793903">Zoom zwingend aktivieren</translation>
+<translation id="5668404140385795438">Website-Anfrage zum Verhindern des Vergrößerns übergehen</translation>
+<translation id="4149994727733219643">Vereinfachte Ansicht für Webseiten</translation>
+<translation id="9100505651305367705">Anbieten, Artikel in vereinfachter Ansicht anzuzeigen, falls unterstützt</translation>
+<translation id="1409426117486808224">Vereinfachte Ansicht für geöffnete Tabs</translation>
+<translation id="702463548815491781">Empfohlen, wenn TalkBack oder der Schalterzugriff aktiviert ist</translation>
+<translation id="8284326494547611709">Untertitel</translation>
+<translation id="4165986682804962316">Website-Einstellungen</translation>
+<translation id="6295158916970320988">Alle Websites</translation>
+<translation id="8380167699614421159">Diese Website zeigt aufdringliche oder irreführende Werbung an</translation>
+<translation id="1919345977826869612">Werbung</translation>
+<translation id="410351446219883937">Autoplay</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Drittanbieter-Cookies blockieren</translation>
+<translation id="6782111308708962316">Websites von Drittanbietern am Speichern und Lesen von Cookiedaten hindern</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-ups und Weiterleitungen</translation>
+<translation id="4751476147751820511">Bewegungs- oder Lichtsensoren</translation>
+<translation id="1717218214683051432">Bewegungssensoren</translation>
+<translation id="2091887806945687916">Ton</translation>
+<translation id="2586657967955657006">Zwischenablage</translation>
+<translation id="6320088164292336938">Vibrieren</translation>
+<translation id="4226663524361240545">Bei Benachrichtigungen kann das Gerät vibrieren</translation>
+<translation id="1446450296470737166">Volle Kontr. über MIDI-Ger. erl.</translation>
+<translation id="3744111561329211289">Hintergrundsynchronisierung</translation>
+<translation id="5649053991847567735">Auto-Downloads</translation>
+<translation id="6181444274883918285">Ausnahme für Website hinzufügen</translation>
+<translation id="5313967007315987356">Website hinzufügen</translation>
+<translation id="1369915414381695676">Website "<ph name="SITE_NAME"/>" hinzugefügt</translation>
+<translation id="7837721118676387834">Automatische Wiedergabe stummgeschalteter Videos für eine bestimmte Website zulassen.</translation>
+<translation id="2621115761605608342">JavaScript für eine bestimmte Website zulassen.</translation>
+<translation id="8801436777607969138">Hier können Sie Websites angeben, für die JavaScript blockiert werden soll.</translation>
+<translation id="8372893542064058268">Lässt die Hintergrundsynchronisierung für eine bestimmte Website zu.</translation>
+<translation id="358794129225322306">Einer Website erlauben, automatisch mehrere Dateien herunterzuladen.</translation>
+<translation id="4008040567710660924">Cookies für eine bestimmte Website werden zugelassen.</translation>
+<translation id="8958424370300090006">Cookies für eine bestimmte Website werden blockiert.</translation>
+<translation id="7882806643839505685">Wiedergabe von Ton auf einer bestimmten Website zulassen.</translation>
+<translation id="4468959413250150279">Eine bestimmte Website stummschalten.</translation>
+<translation id="1994173015038366702">Website-URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Verwendung</translation>
+<translation id="5804241973901381774">Berechtigungen</translation>
+<translation id="4278390842282768270">Zugelassen</translation>
+<translation id="5677928146339483299">Blockiert</translation>
+<translation id="1984937141057606926">Zugelassen, außer Cookies Dritter</translation>
+<translation id="7423098979219808738">Zuerst fragen</translation>
+<translation id="8116925261070264013">Stummgeschaltet</translation>
+<translation id="8300705686683892304">Von App verwaltet</translation>
+<translation id="6192792657125177640">Ausnahmen</translation>
+<translation id="257931822824936280">Maximiert – zum Minimieren klicken</translation>
+<translation id="5100237604440890931">Minimiert – zum Maximieren klicken</translation>
+<translation id="857943718398505171">Zugelassen (empfohlen)</translation>
+<translation id="2913331724188855103">Websites dürfen Cookiedaten speichern und lesen (empfohlen)</translation>
+<translation id="7445411102860286510">Automatische Wiedergabe stummgeschalteter Videos auf Websites zulassen (empfohlen)</translation>
+<translation id="5335288049665977812">Ausführung von JavaScript durch Websites zulassen (empfohlen)</translation>
+<translation id="5527111080432883924">Nachfragen, bevor einer Website erlaubt wird, Texte und Bilder aus der Zwischenablage abzurufen (empfohlen)</translation>
+<translation id="6912998170423641340">Websites dürfen keine Texte oder Bilder aus der Zwischenablage abrufen</translation>
+<translation id="7423538860840206698">Es dürfen keine Dateien aus der Zwischenablage abgerufen werden</translation>
+<translation id="3955193568934677022">Wiedergabe geschützter Inhalte auf Websites zulassen (empfohlen)</translation>
+<translation id="445467742685312942">Websites erlauben, geschützte Inhalte wiederzugeben</translation>
+<translation id="2107397443965016585">Fragen, bevor Websites erlaubt wird, geschützten Inhalt wiederzugeben (empfohlen)</translation>
+<translation id="2910701580606108292">Fragen, bevor die Wiedergabe geschützter Inhalte auf Websites zugelassen wird</translation>
+<translation id="757524316907819857">Wiedergabe von geschützten Inhalten für Websites blockieren</translation>
+<translation id="3277252321222022663">Websites den Zugriff auf Sensoren erlauben (empfohlen)</translation>
+<translation id="5048398596102334565">Websites den Zugriff auf Bewegungssensoren erlauben (empfohlen)</translation>
+<translation id="8816026460808729765">Zugriff auf Sensoren für Websites blockieren</translation>
+<translation id="169515064810179024">Zugriff auf Bewegungssensoren für Websites blockieren</translation>
+<translation id="1660204651932907780">Wiedergabe von Ton auf Websites zulassen (empfohlen)</translation>
+<translation id="3600792891314830896">Websites stummschalten, die Ton wiedergeben</translation>
+<translation id="1743802530341753419">Nachfragen, bevor Websites eine Verbindung zu einem Gerät herstellen (empfohlen)</translation>
+<translation id="851751545965956758">Verhindern, dass Websites eine Verbindung zu Geräten herstellen</translation>
+<translation id="7141896414559753902">Anzeige von Pop-ups und Weiterleitungen für Websites blockieren (empfohlen)</translation>
+<translation id="5494752089476963479">Werbung auf Websites blockieren, auf denen aufdringliche oder irreführende Werbung angezeigt wird</translation>
+<translation id="3123473560110926937">Auf einigen Websites blockiert</translation>
+<translation id="965817943346481315">Blockieren, wenn Website aufdringliche oder irreführende Werbung anzeigt (empfohlen)</translation>
+<translation id="3386292677130313581">Nachfragen, bevor Websites Ihr Standort angezeigt wird (empfohlen)</translation>
+<translation id="9139068048179869749">Nachfragen, bevor Websites Benachrichtigungen senden dürfen (empfohlen)</translation>
+<translation id="4479647676395637221">Nachfragen, bevor Websites Zugriff auf Ihre Kamera erhalten (empfohlen)</translation>
+<translation id="6992289844737586249">Nachfragen, bevor Websites auf Ihr Mikrofon zugreifen dürfen (empfohlen)</translation>
+<translation id="2289270750774289114">Nachfragen, wenn eine Website nach Bluetooth-Geräten in der Nähe suchen möchte (empfohlen)</translation>
+<translation id="7053983685419859001">Blockieren</translation>
+<translation id="7128222689758636196">Für die aktuelle Suchmaschine zulassen</translation>
+<translation id="7589445247086920869">Für die aktuelle Suchmaschine blockieren</translation>
+<translation id="6388207532828177975">Löschen &amp; zurücksetzen</translation>
+<translation id="7999064672810608036">Möchten Sie wirklich alle lokalen Daten einschließlich Cookies löschen und alle Berechtigungen für diese Website zurücksetzen?</translation>
+<translation id="2822354292072154809">Möchten Sie wirklich alle Websiteberechtigungen für <ph name="CHOSEN_OBJECT_NAME"/> zurücksetzen?</translation>
+<translation id="515227803646670480">Gespeich. Daten löschen</translation>
+<translation id="5902828464777634901">Alle von dieser Website gespeicherten lokalen Daten, einschließlich Cookies, werden gelöscht.</translation>
+<translation id="119944043368869598">Alle löschen</translation>
+<translation id="2490684707762498678">Verwaltet von <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Benachrichtigungseinstellungen öffnen</translation>
+<translation id="1404122904123200417">Eingebettet in <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Hier werden von Websites gespeicherte Dateien angezeigt</translation>
+<translation id="4181841719683918333">Sprachen</translation>
+<translation id="2647434099613338025">Sprache hinzufügen</translation>
+<translation id="1952172573699511566">Sofern dies möglich ist, wird Text auf Websites in Ihrer bevorzugten Sprache angezeigt.</translation>
+<translation id="8559990750235505898">Übersetzung für Seiten in andere Sprachen anbieten</translation>
+<translation id="4719927025381752090">Übersetzung anbieten</translation>
+<translation id="8156139159503939589">Welche Sprachen können Sie lesen?</translation>
+<translation id="5689516760719285838">Ort</translation>
+<translation id="2440823041667407902">Standortzugriff</translation>
+<translation id="2023546461831060654">Berechtigungen für Brave in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/> aktivieren</translation>
+<translation id="6665548517310046133">Berechtigung für Brave in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/> aktivieren</translation>
+<translation id="2928908108430545745">Aktivieren Sie die Standortermittlung auch in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/>, damit Brave auf Ihren Standort zugreifen kann.</translation>
+<translation id="1028853271388022585">Aktivieren Sie die Kamera auch in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/>, damit Brave auf sie zugreifen kann.</translation>
+<translation id="2913721282607281710">Aktivieren Sie Benachrichtigungen auch in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/>, damit Brave Ihnen Benachrichtigungen senden kann.</translation>
+<translation id="8753483718490035722">Aktivieren Sie das Mikrofon auch in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/>, damit Brave auf es zugreifen kann.</translation>
+<translation id="1887786770086287077">Der Standortzugriff ist für dieses Gerät deaktiviert. Sie können ihn in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/> aktivieren.</translation>
+<translation id="2570922361219980984">Der Standortzugriff ist für dieses Gerät ebenfalls deaktiviert. Sie können ihn in den <ph name="BEGIN_LINK"/>Android-Einstellungen<ph name="END_LINK"/> aktivieren.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Kamerazugriff</translation>
+<translation id="945632385593298557">Mikrofonzugriff</translation>
+<translation id="6612358246767739896">Geschützte Inhalte</translation>
+<translation id="885701979325669005">Speicher</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> gespeicherte Daten</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Zugriffsberechtigung auf Gerät widerrufen</translation>
+<translation id="4962975101802056554">Alle Berechtigungen für Gerät entziehen</translation>
+<translation id="6545864417968258051">Bluetooth-Suche</translation>
+<translation id="4411535500181276704">Lite-Modus</translation>
+<translation id="7821588508402923572">Ihre Einsparungen bei der Datennutzung werden hier angezeigt</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> eingespart</translation>
+<translation id="8569404424186215731">seit <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Im Lite-Modus werden Seiten schneller in Brave geladen und es werden bis zu 60 Prozent weniger Daten verbraucht.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> Einsparungen bei der Datennutzung</translation>
+<translation id="7494974237137038751">eingesparte Datenmenge</translation>
+<translation id="6111020039983847643">genutzte Datenmenge</translation>
+<translation id="7413229368719586778">Startdatum: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Enddatum: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Nach Website sortieren</translation>
+<translation id="5864174910718532887">Details: Nach Websitename sortiert</translation>
+<translation id="116280672541001035">Genutzt</translation>
+<translation id="8349013245300336738">Nach Menge der verwendeten Daten sortieren</translation>
+<translation id="6378173571450987352">Details: Nach der Menge der verwendeten Daten sortiert</translation>
+<translation id="2631006050119455616">Eingespart</translation>
+<translation id="6643649862576733715">Nach Menge der gespeicherten Daten sortieren</translation>
+<translation id="7302081693174882195">Details: Nach der Menge der gespeicherten Daten sortiert</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> verwendet</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> gespeichert</translation>
+<translation id="2156074688469523661">Restliche Websites (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Sonstiges</translation>
+<translation id="4913161338056004800">Statistiken zurücksetzen</translation>
+<translation id="1856325424225101786">Lite-Modus zurücksetzen?</translation>
+<translation id="3658159451045945436">Durch das Zurücksetzen wird der Verlauf gelöscht. Dazu gehört auch die Liste der besuchten Websites.</translation>
+<translation id="3295530008794733555">Schneller surfen. Weniger Daten verbrauchen.</translation>
+<translation id="7340390500800578919">Im Lite-Modus werden Seiten schneller in Brave geladen und es werden bis zu 60 % weniger Daten verbraucht. Zum Optimieren der von Ihnen besuchten Seiten sendet Brave Ihren Datenverkehr an Brave Software. <ph name="BEGIN_LINK"/>Weitere Informationen<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Lite-Modus aktivieren</translation>
+<translation id="4493497663118223949">Lite-Modus ist aktiviert</translation>
+<translation id="7559975015014302720">Lite-Modus ist deaktiviert</translation>
+<translation id="7606077192958116810">Der Lite-Modus ist aktiviert. Sie können ihn in den Einstellungen verwalten.</translation>
+<translation id="4714588616299687897">Reduzieren Sie Ihre Daten um bis zu 60 %</translation>
+<translation id="1006927014032731288">Brave Software-Server optimieren die Seiten, die Sie besuchen.</translation>
+<translation id="3257320067425202300">Dank Brave haben Sie <ph name="MEGABYTES"/> MB eingespart</translation>
+<translation id="5813223329348543512">Dank Brave haben Sie <ph name="GIGABYTES"/> GB eingespart</translation>
+<translation id="8266862848225348053">Downloadpfad</translation>
+<translation id="7077143737582773186">SD-Karte</translation>
+<translation id="7762668264895820836">SD-Karte <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Fragen, wo Dateien gespeichert werden sollen</translation>
+<translation id="6192333916571137726">Download-Datei</translation>
+<translation id="1672586136351118594">Nicht mehr anzeigen</translation>
+<translation id="2650751991977523696">Datei noch einmal herunterladen?</translation>
+<translation id="8664979001105139458">Dateiname schon vorhanden</translation>
+<translation id="488187801263602086">Datei umbenennen</translation>
+<translation id="5686790454216892815">Dateiname zu lang</translation>
+<translation id="7454641608352164238">Zu wenig Speicherplatz</translation>
+<translation id="8972098258593396643">In Standardordner herunterladen?</translation>
+<translation id="804335162455518893">SD-Karte nicht gefunden</translation>
+<translation id="7475688122056506577">SD-Karte nicht gefunden. Einige Ihrer Dateien fehlen möglicherweise.</translation>
+<translation id="4198423547019359126">Keine verfügbaren Speicherorte für Downloads</translation>
+<translation id="8224471946457685718">"Artikel für mich" bei bestehender WLAN-Verbindung herunterladen</translation>
+<translation id="4970824347203572753">In Ihrem Land nicht verfügbar</translation>
+<translation id="5500777121964041360">In Ihrem Land möglicherweise nicht verfügbar</translation>
+<translation id="1173894706177603556">Umbenennen</translation>
+<translation id="1986685561493779662">Name ist bereits vorhanden</translation>
+<translation id="6441734959916820584">Name ist zu lang</translation>
+<translation id="2923908459366352541">Der Name ist ungültig</translation>
+<translation id="7290209999329137901">Umbenennen nicht verfügbar</translation>
+<translation id="3334729583274622784">Dateiendung ändern?</translation>
+<translation id="107147699690128016">Eine Änderung der Dateiendung kann zum Öffnen der Datei in einer anderen Anwendung führen und Schäden an Ihrem Gerät verursachen.</translation>
+<translation id="8541922081612557424">Über Brave Software Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC Alle Rechte vorbehalten.</translation>
+<translation id="1416550906796893042">Anwendungsversion</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (aktualisiert <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Betriebssystem</translation>
+<translation id="3968054912784331254">Brave-Updates werden für diese Version von Android nicht mehr unterstützt</translation>
+<translation id="7665369617277396874">Konto hinzufügen</translation>
+<translation id="649070405679044769">Bei Brave Software angemeldet als</translation>
+<translation id="6234515504547364178">Von Brave abmelden</translation>
+<translation id="5324858694974489420">Jugendschutzeinstellungen</translation>
+<translation id="8920114477895755567">Warten auf Details zu den Eltern</translation>
+<translation id="5512137114520586844">Dieses Konto wird von <ph name="PARENT_NAME"/> verwaltet.</translation>
+<translation id="2956410042958133412">Dieses Konto wird von <ph name="PARENT_NAME_1"/> und <ph name="PARENT_NAME_2"/> verwaltet.</translation>
+<translation id="8168435359814927499">Inhalte</translation>
+<translation id="5403644198645076998">Nur bestimmte Websites zulassen</translation>
+<translation id="8641930654639604085">Versuchen, nicht jugendfreie Websites zu blockieren</translation>
+<translation id="5639724618331995626">Alle Websites zulassen</translation>
+<translation id="796823723482603597">Powered by Brave</translation>
+<translation id="6324034347079777476">Android-Systemsynchronisierung deaktiviert</translation>
+<translation id="5127805178023152808">Synchronisierung ist deaktiviert</translation>
+<translation id="7015203776128479407">Die erstmalige Einrichtung der Synchronisierung wurde nicht abgeschlossen. Synchronisierung ist deaktiviert.</translation>
+<translation id="2497852260688568942">Die Synchronisierung wurde von Ihrem Administrator deaktiviert</translation>
+<translation id="9100610230175265781">Passphrase erforderlich</translation>
+<translation id="6108923351542677676">Einrichtung läuft...</translation>
+<translation id="4062305924942672200">Rechtliche Hinweise</translation>
+<translation id="4256782883801055595">Open Source-Lizenzen</translation>
+<translation id="1138681184697033370">Brave-Nutzungsbedingungen</translation>
+<translation id="7392539049993970338">Brave-Datenschutzhinweise</translation>
+<translation id="2677748264148917807">Verlassen</translation>
+<translation id="5556459405103347317">Neu laden</translation>
+<translation id="1623104350909869708">Keine weiteren Dialogfelder auf dieser Seite zulassen</translation>
+<translation id="2968755619301702150">Zertifikats-Viewer</translation>
+<translation id="1360432990279830238">Abmelden &amp; Synchronisierung deaktivieren?</translation>
+<translation id="8581481290581777242">Ihre Brave-Daten von diesem Gerät löschen?</translation>
+<translation id="1318865768845061710">Ihre Lesezeichen, Ihr Verlauf, Ihre Passwörter und andere Brave-Daten werden nicht mehr mit Ihrem Brave Software-Konto synchronisiert.</translation>
+<translation id="3325020657155065477">Meine Brave-Daten auch von diesem Gerät löschen</translation>
+<translation id="6136448902816743006">Da Sie sich von einem Konto abmelden, das von <ph name="DOMAIN_NAME"/> verwaltet wird, werden Ihre Brave-Daten auf diesem Gerät gelöscht. Die Daten bleiben jedoch in Ihrem Brave Software-Konto.</translation>
+<translation id="1853026300647876496">Brave Software wird kontaktiert. Das kann einen Moment dauern.</translation>
+<translation id="2328985652426384049">Anmeldung nicht möglich</translation>
+<translation id="7723158744459952869">Die Antwort von Brave Software hat zu lange gedauert</translation>
+<translation id="4572422548854449519">In verwaltetem Konto anmelden</translation>
+<translation id="2689656545739939160">Sie melden sich mit einem von <ph name="MANAGED_DOMAIN"/> verwalteten Konto an und geben dem Administrator der Domain Kontrolle über Ihre Brave-Daten. Die Daten werden diesem Konto dauerhaft zugeordnet. Wenn Sie sich von Brave abmelden, werden Ihre Daten auf dem Gerät gelöscht, bleiben jedoch in Ihrem Brave Software-Konto erhalten.</translation>
+<translation id="1749561566933687563">Lesezeichen synchronisieren</translation>
+<translation id="4242533952199664413">Einstellungen öffnen</translation>
+<translation id="1111673857033749125">Hier werden die Lesezeichen angezeigt, die auf Ihren anderen Geräten gespeichert sind.</translation>
+<translation id="8636825310635137004">Aktivieren Sie die Synchronisierung, um Tabs von Ihren anderen Geräten abzurufen.</translation>
+<translation id="3269956123044984603">Aktivieren Sie "Daten automatisch synchronisieren" in den Android-Kontoeinstellungen, um Tabs von Ihren anderen Geräten abzurufen.</translation>
+<translation id="5157964048453367290">Hier werden Tabs angezeigt, die Sie auf Ihren anderen Geräten in Brave geöffnet haben.</translation>
+<translation id="4684427112815847243">Alles synchronisieren</translation>
+<translation id="2709516037105925701">AutoFill</translation>
+<translation id="8820817407110198400">Lesezeichen</translation>
+<translation id="1644574205037202324">Verlauf</translation>
+<translation id="17513872634828108">Geöffnete Tabs</translation>
+<translation id="1320169905922104972">Kreditkarten und Adressen aus Brave Software Pay</translation>
+<translation id="6337234675334993532">Verschlüsselung</translation>
+<translation id="6698801883190606802">Synchronisierte Daten verwalten</translation>
+<translation id="3598578758776312506">Passwörter mit Brave Software-Anmeldedaten verschlüsseln</translation>
+<translation id="7810580217418711046">Synchronisierte Daten mit dem Brave Software-Passwort vom <ph name="TIME"/> verschlüsseln</translation>
+<translation id="8461694314515752532">Synchronisierte Daten mit eigener Synchronisierungspassphrase verschlüsseln</translation>
+<translation id="2996291259634659425">Passphrase erstellen</translation>
+<translation id="5713644099811900409">Brave Software-Konto</translation>
+<translation id="8997474919031554666">Die Passphrasenverschlüsselung enthält keine Zahlungsmethoden oder Adressen von Brave Software Pay. Nur Personen mit Ihrer Passphrase können Ihre verschlüsselten Daten lesen. Die Passphrase wird nicht an Brave Software gesendet oder von Brave Software gespeichert. Falls Sie sie vergessen oder diese Einstellung ändern möchten, müssen Sie die Synchronisierung zurücksetzen. <ph name="BEGIN_LINK"/>Weitere Informationen<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Passphrase</translation>
+<translation id="7772032839648071052">Passphrase bestätigen</translation>
+<translation id="5304593522240415983">Dieses Feld darf nicht leer sein.</translation>
+<translation id="321773570071367578">Wenn Sie Ihre Passphrase vergessen oder diese Einstellung ändern möchten, <ph name="BEGIN_LINK"/>setzen Sie die Synchronisierung zurück<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Passphrasen stimmen nicht überein.</translation>
+<translation id="5149495116300586333">Die Passphrasenverschlüsselung enthält keine Zahlungsmethoden oder Adressen von Brave Software Pay.
+
+Wenn Sie diese Einstellung ändern möchten, <ph name="BEGIN_LINK"/>setzen Sie die Synchronisierung zurück<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Falsche Passphrase</translation>
+<translation id="5414836363063783498">Überprüfung...</translation>
+<translation id="6846298663435243399">Wird geladen…</translation>
+<translation id="5517095782334947753">Sie haben Lesezeichen, den Verlauf, Passwörter und andere Einstellungen von <ph name="FROM_ACCOUNT"/> übernommen.</translation>
+<translation id="3928666092801078803">Daten zusammenführen</translation>
+<translation id="688738109438487280">Vorhandene Daten werden zu <ph name="TO_ACCOUNT"/> hinzugefügt.</translation>
+<translation id="806745655614357130">Daten getrennt halten</translation>
+<translation id="1145536944570833626">Vorhandene Daten löschen</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> möchte eine Kopplung durchführen</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Hilfe aufrufen<ph name="END_LINK"/>, während nach Geräten gesucht wird…</translation>
+<translation id="5817918615728894473">Koppeln</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Hilfe aufrufen<ph name="END_LINK1"/> oder <ph name="BEGIN_LINK2"/>noch einmal suchen<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Keine kompatiblen Geräte gefunden</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Aktivieren Sie Bluetooth<ph name="END_LINK"/>, um die Kopplung zu ermöglichen</translation>
+<translation id="998321811308652668">Brave kann den Bluetooth-Adapter nicht aktivieren</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Hilfe aufrufen<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave benötigt Zugriff auf den Standort, um nach Geräten suchen zu können. <ph name="BEGIN_LINK"/>Berechtigungen aktualisieren<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave benötigt Zugriff auf den Standort, um nach Geräten suchen zu können. Der Standortzugriff ist <ph name="BEGIN_LINK"/>für dieses Gerät deaktiviert<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave benötigt Zugriff auf den Standort, um nach Geräten suchen zu können. <ph name="BEGIN_LINK1"/>Berechtigungen aktualisieren.<ph name="END_LINK1"/> Außerdem ist der Standortzugriff <ph name="BEGIN_LINK2"/>für dieses Gerät deaktiviert<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Verbundenes Gerät</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstärke: # Balken}other{Signalstärke: # Balken}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> möchte nach Bluetooth-Geräten in der Nähe suchen. Die folgenden Geräte wurden gefunden:</translation>
+<translation id="8368027906805972958">Unbekanntes oder nicht unterstütztes Gerät (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synchronisierung funktioniert nicht</translation>
+<translation id="1810845389119482123">Erste Einrichtung der Synchronisierung nicht abgeschlossen</translation>
+<translation id="3235722914093408050">Einstellungen öffnen und Systemsynchr. aktivieren, um Brave-Synchr. zu starten</translation>
+<translation id="3367813778245106622">Melden Sie sich nochmals an, um die Synchronisierung zu starten</translation>
+<translation id="974555521953189084">Geben Sie Ihre Passphrase ein, um die Synchronisierung zu starten</translation>
+<translation id="2997266899014181325">Aktivieren Sie "Brave-Daten synchronisieren", um die Synchronisierung zu starten.</translation>
+<translation id="8260126382462817229">Melden Sie sich noch einmal an</translation>
+<translation id="5919204609460789179">Zur Synchronisierung müssen Sie <ph name="PRODUCT_NAME"/> aktualisieren</translation>
+<translation id="397583555483684758">Die Synchronisierung funktioniert nicht mehr</translation>
+<translation id="1966710179511230534">Bitte aktualisieren Sie Ihre Anmeldeinformationen.</translation>
+<translation id="7063006564040364415">Verbindung zum Synchronisierungsserver konnte nicht hergestellt werden.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> ist veraltet.</translation>
+<translation id="4170011742729630528">Der Dienst ist momentan nicht verfügbar. Bitte versuchen Sie es später erneut.</translation>
+<translation id="7947953824732555851">Akzeptieren und anmelden</translation>
+<translation id="8583805026567836021">Kontodaten werden gelöscht</translation>
+<translation id="8310344678080805313">Standard-Tabs</translation>
+<translation id="5748802427693696783">Zu Standard-Tabs gewechselt</translation>
+<translation id="7998918019931843664">Geschlossenen Tab wieder öffnen</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Tab "<ph name="TAB_TITLE"/>" schließen</translation>
+<translation id="7243308994586599757">Optionen unten auf dem Bildschirm verfügbar</translation>
+<translation id="4060598801229743805">Optionen sind oben auf dem Bildschirm verfügbar</translation>
+<translation id="2810645512293415242">Vereinfachte Seite für einen geringeren Datenverbrauch und schnelleres Laden.</translation>
+<translation id="3985215325736559418">Soll <ph name="FILE_NAME"/> erneut heruntergeladen werden?</translation>
+<translation id="2450083983707403292">Möchten Sie den Download von <ph name="FILE_NAME"/> noch einmal starten?</translation>
+<translation id="7514365320538308">Herunterladen</translation>
+<translation id="545042621069398927">Download wird beschleunigt.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Datei wird heruntergeladen.}other{# Dateien werden heruntergeladen.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> Dateien (<ph name="MEGABYTES"/> MB) werden heruntergeladen.</translation>
+<translation id="4988210275050210843">Datei wird heruntergeladen (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 Download abgeschlossen.}other{# Downloads abgeschlossen.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 Download fehlgeschlagen.}other{# Downloads fehlgeschlagen.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 Download ausstehend.}other{# Downloads ausstehend.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> – Schaltfläche "<ph name="LINK_NAME"/>"</translation>
+<translation id="3205824638308738187">Fast fertig.</translation>
+<translation id="3960299545138990065">Brave neu starten</translation>
+<translation id="3771001275138982843">Update konnte nicht heruntergeladen werden</translation>
+<translation id="3888648114124182147">Brave-Update wird heruntergeladen…</translation>
+<translation id="1705567146636171298">Brave aktualisieren</translation>
+<translation id="6195417478702700398">Noch besser und komfortabler surfen – jetzt Brave öffnen und aktualisieren</translation>
+<translation id="3512968675351418494">Das Web in Ihrer Sprache – mit der aktuellen Version von Brave</translation>
+<translation id="6427112570124116297">Das Web übersetzen</translation>
+<translation id="1379423114029199501">Brave jetzt aktualisieren und das Internet in Ihrer Sprache entdecken</translation>
+<translation id="5684874026226664614">Hoppla! Diese Seite konnte nicht übersetzt werden.</translation>
+<translation id="6831043979455480757">Übersetzen</translation>
+<translation id="1285320974508926690">Diese Website nie übersetzen</translation>
+<translation id="773466115871691567">Seiten auf <ph name="SOURCE_LANGUAGE"/> immer übersetzen</translation>
+<translation id="1068672505746868501">Seiten auf <ph name="SOURCE_LANGUAGE"/> nie übersetzen</translation>
+<translation id="124116460088058876">Weitere Sprachen</translation>
+<translation id="290376772003165898">Diese Seite ist nicht auf <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Seiten auf <ph name="SOURCE_LANGUAGE"/> werden ab jetzt auf <ph name="TARGET_LANGUAGE"/> übersetzt</translation>
+<translation id="8339163506404995330">Seiten auf <ph name="LANGUAGE"/> werden nicht übersetzt</translation>
+<translation id="5447765697759493033">Diese Website wird nicht übersetzt</translation>
+<translation id="4880127995492972015">Übersetzen…</translation>
+<translation id="641643625718530986">Drucken...</translation>
+<translation id="8909135823018751308">Teilen...</translation>
+<translation id="4996978546172906250">Teilen über</translation>
+<translation id="6333140779060797560">Über <ph name="APPLICATION"/> teilen</translation>
+<translation id="6277522088822131679">Beim Drucken der Seite ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.</translation>
+<translation id="3254409185687681395">Lesezeichen für diese Seite erstellen</translation>
+<translation id="497421865427891073">Weiter</translation>
+<translation id="813082847718468539">Website-Informationen anzeigen</translation>
+<translation id="2532336938189706096">Web-Ansicht</translation>
+<translation id="6005538289190791541">Vorgeschlagenes Passwort</translation>
+<translation id="4634124774493850572">Passwort verwenden</translation>
+<translation id="8285489906452138776">Brave benötigt für diese Website die Berechtigung, auf Ihre Kamera zuzugreifen.</translation>
+<translation id="320189792589364011">Brave benötigt für diese Website die Berechtigung, auf Ihr Mikrofon zuzugreifen.</translation>
+<translation id="7988136689212463100">Brave benötigt für diese Website die Berechtigung, auf Ihre Kamera und Ihr Mikrofon zuzugreifen.</translation>
+<translation id="4931190655840828017">Brave benötigt Zugriff auf Ihren Standort, um ihn mit dieser Website zu teilen.</translation>
+<translation id="3088191967551450609">Brave benötigt Speicherzugriff, um Dateien herunterladen zu können.</translation>
+<translation id="8942627711005830162">In anderem Fenster öffnen</translation>
+<translation id="4195643157523330669">In neuem Tab öffnen</translation>
+<translation id="1100066534610197918">In neuem Tab in Gruppe öffnen</translation>
+<translation id="4860895144060829044">Anrufen</translation>
+<translation id="6896758677409633944">Kopieren</translation>
+<translation id="8393700583063109961">Nachricht senden</translation>
+<translation id="3557336313807607643">Zu Kontakten hinzufügen</translation>
+<translation id="4269820728363426813">URL kopieren</translation>
+<translation id="1206892813135768548">Linktext kopieren</translation>
+<translation id="1204037785786432551">Link herunterladen</translation>
+<translation id="6864459304226931083">Bild herunterladen</translation>
+<translation id="8209050860603202033">Bild öffnen</translation>
+<translation id="8073388330009372546">Bild in neuem Tab öffnen</translation>
+<translation id="6649642165559792194">Bildvorschau <ph name="BEGIN_NEW"/>Neu<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Bild laden</translation>
+<translation id="3845332215609790146">Mit Brave Software Lens suchen <ph name="BEGIN_NEW"/>Neu<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">In <ph name="SEARCH_ENGINE"/> nach dem Bild suchen</translation>
+<translation id="3384347053049321195">Bild teilen</translation>
+<translation id="5833984609253377421">Link teilen</translation>
+<translation id="6475951671322991020">Video herunterladen</translation>
+<translation id="2317945146070194624">In neuem Brave-Tab öffnen</translation>
+<translation id="7975379999046275268">Seitenvorschau <ph name="BEGIN_NEW"/>Neu<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Aktualisierung der Seite</translation>
+<translation id="36525718899759834">App aus dem Play Store abrufen: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Dunkel</translation>
+<translation id="1807246157184219062">Hell</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Serifenlose Schrift</translation>
+<translation id="5016205925109358554">Serifenschrift</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Tab zum Beamen auswählen</translation>
+<translation id="8719023831149562936">Aktueller Tab kann nicht gebeamt werden.</translation>
+<translation id="2139186145475833000">Zum Startbildschirm zufügen</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> öffnen</translation>
+<translation id="2122601567107267586">App konnte nicht geöffnet werden</translation>
+<translation id="5129038482087801250">Web-App installieren</translation>
+<translation id="3789841737615482174">Installieren</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> wurde Ihrem Startbildschirm hinzugefügt.</translation>
+<translation id="7333031090786104871">Vorherige Website wird noch hinzugefügt</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> wird hinzugefügt...</translation>
+<translation id="3778956594442850293">Zum Startbildschirm hinzugefügt</translation>
+<translation id="2146738493024040262">Instant-App öffnen</translation>
+<translation id="7016516562562142042">Für die aktuelle Suchmaschine zugelassen</translation>
+<translation id="6177111841848151710">Für die aktuelle Suchmaschine blockiert</translation>
+<translation id="145097072038377568">In den Android-Einstellungen deaktiviert</translation>
+<translation id="8007176423574883786">Für dieses Gerät deaktiviert</translation>
+<translation id="164269334534774161">Sie sehen sich momentan eine Offlinekopie dieser Seite vom <ph name="CREATION_TIME"/> an</translation>
+<translation id="4594952190837476234">Diese Offlineseite ist vom <ph name="CREATION_TIME"/> und unterscheidet sich gegebenenfalls von der Onlineversion.</translation>
+<translation id="8840953339110955557">Diese Seite unterscheidet sich gegebenenfalls von der Onlineversion.</translation>
+<translation id="6405300764336705484">Dieser Inhalt ist von <ph name="DOMAIN_NAME"/> und wurde von Brave Software bereitgestellt.</translation>
+<translation id="1006017844123154345">Online öffnen</translation>
+<translation id="3326636747541519688">Lite-Modus-Seite von Brave Software bereitgestellt</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Originalseite<ph name="END_LINK"/> aus <ph name="DOMAIN_NAME"/> laden</translation>
+<translation id="7475192538862203634">Sollten Sie diese Meldung häufiger erhalten, sehen Sie sich unsere <ph name="BEGIN_LINK"/>Empfehlungen<ph name="END_LINK"/> an.</translation>
+<translation id="8748850008226585750">Inhalte ausgeblendet</translation>
+<translation id="3810973564298564668">Verwalten</translation>
+<translation id="5199929503336119739">Arbeitsprofil</translation>
+<translation id="528192093759286357">Ziehen Sie zum Beenden des Vollbildmodus von oben und tippen Sie auf die Zurück-Taste.</translation>
+<translation id="2836148919159985482">Tippen Sie zum Beenden des Vollbildmodus auf die Zurück-Taste.</translation>
+<translation id="3967822245660637423">Download abgeschlossen</translation>
+<translation id="2434158240863470628">Download abgeschlossen <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Downloadfehler</translation>
+<translation id="1384959399684842514">Download angehalten</translation>
+<translation id="1671236975893690980">Download ausstehend...</translation>
+<translation id="5561549206367097665">Warten auf Netzwerk…</translation>
+<translation id="5864419784173784555">Warten auf weiteren Download…</translation>
+<translation id="6461962085415701688">Datei kann nicht geöffnet werden</translation>
+<translation id="1178581264944972037">Anhalten</translation>
+<translation id="8200772114523450471">Fortsetzen</translation>
+<translation id="1409879593029778104"><ph name="FILE_NAME"/> konnte nicht heruntergeladen werden, da die Datei bereits vorhanden ist.</translation>
+<translation id="3387650086002190359"><ph name="FILE_NAME"/> konnte aufgrund von Dateisystemfehlern nicht heruntergeladen werden.</translation>
+<translation id="6482749332252372425"><ph name="FILE_NAME"/> konnte nicht heruntergeladen werden, weil nicht genügend Speicherplatz vorhanden ist.</translation>
+<translation id="7619072057915878432"><ph name="FILE_NAME"/> konnte aufgrund von Netzwerkfehlern nicht heruntergeladen werden.</translation>
+<translation id="1477626028522505441"><ph name="FILE_NAME"/> konnte aufgrund von Serverproblemen nicht heruntergeladen werden.</translation>
+<translation id="3692944402865947621">Download von <ph name="FILE_NAME"/> fehlgeschlagen, weil der Speicherort nicht erreichbar ist.</translation>
+<translation id="604996488070107836"><ph name="FILE_NAME"/> konnte aufgrund eines unbekannten Fehlers nicht heruntergeladen werden.</translation>
+<translation id="6738867403308150051">Wird heruntergeladen...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> von ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> von <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB heruntergeladen</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB heruntergeladen</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB heruntergeladen</translation>
+<translation id="9204836675896933765">Noch 1 Datei</translation>
+<translation id="8186512483418048923">Noch <ph name="FILES"/> Dateien</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> Datei heruntergeladen}other{<ph name="FILES_DOWNLOADED_MANY"/> Dateien heruntergeladen}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> Tage übrig</translation>
+<translation id="8190358571722158785">1 Tag übrig</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> Stunden übrig</translation>
+<translation id="510275257476243843">1 Stunde übrig</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> Minuten übrig</translation>
+<translation id="3236059992281584593">1 Minute übrig</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> Sekunden übrig</translation>
+<translation id="2781151931089541271">1 Sekunde übrig</translation>
+<translation id="3303414029551471755">Inhalt herunterladen?</translation>
+<translation id="8617240290563765734">Soll die im heruntergeladenen Inhalt angegebene URL geöffnet werden?</translation>
+<translation id="1373696734384179344">Der Speicher reicht nicht aus, um den ausgewählten Inhalt herunterzuladen.</translation>
+<translation id="5271967389191913893">Das Gerät kann den Inhalt, der heruntergeladen werden soll, nicht öffnen.</translation>
+<translation id="883806473910249246">Beim Herunterladen des Inhalts ist ein Fehler aufgetreten.</translation>
+<translation id="5626134646977739690">Name:</translation>
+<translation id="7963646190083259054">Anbieter:</translation>
+<translation id="3414952576877147120">Größe:</translation>
+<translation id="7375125077091615385">Typ:</translation>
+<translation id="5765780083710877561">Beschreibung:</translation>
+<translation id="4881695831933465202">Öffnen</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB verfügbar</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB verfügbar</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB verfügbar</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> von <ph name="SPACE_AVAILABLE"/> werden verwendet</translation>
+<translation id="3587482841069643663">Alle</translation>
+<translation id="4988526792673242964">Seiten</translation>
+<translation id="3810838688059735925">Videos</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Bilder</translation>
+<translation id="8250920743982581267">Dokumente</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Datei}other{# Dateien}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Bild}other{# Bilder}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Videos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Audiodatei}other{# Audiodateien}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Seite}other{# Seiten}}</translation>
+<translation id="5456381639095306749">Seite herunterladen</translation>
+<translation id="2394602618534698961">Dateien, die Sie herunterladen, werden hier angezeigt</translation>
+<translation id="7810647596859435254">Öffnen mit…</translation>
+<translation id="5655963694829536461">In Downloads suchen</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Meine Dateien</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Artikel erscheinen hier und können auch gelesen werden, wenn Sie offline sind</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
+<translation id="5853623416121554550">pausiert</translation>
+<translation id="8965591936373831584">ausstehend</translation>
+<translation id="2779651927720337254">fehlgeschlagen</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Gerade eben</translation>
+<translation id="4000212216660919741">Offline-Startseite</translation>
+<translation id="9133397713400217035">Offline entdecken</translation>
+<translation id="968900484120156207">Von Ihnen besuchte Seiten werden hier angezeigt</translation>
+<translation id="7882131421121961860">Kein Verlauf gefunden</translation>
+<translation id="3549657413697417275">Im Verlauf suchen</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">JJ</translation>
+<translation id="724102042129299115">Eindruck beim ersten Ausführen von Brave</translation>
+<translation id="2700285883409956633">Durch die Verwendung dieser App stimmen Sie den <ph name="BEGIN_LINK1"/>Nutzungsbedingungen<ph name="END_LINK1"/> und <ph name="BEGIN_LINK2"/>Datenschutzhinweisen<ph name="END_LINK2"/> von Brave zu.</translation>
+<translation id="1640714894372474981">Durch die Nutzung dieser Anwendung stimmen Sie den <ph name="BEGIN_LINK1"/>Nutzungsbedingungen<ph name="END_LINK1"/> und <ph name="BEGIN_LINK2"/>Datenschutzhinweisen<ph name="END_LINK2"/> von Brave sowie den <ph name="BEGIN_LINK3"/>Datenschutzhinweisen für mit Family Link verwaltete Brave Software-Konten<ph name="END_LINK3"/> zu.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> wird in Brave geöffnet. Wenn Sie fortfahren, stimmen Sie den <ph name="BEGIN_LINK1"/>Nutzungsbedingungen<ph name="END_LINK1"/> und <ph name="BEGIN_LINK2"/>Datenschutzhinweisen<ph name="END_LINK2"/> von Brave zu.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> wird in Brave geöffnet. Wenn Sie fortfahren, stimmen Sie den <ph name="BEGIN_LINK1"/>Nutzungsbedingungen<ph name="END_LINK1"/> und <ph name="BEGIN_LINK2"/>Datenschutzhinweisen<ph name="END_LINK2"/> von Brave sowie den <ph name="BEGIN_LINK3"/>Datenschutzhinweisen für mit Family Link verwaltete Brave Software-Konten<ph name="END_LINK3"/> zu.</translation>
+<translation id="673197144963363525">Nutzungsstatistiken und Absturzberichte zur Verbesserung von Brave an Brave Software senden</translation>
+<translation id="3518985090088779359">Akzeptieren &amp; weiter</translation>
+<translation id="7207456302801184289">Willkommen bei Brave</translation>
+<translation id="704822250101715322">Warten auf Abschluss der Brave Software Play-Dienste-Aktualisierung</translation>
+<translation id="1231733316453485619">Synchronisierung aktivieren?</translation>
+<translation id="5132942445612118989">Passwörter, Verlauf und mehr auf allen Geräten synchronisieren</translation>
+<translation id="5736731321935944068">Anhand Ihres Verlaufs kann Brave Software die Brave Software-Suche, Werbung und andere Brave Software-Dienste personalisieren</translation>
+<translation id="4013614219085422040">Anhand Ihres Verlaufs kann Brave Software die Brave Software-Suche und andere Brave Software-Dienste personalisieren</translation>
+<translation id="5581519193887989363">Sie können in den <ph name="BEGIN_LINK1"/>Einstellungen<ph name="END_LINK1"/> auswählen, was Sie synchronisieren möchten.</translation>
+<translation id="741204030948306876">Ja, bitte</translation>
+<translation id="2410754283952462441">Konto auswählen</translation>
+<translation id="2227444325776770048">Als <ph name="USER_FULL_NAME"/> fortfahren</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> ist nicht Ihre E-Mail-Adresse?</translation>
+<translation id="8109613176066109935">Aktivieren Sie die Synchronisierung, um Ihre Lesezeichen auf allen Ihren Geräten zu sehen</translation>
+<translation id="2818669890320396765">Melden Sie sich an und aktivieren Sie die Synchronisierung, um Ihre Lesezeichen auf allen Ihren Geräten zu sehen</translation>
+<translation id="6003646045106347985">Aktivieren Sie die Synchronisierung, um personalisierte, von Brave Software vorgeschlagene Inhalte zu erhalten</translation>
+<translation id="8494430740943879273">Melden Sie sich und aktivieren Sie die Synchronisierung, um personalisierte, von Brave Software vorgeschlagene Inhalte zu erhalten</translation>
+<translation id="5862731021271217234">Aktivieren Sie die Synchronisierung, um Ihre Tabs von Ihren anderen Geräten abzurufen</translation>
+<translation id="3568688522516854065">Melden Sie sich an und aktivieren Sie die Synchronisierung, um Ihre Tabs von Ihren anderen Geräten abzurufen</translation>
+<translation id="1208340532756947324">Aktivieren Sie die Synchronisierung, um geräteübergreifend zu synchronisieren und zu personalisieren</translation>
+<translation id="4472118726404937099">Melden Sie sich an und aktivieren Sie die Synchronisierung, um geräteübergreifend zu synchronisieren und zu personalisieren</translation>
+<translation id="2426805022920575512">Anderes Konto auswählen</translation>
+<translation id="6790428901817661496">Wiedergabe</translation>
+<translation id="1272079795634619415">Stopp</translation>
+<translation id="2874939134665556319">Vorheriger Titel</translation>
+<translation id="4046123991198612571">Nächster Titel</translation>
+<translation id="3859306556332390985">Nach vorne navigieren</translation>
+<translation id="8441146129660941386">Zurück navigieren</translation>
+<translation id="6706288973712894588">Sie sind gerade offline.\n<ph name="BEGIN_LINK"/>Sehen Sie sich Ihren Offline-Feed an.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Zuletzt geöffnete Tabs</translation>
+<translation id="8497726226069778601">Noch keine Seiten</translation>
+<translation id="5423934151118863508">Hier werden Ihre am meisten aufgerufenen Seiten angezeigt.</translation>
+<translation id="6127379762771434464">Eintrag entfernt</translation>
+<translation id="4605958867780575332">Element entfernt: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software-Doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Andere Geräte</translation>
+<translation id="4738836084190194332">Letzte Synchronisierung: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{vor # Minute}other{vor # Minuten}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Vor # Stunde}other{Vor # Stunden}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Vor # Tag}other{Vor # Tagen}}</translation>
+<translation id="2762000892062317888">gerade eben</translation>
+<translation id="1407135791313364759">Alle öffnen</translation>
+<translation id="1209206284964581585">Vorerst ausblenden</translation>
+<translation id="129553762522093515">Kürzlich geschlossen</translation>
+<translation id="8413126021676339697">Gesamtverlauf anzeigen</translation>
+<translation id="7876243839304621966">Alle entfernen</translation>
+<translation id="8487700953926739672">Offline verfügbar</translation>
+<translation id="5224771365102442243">Mit Video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Weitere Informationen<ph name="END_LINK"/> zu vorgeschlagenen Inhalten</translation>
+<translation id="7542481630195938534">Vorschläge können nicht abgerufen werden</translation>
+<translation id="5013696553129441713">Keine neuen Vorschläge</translation>
+<translation id="1736419249208073774">Entdecken</translation>
+<translation id="7444811645081526538">Weitere Kategorien</translation>
+<translation id="6709133671862442373">Nachrichten</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Shopping</translation>
+<translation id="3912508018559818924">Das Beste aus dem Web wird gesucht…</translation>
+<translation id="526421993248218238">Fehler beim Laden der Seite</translation>
+<translation id="614940544461990577">Versuchen Sie Folgendes:</translation>
+<translation id="3288003805934695103">Seite aktualisieren</translation>
+<translation id="2353636109065292463">Internetverbindung überprüfen</translation>
+<translation id="2858138569776157458">Top-Websites</translation>
+<translation id="8364299278605033898">Beliebte Websites ansehen</translation>
+<translation id="1171770572613082465">Tippen Sie auf die Schaltfläche "Top-Websites", um beliebte Websites zu sehen</translation>
+<translation id="5233638681132016545">Neuer Tab</translation>
+<translation id="4521874409998847950">Von <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>bereitgestellt durch Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Neuere Version verfügbar</translation>
+<translation id="4058091506841967397">Update nicht möglich</translation>
+<translation id="6316139424528454185">Android-Version nicht unterstützt</translation>
+<translation id="6989267951144302301">Fehler beim Download</translation>
+<translation id="624789221780392884">Update bereit</translation>
+<translation id="1549000191223877751">Zu anderem Fenster wechseln</translation>
+<translation id="7481312909269577407">Vorwärts</translation>
+<translation id="4084682180776658562">Lesezeichen</translation>
+<translation id="6437478888915024427">Seiteninfo</translation>
+<translation id="7180611975245234373">Aktualisieren</translation>
+<translation id="4913169188695071480">Aktualisierung anhalten</translation>
+<translation id="1829244130665387512">Auf Seite suchen</translation>
+<translation id="6593061639179217415">Desktopwebsite</translation>
+<translation id="9063523880881406963">"Desktopversion ansehen" deaktivieren</translation>
+<translation id="2038563949887743358">"Desktopversion ansehen" aktivieren</translation>
+<translation id="2433507940547922241">Darstellung</translation>
+<translation id="983192555821071799">Alle Tabs schließen</translation>
+<translation id="1310482092992808703">Tabs gruppieren</translation>
+<translation id="7725024127233776428">Seiten, die Sie als Lesezeichen speichern, werden hier angezeigt</translation>
+<translation id="4404568932422911380">Keine Lesezeichen</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> Lesezeichen}other{<ph name="BOOKMARKS_COUNT_MANY"/> Lesezeichen}}</translation>
+<translation id="3739899004075612870">Als Lesezeichen in <ph name="PRODUCT_NAME"/> gespeichert</translation>
+<translation id="3207960819495026254">Mit einem Lesezeichen versehen</translation>
+<translation id="4452548195519783679">Als Lesezeichen in "<ph name="FOLDER_NAME"/>" gespeichert</translation>
+<translation id="8063895661287329888">Fehler beim Hinzufügen des Lesezeichens.</translation>
+<translation id="2842985007712546952">Übergeordneter Ordner</translation>
+<translation id="9065203028668620118">Bearbeiten</translation>
+<translation id="4405224443901389797">Verschieben nach…</translation>
+<translation id="5170568018924773124">In Ordner anzeigen</translation>
+<translation id="8035133914807600019">Neuer Ordner…</translation>
+<translation id="4532845899244822526">Ordner auswählen</translation>
+<translation id="6627583120233659107">Ordner bearbeiten</translation>
+<translation id="1197267115302279827">Lesezeichen verschieben</translation>
+<translation id="6963766334940102469">Lesezeichen löschen</translation>
+<translation id="4351244548802238354">Dialogfeld schließen</translation>
+<translation id="451872707440238414">Lesezeichen durchsuchen</translation>
+<translation id="8901170036886848654">Keine Lesezeichen gefunden</translation>
+<translation id="6404511346730675251">Lesezeichen bearbeiten</translation>
+<translation id="3894427358181296146">Ordner hinzufügen</translation>
+<translation id="5327248766486351172">Name</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Ordner</translation>
+<translation id="5161254044473106830">Titel erforderlich</translation>
+<translation id="2996809686854298943">URL erforderlich</translation>
+<translation id="2536728043171574184">Eine Offline-Kopie dieser Seite wird angezeigt.</translation>
+<translation id="4698034686595694889">Offline in <ph name="APP_NAME"/> ansehen</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> und weitere Websites</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave lädt Ihre Seite, sobald diese bereit ist}other{Brave lädt Ihre Seiten, sobald diese bereit sind}}</translation>
+<translation id="6811034713472274749">Seitenansicht bereit</translation>
+<translation id="4561979708150884304">Keine Verbindung</translation>
+<translation id="8274165955039650276">Downloads aufrufen</translation>
+<translation id="2082238445998314030">Ergebnis <ph name="RESULT_NUMBER"/> von <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Keine Ergebnisse</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite-Modus</translation>
+<translation id="393697183122708255">Keine aktivierte Sprachsuche verfügbar</translation>
+<translation id="7191430249889272776">Tab im Hintergrund geöffnet</translation>
+<translation id="8445059357334030806">In Brave öffnen</translation>
+<translation id="4720023427747327413">In <ph name="PRODUCT_NAME"/> öffnen</translation>
+<translation id="7022756207310403729">Im Browser öffnen</translation>
+<translation id="1113597929977215864">Vereinfachte Ansicht anzeigen</translation>
+<translation id="1513352483775369820">Lesezeichen und Webprotokoll</translation>
+<translation id="4939482511480190003">Helfen Sie uns, Brave zu verbessern. <ph name="BEGIN_LINK"/>An Umfrage teilnehmen<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Zurück</translation>
+<translation id="5596627076506792578">Weitere Optionen</translation>
+<translation id="3522247891732774234">Update verfügbar. Weitere Optionen</translation>
+<translation id="6773423637732432200">Brave kann nicht aktualisiert werden. Weitere Optionen</translation>
+<translation id="3328801116991980348">Websiteinformationen</translation>
+<translation id="5391532827096253100">Die Verbindung zu dieser Website ist nicht sicher. Websiteinformationen</translation>
+<translation id="6206551242102657620">Die Verbindung ist sicher. Websiteinformationen</translation>
+<translation id="6963642900430330478">Diese Seite ist gefährlich. Websiteinformationen</translation>
+<translation id="9070377983101773829">Sprachsuche starten</translation>
+<translation id="8676374126336081632">Eingabe löschen</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> geöffneter Tab, zum Wechseln der Tabs tippen}other{<ph name="OPEN_TABS_MANY"/> geöffnete Tabs, zum Wechseln der Tabs tippen}}</translation>
+<translation id="2369533728426058518">Tabs öffnen</translation>
+<translation id="7071521146534760487">Konto verwalten</translation>
+<translation id="932327136139879170">Privat</translation>
+<translation id="2707726405694321444">Seite aktualisieren</translation>
+<translation id="2891154217021530873">Laden der Seite anhalten</translation>
+<translation id="6710213216561001401">Zurück</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Ausgewählter Tab</translation>
+<translation id="2268044343513325586">Verfeinern</translation>
+<translation id="7846076177841592234">Auswahl aufheben</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> ausgewählt. Optionen sind oben auf dem Bildschirm verfügbar</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> ausgewählt</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 ausgewähltes Element teilen}other{# ausgewählte Elemente teilen}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 ausgewähltes Element entfernen}other{# ausgewählte Elemente entfernen}}</translation>
+<translation id="1283039547216852943">Zum Maximieren tippen</translation>
+<translation id="5962718611393537961">Zum Minimieren tippen</translation>
+<translation id="8076492880354921740">Tabs</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ausgewählt}other{# ausgewählt}}</translation>
+<translation id="6818926723028410516">Einträge auswählen</translation>
+<translation id="4797039098279997504">Tippen, um zu <ph name="URL_OF_THE_CURRENT_TAB"/> zurückzukehren</translation>
+<translation id="6766758767654711248">Tippen, um zur Website zu wechseln</translation>
+<translation id="429312253194641664">Eine Website gibt Medien wieder</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> hat Ihren Bildschirm freigegeben</translation>
+<translation id="8833831881926404480">Eine Website teilt Ihren Bildschirm</translation>
+<translation id="9086455579313502267">Kein Zugriff auf das Netzwerk</translation>
+<translation id="938850635132480979">Fehler: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">In <ph name="APP_NAME"/> öffnen</translation>
+<translation id="548278423535722844">In einer Karten-App öffnen</translation>
+<translation id="7698359219371678927">E-Mail in <ph name="APP_NAME"/> erstellen</translation>
+<translation id="7875915731392087153">E-Mail erstellen</translation>
+<translation id="5665379678064389456">Termin in <ph name="APP_NAME"/> erstellen</translation>
+<translation id="2900528713135656174">Termin erstellen</translation>
+<translation id="2111511281910874386">Seite aufrufen</translation>
+<translation id="3988466920954086464">Instant-Suchergebnisse in diesem Feld ansehen</translation>
+<translation id="2744248271121720757">Tippen Sie auf ein Wort, um eine Sofortsuche zu starten oder weitere Aktionen anzuzeigen</translation>
+<translation id="9155898266292537608">Sie können auch kurz auf ein Wort tippen, um eine Suche zu starten</translation>
+<translation id="3232754137068452469">Web-App</translation>
+<translation id="1430915738399379752">Drucken</translation>
+<translation id="3775705724665058594">An meine Geräte senden</translation>
+<translation id="6364438453358674297">Vorschlag aus Verlauf entfernen?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> geschlossen</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> Tabs geschlossen</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> gelöscht</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> Lesezeichen gelöscht</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> Downloads gelöscht</translation>
+<translation id="1248710015876067820">Nicht unterstützte Anzahl von Brave-Instanzen</translation>
+<translation id="4259722352634471385">Die Navigation zu <ph name="URL"/> ist blockiert.</translation>
+<translation id="8959122750345127698">Navigation nicht möglich: <ph name="URL"/> ist nicht erreichbar.</translation>
+<translation id="5210365745912300556">Schließen</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> schließen</translation>
+<translation id="1227058898775614466">Navigationsverlauf</translation>
+<translation id="9169507124922466868">Navigationsverlauf ist halb geöffnet</translation>
+<translation id="1327257854815634930">Der Navigationsverlauf ist geöffnet</translation>
+<translation id="8788265440806329501">Der Navigationsverlauf wurde geschlossen</translation>
+<translation id="7482656565088326534">Vorschau-Tab</translation>
+<translation id="8427875596167638501">Vorschau-Tab ist halb geöffnet</translation>
+<translation id="9102803872260866941">Vorschau-Tab ist geöffnet</translation>
+<translation id="2942036813789421260">Vorschau-Tab ist geschlossen</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/>-Speicher</translation>
+<translation id="3822502789641063741">Websitespeicher löschen?</translation>
+<translation id="9205995714227143200">Websitespeicher, den Brave nicht für wichtig hält, wie etwa Websites ohne gespeicherte Einstellungen oder solche, die nicht oft besucht werden</translation>
+<translation id="3997476611815694295">Speicher für unwichtige Websites</translation>
+<translation id="8493948351860045254">Speicherplatz freigeben</translation>
+<translation id="2324920234469020158">Alle Cookies, der Cache und andere Daten von Websites, die Brave nicht für wichtig hält, werden gelöscht.</translation>
+<translation id="5447201525962359567">Gesamter Websitespeicher einschließlich Cookies und anderer lokal gespeicherter Daten</translation>
+<translation id="1376578503827013741">Berechnung läuft...</translation>
+<translation id="583281660410589416">Unbekannt</translation>
+<translation id="2323763861024343754">Websitespeicher</translation>
+<translation id="3587672679800759167">Gesamtdaten, die von Brave verwendet werden, wie Konten, Lesezeichen und gespeicherte Einstellungen</translation>
+<translation id="6545017243486555795">Alle Daten löschen</translation>
+<translation id="4095146165863963773">App-Daten löschen?</translation>
+<translation id="53119194224775367">Alle App-Daten in Brave werden dauerhaft gelöscht. Hierzu gehören alle Dateien, Einstellungen, Konten, Datenbanken.</translation>
+<translation id="5307446750509046227">Websitespeicher löschen</translation>
+<translation id="300526633675317032">Der gesamte Websitespeicher (<ph name="SIZE_IN_KB"/>) wird gelöscht.</translation>
+<translation id="8068648041423924542">Zertifikat kann nicht ausgewählt werden.</translation>
+<translation id="2315043854645842844">Die clientseitige Zertifikatauswahl wird vom Betriebssystem nicht unterstützt.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> möchte eine Verbindung herstellen</translation>
+<translation id="5308380583665731573">Verbinden</translation>
+<translation id="868929229000858085">Kontakte durchsuchen</translation>
+<translation id="1919950603503897840">Kontakte auswählen</translation>
+<translation id="7986741934819883144">Kontakt auswählen</translation>
+<translation id="3333961966071413176">Alle Kontakte</translation>
+<translation id="4994033804516042629">Keine Kontakte gefunden</translation>
+<translation id="5403592356182871684">Namen</translation>
+<translation id="2717722538473713889">E-Mail-Adressen</translation>
+<translation id="381841723434055211">Telefonnummern</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 weitere)}other{(+ # weitere)}}</translation>
+<translation id="5197729504361054390">Die von Ihnen ausgewählten Kontakte werden mit <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> geteilt.</translation>
+<translation id="1779089405699405702">Bild-Decodierer</translation>
+<translation id="8067883171444229417">Video ansehen</translation>
+<translation id="6560414384669816528">Suche mit Sogou</translation>
+<translation id="5406914950576900927">Brave kann in China <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> für die Suche verwenden. Sie können dies unter <ph name="BEGIN_LINK"/>Einstellungen<ph name="END_LINK"/> ändern.</translation>
+<translation id="6456271171669383967">Brave Software beibehalten</translation>
+<translation id="4384468725000734951">Suche erfolgt mit Sogou</translation>
+<translation id="6103327872225198548">Suche erfolgt mit Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Diese App wird in Brave ausgeführt</translation>
+<translation id="6143689084714664628">Wird in Brave ausgeführt</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> hat auch Daten in Brave</translation>
+<translation id="2734140769649165081">Sie können die Daten in den Brave-Einstellungen löschen</translation>
+<translation id="8232956427053453090">Daten aufbewahren</translation>
+<translation id="4298388696830689168">Verknüpfte Websites</translation>
+<translation id="5763514718066511291">Tippen, um die URL für diese App zu kopieren</translation>
+<translation id="6496823230996795692">Wenn Sie <ph name="APP_NAME"/> zum ersten Mal nutzen, stellen Sie bitte eine Verbindung zum Internet her.</translation>
+<translation id="751961395872307827">Keine Verbindung zur Website möglich</translation>
+<translation id="4878404682131129617">Tunnelerstellung via Proxyserver ist fehlgeschlagen</translation>
+<translation id="4749960740855309258">Neuen Tab öffnen</translation>
+<translation id="8788968922598763114">Zuletzt geschlossenen Tab öffnen</translation>
+<translation id="7929962904089429003">Menü öffnen</translation>
+<translation id="6039379616847168523">Zum nächsten Tab wechseln</translation>
+<translation id="5210286577605176222">Zum vorherigen Tab wechseln</translation>
+<translation id="124678866338384709">Aktuellen Tab schließen</translation>
+<translation id="3714981814255182093">Suchleiste öffnen</translation>
+<translation id="5441522332038954058">Zur Adressleiste wechseln</translation>
+<translation id="3398320232533725830">Lesezeichen-Manager öffnen</translation>
+<translation id="6583199322650523874">Aktuelle Seite als Lesezeichen speichern</translation>
+<translation id="8489271220582375723">Verlaufsseite öffnen</translation>
+<translation id="4837753911714442426">Optionen zum Drucken einer Seite öffnen</translation>
+<translation id="5726692708398506830">Gesamten Seiteninhalt vergrößern</translation>
+<translation id="3259831549858767975">Gesamten Seiteninhalt verkleinern</translation>
+<translation id="8015452622527143194">Gesamten Seiteninhalt auf Standardgröße zurücksetzen</translation>
+<translation id="3443221991560634068">Aktuelle Seite neu laden</translation>
+<translation id="123724288017357924">Aktuelle Seite neu laden, Cache-Inhalte ignorieren</translation>
+<translation id="305870044889644984">Brave-Hilfe in einem neuen Tab öffnen</translation>
+<translation id="3166827708714933426">Tastenkombinationen für Tabs und Fenster</translation>
+<translation id="3169981355900570544">Tastenkombinationen für Brave Software Brave-Funktionen</translation>
+<translation id="4558311620361989323">Tastenkombinationen für Webseiten</translation>
+<translation id="1908301351964700579">VR ist noch nicht bereit. Starten Sie Brave später neu.</translation>
+<translation id="8970887620466824814">Es gab ein Problem.</translation>
+<translation id="1875543012935658554">Öffnen Sie Brave noch einmal.</translation>
+<translation id="79859296434321399">ARCore installieren, um Augmented-Reality-Inhalte zu sehen</translation>
+<translation id="8558485628462305855">ARCore aktualisieren, um Augmented-Reality-Inhalte zu sehen</translation>
+<translation id="3513704683820682405">Augmented Reality</translation>
+<translation id="5475862044948910901">Augmented-Reality-Sitzung starten?</translation>
 <translation id="7365126855094612066">Die Website kann für die Dauer dieser Sitzung Folgendes tun:
 • Eine 3D-Karte Ihrer Umgebung erstellen
 • Die Bewegung der Kamera verfolgen
 
 Die Website erhält KEINEN Zugriff auf die Kamera. Die Kamerabilder sind nur für Sie sichtbar.</translation>
-<translation id="7375125077091615385">Typ:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Eindruck beim ersten Ausführen von Chrome</translation>
-<translation id="741204030948306876">Ja, bitte</translation>
-<translation id="7413229368719586778">Startdatum: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Zuerst fragen</translation>
-<translation id="7423538860840206698">Es dürfen keine Dateien aus der Zwischenablage abgerufen werden</translation>
-<translation id="7431991332293347422">Legen Sie fest, wie Ihr Browserverlauf zur Personalisierung der Google-Suche verwendet wird</translation>
-<translation id="7437998757836447326">Von Chrome abmelden</translation>
-<translation id="7438641746574390233">Wenn der Lite-Modus aktiviert ist, wird der Seitenaufbau in Chrome mithilfe von Google-Servern beschleunigt. Im Lite-Modus werden sehr langsame Seiten so umgeschrieben, dass nur die wesentlichen Inhalte geladen werden. Der Lite-Modus wird nicht auf Inkognito-Tabs angewendet.</translation>
-<translation id="7444811645081526538">Weitere Kategorien</translation>
-<translation id="7445411102860286510">Automatische Wiedergabe stummgeschalteter Videos auf Websites zulassen (empfohlen)</translation>
-<translation id="7453467225369441013">Sie werden von den meisten Websites, aber nicht aus Ihrem Google-Konto abgemeldet.</translation>
-<translation id="7454641608352164238">Zu wenig Speicherplatz</translation>
-<translation id="7475192538862203634">Sollten Sie diese Meldung häufiger erhalten, sehen Sie sich unsere <ph name="BEGIN_LINK" />Empfehlungen<ph name="END_LINK" /> an.</translation>
-<translation id="7475688122056506577">SD-Karte nicht gefunden. Einige Ihrer Dateien fehlen möglicherweise.</translation>
-<translation id="7479104141328977413">Tab-Verwaltung</translation>
-<translation id="7481312909269577407">Vorwärts</translation>
-<translation id="7482656565088326534">Vorschau-Tab</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (aktualisiert <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">eingesparte Datenmenge</translation>
-<translation id="7498271377022651285">Bitte warten...</translation>
-<translation id="7514365320538308">Herunterladen</translation>
-<translation id="751961395872307827">Keine Verbindung zur Website möglich</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Vorschläge können nicht abgerufen werden</translation>
-<translation id="7559975015014302720">Lite-Modus ist deaktiviert</translation>
-<translation id="7562080006725997899">Browserdaten werden gelöscht</translation>
-<translation id="756809126120519699">Gelöschte Chrome-Daten</translation>
-<translation id="757524316907819857">Wiedergabe von geschützten Inhalten für Websites blockieren</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> Datei heruntergeladen}other{<ph name="FILES_DOWNLOADED_MANY" /> Dateien heruntergeladen}}</translation>
-<translation id="7588219262685291874">Dunkles Design verwenden, wenn Energiesparmodus des Geräts aktiviert ist</translation>
-<translation id="7589445247086920869">Für die aktuelle Suchmaschine blockieren</translation>
-<translation id="7593557518625677601">Einstellungen öffnen und Systemsynchr. aktivieren, um Chrome-Synchr. zu starten</translation>
-<translation id="7596558890252710462">Betriebssystem</translation>
-<translation id="7605594153474022051">Synchronisierung funktioniert nicht</translation>
-<translation id="7606077192958116810">Der Lite-Modus ist aktiviert. Sie können ihn in den Einstellungen verwalten.</translation>
-<translation id="7612619742409846846">Bei Google angemeldet als</translation>
-<translation id="7619072057915878432"><ph name="FILE_NAME" /> konnte aufgrund von Netzwerkfehlern nicht heruntergeladen werden.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Hilfe aufrufen<ph name="END_LINK1" /> oder <ph name="BEGIN_LINK2" />noch einmal suchen<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Willkommen bei Chrome</translation>
-<translation id="7638584964844754484">Falsche Passphrase</translation>
-<translation id="7641339528570811325">Browserdaten löschen…</translation>
-<translation id="7648422057306047504">Passwörter mit Google-Anmeldedaten verschlüsseln</translation>
-<translation id="7649070708921625228">Hilfe</translation>
-<translation id="7658239707568436148">Abbrechen</translation>
-<translation id="7665369617277396874">Konto hinzufügen</translation>
-<translation id="766587987807204883">Artikel erscheinen hier und können auch gelesen werden, wenn Sie offline sind</translation>
-<translation id="7682724950699840886">Probieren Sie folgende Tipps aus: Sorgen Sie dafür, dass auf Ihrem Gerät ausreichend Speicherplatz vorhanden ist, und wiederholen Sie den Export.</translation>
-<translation id="7685301384041462804">Starten Sie den VR-Modus nur dann, wenn Sie dieser Website vertrauen.</translation>
-<translation id="7698359219371678927">E-Mail in <ph name="APP_NAME" /> erstellen</translation>
-<translation id="7704317875155739195">Suchanfragen und URLs automatisch vervollständigen</translation>
-<translation id="7725024127233776428">Seiten, die Sie als Lesezeichen speichern, werden hier angezeigt</translation>
-<translation id="773466115871691567">Seiten auf <ph name="SOURCE_LANGUAGE" /> immer übersetzen</translation>
-<translation id="7746457520633464754">Chrome sendet die URLs einiger von Ihnen besuchter Seiten, bestimmte Systeminformationen und einige Seiteninhalte an Google, um gefährliche Apps und Websites zu erkennen</translation>
-<translation id="7757787379047923882">Text geteilt von <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-Karte <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Adresse hinzufügen</translation>
-<translation id="7772032839648071052">Passphrase bestätigen</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> schließen</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> weitere}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 und <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> weitere}}</translation>
-<translation id="7781829728241885113">Gestern</translation>
-<translation id="7791543448312431591">Hinzufügen</translation>
-<translation id="780301667611848630">Kein Interesse</translation>
-<translation id="7810647596859435254">Öffnen mit…</translation>
-<translation id="7821588508402923572">Ihre Einsparungen bei der Datennutzung werden hier angezeigt</translation>
-<translation id="7837721118676387834">Automatische Wiedergabe stummgeschalteter Videos für eine bestimmte Website zulassen.</translation>
-<translation id="7846076177841592234">Auswahl aufheben</translation>
-<translation id="784934925303690534">Zeitraum</translation>
-<translation id="7851858861565204677">Andere Geräte</translation>
-<translation id="7875915731392087153">E-Mail erstellen</translation>
-<translation id="7876243839304621966">Alle entfernen</translation>
-<translation id="7882131421121961860">Kein Verlauf gefunden</translation>
-<translation id="7882806643839505685">Wiedergabe von Ton auf einer bestimmten Website zulassen.</translation>
-<translation id="7886917304091689118">Wird in Chrome ausgeführt</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Datei wird heruntergeladen.}other{# Dateien werden heruntergeladen.}}</translation>
-<translation id="7929962904089429003">Menü öffnen</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> ist veraltet.</translation>
-<translation id="7947953824732555851">Akzeptieren und anmelden</translation>
-<translation id="7963646190083259054">Anbieter:</translation>
-<translation id="7971136598759319605">Vor 1 Tag aktiv</translation>
-<translation id="7975379999046275268">Seitenvorschau <ph name="BEGIN_NEW" />Neu<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Seiten vorab laden, um das Surfen und die Suche zu beschleunigen</translation>
-<translation id="79859296434321399">ARCore installieren, um Augmented-Reality-Inhalte zu sehen</translation>
-<translation id="7986741934819883144">Kontakt auswählen</translation>
-<translation id="7987073022710626672">Chrome-Nutzungsbedingungen</translation>
-<translation id="7998918019931843664">Geschlossenen Tab wieder öffnen</translation>
-<translation id="7999064672810608036">Möchten Sie wirklich alle lokalen Daten einschließlich Cookies löschen und alle Berechtigungen für diese Website zurücksetzen?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Für dieses Gerät deaktiviert</translation>
-<translation id="8013372441983637696">Meine Chrome-Daten auch von diesem Gerät löschen</translation>
-<translation id="8015452622527143194">Gesamten Seiteninhalt auf Standardgröße zurücksetzen</translation>
-<translation id="802154636333426148">Downloadfehler</translation>
-<translation id="8026334261755873520">Browserdaten löschen</translation>
-<translation id="8035133914807600019">Neuer Ordner…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> Tage übrig</translation>
-<translation id="804335162455518893">SD-Karte nicht gefunden</translation>
-<translation id="805047784848435650">Basierend auf Ihrem Browserverlauf</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB verfügbar</translation>
-<translation id="8058746566562539958">In neuem Chrome-Tab öffnen</translation>
-<translation id="8063895661287329888">Fehler beim Hinzufügen des Lesezeichens.</translation>
-<translation id="806745655614357130">Daten getrennt halten</translation>
-<translation id="8067883171444229417">Video ansehen</translation>
-<translation id="8068648041423924542">Zertifikat kann nicht ausgewählt werden.</translation>
-<translation id="8073388330009372546">Bild in neuem Tab öffnen</translation>
-<translation id="8076492880354921740">Tabs</translation>
-<translation id="8084114998886531721">Gespeichertes Passwort</translation>
-<translation id="8087000398470557479">Dieser Inhalt ist von <ph name="DOMAIN_NAME" /> und wurde von Google bereitgestellt.</translation>
-<translation id="8103578431304235997">Inkognito-Tab</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Aktivieren Sie die Synchronisierung, um Ihre Lesezeichen auf allen Ihren Geräten zu sehen</translation>
-<translation id="8110087112193408731">Ihre Chrome-Aktivitäten in Digital Wellbeing anzeigen?</translation>
-<translation id="8116925261070264013">Stummgeschaltet</translation>
-<translation id="813082847718468539">Website-Informationen anzeigen</translation>
-<translation id="8131740175452115882">Bestätigen</translation>
-<translation id="8156139159503939589">Welche Sprachen können Sie lesen?</translation>
-<translation id="8168435359814927499">Inhalte</translation>
-<translation id="8186512483418048923">Noch <ph name="FILES" /> Dateien</translation>
-<translation id="8190358571722158785">1 Tag übrig</translation>
-<translation id="8200772114523450471">Fortsetzen</translation>
-<translation id="8209050860603202033">Bild öffnen</translation>
-<translation id="8218622182176210845">Konto verwalten</translation>
-<translation id="8224471946457685718">"Artikel für mich" bei bestehender WLAN-Verbindung herunterladen</translation>
-<translation id="8232956427053453090">Daten aufbewahren</translation>
-<translation id="8249310407154411074">Ganz nach oben</translation>
-<translation id="8250920743982581267">Dokumente</translation>
-<translation id="825412236959742607">Diese Seite benötigt zu viel Arbeitsspeicher. Darum hat Chrome einige Inhalte entfernt.</translation>
-<translation id="8260126382462817229">Melden Sie sich noch einmal an</translation>
-<translation id="8261506727792406068">Löschen</translation>
-<translation id="8266862848225348053">Downloadpfad</translation>
-<translation id="8274165955039650276">Downloads aufrufen</translation>
-<translation id="8284326494547611709">Untertitel</translation>
-<translation id="8300705686683892304">Von App verwaltet</translation>
-<translation id="8310344678080805313">Standard-Tabs</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> und weitere Websites</translation>
-<translation id="8327155640814342956">Noch besser und komfortabler surfen – jetzt Chrome öffnen und aktualisieren</translation>
-<translation id="8339163506404995330">Seiten auf <ph name="LANGUAGE" /> werden nicht übersetzt</translation>
-<translation id="8349013245300336738">Nach Menge der verwendeten Daten sortieren</translation>
-<translation id="8364299278605033898">Beliebte Websites ansehen</translation>
-<translation id="8368027906805972958">Unbekanntes oder nicht unterstütztes Gerät (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Lässt die Hintergrundsynchronisierung für eine bestimmte Website zu.</translation>
-<translation id="8378714024927312812">Von Ihrer Organisation verwaltet</translation>
-<translation id="8380167699614421159">Diese Website zeigt aufdringliche oder irreführende Werbung an</translation>
-<translation id="8393700583063109961">Nachricht senden</translation>
-<translation id="8413126021676339697">Gesamtverlauf anzeigen</translation>
-<translation id="8427875596167638501">Vorschau-Tab ist halb geöffnet</translation>
-<translation id="8428213095426709021">Einstellungen</translation>
-<translation id="8438566539970814960">Suchanfragen und das Surfen verbessern</translation>
-<translation id="8441146129660941386">Zurück navigieren</translation>
-<translation id="8443209985646068659">Update nicht möglich</translation>
-<translation id="8445448999790540984">Passwörter können nicht exportiert werden</translation>
-<translation id="8447861592752582886">Zugriffsberechtigung auf Gerät widerrufen</translation>
-<translation id="8461694314515752532">Synchronisierte Daten mit eigener Synchronisierungspassphrase verschlüsseln</translation>
-<translation id="8466613982764129868">Prüfen Sie, ob <ph name="TARGET_DEVICE_NAME" /> mit dem Internet verbunden ist</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Offline verfügbar</translation>
-<translation id="8489271220582375723">Verlaufsseite öffnen</translation>
-<translation id="8493948351860045254">Speicherplatz freigeben</translation>
-<translation id="8497726226069778601">Noch keine Seiten</translation>
-<translation id="8503559462189395349">Chrome-Passwörter</translation>
-<translation id="8503813439785031346">Nutzername</translation>
-<translation id="8514477925623180633">In Chrome gespeicherte Passwörter exportieren</translation>
-<translation id="8514577642972634246">Inkognitomodus aktivieren</translation>
-<translation id="851751545965956758">Verhindern, dass Websites eine Verbindung zu Geräten herstellen</translation>
-<translation id="8523928698583292556">Gespeichertes Passwort löschen</translation>
-<translation id="854522910157234410">Diese Seite öffnen</translation>
-<translation id="8558485628462305855">ARCore aktualisieren, um Augmented-Reality-Inhalte zu sehen</translation>
-<translation id="8559990750235505898">Übersetzung für Seiten in andere Sprachen anbieten</translation>
-<translation id="8562452229998620586">Gespeicherte Passwörter erscheinen hier.</translation>
-<translation id="8569404424186215731">seit <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Letzte 4 Wochen</translation>
-<translation id="857943718398505171">Zugelassen (empfohlen)</translation>
-<translation id="8583805026567836021">Kontodaten werden gelöscht</translation>
-<translation id="860043288473659153">Name des Karteninhabers</translation>
-<translation id="8609465669617005112">Nach oben</translation>
-<translation id="8616006591992756292">Unter <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> sind möglicherweise weitere Arten von Browserverlaufsdaten für Ihr Google-Konto gespeichert.</translation>
-<translation id="8617240290563765734">Soll die im heruntergeladenen Inhalt angegebene URL geöffnet werden?</translation>
-<translation id="8636825310635137004">Aktivieren Sie die Synchronisierung, um Tabs von Ihren anderen Geräten abzurufen.</translation>
-<translation id="8641930654639604085">Versuchen, nicht jugendfreie Websites zu blockieren</translation>
-<translation id="8655129584991699539">Sie können die Daten in den Chrome-Einstellungen löschen</translation>
-<translation id="8662811608048051533">Sie werden von den meisten Websites abgemeldet.</translation>
-<translation id="8664979001105139458">Dateiname schon vorhanden</translation>
-<translation id="8676374126336081632">Eingabe löschen</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstärke: # Balken}other{Signalstärke: # Balken}}</translation>
-<translation id="868929229000858085">Kontakte durchsuchen</translation>
-<translation id="869891660844655955">Ablaufdatum</translation>
-<translation id="8719023831149562936">Aktueller Tab kann nicht gebeamt werden.</translation>
-<translation id="8725066075913043281">Erneut versuchen</translation>
-<translation id="8728487861892616501">Durch die Nutzung dieser Anwendung stimmen Sie den <ph name="BEGIN_LINK1" />Nutzungsbedingungen<ph name="END_LINK1" /> und <ph name="BEGIN_LINK2" />Datenschutzhinweisen<ph name="END_LINK2" /> von Chrome sowie den <ph name="BEGIN_LINK3" />Datenschutzhinweisen für mit Family Link verwaltete Google-Konten<ph name="END_LINK3" /> zu.</translation>
-<translation id="8730621377337864115">Fertig</translation>
-<translation id="8748850008226585750">Inhalte ausgeblendet</translation>
-<translation id="8751914237388039244">Bild auswählen</translation>
-<translation id="8788265440806329501">Der Navigationsverlauf wurde geschlossen</translation>
-<translation id="8788968922598763114">Zuletzt geschlossenen Tab öffnen</translation>
-<translation id="8801436777607969138">Hier können Sie Websites angeben, für die JavaScript blockiert werden soll.</translation>
-<translation id="8812260976093120287">Auf manchen Websites können Sie über Ihr Gerät mit den obigen unterstützten Zahlungs-Apps bezahlen.</translation>
-<translation id="8816026460808729765">Zugriff auf Sensoren für Websites blockieren</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> wird in Chrome geöffnet. Wenn Sie fortfahren, stimmen Sie den <ph name="BEGIN_LINK1" />Nutzungsbedingungen<ph name="END_LINK1" /> und <ph name="BEGIN_LINK2" />Datenschutzhinweisen<ph name="END_LINK2" /> von Chrome sowie den <ph name="BEGIN_LINK3" />Datenschutzhinweisen für mit Family Link verwaltete Google-Konten<ph name="END_LINK3" /> zu.</translation>
-<translation id="8820817407110198400">Lesezeichen</translation>
-<translation id="8833831881926404480">Eine Website teilt Ihren Bildschirm</translation>
-<translation id="883806473910249246">Beim Herunterladen des Inhalts ist ein Fehler aufgetreten.</translation>
-<translation id="8840953339110955557">Diese Seite unterscheidet sich gegebenenfalls von der Onlineversion.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Speicher</translation>
-<translation id="889338405075704026">Zu den Chrome-Einstellungen</translation>
-<translation id="8901170036886848654">Keine Lesezeichen gefunden</translation>
-<translation id="8909135823018751308">Teilen...</translation>
-<translation id="8912362522468806198">Google-Konto</translation>
-<translation id="8920114477895755567">Warten auf Details zu den Eltern</translation>
+<translation id="1188239144602654184">AR-Sitzung starten</translation>
+<translation id="473775607612524610">Aktualisieren</translation>
+<translation id="3133489217401741157"><ph name="MODULE"/> für Brave wird installiert…</translation>
+<translation id="1791662854739702043">Installiert</translation>
+<translation id="5131234170665854056"><ph name="MODULE"/> kann nicht für Brave installiert werden</translation>
+<translation id="2567385386134582609">BILD</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Seiten zur Offline-Ansicht herunterladen</translation>
 <translation id="8922289737868596582">Seiten über die Schaltfläche "Weitere Optionen" zur Offline-Ansicht herunterladen</translation>
-<translation id="8937772741022875483">Ihre Chrome-Aktivitäten aus Digital Wellbeing entfernen?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">In anderem Fenster öffnen</translation>
-<translation id="8951232171465285730">Dank Chrome haben Sie <ph name="MEGABYTES" /> MB eingespart</translation>
-<translation id="8958424370300090006">Cookies für eine bestimmte Website werden blockiert.</translation>
-<translation id="8959122750345127698">Navigation nicht möglich: <ph name="URL" /> ist nicht erreichbar.</translation>
-<translation id="8965591936373831584">ausstehend</translation>
-<translation id="8970887620466824814">Es gab ein Problem.</translation>
-<translation id="8972098258593396643">In Standardordner herunterladen?</translation>
-<translation id="8986494364107987395">Nutzungsstatistiken und Absturzberichte automatisch an Google senden</translation>
-<translation id="8993760627012879038">Neuen Tab im Inkognitomodus öffnen</translation>
-<translation id="8998729206196772491">Sie melden sich mit einem von <ph name="MANAGED_DOMAIN" /> verwalteten Konto an und geben dem Administrator der Domain Kontrolle über Ihre Chrome-Daten. Die Daten werden diesem Konto dauerhaft zugeordnet. Wenn Sie sich von Chrome abmelden, werden Ihre Daten auf dem Gerät gelöscht, bleiben jedoch in Ihrem Google-Konto erhalten.</translation>
-<translation id="9019902583201351841">Von deinen Eltern verwaltet</translation>
-<translation id="9028914725102941583">Synchronisierung aktivieren, um geräteübergreifend zu teilen</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> erlauben, VR zu starten?</translation>
-<translation id="9040142327097499898">Benachrichtigungen sind erlaubt. Der Standortzugriff ist für dieses Gerät deaktiviert.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Videos}}</translation>
-<translation id="9050666287014529139">Passphrase</translation>
-<translation id="9063523880881406963">"Desktopversion ansehen" deaktivieren</translation>
-<translation id="9065203028668620118">Bearbeiten</translation>
-<translation id="9070377983101773829">Sprachsuche starten</translation>
-<translation id="9074336505530349563">Melden Sie sich und aktivieren Sie die Synchronisierung, um personalisierte, von Google vorgeschlagene Inhalte zu erhalten</translation>
-<translation id="9086455579313502267">Kein Zugriff auf das Netzwerk</translation>
-<translation id="9100505651305367705">Anbieten, Artikel in vereinfachter Ansicht anzuzeigen, falls unterstützt</translation>
-<translation id="9100610230175265781">Passphrase erforderlich</translation>
-<translation id="9102803872260866941">Vorschau-Tab ist geöffnet</translation>
+<translation id="5958275228015807058">Ihre Dateien und Seiten finden Sie unter "Downloads"</translation>
+<translation id="5620928963363755975">Ihre Dateien und Seiten finden Sie durch Auswahl der Schaltfläche "Weitere Optionen" unter "Downloads"</translation>
+<translation id="3341058695485821946">Erfahren Sie, wie viel Datenvolumen Sie eingespart haben</translation>
+<translation id="3157842584138209013">Über die Schaltfläche "Weitere Optionen" können Sie sich ansehen, wie viel Datenvolumen Sie einsparen</translation>
+<translation id="8218622182176210845">Konto verwalten</translation>
+<translation id="8090895580117672212">Wenn Sie Ihr Brave Software-Konto verwalten möchten, tippen Sie auf die Schaltfläche "Konto verwalten"</translation>
+<translation id="8856898588039823173">Lite-Modus-Seite von Brave Software bereitgestellt. Zum Laden der Originalseite tippen.</translation>
+<translation id="8134317863207426198">Lite-Modus-Seite von Brave Software bereitgestellt. Zum Laden der Originalseite auf die Schaltfläche "Original laden" tippen.</translation>
+<translation id="4961107849584082341">Lassen Sie sich diese Seite in eine beliebige Sprache übersetzen</translation>
+<translation id="569536719314091526">Über die Schaltfläche "Weitere Optionen" können Sie sich diese Seite in eine beliebige Sprache übersetzen lassen</translation>
+<translation id="1397811292916898096">Mit <ph name="PRODUCT_NAME"/> suchen</translation>
+<translation id="1792959175193046959">Sie können den Standard-Downloadpfad jederzeit ändern</translation>
+<translation id="6942665639005891494">Sie können den Standard-Downloadpfad jederzeit über die Option im Menü "Einstellungen" ändern</translation>
+<translation id="6850409657436465440">Download noch in Bearbeitung</translation>
+<translation id="5817715962196959877">In Brave sind Downloads jetzt noch schneller</translation>
+<translation id="3976396876660209797">Verknüpfung entfernen und neu erstellen</translation>
+<translation id="6766622839693428701">Zum Schließen nach unten wischen.</translation>
+<translation id="1028699632127661925">Wird an <ph name="DEVICE_NAME"/> gesendet…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/>: gesendet von <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Tab erhalten</translation>
 <translation id="9104217018994036254">Die Liste von Geräten, mit denen ein Tab geteilt werden kann.</translation>
-<translation id="9133397713400217035">Offline entdecken</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Original anzeigen</translation>
-<translation id="9139068048179869749">Nachfragen, bevor Websites Benachrichtigungen senden dürfen (empfohlen)</translation>
-<translation id="9139318394846604261">Shopping</translation>
-<translation id="9155898266292537608">Sie können auch kurz auf ein Wort tippen, um eine Suche zu starten</translation>
-<translation id="9169507124922466868">Navigationsverlauf ist halb geöffnet</translation>
-<translation id="9204836675896933765">Noch 1 Datei</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Die Liste von Geräten, mit denen ein Tab geteilt werden kann, ist halb geöffnet.</translation>
+<translation id="2904414404539560095">Die Liste von Geräten, mit denen ein Tab geteilt werden kann, ist ganz geöffnet.</translation>
+<translation id="4135200667068010335">Die Liste von Geräten, mit denen ein Tab geteilt werden kann, ist geschlossen.</translation>
+<translation id="5292796745632149097">Senden an</translation>
+<translation id="1386674309198842382">Vor <ph name="LAST_UPDATED"/> Tagen aktiv</translation>
+<translation id="7971136598759319605">Vor 1 Tag aktiv</translation>
+<translation id="1521774566618522728">Heute aktiv</translation>
+<translation id="3631987586758005671">Wird mit "<ph name="DEVICE_NAME"/>" geteilt</translation>
+<translation id="9028914725102941583">Synchronisierung aktivieren, um geräteübergreifend zu teilen</translation>
+<translation id="6162454065885854378">Wenn Sie Inhalte auf Ihrem Smartphone mit einem anderen Gerät teilen möchten, aktivieren Sie auf beiden Geräten in den Brave-Einstellungen die Synchronisierung</translation>
+<translation id="6084271560289605378">Zu den Brave-Einstellungen</translation>
+<translation id="2318045970523081853">Zum Anrufen tippen</translation>
 <translation id="9209888181064652401">Anrufe nicht möglich</translation>
-<translation id="9219103736887031265">Bilder</translation>
-<translation id="926205370408745186">Chrome-Aktivitäten aus Digital Wellbeing entfernen</translation>
-<translation id="932327136139879170">Privat</translation>
-<translation id="938850635132480979">Fehler: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Mikrofonzugriff</translation>
-<translation id="95817756606698420">Chrome kann in China <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> für die Suche verwenden. Sie können dies unter <ph name="BEGIN_LINK" />Einstellungen<ph name="END_LINK" /> ändern.</translation>
-<translation id="965817943346481315">Blockieren, wenn Website aufdringliche oder irreführende Werbung anzeigt (empfohlen)</translation>
-<translation id="968900484120156207">Von Ihnen besuchte Seiten werden hier angezeigt</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> Minuten übrig</translation>
-<translation id="974555521953189084">Geben Sie Ihre Passphrase ein, um die Synchronisierung zu starten</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Alle Daten für alle Websites werden gelöscht, darunter:</translation>
-<translation id="983192555821071799">Alle Tabs schließen</translation>
-<translation id="987264212798334818">Allgemein</translation>
+<translation id="2860954141821109167">Prüfen Sie, ob auf diesem Gerät eine Telefon-App aktiviert ist</translation>
+<translation id="2067805253194386918">Text</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> kann nicht geteilt werden</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> konnte nicht geteilt werden</translation>
+<translation id="8287068819750208230">Prüfen Sie, ob auf <ph name="TARGET_DEVICE_NAME"/> die Synchronisierung in Brave aktiviert ist</translation>
+<translation id="3016635187733453316">Prüfen Sie, ob das Gerät mit dem Internet verbunden ist</translation>
+<translation id="8466613982764129868">Prüfen Sie, ob <ph name="TARGET_DEVICE_NAME"/> mit dem Internet verbunden ist</translation>
+<translation id="6539092367496845964">Ein Fehler ist aufgetreten. Versuchen Sie es später noch einmal.</translation>
+<translation id="3389286852084373014">SMS zu lang</translation>
+<translation id="2100314319871056947">Teilen Sie den Text am besten in mehreren Abschnitten</translation>
+<translation id="2987620471460279764">Text, der über ein anderes Gerät geteilt wurde</translation>
+<translation id="7757787379047923882">Text geteilt von <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">In die Zwischenablage kopiert</translation>
+<translation id="4696983787092045100">SMS an meine Geräte senden</translation>
+<translation id="1260236875608242557">Suchen und entdecken</translation>
+<translation id="6369229450655021117">Von hier aus können Sie im Web suchen, Inhalte mit Freunden teilen und sich geöffnete Seiten ansehen.</translation>
+<translation id="723171743924126238">Bilder auswählen</translation>
+<translation id="8751914237388039244">Bild auswählen</translation>
+<translation id="1989112275319619282">Durchsuchen</translation>
+<translation id="7055152154916055070">Weiterleitung blockiert:</translation>
+<translation id="5524843473235508879">Weiterleitung blockiert.</translation>
+<translation id="6573096386450695060">Immer zulassen</translation>
+<translation id="5805364706385912897">Diese Seite benötigt zu viel Arbeitsspeicher und wurde daher von Brave angehalten.</translation>
+<translation id="5138664332909611586">Diese Seite benötigt zu viel Arbeitsspeicher. Darum hat Brave einige Inhalte entfernt.</translation>
+<translation id="9137013805542155359">Original anzeigen</translation>
+<translation id="6361779936989026201">Brave Software Assistant für Brave</translation>
+<translation id="7291387454912369099">Assistant für AutoFill</translation>
+<translation id="4565206163201411670">Ihre Brave-Aktivitäten in Digital Wellbeing anzeigen?</translation>
+<translation id="9055113864158719823">Sie sehen in Brave besuchte Websites und können Timer einstellen.\n\nBrave Software erhält Informationen zu den Websites, für die Sie Timer einstellen, sowie zur Dauer des Besuchs. Anhand dieser Informationen wird Digital Wellbeing optimiert.</translation>
+<translation id="4596514158372210596">Brave-Aktivitäten aus Digital Wellbeing entfernen</translation>
+<translation id="1174893863889683998">Ihre Brave-Aktivitäten aus Digital Wellbeing entfernen?</translation>
+<translation id="708829030563435351">In Brave aufgerufene Websites werden nicht angezeigt. Alle Timer für Websites werden gelöscht.</translation>
+<translation id="2056878612599315956">Website pausiert</translation>
+<translation id="671481426037969117">Ihr <ph name="FQDN"/>-Timer ist abgelaufen. Morgen startet er neu.</translation>
+<translation id="7479104141328977413">Tab-Verwaltung</translation>
+<translation id="3524138585025253783">Benutzeroberfläche für Entwickler</translation>
+<translation id="6036057147555329831">Extra ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> erlauben, VR zu starten?</translation>
+<translation id="7685301384041462804">Starten Sie den VR-Modus nur dann, wenn Sie dieser Website vertrauen.</translation>
+<translation id="5033865233969348410">Während Sie sich im VR-Modus befinden, erhält die Website möglicherweise bestimmte Informationen über Sie. Dazu gehören:
+– physische Merkmale wie Ihre Größe
+
+Starten Sie den VR-Modus nur dann, wenn Sie dieser Website vertrauen.</translation>
+<translation id="5534334044554683961">Während Sie sich im VR-Modus befinden, erhält die Website möglicherweise bestimmte Informationen über Sie. Dazu gehören:
+– physische Merkmale wie Ihre Größe und
+– der Grundriss Ihres Zimmers
+
+Starten Sie den VR-Modus nur dann, wenn Sie dieser Website vertrauen.</translation>
+<translation id="4169535189173047238">Nicht zulassen</translation>
+<translation id="2170088579611075216">Zulassen und VR starten</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_el.xtb
+++ b/android/java/strings/translations/android_chrome_strings_el.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="el">
-<translation id="1006017844123154345">Άνοιγμα στο διαδίκτυο</translation>
-<translation id="1028699632127661925">Αποστολή στη συσκευή <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">Προσθήκη <ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">Από ιστοτόπους</translation>
-<translation id="1049743911850919806">Ανώνυμη περιήγηση</translation>
-<translation id="10614374240317010">Δεν έχει αποθηκευθεί ποτέ</translation>
-<translation id="1067922213147265141">Άλλες υπηρεσίες Google</translation>
-<translation id="1068672505746868501">Να μην γίνεται μετάφραση σελίδων στα <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Εάν αλλάξετε την επέκταση αρχείου, το αρχείο μπορεί να ανοίξει σε διαφορετική εφαρμογή και να αποτελέσει δυνητικό κίνδυνο για τη συσκευή σας.</translation>
-<translation id="1100066534610197918">Άνοιγμα σε νέα καρτ. σε ομάδα</translation>
-<translation id="1105960400813249514">Λήψη οθόνης</translation>
-<translation id="1111673857033749125">Οι σελιδοδείκτες που είναι αποθηκευμένοι σε άλλες συσκευές θα εμφανίζονται εδώ.</translation>
-<translation id="1113597929977215864">Εμφάνιση απλοποιημένης προβολής</translation>
-<translation id="1121094540300013208">Αναφορές χρήσης και σφαλμάτων</translation>
-<translation id="1124772482545689468">Χρήστης</translation>
-<translation id="1129510026454351943">Λεπτομέρειες: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 λήψη σε εκκρεμότητα.}other{# λήψεις σε εκκρεμότητα.}}</translation>
-<translation id="1145536944570833626">Διαγραφή υπαρχόντων δεδομένων.</translation>
-<translation id="1146678959555564648">Εισαγωγή VR</translation>
-<translation id="116280672541001035">Χρησιμοποιήθηκαν</translation>
-<translation id="1171770572613082465">Δείτε δημοφιλείς ιστοτόπους πατώντας το κουμπί "Κορυφαίοι ιστότοποι"</translation>
-<translation id="1173894706177603556">Μετονομασία</translation>
-<translation id="1178581264944972037">Παύση</translation>
-<translation id="1181037720776840403">Κατάργηση</translation>
-<translation id="1188239144602654184">Έναρξη AR</translation>
-<translation id="1197267115302279827">Μετακίνηση σελιδοδεικτών</translation>
-<translation id="119944043368869598">Διαγραφή όλων</translation>
-<translation id="1201402288615127009">Επόμενο</translation>
-<translation id="1204037785786432551">Λήψη συνδέσμου</translation>
-<translation id="1206892813135768548">Αντιγραφή κειμένου συνδέσμου</translation>
-<translation id="1208340532756947324">Για συγχρονισμό και εξατομίκευση σε διάφορες συσκευές, ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="1209206284964581585">Προσωρινή απόκρυψη</translation>
-<translation id="1227058898775614466">Ιστορικό περιήγησης</translation>
-<translation id="1231733316453485619">Ενεργοποίηση συγχρονισμού;</translation>
-<translation id="123724288017357924">Επαναφ. τρέχ.σελ. αγνοώντας το περιεχ. κρυφ.μνήμης</translation>
-<translation id="124116460088058876">Περισσότερες γλώσσες</translation>
-<translation id="124678866338384709">Κλείσιμο τρέχουσας καρτέλας</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Αναζήτηση και εξερεύνηση</translation>
-<translation id="1264974993859112054">Αθλητικά</translation>
-<translation id="1266864766717917324">Δεν ήταν δυνατή η κοινοποίηση <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Διακοπή</translation>
-<translation id="1283039547216852943">Πατήστε για ανάπτυξη</translation>
-<translation id="1285320974508926690">Να μην γίνεται ποτέ μετάφραση αυτού του ιστότοπου</translation>
-<translation id="1291207594882862231">Διαγραφή ιστορικού, cookie, δεδομένων ιστότοπου, κρυφής μνήμης…</translation>
-<translation id="129382876167171263">Τα αρχεία που αποθηκεύονται από ιστοτόπους εμφανίζονται εδώ</translation>
-<translation id="129553762522093515">Έκλεισαν πρόσφατα</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Στάλθηκε από <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Ομαδοποίηση καρτελών</translation>
-<translation id="1327257854815634930">Το ιστορικό περιήγησης έχει ανοίξει</translation>
-<translation id="1331212799747679585">Δεν είναι δυνατή η ενημέρωση του Chrome. Περισσότερες επιλογές</translation>
-<translation id="1332501820983677155">Συντομεύσεις λειτουργιών Google Chrome</translation>
-<translation id="1360432990279830238">Αποσύνδεση και απενεργοπ. συγχρονισμού;</translation>
-<translation id="1369915414381695676">Προστέθηκε ο ιστότοπος <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Ανεπαρκής μνήμη για τη λήψη του επιλεγμένου περιεχομένου.</translation>
-<translation id="1376578503827013741">Υπολογισμός…</translation>
-<translation id="1383876407941801731">Αναζήτηση</translation>
-<translation id="1384959399684842514">Η λήψη διακόπηκε προσωρινά.</translation>
-<translation id="1386674309198842382">Ενεργή <ph name="LAST_UPDATED" /> ημέρες πριν</translation>
-<translation id="1397811292916898096">Αναζήτηση με <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Ενσωματωμένο σε <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"Να μην γίνεται εντοπισμός"</translation>
-<translation id="1407135791313364759">Άνοιγμα όλων</translation>
-<translation id="1409426117486808224">Απλοποιημένη προβολή για ανοικτές καρτέλες</translation>
-<translation id="1409879593029778104">Η λήψη του αρχείου <ph name="FILE_NAME" /> απετράπη, επειδή το αρχείο υπάρχει ήδη.</translation>
-<translation id="1414981605391750300">Επικοινωνία με Google… Αυτή η διαδικασία μπορεί να διαρκέσει μερικά λεπτά…</translation>
-<translation id="1416550906796893042">Έκδοση εφαρμογής</translation>
-<translation id="1430915738399379752">Εκτύπωση</translation>
-<translation id="1446450296470737166">Να επιτρέπεται πλήρης έλεγχος σε MIDI</translation>
-<translation id="1450753235335490080">Δεν είναι δυνατή η κοινοποίηση <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Έχει απενεργοποιηθεί στις Ρυθμίσεις Android</translation>
-<translation id="1477626028522505441">Η λήψη του αρχείου <ph name="FILE_NAME" /> απέτυχε λόγω προβλημάτων στον διακομιστή.</translation>
-<translation id="1506061864768559482">Μηχανή αναζήτησης</translation>
-<translation id="1513352483775369820">Σελιδοδείκτες και ιστορικό ιστού</translation>
-<translation id="1513858653616922153">Διαγραφή κωδικού πρόσβασης</translation>
-<translation id="1516229014686355813">Η λειτουργία "Πατήστε για αναζήτηση" αποστέλλει την επιλεγμένη λέξη και την τρέχουσα σελίδα ως περιβάλλον στην Αναζήτηση Google. Μπορείτε να την απενεργοποιήσετε στις <ph name="BEGIN_LINK" />Ρυθμίσεις<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Ενεργή σήμερα</translation>
-<translation id="1544826120773021464">Για να διαχειριστείτε τον Λογαριασμό σας Google, πατήστε το κουμπί Διαχείριση λογαριασμού.</translation>
-<translation id="1549000191223877751">Μεταβείτε σε άλλο παράθυρο</translation>
-<translation id="1553358976309200471">Ενημερώστε το Chrome</translation>
-<translation id="1569387923882100876">Συνδεδεμένη συσκευή</translation>
-<translation id="1571304935088121812">Αντιγραφή ονόματος χρήστη</translation>
-<translation id="1612196535745283361">Το Chrome χρειάζεται πρόσβαση στην τοποθεσία, προκειμένου να κάνει σάρωση για συσκευές. Η πρόσβαση τοποθεσίας είναι <ph name="BEGIN_LINK" />απενεργοποιημένη για αυτήν τη συσκευή<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Κάμερα</translation>
-<translation id="1623104350909869708">Αποτροπή δημιουργίας πρόσθετων παραθύρων διαλόγου από αυτήν τη σελίδα</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Κατάργηση 1 επιλεγμένου στοιχείου}other{Κατάργηση # επιλεγμένων στοιχείων}}</translation>
-<translation id="164269334534774161">Βλέπετε ένα αντίγραφο εκτός σύνδεσης αυτής της σελίδας από <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Ιστορικό</translation>
-<translation id="1647391597548383849">Πρόσβαση στην κάμερα</translation>
-<translation id="1660204651932907780">Να επιτρέπεται στους ιστοτόπους να αναπαράγουν ήχο (συνιστάται)</translation>
-<translation id="1670399744444387456">Βασικά</translation>
-<translation id="1671236975893690980">Λήψη σε εκκρεμότητα…</translation>
-<translation id="1672586136351118594">Να μην εμφανιστεί ξανά</translation>
-<translation id="1692118695553449118">Ο συγχρονισμός είναι ενεργοποιημένος</translation>
-<translation id="169515064810179024">Αποκλεισμός πρόσβασης σε αισθητήρες κίνησης από ιστοτόπους</translation>
-<translation id="1717218214683051432">Αισθητήρες κίνησης</translation>
-<translation id="1718835860248848330">Τελευταία ώρα</translation>
-<translation id="1736419249208073774">Εξερεύνηση</translation>
-<translation id="1743802530341753419">Να γίνεται ερώτηση προτού επιτραπεί στους ιστοτόπους να συνδεθούν σε μια συσκευή (συνιστάται)</translation>
-<translation id="1749561566933687563">Συγχρονίστε τους σελιδοδείκτες σας</translation>
-<translation id="17513872634828108">Ανοικτές καρτέλες</translation>
-<translation id="1779089405699405702">Εργαλείο αποκωδικοποίησης εικόνων</translation>
-<translation id="1782483593938241562">Ημερομηνία λήξης: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Εγκατεστημένο</translation>
-<translation id="1792959175193046959">Αλλάξτε την προεπιλεγμένη τοποθεσία λήψης ανά πάσα στιγμή</translation>
-<translation id="1807246157184219062">Ανοιχτόχρωμο</translation>
-<translation id="1810845389119482123">Η αρχική ρύθμιση συγχρονισμού δεν ολοκληρώθηκε</translation>
-<translation id="1821253160463689938">Χρησιμοποιεί cookie για την απομνημόνευση των προτιμήσεών σας, ακόμα κι αν δεν επισκέπτεστε αυτές τις σελίδες</translation>
-<translation id="1829244130665387512">Εύρεση στη σελίδα</translation>
-<translation id="1853692000353488670">Νέα καρτέλα ανώνυμης περιήγησης</translation>
-<translation id="1856325424225101786">Επαναφορά της λειτουργίας Lite;</translation>
-<translation id="1868024384445905608">Το Chrome κατεβάζει πλέον τα αρχεία πιο γρήγορα</translation>
-<translation id="1883903952484604915">Τα αρχεία μου</translation>
-<translation id="1887786770086287077">Η πρόσβαση στην Τοποθεσία είναι απενεργοποιημένη γι' αυτήν τη συσκευή. Ενεργοποιήστε τη στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Η εφαρμογή <ph name="APP_NAME" /> θα ανοίξει στο Chrome. Εάν συνεχίσετε, συμφωνείτε με τους <ph name="BEGIN_LINK1" />Όρους Παροχής Υπηρεσιών<ph name="END_LINK1" /> και τη <ph name="BEGIN_LINK2" />Σημείωση απορρήτου<ph name="END_LINK2" /> του Chrome.</translation>
-<translation id="1919345977826869612">Διαφημίσεις</translation>
-<translation id="1919950603503897840">Επιλογή επαφών</translation>
-<translation id="1922076542920281912">Για να επιτρέψετε στο Chrome να αποκτήσει πρόσβαση στην τοποθεσία σας, ενεργοποιήστε επίσης την τοποθεσία στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Ενημερώσεις</translation>
-<translation id="19288952978244135">Ανοίξτε ξανά το Chrome.</translation>
-<translation id="1933845786846280168">Επιλεγμένη καρτέλα</translation>
-<translation id="194341124344773587">Ενεργοποίηση των αδειών για το Chrome στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Αποθήκευση κωδικών πρόσβασης</translation>
-<translation id="1952172573699511566">Οι ιστότοποι θα εμφανίζουν κείμενο στην προτιμώμενη γλώσσα σας όταν υπάρχει αυτή η δυνατότητα.</translation>
-<translation id="1960290143419248813">Οι ενημερώσεις Chrome δεν υποστηρίζονται πλέον για αυτήν την έκδοση Android</translation>
-<translation id="1966710179511230534">Ενημερώστε τα στοιχεία σύνδεσής σας.</translation>
-<translation id="1974060860693918893">Σύνθετες</translation>
-<translation id="1984705450038014246">Συγχρονισμός των δεδομένων του Chrome</translation>
-<translation id="1984937141057606926">Να επιτρέπονται, εκτός από τα cookie τρίτου μέρους</translation>
-<translation id="1986685561493779662">Το όνομα υπάρχει ήδη</translation>
-<translation id="1987739130650180037">Κουμπί <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Περιήγηση</translation>
-<translation id="1993768208584545658">Ο ιστότοπος <ph name="SITE" /> επιθυμεί σύζευξη</translation>
-<translation id="1994173015038366702">URL ιστότοπου</translation>
-<translation id="2000419248597011803">Στέλνει ορισμένα cookie και αναζητήσεις από τη γραμμή διευθύνσεων και το πλαίσιο αναζήτησης στην προεπιλεγμένη μηχανή αναζήτησης</translation>
-<translation id="2002537628803770967">Πιστωτικές κάρτες και διευθύνσεις που χρησιμοποιούν το Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Αρχείο}other{# Αρχεία}}</translation>
-<translation id="2017836877785168846">Διαγράφει το ιστορικό και τις αυτόματες συμπληρώσεις στη γραμμή διευθύνσεων.</translation>
-<translation id="2021896219286479412">Στοιχ. ελέγ. σε πλήρη οθόνη</translation>
-<translation id="2038563949887743358">Ενεργοποίηση αιτήματος ιστότοπου για υπολογιστές</translation>
-<translation id="2041019821020695769">Για να επιτρέψετε στο Chrome να σας στέλνει ειδοποιήσεις, ενεργοποιήστε επίσης τις ειδοποιήσεις στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Η εφαρμογή <ph name="APP_NAME" /> έχει επίσης δεδομένα στο Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Ο ιστότοπος τέθηκε σε παύση</translation>
-<translation id="2063713494490388661">Πατήστε για αναζήτηση</translation>
-<translation id="2067805253194386918">κείμενο</translation>
-<translation id="2079545284768500474">Αναίρεση</translation>
-<translation id="2082238445998314030">Αποτέλεσμα <ph name="RESULT_NUMBER" /> από <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Ήχος</translation>
-<translation id="2096012225669085171">Συγχρονισμός και εξατομίκευση σε όλες τις συσκευές</translation>
-<translation id="2100273922101894616">Αυτόματη σύνδεση</translation>
-<translation id="2100314319871056947">Δοκιμάστε να κοινοποιήσετε το κείμενο σε μικρότερα τμήματα.</translation>
-<translation id="2107397443965016585">Να γίνεται ερώτηση προτού επιτραπεί στους ιστοτόπους η αναπαραγωγή προστατευόμενου περιεχομένου (συνιστάται)</translation>
-<translation id="2111511281910874386">Μετάβαση στη σελίδα</translation>
-<translation id="2122601567107267586">Δεν ήταν δυνατό το άνοιγμα της εφαρμογής</translation>
-<translation id="2126426811489709554">Με την υποστήριξη του Chrome</translation>
-<translation id="2131665479022868825">Αποθηκεύτηκαν <ph name="DATA" /></translation>
-<translation id="213279576345780926">Η καρτέλα <ph name="TAB_TITLE" /> έκλεισε</translation>
-<translation id="2139186145475833000">Προσθήκη στην αρχική οθόνη</translation>
-<translation id="2146738493024040262">Άνοιγμα Instant Εφαρμογής</translation>
-<translation id="2148716181193084225">Σήμερα</translation>
-<translation id="2154484045852737596">Επεξεργασία κάρτας</translation>
-<translation id="2154710561487035718">Αντιγραφή διεύθυνσης URL</translation>
-<translation id="2156074688469523661">Ιστότοποι που απομένουν (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Για να κοινοποιήσετε κάτι από το τηλέφωνό σας σε μια άλλη συσκευή, ενεργοποιήστε τον συγχρονισμό στις ρυθμίσεις του Chrome και στις δύο συσκευές.</translation>
-<translation id="2170088579611075216">Αποδοχή και είσοδος σε VR</translation>
-<translation id="218608176142494674">Κοινοποίηση</translation>
-<translation id="2227444325776770048">Συνέχεια ως <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Συγχρονισμός και υπηρ. Google</translation>
-<translation id="2259659629660284697">Εξαγωγή κωδικών πρόσβασης…</translation>
-<translation id="2268044343513325586">Περιορισμός</translation>
-<translation id="2286841657746966508">Διεύθυνση τιμολόγησης</translation>
-<translation id="2289270750774289114">Να γίνεται ερώτηση όταν ένας ιστότοπος επιθυμεί να εντοπίσει κοντινές συσκευες Bluetooth (συνιστάται)</translation>
-<translation id="230115972905494466">Δεν βρέθηκαν συμβατές συσκευές</translation>
-<translation id="2315043854645842844">Η επιλογή πιστοποιητικού από τον πελάτη δεν υποστηρίζεται από το λειτουργικό σύστημα.</translation>
-<translation id="2318045970523081853">Πατήστε για πραγματοποίηση κλήσης</translation>
-<translation id="2321086116217818302">Προετοιμασία κωδικών πρόσβασης…</translation>
-<translation id="2321958826496381788">Σύρετε το ρυθμιστικό έως ότου να διαβάσετε αυτό το μήνυμα άνετα. Το κείμενο θα πρέπει να είναι τουλάχιστον τόσο μεγάλο αφού πατήσετε δύο φορές σε μια παράγραφο.</translation>
-<translation id="2323763861024343754">Αποθηκ. χώρος ιστοσελίδας</translation>
-<translation id="2328985652426384049">Δεν είναι δυνατή η σύνδεση</translation>
-<translation id="2330129964253841015">Να ενημερώνεστε σε περίπτωση παραβίασης των κωδικών πρόσβασής σας</translation>
-<translation id="2349710944427398404">Σύνολο δεδομένων που χρησιμοποιούνται από το Chrome, συμπεριλαμβανομένων των λογαριασμών, των σελιδοδεικτών και των αποθηκευμένων ρυθμίσεων</translation>
-<translation id="2353636109065292463">Έλεγχος της σύνδεσής σας στο διαδίκτυο</translation>
-<translation id="2359808026110333948">Συνέχεια</translation>
-<translation id="2369533728426058518">ανοικτές καρτέλες</translation>
-<translation id="2387895666653383613">Κλιμάκωση κειμένου</translation>
-<translation id="2394602618534698961">Εδώ εμφανίζονται τα αρχεία που κατεβάζετε</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Αυτή η λειτουργία ενεργοποιείται όταν συνδέεστε στον Λογαριασμό σας Google.</translation>
-<translation id="2410754283952462441">Επιλέξτε λογαριασμό</translation>
-<translation id="2414886740292270097">Σκούρο</translation>
-<translation id="2416359993254398973">Το Chrome χρειάζεται άδεια, για να αποκτήσει πρόσβαση στην κάμερα για αυτόν τον ιστότοπο.</translation>
-<translation id="2426805022920575512">Επιλογή άλλου λογαριασμού</translation>
-<translation id="2433507940547922241">Εμφάνιση</translation>
-<translation id="2434158240863470628">Η λήψη ολοκληρώθηκε <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Πρόσβαση τοποθεσίας</translation>
-<translation id="2450083983707403292">Θέλετε να ξεκινήσετε ξανά τη λήψη του αρχείου <ph name="FILE_NAME" />;</translation>
-<translation id="2482878487686419369">Ειδοποιήσεις</translation>
-<translation id="2490684707762498678">Διαχειριζόμενες από την εφαρμογή <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Βοηθός Google στο Chrome</translation>
-<translation id="2496180316473517155">Ιστορικό περιήγησης</translation>
-<translation id="2497852260688568942">Ο συγχρονισμός έχει απενεργοποιηθεί από τον διαχειριστή σας</translation>
-<translation id="2498359688066513246">Βοήθεια και σχόλια</translation>
-<translation id="2501278716633472235">Επιστροφή</translation>
-<translation id="2513403576141822879">Για περισσότερες ρυθμίσεις που σχετίζονται με το απόρρητο, την ασφάλεια και τη συλλογή δεδομένων, ανατρέξτε στην ενότητα <ph name="BEGIN_LINK" />Συγχρονισμός και υπηρεσίες Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Στη λειτουργία Lite, το Chrome φορτώνει τις σελίδες πιο γρήγορα και χρησιμοποιεί έως και 60% λιγότερα δεδομένα. Για να βελτιστοποιήσει τις σελίδες που επισκέπτεστε, το Chrome στέλνει την επισκεψιμότητα ιστού σας στο Google. <ph name="BEGIN_LINK" />Μάθετε περισσότερα<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Αποστέλλει στην Google URL των σελίδων που επισκέπτεστε</translation>
-<translation id="2532336938189706096">Προβολή ιστού</translation>
-<translation id="2534155362429831547">Διαγράφηκαν <ph name="NUMBER_OF_ITEMS" /> στοιχεία</translation>
-<translation id="2536728043171574184">Προβολή ενός αντιγράφου αυτής της σελίδας εκτός σύνδεσης</translation>
-<translation id="2546283357679194313">Cookie και δεδομένα ιστότοπου</translation>
-<translation id="2567385386134582609">ΕΙΚΟΝΑ</translation>
-<translation id="257088987046510401">Θέματα</translation>
-<translation id="2570922361219980984">Η πρόσβαση στην Τοποθεσία είναι απενεργοποιημένη επίσης γι' αυτήν τη συσκευή. Ενεργοποιήστε τη στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Αναπτυγμένη - Κάντε κλικ για σύμπτυξη</translation>
-<translation id="2581165646603367611">Αυτό θα διαγράψει τα cookie, την κρυφή μνήμη και άλλα δεδομένα ιστοτόπων που το Chrome θεωρεί ότι δεν είναι σημαντικά.</translation>
-<translation id="2586657967955657006">Πρόχειρο</translation>
-<translation id="2587052924345400782">Διατίθεται νεότερη έκδοση</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Αριθμός κάρτας</translation>
-<translation id="2621115761605608342">Να επιτρέπεται η JavaScript για έναν συγκεκριμένο ιστότοπο.</translation>
-<translation id="2625189173221582860">Ο κωδικός πρόσβασης αντιγράφηκε</translation>
-<translation id="2631006050119455616">Εξοικονομήθηκαν</translation>
-<translation id="2647434099613338025">Προσθήκη γλώσσας</translation>
-<translation id="2650751991977523696">Επανάληψη λήψης αρχείου;</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Αρχείο ήχου}other{# Αρχεία ήχου}}</translation>
-<translation id="2653659639078652383">Υποβολή</translation>
-<translation id="2677748264148917807">Αποχώρηση</translation>
-<translation id="2704606927547763573">Αντιγράφ.</translation>
-<translation id="2707726405694321444">Ανανέωση σελίδας</translation>
-<translation id="2709516037105925701">Αυτόματη συμπλήρωση</translation>
-<translation id="2717722538473713889">Διευθύνσεις ηλεκτρονικού ταχυδρομείου</translation>
-<translation id="2728754400939377704">Ταξινόμηση κατά ιστότοπο</translation>
-<translation id="2744248271121720757">Πατήστε μια λέξη για άμεση αναζήτηση ή για να δείτε τις σχετικές ενέργειες</translation>
-<translation id="2760989362628427051">Να ενεργοποιείται το σκούρο θέμα όταν το σκούρο θέμα ή η Εξοικονόμηση μπαταρίας της συσκευής σας έχουν ενεργοποιηθεί.</translation>
-<translation id="2762000892062317888">μόλις τώρα</translation>
-<translation id="2777555524387840389">Απομένουν <ph name="SECONDS" /> δευτερόλεπτα</translation>
-<translation id="2779651927720337254">απέτυχε</translation>
-<translation id="2781151931089541271">Απομένει 1 δευτερόλεπτο</translation>
-<translation id="2801022321632964776">Ενημερώστε για να χρησιμοποιείτε τη γλώσσα σας στην πιο πρόσφατη έκδοση του Chrome</translation>
-<translation id="2810645512293415242">Απλοποιημένη σελίδα για την αποθήκευση δεδομένων και για πιο γρήγορη φόρτωση.</translation>
-<translation id="281504910091592009">Προβολή και διαχείριση αποθηκευμένων κωδικών πρόσβασης στον <ph name="BEGIN_LINK" />Λογαριασμό σας Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Για να εμφανίζονται οι σελιδοδείκτες σας σε όλες τις συσκευές σας, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="2822354292072154809">Είστε βέβαοι ότι θέλετε να αναιρεθούν όλες οι άδειες ιστοτόπου για το αντικείμενο <ph name="CHOSEN_OBJECT_NAME" />;</translation>
-<translation id="2836148919159985482">Πατήστε το κουμπί επιστροφής για έξοδο από την πλήρη οθόνη.</translation>
-<translation id="2842985007712546952">Γονικός φάκελος</translation>
-<translation id="2858138569776157458">Κορ. ιστότοποι</translation>
-<translation id="2860954141821109167">Βεβαιωθείτε ότι είναι ενεργοποιημένη μια εφαρμογή τηλεφώνου σε αυτήν τη συσκευή.</translation>
-<translation id="2870560284913253234">Ιστότοπος</translation>
-<translation id="2874939134665556319">Προηγούμενο κομμάτι</translation>
-<translation id="2876369937070532032">Στέλνει URL από ορισμένες σελίδες που επισκέπτεστε στο Google, όταν η ασφάλειά σας βρίσκεται σε κίνδυνο</translation>
-<translation id="2888126860611144412">Σχετικά με το Chrome</translation>
-<translation id="2891154217021530873">Διακοπή φόρτωσης σελίδας</translation>
-<translation id="2893180576842394309">Η Google μπορεί να χρησιμοποιήσει το ιστορικό σας για την εξατομίκευση της Αναζήτησης και άλλων υπηρεσιών Google</translation>
-<translation id="2898264748040935573">Επεξεργασία αποθηκευμένου κωδικού πρόσβασης.</translation>
-<translation id="2900528713135656174">Δημιουργία συμβάντος</translation>
-<translation id="290376772003165898">Η σελίδα δεν είναι στα <ph name="LANGUAGE" />;</translation>
-<translation id="2904414404539560095">Άνοιγμα σε πλήρες ύψος της λίστας συσκευών στις οποίες θα κοινοποιηθεί μια καρτέλα.</translation>
-<translation id="2910701580606108292">Να γίνεται ερώτηση προτού επιτραπεί στους ιστοτόπους η αναπαραγωγή προστατευόμενου περιεχομένου</translation>
-<translation id="2913331724188855103">Να επιτρέπεται στους ιστότοπους η αποθήκευση και η ανάγνωση δεδομένων cookie (συνιστάται)</translation>
-<translation id="2923908459366352541">Το όνομα δεν είναι έγκυρο</translation>
-<translation id="2932150158123903946">Αποθηκευτικός χώρος Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Η καρτέλα προεπισκόπησης είναι κλειστή</translation>
-<translation id="2956410042958133412">Αυτός ο λογαριασμός τελεί υπό τη διαχείριση των γονέων <ph name="PARENT_NAME_1" /> και <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Έγινε εναλλαγή σε καρτέλες ανώνυμης περιήγησης</translation>
-<translation id="2968755619301702150">Πρόγρ. προβολής πιστοποιητικού</translation>
-<translation id="2979025552038692506">Επιλεγμένη καρτέλα ανώνυμης περιήγησης</translation>
-<translation id="2987620471460279764">Κοινόχρηστο κείμενο από άλλη συσκευή</translation>
-<translation id="2989523299700148168">Πραγματοποιήθηκε επίσκεψη πρόσφατα</translation>
-<translation id="2996291259634659425">Δημιουργία φράσης πρόσβασης</translation>
-<translation id="2996809686854298943">Απαιτείται διεύθυνση URL</translation>
-<translation id="300526633675317032">Αυτό θα διαγράψει και τα <ph name="SIZE_IN_KB" /> του αποθηκευτικού χώρου ιστοτόπων.</translation>
-<translation id="3016635187733453316">Βεβαιωθείτε ότι η συσκευή είναι συνδεδεμένη στο διαδίκτυο.</translation>
-<translation id="3029613699374795922">Έγινε λήψη <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Οι φράσεις πρόσβασης δεν συμφωνούν</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Λάβετε βοήθεια<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Η Τοποθεσία είναι απενεργοποιημένη. Ενεργοποιήστε την στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Μπορείτε να ενεργοποιήσετε τον συγχρονισμό ανά πάσα στιγμή στις ρυθμίσεις</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> σελιδοδείκτης}other{<ph name="BOOKMARKS_COUNT_MANY" /> σελιδοδείκτες}}</translation>
-<translation id="3089395242580810162">Άνοιγμα σε καρτ. ανών. περιήγ.</translation>
-<translation id="3115898365077584848">Πληροφορίες εκπομπής</translation>
-<translation id="3123473560110926937">Αποκλεισμός σε ορισμένους ιστοτόπους</translation>
-<translation id="3137521801621304719">Έξοδος από την κατάσταση ανώνυμης περιήγησης</translation>
-<translation id="3143515551205905069">Ακύρωση συγχρονισμού</translation>
-<translation id="3157842584138209013">Δείτε πόσα δεδομένα έχετε αποθηκεύσει από το κουμπί "Περισσότερες επιλογές"</translation>
-<translation id="3166827708714933426">Συντομεύσεις καρτέλας και παραθύρου</translation>
-<translation id="3181954750937456830">Ασφαλής περιήγηση (προστατεύει εσάς και τη συσκευή σας από επικίνδυνους ιστοτόπους)</translation>
-<translation id="3190152372525844641">Ενεργοποίηση των αδειών για το Chrome στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> αποθηκευμένα δεδομένα</translation>
-<translation id="3205824638308738187">Σχεδόν ολοκληρώθηκε!</translation>
-<translation id="3207960819495026254">Προστέθηκε στους σελιδοδείκτες</translation>
-<translation id="3211426585530211793">Το <ph name="ITEM_TITLE" /> διαγράφηκε</translation>
-<translation id="321773570071367578">Εάν ξεχάσετε τη φράση πρόσβασής σας ή θέλετε να αλλάξετε αυτήν τη ρύθμιση, <ph name="BEGIN_LINK" />επαναφέρετε το συγχρονισμό<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Μικρόφωνο</translation>
-<translation id="3232754137068452469">Εφαρμογή ιστού</translation>
-<translation id="3236059992281584593">Απομένει 1 λεπτό</translation>
-<translation id="3244271242291266297">ΜΜ</translation>
-<translation id="3254409185687681395">Προσθήκη αυτής της σελίδας στους σελιδοδείκτες</translation>
-<translation id="3259831549858767975">Σμίκρυνση όλων των στοιχείων της σελίδας</translation>
-<translation id="3269093882174072735">Φόρτωση εικόνας</translation>
-<translation id="3269956123044984603">Για να εμφανίζονται οι καρτέλες από τις άλλες συσκευές σας, ενεργοποιήστε τον "Αυτόματο συγχρονισμό δεδομένων" στις ρυθμίσεις λογαριασμού Android.</translation>
-<translation id="3277252321222022663">Να επιτρέπεται στους ιστοτόπους η πρόσβαση στους αισθητήρες (συνιστάται)</translation>
-<translation id="3282568296779691940">Σύνδεση στο Chrome</translation>
-<translation id="3288003805934695103">Επαναλάβετε τη φόρτωση της σελίδας</translation>
-<translation id="32895400574683172">Οι ειδοποιήσεις επιτρέπονται</translation>
-<translation id="3295530008794733555">Ταχύτερη περιήγηση. Χρήση λιγότερων δεδομένων.</translation>
-<translation id="3295602654194328831">Απόκρυψη πληροφοριών</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Συνέχεια για λήψη του περιεχομένου;</translation>
-<translation id="3306398118552023113">Αυτή η εφαρμογή εκτελείται στο Chrome</translation>
-<translation id="3315103659806849044">Αυτήν τη στιγμή, προσαρμόζετε τις ρυθμίσεις του Συγχρονισμού και των Υπηρεσιών Google. Για να ολοκληρώσετε την ενεργοποίηση του συγχρονισμού, πατήστε το κουμπί Επιβεβαίωσης κοντά στην κορυφή της οθόνης. Πλοήγηση προς τα επάνω</translation>
-<translation id="3328801116991980348">Πληροφορίες ιστοτόπου</translation>
-<translation id="3333961966071413176">Όλες οι επαφές</translation>
-<translation id="3334729583274622784">Θέλετε να αλλάξετε την επέκταση αρχείου;</translation>
-<translation id="3341058695485821946">Δείτε πόσα δεδομένα έχετε εξοικονομήσει</translation>
-<translation id="3350687908700087792">Κλείσιμο όλων των καρτελών ανώνυμης περιήγησης</translation>
-<translation id="3353615205017136254">Σελίδα Lite που παρέχεται από την Google. Πατήστε το κουμπί "φόρτωση αρχικής" για φόρτωση της αρχικής σελίδας.</translation>
-<translation id="3367813778245106622">Συνδεθείτε ξανά για να ξεκινήσετε τον συγχρονισμό</translation>
-<translation id="3374023511497244703">Οι σελιδοδείκτες, το ιστορικό, οι κωδικοί πρόσβασης και άλλα δεδομένα Chrome δεν θα συγχρονίζονται πλέον με τον Λογαριασμό σας Google</translation>
-<translation id="3384347053049321195">Κοινοποίηση εικόνας</translation>
-<translation id="3386292677130313581">Να γίνεται ερώτηση προτού επιτραπεί η κοινοποίηση της τοποθεσίας σας σε ιστότοπους (συνιστάται)</translation>
-<translation id="3387650086002190359">Η λήψη του αρχείου <ph name="FILE_NAME" /> απέτυχε λόγω σφαλμάτων του συστήματος αρχείων.</translation>
-<translation id="3389286852084373014">Το κείμενο είναι υπερβολικά μεγάλο</translation>
-<translation id="3398320232533725830">Άνοιγμα του διαχειριστή σελιδοδεικτών</translation>
-<translation id="3414952576877147120">Μέγεθος:</translation>
-<translation id="3443221991560634068">Επαναφόρτωση της τρέχουσας σελίδας</translation>
-<translation id="3445014427084483498">Μόλις τώρα</translation>
-<translation id="3478363558367712427">Μπορείτε να επιλέξετε τη μηχανή αναζήτησής σας</translation>
+<translation id="6910211073230771657">Διαγράφηκε</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, το κατάλαβα</translation>
+<translation id="7658239707568436148">Ακύρωση</translation>
 <translation id="3479552764303398839">Όχι τώρα</translation>
-<translation id="3492207499832628349">Νέα καρτέλα ανωνυμ. περιήγ.</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Μάθετε περισσότερα<ph name="END_LINK" /> σχετικά με το προτεινόμενο περιεχόμενο</translation>
-<translation id="3513704683820682405">Επαυξημένη πραγματικότητα</translation>
-<translation id="3518985090088779359">Αποδοχή και συνέχεια</translation>
-<translation id="3522247891732774234">Διατίθεται μια ενημέρωση. Περισσότερες επιλογές</translation>
-<translation id="3524138585025253783">Διεπαφή χρήση προγραμματιστή</translation>
-<translation id="3527085408025491307">Φάκελος</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB διαθέσιμα</translation>
-<translation id="3549657413697417275">Αναζήτηση στο ιστορικό σας</translation>
-<translation id="3557336313807607643">Προσθήκη στις επαφές</translation>
-<translation id="3566923219790363270">Το Chrome εξακολουθεί να προετοιμάζεται για VR. Επανεκκίνηση Chrome αργότερα.</translation>
-<translation id="3568688522516854065">Για να εμφανίζονται οι καρτέλες σας από τις άλλες συσκευές σας, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="3587482841069643663">Όλες</translation>
-<translation id="358794129225322306">Να επιτρέπεται σε έναν ιστότοπο να κατεβάζει αυτόματα πολλά αρχεία.</translation>
-<translation id="3590487821116122040">Αποθηκευτικός χώρος ιστοτόπων που το Chrome θεωρεί ότι δεν είναι σημαντικός (π.χ. ιστότοποι χωρίς αποθηκευμένες ρυθμίσεις ή που δεν επισκέπτεστε συχνά)</translation>
-<translation id="3599863153486145794">Διαγράφει το ιστορικό από όλες τις συνδεδεμένες συσκευές. Ο Λογαριασμός σας Google ενδέχεται να διαθέτει άλλες μορφές ιστορικού περιήγησης στη διεύθυνση <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Σίγαση ιστοτόπων που αναπαράγουν ήχο</translation>
-<translation id="3616113530831147358">Ήχος</translation>
-<translation id="3631987586758005671">Κοινοποίηση σε <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Αποκάλυψη κωδικού πρόσβασης</translation>
-<translation id="363596933471559332">Αυτόματη σύνδεση σε ιστότοπους με χρήση αποθηκευμένων διαπιστευτηρίων. Όταν η λειτουργία είναι απενεργοποιημένη, θα σας ζητείται επαλήθευση κάθε φορά πριν από τη σύνδεση σε έναν ιστότοπο.</translation>
-<translation id="3658159451045945436">Η επαναφορά διαγράφει το ιστορικό των αποθηκευμένων δεδομένων, συμπεριλαμβανομένης της λίστας ιστοτόπων που έχετε επισκεφτεί.</translation>
-<translation id="3692944402865947621">Η λήψη του αρχείου <ph name="FILE_NAME" /> απέτυχε επειδή δεν είναι προσβάσιμη η τοποθεσία αποθήκευσης.</translation>
-<translation id="3714981814255182093">Άνοιγμα της γραμμής εύρεσης</translation>
-<translation id="3716182511346448902">Αυτή η σελίδα χρησιμοποιεί πάρα πολλή μνήμη. Για αυτόν τον λόγο, το Chrome την έθεσε σε παύση.</translation>
-<translation id="3730075448226062617">Για να επιτρέψετε στο Chrome να αποκτήσει πρόσβαση στο μικρόφωνό σας, ενεργοποιήστε επίσης το μικρόφωνο στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Ο σελιδοδείκτης προστέθηκε στο <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Συγχρονισμός παρασκηνίου</translation>
-<translation id="3771001275138982843">Δεν ήταν δυνατή η λήψη της ενημέρωσης</translation>
-<translation id="3771033907050503522">Καρτ.αν.περιήγ.</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Ενεργοποιήστε το Bluetooth<ph name="END_LINK" />, για να επιτρέψετε τη σύζευξη</translation>
-<translation id="3775705724665058594">Αποστολή στις συσκευές σας</translation>
-<translation id="3778956594442850293">Προστέθηκε στην αρχική οθόνη</translation>
-<translation id="3789841737615482174">Εγκατάσταση</translation>
-<translation id="3810838688059735925">Βίντεο</translation>
-<translation id="3810973564298564668">Διαχείριση</translation>
-<translation id="381841723434055211">Αριθμοί τηλεφώνου</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> λήψεις διαγράφηκαν</translation>
-<translation id="3822502789641063741">Διαγ.αποθ.χώρου ιστότ.;</translation>
-<translation id="385051799172605136">Πίσω</translation>
-<translation id="3859306556332390985">Αναζήτηση προς τα εμπρός</translation>
-<translation id="3894427358181296146">Προσθήκη φακέλου…</translation>
-<translation id="3895926599014793903">Αναγκαστική ενεργοποίηση εστίασης</translation>
-<translation id="3912508018559818924">Εύρεση των καλύτερων στον ιστό…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Συνδυασμός των δεδομένων μου</translation>
-<translation id="393697183122708255">Δεν έχει ενεργοποιηθεί φωνητ. αναζήτηση</translation>
-<translation id="395206256282351086">Η δυνατότητα "Προτάσεις αναζήτησης και ιστοτόπων" απενεργοποιήθηκε</translation>
-<translation id="3955193568934677022">Να επιτρέπεται στους ιστοτόπους να αναπαράγουν προστατευμένο περιεχόμενο (συνιστάται)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Το Chrome θα φορτώσει τη σελίδα σας όταν είναι έτοιμη}other{Το Chrome θα φορτώσει τις σελίδες σας όταν είναι έτοιμες}}</translation>
-<translation id="3963007978381181125">Η κρυπτογράφηση με φράση πρόσβασης δεν περιλαμβάνει τρόπους πληρωμής και διευθύνσεις από το Google Pay. Μόνο κάποιος που γνωρίζει τη φράση πρόσβασής σας μπορεί να διαβάσει τα κρυπτογραφημένα δεδομένα σας. Η φράση πρόσβασης δεν αποστέλλεται στην Google ούτε αποθηκεύεται από αυτήν. Εάν ξεχάσετε τη φράση πρόσβασής σας ή θέλετε να αλλάξετε αυτήν τη ρύθμιση, θα πρέπει να επαναφέρετε τον συγχρονισμό. <ph name="BEGIN_LINK" />Μάθετε περισσότερα<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Ολοκλήρωση λήψης</translation>
-<translation id="397583555483684758">Ο συγχρονισμός σταμάτησε να λειτουργεί</translation>
-<translation id="3976396876660209797">Κατάργηση και εκ νέου δημιουργία αυτής της συντόμευσης</translation>
-<translation id="3985215325736559418">Θέλετε να κατεβάσετε ξανά το αρχείο <ph name="FILE_NAME" />;</translation>
-<translation id="3987993985790029246">Αντ. συνδ.</translation>
-<translation id="3988213473815854515">Η τοποθεσία επιτρέπεται</translation>
-<translation id="3988466920954086464">Προβολή αποτελεσμάτων αναζήτησης Instant σε αυτό το πλαίσιο</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Ασήμαντος αποθηκευτικός χώρος</translation>
-<translation id="4000212216660919741">Η αρχική σελίδα είναι εκτός σύνδεσης</translation>
+<translation id="5317780077021120954">Αποθήκευση</translation>
+<translation id="4570913071927164677">Λεπτομέρειες</translation>
+<translation id="8730621377337864115">Ολοκληρώθηκε</translation>
+<translation id="8261506727792406068">Διαγραφή</translation>
+<translation id="1181037720776840403">Κατάργηση</translation>
+<translation id="5939518447894949180">Επαναφορά</translation>
 <translation id="4002066346123236978">Τίτλος</translation>
-<translation id="4008040567710660924">Επιτρέπει τα cookie για έναν συγκεκριμένο ιστότοπο.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ω.}other{# ω.}}</translation>
-<translation id="4046123991198612571">Επόμενο κομμάτι</translation>
-<translation id="4048707525896921369">Ενημερωθείτε σχετικά με τα θέματα των ιστοτόπων, χωρίς να αποχωρήσετε από τη σελίδα. Η λειτουργία "Πατήστε για αναζήτηση" στέλνει μια λέξη και τα συμφραζόμενά της στην Αναζήτηση Google και εμφανίζει ορισμούς, εικόνες, αποτελέσματα αναζήτησης και άλλες λεπτομέρειες.
+<translation id="5916664084637901428">Ενεργό</translation>
+<translation id="5860033963881614850">Απενεργοποιημένη</translation>
+<translation id="6165508094623778733">Μάθετε περισσότερα</translation>
+<translation id="6042308850641462728">Περισσότερα</translation>
+<translation id="6040143037577758943">Κλείσιμο</translation>
+<translation id="780301667611848630">Όχι, ευχαριστώ</translation>
+<translation id="1201402288615127009">Επόμενο</translation>
+<translation id="2359808026110333948">Συνέχεια</translation>
+<translation id="2653659639078652383">Υποβολή</translation>
+<translation id="2079545284768500474">Αναίρεση</translation>
+<translation id="7649070708921625228">Βοήθεια</translation>
+<translation id="2148716181193084225">Σήμερα</translation>
+<translation id="7781829728241885113">Χθες</translation>
+<translation id="6945221475159498467">Επιλογή</translation>
+<translation id="7791543448312431591">Προσθήκη</translation>
+<translation id="6527303717912515753">Κοινοποίηση</translation>
+<translation id="1383876407941801731">Αναζήτηση</translation>
+<translation id="3115898365077584848">Πληροφορίες εκπομπής</translation>
+<translation id="3295602654194328831">Απόκρυψη πληροφοριών</translation>
+<translation id="3987993985790029246">Αντ. συνδ.</translation>
+<translation id="2704606927547763573">Αντιγράφ.</translation>
+<translation id="8725066075913043281">Προσπαθήστε ξανά</translation>
+<translation id="385051799172605136">Πίσω</translation>
+<translation id="8131740175452115882">Επιβεβαίωση</translation>
+<translation id="5300589172476337783">Εμφάνιση</translation>
+<translation id="1124772482545689468">Χρήστης</translation>
+<translation id="8609465669617005112">Μετακίνηση προς τα επάνω</translation>
+<translation id="6746124502594467657">Μετακίνηση προς τα κάτω</translation>
+<translation id="8249310407154411074">Μετακίνηση επάνω</translation>
+<translation id="8428213095426709021">Ρυθμίσεις</translation>
+<translation id="2498359688066513246">Βοήθεια και σχόλια</translation>
+<translation id="8378714024927312812">Διαχειριζόμενο από τον οργανισμό σας</translation>
+<translation id="9019902583201351841">Διαχειρίζεται από τους γονείς σου</translation>
+<translation id="4645575059429386691">Διαχειρίζεται από τους γονείς σου</translation>
+<translation id="4883854917563148705">Δεν είναι δυνατή η επαναφορά των υπό διαχείριση ρυθμίσεων</translation>
+<translation id="4307992518367153382">Βασικά στοιχεία</translation>
+<translation id="1974060860693918893">Σύνθετες</translation>
+<translation id="1146678959555564648">Εισαγωγή VR</translation>
+<translation id="987264212798334818">Γενικά</translation>
+<translation id="4275663329226226506">Μέσα</translation>
+<translation id="4759238208242260848">Λήψεις</translation>
+<translation id="218608176142494674">Κοινοποίηση</translation>
+<translation id="8004582292198964060">Πρόγραμμα περιήγησης</translation>
+<translation id="1105960400813249514">Λήψη οθόνης</translation>
+<translation id="4875775213178255010">Προτάσεις περιεχομένου</translation>
+<translation id="2021896219286479412">Στοιχ. ελέγ. σε πλήρη οθόνη</translation>
+<translation id="4587589328781138893">Ιστότοποι</translation>
+<translation id="4943703118917034429">Εικονική πραγματικότητα</translation>
+<translation id="1928696683969751773">Ενημερώσεις</translation>
+<translation id="6064125863973209585">Ολοκληρωμένες λήψεις</translation>
+<translation id="5342314432463739672">Αιτήματα για άδειες</translation>
+<translation id="629730747756840877">Λογαριασμός</translation>
+<translation id="82609232232243542">Σύνδεση στο Brave</translation>
+<translation id="7956662517480676674">Συγχρονισμός και υπηρ. Brave Software</translation>
+<translation id="5294439808117722387">Αυτήν τη στιγμή, προσαρμόζετε τις ρυθμίσεις του Συγχρονισμού και των Υπηρεσιών Brave Software. Για να ολοκληρώσετε την ενεργοποίηση του συγχρονισμού, πατήστε το κουμπί Επιβεβαίωσης κοντά στην κορυφή της οθόνης. Πλοήγηση προς τα επάνω</translation>
+<translation id="2096012225669085171">Συγχρονισμός και εξατομίκευση σε όλες τις συσκευές</translation>
+<translation id="1692118695553449118">Ο συγχρονισμός είναι ενεργοποιημένος</translation>
+<translation id="5514904542973294328">Απενεργοποιήθηκε από τον διαχειριστή αυτής της συσκευής</translation>
+<translation id="6447211988989208781">Στοιχεία ελέγχου δραστηριότητας Brave Software</translation>
+<translation id="4882831918239250449">Ελέγξτε τον τρόπο με τον οποίο το ιστορικό περιήγησής σας χρησιμοποιείται για την εξατομίκευση της Αναζήτησης, των διαφημίσεων και άλλων στοιχείων</translation>
+<translation id="7431991332293347422">Ελέγξτε τον τρόπο με τον οποίο χρησιμοποιείται το ιστορικό περιήγησής σας για την εξατομίκευση της Αναζήτησης και άλλων λειτουργιών</translation>
+<translation id="6303969859164067831">Αποσύνδεση και απενεργοποίηση συγχρονισμού</translation>
+<translation id="1125261911132334651">Διαχείριση Λογαριασμού Brave Software</translation>
+<translation id="6406506848690869874">Συγχρονισμός</translation>
+<translation id="714362445477979774">Συγχρονισμός των δεδομένων του Brave</translation>
+<translation id="4314815835985389558">Διαχείριση συγχρονισμού</translation>
+<translation id="5428209950370661546">Άλλες υπηρεσίες Brave Software</translation>
+<translation id="7704317875155739195">Αυτόματη συμπλήρωση αναζητήσεων και URL</translation>
+<translation id="2000419248597011803">Στέλνει ορισμένα cookie και αναζητήσεις από τη γραμμή διευθύνσεων και το πλαίσιο αναζήτησης στην προεπιλεγμένη μηχανή αναζήτησης</translation>
+<translation id="7981313251711023384">Προφόρτωση ιστοσελίδων για ταχύτερη περιήγηση και αναζήτηση</translation>
+<translation id="1821253160463689938">Χρησιμοποιεί cookie για την απομνημόνευση των προτιμήσεών σας, ακόμα κι αν δεν επισκέπτεστε αυτές τις σελίδες</translation>
+<translation id="6697492270171225480">Εμφάνιση προτάσεων για παρόμοιες σελίδες όταν δεν είναι δυνατή η εύρεση μιας σελίδας</translation>
+<translation id="8109318360573330108">Αποστέλλει στην Brave Software το URL μιας σελίδας στην οποία προσπαθείτε να μεταβείτε</translation>
+<translation id="8438566539970814960">Βελτιώστε τις αναζητήσεις και την περιήγηση</translation>
+<translation id="284843628681142937">Αποστέλλει στην Brave Software URL των σελίδων που επισκέπτεστε</translation>
+<translation id="7222718784508482526">Για περισσότερες ρυθμίσεις που σχετίζονται με το απόρρητο, την ασφάλεια και τη συλλογή δεδομένων, ανατρέξτε στην ενότητα <ph name="BEGIN_LINK"/>Συγχρονισμός και υπηρεσίες Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Συμβάλλετε στη βελτίωση των λειτουργιών και της απόδοσης του Brave</translation>
+<translation id="9063160602596686558">Αποστέλλει αυτόματα στατιστικά στοιχεία χρήσης και αναφορές σφαλμάτων στην Brave Software</translation>
+<translation id="4824958205181053313">Ακύρωση συγχρονισμού;</translation>
+<translation id="3058498974290601450">Μπορείτε να ενεργοποιήσετε τον συγχρονισμό ανά πάσα στιγμή στις ρυθμίσεις</translation>
+<translation id="3143515551205905069">Ακύρωση συγχρονισμού</translation>
+<translation id="1506061864768559482">Μηχανή αναζήτησης</translation>
+<translation id="55737423895878184">Η Τοποθεσία και οι ειδοποιήσεις επιτρέπονται</translation>
+<translation id="3988213473815854515">Η τοποθεσία επιτρέπεται</translation>
+<translation id="32895400574683172">Οι ειδοποιήσεις επιτρέπονται</translation>
+<translation id="9040142327097499898">Οι ειδοποιήσεις επιτρέπονται. Η Τοποθεσία είναι απενεργοποιημένη σε αυτήν τη συσκευή.</translation>
+<translation id="305593374596241526">Η Τοποθεσία είναι απενεργοποιημένη. Ενεργοποιήστε την στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Πραγματοποιήθηκε επίσκεψη πρόσφατα</translation>
+<translation id="6433501201775827830">Επιλέξτε τη μηχανή αναζήτησής σας</translation>
+<translation id="7177466738963138057">Μπορείτε να αλλάξετε αργότερα αυτήν την επιλογή στην περιοχή "Ρυθμίσεις"</translation>
+<translation id="3478363558367712427">Μπορείτε να επιλέξετε τη μηχανή αναζήτησής σας</translation>
+<translation id="4910889077668685004">Εφαρμογές πληρωμών</translation>
+<translation id="5152843274749979095">Δεν έχουν εγκατασταθεί υποστηριζόμενες εφαρμογές</translation>
+<translation id="8812260976093120287">Σε ορισμένους ιστοτόπους, μπορείτε να πληρώσετε χρησιμοποιώντας τις παραπάνω υποστηριζόμενες εφαρμογές πληρωμών στη συσκευή σας.</translation>
+<translation id="7764225426217299476">Προσθήκη διεύθυνσης</translation>
+<translation id="5595485650161345191">Επεξεργασία διεύθυνσης</translation>
+<translation id="5087580092889165836">Προσθήκη κάρτας</translation>
+<translation id="2154484045852737596">Επεξεργασία κάρτας</translation>
+<translation id="6140912465461743537">Χώρα/Περιοχή</translation>
+<translation id="5659593005791499971">Διεύθυνση ηλεκτρονικού ταχυδρομείου</translation>
+<translation id="4378154925671717803">Τηλέφωνο</translation>
+<translation id="4807098396393229769">Όνομα στην κάρτα</translation>
+<translation id="860043288473659153">Όνομα κατόχου κάρτας</translation>
+<translation id="2612676031748830579">Αριθμός κάρτας</translation>
+<translation id="869891660844655955">Ημερομηνία λήξης</translation>
+<translation id="2286841657746966508">Διεύθυνση τιμολόγησης</translation>
+<translation id="663059986967017181">Αντιγράφηκε στο Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ακόμη}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ακόμη}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ακόμη}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ακόμη}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ακόμη}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ακόμη}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ακόμη}other{<ph name="CONTACT_PREVIEW"/>\u2026 και <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ακόμη}}</translation>
+<translation id="7029809446516969842">Κωδ. πρόσβασης</translation>
+<translation id="1943432128510653496">Αποθήκευση κωδικών πρόσβασης</translation>
+<translation id="2100273922101894616">Αυτόματη σύνδεση</translation>
+<translation id="363596933471559332">Αυτόματη σύνδεση σε ιστότοπους με χρήση αποθηκευμένων διαπιστευτηρίων. Όταν η λειτουργία είναι απενεργοποιημένη, θα σας ζητείται επαλήθευση κάθε φορά πριν από τη σύνδεση σε έναν ιστότοπο.</translation>
+<translation id="6995899638241819463">Σας προειδοποιεί σε περίπτωση που οι κωδικοί πρόσβασής σας αποκαλυφθούν στο πλαίσιο μιας παραβίασης δεδομένων.</translation>
+<translation id="1534287762301776620">Αυτή η λειτουργία ενεργοποιείται όταν συνδέεστε στον Λογαριασμό σας Brave Software.</translation>
+<translation id="10614374240317010">Δεν έχει αποθηκευθεί ποτέ</translation>
+<translation id="3098842761938485917">Προβολή και διαχείριση αποθηκευμένων κωδικών πρόσβασης στον <ph name="BEGIN_LINK"/>Λογαριασμό σας Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Οι αποθηκευμένοι κωδικοί πρόσβασής σας θα εμφανιστούν εδώ.</translation>
+<translation id="8084114998886531721">Αποθηκευμένος κωδικός πρόσβασης</translation>
+<translation id="2870560284913253234">Ιστότοπος</translation>
+<translation id="8503813439785031346">Όνομα χρήστη</translation>
+<translation id="6657585470893396449">Κωδικός πρόσβασης</translation>
+<translation id="2154710561487035718">Αντιγραφή διεύθυνσης URL</translation>
+<translation id="1571304935088121812">Αντιγραφή ονόματος χρήστη</translation>
+<translation id="5005498671520578047">Αντιγραφή κωδικού πρόσβασης</translation>
+<translation id="3632295766818638029">Αποκάλυψη κωδικού πρόσβασης</translation>
+<translation id="1513858653616922153">Διαγραφή κωδικού πρόσβασης</translation>
+<translation id="543338862236136125">Επεξεργασία κωδικού πρόσβασης</translation>
+<translation id="4565377596337484307">Απόκρυψη κωδικού πρόσβασης</translation>
+<translation id="8523928698583292556">Διαγραφή αποθηκευμένου κωδικού πρόσβασης</translation>
+<translation id="2898264748040935573">Επεξεργασία αποθηκευμένου κωδικού πρόσβασης.</translation>
+<translation id="5433691172869980887">Το όνομα χρήστη αντιγράφηκε</translation>
+<translation id="5534640966246046842">Ο ιστότοπος αντιγράφηκε</translation>
+<translation id="2625189173221582860">Ο κωδικός πρόσβασης αντιγράφηκε</translation>
+<translation id="4550003330909367850">Για να δείτε ή να αντιγράψετε τον κωδικό πρόσβασης εδώ, ρυθμίστε το κλείδωμα οθόνης σε αυτήν τη συσκευή.</translation>
+<translation id="6154478581116148741">Ενεργοποιήστε το κλείδωμα οθόνης στις Ρυθμίσεις, για να εξαγάγετε τους κωδικούς πρόσβασής σας από αυτήν τη συσκευή</translation>
+<translation id="4842092870884894799">Εμφάνιση αναδυόμενου παραθύρου δημιουργίας κωδικού πρόσβασης</translation>
+<translation id="2259659629660284697">Εξαγωγή κωδικών πρόσβασης…</translation>
+<translation id="133012818630824069">Εξαγωγή κωδικών πρόσβασης που έχουν αποθηκευτεί στο Brave</translation>
+<translation id="6914783257214138813">Οι κωδικοί πρόσβασής σας θα είναι ορατοί σε οποιονδήποτε μπορεί να δει το αρχείο εξαγωγής.</translation>
+<translation id="2321086116217818302">Προετοιμασία κωδικών πρόσβασης…</translation>
+<translation id="8445448999790540984">Δεν είναι δυνατή η εξαγωγή κωδικών πρόσβασης</translation>
+<translation id="3066461326500799725">Μάθετε πώς να χρησιμοποιείτε το Brave Software Drive</translation>
+<translation id="729975465115245577">Η συσκευή σας δεν διαθέτει κάποια εφαρμογή για την αποθήκευση του αρχείου κωδικών πρόσβασης.</translation>
+<translation id="7682724950699840886">Δοκιμάστε τις παρακάτω συμβουλές: Βεβαιωθείτε ότι υπάρχει αρκετός χώρος στη συσκευή σας. Δοκιμάστε να επαναλάβετε την εξαγωγή.</translation>
+<translation id="1129510026454351943">Λεπτομέρειες: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Ξεκλειδώστε για αντιγραφή του κωδικού πρόσβασης</translation>
+<translation id="5515439363601853141">Ξεκλειδώστε για προβολή του κωδικού πρόσβασης</translation>
+<translation id="6221633008163990886">Ξεκλειδώστε για εξαγωγή των κωδικών πρόσβασής σας</translation>
+<translation id="230699814587342492">Κωδικοί πρόσβασης Brave</translation>
+<translation id="6075798973483050474">Επεξεργασία αρχικής σελίδας</translation>
+<translation id="854522910157234410">Άνοιγμα αυτής της σελίδας</translation>
+<translation id="2482878487686419369">Ειδοποιήσεις</translation>
+<translation id="6255999984061454636">Προτάσεις περιεχομένου</translation>
+<translation id="805047784848435650">Βάσει του ιστορικού περιήγησής σας</translation>
+<translation id="1041308826830691739">Από ιστοτόπους</translation>
+<translation id="395206256282351086">Η δυνατότητα "Προτάσεις αναζήτησης και ιστοτόπων" απενεργοποιήθηκε</translation>
+<translation id="257088987046510401">Θέματα</translation>
+<translation id="4650364565596261010">Προεπιλογή συστήματος</translation>
+<translation id="7588219262685291874">Ενεργοποιήστε το σκούρο θέμα όταν η λειτουργία εξοικονόμησης μπαταρίας της συσκευής σας είναι ενεργοποιημένη.</translation>
+<translation id="2760989362628427051">Να ενεργοποιείται το σκούρο θέμα όταν το σκούρο θέμα ή η Εξοικονόμηση μπαταρίας της συσκευής σας έχουν ενεργοποιηθεί.</translation>
+<translation id="6381421346744604172">Μείωση φωτισμού ιστοτόπων</translation>
+<translation id="5040262127954254034">Απόρρητο</translation>
+<translation id="4991384657077828949">Συμβάλετε στη βελτίωση της ασφάλειας του Brave</translation>
+<translation id="1943176487615318915">Για τον εντοπισμό επικίνδυνων εφαρμογών και ιστοτόπων, το Brave στέλνει URL ορισμένων ιστοτόπων που επισκέπτεστε, περιορισμένες πληροφορίες συστήματος και ένα μέρος του περιεχομένου σελίδας στο Brave Software</translation>
+<translation id="3181954750937456830">Ασφαλής περιήγηση (προστατεύει εσάς και τη συσκευή σας από επικίνδυνους ιστοτόπους)</translation>
+<translation id="7315322926489145388">Στέλνει URL από ορισμένες σελίδες που επισκέπτεστε στο Brave Software, όταν η ασφάλειά σας βρίσκεται σε κίνδυνο</translation>
+<translation id="2063713494490388661">Πατήστε για αναζήτηση</translation>
+<translation id="2369463299479365221">Ενημερωθείτε σχετικά με τα θέματα των ιστοτόπων, χωρίς να αποχωρήσετε από τη σελίδα. Η λειτουργία "Πατήστε για αναζήτηση" στέλνει μια λέξη και τα συμφραζόμενά της στην Αναζήτηση Brave Software και εμφανίζει ορισμούς, εικόνες, αποτελέσματα αναζήτησης και άλλες λεπτομέρειες.
 
 Για να τροποποιήσετε τον όρο αναζήτησης, πατήστε παρατεταμένα για να τον επιλέξετε. Για να κάνετε την αναζήτησή σας πιο συγκεκριμένη, σύρετε το παράθυρο εντελώς προς τα επάνω και πατήστε το πλαίσιο αναζήτησης.</translation>
-<translation id="4056223980640387499">Σέπια</translation>
-<translation id="4060598801229743805">Διαθέσιμες επιλογές κοντά στην κορυφή της οθόνης</translation>
-<translation id="4062305924942672200">Νομικές πληροφορίες</translation>
-<translation id="4084682180776658562">Σελιδοδείκτης</translation>
-<translation id="4084712963632273211">Από <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />παρέχεται από την Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Διαγραφή δεδομένων εφαρμογών;</translation>
-<translation id="4099578267706723511">Συμβάλετε στη βελτίωση του Chrome, στέλνοντας στην Google στατιστικά στοιχεία χρήσης και αναφορές σφαλμάτων.</translation>
-<translation id="410351446219883937">Αυτ. αναπαραγωγή</translation>
-<translation id="4116038641877404294">Κατεβάστε σελίδες για να τις χρησιμοποιήσετε εκτός σύνδεσης</translation>
-<translation id="4135200667068010335">Η λίστα συσκευών στις οποίες θα κοινοποιηθεί μια καρτέλα είναι κλειστή.</translation>
-<translation id="4149994727733219643">Απλοποιημένη προβολή για ιστοσελίδες</translation>
-<translation id="4165986682804962316">Ρυθμίσεις ιστότοπου</translation>
-<translation id="4169535189173047238">Να μην επιτρέπεται</translation>
-<translation id="4170011742729630528">Η υπηρεσία δεν είναι διαθέσιμη. Δοκιμάστε ξανά αργότερα.</translation>
-<translation id="4179980317383591987">Χρησιμοποιήθηκαν <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Γλώσσες</translation>
-<translation id="4183868528246477015">Αναζήτηση με Google Lens <ph name="BEGIN_NEW" />Νέο<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Άνοιγμα σε νέα καρτέλα</translation>
-<translation id="4198423547019359126">Δεν υπάρχουν διαθέσιμες τοποθεσίες λήψης</translation>
-<translation id="4209895695669353772">Για λήψη εξατομικευμένου περιεχομένου που προτείνεται από την Google, ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="4226663524361240545">Κατά τη λήψη ειδοποιήσεων ενδέχεται να δονείται η συσκευή</translation>
-<translation id="423219824432660969">Κρυπτογράφηση συγχρονισμένων δεδομένων με τον κωδικό πρόσβασης Google από τις <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Ανοίξτε τις ρυθμίσεις</translation>
-<translation id="4256782883801055595">Άδειες λογισμικού ανοικτού κώδικα</translation>
-<translation id="4259722352634471385">Αποκλείστηκε η μετάβαση στη διεύθυνση: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Αντιγρ. διεύθυνσης συνδέσμου</translation>
-<translation id="4275663329226226506">Μέσα</translation>
-<translation id="4278390842282768270">Επιτρέπεται</translation>
-<translation id="429312253194641664">Ένας ιστότοπος κάνει αναπαραγωγή μέσων</translation>
-<translation id="4298388696830689168">Συνδεδεμένοι ιστότοποι</translation>
-<translation id="4307992518367153382">Βασικά στοιχεία</translation>
-<translation id="4314815835985389558">Διαχείριση συγχρονισμού</translation>
-<translation id="4351244548802238354">Κλείσιμο παραθύρου διαλόγου</translation>
-<translation id="4378154925671717803">Τηλέφωνο</translation>
-<translation id="4384468725000734951">Χρήση του Sogou για αναζήτηση</translation>
-<translation id="4404568932422911380">Δεν υπάρχουν σελιδοδείκτες</translation>
-<translation id="4405224443901389797">Μετακίνηση σε…</translation>
-<translation id="4411535500181276704">Λειτουργία Lite</translation>
-<translation id="4415276339145661267">Διαχείριση Λογαριασμού Google</translation>
-<translation id="4432792777822557199">Από εδώ και στο εξής, οι σελίδες στα <ph name="SOURCE_LANGUAGE" /> θα μεταφράζονται στα <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Σελίδα Lite που παρέχεται από την Google</translation>
-<translation id="4434045419905280838">Αναδυόμενα παράθυρα και ανακατευθύνσεις</translation>
-<translation id="4440958355523780886">Η σελίδα Lite παρέχεται από την Google. Πατήστε για φόρτωση της αρχικής σελίδας.</translation>
-<translation id="4452411734226507615">Κλείσιμο καρτέλας <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Ο σελιδοδείκτης είναι στο "<ph name="FOLDER_NAME" />"</translation>
-<translation id="445467742685312942">Να επιτρέπεται στους ιστοτόπους η αναπαραγωγή προστατευμένου περιεχομένου</translation>
-<translation id="4468959413250150279">Σίγαση ήχου για συγκεκριμένο ιστότοπο.</translation>
-<translation id="4472118726404937099">Για συγχρονισμό και εξατομίκευση σε διάφορες συσκευές, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="447252321002412580">Συμβάλλετε στη βελτίωση των λειτουργιών και της απόδοσης του Chrome</translation>
-<translation id="4479647676395637221">Να γίνεται ερώτηση προτού επιτραπεί στους ιστότοπους να χρησιμοποιούν την κάμερά σας (συνιστάται)</translation>
-<translation id="4479972344484327217">Εγκατάσταση <ph name="MODULE" /> για το Chrome…</translation>
-<translation id="4487967297491345095">Όλα τα δεδομένα εφαρμογών του Chrome θα διαγραφούν οριστικά. Σε αυτά περιλαμβάνονται όλα τα αρχεία, οι ρυθμίσεις, οι λογαριασμοί, οι βάσεις δεδομένων, κ.λπ.</translation>
-<translation id="4493497663118223949">Η λειτουργία Lite είναι ενεργή</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Πριν από # ημέρα}other{Πριν από # ημέρες}}</translation>
-<translation id="451872707440238414">Αναζήτηση στους σελιδοδείκτες</translation>
-<translation id="4521489764227272523">Τα επιλεγμένα δεδομένα καταργήθηκαν από το Chrome και τις συγχρονισμένες συσκευές σας.
-
-Ο Λογαριασμός σας Google μπορεί να έχει άλλες μορφές ιστορικού περιήγησης, όπως αναζητήσεις και δραστηριότητα από άλλες υπηρεσίες της Google στη διεύθυνση <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Επιλογή φακέλου</translation>
-<translation id="4538018662093857852">Ενεργοποίηση λειτουργίας Lite</translation>
-<translation id="4550003330909367850">Για να δείτε ή να αντιγράψετε τον κωδικό πρόσβασης εδώ, ρυθμίστε το κλείδωμα οθόνης σε αυτήν τη συσκευή.</translation>
-<translation id="4558311620361989323">Συντομεύσεις ιστοσελίδας</translation>
-<translation id="4561979708150884304">Δεν υπάρχει σύνδεση</translation>
-<translation id="4565377596337484307">Απόκρυψη κωδικού πρόσβασης</translation>
-<translation id="4570913071927164677">Λεπτομέρειες</translation>
-<translation id="4572422548854449519">Συνδεθείτε στον διαχειριζόμενο λογαριασμό</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Πριν από # λεπτό}other{Πριν από # λεπτά}}</translation>
-<translation id="4587589328781138893">Ιστότοποι</translation>
-<translation id="4594952190837476234">Αυτή η σελίδα εκτός σύνδεσης δημιουργήθηκε στις <ph name="CREATION_TIME" /> και μπορεί να διαφέρει από την έκδοση στο διαδίκτυο.</translation>
-<translation id="4605958867780575332">Το στοιχείο καταργήθηκε <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Ανοίξτε <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Χρήση κωδικού πρόσβασης</translation>
-<translation id="4645575059429386691">Διαχειρίζεται από τους γονείς σου</translation>
-<translation id="4650364565596261010">Προεπιλογή συστήματος</translation>
-<translation id="4663756553811254707">Διαγράφηκαν <ph name="NUMBER_OF_BOOKMARKS" /> σελιδοδείκτες</translation>
-<translation id="4665282149850138822">Ο ιστότοπος <ph name="NAME" /> προστέθηκε στην αρχική οθόνη σας</translation>
-<translation id="4684427112815847243">Συγχρονισμός όλων</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ακόμη}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ακόμη}}</translation>
-<translation id="4696983787092045100">Αποστολή μηνύματος κειμένου στις συσκευές σας</translation>
-<translation id="4698034686595694889">Προβολή εκτός σύνδεσης στο <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Εικόνες και αρχεία στην κρυφή μνήμη</translation>
-<translation id="4714588616299687897">Εξοικονομήστε έως και 60% των δεδομένων σας</translation>
-<translation id="4719927025381752090">Πρόταση για μετάφραση</translation>
-<translation id="4720023427747327413">Άνοιγμα σε <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Συμβάλλετε στη βελτίωση του Chrome. <ph name="BEGIN_LINK" />Λάβετε μέρος στην έρευνα<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Ενημέρωση</translation>
-<translation id="4738836084190194332">Τελευταίος συγχρονισμός: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Άνοιγμα νέας καρτέλας</translation>
-<translation id="4751476147751820511">Αισθητήρες κίνησης ή φωτός</translation>
-<translation id="4759238208242260848">Λήψεις</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ολοκληρωμένη λήψη.}other{# ολοκληρωμένες λήψεις.}}</translation>
-<translation id="4797039098279997504">Αγγίξτε για να επιστρέψετε στη διεύθυνση <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Η κρυπτογράφηση φράσης πρόσβασης δεν περιλαμβάνει τρόπους πληρωμής και διευθύνσεις από το Google Pay.
-
-Για να αλλάξετε αυτήν τη ρύθμιση, <ph name="BEGIN_LINK" />επαναφέρετε τον συγχρονισμό<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Όνομα στην κάρτα</translation>
-<translation id="4824958205181053313">Ακύρωση συγχρονισμού;</translation>
-<translation id="4837753911714442426">Άνοιγμα επιλογών για την εκτύπωση της σελίδας</translation>
-<translation id="4842092870884894799">Εμφάνιση αναδυόμενου παραθύρου δημιουργίας κωδικού πρόσβασης</translation>
-<translation id="4860895144060829044">Κλήση</translation>
-<translation id="4866368707455379617">Δεν είναι δυνατή η εγκατάσταση του <ph name="MODULE" /> για το Chrome</translation>
-<translation id="4875775213178255010">Προτάσεις περιεχομένου</translation>
-<translation id="4878404682131129617">Η δημιουργία διοχέτευσης μέσω διακομιστή μεσολάβησης απέτυχε</translation>
-<translation id="4880127995492972015">Μετάφραση…</translation>
-<translation id="4881695831933465202">Άνοιγμα</translation>
-<translation id="488187801263602086">Μετονομασία αρχείου</translation>
-<translation id="4882831918239250449">Ελέγξτε τον τρόπο με τον οποίο το ιστορικό περιήγησής σας χρησιμοποιείται για την εξατομίκευση της Αναζήτησης, των διαφημίσεων και άλλων στοιχείων</translation>
-<translation id="4883854917563148705">Δεν είναι δυνατή η επαναφορά των υπό διαχείριση ρυθμίσεων</translation>
-<translation id="4885273946141277891">Μη υποστηριζόμενος αριθμός παρουσιών Chrome.</translation>
-<translation id="4910889077668685004">Εφαρμογές πληρωμών</translation>
-<translation id="4913161338056004800">Επαναφορά στατιστικών στοιχείων</translation>
-<translation id="4913169188695071480">Διακοπή ανανέωσης</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Λήψη βοήθειας<ph name="END_LINK" /> κατά τη σάρωση για συσκευές…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Σελίδα}other{# Σελίδες}}</translation>
-<translation id="4932247056774066048">Τα δεδομένα σας Chrome θα διαγραφούν από αυτήν τη συσκευή, λόγω της αποσύνδεσής σας από έναν λογαριασμό, η διαχείριση του οποίου γίνεται από τον τομέα <ph name="DOMAIN_NAME" />. Θα παραμείνει στον Λογαριασμό σας Google.</translation>
-<translation id="4943703118917034429">Εικονική πραγματικότητα</translation>
-<translation id="4943872375798546930">Δεν υπάρχουν αποτελέσματα</translation>
-<translation id="4958708863221495346">Η καρτέλα <ph name="URL_OF_THE_CURRENT_TAB" /> μοιράζεται την οθόνη σας.</translation>
-<translation id="4961107849584082341">Μεταφράστε αυτήν τη σελίδα σε οποιαδήποτε γλώσσα</translation>
-<translation id="4962975101802056554">Ανάκληση όλων των αδειών για τη συσκευή</translation>
-<translation id="4970824347203572753">Δεν είναι διαθέσιμο στην τοποθεσία σας</translation>
-<translation id="497421865427891073">Μετάβαση προς τα εμπρός</translation>
-<translation id="4988210275050210843">Λήψη αρχείου (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Σελίδες</translation>
-<translation id="4994033804516042629">Δεν βρέθηκαν επαφές</translation>
-<translation id="4996978546172906250">Μοιραστείτε μέσω</translation>
-<translation id="5004416275253351869">Στοιχεία ελέγχου δραστηριότητας Google</translation>
-<translation id="5005498671520578047">Αντιγραφή κωδικού πρόσβασης</translation>
-<translation id="5011311129201317034">Ο ιστότοπος <ph name="SITE" /> επιθυμεί σύνδεση</translation>
-<translation id="5013696553129441713">Δεν υπάρχουν νέες προτάσεις</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Ενώ βρίσκεστε σε λειτουργία VR, αυτός ο ιστότοπος ενδέχεται να είναι σε θέση να μάθει πληροφορίες σχετικά:
-  -  τα φυσικά χαρακτηριστικά σας, όπως το ύψος σας
-
-Βεβαιωθείτε ότι εμπιστεύεστε αυτόν τον ιστότοπο προτού ενεργοποιήσετε τη λειτουργία VR.</translation>
+<translation id="2930742481329940825">Η λειτουργία "Πατήστε για αναζήτηση" αποστέλλει την επιλεγμένη λέξη και την τρέχουσα σελίδα ως περιβάλλον στην Αναζήτηση Brave Software. Μπορείτε να την απενεργοποιήσετε στις <ph name="BEGIN_LINK"/>Ρυθμίσεις<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Επιτρέπεται</translation>
-<translation id="5040262127954254034">Απόρρητο</translation>
-<translation id="5048398596102334565">Να επιτρέπεται στους ιστοτόπους η πρόσβαση στους αισθητήρες κίνησης (συνιστάται)</translation>
-<translation id="5063480226653192405">Χρήση</translation>
-<translation id="5087580092889165836">Προσθήκη κάρτας</translation>
-<translation id="5100237604440890931">Συμπτυγμένη - Κάντε κλικ για ανάπτυξη</translation>
-<translation id="510275257476243843">Απομένει 1 ώρα</translation>
-<translation id="5123685120097942451">Καρτέλα ανώνυμης περιήγησης</translation>
-<translation id="5127805178023152808">Ο συγχρονισμός είναι απενεργοποιημένος</translation>
-<translation id="5129038482087801250">Εγκατάσταση εφαρμογής ιστού</translation>
-<translation id="5132942445612118989">Συγχρονίστε κωδικούς πρόσβασης, ιστορικό και πολλά άλλα σε όλες τις συσκευές</translation>
-<translation id="5139940364318403933">Μάθετε πώς να χρησιμοποιείτε το Google Drive</translation>
-<translation id="515227803646670480">Διαγραφή αποθηκευμένων δεδομένων</translation>
-<translation id="5152843274749979095">Δεν έχουν εγκατασταθεί υποστηριζόμενες εφαρμογές</translation>
-<translation id="5161254044473106830">Απαιτείται τίτλος</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 λήψη απέτυχε.}other{# λήψεις απέτυχαν.}}</translation>
-<translation id="5170568018924773124">Εμφάνιση στο φάκελο</translation>
-<translation id="5184329579814168207">Άνοιγμα στο Chrome</translation>
-<translation id="5193988420012215838">Αντιγράφηκε στο πρόχειρό σας</translation>
-<translation id="5197729504361054390">Οι επαφές που επιλέγετε θα κοινοποιηθούν στον ιστότοπο <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Προφίλ εργασίας</translation>
-<translation id="5210286577605176222">Μετάβαση στην προηγούμενη καρτέλα</translation>
-<translation id="5210365745912300556">Κλείσιμο καρτέλας</translation>
-<translation id="5224771365102442243">Με βίντεο</translation>
-<translation id="5230560987958996918">Ο ιστότοπος <ph name="SITE" /> θέλει να κάνει σάρωση για κοντινές συσκευές Bluetooth. Βρέθηκαν οι παρακάτω συσκευές:</translation>
-<translation id="5233638681132016545">Νέα καρτέλα</translation>
-<translation id="526421993248218238">Δεν είναι δυνατή η φόρτωση αυτής της σελίδας</translation>
-<translation id="5271967389191913893">Η συσκευή δεν μπορεί να ανοίξει το περιεχόμενο προς λήψη.</translation>
-<translation id="528192093759286357">Σύρετε από το επάνω τμήμα και αγγίξτε το κουμπί επιστροφής για έξοδο από την πλήρη οθόνη.</translation>
-<translation id="5292796745632149097">Αποστολή προς</translation>
-<translation id="5300589172476337783">Εμφάνιση</translation>
-<translation id="5301954838959518834">OK, το κατάλαβα</translation>
-<translation id="5304593522240415983">Αυτό το πεδίο δεν μπορεί να είναι κενό</translation>
-<translation id="5307446750509046227">Διαγ.αποθ.χώρου ιστότ.</translation>
-<translation id="5308380583665731573">Σύνδεση</translation>
-<translation id="5313967007315987356">Προσθήκη ιστότοπου</translation>
-<translation id="5317780077021120954">Αποθήκευση</translation>
-<translation id="5324858694974489420">Ρυθμίσεις γονικού ελέγχου</translation>
-<translation id="5327248766486351172">Όνομα</translation>
-<translation id="5335288049665977812">Να επιτρέπεται στους ιστότοπους να εκτελούν JavaScript (συνιστάται)</translation>
-<translation id="5342314432463739672">Αιτήματα για άδειες</translation>
-<translation id="5357811892247919462">Έγινε λήψη της καρτέλας</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> ανοιχτή καρτέλα, πατήστε για εναλλαγή καρτελών}other{<ph name="OPEN_TABS_MANY" /> ανοιχτές καρτέλες, πατήστε για εναλλαγή καρτελών}}</translation>
-<translation id="5391532827096253100">Η σύνδεσή σας σε αυτόν τον ιστότοπο δεν είναι ασφαλής. Πληροφορίες ιστοτόπου</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ακόμη)}other{(+ # ακόμη)}}</translation>
-<translation id="5400569084694353794">Χρησιμοποιώντας αυτήν την εφαρμογή, αποδέχεστε τους <ph name="BEGIN_LINK1" />Όρους Παροχής Υπηρεσιών<ph name="END_LINK1" /> και τη <ph name="BEGIN_LINK2" />Σημείωση Απορρήτου<ph name="END_LINK2" /> του Chrome.</translation>
-<translation id="5403592356182871684">Ονόματα</translation>
-<translation id="5403644198645076998">Να επιτρέπονται μόνο συγκεκριμένοι ιστότοποι</translation>
-<translation id="5414836363063783498">Γίνεται επαλήθευση…</translation>
-<translation id="5423934151118863508">Οι πιο δημοφιλείς σελίδες σας θα εμφανίζονται εδώ</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB διαθέσιμα</translation>
-<translation id="543338862236136125">Επεξεργασία κωδικού πρόσβασης</translation>
-<translation id="5433691172869980887">Το όνομα χρήστη αντιγράφηκε</translation>
-<translation id="543509235395288790">Λήψη <ph name="COUNT" /> αρχείων (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Μετάβαση στη γραμμή διευθύνσεων</translation>
-<translation id="5447201525962359567">Όλος ο αποθηκευτικός χώρος ιστοτόπων, συμπεριλαμβανομένων των cookie και άλλων τοπικά αποθηκευμένων δεδομένων</translation>
-<translation id="5447765697759493033">Αυτός ο ιστότοπος δεν θα μεταφραστεί</translation>
-<translation id="545042621069398927">Επιτάχυνση της λήψης σας.</translation>
-<translation id="5456381639095306749">Λήψη σελίδας</translation>
-<translation id="5475862044948910901">Έναρξη περιόδου λειτουργίας επαυξημένης πραγματικότητας;</translation>
-<translation id="548278423535722844">Άνοιγμα σε εφαρμογή χαρτών</translation>
-<translation id="5487521232677179737">Διαγραφή δεδομένων</translation>
-<translation id="5494752089476963479">Αποκλεισμός διαφημίσεων σε ιστοτόπους που εμφανίζουν παρεμβατικές ή παραπλανητικές διαφημίσεις</translation>
-<translation id="5500777121964041360">Μπορεί να μην είναι διαθέσιμο στην τοποθεσία σας</translation>
-<translation id="5512137114520586844">Αυτός ο λογαριασμός τελεί υπό τη διαχείριση του γονέα <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Απενεργοποιήθηκε από τον διαχειριστή αυτής της συσκευής</translation>
-<translation id="5515439363601853141">Ξεκλειδώστε για προβολή του κωδικού πρόσβασης</translation>
-<translation id="5516455585884385570">Άνοιγμα ρυθμίσεων ειδοποιήσεων</translation>
-<translation id="5517095782334947753">Έχετε σελιδοδείκτες, ιστορικό, κωδικούς πρόσβασης και άλλες ρυθμίσεις από τον λογαριασμό <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Η ανακατεύθυνση αποκλείστηκε.</translation>
-<translation id="5527082711130173040">Το Chrome χρειάζεται πρόσβαση στην τοποθεσία, προκειμένου να κάνει σάρωση για συσκευές. <ph name="BEGIN_LINK1" />Ενημέρωση δικαιωμάτων<ph name="END_LINK1" />. Η πρόσβαση τοποθεσίας είναι επίσης <ph name="BEGIN_LINK2" />απενεργοποιημένη για αυτήν τη συσκευή<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Να γίνεται ερώτηση προτού επιτραπεί σε ιστοτόπους η ανάγνωση κειμένου και εικόνων από το πρόχειρο (συνιστάται)</translation>
-<translation id="5530766185686772672">Κλείσιμο καρτ.ανών.περιήγ.</translation>
-<translation id="5534334044554683961">Ενώ βρίσκεστε σε λειτουργία VR, αυτός ο ιστότοπος ενδέχεται να είναι σε θέση να μάθει πληροφορίες σχετικά:
-  -   τα φυσικά χαρακτηριστικά σας, όπως το ύψος σας
-  -   τη διάταξη του δωματίου σας
-
-Βεβαιωθείτε ότι εμπιστεύεστε αυτόν τον ιστότοπο προτού ενεργοποιήσετε τη λειτουργία VR.</translation>
-<translation id="5534640966246046842">Ο ιστότοπος αντιγράφηκε</translation>
-<translation id="5556459405103347317">Επαναφόρτωση</translation>
-<translation id="5561549206367097665">Αναμονή για δίκτυο…</translation>
-<translation id="557283862590186398">Το Chrome χρειάζεται άδεια, για να αποκτήσει πρόσβαση στο μικρόφωνο για αυτόν τον ιστότοπο.</translation>
-<translation id="55737423895878184">Η Τοποθεσία και οι ειδοποιήσεις επιτρέπονται</translation>
-<translation id="5578795271662203820">Αναζήτηση <ph name="SEARCH_ENGINE" /> για την εικόνα</translation>
-<translation id="5581519193887989363">Μπορείτε πάντα να επιλέξετε τα στοιχεία που θέλετε να συγχρονίσετε στις <ph name="BEGIN_LINK1" />ρυθμίσεις<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Επεξεργασία διεύθυνσης</translation>
-<translation id="5596627076506792578">Περισσότερες επιλογές</translation>
-<translation id="5599455543593328020">Κατάσταση ανώνυμης περιήγησης</translation>
-<translation id="5620928963363755975">Βρείτε τα αρχεία και τις σελίδες σας στις Λήψις από το κουμπί Περισσότερες επιλογές</translation>
-<translation id="5626134646977739690">Όνομα:</translation>
-<translation id="5639724618331995626">Να επιτρέπονται όλοι οι ιστότοποι</translation>
-<translation id="5648166631817621825">Τελευταίες 7 ημέρες</translation>
-<translation id="5649053991847567735">Αυτόματες λήψεις</translation>
-<translation id="5655963694829536461">Αναζήτηση λήψεων</translation>
-<translation id="5659593005791499971">Διεύθυνση ηλεκτρονικού ταχυδρομείου</translation>
-<translation id="5665379678064389456">Δημιουργία συμβάντος στην εφαρμογή <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Παράκαμψη του αιτήματος ενός ιστότοπου για παρεμπόδιση εστίασης</translation>
-<translation id="5677928146339483299">Αποκλεισμένο</translation>
-<translation id="5684874026226664614">Ωχ. Δεν ήταν δυνατή η μετάφραση αυτής της σελίδας.</translation>
-<translation id="5686790454216892815">Το όνομα του αρχείου είναι πολύ μεγάλο</translation>
-<translation id="5689516760719285838">Τοποθεσία</translation>
-<translation id="569536719314091526">Μεταφράστε αυτήν τη σελίδα σε οποιαδήποτε γλώσσα από το κουμπί "Περισσότερες επιλογές"</translation>
-<translation id="572328651809341494">Πρόσφατες καρτέλες</translation>
-<translation id="5726692708398506830">Μεγέθυνση όλων των στοιχείων της σελίδας</translation>
-<translation id="5748802427693696783">Έγινε εναλλαγή σε τυπικές καρτέλες</translation>
-<translation id="5749068826913805084">Το Chrome χρειάζεται πρόσβαση στο χώρο αποθήκευσης για τη λήψη αρχείων.</translation>
-<translation id="5763382633136178763">Καρτέλες ανώνυμης περιήγησης</translation>
-<translation id="5763514718066511291">Πατήστε για αντιγραφή του URL για αυτήν την εφαρμογή</translation>
-<translation id="5765780083710877561">Περιγραφή:</translation>
-<translation id="5793665092639000975">Χρήση <ph name="SPACE_USED" /> από <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Η Google μπορεί να χρησιμοποιήσει το ιστορικό σας για την εξατομίκευση της Αναζήτησης, των διαφημίσεων και άλλων υπηρεσιών Google</translation>
-<translation id="5804241973901381774">Άδειες</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Πριν από # ώρα}other{Πριν από # ώρες}}</translation>
-<translation id="5810288467834065221">Πνευματικά δικαιώματα <ph name="YEAR" /> Google LLC. Με την επιφύλαξη παντός δικαιώματος.</translation>
-<translation id="5817918615728894473">Σύζευξη</translation>
-<translation id="583281660410589416">Άγνωστο</translation>
-<translation id="5833984609253377421">Κοινοποίηση συνδέσμου</translation>
-<translation id="5836192821815272682">Λήψη Ενημέρωσης Chrome…</translation>
-<translation id="5853623416121554550">σε παύση</translation>
-<translation id="5854790677617711513">Παλαιότερο από 30 ημέρες</translation>
-<translation id="5858741533101922242">Το Chrome δεν είναι δυνατό να ενεργοποιήσει τον προσαρμογέα Bluetooth</translation>
-<translation id="5860033963881614850">Απενεργοποιημένη</translation>
-<translation id="5862731021271217234">Για να εμφανίζονται οι καρτέλες σας από τις άλλες συσκευές σας, ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="5864174910718532887">Λεπτομέρειες: Ταξινομήθηκαν κατά όνομα ιστοτόπου</translation>
-<translation id="5864419784173784555">Αναμονή για άλλη λήψη…</translation>
-<translation id="5865733239029070421">Αποστέλλει αυτόματα στατιστικά στοιχεία χρήσης και αναφορές σφαλμάτων στην Google</translation>
-<translation id="5869522115854928033">Αποθηκευμένοι κωδικοί πρόσβασης</translation>
-<translation id="5902828464777634901">Όλα τα δεδομένα αποθήκευσης στον ιστοτόπων, όπως τα cookie, θα διαγραφούν</translation>
-<translation id="5916664084637901428">Ενεργό</translation>
-<translation id="5919204609460789179">Ενημερώστε το <ph name="PRODUCT_NAME" /> για να ξεκινήσει ο συγχρονισμός</translation>
-<translation id="5937580074298050696">Εξοικονομήθηκαν <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Επαναφορά</translation>
-<translation id="5942872142862698679">Χρήση του Google για αναζήτηση</translation>
-<translation id="5952764234151283551">Αποστέλλει στην Google το URL μιας σελίδας στην οποία προσπαθείτε να μεταβείτε</translation>
-<translation id="5956665950594638604">Άνοιγμα Κέντρου βοήθειας Chrome σε νέα καρτέλα</translation>
-<translation id="5958275228015807058">Βρείτε τα αρχεία και τις σελίδες σας στις Λήψεις</translation>
-<translation id="5962718611393537961">Πατήστε για σύμπτυξη</translation>
-<translation id="6000066717592683814">Διατήρηση του Google</translation>
-<translation id="6005538289190791541">Προτεινόμενος κωδικός πρόσβασης</translation>
-<translation id="6036057147555329831">Επιπλέον ICU</translation>
-<translation id="6039379616847168523">Μετάβαση στην επόμενη καρτέλα</translation>
-<translation id="6040143037577758943">Κλείσιμο</translation>
-<translation id="6042308850641462728">Περισσότερα</translation>
-<translation id="604996488070107836">Η λήψη του αρχείου <ph name="FILE_NAME" /> απέτυχε λόγω άγνωστου σφάλματος.</translation>
-<translation id="605721222689873409">ΕΕ</translation>
-<translation id="6064125863973209585">Ολοκληρωμένες λήψεις</translation>
-<translation id="6075798973483050474">Επεξεργασία αρχικής σελίδας</translation>
-<translation id="60923314841986378">Απομένουν <ph name="HOURS" /> ώρες</translation>
-<translation id="6108923351542677676">Ρύθμιση σε εξέλιξη…</translation>
-<translation id="6111020039983847643">δεδομένα που χρησιμοποιήθηκαν</translation>
-<translation id="6112702117600201073">Ανανέωση σελίδας</translation>
-<translation id="6127379762771434464">Το στοιχείο καταργήθηκε</translation>
-<translation id="6140912465461743537">Χώρα/Περιοχή</translation>
-<translation id="614940544461990577">Δοκιμάστε να κάνετε τα εξής:</translation>
-<translation id="6154478581116148741">Ενεργοποιήστε το κλείδωμα οθόνης στις Ρυθμίσεις, για να εξαγάγετε τους κωδικούς πρόσβασής σας από αυτήν τη συσκευή</translation>
-<translation id="6159335304067198720">Εξοικονόμηση δεδομένων κατά <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Μάθετε περισσότερα</translation>
-<translation id="6177111841848151710">Αποκλείστηκε για την τρέχουσα μηχανή αναζήτησης</translation>
-<translation id="6181444274883918285">Προσθήκη εξαίρεσης ιστότοπου</translation>
-<translation id="6192333916571137726">Αρχείο Λήψη</translation>
-<translation id="6192792657125177640">Εξαιρέσεις</translation>
-<translation id="6194112207524046168">Για να επιτρέψετε στο Chrome να αποκτήσει πρόσβαση στην κάμερά σας, ενεργοποιήστε επίσης την κάμερα στις <ph name="BEGIN_LINK" />Ρυθμίσεις Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Αποκλεισμός cookie τρίτων</translation>
-<translation id="6206551242102657620">Η σύνδεση είναι ασφαλής. Πληροφορίες ιστοτόπου</translation>
-<translation id="6210748933810148297">Δεν είστε ο χρήστης <ph name="EMAIL" />;</translation>
-<translation id="6221633008163990886">Ξεκλειδώστε για εξαγωγή των κωδικών πρόσβασής σας</translation>
+<translation id="1406000523432664303">"Να μην γίνεται εντοπισμός"</translation>
 <translation id="6232535412751077445">Η ενεργοποίηση της επιλογής "Να μην γίνεται εντοπισμός" σημαίνει ότι θα συμπεριληφθεί ένα αίτημα με την επισκεψιμότητα της περιήγησής σας. Τυχόν αποτελέσματα εξαρτώνται από το κατά πόσο ένας ιστότοπος ανταποκρίνεται στο αίτημα, καθώς και από τον τρόπο με τον οποίο ερμηνεύεται το αίτημα.
 
 Για παράδειγμα, ορισμένοι ιστότοποι ενδέχεται να ανταποκρίνονται σε αυτό το αίτημα εμφανίζοντας διαφημίσεις που δεν βασίζονται σε άλλους ιστότοπους που έχετε επισκεφτεί. Πολλοί ιστότοποι θα εξακολουθούν να συλλέγουν και να χρησιμοποιούν τα δεδομένα περιήγησής σας. Για παράδειγμα, για να βελτιώσουν την ασφάλεια, να παρέχουν περιεχόμενο, διαφημίσεις και προτάσεις, καθώς και για να δημιουργούν στατιστικά στοιχεία αναφοράς.</translation>
-<translation id="624789221780392884">Έτοιμη ενημέρωση</translation>
-<translation id="6255999984061454636">Προτάσεις περιεχομένου</translation>
-<translation id="6277522088822131679">Παρουσιάστηκε ένα πρόβλημα κατά την εκτύπωση της σελίδας. Δοκιμάστε ξανά.</translation>
-<translation id="6295158916970320988">Όλοι οι ιστότοποι</translation>
-<translation id="629730747756840877">Λογαριασμός</translation>
-<translation id="6303969859164067831">Αποσύνδεση και απενεργοποίηση συγχρονισμού</translation>
-<translation id="6316139424528454185">Μη υποστηρ. έκδοση Android</translation>
-<translation id="6320088164292336938">Δόνηση</translation>
-<translation id="6324034347079777476">Ο συγχρονισμός συστήματος Android απενεργοποιήθηκε</translation>
-<translation id="6333140779060797560">Μοιραστείτε μέσω <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Κρυπτογράφηση</translation>
-<translation id="6341580099087024258">Να γίνεται ερώτηση σχετικά με την τοποθεσία αποθήκευσης των αρχείων</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ακόμη}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ακόμη}}</translation>
-<translation id="6364438453358674297">Κατάργηση πρότασης από το ιστορικό;</translation>
-<translation id="6369229450655021117">Από εδώ, μπορείτε να αναζητήσετε στον ιστό, να μοιραστείτε με φίλους και να δείτε ανοικτές σελίδες</translation>
-<translation id="6378173571450987352">Λεπτομέρειες: Ταξινομήθηκαν βάσει του όγκου των δεδομένων που χρησιμοποιήθηκαν</translation>
-<translation id="6381421346744604172">Μείωση φωτισμού ιστοτόπων</translation>
-<translation id="6388207532828177975">Διαγραφή και επαναφορά</translation>
-<translation id="6393863479814692971">Το Chrome χρειάζεται άδεια, για να αποκτήσει πρόσβαση στην κάμερα και το μικρόφωνο για αυτόν τον ιστότοπο.</translation>
-<translation id="6395288395575013217">ΣΥΝΔΕΣΜΟΣ</translation>
-<translation id="6404511346730675251">Επεξεργασία σελιδοδείκτη</translation>
-<translation id="6406506848690869874">Συγχρονισμός</translation>
-<translation id="641643625718530986">Εκτύπωση…</translation>
-<translation id="6416782512398055893">Έγινε λήψη <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Μετάφραση ιστού</translation>
-<translation id="6433501201775827830">Επιλέξτε τη μηχανή αναζήτησής σας</translation>
-<translation id="6437478888915024427">Πληροφορίες σελίδας</translation>
-<translation id="6441734959916820584">Το όνομα είναι πολύ μεγάλο</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Εικόνα}other{# Εικόνες}}</translation>
-<translation id="6447842834002726250">Cookie</translation>
-<translation id="6461962085415701688">Δεν είναι δυνατό το άνοιγμα του αρχείου</translation>
-<translation id="6464977750820128603">Μπορείτε να δείτε και να ορίσετε χρονόμετρα για τους ιστοτόπους που επισκέπτεστε στο Chrome.\n\nΗ Google λαμβάνει πληροφορίες σχετικά με τους ιστοτόπους για τους οποίους ορίζετε χρονόμετρα και τη χρονική διάρκεια που τους χρησιμοποιείτε. Αυτές οι πληροφορίες χρησιμοποιούνται για τη βελτίωση του Digital Wellbeing.</translation>
-<translation id="6475951671322991020">Λήψη βίντεο</translation>
-<translation id="6482749332252372425">Η λήψη του αρχείου <ph name="FILE_NAME" /> απέτυχε λόγω έλλειψης αποθηκευτικού χώρου.</translation>
-<translation id="6496823230996795692">Για να χρησιμοποιήσετε την εφαρμογή <ph name="APP_NAME" /> για πρώτη φορά, συνδεθείτε στο διαδίκτυο.</translation>
-<translation id="6508722015517270189">Επανεκκινήστε το Chrome</translation>
-<translation id="6527303717912515753">Κοινοποίηση</translation>
-<translation id="6532866250404780454">Δεν θα εμφανίζονται οι ιστότοποι που επισκέπτεστε στο Chrome. Όλα τα χρονόμετρα ιστοτόπων θα διαγραφούν.</translation>
-<translation id="6534565668554028783">Η απάντηση από το Google καθυστέρησε υπερβολικά</translation>
-<translation id="6538442820324228105">Έγινε λήψη <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Παρουσιάστηκε κάποιο πρόβλημα. Δοκιμάστε ξανά αργότερα.</translation>
-<translation id="654446541061731451">Επιλέξτε μια καρτέλα για ζεύξη</translation>
-<translation id="6545017243486555795">Διαγραφή όλων των δεδομένων</translation>
-<translation id="6545864417968258051">Σάρωση Bluetooth</translation>
-<translation id="6560414384669816528">Αναζήτηση με το Sogou</translation>
-<translation id="6566259936974865419">Το Chrome έχει εξοικονομήσει <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Να επιτρέπονται πάντα</translation>
-<translation id="6573431926118603307">Οι καρτέλες που έχετε ανοίξει στο Chrome στις άλλες συσκευές σας θα εμφανίζονται εδώ.</translation>
-<translation id="6583199322650523874">Προσθήκη σελιδοδείκτη στην τρέχουσα σελίδα</translation>
-<translation id="6593061639179217415">Για υπολογιστή</translation>
-<translation id="6600954340915313787">Αντιγράφηκε στο Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Προστατ. περιεχ.</translation>
-<translation id="6627583120233659107">Επεξεργασία φακέλου</translation>
-<translation id="6643016212128521049">Διαγραφή</translation>
-<translation id="6643649862576733715">Ταξινόμηση κατά όγκο δεδομένων που εξοικονομήθηκαν</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ακόμη}other{<ph name="CONTACT_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ακόμη}}</translation>
-<translation id="6649642165559792194">Προεπισκόπηση εικόνας <ph name="BEGIN_NEW" />Νέο<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Το Chrome χρειάζεται πρόσβαση στην τοποθεσία, προκειμένου να κάνει σάρωση για συσκευές. <ph name="BEGIN_LINK" />Ενημέρωση δικαιωμάτων<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Κωδικός πρόσβασης</translation>
-<translation id="6659594942844771486">Καρτέλα</translation>
-<translation id="666731172850799929">Άνοιγμα σε <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Σημείωση Απορρήτου του Chrome</translation>
-<translation id="6676840375528380067">Να διαγραφούν τα δεδομένα Chrome από τη συσκευή;</translation>
-<translation id="6697492270171225480">Εμφάνιση προτάσεων για παρόμοιες σελίδες όταν δεν είναι δυνατή η εύρεση μιας σελίδας</translation>
-<translation id="6697947395630195233">Το Chrome χρειάζεται πρόσβαση στην τοποθεσία σας, για να την κοινοποιήσει σε αυτόν τον ιστότοπο.</translation>
-<translation id="6698801883190606802">Διαχείριση συγχρονισμένων δεδομένων</translation>
-<translation id="6699370405921460408">Οι διακομιστές της Google θα βελτιστοποιήσουν τις σελίδες που επισκέπτεστε.</translation>
-<translation id="6706288973712894588">Αυτήν τη στιγμή είστε εκτός σύνδεσης.\n<ph name="BEGIN_LINK" />Εξερευνήστε τη ροή σας εκτός σύνδεσης.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Ειδήσεις</translation>
-<translation id="6710213216561001401">Προηγούμενο</translation>
-<translation id="671481426037969117">Η αντίστροφη μέτρηση <ph name="FQDN" /> εξαντλήθηκε. Θα ξεκινήσει ξανά αύριο.</translation>
-<translation id="6738867403308150051">Λήψη…</translation>
-<translation id="6746124502594467657">Μετακίνηση προς τα κάτω</translation>
-<translation id="6766622839693428701">Σύρετε προς τα κάτω για κλείσιμο.</translation>
-<translation id="6766758767654711248">Πατήστε για μετάβαση στον ιστότοπο</translation>
-<translation id="6767294960381293877">Άνοιγμα σε μισό ύψος της λίστας συσκευών στις οποίες θα κοινοποιηθεί μια καρτέλα.</translation>
-<translation id="6782111308708962316">Αποτροπή αποθήκευσης και ανάγνωσης δεδομένων cookie από ιστότοπους τρίτων</translation>
-<translation id="6790428901817661496">Αναπαραγωγή</translation>
-<translation id="6811034713472274749">Σελίδα έτοιμη για προβολή</translation>
-<translation id="6818926723028410516">Επιλέξτε στοιχεία</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Μετάφραση</translation>
-<translation id="6845325883481699275">Συμβάλετε στη βελτίωση της ασφάλειας του Chrome</translation>
-<translation id="6846298663435243399">Φόρτωση…</translation>
-<translation id="6850409657436465440">Η λήψη σας βρίσκεται ακόμα σε εξέλιξη</translation>
-<translation id="6850830437481525139">Έκλεισαν <ph name="TAB_COUNT" /> καρτέλες</translation>
-<translation id="6864459304226931083">Λήψη εικόνας</translation>
-<translation id="6865313869410766144">Δεδομένα φόρμας αυτόματης συμπλήρωσης</translation>
-<translation id="688738109438487280">Προσθήκη υπαρχόντων δεδομένων στον λογαριασμό <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Ξεκλειδώστε για αντιγραφή του κωδικού πρόσβασης</translation>
-<translation id="6896758677409633944">Αντιγραφή</translation>
-<translation id="6910211073230771657">Διαγράφηκε</translation>
-<translation id="6912998170423641340">Αποκλεισμός ιστοτόπων από ανάγνωση κειμένου και εικόνων από το πρόχειρο</translation>
-<translation id="6914783257214138813">Οι κωδικοί πρόσβασής σας θα είναι ορατοί σε οποιονδήποτε μπορεί να δει το αρχείο εξαγωγής.</translation>
-<translation id="6942665639005891494">Αλλάξτε την προεπιλεγμένη τοποθεσία λήψης ανά πάσα στιγμή χρησιμοποιώντας την επιλογή μενού "Ρυθμίσεις"</translation>
-<translation id="6945221475159498467">Επιλογή</translation>
-<translation id="6963642900430330478">Αυτή η σελίδα είναι επικίνδυνη. Πληροφορίες ιστοτόπου</translation>
-<translation id="6963766334940102469">Διαγραφή σελιδοδεικτών</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Από την αρχή</translation>
-<translation id="6981982820502123353">Προσβασιμότητα</translation>
-<translation id="6989267951144302301">Δεν ήταν δυνατή η λήψη</translation>
-<translation id="6990079615885386641">Λήψη της εφαρμογής από το Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Να γίνεται ερώτηση προτού επιτραπεί στους ιστότοπους να χρησιμοποιήσουν το μικρόφωνό σας (συνιστάται)</translation>
-<translation id="7015203776128479407">Η αρχική ρύθμιση του συγχρονισμού δεν τελείωσε. Ο συγχρονισμός είναι απενεργοποιημένος.</translation>
-<translation id="7016516562562142042">Επιτράπηκε για την τρέχουσα μηχανή αναζήτησης</translation>
-<translation id="7022756207310403729">Άνοιγμα σε πρόγρ. περιήγησης</translation>
-<translation id="702463548815491781">Συνιστάται όταν έχει ενεργοποιηθεί το TalkBack ή η πρόσβαση με διακόπτη</translation>
-<translation id="7029809446516969842">Κωδ. πρόσβασης</translation>
-<translation id="7053983685419859001">Αποκλεισμός</translation>
-<translation id="7055152154916055070">Αποκλεισμένη ανακατεύθυνση:</translation>
-<translation id="7063006564040364415">Δεν ήταν δυνατή η σύνδεση στον διακομιστή συγχρονισμού.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 επιλεγμένο}other{# επιλεγμένα}}</translation>
-<translation id="7071521146534760487">Διαχείριση λογαριασμού</translation>
-<translation id="7077143737582773186">Secure Digital</translation>
-<translation id="7087918508125750058">Επιλέχθηκαν <ph name="ITEM_COUNT" />. Οι επιλογές είναι διαθέσιμες κοντά στο επάνω μέρος της οθόνης</translation>
-<translation id="7121362699166175603">Διαγράφει το ιστορικό και τα στοιχεία αυτόματης συμπλήρωσης στη γραμμή διευθύνσεων. Ο Λογαριασμός σας Google ενδέχεται να διαθέτει άλλες μορφές ιστορικού περιήγησης στη διεύθυνση <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Να επιτρέπεται για την τρέχουσα μηχανή αναζήτησης</translation>
-<translation id="7138678301420049075">Άλλο</translation>
-<translation id="7141896414559753902">Αποκλεισμός εμφάνισης αναδυόμενων παραθύρων και ανακατευθύνσεων σε ιστοτόπους (συνιστάται)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Φόρτωση αρχικής σελίδας<ph name="END_LINK" /> από <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Τελευταίες 24 ώρες</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Μπορείτε να αλλάξετε αργότερα αυτήν την επιλογή στην περιοχή "Ρυθμίσεις"</translation>
-<translation id="7180611975245234373">Ανανέωση</translation>
-<translation id="7189372733857464326">Αναμονή για ολοκλήρωση της ενημέρωσης των Υπηρεσιών Google Play</translation>
-<translation id="7191430249889272776">Η καρτέλα άνοιξε στο παρασκήνιο.</translation>
-<translation id="723171743924126238">Επιλέξτε εικόνες</translation>
-<translation id="7233236755231902816">Για να δείτε τον ιστό στη γλώσσα σας, κατεβάστε την πιο πρόσφατη έκδοση του Chrome</translation>
-<translation id="7243308994586599757">Διαθέσιμες επιλογές κοντά κάτω μέρος της οθόνης</translation>
-<translation id="7248069434667874558">Βεβαιωθείτε ότι ο συγχρονισμός στο Chrome έχει ενεργοποιηθεί για τη συσκευή <ph name="TARGET_DEVICE_NAME" />.</translation>
-<translation id="7250468141469952378">Επιλέχθηκαν <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Αποκλεισμένος ιστότοπος</translation>
-<translation id="7290209999329137901">Η μετονομασία δεν είναι διαθέσιμη</translation>
-<translation id="7291387454912369099">Ολοκλήρωση αγοράς από τον Βοηθό</translation>
-<translation id="7293171162284876153">Για να ξεκινήσετε τον συγχρονισμό, ενεργοποιήστε την επιλογή "Συγχρονισμός των δεδομένων του Chrome".</translation>
-<translation id="729975465115245577">Η συσκευή σας δεν διαθέτει κάποια εφαρμογή για την αποθήκευση του αρχείου κωδικών πρόσβασης.</translation>
-<translation id="7302081693174882195">Λεπτομέρειες: Ταξινομήθηκαν βάσει του όγκου των δεδομένων που αποθηκεύτηκαν</translation>
-<translation id="7328017930301109123">Στη λειτουργία Lite, το Chrome φορτώνει σελίδες πιο γρήγορα και χρησιμοποιεί έως και 60 τοις εκατό λιγότερα δεδομένα.</translation>
-<translation id="7333031090786104871">Η προσθήκη του προηγούμενου ιστοτόπου δεν έχει ολοκληρωθεί</translation>
-<translation id="7352939065658542140">ΒΙΝΤΕΟ</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Κοινοποίηση 1 επιλεγμένου στοιχείου}other{Κοινοποίηση # επιλεγμένων στοιχείων}}</translation>
 <translation id="7359002509206457351">Πρόσβαση σε τρόπους πληρωμής</translation>
+<translation id="8026334261755873520">Διαγραφή δεδομένων περιήγησης</translation>
+<translation id="1291207594882862231">Διαγραφή ιστορικού, cookie, δεδομένων ιστότοπου, κρυφής μνήμης…</translation>
+<translation id="7814200940910057384">Τα δεδομένα του Brave διαγράφηκαν</translation>
+<translation id="1664855196866195614">Τα επιλεγμένα δεδομένα καταργήθηκαν από το Brave και τις συγχρονισμένες συσκευές σας.
+
+Ο Λογαριασμός σας Brave Software μπορεί να έχει άλλες μορφές ιστορικού περιήγησης, όπως αναζητήσεις και δραστηριότητα από άλλες υπηρεσίες της Brave Software στη διεύθυνση <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Εικόνες και αρχεία στην κρυφή μνήμη</translation>
+<translation id="2496180316473517155">Ιστορικό περιήγησης</translation>
+<translation id="2546283357679194313">Cookie και δεδομένα ιστότοπου</translation>
+<translation id="8662811608048051533">Θα αποσυνδεθείτε από τους περισσότερους ιστοτόπους.</translation>
+<translation id="8218628800671693884">Θα αποσυνδεθείτε από τους περισσότερους ιστοτόπους. Δεν θα αποσυνδεθείτε από τον Λογαριασμό σας Brave Software.</translation>
+<translation id="2017836877785168846">Διαγράφει το ιστορικό και τις αυτόματες συμπληρώσεις στη γραμμή διευθύνσεων.</translation>
+<translation id="8096327394278038498">Διαγράφει το ιστορικό και τα στοιχεία αυτόματης συμπλήρωσης στη γραμμή διευθύνσεων. Ο Λογαριασμός σας Brave Software ενδέχεται να διαθέτει άλλες μορφές ιστορικού περιήγησης στη διεύθυνση <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Διαγράφει το ιστορικό από όλες τις συνδεδεμένες συσκευές. Ο Λογαριασμός σας Brave Software ενδέχεται να διαθέτει άλλες μορφές ιστορικού περιήγησης στη διεύθυνση <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Αποθηκευμένοι κωδικοί πρόσβασης</translation>
+<translation id="6865313869410766144">Δεδομένα φόρμας αυτόματης συμπλήρωσης</translation>
+<translation id="7562080006725997899">Διαγραφή δεδομένων περιήγησης</translation>
+<translation id="5487521232677179737">Διαγραφή δεδομένων</translation>
+<translation id="7498271377022651285">Περιμένετε…</translation>
+<translation id="784934925303690534">Χρονικό εύρος</translation>
+<translation id="1718835860248848330">Τελευταία ώρα</translation>
+<translation id="7149893636342594995">Τελευταίες 24 ώρες</translation>
+<translation id="5648166631817621825">Τελευταίες 7 ημέρες</translation>
+<translation id="8571213806525832805">Τελευταίες 4 εβδομάδες</translation>
+<translation id="5854790677617711513">Παλαιότερο από 30 ημέρες</translation>
+<translation id="6979737339423435258">Από την αρχή</translation>
+<translation id="982182592107339124">Αυτή η ενέργεια θα εκκαθαρίσει τα δεδομένα για όλους τους ιστότοπους, όπως:</translation>
+<translation id="6643016212128521049">Διαγραφή</translation>
+<translation id="7641339528570811325">Διαγραφή δεδομένων περιήγησης…</translation>
+<translation id="1670399744444387456">Βασικά</translation>
+<translation id="3245261285041759672">Ο Λογαριασμός σας Brave Software ενδέχεται να διαθέτει άλλες μορφές ιστορικού περιήγησης στη διεύθυνση <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Αποκλεισμένος ιστότοπος</translation>
+<translation id="2534155362429831547">Διαγράφηκαν <ph name="NUMBER_OF_ITEMS"/> στοιχεία</translation>
+<translation id="1121094540300013208">Αναφορές χρήσης και σφαλμάτων</translation>
+<translation id="9079153198295609735">Αυτόματη αποστολή στατιστικών στοιχείων χρήσης και αναφορών σφαλμάτων στην Brave Software</translation>
+<translation id="6981982820502123353">Προσβασιμότητα</translation>
+<translation id="2387895666653383613">Κλιμάκωση κειμένου</translation>
+<translation id="2321958826496381788">Σύρετε το ρυθμιστικό έως ότου να διαβάσετε αυτό το μήνυμα άνετα. Το κείμενο θα πρέπει να είναι τουλάχιστον τόσο μεγάλο αφού πατήσετε δύο φορές σε μια παράγραφο.</translation>
+<translation id="3895926599014793903">Αναγκαστική ενεργοποίηση εστίασης</translation>
+<translation id="5668404140385795438">Παράκαμψη του αιτήματος ενός ιστότοπου για παρεμπόδιση εστίασης</translation>
+<translation id="4149994727733219643">Απλοποιημένη προβολή για ιστοσελίδες</translation>
+<translation id="9100505651305367705">Προσφορά για προβολή άρθρων σε απλοποιημένη προβολή, όταν υποστηρίζεται</translation>
+<translation id="1409426117486808224">Απλοποιημένη προβολή για ανοικτές καρτέλες</translation>
+<translation id="702463548815491781">Συνιστάται όταν έχει ενεργοποιηθεί το TalkBack ή η πρόσβαση με διακόπτη</translation>
+<translation id="8284326494547611709">Υπότιτλοι</translation>
+<translation id="4165986682804962316">Ρυθμίσεις ιστότοπου</translation>
+<translation id="6295158916970320988">Όλοι οι ιστότοποι</translation>
+<translation id="8380167699614421159">Αυτός ο ιστότοπος εμφανίζει παρεμβατικές ή παραπλανητικές διαφημίσεις</translation>
+<translation id="1919345977826869612">Διαφημίσεις</translation>
+<translation id="410351446219883937">Αυτ. αναπαραγωγή</translation>
+<translation id="6447842834002726250">Cookie</translation>
+<translation id="6196640612572343990">Αποκλεισμός cookie τρίτων</translation>
+<translation id="6782111308708962316">Αποτροπή αποθήκευσης και ανάγνωσης δεδομένων cookie από ιστότοπους τρίτων</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Αναδυόμενα παράθυρα και ανακατευθύνσεις</translation>
+<translation id="4751476147751820511">Αισθητήρες κίνησης ή φωτός</translation>
+<translation id="1717218214683051432">Αισθητήρες κίνησης</translation>
+<translation id="2091887806945687916">Ήχος</translation>
+<translation id="2586657967955657006">Πρόχειρο</translation>
+<translation id="6320088164292336938">Δόνηση</translation>
+<translation id="4226663524361240545">Κατά τη λήψη ειδοποιήσεων ενδέχεται να δονείται η συσκευή</translation>
+<translation id="1446450296470737166">Να επιτρέπεται πλήρης έλεγχος σε MIDI</translation>
+<translation id="3744111561329211289">Συγχρονισμός παρασκηνίου</translation>
+<translation id="5649053991847567735">Αυτόματες λήψεις</translation>
+<translation id="6181444274883918285">Προσθήκη εξαίρεσης ιστότοπου</translation>
+<translation id="5313967007315987356">Προσθήκη ιστότοπου</translation>
+<translation id="1369915414381695676">Προστέθηκε ο ιστότοπος <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Να επιτρέπεται η αυτόματη αναπαραγωγή βίντεο που έχουν τεθεί σε σίγαση για έναν συγκεκριμένο ιστότοπο.</translation>
+<translation id="2621115761605608342">Να επιτρέπεται η JavaScript για έναν συγκεκριμένο ιστότοπο.</translation>
+<translation id="8801436777607969138">Αποκλεισμός JavaScript για κάποιο συγκεκριμένο ιστότοπο.</translation>
+<translation id="8372893542064058268">Να επιτρέπεται ο Συγχρονισμός παρασκηνίου για έναν συγκεκριμένο ιστότοπο.</translation>
+<translation id="358794129225322306">Να επιτρέπεται σε έναν ιστότοπο να κατεβάζει αυτόματα πολλά αρχεία.</translation>
+<translation id="4008040567710660924">Επιτρέπει τα cookie για έναν συγκεκριμένο ιστότοπο.</translation>
+<translation id="8958424370300090006">Αποκλεισμός cookie για έναν συγκεκριμένο ιστοτόπο.</translation>
+<translation id="7882806643839505685">Να επιτρέπεται ο ήχος για έναν συγκεκριμένο ιστότοπο.</translation>
+<translation id="4468959413250150279">Σίγαση ήχου για συγκεκριμένο ιστότοπο.</translation>
+<translation id="1994173015038366702">URL ιστότοπου</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Χρήση</translation>
+<translation id="5804241973901381774">Άδειες</translation>
+<translation id="4278390842282768270">Επιτρέπεται</translation>
+<translation id="5677928146339483299">Αποκλεισμένο</translation>
+<translation id="1984937141057606926">Να επιτρέπονται, εκτός από τα cookie τρίτου μέρους</translation>
+<translation id="7423098979219808738">Να γίνεται ερώτηση πρώτα</translation>
+<translation id="8116925261070264013">Σε σίγαση</translation>
+<translation id="8300705686683892304">Διαχείριση από εφαρμογή</translation>
+<translation id="6192792657125177640">Εξαιρέσεις</translation>
+<translation id="257931822824936280">Αναπτυγμένη - Κάντε κλικ για σύμπτυξη</translation>
+<translation id="5100237604440890931">Συμπτυγμένη - Κάντε κλικ για ανάπτυξη</translation>
+<translation id="857943718398505171">Επιτρέπεται (συνιστάται)</translation>
+<translation id="2913331724188855103">Να επιτρέπεται στους ιστότοπους η αποθήκευση και η ανάγνωση δεδομένων cookie (συνιστάται)</translation>
+<translation id="7445411102860286510">Να επιτρέπεται στους ιστότοπους η αυτόματη αναπαραγωγή βίντεο σε σίγαση (συνιστάται)</translation>
+<translation id="5335288049665977812">Να επιτρέπεται στους ιστότοπους να εκτελούν JavaScript (συνιστάται)</translation>
+<translation id="5527111080432883924">Να γίνεται ερώτηση προτού επιτραπεί σε ιστοτόπους η ανάγνωση κειμένου και εικόνων από το πρόχειρο (συνιστάται)</translation>
+<translation id="6912998170423641340">Αποκλεισμός ιστοτόπων από ανάγνωση κειμένου και εικόνων από το πρόχειρο</translation>
+<translation id="7423538860840206698">Αποκλεισμός από ανάγνωση πρόχειρου</translation>
+<translation id="3955193568934677022">Να επιτρέπεται στους ιστοτόπους να αναπαράγουν προστατευμένο περιεχόμενο (συνιστάται)</translation>
+<translation id="445467742685312942">Να επιτρέπεται στους ιστοτόπους η αναπαραγωγή προστατευμένου περιεχομένου</translation>
+<translation id="2107397443965016585">Να γίνεται ερώτηση προτού επιτραπεί στους ιστοτόπους η αναπαραγωγή προστατευόμενου περιεχομένου (συνιστάται)</translation>
+<translation id="2910701580606108292">Να γίνεται ερώτηση προτού επιτραπεί στους ιστοτόπους η αναπαραγωγή προστατευόμενου περιεχομένου</translation>
+<translation id="757524316907819857">Αποκλεισμός αναπαραγωγής προστατευόμενου περιεχομένου από ιστοτόπους</translation>
+<translation id="3277252321222022663">Να επιτρέπεται στους ιστοτόπους η πρόσβαση στους αισθητήρες (συνιστάται)</translation>
+<translation id="5048398596102334565">Να επιτρέπεται στους ιστοτόπους η πρόσβαση στους αισθητήρες κίνησης (συνιστάται)</translation>
+<translation id="8816026460808729765">Αποκλεισμός πρόσβασης στους αισθητήρες από ιστοτόπους</translation>
+<translation id="169515064810179024">Αποκλεισμός πρόσβασης σε αισθητήρες κίνησης από ιστοτόπους</translation>
+<translation id="1660204651932907780">Να επιτρέπεται στους ιστοτόπους να αναπαράγουν ήχο (συνιστάται)</translation>
+<translation id="3600792891314830896">Σίγαση ιστοτόπων που αναπαράγουν ήχο</translation>
+<translation id="1743802530341753419">Να γίνεται ερώτηση προτού επιτραπεί στους ιστοτόπους να συνδεθούν σε μια συσκευή (συνιστάται)</translation>
+<translation id="851751545965956758">Αποκλεισμός ιστοτόπων από τη σύνδεση σε συσκευές</translation>
+<translation id="7141896414559753902">Αποκλεισμός εμφάνισης αναδυόμενων παραθύρων και ανακατευθύνσεων σε ιστοτόπους (συνιστάται)</translation>
+<translation id="5494752089476963479">Αποκλεισμός διαφημίσεων σε ιστοτόπους που εμφανίζουν παρεμβατικές ή παραπλανητικές διαφημίσεις</translation>
+<translation id="3123473560110926937">Αποκλεισμός σε ορισμένους ιστοτόπους</translation>
+<translation id="965817943346481315">Αποκλεισμός εάν ο ιστότοπος εμφανίζει παρεμβατικές ή παραπλανητικές διαφημίσεις (συνιστάται)</translation>
+<translation id="3386292677130313581">Να γίνεται ερώτηση προτού επιτραπεί η κοινοποίηση της τοποθεσίας σας σε ιστότοπους (συνιστάται)</translation>
+<translation id="9139068048179869749">Να γίνεται ερώτηση προτού επιτραπεί στους ιστότοπους να στέλνουν ειδοποιήσεις (συνιστάται)</translation>
+<translation id="4479647676395637221">Να γίνεται ερώτηση προτού επιτραπεί στους ιστότοπους να χρησιμοποιούν την κάμερά σας (συνιστάται)</translation>
+<translation id="6992289844737586249">Να γίνεται ερώτηση προτού επιτραπεί στους ιστότοπους να χρησιμοποιήσουν το μικρόφωνό σας (συνιστάται)</translation>
+<translation id="2289270750774289114">Να γίνεται ερώτηση όταν ένας ιστότοπος επιθυμεί να εντοπίσει κοντινές συσκευες Bluetooth (συνιστάται)</translation>
+<translation id="7053983685419859001">Αποκλεισμός</translation>
+<translation id="7128222689758636196">Να επιτρέπεται για την τρέχουσα μηχανή αναζήτησης</translation>
+<translation id="7589445247086920869">Αποκλεισμός για την τρέχουσα μηχανή αναζήτησης</translation>
+<translation id="6388207532828177975">Διαγραφή και επαναφορά</translation>
+<translation id="7999064672810608036">Είστε βέβαιοι ότι θέλετε να διαγράψετε όλα τα δεδομένα γι' αυτόν τον ιστότοπο, όπως τα cookie, και να επαναφέρετε όλα τα δικαιώματά του;</translation>
+<translation id="2822354292072154809">Είστε βέβαοι ότι θέλετε να αναιρεθούν όλες οι άδειες ιστοτόπου για το αντικείμενο <ph name="CHOSEN_OBJECT_NAME"/>;</translation>
+<translation id="515227803646670480">Διαγραφή αποθηκευμένων δεδομένων</translation>
+<translation id="5902828464777634901">Όλα τα δεδομένα αποθήκευσης στον ιστοτόπων, όπως τα cookie, θα διαγραφούν</translation>
+<translation id="119944043368869598">Διαγραφή όλων</translation>
+<translation id="2490684707762498678">Διαχειριζόμενες από την εφαρμογή <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Άνοιγμα ρυθμίσεων ειδοποιήσεων</translation>
+<translation id="1404122904123200417">Ενσωματωμένο σε <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Τα αρχεία που αποθηκεύονται από ιστοτόπους εμφανίζονται εδώ</translation>
+<translation id="4181841719683918333">Γλώσσες</translation>
+<translation id="2647434099613338025">Προσθήκη γλώσσας</translation>
+<translation id="1952172573699511566">Οι ιστότοποι θα εμφανίζουν κείμενο στην προτιμώμενη γλώσσα σας όταν υπάρχει αυτή η δυνατότητα.</translation>
+<translation id="8559990750235505898">Προσφορά για μετάφραση σελίδων που είναι σε άλλη γλώσσα</translation>
+<translation id="4719927025381752090">Πρόταση για μετάφραση</translation>
+<translation id="8156139159503939589">Σε ποιες γλώσσες μπορείτε να διαβάσετε;</translation>
+<translation id="5689516760719285838">Τοποθεσία</translation>
+<translation id="2440823041667407902">Πρόσβαση τοποθεσίας</translation>
+<translation id="2023546461831060654">Ενεργοποίηση των αδειών για το Brave στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Ενεργοποίηση των αδειών για το Brave στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Για να επιτρέψετε στο Brave να αποκτήσει πρόσβαση στην τοποθεσία σας, ενεργοποιήστε επίσης την τοποθεσία στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Για να επιτρέψετε στο Brave να αποκτήσει πρόσβαση στην κάμερά σας, ενεργοποιήστε επίσης την κάμερα στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Για να επιτρέψετε στο Brave να σας στέλνει ειδοποιήσεις, ενεργοποιήστε επίσης τις ειδοποιήσεις στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Για να επιτρέψετε στο Brave να αποκτήσει πρόσβαση στο μικρόφωνό σας, ενεργοποιήστε επίσης το μικρόφωνο στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Η πρόσβαση στην Τοποθεσία είναι απενεργοποιημένη γι' αυτήν τη συσκευή. Ενεργοποιήστε τη στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Η πρόσβαση στην Τοποθεσία είναι απενεργοποιημένη επίσης γι' αυτήν τη συσκευή. Ενεργοποιήστε τη στις <ph name="BEGIN_LINK"/>Ρυθμίσεις Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Κάμερα</translation>
+<translation id="3227137524299004712">Μικρόφωνο</translation>
+<translation id="1647391597548383849">Πρόσβαση στην κάμερα</translation>
+<translation id="945632385593298557">Πρόσβαση στο μικρόφωνό σας</translation>
+<translation id="6612358246767739896">Προστατ. περιεχ.</translation>
+<translation id="885701979325669005">Αποθήκευση</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> αποθηκευμένα δεδομένα</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Ανάκληση άδειας συσκευής</translation>
+<translation id="4962975101802056554">Ανάκληση όλων των αδειών για τη συσκευή</translation>
+<translation id="6545864417968258051">Σάρωση Bluetooth</translation>
+<translation id="4411535500181276704">Λειτουργία Lite</translation>
+<translation id="7821588508402923572">Η εξοικονόμηση δεδομένων σας θα εμφανίζεται εδώ</translation>
+<translation id="2131665479022868825">Αποθηκεύτηκαν <ph name="DATA"/></translation>
+<translation id="8569404424186215731">από <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Στη λειτουργία Lite, το Brave φορτώνει σελίδες πιο γρήγορα και χρησιμοποιεί έως και 60 τοις εκατό λιγότερα δεδομένα.</translation>
+<translation id="6159335304067198720">Εξοικονόμηση δεδομένων κατά <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">δεδομένα που εξοικονομήθηκαν</translation>
+<translation id="6111020039983847643">δεδομένα που χρησιμοποιήθηκαν</translation>
+<translation id="7413229368719586778">Ημερομηνία έναρξης: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Ημερομηνία λήξης: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Ταξινόμηση κατά ιστότοπο</translation>
+<translation id="5864174910718532887">Λεπτομέρειες: Ταξινομήθηκαν κατά όνομα ιστοτόπου</translation>
+<translation id="116280672541001035">Χρησιμοποιήθηκαν</translation>
+<translation id="8349013245300336738">Ταξινόμηση κατά όγκο δεδομένων που χρησιμοποιήθηκαν</translation>
+<translation id="6378173571450987352">Λεπτομέρειες: Ταξινομήθηκαν βάσει του όγκου των δεδομένων που χρησιμοποιήθηκαν</translation>
+<translation id="2631006050119455616">Εξοικονομήθηκαν</translation>
+<translation id="6643649862576733715">Ταξινόμηση κατά όγκο δεδομένων που εξοικονομήθηκαν</translation>
+<translation id="7302081693174882195">Λεπτομέρειες: Ταξινομήθηκαν βάσει του όγκου των δεδομένων που αποθηκεύτηκαν</translation>
+<translation id="4179980317383591987">Χρησιμοποιήθηκαν <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Εξοικονομήθηκαν <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Ιστότοποι που απομένουν (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Άλλο</translation>
+<translation id="4913161338056004800">Επαναφορά στατιστικών στοιχείων</translation>
+<translation id="1856325424225101786">Επαναφορά της λειτουργίας Lite;</translation>
+<translation id="3658159451045945436">Η επαναφορά διαγράφει το ιστορικό των αποθηκευμένων δεδομένων, συμπεριλαμβανομένης της λίστας ιστοτόπων που έχετε επισκεφτεί.</translation>
+<translation id="3295530008794733555">Ταχύτερη περιήγηση. Χρήση λιγότερων δεδομένων.</translation>
+<translation id="7340390500800578919">Στη λειτουργία Lite, το Brave φορτώνει τις σελίδες πιο γρήγορα και χρησιμοποιεί έως και 60% λιγότερα δεδομένα. Για να βελτιστοποιήσει τις σελίδες που επισκέπτεστε, το Brave στέλνει την επισκεψιμότητα ιστού σας στο Brave Software. <ph name="BEGIN_LINK"/>Μάθετε περισσότερα<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Ενεργοποίηση λειτουργίας Lite</translation>
+<translation id="4493497663118223949">Η λειτουργία Lite είναι ενεργή</translation>
+<translation id="7559975015014302720">Η λειτουργία Lite είναι απενεργοποιημένη</translation>
+<translation id="7606077192958116810">Η λειτουργία Lite είναι ενεργοποιημένη. Διαχειριστείτε τη από τις Ρυθμίσεις.</translation>
+<translation id="4714588616299687897">Εξοικονομήστε έως και 60% των δεδομένων σας</translation>
+<translation id="1006927014032731288">Οι διακομιστές της Brave Software θα βελτιστοποιήσουν τις σελίδες που επισκέπτεστε.</translation>
+<translation id="3257320067425202300">Το Brave έχει εξοικονομήσει <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Το Brave έχει εξοικονομήσει <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Τοποθεσία λήψης</translation>
+<translation id="7077143737582773186">Secure Digital</translation>
+<translation id="7762668264895820836">Κάρτα SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Να γίνεται ερώτηση σχετικά με την τοποθεσία αποθήκευσης των αρχείων</translation>
+<translation id="6192333916571137726">Αρχείο Λήψη</translation>
+<translation id="1672586136351118594">Να μην εμφανιστεί ξανά</translation>
+<translation id="2650751991977523696">Επανάληψη λήψης αρχείου;</translation>
+<translation id="8664979001105139458">Το αρχείο υπάρχει ήδη</translation>
+<translation id="488187801263602086">Μετονομασία αρχείου</translation>
+<translation id="5686790454216892815">Το όνομα του αρχείου είναι πολύ μεγάλο</translation>
+<translation id="7454641608352164238">Ανεπαρκής χώρος</translation>
+<translation id="8972098258593396643">Λήψη στον προεπιλεγμένο φάκελο;</translation>
+<translation id="804335162455518893">Δεν βρέθηκε κάρτα SD</translation>
+<translation id="7475688122056506577">Η κάρτα SD δεν βρέθηκε. Μπορεί να λείπουν μερικά από τα αρχεία σας.</translation>
+<translation id="4198423547019359126">Δεν υπάρχουν διαθέσιμες τοποθεσίες λήψης</translation>
+<translation id="8224471946457685718">Λήψη άρθρων για εσάς στο Wi-Fi</translation>
+<translation id="4970824347203572753">Δεν είναι διαθέσιμο στην τοποθεσία σας</translation>
+<translation id="5500777121964041360">Μπορεί να μην είναι διαθέσιμο στην τοποθεσία σας</translation>
+<translation id="1173894706177603556">Μετονομασία</translation>
+<translation id="1986685561493779662">Το όνομα υπάρχει ήδη</translation>
+<translation id="6441734959916820584">Το όνομα είναι πολύ μεγάλο</translation>
+<translation id="2923908459366352541">Το όνομα δεν είναι έγκυρο</translation>
+<translation id="7290209999329137901">Η μετονομασία δεν είναι διαθέσιμη</translation>
+<translation id="3334729583274622784">Θέλετε να αλλάξετε την επέκταση αρχείου;</translation>
+<translation id="107147699690128016">Εάν αλλάξετε την επέκταση αρχείου, το αρχείο μπορεί να ανοίξει σε διαφορετική εφαρμογή και να αποτελέσει δυνητικό κίνδυνο για τη συσκευή σας.</translation>
+<translation id="8541922081612557424">Σχετικά με το Brave</translation>
+<translation id="5311273890481188673">Πνευματικά δικαιώματα <ph name="YEAR"/> Brave Software LLC. Με την επιφύλαξη παντός δικαιώματος.</translation>
+<translation id="1416550906796893042">Έκδοση εφαρμογής</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Ενημέρωση στις <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Λειτουργικό σύστημα</translation>
+<translation id="3968054912784331254">Οι ενημερώσεις Brave δεν υποστηρίζονται πλέον για αυτήν την έκδοση Android</translation>
+<translation id="7665369617277396874">Προσθήκη λογαριασμού</translation>
+<translation id="649070405679044769">Έχετε συνδεθεί στο Brave Software ως</translation>
+<translation id="6234515504547364178">Αποσύνδεση από το Brave</translation>
+<translation id="5324858694974489420">Ρυθμίσεις γονικού ελέγχου</translation>
+<translation id="8920114477895755567">Αναμονή για λεπτομέρειες γονέων.</translation>
+<translation id="5512137114520586844">Αυτός ο λογαριασμός τελεί υπό τη διαχείριση του γονέα <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Αυτός ο λογαριασμός τελεί υπό τη διαχείριση των γονέων <ph name="PARENT_NAME_1"/> και <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Περιεχόμενο</translation>
+<translation id="5403644198645076998">Να επιτρέπονται μόνο συγκεκριμένοι ιστότοποι</translation>
+<translation id="8641930654639604085">Δοκιμάστε να αποκλείσετε τους ιστοτόπους με περιεχόμενο για ενηλίκους</translation>
+<translation id="5639724618331995626">Να επιτρέπονται όλοι οι ιστότοποι</translation>
+<translation id="796823723482603597">Με την υποστήριξη του Brave</translation>
+<translation id="6324034347079777476">Ο συγχρονισμός συστήματος Android απενεργοποιήθηκε</translation>
+<translation id="5127805178023152808">Ο συγχρονισμός είναι απενεργοποιημένος</translation>
+<translation id="7015203776128479407">Η αρχική ρύθμιση του συγχρονισμού δεν τελείωσε. Ο συγχρονισμός είναι απενεργοποιημένος.</translation>
+<translation id="2497852260688568942">Ο συγχρονισμός έχει απενεργοποιηθεί από τον διαχειριστή σας</translation>
+<translation id="9100610230175265781">Απαιτείται φράση πρόσβασης</translation>
+<translation id="6108923351542677676">Ρύθμιση σε εξέλιξη…</translation>
+<translation id="4062305924942672200">Νομικές πληροφορίες</translation>
+<translation id="4256782883801055595">Άδειες λογισμικού ανοικτού κώδικα</translation>
+<translation id="1138681184697033370">Όροι Παροχής Υπηρεσιών Brave</translation>
+<translation id="7392539049993970338">Σημείωση Απορρήτου του Brave</translation>
+<translation id="2677748264148917807">Αποχώρηση</translation>
+<translation id="5556459405103347317">Επαναφόρτωση</translation>
+<translation id="1623104350909869708">Αποτροπή δημιουργίας πρόσθετων παραθύρων διαλόγου από αυτήν τη σελίδα</translation>
+<translation id="2968755619301702150">Πρόγρ. προβολής πιστοποιητικού</translation>
+<translation id="1360432990279830238">Αποσύνδεση και απενεργοπ. συγχρονισμού;</translation>
+<translation id="8581481290581777242">Να διαγραφούν τα δεδομένα Brave από τη συσκευή;</translation>
+<translation id="1318865768845061710">Οι σελιδοδείκτες, το ιστορικό, οι κωδικοί πρόσβασης και άλλα δεδομένα Brave δεν θα συγχρονίζονται πλέον με τον Λογαριασμό σας Brave Software</translation>
+<translation id="3325020657155065477">Επίσης, να διαγραφούν τα δεδομένα Brave από αυτήν τη συσκευή.</translation>
+<translation id="6136448902816743006">Τα δεδομένα σας Brave θα διαγραφούν από αυτήν τη συσκευή, λόγω της αποσύνδεσής σας από έναν λογαριασμό, η διαχείριση του οποίου γίνεται από τον τομέα <ph name="DOMAIN_NAME"/>. Θα παραμείνει στον Λογαριασμό σας Brave Software.</translation>
+<translation id="1853026300647876496">Επικοινωνία με Brave Software… Αυτή η διαδικασία μπορεί να διαρκέσει μερικά λεπτά…</translation>
+<translation id="2328985652426384049">Δεν είναι δυνατή η σύνδεση</translation>
+<translation id="7723158744459952869">Η απάντηση από το Brave Software καθυστέρησε υπερβολικά</translation>
+<translation id="4572422548854449519">Συνδεθείτε στον διαχειριζόμενο λογαριασμό</translation>
+<translation id="2689656545739939160">Πρόκειται να συνδεθείτε με έναν λογαριασμό του οποίου η διαχείριση γίνεται από <ph name="MANAGED_DOMAIN"/> και παραχωρείτε στον διαχειριστή του τον έλεγχο της διαχείρισης των δεδομένων σας στο Brave. Τα δεδομένα σας θα συσχετιστούν οριστικά με αυτόν τον λογαριασμό. Η αποσύνδεση από το Brave θα διαγράψει τα δεδομένα σας από αυτήν τη συσκευή, αλλά θα διατηρηθούν αποθηκευμένα στον Λογαριασμό σας Brave Software.</translation>
+<translation id="1749561566933687563">Συγχρονίστε τους σελιδοδείκτες σας</translation>
+<translation id="4242533952199664413">Ανοίξτε τις ρυθμίσεις</translation>
+<translation id="1111673857033749125">Οι σελιδοδείκτες που είναι αποθηκευμένοι σε άλλες συσκευές θα εμφανίζονται εδώ.</translation>
+<translation id="8636825310635137004">Για να εμφανίζονται οι καρτέλες από τις άλλες συσκευές σας, ενεργοποιήστε τον συγχρονισμό.</translation>
+<translation id="3269956123044984603">Για να εμφανίζονται οι καρτέλες από τις άλλες συσκευές σας, ενεργοποιήστε τον "Αυτόματο συγχρονισμό δεδομένων" στις ρυθμίσεις λογαριασμού Android.</translation>
+<translation id="5157964048453367290">Οι καρτέλες που έχετε ανοίξει στο Brave στις άλλες συσκευές σας θα εμφανίζονται εδώ.</translation>
+<translation id="4684427112815847243">Συγχρονισμός όλων</translation>
+<translation id="2709516037105925701">Αυτόματη συμπλήρωση</translation>
+<translation id="8820817407110198400">Σελιδοδείκτες</translation>
+<translation id="1644574205037202324">Ιστορικό</translation>
+<translation id="17513872634828108">Ανοικτές καρτέλες</translation>
+<translation id="1320169905922104972">Πιστωτικές κάρτες και διευθύνσεις που χρησιμοποιούν το Brave Software Pay</translation>
+<translation id="6337234675334993532">Κρυπτογράφηση</translation>
+<translation id="6698801883190606802">Διαχείριση συγχρονισμένων δεδομένων</translation>
+<translation id="3598578758776312506">Κρυπτογράφηση κωδικών πρόσβασης με τα διαπιστευτήριά σας Brave Software.</translation>
+<translation id="7810580217418711046">Κρυπτογράφηση συγχρονισμένων δεδομένων με τον κωδικό πρόσβασης Brave Software από τις <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Κρυπτογράφηση συγχρονισμένων δεδομένων με τη δική σας φράση πρόσβασης συγχρονισμού</translation>
+<translation id="2996291259634659425">Δημιουργία φράσης πρόσβασης</translation>
+<translation id="5713644099811900409">Λογαριασμός Brave Software</translation>
+<translation id="8997474919031554666">Η κρυπτογράφηση με φράση πρόσβασης δεν περιλαμβάνει τρόπους πληρωμής και διευθύνσεις από το Brave Software Pay. Μόνο κάποιος που γνωρίζει τη φράση πρόσβασής σας μπορεί να διαβάσει τα κρυπτογραφημένα δεδομένα σας. Η φράση πρόσβασης δεν αποστέλλεται στην Brave Software ούτε αποθηκεύεται από αυτήν. Εάν ξεχάσετε τη φράση πρόσβασής σας ή θέλετε να αλλάξετε αυτήν τη ρύθμιση, θα πρέπει να επαναφέρετε τον συγχρονισμό. <ph name="BEGIN_LINK"/>Μάθετε περισσότερα<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Φράση πρόσβασής σας</translation>
+<translation id="7772032839648071052">Επιβεβαίωση φράσης πρόσβασης</translation>
+<translation id="5304593522240415983">Αυτό το πεδίο δεν μπορεί να είναι κενό</translation>
+<translation id="321773570071367578">Εάν ξεχάσετε τη φράση πρόσβασής σας ή θέλετε να αλλάξετε αυτήν τη ρύθμιση, <ph name="BEGIN_LINK"/>επαναφέρετε το συγχρονισμό<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Οι φράσεις πρόσβασης δεν συμφωνούν</translation>
+<translation id="5149495116300586333">Η κρυπτογράφηση φράσης πρόσβασης δεν περιλαμβάνει τρόπους πληρωμής και διευθύνσεις από το Brave Software Pay.
+
+Για να αλλάξετε αυτήν τη ρύθμιση, <ph name="BEGIN_LINK"/>επαναφέρετε τον συγχρονισμό<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Εσφαλμένη φράση πρόσβασης</translation>
+<translation id="5414836363063783498">Γίνεται επαλήθευση…</translation>
+<translation id="6846298663435243399">Φόρτωση…</translation>
+<translation id="5517095782334947753">Έχετε σελιδοδείκτες, ιστορικό, κωδικούς πρόσβασης και άλλες ρυθμίσεις από τον λογαριασμό <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Συνδυασμός των δεδομένων μου</translation>
+<translation id="688738109438487280">Προσθήκη υπαρχόντων δεδομένων στον λογαριασμό <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Διατήρηση των δεδομένων μου ξεχωριστά</translation>
+<translation id="1145536944570833626">Διαγραφή υπαρχόντων δεδομένων.</translation>
+<translation id="1993768208584545658">Ο ιστότοπος <ph name="SITE"/> επιθυμεί σύζευξη</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Λήψη βοήθειας<ph name="END_LINK"/> κατά τη σάρωση για συσκευές…</translation>
+<translation id="5817918615728894473">Σύζευξη</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Λήψη βοήθειας<ph name="END_LINK1"/> ή <ph name="BEGIN_LINK2"/>επανάληψη σάρωσης<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Δεν βρέθηκαν συμβατές συσκευές</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Ενεργοποιήστε το Bluetooth<ph name="END_LINK"/>, για να επιτρέψετε τη σύζευξη</translation>
+<translation id="998321811308652668">Το Brave δεν είναι δυνατό να ενεργοποιήσει τον προσαρμογέα Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Λάβετε βοήθεια<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Το Brave χρειάζεται πρόσβαση στην τοποθεσία, προκειμένου να κάνει σάρωση για συσκευές. <ph name="BEGIN_LINK"/>Ενημέρωση δικαιωμάτων<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Το Brave χρειάζεται πρόσβαση στην τοποθεσία, προκειμένου να κάνει σάρωση για συσκευές. Η πρόσβαση τοποθεσίας είναι <ph name="BEGIN_LINK"/>απενεργοποιημένη για αυτήν τη συσκευή<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Το Brave χρειάζεται πρόσβαση στην τοποθεσία, προκειμένου να κάνει σάρωση για συσκευές. <ph name="BEGIN_LINK1"/>Ενημέρωση δικαιωμάτων<ph name="END_LINK1"/>. Η πρόσβαση τοποθεσίας είναι επίσης <ph name="BEGIN_LINK2"/>απενεργοποιημένη για αυτήν τη συσκευή<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Συνδεδεμένη συσκευή</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Επίπεδο ισχύος σήματος: # γραμμή}other{Επίπεδο ισχύος σήματος: # γραμμές}}</translation>
+<translation id="5230560987958996918">Ο ιστότοπος <ph name="SITE"/> θέλει να κάνει σάρωση για κοντινές συσκευές Bluetooth. Βρέθηκαν οι παρακάτω συσκευές:</translation>
+<translation id="8368027906805972958">Άγνωστη ή μη υποστηριζόμενη συσκευή (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Ο συγχρονισμός δεν λειτουργεί</translation>
+<translation id="1810845389119482123">Η αρχική ρύθμιση συγχρονισμού δεν ολοκληρώθηκε</translation>
+<translation id="3235722914093408050">Ανοίξτε Ρυθμίσεις Android και ενεργοποιήστε τον συγχρ. συστ. Android για έναρξη Συγχρ. Brave</translation>
+<translation id="3367813778245106622">Συνδεθείτε ξανά για να ξεκινήσετε τον συγχρονισμό</translation>
+<translation id="974555521953189084">Εισαγάγετε τη φράση πρόσβασης για να ξεκινήσετε τον συγχρονισμό.</translation>
+<translation id="2997266899014181325">Για να ξεκινήσετε τον συγχρονισμό, ενεργοποιήστε την επιλογή "Συγχρονισμός των δεδομένων του Brave".</translation>
+<translation id="8260126382462817229">Δοκιμάστε να συνδεθείτε ξανά</translation>
+<translation id="5919204609460789179">Ενημερώστε το <ph name="PRODUCT_NAME"/> για να ξεκινήσει ο συγχρονισμός</translation>
+<translation id="397583555483684758">Ο συγχρονισμός σταμάτησε να λειτουργεί</translation>
+<translation id="1966710179511230534">Ενημερώστε τα στοιχεία σύνδεσής σας.</translation>
+<translation id="7063006564040364415">Δεν ήταν δυνατή η σύνδεση στον διακομιστή συγχρονισμού.</translation>
+<translation id="7942131818088350342">Το <ph name="PRODUCT_NAME"/> δεν είναι ενημερωμένο.</translation>
+<translation id="4170011742729630528">Η υπηρεσία δεν είναι διαθέσιμη. Δοκιμάστε ξανά αργότερα.</translation>
+<translation id="7947953824732555851">Αποδοχή και σύνδεση</translation>
+<translation id="8583805026567836021">Διαγραφή δεδομένων λογαριασμού</translation>
+<translation id="8310344678080805313">Τυπικές καρτέλες</translation>
+<translation id="5748802427693696783">Έγινε εναλλαγή σε τυπικές καρτέλες</translation>
+<translation id="7998918019931843664">Εκ νέου άνοιγμα κλειστής καρτέλας</translation>
+<translation id="8853345339104747198">Καρτέλα <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Κλείσιμο καρτέλας <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Διαθέσιμες επιλογές κοντά κάτω μέρος της οθόνης</translation>
+<translation id="4060598801229743805">Διαθέσιμες επιλογές κοντά στην κορυφή της οθόνης</translation>
+<translation id="2810645512293415242">Απλοποιημένη σελίδα για την αποθήκευση δεδομένων και για πιο γρήγορη φόρτωση.</translation>
+<translation id="3985215325736559418">Θέλετε να κατεβάσετε ξανά το αρχείο <ph name="FILE_NAME"/>;</translation>
+<translation id="2450083983707403292">Θέλετε να ξεκινήσετε ξανά τη λήψη του αρχείου <ph name="FILE_NAME"/>;</translation>
+<translation id="7514365320538308">Λήψη</translation>
+<translation id="545042621069398927">Επιτάχυνση της λήψης σας.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Λήψη αρχείου.}other{Λήψη # αρχείων.}}</translation>
+<translation id="543509235395288790">Λήψη <ph name="COUNT"/> αρχείων (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Λήψη αρχείου (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ολοκληρωμένη λήψη.}other{# ολοκληρωμένες λήψεις.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 λήψη απέτυχε.}other{# λήψεις απέτυχαν.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 λήψη σε εκκρεμότητα.}other{# λήψεις σε εκκρεμότητα.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Κουμπί <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Σχεδόν ολοκληρώθηκε!</translation>
+<translation id="3960299545138990065">Επανεκκινήστε το Brave</translation>
+<translation id="3771001275138982843">Δεν ήταν δυνατή η λήψη της ενημέρωσης</translation>
+<translation id="3888648114124182147">Λήψη Ενημέρωσης Brave…</translation>
+<translation id="1705567146636171298">Ενημερώστε το Brave</translation>
+<translation id="6195417478702700398">Για την καλύτερη δυνατή εμπειρία περιήγησης, ανοίξτε το Brave για να το ενημερώσετε</translation>
+<translation id="3512968675351418494">Για να δείτε τον ιστό στη γλώσσα σας, κατεβάστε την πιο πρόσφατη έκδοση του Brave</translation>
+<translation id="6427112570124116297">Μετάφραση ιστού</translation>
+<translation id="1379423114029199501">Ενημερώστε για να χρησιμοποιείτε τη γλώσσα σας στην πιο πρόσφατη έκδοση του Brave</translation>
+<translation id="5684874026226664614">Ωχ. Δεν ήταν δυνατή η μετάφραση αυτής της σελίδας.</translation>
+<translation id="6831043979455480757">Μετάφραση</translation>
+<translation id="1285320974508926690">Να μην γίνεται ποτέ μετάφραση αυτού του ιστότοπου</translation>
+<translation id="773466115871691567">Να μεταφράζονται πάντα οι σελίδες προς τα <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Να μην γίνεται μετάφραση σελίδων στα <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Περισσότερες γλώσσες</translation>
+<translation id="290376772003165898">Η σελίδα δεν είναι στα <ph name="LANGUAGE"/>;</translation>
+<translation id="4432792777822557199">Από εδώ και στο εξής, οι σελίδες στα <ph name="SOURCE_LANGUAGE"/> θα μεταφράζονται στα <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Οι σελίδες στα <ph name="LANGUAGE"/> δεν θα μεταφράζονται</translation>
+<translation id="5447765697759493033">Αυτός ο ιστότοπος δεν θα μεταφραστεί</translation>
+<translation id="4880127995492972015">Μετάφραση…</translation>
+<translation id="641643625718530986">Εκτύπωση…</translation>
+<translation id="8909135823018751308">Κοινοποίηση…</translation>
+<translation id="4996978546172906250">Μοιραστείτε μέσω</translation>
+<translation id="6333140779060797560">Μοιραστείτε μέσω <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Παρουσιάστηκε ένα πρόβλημα κατά την εκτύπωση της σελίδας. Δοκιμάστε ξανά.</translation>
+<translation id="3254409185687681395">Προσθήκη αυτής της σελίδας στους σελιδοδείκτες</translation>
+<translation id="497421865427891073">Μετάβαση προς τα εμπρός</translation>
+<translation id="813082847718468539">Προβολή πληροφοριών τοποθεσίας</translation>
+<translation id="2532336938189706096">Προβολή ιστού</translation>
+<translation id="6005538289190791541">Προτεινόμενος κωδικός πρόσβασης</translation>
+<translation id="4634124774493850572">Χρήση κωδικού πρόσβασης</translation>
+<translation id="8285489906452138776">Το Brave χρειάζεται άδεια, για να αποκτήσει πρόσβαση στην κάμερα για αυτόν τον ιστότοπο.</translation>
+<translation id="320189792589364011">Το Brave χρειάζεται άδεια, για να αποκτήσει πρόσβαση στο μικρόφωνο για αυτόν τον ιστότοπο.</translation>
+<translation id="7988136689212463100">Το Brave χρειάζεται άδεια, για να αποκτήσει πρόσβαση στην κάμερα και το μικρόφωνο για αυτόν τον ιστότοπο.</translation>
+<translation id="4931190655840828017">Το Brave χρειάζεται πρόσβαση στην τοποθεσία σας, για να την κοινοποιήσει σε αυτόν τον ιστότοπο.</translation>
+<translation id="3088191967551450609">Το Brave χρειάζεται πρόσβαση στο χώρο αποθήκευσης για τη λήψη αρχείων.</translation>
+<translation id="8942627711005830162">Άνοιγμα σε άλλο παράθυρο</translation>
+<translation id="4195643157523330669">Άνοιγμα σε νέα καρτέλα</translation>
+<translation id="1100066534610197918">Άνοιγμα σε νέα καρτ. σε ομάδα</translation>
+<translation id="4860895144060829044">Κλήση</translation>
+<translation id="6896758677409633944">Αντιγραφή</translation>
+<translation id="8393700583063109961">Αποστολή μηνύματος</translation>
+<translation id="3557336313807607643">Προσθήκη στις επαφές</translation>
+<translation id="4269820728363426813">Αντιγρ. διεύθυνσης συνδέσμου</translation>
+<translation id="1206892813135768548">Αντιγραφή κειμένου συνδέσμου</translation>
+<translation id="1204037785786432551">Λήψη συνδέσμου</translation>
+<translation id="6864459304226931083">Λήψη εικόνας</translation>
+<translation id="8209050860603202033">Άνοιγμα εικόνας</translation>
+<translation id="8073388330009372546">Άνοιγμα εικόνας σε νέα καρτέλα</translation>
+<translation id="6649642165559792194">Προεπισκόπηση εικόνας <ph name="BEGIN_NEW"/>Νέο<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Φόρτωση εικόνας</translation>
+<translation id="3845332215609790146">Αναζήτηση με Brave Software Lens <ph name="BEGIN_NEW"/>Νέο<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Αναζήτηση <ph name="SEARCH_ENGINE"/> για την εικόνα</translation>
+<translation id="3384347053049321195">Κοινοποίηση εικόνας</translation>
+<translation id="5833984609253377421">Κοινοποίηση συνδέσμου</translation>
+<translation id="6475951671322991020">Λήψη βίντεο</translation>
+<translation id="2317945146070194624">Άνοιγμα σε νέα καρτέλα Brave</translation>
+<translation id="7975379999046275268">Προεπισκόπηση σελίδας <ph name="BEGIN_NEW"/>Νέο<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Ανανέωση σελίδας</translation>
+<translation id="36525718899759834">Λήψη της εφαρμογής από το Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Σκούρο</translation>
+<translation id="1807246157184219062">Ανοιχτόχρωμο</translation>
+<translation id="4056223980640387499">Σέπια</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">Α</translation>
+<translation id="654446541061731451">Επιλέξτε μια καρτέλα για ζεύξη</translation>
+<translation id="8719023831149562936">Δεν είναι δυνατή η ζεύξη της τρέχουσας καρτέλας</translation>
+<translation id="2139186145475833000">Προσθήκη στην αρχική οθόνη</translation>
+<translation id="4616150815774728855">Ανοίξτε <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Δεν ήταν δυνατό το άνοιγμα της εφαρμογής</translation>
+<translation id="5129038482087801250">Εγκατάσταση εφαρμογής ιστού</translation>
+<translation id="3789841737615482174">Εγκατάσταση</translation>
+<translation id="4665282149850138822">Ο ιστότοπος <ph name="NAME"/> προστέθηκε στην αρχική οθόνη σας</translation>
+<translation id="7333031090786104871">Η προσθήκη του προηγούμενου ιστοτόπου δεν έχει ολοκληρωθεί</translation>
+<translation id="1036727731225946849">Προσθήκη <ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">Προστέθηκε στην αρχική οθόνη</translation>
+<translation id="2146738493024040262">Άνοιγμα Instant Εφαρμογής</translation>
+<translation id="7016516562562142042">Επιτράπηκε για την τρέχουσα μηχανή αναζήτησης</translation>
+<translation id="6177111841848151710">Αποκλείστηκε για την τρέχουσα μηχανή αναζήτησης</translation>
+<translation id="145097072038377568">Έχει απενεργοποιηθεί στις Ρυθμίσεις Android</translation>
+<translation id="8007176423574883786">Έχει απενεργοποιηθεί για αυτήν τη συσκευή</translation>
+<translation id="164269334534774161">Βλέπετε ένα αντίγραφο εκτός σύνδεσης αυτής της σελίδας από <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Αυτή η σελίδα εκτός σύνδεσης δημιουργήθηκε στις <ph name="CREATION_TIME"/> και μπορεί να διαφέρει από την έκδοση στο διαδίκτυο.</translation>
+<translation id="8840953339110955557">Αυτή η σελίδα μπορεί να διαφέρει από την έκδοση στο διαδίκτυο.</translation>
+<translation id="6405300764336705484">Αυτό το περιεχόμενο προέρχεται από το <ph name="DOMAIN_NAME"/> και παρέχεται από την Brave Software.</translation>
+<translation id="1006017844123154345">Άνοιγμα στο διαδίκτυο</translation>
+<translation id="3326636747541519688">Σελίδα Lite που παρέχεται από την Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Φόρτωση αρχικής σελίδας<ph name="END_LINK"/> από <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Εάν αυτό το μήνυμα εμφανίζεται συχνά, δοκιμάστε αυτές τις <ph name="BEGIN_LINK"/>προτάσεις<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Κρυφό περιεχόμενο</translation>
+<translation id="3810973564298564668">Διαχείριση</translation>
+<translation id="5199929503336119739">Προφίλ εργασίας</translation>
+<translation id="528192093759286357">Σύρετε από το επάνω τμήμα και αγγίξτε το κουμπί επιστροφής για έξοδο από την πλήρη οθόνη.</translation>
+<translation id="2836148919159985482">Πατήστε το κουμπί επιστροφής για έξοδο από την πλήρη οθόνη.</translation>
+<translation id="3967822245660637423">Ολοκλήρωση λήψης</translation>
+<translation id="2434158240863470628">Η λήψη ολοκληρώθηκε <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Η λήψη απέτυχε</translation>
+<translation id="1384959399684842514">Η λήψη διακόπηκε προσωρινά.</translation>
+<translation id="1671236975893690980">Λήψη σε εκκρεμότητα…</translation>
+<translation id="5561549206367097665">Αναμονή για δίκτυο…</translation>
+<translation id="5864419784173784555">Αναμονή για άλλη λήψη…</translation>
+<translation id="6461962085415701688">Δεν είναι δυνατό το άνοιγμα του αρχείου</translation>
+<translation id="1178581264944972037">Παύση</translation>
+<translation id="8200772114523450471">Συνέχιση</translation>
+<translation id="1409879593029778104">Η λήψη του αρχείου <ph name="FILE_NAME"/> απετράπη, επειδή το αρχείο υπάρχει ήδη.</translation>
+<translation id="3387650086002190359">Η λήψη του αρχείου <ph name="FILE_NAME"/> απέτυχε λόγω σφαλμάτων του συστήματος αρχείων.</translation>
+<translation id="6482749332252372425">Η λήψη του αρχείου <ph name="FILE_NAME"/> απέτυχε λόγω έλλειψης αποθηκευτικού χώρου.</translation>
+<translation id="7619072057915878432">Η λήψη του αρχείου <ph name="FILE_NAME"/> απέτυχε λόγω προβλημάτων στο δίκτυο.</translation>
+<translation id="1477626028522505441">Η λήψη του αρχείου <ph name="FILE_NAME"/> απέτυχε λόγω προβλημάτων στον διακομιστή.</translation>
+<translation id="3692944402865947621">Η λήψη του αρχείου <ph name="FILE_NAME"/> απέτυχε επειδή δεν είναι προσβάσιμη η τοποθεσία αποθήκευσης.</translation>
+<translation id="604996488070107836">Η λήψη του αρχείου <ph name="FILE_NAME"/> απέτυχε λόγω άγνωστου σφάλματος.</translation>
+<translation id="6738867403308150051">Λήψη…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Έγινε λήψη <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Έγινε λήψη <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Έγινε λήψη <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">1 αρχείο απομένει</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> αρχεία απομένουν</translation>
+<translation id="757855969265046257">{FILES,plural, =1{Έγινε λήψη <ph name="FILES_DOWNLOADED_ONE"/> αρχείου}other{Έγινε λήψη <ph name="FILES_DOWNLOADED_MANY"/> αρχείων}}</translation>
+<translation id="8037750541064988519">Απομένουν <ph name="DAYS"/> ημέρες</translation>
+<translation id="8190358571722158785">Απομένει 1 ημέρα</translation>
+<translation id="60923314841986378">Απομένουν <ph name="HOURS"/> ώρες</translation>
+<translation id="510275257476243843">Απομένει 1 ώρα</translation>
+<translation id="970715775301869095">Απομένουν <ph name="MINUTES"/> λεπτά</translation>
+<translation id="3236059992281584593">Απομένει 1 λεπτό</translation>
+<translation id="2777555524387840389">Απομένουν <ph name="SECONDS"/> δευτερόλεπτα</translation>
+<translation id="2781151931089541271">Απομένει 1 δευτερόλεπτο</translation>
+<translation id="3303414029551471755">Συνέχεια για λήψη του περιεχομένου;</translation>
+<translation id="8617240290563765734">Άνοιγμα της προτεινόμενης διεύθυνσης URL που καθορίζεται στο ληφθέν περιεχόμενο;</translation>
+<translation id="1373696734384179344">Ανεπαρκής μνήμη για τη λήψη του επιλεγμένου περιεχομένου.</translation>
+<translation id="5271967389191913893">Η συσκευή δεν μπορεί να ανοίξει το περιεχόμενο προς λήψη.</translation>
+<translation id="883806473910249246">Παρουσιάστηκε σφάλμα κατά τη λήψη του περιεχομένου.</translation>
+<translation id="5626134646977739690">Όνομα:</translation>
+<translation id="7963646190083259054">Πάροχος υπηρεσιών:</translation>
+<translation id="3414952576877147120">Μέγεθος:</translation>
+<translation id="7375125077091615385">Τύπος:</translation>
+<translation id="5765780083710877561">Περιγραφή:</translation>
+<translation id="4881695831933465202">Άνοιγμα</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB διαθέσιμα</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB διαθέσιμα</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB διαθέσιμα</translation>
+<translation id="5793665092639000975">Χρήση <ph name="SPACE_USED"/> από <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Όλες</translation>
+<translation id="4988526792673242964">Σελίδες</translation>
+<translation id="3810838688059735925">Βίντεο</translation>
+<translation id="3616113530831147358">Ήχος</translation>
+<translation id="9219103736887031265">Εικόνες</translation>
+<translation id="8250920743982581267">Έγγραφα</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Αρχείο}other{# Αρχεία}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Εικόνα}other{# Εικόνες}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Βίντεο}other{# Βίντεο}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Αρχείο ήχου}other{# Αρχεία ήχου}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Σελίδα}other{# Σελίδες}}</translation>
+<translation id="5456381639095306749">Λήψη σελίδας</translation>
+<translation id="2394602618534698961">Εδώ εμφανίζονται τα αρχεία που κατεβάζετε</translation>
+<translation id="7810647596859435254">Άνοιγμα με…</translation>
+<translation id="5655963694829536461">Αναζήτηση λήψεων</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Τα αρχεία μου</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Εδώ εμφανίζονται άρθρα τα οποία μπορείτε να διαβάσετε ακόμη και εκτός σύνδεσης</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ω.}other{# ω.}}</translation>
+<translation id="5853623416121554550">σε παύση</translation>
+<translation id="8965591936373831584">σε εκκρεμότητα</translation>
+<translation id="2779651927720337254">απέτυχε</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Μόλις τώρα</translation>
+<translation id="4000212216660919741">Η αρχική σελίδα είναι εκτός σύνδεσης</translation>
+<translation id="9133397713400217035">Εξερεύνηση εκτός σύνδεσης</translation>
+<translation id="968900484120156207">Εδώ εμφανίζονται οι σελίδες που επισκέπτεστε</translation>
+<translation id="7882131421121961860">Δεν βρέθηκε ιστορικό</translation>
+<translation id="3549657413697417275">Αναζήτηση στο ιστορικό σας</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">ΜΜ</translation>
+<translation id="605721222689873409">ΕΕ</translation>
+<translation id="724102042129299115">Εμπειρία πρώτης εκτέλεσης Brave</translation>
+<translation id="2700285883409956633">Χρησιμοποιώντας αυτήν την εφαρμογή, αποδέχεστε τους <ph name="BEGIN_LINK1"/>Όρους Παροχής Υπηρεσιών<ph name="END_LINK1"/> και τη <ph name="BEGIN_LINK2"/>Σημείωση Απορρήτου<ph name="END_LINK2"/> του Brave.</translation>
+<translation id="1640714894372474981">Χρησιμοποιώντας αυτήν την εφαρμογή, συμφωνείτε με τους <ph name="BEGIN_LINK1"/>Όρους Παροχής Υπηρεσιών<ph name="END_LINK1"/> και τη <ph name="BEGIN_LINK2"/>Σημείωση απορρήτου<ph name="END_LINK2"/> του Brave, καθώς και με τη <ph name="BEGIN_LINK3"/>Σημείωση απορρήτου για Λογαριασμούς Brave Software, των οποίων η διαχείριση γίνεται μέσω του Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Η εφαρμογή <ph name="APP_NAME"/> θα ανοίξει στο Brave. Εάν συνεχίσετε, συμφωνείτε με τους <ph name="BEGIN_LINK1"/>Όρους Παροχής Υπηρεσιών<ph name="END_LINK1"/> και τη <ph name="BEGIN_LINK2"/>Σημείωση απορρήτου<ph name="END_LINK2"/> του Brave.</translation>
+<translation id="5071615083211946659">Η εφαρμογή <ph name="APP_NAME"/> θα ανοίξει στο Brave. Εάν συνεχίσετε, συμφωνείτε με τους <ph name="BEGIN_LINK1"/>Όρους Παροχής Υπηρεσιών<ph name="END_LINK1"/> και τη <ph name="BEGIN_LINK2"/>Σημείωση απορρήτου<ph name="END_LINK2"/> του Brave, καθώς και με τη <ph name="BEGIN_LINK3"/>Σημείωση απορρήτου για Λογαριασμούς Brave Software των οποίων η διαχείριση γίνεται μέσω του Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Συμβάλετε στη βελτίωση του Brave, στέλνοντας στην Brave Software στατιστικά στοιχεία χρήσης και αναφορές σφαλμάτων.</translation>
+<translation id="3518985090088779359">Αποδοχή και συνέχεια</translation>
+<translation id="7207456302801184289">Καλώς ήρθατε στο Brave</translation>
+<translation id="704822250101715322">Αναμονή για ολοκλήρωση της ενημέρωσης των Υπηρεσιών Brave Software Play</translation>
+<translation id="1231733316453485619">Ενεργοποίηση συγχρονισμού;</translation>
+<translation id="5132942445612118989">Συγχρονίστε κωδικούς πρόσβασης, ιστορικό και πολλά άλλα σε όλες τις συσκευές</translation>
+<translation id="5736731321935944068">Η Brave Software μπορεί να χρησιμοποιήσει το ιστορικό σας για την εξατομίκευση της Αναζήτησης, των διαφημίσεων και άλλων υπηρεσιών Brave Software</translation>
+<translation id="4013614219085422040">Η Brave Software μπορεί να χρησιμοποιήσει το ιστορικό σας για την εξατομίκευση της Αναζήτησης και άλλων υπηρεσιών Brave Software</translation>
+<translation id="5581519193887989363">Μπορείτε πάντα να επιλέξετε τα στοιχεία που θέλετε να συγχρονίσετε στις <ph name="BEGIN_LINK1"/>ρυθμίσεις<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Ναι, συμφωνώ</translation>
+<translation id="2410754283952462441">Επιλέξτε λογαριασμό</translation>
+<translation id="2227444325776770048">Συνέχεια ως <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Δεν είστε ο χρήστης <ph name="EMAIL"/>;</translation>
+<translation id="8109613176066109935">Για να εμφανίζονται οι σελιδοδείκτες σας σε όλες τις συσκευές σας, ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="2818669890320396765">Για να εμφανίζονται οι σελιδοδείκτες σας σε όλες τις συσκευές σας, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="6003646045106347985">Για λήψη εξατομικευμένου περιεχομένου που προτείνεται από την Brave Software, ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="8494430740943879273">Για λήψη εξατομικευμένου περιεχομένου που προτείνεται από την Brave Software, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="5862731021271217234">Για να εμφανίζονται οι καρτέλες σας από τις άλλες συσκευές σας, ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="3568688522516854065">Για να εμφανίζονται οι καρτέλες σας από τις άλλες συσκευές σας, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="1208340532756947324">Για συγχρονισμό και εξατομίκευση σε διάφορες συσκευές, ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="4472118726404937099">Για συγχρονισμό και εξατομίκευση σε διάφορες συσκευές, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
+<translation id="2426805022920575512">Επιλογή άλλου λογαριασμού</translation>
+<translation id="6790428901817661496">Αναπαραγωγή</translation>
+<translation id="1272079795634619415">Διακοπή</translation>
+<translation id="2874939134665556319">Προηγούμενο κομμάτι</translation>
+<translation id="4046123991198612571">Επόμενο κομμάτι</translation>
+<translation id="3859306556332390985">Αναζήτηση προς τα εμπρός</translation>
+<translation id="8441146129660941386">Αναζήτηση προς τα πίσω</translation>
+<translation id="6706288973712894588">Αυτήν τη στιγμή είστε εκτός σύνδεσης.\n<ph name="BEGIN_LINK"/>Εξερευνήστε τη ροή σας εκτός σύνδεσης.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Πρόσφατες καρτέλες</translation>
+<translation id="8497726226069778601">Δεν υπάρχει τίποτα να δείτε εδώ…ακόμη</translation>
+<translation id="5423934151118863508">Οι πιο δημοφιλείς σελίδες σας θα εμφανίζονται εδώ</translation>
+<translation id="6127379762771434464">Το στοιχείο καταργήθηκε</translation>
+<translation id="4605958867780575332">Το στοιχείο καταργήθηκε <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Άλλες συσκευές</translation>
+<translation id="4738836084190194332">Τελευταίος συγχρονισμός: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Πριν από # λεπτό}other{Πριν από # λεπτά}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Πριν από # ώρα}other{Πριν από # ώρες}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Πριν από # ημέρα}other{Πριν από # ημέρες}}</translation>
+<translation id="2762000892062317888">μόλις τώρα</translation>
+<translation id="1407135791313364759">Άνοιγμα όλων</translation>
+<translation id="1209206284964581585">Προσωρινή απόκρυψη</translation>
+<translation id="129553762522093515">Έκλεισαν πρόσφατα</translation>
+<translation id="8413126021676339697">Εμφάνιση πλήρους ιστορικού</translation>
+<translation id="7876243839304621966">Κατάργηση όλων</translation>
+<translation id="8487700953926739672">Διαθέσιμο εκτός σύνδεσης</translation>
+<translation id="5224771365102442243">Με βίντεο</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Μάθετε περισσότερα<ph name="END_LINK"/> σχετικά με το προτεινόμενο περιεχόμενο</translation>
+<translation id="7542481630195938534">Δεν είναι δυνατή η λήψη προτάσεων</translation>
+<translation id="5013696553129441713">Δεν υπάρχουν νέες προτάσεις</translation>
+<translation id="1736419249208073774">Εξερεύνηση</translation>
+<translation id="7444811645081526538">Περισσότερες κατηγορίες</translation>
+<translation id="6709133671862442373">Ειδήσεις</translation>
+<translation id="1264974993859112054">Αθλητικά</translation>
+<translation id="9139318394846604261">Αγορές</translation>
+<translation id="3912508018559818924">Εύρεση των καλύτερων στον ιστό…</translation>
+<translation id="526421993248218238">Δεν είναι δυνατή η φόρτωση αυτής της σελίδας</translation>
+<translation id="614940544461990577">Δοκιμάστε να κάνετε τα εξής:</translation>
+<translation id="3288003805934695103">Επαναλάβετε τη φόρτωση της σελίδας</translation>
+<translation id="2353636109065292463">Έλεγχος της σύνδεσής σας στο διαδίκτυο</translation>
+<translation id="2858138569776157458">Κορ. ιστότοποι</translation>
+<translation id="8364299278605033898">Δείτε δημοφιλείς ιστοτόπους</translation>
+<translation id="1171770572613082465">Δείτε δημοφιλείς ιστοτόπους πατώντας το κουμπί "Κορυφαίοι ιστότοποι"</translation>
+<translation id="5233638681132016545">Νέα καρτέλα</translation>
+<translation id="4521874409998847950">Από <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>παρέχεται από την Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Διατίθεται νεότερη έκδοση</translation>
+<translation id="4058091506841967397">Αδύνατη ενημέρωση Brave</translation>
+<translation id="6316139424528454185">Μη υποστηρ. έκδοση Android</translation>
+<translation id="6989267951144302301">Δεν ήταν δυνατή η λήψη</translation>
+<translation id="624789221780392884">Έτοιμη ενημέρωση</translation>
+<translation id="1549000191223877751">Μεταβείτε σε άλλο παράθυρο</translation>
+<translation id="7481312909269577407">Προώθηση</translation>
+<translation id="4084682180776658562">Σελιδοδείκτης</translation>
+<translation id="6437478888915024427">Πληροφορίες σελίδας</translation>
+<translation id="7180611975245234373">Ανανέωση</translation>
+<translation id="4913169188695071480">Διακοπή ανανέωσης</translation>
+<translation id="1829244130665387512">Εύρεση στη σελίδα</translation>
+<translation id="6593061639179217415">Για υπολογιστή</translation>
+<translation id="9063523880881406963">Απενεργοποίηση αιτήματος ιστότοπου για υπολογιστές</translation>
+<translation id="2038563949887743358">Ενεργοποίηση αιτήματος ιστότοπου για υπολογιστές</translation>
+<translation id="2433507940547922241">Εμφάνιση</translation>
+<translation id="983192555821071799">Κλείσιμο όλων των καρτελών</translation>
+<translation id="1310482092992808703">Ομαδοποίηση καρτελών</translation>
+<translation id="7725024127233776428">Εδώ εμφανίζονται οι σελίδες στις οποίες προσθέτετε σελιδοδείκτη</translation>
+<translation id="4404568932422911380">Δεν υπάρχουν σελιδοδείκτες</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> σελιδοδείκτης}other{<ph name="BOOKMARKS_COUNT_MANY"/> σελιδοδείκτες}}</translation>
+<translation id="3739899004075612870">Ο σελιδοδείκτης προστέθηκε στο <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Προστέθηκε στους σελιδοδείκτες</translation>
+<translation id="4452548195519783679">Ο σελιδοδείκτης είναι στο "<ph name="FOLDER_NAME"/>"</translation>
+<translation id="8063895661287329888">Η προσθήκη του σελιδοδείκτη απέτυχε.</translation>
+<translation id="2842985007712546952">Γονικός φάκελος</translation>
+<translation id="9065203028668620118">Επεξεργασία</translation>
+<translation id="4405224443901389797">Μετακίνηση σε…</translation>
+<translation id="5170568018924773124">Εμφάνιση στο φάκελο</translation>
+<translation id="8035133914807600019">Νέος φάκελος…</translation>
+<translation id="4532845899244822526">Επιλογή φακέλου</translation>
+<translation id="6627583120233659107">Επεξεργασία φακέλου</translation>
+<translation id="1197267115302279827">Μετακίνηση σελιδοδεικτών</translation>
+<translation id="6963766334940102469">Διαγραφή σελιδοδεικτών</translation>
+<translation id="4351244548802238354">Κλείσιμο παραθύρου διαλόγου</translation>
+<translation id="451872707440238414">Αναζήτηση στους σελιδοδείκτες</translation>
+<translation id="8901170036886848654">Δεν βρέθηκαν σελιδοδείκτες</translation>
+<translation id="6404511346730675251">Επεξεργασία σελιδοδείκτη</translation>
+<translation id="3894427358181296146">Προσθήκη φακέλου…</translation>
+<translation id="5327248766486351172">Όνομα</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Φάκελος</translation>
+<translation id="5161254044473106830">Απαιτείται τίτλος</translation>
+<translation id="2996809686854298943">Απαιτείται διεύθυνση URL</translation>
+<translation id="2536728043171574184">Προβολή ενός αντιγράφου αυτής της σελίδας εκτός σύνδεσης</translation>
+<translation id="4698034686595694889">Προβολή εκτός σύνδεσης στο <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> και άλλους ιστοτόπους</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Το Brave θα φορτώσει τη σελίδα σας όταν είναι έτοιμη}other{Το Brave θα φορτώσει τις σελίδες σας όταν είναι έτοιμες}}</translation>
+<translation id="6811034713472274749">Σελίδα έτοιμη για προβολή</translation>
+<translation id="4561979708150884304">Δεν υπάρχει σύνδεση</translation>
+<translation id="8274165955039650276">Εμφάνιση λήψεων</translation>
+<translation id="2082238445998314030">Αποτέλεσμα <ph name="RESULT_NUMBER"/> από <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Δεν υπάρχουν αποτελέσματα</translation>
+<translation id="981121421437150478">Εκτός σύνδεσης</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Δεν έχει ενεργοποιηθεί φωνητ. αναζήτηση</translation>
+<translation id="7191430249889272776">Η καρτέλα άνοιξε στο παρασκήνιο.</translation>
+<translation id="8445059357334030806">Άνοιγμα στο Brave</translation>
+<translation id="4720023427747327413">Άνοιγμα σε <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Άνοιγμα σε πρόγρ. περιήγησης</translation>
+<translation id="1113597929977215864">Εμφάνιση απλοποιημένης προβολής</translation>
+<translation id="1513352483775369820">Σελιδοδείκτες και ιστορικό ιστού</translation>
+<translation id="4939482511480190003">Συμβάλλετε στη βελτίωση του Brave. <ph name="BEGIN_LINK"/>Λάβετε μέρος στην έρευνα<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Επιστροφή</translation>
+<translation id="5596627076506792578">Περισσότερες επιλογές</translation>
+<translation id="3522247891732774234">Διατίθεται μια ενημέρωση. Περισσότερες επιλογές</translation>
+<translation id="6773423637732432200">Δεν είναι δυνατή η ενημέρωση του Brave. Περισσότερες επιλογές</translation>
+<translation id="3328801116991980348">Πληροφορίες ιστοτόπου</translation>
+<translation id="5391532827096253100">Η σύνδεσή σας σε αυτόν τον ιστότοπο δεν είναι ασφαλής. Πληροφορίες ιστοτόπου</translation>
+<translation id="6206551242102657620">Η σύνδεση είναι ασφαλής. Πληροφορίες ιστοτόπου</translation>
+<translation id="6963642900430330478">Αυτή η σελίδα είναι επικίνδυνη. Πληροφορίες ιστοτόπου</translation>
+<translation id="9070377983101773829">Έναρξη φωνητικής αναζήτησης</translation>
+<translation id="8676374126336081632">Διαγραφή καταχώρισης</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> ανοιχτή καρτέλα, πατήστε για εναλλαγή καρτελών}other{<ph name="OPEN_TABS_MANY"/> ανοιχτές καρτέλες, πατήστε για εναλλαγή καρτελών}}</translation>
+<translation id="2369533728426058518">ανοικτές καρτέλες</translation>
+<translation id="7071521146534760487">Διαχείριση λογαριασμού</translation>
+<translation id="932327136139879170">Αρχική σελίδα</translation>
+<translation id="2707726405694321444">Ανανέωση σελίδας</translation>
+<translation id="2891154217021530873">Διακοπή φόρτωσης σελίδας</translation>
+<translation id="6710213216561001401">Προηγούμενο</translation>
+<translation id="6659594942844771486">Καρτέλα</translation>
+<translation id="1933845786846280168">Επιλεγμένη καρτέλα</translation>
+<translation id="2268044343513325586">Περιορισμός</translation>
+<translation id="7846076177841592234">Ακύρωση επιλογής</translation>
+<translation id="7087918508125750058">Επιλέχθηκαν <ph name="ITEM_COUNT"/>. Οι επιλογές είναι διαθέσιμες κοντά στο επάνω μέρος της οθόνης</translation>
+<translation id="7250468141469952378">Επιλέχθηκαν <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Κοινοποίηση 1 επιλεγμένου στοιχείου}other{Κοινοποίηση # επιλεγμένων στοιχείων}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Κατάργηση 1 επιλεγμένου στοιχείου}other{Κατάργηση # επιλεγμένων στοιχείων}}</translation>
+<translation id="1283039547216852943">Πατήστε για ανάπτυξη</translation>
+<translation id="5962718611393537961">Πατήστε για σύμπτυξη</translation>
+<translation id="8076492880354921740">Καρτέλες</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 επιλεγμένο}other{# επιλεγμένα}}</translation>
+<translation id="6818926723028410516">Επιλέξτε στοιχεία</translation>
+<translation id="4797039098279997504">Αγγίξτε για να επιστρέψετε στη διεύθυνση <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Πατήστε για μετάβαση στον ιστότοπο</translation>
+<translation id="429312253194641664">Ένας ιστότοπος κάνει αναπαραγωγή μέσων</translation>
+<translation id="4958708863221495346">Η καρτέλα <ph name="URL_OF_THE_CURRENT_TAB"/> μοιράζεται την οθόνη σας.</translation>
+<translation id="8833831881926404480">Κάποιος ιστότοπος μοιράζεται την οθόνη σας</translation>
+<translation id="9086455579313502267">Δεν είναι δυνατή η πρόσβαση στο δίκτυο</translation>
+<translation id="938850635132480979">Σφάλμα: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Άνοιγμα σε <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Άνοιγμα σε εφαρμογή χαρτών</translation>
+<translation id="7698359219371678927">Δημιουργία μηνύματος ηλεκτρονικού ταχυδρομείου στην εφαρμογή <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Δημιουργία μηνύματος ηλεκτρονικού ταχυδρομείου</translation>
+<translation id="5665379678064389456">Δημιουργία συμβάντος στην εφαρμογή <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Δημιουργία συμβάντος</translation>
+<translation id="2111511281910874386">Μετάβαση στη σελίδα</translation>
+<translation id="3988466920954086464">Προβολή αποτελεσμάτων αναζήτησης Instant σε αυτό το πλαίσιο</translation>
+<translation id="2744248271121720757">Πατήστε μια λέξη για άμεση αναζήτηση ή για να δείτε τις σχετικές ενέργειες</translation>
+<translation id="9155898266292537608">Επίσης, μπορείτε να κάνετε αναζήτηση με ένα γρήγορο πάτημα σε μια λέξη</translation>
+<translation id="3232754137068452469">Εφαρμογή ιστού</translation>
+<translation id="1430915738399379752">Εκτύπωση</translation>
+<translation id="3775705724665058594">Αποστολή στις συσκευές σας</translation>
+<translation id="6364438453358674297">Κατάργηση πρότασης από το ιστορικό;</translation>
+<translation id="213279576345780926">Η καρτέλα <ph name="TAB_TITLE"/> έκλεισε</translation>
+<translation id="6850830437481525139">Έκλεισαν <ph name="TAB_COUNT"/> καρτέλες</translation>
+<translation id="3211426585530211793">Το <ph name="ITEM_TITLE"/> διαγράφηκε</translation>
+<translation id="4663756553811254707">Διαγράφηκαν <ph name="NUMBER_OF_BOOKMARKS"/> σελιδοδείκτες</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> λήψεις διαγράφηκαν</translation>
+<translation id="1248710015876067820">Μη υποστηριζόμενος αριθμός παρουσιών Brave.</translation>
+<translation id="4259722352634471385">Αποκλείστηκε η μετάβαση στη διεύθυνση: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Δεν είναι δυνατή η μετάβαση στη διεύθυνση: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Κλείσιμο καρτέλας</translation>
+<translation id="7772375229873196092">Κλείσιμο <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Ιστορικό περιήγησης</translation>
+<translation id="9169507124922466868">Το ιστορικό πλοήγησης έχει ανοίξει κατά το ήμισυ</translation>
+<translation id="1327257854815634930">Το ιστορικό περιήγησης έχει ανοίξει</translation>
+<translation id="8788265440806329501">Το Ιστορικό πλοήγηση έκλεισε</translation>
+<translation id="7482656565088326534">Καρτέλα προεπισκόπησης</translation>
+<translation id="8427875596167638501">Η καρτέλα προεπισκόπησης έχει ανοίξει κατά το ήμισυ</translation>
+<translation id="9102803872260866941">Η καρτέλα προεπισκόπησης είναι ανοικτή</translation>
+<translation id="2942036813789421260">Η καρτέλα προεπισκόπησης είναι κλειστή</translation>
+<translation id="6355102470683871794">Αποθηκευτικός χώρος Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Διαγ.αποθ.χώρου ιστότ.;</translation>
+<translation id="9205995714227143200">Αποθηκευτικός χώρος ιστοτόπων που το Brave θεωρεί ότι δεν είναι σημαντικός (π.χ. ιστότοποι χωρίς αποθηκευμένες ρυθμίσεις ή που δεν επισκέπτεστε συχνά)</translation>
+<translation id="3997476611815694295">Ασήμαντος αποθηκευτικός χώρος</translation>
+<translation id="8493948351860045254">Ελευθερώστε χώρο</translation>
+<translation id="2324920234469020158">Αυτό θα διαγράψει τα cookie, την κρυφή μνήμη και άλλα δεδομένα ιστοτόπων που το Brave θεωρεί ότι δεν είναι σημαντικά.</translation>
+<translation id="5447201525962359567">Όλος ο αποθηκευτικός χώρος ιστοτόπων, συμπεριλαμβανομένων των cookie και άλλων τοπικά αποθηκευμένων δεδομένων</translation>
+<translation id="1376578503827013741">Υπολογισμός…</translation>
+<translation id="583281660410589416">Άγνωστο</translation>
+<translation id="2323763861024343754">Αποθηκ. χώρος ιστοσελίδας</translation>
+<translation id="3587672679800759167">Σύνολο δεδομένων που χρησιμοποιούνται από το Brave, συμπεριλαμβανομένων των λογαριασμών, των σελιδοδεικτών και των αποθηκευμένων ρυθμίσεων</translation>
+<translation id="6545017243486555795">Διαγραφή όλων των δεδομένων</translation>
+<translation id="4095146165863963773">Διαγραφή δεδομένων εφαρμογών;</translation>
+<translation id="53119194224775367">Όλα τα δεδομένα εφαρμογών του Brave θα διαγραφούν οριστικά. Σε αυτά περιλαμβάνονται όλα τα αρχεία, οι ρυθμίσεις, οι λογαριασμοί, οι βάσεις δεδομένων, κ.λπ.</translation>
+<translation id="5307446750509046227">Διαγ.αποθ.χώρου ιστότ.</translation>
+<translation id="300526633675317032">Αυτό θα διαγράψει και τα <ph name="SIZE_IN_KB"/> του αποθηκευτικού χώρου ιστοτόπων.</translation>
+<translation id="8068648041423924542">Δεν είναι δυνατή η επιλογή του πιστοποιητικού.</translation>
+<translation id="2315043854645842844">Η επιλογή πιστοποιητικού από τον πελάτη δεν υποστηρίζεται από το λειτουργικό σύστημα.</translation>
+<translation id="5011311129201317034">Ο ιστότοπος <ph name="SITE"/> επιθυμεί σύνδεση</translation>
+<translation id="5308380583665731573">Σύνδεση</translation>
+<translation id="868929229000858085">Αναζήτηση στις επαφές σας</translation>
+<translation id="1919950603503897840">Επιλογή επαφών</translation>
+<translation id="7986741934819883144">Επιλογή επαφής</translation>
+<translation id="3333961966071413176">Όλες οι επαφές</translation>
+<translation id="4994033804516042629">Δεν βρέθηκαν επαφές</translation>
+<translation id="5403592356182871684">Ονόματα</translation>
+<translation id="2717722538473713889">Διευθύνσεις ηλεκτρονικού ταχυδρομείου</translation>
+<translation id="381841723434055211">Αριθμοί τηλεφώνου</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ακόμη)}other{(+ # ακόμη)}}</translation>
+<translation id="5197729504361054390">Οι επαφές που επιλέγετε θα κοινοποιηθούν στον ιστότοπο <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Εργαλείο αποκωδικοποίησης εικόνων</translation>
+<translation id="8067883171444229417">Αναπαραγωγή βίντεο</translation>
+<translation id="6560414384669816528">Αναζήτηση με το Sogou</translation>
+<translation id="5406914950576900927">Το Brave μπορεί να χρησιμοποιήσει το <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> για την αναζήτηση στην Κίνα. Μπορείτε να αλλάξετε αυτήν την επιλογή στις <ph name="BEGIN_LINK"/>Ρυθμίσεις<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Διατήρηση του Brave Software</translation>
+<translation id="4384468725000734951">Χρήση του Sogou για αναζήτηση</translation>
+<translation id="6103327872225198548">Χρήση του Brave Software για αναζήτηση</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Αυτή η εφαρμογή εκτελείται στο Brave</translation>
+<translation id="6143689084714664628">Εκτέλεση στο Brave</translation>
+<translation id="7675869148432102528">Η εφαρμογή <ph name="APP_NAME"/> έχει επίσης δεδομένα στο Brave</translation>
+<translation id="2734140769649165081">Μπορείτε να διαγράψετε τα δεδομένα στις ρυθμίσεις του Brave</translation>
+<translation id="8232956427053453090">Διατήρηση δεδομένων</translation>
+<translation id="4298388696830689168">Συνδεδεμένοι ιστότοποι</translation>
+<translation id="5763514718066511291">Πατήστε για αντιγραφή του URL για αυτήν την εφαρμογή</translation>
+<translation id="6496823230996795692">Για να χρησιμοποιήσετε την εφαρμογή <ph name="APP_NAME"/> για πρώτη φορά, συνδεθείτε στο διαδίκτυο.</translation>
+<translation id="751961395872307827">Δεν είναι δυνατή η σύνδεση στον ιστότοπο</translation>
+<translation id="4878404682131129617">Η δημιουργία διοχέτευσης μέσω διακομιστή μεσολάβησης απέτυχε</translation>
+<translation id="4749960740855309258">Άνοιγμα νέας καρτέλας</translation>
+<translation id="8788968922598763114">Εκ νέου άνοιγμα της καρτέλας που έκλεισε τελευταία</translation>
+<translation id="7929962904089429003">Άνοιγμα μενού</translation>
+<translation id="6039379616847168523">Μετάβαση στην επόμενη καρτέλα</translation>
+<translation id="5210286577605176222">Μετάβαση στην προηγούμενη καρτέλα</translation>
+<translation id="124678866338384709">Κλείσιμο τρέχουσας καρτέλας</translation>
+<translation id="3714981814255182093">Άνοιγμα της γραμμής εύρεσης</translation>
+<translation id="5441522332038954058">Μετάβαση στη γραμμή διευθύνσεων</translation>
+<translation id="3398320232533725830">Άνοιγμα του διαχειριστή σελιδοδεικτών</translation>
+<translation id="6583199322650523874">Προσθήκη σελιδοδείκτη στην τρέχουσα σελίδα</translation>
+<translation id="8489271220582375723">Άνοιγμα σελίδας "Ιστορικό"</translation>
+<translation id="4837753911714442426">Άνοιγμα επιλογών για την εκτύπωση της σελίδας</translation>
+<translation id="5726692708398506830">Μεγέθυνση όλων των στοιχείων της σελίδας</translation>
+<translation id="3259831549858767975">Σμίκρυνση όλων των στοιχείων της σελίδας</translation>
+<translation id="8015452622527143194">Επαναφορά στοιχείων σελίδας σε κανονικό μέγεθος</translation>
+<translation id="3443221991560634068">Επαναφόρτωση της τρέχουσας σελίδας</translation>
+<translation id="123724288017357924">Επαναφ. τρέχ.σελ. αγνοώντας το περιεχ. κρυφ.μνήμης</translation>
+<translation id="305870044889644984">Άνοιγμα Κέντρου βοήθειας Brave σε νέα καρτέλα</translation>
+<translation id="3166827708714933426">Συντομεύσεις καρτέλας και παραθύρου</translation>
+<translation id="3169981355900570544">Συντομεύσεις λειτουργιών Brave Software Brave</translation>
+<translation id="4558311620361989323">Συντομεύσεις ιστοσελίδας</translation>
+<translation id="1908301351964700579">Το Brave εξακολουθεί να προετοιμάζεται για VR. Επανεκκίνηση Brave αργότερα.</translation>
+<translation id="8970887620466824814">Προέκυψε πρόβλημα.</translation>
+<translation id="1875543012935658554">Ανοίξτε ξανά το Brave.</translation>
+<translation id="79859296434321399">Για να δείτε περιεχόμενο επαυξημένης πραγματικότητας, εγκαταστήστε το ARCore</translation>
+<translation id="8558485628462305855">Για να δείτε περιεχόμενο επαυξημένης πραγματικότητας, ενημερώστε το ARCore</translation>
+<translation id="3513704683820682405">Επαυξημένη πραγματικότητα</translation>
+<translation id="5475862044948910901">Έναρξη περιόδου λειτουργίας επαυξημένης πραγματικότητας;</translation>
 <translation id="7365126855094612066">Για τη διάρκεια αυτής της περιόδου λειτουργίας, ο ιστότοπος θα μπορεί να:
 • δημιουργεί έναν τρισδιάστατο χάρτη του περιβάλλοντός σας
 • παρακολουθεί την κίνηση της κάμερας
 
 Ο ιστότοπος ΔΕΝ αποκτά πρόσβαση στην κάμερα. Μόνο εσείς μπορείτε να δείτε τις εικόνες της κάμερας.</translation>
-<translation id="7375125077091615385">Τύπος:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Εμπειρία πρώτης εκτέλεσης Chrome</translation>
-<translation id="741204030948306876">Ναι, συμφωνώ</translation>
-<translation id="7413229368719586778">Ημερομηνία έναρξης: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Να γίνεται ερώτηση πρώτα</translation>
-<translation id="7423538860840206698">Αποκλεισμός από ανάγνωση πρόχειρου</translation>
-<translation id="7431991332293347422">Ελέγξτε τον τρόπο με τον οποίο χρησιμοποιείται το ιστορικό περιήγησής σας για την εξατομίκευση της Αναζήτησης και άλλων λειτουργιών</translation>
-<translation id="7437998757836447326">Αποσύνδεση από το Chrome</translation>
-<translation id="7438641746574390233">Όταν η λειτουργία Lite είναι ενεργοποιημένη, το Chrome χρησιμοποιεί διακομιστές της Google για να επιταχύνει τη φόρτωση των σελίδων. Η λειτουργία Lite επανεγγράφει τις πολύ αργές σελίδες έτσι ώστε να φορτώνεται μόνο το απαραίτητο περιεχόμενο. Η λειτουργία Lite δεν εφαρμόζεται σε καρτέλες ανώνυμης περιήγησης.</translation>
-<translation id="7444811645081526538">Περισσότερες κατηγορίες</translation>
-<translation id="7445411102860286510">Να επιτρέπεται στους ιστότοπους η αυτόματη αναπαραγωγή βίντεο σε σίγαση (συνιστάται)</translation>
-<translation id="7453467225369441013">Θα αποσυνδεθείτε από τους περισσότερους ιστοτόπους. Δεν θα αποσυνδεθείτε από τον Λογαριασμό σας Google.</translation>
-<translation id="7454641608352164238">Ανεπαρκής χώρος</translation>
-<translation id="7475192538862203634">Εάν αυτό το μήνυμα εμφανίζεται συχνά, δοκιμάστε αυτές τις <ph name="BEGIN_LINK" />προτάσεις<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Η κάρτα SD δεν βρέθηκε. Μπορεί να λείπουν μερικά από τα αρχεία σας.</translation>
-<translation id="7479104141328977413">Διαχείριση καρτέλας</translation>
-<translation id="7481312909269577407">Προώθηση</translation>
-<translation id="7482656565088326534">Καρτέλα προεπισκόπησης</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Ενημέρωση στις <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">δεδομένα που εξοικονομήθηκαν</translation>
-<translation id="7498271377022651285">Περιμένετε…</translation>
-<translation id="7514365320538308">Λήψη</translation>
-<translation id="751961395872307827">Δεν είναι δυνατή η σύνδεση στον ιστότοπο</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Δεν είναι δυνατή η λήψη προτάσεων</translation>
-<translation id="7559975015014302720">Η λειτουργία Lite είναι απενεργοποιημένη</translation>
-<translation id="7562080006725997899">Διαγραφή δεδομένων περιήγησης</translation>
-<translation id="756809126120519699">Τα δεδομένα του Chrome διαγράφηκαν</translation>
-<translation id="757524316907819857">Αποκλεισμός αναπαραγωγής προστατευόμενου περιεχομένου από ιστοτόπους</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Έγινε λήψη <ph name="FILES_DOWNLOADED_ONE" /> αρχείου}other{Έγινε λήψη <ph name="FILES_DOWNLOADED_MANY" /> αρχείων}}</translation>
-<translation id="7588219262685291874">Ενεργοποιήστε το σκούρο θέμα όταν η λειτουργία εξοικονόμησης μπαταρίας της συσκευής σας είναι ενεργοποιημένη.</translation>
-<translation id="7589445247086920869">Αποκλεισμός για την τρέχουσα μηχανή αναζήτησης</translation>
-<translation id="7593557518625677601">Ανοίξτε Ρυθμίσεις Android και ενεργοποιήστε τον συγχρ. συστ. Android για έναρξη Συγχρ. Chrome</translation>
-<translation id="7596558890252710462">Λειτουργικό σύστημα</translation>
-<translation id="7605594153474022051">Ο συγχρονισμός δεν λειτουργεί</translation>
-<translation id="7606077192958116810">Η λειτουργία Lite είναι ενεργοποιημένη. Διαχειριστείτε τη από τις Ρυθμίσεις.</translation>
-<translation id="7612619742409846846">Έχετε συνδεθεί στο Google ως</translation>
-<translation id="7619072057915878432">Η λήψη του αρχείου <ph name="FILE_NAME" /> απέτυχε λόγω προβλημάτων στο δίκτυο.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Λήψη βοήθειας<ph name="END_LINK1" /> ή <ph name="BEGIN_LINK2" />επανάληψη σάρωσης<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Καλώς ήρθατε στο Chrome</translation>
-<translation id="7638584964844754484">Εσφαλμένη φράση πρόσβασης</translation>
-<translation id="7641339528570811325">Διαγραφή δεδομένων περιήγησης…</translation>
-<translation id="7648422057306047504">Κρυπτογράφηση κωδικών πρόσβασης με τα διαπιστευτήριά σας Google.</translation>
-<translation id="7649070708921625228">Βοήθεια</translation>
-<translation id="7658239707568436148">Ακύρωση</translation>
-<translation id="7665369617277396874">Προσθήκη λογαριασμού</translation>
-<translation id="766587987807204883">Εδώ εμφανίζονται άρθρα τα οποία μπορείτε να διαβάσετε ακόμη και εκτός σύνδεσης</translation>
-<translation id="7682724950699840886">Δοκιμάστε τις παρακάτω συμβουλές: Βεβαιωθείτε ότι υπάρχει αρκετός χώρος στη συσκευή σας. Δοκιμάστε να επαναλάβετε την εξαγωγή.</translation>
-<translation id="7685301384041462804">Βεβαιωθείτε ότι εμπιστεύεστε αυτόν τον ιστότοπο προτού ενεργοποιήσετε τη λειτουργία VR.</translation>
-<translation id="7698359219371678927">Δημιουργία μηνύματος ηλεκτρονικού ταχυδρομείου στην εφαρμογή <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Αυτόματη συμπλήρωση αναζητήσεων και URL</translation>
-<translation id="7725024127233776428">Εδώ εμφανίζονται οι σελίδες στις οποίες προσθέτετε σελιδοδείκτη</translation>
-<translation id="773466115871691567">Να μεταφράζονται πάντα οι σελίδες προς τα <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Για τον εντοπισμό επικίνδυνων εφαρμογών και ιστοτόπων, το Chrome στέλνει URL ορισμένων ιστοτόπων που επισκέπτεστε, περιορισμένες πληροφορίες συστήματος και ένα μέρος του περιεχομένου σελίδας στο Google</translation>
-<translation id="7757787379047923882">Το κείμενο κοινοποιήθηκε από τη συσκευή <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Κάρτα SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Προσθήκη διεύθυνσης</translation>
-<translation id="7772032839648071052">Επιβεβαίωση φράσης πρόσβασης</translation>
-<translation id="7772375229873196092">Κλείσιμο <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ακόμη}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 και <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ακόμη}}</translation>
-<translation id="7781829728241885113">Χθες</translation>
-<translation id="7791543448312431591">Προσθήκη</translation>
-<translation id="780301667611848630">Όχι, ευχαριστώ</translation>
-<translation id="7810647596859435254">Άνοιγμα με…</translation>
-<translation id="7821588508402923572">Η εξοικονόμηση δεδομένων σας θα εμφανίζεται εδώ</translation>
-<translation id="7837721118676387834">Να επιτρέπεται η αυτόματη αναπαραγωγή βίντεο που έχουν τεθεί σε σίγαση για έναν συγκεκριμένο ιστότοπο.</translation>
-<translation id="7846076177841592234">Ακύρωση επιλογής</translation>
-<translation id="784934925303690534">Χρονικό εύρος</translation>
-<translation id="7851858861565204677">Άλλες συσκευές</translation>
-<translation id="7875915731392087153">Δημιουργία μηνύματος ηλεκτρονικού ταχυδρομείου</translation>
-<translation id="7876243839304621966">Κατάργηση όλων</translation>
-<translation id="7882131421121961860">Δεν βρέθηκε ιστορικό</translation>
-<translation id="7882806643839505685">Να επιτρέπεται ο ήχος για έναν συγκεκριμένο ιστότοπο.</translation>
-<translation id="7886917304091689118">Εκτέλεση στο Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Λήψη αρχείου.}other{Λήψη # αρχείων.}}</translation>
-<translation id="7929962904089429003">Άνοιγμα μενού</translation>
-<translation id="7942131818088350342">Το <ph name="PRODUCT_NAME" /> δεν είναι ενημερωμένο.</translation>
-<translation id="7947953824732555851">Αποδοχή και σύνδεση</translation>
-<translation id="7963646190083259054">Πάροχος υπηρεσιών:</translation>
-<translation id="7971136598759319605">Ενεργή 1 ημέρα πριν</translation>
-<translation id="7975379999046275268">Προεπισκόπηση σελίδας <ph name="BEGIN_NEW" />Νέο<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Προφόρτωση ιστοσελίδων για ταχύτερη περιήγηση και αναζήτηση</translation>
-<translation id="79859296434321399">Για να δείτε περιεχόμενο επαυξημένης πραγματικότητας, εγκαταστήστε το ARCore</translation>
-<translation id="7986741934819883144">Επιλογή επαφής</translation>
-<translation id="7987073022710626672">Όροι Παροχής Υπηρεσιών Chrome</translation>
-<translation id="7998918019931843664">Εκ νέου άνοιγμα κλειστής καρτέλας</translation>
-<translation id="7999064672810608036">Είστε βέβαιοι ότι θέλετε να διαγράψετε όλα τα δεδομένα γι' αυτόν τον ιστότοπο, όπως τα cookie, και να επαναφέρετε όλα τα δικαιώματά του;</translation>
-<translation id="8004582292198964060">Πρόγραμμα περιήγησης</translation>
-<translation id="8007176423574883786">Έχει απενεργοποιηθεί για αυτήν τη συσκευή</translation>
-<translation id="8013372441983637696">Επίσης, να διαγραφούν τα δεδομένα Chrome από αυτήν τη συσκευή.</translation>
-<translation id="8015452622527143194">Επαναφορά στοιχείων σελίδας σε κανονικό μέγεθος</translation>
-<translation id="802154636333426148">Η λήψη απέτυχε</translation>
-<translation id="8026334261755873520">Διαγραφή δεδομένων περιήγησης</translation>
-<translation id="8035133914807600019">Νέος φάκελος…</translation>
-<translation id="8037750541064988519">Απομένουν <ph name="DAYS" /> ημέρες</translation>
-<translation id="804335162455518893">Δεν βρέθηκε κάρτα SD</translation>
-<translation id="805047784848435650">Βάσει του ιστορικού περιήγησής σας</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB διαθέσιμα</translation>
-<translation id="8058746566562539958">Άνοιγμα σε νέα καρτέλα Chrome</translation>
-<translation id="8063895661287329888">Η προσθήκη του σελιδοδείκτη απέτυχε.</translation>
-<translation id="806745655614357130">Διατήρηση των δεδομένων μου ξεχωριστά</translation>
-<translation id="8067883171444229417">Αναπαραγωγή βίντεο</translation>
-<translation id="8068648041423924542">Δεν είναι δυνατή η επιλογή του πιστοποιητικού.</translation>
-<translation id="8073388330009372546">Άνοιγμα εικόνας σε νέα καρτέλα</translation>
-<translation id="8076492880354921740">Καρτέλες</translation>
-<translation id="8084114998886531721">Αποθηκευμένος κωδικός πρόσβασης</translation>
-<translation id="8087000398470557479">Αυτό το περιεχόμενο προέρχεται από το <ph name="DOMAIN_NAME" /> και παρέχεται από την Google.</translation>
-<translation id="8103578431304235997">Καρτέλα ανώνυμης περιήγησης</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Για να εμφανίζονται οι σελιδοδείκτες σας σε όλες τις συσκευές σας, ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="8110087112193408731">Να εμφανίζεται στο Digital Wellbeing η δραστηριότητά σας στο Chrome;</translation>
-<translation id="8116925261070264013">Σε σίγαση</translation>
-<translation id="813082847718468539">Προβολή πληροφοριών τοποθεσίας</translation>
-<translation id="8131740175452115882">Επιβεβαίωση</translation>
-<translation id="8156139159503939589">Σε ποιες γλώσσες μπορείτε να διαβάσετε;</translation>
-<translation id="8168435359814927499">Περιεχόμενο</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> αρχεία απομένουν</translation>
-<translation id="8190358571722158785">Απομένει 1 ημέρα</translation>
-<translation id="8200772114523450471">Συνέχιση</translation>
-<translation id="8209050860603202033">Άνοιγμα εικόνας</translation>
-<translation id="8218622182176210845">Διαχείριση του λογαριασμού σας</translation>
-<translation id="8224471946457685718">Λήψη άρθρων για εσάς στο Wi-Fi</translation>
-<translation id="8232956427053453090">Διατήρηση δεδομένων</translation>
-<translation id="8249310407154411074">Μετακίνηση επάνω</translation>
-<translation id="8250920743982581267">Έγγραφα</translation>
-<translation id="825412236959742607">Αυτή η σελίδα χρησιμοποιεί πάρα πολλή μνήμη. Για αυτόν τον λόγο, το Chrome κατάργησε κάποιο περιεχόμενο.</translation>
-<translation id="8260126382462817229">Δοκιμάστε να συνδεθείτε ξανά</translation>
-<translation id="8261506727792406068">Διαγραφή</translation>
-<translation id="8266862848225348053">Τοποθεσία λήψης</translation>
-<translation id="8274165955039650276">Εμφάνιση λήψεων</translation>
-<translation id="8284326494547611709">Υπότιτλοι</translation>
-<translation id="8300705686683892304">Διαχείριση από εφαρμογή</translation>
-<translation id="8310344678080805313">Τυπικές καρτέλες</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> και άλλους ιστοτόπους</translation>
-<translation id="8327155640814342956">Για την καλύτερη δυνατή εμπειρία περιήγησης, ανοίξτε το Chrome για να το ενημερώσετε</translation>
-<translation id="8339163506404995330">Οι σελίδες στα <ph name="LANGUAGE" /> δεν θα μεταφράζονται</translation>
-<translation id="8349013245300336738">Ταξινόμηση κατά όγκο δεδομένων που χρησιμοποιήθηκαν</translation>
-<translation id="8364299278605033898">Δείτε δημοφιλείς ιστοτόπους</translation>
-<translation id="8368027906805972958">Άγνωστη ή μη υποστηριζόμενη συσκευή (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Να επιτρέπεται ο Συγχρονισμός παρασκηνίου για έναν συγκεκριμένο ιστότοπο.</translation>
-<translation id="8378714024927312812">Διαχειριζόμενο από τον οργανισμό σας</translation>
-<translation id="8380167699614421159">Αυτός ο ιστότοπος εμφανίζει παρεμβατικές ή παραπλανητικές διαφημίσεις</translation>
-<translation id="8393700583063109961">Αποστολή μηνύματος</translation>
-<translation id="8413126021676339697">Εμφάνιση πλήρους ιστορικού</translation>
-<translation id="8427875596167638501">Η καρτέλα προεπισκόπησης έχει ανοίξει κατά το ήμισυ</translation>
-<translation id="8428213095426709021">Ρυθμίσεις</translation>
-<translation id="8438566539970814960">Βελτιώστε τις αναζητήσεις και την περιήγηση</translation>
-<translation id="8441146129660941386">Αναζήτηση προς τα πίσω</translation>
-<translation id="8443209985646068659">Αδύνατη ενημέρωση Chrome</translation>
-<translation id="8445448999790540984">Δεν είναι δυνατή η εξαγωγή κωδικών πρόσβασης</translation>
-<translation id="8447861592752582886">Ανάκληση άδειας συσκευής</translation>
-<translation id="8461694314515752532">Κρυπτογράφηση συγχρονισμένων δεδομένων με τη δική σας φράση πρόσβασης συγχρονισμού</translation>
-<translation id="8466613982764129868">Βεβαιωθείτε ότι η συσκευή <ph name="TARGET_DEVICE_NAME" /> είναι συνδεδεμένη στο διαδίκτυο.</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Διαθέσιμο εκτός σύνδεσης</translation>
-<translation id="8489271220582375723">Άνοιγμα σελίδας "Ιστορικό"</translation>
-<translation id="8493948351860045254">Ελευθερώστε χώρο</translation>
-<translation id="8497726226069778601">Δεν υπάρχει τίποτα να δείτε εδώ…ακόμη</translation>
-<translation id="8503559462189395349">Κωδικοί πρόσβασης Chrome</translation>
-<translation id="8503813439785031346">Όνομα χρήστη</translation>
-<translation id="8514477925623180633">Εξαγωγή κωδικών πρόσβασης που έχουν αποθηκευτεί στο Chrome</translation>
-<translation id="8514577642972634246">Είσοδος στην κατάσταση ανώνυμης περιήγησης</translation>
-<translation id="851751545965956758">Αποκλεισμός ιστοτόπων από τη σύνδεση σε συσκευές</translation>
-<translation id="8523928698583292556">Διαγραφή αποθηκευμένου κωδικού πρόσβασης</translation>
-<translation id="854522910157234410">Άνοιγμα αυτής της σελίδας</translation>
-<translation id="8558485628462305855">Για να δείτε περιεχόμενο επαυξημένης πραγματικότητας, ενημερώστε το ARCore</translation>
-<translation id="8559990750235505898">Προσφορά για μετάφραση σελίδων που είναι σε άλλη γλώσσα</translation>
-<translation id="8562452229998620586">Οι αποθηκευμένοι κωδικοί πρόσβασής σας θα εμφανιστούν εδώ.</translation>
-<translation id="8569404424186215731">από <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Τελευταίες 4 εβδομάδες</translation>
-<translation id="857943718398505171">Επιτρέπεται (συνιστάται)</translation>
-<translation id="8583805026567836021">Διαγραφή δεδομένων λογαριασμού</translation>
-<translation id="860043288473659153">Όνομα κατόχου κάρτας</translation>
-<translation id="8609465669617005112">Μετακίνηση προς τα επάνω</translation>
-<translation id="8616006591992756292">Ο Λογαριασμός σας Google ενδέχεται να διαθέτει άλλες μορφές ιστορικού περιήγησης στη διεύθυνση <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Άνοιγμα της προτεινόμενης διεύθυνσης URL που καθορίζεται στο ληφθέν περιεχόμενο;</translation>
-<translation id="8636825310635137004">Για να εμφανίζονται οι καρτέλες από τις άλλες συσκευές σας, ενεργοποιήστε τον συγχρονισμό.</translation>
-<translation id="8641930654639604085">Δοκιμάστε να αποκλείσετε τους ιστοτόπους με περιεχόμενο για ενηλίκους</translation>
-<translation id="8655129584991699539">Μπορείτε να διαγράψετε τα δεδομένα στις ρυθμίσεις του Chrome</translation>
-<translation id="8662811608048051533">Θα αποσυνδεθείτε από τους περισσότερους ιστοτόπους.</translation>
-<translation id="8664979001105139458">Το αρχείο υπάρχει ήδη</translation>
-<translation id="8676374126336081632">Διαγραφή καταχώρισης</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Επίπεδο ισχύος σήματος: # γραμμή}other{Επίπεδο ισχύος σήματος: # γραμμές}}</translation>
-<translation id="868929229000858085">Αναζήτηση στις επαφές σας</translation>
-<translation id="869891660844655955">Ημερομηνία λήξης</translation>
-<translation id="8719023831149562936">Δεν είναι δυνατή η ζεύξη της τρέχουσας καρτέλας</translation>
-<translation id="8725066075913043281">Προσπαθήστε ξανά</translation>
-<translation id="8728487861892616501">Χρησιμοποιώντας αυτήν την εφαρμογή, συμφωνείτε με τους <ph name="BEGIN_LINK1" />Όρους Παροχής Υπηρεσιών<ph name="END_LINK1" /> και τη <ph name="BEGIN_LINK2" />Σημείωση απορρήτου<ph name="END_LINK2" /> του Chrome, καθώς και με τη <ph name="BEGIN_LINK3" />Σημείωση απορρήτου για Λογαριασμούς Google, των οποίων η διαχείριση γίνεται μέσω του Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Ολοκληρώθηκε</translation>
-<translation id="8748850008226585750">Κρυφό περιεχόμενο</translation>
-<translation id="8751914237388039244">Επιλογή εικόνας</translation>
-<translation id="8788265440806329501">Το Ιστορικό πλοήγηση έκλεισε</translation>
-<translation id="8788968922598763114">Εκ νέου άνοιγμα της καρτέλας που έκλεισε τελευταία</translation>
-<translation id="8801436777607969138">Αποκλεισμός JavaScript για κάποιο συγκεκριμένο ιστότοπο.</translation>
-<translation id="8812260976093120287">Σε ορισμένους ιστοτόπους, μπορείτε να πληρώσετε χρησιμοποιώντας τις παραπάνω υποστηριζόμενες εφαρμογές πληρωμών στη συσκευή σας.</translation>
-<translation id="8816026460808729765">Αποκλεισμός πρόσβασης στους αισθητήρες από ιστοτόπους</translation>
-<translation id="8816439037877937734">Η εφαρμογή <ph name="APP_NAME" /> θα ανοίξει στο Chrome. Εάν συνεχίσετε, συμφωνείτε με τους <ph name="BEGIN_LINK1" />Όρους Παροχής Υπηρεσιών<ph name="END_LINK1" /> και τη <ph name="BEGIN_LINK2" />Σημείωση απορρήτου<ph name="END_LINK2" /> του Chrome, καθώς και με τη <ph name="BEGIN_LINK3" />Σημείωση απορρήτου για Λογαριασμούς Google των οποίων η διαχείριση γίνεται μέσω του Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Σελιδοδείκτες</translation>
-<translation id="8833831881926404480">Κάποιος ιστότοπος μοιράζεται την οθόνη σας</translation>
-<translation id="883806473910249246">Παρουσιάστηκε σφάλμα κατά τη λήψη του περιεχομένου.</translation>
-<translation id="8840953339110955557">Αυτή η σελίδα μπορεί να διαφέρει από την έκδοση στο διαδίκτυο.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Καρτέλα <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Αποθήκευση</translation>
-<translation id="889338405075704026">Μεταβείτε στις ρυθμίσεις του Chrome</translation>
-<translation id="8901170036886848654">Δεν βρέθηκαν σελιδοδείκτες</translation>
-<translation id="8909135823018751308">Κοινοποίηση…</translation>
-<translation id="8912362522468806198">Λογαριασμός Google</translation>
-<translation id="8920114477895755567">Αναμονή για λεπτομέρειες γονέων.</translation>
+<translation id="1188239144602654184">Έναρξη AR</translation>
+<translation id="473775607612524610">Ενημέρωση</translation>
+<translation id="3133489217401741157">Εγκατάσταση <ph name="MODULE"/> για το Brave…</translation>
+<translation id="1791662854739702043">Εγκατεστημένο</translation>
+<translation id="5131234170665854056">Δεν είναι δυνατή η εγκατάσταση του <ph name="MODULE"/> για το Brave</translation>
+<translation id="2567385386134582609">ΕΙΚΟΝΑ</translation>
+<translation id="6395288395575013217">ΣΥΝΔΕΣΜΟΣ</translation>
+<translation id="7352939065658542140">ΒΙΝΤΕΟ</translation>
+<translation id="4116038641877404294">Κατεβάστε σελίδες για να τις χρησιμοποιήσετε εκτός σύνδεσης</translation>
 <translation id="8922289737868596582">Κατεβάστε σελίδες από το κουμπί "Περισσότερες επιλογές" για να τις χρησιμοποιήσετε εκτός σύνδεσης</translation>
-<translation id="8937772741022875483">Να καταργηθεί η δραστηριότητα του Chrome από το Digital Wellbeing;</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Άνοιγμα σε άλλο παράθυρο</translation>
-<translation id="8951232171465285730">Το Chrome έχει εξοικονομήσει <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Αποκλεισμός cookie για έναν συγκεκριμένο ιστοτόπο.</translation>
-<translation id="8959122750345127698">Δεν είναι δυνατή η μετάβαση στη διεύθυνση: <ph name="URL" /></translation>
-<translation id="8965591936373831584">σε εκκρεμότητα</translation>
-<translation id="8970887620466824814">Προέκυψε πρόβλημα.</translation>
-<translation id="8972098258593396643">Λήψη στον προεπιλεγμένο φάκελο;</translation>
-<translation id="8986494364107987395">Αυτόματη αποστολή στατιστικών στοιχείων χρήσης και αναφορών σφαλμάτων στην Google</translation>
-<translation id="8993760627012879038">Άνοιγμα καρτέλας σε κατάσταση ανώνυμης περιήγησης</translation>
-<translation id="8998729206196772491">Πρόκειται να συνδεθείτε με έναν λογαριασμό του οποίου η διαχείριση γίνεται από <ph name="MANAGED_DOMAIN" /> και παραχωρείτε στον διαχειριστή του τον έλεγχο της διαχείρισης των δεδομένων σας στο Chrome. Τα δεδομένα σας θα συσχετιστούν οριστικά με αυτόν τον λογαριασμό. Η αποσύνδεση από το Chrome θα διαγράψει τα δεδομένα σας από αυτήν τη συσκευή, αλλά θα διατηρηθούν αποθηκευμένα στον Λογαριασμό σας Google.</translation>
-<translation id="9019902583201351841">Διαχειρίζεται από τους γονείς σου</translation>
-<translation id="9028914725102941583">Ενεργοποιήστε τον συγχρονισμό για κοινοποίηση μεταξύ συσκευών.</translation>
-<translation id="9029323097866369874">Να επιτρέπεται στον τομέα <ph name="DOMAIN" /> η ενεργοποίηση της λειτουργίας VR;</translation>
-<translation id="9040142327097499898">Οι ειδοποιήσεις επιτρέπονται. Η Τοποθεσία είναι απενεργοποιημένη σε αυτήν τη συσκευή.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Βίντεο}other{# Βίντεο}}</translation>
-<translation id="9050666287014529139">Φράση πρόσβασής σας</translation>
-<translation id="9063523880881406963">Απενεργοποίηση αιτήματος ιστότοπου για υπολογιστές</translation>
-<translation id="9065203028668620118">Επεξεργασία</translation>
-<translation id="9070377983101773829">Έναρξη φωνητικής αναζήτησης</translation>
-<translation id="9074336505530349563">Για λήψη εξατομικευμένου περιεχομένου που προτείνεται από την Google, συνδεθείτε και ενεργοποιήστε τον συγχρονισμό</translation>
-<translation id="9086455579313502267">Δεν είναι δυνατή η πρόσβαση στο δίκτυο</translation>
-<translation id="9100505651305367705">Προσφορά για προβολή άρθρων σε απλοποιημένη προβολή, όταν υποστηρίζεται</translation>
-<translation id="9100610230175265781">Απαιτείται φράση πρόσβασης</translation>
-<translation id="9102803872260866941">Η καρτέλα προεπισκόπησης είναι ανοικτή</translation>
+<translation id="5958275228015807058">Βρείτε τα αρχεία και τις σελίδες σας στις Λήψεις</translation>
+<translation id="5620928963363755975">Βρείτε τα αρχεία και τις σελίδες σας στις Λήψις από το κουμπί Περισσότερες επιλογές</translation>
+<translation id="3341058695485821946">Δείτε πόσα δεδομένα έχετε εξοικονομήσει</translation>
+<translation id="3157842584138209013">Δείτε πόσα δεδομένα έχετε αποθηκεύσει από το κουμπί "Περισσότερες επιλογές"</translation>
+<translation id="8218622182176210845">Διαχείριση του λογαριασμού σας</translation>
+<translation id="8090895580117672212">Για να διαχειριστείτε τον Λογαριασμό σας Brave Software, πατήστε το κουμπί Διαχείριση λογαριασμού.</translation>
+<translation id="8856898588039823173">Η σελίδα Lite παρέχεται από την Brave Software. Πατήστε για φόρτωση της αρχικής σελίδας.</translation>
+<translation id="8134317863207426198">Σελίδα Lite που παρέχεται από την Brave Software. Πατήστε το κουμπί "φόρτωση αρχικής" για φόρτωση της αρχικής σελίδας.</translation>
+<translation id="4961107849584082341">Μεταφράστε αυτήν τη σελίδα σε οποιαδήποτε γλώσσα</translation>
+<translation id="569536719314091526">Μεταφράστε αυτήν τη σελίδα σε οποιαδήποτε γλώσσα από το κουμπί "Περισσότερες επιλογές"</translation>
+<translation id="1397811292916898096">Αναζήτηση με <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Αλλάξτε την προεπιλεγμένη τοποθεσία λήψης ανά πάσα στιγμή</translation>
+<translation id="6942665639005891494">Αλλάξτε την προεπιλεγμένη τοποθεσία λήψης ανά πάσα στιγμή χρησιμοποιώντας την επιλογή μενού "Ρυθμίσεις"</translation>
+<translation id="6850409657436465440">Η λήψη σας βρίσκεται ακόμα σε εξέλιξη</translation>
+<translation id="5817715962196959877">Το Brave κατεβάζει πλέον τα αρχεία πιο γρήγορα</translation>
+<translation id="3976396876660209797">Κατάργηση και εκ νέου δημιουργία αυτής της συντόμευσης</translation>
+<translation id="6766622839693428701">Σύρετε προς τα κάτω για κλείσιμο.</translation>
+<translation id="1028699632127661925">Αποστολή στη συσκευή <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Στάλθηκε από <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Έγινε λήψη της καρτέλας</translation>
 <translation id="9104217018994036254">Λίστα συσκευών στις οποίες θα κοινοποιηθεί μια καρτέλα.</translation>
-<translation id="9133397713400217035">Εξερεύνηση εκτός σύνδεσης</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Εμφάνιση πρωτοτύπου</translation>
-<translation id="9139068048179869749">Να γίνεται ερώτηση προτού επιτραπεί στους ιστότοπους να στέλνουν ειδοποιήσεις (συνιστάται)</translation>
-<translation id="9139318394846604261">Αγορές</translation>
-<translation id="9155898266292537608">Επίσης, μπορείτε να κάνετε αναζήτηση με ένα γρήγορο πάτημα σε μια λέξη</translation>
-<translation id="9169507124922466868">Το ιστορικό πλοήγησης έχει ανοίξει κατά το ήμισυ</translation>
-<translation id="9204836675896933765">1 αρχείο απομένει</translation>
-<translation id="9206873250291191720">Α</translation>
+<translation id="6767294960381293877">Άνοιγμα σε μισό ύψος της λίστας συσκευών στις οποίες θα κοινοποιηθεί μια καρτέλα.</translation>
+<translation id="2904414404539560095">Άνοιγμα σε πλήρες ύψος της λίστας συσκευών στις οποίες θα κοινοποιηθεί μια καρτέλα.</translation>
+<translation id="4135200667068010335">Η λίστα συσκευών στις οποίες θα κοινοποιηθεί μια καρτέλα είναι κλειστή.</translation>
+<translation id="5292796745632149097">Αποστολή προς</translation>
+<translation id="1386674309198842382">Ενεργή <ph name="LAST_UPDATED"/> ημέρες πριν</translation>
+<translation id="7971136598759319605">Ενεργή 1 ημέρα πριν</translation>
+<translation id="1521774566618522728">Ενεργή σήμερα</translation>
+<translation id="3631987586758005671">Κοινοποίηση σε <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Ενεργοποιήστε τον συγχρονισμό για κοινοποίηση μεταξύ συσκευών.</translation>
+<translation id="6162454065885854378">Για να κοινοποιήσετε κάτι από το τηλέφωνό σας σε μια άλλη συσκευή, ενεργοποιήστε τον συγχρονισμό στις ρυθμίσεις του Brave και στις δύο συσκευές.</translation>
+<translation id="6084271560289605378">Μεταβείτε στις ρυθμίσεις του Brave</translation>
+<translation id="2318045970523081853">Πατήστε για πραγματοποίηση κλήσης</translation>
 <translation id="9209888181064652401">Δεν είναι δυνατή η πραγματοποίηση κλήσεων</translation>
-<translation id="9219103736887031265">Εικόνες</translation>
-<translation id="926205370408745186">Κατάργηση της δραστηριότητάς σας στο Chrome από το Digital Wellbeing</translation>
-<translation id="932327136139879170">Αρχική σελίδα</translation>
-<translation id="938850635132480979">Σφάλμα: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Πρόσβαση στο μικρόφωνό σας</translation>
-<translation id="95817756606698420">Το Chrome μπορεί να χρησιμοποιήσει το <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> για την αναζήτηση στην Κίνα. Μπορείτε να αλλάξετε αυτήν την επιλογή στις <ph name="BEGIN_LINK" />Ρυθμίσεις<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Αποκλεισμός εάν ο ιστότοπος εμφανίζει παρεμβατικές ή παραπλανητικές διαφημίσεις (συνιστάται)</translation>
-<translation id="968900484120156207">Εδώ εμφανίζονται οι σελίδες που επισκέπτεστε</translation>
-<translation id="970715775301869095">Απομένουν <ph name="MINUTES" /> λεπτά</translation>
-<translation id="974555521953189084">Εισαγάγετε τη φράση πρόσβασης για να ξεκινήσετε τον συγχρονισμό.</translation>
-<translation id="981121421437150478">Εκτός σύνδεσης</translation>
-<translation id="982182592107339124">Αυτή η ενέργεια θα εκκαθαρίσει τα δεδομένα για όλους τους ιστότοπους, όπως:</translation>
-<translation id="983192555821071799">Κλείσιμο όλων των καρτελών</translation>
-<translation id="987264212798334818">Γενικά</translation>
+<translation id="2860954141821109167">Βεβαιωθείτε ότι είναι ενεργοποιημένη μια εφαρμογή τηλεφώνου σε αυτήν τη συσκευή.</translation>
+<translation id="2067805253194386918">κείμενο</translation>
+<translation id="1450753235335490080">Δεν είναι δυνατή η κοινοποίηση <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Δεν ήταν δυνατή η κοινοποίηση <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Βεβαιωθείτε ότι ο συγχρονισμός στο Brave έχει ενεργοποιηθεί για τη συσκευή <ph name="TARGET_DEVICE_NAME"/>.</translation>
+<translation id="3016635187733453316">Βεβαιωθείτε ότι η συσκευή είναι συνδεδεμένη στο διαδίκτυο.</translation>
+<translation id="8466613982764129868">Βεβαιωθείτε ότι η συσκευή <ph name="TARGET_DEVICE_NAME"/> είναι συνδεδεμένη στο διαδίκτυο.</translation>
+<translation id="6539092367496845964">Παρουσιάστηκε κάποιο πρόβλημα. Δοκιμάστε ξανά αργότερα.</translation>
+<translation id="3389286852084373014">Το κείμενο είναι υπερβολικά μεγάλο</translation>
+<translation id="2100314319871056947">Δοκιμάστε να κοινοποιήσετε το κείμενο σε μικρότερα τμήματα.</translation>
+<translation id="2987620471460279764">Κοινόχρηστο κείμενο από άλλη συσκευή</translation>
+<translation id="7757787379047923882">Το κείμενο κοινοποιήθηκε από τη συσκευή <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Αντιγράφηκε στο πρόχειρό σας</translation>
+<translation id="4696983787092045100">Αποστολή μηνύματος κειμένου στις συσκευές σας</translation>
+<translation id="1260236875608242557">Αναζήτηση και εξερεύνηση</translation>
+<translation id="6369229450655021117">Από εδώ, μπορείτε να αναζητήσετε στον ιστό, να μοιραστείτε με φίλους και να δείτε ανοικτές σελίδες</translation>
+<translation id="723171743924126238">Επιλέξτε εικόνες</translation>
+<translation id="8751914237388039244">Επιλογή εικόνας</translation>
+<translation id="1989112275319619282">Περιήγηση</translation>
+<translation id="7055152154916055070">Αποκλεισμένη ανακατεύθυνση:</translation>
+<translation id="5524843473235508879">Η ανακατεύθυνση αποκλείστηκε.</translation>
+<translation id="6573096386450695060">Να επιτρέπονται πάντα</translation>
+<translation id="5805364706385912897">Αυτή η σελίδα χρησιμοποιεί πάρα πολλή μνήμη. Για αυτόν τον λόγο, το Brave την έθεσε σε παύση.</translation>
+<translation id="5138664332909611586">Αυτή η σελίδα χρησιμοποιεί πάρα πολλή μνήμη. Για αυτόν τον λόγο, το Brave κατάργησε κάποιο περιεχόμενο.</translation>
+<translation id="9137013805542155359">Εμφάνιση πρωτοτύπου</translation>
+<translation id="6361779936989026201">Βοηθός Brave Software στο Brave</translation>
+<translation id="7291387454912369099">Ολοκλήρωση αγοράς από τον Βοηθό</translation>
+<translation id="4565206163201411670">Να εμφανίζεται στο Digital Wellbeing η δραστηριότητά σας στο Brave;</translation>
+<translation id="9055113864158719823">Μπορείτε να δείτε και να ορίσετε χρονόμετρα για τους ιστοτόπους που επισκέπτεστε στο Brave.\n\nΗ Brave Software λαμβάνει πληροφορίες σχετικά με τους ιστοτόπους για τους οποίους ορίζετε χρονόμετρα και τη χρονική διάρκεια που τους χρησιμοποιείτε. Αυτές οι πληροφορίες χρησιμοποιούνται για τη βελτίωση του Digital Wellbeing.</translation>
+<translation id="4596514158372210596">Κατάργηση της δραστηριότητάς σας στο Brave από το Digital Wellbeing</translation>
+<translation id="1174893863889683998">Να καταργηθεί η δραστηριότητα του Brave από το Digital Wellbeing;</translation>
+<translation id="708829030563435351">Δεν θα εμφανίζονται οι ιστότοποι που επισκέπτεστε στο Brave. Όλα τα χρονόμετρα ιστοτόπων θα διαγραφούν.</translation>
+<translation id="2056878612599315956">Ο ιστότοπος τέθηκε σε παύση</translation>
+<translation id="671481426037969117">Η αντίστροφη μέτρηση <ph name="FQDN"/> εξαντλήθηκε. Θα ξεκινήσει ξανά αύριο.</translation>
+<translation id="7479104141328977413">Διαχείριση καρτέλας</translation>
+<translation id="3524138585025253783">Διεπαφή χρήση προγραμματιστή</translation>
+<translation id="6036057147555329831">Επιπλέον ICU</translation>
+<translation id="9029323097866369874">Να επιτρέπεται στον τομέα <ph name="DOMAIN"/> η ενεργοποίηση της λειτουργίας VR;</translation>
+<translation id="7685301384041462804">Βεβαιωθείτε ότι εμπιστεύεστε αυτόν τον ιστότοπο προτού ενεργοποιήσετε τη λειτουργία VR.</translation>
+<translation id="5033865233969348410">Ενώ βρίσκεστε σε λειτουργία VR, αυτός ο ιστότοπος ενδέχεται να είναι σε θέση να μάθει πληροφορίες σχετικά:
+  -  τα φυσικά χαρακτηριστικά σας, όπως το ύψος σας
+
+Βεβαιωθείτε ότι εμπιστεύεστε αυτόν τον ιστότοπο προτού ενεργοποιήσετε τη λειτουργία VR.</translation>
+<translation id="5534334044554683961">Ενώ βρίσκεστε σε λειτουργία VR, αυτός ο ιστότοπος ενδέχεται να είναι σε θέση να μάθει πληροφορίες σχετικά:
+  -   τα φυσικά χαρακτηριστικά σας, όπως το ύψος σας
+  -   τη διάταξη του δωματίου σας
+
+Βεβαιωθείτε ότι εμπιστεύεστε αυτόν τον ιστότοπο προτού ενεργοποιήσετε τη λειτουργία VR.</translation>
+<translation id="4169535189173047238">Να μην επιτρέπεται</translation>
+<translation id="2170088579611075216">Αποδοχή και είσοδος σε VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_en-GB.xtb
+++ b/android/java/strings/translations/android_chrome_strings_en-GB.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="en-GB">
-<translation id="1006017844123154345">Open Online</translation>
-<translation id="1028699632127661925">Sending to <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Adding <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">From websites</translation>
-<translation id="1049743911850919806">Incognito</translation>
-<translation id="10614374240317010">Never saved</translation>
-<translation id="1067922213147265141">Other Google services</translation>
-<translation id="1068672505746868501">Never translate pages in <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">If you change the file extension, the file may open in a different application and potentially be a hazard to your device.</translation>
-<translation id="1100066534610197918">Open in new tab in group</translation>
-<translation id="1105960400813249514">Screen Capture</translation>
-<translation id="1111673857033749125">Bookmarks saved on your other devices will appear here.</translation>
-<translation id="1113597929977215864">Show simplified view</translation>
-<translation id="1121094540300013208">Usage and crash reports</translation>
-<translation id="1124772482545689468">User</translation>
-<translation id="1129510026454351943">Details: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download pending.}other{# downloads pending.}}</translation>
-<translation id="1145536944570833626">Delete existing data.</translation>
-<translation id="1146678959555564648">Enter VR</translation>
-<translation id="116280672541001035">Used</translation>
-<translation id="1171770572613082465">See popular websites by tapping the 'Top sites' button</translation>
-<translation id="1173894706177603556">Rename</translation>
-<translation id="1178581264944972037">Pause</translation>
-<translation id="1181037720776840403">Remove</translation>
-<translation id="1188239144602654184">Enter AR</translation>
-<translation id="1197267115302279827">Move bookmarks</translation>
-<translation id="119944043368869598">Clear all</translation>
-<translation id="1201402288615127009">Next</translation>
-<translation id="1204037785786432551">Download link</translation>
-<translation id="1206892813135768548">Copy link text</translation>
-<translation id="1208340532756947324">To sync and personalise across devices, turn on sync</translation>
-<translation id="1209206284964581585">Hide for now</translation>
-<translation id="1227058898775614466">Navigation history</translation>
-<translation id="1231733316453485619">Turn on sync?</translation>
-<translation id="123724288017357924">Reload the current page, ignoring cached content</translation>
-<translation id="124116460088058876">More languages</translation>
-<translation id="124678866338384709">Close current tab</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Search and explore</translation>
-<translation id="1264974993859112054">Sports</translation>
-<translation id="1266864766717917324">Couldn't share <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Stop</translation>
-<translation id="1283039547216852943">Tap to expand</translation>
-<translation id="1285320974508926690">Never translate this site</translation>
-<translation id="1291207594882862231">Clear history, cookies, site data, cache…</translation>
-<translation id="129382876167171263">Files saved by websites appear here</translation>
-<translation id="129553762522093515">Recently closed</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Sent from <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Group tabs</translation>
-<translation id="1327257854815634930">Navigation history is opened</translation>
-<translation id="1331212799747679585">Chrome can’t update. More options</translation>
-<translation id="1332501820983677155">Google Chrome feature shortcuts</translation>
-<translation id="1360432990279830238">Sign out and turn off sync?</translation>
-<translation id="1369915414381695676">Site <ph name="SITE_NAME" /> added</translation>
-<translation id="1373696734384179344">Insufficient memory to download the selected content.</translation>
-<translation id="1376578503827013741">Computing…</translation>
-<translation id="1383876407941801731">Search</translation>
-<translation id="1384959399684842514">Download paused</translation>
-<translation id="1386674309198842382">Active <ph name="LAST_UPDATED" /> days ago</translation>
-<translation id="1397811292916898096">Search with <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Embedded in <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">‘Do Not Track’</translation>
-<translation id="1407135791313364759">Open all</translation>
-<translation id="1409426117486808224">Simplified view for open tabs</translation>
-<translation id="1409879593029778104"><ph name="FILE_NAME" /> download prevented because file already exists.</translation>
-<translation id="1414981605391750300">Contacting Google. This may take a minute…</translation>
-<translation id="1416550906796893042">Application version</translation>
-<translation id="1430915738399379752">Print</translation>
-<translation id="1446450296470737166">Allow full control of MIDI devices</translation>
-<translation id="1450753235335490080">Can't share <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Turned off in Android Settings</translation>
-<translation id="1477626028522505441"><ph name="FILE_NAME" /> download failed due to server issues.</translation>
-<translation id="1506061864768559482">Search engine</translation>
-<translation id="1513352483775369820">Bookmarks and web history</translation>
-<translation id="1513858653616922153">Delete password</translation>
-<translation id="1516229014686355813">Tap to Search sends the selected word and the current page as context to Google Search. You can turn it off in <ph name="BEGIN_LINK" />Settings<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Active today</translation>
-<translation id="1544826120773021464">To manage your Google Account, tap the 'Manage account' button</translation>
-<translation id="1549000191223877751">Move to other window</translation>
-<translation id="1553358976309200471">Update Chrome</translation>
-<translation id="1569387923882100876">Connected device</translation>
-<translation id="1571304935088121812">Copy username</translation>
-<translation id="1612196535745283361">Chrome needs location access to scan for devices. Location access is <ph name="BEGIN_LINK" />turned off for this device<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Camera</translation>
-<translation id="1623104350909869708">Prevent this page from creating additional dialogues</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Remove 1 selected item}other{Remove # selected items}}</translation>
-<translation id="164269334534774161">You are viewing an offline copy of this page from <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">History</translation>
-<translation id="1647391597548383849">Access your camera</translation>
-<translation id="1660204651932907780">Allow sites to play sound (recommended)</translation>
-<translation id="1670399744444387456">Basic</translation>
-<translation id="1671236975893690980">Download pending...</translation>
-<translation id="1672586136351118594">Don‘t show again</translation>
-<translation id="1692118695553449118">Sync is on</translation>
-<translation id="169515064810179024">Block sites from accessing motion sensors</translation>
-<translation id="1717218214683051432">Motion sensors</translation>
-<translation id="1718835860248848330">Last hour</translation>
-<translation id="1736419249208073774">Explore</translation>
-<translation id="1743802530341753419">Ask before allowing sites to connect to a device (recommended)</translation>
-<translation id="1749561566933687563">Sync your bookmarks</translation>
-<translation id="17513872634828108">Open tabs</translation>
-<translation id="1779089405699405702">Image decoder</translation>
-<translation id="1782483593938241562">End date <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installed</translation>
-<translation id="1792959175193046959">Change the default download location at any time</translation>
-<translation id="1807246157184219062">Light</translation>
-<translation id="1810845389119482123">Initial sync setup not finished</translation>
-<translation id="1821253160463689938">Uses cookies to remember your preferences, even if you don't visit those pages</translation>
-<translation id="1829244130665387512">Find in page</translation>
-<translation id="1853692000353488670">New incognito tab</translation>
-<translation id="1856325424225101786">Reset Lite mode?</translation>
-<translation id="1868024384445905608">Chrome now downloads files faster</translation>
-<translation id="1883903952484604915">My files</translation>
-<translation id="1887786770086287077">Location access is off for this device. Turn it on in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> will open in Chrome. By continuing, you agree to Chrome’s <ph name="BEGIN_LINK1" />Terms of Service<ph name="END_LINK1" /> and <ph name="BEGIN_LINK2" />Privacy Notice<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Ads</translation>
-<translation id="1919950603503897840">Select contacts</translation>
-<translation id="1922076542920281912">To let Chrome access your location, also turn on location in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Updates</translation>
-<translation id="19288952978244135">Reopen Chrome.</translation>
-<translation id="1933845786846280168">Selected Tab</translation>
-<translation id="194341124344773587">Turn on permission for Chrome in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Save passwords</translation>
-<translation id="1952172573699511566">Websites will show text in your preferred language, when possible.</translation>
-<translation id="1960290143419248813">Chrome updates are no longer supported for this version of Android</translation>
-<translation id="1966710179511230534">Please update your sign-in details.</translation>
-<translation id="1974060860693918893">Advanced</translation>
-<translation id="1984705450038014246">Sync your Chrome data</translation>
-<translation id="1984937141057606926">Allowed, except third-party</translation>
-<translation id="1986685561493779662">Name already exists</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> button</translation>
-<translation id="1989112275319619282">Browse</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> wants to pair</translation>
-<translation id="1994173015038366702">Site URL</translation>
-<translation id="2000419248597011803">Sends some cookies and searches from the address bar and search box to your default search engine</translation>
-<translation id="2002537628803770967">Credit cards and addresses using Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# File}other{# Files}}</translation>
-<translation id="2017836877785168846">Clears history and autocompletions in the address bar.</translation>
-<translation id="2021896219286479412">Full screen site controls</translation>
-<translation id="2038563949887743358">Turn on Request desktop site</translation>
-<translation id="2041019821020695769">To let Chrome send you notifications, also turn on notifications in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> also has data in Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Site paused</translation>
-<translation id="2063713494490388661">Tap to Search</translation>
-<translation id="2067805253194386918">text</translation>
-<translation id="2079545284768500474">Undo</translation>
-<translation id="2082238445998314030">Result <ph name="RESULT_NUMBER" /> of <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Sound</translation>
-<translation id="2096012225669085171">Sync and personalise across devices</translation>
-<translation id="2100273922101894616">Auto Sign-in</translation>
-<translation id="2100314319871056947">Try sharing the text in smaller chunks</translation>
-<translation id="2107397443965016585">Ask before allowing sites to play protected content (recommended)</translation>
-<translation id="2111511281910874386">Go to page</translation>
-<translation id="2122601567107267586">Could not open app</translation>
-<translation id="2126426811489709554">Powered by Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> saved</translation>
-<translation id="213279576345780926">Closed <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Add to Home screen</translation>
-<translation id="2146738493024040262">Open Instant App</translation>
-<translation id="2148716181193084225">Today</translation>
-<translation id="2154484045852737596">Edit card</translation>
-<translation id="2154710561487035718">Copy URL</translation>
-<translation id="2156074688469523661">Remaining sites (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">To share something from your phone to another device, turn on sync in Chrome settings on both devices</translation>
-<translation id="2170088579611075216">Allow and enter VR</translation>
-<translation id="218608176142494674">Sharing</translation>
-<translation id="2227444325776770048">Continue as <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sync and Google services</translation>
-<translation id="2259659629660284697">Export passwords…</translation>
-<translation id="2268044343513325586">Refine</translation>
-<translation id="2286841657746966508">Billing address</translation>
-<translation id="2289270750774289114">Ask when a site wants to discover nearby Bluetooth devices (recommended)</translation>
-<translation id="230115972905494466">No compatible devices found</translation>
-<translation id="2315043854645842844">Client side certificate selection is not supported by the operating system.</translation>
-<translation id="2318045970523081853">Tap to make call</translation>
-<translation id="2321086116217818302">Preparing passwords…</translation>
-<translation id="2321958826496381788">Drag the slider until you can read this comfortably. Text should look at least this big after double-tapping on a paragraph.</translation>
-<translation id="2323763861024343754">Site storage</translation>
-<translation id="2328985652426384049">Can’t sign in</translation>
-<translation id="2330129964253841015">Warn you if passwords are compromised</translation>
-<translation id="2349710944427398404">Total data used by Chrome, including accounts, bookmarks and saved settings</translation>
-<translation id="2353636109065292463">Checking your Internet connection</translation>
-<translation id="2359808026110333948">Continue</translation>
-<translation id="2369533728426058518">open tabs</translation>
-<translation id="2387895666653383613">Text scaling</translation>
-<translation id="2394602618534698961">Files that you download appear here</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">When you sign in to your Google account, this feature is turned on</translation>
-<translation id="2410754283952462441">Choose an account</translation>
-<translation id="2414886740292270097">Dark</translation>
-<translation id="2416359993254398973">Chrome needs permission to access your camera for this site.</translation>
-<translation id="2426805022920575512">Choose another account</translation>
-<translation id="2433507940547922241">Appearance</translation>
-<translation id="2434158240863470628">Download complete <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Location access</translation>
-<translation id="2450083983707403292">Do you want to start downloading <ph name="FILE_NAME" /> again?</translation>
-<translation id="2482878487686419369">Notifications</translation>
-<translation id="2490684707762498678">Managed by <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Assistant in Chrome</translation>
-<translation id="2496180316473517155">Browsing history</translation>
-<translation id="2497852260688568942">Sync is disabled by your administrator</translation>
-<translation id="2498359688066513246">Help &amp; feedback</translation>
-<translation id="2501278716633472235">Go back</translation>
-<translation id="2513403576141822879">For more settings that relate to privacy, security and data collection, see <ph name="BEGIN_LINK" />Sync and Google services<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">In Lite mode, Chrome loads pages faster and uses up to 60 per cent less data. To optimise the pages that you visit, Chrome sends your web traffic to Google. <ph name="BEGIN_LINK" />Find out more<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Sends URLs of pages that you visit to Google</translation>
-<translation id="2532336938189706096">Web View</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> items deleted</translation>
-<translation id="2536728043171574184">Viewing an offline copy of this page</translation>
-<translation id="2546283357679194313">Cookies and site data</translation>
-<translation id="2567385386134582609">IMAGE</translation>
-<translation id="257088987046510401">Themes</translation>
-<translation id="2570922361219980984">Location access is also off for this device. Turn it on in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Expanded – click to collapse.</translation>
-<translation id="2581165646603367611">This will clear cookies, cache and other data of sites Chrome doesn't think is important.</translation>
-<translation id="2586657967955657006">Clipboard</translation>
-<translation id="2587052924345400782">Newer version is available</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Card number</translation>
-<translation id="2621115761605608342">Allow JavaScript for a specific site.</translation>
-<translation id="2625189173221582860">Password copied</translation>
-<translation id="2631006050119455616">Saved</translation>
-<translation id="2647434099613338025">Add language</translation>
-<translation id="2650751991977523696">Download file again?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Audio file}other{# Audio files}}</translation>
-<translation id="2653659639078652383">Submit</translation>
-<translation id="2677748264148917807">Leave</translation>
-<translation id="2704606927547763573">Copied</translation>
-<translation id="2707726405694321444">Refresh page</translation>
-<translation id="2709516037105925701">Auto-fill</translation>
-<translation id="2717722538473713889">Email addresses</translation>
-<translation id="2728754400939377704">Sort by site</translation>
-<translation id="2744248271121720757">Tap a word to search instantly or see related actions</translation>
-<translation id="2760989362628427051">Turn on dark theme when your device's dark theme or Battery Saver is on</translation>
-<translation id="2762000892062317888">just now</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> secs left</translation>
-<translation id="2779651927720337254">failed</translation>
-<translation id="2781151931089541271">1 sec left</translation>
-<translation id="2801022321632964776">Update to get your language in the latest version of Chrome</translation>
-<translation id="2810645512293415242">Simplified page to save data and load faster.</translation>
-<translation id="281504910091592009">View and manage saved passwords in your <ph name="BEGIN_LINK" />Google Account<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">To get your bookmarks on all your devices, sign in and turn on sync</translation>
-<translation id="2822354292072154809">Are you sure that you want to reset all site permissions for <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Touch the back button to exit full screen.</translation>
-<translation id="2842985007712546952">Parent folder</translation>
-<translation id="2858138569776157458">Top sites</translation>
-<translation id="2860954141821109167">Make sure that a phone app is enabled on this device</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Previous track</translation>
-<translation id="2876369937070532032">Sends URLs of some pages that you visit to Google, when your security is at risk</translation>
-<translation id="2888126860611144412">About Chrome</translation>
-<translation id="2891154217021530873">Stop page loading</translation>
-<translation id="2893180576842394309">Google may use your history to personalise Search and other Google services</translation>
-<translation id="2898264748040935573">Edit stored password</translation>
-<translation id="2900528713135656174">Create event</translation>
-<translation id="290376772003165898">Page is not in <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">List of devices to share a tab with, opened at full height.</translation>
-<translation id="2910701580606108292">Ask before allowing sites to play protected content</translation>
-<translation id="2913331724188855103">Allow sites to save and read cookie data (recommended)</translation>
-<translation id="2923908459366352541">Name is invalid</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> storage</translation>
-<translation id="2942036813789421260">Preview tab is closed</translation>
-<translation id="2956410042958133412">This account is managed by <ph name="PARENT_NAME_1" /> and <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Switched to incognito tabs</translation>
-<translation id="2968755619301702150">Certificate viewer</translation>
-<translation id="2979025552038692506">Selected Incognito Tab</translation>
-<translation id="2987620471460279764">Text shared from other device</translation>
-<translation id="2989523299700148168">Recently Visited</translation>
-<translation id="2996291259634659425">Create passphrase</translation>
-<translation id="2996809686854298943">URL required</translation>
-<translation id="300526633675317032">This will clear all <ph name="SIZE_IN_KB" /> of website storage.</translation>
-<translation id="3016635187733453316">Make sure that this device is connected to the Internet</translation>
-<translation id="3029613699374795922">Downloaded <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Passphrases do not match</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Get help<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Location is off; turn it on in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">You can turn on sync at any time in settings</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> bookmark}other{<ph name="BOOKMARKS_COUNT_MANY" /> bookmarks}}</translation>
-<translation id="3089395242580810162">Open in incognito tab</translation>
-<translation id="3115898365077584848">Show info</translation>
-<translation id="3123473560110926937">Blocked on some sites</translation>
-<translation id="3137521801621304719">Leave incognito mode</translation>
-<translation id="3143515551205905069">Cancel sync</translation>
-<translation id="3157842584138209013">See how much data you've saved from the More Options button</translation>
-<translation id="3166827708714933426">Tab and window shortcuts</translation>
-<translation id="3181954750937456830">Safe Browsing (protects you and your device from dangerous sites)</translation>
-<translation id="3190152372525844641">Turn on permissions for Chrome in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> stored data</translation>
-<translation id="3205824638308738187">Almost finished!</translation>
-<translation id="3207960819495026254">Bookmarked</translation>
-<translation id="3211426585530211793">Deleted <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">If you forgot your passphrase or want to change this setting, <ph name="BEGIN_LINK" />reset sync<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Microphone</translation>
-<translation id="3232754137068452469">Web App</translation>
-<translation id="3236059992281584593">1 min left</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Bookmark this page</translation>
-<translation id="3259831549858767975">Make everything on the page smaller</translation>
-<translation id="3269093882174072735">Load image</translation>
-<translation id="3269956123044984603">To get your tabs from your other devices, turn on “Auto-sync data” in Android account settings.</translation>
-<translation id="3277252321222022663">Allow sites to access sensors (recommended)</translation>
-<translation id="3282568296779691940">Sign in to Chrome</translation>
-<translation id="3288003805934695103">Reloading the page</translation>
-<translation id="32895400574683172">Notifications are allowed</translation>
-<translation id="3295530008794733555">Browse faster. Use less data.</translation>
-<translation id="3295602654194328831">Hide info</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Proceed to download the content?</translation>
-<translation id="3306398118552023113">This app is running in Chrome</translation>
-<translation id="3315103659806849044">You are currently customising your Sync and Google service settings. To finish turning on sync, tap the Confirm button near the bottom of the screen. Navigate up</translation>
-<translation id="3328801116991980348">Site information</translation>
-<translation id="3333961966071413176">All contacts</translation>
-<translation id="3334729583274622784">Change file extension?</translation>
-<translation id="3341058695485821946">See how much data you've saved</translation>
-<translation id="3350687908700087792">Close all incognito tabs</translation>
-<translation id="3353615205017136254">Lite page provided by Google. Tap the load original button to load the original page.</translation>
-<translation id="3367813778245106622">Sign in again to start sync</translation>
-<translation id="3374023511497244703">Your bookmarks, history, passwords and other Chrome data will no longer be synced to your Google account</translation>
-<translation id="3384347053049321195">Share image</translation>
-<translation id="3386292677130313581">Ask before allowing sites to know your location (recommended)</translation>
-<translation id="3387650086002190359"><ph name="FILE_NAME" /> download failed due to file system errors.</translation>
-<translation id="3389286852084373014">Text is too large</translation>
-<translation id="3398320232533725830">Open the bookmarks manager</translation>
-<translation id="3414952576877147120">Size:</translation>
-<translation id="3443221991560634068">Reload the current page</translation>
-<translation id="3445014427084483498">Just now</translation>
-<translation id="3478363558367712427">You can choose your search engine</translation>
+<translation id="6910211073230771657">Deleted</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, got it</translation>
+<translation id="7658239707568436148">Cancel</translation>
 <translation id="3479552764303398839">Not now</translation>
-<translation id="3492207499832628349">New incognito tab</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Find out more<ph name="END_LINK" /> about suggested content</translation>
-<translation id="3513704683820682405">Augmented Reality</translation>
-<translation id="3518985090088779359">Accept &amp; continue</translation>
-<translation id="3522247891732774234">Update available. More options</translation>
-<translation id="3524138585025253783">Developer UI</translation>
-<translation id="3527085408025491307">Folder</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB available</translation>
-<translation id="3549657413697417275">Search your history</translation>
-<translation id="3557336313807607643">Add to contacts</translation>
-<translation id="3566923219790363270">Chrome is still preparing for VR. Restart Chrome later.</translation>
-<translation id="3568688522516854065">To get your tabs from your other devices, sign in and turn on sync</translation>
-<translation id="3587482841069643663">All</translation>
-<translation id="358794129225322306">Allow a site to download multiple files automatically.</translation>
-<translation id="3590487821116122040">Site storage Chrome doesn't think is important (e.g. sites with no saved settings or that you don't visit often)</translation>
-<translation id="3599863153486145794">Clears history from all signed-in devices. Your Google Account may have other forms of browsing history at <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Mute sites that play sound</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Sharing to <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Unmask password</translation>
-<translation id="363596933471559332">Automatically sign in to websites using stored credentials. When the feature is off, you’ll be asked for verification every time before signing in to a website.</translation>
-<translation id="3658159451045945436">Resetting wipes your history of data savings, including the list of visited sites.</translation>
-<translation id="3692944402865947621"><ph name="FILE_NAME" /> download failed because storage location is not reachable.</translation>
-<translation id="3714981814255182093">Open the Find Bar</translation>
-<translation id="3716182511346448902">This page uses too much memory, so Chrome paused it.</translation>
-<translation id="3730075448226062617">To let Chrome access your microphone, also turn on microphone in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Bookmarked in <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Background sync</translation>
-<translation id="3771001275138982843">Couldn’t download the update</translation>
-<translation id="3771033907050503522">Incognito Tabs</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Turn on Bluetooth<ph name="END_LINK" /> to allow pairing</translation>
-<translation id="3775705724665058594">Send to your devices</translation>
-<translation id="3778956594442850293">Added to Home screen</translation>
-<translation id="3789841737615482174">Install</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Manage</translation>
-<translation id="381841723434055211">Phone numbers</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> downloads deleted</translation>
-<translation id="3822502789641063741">Clear site storage?</translation>
-<translation id="385051799172605136">Back</translation>
-<translation id="3859306556332390985">Seek forward</translation>
-<translation id="3894427358181296146">Add folder</translation>
-<translation id="3895926599014793903">Force enable zoom</translation>
-<translation id="3912508018559818924">Finding the best from the web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combine my data</translation>
-<translation id="393697183122708255">No enabled voice search available</translation>
-<translation id="395206256282351086">Search and site suggestions disabled</translation>
-<translation id="3955193568934677022">Allow sites to play protected content (recommended)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome will load your page when ready}other{Chrome will load your pages when ready}}</translation>
-<translation id="3963007978381181125">Passphrase encryption doesn’t include payment methods and addresses from Google Pay. Only someone with your passphrase can read your encrypted data. The passphrase is not sent to or stored by Google. If you forget your passphrase or want to change this setting, you'll need to reset sync. <ph name="BEGIN_LINK" />Find out more<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Download complete</translation>
-<translation id="397583555483684758">Sync has stopped working</translation>
-<translation id="3976396876660209797">Remove and recreate this shortcut</translation>
-<translation id="3985215325736559418">Do you want to download <ph name="FILE_NAME" /> again?</translation>
-<translation id="3987993985790029246">Copy link</translation>
-<translation id="3988213473815854515">Location is allowed</translation>
-<translation id="3988466920954086464">See instant search results in this panel</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Unimportant storage</translation>
-<translation id="4000212216660919741">Offline Home</translation>
+<translation id="5317780077021120954">Save</translation>
+<translation id="4570913071927164677">Details</translation>
+<translation id="8730621377337864115">Done</translation>
+<translation id="8261506727792406068">Delete</translation>
+<translation id="1181037720776840403">Remove</translation>
+<translation id="5939518447894949180">Reset</translation>
 <translation id="4002066346123236978">Title</translation>
-<translation id="4008040567710660924">Allow cookies for a specific site.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# hr}other{# hrs}}</translation>
-<translation id="4046123991198612571">Next track</translation>
-<translation id="4048707525896921369">Learn about topics on websites without leaving the page. Tap to Search sends a word and its surrounding context to Google Search, returning definitions, pictures, search results and other details.
+<translation id="5916664084637901428">On</translation>
+<translation id="5860033963881614850">Off</translation>
+<translation id="6165508094623778733">Learn more</translation>
+<translation id="6042308850641462728">More</translation>
+<translation id="6040143037577758943">Close</translation>
+<translation id="780301667611848630">No, thanks</translation>
+<translation id="1201402288615127009">Next</translation>
+<translation id="2359808026110333948">Continue</translation>
+<translation id="2653659639078652383">Submit</translation>
+<translation id="2079545284768500474">Undo</translation>
+<translation id="7649070708921625228">Help</translation>
+<translation id="2148716181193084225">Today</translation>
+<translation id="7781829728241885113">Yesterday</translation>
+<translation id="6945221475159498467">Select</translation>
+<translation id="7791543448312431591">Add</translation>
+<translation id="6527303717912515753">Share</translation>
+<translation id="1383876407941801731">Search</translation>
+<translation id="3115898365077584848">Show info</translation>
+<translation id="3295602654194328831">Hide info</translation>
+<translation id="3987993985790029246">Copy link</translation>
+<translation id="2704606927547763573">Copied</translation>
+<translation id="8725066075913043281">Try again</translation>
+<translation id="385051799172605136">Back</translation>
+<translation id="8131740175452115882">Confirm</translation>
+<translation id="5300589172476337783">Show</translation>
+<translation id="1124772482545689468">User</translation>
+<translation id="8609465669617005112">Move up</translation>
+<translation id="6746124502594467657">Move down</translation>
+<translation id="8249310407154411074">Move to top</translation>
+<translation id="8428213095426709021">Settings</translation>
+<translation id="2498359688066513246">Help &amp; feedback</translation>
+<translation id="8378714024927312812">Managed by your organisation</translation>
+<translation id="9019902583201351841">Managed by your parents</translation>
+<translation id="4645575059429386691">Managed by your parent</translation>
+<translation id="4883854917563148705">Managed settings cannot be reset</translation>
+<translation id="4307992518367153382">Basics</translation>
+<translation id="1974060860693918893">Advanced</translation>
+<translation id="1146678959555564648">Enter VR</translation>
+<translation id="987264212798334818">General</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Downloads</translation>
+<translation id="218608176142494674">Sharing</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Screen Capture</translation>
+<translation id="4875775213178255010">Content Suggestions</translation>
+<translation id="2021896219286479412">Full screen site controls</translation>
+<translation id="4587589328781138893">Sites</translation>
+<translation id="4943703118917034429">Virtual Reality</translation>
+<translation id="1928696683969751773">Updates</translation>
+<translation id="6064125863973209585">Completed downloads</translation>
+<translation id="5342314432463739672">Permission requests</translation>
+<translation id="629730747756840877">Account</translation>
+<translation id="82609232232243542">Sign in to Brave</translation>
+<translation id="7956662517480676674">Sync and Brave Software services</translation>
+<translation id="5294439808117722387">You are currently customising your Sync and Brave Software service settings. To finish turning on sync, tap the Confirm button near the bottom of the screen. Navigate up</translation>
+<translation id="2096012225669085171">Sync and personalise across devices</translation>
+<translation id="1692118695553449118">Sync is on</translation>
+<translation id="5514904542973294328">Disabled by the administrator of this device</translation>
+<translation id="6447211988989208781">Brave Software activity controls</translation>
+<translation id="4882831918239250449">Control how your browsing history is used to personalise Search, ads and more</translation>
+<translation id="7431991332293347422">Control how your browsing history is used to personalise Search and more</translation>
+<translation id="6303969859164067831">Sign out and turn off sync</translation>
+<translation id="1125261911132334651">Manage your Brave Software Account</translation>
+<translation id="6406506848690869874">Sync</translation>
+<translation id="714362445477979774">Sync your Brave data</translation>
+<translation id="4314815835985389558">Manage sync</translation>
+<translation id="5428209950370661546">Other Brave Software services</translation>
+<translation id="7704317875155739195">Auto-complete searches and URLs</translation>
+<translation id="2000419248597011803">Sends some cookies and searches from the address bar and search box to your default search engine</translation>
+<translation id="7981313251711023384">Preload pages for faster browsing and searching</translation>
+<translation id="1821253160463689938">Uses cookies to remember your preferences, even if you don't visit those pages</translation>
+<translation id="6697492270171225480">Show suggestions for similar pages when a page can't be found</translation>
+<translation id="8109318360573330108">Sends the URL of a page that you're trying to reach to Brave Software</translation>
+<translation id="8438566539970814960">Make searches and browsing better</translation>
+<translation id="284843628681142937">Sends URLs of pages that you visit to Brave Software</translation>
+<translation id="7222718784508482526">For more settings that relate to privacy, security and data collection, see <ph name="BEGIN_LINK"/>Sync and Brave Software services<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Help improve Brave's features and performance</translation>
+<translation id="9063160602596686558">Automatically sends usage statistics and crash reports to Brave Software</translation>
+<translation id="4824958205181053313">Cancel sync?</translation>
+<translation id="3058498974290601450">You can turn on sync at any time in settings</translation>
+<translation id="3143515551205905069">Cancel sync</translation>
+<translation id="1506061864768559482">Search engine</translation>
+<translation id="55737423895878184">Location and notifications are allowed</translation>
+<translation id="3988213473815854515">Location is allowed</translation>
+<translation id="32895400574683172">Notifications are allowed</translation>
+<translation id="9040142327097499898">Notifications are allowed. Location is off for this device.</translation>
+<translation id="305593374596241526">Location is off; turn it on in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Recently Visited</translation>
+<translation id="6433501201775827830">Choose your search engine</translation>
+<translation id="7177466738963138057">You can change this later in Settings</translation>
+<translation id="3478363558367712427">You can choose your search engine</translation>
+<translation id="4910889077668685004">Payment apps</translation>
+<translation id="5152843274749979095">No supported apps installed</translation>
+<translation id="8812260976093120287">On some websites, you can pay with above supported payment apps on your device.</translation>
+<translation id="7764225426217299476">Add address</translation>
+<translation id="5595485650161345191">Edit address</translation>
+<translation id="5087580092889165836">Add card</translation>
+<translation id="2154484045852737596">Edit card</translation>
+<translation id="6140912465461743537">Country/Region</translation>
+<translation id="5659593005791499971">Email</translation>
+<translation id="4378154925671717803">Phone</translation>
+<translation id="4807098396393229769">Name on card</translation>
+<translation id="860043288473659153">Cardholder name</translation>
+<translation id="2612676031748830579">Card number</translation>
+<translation id="869891660844655955">Expiry date</translation>
+<translation id="2286841657746966508">Billing address</translation>
+<translation id="663059986967017181">Copied to Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> more}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> more}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> more}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> more}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> more}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> more}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> more}other{<ph name="CONTACT_PREVIEW"/>\u2026 and <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> more}}</translation>
+<translation id="7029809446516969842">Passwords</translation>
+<translation id="1943432128510653496">Save passwords</translation>
+<translation id="2100273922101894616">Auto Sign-in</translation>
+<translation id="363596933471559332">Automatically sign in to websites using stored credentials. When the feature is off, you’ll be asked for verification every time before signing in to a website.</translation>
+<translation id="6995899638241819463">Warn you if passwords are exposed in a data breach</translation>
+<translation id="1534287762301776620">When you sign in to your Brave Software account, this feature is turned on</translation>
+<translation id="10614374240317010">Never saved</translation>
+<translation id="3098842761938485917">View and manage saved passwords in your <ph name="BEGIN_LINK"/>Brave Software Account<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Your saved passwords will appear here.</translation>
+<translation id="8084114998886531721">Saved password</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Username</translation>
+<translation id="6657585470893396449">Password</translation>
+<translation id="2154710561487035718">Copy URL</translation>
+<translation id="1571304935088121812">Copy username</translation>
+<translation id="5005498671520578047">Copy password</translation>
+<translation id="3632295766818638029">Unmask password</translation>
+<translation id="1513858653616922153">Delete password</translation>
+<translation id="543338862236136125">Edit password</translation>
+<translation id="4565377596337484307">Hide password</translation>
+<translation id="8523928698583292556">Delete stored password</translation>
+<translation id="2898264748040935573">Edit stored password</translation>
+<translation id="5433691172869980887">Username copied</translation>
+<translation id="5534640966246046842">Site copied</translation>
+<translation id="2625189173221582860">Password copied</translation>
+<translation id="4550003330909367850">To view or copy your password here, set screen lock on this device.</translation>
+<translation id="6154478581116148741">Turn on screen lock in Settings to export your passwords from this device</translation>
+<translation id="4842092870884894799">Showing password generation pop-up</translation>
+<translation id="2259659629660284697">Export passwords…</translation>
+<translation id="133012818630824069">Export passwords stored with Brave</translation>
+<translation id="6914783257214138813">Your passwords will be visible to anyone who can see the exported file.</translation>
+<translation id="2321086116217818302">Preparing passwords…</translation>
+<translation id="8445448999790540984">Can’t export passwords</translation>
+<translation id="3066461326500799725">Learn how to use Brave Software Drive</translation>
+<translation id="729975465115245577">Your device doesn’t have an app to store the passwords file.</translation>
+<translation id="7682724950699840886">Try the following tips: make sure that there is enough space on your device; try to export again.</translation>
+<translation id="1129510026454351943">Details: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Unlock to copy your password</translation>
+<translation id="5515439363601853141">Unlock to view your password</translation>
+<translation id="6221633008163990886">Unlock to export your passwords</translation>
+<translation id="230699814587342492">Brave Passwords</translation>
+<translation id="6075798973483050474">Edit home page</translation>
+<translation id="854522910157234410">Open this page:</translation>
+<translation id="2482878487686419369">Notifications</translation>
+<translation id="6255999984061454636">Content suggestions</translation>
+<translation id="805047784848435650">Based on your browsing history</translation>
+<translation id="1041308826830691739">From websites</translation>
+<translation id="395206256282351086">Search and site suggestions disabled</translation>
+<translation id="257088987046510401">Themes</translation>
+<translation id="4650364565596261010">System default</translation>
+<translation id="7588219262685291874">Turn on dark theme when your device's Battery Saver is on</translation>
+<translation id="2760989362628427051">Turn on dark theme when your device's dark theme or Battery Saver is on</translation>
+<translation id="6381421346744604172">Darken websites</translation>
+<translation id="5040262127954254034">Privacy</translation>
+<translation id="4991384657077828949">Help improve Brave security</translation>
+<translation id="1943176487615318915">To detect dangerous apps and sites, Brave sends URLs of some pages that you visit, limited system information and some page content to Brave Software</translation>
+<translation id="3181954750937456830">Safe Browsing (protects you and your device from dangerous sites)</translation>
+<translation id="7315322926489145388">Sends URLs of some pages that you visit to Brave Software, when your security is at risk</translation>
+<translation id="2063713494490388661">Tap to Search</translation>
+<translation id="2369463299479365221">Learn about topics on websites without leaving the page. Tap to Search sends a word and its surrounding context to Brave Software Search, returning definitions, pictures, search results and other details.
 
 To adjust your search term, long-press to select. To refine your search, slide the panel all the way up and tap the search box.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Options available near the top of the screen</translation>
-<translation id="4062305924942672200">Legal information</translation>
-<translation id="4084682180776658562">Bookmark</translation>
-<translation id="4084712963632273211">From <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />delivered by Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Delete app data?</translation>
-<translation id="4099578267706723511">Help make Chrome better by sending usage statistics and crash reports to Google.</translation>
-<translation id="410351446219883937">Auto-play</translation>
-<translation id="4116038641877404294">Download pages to use them offline</translation>
-<translation id="4135200667068010335">List of devices with which to share a tab is closed.</translation>
-<translation id="4149994727733219643">Simplified view for web pages</translation>
-<translation id="4165986682804962316">Site settings</translation>
-<translation id="4169535189173047238">Don't allow</translation>
-<translation id="4170011742729630528">The service is not available; try again later.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> used</translation>
-<translation id="4181841719683918333">Languages</translation>
-<translation id="4183868528246477015">Search with Google Lens <ph name="BEGIN_NEW" />New<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Open in new tab</translation>
-<translation id="4198423547019359126">No available download locations</translation>
-<translation id="4209895695669353772">To get personalised content suggested by Google, turn on sync</translation>
-<translation id="4226663524361240545">Notifications may vibrate the device</translation>
-<translation id="423219824432660969">Encrypt synced data with Google password as of <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Open settings</translation>
-<translation id="4256782883801055595">Open-source licences</translation>
-<translation id="4259722352634471385">Navigation is blocked: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copy link address</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Allowed</translation>
-<translation id="429312253194641664">A site is playing media</translation>
-<translation id="4298388696830689168">Linked sites</translation>
-<translation id="4307992518367153382">Basics</translation>
-<translation id="4314815835985389558">Manage sync</translation>
-<translation id="4351244548802238354">Close dialogue</translation>
-<translation id="4378154925671717803">Phone</translation>
-<translation id="4384468725000734951">Using Sogou for search</translation>
-<translation id="4404568932422911380">No bookmarks</translation>
-<translation id="4405224443901389797">Move to…</translation>
-<translation id="4411535500181276704">Lite mode</translation>
-<translation id="4415276339145661267">Manage your Google Account</translation>
-<translation id="4432792777822557199">Pages in <ph name="SOURCE_LANGUAGE" /> will be translated to <ph name="TARGET_LANGUAGE" /> from now on</translation>
-<translation id="4433925000917964731">Lite page provided by Google</translation>
-<translation id="4434045419905280838">Pop-ups and redirects</translation>
-<translation id="4440958355523780886">Lite page provided by Google. Tap to load the original.</translation>
-<translation id="4452411734226507615">Close <ph name="TAB_TITLE" /> tab</translation>
-<translation id="4452548195519783679">Bookmarked to <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Allow sites to play protected content</translation>
-<translation id="4468959413250150279">Mute sound for a specific site.</translation>
-<translation id="4472118726404937099">To sync and personalise across devices, sign in and turn on sync</translation>
-<translation id="447252321002412580">Help improve Chrome's features and performance</translation>
-<translation id="4479647676395637221">Ask first before allowing sites to use your camera (recommended)</translation>
-<translation id="4479972344484327217">Installing <ph name="MODULE" /> for Chrome…</translation>
-<translation id="4487967297491345095">All Chrome’s app data will be deleted permanently. This includes all files, settings, accounts, databases, etc.</translation>
-<translation id="4493497663118223949">Lite mode is on</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# day ago}other{# days ago}}</translation>
-<translation id="451872707440238414">Search your bookmarks</translation>
-<translation id="4521489764227272523">The selected data has been removed from Chrome and your synced devices.
-
-Your Google Account may have other forms of browsing history such as searches and activity from other Google services at <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Choose folder</translation>
-<translation id="4538018662093857852">Turn on Lite mode</translation>
-<translation id="4550003330909367850">To view or copy your password here, set screen lock on this device.</translation>
-<translation id="4558311620361989323">Web page shortcuts</translation>
-<translation id="4561979708150884304">No connection</translation>
-<translation id="4565377596337484307">Hide password</translation>
-<translation id="4570913071927164677">Details</translation>
-<translation id="4572422548854449519">Sign in to managed account</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minute ago}other{# minutes ago}}</translation>
-<translation id="4587589328781138893">Sites</translation>
-<translation id="4594952190837476234">This offline page is from <ph name="CREATION_TIME" /> and may differ from the online version.</translation>
-<translation id="4605958867780575332">Item removed: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Open <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Use password</translation>
-<translation id="4645575059429386691">Managed by your parent</translation>
-<translation id="4650364565596261010">System default</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> bookmarks deleted</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> was added to your Home screen</translation>
-<translation id="4684427112815847243">Sync everything</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> more}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> more}}</translation>
-<translation id="4696983787092045100">Send text to Your Devices</translation>
-<translation id="4698034686595694889">View offline in <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Cached images and files</translation>
-<translation id="4714588616299687897">Save up to 60% of your data</translation>
-<translation id="4719927025381752090">Offer to translate</translation>
-<translation id="4720023427747327413">Open in <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Help improve Chrome. <ph name="BEGIN_LINK" />Take survey<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Update</translation>
-<translation id="4738836084190194332">Last synced: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Open a new tab</translation>
-<translation id="4751476147751820511">Motion or light sensors</translation>
-<translation id="4759238208242260848">Downloads</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download complete.}other{# downloads complete.}}</translation>
-<translation id="4797039098279997504">Touch to return to <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Passphrase encryption doesn’t include payment methods and addresses from Google Pay.
-
-To change this setting, <ph name="BEGIN_LINK" />reset sync<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Name on card</translation>
-<translation id="4824958205181053313">Cancel sync?</translation>
-<translation id="4837753911714442426">Open options to print page</translation>
-<translation id="4842092870884894799">Showing password generation pop-up</translation>
-<translation id="4860895144060829044">Call</translation>
-<translation id="4866368707455379617">Unable to install <ph name="MODULE" /> for Chrome</translation>
-<translation id="4875775213178255010">Content Suggestions</translation>
-<translation id="4878404682131129617">Establishing a tunnel via proxy server failed</translation>
-<translation id="4880127995492972015">Translate…</translation>
-<translation id="4881695831933465202">Open</translation>
-<translation id="488187801263602086">Rename file</translation>
-<translation id="4882831918239250449">Control how your browsing history is used to personalise Search, ads and more</translation>
-<translation id="4883854917563148705">Managed settings cannot be reset</translation>
-<translation id="4885273946141277891">Unsupported number of Chrome instances.</translation>
-<translation id="4910889077668685004">Payment apps</translation>
-<translation id="4913161338056004800">Reset statistics</translation>
-<translation id="4913169188695071480">Stop refreshing</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Get help<ph name="END_LINK" /> while scanning for devices…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Page}other{# Pages}}</translation>
-<translation id="4932247056774066048">Because you're signing out of an account managed by <ph name="DOMAIN_NAME" />, your Chrome data will be deleted from this device. It will remain in your Google account.</translation>
-<translation id="4943703118917034429">Virtual Reality</translation>
-<translation id="4943872375798546930">No results</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> is sharing your screen</translation>
-<translation id="4961107849584082341">Translate this page to any language</translation>
-<translation id="4962975101802056554">Revoke all permissions for device</translation>
-<translation id="4970824347203572753">Not available in your location</translation>
-<translation id="497421865427891073">go forward</translation>
-<translation id="4988210275050210843">Downloading file (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Pages</translation>
-<translation id="4994033804516042629">No contacts found</translation>
-<translation id="4996978546172906250">Share via</translation>
-<translation id="5004416275253351869">Google activity controls</translation>
-<translation id="5005498671520578047">Copy password</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> wants to connect</translation>
-<translation id="5013696553129441713">No new suggestions</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">While you are in VR, this site may be able to find out about:
-  -  your physical features, such as height
-
-Make sure that you trust this site before entering VR.</translation>
+<translation id="2930742481329940825">Tap to Search sends the selected word and the current page as context to Brave Software Search. You can turn it off in <ph name="BEGIN_LINK"/>Settings<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Allow</translation>
-<translation id="5040262127954254034">Privacy</translation>
-<translation id="5048398596102334565">Allow sites to access motion sensors (recommended)</translation>
-<translation id="5063480226653192405">Usage</translation>
-<translation id="5087580092889165836">Add card</translation>
-<translation id="5100237604440890931">Collapsed – click to expand.</translation>
-<translation id="510275257476243843">1 hour left</translation>
-<translation id="5123685120097942451">Incognito tab</translation>
-<translation id="5127805178023152808">Sync is off</translation>
-<translation id="5129038482087801250">Install web app</translation>
-<translation id="5132942445612118989">Sync your passwords, history and more on all devices</translation>
-<translation id="5139940364318403933">Learn how to use Google Drive</translation>
-<translation id="515227803646670480">Clear stored data</translation>
-<translation id="5152843274749979095">No supported apps installed</translation>
-<translation id="5161254044473106830">Title required</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download failed.}other{# downloads failed.}}</translation>
-<translation id="5170568018924773124">Show in folder</translation>
-<translation id="5184329579814168207">Open in Chrome</translation>
-<translation id="5193988420012215838">Copied to your clipboard</translation>
-<translation id="5197729504361054390">The contacts that you select will be shared with <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Work profile</translation>
-<translation id="5210286577605176222">Jump to the previous tab</translation>
-<translation id="5210365745912300556">Close tab</translation>
-<translation id="5224771365102442243">With video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> wants to scan for nearby Bluetooth devices. The following devices have been found:</translation>
-<translation id="5233638681132016545">New tab</translation>
-<translation id="526421993248218238">Can't load this page</translation>
-<translation id="5271967389191913893">Device cannot open the content to be downloaded.</translation>
-<translation id="528192093759286357">Drag from top and touch the back button to exit full screen.</translation>
-<translation id="5292796745632149097">Send to</translation>
-<translation id="5300589172476337783">Show</translation>
-<translation id="5301954838959518834">OK, got it</translation>
-<translation id="5304593522240415983">This field cannot be blank</translation>
-<translation id="5307446750509046227">Clear site storage</translation>
-<translation id="5308380583665731573">Connect</translation>
-<translation id="5313967007315987356">Add site</translation>
-<translation id="5317780077021120954">Save</translation>
-<translation id="5324858694974489420">Parental Settings</translation>
-<translation id="5327248766486351172">Name</translation>
-<translation id="5335288049665977812">Allow sites to run JavaScript (recommended)</translation>
-<translation id="5342314432463739672">Permission requests</translation>
-<translation id="5357811892247919462">Tab received</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> open tab, tap to switch tabs}other{<ph name="OPEN_TABS_MANY" /> open tabs, tap to switch tabs}}</translation>
-<translation id="5391532827096253100">Your connection to this site is not secure. Site information</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 more)}other{(+ # more)}}</translation>
-<translation id="5400569084694353794">By using this application, you agree to Chrome’s <ph name="BEGIN_LINK1" />Terms of Service<ph name="END_LINK1" /> and <ph name="BEGIN_LINK2" />Privacy Notice<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Names</translation>
-<translation id="5403644198645076998">Only allow certain sites</translation>
-<translation id="5414836363063783498">Verifying…</translation>
-<translation id="5423934151118863508">Your most visited pages will appear here</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB available</translation>
-<translation id="543338862236136125">Edit password</translation>
-<translation id="5433691172869980887">Username copied</translation>
-<translation id="543509235395288790">Downloading <ph name="COUNT" /> files (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Jump to the address bar</translation>
-<translation id="5447201525962359567">All site storage, including cookies and other locally stored data</translation>
-<translation id="5447765697759493033">This site will not be translated</translation>
-<translation id="545042621069398927">Speeding up your download.</translation>
-<translation id="5456381639095306749">Download page</translation>
-<translation id="5475862044948910901">Start Augmented Reality session?</translation>
-<translation id="548278423535722844">Open in maps app</translation>
-<translation id="5487521232677179737">Clear data</translation>
-<translation id="5494752089476963479">Block ads on sites that show intrusive or misleading ads</translation>
-<translation id="5500777121964041360">May not be available in your location</translation>
-<translation id="5512137114520586844">This account is managed by <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Disabled by the administrator of this device</translation>
-<translation id="5515439363601853141">Unlock to view your password</translation>
-<translation id="5516455585884385570">Open notification settings</translation>
-<translation id="5517095782334947753">You have bookmarks, history, passwords and other settings from <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Redirect blocked.</translation>
-<translation id="5527082711130173040">Chrome needs location access to scan for devices. <ph name="BEGIN_LINK1" />Update permissions<ph name="END_LINK1" />. Location access is also <ph name="BEGIN_LINK2" />turned off for this device<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Ask before allowing sites to read text and images from the clipboard (recommended)</translation>
-<translation id="5530766185686772672">Close incognito tabs</translation>
-<translation id="5534334044554683961">While you are in VR, this site may be able to find out about:
-  -   your physical features, such as height
-  -   the layout of your room
-
-Make sure that you trust this site before entering VR.</translation>
-<translation id="5534640966246046842">Site copied</translation>
-<translation id="5556459405103347317">Reload</translation>
-<translation id="5561549206367097665">Waiting for network…</translation>
-<translation id="557283862590186398">Chrome needs permission to access your microphone for this site.</translation>
-<translation id="55737423895878184">Location and notifications are allowed</translation>
-<translation id="5578795271662203820">Search <ph name="SEARCH_ENGINE" /> for this image</translation>
-<translation id="5581519193887989363">You can always choose what to sync in <ph name="BEGIN_LINK1" />settings<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Edit address</translation>
-<translation id="5596627076506792578">More options</translation>
-<translation id="5599455543593328020">Incognito mode</translation>
-<translation id="5620928963363755975">Find your files and pages in Downloads from the More Options button</translation>
-<translation id="5626134646977739690">Name:</translation>
-<translation id="5639724618331995626">Allow all sites</translation>
-<translation id="5648166631817621825">Last 7 days</translation>
-<translation id="5649053991847567735">Automatic downloads</translation>
-<translation id="5655963694829536461">Search your downloads</translation>
-<translation id="5659593005791499971">Email</translation>
-<translation id="5665379678064389456">Create event in <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Override a website’s request to prevent zooming in</translation>
-<translation id="5677928146339483299">Blocked</translation>
-<translation id="5684874026226664614">Oops. This page could not be translated.</translation>
-<translation id="5686790454216892815">File name too long</translation>
-<translation id="5689516760719285838">Location</translation>
-<translation id="569536719314091526">Translate this page to any language from the More options button</translation>
-<translation id="572328651809341494">Recent tabs</translation>
-<translation id="5726692708398506830">Make everything on the page bigger</translation>
-<translation id="5748802427693696783">Switched to standard tabs</translation>
-<translation id="5749068826913805084">Chrome needs storage access to download files.</translation>
-<translation id="5763382633136178763">Incognito tabs</translation>
-<translation id="5763514718066511291">Tap to copy the URL for this app</translation>
-<translation id="5765780083710877561">Description:</translation>
-<translation id="5793665092639000975">Using <ph name="SPACE_USED" /> of <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google may use your history to personalise Search, ads and other Google services</translation>
-<translation id="5804241973901381774">Permissions</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# hour ago}other{# hours ago}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. All rights reserved.</translation>
-<translation id="5817918615728894473">Pair</translation>
-<translation id="583281660410589416">Unknown</translation>
-<translation id="5833984609253377421">Share link</translation>
-<translation id="5836192821815272682">Downloading Chrome Update…</translation>
-<translation id="5853623416121554550">paused</translation>
-<translation id="5854790677617711513">Older than 30 days</translation>
-<translation id="5858741533101922242">Chrome is unable to turn on Bluetooth adaptor</translation>
-<translation id="5860033963881614850">Off</translation>
-<translation id="5862731021271217234">To get your tabs from your other devices, turn on sync</translation>
-<translation id="5864174910718532887">Details: Sorted by site name</translation>
-<translation id="5864419784173784555">Waiting for another download…</translation>
-<translation id="5865733239029070421">Automatically sends usage statistics and crash reports to Google</translation>
-<translation id="5869522115854928033">Saved passwords</translation>
-<translation id="5902828464777634901">All local data stored by this website, including cookies, will be deleted.</translation>
-<translation id="5916664084637901428">On</translation>
-<translation id="5919204609460789179">Update <ph name="PRODUCT_NAME" /> to start sync</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> saved</translation>
-<translation id="5939518447894949180">Reset</translation>
-<translation id="5942872142862698679">Using Google for search</translation>
-<translation id="5952764234151283551">Sends the URL of a page that you're trying to reach to Google</translation>
-<translation id="5956665950594638604">Open the Chrome Help Centre in a new tab</translation>
-<translation id="5958275228015807058">Find your files and pages in Downloads</translation>
-<translation id="5962718611393537961">Tap to collapse</translation>
-<translation id="6000066717592683814">Keep Google</translation>
-<translation id="6005538289190791541">Suggested password</translation>
-<translation id="6036057147555329831">Extra ICU</translation>
-<translation id="6039379616847168523">Jump to the next tab</translation>
-<translation id="6040143037577758943">Close</translation>
-<translation id="6042308850641462728">More</translation>
-<translation id="604996488070107836"><ph name="FILE_NAME" /> download failed due to an unknown error.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">Completed downloads</translation>
-<translation id="6075798973483050474">Edit home page</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> hours left</translation>
-<translation id="6108923351542677676">Setup in progress…</translation>
-<translation id="6111020039983847643">data used</translation>
-<translation id="6112702117600201073">Refreshing page</translation>
-<translation id="6127379762771434464">Item removed</translation>
-<translation id="6140912465461743537">Country/Region</translation>
-<translation id="614940544461990577">Try:</translation>
-<translation id="6154478581116148741">Turn on screen lock in Settings to export your passwords from this device</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> data savings</translation>
-<translation id="6165508094623778733">Learn more</translation>
-<translation id="6177111841848151710">Blocked for current search engine</translation>
-<translation id="6181444274883918285">Add site exception</translation>
-<translation id="6192333916571137726">Download File</translation>
-<translation id="6192792657125177640">Exceptions</translation>
-<translation id="6194112207524046168">To let Chrome access your camera, also turn on camera in <ph name="BEGIN_LINK" />Android Settings<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Block third-party cookies</translation>
-<translation id="6206551242102657620">Connection is secure. Site information</translation>
-<translation id="6210748933810148297">Not <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Unlock to export your passwords</translation>
+<translation id="1406000523432664303">‘Do Not Track’</translation>
 <translation id="6232535412751077445">Enabling ‘Do Not Track’ means that a request will be included with your browsing traffic. Any effect depends on whether a website responds to the request and how the request is interpreted.
 
 For example, some websites may respond to this request by showing you ads that aren’t based on other websites that you’ve visited. Many websites will still collect and use your browsing data – for example to improve security, to provide content, ads and recommendations and to generate reporting statistics.</translation>
-<translation id="624789221780392884">Update ready</translation>
-<translation id="6255999984061454636">Content suggestions</translation>
-<translation id="6277522088822131679">There was a problem printing the page. Please try again.</translation>
-<translation id="6295158916970320988">All sites</translation>
-<translation id="629730747756840877">Account</translation>
-<translation id="6303969859164067831">Sign out and turn off sync</translation>
-<translation id="6316139424528454185">Android version is unsupported</translation>
-<translation id="6320088164292336938">Vibrate</translation>
-<translation id="6324034347079777476">Android system sync disabled</translation>
-<translation id="6333140779060797560">Share via <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Encryption</translation>
-<translation id="6341580099087024258">Ask where to save files</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> more}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> more}}</translation>
-<translation id="6364438453358674297">Remove suggestion from history?</translation>
-<translation id="6369229450655021117">From here, you can search the web, share with friends and see open pages</translation>
-<translation id="6378173571450987352">Details: Sorted by amount of data used</translation>
-<translation id="6381421346744604172">Darken websites</translation>
-<translation id="6388207532828177975">Clear &amp; reset</translation>
-<translation id="6393863479814692971">Chrome needs permission to access your camera and microphone for this site.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Edit bookmark</translation>
-<translation id="6406506848690869874">Sync</translation>
-<translation id="641643625718530986">Print…</translation>
-<translation id="6416782512398055893">Downloaded <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Translate the Web</translation>
-<translation id="6433501201775827830">Choose your search engine</translation>
-<translation id="6437478888915024427">Page info</translation>
-<translation id="6441734959916820584">Name is too long</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Image}other{# Images}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Can’t open file</translation>
-<translation id="6464977750820128603">You can see sites that you visit in Chrome and set timers for them.\n\nGoogle gets info about the sites for which you set timers and how long you visit them. This info is used to make Digital Wellbeing better.</translation>
-<translation id="6475951671322991020">Download video</translation>
-<translation id="6482749332252372425"><ph name="FILE_NAME" /> download failed due to lack of storage space.</translation>
-<translation id="6496823230996795692">To use <ph name="APP_NAME" /> for the first time, please connect to the Internet.</translation>
-<translation id="6508722015517270189">Restart Chrome</translation>
-<translation id="6527303717912515753">Share</translation>
-<translation id="6532866250404780454">Sites that you visit in Chrome won't show. All site timers will be deleted.</translation>
-<translation id="6534565668554028783">Google took too long to respond</translation>
-<translation id="6538442820324228105">Downloaded <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Something went wrong. Try again later.</translation>
-<translation id="654446541061731451">Select a tab to beam</translation>
-<translation id="6545017243486555795">Clear All Data</translation>
-<translation id="6545864417968258051">Bluetooth scanning</translation>
-<translation id="6560414384669816528">Search with Sogou</translation>
-<translation id="6566259936974865419">Chrome has saved you <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Always allow</translation>
-<translation id="6573431926118603307">Tabs that you've opened in Chrome on your other devices will appear here.</translation>
-<translation id="6583199322650523874">Bookmark the current page</translation>
-<translation id="6593061639179217415">Desktop site</translation>
-<translation id="6600954340915313787">Copied to Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Protected content</translation>
-<translation id="6627583120233659107">Edit folder</translation>
-<translation id="6643016212128521049">Clear</translation>
-<translation id="6643649862576733715">Sort by amount of data saved</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> more}other{<ph name="CONTACT_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> more}}</translation>
-<translation id="6649642165559792194">Preview image <ph name="BEGIN_NEW" />New<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome needs location access to scan for devices. <ph name="BEGIN_LINK" />Update permissions<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Password</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Open in <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Chrome Privacy Notice</translation>
-<translation id="6676840375528380067">Clear your Chrome data from this device?</translation>
-<translation id="6697492270171225480">Show suggestions for similar pages when a page can't be found</translation>
-<translation id="6697947395630195233">Chrome needs access to your location to share your location with this site.</translation>
-<translation id="6698801883190606802">Manage synced data</translation>
-<translation id="6699370405921460408">Google servers will optimise the pages that you visit.</translation>
-<translation id="6706288973712894588">You are currently offline.\n<ph name="BEGIN_LINK" />Explore your offline feed.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">News</translation>
-<translation id="6710213216561001401">Previous</translation>
-<translation id="671481426037969117">Your <ph name="FQDN" /> timer ran out. It will start again tomorrow.</translation>
-<translation id="6738867403308150051">Downloading…</translation>
-<translation id="6746124502594467657">Move down</translation>
-<translation id="6766622839693428701">Swipe down to close.</translation>
-<translation id="6766758767654711248">Tap to go to site</translation>
-<translation id="6767294960381293877">List of devices to share a tab with, opened at half height.</translation>
-<translation id="6782111308708962316">Prevent third-party websites from saving and reading cookie data</translation>
-<translation id="6790428901817661496">Play</translation>
-<translation id="6811034713472274749">Page is ready to view</translation>
-<translation id="6818926723028410516">Select items</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Translate</translation>
-<translation id="6845325883481699275">Help improve Chrome security</translation>
-<translation id="6846298663435243399">Loading…</translation>
-<translation id="6850409657436465440">Your download is still in progress</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> tabs closed</translation>
-<translation id="6864459304226931083">Download image</translation>
-<translation id="6865313869410766144">Auto-fill form data</translation>
-<translation id="688738109438487280">Add existing data to <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Unlock to copy your password</translation>
-<translation id="6896758677409633944">Copy</translation>
-<translation id="6910211073230771657">Deleted</translation>
-<translation id="6912998170423641340">Block sites from reading text and images from the clipboard</translation>
-<translation id="6914783257214138813">Your passwords will be visible to anyone who can see the exported file.</translation>
-<translation id="6942665639005891494">Change the default download location at any time using the Settings menu option</translation>
-<translation id="6945221475159498467">Select</translation>
-<translation id="6963642900430330478">This page is dangerous. Site information</translation>
-<translation id="6963766334940102469">Delete bookmarks</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">All time</translation>
-<translation id="6981982820502123353">Accessibility</translation>
-<translation id="6989267951144302301">Couldn’t download</translation>
-<translation id="6990079615885386641">Get the app from the Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Ask first before allowing sites to use your microphone (recommended)</translation>
-<translation id="7015203776128479407">Initial sync setup was not finished. Sync is off.</translation>
-<translation id="7016516562562142042">Allowed for current search engine</translation>
-<translation id="7022756207310403729">Open in browser</translation>
-<translation id="702463548815491781">Recommended when TalkBack or Switch Access are on</translation>
-<translation id="7029809446516969842">Passwords</translation>
-<translation id="7053983685419859001">Block</translation>
-<translation id="7055152154916055070">Redirect blocked:</translation>
-<translation id="7063006564040364415">Could not connect to the sync server.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selected}other{# selected}}</translation>
-<translation id="7071521146534760487">Manage account</translation>
-<translation id="7077143737582773186">SD Card</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> selected. Options available near top of the screen</translation>
-<translation id="7121362699166175603">Clears history and auto-completions in the address bar. Your Google Account may have other forms of browsing history at <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Allow for current search engine</translation>
-<translation id="7138678301420049075">Other</translation>
-<translation id="7141896414559753902">Block sites from showing pop-ups and redirects (recommended)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Load original page<ph name="END_LINK" /> from <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Last 24 Hours</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">You can change this later in Settings</translation>
-<translation id="7180611975245234373">Refresh</translation>
-<translation id="7189372733857464326">Waiting for Google Play Services to finish updating</translation>
-<translation id="7191430249889272776">Tab opened in background.</translation>
-<translation id="723171743924126238">Select images</translation>
-<translation id="7233236755231902816">To see the web in your language, get the latest version of Chrome</translation>
-<translation id="7243308994586599757">Options available near bottom of the screen</translation>
-<translation id="7248069434667874558">Make sure that <ph name="TARGET_DEVICE_NAME" /> has sync turned on in Chrome</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> selected</translation>
-<translation id="7274013316676448362">Blocked site</translation>
-<translation id="7290209999329137901">Rename unavailable</translation>
-<translation id="7291387454912369099">Assistant Triggered Checkout</translation>
-<translation id="7293171162284876153">To start sync, turn on 'Sync your Chrome data'.</translation>
-<translation id="729975465115245577">Your device doesn’t have an app to store the passwords file.</translation>
-<translation id="7302081693174882195">Details: Sorted by amount of data saved</translation>
-<translation id="7328017930301109123">In Lite mode, Chrome loads pages faster and uses up to 60 per cent less data.</translation>
-<translation id="7333031090786104871">Still adding previous site</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Share 1 selected item}other{Share # selected items}}</translation>
 <translation id="7359002509206457351">Access payment methods</translation>
+<translation id="8026334261755873520">Clear browsing data</translation>
+<translation id="1291207594882862231">Clear history, cookies, site data, cache…</translation>
+<translation id="7814200940910057384">Cleared Brave data</translation>
+<translation id="1664855196866195614">The selected data has been removed from Brave and your synced devices.
+
+Your Brave Software Account may have other forms of browsing history such as searches and activity from other Brave Software services at <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Cached images and files</translation>
+<translation id="2496180316473517155">Browsing history</translation>
+<translation id="2546283357679194313">Cookies and site data</translation>
+<translation id="8662811608048051533">Signs you out of most sites.</translation>
+<translation id="8218628800671693884">Signs you out of most sites. You won't be signed out of your Brave Software Account.</translation>
+<translation id="2017836877785168846">Clears history and autocompletions in the address bar.</translation>
+<translation id="8096327394278038498">Clears history and auto-completions in the address bar. Your Brave Software Account may have other forms of browsing history at <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Clears history from all signed-in devices. Your Brave Software Account may have other forms of browsing history at <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Saved passwords</translation>
+<translation id="6865313869410766144">Auto-fill form data</translation>
+<translation id="7562080006725997899">Clear browsing data</translation>
+<translation id="5487521232677179737">Clear data</translation>
+<translation id="7498271377022651285">Please wait…</translation>
+<translation id="784934925303690534">Time range</translation>
+<translation id="1718835860248848330">Last hour</translation>
+<translation id="7149893636342594995">Last 24 Hours</translation>
+<translation id="5648166631817621825">Last 7 days</translation>
+<translation id="8571213806525832805">Last 4 weeks</translation>
+<translation id="5854790677617711513">Older than 30 days</translation>
+<translation id="6979737339423435258">All time</translation>
+<translation id="982182592107339124">This will clear data for all sites, including:</translation>
+<translation id="6643016212128521049">Clear</translation>
+<translation id="7641339528570811325">Clear browsing data…</translation>
+<translation id="1670399744444387456">Basic</translation>
+<translation id="3245261285041759672">Your Brave Software Account may have other forms of browsing history at <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Blocked site</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> items deleted</translation>
+<translation id="1121094540300013208">Usage and crash reports</translation>
+<translation id="9079153198295609735">Automatically send usage statistics and crash reports to Brave Software</translation>
+<translation id="6981982820502123353">Accessibility</translation>
+<translation id="2387895666653383613">Text scaling</translation>
+<translation id="2321958826496381788">Drag the slider until you can read this comfortably. Text should look at least this big after double-tapping on a paragraph.</translation>
+<translation id="3895926599014793903">Force enable zoom</translation>
+<translation id="5668404140385795438">Override a website’s request to prevent zooming in</translation>
+<translation id="4149994727733219643">Simplified view for web pages</translation>
+<translation id="9100505651305367705">Offer to show articles in simplified view, when supported</translation>
+<translation id="1409426117486808224">Simplified view for open tabs</translation>
+<translation id="702463548815491781">Recommended when TalkBack or Switch Access are on</translation>
+<translation id="8284326494547611709">Captions</translation>
+<translation id="4165986682804962316">Site settings</translation>
+<translation id="6295158916970320988">All sites</translation>
+<translation id="8380167699614421159">This site shows intrusive or misleading ads</translation>
+<translation id="1919345977826869612">Ads</translation>
+<translation id="410351446219883937">Auto-play</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Block third-party cookies</translation>
+<translation id="6782111308708962316">Prevent third-party websites from saving and reading cookie data</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-ups and redirects</translation>
+<translation id="4751476147751820511">Motion or light sensors</translation>
+<translation id="1717218214683051432">Motion sensors</translation>
+<translation id="2091887806945687916">Sound</translation>
+<translation id="2586657967955657006">Clipboard</translation>
+<translation id="6320088164292336938">Vibrate</translation>
+<translation id="4226663524361240545">Notifications may vibrate the device</translation>
+<translation id="1446450296470737166">Allow full control of MIDI devices</translation>
+<translation id="3744111561329211289">Background sync</translation>
+<translation id="5649053991847567735">Automatic downloads</translation>
+<translation id="6181444274883918285">Add site exception</translation>
+<translation id="5313967007315987356">Add site</translation>
+<translation id="1369915414381695676">Site <ph name="SITE_NAME"/> added</translation>
+<translation id="7837721118676387834">Allow auto-play of muted videos for a specific site.</translation>
+<translation id="2621115761605608342">Allow JavaScript for a specific site.</translation>
+<translation id="8801436777607969138">Block JavaScript for a specific site.</translation>
+<translation id="8372893542064058268">Allow Background Sync for a specific site.</translation>
+<translation id="358794129225322306">Allow a site to download multiple files automatically.</translation>
+<translation id="4008040567710660924">Allow cookies for a specific site.</translation>
+<translation id="8958424370300090006">Block cookies for a specific site.</translation>
+<translation id="7882806643839505685">Allow sound for a specific site.</translation>
+<translation id="4468959413250150279">Mute sound for a specific site.</translation>
+<translation id="1994173015038366702">Site URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Usage</translation>
+<translation id="5804241973901381774">Permissions</translation>
+<translation id="4278390842282768270">Allowed</translation>
+<translation id="5677928146339483299">Blocked</translation>
+<translation id="1984937141057606926">Allowed, except third-party</translation>
+<translation id="7423098979219808738">Ask first</translation>
+<translation id="8116925261070264013">Muted</translation>
+<translation id="8300705686683892304">Managed by app</translation>
+<translation id="6192792657125177640">Exceptions</translation>
+<translation id="257931822824936280">Expanded – click to collapse.</translation>
+<translation id="5100237604440890931">Collapsed – click to expand.</translation>
+<translation id="857943718398505171">Allowed (recommended)</translation>
+<translation id="2913331724188855103">Allow sites to save and read cookie data (recommended)</translation>
+<translation id="7445411102860286510">Allow sites to automatically play muted videos (recommended)</translation>
+<translation id="5335288049665977812">Allow sites to run JavaScript (recommended)</translation>
+<translation id="5527111080432883924">Ask before allowing sites to read text and images from the clipboard (recommended)</translation>
+<translation id="6912998170423641340">Block sites from reading text and images from the clipboard</translation>
+<translation id="7423538860840206698">Blocked from reading clipboard</translation>
+<translation id="3955193568934677022">Allow sites to play protected content (recommended)</translation>
+<translation id="445467742685312942">Allow sites to play protected content</translation>
+<translation id="2107397443965016585">Ask before allowing sites to play protected content (recommended)</translation>
+<translation id="2910701580606108292">Ask before allowing sites to play protected content</translation>
+<translation id="757524316907819857">Block sites from playing protected content</translation>
+<translation id="3277252321222022663">Allow sites to access sensors (recommended)</translation>
+<translation id="5048398596102334565">Allow sites to access motion sensors (recommended)</translation>
+<translation id="8816026460808729765">Block sites from accessing sensors</translation>
+<translation id="169515064810179024">Block sites from accessing motion sensors</translation>
+<translation id="1660204651932907780">Allow sites to play sound (recommended)</translation>
+<translation id="3600792891314830896">Mute sites that play sound</translation>
+<translation id="1743802530341753419">Ask before allowing sites to connect to a device (recommended)</translation>
+<translation id="851751545965956758">Block sites from connecting to devices</translation>
+<translation id="7141896414559753902">Block sites from showing pop-ups and redirects (recommended)</translation>
+<translation id="5494752089476963479">Block ads on sites that show intrusive or misleading ads</translation>
+<translation id="3123473560110926937">Blocked on some sites</translation>
+<translation id="965817943346481315">Block if site shows intrusive or misleading ads (recommended)</translation>
+<translation id="3386292677130313581">Ask before allowing sites to know your location (recommended)</translation>
+<translation id="9139068048179869749">Ask before allowing sites to send notifications (recommended)</translation>
+<translation id="4479647676395637221">Ask first before allowing sites to use your camera (recommended)</translation>
+<translation id="6992289844737586249">Ask first before allowing sites to use your microphone (recommended)</translation>
+<translation id="2289270750774289114">Ask when a site wants to discover nearby Bluetooth devices (recommended)</translation>
+<translation id="7053983685419859001">Block</translation>
+<translation id="7128222689758636196">Allow for current search engine</translation>
+<translation id="7589445247086920869">Block for current search engine</translation>
+<translation id="6388207532828177975">Clear &amp; reset</translation>
+<translation id="7999064672810608036">Are you sure that you want to clear all local data, including cookies, and reset all permissions for this website?</translation>
+<translation id="2822354292072154809">Are you sure that you want to reset all site permissions for <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Clear stored data</translation>
+<translation id="5902828464777634901">All local data stored by this website, including cookies, will be deleted.</translation>
+<translation id="119944043368869598">Clear all</translation>
+<translation id="2490684707762498678">Managed by <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Open notification settings</translation>
+<translation id="1404122904123200417">Embedded in <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Files saved by websites appear here</translation>
+<translation id="4181841719683918333">Languages</translation>
+<translation id="2647434099613338025">Add language</translation>
+<translation id="1952172573699511566">Websites will show text in your preferred language, when possible.</translation>
+<translation id="8559990750235505898">Offer to translate pages in other languages</translation>
+<translation id="4719927025381752090">Offer to translate</translation>
+<translation id="8156139159503939589">What languages do you read?</translation>
+<translation id="5689516760719285838">Location</translation>
+<translation id="2440823041667407902">Location access</translation>
+<translation id="2023546461831060654">Turn on permissions for Brave in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Turn on permission for Brave in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">To let Brave access your location, also turn on location in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">To let Brave access your camera, also turn on camera in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">To let Brave send you notifications, also turn on notifications in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">To let Brave access your microphone, also turn on microphone in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Location access is off for this device. Turn it on in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Location access is also off for this device. Turn it on in <ph name="BEGIN_LINK"/>Android Settings<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Camera</translation>
+<translation id="3227137524299004712">Microphone</translation>
+<translation id="1647391597548383849">Access your camera</translation>
+<translation id="945632385593298557">Access your microphone</translation>
+<translation id="6612358246767739896">Protected content</translation>
+<translation id="885701979325669005">Storage</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> stored data</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revoke device permission</translation>
+<translation id="4962975101802056554">Revoke all permissions for device</translation>
+<translation id="6545864417968258051">Bluetooth scanning</translation>
+<translation id="4411535500181276704">Lite mode</translation>
+<translation id="7821588508402923572">Your data savings will appear here</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> saved</translation>
+<translation id="8569404424186215731">since <ph name="DATE"/></translation>
+<translation id="3252158532344029638">In Lite mode, Brave loads pages faster and uses up to 60 per cent less data.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> data savings</translation>
+<translation id="7494974237137038751">data saved</translation>
+<translation id="6111020039983847643">data used</translation>
+<translation id="7413229368719586778">Start date <ph name="DATE"/></translation>
+<translation id="1782483593938241562">End date <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sort by site</translation>
+<translation id="5864174910718532887">Details: Sorted by site name</translation>
+<translation id="116280672541001035">Used</translation>
+<translation id="8349013245300336738">Sort by amount of data used</translation>
+<translation id="6378173571450987352">Details: Sorted by amount of data used</translation>
+<translation id="2631006050119455616">Saved</translation>
+<translation id="6643649862576733715">Sort by amount of data saved</translation>
+<translation id="7302081693174882195">Details: Sorted by amount of data saved</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> used</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> saved</translation>
+<translation id="2156074688469523661">Remaining sites (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Other</translation>
+<translation id="4913161338056004800">Reset statistics</translation>
+<translation id="1856325424225101786">Reset Lite mode?</translation>
+<translation id="3658159451045945436">Resetting wipes your history of data savings, including the list of visited sites.</translation>
+<translation id="3295530008794733555">Browse faster. Use less data.</translation>
+<translation id="7340390500800578919">In Lite mode, Brave loads pages faster and uses up to 60 per cent less data. To optimise the pages that you visit, Brave sends your web traffic to Brave Software. <ph name="BEGIN_LINK"/>Find out more<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Turn on Lite mode</translation>
+<translation id="4493497663118223949">Lite mode is on</translation>
+<translation id="7559975015014302720">Lite mode is off</translation>
+<translation id="7606077192958116810">Lite mode is on. Manage it in Settings.</translation>
+<translation id="4714588616299687897">Save up to 60% of your data</translation>
+<translation id="1006927014032731288">Brave Software servers will optimise the pages that you visit.</translation>
+<translation id="3257320067425202300">Brave has saved you <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave has saved you <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Download location</translation>
+<translation id="7077143737582773186">SD Card</translation>
+<translation id="7762668264895820836">SD Card <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Ask where to save files</translation>
+<translation id="6192333916571137726">Download File</translation>
+<translation id="1672586136351118594">Don‘t show again</translation>
+<translation id="2650751991977523696">Download file again?</translation>
+<translation id="8664979001105139458">File name already exists</translation>
+<translation id="488187801263602086">Rename file</translation>
+<translation id="5686790454216892815">File name too long</translation>
+<translation id="7454641608352164238">Not enough space</translation>
+<translation id="8972098258593396643">Download to default folder?</translation>
+<translation id="804335162455518893">SD card not found</translation>
+<translation id="7475688122056506577">SD card not found. Some of your files may be missing.</translation>
+<translation id="4198423547019359126">No available download locations</translation>
+<translation id="8224471946457685718">Download articles for you on Wi-Fi</translation>
+<translation id="4970824347203572753">Not available in your location</translation>
+<translation id="5500777121964041360">May not be available in your location</translation>
+<translation id="1173894706177603556">Rename</translation>
+<translation id="1986685561493779662">Name already exists</translation>
+<translation id="6441734959916820584">Name is too long</translation>
+<translation id="2923908459366352541">Name is invalid</translation>
+<translation id="7290209999329137901">Rename unavailable</translation>
+<translation id="3334729583274622784">Change file extension?</translation>
+<translation id="107147699690128016">If you change the file extension, the file may open in a different application and potentially be a hazard to your device.</translation>
+<translation id="8541922081612557424">About Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. All rights reserved.</translation>
+<translation id="1416550906796893042">Application version</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Updated <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operating system</translation>
+<translation id="3968054912784331254">Brave updates are no longer supported for this version of Android</translation>
+<translation id="7665369617277396874">Add account</translation>
+<translation id="649070405679044769">Signed in to Brave Software as</translation>
+<translation id="6234515504547364178">Sign out of Brave</translation>
+<translation id="5324858694974489420">Parental Settings</translation>
+<translation id="8920114477895755567">Waiting for details of parents.</translation>
+<translation id="5512137114520586844">This account is managed by <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">This account is managed by <ph name="PARENT_NAME_1"/> and <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Content</translation>
+<translation id="5403644198645076998">Only allow certain sites</translation>
+<translation id="8641930654639604085">Try to block mature sites</translation>
+<translation id="5639724618331995626">Allow all sites</translation>
+<translation id="796823723482603597">Powered by Brave</translation>
+<translation id="6324034347079777476">Android system sync disabled</translation>
+<translation id="5127805178023152808">Sync is off</translation>
+<translation id="7015203776128479407">Initial sync setup was not finished. Sync is off.</translation>
+<translation id="2497852260688568942">Sync is disabled by your administrator</translation>
+<translation id="9100610230175265781">Passphrase required</translation>
+<translation id="6108923351542677676">Setup in progress…</translation>
+<translation id="4062305924942672200">Legal information</translation>
+<translation id="4256782883801055595">Open-source licences</translation>
+<translation id="1138681184697033370">Brave Terms of Service</translation>
+<translation id="7392539049993970338">Brave Privacy Notice</translation>
+<translation id="2677748264148917807">Leave</translation>
+<translation id="5556459405103347317">Reload</translation>
+<translation id="1623104350909869708">Prevent this page from creating additional dialogues</translation>
+<translation id="2968755619301702150">Certificate viewer</translation>
+<translation id="1360432990279830238">Sign out and turn off sync?</translation>
+<translation id="8581481290581777242">Clear your Brave data from this device?</translation>
+<translation id="1318865768845061710">Your bookmarks, history, passwords and other Brave data will no longer be synced to your Brave Software account</translation>
+<translation id="3325020657155065477">Also clear your Brave data from this device</translation>
+<translation id="6136448902816743006">Because you're signing out of an account managed by <ph name="DOMAIN_NAME"/>, your Brave data will be deleted from this device. It will remain in your Brave Software account.</translation>
+<translation id="1853026300647876496">Contacting Brave Software. This may take a minute…</translation>
+<translation id="2328985652426384049">Can’t sign in</translation>
+<translation id="7723158744459952869">Brave Software took too long to respond</translation>
+<translation id="4572422548854449519">Sign in to managed account</translation>
+<translation id="2689656545739939160">You are signing in with an account managed by <ph name="MANAGED_DOMAIN"/> and giving its administrator control over your Brave data. Your data will become permanently tied to this account. Signing out of Brave will delete your data from this device, but it will remain stored in your Brave Software Account.</translation>
+<translation id="1749561566933687563">Sync your bookmarks</translation>
+<translation id="4242533952199664413">Open settings</translation>
+<translation id="1111673857033749125">Bookmarks saved on your other devices will appear here.</translation>
+<translation id="8636825310635137004">To get your tabs from your other devices, turn on sync.</translation>
+<translation id="3269956123044984603">To get your tabs from your other devices, turn on “Auto-sync data” in Android account settings.</translation>
+<translation id="5157964048453367290">Tabs that you've opened in Brave on your other devices will appear here.</translation>
+<translation id="4684427112815847243">Sync everything</translation>
+<translation id="2709516037105925701">Auto-fill</translation>
+<translation id="8820817407110198400">Bookmarks</translation>
+<translation id="1644574205037202324">History</translation>
+<translation id="17513872634828108">Open tabs</translation>
+<translation id="1320169905922104972">Credit cards and addresses using Brave Software Pay</translation>
+<translation id="6337234675334993532">Encryption</translation>
+<translation id="6698801883190606802">Manage synced data</translation>
+<translation id="3598578758776312506">Encrypt passwords with Brave Software credentials</translation>
+<translation id="7810580217418711046">Encrypt synced data with Brave Software password as of <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Encrypt synced data with your own sync passphrase</translation>
+<translation id="2996291259634659425">Create passphrase</translation>
+<translation id="5713644099811900409">Brave Software Account</translation>
+<translation id="8997474919031554666">Passphrase encryption doesn’t include payment methods and addresses from Brave Software Pay. Only someone with your passphrase can read your encrypted data. The passphrase is not sent to or stored by Brave Software. If you forget your passphrase or want to change this setting, you'll need to reset sync. <ph name="BEGIN_LINK"/>Find out more<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Passphrase</translation>
+<translation id="7772032839648071052">Confirm passphrase</translation>
+<translation id="5304593522240415983">This field cannot be blank</translation>
+<translation id="321773570071367578">If you forgot your passphrase or want to change this setting, <ph name="BEGIN_LINK"/>reset sync<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Passphrases do not match</translation>
+<translation id="5149495116300586333">Passphrase encryption doesn’t include payment methods and addresses from Brave Software Pay.
+
+To change this setting, <ph name="BEGIN_LINK"/>reset sync<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Incorrect passphrase</translation>
+<translation id="5414836363063783498">Verifying…</translation>
+<translation id="6846298663435243399">Loading…</translation>
+<translation id="5517095782334947753">You have bookmarks, history, passwords and other settings from <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combine my data</translation>
+<translation id="688738109438487280">Add existing data to <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Keep my data separate</translation>
+<translation id="1145536944570833626">Delete existing data.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> wants to pair</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Get help<ph name="END_LINK"/> while scanning for devices…</translation>
+<translation id="5817918615728894473">Pair</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Get help<ph name="END_LINK1"/> or <ph name="BEGIN_LINK2"/>re-scan<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">No compatible devices found</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Turn on Bluetooth<ph name="END_LINK"/> to allow pairing</translation>
+<translation id="998321811308652668">Brave is unable to turn on Bluetooth adaptor</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Get help<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave needs location access to scan for devices. <ph name="BEGIN_LINK"/>Update permissions<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave needs location access to scan for devices. Location access is <ph name="BEGIN_LINK"/>turned off for this device<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave needs location access to scan for devices. <ph name="BEGIN_LINK1"/>Update permissions<ph name="END_LINK1"/>. Location access is also <ph name="BEGIN_LINK2"/>turned off for this device<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Connected device</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signal Strength Level: # bar}other{Signal Strength Level: # bars}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> wants to scan for nearby Bluetooth devices. The following devices have been found:</translation>
+<translation id="8368027906805972958">Unknown or unsupported device (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sync isn't working</translation>
+<translation id="1810845389119482123">Initial sync setup not finished</translation>
+<translation id="3235722914093408050">Open Android settings and re-enable Android system sync to start Brave sync</translation>
+<translation id="3367813778245106622">Sign in again to start sync</translation>
+<translation id="974555521953189084">Enter your passphrase to start sync</translation>
+<translation id="2997266899014181325">To start sync, turn on 'Sync your Brave data'.</translation>
+<translation id="8260126382462817229">Try signing in again</translation>
+<translation id="5919204609460789179">Update <ph name="PRODUCT_NAME"/> to start sync</translation>
+<translation id="397583555483684758">Sync has stopped working</translation>
+<translation id="1966710179511230534">Please update your sign-in details.</translation>
+<translation id="7063006564040364415">Could not connect to the sync server.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> is out of date.</translation>
+<translation id="4170011742729630528">The service is not available; try again later.</translation>
+<translation id="7947953824732555851">Accept and sign in</translation>
+<translation id="8583805026567836021">Clearing account data</translation>
+<translation id="8310344678080805313">Standard tabs</translation>
+<translation id="5748802427693696783">Switched to standard tabs</translation>
+<translation id="7998918019931843664">Re-open closed tab</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, tab</translation>
+<translation id="4452411734226507615">Close <ph name="TAB_TITLE"/> tab</translation>
+<translation id="7243308994586599757">Options available near bottom of the screen</translation>
+<translation id="4060598801229743805">Options available near the top of the screen</translation>
+<translation id="2810645512293415242">Simplified page to save data and load faster.</translation>
+<translation id="3985215325736559418">Do you want to download <ph name="FILE_NAME"/> again?</translation>
+<translation id="2450083983707403292">Do you want to start downloading <ph name="FILE_NAME"/> again?</translation>
+<translation id="7514365320538308">Download</translation>
+<translation id="545042621069398927">Speeding up your download.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Downloading file.}other{Downloading # files.}}</translation>
+<translation id="543509235395288790">Downloading <ph name="COUNT"/> files (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Downloading file (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download complete.}other{# downloads complete.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download failed.}other{# downloads failed.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download pending.}other{# downloads pending.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> button</translation>
+<translation id="3205824638308738187">Almost finished!</translation>
+<translation id="3960299545138990065">Restart Brave</translation>
+<translation id="3771001275138982843">Couldn’t download the update</translation>
+<translation id="3888648114124182147">Downloading Brave Update…</translation>
+<translation id="1705567146636171298">Update Brave</translation>
+<translation id="6195417478702700398">For the best browsing experience, open to update Brave</translation>
+<translation id="3512968675351418494">To see the web in your language, get the latest version of Brave</translation>
+<translation id="6427112570124116297">Translate the Web</translation>
+<translation id="1379423114029199501">Update to get your language in the latest version of Brave</translation>
+<translation id="5684874026226664614">Oops. This page could not be translated.</translation>
+<translation id="6831043979455480757">Translate</translation>
+<translation id="1285320974508926690">Never translate this site</translation>
+<translation id="773466115871691567">Always translate pages in <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Never translate pages in <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">More languages</translation>
+<translation id="290376772003165898">Page is not in <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Pages in <ph name="SOURCE_LANGUAGE"/> will be translated to <ph name="TARGET_LANGUAGE"/> from now on</translation>
+<translation id="8339163506404995330">Pages in <ph name="LANGUAGE"/> will not be translated</translation>
+<translation id="5447765697759493033">This site will not be translated</translation>
+<translation id="4880127995492972015">Translate…</translation>
+<translation id="641643625718530986">Print…</translation>
+<translation id="8909135823018751308">Share…</translation>
+<translation id="4996978546172906250">Share via</translation>
+<translation id="6333140779060797560">Share via <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">There was a problem printing the page. Please try again.</translation>
+<translation id="3254409185687681395">Bookmark this page</translation>
+<translation id="497421865427891073">go forward</translation>
+<translation id="813082847718468539">View site information</translation>
+<translation id="2532336938189706096">Web View</translation>
+<translation id="6005538289190791541">Suggested password</translation>
+<translation id="4634124774493850572">Use password</translation>
+<translation id="8285489906452138776">Brave needs permission to access your camera for this site.</translation>
+<translation id="320189792589364011">Brave needs permission to access your microphone for this site.</translation>
+<translation id="7988136689212463100">Brave needs permission to access your camera and microphone for this site.</translation>
+<translation id="4931190655840828017">Brave needs access to your location to share your location with this site.</translation>
+<translation id="3088191967551450609">Brave needs storage access to download files.</translation>
+<translation id="8942627711005830162">Open in other window</translation>
+<translation id="4195643157523330669">Open in new tab</translation>
+<translation id="1100066534610197918">Open in new tab in group</translation>
+<translation id="4860895144060829044">Call</translation>
+<translation id="6896758677409633944">Copy</translation>
+<translation id="8393700583063109961">Send message</translation>
+<translation id="3557336313807607643">Add to contacts</translation>
+<translation id="4269820728363426813">Copy link address</translation>
+<translation id="1206892813135768548">Copy link text</translation>
+<translation id="1204037785786432551">Download link</translation>
+<translation id="6864459304226931083">Download image</translation>
+<translation id="8209050860603202033">Open image</translation>
+<translation id="8073388330009372546">Open image in new tab</translation>
+<translation id="6649642165559792194">Preview image <ph name="BEGIN_NEW"/>New<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Load image</translation>
+<translation id="3845332215609790146">Search with Brave Software Lens <ph name="BEGIN_NEW"/>New<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Search <ph name="SEARCH_ENGINE"/> for this image</translation>
+<translation id="3384347053049321195">Share image</translation>
+<translation id="5833984609253377421">Share link</translation>
+<translation id="6475951671322991020">Download video</translation>
+<translation id="2317945146070194624">Open in new Brave tab</translation>
+<translation id="7975379999046275268">Preview page <ph name="BEGIN_NEW"/>New<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Refreshing page</translation>
+<translation id="36525718899759834">Get the app from the Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Dark</translation>
+<translation id="1807246157184219062">Light</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Select a tab to beam</translation>
+<translation id="8719023831149562936">Can’t beam current tab</translation>
+<translation id="2139186145475833000">Add to Home screen</translation>
+<translation id="4616150815774728855">Open <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Could not open app</translation>
+<translation id="5129038482087801250">Install web app</translation>
+<translation id="3789841737615482174">Install</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> was added to your Home screen</translation>
+<translation id="7333031090786104871">Still adding previous site</translation>
+<translation id="1036727731225946849">Adding <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Added to Home screen</translation>
+<translation id="2146738493024040262">Open Instant App</translation>
+<translation id="7016516562562142042">Allowed for current search engine</translation>
+<translation id="6177111841848151710">Blocked for current search engine</translation>
+<translation id="145097072038377568">Turned off in Android Settings</translation>
+<translation id="8007176423574883786">Turned off for this device</translation>
+<translation id="164269334534774161">You are viewing an offline copy of this page from <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">This offline page is from <ph name="CREATION_TIME"/> and may differ from the online version.</translation>
+<translation id="8840953339110955557">This page may differ from the online version.</translation>
+<translation id="6405300764336705484">This content is from <ph name="DOMAIN_NAME"/>, delivered by Brave Software.</translation>
+<translation id="1006017844123154345">Open Online</translation>
+<translation id="3326636747541519688">Lite page provided by Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Load original page<ph name="END_LINK"/> from <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">If you’re seeing this frequently, try these <ph name="BEGIN_LINK"/>suggestions<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Contents hidden</translation>
+<translation id="3810973564298564668">Manage</translation>
+<translation id="5199929503336119739">Work profile</translation>
+<translation id="528192093759286357">Drag from top and touch the back button to exit full screen.</translation>
+<translation id="2836148919159985482">Touch the back button to exit full screen.</translation>
+<translation id="3967822245660637423">Download complete</translation>
+<translation id="2434158240863470628">Download complete <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Download failed</translation>
+<translation id="1384959399684842514">Download paused</translation>
+<translation id="1671236975893690980">Download pending...</translation>
+<translation id="5561549206367097665">Waiting for network…</translation>
+<translation id="5864419784173784555">Waiting for another download…</translation>
+<translation id="6461962085415701688">Can’t open file</translation>
+<translation id="1178581264944972037">Pause</translation>
+<translation id="8200772114523450471">Resume</translation>
+<translation id="1409879593029778104"><ph name="FILE_NAME"/> download prevented because file already exists.</translation>
+<translation id="3387650086002190359"><ph name="FILE_NAME"/> download failed due to file system errors.</translation>
+<translation id="6482749332252372425"><ph name="FILE_NAME"/> download failed due to lack of storage space.</translation>
+<translation id="7619072057915878432"><ph name="FILE_NAME"/> download failed due to network failures.</translation>
+<translation id="1477626028522505441"><ph name="FILE_NAME"/> download failed due to server issues.</translation>
+<translation id="3692944402865947621"><ph name="FILE_NAME"/> download failed because storage location is not reachable.</translation>
+<translation id="604996488070107836"><ph name="FILE_NAME"/> download failed due to an unknown error.</translation>
+<translation id="6738867403308150051">Downloading…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Downloaded <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Downloaded <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Downloaded <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">1 file left</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> files left</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> file downloaded}other{<ph name="FILES_DOWNLOADED_MANY"/> files downloaded}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> days left</translation>
+<translation id="8190358571722158785">1 day left</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> hours left</translation>
+<translation id="510275257476243843">1 hour left</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> mins left</translation>
+<translation id="3236059992281584593">1 min left</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> secs left</translation>
+<translation id="2781151931089541271">1 sec left</translation>
+<translation id="3303414029551471755">Proceed to download the content?</translation>
+<translation id="8617240290563765734">Open the suggested URL specified in the downloaded content?</translation>
+<translation id="1373696734384179344">Insufficient memory to download the selected content.</translation>
+<translation id="5271967389191913893">Device cannot open the content to be downloaded.</translation>
+<translation id="883806473910249246">An error occurred while downloading the content.</translation>
+<translation id="5626134646977739690">Name:</translation>
+<translation id="7963646190083259054">Vendor:</translation>
+<translation id="3414952576877147120">Size:</translation>
+<translation id="7375125077091615385">Type:</translation>
+<translation id="5765780083710877561">Description:</translation>
+<translation id="4881695831933465202">Open</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB available</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB available</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB available</translation>
+<translation id="5793665092639000975">Using <ph name="SPACE_USED"/> of <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">All</translation>
+<translation id="4988526792673242964">Pages</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Images</translation>
+<translation id="8250920743982581267">Documents</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# File}other{# Files}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Image}other{# Images}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Videos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Audio file}other{# Audio files}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Page}other{# Pages}}</translation>
+<translation id="5456381639095306749">Download page</translation>
+<translation id="2394602618534698961">Files that you download appear here</translation>
+<translation id="7810647596859435254">Open with…</translation>
+<translation id="5655963694829536461">Search your downloads</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">My files</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Articles appear here, which you can read even when you're offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# hr}other{# hrs}}</translation>
+<translation id="5853623416121554550">paused</translation>
+<translation id="8965591936373831584">pending</translation>
+<translation id="2779651927720337254">failed</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Just now</translation>
+<translation id="4000212216660919741">Offline Home</translation>
+<translation id="9133397713400217035">Explore offline</translation>
+<translation id="968900484120156207">Pages that you visit appear here</translation>
+<translation id="7882131421121961860">No history found</translation>
+<translation id="3549657413697417275">Search your history</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave First Run Experience</translation>
+<translation id="2700285883409956633">By using this application, you agree to Brave’s <ph name="BEGIN_LINK1"/>Terms of Service<ph name="END_LINK1"/> and <ph name="BEGIN_LINK2"/>Privacy Notice<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">By using this application, you agree to Brave’s <ph name="BEGIN_LINK1"/>Terms of Service<ph name="END_LINK1"/> and <ph name="BEGIN_LINK2"/>Privacy Notice<ph name="END_LINK2"/>, and the <ph name="BEGIN_LINK3"/>Privacy Notice for Brave Software Accounts Managed with Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> will open in Brave. By continuing, you agree to Brave’s <ph name="BEGIN_LINK1"/>Terms of Service<ph name="END_LINK1"/> and <ph name="BEGIN_LINK2"/>Privacy Notice<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> will open in Brave. By continuing, you agree to Brave's <ph name="BEGIN_LINK1"/>Terms of Service<ph name="END_LINK1"/> and <ph name="BEGIN_LINK2"/>Privacy Notice<ph name="END_LINK2"/>, and the <ph name="BEGIN_LINK3"/>Privacy Notice for Brave Software Accounts Managed with Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Help make Brave better by sending usage statistics and crash reports to Brave Software.</translation>
+<translation id="3518985090088779359">Accept &amp; continue</translation>
+<translation id="7207456302801184289">Welcome to Brave</translation>
+<translation id="704822250101715322">Waiting for Brave Software Play Services to finish updating</translation>
+<translation id="1231733316453485619">Turn on sync?</translation>
+<translation id="5132942445612118989">Sync your passwords, history and more on all devices</translation>
+<translation id="5736731321935944068">Brave Software may use your history to personalise Search, ads and other Brave Software services</translation>
+<translation id="4013614219085422040">Brave Software may use your history to personalise Search and other Brave Software services</translation>
+<translation id="5581519193887989363">You can always choose what to sync in <ph name="BEGIN_LINK1"/>settings<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Yes, I'm in</translation>
+<translation id="2410754283952462441">Choose an account</translation>
+<translation id="2227444325776770048">Continue as <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Not <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">To get your bookmarks on all your devices, turn on sync</translation>
+<translation id="2818669890320396765">To get your bookmarks on all your devices, sign in and turn on sync</translation>
+<translation id="6003646045106347985">To get personalised content suggested by Brave Software, turn on sync</translation>
+<translation id="8494430740943879273">To get personalised content suggested by Brave Software, sign in and turn on sync</translation>
+<translation id="5862731021271217234">To get your tabs from your other devices, turn on sync</translation>
+<translation id="3568688522516854065">To get your tabs from your other devices, sign in and turn on sync</translation>
+<translation id="1208340532756947324">To sync and personalise across devices, turn on sync</translation>
+<translation id="4472118726404937099">To sync and personalise across devices, sign in and turn on sync</translation>
+<translation id="2426805022920575512">Choose another account</translation>
+<translation id="6790428901817661496">Play</translation>
+<translation id="1272079795634619415">Stop</translation>
+<translation id="2874939134665556319">Previous track</translation>
+<translation id="4046123991198612571">Next track</translation>
+<translation id="3859306556332390985">Seek forward</translation>
+<translation id="8441146129660941386">Seek backward</translation>
+<translation id="6706288973712894588">You are currently offline.\n<ph name="BEGIN_LINK"/>Explore your offline feed.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Recent tabs</translation>
+<translation id="8497726226069778601">Nothing to see here… yet</translation>
+<translation id="5423934151118863508">Your most visited pages will appear here</translation>
+<translation id="6127379762771434464">Item removed</translation>
+<translation id="4605958867780575332">Item removed: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Other devices</translation>
+<translation id="4738836084190194332">Last synced: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minute ago}other{# minutes ago}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# hour ago}other{# hours ago}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# day ago}other{# days ago}}</translation>
+<translation id="2762000892062317888">just now</translation>
+<translation id="1407135791313364759">Open all</translation>
+<translation id="1209206284964581585">Hide for now</translation>
+<translation id="129553762522093515">Recently closed</translation>
+<translation id="8413126021676339697">Show full history</translation>
+<translation id="7876243839304621966">Remove all</translation>
+<translation id="8487700953926739672">Available offline</translation>
+<translation id="5224771365102442243">With video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Find out more<ph name="END_LINK"/> about suggested content</translation>
+<translation id="7542481630195938534">Can’t get suggestions</translation>
+<translation id="5013696553129441713">No new suggestions</translation>
+<translation id="1736419249208073774">Explore</translation>
+<translation id="7444811645081526538">More categories</translation>
+<translation id="6709133671862442373">News</translation>
+<translation id="1264974993859112054">Sports</translation>
+<translation id="9139318394846604261">Shopping</translation>
+<translation id="3912508018559818924">Finding the best from the web…</translation>
+<translation id="526421993248218238">Can't load this page</translation>
+<translation id="614940544461990577">Try:</translation>
+<translation id="3288003805934695103">Reloading the page</translation>
+<translation id="2353636109065292463">Checking your Internet connection</translation>
+<translation id="2858138569776157458">Top sites</translation>
+<translation id="8364299278605033898">See popular websites</translation>
+<translation id="1171770572613082465">See popular websites by tapping the 'Top sites' button</translation>
+<translation id="5233638681132016545">New tab</translation>
+<translation id="4521874409998847950">From <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>delivered by Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Newer version is available</translation>
+<translation id="4058091506841967397">Brave can’t update</translation>
+<translation id="6316139424528454185">Android version is unsupported</translation>
+<translation id="6989267951144302301">Couldn’t download</translation>
+<translation id="624789221780392884">Update ready</translation>
+<translation id="1549000191223877751">Move to other window</translation>
+<translation id="7481312909269577407">Forward</translation>
+<translation id="4084682180776658562">Bookmark</translation>
+<translation id="6437478888915024427">Page info</translation>
+<translation id="7180611975245234373">Refresh</translation>
+<translation id="4913169188695071480">Stop refreshing</translation>
+<translation id="1829244130665387512">Find in page</translation>
+<translation id="6593061639179217415">Desktop site</translation>
+<translation id="9063523880881406963">Turn off Request desktop site</translation>
+<translation id="2038563949887743358">Turn on Request desktop site</translation>
+<translation id="2433507940547922241">Appearance</translation>
+<translation id="983192555821071799">Close all tabs</translation>
+<translation id="1310482092992808703">Group tabs</translation>
+<translation id="7725024127233776428">Pages that you bookmark appear here</translation>
+<translation id="4404568932422911380">No bookmarks</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> bookmark}other{<ph name="BOOKMARKS_COUNT_MANY"/> bookmarks}}</translation>
+<translation id="3739899004075612870">Bookmarked in <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Bookmarked</translation>
+<translation id="4452548195519783679">Bookmarked to <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Failed to add bookmark.</translation>
+<translation id="2842985007712546952">Parent folder</translation>
+<translation id="9065203028668620118">Edit</translation>
+<translation id="4405224443901389797">Move to…</translation>
+<translation id="5170568018924773124">Show in folder</translation>
+<translation id="8035133914807600019">New folder…</translation>
+<translation id="4532845899244822526">Choose folder</translation>
+<translation id="6627583120233659107">Edit folder</translation>
+<translation id="1197267115302279827">Move bookmarks</translation>
+<translation id="6963766334940102469">Delete bookmarks</translation>
+<translation id="4351244548802238354">Close dialogue</translation>
+<translation id="451872707440238414">Search your bookmarks</translation>
+<translation id="8901170036886848654">No bookmarks found</translation>
+<translation id="6404511346730675251">Edit bookmark</translation>
+<translation id="3894427358181296146">Add folder</translation>
+<translation id="5327248766486351172">Name</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Folder</translation>
+<translation id="5161254044473106830">Title required</translation>
+<translation id="2996809686854298943">URL required</translation>
+<translation id="2536728043171574184">Viewing an offline copy of this page</translation>
+<translation id="4698034686595694889">View offline in <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> and more sites</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave will load your page when ready}other{Brave will load your pages when ready}}</translation>
+<translation id="6811034713472274749">Page is ready to view</translation>
+<translation id="4561979708150884304">No connection</translation>
+<translation id="8274165955039650276">See downloads</translation>
+<translation id="2082238445998314030">Result <ph name="RESULT_NUMBER"/> of <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">No results</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">No enabled voice search available</translation>
+<translation id="7191430249889272776">Tab opened in background.</translation>
+<translation id="8445059357334030806">Open in Brave</translation>
+<translation id="4720023427747327413">Open in <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Open in browser</translation>
+<translation id="1113597929977215864">Show simplified view</translation>
+<translation id="1513352483775369820">Bookmarks and web history</translation>
+<translation id="4939482511480190003">Help improve Brave. <ph name="BEGIN_LINK"/>Take survey<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Go back</translation>
+<translation id="5596627076506792578">More options</translation>
+<translation id="3522247891732774234">Update available. More options</translation>
+<translation id="6773423637732432200">Brave can’t update. More options</translation>
+<translation id="3328801116991980348">Site information</translation>
+<translation id="5391532827096253100">Your connection to this site is not secure. Site information</translation>
+<translation id="6206551242102657620">Connection is secure. Site information</translation>
+<translation id="6963642900430330478">This page is dangerous. Site information</translation>
+<translation id="9070377983101773829">Start voice search</translation>
+<translation id="8676374126336081632">Clear input</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> open tab, tap to switch tabs}other{<ph name="OPEN_TABS_MANY"/> open tabs, tap to switch tabs}}</translation>
+<translation id="2369533728426058518">open tabs</translation>
+<translation id="7071521146534760487">Manage account</translation>
+<translation id="932327136139879170">Home</translation>
+<translation id="2707726405694321444">Refresh page</translation>
+<translation id="2891154217021530873">Stop page loading</translation>
+<translation id="6710213216561001401">Previous</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Selected Tab</translation>
+<translation id="2268044343513325586">Refine</translation>
+<translation id="7846076177841592234">Cancel selection</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> selected. Options available near top of the screen</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> selected</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Share 1 selected item}other{Share # selected items}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Remove 1 selected item}other{Remove # selected items}}</translation>
+<translation id="1283039547216852943">Tap to expand</translation>
+<translation id="5962718611393537961">Tap to collapse</translation>
+<translation id="8076492880354921740">Tabs</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selected}other{# selected}}</translation>
+<translation id="6818926723028410516">Select items</translation>
+<translation id="4797039098279997504">Touch to return to <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Tap to go to site</translation>
+<translation id="429312253194641664">A site is playing media</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> is sharing your screen</translation>
+<translation id="8833831881926404480">A site is sharing your screen</translation>
+<translation id="9086455579313502267">Unable to access the network</translation>
+<translation id="938850635132480979">Error: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Open in <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Open in maps app</translation>
+<translation id="7698359219371678927">Create email in <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Create email</translation>
+<translation id="5665379678064389456">Create event in <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Create event</translation>
+<translation id="2111511281910874386">Go to page</translation>
+<translation id="3988466920954086464">See instant search results in this panel</translation>
+<translation id="2744248271121720757">Tap a word to search instantly or see related actions</translation>
+<translation id="9155898266292537608">You can also search with a quick tap on a word</translation>
+<translation id="3232754137068452469">Web App</translation>
+<translation id="1430915738399379752">Print</translation>
+<translation id="3775705724665058594">Send to your devices</translation>
+<translation id="6364438453358674297">Remove suggestion from history?</translation>
+<translation id="213279576345780926">Closed <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> tabs closed</translation>
+<translation id="3211426585530211793">Deleted <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> bookmarks deleted</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> downloads deleted</translation>
+<translation id="1248710015876067820">Unsupported number of Brave instances.</translation>
+<translation id="4259722352634471385">Navigation is blocked: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigation is unreachable: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Close tab</translation>
+<translation id="7772375229873196092">Close <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Navigation history</translation>
+<translation id="9169507124922466868">Navigation history is half-opened</translation>
+<translation id="1327257854815634930">Navigation history is opened</translation>
+<translation id="8788265440806329501">Navigation history is closed</translation>
+<translation id="7482656565088326534">Preview tab</translation>
+<translation id="8427875596167638501">Preview tab is half-opened</translation>
+<translation id="9102803872260866941">Preview tab is opened</translation>
+<translation id="2942036813789421260">Preview tab is closed</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> storage</translation>
+<translation id="3822502789641063741">Clear site storage?</translation>
+<translation id="9205995714227143200">Site storage Brave doesn't think is important (e.g. sites with no saved settings or that you don't visit often)</translation>
+<translation id="3997476611815694295">Unimportant storage</translation>
+<translation id="8493948351860045254">Free up space</translation>
+<translation id="2324920234469020158">This will clear cookies, cache and other data of sites Brave doesn't think is important.</translation>
+<translation id="5447201525962359567">All site storage, including cookies and other locally stored data</translation>
+<translation id="1376578503827013741">Computing…</translation>
+<translation id="583281660410589416">Unknown</translation>
+<translation id="2323763861024343754">Site storage</translation>
+<translation id="3587672679800759167">Total data used by Brave, including accounts, bookmarks and saved settings</translation>
+<translation id="6545017243486555795">Clear All Data</translation>
+<translation id="4095146165863963773">Delete app data?</translation>
+<translation id="53119194224775367">All Brave’s app data will be deleted permanently. This includes all files, settings, accounts, databases, etc.</translation>
+<translation id="5307446750509046227">Clear site storage</translation>
+<translation id="300526633675317032">This will clear all <ph name="SIZE_IN_KB"/> of website storage.</translation>
+<translation id="8068648041423924542">Unable to select certificate.</translation>
+<translation id="2315043854645842844">Client side certificate selection is not supported by the operating system.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> wants to connect</translation>
+<translation id="5308380583665731573">Connect</translation>
+<translation id="868929229000858085">Search your contacts</translation>
+<translation id="1919950603503897840">Select contacts</translation>
+<translation id="7986741934819883144">Select a contact</translation>
+<translation id="3333961966071413176">All contacts</translation>
+<translation id="4994033804516042629">No contacts found</translation>
+<translation id="5403592356182871684">Names</translation>
+<translation id="2717722538473713889">Email addresses</translation>
+<translation id="381841723434055211">Phone numbers</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 more)}other{(+ # more)}}</translation>
+<translation id="5197729504361054390">The contacts that you select will be shared with <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Image decoder</translation>
+<translation id="8067883171444229417">Play video</translation>
+<translation id="6560414384669816528">Search with Sogou</translation>
+<translation id="5406914950576900927">Brave can use <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> for search in China. You can change this in <ph name="BEGIN_LINK"/>Settings<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Keep Brave Software</translation>
+<translation id="4384468725000734951">Using Sogou for search</translation>
+<translation id="6103327872225198548">Using Brave Software for search</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">This app is running in Brave</translation>
+<translation id="6143689084714664628">Running in Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> also has data in Brave</translation>
+<translation id="2734140769649165081">You can clear the data in Brave Settings</translation>
+<translation id="8232956427053453090">Keep data</translation>
+<translation id="4298388696830689168">Linked sites</translation>
+<translation id="5763514718066511291">Tap to copy the URL for this app</translation>
+<translation id="6496823230996795692">To use <ph name="APP_NAME"/> for the first time, please connect to the Internet.</translation>
+<translation id="751961395872307827">Can't connect to the site</translation>
+<translation id="4878404682131129617">Establishing a tunnel via proxy server failed</translation>
+<translation id="4749960740855309258">Open a new tab</translation>
+<translation id="8788968922598763114">Reopen the last closed tab</translation>
+<translation id="7929962904089429003">Opening the menu</translation>
+<translation id="6039379616847168523">Jump to the next tab</translation>
+<translation id="5210286577605176222">Jump to the previous tab</translation>
+<translation id="124678866338384709">Close current tab</translation>
+<translation id="3714981814255182093">Open the Find Bar</translation>
+<translation id="5441522332038954058">Jump to the address bar</translation>
+<translation id="3398320232533725830">Open the bookmarks manager</translation>
+<translation id="6583199322650523874">Bookmark the current page</translation>
+<translation id="8489271220582375723">Open the history page</translation>
+<translation id="4837753911714442426">Open options to print page</translation>
+<translation id="5726692708398506830">Make everything on the page bigger</translation>
+<translation id="3259831549858767975">Make everything on the page smaller</translation>
+<translation id="8015452622527143194">Return everything on the page to default size</translation>
+<translation id="3443221991560634068">Reload the current page</translation>
+<translation id="123724288017357924">Reload the current page, ignoring cached content</translation>
+<translation id="305870044889644984">Open the Brave Help Centre in a new tab</translation>
+<translation id="3166827708714933426">Tab and window shortcuts</translation>
+<translation id="3169981355900570544">Brave Software Brave feature shortcuts</translation>
+<translation id="4558311620361989323">Web page shortcuts</translation>
+<translation id="1908301351964700579">Brave is still preparing for VR. Restart Brave later.</translation>
+<translation id="8970887620466824814">Something went wrong.</translation>
+<translation id="1875543012935658554">Reopen Brave.</translation>
+<translation id="79859296434321399">To view augmented reality content, install ARCore</translation>
+<translation id="8558485628462305855">To view augmented reality content, update ARCore</translation>
+<translation id="3513704683820682405">Augmented Reality</translation>
+<translation id="5475862044948910901">Start Augmented Reality session?</translation>
 <translation id="7365126855094612066">For the duration of this session, the site will be able to:
 • create a 3D map of your environment
 • track camera motion
 
 The site does NOT gain access to the camera. The camera images are only visible to you.</translation>
-<translation id="7375125077091615385">Type:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome First Run Experience</translation>
-<translation id="741204030948306876">Yes, I'm in</translation>
-<translation id="7413229368719586778">Start date <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Ask first</translation>
-<translation id="7423538860840206698">Blocked from reading clipboard</translation>
-<translation id="7431991332293347422">Control how your browsing history is used to personalise Search and more</translation>
-<translation id="7437998757836447326">Sign out of Chrome</translation>
-<translation id="7438641746574390233">When Lite mode is on, Chrome uses Google servers to make pages load faster. Lite mode rewrites very slow pages to load only essential content. Lite mode does not apply to Incognito tabs.</translation>
-<translation id="7444811645081526538">More categories</translation>
-<translation id="7445411102860286510">Allow sites to automatically play muted videos (recommended)</translation>
-<translation id="7453467225369441013">Signs you out of most sites. You won't be signed out of your Google Account.</translation>
-<translation id="7454641608352164238">Not enough space</translation>
-<translation id="7475192538862203634">If you’re seeing this frequently, try these <ph name="BEGIN_LINK" />suggestions<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD card not found. Some of your files may be missing.</translation>
-<translation id="7479104141328977413">Tab management</translation>
-<translation id="7481312909269577407">Forward</translation>
-<translation id="7482656565088326534">Preview tab</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Updated <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">data saved</translation>
-<translation id="7498271377022651285">Please wait…</translation>
-<translation id="7514365320538308">Download</translation>
-<translation id="751961395872307827">Can't connect to the site</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Can’t get suggestions</translation>
-<translation id="7559975015014302720">Lite mode is off</translation>
-<translation id="7562080006725997899">Clear browsing data</translation>
-<translation id="756809126120519699">Cleared Chrome data</translation>
-<translation id="757524316907819857">Block sites from playing protected content</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> file downloaded}other{<ph name="FILES_DOWNLOADED_MANY" /> files downloaded}}</translation>
-<translation id="7588219262685291874">Turn on dark theme when your device's Battery Saver is on</translation>
-<translation id="7589445247086920869">Block for current search engine</translation>
-<translation id="7593557518625677601">Open Android settings and re-enable Android system sync to start Chrome sync</translation>
-<translation id="7596558890252710462">Operating system</translation>
-<translation id="7605594153474022051">Sync isn't working</translation>
-<translation id="7606077192958116810">Lite mode is on. Manage it in Settings.</translation>
-<translation id="7612619742409846846">Signed in to Google as</translation>
-<translation id="7619072057915878432"><ph name="FILE_NAME" /> download failed due to network failures.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Get help<ph name="END_LINK1" /> or <ph name="BEGIN_LINK2" />re-scan<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Welcome to Chrome</translation>
-<translation id="7638584964844754484">Incorrect passphrase</translation>
-<translation id="7641339528570811325">Clear browsing data…</translation>
-<translation id="7648422057306047504">Encrypt passwords with Google credentials</translation>
-<translation id="7649070708921625228">Help</translation>
-<translation id="7658239707568436148">Cancel</translation>
-<translation id="7665369617277396874">Add account</translation>
-<translation id="766587987807204883">Articles appear here, which you can read even when you're offline</translation>
-<translation id="7682724950699840886">Try the following tips: make sure that there is enough space on your device; try to export again.</translation>
-<translation id="7685301384041462804">Make sure that you trust this site before entering VR.</translation>
-<translation id="7698359219371678927">Create email in <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Auto-complete searches and URLs</translation>
-<translation id="7725024127233776428">Pages that you bookmark appear here</translation>
-<translation id="773466115871691567">Always translate pages in <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">To detect dangerous apps and sites, Chrome sends URLs of some pages that you visit, limited system information and some page content to Google</translation>
-<translation id="7757787379047923882">Text shared from <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD Card <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Add address</translation>
-<translation id="7772032839648071052">Confirm passphrase</translation>
-<translation id="7772375229873196092">Close <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> more}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 and <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> more}}</translation>
-<translation id="7781829728241885113">Yesterday</translation>
-<translation id="7791543448312431591">Add</translation>
-<translation id="780301667611848630">No, thanks</translation>
-<translation id="7810647596859435254">Open with…</translation>
-<translation id="7821588508402923572">Your data savings will appear here</translation>
-<translation id="7837721118676387834">Allow auto-play of muted videos for a specific site.</translation>
-<translation id="7846076177841592234">Cancel selection</translation>
-<translation id="784934925303690534">Time range</translation>
-<translation id="7851858861565204677">Other devices</translation>
-<translation id="7875915731392087153">Create email</translation>
-<translation id="7876243839304621966">Remove all</translation>
-<translation id="7882131421121961860">No history found</translation>
-<translation id="7882806643839505685">Allow sound for a specific site.</translation>
-<translation id="7886917304091689118">Running in Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Downloading file.}other{Downloading # files.}}</translation>
-<translation id="7929962904089429003">Opening the menu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> is out of date.</translation>
-<translation id="7947953824732555851">Accept and sign in</translation>
-<translation id="7963646190083259054">Vendor:</translation>
-<translation id="7971136598759319605">Active 1 day ago</translation>
-<translation id="7975379999046275268">Preview page <ph name="BEGIN_NEW" />New<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Preload pages for faster browsing and searching</translation>
-<translation id="79859296434321399">To view augmented reality content, install ARCore</translation>
-<translation id="7986741934819883144">Select a contact</translation>
-<translation id="7987073022710626672">Chrome Terms of Service</translation>
-<translation id="7998918019931843664">Re-open closed tab</translation>
-<translation id="7999064672810608036">Are you sure that you want to clear all local data, including cookies, and reset all permissions for this website?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Turned off for this device</translation>
-<translation id="8013372441983637696">Also clear your Chrome data from this device</translation>
-<translation id="8015452622527143194">Return everything on the page to default size</translation>
-<translation id="802154636333426148">Download failed</translation>
-<translation id="8026334261755873520">Clear browsing data</translation>
-<translation id="8035133914807600019">New folder…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> days left</translation>
-<translation id="804335162455518893">SD card not found</translation>
-<translation id="805047784848435650">Based on your browsing history</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB available</translation>
-<translation id="8058746566562539958">Open in new Chrome tab</translation>
-<translation id="8063895661287329888">Failed to add bookmark.</translation>
-<translation id="806745655614357130">Keep my data separate</translation>
-<translation id="8067883171444229417">Play video</translation>
-<translation id="8068648041423924542">Unable to select certificate.</translation>
-<translation id="8073388330009372546">Open image in new tab</translation>
-<translation id="8076492880354921740">Tabs</translation>
-<translation id="8084114998886531721">Saved password</translation>
-<translation id="8087000398470557479">This content is from <ph name="DOMAIN_NAME" />, delivered by Google.</translation>
-<translation id="8103578431304235997">Incognito Tab</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">To get your bookmarks on all your devices, turn on sync</translation>
-<translation id="8110087112193408731">Show your Chrome activity in Digital Wellbeing?</translation>
-<translation id="8116925261070264013">Muted</translation>
-<translation id="813082847718468539">View site information</translation>
-<translation id="8131740175452115882">Confirm</translation>
-<translation id="8156139159503939589">What languages do you read?</translation>
-<translation id="8168435359814927499">Content</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> files left</translation>
-<translation id="8190358571722158785">1 day left</translation>
-<translation id="8200772114523450471">Resume</translation>
-<translation id="8209050860603202033">Open image</translation>
-<translation id="8218622182176210845">Manage your account</translation>
-<translation id="8224471946457685718">Download articles for you on Wi-Fi</translation>
-<translation id="8232956427053453090">Keep data</translation>
-<translation id="8249310407154411074">Move to top</translation>
-<translation id="8250920743982581267">Documents</translation>
-<translation id="825412236959742607">This page uses too much memory, so Chrome removed some content.</translation>
-<translation id="8260126382462817229">Try signing in again</translation>
-<translation id="8261506727792406068">Delete</translation>
-<translation id="8266862848225348053">Download location</translation>
-<translation id="8274165955039650276">See downloads</translation>
-<translation id="8284326494547611709">Captions</translation>
-<translation id="8300705686683892304">Managed by app</translation>
-<translation id="8310344678080805313">Standard tabs</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> and more sites</translation>
-<translation id="8327155640814342956">For the best browsing experience, open to update Chrome</translation>
-<translation id="8339163506404995330">Pages in <ph name="LANGUAGE" /> will not be translated</translation>
-<translation id="8349013245300336738">Sort by amount of data used</translation>
-<translation id="8364299278605033898">See popular websites</translation>
-<translation id="8368027906805972958">Unknown or unsupported device (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Allow Background Sync for a specific site.</translation>
-<translation id="8378714024927312812">Managed by your organisation</translation>
-<translation id="8380167699614421159">This site shows intrusive or misleading ads</translation>
-<translation id="8393700583063109961">Send message</translation>
-<translation id="8413126021676339697">Show full history</translation>
-<translation id="8427875596167638501">Preview tab is half-opened</translation>
-<translation id="8428213095426709021">Settings</translation>
-<translation id="8438566539970814960">Make searches and browsing better</translation>
-<translation id="8441146129660941386">Seek backward</translation>
-<translation id="8443209985646068659">Chrome can’t update</translation>
-<translation id="8445448999790540984">Can’t export passwords</translation>
-<translation id="8447861592752582886">Revoke device permission</translation>
-<translation id="8461694314515752532">Encrypt synced data with your own sync passphrase</translation>
-<translation id="8466613982764129868">Make sure that <ph name="TARGET_DEVICE_NAME" /> is connected to the Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Available offline</translation>
-<translation id="8489271220582375723">Open the history page</translation>
-<translation id="8493948351860045254">Free up space</translation>
-<translation id="8497726226069778601">Nothing to see here… yet</translation>
-<translation id="8503559462189395349">Chrome Passwords</translation>
-<translation id="8503813439785031346">Username</translation>
-<translation id="8514477925623180633">Export passwords stored with Chrome</translation>
-<translation id="8514577642972634246">Enter incognito mode</translation>
-<translation id="851751545965956758">Block sites from connecting to devices</translation>
-<translation id="8523928698583292556">Delete stored password</translation>
-<translation id="854522910157234410">Open this page:</translation>
-<translation id="8558485628462305855">To view augmented reality content, update ARCore</translation>
-<translation id="8559990750235505898">Offer to translate pages in other languages</translation>
-<translation id="8562452229998620586">Your saved passwords will appear here.</translation>
-<translation id="8569404424186215731">since <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Last 4 weeks</translation>
-<translation id="857943718398505171">Allowed (recommended)</translation>
-<translation id="8583805026567836021">Clearing account data</translation>
-<translation id="860043288473659153">Cardholder name</translation>
-<translation id="8609465669617005112">Move up</translation>
-<translation id="8616006591992756292">Your Google Account may have other forms of browsing history at <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Open the suggested URL specified in the downloaded content?</translation>
-<translation id="8636825310635137004">To get your tabs from your other devices, turn on sync.</translation>
-<translation id="8641930654639604085">Try to block mature sites</translation>
-<translation id="8655129584991699539">You can clear the data in Chrome Settings</translation>
-<translation id="8662811608048051533">Signs you out of most sites.</translation>
-<translation id="8664979001105139458">File name already exists</translation>
-<translation id="8676374126336081632">Clear input</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signal Strength Level: # bar}other{Signal Strength Level: # bars}}</translation>
-<translation id="868929229000858085">Search your contacts</translation>
-<translation id="869891660844655955">Expiry date</translation>
-<translation id="8719023831149562936">Can’t beam current tab</translation>
-<translation id="8725066075913043281">Try again</translation>
-<translation id="8728487861892616501">By using this application, you agree to Chrome’s <ph name="BEGIN_LINK1" />Terms of Service<ph name="END_LINK1" /> and <ph name="BEGIN_LINK2" />Privacy Notice<ph name="END_LINK2" />, and the <ph name="BEGIN_LINK3" />Privacy Notice for Google Accounts Managed with Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Done</translation>
-<translation id="8748850008226585750">Contents hidden</translation>
-<translation id="8751914237388039244">Select an image</translation>
-<translation id="8788265440806329501">Navigation history is closed</translation>
-<translation id="8788968922598763114">Reopen the last closed tab</translation>
-<translation id="8801436777607969138">Block JavaScript for a specific site.</translation>
-<translation id="8812260976093120287">On some websites, you can pay with above supported payment apps on your device.</translation>
-<translation id="8816026460808729765">Block sites from accessing sensors</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> will open in Chrome. By continuing, you agree to Chrome's <ph name="BEGIN_LINK1" />Terms of Service<ph name="END_LINK1" /> and <ph name="BEGIN_LINK2" />Privacy Notice<ph name="END_LINK2" />, and the <ph name="BEGIN_LINK3" />Privacy Notice for Google Accounts Managed with Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Bookmarks</translation>
-<translation id="8833831881926404480">A site is sharing your screen</translation>
-<translation id="883806473910249246">An error occurred while downloading the content.</translation>
-<translation id="8840953339110955557">This page may differ from the online version.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, tab</translation>
-<translation id="885701979325669005">Storage</translation>
-<translation id="889338405075704026">Go to Chrome settings</translation>
-<translation id="8901170036886848654">No bookmarks found</translation>
-<translation id="8909135823018751308">Share…</translation>
-<translation id="8912362522468806198">Google Account</translation>
-<translation id="8920114477895755567">Waiting for details of parents.</translation>
+<translation id="1188239144602654184">Enter AR</translation>
+<translation id="473775607612524610">Update</translation>
+<translation id="3133489217401741157">Installing <ph name="MODULE"/> for Brave…</translation>
+<translation id="1791662854739702043">Installed</translation>
+<translation id="5131234170665854056">Unable to install <ph name="MODULE"/> for Brave</translation>
+<translation id="2567385386134582609">IMAGE</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Download pages to use them offline</translation>
 <translation id="8922289737868596582">Download pages from the More Options button to use them offline</translation>
-<translation id="8937772741022875483">Remove your Chrome activity from Digital Wellbeing?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Open in other window</translation>
-<translation id="8951232171465285730">Chrome has saved you <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Block cookies for a specific site.</translation>
-<translation id="8959122750345127698">Navigation is unreachable: <ph name="URL" /></translation>
-<translation id="8965591936373831584">pending</translation>
-<translation id="8970887620466824814">Something went wrong.</translation>
-<translation id="8972098258593396643">Download to default folder?</translation>
-<translation id="8986494364107987395">Automatically send usage statistics and crash reports to Google</translation>
-<translation id="8993760627012879038">Open a new tab in Incognito mode</translation>
-<translation id="8998729206196772491">You are signing in with an account managed by <ph name="MANAGED_DOMAIN" /> and giving its administrator control over your Chrome data. Your data will become permanently tied to this account. Signing out of Chrome will delete your data from this device, but it will remain stored in your Google Account.</translation>
-<translation id="9019902583201351841">Managed by your parents</translation>
-<translation id="9028914725102941583">Turn on sync to share across devices</translation>
-<translation id="9029323097866369874">Allow <ph name="DOMAIN" /> to enter VR?</translation>
-<translation id="9040142327097499898">Notifications are allowed. Location is off for this device.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Videos}}</translation>
-<translation id="9050666287014529139">Passphrase</translation>
-<translation id="9063523880881406963">Turn off Request desktop site</translation>
-<translation id="9065203028668620118">Edit</translation>
-<translation id="9070377983101773829">Start voice search</translation>
-<translation id="9074336505530349563">To get personalised content suggested by Google, sign in and turn on sync</translation>
-<translation id="9086455579313502267">Unable to access the network</translation>
-<translation id="9100505651305367705">Offer to show articles in simplified view, when supported</translation>
-<translation id="9100610230175265781">Passphrase required</translation>
-<translation id="9102803872260866941">Preview tab is opened</translation>
+<translation id="5958275228015807058">Find your files and pages in Downloads</translation>
+<translation id="5620928963363755975">Find your files and pages in Downloads from the More Options button</translation>
+<translation id="3341058695485821946">See how much data you've saved</translation>
+<translation id="3157842584138209013">See how much data you've saved from the More Options button</translation>
+<translation id="8218622182176210845">Manage your account</translation>
+<translation id="8090895580117672212">To manage your Brave Software Account, tap the 'Manage account' button</translation>
+<translation id="8856898588039823173">Lite page provided by Brave Software. Tap to load the original.</translation>
+<translation id="8134317863207426198">Lite page provided by Brave Software. Tap the load original button to load the original page.</translation>
+<translation id="4961107849584082341">Translate this page to any language</translation>
+<translation id="569536719314091526">Translate this page to any language from the More options button</translation>
+<translation id="1397811292916898096">Search with <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Change the default download location at any time</translation>
+<translation id="6942665639005891494">Change the default download location at any time using the Settings menu option</translation>
+<translation id="6850409657436465440">Your download is still in progress</translation>
+<translation id="5817715962196959877">Brave now downloads files faster</translation>
+<translation id="3976396876660209797">Remove and recreate this shortcut</translation>
+<translation id="6766622839693428701">Swipe down to close.</translation>
+<translation id="1028699632127661925">Sending to <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Sent from <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Tab received</translation>
 <translation id="9104217018994036254">List of devices to share a tab with.</translation>
-<translation id="9133397713400217035">Explore offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Show original</translation>
-<translation id="9139068048179869749">Ask before allowing sites to send notifications (recommended)</translation>
-<translation id="9139318394846604261">Shopping</translation>
-<translation id="9155898266292537608">You can also search with a quick tap on a word</translation>
-<translation id="9169507124922466868">Navigation history is half-opened</translation>
-<translation id="9204836675896933765">1 file left</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">List of devices to share a tab with, opened at half height.</translation>
+<translation id="2904414404539560095">List of devices to share a tab with, opened at full height.</translation>
+<translation id="4135200667068010335">List of devices with which to share a tab is closed.</translation>
+<translation id="5292796745632149097">Send to</translation>
+<translation id="1386674309198842382">Active <ph name="LAST_UPDATED"/> days ago</translation>
+<translation id="7971136598759319605">Active 1 day ago</translation>
+<translation id="1521774566618522728">Active today</translation>
+<translation id="3631987586758005671">Sharing to <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Turn on sync to share across devices</translation>
+<translation id="6162454065885854378">To share something from your phone to another device, turn on sync in Brave settings on both devices</translation>
+<translation id="6084271560289605378">Go to Brave settings</translation>
+<translation id="2318045970523081853">Tap to make call</translation>
 <translation id="9209888181064652401">Can't make calls</translation>
-<translation id="9219103736887031265">Images</translation>
-<translation id="926205370408745186">Remove your Chrome activity from Digital Wellbeing</translation>
-<translation id="932327136139879170">Home</translation>
-<translation id="938850635132480979">Error: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Access your microphone</translation>
-<translation id="95817756606698420">Chrome can use <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> for search in China. You can change this in <ph name="BEGIN_LINK" />Settings<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Block if site shows intrusive or misleading ads (recommended)</translation>
-<translation id="968900484120156207">Pages that you visit appear here</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> mins left</translation>
-<translation id="974555521953189084">Enter your passphrase to start sync</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">This will clear data for all sites, including:</translation>
-<translation id="983192555821071799">Close all tabs</translation>
-<translation id="987264212798334818">General</translation>
+<translation id="2860954141821109167">Make sure that a phone app is enabled on this device</translation>
+<translation id="2067805253194386918">text</translation>
+<translation id="1450753235335490080">Can't share <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Couldn't share <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Make sure that <ph name="TARGET_DEVICE_NAME"/> has sync turned on in Brave</translation>
+<translation id="3016635187733453316">Make sure that this device is connected to the Internet</translation>
+<translation id="8466613982764129868">Make sure that <ph name="TARGET_DEVICE_NAME"/> is connected to the Internet</translation>
+<translation id="6539092367496845964">Something went wrong. Try again later.</translation>
+<translation id="3389286852084373014">Text is too large</translation>
+<translation id="2100314319871056947">Try sharing the text in smaller chunks</translation>
+<translation id="2987620471460279764">Text shared from other device</translation>
+<translation id="7757787379047923882">Text shared from <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Copied to your clipboard</translation>
+<translation id="4696983787092045100">Send text to Your Devices</translation>
+<translation id="1260236875608242557">Search and explore</translation>
+<translation id="6369229450655021117">From here, you can search the web, share with friends and see open pages</translation>
+<translation id="723171743924126238">Select images</translation>
+<translation id="8751914237388039244">Select an image</translation>
+<translation id="1989112275319619282">Browse</translation>
+<translation id="7055152154916055070">Redirect blocked:</translation>
+<translation id="5524843473235508879">Redirect blocked.</translation>
+<translation id="6573096386450695060">Always allow</translation>
+<translation id="5805364706385912897">This page uses too much memory, so Brave paused it.</translation>
+<translation id="5138664332909611586">This page uses too much memory, so Brave removed some content.</translation>
+<translation id="9137013805542155359">Show original</translation>
+<translation id="6361779936989026201">Brave Software Assistant in Brave</translation>
+<translation id="7291387454912369099">Assistant Triggered Checkout</translation>
+<translation id="4565206163201411670">Show your Brave activity in Digital Wellbeing?</translation>
+<translation id="9055113864158719823">You can see sites that you visit in Brave and set timers for them.\n\nBrave Software gets info about the sites for which you set timers and how long you visit them. This info is used to make Digital Wellbeing better.</translation>
+<translation id="4596514158372210596">Remove your Brave activity from Digital Wellbeing</translation>
+<translation id="1174893863889683998">Remove your Brave activity from Digital Wellbeing?</translation>
+<translation id="708829030563435351">Sites that you visit in Brave won't show. All site timers will be deleted.</translation>
+<translation id="2056878612599315956">Site paused</translation>
+<translation id="671481426037969117">Your <ph name="FQDN"/> timer ran out. It will start again tomorrow.</translation>
+<translation id="7479104141328977413">Tab management</translation>
+<translation id="3524138585025253783">Developer UI</translation>
+<translation id="6036057147555329831">Extra ICU</translation>
+<translation id="9029323097866369874">Allow <ph name="DOMAIN"/> to enter VR?</translation>
+<translation id="7685301384041462804">Make sure that you trust this site before entering VR.</translation>
+<translation id="5033865233969348410">While you are in VR, this site may be able to find out about:
+  -  your physical features, such as height
+
+Make sure that you trust this site before entering VR.</translation>
+<translation id="5534334044554683961">While you are in VR, this site may be able to find out about:
+  -   your physical features, such as height
+  -   the layout of your room
+
+Make sure that you trust this site before entering VR.</translation>
+<translation id="4169535189173047238">Don't allow</translation>
+<translation id="2170088579611075216">Allow and enter VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_es-419.xtb
+++ b/android/java/strings/translations/android_chrome_strings_es-419.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="es-419">
-<translation id="1006017844123154345">Abrir en línea</translation>
-<translation id="1028699632127661925">Enviando a <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">Agregando <ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">De sitios web</translation>
-<translation id="1049743911850919806">Incógnito</translation>
-<translation id="10614374240317010">Nunca guardado</translation>
-<translation id="1067922213147265141">Otros servicios de Google</translation>
-<translation id="1068672505746868501">No traducir nunca páginas en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Si cambias la extensión de archivo, es posible que el archivo se abra en una app diferente y dañe el dispositivo.</translation>
-<translation id="1100066534610197918">Abrir pestaña nueva en grupo</translation>
-<translation id="1105960400813249514">Captura de pantalla</translation>
-<translation id="1111673857033749125">Los favoritos guardados en tus otros dispositivos aparecerán aquí.</translation>
-<translation id="1113597929977215864">Mostrar la vista simplificada</translation>
-<translation id="1121094540300013208">Informes de uso y de fallos</translation>
-<translation id="1124772482545689468">Usuario</translation>
-<translation id="1129510026454351943">Detalles: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 descarga pendiente}other{# descargas pendientes}}</translation>
-<translation id="1145536944570833626">Borra los datos existentes.</translation>
-<translation id="1146678959555564648">Entrar al modo RV</translation>
-<translation id="116280672541001035">Usados</translation>
-<translation id="1171770572613082465">Presiona el botón "Populares" para ver los sitios web más conocidos</translation>
-<translation id="1173894706177603556">Cambiar nombre</translation>
-<translation id="1178581264944972037">Detener</translation>
-<translation id="1181037720776840403">Quitar</translation>
-<translation id="1188239144602654184">Ingresar a la RA</translation>
-<translation id="1197267115302279827">Mover favoritos</translation>
-<translation id="119944043368869598">Borrar todo</translation>
-<translation id="1201402288615127009">Siguiente</translation>
-<translation id="1204037785786432551">Descargar vínculo</translation>
-<translation id="1206892813135768548">Copiar texto del vínculo</translation>
-<translation id="1208340532756947324">Para sincronizar diferentes dispositivos y personalizar tu experiencia, activa la sincronización</translation>
-<translation id="1209206284964581585">Ocultar por el momento</translation>
-<translation id="1227058898775614466">Historial de navegación</translation>
-<translation id="1231733316453485619">¿Quieres activar la sincronización?</translation>
-<translation id="123724288017357924">Volver a cargar página actual; ignorar contenido en caché</translation>
-<translation id="124116460088058876">Más idiomas</translation>
-<translation id="124678866338384709">Cerrar la pestaña actual</translation>
-<translation id="1258753120186372309">Doodle de Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Buscar y explorar</translation>
-<translation id="1264974993859112054">Deportes</translation>
-<translation id="1266864766717917324">No se pudo compartir <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Interrumpir</translation>
-<translation id="1283039547216852943">Presiona para expandir</translation>
-<translation id="1285320974508926690">Nunca traducir este sitio</translation>
-<translation id="1291207594882862231">Borra el historial, las cookies, los datos del sitio, la caché…</translation>
-<translation id="129382876167171263">Aquí se mostrarán los archivos que guarden los sitios web</translation>
-<translation id="129553762522093515">Cerrado recientemente</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Enviado desde <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Agrupar pestañas</translation>
-<translation id="1327257854815634930">Está abierto el Historial de navegación</translation>
-<translation id="1331212799747679585">No se puede actualizar Chrome. Más opciones</translation>
-<translation id="1332501820983677155">Accesos directos a las funciones de Google Chrome</translation>
-<translation id="1360432990279830238">¿Salir y desactivar la sincronización?</translation>
-<translation id="1369915414381695676">Se agregó el sitio <ph name="SITE_NAME" />.</translation>
-<translation id="1373696734384179344">Memoria insuficiente para descargar el contenido seleccionado</translation>
-<translation id="1376578503827013741">Calculando…</translation>
-<translation id="1383876407941801731">Buscar</translation>
-<translation id="1384959399684842514">Descarga detenida</translation>
-<translation id="1386674309198842382">Activo hace <ph name="LAST_UPDATED" /> días</translation>
-<translation id="1397811292916898096">Buscar con <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Incorporado en <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">No realizar seguimiento</translation>
-<translation id="1407135791313364759">Abrir todas</translation>
-<translation id="1409426117486808224">Vista simplificada para las pestañas abiertas</translation>
-<translation id="1409879593029778104">Se impidió la descarga de <ph name="FILE_NAME" /> porque el archivo ya existe.</translation>
-<translation id="1414981605391750300">Se está estableciendo la comunicación con Google. Esta acción puede demorar unos minutos…</translation>
-<translation id="1416550906796893042">Versión de la aplicación</translation>
-<translation id="1430915738399379752">Imprimir</translation>
-<translation id="1446450296470737166">Control de dispositivos MIDI</translation>
-<translation id="1450753235335490080">No se puede compartir <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Desactivado en la configuración de Android</translation>
-<translation id="1477626028522505441"><ph name="FILE_NAME" /> no se pudo descargar debido a problemas del servidor.</translation>
-<translation id="1506061864768559482">Motor de búsqueda</translation>
-<translation id="1513352483775369820">Favoritos e historial web</translation>
-<translation id="1513858653616922153">Borrar contraseña</translation>
-<translation id="1516229014686355813">La función "Presionar para buscar" envía la palabra seleccionada y la página actual como contexto a la Búsqueda de Google. Para desactivarla, accede a <ph name="BEGIN_LINK" />Configuración<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Activo hoy</translation>
-<translation id="1544826120773021464">Para administrar tu Cuenta de Google, presiona el botón "Administrar cuenta"</translation>
-<translation id="1549000191223877751">Mover a otra ventana</translation>
-<translation id="1553358976309200471">Actualizar Chrome</translation>
-<translation id="1569387923882100876">Dispositivo conectado</translation>
-<translation id="1571304935088121812">Copiar el nombre de usuario</translation>
-<translation id="1612196535745283361">Chrome debe acceder a la ubicación para buscar dispositivos. El acceso a la ubicación está <ph name="BEGIN_LINK" />desactivado en este dispositivo<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Cámara</translation>
-<translation id="1623104350909869708">Evitar que esta página cree cuadros de diálogo adicionales</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Quitar 1 elemento seleccionado}other{Quitar # elementos seleccionados}}</translation>
-<translation id="164269334534774161">Estás viendo una copia sin conexión de esta página del <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historial</translation>
-<translation id="1647391597548383849">Acceso a la cámara</translation>
-<translation id="1660204651932907780">Permitir que los sitios reproduzcan sonido (recomendado)</translation>
-<translation id="1670399744444387456">Básicas</translation>
-<translation id="1671236975893690980">Descarga pendiente…</translation>
-<translation id="1672586136351118594">No volver a mostrar</translation>
-<translation id="1692118695553449118">La sincronización está activada.</translation>
-<translation id="169515064810179024">Impedir que los sitios accedan a los sensores de movimiento</translation>
-<translation id="1717218214683051432">Sensores de movimiento</translation>
-<translation id="1718835860248848330">Última hora</translation>
-<translation id="1736419249208073774">Explorar</translation>
-<translation id="1743802530341753419">Preguntar antes de permitir que los sitios se conecten a un dispositivo (recomendado)</translation>
-<translation id="1749561566933687563">Sincroniza tus favoritos</translation>
-<translation id="17513872634828108">Pestañas abiertas</translation>
-<translation id="1779089405699405702">Decodificador de imágenes</translation>
-<translation id="1782483593938241562">Fecha de finalización: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Instalado</translation>
-<translation id="1792959175193046959">Cambia la ubicación predeterminada de las descargas en cualquier momento</translation>
-<translation id="1807246157184219062">Claro</translation>
-<translation id="1810845389119482123">No se completó la configuración de la sincronización inicial</translation>
-<translation id="1821253160463689938">Usa cookies para recordar tus preferencias, incluso si no visitas esas páginas</translation>
-<translation id="1829244130665387512">Buscar en la página</translation>
-<translation id="1853692000353488670">Nueva pestaña de incógnito</translation>
-<translation id="1856325424225101786">¿Quieres restablecer el modo lite?</translation>
-<translation id="1868024384445905608">Ahora Chrome descarga los archivos más rápido</translation>
-<translation id="1883903952484604915">Mis archivos</translation>
-<translation id="1887786770086287077">En este dispositivo, el acceso a la ubicación está desactivado. Actívalo en la <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> se abrirá en Chrome. Al continuar, aceptas las <ph name="BEGIN_LINK1" />Condiciones del servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />Aviso de privacidad<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="1919345977826869612">Anuncios</translation>
-<translation id="1919950603503897840">Seleccionar contactos</translation>
-<translation id="1922076542920281912">Para permitir que Chrome acceda a tu ubicación, actívala también en <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Actualizaciones</translation>
-<translation id="19288952978244135">Vuelve a abrir Chrome.</translation>
-<translation id="1933845786846280168">Pestaña seleccionada</translation>
-<translation id="194341124344773587">Activa el permiso para Chrome en <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Guardar contraseñas</translation>
-<translation id="1952172573699511566">Los sitios web mostrarán texto en tu idioma preferido, cuando sea posible.</translation>
-<translation id="1960290143419248813">Las actualizaciones de Chrome ya no son compatibles con esta versión de Android</translation>
-<translation id="1966710179511230534">Actualiza los datos de acceso.</translation>
-<translation id="1974060860693918893">Configuración avanzada</translation>
-<translation id="1984705450038014246">Sincroniza tus datos de Chrome</translation>
-<translation id="1984937141057606926">Permitidas, salvo de terceros</translation>
-<translation id="1986685561493779662">El nombre ya existe</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> Botón <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Navegar</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> desea sincronizarse</translation>
-<translation id="1994173015038366702">URL del sitio</translation>
-<translation id="2000419248597011803">Envía algunas cookies y búsquedas de la barra de direcciones y del cuadro de búsqueda a tu motor de búsqueda predeterminado</translation>
-<translation id="2002537628803770967">Tarjetas de crédito y direcciones con Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# archivo}other{# archivos}}</translation>
-<translation id="2017836877785168846">Borra el historial y las opciones de autocompletado en la barra de direcciones.</translation>
-<translation id="2021896219286479412">Controles en pantalla completa</translation>
-<translation id="2038563949887743358">Activar la opción para solicitar versión de escritorio</translation>
-<translation id="2041019821020695769">Para permitir que Chrome te envíe notificaciones, actívalas también en <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> también tiene datos en Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Se pausó el sitio</translation>
-<translation id="2063713494490388661">Presionar para buscar</translation>
-<translation id="2067805253194386918">texto</translation>
-<translation id="2079545284768500474">Deshacer</translation>
-<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER" /> de <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Sonido</translation>
-<translation id="2096012225669085171">Sincroniza y personaliza contenido en diferentes dispositivos</translation>
-<translation id="2100273922101894616">Acceso automático</translation>
-<translation id="2100314319871056947">Intenta compartir el texto en fragmentos más pequeños</translation>
-<translation id="2107397443965016585">Preguntar antes de permitir que los sitios reproduzcan contenido protegido (recomendado)</translation>
-<translation id="2111511281910874386">Ir a la página</translation>
-<translation id="2122601567107267586">No se pudo abrir la app</translation>
-<translation id="2126426811489709554">Con tecnología de Chrome</translation>
-<translation id="2131665479022868825">Datos ahorrados: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Pestaña <ph name="TAB_TITLE" /> cerrada</translation>
-<translation id="2139186145475833000">Agregar a la pantalla principal</translation>
-<translation id="2146738493024040262">Abrir app instantánea</translation>
-<translation id="2148716181193084225">Hoy</translation>
-<translation id="2154484045852737596">Editar tarjeta</translation>
-<translation id="2154710561487035718">Copiar URL</translation>
-<translation id="2156074688469523661">Sitios restantes (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Si quieres compartir contenido entre tu teléfono y otro dispositivo, activa la sincronización en la configuración de Chrome en ambos dispositivos.</translation>
-<translation id="2170088579611075216">Permitir y acceder a la RV</translation>
-<translation id="218608176142494674">Uso compartido</translation>
-<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sincronización y servicios</translation>
-<translation id="2259659629660284697">Exportar contraseñas…</translation>
-<translation id="2268044343513325586">Definir mejor</translation>
-<translation id="2286841657746966508">Dirección de facturación</translation>
-<translation id="2289270750774289114">Preguntarme cuando un sitio intente conectarse a dispositivos Bluetooth cercanos (recomendado)</translation>
-<translation id="230115972905494466">No se encontraron dispositivos compatibles</translation>
-<translation id="2315043854645842844">El sistema operativo no admite la selección de certificados del lado del cliente.</translation>
-<translation id="2318045970523081853">Presiona para realizar la llamada</translation>
-<translation id="2321086116217818302">Preparando las contraseñas…</translation>
-<translation id="2321958826496381788">Arrastra el control deslizante hasta que puedas leer esto cómodamente. El texto debería verse, al menos, de este tamaño al tocar dos veces un párrafo.</translation>
-<translation id="2323763861024343754">Almacenamiento del sitio</translation>
-<translation id="2328985652426384049">No puedes acceder</translation>
-<translation id="2330129964253841015">Advertirme si se vulneran las contraseñas</translation>
-<translation id="2349710944427398404">Cantidad total de datos que usa Chrome, lo que incluye las cuentas, favoritos y opciones de configuración guardadas</translation>
-<translation id="2353636109065292463">Revisando tu conexión a Internet</translation>
-<translation id="2359808026110333948">Continuar</translation>
-<translation id="2369533728426058518">pestañas abiertas</translation>
-<translation id="2387895666653383613">Ajuste de texto</translation>
-<translation id="2394602618534698961">Los archivos que descargues aparecerán aquí</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Esta función se activa cuando accedes a tu Cuenta de Google</translation>
-<translation id="2410754283952462441">Elegir una cuenta</translation>
-<translation id="2414886740292270097">Oscuro</translation>
-<translation id="2416359993254398973">Chrome necesita permiso para acceder a tu cámara para este sitio.</translation>
-<translation id="2426805022920575512">Seleccionar otra cuenta</translation>
-<translation id="2433507940547922241">Diseño</translation>
-<translation id="2434158240863470628">Se completó la descarga <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Acceso a la ubicación</translation>
-<translation id="2450083983707403292">¿Deseas comenzar la descarga de <ph name="FILE_NAME" /> de nuevo?</translation>
-<translation id="2482878487686419369">Notificaciones</translation>
-<translation id="2490684707762498678">Administradas por <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Asistente de Google en Chrome</translation>
-<translation id="2496180316473517155">Historial de navegación</translation>
-<translation id="2497852260688568942">Tu administrador inhabilitó la sincronización</translation>
-<translation id="2498359688066513246">Ayuda y comentarios</translation>
-<translation id="2501278716633472235">Ir atrás</translation>
-<translation id="2513403576141822879">Para obtener más opciones de configuración relacionadas con la privacidad, la seguridad y la recopilación de datos, visita <ph name="BEGIN_LINK" />Sincronización y servicios<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">En el modo lite, Chrome carga las páginas más rápido y usa hasta un 60% menos de datos. Para optimizar las páginas que visitas, Chrome envía tu tráfico en la Web a Google. <ph name="BEGIN_LINK" />Más información<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Envía a Google las URL de las páginas que visitas</translation>
-<translation id="2532336938189706096">Vista web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> elementos borrados</translation>
-<translation id="2536728043171574184">Visualizando una copia sin conexión de la página</translation>
-<translation id="2546283357679194313">Datos de sitios y cookies</translation>
-<translation id="2567385386134582609">IMAGEN</translation>
-<translation id="257088987046510401">Temas</translation>
-<translation id="2570922361219980984">El acceso a la ubicación también está desactivado en este dispositivo. Actívalo en la <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Expandido; haz clic para contraer.</translation>
-<translation id="2581165646603367611">Esta acción borrará la caché, cookies y otros datos de sitios que Chrome no considera importantes.</translation>
-<translation id="2586657967955657006">Portapapeles</translation>
-<translation id="2587052924345400782">Nueva versión disponible</translation>
-<translation id="2593272815202181319">Monoespaciada</translation>
-<translation id="2612676031748830579">Número de tarjeta</translation>
-<translation id="2621115761605608342">Permitir la ejecución de JavaScript para un sitio específico</translation>
-<translation id="2625189173221582860">Se copió la contraseña</translation>
-<translation id="2631006050119455616">Ahorrados</translation>
-<translation id="2647434099613338025">Agregar idioma</translation>
-<translation id="2650751991977523696">¿Deseas volver a descargar el archivo?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# archivo de audio}other{# archivos de audio}}</translation>
-<translation id="2653659639078652383">Enviar</translation>
-<translation id="2677748264148917807">Abandonar</translation>
-<translation id="2704606927547763573">Copiado</translation>
-<translation id="2707726405694321444">Actualizar página</translation>
-<translation id="2709516037105925701">Autocompletar</translation>
-<translation id="2717722538473713889">Direcciones de correo electrónico</translation>
-<translation id="2728754400939377704">Ordenar por sitio</translation>
-<translation id="2744248271121720757">Presiona una palabra para realizar una búsqueda instantánea o ver acciones relacionadas</translation>
-<translation id="2760989362628427051">Activa el tema oscuro cuando esté activado el Ahorro de batería o el tema oscuro de tu dispositivo</translation>
-<translation id="2762000892062317888">recién</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> segundos restantes</translation>
-<translation id="2779651927720337254">error</translation>
-<translation id="2781151931089541271">1 segundo restante</translation>
-<translation id="2801022321632964776">Para obtener tu idioma, actualiza a la versión más reciente de Chrome</translation>
-<translation id="2810645512293415242">La página se simplificó para ahorrar datos y acelerar la carga.</translation>
-<translation id="281504910091592009">Ver y administrar las contraseñas guardadas en tu <ph name="BEGIN_LINK" />cuenta de Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Para que tus favoritos estén en todos tus dispositivos, accede a tu cuenta y activa la sincronización</translation>
-<translation id="2822354292072154809">¿Confirmas que quieres restablecer todos los permisos de sitios para <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Toca el botón Atrás para salir de la pantalla completa.</translation>
-<translation id="2842985007712546952">Carpeta principal</translation>
-<translation id="2858138569776157458">Populares</translation>
-<translation id="2860954141821109167">Comprueba que este dispositivo tenga una app de teléfono habilitada</translation>
-<translation id="2870560284913253234">Sitio</translation>
-<translation id="2874939134665556319">Pista anterior</translation>
-<translation id="2876369937070532032">Enviar a Google las URL de algunas páginas que visitas, cuando tu seguridad esté en riesgo</translation>
-<translation id="2888126860611144412">Acerca de Chrome</translation>
-<translation id="2891154217021530873">Detener la carga de la página</translation>
-<translation id="2893180576842394309">Es posible que Google use tu historial para personalizar la Búsqueda, los anuncios y otros servicios de Google</translation>
-<translation id="2898264748040935573">Edita la contraseña almacenada</translation>
-<translation id="2900528713135656174">Crear evento</translation>
-<translation id="290376772003165898">¿La página no está en <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">La lista de dispositivos con los que se puede compartir una pestaña está totalmente abierta.</translation>
-<translation id="2910701580606108292">Preguntar antes de permitir que los sitios reproduzcan contenido protegido</translation>
-<translation id="2913331724188855103">Permitir que todos los sitios guarden y lean datos de cookies (recomendado)</translation>
-<translation id="2923908459366352541">El nombre no es válido</translation>
-<translation id="2932150158123903946">Almacenamiento de Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Se cerró la pestaña de vista previa</translation>
-<translation id="2956410042958133412"><ph name="PARENT_NAME_1" /> y <ph name="PARENT_NAME_2" /> administran esta cuenta.</translation>
-<translation id="2962095958535813455">Se seleccionaron las pestañas en modo de navegación de incógnito</translation>
-<translation id="2968755619301702150">Visualizador de certificados</translation>
-<translation id="2979025552038692506">Pestaña de incógnito seleccionada</translation>
-<translation id="2987620471460279764">Texto compartido desde otro dispositivo</translation>
-<translation id="2989523299700148168">Visitados recientemente</translation>
-<translation id="2996291259634659425">Crear frase de contraseña</translation>
-<translation id="2996809686854298943">URL obligatoria</translation>
-<translation id="300526633675317032">Se borrarán <ph name="SIZE_IN_KB" /> del almacenamiento del sitio web.</translation>
-<translation id="3016635187733453316">Comprueba que este dispositivo tenga conexión a Internet</translation>
-<translation id="3029613699374795922">Se descargaron <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Las frases de contraseña no coinciden.</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Obtener ayuda<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">La ubicación está desactivada; actívala en <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Puedes activar la sincronización en la configuración en cualquier momento</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> favorito}other{<ph name="BOOKMARKS_COUNT_MANY" /> favoritos}}</translation>
-<translation id="3089395242580810162">Abrir en pestaña de incógnito</translation>
-<translation id="3115898365077584848">Mostrar información</translation>
-<translation id="3123473560110926937">Bloqueados en algunos sitios</translation>
-<translation id="3137521801621304719">Salir del modo de navegación de incógnito</translation>
-<translation id="3143515551205905069">Cancelar sincronización</translation>
-<translation id="3157842584138209013">Para ver cuántos datos redujiste, selecciona el botón Más opciones</translation>
-<translation id="3166827708714933426">Accesos directos a ventanas y pestañas</translation>
-<translation id="3181954750937456830">Navegación segura (te protege a ti y tu dispositivo de sitios peligrosos)</translation>
-<translation id="3190152372525844641">Activa los permisos para Chrome en <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">Datos almacenados: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Ya casi terminas.</translation>
-<translation id="3207960819495026254">Agregada a favoritos</translation>
-<translation id="3211426585530211793">Se borró <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Si olvidaste la frase de contraseña o quieres cambiar esta configuración, <ph name="BEGIN_LINK" />restablece la contraseña<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Micrófono</translation>
-<translation id="3232754137068452469">Aplicación web</translation>
-<translation id="3236059992281584593">1 minuto restante</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Agregar esta página a Favoritos</translation>
-<translation id="3259831549858767975">Achicar todos los elementos de la página</translation>
-<translation id="3269093882174072735">Cargar imagen</translation>
-<translation id="3269956123044984603">Para obtener las pestañas de tus otros dispositivos, activa la opción "Sincronización automática de datos" en la configuración de la cuenta de Android.</translation>
-<translation id="3277252321222022663">Permitir que los sitios accedan a los sensores (recomendado)</translation>
-<translation id="3282568296779691940">Acceder a Chrome</translation>
-<translation id="3288003805934695103">Volver a cargar la página.</translation>
-<translation id="32895400574683172">Las notificaciones están habilitadas</translation>
-<translation id="3295530008794733555">Navega más rápido; usa menos datos</translation>
-<translation id="3295602654194328831">Ocultar información</translation>
-<translation id="3298243779924642547">Básico</translation>
-<translation id="3303414029551471755">¿Deseas descargar el contenido?</translation>
-<translation id="3306398118552023113">Esta app se ejecuta en Chrome</translation>
-<translation id="3315103659806849044">Estás personalizando la opción de configuración "Sincronización y servicios". Para activar la sincronización, presiona el botón Confirmar cerca de la parte inferior de la pantalla. Navegar hacia arriba</translation>
-<translation id="3328801116991980348">Información del sitio</translation>
-<translation id="3333961966071413176">Todos los contactos</translation>
-<translation id="3334729583274622784">¿Quieres cambiar la extensión del archivo?</translation>
-<translation id="3341058695485821946">Consulta cuántos datos redujiste</translation>
-<translation id="3350687908700087792">Cerrar todas las pestañas de incógnito</translation>
-<translation id="3353615205017136254">Google proporcionó la página básica. Para cargar la original, presiona el botón.</translation>
-<translation id="3367813778245106622">Volver a acceder para iniciar la sincronización</translation>
-<translation id="3374023511497244703">Ya no se sincronizarán con tu Cuenta de Google los favoritos, el historial, las contraseñas ni otros datos de Chrome.</translation>
-<translation id="3384347053049321195">Compartir imagen</translation>
-<translation id="3386292677130313581">Preguntar antes de permitir que los sitios conozcan tu ubicación (recomendado)</translation>
-<translation id="3387650086002190359"><ph name="FILE_NAME" /> no se pudo descargar debido a errores del sistema de archivos.</translation>
-<translation id="3389286852084373014">El texto es demasiado largo</translation>
-<translation id="3398320232533725830">Abrir el administrador de favoritos</translation>
-<translation id="3414952576877147120">Tamaño:</translation>
-<translation id="3443221991560634068">Volver a cargar la página actual</translation>
-<translation id="3445014427084483498">Recién</translation>
-<translation id="3478363558367712427">Puedes elegir tu motor de búsqueda</translation>
+<translation id="6910211073230771657">Eliminado</translation>
+<translation id="6965382102122355670">Aceptar</translation>
+<translation id="5301954838959518834">Entendido</translation>
+<translation id="7658239707568436148">Cancelar</translation>
 <translation id="3479552764303398839">Ahora no</translation>
-<translation id="3492207499832628349">Nueva pestaña de incógnito</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Más información<ph name="END_LINK" /> sobre el contenido sugerido</translation>
-<translation id="3513704683820682405">Realidad aumentada</translation>
-<translation id="3518985090088779359">Aceptar y continuar</translation>
-<translation id="3522247891732774234">Actualización disponible. Mas opciones</translation>
-<translation id="3524138585025253783">IU para desarrolladores</translation>
-<translation id="3527085408025491307">Carpeta</translation>
-<translation id="3542235761944717775">KB disponibles: <ph name="KILOBYTES" /></translation>
-<translation id="3549657413697417275">Buscar en el historial</translation>
-<translation id="3557336313807607643">Agregar a contactos</translation>
-<translation id="3566923219790363270">Chrome todavía se está preparando para la RV. Reinicia Chrome más tarde.</translation>
-<translation id="3568688522516854065">Para obtener las pestañas de tus otros dispositivos, accede a tu cuenta y activa la sincronización</translation>
-<translation id="3587482841069643663">Todos</translation>
-<translation id="358794129225322306">Permite que un sitio descargue varios archivos automáticamente.</translation>
-<translation id="3590487821116122040">Almacenamiento de sitios que Chrome no considera importantes (por ejemplo, sitios que no visitas a menudo o sin configuración guardada)</translation>
-<translation id="3599863153486145794">Borra el historial de todos los dispositivos en los que accediste. Es posible que tu cuenta de Google tenga otros formularios del historial de navegación en <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Silenciar los sitios que reproducen sonido</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Compartiendo con <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Quitar máscara de la contraseña</translation>
-<translation id="363596933471559332">Permite acceder automáticamente a los sitios web con las credenciales almacenadas. Si la función está desactivada, siempre se solicitará verificación antes de acceder a un sitio web.</translation>
-<translation id="3658159451045945436">Si lo haces, se borrará el historial de ahorro de datos, incluida la lista de sitios visitados.</translation>
-<translation id="3692944402865947621">Falló la descarga de <ph name="FILE_NAME" /> porque no se puede acceder a la ubicación del almacenamiento.</translation>
-<translation id="3714981814255182093">Abrir la barra de búsqueda</translation>
-<translation id="3716182511346448902">Chrome pausó esta página porque usa demasiada memoria.</translation>
-<translation id="3730075448226062617">Para permitir que Chrome acceda a tu micrófono, actívalo también en <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Agregado a favoritos en <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sincronización en segundo plano</translation>
-<translation id="3771001275138982843">No se pudo descargar la actualización</translation>
-<translation id="3771033907050503522">Pestañas de incógnito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Activa Bluetooth<ph name="END_LINK" /> para permitir la sincronización</translation>
-<translation id="3775705724665058594">Enviar a tus dispositivos</translation>
-<translation id="3778956594442850293">Se agregó a la pantalla principal</translation>
-<translation id="3789841737615482174">Instalar</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Administrar</translation>
-<translation id="381841723434055211">Números de teléfono</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> descargas borradas</translation>
-<translation id="3822502789641063741">¿Borrar el almacenamiento de sitios?</translation>
-<translation id="385051799172605136">Atrás</translation>
-<translation id="3859306556332390985">Buscar más adelante</translation>
-<translation id="3894427358181296146">Agregar carpeta</translation>
-<translation id="3895926599014793903">Forzar habilitación de zoom</translation>
-<translation id="3912508018559818924">Buscando lo mejor de la Web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combinar mis datos</translation>
-<translation id="393697183122708255">La búsqueda por voz no está habilitada</translation>
-<translation id="395206256282351086">Se inhabilitaron las sugerencias de sitios y búsqueda</translation>
-<translation id="3955193568934677022">Permitir que los sitios reproduzcan contenido protegido (recomendado)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome cargará la página cuando esté lista}other{Chrome cargará las páginas cuando estén listas}}</translation>
-<translation id="3963007978381181125">La encriptación de la frase de contraseña no incluye formas de pago ni direcciones de Google Pay. Solo las personas que tengan tu frase de contraseña pueden leer los datos encriptados. Google no envía ni almacena la frase de contraseña. Si la olvidas o quieres cambiar esta configuración, deberás restablecer la sincronización. <ph name="BEGIN_LINK" />Más información<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Descarga completa</translation>
-<translation id="397583555483684758">La sincronización dejó de funcionar</translation>
-<translation id="3976396876660209797">Quita y vuelve a crear este acceso directo</translation>
-<translation id="3985215325736559418">¿No quieres descargar <ph name="FILE_NAME" /> de nuevo?</translation>
-<translation id="3987993985790029246">Copiar vínculo</translation>
-<translation id="3988213473815854515">Se admite la ubicación.</translation>
-<translation id="3988466920954086464">Los resultados de la búsqueda instantánea se muestran en este panel</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Almacenamiento no importante</translation>
-<translation id="4000212216660919741">Página principal sin conexión</translation>
+<translation id="5317780077021120954">Guardar</translation>
+<translation id="4570913071927164677">Detalles</translation>
+<translation id="8730621377337864115">Listo</translation>
+<translation id="8261506727792406068">Borrar</translation>
+<translation id="1181037720776840403">Quitar</translation>
+<translation id="5939518447894949180">Restablecer</translation>
 <translation id="4002066346123236978">Título</translation>
-<translation id="4008040567710660924">Permite las cookies para un sitio específico.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Siguiente pista</translation>
-<translation id="4048707525896921369">Obtén información acerca de temas en sitios web sin salir de la página. "Presionar para buscar" envía una palabra y el contexto en el que se encuentra a la Búsqueda de Google, y muestra definiciones, fotos, resultados de la búsqueda y otros detalles.
+<translation id="5916664084637901428">Sí</translation>
+<translation id="5860033963881614850">No</translation>
+<translation id="6165508094623778733">Más información</translation>
+<translation id="6042308850641462728">Más</translation>
+<translation id="6040143037577758943">Cerrar</translation>
+<translation id="780301667611848630">No, gracias</translation>
+<translation id="1201402288615127009">Siguiente</translation>
+<translation id="2359808026110333948">Continuar</translation>
+<translation id="2653659639078652383">Enviar</translation>
+<translation id="2079545284768500474">Deshacer</translation>
+<translation id="7649070708921625228">Ayuda</translation>
+<translation id="2148716181193084225">Hoy</translation>
+<translation id="7781829728241885113">Ayer</translation>
+<translation id="6945221475159498467">Seleccionar</translation>
+<translation id="7791543448312431591">Agregar</translation>
+<translation id="6527303717912515753">Compartir</translation>
+<translation id="1383876407941801731">Buscar</translation>
+<translation id="3115898365077584848">Mostrar información</translation>
+<translation id="3295602654194328831">Ocultar información</translation>
+<translation id="3987993985790029246">Copiar vínculo</translation>
+<translation id="2704606927547763573">Copiado</translation>
+<translation id="8725066075913043281">Intentar nuevamente</translation>
+<translation id="385051799172605136">Atrás</translation>
+<translation id="8131740175452115882">Confirmar</translation>
+<translation id="5300589172476337783">Mostrar</translation>
+<translation id="1124772482545689468">Usuario</translation>
+<translation id="8609465669617005112">Subir</translation>
+<translation id="6746124502594467657">Mover hacia abajo</translation>
+<translation id="8249310407154411074">Mover al principio</translation>
+<translation id="8428213095426709021">Configuración</translation>
+<translation id="2498359688066513246">Ayuda y comentarios</translation>
+<translation id="8378714024927312812">Administrado por tu organización</translation>
+<translation id="9019902583201351841">Administrado por tus padres</translation>
+<translation id="4645575059429386691">Administrado por tus padres</translation>
+<translation id="4883854917563148705">No puede restablecerse la configuración administrada</translation>
+<translation id="4307992518367153382">Configuración básica</translation>
+<translation id="1974060860693918893">Configuración avanzada</translation>
+<translation id="1146678959555564648">Entrar al modo RV</translation>
+<translation id="987264212798334818">General</translation>
+<translation id="4275663329226226506">Multimedia</translation>
+<translation id="4759238208242260848">Descargas</translation>
+<translation id="218608176142494674">Uso compartido</translation>
+<translation id="8004582292198964060">Navegador</translation>
+<translation id="1105960400813249514">Captura de pantalla</translation>
+<translation id="4875775213178255010">Sugerencias de contenido</translation>
+<translation id="2021896219286479412">Controles en pantalla completa</translation>
+<translation id="4587589328781138893">Sitios</translation>
+<translation id="4943703118917034429">Realidad virtual</translation>
+<translation id="1928696683969751773">Actualizaciones</translation>
+<translation id="6064125863973209585">Descargas completadas</translation>
+<translation id="5342314432463739672">Solicitudes de permisos</translation>
+<translation id="629730747756840877">Cuenta</translation>
+<translation id="82609232232243542">Acceder a Brave</translation>
+<translation id="7956662517480676674">Sincronización y servicios</translation>
+<translation id="5294439808117722387">Estás personalizando la opción de configuración "Sincronización y servicios". Para activar la sincronización, presiona el botón Confirmar cerca de la parte inferior de la pantalla. Navegar hacia arriba</translation>
+<translation id="2096012225669085171">Sincroniza y personaliza contenido en diferentes dispositivos</translation>
+<translation id="1692118695553449118">La sincronización está activada.</translation>
+<translation id="5514904542973294328">El administrador de este dispositivo inhabilitó esta opción</translation>
+<translation id="6447211988989208781">Controles de actividad de Brave Software</translation>
+<translation id="4882831918239250449">Controlar cómo se usa tu historial de navegación para personalizar la Búsqueda, los anuncios y mucho más</translation>
+<translation id="7431991332293347422">Controla cómo se usa tu historial de navegación para personalizar la Búsqueda y mucho más</translation>
+<translation id="6303969859164067831">Salir y desactivar la sincronización</translation>
+<translation id="1125261911132334651">Administrar tu Cuenta de Brave Software</translation>
+<translation id="6406506848690869874">Sincronización</translation>
+<translation id="714362445477979774">Sincroniza tus datos de Brave</translation>
+<translation id="4314815835985389558">Administrar la sincronización</translation>
+<translation id="5428209950370661546">Otros servicios de Brave Software</translation>
+<translation id="7704317875155739195">Autocompletar búsquedas y URL</translation>
+<translation id="2000419248597011803">Envía algunas cookies y búsquedas de la barra de direcciones y del cuadro de búsqueda a tu motor de búsqueda predeterminado</translation>
+<translation id="7981313251711023384">Cargar previamente las páginas para acelerar la navegación y las búsquedas</translation>
+<translation id="1821253160463689938">Usa cookies para recordar tus preferencias, incluso si no visitas esas páginas</translation>
+<translation id="6697492270171225480">Mostrar sugerencias para páginas similares cuando no se puede encontrar una específica</translation>
+<translation id="8109318360573330108">Envía a Brave Software la URL de la página a la que intentas acceder</translation>
+<translation id="8438566539970814960">Mejorar las búsquedas y la navegación</translation>
+<translation id="284843628681142937">Envía a Brave Software las URL de las páginas que visitas</translation>
+<translation id="7222718784508482526">Para obtener más opciones de configuración relacionadas con la privacidad, la seguridad y la recopilación de datos, visita <ph name="BEGIN_LINK"/>Sincronización y servicios<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Ayudar a mejorar las funciones y el rendimiento de Brave</translation>
+<translation id="9063160602596686558">Envía automáticamente informes de fallos y estadísticas de uso a Brave Software</translation>
+<translation id="4824958205181053313">¿Quieres cancelar la sincronización?</translation>
+<translation id="3058498974290601450">Puedes activar la sincronización en la configuración en cualquier momento</translation>
+<translation id="3143515551205905069">Cancelar sincronización</translation>
+<translation id="1506061864768559482">Motor de búsqueda</translation>
+<translation id="55737423895878184">La ubicación y las notificaciones están habilitadas</translation>
+<translation id="3988213473815854515">Se admite la ubicación.</translation>
+<translation id="32895400574683172">Las notificaciones están habilitadas</translation>
+<translation id="9040142327097499898">Las notificaciones están habilitadas. La ubicación está desactivada en este dispositivo.</translation>
+<translation id="305593374596241526">La ubicación está desactivada; actívala en <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Visitados recientemente</translation>
+<translation id="6433501201775827830">Selecciona el motor de búsqueda</translation>
+<translation id="7177466738963138057">Puedes cambiar esta opción más tarde en Configuración</translation>
+<translation id="3478363558367712427">Puedes elegir tu motor de búsqueda</translation>
+<translation id="4910889077668685004">Apps de pago</translation>
+<translation id="5152843274749979095">No hay apps compatibles instaladas</translation>
+<translation id="8812260976093120287">En algunos sitios web, puedes usar las apps compatibles que se enumeran anteriormente para hacer pagos en tu dispositivo.</translation>
+<translation id="7764225426217299476">Agregar dirección</translation>
+<translation id="5595485650161345191">Editar dirección</translation>
+<translation id="5087580092889165836">Agregar tarjeta</translation>
+<translation id="2154484045852737596">Editar tarjeta</translation>
+<translation id="6140912465461743537">País o región</translation>
+<translation id="5659593005791499971">Correo electrónico</translation>
+<translation id="4378154925671717803">Teléfono</translation>
+<translation id="4807098396393229769">Nombre en la tarjeta</translation>
+<translation id="860043288473659153">Nombre del titular de la tarjeta</translation>
+<translation id="2612676031748830579">Número de tarjeta</translation>
+<translation id="869891660844655955">Fecha de vencimiento</translation>
+<translation id="2286841657746966508">Dirección de facturación</translation>
+<translation id="663059986967017181">Se copió en Brave.</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> más}other{<ph name="PAYMENT_METHOD_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> más}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> más}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> más}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> más}other{<ph name="SHIPPING_OPTION_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> más}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> más}other{<ph name="CONTACT_PREVIEW"/> y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> más}}</translation>
+<translation id="7029809446516969842">Contraseñas</translation>
+<translation id="1943432128510653496">Guardar contraseñas</translation>
+<translation id="2100273922101894616">Acceso automático</translation>
+<translation id="363596933471559332">Permite acceder automáticamente a los sitios web con las credenciales almacenadas. Si la función está desactivada, siempre se solicitará verificación antes de acceder a un sitio web.</translation>
+<translation id="6995899638241819463">Advertirme si quedan expuestas las contraseñas ante una violación de la seguridad de los datos</translation>
+<translation id="1534287762301776620">Esta función se activa cuando accedes a tu Cuenta de Brave Software</translation>
+<translation id="10614374240317010">Nunca guardado</translation>
+<translation id="3098842761938485917">Ver y administrar las contraseñas guardadas en tu <ph name="BEGIN_LINK"/>cuenta de Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Las contraseñas guardadas aparecerán aquí.</translation>
+<translation id="8084114998886531721">Se guardó la contraseña</translation>
+<translation id="2870560284913253234">Sitio</translation>
+<translation id="8503813439785031346">Nombre de usuario</translation>
+<translation id="6657585470893396449">Contraseña</translation>
+<translation id="2154710561487035718">Copiar URL</translation>
+<translation id="1571304935088121812">Copiar el nombre de usuario</translation>
+<translation id="5005498671520578047">Copiar contraseña</translation>
+<translation id="3632295766818638029">Quitar máscara de la contraseña</translation>
+<translation id="1513858653616922153">Borrar contraseña</translation>
+<translation id="543338862236136125">Editar la contraseña</translation>
+<translation id="4565377596337484307">Ocultar contraseña</translation>
+<translation id="8523928698583292556">Borrar contraseña almacenada</translation>
+<translation id="2898264748040935573">Edita la contraseña almacenada</translation>
+<translation id="5433691172869980887">Se copió el nombre de usuario</translation>
+<translation id="5534640966246046842">Se copió el sitio</translation>
+<translation id="2625189173221582860">Se copió la contraseña</translation>
+<translation id="4550003330909367850">Para ver o copiar tu contraseña aquí, establece un bloqueo de pantalla en este dispositivo.</translation>
+<translation id="6154478581116148741">Para exportar tus contraseñas de este dispositivo, activa el bloqueo de pantalla en Configuración</translation>
+<translation id="4842092870884894799">Mostrando mensaje emergente de generación de contraseña</translation>
+<translation id="2259659629660284697">Exportar contraseñas…</translation>
+<translation id="133012818630824069">Exportar las contraseñas almacenadas con Brave</translation>
+<translation id="6914783257214138813">Las personas que tengan acceso al archivo exportado podrán ver tus contraseñas.</translation>
+<translation id="2321086116217818302">Preparando las contraseñas…</translation>
+<translation id="8445448999790540984">No se pueden exportar las contraseñas</translation>
+<translation id="3066461326500799725">Aprender a usar Brave Software Drive</translation>
+<translation id="729975465115245577">Tu dispositivo no tiene una app que pueda almacenar el archivo de contraseñas.</translation>
+<translation id="7682724950699840886">Intenta las siguientes sugerencias: Antes de exportar las contraseñas nuevamente, asegúrate de que haya espacio suficiente en tu dispositivo.</translation>
+<translation id="1129510026454351943">Detalles: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Desbloquea la pantalla para copiar tu contraseña</translation>
+<translation id="5515439363601853141">Desbloquea la pantalla para ver tu contraseña</translation>
+<translation id="6221633008163990886">Desbloquea la pantalla para exportar tus contraseñas</translation>
+<translation id="230699814587342492">Contraseñas de Brave</translation>
+<translation id="6075798973483050474">Editar la Página principal</translation>
+<translation id="854522910157234410">Abrir esta página</translation>
+<translation id="2482878487686419369">Notificaciones</translation>
+<translation id="6255999984061454636">Sugerencias de contenido</translation>
+<translation id="805047784848435650">Según tu historial de navegación</translation>
+<translation id="1041308826830691739">De sitios web</translation>
+<translation id="395206256282351086">Se inhabilitaron las sugerencias de sitios y búsqueda</translation>
+<translation id="257088987046510401">Temas</translation>
+<translation id="4650364565596261010">Predeterminado del sistema</translation>
+<translation id="7588219262685291874">Activar el tema oscuro cuando esté activado el Ahorro de batería de tu dispositivo</translation>
+<translation id="2760989362628427051">Activa el tema oscuro cuando esté activado el Ahorro de batería o el tema oscuro de tu dispositivo</translation>
+<translation id="6381421346744604172">Oscurecer sitios web</translation>
+<translation id="5040262127954254034">Privacidad</translation>
+<translation id="4991384657077828949">Ayudar a mejorar la seguridad de Brave</translation>
+<translation id="1943176487615318915">Para detectar apps y sitios peligrosos, Brave envía a Brave Software URL de algunas páginas que visitas, información limitada sobre el sistema y contenido de algunas páginas</translation>
+<translation id="3181954750937456830">Navegación segura (te protege a ti y tu dispositivo de sitios peligrosos)</translation>
+<translation id="7315322926489145388">Enviar a Brave Software las URL de algunas páginas que visitas, cuando tu seguridad esté en riesgo</translation>
+<translation id="2063713494490388661">Presionar para buscar</translation>
+<translation id="2369463299479365221">Obtén información acerca de temas en sitios web sin salir de la página. "Presionar para buscar" envía una palabra y el contexto en el que se encuentra a la Búsqueda de Brave Software, y muestra definiciones, fotos, resultados de la búsqueda y otros detalles.
 
 Para ajustar el término de búsqueda, mantén presionado el texto y selecciónalo. Para perfeccionar la búsqueda, desliza el panel hacia arriba y presiona el cuadro de búsqueda.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Opciones disponibles cerca de la parte superior de la pantalla</translation>
-<translation id="4062305924942672200">Información legal</translation>
-<translation id="4084682180776658562">Marcador</translation>
-<translation id="4084712963632273211">De <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />publicado por Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">¿Borrar datos de app?</translation>
-<translation id="4099578267706723511">Envía las estadísticas de uso y los informes de fallos a Google para ayudarnos a mejorar Chrome.</translation>
-<translation id="410351446219883937">Reproducción automática</translation>
-<translation id="4116038641877404294">Descarga las páginas para usarlas sin conexión</translation>
-<translation id="4135200667068010335">La lista de dispositivos con los que se puede compartir una pestaña está cerrada.</translation>
-<translation id="4149994727733219643">Vista simplificada para páginas web</translation>
-<translation id="4165986682804962316">Configuración del sitio</translation>
-<translation id="4169535189173047238">No permitir</translation>
-<translation id="4170011742729630528">El servicio no se encuentra disponible; vuelve a intentarlo más tarde.</translation>
-<translation id="4179980317383591987">Datos utilizados: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Idiomas</translation>
-<translation id="4183868528246477015">Buscar con Google Lens <ph name="BEGIN_NEW" />Nuevo<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Abrir en una pestaña nueva</translation>
-<translation id="4198423547019359126">No hay ubicaciones de descarga disponibles</translation>
-<translation id="4209895695669353772">Para obtener contenido personalizado y sugerido por Google, activa la sincronización</translation>
-<translation id="4226663524361240545">Es posible que las notificaciones hagan vibrar el dispositivo</translation>
-<translation id="423219824432660969">Encriptar los datos sincronizados con la contraseña de Google a partir del <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Abrir la configuración</translation>
-<translation id="4256782883801055595">Licencias de código abierto</translation>
-<translation id="4259722352634471385">Navegación bloqueada: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copiar dirección del vínculo</translation>
-<translation id="4275663329226226506">Multimedia</translation>
-<translation id="4278390842282768270">Permitido</translation>
-<translation id="429312253194641664">Un sitio está reproduciendo contenido multimedia</translation>
-<translation id="4298388696830689168">Sitios vinculados</translation>
-<translation id="4307992518367153382">Configuración básica</translation>
-<translation id="4314815835985389558">Administrar la sincronización</translation>
-<translation id="4351244548802238354">Cerrar cuadro de diálogo</translation>
-<translation id="4378154925671717803">Teléfono</translation>
-<translation id="4384468725000734951">Se usa Sogou para la búsqueda</translation>
-<translation id="4404568932422911380">No hay favoritos</translation>
-<translation id="4405224443901389797">Mover a…</translation>
-<translation id="4411535500181276704">Modo lite</translation>
-<translation id="4415276339145661267">Administrar tu Cuenta de Google</translation>
-<translation id="4432792777822557199">De ahora en más, las páginas en <ph name="SOURCE_LANGUAGE" /> se traducirán al <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Google proporcionó la página básica</translation>
-<translation id="4434045419905280838">Ventanas emergentes y redirec.</translation>
-<translation id="4440958355523780886">Google proporcionó la página básica. Presiona para cargar la versión original.</translation>
-<translation id="4452411734226507615">Cierra la pestaña <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Se agregó a favoritos en <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Permitir que los sitios reproduzcan contenido protegido</translation>
-<translation id="4468959413250150279">Silenciar un sitio específico.</translation>
-<translation id="4472118726404937099">Para sincronizar diferentes dispositivos y personalizar tu experiencia, accede a tu cuenta y activa la sincronización</translation>
-<translation id="447252321002412580">Ayudar a mejorar las funciones y el rendimiento de Chrome</translation>
-<translation id="4479647676395637221">Preguntar primero antes de permitir que los sitios usen tu cámara (recomendado)</translation>
-<translation id="4479972344484327217">Instalando <ph name="MODULE" /> para Chrome…</translation>
-<translation id="4487967297491345095">Todos los datos de app de Chrome se borrarán de forma permanente. Esta información incluye todos los archivos, opciones de configuración, cuentas, bases de datos, etc.</translation>
-<translation id="4493497663118223949">El modo lite está activado</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Hace # día}other{Hace # días}}</translation>
-<translation id="451872707440238414">Buscar tus favoritos</translation>
-<translation id="4521489764227272523">Los datos seleccionados se quitaron de Chrome y tus dispositivos sincronizados.
-
-Es posible que tu cuenta de Google tenga otros formularios de historial de navegación, como búsquedas y actividad de otros servicios de Google en <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Seleccionar carpeta</translation>
-<translation id="4538018662093857852">Activar el modo lite</translation>
-<translation id="4550003330909367850">Para ver o copiar tu contraseña aquí, establece un bloqueo de pantalla en este dispositivo.</translation>
-<translation id="4558311620361989323">Accesos directos a páginas web</translation>
-<translation id="4561979708150884304">Sin conexión</translation>
-<translation id="4565377596337484307">Ocultar contraseña</translation>
-<translation id="4570913071927164677">Detalles</translation>
-<translation id="4572422548854449519">Acceder a una cuenta administrada</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Hace # minuto}other{Hace # minutos}}</translation>
-<translation id="4587589328781138893">Sitios</translation>
-<translation id="4594952190837476234">Esta página sin conexión se creó el <ph name="CREATION_TIME" /> y es posible que sea diferente con respecto a la versión en línea.</translation>
-<translation id="4605958867780575332">Se quitó el siguiente elemento: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Usar contraseña</translation>
-<translation id="4645575059429386691">Administrado por tus padres</translation>
-<translation id="4650364565596261010">Predeterminado del sistema</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> favoritos eliminados</translation>
-<translation id="4665282149850138822">Se agregó <ph name="NAME" /> a la pantalla principal</translation>
-<translation id="4684427112815847243">Sincronizar todo</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> más}other{<ph name="SHIPPING_OPTION_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> más}}</translation>
-<translation id="4696983787092045100">Enviar texto a tus dispositivos</translation>
-<translation id="4698034686595694889">Ver sin conexión en <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Imágenes y archivos almacenados en caché</translation>
-<translation id="4714588616299687897">Ahorra hasta un 60% de tus datos</translation>
-<translation id="4719927025381752090">Ofrecer la traducción</translation>
-<translation id="4720023427747327413">Abrir en <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Ayuda a mejorar Chrome. <ph name="BEGIN_LINK" />Realiza la encuesta<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Actualizar</translation>
-<translation id="4738836084190194332">Última sincronización: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Abrir una pestaña nueva</translation>
-<translation id="4751476147751820511">Sensores de luz o movimiento</translation>
-<translation id="4759238208242260848">Descargas</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Se completó la descarga.}other{Se completaron # descargas.}}</translation>
-<translation id="4797039098279997504">Toca para volver a <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">La encriptación de la frase de contraseña no incluye formas de pago ni direcciones de Google Pay.
-
-Para cambiar esta configuración, <ph name="BEGIN_LINK" />restablece la sincronización<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Nombre en la tarjeta</translation>
-<translation id="4824958205181053313">¿Quieres cancelar la sincronización?</translation>
-<translation id="4837753911714442426">Abrir opciones para imprimir la página</translation>
-<translation id="4842092870884894799">Mostrando mensaje emergente de generación de contraseña</translation>
-<translation id="4860895144060829044">Llamar</translation>
-<translation id="4866368707455379617">No es posible instalar <ph name="MODULE" /> para Chrome</translation>
-<translation id="4875775213178255010">Sugerencias de contenido</translation>
-<translation id="4878404682131129617">Se produjo un error al establecer conexión a través del servidor proxy</translation>
-<translation id="4880127995492972015">Traducir…</translation>
-<translation id="4881695831933465202">Abrir</translation>
-<translation id="488187801263602086">Cambiar el nombre del archivo</translation>
-<translation id="4882831918239250449">Controlar cómo se usa tu historial de navegación para personalizar la Búsqueda, los anuncios y mucho más</translation>
-<translation id="4883854917563148705">No puede restablecerse la configuración administrada</translation>
-<translation id="4885273946141277891">Cantidad de instancias de Chrome no admitidas</translation>
-<translation id="4910889077668685004">Apps de pago</translation>
-<translation id="4913161338056004800">Restablecer estadísticas</translation>
-<translation id="4913169188695071480">Detener actualización</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Obtener ayuda<ph name="END_LINK" /> mientras se buscan dispositivos…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}other{# páginas}}</translation>
-<translation id="4932247056774066048">Estás saliendo de una cuenta administrada por <ph name="DOMAIN_NAME" />. Se borrarán tus datos de Chrome de este dispositivo, pero permanecerán en tu Cuenta de Google.</translation>
-<translation id="4943703118917034429">Realidad virtual</translation>
-<translation id="4943872375798546930">Sin resultados</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> está compartiendo tu pantalla</translation>
-<translation id="4961107849584082341">Traducir esta página a cualquier idioma</translation>
-<translation id="4962975101802056554">Revocar todos los permisos del dispositivo</translation>
-<translation id="4970824347203572753">No disponible en tu ubicación</translation>
-<translation id="497421865427891073">Avanzar</translation>
-<translation id="4988210275050210843">Descargando archivo (<ph name="MEGABYTES" />)</translation>
-<translation id="4988526792673242964">Páginas</translation>
-<translation id="4994033804516042629">No se encontraron contactos</translation>
-<translation id="4996978546172906250">Compartir mediante</translation>
-<translation id="5004416275253351869">Controles de actividad de Google</translation>
-<translation id="5005498671520578047">Copiar contraseña</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> desea conectarse</translation>
-<translation id="5013696553129441713">No hay sugerencias nuevas</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Mientras usas el modo RV, es posible que este sitio obtenga la siguiente información:
-- tus características físicas, como tu altura
-
-Asegúrate de que este sitio sea de confianza antes de entrar en el modo RV.</translation>
+<translation id="2930742481329940825">La función "Presionar para buscar" envía la palabra seleccionada y la página actual como contexto a la Búsqueda de Brave Software. Para desactivarla, accede a <ph name="BEGIN_LINK"/>Configuración<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Permitir</translation>
-<translation id="5040262127954254034">Privacidad</translation>
-<translation id="5048398596102334565">Permitir que los sitios accedan a los sensores de movimiento (recomendado)</translation>
-<translation id="5063480226653192405">Uso</translation>
-<translation id="5087580092889165836">Agregar tarjeta</translation>
-<translation id="5100237604440890931">Contraído; haz clic para expandir.</translation>
-<translation id="510275257476243843">1 hora restante</translation>
-<translation id="5123685120097942451">Pestaña de incógnito</translation>
-<translation id="5127805178023152808">La sincronización está desactivada.</translation>
-<translation id="5129038482087801250">Instalar la aplicación web</translation>
-<translation id="5132942445612118989">Sincroniza tus contraseñas, historial y más en todos los dispositivos</translation>
-<translation id="5139940364318403933">Aprender a usar Google Drive</translation>
-<translation id="515227803646670480">Borrar datos almacenados</translation>
-<translation id="5152843274749979095">No hay apps compatibles instaladas</translation>
-<translation id="5161254044473106830">Se requiere un título</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{No se pudo realizar la descarga.}other{No se pudieron realizar # descargas.}}</translation>
-<translation id="5170568018924773124">Mostrar en carpeta</translation>
-<translation id="5184329579814168207">Abrir en Chrome</translation>
-<translation id="5193988420012215838">Se copió en tu portapapeles</translation>
-<translation id="5197729504361054390">Los contactos que selecciones se compartirán con <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Perfil de trabajo</translation>
-<translation id="5210286577605176222">Ir a la pestaña anterior</translation>
-<translation id="5210365745912300556">Cerrar pestaña</translation>
-<translation id="5224771365102442243">Con video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> quiere detectar dispositivos Bluetooth cercanos. Se encontraron los siguientes dispositivos:</translation>
-<translation id="5233638681132016545">Nueva pestaña</translation>
-<translation id="526421993248218238">No se puede cargar esta página</translation>
-<translation id="5271967389191913893">El dispositivo no puede abrir el contenido que se descargará.</translation>
-<translation id="528192093759286357">Arrastra el dedo desde la parte superior y toca el botón Atrás para salir de la pantalla completa.</translation>
-<translation id="5292796745632149097">Enviar a</translation>
-<translation id="5300589172476337783">Mostrar</translation>
-<translation id="5301954838959518834">Entendido</translation>
-<translation id="5304593522240415983">Este campo no puede quedar en blanco.</translation>
-<translation id="5307446750509046227">Borrar el almacenamiento de sitios</translation>
-<translation id="5308380583665731573">Conectar</translation>
-<translation id="5313967007315987356">Agregar sitio</translation>
-<translation id="5317780077021120954">Guardar</translation>
-<translation id="5324858694974489420">Configuración parental</translation>
-<translation id="5327248766486351172">Nombre</translation>
-<translation id="5335288049665977812">Permitir que los sitios ejecuten JavaScript (recomendado)</translation>
-<translation id="5342314432463739672">Solicitudes de permisos</translation>
-<translation id="5357811892247919462">Se recibió una pestaña</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> pestaña abierta; presiona para cambiar de pestaña}other{<ph name="OPEN_TABS_MANY" /> pestañas abiertas; presiona para cambiar de pestaña}}</translation>
-<translation id="5391532827096253100">La conexión con este sitio no es segura. Consulta la información del sitio.</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(1 más)}other{(# más)}}</translation>
-<translation id="5400569084694353794">Si usas esta aplicación, aceptas las <ph name="BEGIN_LINK1" />Condiciones del Servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />Aviso de Privacidad<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="5403592356182871684">Nombres</translation>
-<translation id="5403644198645076998">Permitir solo algunos sitios</translation>
-<translation id="5414836363063783498">Verificando…</translation>
-<translation id="5423934151118863508">Aquí aparecerán las páginas que visites con más frecuencia</translation>
-<translation id="5424588387303617268">GB disponibles: <ph name="GIGABYTES" /></translation>
-<translation id="543338862236136125">Editar la contraseña</translation>
-<translation id="5433691172869980887">Se copió el nombre de usuario</translation>
-<translation id="543509235395288790">Descargando <ph name="COUNT" /> archivos (<ph name="MEGABYTES" />)</translation>
-<translation id="5441522332038954058">Ir a la barra de direcciones</translation>
-<translation id="5447201525962359567">Todo el almacenamiento de sitios, lo que incluye cookies y otros datos almacenados de forma local</translation>
-<translation id="5447765697759493033">Este sitio no se traducirá</translation>
-<translation id="545042621069398927">Acelerando la descarga</translation>
-<translation id="5456381639095306749">Descargar página</translation>
-<translation id="5475862044948910901">¿Quieres iniciar la sesión de realidad aumentada?</translation>
-<translation id="548278423535722844">Abrir en una app de mapas</translation>
-<translation id="5487521232677179737">Borrar datos</translation>
-<translation id="5494752089476963479">Bloquear anuncios de sitios que muestran anuncios intrusivos o engañosos</translation>
-<translation id="5500777121964041360">Es posible que no esté disponible en tu ubicación</translation>
-<translation id="5512137114520586844"><ph name="PARENT_NAME" /> administra esta cuenta.</translation>
-<translation id="5514904542973294328">El administrador de este dispositivo inhabilitó esta opción</translation>
-<translation id="5515439363601853141">Desbloquea la pantalla para ver tu contraseña</translation>
-<translation id="5516455585884385570">Abrir la configuración de notificaciones</translation>
-<translation id="5517095782334947753">Tienes favoritos, historial, contraseñas y otras opciones de configuración de <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Se bloqueó el redireccionamiento</translation>
-<translation id="5527082711130173040">Chrome debe acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK1" />Actualiza los permisos<ph name="END_LINK1" />. El acceso a la ubicación también está <ph name="BEGIN_LINK2" />desactivado en este dispositivo<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Preguntar antes de permitir que los sitios lean el texto y las imágenes del portapapeles (recomendado)</translation>
-<translation id="5530766185686772672">Cerrar pest. de incógnito</translation>
-<translation id="5534334044554683961">Mientras usas el modo RV, es posible que este sitio obtenga la siguiente información:
-- tus características físicas, como tu altura
-- la disposición de tu habitación
-
-Asegúrate de que este sitio sea de confianza antes de entrar en el modo RV.</translation>
-<translation id="5534640966246046842">Se copió el sitio</translation>
-<translation id="5556459405103347317">Cargar de nuevo</translation>
-<translation id="5561549206367097665">Esperando red…</translation>
-<translation id="557283862590186398">Chrome necesita permiso para acceder a tu micrófono para este sitio.</translation>
-<translation id="55737423895878184">La ubicación y las notificaciones están habilitadas</translation>
-<translation id="5578795271662203820">Buscar esta imagen en <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">En la <ph name="BEGIN_LINK1" />configuración<ph name="END_LINK1" />, puedes elegir los datos para sincronizar en cualquier momento.</translation>
-<translation id="5595485650161345191">Editar dirección</translation>
-<translation id="5596627076506792578">Más opciones</translation>
-<translation id="5599455543593328020">Modo de navegación incógnito</translation>
-<translation id="5620928963363755975">Encuentra tus archivos y páginas en Descargas desde el botón Más opciones</translation>
-<translation id="5626134646977739690">Nombre:</translation>
-<translation id="5639724618331995626">Permitir todos los sitios</translation>
-<translation id="5648166631817621825">Últimos 7 días</translation>
-<translation id="5649053991847567735">Descargas automáticas</translation>
-<translation id="5655963694829536461">Buscar tus descargas</translation>
-<translation id="5659593005791499971">Correo electrónico</translation>
-<translation id="5665379678064389456">Crear evento en <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Anular la solicitud de inhabilitación del zoom de un sitio web</translation>
-<translation id="5677928146339483299">Bloqueados</translation>
-<translation id="5684874026226664614">No se puede traducir esta página.</translation>
-<translation id="5686790454216892815">El nombre del archivo es demasiado largo</translation>
-<translation id="5689516760719285838">Ubicación</translation>
-<translation id="569536719314091526">Traduce esta página a cualquier idioma desde el botón Más opciones</translation>
-<translation id="572328651809341494">Pestañas recientes</translation>
-<translation id="5726692708398506830">Agrandar todos los elementos de la página</translation>
-<translation id="5748802427693696783">Se seleccionaron las pestañas estándar</translation>
-<translation id="5749068826913805084">Chrome necesita acceder al almacenamiento para descargar archivos.</translation>
-<translation id="5763382633136178763">Pestañas en modo de incógnito</translation>
-<translation id="5763514718066511291">Presiona para copiar la URL para esta app</translation>
-<translation id="5765780083710877561">Descripción:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> de <ph name="SPACE_AVAILABLE" /> en uso</translation>
-<translation id="5797070761912323120">Es posible que Google use tu historial para personalizar la Búsqueda, los anuncios y otros servicios de Google</translation>
-<translation id="5804241973901381774">Permisos</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Hace # hora}other{Hace # horas}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Todos los derechos reservados.</translation>
-<translation id="5817918615728894473">Sincronizar</translation>
-<translation id="583281660410589416">Desconocido</translation>
-<translation id="5833984609253377421">Compartir vínculo</translation>
-<translation id="5836192821815272682">Descargando la actualización de Chrome…</translation>
-<translation id="5853623416121554550">pausado</translation>
-<translation id="5854790677617711513">Hace más de 30 días</translation>
-<translation id="5858741533101922242">Chrome no puede activar el adaptador Bluetooth</translation>
-<translation id="5860033963881614850">No</translation>
-<translation id="5862731021271217234">Para obtener las pestañas de tus otros dispositivos, activa la sincronización</translation>
-<translation id="5864174910718532887">Detalles: Ordenados por nombre de sitio</translation>
-<translation id="5864419784173784555">Esperando que finalice otra descarga…</translation>
-<translation id="5865733239029070421">Envía automáticamente informes de fallos y estadísticas de uso a Google</translation>
-<translation id="5869522115854928033">Contraseñas almacenadas</translation>
-<translation id="5902828464777634901">Se eliminarán todos los datos almacenados en este sitio web, incluidas las cookies.</translation>
-<translation id="5916664084637901428">Sí</translation>
-<translation id="5919204609460789179">Actualiza <ph name="PRODUCT_NAME" /> para iniciar la sincronización</translation>
-<translation id="5937580074298050696">Datos ahorrados: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Restablecer</translation>
-<translation id="5942872142862698679">Se usa Google para la búsqueda</translation>
-<translation id="5952764234151283551">Envía a Google la URL de la página a la que intentas acceder</translation>
-<translation id="5956665950594638604">Abrir Centro de ayuda de Chrome en pestaña nueva</translation>
-<translation id="5958275228015807058">Encuentra tus archivos y páginas en Descargas</translation>
-<translation id="5962718611393537961">Presiona para contraer</translation>
-<translation id="6000066717592683814">Seguir usando Google</translation>
-<translation id="6005538289190791541">Contraseña sugerida</translation>
-<translation id="6036057147555329831">ICU adicional</translation>
-<translation id="6039379616847168523">Ir a la pestaña siguiente</translation>
-<translation id="6040143037577758943">Cerrar</translation>
-<translation id="6042308850641462728">Más</translation>
-<translation id="604996488070107836"><ph name="FILE_NAME" /> no se pudo descargar debido a un error desconocido.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Descargas completadas</translation>
-<translation id="6075798973483050474">Editar la Página principal</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> horas restantes</translation>
-<translation id="6108923351542677676">Configuración en curso…</translation>
-<translation id="6111020039983847643">de datos utilizados</translation>
-<translation id="6112702117600201073">Actualizando la página</translation>
-<translation id="6127379762771434464">Se eliminó el elemento</translation>
-<translation id="6140912465461743537">País o región</translation>
-<translation id="614940544461990577">Intenta:</translation>
-<translation id="6154478581116148741">Para exportar tus contraseñas de este dispositivo, activa el bloqueo de pantalla en Configuración</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> de ahorro de datos</translation>
-<translation id="6165508094623778733">Más información</translation>
-<translation id="6177111841848151710">Se bloqueó para el motor de búsqueda actual</translation>
-<translation id="6181444274883918285">Agregar excepción de sitio web</translation>
-<translation id="6192333916571137726">Descargar archivo</translation>
-<translation id="6192792657125177640">Excepciones</translation>
-<translation id="6194112207524046168">Para permitir que Chrome acceda a tu cámara, actívala también en <ph name="BEGIN_LINK" />Configuración de Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Bloquear cookies de terceros</translation>
-<translation id="6206551242102657620">La conexión es segura. Consulta la información del sitio.</translation>
-<translation id="6210748933810148297">¿No eres <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Desbloquea la pantalla para exportar tus contraseñas</translation>
+<translation id="1406000523432664303">No realizar seguimiento</translation>
 <translation id="6232535412751077445">Si se habilita la opción de "No realizar seguimiento", se incluirá una solicitud con tu tráfico de navegación. Los efectos dependerán de si hay algún sitio web que responda a la solicitud y de cómo se interprete.
 
 Por ejemplo, algunos sitios web pueden responder a la solicitud mediante anuncios que no están basados en otros sitios web que hayas visitado. Muchos sitios web seguirán recopilando y utilizando tus datos de navegación, por ejemplo, para mejorar la seguridad, proporcionar contenido, anuncios y recomendaciones, y generar estadísticas de informes.</translation>
-<translation id="624789221780392884">Actualización lista</translation>
-<translation id="6255999984061454636">Sugerencias de contenido</translation>
-<translation id="6277522088822131679">Se produjo un error al imprimir la página. Vuelve a intentarlo.</translation>
-<translation id="6295158916970320988">Todos los sitios</translation>
-<translation id="629730747756840877">Cuenta</translation>
-<translation id="6303969859164067831">Salir y desactivar la sincronización</translation>
-<translation id="6316139424528454185">Versión Android no compatible</translation>
-<translation id="6320088164292336938">Vibrar</translation>
-<translation id="6324034347079777476">Sincronización del sistema Android inhabilitada</translation>
-<translation id="6333140779060797560">Compartir mediante <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Encriptación</translation>
-<translation id="6341580099087024258">Preguntar dónde guardar los archivos</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> más}other{<ph name="SHIPPING_ADDRESS_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> más}}</translation>
-<translation id="6364438453358674297">¿Borrar la sugerencia del historial?</translation>
-<translation id="6369229450655021117">Desde aquí, puedes realizar búsquedas en la Web, compartir contenido con amigos y ver las páginas abiertas</translation>
-<translation id="6378173571450987352">Detalles: Ordenados por cantidad de datos utilizados</translation>
-<translation id="6381421346744604172">Oscurecer sitios web</translation>
-<translation id="6388207532828177975">Borrar y restablecer</translation>
-<translation id="6393863479814692971">Chrome necesita permiso para acceder a tu cámara y micrófono para este sitio.</translation>
-<translation id="6395288395575013217">VÍNCULO</translation>
-<translation id="6404511346730675251">Editar marcador</translation>
-<translation id="6406506848690869874">Sincronización</translation>
-<translation id="641643625718530986">Imprimir…</translation>
-<translation id="6416782512398055893">Se descargaron <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Traduce la Web</translation>
-<translation id="6433501201775827830">Selecciona el motor de búsqueda</translation>
-<translation id="6437478888915024427">Información de la página</translation>
-<translation id="6441734959916820584">El nombre es demasiado largo</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagen}other{# imágenes}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">No se puede abrir el archivo</translation>
-<translation id="6464977750820128603">Puedes ver los sitios que visites en Chrome y establecer temporizadores para ellos.\n\nGoogle obtiene información sobre los sitios para los que estableces temporizadores y la duración de las visitas a ellos. Esta información se usa para mejorar Bienestar digital.</translation>
-<translation id="6475951671322991020">Descargar video</translation>
-<translation id="6482749332252372425"><ph name="FILE_NAME" /> no se pudo descargar debido a la falta de espacio de almacenamiento.</translation>
-<translation id="6496823230996795692">Para usar <ph name="APP_NAME" /> por primera vez, conéctate a Internet.</translation>
-<translation id="6508722015517270189">Reinicia Chrome.</translation>
-<translation id="6527303717912515753">Compartir</translation>
-<translation id="6532866250404780454">No se mostrarán los sitios que visites en Chrome. Se borrarán todos los temporizadores.</translation>
-<translation id="6534565668554028783">Google tardó demasiado en responder</translation>
-<translation id="6538442820324228105">Se descargaron <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Se produjo un error; vuelve a intentarlo más tarde.</translation>
-<translation id="654446541061731451">Elige una pestaña para transmitir.</translation>
-<translation id="6545017243486555795">Borrar todos los datos</translation>
-<translation id="6545864417968258051">Búsqueda de dispositivos Bluetooth</translation>
-<translation id="6560414384669816528">Buscar con Sogou</translation>
-<translation id="6566259936974865419">Chrome te permitió ahorrar <ph name="GIGABYTES" /> gigabytes</translation>
-<translation id="6573096386450695060">Permitir siempre</translation>
-<translation id="6573431926118603307">Aquí aparecerán las pestañas que abriste en Chrome en tus otros dispositivos.</translation>
-<translation id="6583199322650523874">Agregar la página actual a favoritos</translation>
-<translation id="6593061639179217415">Sitio de escritorio</translation>
-<translation id="6600954340915313787">Se copió en Chrome.</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Contenido protegido</translation>
-<translation id="6627583120233659107">Editar la carpeta</translation>
-<translation id="6643016212128521049">Borrar</translation>
-<translation id="6643649862576733715">Ordenar por cantidad de datos ahorrados</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> más}other{<ph name="CONTACT_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> más}}</translation>
-<translation id="6649642165559792194">Vista previa de imagen <ph name="BEGIN_NEW" />Nueva<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome necesita acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK" />Actualizar permisos<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Contraseña</translation>
-<translation id="6659594942844771486">Pestaña</translation>
-<translation id="666731172850799929">Abrir en <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Aviso de privacidad de Chrome</translation>
-<translation id="6676840375528380067">¿Quieres borrar tus datos de Chrome de este dispositivo?</translation>
-<translation id="6697492270171225480">Mostrar sugerencias para páginas similares cuando no se puede encontrar una específica</translation>
-<translation id="6697947395630195233">Chrome necesita acceso a tu ubicación para compartirla con este sitio.</translation>
-<translation id="6698801883190606802">Administrar datos sincronizados</translation>
-<translation id="6699370405921460408">Los servidores de Google optimizarán las páginas que visites.</translation>
-<translation id="6706288973712894588">En este momento, estás sin conexión.\n<ph name="BEGIN_LINK" />Explora tu feed sin conexión.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Noticias</translation>
-<translation id="6710213216561001401">Anterior</translation>
-<translation id="671481426037969117">Se agotó el temporizador de <ph name="FQDN" />. Volverá a empezar mañana.</translation>
-<translation id="6738867403308150051">Descargando…</translation>
-<translation id="6746124502594467657">Mover hacia abajo</translation>
-<translation id="6766622839693428701">Desliza hacia abajo para cerrar.</translation>
-<translation id="6766758767654711248">Presiona para ir al sitio</translation>
-<translation id="6767294960381293877">La lista de dispositivos con los que se puede compartir una pestaña está abierta a media altura.</translation>
-<translation id="6782111308708962316">Evitar que los sitios web de terceros guarden y lean datos de cookies</translation>
-<translation id="6790428901817661496">Reproducir</translation>
-<translation id="6811034713472274749">Ya puedes ver la página</translation>
-<translation id="6818926723028410516">Seleccionar elementos</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Traducir</translation>
-<translation id="6845325883481699275">Ayudar a mejorar la seguridad de Chrome</translation>
-<translation id="6846298663435243399">Cargando…</translation>
-<translation id="6850409657436465440">La descarga sigue en curso</translation>
-<translation id="6850830437481525139">Pestañas cerradas: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Descargar imagen</translation>
-<translation id="6865313869410766144">Datos del formulario de autocompletar</translation>
-<translation id="688738109438487280">Agrega los datos existentes a <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Desbloquea la pantalla para copiar tu contraseña</translation>
-<translation id="6896758677409633944">Copiar</translation>
-<translation id="6910211073230771657">Eliminado</translation>
-<translation id="6912998170423641340">Impedir que los sitios lean el texto y las imágenes del portapapeles</translation>
-<translation id="6914783257214138813">Las personas que tengan acceso al archivo exportado podrán ver tus contraseñas.</translation>
-<translation id="6942665639005891494">Cambia la ubicación predeterminada de las descargas en cualquier momento en la opción de menú de Configuración</translation>
-<translation id="6945221475159498467">Seleccionar</translation>
-<translation id="6963642900430330478">Esta página es peligrosa. Consulta la información del sitio.</translation>
-<translation id="6963766334940102469">Borrar favoritos</translation>
-<translation id="6965382102122355670">Aceptar</translation>
-<translation id="6979737339423435258">Todos</translation>
-<translation id="6981982820502123353">Accesibilidad</translation>
-<translation id="6989267951144302301">No se pudo descargar</translation>
-<translation id="6990079615885386641">Descargar la aplicación desde Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Preguntar primero antes de permitir que los sitios usen tu micrófono (recomendado)</translation>
-<translation id="7015203776128479407">No se completó la configuración de la sincronización inicial. La sincronización está desactivada.</translation>
-<translation id="7016516562562142042">Se habilitó para el motor de búsqueda actual</translation>
-<translation id="7022756207310403729">Abrir en el navegador</translation>
-<translation id="702463548815491781">Se recomienda cuando TalkBack o "Accesibilidad mejorada" están activadas</translation>
-<translation id="7029809446516969842">Contraseñas</translation>
-<translation id="7053983685419859001">Bloquear</translation>
-<translation id="7055152154916055070">Se bloqueó el redireccionamiento:</translation>
-<translation id="7063006564040364415">No se pudo establecer conexión con el servidor de sincronización.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 seleccionado}other{# seleccionados}}</translation>
-<translation id="7071521146534760487">Administrar cuenta</translation>
-<translation id="7077143737582773186">Tarjeta SD</translation>
-<translation id="7087918508125750058">Elementos seleccionados: <ph name="ITEM_COUNT" />. Opciones disponibles cerca de la parte superior de la pantalla</translation>
-<translation id="7121362699166175603">Borra el historial y las sugerencias de autocompletado en la barra de direcciones. Es posible que tu cuenta de Google tenga otros formularios del historial de navegación en <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Habilitar el motor de búsqueda actual</translation>
-<translation id="7138678301420049075">Otros</translation>
-<translation id="7141896414559753902">Bloquea las ventanas emergentes y los redireccionamientos en los sitios (recomendado)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Cargar página original<ph name="END_LINK" /> de <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Últimas 24 horas</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Puedes cambiar esta opción más tarde en Configuración</translation>
-<translation id="7180611975245234373">Actualizar</translation>
-<translation id="7189372733857464326">Esperando que los servicios de Google Play terminen de actualizarse</translation>
-<translation id="7191430249889272776">Pestaña abierta en segundo plano</translation>
-<translation id="723171743924126238">Seleccionar imágenes</translation>
-<translation id="7233236755231902816">Para ver la Web en tu idioma, obtén la versión más reciente de Chrome</translation>
-<translation id="7243308994586599757">Opciones disponibles junto a la parte inferior de la pantalla</translation>
-<translation id="7248069434667874558">Comprueba que <ph name="TARGET_DEVICE_NAME" /> tenga activada la sincronización en Chrome</translation>
-<translation id="7250468141469952378">Elementos seleccionados: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Sitio bloqueado</translation>
-<translation id="7290209999329137901">No se puede renombrar el elemento porque no está disponible</translation>
-<translation id="7291387454912369099">Confirmación de compra activada</translation>
-<translation id="7293171162284876153">Para comenzar la sincronización, activa "Sincroniza tus datos de Chrome".</translation>
-<translation id="729975465115245577">Tu dispositivo no tiene una app que pueda almacenar el archivo de contraseñas.</translation>
-<translation id="7302081693174882195">Detalles: Ordenados por cantidad de datos ahorrados</translation>
-<translation id="7328017930301109123">En el modo lite, Chrome carga las páginas más rápido y usa hasta un 60 por ciento menos de datos.</translation>
-<translation id="7333031090786104871">Aún se está agregando el sitio anterior</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Comparte 1 elemento seleccionado}other{Comparte # elementos seleccionados}}</translation>
 <translation id="7359002509206457351">Acceder a formas de pago</translation>
+<translation id="8026334261755873520">Eliminar datos de navegación</translation>
+<translation id="1291207594882862231">Borra el historial, las cookies, los datos del sitio, la caché…</translation>
+<translation id="7814200940910057384">Datos de Brave borrados</translation>
+<translation id="1664855196866195614">Los datos seleccionados se quitaron de Brave y tus dispositivos sincronizados.
+
+Es posible que tu cuenta de Brave Software tenga otros formularios de historial de navegación, como búsquedas y actividad de otros servicios de Brave Software en <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Imágenes y archivos almacenados en caché</translation>
+<translation id="2496180316473517155">Historial de navegación</translation>
+<translation id="2546283357679194313">Datos de sitios y cookies</translation>
+<translation id="8662811608048051533">Esta acción te hace salir de la mayoría de los sitios.</translation>
+<translation id="8218628800671693884">Esta acción te hace salir de la mayoría de los sitios. No saldrás de tu cuenta de Brave Software.</translation>
+<translation id="2017836877785168846">Borra el historial y las opciones de autocompletado en la barra de direcciones.</translation>
+<translation id="8096327394278038498">Borra el historial y las sugerencias de autocompletado en la barra de direcciones. Es posible que tu cuenta de Brave Software tenga otros formularios del historial de navegación en <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Borra el historial de todos los dispositivos en los que accediste. Es posible que tu cuenta de Brave Software tenga otros formularios del historial de navegación en <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Contraseñas almacenadas</translation>
+<translation id="6865313869410766144">Datos del formulario de autocompletar</translation>
+<translation id="7562080006725997899">Borrando datos de navegación</translation>
+<translation id="5487521232677179737">Borrar datos</translation>
+<translation id="7498271377022651285">Espera un momento…</translation>
+<translation id="784934925303690534">Intervalo de tiempo</translation>
+<translation id="1718835860248848330">Última hora</translation>
+<translation id="7149893636342594995">Últimas 24 horas</translation>
+<translation id="5648166631817621825">Últimos 7 días</translation>
+<translation id="8571213806525832805">Últimas cuatro semanas</translation>
+<translation id="5854790677617711513">Hace más de 30 días</translation>
+<translation id="6979737339423435258">Todos</translation>
+<translation id="982182592107339124">Esta acción borrará los datos de todos los sitios, entre los que se incluyen:</translation>
+<translation id="6643016212128521049">Borrar</translation>
+<translation id="7641339528570811325">Borrar datos de navegación…</translation>
+<translation id="1670399744444387456">Básicas</translation>
+<translation id="3245261285041759672">Es posible que tu cuenta de Brave Software tenga otros formularios del historial de navegación en <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Sitio bloqueado</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> elementos borrados</translation>
+<translation id="1121094540300013208">Informes de uso y de fallos</translation>
+<translation id="9079153198295609735">Enviar automáticamente estadísticas de uso e informes sobre fallos a Brave Software</translation>
+<translation id="6981982820502123353">Accesibilidad</translation>
+<translation id="2387895666653383613">Ajuste de texto</translation>
+<translation id="2321958826496381788">Arrastra el control deslizante hasta que puedas leer esto cómodamente. El texto debería verse, al menos, de este tamaño al tocar dos veces un párrafo.</translation>
+<translation id="3895926599014793903">Forzar habilitación de zoom</translation>
+<translation id="5668404140385795438">Anular la solicitud de inhabilitación del zoom de un sitio web</translation>
+<translation id="4149994727733219643">Vista simplificada para páginas web</translation>
+<translation id="9100505651305367705">Se ofrece mostrar artículos en una vista simplificada, cuando es compatible</translation>
+<translation id="1409426117486808224">Vista simplificada para las pestañas abiertas</translation>
+<translation id="702463548815491781">Se recomienda cuando TalkBack o "Accesibilidad mejorada" están activadas</translation>
+<translation id="8284326494547611709">Subtítulos</translation>
+<translation id="4165986682804962316">Configuración del sitio</translation>
+<translation id="6295158916970320988">Todos los sitios</translation>
+<translation id="8380167699614421159">Este sitio muestra anuncios intrusivos o engañosos</translation>
+<translation id="1919345977826869612">Anuncios</translation>
+<translation id="410351446219883937">Reproducción automática</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Bloquear cookies de terceros</translation>
+<translation id="6782111308708962316">Evitar que los sitios web de terceros guarden y lean datos de cookies</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Ventanas emergentes y redirec.</translation>
+<translation id="4751476147751820511">Sensores de luz o movimiento</translation>
+<translation id="1717218214683051432">Sensores de movimiento</translation>
+<translation id="2091887806945687916">Sonido</translation>
+<translation id="2586657967955657006">Portapapeles</translation>
+<translation id="6320088164292336938">Vibrar</translation>
+<translation id="4226663524361240545">Es posible que las notificaciones hagan vibrar el dispositivo</translation>
+<translation id="1446450296470737166">Control de dispositivos MIDI</translation>
+<translation id="3744111561329211289">Sincronización en segundo plano</translation>
+<translation id="5649053991847567735">Descargas automáticas</translation>
+<translation id="6181444274883918285">Agregar excepción de sitio web</translation>
+<translation id="5313967007315987356">Agregar sitio</translation>
+<translation id="1369915414381695676">Se agregó el sitio <ph name="SITE_NAME"/>.</translation>
+<translation id="7837721118676387834">Permite la reproducción automática de videos silenciados para un sitio específico.</translation>
+<translation id="2621115761605608342">Permitir la ejecución de JavaScript para un sitio específico</translation>
+<translation id="8801436777607969138">Bloquea JavaScript para un sitio específico.</translation>
+<translation id="8372893542064058268">Permite la sincronización en segundo plano para un sitio específico.</translation>
+<translation id="358794129225322306">Permite que un sitio descargue varios archivos automáticamente.</translation>
+<translation id="4008040567710660924">Permite las cookies para un sitio específico.</translation>
+<translation id="8958424370300090006">Bloquea las cookies en un sitio específico.</translation>
+<translation id="7882806643839505685">Habilitar el sonido de un sitio específico</translation>
+<translation id="4468959413250150279">Silenciar un sitio específico.</translation>
+<translation id="1994173015038366702">URL del sitio</translation>
+<translation id="8941729603749328384">www.ejemplo.com</translation>
+<translation id="5063480226653192405">Uso</translation>
+<translation id="5804241973901381774">Permisos</translation>
+<translation id="4278390842282768270">Permitido</translation>
+<translation id="5677928146339483299">Bloqueados</translation>
+<translation id="1984937141057606926">Permitidas, salvo de terceros</translation>
+<translation id="7423098979219808738">Preguntar primero</translation>
+<translation id="8116925261070264013">Silenciados</translation>
+<translation id="8300705686683892304">Administrados por una app</translation>
+<translation id="6192792657125177640">Excepciones</translation>
+<translation id="257931822824936280">Expandido; haz clic para contraer.</translation>
+<translation id="5100237604440890931">Contraído; haz clic para expandir.</translation>
+<translation id="857943718398505171">Permitido (recomendado)</translation>
+<translation id="2913331724188855103">Permitir que todos los sitios guarden y lean datos de cookies (recomendado)</translation>
+<translation id="7445411102860286510">Permitir que los sitios reproduzcan videos silenciados de forma automática (recomendado)</translation>
+<translation id="5335288049665977812">Permitir que los sitios ejecuten JavaScript (recomendado)</translation>
+<translation id="5527111080432883924">Preguntar antes de permitir que los sitios lean el texto y las imágenes del portapapeles (recomendado)</translation>
+<translation id="6912998170423641340">Impedir que los sitios lean el texto y las imágenes del portapapeles</translation>
+<translation id="7423538860840206698">Se impidió la lectura del portapapeles</translation>
+<translation id="3955193568934677022">Permitir que los sitios reproduzcan contenido protegido (recomendado)</translation>
+<translation id="445467742685312942">Permitir que los sitios reproduzcan contenido protegido</translation>
+<translation id="2107397443965016585">Preguntar antes de permitir que los sitios reproduzcan contenido protegido (recomendado)</translation>
+<translation id="2910701580606108292">Preguntar antes de permitir que los sitios reproduzcan contenido protegido</translation>
+<translation id="757524316907819857">Impedir que los sitios reproduzcan contenido protegido</translation>
+<translation id="3277252321222022663">Permitir que los sitios accedan a los sensores (recomendado)</translation>
+<translation id="5048398596102334565">Permitir que los sitios accedan a los sensores de movimiento (recomendado)</translation>
+<translation id="8816026460808729765">Impedir que los sitios accedan a los sensores</translation>
+<translation id="169515064810179024">Impedir que los sitios accedan a los sensores de movimiento</translation>
+<translation id="1660204651932907780">Permitir que los sitios reproduzcan sonido (recomendado)</translation>
+<translation id="3600792891314830896">Silenciar los sitios que reproducen sonido</translation>
+<translation id="1743802530341753419">Preguntar antes de permitir que los sitios se conecten a un dispositivo (recomendado)</translation>
+<translation id="851751545965956758">Impedir que los sitios se conecten a los dispositivos</translation>
+<translation id="7141896414559753902">Bloquea las ventanas emergentes y los redireccionamientos en los sitios (recomendado)</translation>
+<translation id="5494752089476963479">Bloquear anuncios de sitios que muestran anuncios intrusivos o engañosos</translation>
+<translation id="3123473560110926937">Bloqueados en algunos sitios</translation>
+<translation id="965817943346481315">Bloquear si el sitio muestra anuncios intrusivos o engañosos (opción recomendada)</translation>
+<translation id="3386292677130313581">Preguntar antes de permitir que los sitios conozcan tu ubicación (recomendado)</translation>
+<translation id="9139068048179869749">Preguntar antes de permitir que los sitios envíen notificaciones (recomendado)</translation>
+<translation id="4479647676395637221">Preguntar primero antes de permitir que los sitios usen tu cámara (recomendado)</translation>
+<translation id="6992289844737586249">Preguntar primero antes de permitir que los sitios usen tu micrófono (recomendado)</translation>
+<translation id="2289270750774289114">Preguntarme cuando un sitio intente conectarse a dispositivos Bluetooth cercanos (recomendado)</translation>
+<translation id="7053983685419859001">Bloquear</translation>
+<translation id="7128222689758636196">Habilitar el motor de búsqueda actual</translation>
+<translation id="7589445247086920869">Bloquear el motor de búsqueda actual</translation>
+<translation id="6388207532828177975">Borrar y restablecer</translation>
+<translation id="7999064672810608036">¿Quieres eliminar todos los datos locales de este sitio web, incluidas las cookies, y restablecer todos los permisos?</translation>
+<translation id="2822354292072154809">¿Confirmas que quieres restablecer todos los permisos de sitios para <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Borrar datos almacenados</translation>
+<translation id="5902828464777634901">Se eliminarán todos los datos almacenados en este sitio web, incluidas las cookies.</translation>
+<translation id="119944043368869598">Borrar todo</translation>
+<translation id="2490684707762498678">Administradas por <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Abrir la configuración de notificaciones</translation>
+<translation id="1404122904123200417">Incorporado en <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Aquí se mostrarán los archivos que guarden los sitios web</translation>
+<translation id="4181841719683918333">Idiomas</translation>
+<translation id="2647434099613338025">Agregar idioma</translation>
+<translation id="1952172573699511566">Los sitios web mostrarán texto en tu idioma preferido, cuando sea posible.</translation>
+<translation id="8559990750235505898">Ofrecer la traducción de páginas en otros idiomas</translation>
+<translation id="4719927025381752090">Ofrecer la traducción</translation>
+<translation id="8156139159503939589">¿En qué idioma lees?</translation>
+<translation id="5689516760719285838">Ubicación</translation>
+<translation id="2440823041667407902">Acceso a la ubicación</translation>
+<translation id="2023546461831060654">Activa los permisos para Brave en <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Activa el permiso para Brave en <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Para permitir que Brave acceda a tu ubicación, actívala también en <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Para permitir que Brave acceda a tu cámara, actívala también en <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Para permitir que Brave te envíe notificaciones, actívalas también en <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Para permitir que Brave acceda a tu micrófono, actívalo también en <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">En este dispositivo, el acceso a la ubicación está desactivado. Actívalo en la <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">El acceso a la ubicación también está desactivado en este dispositivo. Actívalo en la <ph name="BEGIN_LINK"/>Configuración de Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Cámara</translation>
+<translation id="3227137524299004712">Micrófono</translation>
+<translation id="1647391597548383849">Acceso a la cámara</translation>
+<translation id="945632385593298557">Acceso al micrófono</translation>
+<translation id="6612358246767739896">Contenido protegido</translation>
+<translation id="885701979325669005">Almacenamiento</translation>
+<translation id="3198916472715691905">Datos almacenados: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revocar permiso para el dispositivo</translation>
+<translation id="4962975101802056554">Revocar todos los permisos del dispositivo</translation>
+<translation id="6545864417968258051">Búsqueda de dispositivos Bluetooth</translation>
+<translation id="4411535500181276704">Modo lite</translation>
+<translation id="7821588508402923572">Aquí aparecerá tu ahorro de datos</translation>
+<translation id="2131665479022868825">Datos ahorrados: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">desde el <ph name="DATE"/></translation>
+<translation id="3252158532344029638">En el modo lite, Brave carga las páginas más rápido y usa hasta un 60 por ciento menos de datos.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> de ahorro de datos</translation>
+<translation id="7494974237137038751">de datos ahorrados</translation>
+<translation id="6111020039983847643">de datos utilizados</translation>
+<translation id="7413229368719586778">Fecha de inicio: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Fecha de finalización: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Ordenar por sitio</translation>
+<translation id="5864174910718532887">Detalles: Ordenados por nombre de sitio</translation>
+<translation id="116280672541001035">Usados</translation>
+<translation id="8349013245300336738">Ordenar por cantidad de datos utilizados</translation>
+<translation id="6378173571450987352">Detalles: Ordenados por cantidad de datos utilizados</translation>
+<translation id="2631006050119455616">Ahorrados</translation>
+<translation id="6643649862576733715">Ordenar por cantidad de datos ahorrados</translation>
+<translation id="7302081693174882195">Detalles: Ordenados por cantidad de datos ahorrados</translation>
+<translation id="4179980317383591987">Datos utilizados: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Datos ahorrados: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Sitios restantes (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Otros</translation>
+<translation id="4913161338056004800">Restablecer estadísticas</translation>
+<translation id="1856325424225101786">¿Quieres restablecer el modo lite?</translation>
+<translation id="3658159451045945436">Si lo haces, se borrará el historial de ahorro de datos, incluida la lista de sitios visitados.</translation>
+<translation id="3295530008794733555">Navega más rápido; usa menos datos</translation>
+<translation id="7340390500800578919">En el modo lite, Brave carga las páginas más rápido y usa hasta un 60% menos de datos. Para optimizar las páginas que visitas, Brave envía tu tráfico en la Web a Brave Software. <ph name="BEGIN_LINK"/>Más información<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Activar el modo lite</translation>
+<translation id="4493497663118223949">El modo lite está activado</translation>
+<translation id="7559975015014302720">El modo lite está desactivado</translation>
+<translation id="7606077192958116810">El modo lite está activado. Puedes administrarlo en Configuración.</translation>
+<translation id="4714588616299687897">Ahorra hasta un 60% de tus datos</translation>
+<translation id="1006927014032731288">Los servidores de Brave Software optimizarán las páginas que visites.</translation>
+<translation id="3257320067425202300">Brave te permitió ahorrar <ph name="MEGABYTES"/> megabytes</translation>
+<translation id="5813223329348543512">Brave te permitió ahorrar <ph name="GIGABYTES"/> gigabytes</translation>
+<translation id="8266862848225348053">Ubicación de las descargas</translation>
+<translation id="7077143737582773186">Tarjeta SD</translation>
+<translation id="7762668264895820836">Tarjeta SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Preguntar dónde guardar los archivos</translation>
+<translation id="6192333916571137726">Descargar archivo</translation>
+<translation id="1672586136351118594">No volver a mostrar</translation>
+<translation id="2650751991977523696">¿Deseas volver a descargar el archivo?</translation>
+<translation id="8664979001105139458">Ya existe el nombre del archivo</translation>
+<translation id="488187801263602086">Cambiar el nombre del archivo</translation>
+<translation id="5686790454216892815">El nombre del archivo es demasiado largo</translation>
+<translation id="7454641608352164238">No hay suficiente espacio</translation>
+<translation id="8972098258593396643">¿Deseas descargarlo a la carpeta predeterminada?</translation>
+<translation id="804335162455518893">No se encontró la tarjeta SD</translation>
+<translation id="7475688122056506577">No se encontró la tarjeta SD. Es posible que falten algunos archivos.</translation>
+<translation id="4198423547019359126">No hay ubicaciones de descarga disponibles</translation>
+<translation id="8224471946457685718">Descargar artículos para ti mediante Wi-Fi</translation>
+<translation id="4970824347203572753">No disponible en tu ubicación</translation>
+<translation id="5500777121964041360">Es posible que no esté disponible en tu ubicación</translation>
+<translation id="1173894706177603556">Cambiar nombre</translation>
+<translation id="1986685561493779662">El nombre ya existe</translation>
+<translation id="6441734959916820584">El nombre es demasiado largo</translation>
+<translation id="2923908459366352541">El nombre no es válido</translation>
+<translation id="7290209999329137901">No se puede renombrar el elemento porque no está disponible</translation>
+<translation id="3334729583274622784">¿Quieres cambiar la extensión del archivo?</translation>
+<translation id="107147699690128016">Si cambias la extensión de archivo, es posible que el archivo se abra en una app diferente y dañe el dispositivo.</translation>
+<translation id="8541922081612557424">Acerca de Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Todos los derechos reservados.</translation>
+<translation id="1416550906796893042">Versión de la aplicación</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (actualización: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistema operativo</translation>
+<translation id="3968054912784331254">Las actualizaciones de Brave ya no son compatibles con esta versión de Android</translation>
+<translation id="7665369617277396874">Agregar cuenta</translation>
+<translation id="649070405679044769">Accediste a Brave Software como</translation>
+<translation id="6234515504547364178">Salir de Brave</translation>
+<translation id="5324858694974489420">Configuración parental</translation>
+<translation id="8920114477895755567">Esperando los detalles parentales</translation>
+<translation id="5512137114520586844"><ph name="PARENT_NAME"/> administra esta cuenta.</translation>
+<translation id="2956410042958133412"><ph name="PARENT_NAME_1"/> y <ph name="PARENT_NAME_2"/> administran esta cuenta.</translation>
+<translation id="8168435359814927499">Contenido</translation>
+<translation id="5403644198645076998">Permitir solo algunos sitios</translation>
+<translation id="8641930654639604085">Tratar de bloquear los sitios para adultos</translation>
+<translation id="5639724618331995626">Permitir todos los sitios</translation>
+<translation id="796823723482603597">Con tecnología de Brave</translation>
+<translation id="6324034347079777476">Sincronización del sistema Android inhabilitada</translation>
+<translation id="5127805178023152808">La sincronización está desactivada.</translation>
+<translation id="7015203776128479407">No se completó la configuración de la sincronización inicial. La sincronización está desactivada.</translation>
+<translation id="2497852260688568942">Tu administrador inhabilitó la sincronización</translation>
+<translation id="9100610230175265781">Se necesita una frase de contraseña.</translation>
+<translation id="6108923351542677676">Configuración en curso…</translation>
+<translation id="4062305924942672200">Información legal</translation>
+<translation id="4256782883801055595">Licencias de código abierto</translation>
+<translation id="1138681184697033370">Condiciones del servicio de Brave</translation>
+<translation id="7392539049993970338">Aviso de privacidad de Brave</translation>
+<translation id="2677748264148917807">Abandonar</translation>
+<translation id="5556459405103347317">Cargar de nuevo</translation>
+<translation id="1623104350909869708">Evitar que esta página cree cuadros de diálogo adicionales</translation>
+<translation id="2968755619301702150">Visualizador de certificados</translation>
+<translation id="1360432990279830238">¿Salir y desactivar la sincronización?</translation>
+<translation id="8581481290581777242">¿Quieres borrar tus datos de Brave de este dispositivo?</translation>
+<translation id="1318865768845061710">Ya no se sincronizarán con tu Cuenta de Brave Software los favoritos, el historial, las contraseñas ni otros datos de Brave.</translation>
+<translation id="3325020657155065477">Borrar también los datos de Brave de este dispositivo</translation>
+<translation id="6136448902816743006">Estás saliendo de una cuenta administrada por <ph name="DOMAIN_NAME"/>. Se borrarán tus datos de Brave de este dispositivo, pero permanecerán en tu Cuenta de Brave Software.</translation>
+<translation id="1853026300647876496">Se está estableciendo la comunicación con Brave Software. Esta acción puede demorar unos minutos…</translation>
+<translation id="2328985652426384049">No puedes acceder</translation>
+<translation id="7723158744459952869">Brave Software tardó demasiado en responder</translation>
+<translation id="4572422548854449519">Acceder a una cuenta administrada</translation>
+<translation id="2689656545739939160">Estás accediendo con una cuenta administrada por <ph name="MANAGED_DOMAIN"/> y dándole permiso a su administrador para que controle tus datos de Brave. Tus datos se vincularán de forma permanente a esta cuenta. Si sales de Brave, tus datos se borrarán en este dispositivo, pero quedarán guardados en tu cuenta de Brave Software.</translation>
+<translation id="1749561566933687563">Sincroniza tus favoritos</translation>
+<translation id="4242533952199664413">Abrir la configuración</translation>
+<translation id="1111673857033749125">Los favoritos guardados en tus otros dispositivos aparecerán aquí.</translation>
+<translation id="8636825310635137004">Activa la sincronización para obtener las pestañas de tus otros dispositivos.</translation>
+<translation id="3269956123044984603">Para obtener las pestañas de tus otros dispositivos, activa la opción "Sincronización automática de datos" en la configuración de la cuenta de Android.</translation>
+<translation id="5157964048453367290">Aquí aparecerán las pestañas que abriste en Brave en tus otros dispositivos.</translation>
+<translation id="4684427112815847243">Sincronizar todo</translation>
+<translation id="2709516037105925701">Autocompletar</translation>
+<translation id="8820817407110198400">Favoritos</translation>
+<translation id="1644574205037202324">Historial</translation>
+<translation id="17513872634828108">Pestañas abiertas</translation>
+<translation id="1320169905922104972">Tarjetas de crédito y direcciones con Brave Software Pay</translation>
+<translation id="6337234675334993532">Encriptación</translation>
+<translation id="6698801883190606802">Administrar datos sincronizados</translation>
+<translation id="3598578758776312506">Encriptar las contraseñas con las credenciales de Brave Software</translation>
+<translation id="7810580217418711046">Encriptar los datos sincronizados con la contraseña de Brave Software a partir del <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Encriptar los datos sincronizados con tu propia frase de contraseña de sincronización</translation>
+<translation id="2996291259634659425">Crear frase de contraseña</translation>
+<translation id="5713644099811900409">Cuenta de Brave Software</translation>
+<translation id="8997474919031554666">La encriptación de la frase de contraseña no incluye formas de pago ni direcciones de Brave Software Pay. Solo las personas que tengan tu frase de contraseña pueden leer los datos encriptados. Brave Software no envía ni almacena la frase de contraseña. Si la olvidas o quieres cambiar esta configuración, deberás restablecer la sincronización. <ph name="BEGIN_LINK"/>Más información<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Frase de contraseña</translation>
+<translation id="7772032839648071052">Confirmar frase de contraseña</translation>
+<translation id="5304593522240415983">Este campo no puede quedar en blanco.</translation>
+<translation id="321773570071367578">Si olvidaste la frase de contraseña o quieres cambiar esta configuración, <ph name="BEGIN_LINK"/>restablece la contraseña<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Las frases de contraseña no coinciden.</translation>
+<translation id="5149495116300586333">La encriptación de la frase de contraseña no incluye formas de pago ni direcciones de Brave Software Pay.
+
+Para cambiar esta configuración, <ph name="BEGIN_LINK"/>restablece la sincronización<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Frase de contraseña incorrecta</translation>
+<translation id="5414836363063783498">Verificando…</translation>
+<translation id="6846298663435243399">Cargando…</translation>
+<translation id="5517095782334947753">Tienes favoritos, historial, contraseñas y otras opciones de configuración de <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combinar mis datos</translation>
+<translation id="688738109438487280">Agrega los datos existentes a <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Mantener mis datos separados</translation>
+<translation id="1145536944570833626">Borra los datos existentes.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> desea sincronizarse</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Obtener ayuda<ph name="END_LINK"/> mientras se buscan dispositivos…</translation>
+<translation id="5817918615728894473">Sincronizar</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Obtener ayuda<ph name="END_LINK1"/> o <ph name="BEGIN_LINK2"/>volver a buscar<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">No se encontraron dispositivos compatibles</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Activa Bluetooth<ph name="END_LINK"/> para permitir la sincronización</translation>
+<translation id="998321811308652668">Brave no puede activar el adaptador Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Obtener ayuda<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave necesita acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK"/>Actualizar permisos<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave debe acceder a la ubicación para buscar dispositivos. El acceso a la ubicación está <ph name="BEGIN_LINK"/>desactivado en este dispositivo<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave debe acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK1"/>Actualiza los permisos<ph name="END_LINK1"/>. El acceso a la ubicación también está <ph name="BEGIN_LINK2"/>desactivado en este dispositivo<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Dispositivo conectado</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Nivel de potencia de la señal: # barra}other{Nivel de potencia de la señal: # barras}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> quiere detectar dispositivos Bluetooth cercanos. Se encontraron los siguientes dispositivos:</translation>
+<translation id="8368027906805972958">Dispositivo desconocido o no compatible (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">La sincronización no funciona</translation>
+<translation id="1810845389119482123">No se completó la configuración de la sincronización inicial</translation>
+<translation id="3235722914093408050">Para iniciar la Sincronización de Brave, abre la configuración de Android y vuelve a habilitar la sincronización del sistema Android</translation>
+<translation id="3367813778245106622">Volver a acceder para iniciar la sincronización</translation>
+<translation id="974555521953189084">Ingresa tu frase de contraseña para iniciar la sincronización</translation>
+<translation id="2997266899014181325">Para comenzar la sincronización, activa "Sincroniza tus datos de Brave".</translation>
+<translation id="8260126382462817229">Intenta volver a acceder</translation>
+<translation id="5919204609460789179">Actualiza <ph name="PRODUCT_NAME"/> para iniciar la sincronización</translation>
+<translation id="397583555483684758">La sincronización dejó de funcionar</translation>
+<translation id="1966710179511230534">Actualiza los datos de acceso.</translation>
+<translation id="7063006564040364415">No se pudo establecer conexión con el servidor de sincronización.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> no está actualizado.</translation>
+<translation id="4170011742729630528">El servicio no se encuentra disponible; vuelve a intentarlo más tarde.</translation>
+<translation id="7947953824732555851">Aceptar y acceder</translation>
+<translation id="8583805026567836021">Borrando datos de cuenta</translation>
+<translation id="8310344678080805313">Pestañas estándar</translation>
+<translation id="5748802427693696783">Se seleccionaron las pestañas estándar</translation>
+<translation id="7998918019931843664">Volver a abrir la pestaña cerrada</translation>
+<translation id="8853345339104747198">Pestaña <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Cierra la pestaña <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opciones disponibles junto a la parte inferior de la pantalla</translation>
+<translation id="4060598801229743805">Opciones disponibles cerca de la parte superior de la pantalla</translation>
+<translation id="2810645512293415242">La página se simplificó para ahorrar datos y acelerar la carga.</translation>
+<translation id="3985215325736559418">¿No quieres descargar <ph name="FILE_NAME"/> de nuevo?</translation>
+<translation id="2450083983707403292">¿Deseas comenzar la descarga de <ph name="FILE_NAME"/> de nuevo?</translation>
+<translation id="7514365320538308">Descargar</translation>
+<translation id="545042621069398927">Acelerando la descarga</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Descargando archivo}other{Descargando # archivos}}</translation>
+<translation id="543509235395288790">Descargando <ph name="COUNT"/> archivos (<ph name="MEGABYTES"/>)</translation>
+<translation id="4988210275050210843">Descargando archivo (<ph name="MEGABYTES"/>)</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Se completó la descarga.}other{Se completaron # descargas.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{No se pudo realizar la descarga.}other{No se pudieron realizar # descargas.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 descarga pendiente}other{# descargas pendientes}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/></translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> Botón <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Ya casi terminas.</translation>
+<translation id="3960299545138990065">Reinicia Brave.</translation>
+<translation id="3771001275138982843">No se pudo descargar la actualización</translation>
+<translation id="3888648114124182147">Descargando la actualización de Brave…</translation>
+<translation id="1705567146636171298">Actualizar Brave</translation>
+<translation id="6195417478702700398">A fin de obtener la mejor experiencia de navegación, abre Brave para actualizarlo</translation>
+<translation id="3512968675351418494">Para ver la Web en tu idioma, obtén la versión más reciente de Brave</translation>
+<translation id="6427112570124116297">Traduce la Web</translation>
+<translation id="1379423114029199501">Para obtener tu idioma, actualiza a la versión más reciente de Brave</translation>
+<translation id="5684874026226664614">No se puede traducir esta página.</translation>
+<translation id="6831043979455480757">Traducir</translation>
+<translation id="1285320974508926690">Nunca traducir este sitio</translation>
+<translation id="773466115871691567">Traducir siempre las páginas en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">No traducir nunca páginas en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Más idiomas</translation>
+<translation id="290376772003165898">¿La página no está en <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">De ahora en más, las páginas en <ph name="SOURCE_LANGUAGE"/> se traducirán al <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">No se traducirán las páginas en <ph name="LANGUAGE"/></translation>
+<translation id="5447765697759493033">Este sitio no se traducirá</translation>
+<translation id="4880127995492972015">Traducir…</translation>
+<translation id="641643625718530986">Imprimir…</translation>
+<translation id="8909135823018751308">Compartir…</translation>
+<translation id="4996978546172906250">Compartir mediante</translation>
+<translation id="6333140779060797560">Compartir mediante <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Se produjo un error al imprimir la página. Vuelve a intentarlo.</translation>
+<translation id="3254409185687681395">Agregar esta página a Favoritos</translation>
+<translation id="497421865427891073">Avanzar</translation>
+<translation id="813082847718468539">Consulta la información del sitio</translation>
+<translation id="2532336938189706096">Vista web</translation>
+<translation id="6005538289190791541">Contraseña sugerida</translation>
+<translation id="4634124774493850572">Usar contraseña</translation>
+<translation id="8285489906452138776">Brave necesita permiso para acceder a tu cámara para este sitio.</translation>
+<translation id="320189792589364011">Brave necesita permiso para acceder a tu micrófono para este sitio.</translation>
+<translation id="7988136689212463100">Brave necesita permiso para acceder a tu cámara y micrófono para este sitio.</translation>
+<translation id="4931190655840828017">Brave necesita acceso a tu ubicación para compartirla con este sitio.</translation>
+<translation id="3088191967551450609">Brave necesita acceder al almacenamiento para descargar archivos.</translation>
+<translation id="8942627711005830162">Abrir en otra ventana</translation>
+<translation id="4195643157523330669">Abrir en una pestaña nueva</translation>
+<translation id="1100066534610197918">Abrir pestaña nueva en grupo</translation>
+<translation id="4860895144060829044">Llamar</translation>
+<translation id="6896758677409633944">Copiar</translation>
+<translation id="8393700583063109961">Enviar mensaje</translation>
+<translation id="3557336313807607643">Agregar a contactos</translation>
+<translation id="4269820728363426813">Copiar dirección del vínculo</translation>
+<translation id="1206892813135768548">Copiar texto del vínculo</translation>
+<translation id="1204037785786432551">Descargar vínculo</translation>
+<translation id="6864459304226931083">Descargar imagen</translation>
+<translation id="8209050860603202033">Abrir imagen</translation>
+<translation id="8073388330009372546">Abrir imagen en pestaña nueva</translation>
+<translation id="6649642165559792194">Vista previa de imagen <ph name="BEGIN_NEW"/>Nueva<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Cargar imagen</translation>
+<translation id="3845332215609790146">Buscar con Brave Software Lens <ph name="BEGIN_NEW"/>Nuevo<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Buscar esta imagen en <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Compartir imagen</translation>
+<translation id="5833984609253377421">Compartir vínculo</translation>
+<translation id="6475951671322991020">Descargar video</translation>
+<translation id="2317945146070194624">Abrir en una nueva pestaña de Brave</translation>
+<translation id="7975379999046275268">Vista previa de página <ph name="BEGIN_NEW"/>Nueva<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Actualizando la página</translation>
+<translation id="36525718899759834">Descargar la aplicación desde Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Oscuro</translation>
+<translation id="1807246157184219062">Claro</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monoespaciada</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Elige una pestaña para transmitir.</translation>
+<translation id="8719023831149562936">Esta pestaña no se puede transmitir.</translation>
+<translation id="2139186145475833000">Agregar a la pantalla principal</translation>
+<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">No se pudo abrir la app</translation>
+<translation id="5129038482087801250">Instalar la aplicación web</translation>
+<translation id="3789841737615482174">Instalar</translation>
+<translation id="4665282149850138822">Se agregó <ph name="NAME"/> a la pantalla principal</translation>
+<translation id="7333031090786104871">Aún se está agregando el sitio anterior</translation>
+<translation id="1036727731225946849">Agregando <ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">Se agregó a la pantalla principal</translation>
+<translation id="2146738493024040262">Abrir app instantánea</translation>
+<translation id="7016516562562142042">Se habilitó para el motor de búsqueda actual</translation>
+<translation id="6177111841848151710">Se bloqueó para el motor de búsqueda actual</translation>
+<translation id="145097072038377568">Desactivado en la configuración de Android</translation>
+<translation id="8007176423574883786">Desactivado para este dispositivo</translation>
+<translation id="164269334534774161">Estás viendo una copia sin conexión de esta página del <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Esta página sin conexión se creó el <ph name="CREATION_TIME"/> y es posible que sea diferente con respecto a la versión en línea.</translation>
+<translation id="8840953339110955557">Es posible que esta página sea diferente con respecto a la versión en línea.</translation>
+<translation id="6405300764336705484">Este contenido es de <ph name="DOMAIN_NAME"/>, publicado por Brave Software.</translation>
+<translation id="1006017844123154345">Abrir en línea</translation>
+<translation id="3326636747541519688">Brave Software proporcionó la página básica</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Cargar página original<ph name="END_LINK"/> de <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Si el mensaje aparece con frecuencia, prueba estas <ph name="BEGIN_LINK"/>sugerencias<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Contenidos ocultos</translation>
+<translation id="3810973564298564668">Administrar</translation>
+<translation id="5199929503336119739">Perfil de trabajo</translation>
+<translation id="528192093759286357">Arrastra el dedo desde la parte superior y toca el botón Atrás para salir de la pantalla completa.</translation>
+<translation id="2836148919159985482">Toca el botón Atrás para salir de la pantalla completa.</translation>
+<translation id="3967822245660637423">Descarga completa</translation>
+<translation id="2434158240863470628">Se completó la descarga <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Error en la descarga</translation>
+<translation id="1384959399684842514">Descarga detenida</translation>
+<translation id="1671236975893690980">Descarga pendiente…</translation>
+<translation id="5561549206367097665">Esperando red…</translation>
+<translation id="5864419784173784555">Esperando que finalice otra descarga…</translation>
+<translation id="6461962085415701688">No se puede abrir el archivo</translation>
+<translation id="1178581264944972037">Detener</translation>
+<translation id="8200772114523450471">Reanudar</translation>
+<translation id="1409879593029778104">Se impidió la descarga de <ph name="FILE_NAME"/> porque el archivo ya existe.</translation>
+<translation id="3387650086002190359"><ph name="FILE_NAME"/> no se pudo descargar debido a errores del sistema de archivos.</translation>
+<translation id="6482749332252372425"><ph name="FILE_NAME"/> no se pudo descargar debido a la falta de espacio de almacenamiento.</translation>
+<translation id="7619072057915878432"><ph name="FILE_NAME"/> no se pudo descargar debido a fallas en la red.</translation>
+<translation id="1477626028522505441"><ph name="FILE_NAME"/> no se pudo descargar debido a problemas del servidor.</translation>
+<translation id="3692944402865947621">Falló la descarga de <ph name="FILE_NAME"/> porque no se puede acceder a la ubicación del almacenamiento.</translation>
+<translation id="604996488070107836"><ph name="FILE_NAME"/> no se pudo descargar debido a un error desconocido.</translation>
+<translation id="6738867403308150051">Descargando…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Se descargaron <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Se descargaron <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Se descargaron <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Queda 1 archivo</translation>
+<translation id="8186512483418048923">Quedan <ph name="FILES"/> archivos</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> archivo descargado}other{<ph name="FILES_DOWNLOADED_MANY"/> archivos descargados}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> días restantes</translation>
+<translation id="8190358571722158785">1 día restante</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> horas restantes</translation>
+<translation id="510275257476243843">1 hora restante</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minutos restantes</translation>
+<translation id="3236059992281584593">1 minuto restante</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> segundos restantes</translation>
+<translation id="2781151931089541271">1 segundo restante</translation>
+<translation id="3303414029551471755">¿Deseas descargar el contenido?</translation>
+<translation id="8617240290563765734">¿Quieres abrir la URL sugerida que se especifica en el contenido descargado?</translation>
+<translation id="1373696734384179344">Memoria insuficiente para descargar el contenido seleccionado</translation>
+<translation id="5271967389191913893">El dispositivo no puede abrir el contenido que se descargará.</translation>
+<translation id="883806473910249246">Se produjo un error al descargar el contenido.</translation>
+<translation id="5626134646977739690">Nombre:</translation>
+<translation id="7963646190083259054">Proveedor:</translation>
+<translation id="3414952576877147120">Tamaño:</translation>
+<translation id="7375125077091615385">Tipo:</translation>
+<translation id="5765780083710877561">Descripción:</translation>
+<translation id="4881695831933465202">Abrir</translation>
+<translation id="3542235761944717775">KB disponibles: <ph name="KILOBYTES"/></translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB disponibles</translation>
+<translation id="5424588387303617268">GB disponibles: <ph name="GIGABYTES"/></translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> de <ph name="SPACE_AVAILABLE"/> en uso</translation>
+<translation id="3587482841069643663">Todos</translation>
+<translation id="4988526792673242964">Páginas</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Imágenes</translation>
+<translation id="8250920743982581267">Documentos</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# archivo}other{# archivos}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagen}other{# imágenes}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# archivo de audio}other{# archivos de audio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}other{# páginas}}</translation>
+<translation id="5456381639095306749">Descargar página</translation>
+<translation id="2394602618534698961">Los archivos que descargues aparecerán aquí</translation>
+<translation id="7810647596859435254">Abrir con…</translation>
+<translation id="5655963694829536461">Buscar tus descargas</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mis archivos</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Los artículos aparecen aquí, y puedes leerlos incluso cuando estás sin conexión</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
+<translation id="5853623416121554550">pausado</translation>
+<translation id="8965591936373831584">pendiente</translation>
+<translation id="2779651927720337254">error</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Recién</translation>
+<translation id="4000212216660919741">Página principal sin conexión</translation>
+<translation id="9133397713400217035">Explorar sin conexión</translation>
+<translation id="968900484120156207">Las páginas que visites aparecerán aquí</translation>
+<translation id="7882131421121961860">No se encontraron entradas en el historial</translation>
+<translation id="3549657413697417275">Buscar en el historial</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Primera experiencia de ejecución de Brave</translation>
+<translation id="2700285883409956633">Si usas esta aplicación, aceptas las <ph name="BEGIN_LINK1"/>Condiciones del Servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>Aviso de Privacidad<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="1640714894372474981">Al usar esta app, aceptas las <ph name="BEGIN_LINK1"/>Condiciones del servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>Aviso de privacidad<ph name="END_LINK2"/> de Brave, y el <ph name="BEGIN_LINK3"/>Aviso de privacidad para las cuentas de Brave Software administradas con Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> se abrirá en Brave. Al continuar, aceptas las <ph name="BEGIN_LINK1"/>Condiciones del servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>Aviso de privacidad<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> se abrirá en Brave. Al continuar, aceptas las <ph name="BEGIN_LINK1"/>Condiciones del servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>Aviso de privacidad<ph name="END_LINK2"/> de Brave, y el <ph name="BEGIN_LINK3"/>Aviso de privacidad para las cuentas de Brave Software administradas con Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Envía las estadísticas de uso y los informes de fallos a Brave Software para ayudarnos a mejorar Brave.</translation>
+<translation id="3518985090088779359">Aceptar y continuar</translation>
+<translation id="7207456302801184289">Te damos la bienvenida a Brave</translation>
+<translation id="704822250101715322">Esperando que los servicios de Brave Software Play terminen de actualizarse</translation>
+<translation id="1231733316453485619">¿Quieres activar la sincronización?</translation>
+<translation id="5132942445612118989">Sincroniza tus contraseñas, historial y más en todos los dispositivos</translation>
+<translation id="5736731321935944068">Es posible que Brave Software use tu historial para personalizar la Búsqueda, los anuncios y otros servicios de Brave Software</translation>
+<translation id="4013614219085422040">Es posible que Brave Software use tu historial para personalizar la Búsqueda, los anuncios y otros servicios de Brave Software</translation>
+<translation id="5581519193887989363">En la <ph name="BEGIN_LINK1"/>configuración<ph name="END_LINK1"/>, puedes elegir los datos para sincronizar en cualquier momento.</translation>
+<translation id="741204030948306876">Sí, acepto</translation>
+<translation id="2410754283952462441">Elegir una cuenta</translation>
+<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">¿No eres <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Para que tus favoritos estén en todos tus dispositivos, activa la sincronización</translation>
+<translation id="2818669890320396765">Para que tus favoritos estén en todos tus dispositivos, accede a tu cuenta y activa la sincronización</translation>
+<translation id="6003646045106347985">Para obtener contenido personalizado y sugerido por Brave Software, activa la sincronización</translation>
+<translation id="8494430740943879273">Para obtener contenido personalizado y sugerido por Brave Software, accede a tu cuenta y activa la sincronización</translation>
+<translation id="5862731021271217234">Para obtener las pestañas de tus otros dispositivos, activa la sincronización</translation>
+<translation id="3568688522516854065">Para obtener las pestañas de tus otros dispositivos, accede a tu cuenta y activa la sincronización</translation>
+<translation id="1208340532756947324">Para sincronizar diferentes dispositivos y personalizar tu experiencia, activa la sincronización</translation>
+<translation id="4472118726404937099">Para sincronizar diferentes dispositivos y personalizar tu experiencia, accede a tu cuenta y activa la sincronización</translation>
+<translation id="2426805022920575512">Seleccionar otra cuenta</translation>
+<translation id="6790428901817661496">Reproducir</translation>
+<translation id="1272079795634619415">Interrumpir</translation>
+<translation id="2874939134665556319">Pista anterior</translation>
+<translation id="4046123991198612571">Siguiente pista</translation>
+<translation id="3859306556332390985">Buscar más adelante</translation>
+<translation id="8441146129660941386">Buscar más atrás</translation>
+<translation id="6706288973712894588">En este momento, estás sin conexión.\n<ph name="BEGIN_LINK"/>Explora tu feed sin conexión.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Pestañas recientes</translation>
+<translation id="8497726226069778601">Aún no hay elementos para ver</translation>
+<translation id="5423934151118863508">Aquí aparecerán las páginas que visites con más frecuencia</translation>
+<translation id="6127379762771434464">Se eliminó el elemento</translation>
+<translation id="4605958867780575332">Se quitó el siguiente elemento: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle de Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Otros dispositivos</translation>
+<translation id="4738836084190194332">Última sincronización: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Hace # minuto}other{Hace # minutos}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Hace # hora}other{Hace # horas}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Hace # día}other{Hace # días}}</translation>
+<translation id="2762000892062317888">recién</translation>
+<translation id="1407135791313364759">Abrir todas</translation>
+<translation id="1209206284964581585">Ocultar por el momento</translation>
+<translation id="129553762522093515">Cerrado recientemente</translation>
+<translation id="8413126021676339697">Mostrar historial completo</translation>
+<translation id="7876243839304621966">Eliminar todo</translation>
+<translation id="8487700953926739672">Disponible sin conexión</translation>
+<translation id="5224771365102442243">Con video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Más información<ph name="END_LINK"/> sobre el contenido sugerido</translation>
+<translation id="7542481630195938534">No se pueden obtener sugerencias</translation>
+<translation id="5013696553129441713">No hay sugerencias nuevas</translation>
+<translation id="1736419249208073774">Explorar</translation>
+<translation id="7444811645081526538">Más categorías</translation>
+<translation id="6709133671862442373">Noticias</translation>
+<translation id="1264974993859112054">Deportes</translation>
+<translation id="9139318394846604261">Compras</translation>
+<translation id="3912508018559818924">Buscando lo mejor de la Web…</translation>
+<translation id="526421993248218238">No se puede cargar esta página</translation>
+<translation id="614940544461990577">Intenta:</translation>
+<translation id="3288003805934695103">Volver a cargar la página.</translation>
+<translation id="2353636109065292463">Revisando tu conexión a Internet</translation>
+<translation id="2858138569776157458">Populares</translation>
+<translation id="8364299278605033898">Ver sitios populares</translation>
+<translation id="1171770572613082465">Presiona el botón "Populares" para ver los sitios web más conocidos</translation>
+<translation id="5233638681132016545">Nueva pestaña</translation>
+<translation id="4521874409998847950">De <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>publicado por Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Nueva versión disponible</translation>
+<translation id="4058091506841967397">No se actualiza Brave</translation>
+<translation id="6316139424528454185">Versión Android no compatible</translation>
+<translation id="6989267951144302301">No se pudo descargar</translation>
+<translation id="624789221780392884">Actualización lista</translation>
+<translation id="1549000191223877751">Mover a otra ventana</translation>
+<translation id="7481312909269577407">Reenviar</translation>
+<translation id="4084682180776658562">Marcador</translation>
+<translation id="6437478888915024427">Información de la página</translation>
+<translation id="7180611975245234373">Actualizar</translation>
+<translation id="4913169188695071480">Detener actualización</translation>
+<translation id="1829244130665387512">Buscar en la página</translation>
+<translation id="6593061639179217415">Sitio de escritorio</translation>
+<translation id="9063523880881406963">Desactivar la opción para solicitar versión de escritorio</translation>
+<translation id="2038563949887743358">Activar la opción para solicitar versión de escritorio</translation>
+<translation id="2433507940547922241">Diseño</translation>
+<translation id="983192555821071799">Cerrar todas las pestañas</translation>
+<translation id="1310482092992808703">Agrupar pestañas</translation>
+<translation id="7725024127233776428">Las páginas que agregues a favoritos aparecerán aquí</translation>
+<translation id="4404568932422911380">No hay favoritos</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> favorito}other{<ph name="BOOKMARKS_COUNT_MANY"/> favoritos}}</translation>
+<translation id="3739899004075612870">Agregado a favoritos en <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Agregada a favoritos</translation>
+<translation id="4452548195519783679">Se agregó a favoritos en <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Se produjo un error al agregar el marcador.</translation>
+<translation id="2842985007712546952">Carpeta principal</translation>
+<translation id="9065203028668620118">Editar</translation>
+<translation id="4405224443901389797">Mover a…</translation>
+<translation id="5170568018924773124">Mostrar en carpeta</translation>
+<translation id="8035133914807600019">Nueva carpeta…</translation>
+<translation id="4532845899244822526">Seleccionar carpeta</translation>
+<translation id="6627583120233659107">Editar la carpeta</translation>
+<translation id="1197267115302279827">Mover favoritos</translation>
+<translation id="6963766334940102469">Borrar favoritos</translation>
+<translation id="4351244548802238354">Cerrar cuadro de diálogo</translation>
+<translation id="451872707440238414">Buscar tus favoritos</translation>
+<translation id="8901170036886848654">No se encontraron favoritos</translation>
+<translation id="6404511346730675251">Editar marcador</translation>
+<translation id="3894427358181296146">Agregar carpeta</translation>
+<translation id="5327248766486351172">Nombre</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Carpeta</translation>
+<translation id="5161254044473106830">Se requiere un título</translation>
+<translation id="2996809686854298943">URL obligatoria</translation>
+<translation id="2536728043171574184">Visualizando una copia sin conexión de la página</translation>
+<translation id="4698034686595694889">Ver sin conexión en <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> y más sitios</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave cargará la página cuando esté lista}other{Brave cargará las páginas cuando estén listas}}</translation>
+<translation id="6811034713472274749">Ya puedes ver la página</translation>
+<translation id="4561979708150884304">Sin conexión</translation>
+<translation id="8274165955039650276">Ver las descargas</translation>
+<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER"/> de <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Sin resultados</translation>
+<translation id="981121421437150478">Sin conexión</translation>
+<translation id="3298243779924642547">Básico</translation>
+<translation id="393697183122708255">La búsqueda por voz no está habilitada</translation>
+<translation id="7191430249889272776">Pestaña abierta en segundo plano</translation>
+<translation id="8445059357334030806">Abrir en Brave</translation>
+<translation id="4720023427747327413">Abrir en <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Abrir en el navegador</translation>
+<translation id="1113597929977215864">Mostrar la vista simplificada</translation>
+<translation id="1513352483775369820">Favoritos e historial web</translation>
+<translation id="4939482511480190003">Ayuda a mejorar Brave. <ph name="BEGIN_LINK"/>Realiza la encuesta<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Ir atrás</translation>
+<translation id="5596627076506792578">Más opciones</translation>
+<translation id="3522247891732774234">Actualización disponible. Mas opciones</translation>
+<translation id="6773423637732432200">No se puede actualizar Brave. Más opciones</translation>
+<translation id="3328801116991980348">Información del sitio</translation>
+<translation id="5391532827096253100">La conexión con este sitio no es segura. Consulta la información del sitio.</translation>
+<translation id="6206551242102657620">La conexión es segura. Consulta la información del sitio.</translation>
+<translation id="6963642900430330478">Esta página es peligrosa. Consulta la información del sitio.</translation>
+<translation id="9070377983101773829">Iniciar búsqueda por voz</translation>
+<translation id="8676374126336081632">Borrar entrada</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> pestaña abierta; presiona para cambiar de pestaña}other{<ph name="OPEN_TABS_MANY"/> pestañas abiertas; presiona para cambiar de pestaña}}</translation>
+<translation id="2369533728426058518">pestañas abiertas</translation>
+<translation id="7071521146534760487">Administrar cuenta</translation>
+<translation id="932327136139879170">Página principal</translation>
+<translation id="2707726405694321444">Actualizar página</translation>
+<translation id="2891154217021530873">Detener la carga de la página</translation>
+<translation id="6710213216561001401">Anterior</translation>
+<translation id="6659594942844771486">Pestaña</translation>
+<translation id="1933845786846280168">Pestaña seleccionada</translation>
+<translation id="2268044343513325586">Definir mejor</translation>
+<translation id="7846076177841592234">Cancelar la selección</translation>
+<translation id="7087918508125750058">Elementos seleccionados: <ph name="ITEM_COUNT"/>. Opciones disponibles cerca de la parte superior de la pantalla</translation>
+<translation id="7250468141469952378">Elementos seleccionados: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Comparte 1 elemento seleccionado}other{Comparte # elementos seleccionados}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Quitar 1 elemento seleccionado}other{Quitar # elementos seleccionados}}</translation>
+<translation id="1283039547216852943">Presiona para expandir</translation>
+<translation id="5962718611393537961">Presiona para contraer</translation>
+<translation id="8076492880354921740">Pestañas</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 seleccionado}other{# seleccionados}}</translation>
+<translation id="6818926723028410516">Seleccionar elementos</translation>
+<translation id="4797039098279997504">Toca para volver a <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Presiona para ir al sitio</translation>
+<translation id="429312253194641664">Un sitio está reproduciendo contenido multimedia</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> está compartiendo tu pantalla</translation>
+<translation id="8833831881926404480">Un sitio está compartiendo tu pantalla</translation>
+<translation id="9086455579313502267">No se puede acceder a la red</translation>
+<translation id="938850635132480979">Error: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Abrir en <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Abrir en una app de mapas</translation>
+<translation id="7698359219371678927">Crear correo electrónico en <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Crear correo electrónico</translation>
+<translation id="5665379678064389456">Crear evento en <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Crear evento</translation>
+<translation id="2111511281910874386">Ir a la página</translation>
+<translation id="3988466920954086464">Los resultados de la búsqueda instantánea se muestran en este panel</translation>
+<translation id="2744248271121720757">Presiona una palabra para realizar una búsqueda instantánea o ver acciones relacionadas</translation>
+<translation id="9155898266292537608">También puedes presionar brevemente la palabra para realizar una búsqueda</translation>
+<translation id="3232754137068452469">Aplicación web</translation>
+<translation id="1430915738399379752">Imprimir</translation>
+<translation id="3775705724665058594">Enviar a tus dispositivos</translation>
+<translation id="6364438453358674297">¿Borrar la sugerencia del historial?</translation>
+<translation id="213279576345780926">Pestaña <ph name="TAB_TITLE"/> cerrada</translation>
+<translation id="6850830437481525139">Pestañas cerradas: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Se borró <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> favoritos eliminados</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> descargas borradas</translation>
+<translation id="1248710015876067820">Cantidad de instancias de Brave no admitidas</translation>
+<translation id="4259722352634471385">Navegación bloqueada: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navegación inaccesible: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Cerrar pestaña</translation>
+<translation id="7772375229873196092">Cerrar <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Historial de navegación</translation>
+<translation id="9169507124922466868">El historial de navegación está abierto a la mitad</translation>
+<translation id="1327257854815634930">Está abierto el Historial de navegación</translation>
+<translation id="8788265440806329501">Se cerró el Historial de navegación</translation>
+<translation id="7482656565088326534">Pestaña de vista previa</translation>
+<translation id="8427875596167638501">La pestaña de vista previa está abierta a la mitad</translation>
+<translation id="9102803872260866941">Está abierta la pestaña de vista previa</translation>
+<translation id="2942036813789421260">Se cerró la pestaña de vista previa</translation>
+<translation id="6355102470683871794">Almacenamiento de Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">¿Borrar el almacenamiento de sitios?</translation>
+<translation id="9205995714227143200">Almacenamiento de sitios que Brave no considera importantes (por ejemplo, sitios que no visitas a menudo o sin configuración guardada)</translation>
+<translation id="3997476611815694295">Almacenamiento no importante</translation>
+<translation id="8493948351860045254">Liberar espacio</translation>
+<translation id="2324920234469020158">Esta acción borrará la caché, cookies y otros datos de sitios que Brave no considera importantes.</translation>
+<translation id="5447201525962359567">Todo el almacenamiento de sitios, lo que incluye cookies y otros datos almacenados de forma local</translation>
+<translation id="1376578503827013741">Calculando…</translation>
+<translation id="583281660410589416">Desconocido</translation>
+<translation id="2323763861024343754">Almacenamiento del sitio</translation>
+<translation id="3587672679800759167">Cantidad total de datos que usa Brave, lo que incluye las cuentas, favoritos y opciones de configuración guardadas</translation>
+<translation id="6545017243486555795">Borrar todos los datos</translation>
+<translation id="4095146165863963773">¿Borrar datos de app?</translation>
+<translation id="53119194224775367">Todos los datos de app de Brave se borrarán de forma permanente. Esta información incluye todos los archivos, opciones de configuración, cuentas, bases de datos, etc.</translation>
+<translation id="5307446750509046227">Borrar el almacenamiento de sitios</translation>
+<translation id="300526633675317032">Se borrarán <ph name="SIZE_IN_KB"/> del almacenamiento del sitio web.</translation>
+<translation id="8068648041423924542">No es posible seleccionar un certificado</translation>
+<translation id="2315043854645842844">El sistema operativo no admite la selección de certificados del lado del cliente.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> desea conectarse</translation>
+<translation id="5308380583665731573">Conectar</translation>
+<translation id="868929229000858085">Busca entre tus contactos</translation>
+<translation id="1919950603503897840">Seleccionar contactos</translation>
+<translation id="7986741934819883144">Seleccionar un contacto</translation>
+<translation id="3333961966071413176">Todos los contactos</translation>
+<translation id="4994033804516042629">No se encontraron contactos</translation>
+<translation id="5403592356182871684">Nombres</translation>
+<translation id="2717722538473713889">Direcciones de correo electrónico</translation>
+<translation id="381841723434055211">Números de teléfono</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(1 más)}other{(# más)}}</translation>
+<translation id="5197729504361054390">Los contactos que selecciones se compartirán con <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Decodificador de imágenes</translation>
+<translation id="8067883171444229417">Reproducir video</translation>
+<translation id="6560414384669816528">Buscar con Sogou</translation>
+<translation id="5406914950576900927">Brave puede usar <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> para realizar búsquedas en China. Puede cambiar esta opción en <ph name="BEGIN_LINK"/>Configuración<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Seguir usando Brave Software</translation>
+<translation id="4384468725000734951">Se usa Sogou para la búsqueda</translation>
+<translation id="6103327872225198548">Se usa Brave Software para la búsqueda</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Esta app se ejecuta en Brave</translation>
+<translation id="6143689084714664628">Se está ejecutando en Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> también tiene datos en Brave</translation>
+<translation id="2734140769649165081">Puedes borrar los datos en la Configuración de Brave</translation>
+<translation id="8232956427053453090">Conservar los datos</translation>
+<translation id="4298388696830689168">Sitios vinculados</translation>
+<translation id="5763514718066511291">Presiona para copiar la URL para esta app</translation>
+<translation id="6496823230996795692">Para usar <ph name="APP_NAME"/> por primera vez, conéctate a Internet.</translation>
+<translation id="751961395872307827">No se puede conectar al sitio</translation>
+<translation id="4878404682131129617">Se produjo un error al establecer conexión a través del servidor proxy</translation>
+<translation id="4749960740855309258">Abrir una pestaña nueva</translation>
+<translation id="8788968922598763114">Volver a abrir la última pestaña cerrada</translation>
+<translation id="7929962904089429003">Abrir el menú</translation>
+<translation id="6039379616847168523">Ir a la pestaña siguiente</translation>
+<translation id="5210286577605176222">Ir a la pestaña anterior</translation>
+<translation id="124678866338384709">Cerrar la pestaña actual</translation>
+<translation id="3714981814255182093">Abrir la barra de búsqueda</translation>
+<translation id="5441522332038954058">Ir a la barra de direcciones</translation>
+<translation id="3398320232533725830">Abrir el administrador de favoritos</translation>
+<translation id="6583199322650523874">Agregar la página actual a favoritos</translation>
+<translation id="8489271220582375723">Abrir la página del historial</translation>
+<translation id="4837753911714442426">Abrir opciones para imprimir la página</translation>
+<translation id="5726692708398506830">Agrandar todos los elementos de la página</translation>
+<translation id="3259831549858767975">Achicar todos los elementos de la página</translation>
+<translation id="8015452622527143194">Restablecer tamaño de los elementos de la página</translation>
+<translation id="3443221991560634068">Volver a cargar la página actual</translation>
+<translation id="123724288017357924">Volver a cargar página actual; ignorar contenido en caché</translation>
+<translation id="305870044889644984">Abrir Centro de ayuda de Brave en pestaña nueva</translation>
+<translation id="3166827708714933426">Accesos directos a ventanas y pestañas</translation>
+<translation id="3169981355900570544">Accesos directos a las funciones de Brave Software Brave</translation>
+<translation id="4558311620361989323">Accesos directos a páginas web</translation>
+<translation id="1908301351964700579">Brave todavía se está preparando para la RV. Reinicia Brave más tarde.</translation>
+<translation id="8970887620466824814">Se produjo un error</translation>
+<translation id="1875543012935658554">Vuelve a abrir Brave.</translation>
+<translation id="79859296434321399">Para ver contenido de realidad aumentada, instala ARCore</translation>
+<translation id="8558485628462305855">Para ver contenido de realidad aumentada, actualiza ARCore</translation>
+<translation id="3513704683820682405">Realidad aumentada</translation>
+<translation id="5475862044948910901">¿Quieres iniciar la sesión de realidad aumentada?</translation>
 <translation id="7365126855094612066">Durante esta sesión, el sitio podrá hacer lo siguiente:
 • Crear un mapa 3D de tu entorno
 • Hacer un seguimiento del movimiento de la cámara
 
 El sitio NO podrá acceder a la cámara. Solo tú podrás ver las imágenes de la cámara.</translation>
-<translation id="7375125077091615385">Tipo:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" /></translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Primera experiencia de ejecución de Chrome</translation>
-<translation id="741204030948306876">Sí, acepto</translation>
-<translation id="7413229368719586778">Fecha de inicio: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Preguntar primero</translation>
-<translation id="7423538860840206698">Se impidió la lectura del portapapeles</translation>
-<translation id="7431991332293347422">Controla cómo se usa tu historial de navegación para personalizar la Búsqueda y mucho más</translation>
-<translation id="7437998757836447326">Salir de Chrome</translation>
-<translation id="7438641746574390233">Cuando el modo lite está activado, Chrome usa los servidores de Google para cargar las páginas más rápido. El modo lite reescribe las páginas muy lentas para cargar solo el contenido esencial. El modo lite no se aplica a las pestañas del modo incógnito.</translation>
-<translation id="7444811645081526538">Más categorías</translation>
-<translation id="7445411102860286510">Permitir que los sitios reproduzcan videos silenciados de forma automática (recomendado)</translation>
-<translation id="7453467225369441013">Esta acción te hace salir de la mayoría de los sitios. No saldrás de tu cuenta de Google.</translation>
-<translation id="7454641608352164238">No hay suficiente espacio</translation>
-<translation id="7475192538862203634">Si el mensaje aparece con frecuencia, prueba estas <ph name="BEGIN_LINK" />sugerencias<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">No se encontró la tarjeta SD. Es posible que falten algunos archivos.</translation>
-<translation id="7479104141328977413">Administración de pestañas</translation>
-<translation id="7481312909269577407">Reenviar</translation>
-<translation id="7482656565088326534">Pestaña de vista previa</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (actualización: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">de datos ahorrados</translation>
-<translation id="7498271377022651285">Espera un momento…</translation>
-<translation id="7514365320538308">Descargar</translation>
-<translation id="751961395872307827">No se puede conectar al sitio</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">No se pueden obtener sugerencias</translation>
-<translation id="7559975015014302720">El modo lite está desactivado</translation>
-<translation id="7562080006725997899">Borrando datos de navegación</translation>
-<translation id="756809126120519699">Datos de Chrome borrados</translation>
-<translation id="757524316907819857">Impedir que los sitios reproduzcan contenido protegido</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> archivo descargado}other{<ph name="FILES_DOWNLOADED_MANY" /> archivos descargados}}</translation>
-<translation id="7588219262685291874">Activar el tema oscuro cuando esté activado el Ahorro de batería de tu dispositivo</translation>
-<translation id="7589445247086920869">Bloquear el motor de búsqueda actual</translation>
-<translation id="7593557518625677601">Para iniciar la Sincronización de Chrome, abre la configuración de Android y vuelve a habilitar la sincronización del sistema Android</translation>
-<translation id="7596558890252710462">Sistema operativo</translation>
-<translation id="7605594153474022051">La sincronización no funciona</translation>
-<translation id="7606077192958116810">El modo lite está activado. Puedes administrarlo en Configuración.</translation>
-<translation id="7612619742409846846">Accediste a Google como</translation>
-<translation id="7619072057915878432"><ph name="FILE_NAME" /> no se pudo descargar debido a fallas en la red.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Obtener ayuda<ph name="END_LINK1" /> o <ph name="BEGIN_LINK2" />volver a buscar<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Te damos la bienvenida a Chrome</translation>
-<translation id="7638584964844754484">Frase de contraseña incorrecta</translation>
-<translation id="7641339528570811325">Borrar datos de navegación…</translation>
-<translation id="7648422057306047504">Encriptar las contraseñas con las credenciales de Google</translation>
-<translation id="7649070708921625228">Ayuda</translation>
-<translation id="7658239707568436148">Cancelar</translation>
-<translation id="7665369617277396874">Agregar cuenta</translation>
-<translation id="766587987807204883">Los artículos aparecen aquí, y puedes leerlos incluso cuando estás sin conexión</translation>
-<translation id="7682724950699840886">Intenta las siguientes sugerencias: Antes de exportar las contraseñas nuevamente, asegúrate de que haya espacio suficiente en tu dispositivo.</translation>
-<translation id="7685301384041462804">Asegúrate de que el sitio sea confiable antes de entrar al modo RV.</translation>
-<translation id="7698359219371678927">Crear correo electrónico en <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Autocompletar búsquedas y URL</translation>
-<translation id="7725024127233776428">Las páginas que agregues a favoritos aparecerán aquí</translation>
-<translation id="773466115871691567">Traducir siempre las páginas en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Para detectar apps y sitios peligrosos, Chrome envía a Google URL de algunas páginas que visitas, información limitada sobre el sistema y contenido de algunas páginas</translation>
-<translation id="7757787379047923882">Texto compartido de <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Tarjeta SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Agregar dirección</translation>
-<translation id="7772032839648071052">Confirmar frase de contraseña</translation>
-<translation id="7772375229873196092">Cerrar <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> más}other{<ph name="PAYMENT_METHOD_PREVIEW" /> y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> más}}</translation>
-<translation id="7781829728241885113">Ayer</translation>
-<translation id="7791543448312431591">Agregar</translation>
-<translation id="780301667611848630">No, gracias</translation>
-<translation id="7810647596859435254">Abrir con…</translation>
-<translation id="7821588508402923572">Aquí aparecerá tu ahorro de datos</translation>
-<translation id="7837721118676387834">Permite la reproducción automática de videos silenciados para un sitio específico.</translation>
-<translation id="7846076177841592234">Cancelar la selección</translation>
-<translation id="784934925303690534">Intervalo de tiempo</translation>
-<translation id="7851858861565204677">Otros dispositivos</translation>
-<translation id="7875915731392087153">Crear correo electrónico</translation>
-<translation id="7876243839304621966">Eliminar todo</translation>
-<translation id="7882131421121961860">No se encontraron entradas en el historial</translation>
-<translation id="7882806643839505685">Habilitar el sonido de un sitio específico</translation>
-<translation id="7886917304091689118">Se está ejecutando en Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Descargando archivo}other{Descargando # archivos}}</translation>
-<translation id="7929962904089429003">Abrir el menú</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> no está actualizado.</translation>
-<translation id="7947953824732555851">Aceptar y acceder</translation>
-<translation id="7963646190083259054">Proveedor:</translation>
-<translation id="7971136598759319605">Activo hace 1 día</translation>
-<translation id="7975379999046275268">Vista previa de página <ph name="BEGIN_NEW" />Nueva<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Cargar previamente las páginas para acelerar la navegación y las búsquedas</translation>
-<translation id="79859296434321399">Para ver contenido de realidad aumentada, instala ARCore</translation>
-<translation id="7986741934819883144">Seleccionar un contacto</translation>
-<translation id="7987073022710626672">Condiciones del servicio de Chrome</translation>
-<translation id="7998918019931843664">Volver a abrir la pestaña cerrada</translation>
-<translation id="7999064672810608036">¿Quieres eliminar todos los datos locales de este sitio web, incluidas las cookies, y restablecer todos los permisos?</translation>
-<translation id="8004582292198964060">Navegador</translation>
-<translation id="8007176423574883786">Desactivado para este dispositivo</translation>
-<translation id="8013372441983637696">Borrar también los datos de Chrome de este dispositivo</translation>
-<translation id="8015452622527143194">Restablecer tamaño de los elementos de la página</translation>
-<translation id="802154636333426148">Error en la descarga</translation>
-<translation id="8026334261755873520">Eliminar datos de navegación</translation>
-<translation id="8035133914807600019">Nueva carpeta…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> días restantes</translation>
-<translation id="804335162455518893">No se encontró la tarjeta SD</translation>
-<translation id="805047784848435650">Según tu historial de navegación</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB disponibles</translation>
-<translation id="8058746566562539958">Abrir en una nueva pestaña de Chrome</translation>
-<translation id="8063895661287329888">Se produjo un error al agregar el marcador.</translation>
-<translation id="806745655614357130">Mantener mis datos separados</translation>
-<translation id="8067883171444229417">Reproducir video</translation>
-<translation id="8068648041423924542">No es posible seleccionar un certificado</translation>
-<translation id="8073388330009372546">Abrir imagen en pestaña nueva</translation>
-<translation id="8076492880354921740">Pestañas</translation>
-<translation id="8084114998886531721">Se guardó la contraseña</translation>
-<translation id="8087000398470557479">Este contenido es de <ph name="DOMAIN_NAME" />, publicado por Google.</translation>
-<translation id="8103578431304235997">Pestaña de incógnito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Para que tus favoritos estén en todos tus dispositivos, activa la sincronización</translation>
-<translation id="8110087112193408731">¿Quieres que se muestre tu actividad de Chrome en Bienestar digital?</translation>
-<translation id="8116925261070264013">Silenciados</translation>
-<translation id="813082847718468539">Consulta la información del sitio</translation>
-<translation id="8131740175452115882">Confirmar</translation>
-<translation id="8156139159503939589">¿En qué idioma lees?</translation>
-<translation id="8168435359814927499">Contenido</translation>
-<translation id="8186512483418048923">Quedan <ph name="FILES" /> archivos</translation>
-<translation id="8190358571722158785">1 día restante</translation>
-<translation id="8200772114523450471">Reanudar</translation>
-<translation id="8209050860603202033">Abrir imagen</translation>
-<translation id="8218622182176210845">Administra tu cuenta</translation>
-<translation id="8224471946457685718">Descargar artículos para ti mediante Wi-Fi</translation>
-<translation id="8232956427053453090">Conservar los datos</translation>
-<translation id="8249310407154411074">Mover al principio</translation>
-<translation id="8250920743982581267">Documentos</translation>
-<translation id="825412236959742607">Chrome quitó parte del contenido de esta página porque usa demasiada memoria.</translation>
-<translation id="8260126382462817229">Intenta volver a acceder</translation>
-<translation id="8261506727792406068">Borrar</translation>
-<translation id="8266862848225348053">Ubicación de las descargas</translation>
-<translation id="8274165955039650276">Ver las descargas</translation>
-<translation id="8284326494547611709">Subtítulos</translation>
-<translation id="8300705686683892304">Administrados por una app</translation>
-<translation id="8310344678080805313">Pestañas estándar</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> y más sitios</translation>
-<translation id="8327155640814342956">A fin de obtener la mejor experiencia de navegación, abre Chrome para actualizarlo</translation>
-<translation id="8339163506404995330">No se traducirán las páginas en <ph name="LANGUAGE" /></translation>
-<translation id="8349013245300336738">Ordenar por cantidad de datos utilizados</translation>
-<translation id="8364299278605033898">Ver sitios populares</translation>
-<translation id="8368027906805972958">Dispositivo desconocido o no compatible (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Permite la sincronización en segundo plano para un sitio específico.</translation>
-<translation id="8378714024927312812">Administrado por tu organización</translation>
-<translation id="8380167699614421159">Este sitio muestra anuncios intrusivos o engañosos</translation>
-<translation id="8393700583063109961">Enviar mensaje</translation>
-<translation id="8413126021676339697">Mostrar historial completo</translation>
-<translation id="8427875596167638501">La pestaña de vista previa está abierta a la mitad</translation>
-<translation id="8428213095426709021">Configuración</translation>
-<translation id="8438566539970814960">Mejorar las búsquedas y la navegación</translation>
-<translation id="8441146129660941386">Buscar más atrás</translation>
-<translation id="8443209985646068659">No se actualiza Chrome</translation>
-<translation id="8445448999790540984">No se pueden exportar las contraseñas</translation>
-<translation id="8447861592752582886">Revocar permiso para el dispositivo</translation>
-<translation id="8461694314515752532">Encriptar los datos sincronizados con tu propia frase de contraseña de sincronización</translation>
-<translation id="8466613982764129868">Comprueba que <ph name="TARGET_DEVICE_NAME" /> tenga conexión a Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponible sin conexión</translation>
-<translation id="8489271220582375723">Abrir la página del historial</translation>
-<translation id="8493948351860045254">Liberar espacio</translation>
-<translation id="8497726226069778601">Aún no hay elementos para ver</translation>
-<translation id="8503559462189395349">Contraseñas de Chrome</translation>
-<translation id="8503813439785031346">Nombre de usuario</translation>
-<translation id="8514477925623180633">Exportar las contraseñas almacenadas con Chrome</translation>
-<translation id="8514577642972634246">Acceder al modo de navegación de incógnito</translation>
-<translation id="851751545965956758">Impedir que los sitios se conecten a los dispositivos</translation>
-<translation id="8523928698583292556">Borrar contraseña almacenada</translation>
-<translation id="854522910157234410">Abrir esta página</translation>
-<translation id="8558485628462305855">Para ver contenido de realidad aumentada, actualiza ARCore</translation>
-<translation id="8559990750235505898">Ofrecer la traducción de páginas en otros idiomas</translation>
-<translation id="8562452229998620586">Las contraseñas guardadas aparecerán aquí.</translation>
-<translation id="8569404424186215731">desde el <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Últimas cuatro semanas</translation>
-<translation id="857943718398505171">Permitido (recomendado)</translation>
-<translation id="8583805026567836021">Borrando datos de cuenta</translation>
-<translation id="860043288473659153">Nombre del titular de la tarjeta</translation>
-<translation id="8609465669617005112">Subir</translation>
-<translation id="8616006591992756292">Es posible que tu cuenta de Google tenga otros formularios del historial de navegación en <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">¿Quieres abrir la URL sugerida que se especifica en el contenido descargado?</translation>
-<translation id="8636825310635137004">Activa la sincronización para obtener las pestañas de tus otros dispositivos.</translation>
-<translation id="8641930654639604085">Tratar de bloquear los sitios para adultos</translation>
-<translation id="8655129584991699539">Puedes borrar los datos en la Configuración de Chrome</translation>
-<translation id="8662811608048051533">Esta acción te hace salir de la mayoría de los sitios.</translation>
-<translation id="8664979001105139458">Ya existe el nombre del archivo</translation>
-<translation id="8676374126336081632">Borrar entrada</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Nivel de potencia de la señal: # barra}other{Nivel de potencia de la señal: # barras}}</translation>
-<translation id="868929229000858085">Busca entre tus contactos</translation>
-<translation id="869891660844655955">Fecha de vencimiento</translation>
-<translation id="8719023831149562936">Esta pestaña no se puede transmitir.</translation>
-<translation id="8725066075913043281">Intentar nuevamente</translation>
-<translation id="8728487861892616501">Al usar esta app, aceptas las <ph name="BEGIN_LINK1" />Condiciones del servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />Aviso de privacidad<ph name="END_LINK2" /> de Chrome, y el <ph name="BEGIN_LINK3" />Aviso de privacidad para las cuentas de Google administradas con Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Listo</translation>
-<translation id="8748850008226585750">Contenidos ocultos</translation>
-<translation id="8751914237388039244">Seleccionar una imagen</translation>
-<translation id="8788265440806329501">Se cerró el Historial de navegación</translation>
-<translation id="8788968922598763114">Volver a abrir la última pestaña cerrada</translation>
-<translation id="8801436777607969138">Bloquea JavaScript para un sitio específico.</translation>
-<translation id="8812260976093120287">En algunos sitios web, puedes usar las apps compatibles que se enumeran anteriormente para hacer pagos en tu dispositivo.</translation>
-<translation id="8816026460808729765">Impedir que los sitios accedan a los sensores</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> se abrirá en Chrome. Al continuar, aceptas las <ph name="BEGIN_LINK1" />Condiciones del servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />Aviso de privacidad<ph name="END_LINK2" /> de Chrome, y el <ph name="BEGIN_LINK3" />Aviso de privacidad para las cuentas de Google administradas con Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Favoritos</translation>
-<translation id="8833831881926404480">Un sitio está compartiendo tu pantalla</translation>
-<translation id="883806473910249246">Se produjo un error al descargar el contenido.</translation>
-<translation id="8840953339110955557">Es posible que esta página sea diferente con respecto a la versión en línea.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Pestaña <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Almacenamiento</translation>
-<translation id="889338405075704026">Ir a la configuración de Chrome</translation>
-<translation id="8901170036886848654">No se encontraron favoritos</translation>
-<translation id="8909135823018751308">Compartir…</translation>
-<translation id="8912362522468806198">Cuenta de Google</translation>
-<translation id="8920114477895755567">Esperando los detalles parentales</translation>
+<translation id="1188239144602654184">Ingresar a la RA</translation>
+<translation id="473775607612524610">Actualizar</translation>
+<translation id="3133489217401741157">Instalando <ph name="MODULE"/> para Brave…</translation>
+<translation id="1791662854739702043">Instalado</translation>
+<translation id="5131234170665854056">No es posible instalar <ph name="MODULE"/> para Brave</translation>
+<translation id="2567385386134582609">IMAGEN</translation>
+<translation id="6395288395575013217">VÍNCULO</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Descarga las páginas para usarlas sin conexión</translation>
 <translation id="8922289737868596582">Descarga páginas desde el botón Más opciones para usarlas sin conexión</translation>
-<translation id="8937772741022875483">¿Quieres quitar tu actividad en Chrome de Bienestar digital?</translation>
-<translation id="8941729603749328384">www.ejemplo.com</translation>
-<translation id="8942627711005830162">Abrir en otra ventana</translation>
-<translation id="8951232171465285730">Chrome te permitió ahorrar <ph name="MEGABYTES" /> megabytes</translation>
-<translation id="8958424370300090006">Bloquea las cookies en un sitio específico.</translation>
-<translation id="8959122750345127698">Navegación inaccesible: <ph name="URL" /></translation>
-<translation id="8965591936373831584">pendiente</translation>
-<translation id="8970887620466824814">Se produjo un error</translation>
-<translation id="8972098258593396643">¿Deseas descargarlo a la carpeta predeterminada?</translation>
-<translation id="8986494364107987395">Enviar automáticamente estadísticas de uso e informes sobre fallos a Google</translation>
-<translation id="8993760627012879038">Abrir ventana nueva en modo de navegación incógnito</translation>
-<translation id="8998729206196772491">Estás accediendo con una cuenta administrada por <ph name="MANAGED_DOMAIN" /> y dándole permiso a su administrador para que controle tus datos de Chrome. Tus datos se vincularán de forma permanente a esta cuenta. Si sales de Chrome, tus datos se borrarán en este dispositivo, pero quedarán guardados en tu cuenta de Google.</translation>
-<translation id="9019902583201351841">Administrado por tus padres</translation>
-<translation id="9028914725102941583">Activa la sincronización para compartir contenido entre dispositivos</translation>
-<translation id="9029323097866369874">¿Quieres permitir que <ph name="DOMAIN" /> entre al modo RV?</translation>
-<translation id="9040142327097499898">Las notificaciones están habilitadas. La ubicación está desactivada en este dispositivo.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videos}}</translation>
-<translation id="9050666287014529139">Frase de contraseña</translation>
-<translation id="9063523880881406963">Desactivar la opción para solicitar versión de escritorio</translation>
-<translation id="9065203028668620118">Editar</translation>
-<translation id="9070377983101773829">Iniciar búsqueda por voz</translation>
-<translation id="9074336505530349563">Para obtener contenido personalizado y sugerido por Google, accede a tu cuenta y activa la sincronización</translation>
-<translation id="9086455579313502267">No se puede acceder a la red</translation>
-<translation id="9100505651305367705">Se ofrece mostrar artículos en una vista simplificada, cuando es compatible</translation>
-<translation id="9100610230175265781">Se necesita una frase de contraseña.</translation>
-<translation id="9102803872260866941">Está abierta la pestaña de vista previa</translation>
+<translation id="5958275228015807058">Encuentra tus archivos y páginas en Descargas</translation>
+<translation id="5620928963363755975">Encuentra tus archivos y páginas en Descargas desde el botón Más opciones</translation>
+<translation id="3341058695485821946">Consulta cuántos datos redujiste</translation>
+<translation id="3157842584138209013">Para ver cuántos datos redujiste, selecciona el botón Más opciones</translation>
+<translation id="8218622182176210845">Administra tu cuenta</translation>
+<translation id="8090895580117672212">Para administrar tu Cuenta de Brave Software, presiona el botón "Administrar cuenta"</translation>
+<translation id="8856898588039823173">Brave Software proporcionó la página básica. Presiona para cargar la versión original.</translation>
+<translation id="8134317863207426198">Brave Software proporcionó la página básica. Para cargar la original, presiona el botón.</translation>
+<translation id="4961107849584082341">Traducir esta página a cualquier idioma</translation>
+<translation id="569536719314091526">Traduce esta página a cualquier idioma desde el botón Más opciones</translation>
+<translation id="1397811292916898096">Buscar con <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Cambia la ubicación predeterminada de las descargas en cualquier momento</translation>
+<translation id="6942665639005891494">Cambia la ubicación predeterminada de las descargas en cualquier momento en la opción de menú de Configuración</translation>
+<translation id="6850409657436465440">La descarga sigue en curso</translation>
+<translation id="5817715962196959877">Ahora Brave descarga los archivos más rápido</translation>
+<translation id="3976396876660209797">Quita y vuelve a crear este acceso directo</translation>
+<translation id="6766622839693428701">Desliza hacia abajo para cerrar.</translation>
+<translation id="1028699632127661925">Enviando a <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Enviado desde <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Se recibió una pestaña</translation>
 <translation id="9104217018994036254">Lista de dispositivos con los que se puede compartir una pestaña.</translation>
-<translation id="9133397713400217035">Explorar sin conexión</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Mostrar original</translation>
-<translation id="9139068048179869749">Preguntar antes de permitir que los sitios envíen notificaciones (recomendado)</translation>
-<translation id="9139318394846604261">Compras</translation>
-<translation id="9155898266292537608">También puedes presionar brevemente la palabra para realizar una búsqueda</translation>
-<translation id="9169507124922466868">El historial de navegación está abierto a la mitad</translation>
-<translation id="9204836675896933765">Queda 1 archivo</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">La lista de dispositivos con los que se puede compartir una pestaña está abierta a media altura.</translation>
+<translation id="2904414404539560095">La lista de dispositivos con los que se puede compartir una pestaña está totalmente abierta.</translation>
+<translation id="4135200667068010335">La lista de dispositivos con los que se puede compartir una pestaña está cerrada.</translation>
+<translation id="5292796745632149097">Enviar a</translation>
+<translation id="1386674309198842382">Activo hace <ph name="LAST_UPDATED"/> días</translation>
+<translation id="7971136598759319605">Activo hace 1 día</translation>
+<translation id="1521774566618522728">Activo hoy</translation>
+<translation id="3631987586758005671">Compartiendo con <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Activa la sincronización para compartir contenido entre dispositivos</translation>
+<translation id="6162454065885854378">Si quieres compartir contenido entre tu teléfono y otro dispositivo, activa la sincronización en la configuración de Brave en ambos dispositivos.</translation>
+<translation id="6084271560289605378">Ir a la configuración de Brave</translation>
+<translation id="2318045970523081853">Presiona para realizar la llamada</translation>
 <translation id="9209888181064652401">No se pueden realizar llamadas</translation>
-<translation id="9219103736887031265">Imágenes</translation>
-<translation id="926205370408745186">Quita tu actividad en Chrome de Bienestar digital</translation>
-<translation id="932327136139879170">Página principal</translation>
-<translation id="938850635132480979">Error: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Acceso al micrófono</translation>
-<translation id="95817756606698420">Chrome puede usar <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> para realizar búsquedas en China. Puede cambiar esta opción en <ph name="BEGIN_LINK" />Configuración<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloquear si el sitio muestra anuncios intrusivos o engañosos (opción recomendada)</translation>
-<translation id="968900484120156207">Las páginas que visites aparecerán aquí</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minutos restantes</translation>
-<translation id="974555521953189084">Ingresa tu frase de contraseña para iniciar la sincronización</translation>
-<translation id="981121421437150478">Sin conexión</translation>
-<translation id="982182592107339124">Esta acción borrará los datos de todos los sitios, entre los que se incluyen:</translation>
-<translation id="983192555821071799">Cerrar todas las pestañas</translation>
-<translation id="987264212798334818">General</translation>
+<translation id="2860954141821109167">Comprueba que este dispositivo tenga una app de teléfono habilitada</translation>
+<translation id="2067805253194386918">texto</translation>
+<translation id="1450753235335490080">No se puede compartir <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">No se pudo compartir <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Comprueba que <ph name="TARGET_DEVICE_NAME"/> tenga activada la sincronización en Brave</translation>
+<translation id="3016635187733453316">Comprueba que este dispositivo tenga conexión a Internet</translation>
+<translation id="8466613982764129868">Comprueba que <ph name="TARGET_DEVICE_NAME"/> tenga conexión a Internet</translation>
+<translation id="6539092367496845964">Se produjo un error; vuelve a intentarlo más tarde.</translation>
+<translation id="3389286852084373014">El texto es demasiado largo</translation>
+<translation id="2100314319871056947">Intenta compartir el texto en fragmentos más pequeños</translation>
+<translation id="2987620471460279764">Texto compartido desde otro dispositivo</translation>
+<translation id="7757787379047923882">Texto compartido de <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Se copió en tu portapapeles</translation>
+<translation id="4696983787092045100">Enviar texto a tus dispositivos</translation>
+<translation id="1260236875608242557">Buscar y explorar</translation>
+<translation id="6369229450655021117">Desde aquí, puedes realizar búsquedas en la Web, compartir contenido con amigos y ver las páginas abiertas</translation>
+<translation id="723171743924126238">Seleccionar imágenes</translation>
+<translation id="8751914237388039244">Seleccionar una imagen</translation>
+<translation id="1989112275319619282">Navegar</translation>
+<translation id="7055152154916055070">Se bloqueó el redireccionamiento:</translation>
+<translation id="5524843473235508879">Se bloqueó el redireccionamiento</translation>
+<translation id="6573096386450695060">Permitir siempre</translation>
+<translation id="5805364706385912897">Brave pausó esta página porque usa demasiada memoria.</translation>
+<translation id="5138664332909611586">Brave quitó parte del contenido de esta página porque usa demasiada memoria.</translation>
+<translation id="9137013805542155359">Mostrar original</translation>
+<translation id="6361779936989026201">Asistente de Brave Software en Brave</translation>
+<translation id="7291387454912369099">Confirmación de compra activada</translation>
+<translation id="4565206163201411670">¿Quieres que se muestre tu actividad de Brave en Bienestar digital?</translation>
+<translation id="9055113864158719823">Puedes ver los sitios que visites en Brave y establecer temporizadores para ellos.\n\nBrave Software obtiene información sobre los sitios para los que estableces temporizadores y la duración de las visitas a ellos. Esta información se usa para mejorar Bienestar digital.</translation>
+<translation id="4596514158372210596">Quita tu actividad en Brave de Bienestar digital</translation>
+<translation id="1174893863889683998">¿Quieres quitar tu actividad en Brave de Bienestar digital?</translation>
+<translation id="708829030563435351">No se mostrarán los sitios que visites en Brave. Se borrarán todos los temporizadores.</translation>
+<translation id="2056878612599315956">Se pausó el sitio</translation>
+<translation id="671481426037969117">Se agotó el temporizador de <ph name="FQDN"/>. Volverá a empezar mañana.</translation>
+<translation id="7479104141328977413">Administración de pestañas</translation>
+<translation id="3524138585025253783">IU para desarrolladores</translation>
+<translation id="6036057147555329831">ICU adicional</translation>
+<translation id="9029323097866369874">¿Quieres permitir que <ph name="DOMAIN"/> entre al modo RV?</translation>
+<translation id="7685301384041462804">Asegúrate de que el sitio sea confiable antes de entrar al modo RV.</translation>
+<translation id="5033865233969348410">Mientras usas el modo RV, es posible que este sitio obtenga la siguiente información:
+- tus características físicas, como tu altura
+
+Asegúrate de que este sitio sea de confianza antes de entrar en el modo RV.</translation>
+<translation id="5534334044554683961">Mientras usas el modo RV, es posible que este sitio obtenga la siguiente información:
+- tus características físicas, como tu altura
+- la disposición de tu habitación
+
+Asegúrate de que este sitio sea de confianza antes de entrar en el modo RV.</translation>
+<translation id="4169535189173047238">No permitir</translation>
+<translation id="2170088579611075216">Permitir y acceder a la RV</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_es.xtb
+++ b/android/java/strings/translations/android_chrome_strings_es.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="es">
-<translation id="1006017844123154345">Abrir versión online</translation>
-<translation id="1028699632127661925">Enviando a <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Añadiendo <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">De sitios web</translation>
-<translation id="1049743911850919806">Incógnito</translation>
-<translation id="10614374240317010">Contraseñas que nunca se guardan</translation>
-<translation id="1067922213147265141">Otros servicios de Google</translation>
-<translation id="1068672505746868501">No traducir nunca las páginas en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Si cambias la extensión del archivo, el archivo podría abrirse en una aplicación diferente y convertirse en un riesgo potencial para tu dispositivo.</translation>
-<translation id="1100066534610197918">Abrir pestaña nueva en grupo</translation>
-<translation id="1105960400813249514">Captura de pantalla</translation>
-<translation id="1111673857033749125">Aquí aparecen los marcadores que hayas guardado en otros dispositivos.</translation>
-<translation id="1113597929977215864">Mostrar vista simplificada</translation>
-<translation id="1121094540300013208">Informes de uso y sobre fallos</translation>
-<translation id="1124772482545689468">Usuario</translation>
-<translation id="1129510026454351943">Detalles: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Hay 1 descarga pendiente.}other{Hay # descargas pendientes.}}</translation>
-<translation id="1145536944570833626">Elimina los datos actuales.</translation>
-<translation id="1146678959555564648">Iniciar RV</translation>
-<translation id="116280672541001035">Usados</translation>
-<translation id="1171770572613082465">Toca el botón Populares para ver los sitios web más populares</translation>
-<translation id="1173894706177603556">Cambiar nombre</translation>
-<translation id="1178581264944972037">Pausar</translation>
-<translation id="1181037720776840403">Quitar</translation>
-<translation id="1188239144602654184">Acceder a RA</translation>
-<translation id="1197267115302279827">Mover marcadores</translation>
-<translation id="119944043368869598">Eliminar todo</translation>
-<translation id="1201402288615127009">Siguiente</translation>
-<translation id="1204037785786432551">Descargar enlace</translation>
-<translation id="1206892813135768548">Copiar texto de enlace</translation>
-<translation id="1208340532756947324">Activa la sincronización para sincronizar y personalizar todos tus dispositivos</translation>
-<translation id="1209206284964581585">Ocultar por ahora</translation>
-<translation id="1227058898775614466">Historial de navegación</translation>
-<translation id="1231733316453485619">¿Activar sincronización?</translation>
-<translation id="123724288017357924">Vuelve a cargar esta página sin contenido en caché</translation>
-<translation id="124116460088058876">Más idiomas</translation>
-<translation id="124678866338384709">Cierra la pestaña actual</translation>
-<translation id="1258753120186372309">Doodles de Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Buscar y explorar</translation>
-<translation id="1264974993859112054">Deportes</translation>
-<translation id="1266864766717917324">No se ha podido compartir: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Interrumpir</translation>
-<translation id="1283039547216852943">Toca para ampliar</translation>
-<translation id="1285320974508926690">No traducir nunca este sitio</translation>
-<translation id="1291207594882862231">Borrar el historial, las cookies, los datos de sitios web, la caché…</translation>
-<translation id="129382876167171263">Los archivos que guarden los sitios web aparecerán aquí</translation>
-<translation id="129553762522093515">Cerrado recientemente</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Enviado desde <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Agrupar pestañas</translation>
-<translation id="1327257854815634930">El historial de navegación está abierto</translation>
-<translation id="1331212799747679585">No se ha podido actualizar Chrome. Más opciones</translation>
-<translation id="1332501820983677155">Combinaciones de teclas de funciones de Google Chrome</translation>
-<translation id="1360432990279830238">¿Cerrar sesión y detener sincronización?</translation>
-<translation id="1369915414381695676">Se ha añadido el sitio <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">No hay memoria suficiente para descargar el contenido seleccionado.</translation>
-<translation id="1376578503827013741">Calculando…</translation>
-<translation id="1383876407941801731">Buscar</translation>
-<translation id="1384959399684842514">Descarga en pausa</translation>
-<translation id="1386674309198842382">Activo hace <ph name="LAST_UPDATED" /> días</translation>
-<translation id="1397811292916898096">Buscar con <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Insertado en <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">No hacer seguimiento</translation>
-<translation id="1407135791313364759">Abrir todas</translation>
-<translation id="1409426117486808224">Vista simplificada de las pestañas abiertas</translation>
-<translation id="1409879593029778104">No se ha descargado <ph name="FILE_NAME" /> porque este archivo ya existe.</translation>
-<translation id="1414981605391750300">Contactando con Google. Esto puede tardar un minuto…</translation>
-<translation id="1416550906796893042">Versión de la aplicación</translation>
-<translation id="1430915738399379752">Imprimir</translation>
-<translation id="1446450296470737166">Control total dispositivos MIDI</translation>
-<translation id="1450753235335490080">No se ha podido compartir: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Ajustes de Android desactivados</translation>
-<translation id="1477626028522505441">No se ha podido descargar <ph name="FILE_NAME" /> debido a problemas con el servidor.</translation>
-<translation id="1506061864768559482">Buscador</translation>
-<translation id="1513352483775369820">Historial web y marcadores</translation>
-<translation id="1513858653616922153">Eliminar contraseña</translation>
-<translation id="1516229014686355813">La función Tocar para buscar envía la palabra seleccionada y la página actual como contexto a la Búsqueda de Google. Puedes desactivarla en <ph name="BEGIN_LINK" />Configuración<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Activo hoy</translation>
-<translation id="1544826120773021464">Para gestionar tu cuenta de Google, toca el botón Gestionar cuenta</translation>
-<translation id="1549000191223877751">Mover a otra ventana</translation>
-<translation id="1553358976309200471">Actualizar Chrome</translation>
-<translation id="1569387923882100876">Dispositivo conectado</translation>
-<translation id="1571304935088121812">Copiar nombre de usuario</translation>
-<translation id="1612196535745283361">Chrome necesita acceder a la ubicación para buscar dispositivos. El acceso a la ubicación está <ph name="BEGIN_LINK" />desactivado en este dispositivo<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Cámara</translation>
-<translation id="1623104350909869708">Evitar que esta página cree cuadros de diálogo adicionales</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Quitar 1 elemento seleccionado}other{Quitar # elementos seleccionados}}</translation>
-<translation id="164269334534774161">Estás viendo una copia sin conexión de esta página del <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historial</translation>
-<translation id="1647391597548383849">Acceder a la cámara</translation>
-<translation id="1660204651932907780">Permitir que los sitios web reproduzcan sonidos (recomendado)</translation>
-<translation id="1670399744444387456">Básico</translation>
-<translation id="1671236975893690980">Descarga pendiente…</translation>
-<translation id="1672586136351118594">No volver a mostrar</translation>
-<translation id="1692118695553449118">La sincronización está activada</translation>
-<translation id="169515064810179024">No permitir que los sitios web accedan a los sensores de movimiento</translation>
-<translation id="1717218214683051432">Sensores de movimiento</translation>
-<translation id="1718835860248848330">Última hora</translation>
-<translation id="1736419249208073774">Más información</translation>
-<translation id="1743802530341753419">Preguntar antes de permitir que los sitios web se conecten a un dispositivo (recomendado)</translation>
-<translation id="1749561566933687563">Sincronizar marcadores</translation>
-<translation id="17513872634828108">Pestañas abiertas</translation>
-<translation id="1779089405699405702">Decodificador de imágenes</translation>
-<translation id="1782483593938241562">Fecha de finalización: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Ubicación</translation>
-<translation id="1792959175193046959">Cambia la ubicación predeterminada de las descargas en cualquier momento</translation>
-<translation id="1807246157184219062">Claro</translation>
-<translation id="1810845389119482123">La configuración de sincronización inicial no ha terminado</translation>
-<translation id="1821253160463689938">Usa cookies para recordar tus preferencias aunque no visites esas páginas</translation>
-<translation id="1829244130665387512">Buscar en la página</translation>
-<translation id="1853692000353488670">Nueva pestaña de incógnito</translation>
-<translation id="1856325424225101786">¿Restablecer el modo básico?</translation>
-<translation id="1868024384445905608">Ahora Chrome descarga los archivos más rápido</translation>
-<translation id="1883903952484604915">Mis archivos</translation>
-<translation id="1887786770086287077">El acceso a la ubicación está desactivado en este dispositivo. Actívalo en los <ph name="BEGIN_LINK" />Ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> se abrirá en Chrome. Si continúas, aceptas las <ph name="BEGIN_LINK1" />condiciones de servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />aviso de privacidad<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="1919345977826869612">Anuncios</translation>
-<translation id="1919950603503897840">Seleccionar contactos</translation>
-<translation id="1922076542920281912">Para que Chrome tenga acceso a tu ubicación, activa la ubicación en los <ph name="BEGIN_LINK" />ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Actualizaciones</translation>
-<translation id="19288952978244135">Vuelve a abrir Chrome.</translation>
-<translation id="1933845786846280168">Pestaña seleccionada</translation>
-<translation id="194341124344773587">Activa el permiso para Chrome en los <ph name="BEGIN_LINK" />ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Guardar contraseñas</translation>
-<translation id="1952172573699511566">Si es posible, los sitios web muestran texto en tu idioma preferido.</translation>
-<translation id="1960290143419248813">Ya no se admiten actualizaciones de Chrome en esta versión de Android.</translation>
-<translation id="1966710179511230534">Actualiza tus datos de inicio de sesión.</translation>
-<translation id="1974060860693918893">Configuración avanzada</translation>
-<translation id="1984705450038014246">Sincronizar tus datos de Chrome</translation>
-<translation id="1984937141057606926">Permitidas (excepto cookies de terceros)</translation>
-<translation id="1986685561493779662">El nombre ya existe</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> Botón <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Examinar</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> quiere vincularse</translation>
-<translation id="1994173015038366702">URL del sitio</translation>
-<translation id="2000419248597011803">Envía algunas cookies y búsquedas de la barra de direcciones y del cuadro de búsqueda a tu buscador predeterminado</translation>
-<translation id="2002537628803770967">Tarjetas de crédito y direcciones con Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# archivo}other{# archivos}}</translation>
-<translation id="2017836877785168846">Borra el historial y los autocompletados de la barra de direcciones.</translation>
-<translation id="2021896219286479412">Controles de pantalla completa</translation>
-<translation id="2038563949887743358">Activar opción para ver como ordenador</translation>
-<translation id="2041019821020695769">Para que Chrome pueda enviarte notificaciones, actívalas también en los <ph name="BEGIN_LINK" />ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> también tiene datos en Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Sitio web en pausa</translation>
-<translation id="2063713494490388661">Tocar para buscar</translation>
-<translation id="2067805253194386918">texto</translation>
-<translation id="2079545284768500474">Deshacer</translation>
-<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER" /> de <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Sonido</translation>
-<translation id="2096012225669085171">Sincroniza y personaliza todos tus dispositivos</translation>
-<translation id="2100273922101894616">Iniciar sesión automáticamente</translation>
-<translation id="2100314319871056947">Prueba a compartir el texto dividiéndolo en partes más pequeñas</translation>
-<translation id="2107397443965016585">Preguntar antes de permitir que los sitios web reproduzcan contenido protegido (opción recomendada)</translation>
-<translation id="2111511281910874386">Ir a la página</translation>
-<translation id="2122601567107267586">No se ha podido abrir la aplicación</translation>
-<translation id="2126426811489709554">Con la tecnología de Chrome</translation>
-<translation id="2131665479022868825">Datos ahorrados: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Pestaña de <ph name="TAB_TITLE" /> cerrada</translation>
-<translation id="2139186145475833000">Añadir a pantalla de inicio</translation>
-<translation id="2146738493024040262">Abrir aplicación instantánea</translation>
-<translation id="2148716181193084225">Hoy</translation>
-<translation id="2154484045852737596">Editar tarjeta</translation>
-<translation id="2154710561487035718">Copiar URL</translation>
-<translation id="2156074688469523661">Sitios web restantes (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Si quieres compartir algo de tu teléfono con otro dispositivo, activa la sincronización en la configuración de Chrome en ambos dispositivos.</translation>
-<translation id="2170088579611075216">Permitir y acceder a la realidad virtual</translation>
-<translation id="218608176142494674">Compartir</translation>
-<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Servicios de Google y sincronización</translation>
-<translation id="2259659629660284697">Exportar contraseñas…</translation>
-<translation id="2268044343513325586">Restringir</translation>
-<translation id="2286841657746966508">Dirección de facturación</translation>
-<translation id="2289270750774289114">Preguntar cuando un sitio web quiera buscar dispositivos Bluetooth cercanos (recomendado)</translation>
-<translation id="230115972905494466">No se han podido encontrar dispositivos compatibles</translation>
-<translation id="2315043854645842844">El sistema operativo no admite la selección de certificados de cliente.</translation>
-<translation id="2318045970523081853">Toca para llamar</translation>
-<translation id="2321086116217818302">Preparando contraseñas…</translation>
-<translation id="2321958826496381788">Arrastra el control deslizante hasta que puedas leer cómodamente. El texto debe tener al menos este tamaño después de tocar un párrafo dos veces.</translation>
-<translation id="2323763861024343754">Almacenamiento del sitio web</translation>
-<translation id="2328985652426384049">No se puede iniciar sesión</translation>
-<translation id="2330129964253841015">Avisar si se vulneran tus contraseñas</translation>
-<translation id="2349710944427398404">Datos totales utilizados por Chrome, incluidos los marcadores, las cuentas y la configuración guardada</translation>
-<translation id="2353636109065292463">Comprobar tu conexión a Internet</translation>
-<translation id="2359808026110333948">Continuar</translation>
-<translation id="2369533728426058518">pestañas abiertas</translation>
-<translation id="2387895666653383613">Ajuste de texto</translation>
-<translation id="2394602618534698961">Los archivos que descargues aparecerán aquí</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Esta función se activará cuando inicies sesión en tu cuenta de Google</translation>
-<translation id="2410754283952462441">Elegir una cuenta</translation>
-<translation id="2414886740292270097">Oscuro</translation>
-<translation id="2416359993254398973">Chrome necesita permiso para acceder a la cámara en este sitio web.</translation>
-<translation id="2426805022920575512">Elegir otra cuenta</translation>
-<translation id="2433507940547922241">Aspecto</translation>
-<translation id="2434158240863470628">Descarga completa <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Acceso a la ubicación</translation>
-<translation id="2450083983707403292">¿Quieres empezar a descargar <ph name="FILE_NAME" /> de nuevo?</translation>
-<translation id="2482878487686419369">Notificaciones</translation>
-<translation id="2490684707762498678">Gestionadas por <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Asistente de Google</translation>
-<translation id="2496180316473517155">Historial de navegación</translation>
-<translation id="2497852260688568942">El administrador ha inhabilitado la sincronización</translation>
-<translation id="2498359688066513246">Ayuda y sugerencias</translation>
-<translation id="2501278716633472235">Volver</translation>
-<translation id="2513403576141822879">Para ver más opciones relacionadas con la privacidad, la seguridad y la recogida de datos, accede a <ph name="BEGIN_LINK" />Servicios de Google y sincronización<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">En el modo básico, Chrome carga las páginas más rápido y reduce el uso de datos hasta un 60 %. Chrome envía tu tráfico web a Google para optimizar las páginas que visitas. <ph name="BEGIN_LINK" />Más información<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Envía las URL de las páginas que visitas a Google</translation>
-<translation id="2532336938189706096">Vista web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> elementos eliminados</translation>
-<translation id="2536728043171574184">Viendo una copia sin conexión de esta página</translation>
-<translation id="2546283357679194313">Cookies y datos de sitios</translation>
-<translation id="2567385386134582609">IMAGEN</translation>
-<translation id="257088987046510401">Temas</translation>
-<translation id="2570922361219980984">El acceso a la ubicación también está desactivado en este dispositivo. Actívalo en los <ph name="BEGIN_LINK" />Ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Ampliado (hacer clic para contraer)</translation>
-<translation id="2581165646603367611">Se borrarán las cookies, la caché y otros datos de los sitios web que Chrome no considere importantes.</translation>
-<translation id="2586657967955657006">Portapapeles</translation>
-<translation id="2587052924345400782">Hay una nueva versión disponible</translation>
-<translation id="2593272815202181319">Monoespaciado</translation>
-<translation id="2612676031748830579">Número de la tarjeta</translation>
-<translation id="2621115761605608342">Habilita JavaScript en un sitio web específico.</translation>
-<translation id="2625189173221582860">Se ha copiado la contraseña</translation>
-<translation id="2631006050119455616">Ahorrados</translation>
-<translation id="2647434099613338025">Añadir idioma</translation>
-<translation id="2650751991977523696">¿Quieres descargar el archivo de nuevo?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# archivo de audio}other{# archivos de audio}}</translation>
-<translation id="2653659639078652383">Enviar</translation>
-<translation id="2677748264148917807">Salir</translation>
-<translation id="2704606927547763573">Copiado</translation>
-<translation id="2707726405694321444">Actualizar página</translation>
-<translation id="2709516037105925701">Autocompletar</translation>
-<translation id="2717722538473713889">Direcciones de correo electrónico</translation>
-<translation id="2728754400939377704">Ordenar por sitio web</translation>
-<translation id="2744248271121720757">Toca una palabra para buscarla de forma instantánea o ver acciones relacionadas</translation>
-<translation id="2760989362628427051">Habilita el tema oscuro cuando esté activado el tema oscuro del dispositivo o el dispositivo esté en modo de ahorro de batería</translation>
-<translation id="2762000892062317888">ahora mismo</translation>
-<translation id="2777555524387840389">Quedan <ph name="SECONDS" /> segundos</translation>
-<translation id="2779651927720337254">ha fallado</translation>
-<translation id="2781151931089541271">Queda 1 segundo</translation>
-<translation id="2801022321632964776">Actualiza para incluir tu idioma en la última versión de Chrome</translation>
-<translation id="2810645512293415242">Esta página se ha simplificado para ahorrar datos y poder cargarla más rápido.</translation>
-<translation id="281504910091592009">Consulta y gestiona las contraseñas guardadas en tu <ph name="BEGIN_LINK" />cuenta de Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Inicia sesión y activa la sincronización para ver tus marcadores en todos tus dispositivos</translation>
-<translation id="2822354292072154809">¿Seguro que quieres restablecer todos los permisos de los sitios web de <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Toca el botón de retroceso para salir de la pantalla completa.</translation>
-<translation id="2842985007712546952">Carpeta principal</translation>
-<translation id="2858138569776157458">Populares</translation>
-<translation id="2860954141821109167">Comprueba que se haya habilitado una aplicación de teléfono en este dispositivo</translation>
-<translation id="2870560284913253234">Sitio</translation>
-<translation id="2874939134665556319">Pista anterior</translation>
-<translation id="2876369937070532032">Envía a Google las URL de algunas de las páginas que visitas cuando tu seguridad corre peligro</translation>
-<translation id="2888126860611144412">Información de Chrome</translation>
-<translation id="2891154217021530873">Detener la carga de la página</translation>
-<translation id="2893180576842394309">Es posible que Google utilice tu historial para personalizar la Búsqueda y otros servicios de Google</translation>
-<translation id="2898264748040935573">Edita la contraseña almacenada</translation>
-<translation id="2900528713135656174">Crear evento</translation>
-<translation id="290376772003165898">¿La página no está en <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">La lista de dispositivos con los que puedes compartir una pestaña está abierta y ocupa toda la pantalla.</translation>
-<translation id="2910701580606108292">Preguntar antes de permitir que los sitios web reproduzcan contenido protegido</translation>
-<translation id="2913331724188855103">Permitir que los sitios guarden y lean datos de cookies (recomendado)</translation>
-<translation id="2923908459366352541">El nombre no es válido</translation>
-<translation id="2932150158123903946">Almacenamiento de Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">La pestaña de vista previa está cerrada</translation>
-<translation id="2956410042958133412">Esta cuenta está administrada por <ph name="PARENT_NAME_1" /> y <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Se ha cambiado a las pestañas de incógnito</translation>
-<translation id="2968755619301702150">Visor de certificados</translation>
-<translation id="2979025552038692506">Pestaña de incógnito seleccionada</translation>
-<translation id="2987620471460279764">Texto compartido desde otro dispositivo</translation>
-<translation id="2989523299700148168">Visitados recientemente</translation>
-<translation id="2996291259634659425">Crea una frase de contraseña</translation>
-<translation id="2996809686854298943">URL necesaria</translation>
-<translation id="300526633675317032">Se borrarán los <ph name="SIZE_IN_KB" /> de almacenamiento del sitio web.</translation>
-<translation id="3016635187733453316">Comprueba que este dispositivo esté conectado a Internet.</translation>
-<translation id="3029613699374795922">kB descargados: <ph name="KBS" /></translation>
-<translation id="3029704984691124060">Las frases de contraseña no coinciden</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Obtener ayuda<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">La ubicación está desactivada. Actívala en los <ph name="BEGIN_LINK" />Ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Puedes activar la sincronización en cualquier momento desde la configuración</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> marcador}other{<ph name="BOOKMARKS_COUNT_MANY" /> marcadores}}</translation>
-<translation id="3089395242580810162">Abrir en pestaña de incógnito</translation>
-<translation id="3115898365077584848">Mostrar información</translation>
-<translation id="3123473560110926937">Bloqueados en algunos sitios web</translation>
-<translation id="3137521801621304719">Salir del modo de incógnito</translation>
-<translation id="3143515551205905069">Cancelar sincronización</translation>
-<translation id="3157842584138209013">Consulta la cantidad de datos que has ahorrado con el botón Más opciones</translation>
-<translation id="3166827708714933426">Combinaciones de teclas de pestañas y ventanas</translation>
-<translation id="3181954750937456830">Navegación Segura (te protege a ti y a tu dispositivo frente a sitios web peligrosos)</translation>
-<translation id="3190152372525844641">Activa los permisos para Chrome en los <ph name="BEGIN_LINK" />ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> de datos almacenados</translation>
-<translation id="3205824638308738187">¡Ya falta poco!</translation>
-<translation id="3207960819495026254">Añadido a marcadores</translation>
-<translation id="3211426585530211793">Se ha eliminado <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Si has olvidado tu frase de contraseña o quieres cambiar esta opción, <ph name="BEGIN_LINK" />restablece la sincronización<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Micrófono</translation>
-<translation id="3232754137068452469">Aplicación web</translation>
-<translation id="3236059992281584593">Queda 1 minuto</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Añadir esta página a marcadores</translation>
-<translation id="3259831549858767975">Reduce todo el contenido de la página</translation>
-<translation id="3269093882174072735">Cargar imagen</translation>
-<translation id="3269956123044984603">Para ver las pestañas de tus otros dispositivos, activa la opción Sincronización automática en la configuración de la cuenta de Android.</translation>
-<translation id="3277252321222022663">Permitir que los sitios web accedan a los sensores (recomendado)</translation>
-<translation id="3282568296779691940">Iniciar sesión en Chrome</translation>
-<translation id="3288003805934695103">Volver a cargar la página</translation>
-<translation id="32895400574683172">Las notificaciones están permitidas</translation>
-<translation id="3295530008794733555">Navega más rápido. Usa menos datos.</translation>
-<translation id="3295602654194328831">Ocultar información</translation>
-<translation id="3298243779924642547">Básico</translation>
-<translation id="3303414029551471755">¿Quieres continuar para descargar el contenido?</translation>
-<translation id="3306398118552023113">Esta aplicación se está ejecutando en Chrome</translation>
-<translation id="3315103659806849044">En estos momentos estás personalizando los ajustes de los servicios de Google y sincronización. Para activar finalmente la sincronización, toca el botón Confirmar, que se encuentra casi al final de la pantalla. Desplázate hacia arriba</translation>
-<translation id="3328801116991980348">Información del sitio</translation>
-<translation id="3333961966071413176">Todos los contactos</translation>
-<translation id="3334729583274622784">¿Cambiar la extensión del archivo?</translation>
-<translation id="3341058695485821946">Consulta la cantidad de datos que has ahorrado</translation>
-<translation id="3350687908700087792">Cerrar todas las pestañas de incógnito</translation>
-<translation id="3353615205017136254">Página básica ofrecida por Google. Si quieres ver la original, toca el botón para cargarla.</translation>
-<translation id="3367813778245106622">Vuelve a iniciar sesión para que comience la sincronización</translation>
-<translation id="3374023511497244703">Tus marcadores, el historial, las contraseñas y otros datos de Chrome dejarán de sincronizarse con tu cuenta de Google</translation>
-<translation id="3384347053049321195">Compartir imagen</translation>
-<translation id="3386292677130313581">Preguntar antes de permitir que los sitios web detecten tu ubicación (recomendado)</translation>
-<translation id="3387650086002190359">No se ha podido descargar <ph name="FILE_NAME" /> debido a problemas con el sistema de archivos.</translation>
-<translation id="3389286852084373014">El texto es demasiado largo</translation>
-<translation id="3398320232533725830">Abre el administrador de marcadores</translation>
-<translation id="3414952576877147120">Tamaño:</translation>
-<translation id="3443221991560634068">Vuelve a cargar la página actual</translation>
-<translation id="3445014427084483498">Ahora mismo</translation>
-<translation id="3478363558367712427">Puedes elegir tu buscador</translation>
+<translation id="6910211073230771657">Eliminado</translation>
+<translation id="6965382102122355670">Aceptar</translation>
+<translation id="5301954838959518834">Entendido</translation>
+<translation id="7658239707568436148">Cancelar</translation>
 <translation id="3479552764303398839">Ahora no</translation>
-<translation id="3492207499832628349">Nueva pestaña de incógnito</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Más información<ph name="END_LINK" /> sobre el contenido sugerido</translation>
-<translation id="3513704683820682405">Realidad aumentada</translation>
-<translation id="3518985090088779359">Aceptar y continuar</translation>
-<translation id="3522247891732774234">Actualización disponible. Más opciones</translation>
-<translation id="3524138585025253783">Interfaz para desarrolladores</translation>
-<translation id="3527085408025491307">Carpeta</translation>
-<translation id="3542235761944717775">kB disponibles: <ph name="KILOBYTES" /></translation>
-<translation id="3549657413697417275">Buscar en el historial</translation>
-<translation id="3557336313807607643">Añadir a contactos</translation>
-<translation id="3566923219790363270">Chrome todavía se está preparando para la realidad virtual. Reinicia Chrome más tarde.</translation>
-<translation id="3568688522516854065">Inicia sesión y activa la sincronización para ver las pestañas de tus otros dispositivos</translation>
-<translation id="3587482841069643663">Todo</translation>
-<translation id="358794129225322306">Permitir que un sitio web descargue varios archivos automáticamente.</translation>
-<translation id="3590487821116122040">Almacenamiento del sitio web que Chrome no considera importante (p. ej., los sitios web sin configuración guardada o aquellos que no visitas a menudo)</translation>
-<translation id="3599863153486145794">Borra el historial de todos los dispositivos en los que hayas iniciado sesión. Es posible que tu cuenta de Google tenga otros tipos de historial de navegación en <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Silenciar los sitios web que reproducen sonidos</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Compartiendo con <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Mostrar contraseña</translation>
-<translation id="363596933471559332">Permite iniciar sesión automáticamente en sitios web con credenciales almacenadas. Si esta función está desactivada, se solicitará la verificación cada vez que se intente iniciar sesión en un sitio web.</translation>
-<translation id="3658159451045945436">Restablecerlo borra tu historial de ahorro de datos, incluidas las listas de los sitios web que has visitado.</translation>
-<translation id="3692944402865947621">No se ha podido descargar <ph name="FILE_NAME" /> porque no se puede acceder a la ubicación del almacenamiento.</translation>
-<translation id="3714981814255182093">Abre la barra de búsqueda</translation>
-<translation id="3716182511346448902">Esta página utiliza demasiada memoria y Chrome la ha pausado.</translation>
-<translation id="3730075448226062617">Para que Chrome pueda acceder a tu micrófono, activa el micrófono en los <ph name="BEGIN_LINK" />ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Marcador añadido a <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sincronización en segundo plano</translation>
-<translation id="3771001275138982843">No se ha podido descargar la actualización</translation>
-<translation id="3771033907050503522">Pestañas incógnito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Activa el Bluetooth<ph name="END_LINK" /> para permitir la vinculación</translation>
-<translation id="3775705724665058594">Enviar a tus dispositivos</translation>
-<translation id="3778956594442850293">Se ha añadido a la pantalla de inicio</translation>
-<translation id="3789841737615482174">Instalar</translation>
-<translation id="3810838688059735925">Vídeo</translation>
-<translation id="3810973564298564668">Gestionar</translation>
-<translation id="381841723434055211">Números de teléfono</translation>
-<translation id="3819178904835489326">Descargas eliminadas: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">¿Borrar almacenamiento web?</translation>
-<translation id="385051799172605136">Atrás</translation>
-<translation id="3859306556332390985">Buscar hacia delante</translation>
-<translation id="3894427358181296146">Añadir carpeta</translation>
-<translation id="3895926599014793903">Forzar zoom</translation>
-<translation id="3912508018559818924">Buscando lo mejor de la Web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combinar mis datos</translation>
-<translation id="393697183122708255">La búsqueda por voz no está disponible</translation>
-<translation id="395206256282351086">Sugerencias de sitios web y búsqueda inhabilitadas</translation>
-<translation id="3955193568934677022">Permitir que los sitios web reproduzcan contenido protegido (recomendado)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome cargará la página cuando el dispositivo esté listo}other{Chrome cargará las páginas cuando el dispositivo esté listo}}</translation>
-<translation id="3963007978381181125">El cifrado mediante frase de contraseña no incluye los métodos de pago ni las direcciones de Google Pay. Solo alguien que tenga tu frase de contraseña puede leer tus datos cifrados. La frase de contraseña no se envía a Google, que tampoco la guarda. Si la olvidas o quieres cambiar esta opción, debes restablecer la sincronización. <ph name="BEGIN_LINK" />Más información<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Descarga completa</translation>
-<translation id="397583555483684758">La sincronización ha dejado de funcionar</translation>
-<translation id="3976396876660209797">Quita esta combinación de teclas y vuelve a crearla</translation>
-<translation id="3985215325736559418">¿Quieres volver a descargar el archivo <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Copiar enlace</translation>
-<translation id="3988213473815854515">Se permite la ubicación</translation>
-<translation id="3988466920954086464">Ver resultados de búsqueda instantánea en este panel</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Almacenamiento no importante</translation>
-<translation id="4000212216660919741">Página principal del modo sin conexión</translation>
+<translation id="5317780077021120954">Guardar</translation>
+<translation id="4570913071927164677">Detalles</translation>
+<translation id="8730621377337864115">Listo</translation>
+<translation id="8261506727792406068">Eliminar</translation>
+<translation id="1181037720776840403">Quitar</translation>
+<translation id="5939518447894949180">Restablecer</translation>
 <translation id="4002066346123236978">Título</translation>
-<translation id="4008040567710660924">Permitir cookies en un sitio web específico.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Pista siguiente</translation>
-<translation id="4048707525896921369">Obtén información sobre los temas que aparecen en los sitios web sin salir de la página. La función Tocar para buscar envía una palabra y el contexto que la rodea a la Búsqueda de Google y te muestra definiciones, imágenes, resultados de búsqueda y más información.
+<translation id="5916664084637901428">Activado</translation>
+<translation id="5860033963881614850">Desactivado</translation>
+<translation id="6165508094623778733">Más información</translation>
+<translation id="6042308850641462728">Más</translation>
+<translation id="6040143037577758943">Cerrar</translation>
+<translation id="780301667611848630">No, gracias</translation>
+<translation id="1201402288615127009">Siguiente</translation>
+<translation id="2359808026110333948">Continuar</translation>
+<translation id="2653659639078652383">Enviar</translation>
+<translation id="2079545284768500474">Deshacer</translation>
+<translation id="7649070708921625228">Ayuda</translation>
+<translation id="2148716181193084225">Hoy</translation>
+<translation id="7781829728241885113">Ayer</translation>
+<translation id="6945221475159498467">Seleccionar</translation>
+<translation id="7791543448312431591">Añadir</translation>
+<translation id="6527303717912515753">Compartir</translation>
+<translation id="1383876407941801731">Buscar</translation>
+<translation id="3115898365077584848">Mostrar información</translation>
+<translation id="3295602654194328831">Ocultar información</translation>
+<translation id="3987993985790029246">Copiar enlace</translation>
+<translation id="2704606927547763573">Copiado</translation>
+<translation id="8725066075913043281">Volver a intentarlo</translation>
+<translation id="385051799172605136">Atrás</translation>
+<translation id="8131740175452115882">Confirmar</translation>
+<translation id="5300589172476337783">Mostrar</translation>
+<translation id="1124772482545689468">Usuario</translation>
+<translation id="8609465669617005112">Subir</translation>
+<translation id="6746124502594467657">Bajar</translation>
+<translation id="8249310407154411074">Mover al principio</translation>
+<translation id="8428213095426709021">Configuración</translation>
+<translation id="2498359688066513246">Ayuda y sugerencias</translation>
+<translation id="8378714024927312812">Gestionado por tu organización</translation>
+<translation id="9019902583201351841">Administrado por tus padres</translation>
+<translation id="4645575059429386691">Administrado por uno de tus padres</translation>
+<translation id="4883854917563148705">No se pueden restablecer los ajustes gestionados</translation>
+<translation id="4307992518367153382">Configuración básica</translation>
+<translation id="1974060860693918893">Configuración avanzada</translation>
+<translation id="1146678959555564648">Iniciar RV</translation>
+<translation id="987264212798334818">General</translation>
+<translation id="4275663329226226506">Multimedia</translation>
+<translation id="4759238208242260848">Descargas</translation>
+<translation id="218608176142494674">Compartir</translation>
+<translation id="8004582292198964060">Navegador</translation>
+<translation id="1105960400813249514">Captura de pantalla</translation>
+<translation id="4875775213178255010">Sugerencias de contenido</translation>
+<translation id="2021896219286479412">Controles de pantalla completa</translation>
+<translation id="4587589328781138893">Sitios web</translation>
+<translation id="4943703118917034429">Realidad virtual</translation>
+<translation id="1928696683969751773">Actualizaciones</translation>
+<translation id="6064125863973209585">Descargas completadas</translation>
+<translation id="5342314432463739672">Solicitudes de permiso</translation>
+<translation id="629730747756840877">Cuenta</translation>
+<translation id="82609232232243542">Iniciar sesión en Brave</translation>
+<translation id="7956662517480676674">Servicios de Brave Software y sincronización</translation>
+<translation id="5294439808117722387">En estos momentos estás personalizando los ajustes de los servicios de Brave Software y sincronización. Para activar finalmente la sincronización, toca el botón Confirmar, que se encuentra casi al final de la pantalla. Desplázate hacia arriba</translation>
+<translation id="2096012225669085171">Sincroniza y personaliza todos tus dispositivos</translation>
+<translation id="1692118695553449118">La sincronización está activada</translation>
+<translation id="5514904542973294328">Inhabilitada por el administrador de este dispositivo</translation>
+<translation id="6447211988989208781">Controles de actividad de Brave Software</translation>
+<translation id="4882831918239250449">Controlar cómo se utiliza el historial de navegación para personalizar la Búsqueda, los anuncios y mucho más</translation>
+<translation id="7431991332293347422">Controlar cómo se utiliza el historial de navegación para personalizar la Búsqueda y otras opciones</translation>
+<translation id="6303969859164067831">Cerrar sesión y desactivar la sincronización</translation>
+<translation id="1125261911132334651">Gestionar tu cuenta de Brave Software</translation>
+<translation id="6406506848690869874">Sincronización</translation>
+<translation id="714362445477979774">Sincronizar tus datos de Brave</translation>
+<translation id="4314815835985389558">Gestionar la sincronización</translation>
+<translation id="5428209950370661546">Otros servicios de Brave Software</translation>
+<translation id="7704317875155739195">Autocompletar búsquedas y URLs</translation>
+<translation id="2000419248597011803">Envía algunas cookies y búsquedas de la barra de direcciones y del cuadro de búsqueda a tu buscador predeterminado</translation>
+<translation id="7981313251711023384">Cargar previamente las páginas para que la navegación y las búsquedas sean más rápidas</translation>
+<translation id="1821253160463689938">Usa cookies para recordar tus preferencias aunque no visites esas páginas</translation>
+<translation id="6697492270171225480">Mostrar sugerencias de páginas similares cuando no se encuentre una página</translation>
+<translation id="8109318360573330108">Envía a Brave Software la URL de una página a la que intentas acceder</translation>
+<translation id="8438566539970814960">Mejorar las búsquedas y la navegación</translation>
+<translation id="284843628681142937">Envía las URL de las páginas que visitas a Brave Software</translation>
+<translation id="7222718784508482526">Para ver más opciones relacionadas con la privacidad, la seguridad y la recogida de datos, accede a <ph name="BEGIN_LINK"/>Servicios de Brave Software y sincronización<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Ayudar a mejorar las funciones y el rendimiento de Brave</translation>
+<translation id="9063160602596686558">Envía automáticamente estadísticas de uso e informes sobre fallos a Brave Software</translation>
+<translation id="4824958205181053313">¿Quieres cancelar la sincronización?</translation>
+<translation id="3058498974290601450">Puedes activar la sincronización en cualquier momento desde la configuración</translation>
+<translation id="3143515551205905069">Cancelar sincronización</translation>
+<translation id="1506061864768559482">Buscador</translation>
+<translation id="55737423895878184">Las notificaciones y la ubicación están permitidas</translation>
+<translation id="3988213473815854515">Se permite la ubicación</translation>
+<translation id="32895400574683172">Las notificaciones están permitidas</translation>
+<translation id="9040142327097499898">Las notificaciones están permitidas. La ubicación está desactivada en este dispositivo.</translation>
+<translation id="305593374596241526">La ubicación está desactivada. Actívala en los <ph name="BEGIN_LINK"/>Ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Visitados recientemente</translation>
+<translation id="6433501201775827830">Elegir tu motor de búsqueda</translation>
+<translation id="7177466738963138057">Puedes cambiar esta opción más tarde en Configuración</translation>
+<translation id="3478363558367712427">Puedes elegir tu buscador</translation>
+<translation id="4910889077668685004">Aplicaciones para pagar</translation>
+<translation id="5152843274749979095">No hay aplicaciones compatibles instaladas</translation>
+<translation id="8812260976093120287">En algunos sitios web, puedes realizar pagos en tu dispositivo con las aplicaciones compatibles mencionadas anteriormente.</translation>
+<translation id="7764225426217299476">Añadir dirección</translation>
+<translation id="5595485650161345191">Editar dirección</translation>
+<translation id="5087580092889165836">Añadir tarjeta</translation>
+<translation id="2154484045852737596">Editar tarjeta</translation>
+<translation id="6140912465461743537">País/región</translation>
+<translation id="5659593005791499971">Correo electrónico</translation>
+<translation id="4378154925671717803">Teléfono</translation>
+<translation id="4807098396393229769">Titular de la tarjeta</translation>
+<translation id="860043288473659153">Nombre del titular de la tarjeta</translation>
+<translation id="2612676031748830579">Número de la tarjeta</translation>
+<translation id="869891660844655955">Fecha de caducidad</translation>
+<translation id="2286841657746966508">Dirección de facturación</translation>
+<translation id="663059986967017181">Copiada a Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> más}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> más}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> más}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> más}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> más}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> más}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> más}other{<ph name="CONTACT_PREVIEW"/>\u2026 y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> más}}</translation>
+<translation id="7029809446516969842">Contraseñas</translation>
+<translation id="1943432128510653496">Guardar contraseñas</translation>
+<translation id="2100273922101894616">Iniciar sesión automáticamente</translation>
+<translation id="363596933471559332">Permite iniciar sesión automáticamente en sitios web con credenciales almacenadas. Si esta función está desactivada, se solicitará la verificación cada vez que se intente iniciar sesión en un sitio web.</translation>
+<translation id="6995899638241819463">Avisar si tus contraseñas se ven expuestas en una quiebra de seguridad de datos</translation>
+<translation id="1534287762301776620">Esta función se activará cuando inicies sesión en tu cuenta de Brave Software</translation>
+<translation id="10614374240317010">Contraseñas que nunca se guardan</translation>
+<translation id="3098842761938485917">Consulta y gestiona las contraseñas guardadas en tu <ph name="BEGIN_LINK"/>cuenta de Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Las contraseñas guardadas aparecerán aquí.</translation>
+<translation id="8084114998886531721">Contraseña guardada</translation>
+<translation id="2870560284913253234">Sitio</translation>
+<translation id="8503813439785031346">Nombre de usuario</translation>
+<translation id="6657585470893396449">Contraseña</translation>
+<translation id="2154710561487035718">Copiar URL</translation>
+<translation id="1571304935088121812">Copiar nombre de usuario</translation>
+<translation id="5005498671520578047">Copiar contraseña</translation>
+<translation id="3632295766818638029">Mostrar contraseña</translation>
+<translation id="1513858653616922153">Eliminar contraseña</translation>
+<translation id="543338862236136125">Cambiar contraseña</translation>
+<translation id="4565377596337484307">Ocultar contraseña</translation>
+<translation id="8523928698583292556">Eliminar contraseña guardada</translation>
+<translation id="2898264748040935573">Edita la contraseña almacenada</translation>
+<translation id="5433691172869980887">Se ha copiado el nombre de usuario</translation>
+<translation id="5534640966246046842">Se ha copiado el sitio web</translation>
+<translation id="2625189173221582860">Se ha copiado la contraseña</translation>
+<translation id="4550003330909367850">Para ver o copiar tu contraseña aquí, configura el bloqueo de pantalla en este dispositivo.</translation>
+<translation id="6154478581116148741">Activa el bloqueo de pantalla en Configuración para exportar las contraseñas de este dispositivo</translation>
+<translation id="4842092870884894799">Mostrando la ventana emergente de generación de contraseña</translation>
+<translation id="2259659629660284697">Exportar contraseñas…</translation>
+<translation id="133012818630824069">Exportar contraseñas almacenadas en Brave</translation>
+<translation id="6914783257214138813">Cualquier usuario que pueda ver el archivo exportado podrá ver tus contraseñas.</translation>
+<translation id="2321086116217818302">Preparando contraseñas…</translation>
+<translation id="8445448999790540984">No se pueden exportar las contraseñas</translation>
+<translation id="3066461326500799725">Más información sobre cómo usar Brave Software Drive</translation>
+<translation id="729975465115245577">Tu dispositivo no tiene ninguna aplicación para almacenar el archivo de contraseñas.</translation>
+<translation id="7682724950699840886">Prueba los siguientes consejos: deja suficiente espacio en el dispositivo y vuelve a exportar las contraseñas.</translation>
+<translation id="1129510026454351943">Detalles: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Desbloquea la pantalla para copiar tu contraseña</translation>
+<translation id="5515439363601853141">Desbloquea la pantalla para ver tu contraseña</translation>
+<translation id="6221633008163990886">Desbloquea el dispositivo para exportar las contraseñas</translation>
+<translation id="230699814587342492">Contraseñas de Brave</translation>
+<translation id="6075798973483050474">Editar página principal</translation>
+<translation id="854522910157234410">Abrir esta página</translation>
+<translation id="2482878487686419369">Notificaciones</translation>
+<translation id="6255999984061454636">Sugerencias de contenido</translation>
+<translation id="805047784848435650">Según tu historial de navegación</translation>
+<translation id="1041308826830691739">De sitios web</translation>
+<translation id="395206256282351086">Sugerencias de sitios web y búsqueda inhabilitadas</translation>
+<translation id="257088987046510401">Temas</translation>
+<translation id="4650364565596261010">Predeterminado del sistema</translation>
+<translation id="7588219262685291874">Activar el tema oscuro cuando el dispositivo esté en modo de ahorro de batería</translation>
+<translation id="2760989362628427051">Habilita el tema oscuro cuando esté activado el tema oscuro del dispositivo o el dispositivo esté en modo de ahorro de batería</translation>
+<translation id="6381421346744604172">Oscurecer sitios web</translation>
+<translation id="5040262127954254034">Privacidad</translation>
+<translation id="4991384657077828949">Ayudar a mejorar la seguridad de Brave</translation>
+<translation id="1943176487615318915">Para detectar aplicaciones y sitios web peligrosos, Brave envía a Brave Software las URL de algunas de las páginas que visitas, información limitada del sistema y parte del contenido de las páginas.</translation>
+<translation id="3181954750937456830">Navegación Segura (te protege a ti y a tu dispositivo frente a sitios web peligrosos)</translation>
+<translation id="7315322926489145388">Envía a Brave Software las URL de algunas de las páginas que visitas cuando tu seguridad corre peligro</translation>
+<translation id="2063713494490388661">Tocar para buscar</translation>
+<translation id="2369463299479365221">Obtén información sobre los temas que aparecen en los sitios web sin salir de la página. La función Tocar para buscar envía una palabra y el contexto que la rodea a la Búsqueda de Brave Software y te muestra definiciones, imágenes, resultados de búsqueda y más información.
 
 Para ajustar el término de búsqueda, mantén pulsado el texto para seleccionarlo. Para restringir la búsqueda, desliza el panel hasta arriba y toca el cuadro de búsqueda.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Opciones disponibles junto a la parte superior de la pantalla</translation>
-<translation id="4062305924942672200">Información legal</translation>
-<translation id="4084682180776658562">Añadir a marcadores</translation>
-<translation id="4084712963632273211">De <ph name="PUBLISHER_ORIGIN" /> (<ph name="BEGIN_DEEMPHASIZED" />ofrecida por Google<ph name="END_DEEMPHASIZED" />)</translation>
-<translation id="4095146165863963773">¿Eliminar datos de la aplicación?</translation>
-<translation id="4099578267706723511">Ayudar a mejorar Chrome enviando estadísticas de uso e informes sobre fallos.</translation>
-<translation id="410351446219883937">Reproducción automática</translation>
-<translation id="4116038641877404294">Descarga páginas para usarlas sin conexión</translation>
-<translation id="4135200667068010335">La lista de dispositivos con los que puedes compartir una pestaña está cerrada.</translation>
-<translation id="4149994727733219643">Vista simplificada de páginas web</translation>
-<translation id="4165986682804962316">Configuración del sitio web</translation>
-<translation id="4169535189173047238">No permitir</translation>
-<translation id="4170011742729630528">El servicio no está disponible. Vuelve a intentarlo más tarde.</translation>
-<translation id="4179980317383591987">Usados: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Idiomas</translation>
-<translation id="4183868528246477015">Buscar con Google Lens <ph name="BEGIN_NEW" />Nuevo<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Abrir en una pestaña nueva</translation>
-<translation id="4198423547019359126">No hay ubicaciones de descarga disponibles</translation>
-<translation id="4209895695669353772">Activa la sincronización para obtener contenido personalizado sugerido por Google</translation>
-<translation id="4226663524361240545">Es posible que las notificaciones hagan que el dispositivo vibre</translation>
-<translation id="423219824432660969">Cifrar los datos sincronizados con la contraseña de Google desde el <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Abrir Configuración</translation>
-<translation id="4256782883801055595">Licencias de código abierto</translation>
-<translation id="4259722352634471385">Se ha bloqueado la navegación: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copiar la dirección del enlace</translation>
-<translation id="4275663329226226506">Multimedia</translation>
-<translation id="4278390842282768270">Permitido</translation>
-<translation id="429312253194641664">Un sitio web está reproduciendo elementos multimedia</translation>
-<translation id="4298388696830689168">Sitios web enlazados</translation>
-<translation id="4307992518367153382">Configuración básica</translation>
-<translation id="4314815835985389558">Gestionar la sincronización</translation>
-<translation id="4351244548802238354">Cerrar cuadro de diálogo</translation>
-<translation id="4378154925671717803">Teléfono</translation>
-<translation id="4384468725000734951">Sogou se ha establecido como motor de búsqueda predeterminado</translation>
-<translation id="4404568932422911380">Sin marcadores</translation>
-<translation id="4405224443901389797">Mover a…</translation>
-<translation id="4411535500181276704">Modo básico</translation>
-<translation id="4415276339145661267">Gestionar tu cuenta de Google</translation>
-<translation id="4432792777822557199">Las páginas en <ph name="SOURCE_LANGUAGE" /> se traducirán al <ph name="TARGET_LANGUAGE" /> a partir de ahora</translation>
-<translation id="4433925000917964731">Página básica ofrecida por Google</translation>
-<translation id="4434045419905280838">Ventanas emergentes y redirecciones</translation>
-<translation id="4440958355523780886">Página básica ofrecida por Google. Toca para cargar la original.</translation>
-<translation id="4452411734226507615">Cerrar la pestaña <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Marcador añadido a <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Permitir que los sitios web reproduzcan contenido protegido</translation>
-<translation id="4468959413250150279">Silencia el sonido de un sitio web específico.</translation>
-<translation id="4472118726404937099">Inicia sesión y activa la sincronización para sincronizar y personalizar todos tus dispositivos</translation>
-<translation id="447252321002412580">Ayudar a mejorar las funciones y el rendimiento de Chrome</translation>
-<translation id="4479647676395637221">Preguntar antes de permitir que los sitios web utilicen la cámara (recomendado)</translation>
-<translation id="4479972344484327217">Instalando <ph name="MODULE" /> para Chrome…</translation>
-<translation id="4487967297491345095">Todos los datos de la aplicación Chrome se eliminarán de forma permanente. Esto incluye todos los archivos, ajustes, cuentas, bases de datos, etc.</translation>
-<translation id="4493497663118223949">El modo básico está activado</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Hace # día}other{Hace # días}}</translation>
-<translation id="451872707440238414">Buscar en tus marcadores</translation>
-<translation id="4521489764227272523">Los datos seleccionados se han quitado de Chrome y de los dispositivos sincronizados.
-
-Es posible que tu cuenta de Google tenga otros tipos de historial de navegación, como búsquedas o actividad de otros servicios de Google, en la página <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Seleccionar carpeta</translation>
-<translation id="4538018662093857852">Activar el modo básico</translation>
-<translation id="4550003330909367850">Para ver o copiar tu contraseña aquí, configura el bloqueo de pantalla en este dispositivo.</translation>
-<translation id="4558311620361989323">Combinaciones de teclas en páginas web</translation>
-<translation id="4561979708150884304">Sin conexión</translation>
-<translation id="4565377596337484307">Ocultar contraseña</translation>
-<translation id="4570913071927164677">Detalles</translation>
-<translation id="4572422548854449519">Inicia sesión en la cuenta gestionada</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Hace # minuto}other{Hace # minutos}}</translation>
-<translation id="4587589328781138893">Sitios web</translation>
-<translation id="4594952190837476234">Esta página sin conexión se creó el <ph name="CREATION_TIME" /> y puede ser distinta de la versión online.</translation>
-<translation id="4605958867780575332">Elemento retirado: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Utilizar contraseña</translation>
-<translation id="4645575059429386691">Administrado por uno de tus padres</translation>
-<translation id="4650364565596261010">Predeterminado del sistema</translation>
-<translation id="4663756553811254707">Se han eliminado <ph name="NUMBER_OF_BOOKMARKS" /> marcadores</translation>
-<translation id="4665282149850138822">Se ha añadido <ph name="NAME" /> a la pantalla de inicio</translation>
-<translation id="4684427112815847243">Sincronizar todo</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> más}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> más}}</translation>
-<translation id="4696983787092045100">Enviar mensaje de texto a tus dispositivos</translation>
-<translation id="4698034686595694889">Ver sin conexión en <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Archivos e imágenes almacenados en caché</translation>
-<translation id="4714588616299687897">Ahorra hasta un 60% de tus datos</translation>
-<translation id="4719927025381752090">Ofrecer la traducción</translation>
-<translation id="4720023427747327413">Abrir en <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136"><ph name="BEGIN_LINK" />Realiza la encuesta<ph name="END_LINK" /> para ayudar a mejorar Chrome</translation>
-<translation id="473775607612524610">Actualizar</translation>
-<translation id="4738836084190194332">Última sincronización: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Abre una pestaña nueva</translation>
-<translation id="4751476147751820511">Sensores de luz o movimiento</translation>
-<translation id="4759238208242260848">Descargas</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Se ha completado 1 descarga.}other{Se han completado # descargas.}}</translation>
-<translation id="4797039098279997504">Toca para volver a <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">El cifrado mediante frase de contraseña no incluye los métodos de pago ni las direcciones de Google Pay.
-
-Para cambiar esta opción, <ph name="BEGIN_LINK" />restablece la sincronización<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Titular de la tarjeta</translation>
-<translation id="4824958205181053313">¿Quieres cancelar la sincronización?</translation>
-<translation id="4837753911714442426">Abre las opciones para imprimir la página</translation>
-<translation id="4842092870884894799">Mostrando la ventana emergente de generación de contraseña</translation>
-<translation id="4860895144060829044">Llamar</translation>
-<translation id="4866368707455379617">No se puede instalar <ph name="MODULE" /> para Chrome</translation>
-<translation id="4875775213178255010">Sugerencias de contenido</translation>
-<translation id="4878404682131129617">No se ha podido establecer conexión a través del servidor proxy</translation>
-<translation id="4880127995492972015">Traducir…</translation>
-<translation id="4881695831933465202">Abrir</translation>
-<translation id="488187801263602086">Cambiar nombre de archivo</translation>
-<translation id="4882831918239250449">Controlar cómo se utiliza el historial de navegación para personalizar la Búsqueda, los anuncios y mucho más</translation>
-<translation id="4883854917563148705">No se pueden restablecer los ajustes gestionados</translation>
-<translation id="4885273946141277891">Número de instancias de Chrome no admitido.</translation>
-<translation id="4910889077668685004">Aplicaciones para pagar</translation>
-<translation id="4913161338056004800">Borrar estadísticas</translation>
-<translation id="4913169188695071480">Dejar de actualizar</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Obtener ayuda<ph name="END_LINK" /> mientras se buscan dispositivos…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}other{# páginas}}</translation>
-<translation id="4932247056774066048">Estás cerrando sesión de una cuenta gestionada por <ph name="DOMAIN_NAME" />, por lo que tus datos de Chrome se eliminarán de este dispositivo. Sin embargo, permanecerán en tu cuenta de Google.</translation>
-<translation id="4943703118917034429">Realidad virtual</translation>
-<translation id="4943872375798546930">Sin resultados</translation>
-<translation id="4958708863221495346">Estás compartiendo tu pantalla a través de <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4961107849584082341">Traduce esta página a cualquier idioma</translation>
-<translation id="4962975101802056554">Revocar todos los permisos de este dispositivo</translation>
-<translation id="4970824347203572753">No está disponible en tu ubicación</translation>
-<translation id="497421865427891073">Avanzar</translation>
-<translation id="4988210275050210843">Descargando archivo (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Páginas</translation>
-<translation id="4994033804516042629">No se han encontrado contactos</translation>
-<translation id="4996978546172906250">Compartir a través de</translation>
-<translation id="5004416275253351869">Controles de actividad de Google</translation>
-<translation id="5005498671520578047">Copiar contraseña</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> quiere conectarse</translation>
-<translation id="5013696553129441713">No hay sugerencias nuevas</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Mientras estés en el modo de realidad virtual, es posible que el sitio web obtenga información sobre lo siguiente:
-  - Tus características físicas, como tu altura.
-
-Asegúrate de que este sitio web sea de confianza antes de acceder al modo de realidad virtual.</translation>
+<translation id="2930742481329940825">La función Tocar para buscar envía la palabra seleccionada y la página actual como contexto a la Búsqueda de Brave Software. Puedes desactivarla en <ph name="BEGIN_LINK"/>Configuración<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Permitir</translation>
-<translation id="5040262127954254034">Privacidad</translation>
-<translation id="5048398596102334565">Permitir que los sitios web accedan a los sensores de movimiento (recomendado)</translation>
-<translation id="5063480226653192405">Uso</translation>
-<translation id="5087580092889165836">Añadir tarjeta</translation>
-<translation id="5100237604440890931">Contraído (hacer clic para ampliar)</translation>
-<translation id="510275257476243843">Queda 1 hora</translation>
-<translation id="5123685120097942451">Pestaña de incógnito</translation>
-<translation id="5127805178023152808">La sincronización está desactivada</translation>
-<translation id="5129038482087801250">Instalar aplicación web</translation>
-<translation id="5132942445612118989">Sincroniza tus contraseñas, tu historial y otras opciones en todos tus dispositivos</translation>
-<translation id="5139940364318403933">Más información sobre cómo usar Google Drive</translation>
-<translation id="515227803646670480">Borrar datos almacenados</translation>
-<translation id="5152843274749979095">No hay aplicaciones compatibles instaladas</translation>
-<translation id="5161254044473106830">Título obligatorio</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{No se ha podido completar 1 descarga.}other{No se han podido completar # descargas.}}</translation>
-<translation id="5170568018924773124">Mostrar en carpeta</translation>
-<translation id="5184329579814168207">Abrir en Chrome</translation>
-<translation id="5193988420012215838">Se ha copiado al portapapeles</translation>
-<translation id="5197729504361054390">Los contactos que selecciones se compartirán con el sitio web <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Perfil de trabajo</translation>
-<translation id="5210286577605176222">Te dirige a la pestaña anterior</translation>
-<translation id="5210365745912300556">Cerrar pestaña</translation>
-<translation id="5224771365102442243">Con vídeo</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> quiere buscar dispositivos Bluetooth cercanos. Se han encontrado los siguientes dispositivos:</translation>
-<translation id="5233638681132016545">Nueva pestaña</translation>
-<translation id="526421993248218238">No puede cargar esta página web</translation>
-<translation id="5271967389191913893">El dispositivo no puede abrir el contenido para descargarlo.</translation>
-<translation id="528192093759286357">Arrastra el dedo desde la parte superior y toca el botón de retroceso para salir de la pantalla completa.</translation>
-<translation id="5292796745632149097">Enviar a</translation>
-<translation id="5300589172476337783">Mostrar</translation>
-<translation id="5301954838959518834">Entendido</translation>
-<translation id="5304593522240415983">Este campo no puede estar vacío</translation>
-<translation id="5307446750509046227">Liberar espacio</translation>
-<translation id="5308380583665731573">Conectar</translation>
-<translation id="5313967007315987356">Añadir sitio</translation>
-<translation id="5317780077021120954">Guardar</translation>
-<translation id="5324858694974489420">Configuración parental</translation>
-<translation id="5327248766486351172">Nombre</translation>
-<translation id="5335288049665977812">Permitir que los sitios web utilicen JavaScript (recomendado)</translation>
-<translation id="5342314432463739672">Solicitudes de permiso</translation>
-<translation id="5357811892247919462">Pestaña recibida</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> pestaña abierta, toca para cambiar de una a otra}other{<ph name="OPEN_TABS_MANY" /> pestañas abiertas, toca para cambiar de una a otra}}</translation>
-<translation id="5391532827096253100">Tu conexión a este sitio web no es segura. Información del sitio web</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(y 1 más)}other{(y # más)}}</translation>
-<translation id="5400569084694353794">Al utilizar esta aplicación, aceptas los <ph name="BEGIN_LINK1" />Términos del Servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />Aviso de Privacidad<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="5403592356182871684">Nombres</translation>
-<translation id="5403644198645076998">Permitir solo determinados sitios web</translation>
-<translation id="5414836363063783498">Verificando…</translation>
-<translation id="5423934151118863508">Aquí aparecerán las páginas a las que accedes con más frecuencia</translation>
-<translation id="5424588387303617268">Disponibilidad: <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Cambiar contraseña</translation>
-<translation id="5433691172869980887">Se ha copiado el nombre de usuario</translation>
-<translation id="543509235395288790">Descargando <ph name="COUNT" /> archivos (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Te dirige a la barra de direcciones</translation>
-<translation id="5447201525962359567">Todo el almacenamiento del sitio web, como las cookies y otros datos almacenados de forma local</translation>
-<translation id="5447765697759493033">Este sitio web no va a traducirse</translation>
-<translation id="545042621069398927">Acelerando descarga.</translation>
-<translation id="5456381639095306749">Descargar página</translation>
-<translation id="5475862044948910901">¿Quieres iniciar la sesión de realidad aumentada?</translation>
-<translation id="548278423535722844">Abrirla en una aplicación de mapas</translation>
-<translation id="5487521232677179737">Borrar datos</translation>
-<translation id="5494752089476963479">Bloquea anuncios invasivos o engañosos en los sitios web que los muestran</translation>
-<translation id="5500777121964041360">Puede que no esté disponible en tu ubicación</translation>
-<translation id="5512137114520586844">Esta cuenta está administrada por <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Inhabilitada por el administrador de este dispositivo</translation>
-<translation id="5515439363601853141">Desbloquea la pantalla para ver tu contraseña</translation>
-<translation id="5516455585884385570">Abrir ajustes de notificaciones</translation>
-<translation id="5517095782334947753">Tienes los marcadores, el historial, las contraseñas y otras opciones de configuración de <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Redirección bloqueada.</translation>
-<translation id="5527082711130173040">Chrome necesita acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK1" />Actualizar permisos<ph name="END_LINK1" />. El acceso a la ubicación también está <ph name="BEGIN_LINK2" />desactivado en este dispositivo<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Preguntar antes de permitir que los sitios web lean texto e imágenes del portapapeles (recomendado)</translation>
-<translation id="5530766185686772672">Cerrar pestañas de incógnito</translation>
-<translation id="5534334044554683961">Mientras estés en el modo de realidad virtual, es posible que el sitio web obtenga información sobre lo siguiente:
-  - Tus características físicas, como tu altura.
-  - La disposición de la habitación.
-
-Asegúrate de que este sitio web sea de confianza antes de acceder al modo de realidad virtual.</translation>
-<translation id="5534640966246046842">Se ha copiado el sitio web</translation>
-<translation id="5556459405103347317">Volver a cargar</translation>
-<translation id="5561549206367097665">Esperando red…</translation>
-<translation id="557283862590186398">Chrome necesita permiso para acceder al micrófono en este sitio web.</translation>
-<translation id="55737423895878184">Las notificaciones y la ubicación están permitidas</translation>
-<translation id="5578795271662203820">Buscar esta imagen en <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Siempre puedes seleccionar qué contenido quieres sincronizar desde <ph name="BEGIN_LINK1" />Ajustes<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Editar dirección</translation>
-<translation id="5596627076506792578">Más opciones</translation>
-<translation id="5599455543593328020">Modo de incógnito</translation>
-<translation id="5620928963363755975">Encuentra tus archivos y páginas en la sección Descargas con el botón Más opciones</translation>
-<translation id="5626134646977739690">Nombre:</translation>
-<translation id="5639724618331995626">Permitir todos los sitios web</translation>
-<translation id="5648166631817621825">Últimos 7 días</translation>
-<translation id="5649053991847567735">Descargas automáticas</translation>
-<translation id="5655963694829536461">Busca en las descargas</translation>
-<translation id="5659593005791499971">Correo electrónico</translation>
-<translation id="5665379678064389456">Crear evento en <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ignorar la solicitud de un sitio web para no ampliar la imagen</translation>
-<translation id="5677928146339483299">Bloqueado</translation>
-<translation id="5684874026226664614">¡Vaya! No se ha podido traducir esta página.</translation>
-<translation id="5686790454216892815">El nombre del archivo es demasiado largo</translation>
-<translation id="5689516760719285838">Ubicación</translation>
-<translation id="569536719314091526">Traduce esta página a cualquier idioma con el botón Más opciones</translation>
-<translation id="572328651809341494">Pestañas recientes</translation>
-<translation id="5726692708398506830">Amplía todo el contenido de la página</translation>
-<translation id="5748802427693696783">Se ha cambiado a las pestañas estándares</translation>
-<translation id="5749068826913805084">Chrome necesita acceso de almacenamiento para descargar archivos.</translation>
-<translation id="5763382633136178763">Pestañas de incógnito</translation>
-<translation id="5763514718066511291">Toca para copiar la URL de esta aplicación</translation>
-<translation id="5765780083710877561">Descripción:</translation>
-<translation id="5793665092639000975">Usando <ph name="SPACE_USED" /> de <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Es posible que Google utilice tu historial para personalizar la Búsqueda, los anuncios y otros servicios de Google</translation>
-<translation id="5804241973901381774">Permisos</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Hace # hora}other{Hace # horas}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Todos los derechos reservados.</translation>
-<translation id="5817918615728894473">Vincular</translation>
-<translation id="583281660410589416">Desconocido</translation>
-<translation id="5833984609253377421">Compartir enlace</translation>
-<translation id="5836192821815272682">Descargando actualización de Chrome…</translation>
-<translation id="5853623416121554550">en pausa</translation>
-<translation id="5854790677617711513">Más de 30 días</translation>
-<translation id="5858741533101922242">Chrome no ha podido activar el adaptador Bluetooth</translation>
-<translation id="5860033963881614850">No</translation>
-<translation id="5862731021271217234">Activa la sincronización para ver las pestañas de tus otros dispositivos</translation>
-<translation id="5864174910718532887">Detalles: ordenados por nombre del sitio web</translation>
-<translation id="5864419784173784555">Esperando otra descarga…</translation>
-<translation id="5865733239029070421">Envía automáticamente estadísticas de uso e informes sobre fallos a Google</translation>
-<translation id="5869522115854928033">Contraseñas guardadas</translation>
-<translation id="5902828464777634901">Se eliminarán todos los datos locales almacenados por este sitio web, incluidas las cookies.</translation>
-<translation id="5916664084637901428">Activado</translation>
-<translation id="5919204609460789179">Actualiza <ph name="PRODUCT_NAME" /> para iniciar la sincronización</translation>
-<translation id="5937580074298050696">Ahorro: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Restablecer</translation>
-<translation id="5942872142862698679">Google se ha establecido como motor de búsqueda predeterminado</translation>
-<translation id="5952764234151283551">Envía a Google la URL de una página a la que intentas acceder</translation>
-<translation id="5956665950594638604">Abre la Ayuda de Chrome en una pestaña nueva</translation>
-<translation id="5958275228015807058">Encuentra tus archivos y páginas en la sección Descargas</translation>
-<translation id="5962718611393537961">Toca para ocultar</translation>
-<translation id="6000066717592683814">Mantener Google como motor de búsqueda predeterminado</translation>
-<translation id="6005538289190791541">Contraseña sugerida</translation>
-<translation id="6036057147555329831">ICU adicional</translation>
-<translation id="6039379616847168523">Te dirige a la siguiente pestaña</translation>
-<translation id="6040143037577758943">Cerrar</translation>
-<translation id="6042308850641462728">Más</translation>
-<translation id="604996488070107836">No ha sido posible descargar el archivo <ph name="FILE_NAME" /> debido a un error desconocido.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Descargas completadas</translation>
-<translation id="6075798973483050474">Editar página principal</translation>
-<translation id="60923314841986378">Quedan <ph name="HOURS" /> horas</translation>
-<translation id="6108923351542677676">Configuración en curso…</translation>
-<translation id="6111020039983847643">de datos utilizados</translation>
-<translation id="6112702117600201073">Actualizando página</translation>
-<translation id="6127379762771434464">Elemento quitado</translation>
-<translation id="6140912465461743537">País/región</translation>
-<translation id="614940544461990577">Prueba a:</translation>
-<translation id="6154478581116148741">Activa el bloqueo de pantalla en Configuración para exportar las contraseñas de este dispositivo</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> de ahorro de datos</translation>
-<translation id="6165508094623778733">Más información</translation>
-<translation id="6177111841848151710">Bloqueado en el motor de búsqueda actual</translation>
-<translation id="6181444274883918285">Añadir excepción de sitio web</translation>
-<translation id="6192333916571137726">Descargar archivo</translation>
-<translation id="6192792657125177640">Excepciones</translation>
-<translation id="6194112207524046168">Para que Chrome pueda acceder a tu cámara, activa la cámara en los <ph name="BEGIN_LINK" />ajustes de Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Bloquear cookies de terceros</translation>
-<translation id="6206551242102657620">La conexión es segura. Información del sitio web</translation>
-<translation id="6210748933810148297">¿No eres <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Desbloquea el dispositivo para exportar las contraseñas</translation>
-<translation id="6232535412751077445">Al habilitar la opción No realizar seguimiento, se incluirá una solicitud con el tráfico de navegación. El efecto dependerá de si algún sitio web responde a la solicitud y de cómo se interpreta.
+<translation id="1406000523432664303">No hacer seguimiento</translation>
+<translation id="6232535412751077445">Al habilitar la opción No hacer seguimiento, se incluirá una solicitud con el tráfico de navegación. El efecto dependerá de si algún sitio web responde a la solicitud y de cómo se interpreta.
 
 Por ejemplo, algunos sitios web pueden responder a la solicitud mostrándote anuncios no basados en otros sitios web que hayas visitado. Muchos sitios web seguirán recopilando y utilizando tus datos de navegación (por ejemplo, para mejorar la seguridad, para proporcionar contenido, anuncios y recomendaciones, o para generar estadísticas de informes).</translation>
-<translation id="624789221780392884">Actualización lista</translation>
-<translation id="6255999984061454636">Sugerencias de contenido</translation>
-<translation id="6277522088822131679">Se ha producido un problema al imprimir la página. Vuelve a intentarlo.</translation>
-<translation id="6295158916970320988">Todos los sitios</translation>
-<translation id="629730747756840877">Cuenta</translation>
-<translation id="6303969859164067831">Cerrar sesión y desactivar la sincronización</translation>
-<translation id="6316139424528454185">Esta versión de Android no es compatible</translation>
-<translation id="6320088164292336938">Vibrar</translation>
-<translation id="6324034347079777476">Sincronización del sistema Android inhabilitada</translation>
-<translation id="6333140779060797560">Compartir a través de <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Cifrado</translation>
-<translation id="6341580099087024258">Preguntar dónde guardar los archivos</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> más}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> más}}</translation>
-<translation id="6364438453358674297">¿Eliminar sugerencia del historial?</translation>
-<translation id="6369229450655021117">Desde aquí, puedes buscar en la Web, compartir contenido con amigos y ver las páginas abiertas</translation>
-<translation id="6378173571450987352">Detalles: ordenados por cantidad de datos usados</translation>
-<translation id="6381421346744604172">Oscurecer sitios web</translation>
-<translation id="6388207532828177975">Borrar y restablecer</translation>
-<translation id="6393863479814692971">Chrome necesita permiso para acceder a la cámara y al micrófono en este sitio web.</translation>
-<translation id="6395288395575013217">ENLACE</translation>
-<translation id="6404511346730675251">Editar marcador</translation>
-<translation id="6406506848690869874">Sincronización</translation>
-<translation id="641643625718530986">Imprimir…</translation>
-<translation id="6416782512398055893">MB descargados: <ph name="MBS" /></translation>
-<translation id="6427112570124116297">Traduce la Web</translation>
-<translation id="6433501201775827830">Elegir tu motor de búsqueda</translation>
-<translation id="6437478888915024427">Información de la página</translation>
-<translation id="6441734959916820584">El nombre es demasiado largo</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagen}other{# imágenes}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">No se puede abrir el archivo</translation>
-<translation id="6464977750820128603">Puedes ver los sitios web que visitas en Chrome y ponerles temporizadores.\n\nGoogle obtiene información sobre estos sitios web y sobre la duración de la visita. La información se usa para mejorar Bienestar digital.</translation>
-<translation id="6475951671322991020">Descargar vídeo</translation>
-<translation id="6482749332252372425">No se ha podido descargar <ph name="FILE_NAME" /> porque no hay suficiente espacio de almacenamiento.</translation>
-<translation id="6496823230996795692">Para utilizar <ph name="APP_NAME" /> por primera vez, conéctate a Internet.</translation>
-<translation id="6508722015517270189">Reinicia Chrome</translation>
-<translation id="6527303717912515753">Compartir</translation>
-<translation id="6532866250404780454">Los sitios web que visites en Chrome no se mostrarán. Se eliminarán todos los temporizadores de los sitios web.</translation>
-<translation id="6534565668554028783">Google ha tardado demasiado en responder</translation>
-<translation id="6538442820324228105">GB descargados: <ph name="GBS" /></translation>
-<translation id="6539092367496845964">Se ha producido un error. Vuelve a intentarlo más tarde.</translation>
-<translation id="654446541061731451">Selecciona una pestaña para compartir</translation>
-<translation id="6545017243486555795">Borrar todos los datos</translation>
-<translation id="6545864417968258051">Búsqueda de dispositivos Bluetooth</translation>
-<translation id="6560414384669816528">Realizar búsquedas con Sogou</translation>
-<translation id="6566259936974865419">Chrome te ha permitido ahorrar <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Permitir siempre</translation>
-<translation id="6573431926118603307">Aquí aparecen las pestañas que hayas abierto en Chrome en otros dispositivos.</translation>
-<translation id="6583199322650523874">Añade la página actual a marcadores</translation>
-<translation id="6593061639179217415">Versión para ordenador</translation>
-<translation id="6600954340915313787">Copiada a Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Contenido protegido</translation>
-<translation id="6627583120233659107">Editar carpeta</translation>
-<translation id="6643016212128521049">Eliminar</translation>
-<translation id="6643649862576733715">Ordenar por cantidad de datos ahorrados</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> más}other{<ph name="CONTACT_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> más}}</translation>
-<translation id="6649642165559792194">Revisar imagen <ph name="BEGIN_NEW" />Nuevo<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome necesita acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK" />Actualizar los permisos<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Contraseña</translation>
-<translation id="6659594942844771486">Pestaña</translation>
-<translation id="666731172850799929">Abrir en <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Aviso de privacidad de Chrome</translation>
-<translation id="6676840375528380067">¿Quieres borrar tus datos de Chrome en este dispositivo?</translation>
-<translation id="6697492270171225480">Mostrar sugerencias de páginas similares cuando no se encuentre una página</translation>
-<translation id="6697947395630195233">Chrome necesita acceder a tu ubicación para compartirla con este sitio web.</translation>
-<translation id="6698801883190606802">Administrar datos sincronizados</translation>
-<translation id="6699370405921460408">Los servidores de Google optimizan las páginas web que visitas.</translation>
-<translation id="6706288973712894588">Actualmente no tienes conexión.\n<ph name="BEGIN_LINK" />Explora tu feed sin conexión.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Noticias</translation>
-<translation id="6710213216561001401">Anterior</translation>
-<translation id="671481426037969117">Se ha agotado el temporizador de <ph name="FQDN" />. Se reiniciará mañana.</translation>
-<translation id="6738867403308150051">Descargando…</translation>
-<translation id="6746124502594467657">Bajar</translation>
-<translation id="6766622839693428701">Desliza el dedo hacia abajo para cerrarla.</translation>
-<translation id="6766758767654711248">Toca para ir al sitio web</translation>
-<translation id="6767294960381293877">La lista de dispositivos con los que puedes compartir una pestaña está abierta y ocupa la mitad inferior de la pantalla.</translation>
-<translation id="6782111308708962316">Impedir que los sitios web de terceros guarden y consulten datos de cookies</translation>
-<translation id="6790428901817661496">Reproducir</translation>
-<translation id="6811034713472274749">Ya se puede ver la página</translation>
-<translation id="6818926723028410516">Seleccionar elementos</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Traducir</translation>
-<translation id="6845325883481699275">Ayudar a mejorar la seguridad de Chrome</translation>
-<translation id="6846298663435243399">Cargando…</translation>
-<translation id="6850409657436465440">Tu descarga sigue en curso</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> pestañas cerradas</translation>
-<translation id="6864459304226931083">Descargar imagen</translation>
-<translation id="6865313869410766144">Datos de Autocompletar formulario</translation>
-<translation id="688738109438487280">Añade los datos actuales a <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Desbloquea la pantalla para copiar tu contraseña</translation>
-<translation id="6896758677409633944">Copiar</translation>
-<translation id="6910211073230771657">Eliminado</translation>
-<translation id="6912998170423641340">Evitar que los sitios web lean texto e imágenes del portapapeles</translation>
-<translation id="6914783257214138813">Cualquier usuario que pueda ver el archivo exportado podrá ver tus contraseñas.</translation>
-<translation id="6942665639005891494">Cambia la ubicación predeterminada de las descargas en cualquier momento con la opción del menú Configuración</translation>
-<translation id="6945221475159498467">Seleccionar</translation>
-<translation id="6963642900430330478">Esta página es peligrosa. Información del sitio web</translation>
-<translation id="6963766334940102469">Eliminar marcadores</translation>
-<translation id="6965382102122355670">Aceptar</translation>
-<translation id="6979737339423435258">Desde siempre</translation>
-<translation id="6981982820502123353">Accesibilidad</translation>
-<translation id="6989267951144302301">Error al descargar</translation>
-<translation id="6990079615885386641">Descarga la aplicación en Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Preguntar antes de permitir que los sitios web utilicen el micrófono (recomendado)</translation>
-<translation id="7015203776128479407">La configuración de sincronización inicial no ha terminado. La sincronización está desactivada.</translation>
-<translation id="7016516562562142042">Permitido en el motor de búsqueda actual</translation>
-<translation id="7022756207310403729">Abrir en el navegador</translation>
-<translation id="702463548815491781">Se recomienda cuando TalkBack o la accesibilidad mediante interruptores están activados</translation>
-<translation id="7029809446516969842">Contraseñas</translation>
-<translation id="7053983685419859001">Bloquear</translation>
-<translation id="7055152154916055070">Redirección bloqueada:</translation>
-<translation id="7063006564040364415">No se ha podido conectar con el servidor de sincronización.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 seleccionado}other{# seleccionados}}</translation>
-<translation id="7071521146534760487">Gestionar cuenta</translation>
-<translation id="7077143737582773186">Tarjeta SD</translation>
-<translation id="7087918508125750058">Elementos seleccionados: <ph name="ITEM_COUNT" />. Hay opciones disponibles en la parte superior de la pantalla</translation>
-<translation id="7121362699166175603">Borra el historial y los autocompletados de la barra de direcciones. Es posible que tu cuenta de Google tenga otros tipos de historial de navegación en <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Permitir para el motor de búsqueda actual</translation>
-<translation id="7138678301420049075">Otro</translation>
-<translation id="7141896414559753902">Impedir que los sitios web muestren ventanas emergentes y redirecciones (recomendado)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Cargar página original<ph name="END_LINK" /> de <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Últimas 24 horas</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Puedes cambiar esta opción más tarde en Configuración</translation>
-<translation id="7180611975245234373">Actualizar</translation>
-<translation id="7189372733857464326">Esperando a que Servicios de Google Play termine de actualizarse</translation>
-<translation id="7191430249889272776">Pestaña abierta en segundo plano.</translation>
-<translation id="723171743924126238">Seleccionar imágenes</translation>
-<translation id="7233236755231902816">Si quieres ver la Web en tu idioma, consigue la última versión de Chrome</translation>
-<translation id="7243308994586599757">Opciones disponibles cerca de la parte inferior de la pantalla</translation>
-<translation id="7248069434667874558">Asegúrate de que la sincronización de tu <ph name="TARGET_DEVICE_NAME" /> está activada en Chrome</translation>
-<translation id="7250468141469952378">Elementos seleccionados: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Sitio web bloqueado</translation>
-<translation id="7290209999329137901">El cambio de nombre no está disponible</translation>
-<translation id="7291387454912369099">Pago con el Asistente activado</translation>
-<translation id="7293171162284876153">Para iniciar la sincronización, activa "Sincronizar tus datos de Chrome".</translation>
-<translation id="729975465115245577">Tu dispositivo no tiene ninguna aplicación para almacenar el archivo de contraseñas.</translation>
-<translation id="7302081693174882195">Detalles: ordenados por cantidad de datos ahorrados</translation>
-<translation id="7328017930301109123">En el modo básico, Chrome carga las páginas más rápido y reduce el uso de datos hasta un 60 por ciento.</translation>
-<translation id="7333031090786104871">Aún se está añadiendo el sitio web anterior</translation>
-<translation id="7352939065658542140">VÍDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Compartir 1 elemento seleccionado}other{Compartir # elementos seleccionados}}</translation>
 <translation id="7359002509206457351">Acceso a métodos de pago</translation>
+<translation id="8026334261755873520">Borrar datos de navegación</translation>
+<translation id="1291207594882862231">Borrar el historial, las cookies, los datos de sitios web, la caché…</translation>
+<translation id="7814200940910057384">Datos de Brave borrados</translation>
+<translation id="1664855196866195614">Los datos seleccionados se han quitado de Brave y de los dispositivos sincronizados.
+
+Es posible que tu cuenta de Brave Software tenga otros tipos de historial de navegación, como búsquedas o actividad de otros servicios de Brave Software, en la página <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Archivos e imágenes almacenados en caché</translation>
+<translation id="2496180316473517155">Historial de navegación</translation>
+<translation id="2546283357679194313">Cookies y datos de sitios</translation>
+<translation id="8662811608048051533">Cierra tu sesión en la mayoría de los sitios web.</translation>
+<translation id="8218628800671693884">Cierra tu sesión en la mayoría de los sitios web. No se cerrará la sesión en tu cuenta de Brave Software.</translation>
+<translation id="2017836877785168846">Borra el historial y los autocompletados de la barra de direcciones.</translation>
+<translation id="8096327394278038498">Borra el historial y los autocompletados de la barra de direcciones. Es posible que tu cuenta de Brave Software tenga otros tipos de historial de navegación en <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Borra el historial de todos los dispositivos en los que hayas iniciado sesión. Es posible que tu cuenta de Brave Software tenga otros tipos de historial de navegación en <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Contraseñas guardadas</translation>
+<translation id="6865313869410766144">Datos de Autocompletar formulario</translation>
+<translation id="7562080006725997899">Borrando datos de navegación</translation>
+<translation id="5487521232677179737">Borrar datos</translation>
+<translation id="7498271377022651285">Espera…</translation>
+<translation id="784934925303690534">Intervalo de tiempo</translation>
+<translation id="1718835860248848330">Última hora</translation>
+<translation id="7149893636342594995">Últimas 24 horas</translation>
+<translation id="5648166631817621825">Últimos 7 días</translation>
+<translation id="8571213806525832805">Últimas cuatro semanas</translation>
+<translation id="5854790677617711513">Más de 30 días</translation>
+<translation id="6979737339423435258">Desde siempre</translation>
+<translation id="982182592107339124">Se borrarán los datos de todos los sitios web, incluidos:</translation>
+<translation id="6643016212128521049">Eliminar</translation>
+<translation id="7641339528570811325">Borrar datos de navegación…</translation>
+<translation id="1670399744444387456">Básico</translation>
+<translation id="3245261285041759672">Es posible que tu cuenta de Brave Software tenga otros tipos de historial de navegación en <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Sitio web bloqueado</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> elementos eliminados</translation>
+<translation id="1121094540300013208">Informes de uso y sobre fallos</translation>
+<translation id="9079153198295609735">Enviar automáticamente estadísticas de uso e informes sobre fallos a Brave Software</translation>
+<translation id="6981982820502123353">Accesibilidad</translation>
+<translation id="2387895666653383613">Ajuste de texto</translation>
+<translation id="2321958826496381788">Arrastra el control deslizante hasta que puedas leer cómodamente. El texto debe tener al menos este tamaño después de tocar un párrafo dos veces.</translation>
+<translation id="3895926599014793903">Forzar zoom</translation>
+<translation id="5668404140385795438">Ignorar la solicitud de un sitio web para no ampliar la imagen</translation>
+<translation id="4149994727733219643">Vista simplificada de páginas web</translation>
+<translation id="9100505651305367705">Pregunta si quieres que los artículos se muestren en vista simplificada, si está disponible</translation>
+<translation id="1409426117486808224">Vista simplificada de las pestañas abiertas</translation>
+<translation id="702463548815491781">Se recomienda cuando TalkBack o la accesibilidad mediante interruptores están activados</translation>
+<translation id="8284326494547611709">Subtítulos</translation>
+<translation id="4165986682804962316">Configuración del sitio web</translation>
+<translation id="6295158916970320988">Todos los sitios</translation>
+<translation id="8380167699614421159">El sitio web muestra anuncios invasivos o engañosos</translation>
+<translation id="1919345977826869612">Anuncios</translation>
+<translation id="410351446219883937">Reproducción automática</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Bloquear cookies de terceros</translation>
+<translation id="6782111308708962316">Impedir que los sitios web de terceros guarden y consulten datos de cookies</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Ventanas emergentes y redirecciones</translation>
+<translation id="4751476147751820511">Sensores de luz o movimiento</translation>
+<translation id="1717218214683051432">Sensores de movimiento</translation>
+<translation id="2091887806945687916">Sonido</translation>
+<translation id="2586657967955657006">Portapapeles</translation>
+<translation id="6320088164292336938">Vibrar</translation>
+<translation id="4226663524361240545">Es posible que las notificaciones hagan que el dispositivo vibre</translation>
+<translation id="1446450296470737166">Control total dispositivos MIDI</translation>
+<translation id="3744111561329211289">Sincronización en segundo plano</translation>
+<translation id="5649053991847567735">Descargas automáticas</translation>
+<translation id="6181444274883918285">Añadir excepción de sitio web</translation>
+<translation id="5313967007315987356">Añadir sitio</translation>
+<translation id="1369915414381695676">Se ha añadido el sitio <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Permitir que un sitio web específico reproduzca automáticamente los vídeos silenciados.</translation>
+<translation id="2621115761605608342">Habilita JavaScript en un sitio web específico.</translation>
+<translation id="8801436777607969138">Bloquear JavaScript en un sitio web específico.</translation>
+<translation id="8372893542064058268">Permite la sincronización en segundo plano de un sitio web específico.</translation>
+<translation id="358794129225322306">Permitir que un sitio web descargue varios archivos automáticamente.</translation>
+<translation id="4008040567710660924">Permitir cookies en un sitio web específico.</translation>
+<translation id="8958424370300090006">Bloquear las cookies de un sitio web específico.</translation>
+<translation id="7882806643839505685">Permite que se reproduzcan sonidos en un sitio web específico.</translation>
+<translation id="4468959413250150279">Silencia el sonido de un sitio web específico.</translation>
+<translation id="1994173015038366702">URL del sitio</translation>
+<translation id="8941729603749328384">www.ejemplo.com</translation>
+<translation id="5063480226653192405">Uso</translation>
+<translation id="5804241973901381774">Permisos</translation>
+<translation id="4278390842282768270">Permitido</translation>
+<translation id="5677928146339483299">Bloqueado</translation>
+<translation id="1984937141057606926">Permitidas (excepto cookies de terceros)</translation>
+<translation id="7423098979219808738">Preguntar antes</translation>
+<translation id="8116925261070264013">Silenciados</translation>
+<translation id="8300705686683892304">Administrados por una aplicación</translation>
+<translation id="6192792657125177640">Excepciones</translation>
+<translation id="257931822824936280">Ampliado (hacer clic para contraer)</translation>
+<translation id="5100237604440890931">Contraído (hacer clic para ampliar)</translation>
+<translation id="857943718398505171">Permitido (recomendado)</translation>
+<translation id="2913331724188855103">Permitir que los sitios guarden y lean datos de cookies (recomendado)</translation>
+<translation id="7445411102860286510">Permite que los sitios web reproduzcan automáticamente los vídeos silenciados (recomendado)</translation>
+<translation id="5335288049665977812">Permitir que los sitios web utilicen JavaScript (recomendado)</translation>
+<translation id="5527111080432883924">Preguntar antes de permitir que los sitios web lean texto e imágenes del portapapeles (recomendado)</translation>
+<translation id="6912998170423641340">Evitar que los sitios web lean texto e imágenes del portapapeles</translation>
+<translation id="7423538860840206698">Se ha bloqueado la lectura del portapapeles</translation>
+<translation id="3955193568934677022">Permitir que los sitios web reproduzcan contenido protegido (recomendado)</translation>
+<translation id="445467742685312942">Permitir que los sitios web reproduzcan contenido protegido</translation>
+<translation id="2107397443965016585">Preguntar antes de permitir que los sitios web reproduzcan contenido protegido (opción recomendada)</translation>
+<translation id="2910701580606108292">Preguntar antes de permitir que los sitios web reproduzcan contenido protegido</translation>
+<translation id="757524316907819857">Impedir que los sitios web reproduzcan contenido protegido</translation>
+<translation id="3277252321222022663">Permitir que los sitios web accedan a los sensores (recomendado)</translation>
+<translation id="5048398596102334565">Permitir que los sitios web accedan a los sensores de movimiento (recomendado)</translation>
+<translation id="8816026460808729765">No permite que los sitios web accedan a los sensores</translation>
+<translation id="169515064810179024">No permitir que los sitios web accedan a los sensores de movimiento</translation>
+<translation id="1660204651932907780">Permitir que los sitios web reproduzcan sonidos (recomendado)</translation>
+<translation id="3600792891314830896">Silenciar los sitios web que reproducen sonidos</translation>
+<translation id="1743802530341753419">Preguntar antes de permitir que los sitios web se conecten a un dispositivo (recomendado)</translation>
+<translation id="851751545965956758">No permitir que los sitios web se conecten a dispositivos</translation>
+<translation id="7141896414559753902">Impedir que los sitios web muestren ventanas emergentes y redirecciones (recomendado)</translation>
+<translation id="5494752089476963479">Bloquea anuncios invasivos o engañosos en los sitios web que los muestran</translation>
+<translation id="3123473560110926937">Bloqueados en algunos sitios web</translation>
+<translation id="965817943346481315">Bloquear si el sitio web muestra anuncios invasivos o engañosos (opción recomendada)</translation>
+<translation id="3386292677130313581">Preguntar antes de permitir que los sitios web detecten tu ubicación (recomendado)</translation>
+<translation id="9139068048179869749">Preguntar antes de permitir que los sitios web envíen notificaciones (recomendado)</translation>
+<translation id="4479647676395637221">Preguntar antes de permitir que los sitios web utilicen la cámara (recomendado)</translation>
+<translation id="6992289844737586249">Preguntar antes de permitir que los sitios web utilicen el micrófono (recomendado)</translation>
+<translation id="2289270750774289114">Preguntar cuando un sitio web quiera buscar dispositivos Bluetooth cercanos (recomendado)</translation>
+<translation id="7053983685419859001">Bloquear</translation>
+<translation id="7128222689758636196">Permitir para el motor de búsqueda actual</translation>
+<translation id="7589445247086920869">Bloquear para el motor de búsqueda actual</translation>
+<translation id="6388207532828177975">Borrar y restablecer</translation>
+<translation id="7999064672810608036">¿Seguro que quieres borrar todos los datos locales, incluidas las cookies, y restablecer todos los permisos de este sitio web?</translation>
+<translation id="2822354292072154809">¿Seguro que quieres restablecer todos los permisos de los sitios web de <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Borrar datos almacenados</translation>
+<translation id="5902828464777634901">Se eliminarán todos los datos locales almacenados por este sitio web, incluidas las cookies.</translation>
+<translation id="119944043368869598">Eliminar todo</translation>
+<translation id="2490684707762498678">Gestionadas por <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Abrir ajustes de notificaciones</translation>
+<translation id="1404122904123200417">Insertado en <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Los archivos que guarden los sitios web aparecerán aquí</translation>
+<translation id="4181841719683918333">Idiomas</translation>
+<translation id="2647434099613338025">Añadir idioma</translation>
+<translation id="1952172573699511566">Si es posible, los sitios web muestran texto en tu idioma preferido.</translation>
+<translation id="8559990750235505898">Ofrecer la traducción de páginas en otros idiomas</translation>
+<translation id="4719927025381752090">Ofrecer la traducción</translation>
+<translation id="8156139159503939589">¿Qué idiomas puedes leer?</translation>
+<translation id="5689516760719285838">Ubicación</translation>
+<translation id="2440823041667407902">Acceso a la ubicación</translation>
+<translation id="2023546461831060654">Activa los permisos para Brave en los <ph name="BEGIN_LINK"/>ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Activa el permiso para Brave en los <ph name="BEGIN_LINK"/>ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Para que Brave tenga acceso a tu ubicación, activa la ubicación en los <ph name="BEGIN_LINK"/>ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Para que Brave pueda acceder a tu cámara, activa la cámara en los <ph name="BEGIN_LINK"/>ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Para que Brave pueda enviarte notificaciones, actívalas también en los <ph name="BEGIN_LINK"/>ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Para que Brave pueda acceder a tu micrófono, activa el micrófono en los <ph name="BEGIN_LINK"/>ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">El acceso a la ubicación está desactivado en este dispositivo. Actívalo en los <ph name="BEGIN_LINK"/>Ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">El acceso a la ubicación también está desactivado en este dispositivo. Actívalo en los <ph name="BEGIN_LINK"/>Ajustes de Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Cámara</translation>
+<translation id="3227137524299004712">Micrófono</translation>
+<translation id="1647391597548383849">Acceder a la cámara</translation>
+<translation id="945632385593298557">Acceder al micrófono</translation>
+<translation id="6612358246767739896">Contenido protegido</translation>
+<translation id="885701979325669005">Almacenamiento</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> de datos almacenados</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revocar permiso de dispositivo</translation>
+<translation id="4962975101802056554">Revocar todos los permisos de este dispositivo</translation>
+<translation id="6545864417968258051">Búsqueda de dispositivos Bluetooth</translation>
+<translation id="4411535500181276704">Modo básico</translation>
+<translation id="7821588508402923572">El ahorro de datos aparecerá aquí</translation>
+<translation id="2131665479022868825">Datos ahorrados: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">desde el <ph name="DATE"/></translation>
+<translation id="3252158532344029638">En el modo básico, Brave carga las páginas más rápido y reduce el uso de datos hasta un 60 por ciento.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> de ahorro de datos</translation>
+<translation id="7494974237137038751">de datos ahorrados</translation>
+<translation id="6111020039983847643">de datos utilizados</translation>
+<translation id="7413229368719586778">Fecha de inicio: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Fecha de finalización: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Ordenar por sitio web</translation>
+<translation id="5864174910718532887">Detalles: ordenados por nombre del sitio web</translation>
+<translation id="116280672541001035">Usados</translation>
+<translation id="8349013245300336738">Ordenar por cantidad de datos usados</translation>
+<translation id="6378173571450987352">Detalles: ordenados por cantidad de datos usados</translation>
+<translation id="2631006050119455616">Ahorrados</translation>
+<translation id="6643649862576733715">Ordenar por cantidad de datos ahorrados</translation>
+<translation id="7302081693174882195">Detalles: ordenados por cantidad de datos ahorrados</translation>
+<translation id="4179980317383591987">Usados: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Ahorro: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Sitios web restantes (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Otro</translation>
+<translation id="4913161338056004800">Borrar estadísticas</translation>
+<translation id="1856325424225101786">¿Restablecer el modo básico?</translation>
+<translation id="3658159451045945436">Restablecerlo borra tu historial de ahorro de datos, incluidas las listas de los sitios web que has visitado.</translation>
+<translation id="3295530008794733555">Navega más rápido. Usa menos datos.</translation>
+<translation id="7340390500800578919">En el modo básico, Brave carga las páginas más rápido y reduce el uso de datos hasta un 60 %. Brave envía tu tráfico web a Brave Software para optimizar las páginas que visitas. <ph name="BEGIN_LINK"/>Más información<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Activar el modo básico</translation>
+<translation id="4493497663118223949">El modo básico está activado</translation>
+<translation id="7559975015014302720">El modo básico está desactivado</translation>
+<translation id="7606077192958116810">El modo básico está activado. Configúralo en Ajustes.</translation>
+<translation id="4714588616299687897">Ahorra hasta un 60% de tus datos</translation>
+<translation id="1006927014032731288">Los servidores de Brave Software optimizan las páginas web que visitas.</translation>
+<translation id="3257320067425202300">Brave te ha permitido ahorrar <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave te ha permitido ahorrar <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Ubicación de las descargas</translation>
+<translation id="7077143737582773186">Tarjeta SD</translation>
+<translation id="7762668264895820836">Tarjeta SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Preguntar dónde guardar los archivos</translation>
+<translation id="6192333916571137726">Descargar archivo</translation>
+<translation id="1672586136351118594">No volver a mostrar</translation>
+<translation id="2650751991977523696">¿Quieres descargar el archivo de nuevo?</translation>
+<translation id="8664979001105139458">El nombre del archivo ya existe</translation>
+<translation id="488187801263602086">Cambiar nombre de archivo</translation>
+<translation id="5686790454216892815">El nombre del archivo es demasiado largo</translation>
+<translation id="7454641608352164238">No hay espacio suficiente</translation>
+<translation id="8972098258593396643">¿Quieres descargarlo en la carpeta predeterminada?</translation>
+<translation id="804335162455518893">No se ha encontrado la tarjeta SD</translation>
+<translation id="7475688122056506577">No se ha encontrado la tarjeta SD. Es posible que falten algunos de tus archivos.</translation>
+<translation id="4198423547019359126">No hay ubicaciones de descarga disponibles</translation>
+<translation id="8224471946457685718">Descargar artículos recomendados para ti con Wi‑Fi</translation>
+<translation id="4970824347203572753">No está disponible en tu ubicación</translation>
+<translation id="5500777121964041360">Puede que no esté disponible en tu ubicación</translation>
+<translation id="1173894706177603556">Cambiar nombre</translation>
+<translation id="1986685561493779662">El nombre ya existe</translation>
+<translation id="6441734959916820584">El nombre es demasiado largo</translation>
+<translation id="2923908459366352541">El nombre no es válido</translation>
+<translation id="7290209999329137901">El cambio de nombre no está disponible</translation>
+<translation id="3334729583274622784">¿Cambiar la extensión del archivo?</translation>
+<translation id="107147699690128016">Si cambias la extensión del archivo, el archivo podría abrirse en una aplicación diferente y convertirse en un riesgo potencial para tu dispositivo.</translation>
+<translation id="8541922081612557424">Información de Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Todos los derechos reservados.</translation>
+<translation id="1416550906796893042">Versión de la aplicación</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (actualizada el <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistema operativo</translation>
+<translation id="3968054912784331254">Ya no se admiten actualizaciones de Brave en esta versión de Android.</translation>
+<translation id="7665369617277396874">Añadir cuenta</translation>
+<translation id="649070405679044769">Has iniciado sesión en Brave Software como</translation>
+<translation id="6234515504547364178">Cerrar sesión en Brave</translation>
+<translation id="5324858694974489420">Configuración parental</translation>
+<translation id="8920114477895755567">Esperando detalles de los padres.</translation>
+<translation id="5512137114520586844">Esta cuenta está administrada por <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Esta cuenta está administrada por <ph name="PARENT_NAME_1"/> y <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Contenido</translation>
+<translation id="5403644198645076998">Permitir solo determinados sitios web</translation>
+<translation id="8641930654639604085">Intentar bloquear sitios web para adultos</translation>
+<translation id="5639724618331995626">Permitir todos los sitios web</translation>
+<translation id="796823723482603597">Con la tecnología de Brave</translation>
+<translation id="6324034347079777476">Sincronización del sistema Android inhabilitada</translation>
+<translation id="5127805178023152808">La sincronización está desactivada</translation>
+<translation id="7015203776128479407">La configuración de sincronización inicial no ha terminado. La sincronización está desactivada.</translation>
+<translation id="2497852260688568942">El administrador ha inhabilitado la sincronización</translation>
+<translation id="9100610230175265781">Se debe introducir una frase de contraseña</translation>
+<translation id="6108923351542677676">Configuración en curso…</translation>
+<translation id="4062305924942672200">Información legal</translation>
+<translation id="4256782883801055595">Licencias de código abierto</translation>
+<translation id="1138681184697033370">Condiciones del servicio de Brave</translation>
+<translation id="7392539049993970338">Aviso de privacidad de Brave</translation>
+<translation id="2677748264148917807">Salir</translation>
+<translation id="5556459405103347317">Volver a cargar</translation>
+<translation id="1623104350909869708">Evitar que esta página cree cuadros de diálogo adicionales</translation>
+<translation id="2968755619301702150">Visor de certificados</translation>
+<translation id="1360432990279830238">¿Cerrar sesión y detener sincronización?</translation>
+<translation id="8581481290581777242">¿Quieres borrar tus datos de Brave en este dispositivo?</translation>
+<translation id="1318865768845061710">Tus marcadores, el historial, las contraseñas y otros datos de Brave dejarán de sincronizarse con tu cuenta de Brave Software</translation>
+<translation id="3325020657155065477">Borrar también los datos de Brave de este dispositivo</translation>
+<translation id="6136448902816743006">Estás cerrando sesión de una cuenta gestionada por <ph name="DOMAIN_NAME"/>, por lo que tus datos de Brave se eliminarán de este dispositivo. Sin embargo, permanecerán en tu cuenta de Brave Software.</translation>
+<translation id="1853026300647876496">Contactando con Brave Software. Esto puede tardar un minuto…</translation>
+<translation id="2328985652426384049">No se puede iniciar sesión</translation>
+<translation id="7723158744459952869">Brave Software ha tardado demasiado en responder</translation>
+<translation id="4572422548854449519">Inicia sesión en la cuenta gestionada</translation>
+<translation id="2689656545739939160">Estás iniciando sesión con una cuenta gestionada por <ph name="MANAGED_DOMAIN"/>, lo que significa que vas a proporcionar a su administrador el control sobre tus datos de Brave. Los datos se vincularán de forma permanente a esta cuenta. Si cierras sesión en Brave, se eliminarán los datos de este dispositivo, pero permanecerán almacenados en tu cuenta de Brave Software.</translation>
+<translation id="1749561566933687563">Sincronizar marcadores</translation>
+<translation id="4242533952199664413">Abrir Configuración</translation>
+<translation id="1111673857033749125">Aquí aparecen los marcadores que hayas guardado en otros dispositivos.</translation>
+<translation id="8636825310635137004">Activa la sincronización para ver las pestañas de tus otros dispositivos.</translation>
+<translation id="3269956123044984603">Para ver las pestañas de tus otros dispositivos, activa la opción Sincronización automática en la configuración de la cuenta de Android.</translation>
+<translation id="5157964048453367290">Aquí aparecen las pestañas que hayas abierto en Brave en otros dispositivos.</translation>
+<translation id="4684427112815847243">Sincronizar todo</translation>
+<translation id="2709516037105925701">Autocompletar</translation>
+<translation id="8820817407110198400">Marcadores</translation>
+<translation id="1644574205037202324">Historial</translation>
+<translation id="17513872634828108">Pestañas abiertas</translation>
+<translation id="1320169905922104972">Tarjetas de crédito y direcciones con Brave Software Pay</translation>
+<translation id="6337234675334993532">Cifrado</translation>
+<translation id="6698801883190606802">Administrar datos sincronizados</translation>
+<translation id="3598578758776312506">Cifrar contraseñas con credenciales de Brave Software</translation>
+<translation id="7810580217418711046">Cifrar los datos sincronizados con la contraseña de Brave Software desde el <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Cifrar los datos sincronizados con tu propia frase de contraseña de sincronización</translation>
+<translation id="2996291259634659425">Crea una frase de contraseña</translation>
+<translation id="5713644099811900409">cuenta de Brave Software</translation>
+<translation id="8997474919031554666">El cifrado mediante frase de contraseña no incluye los métodos de pago ni las direcciones de Brave Software Pay. Solo alguien que tenga tu frase de contraseña puede leer tus datos cifrados. La frase de contraseña no se envía a Brave Software, que tampoco la guarda. Si la olvidas o quieres cambiar esta opción, debes restablecer la sincronización. <ph name="BEGIN_LINK"/>Más información<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Frase de contraseña</translation>
+<translation id="7772032839648071052">Repite la contraseña</translation>
+<translation id="5304593522240415983">Este campo no puede estar vacío</translation>
+<translation id="321773570071367578">Si has olvidado tu frase de contraseña o quieres cambiar esta opción, <ph name="BEGIN_LINK"/>restablece la sincronización<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Las frases de contraseña no coinciden</translation>
+<translation id="5149495116300586333">El cifrado mediante frase de contraseña no incluye los métodos de pago ni las direcciones de Brave Software Pay.
+
+Para cambiar esta opción, <ph name="BEGIN_LINK"/>restablece la sincronización<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">Frase de contraseña incorrecta</translation>
+<translation id="5414836363063783498">Verificando…</translation>
+<translation id="6846298663435243399">Cargando…</translation>
+<translation id="5517095782334947753">Tienes los marcadores, el historial, las contraseñas y otras opciones de configuración de <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combinar mis datos</translation>
+<translation id="688738109438487280">Añade los datos actuales a <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Mantener mis datos separados</translation>
+<translation id="1145536944570833626">Elimina los datos actuales.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> quiere vincularse</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Obtener ayuda<ph name="END_LINK"/> mientras se buscan dispositivos…</translation>
+<translation id="5817918615728894473">Vincular</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Obtener ayuda<ph name="END_LINK1"/> o <ph name="BEGIN_LINK2"/>volver a buscar<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">No se han podido encontrar dispositivos compatibles</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Activa el Bluetooth<ph name="END_LINK"/> para permitir la vinculación</translation>
+<translation id="998321811308652668">Brave no ha podido activar el adaptador Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Obtener ayuda<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave necesita acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK"/>Actualizar los permisos<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave necesita acceder a la ubicación para buscar dispositivos. El acceso a la ubicación está <ph name="BEGIN_LINK"/>desactivado en este dispositivo<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave necesita acceder a la ubicación para buscar dispositivos. <ph name="BEGIN_LINK1"/>Actualizar permisos<ph name="END_LINK1"/>. El acceso a la ubicación también está <ph name="BEGIN_LINK2"/>desactivado en este dispositivo<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Dispositivo conectado</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Nivel de intensidad de la señal: # barra}other{Nivel de intensidad de la señal: # barras}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> quiere buscar dispositivos Bluetooth cercanos. Se han encontrado los siguientes dispositivos:</translation>
+<translation id="8368027906805972958">Dispositivo desconocido o no compatible (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">La sincronización no funciona</translation>
+<translation id="1810845389119482123">La configuración de sincronización inicial no ha terminado</translation>
+<translation id="3235722914093408050">Abre los ajustes de Android y vuelve a habilitar la sincronización del sistema Android para iniciar la sincronización de Brave</translation>
+<translation id="3367813778245106622">Vuelve a iniciar sesión para que comience la sincronización</translation>
+<translation id="974555521953189084">Introduce la frase de contraseña para iniciar la sincronización</translation>
+<translation id="2997266899014181325">Para iniciar la sincronización, activa "Sincronizar tus datos de Brave".</translation>
+<translation id="8260126382462817229">Prueba a iniciar sesión de nuevo</translation>
+<translation id="5919204609460789179">Actualiza <ph name="PRODUCT_NAME"/> para iniciar la sincronización</translation>
+<translation id="397583555483684758">La sincronización ha dejado de funcionar</translation>
+<translation id="1966710179511230534">Actualiza tus datos de inicio de sesión.</translation>
+<translation id="7063006564040364415">No se ha podido conectar con el servidor de sincronización.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> está obsoleto.</translation>
+<translation id="4170011742729630528">El servicio no está disponible. Vuelve a intentarlo más tarde.</translation>
+<translation id="7947953824732555851">Aceptar y acceder</translation>
+<translation id="8583805026567836021">Borrando datos de cuenta</translation>
+<translation id="8310344678080805313">Pestañas estándar</translation>
+<translation id="5748802427693696783">Se ha cambiado a las pestañas estándares</translation>
+<translation id="7998918019931843664">Volver a abrir pestaña cerrada</translation>
+<translation id="8853345339104747198">Pestaña <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Cerrar la pestaña <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opciones disponibles cerca de la parte inferior de la pantalla</translation>
+<translation id="4060598801229743805">Opciones disponibles junto a la parte superior de la pantalla</translation>
+<translation id="2810645512293415242">Esta página se ha simplificado para ahorrar datos y poder cargarla más rápido.</translation>
+<translation id="3985215325736559418">¿Quieres volver a descargar el archivo <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">¿Quieres empezar a descargar <ph name="FILE_NAME"/> de nuevo?</translation>
+<translation id="7514365320538308">Descargar</translation>
+<translation id="545042621069398927">Acelerando descarga.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Descargando archivo.}other{Descargando # archivos.}}</translation>
+<translation id="543509235395288790">Descargando <ph name="COUNT"/> archivos (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Descargando archivo (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Se ha completado 1 descarga.}other{Se han completado # descargas.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{No se ha podido completar 1 descarga.}other{No se han podido completar # descargas.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Hay 1 descarga pendiente.}other{Hay # descargas pendientes.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> Botón <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">¡Ya falta poco!</translation>
+<translation id="3960299545138990065">Reinicia Brave</translation>
+<translation id="3771001275138982843">No se ha podido descargar la actualización</translation>
+<translation id="3888648114124182147">Descargando actualización de Brave…</translation>
+<translation id="1705567146636171298">Actualizar Brave</translation>
+<translation id="6195417478702700398">Para disfrutar de la mejor experiencia de navegación posible, abre Brave para actualizarlo.</translation>
+<translation id="3512968675351418494">Si quieres ver la Web en tu idioma, consigue la última versión de Brave</translation>
+<translation id="6427112570124116297">Traduce la Web</translation>
+<translation id="1379423114029199501">Actualiza para incluir tu idioma en la última versión de Brave</translation>
+<translation id="5684874026226664614">¡Vaya! No se ha podido traducir esta página.</translation>
+<translation id="6831043979455480757">Traducir</translation>
+<translation id="1285320974508926690">No traducir nunca este sitio</translation>
+<translation id="773466115871691567">Traducir siempre las páginas en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">No traducir nunca las páginas en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Más idiomas</translation>
+<translation id="290376772003165898">¿La página no está en <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Las páginas en <ph name="SOURCE_LANGUAGE"/> se traducirán al <ph name="TARGET_LANGUAGE"/> a partir de ahora</translation>
+<translation id="8339163506404995330">No se traducirán las páginas en <ph name="LANGUAGE"/></translation>
+<translation id="5447765697759493033">Este sitio web no va a traducirse</translation>
+<translation id="4880127995492972015">Traducir…</translation>
+<translation id="641643625718530986">Imprimir…</translation>
+<translation id="8909135823018751308">Compartir…</translation>
+<translation id="4996978546172906250">Compartir a través de</translation>
+<translation id="6333140779060797560">Compartir a través de <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Se ha producido un problema al imprimir la página. Vuelve a intentarlo.</translation>
+<translation id="3254409185687681395">Añadir esta página a marcadores</translation>
+<translation id="497421865427891073">Avanzar</translation>
+<translation id="813082847718468539">Ver información del sitio</translation>
+<translation id="2532336938189706096">Vista web</translation>
+<translation id="6005538289190791541">Contraseña sugerida</translation>
+<translation id="4634124774493850572">Utilizar contraseña</translation>
+<translation id="8285489906452138776">Brave necesita permiso para acceder a la cámara en este sitio web.</translation>
+<translation id="320189792589364011">Brave necesita permiso para acceder al micrófono en este sitio web.</translation>
+<translation id="7988136689212463100">Brave necesita permiso para acceder a la cámara y al micrófono en este sitio web.</translation>
+<translation id="4931190655840828017">Brave necesita acceder a tu ubicación para compartirla con este sitio web.</translation>
+<translation id="3088191967551450609">Brave necesita acceso de almacenamiento para descargar archivos.</translation>
+<translation id="8942627711005830162">Abrir en otra ventana</translation>
+<translation id="4195643157523330669">Abrir en una pestaña nueva</translation>
+<translation id="1100066534610197918">Abrir pestaña nueva en grupo</translation>
+<translation id="4860895144060829044">Llamar</translation>
+<translation id="6896758677409633944">Copiar</translation>
+<translation id="8393700583063109961">Enviar mensaje</translation>
+<translation id="3557336313807607643">Añadir a contactos</translation>
+<translation id="4269820728363426813">Copiar la dirección del enlace</translation>
+<translation id="1206892813135768548">Copiar texto de enlace</translation>
+<translation id="1204037785786432551">Descargar enlace</translation>
+<translation id="6864459304226931083">Descargar imagen</translation>
+<translation id="8209050860603202033">Abrir imagen</translation>
+<translation id="8073388330009372546">Abrir en pestaña nueva</translation>
+<translation id="6649642165559792194">Revisar imagen <ph name="BEGIN_NEW"/>Nuevo<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Cargar imagen</translation>
+<translation id="3845332215609790146">Buscar con Brave Software Lens <ph name="BEGIN_NEW"/>Nuevo<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Buscar esta imagen en <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Compartir imagen</translation>
+<translation id="5833984609253377421">Compartir enlace</translation>
+<translation id="6475951671322991020">Descargar vídeo</translation>
+<translation id="2317945146070194624">Abrir en una pestaña nueva</translation>
+<translation id="7975379999046275268">Revisar página <ph name="BEGIN_NEW"/>Nuevo<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Actualizando página</translation>
+<translation id="36525718899759834">Descarga la aplicación en Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Oscuro</translation>
+<translation id="1807246157184219062">Claro</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monoespaciado</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Selecciona una pestaña para compartir</translation>
+<translation id="8719023831149562936">No se puede compartir la pestaña actual.</translation>
+<translation id="2139186145475833000">Añadir a pantalla de inicio</translation>
+<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">No se ha podido abrir la aplicación</translation>
+<translation id="5129038482087801250">Instalar aplicación web</translation>
+<translation id="3789841737615482174">Instalar</translation>
+<translation id="4665282149850138822">Se ha añadido <ph name="NAME"/> a la pantalla de inicio</translation>
+<translation id="7333031090786104871">Aún se está añadiendo el sitio web anterior</translation>
+<translation id="1036727731225946849">Añadiendo <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Se ha añadido a la pantalla de inicio</translation>
+<translation id="2146738493024040262">Abrir aplicación instantánea</translation>
+<translation id="7016516562562142042">Permitido en el motor de búsqueda actual</translation>
+<translation id="6177111841848151710">Bloqueado en el motor de búsqueda actual</translation>
+<translation id="145097072038377568">Ajustes de Android desactivados</translation>
+<translation id="8007176423574883786">Desactivada para este dispositivo</translation>
+<translation id="164269334534774161">Estás viendo una copia sin conexión de esta página del <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Esta página sin conexión se creó el <ph name="CREATION_TIME"/> y puede ser distinta de la versión online.</translation>
+<translation id="8840953339110955557">Esta página puede ser distinta de la versión online.</translation>
+<translation id="6405300764336705484">Este contenido procede de <ph name="DOMAIN_NAME"/>, publicado por Brave Software.</translation>
+<translation id="1006017844123154345">Abrir versión online</translation>
+<translation id="3326636747541519688">Página básica ofrecida por Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Cargar página original<ph name="END_LINK"/> de <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Si este mensaje aparece con frecuencia, prueba estas <ph name="BEGIN_LINK"/>sugerencias<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Contenidos ocultos</translation>
+<translation id="3810973564298564668">Gestionar</translation>
+<translation id="5199929503336119739">Perfil de trabajo</translation>
+<translation id="528192093759286357">Arrastra el dedo desde la parte superior y toca el botón de retroceso para salir de la pantalla completa.</translation>
+<translation id="2836148919159985482">Toca el botón de retroceso para salir de la pantalla completa.</translation>
+<translation id="3967822245660637423">Descarga completa</translation>
+<translation id="2434158240863470628">Descarga completa <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">No se ha podido descargar el archivo</translation>
+<translation id="1384959399684842514">Descarga en pausa</translation>
+<translation id="1671236975893690980">Descarga pendiente…</translation>
+<translation id="5561549206367097665">Esperando red…</translation>
+<translation id="5864419784173784555">Esperando otra descarga…</translation>
+<translation id="6461962085415701688">No se puede abrir el archivo</translation>
+<translation id="1178581264944972037">Pausar</translation>
+<translation id="8200772114523450471">Reanudar</translation>
+<translation id="1409879593029778104">No se ha descargado <ph name="FILE_NAME"/> porque este archivo ya existe.</translation>
+<translation id="3387650086002190359">No se ha podido descargar <ph name="FILE_NAME"/> debido a problemas con el sistema de archivos.</translation>
+<translation id="6482749332252372425">No se ha podido descargar <ph name="FILE_NAME"/> porque no hay suficiente espacio de almacenamiento.</translation>
+<translation id="7619072057915878432">No se ha podido descargar <ph name="FILE_NAME"/> debido a problemas de la red.</translation>
+<translation id="1477626028522505441">No se ha podido descargar <ph name="FILE_NAME"/> debido a problemas con el servidor.</translation>
+<translation id="3692944402865947621">No se ha podido descargar <ph name="FILE_NAME"/> porque no se puede acceder a la ubicación del almacenamiento.</translation>
+<translation id="604996488070107836">No ha sido posible descargar el archivo <ph name="FILE_NAME"/> debido a un error desconocido.</translation>
+<translation id="6738867403308150051">Descargando…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">kB descargados: <ph name="KBS"/></translation>
+<translation id="6416782512398055893">MB descargados: <ph name="MBS"/></translation>
+<translation id="6538442820324228105">GB descargados: <ph name="GBS"/></translation>
+<translation id="9204836675896933765">1 archivo restante</translation>
+<translation id="8186512483418048923">Archivos restantes: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> archivo descargado}other{<ph name="FILES_DOWNLOADED_MANY"/> archivos descargados}}</translation>
+<translation id="8037750541064988519">Quedan <ph name="DAYS"/> días</translation>
+<translation id="8190358571722158785">Queda 1 día</translation>
+<translation id="60923314841986378">Quedan <ph name="HOURS"/> horas</translation>
+<translation id="510275257476243843">Queda 1 hora</translation>
+<translation id="970715775301869095">Quedan <ph name="MINUTES"/> minutos</translation>
+<translation id="3236059992281584593">Queda 1 minuto</translation>
+<translation id="2777555524387840389">Quedan <ph name="SECONDS"/> segundos</translation>
+<translation id="2781151931089541271">Queda 1 segundo</translation>
+<translation id="3303414029551471755">¿Quieres continuar para descargar el contenido?</translation>
+<translation id="8617240290563765734">¿Quieres abrir la URL sugerida que se especifica en el contenido descargado?</translation>
+<translation id="1373696734384179344">No hay memoria suficiente para descargar el contenido seleccionado.</translation>
+<translation id="5271967389191913893">El dispositivo no puede abrir el contenido para descargarlo.</translation>
+<translation id="883806473910249246">No se ha podido descargar el contenido.</translation>
+<translation id="5626134646977739690">Nombre:</translation>
+<translation id="7963646190083259054">Proveedor:</translation>
+<translation id="3414952576877147120">Tamaño:</translation>
+<translation id="7375125077091615385">Tipo:</translation>
+<translation id="5765780083710877561">Descripción:</translation>
+<translation id="4881695831933465202">Abrir</translation>
+<translation id="3542235761944717775">kB disponibles: <ph name="KILOBYTES"/></translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB disponible(s)</translation>
+<translation id="5424588387303617268">Disponibilidad: <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Usando <ph name="SPACE_USED"/> de <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Todo</translation>
+<translation id="4988526792673242964">Páginas</translation>
+<translation id="3810838688059735925">Vídeo</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Imágenes</translation>
+<translation id="8250920743982581267">Documentos</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# archivo}other{# archivos}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagen}other{# imágenes}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}other{# vídeos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# archivo de audio}other{# archivos de audio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}other{# páginas}}</translation>
+<translation id="5456381639095306749">Descargar página</translation>
+<translation id="2394602618534698961">Los archivos que descargues aparecerán aquí</translation>
+<translation id="7810647596859435254">Abrir con…</translation>
+<translation id="5655963694829536461">Busca en las descargas</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mis archivos</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Los artículos se muestran aquí y los puedes leer aunque no tengas conexión a Internet</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
+<translation id="5853623416121554550">en pausa</translation>
+<translation id="8965591936373831584">pendiente</translation>
+<translation id="2779651927720337254">ha fallado</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Ahora mismo</translation>
+<translation id="4000212216660919741">Página principal del modo sin conexión</translation>
+<translation id="9133397713400217035">Explorar sin conexión</translation>
+<translation id="968900484120156207">Las páginas que visites aparecerán aquí.</translation>
+<translation id="7882131421121961860">No se ha encontrado el elemento buscado en el historial</translation>
+<translation id="3549657413697417275">Buscar en el historial</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Primera experiencia de ejecución de Brave</translation>
+<translation id="2700285883409956633">Al utilizar esta aplicación, aceptas los <ph name="BEGIN_LINK1"/>Términos del Servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>Aviso de Privacidad<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="1640714894372474981">Si utilizas esta aplicación, aceptas las <ph name="BEGIN_LINK1"/>condiciones de servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>aviso de privacidad<ph name="END_LINK2"/> de Brave, así como el <ph name="BEGIN_LINK3"/>aviso de privacidad para cuentas de Brave Software gestionadas con Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> se abrirá en Brave. Si continúas, aceptas las <ph name="BEGIN_LINK1"/>condiciones de servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>aviso de privacidad<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> se abrirá en Brave. Si continúas, aceptas las <ph name="BEGIN_LINK1"/>condiciones de servicio<ph name="END_LINK1"/> y el <ph name="BEGIN_LINK2"/>aviso de privacidad<ph name="END_LINK2"/> de Brave, así como el <ph name="BEGIN_LINK3"/>aviso de privacidad para cuentas de Brave Software gestionadas con Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Ayudar a mejorar Brave enviando estadísticas de uso e informes sobre fallos.</translation>
+<translation id="3518985090088779359">Aceptar y continuar</translation>
+<translation id="7207456302801184289">Te damos la bienvenida a Brave</translation>
+<translation id="704822250101715322">Esperando a que Servicios de Brave Software Play termine de actualizarse</translation>
+<translation id="1231733316453485619">¿Activar sincronización?</translation>
+<translation id="5132942445612118989">Sincroniza tus contraseñas, tu historial y otras opciones en todos tus dispositivos</translation>
+<translation id="5736731321935944068">Es posible que Brave Software utilice tu historial para personalizar la Búsqueda, los anuncios y otros servicios de Brave Software</translation>
+<translation id="4013614219085422040">Es posible que Brave Software utilice tu historial para personalizar la Búsqueda y otros servicios de Brave Software</translation>
+<translation id="5581519193887989363">Siempre puedes seleccionar qué contenido quieres sincronizar desde <ph name="BEGIN_LINK1"/>Ajustes<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Sí, acepto</translation>
+<translation id="2410754283952462441">Elegir una cuenta</translation>
+<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">¿No eres <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Activa la sincronización para ver tus marcadores en todos tus dispositivos</translation>
+<translation id="2818669890320396765">Inicia sesión y activa la sincronización para ver tus marcadores en todos tus dispositivos</translation>
+<translation id="6003646045106347985">Activa la sincronización para obtener contenido personalizado sugerido por Brave Software</translation>
+<translation id="8494430740943879273">Inicia sesión y activa la sincronización para obtener contenido personalizado sugerido por Brave Software</translation>
+<translation id="5862731021271217234">Activa la sincronización para ver las pestañas de tus otros dispositivos</translation>
+<translation id="3568688522516854065">Inicia sesión y activa la sincronización para ver las pestañas de tus otros dispositivos</translation>
+<translation id="1208340532756947324">Activa la sincronización para sincronizar y personalizar todos tus dispositivos</translation>
+<translation id="4472118726404937099">Inicia sesión y activa la sincronización para sincronizar y personalizar todos tus dispositivos</translation>
+<translation id="2426805022920575512">Elegir otra cuenta</translation>
+<translation id="6790428901817661496">Reproducir</translation>
+<translation id="1272079795634619415">Interrumpir</translation>
+<translation id="2874939134665556319">Pista anterior</translation>
+<translation id="4046123991198612571">Pista siguiente</translation>
+<translation id="3859306556332390985">Buscar hacia delante</translation>
+<translation id="8441146129660941386">Buscar hacia atrás</translation>
+<translation id="6706288973712894588">Actualmente no tienes conexión.\n<ph name="BEGIN_LINK"/>Explora tu feed sin conexión.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Pestañas recientes</translation>
+<translation id="8497726226069778601">Aún no tienes contenido</translation>
+<translation id="5423934151118863508">Aquí aparecerán las páginas a las que accedes con más frecuencia</translation>
+<translation id="6127379762771434464">Elemento quitado</translation>
+<translation id="4605958867780575332">Elemento retirado: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodles de Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Otros dispositivos</translation>
+<translation id="4738836084190194332">Última sincronización: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Hace # minuto}other{Hace # minutos}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Hace # hora}other{Hace # horas}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Hace # día}other{Hace # días}}</translation>
+<translation id="2762000892062317888">ahora mismo</translation>
+<translation id="1407135791313364759">Abrir todas</translation>
+<translation id="1209206284964581585">Ocultar por ahora</translation>
+<translation id="129553762522093515">Cerrado recientemente</translation>
+<translation id="8413126021676339697">Mostrar historial completo</translation>
+<translation id="7876243839304621966">Eliminar todo</translation>
+<translation id="8487700953926739672">Disponible sin conexión</translation>
+<translation id="5224771365102442243">Con vídeo</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Más información<ph name="END_LINK"/> sobre el contenido sugerido</translation>
+<translation id="7542481630195938534">No se pueden obtener sugerencias</translation>
+<translation id="5013696553129441713">No hay sugerencias nuevas</translation>
+<translation id="1736419249208073774">Más información</translation>
+<translation id="7444811645081526538">Más categorías</translation>
+<translation id="6709133671862442373">Noticias</translation>
+<translation id="1264974993859112054">Deportes</translation>
+<translation id="9139318394846604261">Compras</translation>
+<translation id="3912508018559818924">Buscando lo mejor de la Web…</translation>
+<translation id="526421993248218238">No puede cargar esta página web</translation>
+<translation id="614940544461990577">Prueba a:</translation>
+<translation id="3288003805934695103">Volver a cargar la página</translation>
+<translation id="2353636109065292463">Comprobar tu conexión a Internet</translation>
+<translation id="2858138569776157458">Populares</translation>
+<translation id="8364299278605033898">Descubre los sitios web populares</translation>
+<translation id="1171770572613082465">Toca el botón Populares para ver los sitios web más populares</translation>
+<translation id="5233638681132016545">Nueva pestaña</translation>
+<translation id="4521874409998847950">De <ph name="PUBLISHER_ORIGIN"/> (<ph name="BEGIN_DEEMPHASIZED"/>ofrecida por Brave Software<ph name="END_DEEMPHASIZED"/>)</translation>
+<translation id="2587052924345400782">Hay una nueva versión disponible</translation>
+<translation id="4058091506841967397">No se puede actualizar Brave.</translation>
+<translation id="6316139424528454185">Esta versión de Android no es compatible</translation>
+<translation id="6989267951144302301">Error al descargar</translation>
+<translation id="624789221780392884">Actualización lista</translation>
+<translation id="1549000191223877751">Mover a otra ventana</translation>
+<translation id="7481312909269577407">Adelante</translation>
+<translation id="4084682180776658562">Añadir a marcadores</translation>
+<translation id="6437478888915024427">Información de la página</translation>
+<translation id="7180611975245234373">Actualizar</translation>
+<translation id="4913169188695071480">Dejar de actualizar</translation>
+<translation id="1829244130665387512">Buscar en la página</translation>
+<translation id="6593061639179217415">Versión para ordenador</translation>
+<translation id="9063523880881406963">Desactivar opción para ver como ordenador</translation>
+<translation id="2038563949887743358">Activar opción para ver como ordenador</translation>
+<translation id="2433507940547922241">Aspecto</translation>
+<translation id="983192555821071799">Cerrar todas las pestañas</translation>
+<translation id="1310482092992808703">Agrupar pestañas</translation>
+<translation id="7725024127233776428">Las páginas que añadas a marcadores aparecerán aquí</translation>
+<translation id="4404568932422911380">Sin marcadores</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> marcador}other{<ph name="BOOKMARKS_COUNT_MANY"/> marcadores}}</translation>
+<translation id="3739899004075612870">Marcador añadido a <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Añadido a marcadores</translation>
+<translation id="4452548195519783679">Marcador añadido a <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">No se ha podido añadir el marcador.</translation>
+<translation id="2842985007712546952">Carpeta principal</translation>
+<translation id="9065203028668620118">Editar</translation>
+<translation id="4405224443901389797">Mover a…</translation>
+<translation id="5170568018924773124">Mostrar en carpeta</translation>
+<translation id="8035133914807600019">Nueva carpeta…</translation>
+<translation id="4532845899244822526">Seleccionar carpeta</translation>
+<translation id="6627583120233659107">Editar carpeta</translation>
+<translation id="1197267115302279827">Mover marcadores</translation>
+<translation id="6963766334940102469">Eliminar marcadores</translation>
+<translation id="4351244548802238354">Cerrar cuadro de diálogo</translation>
+<translation id="451872707440238414">Buscar en tus marcadores</translation>
+<translation id="8901170036886848654">No se han encontrado marcadores</translation>
+<translation id="6404511346730675251">Editar marcador</translation>
+<translation id="3894427358181296146">Añadir carpeta</translation>
+<translation id="5327248766486351172">Nombre</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Carpeta</translation>
+<translation id="5161254044473106830">Título obligatorio</translation>
+<translation id="2996809686854298943">URL necesaria</translation>
+<translation id="2536728043171574184">Viendo una copia sin conexión de esta página</translation>
+<translation id="4698034686595694889">Ver sin conexión en <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> y más sitios web</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave cargará la página cuando el dispositivo esté listo}other{Brave cargará las páginas cuando el dispositivo esté listo}}</translation>
+<translation id="6811034713472274749">Ya se puede ver la página</translation>
+<translation id="4561979708150884304">Sin conexión</translation>
+<translation id="8274165955039650276">Ver descargas</translation>
+<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER"/> de <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Sin resultados</translation>
+<translation id="981121421437150478">Sin conexión</translation>
+<translation id="3298243779924642547">Básico</translation>
+<translation id="393697183122708255">La búsqueda por voz no está disponible</translation>
+<translation id="7191430249889272776">Pestaña abierta en segundo plano.</translation>
+<translation id="8445059357334030806">Abrir en Brave</translation>
+<translation id="4720023427747327413">Abrir en <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Abrir en el navegador</translation>
+<translation id="1113597929977215864">Mostrar vista simplificada</translation>
+<translation id="1513352483775369820">Historial web y marcadores</translation>
+<translation id="4939482511480190003"><ph name="BEGIN_LINK"/>Realiza la encuesta<ph name="END_LINK"/> para ayudar a mejorar Brave</translation>
+<translation id="2501278716633472235">Volver</translation>
+<translation id="5596627076506792578">Más opciones</translation>
+<translation id="3522247891732774234">Actualización disponible. Más opciones</translation>
+<translation id="6773423637732432200">No se ha podido actualizar Brave. Más opciones</translation>
+<translation id="3328801116991980348">Información del sitio</translation>
+<translation id="5391532827096253100">Tu conexión a este sitio web no es segura. Información del sitio web</translation>
+<translation id="6206551242102657620">La conexión es segura. Información del sitio web</translation>
+<translation id="6963642900430330478">Esta página es peligrosa. Información del sitio web</translation>
+<translation id="9070377983101773829">Iniciar búsqueda por voz</translation>
+<translation id="8676374126336081632">Borrar entrada</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> pestaña abierta, toca para cambiar de una a otra}other{<ph name="OPEN_TABS_MANY"/> pestañas abiertas, toca para cambiar de una a otra}}</translation>
+<translation id="2369533728426058518">pestañas abiertas</translation>
+<translation id="7071521146534760487">Gestionar cuenta</translation>
+<translation id="932327136139879170">Página principal</translation>
+<translation id="2707726405694321444">Actualizar página</translation>
+<translation id="2891154217021530873">Detener la carga de la página</translation>
+<translation id="6710213216561001401">Anterior</translation>
+<translation id="6659594942844771486">Pestaña</translation>
+<translation id="1933845786846280168">Pestaña seleccionada</translation>
+<translation id="2268044343513325586">Restringir</translation>
+<translation id="7846076177841592234">Cancelar selección</translation>
+<translation id="7087918508125750058">Elementos seleccionados: <ph name="ITEM_COUNT"/>. Hay opciones disponibles en la parte superior de la pantalla</translation>
+<translation id="7250468141469952378">Elementos seleccionados: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Compartir 1 elemento seleccionado}other{Compartir # elementos seleccionados}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Quitar 1 elemento seleccionado}other{Quitar # elementos seleccionados}}</translation>
+<translation id="1283039547216852943">Toca para ampliar</translation>
+<translation id="5962718611393537961">Toca para ocultar</translation>
+<translation id="8076492880354921740">Pestañas</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 seleccionado}other{# seleccionados}}</translation>
+<translation id="6818926723028410516">Seleccionar elementos</translation>
+<translation id="4797039098279997504">Toca para volver a <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Toca para ir al sitio web</translation>
+<translation id="429312253194641664">Un sitio web está reproduciendo elementos multimedia</translation>
+<translation id="4958708863221495346">Estás compartiendo tu pantalla a través de <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="8833831881926404480">Un sitio web está compartiendo tu pantalla</translation>
+<translation id="9086455579313502267">No ha sido posible acceder a la red</translation>
+<translation id="938850635132480979">Error: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Abrir en <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Abrirla en una aplicación de mapas</translation>
+<translation id="7698359219371678927">Crear correo electrónico en <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Crear correo electrónico</translation>
+<translation id="5665379678064389456">Crear evento en <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Crear evento</translation>
+<translation id="2111511281910874386">Ir a la página</translation>
+<translation id="3988466920954086464">Ver resultados de búsqueda instantánea en este panel</translation>
+<translation id="2744248271121720757">Toca una palabra para buscarla de forma instantánea o ver acciones relacionadas</translation>
+<translation id="9155898266292537608">También puedes tocar rápidamente una palabra para hacer búsquedas</translation>
+<translation id="3232754137068452469">Aplicación web</translation>
+<translation id="1430915738399379752">Imprimir</translation>
+<translation id="3775705724665058594">Enviar a tus dispositivos</translation>
+<translation id="6364438453358674297">¿Eliminar sugerencia del historial?</translation>
+<translation id="213279576345780926">Pestaña de <ph name="TAB_TITLE"/> cerrada</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> pestañas cerradas</translation>
+<translation id="3211426585530211793">Se ha eliminado <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">Se han eliminado <ph name="NUMBER_OF_BOOKMARKS"/> marcadores</translation>
+<translation id="3819178904835489326">Descargas eliminadas: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Número de instancias de Brave no admitido.</translation>
+<translation id="4259722352634471385">Se ha bloqueado la navegación: <ph name="URL"/></translation>
+<translation id="8959122750345127698">No se puede realizar la navegación: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Cerrar pestaña</translation>
+<translation id="7772375229873196092">Cerrar <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Historial de navegación</translation>
+<translation id="9169507124922466868">El historial de navegación está medio abierto</translation>
+<translation id="1327257854815634930">El historial de navegación está abierto</translation>
+<translation id="8788265440806329501">El historial de navegación está cerrado</translation>
+<translation id="7482656565088326534">Pestaña de vista previa</translation>
+<translation id="8427875596167638501">La pestaña de vista previa está medio abierta</translation>
+<translation id="9102803872260866941">La pestaña de vista previa está abierta</translation>
+<translation id="2942036813789421260">La pestaña de vista previa está cerrada</translation>
+<translation id="6355102470683871794">Almacenamiento de Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">¿Borrar almacenamiento web?</translation>
+<translation id="9205995714227143200">Almacenamiento del sitio web que Brave no considera importante (p. ej., los sitios web sin configuración guardada o aquellos que no visitas a menudo)</translation>
+<translation id="3997476611815694295">Almacenamiento no importante</translation>
+<translation id="8493948351860045254">Liberar espacio</translation>
+<translation id="2324920234469020158">Se borrarán las cookies, la caché y otros datos de los sitios web que Brave no considere importantes.</translation>
+<translation id="5447201525962359567">Todo el almacenamiento del sitio web, como las cookies y otros datos almacenados de forma local</translation>
+<translation id="1376578503827013741">Calculando…</translation>
+<translation id="583281660410589416">Desconocido</translation>
+<translation id="2323763861024343754">Almacenamiento del sitio web</translation>
+<translation id="3587672679800759167">Datos totales utilizados por Brave, incluidos los marcadores, las cuentas y la configuración guardada</translation>
+<translation id="6545017243486555795">Borrar todos los datos</translation>
+<translation id="4095146165863963773">¿Eliminar datos de la aplicación?</translation>
+<translation id="53119194224775367">Todos los datos de la aplicación Brave se eliminarán de forma permanente. Esto incluye todos los archivos, ajustes, cuentas, bases de datos, etc.</translation>
+<translation id="5307446750509046227">Liberar espacio</translation>
+<translation id="300526633675317032">Se borrarán los <ph name="SIZE_IN_KB"/> de almacenamiento del sitio web.</translation>
+<translation id="8068648041423924542">No se puede seleccionar el certificado.</translation>
+<translation id="2315043854645842844">El sistema operativo no admite la selección de certificados de cliente.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> quiere conectarse</translation>
+<translation id="5308380583665731573">Conectar</translation>
+<translation id="868929229000858085">Buscar en tus contactos</translation>
+<translation id="1919950603503897840">Seleccionar contactos</translation>
+<translation id="7986741934819883144">Selecciona un contacto</translation>
+<translation id="3333961966071413176">Todos los contactos</translation>
+<translation id="4994033804516042629">No se han encontrado contactos</translation>
+<translation id="5403592356182871684">Nombres</translation>
+<translation id="2717722538473713889">Direcciones de correo electrónico</translation>
+<translation id="381841723434055211">Números de teléfono</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(y 1 más)}other{(y # más)}}</translation>
+<translation id="5197729504361054390">Los contactos que selecciones se compartirán con el sitio web <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Decodificador de imágenes</translation>
+<translation id="8067883171444229417">Reproducir vídeo</translation>
+<translation id="6560414384669816528">Realizar búsquedas con Sogou</translation>
+<translation id="5406914950576900927">Brave puede utilizar <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> para hacer búsquedas en China. Puedes cambiar esta opción en <ph name="BEGIN_LINK"/>Configuración<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Mantener Brave Software como motor de búsqueda predeterminado</translation>
+<translation id="4384468725000734951">Sogou se ha establecido como motor de búsqueda predeterminado</translation>
+<translation id="6103327872225198548">Brave Software se ha establecido como motor de búsqueda predeterminado</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Esta aplicación se está ejecutando en Brave</translation>
+<translation id="6143689084714664628">Se está ejecutando en Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> también tiene datos en Brave</translation>
+<translation id="2734140769649165081">Puedes borrar los datos en la configuración de Brave</translation>
+<translation id="8232956427053453090">Conservar datos</translation>
+<translation id="4298388696830689168">Sitios web enlazados</translation>
+<translation id="5763514718066511291">Toca para copiar la URL de esta aplicación</translation>
+<translation id="6496823230996795692">Para utilizar <ph name="APP_NAME"/> por primera vez, conéctate a Internet.</translation>
+<translation id="751961395872307827">No se puede establecer conexión con el sitio web</translation>
+<translation id="4878404682131129617">No se ha podido establecer conexión a través del servidor proxy</translation>
+<translation id="4749960740855309258">Abre una pestaña nueva</translation>
+<translation id="8788968922598763114">Vuelve a abrir la última pestaña cerrada</translation>
+<translation id="7929962904089429003">Abre el menú</translation>
+<translation id="6039379616847168523">Te dirige a la siguiente pestaña</translation>
+<translation id="5210286577605176222">Te dirige a la pestaña anterior</translation>
+<translation id="124678866338384709">Cierra la pestaña actual</translation>
+<translation id="3714981814255182093">Abre la barra de búsqueda</translation>
+<translation id="5441522332038954058">Te dirige a la barra de direcciones</translation>
+<translation id="3398320232533725830">Abre el administrador de marcadores</translation>
+<translation id="6583199322650523874">Añade la página actual a marcadores</translation>
+<translation id="8489271220582375723">Abre la página Historial</translation>
+<translation id="4837753911714442426">Abre las opciones para imprimir la página</translation>
+<translation id="5726692708398506830">Amplía todo el contenido de la página</translation>
+<translation id="3259831549858767975">Reduce todo el contenido de la página</translation>
+<translation id="8015452622527143194">Restaura el tamaño predeterminado del contenido</translation>
+<translation id="3443221991560634068">Vuelve a cargar la página actual</translation>
+<translation id="123724288017357924">Vuelve a cargar esta página sin contenido en caché</translation>
+<translation id="305870044889644984">Abre la Ayuda de Brave en una pestaña nueva</translation>
+<translation id="3166827708714933426">Combinaciones de teclas de pestañas y ventanas</translation>
+<translation id="3169981355900570544">Combinaciones de teclas de funciones de Brave Software Brave</translation>
+<translation id="4558311620361989323">Combinaciones de teclas en páginas web</translation>
+<translation id="1908301351964700579">Brave todavía se está preparando para la realidad virtual. Reinicia Brave más tarde.</translation>
+<translation id="8970887620466824814">Ha ocurrido un error.</translation>
+<translation id="1875543012935658554">Vuelve a abrir Brave.</translation>
+<translation id="79859296434321399">Instala ARCore para visualizar contenido de realidad aumentada</translation>
+<translation id="8558485628462305855">Actualiza ARCore para visualizar contenido de realidad aumentada</translation>
+<translation id="3513704683820682405">Realidad aumentada</translation>
+<translation id="5475862044948910901">¿Quieres iniciar la sesión de realidad aumentada?</translation>
 <translation id="7365126855094612066">Durante esta sesión, el sitio web podrá:
 • crear un mapa 3D de tu entorno
 • hacer un seguimiento del movimiento de la cámara
 
 El sitio web no obtendrá acceso a la cámara. Solo tú puedes ver las imágenes de la cámara.</translation>
-<translation id="7375125077091615385">Tipo:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Primera experiencia de ejecución de Chrome</translation>
-<translation id="741204030948306876">Sí, acepto</translation>
-<translation id="7413229368719586778">Fecha de inicio: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Preguntar antes</translation>
-<translation id="7423538860840206698">Se ha bloqueado la lectura del portapapeles</translation>
-<translation id="7431991332293347422">Controlar cómo se utiliza el historial de navegación para personalizar la Búsqueda y otras opciones</translation>
-<translation id="7437998757836447326">Cerrar sesión en Chrome</translation>
-<translation id="7438641746574390233">Cuando el modo básico está activado, Chrome usa los servidores de Google para cargar las páginas web más rápido. El modo básico reescribe las páginas lentas para cargar solo el contenido esencial. El modo básico no puede activarse en las pestañas de incógnito.</translation>
-<translation id="7444811645081526538">Más categorías</translation>
-<translation id="7445411102860286510">Permite que los sitios web reproduzcan automáticamente los vídeos silenciados (recomendado)</translation>
-<translation id="7453467225369441013">Cierra tu sesión en la mayoría de los sitios web. No se cerrará la sesión en tu cuenta de Google.</translation>
-<translation id="7454641608352164238">No hay espacio suficiente</translation>
-<translation id="7475192538862203634">Si este mensaje aparece con frecuencia, prueba estas <ph name="BEGIN_LINK" />sugerencias<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">No se ha encontrado la tarjeta SD. Es posible que falten algunos de tus archivos.</translation>
-<translation id="7479104141328977413">Gestión de pestañas</translation>
-<translation id="7481312909269577407">Adelante</translation>
-<translation id="7482656565088326534">Pestaña de vista previa</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (actualizada el <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">de datos ahorrados</translation>
-<translation id="7498271377022651285">Espera…</translation>
-<translation id="7514365320538308">Descargar</translation>
-<translation id="751961395872307827">No se puede establecer conexión con el sitio web</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">No se pueden obtener sugerencias</translation>
-<translation id="7559975015014302720">El modo básico está desactivado</translation>
-<translation id="7562080006725997899">Borrando datos de navegación</translation>
-<translation id="756809126120519699">Datos de Chrome borrados</translation>
-<translation id="757524316907819857">Impedir que los sitios web reproduzcan contenido protegido</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> archivo descargado}other{<ph name="FILES_DOWNLOADED_MANY" /> archivos descargados}}</translation>
-<translation id="7588219262685291874">Activar el tema oscuro cuando el dispositivo esté en modo de ahorro de batería</translation>
-<translation id="7589445247086920869">Bloquear para el motor de búsqueda actual</translation>
-<translation id="7593557518625677601">Abre los ajustes de Android y vuelve a habilitar la sincronización del sistema Android para iniciar la sincronización de Chrome</translation>
-<translation id="7596558890252710462">Sistema operativo</translation>
-<translation id="7605594153474022051">La sincronización no funciona</translation>
-<translation id="7606077192958116810">El modo básico está activado. Configúralo en Ajustes.</translation>
-<translation id="7612619742409846846">Has iniciado sesión en Google como</translation>
-<translation id="7619072057915878432">No se ha podido descargar <ph name="FILE_NAME" /> debido a problemas de la red.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Obtener ayuda<ph name="END_LINK1" /> o <ph name="BEGIN_LINK2" />volver a buscar<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Te damos la bienvenida a Chrome</translation>
-<translation id="7638584964844754484">Frase de contraseña incorrecta</translation>
-<translation id="7641339528570811325">Borrar datos de navegación…</translation>
-<translation id="7648422057306047504">Cifrar contraseñas con credenciales de Google</translation>
-<translation id="7649070708921625228">Ayuda</translation>
-<translation id="7658239707568436148">Cancelar</translation>
-<translation id="7665369617277396874">Añadir cuenta</translation>
-<translation id="766587987807204883">Los artículos se muestran aquí y los puedes leer aunque no tengas conexión a Internet</translation>
-<translation id="7682724950699840886">Prueba los siguientes consejos: deja suficiente espacio en el dispositivo y vuelve a exportar las contraseñas.</translation>
-<translation id="7685301384041462804">Asegúrate de que este sitio web sea de confianza antes de acceder al modo de realidad virtual.</translation>
-<translation id="7698359219371678927">Crear correo electrónico en <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Autocompletar búsquedas y URLs</translation>
-<translation id="7725024127233776428">Las páginas que añadas a marcadores aparecerán aquí</translation>
-<translation id="773466115871691567">Traducir siempre las páginas en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Para detectar aplicaciones y sitios web peligrosos, Chrome envía a Google las URL de algunas de las páginas que visitas, información limitada del sistema y parte del contenido de las páginas.</translation>
-<translation id="7757787379047923882">Texto compartido desde <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Tarjeta SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Añadir dirección</translation>
-<translation id="7772032839648071052">Repite la contraseña</translation>
-<translation id="7772375229873196092">Cerrar <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> más}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 y <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> más}}</translation>
-<translation id="7781829728241885113">Ayer</translation>
-<translation id="7791543448312431591">Añadir</translation>
-<translation id="780301667611848630">No, gracias</translation>
-<translation id="7810647596859435254">Abrir con…</translation>
-<translation id="7821588508402923572">El ahorro de datos aparecerá aquí</translation>
-<translation id="7837721118676387834">Permitir que un sitio web específico reproduzca automáticamente los vídeos silenciados.</translation>
-<translation id="7846076177841592234">Cancelar selección</translation>
-<translation id="784934925303690534">Intervalo de tiempo</translation>
-<translation id="7851858861565204677">Otros dispositivos</translation>
-<translation id="7875915731392087153">Crear correo electrónico</translation>
-<translation id="7876243839304621966">Eliminar todo</translation>
-<translation id="7882131421121961860">No se ha encontrado el elemento buscado en el historial</translation>
-<translation id="7882806643839505685">Permite que se reproduzcan sonidos en un sitio web específico.</translation>
-<translation id="7886917304091689118">Se está ejecutando en Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Descargando archivo.}other{Descargando # archivos.}}</translation>
-<translation id="7929962904089429003">Abre el menú</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> está obsoleto.</translation>
-<translation id="7947953824732555851">Aceptar y acceder</translation>
-<translation id="7963646190083259054">Proveedor:</translation>
-<translation id="7971136598759319605">Activo hace 1 día</translation>
-<translation id="7975379999046275268">Revisar página <ph name="BEGIN_NEW" />Nuevo<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Cargar previamente las páginas para que la navegación y las búsquedas sean más rápidas</translation>
-<translation id="79859296434321399">Instala ARCore para visualizar contenido de realidad aumentada</translation>
-<translation id="7986741934819883144">Selecciona un contacto</translation>
-<translation id="7987073022710626672">Condiciones del servicio de Chrome</translation>
-<translation id="7998918019931843664">Volver a abrir pestaña cerrada</translation>
-<translation id="7999064672810608036">¿Seguro que quieres borrar todos los datos locales, incluidas las cookies, y restablecer todos los permisos de este sitio web?</translation>
-<translation id="8004582292198964060">Navegador</translation>
-<translation id="8007176423574883786">Desactivada para este dispositivo</translation>
-<translation id="8013372441983637696">Borrar también los datos de Chrome de este dispositivo</translation>
-<translation id="8015452622527143194">Restaura el tamaño predeterminado del contenido</translation>
-<translation id="802154636333426148">No se ha podido descargar el archivo</translation>
-<translation id="8026334261755873520">Borrar datos de navegación</translation>
-<translation id="8035133914807600019">Nueva carpeta…</translation>
-<translation id="8037750541064988519">Quedan <ph name="DAYS" /> días</translation>
-<translation id="804335162455518893">No se ha encontrado la tarjeta SD</translation>
-<translation id="805047784848435650">Según tu historial de navegación</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB disponible(s)</translation>
-<translation id="8058746566562539958">Abrir en una pestaña nueva</translation>
-<translation id="8063895661287329888">No se ha podido añadir el marcador.</translation>
-<translation id="806745655614357130">Mantener mis datos separados</translation>
-<translation id="8067883171444229417">Reproducir vídeo</translation>
-<translation id="8068648041423924542">No se puede seleccionar el certificado.</translation>
-<translation id="8073388330009372546">Abrir en pestaña nueva</translation>
-<translation id="8076492880354921740">Pestañas</translation>
-<translation id="8084114998886531721">Contraseña guardada</translation>
-<translation id="8087000398470557479">Este contenido procede de <ph name="DOMAIN_NAME" />, publicado por Google.</translation>
-<translation id="8103578431304235997">Pestaña de incógnito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Activa la sincronización para ver tus marcadores en todos tus dispositivos</translation>
-<translation id="8110087112193408731">¿Mostrar tu actividad de Chrome en Bienestar digital?</translation>
-<translation id="8116925261070264013">Silenciados</translation>
-<translation id="813082847718468539">Ver información del sitio</translation>
-<translation id="8131740175452115882">Confirmar</translation>
-<translation id="8156139159503939589">¿Qué idiomas puedes leer?</translation>
-<translation id="8168435359814927499">Contenido</translation>
-<translation id="8186512483418048923">Archivos restantes: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Queda 1 día</translation>
-<translation id="8200772114523450471">Reanudar</translation>
-<translation id="8209050860603202033">Abrir imagen</translation>
-<translation id="8218622182176210845">Gestionar tu cuenta</translation>
-<translation id="8224471946457685718">Descargar artículos recomendados para ti con Wi‑Fi</translation>
-<translation id="8232956427053453090">Conservar datos</translation>
-<translation id="8249310407154411074">Mover al principio</translation>
-<translation id="8250920743982581267">Documentos</translation>
-<translation id="825412236959742607">Esta página utiliza demasiada memoria, por lo que Chrome ha eliminado parte del contenido.</translation>
-<translation id="8260126382462817229">Prueba a iniciar sesión de nuevo</translation>
-<translation id="8261506727792406068">Eliminar</translation>
-<translation id="8266862848225348053">Ubicación de las descargas</translation>
-<translation id="8274165955039650276">Ver descargas</translation>
-<translation id="8284326494547611709">Subtítulos</translation>
-<translation id="8300705686683892304">Administrados por una aplicación</translation>
-<translation id="8310344678080805313">Pestañas estándar</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> y más sitios web</translation>
-<translation id="8327155640814342956">Para disfrutar de la mejor experiencia de navegación posible, abre Chrome para actualizarlo.</translation>
-<translation id="8339163506404995330">No se traducirán las páginas en <ph name="LANGUAGE" /></translation>
-<translation id="8349013245300336738">Ordenar por cantidad de datos usados</translation>
-<translation id="8364299278605033898">Descubre los sitios web populares</translation>
-<translation id="8368027906805972958">Dispositivo desconocido o no compatible (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Permite la sincronización en segundo plano de un sitio web específico.</translation>
-<translation id="8378714024927312812">Gestionado por tu organización</translation>
-<translation id="8380167699614421159">El sitio web muestra anuncios invasivos o engañosos</translation>
-<translation id="8393700583063109961">Enviar mensaje</translation>
-<translation id="8413126021676339697">Mostrar historial completo</translation>
-<translation id="8427875596167638501">La pestaña de vista previa está medio abierta</translation>
-<translation id="8428213095426709021">Configuración</translation>
-<translation id="8438566539970814960">Mejorar las búsquedas y la navegación</translation>
-<translation id="8441146129660941386">Buscar hacia atrás</translation>
-<translation id="8443209985646068659">No se puede actualizar Chrome.</translation>
-<translation id="8445448999790540984">No se pueden exportar las contraseñas</translation>
-<translation id="8447861592752582886">Revocar permiso de dispositivo</translation>
-<translation id="8461694314515752532">Cifrar los datos sincronizados con tu propia frase de contraseña de sincronización</translation>
-<translation id="8466613982764129868">Comprueba que tu <ph name="TARGET_DEVICE_NAME" /> esté conectado a Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponible sin conexión</translation>
-<translation id="8489271220582375723">Abre la página Historial</translation>
-<translation id="8493948351860045254">Liberar espacio</translation>
-<translation id="8497726226069778601">Aún no tienes contenido</translation>
-<translation id="8503559462189395349">Contraseñas de Chrome</translation>
-<translation id="8503813439785031346">Nombre de usuario</translation>
-<translation id="8514477925623180633">Exportar contraseñas almacenadas en Chrome</translation>
-<translation id="8514577642972634246">Navegar en modo de incógnito</translation>
-<translation id="851751545965956758">No permitir que los sitios web se conecten a dispositivos</translation>
-<translation id="8523928698583292556">Eliminar contraseña guardada</translation>
-<translation id="854522910157234410">Abrir esta página</translation>
-<translation id="8558485628462305855">Actualiza ARCore para visualizar contenido de realidad aumentada</translation>
-<translation id="8559990750235505898">Ofrecer la traducción de páginas en otros idiomas</translation>
-<translation id="8562452229998620586">Las contraseñas guardadas aparecerán aquí.</translation>
-<translation id="8569404424186215731">desde el <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Últimas cuatro semanas</translation>
-<translation id="857943718398505171">Permitido (recomendado)</translation>
-<translation id="8583805026567836021">Borrando datos de cuenta</translation>
-<translation id="860043288473659153">Nombre del titular de la tarjeta</translation>
-<translation id="8609465669617005112">Subir</translation>
-<translation id="8616006591992756292">Es posible que tu cuenta de Google tenga otros tipos de historial de navegación en <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">¿Quieres abrir la URL sugerida que se especifica en el contenido descargado?</translation>
-<translation id="8636825310635137004">Activa la sincronización para ver las pestañas de tus otros dispositivos.</translation>
-<translation id="8641930654639604085">Intentar bloquear sitios web para adultos</translation>
-<translation id="8655129584991699539">Puedes borrar los datos en la configuración de Chrome</translation>
-<translation id="8662811608048051533">Cierra tu sesión en la mayoría de los sitios web.</translation>
-<translation id="8664979001105139458">El nombre del archivo ya existe</translation>
-<translation id="8676374126336081632">Borrar entrada</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Nivel de intensidad de la señal: # barra}other{Nivel de intensidad de la señal: # barras}}</translation>
-<translation id="868929229000858085">Buscar en tus contactos</translation>
-<translation id="869891660844655955">Fecha de caducidad</translation>
-<translation id="8719023831149562936">No se puede compartir la pestaña actual.</translation>
-<translation id="8725066075913043281">Volver a intentarlo</translation>
-<translation id="8728487861892616501">Si utilizas esta aplicación, aceptas las <ph name="BEGIN_LINK1" />condiciones de servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />aviso de privacidad<ph name="END_LINK2" /> de Chrome, así como el <ph name="BEGIN_LINK3" />aviso de privacidad para cuentas de Google gestionadas con Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Listo</translation>
-<translation id="8748850008226585750">Contenidos ocultos</translation>
-<translation id="8751914237388039244">Selecciona una imagen</translation>
-<translation id="8788265440806329501">El historial de navegación está cerrado</translation>
-<translation id="8788968922598763114">Vuelve a abrir la última pestaña cerrada</translation>
-<translation id="8801436777607969138">Bloquear JavaScript en un sitio web específico.</translation>
-<translation id="8812260976093120287">En algunos sitios web, puedes realizar pagos en tu dispositivo con las aplicaciones compatibles mencionadas anteriormente.</translation>
-<translation id="8816026460808729765">No permite que los sitios web accedan a los sensores</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> se abrirá en Chrome. Si continúas, aceptas las <ph name="BEGIN_LINK1" />condiciones de servicio<ph name="END_LINK1" /> y el <ph name="BEGIN_LINK2" />aviso de privacidad<ph name="END_LINK2" /> de Chrome, así como el <ph name="BEGIN_LINK3" />aviso de privacidad para cuentas de Google gestionadas con Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Marcadores</translation>
-<translation id="8833831881926404480">Un sitio web está compartiendo tu pantalla</translation>
-<translation id="883806473910249246">No se ha podido descargar el contenido.</translation>
-<translation id="8840953339110955557">Esta página puede ser distinta de la versión online.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Pestaña <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Almacenamiento</translation>
-<translation id="889338405075704026">Ir a configuración de Chrome</translation>
-<translation id="8901170036886848654">No se han encontrado marcadores</translation>
-<translation id="8909135823018751308">Compartir…</translation>
-<translation id="8912362522468806198">cuenta de Google</translation>
-<translation id="8920114477895755567">Esperando detalles de los padres.</translation>
+<translation id="1188239144602654184">Acceder a RA</translation>
+<translation id="473775607612524610">Actualizar</translation>
+<translation id="3133489217401741157">Instalando <ph name="MODULE"/> para Brave…</translation>
+<translation id="1791662854739702043">Ubicación</translation>
+<translation id="5131234170665854056">No se puede instalar <ph name="MODULE"/> para Brave</translation>
+<translation id="2567385386134582609">IMAGEN</translation>
+<translation id="6395288395575013217">ENLACE</translation>
+<translation id="7352939065658542140">VÍDEO</translation>
+<translation id="4116038641877404294">Descarga páginas para usarlas sin conexión</translation>
 <translation id="8922289737868596582">Descarga páginas con el botón con el botón Más opciones para usarlas sin conexión</translation>
-<translation id="8937772741022875483">¿Eliminar tu actividad de Chrome de Bienestar digital?</translation>
-<translation id="8941729603749328384">www.ejemplo.com</translation>
-<translation id="8942627711005830162">Abrir en otra ventana</translation>
-<translation id="8951232171465285730">Chrome te ha permitido ahorrar <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Bloquear las cookies de un sitio web específico.</translation>
-<translation id="8959122750345127698">No se puede realizar la navegación: <ph name="URL" /></translation>
-<translation id="8965591936373831584">pendiente</translation>
-<translation id="8970887620466824814">Ha ocurrido un error.</translation>
-<translation id="8972098258593396643">¿Quieres descargarlo en la carpeta predeterminada?</translation>
-<translation id="8986494364107987395">Enviar automáticamente estadísticas de uso e informes sobre fallos a Google</translation>
-<translation id="8993760627012879038">Abre una nueva pestaña en modo de incógnito</translation>
-<translation id="8998729206196772491">Estás iniciando sesión con una cuenta gestionada por <ph name="MANAGED_DOMAIN" />, lo que significa que vas a proporcionar a su administrador el control sobre tus datos de Chrome. Los datos se vincularán de forma permanente a esta cuenta. Si cierras sesión en Chrome, se eliminarán los datos de este dispositivo, pero permanecerán almacenados en tu cuenta de Google.</translation>
-<translation id="9019902583201351841">Administrado por tus padres</translation>
-<translation id="9028914725102941583">Activar la sincronización para compartir con otros dispositivos</translation>
-<translation id="9029323097866369874">¿Permites a <ph name="DOMAIN" /> acceder al modo de realidad virtual?</translation>
-<translation id="9040142327097499898">Las notificaciones están permitidas. La ubicación está desactivada en este dispositivo.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}other{# vídeos}}</translation>
-<translation id="9050666287014529139">Frase de contraseña</translation>
-<translation id="9063523880881406963">Desactivar opción para ver como ordenador</translation>
-<translation id="9065203028668620118">Editar</translation>
-<translation id="9070377983101773829">Iniciar búsqueda por voz</translation>
-<translation id="9074336505530349563">Inicia sesión y activa la sincronización para obtener contenido personalizado sugerido por Google</translation>
-<translation id="9086455579313502267">No ha sido posible acceder a la red</translation>
-<translation id="9100505651305367705">Pregunta si quieres que los artículos se muestren en vista simplificada, si está disponible</translation>
-<translation id="9100610230175265781">Se debe introducir una frase de contraseña</translation>
-<translation id="9102803872260866941">La pestaña de vista previa está abierta</translation>
+<translation id="5958275228015807058">Encuentra tus archivos y páginas en la sección Descargas</translation>
+<translation id="5620928963363755975">Encuentra tus archivos y páginas en la sección Descargas con el botón Más opciones</translation>
+<translation id="3341058695485821946">Consulta la cantidad de datos que has ahorrado</translation>
+<translation id="3157842584138209013">Consulta la cantidad de datos que has ahorrado con el botón Más opciones</translation>
+<translation id="8218622182176210845">Gestionar tu cuenta</translation>
+<translation id="8090895580117672212">Para gestionar tu cuenta de Brave Software, toca el botón Gestionar cuenta</translation>
+<translation id="8856898588039823173">Página básica ofrecida por Brave Software. Toca para cargar la original.</translation>
+<translation id="8134317863207426198">Página básica ofrecida por Brave Software. Si quieres ver la original, toca el botón para cargarla.</translation>
+<translation id="4961107849584082341">Traduce esta página a cualquier idioma</translation>
+<translation id="569536719314091526">Traduce esta página a cualquier idioma con el botón Más opciones</translation>
+<translation id="1397811292916898096">Buscar con <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Cambia la ubicación predeterminada de las descargas en cualquier momento</translation>
+<translation id="6942665639005891494">Cambia la ubicación predeterminada de las descargas en cualquier momento con la opción del menú Configuración</translation>
+<translation id="6850409657436465440">Tu descarga sigue en curso</translation>
+<translation id="5817715962196959877">Ahora Brave descarga los archivos más rápido</translation>
+<translation id="3976396876660209797">Quita esta combinación de teclas y vuelve a crearla</translation>
+<translation id="6766622839693428701">Desliza el dedo hacia abajo para cerrarla.</translation>
+<translation id="1028699632127661925">Enviando a <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Enviado desde <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Pestaña recibida</translation>
 <translation id="9104217018994036254">Lista de dispositivos con los que puedes compartir una pestaña.</translation>
-<translation id="9133397713400217035">Explorar sin conexión</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Mostrar original</translation>
-<translation id="9139068048179869749">Preguntar antes de permitir que los sitios web envíen notificaciones (recomendado)</translation>
-<translation id="9139318394846604261">Compras</translation>
-<translation id="9155898266292537608">También puedes tocar rápidamente una palabra para hacer búsquedas</translation>
-<translation id="9169507124922466868">El historial de navegación está medio abierto</translation>
-<translation id="9204836675896933765">1 archivo restante</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">La lista de dispositivos con los que puedes compartir una pestaña está abierta y ocupa la mitad inferior de la pantalla.</translation>
+<translation id="2904414404539560095">La lista de dispositivos con los que puedes compartir una pestaña está abierta y ocupa toda la pantalla.</translation>
+<translation id="4135200667068010335">La lista de dispositivos con los que puedes compartir una pestaña está cerrada.</translation>
+<translation id="5292796745632149097">Enviar a</translation>
+<translation id="1386674309198842382">Activo hace <ph name="LAST_UPDATED"/> días</translation>
+<translation id="7971136598759319605">Activo hace 1 día</translation>
+<translation id="1521774566618522728">Activo hoy</translation>
+<translation id="3631987586758005671">Compartiendo con <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Activar la sincronización para compartir con otros dispositivos</translation>
+<translation id="6162454065885854378">Si quieres compartir algo de tu teléfono con otro dispositivo, activa la sincronización en la configuración de Brave en ambos dispositivos.</translation>
+<translation id="6084271560289605378">Ir a configuración de Brave</translation>
+<translation id="2318045970523081853">Toca para llamar</translation>
 <translation id="9209888181064652401">No se pueden hacer llamadas</translation>
-<translation id="9219103736887031265">Imágenes</translation>
-<translation id="926205370408745186">Eliminar tu actividad de Chrome de Bienestar digital</translation>
-<translation id="932327136139879170">Página principal</translation>
-<translation id="938850635132480979">Error: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Acceder al micrófono</translation>
-<translation id="95817756606698420">Chrome puede utilizar <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> para hacer búsquedas en China. Puedes cambiar esta opción en <ph name="BEGIN_LINK" />Configuración<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloquear si el sitio web muestra anuncios invasivos o engañosos (opción recomendada)</translation>
-<translation id="968900484120156207">Las páginas que visites aparecerán aquí.</translation>
-<translation id="970715775301869095">Quedan <ph name="MINUTES" /> minutos</translation>
-<translation id="974555521953189084">Introduce la frase de contraseña para iniciar la sincronización</translation>
-<translation id="981121421437150478">Sin conexión</translation>
-<translation id="982182592107339124">Se borrarán los datos de todos los sitios web, incluidos:</translation>
-<translation id="983192555821071799">Cerrar todas las pestañas</translation>
-<translation id="987264212798334818">General</translation>
+<translation id="2860954141821109167">Comprueba que se haya habilitado una aplicación de teléfono en este dispositivo</translation>
+<translation id="2067805253194386918">texto</translation>
+<translation id="1450753235335490080">No se ha podido compartir: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">No se ha podido compartir: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Asegúrate de que la sincronización de tu <ph name="TARGET_DEVICE_NAME"/> está activada en Brave</translation>
+<translation id="3016635187733453316">Comprueba que este dispositivo esté conectado a Internet.</translation>
+<translation id="8466613982764129868">Comprueba que tu <ph name="TARGET_DEVICE_NAME"/> esté conectado a Internet</translation>
+<translation id="6539092367496845964">Se ha producido un error. Vuelve a intentarlo más tarde.</translation>
+<translation id="3389286852084373014">El texto es demasiado largo</translation>
+<translation id="2100314319871056947">Prueba a compartir el texto dividiéndolo en partes más pequeñas</translation>
+<translation id="2987620471460279764">Texto compartido desde otro dispositivo</translation>
+<translation id="7757787379047923882">Texto compartido desde <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Se ha copiado al portapapeles</translation>
+<translation id="4696983787092045100">Enviar mensaje de texto a tus dispositivos</translation>
+<translation id="1260236875608242557">Buscar y explorar</translation>
+<translation id="6369229450655021117">Desde aquí, puedes buscar en la Web, compartir contenido con amigos y ver las páginas abiertas</translation>
+<translation id="723171743924126238">Seleccionar imágenes</translation>
+<translation id="8751914237388039244">Selecciona una imagen</translation>
+<translation id="1989112275319619282">Examinar</translation>
+<translation id="7055152154916055070">Redirección bloqueada:</translation>
+<translation id="5524843473235508879">Redirección bloqueada.</translation>
+<translation id="6573096386450695060">Permitir siempre</translation>
+<translation id="5805364706385912897">Esta página utiliza demasiada memoria y Brave la ha pausado.</translation>
+<translation id="5138664332909611586">Esta página utiliza demasiada memoria, por lo que Brave ha eliminado parte del contenido.</translation>
+<translation id="9137013805542155359">Mostrar original</translation>
+<translation id="6361779936989026201">Asistente de Brave Software</translation>
+<translation id="7291387454912369099">Pago con el Asistente activado</translation>
+<translation id="4565206163201411670">¿Mostrar tu actividad de Brave en Bienestar digital?</translation>
+<translation id="9055113864158719823">Puedes ver los sitios web que visitas en Brave y ponerles temporizadores.\n\nBrave Software obtiene información sobre estos sitios web y sobre la duración de la visita. La información se usa para mejorar Bienestar digital.</translation>
+<translation id="4596514158372210596">Eliminar tu actividad de Brave de Bienestar digital</translation>
+<translation id="1174893863889683998">¿Eliminar tu actividad de Brave de Bienestar digital?</translation>
+<translation id="708829030563435351">Los sitios web que visites en Brave no se mostrarán. Se eliminarán todos los temporizadores de los sitios web.</translation>
+<translation id="2056878612599315956">Sitio web en pausa</translation>
+<translation id="671481426037969117">Se ha agotado el temporizador de <ph name="FQDN"/>. Se reiniciará mañana.</translation>
+<translation id="7479104141328977413">Gestión de pestañas</translation>
+<translation id="3524138585025253783">Interfaz para desarrolladores</translation>
+<translation id="6036057147555329831">ICU adicional</translation>
+<translation id="9029323097866369874">¿Permites a <ph name="DOMAIN"/> acceder al modo de realidad virtual?</translation>
+<translation id="7685301384041462804">Asegúrate de que este sitio web sea de confianza antes de acceder al modo de realidad virtual.</translation>
+<translation id="5033865233969348410">Mientras estés en el modo de realidad virtual, es posible que el sitio web obtenga información sobre lo siguiente:
+  - Tus características físicas, como tu altura.
+
+Asegúrate de que este sitio web sea de confianza antes de acceder al modo de realidad virtual.</translation>
+<translation id="5534334044554683961">Mientras estés en el modo de realidad virtual, es posible que el sitio web obtenga información sobre lo siguiente:
+  - Tus características físicas, como tu altura.
+  - La disposición de la habitación.
+
+Asegúrate de que este sitio web sea de confianza antes de acceder al modo de realidad virtual.</translation>
+<translation id="4169535189173047238">No permitir</translation>
+<translation id="2170088579611075216">Permitir y acceder a la realidad virtual</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_et.xtb
+++ b/android/java/strings/translations/android_chrome_strings_et.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="et">
-<translation id="1006017844123154345">Ava veebis</translation>
-<translation id="1028699632127661925">Saatmine seadmesse <ph name="DEVICE_NAME" /> …</translation>
-<translation id="1036727731225946849">APK <ph name="WEBAPK_NAME" /> lisamine …</translation>
-<translation id="1041308826830691739">Veebisaitidelt</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Ei ole kunagi salvestatud</translation>
-<translation id="1067922213147265141">Muud Google'i teenused</translation>
-<translation id="1068672505746868501">Ära tõlgi kunagi <ph name="SOURCE_LANGUAGE" /> keeles olevaid lehti</translation>
-<translation id="107147699690128016">Kui muudate faililaiendit, võib fail avaneda mõnes teises rakenduses ja teie seadmele ohtu kujutada.</translation>
-<translation id="1100066534610197918">Ava rühmas uuel vahelehel</translation>
-<translation id="1105960400813249514">Kuva jäädvustamine</translation>
-<translation id="1111673857033749125">Siin kuvatakse teie teistes seadmetes salvestatud järjehoidjad.</translation>
-<translation id="1113597929977215864">Kuva lihtsustatud vaade</translation>
-<translation id="1121094540300013208">Kasutus- ja krahhiaruanded</translation>
-<translation id="1124772482545689468">Kasutaja</translation>
-<translation id="1129510026454351943">Üksikasjad: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 allalaadimine on ootel.}other{# allalaadimist on ootel.}}</translation>
-<translation id="1145536944570833626">Kustutage olemasolevad andmed.</translation>
-<translation id="1146678959555564648">Ava VR</translation>
-<translation id="116280672541001035">Kasutatud</translation>
-<translation id="1171770572613082465">Vaadake populaarseid veebisaite, puudutades nuppu „Popid saidid”</translation>
-<translation id="1173894706177603556">Muuda nime</translation>
-<translation id="1178581264944972037">Peata</translation>
-<translation id="1181037720776840403">Eemalda</translation>
-<translation id="1188239144602654184">Sisene AR-i</translation>
-<translation id="1197267115302279827">Teisalda järjehoidjad</translation>
-<translation id="119944043368869598">Tühjenda kõik</translation>
-<translation id="1201402288615127009">Edasi</translation>
-<translation id="1204037785786432551">Allalaadimislink</translation>
-<translation id="1206892813135768548">Kopeeri lingi tekst</translation>
-<translation id="1208340532756947324">Seadmete vahel sünkroonimiseks ja isikupärastamiseks lülitage sünkroonimine sisse</translation>
-<translation id="1209206284964581585">Peida praeguseks</translation>
-<translation id="1227058898775614466">Navigeerimise ajalugu</translation>
-<translation id="1231733316453485619">Kas lülitada sünkroonimine sisse?</translation>
-<translation id="123724288017357924">Praeguse lehe uuesti laadimine, eirates vahemälus olevat sisu</translation>
-<translation id="124116460088058876">Rohkem keeli</translation>
-<translation id="124678866338384709">Aktiivse vahelehe sulgemine</translation>
-<translation id="1258753120186372309">Google'i Doodle'i vigurlogo: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Otsimine ja avastamine</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Üksust <ph name="CONTENT_TYPE" /> ei õnnestunud jagada</translation>
-<translation id="1272079795634619415">Peata</translation>
-<translation id="1283039547216852943">Laiendamiseks puudutage</translation>
-<translation id="1285320974508926690">Ära kunagi seda saiti tõlgi</translation>
-<translation id="1291207594882862231">Ajaloo, küpsiste, saidiandmete, vahemälu kustutamine …</translation>
-<translation id="129382876167171263">Veebisaitide salvestatud failid kuvatakse siin</translation>
-<translation id="129553762522093515">Viimati suletud</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – saadetud seadmest <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Vahelehtede grupeerimine</translation>
-<translation id="1327257854815634930">Navigeerimisajalugu on avatud</translation>
-<translation id="1331212799747679585">Chrome'i ei saa värskendada. Rohkem valikuid</translation>
-<translation id="1332501820983677155">Google Chrome'i funktsioonide otseteed</translation>
-<translation id="1360432990279830238">Login välja ja keelan sünkroonimise?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> on lisatud</translation>
-<translation id="1373696734384179344">Valitud sisu allalaadimiseks pole piisavalt mäluruumi.</translation>
-<translation id="1376578503827013741">Arvutamine …</translation>
-<translation id="1383876407941801731">Otsi</translation>
-<translation id="1384959399684842514">Allalaadimine peatatud</translation>
-<translation id="1386674309198842382">Aktiivne <ph name="LAST_UPDATED" /> päeva tagasi</translation>
-<translation id="1397811292916898096">Otsi teenusega <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Manustatud saidile <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">„Ära jälgi”</translation>
-<translation id="1407135791313364759">Ava kõik</translation>
-<translation id="1409426117486808224">Avatud vahelehtede lihtsustatud vaade</translation>
-<translation id="1409879593029778104">Faili <ph name="FILE_NAME" /> ei laaditud alla, kuna fail on juba olemas.</translation>
-<translation id="1414981605391750300">Google'iga ühenduse võtmine. See võib natuke aega võtta …</translation>
-<translation id="1416550906796893042">Rakenduse versioon</translation>
-<translation id="1430915738399379752">Printimine</translation>
-<translation id="1446450296470737166">MIDI-seadm. täieliku juht. lub.</translation>
-<translation id="1450753235335490080">Üksust <ph name="CONTENT_TYPE" /> ei saa jagada</translation>
-<translation id="145097072038377568">Android-seadetes välja lülitatud</translation>
-<translation id="1477626028522505441">Faili <ph name="FILE_NAME" /> allalaadimine ebaõnnestus serveriprobleemide tõttu.</translation>
-<translation id="1506061864768559482">Otsingumootor</translation>
-<translation id="1513352483775369820">Järjehoidjad ja veebiajalugu</translation>
-<translation id="1513858653616922153">Kustuta parool</translation>
-<translation id="1516229014686355813">Puudutamine otsimiseks saadab valitud sõna ja praeguse lehe kontekstina Google'i otsingusse. Selle saab välja lülitada jaotises <ph name="BEGIN_LINK" />Seaded<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktiivne täna</translation>
-<translation id="1544826120773021464">Oma Google'i konto haldamiseks puudutage nuppu „Konto haldamine”</translation>
-<translation id="1549000191223877751">Teisalda teise aknasse</translation>
-<translation id="1553358976309200471">Värskenda Chrome'i</translation>
-<translation id="1569387923882100876">Ühendatud seade</translation>
-<translation id="1571304935088121812">Kasutajanime kopeerimine</translation>
-<translation id="1612196535745283361">Chrome vajab seadmete otsimiseks juurdepääsu teie asukohale. Juurdepääs asukohale on <ph name="BEGIN_LINK" />selles seadmes välja lülitatud<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kaamera</translation>
-<translation id="1623104350909869708">Keela sellel lehel lisadialoogide loomine</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Eemalda 1 valitud üksus}other{Eemalda # valitud üksust}}</translation>
-<translation id="164269334534774161">Vaatate selle lehe võrguühenduseta koopiat kuupäevast <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Ajalugu</translation>
-<translation id="1647391597548383849">Juurdepääs kaamerale</translation>
-<translation id="1660204651932907780">Saitidel lubatakse esitada heli (soovitatav)</translation>
-<translation id="1670399744444387456">Põhiseaded</translation>
-<translation id="1671236975893690980">Allalaadimine on ootel …</translation>
-<translation id="1672586136351118594">Ära kuva uuesti</translation>
-<translation id="1692118695553449118">Sünkroonimine on sisse lülitatud</translation>
-<translation id="169515064810179024">Blokeeri saitide juurdepääs liikumisanduritele</translation>
-<translation id="1717218214683051432">Liikumisandurid</translation>
-<translation id="1718835860248848330">Viimase tunni jooksul</translation>
-<translation id="1736419249208073774">Avastage</translation>
-<translation id="1743802530341753419">Küsi luba, kui saidid üritavad seadmega ühendust luua (soovitatav)</translation>
-<translation id="1749561566933687563">Järjehoidjate sünkroonimine</translation>
-<translation id="17513872634828108">Avatud vahelehed</translation>
-<translation id="1779089405699405702">Pildi dekooder</translation>
-<translation id="1782483593938241562">Lõppkuupäev: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installitud</translation>
-<translation id="1792959175193046959">Allalaadimise vaikeasukohta saab alati muuta</translation>
-<translation id="1807246157184219062">Hele</translation>
-<translation id="1810845389119482123">Sünkroonimise algseadistus ei jõudnud lõpule</translation>
-<translation id="1821253160463689938">Kasutage küpsisefaile oma eelistuste meelespidamiseks isegi siis, kui te neid lehti ei külasta</translation>
-<translation id="1829244130665387512">Otsi leheküljelt</translation>
-<translation id="1853692000353488670">Uus inkognito vaheleht</translation>
-<translation id="1856325424225101786">Kas lähtestada lihtsustatud režiim?</translation>
-<translation id="1868024384445905608">Chrome laadib nüüd faile kiiremini alla</translation>
-<translation id="1883903952484604915">Minu failid</translation>
-<translation id="1887786770086287077">Juurdepääs asukohale on selle seadme puhul välja lülitatud. Lülitage see sisse <ph name="BEGIN_LINK" />Androidi seadetes<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> avaneb Chrome'is. Jätkates nõustute Chrome'i <ph name="BEGIN_LINK1" />teenusetingimuste<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />privaatsusteatised<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Reklaamid</translation>
-<translation id="1919950603503897840">Kontaktide valimine</translation>
-<translation id="1922076542920281912">Selleks et anda Chrome'ile juurdepääs teie asukohale, lülitage funktsioon Asukoht sisse ka <ph name="BEGIN_LINK" />Androidi seadetes<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Värskendused</translation>
-<translation id="19288952978244135">Avage Chrome uuesti.</translation>
-<translation id="1933845786846280168">Valitud vaheleht</translation>
-<translation id="194341124344773587">Lülita <ph name="BEGIN_LINK" />Android-seadetes<ph name="END_LINK" /> sisse luba Chrome'ile.</translation>
-<translation id="1943432128510653496">Paroolide salvestamine</translation>
-<translation id="1952172573699511566">Veebisaidid kuvavad teksti võimaluse korral teie eelistatud keeles.</translation>
-<translation id="1960290143419248813">Selles Androidi versioonis ei toetata enam Chrome'i värskendusi</translation>
-<translation id="1966710179511230534">Värskendage oma sisselogimisandmeid.</translation>
-<translation id="1974060860693918893">Täpsemad</translation>
-<translation id="1984705450038014246">Chrome'i andmete sünkroonimine</translation>
-<translation id="1984937141057606926">Lubatud, välja arvatud kolmanda osapoole küpsised</translation>
-<translation id="1986685561493779662">Nimi on juba olemas</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> – nupp <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Sirvi</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> soovib siduda</translation>
-<translation id="1994173015038366702">Saidi URL</translation>
-<translation id="2000419248597011803">Saadab teie vaikeotsingumootorile mõned küpsisefailid ja otsingud teie aadressiribalt ning otsingukastist</translation>
-<translation id="2002537628803770967">Krediitkaardid ja aadressid, mis kasutavad teenust Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fail}other{# faili}}</translation>
-<translation id="2017836877785168846">Kustutab aadressiribalt ajaloo ja automaatse täitmise teabe.</translation>
-<translation id="2021896219286479412">Saidi juhtelemendid täisekraanil</translation>
-<translation id="2038563949887743358">Valiku Taotle arvutisaiti sisselülitamine</translation>
-<translation id="2041019821020695769">Selleks et lubada Chrome'il teile märguandeid saata, lülitage märguanded <ph name="BEGIN_LINK" />Androidi seadetes<ph name="END_LINK" /> ka sisse.</translation>
-<translation id="204321170514947529">Rakendusel <ph name="APP_NAME" /> on samuti Chrome’i andmeid</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Sait on peatatud</translation>
-<translation id="2063713494490388661">Puudutage otsimiseks</translation>
-<translation id="2067805253194386918">tekst</translation>
-<translation id="2079545284768500474">Võta tagasi</translation>
-<translation id="2082238445998314030">Tulemus <ph name="RESULT_NUMBER" />/<ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Heli</translation>
-<translation id="2096012225669085171">Seadmete vahel sünkroonimine ja isikupärastamine</translation>
-<translation id="2100273922101894616">Automaatne sisselogimine</translation>
-<translation id="2100314319871056947">Proovige teksti jagada väiksemate lõikudena</translation>
-<translation id="2107397443965016585">Küsi enne saidile kaitstud sisu esitamiseks loa andmist (soovitatav)</translation>
-<translation id="2111511281910874386">Minge lehele</translation>
-<translation id="2122601567107267586">Rakendust ei õnnestunud avada</translation>
-<translation id="2126426811489709554">Chrome'i toega</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> salvestati</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> suleti</translation>
-<translation id="2139186145475833000">Avaekraanile lisamine</translation>
-<translation id="2146738493024040262">Ava installimata avatav rakendus</translation>
-<translation id="2148716181193084225">Täna</translation>
-<translation id="2154484045852737596">Kaardi muutmine</translation>
-<translation id="2154710561487035718">Kopeeri URL</translation>
-<translation id="2156074688469523661">Järelejäänud saidid (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Kui soovite midagi oma telefonist teise seadmega jagada, lülitage sünkroonimine mõlema seadme Chrome'i seadetes sisse</translation>
-<translation id="2170088579611075216">Luba virtuaalreaalsus ja sisene</translation>
-<translation id="218608176142494674">Jagamine</translation>
-<translation id="2227444325776770048">Jätka kasutajana <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sünkroonimine ja Google'i teen.</translation>
-<translation id="2259659629660284697">Paroolide eksportimine …</translation>
-<translation id="2268044343513325586">Täpsustamine</translation>
-<translation id="2286841657746966508">Arveldusaadress</translation>
-<translation id="2289270750774289114">Küsi, kui sait soovib läheduses asuvaid Bluetoothi seadmeid tuvastada (soovitatav)</translation>
-<translation id="230115972905494466">Ühilduvaid seadmeid ei leitud</translation>
-<translation id="2315043854645842844">Operatsioonisüsteem ei toeta kliendipoolset sertifikaadi valimist.</translation>
-<translation id="2318045970523081853">Puudutage helistamiseks</translation>
-<translation id="2321086116217818302">Paroolide ettevalmistamine …</translation>
-<translation id="2321958826496381788">Lohistage liugurit, kuni saate seda mugavalt lugeda. Lõigu topeltkoputamisel peab tekst olema vähemalt nii suur.</translation>
-<translation id="2323763861024343754">Saidi salvestusruum</translation>
-<translation id="2328985652426384049">Ei saa sisse logida</translation>
-<translation id="2330129964253841015">Hoiata, kui minu paroolid satuvad ohtu</translation>
-<translation id="2349710944427398404">Chrome'i kasutatav andmemaht kokku, sh kontod, järjehoidjad ja salvestatud seaded</translation>
-<translation id="2353636109065292463">Interneti-ühenduse kontrollimine</translation>
-<translation id="2359808026110333948">Jätka</translation>
-<translation id="2369533728426058518">avatud vahelehed</translation>
-<translation id="2387895666653383613">Teksti skaleerimine</translation>
-<translation id="2394602618534698961">Allalaaditud failid kuvatakse siin</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Kui logite oma Google'i kontole sisse, lülitatakse see funktsioon sisse</translation>
-<translation id="2410754283952462441">Konto valimine</translation>
-<translation id="2414886740292270097">Tume</translation>
-<translation id="2416359993254398973">Chrome vajab selle saidi puhul luba, et teie kaamerale juurde pääseda.</translation>
-<translation id="2426805022920575512">Vali muu konto</translation>
-<translation id="2433507940547922241">Välimus</translation>
-<translation id="2434158240863470628">Allalaadimine jõudis lõpule: <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Juurdepääs asukohale</translation>
-<translation id="2450083983707403292">Kas soovite faili <ph name="FILE_NAME" /> allalaadimist uuesti alustada?</translation>
-<translation id="2482878487686419369">Märguanded</translation>
-<translation id="2490684707762498678">Haldab <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google'i assistent Chrome'is</translation>
-<translation id="2496180316473517155">Sirvimise ajalugu</translation>
-<translation id="2497852260688568942">Administraator on sünkroonimise keelanud</translation>
-<translation id="2498359688066513246">Abi ja tagasiside</translation>
-<translation id="2501278716633472235">Mine tagasi</translation>
-<translation id="2513403576141822879">Privaatsuse, turvalisuse ning andmete kogumisega seotud lisaseadete nägemiseks avage valik <ph name="BEGIN_LINK" />Sünkroonimine ja Google'i teenused<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Lihtsustatud režiimis laadib Chrome lehti kiiremini ja kasutab kuni 60% vähem andmemahtu. Külastatud lehtede optimeerimiseks saadab Chrome teie veebiliikluse Google’ile. <ph name="BEGIN_LINK" />Lisateave<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Saadab Google'ile teie külastatud lehtede URL-id</translation>
-<translation id="2532336938189706096">Veebi kuva</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> üksust kustutati</translation>
-<translation id="2536728043171574184">Kuvatakse on lehe võrguühenduseta koopia</translation>
-<translation id="2546283357679194313">Küpsised ja saidiandmed</translation>
-<translation id="2567385386134582609">KUJUTIS</translation>
-<translation id="257088987046510401">Teemad</translation>
-<translation id="2570922361219980984">Ka juurdepääs asukohale on selle seadme puhul välja lülitatud. Lülitage see sisse <ph name="BEGIN_LINK" />Androidi seadetes<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Laiendatud – ahendamiseks klõpsake.</translation>
-<translation id="2581165646603367611">See tühjendab vahemälu, kustutab küpsised ja muud andmed, mis pärinevad Chrome'i arvates ebatähtsatelt saitidelt.</translation>
-<translation id="2586657967955657006">Lõikelaud</translation>
-<translation id="2587052924345400782">Saadaval on uuem versioon</translation>
-<translation id="2593272815202181319">Püsisammkiri</translation>
-<translation id="2612676031748830579">Kaardi number</translation>
-<translation id="2621115761605608342">Lubage JavaScript konkreetse saidi jaoks.</translation>
-<translation id="2625189173221582860">Parool on kopeeritud</translation>
-<translation id="2631006050119455616">Säästetud</translation>
-<translation id="2647434099613338025">Lisa keel</translation>
-<translation id="2650751991977523696">Kas soovite faili uuesti alla laadida?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# helifail}other{# helifaili}}</translation>
-<translation id="2653659639078652383">Esita</translation>
-<translation id="2677748264148917807">Lahku</translation>
-<translation id="2704606927547763573">Kopeeritud</translation>
-<translation id="2707726405694321444">Lehe värskendamine</translation>
-<translation id="2709516037105925701">Automaatne täitmine</translation>
-<translation id="2717722538473713889">E-posti aadressid</translation>
-<translation id="2728754400939377704">Sordi saidi alusel</translation>
-<translation id="2744248271121720757">Puudutage sõna, et kohe otsida või seotud toiminguid näha</translation>
-<translation id="2760989362628427051">Aktiveeri tume teema, kui tume teema või akusäästja on seadmes sisse lülitatud</translation>
-<translation id="2762000892062317888">just praegu</translation>
-<translation id="2777555524387840389">Jäänud on <ph name="SECONDS" /> sekundit</translation>
-<translation id="2779651927720337254">ebaõnnestus</translation>
-<translation id="2781151931089541271">Jäänud on 1 sekund</translation>
-<translation id="2801022321632964776">Oma keele kasutamiseks värskendage Chrome uusimale versioonile</translation>
-<translation id="2810645512293415242">Lihtsustatud leht andmemahu säästmiseks ja laadimise kiirendamiseks.</translation>
-<translation id="281504910091592009">Vaadake ja hallake salvestatud paroole oma <ph name="BEGIN_LINK" />Google'i kontol<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Järjehoidjate kõikidesse seadmetesse hankimiseks logige sisse ja lülitage sünkroonimine sisse</translation>
-<translation id="2822354292072154809">Kas soovite objekti <ph name="CHOSEN_OBJECT_NAME" /> jaoks kindlasti lähtestada kõik saidi load?</translation>
-<translation id="2836148919159985482">Täisekraanilt väljumiseks puudutage tagasinuppu.</translation>
-<translation id="2842985007712546952">Emakaust</translation>
-<translation id="2858138569776157458">Popid saidid</translation>
-<translation id="2860954141821109167">Veenduge, et telefonirakendus oleks selles seadmes lubatud</translation>
-<translation id="2870560284913253234">Sait</translation>
-<translation id="2874939134665556319">Eelmine lugu</translation>
-<translation id="2876369937070532032">Saadab mõnede teie külastatud lehtede URL-id Google'ile, kui teie turvalisus ohtu satub</translation>
-<translation id="2888126860611144412">Teave Chrome'i kohta</translation>
-<translation id="2891154217021530873">Peata lehe laadimine</translation>
-<translation id="2893180576842394309">Google võib kasutada teie ajalugu otsingu ja muude Google'i teenuste isikupärastamiseks</translation>
-<translation id="2898264748040935573">Salvestatud parooli muutmine</translation>
-<translation id="2900528713135656174">Looge sündmus</translation>
-<translation id="290376772003165898">Kas leht ei ole <ph name="LANGUAGE" /> keeles?</translation>
-<translation id="2904414404539560095">Vahelehe jagamise seadmete loend (täiskõrgusel avatud).</translation>
-<translation id="2910701580606108292">Küsi enne saitidel kaitstud sisu esitamise lubamist</translation>
-<translation id="2913331724188855103">Lubab saitidel salvestada küpsiseid ja lugeda küpsiste andmeid (soovitatav)</translation>
-<translation id="2923908459366352541">Nimi on sobimatu</translation>
-<translation id="2932150158123903946">Rakenduse Google <ph name="APP_NAME" /> salvestusruum</translation>
-<translation id="2942036813789421260">Eelvaate vaheleht on suletud</translation>
-<translation id="2956410042958133412">Seda kontot haldavad <ph name="PARENT_NAME_1" /> ja <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Inkognito režiimi vahelehed on aktiveeritud</translation>
-<translation id="2968755619301702150">Sertifikaadikuvaja</translation>
-<translation id="2979025552038692506">Valitud inkognito vaheleht</translation>
-<translation id="2987620471460279764">Muust seadmest jagatud tekst</translation>
-<translation id="2989523299700148168">Hiljuti külastatud</translation>
-<translation id="2996291259634659425">Parooli loomine</translation>
-<translation id="2996809686854298943">Vaja on URL-i</translation>
-<translation id="300526633675317032">See tühjendab veebisaidi salvestusruumi mahuga <ph name="SIZE_IN_KB" />.</translation>
-<translation id="3016635187733453316">Veenduge, et seadmel oleks internetiühendus</translation>
-<translation id="3029613699374795922">Alla on laaditud <ph name="KBS" /> kB</translation>
-<translation id="3029704984691124060">Paroolid ei ühti</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Küsige abi<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Asukoht on välja lülitatud. Lülitage see sisse <ph name="BEGIN_LINK" />Androidi seadetes<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Saate sünkroonimise seadetes alati sisse lülitada</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> järjehoidja}other{<ph name="BOOKMARKS_COUNT_MANY" /> järjehoidjat}}</translation>
-<translation id="3089395242580810162">Ava inkognito vahelehel</translation>
-<translation id="3115898365077584848">Kuva teave</translation>
-<translation id="3123473560110926937">Blokeeritud teatud saitidel</translation>
-<translation id="3137521801621304719">Inkognito režiimist väljumine</translation>
-<translation id="3143515551205905069">Tühista sünkroonimine</translation>
-<translation id="3157842584138209013">Nupu Rohkem valikuid abil saate vaadata, kui palju andmemahtu olete säästnud</translation>
-<translation id="3166827708714933426">Vahelehe ja akna otseteed</translation>
-<translation id="3181954750937456830">Ohutu sirvimine (kaitseb teid ja teie seadet ohtlike saitide eest)</translation>
-<translation id="3190152372525844641">Lülita <ph name="BEGIN_LINK" />Android-seadetes<ph name="END_LINK" /> sisse load Chrome'ile.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> salvestatud andmeid</translation>
-<translation id="3205824638308738187">Peaaegu valmis.</translation>
-<translation id="3207960819495026254">Järjehoidjatesse lisatud</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> kustutati</translation>
-<translation id="321773570071367578">Kui unustasite parooli või soovite seda seadet muuta, <ph name="BEGIN_LINK" />lähtestage sünkroonimine<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Veebirakendus</translation>
-<translation id="3236059992281584593">Jäänud on 1 minut</translation>
-<translation id="3244271242291266297">kk</translation>
-<translation id="3254409185687681395">Lisa see lehekülg järjehoidjatesse</translation>
-<translation id="3259831549858767975">Lehel kuvatud sisu vähendamine</translation>
-<translation id="3269093882174072735">Laadi kujutis</translation>
-<translation id="3269956123044984603">Vahelehtede hankimiseks oma teistest seadmetest lülitage Androidi kontoseadetes sisse valik „Andmete automaatne sünkroonimine”.</translation>
-<translation id="3277252321222022663">Luba saitide jaoks juurdepääs anduritele (soovitatav)</translation>
-<translation id="3282568296779691940">Chrome'i sisselogimine</translation>
-<translation id="3288003805934695103">Laadige leht uuesti</translation>
-<translation id="32895400574683172">Märguanded on lubatud</translation>
-<translation id="3295530008794733555">Sirvige kiiremini. Kasutage vähem andmemahtu.</translation>
-<translation id="3295602654194328831">Peida teave</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Kas soovite jätkata sisu allalaadimist?</translation>
-<translation id="3306398118552023113">Rakendus töötab Chrome'is</translation>
-<translation id="3315103659806849044">Kohandate praegu sünkroonimise ja Google'i teenuste seadeid. Sünkroonimise sisselülitamiseks puudutage ekraani alaosas nuppu Kinnita. Liigu üles</translation>
-<translation id="3328801116991980348">Saiditeave</translation>
-<translation id="3333961966071413176">Kõik kontaktid</translation>
-<translation id="3334729583274622784">Kas muuta faililaiendit?</translation>
-<translation id="3341058695485821946">Vaadake, kui palju andmemahtu olete säästnud</translation>
-<translation id="3350687908700087792">Kõigi inkognito vahelehtede sulgemine</translation>
-<translation id="3353615205017136254">Lihtsustatud lehte pakub Google. Algse lehe laadimiseks puudutage nuppu Laadi algne.</translation>
-<translation id="3367813778245106622">Sünkroonimise alustamiseks logige uuesti sisse</translation>
-<translation id="3374023511497244703">Teie järjehoidjaid, ajalugu, paroole ja muid Chrome'i andmeid ei sünkroonita enam teie Google'i kontoga</translation>
-<translation id="3384347053049321195">Jaga kujutist</translation>
-<translation id="3386292677130313581">Küsi enne saitidele minu asukoha avaldamist (soovitatav)</translation>
-<translation id="3387650086002190359">Faili <ph name="FILE_NAME" /> allalaadimine ebaõnnestus failisüsteemi vigade tõttu.</translation>
-<translation id="3389286852084373014">Tekst on liiga pikk</translation>
-<translation id="3398320232533725830">Järjehoidjate halduri avamine</translation>
-<translation id="3414952576877147120">Suurus:</translation>
-<translation id="3443221991560634068">Praeguse lehe uuesti laadimine</translation>
-<translation id="3445014427084483498">Just praegu</translation>
-<translation id="3478363558367712427">Võite valida oma otsingumootori</translation>
+<translation id="6910211073230771657">Kustutatud</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Selge, sain aru</translation>
+<translation id="7658239707568436148">Tühista</translation>
 <translation id="3479552764303398839">Mitte praegu</translation>
-<translation id="3492207499832628349">Uus inkognito vaheleht</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Lisateave<ph name="END_LINK" /> soovitatud sisu kohta</translation>
-<translation id="3513704683820682405">Liitreaalsus</translation>
-<translation id="3518985090088779359">Nõustu ja jätka</translation>
-<translation id="3522247891732774234">Värskendus on saadaval. Rohkem valikuid</translation>
-<translation id="3524138585025253783">Arendaja kasutajaliides</translation>
-<translation id="3527085408025491307">Kaust</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> kB on saadaval</translation>
-<translation id="3549657413697417275">Otsige oma ajaloost</translation>
-<translation id="3557336313807607643">Kontaktide lisamine</translation>
-<translation id="3566923219790363270">Chrome teeb VR-i kasutamiseks endiselt ettevalmistusi. Taaskäivitage Chrome hiljem.</translation>
-<translation id="3568688522516854065">Oma teistest seadmetest vahelehtede hankimiseks logige sisse ja lülitage sünkroonimine sisse</translation>
-<translation id="3587482841069643663">Kõik</translation>
-<translation id="358794129225322306">Lubab saidil automaatselt mitut faili alla laadida.</translation>
-<translation id="3590487821116122040">Saitide salvestusruum, mida Chrome peab ebatähtsaks (nt saidid, mida külastate harva või millel ei ole salvestatud seadeid)</translation>
-<translation id="3599863153486145794">Kustutab ajaloo kõigist sisselogitud seadmetest. Aadressil <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> võib teie Google'i kontol olla muus vormis sirvimisajalugu.</translation>
-<translation id="3600792891314830896">Heli esitavad saidid vaigistatakse</translation>
-<translation id="3616113530831147358">Heli</translation>
-<translation id="3631987586758005671">Jagamine seadmega <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Parooli kuvamine</translation>
-<translation id="363596933471559332">Teid logitakse salvestatud mandaadiga veebisaitidele automaatselt sisse. Kui funktsioon on välja lülitatud, palutakse teilt kinnitust iga kord enne veebisaidile sisselogimist.</translation>
-<translation id="3658159451045945436">Lähtestamisel kustutatakse säästetud andmemahu ajalugu, sh külastatud saitide loend.</translation>
-<translation id="3692944402865947621">Faili <ph name="FILE_NAME" /> allalaadimine nurjus, kuna salvestuskoht ei ole saadaval.</translation>
-<translation id="3714981814255182093">Leiuriba avamine</translation>
-<translation id="3716182511346448902">Chrome peatas selle lehe, kuna see kasutab liiga palju mälu.</translation>
-<translation id="3730075448226062617">Selleks et anda Chrome'ile juurdepääs teie mikrofonile, lülitage mikrofon sisse ka <ph name="BEGIN_LINK" />Androidi seadetes<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Teenuses <ph name="PRODUCT_NAME" /> järjehoidj. lisatud</translation>
-<translation id="3744111561329211289">Taustal sünkroonimine</translation>
-<translation id="3771001275138982843">Värskendust ei saanud alla laadida</translation>
-<translation id="3771033907050503522">Inkogn. vahelehed</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Lülitage Bluetooth sisse<ph name="END_LINK" />, et sidumine lubada</translation>
-<translation id="3775705724665058594">Saatmine teie seadmetesse</translation>
-<translation id="3778956594442850293">Lisatud avaekraanile</translation>
-<translation id="3789841737615482174">Installi</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Halda</translation>
-<translation id="381841723434055211">Telefoninumbrid</translation>
-<translation id="3819178904835489326">Tuvastati <ph name="NUMBER_OF_DOWNLOADS" /> allalaadimist</translation>
-<translation id="3822502789641063741">Kas tühj. saidi salvestusruum?</translation>
-<translation id="385051799172605136">Tagasi</translation>
-<translation id="3859306556332390985">Keri edasi</translation>
-<translation id="3894427358181296146">Kausta lisamine</translation>
-<translation id="3895926599014793903">Sundluba suumimine</translation>
-<translation id="3912508018559818924">Otsitakse parimat, mida veebil on pakkuda …</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Minu andmete kombineerimine</translation>
-<translation id="393697183122708255">Lubatud häälotsing pole saadaval</translation>
-<translation id="395206256282351086">Otsingu- ja saidisoovitused on keelatud</translation>
-<translation id="3955193568934677022">Luba saitidel esitada kaitstud sisu (soovitatav)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome laadib teie lehe, kui see on valmis}other{Chrome laadib teie lehed, kui need on valmis}}</translation>
-<translation id="3963007978381181125">Parooli krüpteerimine ei hõlma Google Pay makseviise ega aadresse. Teie krüpteeritud andmeid saavad lugeda vaid need, kes teavad teie parooli – seda ei saadeta Google'ile ja Google ei talleta seda. Kui unustate parooli või soovite seda seadet muuta, tuleb teil sünkroonimine lähtestada. <ph name="BEGIN_LINK" />Lisateave<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Allalaadimine on lõpule viidud</translation>
-<translation id="397583555483684758">Sünkroonimine lakkas töötamast</translation>
-<translation id="3976396876660209797">Eemaldage see otsetee ja looge see uuesti</translation>
-<translation id="3985215325736559418">Kas soovite faili <ph name="FILE_NAME" /> uuesti alla laadida?</translation>
-<translation id="3987993985790029246">Kop. link</translation>
-<translation id="3988213473815854515">Asukoht on lubatud</translation>
-<translation id="3988466920954086464">Vaadake kiirotsingu tulemusi sellel paneelil</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Ebatähtis salvestusruum</translation>
-<translation id="4000212216660919741">Võrguühenduseta avaleht</translation>
+<translation id="5317780077021120954">Salvesta</translation>
+<translation id="4570913071927164677">Üksikasjad</translation>
+<translation id="8730621377337864115">Valmis</translation>
+<translation id="8261506727792406068">Kustuta</translation>
+<translation id="1181037720776840403">Eemalda</translation>
+<translation id="5939518447894949180">Lähtesta</translation>
 <translation id="4002066346123236978">Pealkiri</translation>
-<translation id="4008040567710660924">Lubage konkreetse saidi küpsisefailid.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Järgmine lugu</translation>
-<translation id="4048707525896921369">Vaadake veebisaidil olevaid teemasid lehelt lahkumata. Funktsioon Puuduta otsimiseks saadab sõna ja seda ümbritseva konteksti Google'i otsingusse, andes vastuseks definitsioonid, pildid, otsingutulemused ja muud üksikasjad.
+<translation id="5916664084637901428">Sees</translation>
+<translation id="5860033963881614850">Väljas</translation>
+<translation id="6165508094623778733">Lisateave</translation>
+<translation id="6042308850641462728">Rohkem</translation>
+<translation id="6040143037577758943">Sulge</translation>
+<translation id="780301667611848630">Ei, aitäh</translation>
+<translation id="1201402288615127009">Edasi</translation>
+<translation id="2359808026110333948">Jätka</translation>
+<translation id="2653659639078652383">Esita</translation>
+<translation id="2079545284768500474">Võta tagasi</translation>
+<translation id="7649070708921625228">Abi</translation>
+<translation id="2148716181193084225">Täna</translation>
+<translation id="7781829728241885113">Eile</translation>
+<translation id="6945221475159498467">Vali</translation>
+<translation id="7791543448312431591">Lisa</translation>
+<translation id="6527303717912515753">Jaga</translation>
+<translation id="1383876407941801731">Otsi</translation>
+<translation id="3115898365077584848">Kuva teave</translation>
+<translation id="3295602654194328831">Peida teave</translation>
+<translation id="3987993985790029246">Kop. link</translation>
+<translation id="2704606927547763573">Kopeeritud</translation>
+<translation id="8725066075913043281">Proovi uuesti</translation>
+<translation id="385051799172605136">Tagasi</translation>
+<translation id="8131740175452115882">Kinnita</translation>
+<translation id="5300589172476337783">Kuva</translation>
+<translation id="1124772482545689468">Kasutaja</translation>
+<translation id="8609465669617005112">Liiguta üles</translation>
+<translation id="6746124502594467657">Liiguta alla</translation>
+<translation id="8249310407154411074">Teisalda kõige üles</translation>
+<translation id="8428213095426709021">Seaded</translation>
+<translation id="2498359688066513246">Abi ja tagasiside</translation>
+<translation id="8378714024927312812">Haldab teie organisatsioon</translation>
+<translation id="9019902583201351841">Vanemate hallatud</translation>
+<translation id="4645575059429386691">Vanema hallatud</translation>
+<translation id="4883854917563148705">Hallatud seadeid ei saa lähtestada</translation>
+<translation id="4307992518367153382">Põhiteave</translation>
+<translation id="1974060860693918893">Täpsemad</translation>
+<translation id="1146678959555564648">Ava VR</translation>
+<translation id="987264212798334818">Üldine</translation>
+<translation id="4275663329226226506">Meedia</translation>
+<translation id="4759238208242260848">Allalaadimised</translation>
+<translation id="218608176142494674">Jagamine</translation>
+<translation id="8004582292198964060">Brauser</translation>
+<translation id="1105960400813249514">Kuva jäädvustamine</translation>
+<translation id="4875775213178255010">Sisu soovitused</translation>
+<translation id="2021896219286479412">Saidi juhtelemendid täisekraanil</translation>
+<translation id="4587589328781138893">Saidid</translation>
+<translation id="4943703118917034429">Virtuaalreaalsus</translation>
+<translation id="1928696683969751773">Värskendused</translation>
+<translation id="6064125863973209585">Lõpetatud allalaadimised</translation>
+<translation id="5342314432463739672">Lubade taotlused</translation>
+<translation id="629730747756840877">Konto</translation>
+<translation id="82609232232243542">Brave'i sisselogimine</translation>
+<translation id="7956662517480676674">Sünkroonimine ja Brave Software'i teen.</translation>
+<translation id="5294439808117722387">Kohandate praegu sünkroonimise ja Brave Software'i teenuste seadeid. Sünkroonimise sisselülitamiseks puudutage ekraani alaosas nuppu Kinnita. Liigu üles</translation>
+<translation id="2096012225669085171">Seadmete vahel sünkroonimine ja isikupärastamine</translation>
+<translation id="1692118695553449118">Sünkroonimine on sisse lülitatud</translation>
+<translation id="5514904542973294328">Keelas selle seadme administraator</translation>
+<translation id="6447211988989208781">Brave Software'i kontotegevuste haldus</translation>
+<translation id="4882831918239250449">Juhtige, kuidas teie sirvimisajalugu kasutatakse otsingu, reklaamide ja muu isikupärastamiseks</translation>
+<translation id="7431991332293347422">Juhtige, kuidas kasutatakse teie sirvimisajalugu otsingu ja muu isikupärastamiseks</translation>
+<translation id="6303969859164067831">Logi välja ja lülita sünkroonimine välja</translation>
+<translation id="1125261911132334651">Brave Software'i konto haldamine</translation>
+<translation id="6406506848690869874">Sünkroonimine</translation>
+<translation id="714362445477979774">Brave'i andmete sünkroonimine</translation>
+<translation id="4314815835985389558">Sünkroonimise haldamine</translation>
+<translation id="5428209950370661546">Muud Brave Software'i teenused</translation>
+<translation id="7704317875155739195">Otsingute ja URL-ide automaatne täitmine</translation>
+<translation id="2000419248597011803">Saadab teie vaikeotsingumootorile mõned küpsisefailid ja otsingud teie aadressiribalt ning otsingukastist</translation>
+<translation id="7981313251711023384">Eellaaditakse lehti kiiremaks sirvimiseks ja otsimiseks</translation>
+<translation id="1821253160463689938">Kasutage küpsisefaile oma eelistuste meelespidamiseks isegi siis, kui te neid lehti ei külasta</translation>
+<translation id="6697492270171225480">Kui lehte ei leita, kuvatakse sarnaste lehtede soovitusi</translation>
+<translation id="8109318360573330108">Saadab Brave Software'ile teie soovitud lehe URL-i</translation>
+<translation id="8438566539970814960">Otsingute ja sirvimise paremaks muutmine</translation>
+<translation id="284843628681142937">Saadab Brave Software'ile teie külastatud lehtede URL-id</translation>
+<translation id="7222718784508482526">Privaatsuse, turvalisuse ning andmete kogumisega seotud lisaseadete nägemiseks avage valik <ph name="BEGIN_LINK"/>Sünkroonimine ja Brave Software'i teenused<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Aidake täiustada Brave'i funktsioone ja toimivust</translation>
+<translation id="9063160602596686558">Brave Software'ile saadetakse automaatselt kasutusstatistikat ja krahhiaruandeid</translation>
+<translation id="4824958205181053313">Kas tühistada sünkroonimine?</translation>
+<translation id="3058498974290601450">Saate sünkroonimise seadetes alati sisse lülitada</translation>
+<translation id="3143515551205905069">Tühista sünkroonimine</translation>
+<translation id="1506061864768559482">Otsingumootor</translation>
+<translation id="55737423895878184">Asukoht ja märguanded on lubatud</translation>
+<translation id="3988213473815854515">Asukoht on lubatud</translation>
+<translation id="32895400574683172">Märguanded on lubatud</translation>
+<translation id="9040142327097499898">Märguanded on lubatud. Asukoht on selle seadme puhul välja lülitatud.</translation>
+<translation id="305593374596241526">Asukoht on välja lülitatud. Lülitage see sisse <ph name="BEGIN_LINK"/>Androidi seadetes<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Hiljuti külastatud</translation>
+<translation id="6433501201775827830">Valige oma otsingumootor</translation>
+<translation id="7177466738963138057">Seda saate hiljem muuta jaotises Seaded</translation>
+<translation id="3478363558367712427">Võite valida oma otsingumootori</translation>
+<translation id="4910889077668685004">Makserakendused</translation>
+<translation id="5152843274749979095">Toetatud rakendusi pole installitud</translation>
+<translation id="8812260976093120287">Mõnel veebisaidil saate maksta ülalolevate teie seadmes toetatud makserakendustega.</translation>
+<translation id="7764225426217299476">Lisage aadress</translation>
+<translation id="5595485650161345191">Muuda aadressi</translation>
+<translation id="5087580092889165836">Lisa kaart</translation>
+<translation id="2154484045852737596">Kaardi muutmine</translation>
+<translation id="6140912465461743537">Riik/piirkond</translation>
+<translation id="5659593005791499971">Meil</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Kaardil olev nimi</translation>
+<translation id="860043288473659153">Kaardiomaniku nimi</translation>
+<translation id="2612676031748830579">Kaardi number</translation>
+<translation id="869891660844655955">Aegumiskuupäev</translation>
+<translation id="2286841657746966508">Arveldusaadress</translation>
+<translation id="663059986967017181">Brave'i kopeeritud</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Paroolid</translation>
+<translation id="1943432128510653496">Paroolide salvestamine</translation>
+<translation id="2100273922101894616">Automaatne sisselogimine</translation>
+<translation id="363596933471559332">Teid logitakse salvestatud mandaadiga veebisaitidele automaatselt sisse. Kui funktsioon on välja lülitatud, palutakse teilt kinnitust iga kord enne veebisaidile sisselogimist.</translation>
+<translation id="6995899638241819463">Hoiata mind, kui paroolid andmetega seotud rikkumise käigus avalikustatakse</translation>
+<translation id="1534287762301776620">Kui logite oma Brave Software'i kontole sisse, lülitatakse see funktsioon sisse</translation>
+<translation id="10614374240317010">Ei ole kunagi salvestatud</translation>
+<translation id="3098842761938485917">Vaadake ja hallake salvestatud paroole oma <ph name="BEGIN_LINK"/>Brave Software'i kontol<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Salvestatud paroolid ilmuvad siin.</translation>
+<translation id="8084114998886531721">Salvestatud parool</translation>
+<translation id="2870560284913253234">Sait</translation>
+<translation id="8503813439785031346">Kasutajanimi</translation>
+<translation id="6657585470893396449">Parool</translation>
+<translation id="2154710561487035718">Kopeeri URL</translation>
+<translation id="1571304935088121812">Kasutajanime kopeerimine</translation>
+<translation id="5005498671520578047">Parooli kopeerimine</translation>
+<translation id="3632295766818638029">Parooli kuvamine</translation>
+<translation id="1513858653616922153">Kustuta parool</translation>
+<translation id="543338862236136125">Muuda parooli</translation>
+<translation id="4565377596337484307">Peida parool</translation>
+<translation id="8523928698583292556">Salvestatud parooli kustutamine</translation>
+<translation id="2898264748040935573">Salvestatud parooli muutmine</translation>
+<translation id="5433691172869980887">Kasutajanimi on kopeeritud</translation>
+<translation id="5534640966246046842">Sait on kopeeritud</translation>
+<translation id="2625189173221582860">Parool on kopeeritud</translation>
+<translation id="4550003330909367850">Parooli vaatamiseks või siia kleepimiseks määrake selles seadmes ekraanilukk.</translation>
+<translation id="6154478581116148741">Seadmes olevate paroolide eksportimiseks lülitage seadetes ekraanilukk sisse.</translation>
+<translation id="4842092870884894799">Parooli loomise hüpikakna kuvamine</translation>
+<translation id="2259659629660284697">Paroolide eksportimine …</translation>
+<translation id="133012818630824069">Brave'i salvestatud paroolide eksportimine</translation>
+<translation id="6914783257214138813">Teie paroolid on nähtavad kõigile, kes saavad vaadata eksporditud faili.</translation>
+<translation id="2321086116217818302">Paroolide ettevalmistamine …</translation>
+<translation id="8445448999790540984">Paroole ei saa eksportida</translation>
+<translation id="3066461326500799725">Vaadake, kuidas Brave Software Drive'i kasutada</translation>
+<translation id="729975465115245577">Seadmes pole sünkroonimiseks piisavalt salvestusruumi.</translation>
+<translation id="7682724950699840886">Järgige neid nõuandeid: veenduge, et seadmes oleks piisavalt ruumi, seejärel proovige uuesti eksportida.</translation>
+<translation id="1129510026454351943">Üksikasjad: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Avage oma parooli kopeerimiseks</translation>
+<translation id="5515439363601853141">Avage oma parooli vaatamiseks</translation>
+<translation id="6221633008163990886">Paroolide eksportimiseks avage seade</translation>
+<translation id="230699814587342492">Brave'i paroolid</translation>
+<translation id="6075798973483050474">Avalehe muutmine</translation>
+<translation id="854522910157234410">Ava leht</translation>
+<translation id="2482878487686419369">Märguanded</translation>
+<translation id="6255999984061454636">Sisu soovitused</translation>
+<translation id="805047784848435650">Teie sirvimisajaloo põhjal</translation>
+<translation id="1041308826830691739">Veebisaitidelt</translation>
+<translation id="395206256282351086">Otsingu- ja saidisoovitused on keelatud</translation>
+<translation id="257088987046510401">Teemad</translation>
+<translation id="4650364565596261010">Süsteemi vaikeseade</translation>
+<translation id="7588219262685291874">Aktiveeri tume teema, kui akusäästja on seadmes sisse lülitatud</translation>
+<translation id="2760989362628427051">Aktiveeri tume teema, kui tume teema või akusäästja on seadmes sisse lülitatud</translation>
+<translation id="6381421346744604172">Tumenda veebisaidid</translation>
+<translation id="5040262127954254034">Privaatsus</translation>
+<translation id="4991384657077828949">Aidake Brave'i turvalisust täiustada</translation>
+<translation id="1943176487615318915">Ohtlike rakenduste ja saitide tuvastamiseks saadab Brave mõnede teie külastatud lehtede URL-id, piiratud süsteemiteabe ja mõne lehe sisu Brave Software'ile</translation>
+<translation id="3181954750937456830">Ohutu sirvimine (kaitseb teid ja teie seadet ohtlike saitide eest)</translation>
+<translation id="7315322926489145388">Saadab mõnede teie külastatud lehtede URL-id Brave Software'ile, kui teie turvalisus ohtu satub</translation>
+<translation id="2063713494490388661">Puudutage otsimiseks</translation>
+<translation id="2369463299479365221">Vaadake veebisaidil olevaid teemasid lehelt lahkumata. Funktsioon Puuduta otsimiseks saadab sõna ja seda ümbritseva konteksti Brave Software'i otsingusse, andes vastuseks definitsioonid, pildid, otsingutulemused ja muud üksikasjad.
 
 Otsingutermini korrigeerimiseks vajutage valimiseks pikalt. Otsingu täpsustamiseks libistage paneel täiesti üles ja puudutage otsingukasti.</translation>
-<translation id="4056223980640387499">Seepia</translation>
-<translation id="4060598801229743805">Ekraani ülaosas saadaolevad valikud</translation>
-<translation id="4062305924942672200">Juriidiline teave</translation>
-<translation id="4084682180776658562">Järjehoidja</translation>
-<translation id="4084712963632273211">Avaldajalt <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />sisu pakub Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Kas kustutada rakenduse andmed?</translation>
-<translation id="4099578267706723511">Aidake muuta Chrome'i paremaks, saates Google'ile kasutusstatistikat ja krahhiaruandeid.</translation>
-<translation id="410351446219883937">Automaatesitus</translation>
-<translation id="4116038641877404294">Laadige lehed alla, et neid võrguühenduseta kasutada</translation>
-<translation id="4135200667068010335">Vahelehe jagamise seadmete loend on suletud.</translation>
-<translation id="4149994727733219643">Veebilehtede lihtsustatud vaade</translation>
-<translation id="4165986682804962316">Saidi seaded</translation>
-<translation id="4169535189173047238">Ära luba</translation>
-<translation id="4170011742729630528">Teenus pole saadaval, proovige hiljem uuesti.</translation>
-<translation id="4179980317383591987">Kasutati <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Keeled</translation>
-<translation id="4183868528246477015">Otsi Google Lensi abil <ph name="BEGIN_NEW" />Uus<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Ava uuel vahelehel</translation>
-<translation id="4198423547019359126">Ükski allalaadimise asukoht ei ole saadaval</translation>
-<translation id="4209895695669353772">Google'i soovitatud isikupärastatud sisu hankimiseks lülitage sünkroonimine sisse</translation>
-<translation id="4226663524361240545">Seade võib märguannete korral vibreerida</translation>
-<translation id="423219824432660969">Krüpteeri sünkroonitud andmed Google'i parooli abil <ph name="TIME" /> seisuga</translation>
-<translation id="4242533952199664413">Ava seaded</translation>
-<translation id="4256782883801055595">Avatud lähtekoodi litsentsid</translation>
-<translation id="4259722352634471385">Navigeerimine on blokeeritud: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopeeri lingi aadress</translation>
-<translation id="4275663329226226506">Meedia</translation>
-<translation id="4278390842282768270">Lubatud</translation>
-<translation id="429312253194641664">Sait esitab meediasisu</translation>
-<translation id="4298388696830689168">Lingitud saidid</translation>
-<translation id="4307992518367153382">Põhiteave</translation>
-<translation id="4314815835985389558">Sünkroonimise haldamine</translation>
-<translation id="4351244548802238354">Sule dialoog</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Otsimiseks kasutatakse teenust Sogou</translation>
-<translation id="4404568932422911380">Järjehoidjaid pole</translation>
-<translation id="4405224443901389797">Teisalda asukohta …</translation>
-<translation id="4411535500181276704">Lihtsustatud režiim</translation>
-<translation id="4415276339145661267">Google'i konto haldamine</translation>
-<translation id="4432792777822557199"><ph name="SOURCE_LANGUAGE" /> keeles olevad lehed tõlgitakse edaspidi <ph name="TARGET_LANGUAGE" /> keelde</translation>
-<translation id="4433925000917964731">Lihtsustatud lehte pakub Google</translation>
-<translation id="4434045419905280838">Hüpikaknad ja ümbersuunamised</translation>
-<translation id="4440958355523780886">Lihtsustatud lehte pakub Google. Puudutage algse lehe laadimiseks.</translation>
-<translation id="4452411734226507615">Vahelehe <ph name="TAB_TITLE" /> sulgemine</translation>
-<translation id="4452548195519783679">Lisatud järjehoidjana kausta <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Saitidel on lubatud esitada kaitstud sisu</translation>
-<translation id="4468959413250150279">Konkreetse saidi heli vaigistamine.</translation>
-<translation id="4472118726404937099">Seadmete vahel sisu sünkroonimiseks ja isikupärastamiseks logige sisse ja lülitage sünkroonimine sisse.</translation>
-<translation id="447252321002412580">Aidake täiustada Chrome'i funktsioone ja toimivust</translation>
-<translation id="4479647676395637221">Küsi enne saitidele minu kaamera kasutamiseks juurdepääsu lubamist (soovitatav)</translation>
-<translation id="4479972344484327217">Chrome'i jaoks installitakse moodulit <ph name="MODULE" /> …</translation>
-<translation id="4487967297491345095">Kõik Chrome'i rakenduse andmed kustutatakse jäädavalt. See hõlmab kõiki faile, seadeid, kontosid, andmebaase jms.</translation>
-<translation id="4493497663118223949">Lihtsustatud režiim on sees</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# päev tagasi}other{# päeva tagasi}}</translation>
-<translation id="451872707440238414">Otsi järjehoidjatest</translation>
-<translation id="4521489764227272523">Valitud andmed eemaldati Chrome'ist ja teie sünkroonitud seadmetest.
-
-Veebisaidil <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> võib teie Google'i kontol olla muus vormis sirvimisajalugu, nt otsingud ja tegevused muudes Google'i teenustes.</translation>
-<translation id="4532845899244822526">Kausta valimine</translation>
-<translation id="4538018662093857852">Lülita lihtsustatud režiim sisse</translation>
-<translation id="4550003330909367850">Parooli vaatamiseks või siia kleepimiseks määrake selles seadmes ekraanilukk.</translation>
-<translation id="4558311620361989323">Veebilehe otseteed</translation>
-<translation id="4561979708150884304">Ühendus puudub</translation>
-<translation id="4565377596337484307">Peida parool</translation>
-<translation id="4570913071927164677">Üksikasjad</translation>
-<translation id="4572422548854449519">Logige hallatud kontole sisse</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minut tagasi}other{# minutit tagasi}}</translation>
-<translation id="4587589328781138893">Saidid</translation>
-<translation id="4594952190837476234">Võrguühenduseta leht loodi <ph name="CREATION_TIME" /> ja see võib veebiversioonist erineda.</translation>
-<translation id="4605958867780575332">Üksus on eemaldatud: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Ava <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Kasuta parooli</translation>
-<translation id="4645575059429386691">Vanema hallatud</translation>
-<translation id="4650364565596261010">Süsteemi vaikeseade</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> järjehoidjat kustutati</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> lisati teie avaekraanile</translation>
-<translation id="4684427112815847243">Sünkrooni kõik</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Saada tekst seadmetesse</translation>
-<translation id="4698034686595694889">Võrguühenduseta kuvamine rakenduses <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Vahemällu salvestatud kujutised ja failid</translation>
-<translation id="4714588616299687897">Säästke kuni 60% andmemahtu</translation>
-<translation id="4719927025381752090">Paku tõlkimist</translation>
-<translation id="4720023427747327413">Ava teenuses <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Aidake Chrome'i täiustada. <ph name="BEGIN_LINK" />Vastake küsitlusele<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Värskenda</translation>
-<translation id="4738836084190194332">Viimati sünkroonitud: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Uue vahelehe avamine</translation>
-<translation id="4751476147751820511">Liikumis- või valgusandurid</translation>
-<translation id="4759238208242260848">Allalaadimised</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 allalaadimine on lõpule viidud.}other{# allalaadimist on lõpule viidud.}}</translation>
-<translation id="4797039098279997504">Puudutage vahelehele <ph name="URL_OF_THE_CURRENT_TAB" /> naasmiseks</translation>
-<translation id="4802417911091824046">Parooli krüpteerimine ei hõlma Google Pay makseviise ja aadresse.
-
-Seade muutmiseks <ph name="BEGIN_LINK" />lähtestage sünkroonimine<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Kaardil olev nimi</translation>
-<translation id="4824958205181053313">Kas tühistada sünkroonimine?</translation>
-<translation id="4837753911714442426">Valikute avamine lehe printimiseks</translation>
-<translation id="4842092870884894799">Parooli loomise hüpikakna kuvamine</translation>
-<translation id="4860895144060829044">Helistage</translation>
-<translation id="4866368707455379617">Moodulit <ph name="MODULE" /> ei saa Chrome'i jaoks installida</translation>
-<translation id="4875775213178255010">Sisu soovitused</translation>
-<translation id="4878404682131129617">Puhverserveri kaudu tunneli loomine ebaõnnestus</translation>
-<translation id="4880127995492972015">Tõlgi …</translation>
-<translation id="4881695831933465202">Ava</translation>
-<translation id="488187801263602086">Faili ümbernimetamine</translation>
-<translation id="4882831918239250449">Juhtige, kuidas teie sirvimisajalugu kasutatakse otsingu, reklaamide ja muu isikupärastamiseks</translation>
-<translation id="4883854917563148705">Hallatud seadeid ei saa lähtestada</translation>
-<translation id="4885273946141277891">Toetamata arv Chrome'i eksemplare.</translation>
-<translation id="4910889077668685004">Makserakendused</translation>
-<translation id="4913161338056004800">Lähtesta statistika</translation>
-<translation id="4913169188695071480">Peata värskendamine</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Hankige abi<ph name="END_LINK" />, kuni seadmeid otsitakse …</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# leht}other{# lehte}}</translation>
-<translation id="4932247056774066048">Kuna logite välja kontolt, mida haldab <ph name="DOMAIN_NAME" />, kustutatakse sellest seadmest teie Chrome'i andmed. Need jäävad alles teie Google'i kontole.</translation>
-<translation id="4943703118917034429">Virtuaalreaalsus</translation>
-<translation id="4943872375798546930">Tulemusi pole</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> jagab teie ekraani</translation>
-<translation id="4961107849584082341">Tõlkige leht mis tahes keelde</translation>
-<translation id="4962975101802056554">Seadme puhul kõigi lubade tühistamine</translation>
-<translation id="4970824347203572753">Pole teie asukohas saadaval</translation>
-<translation id="497421865427891073">Edasiminek</translation>
-<translation id="4988210275050210843">Faili allalaadimine (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Leheküljed</translation>
-<translation id="4994033804516042629">Kontakte ei leitud</translation>
-<translation id="4996978546172906250">Jagamine:</translation>
-<translation id="5004416275253351869">Google'i kontotegevuste haldus</translation>
-<translation id="5005498671520578047">Parooli kopeerimine</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> soovib ühenduse luua</translation>
-<translation id="5013696553129441713">Uusi soovitusi pole</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">VR-i kasutamise ajal saab sait hankida järgmist teavet:
-  -  teie füüsilised omadused, näiteks pikkus
-
-Enne VR-i aktiveerimist veenduge, et sait oleks usaldusväärne.</translation>
+<translation id="2930742481329940825">Puudutamine otsimiseks saadab valitud sõna ja praeguse lehe kontekstina Brave Software'i otsingusse. Selle saab välja lülitada jaotises <ph name="BEGIN_LINK"/>Seaded<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Luba</translation>
-<translation id="5040262127954254034">Privaatsus</translation>
-<translation id="5048398596102334565">Luba saitide jaoks juurdepääs liikumisanduritele (soovitatav)</translation>
-<translation id="5063480226653192405">Kasutus</translation>
-<translation id="5087580092889165836">Lisa kaart</translation>
-<translation id="5100237604440890931">Ahendatud – laiendamiseks klõpsake.</translation>
-<translation id="510275257476243843">Jäänud on 1 tund</translation>
-<translation id="5123685120097942451">Inkognito vaheleht</translation>
-<translation id="5127805178023152808">Sünkroonimine on välja lülitatud</translation>
-<translation id="5129038482087801250">Veebirakenduse installimine</translation>
-<translation id="5132942445612118989">Teie paroolide, ajaloo ja muude andmete sünkroonimine kõigis seadmetes</translation>
-<translation id="5139940364318403933">Vaadake, kuidas Google Drive'i kasutada</translation>
-<translation id="515227803646670480">Salvestatud andmete kustutamine</translation>
-<translation id="5152843274749979095">Toetatud rakendusi pole installitud</translation>
-<translation id="5161254044473106830">Pealkiri on kohustuslik</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 allalaadimine ebaõnnestus.}other{# allalaadimist ebaõnnestus.}}</translation>
-<translation id="5170568018924773124">Kuva kaustas</translation>
-<translation id="5184329579814168207">Ava Chrome'is</translation>
-<translation id="5193988420012215838">Kopeeritud lõikelauale</translation>
-<translation id="5197729504361054390">Teie valitud kontakte jagatakse saidiga <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Tööprofiil</translation>
-<translation id="5210286577605176222">Eelmisele vahelehele liikumine</translation>
-<translation id="5210365745912300556">Sule vaheleht</translation>
-<translation id="5224771365102442243">Videoga</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> soovib otsida läheduses olevaid Bluetooth-seadmeid. Leiti järgmised seadmed:</translation>
-<translation id="5233638681132016545">Uus vaheleht</translation>
-<translation id="526421993248218238">Seda lehte ei saa laadida</translation>
-<translation id="5271967389191913893">Seade ei saa allalaaditavat sisu avada.</translation>
-<translation id="528192093759286357">Täisekraanilt väljumiseks lohistage ülaservast alla ja puudutage tagasinuppu.</translation>
-<translation id="5292796745632149097">Saatmine</translation>
-<translation id="5300589172476337783">Kuva</translation>
-<translation id="5301954838959518834">Selge, sain aru</translation>
-<translation id="5304593522240415983">See väli ei tohi olla tühi</translation>
-<translation id="5307446750509046227">Tühjenda salvestusruum</translation>
-<translation id="5308380583665731573">Ühendamine</translation>
-<translation id="5313967007315987356">Lisa sait</translation>
-<translation id="5317780077021120954">Salvesta</translation>
-<translation id="5324858694974489420">Vanemlikud seaded</translation>
-<translation id="5327248766486351172">Nimi</translation>
-<translation id="5335288049665977812">Luba saitidel käitada JavaScripti (soovitatav)</translation>
-<translation id="5342314432463739672">Lubade taotlused</translation>
-<translation id="5357811892247919462">Vaheleht võeti vastu</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> avatud vaheleht, puudutage vahelehtede vahetamiseks}other{<ph name="OPEN_TABS_MANY" /> avatud vahelehte, puudutage vahelehtede vahetamiseks}}</translation>
-<translation id="5391532827096253100">Teie ühendus selle saidiga ei ole turvaline. Saidi teave</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(ja veel 1)}other{(ja veel #)}}</translation>
-<translation id="5400569084694353794">Seda rakendust kasutades nõustute Chrome'i <ph name="BEGIN_LINK1" />teenusetingimuste<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />privaatsusteatisega<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Nimed</translation>
-<translation id="5403644198645076998">Luba ainult kindlad saidid</translation>
-<translation id="5414836363063783498">Kinnitamine ...</translation>
-<translation id="5423934151118863508">Teie enim külastatud lehed ilmuvad siin</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB saadaval</translation>
-<translation id="543338862236136125">Muuda parooli</translation>
-<translation id="5433691172869980887">Kasutajanimi on kopeeritud</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> faili allalaadimine (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Aadressiribale liikumine</translation>
-<translation id="5447201525962359567">Saidi kogu salvestusruum, sh küpsised ja muud kohalikus seadmes talletatud andmed</translation>
-<translation id="5447765697759493033">Seda saiti ei tõlgita</translation>
-<translation id="545042621069398927">Allalaadimise kiirendamine.</translation>
-<translation id="5456381639095306749">Laadi leht alla</translation>
-<translation id="5475862044948910901">Kas alustada liitreaalsuse seanssi?</translation>
-<translation id="548278423535722844">Avage kaardirakenduses</translation>
-<translation id="5487521232677179737">Kustuta andmed</translation>
-<translation id="5494752089476963479">Blokeeri reklaamid saitidel, mis kuvavad sekkuvaid või eksitavaid reklaame</translation>
-<translation id="5500777121964041360">Ei pruugi teie asukohas saadaval olla</translation>
-<translation id="5512137114520586844">Seda kontot haldab <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Keelas selle seadme administraator</translation>
-<translation id="5515439363601853141">Avage oma parooli vaatamiseks</translation>
-<translation id="5516455585884385570">Ava märguandeseaded</translation>
-<translation id="5517095782334947753">Teil on järjehoidjad, ajalugu, paroolid ja muud seaded kontolt <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Ümbersuunamine blokeeriti.</translation>
-<translation id="5527082711130173040">Chrome vajab seadmete otsimiseks juurdepääsu teie asukohale. <ph name="BEGIN_LINK1" />Värskendage lube<ph name="END_LINK1" />. Juurdepääs asukohale on samuti <ph name="BEGIN_LINK2" />selles seadmes välja lülitatud<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Küsi luba, kui sait soovib lugeda lõikelaual olevat teksti ja pilte (soovitatav)</translation>
-<translation id="5530766185686772672">Inkognito vahelehtede sulgemine</translation>
-<translation id="5534334044554683961">VR-i kasutamise ajal võib sait hankida järgmist teavet:
-  -   teie füüsilised omadused, näiteks pikkus;
-  -   teie toa paigutus.
-
-Enne VR-i aktiveerimist veenduge, et sait oleks usaldusväärne.</translation>
-<translation id="5534640966246046842">Sait on kopeeritud</translation>
-<translation id="5556459405103347317">Laadi uuesti</translation>
-<translation id="5561549206367097665">Võrguühenduse ootamine …</translation>
-<translation id="557283862590186398">Chrome vajab selle saidi puhul luba, et teie mikrofonile juurde pääseda.</translation>
-<translation id="55737423895878184">Asukoht ja märguanded on lubatud</translation>
-<translation id="5578795271662203820">Otsi otsingust <ph name="SEARCH_ENGINE" /> kujutist</translation>
-<translation id="5581519193887989363">Jaotises <ph name="BEGIN_LINK1" />Seaded<ph name="END_LINK1" /> saate igal ajal valida, mida sünkroonida.</translation>
-<translation id="5595485650161345191">Muuda aadressi</translation>
-<translation id="5596627076506792578">Rohkem valikuid</translation>
-<translation id="5599455543593328020">Inkognito režiim</translation>
-<translation id="5620928963363755975">Leidke oma failid ja lehed jaotisest Allalaadimised, kasutades nuppu Rohkem valikuid</translation>
-<translation id="5626134646977739690">Nimi:</translation>
-<translation id="5639724618331995626">Luba kõik saidid</translation>
-<translation id="5648166631817621825">Viimased seitse päeva</translation>
-<translation id="5649053991847567735">Automaatsed allalaadimised</translation>
-<translation id="5655963694829536461">Otsige oma allalaadimiste hulgast</translation>
-<translation id="5659593005791499971">Meil</translation>
-<translation id="5665379678064389456">Looge sündmus rakenduses <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Sissesuumimise takistamiseks veebisaidi taotluse alistamine</translation>
-<translation id="5677928146339483299">Blokeeritud</translation>
-<translation id="5684874026226664614">Vabandust. Lehte ei õnnestunud tõlkida.</translation>
-<translation id="5686790454216892815">Faili nimi on liiga pikk</translation>
-<translation id="5689516760719285838">Asukoht</translation>
-<translation id="569536719314091526">Tõlkige leht mis tahes keelde nupuga Rohkem valikuid</translation>
-<translation id="572328651809341494">Hiljutised vahelehed</translation>
-<translation id="5726692708398506830">Lehel kuvatud sisu suurendamine</translation>
-<translation id="5748802427693696783">Tavapärased vahelehed on aktiveeritud</translation>
-<translation id="5749068826913805084">Chrome vajab failide allalaadimiseks juurdepääsu salvestusruumile.</translation>
-<translation id="5763382633136178763">Inkognito režiimi vahekaardid</translation>
-<translation id="5763514718066511291">Puudutage URL-i kopeerimiseks selle rakenduse jaoks</translation>
-<translation id="5765780083710877561">Kirjeldus:</translation>
-<translation id="5793665092639000975">Kasutusel on <ph name="SPACE_USED" /> <ph name="SPACE_AVAILABLE" />-st</translation>
-<translation id="5797070761912323120">Google võib kasutada teie ajalugu otsingu, reklaamide ja muude Google'i teenuste isikupärastamiseks</translation>
-<translation id="5804241973901381774">Load</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# tund tagasi}other{# tundi tagasi}}</translation>
-<translation id="5810288467834065221">Autoriõigus <ph name="YEAR" /> Google LLC. Kõik õigused on kaitstud.</translation>
-<translation id="5817918615728894473">Seo</translation>
-<translation id="583281660410589416">Tundmatu</translation>
-<translation id="5833984609253377421">Jaga linki</translation>
-<translation id="5836192821815272682">Chrome'i värskenduse allalaadimine …</translation>
-<translation id="5853623416121554550">peatatud</translation>
-<translation id="5854790677617711513">Vanemad kui 30 päeva</translation>
-<translation id="5858741533101922242">Chrome ei saa Bluetoothi adapterit sisse lülitada</translation>
-<translation id="5860033963881614850">Väljas</translation>
-<translation id="5862731021271217234">Vahelehtede hankimiseks oma teistest seadmetest lülitage sünkroonimine sisse</translation>
-<translation id="5864174910718532887">Üksikasjad: sorditud saidi nime alusel</translation>
-<translation id="5864419784173784555">Teise allalaadimise ootamine …</translation>
-<translation id="5865733239029070421">Google'ile saadetakse automaatselt kasutusstatistikat ja krahhiaruandeid</translation>
-<translation id="5869522115854928033">Salvestatud paroolid</translation>
-<translation id="5902828464777634901">Kõik veebisaidi salvestatud kohalikud andmed (sh küpsised) kustutatakse.</translation>
-<translation id="5916664084637901428">Sees</translation>
-<translation id="5919204609460789179">Sünkroonimise alustamiseks värskendage teenust <ph name="PRODUCT_NAME" /></translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> on säästetud</translation>
-<translation id="5939518447894949180">Lähtesta</translation>
-<translation id="5942872142862698679">Otsimiseks kasutatakse Google'it</translation>
-<translation id="5952764234151283551">Saadab Google'ile teie soovitud lehe URL-i</translation>
-<translation id="5956665950594638604">Chrome'i abikeskuse avamine uuel vahelehel</translation>
-<translation id="5958275228015807058">Leidke oma failid ja lehed jaotisest Allalaadimised</translation>
-<translation id="5962718611393537961">Ahendamiseks puudutage</translation>
-<translation id="6000066717592683814">Säilita Google</translation>
-<translation id="6005538289190791541">Soovitatud parool</translation>
-<translation id="6036057147555329831">Täiendav ICU</translation>
-<translation id="6039379616847168523">Järgmisele vahelehele liikumine</translation>
-<translation id="6040143037577758943">Sulge</translation>
-<translation id="6042308850641462728">Rohkem</translation>
-<translation id="604996488070107836">Faili <ph name="FILE_NAME" /> allalaadimine ebaõnnestus tundmatu vea tõttu.</translation>
-<translation id="605721222689873409">aa</translation>
-<translation id="6064125863973209585">Lõpetatud allalaadimised</translation>
-<translation id="6075798973483050474">Avalehe muutmine</translation>
-<translation id="60923314841986378">Jäänud on <ph name="HOURS" /> tundi</translation>
-<translation id="6108923351542677676">Seadistamine on pooleli ...</translation>
-<translation id="6111020039983847643">kasutatud andmemaht</translation>
-<translation id="6112702117600201073">Lehe värskendamine</translation>
-<translation id="6127379762771434464">Üksus eemaldati</translation>
-<translation id="6140912465461743537">Riik/piirkond</translation>
-<translation id="614940544461990577">Proovige järgmist.</translation>
-<translation id="6154478581116148741">Seadmes olevate paroolide eksportimiseks lülitage seadetes ekraanilukk sisse.</translation>
-<translation id="6159335304067198720">Andmemahu kokkuhoid: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Lisateave</translation>
-<translation id="6177111841848151710">Praeguse otsingumootori puhul blokeeritud</translation>
-<translation id="6181444274883918285">Lisa saidi erand</translation>
-<translation id="6192333916571137726">Faili allalaadimine</translation>
-<translation id="6192792657125177640">Erandid</translation>
-<translation id="6194112207524046168">Selleks et anda Chrome'ile juurdepääs teie kaamerale, lülitage kaamera sisse ka <ph name="BEGIN_LINK" />Androidi seadetes<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokeeri kolmanda osapoole küpsisefailid</translation>
-<translation id="6206551242102657620">Ühendus on turvaline. Saidi teave</translation>
-<translation id="6210748933810148297">Kas pole <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Paroolide eksportimiseks avage seade</translation>
+<translation id="1406000523432664303">„Ära jälgi”</translation>
 <translation id="6232535412751077445">Kui lubate funktsiooni „Ära jälgi”, kaasatakse see taotlus teie sirvimisliiklusesse. Mõju oleneb sellest, kas veebisait reageerib taotlusele ja kuidas seda tõlgendatakse.
 
 Näiteks võivad mõned veebisaidid taotlusele reageerida nii, et näitavad teile reklaame, mis ei põhine muudel külastatud veebisaitidel. Paljud veebisaidid koguvad ning kasutavad endiselt teie sirvimisandmeid, näiteks turvalisuse parandamiseks, sisu, reklaamide ja soovituste pakkumiseks ning aruandlusstatistika loomiseks.</translation>
-<translation id="624789221780392884">Värskendus on valmis</translation>
-<translation id="6255999984061454636">Sisu soovitused</translation>
-<translation id="6277522088822131679">Lehe printimisel ilmnes probleem. Proovige uuesti.</translation>
-<translation id="6295158916970320988">Kõik saidid</translation>
-<translation id="629730747756840877">Konto</translation>
-<translation id="6303969859164067831">Logi välja ja lülita sünkroonimine välja</translation>
-<translation id="6316139424528454185">Seda Androidi versiooni ei toetata</translation>
-<translation id="6320088164292336938">Vibreerimine</translation>
-<translation id="6324034347079777476">Androidi süsteemi sünkroonimine on keelatud</translation>
-<translation id="6333140779060797560">Jagamine rakenduse <ph name="APPLICATION" /> kaudu</translation>
-<translation id="6337234675334993532">Krüpteerimine</translation>
-<translation id="6341580099087024258">Küsi, kuhu failid salvestada</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Kas eemaldada soovitus ajaloost?</translation>
-<translation id="6369229450655021117">Siin saab otsida veebis, jagada sõpradega ja näha avatud lehekülgi</translation>
-<translation id="6378173571450987352">Üksikasjad: sorditud kasutatud andmemahu alusel</translation>
-<translation id="6381421346744604172">Tumenda veebisaidid</translation>
-<translation id="6388207532828177975">Kustuta ja lähtesta</translation>
-<translation id="6393863479814692971">Chrome vajab selle saidi puhul luba, et teie kaamerale ja mikrofonile juurde pääseda.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Muuda järjehoidjat</translation>
-<translation id="6406506848690869874">Sünkroonimine</translation>
-<translation id="641643625718530986">Printimine ...</translation>
-<translation id="6416782512398055893">Alla on laaditud <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Veebi tõlkimine</translation>
-<translation id="6433501201775827830">Valige oma otsingumootor</translation>
-<translation id="6437478888915024427">Lehe teave</translation>
-<translation id="6441734959916820584">Nimi on liiga pikk</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# pilt}other{# pilti}}</translation>
-<translation id="6447842834002726250">Küpsised</translation>
-<translation id="6461962085415701688">Faili ei saa avada</translation>
-<translation id="6464977750820128603">Näete saite, mida Chrome'is külastate, ja saate nendele taimereid määrata.\n\nGoogle saab teavet saitide kohta, millele taimereid määrate, ja näeb, kui kaua neid külastate. Selle teabe abil muudetakse teenus Digitaalne heaolu paremaks.</translation>
-<translation id="6475951671322991020">Laadi video alla</translation>
-<translation id="6482749332252372425">Faili <ph name="FILE_NAME" /> allalaadimine ebaõnnestus, kuna salvestusruumi on liiga vähe.</translation>
-<translation id="6496823230996795692">Rakenduse <ph name="APP_NAME" /> esmakordseks kasutamiseks looge ühendus Internetiga.</translation>
-<translation id="6508722015517270189">Taaskäivitage Chrome</translation>
-<translation id="6527303717912515753">Jaga</translation>
-<translation id="6532866250404780454">Chrome'is külastatud saite ei kuvata. Kõik saitide taimerid kustutatakse.</translation>
-<translation id="6534565668554028783">Google'il kulus reageerimiseks liiga kaua aega</translation>
-<translation id="6538442820324228105">Alla on laaditud <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Midagi läks valesti. Proovige hiljem uuesti.</translation>
-<translation id="654446541061731451">Valige kiirega edastatav vaheleht</translation>
-<translation id="6545017243486555795">Kustuta kõik andmed</translation>
-<translation id="6545864417968258051">Bluetoothi otsimine</translation>
-<translation id="6560414384669816528">Otsi teenusega Sogou</translation>
-<translation id="6566259936974865419">Chrome aitas teil säästa <ph name="GIGABYTES" /> GB andmemahtu</translation>
-<translation id="6573096386450695060">Luba alati</translation>
-<translation id="6573431926118603307">Siin kuvatakse teie teistes seadmetes Chrome'is avatud vahelehed.</translation>
-<translation id="6583199322650523874">Praeguse lehe lisamine järjehoidjatesse</translation>
-<translation id="6593061639179217415">Arvutisait</translation>
-<translation id="6600954340915313787">Chrome'i kopeeritud</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Kaitstud sisu</translation>
-<translation id="6627583120233659107">Muuda kausta</translation>
-<translation id="6643016212128521049">Tühjenda</translation>
-<translation id="6643649862576733715">Sordi säästetud andmemahu alusel</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Kujutise eelvaade <ph name="BEGIN_NEW" />Uus<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome vajab seadmete skannimiseks juurdepääsu teie asukohale. <ph name="BEGIN_LINK" />Värskendage lube<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Parool</translation>
-<translation id="6659594942844771486">Vaheleht</translation>
-<translation id="666731172850799929">Ava rakenduses <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Chrome'i privaatsusteatis</translation>
-<translation id="6676840375528380067">Kas kustutada sellest seadmest Chrome'i andmed?</translation>
-<translation id="6697492270171225480">Kui lehte ei leita, kuvatakse sarnaste lehtede soovitusi</translation>
-<translation id="6697947395630195233">Chrome vajab juurdepääsu teie asukohale, et seda selle saidiga jagada.</translation>
-<translation id="6698801883190606802">Sünkroonitud andmete haldamine</translation>
-<translation id="6699370405921460408">Google'i serverid optimeerivad teie külastatavaid lehti.</translation>
-<translation id="6706288973712894588">Te pole praegu võrguga ühendatud.\n<ph name="BEGIN_LINK" />Uurige võrguühenduseta voogu.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Uudised</translation>
-<translation id="6710213216561001401">Eelmine</translation>
-<translation id="671481426037969117">Teie rakenduse <ph name="FQDN" /> taimeri aeg sai otsa. See alustab uuesti homme.</translation>
-<translation id="6738867403308150051">Allalaadimine ...</translation>
-<translation id="6746124502594467657">Liiguta alla</translation>
-<translation id="6766622839693428701">Sulgemiseks pühkige alla.</translation>
-<translation id="6766758767654711248">Puudutage saidi külastamiseks</translation>
-<translation id="6767294960381293877">Vahelehe jagamise seadmete loend (poolel kõrgusel avatud).</translation>
-<translation id="6782111308708962316">Keela kolmanda osapoole veebisaitidele küpsisefailide andmete salvestamine ja lugemine</translation>
-<translation id="6790428901817661496">Esita</translation>
-<translation id="6811034713472274749">Leht on vaatamiseks valmis</translation>
-<translation id="6818926723028410516">Valige üksused</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Tõlgi</translation>
-<translation id="6845325883481699275">Aidake Chrome'i turvalisust täiustada</translation>
-<translation id="6846298663435243399">Laadimine …</translation>
-<translation id="6850409657436465440">Allalaadimine on endiselt pooleli</translation>
-<translation id="6850830437481525139">Suleti <ph name="TAB_COUNT" /> vahelehte</translation>
-<translation id="6864459304226931083">Laadi kujutis alla</translation>
-<translation id="6865313869410766144">Automaattäitmise vormiandmed</translation>
-<translation id="688738109438487280">Lisab olemasolevad andmed kontole <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Avage oma parooli kopeerimiseks</translation>
-<translation id="6896758677409633944">Kopeeri</translation>
-<translation id="6910211073230771657">Kustutatud</translation>
-<translation id="6912998170423641340">Keela saitidel lugeda lõikelaual olevat teksti ja pilte</translation>
-<translation id="6914783257214138813">Teie paroolid on nähtavad kõigile, kes saavad vaadata eksporditud faili.</translation>
-<translation id="6942665639005891494">Allalaadimise vaikeasukohta saab menüü Seaded valikuga alati muuta</translation>
-<translation id="6945221475159498467">Vali</translation>
-<translation id="6963642900430330478">See leht on ohtlik. Saidi teave</translation>
-<translation id="6963766334940102469">Kustuta järjehoidjad</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Algusest</translation>
-<translation id="6981982820502123353">Juurdepääsetavus</translation>
-<translation id="6989267951144302301">Ei saanud alla laadida</translation>
-<translation id="6990079615885386641">Hankige rakendus Google Play poest: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Küsi enne saitidele minu mikrofoni kasutamiseks juurdepääsu lubamist (soovitatav)</translation>
-<translation id="7015203776128479407">Sünkroonimise algseadistust ei viidud lõpule. Sünkroonimine on välja lülitatud.</translation>
-<translation id="7016516562562142042">Praeguse otsingumootori puhul lubatud</translation>
-<translation id="7022756207310403729">Avamine brauseris</translation>
-<translation id="702463548815491781">Soovitatav juhul, kui TalkBack või lülitiga juurdepääs on sisse lülitatud</translation>
-<translation id="7029809446516969842">Paroolid</translation>
-<translation id="7053983685419859001">Blokeeri</translation>
-<translation id="7055152154916055070">Ümbersuunamine blokeeriti:</translation>
-<translation id="7063006564040364415">Sünkroonimisserveriga ei saanud ühendust.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 on valitud}other{# on valitud}}</translation>
-<translation id="7071521146534760487">Konto haldamine</translation>
-<translation id="7077143737582773186">SD-kaart</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> on valitud.  Valikud on saadaval ekraanikuva ülaosas</translation>
-<translation id="7121362699166175603">Kustutab aadressiribalt ajaloo ja automaatse täitmise andmed. Aadressil <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> võib teie Google'i kontol olla muus vormis sirvimisajalugu.</translation>
-<translation id="7128222689758636196">Lubab praeguse otsingumootori puhul</translation>
-<translation id="7138678301420049075">Muu</translation>
-<translation id="7141896414559753902">Blokeeri saitidel hüpikakende ja ümbersuunamiste kuvamine (soovitatav)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Laadi originaalleht<ph name="END_LINK" /> domeenilt <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Viimased 24 tundi</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Seda saate hiljem muuta jaotises Seaded</translation>
-<translation id="7180611975245234373">Värskenda</translation>
-<translation id="7189372733857464326">Google Play teenuste värskendamise lõpetamise ootamine</translation>
-<translation id="7191430249889272776">Taustal on avatud vaheleht.</translation>
-<translation id="723171743924126238">Kujutiste valimine</translation>
-<translation id="7233236755231902816">Hankige Chrome'i uusim versioon, et saaksite oma keeles veebi sirvida</translation>
-<translation id="7243308994586599757">Valikud on saadaval ekraani allosas</translation>
-<translation id="7248069434667874558">Veenduge, et seadmes <ph name="TARGET_DEVICE_NAME" /> oleks Chrome'i sünkroonimine sisse lülitatud</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> on valitud</translation>
-<translation id="7274013316676448362">Blokeeritud sait</translation>
-<translation id="7290209999329137901">Ümbernimetamine ei ole võimalik</translation>
-<translation id="7291387454912369099">Maksmine assistendi kaudu</translation>
-<translation id="7293171162284876153">Sünkroonimise alustamiseks lülitage sisse valik „Chrome'i andmete sünkroonimine”.</translation>
-<translation id="729975465115245577">Seadmes pole sünkroonimiseks piisavalt salvestusruumi.</translation>
-<translation id="7302081693174882195">Üksikasjad: sorditud säästetud andmemahu alusel</translation>
-<translation id="7328017930301109123">Lihtsustatud režiimis laadib Chrome lehti kiiremini ja kasutab kuni 60 protsenti vähem andmemahtu.</translation>
-<translation id="7333031090786104871">Eelmist saiti alles lisatakse</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Jaga 1 valitud üksust}other{Jaga # valitud üksust}}</translation>
 <translation id="7359002509206457351">Makseviisidele juurdepääsemine</translation>
+<translation id="8026334261755873520">Sirvimisandmete kustutamine</translation>
+<translation id="1291207594882862231">Ajaloo, küpsiste, saidiandmete, vahemälu kustutamine …</translation>
+<translation id="7814200940910057384">Brave'i andmed kustutati</translation>
+<translation id="1664855196866195614">Valitud andmed eemaldati Brave'ist ja teie sünkroonitud seadmetest.
+
+Veebisaidil <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> võib teie Brave Software'i kontol olla muus vormis sirvimisajalugu, nt otsingud ja tegevused muudes Brave Software'i teenustes.</translation>
+<translation id="4699172675775169585">Vahemällu salvestatud kujutised ja failid</translation>
+<translation id="2496180316473517155">Sirvimise ajalugu</translation>
+<translation id="2546283357679194313">Küpsised ja saidiandmed</translation>
+<translation id="8662811608048051533">Logib teid enamikult saitidelt välja.</translation>
+<translation id="8218628800671693884">Logib teid enamikult saitidelt välja. Brave Software'i kontolt teid välja ei logita.</translation>
+<translation id="2017836877785168846">Kustutab aadressiribalt ajaloo ja automaatse täitmise teabe.</translation>
+<translation id="8096327394278038498">Kustutab aadressiribalt ajaloo ja automaatse täitmise andmed. Aadressil <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> võib teie Brave Software'i kontol olla muus vormis sirvimisajalugu.</translation>
+<translation id="8122693181154564064">Kustutab ajaloo kõigist sisselogitud seadmetest. Aadressil <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> võib teie Brave Software'i kontol olla muus vormis sirvimisajalugu.</translation>
+<translation id="5869522115854928033">Salvestatud paroolid</translation>
+<translation id="6865313869410766144">Automaattäitmise vormiandmed</translation>
+<translation id="7562080006725997899">Sirvimisandmete kustutamine</translation>
+<translation id="5487521232677179737">Kustuta andmed</translation>
+<translation id="7498271377022651285">Oodake ...</translation>
+<translation id="784934925303690534">Ajavahemik</translation>
+<translation id="1718835860248848330">Viimase tunni jooksul</translation>
+<translation id="7149893636342594995">Viimased 24 tundi</translation>
+<translation id="5648166631817621825">Viimased seitse päeva</translation>
+<translation id="8571213806525832805">Viimased 4 nädalat</translation>
+<translation id="5854790677617711513">Vanemad kui 30 päeva</translation>
+<translation id="6979737339423435258">Algusest</translation>
+<translation id="982182592107339124">See kustutab kõikide saitide andmed, sealhulgas:</translation>
+<translation id="6643016212128521049">Tühjenda</translation>
+<translation id="7641339528570811325">Sirvimisandmete kustutamine …</translation>
+<translation id="1670399744444387456">Põhiseaded</translation>
+<translation id="3245261285041759672">Aadressil <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> võib teie Brave Software'i kontol olla muus vormis sirvimisajalugu.</translation>
+<translation id="7274013316676448362">Blokeeritud sait</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> üksust kustutati</translation>
+<translation id="1121094540300013208">Kasutus- ja krahhiaruanded</translation>
+<translation id="9079153198295609735">Saada kasutusstatistika ja krahhiaruanded automaatselt Brave Software'ile</translation>
+<translation id="6981982820502123353">Juurdepääsetavus</translation>
+<translation id="2387895666653383613">Teksti skaleerimine</translation>
+<translation id="2321958826496381788">Lohistage liugurit, kuni saate seda mugavalt lugeda. Lõigu topeltkoputamisel peab tekst olema vähemalt nii suur.</translation>
+<translation id="3895926599014793903">Sundluba suumimine</translation>
+<translation id="5668404140385795438">Sissesuumimise takistamiseks veebisaidi taotluse alistamine</translation>
+<translation id="4149994727733219643">Veebilehtede lihtsustatud vaade</translation>
+<translation id="9100505651305367705">Pakutakse artiklite kuvamist lihtsustatud vaates, kui seda toetatakse</translation>
+<translation id="1409426117486808224">Avatud vahelehtede lihtsustatud vaade</translation>
+<translation id="702463548815491781">Soovitatav juhul, kui TalkBack või lülitiga juurdepääs on sisse lülitatud</translation>
+<translation id="8284326494547611709">Subtiitrid</translation>
+<translation id="4165986682804962316">Saidi seaded</translation>
+<translation id="6295158916970320988">Kõik saidid</translation>
+<translation id="8380167699614421159">Sait kuvab sekkuvaid või eksitavaid reklaame.</translation>
+<translation id="1919345977826869612">Reklaamid</translation>
+<translation id="410351446219883937">Automaatesitus</translation>
+<translation id="6447842834002726250">Küpsised</translation>
+<translation id="6196640612572343990">Blokeeri kolmanda osapoole küpsisefailid</translation>
+<translation id="6782111308708962316">Keela kolmanda osapoole veebisaitidele küpsisefailide andmete salvestamine ja lugemine</translation>
+<translation id="7521387064766892559">Javascript</translation>
+<translation id="4434045419905280838">Hüpikaknad ja ümbersuunamised</translation>
+<translation id="4751476147751820511">Liikumis- või valgusandurid</translation>
+<translation id="1717218214683051432">Liikumisandurid</translation>
+<translation id="2091887806945687916">Heli</translation>
+<translation id="2586657967955657006">Lõikelaud</translation>
+<translation id="6320088164292336938">Vibreerimine</translation>
+<translation id="4226663524361240545">Seade võib märguannete korral vibreerida</translation>
+<translation id="1446450296470737166">MIDI-seadm. täieliku juht. lub.</translation>
+<translation id="3744111561329211289">Taustal sünkroonimine</translation>
+<translation id="5649053991847567735">Automaatsed allalaadimised</translation>
+<translation id="6181444274883918285">Lisa saidi erand</translation>
+<translation id="5313967007315987356">Lisa sait</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> on lisatud</translation>
+<translation id="7837721118676387834">Lubage vaigistatud videote automaatne esitamine konkreetsel saidil.</translation>
+<translation id="2621115761605608342">Lubage JavaScript konkreetse saidi jaoks.</translation>
+<translation id="8801436777607969138">JavaScripti blokeerimine konkreetsel saidil.</translation>
+<translation id="8372893542064058268">Konkreetse saidi jaoks taustal sünkroonimise lubamine.</translation>
+<translation id="358794129225322306">Lubab saidil automaatselt mitut faili alla laadida.</translation>
+<translation id="4008040567710660924">Lubage konkreetse saidi küpsisefailid.</translation>
+<translation id="8958424370300090006">Blokeerige konkreetse saidi küpsisefailid.</translation>
+<translation id="7882806643839505685">Konkreetse saidi heli lubamine.</translation>
+<translation id="4468959413250150279">Konkreetse saidi heli vaigistamine.</translation>
+<translation id="1994173015038366702">Saidi URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Kasutus</translation>
+<translation id="5804241973901381774">Load</translation>
+<translation id="4278390842282768270">Lubatud</translation>
+<translation id="5677928146339483299">Blokeeritud</translation>
+<translation id="1984937141057606926">Lubatud, välja arvatud kolmanda osapoole küpsised</translation>
+<translation id="7423098979219808738">Esmalt küsib</translation>
+<translation id="8116925261070264013">Vaigistatud</translation>
+<translation id="8300705686683892304">Neid haldab rakendus</translation>
+<translation id="6192792657125177640">Erandid</translation>
+<translation id="257931822824936280">Laiendatud – ahendamiseks klõpsake.</translation>
+<translation id="5100237604440890931">Ahendatud – laiendamiseks klõpsake.</translation>
+<translation id="857943718398505171">Lubatud (soovitatav)</translation>
+<translation id="2913331724188855103">Lubab saitidel salvestada küpsiseid ja lugeda küpsiste andmeid (soovitatav)</translation>
+<translation id="7445411102860286510">Luba saitidel vaigistatud videoid automaatselt esitada (soovitatav)</translation>
+<translation id="5335288049665977812">Luba saitidel käitada JavaScripti (soovitatav)</translation>
+<translation id="5527111080432883924">Küsi luba, kui sait soovib lugeda lõikelaual olevat teksti ja pilte (soovitatav)</translation>
+<translation id="6912998170423641340">Keela saitidel lugeda lõikelaual olevat teksti ja pilte</translation>
+<translation id="7423538860840206698">Lõikelaua lugemine on blokeeritud</translation>
+<translation id="3955193568934677022">Luba saitidel esitada kaitstud sisu (soovitatav)</translation>
+<translation id="445467742685312942">Saitidel on lubatud esitada kaitstud sisu</translation>
+<translation id="2107397443965016585">Küsi enne saidile kaitstud sisu esitamiseks loa andmist (soovitatav)</translation>
+<translation id="2910701580606108292">Küsi enne saitidel kaitstud sisu esitamise lubamist</translation>
+<translation id="757524316907819857">Saitidel kaitstud sisu esitamise blokeerimine</translation>
+<translation id="3277252321222022663">Luba saitide jaoks juurdepääs anduritele (soovitatav)</translation>
+<translation id="5048398596102334565">Luba saitide jaoks juurdepääs liikumisanduritele (soovitatav)</translation>
+<translation id="8816026460808729765">Blokeeri saitide jaoks juurdepääs anduritele</translation>
+<translation id="169515064810179024">Blokeeri saitide juurdepääs liikumisanduritele</translation>
+<translation id="1660204651932907780">Saitidel lubatakse esitada heli (soovitatav)</translation>
+<translation id="3600792891314830896">Heli esitavad saidid vaigistatakse</translation>
+<translation id="1743802530341753419">Küsi luba, kui saidid üritavad seadmega ühendust luua (soovitatav)</translation>
+<translation id="851751545965956758">Blokeeri saitidel seadmetega ühenduse loomine</translation>
+<translation id="7141896414559753902">Blokeeri saitidel hüpikakende ja ümbersuunamiste kuvamine (soovitatav)</translation>
+<translation id="5494752089476963479">Blokeeri reklaamid saitidel, mis kuvavad sekkuvaid või eksitavaid reklaame</translation>
+<translation id="3123473560110926937">Blokeeritud teatud saitidel</translation>
+<translation id="965817943346481315">Blokeeri, kui sait kuvab sekkuvaid või eksitavaid reklaame (soovitatav)</translation>
+<translation id="3386292677130313581">Küsi enne saitidele minu asukoha avaldamist (soovitatav)</translation>
+<translation id="9139068048179869749">Küsi enne saitidele märguannete saatmise lubamist (soovitatav)</translation>
+<translation id="4479647676395637221">Küsi enne saitidele minu kaamera kasutamiseks juurdepääsu lubamist (soovitatav)</translation>
+<translation id="6992289844737586249">Küsi enne saitidele minu mikrofoni kasutamiseks juurdepääsu lubamist (soovitatav)</translation>
+<translation id="2289270750774289114">Küsi, kui sait soovib läheduses asuvaid Bluetoothi seadmeid tuvastada (soovitatav)</translation>
+<translation id="7053983685419859001">Blokeeri</translation>
+<translation id="7128222689758636196">Lubab praeguse otsingumootori puhul</translation>
+<translation id="7589445247086920869">Blokeerib praeguse otsingumootori puhul</translation>
+<translation id="6388207532828177975">Kustuta ja lähtesta</translation>
+<translation id="7999064672810608036">Kas soovite kindlasti kustutada kõik kohalikud andmed (sh küpsised) ja lähtestada kõik selle veebisaidi load?</translation>
+<translation id="2822354292072154809">Kas soovite objekti <ph name="CHOSEN_OBJECT_NAME"/> jaoks kindlasti lähtestada kõik saidi load?</translation>
+<translation id="515227803646670480">Salvestatud andmete kustutamine</translation>
+<translation id="5902828464777634901">Kõik veebisaidi salvestatud kohalikud andmed (sh küpsised) kustutatakse.</translation>
+<translation id="119944043368869598">Tühjenda kõik</translation>
+<translation id="2490684707762498678">Haldab <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Ava märguandeseaded</translation>
+<translation id="1404122904123200417">Manustatud saidile <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Veebisaitide salvestatud failid kuvatakse siin</translation>
+<translation id="4181841719683918333">Keeled</translation>
+<translation id="2647434099613338025">Lisa keel</translation>
+<translation id="1952172573699511566">Veebisaidid kuvavad teksti võimaluse korral teie eelistatud keeles.</translation>
+<translation id="8559990750235505898">Paku muudes keeltes olevate lehtede tõlkimist</translation>
+<translation id="4719927025381752090">Paku tõlkimist</translation>
+<translation id="8156139159503939589">Millistes keeltes te loete?</translation>
+<translation id="5689516760719285838">Asukoht</translation>
+<translation id="2440823041667407902">Juurdepääs asukohale</translation>
+<translation id="2023546461831060654">Lülita <ph name="BEGIN_LINK"/>Android-seadetes<ph name="END_LINK"/> sisse load Brave'ile.</translation>
+<translation id="6665548517310046133">Lülita <ph name="BEGIN_LINK"/>Android-seadetes<ph name="END_LINK"/> sisse luba Brave'ile.</translation>
+<translation id="2928908108430545745">Selleks et anda Brave'ile juurdepääs teie asukohale, lülitage funktsioon Asukoht sisse ka <ph name="BEGIN_LINK"/>Androidi seadetes<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Selleks et anda Brave'ile juurdepääs teie kaamerale, lülitage kaamera sisse ka <ph name="BEGIN_LINK"/>Androidi seadetes<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Selleks et lubada Brave'il teile märguandeid saata, lülitage märguanded <ph name="BEGIN_LINK"/>Androidi seadetes<ph name="END_LINK"/> ka sisse.</translation>
+<translation id="8753483718490035722">Selleks et anda Brave'ile juurdepääs teie mikrofonile, lülitage mikrofon sisse ka <ph name="BEGIN_LINK"/>Androidi seadetes<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Juurdepääs asukohale on selle seadme puhul välja lülitatud. Lülitage see sisse <ph name="BEGIN_LINK"/>Androidi seadetes<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Ka juurdepääs asukohale on selle seadme puhul välja lülitatud. Lülitage see sisse <ph name="BEGIN_LINK"/>Androidi seadetes<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kaamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Juurdepääs kaamerale</translation>
+<translation id="945632385593298557">Juurdepääs mikrofonile</translation>
+<translation id="6612358246767739896">Kaitstud sisu</translation>
+<translation id="885701979325669005">Salvestamine</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> salvestatud andmeid</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Seadme loa tühistamine</translation>
+<translation id="4962975101802056554">Seadme puhul kõigi lubade tühistamine</translation>
+<translation id="6545864417968258051">Bluetoothi otsimine</translation>
+<translation id="4411535500181276704">Lihtsustatud režiim</translation>
+<translation id="7821588508402923572">Siin kuvatakse teie säästetud andmemaht</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> salvestati</translation>
+<translation id="8569404424186215731">alates kuupäevast <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Lihtsustatud režiimis laadib Brave lehti kiiremini ja kasutab kuni 60 protsenti vähem andmemahtu.</translation>
+<translation id="6159335304067198720">Andmemahu kokkuhoid: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">säästetud andmemaht</translation>
+<translation id="6111020039983847643">kasutatud andmemaht</translation>
+<translation id="7413229368719586778">Alguskuupäev: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Lõppkuupäev: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sordi saidi alusel</translation>
+<translation id="5864174910718532887">Üksikasjad: sorditud saidi nime alusel</translation>
+<translation id="116280672541001035">Kasutatud</translation>
+<translation id="8349013245300336738">Sordi kasutatud andmemahu alusel</translation>
+<translation id="6378173571450987352">Üksikasjad: sorditud kasutatud andmemahu alusel</translation>
+<translation id="2631006050119455616">Säästetud</translation>
+<translation id="6643649862576733715">Sordi säästetud andmemahu alusel</translation>
+<translation id="7302081693174882195">Üksikasjad: sorditud säästetud andmemahu alusel</translation>
+<translation id="4179980317383591987">Kasutati <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> on säästetud</translation>
+<translation id="2156074688469523661">Järelejäänud saidid (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Muu</translation>
+<translation id="4913161338056004800">Lähtesta statistika</translation>
+<translation id="1856325424225101786">Kas lähtestada lihtsustatud režiim?</translation>
+<translation id="3658159451045945436">Lähtestamisel kustutatakse säästetud andmemahu ajalugu, sh külastatud saitide loend.</translation>
+<translation id="3295530008794733555">Sirvige kiiremini. Kasutage vähem andmemahtu.</translation>
+<translation id="7340390500800578919">Lihtsustatud režiimis laadib Brave lehti kiiremini ja kasutab kuni 60% vähem andmemahtu. Külastatud lehtede optimeerimiseks saadab Brave teie veebiliikluse Brave Software’ile. <ph name="BEGIN_LINK"/>Lisateave<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Lülita lihtsustatud režiim sisse</translation>
+<translation id="4493497663118223949">Lihtsustatud režiim on sees</translation>
+<translation id="7559975015014302720">Lihtsustatud režiim on väljas</translation>
+<translation id="7606077192958116810">Lihtsustatud režiim on sees. Hallake seda menüüs Seaded.</translation>
+<translation id="4714588616299687897">Säästke kuni 60% andmemahtu</translation>
+<translation id="1006927014032731288">Brave Software'i serverid optimeerivad teie külastatavaid lehti.</translation>
+<translation id="3257320067425202300">Brave aitas teil säästa <ph name="MEGABYTES"/> MB andmemahtu</translation>
+<translation id="5813223329348543512">Brave aitas teil säästa <ph name="GIGABYTES"/> GB andmemahtu</translation>
+<translation id="8266862848225348053">Allalaadimise asukoht</translation>
+<translation id="7077143737582773186">SD-kaart</translation>
+<translation id="7762668264895820836">SD-kaart <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Küsi, kuhu failid salvestada</translation>
+<translation id="6192333916571137726">Faili allalaadimine</translation>
+<translation id="1672586136351118594">Ära kuva uuesti</translation>
+<translation id="2650751991977523696">Kas soovite faili uuesti alla laadida?</translation>
+<translation id="8664979001105139458">Faili nimi on juba olemas</translation>
+<translation id="488187801263602086">Faili ümbernimetamine</translation>
+<translation id="5686790454216892815">Faili nimi on liiga pikk</translation>
+<translation id="7454641608352164238">Pole piisavalt ruumi</translation>
+<translation id="8972098258593396643">Kas soovite alla laadida vaikekausta?</translation>
+<translation id="804335162455518893">SD-kaarti ei leitud</translation>
+<translation id="7475688122056506577">SD-kaarti ei leitud. Mõned failid võivad puududa.</translation>
+<translation id="4198423547019359126">Ükski allalaadimise asukoht ei ole saadaval</translation>
+<translation id="8224471946457685718">Teile soovitatud artiklite allalaadimine WiFi-ühendusega</translation>
+<translation id="4970824347203572753">Pole teie asukohas saadaval</translation>
+<translation id="5500777121964041360">Ei pruugi teie asukohas saadaval olla</translation>
+<translation id="1173894706177603556">Muuda nime</translation>
+<translation id="1986685561493779662">Nimi on juba olemas</translation>
+<translation id="6441734959916820584">Nimi on liiga pikk</translation>
+<translation id="2923908459366352541">Nimi on sobimatu</translation>
+<translation id="7290209999329137901">Ümbernimetamine ei ole võimalik</translation>
+<translation id="3334729583274622784">Kas muuta faililaiendit?</translation>
+<translation id="107147699690128016">Kui muudate faililaiendit, võib fail avaneda mõnes teises rakenduses ja teie seadmele ohtu kujutada.</translation>
+<translation id="8541922081612557424">Teave Brave'i kohta</translation>
+<translation id="5311273890481188673">Autoriõigus <ph name="YEAR"/> Brave Software LLC. Kõik õigused on kaitstud.</translation>
+<translation id="1416550906796893042">Rakenduse versioon</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (värskendati <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operatsioonisüsteem</translation>
+<translation id="3968054912784331254">Selles Androidi versioonis ei toetata enam Brave'i värskendusi</translation>
+<translation id="7665369617277396874">Konto lisamine</translation>
+<translation id="649070405679044769">Brave Software'isse sisse logitud kasutajana</translation>
+<translation id="6234515504547364178">Brave'ist väljalogimine</translation>
+<translation id="5324858694974489420">Vanemlikud seaded</translation>
+<translation id="8920114477895755567">Vanema üksikasjade ootamine.</translation>
+<translation id="5512137114520586844">Seda kontot haldab <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Seda kontot haldavad <ph name="PARENT_NAME_1"/> ja <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Sisu</translation>
+<translation id="5403644198645076998">Luba ainult kindlad saidid</translation>
+<translation id="8641930654639604085">Proovi blokeerida täiskasvanutele mõeldud saidid</translation>
+<translation id="5639724618331995626">Luba kõik saidid</translation>
+<translation id="796823723482603597">Brave'i toega</translation>
+<translation id="6324034347079777476">Androidi süsteemi sünkroonimine on keelatud</translation>
+<translation id="5127805178023152808">Sünkroonimine on välja lülitatud</translation>
+<translation id="7015203776128479407">Sünkroonimise algseadistust ei viidud lõpule. Sünkroonimine on välja lülitatud.</translation>
+<translation id="2497852260688568942">Administraator on sünkroonimise keelanud</translation>
+<translation id="9100610230175265781">Parool on vajalik</translation>
+<translation id="6108923351542677676">Seadistamine on pooleli ...</translation>
+<translation id="4062305924942672200">Juriidiline teave</translation>
+<translation id="4256782883801055595">Avatud lähtekoodi litsentsid</translation>
+<translation id="1138681184697033370">Brave'i teenusetingimused</translation>
+<translation id="7392539049993970338">Brave'i privaatsusteatis</translation>
+<translation id="2677748264148917807">Lahku</translation>
+<translation id="5556459405103347317">Laadi uuesti</translation>
+<translation id="1623104350909869708">Keela sellel lehel lisadialoogide loomine</translation>
+<translation id="2968755619301702150">Sertifikaadikuvaja</translation>
+<translation id="1360432990279830238">Login välja ja keelan sünkroonimise?</translation>
+<translation id="8581481290581777242">Kas kustutada sellest seadmest Brave'i andmed?</translation>
+<translation id="1318865768845061710">Teie järjehoidjaid, ajalugu, paroole ja muid Brave'i andmeid ei sünkroonita enam teie Brave Software'i kontoga</translation>
+<translation id="3325020657155065477">Kustuta sellest seadmest ka Brave'i andmed</translation>
+<translation id="6136448902816743006">Kuna logite välja kontolt, mida haldab <ph name="DOMAIN_NAME"/>, kustutatakse sellest seadmest teie Brave'i andmed. Need jäävad alles teie Brave Software'i kontole.</translation>
+<translation id="1853026300647876496">Brave Software'iga ühenduse võtmine. See võib natuke aega võtta …</translation>
+<translation id="2328985652426384049">Ei saa sisse logida</translation>
+<translation id="7723158744459952869">Brave Software'il kulus reageerimiseks liiga kaua aega</translation>
+<translation id="4572422548854449519">Logige hallatud kontole sisse</translation>
+<translation id="2689656545739939160">Logite sisse kontoga, mida haldab <ph name="MANAGED_DOMAIN"/>, ja annate selle administraatorile üle Brave'i andmete juhtimise. Teie andmed seotakse jäädavalt selle kontoga. Brave'ist väljalogimisel kustutatakse teie andmed sellest seadmest, kuid need jäävad alles teie Brave Software'i kontole.</translation>
+<translation id="1749561566933687563">Järjehoidjate sünkroonimine</translation>
+<translation id="4242533952199664413">Ava seaded</translation>
+<translation id="1111673857033749125">Siin kuvatakse teie teistes seadmetes salvestatud järjehoidjad.</translation>
+<translation id="8636825310635137004">Vahelehtede hankimiseks oma teistest seadmetest lülitage sünkroonimine sisse.</translation>
+<translation id="3269956123044984603">Vahelehtede hankimiseks oma teistest seadmetest lülitage Androidi kontoseadetes sisse valik „Andmete automaatne sünkroonimine”.</translation>
+<translation id="5157964048453367290">Siin kuvatakse teie teistes seadmetes Brave'is avatud vahelehed.</translation>
+<translation id="4684427112815847243">Sünkrooni kõik</translation>
+<translation id="2709516037105925701">Automaatne täitmine</translation>
+<translation id="8820817407110198400">Järjehoidjad</translation>
+<translation id="1644574205037202324">Ajalugu</translation>
+<translation id="17513872634828108">Avatud vahelehed</translation>
+<translation id="1320169905922104972">Krediitkaardid ja aadressid, mis kasutavad teenust Brave Software Pay</translation>
+<translation id="6337234675334993532">Krüpteerimine</translation>
+<translation id="6698801883190606802">Sünkroonitud andmete haldamine</translation>
+<translation id="3598578758776312506">Paroolide krüpteerimine Brave Software'i mandaatidega</translation>
+<translation id="7810580217418711046">Krüpteeri sünkroonitud andmed Brave Software'i parooli abil <ph name="TIME"/> seisuga</translation>
+<translation id="8461694314515752532">Krüpteeri sünkroonitud andmed sünkroonimisparooliga</translation>
+<translation id="2996291259634659425">Parooli loomine</translation>
+<translation id="5713644099811900409">Brave Software'i konto</translation>
+<translation id="8997474919031554666">Parooli krüpteerimine ei hõlma Brave Software Pay makseviise ega aadresse. Teie krüpteeritud andmeid saavad lugeda vaid need, kes teavad teie parooli – seda ei saadeta Brave Software'ile ja Brave Software ei talleta seda. Kui unustate parooli või soovite seda seadet muuta, tuleb teil sünkroonimine lähtestada. <ph name="BEGIN_LINK"/>Lisateave<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Parool</translation>
+<translation id="7772032839648071052">Kinnitage parool</translation>
+<translation id="5304593522240415983">See väli ei tohi olla tühi</translation>
+<translation id="321773570071367578">Kui unustasite parooli või soovite seda seadet muuta, <ph name="BEGIN_LINK"/>lähtestage sünkroonimine<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Paroolid ei ühti</translation>
+<translation id="5149495116300586333">Parooli krüpteerimine ei hõlma Brave Software Pay makseviise ja aadresse.
+
+Seade muutmiseks <ph name="BEGIN_LINK"/>lähtestage sünkroonimine<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Vale parool</translation>
+<translation id="5414836363063783498">Kinnitamine ...</translation>
+<translation id="6846298663435243399">Laadimine …</translation>
+<translation id="5517095782334947753">Teil on järjehoidjad, ajalugu, paroolid ja muud seaded kontolt <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Minu andmete kombineerimine</translation>
+<translation id="688738109438487280">Lisab olemasolevad andmed kontole <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Hoia minu andmed eraldi</translation>
+<translation id="1145536944570833626">Kustutage olemasolevad andmed.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> soovib siduda</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Hankige abi<ph name="END_LINK"/>, kuni seadmeid otsitakse …</translation>
+<translation id="5817918615728894473">Seo</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Hankige abi<ph name="END_LINK1"/> või <ph name="BEGIN_LINK2"/>otsige uuesti<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Ühilduvaid seadmeid ei leitud</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Lülitage Bluetooth sisse<ph name="END_LINK"/>, et sidumine lubada</translation>
+<translation id="998321811308652668">Brave ei saa Bluetoothi adapterit sisse lülitada</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Küsige abi<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave vajab seadmete skannimiseks juurdepääsu teie asukohale. <ph name="BEGIN_LINK"/>Värskendage lube<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave vajab seadmete otsimiseks juurdepääsu teie asukohale. Juurdepääs asukohale on <ph name="BEGIN_LINK"/>selles seadmes välja lülitatud<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave vajab seadmete otsimiseks juurdepääsu teie asukohale. <ph name="BEGIN_LINK1"/>Värskendage lube<ph name="END_LINK1"/>. Juurdepääs asukohale on samuti <ph name="BEGIN_LINK2"/>selles seadmes välja lülitatud<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Ühendatud seade</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signaalitugevuse tase: # riba}other{Signaalitugevuse tase: # riba}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> soovib otsida läheduses olevaid Bluetooth-seadmeid. Leiti järgmised seadmed:</translation>
+<translation id="8368027906805972958">Tundmatu või toetamata seade (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sünkroonimine ei tööta</translation>
+<translation id="1810845389119482123">Sünkroonimise algseadistus ei jõudnud lõpule</translation>
+<translation id="3235722914093408050">Brave'i sünkroonimise alustamiseks avage Androidi seaded ja lubage uuesti Androidi süsteemi sünkroonimine</translation>
+<translation id="3367813778245106622">Sünkroonimise alustamiseks logige uuesti sisse</translation>
+<translation id="974555521953189084">Sünkroonimise alustamiseks sisestage parool</translation>
+<translation id="2997266899014181325">Sünkroonimise alustamiseks lülitage sisse valik „Brave'i andmete sünkroonimine”.</translation>
+<translation id="8260126382462817229">Proovige uuesti sisse logida</translation>
+<translation id="5919204609460789179">Sünkroonimise alustamiseks värskendage teenust <ph name="PRODUCT_NAME"/></translation>
+<translation id="397583555483684758">Sünkroonimine lakkas töötamast</translation>
+<translation id="1966710179511230534">Värskendage oma sisselogimisandmeid.</translation>
+<translation id="7063006564040364415">Sünkroonimisserveriga ei saanud ühendust.</translation>
+<translation id="7942131818088350342">Teenus <ph name="PRODUCT_NAME"/> on aegunud.</translation>
+<translation id="4170011742729630528">Teenus pole saadaval, proovige hiljem uuesti.</translation>
+<translation id="7947953824732555851">Nõustu ja logi sisse</translation>
+<translation id="8583805026567836021">Kontoandmete kustutamine</translation>
+<translation id="8310344678080805313">Tavapärased vahekaardid</translation>
+<translation id="5748802427693696783">Tavapärased vahelehed on aktiveeritud</translation>
+<translation id="7998918019931843664">Suletud vahelehe uuesti avamine</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, vahekaart</translation>
+<translation id="4452411734226507615">Vahelehe <ph name="TAB_TITLE"/> sulgemine</translation>
+<translation id="7243308994586599757">Valikud on saadaval ekraani allosas</translation>
+<translation id="4060598801229743805">Ekraani ülaosas saadaolevad valikud</translation>
+<translation id="2810645512293415242">Lihtsustatud leht andmemahu säästmiseks ja laadimise kiirendamiseks.</translation>
+<translation id="3985215325736559418">Kas soovite faili <ph name="FILE_NAME"/> uuesti alla laadida?</translation>
+<translation id="2450083983707403292">Kas soovite faili <ph name="FILE_NAME"/> allalaadimist uuesti alustada?</translation>
+<translation id="7514365320538308">Laadi alla</translation>
+<translation id="545042621069398927">Allalaadimise kiirendamine.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Faili allalaadimine.}other{# faili allalaadimine.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> faili allalaadimine (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Faili allalaadimine (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 allalaadimine on lõpule viidud.}other{# allalaadimist on lõpule viidud.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 allalaadimine ebaõnnestus.}other{# allalaadimist ebaõnnestus.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 allalaadimine on ootel.}other{# allalaadimist on ootel.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> – nupp <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Peaaegu valmis.</translation>
+<translation id="3960299545138990065">Taaskäivitage Brave</translation>
+<translation id="3771001275138982843">Värskendust ei saanud alla laadida</translation>
+<translation id="3888648114124182147">Brave'i värskenduse allalaadimine …</translation>
+<translation id="1705567146636171298">Värskenda Brave'i</translation>
+<translation id="6195417478702700398">Parima sirvimiskogemuse tagamiseks avage Brave, et seda värskendada</translation>
+<translation id="3512968675351418494">Hankige Brave'i uusim versioon, et saaksite oma keeles veebi sirvida</translation>
+<translation id="6427112570124116297">Veebi tõlkimine</translation>
+<translation id="1379423114029199501">Oma keele kasutamiseks värskendage Brave uusimale versioonile</translation>
+<translation id="5684874026226664614">Vabandust. Lehte ei õnnestunud tõlkida.</translation>
+<translation id="6831043979455480757">Tõlgi</translation>
+<translation id="1285320974508926690">Ära kunagi seda saiti tõlgi</translation>
+<translation id="773466115871691567">Tõlgi alati <ph name="SOURCE_LANGUAGE"/> keeles olevad lehed</translation>
+<translation id="1068672505746868501">Ära tõlgi kunagi <ph name="SOURCE_LANGUAGE"/> keeles olevaid lehti</translation>
+<translation id="124116460088058876">Rohkem keeli</translation>
+<translation id="290376772003165898">Kas leht ei ole <ph name="LANGUAGE"/> keeles?</translation>
+<translation id="4432792777822557199"><ph name="SOURCE_LANGUAGE"/> keeles olevad lehed tõlgitakse edaspidi <ph name="TARGET_LANGUAGE"/> keelde</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/> keeles olevaid lehti ei tõlgita</translation>
+<translation id="5447765697759493033">Seda saiti ei tõlgita</translation>
+<translation id="4880127995492972015">Tõlgi …</translation>
+<translation id="641643625718530986">Printimine ...</translation>
+<translation id="8909135823018751308">Jaga ...</translation>
+<translation id="4996978546172906250">Jagamine:</translation>
+<translation id="6333140779060797560">Jagamine rakenduse <ph name="APPLICATION"/> kaudu</translation>
+<translation id="6277522088822131679">Lehe printimisel ilmnes probleem. Proovige uuesti.</translation>
+<translation id="3254409185687681395">Lisa see lehekülg järjehoidjatesse</translation>
+<translation id="497421865427891073">Edasiminek</translation>
+<translation id="813082847718468539">Kuvab saidi teabe</translation>
+<translation id="2532336938189706096">Veebi kuva</translation>
+<translation id="6005538289190791541">Soovitatud parool</translation>
+<translation id="4634124774493850572">Kasuta parooli</translation>
+<translation id="8285489906452138776">Brave vajab selle saidi puhul luba, et teie kaamerale juurde pääseda.</translation>
+<translation id="320189792589364011">Brave vajab selle saidi puhul luba, et teie mikrofonile juurde pääseda.</translation>
+<translation id="7988136689212463100">Brave vajab selle saidi puhul luba, et teie kaamerale ja mikrofonile juurde pääseda.</translation>
+<translation id="4931190655840828017">Brave vajab juurdepääsu teie asukohale, et seda selle saidiga jagada.</translation>
+<translation id="3088191967551450609">Brave vajab failide allalaadimiseks juurdepääsu salvestusruumile.</translation>
+<translation id="8942627711005830162">Ava teises aknas</translation>
+<translation id="4195643157523330669">Ava uuel vahelehel</translation>
+<translation id="1100066534610197918">Ava rühmas uuel vahelehel</translation>
+<translation id="4860895144060829044">Helistage</translation>
+<translation id="6896758677409633944">Kopeeri</translation>
+<translation id="8393700583063109961">Saatke sõnum</translation>
+<translation id="3557336313807607643">Kontaktide lisamine</translation>
+<translation id="4269820728363426813">Kopeeri lingi aadress</translation>
+<translation id="1206892813135768548">Kopeeri lingi tekst</translation>
+<translation id="1204037785786432551">Allalaadimislink</translation>
+<translation id="6864459304226931083">Laadi kujutis alla</translation>
+<translation id="8209050860603202033">Ava kujutis</translation>
+<translation id="8073388330009372546">Ava pilt uuel vahelehel</translation>
+<translation id="6649642165559792194">Kujutise eelvaade <ph name="BEGIN_NEW"/>Uus<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Laadi kujutis</translation>
+<translation id="3845332215609790146">Otsi Brave Software Lensi abil <ph name="BEGIN_NEW"/>Uus<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Otsi otsingust <ph name="SEARCH_ENGINE"/> kujutist</translation>
+<translation id="3384347053049321195">Jaga kujutist</translation>
+<translation id="5833984609253377421">Jaga linki</translation>
+<translation id="6475951671322991020">Laadi video alla</translation>
+<translation id="2317945146070194624">Ava uuel Brave'i vahelehel</translation>
+<translation id="7975379999046275268">Lehe eelvaade <ph name="BEGIN_NEW"/>Uus<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Lehe värskendamine</translation>
+<translation id="36525718899759834">Hankige rakendus Brave Software Play poest: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tume</translation>
+<translation id="1807246157184219062">Hele</translation>
+<translation id="4056223980640387499">Seepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Püsisammkiri</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Valige kiirega edastatav vaheleht</translation>
+<translation id="8719023831149562936">Seda vahelehte ei saa kiirega edastada</translation>
+<translation id="2139186145475833000">Avaekraanile lisamine</translation>
+<translation id="4616150815774728855">Ava <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Rakendust ei õnnestunud avada</translation>
+<translation id="5129038482087801250">Veebirakenduse installimine</translation>
+<translation id="3789841737615482174">Installi</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> lisati teie avaekraanile</translation>
+<translation id="7333031090786104871">Eelmist saiti alles lisatakse</translation>
+<translation id="1036727731225946849">APK <ph name="WEBAPK_NAME"/> lisamine …</translation>
+<translation id="3778956594442850293">Lisatud avaekraanile</translation>
+<translation id="2146738493024040262">Ava installimata avatav rakendus</translation>
+<translation id="7016516562562142042">Praeguse otsingumootori puhul lubatud</translation>
+<translation id="6177111841848151710">Praeguse otsingumootori puhul blokeeritud</translation>
+<translation id="145097072038377568">Android-seadetes välja lülitatud</translation>
+<translation id="8007176423574883786">Selle seadme puhul on välja lülitatud</translation>
+<translation id="164269334534774161">Vaatate selle lehe võrguühenduseta koopiat kuupäevast <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Võrguühenduseta leht loodi <ph name="CREATION_TIME"/> ja see võib veebiversioonist erineda.</translation>
+<translation id="8840953339110955557">Leht võib veebiversioonist erineda.</translation>
+<translation id="6405300764336705484">See sisu pärineb domeenilt <ph name="DOMAIN_NAME"/> ja seda pakub Brave Software.</translation>
+<translation id="1006017844123154345">Ava veebis</translation>
+<translation id="3326636747541519688">Lihtsustatud lehte pakub Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Laadi originaalleht<ph name="END_LINK"/> domeenilt <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Kui näete seda sageli, proovige neid <ph name="BEGIN_LINK"/>soovitusi<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Sisu on peidetud</translation>
+<translation id="3810973564298564668">Halda</translation>
+<translation id="5199929503336119739">Tööprofiil</translation>
+<translation id="528192093759286357">Täisekraanilt väljumiseks lohistage ülaservast alla ja puudutage tagasinuppu.</translation>
+<translation id="2836148919159985482">Täisekraanilt väljumiseks puudutage tagasinuppu.</translation>
+<translation id="3967822245660637423">Allalaadimine on lõpule viidud</translation>
+<translation id="2434158240863470628">Allalaadimine jõudis lõpule: <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Allalaadimine ebaõnnestus</translation>
+<translation id="1384959399684842514">Allalaadimine peatatud</translation>
+<translation id="1671236975893690980">Allalaadimine on ootel …</translation>
+<translation id="5561549206367097665">Võrguühenduse ootamine …</translation>
+<translation id="5864419784173784555">Teise allalaadimise ootamine …</translation>
+<translation id="6461962085415701688">Faili ei saa avada</translation>
+<translation id="1178581264944972037">Peata</translation>
+<translation id="8200772114523450471">Taasta</translation>
+<translation id="1409879593029778104">Faili <ph name="FILE_NAME"/> ei laaditud alla, kuna fail on juba olemas.</translation>
+<translation id="3387650086002190359">Faili <ph name="FILE_NAME"/> allalaadimine ebaõnnestus failisüsteemi vigade tõttu.</translation>
+<translation id="6482749332252372425">Faili <ph name="FILE_NAME"/> allalaadimine ebaõnnestus, kuna salvestusruumi on liiga vähe.</translation>
+<translation id="7619072057915878432">Faili <ph name="FILE_NAME"/> allalaadimine ebaõnnestus võrguvea tõttu.</translation>
+<translation id="1477626028522505441">Faili <ph name="FILE_NAME"/> allalaadimine ebaõnnestus serveriprobleemide tõttu.</translation>
+<translation id="3692944402865947621">Faili <ph name="FILE_NAME"/> allalaadimine nurjus, kuna salvestuskoht ei ole saadaval.</translation>
+<translation id="604996488070107836">Faili <ph name="FILE_NAME"/> allalaadimine ebaõnnestus tundmatu vea tõttu.</translation>
+<translation id="6738867403308150051">Allalaadimine ...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Alla on laaditud <ph name="KBS"/> kB</translation>
+<translation id="6416782512398055893">Alla on laaditud <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Alla on laaditud <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Üks fail on jäänud</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> faili on jään.</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fail laaditi alla}other{<ph name="FILES_DOWNLOADED_MANY"/> faili laaditi alla}}</translation>
+<translation id="8037750541064988519">Jäänud on <ph name="DAYS"/> päeva</translation>
+<translation id="8190358571722158785">Jäänud on 1 päev</translation>
+<translation id="60923314841986378">Jäänud on <ph name="HOURS"/> tundi</translation>
+<translation id="510275257476243843">Jäänud on 1 tund</translation>
+<translation id="970715775301869095">Jäänud on <ph name="MINUTES"/> minutit</translation>
+<translation id="3236059992281584593">Jäänud on 1 minut</translation>
+<translation id="2777555524387840389">Jäänud on <ph name="SECONDS"/> sekundit</translation>
+<translation id="2781151931089541271">Jäänud on 1 sekund</translation>
+<translation id="3303414029551471755">Kas soovite jätkata sisu allalaadimist?</translation>
+<translation id="8617240290563765734">Kas avada allalaaditud sisus toodud soovitatud URL?</translation>
+<translation id="1373696734384179344">Valitud sisu allalaadimiseks pole piisavalt mäluruumi.</translation>
+<translation id="5271967389191913893">Seade ei saa allalaaditavat sisu avada.</translation>
+<translation id="883806473910249246">Sisu allalaadimisel ilmnes viga.</translation>
+<translation id="5626134646977739690">Nimi:</translation>
+<translation id="7963646190083259054">Teenusepakkuja:</translation>
+<translation id="3414952576877147120">Suurus:</translation>
+<translation id="7375125077091615385">Tüüp:</translation>
+<translation id="5765780083710877561">Kirjeldus:</translation>
+<translation id="4881695831933465202">Ava</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> kB on saadaval</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB on saadaval</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB saadaval</translation>
+<translation id="5793665092639000975">Kasutusel on <ph name="SPACE_USED"/> <ph name="SPACE_AVAILABLE"/>-st</translation>
+<translation id="3587482841069643663">Kõik</translation>
+<translation id="4988526792673242964">Leheküljed</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Heli</translation>
+<translation id="9219103736887031265">Pildid</translation>
+<translation id="8250920743982581267">Dokumendid</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fail}other{# faili}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# pilt}other{# pilti}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videot}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# helifail}other{# helifaili}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# leht}other{# lehte}}</translation>
+<translation id="5456381639095306749">Laadi leht alla</translation>
+<translation id="2394602618534698961">Allalaaditud failid kuvatakse siin</translation>
+<translation id="7810647596859435254">Ava rakendusega …</translation>
+<translation id="5655963694829536461">Otsige oma allalaadimiste hulgast</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Minu failid</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Artiklid kuvatakse siin ja saate neid lugeda ka võrguühenduseta</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
+<translation id="5853623416121554550">peatatud</translation>
+<translation id="8965591936373831584">ootel</translation>
+<translation id="2779651927720337254">ebaõnnestus</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Just praegu</translation>
+<translation id="4000212216660919741">Võrguühenduseta avaleht</translation>
+<translation id="9133397713400217035">Uurige võrguühenduseta</translation>
+<translation id="968900484120156207">Teie külastatud lehed kuvatakse siin</translation>
+<translation id="7882131421121961860">Ajalugu ei leitud</translation>
+<translation id="3549657413697417275">Otsige oma ajaloost</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">kk</translation>
+<translation id="605721222689873409">aa</translation>
+<translation id="724102042129299115">Brave'i esmakordse käitamise kasutuskogemus</translation>
+<translation id="2700285883409956633">Seda rakendust kasutades nõustute Brave'i <ph name="BEGIN_LINK1"/>teenusetingimuste<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>privaatsusteatisega<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Rakendust kasutades nõustute Brave’i <ph name="BEGIN_LINK1"/>teenusetingimuste<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>privaatsusteatisega<ph name="END_LINK2"/> ning <ph name="BEGIN_LINK3"/>Family Linkiga hallatavate Brave Software'i kontode privaatsusteatisega<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> avaneb Brave'is. Jätkates nõustute Brave'i <ph name="BEGIN_LINK1"/>teenusetingimuste<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>privaatsusteatised<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> avaneb Brave'is. Jätkates nõustute Brave'i <ph name="BEGIN_LINK1"/>teenusetingimuste<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>privaatsusteatisega<ph name="END_LINK2"/> ning <ph name="BEGIN_LINK3"/>Family Linkiga hallatavate Brave Software'i kontode privaatsusteatisega<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Aidake muuta Brave'i paremaks, saates Brave Software'ile kasutusstatistikat ja krahhiaruandeid.</translation>
+<translation id="3518985090088779359">Nõustu ja jätka</translation>
+<translation id="7207456302801184289">Tere tulemast Brave'i</translation>
+<translation id="704822250101715322">Brave Software Play teenuste värskendamise lõpetamise ootamine</translation>
+<translation id="1231733316453485619">Kas lülitada sünkroonimine sisse?</translation>
+<translation id="5132942445612118989">Teie paroolide, ajaloo ja muude andmete sünkroonimine kõigis seadmetes</translation>
+<translation id="5736731321935944068">Brave Software võib kasutada teie ajalugu otsingu, reklaamide ja muude Brave Software'i teenuste isikupärastamiseks</translation>
+<translation id="4013614219085422040">Brave Software võib kasutada teie ajalugu otsingu ja muude Brave Software'i teenuste isikupärastamiseks</translation>
+<translation id="5581519193887989363">Jaotises <ph name="BEGIN_LINK1"/>Seaded<ph name="END_LINK1"/> saate igal ajal valida, mida sünkroonida.</translation>
+<translation id="741204030948306876">Jah, sobib</translation>
+<translation id="2410754283952462441">Konto valimine</translation>
+<translation id="2227444325776770048">Jätka kasutajana <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Kas pole <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Järjehoidjate kõigisse oma seadmetesse hankimiseks lülitage sünkroonimine sisse</translation>
+<translation id="2818669890320396765">Järjehoidjate kõikidesse seadmetesse hankimiseks logige sisse ja lülitage sünkroonimine sisse</translation>
+<translation id="6003646045106347985">Brave Software'i soovitatud isikupärastatud sisu hankimiseks lülitage sünkroonimine sisse</translation>
+<translation id="8494430740943879273">Brave Software'i soovitatud isikupärastatud sisu hankimiseks logige sisse ja lülitage sünkroonimine sisse</translation>
+<translation id="5862731021271217234">Vahelehtede hankimiseks oma teistest seadmetest lülitage sünkroonimine sisse</translation>
+<translation id="3568688522516854065">Oma teistest seadmetest vahelehtede hankimiseks logige sisse ja lülitage sünkroonimine sisse</translation>
+<translation id="1208340532756947324">Seadmete vahel sünkroonimiseks ja isikupärastamiseks lülitage sünkroonimine sisse</translation>
+<translation id="4472118726404937099">Seadmete vahel sisu sünkroonimiseks ja isikupärastamiseks logige sisse ja lülitage sünkroonimine sisse.</translation>
+<translation id="2426805022920575512">Vali muu konto</translation>
+<translation id="6790428901817661496">Esita</translation>
+<translation id="1272079795634619415">Peata</translation>
+<translation id="2874939134665556319">Eelmine lugu</translation>
+<translation id="4046123991198612571">Järgmine lugu</translation>
+<translation id="3859306556332390985">Keri edasi</translation>
+<translation id="8441146129660941386">Keri tagasi</translation>
+<translation id="6706288973712894588">Te pole praegu võrguga ühendatud.\n<ph name="BEGIN_LINK"/>Uurige võrguühenduseta voogu.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Hiljutised vahelehed</translation>
+<translation id="8497726226069778601">Siin pole midagi vaadata ... veel</translation>
+<translation id="5423934151118863508">Teie enim külastatud lehed ilmuvad siin</translation>
+<translation id="6127379762771434464">Üksus eemaldati</translation>
+<translation id="4605958867780575332">Üksus on eemaldatud: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software'i Doodle'i vigurlogo: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Muud seadmed</translation>
+<translation id="4738836084190194332">Viimati sünkroonitud: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minut tagasi}other{# minutit tagasi}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# tund tagasi}other{# tundi tagasi}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# päev tagasi}other{# päeva tagasi}}</translation>
+<translation id="2762000892062317888">just praegu</translation>
+<translation id="1407135791313364759">Ava kõik</translation>
+<translation id="1209206284964581585">Peida praeguseks</translation>
+<translation id="129553762522093515">Viimati suletud</translation>
+<translation id="8413126021676339697">Kuva kogu ajalugu</translation>
+<translation id="7876243839304621966">Eemalda kõik</translation>
+<translation id="8487700953926739672">Võrguühenduseta saadaval</translation>
+<translation id="5224771365102442243">Videoga</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Lisateave<ph name="END_LINK"/> soovitatud sisu kohta</translation>
+<translation id="7542481630195938534">Soovitusi ei saa hankida</translation>
+<translation id="5013696553129441713">Uusi soovitusi pole</translation>
+<translation id="1736419249208073774">Avastage</translation>
+<translation id="7444811645081526538">Rohkem kategooriaid</translation>
+<translation id="6709133671862442373">Uudised</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Ostlemine</translation>
+<translation id="3912508018559818924">Otsitakse parimat, mida veebil on pakkuda …</translation>
+<translation id="526421993248218238">Seda lehte ei saa laadida</translation>
+<translation id="614940544461990577">Proovige järgmist.</translation>
+<translation id="3288003805934695103">Laadige leht uuesti</translation>
+<translation id="2353636109065292463">Interneti-ühenduse kontrollimine</translation>
+<translation id="2858138569776157458">Popid saidid</translation>
+<translation id="8364299278605033898">Vaadake populaarseid veebisaite</translation>
+<translation id="1171770572613082465">Vaadake populaarseid veebisaite, puudutades nuppu „Popid saidid”</translation>
+<translation id="5233638681132016545">Uus vaheleht</translation>
+<translation id="4521874409998847950">Avaldajalt <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>sisu pakub Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Saadaval on uuem versioon</translation>
+<translation id="4058091506841967397">Ei saa värskendada</translation>
+<translation id="6316139424528454185">Seda Androidi versiooni ei toetata</translation>
+<translation id="6989267951144302301">Ei saanud alla laadida</translation>
+<translation id="624789221780392884">Värskendus on valmis</translation>
+<translation id="1549000191223877751">Teisalda teise aknasse</translation>
+<translation id="7481312909269577407">Edasta</translation>
+<translation id="4084682180776658562">Järjehoidja</translation>
+<translation id="6437478888915024427">Lehe teave</translation>
+<translation id="7180611975245234373">Värskenda</translation>
+<translation id="4913169188695071480">Peata värskendamine</translation>
+<translation id="1829244130665387512">Otsi leheküljelt</translation>
+<translation id="6593061639179217415">Arvutisait</translation>
+<translation id="9063523880881406963">Valiku Taotle arvutisaiti väljalülitamine</translation>
+<translation id="2038563949887743358">Valiku Taotle arvutisaiti sisselülitamine</translation>
+<translation id="2433507940547922241">Välimus</translation>
+<translation id="983192555821071799">Sule kõik vahelehed</translation>
+<translation id="1310482092992808703">Vahelehtede grupeerimine</translation>
+<translation id="7725024127233776428">Järjehoidjatesse lisatud lehed kuvatakse siin</translation>
+<translation id="4404568932422911380">Järjehoidjaid pole</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> järjehoidja}other{<ph name="BOOKMARKS_COUNT_MANY"/> järjehoidjat}}</translation>
+<translation id="3739899004075612870">Teenuses <ph name="PRODUCT_NAME"/> järjehoidj. lisatud</translation>
+<translation id="3207960819495026254">Järjehoidjatesse lisatud</translation>
+<translation id="4452548195519783679">Lisatud järjehoidjana kausta <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Järjehoidja lisamine ebaõnnestus.</translation>
+<translation id="2842985007712546952">Emakaust</translation>
+<translation id="9065203028668620118">Muuda</translation>
+<translation id="4405224443901389797">Teisalda asukohta …</translation>
+<translation id="5170568018924773124">Kuva kaustas</translation>
+<translation id="8035133914807600019">Uus kaust …</translation>
+<translation id="4532845899244822526">Kausta valimine</translation>
+<translation id="6627583120233659107">Muuda kausta</translation>
+<translation id="1197267115302279827">Teisalda järjehoidjad</translation>
+<translation id="6963766334940102469">Kustuta järjehoidjad</translation>
+<translation id="4351244548802238354">Sule dialoog</translation>
+<translation id="451872707440238414">Otsi järjehoidjatest</translation>
+<translation id="8901170036886848654">Ei leitud ühtegi järjehoidjat</translation>
+<translation id="6404511346730675251">Muuda järjehoidjat</translation>
+<translation id="3894427358181296146">Kausta lisamine</translation>
+<translation id="5327248766486351172">Nimi</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Kaust</translation>
+<translation id="5161254044473106830">Pealkiri on kohustuslik</translation>
+<translation id="2996809686854298943">Vaja on URL-i</translation>
+<translation id="2536728043171574184">Kuvatakse on lehe võrguühenduseta koopia</translation>
+<translation id="4698034686595694889">Võrguühenduseta kuvamine rakenduses <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ja muud saidid</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave laadib teie lehe, kui see on valmis}other{Brave laadib teie lehed, kui need on valmis}}</translation>
+<translation id="6811034713472274749">Leht on vaatamiseks valmis</translation>
+<translation id="4561979708150884304">Ühendus puudub</translation>
+<translation id="8274165955039650276">Kuva allalaadimised</translation>
+<translation id="2082238445998314030">Tulemus <ph name="RESULT_NUMBER"/>/<ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Tulemusi pole</translation>
+<translation id="981121421437150478">Võrguühenduseta</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Lubatud häälotsing pole saadaval</translation>
+<translation id="7191430249889272776">Taustal on avatud vaheleht.</translation>
+<translation id="8445059357334030806">Ava Brave'is</translation>
+<translation id="4720023427747327413">Ava teenuses <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Avamine brauseris</translation>
+<translation id="1113597929977215864">Kuva lihtsustatud vaade</translation>
+<translation id="1513352483775369820">Järjehoidjad ja veebiajalugu</translation>
+<translation id="4939482511480190003">Aidake Brave'i täiustada. <ph name="BEGIN_LINK"/>Vastake küsitlusele<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Mine tagasi</translation>
+<translation id="5596627076506792578">Rohkem valikuid</translation>
+<translation id="3522247891732774234">Värskendus on saadaval. Rohkem valikuid</translation>
+<translation id="6773423637732432200">Brave'i ei saa värskendada. Rohkem valikuid</translation>
+<translation id="3328801116991980348">Saiditeave</translation>
+<translation id="5391532827096253100">Teie ühendus selle saidiga ei ole turvaline. Saidi teave</translation>
+<translation id="6206551242102657620">Ühendus on turvaline. Saidi teave</translation>
+<translation id="6963642900430330478">See leht on ohtlik. Saidi teave</translation>
+<translation id="9070377983101773829">Häälotsingu alustamine</translation>
+<translation id="8676374126336081632">Tühjenda sisestus</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> avatud vaheleht, puudutage vahelehtede vahetamiseks}other{<ph name="OPEN_TABS_MANY"/> avatud vahelehte, puudutage vahelehtede vahetamiseks}}</translation>
+<translation id="2369533728426058518">avatud vahelehed</translation>
+<translation id="7071521146534760487">Konto haldamine</translation>
+<translation id="932327136139879170">Kodu</translation>
+<translation id="2707726405694321444">Lehe värskendamine</translation>
+<translation id="2891154217021530873">Peata lehe laadimine</translation>
+<translation id="6710213216561001401">Eelmine</translation>
+<translation id="6659594942844771486">Vaheleht</translation>
+<translation id="1933845786846280168">Valitud vaheleht</translation>
+<translation id="2268044343513325586">Täpsustamine</translation>
+<translation id="7846076177841592234">Tühista valik</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> on valitud.  Valikud on saadaval ekraanikuva ülaosas</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> on valitud</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Jaga 1 valitud üksust}other{Jaga # valitud üksust}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Eemalda 1 valitud üksus}other{Eemalda # valitud üksust}}</translation>
+<translation id="1283039547216852943">Laiendamiseks puudutage</translation>
+<translation id="5962718611393537961">Ahendamiseks puudutage</translation>
+<translation id="8076492880354921740">Vahelehed</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 on valitud}other{# on valitud}}</translation>
+<translation id="6818926723028410516">Valige üksused</translation>
+<translation id="4797039098279997504">Puudutage vahelehele <ph name="URL_OF_THE_CURRENT_TAB"/> naasmiseks</translation>
+<translation id="6766758767654711248">Puudutage saidi külastamiseks</translation>
+<translation id="429312253194641664">Sait esitab meediasisu</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> jagab teie ekraani</translation>
+<translation id="8833831881926404480">Sait jagab teie ekraani</translation>
+<translation id="9086455579313502267">Ei saa võrgule juurdepääsu</translation>
+<translation id="938850635132480979">Viga: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Ava rakenduses <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Avage kaardirakenduses</translation>
+<translation id="7698359219371678927">Looge meil rakenduses <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Looge meil</translation>
+<translation id="5665379678064389456">Looge sündmus rakenduses <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Looge sündmus</translation>
+<translation id="2111511281910874386">Minge lehele</translation>
+<translation id="3988466920954086464">Vaadake kiirotsingu tulemusi sellel paneelil</translation>
+<translation id="2744248271121720757">Puudutage sõna, et kohe otsida või seotud toiminguid näha</translation>
+<translation id="9155898266292537608">Otsimiseks võite ka kiirelt sõna puudutada</translation>
+<translation id="3232754137068452469">Veebirakendus</translation>
+<translation id="1430915738399379752">Printimine</translation>
+<translation id="3775705724665058594">Saatmine teie seadmetesse</translation>
+<translation id="6364438453358674297">Kas eemaldada soovitus ajaloost?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> suleti</translation>
+<translation id="6850830437481525139">Suleti <ph name="TAB_COUNT"/> vahelehte</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> kustutati</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> järjehoidjat kustutati</translation>
+<translation id="3819178904835489326">Tuvastati <ph name="NUMBER_OF_DOWNLOADS"/> allalaadimist</translation>
+<translation id="1248710015876067820">Toetamata arv Brave'i eksemplare.</translation>
+<translation id="4259722352634471385">Navigeerimine on blokeeritud: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigeerimine ei ole saadaval: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Sule vaheleht</translation>
+<translation id="7772375229873196092">Sule <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Navigeerimise ajalugu</translation>
+<translation id="9169507124922466868">Navigeerimisajalugu on pooleldi avatud</translation>
+<translation id="1327257854815634930">Navigeerimisajalugu on avatud</translation>
+<translation id="8788265440806329501">Navigeerimisajalugu on suletud</translation>
+<translation id="7482656565088326534">Eelvaate vaheleht</translation>
+<translation id="8427875596167638501">Eelvaate vaheleht on pooleldi avatud</translation>
+<translation id="9102803872260866941">Eelvaate vaheleht on avatud</translation>
+<translation id="2942036813789421260">Eelvaate vaheleht on suletud</translation>
+<translation id="6355102470683871794">Rakenduse Brave Software <ph name="APP_NAME"/> salvestusruum</translation>
+<translation id="3822502789641063741">Kas tühj. saidi salvestusruum?</translation>
+<translation id="9205995714227143200">Saitide salvestusruum, mida Brave peab ebatähtsaks (nt saidid, mida külastate harva või millel ei ole salvestatud seadeid)</translation>
+<translation id="3997476611815694295">Ebatähtis salvestusruum</translation>
+<translation id="8493948351860045254">Vabasta ruum</translation>
+<translation id="2324920234469020158">See tühjendab vahemälu, kustutab küpsised ja muud andmed, mis pärinevad Brave'i arvates ebatähtsatelt saitidelt.</translation>
+<translation id="5447201525962359567">Saidi kogu salvestusruum, sh küpsised ja muud kohalikus seadmes talletatud andmed</translation>
+<translation id="1376578503827013741">Arvutamine …</translation>
+<translation id="583281660410589416">Tundmatu</translation>
+<translation id="2323763861024343754">Saidi salvestusruum</translation>
+<translation id="3587672679800759167">Brave'i kasutatav andmemaht kokku, sh kontod, järjehoidjad ja salvestatud seaded</translation>
+<translation id="6545017243486555795">Kustuta kõik andmed</translation>
+<translation id="4095146165863963773">Kas kustutada rakenduse andmed?</translation>
+<translation id="53119194224775367">Kõik Brave'i rakenduse andmed kustutatakse jäädavalt. See hõlmab kõiki faile, seadeid, kontosid, andmebaase jms.</translation>
+<translation id="5307446750509046227">Tühjenda salvestusruum</translation>
+<translation id="300526633675317032">See tühjendab veebisaidi salvestusruumi mahuga <ph name="SIZE_IN_KB"/>.</translation>
+<translation id="8068648041423924542">Sertifikaati ei saa valida.</translation>
+<translation id="2315043854645842844">Operatsioonisüsteem ei toeta kliendipoolset sertifikaadi valimist.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> soovib ühenduse luua</translation>
+<translation id="5308380583665731573">Ühendamine</translation>
+<translation id="868929229000858085">Otsige kontaktide hulgast</translation>
+<translation id="1919950603503897840">Kontaktide valimine</translation>
+<translation id="7986741934819883144">Kontakti valimine</translation>
+<translation id="3333961966071413176">Kõik kontaktid</translation>
+<translation id="4994033804516042629">Kontakte ei leitud</translation>
+<translation id="5403592356182871684">Nimed</translation>
+<translation id="2717722538473713889">E-posti aadressid</translation>
+<translation id="381841723434055211">Telefoninumbrid</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(ja veel 1)}other{(ja veel #)}}</translation>
+<translation id="5197729504361054390">Teie valitud kontakte jagatakse saidiga <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Pildi dekooder</translation>
+<translation id="8067883171444229417">Esita video</translation>
+<translation id="6560414384669816528">Otsi teenusega Sogou</translation>
+<translation id="5406914950576900927">Brave saab Hiinas otsimiseks kasutada teenust <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>. Seda saate muuta menüüs <ph name="BEGIN_LINK"/>Seaded<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Säilita Brave Software</translation>
+<translation id="4384468725000734951">Otsimiseks kasutatakse teenust Sogou</translation>
+<translation id="6103327872225198548">Otsimiseks kasutatakse Brave Software'it</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Rakendus töötab Brave'is</translation>
+<translation id="6143689084714664628">Töötab Brave'is</translation>
+<translation id="7675869148432102528">Rakendusel <ph name="APP_NAME"/> on samuti Brave’i andmeid</translation>
+<translation id="2734140769649165081">Andmeid saab kustutada Brave’i seadetes.</translation>
+<translation id="8232956427053453090">Säilita andmed</translation>
+<translation id="4298388696830689168">Lingitud saidid</translation>
+<translation id="5763514718066511291">Puudutage URL-i kopeerimiseks selle rakenduse jaoks</translation>
+<translation id="6496823230996795692">Rakenduse <ph name="APP_NAME"/> esmakordseks kasutamiseks looge ühendus Internetiga.</translation>
+<translation id="751961395872307827">Saidiga ei saa ühendust luua</translation>
+<translation id="4878404682131129617">Puhverserveri kaudu tunneli loomine ebaõnnestus</translation>
+<translation id="4749960740855309258">Uue vahelehe avamine</translation>
+<translation id="8788968922598763114">Viimati suletud vahelehe uuesti avamine</translation>
+<translation id="7929962904089429003">Menüü avamine</translation>
+<translation id="6039379616847168523">Järgmisele vahelehele liikumine</translation>
+<translation id="5210286577605176222">Eelmisele vahelehele liikumine</translation>
+<translation id="124678866338384709">Aktiivse vahelehe sulgemine</translation>
+<translation id="3714981814255182093">Leiuriba avamine</translation>
+<translation id="5441522332038954058">Aadressiribale liikumine</translation>
+<translation id="3398320232533725830">Järjehoidjate halduri avamine</translation>
+<translation id="6583199322650523874">Praeguse lehe lisamine järjehoidjatesse</translation>
+<translation id="8489271220582375723">Lehe Ajalugu avamine</translation>
+<translation id="4837753911714442426">Valikute avamine lehe printimiseks</translation>
+<translation id="5726692708398506830">Lehel kuvatud sisu suurendamine</translation>
+<translation id="3259831549858767975">Lehel kuvatud sisu vähendamine</translation>
+<translation id="8015452622527143194">Lehel kuvatud sisu vaikesuuruses kuvamine</translation>
+<translation id="3443221991560634068">Praeguse lehe uuesti laadimine</translation>
+<translation id="123724288017357924">Praeguse lehe uuesti laadimine, eirates vahemälus olevat sisu</translation>
+<translation id="305870044889644984">Brave'i abikeskuse avamine uuel vahelehel</translation>
+<translation id="3166827708714933426">Vahelehe ja akna otseteed</translation>
+<translation id="3169981355900570544">Brave Software Brave'i funktsioonide otseteed</translation>
+<translation id="4558311620361989323">Veebilehe otseteed</translation>
+<translation id="1908301351964700579">Brave teeb VR-i kasutamiseks endiselt ettevalmistusi. Taaskäivitage Brave hiljem.</translation>
+<translation id="8970887620466824814">Midagi läks valesti.</translation>
+<translation id="1875543012935658554">Avage Brave uuesti.</translation>
+<translation id="79859296434321399">Liitreaalsuse sisu vaatamiseks installige ARCore</translation>
+<translation id="8558485628462305855">Liitreaalsuse sisu vaatamiseks värskendage ARCore'i</translation>
+<translation id="3513704683820682405">Liitreaalsus</translation>
+<translation id="5475862044948910901">Kas alustada liitreaalsuse seanssi?</translation>
 <translation id="7365126855094612066">Selle seansi ajal saab sait teha järgmist.
 • Luua teie keskkonnast 3D-kaardi
 • Jälgida kaamera liikumist
 
 Sait EI saa juurdepääsu kaamerale. Kaamera jäädvustatud pildid on nähtavad ainult teile.</translation>
-<translation id="7375125077091615385">Tüüp:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome'i esmakordse käitamise kasutuskogemus</translation>
-<translation id="741204030948306876">Jah, sobib</translation>
-<translation id="7413229368719586778">Alguskuupäev: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Esmalt küsib</translation>
-<translation id="7423538860840206698">Lõikelaua lugemine on blokeeritud</translation>
-<translation id="7431991332293347422">Juhtige, kuidas kasutatakse teie sirvimisajalugu otsingu ja muu isikupärastamiseks</translation>
-<translation id="7437998757836447326">Chrome'ist väljalogimine</translation>
-<translation id="7438641746574390233">Kui lihtsustatud režiim on sees, kasutab Chrome Google'i servereid, et lehtede laadimist kiirendada. Lihtsustatud režiim kirjutab väga aeglased lehed ümber, et laadida ainult oluline sisu. Lihtsustatud režiimi ei saa kasutada inkognito režiimis vahelehtedel.</translation>
-<translation id="7444811645081526538">Rohkem kategooriaid</translation>
-<translation id="7445411102860286510">Luba saitidel vaigistatud videoid automaatselt esitada (soovitatav)</translation>
-<translation id="7453467225369441013">Logib teid enamikult saitidelt välja. Google'i kontolt teid välja ei logita.</translation>
-<translation id="7454641608352164238">Pole piisavalt ruumi</translation>
-<translation id="7475192538862203634">Kui näete seda sageli, proovige neid <ph name="BEGIN_LINK" />soovitusi<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD-kaarti ei leitud. Mõned failid võivad puududa.</translation>
-<translation id="7479104141328977413">Vahelehtede haldamine</translation>
-<translation id="7481312909269577407">Edasta</translation>
-<translation id="7482656565088326534">Eelvaate vaheleht</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (värskendati <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">säästetud andmemaht</translation>
-<translation id="7498271377022651285">Oodake ...</translation>
-<translation id="7514365320538308">Laadi alla</translation>
-<translation id="751961395872307827">Saidiga ei saa ühendust luua</translation>
-<translation id="7521387064766892559">Javascript</translation>
-<translation id="7542481630195938534">Soovitusi ei saa hankida</translation>
-<translation id="7559975015014302720">Lihtsustatud režiim on väljas</translation>
-<translation id="7562080006725997899">Sirvimisandmete kustutamine</translation>
-<translation id="756809126120519699">Chrome'i andmed kustutati</translation>
-<translation id="757524316907819857">Saitidel kaitstud sisu esitamise blokeerimine</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fail laaditi alla}other{<ph name="FILES_DOWNLOADED_MANY" /> faili laaditi alla}}</translation>
-<translation id="7588219262685291874">Aktiveeri tume teema, kui akusäästja on seadmes sisse lülitatud</translation>
-<translation id="7589445247086920869">Blokeerib praeguse otsingumootori puhul</translation>
-<translation id="7593557518625677601">Chrome'i sünkroonimise alustamiseks avage Androidi seaded ja lubage uuesti Androidi süsteemi sünkroonimine</translation>
-<translation id="7596558890252710462">Operatsioonisüsteem</translation>
-<translation id="7605594153474022051">Sünkroonimine ei tööta</translation>
-<translation id="7606077192958116810">Lihtsustatud režiim on sees. Hallake seda menüüs Seaded.</translation>
-<translation id="7612619742409846846">Google'isse sisse logitud kasutajana</translation>
-<translation id="7619072057915878432">Faili <ph name="FILE_NAME" /> allalaadimine ebaõnnestus võrguvea tõttu.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Hankige abi<ph name="END_LINK1" /> või <ph name="BEGIN_LINK2" />otsige uuesti<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Tere tulemast Chrome'i</translation>
-<translation id="7638584964844754484">Vale parool</translation>
-<translation id="7641339528570811325">Sirvimisandmete kustutamine …</translation>
-<translation id="7648422057306047504">Paroolide krüpteerimine Google'i mandaatidega</translation>
-<translation id="7649070708921625228">Abi</translation>
-<translation id="7658239707568436148">Tühista</translation>
-<translation id="7665369617277396874">Konto lisamine</translation>
-<translation id="766587987807204883">Artiklid kuvatakse siin ja saate neid lugeda ka võrguühenduseta</translation>
-<translation id="7682724950699840886">Järgige neid nõuandeid: veenduge, et seadmes oleks piisavalt ruumi, seejärel proovige uuesti eksportida.</translation>
-<translation id="7685301384041462804">Enne VR-i aktiveerimist veenduge, et sait oleks usaldusväärne.</translation>
-<translation id="7698359219371678927">Looge meil rakenduses <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Otsingute ja URL-ide automaatne täitmine</translation>
-<translation id="7725024127233776428">Järjehoidjatesse lisatud lehed kuvatakse siin</translation>
-<translation id="773466115871691567">Tõlgi alati <ph name="SOURCE_LANGUAGE" /> keeles olevad lehed</translation>
-<translation id="7746457520633464754">Ohtlike rakenduste ja saitide tuvastamiseks saadab Chrome mõnede teie külastatud lehtede URL-id, piiratud süsteemiteabe ja mõne lehe sisu Google'ile</translation>
-<translation id="7757787379047923882">Teksti jagati seadmest <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-kaart <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Lisage aadress</translation>
-<translation id="7772032839648071052">Kinnitage parool</translation>
-<translation id="7772375229873196092">Sule <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ja veel <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Eile</translation>
-<translation id="7791543448312431591">Lisa</translation>
-<translation id="780301667611848630">Ei, aitäh</translation>
-<translation id="7810647596859435254">Ava rakendusega …</translation>
-<translation id="7821588508402923572">Siin kuvatakse teie säästetud andmemaht</translation>
-<translation id="7837721118676387834">Lubage vaigistatud videote automaatne esitamine konkreetsel saidil.</translation>
-<translation id="7846076177841592234">Tühista valik</translation>
-<translation id="784934925303690534">Ajavahemik</translation>
-<translation id="7851858861565204677">Muud seadmed</translation>
-<translation id="7875915731392087153">Looge meil</translation>
-<translation id="7876243839304621966">Eemalda kõik</translation>
-<translation id="7882131421121961860">Ajalugu ei leitud</translation>
-<translation id="7882806643839505685">Konkreetse saidi heli lubamine.</translation>
-<translation id="7886917304091689118">Töötab Chrome'is</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Faili allalaadimine.}other{# faili allalaadimine.}}</translation>
-<translation id="7929962904089429003">Menüü avamine</translation>
-<translation id="7942131818088350342">Teenus <ph name="PRODUCT_NAME" /> on aegunud.</translation>
-<translation id="7947953824732555851">Nõustu ja logi sisse</translation>
-<translation id="7963646190083259054">Teenusepakkuja:</translation>
-<translation id="7971136598759319605">Aktiivne 1 päev tagasi</translation>
-<translation id="7975379999046275268">Lehe eelvaade <ph name="BEGIN_NEW" />Uus<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Eellaaditakse lehti kiiremaks sirvimiseks ja otsimiseks</translation>
-<translation id="79859296434321399">Liitreaalsuse sisu vaatamiseks installige ARCore</translation>
-<translation id="7986741934819883144">Kontakti valimine</translation>
-<translation id="7987073022710626672">Chrome'i teenusetingimused</translation>
-<translation id="7998918019931843664">Suletud vahelehe uuesti avamine</translation>
-<translation id="7999064672810608036">Kas soovite kindlasti kustutada kõik kohalikud andmed (sh küpsised) ja lähtestada kõik selle veebisaidi load?</translation>
-<translation id="8004582292198964060">Brauser</translation>
-<translation id="8007176423574883786">Selle seadme puhul on välja lülitatud</translation>
-<translation id="8013372441983637696">Kustuta sellest seadmest ka Chrome'i andmed</translation>
-<translation id="8015452622527143194">Lehel kuvatud sisu vaikesuuruses kuvamine</translation>
-<translation id="802154636333426148">Allalaadimine ebaõnnestus</translation>
-<translation id="8026334261755873520">Sirvimisandmete kustutamine</translation>
-<translation id="8035133914807600019">Uus kaust …</translation>
-<translation id="8037750541064988519">Jäänud on <ph name="DAYS" /> päeva</translation>
-<translation id="804335162455518893">SD-kaarti ei leitud</translation>
-<translation id="805047784848435650">Teie sirvimisajaloo põhjal</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB on saadaval</translation>
-<translation id="8058746566562539958">Ava uuel Chrome'i vahelehel</translation>
-<translation id="8063895661287329888">Järjehoidja lisamine ebaõnnestus.</translation>
-<translation id="806745655614357130">Hoia minu andmed eraldi</translation>
-<translation id="8067883171444229417">Esita video</translation>
-<translation id="8068648041423924542">Sertifikaati ei saa valida.</translation>
-<translation id="8073388330009372546">Ava pilt uuel vahelehel</translation>
-<translation id="8076492880354921740">Vahelehed</translation>
-<translation id="8084114998886531721">Salvestatud parool</translation>
-<translation id="8087000398470557479">See sisu pärineb domeenilt <ph name="DOMAIN_NAME" /> ja seda pakub Google.</translation>
-<translation id="8103578431304235997">Inkognito vaheleht</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Järjehoidjate kõigisse oma seadmetesse hankimiseks lülitage sünkroonimine sisse</translation>
-<translation id="8110087112193408731">Kas kuvada teie Chrome'i tegevused teenuses Digitaalne heaolu?</translation>
-<translation id="8116925261070264013">Vaigistatud</translation>
-<translation id="813082847718468539">Kuvab saidi teabe</translation>
-<translation id="8131740175452115882">Kinnita</translation>
-<translation id="8156139159503939589">Millistes keeltes te loete?</translation>
-<translation id="8168435359814927499">Sisu</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> faili on jään.</translation>
-<translation id="8190358571722158785">Jäänud on 1 päev</translation>
-<translation id="8200772114523450471">Taasta</translation>
-<translation id="8209050860603202033">Ava kujutis</translation>
-<translation id="8218622182176210845">Konto haldamine</translation>
-<translation id="8224471946457685718">Teile soovitatud artiklite allalaadimine WiFi-ühendusega</translation>
-<translation id="8232956427053453090">Säilita andmed</translation>
-<translation id="8249310407154411074">Teisalda kõige üles</translation>
-<translation id="8250920743982581267">Dokumendid</translation>
-<translation id="825412236959742607">Chrome eemaldas osa sisust, kuna leht kasutab liiga palju mälu.</translation>
-<translation id="8260126382462817229">Proovige uuesti sisse logida</translation>
-<translation id="8261506727792406068">Kustuta</translation>
-<translation id="8266862848225348053">Allalaadimise asukoht</translation>
-<translation id="8274165955039650276">Kuva allalaadimised</translation>
-<translation id="8284326494547611709">Subtiitrid</translation>
-<translation id="8300705686683892304">Neid haldab rakendus</translation>
-<translation id="8310344678080805313">Tavapärased vahekaardid</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ja muud saidid</translation>
-<translation id="8327155640814342956">Parima sirvimiskogemuse tagamiseks avage Chrome, et seda värskendada</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" /> keeles olevaid lehti ei tõlgita</translation>
-<translation id="8349013245300336738">Sordi kasutatud andmemahu alusel</translation>
-<translation id="8364299278605033898">Vaadake populaarseid veebisaite</translation>
-<translation id="8368027906805972958">Tundmatu või toetamata seade (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Konkreetse saidi jaoks taustal sünkroonimise lubamine.</translation>
-<translation id="8378714024927312812">Haldab teie organisatsioon</translation>
-<translation id="8380167699614421159">Sait kuvab sekkuvaid või eksitavaid reklaame.</translation>
-<translation id="8393700583063109961">Saatke sõnum</translation>
-<translation id="8413126021676339697">Kuva kogu ajalugu</translation>
-<translation id="8427875596167638501">Eelvaate vaheleht on pooleldi avatud</translation>
-<translation id="8428213095426709021">Seaded</translation>
-<translation id="8438566539970814960">Otsingute ja sirvimise paremaks muutmine</translation>
-<translation id="8441146129660941386">Keri tagasi</translation>
-<translation id="8443209985646068659">Ei saa värskendada</translation>
-<translation id="8445448999790540984">Paroole ei saa eksportida</translation>
-<translation id="8447861592752582886">Seadme loa tühistamine</translation>
-<translation id="8461694314515752532">Krüpteeri sünkroonitud andmed sünkroonimisparooliga</translation>
-<translation id="8466613982764129868">Veenduge, et seadmel <ph name="TARGET_DEVICE_NAME" /> oleks internetiühendus</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Võrguühenduseta saadaval</translation>
-<translation id="8489271220582375723">Lehe Ajalugu avamine</translation>
-<translation id="8493948351860045254">Vabasta ruum</translation>
-<translation id="8497726226069778601">Siin pole midagi vaadata ... veel</translation>
-<translation id="8503559462189395349">Chrome'i paroolid</translation>
-<translation id="8503813439785031346">Kasutajanimi</translation>
-<translation id="8514477925623180633">Chrome'i salvestatud paroolide eksportimine</translation>
-<translation id="8514577642972634246">Inkognito režiimi sisenemine</translation>
-<translation id="851751545965956758">Blokeeri saitidel seadmetega ühenduse loomine</translation>
-<translation id="8523928698583292556">Salvestatud parooli kustutamine</translation>
-<translation id="854522910157234410">Ava leht</translation>
-<translation id="8558485628462305855">Liitreaalsuse sisu vaatamiseks värskendage ARCore'i</translation>
-<translation id="8559990750235505898">Paku muudes keeltes olevate lehtede tõlkimist</translation>
-<translation id="8562452229998620586">Salvestatud paroolid ilmuvad siin.</translation>
-<translation id="8569404424186215731">alates kuupäevast <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Viimased 4 nädalat</translation>
-<translation id="857943718398505171">Lubatud (soovitatav)</translation>
-<translation id="8583805026567836021">Kontoandmete kustutamine</translation>
-<translation id="860043288473659153">Kaardiomaniku nimi</translation>
-<translation id="8609465669617005112">Liiguta üles</translation>
-<translation id="8616006591992756292">Aadressil <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> võib teie Google'i kontol olla muus vormis sirvimisajalugu.</translation>
-<translation id="8617240290563765734">Kas avada allalaaditud sisus toodud soovitatud URL?</translation>
-<translation id="8636825310635137004">Vahelehtede hankimiseks oma teistest seadmetest lülitage sünkroonimine sisse.</translation>
-<translation id="8641930654639604085">Proovi blokeerida täiskasvanutele mõeldud saidid</translation>
-<translation id="8655129584991699539">Andmeid saab kustutada Chrome’i seadetes.</translation>
-<translation id="8662811608048051533">Logib teid enamikult saitidelt välja.</translation>
-<translation id="8664979001105139458">Faili nimi on juba olemas</translation>
-<translation id="8676374126336081632">Tühjenda sisestus</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signaalitugevuse tase: # riba}other{Signaalitugevuse tase: # riba}}</translation>
-<translation id="868929229000858085">Otsige kontaktide hulgast</translation>
-<translation id="869891660844655955">Aegumiskuupäev</translation>
-<translation id="8719023831149562936">Seda vahelehte ei saa kiirega edastada</translation>
-<translation id="8725066075913043281">Proovi uuesti</translation>
-<translation id="8728487861892616501">Rakendust kasutades nõustute Chrome’i <ph name="BEGIN_LINK1" />teenusetingimuste<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />privaatsusteatisega<ph name="END_LINK2" /> ning <ph name="BEGIN_LINK3" />Family Linkiga hallatavate Google'i kontode privaatsusteatisega<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Valmis</translation>
-<translation id="8748850008226585750">Sisu on peidetud</translation>
-<translation id="8751914237388039244">Kujutise valimine</translation>
-<translation id="8788265440806329501">Navigeerimisajalugu on suletud</translation>
-<translation id="8788968922598763114">Viimati suletud vahelehe uuesti avamine</translation>
-<translation id="8801436777607969138">JavaScripti blokeerimine konkreetsel saidil.</translation>
-<translation id="8812260976093120287">Mõnel veebisaidil saate maksta ülalolevate teie seadmes toetatud makserakendustega.</translation>
-<translation id="8816026460808729765">Blokeeri saitide jaoks juurdepääs anduritele</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> avaneb Chrome'is. Jätkates nõustute Chrome'i <ph name="BEGIN_LINK1" />teenusetingimuste<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />privaatsusteatisega<ph name="END_LINK2" /> ning <ph name="BEGIN_LINK3" />Family Linkiga hallatavate Google'i kontode privaatsusteatisega<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Järjehoidjad</translation>
-<translation id="8833831881926404480">Sait jagab teie ekraani</translation>
-<translation id="883806473910249246">Sisu allalaadimisel ilmnes viga.</translation>
-<translation id="8840953339110955557">Leht võib veebiversioonist erineda.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, vahekaart</translation>
-<translation id="885701979325669005">Salvestamine</translation>
-<translation id="889338405075704026">Ava Chrome'i seaded</translation>
-<translation id="8901170036886848654">Ei leitud ühtegi järjehoidjat</translation>
-<translation id="8909135823018751308">Jaga ...</translation>
-<translation id="8912362522468806198">Google'i konto</translation>
-<translation id="8920114477895755567">Vanema üksikasjade ootamine.</translation>
+<translation id="1188239144602654184">Sisene AR-i</translation>
+<translation id="473775607612524610">Värskenda</translation>
+<translation id="3133489217401741157">Brave'i jaoks installitakse moodulit <ph name="MODULE"/> …</translation>
+<translation id="1791662854739702043">Installitud</translation>
+<translation id="5131234170665854056">Moodulit <ph name="MODULE"/> ei saa Brave'i jaoks installida</translation>
+<translation id="2567385386134582609">KUJUTIS</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Laadige lehed alla, et neid võrguühenduseta kasutada</translation>
 <translation id="8922289737868596582">Laadige lehed alla nupu Rohkem valikuid abil, et neid võrguühenduseta kasutada</translation>
-<translation id="8937772741022875483">Kas eemaldada teie Chrome'i tegevused teenusest Digitaalne heaolu?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Ava teises aknas</translation>
-<translation id="8951232171465285730">Chrome aitas teil säästa <ph name="MEGABYTES" /> MB andmemahtu</translation>
-<translation id="8958424370300090006">Blokeerige konkreetse saidi küpsisefailid.</translation>
-<translation id="8959122750345127698">Navigeerimine ei ole saadaval: <ph name="URL" /></translation>
-<translation id="8965591936373831584">ootel</translation>
-<translation id="8970887620466824814">Midagi läks valesti.</translation>
-<translation id="8972098258593396643">Kas soovite alla laadida vaikekausta?</translation>
-<translation id="8986494364107987395">Saada kasutusstatistika ja krahhiaruanded automaatselt Google'ile</translation>
-<translation id="8993760627012879038">Uue vahelehe avamine inkognito režiimis</translation>
-<translation id="8998729206196772491">Logite sisse kontoga, mida haldab <ph name="MANAGED_DOMAIN" />, ja annate selle administraatorile üle Chrome'i andmete juhtimise. Teie andmed seotakse jäädavalt selle kontoga. Chrome'ist väljalogimisel kustutatakse teie andmed sellest seadmest, kuid need jäävad alles teie Google'i kontole.</translation>
-<translation id="9019902583201351841">Vanemate hallatud</translation>
-<translation id="9028914725102941583">Seadmete vahel jagamiseks lülitage sünkroonimine sisse</translation>
-<translation id="9029323097866369874">Kas lubate saidil <ph name="DOMAIN" /> VR-i aktiveerida?</translation>
-<translation id="9040142327097499898">Märguanded on lubatud. Asukoht on selle seadme puhul välja lülitatud.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videot}}</translation>
-<translation id="9050666287014529139">Parool</translation>
-<translation id="9063523880881406963">Valiku Taotle arvutisaiti väljalülitamine</translation>
-<translation id="9065203028668620118">Muuda</translation>
-<translation id="9070377983101773829">Häälotsingu alustamine</translation>
-<translation id="9074336505530349563">Google'i soovitatud isikupärastatud sisu hankimiseks logige sisse ja lülitage sünkroonimine sisse</translation>
-<translation id="9086455579313502267">Ei saa võrgule juurdepääsu</translation>
-<translation id="9100505651305367705">Pakutakse artiklite kuvamist lihtsustatud vaates, kui seda toetatakse</translation>
-<translation id="9100610230175265781">Parool on vajalik</translation>
-<translation id="9102803872260866941">Eelvaate vaheleht on avatud</translation>
+<translation id="5958275228015807058">Leidke oma failid ja lehed jaotisest Allalaadimised</translation>
+<translation id="5620928963363755975">Leidke oma failid ja lehed jaotisest Allalaadimised, kasutades nuppu Rohkem valikuid</translation>
+<translation id="3341058695485821946">Vaadake, kui palju andmemahtu olete säästnud</translation>
+<translation id="3157842584138209013">Nupu Rohkem valikuid abil saate vaadata, kui palju andmemahtu olete säästnud</translation>
+<translation id="8218622182176210845">Konto haldamine</translation>
+<translation id="8090895580117672212">Oma Brave Software'i konto haldamiseks puudutage nuppu „Konto haldamine”</translation>
+<translation id="8856898588039823173">Lihtsustatud lehte pakub Brave Software. Puudutage algse lehe laadimiseks.</translation>
+<translation id="8134317863207426198">Lihtsustatud lehte pakub Brave Software. Algse lehe laadimiseks puudutage nuppu Laadi algne.</translation>
+<translation id="4961107849584082341">Tõlkige leht mis tahes keelde</translation>
+<translation id="569536719314091526">Tõlkige leht mis tahes keelde nupuga Rohkem valikuid</translation>
+<translation id="1397811292916898096">Otsi teenusega <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Allalaadimise vaikeasukohta saab alati muuta</translation>
+<translation id="6942665639005891494">Allalaadimise vaikeasukohta saab menüü Seaded valikuga alati muuta</translation>
+<translation id="6850409657436465440">Allalaadimine on endiselt pooleli</translation>
+<translation id="5817715962196959877">Brave laadib nüüd faile kiiremini alla</translation>
+<translation id="3976396876660209797">Eemaldage see otsetee ja looge see uuesti</translation>
+<translation id="6766622839693428701">Sulgemiseks pühkige alla.</translation>
+<translation id="1028699632127661925">Saatmine seadmesse <ph name="DEVICE_NAME"/> …</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – saadetud seadmest <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Vaheleht võeti vastu</translation>
 <translation id="9104217018994036254">Vahelehe jagamise seadmete loend.</translation>
-<translation id="9133397713400217035">Uurige võrguühenduseta</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Kuva originaal</translation>
-<translation id="9139068048179869749">Küsi enne saitidele märguannete saatmise lubamist (soovitatav)</translation>
-<translation id="9139318394846604261">Ostlemine</translation>
-<translation id="9155898266292537608">Otsimiseks võite ka kiirelt sõna puudutada</translation>
-<translation id="9169507124922466868">Navigeerimisajalugu on pooleldi avatud</translation>
-<translation id="9204836675896933765">Üks fail on jäänud</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Vahelehe jagamise seadmete loend (poolel kõrgusel avatud).</translation>
+<translation id="2904414404539560095">Vahelehe jagamise seadmete loend (täiskõrgusel avatud).</translation>
+<translation id="4135200667068010335">Vahelehe jagamise seadmete loend on suletud.</translation>
+<translation id="5292796745632149097">Saatmine</translation>
+<translation id="1386674309198842382">Aktiivne <ph name="LAST_UPDATED"/> päeva tagasi</translation>
+<translation id="7971136598759319605">Aktiivne 1 päev tagasi</translation>
+<translation id="1521774566618522728">Aktiivne täna</translation>
+<translation id="3631987586758005671">Jagamine seadmega <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Seadmete vahel jagamiseks lülitage sünkroonimine sisse</translation>
+<translation id="6162454065885854378">Kui soovite midagi oma telefonist teise seadmega jagada, lülitage sünkroonimine mõlema seadme Brave'i seadetes sisse</translation>
+<translation id="6084271560289605378">Ava Brave'i seaded</translation>
+<translation id="2318045970523081853">Puudutage helistamiseks</translation>
 <translation id="9209888181064652401">Ei saa helistada</translation>
-<translation id="9219103736887031265">Pildid</translation>
-<translation id="926205370408745186">Chrome'i tegevuste eemaldamine teenusest Digitaalne heaolu</translation>
-<translation id="932327136139879170">Kodu</translation>
-<translation id="938850635132480979">Viga: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Juurdepääs mikrofonile</translation>
-<translation id="95817756606698420">Chrome saab Hiinas otsimiseks kasutada teenust <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />. Seda saate muuta menüüs <ph name="BEGIN_LINK" />Seaded<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokeeri, kui sait kuvab sekkuvaid või eksitavaid reklaame (soovitatav)</translation>
-<translation id="968900484120156207">Teie külastatud lehed kuvatakse siin</translation>
-<translation id="970715775301869095">Jäänud on <ph name="MINUTES" /> minutit</translation>
-<translation id="974555521953189084">Sünkroonimise alustamiseks sisestage parool</translation>
-<translation id="981121421437150478">Võrguühenduseta</translation>
-<translation id="982182592107339124">See kustutab kõikide saitide andmed, sealhulgas:</translation>
-<translation id="983192555821071799">Sule kõik vahelehed</translation>
-<translation id="987264212798334818">Üldine</translation>
+<translation id="2860954141821109167">Veenduge, et telefonirakendus oleks selles seadmes lubatud</translation>
+<translation id="2067805253194386918">tekst</translation>
+<translation id="1450753235335490080">Üksust <ph name="CONTENT_TYPE"/> ei saa jagada</translation>
+<translation id="1266864766717917324">Üksust <ph name="CONTENT_TYPE"/> ei õnnestunud jagada</translation>
+<translation id="8287068819750208230">Veenduge, et seadmes <ph name="TARGET_DEVICE_NAME"/> oleks Brave'i sünkroonimine sisse lülitatud</translation>
+<translation id="3016635187733453316">Veenduge, et seadmel oleks internetiühendus</translation>
+<translation id="8466613982764129868">Veenduge, et seadmel <ph name="TARGET_DEVICE_NAME"/> oleks internetiühendus</translation>
+<translation id="6539092367496845964">Midagi läks valesti. Proovige hiljem uuesti.</translation>
+<translation id="3389286852084373014">Tekst on liiga pikk</translation>
+<translation id="2100314319871056947">Proovige teksti jagada väiksemate lõikudena</translation>
+<translation id="2987620471460279764">Muust seadmest jagatud tekst</translation>
+<translation id="7757787379047923882">Teksti jagati seadmest <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kopeeritud lõikelauale</translation>
+<translation id="4696983787092045100">Saada tekst seadmetesse</translation>
+<translation id="1260236875608242557">Otsimine ja avastamine</translation>
+<translation id="6369229450655021117">Siin saab otsida veebis, jagada sõpradega ja näha avatud lehekülgi</translation>
+<translation id="723171743924126238">Kujutiste valimine</translation>
+<translation id="8751914237388039244">Kujutise valimine</translation>
+<translation id="1989112275319619282">Sirvi</translation>
+<translation id="7055152154916055070">Ümbersuunamine blokeeriti:</translation>
+<translation id="5524843473235508879">Ümbersuunamine blokeeriti.</translation>
+<translation id="6573096386450695060">Luba alati</translation>
+<translation id="5805364706385912897">Brave peatas selle lehe, kuna see kasutab liiga palju mälu.</translation>
+<translation id="5138664332909611586">Brave eemaldas osa sisust, kuna leht kasutab liiga palju mälu.</translation>
+<translation id="9137013805542155359">Kuva originaal</translation>
+<translation id="6361779936989026201">Brave Software'i assistent Brave'is</translation>
+<translation id="7291387454912369099">Maksmine assistendi kaudu</translation>
+<translation id="4565206163201411670">Kas kuvada teie Brave'i tegevused teenuses Digitaalne heaolu?</translation>
+<translation id="9055113864158719823">Näete saite, mida Brave'is külastate, ja saate nendele taimereid määrata.\n\nBrave Software saab teavet saitide kohta, millele taimereid määrate, ja näeb, kui kaua neid külastate. Selle teabe abil muudetakse teenus Digitaalne heaolu paremaks.</translation>
+<translation id="4596514158372210596">Brave'i tegevuste eemaldamine teenusest Digitaalne heaolu</translation>
+<translation id="1174893863889683998">Kas eemaldada teie Brave'i tegevused teenusest Digitaalne heaolu?</translation>
+<translation id="708829030563435351">Brave'is külastatud saite ei kuvata. Kõik saitide taimerid kustutatakse.</translation>
+<translation id="2056878612599315956">Sait on peatatud</translation>
+<translation id="671481426037969117">Teie rakenduse <ph name="FQDN"/> taimeri aeg sai otsa. See alustab uuesti homme.</translation>
+<translation id="7479104141328977413">Vahelehtede haldamine</translation>
+<translation id="3524138585025253783">Arendaja kasutajaliides</translation>
+<translation id="6036057147555329831">Täiendav ICU</translation>
+<translation id="9029323097866369874">Kas lubate saidil <ph name="DOMAIN"/> VR-i aktiveerida?</translation>
+<translation id="7685301384041462804">Enne VR-i aktiveerimist veenduge, et sait oleks usaldusväärne.</translation>
+<translation id="5033865233969348410">VR-i kasutamise ajal saab sait hankida järgmist teavet:
+  -  teie füüsilised omadused, näiteks pikkus
+
+Enne VR-i aktiveerimist veenduge, et sait oleks usaldusväärne.</translation>
+<translation id="5534334044554683961">VR-i kasutamise ajal võib sait hankida järgmist teavet:
+  -   teie füüsilised omadused, näiteks pikkus;
+  -   teie toa paigutus.
+
+Enne VR-i aktiveerimist veenduge, et sait oleks usaldusväärne.</translation>
+<translation id="4169535189173047238">Ära luba</translation>
+<translation id="2170088579611075216">Luba virtuaalreaalsus ja sisene</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_fa.xtb
+++ b/android/java/strings/translations/android_chrome_strings_fa.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="fa">
-<translation id="1006017844123154345">باز کردن نسخه آنلاین</translation>
-<translation id="1028699632127661925">درحال ارسال به <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">درحال افزودن <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">از وب‌سایت‌ها</translation>
-<translation id="1049743911850919806">ناشناس</translation>
-<translation id="10614374240317010">هرگز ذخیره نمی‌شود</translation>
-<translation id="1067922213147265141">‏سایر سرویس‌های Google</translation>
-<translation id="1068672505746868501">هرگز صفحه‌های <ph name="SOURCE_LANGUAGE" /> ترجمه نشوند</translation>
-<translation id="107147699690128016">اگر پسوند فایل را تغییر دهید، ممکن است فایل در برنامه دیگری باز شود و به‌طور بالقوه برای دستگاه مضر باشد.</translation>
-<translation id="1100066534610197918">باز کردن در برگه جدید در گروه</translation>
-<translation id="1105960400813249514">گرفتن عکس از صفحه‌</translation>
-<translation id="1111673857033749125">نشانک‌های ذخیره‌شده در سایر دستگاه‌های شما در اینجا نشان داده می‌شوند.</translation>
-<translation id="1113597929977215864">نمایش نمای ساده‌شده</translation>
-<translation id="1121094540300013208">آمار استفاده و گزارش‌های خرابی</translation>
-<translation id="1124772482545689468">کاربر</translation>
-<translation id="1129510026454351943">جزئیات: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{۱ بارگیری در انتظار است.}one{# بارگیری در انتظار است.}other{# بارگیری در انتظار است.}}</translation>
-<translation id="1145536944570833626">حذف داده‌های موجود.</translation>
-<translation id="1146678959555564648">‏VR را وارد کنید</translation>
-<translation id="116280672541001035">مصرف‌شده</translation>
-<translation id="1171770572613082465">با ضربه زدن روی دکمه «سایت‌های برتر»، وب‌سایت‌های پرطرفدار را ببینید</translation>
-<translation id="1173894706177603556">تغییر نام</translation>
-<translation id="1178581264944972037">مکث</translation>
-<translation id="1181037720776840403">حذف</translation>
-<translation id="1188239144602654184">‏وارد شدن به AR</translation>
-<translation id="1197267115302279827">انتقال نشانک‌ها</translation>
-<translation id="119944043368869598">پاک کردن همه</translation>
-<translation id="1201402288615127009">بعدی</translation>
-<translation id="1204037785786432551">بارگیری پیوند</translation>
-<translation id="1206892813135768548">کپی نوشتار پیوند</translation>
-<translation id="1208340532756947324">برای همگام‌سازی و شخصی‌سازی در همه دستگاه‌ها، همگام‌سازی را روشن کنید</translation>
-<translation id="1209206284964581585">فعلاً پنهان شود</translation>
-<translation id="1227058898775614466">سابقه پیمایش</translation>
-<translation id="1231733316453485619">همگام‌سازی روشن شود؟</translation>
-<translation id="123724288017357924">تازه‌سازی صفحه اصلی با نادیده گرفتن محتوای حافظه پنهان</translation>
-<translation id="124116460088058876">زبان‌های بیشتر</translation>
-<translation id="124678866338384709">بستن برگه کنونی</translation>
-<translation id="1258753120186372309">‏Google doodle: ‏<ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">جستجو و کاوش</translation>
-<translation id="1264974993859112054">ورزش</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> هم‌رسانی نشد</translation>
-<translation id="1272079795634619415">توقف</translation>
-<translation id="1283039547216852943">برای بزرگ کردن ضربه بزنید</translation>
-<translation id="1285320974508926690">این سایت هرگز ترجمه نشود</translation>
-<translation id="1291207594882862231">پاک کردن سابقه، کوکی‌ها، داده‌های سایت، حافظه پنهان…</translation>
-<translation id="129382876167171263">فایل‌هایی را که وب‌سایت‌ها ذخیره کرده‌اند، در اینجا نمایش داده می‌شود</translation>
-<translation id="129553762522093515">اخیراً بسته‌شده</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - ارسال‌شده از <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">گروه‌بندی برگه‌ها</translation>
-<translation id="1327257854815634930">سابقه «پیمایش» باز است.</translation>
-<translation id="1331212799747679585">‏Chrome به‌روزرسانی نشد. گزینه‌های دیگر</translation>
-<translation id="1332501820983677155">‏میان‌برهای ویژه Google Chrome</translation>
-<translation id="1360432990279830238">از سیستم خارج و همگام‌سازی خاموش شود؟</translation>
-<translation id="1369915414381695676">سایت <ph name="SITE_NAME" /> اضافه شد</translation>
-<translation id="1373696734384179344">حافظه برای بارگیری محتوای انتخابی کافی نیست.</translation>
-<translation id="1376578503827013741">درحال محاسبه…</translation>
-<translation id="1383876407941801731">جستجو</translation>
-<translation id="1384959399684842514">بارگیری موقتاً متوقف شد</translation>
-<translation id="1386674309198842382">آخرین فعالیت: <ph name="LAST_UPDATED" /> روز قبل</translation>
-<translation id="1397811292916898096">جستجو با <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">جاسازی‌شده در <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">«ردیابی نشود»</translation>
-<translation id="1407135791313364759">باز کردن همه</translation>
-<translation id="1409426117486808224">نمای ساده‌شده برای برگه‌های باز</translation>
-<translation id="1409879593029778104">بارگیری <ph name="FILE_NAME" /> انجام نشد زیرا فایل از قبل موجود است.</translation>
-<translation id="1414981605391750300">‏درحال اتصال به Google. ممکن است یک دقیقه طول بکشد…</translation>
-<translation id="1416550906796893042">نسخه برنامه</translation>
-<translation id="1430915738399379752">چاپ</translation>
-<translation id="1446450296470737166">‏اجازه کنترل کامل دستگاه‌های MIDI</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> هم‌رسانی نشد</translation>
-<translation id="145097072038377568">‏در تنظیمات Android مسدود شد</translation>
-<translation id="1477626028522505441">به‌دلیل مشکلاتی در سرور، بارگیری <ph name="FILE_NAME" /> انجام نشد.</translation>
-<translation id="1506061864768559482">موتور جستجو</translation>
-<translation id="1513352483775369820">نشانک‌ها و سابقه وب</translation>
-<translation id="1513858653616922153">حذف گذرواژه</translation>
-<translation id="1516229014686355813">‏«ضربه برای جستجو» کلمه انتخاب‌شده و صفحه کنونی را به‌عنوان متن جستجو به «جستجوی Google» ارسال می‌کند. می‌توانید این ویژگی را در <ph name="BEGIN_LINK" />تنظیمات<ph name="END_LINK" /> خاموش کنید.</translation>
-<translation id="1521774566618522728">امروز فعال بود</translation>
-<translation id="1544826120773021464">‏برای مدیریت تنظیمات حساب Google، روی دکمه «مدیریت حساب» ضربه بزنید</translation>
-<translation id="1549000191223877751">انتقال به پنجره دیگر</translation>
-<translation id="1553358976309200471">‏به‌روزرسانی Chrome</translation>
-<translation id="1569387923882100876">دستگاه متصل</translation>
-<translation id="1571304935088121812">کپی کردن نام کاربری</translation>
-<translation id="1612196535745283361">‏Chrome برای جستجوی دستگاه‌ها باید به مکان دسترسی داشته باشد. دسترسی به مکان <ph name="BEGIN_LINK" />برای این دستگاه خاموش است<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">دوربین</translation>
-<translation id="1623104350909869708">جلوگیری از ایجاد پنجره‌های اضافی توسط این صفحه</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{حذف ۱ مورد انتخاب‌شده}one{حذف # مورد انتخاب‌شده}other{حذف # مورد انتخاب‌شده}}</translation>
-<translation id="164269334534774161">شما در حال تماشای کپی آفلاین این صفحه از <ph name="CREATION_TIME" /> هستید</translation>
-<translation id="1644574205037202324">سابقه</translation>
-<translation id="1647391597548383849">دسترسی به دوربین</translation>
-<translation id="1660204651932907780">به سایت‌ها اجازه داده شود صدا پخش کنند (توصیه می‌شود)</translation>
-<translation id="1670399744444387456">پایه</translation>
-<translation id="1671236975893690980">بارگیری معلق است…</translation>
-<translation id="1672586136351118594">دیگر نشان داده نشود</translation>
-<translation id="1692118695553449118">همگام‌سازی روشن است</translation>
-<translation id="169515064810179024">سایت‌ها نمی‌توانند به حسگرهای حرکتی دسترسی داشته باشند</translation>
-<translation id="1717218214683051432">حسگرهای حرکتی</translation>
-<translation id="1718835860248848330">ساعت قبل</translation>
-<translation id="1736419249208073774">کاوش</translation>
-<translation id="1743802530341753419">قبل از اجازه دادن به سایت‌ها برای اتصال به دستگاه سؤال شود (توصیه می‌شود)</translation>
-<translation id="1749561566933687563">همگام‌سازی نشانک‌ها</translation>
-<translation id="17513872634828108">بازکردن برگه‌ها</translation>
-<translation id="1779089405699405702">رمزگشای تصویر</translation>
-<translation id="1782483593938241562">تاریخ پایان: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">نصب‌شده</translation>
-<translation id="1792959175193046959">هرزمان بخواهید می‌توانید محل پیش‌فرض بارگیری را تغییر دهید</translation>
-<translation id="1807246157184219062">روشن</translation>
-<translation id="1810845389119482123">همگام‌سازی اولیه کامل نشد</translation>
-<translation id="1821253160463689938">از کوکی‌ها برای به خاطر سپردن تنظیمات برگزیده‌تان استفاده می‌کند، حتی اگر از آن صفحه‌ها بازدید نکنید</translation>
-<translation id="1829244130665387512">یافتن در صفحه</translation>
-<translation id="1853692000353488670">برگه جدید ناشناس</translation>
-<translation id="1856325424225101786">«حالت ساده» بازنشانی شود؟</translation>
-<translation id="1868024384445905608">‏اکنون Chrome فایل‌ها را سریع‌تر بارگیری می‌کند</translation>
-<translation id="1883903952484604915">فایل‌های من</translation>
-<translation id="1887786770086287077">‏دسترسی به مکان برای این دستگاه خاموش است. آن را در <ph name="BEGIN_LINK" />تنظیمات Android<ph name="END_LINK" /> روشن کنید.</translation>
-<translation id="1891331835972267886">‏<ph name="APP_NAME" /> در Chrome باز می‌شود. درصورت ادامه دادن، با <ph name="BEGIN_LINK1" />شرایط خدمات<ph name="END_LINK1" /> و <ph name="BEGIN_LINK2" />اعلان حریم خصوصی<ph name="END_LINK2" /> Chrome موافقت می‌کنید.</translation>
-<translation id="1919345977826869612">آگهی‌ها</translation>
-<translation id="1919950603503897840">انتخاب مخاطبین</translation>
-<translation id="1922076542920281912">‏برای اینکه به Chrome امکان دهید به مکانتان دسترسی یابد، در <ph name="BEGIN_LINK" />تنظیمات Android<ph name="END_LINK" /> هم مکان را روشن کنید.</translation>
-<translation id="1923695749281512248">‎<ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" />‎</translation>
-<translation id="1928696683969751773">به‌روزرسانی‌ها</translation>
-<translation id="19288952978244135">‏Chrome را دوباره باز کنید.</translation>
-<translation id="1933845786846280168">برگه انتخاب‌شده</translation>
-<translation id="194341124344773587">‏مجوز Chrome را در <ph name="BEGIN_LINK" />تنظیمات Android <ph name="END_LINK" /> روشن کنید.</translation>
-<translation id="1943432128510653496">ذخیره گذرواژه‌ها</translation>
-<translation id="1952172573699511566">درصورت امکان، وب‌سایت‌ها نوشتار را به زبان ترجیحی شما نمایش می‌دهند.</translation>
-<translation id="1960290143419248813">‏به‌روزرسانی‌های Chrome دیگر در این نسخه Android پشتیبانی نمی‌شوند</translation>
-<translation id="1966710179511230534">لطفاً جزئیات ورود به سیستم را به‌روز کنید.</translation>
-<translation id="1974060860693918893">پیشرفته</translation>
-<translation id="1984705450038014246">‏همگام‌سازی داده‌های Chrome</translation>
-<translation id="1984937141057606926">مجاز، به غیر از طرف ثالث</translation>
-<translation id="1986685561493779662">نام ازقبل وجود دارد</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> دکمه <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">مشاهده محتوای موجود در فروشگاه ما</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> می‌خواهد مرتبط شود</translation>
-<translation id="1994173015038366702">نشانی وب سایت</translation>
-<translation id="2000419248597011803">برخی کوکی‌ها و جستجوها را از نوار نشانی و جعبه جستجو به موتور جستجوی پیش‌فرض ارسال می‌کند</translation>
-<translation id="2002537628803770967">‏کارت‌های اعتباری و نشانی‌های مورداستفاده در Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# فایل}one{# فایل}other{# فایل}}</translation>
-<translation id="2017836877785168846">سابقه و تکمیل خودکار را در نوار نشانی پاک می‌کند.</translation>
-<translation id="2021896219286479412">کنترل‌های سایت تمام‌صفحه</translation>
-<translation id="2038563949887743358">روشن کردن درخواست سایت رایانه‌ای</translation>
-<translation id="2041019821020695769">‏برای اینکه به Chrome امکان دهید برایتان اعلان ارسال کند، در <ph name="BEGIN_LINK" />تنظیمات Android<ph name="END_LINK" /> هم اعلان‌ها را روشن کنید.</translation>
-<translation id="204321170514947529">‏<ph name="APP_NAME" /> داده‌هایی در Chrome نیز دارد</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">سایت موقتاً متوقف شد</translation>
-<translation id="2063713494490388661">ضربه برای جستجو</translation>
-<translation id="2067805253194386918">نوشتار</translation>
-<translation id="2079545284768500474">لغو</translation>
-<translation id="2082238445998314030"><ph name="RESULT_NUMBER" /> نتیجه از <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">صدا</translation>
-<translation id="2096012225669085171">همگام‌سازی و شخصی‌سازی در همه دستگاه‌ها</translation>
-<translation id="2100273922101894616">ورود به سیستم خودکار</translation>
-<translation id="2100314319871056947">بخش‌های کوچک‌تری از نوشتار را به اشتراک بگذارید</translation>
-<translation id="2107397443965016585">قبل از اجازه به سایت‌ها برای پخش محتوای محافظت‌شده سؤال شود (توصیه می‌شود)</translation>
-<translation id="2111511281910874386">رفتن به صفحه</translation>
-<translation id="2122601567107267586">باز کردن برنامه امکان‌پذیر نیست</translation>
-<translation id="2126426811489709554">‏ارائه توسط Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> صرفه‌جویی شد</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> بسته شد</translation>
-<translation id="2139186145475833000">افزودن به صفحه اصلی</translation>
-<translation id="2146738493024040262">برنامه فوری را باز کنید</translation>
-<translation id="2148716181193084225">امروز</translation>
-<translation id="2154484045852737596">ویرایش کارت</translation>
-<translation id="2154710561487035718">کپی نشانی وب</translation>
-<translation id="2156074688469523661">سایت‌های باقی‌مانده (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">‏برای به‌اشتراک گذاشتن چیزی از تلفنتان با دستگاهی دیگر، در تنظیمات Chrome هر دو دستگاه «همگام‌سازی» را روشن کنید</translation>
-<translation id="2170088579611075216">‏اجازه دادن و وارد شدن به VR</translation>
-<translation id="218608176142494674">هم‌رسانی</translation>
-<translation id="2227444325776770048">ادامه دادن به‌عنوان <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">‏همگام‌سازی و سرویس‌های Google</translation>
-<translation id="2259659629660284697">درحال صادر کردن گذرواژه‌ها…</translation>
-<translation id="2268044343513325586">فیلتر</translation>
-<translation id="2286841657746966508">آدرس ارسال صورتحساب</translation>
-<translation id="2289270750774289114">وقتی سایتی می‌خواهد دستگا‌ه‌های بلوتوث اطراف را پیدا کند، سؤال شود (توصیه می‌شود)</translation>
-<translation id="230115972905494466">هیچ دستگاه سازگاری پیدا نشد</translation>
-<translation id="2315043854645842844">انتخاب گواهی سمت کلاینت توسط سیستم‌عامل پشتیبانی نمی‌شود.</translation>
-<translation id="2318045970523081853">برای برقراری تماس، ضربه بزنید.</translation>
-<translation id="2321086116217818302">درحال آماده‌سازی گذرواژه‌ها…</translation>
-<translation id="2321958826496381788">لغزنده را بکشید تا زمانی که بتوانید این متن را به راحتی بخوانید. بعد از دو ضربه متوالی روی یک پاراگراف، اندازه نوشتار حداقل باید به این بزرگی باشد.</translation>
-<translation id="2323763861024343754">فضای ذخیره‌سازی سایت</translation>
-<translation id="2328985652426384049">ورود به سیستم امکان‌پذیر نیست</translation>
-<translation id="2330129964253841015">اگر گذرواژه‌هایتان درمعرض خطر باشد، هشدار دریافت کنید</translation>
-<translation id="2349710944427398404">‏کل داده‌های استفاده‌شده توسط Chrome، شامل حساب‌ها، نشانک‌ها و تنظیمات ذخیره‌شده</translation>
-<translation id="2353636109065292463">بررسی اتصال اینترنت</translation>
-<translation id="2359808026110333948">ادامه</translation>
-<translation id="2369533728426058518">برگه‌های باز</translation>
-<translation id="2387895666653383613">اندازه قلم نوشتار</translation>
-<translation id="2394602618534698961">فایل‌هایی که بارگیری می‌کنید، اینجا نشان داده می‌شود</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> مگابایت</translation>
-<translation id="2407481962792080328">‏وقتی به «حساب Google» خود وارد می‌شوید، این ویژگی روشن می‌شود</translation>
-<translation id="2410754283952462441">انتخاب حساب</translation>
-<translation id="2414886740292270097">تاریک</translation>
-<translation id="2416359993254398973">‏Chrome به مجوز دسترسی به دوربین برای این سایت نیاز دارد.</translation>
-<translation id="2426805022920575512">انتخاب حسابی دیگر</translation>
-<translation id="2433507940547922241">شکل ظاهری</translation>
-<translation id="2434158240863470628">بارگیری کامل شد <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">دسترسی به موقعیت مکانی</translation>
-<translation id="2450083983707403292">می‌خواهید بارگیری <ph name="FILE_NAME" /> را دوباره شروع کنید؟</translation>
-<translation id="2482878487686419369">اعلان‌ها</translation>
-<translation id="2490684707762498678">تحت مدیریت <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">‏«دستیار Google» در Chrome</translation>
-<translation id="2496180316473517155">سابقه مرور</translation>
-<translation id="2497852260688568942">سرپرستتان همگام‌سازی را غیرفعال کرده است</translation>
-<translation id="2498359688066513246">راهنمایی و بازخورد</translation>
-<translation id="2501278716633472235">بازگشت</translation>
-<translation id="2513403576141822879">‏برای تنظیمات بیشتر مرتبط با حریم خصوصی، امنیت و جمع‌آوری داده‌ها، <ph name="BEGIN_LINK" />همگام‌سازی و سرویس‌های Google<ph name="END_LINK" /> را ببینید</translation>
-<translation id="2518590038762162553">‏در «حالت ساده»، Chrome صفحه‌ها را سریع‌تر بار می‌کند و تا ۶۰ درصد مصرف داده را کاهش می‌دهد. برای بهینه‌سازی صفحاتی که بازدید می‌کنید، Chrome ترافیک وب شما را به Google ارسال می‌کند. <ph name="BEGIN_LINK" />بیشتر بدانید<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">‏نشانی وب صفحه‌هایی را که بازدید می‌کنید برای Google ارسال می‌کند</translation>
-<translation id="2532336938189706096">نمای وب</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> مورد حذف شد</translation>
-<translation id="2536728043171574184">مشاهده یک کپی آفلاین از این صفحه</translation>
-<translation id="2546283357679194313">کوکی‌ها و داده‌های سایت</translation>
-<translation id="2567385386134582609">تصویر</translation>
-<translation id="257088987046510401">طرح‌‌های قسمت</translation>
-<translation id="2570922361219980984">‏دسترسی به مکان برای این دستگاه نیز خاموش است. آن را در <ph name="BEGIN_LINK" />تنظیمات Android<ph name="END_LINK" /> روشن کنید.</translation>
-<translation id="257931822824936280">بزرگ‌شده - برای کوچک کردن کلیک کنید.</translation>
-<translation id="2581165646603367611">‏این کار کوکی‌ها، حافظه پنهان و داده‌های دیگر سایت‌ها را که از نظر Chrome مهم نیست پاک می‌کند.</translation>
-<translation id="2586657967955657006">بریده‌دان</translation>
-<translation id="2587052924345400782">نسخه جدیدتری در دسترس است</translation>
-<translation id="2593272815202181319">قلم‌های با عرض ثابت</translation>
-<translation id="2612676031748830579">شماره کارت</translation>
-<translation id="2621115761605608342">جاوااسکریپت را برای سایتی خاص مجاز کنید.</translation>
-<translation id="2625189173221582860">گذرواژه کپی شد</translation>
-<translation id="2631006050119455616">ذخیره شده</translation>
-<translation id="2647434099613338025">افزودن زبان</translation>
-<translation id="2650751991977523696">فایل دوباره بارگیری شود؟</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# فایل صوتی}one{# فایل صوتی}other{# فایل صوتی}}</translation>
-<translation id="2653659639078652383">ارائه</translation>
-<translation id="2677748264148917807">خروج</translation>
-<translation id="2704606927547763573">کپی شد</translation>
-<translation id="2707726405694321444">بازخوانی صفحه</translation>
-<translation id="2709516037105925701">تکمیل خودکار</translation>
-<translation id="2717722538473713889">آدرس‌های ایمیل</translation>
-<translation id="2728754400939377704">مرتب‌سازی براساس سایت</translation>
-<translation id="2744248271121720757">برای جستجوی فوری، روی کلمه‌ای ضربه بزنید یا اقدام‌های مرتبط را ببینید</translation>
-<translation id="2760989362628427051">روشن شدن طرح زمینه تیره وقتی طرح زمینه تیره دستگاه یا «بهینه‌سازی باتری» روشن است</translation>
-<translation id="2762000892062317888">هم‌اکنون</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> ثانیه باقی‌مانده است</translation>
-<translation id="2779651927720337254">انجام نشد</translation>
-<translation id="2781151931089541271">۱ ثانیه باقی‌مانده است</translation>
-<translation id="2801022321632964776">‏با به‌روزرسانی به جدیدترین نسخه Chrome، زبانتان را دریافت کنید</translation>
-<translation id="2810645512293415242">صفحه ساده‌شده برای ذخیره داده‌ها و بارگیری با سرعت بیشتر.</translation>
-<translation id="281504910091592009">‏در <ph name="BEGIN_LINK" />حساب Google<ph name="END_LINK" /> خود گذرواژه‌های ذخیره‌شده را مشاهده و مدیریت کنید</translation>
-<translation id="2818669890320396765">برای اینکه نشانک‌هایتان را در همه دستگاه‌ها داشته باشید، به سیستم وارد شوید و همگام‌سازی را روشن کنید</translation>
-<translation id="2822354292072154809">مطمئن‌اید می‌خواهید همه مجوزهای سایت مربوط به <ph name="CHOSEN_OBJECT_NAME" /> را بازنشانی کنید؟</translation>
-<translation id="2836148919159985482">برای خروج از حالت تمام صفحه، دکمه برگشت را لمس کنید.</translation>
-<translation id="2842985007712546952">پوشه اصلی</translation>
-<translation id="2858138569776157458">سایت‌های برتر</translation>
-<translation id="2860954141821109167">مطمئن شوید برنامه تلفن در این دستگاه فعال باشد</translation>
-<translation id="2870560284913253234">سایت</translation>
-<translation id="2874939134665556319">آهنگ قبلی</translation>
-<translation id="2876369937070532032">‏اگر امنیتتان درخطر باشد، نشانی وب برخی از صفحه‌هایی را که بازدید می‌کنید به Google می‌فرستد</translation>
-<translation id="2888126860611144412">‏درباره Chrome</translation>
-<translation id="2891154217021530873">توقف بارگیری صفحه</translation>
-<translation id="2893180576842394309">‏Google ممکن است از سابقه مرور شما برای شخصی کردن جستجو و سایر سرویس‌های Google استفاده کند</translation>
-<translation id="2898264748040935573">ویرایش گذرواژه ذخیره‌شده</translation>
-<translation id="2900528713135656174">ایجاد رویداد</translation>
-<translation id="290376772003165898">صفحه به زبان <ph name="LANGUAGE" /> وجود ندارد؟</translation>
-<translation id="2904414404539560095">فهرست دستگاه‌هایی که می‌توان با آن‌ها برگه هم‌رسانی کرد کاملاً باز است.</translation>
-<translation id="2910701580606108292">قبل از اجازه دادن به سایت‌ها برای پخش محتوای محافظت‌شده سؤال شود</translation>
-<translation id="2913331724188855103">سایت‌ها مجاز به ذخیره و خواندن داده‌های کوکی باشند (توصیه می‌شود)</translation>
-<translation id="2923908459366352541">نام نامعتبر است</translation>
-<translation id="2932150158123903946">‏فضای ذخیره‌سازی Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">برگه پیش‌نمایش بسته است</translation>
-<translation id="2956410042958133412"><ph name="PARENT_NAME_1" /> و <ph name="PARENT_NAME_2" /> این حساب را مدیریت می‌کنند.</translation>
-<translation id="2962095958535813455">به برگه‌های ناشناس تغییر یافت</translation>
-<translation id="2968755619301702150">بیننده گواهی</translation>
-<translation id="2979025552038692506">برگه ناشناس انتخاب‌شده</translation>
-<translation id="2987620471460279764">نوشتار هم‌رسانی‌شده از دستگاه دیگر</translation>
-<translation id="2989523299700148168">اخیراً دیده‌شده</translation>
-<translation id="2996291259634659425">ایجاد عبارت عبور</translation>
-<translation id="2996809686854298943">نشانی وب لازم است</translation>
-<translation id="300526633675317032">این کار کل <ph name="SIZE_IN_KB" /> فضای ذخیره‌سازی وب‌سایت را پاک می‌کند.</translation>
-<translation id="3016635187733453316">مطمئن شوید این دستگاه به اینترنت متصل باشد</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> کیلوبایت بارگیری شد</translation>
-<translation id="3029704984691124060">عبارت‌های عبور مطابقت ندارند</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />دریافت راهنمایی<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">‏مکان خاموش است، آن را در <ph name="BEGIN_LINK" />تنظیمات Android<ph name="END_LINK" /> روشن کنید.</translation>
-<translation id="3058498974290601450">هرزمان خواستید می‌توانید همگام‌سازی را در تنظیمات روشن کنید</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> نشانک}one{<ph name="BOOKMARKS_COUNT_MANY" /> نشانک}other{<ph name="BOOKMARKS_COUNT_MANY" /> نشانک}}</translation>
-<translation id="3089395242580810162">باز کردن در برگه ناشناس</translation>
-<translation id="3115898365077584848">نمایش دادن اطلاعات</translation>
-<translation id="3123473560110926937">در برخی سایت‌ها مسدود می‌شود</translation>
-<translation id="3137521801621304719">خروج از حالت ناشناس</translation>
-<translation id="3143515551205905069">لغو همگام‌سازی</translation>
-<translation id="3157842584138209013">با استفاده از دکمه «گزینه‌های بیشتر»، ببینید چه مقدار داده صرفه‌جویی کرده‌اید</translation>
-<translation id="3166827708714933426">میان‌برهای پنجره و برگه</translation>
-<translation id="3181954750937456830">مرور ایمن (از شما و دستگاهتان درمقابل سایت‌های خطرناک محافظت می‌کند)</translation>
-<translation id="3190152372525844641">‏مجوزهای Chrome را در <ph name="BEGIN_LINK" />تنظیمات Android <ph name="END_LINK" /> روشن کنید.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> داده‌های ذخیره شده</translation>
-<translation id="3205824638308738187">تقریباً پایان یافته است!</translation>
-<translation id="3207960819495026254">نشانک‌گذاری شده</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> حذف شد</translation>
-<translation id="321773570071367578">اگر عبارت عبورتان را فراموش کردید یا می‌خواهید این تنظیم را تغییر دهید، <ph name="BEGIN_LINK" />همگام‌سازی را بازنشانی کنید<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">میکروفن</translation>
-<translation id="3232754137068452469">برنامه وب</translation>
-<translation id="3236059992281584593">۱ دقیقه باقی‌مانده است</translation>
-<translation id="3244271242291266297">ماه</translation>
-<translation id="3254409185687681395">نشانک گذاری این صفحه</translation>
-<translation id="3259831549858767975">کوچک‌تر کردن همه‌چیز در صفحه</translation>
-<translation id="3269093882174072735">بارگیری تصویر</translation>
-<translation id="3269956123044984603">‏برای دسترسی به برگه‌ها از دستگاه‌های دیگرتان، «همگام‌سازی خودکار داده‌ها» را در تنظیمات حساب Android روشن کنید.</translation>
-<translation id="3277252321222022663">مجاز بودن دسترسی سایت‌ها به حسگرها (توصیه می‌شود)</translation>
-<translation id="3282568296779691940">‏ورود به Chrome</translation>
-<translation id="3288003805934695103">تازه‌سازی صفحه</translation>
-<translation id="32895400574683172">اعلان‌ها مجاز هستند</translation>
-<translation id="3295530008794733555">سریع‌تر مرور کنید. از داده کمتری استفاده کنید.</translation>
-<translation id="3295602654194328831">پنهان کردن اطلاعات</translation>
-<translation id="3298243779924642547">ساده</translation>
-<translation id="3303414029551471755">ادامه می‌دهید و محتوا را بارگیری می‌کنید؟</translation>
-<translation id="3306398118552023113">‏این برنامه در Chrome درحال اجرا است</translation>
-<translation id="3315103659806849044">‏شما درحال سفارشی کردن تنظیمات همگام‌سازی و سرویس‌های Google هستید. برای تکمیل روشن کردن همگام‌سازی، روی دکمه «تأیید» در پایین صفحه ضربه بزنید. پیمایش به بالا</translation>
-<translation id="3328801116991980348">اطلاعات سایت</translation>
-<translation id="3333961966071413176">همه مخاطبین</translation>
-<translation id="3334729583274622784">پسوند فایل تغییر کند؟</translation>
-<translation id="3341058695485821946">ببینید چه مقدار داده صرفه‌جویی کرده‌اید</translation>
-<translation id="3350687908700087792">بستن همه برگه‌های ناشناس</translation>
-<translation id="3353615205017136254">‏صفحه ساده‌شده را Google ارائه کرده است. برای بارگیری صفحه اصلی، روی دکمه بارگیری صفحه اصلی ضربه بزنید.</translation>
-<translation id="3367813778245106622">دوباره به سیستم وارد شوید یا همگام‌سازی را شروع کنید</translation>
-<translation id="3374023511497244703">‏نشانک‌ها، سابقه، گذرواژه‌ها و سایر داده‌های Chrome، دیگر با حساب Google شما همگام‌سازی نمی‌شود.</translation>
-<translation id="3384347053049321195">اشتراک‌گذاری تصویر</translation>
-<translation id="3386292677130313581">قبل از اجازه به سایت‌ها برای اطلاع از مکانتان، ابتدا سؤال شود (توصیه می‌شود)</translation>
-<translation id="3387650086002190359">به‌دلیل خطاهای سیستم فایل، بارگیری <ph name="FILE_NAME" /> انجام نشد.</translation>
-<translation id="3389286852084373014">نوشتار خیلی بزرگ است</translation>
-<translation id="3398320232533725830">باز کردن مدیر نشانک‌ها</translation>
-<translation id="3414952576877147120">اندازه:</translation>
-<translation id="3443221991560634068">تازه‌سازی صفحه کنونی</translation>
-<translation id="3445014427084483498">هم‌اکنون</translation>
-<translation id="3478363558367712427">می‌توانید موتور جستجویتان را انتخاب کنید</translation>
+<translation id="6910211073230771657">حذف شد</translation>
+<translation id="6965382102122355670">قبول</translation>
+<translation id="5301954838959518834">بله، متوجه شدم</translation>
+<translation id="7658239707568436148">لغو</translation>
 <translation id="3479552764303398839">اکنون نه</translation>
-<translation id="3492207499832628349">برگه ناشناس جدید</translation>
-<translation id="3493531032208478708">درباره محتوای پیشنهادی <ph name="BEGIN_LINK" />بیشتر بدانید<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">واقعیت افزوده</translation>
-<translation id="3518985090088779359">پذیرش و ادامه</translation>
-<translation id="3522247891732774234">به‌روزرسانی موجود است. گزینه‌های بیشتر</translation>
-<translation id="3524138585025253783">رابط کاربری برنامه‌نویس</translation>
-<translation id="3527085408025491307">پوشه</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> کیلوبایت دردسترس است</translation>
-<translation id="3549657413697417275">جستجو در سابقه</translation>
-<translation id="3557336313807607643">افزودن به مخاطبین</translation>
-<translation id="3566923219790363270">‏Chrome هنوز درحال آماده‌سازی برای VR است. Chrome بعداً بازراه‌اندازی شود.</translation>
-<translation id="3568688522516854065">برای اینکه به برگه‌های بازشده در سایر دستگاه‌ها دسترسی داشته باشید، به سیستم وارد شوید و همگام‌سازی را روشن کنید</translation>
-<translation id="3587482841069643663">همه</translation>
-<translation id="358794129225322306">به سایت اجازه داده شود چند فایل را به‌طور خودکار بارگیری کند.</translation>
-<translation id="3590487821116122040">‏فضای ذخیره‌سازی سایت که از نظر Chrome مهم نیست (مثلاً سایت‌هایی که تنظیمات ذخیره‌شده ندارند یا شما مرتب بازدید نمی‌کنید)</translation>
-<translation id="3599863153486145794">‏سابقه را از همه دستگاه‌های به سیستم واردشده پاک می‌کند. ممکن است حساب Google شما اشکال دیگری از سابقه مرور در <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> داشته باشد.</translation>
-<translation id="3600792891314830896">سایت‌هایی که صدا پخش می‌کنند بی‌صدا شوند</translation>
-<translation id="3616113530831147358">صوتی</translation>
-<translation id="3631987586758005671">درحال هم‌رسانی با <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">نمایش گذرواژه</translation>
-<translation id="363596933471559332">با استفاده از اعتبارنامه‌های ذخیره شده، به‌طور خودکار به سیستم وب‌سایت‌ها وارد شوید. وقتی این قابلیت خاموش است، هر بار قبل از وارد شدن به سیستم وب‌سایت از شما خواسته می‌شود اطلاعات را تأیید کنید.</translation>
-<translation id="3658159451045945436">بازنشانی باعث پاک شدن سابقه داده‌های ذخیره‌شده ازجمله فهرست سایت‌های بازدیدشده می‌شود.</translation>
-<translation id="3692944402865947621">به‌دلیل دردسترس نبودن مکان فضای ذخیره‌سازی، <ph name="FILE_NAME" /> بارگیری نشد.</translation>
-<translation id="3714981814255182093">باز کردن «نوار پیدا کردن»</translation>
-<translation id="3716182511346448902">‏این صفحه از حافظه بسیار زیادی استفاده می‌کند، بنابراین Chrome موقتاً آن را متوقف کرد.</translation>
-<translation id="3730075448226062617">‏برای اینکه به Chrome امکان دهید به میکروفون دسترسی یابد، در <ph name="BEGIN_LINK" />تنظیمات Android<ph name="END_LINK" /> هم میکروفون را روشن کنید.</translation>
-<translation id="3739899004075612870">در <ph name="PRODUCT_NAME" /> نشانک‌گذاری شد</translation>
-<translation id="3744111561329211289">همگام‌سازی پس‌زمینه</translation>
-<translation id="3771001275138982843">به‌روزرسانی بارگیری نشد</translation>
-<translation id="3771033907050503522">برگه‌های ناشناس</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />بلوتوث را روشن کنید<ph name="END_LINK" /> تا مرتبط‌سازی امکان‌پذیر شود</translation>
-<translation id="3775705724665058594">ارسال به دستگاه‌هایتان</translation>
-<translation id="3778956594442850293">به صفحه اصلی اضافه شد</translation>
-<translation id="3789841737615482174">نصب</translation>
-<translation id="3810838688059735925">فیلم</translation>
-<translation id="3810973564298564668">مدیریت</translation>
-<translation id="381841723434055211">شماره‌های تلفن</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> بارگیری حذف شد</translation>
-<translation id="3822502789641063741">فضای ذخیره سایت پاک شود؟</translation>
-<translation id="385051799172605136">بازگشت</translation>
-<translation id="3859306556332390985">جستجو به جلو</translation>
-<translation id="3894427358181296146">افزودن پوشه</translation>
-<translation id="3895926599014793903">فعال کردن اجباری بزرگ‌نمایی</translation>
-<translation id="3912508018559818924">درحال پیدا کردن بهترین مورد از وب…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">ادغام کردن داده‌های من</translation>
-<translation id="393697183122708255">هیچ جستجوی گفتاری فعالی در دسترس نیست</translation>
-<translation id="395206256282351086">پیشنهادهای جستجو و سایت غیرفعال است</translation>
-<translation id="3955193568934677022">به سایت‌ها اجازه داده شود محتوای محافظت‌شده پخش کنند (توصیه می‌شود)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{‏وقتی آماده شدید، Chrome صفحه را بار می‌کند}one{‏وقتی آماده شدید، Chrome صفحه‌ها را بار می‌کند}other{‏وقتی آماده شدید، Chrome صفحه‌ها را بار می‌کند}}</translation>
-<translation id="3963007978381181125">‏رمزگذاری عبارت ورود شامل روش‌های پرداخت و نشانی‌های موجود در Google Pay نمی‌شود. فقط افرادی که عبارت عبورتان را داشته باشند می‌توانند داده‌های رمزگذاری‌شده‌تان را بخوانند. عبارت عبور به Google ارسال یا در سرورهای آن ذخیره نمی‌شود. اگر عبارت عبورتان را فراموش کنید یا بخواهید این تنظیم را تغییر دهید، باید همگام‌سازی را بازنشانی کنید. <ph name="BEGIN_LINK" />بیشتر بدانید<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">بارگیری کامل شد</translation>
-<translation id="397583555483684758">همگام‌سازی متوقف شده است</translation>
-<translation id="3976396876660209797">این میان‌بر را بردارید و دوباره ایجاد کنید</translation>
-<translation id="3985215325736559418">می‌خواهید دوباره <ph name="FILE_NAME" /> را بارگیری کنید؟</translation>
-<translation id="3987993985790029246">کپی پیوند</translation>
-<translation id="3988213473815854515">مکان مجاز است</translation>
-<translation id="3988466920954086464">نتایج جستجوی فوری را در این پانل مشاهده کنید</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> از ؟</translation>
-<translation id="3997476611815694295">فضای ذخیره غیرمهم</translation>
-<translation id="4000212216660919741">صفحه اصلیِ آفلاین</translation>
+<translation id="5317780077021120954">ذخیره</translation>
+<translation id="4570913071927164677">جزئیات</translation>
+<translation id="8730621377337864115">تمام</translation>
+<translation id="8261506727792406068">حذف</translation>
+<translation id="1181037720776840403">حذف</translation>
+<translation id="5939518447894949180">بازنشانی</translation>
 <translation id="4002066346123236978">عنوان</translation>
-<translation id="4008040567710660924">کوکی‌ها را برای سایت خاصی مجاز کنید.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ساعت}one{# ساعت}other{# ساعت}}</translation>
-<translation id="4046123991198612571">آهنگ بعدی</translation>
-<translation id="4048707525896921369">‏بدون ترک کردن صفحه با موضوعات وب‌سایت‌ها آشنا شوید. «ضربه برای جستجو»، کلمه و متن اطراف آن را به «جستجوی Google» ارسال می‌کند و معانی، تصاویر، نتایج جستجو و سایر جزئیات را بازمی‌گرداند.
+<translation id="5916664084637901428">روشن</translation>
+<translation id="5860033963881614850">خاموش</translation>
+<translation id="6165508094623778733">بیشتر بدانید</translation>
+<translation id="6042308850641462728">بیشتر</translation>
+<translation id="6040143037577758943">بستن</translation>
+<translation id="780301667611848630">نه متشکرم</translation>
+<translation id="1201402288615127009">بعدی</translation>
+<translation id="2359808026110333948">ادامه</translation>
+<translation id="2653659639078652383">ارائه</translation>
+<translation id="2079545284768500474">لغو</translation>
+<translation id="7649070708921625228">راهنما</translation>
+<translation id="2148716181193084225">امروز</translation>
+<translation id="7781829728241885113">دیروز</translation>
+<translation id="6945221475159498467">انتخاب</translation>
+<translation id="7791543448312431591">افزودن</translation>
+<translation id="6527303717912515753">اشتراک‌گذاری</translation>
+<translation id="1383876407941801731">جستجو</translation>
+<translation id="3115898365077584848">نمایش دادن اطلاعات</translation>
+<translation id="3295602654194328831">پنهان کردن اطلاعات</translation>
+<translation id="3987993985790029246">کپی پیوند</translation>
+<translation id="2704606927547763573">کپی شد</translation>
+<translation id="8725066075913043281">سعی مجدد</translation>
+<translation id="385051799172605136">بازگشت</translation>
+<translation id="8131740175452115882">تأیید</translation>
+<translation id="5300589172476337783">نمایش</translation>
+<translation id="1124772482545689468">کاربر</translation>
+<translation id="8609465669617005112">انتقال به بالا</translation>
+<translation id="6746124502594467657">انتقال به پایین</translation>
+<translation id="8249310407154411074">انتقال به بالا</translation>
+<translation id="8428213095426709021">تنظیمات</translation>
+<translation id="2498359688066513246">راهنمایی و بازخورد</translation>
+<translation id="8378714024927312812">توسط سازمانتان مدیریت می‌شود</translation>
+<translation id="9019902583201351841">مدیریت شده توسط والدین شما</translation>
+<translation id="4645575059429386691">مدیریت شده توسط والدین شما</translation>
+<translation id="4883854917563148705">تنظیمات مدیریت‌شده بازنشانی نشدند</translation>
+<translation id="4307992518367153382">موارد اصلی</translation>
+<translation id="1974060860693918893">پیشرفته</translation>
+<translation id="1146678959555564648">‏VR را وارد کنید</translation>
+<translation id="987264212798334818">موارد کلی</translation>
+<translation id="4275663329226226506">رسانه</translation>
+<translation id="4759238208242260848">بارگیری‌ها</translation>
+<translation id="218608176142494674">هم‌رسانی</translation>
+<translation id="8004582292198964060">مرورگر</translation>
+<translation id="1105960400813249514">گرفتن عکس از صفحه‌</translation>
+<translation id="4875775213178255010">محتواهای پیشنهادی</translation>
+<translation id="2021896219286479412">کنترل‌های سایت تمام‌صفحه</translation>
+<translation id="4587589328781138893">سایت‌ها</translation>
+<translation id="4943703118917034429">واقعیت مجازی</translation>
+<translation id="1928696683969751773">به‌روزرسانی‌ها</translation>
+<translation id="6064125863973209585">بارگیری‌های کامل‌شده</translation>
+<translation id="5342314432463739672">درخواست‌های مجوز</translation>
+<translation id="629730747756840877">حساب</translation>
+<translation id="82609232232243542">‏ورود به Brave</translation>
+<translation id="7956662517480676674">‏همگام‌سازی و سرویس‌های Brave Software</translation>
+<translation id="5294439808117722387">‏شما درحال سفارشی کردن تنظیمات همگام‌سازی و سرویس‌های Brave Software هستید. برای تکمیل روشن کردن همگام‌سازی، روی دکمه «تأیید» در پایین صفحه ضربه بزنید. پیمایش به بالا</translation>
+<translation id="2096012225669085171">همگام‌سازی و شخصی‌سازی در همه دستگاه‌ها</translation>
+<translation id="1692118695553449118">همگام‌سازی روشن است</translation>
+<translation id="5514904542973294328">توسط سرپرست این دستگاه غیرفعال شده است</translation>
+<translation id="6447211988989208781">‏کنترل‌های فعالیت Brave Software</translation>
+<translation id="4882831918239250449">کنترل نحوه استفاده از سابقه مرور برای شخصی‌سازی «جستجو»، آگهی‌ها و موارد دیگر</translation>
+<translation id="7431991332293347422">کنترل نحوه استفاده از سابقه مرور برای شخصی‌سازی «جستجو» و موارد دیگر</translation>
+<translation id="6303969859164067831">خروج از سیستم و خاموش کردن همگام‌سازی</translation>
+<translation id="1125261911132334651">‏مدیریت حساب Brave Software</translation>
+<translation id="6406506848690869874">همگام‌سازی</translation>
+<translation id="714362445477979774">‏همگام‌سازی داده‌های Brave</translation>
+<translation id="4314815835985389558">مدیریت همگام‌سازی</translation>
+<translation id="5428209950370661546">‏سایر سرویس‌های Brave Software</translation>
+<translation id="7704317875155739195">تکمیل خودکار جستجوها و نشانی‌های وب</translation>
+<translation id="2000419248597011803">برخی کوکی‌ها و جستجوها را از نوار نشانی و جعبه جستجو به موتور جستجوی پیش‌فرض ارسال می‌کند</translation>
+<translation id="7981313251711023384">پیش‌بارگیری صفحه‌ها برای مرور و جستجوی سریع‌تر</translation>
+<translation id="1821253160463689938">از کوکی‌ها برای به خاطر سپردن تنظیمات برگزیده‌تان استفاده می‌کند، حتی اگر از آن صفحه‌ها بازدید نکنید</translation>
+<translation id="6697492270171225480">نمایش پیشنهادهای صفحه‌های مشابه وقتی صفحه‌ای پیدا نمی‌شود</translation>
+<translation id="8109318360573330108">‏نشانی وب صفحه‌ای را که باز می‌کنید به Brave Software ارسال می‌کند</translation>
+<translation id="8438566539970814960">بهبود جستجوها و مرور</translation>
+<translation id="284843628681142937">‏نشانی وب صفحه‌هایی را که بازدید می‌کنید برای Brave Software ارسال می‌کند</translation>
+<translation id="7222718784508482526">‏برای تنظیمات بیشتر مرتبط با حریم خصوصی، امنیت و جمع‌آوری داده‌ها، <ph name="BEGIN_LINK"/>همگام‌سازی و سرویس‌های Brave Software<ph name="END_LINK"/> را ببینید</translation>
+<translation id="918192811481327695">‏کمک به بهبود ویژگی‌ها و عملکرد Brave</translation>
+<translation id="9063160602596686558">‏به‌طور خودکار آمار کاربرد و گزارش‌های خرابی را به Brave Software ارسال می‌کند</translation>
+<translation id="4824958205181053313">همگام‌سازی لغو شود؟</translation>
+<translation id="3058498974290601450">هرزمان خواستید می‌توانید همگام‌سازی را در تنظیمات روشن کنید</translation>
+<translation id="3143515551205905069">لغو همگام‌سازی</translation>
+<translation id="1506061864768559482">موتور جستجو</translation>
+<translation id="55737423895878184">مکان و اعلان‌ها مجاز هستند</translation>
+<translation id="3988213473815854515">مکان مجاز است</translation>
+<translation id="32895400574683172">اعلان‌ها مجاز هستند</translation>
+<translation id="9040142327097499898">اعلان‌ها مجاز هستند. مکان برای این دستگاه خاموش است.</translation>
+<translation id="305593374596241526">‏مکان خاموش است، آن را در <ph name="BEGIN_LINK"/>تنظیمات Android<ph name="END_LINK"/> روشن کنید.</translation>
+<translation id="2989523299700148168">اخیراً دیده‌شده</translation>
+<translation id="6433501201775827830">انتخاب موتور جستجو</translation>
+<translation id="7177466738963138057">می‌توانید بعداً این مورد را در تنظیمات تغییر دهید</translation>
+<translation id="3478363558367712427">می‌توانید موتور جستجویتان را انتخاب کنید</translation>
+<translation id="4910889077668685004">برنامه‌های پرداخت</translation>
+<translation id="5152843274749979095">هیچ برنامه پشتیبانی‌شده‌ای نصب نشده است</translation>
+<translation id="8812260976093120287">در بعضی از وب‌سایت‌ها، می‌توانید با برنامه‌های پرداخت پشتیبانی‌شده بالا در دستگاهتان پرداخت کنید.</translation>
+<translation id="7764225426217299476">افزودن آدرس</translation>
+<translation id="5595485650161345191">ویرایش آدرس</translation>
+<translation id="5087580092889165836">افزودن کارت</translation>
+<translation id="2154484045852737596">ویرایش کارت</translation>
+<translation id="6140912465461743537">کشور/منطقه</translation>
+<translation id="5659593005791499971">ایمیل</translation>
+<translation id="4378154925671717803">تلفن</translation>
+<translation id="4807098396393229769">نام روی کارت</translation>
+<translation id="860043288473659153">نام صاحب کارت</translation>
+<translation id="2612676031748830579">شماره کارت</translation>
+<translation id="869891660844655955">تاریخ انقضا</translation>
+<translation id="2286841657746966508">آدرس ارسال صورتحساب</translation>
+<translation id="663059986967017181">‏کپی در Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> روش پرداخت دیگر}one{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> روش پرداخت دیگر}other{‏<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> روش پرداخت دیگر}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> نشانی دیگر}one{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> نشانی دیگر}other{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> نشانی دیگر}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> گزینه دیگر}one{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> گزینه دیگر}other{‏<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> گزینه دیگر}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{‏<ph name="CONTACT_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> گزینه تماس دیگر}one{‏<ph name="CONTACT_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> گزینه تماس دیگر}other{‏<ph name="CONTACT_PREVIEW"/>\u2026 و <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> گزینه تماس دیگر}}</translation>
+<translation id="7029809446516969842">گذرواژه‌ها</translation>
+<translation id="1943432128510653496">ذخیره گذرواژه‌ها</translation>
+<translation id="2100273922101894616">ورود به سیستم خودکار</translation>
+<translation id="363596933471559332">با استفاده از اعتبارنامه‌های ذخیره شده، به‌طور خودکار به سیستم وب‌سایت‌ها وارد شوید. وقتی این قابلیت خاموش است، هر بار قبل از وارد شدن به سیستم وب‌سایت از شما خواسته می‌شود اطلاعات را تأیید کنید.</translation>
+<translation id="6995899638241819463">اگر گذرواژه‌ها به دلیل نقض داده لو رفته باشد، هشدار می‌دهد</translation>
+<translation id="1534287762301776620">‏وقتی به «حساب Brave Software» خود وارد می‌شوید، این ویژگی روشن می‌شود</translation>
+<translation id="10614374240317010">هرگز ذخیره نمی‌شود</translation>
+<translation id="3098842761938485917">‏در <ph name="BEGIN_LINK"/>حساب Brave Software<ph name="END_LINK"/> خود گذرواژه‌های ذخیره‌شده را مشاهده و مدیریت کنید</translation>
+<translation id="8562452229998620586">گذرواژه‌های ذخیره شده در اینجا ظاهر می‌شود.</translation>
+<translation id="8084114998886531721">گذرواژه ذخیره‌شده</translation>
+<translation id="2870560284913253234">سایت</translation>
+<translation id="8503813439785031346">نام کاربری</translation>
+<translation id="6657585470893396449">گذرواژه</translation>
+<translation id="2154710561487035718">کپی نشانی وب</translation>
+<translation id="1571304935088121812">کپی کردن نام کاربری</translation>
+<translation id="5005498671520578047">کپی گذرواژه</translation>
+<translation id="3632295766818638029">نمایش گذرواژه</translation>
+<translation id="1513858653616922153">حذف گذرواژه</translation>
+<translation id="543338862236136125">ویرایش گذرواژه</translation>
+<translation id="4565377596337484307">عدم نمایش گذرواژه</translation>
+<translation id="8523928698583292556">حذف گذرواژه ذخیره‌شده</translation>
+<translation id="2898264748040935573">ویرایش گذرواژه ذخیره‌شده</translation>
+<translation id="5433691172869980887">نام کاربری کپی شد</translation>
+<translation id="5534640966246046842">سایت کپی شد</translation>
+<translation id="2625189173221582860">گذرواژه کپی شد</translation>
+<translation id="4550003330909367850">برای مشاهده یا کپی کردن گذرواژه‌تان در اینجا، قفل صفحه را در این دستگاه تنظیم کنید.</translation>
+<translation id="6154478581116148741">برای صادر کردن گذرواژه‌ها از این دستگاه، قفل صفحه را در تنظیمات روشن کنید.</translation>
+<translation id="4842092870884894799">نمایش پنجره تولید گذرواژه</translation>
+<translation id="2259659629660284697">درحال صادر کردن گذرواژه‌ها…</translation>
+<translation id="133012818630824069">‏صادر کردن گذرواژه‌های ذخیره‌شده در Brave</translation>
+<translation id="6914783257214138813">گذرواژه‌های شما برای همه افرادی که می‌توانند فایل صادرشده را ببینید، نمایان خواهند بود.</translation>
+<translation id="2321086116217818302">درحال آماده‌سازی گذرواژه‌ها…</translation>
+<translation id="8445448999790540984">گذرواژه‌ها صادر نشدند</translation>
+<translation id="3066461326500799725">‏آشنایی با نحوه استفاده از Brave Software Drive</translation>
+<translation id="729975465115245577">دستگاه شما برنامه‌ای برای ذخیره فایل گذرواژه‌ها ندارد.</translation>
+<translation id="7682724950699840886">نکات زیر را امتحان کنید: مطمئن شوید که در دستگاهتان فضای کافی وجود داشته باشد، سعی کنید دوباره صادر کنید.</translation>
+<translation id="1129510026454351943">جزئیات: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">برای کپی کردن گذرواژه‌تان، قفل صفحه را باز کنید</translation>
+<translation id="5515439363601853141">برای مشاهده گذرواژه‌تان، قفل صفحه را باز کنید</translation>
+<translation id="6221633008163990886">برای صادر کردن گذرواژه‌ها، قفل را باز کنید</translation>
+<translation id="230699814587342492">‏گذرواژه‌های Brave</translation>
+<translation id="6075798973483050474">ویرایش صفحه اصلی</translation>
+<translation id="854522910157234410">باز کردن این صفحه</translation>
+<translation id="2482878487686419369">اعلان‌ها</translation>
+<translation id="6255999984061454636">پیشنهادهای محتوا</translation>
+<translation id="805047784848435650">براساس سابقه مرور شما</translation>
+<translation id="1041308826830691739">از وب‌سایت‌ها</translation>
+<translation id="395206256282351086">پیشنهادهای جستجو و سایت غیرفعال است</translation>
+<translation id="257088987046510401">طرح‌‌های قسمت</translation>
+<translation id="4650364565596261010">پیش‌فرض سیستم</translation>
+<translation id="7588219262685291874">روشن شدن طرح زمینه تیره وقتی «بهینه‌سازی باتری» دستگاه روشن است</translation>
+<translation id="2760989362628427051">روشن شدن طرح زمینه تیره وقتی طرح زمینه تیره دستگاه یا «بهینه‌سازی باتری» روشن است</translation>
+<translation id="6381421346744604172">تاریک کردن وب‌سایت‌ها</translation>
+<translation id="5040262127954254034">حریم خصوصی</translation>
+<translation id="4991384657077828949">‏کمک به بهبود امنیت Brave</translation>
+<translation id="1943176487615318915">‏برای حذف برنامه‌ها و سایت‌های خطرناک، Brave نشانی‌های وب برخی از صفحه‌هایی را که بازدید می‌کنید، اطلاعات سیستم محدود و برخی از محتوای صفحه را به Brave Software می‌فرستد.</translation>
+<translation id="3181954750937456830">مرور ایمن (از شما و دستگاهتان درمقابل سایت‌های خطرناک محافظت می‌کند)</translation>
+<translation id="7315322926489145388">‏اگر امنیتتان درخطر باشد، نشانی وب برخی از صفحه‌هایی را که بازدید می‌کنید به Brave Software می‌فرستد</translation>
+<translation id="2063713494490388661">ضربه برای جستجو</translation>
+<translation id="2369463299479365221">‏بدون ترک کردن صفحه با موضوعات وب‌سایت‌ها آشنا شوید. «ضربه برای جستجو»، کلمه و متن اطراف آن را به «جستجوی Brave Software» ارسال می‌کند و معانی، تصاویر، نتایج جستجو و سایر جزئیات را بازمی‌گرداند.
 
 عبارت جستجو را با فشار طولانی انتخاب و تنظیم کنید. برای تصحیح جستجویتان، پانل را به‌طور کامل به بالا بلغزانید و روی کادر جستجو ضربه بزنید.</translation>
-<translation id="4056223980640387499">سپیا</translation>
-<translation id="4060598801229743805">گزینه‌هایی در نزدیکی بالای صفحه دردسترس هستند</translation>
-<translation id="4062305924942672200">اطلاعات حقوقی</translation>
-<translation id="4084682180776658562">نشانک</translation>
-<translation id="4084712963632273211">‏از<ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />توسط Google ارائه می‌شود<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">داده‌های برنامه پاک شود؟</translation>
-<translation id="4099578267706723511">‏‫با ارسال آمار کاربرد و گزارش‌های خرابی به Google، به بهتر شدن Chrome کمک کنید.</translation>
-<translation id="410351446219883937">پخش خودکار</translation>
-<translation id="4116038641877404294">برای استفاده از صفحه‌ها در حالت آفلاین، آن‌ها را بارگیری کنید</translation>
-<translation id="4135200667068010335">فهرست دستگاه‌هایی که می‌توان با آن‌ها برگه هم‌رسانی کرد، بسته است.</translation>
-<translation id="4149994727733219643">نمای ساده‌شده برای صفحه‌های وب</translation>
-<translation id="4165986682804962316">تنظیمات سایت</translation>
-<translation id="4169535189173047238">اجازه داده نشود</translation>
-<translation id="4170011742729630528">این سرویس در دسترس نیست؛ بعداً دوباره امتحان کنید.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> استفاده‌شده</translation>
-<translation id="4181841719683918333">زبان‌ها</translation>
-<translation id="4183868528246477015">‏جستجو با «لنز Google» <ph name="BEGIN_NEW" />جدید<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">باز کردن در برگهٔ جدید</translation>
-<translation id="4198423547019359126">مکانی برای بارگیری دردسترس نیست</translation>
-<translation id="4209895695669353772">‏برای اینکه Google محتوای شخصی‌شده به شما پیشنهاد دهد، همگام‌سازی را روشن کنید</translation>
-<translation id="4226663524361240545">اعلان‌ها ممکن است دستگاه را بلرزانند</translation>
-<translation id="423219824432660969">‏رمزگذاری داده‌های همگام‌سازی‌شده با گذرواژه Google از <ph name="TIME" /></translation>
-<translation id="4242533952199664413">باز کردن تنظیمات</translation>
-<translation id="4256782883801055595">مجوزهای متن‌باز</translation>
-<translation id="4259722352634471385">پیمایش مسدود شده است: <ph name="URL" /></translation>
-<translation id="4269820728363426813">کپی نشانی پیوند</translation>
-<translation id="4275663329226226506">رسانه</translation>
-<translation id="4278390842282768270">مجاز است</translation>
-<translation id="429312253194641664">سایتی درحال پخش رسانه است</translation>
-<translation id="4298388696830689168">سایت‌های مرتبط</translation>
-<translation id="4307992518367153382">موارد اصلی</translation>
-<translation id="4314815835985389558">مدیریت همگام‌سازی</translation>
-<translation id="4351244548802238354">بستن کادر گفتگو</translation>
-<translation id="4378154925671717803">تلفن</translation>
-<translation id="4384468725000734951">‏استفاده از Sogou برای جستجو</translation>
-<translation id="4404568932422911380">هیچ نشانکی موجود نیست</translation>
-<translation id="4405224443901389797">انتقال به…</translation>
-<translation id="4411535500181276704">حالت ساده</translation>
-<translation id="4415276339145661267">‏مدیریت حساب Google</translation>
-<translation id="4432792777822557199">از این به بعد، صفحه‌های <ph name="SOURCE_LANGUAGE" />، به <ph name="TARGET_LANGUAGE" /> ترجمه خواهند شد</translation>
-<translation id="4433925000917964731">‏صفحه ساده‌شده را Google ارائه کرده است</translation>
-<translation id="4434045419905280838">پنجره‌های بازشو و هدایت‌ها</translation>
-<translation id="4440958355523780886">‏صفحه ساده‌شده را Google ارائه کرده است. برای بارگیری صفحه اصلی، ضربه بزنید.</translation>
-<translation id="4452411734226507615">بستن برگه <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">در <ph name="FOLDER_NAME" /> نشانک گذاشته شد</translation>
-<translation id="445467742685312942">به سایت‌ها اجازه داده شود محتوای محافظت‌شده پخش کنند</translation>
-<translation id="4468959413250150279">سایتی خاص بی‌صدا شود.</translation>
-<translation id="4472118726404937099">برای همگام‌سازی و شخصی‌سازی در همه دستگاه‌ها، به سیستم وارد شوید و همگام‌سازی را روشن کنید</translation>
-<translation id="447252321002412580">‏کمک به بهبود ویژگی‌ها و عملکرد Chrome</translation>
-<translation id="4479647676395637221">قبل از اجازه به سایت‌ها برای استفاده از دوربین، ابتدا سؤال شود (توصیه می‌شود)</translation>
-<translation id="4479972344484327217">‏درحال نصب <ph name="MODULE" /> برای Chrome…</translation>
-<translation id="4487967297491345095">‏همه داده‌های برنامه Chrome به‌طور دائم حذف خواهند شد. این داده‌ها شامل همه فایل‌ها، تنظیمات، حساب‌ها، پایگاه‌های داده و غیره می‌شود.</translation>
-<translation id="4493497663118223949">«حالت ساده» روشن است</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{۱ روز قبل}one{#  روز قبل}other{#  روز قبل}}</translation>
-<translation id="451872707440238414">جستجوی نشانک‌های شما</translation>
-<translation id="4521489764227272523">‏داده‌های انتخاب‌‌شده از Chrome و دستگاه‌های همگام‌سازی‌شده شما حذف شدند.
-
-ممکن است اشکال دیگری از سابقه مرورتان در حساب Google شما وجود داشته باشد، مانند جستجو‌ها و فعالیت دیگر سرویس‌های Google در <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">انتخاب پوشه</translation>
-<translation id="4538018662093857852">روشن کردن حالت ساده</translation>
-<translation id="4550003330909367850">برای مشاهده یا کپی کردن گذرواژه‌تان در اینجا، قفل صفحه را در این دستگاه تنظیم کنید.</translation>
-<translation id="4558311620361989323">میان‌برهای صفحه وب</translation>
-<translation id="4561979708150884304">اتصال برقرار نیست</translation>
-<translation id="4565377596337484307">عدم نمایش گذرواژه</translation>
-<translation id="4570913071927164677">جزئیات</translation>
-<translation id="4572422548854449519">به حساب مدیریت‌شده وارد شوید</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# دقیقه قبل}one{# دقیقه قبل}other{# دقیقه قبل}}</translation>
-<translation id="4587589328781138893">سایت‌ها</translation>
-<translation id="4594952190837476234">این صفحه آفلاین مربوط به تاریخ <ph name="CREATION_TIME" /> است و ممکن است با نسخه آنلاین متفاوت باشد.</translation>
-<translation id="4605958867780575332">مورد حذف شد: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">باز کردن <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">استفاده از گذرواژه</translation>
-<translation id="4645575059429386691">مدیریت شده توسط والدین شما</translation>
-<translation id="4650364565596261010">پیش‌فرض سیستم</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> نشانک حذف شد</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> به صفحه اصلی شما اضافه شد</translation>
-<translation id="4684427112815847243">همگام‌سازی همه</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> گزینه دیگر}one{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> گزینه دیگر}other{‏<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> گزینه دیگر}}</translation>
-<translation id="4696983787092045100">ارسال نوشتار به دستگاه‌های شما</translation>
-<translation id="4698034686595694889">مشاهده آفلاین در <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">تصاویر و فایل‌های قرار گرفته در حافظه پنهان</translation>
-<translation id="4714588616299687897">صرفه‌جویی تا ۶۰ درصد داده‌ها</translation>
-<translation id="4719927025381752090">پیشنهاد برای ترجمه</translation>
-<translation id="4720023427747327413">بازکردن در <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">‏به بهبود Chrome کمک کنید. <ph name="BEGIN_LINK" />در نظرسنجی شرکت کنید<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">به‌روزرسانی</translation>
-<translation id="4738836084190194332">آخرین همگام‌سازی: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">باز کردن برگه جدید</translation>
-<translation id="4751476147751820511">حسگرهای نوری یا حرکتی</translation>
-<translation id="4759238208242260848">بارگیری‌ها</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{۱ بارگیری کامل شد.}one{# بارگیری کامل شد.}other{# بارگیری کامل شد.}}</translation>
-<translation id="4797039098279997504">برای برگشتن به <ph name="URL_OF_THE_CURRENT_TAB" />، لمس کنید</translation>
-<translation id="4802417911091824046">‏رمزگذاری عبارت ورود شامل روش‌های پرداخت و نشانی‌های موجود در Google Pay نمی‌شود.
-
-برای تغییر این تنظیم، <ph name="BEGIN_LINK" />همگام‌سازی را بازنشانی کنید<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">نام روی کارت</translation>
-<translation id="4824958205181053313">همگام‌سازی لغو شود؟</translation>
-<translation id="4837753911714442426">باز کردن گزینه‌های چاپ صفحه</translation>
-<translation id="4842092870884894799">نمایش پنجره تولید گذرواژه</translation>
-<translation id="4860895144060829044">تماس</translation>
-<translation id="4866368707455379617">‏<ph name="MODULE" /> برای Chrome نصب نشد</translation>
-<translation id="4875775213178255010">محتواهای پیشنهادی</translation>
-<translation id="4878404682131129617">برقراری تونل ازطریق سرور پروکسی ناموفق بود</translation>
-<translation id="4880127995492972015">ترجمه…</translation>
-<translation id="4881695831933465202">باز کردن</translation>
-<translation id="488187801263602086">تغییر نام فایل</translation>
-<translation id="4882831918239250449">کنترل نحوه استفاده از سابقه مرور برای شخصی‌سازی «جستجو»، آگهی‌ها و موارد دیگر</translation>
-<translation id="4883854917563148705">تنظیمات مدیریت‌شده بازنشانی نشدند</translation>
-<translation id="4885273946141277891">‏این تعداد از نسخه‌های Chrome پشتیبانی نمی‌شود.</translation>
-<translation id="4910889077668685004">برنامه‌های پرداخت</translation>
-<translation id="4913161338056004800">بازنشانی آمار</translation>
-<translation id="4913169188695071480">توقف تازه‌سازی</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />دریافت راهنمایی<ph name="END_LINK" /> درحین اسکن دستگاه‌ها…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# صفحه}one{# صفحه}other{# صفحه}}</translation>
-<translation id="4932247056774066048">‏از آنجایی‌که درحال خروج از سیستم حساب مدیریت‌شده توسط <ph name="DOMAIN_NAME" /> هستید، داده‌های Chrome شما از این دستگاه حذف می‌شود. این مورد در حساب Google شما باقی می‌ماند.</translation>
-<translation id="4943703118917034429">واقعیت مجازی</translation>
-<translation id="4943872375798546930">نتیجه‌ای پیدا نشد</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> درحال اشتراک‌گذاری صفحه شما است</translation>
-<translation id="4961107849584082341">ترجمه این صفحه به زبان‌های دیگر</translation>
-<translation id="4962975101802056554">لغو همه مجوزها برای دستگاه</translation>
-<translation id="4970824347203572753">در مکان شما دردسترس نیست</translation>
-<translation id="497421865427891073">جلو رفتن</translation>
-<translation id="4988210275050210843">درحال بارگیری فایل (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">صفحات</translation>
-<translation id="4994033804516042629">مخاطبی پیدا نشد</translation>
-<translation id="4996978546172906250">اشتراک‌گذاری از طریق</translation>
-<translation id="5004416275253351869">‏کنترل‌های فعالیت Google</translation>
-<translation id="5005498671520578047">کپی گذرواژه</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> می‌خواهد مرتبط شود</translation>
-<translation id="5013696553129441713">هیچ پیشنهاد جدیدی نیست</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">‏درمدتی که در حالت VR هستید، این سایت می‌تواند به این‌ها پی‌ببرد:
-  -  ویژگی‌های فیزیکی، مانند قد شما
-
-پیش از وارد شدن به VR، مطمئن شوید به این سایت اعتماد دارید.</translation>
+<translation id="2930742481329940825">‏«ضربه برای جستجو» کلمه انتخاب‌شده و صفحه کنونی را به‌عنوان متن جستجو به «جستجوی Brave Software» ارسال می‌کند. می‌توانید این ویژگی را در <ph name="BEGIN_LINK"/>تنظیمات<ph name="END_LINK"/> خاموش کنید.</translation>
 <translation id="5039804452771397117">اجازه دادن</translation>
-<translation id="5040262127954254034">حریم خصوصی</translation>
-<translation id="5048398596102334565">مجاز بودن دسترسی سایت‌ها به حسگرهای حرکتی (توصیه می‌شود)</translation>
-<translation id="5063480226653192405">کاربر </translation>
-<translation id="5087580092889165836">افزودن کارت</translation>
-<translation id="5100237604440890931">کوچک شده - برای بزرگ کردن کلیک کنید.</translation>
-<translation id="510275257476243843">۱ ساعت باقی‌مانده است</translation>
-<translation id="5123685120097942451">برگه ناشناس</translation>
-<translation id="5127805178023152808">همگام‌سازی خاموش است</translation>
-<translation id="5129038482087801250">نصب برنامه وب</translation>
-<translation id="5132942445612118989">همگام‌سازی گذرواژه‌ها، سابقه و موارد دیگر در همه دستگاه‌ها</translation>
-<translation id="5139940364318403933">‏آشنایی با نحوه استفاده از Google Drive</translation>
-<translation id="515227803646670480">پاک کردن داده ذخیره شده</translation>
-<translation id="5152843274749979095">هیچ برنامه پشتیبانی‌شده‌ای نصب نشده است</translation>
-<translation id="5161254044473106830">عنوان مورد نیاز است</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{۱ بارگیری انجام نشد.}one{# بارگیری انجام نشد.}other{# بارگیری انجام نشد.}}</translation>
-<translation id="5170568018924773124">نمایش در پوشه</translation>
-<translation id="5184329579814168207">‏باز کردن در Chrome</translation>
-<translation id="5193988420012215838">در بریده‌دان کپی شد</translation>
-<translation id="5197729504361054390">مخاطبین انتخابی شما با <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> هم‌رسانی می‌شود.</translation>
-<translation id="5199929503336119739">نمایه کاری</translation>
-<translation id="5210286577605176222">رفتن به برگه قبلی</translation>
-<translation id="5210365745912300556">بستن برگه</translation>
-<translation id="5224771365102442243">دارای ویدیو</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> می‌خواهد دستگاه‌های «بلوتوث» اطراف را جستجو کند. دستگاه‌های زیر پیدا شدند:</translation>
-<translation id="5233638681132016545">برگه جدید</translation>
-<translation id="526421993248218238">این صفحه بار نشد</translation>
-<translation id="5271967389191913893">دستگاه نمی‌تواند محتوا را برای بارگیری باز کند.</translation>
-<translation id="528192093759286357">برای خروج از حالت تمام صفحه، از بالا صفحه را بکشید و دکمه برگشت را لمس کنید.</translation>
-<translation id="5292796745632149097">ارسال به</translation>
-<translation id="5300589172476337783">نمایش</translation>
-<translation id="5301954838959518834">بله، متوجه شدم</translation>
-<translation id="5304593522240415983">این قسمت باید پر شود</translation>
-<translation id="5307446750509046227">پاک کردن فضای ذخیره‌سازی سایت</translation>
-<translation id="5308380583665731573">اتصال</translation>
-<translation id="5313967007315987356">افزودن سایت</translation>
-<translation id="5317780077021120954">ذخیره</translation>
-<translation id="5324858694974489420">تنظیمات والدین</translation>
-<translation id="5327248766486351172">نام</translation>
-<translation id="5335288049665977812">مجاز کردن همه سایت‌ها برای اجرای جاوااسکریپت (توصیه‌ می‌شود)</translation>
-<translation id="5342314432463739672">درخواست‌های مجوز</translation>
-<translation id="5357811892247919462">برگه دریافت شد</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> برگه باز، برای جستجوی برگه ضربه بزنید}one{<ph name="OPEN_TABS_MANY" /> برگه باز، برای جستجوی برگه ضربه بزنید}other{<ph name="OPEN_TABS_MANY" /> برگه باز، برای جستجوی برگه ضربه بزنید}}</translation>
-<translation id="5391532827096253100">اتصال شما به این سایت امن نیست. اطلاعات سایت</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ ۱ مورد دیگر)}one{(+ # مورد دیگر)}other{(+ # مورد دیگر)}}</translation>
-<translation id="5400569084694353794">‏استفاده از این برنامه به معنای اعلام موافقت شما با <ph name="BEGIN_LINK1" />شرایط خدمات<ph name="END_LINK1" /> و <ph name="BEGIN_LINK2" />اعلامیه حریم خصوصی<ph name="END_LINK2" /> Chrome است.</translation>
-<translation id="5403592356182871684">نام‌ها</translation>
-<translation id="5403644198645076998">فقط بعضی از سایت‌ها مجاز هستند</translation>
-<translation id="5414836363063783498">در حال تأیید...</translation>
-<translation id="5423934151118863508">صفحاتی که بیشترین بازدید را از آنها داشته‌اید در اینجا نمایان می‌شوند</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> گیگابایت در دسترس</translation>
-<translation id="543338862236136125">ویرایش گذرواژه</translation>
-<translation id="5433691172869980887">نام کاربری کپی شد</translation>
-<translation id="543509235395288790">درحال بارگیری <ph name="COUNT" /> فایل (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">رفتن به نوار نشانی</translation>
-<translation id="5447201525962359567">همه فضای ذخیره سایت‌ها، ازجمله کوکی‌ها و سایر داده‌های ذخیره‌شده در دستگاه</translation>
-<translation id="5447765697759493033">این سایت ترجمه نخواهد شد</translation>
-<translation id="545042621069398927">درحال سرعت بخشیدن به بارگیری.</translation>
-<translation id="5456381639095306749">بارگیری صفحه</translation>
-<translation id="5475862044948910901">جلسه «واقعیت افزوده» شروع شود؟</translation>
-<translation id="548278423535722844">‏باز کردن در برنامه Maps</translation>
-<translation id="5487521232677179737">پاک کردن داده‌ها</translation>
-<translation id="5494752089476963479">آگهی سایت‌هایی که آگهی‌های مزاحم یا گمراه‌کننده نشان می‌دهند، مسدود می‌شود</translation>
-<translation id="5500777121964041360">ممکن است در مکان شما دردسترس نباشد</translation>
-<translation id="5512137114520586844"><ph name="PARENT_NAME" /> این حساب را مدیریت می‌کند.</translation>
-<translation id="5514904542973294328">توسط سرپرست این دستگاه غیرفعال شده است</translation>
-<translation id="5515439363601853141">برای مشاهده گذرواژه‌تان، قفل صفحه را باز کنید</translation>
-<translation id="5516455585884385570">باز کردن تنظیمات اعلان</translation>
-<translation id="5517095782334947753">نشانک، سابقه، گذرواژه و تنظیمات دیگری از <ph name="FROM_ACCOUNT" /> دارید.</translation>
-<translation id="5524843473235508879">هدایت کردن مسدود شد.</translation>
-<translation id="5527082711130173040">‏Chrome برای جستجوی دستگاه‌ها باید به مکان دسترسی داشته باشد. <ph name="BEGIN_LINK1" />به‌روزرسانی مجوزها<ph name="END_LINK1" /> . دسترسی به مکان نیز <ph name="BEGIN_LINK2" />برای این دستگاه خاموش است<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">قبل از اینکه به سایت‌ها اجازه داده شود به نوشتار و تصاویر بریده‌دان دسترسی پیدا کنند سؤال شود (توصیه می‌شود)</translation>
-<translation id="5530766185686772672">بستن برگه‌های ناشناس</translation>
-<translation id="5534334044554683961">‏درمدتی که در حالت VR هستید، این سایت می‌تواند به این‌ها پی‌ببرد:
-  -   ویژگی‌های فیزیکی، مانند قد شما
-  -   چیدمان اتاقتان
-
-پیش از وارد شدن به VR، مطمئن شوید به این سایت اعتماد دارید.</translation>
-<translation id="5534640966246046842">سایت کپی شد</translation>
-<translation id="5556459405103347317">تازه‌سازی</translation>
-<translation id="5561549206367097665">در انتظار شبکه…</translation>
-<translation id="557283862590186398">‏Chrome برای این سایت به مجوز دسترسی به میکروفون نیاز دارد.</translation>
-<translation id="55737423895878184">مکان و اعلان‌ها مجاز هستند</translation>
-<translation id="5578795271662203820">جستجوی <ph name="SEARCH_ENGINE" /> برای این تصویر</translation>
-<translation id="5581519193887989363">هرزمان خواستید می‌توانید مواردی را که می‌خواهید همگام‌سازی شود در <ph name="BEGIN_LINK1" />تنظیمات<ph name="END_LINK1" /> انتخاب کنید.</translation>
-<translation id="5595485650161345191">ویرایش آدرس</translation>
-<translation id="5596627076506792578">گزینه‌های بیشتر</translation>
-<translation id="5599455543593328020">حالت ناشناس</translation>
-<translation id="5620928963363755975">با استفاده از دکمه «گزینه‌های بیشتر»، فایل‌ها و صفحه‌هایتان را در «بارگیری‌ها» پیدا کنید</translation>
-<translation id="5626134646977739690">نام:</translation>
-<translation id="5639724618331995626">همه سایت‌ها مجاز هستند</translation>
-<translation id="5648166631817621825">۷ روز گذشته</translation>
-<translation id="5649053991847567735">بارگیری‌های خودکار</translation>
-<translation id="5655963694829536461">بارگیری‌هایتان را جستجو کنید</translation>
-<translation id="5659593005791499971">ایمیل</translation>
-<translation id="5665379678064389456">ایجاد رویداد در <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">لغو درخواست وب‌سایت برای جلوگیری از بزرگ‌نمایی</translation>
-<translation id="5677928146339483299">مسدود است</translation>
-<translation id="5684874026226664614">متأسفیم. این صفحه ترجمه نشد.</translation>
-<translation id="5686790454216892815">نام فایل خیلی طولانی است</translation>
-<translation id="5689516760719285838">مکان</translation>
-<translation id="569536719314091526">با استفاده از دکمه «گزینه‌های بیشتر»، این صفحه را به زبان‌های دیگر ترجمه کنید</translation>
-<translation id="572328651809341494">برگه‌های اخیر</translation>
-<translation id="5726692708398506830">بزرگ‌تر کردن همه‌چیز در صفحه</translation>
-<translation id="5748802427693696783">به برگه‌های استاندارد تغییر یافت</translation>
-<translation id="5749068826913805084">‏Chrome برای بارگیری فایل‌ها باید به حافظه دسترسی داشته باشد.</translation>
-<translation id="5763382633136178763">برگه‌های ناشناس</translation>
-<translation id="5763514718066511291">برای کپی کردن نشانی وب این برنامه ضربه بزنید</translation>
-<translation id="5765780083710877561">توضیح:</translation>
-<translation id="5793665092639000975">درحال استفاده از <ph name="SPACE_USED" /> از <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">‏Google ممکن است از سابقه مرور شما برای شخصی کردن جستجو، آگهی‌ها و سایر سرویس‌های Google استفاده کند</translation>
-<translation id="5804241973901381774">مجوزها</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{۱ ساعت قبل}one{# ساعت قبل}other{# ساعت قبل}}</translation>
-<translation id="5810288467834065221">‏حق نسخه‌برداری <ph name="YEAR" /> Google LLC.‎ کلیه حقوق محفوظ است.</translation>
-<translation id="5817918615728894473">مرتبط‌سازی</translation>
-<translation id="583281660410589416">ناشناس</translation>
-<translation id="5833984609253377421">اشتراک‌گذاری پیوند</translation>
-<translation id="5836192821815272682">‏درحال بارگیری به‌روزرسانی Chrome…</translation>
-<translation id="5853623416121554550">مکث</translation>
-<translation id="5854790677617711513">قدیمی‌تر از ۳۰ روز</translation>
-<translation id="5858741533101922242">‏Chrome قادر به روشن کردن آداپتور بلوتوث نیست</translation>
-<translation id="5860033963881614850">خاموش</translation>
-<translation id="5862731021271217234">برای اینکه به برگه‌های بازشده در سایر دستگاه‌ها دسترسی داشته باشید، همگام‌سازی را روشن کنید</translation>
-<translation id="5864174910718532887">جزئیات: مرتب‌شده براساس نام سایت</translation>
-<translation id="5864419784173784555">در انتظار بارگیری موردی دیگر…</translation>
-<translation id="5865733239029070421">‏به‌طور خودکار آمار کاربرد و گزارش‌های خرابی را به Google ارسال می‌کند</translation>
-<translation id="5869522115854928033">گذرواژه‌های ذخیره‌شده</translation>
-<translation id="5902828464777634901">تمام داده‌های محلی ذخیره شده مرتبط با این وب‌سایت، از جمله کوکی‌ها، حذف می‌شوند.</translation>
-<translation id="5916664084637901428">روشن</translation>
-<translation id="5919204609460789179">برای شروع همگام‌سازی، <ph name="PRODUCT_NAME" /> را به‌روزرسانی کنید</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> صرفه‌جویی‌شده</translation>
-<translation id="5939518447894949180">بازنشانی</translation>
-<translation id="5942872142862698679">‏استفاده از Google برای جستجو</translation>
-<translation id="5952764234151283551">‏نشانی وب صفحه‌ای را که باز می‌کنید به Google ارسال می‌کند</translation>
-<translation id="5956665950594638604">‏باز کردن مرکز راهنمایی Chrome در برگه جدید</translation>
-<translation id="5958275228015807058">فایل‌ها و صفحه‌هایتان را در «بارگیری‌ها» پیدا کنید</translation>
-<translation id="5962718611393537961">برای کوچک کردن ضربه بزنید</translation>
-<translation id="6000066717592683814">‏حفظ Google</translation>
-<translation id="6005538289190791541">گذرواژه پیشنهادی</translation>
-<translation id="6036057147555329831">‏ICU اضافی</translation>
-<translation id="6039379616847168523">رفتن به برگه بعدی</translation>
-<translation id="6040143037577758943">بستن</translation>
-<translation id="6042308850641462728">بیشتر</translation>
-<translation id="604996488070107836">به‌دلیل خطایی ناشناس، بارگیری <ph name="FILE_NAME" /> انجام نشد.</translation>
-<translation id="605721222689873409">سال</translation>
-<translation id="6064125863973209585">بارگیری‌های کامل‌شده</translation>
-<translation id="6075798973483050474">ویرایش صفحه اصلی</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> ساعت باقی‌مانده است</translation>
-<translation id="6108923351542677676">تنظیم در حال انجام است...</translation>
-<translation id="6111020039983847643">داده مصرف‌شده</translation>
-<translation id="6112702117600201073">درحال بازخوانی صفحه</translation>
-<translation id="6127379762771434464">مورد برداشته شد</translation>
-<translation id="6140912465461743537">کشور/منطقه</translation>
-<translation id="614940544461990577">این موارد را امتحان کنید:</translation>
-<translation id="6154478581116148741">برای صادر کردن گذرواژه‌ها از این دستگاه، قفل صفحه را در تنظیمات روشن کنید.</translation>
-<translation id="6159335304067198720">ذخیره داده‌ها: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">بیشتر بدانید</translation>
-<translation id="6177111841848151710">برای موتور جستجوی فعلی مسدود شده است</translation>
-<translation id="6181444274883918285">افزودن سایتی به استثناها</translation>
-<translation id="6192333916571137726">فایل بارگیری</translation>
-<translation id="6192792657125177640">موارد استثنا</translation>
-<translation id="6194112207524046168">‏برای اینکه به Chrome امکان دهید به دوربین دسترسی یابد، در <ph name="BEGIN_LINK" />تنظیمات Android<ph name="END_LINK" /> هم دوربین را روشن کنید.</translation>
-<translation id="6196640612572343990">مسدود کردن کوکی‌های شخص ثالث</translation>
-<translation id="6206551242102657620">اتصال امن است. اطلاعات سایت</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> ایمیل شما نیست؟</translation>
-<translation id="6221633008163990886">برای صادر کردن گذرواژه‌ها، قفل را باز کنید</translation>
+<translation id="1406000523432664303">«ردیابی نشود»</translation>
 <translation id="6232535412751077445">فعال کردن «ردیابی نشود» به این معنی است که درخواستی به ترافیک مرور شما اضافه می‌شود. نتیجه به این بستگی دارد که وب‌سایت به درخواست‌ پاسخ بدهد یا نه و درخواست چگونه تفسیر شود.
 
 مثلاً ممکن است برخی از وب‌سایت‌ها با نمایش آگهی‌هایی که براساس وب‌سایت‌های نیستند که بازدید کرده‌اید به این درخواست پاسخ دهند. بسیاری از وب‌سایت‌ها همچنان داده‌های محصول مرور شما را جمع‌آوری و استفاده می‌کنند — مثلاً برای بهبود امنیت، ارائه محتوا، آگهی‌ها و توصیه‌ها و برای ایجاد آمارهای گزارش‌دهی.</translation>
-<translation id="624789221780392884">به‌روزرسانی آماده است</translation>
-<translation id="6255999984061454636">پیشنهادهای محتوا</translation>
-<translation id="6277522088822131679">در چاپ صفحه مشکلی پیش آمد. لطفاً دوباره امتحان کنید.</translation>
-<translation id="6295158916970320988">همه سایت‌ها</translation>
-<translation id="629730747756840877">حساب</translation>
-<translation id="6303969859164067831">خروج از سیستم و خاموش کردن همگام‌سازی</translation>
-<translation id="6316139424528454185">‏نسخه Android پشتیبانی نمی‌شود</translation>
-<translation id="6320088164292336938">لرزش</translation>
-<translation id="6324034347079777476">‏همگام‌سازی سیستم Android غیرفعال شد</translation>
-<translation id="6333140779060797560">اشتراک‌گذاری از طریق <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">رمزگذاری</translation>
-<translation id="6341580099087024258">مکان ذخیره شدن فایل‌ها پرسیده شود</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> نشانی دیگر}one{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> نشانی دیگر}other{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> نشانی دیگر}}</translation>
-<translation id="6364438453358674297">پیشنهاد از سابقه حذف شود؟</translation>
-<translation id="6369229450655021117">از اینجا می‌توانید وب را جستجو کنید، با دوستان هم‌رسانی کنید و صفحات باز را ببینید</translation>
-<translation id="6378173571450987352">جزئیات: مرتب‌شده براساس مقدار داده استفاده‌شده</translation>
-<translation id="6381421346744604172">تاریک کردن وب‌سایت‌ها</translation>
-<translation id="6388207532828177975">پاک کردن و بازنشانی</translation>
-<translation id="6393863479814692971">‏Chrome برای این سایت به مجوز دسترسی به دوربین و میکروفون نیاز دارد.</translation>
-<translation id="6395288395575013217">پیوند</translation>
-<translation id="6404511346730675251">ویرایش نشانک</translation>
-<translation id="6406506848690869874">همگام‌سازی</translation>
-<translation id="641643625718530986">چاپ...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> مگابایت بارگیری شد</translation>
-<translation id="6427112570124116297">وب را ترجمه کنید</translation>
-<translation id="6433501201775827830">انتخاب موتور جستجو</translation>
-<translation id="6437478888915024427">اطلاعات صفحه</translation>
-<translation id="6441734959916820584">نام خیلی طولانی است</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# تصویر}one{# تصویر}other{# تصویر}}</translation>
-<translation id="6447842834002726250">کوکی‌ها</translation>
-<translation id="6461962085415701688">فایل باز نمی‌شود</translation>
-<translation id="6464977750820128603">‏می‌توانید سایت‌هایی را که در Chrome بازدید می‌کنید مشاهده کنید و تایمرهایی را برای آن‌ها تنظیم کنید.\n\n‏Google اطلاعاتی درباره سایت‌هایی که برای آن‌ها تایمر تنظیم می‌کنید و مدت زمانی که از آن‌ها بازدید می‌کنید، دریافت می‌کند. از این اطلاعات برای بهبود «آسایش دیجیتالی» استفاده می‌شود.</translation>
-<translation id="6475951671322991020">بارگیری ویدیو</translation>
-<translation id="6482749332252372425">به‌دلیل نبودن فضای ذخیره‌سازی، بارگیری <ph name="FILE_NAME" /> انجام نشد.</translation>
-<translation id="6496823230996795692">برای استفاده از <ph name="APP_NAME" /> برای اولین‌ بار، لطفاً به اینترنت وصل شوید.</translation>
-<translation id="6508722015517270189">‏Chrome را راه‌اندازی مجدد کنید</translation>
-<translation id="6527303717912515753">اشتراک‌گذاری</translation>
-<translation id="6532866250404780454">‏سایت‌هایی که در Chrome بازدید می‌کنید، نشان داده نخواهد شد. همه تایمرهای سایت حذف خواهد شد.</translation>
-<translation id="6534565668554028783">‏پاسخ Google بیش از حد طول کشیده است</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> گیگابایت بارگیری شد</translation>
-<translation id="6539092367496845964">مشکلی پیش آمد. بعداً دوباره امتحان کنید.</translation>
-<translation id="654446541061731451">برگه‌ای برای انتقال با پرتو انتخاب کنید</translation>
-<translation id="6545017243486555795">پاک کردن همه داده‌ها</translation>
-<translation id="6545864417968258051">اسکن کردن بلوتوث</translation>
-<translation id="6560414384669816528">‏جستجو با Sogou</translation>
-<translation id="6566259936974865419">‏Chrome‏ <ph name="GIGABYTES" /> گیگابایت از داده‌های شما را ذخیره کرده است</translation>
-<translation id="6573096386450695060">همیشه مجاز</translation>
-<translation id="6573431926118603307">‏برگه‌هایی که در دستگاه‌های دیگر در Chrome باز کرده‌اید، در اینجا نمایان می‌شوند.</translation>
-<translation id="6583199322650523874">نشانک گذاشتن صفحه کنونی</translation>
-<translation id="6593061639179217415">سایت مخصوص رایانه</translation>
-<translation id="6600954340915313787">‏کپی در Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> گیگابایت</translation>
-<translation id="6612358246767739896">محتوای محافظت‌شده</translation>
-<translation id="6627583120233659107">ویرایش پوشه</translation>
-<translation id="6643016212128521049">پاک کردن</translation>
-<translation id="6643649862576733715">مرتب‌سازی براساس مقدار داده صرفه‌جویی‌شده</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{‏<ph name="CONTACT_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> گزینه تماس دیگر}one{‏<ph name="CONTACT_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> گزینه تماس دیگر}other{‏<ph name="CONTACT_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> گزینه تماس دیگر}}</translation>
-<translation id="6649642165559792194">پیش‌نمایش تصویر <ph name="BEGIN_NEW" />جدید<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">‏Chrome برای جستجوی دستگاه‌ها باید به مکان دسترسی داشته باشد. <ph name="BEGIN_LINK" />به‌روزرسانی مجوزها<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">گذرواژه</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">باز کردن در <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">‏اخطار حریم خصوصی Chrome</translation>
-<translation id="6676840375528380067">‏داده‌های Chrome شما از این دستگاه پاک شود؟</translation>
-<translation id="6697492270171225480">نمایش پیشنهادهای صفحه‌های مشابه وقتی صفحه‌ای پیدا نمی‌شود</translation>
-<translation id="6697947395630195233">‏Chrome برای اشتراک‌گذاری مکانتان با این سایت باید به مکانتان دسترسی داشته باشد.</translation>
-<translation id="6698801883190606802">مدیریت داده‌های همگام‌سازی شده</translation>
-<translation id="6699370405921460408">‏سرورهای Google صفحه‌هایی را که بازدید می‌کنید بهینه می‌کنند.</translation>
-<translation id="6706288973712894588">‏درحال حاضر آفلاین هستید.\n<ph name="BEGIN_LINK" />فید آفلاین خود را کاوش کنید.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">اخبار</translation>
-<translation id="6710213216561001401">قبلی</translation>
-<translation id="671481426037969117">تایمر <ph name="FQDN" /> شما متوقف شد. دوباره فردا شروع به کار می‌کند.</translation>
-<translation id="6738867403308150051">در حال بارگیری…</translation>
-<translation id="6746124502594467657">انتقال به پایین</translation>
-<translation id="6766622839693428701">برای بستن، تند به پایین بکشید.</translation>
-<translation id="6766758767654711248">برای رفتن به سایت، ضربه بزنید</translation>
-<translation id="6767294960381293877">فهرست نیمه‌باز دستگاه‌هایی که می‌توان با آن‌ها برگه هم‌رسانی کرد.</translation>
-<translation id="6782111308708962316">جلوگیری از ذخیره کردن و خواندن داده‌های کوکی توسط وب‌سایت‌های شخص ثالث</translation>
-<translation id="6790428901817661496">پخش</translation>
-<translation id="6811034713472274749">صفحه آماده مشاهده است</translation>
-<translation id="6818926723028410516">انتخاب موارد</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">ترجمه</translation>
-<translation id="6845325883481699275">‏کمک به بهبود امنیت Chrome</translation>
-<translation id="6846298663435243399">در حال بارگیری…</translation>
-<translation id="6850409657436465440">بارگیری هنوز درحال انجام است</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> برگه بسته شد</translation>
-<translation id="6864459304226931083">بارگیری تصویر</translation>
-<translation id="6865313869410766144">تکمیل خودکار داده‌های فرم</translation>
-<translation id="688738109438487280">افزودن داده‌های موجود به <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">برای کپی کردن گذرواژه‌تان، قفل صفحه را باز کنید</translation>
-<translation id="6896758677409633944">کپی</translation>
-<translation id="6910211073230771657">حذف شد</translation>
-<translation id="6912998170423641340">سایت‌ها از خواندن نوشتار و تصاویر بریده‌دان منع شوند</translation>
-<translation id="6914783257214138813">گذرواژه‌های شما برای همه افرادی که می‌توانند فایل صادرشده را ببینید، نمایان خواهند بود.</translation>
-<translation id="6942665639005891494">هرزمان بخواهید می‌توانید با استفاده از منوی «تنظیمات»، محل پیش‌فرض بارگیری را تغییر دهید</translation>
-<translation id="6945221475159498467">انتخاب</translation>
-<translation id="6963642900430330478">این صفحه خطرناک است. اطلاعات سایت</translation>
-<translation id="6963766334940102469">حذف نشانک‌ها</translation>
-<translation id="6965382102122355670">قبول</translation>
-<translation id="6979737339423435258">از ابتدا تا الآن</translation>
-<translation id="6981982820502123353">قابلیت دسترسی</translation>
-<translation id="6989267951144302301">بارگیری نشد</translation>
-<translation id="6990079615885386641">‏دریافت برنامه از فروشگاه Google Play: ‏<ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">قبل از اجازه به سایت‌ها برای استفاده از میکروفون ابتدا سؤال شود (توصیه می‌شود)</translation>
-<translation id="7015203776128479407">راه‌اندازی اولیه همگام‌سازی کامل نشد. همگام‌سازی خاموش است.</translation>
-<translation id="7016516562562142042">برای موتور جستجوی فعلی مجاز است</translation>
-<translation id="7022756207310403729">بازکردن در مرورگر</translation>
-<translation id="702463548815491781">‏توصیه در زمانی‌که TalkBack یا «دسترسی سوئیچ» روشن است</translation>
-<translation id="7029809446516969842">گذرواژه‌ها</translation>
-<translation id="7053983685419859001">مسدود کردن</translation>
-<translation id="7055152154916055070">هدایت کردن مسدود شده است:</translation>
-<translation id="7063006564040364415">اتصال به سرور همگام‌سازی ممکن نیست.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{۱ مورد انتخاب شد}one{# مورد انتخاب شد}other{# مورد انتخاب شد}}</translation>
-<translation id="7071521146534760487">مدیریت حساب</translation>
-<translation id="7077143737582773186">‏کارت SD</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> مورد انتخاب شد.  گزینه‌ها در نزدیکی بالای صفحه دردسترس است</translation>
-<translation id="7121362699166175603">‏سابقه و تکمیل‌های خودکار را در نوار نشانی پاک می‌کند. ممکن است حساب Google شما اشکال دیگری از سابقه مرور در <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> داشته باشد.</translation>
-<translation id="7128222689758636196">مجاز کردن موتور جستجوی کنونی</translation>
-<translation id="7138678301420049075">دیگر</translation>
-<translation id="7141896414559753902">مسدود کردن نمایش پنجره‌های بازشو و هدایت‌ها در سایت‌ها (توصیه می‌شود)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />بار کردن صفحه اصلی<ph name="END_LINK" /> از <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">۲۴ ساعت گذشته</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> کیلوبایت</translation>
-<translation id="7177466738963138057">می‌توانید بعداً این مورد را در تنظیمات تغییر دهید</translation>
-<translation id="7180611975245234373">بازخوانی</translation>
-<translation id="7189372733857464326">‏در انتظار «سرویس‌های Google Play» برای اتمام به‌روزرسانی است</translation>
-<translation id="7191430249889272776">برگه در پس‌زمینه باز شد.</translation>
-<translation id="723171743924126238">انتخاب تصاویر</translation>
-<translation id="7233236755231902816">‏برای اینکه وب را به زبان خود ببینید، آخرین نسخه Chrome را دریافت کنید</translation>
-<translation id="7243308994586599757">گزینه‌ها در نزدیک پایین صفحه نمایش در دسترس هستند</translation>
-<translation id="7248069434667874558">‏مطمئن شوید همگام‌سازی <ph name="TARGET_DEVICE_NAME" /> در Chrome روشن باشد</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> مورد انتخاب شد</translation>
-<translation id="7274013316676448362">سایت مسدودشده</translation>
-<translation id="7290209999329137901">عدم‌دسترسی به تغییر نام</translation>
-<translation id="7291387454912369099">تسویه‌حساب فعال‌شده ازسوی دستیار</translation>
-<translation id="7293171162284876153">‏برای شروع همگام‌سازی، «همگام‌سازی داده‌های Chrome» را روشن کنید.</translation>
-<translation id="729975465115245577">دستگاه شما برنامه‌ای برای ذخیره فایل گذرواژه‌ها ندارد.</translation>
-<translation id="7302081693174882195">جزئیات: مرتب‌شده براساس مقدار داده صرفه‌جویی‌شده</translation>
-<translation id="7328017930301109123">‏در «حالت ساده»، Chrome صفحه‌ها را سریع‌تر بار می‌کند و تا ۶۰ درصد مصرف داده را کاهش می‌دهد.</translation>
-<translation id="7333031090786104871">همچنان درحال افزودن سایت قبلی</translation>
-<translation id="7352939065658542140">ویدیو</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{اشتراک‌گذاری ۱ مورد انتخاب‌شده}one{اشتراک‌گذاری # مورد انتخاب‌شده}other{اشتراک‌گذاری # مورد انتخاب‌شده}}</translation>
 <translation id="7359002509206457351">دسترسی به روش‌های پرداخت</translation>
+<translation id="8026334261755873520">پاک کردن داده‌های مرور</translation>
+<translation id="1291207594882862231">پاک کردن سابقه، کوکی‌ها، داده‌های سایت، حافظه پنهان…</translation>
+<translation id="7814200940910057384">‏داده‌های Brave پاک شد</translation>
+<translation id="1664855196866195614">‏داده‌های انتخاب‌‌شده از Brave و دستگاه‌های همگام‌سازی‌شده شما حذف شدند.
+
+ممکن است اشکال دیگری از سابقه مرورتان در حساب Brave Software شما وجود داشته باشد، مانند جستجو‌ها و فعالیت دیگر سرویس‌های Brave Software در <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">تصاویر و فایل‌های قرار گرفته در حافظه پنهان</translation>
+<translation id="2496180316473517155">سابقه مرور</translation>
+<translation id="2546283357679194313">کوکی‌ها و داده‌های سایت</translation>
+<translation id="8662811608048051533">شما را از سیستم اکثر سایت‌ها خارج می‌کند.</translation>
+<translation id="8218628800671693884">‏شما را از سیستم اکثر سایت‌ها خارج می‌‌کند. از سیستم حساب Brave Software خارج نمی‌شوید.</translation>
+<translation id="2017836877785168846">سابقه و تکمیل خودکار را در نوار نشانی پاک می‌کند.</translation>
+<translation id="8096327394278038498">‏سابقه و تکمیل‌های خودکار را در نوار نشانی پاک می‌کند. ممکن است حساب Brave Software شما اشکال دیگری از سابقه مرور در <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> داشته باشد.</translation>
+<translation id="8122693181154564064">‏سابقه را از همه دستگاه‌های به سیستم واردشده پاک می‌کند. ممکن است حساب Brave Software شما اشکال دیگری از سابقه مرور در <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> داشته باشد.</translation>
+<translation id="5869522115854928033">گذرواژه‌های ذخیره‌شده</translation>
+<translation id="6865313869410766144">تکمیل خودکار داده‌های فرم</translation>
+<translation id="7562080006725997899">پاک کردن داده‌های مرور</translation>
+<translation id="5487521232677179737">پاک کردن داده‌ها</translation>
+<translation id="7498271377022651285">لطفاً صبر کنید...</translation>
+<translation id="784934925303690534">محدوده زمانی</translation>
+<translation id="1718835860248848330">ساعت قبل</translation>
+<translation id="7149893636342594995">۲۴ ساعت گذشته</translation>
+<translation id="5648166631817621825">۷ روز گذشته</translation>
+<translation id="8571213806525832805">۴ هفته گذشته</translation>
+<translation id="5854790677617711513">قدیمی‌تر از ۳۰ روز</translation>
+<translation id="6979737339423435258">از ابتدا تا الآن</translation>
+<translation id="982182592107339124">با این کار داده‌های همه سایت‌ها پاک می‌شود، از جمله:</translation>
+<translation id="6643016212128521049">پاک کردن</translation>
+<translation id="7641339528570811325">پاک کردن داده‌های محصول مرور…</translation>
+<translation id="1670399744444387456">پایه</translation>
+<translation id="3245261285041759672">‏ممکن است حساب Brave Software شما اشکال دیگری از سابقه مرور در <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> داشته باشد.</translation>
+<translation id="7274013316676448362">سایت مسدودشده</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> مورد حذف شد</translation>
+<translation id="1121094540300013208">آمار استفاده و گزارش‌های خرابی</translation>
+<translation id="9079153198295609735">‏ارسال خودکار آمار کاربرد و گزارش‌های خرابی به Brave Software</translation>
+<translation id="6981982820502123353">قابلیت دسترسی</translation>
+<translation id="2387895666653383613">اندازه قلم نوشتار</translation>
+<translation id="2321958826496381788">لغزنده را بکشید تا زمانی که بتوانید این متن را به راحتی بخوانید. بعد از دو ضربه متوالی روی یک پاراگراف، اندازه نوشتار حداقل باید به این بزرگی باشد.</translation>
+<translation id="3895926599014793903">فعال کردن اجباری بزرگ‌نمایی</translation>
+<translation id="5668404140385795438">لغو درخواست وب‌سایت برای جلوگیری از بزرگ‌نمایی</translation>
+<translation id="4149994727733219643">نمای ساده‌شده برای صفحه‌های وب</translation>
+<translation id="9100505651305367705">پیشنهاد نمایش مقالات در نمای ساده‌شده، درصورت پشتیبانی</translation>
+<translation id="1409426117486808224">نمای ساده‌شده برای برگه‌های باز</translation>
+<translation id="702463548815491781">‏توصیه در زمانی‌که TalkBack یا «دسترسی سوئیچ» روشن است</translation>
+<translation id="8284326494547611709">زیرنویس‌ها</translation>
+<translation id="4165986682804962316">تنظیمات سایت</translation>
+<translation id="6295158916970320988">همه سایت‌ها</translation>
+<translation id="8380167699614421159">این سایتْ آگهی‌های مزاحم یا گمراه‌کننده نشان می‌دهد</translation>
+<translation id="1919345977826869612">آگهی‌ها</translation>
+<translation id="410351446219883937">پخش خودکار</translation>
+<translation id="6447842834002726250">کوکی‌ها</translation>
+<translation id="6196640612572343990">مسدود کردن کوکی‌های شخص ثالث</translation>
+<translation id="6782111308708962316">جلوگیری از ذخیره کردن و خواندن داده‌های کوکی توسط وب‌سایت‌های شخص ثالث</translation>
+<translation id="7521387064766892559">جاوا اسکریپت</translation>
+<translation id="4434045419905280838">پنجره‌های بازشو و هدایت‌ها</translation>
+<translation id="4751476147751820511">حسگرهای نوری یا حرکتی</translation>
+<translation id="1717218214683051432">حسگرهای حرکتی</translation>
+<translation id="2091887806945687916">صدا</translation>
+<translation id="2586657967955657006">بریده‌دان</translation>
+<translation id="6320088164292336938">لرزش</translation>
+<translation id="4226663524361240545">اعلان‌ها ممکن است دستگاه را بلرزانند</translation>
+<translation id="1446450296470737166">‏اجازه کنترل کامل دستگاه‌های MIDI</translation>
+<translation id="3744111561329211289">همگام‌سازی پس‌زمینه</translation>
+<translation id="5649053991847567735">بارگیری‌های خودکار</translation>
+<translation id="6181444274883918285">افزودن سایتی به استثناها</translation>
+<translation id="5313967007315987356">افزودن سایت</translation>
+<translation id="1369915414381695676">سایت <ph name="SITE_NAME"/> اضافه شد</translation>
+<translation id="7837721118676387834">به پخش‌خودکار ویدیو‌های صامت‌شده برای سایتی خاص امکان دهید.</translation>
+<translation id="2621115761605608342">جاوااسکریپت را برای سایتی خاص مجاز کنید.</translation>
+<translation id="8801436777607969138">مسدود کردن جاوااسکریپت برای سایتی خاص.</translation>
+<translation id="8372893542064058268">«همگام‌سازی پس‌زمینه» را برای یک سایت خاص مجاز کنید.</translation>
+<translation id="358794129225322306">به سایت اجازه داده شود چند فایل را به‌طور خودکار بارگیری کند.</translation>
+<translation id="4008040567710660924">کوکی‌ها را برای سایت خاصی مجاز کنید.</translation>
+<translation id="8958424370300090006">کوکی‌ها را برای سایت خاصی مسدود کنید.</translation>
+<translation id="7882806643839505685">پخش صدا برای سایت خاصی مجاز شود.</translation>
+<translation id="4468959413250150279">سایتی خاص بی‌صدا شود.</translation>
+<translation id="1994173015038366702">نشانی وب سایت</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">کاربر</translation>
+<translation id="5804241973901381774">مجوزها</translation>
+<translation id="4278390842282768270">مجاز است</translation>
+<translation id="5677928146339483299">مسدود است</translation>
+<translation id="1984937141057606926">مجاز، به غیر از طرف ثالث</translation>
+<translation id="7423098979219808738">ابتدا سؤال شود</translation>
+<translation id="8116925261070264013">صامت‌شده</translation>
+<translation id="8300705686683892304">مدیریت‌شده توسط برنامه</translation>
+<translation id="6192792657125177640">موارد استثنا</translation>
+<translation id="257931822824936280">بزرگ‌شده - برای کوچک کردن کلیک کنید.</translation>
+<translation id="5100237604440890931">کوچک شده - برای بزرگ کردن کلیک کنید.</translation>
+<translation id="857943718398505171">مجاز (توصیه می‌شود)</translation>
+<translation id="2913331724188855103">سایت‌ها مجاز به ذخیره و خواندن داده‌های کوکی باشند (توصیه می‌شود)</translation>
+<translation id="7445411102860286510">اجازه به سایت‌ها برای پخش خودکار ویدیوهای صامت‌شده (توصیه می‌شود)</translation>
+<translation id="5335288049665977812">مجاز کردن همه سایت‌ها برای اجرای جاوااسکریپت (توصیه‌ می‌شود)</translation>
+<translation id="5527111080432883924">قبل از اینکه به سایت‌ها اجازه داده شود به نوشتار و تصاویر بریده‌دان دسترسی پیدا کنند سؤال شود (توصیه می‌شود)</translation>
+<translation id="6912998170423641340">سایت‌ها از خواندن نوشتار و تصاویر بریده‌دان منع شوند</translation>
+<translation id="7423538860840206698">خواندن محتوای بریده‌دان مسدود شد</translation>
+<translation id="3955193568934677022">به سایت‌ها اجازه داده شود محتوای محافظت‌شده پخش کنند (توصیه می‌شود)</translation>
+<translation id="445467742685312942">به سایت‌ها اجازه داده شود محتوای محافظت‌شده پخش کنند</translation>
+<translation id="2107397443965016585">قبل از اجازه به سایت‌ها برای پخش محتوای محافظت‌شده سؤال شود (توصیه می‌شود)</translation>
+<translation id="2910701580606108292">قبل از اجازه دادن به سایت‌ها برای پخش محتوای محافظت‌شده سؤال شود</translation>
+<translation id="757524316907819857">مسدود کردن سایت‌ها برای پخش محتوای محافظت‌شده</translation>
+<translation id="3277252321222022663">مجاز بودن دسترسی سایت‌ها به حسگرها (توصیه می‌شود)</translation>
+<translation id="5048398596102334565">مجاز بودن دسترسی سایت‌ها به حسگرهای حرکتی (توصیه می‌شود)</translation>
+<translation id="8816026460808729765">سایت‌ها نمی‌توانند به حسگرها دسترسی داشته باشند</translation>
+<translation id="169515064810179024">سایت‌ها نمی‌توانند به حسگرهای حرکتی دسترسی داشته باشند</translation>
+<translation id="1660204651932907780">به سایت‌ها اجازه داده شود صدا پخش کنند (توصیه می‌شود)</translation>
+<translation id="3600792891314830896">سایت‌هایی که صدا پخش می‌کنند بی‌صدا شوند</translation>
+<translation id="1743802530341753419">قبل از اجازه دادن به سایت‌ها برای اتصال به دستگاه سؤال شود (توصیه می‌شود)</translation>
+<translation id="851751545965956758">مسدود کردن سایت‌ها برای اتصال به دستگاه‌ها</translation>
+<translation id="7141896414559753902">مسدود کردن نمایش پنجره‌های بازشو و هدایت‌ها در سایت‌ها (توصیه می‌شود)</translation>
+<translation id="5494752089476963479">آگهی سایت‌هایی که آگهی‌های مزاحم یا گمراه‌کننده نشان می‌دهند، مسدود می‌شود</translation>
+<translation id="3123473560110926937">در برخی سایت‌ها مسدود می‌شود</translation>
+<translation id="965817943346481315">اگر سایتْ آگهی‌های مزاحم یا گمراه‌کننده نشان می‌دهد مسدود شود (توصیه می‌شود)</translation>
+<translation id="3386292677130313581">قبل از اجازه به سایت‌ها برای اطلاع از مکانتان، ابتدا سؤال شود (توصیه می‌شود)</translation>
+<translation id="9139068048179869749">قبل از اجازه به سایت‌ها برای ارسال اعلان ابتدا سؤال شود (توصیه می‌شود)</translation>
+<translation id="4479647676395637221">قبل از اجازه به سایت‌ها برای استفاده از دوربین، ابتدا سؤال شود (توصیه می‌شود)</translation>
+<translation id="6992289844737586249">قبل از اجازه به سایت‌ها برای استفاده از میکروفون ابتدا سؤال شود (توصیه می‌شود)</translation>
+<translation id="2289270750774289114">وقتی سایتی می‌خواهد دستگا‌ه‌های بلوتوث اطراف را پیدا کند، سؤال شود (توصیه می‌شود)</translation>
+<translation id="7053983685419859001">مسدود کردن</translation>
+<translation id="7128222689758636196">مجاز کردن موتور جستجوی کنونی</translation>
+<translation id="7589445247086920869">مسدود کردن موتور جستجوی کنونی</translation>
+<translation id="6388207532828177975">پاک کردن و بازنشانی</translation>
+<translation id="7999064672810608036">مطمئنید که می‌خواهید تمام داده‌های محلی، شامل کوکی‌ها را حذف کنید و تمام مجوزهای این وب‌سایت را بازنشانی کنید؟</translation>
+<translation id="2822354292072154809">مطمئن‌اید می‌خواهید همه مجوزهای سایت مربوط به <ph name="CHOSEN_OBJECT_NAME"/> را بازنشانی کنید؟</translation>
+<translation id="515227803646670480">پاک کردن داده ذخیره شده</translation>
+<translation id="5902828464777634901">تمام داده‌های محلی ذخیره شده مرتبط با این وب‌سایت، از جمله کوکی‌ها، حذف می‌شوند.</translation>
+<translation id="119944043368869598">پاک کردن همه</translation>
+<translation id="2490684707762498678">تحت مدیریت <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">باز کردن تنظیمات اعلان</translation>
+<translation id="1404122904123200417">جاسازی‌شده در <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">فایل‌هایی را که وب‌سایت‌ها ذخیره کرده‌اند، در اینجا نمایش داده می‌شود</translation>
+<translation id="4181841719683918333">زبان‌ها</translation>
+<translation id="2647434099613338025">افزودن زبان</translation>
+<translation id="1952172573699511566">درصورت امکان، وب‌سایت‌ها نوشتار را به زبان ترجیحی شما نمایش می‌دهند.</translation>
+<translation id="8559990750235505898">پیشنهاد ترجمه صفحات نوشته‌شده به زبان‌های دیگر</translation>
+<translation id="4719927025381752090">پیشنهاد برای ترجمه</translation>
+<translation id="8156139159503939589">به چه زبانی مطالعه می‌کنید؟</translation>
+<translation id="5689516760719285838">مکان</translation>
+<translation id="2440823041667407902">دسترسی به موقعیت مکانی</translation>
+<translation id="2023546461831060654">‏مجوزهای Brave را در <ph name="BEGIN_LINK"/>تنظیمات Android <ph name="END_LINK"/> روشن کنید.</translation>
+<translation id="6665548517310046133">‏مجوز Brave را در <ph name="BEGIN_LINK"/>تنظیمات Android <ph name="END_LINK"/> روشن کنید.</translation>
+<translation id="2928908108430545745">‏برای اینکه به Brave امکان دهید به مکانتان دسترسی یابد، در <ph name="BEGIN_LINK"/>تنظیمات Android<ph name="END_LINK"/> هم مکان را روشن کنید.</translation>
+<translation id="1028853271388022585">‏برای اینکه به Brave امکان دهید به دوربین دسترسی یابد، در <ph name="BEGIN_LINK"/>تنظیمات Android<ph name="END_LINK"/> هم دوربین را روشن کنید.</translation>
+<translation id="2913721282607281710">‏برای اینکه به Brave امکان دهید برایتان اعلان ارسال کند، در <ph name="BEGIN_LINK"/>تنظیمات Android<ph name="END_LINK"/> هم اعلان‌ها را روشن کنید.</translation>
+<translation id="8753483718490035722">‏برای اینکه به Brave امکان دهید به میکروفون دسترسی یابد، در <ph name="BEGIN_LINK"/>تنظیمات Android<ph name="END_LINK"/> هم میکروفون را روشن کنید.</translation>
+<translation id="1887786770086287077">‏دسترسی به مکان برای این دستگاه خاموش است. آن را در <ph name="BEGIN_LINK"/>تنظیمات Android<ph name="END_LINK"/> روشن کنید.</translation>
+<translation id="2570922361219980984">‏دسترسی به مکان برای این دستگاه نیز خاموش است. آن را در <ph name="BEGIN_LINK"/>تنظیمات Android<ph name="END_LINK"/> روشن کنید.</translation>
+<translation id="1620510694547887537">دوربین</translation>
+<translation id="3227137524299004712">میکروفن</translation>
+<translation id="1647391597548383849">دسترسی به دوربین</translation>
+<translation id="945632385593298557">دسترسی به میکروفن</translation>
+<translation id="6612358246767739896">محتوای محافظت‌شده</translation>
+<translation id="885701979325669005">فضای ذخیره‌سازی</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> داده‌های ذخیره شده</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">لغو مجوز دستگاه</translation>
+<translation id="4962975101802056554">لغو همه مجوزها برای دستگاه</translation>
+<translation id="6545864417968258051">اسکن کردن بلوتوث</translation>
+<translation id="4411535500181276704">حالت ساده</translation>
+<translation id="7821588508402923572">میزان داده صرفه‌جویی‌شده اینجا نشان داده می‌شود</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> صرفه‌جویی شد</translation>
+<translation id="8569404424186215731">از <ph name="DATE"/></translation>
+<translation id="3252158532344029638">‏در «حالت ساده»، Brave صفحه‌ها را سریع‌تر بار می‌کند و تا ۶۰ درصد مصرف داده را کاهش می‌دهد.</translation>
+<translation id="6159335304067198720">ذخیره داده‌ها: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">داده صرفه‌جویی‌شده</translation>
+<translation id="6111020039983847643">داده مصرف‌شده</translation>
+<translation id="7413229368719586778">تاریخ شروع: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">تاریخ پایان: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">مرتب‌سازی براساس سایت</translation>
+<translation id="5864174910718532887">جزئیات: مرتب‌شده براساس نام سایت</translation>
+<translation id="116280672541001035">مصرف‌شده</translation>
+<translation id="8349013245300336738">مرتب‌سازی براساس مقدار داده استفاده‌شده</translation>
+<translation id="6378173571450987352">جزئیات: مرتب‌شده براساس مقدار داده استفاده‌شده</translation>
+<translation id="2631006050119455616">ذخیره شده</translation>
+<translation id="6643649862576733715">مرتب‌سازی براساس مقدار داده صرفه‌جویی‌شده</translation>
+<translation id="7302081693174882195">جزئیات: مرتب‌شده براساس مقدار داده صرفه‌جویی‌شده</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> استفاده‌شده</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> صرفه‌جویی‌شده</translation>
+<translation id="2156074688469523661">سایت‌های باقی‌مانده (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">دیگر</translation>
+<translation id="4913161338056004800">بازنشانی آمار</translation>
+<translation id="1856325424225101786">«حالت ساده» بازنشانی شود؟</translation>
+<translation id="3658159451045945436">بازنشانی باعث پاک شدن سابقه داده‌های ذخیره‌شده ازجمله فهرست سایت‌های بازدیدشده می‌شود.</translation>
+<translation id="3295530008794733555">سریع‌تر مرور کنید. از داده کمتری استفاده کنید.</translation>
+<translation id="7340390500800578919">‏در «حالت ساده»، Brave صفحه‌ها را سریع‌تر بار می‌کند و تا ۶۰ درصد مصرف داده را کاهش می‌دهد. برای بهینه‌سازی صفحاتی که بازدید می‌کنید، Brave ترافیک وب شما را به Brave Software ارسال می‌کند. <ph name="BEGIN_LINK"/>بیشتر بدانید<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">روشن کردن حالت ساده</translation>
+<translation id="4493497663118223949">«حالت ساده» روشن است</translation>
+<translation id="7559975015014302720">«حالت ساده» خاموش است</translation>
+<translation id="7606077192958116810">حالت ساده روشن است. آن را در «تنظیمات» مدیریت کنید.</translation>
+<translation id="4714588616299687897">صرفه‌جویی تا ۶۰ درصد داده‌ها</translation>
+<translation id="1006927014032731288">‏سرورهای Brave Software صفحه‌هایی را که بازدید می‌کنید بهینه می‌کنند.</translation>
+<translation id="3257320067425202300">‏Brave ‏<ph name="MEGABYTES"/> مگابایت از داده‌های شما را ذخیره کرده است</translation>
+<translation id="5813223329348543512">‏Brave‏ <ph name="GIGABYTES"/> گیگابایت از داده‌های شما را ذخیره کرده است</translation>
+<translation id="8266862848225348053">مکان بارگیری</translation>
+<translation id="7077143737582773186">‏کارت SD</translation>
+<translation id="7762668264895820836">‏کارت SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">مکان ذخیره شدن فایل‌ها پرسیده شود</translation>
+<translation id="6192333916571137726">فایل بارگیری</translation>
+<translation id="1672586136351118594">دیگر نشان داده نشود</translation>
+<translation id="2650751991977523696">فایل دوباره بارگیری شود؟</translation>
+<translation id="8664979001105139458">نام فایل از قبل وجود دارد</translation>
+<translation id="488187801263602086">تغییر نام فایل</translation>
+<translation id="5686790454216892815">نام فایل خیلی طولانی است</translation>
+<translation id="7454641608352164238">فضای کافی وجود ندارد</translation>
+<translation id="8972098258593396643">در پوشه پیش‌فرض بارگیری شود؟</translation>
+<translation id="804335162455518893">‏کارت SD پیدا نشد</translation>
+<translation id="7475688122056506577">‏کارت SD پیدا نشد. ممکن است بعضی از فایل‌هایتان جا بیافتد.</translation>
+<translation id="4198423547019359126">مکانی برای بارگیری دردسترس نیست</translation>
+<translation id="8224471946457685718">‏بارگیری مقالات برای شما با Wi-Fi</translation>
+<translation id="4970824347203572753">در مکان شما دردسترس نیست</translation>
+<translation id="5500777121964041360">ممکن است در مکان شما دردسترس نباشد</translation>
+<translation id="1173894706177603556">تغییر نام</translation>
+<translation id="1986685561493779662">نام ازقبل وجود دارد</translation>
+<translation id="6441734959916820584">نام خیلی طولانی است</translation>
+<translation id="2923908459366352541">نام نامعتبر است</translation>
+<translation id="7290209999329137901">عدم‌دسترسی به تغییر نام</translation>
+<translation id="3334729583274622784">پسوند فایل تغییر کند؟</translation>
+<translation id="107147699690128016">اگر پسوند فایل را تغییر دهید، ممکن است فایل در برنامه دیگری باز شود و به‌طور بالقوه برای دستگاه مضر باشد.</translation>
+<translation id="8541922081612557424">‏درباره Brave</translation>
+<translation id="5311273890481188673">‏حق نسخه‌برداری <ph name="YEAR"/> Brave Software LLC.‎ کلیه حقوق محفوظ است.</translation>
+<translation id="1416550906796893042">نسخه برنامه</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (زمان به‌روزرسانی <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">سیستم عامل</translation>
+<translation id="3968054912784331254">‏به‌روزرسانی‌های Brave دیگر در این نسخه Android پشتیبانی نمی‌شوند</translation>
+<translation id="7665369617277396874">افزودن حساب</translation>
+<translation id="649070405679044769">‏ثبت ورودشده در Brave Software به‌عنوان</translation>
+<translation id="6234515504547364178">‏خروج از سیستم Brave</translation>
+<translation id="5324858694974489420">تنظیمات والدین</translation>
+<translation id="8920114477895755567">در انتظار اطلاعات والدین.</translation>
+<translation id="5512137114520586844"><ph name="PARENT_NAME"/> این حساب را مدیریت می‌کند.</translation>
+<translation id="2956410042958133412"><ph name="PARENT_NAME_1"/> و <ph name="PARENT_NAME_2"/> این حساب را مدیریت می‌کنند.</translation>
+<translation id="8168435359814927499">محتوا</translation>
+<translation id="5403644198645076998">فقط بعضی از سایت‌ها مجاز هستند</translation>
+<translation id="8641930654639604085">سایت‌های مخصوص بزرگ‌سالان مسدود شوند</translation>
+<translation id="5639724618331995626">همه سایت‌ها مجاز هستند</translation>
+<translation id="796823723482603597">‏ارائه توسط Brave</translation>
+<translation id="6324034347079777476">‏همگام‌سازی سیستم Android غیرفعال شد</translation>
+<translation id="5127805178023152808">همگام‌سازی خاموش است</translation>
+<translation id="7015203776128479407">راه‌اندازی اولیه همگام‌سازی کامل نشد. همگام‌سازی خاموش است.</translation>
+<translation id="2497852260688568942">سرپرستتان همگام‌سازی را غیرفعال کرده است</translation>
+<translation id="9100610230175265781">عبارت عبور لازم است</translation>
+<translation id="6108923351542677676">تنظیم در حال انجام است...</translation>
+<translation id="4062305924942672200">اطلاعات حقوقی</translation>
+<translation id="4256782883801055595">مجوزهای متن‌باز</translation>
+<translation id="1138681184697033370">‏شرایط خدمات Brave</translation>
+<translation id="7392539049993970338">‏اخطار حریم خصوصی Brave</translation>
+<translation id="2677748264148917807">خروج</translation>
+<translation id="5556459405103347317">تازه‌سازی</translation>
+<translation id="1623104350909869708">جلوگیری از ایجاد پنجره‌های اضافی توسط این صفحه</translation>
+<translation id="2968755619301702150">بیننده گواهی</translation>
+<translation id="1360432990279830238">از سیستم خارج و همگام‌سازی خاموش شود؟</translation>
+<translation id="8581481290581777242">‏داده‌های Brave شما از این دستگاه پاک شود؟</translation>
+<translation id="1318865768845061710">‏نشانک‌ها، سابقه، گذرواژه‌ها و سایر داده‌های Brave، دیگر با حساب Brave Software شما همگام‌سازی نمی‌شود.</translation>
+<translation id="3325020657155065477">‏داده‌های این Brave هم از این دستگاه پاک شود</translation>
+<translation id="6136448902816743006">‏از آنجایی‌که درحال خروج از سیستم حساب مدیریت‌شده توسط <ph name="DOMAIN_NAME"/> هستید، داده‌های Brave شما از این دستگاه حذف می‌شود. این مورد در حساب Brave Software شما باقی می‌ماند.</translation>
+<translation id="1853026300647876496">‏درحال اتصال به Brave Software. ممکن است یک دقیقه طول بکشد…</translation>
+<translation id="2328985652426384049">ورود به سیستم امکان‌پذیر نیست</translation>
+<translation id="7723158744459952869">‏پاسخ Brave Software بیش از حد طول کشیده است</translation>
+<translation id="4572422548854449519">به حساب مدیریت‌شده وارد شوید</translation>
+<translation id="2689656545739939160">‏هم‌اکنون درحال ورود به سیستم با یک حساب مدیریت‌شده توسط <ph name="MANAGED_DOMAIN"/> و ارائه کنترل داده‌های Brave خودتان به سرپرست این حساب هستید. داده‌هایتان به‌طور دائم به این حساب مرتبط می‌شوند. با خروج از Brave، داده‌هایتان از این دستگاه حذف می‌شوند اما همچنان در حساب Brave Software شما باقی می‌ماند.</translation>
+<translation id="1749561566933687563">همگام‌سازی نشانک‌ها</translation>
+<translation id="4242533952199664413">باز کردن تنظیمات</translation>
+<translation id="1111673857033749125">نشانک‌های ذخیره‌شده در سایر دستگاه‌های شما در اینجا نشان داده می‌شوند.</translation>
+<translation id="8636825310635137004">برای دسترسی به برگه‌هایتان در دستگاه‌های دیگر، همگام‌سازی را روشن کنید.</translation>
+<translation id="3269956123044984603">‏برای دسترسی به برگه‌ها از دستگاه‌های دیگرتان، «همگام‌سازی خودکار داده‌ها» را در تنظیمات حساب Android روشن کنید.</translation>
+<translation id="5157964048453367290">‏برگه‌هایی که در دستگاه‌های دیگر در Brave باز کرده‌اید، در اینجا نمایان می‌شوند.</translation>
+<translation id="4684427112815847243">همگام‌سازی همه</translation>
+<translation id="2709516037105925701">تکمیل خودکار</translation>
+<translation id="8820817407110198400">نشانک‌ها</translation>
+<translation id="1644574205037202324">سابقه</translation>
+<translation id="17513872634828108">بازکردن برگه‌ها</translation>
+<translation id="1320169905922104972">‏کارت‌های اعتباری و نشانی‌های مورداستفاده در Brave Software Pay</translation>
+<translation id="6337234675334993532">رمزگذاری</translation>
+<translation id="6698801883190606802">مدیریت داده‌های همگام‌سازی شده</translation>
+<translation id="3598578758776312506">‏رمزگذاری گذرواژه‌ها با اعتبارنامه‌های Brave Software</translation>
+<translation id="7810580217418711046">‏رمزگذاری داده‌های همگام‌سازی‌شده با گذرواژه Brave Software از <ph name="TIME"/></translation>
+<translation id="8461694314515752532">رمزگذاری داده‌های همگام‌سازی‌شده با عبارت عبور همگام‌سازی خودتان</translation>
+<translation id="2996291259634659425">ایجاد عبارت عبور</translation>
+<translation id="5713644099811900409">‏حساب Brave Software</translation>
+<translation id="8997474919031554666">‏رمزگذاری عبارت ورود شامل روش‌های پرداخت و نشانی‌های موجود در Brave Software Pay نمی‌شود. فقط افرادی که عبارت عبورتان را داشته باشند می‌توانند داده‌های رمزگذاری‌شده‌تان را بخوانند. عبارت عبور به Brave Software ارسال یا در سرورهای آن ذخیره نمی‌شود. اگر عبارت عبورتان را فراموش کنید یا بخواهید این تنظیم را تغییر دهید، باید همگام‌سازی را بازنشانی کنید. <ph name="BEGIN_LINK"/>بیشتر بدانید<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">عبارت عبور</translation>
+<translation id="7772032839648071052">تأیید عبارت عبور</translation>
+<translation id="5304593522240415983">این قسمت باید پر شود</translation>
+<translation id="321773570071367578">اگر عبارت عبورتان را فراموش کردید یا می‌خواهید این تنظیم را تغییر دهید، <ph name="BEGIN_LINK"/>همگام‌سازی را بازنشانی کنید<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">عبارت‌های عبور مطابقت ندارند</translation>
+<translation id="5149495116300586333">‏رمزگذاری عبارت ورود شامل روش‌های پرداخت و نشانی‌های موجود در Brave Software Pay نمی‌شود.
+
+برای تغییر این تنظیم، <ph name="BEGIN_LINK"/>همگام‌سازی را بازنشانی کنید<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">عبارت عبور نادرست است</translation>
+<translation id="5414836363063783498">در حال تأیید...</translation>
+<translation id="6846298663435243399">در حال بارگیری…</translation>
+<translation id="5517095782334947753">نشانک، سابقه، گذرواژه و تنظیمات دیگری از <ph name="FROM_ACCOUNT"/> دارید.</translation>
+<translation id="3928666092801078803">ادغام کردن داده‌های من</translation>
+<translation id="688738109438487280">افزودن داده‌های موجود به <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">داده‌های من مجزا باشد</translation>
+<translation id="1145536944570833626">حذف داده‌های موجود.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> می‌خواهد مرتبط شود</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>دریافت راهنمایی<ph name="END_LINK"/> درحین اسکن دستگاه‌ها…</translation>
+<translation id="5817918615728894473">مرتبط‌سازی</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>دریافت راهنمایی<ph name="END_LINK1"/> یا <ph name="BEGIN_LINK2"/>اسکن مجدد<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">هیچ دستگاه سازگاری پیدا نشد</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>بلوتوث را روشن کنید<ph name="END_LINK"/> تا مرتبط‌سازی امکان‌پذیر شود</translation>
+<translation id="998321811308652668">‏Brave قادر به روشن کردن آداپتور بلوتوث نیست</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>دریافت راهنمایی<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">‏Brave برای جستجوی دستگاه‌ها باید به مکان دسترسی داشته باشد. <ph name="BEGIN_LINK"/>به‌روزرسانی مجوزها<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">‏Brave برای جستجوی دستگاه‌ها باید به مکان دسترسی داشته باشد. دسترسی به مکان <ph name="BEGIN_LINK"/>برای این دستگاه خاموش است<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">‏Brave برای جستجوی دستگاه‌ها باید به مکان دسترسی داشته باشد. <ph name="BEGIN_LINK1"/>به‌روزرسانی مجوزها<ph name="END_LINK1"/> . دسترسی به مکان نیز <ph name="BEGIN_LINK2"/>برای این دستگاه خاموش است<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">دستگاه متصل</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{سطح قدرت سیگنال: # نوار}one{سطح قدرت سیگنال: # نوار}other{سطح قدرت سیگنال: # نوار}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> می‌خواهد دستگاه‌های «بلوتوث» اطراف را جستجو کند. دستگاه‌های زیر پیدا شدند:</translation>
+<translation id="8368027906805972958">دستگاه ناشناس یا پشتیبانی‌نشده (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">همگام‌سازی کار نمی‌کند</translation>
+<translation id="1810845389119482123">همگام‌سازی اولیه کامل نشد</translation>
+<translation id="3235722914093408050">‏برای شروع همگام‌سازی Brave، تنظیمات Android را باز کنید و همگام‌سازی سیستم Android را دوباره فعال کنید</translation>
+<translation id="3367813778245106622">دوباره به سیستم وارد شوید یا همگام‌سازی را شروع کنید</translation>
+<translation id="974555521953189084">برای شروع همگام‌سازی، عبارت عبورتان را وارد کنید</translation>
+<translation id="2997266899014181325">‏برای شروع همگام‌سازی، «همگام‌سازی داده‌های Brave» را روشن کنید.</translation>
+<translation id="8260126382462817229">دوباره سعی کنید به سیستم وارد شوید</translation>
+<translation id="5919204609460789179">برای شروع همگام‌سازی، <ph name="PRODUCT_NAME"/> را به‌روزرسانی کنید</translation>
+<translation id="397583555483684758">همگام‌سازی متوقف شده است</translation>
+<translation id="1966710179511230534">لطفاً جزئیات ورود به سیستم را به‌روز کنید.</translation>
+<translation id="7063006564040364415">اتصال به سرور همگام‌سازی ممکن نیست.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> قدیمی است.</translation>
+<translation id="4170011742729630528">این سرویس در دسترس نیست؛ بعداً دوباره امتحان کنید.</translation>
+<translation id="7947953824732555851">پذیرش و ورود به سیستم</translation>
+<translation id="8583805026567836021">پاک‌سازی داده‌های حساب</translation>
+<translation id="8310344678080805313">برگه‌های استاندارد</translation>
+<translation id="5748802427693696783">به برگه‌های استاندارد تغییر یافت</translation>
+<translation id="7998918019931843664">بازکردن مجدد برگه‌های بسته شده</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>، برگه</translation>
+<translation id="4452411734226507615">بستن برگه <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">گزینه‌ها در نزدیک پایین صفحه نمایش در دسترس هستند</translation>
+<translation id="4060598801229743805">گزینه‌هایی در نزدیکی بالای صفحه دردسترس هستند</translation>
+<translation id="2810645512293415242">صفحه ساده‌شده برای ذخیره داده‌ها و بارگیری با سرعت بیشتر.</translation>
+<translation id="3985215325736559418">می‌خواهید دوباره <ph name="FILE_NAME"/> را بارگیری کنید؟</translation>
+<translation id="2450083983707403292">می‌خواهید بارگیری <ph name="FILE_NAME"/> را دوباره شروع کنید؟</translation>
+<translation id="7514365320538308">بارگیری</translation>
+<translation id="545042621069398927">درحال سرعت بخشیدن به بارگیری.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{درحال بارگیری فایل.}one{درحال بارگیری # فایل.}other{درحال بارگیری # فایل.}}</translation>
+<translation id="543509235395288790">درحال بارگیری <ph name="COUNT"/> فایل (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">درحال بارگیری فایل (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{۱ بارگیری کامل شد.}one{# بارگیری کامل شد.}other{# بارگیری کامل شد.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{۱ بارگیری انجام نشد.}one{# بارگیری انجام نشد.}other{# بارگیری انجام نشد.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{۱ بارگیری در انتظار است.}one{# بارگیری در انتظار است.}other{# بارگیری در انتظار است.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> دکمه <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">تقریباً پایان یافته است!</translation>
+<translation id="3960299545138990065">‏Brave را راه‌اندازی مجدد کنید</translation>
+<translation id="3771001275138982843">به‌روزرسانی بارگیری نشد</translation>
+<translation id="3888648114124182147">‏درحال بارگیری به‌روزرسانی Brave…</translation>
+<translation id="1705567146636171298">‏به‌روزرسانی Brave</translation>
+<translation id="6195417478702700398">‏برای بهترین تجربه مرور، Brave را به‌روزرسانی کنید</translation>
+<translation id="3512968675351418494">‏برای اینکه وب را به زبان خود ببینید، آخرین نسخه Brave را دریافت کنید</translation>
+<translation id="6427112570124116297">وب را ترجمه کنید</translation>
+<translation id="1379423114029199501">‏با به‌روزرسانی به جدیدترین نسخه Brave، زبانتان را دریافت کنید</translation>
+<translation id="5684874026226664614">متأسفیم. این صفحه ترجمه نشد.</translation>
+<translation id="6831043979455480757">ترجمه</translation>
+<translation id="1285320974508926690">این سایت هرگز ترجمه نشود</translation>
+<translation id="773466115871691567">صفحه‌های <ph name="SOURCE_LANGUAGE"/> همیشه ترجمه شوند</translation>
+<translation id="1068672505746868501">هرگز صفحه‌های <ph name="SOURCE_LANGUAGE"/> ترجمه نشوند</translation>
+<translation id="124116460088058876">زبان‌های بیشتر</translation>
+<translation id="290376772003165898">صفحه به زبان <ph name="LANGUAGE"/> وجود ندارد؟</translation>
+<translation id="4432792777822557199">از این به بعد، صفحه‌های <ph name="SOURCE_LANGUAGE"/>، به <ph name="TARGET_LANGUAGE"/> ترجمه خواهند شد</translation>
+<translation id="8339163506404995330">صفحه‌های <ph name="LANGUAGE"/> ترجمه نخواند شد</translation>
+<translation id="5447765697759493033">این سایت ترجمه نخواهد شد</translation>
+<translation id="4880127995492972015">ترجمه…</translation>
+<translation id="641643625718530986">چاپ...</translation>
+<translation id="8909135823018751308">اشتراک‌گذاری‌...</translation>
+<translation id="4996978546172906250">اشتراک‌گذاری از طریق</translation>
+<translation id="6333140779060797560">اشتراک‌گذاری از طریق <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">در چاپ صفحه مشکلی پیش آمد. لطفاً دوباره امتحان کنید.</translation>
+<translation id="3254409185687681395">نشانک گذاری این صفحه</translation>
+<translation id="497421865427891073">جلو رفتن</translation>
+<translation id="813082847718468539">مشاهدهٔ اطلاعات سایت</translation>
+<translation id="2532336938189706096">نمای وب</translation>
+<translation id="6005538289190791541">گذرواژه پیشنهادی</translation>
+<translation id="4634124774493850572">استفاده از گذرواژه</translation>
+<translation id="8285489906452138776">‏Brave به مجوز دسترسی به دوربین برای این سایت نیاز دارد.</translation>
+<translation id="320189792589364011">‏Brave برای این سایت به مجوز دسترسی به میکروفون نیاز دارد.</translation>
+<translation id="7988136689212463100">‏Brave برای این سایت به مجوز دسترسی به دوربین و میکروفون نیاز دارد.</translation>
+<translation id="4931190655840828017">‏Brave برای اشتراک‌گذاری مکانتان با این سایت باید به مکانتان دسترسی داشته باشد.</translation>
+<translation id="3088191967551450609">‏Brave برای بارگیری فایل‌ها باید به حافظه دسترسی داشته باشد.</translation>
+<translation id="8942627711005830162">باز کردن در پنجره دیگر</translation>
+<translation id="4195643157523330669">باز کردن در برگهٔ جدید</translation>
+<translation id="1100066534610197918">باز کردن در برگه جدید در گروه</translation>
+<translation id="4860895144060829044">تماس</translation>
+<translation id="6896758677409633944">کپی</translation>
+<translation id="8393700583063109961">ارسال پیام</translation>
+<translation id="3557336313807607643">افزودن به مخاطبین</translation>
+<translation id="4269820728363426813">کپی نشانی پیوند</translation>
+<translation id="1206892813135768548">کپی نوشتار پیوند</translation>
+<translation id="1204037785786432551">بارگیری پیوند</translation>
+<translation id="6864459304226931083">بارگیری تصویر</translation>
+<translation id="8209050860603202033">باز کردن تصویر</translation>
+<translation id="8073388330009372546">باز کردن تصویر در برگه جدید</translation>
+<translation id="6649642165559792194">پیش‌نمایش تصویر <ph name="BEGIN_NEW"/>جدید<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">بارگیری تصویر</translation>
+<translation id="3845332215609790146">‏جستجو با «لنز Brave Software» <ph name="BEGIN_NEW"/>جدید<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">جستجوی <ph name="SEARCH_ENGINE"/> برای این تصویر</translation>
+<translation id="3384347053049321195">اشتراک‌گذاری تصویر</translation>
+<translation id="5833984609253377421">اشتراک‌گذاری پیوند</translation>
+<translation id="6475951671322991020">بارگیری ویدیو</translation>
+<translation id="2317945146070194624">‏باز کردن در برگه جدید Brave</translation>
+<translation id="7975379999046275268">پیش‌نمایش صفحه <ph name="BEGIN_NEW"/>جدید<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">درحال بازخوانی صفحه</translation>
+<translation id="36525718899759834">‏دریافت برنامه از فروشگاه Brave Software Play: ‏<ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">تاریک</translation>
+<translation id="1807246157184219062">روشن</translation>
+<translation id="4056223980640387499">سپیا</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">قلم‌های با عرض ثابت</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">برگه‌ای برای انتقال با پرتو انتخاب کنید</translation>
+<translation id="8719023831149562936">انتقال برگه کنونی با پرتو ممکن نیست</translation>
+<translation id="2139186145475833000">افزودن به صفحه اصلی</translation>
+<translation id="4616150815774728855">باز کردن <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">باز کردن برنامه امکان‌پذیر نیست</translation>
+<translation id="5129038482087801250">نصب برنامه وب</translation>
+<translation id="3789841737615482174">نصب</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> به صفحه اصلی شما اضافه شد</translation>
+<translation id="7333031090786104871">همچنان درحال افزودن سایت قبلی</translation>
+<translation id="1036727731225946849">درحال افزودن <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">به صفحه اصلی اضافه شد</translation>
+<translation id="2146738493024040262">برنامه فوری را باز کنید</translation>
+<translation id="7016516562562142042">برای موتور جستجوی فعلی مجاز است</translation>
+<translation id="6177111841848151710">برای موتور جستجوی فعلی مسدود شده است</translation>
+<translation id="145097072038377568">‏در تنظیمات Android مسدود شد</translation>
+<translation id="8007176423574883786">برای این دستگاه غیرفعال شد</translation>
+<translation id="164269334534774161">شما در حال تماشای کپی آفلاین این صفحه از <ph name="CREATION_TIME"/> هستید</translation>
+<translation id="4594952190837476234">این صفحه آفلاین مربوط به تاریخ <ph name="CREATION_TIME"/> است و ممکن است با نسخه آنلاین متفاوت باشد.</translation>
+<translation id="8840953339110955557">ممکن است این صفحه با نسخه آنلاین متفاوت باشد.</translation>
+<translation id="6405300764336705484">‏این محتوا از <ph name="DOMAIN_NAME"/> است و توسط Brave Software ارائه می‌شود.</translation>
+<translation id="1006017844123154345">باز کردن نسخه آنلاین</translation>
+<translation id="3326636747541519688">‏صفحه ساده‌شده را Brave Software ارائه کرده است</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>بار کردن صفحه اصلی<ph name="END_LINK"/> از <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">اگر این مورد را مکرراً مشاهده می‌کنید، این <ph name="BEGIN_LINK"/>پیشنهادات<ph name="END_LINK"/> را امتحان کنید.</translation>
+<translation id="8748850008226585750">محتوا پنهان است</translation>
+<translation id="3810973564298564668">مدیریت</translation>
+<translation id="5199929503336119739">نمایه کاری</translation>
+<translation id="528192093759286357">برای خروج از حالت تمام صفحه، از بالا صفحه را بکشید و دکمه برگشت را لمس کنید.</translation>
+<translation id="2836148919159985482">برای خروج از حالت تمام صفحه، دکمه برگشت را لمس کنید.</translation>
+<translation id="3967822245660637423">بارگیری کامل شد</translation>
+<translation id="2434158240863470628">بارگیری کامل شد <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">بارگیری نشد</translation>
+<translation id="1384959399684842514">بارگیری موقتاً متوقف شد</translation>
+<translation id="1671236975893690980">بارگیری معلق است…</translation>
+<translation id="5561549206367097665">در انتظار شبکه…</translation>
+<translation id="5864419784173784555">در انتظار بارگیری موردی دیگر…</translation>
+<translation id="6461962085415701688">فایل باز نمی‌شود</translation>
+<translation id="1178581264944972037">مکث</translation>
+<translation id="8200772114523450471">ازسرگیری</translation>
+<translation id="1409879593029778104">بارگیری <ph name="FILE_NAME"/> انجام نشد زیرا فایل از قبل موجود است.</translation>
+<translation id="3387650086002190359">به‌دلیل خطاهای سیستم فایل، بارگیری <ph name="FILE_NAME"/> انجام نشد.</translation>
+<translation id="6482749332252372425">به‌دلیل نبودن فضای ذخیره‌سازی، بارگیری <ph name="FILE_NAME"/> انجام نشد.</translation>
+<translation id="7619072057915878432">به‌دلیل نقص‌هایی در شبکه، بارگیری <ph name="FILE_NAME"/> انجام نشد.</translation>
+<translation id="1477626028522505441">به‌دلیل مشکلاتی در سرور، بارگیری <ph name="FILE_NAME"/> انجام نشد.</translation>
+<translation id="3692944402865947621">به‌دلیل دردسترس نبودن مکان فضای ذخیره‌سازی، <ph name="FILE_NAME"/> بارگیری نشد.</translation>
+<translation id="604996488070107836">به‌دلیل خطایی ناشناس، بارگیری <ph name="FILE_NAME"/> انجام نشد.</translation>
+<translation id="6738867403308150051">در حال بارگیری…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> کیلوبایت</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> مگابایت</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> گیگابایت</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> از ؟</translation>
+<translation id="1923695749281512248">‎<ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/>‎</translation>
+<translation id="3029613699374795922"><ph name="KBS"/> کیلوبایت بارگیری شد</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> مگابایت بارگیری شد</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> گیگابایت بارگیری شد</translation>
+<translation id="9204836675896933765">۱ فایل باقی مانده است</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> فایل باقی مانده است</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> فایل بارگیری شد}one{<ph name="FILES_DOWNLOADED_MANY"/> فایل بارگیری شد}other{<ph name="FILES_DOWNLOADED_MANY"/> فایل بارگیری شد}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> روز باقی‌مانده است</translation>
+<translation id="8190358571722158785">۱ روز باقی‌مانده است</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> ساعت باقی‌مانده است</translation>
+<translation id="510275257476243843">۱ ساعت باقی‌مانده است</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> دقیقه باقی‌مانده است</translation>
+<translation id="3236059992281584593">۱ دقیقه باقی‌مانده است</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> ثانیه باقی‌مانده است</translation>
+<translation id="2781151931089541271">۱ ثانیه باقی‌مانده است</translation>
+<translation id="3303414029551471755">ادامه می‌دهید و محتوا را بارگیری می‌کنید؟</translation>
+<translation id="8617240290563765734">نشانی وب مشخص شده در محتوای بارگیری‌شده باز شود؟</translation>
+<translation id="1373696734384179344">حافظه برای بارگیری محتوای انتخابی کافی نیست.</translation>
+<translation id="5271967389191913893">دستگاه نمی‌تواند محتوا را برای بارگیری باز کند.</translation>
+<translation id="883806473910249246">هنگام بارگیری محتوا خطایی روی داد.</translation>
+<translation id="5626134646977739690">نام:</translation>
+<translation id="7963646190083259054">ارائه‌دهنده:</translation>
+<translation id="3414952576877147120">اندازه:</translation>
+<translation id="7375125077091615385">نوع:</translation>
+<translation id="5765780083710877561">توضیح:</translation>
+<translation id="4881695831933465202">باز کردن</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> کیلوبایت دردسترس است</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> مگابایت موجود است</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> گیگابایت در دسترس</translation>
+<translation id="5793665092639000975">درحال استفاده از <ph name="SPACE_USED"/> از <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">همه</translation>
+<translation id="4988526792673242964">صفحات</translation>
+<translation id="3810838688059735925">فیلم</translation>
+<translation id="3616113530831147358">صوتی</translation>
+<translation id="9219103736887031265">تصاویر</translation>
+<translation id="8250920743982581267">اسناد</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# فایل}one{# فایل}other{# فایل}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# تصویر}one{# تصویر}other{# تصویر}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# ویدیو}one{# ویدیو}other{# ویدیو}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# فایل صوتی}one{# فایل صوتی}other{# فایل صوتی}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# صفحه}one{# صفحه}other{# صفحه}}</translation>
+<translation id="5456381639095306749">بارگیری صفحه</translation>
+<translation id="2394602618534698961">فایل‌هایی که بارگیری می‌کنید، اینجا نشان داده می‌شود</translation>
+<translation id="7810647596859435254">باز کردن با…</translation>
+<translation id="5655963694829536461">بارگیری‌هایتان را جستجو کنید</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">فایل‌های من</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">مقاله‌ها اینجا نشان داده می‌شوند و حتی درحالت آفلاین هم می‌توانید آن‌ها را بخوانید.</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ساعت}one{# ساعت}other{# ساعت}}</translation>
+<translation id="5853623416121554550">مکث</translation>
+<translation id="8965591936373831584">در انتظار</translation>
+<translation id="2779651927720337254">انجام نشد</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">هم‌اکنون</translation>
+<translation id="4000212216660919741">صفحه اصلیِ آفلاین</translation>
+<translation id="9133397713400217035">کاوش درحالت آفلاین</translation>
+<translation id="968900484120156207">صفحاتی را که بازدید کرده‌اید، اینجا نمایش داده می‌شوند</translation>
+<translation id="7882131421121961860">هیچ سابقه‌ای پیدا نشد</translation>
+<translation id="3549657413697417275">جستجو در سابقه</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">ماه</translation>
+<translation id="605721222689873409">سال</translation>
+<translation id="724102042129299115">‏اولین تجربه اجرا Brave</translation>
+<translation id="2700285883409956633">‏استفاده از این برنامه به معنای اعلام موافقت شما با <ph name="BEGIN_LINK1"/>شرایط خدمات<ph name="END_LINK1"/> و <ph name="BEGIN_LINK2"/>اعلامیه حریم خصوصی<ph name="END_LINK2"/> Brave است.</translation>
+<translation id="1640714894372474981">‏درصورت استفاده از این برنامه، با <ph name="BEGIN_LINK1"/>شرایط خدمات<ph name="END_LINK1"/> و <ph name="BEGIN_LINK2"/>اعلان حریم خصوصی<ph name="END_LINK2"/> و <ph name="BEGIN_LINK3"/>اعلان حریم خصوصی برای حساب‌های Brave Software مدیریت‌شده با Family Link<ph name="END_LINK3"/> مربوط به Brave موافقت می‌کنید.</translation>
+<translation id="4218324479468769727">‏<ph name="APP_NAME"/> در Brave باز می‌شود. درصورت ادامه دادن، با <ph name="BEGIN_LINK1"/>شرایط خدمات<ph name="END_LINK1"/> و <ph name="BEGIN_LINK2"/>اعلان حریم خصوصی<ph name="END_LINK2"/> Brave موافقت می‌کنید.</translation>
+<translation id="5071615083211946659">‏<ph name="APP_NAME"/> در Brave باز خواهد شد. درصورت ادامه دادن، با <ph name="BEGIN_LINK1"/>شرایط خدمات<ph name="END_LINK1"/> و <ph name="BEGIN_LINK2"/>اعلان حریم خصوصی<ph name="END_LINK2"/> Brave و <ph name="BEGIN_LINK3"/>اعلان حریم خصوصی برای حساب‌های Brave Software مدیریت‌شده با Family<ph name="END_LINK3"/> موافقت می‌کنید.</translation>
+<translation id="673197144963363525">‏‫با ارسال آمار کاربرد و گزارش‌های خرابی به Brave Software، به بهتر شدن Brave کمک کنید.</translation>
+<translation id="3518985090088779359">پذیرش و ادامه</translation>
+<translation id="7207456302801184289">‏به Brave خوش آمدید</translation>
+<translation id="704822250101715322">‏در انتظار «سرویس‌های Brave Software Play» برای اتمام به‌روزرسانی است</translation>
+<translation id="1231733316453485619">همگام‌سازی روشن شود؟</translation>
+<translation id="5132942445612118989">همگام‌سازی گذرواژه‌ها، سابقه و موارد دیگر در همه دستگاه‌ها</translation>
+<translation id="5736731321935944068">‏Brave Software ممکن است از سابقه مرور شما برای شخصی کردن جستجو، آگهی‌ها و سایر سرویس‌های Brave Software استفاده کند</translation>
+<translation id="4013614219085422040">‏Brave Software ممکن است از سابقه مرور شما برای شخصی کردن جستجو و سایر سرویس‌های Brave Software استفاده کند</translation>
+<translation id="5581519193887989363">هرزمان خواستید می‌توانید مواردی را که می‌خواهید همگام‌سازی شود در <ph name="BEGIN_LINK1"/>تنظیمات<ph name="END_LINK1"/> انتخاب کنید.</translation>
+<translation id="741204030948306876">بله، موافقم</translation>
+<translation id="2410754283952462441">انتخاب حساب</translation>
+<translation id="2227444325776770048">ادامه دادن به‌عنوان <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> ایمیل شما نیست؟</translation>
+<translation id="8109613176066109935">برای اینکه به نشانک‌ها در همه دستگاه‌هایتان دسترسی داشته باشید، همگام‌سازی را روشن کنید</translation>
+<translation id="2818669890320396765">برای اینکه نشانک‌هایتان را در همه دستگاه‌ها داشته باشید، به سیستم وارد شوید و همگام‌سازی را روشن کنید</translation>
+<translation id="6003646045106347985">‏برای اینکه Brave Software محتوای شخصی‌شده به شما پیشنهاد دهد، همگام‌سازی را روشن کنید</translation>
+<translation id="8494430740943879273">‏برای اینکه Brave Software محتوای شخصی‌شده به شما پیشنهاد دهد، به سیستم وارده شوید و همگام‌سازی را روشن کنید</translation>
+<translation id="5862731021271217234">برای اینکه به برگه‌های بازشده در سایر دستگاه‌ها دسترسی داشته باشید، همگام‌سازی را روشن کنید</translation>
+<translation id="3568688522516854065">برای اینکه به برگه‌های بازشده در سایر دستگاه‌ها دسترسی داشته باشید، به سیستم وارد شوید و همگام‌سازی را روشن کنید</translation>
+<translation id="1208340532756947324">برای همگام‌سازی و شخصی‌سازی در همه دستگاه‌ها، همگام‌سازی را روشن کنید</translation>
+<translation id="4472118726404937099">برای همگام‌سازی و شخصی‌سازی در همه دستگاه‌ها، به سیستم وارد شوید و همگام‌سازی را روشن کنید</translation>
+<translation id="2426805022920575512">انتخاب حسابی دیگر</translation>
+<translation id="6790428901817661496">پخش</translation>
+<translation id="1272079795634619415">توقف</translation>
+<translation id="2874939134665556319">آهنگ قبلی</translation>
+<translation id="4046123991198612571">آهنگ بعدی</translation>
+<translation id="3859306556332390985">جستجو به جلو</translation>
+<translation id="8441146129660941386">جستجو به عقب</translation>
+<translation id="6706288973712894588">‏درحال حاضر آفلاین هستید.\n<ph name="BEGIN_LINK"/>فید آفلاین خود را کاوش کنید.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">برگه‌های اخیر</translation>
+<translation id="8497726226069778601">هنوز… چیزی برای دیدن وجود ندارد</translation>
+<translation id="5423934151118863508">صفحاتی که بیشترین بازدید را از آنها داشته‌اید در اینجا نمایان می‌شوند</translation>
+<translation id="6127379762771434464">مورد برداشته شد</translation>
+<translation id="4605958867780575332">مورد حذف شد: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">‏Brave Software doodle: ‏<ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">دستگاه‌های دیگر</translation>
+<translation id="4738836084190194332">آخرین همگام‌سازی: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# دقیقه قبل}one{# دقیقه قبل}other{# دقیقه قبل}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{۱ ساعت قبل}one{# ساعت قبل}other{# ساعت قبل}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{۱ روز قبل}one{#  روز قبل}other{#  روز قبل}}</translation>
+<translation id="2762000892062317888">هم‌اکنون</translation>
+<translation id="1407135791313364759">باز کردن همه</translation>
+<translation id="1209206284964581585">فعلاً پنهان شود</translation>
+<translation id="129553762522093515">اخیراً بسته‌شده</translation>
+<translation id="8413126021676339697">نمایش کل سابقه</translation>
+<translation id="7876243839304621966">حذف همه</translation>
+<translation id="8487700953926739672">امکان دسترسی به صورت آفلاین</translation>
+<translation id="5224771365102442243">دارای ویدیو</translation>
+<translation id="3493531032208478708">درباره محتوای پیشنهادی <ph name="BEGIN_LINK"/>بیشتر بدانید<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">دریافت پیشنهادها امکان‌پذیر نیست</translation>
+<translation id="5013696553129441713">هیچ پیشنهاد جدیدی نیست</translation>
+<translation id="1736419249208073774">کاوش</translation>
+<translation id="7444811645081526538">دسته‌های بیشتر</translation>
+<translation id="6709133671862442373">اخبار</translation>
+<translation id="1264974993859112054">ورزش</translation>
+<translation id="9139318394846604261">خرید</translation>
+<translation id="3912508018559818924">درحال پیدا کردن بهترین مورد از وب…</translation>
+<translation id="526421993248218238">این صفحه بار نشد</translation>
+<translation id="614940544461990577">این موارد را امتحان کنید:</translation>
+<translation id="3288003805934695103">تازه‌سازی صفحه</translation>
+<translation id="2353636109065292463">بررسی اتصال اینترنت</translation>
+<translation id="2858138569776157458">سایت‌های برتر</translation>
+<translation id="8364299278605033898">مشاهده وب‌سایت‌های پرطرفدار</translation>
+<translation id="1171770572613082465">با ضربه زدن روی دکمه «سایت‌های برتر»، وب‌سایت‌های پرطرفدار را ببینید</translation>
+<translation id="5233638681132016545">برگه جدید</translation>
+<translation id="4521874409998847950">‏از<ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>توسط Brave Software ارائه می‌شود<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">نسخه جدیدتری در دسترس است</translation>
+<translation id="4058091506841967397">‏Brave به‌روزرسانی نشد</translation>
+<translation id="6316139424528454185">‏نسخه Android پشتیبانی نمی‌شود</translation>
+<translation id="6989267951144302301">بارگیری نشد</translation>
+<translation id="624789221780392884">به‌روزرسانی آماده است</translation>
+<translation id="1549000191223877751">انتقال به پنجره دیگر</translation>
+<translation id="7481312909269577407">ارسال کردن</translation>
+<translation id="4084682180776658562">نشانک</translation>
+<translation id="6437478888915024427">اطلاعات صفحه</translation>
+<translation id="7180611975245234373">بازخوانی</translation>
+<translation id="4913169188695071480">توقف تازه‌سازی</translation>
+<translation id="1829244130665387512">یافتن در صفحه</translation>
+<translation id="6593061639179217415">سایت مخصوص رایانه</translation>
+<translation id="9063523880881406963">خاموش کردن درخواست سایت رایانه‌ای</translation>
+<translation id="2038563949887743358">روشن کردن درخواست سایت رایانه‌ای</translation>
+<translation id="2433507940547922241">شکل ظاهری</translation>
+<translation id="983192555821071799">بستن همه برگه‌ها</translation>
+<translation id="1310482092992808703">گروه‌بندی برگه‌ها</translation>
+<translation id="7725024127233776428">صفحاتی را که نشانک‌گذاری می‌کنید، در اینجا نشان داده می‌شوند</translation>
+<translation id="4404568932422911380">هیچ نشانکی موجود نیست</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> نشانک}one{<ph name="BOOKMARKS_COUNT_MANY"/> نشانک}other{<ph name="BOOKMARKS_COUNT_MANY"/> نشانک}}</translation>
+<translation id="3739899004075612870">در <ph name="PRODUCT_NAME"/> نشانک‌گذاری شد</translation>
+<translation id="3207960819495026254">نشانک‌گذاری شده</translation>
+<translation id="4452548195519783679">در <ph name="FOLDER_NAME"/> نشانک گذاشته شد</translation>
+<translation id="8063895661287329888">نشانک اضافه نشد.</translation>
+<translation id="2842985007712546952">پوشه اصلی</translation>
+<translation id="9065203028668620118">ویرایش</translation>
+<translation id="4405224443901389797">انتقال به…</translation>
+<translation id="5170568018924773124">نمایش در پوشه</translation>
+<translation id="8035133914807600019">پوشه جدید…</translation>
+<translation id="4532845899244822526">انتخاب پوشه</translation>
+<translation id="6627583120233659107">ویرایش پوشه</translation>
+<translation id="1197267115302279827">انتقال نشانک‌ها</translation>
+<translation id="6963766334940102469">حذف نشانک‌ها</translation>
+<translation id="4351244548802238354">بستن کادر گفتگو</translation>
+<translation id="451872707440238414">جستجوی نشانک‌های شما</translation>
+<translation id="8901170036886848654">نشانکی پیدا نشد</translation>
+<translation id="6404511346730675251">ویرایش نشانک</translation>
+<translation id="3894427358181296146">افزودن پوشه</translation>
+<translation id="5327248766486351172">نام</translation>
+<translation id="7400418766976504921">نشانی وب</translation>
+<translation id="3527085408025491307">پوشه</translation>
+<translation id="5161254044473106830">عنوان مورد نیاز است</translation>
+<translation id="2996809686854298943">نشانی وب لازم است</translation>
+<translation id="2536728043171574184">مشاهده یک کپی آفلاین از این صفحه</translation>
+<translation id="4698034686595694889">مشاهده آفلاین در <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> و سایت‌های دیگر</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{‏وقتی آماده شدید، Brave صفحه را بار می‌کند}one{‏وقتی آماده شدید، Brave صفحه‌ها را بار می‌کند}other{‏وقتی آماده شدید، Brave صفحه‌ها را بار می‌کند}}</translation>
+<translation id="6811034713472274749">صفحه آماده مشاهده است</translation>
+<translation id="4561979708150884304">اتصال برقرار نیست</translation>
+<translation id="8274165955039650276">مشاهده بارگیری‌ها</translation>
+<translation id="2082238445998314030"><ph name="RESULT_NUMBER"/> نتیجه از <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">نتیجه‌ای پیدا نشد</translation>
+<translation id="981121421437150478">آفلاین</translation>
+<translation id="3298243779924642547">ساده</translation>
+<translation id="393697183122708255">هیچ جستجوی گفتاری فعالی در دسترس نیست</translation>
+<translation id="7191430249889272776">برگه در پس‌زمینه باز شد.</translation>
+<translation id="8445059357334030806">‏باز کردن در Brave</translation>
+<translation id="4720023427747327413">بازکردن در <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">بازکردن در مرورگر</translation>
+<translation id="1113597929977215864">نمایش نمای ساده‌شده</translation>
+<translation id="1513352483775369820">نشانک‌ها و سابقه وب</translation>
+<translation id="4939482511480190003">‏به بهبود Brave کمک کنید. <ph name="BEGIN_LINK"/>در نظرسنجی شرکت کنید<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">بازگشت</translation>
+<translation id="5596627076506792578">گزینه‌های بیشتر</translation>
+<translation id="3522247891732774234">به‌روزرسانی موجود است. گزینه‌های بیشتر</translation>
+<translation id="6773423637732432200">‏Brave به‌روزرسانی نشد. گزینه‌های دیگر</translation>
+<translation id="3328801116991980348">اطلاعات سایت</translation>
+<translation id="5391532827096253100">اتصال شما به این سایت امن نیست. اطلاعات سایت</translation>
+<translation id="6206551242102657620">اتصال امن است. اطلاعات سایت</translation>
+<translation id="6963642900430330478">این صفحه خطرناک است. اطلاعات سایت</translation>
+<translation id="9070377983101773829">شروع جستجوی گفتاری</translation>
+<translation id="8676374126336081632">پاک کردن ورودی</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> برگه باز، برای جستجوی برگه ضربه بزنید}one{<ph name="OPEN_TABS_MANY"/> برگه باز، برای جستجوی برگه ضربه بزنید}other{<ph name="OPEN_TABS_MANY"/> برگه باز، برای جستجوی برگه ضربه بزنید}}</translation>
+<translation id="2369533728426058518">برگه‌های باز</translation>
+<translation id="7071521146534760487">مدیریت حساب</translation>
+<translation id="932327136139879170">منزل</translation>
+<translation id="2707726405694321444">بازخوانی صفحه</translation>
+<translation id="2891154217021530873">توقف بارگیری صفحه</translation>
+<translation id="6710213216561001401">قبلی</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">برگه انتخاب‌شده</translation>
+<translation id="2268044343513325586">فیلتر</translation>
+<translation id="7846076177841592234">لغو انتخاب</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> مورد انتخاب شد.  گزینه‌ها در نزدیکی بالای صفحه دردسترس است</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> مورد انتخاب شد</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{اشتراک‌گذاری ۱ مورد انتخاب‌شده}one{اشتراک‌گذاری # مورد انتخاب‌شده}other{اشتراک‌گذاری # مورد انتخاب‌شده}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{حذف ۱ مورد انتخاب‌شده}one{حذف # مورد انتخاب‌شده}other{حذف # مورد انتخاب‌شده}}</translation>
+<translation id="1283039547216852943">برای بزرگ کردن ضربه بزنید</translation>
+<translation id="5962718611393537961">برای کوچک کردن ضربه بزنید</translation>
+<translation id="8076492880354921740">برگه‌ها</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{۱ مورد انتخاب شد}one{# مورد انتخاب شد}other{# مورد انتخاب شد}}</translation>
+<translation id="6818926723028410516">انتخاب موارد</translation>
+<translation id="4797039098279997504">برای برگشتن به <ph name="URL_OF_THE_CURRENT_TAB"/>، لمس کنید</translation>
+<translation id="6766758767654711248">برای رفتن به سایت، ضربه بزنید</translation>
+<translation id="429312253194641664">سایتی درحال پخش رسانه است</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> درحال اشتراک‌گذاری صفحه شما است</translation>
+<translation id="8833831881926404480">سایتی درحال به‌اشتراک گذاشتن صفحه‌تان است</translation>
+<translation id="9086455579313502267">دسترسی به شبکه امکان‌پذیر نیست</translation>
+<translation id="938850635132480979">خطا: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">باز کردن در <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">‏باز کردن در برنامه Maps</translation>
+<translation id="7698359219371678927">ایجاد ایمیل در <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">ایجاد ایمیل</translation>
+<translation id="5665379678064389456">ایجاد رویداد در <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">ایجاد رویداد</translation>
+<translation id="2111511281910874386">رفتن به صفحه</translation>
+<translation id="3988466920954086464">نتایج جستجوی فوری را در این پانل مشاهده کنید</translation>
+<translation id="2744248271121720757">برای جستجوی فوری، روی کلمه‌ای ضربه بزنید یا اقدام‌های مرتبط را ببینید</translation>
+<translation id="9155898266292537608">می‌توانید با ضربه‌ای سریع روی کلمه نیز جستجو کنید</translation>
+<translation id="3232754137068452469">برنامه وب</translation>
+<translation id="1430915738399379752">چاپ</translation>
+<translation id="3775705724665058594">ارسال به دستگاه‌هایتان</translation>
+<translation id="6364438453358674297">پیشنهاد از سابقه حذف شود؟</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> بسته شد</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> برگه بسته شد</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> حذف شد</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> نشانک حذف شد</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> بارگیری حذف شد</translation>
+<translation id="1248710015876067820">‏این تعداد از نسخه‌های Brave پشتیبانی نمی‌شود.</translation>
+<translation id="4259722352634471385">پیمایش مسدود شده است: <ph name="URL"/></translation>
+<translation id="8959122750345127698">پیمایش غیرقابل دسترسی است: <ph name="URL"/></translation>
+<translation id="5210365745912300556">بستن برگه</translation>
+<translation id="7772375229873196092">بستن <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">سابقه پیمایش</translation>
+<translation id="9169507124922466868">سابقه «پیمایش» نیمه‌باز است</translation>
+<translation id="1327257854815634930">سابقه «پیمایش» باز است.</translation>
+<translation id="8788265440806329501">سابقه «پیمایش» بسته است</translation>
+<translation id="7482656565088326534">برگه پیش‌نمایش</translation>
+<translation id="8427875596167638501">برگه پیش‌نمایش نیمه‌باز است</translation>
+<translation id="9102803872260866941">برگه پیش‌نمایش باز است</translation>
+<translation id="2942036813789421260">برگه پیش‌نمایش بسته است</translation>
+<translation id="6355102470683871794">‏فضای ذخیره‌سازی Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">فضای ذخیره سایت پاک شود؟</translation>
+<translation id="9205995714227143200">‏فضای ذخیره‌سازی سایت که از نظر Brave مهم نیست (مثلاً سایت‌هایی که تنظیمات ذخیره‌شده ندارند یا شما مرتب بازدید نمی‌کنید)</translation>
+<translation id="3997476611815694295">فضای ذخیره غیرمهم</translation>
+<translation id="8493948351860045254">آزاد کردن فضا</translation>
+<translation id="2324920234469020158">‏این کار کوکی‌ها، حافظه پنهان و داده‌های دیگر سایت‌ها را که از نظر Brave مهم نیست پاک می‌کند.</translation>
+<translation id="5447201525962359567">همه فضای ذخیره سایت‌ها، ازجمله کوکی‌ها و سایر داده‌های ذخیره‌شده در دستگاه</translation>
+<translation id="1376578503827013741">درحال محاسبه…</translation>
+<translation id="583281660410589416">ناشناس</translation>
+<translation id="2323763861024343754">فضای ذخیره‌سازی سایت</translation>
+<translation id="3587672679800759167">‏کل داده‌های استفاده‌شده توسط Brave، شامل حساب‌ها، نشانک‌ها و تنظیمات ذخیره‌شده</translation>
+<translation id="6545017243486555795">پاک کردن همه داده‌ها</translation>
+<translation id="4095146165863963773">داده‌های برنامه پاک شود؟</translation>
+<translation id="53119194224775367">‏همه داده‌های برنامه Brave به‌طور دائم حذف خواهند شد. این داده‌ها شامل همه فایل‌ها، تنظیمات، حساب‌ها، پایگاه‌های داده و غیره می‌شود.</translation>
+<translation id="5307446750509046227">پاک کردن فضای ذخیره‌سازی سایت</translation>
+<translation id="300526633675317032">این کار کل <ph name="SIZE_IN_KB"/> فضای ذخیره‌سازی وب‌سایت را پاک می‌کند.</translation>
+<translation id="8068648041423924542">انتخاب گواهی ممکن نیست.</translation>
+<translation id="2315043854645842844">انتخاب گواهی سمت کلاینت توسط سیستم‌عامل پشتیبانی نمی‌شود.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> می‌خواهد مرتبط شود</translation>
+<translation id="5308380583665731573">اتصال</translation>
+<translation id="868929229000858085">جستجوی مخاطبین</translation>
+<translation id="1919950603503897840">انتخاب مخاطبین</translation>
+<translation id="7986741934819883144">مخاطبی انتخاب کنید</translation>
+<translation id="3333961966071413176">همه مخاطبین</translation>
+<translation id="4994033804516042629">مخاطبی پیدا نشد</translation>
+<translation id="5403592356182871684">نام‌ها</translation>
+<translation id="2717722538473713889">آدرس‌های ایمیل</translation>
+<translation id="381841723434055211">شماره‌های تلفن</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ ۱ مورد دیگر)}one{(+ # مورد دیگر)}other{(+ # مورد دیگر)}}</translation>
+<translation id="5197729504361054390">مخاطبین انتخابی شما با <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> هم‌رسانی می‌شود.</translation>
+<translation id="1779089405699405702">رمزگشای تصویر</translation>
+<translation id="8067883171444229417">پخش ویدیو</translation>
+<translation id="6560414384669816528">‏جستجو با Sogou</translation>
+<translation id="5406914950576900927">‏Brave می‌تواند از <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> برای جستجو در چین استفاده کند. در <ph name="BEGIN_LINK"/>تنظیمات<ph name="END_LINK"/> می‌توانید این را تغییر دهید.</translation>
+<translation id="6456271171669383967">‏حفظ Brave Software</translation>
+<translation id="4384468725000734951">‏استفاده از Sogou برای جستجو</translation>
+<translation id="6103327872225198548">‏استفاده از Brave Software برای جستجو</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">‏این برنامه در Brave درحال اجرا است</translation>
+<translation id="6143689084714664628">‏درحال اجرا در Brave</translation>
+<translation id="7675869148432102528">‏<ph name="APP_NAME"/> داده‌هایی در Brave نیز دارد</translation>
+<translation id="2734140769649165081">‏می‌توانید داده‌ها را در تنظیمات Brave پاک کنید</translation>
+<translation id="8232956427053453090">نگه‌داشتن داده</translation>
+<translation id="4298388696830689168">سایت‌های مرتبط</translation>
+<translation id="5763514718066511291">برای کپی کردن نشانی وب این برنامه ضربه بزنید</translation>
+<translation id="6496823230996795692">برای استفاده از <ph name="APP_NAME"/> برای اولین‌ بار، لطفاً به اینترنت وصل شوید.</translation>
+<translation id="751961395872307827">نمی‌توان به این سایت متصل شد</translation>
+<translation id="4878404682131129617">برقراری تونل ازطریق سرور پروکسی ناموفق بود</translation>
+<translation id="4749960740855309258">باز کردن برگه جدید</translation>
+<translation id="8788968922598763114">دوباره باز کردن آخرین برگه بسته‌شده</translation>
+<translation id="7929962904089429003">باز کردن منو</translation>
+<translation id="6039379616847168523">رفتن به برگه بعدی</translation>
+<translation id="5210286577605176222">رفتن به برگه قبلی</translation>
+<translation id="124678866338384709">بستن برگه کنونی</translation>
+<translation id="3714981814255182093">باز کردن «نوار پیدا کردن»</translation>
+<translation id="5441522332038954058">رفتن به نوار نشانی</translation>
+<translation id="3398320232533725830">باز کردن مدیر نشانک‌ها</translation>
+<translation id="6583199322650523874">نشانک گذاشتن صفحه کنونی</translation>
+<translation id="8489271220582375723">باز کردن صفحه سابقه</translation>
+<translation id="4837753911714442426">باز کردن گزینه‌های چاپ صفحه</translation>
+<translation id="5726692708398506830">بزرگ‌تر کردن همه‌چیز در صفحه</translation>
+<translation id="3259831549858767975">کوچک‌تر کردن همه‌چیز در صفحه</translation>
+<translation id="8015452622527143194">برگرداندن همه‌چیز در صفحه به‌اندازه پیش‌فرض</translation>
+<translation id="3443221991560634068">تازه‌سازی صفحه کنونی</translation>
+<translation id="123724288017357924">تازه‌سازی صفحه اصلی با نادیده گرفتن محتوای حافظه پنهان</translation>
+<translation id="305870044889644984">‏باز کردن مرکز راهنمایی Brave در برگه جدید</translation>
+<translation id="3166827708714933426">میان‌برهای پنجره و برگه</translation>
+<translation id="3169981355900570544">‏میان‌برهای ویژه Brave Software Brave</translation>
+<translation id="4558311620361989323">میان‌برهای صفحه وب</translation>
+<translation id="1908301351964700579">‏Brave هنوز درحال آماده‌سازی برای VR است. Brave بعداً بازراه‌اندازی شود.</translation>
+<translation id="8970887620466824814">مشکلی پیش آمد.</translation>
+<translation id="1875543012935658554">‏Brave را دوباره باز کنید.</translation>
+<translation id="79859296434321399">‏برای مشاهده محتوای واقعیت افزوده، ARCore را نصب کنید</translation>
+<translation id="8558485628462305855">‏برای مشاهده محتوای واقعیت افزوده، ARCore را به‌روزرسانی کنید</translation>
+<translation id="3513704683820682405">واقعیت افزوده</translation>
+<translation id="5475862044948910901">جلسه «واقعیت افزوده» شروع شود؟</translation>
 <translation id="7365126855094612066">طی این جلسه، سایت می‌تواند:
 • نقشه سه‌بعدی محیط را ایجاد کند
 • حرکت دوربین را ردیابی کند
 
 سایت نمی‌تواند به دوربین دسترسی یابد. تصاویر دوربین فقط برای شما قابل‌مشاهده است.</translation>
-<translation id="7375125077091615385">نوع:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">نشانی وب</translation>
-<translation id="7403691278183511381">‏اولین تجربه اجرا Chrome</translation>
-<translation id="741204030948306876">بله، موافقم</translation>
-<translation id="7413229368719586778">تاریخ شروع: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">ابتدا سؤال شود</translation>
-<translation id="7423538860840206698">خواندن محتوای بریده‌دان مسدود شد</translation>
-<translation id="7431991332293347422">کنترل نحوه استفاده از سابقه مرور برای شخصی‌سازی «جستجو» و موارد دیگر</translation>
-<translation id="7437998757836447326">‏خروج از سیستم Chrome</translation>
-<translation id="7438641746574390233">‏وقتی «حالت ساده» روشن است، Chrome از سرورهای Google برای بار کردن سریع‌تر صفحه‌ها استفاده می‌کند. در «حالت ساده»، صفحه‌ها خیلی آهسته بازنویسی می‌شود تا فقط محتوای اساسی بار شود. «حالت ساده» روی برگه‌های ناشناس اعمال نمی‌شود.</translation>
-<translation id="7444811645081526538">دسته‌های بیشتر</translation>
-<translation id="7445411102860286510">اجازه به سایت‌ها برای پخش خودکار ویدیوهای صامت‌شده (توصیه می‌شود)</translation>
-<translation id="7453467225369441013">‏شما را از سیستم اکثر سایت‌ها خارج می‌‌کند. از سیستم حساب Google خارج نمی‌شوید.</translation>
-<translation id="7454641608352164238">فضای کافی وجود ندارد</translation>
-<translation id="7475192538862203634">اگر این مورد را مکرراً مشاهده می‌کنید، این <ph name="BEGIN_LINK" />پیشنهادات<ph name="END_LINK" /> را امتحان کنید.</translation>
-<translation id="7475688122056506577">‏کارت SD پیدا نشد. ممکن است بعضی از فایل‌هایتان جا بیافتد.</translation>
-<translation id="7479104141328977413">مدیریت برگه</translation>
-<translation id="7481312909269577407">ارسال کردن</translation>
-<translation id="7482656565088326534">برگه پیش‌نمایش</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (زمان به‌روزرسانی <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">داده صرفه‌جویی‌شده</translation>
-<translation id="7498271377022651285">لطفاً صبر کنید...</translation>
-<translation id="7514365320538308">بارگیری</translation>
-<translation id="751961395872307827">نمی‌توان به این سایت متصل شد</translation>
-<translation id="7521387064766892559">جاوا اسکریپت</translation>
-<translation id="7542481630195938534">دریافت پیشنهادها امکان‌پذیر نیست</translation>
-<translation id="7559975015014302720">«حالت ساده» خاموش است</translation>
-<translation id="7562080006725997899">پاک کردن داده‌های مرور</translation>
-<translation id="756809126120519699">‏داده‌های Chrome پاک شد</translation>
-<translation id="757524316907819857">مسدود کردن سایت‌ها برای پخش محتوای محافظت‌شده</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> فایل بارگیری شد}one{<ph name="FILES_DOWNLOADED_MANY" /> فایل بارگیری شد}other{<ph name="FILES_DOWNLOADED_MANY" /> فایل بارگیری شد}}</translation>
-<translation id="7588219262685291874">روشن شدن طرح زمینه تیره وقتی «بهینه‌سازی باتری» دستگاه روشن است</translation>
-<translation id="7589445247086920869">مسدود کردن موتور جستجوی کنونی</translation>
-<translation id="7593557518625677601">‏برای شروع همگام‌سازی Chrome، تنظیمات Android را باز کنید و همگام‌سازی سیستم Android را دوباره فعال کنید</translation>
-<translation id="7596558890252710462">سیستم عامل</translation>
-<translation id="7605594153474022051">همگام‌سازی کار نمی‌کند</translation>
-<translation id="7606077192958116810">حالت ساده روشن است. آن را در «تنظیمات» مدیریت کنید.</translation>
-<translation id="7612619742409846846">‏ثبت ورودشده در Google به‌عنوان</translation>
-<translation id="7619072057915878432">به‌دلیل نقص‌هایی در شبکه، بارگیری <ph name="FILE_NAME" /> انجام نشد.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />دریافت راهنمایی<ph name="END_LINK1" /> یا <ph name="BEGIN_LINK2" />اسکن مجدد<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">‏به Chrome خوش آمدید</translation>
-<translation id="7638584964844754484">عبارت عبور نادرست است</translation>
-<translation id="7641339528570811325">پاک کردن داده‌های محصول مرور…</translation>
-<translation id="7648422057306047504">‏رمزگذاری گذرواژه‌ها با اعتبارنامه‌های Google</translation>
-<translation id="7649070708921625228">راهنما</translation>
-<translation id="7658239707568436148">لغو</translation>
-<translation id="7665369617277396874">افزودن حساب</translation>
-<translation id="766587987807204883">مقاله‌ها اینجا نشان داده می‌شوند و حتی درحالت آفلاین هم می‌توانید آن‌ها را بخوانید.</translation>
-<translation id="7682724950699840886">نکات زیر را امتحان کنید: مطمئن شوید که در دستگاهتان فضای کافی وجود داشته باشد، سعی کنید دوباره صادر کنید.</translation>
-<translation id="7685301384041462804">‏پیش از وارد شدن به حالت VR، مطمئن شوید به این سایت اعتماد دارید.</translation>
-<translation id="7698359219371678927">ایجاد ایمیل در <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">تکمیل خودکار جستجوها و نشانی‌های وب</translation>
-<translation id="7725024127233776428">صفحاتی را که نشانک‌گذاری می‌کنید، در اینجا نشان داده می‌شوند</translation>
-<translation id="773466115871691567">صفحه‌های <ph name="SOURCE_LANGUAGE" /> همیشه ترجمه شوند</translation>
-<translation id="7746457520633464754">‏برای حذف برنامه‌ها و سایت‌های خطرناک، Chrome نشانی‌های وب برخی از صفحه‌هایی را که بازدید می‌کنید، اطلاعات سیستم محدود و برخی از محتوای صفحه را به Google می‌فرستد.</translation>
-<translation id="7757787379047923882">نوشتار هم‌رسانی‌شده از <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">‏کارت SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">افزودن آدرس</translation>
-<translation id="7772032839648071052">تأیید عبارت عبور</translation>
-<translation id="7772375229873196092">بستن <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> روش پرداخت دیگر}one{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> روش پرداخت دیگر}other{‏<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 و <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> روش پرداخت دیگر}}</translation>
-<translation id="7781829728241885113">دیروز</translation>
-<translation id="7791543448312431591">افزودن</translation>
-<translation id="780301667611848630">نه متشکرم</translation>
-<translation id="7810647596859435254">باز کردن با…</translation>
-<translation id="7821588508402923572">میزان داده صرفه‌جویی‌شده اینجا نشان داده می‌شود</translation>
-<translation id="7837721118676387834">به پخش‌خودکار ویدیو‌های صامت‌شده برای سایتی خاص امکان دهید.</translation>
-<translation id="7846076177841592234">لغو انتخاب</translation>
-<translation id="784934925303690534">محدوده زمانی</translation>
-<translation id="7851858861565204677">دستگاه‌های دیگر</translation>
-<translation id="7875915731392087153">ایجاد ایمیل</translation>
-<translation id="7876243839304621966">حذف همه</translation>
-<translation id="7882131421121961860">هیچ سابقه‌ای پیدا نشد</translation>
-<translation id="7882806643839505685">پخش صدا برای سایت خاصی مجاز شود.</translation>
-<translation id="7886917304091689118">‏درحال اجرا در Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{درحال بارگیری فایل.}one{درحال بارگیری # فایل.}other{درحال بارگیری # فایل.}}</translation>
-<translation id="7929962904089429003">باز کردن منو</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> قدیمی است.</translation>
-<translation id="7947953824732555851">پذیرش و ورود به سیستم</translation>
-<translation id="7963646190083259054">ارائه‌دهنده:</translation>
-<translation id="7971136598759319605">آخرین فعالیت: ۱ روز قبل</translation>
-<translation id="7975379999046275268">پیش‌نمایش صفحه <ph name="BEGIN_NEW" />جدید<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">پیش‌بارگیری صفحه‌ها برای مرور و جستجوی سریع‌تر</translation>
-<translation id="79859296434321399">‏برای مشاهده محتوای واقعیت افزوده، ARCore را نصب کنید</translation>
-<translation id="7986741934819883144">مخاطبی انتخاب کنید</translation>
-<translation id="7987073022710626672">‏شرایط خدمات Chrome</translation>
-<translation id="7998918019931843664">بازکردن مجدد برگه‌های بسته شده</translation>
-<translation id="7999064672810608036">مطمئنید که می‌خواهید تمام داده‌های محلی، شامل کوکی‌ها را حذف کنید و تمام مجوزهای این وب‌سایت را بازنشانی کنید؟</translation>
-<translation id="8004582292198964060">مرورگر</translation>
-<translation id="8007176423574883786">برای این دستگاه غیرفعال شد</translation>
-<translation id="8013372441983637696">‏داده‌های این Chrome هم از این دستگاه پاک شود</translation>
-<translation id="8015452622527143194">برگرداندن همه‌چیز در صفحه به‌اندازه پیش‌فرض</translation>
-<translation id="802154636333426148">بارگیری نشد</translation>
-<translation id="8026334261755873520">پاک کردن داده‌های مرور</translation>
-<translation id="8035133914807600019">پوشه جدید…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> روز باقی‌مانده است</translation>
-<translation id="804335162455518893">‏کارت SD پیدا نشد</translation>
-<translation id="805047784848435650">براساس سابقه مرور شما</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> مگابایت موجود است</translation>
-<translation id="8058746566562539958">‏باز کردن در برگه جدید Chrome</translation>
-<translation id="8063895661287329888">نشانک اضافه نشد.</translation>
-<translation id="806745655614357130">داده‌های من مجزا باشد</translation>
-<translation id="8067883171444229417">پخش ویدیو</translation>
-<translation id="8068648041423924542">انتخاب گواهی ممکن نیست.</translation>
-<translation id="8073388330009372546">باز کردن تصویر در برگه جدید</translation>
-<translation id="8076492880354921740">برگه‌ها</translation>
-<translation id="8084114998886531721">گذرواژه ذخیره‌شده</translation>
-<translation id="8087000398470557479">‏این محتوا از <ph name="DOMAIN_NAME" /> است و توسط Google ارائه می‌شود.</translation>
-<translation id="8103578431304235997">برگه ناشناس</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">برای اینکه به نشانک‌ها در همه دستگاه‌هایتان دسترسی داشته باشید، همگام‌سازی را روشن کنید</translation>
-<translation id="8110087112193408731">‏فعالیت Chrome شما در «آسایش دیجیتالی» نشان داده شود؟</translation>
-<translation id="8116925261070264013">صامت‌شده</translation>
-<translation id="813082847718468539">مشاهدهٔ اطلاعات سایت</translation>
-<translation id="8131740175452115882">تأیید</translation>
-<translation id="8156139159503939589">به چه زبانی مطالعه می‌کنید؟</translation>
-<translation id="8168435359814927499">محتوا</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> فایل باقی مانده است</translation>
-<translation id="8190358571722158785">۱ روز باقی‌مانده است</translation>
-<translation id="8200772114523450471">ازسرگیری</translation>
-<translation id="8209050860603202033">باز کردن تصویر</translation>
-<translation id="8218622182176210845">مدیریت حساب</translation>
-<translation id="8224471946457685718">‏بارگیری مقالات برای شما با Wi-Fi</translation>
-<translation id="8232956427053453090">نگه‌داشتن داده</translation>
-<translation id="8249310407154411074">انتقال به بالا</translation>
-<translation id="8250920743982581267">اسناد</translation>
-<translation id="825412236959742607">‏این صفحه حافظه خیلی زیادی استفاده می‌کند، به‌همین‌دلیل Chrome برخی از محتوا را پاک کرد.</translation>
-<translation id="8260126382462817229">دوباره سعی کنید به سیستم وارد شوید</translation>
-<translation id="8261506727792406068">حذف</translation>
-<translation id="8266862848225348053">مکان بارگیری</translation>
-<translation id="8274165955039650276">مشاهده بارگیری‌ها</translation>
-<translation id="8284326494547611709">زیرنویس‌ها</translation>
-<translation id="8300705686683892304">مدیریت‌شده توسط برنامه</translation>
-<translation id="8310344678080805313">برگه‌های استاندارد</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> و سایت‌های دیگر</translation>
-<translation id="8327155640814342956">‏برای بهترین تجربه مرور، Chrome را به‌روزرسانی کنید</translation>
-<translation id="8339163506404995330">صفحه‌های <ph name="LANGUAGE" /> ترجمه نخواند شد</translation>
-<translation id="8349013245300336738">مرتب‌سازی براساس مقدار داده استفاده‌شده</translation>
-<translation id="8364299278605033898">مشاهده وب‌سایت‌های پرطرفدار</translation>
-<translation id="8368027906805972958">دستگاه ناشناس یا پشتیبانی‌نشده (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">«همگام‌سازی پس‌زمینه» را برای یک سایت خاص مجاز کنید.</translation>
-<translation id="8378714024927312812">توسط سازمانتان مدیریت می‌شود</translation>
-<translation id="8380167699614421159">این سایتْ آگهی‌های مزاحم یا گمراه‌کننده نشان می‌دهد</translation>
-<translation id="8393700583063109961">ارسال پیام</translation>
-<translation id="8413126021676339697">نمایش کل سابقه</translation>
-<translation id="8427875596167638501">برگه پیش‌نمایش نیمه‌باز است</translation>
-<translation id="8428213095426709021">تنظیمات</translation>
-<translation id="8438566539970814960">بهبود جستجوها و مرور</translation>
-<translation id="8441146129660941386">جستجو به عقب</translation>
-<translation id="8443209985646068659">‏Chrome به‌روزرسانی نشد</translation>
-<translation id="8445448999790540984">گذرواژه‌ها صادر نشدند</translation>
-<translation id="8447861592752582886">لغو مجوز دستگاه</translation>
-<translation id="8461694314515752532">رمزگذاری داده‌های همگام‌سازی‌شده با عبارت عبور همگام‌سازی خودتان</translation>
-<translation id="8466613982764129868">مطمئن شوید <ph name="TARGET_DEVICE_NAME" /> به اینترنت متصل باشد</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">امکان دسترسی به صورت آفلاین</translation>
-<translation id="8489271220582375723">باز کردن صفحه سابقه</translation>
-<translation id="8493948351860045254">آزاد کردن فضا</translation>
-<translation id="8497726226069778601">هنوز… چیزی برای دیدن وجود ندارد</translation>
-<translation id="8503559462189395349">‏گذرواژه‌های Chrome</translation>
-<translation id="8503813439785031346">نام کاربری</translation>
-<translation id="8514477925623180633">‏صادر کردن گذرواژه‌های ذخیره‌شده در Chrome</translation>
-<translation id="8514577642972634246">ورود به حالت ناشناس</translation>
-<translation id="851751545965956758">مسدود کردن سایت‌ها برای اتصال به دستگاه‌ها</translation>
-<translation id="8523928698583292556">حذف گذرواژه ذخیره‌شده</translation>
-<translation id="854522910157234410">باز کردن این صفحه</translation>
-<translation id="8558485628462305855">‏برای مشاهده محتوای واقعیت افزوده، ARCore را به‌روزرسانی کنید</translation>
-<translation id="8559990750235505898">پیشنهاد ترجمه صفحات نوشته‌شده به زبان‌های دیگر</translation>
-<translation id="8562452229998620586">گذرواژه‌های ذخیره شده در اینجا ظاهر می‌شود.</translation>
-<translation id="8569404424186215731">از <ph name="DATE" /></translation>
-<translation id="8571213806525832805">۴ هفته گذشته</translation>
-<translation id="857943718398505171">مجاز (توصیه می‌شود)</translation>
-<translation id="8583805026567836021">پاک‌سازی داده‌های حساب</translation>
-<translation id="860043288473659153">نام صاحب کارت</translation>
-<translation id="8609465669617005112">انتقال به بالا</translation>
-<translation id="8616006591992756292">‏ممکن است حساب Google شما اشکال دیگری از سابقه مرور در <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> داشته باشد.</translation>
-<translation id="8617240290563765734">نشانی وب مشخص شده در محتوای بارگیری‌شده باز شود؟</translation>
-<translation id="8636825310635137004">برای دسترسی به برگه‌هایتان در دستگاه‌های دیگر، همگام‌سازی را روشن کنید.</translation>
-<translation id="8641930654639604085">سایت‌های مخصوص بزرگ‌سالان مسدود شوند</translation>
-<translation id="8655129584991699539">‏می‌توانید داده‌ها را در تنظیمات Chrome پاک کنید</translation>
-<translation id="8662811608048051533">شما را از سیستم اکثر سایت‌ها خارج می‌کند.</translation>
-<translation id="8664979001105139458">نام فایل از قبل وجود دارد</translation>
-<translation id="8676374126336081632">پاک کردن ورودی</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{سطح قدرت سیگنال: # نوار}one{سطح قدرت سیگنال: # نوار}other{سطح قدرت سیگنال: # نوار}}</translation>
-<translation id="868929229000858085">جستجوی مخاطبین</translation>
-<translation id="869891660844655955">تاریخ انقضا</translation>
-<translation id="8719023831149562936">انتقال برگه کنونی با پرتو ممکن نیست</translation>
-<translation id="8725066075913043281">سعی مجدد</translation>
-<translation id="8728487861892616501">‏درصورت استفاده از این برنامه، با <ph name="BEGIN_LINK1" />شرایط خدمات<ph name="END_LINK1" /> و <ph name="BEGIN_LINK2" />اعلان حریم خصوصی<ph name="END_LINK2" /> و <ph name="BEGIN_LINK3" />اعلان حریم خصوصی برای حساب‌های Google مدیریت‌شده با Family Link<ph name="END_LINK3" /> مربوط به Chrome موافقت می‌کنید.</translation>
-<translation id="8730621377337864115">تمام</translation>
-<translation id="8748850008226585750">محتوا پنهان است</translation>
-<translation id="8751914237388039244">تصویری انتخاب کنید</translation>
-<translation id="8788265440806329501">سابقه «پیمایش» بسته است</translation>
-<translation id="8788968922598763114">دوباره باز کردن آخرین برگه بسته‌شده</translation>
-<translation id="8801436777607969138">مسدود کردن جاوااسکریپت برای سایتی خاص.</translation>
-<translation id="8812260976093120287">در بعضی از وب‌سایت‌ها، می‌توانید با برنامه‌های پرداخت پشتیبانی‌شده بالا در دستگاهتان پرداخت کنید.</translation>
-<translation id="8816026460808729765">سایت‌ها نمی‌توانند به حسگرها دسترسی داشته باشند</translation>
-<translation id="8816439037877937734">‏<ph name="APP_NAME" /> در Chrome باز خواهد شد. درصورت ادامه دادن، با <ph name="BEGIN_LINK1" />شرایط خدمات<ph name="END_LINK1" /> و <ph name="BEGIN_LINK2" />اعلان حریم خصوصی<ph name="END_LINK2" /> Chrome و <ph name="BEGIN_LINK3" />اعلان حریم خصوصی برای حساب‌های Google مدیریت‌شده با Family<ph name="END_LINK3" /> موافقت می‌کنید.</translation>
-<translation id="8820817407110198400">نشانک‌ها</translation>
-<translation id="8833831881926404480">سایتی درحال به‌اشتراک گذاشتن صفحه‌تان است</translation>
-<translation id="883806473910249246">هنگام بارگیری محتوا خطایی روی داد.</translation>
-<translation id="8840953339110955557">ممکن است این صفحه با نسخه آنلاین متفاوت باشد.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />، برگه</translation>
-<translation id="885701979325669005">فضای ذخیره‌سازی</translation>
-<translation id="889338405075704026">‏به تنظیمات Chrome بروید</translation>
-<translation id="8901170036886848654">نشانکی پیدا نشد</translation>
-<translation id="8909135823018751308">اشتراک‌گذاری‌...</translation>
-<translation id="8912362522468806198">‏حساب Google</translation>
-<translation id="8920114477895755567">در انتظار اطلاعات والدین.</translation>
+<translation id="1188239144602654184">‏وارد شدن به AR</translation>
+<translation id="473775607612524610">به‌روزرسانی</translation>
+<translation id="3133489217401741157">‏درحال نصب <ph name="MODULE"/> برای Brave…</translation>
+<translation id="1791662854739702043">نصب‌شده</translation>
+<translation id="5131234170665854056">‏<ph name="MODULE"/> برای Brave نصب نشد</translation>
+<translation id="2567385386134582609">تصویر</translation>
+<translation id="6395288395575013217">پیوند</translation>
+<translation id="7352939065658542140">ویدیو</translation>
+<translation id="4116038641877404294">برای استفاده از صفحه‌ها در حالت آفلاین، آن‌ها را بارگیری کنید</translation>
 <translation id="8922289737868596582">برای استفاده از صفحه‌ها در حالت آفلاین، آن‌ها را با دکمه «گزینه‌های بیشتر» بارگیری کنید</translation>
-<translation id="8937772741022875483">‏فعالیت Chrome شما در «آسایش دیجیتالی» برداشته شود؟</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">باز کردن در پنجره دیگر</translation>
-<translation id="8951232171465285730">‏Chrome ‏<ph name="MEGABYTES" /> مگابایت از داده‌های شما را ذخیره کرده است</translation>
-<translation id="8958424370300090006">کوکی‌ها را برای سایت خاصی مسدود کنید.</translation>
-<translation id="8959122750345127698">پیمایش غیرقابل دسترسی است: <ph name="URL" /></translation>
-<translation id="8965591936373831584">در انتظار</translation>
-<translation id="8970887620466824814">مشکلی پیش آمد.</translation>
-<translation id="8972098258593396643">در پوشه پیش‌فرض بارگیری شود؟</translation>
-<translation id="8986494364107987395">‏ارسال خودکار آمار کاربرد و گزارش‌های خرابی به Google</translation>
-<translation id="8993760627012879038">باز کردن برگه جدیدی در حالت ناشناس</translation>
-<translation id="8998729206196772491">‏هم‌اکنون درحال ورود به سیستم با یک حساب مدیریت‌شده توسط <ph name="MANAGED_DOMAIN" /> و ارائه کنترل داده‌های Chrome خودتان به سرپرست این حساب هستید. داده‌هایتان به‌طور دائم به این حساب مرتبط می‌شوند. با خروج از Chrome، داده‌هایتان از این دستگاه حذف می‌شوند اما همچنان در حساب Google شما باقی می‌ماند.</translation>
-<translation id="9019902583201351841">مدیریت شده توسط والدین شما</translation>
-<translation id="9028914725102941583">برای اشتراک‌گذاری بین دستگاه‌ها، «همگام‌سازی» را روشن کنید</translation>
-<translation id="9029323097866369874">‏به <ph name="DOMAIN" /> اجازه می‌دهید به حالت VR وارد شود؟</translation>
-<translation id="9040142327097499898">اعلان‌ها مجاز هستند. مکان برای این دستگاه خاموش است.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# ویدیو}one{# ویدیو}other{# ویدیو}}</translation>
-<translation id="9050666287014529139">عبارت عبور</translation>
-<translation id="9063523880881406963">خاموش کردن درخواست سایت رایانه‌ای</translation>
-<translation id="9065203028668620118">ویرایش</translation>
-<translation id="9070377983101773829">شروع جستجوی گفتاری</translation>
-<translation id="9074336505530349563">‏برای اینکه Google محتوای شخصی‌شده به شما پیشنهاد دهد، به سیستم وارده شوید و همگام‌سازی را روشن کنید</translation>
-<translation id="9086455579313502267">دسترسی به شبکه امکان‌پذیر نیست</translation>
-<translation id="9100505651305367705">پیشنهاد نمایش مقالات در نمای ساده‌شده، درصورت پشتیبانی</translation>
-<translation id="9100610230175265781">عبارت عبور لازم است</translation>
-<translation id="9102803872260866941">برگه پیش‌نمایش باز است</translation>
+<translation id="5958275228015807058">فایل‌ها و صفحه‌هایتان را در «بارگیری‌ها» پیدا کنید</translation>
+<translation id="5620928963363755975">با استفاده از دکمه «گزینه‌های بیشتر»، فایل‌ها و صفحه‌هایتان را در «بارگیری‌ها» پیدا کنید</translation>
+<translation id="3341058695485821946">ببینید چه مقدار داده صرفه‌جویی کرده‌اید</translation>
+<translation id="3157842584138209013">با استفاده از دکمه «گزینه‌های بیشتر»، ببینید چه مقدار داده صرفه‌جویی کرده‌اید</translation>
+<translation id="8218622182176210845">مدیریت حساب</translation>
+<translation id="8090895580117672212">‏برای مدیریت تنظیمات حساب Brave Software، روی دکمه «مدیریت حساب» ضربه بزنید</translation>
+<translation id="8856898588039823173">‏صفحه ساده‌شده را Brave Software ارائه کرده است. برای بارگیری صفحه اصلی، ضربه بزنید.</translation>
+<translation id="8134317863207426198">‏صفحه ساده‌شده را Brave Software ارائه کرده است. برای بارگیری صفحه اصلی، روی دکمه بارگیری صفحه اصلی ضربه بزنید.</translation>
+<translation id="4961107849584082341">ترجمه این صفحه به زبان‌های دیگر</translation>
+<translation id="569536719314091526">با استفاده از دکمه «گزینه‌های بیشتر»، این صفحه را به زبان‌های دیگر ترجمه کنید</translation>
+<translation id="1397811292916898096">جستجو با <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">هرزمان بخواهید می‌توانید محل پیش‌فرض بارگیری را تغییر دهید</translation>
+<translation id="6942665639005891494">هرزمان بخواهید می‌توانید با استفاده از منوی «تنظیمات»، محل پیش‌فرض بارگیری را تغییر دهید</translation>
+<translation id="6850409657436465440">بارگیری هنوز درحال انجام است</translation>
+<translation id="5817715962196959877">‏اکنون Brave فایل‌ها را سریع‌تر بارگیری می‌کند</translation>
+<translation id="3976396876660209797">این میان‌بر را بردارید و دوباره ایجاد کنید</translation>
+<translation id="6766622839693428701">برای بستن، تند به پایین بکشید.</translation>
+<translation id="1028699632127661925">درحال ارسال به <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - ارسال‌شده از <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">برگه دریافت شد</translation>
 <translation id="9104217018994036254">فهرست دستگاه‌هایی که می‌توان با آن‌ها برگه هم‌رسانی کرد.</translation>
-<translation id="9133397713400217035">کاوش درحالت آفلاین</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">نمایش مورد اصلی</translation>
-<translation id="9139068048179869749">قبل از اجازه به سایت‌ها برای ارسال اعلان ابتدا سؤال شود (توصیه می‌شود)</translation>
-<translation id="9139318394846604261">خرید</translation>
-<translation id="9155898266292537608">می‌توانید با ضربه‌ای سریع روی کلمه نیز جستجو کنید</translation>
-<translation id="9169507124922466868">سابقه «پیمایش» نیمه‌باز است</translation>
-<translation id="9204836675896933765">۱ فایل باقی مانده است</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">فهرست نیمه‌باز دستگاه‌هایی که می‌توان با آن‌ها برگه هم‌رسانی کرد.</translation>
+<translation id="2904414404539560095">فهرست دستگاه‌هایی که می‌توان با آن‌ها برگه هم‌رسانی کرد کاملاً باز است.</translation>
+<translation id="4135200667068010335">فهرست دستگاه‌هایی که می‌توان با آن‌ها برگه هم‌رسانی کرد، بسته است.</translation>
+<translation id="5292796745632149097">ارسال به</translation>
+<translation id="1386674309198842382">آخرین فعالیت: <ph name="LAST_UPDATED"/> روز قبل</translation>
+<translation id="7971136598759319605">آخرین فعالیت: ۱ روز قبل</translation>
+<translation id="1521774566618522728">امروز فعال بود</translation>
+<translation id="3631987586758005671">درحال هم‌رسانی با <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">برای اشتراک‌گذاری بین دستگاه‌ها، «همگام‌سازی» را روشن کنید</translation>
+<translation id="6162454065885854378">‏برای به‌اشتراک گذاشتن چیزی از تلفنتان با دستگاهی دیگر، در تنظیمات Brave هر دو دستگاه «همگام‌سازی» را روشن کنید</translation>
+<translation id="6084271560289605378">‏به تنظیمات Brave بروید</translation>
+<translation id="2318045970523081853">برای برقراری تماس، ضربه بزنید.</translation>
 <translation id="9209888181064652401">برقراری تماس ممکن نیست</translation>
-<translation id="9219103736887031265">تصاویر</translation>
-<translation id="926205370408745186">‏فعالیت Chrome شما از «آسایش دیجیتالی» برداشته شود</translation>
-<translation id="932327136139879170">منزل</translation>
-<translation id="938850635132480979">خطا: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">دسترسی به میکروفن</translation>
-<translation id="95817756606698420">‏Chrome می‌تواند از <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> برای جستجو در چین استفاده کند. در <ph name="BEGIN_LINK" />تنظیمات<ph name="END_LINK" /> می‌توانید این را تغییر دهید.</translation>
-<translation id="965817943346481315">اگر سایتْ آگهی‌های مزاحم یا گمراه‌کننده نشان می‌دهد مسدود شود (توصیه می‌شود)</translation>
-<translation id="968900484120156207">صفحاتی را که بازدید کرده‌اید، اینجا نمایش داده می‌شوند</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> دقیقه باقی‌مانده است</translation>
-<translation id="974555521953189084">برای شروع همگام‌سازی، عبارت عبورتان را وارد کنید</translation>
-<translation id="981121421437150478">آفلاین</translation>
-<translation id="982182592107339124">با این کار داده‌های همه سایت‌ها پاک می‌شود، از جمله:</translation>
-<translation id="983192555821071799">بستن همه برگه‌ها</translation>
-<translation id="987264212798334818">موارد کلی</translation>
+<translation id="2860954141821109167">مطمئن شوید برنامه تلفن در این دستگاه فعال باشد</translation>
+<translation id="2067805253194386918">نوشتار</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> هم‌رسانی نشد</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> هم‌رسانی نشد</translation>
+<translation id="8287068819750208230">‏مطمئن شوید همگام‌سازی <ph name="TARGET_DEVICE_NAME"/> در Brave روشن باشد</translation>
+<translation id="3016635187733453316">مطمئن شوید این دستگاه به اینترنت متصل باشد</translation>
+<translation id="8466613982764129868">مطمئن شوید <ph name="TARGET_DEVICE_NAME"/> به اینترنت متصل باشد</translation>
+<translation id="6539092367496845964">مشکلی پیش آمد. بعداً دوباره امتحان کنید.</translation>
+<translation id="3389286852084373014">نوشتار خیلی بزرگ است</translation>
+<translation id="2100314319871056947">بخش‌های کوچک‌تری از نوشتار را به اشتراک بگذارید</translation>
+<translation id="2987620471460279764">نوشتار هم‌رسانی‌شده از دستگاه دیگر</translation>
+<translation id="7757787379047923882">نوشتار هم‌رسانی‌شده از <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">در بریده‌دان کپی شد</translation>
+<translation id="4696983787092045100">ارسال نوشتار به دستگاه‌های شما</translation>
+<translation id="1260236875608242557">جستجو و کاوش</translation>
+<translation id="6369229450655021117">از اینجا می‌توانید وب را جستجو کنید، با دوستان هم‌رسانی کنید و صفحات باز را ببینید</translation>
+<translation id="723171743924126238">انتخاب تصاویر</translation>
+<translation id="8751914237388039244">تصویری انتخاب کنید</translation>
+<translation id="1989112275319619282">مشاهده محتوای موجود در فروشگاه ما</translation>
+<translation id="7055152154916055070">هدایت کردن مسدود شده است:</translation>
+<translation id="5524843473235508879">هدایت کردن مسدود شد.</translation>
+<translation id="6573096386450695060">همیشه مجاز</translation>
+<translation id="5805364706385912897">‏این صفحه از حافظه بسیار زیادی استفاده می‌کند، بنابراین Brave موقتاً آن را متوقف کرد.</translation>
+<translation id="5138664332909611586">‏این صفحه حافظه خیلی زیادی استفاده می‌کند، به‌همین‌دلیل Brave برخی از محتوا را پاک کرد.</translation>
+<translation id="9137013805542155359">نمایش مورد اصلی</translation>
+<translation id="6361779936989026201">‏«دستیار Brave Software» در Brave</translation>
+<translation id="7291387454912369099">تسویه‌حساب فعال‌شده ازسوی دستیار</translation>
+<translation id="4565206163201411670">‏فعالیت Brave شما در «آسایش دیجیتالی» نشان داده شود؟</translation>
+<translation id="9055113864158719823">‏می‌توانید سایت‌هایی را که در Brave بازدید می‌کنید مشاهده کنید و تایمرهایی را برای آن‌ها تنظیم کنید.\n\n‏Brave Software اطلاعاتی درباره سایت‌هایی که برای آن‌ها تایمر تنظیم می‌کنید و مدت زمانی که از آن‌ها بازدید می‌کنید، دریافت می‌کند. از این اطلاعات برای بهبود «آسایش دیجیتالی» استفاده می‌شود.</translation>
+<translation id="4596514158372210596">‏فعالیت Brave شما از «آسایش دیجیتالی» برداشته شود</translation>
+<translation id="1174893863889683998">‏فعالیت Brave شما در «آسایش دیجیتالی» برداشته شود؟</translation>
+<translation id="708829030563435351">‏سایت‌هایی که در Brave بازدید می‌کنید، نشان داده نخواهد شد. همه تایمرهای سایت حذف خواهد شد.</translation>
+<translation id="2056878612599315956">سایت موقتاً متوقف شد</translation>
+<translation id="671481426037969117">تایمر <ph name="FQDN"/> شما متوقف شد. دوباره فردا شروع به کار می‌کند.</translation>
+<translation id="7479104141328977413">مدیریت برگه</translation>
+<translation id="3524138585025253783">رابط کاربری برنامه‌نویس</translation>
+<translation id="6036057147555329831">‏ICU اضافی</translation>
+<translation id="9029323097866369874">‏به <ph name="DOMAIN"/> اجازه می‌دهید به حالت VR وارد شود؟</translation>
+<translation id="7685301384041462804">‏پیش از وارد شدن به حالت VR، مطمئن شوید به این سایت اعتماد دارید.</translation>
+<translation id="5033865233969348410">‏درمدتی که در حالت VR هستید، این سایت می‌تواند به این‌ها پی‌ببرد:
+  -  ویژگی‌های فیزیکی، مانند قد شما
+
+پیش از وارد شدن به VR، مطمئن شوید به این سایت اعتماد دارید.</translation>
+<translation id="5534334044554683961">‏درمدتی که در حالت VR هستید، این سایت می‌تواند به این‌ها پی‌ببرد:
+  -   ویژگی‌های فیزیکی، مانند قد شما
+  -   چیدمان اتاقتان
+
+پیش از وارد شدن به VR، مطمئن شوید به این سایت اعتماد دارید.</translation>
+<translation id="4169535189173047238">اجازه داده نشود</translation>
+<translation id="2170088579611075216">‏اجازه دادن و وارد شدن به VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_fi.xtb
+++ b/android/java/strings/translations/android_chrome_strings_fi.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="fi">
-<translation id="1006017844123154345">Avaa verkkoversio</translation>
-<translation id="1028699632127661925">Lähetetään: <ph name="DEVICE_NAME" /></translation>
-<translation id="1036727731225946849">Lisätään <ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">Verkkosivustoilta</translation>
-<translation id="1049743911850919806">Incognito</translation>
-<translation id="10614374240317010">Ei tallenneta</translation>
-<translation id="1067922213147265141">Muut Google-palvelut</translation>
-<translation id="1068672505746868501">Älä koskaan käännä kielellä <ph name="SOURCE_LANGUAGE" /> kirjoitettuja sivuja.</translation>
-<translation id="107147699690128016">Jos vaihdat tiedostotunnisteen, tiedosto voi avautua eri sovelluksessa ja mahdollisesti vahingoittaa laitetta.</translation>
-<translation id="1100066534610197918">Avaa uusi välilehti ja ryhmä</translation>
-<translation id="1105960400813249514">Kuvakaappaus</translation>
-<translation id="1111673857033749125">Muilla laitteilla tallentamasi kirjanmerkit näytetään täällä.</translation>
-<translation id="1113597929977215864">Näytä yksinkertaistettu näkymä</translation>
-<translation id="1121094540300013208">Käyttö- ja virheraportit</translation>
-<translation id="1124772482545689468">Käyttäjä</translation>
-<translation id="1129510026454351943">Tiedot: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 lataus odottaa}other{# latausta odottaa}}</translation>
-<translation id="1145536944570833626">Poistaa olemassa olevat tiedot.</translation>
-<translation id="1146678959555564648">Siirry VR-tilaan</translation>
-<translation id="116280672541001035">Käytetty</translation>
-<translation id="1171770572613082465">Katso suositut sivustot napauttamalla Suosituimmat sivustot ‑painiketta</translation>
-<translation id="1173894706177603556">Muuta nimeä</translation>
-<translation id="1178581264944972037">Tauko</translation>
-<translation id="1181037720776840403">Poista</translation>
-<translation id="1188239144602654184">Lisää AR</translation>
-<translation id="1197267115302279827">Siirrä kirjanmerkkejä</translation>
-<translation id="119944043368869598">Tyhjennä kaikki</translation>
-<translation id="1201402288615127009">Seuraava</translation>
-<translation id="1204037785786432551">Lataa linkin kohde</translation>
-<translation id="1206892813135768548">Kopioi linkin teksti</translation>
-<translation id="1208340532756947324">Ota synkronointi käyttöön, niin sisältö synkronoidaan ja yksilöidään eri laitteilla</translation>
-<translation id="1209206284964581585">Piilota toistaiseksi</translation>
-<translation id="1227058898775614466">Navigointihistoria</translation>
-<translation id="1231733316453485619">Otetaanko synkronointi käyttöön?</translation>
-<translation id="123724288017357924">Päivitä nykyinen sivu, ohita välimuistin sisältö</translation>
-<translation id="124116460088058876">Lisää kieliä</translation>
-<translation id="124678866338384709">Sulje nykyinen välilehti</translation>
-<translation id="1258753120186372309">Google-piirros: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Hae ja tutki</translation>
-<translation id="1264974993859112054">Urheilu</translation>
-<translation id="1266864766717917324">Jakaminen epäonnistui: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Pysäytä</translation>
-<translation id="1283039547216852943">Laajenna napauttamalla.</translation>
-<translation id="1285320974508926690">Älä käännä tätä sivustoa</translation>
-<translation id="1291207594882862231">Tyhjennä historia, evästeet, sivustojen tiedot, välimuisti ja niin edelleen.</translation>
-<translation id="129382876167171263">Sivustojen tallentamat tiedostot näkyvät tässä</translation>
-<translation id="129553762522093515">Hiljattain suljetut välilehdet</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Lähetetty laitteelta <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Ryhmittele välilehtiä</translation>
-<translation id="1327257854815634930">Navigointihistoria avattu</translation>
-<translation id="1331212799747679585">Chromea ei voi päivittää. Lisää vaihtoehtoja</translation>
-<translation id="1332501820983677155">Google Chromen ominaisuuksien pikanäppäimet</translation>
-<translation id="1360432990279830238">Kirjaudu ulos ja lopeta synkronointi?</translation>
-<translation id="1369915414381695676">Sivusto <ph name="SITE_NAME" /> lisättiin.</translation>
-<translation id="1373696734384179344">Liian vähän muistia valitun sisällön lataamiseen.</translation>
-<translation id="1376578503827013741">Lasketaan…</translation>
-<translation id="1383876407941801731">Haku</translation>
-<translation id="1384959399684842514">Lataus keskeytettiin.</translation>
-<translation id="1386674309198842382">Aktiivinen <ph name="LAST_UPDATED" /> päivää sitten</translation>
-<translation id="1397811292916898096">Hae nimellä <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Upotettu osoitteeseen <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Do Not Track</translation>
-<translation id="1407135791313364759">Avaa kaikki</translation>
-<translation id="1409426117486808224">Yksinkertaisempi avoimien välilehtien näkymä</translation>
-<translation id="1409879593029778104">Tiedoston <ph name="FILE_NAME" /> lataus estettiin, koska tiedosto on jo olemassa.</translation>
-<translation id="1414981605391750300">Otetaan yhteyttä Googleen. Tämä voi kestää hetken…</translation>
-<translation id="1416550906796893042">Sovellusversio</translation>
-<translation id="1430915738399379752">Tulosta</translation>
-<translation id="1446450296470737166">Salli MIDI-laitteiden täysi käyttöoik.</translation>
-<translation id="1450753235335490080">Jakaminen ei onnistu: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Poistettu käytöstä Android-asetuksissa</translation>
-<translation id="1477626028522505441">Tiedoston <ph name="FILE_NAME" /> lataus epäonnistui palvelinongelman vuoksi.</translation>
-<translation id="1506061864768559482">Hakukone</translation>
-<translation id="1513352483775369820">Kirjanmerkit ja verkkohistoria</translation>
-<translation id="1513858653616922153">Poista salasana</translation>
-<translation id="1516229014686355813">Napauttamalla hakeminen lähettää valitun sanan ja nykyisen sivun Google Haulle hakukontekstina. Voit poistaa ominaisuuden käytöstä <ph name="BEGIN_LINK" />asetuksissa<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktiivinen tänään</translation>
-<translation id="1544826120773021464">Voit ylläpitää Google-tiliäsi napauttamalla Ylläpidä tiliä ‑painiketta</translation>
-<translation id="1549000191223877751">Siirrä toiseen ikkunaan</translation>
-<translation id="1553358976309200471">Päivitä Chrome</translation>
-<translation id="1569387923882100876">Yhdistetty laite</translation>
-<translation id="1571304935088121812">Kopioi käyttäjänimi</translation>
-<translation id="1612196535745283361">Chrome tarvitsee sijaintitietoja hakeakseen laitteita. Sijaintitiedot on <ph name="BEGIN_LINK" />poistettu käytöstä tällä laitteella<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Estä tätä sivua luomasta muita viestejä</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Poista 1 valittu kohde}other{Poista # valittua kohdetta}}</translation>
-<translation id="164269334534774161">Katselet sivun offline-kopiota, joka luotiin <ph name="CREATION_TIME" />.</translation>
-<translation id="1644574205037202324">Historia</translation>
-<translation id="1647391597548383849">Kameran käyttöoikeus</translation>
-<translation id="1660204651932907780">Salli sivustojen toistaa ääniä (suositus)</translation>
-<translation id="1670399744444387456">Perusvaihtoehdot</translation>
-<translation id="1671236975893690980">Lataus odottaa…</translation>
-<translation id="1672586136351118594">Älä näytä uudelleen</translation>
-<translation id="1692118695553449118">Synkronointi on käytössä.</translation>
-<translation id="169515064810179024">Estä sivustoja käyttämästä liiketunnistimien lukemia</translation>
-<translation id="1717218214683051432">Liiketunnistimet</translation>
-<translation id="1718835860248848330">Viimeinen tunti</translation>
-<translation id="1736419249208073774">Tutustu</translation>
-<translation id="1743802530341753419">Pyydä lupaa, kun sivustot yrittävät yhdistää laitteeseen (suositus)</translation>
-<translation id="1749561566933687563">Synkronoi kirjanmerkit</translation>
-<translation id="17513872634828108">Avoimet välilehdet</translation>
-<translation id="1779089405699405702">Kuvien dekooderi</translation>
-<translation id="1782483593938241562">Päättymispäivä: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Asennettu</translation>
-<translation id="1792959175193046959">Muuta oletuslataussijaintia milloin tahansa</translation>
-<translation id="1807246157184219062">Vaalea</translation>
-<translation id="1810845389119482123">Synkronoinnin alkumääritys ei valmis</translation>
-<translation id="1821253160463689938">Käyttää evästeitä asetustesi muistamiseen, vaikka et kävisi kyseisillä sivuilla</translation>
-<translation id="1829244130665387512">Haku sivulta</translation>
-<translation id="1853692000353488670">Uusi incognito-välilehti</translation>
-<translation id="1856325424225101786">Palautetaanko yksinkertaistettu tila?</translation>
-<translation id="1868024384445905608">Chrome lataa tiedostot nyt nopeammin</translation>
-<translation id="1883903952484604915">Omat tiedostot</translation>
-<translation id="1887786770086287077">Sijainti on poissa käytöstä tällä laitteella. Voit ottaa sen käyttöön <ph name="BEGIN_LINK" />Android-asetuksista<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> avautuu Chromessa. Jatkamalla hyväksyt Chromen <ph name="BEGIN_LINK1" />käyttöehdot<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />tietosuojailmoituksen<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Mainokset</translation>
-<translation id="1919950603503897840">Valitse kontaktit</translation>
-<translation id="1922076542920281912">Ota sijaintitiedot käyttöön myös <ph name="BEGIN_LINK" />Android-asetuksissa<ph name="END_LINK" />, niin Chrome voi käyttää sijaintiasi.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Päivitykset</translation>
-<translation id="19288952978244135">Avaa Chrome uudelleen.</translation>
-<translation id="1933845786846280168">Valittu välilehti</translation>
-<translation id="194341124344773587">Ota käyttöoikeus käyttöön Chromelle <ph name="BEGIN_LINK" />Android-asetuksissa<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Salasanojen tallentaminen</translation>
-<translation id="1952172573699511566">Verkkosivustot näyttävät tekstin valitsemallasi kielellä, kun se on mahdollista.</translation>
-<translation id="1960290143419248813">Chrome-päivityksiä ei enää tueta tässä Android-versiossa.</translation>
-<translation id="1966710179511230534">Päivitä kirjautumistietosi.</translation>
-<translation id="1974060860693918893">Lisäasetukset</translation>
-<translation id="1984705450038014246">Chrome-datan synkronointi</translation>
-<translation id="1984937141057606926">Sallittu, paitsi kolmannen osapuolen evästeet</translation>
-<translation id="1986685561493779662">Nimi on jo käytössä</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" />-painike</translation>
-<translation id="1989112275319619282">Selaa</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> haluaa muodostaa laiteparin</translation>
-<translation id="1994173015038366702">Sivuston URL-osoite</translation>
-<translation id="2000419248597011803">Lähettää joitakin osoitekentän ja hakukentän kautta tehtyjä hakuja sekä joitakin evästeitä oletushakukoneellesi</translation>
-<translation id="2002537628803770967">Luottokortit ja osoitteet Google Paysta</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# tiedosto}other{# tiedostoa}}</translation>
-<translation id="2017836877785168846">Tyhjentää historian ja osoitepalkin automaattiset täydennykset.</translation>
-<translation id="2021896219286479412">Ohjaimet koko näytön tilassa</translation>
-<translation id="2038563949887743358">Ota käyttöön Käytä tietokoneversiota</translation>
-<translation id="2041019821020695769">Ota ilmoitukset käyttöön myös <ph name="BEGIN_LINK" />Android-asetuksissa<ph name="END_LINK" />, niin Chrome voi lähettää sinulle ilmoituksia.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> sisältää dataa myös Chromessa</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Sivusto keskeytetty</translation>
-<translation id="2063713494490388661">Hae napauttamalla</translation>
-<translation id="2067805253194386918">tekstiviesti</translation>
-<translation id="2079545284768500474">Kumoa</translation>
-<translation id="2082238445998314030">Tulos <ph name="RESULT_NUMBER" />/<ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Ääni</translation>
-<translation id="2096012225669085171">Synkronoi ja yksilöi kaikilla laitteilla</translation>
-<translation id="2100273922101894616">Automaattinen kirjautuminen</translation>
-<translation id="2100314319871056947">Kokeile jakaa teksti pienempinä pätkinä</translation>
-<translation id="2107397443965016585">Kysy, saavatko sivustot toistaa suojattua sisältöä (suositus)</translation>
-<translation id="2111511281910874386">Siirry sivulle</translation>
-<translation id="2122601567107267586">Sovelluksen avaaminen epäonnistui</translation>
-<translation id="2126426811489709554">Palvelun tarjoaa Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> tallennettu</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> suljettiin</translation>
-<translation id="2139186145475833000">Lisää aloitusnäyttöön</translation>
-<translation id="2146738493024040262">Avaa Instant-sovellus</translation>
-<translation id="2148716181193084225">Tänään</translation>
-<translation id="2154484045852737596">Muokkaa korttia</translation>
-<translation id="2154710561487035718">Kopioi URL-osoite</translation>
-<translation id="2156074688469523661">Jäljellä olevat sivustot (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Jos haluat jakaa jotakin puhelimelta toiselle laitteelle, ota synkronointi käyttöön molempien laitteiden Chrome-asetuksista</translation>
-<translation id="2170088579611075216">Salli ja aloita VR</translation>
-<translation id="218608176142494674">Jakaminen</translation>
-<translation id="2227444325776770048">Jatka tilillä <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synkronointi ja Google-palvelut</translation>
-<translation id="2259659629660284697">Vie salasanat…</translation>
-<translation id="2268044343513325586">Tarkenna</translation>
-<translation id="2286841657746966508">Laskutusosoite</translation>
-<translation id="2289270750774289114">Kysy aina, kun sivusto pyytää lupaa löytää lähellä olevat Bluetooth-laitteet (suositus)</translation>
-<translation id="230115972905494466">Yhteensopivia laitteita ei löytynyt.</translation>
-<translation id="2315043854645842844">Käyttöjärjestelmä ei tue palvelimen varmennevalintaa.</translation>
-<translation id="2318045970523081853">Soita napauttamalla</translation>
-<translation id="2321086116217818302">Valmistellaan salasanoja…</translation>
-<translation id="2321958826496381788">Vedä liukusäädintä, kunnes voit lukea tämän mukavasti. Tekstin tulisi olla vähintään näin suurta kaksoisnapautettuasi kappaletta.</translation>
-<translation id="2323763861024343754">Sivustotietoja tallennettu</translation>
-<translation id="2328985652426384049">Kirjautuminen epäonnistui</translation>
-<translation id="2330129964253841015">Varoita, jos salasanoja vaarantuu</translation>
-<translation id="2349710944427398404">Chromen käyttämän tallennustilan kokonaismäärä, mukaan lukien tilit, kirjanmerkit ja tallennetut asetukset.</translation>
-<translation id="2353636109065292463">Internetyhteyttäsi tarkistetaan</translation>
-<translation id="2359808026110333948">Jatka</translation>
-<translation id="2369533728426058518">Avoimet välilehdet</translation>
-<translation id="2387895666653383613">Tekstin skaalaus</translation>
-<translation id="2394602618534698961">Lataamasi tiedostot näkyvät tässä</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> Mt</translation>
-<translation id="2407481962792080328">Tämä ominaisuus otetaan käyttöön, kun kirjaudut Google-tilillesi</translation>
-<translation id="2410754283952462441">Valitse tili</translation>
-<translation id="2414886740292270097">Tumma</translation>
-<translation id="2416359993254398973">Chrome tarvitsee oikeuden käyttää kameraasi tällä sivustolla.</translation>
-<translation id="2426805022920575512">Valitse toinen tili</translation>
-<translation id="2433507940547922241">Ulkonäkö</translation>
-<translation id="2434158240863470628">Lataus valmis <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Sijaintitietojen käyttöoikeus</translation>
-<translation id="2450083983707403292">Haluatko aloittaa tiedoston <ph name="FILE_NAME" /> lataamisen uudelleen?</translation>
-<translation id="2482878487686419369">Ilmoitukset</translation>
-<translation id="2490684707762498678">Ylläpitäjä: <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Chromen Google Assistant</translation>
-<translation id="2496180316473517155">Selaushistoria</translation>
-<translation id="2497852260688568942">Järjestelmänvalvoja on poistanut synkronoinnin käytöstä.</translation>
-<translation id="2498359688066513246">Ohjeet ja palaute</translation>
-<translation id="2501278716633472235">Takaisin</translation>
-<translation id="2513403576141822879">Näet lisää yksityisyyteen, tietoturvaan ja datankeruuseen liittyviä asetuksia <ph name="BEGIN_LINK" />Synkronointi ja Google-palvelut<ph name="END_LINK" /> ‑kohdassa.</translation>
-<translation id="2518590038762162553">Yksinkertaistetussa tilassa Chrome lataa sivuja nopeammin ja käyttää jopa 60 % vähemmän dataa. Chrome lähettää verkkoliikenteesi tietoja Googlelle avaamiesi sivujen optimoimiseksi. <ph name="BEGIN_LINK" />Lue lisää<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Lähettää avaamiesi sivujen URL-osoitteet Googlelle</translation>
-<translation id="2532336938189706096">Verkkonäkymä</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> kohdetta poistettu</translation>
-<translation id="2536728043171574184">Näkyvissä on sivun offline-versio.</translation>
-<translation id="2546283357679194313">Evästeet ja sivustotiedot</translation>
-<translation id="2567385386134582609">KUVA</translation>
-<translation id="257088987046510401">Teemat</translation>
-<translation id="2570922361219980984">Sijainti on poissa käytöstä myös tällä laitteella. Voit ottaa sen käyttöön <ph name="BEGIN_LINK" />Android-asetuksista<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Laajennettu – tiivistä klikkaamalla.</translation>
-<translation id="2581165646603367611">Evästeet, välimuisti ja muut Chromen vähemmän tärkeinä pitämät sivustotiedot poistetaan.</translation>
-<translation id="2586657967955657006">Leikepöytä</translation>
-<translation id="2587052924345400782">Uudempi versio on saatavilla.</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Kortin numero</translation>
-<translation id="2621115761605608342">Salli JavaScript tietyllä sivustolla.</translation>
-<translation id="2625189173221582860">Salasana kopioitu</translation>
-<translation id="2631006050119455616">Säästetty</translation>
-<translation id="2647434099613338025">Lisää kieli</translation>
-<translation id="2650751991977523696">Ladataanko tiedosto uudelleen?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# äänitiedosto}other{# äänitiedostoa}}</translation>
-<translation id="2653659639078652383">Lähetä</translation>
-<translation id="2677748264148917807">Poistu</translation>
-<translation id="2704606927547763573">Kopioitu</translation>
-<translation id="2707726405694321444">Päivitä sivu</translation>
-<translation id="2709516037105925701">Automaattinen täyttö</translation>
-<translation id="2717722538473713889">Sähköpostiosoitteet</translation>
-<translation id="2728754400939377704">Lajittele sivuston mukaan</translation>
-<translation id="2744248271121720757">Napauta sanaa etsiäksesi välittömästi tai nähdäksesi asiaan liittyviä toimia.</translation>
-<translation id="2760989362628427051">Ota tumma teema käyttöön, kun laitteen tumma teema tai virransäästö on käytössä</translation>
-<translation id="2762000892062317888">äsken</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> sekuntia jäljellä</translation>
-<translation id="2779651927720337254">epäonnistui</translation>
-<translation id="2781151931089541271">1 sekunti jäljellä</translation>
-<translation id="2801022321632964776">Päivitä Chrome uusimpaan versioon, niin se toimii omalla kielelläsi</translation>
-<translation id="2810645512293415242">Yksinkertaistettu sivu, joka säästää dataa ja latautuu nopeammin.</translation>
-<translation id="281504910091592009">Katso ja ylläpidä <ph name="BEGIN_LINK" />Google-tilille<ph name="END_LINK" /> tallennettuja salasanoja</translation>
-<translation id="2818669890320396765">Kirjaudu sisään ja ota synkronointi käyttöön, niin voit käyttää kirjanmerkkejäsi kaikilla laitteilla</translation>
-<translation id="2822354292072154809">Haluatko varmasti nollata kaikki sivuston käyttöoikeudet (<ph name="CHOSEN_OBJECT_NAME" />)?</translation>
-<translation id="2836148919159985482">Poistu koko näytön tilasta Takaisin-painikkeella.</translation>
-<translation id="2842985007712546952">Ylätason kansio</translation>
-<translation id="2858138569776157458">Suosituimmat</translation>
-<translation id="2860954141821109167">Varmista, että puhelinsovellus on käytössä tällä laitteella</translation>
-<translation id="2870560284913253234">Sivusto</translation>
-<translation id="2874939134665556319">Edellinen kappale</translation>
-<translation id="2876369937070532032">Lähettää joidenkin avattujen sivujen URL-osoitteet Googlelle, kun turvallisuutesi on vaarassa</translation>
-<translation id="2888126860611144412">Tietoja Chromesta</translation>
-<translation id="2891154217021530873">Pysäytä sivun lataus</translation>
-<translation id="2893180576842394309">Google voi muokata Hakua ja muita Googlen palveluita historiasi perusteella</translation>
-<translation id="2898264748040935573">Muokkaa tallennettua salasanaa</translation>
-<translation id="2900528713135656174">Luo tapahtuma</translation>
-<translation id="290376772003165898">Eikö sivu ole kirjoitettu kielellä <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Välilehden jakamisen laiteluettelo avataan koko näytön korkeudella.</translation>
-<translation id="2910701580606108292">Kysy, saavatko sivustot toistaa suojattua sisältöä</translation>
-<translation id="2913331724188855103">Salli sivustojen tallentaa ja lukea evästetietoja (suositus).</translation>
-<translation id="2923908459366352541">Nimi on virheellinen</translation>
-<translation id="2932150158123903946">Tallennustila: Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Esikatseluvälilehti on suljettu</translation>
-<translation id="2956410042958133412">Tätä tiliä hallinnoivat <ph name="PARENT_NAME_1" /> ja <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Vaihdettiin näkyviin incognito-välilehdet.</translation>
-<translation id="2968755619301702150">Varmennetiedot</translation>
-<translation id="2979025552038692506">Valittu incognito-välilehti</translation>
-<translation id="2987620471460279764">Toiselta laitteelta jaettu teksti</translation>
-<translation id="2989523299700148168">Viimeksi käytetyt</translation>
-<translation id="2996291259634659425">Luo tunnuslause</translation>
-<translation id="2996809686854298943">URL-osoite vaaditaan</translation>
-<translation id="300526633675317032">Tämä tyhjentää yhteensä <ph name="SIZE_IN_KB" /> tallennettuja sivustotietoja.</translation>
-<translation id="3016635187733453316">Varmista, että laite on yhteydessä internetiin</translation>
-<translation id="3029613699374795922">Ladattu: <ph name="KBS" /> kt</translation>
-<translation id="3029704984691124060">Tunnuslauseet eivät vastaa toisiaan.</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Tutustu ohjeisiin<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Sijainti on pois käytöstä. Voit ottaa sen käyttöön <ph name="BEGIN_LINK" />Android-asetuksista<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Voit ottaa synkronoinnin käyttöön milloin tahansa asetuksista.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> kirjanmerkki}other{<ph name="BOOKMARKS_COUNT_MANY" /> kirjanmerkkiä}}</translation>
-<translation id="3089395242580810162">Avaa incognito-välilehdellä</translation>
-<translation id="3115898365077584848">Näytä tiedot</translation>
-<translation id="3123473560110926937">Estetty tietyillä sivustoilla</translation>
-<translation id="3137521801621304719">Poistu incognito-tilasta</translation>
-<translation id="3143515551205905069">Peruuta synkronointi</translation>
-<translation id="3157842584138209013">Lisäasetukset-painiketta klikkaamalla voit katsoa, kuinka paljon dataa olet säästänyt.</translation>
-<translation id="3166827708714933426">Välilehti- ja ikkunapikanäppäimet</translation>
-<translation id="3181954750937456830">Selaussuoja (suojaa sinua ja laitettasi vaarallisilta sivustoilta)</translation>
-<translation id="3190152372525844641">Ota käyttöoikeudet käyttöön Chromelle <ph name="BEGIN_LINK" />Android-asetuksissa<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> tallennettua tietoa</translation>
-<translation id="3205824638308738187">Melkein valmista</translation>
-<translation id="3207960819495026254">Kirjanmerkeissä</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> poistettiin.</translation>
-<translation id="321773570071367578">Jos unohdat tunnuslauseesi tai haluat muokata tätä asetusta, <ph name="BEGIN_LINK" />nollaa synkronointi<ph name="END_LINK" />.</translation>
-<translation id="3227137524299004712">Mikrofoni</translation>
-<translation id="3232754137068452469">Verkkosovellus</translation>
-<translation id="3236059992281584593">1 minuutti jäljellä</translation>
-<translation id="3244271242291266297">KK</translation>
-<translation id="3254409185687681395">Luo kirjanmerkki tälle sivulle</translation>
-<translation id="3259831549858767975">Pienennä sivun kaikki sisältö</translation>
-<translation id="3269093882174072735">Lataa kuva</translation>
-<translation id="3269956123044984603">Ota tietojen automaattinen synkronointi käyttöön Androidin tiliasetuksissa, niin voit käyttää välilehtiäsi kaikilla laitteilla.</translation>
-<translation id="3277252321222022663">Anna sivustojen käyttää tunnistimia (suositus)</translation>
-<translation id="3282568296779691940">Kirjaudu Chromeen</translation>
-<translation id="3288003805934695103">Lataa sivu uudelleen.</translation>
-<translation id="32895400574683172">Ilmoitukset sallitaan</translation>
-<translation id="3295530008794733555">Selaa nettiä nopeammin. Käytä vähemmän dataa.</translation>
-<translation id="3295602654194328831">Piilota tiedot</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Jatketaanko sisällön lataamiseen?</translation>
-<translation id="3306398118552023113">Tämä sovellus on käynnissä Chromessa</translation>
-<translation id="3315103659806849044">Yksilöit parhaillaan synkronoinnin ja Google-palvelujen asetuksia. Viimeistele synkronoinnin käyttöönotto napauttamalla näytön alaosasta Vahvista-painiketta. Siirry ylös</translation>
-<translation id="3328801116991980348">Tietoja sivustosta</translation>
-<translation id="3333961966071413176">Kaikki yhteystiedot</translation>
-<translation id="3334729583274622784">Vaihdetaanko tiedostotunniste?</translation>
-<translation id="3341058695485821946">Katso paljonko dataa olet säästänyt</translation>
-<translation id="3350687908700087792">Sulje kaikki incognito-välilehdet.</translation>
-<translation id="3353615205017136254">Googlen tarjoama yksinkertaistettu sivu. Valitse Lataa alkuperäinen, jos haluat ladata alkuperäisen sivun.</translation>
-<translation id="3367813778245106622">Aloita synkronointi kirjautumalla uudelleen sisään.</translation>
-<translation id="3374023511497244703">Kirjanmerkkejä, historiaa, salasanoja tai muuta Chrome-dataa ei enää synkronoida Google-tilille.</translation>
-<translation id="3384347053049321195">Jaa kuva</translation>
-<translation id="3386292677130313581">Pyydä lupaa, kun sivustot yrittävät käyttää sijaintiasi (suositus).</translation>
-<translation id="3387650086002190359">Tiedoston <ph name="FILE_NAME" /> lataus epäonnistui tiedostojärjestelmävirheen vuoksi.</translation>
-<translation id="3389286852084373014">Teksti on liian suuri</translation>
-<translation id="3398320232533725830">Avaa kirjanmerkkien hallinta</translation>
-<translation id="3414952576877147120">Koko:</translation>
-<translation id="3443221991560634068">Päivitä nykyinen sivu</translation>
-<translation id="3445014427084483498">Äsken</translation>
-<translation id="3478363558367712427">Voit valita hakukoneen</translation>
+<translation id="6910211073230771657">Poistettu</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Selvä</translation>
+<translation id="7658239707568436148">Peruuta</translation>
 <translation id="3479552764303398839">Ei nyt</translation>
-<translation id="3492207499832628349">Uusi incognito-välilehti</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Lue lisätietoja<ph name="END_LINK" /> suositellusta sisällöstä.</translation>
-<translation id="3513704683820682405">Lisätty todellisuus</translation>
-<translation id="3518985090088779359">Hyväksy ja jatka</translation>
-<translation id="3522247891732774234">Päivitys on saatavilla. Näytä lisäasetukset.</translation>
-<translation id="3524138585025253783">Kehittäjän UI</translation>
-<translation id="3527085408025491307">Kansio</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> kt käytettävissä</translation>
-<translation id="3549657413697417275">Haku omasta historiasta</translation>
-<translation id="3557336313807607643">Lisää yhteystietoihin</translation>
-<translation id="3566923219790363270">Chrome valmistelee edelleen VR-selainta. Käynnistä Chrome myöhemmin uudelleen.</translation>
-<translation id="3568688522516854065">Kirjaudu sisään ja ota synkronointi käyttöön, niin voit käyttää välilehtiä muilta laitteiltasi</translation>
-<translation id="3587482841069643663">Kaikki</translation>
-<translation id="358794129225322306">Anna sivuston ladata useita tiedostoja automaattisesti.</translation>
-<translation id="3590487821116122040">Tallennetut sivustotiedot, joita Chrome ei pidä tärkeinä (esim. sivustot, joilla ei ole tallennettuja asetuksia tai joilla et käy usein).</translation>
-<translation id="3599863153486145794">Tyhjentää kaikkien sisäänkirjautuneiden laitteiden historian. Google-tililläsi voi olla muuta toimintaa osoitteessa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Mykistä ääniä toistavat sivustot</translation>
-<translation id="3616113530831147358">Ääni</translation>
-<translation id="3631987586758005671">Jaetaan: <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Paljasta salasana</translation>
-<translation id="363596933471559332">Kirjaudu automaattisesti verkkosivustoille käyttämällä tallennettuja kirjautumistietoja. Jos tämä toiminto ei ole käytössä, sinua pyydetään vahvistamaan kirjautuminen aina, kun kirjaudut sivustolle.</translation>
-<translation id="3658159451045945436">Nollaaminen tyhjentää datansäästöhistoriasi, mukaan lukien luettelon paikoista, joissa olet käynyt.</translation>
-<translation id="3692944402865947621">Lataus epäonnistui, koska tallennussijainti ei ole saatavilla: <ph name="FILE_NAME" /></translation>
-<translation id="3714981814255182093">Avaa hakupalkki</translation>
-<translation id="3716182511346448902">Tämä sivu käyttää liikaa muistia, joten Chrome keskeytti sen.</translation>
-<translation id="3730075448226062617">Ota mikrofoni käyttöön myös <ph name="BEGIN_LINK" />Android-asetuksissa<ph name="END_LINK" />, niin Chrome voi käyttää mikrofoniasi.</translation>
-<translation id="3739899004075612870">Lisätty kirjanmerkkeihin: <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Taustasynkronointi</translation>
-<translation id="3771001275138982843">Päivityksen lataaminen epäonnistui</translation>
-<translation id="3771033907050503522">Incognito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Ota Bluetooth käyttöön<ph name="END_LINK" />, jotta laiteparin muodostus onnistuu.</translation>
-<translation id="3775705724665058594">Lähetä laitteillesi</translation>
-<translation id="3778956594442850293">Lisätty aloitusnäytölle</translation>
-<translation id="3789841737615482174">Asenna</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Hallinnoi</translation>
-<translation id="381841723434055211">Puhelinnumerot</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> latausta poistettiin.</translation>
-<translation id="3822502789641063741">Poistetaanko tiedot?</translation>
-<translation id="385051799172605136">Edellinen</translation>
-<translation id="3859306556332390985">Kelaa eteenpäin</translation>
-<translation id="3894427358181296146">Lisää kansio</translation>
-<translation id="3895926599014793903">Ota zoomaus käyttöön</translation>
-<translation id="3912508018559818924">Haetaan verkon parasta sisältöä…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Yhdistä tiedot</translation>
-<translation id="393697183122708255">Puhehaku ei ole käytössä</translation>
-<translation id="395206256282351086">Haku- ja sivustoehdotukset on poistettu käytöstä.</translation>
-<translation id="3955193568934677022">Salli sivustojen toistaa suojattua sisältöä (suositus)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome lataa sivusi, kun se on valmis}other{Chrome lataa sivusi, kun ne ovat valmiina}}</translation>
-<translation id="3963007978381181125">Google Payn maksutapoja tai osoitteita ei salata tunnuslauseella. Salattua dataa voidaan lukea vain tunnuslauseesi avulla. Tunnuslausetta ei lähetetä Googlelle eikä Google tallenna sitä. Jos unohdat tunnuslauseesi tai haluat muokata tätä asetusta, synkronointi täytyy nollata. <ph name="BEGIN_LINK" />Lisätietoja<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Lataus on valmis</translation>
-<translation id="397583555483684758">Synkronointi on lakannut toimimasta.</translation>
-<translation id="3976396876660209797">Poista tämä pikakuvake ja luo se uudelleen.</translation>
-<translation id="3985215325736559418">Haluatko ladata tiedoston <ph name="FILE_NAME" /> uudelleen?</translation>
-<translation id="3987993985790029246">Kopioi linkki</translation>
-<translation id="3988213473815854515">Sijainnin käyttö on sallittu.</translation>
-<translation id="3988466920954086464">Näytä Instant-hakutulokset tässä paneelissa</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Vähemmän tärkeät tiedot</translation>
-<translation id="4000212216660919741">Offline-etusivu</translation>
+<translation id="5317780077021120954">Tallenna</translation>
+<translation id="4570913071927164677">Tiedot</translation>
+<translation id="8730621377337864115">Valmis</translation>
+<translation id="8261506727792406068">Poista</translation>
+<translation id="1181037720776840403">Poista</translation>
+<translation id="5939518447894949180">Tyhjennä</translation>
 <translation id="4002066346123236978">Nimi</translation>
-<translation id="4008040567710660924">Salli evästeet tietyllä sivustolla.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Seuraava kappale</translation>
-<translation id="4048707525896921369">Lue lisätietoja verkkosivujen aiheista poistumatta sivulta. Napauttamalla hakeminen lähettää sanan ja sen asiayhteyden Google Hakuun ja palauttaa määritelmiä, kuvia, hakutuloksia ja muita tietoja.
+<translation id="5916664084637901428">Käytössä</translation>
+<translation id="5860033963881614850">Pois käytöstä</translation>
+<translation id="6165508094623778733">Lisätietoja</translation>
+<translation id="6042308850641462728">Lisää</translation>
+<translation id="6040143037577758943">Sulje</translation>
+<translation id="780301667611848630">Ei kiitos</translation>
+<translation id="1201402288615127009">Seuraava</translation>
+<translation id="2359808026110333948">Jatka</translation>
+<translation id="2653659639078652383">Lähetä</translation>
+<translation id="2079545284768500474">Kumoa</translation>
+<translation id="7649070708921625228">Ohje</translation>
+<translation id="2148716181193084225">Tänään</translation>
+<translation id="7781829728241885113">Eilen</translation>
+<translation id="6945221475159498467">Valitse</translation>
+<translation id="7791543448312431591">Lisää</translation>
+<translation id="6527303717912515753">Jaa</translation>
+<translation id="1383876407941801731">Haku</translation>
+<translation id="3115898365077584848">Näytä tiedot</translation>
+<translation id="3295602654194328831">Piilota tiedot</translation>
+<translation id="3987993985790029246">Kopioi linkki</translation>
+<translation id="2704606927547763573">Kopioitu</translation>
+<translation id="8725066075913043281">Yritä uudelleen</translation>
+<translation id="385051799172605136">Edellinen</translation>
+<translation id="8131740175452115882">Vahvista</translation>
+<translation id="5300589172476337783">Näytä</translation>
+<translation id="1124772482545689468">Käyttäjä</translation>
+<translation id="8609465669617005112">Siirrä ylös</translation>
+<translation id="6746124502594467657">Siirrä alas</translation>
+<translation id="8249310407154411074">Siirrä ylimmäksi</translation>
+<translation id="8428213095426709021">Asetukset</translation>
+<translation id="2498359688066513246">Ohjeet ja palaute</translation>
+<translation id="8378714024927312812">Organisaatiosi ylläpitämä</translation>
+<translation id="9019902583201351841">Vanhempiesi hallinnoima</translation>
+<translation id="4645575059429386691">Vanhempasi hallinnoima</translation>
+<translation id="4883854917563148705">Ylläpidettyjä asetuksia ei voi nollata</translation>
+<translation id="4307992518367153382">Perustiedot</translation>
+<translation id="1974060860693918893">Lisäasetukset</translation>
+<translation id="1146678959555564648">Siirry VR-tilaan</translation>
+<translation id="987264212798334818">Yleistä</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Lataukset</translation>
+<translation id="218608176142494674">Jakaminen</translation>
+<translation id="8004582292198964060">Selain</translation>
+<translation id="1105960400813249514">Kuvakaappaus</translation>
+<translation id="4875775213178255010">Sisältöehdotukset</translation>
+<translation id="2021896219286479412">Ohjaimet koko näytön tilassa</translation>
+<translation id="4587589328781138893">Sivustot</translation>
+<translation id="4943703118917034429">Virtuaalitodellisuus</translation>
+<translation id="1928696683969751773">Päivitykset</translation>
+<translation id="6064125863973209585">Valmiit lataukset</translation>
+<translation id="5342314432463739672">Käyttöoikeuspyynnöt</translation>
+<translation id="629730747756840877">Tili</translation>
+<translation id="82609232232243542">Kirjaudu Braveen</translation>
+<translation id="7956662517480676674">Synkronointi ja Brave Software-palvelut</translation>
+<translation id="5294439808117722387">Yksilöit parhaillaan synkronoinnin ja Brave Software-palvelujen asetuksia. Viimeistele synkronoinnin käyttöönotto napauttamalla näytön alaosasta Vahvista-painiketta. Siirry ylös</translation>
+<translation id="2096012225669085171">Synkronoi ja yksilöi kaikilla laitteilla</translation>
+<translation id="1692118695553449118">Synkronointi on käytössä.</translation>
+<translation id="5514904542973294328">Laitteen järjestelmänvalvojan estämä</translation>
+<translation id="6447211988989208781">Brave Software-toimintojen hallinta</translation>
+<translation id="4882831918239250449">Määritä, miten selaushistoria personoi hakua, mainoksia ja muita</translation>
+<translation id="7431991332293347422">Määritä, miten selaushistoria personoi Hakua ja muita</translation>
+<translation id="6303969859164067831">Kirjaudu ulos ja poista synkronointi käytöstä</translation>
+<translation id="1125261911132334651">Ylläpidä Brave Software-tiliäsi</translation>
+<translation id="6406506848690869874">Synkronointi</translation>
+<translation id="714362445477979774">Brave-datan synkronointi</translation>
+<translation id="4314815835985389558">Synkronointiasetusten muokkaus</translation>
+<translation id="5428209950370661546">Muut Brave Software-palvelut</translation>
+<translation id="7704317875155739195">Täydennä automaattisesti hakuja ja URL-osoitteita</translation>
+<translation id="2000419248597011803">Lähettää joitakin osoitekentän ja hakukentän kautta tehtyjä hakuja sekä joitakin evästeitä oletushakukoneellesi</translation>
+<translation id="7981313251711023384">Esilataa sivuja nopeuttaaksesi lataamista ja hakemista</translation>
+<translation id="1821253160463689938">Käyttää evästeitä asetustesi muistamiseen, vaikka et kävisi kyseisillä sivuilla</translation>
+<translation id="6697492270171225480">Näytä ehdotuksia samankaltaisista sivuista, kun sivua ei löydy</translation>
+<translation id="8109318360573330108">Lähettää Brave Softwarelle etsimäsi sivun URL-osoitteen</translation>
+<translation id="8438566539970814960">Paranna hakuja ja selausta</translation>
+<translation id="284843628681142937">Lähettää avaamiesi sivujen URL-osoitteet Brave Softwarelle</translation>
+<translation id="7222718784508482526">Näet lisää yksityisyyteen, tietoturvaan ja datankeruuseen liittyviä asetuksia <ph name="BEGIN_LINK"/>Synkronointi ja Brave Software-palvelut<ph name="END_LINK"/> ‑kohdassa.</translation>
+<translation id="918192811481327695">Auta parantamaan Braven ominaisuuksia ja suorituskykyä</translation>
+<translation id="9063160602596686558">Lähettää automaattisesti käyttötilastoja ja virheraportteja Brave Softwarelle</translation>
+<translation id="4824958205181053313">Peruutetaanko synkronointi?</translation>
+<translation id="3058498974290601450">Voit ottaa synkronoinnin käyttöön milloin tahansa asetuksista.</translation>
+<translation id="3143515551205905069">Peruuta synkronointi</translation>
+<translation id="1506061864768559482">Hakukone</translation>
+<translation id="55737423895878184">Sijainti ja ilmoitukset sallitaan</translation>
+<translation id="3988213473815854515">Sijainnin käyttö on sallittu.</translation>
+<translation id="32895400574683172">Ilmoitukset sallitaan</translation>
+<translation id="9040142327097499898">Ilmoitukset sallitaan. Sijainti on poissa käytöstä tällä laitteella.</translation>
+<translation id="305593374596241526">Sijainti on pois käytöstä. Voit ottaa sen käyttöön <ph name="BEGIN_LINK"/>Android-asetuksista<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Viimeksi käytetyt</translation>
+<translation id="6433501201775827830">Valitse hakukone</translation>
+<translation id="7177466738963138057">Voit muuttaa tätä myöhemmin Asetuksista.</translation>
+<translation id="3478363558367712427">Voit valita hakukoneen</translation>
+<translation id="4910889077668685004">Maksusovellukset</translation>
+<translation id="5152843274749979095">Ei asennettuja tuettuja sovelluksia</translation>
+<translation id="8812260976093120287">Tietyt sivustot tukevat yllä mainittuja laitteesi yhteensopivia maksusovelluksia.</translation>
+<translation id="7764225426217299476">Lisää osoite</translation>
+<translation id="5595485650161345191">Osoitteen muokkaus</translation>
+<translation id="5087580092889165836">Lisää kortti</translation>
+<translation id="2154484045852737596">Muokkaa korttia</translation>
+<translation id="6140912465461743537">Maa/alue</translation>
+<translation id="5659593005791499971">Sähköposti</translation>
+<translation id="4378154925671717803">Puhelin</translation>
+<translation id="4807098396393229769">Kortissa oleva nimi</translation>
+<translation id="860043288473659153">Kortinhaltijan nimi</translation>
+<translation id="2612676031748830579">Kortin numero</translation>
+<translation id="869891660844655955">Vanhenemispäivämäärä</translation>
+<translation id="2286841657746966508">Laskutusosoite</translation>
+<translation id="663059986967017181">Kopioitiin Braveen.</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> muu}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> muuta}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> muu}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> muuta}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> muu}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> muuta}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> muu}other{<ph name="CONTACT_PREVIEW"/>\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> muuta}}</translation>
+<translation id="7029809446516969842">Salasanat</translation>
+<translation id="1943432128510653496">Salasanojen tallentaminen</translation>
+<translation id="2100273922101894616">Automaattinen kirjautuminen</translation>
+<translation id="363596933471559332">Kirjaudu automaattisesti verkkosivustoille käyttämällä tallennettuja kirjautumistietoja. Jos tämä toiminto ei ole käytössä, sinua pyydetään vahvistamaan kirjautuminen aina, kun kirjaudut sivustolle.</translation>
+<translation id="6995899638241819463">Varoita, jos salasanoja vaarantuu tietosuojaloukkauksessa</translation>
+<translation id="1534287762301776620">Tämä ominaisuus otetaan käyttöön, kun kirjaudut Brave Software-tilillesi</translation>
+<translation id="10614374240317010">Ei tallenneta</translation>
+<translation id="3098842761938485917">Katso ja ylläpidä <ph name="BEGIN_LINK"/>Brave Software-tilille<ph name="END_LINK"/> tallennettuja salasanoja</translation>
+<translation id="8562452229998620586">Tässä näytetään tallennetut salasanasi.</translation>
+<translation id="8084114998886531721">Salasana tallennettu</translation>
+<translation id="2870560284913253234">Sivusto</translation>
+<translation id="8503813439785031346">Käyttäjätunnus</translation>
+<translation id="6657585470893396449">Salasana</translation>
+<translation id="2154710561487035718">Kopioi URL-osoite</translation>
+<translation id="1571304935088121812">Kopioi käyttäjänimi</translation>
+<translation id="5005498671520578047">Kopioi salasana</translation>
+<translation id="3632295766818638029">Paljasta salasana</translation>
+<translation id="1513858653616922153">Poista salasana</translation>
+<translation id="543338862236136125">Muokkaa salasanaa</translation>
+<translation id="4565377596337484307">Piilota salasana</translation>
+<translation id="8523928698583292556">Poista tallennettu salasana</translation>
+<translation id="2898264748040935573">Muokkaa tallennettua salasanaa</translation>
+<translation id="5433691172869980887">Käyttäjänimi kopioitu</translation>
+<translation id="5534640966246046842">Sivusto kopioitu</translation>
+<translation id="2625189173221582860">Salasana kopioitu</translation>
+<translation id="4550003330909367850">Aseta laitteelle näytön lukitus, niin voit nähdä ja kopioida salasanasi tässä.</translation>
+<translation id="6154478581116148741">Ota näytön lukitus käyttöön asetuksista viedäksesi salasanoja laitteelta.</translation>
+<translation id="4842092870884894799">Salasanojen luomisen ponnahdusikkuna on näkyvissä.</translation>
+<translation id="2259659629660284697">Vie salasanat…</translation>
+<translation id="133012818630824069">Vie Braveen tallennetut salasanat</translation>
+<translation id="6914783257214138813">Salasanasi näkyvät kaikille, jotka näkevät viedyn tiedoston.</translation>
+<translation id="2321086116217818302">Valmistellaan salasanoja…</translation>
+<translation id="8445448999790540984">Salasanojen vienti epäonnistui</translation>
+<translation id="3066461326500799725">Ohjeet Brave Software Driven käyttöön</translation>
+<translation id="729975465115245577">Laitteella ei ole sovellusta, johon salasanatiedoston voisi tallentaa.</translation>
+<translation id="7682724950699840886">Kokeile seuraavia keinoja: varmista, että laitteellasi on tarpeeksi tilaa, yritä viedä uudelleen.</translation>
+<translation id="1129510026454351943">Tiedot: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Avaa lukitus kopioidaksesi salasanan</translation>
+<translation id="5515439363601853141">Avaa lukitus nähdäksesi salasanan</translation>
+<translation id="6221633008163990886">Avaa lukitus viedäksesi salasanoja.</translation>
+<translation id="230699814587342492">Brave-salasanat</translation>
+<translation id="6075798973483050474">Muokkaa etusivua</translation>
+<translation id="854522910157234410">Avaa tämä sivu</translation>
+<translation id="2482878487686419369">Ilmoitukset</translation>
+<translation id="6255999984061454636">Sisältöehdotukset</translation>
+<translation id="805047784848435650">Selaushistoriasi perusteella</translation>
+<translation id="1041308826830691739">Verkkosivustoilta</translation>
+<translation id="395206256282351086">Haku- ja sivustoehdotukset on poistettu käytöstä.</translation>
+<translation id="257088987046510401">Teemat</translation>
+<translation id="4650364565596261010">Järjestelmän oletusarvo</translation>
+<translation id="7588219262685291874">Ota tumma teema käyttöön, kun laitteen virransäästö on käytössä</translation>
+<translation id="2760989362628427051">Ota tumma teema käyttöön, kun laitteen tumma teema tai virransäästö on käytössä</translation>
+<translation id="6381421346744604172">Tummenna sivustot</translation>
+<translation id="5040262127954254034">Tietosuoja</translation>
+<translation id="4991384657077828949">Auta parantamaan Braven suojausta</translation>
+<translation id="1943176487615318915">Vaarallisia sovelluksia ja sivustoja löytääkseen Brave lähettää joidenkin avattujen sivujen URL-osoitteita, rajallisia järjestelmätietoja ja osia sivujen sisällöstä Brave Softwarelle</translation>
+<translation id="3181954750937456830">Selaussuoja (suojaa sinua ja laitettasi vaarallisilta sivustoilta)</translation>
+<translation id="7315322926489145388">Lähettää joidenkin avattujen sivujen URL-osoitteet Brave Softwarelle, kun turvallisuutesi on vaarassa</translation>
+<translation id="2063713494490388661">Hae napauttamalla</translation>
+<translation id="2369463299479365221">Lue lisätietoja verkkosivujen aiheista poistumatta sivulta. Napauttamalla hakeminen lähettää sanan ja sen asiayhteyden Brave Software Hakuun ja palauttaa määritelmiä, kuvia, hakutuloksia ja muita tietoja.
 
 Muokkaa hakutermiä valitsemalla se pitkällä painalluksella. Tarkenna hakua liu'uttamalla paneeli yläasentoon ja napauttamalla hakukenttää.</translation>
-<translation id="4056223980640387499">Seepia</translation>
-<translation id="4060598801229743805">Toimintoja on käytettävissä näytön yläosassa.</translation>
-<translation id="4062305924942672200">Oikeudelliset tiedot</translation>
-<translation id="4084682180776658562">Kirjanmerkki</translation>
-<translation id="4084712963632273211">Lähde: <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />Googlen toimittama<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Poistetaanko sovellustiedot?</translation>
-<translation id="4099578267706723511">Auta parantamaan Chromea lähettämällä käyttötilastoja ja virheraportteja Googlelle.</translation>
-<translation id="410351446219883937">Automaattinen toisto</translation>
-<translation id="4116038641877404294">Lataa sivuja offline-käyttöä varten</translation>
-<translation id="4135200667068010335">Välilehden jakamisen laiteluettelo on suljettu.</translation>
-<translation id="4149994727733219643">Yksinkertaisempi sivunäkymä</translation>
-<translation id="4165986682804962316">Sivustoasetukset</translation>
-<translation id="4169535189173047238">Älä salli</translation>
-<translation id="4170011742729630528">Palvelu ei ole käytettävissä. Yritä myöhemmin uudelleen.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> käytetty</translation>
-<translation id="4181841719683918333">Kielet</translation>
-<translation id="4183868528246477015">Hae Google Lensillä <ph name="BEGIN_NEW" />Uusi<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Avaa uudelle välilehdelle</translation>
-<translation id="4198423547019359126">Tallennussijainteja ei ole saatavilla</translation>
-<translation id="4209895695669353772">Ota synkronointi käyttöön, niin näet Googlen suosittelemaa yksilöllistä sisältöä</translation>
-<translation id="4226663524361240545">Laite voi väristä ilmoitusten yhteydessä.</translation>
-<translation id="423219824432660969">Salaa synkronoitu data Google-salasanalla (<ph name="TIME" />)</translation>
-<translation id="4242533952199664413">Avaa asetukset</translation>
-<translation id="4256782883801055595">Avoimen lähdekoodin käyttöluvat</translation>
-<translation id="4259722352634471385">Kohde on estetty: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopioi linkin osoite</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Sallittu</translation>
-<translation id="429312253194641664">Sivusto toistaa mediaa</translation>
-<translation id="4298388696830689168">Linkitetyt sivustot</translation>
-<translation id="4307992518367153382">Perustiedot</translation>
-<translation id="4314815835985389558">Synkronointiasetusten muokkaus</translation>
-<translation id="4351244548802238354">Sulje ikkuna</translation>
-<translation id="4378154925671717803">Puhelin</translation>
-<translation id="4384468725000734951">Hakukoneena käytetään Sogouta.</translation>
-<translation id="4404568932422911380">Ei kirjanmerkkejä</translation>
-<translation id="4405224443901389797">Siirrä…</translation>
-<translation id="4411535500181276704">Yksinkertaistettu tila</translation>
-<translation id="4415276339145661267">Ylläpidä Google-tiliäsi</translation>
-<translation id="4432792777822557199">Kielellä <ph name="SOURCE_LANGUAGE" /> kirjoitetut sivut käännetään tästä lähtien kielelle <ph name="TARGET_LANGUAGE" />.</translation>
-<translation id="4433925000917964731">Googlen tarjoama yksinkertaistettu sivu</translation>
-<translation id="4434045419905280838">Ponn.ikkunat ja uudelleenohj.</translation>
-<translation id="4440958355523780886">Googlen tarjoama yksinkertaistettu sivu. Lataa alkuperäinen napauttamalla.</translation>
-<translation id="4452411734226507615">Sulje välilehti <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Lisätty kirjanmerkiksi kansioon <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Salli sivustojen toistaa suojattua sisältöä</translation>
-<translation id="4468959413250150279">Mykistä tietyn sivuston äänet.</translation>
-<translation id="4472118726404937099">Kirjaudu sisään ja ota synkronointi käyttöön, niin sisältö synkronoidaan ja yksilöidään eri laitteilla</translation>
-<translation id="447252321002412580">Auta parantamaan Chromen ominaisuuksia ja suorituskykyä</translation>
-<translation id="4479647676395637221">Pyydä lupaa, kun sivustot yrittävät käyttää kameraasi (suositus).</translation>
-<translation id="4479972344484327217">Asennetaan <ph name="MODULE" /> Chromeen…</translation>
-<translation id="4487967297491345095">Kaikki Chromen sovellustiedot, mukaan lukien tiedostot, asetukset, tilit ja tietokannat, poistetaan pysyvästi.</translation>
-<translation id="4493497663118223949">Yksinkertaistettu tila on käytössä</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# päivä sitten}other{# päivää sitten}}</translation>
-<translation id="451872707440238414">Hae kirjanmerkeistä</translation>
-<translation id="4521489764227272523">Valitut tiedot on poistettu Chromesta ja synkronoiduilta laitteilta.
-
-Google-tililläsi voi olla muita selaushistoriatietoja, kuten hakuja ja toimintaa muista Google-palveluista. Voit katsella tietoja osoitteessa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Valitse kansio</translation>
-<translation id="4538018662093857852">Ota yksinkertaistettu tila käyttöön</translation>
-<translation id="4550003330909367850">Aseta laitteelle näytön lukitus, niin voit nähdä ja kopioida salasanasi tässä.</translation>
-<translation id="4558311620361989323">Verkkosivun pikanäppäimet</translation>
-<translation id="4561979708150884304">Ei yhteyttä</translation>
-<translation id="4565377596337484307">Piilota salasana</translation>
-<translation id="4570913071927164677">Tiedot</translation>
-<translation id="4572422548854449519">Kirjaudu hallinnoidulle tilille</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minuutti sitten}other{# minuuttia sitten}}</translation>
-<translation id="4587589328781138893">Sivustot</translation>
-<translation id="4594952190837476234">Offline-sivu vastaa tilannetta <ph name="CREATION_TIME" /> ja saattaa poiketa nykyisestä verkkoversiosta.</translation>
-<translation id="4605958867780575332">Kohde poistettiin: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Avaa <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Käytä salasanaa</translation>
-<translation id="4645575059429386691">Vanhempasi hallinnoima</translation>
-<translation id="4650364565596261010">Järjestelmän oletusarvo</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> kirjanmerkkiä poistettiin</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> lisättiin aloitusnäytölle.</translation>
-<translation id="4684427112815847243">Synkronoi kaikki</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> muu}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> muuta}}</translation>
-<translation id="4696983787092045100">Lähetä teksti laitteillesi</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> voi näyttää sisältöä offline-tilassa</translation>
-<translation id="4699172675775169585">Välimuistissa olevat kuvat ja tiedostot</translation>
-<translation id="4714588616299687897">Käytä jopa 60 % vähemmän dataa</translation>
-<translation id="4719927025381752090">Tarjoudu kääntämään</translation>
-<translation id="4720023427747327413">Avaa kohteessa <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Auta parantamaan Chromea. <ph name="BEGIN_LINK" />Vastaa kyselyyn.<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Päivitä</translation>
-<translation id="4738836084190194332">Viimeisin synkronointi: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Uuden välilehden avaaminen</translation>
-<translation id="4751476147751820511">Liike- tai valotunnistimet</translation>
-<translation id="4759238208242260848">Lataukset</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 lataus on valmis}other{# latausta on valmiina}}</translation>
-<translation id="4797039098279997504">Palaa osoitteeseen <ph name="URL_OF_THE_CURRENT_TAB" /> koskettamalla.</translation>
-<translation id="4802417911091824046">Google Payn maksutapoja tai osoitteita ei salata tunnuslauseella.
-
-Jos haluat muokata asetusta, <ph name="BEGIN_LINK" />nollaa synkronointi<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Kortissa oleva nimi</translation>
-<translation id="4824958205181053313">Peruutetaanko synkronointi?</translation>
-<translation id="4837753911714442426">Avaa sivun tulostusvaihtoehdot</translation>
-<translation id="4842092870884894799">Salasanojen luomisen ponnahdusikkuna on näkyvissä.</translation>
-<translation id="4860895144060829044">Soita</translation>
-<translation id="4866368707455379617">Kohteen <ph name="MODULE" /> asennus Chromeen epäonnistui</translation>
-<translation id="4875775213178255010">Sisältöehdotukset</translation>
-<translation id="4878404682131129617">Tunnelin muodostaminen välityspalvelimen kautta epäonnistui</translation>
-<translation id="4880127995492972015">Käännä…</translation>
-<translation id="4881695831933465202">Avaa</translation>
-<translation id="488187801263602086">Nimeä tiedosto uudelleen</translation>
-<translation id="4882831918239250449">Määritä, miten selaushistoria personoi hakua, mainoksia ja muita</translation>
-<translation id="4883854917563148705">Ylläpidettyjä asetuksia ei voi nollata</translation>
-<translation id="4885273946141277891">Chromen versioiden määrää ei tueta.</translation>
-<translation id="4910889077668685004">Maksusovellukset</translation>
-<translation id="4913161338056004800">Nollaa tilastot</translation>
-<translation id="4913169188695071480">Lopeta päivittäminen</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Tutustu ohjeisiin<ph name="END_LINK" /> laitteiden skannauksen aikana…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# sivu}other{# sivua}}</translation>
-<translation id="4932247056774066048">Koska olet kirjautumassa ulos tililtä, jota <ph name="DOMAIN_NAME" /> ylläpitää, Chrome-datasi poistetaan tältä laitteelta. Se pysyy Google-tililläsi.</translation>
-<translation id="4943703118917034429">Virtuaalitodellisuus</translation>
-<translation id="4943872375798546930">Ei tuloksia</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> jakaa näyttösi.</translation>
-<translation id="4961107849584082341">Käännä sivu mille tahansa kielelle</translation>
-<translation id="4962975101802056554">Peru kaikki laitteen käyttöoikeudet</translation>
-<translation id="4970824347203572753">Ei käytettävissä sijainnissasi</translation>
-<translation id="497421865427891073">Siirry eteenpäin</translation>
-<translation id="4988210275050210843">Ladataan tiedostoa (<ph name="MEGABYTES" />)</translation>
-<translation id="4988526792673242964">Sivut</translation>
-<translation id="4994033804516042629">Kontakteja ei löytynyt</translation>
-<translation id="4996978546172906250">Jaa palvelussa:</translation>
-<translation id="5004416275253351869">Google-toimintojen hallinta</translation>
-<translation id="5005498671520578047">Kopioi salasana</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> haluaa muodostaa yhteyden</translation>
-<translation id="5013696553129441713">Ei uusia ehdotuksia</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Kun olet VR-tilassa, sivusto voi saada tietää
-  –  fyysisiä piirteitäsi, kuten pituutesi.
-
-Varmista, että sivusto on luotettava, ennen kuin siirryt VR-tilaan.</translation>
+<translation id="2930742481329940825">Napauttamalla hakeminen lähettää valitun sanan ja nykyisen sivun Brave Software Haulle hakukontekstina. Voit poistaa ominaisuuden käytöstä <ph name="BEGIN_LINK"/>asetuksissa<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Salli</translation>
-<translation id="5040262127954254034">Tietosuoja</translation>
-<translation id="5048398596102334565">Anna sivustojen käyttää liiketunnistimien lukemia (suositus)</translation>
-<translation id="5063480226653192405">Käyttö</translation>
-<translation id="5087580092889165836">Lisää kortti</translation>
-<translation id="5100237604440890931">Tiivistetty – laajenna klikkaamalla.</translation>
-<translation id="510275257476243843">1 tunti jäljellä</translation>
-<translation id="5123685120097942451">Incognito-välilehti</translation>
-<translation id="5127805178023152808">Synkronointi ei ole käytössä</translation>
-<translation id="5129038482087801250">Asenna verkkosovellus</translation>
-<translation id="5132942445612118989">Synkronoi salasanasi, historiasi ja paljon muuta kaikilla laitteilla</translation>
-<translation id="5139940364318403933">Ohjeet Google Driven käyttöön</translation>
-<translation id="515227803646670480">Poista tallennetut tiedot</translation>
-<translation id="5152843274749979095">Ei asennettuja tuettuja sovelluksia</translation>
-<translation id="5161254044473106830">Nimike vaaditaan</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 lataus epäonnistui}other{# latausta epäonnistui}}</translation>
-<translation id="5170568018924773124">Näytä kansiossa</translation>
-<translation id="5184329579814168207">Avaa Chromessa</translation>
-<translation id="5193988420012215838">Kopioitu leikepöydälle</translation>
-<translation id="5197729504361054390"><ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> saa valitsemasi yhteystiedot.</translation>
-<translation id="5199929503336119739">Työprofiili</translation>
-<translation id="5210286577605176222">Siirry edelliselle välilehdelle</translation>
-<translation id="5210365745912300556">Sulje välilehti</translation>
-<translation id="5224771365102442243">Video sivulla</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> haluaa etsiä lähellä olevia Bluetooth-laitteita. Seuraavat laitteet löydettiin:</translation>
-<translation id="5233638681132016545">Uusi välilehti</translation>
-<translation id="526421993248218238">Sivun lataaminen epäonnistui</translation>
-<translation id="5271967389191913893">Laite ei voi avata ladattavaa sisältöä.</translation>
-<translation id="528192093759286357">Poistu koko näytön tilasta vetämällä näytön yläreunasta ja koskettamalla Takaisin-painiketta.</translation>
-<translation id="5292796745632149097">Lähetä:</translation>
-<translation id="5300589172476337783">Näytä</translation>
-<translation id="5301954838959518834">Selvä</translation>
-<translation id="5304593522240415983">Kenttä ei voi olla tyhjä.</translation>
-<translation id="5307446750509046227">Poista sivustotiedot</translation>
-<translation id="5308380583665731573">Muodosta yhteys</translation>
-<translation id="5313967007315987356">Lisää sivusto</translation>
-<translation id="5317780077021120954">Tallenna</translation>
-<translation id="5324858694974489420">Vanhempien asetukset</translation>
-<translation id="5327248766486351172">Nimi</translation>
-<translation id="5335288049665977812">Anna kaikkien sivustojen käyttää JavaScriptiä (suositus).</translation>
-<translation id="5342314432463739672">Käyttöoikeuspyynnöt</translation>
-<translation id="5357811892247919462">Välilehti vastaanotettu</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> avoin välilehti, vaihda välilehteä napauttamalla}other{<ph name="OPEN_TABS_MANY" /> avointa välilehteä, vaihda välilehteä napauttamalla}}</translation>
-<translation id="5391532827096253100">Sivustolle muodostamasi yhteys ei ole turvallinen. Sivuston tiedot</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 muu)}other{(+ # muuta)}}</translation>
-<translation id="5400569084694353794">Käyttämällä sovellusta hyväksyt Chromen <ph name="BEGIN_LINK1" />käyttöehdot<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />tietosuojailmoituksen<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Nimet</translation>
-<translation id="5403644198645076998">Salli vain tietyt sivustot</translation>
-<translation id="5414836363063783498">Vahvistetaan…</translation>
-<translation id="5423934151118863508">Käydyimmät sivusi näkyvät täällä</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> Gt käytettävissä</translation>
-<translation id="543338862236136125">Muokkaa salasanaa</translation>
-<translation id="5433691172869980887">Käyttäjänimi kopioitu</translation>
-<translation id="543509235395288790">Ladataan <ph name="COUNT" /> tiedostoa (<ph name="MEGABYTES" />)</translation>
-<translation id="5441522332038954058">Siirry osoitepalkkiin</translation>
-<translation id="5447201525962359567">Kaikki tallennetut sivustotiedot, mukaan lukien evästeet ja muut paikallisesti tallennetut tiedot</translation>
-<translation id="5447765697759493033">Sivustoa ei käännetä.</translation>
-<translation id="545042621069398927">Lataustasi nopeutetaan</translation>
-<translation id="5456381639095306749">Lataa sivu</translation>
-<translation id="5475862044948910901">Aloitetaanko lisätyn todellisuuden käyttökerta?</translation>
-<translation id="548278423535722844">Avaa karttasovelluksessa</translation>
-<translation id="5487521232677179737">Poista tiedot</translation>
-<translation id="5494752089476963479">Estä häiritseviä tai harhaanjohtavia mainoksia näyttävien sivustojen mainokset</translation>
-<translation id="5500777121964041360">Ei ole välttämättä käytettävissä asuinpaikassasi</translation>
-<translation id="5512137114520586844">Tätä tiliä hallinnoi <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Laitteen järjestelmänvalvojan estämä</translation>
-<translation id="5515439363601853141">Avaa lukitus nähdäksesi salasanan</translation>
-<translation id="5516455585884385570">Avaa ilmoitusasetukset</translation>
-<translation id="5517095782334947753">Tililläsi <ph name="FROM_ACCOUNT" /> on kirjanmerkkejä, salasanoja ja muita asetuksia.</translation>
-<translation id="5524843473235508879">Uudelleenohjaus estetty</translation>
-<translation id="5527082711130173040">Chrome tarvitsee sijaintitietoja hakeakseen laitteita. <ph name="BEGIN_LINK1" />Päivitä käyttöoikeudet<ph name="END_LINK1" />. Sijaintitiedot on lisäksi <ph name="BEGIN_LINK2" />poistettu käytöstä tällä laitteella<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Pyydä lupaa, kun sivustot yrittävät lukea tekstiä ja kuvia leikepöydältä (suositus)</translation>
-<translation id="5530766185686772672">Sulje incognito-välilehdet</translation>
-<translation id="5534334044554683961">Kun olet VR-tilassa, sivusto voi saada tietää
-  –  fyysisiä piirteitäsi, kuten pituutesi
-  –  huoneesi asettelun.
-
-Varmista, että sivusto on luotettava, ennen kuin siirryt VR-tilaan.</translation>
-<translation id="5534640966246046842">Sivusto kopioitu</translation>
-<translation id="5556459405103347317">Lataa uudelleen</translation>
-<translation id="5561549206367097665">Odotetaan verkkoyhteyttä…</translation>
-<translation id="557283862590186398">Chrome tarvitsee oikeuden käyttää mikrofoniasi tällä sivustolla.</translation>
-<translation id="55737423895878184">Sijainti ja ilmoitukset sallitaan</translation>
-<translation id="5578795271662203820">Etsi tätä kuvaa palvelusta <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Voit valita synkronoitavan sisällön <ph name="BEGIN_LINK1" />asetuksissa<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Osoitteen muokkaus</translation>
-<translation id="5596627076506792578">Lisäasetukset</translation>
-<translation id="5599455543593328020">Incognito-tila</translation>
-<translation id="5620928963363755975">Valitse Lisäasetukset ja sitten Lataukset, niin löydät tiedostosi ja sivusi.</translation>
-<translation id="5626134646977739690">Nimi:</translation>
-<translation id="5639724618331995626">Salli kaikki sivustot</translation>
-<translation id="5648166631817621825">Viimeiset seitsemän päivää</translation>
-<translation id="5649053991847567735">Automaattiset lataukset</translation>
-<translation id="5655963694829536461">Hae omista latauksistasi</translation>
-<translation id="5659593005791499971">Sähköposti</translation>
-<translation id="5665379678064389456">Luo tapahtuma sovelluksessa <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ohita sivuston zoomauksen estämispyyntö</translation>
-<translation id="5677928146339483299">Estetty</translation>
-<translation id="5684874026226664614">Hups, tätä sivua ei voi kääntää.</translation>
-<translation id="5686790454216892815">Tiedoston nimi on liian pitkä</translation>
-<translation id="5689516760719285838">Sijainti</translation>
-<translation id="569536719314091526">Käännä sivu mille tahansa kielelle Lisävalinnat-painikkeella</translation>
-<translation id="572328651809341494">Hiljattain suljetut välilehdet</translation>
-<translation id="5726692708398506830">Suurenna sivun kaikki sisältö</translation>
-<translation id="5748802427693696783">Vaihdettiin näkyviin tavalliset välilehdet.</translation>
-<translation id="5749068826913805084">Chrome tarvitsee tallennustilan käyttöoikeuden tiedostojen lataamiseen.</translation>
-<translation id="5763382633136178763">Incognito-välilehdet</translation>
-<translation id="5763514718066511291">Kosketa kopioidaksesi tämän sovelluksen URL-osoite</translation>
-<translation id="5765780083710877561">Kuvaus:</translation>
-<translation id="5793665092639000975">Käytössä <ph name="SPACE_USED" /> / <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google voi muokata Hakua, mainoksia ja muita Googlen palveluita historiasi perusteella</translation>
-<translation id="5804241973901381774">Käyttöoikeudet</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# tunti sitten}other{# tuntia sitten}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Kaikki oikeudet pidätetään.</translation>
-<translation id="5817918615728894473">Muodosta laitepari</translation>
-<translation id="583281660410589416">Tuntematon</translation>
-<translation id="5833984609253377421">Jaa linkki</translation>
-<translation id="5836192821815272682">Ladataan Chrome-päivitystä…</translation>
-<translation id="5853623416121554550">keskeytetty</translation>
-<translation id="5854790677617711513">Yli 30 päivää vanhat</translation>
-<translation id="5858741533101922242">Chrome ei voi ottaa käyttöön Bluetooth-sovitinta.</translation>
-<translation id="5860033963881614850">Pois käytöstä</translation>
-<translation id="5862731021271217234">Ota synkronointi käyttöön, niin voit käyttää välilehtiä muilta laitteiltasi</translation>
-<translation id="5864174910718532887">Lisätiedot: Lajiteltu sivuston nimen mukaan</translation>
-<translation id="5864419784173784555">Odottaa toista latausta…</translation>
-<translation id="5865733239029070421">Lähettää automaattisesti käyttötilastoja ja virheraportteja Googlelle</translation>
-<translation id="5869522115854928033">Tallennetut salasanat</translation>
-<translation id="5902828464777634901">Kaikki tämän sivuston tallentamat paikalliset tiedot (myös evästeet) poistetaan.</translation>
-<translation id="5916664084637901428">Käytössä</translation>
-<translation id="5919204609460789179">Aloita synkronointi päivittämällä <ph name="PRODUCT_NAME" /></translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> säästetty</translation>
-<translation id="5939518447894949180">Tyhjennä</translation>
-<translation id="5942872142862698679">Hakukoneena käytetään Googlea.</translation>
-<translation id="5952764234151283551">Lähettää Googlelle etsimäsi sivun URL-osoitteen</translation>
-<translation id="5956665950594638604">Avaa Chromen ohjekeskus uudella välilehdellä</translation>
-<translation id="5958275228015807058">Löydät tiedostosi ja sivusi Latauksista</translation>
-<translation id="5962718611393537961">Tiivistä napauttamalla.</translation>
-<translation id="6000066717592683814">Käytä Googlea</translation>
-<translation id="6005538289190791541">Salasanaehdotus</translation>
-<translation id="6036057147555329831">Ylimääräinen ICU</translation>
-<translation id="6039379616847168523">Siirry seuraavalle välilehdelle</translation>
-<translation id="6040143037577758943">Sulje</translation>
-<translation id="6042308850641462728">Lisää</translation>
-<translation id="604996488070107836">Tiedoston <ph name="FILE_NAME" /> lataus epäonnistui tuntemattoman virheen vuoksi.</translation>
-<translation id="605721222689873409">VV</translation>
-<translation id="6064125863973209585">Valmiit lataukset</translation>
-<translation id="6075798973483050474">Muokkaa etusivua</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> tuntia jäljellä</translation>
-<translation id="6108923351542677676">Synkronointia valmistellaan…</translation>
-<translation id="6111020039983847643">dataa käytetty</translation>
-<translation id="6112702117600201073">Sivun päivittäminen</translation>
-<translation id="6127379762771434464">Kohde poistettu</translation>
-<translation id="6140912465461743537">Maa/alue</translation>
-<translation id="614940544461990577">Kokeile seuraavia toimenpiteitä:</translation>
-<translation id="6154478581116148741">Ota näytön lukitus käyttöön asetuksista viedäksesi salasanoja laitteelta.</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> vähemmän tiedonsiirtoa</translation>
-<translation id="6165508094623778733">Lisätietoja</translation>
-<translation id="6177111841848151710">Estetty nykyiseltä hakukoneelta</translation>
-<translation id="6181444274883918285">Lisää sivustopoikkeus</translation>
-<translation id="6192333916571137726">Lataaminen-tiedosto</translation>
-<translation id="6192792657125177640">Poikkeukset</translation>
-<translation id="6194112207524046168">Ota kamera käyttöön myös <ph name="BEGIN_LINK" />Android-asetuksissa<ph name="END_LINK" />, niin Chrome voi käyttää kameraasi.</translation>
-<translation id="6196640612572343990">Estä kolmannen osapuolen evästeet</translation>
-<translation id="6206551242102657620">Yhteys on turvallinen. Sivuston tiedot</translation>
-<translation id="6210748933810148297">Etkö ole <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Avaa lukitus viedäksesi salasanoja.</translation>
+<translation id="1406000523432664303">Do Not Track</translation>
 <translation id="6232535412751077445">Do Not Track -toiminnon käyttöönotto tarkoittaa sitä, että selausliikenteeseesi sisällytetään pyyntö. Sen vaikutus riippuu siitä, vastaako verkkosivusto pyyntöön ja miten pyyntöä tulkitaan.
 
 Jotkin verkkosivustot voivat vastata tähän pyyntöön esimerkiksi näyttämällä sinulle mainoksia, jotka eivät perustu muihin vierailemiisi verkkosivustoihin. Monet sivustot keräävät ja käyttävät silti edelleen selaustietojasi – esimerkiksi turvallisuuden parantamiseen, sisällön, mainosten ja suositusten tarjoamiseen sekä raportointitilastojen luomiseen.</translation>
-<translation id="624789221780392884">Päivitys on valmis</translation>
-<translation id="6255999984061454636">Sisältöehdotukset</translation>
-<translation id="6277522088822131679">Sivua tulostettaessa tapahtui virhe. Yritä uudelleen.</translation>
-<translation id="6295158916970320988">Kaikki sivustot</translation>
-<translation id="629730747756840877">Tili</translation>
-<translation id="6303969859164067831">Kirjaudu ulos ja poista synkronointi käytöstä</translation>
-<translation id="6316139424528454185">Android-versiota ei tueta</translation>
-<translation id="6320088164292336938">Värinä</translation>
-<translation id="6324034347079777476">Android-järjestelmän synkronointi poistettu käytöstä</translation>
-<translation id="6333140779060797560">Jaa sovelluksella <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Salaus</translation>
-<translation id="6341580099087024258">Kysy tiedostojen tallennussijaintia</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> muu}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> muuta}}</translation>
-<translation id="6364438453358674297">Poistetaanko ehdotus historiasta?</translation>
-<translation id="6369229450655021117">Tässä voit tehdä verkkohakuja, jakaa sisältöä kavereiden kanssa ja nähdä avoimet sivut</translation>
-<translation id="6378173571450987352">Lisätiedot: Lajiteltu käytetyn datan mukaan</translation>
-<translation id="6381421346744604172">Tummenna sivustot</translation>
-<translation id="6388207532828177975">Tyhjennä ja nollaa</translation>
-<translation id="6393863479814692971">Chrome tarvitsee oikeuden käyttää kameraasi ja mikrofoniasi tällä sivustolla.</translation>
-<translation id="6395288395575013217">LINKITÄ</translation>
-<translation id="6404511346730675251">Muokkaa kirjanmerkkiä</translation>
-<translation id="6406506848690869874">Synkronointi</translation>
-<translation id="641643625718530986">Tulosta…</translation>
-<translation id="6416782512398055893">Ladattu: <ph name="MBS" /> Mt</translation>
-<translation id="6427112570124116297">Käännä verkon sisältö</translation>
-<translation id="6433501201775827830">Valitse hakukone</translation>
-<translation id="6437478888915024427">Sivun tiedot</translation>
-<translation id="6441734959916820584">Nimi on liian pitkä</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# kuva}other{# kuvaa}}</translation>
-<translation id="6447842834002726250">Evästeet</translation>
-<translation id="6461962085415701688">Tiedoston avaaminen epäonnistui</translation>
-<translation id="6464977750820128603">Voit nähdä Chromessa käyttämäsi sivustot ja asettaa niille ajastimia.\n\nGoogle saa tietoa sivustoista, joille asetat ajastimia, ja sivustojen käytön kestosta. Tietoja käytetään Digitaalisen hyvinvoinnin parantamiseen.</translation>
-<translation id="6475951671322991020">Lataa video</translation>
-<translation id="6482749332252372425">Tiedoston <ph name="FILE_NAME" /> lataus epäonnistui, koska tallennustila ei riitä.</translation>
-<translation id="6496823230996795692">Muodosta internetyhteys, ennen kuin <ph name="APP_NAME" /> on käytössäsi ensimmäisen kerran.</translation>
-<translation id="6508722015517270189">Käynnistä Chrome uudelleen.</translation>
-<translation id="6527303717912515753">Jaa</translation>
-<translation id="6532866250404780454">Chromessa käyttämäsi sivustot eivät näy. Kaikki sivuston ajastimet poistetaan.</translation>
-<translation id="6534565668554028783">Google ei vastannut riittävän nopeasti.</translation>
-<translation id="6538442820324228105">Ladattu: <ph name="GBS" /> Gt</translation>
-<translation id="6539092367496845964">Jotain meni vikaan. Yritä myöhemmin uudelleen.</translation>
-<translation id="654446541061731451">Valitse siirrettävä välilehti</translation>
-<translation id="6545017243486555795">Poista kaikki tiedot</translation>
-<translation id="6545864417968258051">Bluetooth-haku</translation>
-<translation id="6560414384669816528">Käytä Sogouta</translation>
-<translation id="6566259936974865419">Chrome on säästänyt <ph name="GIGABYTES" /> Gt tilaa</translation>
-<translation id="6573096386450695060">Salli aina</translation>
-<translation id="6573431926118603307">Muilla laitteilla Chromessa avaamasi välilehdet näytetään täällä.</translation>
-<translation id="6583199322650523874">Lisää nykyinen sivu kirjanmerkkeihin</translation>
-<translation id="6593061639179217415">Tietokonesivusto</translation>
-<translation id="6600954340915313787">Kopioitiin Chromeen.</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> Gt</translation>
-<translation id="6612358246767739896">Suojattu sisältö</translation>
-<translation id="6627583120233659107">Muokkaa kansiota</translation>
-<translation id="6643016212128521049">Tyhjennä</translation>
-<translation id="6643649862576733715">Lajittele säästetyn datan määrän mukaan</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> muu}other{<ph name="CONTACT_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> muuta}}</translation>
-<translation id="6649642165559792194">Esikatsele kuva <ph name="BEGIN_NEW" />Uusi<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome tarvitsee sijaintitietojen käyttöoikeuden hakeakseen laitteita. <ph name="BEGIN_LINK" />Päivitä käyttöoikeudet<ph name="END_LINK" />.</translation>
-<translation id="6657585470893396449">Salasana</translation>
-<translation id="6659594942844771486">Välilehti</translation>
-<translation id="666731172850799929">Avaa sovelluksessa <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Chromen tietosuojailmoitus</translation>
-<translation id="6676840375528380067">Poistetaanko Chrome-data tältä laitteelta?</translation>
-<translation id="6697492270171225480">Näytä ehdotuksia samankaltaisista sivuista, kun sivua ei löydy</translation>
-<translation id="6697947395630195233">Chrome tarvitsee oikeuden käyttää sijaintiasi, jotta se voidaan jakaa tämän sivuston kanssa.</translation>
-<translation id="6698801883190606802">Hallinnoi synkronoituja tietoja</translation>
-<translation id="6699370405921460408">Googlen palvelimet optimoivat sivut, joilla käyt.</translation>
-<translation id="6706288973712894588">Olet offline-tilassa.\n<ph name="BEGIN_LINK" />Tutustu offline-fiidiin.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Uutiset</translation>
-<translation id="6710213216561001401">Edellinen</translation>
-<translation id="671481426037969117">Ajastimesta (<ph name="FQDN" />) loppui aika. Se alkaa alusta huomenna.</translation>
-<translation id="6738867403308150051">Ladataan…</translation>
-<translation id="6746124502594467657">Siirrä alas</translation>
-<translation id="6766622839693428701">Sulje pyyhkäisemällä alas.</translation>
-<translation id="6766758767654711248">Siirry sivustolle napauttamalla.</translation>
-<translation id="6767294960381293877">Välilehden jakamisen laiteluettelo avataan puolen näytön korkeudella.</translation>
-<translation id="6782111308708962316">Estä kolmannen osapuolen verkkosivustoja tallentamasta ja lukemasta evästetietoja</translation>
-<translation id="6790428901817661496">Toista</translation>
-<translation id="6811034713472274749">Sivu on valmis näytettäväksi</translation>
-<translation id="6818926723028410516">Valitse kohteet</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Käännä</translation>
-<translation id="6845325883481699275">Auta parantamaan Chromen suojausta</translation>
-<translation id="6846298663435243399">Ladataan…</translation>
-<translation id="6850409657436465440">Latauksesi on vielä kesken.</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> välilehteä suljettiin.</translation>
-<translation id="6864459304226931083">Lataa kuva</translation>
-<translation id="6865313869410766144">Automaattisesti täydennetyt lomaketiedot</translation>
-<translation id="688738109438487280">Lisää olemassa olevat tiedot tilille <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Avaa lukitus kopioidaksesi salasanan</translation>
-<translation id="6896758677409633944">Kopioi</translation>
-<translation id="6910211073230771657">Poistettu</translation>
-<translation id="6912998170423641340">Estä sivustoja lukemasta tekstiä ja kuvia leikepöydältä</translation>
-<translation id="6914783257214138813">Salasanasi näkyvät kaikille, jotka näkevät viedyn tiedoston.</translation>
-<translation id="6942665639005891494">Muuta oletuslataussijaintia milloin tahansa Asetukset-valikon kautta</translation>
-<translation id="6945221475159498467">Valitse</translation>
-<translation id="6963642900430330478">Tämä sivu on vaarallinen. Sivuston tiedot</translation>
-<translation id="6963766334940102469">Poista kirjanmerkkejä</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Kaikki</translation>
-<translation id="6981982820502123353">Esteettömyys</translation>
-<translation id="6989267951144302301">Lataus epäonnistui</translation>
-<translation id="6990079615885386641">Hanki sovellus Google Play Kaupasta: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Pyydä lupaa, kun sivustot yrittävät käyttää mikrofonia (suositus).</translation>
-<translation id="7015203776128479407">Synkronoinnin ensimääritystä ei tehty loppuun. Synkronointi ei ole käytössä.</translation>
-<translation id="7016516562562142042">Sallittu nykyisellä hakukoneella</translation>
-<translation id="7022756207310403729">Avaa selaimessa</translation>
-<translation id="702463548815491781">Suositellaan käytettäväksi, kun TalkBack tai Kytkimen käyttö on päällä</translation>
-<translation id="7029809446516969842">Salasanat</translation>
-<translation id="7053983685419859001">Estä</translation>
-<translation id="7055152154916055070">Uudelleenohjaus estetty:</translation>
-<translation id="7063006564040364415">Synkronointipalvelimeen ei saada yhteyttä.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 valittu}other{# valittu}}</translation>
-<translation id="7071521146534760487">Hallinnoi tiliä</translation>
-<translation id="7077143737582773186">Secure Digital</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> valittu. Toimintoja on käytettävissä näytön yläosassa.</translation>
-<translation id="7121362699166175603">Tyhjentää historian ja osoitekentän automaattiset täydennykset. Google-tililläsi voi olla muita selaushistoriatietoja osoitteessa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Salli nykyiselle hakukoneelle</translation>
-<translation id="7138678301420049075">Muu</translation>
-<translation id="7141896414559753902">Estä ponnahdusikkunoiden näyttäminen sivustoilla (suositus)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Lataa alkuperäinen sivu<ph name="END_LINK" /> osoitteesta <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Viimeiset 24 tuntia</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kt</translation>
-<translation id="7177466738963138057">Voit muuttaa tätä myöhemmin Asetuksista.</translation>
-<translation id="7180611975245234373">Päivitä</translation>
-<translation id="7189372733857464326">Odotetaan Google Play Palveluiden päivittymistä</translation>
-<translation id="7191430249889272776">Välilehti avattiin taustalla.</translation>
-<translation id="723171743924126238">Valitse kuvat</translation>
-<translation id="7233236755231902816">Päivitä Chrome uusimpaan versioon, niin näet verkon sisällön omalla kielelläsi</translation>
-<translation id="7243308994586599757">Asetukset löytyvät näytön alalaidasta.</translation>
-<translation id="7248069434667874558">Varmista, että <ph name="TARGET_DEVICE_NAME" /> käyttää synkronointia Chromessa</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> valittu</translation>
-<translation id="7274013316676448362">Estetty sivusto</translation>
-<translation id="7290209999329137901">Uudelleennimeäminen ei saatavilla</translation>
-<translation id="7291387454912369099">Assistantin käynnistämä maksaminen</translation>
-<translation id="7293171162284876153">Aloita synkronointi ottamalla Chrome-datan synkronointi käyttöön.</translation>
-<translation id="729975465115245577">Laitteella ei ole sovellusta, johon salasanatiedoston voisi tallentaa.</translation>
-<translation id="7302081693174882195">Lisätiedot: Lajiteltu säästetyn datan mukaan</translation>
-<translation id="7328017930301109123">Yksinkertaistetussa tilassa Chrome lataa sivuja nopeammin ja käyttää jopa 60 prosenttia vähemmän dataa.</translation>
-<translation id="7333031090786104871">Edellisen sivuston lisääminen kesken</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Jaa 1 valittu kohde}other{Jaa # valittua kohdetta}}</translation>
 <translation id="7359002509206457351">Pääsy maksutapoihin</translation>
+<translation id="8026334261755873520">Poista selaustiedot</translation>
+<translation id="1291207594882862231">Tyhjennä historia, evästeet, sivustojen tiedot, välimuisti ja niin edelleen.</translation>
+<translation id="7814200940910057384">Brave-tiedot tyhjennetty</translation>
+<translation id="1664855196866195614">Valitut tiedot on poistettu Bravesta ja synkronoiduilta laitteilta.
+
+Brave Software-tililläsi voi olla muita selaushistoriatietoja, kuten hakuja ja toimintaa muista Brave Software-palveluista. Voit katsella tietoja osoitteessa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Välimuistissa olevat kuvat ja tiedostot</translation>
+<translation id="2496180316473517155">Selaushistoria</translation>
+<translation id="2546283357679194313">Evästeet ja sivustotiedot</translation>
+<translation id="8662811608048051533">Kirjaa sinut ulos useimmilta sivustoilta.</translation>
+<translation id="8218628800671693884">Tämä kirjaa sinut ulos useimmilta sivustoilta. Sinua ei kirjata ulos Brave Software-tililtäsi.</translation>
+<translation id="2017836877785168846">Tyhjentää historian ja osoitepalkin automaattiset täydennykset.</translation>
+<translation id="8096327394278038498">Tyhjentää historian ja osoitekentän automaattiset täydennykset. Brave Software-tililläsi voi olla muita selaushistoriatietoja osoitteessa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Tyhjentää kaikkien sisäänkirjautuneiden laitteiden historian. Brave Software-tililläsi voi olla muuta toimintaa osoitteessa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Tallennetut salasanat</translation>
+<translation id="6865313869410766144">Automaattisesti täydennetyt lomaketiedot</translation>
+<translation id="7562080006725997899">Selaustietoja poistetaan</translation>
+<translation id="5487521232677179737">Poista tiedot</translation>
+<translation id="7498271377022651285">Odota…</translation>
+<translation id="784934925303690534">Aikaväli</translation>
+<translation id="1718835860248848330">Viimeinen tunti</translation>
+<translation id="7149893636342594995">Viimeiset 24 tuntia</translation>
+<translation id="5648166631817621825">Viimeiset seitsemän päivää</translation>
+<translation id="8571213806525832805">Viimeiset neljä viikkoa</translation>
+<translation id="5854790677617711513">Yli 30 päivää vanhat</translation>
+<translation id="6979737339423435258">Kaikki</translation>
+<translation id="982182592107339124">Kaikkien sivustojen tiedot poistetaan, esimerkiksi:</translation>
+<translation id="6643016212128521049">Tyhjennä</translation>
+<translation id="7641339528570811325">Poista selaustiedot…</translation>
+<translation id="1670399744444387456">Perusvaihtoehdot</translation>
+<translation id="3245261285041759672">Brave Software-tililläsi voi olla muita selaushistoriatietoja osoitteessa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Estetty sivusto</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> kohdetta poistettu</translation>
+<translation id="1121094540300013208">Käyttö- ja virheraportit</translation>
+<translation id="9079153198295609735">Lähetä Brave Softwarelle käyttötilastoja ja virheraportteja automaattisesti</translation>
+<translation id="6981982820502123353">Esteettömyys</translation>
+<translation id="2387895666653383613">Tekstin skaalaus</translation>
+<translation id="2321958826496381788">Vedä liukusäädintä, kunnes voit lukea tämän mukavasti. Tekstin tulisi olla vähintään näin suurta kaksoisnapautettuasi kappaletta.</translation>
+<translation id="3895926599014793903">Ota zoomaus käyttöön</translation>
+<translation id="5668404140385795438">Ohita sivuston zoomauksen estämispyyntö</translation>
+<translation id="4149994727733219643">Yksinkertaisempi sivunäkymä</translation>
+<translation id="9100505651305367705">Tarjoa yksinkertaistettua näkymää, jos artikkeli tukee sitä</translation>
+<translation id="1409426117486808224">Yksinkertaisempi avoimien välilehtien näkymä</translation>
+<translation id="702463548815491781">Suositellaan käytettäväksi, kun TalkBack tai Kytkimen käyttö on päällä</translation>
+<translation id="8284326494547611709">Tekstitykset</translation>
+<translation id="4165986682804962316">Sivustoasetukset</translation>
+<translation id="6295158916970320988">Kaikki sivustot</translation>
+<translation id="8380167699614421159">Tällä sivustolla on häiritseviä tai harhaanjohtavia mainoksia</translation>
+<translation id="1919345977826869612">Mainokset</translation>
+<translation id="410351446219883937">Automaattinen toisto</translation>
+<translation id="6447842834002726250">Evästeet</translation>
+<translation id="6196640612572343990">Estä kolmannen osapuolen evästeet</translation>
+<translation id="6782111308708962316">Estä kolmannen osapuolen verkkosivustoja tallentamasta ja lukemasta evästetietoja</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Ponn.ikkunat ja uudelleenohj.</translation>
+<translation id="4751476147751820511">Liike- tai valotunnistimet</translation>
+<translation id="1717218214683051432">Liiketunnistimet</translation>
+<translation id="2091887806945687916">Ääni</translation>
+<translation id="2586657967955657006">Leikepöytä</translation>
+<translation id="6320088164292336938">Värinä</translation>
+<translation id="4226663524361240545">Laite voi väristä ilmoitusten yhteydessä.</translation>
+<translation id="1446450296470737166">Salli MIDI-laitteiden täysi käyttöoik.</translation>
+<translation id="3744111561329211289">Taustasynkronointi</translation>
+<translation id="5649053991847567735">Automaattiset lataukset</translation>
+<translation id="6181444274883918285">Lisää sivustopoikkeus</translation>
+<translation id="5313967007315987356">Lisää sivusto</translation>
+<translation id="1369915414381695676">Sivusto <ph name="SITE_NAME"/> lisättiin.</translation>
+<translation id="7837721118676387834">Sallii tietylle sivustolle mykistettyjen videoiden automaattisen toiston.</translation>
+<translation id="2621115761605608342">Salli JavaScript tietyllä sivustolla.</translation>
+<translation id="8801436777607969138">Estä JavaScript tietyllä sivustolla.</translation>
+<translation id="8372893542064058268">Salli taustasynkronointi tietyllä sivustolla.</translation>
+<translation id="358794129225322306">Anna sivuston ladata useita tiedostoja automaattisesti.</translation>
+<translation id="4008040567710660924">Salli evästeet tietyllä sivustolla.</translation>
+<translation id="8958424370300090006">Estä evästeet tietyltä sivustolta.</translation>
+<translation id="7882806643839505685">Salli tietyn sivuston äänet.</translation>
+<translation id="4468959413250150279">Mykistä tietyn sivuston äänet.</translation>
+<translation id="1994173015038366702">Sivuston URL-osoite</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Käyttö</translation>
+<translation id="5804241973901381774">Käyttöoikeudet</translation>
+<translation id="4278390842282768270">Sallittu</translation>
+<translation id="5677928146339483299">Estetty</translation>
+<translation id="1984937141057606926">Sallittu, paitsi kolmannen osapuolen evästeet</translation>
+<translation id="7423098979219808738">Kysy ensin</translation>
+<translation id="8116925261070264013">Mykistetty</translation>
+<translation id="8300705686683892304">Sovelluksen ylläpitämät</translation>
+<translation id="6192792657125177640">Poikkeukset</translation>
+<translation id="257931822824936280">Laajennettu – tiivistä klikkaamalla.</translation>
+<translation id="5100237604440890931">Tiivistetty – laajenna klikkaamalla.</translation>
+<translation id="857943718398505171">Sallittu (suositus)</translation>
+<translation id="2913331724188855103">Salli sivustojen tallentaa ja lukea evästetietoja (suositus).</translation>
+<translation id="7445411102860286510">Salli sivustoille mykistettyjen videoiden automaattinen toisto (suositus)</translation>
+<translation id="5335288049665977812">Anna kaikkien sivustojen käyttää JavaScriptiä (suositus).</translation>
+<translation id="5527111080432883924">Pyydä lupaa, kun sivustot yrittävät lukea tekstiä ja kuvia leikepöydältä (suositus)</translation>
+<translation id="6912998170423641340">Estä sivustoja lukemasta tekstiä ja kuvia leikepöydältä</translation>
+<translation id="7423538860840206698">Leikepöydältä lukeminen estetty</translation>
+<translation id="3955193568934677022">Salli sivustojen toistaa suojattua sisältöä (suositus)</translation>
+<translation id="445467742685312942">Salli sivustojen toistaa suojattua sisältöä</translation>
+<translation id="2107397443965016585">Kysy, saavatko sivustot toistaa suojattua sisältöä (suositus)</translation>
+<translation id="2910701580606108292">Kysy, saavatko sivustot toistaa suojattua sisältöä</translation>
+<translation id="757524316907819857">Estä sivustoja toistamasta suojattua sisältöä</translation>
+<translation id="3277252321222022663">Anna sivustojen käyttää tunnistimia (suositus)</translation>
+<translation id="5048398596102334565">Anna sivustojen käyttää liiketunnistimien lukemia (suositus)</translation>
+<translation id="8816026460808729765">Estä sivustoja käyttämästä tunnistimia</translation>
+<translation id="169515064810179024">Estä sivustoja käyttämästä liiketunnistimien lukemia</translation>
+<translation id="1660204651932907780">Salli sivustojen toistaa ääniä (suositus)</translation>
+<translation id="3600792891314830896">Mykistä ääniä toistavat sivustot</translation>
+<translation id="1743802530341753419">Pyydä lupaa, kun sivustot yrittävät yhdistää laitteeseen (suositus)</translation>
+<translation id="851751545965956758">Estä sivustoja yhdistämästä laitteisiin</translation>
+<translation id="7141896414559753902">Estä ponnahdusikkunoiden näyttäminen sivustoilla (suositus)</translation>
+<translation id="5494752089476963479">Estä häiritseviä tai harhaanjohtavia mainoksia näyttävien sivustojen mainokset</translation>
+<translation id="3123473560110926937">Estetty tietyillä sivustoilla</translation>
+<translation id="965817943346481315">Estä, jos sivusto näyttää häiritseviä tai harhaanjohtavia mainoksia (suositus)</translation>
+<translation id="3386292677130313581">Pyydä lupaa, kun sivustot yrittävät käyttää sijaintiasi (suositus).</translation>
+<translation id="9139068048179869749">Pyydä lupaa, kun sivustot yrittävät lähettää ilmoituksia (suositus).</translation>
+<translation id="4479647676395637221">Pyydä lupaa, kun sivustot yrittävät käyttää kameraasi (suositus).</translation>
+<translation id="6992289844737586249">Pyydä lupaa, kun sivustot yrittävät käyttää mikrofonia (suositus).</translation>
+<translation id="2289270750774289114">Kysy aina, kun sivusto pyytää lupaa löytää lähellä olevat Bluetooth-laitteet (suositus)</translation>
+<translation id="7053983685419859001">Estä</translation>
+<translation id="7128222689758636196">Salli nykyiselle hakukoneelle</translation>
+<translation id="7589445247086920869">Estä nykyiselle hakukoneelle</translation>
+<translation id="6388207532828177975">Tyhjennä ja nollaa</translation>
+<translation id="7999064672810608036">Haluatko varmasti tyhjentää kaikki paikalliset tiedot, mukaan lukien evästeet, ja nollata kaikki tämän verkkosivuston käyttöluvat?</translation>
+<translation id="2822354292072154809">Haluatko varmasti nollata kaikki sivuston käyttöoikeudet (<ph name="CHOSEN_OBJECT_NAME"/>)?</translation>
+<translation id="515227803646670480">Poista tallennetut tiedot</translation>
+<translation id="5902828464777634901">Kaikki tämän sivuston tallentamat paikalliset tiedot (myös evästeet) poistetaan.</translation>
+<translation id="119944043368869598">Tyhjennä kaikki</translation>
+<translation id="2490684707762498678">Ylläpitäjä: <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Avaa ilmoitusasetukset</translation>
+<translation id="1404122904123200417">Upotettu osoitteeseen <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Sivustojen tallentamat tiedostot näkyvät tässä</translation>
+<translation id="4181841719683918333">Kielet</translation>
+<translation id="2647434099613338025">Lisää kieli</translation>
+<translation id="1952172573699511566">Verkkosivustot näyttävät tekstin valitsemallasi kielellä, kun se on mahdollista.</translation>
+<translation id="8559990750235505898">Tarjoudu kääntämään vierailla kielillä kirjoitettuja sivuja</translation>
+<translation id="4719927025381752090">Tarjoudu kääntämään</translation>
+<translation id="8156139159503939589">Mitä kieliä ymmärrät?</translation>
+<translation id="5689516760719285838">Sijainti</translation>
+<translation id="2440823041667407902">Sijaintitietojen käyttöoikeus</translation>
+<translation id="2023546461831060654">Ota käyttöoikeudet käyttöön Bravelle <ph name="BEGIN_LINK"/>Android-asetuksissa<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Ota käyttöoikeus käyttöön Bravelle <ph name="BEGIN_LINK"/>Android-asetuksissa<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Ota sijaintitiedot käyttöön myös <ph name="BEGIN_LINK"/>Android-asetuksissa<ph name="END_LINK"/>, niin Brave voi käyttää sijaintiasi.</translation>
+<translation id="1028853271388022585">Ota kamera käyttöön myös <ph name="BEGIN_LINK"/>Android-asetuksissa<ph name="END_LINK"/>, niin Brave voi käyttää kameraasi.</translation>
+<translation id="2913721282607281710">Ota ilmoitukset käyttöön myös <ph name="BEGIN_LINK"/>Android-asetuksissa<ph name="END_LINK"/>, niin Brave voi lähettää sinulle ilmoituksia.</translation>
+<translation id="8753483718490035722">Ota mikrofoni käyttöön myös <ph name="BEGIN_LINK"/>Android-asetuksissa<ph name="END_LINK"/>, niin Brave voi käyttää mikrofoniasi.</translation>
+<translation id="1887786770086287077">Sijainti on poissa käytöstä tällä laitteella. Voit ottaa sen käyttöön <ph name="BEGIN_LINK"/>Android-asetuksista<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Sijainti on poissa käytöstä myös tällä laitteella. Voit ottaa sen käyttöön <ph name="BEGIN_LINK"/>Android-asetuksista<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofoni</translation>
+<translation id="1647391597548383849">Kameran käyttöoikeus</translation>
+<translation id="945632385593298557">Mikrofonin käyttöoikeus</translation>
+<translation id="6612358246767739896">Suojattu sisältö</translation>
+<translation id="885701979325669005">Tallennus</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> tallennettua tietoa</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Peruuta laitteen käyttöoikeus</translation>
+<translation id="4962975101802056554">Peru kaikki laitteen käyttöoikeudet</translation>
+<translation id="6545864417968258051">Bluetooth-haku</translation>
+<translation id="4411535500181276704">Yksinkertaistettu tila</translation>
+<translation id="7821588508402923572">Datasäästösi näkyvät täällä</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> tallennettu</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> alkaen</translation>
+<translation id="3252158532344029638">Yksinkertaistetussa tilassa Brave lataa sivuja nopeammin ja käyttää jopa 60 prosenttia vähemmän dataa.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> vähemmän tiedonsiirtoa</translation>
+<translation id="7494974237137038751">dataa säästetty</translation>
+<translation id="6111020039983847643">dataa käytetty</translation>
+<translation id="7413229368719586778">Alkamispäivä: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Päättymispäivä: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Lajittele sivuston mukaan</translation>
+<translation id="5864174910718532887">Lisätiedot: Lajiteltu sivuston nimen mukaan</translation>
+<translation id="116280672541001035">Käytetty</translation>
+<translation id="8349013245300336738">Lajittele käytetyn datan määrän mukaan</translation>
+<translation id="6378173571450987352">Lisätiedot: Lajiteltu käytetyn datan mukaan</translation>
+<translation id="2631006050119455616">Säästetty</translation>
+<translation id="6643649862576733715">Lajittele säästetyn datan määrän mukaan</translation>
+<translation id="7302081693174882195">Lisätiedot: Lajiteltu säästetyn datan mukaan</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> käytetty</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> säästetty</translation>
+<translation id="2156074688469523661">Jäljellä olevat sivustot (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Muu</translation>
+<translation id="4913161338056004800">Nollaa tilastot</translation>
+<translation id="1856325424225101786">Palautetaanko yksinkertaistettu tila?</translation>
+<translation id="3658159451045945436">Nollaaminen tyhjentää datansäästöhistoriasi, mukaan lukien luettelon paikoista, joissa olet käynyt.</translation>
+<translation id="3295530008794733555">Selaa nettiä nopeammin. Käytä vähemmän dataa.</translation>
+<translation id="7340390500800578919">Yksinkertaistetussa tilassa Brave lataa sivuja nopeammin ja käyttää jopa 60 % vähemmän dataa. Brave lähettää verkkoliikenteesi tietoja Brave Softwarelle avaamiesi sivujen optimoimiseksi. <ph name="BEGIN_LINK"/>Lue lisää<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Ota yksinkertaistettu tila käyttöön</translation>
+<translation id="4493497663118223949">Yksinkertaistettu tila on käytössä</translation>
+<translation id="7559975015014302720">Yksinkertaistettu tila on poissa käytöstä</translation>
+<translation id="7606077192958116810">Yksinkertaistettu tila on käytössä. Ylläpidä sitä asetuksissa.</translation>
+<translation id="4714588616299687897">Käytä jopa 60 % vähemmän dataa</translation>
+<translation id="1006927014032731288">Brave Softwaren palvelimet optimoivat sivut, joilla käyt.</translation>
+<translation id="3257320067425202300">Brave on säästänyt <ph name="MEGABYTES"/> Mt tilaa</translation>
+<translation id="5813223329348543512">Brave on säästänyt <ph name="GIGABYTES"/> Gt tilaa</translation>
+<translation id="8266862848225348053">Lataussijainti</translation>
+<translation id="7077143737582773186">Secure Digital</translation>
+<translation id="7762668264895820836">SD-kortti <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Kysy tiedostojen tallennussijaintia</translation>
+<translation id="6192333916571137726">Lataaminen-tiedosto</translation>
+<translation id="1672586136351118594">Älä näytä uudelleen</translation>
+<translation id="2650751991977523696">Ladataanko tiedosto uudelleen?</translation>
+<translation id="8664979001105139458">Tiedoston nimi on jo käytössä</translation>
+<translation id="488187801263602086">Nimeä tiedosto uudelleen</translation>
+<translation id="5686790454216892815">Tiedoston nimi on liian pitkä</translation>
+<translation id="7454641608352164238">Tallennustila ei riitä</translation>
+<translation id="8972098258593396643">Ladataanko tiedosto oletuskansioon?</translation>
+<translation id="804335162455518893">SD-korttia ei löydy</translation>
+<translation id="7475688122056506577">SD-korttia ei löydy. Osa tiedostoista voi puuttua.</translation>
+<translation id="4198423547019359126">Tallennussijainteja ei ole saatavilla</translation>
+<translation id="8224471946457685718">Lataa sinulle valittuja artikkeleita Wi-Fin kautta</translation>
+<translation id="4970824347203572753">Ei käytettävissä sijainnissasi</translation>
+<translation id="5500777121964041360">Ei ole välttämättä käytettävissä asuinpaikassasi</translation>
+<translation id="1173894706177603556">Muuta nimeä</translation>
+<translation id="1986685561493779662">Nimi on jo käytössä</translation>
+<translation id="6441734959916820584">Nimi on liian pitkä</translation>
+<translation id="2923908459366352541">Nimi on virheellinen</translation>
+<translation id="7290209999329137901">Uudelleennimeäminen ei saatavilla</translation>
+<translation id="3334729583274622784">Vaihdetaanko tiedostotunniste?</translation>
+<translation id="107147699690128016">Jos vaihdat tiedostotunnisteen, tiedosto voi avautua eri sovelluksessa ja mahdollisesti vahingoittaa laitetta.</translation>
+<translation id="8541922081612557424">Tietoja Bravesta</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Kaikki oikeudet pidätetään.</translation>
+<translation id="1416550906796893042">Sovellusversio</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (päivitettiin <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Käyttöjärjestelmä</translation>
+<translation id="3968054912784331254">Brave-päivityksiä ei enää tueta tässä Android-versiossa.</translation>
+<translation id="7665369617277396874">Lisää tili</translation>
+<translation id="649070405679044769">Olet kirjautunut Brave Softwareen käyttäjänä</translation>
+<translation id="6234515504547364178">Uloskirjautuminen Bravesta</translation>
+<translation id="5324858694974489420">Vanhempien asetukset</translation>
+<translation id="8920114477895755567">Odotetaan vanhempien tietoja.</translation>
+<translation id="5512137114520586844">Tätä tiliä hallinnoi <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Tätä tiliä hallinnoivat <ph name="PARENT_NAME_1"/> ja <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Sisältö</translation>
+<translation id="5403644198645076998">Salli vain tietyt sivustot</translation>
+<translation id="8641930654639604085">Pyri estämään aikuisille tarkoitetut sivustot</translation>
+<translation id="5639724618331995626">Salli kaikki sivustot</translation>
+<translation id="796823723482603597">Palvelun tarjoaa Brave</translation>
+<translation id="6324034347079777476">Android-järjestelmän synkronointi poistettu käytöstä</translation>
+<translation id="5127805178023152808">Synkronointi ei ole käytössä</translation>
+<translation id="7015203776128479407">Synkronoinnin ensimääritystä ei tehty loppuun. Synkronointi ei ole käytössä.</translation>
+<translation id="2497852260688568942">Järjestelmänvalvoja on poistanut synkronoinnin käytöstä.</translation>
+<translation id="9100610230175265781">Tunnuslause tarvitaan</translation>
+<translation id="6108923351542677676">Synkronointia valmistellaan…</translation>
+<translation id="4062305924942672200">Oikeudelliset tiedot</translation>
+<translation id="4256782883801055595">Avoimen lähdekoodin käyttöluvat</translation>
+<translation id="1138681184697033370">Braven käyttöehdot</translation>
+<translation id="7392539049993970338">Braven tietosuojailmoitus</translation>
+<translation id="2677748264148917807">Poistu</translation>
+<translation id="5556459405103347317">Lataa uudelleen</translation>
+<translation id="1623104350909869708">Estä tätä sivua luomasta muita viestejä</translation>
+<translation id="2968755619301702150">Varmennetiedot</translation>
+<translation id="1360432990279830238">Kirjaudu ulos ja lopeta synkronointi?</translation>
+<translation id="8581481290581777242">Poistetaanko Brave-data tältä laitteelta?</translation>
+<translation id="1318865768845061710">Kirjanmerkkejä, historiaa, salasanoja tai muuta Brave-dataa ei enää synkronoida Brave Software-tilille.</translation>
+<translation id="3325020657155065477">Poistetaanko Brave-data tältä laitteelta?</translation>
+<translation id="6136448902816743006">Koska olet kirjautumassa ulos tililtä, jota <ph name="DOMAIN_NAME"/> ylläpitää, Brave-datasi poistetaan tältä laitteelta. Se pysyy Brave Software-tililläsi.</translation>
+<translation id="1853026300647876496">Otetaan yhteyttä Brave Softwareen. Tämä voi kestää hetken…</translation>
+<translation id="2328985652426384049">Kirjautuminen epäonnistui</translation>
+<translation id="7723158744459952869">Brave Software ei vastannut riittävän nopeasti.</translation>
+<translation id="4572422548854449519">Kirjaudu hallinnoidulle tilille</translation>
+<translation id="2689656545739939160">Olet kirjautumassa sisään verkkotunnuksen <ph name="MANAGED_DOMAIN"/> hallinnoimalla tilillä ja antamassa sen järjestelmänvalvojalle oikeuden hallita Brave-tietojasi. Tietosi liitetään pysyvästi tähän tiliin. Bravesta uloskirjautuminen poistaa tietosi tältä laitteelta, mutta ne säilyvät Brave Software-tililläsi.</translation>
+<translation id="1749561566933687563">Synkronoi kirjanmerkit</translation>
+<translation id="4242533952199664413">Avaa asetukset</translation>
+<translation id="1111673857033749125">Muilla laitteilla tallentamasi kirjanmerkit näytetään täällä.</translation>
+<translation id="8636825310635137004">Ota synkronointi käyttöön, niin voit käyttää välilehtiäsi kaikilla laitteilla.</translation>
+<translation id="3269956123044984603">Ota tietojen automaattinen synkronointi käyttöön Androidin tiliasetuksissa, niin voit käyttää välilehtiäsi kaikilla laitteilla.</translation>
+<translation id="5157964048453367290">Muilla laitteilla Bravessa avaamasi välilehdet näytetään täällä.</translation>
+<translation id="4684427112815847243">Synkronoi kaikki</translation>
+<translation id="2709516037105925701">Automaattinen täyttö</translation>
+<translation id="8820817407110198400">Kirjanmerkit</translation>
+<translation id="1644574205037202324">Historia</translation>
+<translation id="17513872634828108">Avoimet välilehdet</translation>
+<translation id="1320169905922104972">Luottokortit ja osoitteet Brave Software Paysta</translation>
+<translation id="6337234675334993532">Salaus</translation>
+<translation id="6698801883190606802">Hallinnoi synkronoituja tietoja</translation>
+<translation id="3598578758776312506">Salaa salasanat Brave Software-kirjautumistiedoilla</translation>
+<translation id="7810580217418711046">Salaa synkronoitu data Brave Software-salasanalla (<ph name="TIME"/>)</translation>
+<translation id="8461694314515752532">Salaa synkronoidut tiedot oman synkronoinnin tunnuslauseesi avulla</translation>
+<translation id="2996291259634659425">Luo tunnuslause</translation>
+<translation id="5713644099811900409">Brave Software-tilisi avulla</translation>
+<translation id="8997474919031554666">Brave Software Payn maksutapoja tai osoitteita ei salata tunnuslauseella. Salattua dataa voidaan lukea vain tunnuslauseesi avulla. Tunnuslausetta ei lähetetä Brave Softwarelle eikä Brave Software tallenna sitä. Jos unohdat tunnuslauseesi tai haluat muokata tätä asetusta, synkronointi täytyy nollata. <ph name="BEGIN_LINK"/>Lisätietoja<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Tunnuslause</translation>
+<translation id="7772032839648071052">Vahvista tunnuslause</translation>
+<translation id="5304593522240415983">Kenttä ei voi olla tyhjä.</translation>
+<translation id="321773570071367578">Jos unohdat tunnuslauseesi tai haluat muokata tätä asetusta, <ph name="BEGIN_LINK"/>nollaa synkronointi<ph name="END_LINK"/>.</translation>
+<translation id="3029704984691124060">Tunnuslauseet eivät vastaa toisiaan.</translation>
+<translation id="5149495116300586333">Brave Software Payn maksutapoja tai osoitteita ei salata tunnuslauseella.
+
+Jos haluat muokata asetusta, <ph name="BEGIN_LINK"/>nollaa synkronointi<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">Väärä tunnuslause.</translation>
+<translation id="5414836363063783498">Vahvistetaan…</translation>
+<translation id="6846298663435243399">Ladataan…</translation>
+<translation id="5517095782334947753">Tililläsi <ph name="FROM_ACCOUNT"/> on kirjanmerkkejä, salasanoja ja muita asetuksia.</translation>
+<translation id="3928666092801078803">Yhdistä tiedot</translation>
+<translation id="688738109438487280">Lisää olemassa olevat tiedot tilille <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Pidä tiedot erillään</translation>
+<translation id="1145536944570833626">Poistaa olemassa olevat tiedot.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> haluaa muodostaa laiteparin</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Tutustu ohjeisiin<ph name="END_LINK"/> laitteiden skannauksen aikana…</translation>
+<translation id="5817918615728894473">Muodosta laitepari</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Lue ohjeita<ph name="END_LINK1"/> tai <ph name="BEGIN_LINK2"/>hae uudelleen<ph name="END_LINK2"/>.</translation>
+<translation id="230115972905494466">Yhteensopivia laitteita ei löytynyt.</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Ota Bluetooth käyttöön<ph name="END_LINK"/>, jotta laiteparin muodostus onnistuu.</translation>
+<translation id="998321811308652668">Brave ei voi ottaa käyttöön Bluetooth-sovitinta.</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Tutustu ohjeisiin<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave tarvitsee sijaintitietojen käyttöoikeuden hakeakseen laitteita. <ph name="BEGIN_LINK"/>Päivitä käyttöoikeudet<ph name="END_LINK"/>.</translation>
+<translation id="852740676285943527">Brave tarvitsee sijaintitietoja hakeakseen laitteita. Sijaintitiedot on <ph name="BEGIN_LINK"/>poistettu käytöstä tällä laitteella<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave tarvitsee sijaintitietoja hakeakseen laitteita. <ph name="BEGIN_LINK1"/>Päivitä käyttöoikeudet<ph name="END_LINK1"/>. Sijaintitiedot on lisäksi <ph name="BEGIN_LINK2"/>poistettu käytöstä tällä laitteella<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Yhdistetty laite</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signaalin voimakkuus: # palkki}other{Signaalin voimakkuus: # palkkia}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> haluaa etsiä lähellä olevia Bluetooth-laitteita. Seuraavat laitteet löydettiin:</translation>
+<translation id="8368027906805972958">Tuntematon tai ei-tuettu laite (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synkronointi ei toimi</translation>
+<translation id="1810845389119482123">Synkronoinnin alkumääritys ei valmis</translation>
+<translation id="3235722914093408050">Avaa Android-asetukset ja ota järjestelmän synkronointi uudelleen käyttöön.</translation>
+<translation id="3367813778245106622">Aloita synkronointi kirjautumalla uudelleen sisään.</translation>
+<translation id="974555521953189084">Aloita synkronointi antamalla tunnuslauseesi.</translation>
+<translation id="2997266899014181325">Aloita synkronointi ottamalla Brave-datan synkronointi käyttöön.</translation>
+<translation id="8260126382462817229">Yritä kirjautua uudelleen sisään.</translation>
+<translation id="5919204609460789179">Aloita synkronointi päivittämällä <ph name="PRODUCT_NAME"/></translation>
+<translation id="397583555483684758">Synkronointi on lakannut toimimasta.</translation>
+<translation id="1966710179511230534">Päivitä kirjautumistietosi.</translation>
+<translation id="7063006564040364415">Synkronointipalvelimeen ei saada yhteyttä.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> on vanhentunut.</translation>
+<translation id="4170011742729630528">Palvelu ei ole käytettävissä. Yritä myöhemmin uudelleen.</translation>
+<translation id="7947953824732555851">Hyväksy ja kirjaudu sisään</translation>
+<translation id="8583805026567836021">Poistetaan tilin tietoja</translation>
+<translation id="8310344678080805313">Tavalliset välilehdet</translation>
+<translation id="5748802427693696783">Vaihdettiin näkyviin tavalliset välilehdet.</translation>
+<translation id="7998918019931843664">Avaa suljettu välilehti uudelleen</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, välilehti</translation>
+<translation id="4452411734226507615">Sulje välilehti <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Asetukset löytyvät näytön alalaidasta.</translation>
+<translation id="4060598801229743805">Toimintoja on käytettävissä näytön yläosassa.</translation>
+<translation id="2810645512293415242">Yksinkertaistettu sivu, joka säästää dataa ja latautuu nopeammin.</translation>
+<translation id="3985215325736559418">Haluatko ladata tiedoston <ph name="FILE_NAME"/> uudelleen?</translation>
+<translation id="2450083983707403292">Haluatko aloittaa tiedoston <ph name="FILE_NAME"/> lataamisen uudelleen?</translation>
+<translation id="7514365320538308">Lataa</translation>
+<translation id="545042621069398927">Lataustasi nopeutetaan</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Ladataan tiedostoa}other{Ladataan # tiedostoa}}</translation>
+<translation id="543509235395288790">Ladataan <ph name="COUNT"/> tiedostoa (<ph name="MEGABYTES"/>)</translation>
+<translation id="4988210275050210843">Ladataan tiedostoa (<ph name="MEGABYTES"/>)</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 lataus on valmis}other{# latausta on valmiina}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 lataus epäonnistui}other{# latausta epäonnistui}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 lataus odottaa}other{# latausta odottaa}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/>-painike</translation>
+<translation id="3205824638308738187">Melkein valmista</translation>
+<translation id="3960299545138990065">Käynnistä Brave uudelleen.</translation>
+<translation id="3771001275138982843">Päivityksen lataaminen epäonnistui</translation>
+<translation id="3888648114124182147">Ladataan Brave-päivitystä…</translation>
+<translation id="1705567146636171298">Päivitä Brave</translation>
+<translation id="6195417478702700398">Jotta saat parhaan mahdollisen selauskokemuksen, avaa ja päivitä Brave nyt</translation>
+<translation id="3512968675351418494">Päivitä Brave uusimpaan versioon, niin näet verkon sisällön omalla kielelläsi</translation>
+<translation id="6427112570124116297">Käännä verkon sisältö</translation>
+<translation id="1379423114029199501">Päivitä Brave uusimpaan versioon, niin se toimii omalla kielelläsi</translation>
+<translation id="5684874026226664614">Hups, tätä sivua ei voi kääntää.</translation>
+<translation id="6831043979455480757">Käännä</translation>
+<translation id="1285320974508926690">Älä käännä tätä sivustoa</translation>
+<translation id="773466115871691567">Käännä aina kielellä <ph name="SOURCE_LANGUAGE"/> kirjoitut sivut</translation>
+<translation id="1068672505746868501">Älä koskaan käännä kielellä <ph name="SOURCE_LANGUAGE"/> kirjoitettuja sivuja.</translation>
+<translation id="124116460088058876">Lisää kieliä</translation>
+<translation id="290376772003165898">Eikö sivu ole kirjoitettu kielellä <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Kielellä <ph name="SOURCE_LANGUAGE"/> kirjoitetut sivut käännetään tästä lähtien kielelle <ph name="TARGET_LANGUAGE"/>.</translation>
+<translation id="8339163506404995330">Kielellä <ph name="LANGUAGE"/> kirjoitettuja sivuja ei käännetä.</translation>
+<translation id="5447765697759493033">Sivustoa ei käännetä.</translation>
+<translation id="4880127995492972015">Käännä…</translation>
+<translation id="641643625718530986">Tulosta…</translation>
+<translation id="8909135823018751308">Jaa…</translation>
+<translation id="4996978546172906250">Jaa palvelussa:</translation>
+<translation id="6333140779060797560">Jaa sovelluksella <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Sivua tulostettaessa tapahtui virhe. Yritä uudelleen.</translation>
+<translation id="3254409185687681395">Luo kirjanmerkki tälle sivulle</translation>
+<translation id="497421865427891073">Siirry eteenpäin</translation>
+<translation id="813082847718468539">Näytä sivuston tiedot</translation>
+<translation id="2532336938189706096">Verkkonäkymä</translation>
+<translation id="6005538289190791541">Salasanaehdotus</translation>
+<translation id="4634124774493850572">Käytä salasanaa</translation>
+<translation id="8285489906452138776">Brave tarvitsee oikeuden käyttää kameraasi tällä sivustolla.</translation>
+<translation id="320189792589364011">Brave tarvitsee oikeuden käyttää mikrofoniasi tällä sivustolla.</translation>
+<translation id="7988136689212463100">Brave tarvitsee oikeuden käyttää kameraasi ja mikrofoniasi tällä sivustolla.</translation>
+<translation id="4931190655840828017">Brave tarvitsee oikeuden käyttää sijaintiasi, jotta se voidaan jakaa tämän sivuston kanssa.</translation>
+<translation id="3088191967551450609">Brave tarvitsee tallennustilan käyttöoikeuden tiedostojen lataamiseen.</translation>
+<translation id="8942627711005830162">Avaa uudessa ikkunassa</translation>
+<translation id="4195643157523330669">Avaa uudelle välilehdelle</translation>
+<translation id="1100066534610197918">Avaa uusi välilehti ja ryhmä</translation>
+<translation id="4860895144060829044">Soita</translation>
+<translation id="6896758677409633944">Kopioi</translation>
+<translation id="8393700583063109961">Lähetä viesti</translation>
+<translation id="3557336313807607643">Lisää yhteystietoihin</translation>
+<translation id="4269820728363426813">Kopioi linkin osoite</translation>
+<translation id="1206892813135768548">Kopioi linkin teksti</translation>
+<translation id="1204037785786432551">Lataa linkin kohde</translation>
+<translation id="6864459304226931083">Lataa kuva</translation>
+<translation id="8209050860603202033">Avaa kuva</translation>
+<translation id="8073388330009372546">Avaa kuva uudessa välilehdessä</translation>
+<translation id="6649642165559792194">Esikatsele kuva <ph name="BEGIN_NEW"/>Uusi<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Lataa kuva</translation>
+<translation id="3845332215609790146">Hae Brave Software Lensillä <ph name="BEGIN_NEW"/>Uusi<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Etsi tätä kuvaa palvelusta <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Jaa kuva</translation>
+<translation id="5833984609253377421">Jaa linkki</translation>
+<translation id="6475951671322991020">Lataa video</translation>
+<translation id="2317945146070194624">Avaa, uusi Brave-välilehti</translation>
+<translation id="7975379999046275268">Esikatsele sivu <ph name="BEGIN_NEW"/>Uusi<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Sivun päivittäminen</translation>
+<translation id="36525718899759834">Hanki sovellus Brave Software Play Kaupasta: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tumma</translation>
+<translation id="1807246157184219062">Vaalea</translation>
+<translation id="4056223980640387499">Seepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Valitse siirrettävä välilehti</translation>
+<translation id="8719023831149562936">Nykyistä välilehteä ei voi jakaa</translation>
+<translation id="2139186145475833000">Lisää aloitusnäyttöön</translation>
+<translation id="4616150815774728855">Avaa <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Sovelluksen avaaminen epäonnistui</translation>
+<translation id="5129038482087801250">Asenna verkkosovellus</translation>
+<translation id="3789841737615482174">Asenna</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> lisättiin aloitusnäytölle.</translation>
+<translation id="7333031090786104871">Edellisen sivuston lisääminen kesken</translation>
+<translation id="1036727731225946849">Lisätään <ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">Lisätty aloitusnäytölle</translation>
+<translation id="2146738493024040262">Avaa Instant-sovellus</translation>
+<translation id="7016516562562142042">Sallittu nykyisellä hakukoneella</translation>
+<translation id="6177111841848151710">Estetty nykyiseltä hakukoneelta</translation>
+<translation id="145097072038377568">Poistettu käytöstä Android-asetuksissa</translation>
+<translation id="8007176423574883786">Ei käytössä tällä laitteella</translation>
+<translation id="164269334534774161">Katselet sivun offline-kopiota, joka luotiin <ph name="CREATION_TIME"/>.</translation>
+<translation id="4594952190837476234">Offline-sivu vastaa tilannetta <ph name="CREATION_TIME"/> ja saattaa poiketa nykyisestä verkkoversiosta.</translation>
+<translation id="8840953339110955557">Tämä sivu saattaa poiketa verkossa olevasta versiosta.</translation>
+<translation id="6405300764336705484">Brave Software on toimittanut tämän sisällön osoitteesta <ph name="DOMAIN_NAME"/>.</translation>
+<translation id="1006017844123154345">Avaa verkkoversio</translation>
+<translation id="3326636747541519688">Brave Softwaren tarjoama yksinkertaistettu sivu</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Lataa alkuperäinen sivu<ph name="END_LINK"/> osoitteesta <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Jos näet tämän ilmoituksen usein, kokeile näitä <ph name="BEGIN_LINK"/>ehdotuksia<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Sisältö piilotettu</translation>
+<translation id="3810973564298564668">Hallinnoi</translation>
+<translation id="5199929503336119739">Työprofiili</translation>
+<translation id="528192093759286357">Poistu koko näytön tilasta vetämällä näytön yläreunasta ja koskettamalla Takaisin-painiketta.</translation>
+<translation id="2836148919159985482">Poistu koko näytön tilasta Takaisin-painikkeella.</translation>
+<translation id="3967822245660637423">Lataus on valmis</translation>
+<translation id="2434158240863470628">Lataus valmis <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Lataus epäonnistui.</translation>
+<translation id="1384959399684842514">Lataus keskeytettiin.</translation>
+<translation id="1671236975893690980">Lataus odottaa…</translation>
+<translation id="5561549206367097665">Odotetaan verkkoyhteyttä…</translation>
+<translation id="5864419784173784555">Odottaa toista latausta…</translation>
+<translation id="6461962085415701688">Tiedoston avaaminen epäonnistui</translation>
+<translation id="1178581264944972037">Tauko</translation>
+<translation id="8200772114523450471">Jatka</translation>
+<translation id="1409879593029778104">Tiedoston <ph name="FILE_NAME"/> lataus estettiin, koska tiedosto on jo olemassa.</translation>
+<translation id="3387650086002190359">Tiedoston <ph name="FILE_NAME"/> lataus epäonnistui tiedostojärjestelmävirheen vuoksi.</translation>
+<translation id="6482749332252372425">Tiedoston <ph name="FILE_NAME"/> lataus epäonnistui, koska tallennustila ei riitä.</translation>
+<translation id="7619072057915878432">Tiedoston <ph name="FILE_NAME"/> lataus epäonnistui verkkovirheen vuoksi.</translation>
+<translation id="1477626028522505441">Tiedoston <ph name="FILE_NAME"/> lataus epäonnistui palvelinongelman vuoksi.</translation>
+<translation id="3692944402865947621">Lataus epäonnistui, koska tallennussijainti ei ole saatavilla: <ph name="FILE_NAME"/></translation>
+<translation id="604996488070107836">Tiedoston <ph name="FILE_NAME"/> lataus epäonnistui tuntemattoman virheen vuoksi.</translation>
+<translation id="6738867403308150051">Ladataan…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kt</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> Mt</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> Gt</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Ladattu: <ph name="KBS"/> kt</translation>
+<translation id="6416782512398055893">Ladattu: <ph name="MBS"/> Mt</translation>
+<translation id="6538442820324228105">Ladattu: <ph name="GBS"/> Gt</translation>
+<translation id="9204836675896933765">1 tiedosto jäljellä</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> tiedostoa jäljellä</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> tiedosto ladattu}other{<ph name="FILES_DOWNLOADED_MANY"/> tiedostoa ladattu}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> päivää jäljellä</translation>
+<translation id="8190358571722158785">1 päivä jäljellä</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> tuntia jäljellä</translation>
+<translation id="510275257476243843">1 tunti jäljellä</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minuuttia jäljellä</translation>
+<translation id="3236059992281584593">1 minuutti jäljellä</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> sekuntia jäljellä</translation>
+<translation id="2781151931089541271">1 sekunti jäljellä</translation>
+<translation id="3303414029551471755">Jatketaanko sisällön lataamiseen?</translation>
+<translation id="8617240290563765734">Avataanko ladatussa sisällössä määritetty ehdotettu URL-osoite?</translation>
+<translation id="1373696734384179344">Liian vähän muistia valitun sisällön lataamiseen.</translation>
+<translation id="5271967389191913893">Laite ei voi avata ladattavaa sisältöä.</translation>
+<translation id="883806473910249246">Sisältöä ladattaessa tapahtui virhe.</translation>
+<translation id="5626134646977739690">Nimi:</translation>
+<translation id="7963646190083259054">Toimittaja:</translation>
+<translation id="3414952576877147120">Koko:</translation>
+<translation id="7375125077091615385">Tyyppi:</translation>
+<translation id="5765780083710877561">Kuvaus:</translation>
+<translation id="4881695831933465202">Avaa</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> kt käytettävissä</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> Mt käytettävissä</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> Gt käytettävissä</translation>
+<translation id="5793665092639000975">Käytössä <ph name="SPACE_USED"/> / <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Kaikki</translation>
+<translation id="4988526792673242964">Sivut</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Ääni</translation>
+<translation id="9219103736887031265">Kuvat</translation>
+<translation id="8250920743982581267">Dokumentit</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# tiedosto}other{# tiedostoa}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# kuva}other{# kuvaa}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videota}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# äänitiedosto}other{# äänitiedostoa}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# sivu}other{# sivua}}</translation>
+<translation id="5456381639095306749">Lataa sivu</translation>
+<translation id="2394602618534698961">Lataamasi tiedostot näkyvät tässä</translation>
+<translation id="7810647596859435254">Avaa sovelluksessa…</translation>
+<translation id="5655963694829536461">Hae omista latauksistasi</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Omat tiedostot</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Tässä näet artikkelit, jotka voit lukea myös offline-tilassa</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
+<translation id="5853623416121554550">keskeytetty</translation>
+<translation id="8965591936373831584">odottaa</translation>
+<translation id="2779651927720337254">epäonnistui</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Äsken</translation>
+<translation id="4000212216660919741">Offline-etusivu</translation>
+<translation id="9133397713400217035">Tutki offline-tilassa</translation>
+<translation id="968900484120156207">Avaamasi sivut näkyvät tässä</translation>
+<translation id="7882131421121961860">Historiaa ei löytynyt.</translation>
+<translation id="3549657413697417275">Haku omasta historiasta</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">KK</translation>
+<translation id="605721222689873409">VV</translation>
+<translation id="724102042129299115">Braven ensimmäinen käyttökerta</translation>
+<translation id="2700285883409956633">Käyttämällä sovellusta hyväksyt Braven <ph name="BEGIN_LINK1"/>käyttöehdot<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>tietosuojailmoituksen<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Käyttämällä tätä sovellusta hyväksyt Braven <ph name="BEGIN_LINK1"/>käyttöehdot<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>tietosuojailmoituksen<ph name="END_LINK2"/> sekä <ph name="BEGIN_LINK3"/>Family Linkin kautta hallittavia Brave Software-tilejä koskevan tietosuojailmoituksen<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> avautuu Bravessa. Jatkamalla hyväksyt Braven <ph name="BEGIN_LINK1"/>käyttöehdot<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>tietosuojailmoituksen<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> avautuu Bravessa. Jatkamalla hyväksyt Braven <ph name="BEGIN_LINK1"/>käyttöehdot<ph name="END_LINK1"/> ja <ph name="BEGIN_LINK2"/>tietosuojailmoituksen<ph name="END_LINK2"/> sekä <ph name="BEGIN_LINK3"/>Family Linkin kautta hallittavia Brave Software-tilejä koskevan tietosuojailmoituksen<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Auta parantamaan Bravea lähettämällä käyttötilastoja ja virheraportteja Brave Softwarelle.</translation>
+<translation id="3518985090088779359">Hyväksy ja jatka</translation>
+<translation id="7207456302801184289">Tervetuloa Braveen</translation>
+<translation id="704822250101715322">Odotetaan Brave Software Play Palveluiden päivittymistä</translation>
+<translation id="1231733316453485619">Otetaanko synkronointi käyttöön?</translation>
+<translation id="5132942445612118989">Synkronoi salasanasi, historiasi ja paljon muuta kaikilla laitteilla</translation>
+<translation id="5736731321935944068">Brave Software voi muokata Hakua, mainoksia ja muita Brave Softwaren palveluita historiasi perusteella</translation>
+<translation id="4013614219085422040">Brave Software voi muokata Hakua ja muita Brave Softwaren palveluita historiasi perusteella</translation>
+<translation id="5581519193887989363">Voit valita synkronoitavan sisällön <ph name="BEGIN_LINK1"/>asetuksissa<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Kyllä</translation>
+<translation id="2410754283952462441">Valitse tili</translation>
+<translation id="2227444325776770048">Jatka tilillä <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Etkö ole <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Ota synkronointi käyttöön, niin voit käyttää kirjanmerkkejä kaikilla laitteillasi</translation>
+<translation id="2818669890320396765">Kirjaudu sisään ja ota synkronointi käyttöön, niin voit käyttää kirjanmerkkejäsi kaikilla laitteilla</translation>
+<translation id="6003646045106347985">Ota synkronointi käyttöön, niin näet Brave Softwaren suosittelemaa yksilöllistä sisältöä</translation>
+<translation id="8494430740943879273">Kirjaudu sisään ja ota synkronointi käyttöön, niin näet Brave Softwaren suosittelemaa yksilöllistä sisältöä</translation>
+<translation id="5862731021271217234">Ota synkronointi käyttöön, niin voit käyttää välilehtiä muilta laitteiltasi</translation>
+<translation id="3568688522516854065">Kirjaudu sisään ja ota synkronointi käyttöön, niin voit käyttää välilehtiä muilta laitteiltasi</translation>
+<translation id="1208340532756947324">Ota synkronointi käyttöön, niin sisältö synkronoidaan ja yksilöidään eri laitteilla</translation>
+<translation id="4472118726404937099">Kirjaudu sisään ja ota synkronointi käyttöön, niin sisältö synkronoidaan ja yksilöidään eri laitteilla</translation>
+<translation id="2426805022920575512">Valitse toinen tili</translation>
+<translation id="6790428901817661496">Toista</translation>
+<translation id="1272079795634619415">Pysäytä</translation>
+<translation id="2874939134665556319">Edellinen kappale</translation>
+<translation id="4046123991198612571">Seuraava kappale</translation>
+<translation id="3859306556332390985">Kelaa eteenpäin</translation>
+<translation id="8441146129660941386">Kelaa taaksepäin</translation>
+<translation id="6706288973712894588">Olet offline-tilassa.\n<ph name="BEGIN_LINK"/>Tutustu offline-fiidiin.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Hiljattain suljetut välilehdet</translation>
+<translation id="8497726226069778601">Täällä ei ole mitään nähtävää… vielä</translation>
+<translation id="5423934151118863508">Käydyimmät sivusi näkyvät täällä</translation>
+<translation id="6127379762771434464">Kohde poistettu</translation>
+<translation id="4605958867780575332">Kohde poistettiin: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software-piirros: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Muut laitteet</translation>
+<translation id="4738836084190194332">Viimeisin synkronointi: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minuutti sitten}other{# minuuttia sitten}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# tunti sitten}other{# tuntia sitten}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# päivä sitten}other{# päivää sitten}}</translation>
+<translation id="2762000892062317888">äsken</translation>
+<translation id="1407135791313364759">Avaa kaikki</translation>
+<translation id="1209206284964581585">Piilota toistaiseksi</translation>
+<translation id="129553762522093515">Hiljattain suljetut välilehdet</translation>
+<translation id="8413126021676339697">Näytä koko selaushistoria</translation>
+<translation id="7876243839304621966">Poista kaikki</translation>
+<translation id="8487700953926739672">Käytettävissä offline-tilassa</translation>
+<translation id="5224771365102442243">Video sivulla</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Lue lisätietoja<ph name="END_LINK"/> suositellusta sisällöstä.</translation>
+<translation id="7542481630195938534">Ehdotusten haku epäonnistui</translation>
+<translation id="5013696553129441713">Ei uusia ehdotuksia</translation>
+<translation id="1736419249208073774">Tutustu</translation>
+<translation id="7444811645081526538">Lisää luokkia</translation>
+<translation id="6709133671862442373">Uutiset</translation>
+<translation id="1264974993859112054">Urheilu</translation>
+<translation id="9139318394846604261">Ostokset</translation>
+<translation id="3912508018559818924">Haetaan verkon parasta sisältöä…</translation>
+<translation id="526421993248218238">Sivun lataaminen epäonnistui</translation>
+<translation id="614940544461990577">Kokeile seuraavia toimenpiteitä:</translation>
+<translation id="3288003805934695103">Lataa sivu uudelleen.</translation>
+<translation id="2353636109065292463">Internetyhteyttäsi tarkistetaan</translation>
+<translation id="2858138569776157458">Suosituimmat</translation>
+<translation id="8364299278605033898">Katso suositut sivustot</translation>
+<translation id="1171770572613082465">Katso suositut sivustot napauttamalla Suosituimmat sivustot ‑painiketta</translation>
+<translation id="5233638681132016545">Uusi välilehti</translation>
+<translation id="4521874409998847950">Lähde: <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>Brave Softwaren toimittama<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Uudempi versio on saatavilla.</translation>
+<translation id="4058091506841967397">Bravea ei voi päivittää</translation>
+<translation id="6316139424528454185">Android-versiota ei tueta</translation>
+<translation id="6989267951144302301">Lataus epäonnistui</translation>
+<translation id="624789221780392884">Päivitys on valmis</translation>
+<translation id="1549000191223877751">Siirrä toiseen ikkunaan</translation>
+<translation id="7481312909269577407">Seuraava</translation>
+<translation id="4084682180776658562">Kirjanmerkki</translation>
+<translation id="6437478888915024427">Sivun tiedot</translation>
+<translation id="7180611975245234373">Päivitä</translation>
+<translation id="4913169188695071480">Lopeta päivittäminen</translation>
+<translation id="1829244130665387512">Haku sivulta</translation>
+<translation id="6593061639179217415">Tietokonesivusto</translation>
+<translation id="9063523880881406963">Poista käytöstä Käytä tietokoneversiota</translation>
+<translation id="2038563949887743358">Ota käyttöön Käytä tietokoneversiota</translation>
+<translation id="2433507940547922241">Ulkonäkö</translation>
+<translation id="983192555821071799">Sulje kaikki välilehdet</translation>
+<translation id="1310482092992808703">Ryhmittele välilehtiä</translation>
+<translation id="7725024127233776428">Kirjanmerkeiksi lisätyt sivut näkyvät tässä</translation>
+<translation id="4404568932422911380">Ei kirjanmerkkejä</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> kirjanmerkki}other{<ph name="BOOKMARKS_COUNT_MANY"/> kirjanmerkkiä}}</translation>
+<translation id="3739899004075612870">Lisätty kirjanmerkkeihin: <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Kirjanmerkeissä</translation>
+<translation id="4452548195519783679">Lisätty kirjanmerkiksi kansioon <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Kirjanmerkin lisääminen epäonnistui.</translation>
+<translation id="2842985007712546952">Ylätason kansio</translation>
+<translation id="9065203028668620118">Muokkaa</translation>
+<translation id="4405224443901389797">Siirrä…</translation>
+<translation id="5170568018924773124">Näytä kansiossa</translation>
+<translation id="8035133914807600019">Uusi kansio…</translation>
+<translation id="4532845899244822526">Valitse kansio</translation>
+<translation id="6627583120233659107">Muokkaa kansiota</translation>
+<translation id="1197267115302279827">Siirrä kirjanmerkkejä</translation>
+<translation id="6963766334940102469">Poista kirjanmerkkejä</translation>
+<translation id="4351244548802238354">Sulje ikkuna</translation>
+<translation id="451872707440238414">Hae kirjanmerkeistä</translation>
+<translation id="8901170036886848654">Kirjanmerkkejä ei löytynyt.</translation>
+<translation id="6404511346730675251">Muokkaa kirjanmerkkiä</translation>
+<translation id="3894427358181296146">Lisää kansio</translation>
+<translation id="5327248766486351172">Nimi</translation>
+<translation id="7400418766976504921">URL-osoite</translation>
+<translation id="3527085408025491307">Kansio</translation>
+<translation id="5161254044473106830">Nimike vaaditaan</translation>
+<translation id="2996809686854298943">URL-osoite vaaditaan</translation>
+<translation id="2536728043171574184">Näkyvissä on sivun offline-versio.</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> voi näyttää sisältöä offline-tilassa</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ja muita sivustoja</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave lataa sivusi, kun se on valmis}other{Brave lataa sivusi, kun ne ovat valmiina}}</translation>
+<translation id="6811034713472274749">Sivu on valmis näytettäväksi</translation>
+<translation id="4561979708150884304">Ei yhteyttä</translation>
+<translation id="8274165955039650276">Näytä lataukset</translation>
+<translation id="2082238445998314030">Tulos <ph name="RESULT_NUMBER"/>/<ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Ei tuloksia</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Puhehaku ei ole käytössä</translation>
+<translation id="7191430249889272776">Välilehti avattiin taustalla.</translation>
+<translation id="8445059357334030806">Avaa Bravessa</translation>
+<translation id="4720023427747327413">Avaa kohteessa <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Avaa selaimessa</translation>
+<translation id="1113597929977215864">Näytä yksinkertaistettu näkymä</translation>
+<translation id="1513352483775369820">Kirjanmerkit ja verkkohistoria</translation>
+<translation id="4939482511480190003">Auta parantamaan Bravea. <ph name="BEGIN_LINK"/>Vastaa kyselyyn.<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Takaisin</translation>
+<translation id="5596627076506792578">Lisäasetukset</translation>
+<translation id="3522247891732774234">Päivitys on saatavilla. Näytä lisäasetukset.</translation>
+<translation id="6773423637732432200">Bravea ei voi päivittää. Lisää vaihtoehtoja</translation>
+<translation id="3328801116991980348">Tietoja sivustosta</translation>
+<translation id="5391532827096253100">Sivustolle muodostamasi yhteys ei ole turvallinen. Sivuston tiedot</translation>
+<translation id="6206551242102657620">Yhteys on turvallinen. Sivuston tiedot</translation>
+<translation id="6963642900430330478">Tämä sivu on vaarallinen. Sivuston tiedot</translation>
+<translation id="9070377983101773829">Aloita puhehaku</translation>
+<translation id="8676374126336081632">Tyhjennä teksti</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> avoin välilehti, vaihda välilehteä napauttamalla}other{<ph name="OPEN_TABS_MANY"/> avointa välilehteä, vaihda välilehteä napauttamalla}}</translation>
+<translation id="2369533728426058518">Avoimet välilehdet</translation>
+<translation id="7071521146534760487">Hallinnoi tiliä</translation>
+<translation id="932327136139879170">Etusivu</translation>
+<translation id="2707726405694321444">Päivitä sivu</translation>
+<translation id="2891154217021530873">Pysäytä sivun lataus</translation>
+<translation id="6710213216561001401">Edellinen</translation>
+<translation id="6659594942844771486">Välilehti</translation>
+<translation id="1933845786846280168">Valittu välilehti</translation>
+<translation id="2268044343513325586">Tarkenna</translation>
+<translation id="7846076177841592234">Peruuta valinta</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> valittu. Toimintoja on käytettävissä näytön yläosassa.</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> valittu</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Jaa 1 valittu kohde}other{Jaa # valittua kohdetta}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Poista 1 valittu kohde}other{Poista # valittua kohdetta}}</translation>
+<translation id="1283039547216852943">Laajenna napauttamalla.</translation>
+<translation id="5962718611393537961">Tiivistä napauttamalla.</translation>
+<translation id="8076492880354921740">Välilehdet</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 valittu}other{# valittu}}</translation>
+<translation id="6818926723028410516">Valitse kohteet</translation>
+<translation id="4797039098279997504">Palaa osoitteeseen <ph name="URL_OF_THE_CURRENT_TAB"/> koskettamalla.</translation>
+<translation id="6766758767654711248">Siirry sivustolle napauttamalla.</translation>
+<translation id="429312253194641664">Sivusto toistaa mediaa</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> jakaa näyttösi.</translation>
+<translation id="8833831881926404480">Sivusto jakaa näyttösi</translation>
+<translation id="9086455579313502267">Ei yhteyttä verkkoon.</translation>
+<translation id="938850635132480979">(Virhe: <ph name="ERROR_CODE"/>)</translation>
+<translation id="666731172850799929">Avaa sovelluksessa <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Avaa karttasovelluksessa</translation>
+<translation id="7698359219371678927">Luo sähköposti sovelluksessa <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Luo sähköposti</translation>
+<translation id="5665379678064389456">Luo tapahtuma sovelluksessa <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Luo tapahtuma</translation>
+<translation id="2111511281910874386">Siirry sivulle</translation>
+<translation id="3988466920954086464">Näytä Instant-hakutulokset tässä paneelissa</translation>
+<translation id="2744248271121720757">Napauta sanaa etsiäksesi välittömästi tai nähdäksesi asiaan liittyviä toimia.</translation>
+<translation id="9155898266292537608">Voit hakea myös napauttamalla sanaa nopeasti.</translation>
+<translation id="3232754137068452469">Verkkosovellus</translation>
+<translation id="1430915738399379752">Tulosta</translation>
+<translation id="3775705724665058594">Lähetä laitteillesi</translation>
+<translation id="6364438453358674297">Poistetaanko ehdotus historiasta?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> suljettiin</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> välilehteä suljettiin.</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> poistettiin.</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> kirjanmerkkiä poistettiin</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> latausta poistettiin.</translation>
+<translation id="1248710015876067820">Braven versioiden määrää ei tueta.</translation>
+<translation id="4259722352634471385">Kohde on estetty: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Kohde ei ole saatavilla: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Sulje välilehti</translation>
+<translation id="7772375229873196092">Sulje <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Navigointihistoria</translation>
+<translation id="9169507124922466868">Navigointihistoria on puoliksi auki</translation>
+<translation id="1327257854815634930">Navigointihistoria avattu</translation>
+<translation id="8788265440806329501">Navigointihistoria suljettu</translation>
+<translation id="7482656565088326534">Esikatseluvälilehti</translation>
+<translation id="8427875596167638501">Esikatseluvälilehti on puoliksi auki</translation>
+<translation id="9102803872260866941">Esikatseluvälilehti on avattu</translation>
+<translation id="2942036813789421260">Esikatseluvälilehti on suljettu</translation>
+<translation id="6355102470683871794">Tallennustila: Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Poistetaanko tiedot?</translation>
+<translation id="9205995714227143200">Tallennetut sivustotiedot, joita Brave ei pidä tärkeinä (esim. sivustot, joilla ei ole tallennettuja asetuksia tai joilla et käy usein).</translation>
+<translation id="3997476611815694295">Vähemmän tärkeät tiedot</translation>
+<translation id="8493948351860045254">Vapauta tilaa</translation>
+<translation id="2324920234469020158">Evästeet, välimuisti ja muut Braven vähemmän tärkeinä pitämät sivustotiedot poistetaan.</translation>
+<translation id="5447201525962359567">Kaikki tallennetut sivustotiedot, mukaan lukien evästeet ja muut paikallisesti tallennetut tiedot</translation>
+<translation id="1376578503827013741">Lasketaan…</translation>
+<translation id="583281660410589416">Tuntematon</translation>
+<translation id="2323763861024343754">Sivustotietoja tallennettu</translation>
+<translation id="3587672679800759167">Braven käyttämän tallennustilan kokonaismäärä, mukaan lukien tilit, kirjanmerkit ja tallennetut asetukset.</translation>
+<translation id="6545017243486555795">Poista kaikki tiedot</translation>
+<translation id="4095146165863963773">Poistetaanko sovellustiedot?</translation>
+<translation id="53119194224775367">Kaikki Braven sovellustiedot, mukaan lukien tiedostot, asetukset, tilit ja tietokannat, poistetaan pysyvästi.</translation>
+<translation id="5307446750509046227">Poista sivustotiedot</translation>
+<translation id="300526633675317032">Tämä tyhjentää yhteensä <ph name="SIZE_IN_KB"/> tallennettuja sivustotietoja.</translation>
+<translation id="8068648041423924542">Varmenteen valinta epäonnistui</translation>
+<translation id="2315043854645842844">Käyttöjärjestelmä ei tue palvelimen varmennevalintaa.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> haluaa muodostaa yhteyden</translation>
+<translation id="5308380583665731573">Muodosta yhteys</translation>
+<translation id="868929229000858085">Hae yhteystiedoistasi</translation>
+<translation id="1919950603503897840">Valitse kontaktit</translation>
+<translation id="7986741934819883144">Valitse yhteystieto</translation>
+<translation id="3333961966071413176">Kaikki yhteystiedot</translation>
+<translation id="4994033804516042629">Kontakteja ei löytynyt</translation>
+<translation id="5403592356182871684">Nimet</translation>
+<translation id="2717722538473713889">Sähköpostiosoitteet</translation>
+<translation id="381841723434055211">Puhelinnumerot</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 muu)}other{(+ # muuta)}}</translation>
+<translation id="5197729504361054390"><ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> saa valitsemasi yhteystiedot.</translation>
+<translation id="1779089405699405702">Kuvien dekooderi</translation>
+<translation id="8067883171444229417">Toista video</translation>
+<translation id="6560414384669816528">Käytä Sogouta</translation>
+<translation id="5406914950576900927">Brave voi käyttää <ph name="BEGIN_BOLD"/>Sogouta<ph name="END_BOLD"/> hakujen tekemiseen Kiinassa. Voit muokata tätä <ph name="BEGIN_LINK"/>Asetuksissa<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Käytä Brave Softwarea</translation>
+<translation id="4384468725000734951">Hakukoneena käytetään Sogouta.</translation>
+<translation id="6103327872225198548">Hakukoneena käytetään Brave Softwarea.</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Tämä sovellus on käynnissä Bravessa</translation>
+<translation id="6143689084714664628">Käynnissä Bravessa</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> sisältää dataa myös Bravessa</translation>
+<translation id="2734140769649165081">Voit tyhjentää datan Braven asetuksissa</translation>
+<translation id="8232956427053453090">Säilytä data</translation>
+<translation id="4298388696830689168">Linkitetyt sivustot</translation>
+<translation id="5763514718066511291">Kosketa kopioidaksesi tämän sovelluksen URL-osoite</translation>
+<translation id="6496823230996795692">Muodosta internetyhteys, ennen kuin <ph name="APP_NAME"/> on käytössäsi ensimmäisen kerran.</translation>
+<translation id="751961395872307827">Yhteyden muodostaminen sivustoon epäonnistui</translation>
+<translation id="4878404682131129617">Tunnelin muodostaminen välityspalvelimen kautta epäonnistui</translation>
+<translation id="4749960740855309258">Uuden välilehden avaaminen</translation>
+<translation id="8788968922598763114">Avaa viimeksi suljettu välilehti uudelleen</translation>
+<translation id="7929962904089429003">Avaa valikko</translation>
+<translation id="6039379616847168523">Siirry seuraavalle välilehdelle</translation>
+<translation id="5210286577605176222">Siirry edelliselle välilehdelle</translation>
+<translation id="124678866338384709">Sulje nykyinen välilehti</translation>
+<translation id="3714981814255182093">Avaa hakupalkki</translation>
+<translation id="5441522332038954058">Siirry osoitepalkkiin</translation>
+<translation id="3398320232533725830">Avaa kirjanmerkkien hallinta</translation>
+<translation id="6583199322650523874">Lisää nykyinen sivu kirjanmerkkeihin</translation>
+<translation id="8489271220582375723">Avaa Historia-sivu</translation>
+<translation id="4837753911714442426">Avaa sivun tulostusvaihtoehdot</translation>
+<translation id="5726692708398506830">Suurenna sivun kaikki sisältö</translation>
+<translation id="3259831549858767975">Pienennä sivun kaikki sisältö</translation>
+<translation id="8015452622527143194">Palauta sivun kaiken sisällön oletuskoko</translation>
+<translation id="3443221991560634068">Päivitä nykyinen sivu</translation>
+<translation id="123724288017357924">Päivitä nykyinen sivu, ohita välimuistin sisältö</translation>
+<translation id="305870044889644984">Avaa Braven ohjekeskus uudella välilehdellä</translation>
+<translation id="3166827708714933426">Välilehti- ja ikkunapikanäppäimet</translation>
+<translation id="3169981355900570544">Brave Software Braven ominaisuuksien pikanäppäimet</translation>
+<translation id="4558311620361989323">Verkkosivun pikanäppäimet</translation>
+<translation id="1908301351964700579">Brave valmistelee edelleen VR-selainta. Käynnistä Brave myöhemmin uudelleen.</translation>
+<translation id="8970887620466824814">Tapahtui virhe.</translation>
+<translation id="1875543012935658554">Avaa Brave uudelleen.</translation>
+<translation id="79859296434321399">Asenna ARCore, niin voit nähdä AR-sisältöä.</translation>
+<translation id="8558485628462305855">Päivitä ARCore, niin voit nähdä AR-sisältöä.</translation>
+<translation id="3513704683820682405">Lisätty todellisuus</translation>
+<translation id="5475862044948910901">Aloitetaanko lisätyn todellisuuden käyttökerta?</translation>
 <translation id="7365126855094612066">Tämän käyttökerran ajan sivusto voi
 • luoda 3D-kartan ympäristöstäsi
 • seurata kameran liikettä
 
 Sivusto EI saa kameran käyttöoikeutta. Kamerakuvat näkyvät vain sinulle.</translation>
-<translation id="7375125077091615385">Tyyppi:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL-osoite</translation>
-<translation id="7403691278183511381">Chromen ensimmäinen käyttökerta</translation>
-<translation id="741204030948306876">Kyllä</translation>
-<translation id="7413229368719586778">Alkamispäivä: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Kysy ensin</translation>
-<translation id="7423538860840206698">Leikepöydältä lukeminen estetty</translation>
-<translation id="7431991332293347422">Määritä, miten selaushistoria personoi Hakua ja muita</translation>
-<translation id="7437998757836447326">Uloskirjautuminen Chromesta</translation>
-<translation id="7438641746574390233">Kun yksinkertaistettu tila on käytössä, Chrome saa Googlen palvelimien avulla sivut latautumaan nopeammin. Yksinkertaistettu tila kirjoittaa hyvin hitaat sivut uudelleen niin, että vain tärkein sisältö latautuu. Yksinkertaistettu tila ei koske incognito-välilehtiä.</translation>
-<translation id="7444811645081526538">Lisää luokkia</translation>
-<translation id="7445411102860286510">Salli sivustoille mykistettyjen videoiden automaattinen toisto (suositus)</translation>
-<translation id="7453467225369441013">Tämä kirjaa sinut ulos useimmilta sivustoilta. Sinua ei kirjata ulos Google-tililtäsi.</translation>
-<translation id="7454641608352164238">Tallennustila ei riitä</translation>
-<translation id="7475192538862203634">Jos näet tämän ilmoituksen usein, kokeile näitä <ph name="BEGIN_LINK" />ehdotuksia<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD-korttia ei löydy. Osa tiedostoista voi puuttua.</translation>
-<translation id="7479104141328977413">Välilehtien ylläpito</translation>
-<translation id="7481312909269577407">Seuraava</translation>
-<translation id="7482656565088326534">Esikatseluvälilehti</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (päivitettiin <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">dataa säästetty</translation>
-<translation id="7498271377022651285">Odota…</translation>
-<translation id="7514365320538308">Lataa</translation>
-<translation id="751961395872307827">Yhteyden muodostaminen sivustoon epäonnistui</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Ehdotusten haku epäonnistui</translation>
-<translation id="7559975015014302720">Yksinkertaistettu tila on poissa käytöstä</translation>
-<translation id="7562080006725997899">Selaustietoja poistetaan</translation>
-<translation id="756809126120519699">Chrome-tiedot tyhjennetty</translation>
-<translation id="757524316907819857">Estä sivustoja toistamasta suojattua sisältöä</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> tiedosto ladattu}other{<ph name="FILES_DOWNLOADED_MANY" /> tiedostoa ladattu}}</translation>
-<translation id="7588219262685291874">Ota tumma teema käyttöön, kun laitteen virransäästö on käytössä</translation>
-<translation id="7589445247086920869">Estä nykyiselle hakukoneelle</translation>
-<translation id="7593557518625677601">Avaa Android-asetukset ja ota järjestelmän synkronointi uudelleen käyttöön.</translation>
-<translation id="7596558890252710462">Käyttöjärjestelmä</translation>
-<translation id="7605594153474022051">Synkronointi ei toimi</translation>
-<translation id="7606077192958116810">Yksinkertaistettu tila on käytössä. Ylläpidä sitä asetuksissa.</translation>
-<translation id="7612619742409846846">Olet kirjautunut Googleen käyttäjänä</translation>
-<translation id="7619072057915878432">Tiedoston <ph name="FILE_NAME" /> lataus epäonnistui verkkovirheen vuoksi.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Lue ohjeita<ph name="END_LINK1" /> tai <ph name="BEGIN_LINK2" />hae uudelleen<ph name="END_LINK2" />.</translation>
-<translation id="7626032353295482388">Tervetuloa Chromeen</translation>
-<translation id="7638584964844754484">Väärä tunnuslause.</translation>
-<translation id="7641339528570811325">Poista selaustiedot…</translation>
-<translation id="7648422057306047504">Salaa salasanat Google-kirjautumistiedoilla</translation>
-<translation id="7649070708921625228">Ohje</translation>
-<translation id="7658239707568436148">Peruuta</translation>
-<translation id="7665369617277396874">Lisää tili</translation>
-<translation id="766587987807204883">Tässä näet artikkelit, jotka voit lukea myös offline-tilassa</translation>
-<translation id="7682724950699840886">Kokeile seuraavia keinoja: varmista, että laitteellasi on tarpeeksi tilaa, yritä viedä uudelleen.</translation>
-<translation id="7685301384041462804">Varmista, että sivusto on luotettava, ennen kuin siirryt VR-tilaan.</translation>
-<translation id="7698359219371678927">Luo sähköposti sovelluksessa <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Täydennä automaattisesti hakuja ja URL-osoitteita</translation>
-<translation id="7725024127233776428">Kirjanmerkeiksi lisätyt sivut näkyvät tässä</translation>
-<translation id="773466115871691567">Käännä aina kielellä <ph name="SOURCE_LANGUAGE" /> kirjoitut sivut</translation>
-<translation id="7746457520633464754">Vaarallisia sovelluksia ja sivustoja löytääkseen Chrome lähettää joidenkin avattujen sivujen URL-osoitteita, rajallisia järjestelmätietoja ja osia sivujen sisällöstä Googlelle</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> jakoi tekstin</translation>
-<translation id="7762668264895820836">SD-kortti <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Lisää osoite</translation>
-<translation id="7772032839648071052">Vahvista tunnuslause</translation>
-<translation id="7772375229873196092">Sulje <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> muu}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ja <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> muuta}}</translation>
-<translation id="7781829728241885113">Eilen</translation>
-<translation id="7791543448312431591">Lisää</translation>
-<translation id="780301667611848630">Ei kiitos</translation>
-<translation id="7810647596859435254">Avaa sovelluksessa…</translation>
-<translation id="7821588508402923572">Datasäästösi näkyvät täällä</translation>
-<translation id="7837721118676387834">Sallii tietylle sivustolle mykistettyjen videoiden automaattisen toiston.</translation>
-<translation id="7846076177841592234">Peruuta valinta</translation>
-<translation id="784934925303690534">Aikaväli</translation>
-<translation id="7851858861565204677">Muut laitteet</translation>
-<translation id="7875915731392087153">Luo sähköposti</translation>
-<translation id="7876243839304621966">Poista kaikki</translation>
-<translation id="7882131421121961860">Historiaa ei löytynyt.</translation>
-<translation id="7882806643839505685">Salli tietyn sivuston äänet.</translation>
-<translation id="7886917304091689118">Käynnissä Chromessa</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Ladataan tiedostoa}other{Ladataan # tiedostoa}}</translation>
-<translation id="7929962904089429003">Avaa valikko</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> on vanhentunut.</translation>
-<translation id="7947953824732555851">Hyväksy ja kirjaudu sisään</translation>
-<translation id="7963646190083259054">Toimittaja:</translation>
-<translation id="7971136598759319605">Aktiivinen 1 päivä sitten</translation>
-<translation id="7975379999046275268">Esikatsele sivu <ph name="BEGIN_NEW" />Uusi<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Esilataa sivuja nopeuttaaksesi lataamista ja hakemista</translation>
-<translation id="79859296434321399">Asenna ARCore, niin voit nähdä AR-sisältöä.</translation>
-<translation id="7986741934819883144">Valitse yhteystieto</translation>
-<translation id="7987073022710626672">Chromen käyttöehdot</translation>
-<translation id="7998918019931843664">Avaa suljettu välilehti uudelleen</translation>
-<translation id="7999064672810608036">Haluatko varmasti tyhjentää kaikki paikalliset tiedot, mukaan lukien evästeet, ja nollata kaikki tämän verkkosivuston käyttöluvat?</translation>
-<translation id="8004582292198964060">Selain</translation>
-<translation id="8007176423574883786">Ei käytössä tällä laitteella</translation>
-<translation id="8013372441983637696">Poistetaanko Chrome-data tältä laitteelta?</translation>
-<translation id="8015452622527143194">Palauta sivun kaiken sisällön oletuskoko</translation>
-<translation id="802154636333426148">Lataus epäonnistui.</translation>
-<translation id="8026334261755873520">Poista selaustiedot</translation>
-<translation id="8035133914807600019">Uusi kansio…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> päivää jäljellä</translation>
-<translation id="804335162455518893">SD-korttia ei löydy</translation>
-<translation id="805047784848435650">Selaushistoriasi perusteella</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> Mt käytettävissä</translation>
-<translation id="8058746566562539958">Avaa, uusi Chrome-välilehti</translation>
-<translation id="8063895661287329888">Kirjanmerkin lisääminen epäonnistui.</translation>
-<translation id="806745655614357130">Pidä tiedot erillään</translation>
-<translation id="8067883171444229417">Toista video</translation>
-<translation id="8068648041423924542">Varmenteen valinta epäonnistui</translation>
-<translation id="8073388330009372546">Avaa kuva uudessa välilehdessä</translation>
-<translation id="8076492880354921740">Välilehdet</translation>
-<translation id="8084114998886531721">Salasana tallennettu</translation>
-<translation id="8087000398470557479">Google on toimittanut tämän sisällön osoitteesta <ph name="DOMAIN_NAME" />.</translation>
-<translation id="8103578431304235997">Incognito-välilehti</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Ota synkronointi käyttöön, niin voit käyttää kirjanmerkkejä kaikilla laitteillasi</translation>
-<translation id="8110087112193408731">Näytetäänkö Chrome-toimintasi Digitaalisessa hyvinvoinnissa?</translation>
-<translation id="8116925261070264013">Mykistetty</translation>
-<translation id="813082847718468539">Näytä sivuston tiedot</translation>
-<translation id="8131740175452115882">Vahvista</translation>
-<translation id="8156139159503939589">Mitä kieliä ymmärrät?</translation>
-<translation id="8168435359814927499">Sisältö</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> tiedostoa jäljellä</translation>
-<translation id="8190358571722158785">1 päivä jäljellä</translation>
-<translation id="8200772114523450471">Jatka</translation>
-<translation id="8209050860603202033">Avaa kuva</translation>
-<translation id="8218622182176210845">Ylläpidä tiliäsi</translation>
-<translation id="8224471946457685718">Lataa sinulle valittuja artikkeleita Wi-Fin kautta</translation>
-<translation id="8232956427053453090">Säilytä data</translation>
-<translation id="8249310407154411074">Siirrä ylimmäksi</translation>
-<translation id="8250920743982581267">Dokumentit</translation>
-<translation id="825412236959742607">Tämä sivu käyttää liikaa muistia, joten Chrome poisti osan sisällöstä.</translation>
-<translation id="8260126382462817229">Yritä kirjautua uudelleen sisään.</translation>
-<translation id="8261506727792406068">Poista</translation>
-<translation id="8266862848225348053">Lataussijainti</translation>
-<translation id="8274165955039650276">Näytä lataukset</translation>
-<translation id="8284326494547611709">Tekstitykset</translation>
-<translation id="8300705686683892304">Sovelluksen ylläpitämät</translation>
-<translation id="8310344678080805313">Tavalliset välilehdet</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ja muita sivustoja</translation>
-<translation id="8327155640814342956">Jotta saat parhaan mahdollisen selauskokemuksen, avaa ja päivitä Chrome nyt</translation>
-<translation id="8339163506404995330">Kielellä <ph name="LANGUAGE" /> kirjoitettuja sivuja ei käännetä.</translation>
-<translation id="8349013245300336738">Lajittele käytetyn datan määrän mukaan</translation>
-<translation id="8364299278605033898">Katso suositut sivustot</translation>
-<translation id="8368027906805972958">Tuntematon tai ei-tuettu laite (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Salli taustasynkronointi tietyllä sivustolla.</translation>
-<translation id="8378714024927312812">Organisaatiosi ylläpitämä</translation>
-<translation id="8380167699614421159">Tällä sivustolla on häiritseviä tai harhaanjohtavia mainoksia</translation>
-<translation id="8393700583063109961">Lähetä viesti</translation>
-<translation id="8413126021676339697">Näytä koko selaushistoria</translation>
-<translation id="8427875596167638501">Esikatseluvälilehti on puoliksi auki</translation>
-<translation id="8428213095426709021">Asetukset</translation>
-<translation id="8438566539970814960">Paranna hakuja ja selausta</translation>
-<translation id="8441146129660941386">Kelaa taaksepäin</translation>
-<translation id="8443209985646068659">Chromea ei voi päivittää</translation>
-<translation id="8445448999790540984">Salasanojen vienti epäonnistui</translation>
-<translation id="8447861592752582886">Peruuta laitteen käyttöoikeus</translation>
-<translation id="8461694314515752532">Salaa synkronoidut tiedot oman synkronoinnin tunnuslauseesi avulla</translation>
-<translation id="8466613982764129868">Varmista, että <ph name="TARGET_DEVICE_NAME" /> on yhteydessä internetiin</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Käytettävissä offline-tilassa</translation>
-<translation id="8489271220582375723">Avaa Historia-sivu</translation>
-<translation id="8493948351860045254">Vapauta tilaa</translation>
-<translation id="8497726226069778601">Täällä ei ole mitään nähtävää… vielä</translation>
-<translation id="8503559462189395349">Chrome-salasanat</translation>
-<translation id="8503813439785031346">Käyttäjätunnus</translation>
-<translation id="8514477925623180633">Vie Chromeen tallennetut salasanat</translation>
-<translation id="8514577642972634246">Siirry incognito-tilaan</translation>
-<translation id="851751545965956758">Estä sivustoja yhdistämästä laitteisiin</translation>
-<translation id="8523928698583292556">Poista tallennettu salasana</translation>
-<translation id="854522910157234410">Avaa tämä sivu</translation>
-<translation id="8558485628462305855">Päivitä ARCore, niin voit nähdä AR-sisältöä.</translation>
-<translation id="8559990750235505898">Tarjoudu kääntämään vierailla kielillä kirjoitettuja sivuja</translation>
-<translation id="8562452229998620586">Tässä näytetään tallennetut salasanasi.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> alkaen</translation>
-<translation id="8571213806525832805">Viimeiset neljä viikkoa</translation>
-<translation id="857943718398505171">Sallittu (suositus)</translation>
-<translation id="8583805026567836021">Poistetaan tilin tietoja</translation>
-<translation id="860043288473659153">Kortinhaltijan nimi</translation>
-<translation id="8609465669617005112">Siirrä ylös</translation>
-<translation id="8616006591992756292">Google-tililläsi voi olla muita selaushistoriatietoja osoitteessa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Avataanko ladatussa sisällössä määritetty ehdotettu URL-osoite?</translation>
-<translation id="8636825310635137004">Ota synkronointi käyttöön, niin voit käyttää välilehtiäsi kaikilla laitteilla.</translation>
-<translation id="8641930654639604085">Pyri estämään aikuisille tarkoitetut sivustot</translation>
-<translation id="8655129584991699539">Voit tyhjentää datan Chromen asetuksissa</translation>
-<translation id="8662811608048051533">Kirjaa sinut ulos useimmilta sivustoilta.</translation>
-<translation id="8664979001105139458">Tiedoston nimi on jo käytössä</translation>
-<translation id="8676374126336081632">Tyhjennä teksti</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signaalin voimakkuus: # palkki}other{Signaalin voimakkuus: # palkkia}}</translation>
-<translation id="868929229000858085">Hae yhteystiedoistasi</translation>
-<translation id="869891660844655955">Vanhenemispäivämäärä</translation>
-<translation id="8719023831149562936">Nykyistä välilehteä ei voi jakaa</translation>
-<translation id="8725066075913043281">Yritä uudelleen</translation>
-<translation id="8728487861892616501">Käyttämällä tätä sovellusta hyväksyt Chromen <ph name="BEGIN_LINK1" />käyttöehdot<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />tietosuojailmoituksen<ph name="END_LINK2" /> sekä <ph name="BEGIN_LINK3" />Family Linkin kautta hallittavia Google-tilejä koskevan tietosuojailmoituksen<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Valmis</translation>
-<translation id="8748850008226585750">Sisältö piilotettu</translation>
-<translation id="8751914237388039244">Valitse kuva</translation>
-<translation id="8788265440806329501">Navigointihistoria suljettu</translation>
-<translation id="8788968922598763114">Avaa viimeksi suljettu välilehti uudelleen</translation>
-<translation id="8801436777607969138">Estä JavaScript tietyllä sivustolla.</translation>
-<translation id="8812260976093120287">Tietyt sivustot tukevat yllä mainittuja laitteesi yhteensopivia maksusovelluksia.</translation>
-<translation id="8816026460808729765">Estä sivustoja käyttämästä tunnistimia</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> avautuu Chromessa. Jatkamalla hyväksyt Chromen <ph name="BEGIN_LINK1" />käyttöehdot<ph name="END_LINK1" /> ja <ph name="BEGIN_LINK2" />tietosuojailmoituksen<ph name="END_LINK2" /> sekä <ph name="BEGIN_LINK3" />Family Linkin kautta hallittavia Google-tilejä koskevan tietosuojailmoituksen<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Kirjanmerkit</translation>
-<translation id="8833831881926404480">Sivusto jakaa näyttösi</translation>
-<translation id="883806473910249246">Sisältöä ladattaessa tapahtui virhe.</translation>
-<translation id="8840953339110955557">Tämä sivu saattaa poiketa verkossa olevasta versiosta.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, välilehti</translation>
-<translation id="885701979325669005">Tallennus</translation>
-<translation id="889338405075704026">Siirry Chrome-asetuksiin</translation>
-<translation id="8901170036886848654">Kirjanmerkkejä ei löytynyt.</translation>
-<translation id="8909135823018751308">Jaa…</translation>
-<translation id="8912362522468806198">Google-tilisi avulla</translation>
-<translation id="8920114477895755567">Odotetaan vanhempien tietoja.</translation>
+<translation id="1188239144602654184">Lisää AR</translation>
+<translation id="473775607612524610">Päivitä</translation>
+<translation id="3133489217401741157">Asennetaan <ph name="MODULE"/> Braveen…</translation>
+<translation id="1791662854739702043">Asennettu</translation>
+<translation id="5131234170665854056">Kohteen <ph name="MODULE"/> asennus Braveen epäonnistui</translation>
+<translation id="2567385386134582609">KUVA</translation>
+<translation id="6395288395575013217">LINKITÄ</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Lataa sivuja offline-käyttöä varten</translation>
 <translation id="8922289737868596582">Lataa sivuja lisäasetuksien kautta, niin voit käyttää niitä offline-tilassa.</translation>
-<translation id="8937772741022875483">Poistetaanko Chrome-toimintasi Digitaalisesta hyvinvoinnista?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Avaa uudessa ikkunassa</translation>
-<translation id="8951232171465285730">Chrome on säästänyt <ph name="MEGABYTES" /> Mt tilaa</translation>
-<translation id="8958424370300090006">Estä evästeet tietyltä sivustolta.</translation>
-<translation id="8959122750345127698">Kohde ei ole saatavilla: <ph name="URL" /></translation>
-<translation id="8965591936373831584">odottaa</translation>
-<translation id="8970887620466824814">Tapahtui virhe.</translation>
-<translation id="8972098258593396643">Ladataanko tiedosto oletuskansioon?</translation>
-<translation id="8986494364107987395">Lähetä Googlelle käyttötilastoja ja virheraportteja automaattisesti</translation>
-<translation id="8993760627012879038">Avaa uusi välilehti incognito-tilassa</translation>
-<translation id="8998729206196772491">Olet kirjautumassa sisään verkkotunnuksen <ph name="MANAGED_DOMAIN" /> hallinnoimalla tilillä ja antamassa sen järjestelmänvalvojalle oikeuden hallita Chrome-tietojasi. Tietosi liitetään pysyvästi tähän tiliin. Chromesta uloskirjautuminen poistaa tietosi tältä laitteelta, mutta ne säilyvät Google-tililläsi.</translation>
-<translation id="9019902583201351841">Vanhempiesi hallinnoima</translation>
-<translation id="9028914725102941583">Ota synkronointi käyttöön, niin voit jakaa sisältöä laitteiden välillä</translation>
-<translation id="9029323097866369874">Saako <ph name="DOMAIN" /> siirtyä VR-tilaan?</translation>
-<translation id="9040142327097499898">Ilmoitukset sallitaan. Sijainti on poissa käytöstä tällä laitteella.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videota}}</translation>
-<translation id="9050666287014529139">Tunnuslause</translation>
-<translation id="9063523880881406963">Poista käytöstä Käytä tietokoneversiota</translation>
-<translation id="9065203028668620118">Muokkaa</translation>
-<translation id="9070377983101773829">Aloita puhehaku</translation>
-<translation id="9074336505530349563">Kirjaudu sisään ja ota synkronointi käyttöön, niin näet Googlen suosittelemaa yksilöllistä sisältöä</translation>
-<translation id="9086455579313502267">Ei yhteyttä verkkoon.</translation>
-<translation id="9100505651305367705">Tarjoa yksinkertaistettua näkymää, jos artikkeli tukee sitä</translation>
-<translation id="9100610230175265781">Tunnuslause tarvitaan</translation>
-<translation id="9102803872260866941">Esikatseluvälilehti on avattu</translation>
+<translation id="5958275228015807058">Löydät tiedostosi ja sivusi Latauksista</translation>
+<translation id="5620928963363755975">Valitse Lisäasetukset ja sitten Lataukset, niin löydät tiedostosi ja sivusi.</translation>
+<translation id="3341058695485821946">Katso paljonko dataa olet säästänyt</translation>
+<translation id="3157842584138209013">Lisäasetukset-painiketta klikkaamalla voit katsoa, kuinka paljon dataa olet säästänyt.</translation>
+<translation id="8218622182176210845">Ylläpidä tiliäsi</translation>
+<translation id="8090895580117672212">Voit ylläpitää Brave Software-tiliäsi napauttamalla Ylläpidä tiliä ‑painiketta</translation>
+<translation id="8856898588039823173">Brave Softwaren tarjoama yksinkertaistettu sivu. Lataa alkuperäinen napauttamalla.</translation>
+<translation id="8134317863207426198">Brave Softwaren tarjoama yksinkertaistettu sivu. Valitse Lataa alkuperäinen, jos haluat ladata alkuperäisen sivun.</translation>
+<translation id="4961107849584082341">Käännä sivu mille tahansa kielelle</translation>
+<translation id="569536719314091526">Käännä sivu mille tahansa kielelle Lisävalinnat-painikkeella</translation>
+<translation id="1397811292916898096">Hae nimellä <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Muuta oletuslataussijaintia milloin tahansa</translation>
+<translation id="6942665639005891494">Muuta oletuslataussijaintia milloin tahansa Asetukset-valikon kautta</translation>
+<translation id="6850409657436465440">Latauksesi on vielä kesken.</translation>
+<translation id="5817715962196959877">Brave lataa tiedostot nyt nopeammin</translation>
+<translation id="3976396876660209797">Poista tämä pikakuvake ja luo se uudelleen.</translation>
+<translation id="6766622839693428701">Sulje pyyhkäisemällä alas.</translation>
+<translation id="1028699632127661925">Lähetetään: <ph name="DEVICE_NAME"/></translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Lähetetty laitteelta <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Välilehti vastaanotettu</translation>
 <translation id="9104217018994036254">Välilehden jakamisen laiteluettelo.</translation>
-<translation id="9133397713400217035">Tutki offline-tilassa</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Näytä alkuperäinen</translation>
-<translation id="9139068048179869749">Pyydä lupaa, kun sivustot yrittävät lähettää ilmoituksia (suositus).</translation>
-<translation id="9139318394846604261">Ostokset</translation>
-<translation id="9155898266292537608">Voit hakea myös napauttamalla sanaa nopeasti.</translation>
-<translation id="9169507124922466868">Navigointihistoria on puoliksi auki</translation>
-<translation id="9204836675896933765">1 tiedosto jäljellä</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Välilehden jakamisen laiteluettelo avataan puolen näytön korkeudella.</translation>
+<translation id="2904414404539560095">Välilehden jakamisen laiteluettelo avataan koko näytön korkeudella.</translation>
+<translation id="4135200667068010335">Välilehden jakamisen laiteluettelo on suljettu.</translation>
+<translation id="5292796745632149097">Lähetä:</translation>
+<translation id="1386674309198842382">Aktiivinen <ph name="LAST_UPDATED"/> päivää sitten</translation>
+<translation id="7971136598759319605">Aktiivinen 1 päivä sitten</translation>
+<translation id="1521774566618522728">Aktiivinen tänään</translation>
+<translation id="3631987586758005671">Jaetaan: <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Ota synkronointi käyttöön, niin voit jakaa sisältöä laitteiden välillä</translation>
+<translation id="6162454065885854378">Jos haluat jakaa jotakin puhelimelta toiselle laitteelle, ota synkronointi käyttöön molempien laitteiden Brave-asetuksista</translation>
+<translation id="6084271560289605378">Siirry Brave-asetuksiin</translation>
+<translation id="2318045970523081853">Soita napauttamalla</translation>
 <translation id="9209888181064652401">Puheluiden soittaminen ei onnistu</translation>
-<translation id="9219103736887031265">Kuvat</translation>
-<translation id="926205370408745186">Poista Chrome-toimintasi Digitaalisesta hyvinvoinnista</translation>
-<translation id="932327136139879170">Etusivu</translation>
-<translation id="938850635132480979">(Virhe: <ph name="ERROR_CODE" />)</translation>
-<translation id="945632385593298557">Mikrofonin käyttöoikeus</translation>
-<translation id="95817756606698420">Chrome voi käyttää <ph name="BEGIN_BOLD" />Sogouta<ph name="END_BOLD" /> hakujen tekemiseen Kiinassa. Voit muokata tätä <ph name="BEGIN_LINK" />Asetuksissa<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Estä, jos sivusto näyttää häiritseviä tai harhaanjohtavia mainoksia (suositus)</translation>
-<translation id="968900484120156207">Avaamasi sivut näkyvät tässä</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minuuttia jäljellä</translation>
-<translation id="974555521953189084">Aloita synkronointi antamalla tunnuslauseesi.</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Kaikkien sivustojen tiedot poistetaan, esimerkiksi:</translation>
-<translation id="983192555821071799">Sulje kaikki välilehdet</translation>
-<translation id="987264212798334818">Yleistä</translation>
+<translation id="2860954141821109167">Varmista, että puhelinsovellus on käytössä tällä laitteella</translation>
+<translation id="2067805253194386918">tekstiviesti</translation>
+<translation id="1450753235335490080">Jakaminen ei onnistu: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Jakaminen epäonnistui: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Varmista, että <ph name="TARGET_DEVICE_NAME"/> käyttää synkronointia Bravessa</translation>
+<translation id="3016635187733453316">Varmista, että laite on yhteydessä internetiin</translation>
+<translation id="8466613982764129868">Varmista, että <ph name="TARGET_DEVICE_NAME"/> on yhteydessä internetiin</translation>
+<translation id="6539092367496845964">Jotain meni vikaan. Yritä myöhemmin uudelleen.</translation>
+<translation id="3389286852084373014">Teksti on liian suuri</translation>
+<translation id="2100314319871056947">Kokeile jakaa teksti pienempinä pätkinä</translation>
+<translation id="2987620471460279764">Toiselta laitteelta jaettu teksti</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> jakoi tekstin</translation>
+<translation id="5193988420012215838">Kopioitu leikepöydälle</translation>
+<translation id="4696983787092045100">Lähetä teksti laitteillesi</translation>
+<translation id="1260236875608242557">Hae ja tutki</translation>
+<translation id="6369229450655021117">Tässä voit tehdä verkkohakuja, jakaa sisältöä kavereiden kanssa ja nähdä avoimet sivut</translation>
+<translation id="723171743924126238">Valitse kuvat</translation>
+<translation id="8751914237388039244">Valitse kuva</translation>
+<translation id="1989112275319619282">Selaa</translation>
+<translation id="7055152154916055070">Uudelleenohjaus estetty:</translation>
+<translation id="5524843473235508879">Uudelleenohjaus estetty</translation>
+<translation id="6573096386450695060">Salli aina</translation>
+<translation id="5805364706385912897">Tämä sivu käyttää liikaa muistia, joten Brave keskeytti sen.</translation>
+<translation id="5138664332909611586">Tämä sivu käyttää liikaa muistia, joten Brave poisti osan sisällöstä.</translation>
+<translation id="9137013805542155359">Näytä alkuperäinen</translation>
+<translation id="6361779936989026201">Braven Brave Software Assistant</translation>
+<translation id="7291387454912369099">Assistantin käynnistämä maksaminen</translation>
+<translation id="4565206163201411670">Näytetäänkö Brave-toimintasi Digitaalisessa hyvinvoinnissa?</translation>
+<translation id="9055113864158719823">Voit nähdä Bravessa käyttämäsi sivustot ja asettaa niille ajastimia.\n\nBrave Software saa tietoa sivustoista, joille asetat ajastimia, ja sivustojen käytön kestosta. Tietoja käytetään Digitaalisen hyvinvoinnin parantamiseen.</translation>
+<translation id="4596514158372210596">Poista Brave-toimintasi Digitaalisesta hyvinvoinnista</translation>
+<translation id="1174893863889683998">Poistetaanko Brave-toimintasi Digitaalisesta hyvinvoinnista?</translation>
+<translation id="708829030563435351">Bravessa käyttämäsi sivustot eivät näy. Kaikki sivuston ajastimet poistetaan.</translation>
+<translation id="2056878612599315956">Sivusto keskeytetty</translation>
+<translation id="671481426037969117">Ajastimesta (<ph name="FQDN"/>) loppui aika. Se alkaa alusta huomenna.</translation>
+<translation id="7479104141328977413">Välilehtien ylläpito</translation>
+<translation id="3524138585025253783">Kehittäjän UI</translation>
+<translation id="6036057147555329831">Ylimääräinen ICU</translation>
+<translation id="9029323097866369874">Saako <ph name="DOMAIN"/> siirtyä VR-tilaan?</translation>
+<translation id="7685301384041462804">Varmista, että sivusto on luotettava, ennen kuin siirryt VR-tilaan.</translation>
+<translation id="5033865233969348410">Kun olet VR-tilassa, sivusto voi saada tietää
+  –  fyysisiä piirteitäsi, kuten pituutesi.
+
+Varmista, että sivusto on luotettava, ennen kuin siirryt VR-tilaan.</translation>
+<translation id="5534334044554683961">Kun olet VR-tilassa, sivusto voi saada tietää
+  –  fyysisiä piirteitäsi, kuten pituutesi
+  –  huoneesi asettelun.
+
+Varmista, että sivusto on luotettava, ennen kuin siirryt VR-tilaan.</translation>
+<translation id="4169535189173047238">Älä salli</translation>
+<translation id="2170088579611075216">Salli ja aloita VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_fil.xtb
+++ b/android/java/strings/translations/android_chrome_strings_fil.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="fil">
-<translation id="1006017844123154345">Buksan Online</translation>
-<translation id="1028699632127661925">Ipinapadala sa <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Idinaragdag ang <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Mula sa mga website</translation>
-<translation id="1049743911850919806">Incognito</translation>
-<translation id="10614374240317010">Hindi kailanman nag-save</translation>
-<translation id="1067922213147265141">Iba pang serbisyo ng Google</translation>
-<translation id="1068672505746868501">Huwag kailanman isalin ang mga page sa <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Kung babaguhin mo ang file extension, puwedeng bumukas ang file sa ibang application at posible itong maging mapanganib sa iyong device.</translation>
-<translation id="1100066534610197918">Buksan sa bagong tab sa grupo</translation>
-<translation id="1105960400813249514">Screen Capture</translation>
-<translation id="1111673857033749125">Dito lalabas ang mga naka-save na bookmark sa iba mo pang mga device.</translation>
-<translation id="1113597929977215864">Ipakita ang pinasimpleng view</translation>
-<translation id="1121094540300013208">Mga ulat sa paggamit at pag-crash</translation>
-<translation id="1124772482545689468">User</translation>
-<translation id="1129510026454351943">Mga Detalye: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Nakabinbin ang 1 pag-download.}one{Nakabinbin ang # pag-download.}other{Nakabinbin ang # na pag-download.}}</translation>
-<translation id="1145536944570833626">I-delete ang kasalukuyang data.</translation>
-<translation id="1146678959555564648">Pumasok sa VR</translation>
-<translation id="116280672541001035">Nagamit</translation>
-<translation id="1171770572613082465">Tingnan ang mga sikat na website sa pamamagitan ng pag-tap sa button na "Mga nangungunang site"</translation>
-<translation id="1173894706177603556">Pangalanang muli</translation>
-<translation id="1178581264944972037">I-pause</translation>
-<translation id="1181037720776840403">Alisin</translation>
-<translation id="1188239144602654184">Pumasok sa AR</translation>
-<translation id="1197267115302279827">Ilipat ang mga bookmark</translation>
-<translation id="119944043368869598">I-clear lahat</translation>
-<translation id="1201402288615127009">Susunod</translation>
-<translation id="1204037785786432551">Link sa pag-download</translation>
-<translation id="1206892813135768548">Kopyahin ang text ng link</translation>
-<translation id="1208340532756947324">Para mag-sync at mag-personalize sa mga device, i-on ang pag-sync</translation>
-<translation id="1209206284964581585">Itago sa ngayon</translation>
-<translation id="1227058898775614466">History ng pag-navigate</translation>
-<translation id="1231733316453485619">I-on ang pag-sync?</translation>
-<translation id="123724288017357924">I-reload ang page, balewalain ang cached content</translation>
-<translation id="124116460088058876">Higit pang wika</translation>
-<translation id="124678866338384709">Isara ang kasalukuyang tab</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Maghanap at mag-explore</translation>
-<translation id="1264974993859112054">Pampalakasan</translation>
-<translation id="1266864766717917324">Hindi maibahagi ang <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Stop</translation>
-<translation id="1283039547216852943">I-tap upang palawakin</translation>
-<translation id="1285320974508926690">Huwag isalin kailanman ang site na ito</translation>
-<translation id="1291207594882862231">I-clear ang history, cookies, site data, cache…</translation>
-<translation id="129382876167171263">Lalabas dito ang mga file na na-save ng mga website</translation>
-<translation id="129553762522093515">Kamakailang isinara</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Ipinadala mula sa <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Igrupo ang mga tab</translation>
-<translation id="1327257854815634930">Nakabukas ang history ng pag-navigate</translation>
-<translation id="1331212799747679585">Hindi ma-update ang Chrome. Higit pang opsyon</translation>
-<translation id="1332501820983677155">Mga shortcut ng feature ng Google Chrome</translation>
-<translation id="1360432990279830238">Mag-sign out at i-off ang pag-sync?</translation>
-<translation id="1369915414381695676">Nadagdag na ang site ng <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Hindi sapat ang memory upang ma-download ang napiling content.</translation>
-<translation id="1376578503827013741">Kino-compute…</translation>
-<translation id="1383876407941801731">Hanapin</translation>
-<translation id="1384959399684842514">Na-pause ang pag-download</translation>
-<translation id="1386674309198842382">Aktibo <ph name="LAST_UPDATED" /> (na) araw ang nakalipas</translation>
-<translation id="1397811292916898096">Maghanap gamit ang <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Naka-embed sa <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“Huwag Subaybayan”</translation>
-<translation id="1407135791313364759">Buksan lahat</translation>
-<translation id="1409426117486808224">Pinasimpleng view para sa mga bukas na tab</translation>
-<translation id="1409879593029778104">Pinigilan ang pag-download sa <ph name="FILE_NAME" /> dahil may ganitong file na sa kasalukuyan.</translation>
-<translation id="1414981605391750300">Nakikipag-ugnayan sa Google. Maaari itong umabot nang isang minuto…</translation>
-<translation id="1416550906796893042">Bersyon ng application</translation>
-<translation id="1430915738399379752">I-print</translation>
-<translation id="1446450296470737166">Payagan ganap na kontrol sa MIDI device</translation>
-<translation id="1450753235335490080">Hindi maibahagi ang <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Naka-off sa Mga Setting ng Android</translation>
-<translation id="1477626028522505441">Hindi na-download ang <ph name="FILE_NAME" /> dahil sa mga isyu sa server.</translation>
-<translation id="1506061864768559482">Search engine</translation>
-<translation id="1513352483775369820">Bookmark at history ng web</translation>
-<translation id="1513858653616922153">I-delete ang password</translation>
-<translation id="1516229014686355813">Ipinapadala sa Google Search ng I-tap para Maghanap ang napiling salita at ang kasalukuyang page bilang konteksto. Maaari mo itong i-off sa <ph name="BEGIN_LINK" />Mga Setting<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktibo ngayong araw</translation>
-<translation id="1544826120773021464">Para pamahalaan ang iyong Google account, i-tap ang button na "Pamahalaan ang account"</translation>
-<translation id="1549000191223877751">Lumipat sa ibang window</translation>
-<translation id="1553358976309200471">I-update ang Chrome</translation>
-<translation id="1569387923882100876">Nakakonektang Device</translation>
-<translation id="1571304935088121812">Kopyahin ang username</translation>
-<translation id="1612196535745283361">Kailangan ng Chrome ng access sa lokasyon upang magkapag-scan ng mga device. Ang access sa lokasyon ay <ph name="BEGIN_LINK" />naka-off para sa device na ito<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Camera</translation>
-<translation id="1623104350909869708">Pigilan ang pahinang ito sa paggawa ng mga karagdagang dialog</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Alisin ang 1 piniling item}one{Alisin ang # piniling item}other{Alisin ang # na piniling item}}</translation>
-<translation id="164269334534774161">Tinitingnan mo ang offline na kopya ng page na ito mula sa <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">History</translation>
-<translation id="1647391597548383849">I-access ang iyong camera</translation>
-<translation id="1660204651932907780">Payagan ang mga site na mag-play ng tunog (inirerekomenda)</translation>
-<translation id="1670399744444387456">Pangunahin</translation>
-<translation id="1671236975893690980">Nakabinbin ang pag-download...</translation>
-<translation id="1672586136351118594">Huwag ipakitang muli</translation>
-<translation id="1692118695553449118">Naka-on ang pag-sync</translation>
-<translation id="169515064810179024">I-block ang mga site sa pag-access sa mga sensor ng paggalaw</translation>
-<translation id="1717218214683051432">Mga sensor ng paggalaw</translation>
-<translation id="1718835860248848330">Huling oras</translation>
-<translation id="1736419249208073774">I-explore</translation>
-<translation id="1743802530341753419">Magtanong bago payagan ang mga site na kumonekta sa isang device (inirerekomenda)</translation>
-<translation id="1749561566933687563">I-sync ang iyong mga bookmark</translation>
-<translation id="17513872634828108">Mga bukas na tab</translation>
-<translation id="1779089405699405702">Pang-decode ng larawan</translation>
-<translation id="1782483593938241562">Petsa ng pagtatapos <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Na-install</translation>
-<translation id="1792959175193046959">Baguhin ang default na lokasyon ng pag-download anumang oras</translation>
-<translation id="1807246157184219062">Maliwanag</translation>
-<translation id="1810845389119482123">Hindi natapos ang paunang pag-set up ng pag-sync</translation>
-<translation id="1821253160463689938">Gumamit ng mga cookie para matandaan ang iyong mga kagustuhan, kahit na hindi mo binibisita ang mga page na iyon</translation>
-<translation id="1829244130665387512">Hanapin sa page</translation>
-<translation id="1853692000353488670">Bagong tab na incognito</translation>
-<translation id="1856325424225101786">I-reset ang Lite mode?</translation>
-<translation id="1868024384445905608">Mas mabilis nang mag-download ng mga file ang Chrome</translation>
-<translation id="1883903952484604915">Aking Mga File</translation>
-<translation id="1887786770086287077">Naka-off ang access sa lokasyon para sa device na ito. I-on ito sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Bubukas ang <ph name="APP_NAME" /> sa Chrome. Sa pamamagitan ng pagpapatuloy, sumasang-ayon ka sa <ph name="BEGIN_LINK1" />Mga Tuntunin ng Serbisyo<ph name="END_LINK1" /> at <ph name="BEGIN_LINK2" />Notification ng Privacy<ph name="END_LINK2" /> ng Chrome.</translation>
-<translation id="1919345977826869612">Mga Ad</translation>
-<translation id="1919950603503897840">Pumili ng mga contact</translation>
-<translation id="1922076542920281912">Para payagan ang Chrome na i-access ang iyong lokasyon, i-on din ang lokasyon sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Mga Update</translation>
-<translation id="19288952978244135">Muling buksan ang Chrome.</translation>
-<translation id="1933845786846280168">Napiling Tab</translation>
-<translation id="194341124344773587">I-on ang pahintulot para sa Chrome sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">I-save ang mga password</translation>
-<translation id="1952172573699511566">Magpapakita ang mga website ng text sa iyong gustong wika, kung posible.</translation>
-<translation id="1960290143419248813">Hindi na sinusuportahan ang mga update sa Chrome para sa bersyong ito ng Android.</translation>
-<translation id="1966710179511230534">Paki-update ang iyong mga detalye sa pag-sign in.</translation>
-<translation id="1974060860693918893">Advanced</translation>
-<translation id="1984705450038014246">I-sync ang iyong data ng Chrome</translation>
-<translation id="1984937141057606926">Pinapayagan, maliban ang third-party</translation>
-<translation id="1986685561493779662">May ganito nang pangalan</translation>
-<translation id="1987739130650180037">Button ng <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Mag-browse</translation>
-<translation id="1993768208584545658">Gustong makipagpares ng <ph name="SITE" /></translation>
-<translation id="1994173015038366702">URL ng site</translation>
-<translation id="2000419248597011803">Nagpapadala ng ilang cookies at paghahanap mula sa address bar at box para sa paghahanap sa iyong default na search engine</translation>
-<translation id="2002537628803770967">Mga credit card at address na gumagamit ng Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# File}one{# File}other{# na File}}</translation>
-<translation id="2017836877785168846">Kini-clear ang history at mga awtomatikong pagkumpleto sa address bar.</translation>
-<translation id="2021896219286479412">Control ng full screen sa site</translation>
-<translation id="2038563949887743358">I-on ang Hilingin ang site sa desktop</translation>
-<translation id="2041019821020695769">Para payagan ang Chrome na magpadala sa iyo ng mga notification, i-on din ang mga notification sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">May data rin ang <ph name="APP_NAME" /> sa Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Naka-pause ang site</translation>
-<translation id="2063713494490388661">Mag-tap upang Maghanap</translation>
-<translation id="2067805253194386918">text</translation>
-<translation id="2079545284768500474">I-undo</translation>
-<translation id="2082238445998314030">Resulta <ph name="RESULT_NUMBER" /> sa <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Tunog</translation>
-<translation id="2096012225669085171">Mag-sync at mag-personalize sa lahat ng device</translation>
-<translation id="2100273922101894616">Awtomatikong Mag-sign in</translation>
-<translation id="2100314319871056947">Subukang ibahagi ang text sa mas maliliit na bahagi</translation>
-<translation id="2107397443965016585">Magtanong bago pahintulutan ang mga site na mag-play ng pinoprotektahang content (inirerekomenda)</translation>
-<translation id="2111511281910874386">Pumunta sa page</translation>
-<translation id="2122601567107267586">Hindi mabuksan ang app</translation>
-<translation id="2126426811489709554">Pinapagana ng Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> ang natipid</translation>
-<translation id="213279576345780926">Isinarang <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Idagdag sa Home screen</translation>
-<translation id="2146738493024040262">Buksan ang Instant App</translation>
-<translation id="2148716181193084225">Ngayon</translation>
-<translation id="2154484045852737596">I-edit ang card</translation>
-<translation id="2154710561487035718">Kopyahin ang URL</translation>
-<translation id="2156074688469523661">Mga natitirang site (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Para magbahagi ng isang bagay sa isa pang device mula sa iyong telepono, i-on ang pag-sync sa mga setting ng Chrome sa dalawang device</translation>
-<translation id="2170088579611075216">Payagan at pumasok sa VR</translation>
-<translation id="218608176142494674">Pagbabahagi</translation>
-<translation id="2227444325776770048">Magpatuloy bilang si <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sync at mga serbisyo ng Google</translation>
-<translation id="2259659629660284697">I-export ang mga password…</translation>
-<translation id="2268044343513325586">Pinuhin</translation>
-<translation id="2286841657746966508">Billing address</translation>
-<translation id="2289270750774289114">Magtanong kapag gusto ng isang site na tumuklas ng mga Bluetooth device na nasa malapit (inirerekomenda)</translation>
-<translation id="230115972905494466">Walang nahanap na tugmang device</translation>
-<translation id="2315043854645842844">Hindi sinusuportahan ng operating system ang pagpipilian ng certificate sa panig ng kliyente.</translation>
-<translation id="2318045970523081853">I-tap para tumawag</translation>
-<translation id="2321086116217818302">Inihahanda ang mga password…</translation>
-<translation id="2321958826496381788">I-drag ang slider hanggang sa mabasa mo ito nang kumportable. Dapat ay halos ganito kalaki ang text pagkatapos mag-double tap sa isang talata.</translation>
-<translation id="2323763861024343754">Storage ng site</translation>
-<translation id="2328985652426384049">Hindi makapag-sign in</translation>
-<translation id="2330129964253841015">Balaan ka kung makokompromiso ang mga password</translation>
-<translation id="2349710944427398404">Kabuuang data na ginagamit ng Chrome, kabilang ang mga account, bookmark at naka-save na setting</translation>
-<translation id="2353636109065292463">Sinusuri ang iyong koneksyon sa internet</translation>
-<translation id="2359808026110333948">Magpatuloy</translation>
-<translation id="2369533728426058518">magbukas ng mga tab</translation>
-<translation id="2387895666653383613">Pag-scale ng text</translation>
-<translation id="2394602618534698961">Lalabas dito ang mga file na dina-download mo</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Kapag nag-sign in ka sa iyong Google Account, mao-on ang feature na ito</translation>
-<translation id="2410754283952462441">Pumili ng account</translation>
-<translation id="2414886740292270097">Madilim</translation>
-<translation id="2416359993254398973">Kailangan ng Chrome ng pahintulot na i-access ang iyong camera para sa site na ito.</translation>
-<translation id="2426805022920575512">Pumili ng ibang account</translation>
-<translation id="2433507940547922241">Hitsura</translation>
-<translation id="2434158240863470628">Tapos nang mag-download <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Access sa lokasyon</translation>
-<translation id="2450083983707403292">Gusto mo bang simulang muli ang pag-download sa <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Mga Abiso</translation>
-<translation id="2490684707762498678">Pinapamahalaan ng <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Assistant sa Chrome</translation>
-<translation id="2496180316473517155">History ng Pag-browse</translation>
-<translation id="2497852260688568942">Na-disable ng iyong administrator ang pag-sync</translation>
-<translation id="2498359688066513246">Tulong at feedback</translation>
-<translation id="2501278716633472235">Bumalik</translation>
-<translation id="2513403576141822879">Para sa higit pang setting na nauugnay sa privacy, seguridad, at pangongolekta ng data, tingnan ang <ph name="BEGIN_LINK" />Pag-sync at mga serbisyo ng Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Sa Lite mode, mas mabilis na naglo-load ng mga page ang Chrome at gumagamit ito ng hanggang 60 porsyentong mas kaunting data. Para i-optimize ang mga page na binibisita mo, ipinapadala ng Chrome ang iyong trapiko sa web sa Google. <ph name="BEGIN_LINK" />Matuto pa<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Ipinapadala sa Google ang mga URL ng mga page na binibisita mo</translation>
-<translation id="2532336938189706096">View ng Web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> (na) item ang na-delete</translation>
-<translation id="2536728043171574184">Tinitingnan ang isang offline na kopya ng page na ito</translation>
-<translation id="2546283357679194313">Cookies at data ng site</translation>
-<translation id="2567385386134582609">LARAWAN</translation>
-<translation id="257088987046510401">Mga tema</translation>
-<translation id="2570922361219980984">Naka-off din ang access sa lokasyon para sa device na ito. I-on ito sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Pinalawak - i-click upang i-collapse.</translation>
-<translation id="2581165646603367611">Iki-clear nito ang cookies, cache at iba pang data ng mga site na sa tingin ng Chrome ay hindi mahalaga.</translation>
-<translation id="2586657967955657006">Clipboard</translation>
-<translation id="2587052924345400782">May available na mas bagong bersyon</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Numero ng card</translation>
-<translation id="2621115761605608342">Payagan ang JavaScript para sa isang partikular na site.</translation>
-<translation id="2625189173221582860">Nakopya ang password</translation>
-<translation id="2631006050119455616">Na-save</translation>
-<translation id="2647434099613338025">Magdagdag ng wika</translation>
-<translation id="2650751991977523696">I-download ulit ang file?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Audio file}one{# Audio file}other{# na Audio file}}</translation>
-<translation id="2653659639078652383">Isumite</translation>
-<translation id="2677748264148917807">Umalis</translation>
-<translation id="2704606927547763573">Kinopya</translation>
-<translation id="2707726405694321444">I-refresh ang page</translation>
-<translation id="2709516037105925701">AutoFill</translation>
-<translation id="2717722538473713889">Mga email address</translation>
-<translation id="2728754400939377704">Pagbukud-bukurin ayon sa site</translation>
-<translation id="2744248271121720757">Mag-tap ng salita upang hanapin agad ito o tingnan ang mga nauugnay na pagkilos</translation>
-<translation id="2760989362628427051">I-on ang madilim na tema kapag naka-on ang madilim na tema o Pangtipid sa Baterya ng iyong device</translation>
-<translation id="2762000892062317888">ngayon lang</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> (na) segundo na lang ang natitira</translation>
-<translation id="2779651927720337254">nabigo</translation>
-<translation id="2781151931089541271">1 segundo na lang ang natitira</translation>
-<translation id="2801022321632964776">I-update para makuha ang iyong wika sa pinakabagong bersyon ng Chrome</translation>
-<translation id="2810645512293415242">Pinasimple ang page upang ma-save ang data at mag-load nang mas mabilis.</translation>
-<translation id="281504910091592009">Tingnan at pamahalaan ang mga naka-save na password sa iyong <ph name="BEGIN_LINK" />Google Account<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Para makuha ang iyong mga bookmark sa lahat ng device mo, mag-sign in at i-on ang pag-sync</translation>
-<translation id="2822354292072154809">Sigurado ka bang gusto mong i-reset ang lahat ng pahintulot sa site para sa <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Pindutin ang button na bumalik upang lumabas sa full screen.</translation>
-<translation id="2842985007712546952">Pangunahing folder</translation>
-<translation id="2858138569776157458">Top na sites</translation>
-<translation id="2860954141821109167">Tiyaking may naka-enable na phone app sa device na ito</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Nakaraang track</translation>
-<translation id="2876369937070532032">Ipadala ang mga URL ng ilang page na binibisita mo sa Google kapag nanganganib ang iyong seguridad</translation>
-<translation id="2888126860611144412">Tungkol sa Chrome</translation>
-<translation id="2891154217021530873">Ihinto ang pag-load ng page</translation>
-<translation id="2893180576842394309">Maaaring gamitin ng Google ang iyong history para i-personalize ang Search at iba pang serbisyo ng Google</translation>
-<translation id="2898264748040935573">I-edit ang naka-store na password</translation>
-<translation id="2900528713135656174">Gumawa ng event</translation>
-<translation id="290376772003165898">Hindi nakasalin ang page sa <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Nakabukas ang listahan ng mga device kung saan magbabahagi ng tab nang buo ang taas.</translation>
-<translation id="2910701580606108292">Magtanong bago payagan ang mga site na mag-play ng pinoprotektahang content</translation>
-<translation id="2913331724188855103">Payagan ang mga site na mag-save at magbasa ng data ng cookie (inirerekomenda)</translation>
-<translation id="2923908459366352541">Di-wasto ang pangalan</translation>
-<translation id="2932150158123903946">Storage ng <ph name="APP_NAME" /> sa Google</translation>
-<translation id="2942036813789421260">Nakasara ang tab na preview</translation>
-<translation id="2956410042958133412">Pinapamahalaan ang account na ito ng <ph name="PARENT_NAME_1" /> at <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Lumipat sa mga tab na incognito</translation>
-<translation id="2968755619301702150">Viewer ng certificate</translation>
-<translation id="2979025552038692506">Napiling Tab na Incognito</translation>
-<translation id="2987620471460279764">Ibinahaging text mula sa ibang device</translation>
-<translation id="2989523299700148168">Mga kamakailang binisita</translation>
-<translation id="2996291259634659425">Gumawa ng passphrase</translation>
-<translation id="2996809686854298943">Kinakailangan ang URL</translation>
-<translation id="300526633675317032">Iki-clear nito ang lahat ng <ph name="SIZE_IN_KB" /> ng storage ng website.</translation>
-<translation id="3016635187733453316">Siguraduhing nakakonekta ang device sa internet</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB ang na-download</translation>
-<translation id="3029704984691124060">Hindi nagtutugma ang mga passphrase</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Humingi ng tulong<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Naka-off ang lokasyon; i-on ito sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Maaari mong i-on ang pag-sync anumang oras sa mga setting.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> bookmark}one{<ph name="BOOKMARKS_COUNT_MANY" /> bookmark}other{<ph name="BOOKMARKS_COUNT_MANY" /> na bookmark}}</translation>
-<translation id="3089395242580810162">Buksan sa tab na incognito</translation>
-<translation id="3115898365077584848">Ipakita ang Impormasyon</translation>
-<translation id="3123473560110926937">Naka-block sa ilang site</translation>
-<translation id="3137521801621304719">Umalis sa mode na incognito</translation>
-<translation id="3143515551205905069">Kanselahin ang pag-sync</translation>
-<translation id="3157842584138209013">Tingnan kung gaano karaming data ang iyong natipid sa button ng Higit Pang Opsyon</translation>
-<translation id="3166827708714933426">Mga shortcut ng tab at window</translation>
-<translation id="3181954750937456830">Ligtas na Pag-browse (pinoprotektahan ka at ang iyong device mula sa mga mapanganib na site)</translation>
-<translation id="3190152372525844641">I-on ang mga pahintulot para sa Chrome sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> ang naka-store na data</translation>
-<translation id="3205824638308738187">Halos tapos na!</translation>
-<translation id="3207960819495026254">Naka-bookmark</translation>
-<translation id="3211426585530211793">Na-delete ang <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Kung nakalimutan mo ang iyong passphrase o gusto mong baguhin ang setting na ito, <ph name="BEGIN_LINK" />i-reset ang pag-sync<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikropono</translation>
-<translation id="3232754137068452469">Web App</translation>
-<translation id="3236059992281584593">1 minuto na lang ang natitira</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">I-bookmark ang page na ito</translation>
-<translation id="3259831549858767975">Paliitin ang lahat ng nasa page</translation>
-<translation id="3269093882174072735">I-load ang larawan</translation>
-<translation id="3269956123044984603">Upang makuha ang iyong mga tab mula sa iba mo pang mga device, i-on ang "I-auto sync ang data" sa mga setting ng Android account.</translation>
-<translation id="3277252321222022663">Payagan ang mga site na i-access ang mga sensor (inirerekomenda)</translation>
-<translation id="3282568296779691940">Mag-sign in sa Chrome</translation>
-<translation id="3288003805934695103">I-reload ang page</translation>
-<translation id="32895400574683172">Pinapayagan ang mga notification</translation>
-<translation id="3295530008794733555">Mag-browse nang mas mabilis. Gumamit ng mas kaunting data.</translation>
-<translation id="3295602654194328831">Itago ang Impormasyon</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Magpatuloy na i-download ang content?</translation>
-<translation id="3306398118552023113">Gumagana ang app na ito sa Chrome</translation>
-<translation id="3315103659806849044">Kasalukuyan mong kino-customize ang iyong mga setting ng Pag-sync at serbisyo ng Google. Para tapusin ang pag-on ng pag-sync, i-tap ang button na Kumpirmahin malapit sa ibaba ng screen. Mag-navigate pataas</translation>
-<translation id="3328801116991980348">Impormasyon ng site</translation>
-<translation id="3333961966071413176">Lahat ng contact</translation>
-<translation id="3334729583274622784">Baguhin ang file extension?</translation>
-<translation id="3341058695485821946">Tingnan kung gaano karaming data ang iyong natipid</translation>
-<translation id="3350687908700087792">Isara ang lahat ng incognito na tab</translation>
-<translation id="3353615205017136254">Hatid ng Google ang lite na page. I-tap ang button na “i-load ang orihinal” para i-load ang orihinal na page.</translation>
-<translation id="3367813778245106622">Mag-sign in muli upang simulan ang pag-sync</translation>
-<translation id="3374023511497244703">Hindi na isi-sync ang iyong mga bookmark, history, mga password, at iba pang data ng Chrome sa Google Account mo</translation>
-<translation id="3384347053049321195">Magbahagi ng larawan</translation>
-<translation id="3386292677130313581">Magtanong bago payagan ang mga site na malaman ang iyong lokasyon (inirerekomenda)</translation>
-<translation id="3387650086002190359">Hindi na-download ang <ph name="FILE_NAME" /> dahil sa mga error sa file system.</translation>
-<translation id="3389286852084373014">Masyadong malaki ang text</translation>
-<translation id="3398320232533725830">Buksan ang bookmarks manager</translation>
-<translation id="3414952576877147120">Laki:</translation>
-<translation id="3443221991560634068">I-reload ang kasalukuyang page</translation>
-<translation id="3445014427084483498">Ngayon Lang</translation>
-<translation id="3478363558367712427">Puwede mong piliin ang iyong search engine</translation>
+<translation id="6910211073230771657">Na-delete</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, nakuha ko</translation>
+<translation id="7658239707568436148">Kanselahin</translation>
 <translation id="3479552764303398839">Hindi ngayon</translation>
-<translation id="3492207499832628349">Bagong tab na incognito</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Matuto pa<ph name="END_LINK" /> tungkol sa iminumungkahing content</translation>
-<translation id="3513704683820682405">Augmented Reality</translation>
-<translation id="3518985090088779359">Tanggapin, magpatuloy</translation>
-<translation id="3522247891732774234">May available na update. Higit pang mga opsyon</translation>
-<translation id="3524138585025253783">Developer UI</translation>
-<translation id="3527085408025491307">Folder</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB ang available</translation>
-<translation id="3549657413697417275">Hanapin sa iyong history</translation>
-<translation id="3557336313807607643">Idagdag sa mga contact</translation>
-<translation id="3566923219790363270">Naghahanda pa rin ang Chrome para sa VR. I-restart ang Chrome sa ibang pagkakataon.</translation>
-<translation id="3568688522516854065">Para makuha ang iyong mga tab sa iba mo pang device, mag-sign in at i-on ang pag-sync</translation>
-<translation id="3587482841069643663">Lahat</translation>
-<translation id="358794129225322306">Payagan ang isang site na awtomatikong mag-download ng maraming file.</translation>
-<translation id="3590487821116122040">Storage ng site na sa tingin ng Chrome ay hindi mahalaga (hal. mga site na walang mga naka-save na setting o hindi mo madalas bisitahin)</translation>
-<translation id="3599863153486145794">Kini-clear ang history sa lahat ng naka-sign in na device. Maaaring may iba pang anyo ng history ng pag-browse ang iyong Google Account sa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">I-mute ang mga site na nagpe-play ng tunog</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Ibinabahagi sa <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">I-unmask ang password</translation>
-<translation id="363596933471559332">Awtomatikong mag-sign in sa mga website gamit ang mga naka-store na kredensyal. Kapag naka-off ang feature, hihilingin sa iyong mag-verify sa tuwing magsa-sign in ka sa isang website.</translation>
-<translation id="3658159451045945436">Kapag na-reset, mabubura ang iyong history ng pagtitipid ng data, kabilang ang listahan ng mga binisitang site.</translation>
-<translation id="3692944402865947621">Hindi na-download ang <ph name="FILE_NAME" /> dahil hindi maabot ang lokasyon ng storage.</translation>
-<translation id="3714981814255182093">Buksan ang Bar sa Paghahanap</translation>
-<translation id="3716182511346448902">Masyadong malaki ang ginagamit na memory ng page na ito kaya na-pause ito ng Chrome.</translation>
-<translation id="3730075448226062617">Para payagang i-access ng Chrome ang iyong mikropono, i-on din ang mikropono sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Naka-bookmark sa <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Pag-sync sa background</translation>
-<translation id="3771001275138982843">Hindi ma-download ang update</translation>
-<translation id="3771033907050503522">Mga Tab na Incognito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />I-on ang Bluetooth<ph name="END_LINK" /> upang payagan ang pagpapares</translation>
-<translation id="3775705724665058594">Ipadala sa iyong mga device</translation>
-<translation id="3778956594442850293">Idinagdag sa Home screen</translation>
-<translation id="3789841737615482174">Mag-install</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Mamahala</translation>
-<translation id="381841723434055211">Mga numero ng telepono</translation>
-<translation id="3819178904835489326">Na-delete ang <ph name="NUMBER_OF_DOWNLOADS" /> (na) pag-download</translation>
-<translation id="3822502789641063741">I-clear ang storage ng site?</translation>
-<translation id="385051799172605136">Bumalik</translation>
-<translation id="3859306556332390985">Maghanap nang pasulong</translation>
-<translation id="3894427358181296146">Magdagdag ng folder</translation>
-<translation id="3895926599014793903">Puwersahang i-enable ang zoom</translation>
-<translation id="3912508018559818924">Hinahanap ang pinakamahusay mula sa web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Pagsamahin ang aking data</translation>
-<translation id="393697183122708255">Walang available na naka-enable na paghahanap gamit ang boses</translation>
-<translation id="395206256282351086">Naka-disable ang mga suhestyon sa paghahanap at site</translation>
-<translation id="3955193568934677022">Pahintulutan ang mga site na mag-play ng pinoprotektahang content (inirerekomenda)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Ilo-load ng Chrome ang iyong page kapag handa na}one{Ilo-load ng Chrome ang iyong mga page kapag handa na}other{Ilo-load ng Chrome ang iyong mga page kapag handa na}}</translation>
-<translation id="3963007978381181125">Hindi kasama sa pag-encrypt ng passphrase ang mga paraan ng pagbabayad at address mula sa Google Pay. Ang tao lang na may alam ng iyong passphrase ang makakabasa sa naka-encrypt mong data. Hindi ipinapadala sa Google ang passphrase at hindi nito ito sino-store. Kung makalimutan mo ang iyong passphrase o gusto mong baguhin ang setting na ito, kakailanganin mong i-reset ang pag-sync. <ph name="BEGIN_LINK" />Matuto pa<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Tapos na ang pag-download</translation>
-<translation id="397583555483684758">Huminto ang pag-sync</translation>
-<translation id="3976396876660209797">Alisin at gawing muli ang shortcut na ito</translation>
-<translation id="3985215325736559418">Gusto mo bang muling i-download ang <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Kopyahin ang link</translation>
-<translation id="3988213473815854515">Pinapahintulutan ang lokasyon</translation>
-<translation id="3988466920954086464">Tingnan ang mga instant na resulta ng paghahanap sa panel na ito</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Storage ng hindi mahalaga</translation>
-<translation id="4000212216660919741">Offline Home</translation>
+<translation id="5317780077021120954">I-save</translation>
+<translation id="4570913071927164677">Mga Detalye</translation>
+<translation id="8730621377337864115">Tapos na</translation>
+<translation id="8261506727792406068">I-delete</translation>
+<translation id="1181037720776840403">Alisin</translation>
+<translation id="5939518447894949180">I-reset</translation>
 <translation id="4002066346123236978">Pamagat</translation>
-<translation id="4008040567710660924">Payagan ang cookies para sa isang partikular na site.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# oras}one{# oras}other{# na oras}}</translation>
-<translation id="4046123991198612571">Susunod na track</translation>
-<translation id="4048707525896921369">Matuto tungkol sa mga paksa sa mga website nang hindi umaalis sa page. Ipinapadala sa Google Search ng I-tap para Maghanap ang salita at ang konteksto nito, na nagbibigay ng mga kahulugan, larawan, resulta ng paghahanap, at iba pang detalye.
+<translation id="5916664084637901428">Naka-on</translation>
+<translation id="5860033963881614850">Naka-off</translation>
+<translation id="6165508094623778733">Matuto pa</translation>
+<translation id="6042308850641462728">Higit pa</translation>
+<translation id="6040143037577758943">Isara</translation>
+<translation id="780301667611848630">Hindi salamat</translation>
+<translation id="1201402288615127009">Susunod</translation>
+<translation id="2359808026110333948">Magpatuloy</translation>
+<translation id="2653659639078652383">Isumite</translation>
+<translation id="2079545284768500474">I-undo</translation>
+<translation id="7649070708921625228">Tulong</translation>
+<translation id="2148716181193084225">Ngayon</translation>
+<translation id="7781829728241885113">Kahapon</translation>
+<translation id="6945221475159498467">Pumili</translation>
+<translation id="7791543448312431591">Idagdag</translation>
+<translation id="6527303717912515753">Ibahagi</translation>
+<translation id="1383876407941801731">Hanapin</translation>
+<translation id="3115898365077584848">Ipakita ang Impormasyon</translation>
+<translation id="3295602654194328831">Itago ang Impormasyon</translation>
+<translation id="3987993985790029246">Kopyahin ang link</translation>
+<translation id="2704606927547763573">Kinopya</translation>
+<translation id="8725066075913043281">Muling subukan</translation>
+<translation id="385051799172605136">Bumalik</translation>
+<translation id="8131740175452115882">Kumpirmahin</translation>
+<translation id="5300589172476337783">Ipakita</translation>
+<translation id="1124772482545689468">User</translation>
+<translation id="8609465669617005112">Lumipat</translation>
+<translation id="6746124502594467657">Ibaba</translation>
+<translation id="8249310407154411074">Ilipat sa itaas</translation>
+<translation id="8428213095426709021">Mga Setting</translation>
+<translation id="2498359688066513246">Tulong at feedback</translation>
+<translation id="8378714024927312812">Pinapamahalaan ng iyong organisasyon</translation>
+<translation id="9019902583201351841">Pinamamahalaan ng iyong mga magulang</translation>
+<translation id="4645575059429386691">Pinamamahalaan ng iyong magulang</translation>
+<translation id="4883854917563148705">Hindi puwedeng i-reset ang mga pinapamahalaang setting</translation>
+<translation id="4307992518367153382">Mga Pangunahing Kaalaman</translation>
+<translation id="1974060860693918893">Advanced</translation>
+<translation id="1146678959555564648">Pumasok sa VR</translation>
+<translation id="987264212798334818">Pangkalahatan</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Mga Download</translation>
+<translation id="218608176142494674">Pagbabahagi</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Screen Capture</translation>
+<translation id="4875775213178255010">Mga Iminumungkahing Content</translation>
+<translation id="2021896219286479412">Control ng full screen sa site</translation>
+<translation id="4587589328781138893">Mga Site</translation>
+<translation id="4943703118917034429">Virtual Reality</translation>
+<translation id="1928696683969751773">Mga Update</translation>
+<translation id="6064125863973209585">Mga nakumpletong download</translation>
+<translation id="5342314432463739672">Mga kahilingan sa pahintulot</translation>
+<translation id="629730747756840877">Account</translation>
+<translation id="82609232232243542">Mag-sign in sa Brave</translation>
+<translation id="7956662517480676674">Sync at mga serbisyo ng Brave Software</translation>
+<translation id="5294439808117722387">Kasalukuyan mong kino-customize ang iyong mga setting ng Pag-sync at serbisyo ng Brave Software. Para tapusin ang pag-on ng pag-sync, i-tap ang button na Kumpirmahin malapit sa ibaba ng screen. Mag-navigate pataas</translation>
+<translation id="2096012225669085171">Mag-sync at mag-personalize sa lahat ng device</translation>
+<translation id="1692118695553449118">Naka-on ang pag-sync</translation>
+<translation id="5514904542973294328">Na-disable ng administrator ng device na ito</translation>
+<translation id="6447211988989208781">Mga kontrol ng aktibidad sa Brave Software</translation>
+<translation id="4882831918239250449">Kontrolin kung paano ginagamit ang iyong history ng pag-browse para i-personalize ang Paghahanap, mga ad, at iba pa</translation>
+<translation id="7431991332293347422">Kontrolin kung paano ginagamit ang iyong history ng pag-browse para i-personalize ang Paghahanap at higit pa</translation>
+<translation id="6303969859164067831">Mag-sign out at i-off ang pag-sync</translation>
+<translation id="1125261911132334651">Pamahalaan ang iyong Brave Software Account</translation>
+<translation id="6406506848690869874">Pag-sync</translation>
+<translation id="714362445477979774">I-sync ang iyong data ng Brave</translation>
+<translation id="4314815835985389558">Pamahalaan ang pag-sync</translation>
+<translation id="5428209950370661546">Iba pang serbisyo ng Brave Software</translation>
+<translation id="7704317875155739195">Awtomatikong kumpletuhin ang mga paghahanap at URL</translation>
+<translation id="2000419248597011803">Nagpapadala ng ilang cookies at paghahanap mula sa address bar at box para sa paghahanap sa iyong default na search engine</translation>
+<translation id="7981313251711023384">I-preload ang mga page para sa mas mabilis na pag-browse at paghahanap</translation>
+<translation id="1821253160463689938">Gumamit ng mga cookie para matandaan ang iyong mga kagustuhan, kahit na hindi mo binibisita ang mga page na iyon</translation>
+<translation id="6697492270171225480">Magpakita ng mga mungkahi para sa mga katulad na page kapag hindi mahanap ang isang page</translation>
+<translation id="8109318360573330108">Ipinapadala sa Brave Software ang URL ng page na sinusubukan mong puntahan</translation>
+<translation id="8438566539970814960">Mas pahusayin ang mga paghahanap at pag-browse</translation>
+<translation id="284843628681142937">Ipinapadala sa Brave Software ang mga URL ng mga page na binibisita mo</translation>
+<translation id="7222718784508482526">Para sa higit pang setting na nauugnay sa privacy, seguridad, at pangongolekta ng data, tingnan ang <ph name="BEGIN_LINK"/>Pag-sync at mga serbisyo ng Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Tumulong sa pagpapahusay sa mga feature at performance ng Brave</translation>
+<translation id="9063160602596686558">Awtomatikong nagpapadala sa Brave Software ng mga istatistika ng paggamit at ulat ng pag-crash</translation>
+<translation id="4824958205181053313">Kanselahin ang pag-sync?</translation>
+<translation id="3058498974290601450">Maaari mong i-on ang pag-sync anumang oras sa mga setting.</translation>
+<translation id="3143515551205905069">Kanselahin ang pag-sync</translation>
+<translation id="1506061864768559482">Search engine</translation>
+<translation id="55737423895878184">Pinapayagan ang lokasyon at mga notification</translation>
+<translation id="3988213473815854515">Pinapahintulutan ang lokasyon</translation>
+<translation id="32895400574683172">Pinapayagan ang mga notification</translation>
+<translation id="9040142327097499898">Pinapayagan ang mga notification. Naka-off ang lokasyon para sa device na ito.</translation>
+<translation id="305593374596241526">Naka-off ang lokasyon; i-on ito sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Mga kamakailang binisita</translation>
+<translation id="6433501201775827830">Pumili ng iyong search engine</translation>
+<translation id="7177466738963138057">Maaari mo itong baguhin sa ibang pagkakataon sa Mga Setting</translation>
+<translation id="3478363558367712427">Puwede mong piliin ang iyong search engine</translation>
+<translation id="4910889077668685004">Mga app sa pagbabayad</translation>
+<translation id="5152843274749979095">Walang naka-install na sinusuportahang app</translation>
+<translation id="8812260976093120287">Sa ilang website, maaari kang magbayad sa iyong device gamit ang mga sinusuportahang app sa pagbabayad sa itaas.</translation>
+<translation id="7764225426217299476">Magdagdag ng address</translation>
+<translation id="5595485650161345191">Mag-edit ng address</translation>
+<translation id="5087580092889165836">Magdagdag ng card</translation>
+<translation id="2154484045852737596">I-edit ang card</translation>
+<translation id="6140912465461743537">Bansa/Rehiyon</translation>
+<translation id="5659593005791499971">Email</translation>
+<translation id="4378154925671717803">Telepono</translation>
+<translation id="4807098396393229769">Pangalang makikita sa card</translation>
+<translation id="860043288473659153">Pangalan ng cardholder</translation>
+<translation id="2612676031748830579">Numero ng card</translation>
+<translation id="869891660844655955">Expiration date</translation>
+<translation id="2286841657746966508">Billing address</translation>
+<translation id="663059986967017181">Kinopya sa Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> iba pa}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> iba pa}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> na iba pa}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> iba pa}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> iba pa}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> na iba pa}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> iba pa}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> iba pa}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> na iba pa}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> iba pa}one{<ph name="CONTACT_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> iba pa}other{<ph name="CONTACT_PREVIEW"/>\u2026 at <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> na iba pa}}</translation>
+<translation id="7029809446516969842">Mga Password</translation>
+<translation id="1943432128510653496">I-save ang mga password</translation>
+<translation id="2100273922101894616">Awtomatikong Mag-sign in</translation>
+<translation id="363596933471559332">Awtomatikong mag-sign in sa mga website gamit ang mga naka-store na kredensyal. Kapag naka-off ang feature, hihilingin sa iyong mag-verify sa tuwing magsa-sign in ka sa isang website.</translation>
+<translation id="6995899638241819463">Balaan ka kung ma-expose ang mga password sa isang paglabag sa data</translation>
+<translation id="1534287762301776620">Kapag nag-sign in ka sa iyong Brave Software Account, mao-on ang feature na ito</translation>
+<translation id="10614374240317010">Hindi kailanman nag-save</translation>
+<translation id="3098842761938485917">Tingnan at pamahalaan ang mga naka-save na password sa iyong <ph name="BEGIN_LINK"/>Brave Software Account<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Lalabas dito ang mga naka-save na password.</translation>
+<translation id="8084114998886531721">Naka-save na password</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Username</translation>
+<translation id="6657585470893396449">Password</translation>
+<translation id="2154710561487035718">Kopyahin ang URL</translation>
+<translation id="1571304935088121812">Kopyahin ang username</translation>
+<translation id="5005498671520578047">Kopyahin password</translation>
+<translation id="3632295766818638029">I-unmask ang password</translation>
+<translation id="1513858653616922153">I-delete ang password</translation>
+<translation id="543338862236136125">I-edit ang password</translation>
+<translation id="4565377596337484307">Itago ang password</translation>
+<translation id="8523928698583292556">I-delete ang naka-store na password</translation>
+<translation id="2898264748040935573">I-edit ang naka-store na password</translation>
+<translation id="5433691172869980887">Nakopya ang username</translation>
+<translation id="5534640966246046842">Nakopya ang site</translation>
+<translation id="2625189173221582860">Nakopya ang password</translation>
+<translation id="4550003330909367850">Upang tingnan o kopyahin ang iyong password dito, magtakda ng lock ng screen sa device na ito.</translation>
+<translation id="6154478581116148741">I-on ang lock ng screen sa Mga Setting upang i-export ang iyong mga password mula sa device na ito</translation>
+<translation id="4842092870884894799">Ipinapakita ang popup para sa pagbuo ng password</translation>
+<translation id="2259659629660284697">I-export ang mga password…</translation>
+<translation id="133012818630824069">Mag-export ng mga password na naka-store sa Brave</translation>
+<translation id="6914783257214138813">Makikita ng sinumang makakatingin sa na-export na file ang iyong mga password.</translation>
+<translation id="2321086116217818302">Inihahanda ang mga password…</translation>
+<translation id="8445448999790540984">Hindi ma-export ang mga password</translation>
+<translation id="3066461326500799725">Alamin kung paano gamitin ang Brave Software Drive</translation>
+<translation id="729975465115245577">Walang app sa iyong device upang ma-store ang file ng mga password.</translation>
+<translation id="7682724950699840886">Subukan ang mga sumusunod na tip: tiyaking may sapat na espasyo sa iyong device, at subukang mag-export muli.</translation>
+<translation id="1129510026454351943">Mga Detalye: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">I-unlock upang kopyahin ang iyong password</translation>
+<translation id="5515439363601853141">I-unlock upang tingnan ang iyong password</translation>
+<translation id="6221633008163990886">I-unlock upang i-export ang iyong mga password</translation>
+<translation id="230699814587342492">Mga Password sa Brave</translation>
+<translation id="6075798973483050474">I-edit ang home page</translation>
+<translation id="854522910157234410">Buksan ang page na ito</translation>
+<translation id="2482878487686419369">Mga Abiso</translation>
+<translation id="6255999984061454636">Mga suhestyong content</translation>
+<translation id="805047784848435650">Batay sa iyong history ng pag-browse</translation>
+<translation id="1041308826830691739">Mula sa mga website</translation>
+<translation id="395206256282351086">Naka-disable ang mga suhestyon sa paghahanap at site</translation>
+<translation id="257088987046510401">Mga tema</translation>
+<translation id="4650364565596261010">Default ng system</translation>
+<translation id="7588219262685291874">I-on ang madilim na tema kapag naka-on ang Pangtipid sa Baterya ng iyong device</translation>
+<translation id="2760989362628427051">I-on ang madilim na tema kapag naka-on ang madilim na tema o Pangtipid sa Baterya ng iyong device</translation>
+<translation id="6381421346744604172">Padilimin ang mga website</translation>
+<translation id="5040262127954254034">Privacy</translation>
+<translation id="4991384657077828949">Tulungang paigtingin ang seguridad ng Brave</translation>
+<translation id="1943176487615318915">Para matukoy ang mapapanganib na app at site, nagpapadala ang Brave ng mga URL ng ilang page na binibisita mo, limitadong impormasyon ng system, at ilang content ng page sa Brave Software</translation>
+<translation id="3181954750937456830">Ligtas na Pag-browse (pinoprotektahan ka at ang iyong device mula sa mga mapanganib na site)</translation>
+<translation id="7315322926489145388">Ipadala ang mga URL ng ilang page na binibisita mo sa Brave Software kapag nanganganib ang iyong seguridad</translation>
+<translation id="2063713494490388661">Mag-tap upang Maghanap</translation>
+<translation id="2369463299479365221">Matuto tungkol sa mga paksa sa mga website nang hindi umaalis sa page. Ipinapadala sa Brave Software Search ng I-tap para Maghanap ang salita at ang konteksto nito, na nagbibigay ng mga kahulugan, larawan, resulta ng paghahanap, at iba pang detalye.
 
 Para isaayos ang iyong termino para sa paghahanap, pumindot nang matagal para pumili. Para pinuhin ang iyong paghahanap, i-slide ang panel hanggang sa pinakaitaas at i-tap ang box para sa paghahanap.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Available ang mga opsyon malapit sa bandang itaas ng screen</translation>
-<translation id="4062305924942672200">Impormasyong legal</translation>
-<translation id="4084682180776658562">Bookmark</translation>
-<translation id="4084712963632273211">Mula sa <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />ihinatid ng Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">I-delete ang data ng app?</translation>
-<translation id="4099578267706723511">Tulungang mapahusay ang Chrome sa pamamagitan ng pagpapadala sa Google ng mga istatistika ng paggamit at ulat ng pag-crash.</translation>
-<translation id="410351446219883937">I-autoplay</translation>
-<translation id="4116038641877404294">I-download ang mga page para magamit ang mga ito offline</translation>
-<translation id="4135200667068010335">Nakasara ang listahan ng mga device kung saan magbabahagi ng tab.</translation>
-<translation id="4149994727733219643">Pinasimpleng view para sa mga web page</translation>
-<translation id="4165986682804962316">Mga setting ng site</translation>
-<translation id="4169535189173047238">Huwag payagan</translation>
-<translation id="4170011742729630528">Hindi available ang serbisyo; subukang muli sa ibang pagkakataon.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> ang nagamit</translation>
-<translation id="4181841719683918333">Mga Wika</translation>
-<translation id="4183868528246477015">Hanapin gamit ang Google Lens <ph name="BEGIN_NEW" />Bago<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Buksan sa bagong tab</translation>
-<translation id="4198423547019359126">Walang available na lokasyon ng pag-download</translation>
-<translation id="4209895695669353772">Para makakuha ng naka-personalize na content na iminumungkahi ng Google, i-on ang pag-sync</translation>
-<translation id="4226663524361240545">Maaaring mag-vibrate ang device dahil sa mga notification</translation>
-<translation id="423219824432660969">I-encrypt ang naka-sync na data gamit ang password sa Google simula noong <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Buksan ang mga setting</translation>
-<translation id="4256782883801055595">Mga lisensya ng open source</translation>
-<translation id="4259722352634471385">Naka-block ang navigation: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopyahin ang address ng link</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Pinapayagan</translation>
-<translation id="429312253194641664">May site na nagpe-play ng media</translation>
-<translation id="4298388696830689168">Mga naka-link na site</translation>
-<translation id="4307992518367153382">Mga Pangunahing Kaalaman</translation>
-<translation id="4314815835985389558">Pamahalaan ang pag-sync</translation>
-<translation id="4351244548802238354">Isara ang dialog</translation>
-<translation id="4378154925671717803">Telepono</translation>
-<translation id="4384468725000734951">Ginagamit ang Sogou para sa paghahanap</translation>
-<translation id="4404568932422911380">Walang bookmark</translation>
-<translation id="4405224443901389797">Ilipat sa…</translation>
-<translation id="4411535500181276704">Lite mode</translation>
-<translation id="4415276339145661267">Pamahalaan ang iyong Google Account</translation>
-<translation id="4432792777822557199">Simula ngayon ay isasalin na sa <ph name="TARGET_LANGUAGE" /> ang mga page na nasa <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Hatid ng Google ang lite na page</translation>
-<translation id="4434045419905280838">Mga pop-up at pag-redirect</translation>
-<translation id="4440958355523780886">Lite na page na hatid ng Google. Mag-tap para i-load ang orihinal.</translation>
-<translation id="4452411734226507615">Isara ang tab na <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Na-bookmark sa <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Pahintulutan ang mga site na mag-play ng pinoprotektahang content</translation>
-<translation id="4468959413250150279">I-mute ang tunog para sa isang partikular na site.</translation>
-<translation id="4472118726404937099">Para mag-sync at mag-personalize sa mga device, mag-sign in at i-on ang pag-sync</translation>
-<translation id="447252321002412580">Tumulong sa pagpapahusay sa mga feature at performance ng Chrome</translation>
-<translation id="4479647676395637221">Magtanong muna bago payagan ang mga site na gamitin ang iyong camera (inirerekomenda)</translation>
-<translation id="4479972344484327217">Ini-install ang <ph name="MODULE" /> para sa Chrome…</translation>
-<translation id="4487967297491345095">Permanenteng ide-delete ang lahat ng data ng app ng Chrome. Kabilang dito ang lahat ng file, setting, account, database, atbp.</translation>
-<translation id="4493497663118223949">Naka-on ang Lite mode</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# araw ang nakalipas}one{# araw ang nakalipas}other{# na araw ang nakalipas}}</translation>
-<translation id="451872707440238414">Maghanap sa iyong mga bookmark</translation>
-<translation id="4521489764227272523">Inalis ang napiling data sa Chrome at sa iyong mga naka-sync na device.
-
-Maaaring may ibang uri ng history ng pag-browse ang iyong Google account tulad ng mga paghahanap at aktibidad mula sa iba pang serbisyo ng Google sa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Pumili ng folder</translation>
-<translation id="4538018662093857852">I-on ang Lite mode</translation>
-<translation id="4550003330909367850">Upang tingnan o kopyahin ang iyong password dito, magtakda ng lock ng screen sa device na ito.</translation>
-<translation id="4558311620361989323">Mga shortcut ng webpage</translation>
-<translation id="4561979708150884304">Walang koneksyon</translation>
-<translation id="4565377596337484307">Itago ang password</translation>
-<translation id="4570913071927164677">Mga Detalye</translation>
-<translation id="4572422548854449519">Mag-sign in sa pinamamahalaang account</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minuto ang nakalipas}one{# minuto ang nakalipas}other{# na minuto ang nakalipas}}</translation>
-<translation id="4587589328781138893">Mga Site</translation>
-<translation id="4594952190837476234">Naka-offline ang page na ito mula noong <ph name="CREATION_TIME" /> at maaaring iba ito sa online na bersyon.</translation>
-<translation id="4605958867780575332">Naalis na item: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Buksan ang <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Gamitin ang password</translation>
-<translation id="4645575059429386691">Pinamamahalaan ng iyong magulang</translation>
-<translation id="4650364565596261010">Default ng system</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> (na) bookmark ang na-delete</translation>
-<translation id="4665282149850138822">Idinagdag ang <ph name="NAME" /> sa iyong Home screen</translation>
-<translation id="4684427112815847243">I-sync lahat</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> iba pa}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> iba pa}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> na iba pa}}</translation>
-<translation id="4696983787092045100">Ipadala ang text sa Iyong Mga Device</translation>
-<translation id="4698034686595694889">Tingnan offline sa <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Mga naka-cache na larawan at file</translation>
-<translation id="4714588616299687897">Makatipid nang hanggang 60% ng iyong data</translation>
-<translation id="4719927025381752090">Mag-alok na magsalin</translation>
-<translation id="4720023427747327413">Buksan sa <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Tumulong na pahusayin ang Chrome. <ph name="BEGIN_LINK" />Sagutan ang survey<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">I-update</translation>
-<translation id="4738836084190194332">Huling na-sync: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Magbukas ng bagong tab</translation>
-<translation id="4751476147751820511">Mga motion o light sensor</translation>
-<translation id="4759238208242260848">Mga Download </translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Tapos na ang 1 pag-download.}one{Tapos na ang # pag-download.}other{Tapos na ang # na pag-download.}}</translation>
-<translation id="4797039098279997504">Pindutin upang bumalik sa <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Hindi kasama sa pag-encrypt ng passphrase ang mga paraan ng pagbabayad at address mula sa Google Pay.
-
-Para baguhin ang setting na ito, <ph name="BEGIN_LINK" />i-reset ang pag-sync<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Pangalang makikita sa card</translation>
-<translation id="4824958205181053313">Kanselahin ang pag-sync?</translation>
-<translation id="4837753911714442426">Buksan ang mga opsyon sa pag-print ng page</translation>
-<translation id="4842092870884894799">Ipinapakita ang popup para sa pagbuo ng password</translation>
-<translation id="4860895144060829044">Tawagan</translation>
-<translation id="4866368707455379617">Hindi ma-install ang <ph name="MODULE" /> para sa Chrome</translation>
-<translation id="4875775213178255010">Mga Iminumungkahing Content</translation>
-<translation id="4878404682131129617">Hindi nakagawa ng tunnel sa pamamagitan ng proxy server</translation>
-<translation id="4880127995492972015">Isalin…</translation>
-<translation id="4881695831933465202">Buksan</translation>
-<translation id="488187801263602086">Palitan ang pangalan ng file</translation>
-<translation id="4882831918239250449">Kontrolin kung paano ginagamit ang iyong history ng pag-browse para i-personalize ang Paghahanap, mga ad, at iba pa</translation>
-<translation id="4883854917563148705">Hindi puwedeng i-reset ang mga pinapamahalaang setting</translation>
-<translation id="4885273946141277891">Hindi sinusuportahang bilang ng mga instance ng Chrome.</translation>
-<translation id="4910889077668685004">Mga app sa pagbabayad</translation>
-<translation id="4913161338056004800">I-reset ang mga istatistika</translation>
-<translation id="4913169188695071480">Ihinto ang pag-refresh</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Humingi ng tulong<ph name="END_LINK" /> habang nag-ii-scan ng mga device…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Page}one{# Page}other{# na Page}}</translation>
-<translation id="4932247056774066048">Dahil nagsa-sign out ka sa isang account na pinapamahalaan ng <ph name="DOMAIN_NAME" />, made-delete ang data ng Chrome sa device na ito. Mananatili ito sa iyong Google Account.</translation>
-<translation id="4943703118917034429">Virtual Reality</translation>
-<translation id="4943872375798546930">Walang mga resulta</translation>
-<translation id="4958708863221495346">Ibinabahagi ng <ph name="URL_OF_THE_CURRENT_TAB" /> ang iyong screen</translation>
-<translation id="4961107849584082341">Isalin ang page na ito sa anumang wika</translation>
-<translation id="4962975101802056554">Bawiin ang lahat ng pahintulot para sa device</translation>
-<translation id="4970824347203572753">Hindi available sa iyong lokasyon</translation>
-<translation id="497421865427891073">Sumulong</translation>
-<translation id="4988210275050210843">Nagda-download ng file (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Mga Page</translation>
-<translation id="4994033804516042629">Walang nakitang contact</translation>
-<translation id="4996978546172906250">Ibahagi gamit ang</translation>
-<translation id="5004416275253351869">Mga kontrol ng aktibidad sa Google</translation>
-<translation id="5005498671520578047">Kopyahin password</translation>
-<translation id="5011311129201317034">Gustong kumonekta ng <ph name="SITE" /></translation>
-<translation id="5013696553129441713">Walang bagong suhestyon</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Habang nasa VR ka, puwedeng malaman ng site na ito ang tungkol sa:
-  -  iyong mga pisikal na katangian, gaya ng tangkad
-
-Tiyaking pinagkakatiwalaan mo ang site na ito bago ka pumasok sa VR.</translation>
+<translation id="2930742481329940825">Ipinapadala sa Brave Software Search ng I-tap para Maghanap ang napiling salita at ang kasalukuyang page bilang konteksto. Maaari mo itong i-off sa <ph name="BEGIN_LINK"/>Mga Setting<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Payagan</translation>
-<translation id="5040262127954254034">Privacy</translation>
-<translation id="5048398596102334565">Payagan ang mga site na i-access ang mga sensor ng paggalaw (inirerekomenda)</translation>
-<translation id="5063480226653192405">Paggamit</translation>
-<translation id="5087580092889165836">Magdagdag ng card</translation>
-<translation id="5100237604440890931">Naka-collapse - i-click upang palawakin</translation>
-<translation id="510275257476243843">1 oras na lang ang natitira</translation>
-<translation id="5123685120097942451">Tab na incognito</translation>
-<translation id="5127805178023152808">Naka-off ang pag-sync</translation>
-<translation id="5129038482087801250">I-install ang web app</translation>
-<translation id="5132942445612118989">I-sync ang iyong mga password, history, at higit pa sa lahat ng device</translation>
-<translation id="5139940364318403933">Alamin kung paano gamitin ang Google Drive</translation>
-<translation id="515227803646670480">I-clear ang naka-store na data</translation>
-<translation id="5152843274749979095">Walang naka-install na sinusuportahang app</translation>
-<translation id="5161254044473106830">Kailangan ng pamagat</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ang hindi na-download.}one{# ang hindi na-download.}other{# ang hindi na-download.}}</translation>
-<translation id="5170568018924773124">Ipinakita sa folder</translation>
-<translation id="5184329579814168207">Buksan sa Chrome</translation>
-<translation id="5193988420012215838">Kinopya sa iyong clipboard</translation>
-<translation id="5197729504361054390">Ibabahagi sa <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> ang mga contact na pipiliin mo.</translation>
-<translation id="5199929503336119739">Profile sa trabaho</translation>
-<translation id="5210286577605176222">Pumunta sa nakaraang tab</translation>
-<translation id="5210365745912300556">Isara ang tab</translation>
-<translation id="5224771365102442243">May video</translation>
-<translation id="5230560987958996918">Gustong mag-scan ng <ph name="SITE" /> para sa mga Bluetooth device na nasa malapit. Nahanap ang mga sumusunod na device:</translation>
-<translation id="5233638681132016545">Bagong tab</translation>
-<translation id="526421993248218238">Hindi ma-load ang page na ito</translation>
-<translation id="5271967389191913893">Hindi mabuksan ng device ang content na ida-download.</translation>
-<translation id="528192093759286357">I-drag mula sa itaas at pindutin ang button na bumalik upang lumabas sa full screen.</translation>
-<translation id="5292796745632149097">Ipadala kay</translation>
-<translation id="5300589172476337783">Ipakita</translation>
-<translation id="5301954838959518834">OK, nakuha ko</translation>
-<translation id="5304593522240415983">Hindi maaaring maging blangko ang field na ito</translation>
-<translation id="5307446750509046227">I-clear ang storage ng site</translation>
-<translation id="5308380583665731573">Kumonekta</translation>
-<translation id="5313967007315987356">Magdagdag ng site</translation>
-<translation id="5317780077021120954">I-save</translation>
-<translation id="5324858694974489420">Mga Setting para sa Magulang</translation>
-<translation id="5327248766486351172">Pangalan</translation>
-<translation id="5335288049665977812">Payagan ang mga site na magpatakbo ng JavaScript (inirerekomenda)</translation>
-<translation id="5342314432463739672">Mga kahilingan sa pahintulot</translation>
-<translation id="5357811892247919462">Natanggap ang tab</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> nakabukas na tab, i-tap para lumipat ng tab}one{<ph name="OPEN_TABS_MANY" /> nakabukas na tab, i-tap para lumipat ng tab}other{<ph name="OPEN_TABS_MANY" /> na nakabukas na tab, i-tap para lumipat ng tab}}</translation>
-<translation id="5391532827096253100">Hindi secure ang iyong koneksyon sa site na ito. Impormasyon ng site</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 pa)}one{(+ # pa)}other{(+ # pa)}}</translation>
-<translation id="5400569084694353794">Kapag ginamit mo ang application na ito, ang ibig sabihin, sumasang-ayon ka sa <ph name="BEGIN_LINK1" />Mga Tuntunin ng Serbisyo<ph name="END_LINK1" /> at <ph name="BEGIN_LINK2" />Patakaran sa Privacy<ph name="END_LINK2" /> ng Chrome.</translation>
-<translation id="5403592356182871684">Mga Pangalan</translation>
-<translation id="5403644198645076998">Ilang partikular na site lang ang payagan</translation>
-<translation id="5414836363063783498">Vine-verify…</translation>
-<translation id="5423934151118863508">Lalabas dito ang mga page na madalas mong bisitahin</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB ang available</translation>
-<translation id="543338862236136125">I-edit ang password</translation>
-<translation id="5433691172869980887">Nakopya ang username</translation>
-<translation id="543509235395288790">Nagda-download ng <ph name="COUNT" /> (na) file (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Pumunta sa address bar</translation>
-<translation id="5447201525962359567">Lahat ng storage ng site, kabilang ang cookies at iba pang lokal na naka-store na data</translation>
-<translation id="5447765697759493033">Hindi isasalin ang site na ito</translation>
-<translation id="545042621069398927">Pinapabilis ang iyong pag-download.</translation>
-<translation id="5456381639095306749">I-download ang page</translation>
-<translation id="5475862044948910901">Magsimula ng session ng Augmented Reality?</translation>
-<translation id="548278423535722844">Buksan sa app na mga mapa</translation>
-<translation id="5487521232677179737">I-clear ang data</translation>
-<translation id="5494752089476963479">I-block ang mga ad sa mga site na nagpapakita ng mga nakakasagabal o nakakapanlinlang na ad</translation>
-<translation id="5500777121964041360">Maaaring hindi available sa iyong lokasyon</translation>
-<translation id="5512137114520586844">Pinapamahalaan ang account na ito ng <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Na-disable ng administrator ng device na ito</translation>
-<translation id="5515439363601853141">I-unlock upang tingnan ang iyong password</translation>
-<translation id="5516455585884385570">Buksan ang mga setting ng notification</translation>
-<translation id="5517095782334947753">Mayroon kang mga bookmark, history, password at iba pang mga setting mula sa <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Na-block ang pag-redirect.</translation>
-<translation id="5527082711130173040">Kailangan ng Chrome ng access sa lokasyon upang makapag-scan ng mga device. <ph name="BEGIN_LINK1" />I-update ang mga pahintulot<ph name="END_LINK1" />. Ang access sa lokasyon ay <ph name="BEGIN_LINK2" />naka-off din para sa device na ito<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Magtanong bago payagan ang mga site na i-read ang text at mga larawan mula sa clipboard (inirerekomenda)</translation>
-<translation id="5530766185686772672">Isara ang mga tab na incognito</translation>
-<translation id="5534334044554683961">Habang nasa VR ka, puwedeng malaman ng site na ito ang tungkol sa:
-  -   iyong mga pisikal na katangian, gaya ng tangkad
-  -   layout ng kwarto mo
-
-Tiyaking pinagkakatiwalaan mo ang site na ito bago ka pumasok sa VR.</translation>
-<translation id="5534640966246046842">Nakopya ang site</translation>
-<translation id="5556459405103347317">I-reload</translation>
-<translation id="5561549206367097665">Naghihintay ng network…</translation>
-<translation id="557283862590186398">Kailangan ng Chrome ng pahintulot na i-access ang iyong mikropono para sa site na ito.</translation>
-<translation id="55737423895878184">Pinapayagan ang lokasyon at mga notification</translation>
-<translation id="5578795271662203820">Hanapin sa <ph name="SEARCH_ENGINE" /> ang larawan</translation>
-<translation id="5581519193887989363">Mapipili mo kung ano ang isi-sync anumang oras sa <ph name="BEGIN_LINK1" />mga setting<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Mag-edit ng address</translation>
-<translation id="5596627076506792578">Higit pang opsyon</translation>
-<translation id="5599455543593328020">Incognito mode</translation>
-<translation id="5620928963363755975">Hanapin ang iyong mga file at page sa Mga Download mula sa button na Higit Pang Opsyon</translation>
-<translation id="5626134646977739690">Pangalan:</translation>
-<translation id="5639724618331995626">Payagan ang lahat ng site</translation>
-<translation id="5648166631817621825">Nakalipas na 7 araw</translation>
-<translation id="5649053991847567735">Mga awtomatikong pag-download</translation>
-<translation id="5655963694829536461">Maghanap sa iyong mga download</translation>
-<translation id="5659593005791499971">Email</translation>
-<translation id="5665379678064389456">Gumawa ng event sa <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">I-override ang kahilingan ng isang website upang mapigilan ang pagzu-zoom in</translation>
-<translation id="5677928146339483299">Naka-block</translation>
-<translation id="5684874026226664614">Oops. Hindi maisalin ang pahinang ito.</translation>
-<translation id="5686790454216892815">Masyadong mahaba ang pangalan ng file</translation>
-<translation id="5689516760719285838">Lokasyon</translation>
-<translation id="569536719314091526">Isalin ang page na ito sa anumang wika mula sa button na Higit pang opsyon</translation>
-<translation id="572328651809341494">Mga kamakailang tab</translation>
-<translation id="5726692708398506830">Palakihin ang lahat ng nasa page</translation>
-<translation id="5748802427693696783">Lumipat sa mga karaniwang tab</translation>
-<translation id="5749068826913805084">Kailangan ng Chrome ng access sa storage para mag-download ng mga file.</translation>
-<translation id="5763382633136178763">Mga tab na incognito</translation>
-<translation id="5763514718066511291">I-tap upang kopyahin ang URL para sa app na ito</translation>
-<translation id="5765780083710877561">Paglalarawan:</translation>
-<translation id="5793665092639000975">Gumagamit ng <ph name="SPACE_USED" /> ng <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Maaaring gamitin ng Google ang iyong history para i-personalize ang Search, mga ad, at iba pang serbisyo ng Google</translation>
-<translation id="5804241973901381774">Mga Pahintulot</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# oras ang nakalipas}one{# oras ang nakalipas}other{# na oras ang nakalipas}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Nakalaan ang lahat ng karapatan.</translation>
-<translation id="5817918615728894473">Ipares</translation>
-<translation id="583281660410589416">Hindi-alam</translation>
-<translation id="5833984609253377421">Ibahagi ang link</translation>
-<translation id="5836192821815272682">Dina-download ang Update sa Chrome…</translation>
-<translation id="5853623416121554550">naka-pause</translation>
-<translation id="5854790677617711513">Mas matagal sa 30 araw</translation>
-<translation id="5858741533101922242">Hindi ma-on ng Chrome ang Bluetooth adapter</translation>
-<translation id="5860033963881614850">Naka-off</translation>
-<translation id="5862731021271217234">Para makuha ang iyong mga tab mula sa iba mo pang device, i-on ang pag-sync</translation>
-<translation id="5864174910718532887">Mga detalye: Pinagbukud-bukod ayon sa pangalan ng site</translation>
-<translation id="5864419784173784555">Naghihintay ng isa pang download…</translation>
-<translation id="5865733239029070421">Awtomatikong nagpapadala sa Google ng mga istatistika ng paggamit at ulat ng pag-crash</translation>
-<translation id="5869522115854928033">Mga naka-save na password</translation>
-<translation id="5902828464777634901">Made-delete ang lahat ng lokal na data na ini-store ng website na ito, kasama ang cookies.</translation>
-<translation id="5916664084637901428">Naka-on</translation>
-<translation id="5919204609460789179">I-update ang <ph name="PRODUCT_NAME" /> upang simulan ang pag-sync</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> ang natipid</translation>
-<translation id="5939518447894949180">I-reset</translation>
-<translation id="5942872142862698679">Ginagamit ang Google para sa paghahanap</translation>
-<translation id="5952764234151283551">Ipinapadala sa Google ang URL ng page na sinusubukan mong puntahan</translation>
-<translation id="5956665950594638604">Buksan ang Help Center ng Chrome sa bagong tab</translation>
-<translation id="5958275228015807058">Hanapin ang iyong mga file at page sa Mga Download</translation>
-<translation id="5962718611393537961">I-tap upang i-collapse</translation>
-<translation id="6000066717592683814">Panatilihin ang Google</translation>
-<translation id="6005538289190791541">Iminumungkahing password</translation>
-<translation id="6036057147555329831">Karagdagang ICU</translation>
-<translation id="6039379616847168523">Pumunta sa susunod na tab</translation>
-<translation id="6040143037577758943">Isara</translation>
-<translation id="6042308850641462728">Higit pa</translation>
-<translation id="604996488070107836">Hindi na-download ang <ph name="FILE_NAME" /> dahil sa isang hindi alam na error.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">Mga nakumpletong download</translation>
-<translation id="6075798973483050474">I-edit ang home page</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> (na) oras na lang ang natitira</translation>
-<translation id="6108923351542677676">Kasalukuyang sine-setup…</translation>
-<translation id="6111020039983847643">nagamit na data</translation>
-<translation id="6112702117600201073">Nire-refresh ang page</translation>
-<translation id="6127379762771434464">Inalis ang item</translation>
-<translation id="6140912465461743537">Bansa/Rehiyon</translation>
-<translation id="614940544461990577">Subukang:</translation>
-<translation id="6154478581116148741">I-on ang lock ng screen sa Mga Setting upang i-export ang iyong mga password mula sa device na ito</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> ang natipid sa data</translation>
-<translation id="6165508094623778733">Matuto pa</translation>
-<translation id="6177111841848151710">Naka-block para sa kasalukuyang search engine</translation>
-<translation id="6181444274883918285">Magdagdag ng pagbubukod ng site</translation>
-<translation id="6192333916571137726">File ng download</translation>
-<translation id="6192792657125177640">Mga Pagbubukod</translation>
-<translation id="6194112207524046168">Para payagang i-access ng Chrome ang iyong camera, i-on din ang camera sa <ph name="BEGIN_LINK" />Mga Setting ng Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">I-block ang mga third-party na cookie</translation>
-<translation id="6206551242102657620">Secure ang koneksyon. Impormasyon ng site</translation>
-<translation id="6210748933810148297">Hindi si <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">I-unlock upang i-export ang iyong mga password</translation>
+<translation id="1406000523432664303">“Huwag Subaybayan”</translation>
 <translation id="6232535412751077445">Kapag na-enable mo ang “Huwag Subaybayan,” magsasama ng isang kahilingan sa trapiko ng iyong pagba-browse. Ang anumang magiging epekto ay dedepende sa pagtugon at pagbibigay-kahulugan ng website sa nabanggit na kahilingan.
 
 Halimbawa, puwedeng tumugon ang ilang website sa kahilingang ito sa pamamagitan ng pagpapakita sa iyo ng mga ad na hindi ibinatay sa iba pang nabisita mo nang website. Kokolektahin at gagamitin pa rin ng maraming website ang iyong data sa pag-browse - halimbawa, para mapahusay ang seguridad, makapagpakita ng content, mga ad, at rekomendasyon, at makabuo ng mga istatistika sa pag-uulat.</translation>
-<translation id="624789221780392884">Handa na ang pag-update</translation>
-<translation id="6255999984061454636">Mga suhestyong content</translation>
-<translation id="6277522088822131679">Nagkaproblema sa pag-print sa pahina. Pakisubukang muli.</translation>
-<translation id="6295158916970320988">Lahat ng site</translation>
-<translation id="629730747756840877">Account</translation>
-<translation id="6303969859164067831">Mag-sign out at i-off ang pag-sync</translation>
-<translation id="6316139424528454185">Hindi sinusuportahan ang bersyon ng Android</translation>
-<translation id="6320088164292336938">Mag-vibrate</translation>
-<translation id="6324034347079777476">Naka-disable ang pag-sync ng Android system</translation>
-<translation id="6333140779060797560">Ibahagi sa pamamagitan ng <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Pag-encrypt</translation>
-<translation id="6341580099087024258">Itanong kung saan magse-save ng mga file</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> iba pa}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> iba pa}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> na iba pa}}</translation>
-<translation id="6364438453358674297">Alisin ang suhestyon mula sa history?</translation>
-<translation id="6369229450655021117">Mula rito, maaari kang maghanap sa web, magbahagi sa mga kaibigan, at tumingin ng mga bukas na page</translation>
-<translation id="6378173571450987352">Mga detalye: Pinagbukud-bukod ayon sa laki ng nagamit na data</translation>
-<translation id="6381421346744604172">Padilimin ang mga website</translation>
-<translation id="6388207532828177975">I-clear at i-reset</translation>
-<translation id="6393863479814692971">Kailangan ng Chrome ng pahintulot na i-access ang iyong camera at mikropono para sa site na ito.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">I-edit ang bookmark</translation>
-<translation id="6406506848690869874">Pag-sync</translation>
-<translation id="641643625718530986">I-print…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB ang na-download</translation>
-<translation id="6427112570124116297">I-translate ang Web</translation>
-<translation id="6433501201775827830">Pumili ng iyong search engine</translation>
-<translation id="6437478888915024427">Impormasyon ng page</translation>
-<translation id="6441734959916820584">Masyadong mahaba ang pangalan</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Larawan}one{# Larawan}other{# na Larawan}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Hindi mabuksan ang file</translation>
-<translation id="6464977750820128603">Puwede mong makita ang mga site na binibisita mo sa Chrome at puwede kang magtakda ng mga timer para sa mga ito.\n\nKumukuha ng impormasyon ang Google tungkol sa mga site kung saan ka nagtakda ng mga timer at inaalam nito kung gaano mo katagal binisita ang mga ito. Ginagamit ang impormasyong ito para pahusayin ang Digital Wellness.</translation>
-<translation id="6475951671322991020">I-download ang video</translation>
-<translation id="6482749332252372425">Hindi na-download ang <ph name="FILE_NAME" /> dahil kulang ang espasyo sa storage.</translation>
-<translation id="6496823230996795692">Upang magamit ang <ph name="APP_NAME" /> sa unang pagkakataon, kumonekta sa internet.</translation>
-<translation id="6508722015517270189">I-restart ang Chrome</translation>
-<translation id="6527303717912515753">Ibahagi</translation>
-<translation id="6532866250404780454">Hindi lalabas ang mga site na binibisita mo sa Chrome. Ide-delete ang lahat ng timer sa site.</translation>
-<translation id="6534565668554028783">Masyadong matagal bago nakatugon ang Google</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB ang na-download</translation>
-<translation id="6539092367496845964">Nagkaproblema. Subukan ulit sa ibang pagkakataon.</translation>
-<translation id="654446541061731451">Pumili ng tab upang mag-beam</translation>
-<translation id="6545017243486555795">I-clear ang Lahat ng Data</translation>
-<translation id="6545864417968258051">Pag-scan ng Bluetooth</translation>
-<translation id="6560414384669816528">Maghanap gamit ang Sogou</translation>
-<translation id="6566259936974865419">Nag-save ang Chrome ng <ph name="GIGABYTES" /> GB para sa iyo</translation>
-<translation id="6573096386450695060">Payagan sa lahat ng oras</translation>
-<translation id="6573431926118603307">Dito lalabas ang mga nabuksan mong tab sa Chrome sa iba mo pang mga device.</translation>
-<translation id="6583199322650523874">I-bookmark ang kasalukuyang page</translation>
-<translation id="6593061639179217415">Desktop site</translation>
-<translation id="6600954340915313787">Kinopya sa Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Pinoprotektahang content</translation>
-<translation id="6627583120233659107">I-edit ang folder</translation>
-<translation id="6643016212128521049">I-clear</translation>
-<translation id="6643649862576733715">Pagbukud-bukurin ayon sa dami ng data na natipid</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> iba pa}one{<ph name="CONTACT_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> iba pa}other{<ph name="CONTACT_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> na iba pa}}</translation>
-<translation id="6649642165559792194">I-preview ang larawang <ph name="BEGIN_NEW" />Bago<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Kailangan ng Chrome ng access sa lokasyon upang makapag-scan at makakita ng mga device. <ph name="BEGIN_LINK" />I-update ang mga pahintulot<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Password</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Buksan sa <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Notification ng Privacy ng Chrome</translation>
-<translation id="6676840375528380067">I-clear ang iyong data sa Chrome sa device na ito?</translation>
-<translation id="6697492270171225480">Magpakita ng mga mungkahi para sa mga katulad na page kapag hindi mahanap ang isang page</translation>
-<translation id="6697947395630195233">Kailangan ng Chrome ng access sa iyong lokasyon upang ibahagi ang lokasyon mo sa site na ito.</translation>
-<translation id="6698801883190606802">Pamahalaan ang na-sync na data</translation>
-<translation id="6699370405921460408">Io-optimize ng mga server ng Google ang mga page na binibisita mo.</translation>
-<translation id="6706288973712894588">Kasalukuyan kang offline.\n<ph name="BEGIN_LINK" />I-explore ang iyong offline na feed.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Balita</translation>
-<translation id="6710213216561001401">Nakaraan</translation>
-<translation id="671481426037969117">Natapos na ang iyong timer ng <ph name="FQDN" />. Magsisimula itong muli bukas.</translation>
-<translation id="6738867403308150051">Nagda-download...</translation>
-<translation id="6746124502594467657">Ibaba</translation>
-<translation id="6766622839693428701">Mag-swipe pababa para isara.</translation>
-<translation id="6766758767654711248">I-tap para pumunta sa site</translation>
-<translation id="6767294960381293877">Nakabukas ang listahan ng mga device kung saan magbabahagi ng tab nang kalahati ang taas.</translation>
-<translation id="6782111308708962316">Pigilan ang mga third-party na website na mag-save at magbasa ng data ng cookie</translation>
-<translation id="6790428901817661496">I-play</translation>
-<translation id="6811034713472274749">Maaari nang tingnan ang page</translation>
-<translation id="6818926723028410516">Pumili ng mga item</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Isalin</translation>
-<translation id="6845325883481699275">Tulungang paigtingin ang seguridad ng Chrome</translation>
-<translation id="6846298663435243399">Naglo-load…</translation>
-<translation id="6850409657436465440">Isinasagawa pa rin ang iyong pag-download</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> (na) tab ang isinara</translation>
-<translation id="6864459304226931083">I-download ang larawan</translation>
-<translation id="6865313869410766144">Data ng form ng autofill</translation>
-<translation id="688738109438487280">Idagdag ang kasalukuyang data sa <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">I-unlock upang kopyahin ang iyong password</translation>
-<translation id="6896758677409633944">Copy</translation>
-<translation id="6910211073230771657">Na-delete</translation>
-<translation id="6912998170423641340">I-block ang mga site sa pag-read ng text at mga larawan mula sa clipboard</translation>
-<translation id="6914783257214138813">Makikita ng sinumang makakatingin sa na-export na file ang iyong mga password.</translation>
-<translation id="6942665639005891494">Baguhin ang default na lokasyon ng pag-download anumang oras gamit ang opsyong menu ng Mga Setting</translation>
-<translation id="6945221475159498467">Pumili</translation>
-<translation id="6963642900430330478">Mapanganib ang page na ito. Impormasyon ng site</translation>
-<translation id="6963766334940102469">Mag-delete ng mga bookmark</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Lahat ng oras</translation>
-<translation id="6981982820502123353">Pagiging Accessible</translation>
-<translation id="6989267951144302301">Hindi ma-download</translation>
-<translation id="6990079615885386641">Kunin ang app mula sa Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Magtanong muna bago payagan ang mga site na gamitin ang iyong mikropono (inirerekomenda)</translation>
-<translation id="7015203776128479407">Hindi natapos ang pag-set up ng unang pag-sync. Naka-off ang pag-sync.</translation>
-<translation id="7016516562562142042">Pinapayagan para sa kasalukuyang search engine</translation>
-<translation id="7022756207310403729">Buksan sa browser</translation>
-<translation id="702463548815491781">Inirerekomenda kapag naka-on ang TalkBack o Switch Access</translation>
-<translation id="7029809446516969842">Mga Password</translation>
-<translation id="7053983685419859001">I-block</translation>
-<translation id="7055152154916055070">Na-block ang pag-redirect:</translation>
-<translation id="7063006564040364415">Hindi makakonekta sa server ng pag-sync.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ang napili}one{# ang napili}other{# ang napili}}</translation>
-<translation id="7071521146534760487">Pamahalaan ang account</translation>
-<translation id="7077143737582773186">SD Card</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> ang napili.  Available ang mga opsyon malapit sa itaas ng screen</translation>
-<translation id="7121362699166175603">Kini-clear ang history at mga autocompletion sa address bar. Maaaring may iba pang anyo ng history ng pag-browse ang iyong Google Account sa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Payagan para sa kasalukuyang search engine</translation>
-<translation id="7138678301420049075">Iba pa</translation>
-<translation id="7141896414559753902">I-block ang pagpapakita ng mga site ng mga pop-up at pag-redirect (inirerekomenda)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />I-load ang orihinal na page<ph name="END_LINK" /> mula sa <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Nakalipas na 24 na oras</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Maaari mo itong baguhin sa ibang pagkakataon sa Mga Setting</translation>
-<translation id="7180611975245234373">I-refresh</translation>
-<translation id="7189372733857464326">Hinihintay ang Mga Serbisyo ng Google Play na matapos sa pag-update</translation>
-<translation id="7191430249889272776">Binuksan ang tab sa background.</translation>
-<translation id="723171743924126238">Pumili ng mga larawan</translation>
-<translation id="7233236755231902816">Para makita ang web sa iyong wika, kunin ang pinakabagong bersyon ng Chrome</translation>
-<translation id="7243308994586599757">May mga opsyon malapit sa ibaba ng screen</translation>
-<translation id="7248069434667874558">Tiyaking naka-on sa <ph name="TARGET_DEVICE_NAME" /> ang pag-sync sa Chrome</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> ang napili</translation>
-<translation id="7274013316676448362">Naka-block na site</translation>
-<translation id="7290209999329137901">Hindi available ang pag-rename</translation>
-<translation id="7291387454912369099">Assistant Triggered na Pag-check out</translation>
-<translation id="7293171162284876153">Para simulan ang pag-sync, i-on ang "I-sync ang iyong data sa Chrome."</translation>
-<translation id="729975465115245577">Walang app sa iyong device upang ma-store ang file ng mga password.</translation>
-<translation id="7302081693174882195">Mga detalye: Pinagbukud-bukod ayon sa laki ng natipid na data</translation>
-<translation id="7328017930301109123">Sa Lite mode, mas mabilis na nilo-load ng Chrome ang mga page at mas kaunti nang 60 porsyento ang ginagamit nitong data.</translation>
-<translation id="7333031090786104871">Nagdaragdag pa rin ng nakaraang site</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Ibahagi ang 1 piniling item}one{Ibahagi ang # piniling item}other{Ibahagi ang # na piniling item}}</translation>
 <translation id="7359002509206457351">I-access ang mga paraan ng pagbabayad</translation>
+<translation id="8026334261755873520">I-clear ang data sa pag-browse</translation>
+<translation id="1291207594882862231">I-clear ang history, cookies, site data, cache…</translation>
+<translation id="7814200940910057384">Na-clear ang data ng Brave</translation>
+<translation id="1664855196866195614">Inalis ang napiling data sa Brave at sa iyong mga naka-sync na device.
+
+Maaaring may ibang uri ng history ng pag-browse ang iyong Brave Software account tulad ng mga paghahanap at aktibidad mula sa iba pang serbisyo ng Brave Software sa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Mga naka-cache na larawan at file</translation>
+<translation id="2496180316473517155">History ng Pag-browse</translation>
+<translation id="2546283357679194313">Cookies at data ng site</translation>
+<translation id="8662811608048051533">Nagsa-sign out sa iyo sa karamihan ng site.</translation>
+<translation id="8218628800671693884">Isa-sign out ka sa karamihan ng mga site. Hindi ka masa-sign out sa iyong Brave Software Account.</translation>
+<translation id="2017836877785168846">Kini-clear ang history at mga awtomatikong pagkumpleto sa address bar.</translation>
+<translation id="8096327394278038498">Kini-clear ang history at mga autocompletion sa address bar. Maaaring may iba pang anyo ng history ng pag-browse ang iyong Brave Software Account sa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Kini-clear ang history sa lahat ng naka-sign in na device. Maaaring may iba pang anyo ng history ng pag-browse ang iyong Brave Software Account sa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Mga naka-save na password</translation>
+<translation id="6865313869410766144">Data ng form ng autofill</translation>
+<translation id="7562080006725997899">Kini-clear ang data sa pag-browse</translation>
+<translation id="5487521232677179737">I-clear ang data</translation>
+<translation id="7498271377022651285">Mangyaring maghintay…</translation>
+<translation id="784934925303690534">Sakop na oras</translation>
+<translation id="1718835860248848330">Huling oras</translation>
+<translation id="7149893636342594995">Nakalipas na 24 na oras</translation>
+<translation id="5648166631817621825">Nakalipas na 7 araw</translation>
+<translation id="8571213806525832805">Huling 4 na linggo</translation>
+<translation id="5854790677617711513">Mas matagal sa 30 araw</translation>
+<translation id="6979737339423435258">Lahat ng oras</translation>
+<translation id="982182592107339124">Iki-clear nito ang data para sa lahat ng site, kabilang ang:</translation>
+<translation id="6643016212128521049">I-clear</translation>
+<translation id="7641339528570811325">I-clear ang data sa pag-browse...</translation>
+<translation id="1670399744444387456">Pangunahin</translation>
+<translation id="3245261285041759672">Maaaring may iba pang anyo ng history ng pag-browse ang iyong Brave Software Account sa <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Naka-block na site</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> (na) item ang na-delete</translation>
+<translation id="1121094540300013208">Mga ulat sa paggamit at pag-crash</translation>
+<translation id="9079153198295609735">Awtomatikong ipadala ang mga istatistika ng paggamit at mga ulat ng pag-crash sa Brave Software</translation>
+<translation id="6981982820502123353">Pagiging Accessible</translation>
+<translation id="2387895666653383613">Pag-scale ng text</translation>
+<translation id="2321958826496381788">I-drag ang slider hanggang sa mabasa mo ito nang kumportable. Dapat ay halos ganito kalaki ang text pagkatapos mag-double tap sa isang talata.</translation>
+<translation id="3895926599014793903">Puwersahang i-enable ang zoom</translation>
+<translation id="5668404140385795438">I-override ang kahilingan ng isang website upang mapigilan ang pagzu-zoom in</translation>
+<translation id="4149994727733219643">Pinasimpleng view para sa mga web page</translation>
+<translation id="9100505651305367705">Mag-alok na ipakita ang mga artikulo sa pinasimpleng view, kapag sinusuportahan</translation>
+<translation id="1409426117486808224">Pinasimpleng view para sa mga bukas na tab</translation>
+<translation id="702463548815491781">Inirerekomenda kapag naka-on ang TalkBack o Switch Access</translation>
+<translation id="8284326494547611709">Mga Caption</translation>
+<translation id="4165986682804962316">Mga setting ng site</translation>
+<translation id="6295158916970320988">Lahat ng site</translation>
+<translation id="8380167699614421159">Nagpapakita ang site na ito ng mga nakakasagabal o nakakapanlinlang na ad</translation>
+<translation id="1919345977826869612">Mga Ad</translation>
+<translation id="410351446219883937">I-autoplay</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">I-block ang mga third-party na cookie</translation>
+<translation id="6782111308708962316">Pigilan ang mga third-party na website na mag-save at magbasa ng data ng cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Mga pop-up at pag-redirect</translation>
+<translation id="4751476147751820511">Mga motion o light sensor</translation>
+<translation id="1717218214683051432">Mga sensor ng paggalaw</translation>
+<translation id="2091887806945687916">Tunog</translation>
+<translation id="2586657967955657006">Clipboard</translation>
+<translation id="6320088164292336938">Mag-vibrate</translation>
+<translation id="4226663524361240545">Maaaring mag-vibrate ang device dahil sa mga notification</translation>
+<translation id="1446450296470737166">Payagan ganap na kontrol sa MIDI device</translation>
+<translation id="3744111561329211289">Pag-sync sa background</translation>
+<translation id="5649053991847567735">Mga awtomatikong pag-download</translation>
+<translation id="6181444274883918285">Magdagdag ng pagbubukod ng site</translation>
+<translation id="5313967007315987356">Magdagdag ng site</translation>
+<translation id="1369915414381695676">Nadagdag na ang site ng <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Payagan ang pag-autoplay ng mga naka-mute na video para sa isang partikular na site.</translation>
+<translation id="2621115761605608342">Payagan ang JavaScript para sa isang partikular na site.</translation>
+<translation id="8801436777607969138">I-block ang JavaScript para sa isang partikular na site.</translation>
+<translation id="8372893542064058268">Payagan ang Pag-sync sa Background para sa isang partikular na site.</translation>
+<translation id="358794129225322306">Payagan ang isang site na awtomatikong mag-download ng maraming file.</translation>
+<translation id="4008040567710660924">Payagan ang cookies para sa isang partikular na site.</translation>
+<translation id="8958424370300090006">Mag-block ng cookies para sa isang partikular na site.</translation>
+<translation id="7882806643839505685">Payagan ang tunog para sa isang partikular na site.</translation>
+<translation id="4468959413250150279">I-mute ang tunog para sa isang partikular na site.</translation>
+<translation id="1994173015038366702">URL ng site</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Paggamit</translation>
+<translation id="5804241973901381774">Mga Pahintulot</translation>
+<translation id="4278390842282768270">Pinapayagan</translation>
+<translation id="5677928146339483299">Naka-block</translation>
+<translation id="1984937141057606926">Pinapayagan, maliban ang third-party</translation>
+<translation id="7423098979219808738">Magtanong muna</translation>
+<translation id="8116925261070264013">Naka-mute</translation>
+<translation id="8300705686683892304">Pinapamahalaan ng app</translation>
+<translation id="6192792657125177640">Mga Pagbubukod</translation>
+<translation id="257931822824936280">Pinalawak - i-click upang i-collapse.</translation>
+<translation id="5100237604440890931">Naka-collapse - i-click upang palawakin</translation>
+<translation id="857943718398505171">Pinapayagan (inirerekomenda)</translation>
+<translation id="2913331724188855103">Payagan ang mga site na mag-save at magbasa ng data ng cookie (inirerekomenda)</translation>
+<translation id="7445411102860286510">Payagan ang mga site na awtomatikong mag-play ng mga naka-mute na video (inirerekomenda)</translation>
+<translation id="5335288049665977812">Payagan ang mga site na magpatakbo ng JavaScript (inirerekomenda)</translation>
+<translation id="5527111080432883924">Magtanong bago payagan ang mga site na i-read ang text at mga larawan mula sa clipboard (inirerekomenda)</translation>
+<translation id="6912998170423641340">I-block ang mga site sa pag-read ng text at mga larawan mula sa clipboard</translation>
+<translation id="7423538860840206698">Na-block sa pag-read ng clipboard</translation>
+<translation id="3955193568934677022">Pahintulutan ang mga site na mag-play ng pinoprotektahang content (inirerekomenda)</translation>
+<translation id="445467742685312942">Pahintulutan ang mga site na mag-play ng pinoprotektahang content</translation>
+<translation id="2107397443965016585">Magtanong bago pahintulutan ang mga site na mag-play ng pinoprotektahang content (inirerekomenda)</translation>
+<translation id="2910701580606108292">Magtanong bago payagan ang mga site na mag-play ng pinoprotektahang content</translation>
+<translation id="757524316907819857">I-block ang mga site sa pag-play ng pinoprotektahang content</translation>
+<translation id="3277252321222022663">Payagan ang mga site na i-access ang mga sensor (inirerekomenda)</translation>
+<translation id="5048398596102334565">Payagan ang mga site na i-access ang mga sensor ng paggalaw (inirerekomenda)</translation>
+<translation id="8816026460808729765">I-block ang mga site sa pag-access sa mga sensor</translation>
+<translation id="169515064810179024">I-block ang mga site sa pag-access sa mga sensor ng paggalaw</translation>
+<translation id="1660204651932907780">Payagan ang mga site na mag-play ng tunog (inirerekomenda)</translation>
+<translation id="3600792891314830896">I-mute ang mga site na nagpe-play ng tunog</translation>
+<translation id="1743802530341753419">Magtanong bago payagan ang mga site na kumonekta sa isang device (inirerekomenda)</translation>
+<translation id="851751545965956758">I-block ang mga site sa pagkonekta sa mga device</translation>
+<translation id="7141896414559753902">I-block ang pagpapakita ng mga site ng mga pop-up at pag-redirect (inirerekomenda)</translation>
+<translation id="5494752089476963479">I-block ang mga ad sa mga site na nagpapakita ng mga nakakasagabal o nakakapanlinlang na ad</translation>
+<translation id="3123473560110926937">Naka-block sa ilang site</translation>
+<translation id="965817943346481315">I-block kung nagpapakita ang site ng mga nakakasagabal o nakakapanlinlang na ad (inirerekomenda)</translation>
+<translation id="3386292677130313581">Magtanong bago payagan ang mga site na malaman ang iyong lokasyon (inirerekomenda)</translation>
+<translation id="9139068048179869749">Magtanong bago payagan ang mga site na magpadala ng mga notification (inirerekomenda)</translation>
+<translation id="4479647676395637221">Magtanong muna bago payagan ang mga site na gamitin ang iyong camera (inirerekomenda)</translation>
+<translation id="6992289844737586249">Magtanong muna bago payagan ang mga site na gamitin ang iyong mikropono (inirerekomenda)</translation>
+<translation id="2289270750774289114">Magtanong kapag gusto ng isang site na tumuklas ng mga Bluetooth device na nasa malapit (inirerekomenda)</translation>
+<translation id="7053983685419859001">I-block</translation>
+<translation id="7128222689758636196">Payagan para sa kasalukuyang search engine</translation>
+<translation id="7589445247086920869">I-block para sa kasalukuyang search engine</translation>
+<translation id="6388207532828177975">I-clear at i-reset</translation>
+<translation id="7999064672810608036">Sigurado ka bang gusto mong i-clear ang lahat ng lokal na data, kasama ang cookies, at i-reset ang lahat ng pahintulot para sa website na ito?</translation>
+<translation id="2822354292072154809">Sigurado ka bang gusto mong i-reset ang lahat ng pahintulot sa site para sa <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">I-clear ang naka-store na data</translation>
+<translation id="5902828464777634901">Made-delete ang lahat ng lokal na data na ini-store ng website na ito, kasama ang cookies.</translation>
+<translation id="119944043368869598">I-clear lahat</translation>
+<translation id="2490684707762498678">Pinapamahalaan ng <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Buksan ang mga setting ng notification</translation>
+<translation id="1404122904123200417">Naka-embed sa <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Lalabas dito ang mga file na na-save ng mga website</translation>
+<translation id="4181841719683918333">Mga Wika</translation>
+<translation id="2647434099613338025">Magdagdag ng wika</translation>
+<translation id="1952172573699511566">Magpapakita ang mga website ng text sa iyong gustong wika, kung posible.</translation>
+<translation id="8559990750235505898">Mag-alok na magsalin ng mga page sa iba pang wika</translation>
+<translation id="4719927025381752090">Mag-alok na magsalin</translation>
+<translation id="8156139159503939589">Anong mga wika ang binabasa mo?</translation>
+<translation id="5689516760719285838">Lokasyon</translation>
+<translation id="2440823041667407902">Access sa lokasyon</translation>
+<translation id="2023546461831060654">I-on ang mga pahintulot para sa Brave sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">I-on ang pahintulot para sa Brave sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Para payagan ang Brave na i-access ang iyong lokasyon, i-on din ang lokasyon sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Para payagang i-access ng Brave ang iyong camera, i-on din ang camera sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Para payagan ang Brave na magpadala sa iyo ng mga notification, i-on din ang mga notification sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Para payagang i-access ng Brave ang iyong mikropono, i-on din ang mikropono sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Naka-off ang access sa lokasyon para sa device na ito. I-on ito sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Naka-off din ang access sa lokasyon para sa device na ito. I-on ito sa <ph name="BEGIN_LINK"/>Mga Setting ng Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Camera</translation>
+<translation id="3227137524299004712">Mikropono</translation>
+<translation id="1647391597548383849">I-access ang iyong camera</translation>
+<translation id="945632385593298557">I-access ang iyong mikropono</translation>
+<translation id="6612358246767739896">Pinoprotektahang content</translation>
+<translation id="885701979325669005">Storage</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> ang naka-store na data</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Bawiin ang pahintulot ng device</translation>
+<translation id="4962975101802056554">Bawiin ang lahat ng pahintulot para sa device</translation>
+<translation id="6545864417968258051">Pag-scan ng Bluetooth</translation>
+<translation id="4411535500181276704">Lite mode</translation>
+<translation id="7821588508402923572">Lalabas dito ang mga natipid sa iyong data</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> ang natipid</translation>
+<translation id="8569404424186215731">simula noong <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Sa Lite mode, mas mabilis na nilo-load ng Brave ang mga page at mas kaunti nang 60 porsyento ang ginagamit nitong data.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> ang natipid sa data</translation>
+<translation id="7494974237137038751">natipid na data</translation>
+<translation id="6111020039983847643">nagamit na data</translation>
+<translation id="7413229368719586778">Petsa ng pagsisimula <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Petsa ng pagtatapos <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Pagbukud-bukurin ayon sa site</translation>
+<translation id="5864174910718532887">Mga detalye: Pinagbukud-bukod ayon sa pangalan ng site</translation>
+<translation id="116280672541001035">Nagamit</translation>
+<translation id="8349013245300336738">Pagbukud-bukurin ayon sa dami ng data na nagamit</translation>
+<translation id="6378173571450987352">Mga detalye: Pinagbukud-bukod ayon sa laki ng nagamit na data</translation>
+<translation id="2631006050119455616">Na-save</translation>
+<translation id="6643649862576733715">Pagbukud-bukurin ayon sa dami ng data na natipid</translation>
+<translation id="7302081693174882195">Mga detalye: Pinagbukud-bukod ayon sa laki ng natipid na data</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> ang nagamit</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> ang natipid</translation>
+<translation id="2156074688469523661">Mga natitirang site (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Iba pa</translation>
+<translation id="4913161338056004800">I-reset ang mga istatistika</translation>
+<translation id="1856325424225101786">I-reset ang Lite mode?</translation>
+<translation id="3658159451045945436">Kapag na-reset, mabubura ang iyong history ng pagtitipid ng data, kabilang ang listahan ng mga binisitang site.</translation>
+<translation id="3295530008794733555">Mag-browse nang mas mabilis. Gumamit ng mas kaunting data.</translation>
+<translation id="7340390500800578919">Sa Lite mode, mas mabilis na naglo-load ng mga page ang Brave at gumagamit ito ng hanggang 60 porsyentong mas kaunting data. Para i-optimize ang mga page na binibisita mo, ipinapadala ng Brave ang iyong trapiko sa web sa Brave Software. <ph name="BEGIN_LINK"/>Matuto pa<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">I-on ang Lite mode</translation>
+<translation id="4493497663118223949">Naka-on ang Lite mode</translation>
+<translation id="7559975015014302720">Naka-off ang Lite mode</translation>
+<translation id="7606077192958116810">Naka-on ang Lite mode. Pamahalaan ito sa Mga Setting.</translation>
+<translation id="4714588616299687897">Makatipid nang hanggang 60% ng iyong data</translation>
+<translation id="1006927014032731288">Io-optimize ng mga server ng Brave Software ang mga page na binibisita mo.</translation>
+<translation id="3257320067425202300">Nag-save ang Brave ng <ph name="MEGABYTES"/> MB para sa iyo</translation>
+<translation id="5813223329348543512">Nag-save ang Brave ng <ph name="GIGABYTES"/> GB para sa iyo</translation>
+<translation id="8266862848225348053">Lokasyon ng download</translation>
+<translation id="7077143737582773186">SD Card</translation>
+<translation id="7762668264895820836">SD card <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Itanong kung saan magse-save ng mga file</translation>
+<translation id="6192333916571137726">File ng download</translation>
+<translation id="1672586136351118594">Huwag ipakitang muli</translation>
+<translation id="2650751991977523696">I-download ulit ang file?</translation>
+<translation id="8664979001105139458">May ganito nang pangalan ng file</translation>
+<translation id="488187801263602086">Palitan ang pangalan ng file</translation>
+<translation id="5686790454216892815">Masyadong mahaba ang pangalan ng file</translation>
+<translation id="7454641608352164238">Walang sapat na espasyo</translation>
+<translation id="8972098258593396643">I-download sa default na folder?</translation>
+<translation id="804335162455518893">Hindi nakita ang SD card</translation>
+<translation id="7475688122056506577">Hindi nakita ang SD card. Maaaring nawawala ang ilan sa iyong mga file.</translation>
+<translation id="4198423547019359126">Walang available na lokasyon ng pag-download</translation>
+<translation id="8224471946457685718">Mag-download ng mga artikulo para sa iyo sa Wi-Fi</translation>
+<translation id="4970824347203572753">Hindi available sa iyong lokasyon</translation>
+<translation id="5500777121964041360">Maaaring hindi available sa iyong lokasyon</translation>
+<translation id="1173894706177603556">Pangalanang muli</translation>
+<translation id="1986685561493779662">May ganito nang pangalan</translation>
+<translation id="6441734959916820584">Masyadong mahaba ang pangalan</translation>
+<translation id="2923908459366352541">Di-wasto ang pangalan</translation>
+<translation id="7290209999329137901">Hindi available ang pag-rename</translation>
+<translation id="3334729583274622784">Baguhin ang file extension?</translation>
+<translation id="107147699690128016">Kung babaguhin mo ang file extension, puwedeng bumukas ang file sa ibang application at posible itong maging mapanganib sa iyong device.</translation>
+<translation id="8541922081612557424">Tungkol sa Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Nakalaan ang lahat ng karapatan.</translation>
+<translation id="1416550906796893042">Bersyon ng application</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Na-update <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operating system</translation>
+<translation id="3968054912784331254">Hindi na sinusuportahan ang mga update sa Brave para sa bersyong ito ng Android.</translation>
+<translation id="7665369617277396874">Magdagdag ng account</translation>
+<translation id="649070405679044769">Naka-sign in sa Brave Software bilang</translation>
+<translation id="6234515504547364178">Mag-sign out sa Brave</translation>
+<translation id="5324858694974489420">Mga Setting para sa Magulang</translation>
+<translation id="8920114477895755567">Hinihintay ang mga detalye ng mga magulang.</translation>
+<translation id="5512137114520586844">Pinapamahalaan ang account na ito ng <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Pinapamahalaan ang account na ito ng <ph name="PARENT_NAME_1"/> at <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Content</translation>
+<translation id="5403644198645076998">Ilang partikular na site lang ang payagan</translation>
+<translation id="8641930654639604085">Subukang i-block ang mga site na para sa mga nasa hustong gulang</translation>
+<translation id="5639724618331995626">Payagan ang lahat ng site</translation>
+<translation id="796823723482603597">Pinapagana ng Brave</translation>
+<translation id="6324034347079777476">Naka-disable ang pag-sync ng Android system</translation>
+<translation id="5127805178023152808">Naka-off ang pag-sync</translation>
+<translation id="7015203776128479407">Hindi natapos ang pag-set up ng unang pag-sync. Naka-off ang pag-sync.</translation>
+<translation id="2497852260688568942">Na-disable ng iyong administrator ang pag-sync</translation>
+<translation id="9100610230175265781">Kinakailangan ang passphrase</translation>
+<translation id="6108923351542677676">Kasalukuyang sine-setup…</translation>
+<translation id="4062305924942672200">Impormasyong legal</translation>
+<translation id="4256782883801055595">Mga lisensya ng open source</translation>
+<translation id="1138681184697033370">Mga Tuntunin ng Serbisyo ng Brave</translation>
+<translation id="7392539049993970338">Notification ng Privacy ng Brave</translation>
+<translation id="2677748264148917807">Umalis</translation>
+<translation id="5556459405103347317">I-reload</translation>
+<translation id="1623104350909869708">Pigilan ang pahinang ito sa paggawa ng mga karagdagang dialog</translation>
+<translation id="2968755619301702150">Viewer ng certificate</translation>
+<translation id="1360432990279830238">Mag-sign out at i-off ang pag-sync?</translation>
+<translation id="8581481290581777242">I-clear ang iyong data sa Brave sa device na ito?</translation>
+<translation id="1318865768845061710">Hindi na isi-sync ang iyong mga bookmark, history, mga password, at iba pang data ng Brave sa Brave Software Account mo</translation>
+<translation id="3325020657155065477">I-clear din ang iyong data ng Brave sa device na ito</translation>
+<translation id="6136448902816743006">Dahil nagsa-sign out ka sa isang account na pinapamahalaan ng <ph name="DOMAIN_NAME"/>, made-delete ang data ng Brave sa device na ito. Mananatili ito sa iyong Brave Software Account.</translation>
+<translation id="1853026300647876496">Nakikipag-ugnayan sa Brave Software. Maaari itong umabot nang isang minuto…</translation>
+<translation id="2328985652426384049">Hindi makapag-sign in</translation>
+<translation id="7723158744459952869">Masyadong matagal bago nakatugon ang Brave Software</translation>
+<translation id="4572422548854449519">Mag-sign in sa pinamamahalaang account</translation>
+<translation id="2689656545739939160">Nagsa-sign in ka gamit ang isang account na pinamamahalaan ng <ph name="MANAGED_DOMAIN"/> at binibigyan mo ang administrator nito ng kontrol sa iyong data sa Brave. Permanenteng mauugnay ang iyong data sa account na ito. Made-delete ang data mo sa device na ito kapag nag-sign out ka sa Brave, ngunit mananatili itong naka-store sa iyong Brave Software Account.</translation>
+<translation id="1749561566933687563">I-sync ang iyong mga bookmark</translation>
+<translation id="4242533952199664413">Buksan ang mga setting</translation>
+<translation id="1111673857033749125">Dito lalabas ang mga naka-save na bookmark sa iba mo pang mga device.</translation>
+<translation id="8636825310635137004">Upang makuha ang iyong mga tab mula sa iba mo pang mga device, i-on ang pag-sync.</translation>
+<translation id="3269956123044984603">Upang makuha ang iyong mga tab mula sa iba mo pang mga device, i-on ang "I-auto sync ang data" sa mga setting ng Android account.</translation>
+<translation id="5157964048453367290">Dito lalabas ang mga nabuksan mong tab sa Brave sa iba mo pang mga device.</translation>
+<translation id="4684427112815847243">I-sync lahat</translation>
+<translation id="2709516037105925701">AutoFill</translation>
+<translation id="8820817407110198400">Mga Bookmark</translation>
+<translation id="1644574205037202324">History</translation>
+<translation id="17513872634828108">Mga bukas na tab</translation>
+<translation id="1320169905922104972">Mga credit card at address na gumagamit ng Brave Software Pay</translation>
+<translation id="6337234675334993532">Pag-encrypt</translation>
+<translation id="6698801883190606802">Pamahalaan ang na-sync na data</translation>
+<translation id="3598578758776312506">I-encrypt ang mga password gamit ang mga kredensyal ng Brave Software</translation>
+<translation id="7810580217418711046">I-encrypt ang naka-sync na data gamit ang password sa Brave Software simula noong <ph name="TIME"/></translation>
+<translation id="8461694314515752532">I-encrypt ang naka-sync na data gamit ang iyong sariling passphrase sa pag-sync</translation>
+<translation id="2996291259634659425">Gumawa ng passphrase</translation>
+<translation id="5713644099811900409">Brave Software Account</translation>
+<translation id="8997474919031554666">Hindi kasama sa pag-encrypt ng passphrase ang mga paraan ng pagbabayad at address mula sa Brave Software Pay. Ang tao lang na may alam ng iyong passphrase ang makakabasa sa naka-encrypt mong data. Hindi ipinapadala sa Brave Software ang passphrase at hindi nito ito sino-store. Kung makalimutan mo ang iyong passphrase o gusto mong baguhin ang setting na ito, kakailanganin mong i-reset ang pag-sync. <ph name="BEGIN_LINK"/>Matuto pa<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Passphrase</translation>
+<translation id="7772032839648071052">Kumpirmahin ang passphrase</translation>
+<translation id="5304593522240415983">Hindi maaaring maging blangko ang field na ito</translation>
+<translation id="321773570071367578">Kung nakalimutan mo ang iyong passphrase o gusto mong baguhin ang setting na ito, <ph name="BEGIN_LINK"/>i-reset ang pag-sync<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Hindi nagtutugma ang mga passphrase</translation>
+<translation id="5149495116300586333">Hindi kasama sa pag-encrypt ng passphrase ang mga paraan ng pagbabayad at address mula sa Brave Software Pay.
+
+Para baguhin ang setting na ito, <ph name="BEGIN_LINK"/>i-reset ang pag-sync<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Maling passphrase</translation>
+<translation id="5414836363063783498">Vine-verify…</translation>
+<translation id="6846298663435243399">Naglo-load…</translation>
+<translation id="5517095782334947753">Mayroon kang mga bookmark, history, password at iba pang mga setting mula sa <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Pagsamahin ang aking data</translation>
+<translation id="688738109438487280">Idagdag ang kasalukuyang data sa <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Panatilihing hiwalay ang aking data</translation>
+<translation id="1145536944570833626">I-delete ang kasalukuyang data.</translation>
+<translation id="1993768208584545658">Gustong makipagpares ng <ph name="SITE"/></translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Humingi ng tulong<ph name="END_LINK"/> habang nag-ii-scan ng mga device…</translation>
+<translation id="5817918615728894473">Ipares</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Humingi ng tulong<ph name="END_LINK1"/> o <ph name="BEGIN_LINK2"/>muling mag-scan<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Walang nahanap na tugmang device</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>I-on ang Bluetooth<ph name="END_LINK"/> upang payagan ang pagpapares</translation>
+<translation id="998321811308652668">Hindi ma-on ng Brave ang Bluetooth adapter</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Humingi ng tulong<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Kailangan ng Brave ng access sa lokasyon upang makapag-scan at makakita ng mga device. <ph name="BEGIN_LINK"/>I-update ang mga pahintulot<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Kailangan ng Brave ng access sa lokasyon upang magkapag-scan ng mga device. Ang access sa lokasyon ay <ph name="BEGIN_LINK"/>naka-off para sa device na ito<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Kailangan ng Brave ng access sa lokasyon upang makapag-scan ng mga device. <ph name="BEGIN_LINK1"/>I-update ang mga pahintulot<ph name="END_LINK1"/>. Ang access sa lokasyon ay <ph name="BEGIN_LINK2"/>naka-off din para sa device na ito<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Nakakonektang Device</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Antas ng Lakas ng Signal: # bar}one{Antas ng Lakas ng Signal: # bar}other{Antas ng Lakas ng Signal: # na bar}}</translation>
+<translation id="5230560987958996918">Gustong mag-scan ng <ph name="SITE"/> para sa mga Bluetooth device na nasa malapit. Nahanap ang mga sumusunod na device:</translation>
+<translation id="8368027906805972958">Hindi alam o hindi sinusuportahang device (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Hindi gumagana ang pag-sync</translation>
+<translation id="1810845389119482123">Hindi natapos ang paunang pag-set up ng pag-sync</translation>
+<translation id="3235722914093408050">Buksan ang mga setting ng Android at muling i-enable ang Android system sync upang simulan ang Brave sync</translation>
+<translation id="3367813778245106622">Mag-sign in muli upang simulan ang pag-sync</translation>
+<translation id="974555521953189084">Ilagay ang iyong passphrase upang simulan ang pag-sync</translation>
+<translation id="2997266899014181325">Para simulan ang pag-sync, i-on ang "I-sync ang iyong data sa Brave."</translation>
+<translation id="8260126382462817229">Subukang mag-sign in muli</translation>
+<translation id="5919204609460789179">I-update ang <ph name="PRODUCT_NAME"/> upang simulan ang pag-sync</translation>
+<translation id="397583555483684758">Huminto ang pag-sync</translation>
+<translation id="1966710179511230534">Paki-update ang iyong mga detalye sa pag-sign in.</translation>
+<translation id="7063006564040364415">Hindi makakonekta sa server ng pag-sync.</translation>
+<translation id="7942131818088350342">Luma na ang <ph name="PRODUCT_NAME"/>.</translation>
+<translation id="4170011742729630528">Hindi available ang serbisyo; subukang muli sa ibang pagkakataon.</translation>
+<translation id="7947953824732555851">I-accept, mag-sign in</translation>
+<translation id="8583805026567836021">Kini-clear ang data ng account</translation>
+<translation id="8310344678080805313">Mga karaniwang tab</translation>
+<translation id="5748802427693696783">Lumipat sa mga karaniwang tab</translation>
+<translation id="7998918019931843664">Muling buksan ang isinarang tab</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, tab</translation>
+<translation id="4452411734226507615">Isara ang tab na <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">May mga opsyon malapit sa ibaba ng screen</translation>
+<translation id="4060598801229743805">Available ang mga opsyon malapit sa bandang itaas ng screen</translation>
+<translation id="2810645512293415242">Pinasimple ang page upang ma-save ang data at mag-load nang mas mabilis.</translation>
+<translation id="3985215325736559418">Gusto mo bang muling i-download ang <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Gusto mo bang simulang muli ang pag-download sa <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">I-download</translation>
+<translation id="545042621069398927">Pinapabilis ang iyong pag-download.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Nagda-download ng file.}one{Nagda-download ng # file.}other{Nagda-download ng # na file.}}</translation>
+<translation id="543509235395288790">Nagda-download ng <ph name="COUNT"/> (na) file (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Nagda-download ng file (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Tapos na ang 1 pag-download.}one{Tapos na ang # pag-download.}other{Tapos na ang # na pag-download.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ang hindi na-download.}one{# ang hindi na-download.}other{# ang hindi na-download.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Nakabinbin ang 1 pag-download.}one{Nakabinbin ang # pag-download.}other{Nakabinbin ang # na pag-download.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Button ng <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Halos tapos na!</translation>
+<translation id="3960299545138990065">I-restart ang Brave</translation>
+<translation id="3771001275138982843">Hindi ma-download ang update</translation>
+<translation id="3888648114124182147">Dina-download ang Update sa Brave…</translation>
+<translation id="1705567146636171298">I-update ang Brave</translation>
+<translation id="6195417478702700398">Para sa pinakamagandang karanasan sa pag-browse, buksan para i-update ang Brave</translation>
+<translation id="3512968675351418494">Para makita ang web sa iyong wika, kunin ang pinakabagong bersyon ng Brave</translation>
+<translation id="6427112570124116297">I-translate ang Web</translation>
+<translation id="1379423114029199501">I-update para makuha ang iyong wika sa pinakabagong bersyon ng Brave</translation>
+<translation id="5684874026226664614">Oops. Hindi maisalin ang pahinang ito.</translation>
+<translation id="6831043979455480757">Isalin</translation>
+<translation id="1285320974508926690">Huwag isalin kailanman ang site na ito</translation>
+<translation id="773466115871691567">Palaging isalin ang mga page sa <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Huwag kailanman isalin ang mga page sa <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Higit pang wika</translation>
+<translation id="290376772003165898">Hindi nakasalin ang page sa <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Simula ngayon ay isasalin na sa <ph name="TARGET_LANGUAGE"/> ang mga page na nasa <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Hindi isasalin ang mga page na nasa <ph name="LANGUAGE"/></translation>
+<translation id="5447765697759493033">Hindi isasalin ang site na ito</translation>
+<translation id="4880127995492972015">Isalin…</translation>
+<translation id="641643625718530986">I-print…</translation>
+<translation id="8909135823018751308">Ibahagi…</translation>
+<translation id="4996978546172906250">Ibahagi gamit ang</translation>
+<translation id="6333140779060797560">Ibahagi sa pamamagitan ng <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Nagkaproblema sa pag-print sa pahina. Pakisubukang muli.</translation>
+<translation id="3254409185687681395">I-bookmark ang page na ito</translation>
+<translation id="497421865427891073">Sumulong</translation>
+<translation id="813082847718468539">Tingnan ang impormasyon ng site</translation>
+<translation id="2532336938189706096">View ng Web</translation>
+<translation id="6005538289190791541">Iminumungkahing password</translation>
+<translation id="4634124774493850572">Gamitin ang password</translation>
+<translation id="8285489906452138776">Kailangan ng Brave ng pahintulot na i-access ang iyong camera para sa site na ito.</translation>
+<translation id="320189792589364011">Kailangan ng Brave ng pahintulot na i-access ang iyong mikropono para sa site na ito.</translation>
+<translation id="7988136689212463100">Kailangan ng Brave ng pahintulot na i-access ang iyong camera at mikropono para sa site na ito.</translation>
+<translation id="4931190655840828017">Kailangan ng Brave ng access sa iyong lokasyon upang ibahagi ang lokasyon mo sa site na ito.</translation>
+<translation id="3088191967551450609">Kailangan ng Brave ng access sa storage para mag-download ng mga file.</translation>
+<translation id="8942627711005830162">Buksan sa ibang window</translation>
+<translation id="4195643157523330669">Buksan sa bagong tab</translation>
+<translation id="1100066534610197918">Buksan sa bagong tab sa grupo</translation>
+<translation id="4860895144060829044">Tawagan</translation>
+<translation id="6896758677409633944">Copy</translation>
+<translation id="8393700583063109961">Ipadala ang mensahe</translation>
+<translation id="3557336313807607643">Idagdag sa mga contact</translation>
+<translation id="4269820728363426813">Kopyahin ang address ng link</translation>
+<translation id="1206892813135768548">Kopyahin ang text ng link</translation>
+<translation id="1204037785786432551">Link sa pag-download</translation>
+<translation id="6864459304226931083">I-download ang larawan</translation>
+<translation id="8209050860603202033">Buksan ang larawan</translation>
+<translation id="8073388330009372546">Buksan ang larawan sa bagong tab</translation>
+<translation id="6649642165559792194">I-preview ang larawang <ph name="BEGIN_NEW"/>Bago<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">I-load ang larawan</translation>
+<translation id="3845332215609790146">Hanapin gamit ang Brave Software Lens <ph name="BEGIN_NEW"/>Bago<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Hanapin sa <ph name="SEARCH_ENGINE"/> ang larawan</translation>
+<translation id="3384347053049321195">Magbahagi ng larawan</translation>
+<translation id="5833984609253377421">Ibahagi ang link</translation>
+<translation id="6475951671322991020">I-download ang video</translation>
+<translation id="2317945146070194624">Buksan sa bagong tab ng Brave</translation>
+<translation id="7975379999046275268">I-preview ang page na <ph name="BEGIN_NEW"/>Bago<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Nire-refresh ang page</translation>
+<translation id="36525718899759834">Kunin ang app mula sa Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Madilim</translation>
+<translation id="1807246157184219062">Maliwanag</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Pumili ng tab upang mag-beam</translation>
+<translation id="8719023831149562936">Hindi ma-beam ang kasalukuyang tab</translation>
+<translation id="2139186145475833000">Idagdag sa Home screen</translation>
+<translation id="4616150815774728855">Buksan ang <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Hindi mabuksan ang app</translation>
+<translation id="5129038482087801250">I-install ang web app</translation>
+<translation id="3789841737615482174">Mag-install</translation>
+<translation id="4665282149850138822">Idinagdag ang <ph name="NAME"/> sa iyong Home screen</translation>
+<translation id="7333031090786104871">Nagdaragdag pa rin ng nakaraang site</translation>
+<translation id="1036727731225946849">Idinaragdag ang <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Idinagdag sa Home screen</translation>
+<translation id="2146738493024040262">Buksan ang Instant App</translation>
+<translation id="7016516562562142042">Pinapayagan para sa kasalukuyang search engine</translation>
+<translation id="6177111841848151710">Naka-block para sa kasalukuyang search engine</translation>
+<translation id="145097072038377568">Naka-off sa Mga Setting ng Android</translation>
+<translation id="8007176423574883786">Naka-off para sa device na ito</translation>
+<translation id="164269334534774161">Tinitingnan mo ang offline na kopya ng page na ito mula sa <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Naka-offline ang page na ito mula noong <ph name="CREATION_TIME"/> at maaaring iba ito sa online na bersyon.</translation>
+<translation id="8840953339110955557">Maaaring iba ang page na ito sa online na bersyon.</translation>
+<translation id="6405300764336705484">Ang content na ito ay mula sa <ph name="DOMAIN_NAME"/>, na ipinadala ng Brave Software.</translation>
+<translation id="1006017844123154345">Buksan Online</translation>
+<translation id="3326636747541519688">Hatid ng Brave Software ang lite na page</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>I-load ang orihinal na page<ph name="END_LINK"/> mula sa <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Kung madalas mo itong makita, subukan ang <ph name="BEGIN_LINK"/>mga suhestyon<ph name="END_LINK"/> na ito.</translation>
+<translation id="8748850008226585750">Nakatago ang mga content</translation>
+<translation id="3810973564298564668">Mamahala</translation>
+<translation id="5199929503336119739">Profile sa trabaho</translation>
+<translation id="528192093759286357">I-drag mula sa itaas at pindutin ang button na bumalik upang lumabas sa full screen.</translation>
+<translation id="2836148919159985482">Pindutin ang button na bumalik upang lumabas sa full screen.</translation>
+<translation id="3967822245660637423">Tapos na ang pag-download</translation>
+<translation id="2434158240863470628">Tapos nang mag-download <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Hindi na-download</translation>
+<translation id="1384959399684842514">Na-pause ang pag-download</translation>
+<translation id="1671236975893690980">Nakabinbin ang pag-download...</translation>
+<translation id="5561549206367097665">Naghihintay ng network…</translation>
+<translation id="5864419784173784555">Naghihintay ng isa pang download…</translation>
+<translation id="6461962085415701688">Hindi mabuksan ang file</translation>
+<translation id="1178581264944972037">I-pause</translation>
+<translation id="8200772114523450471">Resume</translation>
+<translation id="1409879593029778104">Pinigilan ang pag-download sa <ph name="FILE_NAME"/> dahil may ganitong file na sa kasalukuyan.</translation>
+<translation id="3387650086002190359">Hindi na-download ang <ph name="FILE_NAME"/> dahil sa mga error sa file system.</translation>
+<translation id="6482749332252372425">Hindi na-download ang <ph name="FILE_NAME"/> dahil kulang ang espasyo sa storage.</translation>
+<translation id="7619072057915878432">Hindi na-download ang <ph name="FILE_NAME"/> dahil sa mga problema sa network.</translation>
+<translation id="1477626028522505441">Hindi na-download ang <ph name="FILE_NAME"/> dahil sa mga isyu sa server.</translation>
+<translation id="3692944402865947621">Hindi na-download ang <ph name="FILE_NAME"/> dahil hindi maabot ang lokasyon ng storage.</translation>
+<translation id="604996488070107836">Hindi na-download ang <ph name="FILE_NAME"/> dahil sa isang hindi alam na error.</translation>
+<translation id="6738867403308150051">Nagda-download...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB ang na-download</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB ang na-download</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB ang na-download</translation>
+<translation id="9204836675896933765">1 file ang natitira</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> (na) file ang natitira</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> file ang na-download}one{<ph name="FILES_DOWNLOADED_MANY"/> file ang na-download}other{<ph name="FILES_DOWNLOADED_MANY"/> na file ang na-download}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> (na) araw na lang ang natitira</translation>
+<translation id="8190358571722158785">1 araw na lang ang natitira</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> (na) oras na lang ang natitira</translation>
+<translation id="510275257476243843">1 oras na lang ang natitira</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> (na) minuto na lang ang natitira</translation>
+<translation id="3236059992281584593">1 minuto na lang ang natitira</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> (na) segundo na lang ang natitira</translation>
+<translation id="2781151931089541271">1 segundo na lang ang natitira</translation>
+<translation id="3303414029551471755">Magpatuloy na i-download ang content?</translation>
+<translation id="8617240290563765734">Buksan ang iminumungkahing URL na tinukoy sa na-download na content?</translation>
+<translation id="1373696734384179344">Hindi sapat ang memory upang ma-download ang napiling content.</translation>
+<translation id="5271967389191913893">Hindi mabuksan ng device ang content na ida-download.</translation>
+<translation id="883806473910249246">Nagka-error habang dina-download ang content.</translation>
+<translation id="5626134646977739690">Pangalan:</translation>
+<translation id="7963646190083259054">Vendor:</translation>
+<translation id="3414952576877147120">Laki:</translation>
+<translation id="7375125077091615385">Uri:</translation>
+<translation id="5765780083710877561">Paglalarawan:</translation>
+<translation id="4881695831933465202">Buksan</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB ang available</translation>
+<translation id="8051695050440594747">Available ang <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB ang available</translation>
+<translation id="5793665092639000975">Gumagamit ng <ph name="SPACE_USED"/> ng <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Lahat</translation>
+<translation id="4988526792673242964">Mga Page</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Mga Larawan</translation>
+<translation id="8250920743982581267">Mga Dokumento</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# File}one{# File}other{# na File}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Larawan}one{# Larawan}other{# na Larawan}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}one{# Video}other{# na Video}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Audio file}one{# Audio file}other{# na Audio file}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Page}one{# Page}other{# na Page}}</translation>
+<translation id="5456381639095306749">I-download ang page</translation>
+<translation id="2394602618534698961">Lalabas dito ang mga file na dina-download mo</translation>
+<translation id="7810647596859435254">Buksan gamit ang…</translation>
+<translation id="5655963694829536461">Maghanap sa iyong mga download</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Aking Mga File</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Lalabas dito ang mga artikulong mababasa mo kahit offline ka</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# oras}one{# oras}other{# na oras}}</translation>
+<translation id="5853623416121554550">naka-pause</translation>
+<translation id="8965591936373831584">nakabinbin</translation>
+<translation id="2779651927720337254">nabigo</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Ngayon Lang</translation>
+<translation id="4000212216660919741">Offline Home</translation>
+<translation id="9133397713400217035">I-explore Offline</translation>
+<translation id="968900484120156207">Lalabas dito ang mga page na binibisita mo</translation>
+<translation id="7882131421121961860">Walang nakitang history</translation>
+<translation id="3549657413697417275">Hanapin sa iyong history</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Unang Karanasan sa Pagtakbo ng Brave</translation>
+<translation id="2700285883409956633">Kapag ginamit mo ang application na ito, ang ibig sabihin, sumasang-ayon ka sa <ph name="BEGIN_LINK1"/>Mga Tuntunin ng Serbisyo<ph name="END_LINK1"/> at <ph name="BEGIN_LINK2"/>Patakaran sa Privacy<ph name="END_LINK2"/> ng Brave.</translation>
+<translation id="1640714894372474981">Kapag ginamit ang application na ito, nangangahulugan ito na sumasang-ayon ka sa <ph name="BEGIN_LINK1"/>Mga Tuntunin ng Serbisyo <ph name="END_LINK1"/> at <ph name="BEGIN_LINK2"/>Notification ng Privacy<ph name="END_LINK2"/> ng Brave, at sa <ph name="BEGIN_LINK3"/>Notification ng Privacy para sa Mga Brave Software Account na Pinamamahalaan gamit ang Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Bubukas ang <ph name="APP_NAME"/> sa Brave. Sa pamamagitan ng pagpapatuloy, sumasang-ayon ka sa <ph name="BEGIN_LINK1"/>Mga Tuntunin ng Serbisyo<ph name="END_LINK1"/> at <ph name="BEGIN_LINK2"/>Notification ng Privacy<ph name="END_LINK2"/> ng Brave.</translation>
+<translation id="5071615083211946659">Bubukas ang <ph name="APP_NAME"/> sa Brave. Sa pamamagitan ng pagpapatuloy, sumasang-ayon ka sa <ph name="BEGIN_LINK1"/>Mga Tuntunin ng Serbisyo<ph name="END_LINK1"/> at <ph name="BEGIN_LINK2"/>Notification ng Privacy<ph name="END_LINK2"/> ng Brave, at sa <ph name="BEGIN_LINK3"/>Notification ng Privacy para sa Mga Brave Software Account na Pinamamahalaan gamit ang Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Tulungang mapahusay ang Brave sa pamamagitan ng pagpapadala sa Brave Software ng mga istatistika ng paggamit at ulat ng pag-crash.</translation>
+<translation id="3518985090088779359">Tanggapin, magpatuloy</translation>
+<translation id="7207456302801184289">Welcome sa Brave</translation>
+<translation id="704822250101715322">Hinihintay ang Mga Serbisyo ng Brave Software Play na matapos sa pag-update</translation>
+<translation id="1231733316453485619">I-on ang pag-sync?</translation>
+<translation id="5132942445612118989">I-sync ang iyong mga password, history, at higit pa sa lahat ng device</translation>
+<translation id="5736731321935944068">Maaaring gamitin ng Brave Software ang iyong history para i-personalize ang Search, mga ad, at iba pang serbisyo ng Brave Software</translation>
+<translation id="4013614219085422040">Maaaring gamitin ng Brave Software ang iyong history para i-personalize ang Search at iba pang serbisyo ng Brave Software</translation>
+<translation id="5581519193887989363">Mapipili mo kung ano ang isi-sync anumang oras sa <ph name="BEGIN_LINK1"/>mga setting<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Oo, sali ako</translation>
+<translation id="2410754283952462441">Pumili ng account</translation>
+<translation id="2227444325776770048">Magpatuloy bilang si <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Hindi si <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Para makuha ang iyong mga bookmark sa lahat ng device mo, i-on ang pag-sync</translation>
+<translation id="2818669890320396765">Para makuha ang iyong mga bookmark sa lahat ng device mo, mag-sign in at i-on ang pag-sync</translation>
+<translation id="6003646045106347985">Para makakuha ng naka-personalize na content na iminumungkahi ng Brave Software, i-on ang pag-sync</translation>
+<translation id="8494430740943879273">Para makakuha ng naka-personalize na content na iminumungkahi ng Brave Software, mag-sign in at i-on ang pag-sync</translation>
+<translation id="5862731021271217234">Para makuha ang iyong mga tab mula sa iba mo pang device, i-on ang pag-sync</translation>
+<translation id="3568688522516854065">Para makuha ang iyong mga tab sa iba mo pang device, mag-sign in at i-on ang pag-sync</translation>
+<translation id="1208340532756947324">Para mag-sync at mag-personalize sa mga device, i-on ang pag-sync</translation>
+<translation id="4472118726404937099">Para mag-sync at mag-personalize sa mga device, mag-sign in at i-on ang pag-sync</translation>
+<translation id="2426805022920575512">Pumili ng ibang account</translation>
+<translation id="6790428901817661496">I-play</translation>
+<translation id="1272079795634619415">Stop</translation>
+<translation id="2874939134665556319">Nakaraang track</translation>
+<translation id="4046123991198612571">Susunod na track</translation>
+<translation id="3859306556332390985">Maghanap nang pasulong</translation>
+<translation id="8441146129660941386">Maghanap nang pabalik</translation>
+<translation id="6706288973712894588">Kasalukuyan kang offline.\n<ph name="BEGIN_LINK"/>I-explore ang iyong offline na feed.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Mga kamakailang tab</translation>
+<translation id="8497726226069778601">Walang makikita dito... sa ngayon</translation>
+<translation id="5423934151118863508">Lalabas dito ang mga page na madalas mong bisitahin</translation>
+<translation id="6127379762771434464">Inalis ang item</translation>
+<translation id="4605958867780575332">Naalis na item: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Iba pang device</translation>
+<translation id="4738836084190194332">Huling na-sync: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minuto ang nakalipas}one{# minuto ang nakalipas}other{# na minuto ang nakalipas}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# oras ang nakalipas}one{# oras ang nakalipas}other{# na oras ang nakalipas}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# araw ang nakalipas}one{# araw ang nakalipas}other{# na araw ang nakalipas}}</translation>
+<translation id="2762000892062317888">ngayon lang</translation>
+<translation id="1407135791313364759">Buksan lahat</translation>
+<translation id="1209206284964581585">Itago sa ngayon</translation>
+<translation id="129553762522093515">Kamakailang isinara</translation>
+<translation id="8413126021676339697">Ipakita ang buong history</translation>
+<translation id="7876243839304621966">Alisin lahat</translation>
+<translation id="8487700953926739672">Available sa offline</translation>
+<translation id="5224771365102442243">May video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Matuto pa<ph name="END_LINK"/> tungkol sa iminumungkahing content</translation>
+<translation id="7542481630195938534">Hindi makakuha ng mga suhestyon</translation>
+<translation id="5013696553129441713">Walang bagong suhestyon</translation>
+<translation id="1736419249208073774">I-explore</translation>
+<translation id="7444811645081526538">Higit pang kategorya</translation>
+<translation id="6709133671862442373">Balita</translation>
+<translation id="1264974993859112054">Pampalakasan</translation>
+<translation id="9139318394846604261">Shopping</translation>
+<translation id="3912508018559818924">Hinahanap ang pinakamahusay mula sa web…</translation>
+<translation id="526421993248218238">Hindi ma-load ang page na ito</translation>
+<translation id="614940544461990577">Subukang:</translation>
+<translation id="3288003805934695103">I-reload ang page</translation>
+<translation id="2353636109065292463">Sinusuri ang iyong koneksyon sa internet</translation>
+<translation id="2858138569776157458">Top na sites</translation>
+<translation id="8364299278605033898">Tingnan ang mga sikat na website</translation>
+<translation id="1171770572613082465">Tingnan ang mga sikat na website sa pamamagitan ng pag-tap sa button na "Mga nangungunang site"</translation>
+<translation id="5233638681132016545">Bagong tab</translation>
+<translation id="4521874409998847950">Mula sa <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>ihinatid ng Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">May available na mas bagong bersyon</translation>
+<translation id="4058091506841967397">Hindi ma-update: Brave</translation>
+<translation id="6316139424528454185">Hindi sinusuportahan ang bersyon ng Android</translation>
+<translation id="6989267951144302301">Hindi ma-download</translation>
+<translation id="624789221780392884">Handa na ang pag-update</translation>
+<translation id="1549000191223877751">Lumipat sa ibang window</translation>
+<translation id="7481312909269577407">Sumulong</translation>
+<translation id="4084682180776658562">Bookmark</translation>
+<translation id="6437478888915024427">Impormasyon ng page</translation>
+<translation id="7180611975245234373">I-refresh</translation>
+<translation id="4913169188695071480">Ihinto ang pag-refresh</translation>
+<translation id="1829244130665387512">Hanapin sa page</translation>
+<translation id="6593061639179217415">Desktop site</translation>
+<translation id="9063523880881406963">I-off ang Hilingin ang site sa desktop</translation>
+<translation id="2038563949887743358">I-on ang Hilingin ang site sa desktop</translation>
+<translation id="2433507940547922241">Hitsura</translation>
+<translation id="983192555821071799">Isara ang lahat ng tab</translation>
+<translation id="1310482092992808703">Igrupo ang mga tab</translation>
+<translation id="7725024127233776428">Lalabas dito ang mga page na iyong.na-bookmark</translation>
+<translation id="4404568932422911380">Walang bookmark</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> bookmark}one{<ph name="BOOKMARKS_COUNT_MANY"/> bookmark}other{<ph name="BOOKMARKS_COUNT_MANY"/> na bookmark}}</translation>
+<translation id="3739899004075612870">Naka-bookmark sa <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Naka-bookmark</translation>
+<translation id="4452548195519783679">Na-bookmark sa <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Hindi naidagdag ang bookmark.</translation>
+<translation id="2842985007712546952">Pangunahing folder</translation>
+<translation id="9065203028668620118">I-edit</translation>
+<translation id="4405224443901389797">Ilipat sa…</translation>
+<translation id="5170568018924773124">Ipinakita sa folder</translation>
+<translation id="8035133914807600019">Bagong folder…</translation>
+<translation id="4532845899244822526">Pumili ng folder</translation>
+<translation id="6627583120233659107">I-edit ang folder</translation>
+<translation id="1197267115302279827">Ilipat ang mga bookmark</translation>
+<translation id="6963766334940102469">Mag-delete ng mga bookmark</translation>
+<translation id="4351244548802238354">Isara ang dialog</translation>
+<translation id="451872707440238414">Maghanap sa iyong mga bookmark</translation>
+<translation id="8901170036886848654">Walang nakitang bookmark</translation>
+<translation id="6404511346730675251">I-edit ang bookmark</translation>
+<translation id="3894427358181296146">Magdagdag ng folder</translation>
+<translation id="5327248766486351172">Pangalan</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Folder</translation>
+<translation id="5161254044473106830">Kailangan ng pamagat</translation>
+<translation id="2996809686854298943">Kinakailangan ang URL</translation>
+<translation id="2536728043171574184">Tinitingnan ang isang offline na kopya ng page na ito</translation>
+<translation id="4698034686595694889">Tingnan offline sa <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> at higit pang site</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Ilo-load ng Brave ang iyong page kapag handa na}one{Ilo-load ng Brave ang iyong mga page kapag handa na}other{Ilo-load ng Brave ang iyong mga page kapag handa na}}</translation>
+<translation id="6811034713472274749">Maaari nang tingnan ang page</translation>
+<translation id="4561979708150884304">Walang koneksyon</translation>
+<translation id="8274165955039650276">Tingnan ang mga download</translation>
+<translation id="2082238445998314030">Resulta <ph name="RESULT_NUMBER"/> sa <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Walang mga resulta</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Walang available na naka-enable na paghahanap gamit ang boses</translation>
+<translation id="7191430249889272776">Binuksan ang tab sa background.</translation>
+<translation id="8445059357334030806">Buksan sa Brave</translation>
+<translation id="4720023427747327413">Buksan sa <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Buksan sa browser</translation>
+<translation id="1113597929977215864">Ipakita ang pinasimpleng view</translation>
+<translation id="1513352483775369820">Bookmark at history ng web</translation>
+<translation id="4939482511480190003">Tumulong na pahusayin ang Brave. <ph name="BEGIN_LINK"/>Sagutan ang survey<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Bumalik</translation>
+<translation id="5596627076506792578">Higit pang opsyon</translation>
+<translation id="3522247891732774234">May available na update. Higit pang mga opsyon</translation>
+<translation id="6773423637732432200">Hindi ma-update ang Brave. Higit pang opsyon</translation>
+<translation id="3328801116991980348">Impormasyon ng site</translation>
+<translation id="5391532827096253100">Hindi secure ang iyong koneksyon sa site na ito. Impormasyon ng site</translation>
+<translation id="6206551242102657620">Secure ang koneksyon. Impormasyon ng site</translation>
+<translation id="6963642900430330478">Mapanganib ang page na ito. Impormasyon ng site</translation>
+<translation id="9070377983101773829">Simulan ang paghahanap gamit ang boses</translation>
+<translation id="8676374126336081632">I-clear ang input</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> nakabukas na tab, i-tap para lumipat ng tab}one{<ph name="OPEN_TABS_MANY"/> nakabukas na tab, i-tap para lumipat ng tab}other{<ph name="OPEN_TABS_MANY"/> na nakabukas na tab, i-tap para lumipat ng tab}}</translation>
+<translation id="2369533728426058518">magbukas ng mga tab</translation>
+<translation id="7071521146534760487">Pamahalaan ang account</translation>
+<translation id="932327136139879170">Home</translation>
+<translation id="2707726405694321444">I-refresh ang page</translation>
+<translation id="2891154217021530873">Ihinto ang pag-load ng page</translation>
+<translation id="6710213216561001401">Nakaraan</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Napiling Tab</translation>
+<translation id="2268044343513325586">Pinuhin</translation>
+<translation id="7846076177841592234">Kanselahin ang pinili</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> ang napili.  Available ang mga opsyon malapit sa itaas ng screen</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> ang napili</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Ibahagi ang 1 piniling item}one{Ibahagi ang # piniling item}other{Ibahagi ang # na piniling item}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Alisin ang 1 piniling item}one{Alisin ang # piniling item}other{Alisin ang # na piniling item}}</translation>
+<translation id="1283039547216852943">I-tap upang palawakin</translation>
+<translation id="5962718611393537961">I-tap upang i-collapse</translation>
+<translation id="8076492880354921740">Mga Tab</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ang napili}one{# ang napili}other{# ang napili}}</translation>
+<translation id="6818926723028410516">Pumili ng mga item</translation>
+<translation id="4797039098279997504">Pindutin upang bumalik sa <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">I-tap para pumunta sa site</translation>
+<translation id="429312253194641664">May site na nagpe-play ng media</translation>
+<translation id="4958708863221495346">Ibinabahagi ng <ph name="URL_OF_THE_CURRENT_TAB"/> ang iyong screen</translation>
+<translation id="8833831881926404480">Ibinabahagi ng isang site ang iyong screen</translation>
+<translation id="9086455579313502267">Hindi magawang ma-access ang network</translation>
+<translation id="938850635132480979">Error: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Buksan sa <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Buksan sa app na mga mapa</translation>
+<translation id="7698359219371678927">Gumawa ng email sa <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Gumawa ng email</translation>
+<translation id="5665379678064389456">Gumawa ng event sa <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Gumawa ng event</translation>
+<translation id="2111511281910874386">Pumunta sa page</translation>
+<translation id="3988466920954086464">Tingnan ang mga instant na resulta ng paghahanap sa panel na ito</translation>
+<translation id="2744248271121720757">Mag-tap ng salita upang hanapin agad ito o tingnan ang mga nauugnay na pagkilos</translation>
+<translation id="9155898266292537608">Makakapaghanap ka rin gamit ang mabilisang pag-tap sa isang salita</translation>
+<translation id="3232754137068452469">Web App</translation>
+<translation id="1430915738399379752">I-print</translation>
+<translation id="3775705724665058594">Ipadala sa iyong mga device</translation>
+<translation id="6364438453358674297">Alisin ang suhestyon mula sa history?</translation>
+<translation id="213279576345780926">Isinarang <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> (na) tab ang isinara</translation>
+<translation id="3211426585530211793">Na-delete ang <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> (na) bookmark ang na-delete</translation>
+<translation id="3819178904835489326">Na-delete ang <ph name="NUMBER_OF_DOWNLOADS"/> (na) pag-download</translation>
+<translation id="1248710015876067820">Hindi sinusuportahang bilang ng mga instance ng Brave.</translation>
+<translation id="4259722352634471385">Naka-block ang navigation: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Hindi gumagana ang navigation: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Isara ang tab</translation>
+<translation id="7772375229873196092">Isara ang <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">History ng pag-navigate</translation>
+<translation id="9169507124922466868">Nakabukas nang kalahati ang history ng pag-navigate</translation>
+<translation id="1327257854815634930">Nakabukas ang history ng pag-navigate</translation>
+<translation id="8788265440806329501">Nakasara ang history ng pag-navigate</translation>
+<translation id="7482656565088326534">Tab na preview</translation>
+<translation id="8427875596167638501">Nakabukas nang kalahati ang tab na preview</translation>
+<translation id="9102803872260866941">Nakabukas ang tab na preview</translation>
+<translation id="2942036813789421260">Nakasara ang tab na preview</translation>
+<translation id="6355102470683871794">Storage ng <ph name="APP_NAME"/> sa Brave Software</translation>
+<translation id="3822502789641063741">I-clear ang storage ng site?</translation>
+<translation id="9205995714227143200">Storage ng site na sa tingin ng Brave ay hindi mahalaga (hal. mga site na walang mga naka-save na setting o hindi mo madalas bisitahin)</translation>
+<translation id="3997476611815694295">Storage ng hindi mahalaga</translation>
+<translation id="8493948351860045254">Magbakante ng espasyo</translation>
+<translation id="2324920234469020158">Iki-clear nito ang cookies, cache at iba pang data ng mga site na sa tingin ng Brave ay hindi mahalaga.</translation>
+<translation id="5447201525962359567">Lahat ng storage ng site, kabilang ang cookies at iba pang lokal na naka-store na data</translation>
+<translation id="1376578503827013741">Kino-compute…</translation>
+<translation id="583281660410589416">Hindi-alam</translation>
+<translation id="2323763861024343754">Storage ng site</translation>
+<translation id="3587672679800759167">Kabuuang data na ginagamit ng Brave, kabilang ang mga account, bookmark at naka-save na setting</translation>
+<translation id="6545017243486555795">I-clear ang Lahat ng Data</translation>
+<translation id="4095146165863963773">I-delete ang data ng app?</translation>
+<translation id="53119194224775367">Permanenteng ide-delete ang lahat ng data ng app ng Brave. Kabilang dito ang lahat ng file, setting, account, database, atbp.</translation>
+<translation id="5307446750509046227">I-clear ang storage ng site</translation>
+<translation id="300526633675317032">Iki-clear nito ang lahat ng <ph name="SIZE_IN_KB"/> ng storage ng website.</translation>
+<translation id="8068648041423924542">Hindi makapili ng certificate.</translation>
+<translation id="2315043854645842844">Hindi sinusuportahan ng operating system ang pagpipilian ng certificate sa panig ng kliyente.</translation>
+<translation id="5011311129201317034">Gustong kumonekta ng <ph name="SITE"/></translation>
+<translation id="5308380583665731573">Kumonekta</translation>
+<translation id="868929229000858085">Maghanap sa iyong mga contact</translation>
+<translation id="1919950603503897840">Pumili ng mga contact</translation>
+<translation id="7986741934819883144">Pumili ng contact</translation>
+<translation id="3333961966071413176">Lahat ng contact</translation>
+<translation id="4994033804516042629">Walang nakitang contact</translation>
+<translation id="5403592356182871684">Mga Pangalan</translation>
+<translation id="2717722538473713889">Mga email address</translation>
+<translation id="381841723434055211">Mga numero ng telepono</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 pa)}one{(+ # pa)}other{(+ # pa)}}</translation>
+<translation id="5197729504361054390">Ibabahagi sa <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> ang mga contact na pipiliin mo.</translation>
+<translation id="1779089405699405702">Pang-decode ng larawan</translation>
+<translation id="8067883171444229417">I-play ang video</translation>
+<translation id="6560414384669816528">Maghanap gamit ang Sogou</translation>
+<translation id="5406914950576900927">Maaaring gamitin ng Brave ang <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> para sa paghahanap sa China. Maaari mo itong baguhin sa <ph name="BEGIN_LINK"/>Mga Setting<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Panatilihin ang Brave Software</translation>
+<translation id="4384468725000734951">Ginagamit ang Sogou para sa paghahanap</translation>
+<translation id="6103327872225198548">Ginagamit ang Brave Software para sa paghahanap</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Gumagana ang app na ito sa Brave</translation>
+<translation id="6143689084714664628">Gumagana sa Brave</translation>
+<translation id="7675869148432102528">May data rin ang <ph name="APP_NAME"/> sa Brave</translation>
+<translation id="2734140769649165081">Maaari mong i-clear ang data sa Mga Setting ng Brave</translation>
+<translation id="8232956427053453090">Panatilihin ang data</translation>
+<translation id="4298388696830689168">Mga naka-link na site</translation>
+<translation id="5763514718066511291">I-tap upang kopyahin ang URL para sa app na ito</translation>
+<translation id="6496823230996795692">Upang magamit ang <ph name="APP_NAME"/> sa unang pagkakataon, kumonekta sa internet.</translation>
+<translation id="751961395872307827">Hindi makakonekta sa site</translation>
+<translation id="4878404682131129617">Hindi nakagawa ng tunnel sa pamamagitan ng proxy server</translation>
+<translation id="4749960740855309258">Magbukas ng bagong tab</translation>
+<translation id="8788968922598763114">Muling buksan ang huling isinarang tab</translation>
+<translation id="7929962904089429003">Buksan ang menu</translation>
+<translation id="6039379616847168523">Pumunta sa susunod na tab</translation>
+<translation id="5210286577605176222">Pumunta sa nakaraang tab</translation>
+<translation id="124678866338384709">Isara ang kasalukuyang tab</translation>
+<translation id="3714981814255182093">Buksan ang Bar sa Paghahanap</translation>
+<translation id="5441522332038954058">Pumunta sa address bar</translation>
+<translation id="3398320232533725830">Buksan ang bookmarks manager</translation>
+<translation id="6583199322650523874">I-bookmark ang kasalukuyang page</translation>
+<translation id="8489271220582375723">Buksan ang page ng history</translation>
+<translation id="4837753911714442426">Buksan ang mga opsyon sa pag-print ng page</translation>
+<translation id="5726692708398506830">Palakihin ang lahat ng nasa page</translation>
+<translation id="3259831549858767975">Paliitin ang lahat ng nasa page</translation>
+<translation id="8015452622527143194">Ibalik ang lahat ng nasa page sa default na sukat</translation>
+<translation id="3443221991560634068">I-reload ang kasalukuyang page</translation>
+<translation id="123724288017357924">I-reload ang page, balewalain ang cached content</translation>
+<translation id="305870044889644984">Buksan ang Help Center ng Brave sa bagong tab</translation>
+<translation id="3166827708714933426">Mga shortcut ng tab at window</translation>
+<translation id="3169981355900570544">Mga shortcut ng feature ng Brave Software Brave</translation>
+<translation id="4558311620361989323">Mga shortcut ng webpage</translation>
+<translation id="1908301351964700579">Naghahanda pa rin ang Brave para sa VR. I-restart ang Brave sa ibang pagkakataon.</translation>
+<translation id="8970887620466824814">Nagkaproblema.</translation>
+<translation id="1875543012935658554">Muling buksan ang Brave.</translation>
+<translation id="79859296434321399">Para matingnan ang augmented reality na content, i-install ang ARCore</translation>
+<translation id="8558485628462305855">Para matingnan ang augmented reality na content, i-update ang ARCore</translation>
+<translation id="3513704683820682405">Augmented Reality</translation>
+<translation id="5475862044948910901">Magsimula ng session ng Augmented Reality?</translation>
 <translation id="7365126855094612066">Para sa tagal ng session na ito, magagawa ng site na:
 • gumawa ng 3D na mapa ng iyong kapaligiran
 • subaybayan ang paggalaw ng camera
 
 HINDI magkakaroon ng access sa camera ang site. Ikaw lang ang makakakita ng mga larawan ng camera.</translation>
-<translation id="7375125077091615385">Uri:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Unang Karanasan sa Pagtakbo ng Chrome</translation>
-<translation id="741204030948306876">Oo, sali ako</translation>
-<translation id="7413229368719586778">Petsa ng pagsisimula <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Magtanong muna</translation>
-<translation id="7423538860840206698">Na-block sa pag-read ng clipboard</translation>
-<translation id="7431991332293347422">Kontrolin kung paano ginagamit ang iyong history ng pag-browse para i-personalize ang Paghahanap at higit pa</translation>
-<translation id="7437998757836447326">Mag-sign out sa Chrome</translation>
-<translation id="7438641746574390233">Kapag naka-on ang Lite mode, ginagamit ng Chrome ang mga server ng Google para mapabilis ang pag-load ng mga page. Muling isinusulat ng Lite mode ang mga napakabagal na page para ma-load lang ang mahalagang content. Hindi nalalapat sa mga tab na Incognito ang Lite mode.</translation>
-<translation id="7444811645081526538">Higit pang kategorya</translation>
-<translation id="7445411102860286510">Payagan ang mga site na awtomatikong mag-play ng mga naka-mute na video (inirerekomenda)</translation>
-<translation id="7453467225369441013">Isa-sign out ka sa karamihan ng mga site. Hindi ka masa-sign out sa iyong Google Account.</translation>
-<translation id="7454641608352164238">Walang sapat na espasyo</translation>
-<translation id="7475192538862203634">Kung madalas mo itong makita, subukan ang <ph name="BEGIN_LINK" />mga suhestyon<ph name="END_LINK" /> na ito.</translation>
-<translation id="7475688122056506577">Hindi nakita ang SD card. Maaaring nawawala ang ilan sa iyong mga file.</translation>
-<translation id="7479104141328977413">Pamamahala sa tab</translation>
-<translation id="7481312909269577407">Sumulong</translation>
-<translation id="7482656565088326534">Tab na preview</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Na-update <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">natipid na data</translation>
-<translation id="7498271377022651285">Mangyaring maghintay…</translation>
-<translation id="7514365320538308">I-download</translation>
-<translation id="751961395872307827">Hindi makakonekta sa site</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Hindi makakuha ng mga suhestyon</translation>
-<translation id="7559975015014302720">Naka-off ang Lite mode</translation>
-<translation id="7562080006725997899">Kini-clear ang data sa pag-browse</translation>
-<translation id="756809126120519699">Na-clear ang data ng Chrome</translation>
-<translation id="757524316907819857">I-block ang mga site sa pag-play ng pinoprotektahang content</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> file ang na-download}one{<ph name="FILES_DOWNLOADED_MANY" /> file ang na-download}other{<ph name="FILES_DOWNLOADED_MANY" /> na file ang na-download}}</translation>
-<translation id="7588219262685291874">I-on ang madilim na tema kapag naka-on ang Pangtipid sa Baterya ng iyong device</translation>
-<translation id="7589445247086920869">I-block para sa kasalukuyang search engine</translation>
-<translation id="7593557518625677601">Buksan ang mga setting ng Android at muling i-enable ang Android system sync upang simulan ang Chrome sync</translation>
-<translation id="7596558890252710462">Operating system</translation>
-<translation id="7605594153474022051">Hindi gumagana ang pag-sync</translation>
-<translation id="7606077192958116810">Naka-on ang Lite mode. Pamahalaan ito sa Mga Setting.</translation>
-<translation id="7612619742409846846">Naka-sign in sa Google bilang</translation>
-<translation id="7619072057915878432">Hindi na-download ang <ph name="FILE_NAME" /> dahil sa mga problema sa network.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Humingi ng tulong<ph name="END_LINK1" /> o <ph name="BEGIN_LINK2" />muling mag-scan<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Welcome sa Chrome</translation>
-<translation id="7638584964844754484">Maling passphrase</translation>
-<translation id="7641339528570811325">I-clear ang data sa pag-browse...</translation>
-<translation id="7648422057306047504">I-encrypt ang mga password gamit ang mga kredensyal ng Google</translation>
-<translation id="7649070708921625228">Tulong</translation>
-<translation id="7658239707568436148">Kanselahin</translation>
-<translation id="7665369617277396874">Magdagdag ng account</translation>
-<translation id="766587987807204883">Lalabas dito ang mga artikulong mababasa mo kahit offline ka</translation>
-<translation id="7682724950699840886">Subukan ang mga sumusunod na tip: tiyaking may sapat na espasyo sa iyong device, at subukang mag-export muli.</translation>
-<translation id="7685301384041462804">Tiyaking pinagkakatiwalaan mo ang site na ito bago ka pumasok sa VR.</translation>
-<translation id="7698359219371678927">Gumawa ng email sa <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Awtomatikong kumpletuhin ang mga paghahanap at URL</translation>
-<translation id="7725024127233776428">Lalabas dito ang mga page na iyong.na-bookmark</translation>
-<translation id="773466115871691567">Palaging isalin ang mga page sa <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Para matukoy ang mapapanganib na app at site, nagpapadala ang Chrome ng mga URL ng ilang page na binibisita mo, limitadong impormasyon ng system, at ilang content ng page sa Google</translation>
-<translation id="7757787379047923882">Ibinahagi ang text mula sa <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD card <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Magdagdag ng address</translation>
-<translation id="7772032839648071052">Kumpirmahin ang passphrase</translation>
-<translation id="7772375229873196092">Isara ang <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> iba pa}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> iba pa}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 at <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> na iba pa}}</translation>
-<translation id="7781829728241885113">Kahapon</translation>
-<translation id="7791543448312431591">Idagdag</translation>
-<translation id="780301667611848630">Hindi salamat</translation>
-<translation id="7810647596859435254">Buksan gamit ang…</translation>
-<translation id="7821588508402923572">Lalabas dito ang mga natipid sa iyong data</translation>
-<translation id="7837721118676387834">Payagan ang pag-autoplay ng mga naka-mute na video para sa isang partikular na site.</translation>
-<translation id="7846076177841592234">Kanselahin ang pinili</translation>
-<translation id="784934925303690534">Sakop na oras</translation>
-<translation id="7851858861565204677">Iba pang device</translation>
-<translation id="7875915731392087153">Gumawa ng email</translation>
-<translation id="7876243839304621966">Alisin lahat</translation>
-<translation id="7882131421121961860">Walang nakitang history</translation>
-<translation id="7882806643839505685">Payagan ang tunog para sa isang partikular na site.</translation>
-<translation id="7886917304091689118">Gumagana sa Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Nagda-download ng file.}one{Nagda-download ng # file.}other{Nagda-download ng # na file.}}</translation>
-<translation id="7929962904089429003">Buksan ang menu</translation>
-<translation id="7942131818088350342">Luma na ang <ph name="PRODUCT_NAME" />.</translation>
-<translation id="7947953824732555851">I-accept, mag-sign in</translation>
-<translation id="7963646190083259054">Vendor:</translation>
-<translation id="7971136598759319605">Aktibo 1 araw ang nakalipas</translation>
-<translation id="7975379999046275268">I-preview ang page na <ph name="BEGIN_NEW" />Bago<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">I-preload ang mga page para sa mas mabilis na pag-browse at paghahanap</translation>
-<translation id="79859296434321399">Para matingnan ang augmented reality na content, i-install ang ARCore</translation>
-<translation id="7986741934819883144">Pumili ng contact</translation>
-<translation id="7987073022710626672">Mga Tuntunin ng Serbisyo ng Chrome</translation>
-<translation id="7998918019931843664">Muling buksan ang isinarang tab</translation>
-<translation id="7999064672810608036">Sigurado ka bang gusto mong i-clear ang lahat ng lokal na data, kasama ang cookies, at i-reset ang lahat ng pahintulot para sa website na ito?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Naka-off para sa device na ito</translation>
-<translation id="8013372441983637696">I-clear din ang iyong data ng Chrome sa device na ito</translation>
-<translation id="8015452622527143194">Ibalik ang lahat ng nasa page sa default na sukat</translation>
-<translation id="802154636333426148">Hindi na-download</translation>
-<translation id="8026334261755873520">I-clear ang data sa pag-browse</translation>
-<translation id="8035133914807600019">Bagong folder…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> (na) araw na lang ang natitira</translation>
-<translation id="804335162455518893">Hindi nakita ang SD card</translation>
-<translation id="805047784848435650">Batay sa iyong history ng pag-browse</translation>
-<translation id="8051695050440594747">Available ang <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">Buksan sa bagong tab ng Chrome</translation>
-<translation id="8063895661287329888">Hindi naidagdag ang bookmark.</translation>
-<translation id="806745655614357130">Panatilihing hiwalay ang aking data</translation>
-<translation id="8067883171444229417">I-play ang video</translation>
-<translation id="8068648041423924542">Hindi makapili ng certificate.</translation>
-<translation id="8073388330009372546">Buksan ang larawan sa bagong tab</translation>
-<translation id="8076492880354921740">Mga Tab</translation>
-<translation id="8084114998886531721">Naka-save na password</translation>
-<translation id="8087000398470557479">Ang content na ito ay mula sa <ph name="DOMAIN_NAME" />, na ipinadala ng Google.</translation>
-<translation id="8103578431304235997">Tab na Incognito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Para makuha ang iyong mga bookmark sa lahat ng device mo, i-on ang pag-sync</translation>
-<translation id="8110087112193408731">Ipakita sa Digital Wellness ang aktibidad mo sa Chrome?</translation>
-<translation id="8116925261070264013">Naka-mute</translation>
-<translation id="813082847718468539">Tingnan ang impormasyon ng site</translation>
-<translation id="8131740175452115882">Kumpirmahin</translation>
-<translation id="8156139159503939589">Anong mga wika ang binabasa mo?</translation>
-<translation id="8168435359814927499">Content</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> (na) file ang natitira</translation>
-<translation id="8190358571722158785">1 araw na lang ang natitira</translation>
-<translation id="8200772114523450471">Resume</translation>
-<translation id="8209050860603202033">Buksan ang larawan</translation>
-<translation id="8218622182176210845">Pamahalaan ang iyong account</translation>
-<translation id="8224471946457685718">Mag-download ng mga artikulo para sa iyo sa Wi-Fi</translation>
-<translation id="8232956427053453090">Panatilihin ang data</translation>
-<translation id="8249310407154411074">Ilipat sa itaas</translation>
-<translation id="8250920743982581267">Mga Dokumento</translation>
-<translation id="825412236959742607">Masyadong malaki ang ginagamit na memory ng page na ito kaya inalis ng Chrome ang ilang content.</translation>
-<translation id="8260126382462817229">Subukang mag-sign in muli</translation>
-<translation id="8261506727792406068">I-delete</translation>
-<translation id="8266862848225348053">Lokasyon ng download</translation>
-<translation id="8274165955039650276">Tingnan ang mga download</translation>
-<translation id="8284326494547611709">Mga Caption</translation>
-<translation id="8300705686683892304">Pinapamahalaan ng app</translation>
-<translation id="8310344678080805313">Mga karaniwang tab</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> at higit pang site</translation>
-<translation id="8327155640814342956">Para sa pinakamagandang karanasan sa pag-browse, buksan para i-update ang Chrome</translation>
-<translation id="8339163506404995330">Hindi isasalin ang mga page na nasa <ph name="LANGUAGE" /></translation>
-<translation id="8349013245300336738">Pagbukud-bukurin ayon sa dami ng data na nagamit</translation>
-<translation id="8364299278605033898">Tingnan ang mga sikat na website</translation>
-<translation id="8368027906805972958">Hindi alam o hindi sinusuportahang device (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Payagan ang Pag-sync sa Background para sa isang partikular na site.</translation>
-<translation id="8378714024927312812">Pinapamahalaan ng iyong organisasyon</translation>
-<translation id="8380167699614421159">Nagpapakita ang site na ito ng mga nakakasagabal o nakakapanlinlang na ad</translation>
-<translation id="8393700583063109961">Ipadala ang mensahe</translation>
-<translation id="8413126021676339697">Ipakita ang buong history</translation>
-<translation id="8427875596167638501">Nakabukas nang kalahati ang tab na preview</translation>
-<translation id="8428213095426709021">Mga Setting</translation>
-<translation id="8438566539970814960">Mas pahusayin ang mga paghahanap at pag-browse</translation>
-<translation id="8441146129660941386">Maghanap nang pabalik</translation>
-<translation id="8443209985646068659">Hindi ma-update: Chrome</translation>
-<translation id="8445448999790540984">Hindi ma-export ang mga password</translation>
-<translation id="8447861592752582886">Bawiin ang pahintulot ng device</translation>
-<translation id="8461694314515752532">I-encrypt ang naka-sync na data gamit ang iyong sariling passphrase sa pag-sync</translation>
-<translation id="8466613982764129868">Tiyaking nakakonekta ang <ph name="TARGET_DEVICE_NAME" /> sa internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Available sa offline</translation>
-<translation id="8489271220582375723">Buksan ang page ng history</translation>
-<translation id="8493948351860045254">Magbakante ng espasyo</translation>
-<translation id="8497726226069778601">Walang makikita dito... sa ngayon</translation>
-<translation id="8503559462189395349">Mga Password sa Chrome</translation>
-<translation id="8503813439785031346">Username</translation>
-<translation id="8514477925623180633">Mag-export ng mga password na naka-store sa Chrome</translation>
-<translation id="8514577642972634246">Pumasok sa mode na incognito</translation>
-<translation id="851751545965956758">I-block ang mga site sa pagkonekta sa mga device</translation>
-<translation id="8523928698583292556">I-delete ang naka-store na password</translation>
-<translation id="854522910157234410">Buksan ang page na ito</translation>
-<translation id="8558485628462305855">Para matingnan ang augmented reality na content, i-update ang ARCore</translation>
-<translation id="8559990750235505898">Mag-alok na magsalin ng mga page sa iba pang wika</translation>
-<translation id="8562452229998620586">Lalabas dito ang mga naka-save na password.</translation>
-<translation id="8569404424186215731">simula noong <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Huling 4 na linggo</translation>
-<translation id="857943718398505171">Pinapayagan (inirerekomenda)</translation>
-<translation id="8583805026567836021">Kini-clear ang data ng account</translation>
-<translation id="860043288473659153">Pangalan ng cardholder</translation>
-<translation id="8609465669617005112">Lumipat</translation>
-<translation id="8616006591992756292">Maaaring may iba pang anyo ng history ng pag-browse ang iyong Google Account sa <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Buksan ang iminumungkahing URL na tinukoy sa na-download na content?</translation>
-<translation id="8636825310635137004">Upang makuha ang iyong mga tab mula sa iba mo pang mga device, i-on ang pag-sync.</translation>
-<translation id="8641930654639604085">Subukang i-block ang mga site na para sa mga nasa hustong gulang</translation>
-<translation id="8655129584991699539">Maaari mong i-clear ang data sa Mga Setting ng Chrome</translation>
-<translation id="8662811608048051533">Nagsa-sign out sa iyo sa karamihan ng site.</translation>
-<translation id="8664979001105139458">May ganito nang pangalan ng file</translation>
-<translation id="8676374126336081632">I-clear ang input</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Antas ng Lakas ng Signal: # bar}one{Antas ng Lakas ng Signal: # bar}other{Antas ng Lakas ng Signal: # na bar}}</translation>
-<translation id="868929229000858085">Maghanap sa iyong mga contact</translation>
-<translation id="869891660844655955">Expiration date</translation>
-<translation id="8719023831149562936">Hindi ma-beam ang kasalukuyang tab</translation>
-<translation id="8725066075913043281">Muling subukan</translation>
-<translation id="8728487861892616501">Kapag ginamit ang application na ito, nangangahulugan ito na sumasang-ayon ka sa <ph name="BEGIN_LINK1" />Mga Tuntunin ng Serbisyo <ph name="END_LINK1" /> at <ph name="BEGIN_LINK2" />Notification ng Privacy<ph name="END_LINK2" /> ng Chrome, at sa <ph name="BEGIN_LINK3" />Notification ng Privacy para sa Mga Google Account na Pinamamahalaan gamit ang Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Tapos na</translation>
-<translation id="8748850008226585750">Nakatago ang mga content</translation>
-<translation id="8751914237388039244">Pumili ng larawan</translation>
-<translation id="8788265440806329501">Nakasara ang history ng pag-navigate</translation>
-<translation id="8788968922598763114">Muling buksan ang huling isinarang tab</translation>
-<translation id="8801436777607969138">I-block ang JavaScript para sa isang partikular na site.</translation>
-<translation id="8812260976093120287">Sa ilang website, maaari kang magbayad sa iyong device gamit ang mga sinusuportahang app sa pagbabayad sa itaas.</translation>
-<translation id="8816026460808729765">I-block ang mga site sa pag-access sa mga sensor</translation>
-<translation id="8816439037877937734">Bubukas ang <ph name="APP_NAME" /> sa Chrome. Sa pamamagitan ng pagpapatuloy, sumasang-ayon ka sa <ph name="BEGIN_LINK1" />Mga Tuntunin ng Serbisyo<ph name="END_LINK1" /> at <ph name="BEGIN_LINK2" />Notification ng Privacy<ph name="END_LINK2" /> ng Chrome, at sa <ph name="BEGIN_LINK3" />Notification ng Privacy para sa Mga Google Account na Pinamamahalaan gamit ang Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Mga Bookmark</translation>
-<translation id="8833831881926404480">Ibinabahagi ng isang site ang iyong screen</translation>
-<translation id="883806473910249246">Nagka-error habang dina-download ang content.</translation>
-<translation id="8840953339110955557">Maaaring iba ang page na ito sa online na bersyon.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, tab</translation>
-<translation id="885701979325669005">Storage</translation>
-<translation id="889338405075704026">Pumunta sa mga setting ng Chrome</translation>
-<translation id="8901170036886848654">Walang nakitang bookmark</translation>
-<translation id="8909135823018751308">Ibahagi…</translation>
-<translation id="8912362522468806198">Google Account</translation>
-<translation id="8920114477895755567">Hinihintay ang mga detalye ng mga magulang.</translation>
+<translation id="1188239144602654184">Pumasok sa AR</translation>
+<translation id="473775607612524610">I-update</translation>
+<translation id="3133489217401741157">Ini-install ang <ph name="MODULE"/> para sa Brave…</translation>
+<translation id="1791662854739702043">Na-install</translation>
+<translation id="5131234170665854056">Hindi ma-install ang <ph name="MODULE"/> para sa Brave</translation>
+<translation id="2567385386134582609">LARAWAN</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">I-download ang mga page para magamit ang mga ito offline</translation>
 <translation id="8922289737868596582">I-download ang mga page mula sa button na Higit pang opsyon para magamit ang mga ito offline</translation>
-<translation id="8937772741022875483">Alisin sa Digital Wellness ang aktibidad mo sa Chrome?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Buksan sa ibang window</translation>
-<translation id="8951232171465285730">Nag-save ang Chrome ng <ph name="MEGABYTES" /> MB para sa iyo</translation>
-<translation id="8958424370300090006">Mag-block ng cookies para sa isang partikular na site.</translation>
-<translation id="8959122750345127698">Hindi gumagana ang navigation: <ph name="URL" /></translation>
-<translation id="8965591936373831584">nakabinbin</translation>
-<translation id="8970887620466824814">Nagkaproblema.</translation>
-<translation id="8972098258593396643">I-download sa default na folder?</translation>
-<translation id="8986494364107987395">Awtomatikong ipadala ang mga istatistika ng paggamit at mga ulat ng pag-crash sa Google</translation>
-<translation id="8993760627012879038">Magbukas ng bagong tab sa Incognito mode</translation>
-<translation id="8998729206196772491">Nagsa-sign in ka gamit ang isang account na pinamamahalaan ng <ph name="MANAGED_DOMAIN" /> at binibigyan mo ang administrator nito ng kontrol sa iyong data sa Chrome. Permanenteng mauugnay ang iyong data sa account na ito. Made-delete ang data mo sa device na ito kapag nag-sign out ka sa Chrome, ngunit mananatili itong naka-store sa iyong Google Account.</translation>
-<translation id="9019902583201351841">Pinamamahalaan ng iyong mga magulang</translation>
-<translation id="9028914725102941583">I-on ang pag-sync para makapagbahagi sa mga device</translation>
-<translation id="9029323097866369874">Payagan ang <ph name="DOMAIN" /> na pumasok sa VR?</translation>
-<translation id="9040142327097499898">Pinapayagan ang mga notification. Naka-off ang lokasyon para sa device na ito.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}one{# Video}other{# na Video}}</translation>
-<translation id="9050666287014529139">Passphrase</translation>
-<translation id="9063523880881406963">I-off ang Hilingin ang site sa desktop</translation>
-<translation id="9065203028668620118">I-edit</translation>
-<translation id="9070377983101773829">Simulan ang paghahanap gamit ang boses</translation>
-<translation id="9074336505530349563">Para makakuha ng naka-personalize na content na iminumungkahi ng Google, mag-sign in at i-on ang pag-sync</translation>
-<translation id="9086455579313502267">Hindi magawang ma-access ang network</translation>
-<translation id="9100505651305367705">Mag-alok na ipakita ang mga artikulo sa pinasimpleng view, kapag sinusuportahan</translation>
-<translation id="9100610230175265781">Kinakailangan ang passphrase</translation>
-<translation id="9102803872260866941">Nakabukas ang tab na preview</translation>
+<translation id="5958275228015807058">Hanapin ang iyong mga file at page sa Mga Download</translation>
+<translation id="5620928963363755975">Hanapin ang iyong mga file at page sa Mga Download mula sa button na Higit Pang Opsyon</translation>
+<translation id="3341058695485821946">Tingnan kung gaano karaming data ang iyong natipid</translation>
+<translation id="3157842584138209013">Tingnan kung gaano karaming data ang iyong natipid sa button ng Higit Pang Opsyon</translation>
+<translation id="8218622182176210845">Pamahalaan ang iyong account</translation>
+<translation id="8090895580117672212">Para pamahalaan ang iyong Brave Software account, i-tap ang button na "Pamahalaan ang account"</translation>
+<translation id="8856898588039823173">Lite na page na hatid ng Brave Software. Mag-tap para i-load ang orihinal.</translation>
+<translation id="8134317863207426198">Hatid ng Brave Software ang lite na page. I-tap ang button na “i-load ang orihinal” para i-load ang orihinal na page.</translation>
+<translation id="4961107849584082341">Isalin ang page na ito sa anumang wika</translation>
+<translation id="569536719314091526">Isalin ang page na ito sa anumang wika mula sa button na Higit pang opsyon</translation>
+<translation id="1397811292916898096">Maghanap gamit ang <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Baguhin ang default na lokasyon ng pag-download anumang oras</translation>
+<translation id="6942665639005891494">Baguhin ang default na lokasyon ng pag-download anumang oras gamit ang opsyong menu ng Mga Setting</translation>
+<translation id="6850409657436465440">Isinasagawa pa rin ang iyong pag-download</translation>
+<translation id="5817715962196959877">Mas mabilis nang mag-download ng mga file ang Brave</translation>
+<translation id="3976396876660209797">Alisin at gawing muli ang shortcut na ito</translation>
+<translation id="6766622839693428701">Mag-swipe pababa para isara.</translation>
+<translation id="1028699632127661925">Ipinapadala sa <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Ipinadala mula sa <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Natanggap ang tab</translation>
 <translation id="9104217018994036254">Listahan ng mga device kung saan magbabahagi ng tab.</translation>
-<translation id="9133397713400217035">I-explore Offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Ipakita ang orihinal</translation>
-<translation id="9139068048179869749">Magtanong bago payagan ang mga site na magpadala ng mga notification (inirerekomenda)</translation>
-<translation id="9139318394846604261">Shopping</translation>
-<translation id="9155898266292537608">Makakapaghanap ka rin gamit ang mabilisang pag-tap sa isang salita</translation>
-<translation id="9169507124922466868">Nakabukas nang kalahati ang history ng pag-navigate</translation>
-<translation id="9204836675896933765">1 file ang natitira</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Nakabukas ang listahan ng mga device kung saan magbabahagi ng tab nang kalahati ang taas.</translation>
+<translation id="2904414404539560095">Nakabukas ang listahan ng mga device kung saan magbabahagi ng tab nang buo ang taas.</translation>
+<translation id="4135200667068010335">Nakasara ang listahan ng mga device kung saan magbabahagi ng tab.</translation>
+<translation id="5292796745632149097">Ipadala kay</translation>
+<translation id="1386674309198842382">Aktibo <ph name="LAST_UPDATED"/> (na) araw ang nakalipas</translation>
+<translation id="7971136598759319605">Aktibo 1 araw ang nakalipas</translation>
+<translation id="1521774566618522728">Aktibo ngayong araw</translation>
+<translation id="3631987586758005671">Ibinabahagi sa <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">I-on ang pag-sync para makapagbahagi sa mga device</translation>
+<translation id="6162454065885854378">Para magbahagi ng isang bagay sa isa pang device mula sa iyong telepono, i-on ang pag-sync sa mga setting ng Brave sa dalawang device</translation>
+<translation id="6084271560289605378">Pumunta sa mga setting ng Brave</translation>
+<translation id="2318045970523081853">I-tap para tumawag</translation>
 <translation id="9209888181064652401">Hindi makatawag</translation>
-<translation id="9219103736887031265">Mga Larawan</translation>
-<translation id="926205370408745186">Alisin sa Digital Wellness ang iyong aktibidad sa Chrome</translation>
-<translation id="932327136139879170">Home</translation>
-<translation id="938850635132480979">Error: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">I-access ang iyong mikropono</translation>
-<translation id="95817756606698420">Maaaring gamitin ng Chrome ang <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> para sa paghahanap sa China. Maaari mo itong baguhin sa <ph name="BEGIN_LINK" />Mga Setting<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">I-block kung nagpapakita ang site ng mga nakakasagabal o nakakapanlinlang na ad (inirerekomenda)</translation>
-<translation id="968900484120156207">Lalabas dito ang mga page na binibisita mo</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> (na) minuto na lang ang natitira</translation>
-<translation id="974555521953189084">Ilagay ang iyong passphrase upang simulan ang pag-sync</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Iki-clear nito ang data para sa lahat ng site, kabilang ang:</translation>
-<translation id="983192555821071799">Isara ang lahat ng tab</translation>
-<translation id="987264212798334818">Pangkalahatan</translation>
+<translation id="2860954141821109167">Tiyaking may naka-enable na phone app sa device na ito</translation>
+<translation id="2067805253194386918">text</translation>
+<translation id="1450753235335490080">Hindi maibahagi ang <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Hindi maibahagi ang <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Tiyaking naka-on sa <ph name="TARGET_DEVICE_NAME"/> ang pag-sync sa Brave</translation>
+<translation id="3016635187733453316">Siguraduhing nakakonekta ang device sa internet</translation>
+<translation id="8466613982764129868">Tiyaking nakakonekta ang <ph name="TARGET_DEVICE_NAME"/> sa internet</translation>
+<translation id="6539092367496845964">Nagkaproblema. Subukan ulit sa ibang pagkakataon.</translation>
+<translation id="3389286852084373014">Masyadong malaki ang text</translation>
+<translation id="2100314319871056947">Subukang ibahagi ang text sa mas maliliit na bahagi</translation>
+<translation id="2987620471460279764">Ibinahaging text mula sa ibang device</translation>
+<translation id="7757787379047923882">Ibinahagi ang text mula sa <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kinopya sa iyong clipboard</translation>
+<translation id="4696983787092045100">Ipadala ang text sa Iyong Mga Device</translation>
+<translation id="1260236875608242557">Maghanap at mag-explore</translation>
+<translation id="6369229450655021117">Mula rito, maaari kang maghanap sa web, magbahagi sa mga kaibigan, at tumingin ng mga bukas na page</translation>
+<translation id="723171743924126238">Pumili ng mga larawan</translation>
+<translation id="8751914237388039244">Pumili ng larawan</translation>
+<translation id="1989112275319619282">Mag-browse</translation>
+<translation id="7055152154916055070">Na-block ang pag-redirect:</translation>
+<translation id="5524843473235508879">Na-block ang pag-redirect.</translation>
+<translation id="6573096386450695060">Payagan sa lahat ng oras</translation>
+<translation id="5805364706385912897">Masyadong malaki ang ginagamit na memory ng page na ito kaya na-pause ito ng Brave.</translation>
+<translation id="5138664332909611586">Masyadong malaki ang ginagamit na memory ng page na ito kaya inalis ng Brave ang ilang content.</translation>
+<translation id="9137013805542155359">Ipakita ang orihinal</translation>
+<translation id="6361779936989026201">Brave Software Assistant sa Brave</translation>
+<translation id="7291387454912369099">Assistant Triggered na Pag-check out</translation>
+<translation id="4565206163201411670">Ipakita sa Digital Wellness ang aktibidad mo sa Brave?</translation>
+<translation id="9055113864158719823">Puwede mong makita ang mga site na binibisita mo sa Brave at puwede kang magtakda ng mga timer para sa mga ito.\n\nKumukuha ng impormasyon ang Brave Software tungkol sa mga site kung saan ka nagtakda ng mga timer at inaalam nito kung gaano mo katagal binisita ang mga ito. Ginagamit ang impormasyong ito para pahusayin ang Digital Wellness.</translation>
+<translation id="4596514158372210596">Alisin sa Digital Wellness ang iyong aktibidad sa Brave</translation>
+<translation id="1174893863889683998">Alisin sa Digital Wellness ang aktibidad mo sa Brave?</translation>
+<translation id="708829030563435351">Hindi lalabas ang mga site na binibisita mo sa Brave. Ide-delete ang lahat ng timer sa site.</translation>
+<translation id="2056878612599315956">Naka-pause ang site</translation>
+<translation id="671481426037969117">Natapos na ang iyong timer ng <ph name="FQDN"/>. Magsisimula itong muli bukas.</translation>
+<translation id="7479104141328977413">Pamamahala sa tab</translation>
+<translation id="3524138585025253783">Developer UI</translation>
+<translation id="6036057147555329831">Karagdagang ICU</translation>
+<translation id="9029323097866369874">Payagan ang <ph name="DOMAIN"/> na pumasok sa VR?</translation>
+<translation id="7685301384041462804">Tiyaking pinagkakatiwalaan mo ang site na ito bago ka pumasok sa VR.</translation>
+<translation id="5033865233969348410">Habang nasa VR ka, puwedeng malaman ng site na ito ang tungkol sa:
+  -  iyong mga pisikal na katangian, gaya ng tangkad
+
+Tiyaking pinagkakatiwalaan mo ang site na ito bago ka pumasok sa VR.</translation>
+<translation id="5534334044554683961">Habang nasa VR ka, puwedeng malaman ng site na ito ang tungkol sa:
+  -   iyong mga pisikal na katangian, gaya ng tangkad
+  -   layout ng kwarto mo
+
+Tiyaking pinagkakatiwalaan mo ang site na ito bago ka pumasok sa VR.</translation>
+<translation id="4169535189173047238">Huwag payagan</translation>
+<translation id="2170088579611075216">Payagan at pumasok sa VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_fr.xtb
+++ b/android/java/strings/translations/android_chrome_strings_fr.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="fr">
-<translation id="1006017844123154345">Ouvrir la version en ligne</translation>
-<translation id="1028699632127661925">Envoi sur <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">Ajout de <ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">À partir de sites Web</translation>
-<translation id="1049743911850919806">Navigation privée</translation>
-<translation id="10614374240317010">Jamais enregistrés</translation>
-<translation id="1067922213147265141">Autres services Google</translation>
-<translation id="1068672505746868501">Ne jamais traduire les pages en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Si vous modifiez l'extension du fichier, celui-ci pourrait s'ouvrir dans une application différente et potentiellement endommager votre appareil.</translation>
-<translation id="1100066534610197918">Dans nouvel onglet dans groupe</translation>
-<translation id="1105960400813249514">Capture d'écran</translation>
-<translation id="1111673857033749125">Les favoris enregistrés sur vos autres appareils s'affichent ici.</translation>
-<translation id="1113597929977215864">Afficher la vue simplifiée</translation>
-<translation id="1121094540300013208">Statistiques d'utilisation et rapports d'erreur</translation>
-<translation id="1124772482545689468">Utilisateur</translation>
-<translation id="1129510026454351943">Détails°: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 téléchargement en attente.}one{# téléchargement en attente.}other{# téléchargements en attente.}}</translation>
-<translation id="1145536944570833626">Supprimer les données existantes.</translation>
-<translation id="1146678959555564648">Activer la réalité virtuelle</translation>
-<translation id="116280672541001035">Utilisées</translation>
-<translation id="1171770572613082465">Appuyez sur le bouton "Sites populaires" pour afficher les sites Web les plus visités</translation>
-<translation id="1173894706177603556">Renommer</translation>
-<translation id="1178581264944972037">Suspendre</translation>
-<translation id="1181037720776840403">Supprimer</translation>
-<translation id="1188239144602654184">Lancer</translation>
-<translation id="1197267115302279827">Déplacer les favoris</translation>
-<translation id="119944043368869598">Tout effacer</translation>
-<translation id="1201402288615127009">Suivant</translation>
-<translation id="1204037785786432551">Télécharger le lien</translation>
-<translation id="1206892813135768548">Copier le texte du lien</translation>
-<translation id="1208340532756947324">Activez la synchronisation pour accéder à vos données et les personnaliser sur tous vos appareils</translation>
-<translation id="1209206284964581585">Masquer pour le moment</translation>
-<translation id="1227058898775614466">Historique de navigation</translation>
-<translation id="1231733316453485619">Activer la synchronisation ?</translation>
-<translation id="123724288017357924">Actualiser page active et ignorer contenu en cache</translation>
-<translation id="124116460088058876">Plus de langues</translation>
-<translation id="124678866338384709">Fermer l'onglet actuel</translation>
-<translation id="1258753120186372309">Doodle : <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Rechercher et explorer</translation>
-<translation id="1264974993859112054">Sports</translation>
-<translation id="1266864766717917324">Impossible de partager le contenu suivant : <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Arrêter</translation>
-<translation id="1283039547216852943">Appuyer pour développer</translation>
-<translation id="1285320974508926690">Ne jamais traduire ce site</translation>
-<translation id="1291207594882862231">Efface l'historique, vider le cache, supprimer les cookies et les données de site…</translation>
-<translation id="129382876167171263">Les fichiers enregistrés par des sites Web sont répertoriés ici</translation>
-<translation id="129553762522093515">Récemment fermés</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> (envoyé depuis <ph name="DEVICE_NAME" />)</translation>
-<translation id="1310482092992808703">Regrouper les onglets</translation>
-<translation id="1327257854815634930">Historique de navigation ouvert</translation>
-<translation id="1331212799747679585">Impossible de mettre à jour Chrome. Plus d'options</translation>
-<translation id="1332501820983677155">Raccourcis liés aux fonctionnalités de Google Chrome</translation>
-<translation id="1360432990279830238">Se déconnecter et arrêter la synchro. ?</translation>
-<translation id="1369915414381695676">Site "<ph name="SITE_NAME" />" ajouté</translation>
-<translation id="1373696734384179344">Mémoire insuffisante pour télécharger le contenu sélectionné.</translation>
-<translation id="1376578503827013741">Calcul…</translation>
-<translation id="1383876407941801731">Rechercher</translation>
-<translation id="1384959399684842514">Téléchargement suspendu</translation>
-<translation id="1386674309198842382">Actif il y a <ph name="LAST_UPDATED" /> jours</translation>
-<translation id="1397811292916898096">Rechercher avec <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Intégration sur <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Interdire le suivi</translation>
-<translation id="1407135791313364759">Tout ouvrir</translation>
-<translation id="1409426117486808224">Vue simplifiée pour les onglets ouverts</translation>
-<translation id="1409879593029778104">Le téléchargement du fichier "<ph name="FILE_NAME" />" a été bloqué, car le fichier existe déjà.</translation>
-<translation id="1414981605391750300">Mise en relation avec Google. Cette opération peut prendre une minute…</translation>
-<translation id="1416550906796893042">Version de l'application</translation>
-<translation id="1430915738399379752">Imprimer</translation>
-<translation id="1446450296470737166">Autoriser le contrôle complet des appareils MIDI</translation>
-<translation id="1450753235335490080">Impossible de partager le contenu suivant : <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Désactivée dans les paramètres Android</translation>
-<translation id="1477626028522505441">Échec du téléchargement du fichier "<ph name="FILE_NAME" />" en raison de problèmes liés au serveur.</translation>
-<translation id="1506061864768559482">Moteur de recherche</translation>
-<translation id="1513352483775369820">Favoris et historique Web</translation>
-<translation id="1513858653616922153">Supprimer le mot de passe</translation>
-<translation id="1516229014686355813">La fonctionnalité "Appuyer pour rechercher" transmet le mot sélectionné et la page actuelle en tant que contexte à la recherche Google. Vous pouvez la désactiver dans les <ph name="BEGIN_LINK" />paramètres<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Actif aujourd'hui</translation>
-<translation id="1544826120773021464">Pour gérer votre compte Google, appuyez sur le bouton "Gérer le compte"</translation>
-<translation id="1549000191223877751">Déplacer vers autre fenêtre</translation>
-<translation id="1553358976309200471">Mettre à jour Chrome</translation>
-<translation id="1569387923882100876">Appareil connecté</translation>
-<translation id="1571304935088121812">Copier le nom d'utilisateur</translation>
-<translation id="1612196535745283361">Chrome doit avoir accès aux données de localisation pour rechercher des appareils. Cette fonctionnalité est <ph name="BEGIN_LINK" />désactivée pour cet appareil<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Appareil photo</translation>
-<translation id="1623104350909869708">Empêcher cette page de générer des boîtes de dialogue supplémentaires</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Supprimer 1 élément sélectionné}one{Supprimer # élément sélectionné}other{Supprimer # éléments sélectionnés}}</translation>
-<translation id="164269334534774161">Vous regardez une copie hors connexion de cette page depuis le <ph name="CREATION_TIME" />.</translation>
-<translation id="1644574205037202324">Historique</translation>
-<translation id="1647391597548383849">Accéder à votre caméra</translation>
-<translation id="1660204651932907780">Autoriser le son des sites (recommandé)</translation>
-<translation id="1670399744444387456">Général</translation>
-<translation id="1671236975893690980">Téléchargement en attente…</translation>
-<translation id="1672586136351118594">Ne plus afficher</translation>
-<translation id="1692118695553449118">La synchronisation est activée.</translation>
-<translation id="169515064810179024">Empêcher les sites d'accéder aux capteurs de mouvement</translation>
-<translation id="1717218214683051432">Capteurs de mouvement</translation>
-<translation id="1718835860248848330">Dernière heure</translation>
-<translation id="1736419249208073774">Découvrir</translation>
-<translation id="1743802530341753419">Demander avant d'autoriser les sites à se connecter à un appareil (recommandé)</translation>
-<translation id="1749561566933687563">Synchroniser vos favoris</translation>
-<translation id="17513872634828108">Onglets ouverts</translation>
-<translation id="1779089405699405702">Décodage d'images</translation>
-<translation id="1782483593938241562">Date de fin : <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installé dans</translation>
-<translation id="1792959175193046959">Modifier à tout moment l'emplacement de téléchargement par défaut</translation>
-<translation id="1807246157184219062">Clair</translation>
-<translation id="1810845389119482123">Configuration de la synchronisation initiale non terminée</translation>
-<translation id="1821253160463689938">Utilise des cookies pour mémoriser vos préférences, même si vous n'accédez pas à ces pages</translation>
-<translation id="1829244130665387512">Recherchez sur la page</translation>
-<translation id="1853692000353488670">Nouvel onglet de navigation privée</translation>
-<translation id="1856325424225101786">Réinitialiser le mode simplifié ?</translation>
-<translation id="1868024384445905608">Chrome permet désormais de télécharger des fichiers plus vite</translation>
-<translation id="1883903952484604915">Mes fichiers</translation>
-<translation id="1887786770086287077">L'accès à la position est désactivé pour cet appareil. Activez-le dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> va s'ouvrir dans Chrome. En continuant, vous acceptez les <ph name="BEGIN_LINK1" />Conditions d'utilisation<ph name="END_LINK1" /> et l'<ph name="BEGIN_LINK2" />Avis de confidentialité<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="1919345977826869612">Annonces</translation>
-<translation id="1919950603503897840">Sélectionner des contacts</translation>
-<translation id="1922076542920281912">Pour autoriser Chrome à accéder à votre position, activez également la localisation dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Mises à jour</translation>
-<translation id="19288952978244135">Rouvrez Chrome.</translation>
-<translation id="1933845786846280168">Onglet sélectionné</translation>
-<translation id="194341124344773587">Activer l'autorisation pour Chrome dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" /></translation>
-<translation id="1943432128510653496">Enregistrer les mots de passe</translation>
-<translation id="1952172573699511566">Les sites Web s'afficheront dans votre langue préférée lorsque ce sera possible.</translation>
-<translation id="1960290143419248813">Les mises à jour de Chrome ne sont plus disponibles avec cette version d'Android</translation>
-<translation id="1966710179511230534">Veuillez mettre à jour vos informations de connexion.</translation>
-<translation id="1974060860693918893">Paramètres avancés</translation>
-<translation id="1984705450038014246">Synchroniser vos données Chrome</translation>
-<translation id="1984937141057606926">Autorisés, sauf cookies tiers</translation>
-<translation id="1986685561493779662">Nom déjà attribué</translation>
-<translation id="1987739130650180037">Bouton <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Parcourir</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> tente de s'associer</translation>
-<translation id="1994173015038366702">URL du site</translation>
-<translation id="2000419248597011803">Envoie des cookies et des recherches effectuées à partir de la barre d'adresse et du champ de recherche à votre moteur de recherche par défaut</translation>
-<translation id="2002537628803770967">Cartes de crédit et adresses utilisées dans Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fichier}one{# fichier}other{# fichiers}}</translation>
-<translation id="2017836877785168846">Efface l'historique et les saisies semi-automatiques dans la barre d'adresse.</translation>
-<translation id="2021896219286479412">Commandes du site en plein écran</translation>
-<translation id="2038563949887743358">Activer "Voir version ordinateur"</translation>
-<translation id="2041019821020695769">Pour autoriser Chrome à vous envoyer des notifications, activez également ces dernières dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> a également des données dans Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Site en pause</translation>
-<translation id="2063713494490388661">Appuyer pour rechercher</translation>
-<translation id="2067805253194386918">texte</translation>
-<translation id="2079545284768500474">Annuler</translation>
-<translation id="2082238445998314030">Résultat <ph name="RESULT_NUMBER" /> sur <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Son</translation>
-<translation id="2096012225669085171">Synchroniser et personnaliser les données sur tous les appareils</translation>
-<translation id="2100273922101894616">Connexion automatique</translation>
-<translation id="2100314319871056947">Essayez de scinder le texte pour le partager en plusieurs fois</translation>
-<translation id="2107397443965016585">Demander avant d'autoriser les sites à lire les contenus protégés (recommandé)</translation>
-<translation id="2111511281910874386">Accéder à la page</translation>
-<translation id="2122601567107267586">Impossible d'ouvrir l'application</translation>
-<translation id="2126426811489709554">Proposé par Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> économisés</translation>
-<translation id="213279576345780926">L'onglet "<ph name="TAB_TITLE" />" a été fermé.</translation>
-<translation id="2139186145475833000">Ajouter à l'écran d'accueil</translation>
-<translation id="2146738493024040262">Ouvrir l'appli instantanée</translation>
-<translation id="2148716181193084225">Aujourd'hui</translation>
-<translation id="2154484045852737596">Modifier la carte</translation>
-<translation id="2154710561487035718">Copier l'URL</translation>
-<translation id="2156074688469523661">Sites restants (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Pour partager un contenu entre votre téléphone et un autre appareil, activez la synchronisation dans les paramètres Chrome sur les deux appareils</translation>
-<translation id="2170088579611075216">Autoriser et activer la RV</translation>
-<translation id="218608176142494674">Partage</translation>
-<translation id="2227444325776770048">Continuer en tant que <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Services Google/Synchronisation</translation>
-<translation id="2259659629660284697">Exporter les mots de passe…</translation>
-<translation id="2268044343513325586">Affiner</translation>
-<translation id="2286841657746966508">Adresse de facturation</translation>
-<translation id="2289270750774289114">Me demander lorsqu'un site souhaite accéder aux appareils Bluetooth se trouvant à proximité (recommandé)</translation>
-<translation id="230115972905494466">Aucun appareil compatible détecté</translation>
-<translation id="2315043854645842844">La sélection de certificat côté client n'est pas compatible avec le système d'exploitation.</translation>
-<translation id="2318045970523081853">Appuyer pour passer un appel</translation>
-<translation id="2321086116217818302">Préparation des mots de passe…</translation>
-<translation id="2321958826496381788">Faites glisser le curseur pour lire le texte aisément. Sa taille doit être similaire à celle-ci lorsque vous appuyez deux fois sur un paragraphe.</translation>
-<translation id="2323763861024343754">Données de site stockées</translation>
-<translation id="2328985652426384049">Impossible de se connecter</translation>
-<translation id="2330129964253841015">M'avertir quand des mots de passe ont été piratés</translation>
-<translation id="2349710944427398404">Espace de stockage utilisé pour l'ensemble des données Chrome, y compris les comptes, favoris et paramètres enregistrés</translation>
-<translation id="2353636109065292463">Vérifier votre connexion Internet</translation>
-<translation id="2359808026110333948">Continuer</translation>
-<translation id="2369533728426058518">onglets ouverts</translation>
-<translation id="2387895666653383613">Mise à l'échelle du texte</translation>
-<translation id="2394602618534698961">Les fichiers que vous téléchargez sont affichés ici</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> Mo</translation>
-<translation id="2407481962792080328">Lorsque vous vous connectez à votre compte Google, cette fonctionnalité est activée</translation>
-<translation id="2410754283952462441">Sélectionner un compte</translation>
-<translation id="2414886740292270097">Sombre</translation>
-<translation id="2416359993254398973">Chrome a besoin de votre autorisation pour accéder à votre appareil photo pour ce site.</translation>
-<translation id="2426805022920575512">Sélectionner un autre compte</translation>
-<translation id="2433507940547922241">Apparence</translation>
-<translation id="2434158240863470628">Téléchargement terminé <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Accès à la position</translation>
-<translation id="2450083983707403292">Souhaitez-vous relancer le téléchargement du fichier <ph name="FILE_NAME" /> ?</translation>
-<translation id="2482878487686419369">Notifications</translation>
-<translation id="2490684707762498678">Géré par <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Assistant Google dans Chrome</translation>
-<translation id="2496180316473517155">Historique de navigation</translation>
-<translation id="2497852260688568942">Votre administrateur a désactivé la synchronisation</translation>
-<translation id="2498359688066513246">Aide et commentaires</translation>
-<translation id="2501278716633472235">Retour</translation>
-<translation id="2513403576141822879">Pour accéder à d'autres paramètres liés à la confidentialité, à la sécurité et à la collecte de données, consultez la section <ph name="BEGIN_LINK" />Services Google/Synchronisation<ph name="END_LINK" />.</translation>
-<translation id="2518590038762162553">En mode simplifié, Chrome charge les pages plus rapidement et consomme jusqu'à 60 % de données en moins. Pour optimiser les pages que vous consultez, Chrome envoie votre trafic Web à Google. <ph name="BEGIN_LINK" />En savoir plus<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Envoie les URL des pages que vous consultez à Google</translation>
-<translation id="2532336938189706096">Vue Web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> éléments supprimés</translation>
-<translation id="2536728043171574184">Affichage d'une copie hors connexion de la page</translation>
-<translation id="2546283357679194313">Cookies et données de site</translation>
-<translation id="2567385386134582609">IMAGE</translation>
-<translation id="257088987046510401">Thèmes</translation>
-<translation id="2570922361219980984">L'accès à la position est également désactivé pour cet appareil. Activez-le dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Développé – Cliquer pour réduire</translation>
-<translation id="2581165646603367611">Cette action aura pour effet de vider le cache et de supprimer les cookies, ainsi que d'autres données de site que Chrome ne considère pas comme importantes.</translation>
-<translation id="2586657967955657006">Presse-papiers</translation>
-<translation id="2587052924345400782">Nouvelle version disponible</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Numéro de carte</translation>
-<translation id="2621115761605608342">Autorisez le langage JavaScript pour un site spécifique.</translation>
-<translation id="2625189173221582860">Mot de passe copié</translation>
-<translation id="2631006050119455616">Économisées</translation>
-<translation id="2647434099613338025">Ajouter une langue</translation>
-<translation id="2650751991977523696">Télécharger de nouveau le fichier ?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# fichier audio}one{# fichier audio}other{# fichiers audio}}</translation>
-<translation id="2653659639078652383">Valider</translation>
-<translation id="2677748264148917807">Quitter</translation>
-<translation id="2704606927547763573">Copié</translation>
-<translation id="2707726405694321444">Actualiser la page</translation>
-<translation id="2709516037105925701">Saisie automatique</translation>
-<translation id="2717722538473713889">Adresses e-mail</translation>
-<translation id="2728754400939377704">Trier par site</translation>
-<translation id="2744248271121720757">Appuyez sur un mot pour lancer une recherche instantanée ou afficher les actions associées</translation>
-<translation id="2760989362628427051">Activer le thème sombre lorsque le thème sombre ou l'économiseur de batterie de votre appareil est activé</translation>
-<translation id="2762000892062317888">à l'instant</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> secondes restantes</translation>
-<translation id="2779651927720337254">échec</translation>
-<translation id="2781151931089541271">1 seconde restante</translation>
-<translation id="2801022321632964776">Lancez la mise à jour pour obtenir votre langue dans la dernière version de Chrome</translation>
-<translation id="2810645512293415242">Page simplifiée pour économiser des données et accélérer le chargement.</translation>
-<translation id="281504910091592009">Afficher et gérer les mots de passe enregistrés dans votre <ph name="BEGIN_LINK" />compte Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Connectez-vous et activez la synchronisation pour accéder à vos favoris sur tous vos appareils</translation>
-<translation id="2822354292072154809">Voulez-vous vraiment réinitialiser toutes les autorisations du site pour <ph name="CHOSEN_OBJECT_NAME" /> ?</translation>
-<translation id="2836148919159985482">Appuyez sur le bouton Retour pour quitter le mode plein écran.</translation>
-<translation id="2842985007712546952">Dossier parent</translation>
-<translation id="2858138569776157458">Sites populaires</translation>
-<translation id="2860954141821109167">Assurez-vous qu'une application Téléphone est activée sur cet appareil</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Piste précédente</translation>
-<translation id="2876369937070532032">Envoyer à Google les URL des pages que vous consultez présentant un risque pour votre sécurité</translation>
-<translation id="2888126860611144412">À propos de Chrome</translation>
-<translation id="2891154217021530873">Arrêter le chargement de la page</translation>
-<translation id="2893180576842394309">Google peut utiliser votre historique pour personnaliser la recherche et d'autres services Google</translation>
-<translation id="2898264748040935573">Modifier le mot de passe enregistré</translation>
-<translation id="2900528713135656174">Créer un événement</translation>
-<translation id="290376772003165898">La page n'est pas en <ph name="LANGUAGE" /> ?</translation>
-<translation id="2904414404539560095">La liste des appareils avec lesquels vous pouvez partager un onglet est ouverte à hauteur maximale.</translation>
-<translation id="2910701580606108292">Demander avant d'autoriser les sites à lire les contenus protégés</translation>
-<translation id="2913331724188855103">Autoriser les sites à enregistrer et à lire les données des cookies (recommandé)</translation>
-<translation id="2923908459366352541">Le nom n'est pas valide</translation>
-<translation id="2932150158123903946">Stockage Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">L'onglet "Aperçu" est fermé</translation>
-<translation id="2956410042958133412">Ce compte est géré par <ph name="PARENT_NAME_1" /> et <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Onglets de navigation privée sélectionnés</translation>
-<translation id="2968755619301702150">Lecteur de certificat</translation>
-<translation id="2979025552038692506">Onglet de navigation privée sélectionné</translation>
-<translation id="2987620471460279764">Texte partagé depuis un autre appareil</translation>
-<translation id="2989523299700148168">Consultations récentes</translation>
-<translation id="2996291259634659425">Créer une phrase secrète</translation>
-<translation id="2996809686854298943">Veuillez saisir une URL.</translation>
-<translation id="300526633675317032">Cette action aura pour effet de libérer l'espace de stockage utilisé pour les données de site (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">Assurez-vous que cet appareil est bien connecté à Internet</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> Ko téléchargé(s)</translation>
-<translation id="3029704984691124060">Les phrases secrètes ne correspondent pas.</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Obtenir de l'aide<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">La localisation est désactivée. Activez-la dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Vous pouvez activer la synchronisation à tout moment dans les paramètres</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> favori}one{<ph name="BOOKMARKS_COUNT_MANY" /> favori}other{<ph name="BOOKMARKS_COUNT_MANY" /> favoris}}</translation>
-<translation id="3089395242580810162">Ouvrir onglet navig. privée</translation>
-<translation id="3115898365077584848">Afficher les informations</translation>
-<translation id="3123473560110926937">Bloqué sur certains sites</translation>
-<translation id="3137521801621304719">Désactiver le mode navigation privée</translation>
-<translation id="3143515551205905069">Annuler la synchronisation</translation>
-<translation id="3157842584138209013">Découvrez la quantité de données économisées en cliquant sur le bouton "Plus d'options"</translation>
-<translation id="3166827708714933426">Raccourcis liés aux onglets et aux fenêtres</translation>
-<translation id="3181954750937456830">Navigation sécurisée (assure votre protection et celle de votre appareil contre les sites dangereux)</translation>
-<translation id="3190152372525844641">Activer les autorisations pour Chrome dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" /></translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> de données stockées</translation>
-<translation id="3205824638308738187">C'est presque fini !</translation>
-<translation id="3207960819495026254">Favori</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> a été supprimé</translation>
-<translation id="321773570071367578">Si vous avez oublié votre phrase secrète, ou si vous souhaitez modifier ce paramètre, <ph name="BEGIN_LINK" />réinitialisez la synchronisation<ph name="END_LINK" />.</translation>
-<translation id="3227137524299004712">Micro</translation>
-<translation id="3232754137068452469">Application Web</translation>
-<translation id="3236059992281584593">1 minute restante</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Ajouter cette page aux favoris</translation>
-<translation id="3259831549858767975">Réduire tous les éléments de la page</translation>
-<translation id="3269093882174072735">Charger l'image</translation>
-<translation id="3269956123044984603">Activez l'option "Synchro auto des données" dans les paramètres Android de votre compte Google pour accéder à vos onglets sur vos autres appareils.</translation>
-<translation id="3277252321222022663">Autoriser les sites à accéder à vos capteurs (recommandé)</translation>
-<translation id="3282568296779691940">Connectez-vous à Chrome</translation>
-<translation id="3288003805934695103">Recharger la page</translation>
-<translation id="32895400574683172">Les notifications sont autorisées</translation>
-<translation id="3295530008794733555">Naviguez plus rapidement en consommant moins de données</translation>
-<translation id="3295602654194328831">Masquer les informations</translation>
-<translation id="3298243779924642547">Simplifié</translation>
-<translation id="3303414029551471755">Poursuivre et télécharger le contenu ?</translation>
-<translation id="3306398118552023113">Cette application s'exécute dans Chrome</translation>
-<translation id="3315103659806849044">Vous personnalisez actuellement les paramètres relatifs aux services Google et à la synchronisation. Pour valider l'activation de la synchronisation, appuyez sur le bouton "Confirmer" en bas de l'écran. Revenir en haut de la page</translation>
-<translation id="3328801116991980348">Informations sur le site</translation>
-<translation id="3333961966071413176">Tous les contacts</translation>
-<translation id="3334729583274622784">Modifier l'extension du fichier ?</translation>
-<translation id="3341058695485821946">Découvrez la quantité de données économisées</translation>
-<translation id="3350687908700087792">Fermer tous les onglets de navigation privée</translation>
-<translation id="3353615205017136254">Page simplifiée fournie par Google. Appuyez sur le bouton "Charger le site d'origine" pour charger la page d'origine.</translation>
-<translation id="3367813778245106622">Connectez-vous de nouveau à votre compte pour démarrer la synchronisation.</translation>
-<translation id="3374023511497244703">Vos favoris, votre historique, vos mots de passe et d'autres données Chrome ne seront plus synchronisés avec votre compte Google</translation>
-<translation id="3384347053049321195">Partager l'image</translation>
-<translation id="3386292677130313581">Demander avant d'autoriser des sites à accéder à ma position (recommandé)</translation>
-<translation id="3387650086002190359">Échec du téléchargement du fichier "<ph name="FILE_NAME" />" en raison d'erreurs liées au système de fichiers.</translation>
-<translation id="3389286852084373014">Volume de texte trop important</translation>
-<translation id="3398320232533725830">Ouvrir le gestionnaire de favoris</translation>
-<translation id="3414952576877147120">Taille :</translation>
-<translation id="3443221991560634068">Actualiser la page active</translation>
-<translation id="3445014427084483498">À l'instant</translation>
-<translation id="3478363558367712427">Vous pouvez choisir votre moteur de recherche</translation>
+<translation id="6910211073230771657">Supprimé</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK</translation>
+<translation id="7658239707568436148">Annuler</translation>
 <translation id="3479552764303398839">Pas maintenant</translation>
-<translation id="3492207499832628349">Nouvel onglet nav. privée</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />En savoir plus<ph name="END_LINK" /> sur le contenu suggéré</translation>
-<translation id="3513704683820682405">Réalité augmentée</translation>
-<translation id="3518985090088779359">Accepter et continuer</translation>
-<translation id="3522247891732774234">Mise à jour disponible. Plus d'options</translation>
-<translation id="3524138585025253783">UI des développeurs</translation>
-<translation id="3527085408025491307">Dossier</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> Ko disponibles</translation>
-<translation id="3549657413697417275">Recherchez dans l'historique</translation>
-<translation id="3557336313807607643">Ajouter aux contacts</translation>
-<translation id="3566923219790363270">Le mode de réalité virtuelle n'est pas encore prêt. Redémarrez Chrome plus tard.</translation>
-<translation id="3568688522516854065">Connectez-vous et activez la synchronisation pour accéder à vos onglets sur vos autres appareils</translation>
-<translation id="3587482841069643663">Tous</translation>
-<translation id="358794129225322306">Autoriser un site à télécharger automatiquement plusieurs fichiers</translation>
-<translation id="3590487821116122040">Données de site stockées que Chrome ne considère pas comme importantes (par exemple, pour des sites sans paramètres enregistrés ou que vous ne consultez pas souvent)</translation>
-<translation id="3599863153486145794">Efface l'historique de tous les appareils sur lesquels vous êtes connecté à votre compte Google. Ce dernier peut conserver d'autres formes d'historique de navigation sur la page <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Couper le son des sites</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Partage avec <ph name="DEVICE_NAME" />…</translation>
-<translation id="3632295766818638029">Afficher le mot de passe</translation>
-<translation id="363596933471559332">Connexion automatique aux sites Web à l'aide des identifiants enregistrés. Lorsque la fonctionnalité est désactivée, vous êtes invité à effectuer la validation avant chaque connexion à un site Web.</translation>
-<translation id="3658159451045945436">Le processus de réinitialisation efface l'historique de l'économiseur de données, y compris la liste des sites consultés.</translation>
-<translation id="3692944402865947621">Échec du téléchargement du fichier "<ph name="FILE_NAME" />" en raison de l'espace de stockage indisponible.</translation>
-<translation id="3714981814255182093">Ouvrir la barre de recherche</translation>
-<translation id="3716182511346448902">Cette page utilise trop de mémoire, Chrome a donc interrompu son chargement.</translation>
-<translation id="3730075448226062617">Pour autoriser Chrome à accéder au micro, activez également ce dernier dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Favori ajouté dans <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Synchronisation en arrière-plan</translation>
-<translation id="3771001275138982843">Impossible de télécharger la mise à jour</translation>
-<translation id="3771033907050503522">Ongl. navig. priv.</translation>
-<translation id="3773755127849930740">Pour permettre l'association, <ph name="BEGIN_LINK" />activez le Bluetooth<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">Envoyer à vos appareils</translation>
-<translation id="3778956594442850293">Ajouté à l'écran d'accueil</translation>
-<translation id="3789841737615482174">Installer</translation>
-<translation id="3810838688059735925">Vidéo</translation>
-<translation id="3810973564298564668">Gérer</translation>
-<translation id="381841723434055211">Numéros de téléphone</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> téléchargements supprimés</translation>
-<translation id="3822502789641063741">Suppr. données de site ?</translation>
-<translation id="385051799172605136">Retour</translation>
-<translation id="3859306556332390985">Avance rapide</translation>
-<translation id="3894427358181296146">Ajouter un dossier</translation>
-<translation id="3895926599014793903">Forcer l'activation du zoom</translation>
-<translation id="3912508018559818924">Recherche du meilleur contenu sur le Web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combiner mes données</translation>
-<translation id="393697183122708255">Aucune recherche vocale activée dispo.</translation>
-<translation id="395206256282351086">Suggestions de recherches et de sites désactivées</translation>
-<translation id="3955193568934677022">Autoriser les sites à lire les contenus protégés (recommandé)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome chargera votre page dès qu'elle sera prête}one{Chrome chargera votre page dès qu'elle sera prête}other{Chrome chargera vos pages dès qu'elles seront prêtes}}</translation>
-<translation id="3963007978381181125">Le chiffrement par phrase secrète ne s'applique pas aux modes de paiement et adresses Google Pay. Seule une personne connaissant votre phrase secrète peut lire vos données chiffrées. La phrase secrète ne nous est pas envoyée et nous ne la stockons pas. Si vous l'oubliez ou si vous souhaitez modifier ce paramètre, vous devrez réinitialiser la synchronisation. <ph name="BEGIN_LINK" />En savoir plus<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Téléchargement terminé</translation>
-<translation id="397583555483684758">La synchronisation s'est arrêtée.</translation>
-<translation id="3976396876660209797">Supprimez et recréez ce raccourci</translation>
-<translation id="3985215325736559418">Voulez-vous télécharger <ph name="FILE_NAME" /> de nouveau ?</translation>
-<translation id="3987993985790029246">Copier lien</translation>
-<translation id="3988213473815854515">Position autorisée</translation>
-<translation id="3988466920954086464">Consultez les résultats de la recherche instantanée dans ce panneau</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/ ?</translation>
-<translation id="3997476611815694295">Stockage non important</translation>
-<translation id="4000212216660919741">Mode hors connexion</translation>
+<translation id="5317780077021120954">Enregistrer</translation>
+<translation id="4570913071927164677">Détails</translation>
+<translation id="8730621377337864115">OK</translation>
+<translation id="8261506727792406068">Supprimer</translation>
+<translation id="1181037720776840403">Supprimer</translation>
+<translation id="5939518447894949180">Réinitialiser</translation>
 <translation id="4002066346123236978">Titre</translation>
-<translation id="4008040567710660924">Autorisez les cookies pour un site spécifique.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Piste suivante</translation>
-<translation id="4048707525896921369">Découvrez les thèmes abordés sur les sites Web sans quitter la page. La fonctionnalité "Appuyer pour rechercher" transmet un mot et son contexte à la recherche Google, qui renvoie à son tour des définitions, des images, des résultats de recherche et d'autres informations.
+<translation id="5916664084637901428">Activé</translation>
+<translation id="5860033963881614850">Désactivé</translation>
+<translation id="6165508094623778733">En savoir plus</translation>
+<translation id="6042308850641462728">Plus</translation>
+<translation id="6040143037577758943">Fermer</translation>
+<translation id="780301667611848630">Non merci</translation>
+<translation id="1201402288615127009">Suivant</translation>
+<translation id="2359808026110333948">Continuer</translation>
+<translation id="2653659639078652383">Valider</translation>
+<translation id="2079545284768500474">Annuler</translation>
+<translation id="7649070708921625228">Aide</translation>
+<translation id="2148716181193084225">Aujourd'hui</translation>
+<translation id="7781829728241885113">Hier</translation>
+<translation id="6945221475159498467">Sélectionner</translation>
+<translation id="7791543448312431591">Ajouter</translation>
+<translation id="6527303717912515753">Partager</translation>
+<translation id="1383876407941801731">Rechercher</translation>
+<translation id="3115898365077584848">Afficher les informations</translation>
+<translation id="3295602654194328831">Masquer les informations</translation>
+<translation id="3987993985790029246">Copier lien</translation>
+<translation id="2704606927547763573">Copié</translation>
+<translation id="8725066075913043281">Réessayer</translation>
+<translation id="385051799172605136">Retour</translation>
+<translation id="8131740175452115882">Confirmer</translation>
+<translation id="5300589172476337783">Afficher</translation>
+<translation id="1124772482545689468">Utilisateur</translation>
+<translation id="8609465669617005112">Monter</translation>
+<translation id="6746124502594467657">Descendre</translation>
+<translation id="8249310407154411074">Déplacer vers le haut</translation>
+<translation id="8428213095426709021">Paramètres</translation>
+<translation id="2498359688066513246">Aide et commentaires</translation>
+<translation id="8378714024927312812">Géré par votre organisation</translation>
+<translation id="9019902583201351841">Géré par tes parents</translation>
+<translation id="4645575059429386691">Géré par ton papa/ta maman</translation>
+<translation id="4883854917563148705">Impossible de réinitialiser les paramètres gérés</translation>
+<translation id="4307992518367153382">Options de base</translation>
+<translation id="1974060860693918893">Paramètres avancés</translation>
+<translation id="1146678959555564648">Activer la réalité virtuelle</translation>
+<translation id="987264212798334818">Général</translation>
+<translation id="4275663329226226506">Médias</translation>
+<translation id="4759238208242260848">Téléchargements</translation>
+<translation id="218608176142494674">Partage</translation>
+<translation id="8004582292198964060">Navigateur</translation>
+<translation id="1105960400813249514">Capture d'écran</translation>
+<translation id="4875775213178255010">Recommandations de contenus</translation>
+<translation id="2021896219286479412">Commandes du site en plein écran</translation>
+<translation id="4587589328781138893">Sites</translation>
+<translation id="4943703118917034429">Réalité virtuelle</translation>
+<translation id="1928696683969751773">Mises à jour</translation>
+<translation id="6064125863973209585">Téléchargements terminés</translation>
+<translation id="5342314432463739672">Demandes d'autorisation</translation>
+<translation id="629730747756840877">Compte</translation>
+<translation id="82609232232243542">Connectez-vous à Brave</translation>
+<translation id="7956662517480676674">Services Brave Software/Synchronisation</translation>
+<translation id="5294439808117722387">Vous personnalisez actuellement les paramètres relatifs aux services Brave Software et à la synchronisation. Pour valider l'activation de la synchronisation, appuyez sur le bouton "Confirmer" en bas de l'écran. Revenir en haut de la page</translation>
+<translation id="2096012225669085171">Synchroniser et personnaliser les données sur tous les appareils</translation>
+<translation id="1692118695553449118">La synchronisation est activée.</translation>
+<translation id="5514904542973294328">Désactivé par l'administrateur de cet appareil</translation>
+<translation id="6447211988989208781">Commandes Brave Software relatives à l'activité</translation>
+<translation id="4882831918239250449">Contrôler la manière dont votre historique de navigation est utilisé pour personnaliser la recherche, les annonces, etc.</translation>
+<translation id="7431991332293347422">Contrôler la manière dont votre historique de navigation est utilisé pour personnaliser la recherche et plus encore</translation>
+<translation id="6303969859164067831">Se déconnecter et désactiver la synchronisation</translation>
+<translation id="1125261911132334651">Gérer votre compte Brave Software</translation>
+<translation id="6406506848690869874">Synchronisation</translation>
+<translation id="714362445477979774">Synchroniser vos données Brave</translation>
+<translation id="4314815835985389558">Gérer la synchronisation</translation>
+<translation id="5428209950370661546">Autres services Brave Software</translation>
+<translation id="7704317875155739195">Saisir semi-automatiquement les recherches et les URL</translation>
+<translation id="2000419248597011803">Envoie des cookies et des recherches effectuées à partir de la barre d'adresse et du champ de recherche à votre moteur de recherche par défaut</translation>
+<translation id="7981313251711023384">Précharger les pages pour accélérer la navigation et la recherche</translation>
+<translation id="1821253160463689938">Utilise des cookies pour mémoriser vos préférences, même si vous n'accédez pas à ces pages</translation>
+<translation id="6697492270171225480">Afficher des suggestions de pages similaires lorsqu'une page est introuvable</translation>
+<translation id="8109318360573330108">Envoie l'URL de la page que vous essayez d'ouvrir à Brave Software</translation>
+<translation id="8438566539970814960">Améliorer les recherches et la navigation</translation>
+<translation id="284843628681142937">Envoie les URL des pages que vous consultez à Brave Software</translation>
+<translation id="7222718784508482526">Pour accéder à d'autres paramètres liés à la confidentialité, à la sécurité et à la collecte de données, consultez la section <ph name="BEGIN_LINK"/>Services Brave Software/Synchronisation<ph name="END_LINK"/>.</translation>
+<translation id="918192811481327695">Contribuer à l'amélioration des fonctionnalités et des performances de Brave</translation>
+<translation id="9063160602596686558">Envoie automatiquement des statistiques d'utilisation et des rapports d'erreur à Brave Software</translation>
+<translation id="4824958205181053313">Annuler la synchronisation ?</translation>
+<translation id="3058498974290601450">Vous pouvez activer la synchronisation à tout moment dans les paramètres</translation>
+<translation id="3143515551205905069">Annuler la synchronisation</translation>
+<translation id="1506061864768559482">Moteur de recherche</translation>
+<translation id="55737423895878184">La localisation et les notifications sont autorisées</translation>
+<translation id="3988213473815854515">Position autorisée</translation>
+<translation id="32895400574683172">Les notifications sont autorisées</translation>
+<translation id="9040142327097499898">Les notifications sont autorisées. La localisation est désactivée pour cet appareil.</translation>
+<translation id="305593374596241526">La localisation est désactivée. Activez-la dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Consultations récentes</translation>
+<translation id="6433501201775827830">Sélectionner votre moteur de recherche</translation>
+<translation id="7177466738963138057">Vous pourrez modifier le moteur de recherche plus tard dans les paramètres</translation>
+<translation id="3478363558367712427">Vous pouvez choisir votre moteur de recherche</translation>
+<translation id="4910889077668685004">Applications de paiement</translation>
+<translation id="5152843274749979095">Aucune application compatible n'est installée</translation>
+<translation id="8812260976093120287">Sur certains sites Web, vous pouvez payer depuis votre appareil avec les applications de paiement compatibles indiquées ci-dessus.</translation>
+<translation id="7764225426217299476">Ajouter une adresse</translation>
+<translation id="5595485650161345191">Modifier l'adresse</translation>
+<translation id="5087580092889165836">Ajouter une carte</translation>
+<translation id="2154484045852737596">Modifier la carte</translation>
+<translation id="6140912465461743537">Pays/Région</translation>
+<translation id="5659593005791499971">E-mail</translation>
+<translation id="4378154925671717803">Téléphone</translation>
+<translation id="4807098396393229769">Titulaire de la carte</translation>
+<translation id="860043288473659153">Nom du titulaire de la carte</translation>
+<translation id="2612676031748830579">Numéro de carte</translation>
+<translation id="869891660844655955">Date d'expiration</translation>
+<translation id="2286841657746966508">Adresse de facturation</translation>
+<translation id="663059986967017181">Copiée dans Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> de plus}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> de plus}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> de plus}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> de plus}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> de plus}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> de plus}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> de plus}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> de plus}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> de plus}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> de plus}one{<ph name="CONTACT_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> de plus}other{<ph name="CONTACT_PREVIEW"/>\u2026 et <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> de plus}}</translation>
+<translation id="7029809446516969842">Mots de passe</translation>
+<translation id="1943432128510653496">Enregistrer les mots de passe</translation>
+<translation id="2100273922101894616">Connexion automatique</translation>
+<translation id="363596933471559332">Connexion automatique aux sites Web à l'aide des identifiants enregistrés. Lorsque la fonctionnalité est désactivée, vous êtes invité à effectuer la validation avant chaque connexion à un site Web.</translation>
+<translation id="6995899638241819463">Recevoir une alerte si des mots de passe sont compromis lors d'une violation des données</translation>
+<translation id="1534287762301776620">Lorsque vous vous connectez à votre compte Brave Software, cette fonctionnalité est activée</translation>
+<translation id="10614374240317010">Jamais enregistrés</translation>
+<translation id="3098842761938485917">Afficher et gérer les mots de passe enregistrés dans votre <ph name="BEGIN_LINK"/>compte Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Les mots de passe enregistrés s'affichent ici.</translation>
+<translation id="8084114998886531721">Mot de passe enregistré</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Nom d'utilisateur</translation>
+<translation id="6657585470893396449">Mot de passe</translation>
+<translation id="2154710561487035718">Copier l'URL</translation>
+<translation id="1571304935088121812">Copier le nom d'utilisateur</translation>
+<translation id="5005498671520578047">Copier mot de passe</translation>
+<translation id="3632295766818638029">Afficher le mot de passe</translation>
+<translation id="1513858653616922153">Supprimer le mot de passe</translation>
+<translation id="543338862236136125">Modifier le mot de passe</translation>
+<translation id="4565377596337484307">Masquer le mot de passe</translation>
+<translation id="8523928698583292556">Supprimer le mot de passe enregistré</translation>
+<translation id="2898264748040935573">Modifier le mot de passe enregistré</translation>
+<translation id="5433691172869980887">Nom d'utilisateur copié</translation>
+<translation id="5534640966246046842">Site copié</translation>
+<translation id="2625189173221582860">Mot de passe copié</translation>
+<translation id="4550003330909367850">Pour afficher ou copier votre mot de passe ici, définissez le verrouillage de l'écran sur cet appareil.</translation>
+<translation id="6154478581116148741">Activez le verrouillage de l'écran dans les paramètres pour exporter vos mots de passe à partir de cet appareil</translation>
+<translation id="4842092870884894799">Affichage de la fenêtre contextuelle de génération de mot de passe</translation>
+<translation id="2259659629660284697">Exporter les mots de passe…</translation>
+<translation id="133012818630824069">Exporter les mots de passe enregistrés dans Brave</translation>
+<translation id="6914783257214138813">Toute personne ayant accès au fichier exporté pourra voir ces mots de passe.</translation>
+<translation id="2321086116217818302">Préparation des mots de passe…</translation>
+<translation id="8445448999790540984">Impossible d'exporter les mots de passe</translation>
+<translation id="3066461326500799725">Découvrez comment utiliser Brave Software Drive</translation>
+<translation id="729975465115245577">Aucune application n'est installée sur votre appareil pour stocker le fichier de mots de passe.</translation>
+<translation id="7682724950699840886">Essayez l'astuce suivante°: assurez-vous de disposer de suffisamment d'espace sur votre appareil, puis tentez à nouveau d'exporter les mots de passe.</translation>
+<translation id="1129510026454351943">Détails°: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Déverrouillez pour copier votre mot de passe</translation>
+<translation id="5515439363601853141">Déverrouillez pour afficher votre mot de passe</translation>
+<translation id="6221633008163990886">Déverrouiller pour exporter vos mots de passe</translation>
+<translation id="230699814587342492">Mots de passe Brave Software Brave</translation>
+<translation id="6075798973483050474">Modifier la page d'accueil</translation>
+<translation id="854522910157234410">Ouvrir cette page</translation>
+<translation id="2482878487686419369">Notifications</translation>
+<translation id="6255999984061454636">Recommandations de contenus</translation>
+<translation id="805047784848435650">En fonction de votre historique de navigation</translation>
+<translation id="1041308826830691739">À partir de sites Web</translation>
+<translation id="395206256282351086">Suggestions de recherches et de sites désactivées</translation>
+<translation id="257088987046510401">Thèmes</translation>
+<translation id="4650364565596261010">Paramètre par défaut du système</translation>
+<translation id="7588219262685291874">Activer le thème sombre lorsque l'économiseur de batterie de l'appareil est activé</translation>
+<translation id="2760989362628427051">Activer le thème sombre lorsque le thème sombre ou l'économiseur de batterie de votre appareil est activé</translation>
+<translation id="6381421346744604172">Assombrir les sites Web</translation>
+<translation id="5040262127954254034">Confidentialité</translation>
+<translation id="4991384657077828949">Contribuer à améliorer la sécurité de Brave</translation>
+<translation id="1943176487615318915">Pour détecter les applications et sites dangereux, Brave envoie à Brave Software l'URL de certaines pages que vous consultez, ainsi que des informations système limitées et une partie du contenu de certaines pages.</translation>
+<translation id="3181954750937456830">Navigation sécurisée (assure votre protection et celle de votre appareil contre les sites dangereux)</translation>
+<translation id="7315322926489145388">Envoyer à Brave Software les URL des pages que vous consultez présentant un risque pour votre sécurité</translation>
+<translation id="2063713494490388661">Appuyer pour rechercher</translation>
+<translation id="2369463299479365221">Découvrez les thèmes abordés sur les sites Web sans quitter la page. La fonctionnalité "Appuyer pour rechercher" transmet un mot et son contexte à la recherche Brave Software, qui renvoie à son tour des définitions, des images, des résultats de recherche et d'autres informations.
 
 Pour modifier le terme de recherche, appuyez dessus de manière prolongée afin de le sélectionner. Pour affiner la recherche, faites glisser le panneau jusqu'en haut et appuyez sur le champ de recherche.</translation>
-<translation id="4056223980640387499">Sépia</translation>
-<translation id="4060598801229743805">Options disponibles à proximité du haut de l'écran</translation>
-<translation id="4062305924942672200">Informations légales</translation>
-<translation id="4084682180776658562">Favori</translation>
-<translation id="4084712963632273211">De <ph name="PUBLISHER_ORIGIN" />, <ph name="BEGIN_DEEMPHASIZED" />proposé par Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Supprimer les données de l'application ?</translation>
-<translation id="4099578267706723511">Envoyer des statistiques d'utilisation et des rapports d'erreur pour améliorer Chrome</translation>
-<translation id="410351446219883937">Lecture automatique</translation>
-<translation id="4116038641877404294">Téléchargez des pages pour y accéder hors connexion</translation>
-<translation id="4135200667068010335">La liste des appareils avec lesquels vous pouvez partager un onglet est fermée.</translation>
-<translation id="4149994727733219643">Vue simplifiée pour les pages Web</translation>
-<translation id="4165986682804962316">Paramètres de site</translation>
-<translation id="4169535189173047238">Interdire</translation>
-<translation id="4170011742729630528">Service indisponible. Veuillez réessayer plus tard.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> utilisé(s)</translation>
-<translation id="4181841719683918333">Langues</translation>
-<translation id="4183868528246477015">Utiliser Google Lens <ph name="BEGIN_NEW" />Nouveau<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Ouvrir dans un nouvel onglet</translation>
-<translation id="4198423547019359126">Aucun emplacement de téléchargements disponible</translation>
-<translation id="4209895695669353772">Activez la synchronisation pour obtenir des suggestions de contenu personnalisées de la part de Google</translation>
-<translation id="4226663524361240545">L'appareil vibrera en cas de notifications.</translation>
-<translation id="423219824432660969">Chiffrer les données synchronisées avec le mot de passe Google à la date suivante : <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Ouvrir les paramètres</translation>
-<translation id="4256782883801055595">Licences Open Source</translation>
-<translation id="4259722352634471385">La navigation sur <ph name="URL" /> est bloquée.</translation>
-<translation id="4269820728363426813">Copier l'adresse du lien</translation>
-<translation id="4275663329226226506">Médias</translation>
-<translation id="4278390842282768270">Autorisé</translation>
-<translation id="429312253194641664">Un site est en train de lire un contenu multimédia</translation>
-<translation id="4298388696830689168">Sites associés</translation>
-<translation id="4307992518367153382">Options de base</translation>
-<translation id="4314815835985389558">Gérer la synchronisation</translation>
-<translation id="4351244548802238354">Fermer la boîte de dialogue</translation>
-<translation id="4378154925671717803">Téléphone</translation>
-<translation id="4384468725000734951">Utilisation de Sogou pour les recherches</translation>
-<translation id="4404568932422911380">Aucun favori</translation>
-<translation id="4405224443901389797">Déplacer vers…</translation>
-<translation id="4411535500181276704">Mode simplifié</translation>
-<translation id="4415276339145661267">Gérer votre compte Google</translation>
-<translation id="4432792777822557199">Les pages en <ph name="SOURCE_LANGUAGE" /> seront désormais traduites en <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Page simplifiée fournie par Google</translation>
-<translation id="4434045419905280838">Pop-up et redirections</translation>
-<translation id="4440958355523780886">Page simplifiée fournie par Google. Appuyez pour charger la page d'origine.</translation>
-<translation id="4452411734226507615">Fermer l'onglet <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Ajouté aux favoris dans "<ph name="FOLDER_NAME" />"</translation>
-<translation id="445467742685312942">Autoriser les sites à lire les contenus protégés</translation>
-<translation id="4468959413250150279">Coupe le son d'un site spécifique.</translation>
-<translation id="4472118726404937099">Connectez-vous et activez la synchronisation pour accéder à vos données et les personnaliser sur tous vos appareils</translation>
-<translation id="447252321002412580">Contribuer à l'amélioration des fonctionnalités et des performances de Chrome</translation>
-<translation id="4479647676395637221">Demander avant d'autoriser des sites à utiliser ma caméra (recommandé)</translation>
-<translation id="4479972344484327217">Installation du module <ph name="MODULE" /> pour Chrome…</translation>
-<translation id="4487967297491345095">Toutes les données de l'application Chrome seront supprimées de façon définitive, y compris les fichiers, paramètres, comptes, bases de données, etc.</translation>
-<translation id="4493497663118223949">Mode simplifié activé</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Il y a # jour}one{Il y a # jour}other{Il y a # jours}}</translation>
-<translation id="451872707440238414">Rechercher dans vos favoris</translation>
-<translation id="4521489764227272523">Les données sélectionnées ont été supprimées de Chrome et des appareils synchronisés.
-
-Votre compte Google conserve peut-être d'autres contenus d'historique de navigation sur la page <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> concernant, par exemple, vos recherches ou vos activités via d'autres services Google.</translation>
-<translation id="4532845899244822526">Sélectionner un dossier</translation>
-<translation id="4538018662093857852">Activer le mode simplifié</translation>
-<translation id="4550003330909367850">Pour afficher ou copier votre mot de passe ici, définissez le verrouillage de l'écran sur cet appareil.</translation>
-<translation id="4558311620361989323">Raccourcis de pages Web</translation>
-<translation id="4561979708150884304">Aucune connexion</translation>
-<translation id="4565377596337484307">Masquer le mot de passe</translation>
-<translation id="4570913071927164677">Détails</translation>
-<translation id="4572422548854449519">Se connecter à un compte géré</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Il y a # minute}one{Il y a # minute}other{Il y a # minutes}}</translation>
-<translation id="4587589328781138893">Sites</translation>
-<translation id="4594952190837476234">Cette page hors connexion date du <ph name="CREATION_TIME" /> et peut différer de la version en ligne.</translation>
-<translation id="4605958867780575332">Élément supprimé : <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Ouvrir <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Utiliser le mot de passe</translation>
-<translation id="4645575059429386691">Géré par ton papa/ta maman</translation>
-<translation id="4650364565596261010">Paramètre par défaut du système</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> favoris ont été supprimés.</translation>
-<translation id="4665282149850138822">Le site "<ph name="NAME" />" a bien été ajouté à votre écran d'accueil.</translation>
-<translation id="4684427112815847243">Tout synchroniser</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> de plus}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> de plus}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> de plus}}</translation>
-<translation id="4696983787092045100">Envoyer le SMS à vos appareils</translation>
-<translation id="4698034686595694889">Afficher hors connexion dans <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Images et fichiers en cache</translation>
-<translation id="4714588616299687897">Économisez jusqu'à 60 % de vos données</translation>
-<translation id="4719927025381752090">Proposer de traduire</translation>
-<translation id="4720023427747327413">Ouvrir dans <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Aidez-nous à améliorer Chrome. <ph name="BEGIN_LINK" />Répondez à notre enquête<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Mettre à jour</translation>
-<translation id="4738836084190194332">Dernière synchronisation : <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Ouvrir un nouvel onglet</translation>
-<translation id="4751476147751820511">Capteurs de mouvement ou de lumière</translation>
-<translation id="4759238208242260848">Téléchargements</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 téléchargement terminé.}one{# téléchargement terminé.}other{# téléchargements terminés.}}</translation>
-<translation id="4797039098279997504">Appuyer ici pour revenir à l'adresse <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Le chiffrement par phrase secrète ne s'applique pas aux modes de paiement et adresses Google Pay.
-
-Pour modifier ce paramètre, <ph name="BEGIN_LINK" />réinitialisez la synchronisation<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Titulaire de la carte</translation>
-<translation id="4824958205181053313">Annuler la synchronisation ?</translation>
-<translation id="4837753911714442426">Afficher les options d'impression de la page</translation>
-<translation id="4842092870884894799">Affichage de la fenêtre contextuelle de génération de mot de passe</translation>
-<translation id="4860895144060829044">Appeler</translation>
-<translation id="4866368707455379617">Impossible d'installer le module <ph name="MODULE" /> pour Chrome</translation>
-<translation id="4875775213178255010">Recommandations de contenus</translation>
-<translation id="4878404682131129617">Échec de l'établissement d'un tunnel via un serveur proxy</translation>
-<translation id="4880127995492972015">Traduire…</translation>
-<translation id="4881695831933465202">Ouvrir</translation>
-<translation id="488187801263602086">Renommer le fichier</translation>
-<translation id="4882831918239250449">Contrôler la manière dont votre historique de navigation est utilisé pour personnaliser la recherche, les annonces, etc.</translation>
-<translation id="4883854917563148705">Impossible de réinitialiser les paramètres gérés</translation>
-<translation id="4885273946141277891">Le nombre d'instances de Chrome n'est pas compatible.</translation>
-<translation id="4910889077668685004">Applications de paiement</translation>
-<translation id="4913161338056004800">Réinitialiser les statistiques</translation>
-<translation id="4913169188695071480">Ne plus actualiser</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Obtenir de l'aide<ph name="END_LINK" /> lors de la recherche d'appareils…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# page}one{# page}other{# pages}}</translation>
-<translation id="4932247056774066048">Vous vous déconnectez d'un compte géré par <ph name="DOMAIN_NAME" />. Vos données Chrome seront donc supprimées de cet appareil, mais elles seront conservées dans votre compte Google.</translation>
-<translation id="4943703118917034429">Réalité virtuelle</translation>
-<translation id="4943872375798546930">Aucun résultat</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> partage votre écran.</translation>
-<translation id="4961107849584082341">Traduire cette page dans n'importe quelle langue</translation>
-<translation id="4962975101802056554">Révoquer toutes les autorisations de l'appareil</translation>
-<translation id="4970824347203572753">Fonctionnalité non disponible dans votre pays</translation>
-<translation id="497421865427891073">Avancer</translation>
-<translation id="4988210275050210843">Téléchargement du fichier (<ph name="MEGABYTES" />)…</translation>
-<translation id="4988526792673242964">Pages</translation>
-<translation id="4994033804516042629">Aucun contact trouvé</translation>
-<translation id="4996978546172906250">Partager via</translation>
-<translation id="5004416275253351869">Commandes Google relatives à l'activité</translation>
-<translation id="5005498671520578047">Copier mot de passe</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> tente de se connecter</translation>
-<translation id="5013696553129441713">Aucune nouvelle suggestion</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Lorsque vous utilisez le mode RV, le site peut retenir les informations suivantes :
-  – Vos caractéristiques physiques, telles que votre taille
-
-N'activez la RV que si vous faites confiance à ce site.</translation>
+<translation id="2930742481329940825">La fonctionnalité "Appuyer pour rechercher" transmet le mot sélectionné et la page actuelle en tant que contexte à la recherche Brave Software. Vous pouvez la désactiver dans les <ph name="BEGIN_LINK"/>paramètres<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Autoriser</translation>
-<translation id="5040262127954254034">Confidentialité</translation>
-<translation id="5048398596102334565">Autoriser les sites à accéder à vos capteurs de mouvement (recommandé)</translation>
-<translation id="5063480226653192405">Utilisation</translation>
-<translation id="5087580092889165836">Ajouter une carte</translation>
-<translation id="5100237604440890931">Réduit – Cliquer pour développer</translation>
-<translation id="510275257476243843">1 heure restante</translation>
-<translation id="5123685120097942451">Onglet de navigation privée</translation>
-<translation id="5127805178023152808">La synchronisation est désactivée.</translation>
-<translation id="5129038482087801250">Installer l'application Web</translation>
-<translation id="5132942445612118989">Synchroniser vos mots de passe, votre historique et plus encore sur tous les appareils</translation>
-<translation id="5139940364318403933">Découvrez comment utiliser Google Drive</translation>
-<translation id="515227803646670480">Effacer les données stockées</translation>
-<translation id="5152843274749979095">Aucune application compatible n'est installée</translation>
-<translation id="5161254044473106830">Veuillez saisir un titre.</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Échec de 1 téléchargement.}one{Échec de # téléchargement.}other{Échec de # téléchargements.}}</translation>
-<translation id="5170568018924773124">Afficher le dossier</translation>
-<translation id="5184329579814168207">Ouvrir dans Chrome</translation>
-<translation id="5193988420012215838">Copié dans le presse-papiers</translation>
-<translation id="5197729504361054390">Les contacts que vous sélectionnez seront partagés avec <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Profil professionnel</translation>
-<translation id="5210286577605176222">Accéder à l'onglet précédent</translation>
-<translation id="5210365745912300556">Fermer l'onglet</translation>
-<translation id="5224771365102442243">Avec vidéo</translation>
-<translation id="5230560987958996918">Le site <ph name="SITE" /> souhaite rechercher les appareils Bluetooth à proximité. Les appareils suivants ont été détectés :</translation>
-<translation id="5233638681132016545">Nouvel onglet</translation>
-<translation id="526421993248218238">Impossible de charger cette page</translation>
-<translation id="5271967389191913893">Impossible d'ouvrir le contenu à télécharger sur l'appareil.</translation>
-<translation id="528192093759286357">Pour quitter le mode plein écran, faites glisser un doigt du haut vers le bas, puis appuyez sur le bouton Retour.</translation>
-<translation id="5292796745632149097">Envoyer sur</translation>
-<translation id="5300589172476337783">Afficher</translation>
-<translation id="5301954838959518834">OK</translation>
-<translation id="5304593522240415983">Champ obligatoire.</translation>
-<translation id="5307446750509046227">Effacer données stockage</translation>
-<translation id="5308380583665731573">Connexion</translation>
-<translation id="5313967007315987356">Ajouter un site</translation>
-<translation id="5317780077021120954">Enregistrer</translation>
-<translation id="5324858694974489420">Paramètres parentaux</translation>
-<translation id="5327248766486351172">Nom</translation>
-<translation id="5335288049665977812">Autoriser les sites à exécuter JavaScript (recommandé)</translation>
-<translation id="5342314432463739672">Demandes d'autorisation</translation>
-<translation id="5357811892247919462">Onglet reçu</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> onglet ouvert, appuyez pour changer d'onglet}one{<ph name="OPEN_TABS_MANY" /> onglet ouvert, appuyez pour changer d'onglet}other{<ph name="OPEN_TABS_MANY" /> onglets ouverts, appuyez pour changer d'onglet}}</translation>
-<translation id="5391532827096253100">Votre connexion à ce site n'est pas sécurisée. Informations sur le site</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 autre)}one{(+ # autre)}other{(+ # autres)}}</translation>
-<translation id="5400569084694353794">En utilisant cette application, vous acceptez les <ph name="BEGIN_LINK1" />Conditions d'utilisation<ph name="END_LINK1" /> et l'<ph name="BEGIN_LINK2" />Avis de confidentialité<ph name="END_LINK2" /> de Chrome.</translation>
-<translation id="5403592356182871684">Noms</translation>
-<translation id="5403644198645076998">N'autoriser que certains sites</translation>
-<translation id="5414836363063783498">Validation en cours…</translation>
-<translation id="5423934151118863508">Les pages les plus consultées s'affichent ici.</translation>
-<translation id="5424588387303617268">Espace disponible : <ph name="GIGABYTES" /> Go</translation>
-<translation id="543338862236136125">Modifier le mot de passe</translation>
-<translation id="5433691172869980887">Nom d'utilisateur copié</translation>
-<translation id="543509235395288790">Téléchargement de <ph name="COUNT" /> fichiers (<ph name="MEGABYTES" />)…</translation>
-<translation id="5441522332038954058">Accéder à la barre d'adresse</translation>
-<translation id="5447201525962359567">Toutes les données de site stockées, y compris les cookies et d'autres données stockées en local</translation>
-<translation id="5447765697759493033">Ce site ne sera pas traduit</translation>
-<translation id="545042621069398927">Accélération du téléchargement…</translation>
-<translation id="5456381639095306749">Télécharger la page</translation>
-<translation id="5475862044948910901">Lancer une session en réalité augmentée ?</translation>
-<translation id="548278423535722844">Ouvrir dans une application de plans</translation>
-<translation id="5487521232677179737">Effacer les données</translation>
-<translation id="5494752089476963479">Bloquer les annonces sur les sites qui affichent des annonces intrusives ou trompeuses</translation>
-<translation id="5500777121964041360">Cette fonctionnalité n'est peut-être pas disponible dans votre pays</translation>
-<translation id="5512137114520586844">Ce compte est géré par <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Désactivé par l'administrateur de cet appareil</translation>
-<translation id="5515439363601853141">Déverrouillez pour afficher votre mot de passe</translation>
-<translation id="5516455585884385570">Ouvrir les paramètres de notification</translation>
-<translation id="5517095782334947753">Vous disposez des favoris, de l'historique, des mots de passe et d'autres paramètres du compte <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Redirection bloquée.</translation>
-<translation id="5527082711130173040">Chrome doit avoir accès aux données de localisation pour rechercher des appareils. <ph name="BEGIN_LINK1" />Modifiez les autorisations.<ph name="END_LINK1" /> De plus, l'accès aux données de localisation est <ph name="BEGIN_LINK2" />désactivé pour cet appareil<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Demander avant d'autoriser les sites à accéder en lecture au texte et aux images du presse-papiers (recommandé)</translation>
-<translation id="5530766185686772672">Fermer onglets navig. privée</translation>
-<translation id="5534334044554683961">Lorsque vous utilisez le mode RV, le site peut retenir les informations suivantes :
-  – Vos caractéristiques physiques, telles que votre taille
-  – La disposition de la pièce
-
-N'activez la RV que si vous faites confiance à ce site.</translation>
-<translation id="5534640966246046842">Site copié</translation>
-<translation id="5556459405103347317">Actualiser</translation>
-<translation id="5561549206367097665">En attente de connexion au réseau…</translation>
-<translation id="557283862590186398">Chrome a besoin de votre autorisation pour accéder à votre micro pour ce site.</translation>
-<translation id="55737423895878184">La localisation et les notifications sont autorisées</translation>
-<translation id="5578795271662203820">Rechercher l'image sur <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Vous avez toujours la possibilité de sélectionner les éléments à synchroniser dans les <ph name="BEGIN_LINK1" />paramètres<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Modifier l'adresse</translation>
-<translation id="5596627076506792578">Plus d'options</translation>
-<translation id="5599455543593328020">Mode Navigation privée</translation>
-<translation id="5620928963363755975">Recherchez vos fichiers et vos pages dans les téléchargements, à partir du bouton "Plus d'options"</translation>
-<translation id="5626134646977739690">Nom :</translation>
-<translation id="5639724618331995626">Autoriser tous les sites</translation>
-<translation id="5648166631817621825">7 derniers jours</translation>
-<translation id="5649053991847567735">Téléchargements automatiques</translation>
-<translation id="5655963694829536461">Recherchez dans les téléchargements</translation>
-<translation id="5659593005791499971">E-mail</translation>
-<translation id="5665379678064389456">Créer un événement dans <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ignore la demande d'un site d'empêcher les zooms avant</translation>
-<translation id="5677928146339483299">Bloqué</translation>
-<translation id="5684874026226664614">Petit problème… Impossible de traduire cette page.</translation>
-<translation id="5686790454216892815">Nom de fichier trop long</translation>
-<translation id="5689516760719285838">Position</translation>
-<translation id="569536719314091526">Traduire cette page dans n'importe quelle langue à partir du bouton "Plus d'options"</translation>
-<translation id="572328651809341494">Onglets récents</translation>
-<translation id="5726692708398506830">Agrandir tous les éléments de la page</translation>
-<translation id="5748802427693696783">Onglets standards sélectionnés</translation>
-<translation id="5749068826913805084">Pour télécharger des fichiers, Chrome a besoin d'accéder à l'espace de stockage.</translation>
-<translation id="5763382633136178763">Onglets de navigation privée</translation>
-<translation id="5763514718066511291">Appuyez pour copier l'URL pour cette application</translation>
-<translation id="5765780083710877561">Description :</translation>
-<translation id="5793665092639000975">Utilisation de <ph name="SPACE_USED" /> sur <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google peut utiliser votre historique pour personnaliser la recherche, les annonces et d'autres services Google</translation>
-<translation id="5804241973901381774">Autorisations</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Il y a # heure}one{Il y a # heure}other{Il y a # heures}}</translation>
-<translation id="5810288467834065221">© <ph name="YEAR" /> Google LLC. Tous droits réservés.</translation>
-<translation id="5817918615728894473">Associer</translation>
-<translation id="583281660410589416">Inconnu</translation>
-<translation id="5833984609253377421">Partager le lien</translation>
-<translation id="5836192821815272682">Téléchargement de la mise à jour de Chrome…</translation>
-<translation id="5853623416121554550">suspendu</translation>
-<translation id="5854790677617711513">Datant de plus de 30 jours</translation>
-<translation id="5858741533101922242">Impossible d'activer l'adaptateur Bluetooth dans Chrome</translation>
-<translation id="5860033963881614850">Désactivé</translation>
-<translation id="5862731021271217234">Activez la synchronisation pour accéder à vos onglets sur vos autres appareils</translation>
-<translation id="5864174910718532887">Détails : tri effectué par nom de site</translation>
-<translation id="5864419784173784555">En attente d'un autre téléchargement…</translation>
-<translation id="5865733239029070421">Envoie automatiquement des statistiques d'utilisation et des rapports d'erreur à Google</translation>
-<translation id="5869522115854928033">Mots de passe enregistrés</translation>
-<translation id="5902828464777634901">Toutes les données locales stockées par ce site, y compris les cookies, seront supprimées.</translation>
-<translation id="5916664084637901428">Activé</translation>
-<translation id="5919204609460789179">Mettre à jour <ph name="PRODUCT_NAME" /> pour lancer la synchronisation</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> économisé(s)</translation>
-<translation id="5939518447894949180">Réinitialiser</translation>
-<translation id="5942872142862698679">Utilisation de Google pour les recherches</translation>
-<translation id="5952764234151283551">Envoie l'URL de la page que vous essayez d'ouvrir à Google</translation>
-<translation id="5956665950594638604">Ouvrir le centre d'aide dans un nouvel onglet</translation>
-<translation id="5958275228015807058">Recherchez vos fichiers et vos pages dans la section "Téléchargements"</translation>
-<translation id="5962718611393537961">Appuyer pour réduire</translation>
-<translation id="6000066717592683814">Conserver Google</translation>
-<translation id="6005538289190791541">Mot de passe suggéré</translation>
-<translation id="6036057147555329831">ICU supplémentaire</translation>
-<translation id="6039379616847168523">Accéder à l'onglet suivant</translation>
-<translation id="6040143037577758943">Fermer</translation>
-<translation id="6042308850641462728">Plus</translation>
-<translation id="604996488070107836">Échec du téléchargement du fichier "<ph name="FILE_NAME" />" en raison d'une erreur inconnue.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Téléchargements terminés</translation>
-<translation id="6075798973483050474">Modifier la page d'accueil</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> heures restantes</translation>
-<translation id="6108923351542677676">Configuration en cours…</translation>
-<translation id="6111020039983847643">de données utilisées</translation>
-<translation id="6112702117600201073">Actualisation de la page</translation>
-<translation id="6127379762771434464">Élément supprimé</translation>
-<translation id="6140912465461743537">Pays/Région</translation>
-<translation id="614940544461990577">Voici quelques conseils :</translation>
-<translation id="6154478581116148741">Activez le verrouillage de l'écran dans les paramètres pour exporter vos mots de passe à partir de cet appareil</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> de données économisées</translation>
-<translation id="6165508094623778733">En savoir plus</translation>
-<translation id="6177111841848151710">Bloqué pour le moteur de recherche actuel</translation>
-<translation id="6181444274883918285">Ajouter une exception pour un site</translation>
-<translation id="6192333916571137726">Télécharger le fichier</translation>
-<translation id="6192792657125177640">Exceptions</translation>
-<translation id="6194112207524046168">Pour autoriser Chrome à accéder à votre appareil photo, activez également ce dernier dans les <ph name="BEGIN_LINK" />paramètres Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Bloquer les cookies tiers</translation>
-<translation id="6206551242102657620">La connexion est sécurisée. Informations sur le site</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> n'est pas votre adresse e-mail ?</translation>
-<translation id="6221633008163990886">Déverrouiller pour exporter vos mots de passe</translation>
+<translation id="1406000523432664303">Interdire le suivi</translation>
 <translation id="6232535412751077445">Si vous interdisez le suivi, une demande sera incluse dans le trafic lié à votre navigation. Les résultats obtenus dépendent de la réponse du site (s'il répond ou non) et de la manière dont il interprète la demande.
 
 Par exemple, certains sites Web peuvent répondre à cette demande en diffusant des annonces qui ne sont pas déterminées en fonction des autres sites Web que vous avez consultés. Toutefois, nombre d'entre eux recueillent et utilisent vos données de navigation afin, par exemple, d'améliorer la sécurité ou d'afficher du contenu, des services, des annonces et des recommandations, ou encore pour générer des rapports statistiques.</translation>
-<translation id="624789221780392884">Mise à jour prête</translation>
-<translation id="6255999984061454636">Recommandations de contenus</translation>
-<translation id="6277522088822131679">Un problème est survenu lors de l'impression de la page. Veuillez réessayer.</translation>
-<translation id="6295158916970320988">Tous les sites</translation>
-<translation id="629730747756840877">Compte</translation>
-<translation id="6303969859164067831">Se déconnecter et désactiver la synchronisation</translation>
-<translation id="6316139424528454185">Version Android non compatible</translation>
-<translation id="6320088164292336938">Vibreur</translation>
-<translation id="6324034347079777476">La synchronisation du système Android est désactivée.</translation>
-<translation id="6333140779060797560">Partager via <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Chiffrement</translation>
-<translation id="6341580099087024258">Demander où enregistrer les fichiers</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> de plus}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> de plus}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> de plus}}</translation>
-<translation id="6364438453358674297">Supprimer la suggestion de l'historique ?</translation>
-<translation id="6369229450655021117">Ici, vous pouvez faire des recherches sur le Web, partager des contenus avec vos amis et voir les pages ouvertes</translation>
-<translation id="6378173571450987352">Détails : tri effectué par volume de données utilisées</translation>
-<translation id="6381421346744604172">Assombrir les sites Web</translation>
-<translation id="6388207532828177975">Effacer et réinitialiser</translation>
-<translation id="6393863479814692971">Chrome a besoin de votre autorisation pour accéder à votre appareil photo et à votre micro pour ce site.</translation>
-<translation id="6395288395575013217">LIEN</translation>
-<translation id="6404511346730675251">Modifier le favori</translation>
-<translation id="6406506848690869874">Synchronisation</translation>
-<translation id="641643625718530986">Imprimer…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> Mo téléchargé(s)</translation>
-<translation id="6427112570124116297">Traduire le Web</translation>
-<translation id="6433501201775827830">Sélectionner votre moteur de recherche</translation>
-<translation id="6437478888915024427">Infos sur la page</translation>
-<translation id="6441734959916820584">Nom trop long</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# image}one{# image}other{# images}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Impossible d'ouvrir le fichier</translation>
-<translation id="6464977750820128603">Vous pouvez voir les sites que vous avez consultés dans Chrome et définir des minuteurs pour ceux-ci.\n\nGoogle obtient des informations sur les sites pour lesquels vous définissez des minuteurs et peut déterminer le temps que vous passez sur ces derniers. Ces informations sont utilisées pour améliorer Bien-être numérique.</translation>
-<translation id="6475951671322991020">Télécharger la vidéo</translation>
-<translation id="6482749332252372425">Échec du téléchargement du fichier "<ph name="FILE_NAME" />" en raison de l'espace de stockage insuffisant.</translation>
-<translation id="6496823230996795692">Pour utiliser <ph name="APP_NAME" /> pour la première fois, veuillez vous connecter à Internet.</translation>
-<translation id="6508722015517270189">Relancez Chrome</translation>
-<translation id="6527303717912515753">Partager</translation>
-<translation id="6532866250404780454">Les sites que vous consultez dans Chrome ne s'afficheront pas. Tous les minuteurs de site seront supprimés.</translation>
-<translation id="6534565668554028783">Google a mis trop de temps à répondre</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> Go téléchargé(s)</translation>
-<translation id="6539092367496845964">Un problème est survenu. Réessayez plus tard.</translation>
-<translation id="654446541061731451">Sélectionnez un onglet à partager.</translation>
-<translation id="6545017243486555795">Supprimer toutes les données</translation>
-<translation id="6545864417968258051">Recherche Bluetooth</translation>
-<translation id="6560414384669816528">Rechercher avec Sogou</translation>
-<translation id="6566259936974865419">Chrome vous a permis de gagner <ph name="GIGABYTES" /> Go</translation>
-<translation id="6573096386450695060">Toujours autoriser</translation>
-<translation id="6573431926118603307">Les onglets que vous avez ouverts dans Chrome sur vos autres appareils s'affichent ici.</translation>
-<translation id="6583199322650523874">Marquer la page actuelle en tant que favori</translation>
-<translation id="6593061639179217415">Version pour ordinateur</translation>
-<translation id="6600954340915313787">Copiée dans Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> Go</translation>
-<translation id="6612358246767739896">Contenu protégé</translation>
-<translation id="6627583120233659107">Modifier le dossier</translation>
-<translation id="6643016212128521049">Effacer</translation>
-<translation id="6643649862576733715">Trier en fonction de la quantité de données économisées</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> de plus}one{<ph name="CONTACT_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> de plus}other{<ph name="CONTACT_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> de plus}}</translation>
-<translation id="6649642165559792194">Prévisualiser l'image <ph name="BEGIN_NEW" />Nouveau<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome doit accéder aux données de localisation pour rechercher des appareils. <ph name="BEGIN_LINK" />Mettre à jour les autorisations<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Mot de passe</translation>
-<translation id="6659594942844771486">Onglet</translation>
-<translation id="666731172850799929">Ouvrir dans <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Avis de confidentialité de Chrome</translation>
-<translation id="6676840375528380067">Supprimer vos données Chrome sur cet appareil ?</translation>
-<translation id="6697492270171225480">Afficher des suggestions de pages similaires lorsqu'une page est introuvable</translation>
-<translation id="6697947395630195233">Chrome a besoin d'accéder à votre position pour la partager avec ce site.</translation>
-<translation id="6698801883190606802">Gérer les données synchronisées</translation>
-<translation id="6699370405921460408">Grâce aux serveurs Google, les pages que vous consultez sont optimisées.</translation>
-<translation id="6706288973712894588">Vous êtes actuellement hors connexion.\n<ph name="BEGIN_LINK" />Consultez votre flux hors connexion.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Actualités</translation>
-<translation id="6710213216561001401">Précédent</translation>
-<translation id="671481426037969117">Votre minuteur <ph name="FQDN" /> a expiré. Il redémarrera demain.</translation>
-<translation id="6738867403308150051">Téléchargement en cours…</translation>
-<translation id="6746124502594467657">Descendre</translation>
-<translation id="6766622839693428701">Balayez l'écran vers le bas pour fermer la feuille.</translation>
-<translation id="6766758767654711248">Appuyez pour accéder au site</translation>
-<translation id="6767294960381293877">La liste des appareils avec lesquels vous pouvez partager un onglet est ouverte à mi-hauteur.</translation>
-<translation id="6782111308708962316">Empêcher les sites Web tiers d'enregistrer et de lire les données des cookies</translation>
-<translation id="6790428901817661496">Lire</translation>
-<translation id="6811034713472274749">La page est prête à être affichée</translation>
-<translation id="6818926723028410516">Sélectionner des éléments</translation>
-<translation id="6820686453637990663">Code CVC :</translation>
-<translation id="6831043979455480757">Traduire</translation>
-<translation id="6845325883481699275">Contribuer à améliorer la sécurité de Chrome</translation>
-<translation id="6846298663435243399">Chargement en cours…</translation>
-<translation id="6850409657436465440">Téléchargement toujours en cours</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> onglets ont été fermés.</translation>
-<translation id="6864459304226931083">Télécharger l'image</translation>
-<translation id="6865313869410766144">Données de saisie automatique</translation>
-<translation id="688738109438487280">Ajoutez les données existantes au compte <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Déverrouillez pour copier votre mot de passe</translation>
-<translation id="6896758677409633944">Copier</translation>
-<translation id="6910211073230771657">Supprimé</translation>
-<translation id="6912998170423641340">Interdire aux sites d'accéder en lecture au texte et aux images du presse-papiers</translation>
-<translation id="6914783257214138813">Toute personne ayant accès au fichier exporté pourra voir ces mots de passe.</translation>
-<translation id="6942665639005891494">Modifier à tout moment l'emplacement de téléchargement par défaut à l'aide de l'option de menu "Paramètres"</translation>
-<translation id="6945221475159498467">Sélectionner</translation>
-<translation id="6963642900430330478">Cette page est dangereuse. Informations sur le site</translation>
-<translation id="6963766334940102469">Supprimer des favoris</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Toutes les périodes</translation>
-<translation id="6981982820502123353">Accessibilité</translation>
-<translation id="6989267951144302301">Échec du téléchargement</translation>
-<translation id="6990079615885386641">Télécharger l'application sur le Google Play Store : <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Demander avant d'autoriser des sites à utiliser mon micro (recommandé)</translation>
-<translation id="7015203776128479407">La configuration de la synchronisation initiale n'était pas terminée. La synchronisation est désactivée.</translation>
-<translation id="7016516562562142042">Autorisé pour le moteur de recherche actuel</translation>
-<translation id="7022756207310403729">Ouvrir dans le navigateur</translation>
-<translation id="702463548815491781">Recommandé quand TalkBack ou Switch Access sont activés</translation>
-<translation id="7029809446516969842">Mots de passe</translation>
-<translation id="7053983685419859001">Bloquer</translation>
-<translation id="7055152154916055070">Redirection bloquée :</translation>
-<translation id="7063006564040364415">Impossible de se connecter au serveur de synchronisation.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 élément sélectionné}one{# élément sélectionné}other{# éléments sélectionnés}}</translation>
-<translation id="7071521146534760487">Gérer le compte</translation>
-<translation id="7077143737582773186">Carte SD</translation>
-<translation id="7087918508125750058">Nombre d'éléments sélectionnés : <ph name="ITEM_COUNT" />. Options disponibles dans la partie supérieure de l'écran</translation>
-<translation id="7121362699166175603">Efface l'historique et les saisies semi-automatiques dans la barre d'adresse. Votre compte Google conserve peut-être d'autres formes d'historique de navigation sur la page <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Autoriser pour le moteur de recherche actuel</translation>
-<translation id="7138678301420049075">Autre</translation>
-<translation id="7141896414559753902">Bloquer l'affichage de fenêtres pop-up et de redirections par les sites (recommandé)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Charger la page originale<ph name="END_LINK" /> de <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Dernières 24 heures</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> Ko</translation>
-<translation id="7177466738963138057">Vous pourrez modifier le moteur de recherche plus tard dans les paramètres</translation>
-<translation id="7180611975245234373">Actualiser</translation>
-<translation id="7189372733857464326">En attente de la fin de la mise à jour des services Google Play</translation>
-<translation id="7191430249889272776">L'onglet a été ouvert en arrière-plan.</translation>
-<translation id="723171743924126238">Sélectionner des images</translation>
-<translation id="7233236755231902816">Pour afficher le Web dans votre langue, téléchargez la dernière version de Chrome</translation>
-<translation id="7243308994586599757">Options disponibles au bas de l'écran</translation>
-<translation id="7248069434667874558">Assurez-vous que la synchronisation est activée sur votre <ph name="TARGET_DEVICE_NAME" /> dans Chrome</translation>
-<translation id="7250468141469952378">Nombre d'éléments sélectionnés : <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Site bloqué</translation>
-<translation id="7290209999329137901">Option de changement de nom indisponible</translation>
-<translation id="7291387454912369099">Règlement via l'Assistant</translation>
-<translation id="7293171162284876153">Pour lancer la synchronisation, activez l'option "Synchroniser vos données Chrome".</translation>
-<translation id="729975465115245577">Aucune application n'est installée sur votre appareil pour stocker le fichier de mots de passe.</translation>
-<translation id="7302081693174882195">Détails : tri effectué par volume de données enregistrées</translation>
-<translation id="7328017930301109123">En mode simplifié, Chrome charge les pages plus rapidement et consomme jusqu'à 60 pour cent de données en moins.</translation>
-<translation id="7333031090786104871">L'ajout du site précédent est toujours en cours</translation>
-<translation id="7352939065658542140">VIDÉO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Partager 1 élément sélectionné}one{Partager # élément sélectionné}other{Partager # éléments sélectionnés}}</translation>
 <translation id="7359002509206457351">Accéder aux modes de paiement</translation>
+<translation id="8026334261755873520">Effacer les données de navigation</translation>
+<translation id="1291207594882862231">Efface l'historique, vider le cache, supprimer les cookies et les données de site…</translation>
+<translation id="7814200940910057384">Données de Brave effacées</translation>
+<translation id="1664855196866195614">Les données sélectionnées ont été supprimées de Brave et des appareils synchronisés.
+
+Votre compte Brave Software conserve peut-être d'autres contenus d'historique de navigation sur la page <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> concernant, par exemple, vos recherches ou vos activités via d'autres services Brave Software.</translation>
+<translation id="4699172675775169585">Images et fichiers en cache</translation>
+<translation id="2496180316473517155">Historique de navigation</translation>
+<translation id="2546283357679194313">Cookies et données de site</translation>
+<translation id="8662811608048051533">Vous déconnecte de la plupart des sites.</translation>
+<translation id="8218628800671693884">Vous déconnecte de la plupart des sites. Vous ne serez cependant pas déconnecté de votre compte Brave Software.</translation>
+<translation id="2017836877785168846">Efface l'historique et les saisies semi-automatiques dans la barre d'adresse.</translation>
+<translation id="8096327394278038498">Efface l'historique et les saisies semi-automatiques dans la barre d'adresse. Votre compte Brave Software conserve peut-être d'autres formes d'historique de navigation sur la page <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Efface l'historique de tous les appareils sur lesquels vous êtes connecté à votre compte Brave Software. Ce dernier peut conserver d'autres formes d'historique de navigation sur la page <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Mots de passe enregistrés</translation>
+<translation id="6865313869410766144">Données de saisie automatique</translation>
+<translation id="7562080006725997899">Effacement des données de navigation en cours</translation>
+<translation id="5487521232677179737">Effacer les données</translation>
+<translation id="7498271377022651285">Veuillez patienter…</translation>
+<translation id="784934925303690534">Période</translation>
+<translation id="1718835860248848330">Dernière heure</translation>
+<translation id="7149893636342594995">Dernières 24 heures</translation>
+<translation id="5648166631817621825">7 derniers jours</translation>
+<translation id="8571213806525832805">4 dernières semaines</translation>
+<translation id="5854790677617711513">Datant de plus de 30 jours</translation>
+<translation id="6979737339423435258">Toutes les périodes</translation>
+<translation id="982182592107339124">Cette action entraînera la suppression des données pour tous les sites, y compris :</translation>
+<translation id="6643016212128521049">Effacer</translation>
+<translation id="7641339528570811325">Effacer les données de navigation</translation>
+<translation id="1670399744444387456">Général</translation>
+<translation id="3245261285041759672">Votre compte Brave Software conserve peut-être d'autres formes d'historique de navigation sur la page <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Site bloqué</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> éléments supprimés</translation>
+<translation id="1121094540300013208">Statistiques d'utilisation et rapports d'erreur</translation>
+<translation id="9079153198295609735">Envoie automatiquement les statistiques d'utilisation et les rapports d'erreur à Brave Software</translation>
+<translation id="6981982820502123353">Accessibilité</translation>
+<translation id="2387895666653383613">Mise à l'échelle du texte</translation>
+<translation id="2321958826496381788">Faites glisser le curseur pour lire le texte aisément. Sa taille doit être similaire à celle-ci lorsque vous appuyez deux fois sur un paragraphe.</translation>
+<translation id="3895926599014793903">Forcer l'activation du zoom</translation>
+<translation id="5668404140385795438">Ignore la demande d'un site d'empêcher les zooms avant</translation>
+<translation id="4149994727733219643">Vue simplifiée pour les pages Web</translation>
+<translation id="9100505651305367705">Propose une vue simplifiée des articles, si compatibles</translation>
+<translation id="1409426117486808224">Vue simplifiée pour les onglets ouverts</translation>
+<translation id="702463548815491781">Recommandé quand TalkBack ou Switch Access sont activés</translation>
+<translation id="8284326494547611709">Sous-titres</translation>
+<translation id="4165986682804962316">Paramètres de site</translation>
+<translation id="6295158916970320988">Tous les sites</translation>
+<translation id="8380167699614421159">Ce site affiche des annonces intrusives ou trompeuses</translation>
+<translation id="1919345977826869612">Annonces</translation>
+<translation id="410351446219883937">Lecture automatique</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Bloquer les cookies tiers</translation>
+<translation id="6782111308708962316">Empêcher les sites Web tiers d'enregistrer et de lire les données des cookies</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-up et redirections</translation>
+<translation id="4751476147751820511">Capteurs de mouvement ou de lumière</translation>
+<translation id="1717218214683051432">Capteurs de mouvement</translation>
+<translation id="2091887806945687916">Son</translation>
+<translation id="2586657967955657006">Presse-papiers</translation>
+<translation id="6320088164292336938">Vibreur</translation>
+<translation id="4226663524361240545">L'appareil vibrera en cas de notifications.</translation>
+<translation id="1446450296470737166">Autoriser le contrôle complet des appareils MIDI</translation>
+<translation id="3744111561329211289">Synchronisation en arrière-plan</translation>
+<translation id="5649053991847567735">Téléchargements automatiques</translation>
+<translation id="6181444274883918285">Ajouter une exception pour un site</translation>
+<translation id="5313967007315987356">Ajouter un site</translation>
+<translation id="1369915414381695676">Site "<ph name="SITE_NAME"/>" ajouté</translation>
+<translation id="7837721118676387834">Autorisez la lecture automatique des vidéos dont le son est coupé pour un site spécifique.</translation>
+<translation id="2621115761605608342">Autorisez le langage JavaScript pour un site spécifique.</translation>
+<translation id="8801436777607969138">Bloquer JavaScript sur un site spécifique.</translation>
+<translation id="8372893542064058268">Autorise la synchronisation en arrière-plan pour un site spécifique.</translation>
+<translation id="358794129225322306">Autoriser un site à télécharger automatiquement plusieurs fichiers</translation>
+<translation id="4008040567710660924">Autorisez les cookies pour un site spécifique.</translation>
+<translation id="8958424370300090006">Bloquez les cookies pour un site spécifique.</translation>
+<translation id="7882806643839505685">Autorisez le son pour un site spécifique.</translation>
+<translation id="4468959413250150279">Coupe le son d'un site spécifique.</translation>
+<translation id="1994173015038366702">URL du site</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Utilisation</translation>
+<translation id="5804241973901381774">Autorisations</translation>
+<translation id="4278390842282768270">Autorisé</translation>
+<translation id="5677928146339483299">Bloqué</translation>
+<translation id="1984937141057606926">Autorisés, sauf cookies tiers</translation>
+<translation id="7423098979219808738">Demander d'abord</translation>
+<translation id="8116925261070264013">Son coupé</translation>
+<translation id="8300705686683892304">Gérés par l'application</translation>
+<translation id="6192792657125177640">Exceptions</translation>
+<translation id="257931822824936280">Développé – Cliquer pour réduire</translation>
+<translation id="5100237604440890931">Réduit – Cliquer pour développer</translation>
+<translation id="857943718398505171">Autorisé (recommandé)</translation>
+<translation id="2913331724188855103">Autoriser les sites à enregistrer et à lire les données des cookies (recommandé)</translation>
+<translation id="7445411102860286510">Autoriser les sites à lire automatiquement des vidéos dont le son est coupé (recommandé)</translation>
+<translation id="5335288049665977812">Autoriser les sites à exécuter JavaScript (recommandé)</translation>
+<translation id="5527111080432883924">Demander avant d'autoriser les sites à accéder en lecture au texte et aux images du presse-papiers (recommandé)</translation>
+<translation id="6912998170423641340">Interdire aux sites d'accéder en lecture au texte et aux images du presse-papiers</translation>
+<translation id="7423538860840206698">Accès en lecture au presse-papiers bloqué</translation>
+<translation id="3955193568934677022">Autoriser les sites à lire les contenus protégés (recommandé)</translation>
+<translation id="445467742685312942">Autoriser les sites à lire les contenus protégés</translation>
+<translation id="2107397443965016585">Demander avant d'autoriser les sites à lire les contenus protégés (recommandé)</translation>
+<translation id="2910701580606108292">Demander avant d'autoriser les sites à lire les contenus protégés</translation>
+<translation id="757524316907819857">Empêcher les sites de lire les contenus protégés</translation>
+<translation id="3277252321222022663">Autoriser les sites à accéder à vos capteurs (recommandé)</translation>
+<translation id="5048398596102334565">Autoriser les sites à accéder à vos capteurs de mouvement (recommandé)</translation>
+<translation id="8816026460808729765">Bloque l'accès aux capteurs pour certains sites</translation>
+<translation id="169515064810179024">Empêcher les sites d'accéder aux capteurs de mouvement</translation>
+<translation id="1660204651932907780">Autoriser le son des sites (recommandé)</translation>
+<translation id="3600792891314830896">Couper le son des sites</translation>
+<translation id="1743802530341753419">Demander avant d'autoriser les sites à se connecter à un appareil (recommandé)</translation>
+<translation id="851751545965956758">Interdire à tous les sites de se connecter à des appareils</translation>
+<translation id="7141896414559753902">Bloquer l'affichage de fenêtres pop-up et de redirections par les sites (recommandé)</translation>
+<translation id="5494752089476963479">Bloquer les annonces sur les sites qui affichent des annonces intrusives ou trompeuses</translation>
+<translation id="3123473560110926937">Bloqué sur certains sites</translation>
+<translation id="965817943346481315">Bloquer si le site affiche des annonces intrusives ou trompeuses (recommandé)</translation>
+<translation id="3386292677130313581">Demander avant d'autoriser des sites à accéder à ma position (recommandé)</translation>
+<translation id="9139068048179869749">Demander avant d'autoriser des sites à envoyer des notifications (recommandé)</translation>
+<translation id="4479647676395637221">Demander avant d'autoriser des sites à utiliser ma caméra (recommandé)</translation>
+<translation id="6992289844737586249">Demander avant d'autoriser des sites à utiliser mon micro (recommandé)</translation>
+<translation id="2289270750774289114">Me demander lorsqu'un site souhaite accéder aux appareils Bluetooth se trouvant à proximité (recommandé)</translation>
+<translation id="7053983685419859001">Bloquer</translation>
+<translation id="7128222689758636196">Autoriser pour le moteur de recherche actuel</translation>
+<translation id="7589445247086920869">Bloquer l'accès pour le moteur de recherche actuel</translation>
+<translation id="6388207532828177975">Effacer et réinitialiser</translation>
+<translation id="7999064672810608036">Voulez-vous vraiment effacer toutes les données locales, y compris les cookies, et réinitialiser toutes les autorisations pour ce site Web ?</translation>
+<translation id="2822354292072154809">Voulez-vous vraiment réinitialiser toutes les autorisations du site pour <ph name="CHOSEN_OBJECT_NAME"/> ?</translation>
+<translation id="515227803646670480">Effacer les données stockées</translation>
+<translation id="5902828464777634901">Toutes les données locales stockées par ce site, y compris les cookies, seront supprimées.</translation>
+<translation id="119944043368869598">Tout effacer</translation>
+<translation id="2490684707762498678">Géré par <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Ouvrir les paramètres de notification</translation>
+<translation id="1404122904123200417">Intégration sur <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Les fichiers enregistrés par des sites Web sont répertoriés ici</translation>
+<translation id="4181841719683918333">Langues</translation>
+<translation id="2647434099613338025">Ajouter une langue</translation>
+<translation id="1952172573699511566">Les sites Web s'afficheront dans votre langue préférée lorsque ce sera possible.</translation>
+<translation id="8559990750235505898">Proposer de traduire les pages dans d'autres langues</translation>
+<translation id="4719927025381752090">Proposer de traduire</translation>
+<translation id="8156139159503939589">Quelles langues comprenez-vous ?</translation>
+<translation id="5689516760719285838">Position</translation>
+<translation id="2440823041667407902">Accès à la position</translation>
+<translation id="2023546461831060654">Activer les autorisations pour Brave dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/></translation>
+<translation id="6665548517310046133">Activer l'autorisation pour Brave dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/></translation>
+<translation id="2928908108430545745">Pour autoriser Brave à accéder à votre position, activez également la localisation dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Pour autoriser Brave à accéder à votre appareil photo, activez également ce dernier dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Pour autoriser Brave à vous envoyer des notifications, activez également ces dernières dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Pour autoriser Brave à accéder au micro, activez également ce dernier dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">L'accès à la position est désactivé pour cet appareil. Activez-le dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">L'accès à la position est également désactivé pour cet appareil. Activez-le dans les <ph name="BEGIN_LINK"/>paramètres Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Appareil photo</translation>
+<translation id="3227137524299004712">Micro</translation>
+<translation id="1647391597548383849">Accéder à votre caméra</translation>
+<translation id="945632385593298557">Accéder à votre micro</translation>
+<translation id="6612358246767739896">Contenu protégé</translation>
+<translation id="885701979325669005">Données stockées</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> de données stockées</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Révoquer l'autorisation d'accès à l'appareil</translation>
+<translation id="4962975101802056554">Révoquer toutes les autorisations de l'appareil</translation>
+<translation id="6545864417968258051">Recherche Bluetooth</translation>
+<translation id="4411535500181276704">Mode simplifié</translation>
+<translation id="7821588508402923572">Vos économies de données s'affichent ici</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> économisés</translation>
+<translation id="8569404424186215731">depuis le <ph name="DATE"/></translation>
+<translation id="3252158532344029638">En mode simplifié, Brave charge les pages plus rapidement et consomme jusqu'à 60 pour cent de données en moins.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> de données économisées</translation>
+<translation id="7494974237137038751">de données économisées</translation>
+<translation id="6111020039983847643">de données utilisées</translation>
+<translation id="7413229368719586778">Date de début : <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Date de fin : <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Trier par site</translation>
+<translation id="5864174910718532887">Détails : tri effectué par nom de site</translation>
+<translation id="116280672541001035">Utilisées</translation>
+<translation id="8349013245300336738">Trier en fonction de la quantité de données utilisées</translation>
+<translation id="6378173571450987352">Détails : tri effectué par volume de données utilisées</translation>
+<translation id="2631006050119455616">Économisées</translation>
+<translation id="6643649862576733715">Trier en fonction de la quantité de données économisées</translation>
+<translation id="7302081693174882195">Détails : tri effectué par volume de données enregistrées</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> utilisé(s)</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> économisé(s)</translation>
+<translation id="2156074688469523661">Sites restants (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Autre</translation>
+<translation id="4913161338056004800">Réinitialiser les statistiques</translation>
+<translation id="1856325424225101786">Réinitialiser le mode simplifié ?</translation>
+<translation id="3658159451045945436">Le processus de réinitialisation efface l'historique de l'économiseur de données, y compris la liste des sites consultés.</translation>
+<translation id="3295530008794733555">Naviguez plus rapidement en consommant moins de données</translation>
+<translation id="7340390500800578919">En mode simplifié, Brave charge les pages plus rapidement et consomme jusqu'à 60 % de données en moins. Pour optimiser les pages que vous consultez, Brave envoie votre trafic Web à Brave Software. <ph name="BEGIN_LINK"/>En savoir plus<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Activer le mode simplifié</translation>
+<translation id="4493497663118223949">Mode simplifié activé</translation>
+<translation id="7559975015014302720">Mode simplifié désactivé</translation>
+<translation id="7606077192958116810">Le mode simplifié est activé. Gérez-le dans les paramètres.</translation>
+<translation id="4714588616299687897">Économisez jusqu'à 60 % de vos données</translation>
+<translation id="1006927014032731288">Grâce aux serveurs Brave Software, les pages que vous consultez sont optimisées.</translation>
+<translation id="3257320067425202300">Brave vous a permis de gagner <ph name="MEGABYTES"/> Mo</translation>
+<translation id="5813223329348543512">Brave vous a permis de gagner <ph name="GIGABYTES"/> Go</translation>
+<translation id="8266862848225348053">Emplacement de téléchargement</translation>
+<translation id="7077143737582773186">Carte SD</translation>
+<translation id="7762668264895820836">Carte SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Demander où enregistrer les fichiers</translation>
+<translation id="6192333916571137726">Télécharger le fichier</translation>
+<translation id="1672586136351118594">Ne plus afficher</translation>
+<translation id="2650751991977523696">Télécharger de nouveau le fichier ?</translation>
+<translation id="8664979001105139458">Nom de fichier déjà attribué</translation>
+<translation id="488187801263602086">Renommer le fichier</translation>
+<translation id="5686790454216892815">Nom de fichier trop long</translation>
+<translation id="7454641608352164238">Espace insuffisant</translation>
+<translation id="8972098258593396643">Télécharger dans le dossier par défaut ?</translation>
+<translation id="804335162455518893">Carte SD introuvable</translation>
+<translation id="7475688122056506577">Carte SD introuvable. Certains de vos fichiers risquent d'être manquants.</translation>
+<translation id="4198423547019359126">Aucun emplacement de téléchargements disponible</translation>
+<translation id="8224471946457685718">Télécharger des articles pour vous via le Wi-Fi</translation>
+<translation id="4970824347203572753">Fonctionnalité non disponible dans votre pays</translation>
+<translation id="5500777121964041360">Cette fonctionnalité n'est peut-être pas disponible dans votre pays</translation>
+<translation id="1173894706177603556">Renommer</translation>
+<translation id="1986685561493779662">Nom déjà attribué</translation>
+<translation id="6441734959916820584">Nom trop long</translation>
+<translation id="2923908459366352541">Le nom n'est pas valide</translation>
+<translation id="7290209999329137901">Option de changement de nom indisponible</translation>
+<translation id="3334729583274622784">Modifier l'extension du fichier ?</translation>
+<translation id="107147699690128016">Si vous modifiez l'extension du fichier, celui-ci pourrait s'ouvrir dans une application différente et potentiellement endommager votre appareil.</translation>
+<translation id="8541922081612557424">À propos de Brave</translation>
+<translation id="5311273890481188673">© <ph name="YEAR"/> Brave Software LLC. Tous droits réservés.</translation>
+<translation id="1416550906796893042">Version de l'application</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Dernière mise à jour <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Système d'exploitation</translation>
+<translation id="3968054912784331254">Les mises à jour de Brave ne sont plus disponibles avec cette version d'Android</translation>
+<translation id="7665369617277396874">Ajouter un compte</translation>
+<translation id="649070405679044769">Connecté à Brave Software en tant que</translation>
+<translation id="6234515504547364178">Se déconnecter de Brave</translation>
+<translation id="5324858694974489420">Paramètres parentaux</translation>
+<translation id="8920114477895755567">En attente des coordonnées des parents…</translation>
+<translation id="5512137114520586844">Ce compte est géré par <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Ce compte est géré par <ph name="PARENT_NAME_1"/> et <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Contenu</translation>
+<translation id="5403644198645076998">N'autoriser que certains sites</translation>
+<translation id="8641930654639604085">Essayer de bloquer les sites réservés aux adultes</translation>
+<translation id="5639724618331995626">Autoriser tous les sites</translation>
+<translation id="796823723482603597">Proposé par Brave</translation>
+<translation id="6324034347079777476">La synchronisation du système Android est désactivée.</translation>
+<translation id="5127805178023152808">La synchronisation est désactivée.</translation>
+<translation id="7015203776128479407">La configuration de la synchronisation initiale n'était pas terminée. La synchronisation est désactivée.</translation>
+<translation id="2497852260688568942">Votre administrateur a désactivé la synchronisation</translation>
+<translation id="9100610230175265781">Veuillez saisir la phrase secrète.</translation>
+<translation id="6108923351542677676">Configuration en cours…</translation>
+<translation id="4062305924942672200">Informations légales</translation>
+<translation id="4256782883801055595">Licences Open Source</translation>
+<translation id="1138681184697033370">Conditions d'utilisation de Brave</translation>
+<translation id="7392539049993970338">Avis de confidentialité de Brave</translation>
+<translation id="2677748264148917807">Quitter</translation>
+<translation id="5556459405103347317">Actualiser</translation>
+<translation id="1623104350909869708">Empêcher cette page de générer des boîtes de dialogue supplémentaires</translation>
+<translation id="2968755619301702150">Lecteur de certificat</translation>
+<translation id="1360432990279830238">Se déconnecter et arrêter la synchro. ?</translation>
+<translation id="8581481290581777242">Supprimer vos données Brave sur cet appareil ?</translation>
+<translation id="1318865768845061710">Vos favoris, votre historique, vos mots de passe et d'autres données Brave ne seront plus synchronisés avec votre compte Brave Software</translation>
+<translation id="3325020657155065477">Supprimer également vos données Brave sur cet appareil</translation>
+<translation id="6136448902816743006">Vous vous déconnectez d'un compte géré par <ph name="DOMAIN_NAME"/>. Vos données Brave seront donc supprimées de cet appareil, mais elles seront conservées dans votre compte Brave Software.</translation>
+<translation id="1853026300647876496">Mise en relation avec Brave Software. Cette opération peut prendre une minute…</translation>
+<translation id="2328985652426384049">Impossible de se connecter</translation>
+<translation id="7723158744459952869">Brave Software a mis trop de temps à répondre</translation>
+<translation id="4572422548854449519">Se connecter à un compte géré</translation>
+<translation id="2689656545739939160">Vous vous connectez avec un compte géré par <ph name="MANAGED_DOMAIN"/>, ce qui permettra à son administrateur de contrôler vos données Brave. Celles-ci seront définitivement associées à ce compte. Si vous vous déconnectez de Brave, vos données seront supprimées de cet appareil, mais elles seront conservées dans votre compte Brave Software.</translation>
+<translation id="1749561566933687563">Synchroniser vos favoris</translation>
+<translation id="4242533952199664413">Ouvrir les paramètres</translation>
+<translation id="1111673857033749125">Les favoris enregistrés sur vos autres appareils s'affichent ici.</translation>
+<translation id="8636825310635137004">Activez la synchronisation pour accéder à vos onglets sur vos autres appareils.</translation>
+<translation id="3269956123044984603">Activez l'option "Synchro auto des données" dans les paramètres Android de votre compte Brave Software pour accéder à vos onglets sur vos autres appareils.</translation>
+<translation id="5157964048453367290">Les onglets que vous avez ouverts dans Brave sur vos autres appareils s'affichent ici.</translation>
+<translation id="4684427112815847243">Tout synchroniser</translation>
+<translation id="2709516037105925701">Saisie automatique</translation>
+<translation id="8820817407110198400">Favoris</translation>
+<translation id="1644574205037202324">Historique</translation>
+<translation id="17513872634828108">Onglets ouverts</translation>
+<translation id="1320169905922104972">Cartes de crédit et adresses utilisées dans Brave Software Pay</translation>
+<translation id="6337234675334993532">Chiffrement</translation>
+<translation id="6698801883190606802">Gérer les données synchronisées</translation>
+<translation id="3598578758776312506">Chiffrer les mots de passe avec vos identifiants Brave Software</translation>
+<translation id="7810580217418711046">Chiffrer les données synchronisées avec le mot de passe Brave Software à la date suivante : <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Chiffrer les données synchronisées avec votre propre phrase secrète de synchronisation</translation>
+<translation id="2996291259634659425">Créer une phrase secrète</translation>
+<translation id="5713644099811900409">Compte Brave Software</translation>
+<translation id="8997474919031554666">Le chiffrement par phrase secrète ne s'applique pas aux modes de paiement et adresses Brave Software Pay. Seule une personne connaissant votre phrase secrète peut lire vos données chiffrées. La phrase secrète ne nous est pas envoyée et nous ne la stockons pas. Si vous l'oubliez ou si vous souhaitez modifier ce paramètre, vous devrez réinitialiser la synchronisation. <ph name="BEGIN_LINK"/>En savoir plus<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Phrase secrète</translation>
+<translation id="7772032839648071052">Confirmer la phrase secrète</translation>
+<translation id="5304593522240415983">Champ obligatoire.</translation>
+<translation id="321773570071367578">Si vous avez oublié votre phrase secrète, ou si vous souhaitez modifier ce paramètre, <ph name="BEGIN_LINK"/>réinitialisez la synchronisation<ph name="END_LINK"/>.</translation>
+<translation id="3029704984691124060">Les phrases secrètes ne correspondent pas.</translation>
+<translation id="5149495116300586333">Le chiffrement par phrase secrète ne s'applique pas aux modes de paiement et adresses Brave Software Pay.
+
+Pour modifier ce paramètre, <ph name="BEGIN_LINK"/>réinitialisez la synchronisation<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Phrase secrète incorrecte.</translation>
+<translation id="5414836363063783498">Validation en cours…</translation>
+<translation id="6846298663435243399">Chargement en cours…</translation>
+<translation id="5517095782334947753">Vous disposez des favoris, de l'historique, des mots de passe et d'autres paramètres du compte <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combiner mes données</translation>
+<translation id="688738109438487280">Ajoutez les données existantes au compte <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Conserver mes données à part</translation>
+<translation id="1145536944570833626">Supprimer les données existantes.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> tente de s'associer</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Obtenir de l'aide<ph name="END_LINK"/> lors de la recherche d'appareils…</translation>
+<translation id="5817918615728894473">Associer</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Obtenir de l'aide<ph name="END_LINK1"/> ou <ph name="BEGIN_LINK2"/>effectuer une nouvelle recherche<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Aucun appareil compatible détecté</translation>
+<translation id="3773755127849930740">Pour permettre l'association, <ph name="BEGIN_LINK"/>activez le Bluetooth<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Impossible d'activer l'adaptateur Bluetooth dans Brave</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Obtenir de l'aide<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave doit accéder aux données de localisation pour rechercher des appareils. <ph name="BEGIN_LINK"/>Mettre à jour les autorisations<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave doit avoir accès aux données de localisation pour rechercher des appareils. Cette fonctionnalité est <ph name="BEGIN_LINK"/>désactivée pour cet appareil<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave doit avoir accès aux données de localisation pour rechercher des appareils. <ph name="BEGIN_LINK1"/>Modifiez les autorisations.<ph name="END_LINK1"/> De plus, l'accès aux données de localisation est <ph name="BEGIN_LINK2"/>désactivé pour cet appareil<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Appareil connecté</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Intensité du signal : # barre}one{Intensité du signal : # barre}other{Intensité du signal : # barres}}</translation>
+<translation id="5230560987958996918">Le site <ph name="SITE"/> souhaite rechercher les appareils Bluetooth à proximité. Les appareils suivants ont été détectés :</translation>
+<translation id="8368027906805972958">Appareil inconnu ou non compatible (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">La synchronisation ne fonctionne pas</translation>
+<translation id="1810845389119482123">Configuration de la synchronisation initiale non terminée</translation>
+<translation id="3235722914093408050">Ouvrez paramètres Android et réactivez synchro système Android pour démarrer synchro Brave.</translation>
+<translation id="3367813778245106622">Connectez-vous de nouveau à votre compte pour démarrer la synchronisation.</translation>
+<translation id="974555521953189084">Saisissez votre phrase secrète pour lancer la synchronisation.</translation>
+<translation id="2997266899014181325">Pour lancer la synchronisation, activez l'option "Synchroniser vos données Brave".</translation>
+<translation id="8260126382462817229">Essayez de vous connecter de nouveau à votre compte.</translation>
+<translation id="5919204609460789179">Mettre à jour <ph name="PRODUCT_NAME"/> pour lancer la synchronisation</translation>
+<translation id="397583555483684758">La synchronisation s'est arrêtée.</translation>
+<translation id="1966710179511230534">Veuillez mettre à jour vos informations de connexion.</translation>
+<translation id="7063006564040364415">Impossible de se connecter au serveur de synchronisation.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> est obsolète.</translation>
+<translation id="4170011742729630528">Service indisponible. Veuillez réessayer plus tard.</translation>
+<translation id="7947953824732555851">Accepter/Se connecter</translation>
+<translation id="8583805026567836021">Suppression des données du compte</translation>
+<translation id="8310344678080805313">Onglets standards</translation>
+<translation id="5748802427693696783">Onglets standards sélectionnés</translation>
+<translation id="7998918019931843664">Rouvrir un onglet fermé</translation>
+<translation id="8853345339104747198">"<ph name="TAB_TITLE"/>", onglet</translation>
+<translation id="4452411734226507615">Fermer l'onglet <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Options disponibles au bas de l'écran</translation>
+<translation id="4060598801229743805">Options disponibles à proximité du haut de l'écran</translation>
+<translation id="2810645512293415242">Page simplifiée pour économiser des données et accélérer le chargement.</translation>
+<translation id="3985215325736559418">Voulez-vous télécharger <ph name="FILE_NAME"/> de nouveau ?</translation>
+<translation id="2450083983707403292">Souhaitez-vous relancer le téléchargement du fichier <ph name="FILE_NAME"/> ?</translation>
+<translation id="7514365320538308">Télécharger</translation>
+<translation id="545042621069398927">Accélération du téléchargement…</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Téléchargement du fichier…}one{Téléchargement de # fichier…}other{Téléchargement de # fichiers…}}</translation>
+<translation id="543509235395288790">Téléchargement de <ph name="COUNT"/> fichiers (<ph name="MEGABYTES"/>)…</translation>
+<translation id="4988210275050210843">Téléchargement du fichier (<ph name="MEGABYTES"/>)…</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 téléchargement terminé.}one{# téléchargement terminé.}other{# téléchargements terminés.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Échec de 1 téléchargement.}one{Échec de # téléchargement.}other{Échec de # téléchargements.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 téléchargement en attente.}one{# téléchargement en attente.}other{# téléchargements en attente.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Bouton <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">C'est presque fini !</translation>
+<translation id="3960299545138990065">Relancez Brave</translation>
+<translation id="3771001275138982843">Impossible de télécharger la mise à jour</translation>
+<translation id="3888648114124182147">Téléchargement de la mise à jour de Brave…</translation>
+<translation id="1705567146636171298">Mettre à jour Brave</translation>
+<translation id="6195417478702700398">Pour une expérience de navigation optimale, ouvrez pour mettre à jour Brave</translation>
+<translation id="3512968675351418494">Pour afficher le Web dans votre langue, téléchargez la dernière version de Brave</translation>
+<translation id="6427112570124116297">Traduire le Web</translation>
+<translation id="1379423114029199501">Lancez la mise à jour pour obtenir votre langue dans la dernière version de Brave</translation>
+<translation id="5684874026226664614">Petit problème… Impossible de traduire cette page.</translation>
+<translation id="6831043979455480757">Traduire</translation>
+<translation id="1285320974508926690">Ne jamais traduire ce site</translation>
+<translation id="773466115871691567">Toujours traduire les pages en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Ne jamais traduire les pages en <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Plus de langues</translation>
+<translation id="290376772003165898">La page n'est pas en <ph name="LANGUAGE"/> ?</translation>
+<translation id="4432792777822557199">Les pages en <ph name="SOURCE_LANGUAGE"/> seront désormais traduites en <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Les pages en <ph name="LANGUAGE"/> ne seront pas traduites</translation>
+<translation id="5447765697759493033">Ce site ne sera pas traduit</translation>
+<translation id="4880127995492972015">Traduire…</translation>
+<translation id="641643625718530986">Imprimer…</translation>
+<translation id="8909135823018751308">Partager…</translation>
+<translation id="4996978546172906250">Partager via</translation>
+<translation id="6333140779060797560">Partager via <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Un problème est survenu lors de l'impression de la page. Veuillez réessayer.</translation>
+<translation id="3254409185687681395">Ajouter cette page aux favoris</translation>
+<translation id="497421865427891073">Avancer</translation>
+<translation id="813082847718468539">Afficher des informations à propos du site</translation>
+<translation id="2532336938189706096">Vue Web</translation>
+<translation id="6005538289190791541">Mot de passe suggéré</translation>
+<translation id="4634124774493850572">Utiliser le mot de passe</translation>
+<translation id="8285489906452138776">Brave a besoin de votre autorisation pour accéder à votre appareil photo pour ce site.</translation>
+<translation id="320189792589364011">Brave a besoin de votre autorisation pour accéder à votre micro pour ce site.</translation>
+<translation id="7988136689212463100">Brave a besoin de votre autorisation pour accéder à votre appareil photo et à votre micro pour ce site.</translation>
+<translation id="4931190655840828017">Brave a besoin d'accéder à votre position pour la partager avec ce site.</translation>
+<translation id="3088191967551450609">Pour télécharger des fichiers, Brave a besoin d'accéder à l'espace de stockage.</translation>
+<translation id="8942627711005830162">Ouvrir dans une autre fenêtre</translation>
+<translation id="4195643157523330669">Ouvrir dans un nouvel onglet</translation>
+<translation id="1100066534610197918">Dans nouvel onglet dans groupe</translation>
+<translation id="4860895144060829044">Appeler</translation>
+<translation id="6896758677409633944">Copier</translation>
+<translation id="8393700583063109961">Envoyer un message</translation>
+<translation id="3557336313807607643">Ajouter aux contacts</translation>
+<translation id="4269820728363426813">Copier l'adresse du lien</translation>
+<translation id="1206892813135768548">Copier le texte du lien</translation>
+<translation id="1204037785786432551">Télécharger le lien</translation>
+<translation id="6864459304226931083">Télécharger l'image</translation>
+<translation id="8209050860603202033">Ouvrir l'image</translation>
+<translation id="8073388330009372546">Ouvrir image dans autre onglet</translation>
+<translation id="6649642165559792194">Prévisualiser l'image <ph name="BEGIN_NEW"/>Nouveau<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Charger l'image</translation>
+<translation id="3845332215609790146">Utiliser Brave Software Lens <ph name="BEGIN_NEW"/>Nouveau<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Rechercher l'image sur <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Partager l'image</translation>
+<translation id="5833984609253377421">Partager le lien</translation>
+<translation id="6475951671322991020">Télécharger la vidéo</translation>
+<translation id="2317945146070194624">Ouvrir dans nouvel onglet Brave</translation>
+<translation id="7975379999046275268">Prévisualiser la page <ph name="BEGIN_NEW"/>Nouveau<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Actualisation de la page</translation>
+<translation id="36525718899759834">Télécharger l'application sur le Brave Software Play Store : <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Sombre</translation>
+<translation id="1807246157184219062">Clair</translation>
+<translation id="4056223980640387499">Sépia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Sélectionnez un onglet à partager.</translation>
+<translation id="8719023831149562936">Impossible de partager l'onglet actuel.</translation>
+<translation id="2139186145475833000">Ajouter à l'écran d'accueil</translation>
+<translation id="4616150815774728855">Ouvrir <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Impossible d'ouvrir l'application</translation>
+<translation id="5129038482087801250">Installer l'application Web</translation>
+<translation id="3789841737615482174">Installer</translation>
+<translation id="4665282149850138822">Le site "<ph name="NAME"/>" a bien été ajouté à votre écran d'accueil.</translation>
+<translation id="7333031090786104871">L'ajout du site précédent est toujours en cours</translation>
+<translation id="1036727731225946849">Ajout de <ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">Ajouté à l'écran d'accueil</translation>
+<translation id="2146738493024040262">Ouvrir l'appli instantanée</translation>
+<translation id="7016516562562142042">Autorisé pour le moteur de recherche actuel</translation>
+<translation id="6177111841848151710">Bloqué pour le moteur de recherche actuel</translation>
+<translation id="145097072038377568">Désactivée dans les paramètres Android</translation>
+<translation id="8007176423574883786">Désactivée pour cet appareil</translation>
+<translation id="164269334534774161">Vous regardez une copie hors connexion de cette page depuis le <ph name="CREATION_TIME"/>.</translation>
+<translation id="4594952190837476234">Cette page hors connexion date du <ph name="CREATION_TIME"/> et peut différer de la version en ligne.</translation>
+<translation id="8840953339110955557">Cette page peut différer de la version en ligne.</translation>
+<translation id="6405300764336705484">Ce contenu est issu de <ph name="DOMAIN_NAME"/>. Il est diffusé par Brave Software.</translation>
+<translation id="1006017844123154345">Ouvrir la version en ligne</translation>
+<translation id="3326636747541519688">Page simplifiée fournie par Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Charger la page originale<ph name="END_LINK"/> de <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Si vous rencontrez souvent ce problème, essayez les <ph name="BEGIN_LINK"/>suggestions<ph name="END_LINK"/> suivantes.</translation>
+<translation id="8748850008226585750">Contenu masqué</translation>
+<translation id="3810973564298564668">Gérer</translation>
+<translation id="5199929503336119739">Profil professionnel</translation>
+<translation id="528192093759286357">Pour quitter le mode plein écran, faites glisser un doigt du haut vers le bas, puis appuyez sur le bouton Retour.</translation>
+<translation id="2836148919159985482">Appuyez sur le bouton Retour pour quitter le mode plein écran.</translation>
+<translation id="3967822245660637423">Téléchargement terminé</translation>
+<translation id="2434158240863470628">Téléchargement terminé <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Échec du téléchargement</translation>
+<translation id="1384959399684842514">Téléchargement suspendu</translation>
+<translation id="1671236975893690980">Téléchargement en attente…</translation>
+<translation id="5561549206367097665">En attente de connexion au réseau…</translation>
+<translation id="5864419784173784555">En attente d'un autre téléchargement…</translation>
+<translation id="6461962085415701688">Impossible d'ouvrir le fichier</translation>
+<translation id="1178581264944972037">Suspendre</translation>
+<translation id="8200772114523450471">Reprendre</translation>
+<translation id="1409879593029778104">Le téléchargement du fichier "<ph name="FILE_NAME"/>" a été bloqué, car le fichier existe déjà.</translation>
+<translation id="3387650086002190359">Échec du téléchargement du fichier "<ph name="FILE_NAME"/>" en raison d'erreurs liées au système de fichiers.</translation>
+<translation id="6482749332252372425">Échec du téléchargement du fichier "<ph name="FILE_NAME"/>" en raison de l'espace de stockage insuffisant.</translation>
+<translation id="7619072057915878432">Échec du téléchargement du fichier "<ph name="FILE_NAME"/>" en raison de l'échec du réseau.</translation>
+<translation id="1477626028522505441">Échec du téléchargement du fichier "<ph name="FILE_NAME"/>" en raison de problèmes liés au serveur.</translation>
+<translation id="3692944402865947621">Échec du téléchargement du fichier "<ph name="FILE_NAME"/>" en raison de l'espace de stockage indisponible.</translation>
+<translation id="604996488070107836">Échec du téléchargement du fichier "<ph name="FILE_NAME"/>" en raison d'une erreur inconnue.</translation>
+<translation id="6738867403308150051">Téléchargement en cours…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> Ko</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> Mo</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> Go</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/ ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> Ko téléchargé(s)</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> Mo téléchargé(s)</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> Go téléchargé(s)</translation>
+<translation id="9204836675896933765">1 fichier restant</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> fichiers restants</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fichier téléchargé}one{<ph name="FILES_DOWNLOADED_MANY"/> fichier téléchargé}other{<ph name="FILES_DOWNLOADED_MANY"/> fichiers téléchargés}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> jours restants</translation>
+<translation id="8190358571722158785">1 jour restant</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> heures restantes</translation>
+<translation id="510275257476243843">1 heure restante</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minutes restantes</translation>
+<translation id="3236059992281584593">1 minute restante</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> secondes restantes</translation>
+<translation id="2781151931089541271">1 seconde restante</translation>
+<translation id="3303414029551471755">Poursuivre et télécharger le contenu ?</translation>
+<translation id="8617240290563765734">Ouvrir l'URL suggérée indiquée dans le contenu téléchargé ?</translation>
+<translation id="1373696734384179344">Mémoire insuffisante pour télécharger le contenu sélectionné.</translation>
+<translation id="5271967389191913893">Impossible d'ouvrir le contenu à télécharger sur l'appareil.</translation>
+<translation id="883806473910249246">Une erreur s'est produite lors du téléchargement du contenu.</translation>
+<translation id="5626134646977739690">Nom :</translation>
+<translation id="7963646190083259054">Fournisseur :</translation>
+<translation id="3414952576877147120">Taille :</translation>
+<translation id="7375125077091615385">Type :</translation>
+<translation id="5765780083710877561">Description :</translation>
+<translation id="4881695831933465202">Ouvrir</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> Ko disponibles</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> Mo disponibles</translation>
+<translation id="5424588387303617268">Espace disponible : <ph name="GIGABYTES"/> Go</translation>
+<translation id="5793665092639000975">Utilisation de <ph name="SPACE_USED"/> sur <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Tous</translation>
+<translation id="4988526792673242964">Pages</translation>
+<translation id="3810838688059735925">Vidéo</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Images</translation>
+<translation id="8250920743982581267">Documents</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fichier}one{# fichier}other{# fichiers}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# image}one{# image}other{# images}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vidéo}one{# vidéo}other{# vidéos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# fichier audio}one{# fichier audio}other{# fichiers audio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# page}one{# page}other{# pages}}</translation>
+<translation id="5456381639095306749">Télécharger la page</translation>
+<translation id="2394602618534698961">Les fichiers que vous téléchargez sont affichés ici</translation>
+<translation id="7810647596859435254">Ouvrir avec…</translation>
+<translation id="5655963694829536461">Recherchez dans les téléchargements</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mes fichiers</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Les articles sont affichés ici (vous pouvez les lire même lorsque vous êtes hors connexion)</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}other{# h}}</translation>
+<translation id="5853623416121554550">suspendu</translation>
+<translation id="8965591936373831584">en attente</translation>
+<translation id="2779651927720337254">échec</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">À l'instant</translation>
+<translation id="4000212216660919741">Mode hors connexion</translation>
+<translation id="9133397713400217035">Consulter hors connexion</translation>
+<translation id="968900484120156207">Les pages que vous consultez sont répertoriées ici</translation>
+<translation id="7882131421121961860">Aucun historique trouvé</translation>
+<translation id="3549657413697417275">Recherchez dans l'historique</translation>
+<translation id="6820686453637990663">Code CVC :</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Expérience de première utilisation de Brave</translation>
+<translation id="2700285883409956633">En utilisant cette application, vous acceptez les <ph name="BEGIN_LINK1"/>Conditions d'utilisation<ph name="END_LINK1"/> et l'<ph name="BEGIN_LINK2"/>Avis de confidentialité<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="1640714894372474981">En utilisant cette application, vous acceptez les <ph name="BEGIN_LINK1"/>Conditions d'utilisation<ph name="END_LINK1"/> et l'<ph name="BEGIN_LINK2"/>Avis de confidentialité<ph name="END_LINK2"/> de Brave, ainsi que l'<ph name="BEGIN_LINK3"/>Avis de confidentialité relatif aux comptes Brave Software gérés dans Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> va s'ouvrir dans Brave. En continuant, vous acceptez les <ph name="BEGIN_LINK1"/>Conditions d'utilisation<ph name="END_LINK1"/> et l'<ph name="BEGIN_LINK2"/>Avis de confidentialité<ph name="END_LINK2"/> de Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> va s'ouvrir dans Brave. En continuant, vous acceptez les <ph name="BEGIN_LINK1"/>Conditions d'utilisation<ph name="END_LINK1"/> et l'<ph name="BEGIN_LINK2"/>Avis de confidentialité<ph name="END_LINK2"/> de Brave, ainsi que l'<ph name="BEGIN_LINK3"/>Avis de confidentialité relatif aux comptes Brave Software gérés dans Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Envoyer des statistiques d'utilisation et des rapports d'erreur pour améliorer Brave</translation>
+<translation id="3518985090088779359">Accepter et continuer</translation>
+<translation id="7207456302801184289">Bienvenue dans Brave</translation>
+<translation id="704822250101715322">En attente de la fin de la mise à jour des services Brave Software Play</translation>
+<translation id="1231733316453485619">Activer la synchronisation ?</translation>
+<translation id="5132942445612118989">Synchroniser vos mots de passe, votre historique et plus encore sur tous les appareils</translation>
+<translation id="5736731321935944068">Brave Software peut utiliser votre historique pour personnaliser la recherche, les annonces et d'autres services Brave Software</translation>
+<translation id="4013614219085422040">Brave Software peut utiliser votre historique pour personnaliser la recherche et d'autres services Brave Software</translation>
+<translation id="5581519193887989363">Vous avez toujours la possibilité de sélectionner les éléments à synchroniser dans les <ph name="BEGIN_LINK1"/>paramètres<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">J'accepte</translation>
+<translation id="2410754283952462441">Sélectionner un compte</translation>
+<translation id="2227444325776770048">Continuer en tant que <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> n'est pas votre adresse e-mail ?</translation>
+<translation id="8109613176066109935">Activez la synchronisation pour accéder à vos favoris sur tous vos appareils</translation>
+<translation id="2818669890320396765">Connectez-vous et activez la synchronisation pour accéder à vos favoris sur tous vos appareils</translation>
+<translation id="6003646045106347985">Activez la synchronisation pour obtenir des suggestions de contenu personnalisées de la part de Brave Software</translation>
+<translation id="8494430740943879273">Connectez-vous et activez la synchronisation pour obtenir des suggestions de contenu personnalisées de la part de Brave Software</translation>
+<translation id="5862731021271217234">Activez la synchronisation pour accéder à vos onglets sur vos autres appareils</translation>
+<translation id="3568688522516854065">Connectez-vous et activez la synchronisation pour accéder à vos onglets sur vos autres appareils</translation>
+<translation id="1208340532756947324">Activez la synchronisation pour accéder à vos données et les personnaliser sur tous vos appareils</translation>
+<translation id="4472118726404937099">Connectez-vous et activez la synchronisation pour accéder à vos données et les personnaliser sur tous vos appareils</translation>
+<translation id="2426805022920575512">Sélectionner un autre compte</translation>
+<translation id="6790428901817661496">Lire</translation>
+<translation id="1272079795634619415">Arrêter</translation>
+<translation id="2874939134665556319">Piste précédente</translation>
+<translation id="4046123991198612571">Piste suivante</translation>
+<translation id="3859306556332390985">Avance rapide</translation>
+<translation id="8441146129660941386">Retour rapide</translation>
+<translation id="6706288973712894588">Vous êtes actuellement hors connexion.\n<ph name="BEGIN_LINK"/>Consultez votre flux hors connexion.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Onglets récents</translation>
+<translation id="8497726226069778601">Aucune page à afficher pour le moment</translation>
+<translation id="5423934151118863508">Les pages les plus consultées s'affichent ici.</translation>
+<translation id="6127379762771434464">Élément supprimé</translation>
+<translation id="4605958867780575332">Élément supprimé : <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle : <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Autres appareils</translation>
+<translation id="4738836084190194332">Dernière synchronisation : <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Il y a # minute}one{Il y a # minute}other{Il y a # minutes}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Il y a # heure}one{Il y a # heure}other{Il y a # heures}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Il y a # jour}one{Il y a # jour}other{Il y a # jours}}</translation>
+<translation id="2762000892062317888">à l'instant</translation>
+<translation id="1407135791313364759">Tout ouvrir</translation>
+<translation id="1209206284964581585">Masquer pour le moment</translation>
+<translation id="129553762522093515">Récemment fermés</translation>
+<translation id="8413126021676339697">Afficher l'historique complet</translation>
+<translation id="7876243839304621966">Tout supprimer</translation>
+<translation id="8487700953926739672">Disponible hors connexion</translation>
+<translation id="5224771365102442243">Avec vidéo</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>En savoir plus<ph name="END_LINK"/> sur le contenu suggéré</translation>
+<translation id="7542481630195938534">Impossible d'obtenir des suggestions</translation>
+<translation id="5013696553129441713">Aucune nouvelle suggestion</translation>
+<translation id="1736419249208073774">Découvrir</translation>
+<translation id="7444811645081526538">Autres catégories</translation>
+<translation id="6709133671862442373">Actualités</translation>
+<translation id="1264974993859112054">Sports</translation>
+<translation id="9139318394846604261">Achats</translation>
+<translation id="3912508018559818924">Recherche du meilleur contenu sur le Web…</translation>
+<translation id="526421993248218238">Impossible de charger cette page</translation>
+<translation id="614940544461990577">Voici quelques conseils :</translation>
+<translation id="3288003805934695103">Recharger la page</translation>
+<translation id="2353636109065292463">Vérifier votre connexion Internet</translation>
+<translation id="2858138569776157458">Sites populaires</translation>
+<translation id="8364299278605033898">Affichez les sites Web populaires</translation>
+<translation id="1171770572613082465">Appuyez sur le bouton "Sites populaires" pour afficher les sites Web les plus visités</translation>
+<translation id="5233638681132016545">Nouvel onglet</translation>
+<translation id="4521874409998847950">De <ph name="PUBLISHER_ORIGIN"/>, <ph name="BEGIN_DEEMPHASIZED"/>proposé par Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Nouvelle version disponible</translation>
+<translation id="4058091506841967397">Impossible mettre à jour Brave</translation>
+<translation id="6316139424528454185">Version Android non compatible</translation>
+<translation id="6989267951144302301">Échec du téléchargement</translation>
+<translation id="624789221780392884">Mise à jour prête</translation>
+<translation id="1549000191223877751">Déplacer vers autre fenêtre</translation>
+<translation id="7481312909269577407">Avancer</translation>
+<translation id="4084682180776658562">Favori</translation>
+<translation id="6437478888915024427">Infos sur la page</translation>
+<translation id="7180611975245234373">Actualiser</translation>
+<translation id="4913169188695071480">Ne plus actualiser</translation>
+<translation id="1829244130665387512">Recherchez sur la page</translation>
+<translation id="6593061639179217415">Version pour ordinateur</translation>
+<translation id="9063523880881406963">Désactiver "Voir version ordinateur"</translation>
+<translation id="2038563949887743358">Activer "Voir version ordinateur"</translation>
+<translation id="2433507940547922241">Apparence</translation>
+<translation id="983192555821071799">Fermer tous les onglets</translation>
+<translation id="1310482092992808703">Regrouper les onglets</translation>
+<translation id="7725024127233776428">Les pages que vous ajoutez aux favoris sont répertoriées ici</translation>
+<translation id="4404568932422911380">Aucun favori</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> favori}one{<ph name="BOOKMARKS_COUNT_MANY"/> favori}other{<ph name="BOOKMARKS_COUNT_MANY"/> favoris}}</translation>
+<translation id="3739899004075612870">Favori ajouté dans <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Favori</translation>
+<translation id="4452548195519783679">Ajouté aux favoris dans "<ph name="FOLDER_NAME"/>"</translation>
+<translation id="8063895661287329888">Échec de l'ajout du favori</translation>
+<translation id="2842985007712546952">Dossier parent</translation>
+<translation id="9065203028668620118">Édition</translation>
+<translation id="4405224443901389797">Déplacer vers…</translation>
+<translation id="5170568018924773124">Afficher le dossier</translation>
+<translation id="8035133914807600019">Nouveau dossier…</translation>
+<translation id="4532845899244822526">Sélectionner un dossier</translation>
+<translation id="6627583120233659107">Modifier le dossier</translation>
+<translation id="1197267115302279827">Déplacer les favoris</translation>
+<translation id="6963766334940102469">Supprimer des favoris</translation>
+<translation id="4351244548802238354">Fermer la boîte de dialogue</translation>
+<translation id="451872707440238414">Rechercher dans vos favoris</translation>
+<translation id="8901170036886848654">Aucun favori trouvé</translation>
+<translation id="6404511346730675251">Modifier le favori</translation>
+<translation id="3894427358181296146">Ajouter un dossier</translation>
+<translation id="5327248766486351172">Nom</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Dossier</translation>
+<translation id="5161254044473106830">Veuillez saisir un titre.</translation>
+<translation id="2996809686854298943">Veuillez saisir une URL.</translation>
+<translation id="2536728043171574184">Affichage d'une copie hors connexion de la page</translation>
+<translation id="4698034686595694889">Afficher hors connexion dans <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> et autres sites</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave chargera votre page dès qu'elle sera prête}one{Brave chargera votre page dès qu'elle sera prête}other{Brave chargera vos pages dès qu'elles seront prêtes}}</translation>
+<translation id="6811034713472274749">La page est prête à être affichée</translation>
+<translation id="4561979708150884304">Aucune connexion</translation>
+<translation id="8274165955039650276">Voir les téléchargements</translation>
+<translation id="2082238445998314030">Résultat <ph name="RESULT_NUMBER"/> sur <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Aucun résultat</translation>
+<translation id="981121421437150478">Hors connexion</translation>
+<translation id="3298243779924642547">Simplifié</translation>
+<translation id="393697183122708255">Aucune recherche vocale activée dispo.</translation>
+<translation id="7191430249889272776">L'onglet a été ouvert en arrière-plan.</translation>
+<translation id="8445059357334030806">Ouvrir dans Brave</translation>
+<translation id="4720023427747327413">Ouvrir dans <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Ouvrir dans le navigateur</translation>
+<translation id="1113597929977215864">Afficher la vue simplifiée</translation>
+<translation id="1513352483775369820">Favoris et historique Web</translation>
+<translation id="4939482511480190003">Aidez-nous à améliorer Brave. <ph name="BEGIN_LINK"/>Répondez à notre enquête<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Retour</translation>
+<translation id="5596627076506792578">Plus d'options</translation>
+<translation id="3522247891732774234">Mise à jour disponible. Plus d'options</translation>
+<translation id="6773423637732432200">Impossible de mettre à jour Brave. Plus d'options</translation>
+<translation id="3328801116991980348">Informations sur le site</translation>
+<translation id="5391532827096253100">Votre connexion à ce site n'est pas sécurisée. Informations sur le site</translation>
+<translation id="6206551242102657620">La connexion est sécurisée. Informations sur le site</translation>
+<translation id="6963642900430330478">Cette page est dangereuse. Informations sur le site</translation>
+<translation id="9070377983101773829">Démarrer la recherche vocale</translation>
+<translation id="8676374126336081632">Effacer la saisie</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> onglet ouvert, appuyez pour changer d'onglet}one{<ph name="OPEN_TABS_MANY"/> onglet ouvert, appuyez pour changer d'onglet}other{<ph name="OPEN_TABS_MANY"/> onglets ouverts, appuyez pour changer d'onglet}}</translation>
+<translation id="2369533728426058518">onglets ouverts</translation>
+<translation id="7071521146534760487">Gérer le compte</translation>
+<translation id="932327136139879170">Accueil</translation>
+<translation id="2707726405694321444">Actualiser la page</translation>
+<translation id="2891154217021530873">Arrêter le chargement de la page</translation>
+<translation id="6710213216561001401">Précédent</translation>
+<translation id="6659594942844771486">Onglet</translation>
+<translation id="1933845786846280168">Onglet sélectionné</translation>
+<translation id="2268044343513325586">Affiner</translation>
+<translation id="7846076177841592234">Annuler la sélection</translation>
+<translation id="7087918508125750058">Nombre d'éléments sélectionnés : <ph name="ITEM_COUNT"/>. Options disponibles dans la partie supérieure de l'écran</translation>
+<translation id="7250468141469952378">Nombre d'éléments sélectionnés : <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Partager 1 élément sélectionné}one{Partager # élément sélectionné}other{Partager # éléments sélectionnés}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Supprimer 1 élément sélectionné}one{Supprimer # élément sélectionné}other{Supprimer # éléments sélectionnés}}</translation>
+<translation id="1283039547216852943">Appuyer pour développer</translation>
+<translation id="5962718611393537961">Appuyer pour réduire</translation>
+<translation id="8076492880354921740">Onglets</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 élément sélectionné}one{# élément sélectionné}other{# éléments sélectionnés}}</translation>
+<translation id="6818926723028410516">Sélectionner des éléments</translation>
+<translation id="4797039098279997504">Appuyer ici pour revenir à l'adresse <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Appuyez pour accéder au site</translation>
+<translation id="429312253194641664">Un site est en train de lire un contenu multimédia</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> partage votre écran.</translation>
+<translation id="8833831881926404480">Votre écran est partagé par un site</translation>
+<translation id="9086455579313502267">Impossible d'accéder au réseau.</translation>
+<translation id="938850635132480979">Erreur <ph name="ERROR_CODE"/>.</translation>
+<translation id="666731172850799929">Ouvrir dans <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Ouvrir dans une application de plans</translation>
+<translation id="7698359219371678927">Créer un e-mail dans <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Créer un e-mail</translation>
+<translation id="5665379678064389456">Créer un événement dans <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Créer un événement</translation>
+<translation id="2111511281910874386">Accéder à la page</translation>
+<translation id="3988466920954086464">Consultez les résultats de la recherche instantanée dans ce panneau</translation>
+<translation id="2744248271121720757">Appuyez sur un mot pour lancer une recherche instantanée ou afficher les actions associées</translation>
+<translation id="9155898266292537608">Vous pouvez également effectuer une recherche en appuyant brièvement sur un mot</translation>
+<translation id="3232754137068452469">Application Web</translation>
+<translation id="1430915738399379752">Imprimer</translation>
+<translation id="3775705724665058594">Envoyer à vos appareils</translation>
+<translation id="6364438453358674297">Supprimer la suggestion de l'historique ?</translation>
+<translation id="213279576345780926">L'onglet "<ph name="TAB_TITLE"/>" a été fermé.</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> onglets ont été fermés.</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> a été supprimé</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> favoris ont été supprimés.</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> téléchargements supprimés</translation>
+<translation id="1248710015876067820">Le nombre d'instances de Brave n'est pas compatible.</translation>
+<translation id="4259722352634471385">La navigation sur <ph name="URL"/> est bloquée.</translation>
+<translation id="8959122750345127698">Impossible d'accéder à <ph name="URL"/>.</translation>
+<translation id="5210365745912300556">Fermer l'onglet</translation>
+<translation id="7772375229873196092">Fermer <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Historique de navigation</translation>
+<translation id="9169507124922466868">L'historique de navigation est ouvert à moitié</translation>
+<translation id="1327257854815634930">Historique de navigation ouvert</translation>
+<translation id="8788265440806329501">Historique de navigation fermé</translation>
+<translation id="7482656565088326534">Onglet ''Aperçu''</translation>
+<translation id="8427875596167638501">L'onglet "Aperçu" est ouvert à moitié</translation>
+<translation id="9102803872260866941">L'onglet "Aperçu" est ouvert</translation>
+<translation id="2942036813789421260">L'onglet "Aperçu" est fermé</translation>
+<translation id="6355102470683871794">Stockage Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Suppr. données de site ?</translation>
+<translation id="9205995714227143200">Données de site stockées que Brave ne considère pas comme importantes (par exemple, pour des sites sans paramètres enregistrés ou que vous ne consultez pas souvent)</translation>
+<translation id="3997476611815694295">Stockage non important</translation>
+<translation id="8493948351860045254">Libérer de l'espace</translation>
+<translation id="2324920234469020158">Cette action aura pour effet de vider le cache et de supprimer les cookies, ainsi que d'autres données de site que Brave ne considère pas comme importantes.</translation>
+<translation id="5447201525962359567">Toutes les données de site stockées, y compris les cookies et d'autres données stockées en local</translation>
+<translation id="1376578503827013741">Calcul…</translation>
+<translation id="583281660410589416">Inconnu</translation>
+<translation id="2323763861024343754">Données de site stockées</translation>
+<translation id="3587672679800759167">Espace de stockage utilisé pour l'ensemble des données Brave, y compris les comptes, favoris et paramètres enregistrés</translation>
+<translation id="6545017243486555795">Supprimer toutes les données</translation>
+<translation id="4095146165863963773">Supprimer les données de l'application ?</translation>
+<translation id="53119194224775367">Toutes les données de l'application Brave seront supprimées de façon définitive, y compris les fichiers, paramètres, comptes, bases de données, etc.</translation>
+<translation id="5307446750509046227">Effacer données stockage</translation>
+<translation id="300526633675317032">Cette action aura pour effet de libérer l'espace de stockage utilisé pour les données de site (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">Impossible de sélectionner le certificat</translation>
+<translation id="2315043854645842844">La sélection de certificat côté client n'est pas compatible avec le système d'exploitation.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> tente de se connecter</translation>
+<translation id="5308380583665731573">Connexion</translation>
+<translation id="868929229000858085">Rechercher des contacts</translation>
+<translation id="1919950603503897840">Sélectionner des contacts</translation>
+<translation id="7986741934819883144">Sélectionner un contact</translation>
+<translation id="3333961966071413176">Tous les contacts</translation>
+<translation id="4994033804516042629">Aucun contact trouvé</translation>
+<translation id="5403592356182871684">Noms</translation>
+<translation id="2717722538473713889">Adresses e-mail</translation>
+<translation id="381841723434055211">Numéros de téléphone</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 autre)}one{(+ # autre)}other{(+ # autres)}}</translation>
+<translation id="5197729504361054390">Les contacts que vous sélectionnez seront partagés avec <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Décodage d'images</translation>
+<translation id="8067883171444229417">Lire la vidéo</translation>
+<translation id="6560414384669816528">Rechercher avec Sogou</translation>
+<translation id="5406914950576900927">Brave peut utiliser <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> pour les recherches effectuées en Chine. Vous pouvez modifier cette option dans les <ph name="BEGIN_LINK"/>paramètres<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Conserver Brave Software</translation>
+<translation id="4384468725000734951">Utilisation de Sogou pour les recherches</translation>
+<translation id="6103327872225198548">Utilisation de Brave Software pour les recherches</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Cette application s'exécute dans Brave</translation>
+<translation id="6143689084714664628">En cours d'exécution dans Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> a également des données dans Brave</translation>
+<translation id="2734140769649165081">Vous pouvez effacer les données dans les paramètres Brave</translation>
+<translation id="8232956427053453090">Conserver les données</translation>
+<translation id="4298388696830689168">Sites associés</translation>
+<translation id="5763514718066511291">Appuyez pour copier l'URL pour cette application</translation>
+<translation id="6496823230996795692">Pour utiliser <ph name="APP_NAME"/> pour la première fois, veuillez vous connecter à Internet.</translation>
+<translation id="751961395872307827">Impossible de se connecter au site</translation>
+<translation id="4878404682131129617">Échec de l'établissement d'un tunnel via un serveur proxy</translation>
+<translation id="4749960740855309258">Ouvrir un nouvel onglet</translation>
+<translation id="8788968922598763114">Rouvrir le dernier onglet fermé</translation>
+<translation id="7929962904089429003">Ouvrir le menu</translation>
+<translation id="6039379616847168523">Accéder à l'onglet suivant</translation>
+<translation id="5210286577605176222">Accéder à l'onglet précédent</translation>
+<translation id="124678866338384709">Fermer l'onglet actuel</translation>
+<translation id="3714981814255182093">Ouvrir la barre de recherche</translation>
+<translation id="5441522332038954058">Accéder à la barre d'adresse</translation>
+<translation id="3398320232533725830">Ouvrir le gestionnaire de favoris</translation>
+<translation id="6583199322650523874">Marquer la page actuelle en tant que favori</translation>
+<translation id="8489271220582375723">Ouvrir la page "Historique"</translation>
+<translation id="4837753911714442426">Afficher les options d'impression de la page</translation>
+<translation id="5726692708398506830">Agrandir tous les éléments de la page</translation>
+<translation id="3259831549858767975">Réduire tous les éléments de la page</translation>
+<translation id="8015452622527143194">Rétablir taille par défaut des éléments de la page</translation>
+<translation id="3443221991560634068">Actualiser la page active</translation>
+<translation id="123724288017357924">Actualiser page active et ignorer contenu en cache</translation>
+<translation id="305870044889644984">Ouvrir le centre d'aide dans un nouvel onglet</translation>
+<translation id="3166827708714933426">Raccourcis liés aux onglets et aux fenêtres</translation>
+<translation id="3169981355900570544">Raccourcis liés aux fonctionnalités de Brave Software Brave</translation>
+<translation id="4558311620361989323">Raccourcis de pages Web</translation>
+<translation id="1908301351964700579">Le mode de réalité virtuelle n'est pas encore prêt. Redémarrez Brave plus tard.</translation>
+<translation id="8970887620466824814">Un problème est survenu</translation>
+<translation id="1875543012935658554">Rouvrez Brave.</translation>
+<translation id="79859296434321399">Pour afficher des contenus en réalité augmentée, installez ARCore</translation>
+<translation id="8558485628462305855">Pour afficher des contenus en réalité augmentée, mettez à jour ARCore</translation>
+<translation id="3513704683820682405">Réalité augmentée</translation>
+<translation id="5475862044948910901">Lancer une session en réalité augmentée ?</translation>
 <translation id="7365126855094612066">Pendant toute la durée de cette session, les actions suivantes peuvent être effectuées sur le site :
 • Créer un plan 3D de votre environnement
 • Suivre les mouvements de la caméra
 
 En revanche, le site n'a PAS accès à la caméra. Vous seul pouvez voir les images de la caméra.</translation>
-<translation id="7375125077091615385">Type :</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Expérience de première utilisation de Chrome</translation>
-<translation id="741204030948306876">J'accepte</translation>
-<translation id="7413229368719586778">Date de début : <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Demander d'abord</translation>
-<translation id="7423538860840206698">Accès en lecture au presse-papiers bloqué</translation>
-<translation id="7431991332293347422">Contrôler la manière dont votre historique de navigation est utilisé pour personnaliser la recherche et plus encore</translation>
-<translation id="7437998757836447326">Se déconnecter de Chrome</translation>
-<translation id="7438641746574390233">Lorsque le mode simplifié est activé, Chrome utilise les serveurs Google pour accélérer le chargement des pages. Le mode simplifié réécrit les pages dont le chargement est très lent pour ne charger que le contenu essentiel. Ce mode ne s'applique pas aux onglets de navigation privée.</translation>
-<translation id="7444811645081526538">Autres catégories</translation>
-<translation id="7445411102860286510">Autoriser les sites à lire automatiquement des vidéos dont le son est coupé (recommandé)</translation>
-<translation id="7453467225369441013">Vous déconnecte de la plupart des sites. Vous ne serez cependant pas déconnecté de votre compte Google.</translation>
-<translation id="7454641608352164238">Espace insuffisant</translation>
-<translation id="7475192538862203634">Si vous rencontrez souvent ce problème, essayez les <ph name="BEGIN_LINK" />suggestions<ph name="END_LINK" /> suivantes.</translation>
-<translation id="7475688122056506577">Carte SD introuvable. Certains de vos fichiers risquent d'être manquants.</translation>
-<translation id="7479104141328977413">Gestion des onglets</translation>
-<translation id="7481312909269577407">Avancer</translation>
-<translation id="7482656565088326534">Onglet ''Aperçu''</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Dernière mise à jour <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">de données économisées</translation>
-<translation id="7498271377022651285">Veuillez patienter…</translation>
-<translation id="7514365320538308">Télécharger</translation>
-<translation id="751961395872307827">Impossible de se connecter au site</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Impossible d'obtenir des suggestions</translation>
-<translation id="7559975015014302720">Mode simplifié désactivé</translation>
-<translation id="7562080006725997899">Effacement des données de navigation en cours</translation>
-<translation id="756809126120519699">Données de Chrome effacées</translation>
-<translation id="757524316907819857">Empêcher les sites de lire les contenus protégés</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fichier téléchargé}one{<ph name="FILES_DOWNLOADED_MANY" /> fichier téléchargé}other{<ph name="FILES_DOWNLOADED_MANY" /> fichiers téléchargés}}</translation>
-<translation id="7588219262685291874">Activer le thème sombre lorsque l'économiseur de batterie de l'appareil est activé</translation>
-<translation id="7589445247086920869">Bloquer l'accès pour le moteur de recherche actuel</translation>
-<translation id="7593557518625677601">Ouvrez paramètres Android et réactivez synchro système Android pour démarrer synchro Chrome.</translation>
-<translation id="7596558890252710462">Système d'exploitation</translation>
-<translation id="7605594153474022051">La synchronisation ne fonctionne pas</translation>
-<translation id="7606077192958116810">Le mode simplifié est activé. Gérez-le dans les paramètres.</translation>
-<translation id="7612619742409846846">Connecté à Google en tant que</translation>
-<translation id="7619072057915878432">Échec du téléchargement du fichier "<ph name="FILE_NAME" />" en raison de l'échec du réseau.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Obtenir de l'aide<ph name="END_LINK1" /> ou <ph name="BEGIN_LINK2" />effectuer une nouvelle recherche<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Bienvenue dans Chrome</translation>
-<translation id="7638584964844754484">Phrase secrète incorrecte.</translation>
-<translation id="7641339528570811325">Effacer les données de navigation</translation>
-<translation id="7648422057306047504">Chiffrer les mots de passe avec vos identifiants Google</translation>
-<translation id="7649070708921625228">Aide</translation>
-<translation id="7658239707568436148">Annuler</translation>
-<translation id="7665369617277396874">Ajouter un compte</translation>
-<translation id="766587987807204883">Les articles sont affichés ici (vous pouvez les lire même lorsque vous êtes hors connexion)</translation>
-<translation id="7682724950699840886">Essayez l'astuce suivante°: assurez-vous de disposer de suffisamment d'espace sur votre appareil, puis tentez à nouveau d'exporter les mots de passe.</translation>
-<translation id="7685301384041462804">N'activez la RV que si vous faites confiance à ce site.</translation>
-<translation id="7698359219371678927">Créer un e-mail dans <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Saisir semi-automatiquement les recherches et les URL</translation>
-<translation id="7725024127233776428">Les pages que vous ajoutez aux favoris sont répertoriées ici</translation>
-<translation id="773466115871691567">Toujours traduire les pages en <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Pour détecter les applications et sites dangereux, Chrome envoie à Google l'URL de certaines pages que vous consultez, ainsi que des informations système limitées et une partie du contenu de certaines pages.</translation>
-<translation id="7757787379047923882">Texte partagé par <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Carte SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Ajouter une adresse</translation>
-<translation id="7772032839648071052">Confirmer la phrase secrète</translation>
-<translation id="7772375229873196092">Fermer <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> de plus}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> de plus}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 et <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> de plus}}</translation>
-<translation id="7781829728241885113">Hier</translation>
-<translation id="7791543448312431591">Ajouter</translation>
-<translation id="780301667611848630">Non merci</translation>
-<translation id="7810647596859435254">Ouvrir avec…</translation>
-<translation id="7821588508402923572">Vos économies de données s'affichent ici</translation>
-<translation id="7837721118676387834">Autorisez la lecture automatique des vidéos dont le son est coupé pour un site spécifique.</translation>
-<translation id="7846076177841592234">Annuler la sélection</translation>
-<translation id="784934925303690534">Période</translation>
-<translation id="7851858861565204677">Autres appareils</translation>
-<translation id="7875915731392087153">Créer un e-mail</translation>
-<translation id="7876243839304621966">Tout supprimer</translation>
-<translation id="7882131421121961860">Aucun historique trouvé</translation>
-<translation id="7882806643839505685">Autorisez le son pour un site spécifique.</translation>
-<translation id="7886917304091689118">En cours d'exécution dans Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Téléchargement du fichier…}one{Téléchargement de # fichier…}other{Téléchargement de # fichiers…}}</translation>
-<translation id="7929962904089429003">Ouvrir le menu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> est obsolète.</translation>
-<translation id="7947953824732555851">Accepter/Se connecter</translation>
-<translation id="7963646190083259054">Fournisseur :</translation>
-<translation id="7971136598759319605">Actif il y a 1 jour</translation>
-<translation id="7975379999046275268">Prévisualiser la page <ph name="BEGIN_NEW" />Nouveau<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Précharger les pages pour accélérer la navigation et la recherche</translation>
-<translation id="79859296434321399">Pour afficher des contenus en réalité augmentée, installez ARCore</translation>
-<translation id="7986741934819883144">Sélectionner un contact</translation>
-<translation id="7987073022710626672">Conditions d'utilisation de Chrome</translation>
-<translation id="7998918019931843664">Rouvrir un onglet fermé</translation>
-<translation id="7999064672810608036">Voulez-vous vraiment effacer toutes les données locales, y compris les cookies, et réinitialiser toutes les autorisations pour ce site Web ?</translation>
-<translation id="8004582292198964060">Navigateur</translation>
-<translation id="8007176423574883786">Désactivée pour cet appareil</translation>
-<translation id="8013372441983637696">Supprimer également vos données Chrome sur cet appareil</translation>
-<translation id="8015452622527143194">Rétablir taille par défaut des éléments de la page</translation>
-<translation id="802154636333426148">Échec du téléchargement</translation>
-<translation id="8026334261755873520">Effacer les données de navigation</translation>
-<translation id="8035133914807600019">Nouveau dossier…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> jours restants</translation>
-<translation id="804335162455518893">Carte SD introuvable</translation>
-<translation id="805047784848435650">En fonction de votre historique de navigation</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> Mo disponibles</translation>
-<translation id="8058746566562539958">Ouvrir dans nouvel onglet Chrome</translation>
-<translation id="8063895661287329888">Échec de l'ajout du favori</translation>
-<translation id="806745655614357130">Conserver mes données à part</translation>
-<translation id="8067883171444229417">Lire la vidéo</translation>
-<translation id="8068648041423924542">Impossible de sélectionner le certificat</translation>
-<translation id="8073388330009372546">Ouvrir image dans autre onglet</translation>
-<translation id="8076492880354921740">Onglets</translation>
-<translation id="8084114998886531721">Mot de passe enregistré</translation>
-<translation id="8087000398470557479">Ce contenu est issu de <ph name="DOMAIN_NAME" />. Il est diffusé par Google.</translation>
-<translation id="8103578431304235997">Onglet de navigation privée</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Activez la synchronisation pour accéder à vos favoris sur tous vos appareils</translation>
-<translation id="8110087112193408731">Afficher votre activité Chrome dans Bien-être numérique ?</translation>
-<translation id="8116925261070264013">Son coupé</translation>
-<translation id="813082847718468539">Afficher des informations à propos du site</translation>
-<translation id="8131740175452115882">Confirmer</translation>
-<translation id="8156139159503939589">Quelles langues comprenez-vous ?</translation>
-<translation id="8168435359814927499">Contenu</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> fichiers restants</translation>
-<translation id="8190358571722158785">1 jour restant</translation>
-<translation id="8200772114523450471">Reprendre</translation>
-<translation id="8209050860603202033">Ouvrir l'image</translation>
-<translation id="8218622182176210845">Gérer votre compte</translation>
-<translation id="8224471946457685718">Télécharger des articles pour vous via le Wi-Fi</translation>
-<translation id="8232956427053453090">Conserver les données</translation>
-<translation id="8249310407154411074">Déplacer vers le haut</translation>
-<translation id="8250920743982581267">Documents</translation>
-<translation id="825412236959742607">Cette page utilise trop de mémoire, Chrome a donc supprimé du contenu.</translation>
-<translation id="8260126382462817229">Essayez de vous connecter de nouveau à votre compte.</translation>
-<translation id="8261506727792406068">Supprimer</translation>
-<translation id="8266862848225348053">Emplacement de téléchargement</translation>
-<translation id="8274165955039650276">Voir les téléchargements</translation>
-<translation id="8284326494547611709">Sous-titres</translation>
-<translation id="8300705686683892304">Gérés par l'application</translation>
-<translation id="8310344678080805313">Onglets standards</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> et autres sites</translation>
-<translation id="8327155640814342956">Pour une expérience de navigation optimale, ouvrez pour mettre à jour Chrome</translation>
-<translation id="8339163506404995330">Les pages en <ph name="LANGUAGE" /> ne seront pas traduites</translation>
-<translation id="8349013245300336738">Trier en fonction de la quantité de données utilisées</translation>
-<translation id="8364299278605033898">Affichez les sites Web populaires</translation>
-<translation id="8368027906805972958">Appareil inconnu ou non compatible (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Autorise la synchronisation en arrière-plan pour un site spécifique.</translation>
-<translation id="8378714024927312812">Géré par votre organisation</translation>
-<translation id="8380167699614421159">Ce site affiche des annonces intrusives ou trompeuses</translation>
-<translation id="8393700583063109961">Envoyer un message</translation>
-<translation id="8413126021676339697">Afficher l'historique complet</translation>
-<translation id="8427875596167638501">L'onglet "Aperçu" est ouvert à moitié</translation>
-<translation id="8428213095426709021">Paramètres</translation>
-<translation id="8438566539970814960">Améliorer les recherches et la navigation</translation>
-<translation id="8441146129660941386">Retour rapide</translation>
-<translation id="8443209985646068659">Impossible mettre à jour Chrome</translation>
-<translation id="8445448999790540984">Impossible d'exporter les mots de passe</translation>
-<translation id="8447861592752582886">Révoquer l'autorisation d'accès à l'appareil</translation>
-<translation id="8461694314515752532">Chiffrer les données synchronisées avec votre propre phrase secrète de synchronisation</translation>
-<translation id="8466613982764129868">Assurez-vous que l'appareil <ph name="TARGET_DEVICE_NAME" /> est connecté à Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponible hors connexion</translation>
-<translation id="8489271220582375723">Ouvrir la page "Historique"</translation>
-<translation id="8493948351860045254">Libérer de l'espace</translation>
-<translation id="8497726226069778601">Aucune page à afficher pour le moment</translation>
-<translation id="8503559462189395349">Mots de passe Google Chrome</translation>
-<translation id="8503813439785031346">Nom d'utilisateur</translation>
-<translation id="8514477925623180633">Exporter les mots de passe enregistrés dans Chrome</translation>
-<translation id="8514577642972634246">Activer le mode navigation privée</translation>
-<translation id="851751545965956758">Interdire à tous les sites de se connecter à des appareils</translation>
-<translation id="8523928698583292556">Supprimer le mot de passe enregistré</translation>
-<translation id="854522910157234410">Ouvrir cette page</translation>
-<translation id="8558485628462305855">Pour afficher des contenus en réalité augmentée, mettez à jour ARCore</translation>
-<translation id="8559990750235505898">Proposer de traduire les pages dans d'autres langues</translation>
-<translation id="8562452229998620586">Les mots de passe enregistrés s'affichent ici.</translation>
-<translation id="8569404424186215731">depuis le <ph name="DATE" /></translation>
-<translation id="8571213806525832805">4 dernières semaines</translation>
-<translation id="857943718398505171">Autorisé (recommandé)</translation>
-<translation id="8583805026567836021">Suppression des données du compte</translation>
-<translation id="860043288473659153">Nom du titulaire de la carte</translation>
-<translation id="8609465669617005112">Monter</translation>
-<translation id="8616006591992756292">Votre compte Google conserve peut-être d'autres formes d'historique de navigation sur la page <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Ouvrir l'URL suggérée indiquée dans le contenu téléchargé ?</translation>
-<translation id="8636825310635137004">Activez la synchronisation pour accéder à vos onglets sur vos autres appareils.</translation>
-<translation id="8641930654639604085">Essayer de bloquer les sites réservés aux adultes</translation>
-<translation id="8655129584991699539">Vous pouvez effacer les données dans les paramètres Chrome</translation>
-<translation id="8662811608048051533">Vous déconnecte de la plupart des sites.</translation>
-<translation id="8664979001105139458">Nom de fichier déjà attribué</translation>
-<translation id="8676374126336081632">Effacer la saisie</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Intensité du signal : # barre}one{Intensité du signal : # barre}other{Intensité du signal : # barres}}</translation>
-<translation id="868929229000858085">Rechercher des contacts</translation>
-<translation id="869891660844655955">Date d'expiration</translation>
-<translation id="8719023831149562936">Impossible de partager l'onglet actuel.</translation>
-<translation id="8725066075913043281">Réessayer</translation>
-<translation id="8728487861892616501">En utilisant cette application, vous acceptez les <ph name="BEGIN_LINK1" />Conditions d'utilisation<ph name="END_LINK1" /> et l'<ph name="BEGIN_LINK2" />Avis de confidentialité<ph name="END_LINK2" /> de Chrome, ainsi que l'<ph name="BEGIN_LINK3" />Avis de confidentialité relatif aux comptes Google gérés dans Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">OK</translation>
-<translation id="8748850008226585750">Contenu masqué</translation>
-<translation id="8751914237388039244">Sélectionner une image</translation>
-<translation id="8788265440806329501">Historique de navigation fermé</translation>
-<translation id="8788968922598763114">Rouvrir le dernier onglet fermé</translation>
-<translation id="8801436777607969138">Bloquer JavaScript sur un site spécifique.</translation>
-<translation id="8812260976093120287">Sur certains sites Web, vous pouvez payer depuis votre appareil avec les applications de paiement compatibles indiquées ci-dessus.</translation>
-<translation id="8816026460808729765">Bloque l'accès aux capteurs pour certains sites</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> va s'ouvrir dans Chrome. En continuant, vous acceptez les <ph name="BEGIN_LINK1" />Conditions d'utilisation<ph name="END_LINK1" /> et l'<ph name="BEGIN_LINK2" />Avis de confidentialité<ph name="END_LINK2" /> de Chrome, ainsi que l'<ph name="BEGIN_LINK3" />Avis de confidentialité relatif aux comptes Google gérés dans Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Favoris</translation>
-<translation id="8833831881926404480">Votre écran est partagé par un site</translation>
-<translation id="883806473910249246">Une erreur s'est produite lors du téléchargement du contenu.</translation>
-<translation id="8840953339110955557">Cette page peut différer de la version en ligne.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">"<ph name="TAB_TITLE" />", onglet</translation>
-<translation id="885701979325669005">Données stockées</translation>
-<translation id="889338405075704026">Accéder aux paramètres Chrome</translation>
-<translation id="8901170036886848654">Aucun favori trouvé</translation>
-<translation id="8909135823018751308">Partager…</translation>
-<translation id="8912362522468806198">Compte Google</translation>
-<translation id="8920114477895755567">En attente des coordonnées des parents…</translation>
+<translation id="1188239144602654184">Lancer</translation>
+<translation id="473775607612524610">Mettre à jour</translation>
+<translation id="3133489217401741157">Installation du module <ph name="MODULE"/> pour Brave…</translation>
+<translation id="1791662854739702043">Installé dans</translation>
+<translation id="5131234170665854056">Impossible d'installer le module <ph name="MODULE"/> pour Brave</translation>
+<translation id="2567385386134582609">IMAGE</translation>
+<translation id="6395288395575013217">LIEN</translation>
+<translation id="7352939065658542140">VIDÉO</translation>
+<translation id="4116038641877404294">Téléchargez des pages pour y accéder hors connexion</translation>
 <translation id="8922289737868596582">Téléchargez des pages pour y accéder hors connexion, à partir du bouton "Plus d'options"</translation>
-<translation id="8937772741022875483">Supprimer votre activité Chrome de Bien-être numérique ?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Ouvrir dans une autre fenêtre</translation>
-<translation id="8951232171465285730">Chrome vous a permis de gagner <ph name="MEGABYTES" /> Mo</translation>
-<translation id="8958424370300090006">Bloquez les cookies pour un site spécifique.</translation>
-<translation id="8959122750345127698">Impossible d'accéder à <ph name="URL" />.</translation>
-<translation id="8965591936373831584">en attente</translation>
-<translation id="8970887620466824814">Un problème est survenu</translation>
-<translation id="8972098258593396643">Télécharger dans le dossier par défaut ?</translation>
-<translation id="8986494364107987395">Envoie automatiquement les statistiques d'utilisation et les rapports d'erreur à Google</translation>
-<translation id="8993760627012879038">Ouvrir un nouvel onglet en mode navigation privée</translation>
-<translation id="8998729206196772491">Vous vous connectez avec un compte géré par <ph name="MANAGED_DOMAIN" />, ce qui permettra à son administrateur de contrôler vos données Chrome. Celles-ci seront définitivement associées à ce compte. Si vous vous déconnectez de Chrome, vos données seront supprimées de cet appareil, mais elles seront conservées dans votre compte Google.</translation>
-<translation id="9019902583201351841">Géré par tes parents</translation>
-<translation id="9028914725102941583">Activer la synchronisation pour partager des contenus entre des appareils</translation>
-<translation id="9029323097866369874">Autoriser le site <ph name="DOMAIN" /> à activer la RV ?</translation>
-<translation id="9040142327097499898">Les notifications sont autorisées. La localisation est désactivée pour cet appareil.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vidéo}one{# vidéo}other{# vidéos}}</translation>
-<translation id="9050666287014529139">Phrase secrète</translation>
-<translation id="9063523880881406963">Désactiver "Voir version ordinateur"</translation>
-<translation id="9065203028668620118">Édition</translation>
-<translation id="9070377983101773829">Démarrer la recherche vocale</translation>
-<translation id="9074336505530349563">Connectez-vous et activez la synchronisation pour obtenir des suggestions de contenu personnalisées de la part de Google</translation>
-<translation id="9086455579313502267">Impossible d'accéder au réseau.</translation>
-<translation id="9100505651305367705">Propose une vue simplifiée des articles, si compatibles</translation>
-<translation id="9100610230175265781">Veuillez saisir la phrase secrète.</translation>
-<translation id="9102803872260866941">L'onglet "Aperçu" est ouvert</translation>
+<translation id="5958275228015807058">Recherchez vos fichiers et vos pages dans la section "Téléchargements"</translation>
+<translation id="5620928963363755975">Recherchez vos fichiers et vos pages dans les téléchargements, à partir du bouton "Plus d'options"</translation>
+<translation id="3341058695485821946">Découvrez la quantité de données économisées</translation>
+<translation id="3157842584138209013">Découvrez la quantité de données économisées en cliquant sur le bouton "Plus d'options"</translation>
+<translation id="8218622182176210845">Gérer votre compte</translation>
+<translation id="8090895580117672212">Pour gérer votre compte Brave Software, appuyez sur le bouton "Gérer le compte"</translation>
+<translation id="8856898588039823173">Page simplifiée fournie par Brave Software. Appuyez pour charger la page d'origine.</translation>
+<translation id="8134317863207426198">Page simplifiée fournie par Brave Software. Appuyez sur le bouton "Charger le site d'origine" pour charger la page d'origine.</translation>
+<translation id="4961107849584082341">Traduire cette page dans n'importe quelle langue</translation>
+<translation id="569536719314091526">Traduire cette page dans n'importe quelle langue à partir du bouton "Plus d'options"</translation>
+<translation id="1397811292916898096">Rechercher avec <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Modifier à tout moment l'emplacement de téléchargement par défaut</translation>
+<translation id="6942665639005891494">Modifier à tout moment l'emplacement de téléchargement par défaut à l'aide de l'option de menu "Paramètres"</translation>
+<translation id="6850409657436465440">Téléchargement toujours en cours</translation>
+<translation id="5817715962196959877">Brave permet désormais de télécharger des fichiers plus vite</translation>
+<translation id="3976396876660209797">Supprimez et recréez ce raccourci</translation>
+<translation id="6766622839693428701">Balayez l'écran vers le bas pour fermer la feuille.</translation>
+<translation id="1028699632127661925">Envoi sur <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> (envoyé depuis <ph name="DEVICE_NAME"/>)</translation>
+<translation id="5357811892247919462">Onglet reçu</translation>
 <translation id="9104217018994036254">Liste des appareils avec lesquels vous pouvez partager un onglet.</translation>
-<translation id="9133397713400217035">Consulter hors connexion</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Afficher l'original</translation>
-<translation id="9139068048179869749">Demander avant d'autoriser des sites à envoyer des notifications (recommandé)</translation>
-<translation id="9139318394846604261">Achats</translation>
-<translation id="9155898266292537608">Vous pouvez également effectuer une recherche en appuyant brièvement sur un mot</translation>
-<translation id="9169507124922466868">L'historique de navigation est ouvert à moitié</translation>
-<translation id="9204836675896933765">1 fichier restant</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">La liste des appareils avec lesquels vous pouvez partager un onglet est ouverte à mi-hauteur.</translation>
+<translation id="2904414404539560095">La liste des appareils avec lesquels vous pouvez partager un onglet est ouverte à hauteur maximale.</translation>
+<translation id="4135200667068010335">La liste des appareils avec lesquels vous pouvez partager un onglet est fermée.</translation>
+<translation id="5292796745632149097">Envoyer sur</translation>
+<translation id="1386674309198842382">Actif il y a <ph name="LAST_UPDATED"/> jours</translation>
+<translation id="7971136598759319605">Actif il y a 1 jour</translation>
+<translation id="1521774566618522728">Actif aujourd'hui</translation>
+<translation id="3631987586758005671">Partage avec <ph name="DEVICE_NAME"/>…</translation>
+<translation id="9028914725102941583">Activer la synchronisation pour partager des contenus entre des appareils</translation>
+<translation id="6162454065885854378">Pour partager un contenu entre votre téléphone et un autre appareil, activez la synchronisation dans les paramètres Brave sur les deux appareils</translation>
+<translation id="6084271560289605378">Accéder aux paramètres Brave</translation>
+<translation id="2318045970523081853">Appuyer pour passer un appel</translation>
 <translation id="9209888181064652401">Impossible de passer des appels</translation>
-<translation id="9219103736887031265">Images</translation>
-<translation id="926205370408745186">Supprimer votre activité Chrome de Bien-être numérique</translation>
-<translation id="932327136139879170">Accueil</translation>
-<translation id="938850635132480979">Erreur <ph name="ERROR_CODE" />.</translation>
-<translation id="945632385593298557">Accéder à votre micro</translation>
-<translation id="95817756606698420">Chrome peut utiliser <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> pour les recherches effectuées en Chine. Vous pouvez modifier cette option dans les <ph name="BEGIN_LINK" />paramètres<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloquer si le site affiche des annonces intrusives ou trompeuses (recommandé)</translation>
-<translation id="968900484120156207">Les pages que vous consultez sont répertoriées ici</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minutes restantes</translation>
-<translation id="974555521953189084">Saisissez votre phrase secrète pour lancer la synchronisation.</translation>
-<translation id="981121421437150478">Hors connexion</translation>
-<translation id="982182592107339124">Cette action entraînera la suppression des données pour tous les sites, y compris :</translation>
-<translation id="983192555821071799">Fermer tous les onglets</translation>
-<translation id="987264212798334818">Général</translation>
+<translation id="2860954141821109167">Assurez-vous qu'une application Téléphone est activée sur cet appareil</translation>
+<translation id="2067805253194386918">texte</translation>
+<translation id="1450753235335490080">Impossible de partager le contenu suivant : <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Impossible de partager le contenu suivant : <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Assurez-vous que la synchronisation est activée sur votre <ph name="TARGET_DEVICE_NAME"/> dans Brave</translation>
+<translation id="3016635187733453316">Assurez-vous que cet appareil est bien connecté à Internet</translation>
+<translation id="8466613982764129868">Assurez-vous que l'appareil <ph name="TARGET_DEVICE_NAME"/> est connecté à Internet</translation>
+<translation id="6539092367496845964">Un problème est survenu. Réessayez plus tard.</translation>
+<translation id="3389286852084373014">Volume de texte trop important</translation>
+<translation id="2100314319871056947">Essayez de scinder le texte pour le partager en plusieurs fois</translation>
+<translation id="2987620471460279764">Texte partagé depuis un autre appareil</translation>
+<translation id="7757787379047923882">Texte partagé par <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Copié dans le presse-papiers</translation>
+<translation id="4696983787092045100">Envoyer le SMS à vos appareils</translation>
+<translation id="1260236875608242557">Rechercher et explorer</translation>
+<translation id="6369229450655021117">Ici, vous pouvez faire des recherches sur le Web, partager des contenus avec vos amis et voir les pages ouvertes</translation>
+<translation id="723171743924126238">Sélectionner des images</translation>
+<translation id="8751914237388039244">Sélectionner une image</translation>
+<translation id="1989112275319619282">Parcourir</translation>
+<translation id="7055152154916055070">Redirection bloquée :</translation>
+<translation id="5524843473235508879">Redirection bloquée.</translation>
+<translation id="6573096386450695060">Toujours autoriser</translation>
+<translation id="5805364706385912897">Cette page utilise trop de mémoire, Brave a donc interrompu son chargement.</translation>
+<translation id="5138664332909611586">Cette page utilise trop de mémoire, Brave a donc supprimé du contenu.</translation>
+<translation id="9137013805542155359">Afficher l'original</translation>
+<translation id="6361779936989026201">Assistant Brave Software dans Brave</translation>
+<translation id="7291387454912369099">Règlement via l'Assistant</translation>
+<translation id="4565206163201411670">Afficher votre activité Brave dans Bien-être numérique ?</translation>
+<translation id="9055113864158719823">Vous pouvez voir les sites que vous avez consultés dans Brave et définir des minuteurs pour ceux-ci.\n\nBrave Software obtient des informations sur les sites pour lesquels vous définissez des minuteurs et peut déterminer le temps que vous passez sur ces derniers. Ces informations sont utilisées pour améliorer Bien-être numérique.</translation>
+<translation id="4596514158372210596">Supprimer votre activité Brave de Bien-être numérique</translation>
+<translation id="1174893863889683998">Supprimer votre activité Brave de Bien-être numérique ?</translation>
+<translation id="708829030563435351">Les sites que vous consultez dans Brave ne s'afficheront pas. Tous les minuteurs de site seront supprimés.</translation>
+<translation id="2056878612599315956">Site en pause</translation>
+<translation id="671481426037969117">Votre minuteur <ph name="FQDN"/> a expiré. Il redémarrera demain.</translation>
+<translation id="7479104141328977413">Gestion des onglets</translation>
+<translation id="3524138585025253783">UI des développeurs</translation>
+<translation id="6036057147555329831">ICU supplémentaire</translation>
+<translation id="9029323097866369874">Autoriser le site <ph name="DOMAIN"/> à activer la RV ?</translation>
+<translation id="7685301384041462804">N'activez la RV que si vous faites confiance à ce site.</translation>
+<translation id="5033865233969348410">Lorsque vous utilisez le mode RV, le site peut retenir les informations suivantes :
+  – Vos caractéristiques physiques, telles que votre taille
+
+N'activez la RV que si vous faites confiance à ce site.</translation>
+<translation id="5534334044554683961">Lorsque vous utilisez le mode RV, le site peut retenir les informations suivantes :
+  – Vos caractéristiques physiques, telles que votre taille
+  – La disposition de la pièce
+
+N'activez la RV que si vous faites confiance à ce site.</translation>
+<translation id="4169535189173047238">Interdire</translation>
+<translation id="2170088579611075216">Autoriser et activer la RV</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_gu.xtb
+++ b/android/java/strings/translations/android_chrome_strings_gu.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="gu">
-<translation id="1006017844123154345">ઑનલાઇન ખોલો</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> પર મોકલી રહ્યાં છીએ...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> ઉમેરી રહ્યાં છીએ…</translation>
-<translation id="1041308826830691739">વેબસાઇટ પરથી</translation>
-<translation id="1049743911850919806">છૂપી</translation>
-<translation id="10614374240317010">ક્યારેય ન સચવાયેલું</translation>
-<translation id="1067922213147265141">અન્ય Google સેવાઓ</translation>
-<translation id="1068672505746868501">પેજનો ક્યારેય પણ <ph name="SOURCE_LANGUAGE" />માં અનુવાદ કરશો નહીં</translation>
-<translation id="107147699690128016">જો તમે ફાઇલનું એક્સ્ટેંશન બદલશો, તો તે કોઈ અલગ ઍપ્લિકેશનમાં ખુલી શકે છે અને તમારા ડિવાઇસ માટે નુકસાનકારક હોવાનું સંભવિત હોય શકે.</translation>
-<translation id="1100066534610197918">ગ્રૂપમાં નવા ટૅબમાં ખોલો</translation>
-<translation id="1105960400813249514">સ્ક્રીન કૅપ્ચર</translation>
-<translation id="1111673857033749125">તમારા અન્ય ઉપકરણો પર સાચવેલા બુકમાર્ક્સ અહીં દેખાશે.</translation>
-<translation id="1113597929977215864">સરળ દૃશ્ય બતાવો</translation>
-<translation id="1121094540300013208">વપરાશ અને ક્રૅશ રિપોર્ટ</translation>
-<translation id="1124772482545689468">વપરાશકર્તા</translation>
-<translation id="1129510026454351943">વિગતો: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 ડાઉનલોડ બાકી.}one{# ડાઉનલોડ બાકી.}other{# ડાઉનલોડ બાકી.}}</translation>
-<translation id="1145536944570833626">અસ્તિત્વમાંના ડેટાને ડિલીટ કરો.</translation>
-<translation id="1146678959555564648">VR માં દાખલ થાઓ</translation>
-<translation id="116280672541001035">વપરાયેલ</translation>
-<translation id="1171770572613082465">"લોકપ્રિય સાઇટ" બટન પર ટૅપ કરીને લોકપ્રિય વેબસાઇટ જુઓ</translation>
-<translation id="1173894706177603556">નામ બદલો</translation>
-<translation id="1178581264944972037">થોભો</translation>
-<translation id="1181037720776840403">કાઢી નાખો</translation>
-<translation id="1188239144602654184">AR દાખલ કરો</translation>
-<translation id="1197267115302279827">બુકમાર્ક્સ ખસેડો</translation>
-<translation id="119944043368869598">બધા દૂર કરો</translation>
-<translation id="1201402288615127009">આગલું</translation>
-<translation id="1204037785786432551">ડાઉનલોડ કરવાની લિંક</translation>
-<translation id="1206892813135768548">લિંક ટેક્સ્ટ કૉપિ કરો</translation>
-<translation id="1208340532756947324">સમગ્ર ઉપકરણોમાં સિંક તથા વ્યક્તિગત કરવા માટે સિંક ચાલુ કરો</translation>
-<translation id="1209206284964581585">હમણાં માટે છુપાવો</translation>
-<translation id="1227058898775614466">નૅવિગેશન ઇતિહાસ</translation>
-<translation id="1231733316453485619">સિંક કરવાનું ચાલુ કરીએ?</translation>
-<translation id="123724288017357924">કૅશ કરેલ કન્ટેન્ટને અવગણીને વર્તમાન પેજ ફરીથી લોડ કરો</translation>
-<translation id="124116460088058876">વધુ ભાષાઓ</translation>
-<translation id="124678866338384709">વર્તમાન ટૅબ બંધ કરો</translation>
-<translation id="1258753120186372309">Google ડૂડલ: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">શોધો તેમજ શોધખોળ કરો</translation>
-<translation id="1264974993859112054">રમત-ગમત</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> શેર કરી શકાયો નથી</translation>
-<translation id="1272079795634619415">રોકો</translation>
-<translation id="1283039547216852943">વિસ્તૃત કરવા માટે ટૅપ કરો</translation>
-<translation id="1285320974508926690">આ સાઇટનું ક્યારેય ભાષાંતર કરશો નહીં</translation>
-<translation id="1291207594882862231">ઇતિહાસ, કુકી, સાઇટ ડેટા, કૅશ સાફ કરો…</translation>
-<translation id="129382876167171263">વેબસાઇટ દ્વારા સાચવવામાં આવેલી ફાઇલો અહી દેખાશે</translation>
-<translation id="129553762522093515">તાજેતરમાં બંધ કરેલા</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> પરથી મોકલેલ</translation>
-<translation id="1310482092992808703">ટૅબનું ગ્રૂપ બનાવો</translation>
-<translation id="1327257854815634930">નૅવિગેશન ઇતિહાસ ખુલ્લો છે</translation>
-<translation id="1331212799747679585">Chrome અપડેટ કરી શકાતું નથી. વધુ વિકલ્પો</translation>
-<translation id="1332501820983677155">Google Chrome સુવિધાના શૉર્ટકટ્સ</translation>
-<translation id="1360432990279830238">સાઇન આઉટ કરી સિંકનો વિકલ્પ બંધ કરવો છે?</translation>
-<translation id="1369915414381695676">સાઈટ <ph name="SITE_NAME" /> ઉમેરવામાં આવી</translation>
-<translation id="1373696734384179344">પસંદ કરેલ કન્ટેન્ટ ડાઉનલોડ કરવા માટે મેમરી અપૂરતી છે.</translation>
-<translation id="1376578503827013741">ગણતરી કરી રહ્યાં છે…</translation>
-<translation id="1383876407941801731">શોધો</translation>
-<translation id="1384959399684842514">ડાઉનલોડ થોભાવ્યું</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> દિવસ પહેલાં સક્રિય હતું</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> વડે શોધો</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" /> માં એમ્બેડ કર્યું</translation>
-<translation id="1406000523432664303">“ટ્રેક કરશો નહીં”</translation>
-<translation id="1407135791313364759">બધું ખોલો</translation>
-<translation id="1409426117486808224">ખુલ્લી ટૅબ માટે સરળ દૃશ્ય</translation>
-<translation id="1409879593029778104"><ph name="FILE_NAME" /> ડાઉનલોડ રોકાયું કારણકે ફાઇલ પહેલેથી અસ્તિત્વ ધરાવે છે.</translation>
-<translation id="1414981605391750300">Googleનો સંપર્ક કરી રહ્યાં છીએ. આમાં એક મિનિટ લાગી શકે છે…</translation>
-<translation id="1416550906796893042">ઍપ્લિકેશન વર્ઝન</translation>
-<translation id="1430915738399379752">પ્રિન્ટ</translation>
-<translation id="1446450296470737166">MIDI ઉપકરણોના પૂર્ણ નિયંત્રણની મંજૂરી આપો</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> શેર કરી શકતાં નથી</translation>
-<translation id="145097072038377568">Android સેટિંગ્સમાં બંધ કરી</translation>
-<translation id="1477626028522505441">સર્વર સમસ્યાઓને કારણે <ph name="FILE_NAME" /> ડાઉનલોડ નિષ્ફળ થયું.</translation>
-<translation id="1506061864768559482">શોધ એન્જિન</translation>
-<translation id="1513352483775369820">બુકમાર્ક્સ અને વેબ ઇતિહાસ</translation>
-<translation id="1513858653616922153">પાસવર્ડ ડિલીટ કરો</translation>
-<translation id="1516229014686355813">શોધવા માટે ટૅપ કરો પસંદ કરાયેલ શબ્દ અને હાલના પેજને સંદર્ભ તરીકે Google શોધને મોકલે છે. તમે તેને <ph name="BEGIN_LINK" />સેટિંગ<ph name="END_LINK" />માં બંધ કરી શકો છો.</translation>
-<translation id="1521774566618522728">આજે સક્રિય છે</translation>
-<translation id="1544826120773021464">તમારું Google એકાઉન્ટ મેનેજ કરવા માટે, "એકાઉન્ટ મેનેજ કરો" બટન પર ટૅપ કરો</translation>
-<translation id="1549000191223877751">અન્ય વિંડો પર ખસેડો</translation>
-<translation id="1553358976309200471">Chrome અપડેટ કરો</translation>
-<translation id="1569387923882100876">કનેક્ટ કરેલ ઉપકરણ</translation>
-<translation id="1571304935088121812">વપરાશકર્તાનામ કૉપિ કરો</translation>
-<translation id="1612196535745283361">ઉપકરણો માટે સ્કેન કરવા Chrome ને સ્થાન ઍક્સેસની જરૂર છે. સ્થાન ઍક્સેસ, <ph name="BEGIN_LINK" />આ ઉપકરણ માટે બંધ કરેલ છે<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">કૅમેરો</translation>
-<translation id="1623104350909869708">આ પૃષ્ઠને વધારાના સંવાદો બનાવતા અટકાવો</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{પસંદ કરેલ 1 આઇટમ દૂર કરો}one{પસંદ કરેલ # આઇટમ દૂર કરો}other{પસંદ કરેલ # આઇટમ દૂર કરો}}</translation>
-<translation id="164269334534774161">તમે <ph name="CREATION_TIME" />માંથી આ પેજની ઑફલાઇન કૉપિ જોઈ રહ્યા છો</translation>
-<translation id="1644574205037202324">ઇતિહાસ</translation>
-<translation id="1647391597548383849">તમારા કૅમેરાની ઍક્સેસ</translation>
-<translation id="1660204651932907780">સાઇટને અવાજ ચલાવવાની મંજૂરી આપો (સુઝાવ આપેલ)</translation>
-<translation id="1670399744444387456">મૂળભૂત</translation>
-<translation id="1671236975893690980">ડાઉનલોડ બાકી…</translation>
-<translation id="1672586136351118594">ફરીથી બતાવશો નહીં</translation>
-<translation id="1692118695553449118">સમન્વયન ચાલુ છે</translation>
-<translation id="169515064810179024">સાઇટને મોશન સેન્સરને ઍક્સેસ કરવાથી બ્લૉક કરો</translation>
-<translation id="1717218214683051432">મોશન સેન્સર</translation>
-<translation id="1718835860248848330">છેલ્લા એક કલાક</translation>
-<translation id="1736419249208073774">શોધખોળ કરો</translation>
-<translation id="1743802530341753419">સાઇટને ઉપકરણ સાથે કનેક્ટ કરવાની મંજૂરી આપતા પહેલાં પૂછો (સુઝાવ આપેલ)</translation>
-<translation id="1749561566933687563">તમારા બુકમાર્ક્સ સમન્વયિત કરો</translation>
-<translation id="17513872634828108">ટેબ્સ ખોલો</translation>
-<translation id="1779089405699405702">છબી ડીકોડર</translation>
-<translation id="1782483593938241562">સમાપ્તિ તારીખ <ph name="DATE" /></translation>
-<translation id="1791662854739702043">ઇન્સ્ટોલ કરેલું</translation>
-<translation id="1792959175193046959">ડિફૉલ્ટ ડાઉનલોડ સ્થાનને કોઈપણ સમયે બદલો</translation>
-<translation id="1807246157184219062">આછું</translation>
-<translation id="1810845389119482123">સિંકનું પ્રારંભિક સેટઅપ પૂર્ણ થયું નથી</translation>
-<translation id="1821253160463689938">તમારી પસંદગીઓ યાદ રાખવા માટે કુકીનો ઉપયોગ કરે છે, પછી ભલે તમે તે પેજની મુલાકાત ન પણ લો</translation>
-<translation id="1829244130665387512">આ પૃષ્ઠમાં શોધો</translation>
-<translation id="1853692000353488670">નવી છુપી ટેબ</translation>
-<translation id="1856325424225101786">લાઇટ મોડને રીસેટ કરીએ?</translation>
-<translation id="1868024384445905608">Chrome હવે ફાઇલોને વધુ ઝડપથી ડાઉનલોડ કરે છે</translation>
-<translation id="1883903952484604915">મારી ફાઇલો</translation>
-<translation id="1887786770086287077">આ ઉપકરણ માટે સ્થાન ઍક્સેસ બંધ છે. તેને <ph name="BEGIN_LINK" />Android સેટિંગ<ph name="END_LINK" />માં ચાલુ કરો.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> Chromeમાં ખૂલશે. ચાલુ રાખીને, તમે Chromeની <ph name="BEGIN_LINK1" />સેવાની શરતો<ph name="END_LINK1" /> અને <ph name="BEGIN_LINK2" />ગોપનીયતા સૂચના<ph name="END_LINK2" /> સાથે સંમત થાઓ છો.</translation>
-<translation id="1919345977826869612">જાહેરાતો</translation>
-<translation id="1919950603503897840">સંપર્કો પસંદ કરો</translation>
-<translation id="1922076542920281912">Chrome તમારું સ્થાન ઍક્સેસ કરી શકે તે માટે <ph name="BEGIN_LINK" />Android સેટિંગ<ph name="END_LINK" />માં પણ સ્થાન ચાલુ કરો.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">અપડેટ</translation>
-<translation id="19288952978244135">Chrome ફરીથી ખોલો.</translation>
-<translation id="1933845786846280168">પસંદ કરેલ ટૅબ</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android સેટિંગ્સ<ph name="END_LINK" />માં Chrome માટે પરવાનગી ચાલુ કરો.</translation>
-<translation id="1943432128510653496">પાસવર્ડ સાચવો</translation>
-<translation id="1952172573699511566">જ્યારે શક્ય હશે, ત્યારે વેબસાઇટ તમારી પસંદગીની ભાષામાં ટેક્સ્ટ બતાવશે.</translation>
-<translation id="1960290143419248813">Androidના આ વર્ઝન માટે Chrome અપડેટ હવે સમર્થિત નથી</translation>
-<translation id="1966710179511230534">કૃપા કરીને તમારી સાઇન-ઇન વિગતો અપડેટ કરો.</translation>
-<translation id="1974060860693918893">વિગતવાર</translation>
-<translation id="1984705450038014246">તમારા Chromeના ડેટાને સિંક કરો</translation>
-<translation id="1984937141057606926">મંજૂર, તૃતીય-પક્ષ સિવાય</translation>
-<translation id="1986685561493779662">નામ પહેલેથી જ અસ્તિત્વમાં છે</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> બટન</translation>
-<translation id="1989112275319619282">બ્રાઉઝ કરો</translation>
-<translation id="1993768208584545658"><ph name="SITE" />, જોડી કરવા માગે છે</translation>
-<translation id="1994173015038366702">સાઈટ URL</translation>
-<translation id="2000419248597011803">ઍડ્રેસ બાર અને શોધ બૉક્સમાંથી કેટલીક કુકી અને શોધને તમારા ડિફૉલ્ટ શોધ એંજિન પર મોકલે છે</translation>
-<translation id="2002537628803770967">Google Payનો ઉપયોગ કરતા ક્રેડિટ કાર્ડ અને સરનામાં</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ફાઇલ}one{# ફાઇલો}other{# ફાઇલો}}</translation>
-<translation id="2017836877785168846">ઍડ્રેસ બારમાં ઇતિહાસ અને સ્વતઃપૂર્ણ કરવું સાફ કરો.</translation>
-<translation id="2021896219286479412">પૂર્ણ સ્ક્રીન સાઇટ નિયંત્રણો</translation>
-<translation id="2038563949887743358">વિનંતી ડેસ્કટૉપ સાઇટ ચાલુ કરો</translation>
-<translation id="2041019821020695769">Chrome તમને નોટિફિકેશન મોકલી શકે તે માટે <ph name="BEGIN_LINK" />Android સેટિંગ<ph name="END_LINK" />માં પણ નોટિફિકેશન ચાલુ કરો.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> નો ડેટા Chromeમાં પણ છે</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">સાઇટ રોકવામાં આવી</translation>
-<translation id="2063713494490388661">શોધવા માટે ટેપ કરો</translation>
-<translation id="2067805253194386918">ટેક્સ્ટ</translation>
-<translation id="2079545284768500474">છેલ્લો ફેરફાર રદ કરો</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" /> માંથી <ph name="RESULT_NUMBER" /> પરિણામ</translation>
-<translation id="2091887806945687916">ધ્વનિ</translation>
-<translation id="2096012225669085171">સમગ્ર ઉપકરણો પર સિંક કરો અને વ્યક્તિગત બનાવો</translation>
-<translation id="2100273922101894616">સ્વતઃ સાઇન-ઇન</translation>
-<translation id="2100314319871056947">ટેક્સ્ટને નાના-નાના ટૂકડામાં શેર કરી જુઓ</translation>
-<translation id="2107397443965016585">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપતા પહેલાંં પૂછો (સુઝાવ આપેલ)</translation>
-<translation id="2111511281910874386">પૃષ્ઠ પર જાઓ</translation>
-<translation id="2122601567107267586">ઍપ ખોલી ન શક્યાં</translation>
-<translation id="2126426811489709554">Chrome દ્વારા સંચાલિત</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> સાચવ્યો</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> બંધ કર્યું છે</translation>
-<translation id="2139186145475833000">હોમસ્ક્રીન પર ઉમેરો</translation>
-<translation id="2146738493024040262">ઝટપટ ઍપ્લિકેશન ખોલો</translation>
-<translation id="2148716181193084225">આજે</translation>
-<translation id="2154484045852737596">કાર્ડમાં ફેરફાર કરો</translation>
-<translation id="2154710561487035718">URL ની કૉપિ કરો</translation>
-<translation id="2156074688469523661">બાકી સાઇટ (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">તમારા ફોનથી કોઈ અન્ય ડિવાઇસ પર કંઈક શેર કરવા માટે, બન્ને ડિવાઇસ પરના Chrome સેટિંગમાં સિંકની સુવિધા ચાલુ કરો</translation>
-<translation id="2170088579611075216">VRને મંજૂરી આપો અને તેમાં પ્રવેશ કરો</translation>
-<translation id="218608176142494674">શેરિંગ</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> તરીકે ચાલુ રાખો</translation>
-<translation id="2234876718134438132">સિંક અને Google સેવાઓ</translation>
-<translation id="2259659629660284697">બધા પાસવર્ડની નિકાસ કરો…</translation>
-<translation id="2268044343513325586">સુધારો</translation>
-<translation id="2286841657746966508">બિલિંગ સરનામું</translation>
-<translation id="2289270750774289114">જ્યારે કોઈ સાઇટ નજીકના બ્લૂટૂથ ડિવાઇસને શોધવા માગે ત્યારે પૂછો (સુઝાવ આપેલ)</translation>
-<translation id="230115972905494466">કોઈ સુસંગત ઉપકરણો મળ્યા નથી</translation>
-<translation id="2315043854645842844">ઓપરેટિંગ સિસ્ટમ દ્વારા ક્લાઇન્ટ તરફની પ્રમાણપત્ર પસંદગી સપોર્ટ કરતી નથી.</translation>
-<translation id="2318045970523081853">કૉલ કરવા માટે ટૅપ કરો</translation>
-<translation id="2321086116217818302">પાસવર્ડ તૈયાર કરી રહ્યાં છીએ…</translation>
-<translation id="2321958826496381788">જ્યાં સુધી તમે આ અનુકૂળ રીતે વાંચી ન શકો ત્યાં સુધી સ્લાઇડર ખેંચો. ફકરા પર ડબલ-ટેપિંગ પછી ટેક્સ્ટ ઓછામાં ઓછી આટલી મોટી દેખાવી જોઈએ.</translation>
-<translation id="2323763861024343754">સાઇટ સ્ટોરેજ</translation>
-<translation id="2328985652426384049">સાઇન ઇન કરી શકાતું નથી</translation>
-<translation id="2330129964253841015">જો પાસવર્ડમાં ચેડાં થાય તો તમને ચેતવણી આપવામાં આવશે</translation>
-<translation id="2349710944427398404">Chrome દ્વારા ઉપયોગમાં લેવાયેલ કુલ સ્ટોરેજ, એકાઉન્ટ્સ, બુકમાર્ક્સ અને સાચવેલ સેટિંગ્સ સહિત</translation>
-<translation id="2353636109065292463">તમારું ઇન્ટરનેટ કનેક્શન તપાસી રહ્યાં છીએ</translation>
-<translation id="2359808026110333948">આગળ વધો</translation>
-<translation id="2369533728426058518">ટૅબ્સ ખોલો</translation>
-<translation id="2387895666653383613">ટેક્સ્ટ માપન</translation>
-<translation id="2394602618534698961">તમે ડાઉનલોડ કરો તે ફાઇલો અહીં દેખાશે</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">જ્યારે તમે તમારા Google એકાઉન્ટમાં સાઇન ઇન કરો છો, ત્યારે આ સુવિધા ચાલુ કરવામાં આવે છે</translation>
-<translation id="2410754283952462441">એકાઉન્ટ પસંદ કરો</translation>
-<translation id="2414886740292270097">ઘાટું</translation>
-<translation id="2416359993254398973">Chromeને આ સાઇટ માટે તમારા કૅમેરાના ઍક્સેસની પરવાનગીની જરૂર પડે છે.</translation>
-<translation id="2426805022920575512">બીજું એકાઉન્ટ પસંદ કરો</translation>
-<translation id="2433507940547922241">દેખાવ</translation>
-<translation id="2434158240863470628">ડાઉનલોડ પૂર્ણ <ph name="SEPARATOR" /><ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">સ્થાન ઍક્સેસ</translation>
-<translation id="2450083983707403292">શું તમે <ph name="FILE_NAME" />ને ફરી ડાઉનલોડ કરવાનું શરૂ કરવા માગો છો?</translation>
-<translation id="2482878487686419369">સૂચનાઓ</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> દ્વારા સંચાલિત</translation>
-<translation id="2494974097748878569">Chromeમાં Google આસિસ્ટંટ</translation>
-<translation id="2496180316473517155">બ્રાઉઝિંગ ઇતિહાસ</translation>
-<translation id="2497852260688568942">સમન્વયન, તમારા વ્યવસ્થાપક દ્વારા અક્ષમ કરવામાં આવ્યું છે</translation>
-<translation id="2498359688066513246">સહાય અને પ્રતિસાદ</translation>
-<translation id="2501278716633472235">પાછા જાઓ</translation>
-<translation id="2513403576141822879">ગોપનીયતા, સુરક્ષા, અને ડેટા સંગ્રહથી સંબંધિત વધુ સેટિંગ માટે, <ph name="BEGIN_LINK" />સિંક અને Google સેવાઓ<ph name="END_LINK" /> જુઓ</translation>
-<translation id="2518590038762162553">લાઇટ મોડમાં, Chrome પેજને વધુ ઝડપથી લોડ કરે છે અને તે 60 ટકા ઓછા ડેટાનો વપરાશ કરે છે. તમે જે પેજની મુલાકાત લેતા હો તેને ઑપ્ટિમાઇઝ કરવા માટે, Chrome તમારો વેબ ટ્રાફિક Googleને મોકલે છે. <ph name="BEGIN_LINK" />વધુ જાણો<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">તમે મુલાકાત લો તે પેજના URLs Googleને મોકલે છે</translation>
-<translation id="2532336938189706096">વેબ દૃશ્ય</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> આઇટમ કાઢી નાખી</translation>
-<translation id="2536728043171574184">આ પેજની ઓફલાઇન કૉપિ જોઈ રહ્યા છે</translation>
-<translation id="2546283357679194313">કૂકીઝ અને સાઇટ ડેટા</translation>
-<translation id="2567385386134582609">છબી</translation>
-<translation id="257088987046510401">થીમ્સ</translation>
-<translation id="2570922361219980984">આ ઉપકરણ માટે સ્થાન ઍક્સેસ પણ બંધ છે. તેને <ph name="BEGIN_LINK" />Android સેટિંગ<ph name="END_LINK" />માં ચાલુ કરો.</translation>
-<translation id="257931822824936280">વિસ્તૃત - સંકુચિત કરવા માટે ક્લિક કરો.</translation>
-<translation id="2581165646603367611">આ કુકી, કૅશ અને Chromeને લાગતું હોય કે આ મહત્વનું નથી એવા સાઇટના બીજા ડેટાને સાફ કરશે.</translation>
-<translation id="2586657967955657006">ક્લિપબોર્ડ</translation>
-<translation id="2587052924345400782">નવું વર્ઝન ઉપલબ્ધ છે</translation>
-<translation id="2593272815202181319">મોનોસ્પેસ</translation>
-<translation id="2612676031748830579">કાર્ડ નંબર</translation>
-<translation id="2621115761605608342">ચોક્કસ સાઇટ માટે JavaScript ની મંજૂરી આપો.</translation>
-<translation id="2625189173221582860">પાસવર્ડ કૉપિ કર્યો</translation>
-<translation id="2631006050119455616">બચાવેલ</translation>
-<translation id="2647434099613338025">ભાષા ઉમેરો</translation>
-<translation id="2650751991977523696">ફાઇલને ફરીથી ડાઉનલોડ કરીએ?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ઑડિયો ફાઇલ}one{# ઑડિયો ફાઇલો}other{# ઑડિયો ફાઇલો}}</translation>
-<translation id="2653659639078652383">સબમિટ કરો</translation>
-<translation id="2677748264148917807">છોડો</translation>
-<translation id="2704606927547763573">કૉપિ કર્યું</translation>
-<translation id="2707726405694321444">પેજ રિફ્રેશ કરો</translation>
-<translation id="2709516037105925701">સ્વતઃભરો</translation>
-<translation id="2717722538473713889">ઇમેઇલ ઍડ્રેસ</translation>
-<translation id="2728754400939377704">સાઇટ અનુસાર સૉર્ટ કરો</translation>
-<translation id="2744248271121720757">ઝટપટ શોધ કરવા માટે શબ્દ પર ટૅપ કરો અથવા સંબંધિત ક્રિયાઓ જુઓ</translation>
-<translation id="2760989362628427051">જ્યારે તમારા ડિવાઇસની ઘેરી થીમ અથવા બૅટરી સેવર ચાલુ હોય ત્યારે ઘેરી થીમ ચાલુ કરો</translation>
-<translation id="2762000892062317888">હમણાં જ</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> સેકંડ બાકી</translation>
-<translation id="2779651927720337254">નિષ્ફળ થયું</translation>
-<translation id="2781151931089541271">1 સેકંડ બાકી</translation>
-<translation id="2801022321632964776">Chromeના એકદમ નવા વર્ઝનમાં તમારી ભાષા મેળવવા માટે અપડેટ કરો</translation>
-<translation id="2810645512293415242">ડેટા બચાવવા અને વધુ ઝડપથી પેજ લોડ કરવા માટે પેજ સરળ બનાવ્યું.</translation>
-<translation id="281504910091592009">સાચવેલા પાસવર્ડ તમારા <ph name="BEGIN_LINK" />Google એકાઉન્ટ<ph name="END_LINK" />માં જુઓ અને મેનેજ કરો</translation>
-<translation id="2818669890320396765">તમારા બધા ઉપકરણો પર તમારા બુકમાર્ક મેળવવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો</translation>
-<translation id="2822354292072154809">શું તમે ખરેખર <ph name="CHOSEN_OBJECT_NAME" />ની બધી સાઇટ પસંદગીઓને રીસેટ કરવા માગો છે?</translation>
-<translation id="2836148919159985482">પૂર્ણ સ્ક્રીનથી બહાર નીકળવા માટે પાછળ બટન ટચ કરો.</translation>
-<translation id="2842985007712546952">પેરન્ટ ફોલ્ડર</translation>
-<translation id="2858138569776157458">લોકપ્રિય સાઇટ</translation>
-<translation id="2860954141821109167">ખાતરી કરો કે આ ડિવાઇસ પર ફોન ઍપ ચાલુ કરેલી છે</translation>
-<translation id="2870560284913253234">સાઇટ</translation>
-<translation id="2874939134665556319">પાછલું ટ્રૅક</translation>
-<translation id="2876369937070532032">તમારી સુરક્ષા જોખમમાં હોય ત્યારે, તમે મુલાકાત લેતા હો તે કેટલાક પેજના URLs Googleને મોકલે છે</translation>
-<translation id="2888126860611144412">Chrome વિશે</translation>
-<translation id="2891154217021530873">પૃષ્ઠ લોડ કરવાનું રોકો</translation>
-<translation id="2893180576842394309">Google, શોધ અને અન્ય Google સેવાઓને વ્યક્તિગત કરવા માટે તમારા ઇતિહાસનો ઉપયોગ કરી શકે છે</translation>
-<translation id="2898264748040935573">સાચવેલા પાસવર્ડમાં ફેરફાર કરો</translation>
-<translation id="2900528713135656174">ઇવેન્ટ બનાવો</translation>
-<translation id="290376772003165898">પેજ <ph name="LANGUAGE" />માં નથી?</translation>
-<translation id="2904414404539560095">કોઈ ટૅબ સાથે શેર કરવાના ડિવાઇસની સૂચિ સંપૂર્ણ ઊંચાઈએ ખૂલે છે.</translation>
-<translation id="2910701580606108292">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપતા પહેલાંં પૂછો</translation>
-<translation id="2913331724188855103">સાઇટને કૂકી ડેટા સાચવવા અને વાંચવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
-<translation id="2923908459366352541">નામ અમાન્ય છે</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> સ્ટોરેજ</translation>
-<translation id="2942036813789421260">પ્રીવ્યૂની ટૅબ બંધ કરવામાં આવી</translation>
-<translation id="2956410042958133412">આ એકાઉન્ટ <ph name="PARENT_NAME_1" /> અને <ph name="PARENT_NAME_2" /> દ્વારા મેનેજ થાય છે.</translation>
-<translation id="2962095958535813455">છૂપા ટૅબ્સ પર સ્વિચ કર્યું</translation>
-<translation id="2968755619301702150">પ્રમાણપત્ર દર્શક</translation>
-<translation id="2979025552038692506">પસંદ કરેલ છૂપું ટૅબ</translation>
-<translation id="2987620471460279764">બીજા ડિવાઇસ પરથી શેર થયેલી ટેક્સ્ટ</translation>
-<translation id="2989523299700148168">તાજેતરમાં મુલાકાત લીધેલ</translation>
-<translation id="2996291259634659425">પાસફ્રેઝ બનાવો</translation>
-<translation id="2996809686854298943">URL આવશ્યક છે</translation>
-<translation id="300526633675317032">આ <ph name="SIZE_IN_KB" /> નું બધું વેબસાઇટ સ્ટોરેજ સાફ કરશે.</translation>
-<translation id="3016635187733453316">ખાતરી કરો કે આ ડિવાઇસ ઇન્ટરનેટ સાથે કનેક્ટ કરેલું છે</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB ડાઉનલોડ કર્યા</translation>
-<translation id="3029704984691124060">પાસફ્રેઝેસ મેળ ખાતા નથી</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />સહાય મેળવો<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">સ્થાન બંધ છે, તેને <ph name="BEGIN_LINK" />Android સેટિંગ<ph name="END_LINK" />માં ચાલુ કરો.</translation>
-<translation id="3058498974290601450">તમે કોઈ પણ સમયે સેટિંગમાં 'સિંક કરો' ચાલુ કરી શકો છો</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> બુકમાર્ક}one{<ph name="BOOKMARKS_COUNT_MANY" /> બુકમાર્ક}other{<ph name="BOOKMARKS_COUNT_MANY" /> બુકમાર્ક}}</translation>
-<translation id="3089395242580810162">છુપા ટેબમાં ખોલો</translation>
-<translation id="3115898365077584848">માહિતી બતાવો</translation>
-<translation id="3123473560110926937">કેટલીક સાઇટ પર બ્લૉક કરેલ</translation>
-<translation id="3137521801621304719">છુપા મોડને છોડો</translation>
-<translation id="3143515551205905069">સિંક કરવાનું રદ કરો</translation>
-<translation id="3157842584138209013">વધુ વિકલ્પો બટનની મદદથી તમે કેટલો ડેટા સાચવ્યો તે જુઓ</translation>
-<translation id="3166827708714933426">ટૅબ અને વિંડો શૉર્ટકટ્સ</translation>
-<translation id="3181954750937456830">Safe Browsing (તમારું અને તમારા ડિવાઇસનું જોખમી સાઇટથી રક્ષણ કરે છે)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android સેટિંગ્સ<ph name="END_LINK" />માં Chrome માટે પરવાનગીઓ ચાલુ કરો.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> સંગ્રહિત ડેટા</translation>
-<translation id="3205824638308738187">લગભગ સમાપ્ત થયું!</translation>
-<translation id="3207960819495026254">બુકમાર્ક કરેલ</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> કાઢી નાખી</translation>
-<translation id="321773570071367578">જો તમે તમારો પાસફ્રેઝ ભૂલી ગયાં હોવ અથવા આ સેટિંગ બદલવા માંગતા હોવ, તો <ph name="BEGIN_LINK" />સમન્વયનને ફરીથી સેટ કરો<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">માઇક્રોફોન</translation>
-<translation id="3232754137068452469">વેબ ઍપ</translation>
-<translation id="3236059992281584593">1 મિનિટ બાકી</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">આ પૃષ્ઠને બુકમાર્ક કરો</translation>
-<translation id="3259831549858767975">પૃષ્ઠ પરની તમામ સામગ્રીને નાની કરો</translation>
-<translation id="3269093882174072735">છબી લોડ કરો</translation>
-<translation id="3269956123044984603">તમારા બીજા ડિવાઇસ પરથી તમારા ટૅબ્સ મેળવવા માટે, Android એકાઉન્ટ સેટિંગમાં "સ્વતઃ-સિંક કરો ડેટા" ચાલુ કરો.</translation>
-<translation id="3277252321222022663">સાઇટને સેન્સરના ઍક્સેસની મંજૂરી આપો (સુઝાવ આપેલ)</translation>
-<translation id="3282568296779691940">Chrome માં સાઇન ઇન કરો</translation>
-<translation id="3288003805934695103">પૃષ્ઠ ફરીથી લોડ કરીને</translation>
-<translation id="32895400574683172">નોટિફિકેશનોની મંજૂરી છે</translation>
-<translation id="3295530008794733555">વધુ ઝડપથી બ્રાઉઝ કરો. ઓછા ડેટાનો ઉપયોગ કરો.</translation>
-<translation id="3295602654194328831">માહિતી છુપાવો</translation>
-<translation id="3298243779924642547">લાઇટ</translation>
-<translation id="3303414029551471755">કન્ટેન્ટ ડાઉનલોડ કરવા માટે આગળ વધીએ?</translation>
-<translation id="3306398118552023113">આ ઍપ Chromeમાં ચાલી રહી છે</translation>
-<translation id="3315103659806849044">તમે હાલમાં તમારા સિંક અને Google સેવા સેટિંગને કસ્ટમાઇઝ કરી રહ્યાં છો. સિંક ચાલુ કરવાનું પૂર્ણ કરવા માટે, સ્ક્રીનની નીચેની બાજુએ કન્ફર્મ કરો બટન પર ટૅપ કરો. ઉપર નૅવિગેટ કરો</translation>
-<translation id="3328801116991980348">સાઇટ માહિતી</translation>
-<translation id="3333961966071413176">બધા સંપર્કો</translation>
-<translation id="3334729583274622784">ફાઇલનું એક્સ્ટેંશન બદલવું છે?</translation>
-<translation id="3341058695485821946">તમે કેટલો ડેટા સાચવ્યો તે જુઓ</translation>
-<translation id="3350687908700087792">બધા છુપા ટેબ્સ બંધ કરો</translation>
-<translation id="3353615205017136254">Google દ્વારા પૂરું પાડવામાં આવેલું લાઇટ વર્ઝનનું પેજ. ઑરિજિનલ પેજ લોડ કરવા માટે ઑરિજિનલ લોડ કરો બટન ટૅપ કરો.</translation>
-<translation id="3367813778245106622">સમન્વયન શરૂ કરવા માટે ફરીથી સાઇન ઇન કરો</translation>
-<translation id="3374023511497244703">તમારો બુકમાર્ક, ઇતિહાસ, પાસવર્ડ અને અન્ય Chrome ડેટા હવેથી તમારા Google એકાઉન્ટ પર સિંક થશે નહીં</translation>
-<translation id="3384347053049321195">છબી શેર કરો</translation>
-<translation id="3386292677130313581">સાઇટ્સને તમારા સ્થાનને જાણવાની મંજૂરી આપતાં પહેલાં પૂછો (ભલામણ કરેલ)</translation>
-<translation id="3387650086002190359">ફાઇલ સિસ્ટમ ભૂલોના કારણે <ph name="FILE_NAME" /> ડાઉનલોડ નિષ્ફળ થયું.</translation>
-<translation id="3389286852084373014">ટેક્સ્ટ ખૂબ મોટી છે</translation>
-<translation id="3398320232533725830">બુકમાર્ક્સ સંચાલક ખોલો</translation>
-<translation id="3414952576877147120">કદ:</translation>
-<translation id="3443221991560634068">વર્તમાન પૃષ્ઠ ફરીથી લોડ કરો</translation>
-<translation id="3445014427084483498">હમણાં જ</translation>
-<translation id="3478363558367712427">તમે તમારું શોધ એન્જિન પસંદ કરી શકો છો</translation>
+<translation id="6910211073230771657">કાઢી નાખ્યું</translation>
+<translation id="6965382102122355670">બરાબર, સમજાઇ ગયું</translation>
+<translation id="5301954838959518834">બરાબર, સમજાઇ ગયું</translation>
+<translation id="7658239707568436148">રદ કરો</translation>
 <translation id="3479552764303398839">હમણાં નહીં</translation>
-<translation id="3492207499832628349">નવી છુપી ટેબ</translation>
-<translation id="3493531032208478708">સૂચવેલ કન્ટેન્ટ વિશે <ph name="BEGIN_LINK" />વધુ જાણો<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">ઑગ્મેન્ટેડ રિયાલિટી</translation>
-<translation id="3518985090088779359">સ્વીકારો અને ચાલુ રાખો</translation>
-<translation id="3522247891732774234">અપડેટ ઉપલબ્ધ છે. વધુ વિકલ્પો</translation>
-<translation id="3524138585025253783">ડેવલપર UI</translation>
-<translation id="3527085408025491307">ફોલ્ડર</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB ઉપલબ્ધ</translation>
-<translation id="3549657413697417275">તમારો ઇતિહાસ શોધો</translation>
-<translation id="3557336313807607643">સંપર્કોમાં ઉમેરો</translation>
-<translation id="3566923219790363270">Chrome હજી પણ VR માટે તૈયારી કરી રહ્યું છે. Chromeને પછી ફરી શરૂ કરો.</translation>
-<translation id="3568688522516854065">તમારા અન્ય ઉપકરણો પરથી તમારા ટૅબ મેળવવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો.</translation>
-<translation id="3587482841069643663">બધા</translation>
-<translation id="358794129225322306">એકથી વધુ ફાઇલો ઑટોમૅટિક રીતે ડાઉનલોડ કરવાની મંજૂરી સાઇટને આપો.</translation>
-<translation id="3590487821116122040">Chrome ને મહત્વનું ન લાગતું સાઇટ સ્ટોરેજ (ઉદા., કોઇ સાચવેલ સેટિંગ્સ ન હોય તેવી અથવા વારંવાર મુલાકાત ન લેવાતી હોય તેવી સાઇટ્સ)</translation>
-<translation id="3599863153486145794">બધા સાઇન ઇન કરેલ ડિવાઇસમાંથી ઇતિહાસ સાફ કરે છે. તમારા Google એકાઉન્ટમાં <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> પર બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો હોય શકે.</translation>
-<translation id="3600792891314830896">જે સાઇટ અવાજ ચલાવતી હોય તેઓનો અવાજ બંધ કરો</translation>
-<translation id="3616113530831147358">ઑડિઓ</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> પર શેર કરી રહ્યાં છે</translation>
-<translation id="3632295766818638029">પાસવર્ડ બતાવો</translation>
-<translation id="363596933471559332">સંગ્રહિત ઓળખપત્રોનો ઉપયોગ કરીને વેબસાઇટ્સમાં આપમેળે સાઇન ઇન કરો. જ્યારે સુવિધા બંધ હોય છે, ત્યારે વેબસાઇટમાં સાઇન ઇન કરતાં પહેલાં દર વખતે તમને ચકાસણી માટે કહેવામાં આવશે.</translation>
-<translation id="3658159451045945436">રીસેટ કરવાથી મુલાકાત લીધેલી સાઇટની સૂચિ સહિત તમારા ડેટા બચતના ઇતિહાસને કાઢી નાખે છે.</translation>
-<translation id="3692944402865947621">સ્ટોરેજ સ્થાન સુધી પહોંચી ન શકવાને કારણે <ph name="FILE_NAME" />નું ડાઉનલોડ નિષ્ફળ થયું.</translation>
-<translation id="3714981814255182093">શોધો બાર ખોલો</translation>
-<translation id="3716182511346448902">આ પેજ ઘણી વધુ મેમરીનો ઉપયોગ કરે છે, તેથી Chromeએ તેને થોભાવ્યું છે.</translation>
-<translation id="3730075448226062617">Chrome તમારું માઇક્રોફોન ઍક્સેસ કરી શકે તે માટે <ph name="BEGIN_LINK" />Android સેટિંગ<ph name="END_LINK" />માં પણ માઇક્રોફોન ચાલુ કરો.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> માં બુકમાર્ક કર્યું</translation>
-<translation id="3744111561329211289">પૃષ્ઠભૂમિ સમન્વયન</translation>
-<translation id="3771001275138982843">અપડેટ ડાઉનલોડ કરી શકાઈ નથી</translation>
-<translation id="3771033907050503522">છૂપા ટેબ્સ</translation>
-<translation id="3773755127849930740">જોડી કરવાની મંજૂરી આપવા માટે <ph name="BEGIN_LINK" />Bluetooth ચાલુ કરો<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">તમારા ડિવાઇસ પર મોકલો</translation>
-<translation id="3778956594442850293">હોમ સ્ક્રીન પર ઉમેર્યું</translation>
-<translation id="3789841737615482174">ઇન્સ્ટોલ કરો</translation>
-<translation id="3810838688059735925">વીડિયો</translation>
-<translation id="3810973564298564668">મેનેજ કરો</translation>
-<translation id="381841723434055211">ફોન નંબર</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> ડાઉનલોડ કાઢી નાખ્યાં</translation>
-<translation id="3822502789641063741">સાઇટ સ્ટોરેજ સાફ કરીએ?</translation>
-<translation id="385051799172605136">પાછળ</translation>
-<translation id="3859306556332390985">આગળ કરો</translation>
-<translation id="3894427358181296146">ફોલ્ડર ઉમેરો</translation>
-<translation id="3895926599014793903">ફરજિયાતપૂર્વક ઝૂમ ચાલુ કરો</translation>
-<translation id="3912508018559818924">વેબમાંથી શ્રેષ્ઠ શોધવું…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">મારા ડેટાને સંયોજિત કરો</translation>
-<translation id="393697183122708255">કોઈ સક્ષમ વૉઇસ શોધ ઉપલબ્ધ નથી</translation>
-<translation id="395206256282351086">શોધ અને સાઇટ સૂચનો બંધ છે</translation>
-<translation id="3955193568934677022">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{તૈયાર હશે ત્યારે Chrome તમારું પેજ લોડ કરશે}one{તૈયાર હશે ત્યારે Chrome તમારાં પેજ લોડ કરશે}other{તૈયાર હશે ત્યારે Chrome તમારાં પેજ લોડ કરશે}}</translation>
-<translation id="3963007978381181125">પાસફ્રેઝ એન્ક્રિપ્શનમાં Google Payની ચુકવણી પદ્ધતિઓ અને ઍડ્રેસ સામેલ હોતા નથી. માત્ર તમારા પાસફ્રેઝ ધરાવતી કોઈ વ્યક્તિ જ તમારા એન્ક્રિપ્ટ કરેલા ડેટાને વાંચી શકે છે. Googleને પાસફ્રેઝ મોકલવામાં આવતો નથી કે તેના દ્વારા સંગ્રહિત કરવામાં આવતો નથી. જો તમે તમારો પાસફ્રેઝ ભૂલી જાઓ અથવા આ સેટિંગ બદલવા માંગતા હો, તો તમારે સિંકને રીસેટ કરવું પડશે. <ph name="BEGIN_LINK" />વધુ જાણો<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ડાઉનલોડ પૂર્ણ</translation>
-<translation id="397583555483684758">સમન્વયન એ કામ કરવાનું બંધ કરી દીધું છે</translation>
-<translation id="3976396876660209797">આ શૉર્ટકટ દૂર કરો અને ફરી બનાવો</translation>
-<translation id="3985215325736559418">શું તમે <ph name="FILE_NAME" /> ને ફરી ડાઉનલોડ કરવા માગો છો?</translation>
-<translation id="3987993985790029246">લિંક કૉપિ કરો</translation>
-<translation id="3988213473815854515">સ્થાન માન્ય છે</translation>
-<translation id="3988466920954086464">ઝટપટ શોધ પરિણામો આ પૅનલમાં જુઓ</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">બિનમહત્વપૂર્ણ સ્ટોરેજ</translation>
-<translation id="4000212216660919741">ઑફલાઇન હોમ</translation>
+<translation id="5317780077021120954">સાચવો</translation>
+<translation id="4570913071927164677">વિગતો</translation>
+<translation id="8730621377337864115">થઈ ગયું</translation>
+<translation id="8261506727792406068">ડિલીટ કરો</translation>
+<translation id="1181037720776840403">કાઢી નાખો</translation>
+<translation id="5939518447894949180">રીસેટ કરો</translation>
 <translation id="4002066346123236978">શીર્ષક</translation>
-<translation id="4008040567710660924">કોઈ ચોક્કસ સાઇટ માટે કુકીને મંજૂરી આપો.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# કલાક}one{# કલાક}other{# કલાક}}</translation>
-<translation id="4046123991198612571">આગલો ટ્રૅક</translation>
-<translation id="4048707525896921369">પેજ છોડ્યાં વગર વેબસાઇટ પરના મુદ્દાઓ વિશે જાણો. શોધને ટૅપ કરવાથી એક શબ્દ અને તેની આસપાસનો સંદર્ભ Google શોધને મોકલે છે, જે વ્યાખ્યાઓ, ફોટોો, શોધ પરિણામો અને અન્ય વિગતો પરત કરે છે.
+<translation id="5916664084637901428">ચાલુ</translation>
+<translation id="5860033963881614850">બંધ</translation>
+<translation id="6165508094623778733">વધુ જાણો</translation>
+<translation id="6042308850641462728">વધુ</translation>
+<translation id="6040143037577758943">બંધ કરો</translation>
+<translation id="780301667611848630">નહીં, આભાર</translation>
+<translation id="1201402288615127009">આગલું</translation>
+<translation id="2359808026110333948">આગળ વધો</translation>
+<translation id="2653659639078652383">સબમિટ કરો</translation>
+<translation id="2079545284768500474">છેલ્લો ફેરફાર રદ કરો</translation>
+<translation id="7649070708921625228">સહાય</translation>
+<translation id="2148716181193084225">આજે</translation>
+<translation id="7781829728241885113">ગઈ કાલે</translation>
+<translation id="6945221475159498467">પસંદ કરો</translation>
+<translation id="7791543448312431591">ઉમેરો</translation>
+<translation id="6527303717912515753">શેર કરો</translation>
+<translation id="1383876407941801731">શોધો</translation>
+<translation id="3115898365077584848">માહિતી બતાવો</translation>
+<translation id="3295602654194328831">માહિતી છુપાવો</translation>
+<translation id="3987993985790029246">લિંક કૉપિ કરો</translation>
+<translation id="2704606927547763573">કૉપિ કર્યું</translation>
+<translation id="8725066075913043281">ફરી પ્રયાસ કરો</translation>
+<translation id="385051799172605136">પાછળ</translation>
+<translation id="8131740175452115882">પુષ્ટિ કરો</translation>
+<translation id="5300589172476337783">બતાવો</translation>
+<translation id="1124772482545689468">વપરાશકર્તા</translation>
+<translation id="8609465669617005112">ઉપર ખસેડો</translation>
+<translation id="6746124502594467657">નીચે ખસેડો</translation>
+<translation id="8249310407154411074">ટોચે ખસેડો</translation>
+<translation id="8428213095426709021">સેટિંગ્સ</translation>
+<translation id="2498359688066513246">સહાય અને પ્રતિસાદ</translation>
+<translation id="8378714024927312812">તમારી સંસ્થા દ્વારા મેનેજ કરેલ</translation>
+<translation id="9019902583201351841">તમારા માતાપિતા દ્વારા સંચાલિત</translation>
+<translation id="4645575059429386691">તમારા માતાપિતા દ્વારા સંચાલિત</translation>
+<translation id="4883854917563148705">મેનેજ કરવામાં આવેલા સેટિંગને રીસેટ કરી શકાતા નથી</translation>
+<translation id="4307992518367153382">પાયાગત</translation>
+<translation id="1974060860693918893">વિગતવાર</translation>
+<translation id="1146678959555564648">VR માં દાખલ થાઓ</translation>
+<translation id="987264212798334818">સામાન્ય</translation>
+<translation id="4275663329226226506">મીડિયા</translation>
+<translation id="4759238208242260848">ડાઉનલોડ્સ</translation>
+<translation id="218608176142494674">શેરિંગ</translation>
+<translation id="8004582292198964060">બ્રાઉઝર</translation>
+<translation id="1105960400813249514">સ્ક્રીન કૅપ્ચર</translation>
+<translation id="4875775213178255010">કન્ટેન્ટ માટે સૂચનો</translation>
+<translation id="2021896219286479412">પૂર્ણ સ્ક્રીન સાઇટ નિયંત્રણો</translation>
+<translation id="4587589328781138893">સાઇટ</translation>
+<translation id="4943703118917034429">વર્ચ્યુઅલ રિયાલિટી</translation>
+<translation id="1928696683969751773">અપડેટ</translation>
+<translation id="6064125863973209585">પૂર્ણ થયેલા ડાઉનલોડ</translation>
+<translation id="5342314432463739672">પરવાનગીની વિનંતી કરી</translation>
+<translation id="629730747756840877">એકાઉન્ટ</translation>
+<translation id="82609232232243542">Brave માં સાઇન ઇન કરો</translation>
+<translation id="7956662517480676674">સિંક અને Brave Software સેવાઓ</translation>
+<translation id="5294439808117722387">તમે હાલમાં તમારા સિંક અને Brave Software સેવા સેટિંગને કસ્ટમાઇઝ કરી રહ્યાં છો. સિંક ચાલુ કરવાનું પૂર્ણ કરવા માટે, સ્ક્રીનની નીચેની બાજુએ કન્ફર્મ કરો બટન પર ટૅપ કરો. ઉપર નૅવિગેટ કરો</translation>
+<translation id="2096012225669085171">સમગ્ર ઉપકરણો પર સિંક કરો અને વ્યક્તિગત બનાવો</translation>
+<translation id="1692118695553449118">સમન્વયન ચાલુ છે</translation>
+<translation id="5514904542973294328">આ ઉપકરણના વ્યવસ્થાપકે અક્ષમ કરેલ છે</translation>
+<translation id="6447211988989208781">Brave Software પ્રવૃત્તિ નિયંત્રણો</translation>
+<translation id="4882831918239250449">તમારા બ્રાઉઝિંગ ઇતિહાસને શોધ, જાહેરાતો અને વધુ સુવિધાને વ્યક્તિગત કરવા માટે કેવી રીતે ઉપયોગમાં લેવાય તેને નિયંત્રિત કરો</translation>
+<translation id="7431991332293347422">શોધ અને અન્ય બાબતોને તમને મનગમતી બનાવવા માટે તમારા બ્રાઉઝિંગ ઇતિહાસનો ઉપયોગ કરવાની રીત નિયંત્રિત કરો</translation>
+<translation id="6303969859164067831">સાઇન આઉટ કરો અને સિંક બંધ કરો</translation>
+<translation id="1125261911132334651">તમારું Brave Software એકાઉન્ટ મેનેજ કરો</translation>
+<translation id="6406506848690869874">સમન્વયન</translation>
+<translation id="714362445477979774">તમારા Braveના ડેટાને સિંક કરો</translation>
+<translation id="4314815835985389558">સિંક મેનેજ કરો</translation>
+<translation id="5428209950370661546">અન્ય Brave Software સેવાઓ</translation>
+<translation id="7704317875155739195">શોધ અને URLsને આપમેળે પૂર્ણ કરો</translation>
+<translation id="2000419248597011803">ઍડ્રેસ બાર અને શોધ બૉક્સમાંથી કેટલીક કુકી અને શોધને તમારા ડિફૉલ્ટ શોધ એંજિન પર મોકલે છે</translation>
+<translation id="7981313251711023384">ઝડપી બ્રાઉઝિંગ અને શોધ માટે પેજને પહેલેથી લોડ કરો</translation>
+<translation id="1821253160463689938">તમારી પસંદગીઓ યાદ રાખવા માટે કુકીનો ઉપયોગ કરે છે, પછી ભલે તમે તે પેજની મુલાકાત ન પણ લો</translation>
+<translation id="6697492270171225480">જ્યારે કોઈ પેજ ન મળે ત્યારે તેના જેવા પેજ માટે સૂચનો બતાવો</translation>
+<translation id="8109318360573330108">તમે જેના પર પહોંચવાનો પ્રયાસ કરતા હોય તે પેજનું URL Brave Softwareને મોકલાવે છે</translation>
+<translation id="8438566539970814960">શોધ અને બ્રાઉઝિંગ વધુ સારું બનાવો</translation>
+<translation id="284843628681142937">તમે મુલાકાત લો તે પેજના URLs Brave Softwareને મોકલે છે</translation>
+<translation id="7222718784508482526">ગોપનીયતા, સુરક્ષા, અને ડેટા સંગ્રહથી સંબંધિત વધુ સેટિંગ માટે, <ph name="BEGIN_LINK"/>સિંક અને Brave Software સેવાઓ<ph name="END_LINK"/> જુઓ</translation>
+<translation id="918192811481327695">Braveની સુવિધાઓ અને પ્રદર્શનને સુધારવામાં સહાય કરો</translation>
+<translation id="9063160602596686558">Brave Softwareને વપરાશના આંકડા અને ક્રૅશ રિપોર્ટ ઑટોમૅટિક રીતે મોકલે છે</translation>
+<translation id="4824958205181053313">સિંક કરવાનું રદ કરીએ?</translation>
+<translation id="3058498974290601450">તમે કોઈ પણ સમયે સેટિંગમાં 'સિંક કરો' ચાલુ કરી શકો છો</translation>
+<translation id="3143515551205905069">સિંક કરવાનું રદ કરો</translation>
+<translation id="1506061864768559482">શોધ એન્જિન</translation>
+<translation id="55737423895878184">સ્થાન અને નોટિફિકેશનોની મંજૂરી છે</translation>
+<translation id="3988213473815854515">સ્થાન માન્ય છે</translation>
+<translation id="32895400574683172">નોટિફિકેશનોની મંજૂરી છે</translation>
+<translation id="9040142327097499898">નોટિફિકેશનની મંજૂરી છે. આ ઉપકરણ માટે સ્થાન ઍક્સેસ બંધ છે.</translation>
+<translation id="305593374596241526">સ્થાન બંધ છે, તેને <ph name="BEGIN_LINK"/>Android સેટિંગ<ph name="END_LINK"/>માં ચાલુ કરો.</translation>
+<translation id="2989523299700148168">તાજેતરમાં મુલાકાત લીધેલ</translation>
+<translation id="6433501201775827830">તમારું શોધ એંજિન પસંદ કરો</translation>
+<translation id="7177466738963138057">તમે આને થોડા સમય પછી સેટિંગ્સમાં જઈને બદલી શકો છો</translation>
+<translation id="3478363558367712427">તમે તમારું શોધ એન્જિન પસંદ કરી શકો છો</translation>
+<translation id="4910889077668685004">ચુકવણી ઍપ્લિકેશનો</translation>
+<translation id="5152843274749979095">કોઇ સમર્થિત ઍપ્લિકેશનો ઇન્સ્ટૉલ થયેલ નથી</translation>
+<translation id="8812260976093120287">કેટલીક વેબસાઇટ પર, તમે સમર્થિત ચુકવણી ઍપ્લિકેશનો વડે ચુકવણી કરી શકો છો.</translation>
+<translation id="7764225426217299476">સરનામું ઉમેરો</translation>
+<translation id="5595485650161345191">ઍડ્રેસમાં ફેરફાર કરો</translation>
+<translation id="5087580092889165836">કાર્ડ ઉમેરો</translation>
+<translation id="2154484045852737596">કાર્ડમાં ફેરફાર કરો</translation>
+<translation id="6140912465461743537">દેશ/પ્રદેશ</translation>
+<translation id="5659593005791499971">ઇમેઇલ</translation>
+<translation id="4378154925671717803">ફોન</translation>
+<translation id="4807098396393229769">કાર્ડ પરનું નામ</translation>
+<translation id="860043288473659153">કાર્ડધારકનું નામ</translation>
+<translation id="2612676031748830579">કાર્ડ નંબર</translation>
+<translation id="869891660844655955">સમાપ્તિ તારીખ</translation>
+<translation id="2286841657746966508">બિલિંગ સરનામું</translation>
+<translation id="663059986967017181">Brave માં કોપી કરાયું</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">પાસવર્ડ્સ</translation>
+<translation id="1943432128510653496">પાસવર્ડ સાચવો</translation>
+<translation id="2100273922101894616">સ્વતઃ સાઇન-ઇન</translation>
+<translation id="363596933471559332">સંગ્રહિત ઓળખપત્રોનો ઉપયોગ કરીને વેબસાઇટ્સમાં આપમેળે સાઇન ઇન કરો. જ્યારે સુવિધા બંધ હોય છે, ત્યારે વેબસાઇટમાં સાઇન ઇન કરતાં પહેલાં દર વખતે તમને ચકાસણી માટે કહેવામાં આવશે.</translation>
+<translation id="6995899638241819463">જો ડેટા ઉલ્લંઘનમાં પાસવર્ડ જાહેર થાય તો તમને ચેતવણી આપવામાં આવે છે</translation>
+<translation id="1534287762301776620">જ્યારે તમે તમારા Brave Software એકાઉન્ટમાં સાઇન ઇન કરો છો, ત્યારે આ સુવિધા ચાલુ કરવામાં આવે છે</translation>
+<translation id="10614374240317010">ક્યારેય ન સચવાયેલું</translation>
+<translation id="3098842761938485917">સાચવેલા પાસવર્ડ તમારા <ph name="BEGIN_LINK"/>Brave Software એકાઉન્ટ<ph name="END_LINK"/>માં જુઓ અને મેનેજ કરો</translation>
+<translation id="8562452229998620586">તમારા સાચવેલા પાસવર્ડ્સ અહીં દેખાશે.</translation>
+<translation id="8084114998886531721">સાચવેલ પાસવર્ડ</translation>
+<translation id="2870560284913253234">સાઇટ</translation>
+<translation id="8503813439785031346">વપરાશકર્તાનામ</translation>
+<translation id="6657585470893396449">પાસવર્ડ</translation>
+<translation id="2154710561487035718">URL ની કૉપિ કરો</translation>
+<translation id="1571304935088121812">વપરાશકર્તાનામ કૉપિ કરો</translation>
+<translation id="5005498671520578047">પાસવર્ડની કૉપિ કરો</translation>
+<translation id="3632295766818638029">પાસવર્ડ બતાવો</translation>
+<translation id="1513858653616922153">પાસવર્ડ ડિલીટ કરો</translation>
+<translation id="543338862236136125">પાસવર્ડમાં ફેરફાર કરો</translation>
+<translation id="4565377596337484307">પાસવર્ડ છુપાવો</translation>
+<translation id="8523928698583292556">સંગ્રહિત કરેલ પાસવર્ડ ડિલીટ કરો</translation>
+<translation id="2898264748040935573">સાચવેલા પાસવર્ડમાં ફેરફાર કરો</translation>
+<translation id="5433691172869980887">વપરાશકર્તાનામ કૉપિ કર્યું</translation>
+<translation id="5534640966246046842">સાઇટ કૉપિ કરી</translation>
+<translation id="2625189173221582860">પાસવર્ડ કૉપિ કર્યો</translation>
+<translation id="4550003330909367850">અહીં તમારો પાસવર્ડ જોવા અથવા કૉપિ કરવા માટે, આ ડિવાઇસ પર સ્ક્રીન લૉક સેટ કરો.</translation>
+<translation id="6154478581116148741">આ ઉપકરણ પરથી તમારા બધા પાસવર્ડને નિકાસ કરવા માટે સેટિંગમાંથી સ્ક્રીન લૉક ચાલુ કરો</translation>
+<translation id="4842092870884894799">પાસવર્ડ જનરેશન પોપઅપ દર્શાવે છે</translation>
+<translation id="2259659629660284697">બધા પાસવર્ડની નિકાસ કરો…</translation>
+<translation id="133012818630824069">Braveમાં સંગ્રહિત કરેલા પાસવર્ડની નિકાસ કરો</translation>
+<translation id="6914783257214138813">જે કોઈપણ તમારી નિકાસ કરેલ પાસવર્ડની ફાઇલને જોઈ શકશે, તેમને તમારા પાસવર્ડ પણ દૃશ્યક્ષમ થશે.</translation>
+<translation id="2321086116217818302">પાસવર્ડ તૈયાર કરી રહ્યાં છીએ…</translation>
+<translation id="8445448999790540984">બધા પાસવર્ડ નિકાસ કરી શકાતાં નથી</translation>
+<translation id="3066461326500799725">Brave Software ડ્રાઇવનો ઉપયોગ કેવી રીતે કરવો તે જાણો</translation>
+<translation id="729975465115245577">તમારા ઉપકરણ પાસે પાસવર્ડ ફાઇલને સ્ટોર કરવા માટેની ઍપ નથી.</translation>
+<translation id="7682724950699840886">નીચેની ટિપ અજમાવી જુઓ: ખાતરી કરો કે તમારા ઉપકરણ પર પૂરતી સ્પેસ છે, ફરીથી નિકાસ કરવાનો પ્રયાસ કરો.</translation>
+<translation id="1129510026454351943">વિગતો: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">તમારો પાસવર્ડ કૉપિ કરવા માટે અનલૉક કરો</translation>
+<translation id="5515439363601853141">તમારો પાસવર્ડ જોવા માટે અનલૉક કરો</translation>
+<translation id="6221633008163990886">તમારા બધા પાસવર્ડને નિકાસ કરવા માટે અનલૉક કરો</translation>
+<translation id="230699814587342492">Brave પાસવર્ડ</translation>
+<translation id="6075798973483050474">હોમ પેજમાં ફેરફાર કરો</translation>
+<translation id="854522910157234410">આ પૃષ્ઠ ખોલો</translation>
+<translation id="2482878487686419369">સૂચનાઓ</translation>
+<translation id="6255999984061454636">કન્ટેન્ટ માટેના સૂચનો</translation>
+<translation id="805047784848435650">તમારા બ્રાઉઝિંગ ઇતિહાસના આધારે</translation>
+<translation id="1041308826830691739">વેબસાઇટ પરથી</translation>
+<translation id="395206256282351086">શોધ અને સાઇટ સૂચનો બંધ છે</translation>
+<translation id="257088987046510401">થીમ્સ</translation>
+<translation id="4650364565596261010">સિસ્ટમ ડિફૉલ્ટ</translation>
+<translation id="7588219262685291874">જ્યારે તમારા ડિવાઇસનું બૅટરી સેવર ચાલુ હોય ત્યારે ઘેરી થીમ ચાલુ કરો</translation>
+<translation id="2760989362628427051">જ્યારે તમારા ડિવાઇસની ઘેરી થીમ અથવા બૅટરી સેવર ચાલુ હોય ત્યારે ઘેરી થીમ ચાલુ કરો</translation>
+<translation id="6381421346744604172">ડાર્કન વેબસાઇટ</translation>
+<translation id="5040262127954254034">ગોપનીયતા</translation>
+<translation id="4991384657077828949">Brave સુરક્ષાને વધુ સારી બનાવવામાં સહાય કરો</translation>
+<translation id="1943176487615318915">જોખમી ઍપ અને સાઇટ શોધી કાઢવા માટે, Brave તમે મુલાકાત લો તે કેટલાક પેજના URLs, સિસ્ટમ વિશેની સીમિત માહિતી અને પેજનું કેટલુંક કન્ટેન્ટ Brave Softwareને મોકલે છે</translation>
+<translation id="3181954750937456830">Safe Browsing (તમારું અને તમારા ડિવાઇસનું જોખમી સાઇટથી રક્ષણ કરે છે)</translation>
+<translation id="7315322926489145388">તમારી સુરક્ષા જોખમમાં હોય ત્યારે, તમે મુલાકાત લેતા હો તે કેટલાક પેજના URLs Brave Softwareને મોકલે છે</translation>
+<translation id="2063713494490388661">શોધવા માટે ટેપ કરો</translation>
+<translation id="2369463299479365221">પેજ છોડ્યાં વગર વેબસાઇટ પરના મુદ્દાઓ વિશે જાણો. શોધને ટૅપ કરવાથી એક શબ્દ અને તેની આસપાસનો સંદર્ભ Brave Software શોધને મોકલે છે, જે વ્યાખ્યાઓ, ફોટોો, શોધ પરિણામો અને અન્ય વિગતો પરત કરે છે.
 
 તમારા શોધ શબ્દને બંધબેસતો કરવા, પસંદ કરવા માટે થોડીવાર દબાવી રાખવું. તમારી શોધને સુધારવા માટે, પૅનલને આખી ઉપર સ્લાઇડ કરો અને શોધ બૉક્સને ટૅપ કરો.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">સ્ક્રીનની ટોચ પર વિકલ્પો ઉપલબ્ધ છે</translation>
-<translation id="4062305924942672200">કાનુની માહિતી</translation>
-<translation id="4084682180776658562">બુકમાર્ક</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" /> તરફથી - <ph name="BEGIN_DEEMPHASIZED" />Google દ્વારા વિતરિત <ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">ઍપ મેમરીન ડેટા ડિલીટ કરી દઈએ?</translation>
-<translation id="4099578267706723511">ઉપયોગનાં આંકડા અને ક્રૅશ રિપોર્ટ Googleને મોકલીને Chromeને વધુ સારું બનાવવામાં મદદ કરો.</translation>
-<translation id="410351446219883937">ઑટોપ્લે</translation>
-<translation id="4116038641877404294">ઇન્ટરનેટ ન હોય ત્યારે પણ ઉપયોગમાં લેવા માટે પેજ ડાઉનલોડ કરો</translation>
-<translation id="4135200667068010335">કોઈ ટૅબ સાથે શેર કરવાના ડિવાઇસની સૂચિ બંધ છે.</translation>
-<translation id="4149994727733219643">વેબપેજ માટે સરળ દૃશ્ય</translation>
-<translation id="4165986682804962316">સાઇટ સેટિંગ્સ</translation>
-<translation id="4169535189173047238">મંજૂરી આપશો નહીં</translation>
-<translation id="4170011742729630528">સેવા ઉપલબ્ધ નથી; પછી ફરીથી પ્રયાસ કરો</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> ડેટા વપરાયો</translation>
-<translation id="4181841719683918333">ભાષાઓ</translation>
-<translation id="4183868528246477015">Google લેન્સ વડે શોધો <ph name="BEGIN_NEW" />નવું<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">નવા ટૅબમાં ખોલો</translation>
-<translation id="4198423547019359126">કોઈ ડાઉનલોડ સ્થાનો ઉપલબ્ધ નથી</translation>
-<translation id="4209895695669353772">Google દ્વારા સૂચવેલ વ્યક્તિગત કરેલ કન્ટેન્ટ મેળવવા માટે, સિંક કરવાનું ચાલુ કરો</translation>
-<translation id="4226663524361240545">સૂચનાઓ ઉપકરણને વાઇબ્રેટ કરી શકે છે</translation>
-<translation id="423219824432660969"><ph name="TIME" /> પ્રમાણે Google પાસવર્ડ વડે સિંક કરેલા ડેટાને એન્ક્રિપ્ટ કરો</translation>
-<translation id="4242533952199664413">સેટિંગ્સ ખોલો</translation>
-<translation id="4256782883801055595">ઓપન સોર્સ લાઇસન્સ</translation>
-<translation id="4259722352634471385">નેવિગેશન અવરોધિત છે: <ph name="URL" /></translation>
-<translation id="4269820728363426813">લિંક સરનામું કૉપિ કરો</translation>
-<translation id="4275663329226226506">મીડિયા</translation>
-<translation id="4278390842282768270">મંજૂર</translation>
-<translation id="429312253194641664">સાઇટ મીડિયા ચલાવી રહી છે</translation>
-<translation id="4298388696830689168">લિંક કરેલી સાઇટ</translation>
-<translation id="4307992518367153382">પાયાગત</translation>
-<translation id="4314815835985389558">સિંક મેનેજ કરો</translation>
-<translation id="4351244548802238354">સંવાદ બંધ કરો</translation>
-<translation id="4378154925671717803">ફોન</translation>
-<translation id="4384468725000734951">શોધ માટે Sogou નો ઉપયોગ કરી રહ્યાં છે</translation>
-<translation id="4404568932422911380">કોઈ બુકમાર્ક નથી</translation>
-<translation id="4405224443901389797">આમાં ખસેડો…</translation>
-<translation id="4411535500181276704">લાઇટ મોડ</translation>
-<translation id="4415276339145661267">તમારું Google એકાઉન્ટ મેનેજ કરો</translation>
-<translation id="4432792777822557199">હવેથી <ph name="SOURCE_LANGUAGE" />માં છે તે પેજનો અનુવાદ <ph name="TARGET_LANGUAGE" />માં થશે</translation>
-<translation id="4433925000917964731">Google દ્વારા પૂરું પાડવામાં આવેલું લાઇટ વર્ઝનનું પેજ</translation>
-<translation id="4434045419905280838">પૉપ-અપ અને રીડાયરેક્ટ</translation>
-<translation id="4440958355523780886">Google દ્વારા પ્રદાન કરવામાં આવેલું લાઇટ પેજ. ઑરિજિનલ લોડ કરવા માટે ટૅપ કરો.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> ટૅબ બંધ કરો</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> પર બુકમાર્ક કર્યું</translation>
-<translation id="445467742685312942">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપો</translation>
-<translation id="4468959413250150279">કોઈ એક ચોક્કસ સાઇટ માટે અવાજ બંધ કરો.</translation>
-<translation id="4472118726404937099">સમગ્ર ઉપકરણો સિંક કરવા અને વ્યક્તિગત કરવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો</translation>
-<translation id="447252321002412580">Chromeની સુવિધાઓ અને પ્રદર્શનને સુધારવામાં સહાય કરો</translation>
-<translation id="4479647676395637221">સાઇટ્સને તમારા કૅમેરાના ઉપયોગની મંજૂરી આપતાં પહેલાં પૂછો (ભલામણ કરેલ)</translation>
-<translation id="4479972344484327217">Chrome માટે <ph name="MODULE" /> ઇન્સ્ટૉલ કરી રહ્યાં છે…</translation>
-<translation id="4487967297491345095">Chrome નો તમામ ઍપ્લિકેશન ડેટા કાયમીરૂપે કાઢી નાખવામાં આવશે. આમાં તમામ ફાઇલો, સેટિંગ્સ, એકાઉન્ટ, ડેટાબેઝ, વગેરેનો સમાવેશ થાય છે.</translation>
-<translation id="4493497663118223949">લાઇટ મોડ ચાલુ છે</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# દિવસ પહેલાં}one{# દિવસ પહેલાં}other{# દિવસ પહેલાં}}</translation>
-<translation id="451872707440238414">તમારા બુકમાર્ક શોધો</translation>
-<translation id="4521489764227272523">પસંદ કરેલો ડેટા Chrome અને તમારા સિંક કરેલ ડિવાઇસમાંથી ડિલીટ કરવામાં આવ્યો છે.
-
-તમારા Google એકાઉન્ટમાં બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો જેમ કે શોધ અને બીજા Google સેવાઓ પરની પ્રવૃત્તિઓ <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> પર હોય શકે છે.</translation>
-<translation id="4532845899244822526">ફોલ્ડર પસંદ કરો</translation>
-<translation id="4538018662093857852">લાઇટ મોડ ચાલુ કરો</translation>
-<translation id="4550003330909367850">અહીં તમારો પાસવર્ડ જોવા અથવા કૉપિ કરવા માટે, આ ડિવાઇસ પર સ્ક્રીન લૉક સેટ કરો.</translation>
-<translation id="4558311620361989323">વેબ પેજના શૉર્ટકટ</translation>
-<translation id="4561979708150884304">કોઈ કનેક્શન નથી</translation>
-<translation id="4565377596337484307">પાસવર્ડ છુપાવો</translation>
-<translation id="4570913071927164677">વિગતો</translation>
-<translation id="4572422548854449519">મેનેજ એકાઉન્ટમાં સાઇન ઇન કરો</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# મિનિટ પહેલાં}one{# મિનિટ પહેલાં}other{# મિનિટ પહેલાં}}</translation>
-<translation id="4587589328781138893">સાઇટ</translation>
-<translation id="4594952190837476234">આ ઑફલાઇન પેજ <ph name="CREATION_TIME" /> ના રોજનું છે અને તે ઑનલાઇન વર્ઝનથી અલગ હોઈ શકે છે.</translation>
-<translation id="4605958867780575332">આઇટમ દૂર કરી: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> ખોલો</translation>
-<translation id="4634124774493850572">પાસવર્ડનો ઉપયોગ કરો</translation>
-<translation id="4645575059429386691">તમારા માતાપિતા દ્વારા સંચાલિત</translation>
-<translation id="4650364565596261010">સિસ્ટમ ડિફૉલ્ટ</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> બુકમાર્ક્સ કાઢી નાખ્યાં</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> ને તમારા હોમ સ્ક્રીન પર ઉમેરવામાં આવ્યું હતું</translation>
-<translation id="4684427112815847243">દરેક વસ્તુ સમન્વયિત કરો</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">તમારા ડિવાઇસ પર ટેક્સ્ટ મોકલો</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" />માં ઑફલાઇન જુઓ</translation>
-<translation id="4699172675775169585">કેશ કરેલ છબીઓ અને ફાઇલો</translation>
-<translation id="4714588616299687897">તમારો 60% જેટલો ડેટા બચાવો</translation>
-<translation id="4719927025381752090">અનુવાદ કરવાની ઑફર કરો</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" /> માં ખોલો</translation>
-<translation id="4720982865791209136">Chromeને બહેતર બનાવવામાં સહાય કરો. <ph name="BEGIN_LINK" />સર્વેક્ષણમાં ભાગ લો<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">અપડેટ કરો</translation>
-<translation id="4738836084190194332">છેલ્લે સમન્વયિત: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">એક નવું ટૅબ ખોલો</translation>
-<translation id="4751476147751820511">મોશન અથવા લાઇટ સેન્સર</translation>
-<translation id="4759238208242260848">ડાઉનલોડ્સ</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ડાઉનલોડ પૂર્ણ થયું.}one{# ડાઉનલોડ પૂર્ણ થયું.}other{# ડાઉનલોડ પૂર્ણ થયાં.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" /> પર પાછા આવવા માટે ટચ કરો</translation>
-<translation id="4802417911091824046">પાસફ્રેઝ એન્ક્રિપ્શનમાં Google Payની ચુકવણી પદ્ધતિઓ અને ઍડ્રેસ સામેલ હોતા નથી. 
-
-આ સેટિંગ બદલવા માટે, <ph name="BEGIN_LINK" />સિંકને રીસેટ કરો<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">કાર્ડ પરનું નામ</translation>
-<translation id="4824958205181053313">સિંક કરવાનું રદ કરીએ?</translation>
-<translation id="4837753911714442426">પેજને પ્રિન્ટ કરવાના વિકલ્પો ખોલો</translation>
-<translation id="4842092870884894799">પાસવર્ડ જનરેશન પોપઅપ દર્શાવે છે</translation>
-<translation id="4860895144060829044">કૉલ કરો</translation>
-<translation id="4866368707455379617">Chrome માટે <ph name="MODULE" /> ઇન્સ્ટૉલ કરવામાં અસમર્થ</translation>
-<translation id="4875775213178255010">કન્ટેન્ટ માટે સૂચનો</translation>
-<translation id="4878404682131129617">પ્રૉક્સી સર્વર મારફતે એક ટનલને સ્થાપિત કરવું નિષ્ફળ થયું</translation>
-<translation id="4880127995492972015">અનુવાદ કરો…</translation>
-<translation id="4881695831933465202">ખોલો</translation>
-<translation id="488187801263602086">ફાઇલનું નામ બદલો</translation>
-<translation id="4882831918239250449">તમારા બ્રાઉઝિંગ ઇતિહાસને શોધ, જાહેરાતો અને વધુ સુવિધાને વ્યક્તિગત કરવા માટે કેવી રીતે ઉપયોગમાં લેવાય તેને નિયંત્રિત કરો</translation>
-<translation id="4883854917563148705">મેનેજ કરવામાં આવેલા સેટિંગને રીસેટ કરી શકાતા નથી</translation>
-<translation id="4885273946141277891">અસમર્થિત સંખ્યામાં Chrome આવૃત્તિઓ.</translation>
-<translation id="4910889077668685004">ચુકવણી ઍપ્લિકેશનો</translation>
-<translation id="4913161338056004800">આંકડા રીસેટ કરો</translation>
-<translation id="4913169188695071480">તાજું કરવાનું રોકો</translation>
-<translation id="4915549754973153784">ઉપકરણોને સ્કેન કરતી વખતે <ph name="BEGIN_LINK" />સહાય મેળવો<ph name="END_LINK" />…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# પેજ}one{# પેજ}other{# પેજ}}</translation>
-<translation id="4932247056774066048"><ph name="DOMAIN_NAME" /> દ્વારા મેનેજ કરવામાં આવતા એકાઉન્ટમાંથી તમે સાઇન આઉટ કરી રહ્યાં હોવાને કારણે આ ડિવાઇસમાંથી તમારો Chrome ડેટા ડિલીટ કરવામાં આવશે. તે તમારા Google એકાઉન્ટમાં રહેશે.</translation>
-<translation id="4943703118917034429">વર્ચ્યુઅલ રિયાલિટી</translation>
-<translation id="4943872375798546930">પરિણામો નથી</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" />, તમારી સ્ક્રીન શેર કરી રહ્યું છે</translation>
-<translation id="4961107849584082341">આ પેજનો અનુવાદ કોઈપણ ભાષામાં કરો</translation>
-<translation id="4962975101802056554">ડિવાઇસ માટેની બધી પરવાનગીઓને રદબાતલ કરો</translation>
-<translation id="4970824347203572753">તમારા સ્થાનમાં ઉપલબ્ધ નથી</translation>
-<translation id="497421865427891073">આગળ જાઓ</translation>
-<translation id="4988210275050210843">(<ph name="MEGABYTES" />)ની ફાઇલ ડાઉનલોડ કરી રહ્યાં છીએ.</translation>
-<translation id="4988526792673242964">પૃષ્ઠો</translation>
-<translation id="4994033804516042629">કોઈ સંપર્કો મળ્યા નથી</translation>
-<translation id="4996978546172906250">આનાથી શેર કરો</translation>
-<translation id="5004416275253351869">Google પ્રવૃત્તિ નિયંત્રણો</translation>
-<translation id="5005498671520578047">પાસવર્ડની કૉપિ કરો</translation>
-<translation id="5011311129201317034"><ph name="SITE" />, કનેક્ટ કરવા માગે છે</translation>
-<translation id="5013696553129441713">કોઈ નવા સૂચનો નથી</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">તમે VR મોડમાં હો, ત્યારે આ સાઇટ આ વિશેની જાણકારી મેળવી શકે:
-  -  તમારી શારીરિક લાક્ષણિકતાઓ, જેમ કે ઊંચાઈ
-
-VR મોડમાં દાખલ થતા પહેલા ખાતરી કરો કે તમે આ સાઇટ પર વિશ્વાસ કરો છો.</translation>
+<translation id="2930742481329940825">શોધવા માટે ટૅપ કરો પસંદ કરાયેલ શબ્દ અને હાલના પેજને સંદર્ભ તરીકે Brave Software શોધને મોકલે છે. તમે તેને <ph name="BEGIN_LINK"/>સેટિંગ<ph name="END_LINK"/>માં બંધ કરી શકો છો.</translation>
 <translation id="5039804452771397117">મંજૂરી આપો</translation>
-<translation id="5040262127954254034">ગોપનીયતા</translation>
-<translation id="5048398596102334565">સાઇટને મોશન સેન્સરના ઍક્સેસની મંજૂરી આપો (સુઝાવ આપેલ)</translation>
-<translation id="5063480226653192405">ઉપયોગ</translation>
-<translation id="5087580092889165836">કાર્ડ ઉમેરો</translation>
-<translation id="5100237604440890931">સંકુચિત - વિસ્તૃત કરવા માટે ક્લિક કરો.</translation>
-<translation id="510275257476243843">1 કલાક બાકી</translation>
-<translation id="5123685120097942451">છૂપા મોડમાંની ટૅબ</translation>
-<translation id="5127805178023152808">સમન્વયન બંધ છે</translation>
-<translation id="5129038482087801250">વેબ ઍપ ઇન્સ્ટૉલ કરો</translation>
-<translation id="5132942445612118989">બધા ડિવાઇસ પર તમારા પાસવર્ડ, ઇતિહાસ અને વધુ સિંક કરો</translation>
-<translation id="5139940364318403933">Google ડ્રાઇવનો ઉપયોગ કેવી રીતે કરવો તે જાણો</translation>
-<translation id="515227803646670480">સ્ટોર કરેલ ડેટા સાફ કરો</translation>
-<translation id="5152843274749979095">કોઇ સમર્થિત ઍપ્લિકેશનો ઇન્સ્ટૉલ થયેલ નથી</translation>
-<translation id="5161254044473106830">શીર્ષક જરૂરી</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ડાઉનલોડ નિષ્ફળ થયું.}one{# ડાઉનલોડ નિષ્ફળ થયું.}other{# ડાઉનલોડ નિષ્ફળ થયાં.}}</translation>
-<translation id="5170568018924773124">ફોલ્ડરમાં બતાવો</translation>
-<translation id="5184329579814168207">Chrome માં ખોલો</translation>
-<translation id="5193988420012215838">તમારા ક્લિપબોર્ડ પર કૉપિ કરવામાં આવી</translation>
-<translation id="5197729504361054390">તમે પસંદ કરશો તે સંપર્કોને <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> સાથે શેર કરવામાં આવશે.</translation>
-<translation id="5199929503336119739">કાર્ય પ્રોફાઇલ</translation>
-<translation id="5210286577605176222">પાછલી ટૅબ પર જાઓ</translation>
-<translation id="5210365745912300556">ટૅબ બંધ કરો</translation>
-<translation id="5224771365102442243">વીડિયો દ્વારા</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> નજીકના બ્લૂટૂથ ડિવાઇસ માટે સ્કૅન કરવા માગે છે. નીચે મુજબના ડિવાઇસ મળ્યા છે:</translation>
-<translation id="5233638681132016545">નવું ટૅબ</translation>
-<translation id="526421993248218238">આ પેજ લોડ કરી શકાતું નથી</translation>
-<translation id="5271967389191913893">ડિવાઇસ, ડાઉનલોડ કરવાની કન્ટેન્ટ ખોલી શકતું નથી.</translation>
-<translation id="528192093759286357">પૂર્ણસ્ક્રીનથી બહાર નીકળવા માટે ઉપરથી ખેંચો અને પાછળ બટનને ટચ કરો.</translation>
-<translation id="5292796745632149097">આના પર મોકલો</translation>
-<translation id="5300589172476337783">બતાવો</translation>
-<translation id="5301954838959518834">બરાબર, સમજાઇ ગયું</translation>
-<translation id="5304593522240415983">આ ફીલ્ડ ખાલી હોઈ શકતું નથી</translation>
-<translation id="5307446750509046227">સાઇટ સ્ટોરેજ સાફ કરો</translation>
-<translation id="5308380583665731573">કનેક્ટ કરો</translation>
-<translation id="5313967007315987356">સાઈટ ઉમેરો</translation>
-<translation id="5317780077021120954">સાચવો</translation>
-<translation id="5324858694974489420">પેરેંટલ સેટિંગ્સ</translation>
-<translation id="5327248766486351172">નામ</translation>
-<translation id="5335288049665977812">સાઇટ્સને JavaScript ચલાવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
-<translation id="5342314432463739672">પરવાનગીની વિનંતી કરી</translation>
-<translation id="5357811892247919462">ટૅબ પ્રાપ્ત થયું</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> ખુલ્લી ટૅબ, ટૅબને સ્વિચ કરવા માટે ટૅપ કરો}one{<ph name="OPEN_TABS_MANY" /> ખુલ્લી ટૅબ, ટૅબને સ્વિચ કરવા માટે ટૅપ કરો}other{<ph name="OPEN_TABS_MANY" /> ખુલ્લી ટૅબ, ટૅબને સ્વિચ કરવા માટે ટૅપ કરો}}</translation>
-<translation id="5391532827096253100">આ સાઇટ સાથેનું તમારું કનેક્શન સુરક્ષિત નથી. સાઇટની માહિતી</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ વધુ 1)}one{(+ વધુ #)}other{(+ વધુ #)}}</translation>
-<translation id="5400569084694353794">આ એપ્લિકેશનનો ઉપયોગ કરીને, તમે Chrome ની <ph name="BEGIN_LINK1" />સેવાની શરતો<ph name="END_LINK1" /> અને <ph name="BEGIN_LINK2" />ગોપનીયતા સૂચના<ph name="END_LINK2" /> સાથે સંમત છો.</translation>
-<translation id="5403592356182871684">નામ</translation>
-<translation id="5403644198645076998">ફક્ત અમુક સાઇટની મંજૂરી આપો</translation>
-<translation id="5414836363063783498">ચકાસી રહ્યું છે...</translation>
-<translation id="5423934151118863508">તમારા સૌથી વધુ મુલાકાત લીધેલા પૃષ્ઠો અહીં દેખાશે</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB ઉપલબ્ધ</translation>
-<translation id="543338862236136125">પાસવર્ડમાં ફેરફાર કરો</translation>
-<translation id="5433691172869980887">વપરાશકર્તાનામ કૉપિ કર્યું</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> ફાઇલ (<ph name="MEGABYTES" />) ડાઉનલોડ કરી રહ્યાં છીએ.</translation>
-<translation id="5441522332038954058">સરનામાં બાર પર જાઓ</translation>
-<translation id="5447201525962359567">કુકીઝ અને અન્ય સ્થાનિક રીતે સંગ્રહિત કરેલ ડેટા સહિત, બધું સાઇટ સ્ટોરેજ</translation>
-<translation id="5447765697759493033">આ સાઇટનો અનુવાદ થશે નહીં</translation>
-<translation id="545042621069398927">તમારા ડાઉનલોડની ગતિ વધારી રહ્યાં છીએ.</translation>
-<translation id="5456381639095306749">પૃષ્ઠ ડાઉનલોડ કરો</translation>
-<translation id="5475862044948910901">ઑગ્મેન્ટેડ રિયાલિટી સત્ર શરૂ કરીએ?</translation>
-<translation id="548278423535722844">નકશા અ‍ૅપ્લિકેશનમાં ખોલો</translation>
-<translation id="5487521232677179737">ડેટા સાફ કરો</translation>
-<translation id="5494752089476963479">ઘૃણાસ્પદ અથવા ભ્રામક જાહેરાતો બતાવતી સાઇટ પરથી જાહેરાતો બ્લૉક કરો</translation>
-<translation id="5500777121964041360">તમારા સ્થાનમાં ઉપલબ્ધ ન હોઈ શકે</translation>
-<translation id="5512137114520586844">આ એકાઉન્ટ <ph name="PARENT_NAME" /> દ્વારા મેનેજ થાય છે.</translation>
-<translation id="5514904542973294328">આ ઉપકરણના વ્યવસ્થાપકે અક્ષમ કરેલ છે</translation>
-<translation id="5515439363601853141">તમારો પાસવર્ડ જોવા માટે અનલૉક કરો</translation>
-<translation id="5516455585884385570">નોટિફિકેશનના સેટિંગ ખોલો</translation>
-<translation id="5517095782334947753">તમારી પાસે <ph name="FROM_ACCOUNT" /> ના બુકમાર્ક્સ, ઇતિહાસ, પાસવર્ડ્સ અને અન્ય સેટિંગ્સ છે.</translation>
-<translation id="5524843473235508879">રીડાયરેક્ટ કરવાનું અવરોધિત.</translation>
-<translation id="5527082711130173040">ઉપકરણો માટે સ્કેન કરવા Chrome ને સ્થાન ઍક્સેસની જરૂર છે. <ph name="BEGIN_LINK1" />પરવાનગીઓ અપડેટ કરો<ph name="END_LINK1" />. સ્થાન ઍક્સેસ પણ <ph name="BEGIN_LINK2" />આ ઉપકરણ માટે બંધ કરેલ છે<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">સાઇટને ક્લિપબોર્ડ પરની ટેક્સ્ટ અને છબીઓને વાંચવાની મંજૂરી આપતાં પહેલાં પૂછો (સુઝાવ આપેલ)</translation>
-<translation id="5530766185686772672">છુપા ટેબ્સ બંધ કરો</translation>
-<translation id="5534334044554683961">તમે VR મોડમાં હો, ત્યારે આ સાઇટ આ વિશેની જાણકારી મેળવી શકે:
-  -   તમારી શારીરિક લાક્ષણિકતાઓ, જેમ કે ઊંચાઈ
-  -   તમારા રૂમનું લેઆઉટ
-
-VR મોડમાં દાખલ થતા પહેલા ખાતરી કરો કે તમે આ સાઇટ પર વિશ્વાસ કરો છો.</translation>
-<translation id="5534640966246046842">સાઇટ કૉપિ કરી</translation>
-<translation id="5556459405103347317">ફરિથી લોડ કરો</translation>
-<translation id="5561549206367097665">નેટવર્કની રાહ જોઈ રહ્યાં છે…</translation>
-<translation id="557283862590186398">Chromeને આ સાઇટ માટે તમારા માઇક્રોફોનના ઍક્સેસની પરવાનગીની જરૂર પડે છે.</translation>
-<translation id="55737423895878184">સ્થાન અને નોટિફિકેશનોની મંજૂરી છે</translation>
-<translation id="5578795271662203820">આ છબી માટે <ph name="SEARCH_ENGINE" /> માં શોધો</translation>
-<translation id="5581519193887989363">શું સિંક કરવું તે હંમેશાં તમે <ph name="BEGIN_LINK1" />સેટિંગ<ph name="END_LINK1" />માં પસંદ કરી શકો છો.</translation>
-<translation id="5595485650161345191">ઍડ્રેસમાં ફેરફાર કરો</translation>
-<translation id="5596627076506792578">વધુ વિકલ્પો</translation>
-<translation id="5599455543593328020">છૂપો મોડ</translation>
-<translation id="5620928963363755975">વધુ વિકલ્પો બટનની મદદથી ડાઉનલોડ કરેલમાંથી તમારી ફાઇલો અને પેજ શોધો</translation>
-<translation id="5626134646977739690">નામ:</translation>
-<translation id="5639724618331995626">તમામ સાઇટની મંજૂરી આપો</translation>
-<translation id="5648166631817621825">છેલ્લા 7 દિવસ</translation>
-<translation id="5649053991847567735">આપમેળે ડાઉનલોડ્સ</translation>
-<translation id="5655963694829536461">તમારા ડાઉનલોડમાં શોધો</translation>
-<translation id="5659593005791499971">ઇમેઇલ</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> માં ઇવેન્ટ બનાવો</translation>
-<translation id="5668404140385795438">ઝૂમ વધારવાનું અટકાવવા માટે વેબસાઇટની વિનંતી ઑવરરાઇડ કરો</translation>
-<translation id="5677928146339483299">અવરોધિત</translation>
-<translation id="5684874026226664614">અરેરે. આ પૃષ્ઠનો અનુવાદ કરી શકાયો નથી.</translation>
-<translation id="5686790454216892815">ફાઇલનું નામ ખૂબ લાંબું છે</translation>
-<translation id="5689516760719285838">સ્થાન</translation>
-<translation id="569536719314091526">વધુ વિકલ્પો બટનમાંથી આ પેજનો અનુવાદ કોઈપણ ભાષામાં કરો</translation>
-<translation id="572328651809341494">તાજેતરના ટેબ્સ</translation>
-<translation id="5726692708398506830">પૃષ્ઠ પરની તમામ સામગ્રીને મોટી કરો</translation>
-<translation id="5748802427693696783">માનક ટૅબ્સ પર સ્વિચ કરેલ છે</translation>
-<translation id="5749068826913805084">ફાઇલો ડાઉનલોડ કરવા માટે Chrome ને સ્ટોરેજ ઍક્સેસની જરૂર છે.</translation>
-<translation id="5763382633136178763">છૂપા ટેબ્સ</translation>
-<translation id="5763514718066511291">આ ઍપ માટેની URL કૉપિ કરવા માટે ટૅપ કરો</translation>
-<translation id="5765780083710877561">વર્ણન:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" />માંથી <ph name="SPACE_USED" />નો વપરાશ કરી રહ્યાં છીએ</translation>
-<translation id="5797070761912323120">Google, શોધ, જાહેરાતો અને અન્ય Google સેવાઓને વ્યક્તિગત કરવા માટે તમારા ઇતિહાસનો ઉપયોગ કરી શકે છે</translation>
-<translation id="5804241973901381774">પરવાનગીઓ</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# કલાક પહેલાં}one{# કલાક પહેલાં}other{# કલાક પહેલાં}}</translation>
-<translation id="5810288467834065221">કૉપિરાઇટ <ph name="YEAR" /> Google LLC. સર્વાધિકાર સુરક્ષિત.</translation>
-<translation id="5817918615728894473">જોડી કરો</translation>
-<translation id="583281660410589416">અજ્ઞાત</translation>
-<translation id="5833984609253377421">લિંક શેર કરો</translation>
-<translation id="5836192821815272682">Chrome અપડેટ ડાઉનલોડ કરી રહ્યાં છીએ…</translation>
-<translation id="5853623416121554550">થોભાવેલ</translation>
-<translation id="5854790677617711513">30 દિવસ કરતા જૂનો</translation>
-<translation id="5858741533101922242">Chrome, Bluetooth એડેપ્ટરને ચાલુ કરવામાં અસમર્થ છે</translation>
-<translation id="5860033963881614850">બંધ</translation>
-<translation id="5862731021271217234">તમારા અન્ય ઉપકરણો પરથી તમારા ટૅબ મેળવવા માટે, સિંક કરવાનું ચાલુ કરો</translation>
-<translation id="5864174910718532887">વિગતો: સાઇટના નામ દ્વારા સૉર્ટ કરાયેલ</translation>
-<translation id="5864419784173784555">બીજા ડાઉનલોડ માટે રાહ જોઈ રહ્યાં છે…</translation>
-<translation id="5865733239029070421">Googleને વપરાશના આંકડા અને ક્રૅશ રિપોર્ટ ઑટોમૅટિક રીતે મોકલે છે</translation>
-<translation id="5869522115854928033">સાચવેલા પાસવર્ડ્સ</translation>
-<translation id="5902828464777634901">કૂકીઝ સહિતનો આ વેબસાઇટ દ્વારા સ્ટોર કરેલો બધો સ્થાનિક ડેટા કાઢી નાખવામાં આવશે.</translation>
-<translation id="5916664084637901428">ચાલુ</translation>
-<translation id="5919204609460789179">સમન્વયન પ્રારંભ કરવા માટે <ph name="PRODUCT_NAME" /> અપડેટ કરો</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> ડેટા બચાવ્યો</translation>
-<translation id="5939518447894949180">રીસેટ કરો</translation>
-<translation id="5942872142862698679">શોધ માટે Google નો ઉપયોગ કરી રહ્યાં છે</translation>
-<translation id="5952764234151283551">તમે જેના પર પહોંચવાનો પ્રયાસ કરતા હોય તે પેજનું URL Googleને મોકલાવે છે</translation>
-<translation id="5956665950594638604">Chrome સહાયતા કેન્દ્રમાં એક નવું ટૅબ ખોલો</translation>
-<translation id="5958275228015807058">ડાઉનલોડ કરેલમાંથી તમારી ફાઇલો અને પેજ શોધો</translation>
-<translation id="5962718611393537961">સંકુચિત કરવા માટે ટૅપ કરો</translation>
-<translation id="6000066717592683814">Google રાખો</translation>
-<translation id="6005538289190791541">સૂચવેલ પાસવર્ડ</translation>
-<translation id="6036057147555329831">અતિરિક્ત ICU</translation>
-<translation id="6039379616847168523">આગલા ટૅબ પર જાઓ</translation>
-<translation id="6040143037577758943">બંધ કરો</translation>
-<translation id="6042308850641462728">વધુ</translation>
-<translation id="604996488070107836">કોઇ અજાણી ભૂલને કારણે <ph name="FILE_NAME" /> ડાઉનલોડ નિષ્ફળ થયું.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">પૂર્ણ થયેલા ડાઉનલોડ</translation>
-<translation id="6075798973483050474">હોમ પેજમાં ફેરફાર કરો</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> કલાક બાકી</translation>
-<translation id="6108923351542677676">સેટઅપની પ્રક્રિયા ચાલુ છે...</translation>
-<translation id="6111020039983847643">ડેટા વપરાશ</translation>
-<translation id="6112702117600201073">પૃષ્ઠ તાજું કરી રહ્યું છે</translation>
-<translation id="6127379762771434464">આઇટમ દૂર કરી</translation>
-<translation id="6140912465461743537">દેશ/પ્રદેશ</translation>
-<translation id="614940544461990577">પ્રયાસ કરો:</translation>
-<translation id="6154478581116148741">આ ઉપકરણ પરથી તમારા બધા પાસવર્ડને નિકાસ કરવા માટે સેટિંગમાંથી સ્ક્રીન લૉક ચાલુ કરો</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> ડેટા બચત</translation>
-<translation id="6165508094623778733">વધુ જાણો</translation>
-<translation id="6177111841848151710">હાલનાં શોધ એંજિન માટે અવરોધિત</translation>
-<translation id="6181444274883918285">સાઇટ અપવાદ ઉમેરો</translation>
-<translation id="6192333916571137726">ફાઇલ ડાઉનલોડ કરો</translation>
-<translation id="6192792657125177640">અપવાદો</translation>
-<translation id="6194112207524046168">Chrome તમારો કૅમેરા ઍક્સેસ કરી શકે તે માટે <ph name="BEGIN_LINK" />Android સેટિંગ<ph name="END_LINK" />માં પણ કૅમેરા ચાલુ કરો.</translation>
-<translation id="6196640612572343990">તૃતીય પક્ષની કુકીઝ અવરોધિત કરો</translation>
-<translation id="6206551242102657620">કનેક્શન સુરક્ષિત છે. સાઇટની માહિતી</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> નથી?</translation>
-<translation id="6221633008163990886">તમારા બધા પાસવર્ડને નિકાસ કરવા માટે અનલૉક કરો</translation>
+<translation id="1406000523432664303">“ટ્રેક કરશો નહીં”</translation>
 <translation id="6232535412751077445">'ટ્રૅક કરશો નહીં’ ને સક્ષમ કરવાનો અર્થ છે કે તમારા બ્રાઉઝિંગ ટ્રાફિકમાં વિનંતી શામેલ કરવામાં આવશે. કોઈ વેબસાઇટ, વિનંતી પર પ્રતિસાદ કરે છે કે નહીં અને વિનંતીનું અર્થઘટન કેવી રીતે કર્યું તેના પર કોઈ પણ અસર આધારિત હોય છે.
 
 ઉદાહરણ તરીકે, કેટલીક વેબસાઇટ, તમે મુલાકાત લીધેલી બીજા વેબસાઇટ પર આધારિત ન હોય તેવી જાહેરાતો તમને બતાવીને આ વિનંતી પર પ્રતિસાદ આપી શકે છે. ઘણી વેબસાઇટ હજી પણ તમારા બ્રાઉઝિંગ ડેટાને ભેગો કરશે અને ઉપયોગ કરશે — ઉદાહરણ તરીકે સુરક્ષાને બહેતર બનાવવા, કન્ટેન્ટ, જાહેરાતો અને ભલામણો આપવા અને રિપોર્ટિંગ આંકડા જનરેટ કરવા માટે.</translation>
-<translation id="624789221780392884">અપડેટ તૈયાર</translation>
-<translation id="6255999984061454636">કન્ટેન્ટ માટેના સૂચનો</translation>
-<translation id="6277522088822131679">પૃષ્ઠને છાપવામાં સમસ્યા હતી. કૃપા કરીને ફરીથી પ્રયાસ કરો.</translation>
-<translation id="6295158916970320988">બધી સાઇટ્સ</translation>
-<translation id="629730747756840877">એકાઉન્ટ</translation>
-<translation id="6303969859164067831">સાઇન આઉટ કરો અને સિંક બંધ કરો</translation>
-<translation id="6316139424528454185">Android વર્ઝન અસમર્થિત છે</translation>
-<translation id="6320088164292336938">વાઇબ્રેટ</translation>
-<translation id="6324034347079777476">Android સિસ્ટમ સમન્વયન અક્ષમ છે</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> મારફતે શેર કરો</translation>
-<translation id="6337234675334993532">એન્ક્રિપ્શન</translation>
-<translation id="6341580099087024258">ફાઇલો ક્યાં સાચવવી તે પૂછો</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">ઇતિહાસમાંથી સૂચનને દૂર કરીએ?</translation>
-<translation id="6369229450655021117">અહીંથી, તમે વેબમાં શોધી શકશો, મિત્રો સાથે શેર કરી શકશો અને ખુલ્લા પેજ પણ જોઈ શકશો</translation>
-<translation id="6378173571450987352">વિગતો: વપરાયેલ ડેટાની માત્રા દ્વારા સૉર્ટ કરાયેલ</translation>
-<translation id="6381421346744604172">ડાર્કન વેબસાઇટ</translation>
-<translation id="6388207532828177975">સાફ કરો અને ફરીથી સેટ કરો</translation>
-<translation id="6393863479814692971">Chromeને આ સાઇટ માટે તમારા કૅમેરા અને માઇક્રોફોનના ઍક્સેસની પરવાનગીની જરૂર પડે છે.</translation>
-<translation id="6395288395575013217">લિંક</translation>
-<translation id="6404511346730675251">બુકમાર્કમાં ફેરફાર કરો</translation>
-<translation id="6406506848690869874">સમન્વયન</translation>
-<translation id="641643625718530986">પ્રિન્ટ…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB ડાઉનલોડ કર્યા</translation>
-<translation id="6427112570124116297">વેબનો અનુવાદ કરો</translation>
-<translation id="6433501201775827830">તમારું શોધ એંજિન પસંદ કરો</translation>
-<translation id="6437478888915024427">પેજ વિશે માહિતી</translation>
-<translation id="6441734959916820584">નામ ખૂબ લાંબું છે</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# છબી}one{# છબીઓ}other{# છબીઓ}}</translation>
-<translation id="6447842834002726250">કૂકીઝ</translation>
-<translation id="6461962085415701688">ફાઇલ ખોલી શકતાં નથી</translation>
-<translation id="6464977750820128603">તમે Chromeમાં મુલાકાત લીધેલી સાઇટ જોઈ શકશો અને તેના માટે ટાઇમર પણ સેટ કરી શકશો.\n\nતમે જે સાઇટ માટે ટાઇમર સેટ કરો છો અને કેટલા સમય માટે તેની મુલાકાત લો છો, તે માહિતી Google મેળવે છે. આ માહિતી ડિજિટલ લાઇફસ્ટાઇલને બહેતર બનાવવા માટે ઉપયોગમાં લેવામાં આવે છે.</translation>
-<translation id="6475951671322991020">વીડિયો ડાઉનલોડ કરો</translation>
-<translation id="6482749332252372425">સ્ટોરેજ સ્થાનના અભાવના કારણે <ph name="FILE_NAME" /> ડાઉનલોડ નિષ્ફળ થયું.</translation>
-<translation id="6496823230996795692">પહેલી વખત <ph name="APP_NAME" />નો ઉપયોગ કરવા માટે, કૃપા કરીને ઇન્ટરનેટ સાથે કનેક્ટ કરો.</translation>
-<translation id="6508722015517270189">Chrome ને પુનઃપ્રારંભ કરો</translation>
-<translation id="6527303717912515753">શેર કરો</translation>
-<translation id="6532866250404780454">Chromeમાં તમે મુલાકાત લીધેલી સાઇટ બતાવવામાં આવશે નહીં. સાઇટના બધા ટાઇમર ડિલીટ કરવામાં આવશે.</translation>
-<translation id="6534565668554028783">પ્રતિભાવ આપવા માટે Googleએ ઘણો સમય લીધો</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB ડાઉનલોડ કર્યા</translation>
-<translation id="6539092367496845964">કંઈક ખોટું થયું હતું. થોડીવાર પછી ફરી પ્રયાસ કરો.</translation>
-<translation id="654446541061731451">બીમ કરવા માટે એક ટેબ પસંદ કરો</translation>
-<translation id="6545017243486555795">બધો ડેટા સાફ કરો</translation>
-<translation id="6545864417968258051">બ્લૂટૂથ સ્કૅનિંગ</translation>
-<translation id="6560414384669816528">Sogou થી શોધો</translation>
-<translation id="6566259936974865419">Chrome એ તમારો <ph name="GIGABYTES" /> GB બચાવ્યો</translation>
-<translation id="6573096386450695060">હંમેશાં મંજૂરી આપો</translation>
-<translation id="6573431926118603307">તમારા અન્ય ઉપકરણો પર તમે Chrome માં ખોલેલા ટૅબ્સ અહીં દેખાશે.</translation>
-<translation id="6583199322650523874">વર્તમાન પૃષ્ઠને બુકમાર્ક કરો</translation>
-<translation id="6593061639179217415">ડેસ્કટૉપ સાઇટ</translation>
-<translation id="6600954340915313787">Chrome માં કોપી કરાયું</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">સુરક્ષિત કન્ટેન્ટ</translation>
-<translation id="6627583120233659107">ફોલ્ડરમાં ફેરફાર કરો</translation>
-<translation id="6643016212128521049">સાફ કરો</translation>
-<translation id="6643649862576733715">બચાવાયેલ ડેટાના પ્રમાણ અનુસાર સૉર્ટ કરો</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">છબીને પ્રીવ્યૂ કરો <ph name="BEGIN_NEW" />નવું<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">ઉપકરણો માટે સ્કેન કરવા માટે Chrome ને સ્થાન ઍક્સેસની જરૂર છે. <ph name="BEGIN_LINK" />પરવાનગીઓ અપડેટ કરો<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">પાસવર્ડ</translation>
-<translation id="6659594942844771486">ટૅબ</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" /> માં ખોલો</translation>
-<translation id="666981079809192359">Chrome ગોપનીયતા સૂચના</translation>
-<translation id="6676840375528380067">આ ડિવાઇસમાંથી તમારા Chrome ડેટાને સાફ કરીએ?</translation>
-<translation id="6697492270171225480">જ્યારે કોઈ પેજ ન મળે ત્યારે તેના જેવા પેજ માટે સૂચનો બતાવો</translation>
-<translation id="6697947395630195233">Chromeને આ સાઇટ સાથે તમારું સ્થાન શેર કરવા માટે તમારા સ્થાનના ઍક્સેસની જરૂર પડે છે.</translation>
-<translation id="6698801883190606802">સમન્વયિત ડેટા સંચાલિત કરો</translation>
-<translation id="6699370405921460408">Google સર્વર, તમે મુલાકાત લો છો તે પેજને ઑપ્ટિમાઇઝ કરશે.</translation>
-<translation id="6706288973712894588">તમે હાલમાં ઑફલાઇન છો.\n<ph name="BEGIN_LINK" />તમારી ઑફલાઇન ફીડમાં શોધખોળ કરો.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">News</translation>
-<translation id="6710213216561001401">પાછલી</translation>
-<translation id="671481426037969117">તમારું <ph name="FQDN" /> ટાઇમર સમાપ્ત થયું. તે આવતી કાલે ફરી શરૂ થશે.</translation>
-<translation id="6738867403308150051">ડાઉનલોડ કરી રહ્યું છે...</translation>
-<translation id="6746124502594467657">નીચે ખસેડો</translation>
-<translation id="6766622839693428701">બંધ કરવા માટે નીચેની તરફ સ્વાઇપ કરો.</translation>
-<translation id="6766758767654711248">સાઇટ પર જવા માટે ટૅપ કરો</translation>
-<translation id="6767294960381293877">કોઈ ટૅબ સાથે શેર કરવાના ડિવાઇસની સૂચિ અડધી ઊંચાઈએ ખૂલે છે.</translation>
-<translation id="6782111308708962316">તૃતીય-પક્ષ વેબસાઇટને કુકી ડેટા સાચવવા અને વાંચવાથી અટકાવો</translation>
-<translation id="6790428901817661496">ચલાવો</translation>
-<translation id="6811034713472274749">પેજ જોવા માટે તૈયાર છે</translation>
-<translation id="6818926723028410516">આઇટમ પસંદ કરો</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">અનુવાદ કરો</translation>
-<translation id="6845325883481699275">Chrome સુરક્ષાને વધુ સારી બનાવવામાં સહાય કરો</translation>
-<translation id="6846298663435243399">લોડ કરી રહ્યું છે...</translation>
-<translation id="6850409657436465440">તમારું ડાઉનલોડ હજી પણ પ્રક્રિયામાં છે</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> ટેબ્સ બંધ કર્યા</translation>
-<translation id="6864459304226931083">છબી ડાઉનલોડ કરો</translation>
-<translation id="6865313869410766144">સ્વતઃભરણ ફોર્મ ડેટા</translation>
-<translation id="688738109438487280">અસ્તિત્વમાંના ડેટાને <ph name="TO_ACCOUNT" /> માં ઉમેરો.</translation>
-<translation id="6891726759199484455">તમારો પાસવર્ડ કૉપિ કરવા માટે અનલૉક કરો</translation>
-<translation id="6896758677409633944">કૉપિ કરો</translation>
-<translation id="6910211073230771657">કાઢી નાખ્યું</translation>
-<translation id="6912998170423641340">બધી સાઇટને ક્લિપબોર્ડ પરની ટેક્સ્ટ અને છબીઓ વાંચવાથી બ્લૉક કરો</translation>
-<translation id="6914783257214138813">જે કોઈપણ તમારી નિકાસ કરેલ પાસવર્ડની ફાઇલને જોઈ શકશે, તેમને તમારા પાસવર્ડ પણ દૃશ્યક્ષમ થશે.</translation>
-<translation id="6942665639005891494">સેટિંગ મેનૂ વિકલ્પનો ઉપયોગ કરીને ડિફૉલ્ટ ડાઉનલોડ સ્થાનને કોઈપણ સમયે બદલો</translation>
-<translation id="6945221475159498467">પસંદ કરો</translation>
-<translation id="6963642900430330478">આ પેજ જોખમી છે. સાઇટની માહિતી</translation>
-<translation id="6963766334940102469">બુકમાર્ક્સ ડિલીટ કરો</translation>
-<translation id="6965382102122355670">બરાબર, સમજાઇ ગયું</translation>
-<translation id="6979737339423435258">હંમેશાં</translation>
-<translation id="6981982820502123353">ઍક્સેસિબિલિટી</translation>
-<translation id="6989267951144302301">ડાઉનલોડ ન કરી શક્યા</translation>
-<translation id="6990079615885386641">Google Play Store માંથી ઍપ્લિકેશન મેળવો: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">સાઇટ્સને તમારા માઇક્રોફોનનો ઉપયોગ કરવાની મંજૂરી આપતાં પહેલા પૂછો (ભલામણ કરેલ)</translation>
-<translation id="7015203776128479407">આરંભિક સિંક સેટઅપ પૂરું થયું નથી. સિંક કરવાનું બંધ છે.</translation>
-<translation id="7016516562562142042">હાલનાં શોધ એંજિન માટે મંજૂર</translation>
-<translation id="7022756207310403729">બ્રાઉઝરમાં ખોલો</translation>
-<translation id="702463548815491781">જ્યારે ટૉકબૅક અથવા સ્વિચ ઍક્સેસ ચાલુ હોય ત્યારે આપેલ સુઝાવ</translation>
-<translation id="7029809446516969842">પાસવર્ડ્સ</translation>
-<translation id="7053983685419859001">અવરોધિત કરો</translation>
-<translation id="7055152154916055070">રીડાયરેક્ટ કરવાનું બ્લૉક કરવામાં આવ્યું છે:</translation>
-<translation id="7063006564040364415">સમન્વયન સર્વર સાથે કનેક્ટ કરી શકાયું નથી</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 પસંદ કરી}one{# પસંદ કરી}other{# પસંદ કરી}}</translation>
-<translation id="7071521146534760487">એકાઉન્ટને મેનેજ કરો</translation>
-<translation id="7077143737582773186">SD કાર્ડ</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" />ની પસંદગી કરી. સ્ક્રીનના ટોચની નજીક વિકલ્પો ઉપલબ્ધ છે</translation>
-<translation id="7121362699166175603">ઍડ્રેસ બારમાં ઇતિહાસ અને ઑટોમૅટિક રીતે પૂર્ણતા સાફ કરે છે. તમારા Google એકાઉન્ટમાં <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> પર બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો હોય શકે.</translation>
-<translation id="7128222689758636196">હાલનાં શોધ એંજિન માટે પરવાનગી આપો</translation>
-<translation id="7138678301420049075">અન્ય</translation>
-<translation id="7141896414559753902">સાઇટને પૉપ-અપ અને રીડાયરેક્ટ બતાવવા દેવાથી બ્લૉક કરો (સુઝાવ આપેલ)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" />માંથી <ph name="BEGIN_LINK" />ઑરિજિનલ પેજ લોડ કરો<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">છેલ્લા 24 કલાક</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">તમે આને થોડા સમય પછી સેટિંગ્સમાં જઈને બદલી શકો છો</translation>
-<translation id="7180611975245234373">રિફ્રેશ કરો</translation>
-<translation id="7189372733857464326">Google Play સેવાઓ દ્વારા અપડેટ થવાનું સમાપ્ત કરવાની રાહ જોવામાં આવી રહી છે</translation>
-<translation id="7191430249889272776">ટેબ પૃષ્ઠભૂમિમાં ખોલવામાં આવ્યું છે.</translation>
-<translation id="723171743924126238">છબીઓ પસંદ કરો</translation>
-<translation id="7233236755231902816">વેબ તમારી ભાષામાં જોવા માટે Chromeનું એકદમ નવું વર્ઝન મેળવો</translation>
-<translation id="7243308994586599757">સ્ક્રીનના તળિયા નજીક વિકલ્પો ઉપલબ્ધ છે</translation>
-<translation id="7248069434667874558">ખાતરી કરો કે <ph name="TARGET_DEVICE_NAME" />માં Chromeમાં સિંક ચાલુ કરેલું છે</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" />ની પસંદગી કરી</translation>
-<translation id="7274013316676448362">અવરોધિત સાઇટ</translation>
-<translation id="7290209999329137901">નામ બદલવું ઉપલબ્ધ નથી</translation>
-<translation id="7291387454912369099">આસિસ્ટંટે ચેકઆઉટ ટ્રિગર કર્યું</translation>
-<translation id="7293171162284876153">સિંક શરુ કરવા માટે, "તમારો Chromeનો ડેટા સિંક કરો" ચાલુ કરો.</translation>
-<translation id="729975465115245577">તમારા ઉપકરણ પાસે પાસવર્ડ ફાઇલને સ્ટોર કરવા માટેની ઍપ નથી.</translation>
-<translation id="7302081693174882195">વિગતો: સાચવેલ ડેટાની માત્રા દ્વારા સૉર્ટ કરેલ</translation>
-<translation id="7328017930301109123">લાઇટ મોડમાં, Chrome પેજને વધુ ઝડપથી લોડ કરે છે અને તે 60 ટકા ઓછા ડેટાનો ઉપયોગ કરે છે.</translation>
-<translation id="7333031090786104871">હજીપણ પાછલી સાઇટ ઉમેરી રહ્યાં છે</translation>
-<translation id="7352939065658542140">વીડિયો</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{પસંદ કરેલ 1 આઇટમ શેર કરો}one{પસંદ કરેલ # આઇટમ શેર કરો}other{પસંદ કરેલ # આઇટમ શેર કરો}}</translation>
 <translation id="7359002509206457351">ચુકવણી પદ્ધતિઓને ઍક્સેસ કરો</translation>
+<translation id="8026334261755873520">બ્રાઉઝિંગ ડેટા સાફ કરો</translation>
+<translation id="1291207594882862231">ઇતિહાસ, કુકી, સાઇટ ડેટા, કૅશ સાફ કરો…</translation>
+<translation id="7814200940910057384">Brave ડેટા સાફ કર્યો</translation>
+<translation id="1664855196866195614">પસંદ કરેલો ડેટા Brave અને તમારા સિંક કરેલ ડિવાઇસમાંથી ડિલીટ કરવામાં આવ્યો છે.
+
+તમારા Brave Software એકાઉન્ટમાં બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો જેમ કે શોધ અને બીજા Brave Software સેવાઓ પરની પ્રવૃત્તિઓ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> પર હોય શકે છે.</translation>
+<translation id="4699172675775169585">કેશ કરેલ છબીઓ અને ફાઇલો</translation>
+<translation id="2496180316473517155">બ્રાઉઝિંગ ઇતિહાસ</translation>
+<translation id="2546283357679194313">કૂકીઝ અને સાઇટ ડેટા</translation>
+<translation id="8662811608048051533">તમને મોટાભાગની સાઇટોમાંથી સાઇન આઉટ કરે છે.</translation>
+<translation id="8218628800671693884">તમને મોટાભાગની સાઇટોમાંથી સાઇન આઉટ કરે છે. તમે તમારા Brave Software એકાઉન્ટમાંથી સાઇન આઉટ નહિ થાઓ.</translation>
+<translation id="2017836877785168846">ઍડ્રેસ બારમાં ઇતિહાસ અને સ્વતઃપૂર્ણ કરવું સાફ કરો.</translation>
+<translation id="8096327394278038498">ઍડ્રેસ બારમાં ઇતિહાસ અને ઑટોમૅટિક રીતે પૂર્ણતા સાફ કરે છે. તમારા Brave Software એકાઉન્ટમાં <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> પર બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો હોય શકે.</translation>
+<translation id="8122693181154564064">બધા સાઇન ઇન કરેલ ડિવાઇસમાંથી ઇતિહાસ સાફ કરે છે. તમારા Brave Software એકાઉન્ટમાં <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> પર બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો હોય શકે.</translation>
+<translation id="5869522115854928033">સાચવેલા પાસવર્ડ્સ</translation>
+<translation id="6865313869410766144">સ્વતઃભરણ ફોર્મ ડેટા</translation>
+<translation id="7562080006725997899">બ્રાઉઝિંગ ડેટા સાફ કરો</translation>
+<translation id="5487521232677179737">ડેટા સાફ કરો</translation>
+<translation id="7498271377022651285">કૃપા કરીને રાહ જુઓ…</translation>
+<translation id="784934925303690534">સમય શ્રેણી</translation>
+<translation id="1718835860248848330">છેલ્લા એક કલાક</translation>
+<translation id="7149893636342594995">છેલ્લા 24 કલાક</translation>
+<translation id="5648166631817621825">છેલ્લા 7 દિવસ</translation>
+<translation id="8571213806525832805">છેલ્લા 4 અઠવાડિયા</translation>
+<translation id="5854790677617711513">30 દિવસ કરતા જૂનો</translation>
+<translation id="6979737339423435258">હંમેશાં</translation>
+<translation id="982182592107339124">આ બધી સાઇટ્સ પરથી ડેટા સાફ કરશે, આ સહિત:</translation>
+<translation id="6643016212128521049">સાફ કરો</translation>
+<translation id="7641339528570811325">બ્રાઉઝિંગ ડેટા સાફ કરો…</translation>
+<translation id="1670399744444387456">મૂળભૂત</translation>
+<translation id="3245261285041759672">તમારા Brave Software એકાઉન્ટમાં <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> પર બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો હોય શકે.</translation>
+<translation id="7274013316676448362">અવરોધિત સાઇટ</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> આઇટમ કાઢી નાખી</translation>
+<translation id="1121094540300013208">વપરાશ અને ક્રૅશ રિપોર્ટ</translation>
+<translation id="9079153198295609735">ઉપયોગિતા આંકડાઓ અને ક્રૅશ રિપોર્ટ Brave Softwareને ઑટોમૅટિક રીતે મોકલો</translation>
+<translation id="6981982820502123353">ઍક્સેસિબિલિટી</translation>
+<translation id="2387895666653383613">ટેક્સ્ટ માપન</translation>
+<translation id="2321958826496381788">જ્યાં સુધી તમે આ અનુકૂળ રીતે વાંચી ન શકો ત્યાં સુધી સ્લાઇડર ખેંચો. ફકરા પર ડબલ-ટેપિંગ પછી ટેક્સ્ટ ઓછામાં ઓછી આટલી મોટી દેખાવી જોઈએ.</translation>
+<translation id="3895926599014793903">ફરજિયાતપૂર્વક ઝૂમ ચાલુ કરો</translation>
+<translation id="5668404140385795438">ઝૂમ વધારવાનું અટકાવવા માટે વેબસાઇટની વિનંતી ઑવરરાઇડ કરો</translation>
+<translation id="4149994727733219643">વેબપેજ માટે સરળ દૃશ્ય</translation>
+<translation id="9100505651305367705">જ્યારે સપોર્ટ કરતું હોય, ત્યારે લેખો સરળ દૃશ્યમાં બતાવવાનું ઑફર કરો</translation>
+<translation id="1409426117486808224">ખુલ્લી ટૅબ માટે સરળ દૃશ્ય</translation>
+<translation id="702463548815491781">જ્યારે ટૉકબૅક અથવા સ્વિચ ઍક્સેસ ચાલુ હોય ત્યારે આપેલ સુઝાવ</translation>
+<translation id="8284326494547611709">કૅપ્શન્સ</translation>
+<translation id="4165986682804962316">સાઇટ સેટિંગ્સ</translation>
+<translation id="6295158916970320988">બધી સાઇટ્સ</translation>
+<translation id="8380167699614421159">આ સાઇટ ઘૃણાસ્પદ અથવા ભ્રામક જાહેરાતો બતાવે છે</translation>
+<translation id="1919345977826869612">જાહેરાતો</translation>
+<translation id="410351446219883937">ઑટોપ્લે</translation>
+<translation id="6447842834002726250">કૂકીઝ</translation>
+<translation id="6196640612572343990">તૃતીય પક્ષની કુકીઝ અવરોધિત કરો</translation>
+<translation id="6782111308708962316">તૃતીય-પક્ષ વેબસાઇટને કુકી ડેટા સાચવવા અને વાંચવાથી અટકાવો</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">પૉપ-અપ અને રીડાયરેક્ટ</translation>
+<translation id="4751476147751820511">મોશન અથવા લાઇટ સેન્સર</translation>
+<translation id="1717218214683051432">મોશન સેન્સર</translation>
+<translation id="2091887806945687916">ધ્વનિ</translation>
+<translation id="2586657967955657006">ક્લિપબોર્ડ</translation>
+<translation id="6320088164292336938">વાઇબ્રેટ</translation>
+<translation id="4226663524361240545">સૂચનાઓ ઉપકરણને વાઇબ્રેટ કરી શકે છે</translation>
+<translation id="1446450296470737166">MIDI ઉપકરણોના પૂર્ણ નિયંત્રણની મંજૂરી આપો</translation>
+<translation id="3744111561329211289">પૃષ્ઠભૂમિ સમન્વયન</translation>
+<translation id="5649053991847567735">આપમેળે ડાઉનલોડ્સ</translation>
+<translation id="6181444274883918285">સાઇટ અપવાદ ઉમેરો</translation>
+<translation id="5313967007315987356">સાઈટ ઉમેરો</translation>
+<translation id="1369915414381695676">સાઈટ <ph name="SITE_NAME"/> ઉમેરવામાં આવી</translation>
+<translation id="7837721118676387834">કોઈ ચોક્કસ સાઇટ માટે મ્યૂટ કરેલ વિડિઓઝને ઑટોપ્લેની મંજૂરી આપો.</translation>
+<translation id="2621115761605608342">ચોક્કસ સાઇટ માટે JavaScript ની મંજૂરી આપો.</translation>
+<translation id="8801436777607969138">કોઈ ચોક્કસ સાઇટ માટે JavaScriptને બ્લૉક કરો.</translation>
+<translation id="8372893542064058268">ચોક્કસ સાઇટ માટે પૃષ્ઠભૂમિ સમન્વયનની મંજૂરી આપો.</translation>
+<translation id="358794129225322306">એકથી વધુ ફાઇલો ઑટોમૅટિક રીતે ડાઉનલોડ કરવાની મંજૂરી સાઇટને આપો.</translation>
+<translation id="4008040567710660924">કોઈ ચોક્કસ સાઇટ માટે કુકીને મંજૂરી આપો.</translation>
+<translation id="8958424370300090006">કોઈ ચોક્કસ સાઇટ માટે કુકીને બ્લૉક કરો.</translation>
+<translation id="7882806643839505685">કોઈ એક ચોક્કસ સાઇટ માટે અવાજ ચલાવવાની મંજૂરી આપો.</translation>
+<translation id="4468959413250150279">કોઈ એક ચોક્કસ સાઇટ માટે અવાજ બંધ કરો.</translation>
+<translation id="1994173015038366702">સાઈટ URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">ઉપયોગ</translation>
+<translation id="5804241973901381774">પરવાનગીઓ</translation>
+<translation id="4278390842282768270">મંજૂર</translation>
+<translation id="5677928146339483299">અવરોધિત</translation>
+<translation id="1984937141057606926">મંજૂર, તૃતીય-પક્ષ સિવાય</translation>
+<translation id="7423098979219808738">પ્રથમ પૂછો</translation>
+<translation id="8116925261070264013">મ્યૂટ કરેલ</translation>
+<translation id="8300705686683892304">ઍપ દ્વારા મેનેજ થતી</translation>
+<translation id="6192792657125177640">અપવાદો</translation>
+<translation id="257931822824936280">વિસ્તૃત - સંકુચિત કરવા માટે ક્લિક કરો.</translation>
+<translation id="5100237604440890931">સંકુચિત - વિસ્તૃત કરવા માટે ક્લિક કરો.</translation>
+<translation id="857943718398505171">મંજૂર (ભલામણ કરેલ)</translation>
+<translation id="2913331724188855103">સાઇટને કૂકી ડેટા સાચવવા અને વાંચવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
+<translation id="7445411102860286510">સાઇટ્સને આપમેળે મ્યૂટ કરેલ વિડિઓઝને ચલાવવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
+<translation id="5335288049665977812">સાઇટ્સને JavaScript ચલાવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
+<translation id="5527111080432883924">સાઇટને ક્લિપબોર્ડ પરની ટેક્સ્ટ અને છબીઓને વાંચવાની મંજૂરી આપતાં પહેલાં પૂછો (સુઝાવ આપેલ)</translation>
+<translation id="6912998170423641340">બધી સાઇટને ક્લિપબોર્ડ પરની ટેક્સ્ટ અને છબીઓ વાંચવાથી બ્લૉક કરો</translation>
+<translation id="7423538860840206698">ક્લિપબોર્ડ વાંચવાનું બ્લૉક કરેલ છે</translation>
+<translation id="3955193568934677022">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
+<translation id="445467742685312942">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપો</translation>
+<translation id="2107397443965016585">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપતા પહેલાંં પૂછો (સુઝાવ આપેલ)</translation>
+<translation id="2910701580606108292">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાની મંજૂરી આપતા પહેલાંં પૂછો</translation>
+<translation id="757524316907819857">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાથી બ્લૉક કરો</translation>
+<translation id="3277252321222022663">સાઇટને સેન્સરના ઍક્સેસની મંજૂરી આપો (સુઝાવ આપેલ)</translation>
+<translation id="5048398596102334565">સાઇટને મોશન સેન્સરના ઍક્સેસની મંજૂરી આપો (સુઝાવ આપેલ)</translation>
+<translation id="8816026460808729765">સાઇટને સેન્સરને ઍક્સેસ કરવાથી બ્લૉક કરો</translation>
+<translation id="169515064810179024">સાઇટને મોશન સેન્સરને ઍક્સેસ કરવાથી બ્લૉક કરો</translation>
+<translation id="1660204651932907780">સાઇટને અવાજ ચલાવવાની મંજૂરી આપો (સુઝાવ આપેલ)</translation>
+<translation id="3600792891314830896">જે સાઇટ અવાજ ચલાવતી હોય તેઓનો અવાજ બંધ કરો</translation>
+<translation id="1743802530341753419">સાઇટને ઉપકરણ સાથે કનેક્ટ કરવાની મંજૂરી આપતા પહેલાં પૂછો (સુઝાવ આપેલ)</translation>
+<translation id="851751545965956758">સાઇટને ઉપકરણો સાથે કનેક્ટ થવાથી બ્લૉક કરો</translation>
+<translation id="7141896414559753902">સાઇટને પૉપ-અપ અને રીડાયરેક્ટ બતાવવા દેવાથી બ્લૉક કરો (સુઝાવ આપેલ)</translation>
+<translation id="5494752089476963479">ઘૃણાસ્પદ અથવા ભ્રામક જાહેરાતો બતાવતી સાઇટ પરથી જાહેરાતો બ્લૉક કરો</translation>
+<translation id="3123473560110926937">કેટલીક સાઇટ પર બ્લૉક કરેલ</translation>
+<translation id="965817943346481315">જો સાઇટ ઘૃણાસ્પદ અથવા ભ્રામક જાહેરાતો બતાવતી હોય, તો બ્લૉક કરો (ભલામણ કરેલ)</translation>
+<translation id="3386292677130313581">સાઇટ્સને તમારા સ્થાનને જાણવાની મંજૂરી આપતાં પહેલાં પૂછો (ભલામણ કરેલ)</translation>
+<translation id="9139068048179869749">સાઇટ્સને સૂચનાઓ મોકલતાં પહેલાં પૂછો (ભલામણ કરેલ)</translation>
+<translation id="4479647676395637221">સાઇટ્સને તમારા કૅમેરાના ઉપયોગની મંજૂરી આપતાં પહેલાં પૂછો (ભલામણ કરેલ)</translation>
+<translation id="6992289844737586249">સાઇટ્સને તમારા માઇક્રોફોનનો ઉપયોગ કરવાની મંજૂરી આપતાં પહેલા પૂછો (ભલામણ કરેલ)</translation>
+<translation id="2289270750774289114">જ્યારે કોઈ સાઇટ નજીકના બ્લૂટૂથ ડિવાઇસને શોધવા માગે ત્યારે પૂછો (સુઝાવ આપેલ)</translation>
+<translation id="7053983685419859001">અવરોધિત કરો</translation>
+<translation id="7128222689758636196">હાલનાં શોધ એંજિન માટે પરવાનગી આપો</translation>
+<translation id="7589445247086920869">હાલનું શોધ એંજિન અવરોધિત કરો</translation>
+<translation id="6388207532828177975">સાફ કરો અને ફરીથી સેટ કરો</translation>
+<translation id="7999064672810608036">શું તમે ખરેખર કૂકીઝ સહિત આ વેબસાઇટ માટેનો બધો ડેટા સાફ કરી અને આ વેબસાઇટ માટેની બધી પરવાનગીઓ ફરીથી સેટ કરવા માગો છો?</translation>
+<translation id="2822354292072154809">શું તમે ખરેખર <ph name="CHOSEN_OBJECT_NAME"/>ની બધી સાઇટ પસંદગીઓને રીસેટ કરવા માગો છે?</translation>
+<translation id="515227803646670480">સ્ટોર કરેલ ડેટા સાફ કરો</translation>
+<translation id="5902828464777634901">કૂકીઝ સહિતનો આ વેબસાઇટ દ્વારા સ્ટોર કરેલો બધો સ્થાનિક ડેટા કાઢી નાખવામાં આવશે.</translation>
+<translation id="119944043368869598">બધા દૂર કરો</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> દ્વારા સંચાલિત</translation>
+<translation id="5516455585884385570">નોટિફિકેશનના સેટિંગ ખોલો</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/> માં એમ્બેડ કર્યું</translation>
+<translation id="129382876167171263">વેબસાઇટ દ્વારા સાચવવામાં આવેલી ફાઇલો અહી દેખાશે</translation>
+<translation id="4181841719683918333">ભાષાઓ</translation>
+<translation id="2647434099613338025">ભાષા ઉમેરો</translation>
+<translation id="1952172573699511566">જ્યારે શક્ય હશે, ત્યારે વેબસાઇટ તમારી પસંદગીની ભાષામાં ટેક્સ્ટ બતાવશે.</translation>
+<translation id="8559990750235505898">પેજનો અન્ય ભાષાઓમાં અનુવાદ કરવાની ઑફર કરો</translation>
+<translation id="4719927025381752090">અનુવાદ કરવાની ઑફર કરો</translation>
+<translation id="8156139159503939589">તમે કઈ ભાષાઓ વાંચી શકો છો?</translation>
+<translation id="5689516760719285838">સ્થાન</translation>
+<translation id="2440823041667407902">સ્થાન ઍક્સેસ</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android સેટિંગ્સ<ph name="END_LINK"/>માં Brave માટે પરવાનગીઓ ચાલુ કરો.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android સેટિંગ્સ<ph name="END_LINK"/>માં Brave માટે પરવાનગી ચાલુ કરો.</translation>
+<translation id="2928908108430545745">Brave તમારું સ્થાન ઍક્સેસ કરી શકે તે માટે <ph name="BEGIN_LINK"/>Android સેટિંગ<ph name="END_LINK"/>માં પણ સ્થાન ચાલુ કરો.</translation>
+<translation id="1028853271388022585">Brave તમારો કૅમેરા ઍક્સેસ કરી શકે તે માટે <ph name="BEGIN_LINK"/>Android સેટિંગ<ph name="END_LINK"/>માં પણ કૅમેરા ચાલુ કરો.</translation>
+<translation id="2913721282607281710">Brave તમને નોટિફિકેશન મોકલી શકે તે માટે <ph name="BEGIN_LINK"/>Android સેટિંગ<ph name="END_LINK"/>માં પણ નોટિફિકેશન ચાલુ કરો.</translation>
+<translation id="8753483718490035722">Brave તમારું માઇક્રોફોન ઍક્સેસ કરી શકે તે માટે <ph name="BEGIN_LINK"/>Android સેટિંગ<ph name="END_LINK"/>માં પણ માઇક્રોફોન ચાલુ કરો.</translation>
+<translation id="1887786770086287077">આ ઉપકરણ માટે સ્થાન ઍક્સેસ બંધ છે. તેને <ph name="BEGIN_LINK"/>Android સેટિંગ<ph name="END_LINK"/>માં ચાલુ કરો.</translation>
+<translation id="2570922361219980984">આ ઉપકરણ માટે સ્થાન ઍક્સેસ પણ બંધ છે. તેને <ph name="BEGIN_LINK"/>Android સેટિંગ<ph name="END_LINK"/>માં ચાલુ કરો.</translation>
+<translation id="1620510694547887537">કૅમેરો</translation>
+<translation id="3227137524299004712">માઇક્રોફોન</translation>
+<translation id="1647391597548383849">તમારા કૅમેરાની ઍક્સેસ</translation>
+<translation id="945632385593298557">તમારા માઇક્રોફોનની ઍક્સેસ</translation>
+<translation id="6612358246767739896">સુરક્ષિત કન્ટેન્ટ</translation>
+<translation id="885701979325669005">સ્ટોરેજ</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> સંગ્રહિત ડેટા</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">ઉપકરણની પરવાનગી રદબાતલ કરો</translation>
+<translation id="4962975101802056554">ડિવાઇસ માટેની બધી પરવાનગીઓને રદબાતલ કરો</translation>
+<translation id="6545864417968258051">બ્લૂટૂથ સ્કૅનિંગ</translation>
+<translation id="4411535500181276704">લાઇટ મોડ</translation>
+<translation id="7821588508402923572">તમારી ડેટા બચત અહીં દેખાશે</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> સાચવ્યો</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> થી</translation>
+<translation id="3252158532344029638">લાઇટ મોડમાં, Brave પેજને વધુ ઝડપથી લોડ કરે છે અને તે 60 ટકા ઓછા ડેટાનો ઉપયોગ કરે છે.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> ડેટા બચત</translation>
+<translation id="7494974237137038751">ડેટા બચત</translation>
+<translation id="6111020039983847643">ડેટા વપરાશ</translation>
+<translation id="7413229368719586778">પ્રારંભ તારીખ <ph name="DATE"/></translation>
+<translation id="1782483593938241562">સમાપ્તિ તારીખ <ph name="DATE"/></translation>
+<translation id="2728754400939377704">સાઇટ અનુસાર સૉર્ટ કરો</translation>
+<translation id="5864174910718532887">વિગતો: સાઇટના નામ દ્વારા સૉર્ટ કરાયેલ</translation>
+<translation id="116280672541001035">વપરાયેલ</translation>
+<translation id="8349013245300336738">વપરાયેલ ડેટાના પ્રમાણ અનુસાર સૉર્ટ કરો</translation>
+<translation id="6378173571450987352">વિગતો: વપરાયેલ ડેટાની માત્રા દ્વારા સૉર્ટ કરાયેલ</translation>
+<translation id="2631006050119455616">બચાવેલ</translation>
+<translation id="6643649862576733715">બચાવાયેલ ડેટાના પ્રમાણ અનુસાર સૉર્ટ કરો</translation>
+<translation id="7302081693174882195">વિગતો: સાચવેલ ડેટાની માત્રા દ્વારા સૉર્ટ કરેલ</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> ડેટા વપરાયો</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> ડેટા બચાવ્યો</translation>
+<translation id="2156074688469523661">બાકી સાઇટ (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">અન્ય</translation>
+<translation id="4913161338056004800">આંકડા રીસેટ કરો</translation>
+<translation id="1856325424225101786">લાઇટ મોડને રીસેટ કરીએ?</translation>
+<translation id="3658159451045945436">રીસેટ કરવાથી મુલાકાત લીધેલી સાઇટની સૂચિ સહિત તમારા ડેટા બચતના ઇતિહાસને કાઢી નાખે છે.</translation>
+<translation id="3295530008794733555">વધુ ઝડપથી બ્રાઉઝ કરો. ઓછા ડેટાનો ઉપયોગ કરો.</translation>
+<translation id="7340390500800578919">લાઇટ મોડમાં, Brave પેજને વધુ ઝડપથી લોડ કરે છે અને તે 60 ટકા ઓછા ડેટાનો વપરાશ કરે છે. તમે જે પેજની મુલાકાત લેતા હો તેને ઑપ્ટિમાઇઝ કરવા માટે, Brave તમારો વેબ ટ્રાફિક Brave Softwareને મોકલે છે. <ph name="BEGIN_LINK"/>વધુ જાણો<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">લાઇટ મોડ ચાલુ કરો</translation>
+<translation id="4493497663118223949">લાઇટ મોડ ચાલુ છે</translation>
+<translation id="7559975015014302720">લાઇટ મોડ બંધ છે</translation>
+<translation id="7606077192958116810">લાઇટ મોડ ચાલુ છે. તેને સેટિંગમાં મેનેજ કરો.</translation>
+<translation id="4714588616299687897">તમારો 60% જેટલો ડેટા બચાવો</translation>
+<translation id="1006927014032731288">Brave Software સર્વર, તમે મુલાકાત લો છો તે પેજને ઑપ્ટિમાઇઝ કરશે.</translation>
+<translation id="3257320067425202300">Brave એ તમારો <ph name="MEGABYTES"/> MB ડેટા બચાવ્યો</translation>
+<translation id="5813223329348543512">Brave એ તમારો <ph name="GIGABYTES"/> GB બચાવ્યો</translation>
+<translation id="8266862848225348053">સ્થાન ડાઉનલોડ કરો</translation>
+<translation id="7077143737582773186">SD કાર્ડ</translation>
+<translation id="7762668264895820836">SD કાર્ડ <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">ફાઇલો ક્યાં સાચવવી તે પૂછો</translation>
+<translation id="6192333916571137726">ફાઇલ ડાઉનલોડ કરો</translation>
+<translation id="1672586136351118594">ફરીથી બતાવશો નહીં</translation>
+<translation id="2650751991977523696">ફાઇલને ફરીથી ડાઉનલોડ કરીએ?</translation>
+<translation id="8664979001105139458">ફાઇલનું નામ પહેલેથી અસ્તિત્વમાં છે</translation>
+<translation id="488187801263602086">ફાઇલનું નામ બદલો</translation>
+<translation id="5686790454216892815">ફાઇલનું નામ ખૂબ લાંબું છે</translation>
+<translation id="7454641608352164238">પર્યાપ્ત જગ્યા નથી</translation>
+<translation id="8972098258593396643">ડિફૉલ્ટ ફોલ્ડરમાં ડાઉનલોડ કરીએ?</translation>
+<translation id="804335162455518893">SD કાર્ડ મળ્યું નથી</translation>
+<translation id="7475688122056506577">SD કાર્ડ મળ્યું નથી. તમારી અમુક ફાઇલો ખૂટતી હોઈ શકે છે.</translation>
+<translation id="4198423547019359126">કોઈ ડાઉનલોડ સ્થાનો ઉપલબ્ધ નથી</translation>
+<translation id="8224471946457685718">વાઇ-ફાઇ પર તમારા માટે લેખ ડાઉનલોડ કરો</translation>
+<translation id="4970824347203572753">તમારા સ્થાનમાં ઉપલબ્ધ નથી</translation>
+<translation id="5500777121964041360">તમારા સ્થાનમાં ઉપલબ્ધ ન હોઈ શકે</translation>
+<translation id="1173894706177603556">નામ બદલો</translation>
+<translation id="1986685561493779662">નામ પહેલેથી જ અસ્તિત્વમાં છે</translation>
+<translation id="6441734959916820584">નામ ખૂબ લાંબું છે</translation>
+<translation id="2923908459366352541">નામ અમાન્ય છે</translation>
+<translation id="7290209999329137901">નામ બદલવું ઉપલબ્ધ નથી</translation>
+<translation id="3334729583274622784">ફાઇલનું એક્સ્ટેંશન બદલવું છે?</translation>
+<translation id="107147699690128016">જો તમે ફાઇલનું એક્સ્ટેંશન બદલશો, તો તે કોઈ અલગ ઍપ્લિકેશનમાં ખુલી શકે છે અને તમારા ડિવાઇસ માટે નુકસાનકારક હોવાનું સંભવિત હોય શકે.</translation>
+<translation id="8541922081612557424">Brave વિશે</translation>
+<translation id="5311273890481188673">કૉપિરાઇટ <ph name="YEAR"/> Brave Software LLC. સર્વાધિકાર સુરક્ષિત.</translation>
+<translation id="1416550906796893042">ઍપ્લિકેશન વર્ઝન</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (અપડેટ કર્યું <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">ઓપરેટિંગ સિસ્ટમ</translation>
+<translation id="3968054912784331254">Androidના આ વર્ઝન માટે Brave અપડેટ હવે સમર્થિત નથી</translation>
+<translation id="7665369617277396874">એકાઉન્ટ ઉમેરો</translation>
+<translation id="649070405679044769">Brave Software પર આ તરીકે સાઇન ઇન કરો</translation>
+<translation id="6234515504547364178">Braveમાંથી સાઇન આઉટ કરો</translation>
+<translation id="5324858694974489420">પેરેંટલ સેટિંગ્સ</translation>
+<translation id="8920114477895755567">માતાપિતાની વિગતોની રાહ જોઈ રહ્યાં છે.</translation>
+<translation id="5512137114520586844">આ એકાઉન્ટ <ph name="PARENT_NAME"/> દ્વારા મેનેજ થાય છે.</translation>
+<translation id="2956410042958133412">આ એકાઉન્ટ <ph name="PARENT_NAME_1"/> અને <ph name="PARENT_NAME_2"/> દ્વારા મેનેજ થાય છે.</translation>
+<translation id="8168435359814927499">કન્ટેન્ટ</translation>
+<translation id="5403644198645076998">ફક્ત અમુક સાઇટની મંજૂરી આપો</translation>
+<translation id="8641930654639604085">વયસ્ક સાઇટને અવરોધિત કરવાનો પ્રયાસ કરો</translation>
+<translation id="5639724618331995626">તમામ સાઇટની મંજૂરી આપો</translation>
+<translation id="796823723482603597">Brave દ્વારા સંચાલિત</translation>
+<translation id="6324034347079777476">Android સિસ્ટમ સમન્વયન અક્ષમ છે</translation>
+<translation id="5127805178023152808">સમન્વયન બંધ છે</translation>
+<translation id="7015203776128479407">આરંભિક સિંક સેટઅપ પૂરું થયું નથી. સિંક કરવાનું બંધ છે.</translation>
+<translation id="2497852260688568942">સમન્વયન, તમારા વ્યવસ્થાપક દ્વારા અક્ષમ કરવામાં આવ્યું છે</translation>
+<translation id="9100610230175265781">પાસફ્રેઝ આવશ્યક છે</translation>
+<translation id="6108923351542677676">સેટઅપની પ્રક્રિયા ચાલુ છે...</translation>
+<translation id="4062305924942672200">કાનુની માહિતી</translation>
+<translation id="4256782883801055595">ઓપન સોર્સ લાઇસન્સ</translation>
+<translation id="1138681184697033370">Brave સેવાની શરતો</translation>
+<translation id="7392539049993970338">Brave ગોપનીયતા સૂચના</translation>
+<translation id="2677748264148917807">છોડો</translation>
+<translation id="5556459405103347317">ફરિથી લોડ કરો</translation>
+<translation id="1623104350909869708">આ પૃષ્ઠને વધારાના સંવાદો બનાવતા અટકાવો</translation>
+<translation id="2968755619301702150">પ્રમાણપત્ર દર્શક</translation>
+<translation id="1360432990279830238">સાઇન આઉટ કરી સિંકનો વિકલ્પ બંધ કરવો છે?</translation>
+<translation id="8581481290581777242">આ ડિવાઇસમાંથી તમારા Brave ડેટાને સાફ કરીએ?</translation>
+<translation id="1318865768845061710">તમારો બુકમાર્ક, ઇતિહાસ, પાસવર્ડ અને અન્ય Brave ડેટા હવેથી તમારા Brave Software એકાઉન્ટ પર સિંક થશે નહીં</translation>
+<translation id="3325020657155065477">આ ડિવાઇસમાંથી તમારો Brave ડેટા પણ સાફ કરો</translation>
+<translation id="6136448902816743006"><ph name="DOMAIN_NAME"/> દ્વારા મેનેજ કરવામાં આવતા એકાઉન્ટમાંથી તમે સાઇન આઉટ કરી રહ્યાં હોવાને કારણે આ ડિવાઇસમાંથી તમારો Brave ડેટા ડિલીટ કરવામાં આવશે. તે તમારા Brave Software એકાઉન્ટમાં રહેશે.</translation>
+<translation id="1853026300647876496">Brave Softwareનો સંપર્ક કરી રહ્યાં છીએ. આમાં એક મિનિટ લાગી શકે છે…</translation>
+<translation id="2328985652426384049">સાઇન ઇન કરી શકાતું નથી</translation>
+<translation id="7723158744459952869">પ્રતિભાવ આપવા માટે Brave Softwareએ ઘણો સમય લીધો</translation>
+<translation id="4572422548854449519">મેનેજ એકાઉન્ટમાં સાઇન ઇન કરો</translation>
+<translation id="2689656545739939160">તમે <ph name="MANAGED_DOMAIN"/> દ્વારા મેનેજ એકાઉન્ટમાં સાઇન ઇન કરી રહ્યાં છો અને તમારા Brave ડેટા પર એનું એડમિન નિયંત્રણ આપી રહ્યાં છો. તમારો ડેટા આ એકાઉન્ટ સાથે કાયમીરૂપે જોડાયેલું રહેશે. Braveમાંથી સાઇન આઉટ કરવું આ ડિવાઇસ પરથી તમારો ડેટા ડિલીટ કરશે, પરંતુ એ તમારા Brave Software એકાઉન્ટમાં સ્ટોર રહેશે.</translation>
+<translation id="1749561566933687563">તમારા બુકમાર્ક્સ સમન્વયિત કરો</translation>
+<translation id="4242533952199664413">સેટિંગ્સ ખોલો</translation>
+<translation id="1111673857033749125">તમારા અન્ય ઉપકરણો પર સાચવેલા બુકમાર્ક્સ અહીં દેખાશે.</translation>
+<translation id="8636825310635137004">તમારા અન્ય ઉપકરણો પરથી તમારા ટૅબ્સ મેળવવા માટે, સમન્વયન ચાલુ કરો.</translation>
+<translation id="3269956123044984603">તમારા બીજા ડિવાઇસ પરથી તમારા ટૅબ્સ મેળવવા માટે, Android એકાઉન્ટ સેટિંગમાં "સ્વતઃ-સિંક કરો ડેટા" ચાલુ કરો.</translation>
+<translation id="5157964048453367290">તમારા અન્ય ઉપકરણો પર તમે Brave માં ખોલેલા ટૅબ્સ અહીં દેખાશે.</translation>
+<translation id="4684427112815847243">દરેક વસ્તુ સમન્વયિત કરો</translation>
+<translation id="2709516037105925701">સ્વતઃભરો</translation>
+<translation id="8820817407110198400">બુકમાર્ક્સ</translation>
+<translation id="1644574205037202324">ઇતિહાસ</translation>
+<translation id="17513872634828108">ટેબ્સ ખોલો</translation>
+<translation id="1320169905922104972">Brave Software Payનો ઉપયોગ કરતા ક્રેડિટ કાર્ડ અને સરનામાં</translation>
+<translation id="6337234675334993532">એન્ક્રિપ્શન</translation>
+<translation id="6698801883190606802">સમન્વયિત ડેટા સંચાલિત કરો</translation>
+<translation id="3598578758776312506">Brave Software લૉગ ઇન વિગત સાથે પાસવર્ડને એન્ક્રિપ્ટ કરો</translation>
+<translation id="7810580217418711046"><ph name="TIME"/> પ્રમાણે Brave Software પાસવર્ડ વડે સિંક કરેલા ડેટાને એન્ક્રિપ્ટ કરો</translation>
+<translation id="8461694314515752532">તમારા પોતાના સિંક પાસફ્રેઝ સાથે સિંક કરેલા ડેટાને એન્ક્રિપ્ટ કરો</translation>
+<translation id="2996291259634659425">પાસફ્રેઝ બનાવો</translation>
+<translation id="5713644099811900409">Brave Software એકાઉન્ટ</translation>
+<translation id="8997474919031554666">પાસફ્રેઝ એન્ક્રિપ્શનમાં Brave Software Payની ચુકવણી પદ્ધતિઓ અને ઍડ્રેસ સામેલ હોતા નથી. માત્ર તમારા પાસફ્રેઝ ધરાવતી કોઈ વ્યક્તિ જ તમારા એન્ક્રિપ્ટ કરેલા ડેટાને વાંચી શકે છે. Brave Softwareને પાસફ્રેઝ મોકલવામાં આવતો નથી કે તેના દ્વારા સંગ્રહિત કરવામાં આવતો નથી. જો તમે તમારો પાસફ્રેઝ ભૂલી જાઓ અથવા આ સેટિંગ બદલવા માંગતા હો, તો તમારે સિંકને રીસેટ કરવું પડશે. <ph name="BEGIN_LINK"/>વધુ જાણો<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">પાસફ્રેઝ</translation>
+<translation id="7772032839648071052">પાસફ્રેઝની પુષ્ટિ કરો</translation>
+<translation id="5304593522240415983">આ ફીલ્ડ ખાલી હોઈ શકતું નથી</translation>
+<translation id="321773570071367578">જો તમે તમારો પાસફ્રેઝ ભૂલી ગયાં હોવ અથવા આ સેટિંગ બદલવા માંગતા હોવ, તો <ph name="BEGIN_LINK"/>સમન્વયનને ફરીથી સેટ કરો<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">પાસફ્રેઝેસ મેળ ખાતા નથી</translation>
+<translation id="5149495116300586333">પાસફ્રેઝ એન્ક્રિપ્શનમાં Brave Software Payની ચુકવણી પદ્ધતિઓ અને ઍડ્રેસ સામેલ હોતા નથી. 
+
+આ સેટિંગ બદલવા માટે, <ph name="BEGIN_LINK"/>સિંકને રીસેટ કરો<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">ખોટો પાસફ્રેઝ</translation>
+<translation id="5414836363063783498">ચકાસી રહ્યું છે...</translation>
+<translation id="6846298663435243399">લોડ કરી રહ્યું છે...</translation>
+<translation id="5517095782334947753">તમારી પાસે <ph name="FROM_ACCOUNT"/> ના બુકમાર્ક્સ, ઇતિહાસ, પાસવર્ડ્સ અને અન્ય સેટિંગ્સ છે.</translation>
+<translation id="3928666092801078803">મારા ડેટાને સંયોજિત કરો</translation>
+<translation id="688738109438487280">અસ્તિત્વમાંના ડેટાને <ph name="TO_ACCOUNT"/> માં ઉમેરો.</translation>
+<translation id="806745655614357130">મારા ડેટાને અલગ રાખો</translation>
+<translation id="1145536944570833626">અસ્તિત્વમાંના ડેટાને ડિલીટ કરો.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/>, જોડી કરવા માગે છે</translation>
+<translation id="4915549754973153784">ઉપકરણોને સ્કેન કરતી વખતે <ph name="BEGIN_LINK"/>સહાય મેળવો<ph name="END_LINK"/>…</translation>
+<translation id="5817918615728894473">જોડી કરો</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>સહાય મેળવો<ph name="END_LINK1"/> અથવા <ph name="BEGIN_LINK2"/>ફરીથી સ્કેન કરો<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">કોઈ સુસંગત ઉપકરણો મળ્યા નથી</translation>
+<translation id="3773755127849930740">જોડી કરવાની મંજૂરી આપવા માટે <ph name="BEGIN_LINK"/>Bluetooth ચાલુ કરો<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave, Bluetooth એડેપ્ટરને ચાલુ કરવામાં અસમર્થ છે</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>સહાય મેળવો<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">ઉપકરણો માટે સ્કેન કરવા માટે Brave ને સ્થાન ઍક્સેસની જરૂર છે. <ph name="BEGIN_LINK"/>પરવાનગીઓ અપડેટ કરો<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">ઉપકરણો માટે સ્કેન કરવા Brave ને સ્થાન ઍક્સેસની જરૂર છે. સ્થાન ઍક્સેસ, <ph name="BEGIN_LINK"/>આ ઉપકરણ માટે બંધ કરેલ છે<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">ઉપકરણો માટે સ્કેન કરવા Brave ને સ્થાન ઍક્સેસની જરૂર છે. <ph name="BEGIN_LINK1"/>પરવાનગીઓ અપડેટ કરો<ph name="END_LINK1"/>. સ્થાન ઍક્સેસ પણ <ph name="BEGIN_LINK2"/>આ ઉપકરણ માટે બંધ કરેલ છે<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">કનેક્ટ કરેલ ઉપકરણ</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{સિગ્નલની ક્ષમતાનું સ્તર: # બાર}one{સિગ્નલની ક્ષમતાનું સ્તર: # બાર}other{સિગ્નલની ક્ષમતાનું સ્તર: # બાર}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> નજીકના બ્લૂટૂથ ડિવાઇસ માટે સ્કૅન કરવા માગે છે. નીચે મુજબના ડિવાઇસ મળ્યા છે:</translation>
+<translation id="8368027906805972958">અજાણ્યું અથવા અસમર્થિત ડિવાઇસ (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">સમન્વયન કામ કરતું નથી</translation>
+<translation id="1810845389119482123">સિંકનું પ્રારંભિક સેટઅપ પૂર્ણ થયું નથી</translation>
+<translation id="3235722914093408050">Brave સિંક શરૂ કરવા Android સેટિંગ ખોલો અને Android સિસ્ટમ સિંક ફરી ચાલુ કરો</translation>
+<translation id="3367813778245106622">સમન્વયન શરૂ કરવા માટે ફરીથી સાઇન ઇન કરો</translation>
+<translation id="974555521953189084">સમન્વયન શરૂ કરવા માટે તમારો પાસફ્રેઝ દાખલ કરો</translation>
+<translation id="2997266899014181325">સિંક શરુ કરવા માટે, "તમારો Braveનો ડેટા સિંક કરો" ચાલુ કરો.</translation>
+<translation id="8260126382462817229">ફરીથી સાઇન ઇન કરવાનો પ્રયાસ કરો</translation>
+<translation id="5919204609460789179">સમન્વયન પ્રારંભ કરવા માટે <ph name="PRODUCT_NAME"/> અપડેટ કરો</translation>
+<translation id="397583555483684758">સમન્વયન એ કામ કરવાનું બંધ કરી દીધું છે</translation>
+<translation id="1966710179511230534">કૃપા કરીને તમારી સાઇન-ઇન વિગતો અપડેટ કરો.</translation>
+<translation id="7063006564040364415">સમન્વયન સર્વર સાથે કનેક્ટ કરી શકાયું નથી</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> જૂનું થઈ ગયું છે.</translation>
+<translation id="4170011742729630528">સેવા ઉપલબ્ધ નથી; પછી ફરીથી પ્રયાસ કરો</translation>
+<translation id="7947953824732555851">સ્વીકારો અને સાઇન ઇન કરો</translation>
+<translation id="8583805026567836021">એકાઉન્ટ ડેટા સાફ કરી રહ્યું છે</translation>
+<translation id="8310344678080805313">માનક ટેબ્સ</translation>
+<translation id="5748802427693696783">માનક ટૅબ્સ પર સ્વિચ કરેલ છે</translation>
+<translation id="7998918019931843664">બંધ કરેલ ટેબ ફરીથી ખોલો</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, ટેબ</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> ટૅબ બંધ કરો</translation>
+<translation id="7243308994586599757">સ્ક્રીનના તળિયા નજીક વિકલ્પો ઉપલબ્ધ છે</translation>
+<translation id="4060598801229743805">સ્ક્રીનની ટોચ પર વિકલ્પો ઉપલબ્ધ છે</translation>
+<translation id="2810645512293415242">ડેટા બચાવવા અને વધુ ઝડપથી પેજ લોડ કરવા માટે પેજ સરળ બનાવ્યું.</translation>
+<translation id="3985215325736559418">શું તમે <ph name="FILE_NAME"/> ને ફરી ડાઉનલોડ કરવા માગો છો?</translation>
+<translation id="2450083983707403292">શું તમે <ph name="FILE_NAME"/>ને ફરી ડાઉનલોડ કરવાનું શરૂ કરવા માગો છો?</translation>
+<translation id="7514365320538308">ડાઉનલોડ કરો</translation>
+<translation id="545042621069398927">તમારા ડાઉનલોડની ગતિ વધારી રહ્યાં છીએ.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ફાઇલ ડાઉનલોડ કરી રહ્યાં છીએ.}one{# ફાઇલ ડાઉનલોડ કરી રહ્યાં છે.}other{# ફાઇલ ડાઉનલોડ કરી રહ્યાં છે.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> ફાઇલ (<ph name="MEGABYTES"/>) ડાઉનલોડ કરી રહ્યાં છીએ.</translation>
+<translation id="4988210275050210843">(<ph name="MEGABYTES"/>)ની ફાઇલ ડાઉનલોડ કરી રહ્યાં છીએ.</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ડાઉનલોડ પૂર્ણ થયું.}one{# ડાઉનલોડ પૂર્ણ થયું.}other{# ડાઉનલોડ પૂર્ણ થયાં.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ડાઉનલોડ નિષ્ફળ થયું.}one{# ડાઉનલોડ નિષ્ફળ થયું.}other{# ડાઉનલોડ નિષ્ફળ થયાં.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 ડાઉનલોડ બાકી.}one{# ડાઉનલોડ બાકી.}other{# ડાઉનલોડ બાકી.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> બટન</translation>
+<translation id="3205824638308738187">લગભગ સમાપ્ત થયું!</translation>
+<translation id="3960299545138990065">Brave ને પુનઃપ્રારંભ કરો</translation>
+<translation id="3771001275138982843">અપડેટ ડાઉનલોડ કરી શકાઈ નથી</translation>
+<translation id="3888648114124182147">Brave અપડેટ ડાઉનલોડ કરી રહ્યાં છીએ…</translation>
+<translation id="1705567146636171298">Brave અપડેટ કરો</translation>
+<translation id="6195417478702700398">બ્રાઉઝિંગનો શ્રેષ્ઠ અનુભવ મેળવવા અપડેટ કરવા માટે Brave ખોલો</translation>
+<translation id="3512968675351418494">વેબ તમારી ભાષામાં જોવા માટે Braveનું એકદમ નવું વર્ઝન મેળવો</translation>
+<translation id="6427112570124116297">વેબનો અનુવાદ કરો</translation>
+<translation id="1379423114029199501">Braveના એકદમ નવા વર્ઝનમાં તમારી ભાષા મેળવવા માટે અપડેટ કરો</translation>
+<translation id="5684874026226664614">અરેરે. આ પૃષ્ઠનો અનુવાદ કરી શકાયો નથી.</translation>
+<translation id="6831043979455480757">અનુવાદ કરો</translation>
+<translation id="1285320974508926690">આ સાઇટનું ક્યારેય ભાષાંતર કરશો નહીં</translation>
+<translation id="773466115871691567">હંમેશાં પેજનો <ph name="SOURCE_LANGUAGE"/>માં અનુવાદ કરો</translation>
+<translation id="1068672505746868501">પેજનો ક્યારેય પણ <ph name="SOURCE_LANGUAGE"/>માં અનુવાદ કરશો નહીં</translation>
+<translation id="124116460088058876">વધુ ભાષાઓ</translation>
+<translation id="290376772003165898">પેજ <ph name="LANGUAGE"/>માં નથી?</translation>
+<translation id="4432792777822557199">હવેથી <ph name="SOURCE_LANGUAGE"/>માં છે તે પેજનો અનુવાદ <ph name="TARGET_LANGUAGE"/>માં થશે</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/>માં છે તે પેજનો અનુવાદ થશે નહીં</translation>
+<translation id="5447765697759493033">આ સાઇટનો અનુવાદ થશે નહીં</translation>
+<translation id="4880127995492972015">અનુવાદ કરો…</translation>
+<translation id="641643625718530986">પ્રિન્ટ…</translation>
+<translation id="8909135823018751308">શેર કરો…</translation>
+<translation id="4996978546172906250">આનાથી શેર કરો</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> મારફતે શેર કરો</translation>
+<translation id="6277522088822131679">પૃષ્ઠને છાપવામાં સમસ્યા હતી. કૃપા કરીને ફરીથી પ્રયાસ કરો.</translation>
+<translation id="3254409185687681395">આ પૃષ્ઠને બુકમાર્ક કરો</translation>
+<translation id="497421865427891073">આગળ જાઓ</translation>
+<translation id="813082847718468539">સ્થાન માહિતી જુઓ</translation>
+<translation id="2532336938189706096">વેબ દૃશ્ય</translation>
+<translation id="6005538289190791541">સૂચવેલ પાસવર્ડ</translation>
+<translation id="4634124774493850572">પાસવર્ડનો ઉપયોગ કરો</translation>
+<translation id="8285489906452138776">Braveને આ સાઇટ માટે તમારા કૅમેરાના ઍક્સેસની પરવાનગીની જરૂર પડે છે.</translation>
+<translation id="320189792589364011">Braveને આ સાઇટ માટે તમારા માઇક્રોફોનના ઍક્સેસની પરવાનગીની જરૂર પડે છે.</translation>
+<translation id="7988136689212463100">Braveને આ સાઇટ માટે તમારા કૅમેરા અને માઇક્રોફોનના ઍક્સેસની પરવાનગીની જરૂર પડે છે.</translation>
+<translation id="4931190655840828017">Braveને આ સાઇટ સાથે તમારું સ્થાન શેર કરવા માટે તમારા સ્થાનના ઍક્સેસની જરૂર પડે છે.</translation>
+<translation id="3088191967551450609">ફાઇલો ડાઉનલોડ કરવા માટે Brave ને સ્ટોરેજ ઍક્સેસની જરૂર છે.</translation>
+<translation id="8942627711005830162">અન્ય વિંડોમાં ખોલો</translation>
+<translation id="4195643157523330669">નવા ટૅબમાં ખોલો</translation>
+<translation id="1100066534610197918">ગ્રૂપમાં નવા ટૅબમાં ખોલો</translation>
+<translation id="4860895144060829044">કૉલ કરો</translation>
+<translation id="6896758677409633944">કૉપિ કરો</translation>
+<translation id="8393700583063109961">સંદેશ મોકલો</translation>
+<translation id="3557336313807607643">સંપર્કોમાં ઉમેરો</translation>
+<translation id="4269820728363426813">લિંક સરનામું કૉપિ કરો</translation>
+<translation id="1206892813135768548">લિંક ટેક્સ્ટ કૉપિ કરો</translation>
+<translation id="1204037785786432551">ડાઉનલોડ કરવાની લિંક</translation>
+<translation id="6864459304226931083">છબી ડાઉનલોડ કરો</translation>
+<translation id="8209050860603202033">છબી ખોલો</translation>
+<translation id="8073388330009372546">નવા ટેબમાં છબી ખોલો</translation>
+<translation id="6649642165559792194">છબીને પ્રીવ્યૂ કરો <ph name="BEGIN_NEW"/>નવું<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">છબી લોડ કરો</translation>
+<translation id="3845332215609790146">Brave Software લેન્સ વડે શોધો <ph name="BEGIN_NEW"/>નવું<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">આ છબી માટે <ph name="SEARCH_ENGINE"/> માં શોધો</translation>
+<translation id="3384347053049321195">છબી શેર કરો</translation>
+<translation id="5833984609253377421">લિંક શેર કરો</translation>
+<translation id="6475951671322991020">વીડિયો ડાઉનલોડ કરો</translation>
+<translation id="2317945146070194624">નવા Brave ટૅબમાં ખોલો</translation>
+<translation id="7975379999046275268">પેજને પ્રીવ્યૂ કરો <ph name="BEGIN_NEW"/>નવું<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">પૃષ્ઠ તાજું કરી રહ્યું છે</translation>
+<translation id="36525718899759834">Brave Software Play Store માંથી ઍપ્લિકેશન મેળવો: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">ઘાટું</translation>
+<translation id="1807246157184219062">આછું</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">મોનોસ્પેસ</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">બીમ કરવા માટે એક ટેબ પસંદ કરો</translation>
+<translation id="8719023831149562936">વર્તમાન ટેબને બીમ કરી શકતાં નથી</translation>
+<translation id="2139186145475833000">હોમસ્ક્રીન પર ઉમેરો</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> ખોલો</translation>
+<translation id="2122601567107267586">ઍપ ખોલી ન શક્યાં</translation>
+<translation id="5129038482087801250">વેબ ઍપ ઇન્સ્ટૉલ કરો</translation>
+<translation id="3789841737615482174">ઇન્સ્ટોલ કરો</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> ને તમારા હોમ સ્ક્રીન પર ઉમેરવામાં આવ્યું હતું</translation>
+<translation id="7333031090786104871">હજીપણ પાછલી સાઇટ ઉમેરી રહ્યાં છે</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> ઉમેરી રહ્યાં છીએ…</translation>
+<translation id="3778956594442850293">હોમ સ્ક્રીન પર ઉમેર્યું</translation>
+<translation id="2146738493024040262">ઝટપટ ઍપ્લિકેશન ખોલો</translation>
+<translation id="7016516562562142042">હાલનાં શોધ એંજિન માટે મંજૂર</translation>
+<translation id="6177111841848151710">હાલનાં શોધ એંજિન માટે અવરોધિત</translation>
+<translation id="145097072038377568">Android સેટિંગ્સમાં બંધ કરી</translation>
+<translation id="8007176423574883786">આ ઉપકરણ માટે બંધ કર્યું</translation>
+<translation id="164269334534774161">તમે <ph name="CREATION_TIME"/>માંથી આ પેજની ઑફલાઇન કૉપિ જોઈ રહ્યા છો</translation>
+<translation id="4594952190837476234">આ ઑફલાઇન પેજ <ph name="CREATION_TIME"/> ના રોજનું છે અને તે ઑનલાઇન વર્ઝનથી અલગ હોઈ શકે છે.</translation>
+<translation id="8840953339110955557">આ પેજ ઑનલાઇન વર્ઝનથી અલગ હોય શકે છે.</translation>
+<translation id="6405300764336705484">આ કન્ટેન્ટ <ph name="DOMAIN_NAME"/> માંથી, Brave Software દ્વારા વિતરિત કરેલ છે.</translation>
+<translation id="1006017844123154345">ઑનલાઇન ખોલો</translation>
+<translation id="3326636747541519688">Brave Software દ્વારા પૂરું પાડવામાં આવેલું લાઇટ વર્ઝનનું પેજ</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/>માંથી <ph name="BEGIN_LINK"/>ઑરિજિનલ પેજ લોડ કરો<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">જો તમે આ વારંવાર જોઈ રહ્યાં છો, તો આ <ph name="BEGIN_LINK"/>સૂચનો<ph name="END_LINK"/>ને અજમાવી જુઓ.</translation>
+<translation id="8748850008226585750">સામગ્રીઓ છુપાવેલ છે</translation>
+<translation id="3810973564298564668">મેનેજ કરો</translation>
+<translation id="5199929503336119739">કાર્ય પ્રોફાઇલ</translation>
+<translation id="528192093759286357">પૂર્ણસ્ક્રીનથી બહાર નીકળવા માટે ઉપરથી ખેંચો અને પાછળ બટનને ટચ કરો.</translation>
+<translation id="2836148919159985482">પૂર્ણ સ્ક્રીનથી બહાર નીકળવા માટે પાછળ બટન ટચ કરો.</translation>
+<translation id="3967822245660637423">ડાઉનલોડ પૂર્ણ</translation>
+<translation id="2434158240863470628">ડાઉનલોડ પૂર્ણ <ph name="SEPARATOR"/><ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">ડાઉનલોડ નિષ્ફળ થયું</translation>
+<translation id="1384959399684842514">ડાઉનલોડ થોભાવ્યું</translation>
+<translation id="1671236975893690980">ડાઉનલોડ બાકી…</translation>
+<translation id="5561549206367097665">નેટવર્કની રાહ જોઈ રહ્યાં છે…</translation>
+<translation id="5864419784173784555">બીજા ડાઉનલોડ માટે રાહ જોઈ રહ્યાં છે…</translation>
+<translation id="6461962085415701688">ફાઇલ ખોલી શકતાં નથી</translation>
+<translation id="1178581264944972037">થોભો</translation>
+<translation id="8200772114523450471">રિઝ્યુમે</translation>
+<translation id="1409879593029778104"><ph name="FILE_NAME"/> ડાઉનલોડ રોકાયું કારણકે ફાઇલ પહેલેથી અસ્તિત્વ ધરાવે છે.</translation>
+<translation id="3387650086002190359">ફાઇલ સિસ્ટમ ભૂલોના કારણે <ph name="FILE_NAME"/> ડાઉનલોડ નિષ્ફળ થયું.</translation>
+<translation id="6482749332252372425">સ્ટોરેજ સ્થાનના અભાવના કારણે <ph name="FILE_NAME"/> ડાઉનલોડ નિષ્ફળ થયું.</translation>
+<translation id="7619072057915878432">નેટવર્ક નિષ્ફળતાને કારણે <ph name="FILE_NAME"/> ડાઉનલોડ નિષ્ફળ થયું.</translation>
+<translation id="1477626028522505441">સર્વર સમસ્યાઓને કારણે <ph name="FILE_NAME"/> ડાઉનલોડ નિષ્ફળ થયું.</translation>
+<translation id="3692944402865947621">સ્ટોરેજ સ્થાન સુધી પહોંચી ન શકવાને કારણે <ph name="FILE_NAME"/>નું ડાઉનલોડ નિષ્ફળ થયું.</translation>
+<translation id="604996488070107836">કોઇ અજાણી ભૂલને કારણે <ph name="FILE_NAME"/> ડાઉનલોડ નિષ્ફળ થયું.</translation>
+<translation id="6738867403308150051">ડાઉનલોડ કરી રહ્યું છે...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB ડાઉનલોડ કર્યા</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB ડાઉનલોડ કર્યા</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB ડાઉનલોડ કર્યા</translation>
+<translation id="9204836675896933765">1 ફાઇલ બાકી છે</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> ફાઇલ બાકી છે</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> ફાઇલ ડાઉનલોડ કરી}one{<ph name="FILES_DOWNLOADED_MANY"/> ફાઇલ ડાઉનલોડ કરી}other{<ph name="FILES_DOWNLOADED_MANY"/> ફાઇલ ડાઉનલોડ કરી}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> દિવસ બાકી</translation>
+<translation id="8190358571722158785">1 દિવસ બાકી</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> કલાક બાકી</translation>
+<translation id="510275257476243843">1 કલાક બાકી</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> મિનિટ બાકી</translation>
+<translation id="3236059992281584593">1 મિનિટ બાકી</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> સેકંડ બાકી</translation>
+<translation id="2781151931089541271">1 સેકંડ બાકી</translation>
+<translation id="3303414029551471755">કન્ટેન્ટ ડાઉનલોડ કરવા માટે આગળ વધીએ?</translation>
+<translation id="8617240290563765734">ડાઉનલોડ કરેલી કન્ટેન્ટમાં ઉલ્લેખિત, સૂચવેલ URL ખોલીએ?</translation>
+<translation id="1373696734384179344">પસંદ કરેલ કન્ટેન્ટ ડાઉનલોડ કરવા માટે મેમરી અપૂરતી છે.</translation>
+<translation id="5271967389191913893">ડિવાઇસ, ડાઉનલોડ કરવાની કન્ટેન્ટ ખોલી શકતું નથી.</translation>
+<translation id="883806473910249246">કન્ટેન્ટ ડાઉનલોડ કરતી વખતે એક ભૂલ આવી.</translation>
+<translation id="5626134646977739690">નામ:</translation>
+<translation id="7963646190083259054">વિક્રેતા:</translation>
+<translation id="3414952576877147120">કદ:</translation>
+<translation id="7375125077091615385">પ્રકાર:</translation>
+<translation id="5765780083710877561">વર્ણન:</translation>
+<translation id="4881695831933465202">ખોલો</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB ઉપલબ્ધ</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB ઉપલબ્ધ</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB ઉપલબ્ધ</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/>માંથી <ph name="SPACE_USED"/>નો વપરાશ કરી રહ્યાં છીએ</translation>
+<translation id="3587482841069643663">બધા</translation>
+<translation id="4988526792673242964">પૃષ્ઠો</translation>
+<translation id="3810838688059735925">વીડિયો</translation>
+<translation id="3616113530831147358">ઑડિઓ</translation>
+<translation id="9219103736887031265">છબીઓ</translation>
+<translation id="8250920743982581267">દસ્તાવેજો</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ફાઇલ}one{# ફાઇલો}other{# ફાઇલો}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# છબી}one{# છબીઓ}other{# છબીઓ}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# વીડિયો}one{# વીડિયો}other{# વીડિયો}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ઑડિયો ફાઇલ}one{# ઑડિયો ફાઇલો}other{# ઑડિયો ફાઇલો}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# પેજ}one{# પેજ}other{# પેજ}}</translation>
+<translation id="5456381639095306749">પૃષ્ઠ ડાઉનલોડ કરો</translation>
+<translation id="2394602618534698961">તમે ડાઉનલોડ કરો તે ફાઇલો અહીં દેખાશે</translation>
+<translation id="7810647596859435254">આની સાથે ખોલો…</translation>
+<translation id="5655963694829536461">તમારા ડાઉનલોડમાં શોધો</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">મારી ફાઇલો</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">લેખો અહીં દેખાય છે, જે તમે ઑફલાઇન હો ત્યારે પણ વાંચી શકો છો</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# કલાક}one{# કલાક}other{# કલાક}}</translation>
+<translation id="5853623416121554550">થોભાવેલ</translation>
+<translation id="8965591936373831584">બાકી</translation>
+<translation id="2779651927720337254">નિષ્ફળ થયું</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">હમણાં જ</translation>
+<translation id="4000212216660919741">ઑફલાઇન હોમ</translation>
+<translation id="9133397713400217035">ઑફલાઇનમાં શોધખોળ કરો</translation>
+<translation id="968900484120156207">તમે મુલાકાત લીધેલા પેજ અહીં દેખાય છે</translation>
+<translation id="7882131421121961860">કોઈ ઇતિહાસ મળ્યો નથી</translation>
+<translation id="3549657413697417275">તમારો ઇતિહાસ શોધો</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave પ્રથમ વાર ઉપયોગ કર્યાનો અનુભવ</translation>
+<translation id="2700285883409956633">આ એપ્લિકેશનનો ઉપયોગ કરીને, તમે Brave ની <ph name="BEGIN_LINK1"/>સેવાની શરતો<ph name="END_LINK1"/> અને <ph name="BEGIN_LINK2"/>ગોપનીયતા સૂચના<ph name="END_LINK2"/> સાથે સંમત છો.</translation>
+<translation id="1640714894372474981">આ ઍપ્લિકેશનનો ઉપયોગ કરીને તમે Braveની <ph name="BEGIN_LINK1"/>સેવાની શરતો<ph name="END_LINK1"/> અને <ph name="BEGIN_LINK2"/>ગોપનીયતા સૂચના<ph name="END_LINK2"/> અને <ph name="BEGIN_LINK3"/>Family Link દ્વારા મેનેજ થતા Brave Software એકાઉન્ટ્સ માટેની ગોપનીયતા સૂચના<ph name="END_LINK3"/> સાથે સંમત થાઓ છો.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> Braveમાં ખૂલશે. ચાલુ રાખીને, તમે Braveની <ph name="BEGIN_LINK1"/>સેવાની શરતો<ph name="END_LINK1"/> અને <ph name="BEGIN_LINK2"/>ગોપનીયતા સૂચના<ph name="END_LINK2"/> સાથે સંમત થાઓ છો.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Braveમાં ખૂલશે. ચાલુ રાખીને, તમે Braveની <ph name="BEGIN_LINK1"/>સેવાની શરતો<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>ગોપનીયતા સૂચના<ph name="END_LINK2"/> અને <ph name="BEGIN_LINK3"/>Family Link દ્વારા મેનેજ થતા Brave Software એકાઉન્ટ માટેની ગોપનીયતા સૂચના<ph name="END_LINK3"/> સાથે સંમત થાઓ છો.</translation>
+<translation id="673197144963363525">ઉપયોગનાં આંકડા અને ક્રૅશ રિપોર્ટ Brave Softwareને મોકલીને Braveને વધુ સારું બનાવવામાં મદદ કરો.</translation>
+<translation id="3518985090088779359">સ્વીકારો અને ચાલુ રાખો</translation>
+<translation id="7207456302801184289">Brave પર આપનું સ્વાગત છે</translation>
+<translation id="704822250101715322">Brave Software Play સેવાઓ દ્વારા અપડેટ થવાનું સમાપ્ત કરવાની રાહ જોવામાં આવી રહી છે</translation>
+<translation id="1231733316453485619">સિંક કરવાનું ચાલુ કરીએ?</translation>
+<translation id="5132942445612118989">બધા ડિવાઇસ પર તમારા પાસવર્ડ, ઇતિહાસ અને વધુ સિંક કરો</translation>
+<translation id="5736731321935944068">Brave Software, શોધ, જાહેરાતો અને અન્ય Brave Software સેવાઓને વ્યક્તિગત કરવા માટે તમારા ઇતિહાસનો ઉપયોગ કરી શકે છે</translation>
+<translation id="4013614219085422040">Brave Software, શોધ અને અન્ય Brave Software સેવાઓને વ્યક્તિગત કરવા માટે તમારા ઇતિહાસનો ઉપયોગ કરી શકે છે</translation>
+<translation id="5581519193887989363">શું સિંક કરવું તે હંમેશાં તમે <ph name="BEGIN_LINK1"/>સેટિંગ<ph name="END_LINK1"/>માં પસંદ કરી શકો છો.</translation>
+<translation id="741204030948306876">હા, હું સંમત છું</translation>
+<translation id="2410754283952462441">એકાઉન્ટ પસંદ કરો</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> તરીકે ચાલુ રાખો</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> નથી?</translation>
+<translation id="8109613176066109935">તમારા બધા ઉપકરણો પર તમારા બુકમાર્ક મેળવવા માટે, સિંક કરવાનું ચાલુ કરો</translation>
+<translation id="2818669890320396765">તમારા બધા ઉપકરણો પર તમારા બુકમાર્ક મેળવવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો</translation>
+<translation id="6003646045106347985">Brave Software દ્વારા સૂચવેલ વ્યક્તિગત કરેલ કન્ટેન્ટ મેળવવા માટે, સિંક કરવાનું ચાલુ કરો</translation>
+<translation id="8494430740943879273">Brave Software દ્વારા સૂચવેલ વ્યક્તિગત કરેલ કન્ટેન્ટ મેળવવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો</translation>
+<translation id="5862731021271217234">તમારા અન્ય ઉપકરણો પરથી તમારા ટૅબ મેળવવા માટે, સિંક કરવાનું ચાલુ કરો</translation>
+<translation id="3568688522516854065">તમારા અન્ય ઉપકરણો પરથી તમારા ટૅબ મેળવવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો.</translation>
+<translation id="1208340532756947324">સમગ્ર ઉપકરણોમાં સિંક તથા વ્યક્તિગત કરવા માટે સિંક ચાલુ કરો</translation>
+<translation id="4472118726404937099">સમગ્ર ઉપકરણો સિંક કરવા અને વ્યક્તિગત કરવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો</translation>
+<translation id="2426805022920575512">બીજું એકાઉન્ટ પસંદ કરો</translation>
+<translation id="6790428901817661496">ચલાવો</translation>
+<translation id="1272079795634619415">રોકો</translation>
+<translation id="2874939134665556319">પાછલું ટ્રૅક</translation>
+<translation id="4046123991198612571">આગલો ટ્રૅક</translation>
+<translation id="3859306556332390985">આગળ કરો</translation>
+<translation id="8441146129660941386">પાછળ કરો</translation>
+<translation id="6706288973712894588">તમે હાલમાં ઑફલાઇન છો.\n<ph name="BEGIN_LINK"/>તમારી ઑફલાઇન ફીડમાં શોધખોળ કરો.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">તાજેતરના ટેબ્સ</translation>
+<translation id="8497726226069778601">હજી સુધી... અહીં જોવા માટે કંઈ નથી</translation>
+<translation id="5423934151118863508">તમારા સૌથી વધુ મુલાકાત લીધેલા પૃષ્ઠો અહીં દેખાશે</translation>
+<translation id="6127379762771434464">આઇટમ દૂર કરી</translation>
+<translation id="4605958867780575332">આઇટમ દૂર કરી: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software ડૂડલ: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">અન્ય ઉપકરણો</translation>
+<translation id="4738836084190194332">છેલ્લે સમન્વયિત: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# મિનિટ પહેલાં}one{# મિનિટ પહેલાં}other{# મિનિટ પહેલાં}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# કલાક પહેલાં}one{# કલાક પહેલાં}other{# કલાક પહેલાં}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# દિવસ પહેલાં}one{# દિવસ પહેલાં}other{# દિવસ પહેલાં}}</translation>
+<translation id="2762000892062317888">હમણાં જ</translation>
+<translation id="1407135791313364759">બધું ખોલો</translation>
+<translation id="1209206284964581585">હમણાં માટે છુપાવો</translation>
+<translation id="129553762522093515">તાજેતરમાં બંધ કરેલા</translation>
+<translation id="8413126021676339697">પૂર્ણ ઇતિહાસ બતાવો</translation>
+<translation id="7876243839304621966">બધું દૂર કરો</translation>
+<translation id="8487700953926739672">ઑફલાઇન ઉપલબ્ધ</translation>
+<translation id="5224771365102442243">વીડિયો દ્વારા</translation>
+<translation id="3493531032208478708">સૂચવેલ કન્ટેન્ટ વિશે <ph name="BEGIN_LINK"/>વધુ જાણો<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">સૂચનો મેળવી શકતાં નથી</translation>
+<translation id="5013696553129441713">કોઈ નવા સૂચનો નથી</translation>
+<translation id="1736419249208073774">શોધખોળ કરો</translation>
+<translation id="7444811645081526538">વધુ કૅટેગરી</translation>
+<translation id="6709133671862442373">News</translation>
+<translation id="1264974993859112054">રમત-ગમત</translation>
+<translation id="9139318394846604261">ખરીદી</translation>
+<translation id="3912508018559818924">વેબમાંથી શ્રેષ્ઠ શોધવું…</translation>
+<translation id="526421993248218238">આ પેજ લોડ કરી શકાતું નથી</translation>
+<translation id="614940544461990577">પ્રયાસ કરો:</translation>
+<translation id="3288003805934695103">પૃષ્ઠ ફરીથી લોડ કરીને</translation>
+<translation id="2353636109065292463">તમારું ઇન્ટરનેટ કનેક્શન તપાસી રહ્યાં છીએ</translation>
+<translation id="2858138569776157458">લોકપ્રિય સાઇટ</translation>
+<translation id="8364299278605033898">લોકપ્રિય વેબસાઇટ જુઓ</translation>
+<translation id="1171770572613082465">"લોકપ્રિય સાઇટ" બટન પર ટૅપ કરીને લોકપ્રિય વેબસાઇટ જુઓ</translation>
+<translation id="5233638681132016545">નવું ટૅબ</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/> તરફથી - <ph name="BEGIN_DEEMPHASIZED"/>Brave Software દ્વારા વિતરિત <ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">નવું વર્ઝન ઉપલબ્ધ છે</translation>
+<translation id="4058091506841967397">Brave અપડેટ કરી શકતા નથી</translation>
+<translation id="6316139424528454185">Android વર્ઝન અસમર્થિત છે</translation>
+<translation id="6989267951144302301">ડાઉનલોડ ન કરી શક્યા</translation>
+<translation id="624789221780392884">અપડેટ તૈયાર</translation>
+<translation id="1549000191223877751">અન્ય વિંડો પર ખસેડો</translation>
+<translation id="7481312909269577407">ફોર્વર્ડ કરો</translation>
+<translation id="4084682180776658562">બુકમાર્ક</translation>
+<translation id="6437478888915024427">પેજ વિશે માહિતી</translation>
+<translation id="7180611975245234373">રિફ્રેશ કરો</translation>
+<translation id="4913169188695071480">તાજું કરવાનું રોકો</translation>
+<translation id="1829244130665387512">આ પૃષ્ઠમાં શોધો</translation>
+<translation id="6593061639179217415">ડેસ્કટૉપ સાઇટ</translation>
+<translation id="9063523880881406963">વિનંતી ડેસ્કટૉપ સાઇટ બંધ કરો</translation>
+<translation id="2038563949887743358">વિનંતી ડેસ્કટૉપ સાઇટ ચાલુ કરો</translation>
+<translation id="2433507940547922241">દેખાવ</translation>
+<translation id="983192555821071799">બધા ટેબ્સ બંધ કરો</translation>
+<translation id="1310482092992808703">ટૅબનું ગ્રૂપ બનાવો</translation>
+<translation id="7725024127233776428">બુકમાર્ક કરેલા પેજ અહીં દેખાય છે</translation>
+<translation id="4404568932422911380">કોઈ બુકમાર્ક નથી</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> બુકમાર્ક}one{<ph name="BOOKMARKS_COUNT_MANY"/> બુકમાર્ક}other{<ph name="BOOKMARKS_COUNT_MANY"/> બુકમાર્ક}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> માં બુકમાર્ક કર્યું</translation>
+<translation id="3207960819495026254">બુકમાર્ક કરેલ</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> પર બુકમાર્ક કર્યું</translation>
+<translation id="8063895661287329888">બુકમાર્ક ઉમેરવામાં નિષ્ફળ થયાં.</translation>
+<translation id="2842985007712546952">પેરન્ટ ફોલ્ડર</translation>
+<translation id="9065203028668620118">ફેરફાર કરો</translation>
+<translation id="4405224443901389797">આમાં ખસેડો…</translation>
+<translation id="5170568018924773124">ફોલ્ડરમાં બતાવો</translation>
+<translation id="8035133914807600019">નવું ફોલ્ડર...</translation>
+<translation id="4532845899244822526">ફોલ્ડર પસંદ કરો</translation>
+<translation id="6627583120233659107">ફોલ્ડરમાં ફેરફાર કરો</translation>
+<translation id="1197267115302279827">બુકમાર્ક્સ ખસેડો</translation>
+<translation id="6963766334940102469">બુકમાર્ક્સ ડિલીટ કરો</translation>
+<translation id="4351244548802238354">સંવાદ બંધ કરો</translation>
+<translation id="451872707440238414">તમારા બુકમાર્ક શોધો</translation>
+<translation id="8901170036886848654">કોઇ બુકમાર્ક્સ મળ્યાં નથી</translation>
+<translation id="6404511346730675251">બુકમાર્કમાં ફેરફાર કરો</translation>
+<translation id="3894427358181296146">ફોલ્ડર ઉમેરો</translation>
+<translation id="5327248766486351172">નામ</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">ફોલ્ડર</translation>
+<translation id="5161254044473106830">શીર્ષક જરૂરી</translation>
+<translation id="2996809686854298943">URL આવશ્યક છે</translation>
+<translation id="2536728043171574184">આ પેજની ઓફલાઇન કૉપિ જોઈ રહ્યા છે</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/>માં ઑફલાઇન જુઓ</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> અને વધુ સાઇટ</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{તૈયાર હશે ત્યારે Brave તમારું પેજ લોડ કરશે}one{તૈયાર હશે ત્યારે Brave તમારાં પેજ લોડ કરશે}other{તૈયાર હશે ત્યારે Brave તમારાં પેજ લોડ કરશે}}</translation>
+<translation id="6811034713472274749">પેજ જોવા માટે તૈયાર છે</translation>
+<translation id="4561979708150884304">કોઈ કનેક્શન નથી</translation>
+<translation id="8274165955039650276">ડાઉનલોડ જુઓ</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/> માંથી <ph name="RESULT_NUMBER"/> પરિણામ</translation>
+<translation id="4943872375798546930">પરિણામો નથી</translation>
+<translation id="981121421437150478">ઑફલાઇન</translation>
+<translation id="3298243779924642547">લાઇટ</translation>
+<translation id="393697183122708255">કોઈ સક્ષમ વૉઇસ શોધ ઉપલબ્ધ નથી</translation>
+<translation id="7191430249889272776">ટેબ પૃષ્ઠભૂમિમાં ખોલવામાં આવ્યું છે.</translation>
+<translation id="8445059357334030806">Brave માં ખોલો</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/> માં ખોલો</translation>
+<translation id="7022756207310403729">બ્રાઉઝરમાં ખોલો</translation>
+<translation id="1113597929977215864">સરળ દૃશ્ય બતાવો</translation>
+<translation id="1513352483775369820">બુકમાર્ક્સ અને વેબ ઇતિહાસ</translation>
+<translation id="4939482511480190003">Braveને બહેતર બનાવવામાં સહાય કરો. <ph name="BEGIN_LINK"/>સર્વેક્ષણમાં ભાગ લો<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">પાછા જાઓ</translation>
+<translation id="5596627076506792578">વધુ વિકલ્પો</translation>
+<translation id="3522247891732774234">અપડેટ ઉપલબ્ધ છે. વધુ વિકલ્પો</translation>
+<translation id="6773423637732432200">Brave અપડેટ કરી શકાતું નથી. વધુ વિકલ્પો</translation>
+<translation id="3328801116991980348">સાઇટ માહિતી</translation>
+<translation id="5391532827096253100">આ સાઇટ સાથેનું તમારું કનેક્શન સુરક્ષિત નથી. સાઇટની માહિતી</translation>
+<translation id="6206551242102657620">કનેક્શન સુરક્ષિત છે. સાઇટની માહિતી</translation>
+<translation id="6963642900430330478">આ પેજ જોખમી છે. સાઇટની માહિતી</translation>
+<translation id="9070377983101773829">વૉઇસ શોધ પ્રારંભ કરો</translation>
+<translation id="8676374126336081632">ઇનપુટ સાફ કરો</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> ખુલ્લી ટૅબ, ટૅબને સ્વિચ કરવા માટે ટૅપ કરો}one{<ph name="OPEN_TABS_MANY"/> ખુલ્લી ટૅબ, ટૅબને સ્વિચ કરવા માટે ટૅપ કરો}other{<ph name="OPEN_TABS_MANY"/> ખુલ્લી ટૅબ, ટૅબને સ્વિચ કરવા માટે ટૅપ કરો}}</translation>
+<translation id="2369533728426058518">ટૅબ્સ ખોલો</translation>
+<translation id="7071521146534760487">એકાઉન્ટને મેનેજ કરો</translation>
+<translation id="932327136139879170">હોમ</translation>
+<translation id="2707726405694321444">પેજ રિફ્રેશ કરો</translation>
+<translation id="2891154217021530873">પૃષ્ઠ લોડ કરવાનું રોકો</translation>
+<translation id="6710213216561001401">પાછલી</translation>
+<translation id="6659594942844771486">ટૅબ</translation>
+<translation id="1933845786846280168">પસંદ કરેલ ટૅબ</translation>
+<translation id="2268044343513325586">સુધારો</translation>
+<translation id="7846076177841592234">પસંદગી રદ કરો</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/>ની પસંદગી કરી. સ્ક્રીનના ટોચની નજીક વિકલ્પો ઉપલબ્ધ છે</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/>ની પસંદગી કરી</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{પસંદ કરેલ 1 આઇટમ શેર કરો}one{પસંદ કરેલ # આઇટમ શેર કરો}other{પસંદ કરેલ # આઇટમ શેર કરો}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{પસંદ કરેલ 1 આઇટમ દૂર કરો}one{પસંદ કરેલ # આઇટમ દૂર કરો}other{પસંદ કરેલ # આઇટમ દૂર કરો}}</translation>
+<translation id="1283039547216852943">વિસ્તૃત કરવા માટે ટૅપ કરો</translation>
+<translation id="5962718611393537961">સંકુચિત કરવા માટે ટૅપ કરો</translation>
+<translation id="8076492880354921740">ટૅબ્સ</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 પસંદ કરી}one{# પસંદ કરી}other{# પસંદ કરી}}</translation>
+<translation id="6818926723028410516">આઇટમ પસંદ કરો</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/> પર પાછા આવવા માટે ટચ કરો</translation>
+<translation id="6766758767654711248">સાઇટ પર જવા માટે ટૅપ કરો</translation>
+<translation id="429312253194641664">સાઇટ મીડિયા ચલાવી રહી છે</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/>, તમારી સ્ક્રીન શેર કરી રહ્યું છે</translation>
+<translation id="8833831881926404480">સાઇટ તમારી સ્ક્રીન શેર કરી રહી છે</translation>
+<translation id="9086455579313502267">નેટવર્ક ઍક્સેસ કરવામાં અક્ષમ છે</translation>
+<translation id="938850635132480979">ભૂલ: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/> માં ખોલો</translation>
+<translation id="548278423535722844">નકશા અ‍ૅપ્લિકેશનમાં ખોલો</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> માં ઇમેઇલ બનાવો</translation>
+<translation id="7875915731392087153">ઇમેઇલ બનાવો</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> માં ઇવેન્ટ બનાવો</translation>
+<translation id="2900528713135656174">ઇવેન્ટ બનાવો</translation>
+<translation id="2111511281910874386">પૃષ્ઠ પર જાઓ</translation>
+<translation id="3988466920954086464">ઝટપટ શોધ પરિણામો આ પૅનલમાં જુઓ</translation>
+<translation id="2744248271121720757">ઝટપટ શોધ કરવા માટે શબ્દ પર ટૅપ કરો અથવા સંબંધિત ક્રિયાઓ જુઓ</translation>
+<translation id="9155898266292537608">તમે કોઈએક શબ્દ પર ટૅપ કરીને પણ ઝડપથી શોધી શકો છો</translation>
+<translation id="3232754137068452469">વેબ ઍપ</translation>
+<translation id="1430915738399379752">પ્રિન્ટ</translation>
+<translation id="3775705724665058594">તમારા ડિવાઇસ પર મોકલો</translation>
+<translation id="6364438453358674297">ઇતિહાસમાંથી સૂચનને દૂર કરીએ?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> બંધ કર્યું છે</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> ટેબ્સ બંધ કર્યા</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> કાઢી નાખી</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> બુકમાર્ક્સ કાઢી નાખ્યાં</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> ડાઉનલોડ કાઢી નાખ્યાં</translation>
+<translation id="1248710015876067820">અસમર્થિત સંખ્યામાં Brave આવૃત્તિઓ.</translation>
+<translation id="4259722352634471385">નેવિગેશન અવરોધિત છે: <ph name="URL"/></translation>
+<translation id="8959122750345127698">નેવિગેશન બિનપહોંચ યોગ્ય છે: <ph name="URL"/></translation>
+<translation id="5210365745912300556">ટૅબ બંધ કરો</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/>ને બંધ કરો</translation>
+<translation id="1227058898775614466">નૅવિગેશન ઇતિહાસ</translation>
+<translation id="9169507124922466868">નૅવિગેશન ઇતિહાસ અડધા ભાગમાં ખુલ્લો છે</translation>
+<translation id="1327257854815634930">નૅવિગેશન ઇતિહાસ ખુલ્લો છે</translation>
+<translation id="8788265440806329501">નૅવિગેશન ઇતિહાસ બંધ છે</translation>
+<translation id="7482656565088326534">પ્રીવ્યૂ ટૅબ</translation>
+<translation id="8427875596167638501">પ્રીવ્યૂ ટૅબ અડધી ઊંચાઈએ ખુલી</translation>
+<translation id="9102803872260866941">પ્રીવ્યૂની ટૅબ ખોલવામાં આવી</translation>
+<translation id="2942036813789421260">પ્રીવ્યૂની ટૅબ બંધ કરવામાં આવી</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> સ્ટોરેજ</translation>
+<translation id="3822502789641063741">સાઇટ સ્ટોરેજ સાફ કરીએ?</translation>
+<translation id="9205995714227143200">Brave ને મહત્વનું ન લાગતું સાઇટ સ્ટોરેજ (ઉદા., કોઇ સાચવેલ સેટિંગ્સ ન હોય તેવી અથવા વારંવાર મુલાકાત ન લેવાતી હોય તેવી સાઇટ્સ)</translation>
+<translation id="3997476611815694295">બિનમહત્વપૂર્ણ સ્ટોરેજ</translation>
+<translation id="8493948351860045254">સ્થાન ખાલી કરો</translation>
+<translation id="2324920234469020158">આ કુકી, કૅશ અને Braveને લાગતું હોય કે આ મહત્વનું નથી એવા સાઇટના બીજા ડેટાને સાફ કરશે.</translation>
+<translation id="5447201525962359567">કુકીઝ અને અન્ય સ્થાનિક રીતે સંગ્રહિત કરેલ ડેટા સહિત, બધું સાઇટ સ્ટોરેજ</translation>
+<translation id="1376578503827013741">ગણતરી કરી રહ્યાં છે…</translation>
+<translation id="583281660410589416">અજ્ઞાત</translation>
+<translation id="2323763861024343754">સાઇટ સ્ટોરેજ</translation>
+<translation id="3587672679800759167">Brave દ્વારા ઉપયોગમાં લેવાયેલ કુલ સ્ટોરેજ, એકાઉન્ટ્સ, બુકમાર્ક્સ અને સાચવેલ સેટિંગ્સ સહિત</translation>
+<translation id="6545017243486555795">બધો ડેટા સાફ કરો</translation>
+<translation id="4095146165863963773">ઍપ મેમરીન ડેટા ડિલીટ કરી દઈએ?</translation>
+<translation id="53119194224775367">Brave નો તમામ ઍપ્લિકેશન ડેટા કાયમીરૂપે કાઢી નાખવામાં આવશે. આમાં તમામ ફાઇલો, સેટિંગ્સ, એકાઉન્ટ, ડેટાબેઝ, વગેરેનો સમાવેશ થાય છે.</translation>
+<translation id="5307446750509046227">સાઇટ સ્ટોરેજ સાફ કરો</translation>
+<translation id="300526633675317032">આ <ph name="SIZE_IN_KB"/> નું બધું વેબસાઇટ સ્ટોરેજ સાફ કરશે.</translation>
+<translation id="8068648041423924542">પ્રમાણપત્ર પસંદ કરવામાં અસમર્થ.</translation>
+<translation id="2315043854645842844">ઓપરેટિંગ સિસ્ટમ દ્વારા ક્લાઇન્ટ તરફની પ્રમાણપત્ર પસંદગી સપોર્ટ કરતી નથી.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/>, કનેક્ટ કરવા માગે છે</translation>
+<translation id="5308380583665731573">કનેક્ટ કરો</translation>
+<translation id="868929229000858085">તમારા સંપર્કો શોધો</translation>
+<translation id="1919950603503897840">સંપર્કો પસંદ કરો</translation>
+<translation id="7986741934819883144">સંપર્ક પસંદ કરો</translation>
+<translation id="3333961966071413176">બધા સંપર્કો</translation>
+<translation id="4994033804516042629">કોઈ સંપર્કો મળ્યા નથી</translation>
+<translation id="5403592356182871684">નામ</translation>
+<translation id="2717722538473713889">ઇમેઇલ ઍડ્રેસ</translation>
+<translation id="381841723434055211">ફોન નંબર</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ વધુ 1)}one{(+ વધુ #)}other{(+ વધુ #)}}</translation>
+<translation id="5197729504361054390">તમે પસંદ કરશો તે સંપર્કોને <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> સાથે શેર કરવામાં આવશે.</translation>
+<translation id="1779089405699405702">છબી ડીકોડર</translation>
+<translation id="8067883171444229417">વીડિયો ચલાવો</translation>
+<translation id="6560414384669816528">Sogou થી શોધો</translation>
+<translation id="5406914950576900927">Brave, ચાઇનામાં શોધ માટે <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> નો ઉપયોગ કરી શકે છે. તમે આને <ph name="BEGIN_LINK"/>સેટિંગ્સ<ph name="END_LINK"/>માં બદલી શકો છો.</translation>
+<translation id="6456271171669383967">Brave Software રાખો</translation>
+<translation id="4384468725000734951">શોધ માટે Sogou નો ઉપયોગ કરી રહ્યાં છે</translation>
+<translation id="6103327872225198548">શોધ માટે Brave Software નો ઉપયોગ કરી રહ્યાં છે</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">આ ઍપ Braveમાં ચાલી રહી છે</translation>
+<translation id="6143689084714664628">Braveમાં ચાલી રહ્યું છે</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> નો ડેટા Braveમાં પણ છે</translation>
+<translation id="2734140769649165081">Brave સેટિંગમાં તમે ડેટા સાફ કરી શકો છો</translation>
+<translation id="8232956427053453090">ડેટા રાખો</translation>
+<translation id="4298388696830689168">લિંક કરેલી સાઇટ</translation>
+<translation id="5763514718066511291">આ ઍપ માટેની URL કૉપિ કરવા માટે ટૅપ કરો</translation>
+<translation id="6496823230996795692">પહેલી વખત <ph name="APP_NAME"/>નો ઉપયોગ કરવા માટે, કૃપા કરીને ઇન્ટરનેટ સાથે કનેક્ટ કરો.</translation>
+<translation id="751961395872307827">સાઇટ સાથે કનેક્ટ કરી શકાતું નથી</translation>
+<translation id="4878404682131129617">પ્રૉક્સી સર્વર મારફતે એક ટનલને સ્થાપિત કરવું નિષ્ફળ થયું</translation>
+<translation id="4749960740855309258">એક નવું ટૅબ ખોલો</translation>
+<translation id="8788968922598763114">છેલ્લે બંધ કરેલ ટૅબ ફરીથી ખોલો</translation>
+<translation id="7929962904089429003">મેનૂ ખોલો</translation>
+<translation id="6039379616847168523">આગલા ટૅબ પર જાઓ</translation>
+<translation id="5210286577605176222">પાછલી ટૅબ પર જાઓ</translation>
+<translation id="124678866338384709">વર્તમાન ટૅબ બંધ કરો</translation>
+<translation id="3714981814255182093">શોધો બાર ખોલો</translation>
+<translation id="5441522332038954058">સરનામાં બાર પર જાઓ</translation>
+<translation id="3398320232533725830">બુકમાર્ક્સ સંચાલક ખોલો</translation>
+<translation id="6583199322650523874">વર્તમાન પૃષ્ઠને બુકમાર્ક કરો</translation>
+<translation id="8489271220582375723">ઇતિહાસ પૃષ્ઠ ખોલો</translation>
+<translation id="4837753911714442426">પેજને પ્રિન્ટ કરવાના વિકલ્પો ખોલો</translation>
+<translation id="5726692708398506830">પૃષ્ઠ પરની તમામ સામગ્રીને મોટી કરો</translation>
+<translation id="3259831549858767975">પૃષ્ઠ પરની તમામ સામગ્રીને નાની કરો</translation>
+<translation id="8015452622527143194">પેજ પરનું બધું કન્ટેન્ટ પાછું ડિફૉલ્ટ કદમાં બદલો</translation>
+<translation id="3443221991560634068">વર્તમાન પૃષ્ઠ ફરીથી લોડ કરો</translation>
+<translation id="123724288017357924">કૅશ કરેલ કન્ટેન્ટને અવગણીને વર્તમાન પેજ ફરીથી લોડ કરો</translation>
+<translation id="305870044889644984">Brave સહાયતા કેન્દ્રમાં એક નવું ટૅબ ખોલો</translation>
+<translation id="3166827708714933426">ટૅબ અને વિંડો શૉર્ટકટ્સ</translation>
+<translation id="3169981355900570544">Brave Software Brave સુવિધાના શૉર્ટકટ્સ</translation>
+<translation id="4558311620361989323">વેબ પેજના શૉર્ટકટ</translation>
+<translation id="1908301351964700579">Brave હજી પણ VR માટે તૈયારી કરી રહ્યું છે. Braveને પછી ફરી શરૂ કરો.</translation>
+<translation id="8970887620466824814">કંઈક ખોટું થયું.</translation>
+<translation id="1875543012935658554">Brave ફરીથી ખોલો.</translation>
+<translation id="79859296434321399">ઑગ્મેન્ટેડ રિયાલિટી કન્ટેન્ટ જોવા માટે, ARCore ઇન્સ્ટૉલ કરો</translation>
+<translation id="8558485628462305855">ઑગ્મેન્ટેડ રિયાલિટી કન્ટેન્ટ જોવા માટે ARCore અપડેટ કરો</translation>
+<translation id="3513704683820682405">ઑગ્મેન્ટેડ રિયાલિટી</translation>
+<translation id="5475862044948910901">ઑગ્મેન્ટેડ રિયાલિટી સત્ર શરૂ કરીએ?</translation>
 <translation id="7365126855094612066">આ સત્રના સમયગાળા દરમ્યાન, સાઇટ નીચે જણાવેલી પ્રવૃત્તિ કરી શકશે:
 • તમારી આસપાસનો 3D નકશો બનાવી શકે છે
 • કૅમેરા મોશનને ટ્રૅક કરી શકે છે
 
 સાઇટ કૅમેરાને ઍક્સેસ કરતી નથી. કૅમેરામાં રહેલા ફોટાને માત્ર તમે જ જોઈ શકશો.</translation>
-<translation id="7375125077091615385">પ્રકાર:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome પ્રથમ વાર ઉપયોગ કર્યાનો અનુભવ</translation>
-<translation id="741204030948306876">હા, હું સંમત છું</translation>
-<translation id="7413229368719586778">પ્રારંભ તારીખ <ph name="DATE" /></translation>
-<translation id="7423098979219808738">પ્રથમ પૂછો</translation>
-<translation id="7423538860840206698">ક્લિપબોર્ડ વાંચવાનું બ્લૉક કરેલ છે</translation>
-<translation id="7431991332293347422">શોધ અને અન્ય બાબતોને તમને મનગમતી બનાવવા માટે તમારા બ્રાઉઝિંગ ઇતિહાસનો ઉપયોગ કરવાની રીત નિયંત્રિત કરો</translation>
-<translation id="7437998757836447326">Chromeમાંથી સાઇન આઉટ કરો</translation>
-<translation id="7438641746574390233">જ્યારે લાઇટ મોડ ચાલુ હોય છે, ત્યારે Chrome પેજ લોડ થવાની ક્રિયાને વધુ ઝડપી બનાવવા માટે Google સર્વરનો ઉપયોગ કરે છે. લાઇટ મોડ ફક્ત જરૂરી કન્ટેન્ટને લોડ કરવા માટે ખૂબ ધીમા પેજને ફરીથી લખે છે. લાઇટ મોડ, છૂપા મોડમાં લાગુ થતું નથી.</translation>
-<translation id="7444811645081526538">વધુ કૅટેગરી</translation>
-<translation id="7445411102860286510">સાઇટ્સને આપમેળે મ્યૂટ કરેલ વિડિઓઝને ચલાવવાની મંજૂરી આપો (ભલામણ કરેલ)</translation>
-<translation id="7453467225369441013">તમને મોટાભાગની સાઇટોમાંથી સાઇન આઉટ કરે છે. તમે તમારા Google એકાઉન્ટમાંથી સાઇન આઉટ નહિ થાઓ.</translation>
-<translation id="7454641608352164238">પર્યાપ્ત જગ્યા નથી</translation>
-<translation id="7475192538862203634">જો તમે આ વારંવાર જોઈ રહ્યાં છો, તો આ <ph name="BEGIN_LINK" />સૂચનો<ph name="END_LINK" />ને અજમાવી જુઓ.</translation>
-<translation id="7475688122056506577">SD કાર્ડ મળ્યું નથી. તમારી અમુક ફાઇલો ખૂટતી હોઈ શકે છે.</translation>
-<translation id="7479104141328977413">ટૅબ મેનેજમેન્ટ</translation>
-<translation id="7481312909269577407">ફોર્વર્ડ કરો</translation>
-<translation id="7482656565088326534">પ્રીવ્યૂ ટૅબ</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (અપડેટ કર્યું <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">ડેટા બચત</translation>
-<translation id="7498271377022651285">કૃપા કરીને રાહ જુઓ…</translation>
-<translation id="7514365320538308">ડાઉનલોડ કરો</translation>
-<translation id="751961395872307827">સાઇટ સાથે કનેક્ટ કરી શકાતું નથી</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">સૂચનો મેળવી શકતાં નથી</translation>
-<translation id="7559975015014302720">લાઇટ મોડ બંધ છે</translation>
-<translation id="7562080006725997899">બ્રાઉઝિંગ ડેટા સાફ કરો</translation>
-<translation id="756809126120519699">Chrome ડેટા સાફ કર્યો</translation>
-<translation id="757524316907819857">સાઇટને સંરક્ષિત કન્ટેન્ટ ચલાવવાથી બ્લૉક કરો</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> ફાઇલ ડાઉનલોડ કરી}one{<ph name="FILES_DOWNLOADED_MANY" /> ફાઇલ ડાઉનલોડ કરી}other{<ph name="FILES_DOWNLOADED_MANY" /> ફાઇલ ડાઉનલોડ કરી}}</translation>
-<translation id="7588219262685291874">જ્યારે તમારા ડિવાઇસનું બૅટરી સેવર ચાલુ હોય ત્યારે ઘેરી થીમ ચાલુ કરો</translation>
-<translation id="7589445247086920869">હાલનું શોધ એંજિન અવરોધિત કરો</translation>
-<translation id="7593557518625677601">Chrome સિંક શરૂ કરવા Android સેટિંગ ખોલો અને Android સિસ્ટમ સિંક ફરી ચાલુ કરો</translation>
-<translation id="7596558890252710462">ઓપરેટિંગ સિસ્ટમ</translation>
-<translation id="7605594153474022051">સમન્વયન કામ કરતું નથી</translation>
-<translation id="7606077192958116810">લાઇટ મોડ ચાલુ છે. તેને સેટિંગમાં મેનેજ કરો.</translation>
-<translation id="7612619742409846846">Google પર આ તરીકે સાઇન ઇન કરો</translation>
-<translation id="7619072057915878432">નેટવર્ક નિષ્ફળતાને કારણે <ph name="FILE_NAME" /> ડાઉનલોડ નિષ્ફળ થયું.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />સહાય મેળવો<ph name="END_LINK1" /> અથવા <ph name="BEGIN_LINK2" />ફરીથી સ્કેન કરો<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome પર આપનું સ્વાગત છે</translation>
-<translation id="7638584964844754484">ખોટો પાસફ્રેઝ</translation>
-<translation id="7641339528570811325">બ્રાઉઝિંગ ડેટા સાફ કરો…</translation>
-<translation id="7648422057306047504">Google લૉગ ઇન વિગત સાથે પાસવર્ડને એન્ક્રિપ્ટ કરો</translation>
-<translation id="7649070708921625228">સહાય</translation>
-<translation id="7658239707568436148">રદ કરો</translation>
-<translation id="7665369617277396874">એકાઉન્ટ ઉમેરો</translation>
-<translation id="766587987807204883">લેખો અહીં દેખાય છે, જે તમે ઑફલાઇન હો ત્યારે પણ વાંચી શકો છો</translation>
-<translation id="7682724950699840886">નીચેની ટિપ અજમાવી જુઓ: ખાતરી કરો કે તમારા ઉપકરણ પર પૂરતી સ્પેસ છે, ફરીથી નિકાસ કરવાનો પ્રયાસ કરો.</translation>
-<translation id="7685301384041462804">VR મોડમાં દાખલ થતા પહેલાં ખાતરી કરો કે તમે આ સાઇટ પર વિશ્વાસ કરો છો.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> માં ઇમેઇલ બનાવો</translation>
-<translation id="7704317875155739195">શોધ અને URLsને આપમેળે પૂર્ણ કરો</translation>
-<translation id="7725024127233776428">બુકમાર્ક કરેલા પેજ અહીં દેખાય છે</translation>
-<translation id="773466115871691567">હંમેશાં પેજનો <ph name="SOURCE_LANGUAGE" />માં અનુવાદ કરો</translation>
-<translation id="7746457520633464754">જોખમી ઍપ અને સાઇટ શોધી કાઢવા માટે, Chrome તમે મુલાકાત લો તે કેટલાક પેજના URLs, સિસ્ટમ વિશેની સીમિત માહિતી અને પેજનું કેટલુંક કન્ટેન્ટ Googleને મોકલે છે</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" />માંથી ટેક્સ્ટ શેર કરી</translation>
-<translation id="7762668264895820836">SD કાર્ડ <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">સરનામું ઉમેરો</translation>
-<translation id="7772032839648071052">પાસફ્રેઝની પુષ્ટિ કરો</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" />ને બંધ કરો</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 અને વધુ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">ગઈ કાલે</translation>
-<translation id="7791543448312431591">ઉમેરો</translation>
-<translation id="780301667611848630">નહીં, આભાર</translation>
-<translation id="7810647596859435254">આની સાથે ખોલો…</translation>
-<translation id="7821588508402923572">તમારી ડેટા બચત અહીં દેખાશે</translation>
-<translation id="7837721118676387834">કોઈ ચોક્કસ સાઇટ માટે મ્યૂટ કરેલ વિડિઓઝને ઑટોપ્લેની મંજૂરી આપો.</translation>
-<translation id="7846076177841592234">પસંદગી રદ કરો</translation>
-<translation id="784934925303690534">સમય શ્રેણી</translation>
-<translation id="7851858861565204677">અન્ય ઉપકરણો</translation>
-<translation id="7875915731392087153">ઇમેઇલ બનાવો</translation>
-<translation id="7876243839304621966">બધું દૂર કરો</translation>
-<translation id="7882131421121961860">કોઈ ઇતિહાસ મળ્યો નથી</translation>
-<translation id="7882806643839505685">કોઈ એક ચોક્કસ સાઇટ માટે અવાજ ચલાવવાની મંજૂરી આપો.</translation>
-<translation id="7886917304091689118">Chromeમાં ચાલી રહ્યું છે</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ફાઇલ ડાઉનલોડ કરી રહ્યાં છીએ.}one{# ફાઇલ ડાઉનલોડ કરી રહ્યાં છે.}other{# ફાઇલ ડાઉનલોડ કરી રહ્યાં છે.}}</translation>
-<translation id="7929962904089429003">મેનૂ ખોલો</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> જૂનું થઈ ગયું છે.</translation>
-<translation id="7947953824732555851">સ્વીકારો અને સાઇન ઇન કરો</translation>
-<translation id="7963646190083259054">વિક્રેતા:</translation>
-<translation id="7971136598759319605">1 દિવસ પહેલાં સક્રિય હતું</translation>
-<translation id="7975379999046275268">પેજને પ્રીવ્યૂ કરો <ph name="BEGIN_NEW" />નવું<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">ઝડપી બ્રાઉઝિંગ અને શોધ માટે પેજને પહેલેથી લોડ કરો</translation>
-<translation id="79859296434321399">ઑગ્મેન્ટેડ રિયાલિટી કન્ટેન્ટ જોવા માટે, ARCore ઇન્સ્ટૉલ કરો</translation>
-<translation id="7986741934819883144">સંપર્ક પસંદ કરો</translation>
-<translation id="7987073022710626672">Chrome સેવાની શરતો</translation>
-<translation id="7998918019931843664">બંધ કરેલ ટેબ ફરીથી ખોલો</translation>
-<translation id="7999064672810608036">શું તમે ખરેખર કૂકીઝ સહિત આ વેબસાઇટ માટેનો બધો ડેટા સાફ કરી અને આ વેબસાઇટ માટેની બધી પરવાનગીઓ ફરીથી સેટ કરવા માગો છો?</translation>
-<translation id="8004582292198964060">બ્રાઉઝર</translation>
-<translation id="8007176423574883786">આ ઉપકરણ માટે બંધ કર્યું</translation>
-<translation id="8013372441983637696">આ ડિવાઇસમાંથી તમારો Chrome ડેટા પણ સાફ કરો</translation>
-<translation id="8015452622527143194">પેજ પરનું બધું કન્ટેન્ટ પાછું ડિફૉલ્ટ કદમાં બદલો</translation>
-<translation id="802154636333426148">ડાઉનલોડ નિષ્ફળ થયું</translation>
-<translation id="8026334261755873520">બ્રાઉઝિંગ ડેટા સાફ કરો</translation>
-<translation id="8035133914807600019">નવું ફોલ્ડર...</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> દિવસ બાકી</translation>
-<translation id="804335162455518893">SD કાર્ડ મળ્યું નથી</translation>
-<translation id="805047784848435650">તમારા બ્રાઉઝિંગ ઇતિહાસના આધારે</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB ઉપલબ્ધ</translation>
-<translation id="8058746566562539958">નવા Chrome ટૅબમાં ખોલો</translation>
-<translation id="8063895661287329888">બુકમાર્ક ઉમેરવામાં નિષ્ફળ થયાં.</translation>
-<translation id="806745655614357130">મારા ડેટાને અલગ રાખો</translation>
-<translation id="8067883171444229417">વીડિયો ચલાવો</translation>
-<translation id="8068648041423924542">પ્રમાણપત્ર પસંદ કરવામાં અસમર્થ.</translation>
-<translation id="8073388330009372546">નવા ટેબમાં છબી ખોલો</translation>
-<translation id="8076492880354921740">ટૅબ્સ</translation>
-<translation id="8084114998886531721">સાચવેલ પાસવર્ડ</translation>
-<translation id="8087000398470557479">આ કન્ટેન્ટ <ph name="DOMAIN_NAME" /> માંથી, Google દ્વારા વિતરિત કરેલ છે.</translation>
-<translation id="8103578431304235997">છૂપું ટૅબ</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">તમારા બધા ઉપકરણો પર તમારા બુકમાર્ક મેળવવા માટે, સિંક કરવાનું ચાલુ કરો</translation>
-<translation id="8110087112193408731">શું તમારી Chromeની પ્રવૃત્તિ ડિજિટલ લાઇફસ્ટાઇલમાં બતાવીએ?</translation>
-<translation id="8116925261070264013">મ્યૂટ કરેલ</translation>
-<translation id="813082847718468539">સ્થાન માહિતી જુઓ</translation>
-<translation id="8131740175452115882">પુષ્ટિ કરો</translation>
-<translation id="8156139159503939589">તમે કઈ ભાષાઓ વાંચી શકો છો?</translation>
-<translation id="8168435359814927499">કન્ટેન્ટ</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> ફાઇલ બાકી છે</translation>
-<translation id="8190358571722158785">1 દિવસ બાકી</translation>
-<translation id="8200772114523450471">રિઝ્યુમે</translation>
-<translation id="8209050860603202033">છબી ખોલો</translation>
-<translation id="8218622182176210845">તમારું એકાઉન્ટ મેનેજ કરો</translation>
-<translation id="8224471946457685718">વાઇ-ફાઇ પર તમારા માટે લેખ ડાઉનલોડ કરો</translation>
-<translation id="8232956427053453090">ડેટા રાખો</translation>
-<translation id="8249310407154411074">ટોચે ખસેડો</translation>
-<translation id="8250920743982581267">દસ્તાવેજો</translation>
-<translation id="825412236959742607">આ પેજ મેમરીનો બહુ ઉપયોગ કરે છે, તેથી Chromeએ કેટલુંક કન્ટેન્ટ કાઢી નાખ્યું છે.</translation>
-<translation id="8260126382462817229">ફરીથી સાઇન ઇન કરવાનો પ્રયાસ કરો</translation>
-<translation id="8261506727792406068">ડિલીટ કરો</translation>
-<translation id="8266862848225348053">સ્થાન ડાઉનલોડ કરો</translation>
-<translation id="8274165955039650276">ડાઉનલોડ જુઓ</translation>
-<translation id="8284326494547611709">કૅપ્શન્સ</translation>
-<translation id="8300705686683892304">ઍપ દ્વારા મેનેજ થતી</translation>
-<translation id="8310344678080805313">માનક ટેબ્સ</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> અને વધુ સાઇટ</translation>
-<translation id="8327155640814342956">બ્રાઉઝિંગનો શ્રેષ્ઠ અનુભવ મેળવવા અપડેટ કરવા માટે Chrome ખોલો</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" />માં છે તે પેજનો અનુવાદ થશે નહીં</translation>
-<translation id="8349013245300336738">વપરાયેલ ડેટાના પ્રમાણ અનુસાર સૉર્ટ કરો</translation>
-<translation id="8364299278605033898">લોકપ્રિય વેબસાઇટ જુઓ</translation>
-<translation id="8368027906805972958">અજાણ્યું અથવા અસમર્થિત ડિવાઇસ (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">ચોક્કસ સાઇટ માટે પૃષ્ઠભૂમિ સમન્વયનની મંજૂરી આપો.</translation>
-<translation id="8378714024927312812">તમારી સંસ્થા દ્વારા મેનેજ કરેલ</translation>
-<translation id="8380167699614421159">આ સાઇટ ઘૃણાસ્પદ અથવા ભ્રામક જાહેરાતો બતાવે છે</translation>
-<translation id="8393700583063109961">સંદેશ મોકલો</translation>
-<translation id="8413126021676339697">પૂર્ણ ઇતિહાસ બતાવો</translation>
-<translation id="8427875596167638501">પ્રીવ્યૂ ટૅબ અડધી ઊંચાઈએ ખુલી</translation>
-<translation id="8428213095426709021">સેટિંગ્સ</translation>
-<translation id="8438566539970814960">શોધ અને બ્રાઉઝિંગ વધુ સારું બનાવો</translation>
-<translation id="8441146129660941386">પાછળ કરો</translation>
-<translation id="8443209985646068659">Chrome અપડેટ કરી શકતા નથી</translation>
-<translation id="8445448999790540984">બધા પાસવર્ડ નિકાસ કરી શકાતાં નથી</translation>
-<translation id="8447861592752582886">ઉપકરણની પરવાનગી રદબાતલ કરો</translation>
-<translation id="8461694314515752532">તમારા પોતાના સિંક પાસફ્રેઝ સાથે સિંક કરેલા ડેટાને એન્ક્રિપ્ટ કરો</translation>
-<translation id="8466613982764129868">ખાતરી કરો કે <ph name="TARGET_DEVICE_NAME" />ને ઇન્ટરનેટ સાથે કનેક્ટ કરેલું છે</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ઑફલાઇન ઉપલબ્ધ</translation>
-<translation id="8489271220582375723">ઇતિહાસ પૃષ્ઠ ખોલો</translation>
-<translation id="8493948351860045254">સ્થાન ખાલી કરો</translation>
-<translation id="8497726226069778601">હજી સુધી... અહીં જોવા માટે કંઈ નથી</translation>
-<translation id="8503559462189395349">Chrome પાસવર્ડ</translation>
-<translation id="8503813439785031346">વપરાશકર્તાનામ</translation>
-<translation id="8514477925623180633">Chromeમાં સંગ્રહિત કરેલા પાસવર્ડની નિકાસ કરો</translation>
-<translation id="8514577642972634246">છુપા મોડમાં દાખલ થાઓ</translation>
-<translation id="851751545965956758">સાઇટને ઉપકરણો સાથે કનેક્ટ થવાથી બ્લૉક કરો</translation>
-<translation id="8523928698583292556">સંગ્રહિત કરેલ પાસવર્ડ ડિલીટ કરો</translation>
-<translation id="854522910157234410">આ પૃષ્ઠ ખોલો</translation>
-<translation id="8558485628462305855">ઑગ્મેન્ટેડ રિયાલિટી કન્ટેન્ટ જોવા માટે ARCore અપડેટ કરો</translation>
-<translation id="8559990750235505898">પેજનો અન્ય ભાષાઓમાં અનુવાદ કરવાની ઑફર કરો</translation>
-<translation id="8562452229998620586">તમારા સાચવેલા પાસવર્ડ્સ અહીં દેખાશે.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> થી</translation>
-<translation id="8571213806525832805">છેલ્લા 4 અઠવાડિયા</translation>
-<translation id="857943718398505171">મંજૂર (ભલામણ કરેલ)</translation>
-<translation id="8583805026567836021">એકાઉન્ટ ડેટા સાફ કરી રહ્યું છે</translation>
-<translation id="860043288473659153">કાર્ડધારકનું નામ</translation>
-<translation id="8609465669617005112">ઉપર ખસેડો</translation>
-<translation id="8616006591992756292">તમારા Google એકાઉન્ટમાં <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> પર બ્રાઉઝિંગ ઇતિહાસના બીજા સ્વરૂપો હોય શકે.</translation>
-<translation id="8617240290563765734">ડાઉનલોડ કરેલી કન્ટેન્ટમાં ઉલ્લેખિત, સૂચવેલ URL ખોલીએ?</translation>
-<translation id="8636825310635137004">તમારા અન્ય ઉપકરણો પરથી તમારા ટૅબ્સ મેળવવા માટે, સમન્વયન ચાલુ કરો.</translation>
-<translation id="8641930654639604085">વયસ્ક સાઇટને અવરોધિત કરવાનો પ્રયાસ કરો</translation>
-<translation id="8655129584991699539">Chrome સેટિંગમાં તમે ડેટા સાફ કરી શકો છો</translation>
-<translation id="8662811608048051533">તમને મોટાભાગની સાઇટોમાંથી સાઇન આઉટ કરે છે.</translation>
-<translation id="8664979001105139458">ફાઇલનું નામ પહેલેથી અસ્તિત્વમાં છે</translation>
-<translation id="8676374126336081632">ઇનપુટ સાફ કરો</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{સિગ્નલની ક્ષમતાનું સ્તર: # બાર}one{સિગ્નલની ક્ષમતાનું સ્તર: # બાર}other{સિગ્નલની ક્ષમતાનું સ્તર: # બાર}}</translation>
-<translation id="868929229000858085">તમારા સંપર્કો શોધો</translation>
-<translation id="869891660844655955">સમાપ્તિ તારીખ</translation>
-<translation id="8719023831149562936">વર્તમાન ટેબને બીમ કરી શકતાં નથી</translation>
-<translation id="8725066075913043281">ફરી પ્રયાસ કરો</translation>
-<translation id="8728487861892616501">આ ઍપ્લિકેશનનો ઉપયોગ કરીને તમે Chromeની <ph name="BEGIN_LINK1" />સેવાની શરતો<ph name="END_LINK1" /> અને <ph name="BEGIN_LINK2" />ગોપનીયતા સૂચના<ph name="END_LINK2" /> અને <ph name="BEGIN_LINK3" />Family Link દ્વારા મેનેજ થતા Google એકાઉન્ટ્સ માટેની ગોપનીયતા સૂચના<ph name="END_LINK3" /> સાથે સંમત થાઓ છો.</translation>
-<translation id="8730621377337864115">થઈ ગયું</translation>
-<translation id="8748850008226585750">સામગ્રીઓ છુપાવેલ છે</translation>
-<translation id="8751914237388039244">છબી પસંદ કરો</translation>
-<translation id="8788265440806329501">નૅવિગેશન ઇતિહાસ બંધ છે</translation>
-<translation id="8788968922598763114">છેલ્લે બંધ કરેલ ટૅબ ફરીથી ખોલો</translation>
-<translation id="8801436777607969138">કોઈ ચોક્કસ સાઇટ માટે JavaScriptને બ્લૉક કરો.</translation>
-<translation id="8812260976093120287">કેટલીક વેબસાઇટ પર, તમે સમર્થિત ચુકવણી ઍપ્લિકેશનો વડે ચુકવણી કરી શકો છો.</translation>
-<translation id="8816026460808729765">સાઇટને સેન્સરને ઍક્સેસ કરવાથી બ્લૉક કરો</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chromeમાં ખૂલશે. ચાલુ રાખીને, તમે Chromeની <ph name="BEGIN_LINK1" />સેવાની શરતો<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />ગોપનીયતા સૂચના<ph name="END_LINK2" /> અને <ph name="BEGIN_LINK3" />Family Link દ્વારા મેનેજ થતા Google એકાઉન્ટ માટેની ગોપનીયતા સૂચના<ph name="END_LINK3" /> સાથે સંમત થાઓ છો.</translation>
-<translation id="8820817407110198400">બુકમાર્ક્સ</translation>
-<translation id="8833831881926404480">સાઇટ તમારી સ્ક્રીન શેર કરી રહી છે</translation>
-<translation id="883806473910249246">કન્ટેન્ટ ડાઉનલોડ કરતી વખતે એક ભૂલ આવી.</translation>
-<translation id="8840953339110955557">આ પેજ ઑનલાઇન વર્ઝનથી અલગ હોય શકે છે.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, ટેબ</translation>
-<translation id="885701979325669005">સ્ટોરેજ</translation>
-<translation id="889338405075704026">Chrome સેટિંગ પર જાઓ</translation>
-<translation id="8901170036886848654">કોઇ બુકમાર્ક્સ મળ્યાં નથી</translation>
-<translation id="8909135823018751308">શેર કરો…</translation>
-<translation id="8912362522468806198">Google એકાઉન્ટ</translation>
-<translation id="8920114477895755567">માતાપિતાની વિગતોની રાહ જોઈ રહ્યાં છે.</translation>
+<translation id="1188239144602654184">AR દાખલ કરો</translation>
+<translation id="473775607612524610">અપડેટ કરો</translation>
+<translation id="3133489217401741157">Brave માટે <ph name="MODULE"/> ઇન્સ્ટૉલ કરી રહ્યાં છે…</translation>
+<translation id="1791662854739702043">ઇન્સ્ટોલ કરેલું</translation>
+<translation id="5131234170665854056">Brave માટે <ph name="MODULE"/> ઇન્સ્ટૉલ કરવામાં અસમર્થ</translation>
+<translation id="2567385386134582609">છબી</translation>
+<translation id="6395288395575013217">લિંક</translation>
+<translation id="7352939065658542140">વીડિયો</translation>
+<translation id="4116038641877404294">ઇન્ટરનેટ ન હોય ત્યારે પણ ઉપયોગમાં લેવા માટે પેજ ડાઉનલોડ કરો</translation>
 <translation id="8922289737868596582">વધુ વિકલ્પો બટનની મદદથી પેજ ડાઉનલોડ કરો, જેથી તમે ઇન્ટરનેટ વિના પણ તેનો ઉપયોગ કરી શકો</translation>
-<translation id="8937772741022875483">તમારી Chromeની પ્રવૃત્તિને ડિજિટલ લાઇફસ્ટાઇલમાંથી કાઢી નાખીએ?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">અન્ય વિંડોમાં ખોલો</translation>
-<translation id="8951232171465285730">Chrome એ તમારો <ph name="MEGABYTES" /> MB ડેટા બચાવ્યો</translation>
-<translation id="8958424370300090006">કોઈ ચોક્કસ સાઇટ માટે કુકીને બ્લૉક કરો.</translation>
-<translation id="8959122750345127698">નેવિગેશન બિનપહોંચ યોગ્ય છે: <ph name="URL" /></translation>
-<translation id="8965591936373831584">બાકી</translation>
-<translation id="8970887620466824814">કંઈક ખોટું થયું.</translation>
-<translation id="8972098258593396643">ડિફૉલ્ટ ફોલ્ડરમાં ડાઉનલોડ કરીએ?</translation>
-<translation id="8986494364107987395">ઉપયોગિતા આંકડાઓ અને ક્રૅશ રિપોર્ટ Googleને ઑટોમૅટિક રીતે મોકલો</translation>
-<translation id="8993760627012879038">છુપા મોડમાં એક નવું ટૅબ ખોલો</translation>
-<translation id="8998729206196772491">તમે <ph name="MANAGED_DOMAIN" /> દ્વારા મેનેજ એકાઉન્ટમાં સાઇન ઇન કરી રહ્યાં છો અને તમારા Chrome ડેટા પર એનું એડમિન નિયંત્રણ આપી રહ્યાં છો. તમારો ડેટા આ એકાઉન્ટ સાથે કાયમીરૂપે જોડાયેલું રહેશે. Chromeમાંથી સાઇન આઉટ કરવું આ ડિવાઇસ પરથી તમારો ડેટા ડિલીટ કરશે, પરંતુ એ તમારા Google એકાઉન્ટમાં સ્ટોર રહેશે.</translation>
-<translation id="9019902583201351841">તમારા માતાપિતા દ્વારા સંચાલિત</translation>
-<translation id="9028914725102941583">બધા ડિવાઇસ પર શેર કરવા માટે 'સિંક કરો'ની સુવિધા ચાલુ કરો</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" />ને VR મોડમાં દાખલ થવાની મંજૂરી આપીએ?</translation>
-<translation id="9040142327097499898">નોટિફિકેશનની મંજૂરી છે. આ ઉપકરણ માટે સ્થાન ઍક્સેસ બંધ છે.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# વીડિયો}one{# વીડિયો}other{# વીડિયો}}</translation>
-<translation id="9050666287014529139">પાસફ્રેઝ</translation>
-<translation id="9063523880881406963">વિનંતી ડેસ્કટૉપ સાઇટ બંધ કરો</translation>
-<translation id="9065203028668620118">ફેરફાર કરો</translation>
-<translation id="9070377983101773829">વૉઇસ શોધ પ્રારંભ કરો</translation>
-<translation id="9074336505530349563">Google દ્વારા સૂચવેલ વ્યક્તિગત કરેલ કન્ટેન્ટ મેળવવા માટે, સાઇન ઇન કરો અને સિંક કરવાનું ચાલુ કરો</translation>
-<translation id="9086455579313502267">નેટવર્ક ઍક્સેસ કરવામાં અક્ષમ છે</translation>
-<translation id="9100505651305367705">જ્યારે સપોર્ટ કરતું હોય, ત્યારે લેખો સરળ દૃશ્યમાં બતાવવાનું ઑફર કરો</translation>
-<translation id="9100610230175265781">પાસફ્રેઝ આવશ્યક છે</translation>
-<translation id="9102803872260866941">પ્રીવ્યૂની ટૅબ ખોલવામાં આવી</translation>
+<translation id="5958275228015807058">ડાઉનલોડ કરેલમાંથી તમારી ફાઇલો અને પેજ શોધો</translation>
+<translation id="5620928963363755975">વધુ વિકલ્પો બટનની મદદથી ડાઉનલોડ કરેલમાંથી તમારી ફાઇલો અને પેજ શોધો</translation>
+<translation id="3341058695485821946">તમે કેટલો ડેટા સાચવ્યો તે જુઓ</translation>
+<translation id="3157842584138209013">વધુ વિકલ્પો બટનની મદદથી તમે કેટલો ડેટા સાચવ્યો તે જુઓ</translation>
+<translation id="8218622182176210845">તમારું એકાઉન્ટ મેનેજ કરો</translation>
+<translation id="8090895580117672212">તમારું Brave Software એકાઉન્ટ મેનેજ કરવા માટે, "એકાઉન્ટ મેનેજ કરો" બટન પર ટૅપ કરો</translation>
+<translation id="8856898588039823173">Brave Software દ્વારા પ્રદાન કરવામાં આવેલું લાઇટ પેજ. ઑરિજિનલ લોડ કરવા માટે ટૅપ કરો.</translation>
+<translation id="8134317863207426198">Brave Software દ્વારા પૂરું પાડવામાં આવેલું લાઇટ વર્ઝનનું પેજ. ઑરિજિનલ પેજ લોડ કરવા માટે ઑરિજિનલ લોડ કરો બટન ટૅપ કરો.</translation>
+<translation id="4961107849584082341">આ પેજનો અનુવાદ કોઈપણ ભાષામાં કરો</translation>
+<translation id="569536719314091526">વધુ વિકલ્પો બટનમાંથી આ પેજનો અનુવાદ કોઈપણ ભાષામાં કરો</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> વડે શોધો</translation>
+<translation id="1792959175193046959">ડિફૉલ્ટ ડાઉનલોડ સ્થાનને કોઈપણ સમયે બદલો</translation>
+<translation id="6942665639005891494">સેટિંગ મેનૂ વિકલ્પનો ઉપયોગ કરીને ડિફૉલ્ટ ડાઉનલોડ સ્થાનને કોઈપણ સમયે બદલો</translation>
+<translation id="6850409657436465440">તમારું ડાઉનલોડ હજી પણ પ્રક્રિયામાં છે</translation>
+<translation id="5817715962196959877">Brave હવે ફાઇલોને વધુ ઝડપથી ડાઉનલોડ કરે છે</translation>
+<translation id="3976396876660209797">આ શૉર્ટકટ દૂર કરો અને ફરી બનાવો</translation>
+<translation id="6766622839693428701">બંધ કરવા માટે નીચેની તરફ સ્વાઇપ કરો.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> પર મોકલી રહ્યાં છીએ...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> પરથી મોકલેલ</translation>
+<translation id="5357811892247919462">ટૅબ પ્રાપ્ત થયું</translation>
 <translation id="9104217018994036254">ટૅબ જે ડિવાઇસ સાથે શેર કરવું છે તેની સૂચિ.</translation>
-<translation id="9133397713400217035">ઑફલાઇનમાં શોધખોળ કરો</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">મૂળ બતાવો</translation>
-<translation id="9139068048179869749">સાઇટ્સને સૂચનાઓ મોકલતાં પહેલાં પૂછો (ભલામણ કરેલ)</translation>
-<translation id="9139318394846604261">ખરીદી</translation>
-<translation id="9155898266292537608">તમે કોઈએક શબ્દ પર ટૅપ કરીને પણ ઝડપથી શોધી શકો છો</translation>
-<translation id="9169507124922466868">નૅવિગેશન ઇતિહાસ અડધા ભાગમાં ખુલ્લો છે</translation>
-<translation id="9204836675896933765">1 ફાઇલ બાકી છે</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">કોઈ ટૅબ સાથે શેર કરવાના ડિવાઇસની સૂચિ અડધી ઊંચાઈએ ખૂલે છે.</translation>
+<translation id="2904414404539560095">કોઈ ટૅબ સાથે શેર કરવાના ડિવાઇસની સૂચિ સંપૂર્ણ ઊંચાઈએ ખૂલે છે.</translation>
+<translation id="4135200667068010335">કોઈ ટૅબ સાથે શેર કરવાના ડિવાઇસની સૂચિ બંધ છે.</translation>
+<translation id="5292796745632149097">આના પર મોકલો</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> દિવસ પહેલાં સક્રિય હતું</translation>
+<translation id="7971136598759319605">1 દિવસ પહેલાં સક્રિય હતું</translation>
+<translation id="1521774566618522728">આજે સક્રિય છે</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> પર શેર કરી રહ્યાં છે</translation>
+<translation id="9028914725102941583">બધા ડિવાઇસ પર શેર કરવા માટે 'સિંક કરો'ની સુવિધા ચાલુ કરો</translation>
+<translation id="6162454065885854378">તમારા ફોનથી કોઈ અન્ય ડિવાઇસ પર કંઈક શેર કરવા માટે, બન્ને ડિવાઇસ પરના Brave સેટિંગમાં સિંકની સુવિધા ચાલુ કરો</translation>
+<translation id="6084271560289605378">Brave સેટિંગ પર જાઓ</translation>
+<translation id="2318045970523081853">કૉલ કરવા માટે ટૅપ કરો</translation>
 <translation id="9209888181064652401">કૉલ કરી શકતા નથી</translation>
-<translation id="9219103736887031265">છબીઓ</translation>
-<translation id="926205370408745186">ડિજિટલ લાઇફસ્ટાઇલમાંથી તમારી Chromeની પ્રવૃત્તિને કેવી રીતે કાઢવી</translation>
-<translation id="932327136139879170">હોમ</translation>
-<translation id="938850635132480979">ભૂલ: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">તમારા માઇક્રોફોનની ઍક્સેસ</translation>
-<translation id="95817756606698420">Chrome, ચાઇનામાં શોધ માટે <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> નો ઉપયોગ કરી શકે છે. તમે આને <ph name="BEGIN_LINK" />સેટિંગ્સ<ph name="END_LINK" />માં બદલી શકો છો.</translation>
-<translation id="965817943346481315">જો સાઇટ ઘૃણાસ્પદ અથવા ભ્રામક જાહેરાતો બતાવતી હોય, તો બ્લૉક કરો (ભલામણ કરેલ)</translation>
-<translation id="968900484120156207">તમે મુલાકાત લીધેલા પેજ અહીં દેખાય છે</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> મિનિટ બાકી</translation>
-<translation id="974555521953189084">સમન્વયન શરૂ કરવા માટે તમારો પાસફ્રેઝ દાખલ કરો</translation>
-<translation id="981121421437150478">ઑફલાઇન</translation>
-<translation id="982182592107339124">આ બધી સાઇટ્સ પરથી ડેટા સાફ કરશે, આ સહિત:</translation>
-<translation id="983192555821071799">બધા ટેબ્સ બંધ કરો</translation>
-<translation id="987264212798334818">સામાન્ય</translation>
+<translation id="2860954141821109167">ખાતરી કરો કે આ ડિવાઇસ પર ફોન ઍપ ચાલુ કરેલી છે</translation>
+<translation id="2067805253194386918">ટેક્સ્ટ</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> શેર કરી શકતાં નથી</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> શેર કરી શકાયો નથી</translation>
+<translation id="8287068819750208230">ખાતરી કરો કે <ph name="TARGET_DEVICE_NAME"/>માં Braveમાં સિંક ચાલુ કરેલું છે</translation>
+<translation id="3016635187733453316">ખાતરી કરો કે આ ડિવાઇસ ઇન્ટરનેટ સાથે કનેક્ટ કરેલું છે</translation>
+<translation id="8466613982764129868">ખાતરી કરો કે <ph name="TARGET_DEVICE_NAME"/>ને ઇન્ટરનેટ સાથે કનેક્ટ કરેલું છે</translation>
+<translation id="6539092367496845964">કંઈક ખોટું થયું હતું. થોડીવાર પછી ફરી પ્રયાસ કરો.</translation>
+<translation id="3389286852084373014">ટેક્સ્ટ ખૂબ મોટી છે</translation>
+<translation id="2100314319871056947">ટેક્સ્ટને નાના-નાના ટૂકડામાં શેર કરી જુઓ</translation>
+<translation id="2987620471460279764">બીજા ડિવાઇસ પરથી શેર થયેલી ટેક્સ્ટ</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/>માંથી ટેક્સ્ટ શેર કરી</translation>
+<translation id="5193988420012215838">તમારા ક્લિપબોર્ડ પર કૉપિ કરવામાં આવી</translation>
+<translation id="4696983787092045100">તમારા ડિવાઇસ પર ટેક્સ્ટ મોકલો</translation>
+<translation id="1260236875608242557">શોધો તેમજ શોધખોળ કરો</translation>
+<translation id="6369229450655021117">અહીંથી, તમે વેબમાં શોધી શકશો, મિત્રો સાથે શેર કરી શકશો અને ખુલ્લા પેજ પણ જોઈ શકશો</translation>
+<translation id="723171743924126238">છબીઓ પસંદ કરો</translation>
+<translation id="8751914237388039244">છબી પસંદ કરો</translation>
+<translation id="1989112275319619282">બ્રાઉઝ કરો</translation>
+<translation id="7055152154916055070">રીડાયરેક્ટ કરવાનું બ્લૉક કરવામાં આવ્યું છે:</translation>
+<translation id="5524843473235508879">રીડાયરેક્ટ કરવાનું અવરોધિત.</translation>
+<translation id="6573096386450695060">હંમેશાં મંજૂરી આપો</translation>
+<translation id="5805364706385912897">આ પેજ ઘણી વધુ મેમરીનો ઉપયોગ કરે છે, તેથી Braveએ તેને થોભાવ્યું છે.</translation>
+<translation id="5138664332909611586">આ પેજ મેમરીનો બહુ ઉપયોગ કરે છે, તેથી Braveએ કેટલુંક કન્ટેન્ટ કાઢી નાખ્યું છે.</translation>
+<translation id="9137013805542155359">મૂળ બતાવો</translation>
+<translation id="6361779936989026201">Braveમાં Brave Software આસિસ્ટંટ</translation>
+<translation id="7291387454912369099">આસિસ્ટંટે ચેકઆઉટ ટ્રિગર કર્યું</translation>
+<translation id="4565206163201411670">શું તમારી Braveની પ્રવૃત્તિ ડિજિટલ લાઇફસ્ટાઇલમાં બતાવીએ?</translation>
+<translation id="9055113864158719823">તમે Braveમાં મુલાકાત લીધેલી સાઇટ જોઈ શકશો અને તેના માટે ટાઇમર પણ સેટ કરી શકશો.\n\nતમે જે સાઇટ માટે ટાઇમર સેટ કરો છો અને કેટલા સમય માટે તેની મુલાકાત લો છો, તે માહિતી Brave Software મેળવે છે. આ માહિતી ડિજિટલ લાઇફસ્ટાઇલને બહેતર બનાવવા માટે ઉપયોગમાં લેવામાં આવે છે.</translation>
+<translation id="4596514158372210596">ડિજિટલ લાઇફસ્ટાઇલમાંથી તમારી Braveની પ્રવૃત્તિને કેવી રીતે કાઢવી</translation>
+<translation id="1174893863889683998">તમારી Braveની પ્રવૃત્તિને ડિજિટલ લાઇફસ્ટાઇલમાંથી કાઢી નાખીએ?</translation>
+<translation id="708829030563435351">Braveમાં તમે મુલાકાત લીધેલી સાઇટ બતાવવામાં આવશે નહીં. સાઇટના બધા ટાઇમર ડિલીટ કરવામાં આવશે.</translation>
+<translation id="2056878612599315956">સાઇટ રોકવામાં આવી</translation>
+<translation id="671481426037969117">તમારું <ph name="FQDN"/> ટાઇમર સમાપ્ત થયું. તે આવતી કાલે ફરી શરૂ થશે.</translation>
+<translation id="7479104141328977413">ટૅબ મેનેજમેન્ટ</translation>
+<translation id="3524138585025253783">ડેવલપર UI</translation>
+<translation id="6036057147555329831">અતિરિક્ત ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/>ને VR મોડમાં દાખલ થવાની મંજૂરી આપીએ?</translation>
+<translation id="7685301384041462804">VR મોડમાં દાખલ થતા પહેલાં ખાતરી કરો કે તમે આ સાઇટ પર વિશ્વાસ કરો છો.</translation>
+<translation id="5033865233969348410">તમે VR મોડમાં હો, ત્યારે આ સાઇટ આ વિશેની જાણકારી મેળવી શકે:
+  -  તમારી શારીરિક લાક્ષણિકતાઓ, જેમ કે ઊંચાઈ
+
+VR મોડમાં દાખલ થતા પહેલા ખાતરી કરો કે તમે આ સાઇટ પર વિશ્વાસ કરો છો.</translation>
+<translation id="5534334044554683961">તમે VR મોડમાં હો, ત્યારે આ સાઇટ આ વિશેની જાણકારી મેળવી શકે:
+  -   તમારી શારીરિક લાક્ષણિકતાઓ, જેમ કે ઊંચાઈ
+  -   તમારા રૂમનું લેઆઉટ
+
+VR મોડમાં દાખલ થતા પહેલા ખાતરી કરો કે તમે આ સાઇટ પર વિશ્વાસ કરો છો.</translation>
+<translation id="4169535189173047238">મંજૂરી આપશો નહીં</translation>
+<translation id="2170088579611075216">VRને મંજૂરી આપો અને તેમાં પ્રવેશ કરો</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_hi.xtb
+++ b/android/java/strings/translations/android_chrome_strings_hi.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="hi">
-<translation id="1006017844123154345">ऑनलाइन खोलें</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> पर भेजा जा रहा है...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> जोड़ा जा रहा है...</translation>
-<translation id="1041308826830691739">वेबसाइटों से</translation>
-<translation id="1049743911850919806">गुप्त</translation>
-<translation id="10614374240317010">कभी नहीं सेव किया गया</translation>
-<translation id="1067922213147265141">Google की दूसरी सेवाएंं</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" /> भाषा के पेज का कभी भी अनुवाद न करें</translation>
-<translation id="107147699690128016">अगर आप फ़ाइल का एक्सटेंशन बदलते हैं, तो हो सकता है कि फ़ाइल अलग ऐप्लिकेशन में खुले. इससे आपके डिवाइस को नुकसान पहुंच सकता है.</translation>
-<translation id="1100066534610197918">समूह में नए टैब में खोलें</translation>
-<translation id="1105960400813249514">स्‍क्रीन कैप्‍चर</translation>
-<translation id="1111673857033749125">आपके अन्‍य डिवाइस पर सहेजे गए बुकमार्क यहां दिखाई देंगे.</translation>
-<translation id="1113597929977215864">सरल बनाया गया व्यू दिखाएं</translation>
-<translation id="1121094540300013208">इस्तेमाल और खराबी रिपोर्ट</translation>
-<translation id="1124772482545689468">उपयोगकर्ता</translation>
-<translation id="1129510026454351943">विवरण: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 डाउनलोड बाकी है.}one{# डाउनलोड बाकी हैं.}other{# डाउनलोड बाकी हैं.}}</translation>
-<translation id="1145536944570833626">मौजूदा डेटा मिटाएं.</translation>
-<translation id="1146678959555564648">VR डालें</translation>
-<translation id="116280672541001035">इस्तेमाल किया गया</translation>
-<translation id="1171770572613082465">"मुख्य साइटें" बटन पर टैप करके लोकप्रिय साइटें देखें</translation>
-<translation id="1173894706177603556">नाम बदलें</translation>
-<translation id="1178581264944972037">रोकें</translation>
-<translation id="1181037720776840403">हटाएं</translation>
-<translation id="1188239144602654184">ऑगमेंटेड रिएलिटी (AR) सत्र शुरू करें</translation>
-<translation id="1197267115302279827">बुकमार्क ले जाएं</translation>
-<translation id="119944043368869598">सारा डेटा साफ़ करें</translation>
-<translation id="1201402288615127009">अगला</translation>
-<translation id="1204037785786432551">डाउनलोड करने का लिंक</translation>
-<translation id="1206892813135768548">लिंक लेख को कॉपी करें</translation>
-<translation id="1208340532756947324">सभी डिवाइस पर सिंक करने और मनमुताबिक बनाने के लिए, 'सिंक करें' को चालू करें</translation>
-<translation id="1209206284964581585">अभी छिपाएं</translation>
-<translation id="1227058898775614466">नेविगेशन का इतिहास</translation>
-<translation id="1231733316453485619">क्या सिंक करना चालू करें?</translation>
-<translation id="123724288017357924">कैश सामग्री को अनदेखा कर, मौजूदा पेज फिर लोड करें</translation>
-<translation id="124116460088058876">ज़्यादा भाषाएं</translation>
-<translation id="124678866338384709">वर्तमान टैब को बंद करें</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">खोजें और एक्सप्लोर करें</translation>
-<translation id="1264974993859112054">खेल-कूद</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> शेयर नहीं किया जा सका</translation>
-<translation id="1272079795634619415">रोकें</translation>
-<translation id="1283039547216852943">पूरा खोलने के लिए टैप करें</translation>
-<translation id="1285320974508926690">कभी भी इस साइट का अनुवाद न करें</translation>
-<translation id="1291207594882862231">इतिहास, कुकी, साइट डेटा, कैश साफ़ करें…</translation>
-<translation id="129382876167171263">यहां वे फ़ाइलें दिखाई देती हैं जिन्हें वेबसाइटें सेव करती हैं</translation>
-<translation id="129553762522093515">हाल ही में बंद किए गए</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> से भेजा गया</translation>
-<translation id="1310482092992808703">टैब को समूह में लगाएं</translation>
-<translation id="1327257854815634930">नेविगेशन का इतिहास अपने पूरे आकार में खुला हुआ है</translation>
-<translation id="1331212799747679585">Chrome अपडेट नहीं किया जा सकता. ज़्यादा विकल्प</translation>
-<translation id="1332501820983677155">Google Chrome सुविधा शॉर्टकट</translation>
-<translation id="1360432990279830238">साइन आउट करें और सिंक बंद करें?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> साइट जोड़ी गई</translation>
-<translation id="1373696734384179344">चयनित सामग्री डाउनलोड करने के लिए मेमोरी अपर्याप्‍त है.</translation>
-<translation id="1376578503827013741">गणना की जा रही है…</translation>
-<translation id="1383876407941801731">खोजें</translation>
-<translation id="1384959399684842514">डाउनलोड रोका गया</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" />दिन पहले सिंक किया गया</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> के ज़रिए खोजें</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" /> में एम्बेड किया गया है</translation>
-<translation id="1406000523432664303">“नज़र न रखें”</translation>
-<translation id="1407135791313364759">सभी बुकमार्क खोलें</translation>
-<translation id="1409426117486808224">खुले टैब के लिए सरल बनाया गया व्यू</translation>
-<translation id="1409879593029778104"><ph name="FILE_NAME" /> डाउनलोड को रोका गया क्‍योंकि फ़ाइल पहले से मौजूद है.</translation>
-<translation id="1414981605391750300">Google से संपर्क किया जा रहा है. इसमें कुछ समय लग सकता है…</translation>
-<translation id="1416550906796893042">ऐप्‍लिकेशन वर्शन</translation>
-<translation id="1430915738399379752">प्रिंट करें</translation>
-<translation id="1446450296470737166">MIDI डिवाइस के पूरे नियंत्रण की अनुमति दें</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> शेयर नहीं किया जा सकता</translation>
-<translation id="145097072038377568">Android सेटिंग में बंद कर दिया गया है</translation>
-<translation id="1477626028522505441">सर्वर संबधी समस्‍याओं के कारण <ph name="FILE_NAME" /> डाउनलोड विफल रहा.</translation>
-<translation id="1506061864768559482">सर्च इंजन</translation>
-<translation id="1513352483775369820">बुकमार्क और वेब इतिहास</translation>
-<translation id="1513858653616922153">पासवर्ड मिटाएं</translation>
-<translation id="1516229014686355813">'खोजने के लिए टैप करें' सुविधा चुने हुए शब्‍द और मौजूदा पेज को संदर्भ के रूप में 'Google सर्च' पर भेजती है. आप इसे <ph name="BEGIN_LINK" />सेटिंग<ph name="END_LINK" /> में जाकर बंद कर सकते हैं.</translation>
-<translation id="1521774566618522728">आज सक्रिय है</translation>
-<translation id="1544826120773021464">अपना Google खाता प्रबंधित करने के लिए, "खाता प्रबंधित करें" बटन पर टैप करें</translation>
-<translation id="1549000191223877751">अन्य विंडो में ले जाएं</translation>
-<translation id="1553358976309200471">Chrome अपडेट करें</translation>
-<translation id="1569387923882100876">कनेक्ट किया गया डिवाइस</translation>
-<translation id="1571304935088121812">उपयोगकर्ता नाम की कॉपी करें</translation>
-<translation id="1612196535745283361">डिवाइस स्कैन करने के लिए Chrome को जगह की जानकारी का एक्सेस की ज़रूरत होती है. जगह की जानकारी का एक्सेस <ph name="BEGIN_LINK" />इस डिवाइस के लिए बंद<ph name="END_LINK" /> है.</translation>
-<translation id="1620510694547887537">कैमरा</translation>
-<translation id="1623104350909869708">इस पेज को अतिरिक्त डॉयलॉग बनाने से रोकें</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 चयनित आइटम निकालें}one{# चयनित आइटम निकालें}other{# चयनित आइटम निकालें}}</translation>
-<translation id="164269334534774161">आप <ph name="CREATION_TIME" /> से इस पेज की ऑफ़लाइन कॉपी देख रहे हैं</translation>
-<translation id="1644574205037202324">इतिहास</translation>
-<translation id="1647391597548383849">अपना कैमरा एक्सेस करें</translation>
-<translation id="1660204651932907780">साइटों को आवाज़ चलाने दें (सुझाया गया)</translation>
-<translation id="1670399744444387456">मूलभूत</translation>
-<translation id="1671236975893690980">डाउनलोड लंबित…</translation>
-<translation id="1672586136351118594">फिर से न दिखाएं</translation>
-<translation id="1692118695553449118">समन्वयन चालू है</translation>
-<translation id="169515064810179024">साइटों को हलचल पकड़ने वाले सेंसर ऐक्सेस करने से रोकें</translation>
-<translation id="1717218214683051432">मोशन सेंसर</translation>
-<translation id="1718835860248848330">अंतिम घंटा</translation>
-<translation id="1736419249208073774">बेहतर जानें</translation>
-<translation id="1743802530341753419">साइटों को डिवाइस से कनेक्ट करने की अनुमति देने से पहले पूछें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
-<translation id="1749561566933687563">अपने बुकमार्क समन्‍वयित करें</translation>
-<translation id="17513872634828108">टैब खोलें</translation>
-<translation id="1779089405699405702">इमेज डीकोडर</translation>
-<translation id="1782483593938241562">खत्म होने की तारीख: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">इंस्‍टॉल किया गया</translation>
-<translation id="1792959175193046959">डिफ़ॉल्ट डाउनलोड स्थान किसी भी समय बदलें</translation>
-<translation id="1807246157184219062">हल्का</translation>
-<translation id="1810845389119482123">शुरुआती सिंक सेट अप पूरा नहीं हुआ</translation>
-<translation id="1821253160463689938">आपकी पसंद याद रखने के लिए कुकी का इस्तेमाल करती है, भले ही आप उन पेजों पर नहीं जाते</translation>
-<translation id="1829244130665387512">पेज में ढूंढें</translation>
-<translation id="1853692000353488670">नया गुप्त टैब</translation>
-<translation id="1856325424225101786">लाइट मोड रीसेट करें?</translation>
-<translation id="1868024384445905608">Chrome अब ज़्यादा तेज़ी से फ़ाइलें डाउनलोड करता है</translation>
-<translation id="1883903952484604915">मेरी फ़ाइलें</translation>
-<translation id="1887786770086287077">इस डिवाइस के लिए जगह की जानकारी का एक्सेस बंद है. उसे <ph name="BEGIN_LINK" />Android सेटिंग<ph name="END_LINK" /> में चालू करें.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> Chrome में खुलेगा. जारी रखकर, आप Chrome की <ph name="BEGIN_LINK1" />सेवा की शर्तों<ph name="END_LINK1" /> और <ph name="BEGIN_LINK2" />निजता सूचना<ph name="END_LINK2" /> से सहमत होते हैं.</translation>
-<translation id="1919345977826869612">विज्ञापन</translation>
-<translation id="1919950603503897840">संपर्कों को चुनें</translation>
-<translation id="1922076542920281912">Chrome को अपनी जगह की जानकारी ऐक्सेस करने देने के लिए, <ph name="BEGIN_LINK" />Android की सेटिंग<ph name="END_LINK" /> में जाकर भी जगह की जानकारी चालू करें.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">अपडेट</translation>
-<translation id="19288952978244135">Chrome को फिर से खोलें.</translation>
-<translation id="1933845786846280168">चयनित टैब</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android सेटिंग<ph name="END_LINK" /> में Chrome के लिए अनुमति चालू करें.</translation>
-<translation id="1943432128510653496">पासवर्ड सेव करें</translation>
-<translation id="1952172573699511566">जब संभव होगा, वेबसाइटें आपकी पसंदीदा भाषा में टेक्स्ट दिखाएंगी.</translation>
-<translation id="1960290143419248813">Chrome अपडेट, अब Android के इस वर्शन पर काम नहीं करते हैं.</translation>
-<translation id="1966710179511230534">कृपया अपने साइन के विवरण अपडेट करें.</translation>
-<translation id="1974060860693918893">बेहतर</translation>
-<translation id="1984705450038014246">अपना Chrome डेटा सिंक करें</translation>
-<translation id="1984937141057606926">तृतीय-पक्ष को छोड़कर अनुमति है</translation>
-<translation id="1986685561493779662">नाम पहले से मौजूद है</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> बटन</translation>
-<translation id="1989112275319619282">ब्राउज़ करें</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> युग्मित करना चाहता है</translation>
-<translation id="1994173015038366702">साइट URL</translation>
-<translation id="2000419248597011803">'पता बार' और 'खोज बॉक्स' की कुछ कुकी और खोजों को आपके डिफ़ॉल्ट खोज इंजन पर भेजा जाता है</translation>
-<translation id="2002537628803770967">Google Pay का इस्तेमाल करने वाले क्रेडिट कार्ड और पते</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# फ़ाइल}one{# फ़ाइलें}other{# फ़ाइलें}}</translation>
-<translation id="2017836877785168846">इतिहास साफ़ करता है और पता बार मेंअपने-आपपूर्णता को साफ़ करता है.</translation>
-<translation id="2021896219286479412">पूरी स्क्रीन के साइट नियंत्रण</translation>
-<translation id="2038563949887743358">अनुरोध डेस्कटॉप साइट चालू करें</translation>
-<translation id="2041019821020695769">Chrome को आपको सूचनाएं भेजने देने के लिए, <ph name="BEGIN_LINK" />Android की सेटिंग<ph name="END_LINK" /> में जाकर भी सूचनाएं चालू करें.</translation>
-<translation id="204321170514947529">Chrome में <ph name="APP_NAME" /> का डेटा भी है</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">साइट रोकी गई</translation>
-<translation id="2063713494490388661">खोजने के लिए टैप करें</translation>
-<translation id="2067805253194386918">टेक्स्ट</translation>
-<translation id="2079545284768500474">वापस लाएं</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" /> में से <ph name="RESULT_NUMBER" /> परिणाम</translation>
-<translation id="2091887806945687916">आवाज़</translation>
-<translation id="2096012225669085171">सभी डिवाइस में सिंक करना और मनमुताबिक बनाना</translation>
-<translation id="2100273922101894616">अपने आप साइन इन करने की सुविधा</translation>
-<translation id="2100314319871056947">टेक्स्ट को छोटे-छोटे हिस्सों में शेयर करने की कोशिश करें</translation>
-<translation id="2107397443965016585">साइटों को सुरक्षित सामग्री चलाने देने से पहले पूछें (ऐसा करने का सुझाव दिया जाता है)</translation>
-<translation id="2111511281910874386">पेज पर जाएं</translation>
-<translation id="2122601567107267586">ऐप्लिकेशन नहीं खोला जा सका</translation>
-<translation id="2126426811489709554">Chrome के द्वारा संचालित</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> बचाया गया</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> बंद है</translation>
-<translation id="2139186145475833000">होम स्क्रीन में जोड़ें</translation>
-<translation id="2146738493024040262">इंस्टैंट ऐप्लिकेशन खोलें</translation>
-<translation id="2148716181193084225">आज</translation>
-<translation id="2154484045852737596">कार्ड में बदलाव करें</translation>
-<translation id="2154710561487035718">URL की कॉपी बनाएं</translation>
-<translation id="2156074688469523661">बाकी साइटें (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">अपने फ़ोन से किसी दूसरे डिवाइस पर कुछ शेयर करने के लिए, दोनों डिवाइस पर Chrome की सेटिंग में जाकर सिंक की सुविधा चालू करें</translation>
-<translation id="2170088579611075216">अनुमति दें और VR चालू करें</translation>
-<translation id="218608176142494674">शेयर किया जा रहा है</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> के रूप में जारी रखें</translation>
-<translation id="2234876718134438132">सिंक और Google सेवाएं</translation>
-<translation id="2259659629660284697">पासवर्ड निर्यात करें…</translation>
-<translation id="2268044343513325586">बेहतर बनाएं</translation>
-<translation id="2286841657746966508">बिलिंग पता</translation>
-<translation id="2289270750774289114">जब कोई साइट आस-पास के ब्लूटूथ डिवाइस को खोजना चाहे, तो इसके लिए पूछें (सुझाया गया)</translation>
-<translation id="230115972905494466">कोई संगत डिवाइस नहीं मिला</translation>
-<translation id="2315043854645842844">क्लाइंट-साइड प्रमाणपत्र चुनना ऑपरेटिंग सिस्टम से नहीं किया जा सकता है.</translation>
-<translation id="2318045970523081853">कॉल करने के लिए टैप करें</translation>
-<translation id="2321086116217818302">पासवर्ड तैयार हो रहे हैं…</translation>
-<translation id="2321958826496381788">इस टेक्स्ट को आसानी से पढ़ने लायक बनाने के लिए, स्‍लाइडर को आगे की ओर खींचें. पैराग्राफ़ पर डबल-टैप करने के बाद, टेक्स्ट को इतना बड़ा दिखाई देना चाहिए.</translation>
-<translation id="2323763861024343754">साइट मेमोरी</translation>
-<translation id="2328985652426384049">साइन इन नहीं कर सकते</translation>
-<translation id="2330129964253841015">अगर आपके पासवर्ड का गलत इस्तेमाल हुआ है, तो आपको चेतावनी दे</translation>
-<translation id="2349710944427398404">Chrome द्वारा उपयोग किया गया कुल डेटा, जिसमें खाते, बुकमार्क और सहेजी गईं सेटिंग शामिल हैं</translation>
-<translation id="2353636109065292463">आपके इंटरनेट कनेक्शन की जाँच की जा रही है</translation>
-<translation id="2359808026110333948">जारी रखें</translation>
-<translation id="2369533728426058518">खुले टैब</translation>
-<translation id="2387895666653383613">लेख स्‍केलिंग</translation>
-<translation id="2394602618534698961">आप जिन फ़ाइलों को डाउनलोड करते हैं वे यहां दिखाई देंगी</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> एमबी</translation>
-<translation id="2407481962792080328">जब आप अपने Google खाते में लॉग इन करते हैं, तो यह सुविधा चालू हो जाती है</translation>
-<translation id="2410754283952462441">कोई खाता चुनें</translation>
-<translation id="2414886740292270097">गहरा</translation>
-<translation id="2416359993254398973">Chrome को इस साइट के लिए आपका कैमरा एक्सेस करने की अनुमति चाहिए.</translation>
-<translation id="2426805022920575512">दूसरा खाता चुनें</translation>
-<translation id="2433507940547922241">प्रकटन</translation>
-<translation id="2434158240863470628">डाउनलोड हो गया <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">जगह की जानकारी का एक्‍सेस दें</translation>
-<translation id="2450083983707403292">क्या आप <ph name="FILE_NAME" /> को डाउनलोड करना फिर से शुरू करना चाहते हैं?</translation>
-<translation id="2482878487686419369">सूचनाएं</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> प्रबंधित करता है</translation>
-<translation id="2494974097748878569">Chrome में Google Assistant</translation>
-<translation id="2496180316473517155">ब्राउज़िंग इतिहास...</translation>
-<translation id="2497852260688568942">सिंक को आपके व्यवस्थापक ने अक्षम कर दिया है</translation>
-<translation id="2498359688066513246">सहायता और फ़ीडबैक</translation>
-<translation id="2501278716633472235">वापस जाएं</translation>
-<translation id="2513403576141822879">निजता, सुरक्षा और डेटा इकट्ठा करने से जुड़ी ज़्यादा सेटिंग के लिए, <ph name="BEGIN_LINK" />सिंक और Google सेवाएं<ph name="END_LINK" /> देखें</translation>
-<translation id="2518590038762162553">Chrome, लाइट मोड में पेजों को ज़्यादा तेज़ी से लोड करता है और 60 प्रतिशत तक कम डेटा इस्तेमाल करता है. जिन पेजों पर आप जाते हैं उनको ऑप्टिमाइज़ करने के लिए Chrome आपके वेब ट्रैफ़िक की जानकारी Google को भेजता है. <ph name="BEGIN_LINK" />ज़्यादा जानें<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">आप जिन पेजों पर जाते हैं उनके यूआरएल Google को भेजती है</translation>
-<translation id="2532336938189706096">वेब व्यू</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> आइटम मिटाए गए</translation>
-<translation id="2536728043171574184">इस पृष्‍ठ की ऑफ़लाइन कॉपी देख रहे हैं</translation>
-<translation id="2546283357679194313">कुकी और साइट डेटा</translation>
-<translation id="2567385386134582609">इमेज</translation>
-<translation id="257088987046510401">थीम</translation>
-<translation id="2570922361219980984">इस डिवाइस के लिए जगह की जानकारी का एक्सेस भी बंद है. उसे <ph name="BEGIN_LINK" />Android सेटिंग<ph name="END_LINK" /> में चालू करें.</translation>
-<translation id="257931822824936280">बड़ा किया गया - छोटा करने के लिए क्‍लिक करें.</translation>
-<translation id="2581165646603367611">यह साइट की कुकी, कैश और अन्य डेटा निकाल देगा जो Chrome के विचार में महत्वपूर्ण नहीं है.</translation>
-<translation id="2586657967955657006">क्लिपबोर्ड</translation>
-<translation id="2587052924345400782">नया वर्शन उपलब्ध है</translation>
-<translation id="2593272815202181319">मोनोस्पेस</translation>
-<translation id="2612676031748830579">कार्ड संख्या</translation>
-<translation id="2621115761605608342">किसी खास साइट के लिए JavaScript चलाने की अनुमति दें.</translation>
-<translation id="2625189173221582860">पासवर्ड कॉपी किया गया</translation>
-<translation id="2631006050119455616">बचाया गया</translation>
-<translation id="2647434099613338025">भाषा जोड़ें</translation>
-<translation id="2650751991977523696">फ़ाइल दोबारा डाउनलोड करें?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ऑडियो फ़ाइल}one{# ऑडियो फ़ाइलें}other{# ऑडियो फ़ाइलें}}</translation>
-<translation id="2653659639078652383">सबमिट करें</translation>
-<translation id="2677748264148917807">छोड़ें</translation>
-<translation id="2704606927547763573">कॉपी किया गया</translation>
-<translation id="2707726405694321444">पेज रीफ्रेश करें</translation>
-<translation id="2709516037105925701">ऑटोमैटिक भरना</translation>
-<translation id="2717722538473713889">ईमेल पते</translation>
-<translation id="2728754400939377704">साइट के हिसाब से क्रम में लगाएं</translation>
-<translation id="2744248271121720757">इंस्टैंट सर्च या मिलती-जुलती कार्रवाई देखने के लिए किसी शब्द पर टैप करें</translation>
-<translation id="2760989362628427051">अपने डिवाइस की गहरे रंग वाली थीम या 'बैटरी सेवर' चालू होने पर गहरे रंग वाली थीम चालू करें</translation>
-<translation id="2762000892062317888">अभी-अभी</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> सेकंड शेष</translation>
-<translation id="2779651927720337254">डाउनलोड नहीं हो सका</translation>
-<translation id="2781151931089541271">1 सेकंड शेष</translation>
-<translation id="2801022321632964776">Chrome के नए वर्शन में अपनी भाषा पाने के लिए अपडेट करें</translation>
-<translation id="2810645512293415242">डेटा बचाने और तेज़ी से लोड करने के लिए आसान बनाया गया पेज.</translation>
-<translation id="281504910091592009">अपने <ph name="BEGIN_LINK" />Google खाते<ph name="END_LINK" /> में सेव किए गए पासवर्ड देखें और उन्हें प्रबंधित करें</translation>
-<translation id="2818669890320396765">अपने सभी डिवाइस पर अपने बुकमार्क पाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
-<translation id="2822354292072154809">क्या आप वाकई <ph name="CHOSEN_OBJECT_NAME" /> की सभी साइट अनुमतियां रीसेट करना चाहते हैं?</translation>
-<translation id="2836148919159985482">फ़ुल स्क्रीन से बाहर निकलने के लिए वापस जाएं बटन स्पर्श करें.</translation>
-<translation id="2842985007712546952">मूल फ़ोल्‍डर</translation>
-<translation id="2858138569776157458">मुख्य साइटें</translation>
-<translation id="2860954141821109167">पक्का करें कि इस डिवाइस पर फ़ोन ऐप्लिकेशन चालू है</translation>
-<translation id="2870560284913253234">साइट</translation>
-<translation id="2874939134665556319">पिछला ट्रैक</translation>
-<translation id="2876369937070532032">आपकी सुरक्षा को खतरा होने पर उन पेज के यूआरएल भेजे जाते हैं जिन पर आप Google के ज़रिए जाते हैं.</translation>
-<translation id="2888126860611144412">Chrome के बारे में</translation>
-<translation id="2891154217021530873">पेज को लोड करना रोकें</translation>
-<translation id="2893180576842394309">खोज और दूसरी Google सेवाओं को मनमुताबिक बनाने के लिए, Google आपके इतिहास का इस्तेमाल कर सकता है</translation>
-<translation id="2898264748040935573">सेव किया गया पासवर्ड बदलें</translation>
-<translation id="2900528713135656174">इवेंट बनाएं</translation>
-<translation id="290376772003165898">क्या पेज <ph name="LANGUAGE" /> भाषा में नहीं है?</translation>
-<translation id="2904414404539560095">टैब शेयर करने वाले डिवाइस की सूची पूरी खुली हुई है.</translation>
-<translation id="2910701580606108292">साइटों को सुरक्षित सामग्री चलाने की अनुमति देने से पहले पूछें</translation>
-<translation id="2913331724188855103">साइटों को कुकी डेटा सेव करने और पढ़ने की अनुमति दें (सुझाए गए)</translation>
-<translation id="2923908459366352541">नाम अमान्य है</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> मेमोरी</translation>
-<translation id="2942036813789421260">झलक टैब बंद है</translation>
-<translation id="2956410042958133412">यह खाता <ph name="PARENT_NAME_1" /> और <ph name="PARENT_NAME_2" /> के द्वारा प्रबंधित है.</translation>
-<translation id="2962095958535813455">गुप्त टैब पर स्विच कर दिया गया</translation>
-<translation id="2968755619301702150">प्रमाणपत्र व्यूअर</translation>
-<translation id="2979025552038692506">चयनित गुप्त टैब</translation>
-<translation id="2987620471460279764">दूसरी साइटों से शेयर किया गया टेक्स्ट</translation>
-<translation id="2989523299700148168">हाल ही में देखे गए</translation>
-<translation id="2996291259634659425">'पासफ़्रेज़' बनाएं</translation>
-<translation id="2996809686854298943">URL ज़रूरी है</translation>
-<translation id="300526633675317032">इससे वेबसाइट की पूरी <ph name="SIZE_IN_KB" /> मेमोरी साफ़ हो जाएगी.</translation>
-<translation id="3016635187733453316">पक्का करें कि इस डिवाइस को इंटरनेट से कनेक्ट किया गया है</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> केबी डाउनलोड किया गया</translation>
-<translation id="3029704984691124060">पासफ़्रेज़ मिलान नहीं करते</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />सहायता पाएं<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">स्थान सेवा बंद है, उसे <ph name="BEGIN_LINK" />Android सेटिंग<ph name="END_LINK" /> में चालू करें.</translation>
-<translation id="3058498974290601450">आप सेटिंग में किसी भी समय सिंक चालू कर सकते हैं</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> बुकमार्क}one{<ph name="BOOKMARKS_COUNT_MANY" /> बुकमार्क}other{<ph name="BOOKMARKS_COUNT_MANY" /> बुकमार्क}}</translation>
-<translation id="3089395242580810162">गुप्त टैब में खोलें</translation>
-<translation id="3115898365077584848">जानकारी दिखाएं</translation>
-<translation id="3123473560110926937">कुछ साइटों पर ब्लॉक किए गए हैं</translation>
-<translation id="3137521801621304719">गुप्त मोड छोड़ें</translation>
-<translation id="3143515551205905069">लिंक करना रोक दें</translation>
-<translation id="3157842584138209013">ज़्यादा विकल्प बटन से देखें कि आपने कितना डेटा बचाया है</translation>
-<translation id="3166827708714933426">टैब और विंडो शॉर्टकट</translation>
-<translation id="3181954750937456830">सुरक्षित ब्राउज़िंग (आपकी और आपके डिवाइस की खतरनाक साइट से सुरक्षा करती है)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android सेटिंग<ph name="END_LINK" /> में Chrome के लिए अनुमतियां चालू करें.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> संग्रहित डेटा</translation>
-<translation id="3205824638308738187">करीब-करीब पूरा हो गया!</translation>
-<translation id="3207960819495026254">बुकमार्क किया गया</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> मिटाया गया</translation>
-<translation id="321773570071367578">अगर आप अपना 'पासफ़्रेज़' भूल गए हैं या यह सेटिंग बदलना चाहते हैं, तो <ph name="BEGIN_LINK" /> सिंक रीसेट करें<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">माइक्रोफ़ोन</translation>
-<translation id="3232754137068452469">वेब ऐप्लिकेशन</translation>
-<translation id="3236059992281584593">1 मिनट शेष</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">इस पेज को बुकमार्क करें</translation>
-<translation id="3259831549858767975">पेज पर सब कुछ छोटा करें</translation>
-<translation id="3269093882174072735">इमेज लोड करें</translation>
-<translation id="3269956123044984603">अपने अन्य डिवाइस से अपने टैब पाने के लिए, Android खाता सेटिंग में “डेटा अपने-आप सिंक करें” चालू करें.</translation>
-<translation id="3277252321222022663">साइटों को सेंसर ऐक्सेस करने दें (सुझाया गया)</translation>
-<translation id="3282568296779691940">Chrome में साइन इन करें</translation>
-<translation id="3288003805934695103">पेज को पुनः लोड करें</translation>
-<translation id="32895400574683172">सूचनाओं की अनुमति है</translation>
-<translation id="3295530008794733555">तेज़ी से ब्राउज़ करें. कम डेटा इस्तेमाल करें.</translation>
-<translation id="3295602654194328831">जानकारी छिपाएं</translation>
-<translation id="3298243779924642547">लाइट</translation>
-<translation id="3303414029551471755">सामग्री डाउनलोड करने के लिए आगे बढ़ें?</translation>
-<translation id="3306398118552023113">Chrome में यह ऐप्‍लि‍केशन चल रहा है</translation>
-<translation id="3315103659806849044">आप इस समय अपनी सिंक की सुविधा और Google सेवा की सेटिंग कस्टमाइज़ कर रहे हैं. सिंक चालू करने की प्रक्रिया पूरी करने के लिए, स्क्रीन के निचले हिस्से पर मौजूद 'पुष्टि करें' बटन पर टैप करें. ऊपर जाएं</translation>
-<translation id="3328801116991980348">साइट जानकारी</translation>
-<translation id="3333961966071413176">सभी संपर्क</translation>
-<translation id="3334729583274622784">फ़ाइल एक्सटेंशन बदलना चाहते हैं?</translation>
-<translation id="3341058695485821946">देखें कि आपने कितना डेटा बचाया है</translation>
-<translation id="3350687908700087792">सभी गुप्त टैब बंद करें</translation>
-<translation id="3353615205017136254">लाइट पेज Google ने मुहैया कराया है. मूल पेज लोड करने के लिए 'मूल पेज लोड करें' बटन पर टैप करें.</translation>
-<translation id="3367813778245106622">सिंक शुरू करने के लिए फिर से साइन इन करें</translation>
-<translation id="3374023511497244703">आपके बुकमार्क, इतिहास, पासवर्ड, और Chrome पर मौजूद दूसरा डेटा अब Google खाते से सिंक नहीं होगा</translation>
-<translation id="3384347053049321195">इमेज शेयर करें</translation>
-<translation id="3386292677130313581">साइटों को अपनी जगह की जानकारी देने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया)</translation>
-<translation id="3387650086002190359">सिस्‍टम त्रुटियों के कारण <ph name="FILE_NAME" /> डाउनलोड विफल रहा.</translation>
-<translation id="3389286852084373014">टेक्स्ट बहुत बड़ा है</translation>
-<translation id="3398320232533725830">बुकमार्क प्रबंधक खोलें</translation>
-<translation id="3414952576877147120">आकार:</translation>
-<translation id="3443221991560634068">वर्तमान पेज फिर से लोड करें</translation>
-<translation id="3445014427084483498">अभी-अभी</translation>
-<translation id="3478363558367712427">आप अपना सर्च इंजन चुन सकते हैं</translation>
+<translation id="6910211073230771657">हटाया गया</translation>
+<translation id="6965382102122355670">ठीक है</translation>
+<translation id="5301954838959518834">ठीक है, समझ लिया</translation>
+<translation id="7658239707568436148">अभी नहीं</translation>
 <translation id="3479552764303398839">अभी नहीं</translation>
-<translation id="3492207499832628349">नया गुप्त टैब</translation>
-<translation id="3493531032208478708">सुझाई गई सामग्री के बारे में <ph name="BEGIN_LINK" />ज़्यादा जानें<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">ऑगमेंटेड रिएलिटी (AR)</translation>
-<translation id="3518985090088779359">स्‍वीकार करें और जारी रखें</translation>
-<translation id="3522247891732774234">अपडेट उपलब्ध है. ज़्यादा विकल्प</translation>
-<translation id="3524138585025253783">डेवलपर यूज़र इंटरफ़ेस (यूआई)</translation>
-<translation id="3527085408025491307">फ़ोल्डर</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> केबी उपलब्ध</translation>
-<translation id="3549657413697417275">अपने इतिहास में खोजें</translation>
-<translation id="3557336313807607643">संपर्कों में जोड़ें</translation>
-<translation id="3566923219790363270">Chrome अब भी VR के लिए तैयारी कर रहा है. Chrome को बाद में रीस्टार्ट करें.</translation>
-<translation id="3568688522516854065">अपने दूसरे डिवाइस से अपने टैब पाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
-<translation id="3587482841069643663">सभी</translation>
-<translation id="358794129225322306">किसी साइट को अपने आप एक से ज़्यादा फ़ाइलें लोड करने की मंज़ूरी दें.</translation>
-<translation id="3590487821116122040">ऐसी 'साइट मेमोरी' जो Chrome के हिसाब से ज़रूरी नहीं है (जैसे कि ऐसी साइट जिनमें कोई भी सेटिंग नहीं सेव की गई है या जिन पर आप अक्सर नहीं जाते हैं)</translation>
-<translation id="3599863153486145794">साइन इन किए हुए सभी डिवाइसों से इतिहास साफ़ कर देता है. आपके Google खाते में <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> पर अन्य प्रकार के ब्राउज़िंग इतिहास हो सकते हैं.</translation>
-<translation id="3600792891314830896">आवाज़ चलाने वाली साइटों की आवाज़ बंद करें</translation>
-<translation id="3616113530831147358">ऑडियो</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> के साथ शेयर किया जा रहा है</translation>
-<translation id="3632295766818638029">पासवर्ड दिखाएं</translation>
-<translation id="363596933471559332">स्टोर किए गए क्रेडेंशियल का इस्तेमाल करके वेबसाइटों में अपने आप साइन इन करें. सुविधा के बंद होने पर, किसी वेबसाइट में साइन इन करने से पहले आपसे हर बार पुष्टि करने को कहा जाएगा.</translation>
-<translation id="3658159451045945436">रीसेट करने से आपकी देखी गई साइटों की सूची के साथ ही, डेटा बचाने का आपका इतिहास हमेशा के लिए मिट जाता है.</translation>
-<translation id="3692944402865947621"><ph name="FILE_NAME" /> डाउनलोड नहीं हो सकी क्योंकि स्टोर करने की जगह नहीं मिली.</translation>
-<translation id="3714981814255182093">ढूंढें बार खोलें</translation>
-<translation id="3716182511346448902">यह पेज बहुत ज़्यादा मेमोरी का इस्तेमाल करता है, इसलिए Chrome ने इसे रोक दिया है.</translation>
-<translation id="3730075448226062617">Chrome को अपना माइक्रोफ़ोन ऐक्सेस करने देने के लिए, <ph name="BEGIN_LINK" />Android की सेटिंग<ph name="END_LINK" /> में जाकर भी माइक्रोफ़ोन चालू करें.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> में बुकमार्क किया गया</translation>
-<translation id="3744111561329211289">बैकग्राउंड सिंक</translation>
-<translation id="3771001275138982843">अपडेट डाउनलोड नहीं किया जा सका</translation>
-<translation id="3771033907050503522">गुप्त टैब</translation>
-<translation id="3773755127849930740">युग्मन की अनुमति देने के लिए <ph name="BEGIN_LINK" />ब्लूटूथ चालू करें<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">अपने डिवाइस पर भेजें</translation>
-<translation id="3778956594442850293">होम स्‍क्रीन में जोड़ा गया</translation>
-<translation id="3789841737615482174">इंस्‍टॉल करें</translation>
-<translation id="3810838688059735925">वीडियो</translation>
-<translation id="3810973564298564668">प्रबंधित करें</translation>
-<translation id="381841723434055211">फ़ोन नंबर</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> डाउनलोड हटाए गए</translation>
-<translation id="3822502789641063741">क्या आप साइट मेमोरी खाली करना चाहते हैं?</translation>
-<translation id="385051799172605136">वापस</translation>
-<translation id="3859306556332390985">आगे जाएं</translation>
-<translation id="3894427358181296146">फ़ोल्डर जोड़ें</translation>
-<translation id="3895926599014793903">ज़बरदस्ती ज़ूम करना चालू करें</translation>
-<translation id="3912508018559818924">वेब की सबसे अच्छी जानकारी ढूंढी जा रही है…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">मेरा डेटा संयोजित करें</translation>
-<translation id="393697183122708255">कोई चालू बोलकर खोजने की सुविधा उपलब्‍ध नहीं है</translation>
-<translation id="395206256282351086">खोज और साइट सुझाव बंद हैं</translation>
-<translation id="3955193568934677022">साइटों को सुरक्षित सामग्री चलाने दें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{तैयार होने पर Chrome आपका पेज लोड करेगा}one{तैयार होने पर Chrome आपके पेज लोड करेगा}other{तैयार होने पर Chrome आपके पेज लोड करेगा}}</translation>
-<translation id="3963007978381181125">लंबा पासवर्ड सुरक्षित करने के तरीके में Google Pay से भुगतान करने की विधि और पते शामिल नहीं हैं. सिर्फ़ वह इंसान आपका सुरक्षित किया हुआ डेटा पढ़ सकता है जिसके पास आपका लंबा पासवर्ड है. Google की ओर से लंबा पासवर्ड भेजा या संग्रहित नहीं किया जाता है. अगर आप अपना लंबा पासवर्ड भूल जाते हैं या इस सेटिंग को बदलना चाहते हैं, तो आपको सिंक रीसेट करना होगा. <ph name="BEGIN_LINK" />ज़्यादा जानें<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">डाउनलोड पूरा हुआ</translation>
-<translation id="397583555483684758">समन्‍वयन ने काम करना बंद कर दिया है</translation>
-<translation id="3976396876660209797">इस शॉर्टकट को निकालें और इसे फिर से बनाएं</translation>
-<translation id="3985215325736559418">क्या आप <ph name="FILE_NAME" /> को फिर से डाउनलोड करना चाहते हैं?</translation>
-<translation id="3987993985790029246">लिंक की प्रति बनाएं</translation>
-<translation id="3988213473815854515">स्‍थान अनुमत है</translation>
-<translation id="3988466920954086464">झटपट खोज नतीजे इस पैनल में देखें</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">महत्वहीन मेमोरी</translation>
-<translation id="4000212216660919741">ऑफ़लाइन होम</translation>
+<translation id="5317780077021120954">सेव करें</translation>
+<translation id="4570913071927164677">विवरण</translation>
+<translation id="8730621377337864115">हो गया</translation>
+<translation id="8261506727792406068">मिटाएं</translation>
+<translation id="1181037720776840403">हटाएं</translation>
+<translation id="5939518447894949180">रीसेट करें</translation>
 <translation id="4002066346123236978">शीर्षक</translation>
-<translation id="4008040567710660924">किसी खास साइट के लिए कुकी की मंज़ूरी दें.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# घंटा}one{# घंटे}other{# घंटे}}</translation>
-<translation id="4046123991198612571">अगला ट्रैक</translation>
-<translation id="4048707525896921369">पेज को छोड़े बिना वेबसाइटों पर मौजूद विषयों के बारे में जानें. 'खोजने के लिए टैप करें' सुविधा, 'Google सर्च' को कोई शब्‍द और उससे जुड़ी जानकारी भेजती है. इससे परिभाषाएं, तस्वीर, खोज नतीजे और दूसरी जानकारियां हासिल होती हैं.
+<translation id="5916664084637901428">चालू</translation>
+<translation id="5860033963881614850">बंद</translation>
+<translation id="6165508094623778733">ज़्यादा जानें</translation>
+<translation id="6042308850641462728">और ज़्यादा</translation>
+<translation id="6040143037577758943">बंद करें</translation>
+<translation id="780301667611848630">नहीं, रहने दें</translation>
+<translation id="1201402288615127009">अगला</translation>
+<translation id="2359808026110333948">जारी रखें</translation>
+<translation id="2653659639078652383">सबमिट करें</translation>
+<translation id="2079545284768500474">वापस लाएं</translation>
+<translation id="7649070708921625228">सहायता</translation>
+<translation id="2148716181193084225">आज</translation>
+<translation id="7781829728241885113">बीता कल</translation>
+<translation id="6945221475159498467">चुनें</translation>
+<translation id="7791543448312431591">जोड़ें</translation>
+<translation id="6527303717912515753">शेयर करें</translation>
+<translation id="1383876407941801731">खोजें</translation>
+<translation id="3115898365077584848">जानकारी दिखाएं</translation>
+<translation id="3295602654194328831">जानकारी छिपाएं</translation>
+<translation id="3987993985790029246">लिंक की प्रति बनाएं</translation>
+<translation id="2704606927547763573">कॉपी किया गया</translation>
+<translation id="8725066075913043281">फिर से कोशिश करें</translation>
+<translation id="385051799172605136">वापस</translation>
+<translation id="8131740175452115882">दुबारा पूछें</translation>
+<translation id="5300589172476337783">दिखाएं</translation>
+<translation id="1124772482545689468">उपयोगकर्ता</translation>
+<translation id="8609465669617005112">ऊपर जाएं</translation>
+<translation id="6746124502594467657">नीचे जाएं</translation>
+<translation id="8249310407154411074">सबसे ऊपर ले जाएं</translation>
+<translation id="8428213095426709021">सेटिंग</translation>
+<translation id="2498359688066513246">सहायता और फ़ीडबैक</translation>
+<translation id="8378714024927312812">आपके संगठन की ओर से प्रबंधित</translation>
+<translation id="9019902583201351841">आपके अभिभावकों द्वारा प्रबंधित</translation>
+<translation id="4645575059429386691">आपके अभिभावक द्वारा प्रबंधित</translation>
+<translation id="4883854917563148705">प्रबंधित सेटिंग रीसेट नहीं की जा सकती हैं</translation>
+<translation id="4307992518367153382">बुनियादी चीज़ें</translation>
+<translation id="1974060860693918893">बेहतर</translation>
+<translation id="1146678959555564648">VR डालें</translation>
+<translation id="987264212798334818">सामान्य</translation>
+<translation id="4275663329226226506">मीडिया</translation>
+<translation id="4759238208242260848">डाउनलोड</translation>
+<translation id="218608176142494674">शेयर किया जा रहा है</translation>
+<translation id="8004582292198964060">ब्राउज़र</translation>
+<translation id="1105960400813249514">स्‍क्रीन कैप्‍चर</translation>
+<translation id="4875775213178255010">सामग्री के सुझाव</translation>
+<translation id="2021896219286479412">पूरी स्क्रीन के साइट नियंत्रण</translation>
+<translation id="4587589328781138893">साइटें</translation>
+<translation id="4943703118917034429">वर्चुअल रियलिटी</translation>
+<translation id="1928696683969751773">अपडेट</translation>
+<translation id="6064125863973209585">पूरे हो चुके डाउनलोड</translation>
+<translation id="5342314432463739672">अनुमति से जुड़े अनुरोध</translation>
+<translation id="629730747756840877">खाता</translation>
+<translation id="82609232232243542">Brave में साइन इन करें</translation>
+<translation id="7956662517480676674">सिंक और Brave Software सेवाएं</translation>
+<translation id="5294439808117722387">आप इस समय अपनी सिंक की सुविधा और Brave Software सेवा की सेटिंग कस्टमाइज़ कर रहे हैं. सिंक चालू करने की प्रक्रिया पूरी करने के लिए, स्क्रीन के निचले हिस्से पर मौजूद 'पुष्टि करें' बटन पर टैप करें. ऊपर जाएं</translation>
+<translation id="2096012225669085171">सभी डिवाइस में सिंक करना और मनमुताबिक बनाना</translation>
+<translation id="1692118695553449118">समन्वयन चालू है</translation>
+<translation id="5514904542973294328">इस डिवाइस के व्यवस्थापक ने अक्षम किया है</translation>
+<translation id="6447211988989208781">Brave Software गतिविधि नियंत्रण</translation>
+<translation id="4882831918239250449">यह नियंत्रित करें कि खोज, विज्ञापनों वगैरह को मनमुताबिक बनाने के लिए आपके ब्राउज़िंग इतिहास का इस्तेमाल कैसे किया जाए</translation>
+<translation id="7431991332293347422">यह नियंत्रित करें कि खोज वगैरह को मनमुताबिक बनाने के लिए आपके ब्राउज़िंग इतिहास का इस्तेमाल कैसे किया जाए</translation>
+<translation id="6303969859164067831">साइन आउट करें और सिंक बंद करें</translation>
+<translation id="1125261911132334651">अपना Brave Software खाता प्रबंधित करें</translation>
+<translation id="6406506848690869874">सिंक</translation>
+<translation id="714362445477979774">अपना Brave डेटा सिंक करें</translation>
+<translation id="4314815835985389558">सिंक प्रबंधित करें</translation>
+<translation id="5428209950370661546">Brave Software की दूसरी सेवाएंं</translation>
+<translation id="7704317875155739195">खोजों और यूआरएल को अपने आप पूरा करें</translation>
+<translation id="2000419248597011803">'पता बार' और 'खोज बॉक्स' की कुछ कुकी और खोजों को आपके डिफ़ॉल्ट खोज इंजन पर भेजा जाता है</translation>
+<translation id="7981313251711023384">ज़्यादा तेज़ी से ब्राउज़ करने और खोजने के लिए पेज पहले से लोड करें</translation>
+<translation id="1821253160463689938">आपकी पसंद याद रखने के लिए कुकी का इस्तेमाल करती है, भले ही आप उन पेजों पर नहीं जाते</translation>
+<translation id="6697492270171225480">जब कोई पेज मिल नहीं पा रहा हो तो मिलते-जुलते पेज के सुझाव दिखाएं</translation>
+<translation id="8109318360573330108">आप जिस पेज पर जाने की कोशिश कर रहे हैं उसका यूआरएल Brave Software को भेजती है</translation>
+<translation id="8438566539970814960">खोजों और ब्राउज़िंग को बेहतर बनाएं</translation>
+<translation id="284843628681142937">आप जिन पेजों पर जाते हैं उनके यूआरएल Brave Software को भेजती है</translation>
+<translation id="7222718784508482526">निजता, सुरक्षा और डेटा इकट्ठा करने से जुड़ी ज़्यादा सेटिंग के लिए, <ph name="BEGIN_LINK"/>सिंक और Brave Software सेवाएं<ph name="END_LINK"/> देखें</translation>
+<translation id="918192811481327695">Brave के फ़ीचर और परफ़ॉर्मेंस को बेहतर बनाने में सहायता करें</translation>
+<translation id="9063160602596686558">Brave Software को इस्तेमाल के आंकड़े और खराबी रिपोर्ट अपने आप भेजती है</translation>
+<translation id="4824958205181053313">सिंक करना रद्द करें?</translation>
+<translation id="3058498974290601450">आप सेटिंग में किसी भी समय सिंक चालू कर सकते हैं</translation>
+<translation id="3143515551205905069">लिंक करना रोक दें</translation>
+<translation id="1506061864768559482">सर्च इंजन</translation>
+<translation id="55737423895878184">स्थान और सूचनाओं की अनुमति है</translation>
+<translation id="3988213473815854515">स्‍थान अनुमत है</translation>
+<translation id="32895400574683172">सूचनाओं की अनुमति है</translation>
+<translation id="9040142327097499898">सूचनाओं की अनुमति है. इस डिवाइस के लिए स्थान की जानकारी बंद है.</translation>
+<translation id="305593374596241526">स्थान सेवा बंद है, उसे <ph name="BEGIN_LINK"/>Android सेटिंग<ph name="END_LINK"/> में चालू करें.</translation>
+<translation id="2989523299700148168">हाल ही में देखे गए</translation>
+<translation id="6433501201775827830">अपना सर्च इंजन चुनें</translation>
+<translation id="7177466738963138057">आप इसे बाद में सेटिंग में जाकर बदल सकते हैं</translation>
+<translation id="3478363558367712427">आप अपना सर्च इंजन चुन सकते हैं</translation>
+<translation id="4910889077668685004">भुगतान ऐप्लिकेशन</translation>
+<translation id="5152843274749979095">भुगतान करने के लिए कोई ऐप्लिकेशन इंस्‍टॉल नहीं है</translation>
+<translation id="8812260976093120287">कुछ वेबसाइटों पर, आप ऊपर समर्थित भुगतान ऐप्लिकेशन के ज़रिए अपने डिवाइस पर भुगतान कर सकते हैं.</translation>
+<translation id="7764225426217299476">पता जोड़ें</translation>
+<translation id="5595485650161345191">पते में बदलाव करें</translation>
+<translation id="5087580092889165836">कार्ड जोड़ें</translation>
+<translation id="2154484045852737596">कार्ड में बदलाव करें</translation>
+<translation id="6140912465461743537">देश/क्षेत्र</translation>
+<translation id="5659593005791499971">ईमेल</translation>
+<translation id="4378154925671717803">फ़ोन</translation>
+<translation id="4807098396393229769">कार्ड पर नाम</translation>
+<translation id="860043288473659153">कार्डधारक का नाम</translation>
+<translation id="2612676031748830579">कार्ड संख्या</translation>
+<translation id="869891660844655955">समय समाप्ति तारीख</translation>
+<translation id="2286841657746966508">बिलिंग पता</translation>
+<translation id="663059986967017181">Brave पर कॉपी किया गया</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> अन्य}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> अन्य}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> अन्य}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> अन्य}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> अन्य}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> अन्य}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> अन्य}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> अन्य}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> अन्य}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> अन्य}one{<ph name="CONTACT_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> अन्य}other{<ph name="CONTACT_PREVIEW"/>\u2026 और <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> अन्य}}</translation>
+<translation id="7029809446516969842">पासवर्ड</translation>
+<translation id="1943432128510653496">पासवर्ड सेव करें</translation>
+<translation id="2100273922101894616">अपने आप साइन इन करने की सुविधा</translation>
+<translation id="363596933471559332">स्टोर किए गए क्रेडेंशियल का इस्तेमाल करके वेबसाइटों में अपने आप साइन इन करें. सुविधा के बंद होने पर, किसी वेबसाइट में साइन इन करने से पहले आपसे हर बार पुष्टि करने को कहा जाएगा.</translation>
+<translation id="6995899638241819463">डेटा का उल्लंघन होने पर अगर आपके पासवर्ड बिना अनुमति के सार्वजनिक हो जाते हैं, तो आपको चेतावनी मिलती है</translation>
+<translation id="1534287762301776620">जब आप अपने Brave Software खाते में लॉग इन करते हैं, तो यह सुविधा चालू हो जाती है</translation>
+<translation id="10614374240317010">कभी नहीं सेव किया गया</translation>
+<translation id="3098842761938485917">अपने <ph name="BEGIN_LINK"/>Brave Software खाते<ph name="END_LINK"/> में सेव किए गए पासवर्ड देखें और उन्हें प्रबंधित करें</translation>
+<translation id="8562452229998620586">सहेजे गए पासवर्ड यहां दिखाई देंगे.</translation>
+<translation id="8084114998886531721">सहेजा गया पासवर्ड</translation>
+<translation id="2870560284913253234">साइट</translation>
+<translation id="8503813439785031346">उपयोगकर्ता नाम</translation>
+<translation id="6657585470893396449">पासवर्ड</translation>
+<translation id="2154710561487035718">URL की कॉपी बनाएं</translation>
+<translation id="1571304935088121812">उपयोगकर्ता नाम की कॉपी करें</translation>
+<translation id="5005498671520578047">पासवर्ड कॉपी करें</translation>
+<translation id="3632295766818638029">पासवर्ड दिखाएं</translation>
+<translation id="1513858653616922153">पासवर्ड मिटाएं</translation>
+<translation id="543338862236136125">पासवर्ड में बदलाव करें</translation>
+<translation id="4565377596337484307">पासवर्ड छिपाएं</translation>
+<translation id="8523928698583292556">स्टोर किया गया पासवर्ड मिटाएं</translation>
+<translation id="2898264748040935573">सेव किया गया पासवर्ड बदलें</translation>
+<translation id="5433691172869980887">उपयोगकर्ता नाम कॉपी किया गया</translation>
+<translation id="5534640966246046842">साइट की कॉपी की गई</translation>
+<translation id="2625189173221582860">पासवर्ड कॉपी किया गया</translation>
+<translation id="4550003330909367850">यहां अपना पासवर्ड देखने या उसे कॉपी करने के लिए, इस डिवाइस पर स्क्रीन लॉक सेट करें.</translation>
+<translation id="6154478581116148741">इस डिवाइस से अपने पासवर्ड निर्यात करने के लिए सेटिंग में स्क्रीन लॉक चालू करें</translation>
+<translation id="4842092870884894799">पासवर्ड जेनरेशन पॉपअप दिखाया जा रहा है</translation>
+<translation id="2259659629660284697">पासवर्ड निर्यात करें…</translation>
+<translation id="133012818630824069">Brave के ज़रिए संग्रहित पासवर्ड निर्यात करें</translation>
+<translation id="6914783257214138813">आपके पासवर्ड, निर्यात की गई फ़ाइल देख पाने वाले सभी व्यक्तियों को दिखाई देंगे.</translation>
+<translation id="2321086116217818302">पासवर्ड तैयार हो रहे हैं…</translation>
+<translation id="8445448999790540984">पासवर्ड निर्यात नहीं कर सकते</translation>
+<translation id="3066461326500799725">Brave Software डिस्क के इस्तेमाल का तरीका जानें</translation>
+<translation id="729975465115245577">आपके डिवाइस में पासवर्ड फ़ाइल को स्टोर करने वाला कोई ऐप्लिकेशन नहीं है.</translation>
+<translation id="7682724950699840886">ये सलाह आज़माएं: पक्का करें कि आपके डिवाइस पर ज़रूरी जगह उपलब्ध है, फिर दोबारा निर्यात करके देखें.</translation>
+<translation id="1129510026454351943">विवरण: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">अपना पासवर्ड कॉपी करने के लिए अनलॉक करें</translation>
+<translation id="5515439363601853141">अपना पासवर्ड देखने के लिए अनलॉक करें</translation>
+<translation id="6221633008163990886">अपने पासवर्ड निर्यात करने के लिए अनलॉक करें</translation>
+<translation id="230699814587342492">Brave पासवर्ड</translation>
+<translation id="6075798973483050474">होम पेज में बदलाव करें</translation>
+<translation id="854522910157234410">यह पेज खोलें</translation>
+<translation id="2482878487686419369">सूचनाएं</translation>
+<translation id="6255999984061454636">सामग्री के सुझाव</translation>
+<translation id="805047784848435650">आपके ब्राउज़िंग इतिहास के आधार पर</translation>
+<translation id="1041308826830691739">वेबसाइटों से</translation>
+<translation id="395206256282351086">खोज और साइट सुझाव बंद हैं</translation>
+<translation id="257088987046510401">थीम</translation>
+<translation id="4650364565596261010">सिस्टम डिफ़ॉल्ट</translation>
+<translation id="7588219262685291874">आपके डिवाइस की 'बैटरी सेवर' सुविधा चालू होने पर 'गहरे रंग वाली थीम' चालू करें</translation>
+<translation id="2760989362628427051">अपने डिवाइस की गहरे रंग वाली थीम या 'बैटरी सेवर' चालू होने पर गहरे रंग वाली थीम चालू करें</translation>
+<translation id="6381421346744604172">वेबसाइटों को गहरा करने का विकल्प</translation>
+<translation id="5040262127954254034">निजता</translation>
+<translation id="4991384657077828949">'Brave सुरक्षा' को बेहतर बनाने में मदद करें</translation>
+<translation id="1943176487615318915">खतरनाक ऐप्लिकेशन और साइटों का पता लगाने के लिए, Brave ऐसे कुछ पेज का यूआरएल Brave Software को भेजता है जिन पर आप जाते हैं. साथ ही, वह सिस्टम की सीमित जानकारी और पेज की कुछ सामग्री भी Brave Software को भेजता है</translation>
+<translation id="3181954750937456830">सुरक्षित ब्राउज़िंग (आपकी और आपके डिवाइस की खतरनाक साइट से सुरक्षा करती है)</translation>
+<translation id="7315322926489145388">आपकी सुरक्षा को खतरा होने पर उन पेज के यूआरएल भेजे जाते हैं जिन पर आप Brave Software के ज़रिए जाते हैं.</translation>
+<translation id="2063713494490388661">खोजने के लिए टैप करें</translation>
+<translation id="2369463299479365221">पेज को छोड़े बिना वेबसाइटों पर मौजूद विषयों के बारे में जानें. 'खोजने के लिए टैप करें' सुविधा, 'Brave Software सर्च' को कोई शब्‍द और उससे जुड़ी जानकारी भेजती है. इससे परिभाषाएं, तस्वीर, खोज नतीजे और दूसरी जानकारियां हासिल होती हैं.
 
 अपने खोज के शब्द को एडजस्‍ट करने के लिए उसे चुनें. चुनने के लिए उसे देर तक दबाकर रखें. अपनी खोज को बेहतर बनाने के लिए, पैनल को सीधे ऊपर स्‍लाइड करें और 'खोज बॉक्‍स' पर टैप करें.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">स्क्रीन के शीर्ष भाग में मौजूद विकल्प</translation>
-<translation id="4062305924942672200">कानूनी जानकारी</translation>
-<translation id="4084682180776658562">बुकमार्क</translation>
-<translation id="4084712963632273211">प्रकाशक: <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />Google की ओर से डिलीवर किया गया<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">ऐप्लिकेशन डेटा मिटाएं?</translation>
-<translation id="4099578267706723511">Google को इस्तेमाल के आंकड़े और खराबी रिपोर्ट भेजकर Chrome को बेहतर बनाने में मदद करें.</translation>
-<translation id="410351446219883937">अपने आप चलाएं</translation>
-<translation id="4116038641877404294">पेजों को ऑफ़लाइन इस्तेमाल करने के लिए उन्हें डाउनलोड करें</translation>
-<translation id="4135200667068010335">टैब शेयर करने के लिए चुने गए डिवाइस की सूची बंद है.</translation>
-<translation id="4149994727733219643">वेब पेजों के लिए सरल बनाया गया व्यू</translation>
-<translation id="4165986682804962316">साइट सेटिंग</translation>
-<translation id="4169535189173047238">अनुमति न दें</translation>
-<translation id="4170011742729630528">सेवा उपलब्ध नहीं है; बाद में फिर से प्रयास करें.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> इस्तेमाल किए गए</translation>
-<translation id="4181841719683918333">भाषाएं</translation>
-<translation id="4183868528246477015">'Google लेंस' से खोजें <ph name="BEGIN_NEW" />नया<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">नए टैब में खोलें</translation>
-<translation id="4198423547019359126">डाउनलोड करने की कोई जगह उपलब्ध नहीं है</translation>
-<translation id="4209895695669353772">Google की ओर से सुझाई गई मनमुताबिक सामग्री पाने के लिए, 'सिंक करें' को चालू करें</translation>
-<translation id="4226663524361240545">नोटिफ़िकेशन से डिवाइस में कंपन हो सकता है</translation>
-<translation id="423219824432660969"><ph name="TIME" /> तक का सुरक्षित किया गया किया गया डेटा 'Google पासवर्ड' से सिंक करें</translation>
-<translation id="4242533952199664413">सेटिंग खोलें</translation>
-<translation id="4256782883801055595">ओपन सोर्स लाइसेंस</translation>
-<translation id="4259722352634471385">मार्गदर्शक अवरोधित है: <ph name="URL" /></translation>
-<translation id="4269820728363426813">लिंक पते को कॉपी करें</translation>
-<translation id="4275663329226226506">मीडिया</translation>
-<translation id="4278390842282768270">अनुमति है</translation>
-<translation id="429312253194641664">किसी साइट पर मीडिया चल रहा है</translation>
-<translation id="4298388696830689168">लिंक की हुई साइटें</translation>
-<translation id="4307992518367153382">बुनियादी चीज़ें</translation>
-<translation id="4314815835985389558">सिंक प्रबंधित करें</translation>
-<translation id="4351244548802238354">संवाद बंद करें</translation>
-<translation id="4378154925671717803">फ़ोन</translation>
-<translation id="4384468725000734951">खोज के लिए Sogou का इस्तेमाल कर रहे हैं</translation>
-<translation id="4404568932422911380">कोई बुकमार्क नहीं</translation>
-<translation id="4405224443901389797">इसमें ले जाएं…</translation>
-<translation id="4411535500181276704">लाइट मोड</translation>
-<translation id="4415276339145661267">अपना Google खाता प्रबंधित करें</translation>
-<translation id="4432792777822557199">अब से <ph name="SOURCE_LANGUAGE" /> भाषा के पेज का अनुवाद <ph name="TARGET_LANGUAGE" /> भाषा में किया जाएगा</translation>
-<translation id="4433925000917964731">लाइट पेज Google ने मुहैया कराया है</translation>
-<translation id="4434045419905280838">पॉप-अप और रीडायरेक्ट</translation>
-<translation id="4440958355523780886">Google की ओर से 'लाइट पेज' दिया गया. 'मूल पेज' लोड करने के लिए टैप करें.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> टैब बंद करें</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> में बुकमार्क किया गया</translation>
-<translation id="445467742685312942">साइटों को सभी सुरक्षित सामग्री चलाने दें</translation>
-<translation id="4468959413250150279">किसी खास साइट के लिए आवाज़ बंद करें.</translation>
-<translation id="4472118726404937099">सभी डिवाइस पर सिंक करने और मनमुताबिक बनाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
-<translation id="447252321002412580">Chrome के फ़ीचर और परफ़ॉर्मेंस को बेहतर बनाने में सहायता करें</translation>
-<translation id="4479647676395637221">साइटों को अपने कैमरे का इस्तेमाल करने देने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया )</translation>
-<translation id="4479972344484327217">Chrome के लिए <ph name="MODULE" /> इंस्टॉल किया जा रहा है…</translation>
-<translation id="4487967297491345095">Chrome का सभी ऐप्लिकेशन डेटा हमेशा केे लिए हटा दिया जाएगा. इसमें सभी फ़ाइलें, सेटिंग, खाते, डेटाबेस वगैरह शामिल हैं.</translation>
-<translation id="4493497663118223949">लाइट मोड चालू है</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# दिन पहले}one{# दिन पहले}other{# दिन पहले}}</translation>
-<translation id="451872707440238414">अपने बुकमार्क में खोजें</translation>
-<translation id="4521489764227272523">चुना गया डेटा Chrome और आपके सिंक किए गए डिवाइस से हटा दिया गया है.
-
-आपके Google खाते में <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> पर की जाने वाली खोजों और अन्य Google सेवाओं की गतिविधि जैसे दूसरी तरह के ब्राउज़िंग इतिहास मौजूद हो सकते हैं.</translation>
-<translation id="4532845899244822526">फ़ोल्डर चुनें</translation>
-<translation id="4538018662093857852">लाइट मोड चालू करें</translation>
-<translation id="4550003330909367850">यहां अपना पासवर्ड देखने या उसे कॉपी करने के लिए, इस डिवाइस पर स्क्रीन लॉक सेट करें.</translation>
-<translation id="4558311620361989323">वेबपेज शॉर्टकट</translation>
-<translation id="4561979708150884304">कोई कनेक्शन नहीं</translation>
-<translation id="4565377596337484307">पासवर्ड छिपाएं</translation>
-<translation id="4570913071927164677">विवरण</translation>
-<translation id="4572422548854449519">प्रबंधित खाते में साइन इन करें</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# मिनट पहले}one{# मिनट पहले}other{# मिनट पहले}}</translation>
-<translation id="4587589328781138893">साइटें</translation>
-<translation id="4594952190837476234">यह पेज <ph name="CREATION_TIME" /> का है और यह ऑनलाइन वर्शन से अलग हो सकता है.</translation>
-<translation id="4605958867780575332">आइटम निकाला गया: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> को खोलें</translation>
-<translation id="4634124774493850572">पासवर्ड का इस्तेमाल करें</translation>
-<translation id="4645575059429386691">आपके अभिभावक द्वारा प्रबंधित</translation>
-<translation id="4650364565596261010">सिस्टम डिफ़ॉल्ट</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> बुकमार्क का पता लगा</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> को आपकी होम स्क्रीन में जोड़ा गया था</translation>
-<translation id="4684427112815847243">सब कुछ सिंक करें</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> अन्य}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> अन्य}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> अन्य}}</translation>
-<translation id="4696983787092045100">अपने डिवाइस पर मैसेज भेजें</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> में ऑफ़लाइन देखें</translation>
-<translation id="4699172675775169585">कैश इमेज और फ़ाइलें</translation>
-<translation id="4714588616299687897">अपना 60% तक डेटा बचाएं</translation>
-<translation id="4719927025381752090">अनुवाद करना ऑफ़र करें</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" /> में खोलें</translation>
-<translation id="4720982865791209136">Chrome को बेहतर बनाने में सहायता करें. <ph name="BEGIN_LINK" />सर्वे में भाग लें<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">अपडेट करें</translation>
-<translation id="4738836084190194332">अंतिम बार सिंक किया गया: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">नया टैब खोलें</translation>
-<translation id="4751476147751820511">गति या लाइट सेंसर</translation>
-<translation id="4759238208242260848">डाउनलोड</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 डाउनलोड पूरा हुआ.}one{# डाउनलोड पूरे हुए.}other{# डाउनलोड पूरे हुए.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" /> पर वापस लौटने के लिए स्पर्श करें</translation>
-<translation id="4802417911091824046">लंबा पासवर्ड सुरक्षित करने में Google Pay से भुगतान करने के तरीके और पते शामिल नहीं हैं.
-
-यह सेटिंग बदलने के लिए, <ph name="BEGIN_LINK" />सिंक रीसेट करें<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">कार्ड पर नाम</translation>
-<translation id="4824958205181053313">सिंक करना रद्द करें?</translation>
-<translation id="4837753911714442426">पेज प्रिंट करने के विकल्प खोलें</translation>
-<translation id="4842092870884894799">पासवर्ड जेनरेशन पॉपअप दिखाया जा रहा है</translation>
-<translation id="4860895144060829044">कॉल करें</translation>
-<translation id="4866368707455379617">Chrome के लिए <ph name="MODULE" /> इंस्टॉल नहीं किया जा सका</translation>
-<translation id="4875775213178255010">सामग्री के सुझाव</translation>
-<translation id="4878404682131129617">प्रॉक्सी सर्वर के ज़रिए सुरंग बनाना विफल रहा</translation>
-<translation id="4880127995492972015">अनुवाद करें…</translation>
-<translation id="4881695831933465202">खोलें</translation>
-<translation id="488187801263602086">फ़ाइल का नाम बदलें</translation>
-<translation id="4882831918239250449">यह नियंत्रित करें कि खोज, विज्ञापनों वगैरह को मनमुताबिक बनाने के लिए आपके ब्राउज़िंग इतिहास का इस्तेमाल कैसे किया जाए</translation>
-<translation id="4883854917563148705">प्रबंधित सेटिंग रीसेट नहीं की जा सकती हैं</translation>
-<translation id="4885273946141277891">Chrome इंस्टेंस की असमर्थित संख्या.</translation>
-<translation id="4910889077668685004">भुगतान ऐप्लिकेशन</translation>
-<translation id="4913161338056004800">आंकड़े रीसेट करें</translation>
-<translation id="4913169188695071480">रीफ्रेश करना बंद करें</translation>
-<translation id="4915549754973153784">डिवाइस स्कैन करने में <ph name="BEGIN_LINK" />सहायता पाएं<ph name="END_LINK" />...</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# पेज}one{# पेज}other{# पेज}}</translation>
-<translation id="4932247056774066048">आप किसी ऐसे खाते से साइन आउट कर रहे हैं जिसे <ph name="DOMAIN_NAME" /> से प्रबंधित किया जाता है. इस वजह से, Chrome पर मौजूद आपका डेटा इस डिवाइस से मिटा दिया जाएगा. हालांकि, यह डेटा आपके Google खाते पर मौजूद रहेगा.</translation>
-<translation id="4943703118917034429">वर्चुअल रियलिटी</translation>
-<translation id="4943872375798546930">कोई परिणाम नहीं</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> आपकी स्क्रीन शेयर कर रहा है</translation>
-<translation id="4961107849584082341">इस पेज का अनुवाद किसी भी भाषा में करें</translation>
-<translation id="4962975101802056554">डिवाइस की सभी अनुमतियां निरस्त करें</translation>
-<translation id="4970824347203572753">आपके देश में उपलब्ध नहीं है</translation>
-<translation id="497421865427891073">आगे जाएं</translation>
-<translation id="4988210275050210843">फ़ाइल डाउनलोड हो रही है (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">पेज</translation>
-<translation id="4994033804516042629">कोई संपर्क नहीं मिला</translation>
-<translation id="4996978546172906250">इससे शेयर करें</translation>
-<translation id="5004416275253351869">Google गतिविधि नियंत्रण</translation>
-<translation id="5005498671520578047">पासवर्ड कॉपी करें</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> कनेक्ट करना चाहती है</translation>
-<translation id="5013696553129441713">कोई नया सुझाव नहीं है</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">जब आप वीआर इस्तेमाल करते हैं, तो साइट ये बातें जान सकती है:
-  -  आपकी शारीरिक बनावट, जैसे कि लंबाई
-
-वीआर इस्तेमाल करने से पहले पक्का कर लें कि आप इस साइट पर भरोसा करते हैं.</translation>
+<translation id="2930742481329940825">'खोजने के लिए टैप करें' सुविधा चुने हुए शब्‍द और मौजूदा पेज को संदर्भ के रूप में 'Brave Software सर्च' पर भेजती है. आप इसे <ph name="BEGIN_LINK"/>सेटिंग<ph name="END_LINK"/> में जाकर बंद कर सकते हैं.</translation>
 <translation id="5039804452771397117">अनुमति दें</translation>
-<translation id="5040262127954254034">निजता</translation>
-<translation id="5048398596102334565">साइटों को मोशन सेंसर ऐक्‍सेस करने दें (सुझाया गया)</translation>
-<translation id="5063480226653192405">उपयोग</translation>
-<translation id="5087580092889165836">कार्ड जोड़ें</translation>
-<translation id="5100237604440890931">छोटा किया गया - पूरा खोलने के लिए क्लिक करें.</translation>
-<translation id="510275257476243843">1 घंटा शेष</translation>
-<translation id="5123685120097942451">गुप्त टैब</translation>
-<translation id="5127805178023152808">समन्वयन बंद है</translation>
-<translation id="5129038482087801250">वेब ऐप्लिकेशन इंस्टॉल करें</translation>
-<translation id="5132942445612118989">सभी डिवाइस पर अपने पासवर्ड, इतिहास और दूसरी कई चीज़ें सिंक करें</translation>
-<translation id="5139940364318403933">Google डिस्क के इस्तेमाल का तरीका जानें</translation>
-<translation id="515227803646670480">सेव किया गया डेटा साफ़ करें</translation>
-<translation id="5152843274749979095">भुगतान करने के लिए कोई ऐप्लिकेशन इंस्‍टॉल नहीं है</translation>
-<translation id="5161254044473106830">शीर्षक आवश्‍यक</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 डाउनलोड नहीं हो सका.}one{# डाउनलोड नहीं हो सके.}other{# डाउनलोड नहीं हो सके.}}</translation>
-<translation id="5170568018924773124">फ़ोल्डर में दिखाएं</translation>
-<translation id="5184329579814168207">Chrome में खोलें</translation>
-<translation id="5193988420012215838">आपके क्लिपबोर्ड पर कॉपी की गई</translation>
-<translation id="5197729504361054390">आप जो संपर्क चुनेंगे उन्हें <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> के साथ शेयर किया जाएगा.</translation>
-<translation id="5199929503336119739">वर्क प्रोफ़ाइल</translation>
-<translation id="5210286577605176222">सीधे पिछले टैब पर जाएं</translation>
-<translation id="5210365745912300556">टैब बंद करें</translation>
-<translation id="5224771365102442243">वीडियो के साथ</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> आस-पास मौजूद ब्लूटूथ वाले डिवाइस स्कैन करना चाहती है. ये डिवाइस मिले हैं:</translation>
-<translation id="5233638681132016545">नया टैब</translation>
-<translation id="526421993248218238">यह पेज लोड नहीं हो पा रहा है</translation>
-<translation id="5271967389191913893">डाउनलोड की जाने वाली सामग्री को डिवाइस नहीं खोल सकता.</translation>
-<translation id="528192093759286357">फ़ुल स्क्रीन से बाहर निकलने के लिए ऊपर से खींचें और वापस जाएं स्पर्श करें.</translation>
-<translation id="5292796745632149097">इस पर भेजें</translation>
-<translation id="5300589172476337783">दिखाएं</translation>
-<translation id="5301954838959518834">ठीक है, समझ लिया</translation>
-<translation id="5304593522240415983">यह फ़ील्‍ड खाली नहीं छोड़ी जा सकती</translation>
-<translation id="5307446750509046227">साइट की मेमोरी मिटाएं</translation>
-<translation id="5308380583665731573">कनेक्ट करें</translation>
-<translation id="5313967007315987356">साइट जोड़ें</translation>
-<translation id="5317780077021120954">सेव करें</translation>
-<translation id="5324858694974489420">अभिभावकीय सेटिंग</translation>
-<translation id="5327248766486351172">नाम</translation>
-<translation id="5335288049665977812">साइटों को JavaScript चलाने की अनुमति दें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
-<translation id="5342314432463739672">अनुमति से जुड़े अनुरोध</translation>
-<translation id="5357811892247919462">टैब मिला</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> टैब खुला है, एक टैब से दूसरे टैब पर जाने के लिए टैप करें}one{<ph name="OPEN_TABS_MANY" /> टैब खुले हैं, एक टैब से दूसरे टैब पर जाने के लिए टैप करें}other{<ph name="OPEN_TABS_MANY" /> टैब खुले हैं, एक टैब से दूसरे टैब पर जाने के लिए टैप करें}}</translation>
-<translation id="5391532827096253100">इस साइट से आपका कनेक्शन सुरक्षित नहीं है. साइट की जानकारी</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 और)}one{(+ # और)}other{(+ # और)}}</translation>
-<translation id="5400569084694353794">इस ऐप्‍लिकेशन का इस्तेमाल करके, आप Chrome की <ph name="BEGIN_LINK1" />सेवा की शर्तों<ph name="END_LINK1" /> और <ph name="BEGIN_LINK2" />निजता सूचना<ph name="END_LINK2" /> से सहमत होते हैं.</translation>
-<translation id="5403592356182871684">नाम</translation>
-<translation id="5403644198645076998">सिर्फ़ कुछ निश्चित साइटों को ही अनुमति दें</translation>
-<translation id="5414836363063783498">सत्यापन हो रहा है...</translation>
-<translation id="5423934151118863508">  सबसे ज़्यादा देखे गए पेज यहां दिखाई देंगे</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> जीबी उपलब्ध है</translation>
-<translation id="543338862236136125">पासवर्ड में बदलाव करें</translation>
-<translation id="5433691172869980887">उपयोगकर्ता नाम कॉपी किया गया</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> फ़ाइलें डाउनलोड हो रही हैं (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">सीधे पता बार पर जाएं</translation>
-<translation id="5447201525962359567">सभी साइट मेमोरी, जिसमें कुकी और स्थानीय रूप से संग्रहित अन्य डेटा शामिल है</translation>
-<translation id="5447765697759493033">इस साइट का अनुवाद नहीं किया जाएगा</translation>
-<translation id="545042621069398927">आपके डाउनलोड की गति बढ़ाई जा रही है.</translation>
-<translation id="5456381639095306749">पेज डाउनलोड करें</translation>
-<translation id="5475862044948910901">ऑगमेंटेड रिएलिटी (AR) सत्र शुरू करें?</translation>
-<translation id="548278423535722844">मैप ऐप्लिकेशन में खोलें</translation>
-<translation id="5487521232677179737">डेटा साफ़ करें</translation>
-<translation id="5494752089476963479">तंग करने वाले या गुमराह करने वाले विज्ञापन दिखाने वाली साइटों पर विज्ञापन ब्लॉक करें</translation>
-<translation id="5500777121964041360">शायद, यह सुविधा आपके देश में उपलब्ध न हाे</translation>
-<translation id="5512137114520586844">यह खाता <ph name="PARENT_NAME" /> द्वारा प्रबंधित है.</translation>
-<translation id="5514904542973294328">इस डिवाइस के व्यवस्थापक ने अक्षम किया है</translation>
-<translation id="5515439363601853141">अपना पासवर्ड देखने के लिए अनलॉक करें</translation>
-<translation id="5516455585884385570">सूचना सेटिंग खोलें</translation>
-<translation id="5517095782334947753">आपके पास <ph name="FROM_ACCOUNT" /> के बुकमार्क, इतिहास, पासवर्ड और अन्य सेटिंग हैं.</translation>
-<translation id="5524843473235508879">रीडायरेक्ट ब्लॉक किया गया.</translation>
-<translation id="5527082711130173040">डिवाइस स्कैन करने के लिए Chrome को जगह की जानकारी का एक्सेस की ज़रूरत होती है. <ph name="BEGIN_LINK1" />अनुमतियां अपडेट करें<ph name="END_LINK1" />. जगह की जानकारी का एक्सेस <ph name="BEGIN_LINK2" />इस डिवाइस के लिए भी बंद<ph name="END_LINK2" /> है.</translation>
-<translation id="5527111080432883924">साइटों को क्लिपबोर्ड से टेक्स्ट और इमेज पढ़ने की अनुमति देने से पहले पूछें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
-<translation id="5530766185686772672">गुप्त टैब बंद करें</translation>
-<translation id="5534334044554683961">जब आप वीआर इस्तेमाल करते हैं, तो साइट ये बातें जान सकती है:
-  -  आपकी शारीरिक बनावट, जैसे कि लंबाई
- -  आपके कमरे का लेआउट
-
-वीआर इस्तेमाल करने से पहले पक्का कर लें कि आप इस साइट पर भरोसा करते हैं.</translation>
-<translation id="5534640966246046842">साइट की कॉपी की गई</translation>
-<translation id="5556459405103347317">फिर लोड करें</translation>
-<translation id="5561549206367097665">नेटवर्क का इंतज़ार किया जा रहा है…</translation>
-<translation id="557283862590186398">Chrome को इस साइट के लिए आपका माइक्रोफ़ोन एक्सेस करने की अनुमति चाहिए.</translation>
-<translation id="55737423895878184">स्थान और सूचनाओं की अनुमति है</translation>
-<translation id="5578795271662203820">इस इमेज के लिए <ph name="SEARCH_ENGINE" /> पर खोजें</translation>
-<translation id="5581519193887989363">आप जब चाहें तब <ph name="BEGIN_LINK1" />सेटिंग<ph name="END_LINK1" /> में जाकर किसी भी चीज़ को सिंक करने का विकल्प चुन सकते हैं.</translation>
-<translation id="5595485650161345191">पते में बदलाव करें</translation>
-<translation id="5596627076506792578">ज़्यादा विकल्प</translation>
-<translation id="5599455543593328020">गुप्त मोड</translation>
-<translation id="5620928963363755975">ज़्यादा विकल्प बटन से डाउनलोड में जाकर अपनी फ़ाइलें और पेज पाएं</translation>
-<translation id="5626134646977739690">नाम:</translation>
-<translation id="5639724618331995626">सभी साइटों को अनुमति दें</translation>
-<translation id="5648166631817621825">पिछले 7 दिन</translation>
-<translation id="5649053991847567735">अपने आप होने वाले डाउनलोड</translation>
-<translation id="5655963694829536461">अपने डाउनलोड में खोजें</translation>
-<translation id="5659593005791499971">ईमेल</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> में इवेंट बनाएं</translation>
-<translation id="5668404140385795438">किसी वेबसाइट के वेबपेज ज़ूम इन न करने के नियम को बदल देता है</translation>
-<translation id="5677928146339483299">ब्लॉक किया गया है</translation>
-<translation id="5684874026226664614">ओह. इस पेज का अनुवाद नहीं किया जा सका.</translation>
-<translation id="5686790454216892815">फ़ाइल का नाम बहुत लंबा है</translation>
-<translation id="5689516760719285838">स्थान</translation>
-<translation id="569536719314091526">'ज़्यादा विकल्प' बटन से इस पेज का अनुवाद किसी भी भाषा में करें</translation>
-<translation id="572328651809341494">हाल ही के टैब</translation>
-<translation id="5726692708398506830">पेज पर सब कुछ बड़ा करें</translation>
-<translation id="5748802427693696783">मानक टैब पर स्विच कर दिया गया</translation>
-<translation id="5749068826913805084">फ़ाइलें डाउनलोड करने के लिए Chrome को मेमोरी के ऐक्‍सेस की ज़रूरत होगी.</translation>
-<translation id="5763382633136178763">गुप्त टैब</translation>
-<translation id="5763514718066511291">इस ऐप्लिकेशन का यूआरएल कॉपी करने के लिए टैप करें</translation>
-<translation id="5765780083710877561">वर्णन:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" /> में से <ph name="SPACE_USED" /> का इस्तेमाल किया जा रहा है</translation>
-<translation id="5797070761912323120">खोज, विज्ञापन, और दूसरी Google सेवाओं को मनमुताबिक बनाने के लिए, Google आपके इतिहास का इस्तेमाल कर सकता है</translation>
-<translation id="5804241973901381774">अनुमतियां</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# घंटा पहले}one{# घंटे पहले}other{# घंटे पहले}}</translation>
-<translation id="5810288467834065221">कॉपीराइट <ph name="YEAR" /> Google LLC. सर्वाधिकार सुरक्षित.</translation>
-<translation id="5817918615728894473">युग्‍मित करें</translation>
-<translation id="583281660410589416">अज्ञात</translation>
-<translation id="5833984609253377421">लिंक शेयर करें</translation>
-<translation id="5836192821815272682">Chrome का अपडेट डाउनलोड हो रहा है…</translation>
-<translation id="5853623416121554550">रोका गया</translation>
-<translation id="5854790677617711513">30 दिनों से ज़्यादा पुराना</translation>
-<translation id="5858741533101922242">Chrome, ब्लूटूथ एडाप्टर को चालू नहीं कर सका</translation>
-<translation id="5860033963881614850">बंद</translation>
-<translation id="5862731021271217234">अपने दूसरे डिवाइस से अपने टैब पाने के लिए, 'सिंक करें' को चालू करें</translation>
-<translation id="5864174910718532887">जानकारी: 'साइट नाम' के अनुसार क्रम से लगाया गया</translation>
-<translation id="5864419784173784555">दूसरे डाउनलोड का इंतज़ार किया जा रहा है…</translation>
-<translation id="5865733239029070421">Google को इस्तेमाल के आंकड़े और खराबी रिपोर्ट अपने आप भेजती है</translation>
-<translation id="5869522115854928033">सेव किए गए पासवर्ड</translation>
-<translation id="5902828464777634901">कुकी सहित, ऐसा सारा डेटा मिटा दिया जाएगा, जिसे इस वेबसाइट ने सेव किया है.</translation>
-<translation id="5916664084637901428">चालू</translation>
-<translation id="5919204609460789179">सिंक शुरू करने के लिए <ph name="PRODUCT_NAME" /> अपडेट करें</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> सेव किए गए</translation>
-<translation id="5939518447894949180">रीसेट करें</translation>
-<translation id="5942872142862698679">खोजने के लिए Google का उपयोग किया जा रहा है</translation>
-<translation id="5952764234151283551">आप जिस पेज पर जाने की कोशिश कर रहे हैं उसका यूआरएल Google को भेजती है</translation>
-<translation id="5956665950594638604">Chrome सहायता केंद्र को नए टैब में खोलें</translation>
-<translation id="5958275228015807058">डाउनलोड में जाकर अपनी फ़ाइलें और पेज पाएं</translation>
-<translation id="5962718611393537961">छोटा करने के लिए टैप करें</translation>
-<translation id="6000066717592683814">Google को डिफ़ॉल्ट बनाए रखें</translation>
-<translation id="6005538289190791541">सुझाया गया पासवर्ड</translation>
-<translation id="6036057147555329831">कुछ और ICU</translation>
-<translation id="6039379616847168523">सीधे अगले टैब पर जाएं</translation>
-<translation id="6040143037577758943">बंद करें</translation>
-<translation id="6042308850641462728">और ज़्यादा</translation>
-<translation id="604996488070107836">किसी अज्ञात गड़बड़ी के कारण <ph name="FILE_NAME" /> का डाउनलोड विफल रहा.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">पूरे हो चुके डाउनलोड</translation>
-<translation id="6075798973483050474">होम पेज में बदलाव करें</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> घंटे शेष</translation>
-<translation id="6108923351542677676">सेटअप प्रगति में है…</translation>
-<translation id="6111020039983847643">डेटा इस्तेमाल किया गया</translation>
-<translation id="6112702117600201073">पृष्‍ठ रीफ्रेश किया जा रहा है</translation>
-<translation id="6127379762771434464">आइटम निकाला गया</translation>
-<translation id="6140912465461743537">देश/क्षेत्र</translation>
-<translation id="614940544461990577">यह आज़माकर देखें:</translation>
-<translation id="6154478581116148741">इस डिवाइस से अपने पासवर्ड निर्यात करने के लिए सेटिंग में स्क्रीन लॉक चालू करें</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> डेटा बचत</translation>
-<translation id="6165508094623778733">ज़्यादा जानें</translation>
-<translation id="6177111841848151710">मौजूदा सर्च इंजन के लिए ब्लॉक किया गया है</translation>
-<translation id="6181444274883918285">अपवाद वाली साइट जोड़ें</translation>
-<translation id="6192333916571137726">डाउनलोड फ़ाइल कहां सेव करें</translation>
-<translation id="6192792657125177640">अपवाद</translation>
-<translation id="6194112207524046168">Chrome को अपना कैमरा ऐक्सेस करने देने के लिए, <ph name="BEGIN_LINK" />Android की सेटिंग<ph name="END_LINK" /> में जाकर भी कैमरा चालू करें.</translation>
-<translation id="6196640612572343990">तीसरे पक्ष की कुकी ब्लॉक करें</translation>
-<translation id="6206551242102657620">कनेक्शन सुरक्षित है. साइट की जानकारी</translation>
-<translation id="6210748933810148297">क्या <ph name="EMAIL" /> नहीं हैं?</translation>
-<translation id="6221633008163990886">अपने पासवर्ड निर्यात करने के लिए अनलॉक करें</translation>
+<translation id="1406000523432664303">“नज़र न रखें”</translation>
 <translation id="6232535412751077445">‘नज़र न रखें’ सुविधा को चालू करने का मतलब है कि आपके ब्राउज़िंग ट्रैफ़िक के साथ कोई अनुरोध शामिल किया जाएगा. कोई भी प्रभाव इस बात पर निर्भर करता है कि वेबसाइट, अनुरोध का जवाब देती है या नहीं और अनुरोध को किस तरह समझा जाता है.
 
 उदाहरण के लिए, कुछ वेबसाइटें इस अनुरोध का जवाब आपको ऐसे विज्ञापन दिखाकर दे सकती हैं, जो उन दूसरी वेबसाइटों पर आधारित नहीं हैं जिन्हें आपने देखा है. कई वेबसाइटें अब भी आपके ब्राउज़िंग डेटा को जमा और उनका उपयोग करेंगी - उदाहरण के तौर पर, सुरक्षा को बेहतर बनाने के लिए, अपनी वेबसाइट पर सामग्री, सेवाएं, विज्ञापन और सुझाव देने के लिए और रिपोर्टिंग के आकंड़े जनरेट करने के लिए.</translation>
-<translation id="624789221780392884">अपडेट तैयार है</translation>
-<translation id="6255999984061454636">सामग्री के सुझाव</translation>
-<translation id="6277522088822131679">पेज को प्रिंट करने में समस्या थी. कृपया फिर से प्रयास करें.</translation>
-<translation id="6295158916970320988">सभी साइटें</translation>
-<translation id="629730747756840877">खाता</translation>
-<translation id="6303969859164067831">साइन आउट करें और सिंक बंद करें</translation>
-<translation id="6316139424528454185">Android वर्शन काम नहीं कर रहा है</translation>
-<translation id="6320088164292336938">कंपन</translation>
-<translation id="6324034347079777476">Android सिस्टम समन्वयन अक्षम है</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> के द्वारा शेयर करें</translation>
-<translation id="6337234675334993532">सुरक्षित करने का तरीका</translation>
-<translation id="6341580099087024258">फ़ाइलें सेव करने की जगह पूछें</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> अन्य}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> अन्य}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> अन्य}}</translation>
-<translation id="6364438453358674297">सुझाव को इतिहास से निकालें?</translation>
-<translation id="6369229450655021117">यहां से, आप वेब खोज सकते हैं, दोस्तों के साथ शेयर कर सकते हैं और खुले हुए पेज देख सकते हैं</translation>
-<translation id="6378173571450987352">जानकारी: इस्तेमाल किए गए डेटा की मात्रा के अनुसार क्रम से लगाया गया</translation>
-<translation id="6381421346744604172">वेबसाइटों को गहरा करने का विकल्प</translation>
-<translation id="6388207532828177975">साफ़ करें और रीसेट करें</translation>
-<translation id="6393863479814692971">Chrome को इस साइट के लिए आपका कैमरा और माइक्रोफ़ोन के एक्सेस करने की अनुमति चाहिए.</translation>
-<translation id="6395288395575013217">लिंक</translation>
-<translation id="6404511346730675251">बुकमार्क में बदलाव करें</translation>
-<translation id="6406506848690869874">सिंक</translation>
-<translation id="641643625718530986">प्रिंट करें…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> एमबी डाउनलोड किया गया</translation>
-<translation id="6427112570124116297">वेब का अनुवाद करें</translation>
-<translation id="6433501201775827830">अपना सर्च इंजन चुनें</translation>
-<translation id="6437478888915024427">पेज की जानकारी</translation>
-<translation id="6441734959916820584">नाम बहुत लंबा है</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# इमेज}one{# इमेज}other{# इमेज}}</translation>
-<translation id="6447842834002726250">कुकी</translation>
-<translation id="6461962085415701688">फ़ाइल नहीं खोली जा सकती</translation>
-<translation id="6464977750820128603">आप Chrome में जिन साइटों पर जाते हैं उन्हें देख सकते हैं और उनके लिए टाइमर लगा सकते हैं.\n\nGoogle उन साइटों की जानकारी लेता है जिनके लिए आप टाइमर लगाते हैं. साथ ही, यह जानकारी भी ली जाती है कि आप उन साइटों पर कितनी देर तक रहे. इस जानकारी का इस्तेमाल 'डिजिटल वेलबीइंग' को बेहतर बनाने के लिए किया जाता है.</translation>
-<translation id="6475951671322991020">वीडियो डाउनलोड करें</translation>
-<translation id="6482749332252372425">मेमोरी स्‍थान कम होने के कारण <ph name="FILE_NAME" /> डाउनलोड विफल रहा.</translation>
-<translation id="6496823230996795692">पहली बार <ph name="APP_NAME" /> का उपयोग करने के लिए, कृपया इंटरनेट चालू करें.</translation>
-<translation id="6508722015517270189">Chrome को फिर से शुरू करें</translation>
-<translation id="6527303717912515753">शेयर करें</translation>
-<translation id="6532866250404780454">आप Chrome में जिन साइटों पर जाते हैं, वे नहीं दिखाई देंगी. साइट के सभी टाइमर मिटा दिए जाएंगे.</translation>
-<translation id="6534565668554028783">Google को प्रतिक्रिया देने में बहुत ज़्यादा समय लगा</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> जीबी डाउनलोड किया गया</translation>
-<translation id="6539092367496845964">कोई गड़बड़ी हुई. बाद में कोशिश करें.</translation>
-<translation id="654446541061731451">बीम के लिए टैब को चुनें</translation>
-<translation id="6545017243486555795">सभी डेटा साफ़ करें</translation>
-<translation id="6545864417968258051">ब्लूटूथ स्कैन करना</translation>
-<translation id="6560414384669816528">Sogou से खोजें</translation>
-<translation id="6566259936974865419">Chrome ने आपके <ph name="GIGABYTES" /> जीबी की बचत की</translation>
-<translation id="6573096386450695060">हमेशा मंज़ूरी दें</translation>
-<translation id="6573431926118603307">  अपने अन्य डिवाइस पर खोले गए टैब यहां दिखाई देंगे.</translation>
-<translation id="6583199322650523874">वर्तमान पेज को बुकमार्क करें</translation>
-<translation id="6593061639179217415">डेस्कटॉप साइट</translation>
-<translation id="6600954340915313787">Chrome पर कॉपी किया गया</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> जीबी</translation>
-<translation id="6612358246767739896">सुरक्षित सामग्री</translation>
-<translation id="6627583120233659107">फ़ोल्‍डर में बदलाव करें</translation>
-<translation id="6643016212128521049">साफ़ करें</translation>
-<translation id="6643649862576733715">सेव किए गए डेटा की मात्रा के हिसाब से क्रम में लगाएं</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> अन्य}one{<ph name="CONTACT_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> अन्य}other{<ph name="CONTACT_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> अन्य}}</translation>
-<translation id="6649642165559792194">इमेज की झलक देखें <ph name="BEGIN_NEW" />नई<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">डिवाइस स्‍कैन करने के लिए Chrome को जगह की जानकारी का एक्‍सेस की ज़रूरत है. <ph name="BEGIN_LINK" />अनुमतियां अपडेट करें<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">पासवर्ड</translation>
-<translation id="6659594942844771486">टैब</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" /> में खोलें</translation>
-<translation id="666981079809192359">Chrome निजता सूचना</translation>
-<translation id="6676840375528380067">इस डिवाइस से अपना Chrome डेटा हटाएं?</translation>
-<translation id="6697492270171225480">जब कोई पेज मिल नहीं पा रहा हो तो मिलते-जुलते पेज के सुझाव दिखाएं</translation>
-<translation id="6697947395630195233">इस साइट से आपकी जगह की जानकारी शेयर करने के लिए Chrome को आपकी जगह की जानकारी का एक्सेस चाहिए</translation>
-<translation id="6698801883190606802">सिंक किया गया डेटा प्रबंधित करें</translation>
-<translation id="6699370405921460408">Google के सर्वर उन पेज को ऑप्टिमाइज़ करेंगे जिन पर आप जाते हैं.</translation>
-<translation id="6706288973712894588">फ़िलहाल, आप ऑफ़लाइन हैं.\n<ph name="BEGIN_LINK" />अपने ऑफ़लाइन फ़ीड के बारे में और जानें.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">समाचार</translation>
-<translation id="6710213216561001401">पिछला</translation>
-<translation id="671481426037969117"><ph name="FQDN" /> इस्तेमाल करने का समय खत्म हो गया. यह कल फिर से शुरू होगा.</translation>
-<translation id="6738867403308150051">डाउनलोड हो रहे हैं...</translation>
-<translation id="6746124502594467657">नीचे जाएं</translation>
-<translation id="6766622839693428701">बंद करने के लिए नीचे स्वाइप करें.</translation>
-<translation id="6766758767654711248">साइट पर जाने के लिए टैप करें</translation>
-<translation id="6767294960381293877">टैब शेयर करने के लिए चुने जाने वाले डिवाइस की सूची आधी खुली हुई है.</translation>
-<translation id="6782111308708962316">तृतीय पक्ष वेबसाइट को कुकी डेटा सहेजने और पढ़ने से रोकें</translation>
-<translation id="6790428901817661496">चलाएं</translation>
-<translation id="6811034713472274749">पेज देखने के लिए तैयार है</translation>
-<translation id="6818926723028410516">आइटम चुनें</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">अनुवाद करें</translation>
-<translation id="6845325883481699275">'Chrome सुरक्षा' को बेहतर बनाने में मदद करें</translation>
-<translation id="6846298663435243399">लोड हो रहा है...</translation>
-<translation id="6850409657436465440">आपका डाउनलोड अब भी जारी है</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> टैब बंद किए गए</translation>
-<translation id="6864459304226931083">इमेज डाउनलोड करें</translation>
-<translation id="6865313869410766144">ऑटोमैटिक भरने वाले फ़ॉर्म का डेटा</translation>
-<translation id="688738109438487280">मौजूदा डेटा <ph name="TO_ACCOUNT" /> में जोड़ें.</translation>
-<translation id="6891726759199484455">अपना पासवर्ड कॉपी करने के लिए अनलॉक करें</translation>
-<translation id="6896758677409633944">कॉपी बनाएं</translation>
-<translation id="6910211073230771657">हटाया गया</translation>
-<translation id="6912998170423641340">साइटों को क्लिपबोर्ड से टेक्स्ट और इमेज पढ़ने से रोकें</translation>
-<translation id="6914783257214138813">आपके पासवर्ड, निर्यात की गई फ़ाइल देख पाने वाले सभी व्यक्तियों को दिखाई देंगे.</translation>
-<translation id="6942665639005891494">सेटिंग मेन्यू विकल्प का इस्तेमाल करके डिफ़ॉल्ट डाउनलोड स्थान किसी भी समय बदलें</translation>
-<translation id="6945221475159498467">चुनें</translation>
-<translation id="6963642900430330478">यह पेज खतरनाक है. साइट की जानकारी</translation>
-<translation id="6963766334940102469">बुकमार्क मिटाएं</translation>
-<translation id="6965382102122355670">ठीक है</translation>
-<translation id="6979737339423435258">हमेशा</translation>
-<translation id="6981982820502123353">सुलभता</translation>
-<translation id="6989267951144302301">डाउनलोड नहीं किया जा सका</translation>
-<translation id="6990079615885386641">Google Play स्‍टोर से ऐप्लिकेशन डाउनलोड करें: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">साइटों को अपने माइक्रोफ़ोन का इस्तेमाल करने देने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया)</translation>
-<translation id="7015203776128479407">शुरुआती सिंक सेटअप पूरा नहीं हुआ. सिंक बंद है.</translation>
-<translation id="7016516562562142042">मौजूदा सर्च इंजन के लिए अनुमति दी गई है</translation>
-<translation id="7022756207310403729">ब्राउज़र में खोलें</translation>
-<translation id="702463548815491781">उस समय के लिए सुझाया गया जब 'टॉकबैक' या 'ऐक्सेस करने का तरीका बदलें' चालू हों</translation>
-<translation id="7029809446516969842">पासवर्ड</translation>
-<translation id="7053983685419859001">ब्लॉक करें</translation>
-<translation id="7055152154916055070">रीडायरेक्ट ब्लॉक किया गया:</translation>
-<translation id="7063006564040364415">समन्‍वयन सर्वर से कनेक्‍ट नहीं किया जा सका.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 चुना गया}one{# चुने गए}other{# चुने गए}}</translation>
-<translation id="7071521146534760487">खाता प्रबंधित करें</translation>
-<translation id="7077143737582773186">SD कार्ड</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> चुने गए.  विकल्प, स्क्रीन के ऊपरी भाग के पास उपलब्ध हैं</translation>
-<translation id="7121362699166175603">पता बार मेंअपने-आपपूर्णता और इतिहास को हटाता है. आपके Google खाते में <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> पर अन्य प्रकार के ब्राउज़िंग इतिहास हो सकतेे हैं.</translation>
-<translation id="7128222689758636196">मौजूदा सर्च इंजन के लिए अनुमति दें</translation>
-<translation id="7138678301420049075">अन्य</translation>
-<translation id="7141896414559753902">साइटों को पॉप-अप और रीडायरेक्ट दिखाने से रोकें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> से <ph name="BEGIN_LINK" />मूल पेज लोड करें<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">पिछले 24 घंटे</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> केबी</translation>
-<translation id="7177466738963138057">आप इसे बाद में सेटिंग में जाकर बदल सकते हैं</translation>
-<translation id="7180611975245234373">रीफ्रेश करें</translation>
-<translation id="7189372733857464326">Google Play सेवाएं द्वारा अपडेट खत्म किए जाने की प्रतीक्षा की जा रही है</translation>
-<translation id="7191430249889272776">पृष्ठभूमि में टैब खोला गया.</translation>
-<translation id="723171743924126238">फ़ोटो चुनें</translation>
-<translation id="7233236755231902816">वेब को अपनी भाषा में देखने के लिए, Chrome का नया वर्शन पाएं</translation>
-<translation id="7243308994586599757">विकल्‍प स्‍क्रीन के नीचे उपलब्‍ध हैं</translation>
-<translation id="7248069434667874558">पक्का करें कि <ph name="TARGET_DEVICE_NAME" /> पर Chrome में सिंक करने की सुविधा चालू है</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> चुने गए</translation>
-<translation id="7274013316676448362">अवरोधित साइट</translation>
-<translation id="7290209999329137901">नाम बदलने की सुविधा उपलब्ध नहीं है</translation>
-<translation id="7291387454912369099">Assistant के ज़रिए अपने आप भरें</translation>
-<translation id="7293171162284876153">सिंक शुरू करने के लिए, "अपना Chrome डेटा सिंक करें" को चालू करें.</translation>
-<translation id="729975465115245577">आपके डिवाइस में पासवर्ड फ़ाइल को स्टोर करने वाला कोई ऐप्लिकेशन नहीं है.</translation>
-<translation id="7302081693174882195">जानकारी: बचाए गए डेटा की मात्रा के अनुसार क्रम से लगाया गया</translation>
-<translation id="7328017930301109123">'लाइट मोड' में, Chrome पेजों को ज़्यादा तेज़ी से लोड करता है और 60 प्रतिशत तक कम डेटा इस्तेमाल करता है.</translation>
-<translation id="7333031090786104871">पिछली साइट अब भी जोड़ी जा रही है</translation>
-<translation id="7352939065658542140">वीडियो</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 चयनित आइटम शेयर करें}one{# चयनित आइटम शेयर करें}other{# चयनित आइटम शेयर करें}}</translation>
 <translation id="7359002509206457351">भुगतान के तरीकों को ऐक्सेस करें</translation>
+<translation id="8026334261755873520">ब्राउज़िंग डेटा साफ़ करें</translation>
+<translation id="1291207594882862231">इतिहास, कुकी, साइट डेटा, कैश साफ़ करें…</translation>
+<translation id="7814200940910057384">साफ़ किया गया Brave डेटा</translation>
+<translation id="1664855196866195614">चुना गया डेटा Brave और आपके सिंक किए गए डिवाइस से हटा दिया गया है.
+
+आपके Brave Software खाते में <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> पर की जाने वाली खोजों और अन्य Brave Software सेवाओं की गतिविधि जैसे दूसरी तरह के ब्राउज़िंग इतिहास मौजूद हो सकते हैं.</translation>
+<translation id="4699172675775169585">कैश इमेज और फ़ाइलें</translation>
+<translation id="2496180316473517155">ब्राउज़िंग इतिहास...</translation>
+<translation id="2546283357679194313">कुकी और साइट डेटा</translation>
+<translation id="8662811608048051533">आपको ज़्यादातर साइट से साइन आउट कर देता है.</translation>
+<translation id="8218628800671693884">आपको ज़्यादातर साइटों से साइन आउट कर देता है. आप अपने Brave Software खाते से साइन आउट नहीं होंगे.</translation>
+<translation id="2017836877785168846">इतिहास साफ़ करता है और पता बार मेंअपने-आपपूर्णता को साफ़ करता है.</translation>
+<translation id="8096327394278038498">पता बार मेंअपने-आपपूर्णता और इतिहास को हटाता है. आपके Brave Software खाते में <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> पर अन्य प्रकार के ब्राउज़िंग इतिहास हो सकतेे हैं.</translation>
+<translation id="8122693181154564064">साइन इन किए हुए सभी डिवाइसों से इतिहास साफ़ कर देता है. आपके Brave Software खाते में <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> पर अन्य प्रकार के ब्राउज़िंग इतिहास हो सकते हैं.</translation>
+<translation id="5869522115854928033">सेव किए गए पासवर्ड</translation>
+<translation id="6865313869410766144">ऑटोमैटिक भरने वाले फ़ॉर्म का डेटा</translation>
+<translation id="7562080006725997899">ब्राउज़िंग डेटा साफ़ हो रहा है</translation>
+<translation id="5487521232677179737">डेटा साफ़ करें</translation>
+<translation id="7498271377022651285">कृपया प्रतीक्षा करें...</translation>
+<translation id="784934925303690534">समय सीमा</translation>
+<translation id="1718835860248848330">अंतिम घंटा</translation>
+<translation id="7149893636342594995">पिछले 24 घंटे</translation>
+<translation id="5648166631817621825">पिछले 7 दिन</translation>
+<translation id="8571213806525832805">पिछले चार हफ़्ते</translation>
+<translation id="5854790677617711513">30 दिनों से ज़्यादा पुराना</translation>
+<translation id="6979737339423435258">हमेशा</translation>
+<translation id="982182592107339124">इससे इन सभी साइटों का डेटा साफ़ हो जाएगा:</translation>
+<translation id="6643016212128521049">साफ़ करें</translation>
+<translation id="7641339528570811325">ब्राउज़िंग डेटा साफ़ करें…</translation>
+<translation id="1670399744444387456">मूलभूत</translation>
+<translation id="3245261285041759672">आपके Brave Software खाते में <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> पर अन्य प्रकार के ब्राउज़िंग इतिहास हो सकतेे हैं.</translation>
+<translation id="7274013316676448362">अवरोधित साइट</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> आइटम मिटाए गए</translation>
+<translation id="1121094540300013208">इस्तेमाल और खराबी रिपोर्ट</translation>
+<translation id="9079153198295609735">इस्तेमाल के आंकड़े और खराबी रिपोर्ट अपने आप Brave Software को भेजें</translation>
+<translation id="6981982820502123353">सुलभता</translation>
+<translation id="2387895666653383613">लेख स्‍केलिंग</translation>
+<translation id="2321958826496381788">इस टेक्स्ट को आसानी से पढ़ने लायक बनाने के लिए, स्‍लाइडर को आगे की ओर खींचें. पैराग्राफ़ पर डबल-टैप करने के बाद, टेक्स्ट को इतना बड़ा दिखाई देना चाहिए.</translation>
+<translation id="3895926599014793903">ज़बरदस्ती ज़ूम करना चालू करें</translation>
+<translation id="5668404140385795438">किसी वेबसाइट के वेबपेज ज़ूम इन न करने के नियम को बदल देता है</translation>
+<translation id="4149994727733219643">वेब पेजों के लिए सरल बनाया गया व्यू</translation>
+<translation id="9100505651305367705">अगर सुविधा उपलब्ध है, तो लेख को सरल बनाए गए व्यू में दिखाना ऑफ़र करें</translation>
+<translation id="1409426117486808224">खुले टैब के लिए सरल बनाया गया व्यू</translation>
+<translation id="702463548815491781">उस समय के लिए सुझाया गया जब 'टॉकबैक' या 'ऐक्सेस करने का तरीका बदलें' चालू हों</translation>
+<translation id="8284326494547611709">कैप्शन</translation>
+<translation id="4165986682804962316">साइट सेटिंग</translation>
+<translation id="6295158916970320988">सभी साइटें</translation>
+<translation id="8380167699614421159">इस साइट में तंग करने वाले या गुमराह करने वाले विज्ञापन दिखाई देते हैं</translation>
+<translation id="1919345977826869612">विज्ञापन</translation>
+<translation id="410351446219883937">अपने आप चलाएं</translation>
+<translation id="6447842834002726250">कुकी</translation>
+<translation id="6196640612572343990">तीसरे पक्ष की कुकी ब्लॉक करें</translation>
+<translation id="6782111308708962316">तृतीय पक्ष वेबसाइट को कुकी डेटा सहेजने और पढ़ने से रोकें</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">पॉप-अप और रीडायरेक्ट</translation>
+<translation id="4751476147751820511">गति या लाइट सेंसर</translation>
+<translation id="1717218214683051432">मोशन सेंसर</translation>
+<translation id="2091887806945687916">आवाज़</translation>
+<translation id="2586657967955657006">क्लिपबोर्ड</translation>
+<translation id="6320088164292336938">कंपन</translation>
+<translation id="4226663524361240545">नोटिफ़िकेशन से डिवाइस में कंपन हो सकता है</translation>
+<translation id="1446450296470737166">MIDI डिवाइस के पूरे नियंत्रण की अनुमति दें</translation>
+<translation id="3744111561329211289">बैकग्राउंड सिंक</translation>
+<translation id="5649053991847567735">अपने आप होने वाले डाउनलोड</translation>
+<translation id="6181444274883918285">अपवाद वाली साइट जोड़ें</translation>
+<translation id="5313967007315987356">साइट जोड़ें</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> साइट जोड़ी गई</translation>
+<translation id="7837721118676387834">किसी खास साइट पर म्यूट किए गए वीडियो को अपने आप चलाने की अनुमति दें.</translation>
+<translation id="2621115761605608342">किसी खास साइट के लिए JavaScript चलाने की अनुमति दें.</translation>
+<translation id="8801436777607969138">किसी खास साइट के लिए JavaScript पर रोक लगाएं.</translation>
+<translation id="8372893542064058268">किसी विशिष्ट साइट के लिए पृष्ठभूमि समन्वयन की अनुमति दें.</translation>
+<translation id="358794129225322306">किसी साइट को अपने आप एक से ज़्यादा फ़ाइलें लोड करने की मंज़ूरी दें.</translation>
+<translation id="4008040567710660924">किसी खास साइट के लिए कुकी की मंज़ूरी दें.</translation>
+<translation id="8958424370300090006">किसी खास साइट के लिए कुकी ब्लॉक करें.</translation>
+<translation id="7882806643839505685">किसी खास साइट के लिए आवाज़ की अनुमति दें.</translation>
+<translation id="4468959413250150279">किसी खास साइट के लिए आवाज़ बंद करें.</translation>
+<translation id="1994173015038366702">साइट URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">उपयोग</translation>
+<translation id="5804241973901381774">अनुमतियां</translation>
+<translation id="4278390842282768270">अनुमति है</translation>
+<translation id="5677928146339483299">ब्लॉक किया गया है</translation>
+<translation id="1984937141057606926">तृतीय-पक्ष को छोड़कर अनुमति है</translation>
+<translation id="7423098979219808738">पहले पूछें</translation>
+<translation id="8116925261070264013">आवाज़ बंद की गई</translation>
+<translation id="8300705686683892304">ऐप्लिकेशन प्रबंधित करता है</translation>
+<translation id="6192792657125177640">अपवाद</translation>
+<translation id="257931822824936280">बड़ा किया गया - छोटा करने के लिए क्‍लिक करें.</translation>
+<translation id="5100237604440890931">छोटा किया गया - पूरा खोलने के लिए क्लिक करें.</translation>
+<translation id="857943718398505171">अनुमति दी गई (सुझाया गया)</translation>
+<translation id="2913331724188855103">साइटों को कुकी डेटा सेव करने और पढ़ने की अनुमति दें (सुझाए गए)</translation>
+<translation id="7445411102860286510">साइटों को म्यूट किए गए वीडियो अपने आप चलाने की अनुमति दें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
+<translation id="5335288049665977812">साइटों को JavaScript चलाने की अनुमति दें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
+<translation id="5527111080432883924">साइटों को क्लिपबोर्ड से टेक्स्ट और इमेज पढ़ने की अनुमति देने से पहले पूछें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
+<translation id="6912998170423641340">साइटों को क्लिपबोर्ड से टेक्स्ट और इमेज पढ़ने से रोकें</translation>
+<translation id="7423538860840206698">क्लिपबोर्ड पढ़ने से ब्लॉक किया गया है</translation>
+<translation id="3955193568934677022">साइटों को सुरक्षित सामग्री चलाने दें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
+<translation id="445467742685312942">साइटों को सभी सुरक्षित सामग्री चलाने दें</translation>
+<translation id="2107397443965016585">साइटों को सुरक्षित सामग्री चलाने देने से पहले पूछें (ऐसा करने का सुझाव दिया जाता है)</translation>
+<translation id="2910701580606108292">साइटों को सुरक्षित सामग्री चलाने की अनुमति देने से पहले पूछें</translation>
+<translation id="757524316907819857">साइटों को सुरक्षित सामग्री चलाने से रोकें</translation>
+<translation id="3277252321222022663">साइटों को सेंसर ऐक्सेस करने दें (सुझाया गया)</translation>
+<translation id="5048398596102334565">साइटों को मोशन सेंसर ऐक्‍सेस करने दें (सुझाया गया)</translation>
+<translation id="8816026460808729765">साइटों को सेंसर ऐक्सेस करने से रोकें</translation>
+<translation id="169515064810179024">साइटों को हलचल पकड़ने वाले सेंसर ऐक्सेस करने से रोकें</translation>
+<translation id="1660204651932907780">साइटों को आवाज़ चलाने दें (सुझाया गया)</translation>
+<translation id="3600792891314830896">आवाज़ चलाने वाली साइटों की आवाज़ बंद करें</translation>
+<translation id="1743802530341753419">साइटों को डिवाइस से कनेक्ट करने की अनुमति देने से पहले पूछें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
+<translation id="851751545965956758">साइटों को डिवाइस से कनेक्ट होने से रोकें</translation>
+<translation id="7141896414559753902">साइटों को पॉप-अप और रीडायरेक्ट दिखाने से रोकें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
+<translation id="5494752089476963479">तंग करने वाले या गुमराह करने वाले विज्ञापन दिखाने वाली साइटों पर विज्ञापन ब्लॉक करें</translation>
+<translation id="3123473560110926937">कुछ साइटों पर ब्लॉक किए गए हैं</translation>
+<translation id="965817943346481315">अगर साइट तंग करने वाले या गुमराह करने वाले विज्ञापन दिखाई देते हैं, तो उन्हें ब्लॉक करें (सुझाव)</translation>
+<translation id="3386292677130313581">साइटों को अपनी जगह की जानकारी देने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया)</translation>
+<translation id="9139068048179869749">साइटों को सूचनाएं भेजने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया)</translation>
+<translation id="4479647676395637221">साइटों को अपने कैमरे का इस्तेमाल करने देने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया )</translation>
+<translation id="6992289844737586249">साइटों को अपने माइक्रोफ़ोन का इस्तेमाल करने देने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया)</translation>
+<translation id="2289270750774289114">जब कोई साइट आस-पास के ब्लूटूथ डिवाइस को खोजना चाहे, तो इसके लिए पूछें (सुझाया गया)</translation>
+<translation id="7053983685419859001">ब्लॉक करें</translation>
+<translation id="7128222689758636196">मौजूदा सर्च इंजन के लिए अनुमति दें</translation>
+<translation id="7589445247086920869">मौजूदा सर्च इंजन के लिए ब्लॉक करें</translation>
+<translation id="6388207532828177975">साफ़ करें और रीसेट करें</translation>
+<translation id="7999064672810608036">क्‍या आप वाकई कुकी सहित इस वेबसाइट का सभी स्‍थानीय डेटा साफ़ करना और इसकी सभी अनुमतियों को रीसेट करना चाहते हैं?</translation>
+<translation id="2822354292072154809">क्या आप वाकई <ph name="CHOSEN_OBJECT_NAME"/> की सभी साइट अनुमतियां रीसेट करना चाहते हैं?</translation>
+<translation id="515227803646670480">सेव किया गया डेटा साफ़ करें</translation>
+<translation id="5902828464777634901">कुकी सहित, ऐसा सारा डेटा मिटा दिया जाएगा, जिसे इस वेबसाइट ने सेव किया है.</translation>
+<translation id="119944043368869598">सारा डेटा साफ़ करें</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> प्रबंधित करता है</translation>
+<translation id="5516455585884385570">सूचना सेटिंग खोलें</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/> में एम्बेड किया गया है</translation>
+<translation id="129382876167171263">यहां वे फ़ाइलें दिखाई देती हैं जिन्हें वेबसाइटें सेव करती हैं</translation>
+<translation id="4181841719683918333">भाषाएं</translation>
+<translation id="2647434099613338025">भाषा जोड़ें</translation>
+<translation id="1952172573699511566">जब संभव होगा, वेबसाइटें आपकी पसंदीदा भाषा में टेक्स्ट दिखाएंगी.</translation>
+<translation id="8559990750235505898">अन्य भाषाओं में पेज का अनुवाद करना ऑफ़र करें</translation>
+<translation id="4719927025381752090">अनुवाद करना ऑफ़र करें</translation>
+<translation id="8156139159503939589">आप किन भाषाओं में पढ़ सकते हैं?</translation>
+<translation id="5689516760719285838">स्थान</translation>
+<translation id="2440823041667407902">जगह की जानकारी का एक्‍सेस दें</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android सेटिंग<ph name="END_LINK"/> में Brave के लिए अनुमतियां चालू करें.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android सेटिंग<ph name="END_LINK"/> में Brave के लिए अनुमति चालू करें.</translation>
+<translation id="2928908108430545745">Brave को अपनी जगह की जानकारी ऐक्सेस करने देने के लिए, <ph name="BEGIN_LINK"/>Android की सेटिंग<ph name="END_LINK"/> में जाकर भी जगह की जानकारी चालू करें.</translation>
+<translation id="1028853271388022585">Brave को अपना कैमरा ऐक्सेस करने देने के लिए, <ph name="BEGIN_LINK"/>Android की सेटिंग<ph name="END_LINK"/> में जाकर भी कैमरा चालू करें.</translation>
+<translation id="2913721282607281710">Brave को आपको सूचनाएं भेजने देने के लिए, <ph name="BEGIN_LINK"/>Android की सेटिंग<ph name="END_LINK"/> में जाकर भी सूचनाएं चालू करें.</translation>
+<translation id="8753483718490035722">Brave को अपना माइक्रोफ़ोन ऐक्सेस करने देने के लिए, <ph name="BEGIN_LINK"/>Android की सेटिंग<ph name="END_LINK"/> में जाकर भी माइक्रोफ़ोन चालू करें.</translation>
+<translation id="1887786770086287077">इस डिवाइस के लिए जगह की जानकारी का एक्सेस बंद है. उसे <ph name="BEGIN_LINK"/>Android सेटिंग<ph name="END_LINK"/> में चालू करें.</translation>
+<translation id="2570922361219980984">इस डिवाइस के लिए जगह की जानकारी का एक्सेस भी बंद है. उसे <ph name="BEGIN_LINK"/>Android सेटिंग<ph name="END_LINK"/> में चालू करें.</translation>
+<translation id="1620510694547887537">कैमरा</translation>
+<translation id="3227137524299004712">माइक्रोफ़ोन</translation>
+<translation id="1647391597548383849">अपना कैमरा एक्सेस करें</translation>
+<translation id="945632385593298557">अपना माइक्रोफ़ोन एक्सेस करें</translation>
+<translation id="6612358246767739896">सुरक्षित सामग्री</translation>
+<translation id="885701979325669005">मेमोरी</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> संग्रहित डेटा</translation>
+<translation id="8847988622838149491">यूएसबी</translation>
+<translation id="8447861592752582886">डिवाइस अनुमति निरस्त करें</translation>
+<translation id="4962975101802056554">डिवाइस की सभी अनुमतियां निरस्त करें</translation>
+<translation id="6545864417968258051">ब्लूटूथ स्कैन करना</translation>
+<translation id="4411535500181276704">लाइट मोड</translation>
+<translation id="7821588508402923572">बचाया गया डेटा यहां दिखाई देगा</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> बचाया गया</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> से</translation>
+<translation id="3252158532344029638">'लाइट मोड' में, Brave पेजों को ज़्यादा तेज़ी से लोड करता है और 60 प्रतिशत तक कम डेटा इस्तेमाल करता है.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> डेटा बचत</translation>
+<translation id="7494974237137038751">डेटा बचाया गया</translation>
+<translation id="6111020039983847643">डेटा इस्तेमाल किया गया</translation>
+<translation id="7413229368719586778">शुरू होने की तारीख: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">खत्म होने की तारीख: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">साइट के हिसाब से क्रम में लगाएं</translation>
+<translation id="5864174910718532887">जानकारी: 'साइट नाम' के अनुसार क्रम से लगाया गया</translation>
+<translation id="116280672541001035">इस्तेमाल किया गया</translation>
+<translation id="8349013245300336738">इस्तेमाल किए गए डेटा की मात्रा के हिसाब से क्रम में लगाएं</translation>
+<translation id="6378173571450987352">जानकारी: इस्तेमाल किए गए डेटा की मात्रा के अनुसार क्रम से लगाया गया</translation>
+<translation id="2631006050119455616">बचाया गया</translation>
+<translation id="6643649862576733715">सेव किए गए डेटा की मात्रा के हिसाब से क्रम में लगाएं</translation>
+<translation id="7302081693174882195">जानकारी: बचाए गए डेटा की मात्रा के अनुसार क्रम से लगाया गया</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> इस्तेमाल किए गए</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> सेव किए गए</translation>
+<translation id="2156074688469523661">बाकी साइटें (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">अन्य</translation>
+<translation id="4913161338056004800">आंकड़े रीसेट करें</translation>
+<translation id="1856325424225101786">लाइट मोड रीसेट करें?</translation>
+<translation id="3658159451045945436">रीसेट करने से आपकी देखी गई साइटों की सूची के साथ ही, डेटा बचाने का आपका इतिहास हमेशा के लिए मिट जाता है.</translation>
+<translation id="3295530008794733555">तेज़ी से ब्राउज़ करें. कम डेटा इस्तेमाल करें.</translation>
+<translation id="7340390500800578919">Brave, लाइट मोड में पेजों को ज़्यादा तेज़ी से लोड करता है और 60 प्रतिशत तक कम डेटा इस्तेमाल करता है. जिन पेजों पर आप जाते हैं उनको ऑप्टिमाइज़ करने के लिए Brave आपके वेब ट्रैफ़िक की जानकारी Brave Software को भेजता है. <ph name="BEGIN_LINK"/>ज़्यादा जानें<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">लाइट मोड चालू करें</translation>
+<translation id="4493497663118223949">लाइट मोड चालू है</translation>
+<translation id="7559975015014302720">लाइट मोड बंद है</translation>
+<translation id="7606077192958116810">लाइट मोड चालू है. इसे 'सेटिंग' में जाकर प्रबंधित करें.</translation>
+<translation id="4714588616299687897">अपना 60% तक डेटा बचाएं</translation>
+<translation id="1006927014032731288">Brave Software के सर्वर उन पेज को ऑप्टिमाइज़ करेंगे जिन पर आप जाते हैं.</translation>
+<translation id="3257320067425202300">Brave ने आपके <ph name="MEGABYTES"/> एमबी की बचत की</translation>
+<translation id="5813223329348543512">Brave ने आपके <ph name="GIGABYTES"/> जीबी की बचत की</translation>
+<translation id="8266862848225348053">डाउनलोड सेव करने की जगह</translation>
+<translation id="7077143737582773186">SD कार्ड</translation>
+<translation id="7762668264895820836">SD कार्ड <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">फ़ाइलें सेव करने की जगह पूछें</translation>
+<translation id="6192333916571137726">डाउनलोड फ़ाइल कहां सेव करें</translation>
+<translation id="1672586136351118594">फिर से न दिखाएं</translation>
+<translation id="2650751991977523696">फ़ाइल दोबारा डाउनलोड करें?</translation>
+<translation id="8664979001105139458">इस नाम की फ़ाइल पहले से मौजूद है</translation>
+<translation id="488187801263602086">फ़ाइल का नाम बदलें</translation>
+<translation id="5686790454216892815">फ़ाइल का नाम बहुत लंबा है</translation>
+<translation id="7454641608352164238">जगह काफ़ी नहीं है</translation>
+<translation id="8972098258593396643">डिफ़ॉल्ट फ़ोल्डर में डाउनलोड करें?</translation>
+<translation id="804335162455518893">SD कार्ड नहीं मिला</translation>
+<translation id="7475688122056506577">SD कार्ड नहीं मिला. हो सकता है कि आपकी कुछ फ़ाइलें उपलब्ध न हों.</translation>
+<translation id="4198423547019359126">डाउनलोड करने की कोई जगह उपलब्ध नहीं है</translation>
+<translation id="8224471946457685718">वाई-फ़ाई चालू हाेने पर अपने लिए लेख डाउनलोड करें</translation>
+<translation id="4970824347203572753">आपके देश में उपलब्ध नहीं है</translation>
+<translation id="5500777121964041360">शायद, यह सुविधा आपके देश में उपलब्ध न हाे</translation>
+<translation id="1173894706177603556">नाम बदलें</translation>
+<translation id="1986685561493779662">नाम पहले से मौजूद है</translation>
+<translation id="6441734959916820584">नाम बहुत लंबा है</translation>
+<translation id="2923908459366352541">नाम अमान्य है</translation>
+<translation id="7290209999329137901">नाम बदलने की सुविधा उपलब्ध नहीं है</translation>
+<translation id="3334729583274622784">फ़ाइल एक्सटेंशन बदलना चाहते हैं?</translation>
+<translation id="107147699690128016">अगर आप फ़ाइल का एक्सटेंशन बदलते हैं, तो हो सकता है कि फ़ाइल अलग ऐप्लिकेशन में खुले. इससे आपके डिवाइस को नुकसान पहुंच सकता है.</translation>
+<translation id="8541922081612557424">Brave के बारे में</translation>
+<translation id="5311273890481188673">कॉपीराइट <ph name="YEAR"/> Brave Software LLC. सर्वाधिकार सुरक्षित.</translation>
+<translation id="1416550906796893042">ऐप्‍लिकेशन वर्शन</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (<ph name="TIME_SINCE_UPDATE"/> अपडेट किया गया)</translation>
+<translation id="7596558890252710462">ऑपरेटिंग सिस्टम</translation>
+<translation id="3968054912784331254">Brave अपडेट, अब Android के इस वर्शन पर काम नहीं करते हैं.</translation>
+<translation id="7665369617277396874">खाता जोड़ें</translation>
+<translation id="649070405679044769">आपने Brave Software में इस ईमेल पते से साइन इन किया है</translation>
+<translation id="6234515504547364178">Brave से साइन आउट करें</translation>
+<translation id="5324858694974489420">अभिभावकीय सेटिंग</translation>
+<translation id="8920114477895755567">अभिभावकों के विवरण की प्रतीक्षा कर रहे हैं.</translation>
+<translation id="5512137114520586844">यह खाता <ph name="PARENT_NAME"/> द्वारा प्रबंधित है.</translation>
+<translation id="2956410042958133412">यह खाता <ph name="PARENT_NAME_1"/> और <ph name="PARENT_NAME_2"/> के द्वारा प्रबंधित है.</translation>
+<translation id="8168435359814927499">सामग्री</translation>
+<translation id="5403644198645076998">सिर्फ़ कुछ निश्चित साइटों को ही अनुमति दें</translation>
+<translation id="8641930654639604085">वयस्क साइटें ब्लॉक करने की कोशिश करें</translation>
+<translation id="5639724618331995626">सभी साइटों को अनुमति दें</translation>
+<translation id="796823723482603597">Brave के द्वारा संचालित</translation>
+<translation id="6324034347079777476">Android सिस्टम समन्वयन अक्षम है</translation>
+<translation id="5127805178023152808">समन्वयन बंद है</translation>
+<translation id="7015203776128479407">शुरुआती सिंक सेटअप पूरा नहीं हुआ. सिंक बंद है.</translation>
+<translation id="2497852260688568942">सिंक को आपके व्यवस्थापक ने अक्षम कर दिया है</translation>
+<translation id="9100610230175265781">पासफ़्रेज़ ज़रूरी है</translation>
+<translation id="6108923351542677676">सेटअप प्रगति में है…</translation>
+<translation id="4062305924942672200">कानूनी जानकारी</translation>
+<translation id="4256782883801055595">ओपन सोर्स लाइसेंस</translation>
+<translation id="1138681184697033370">Brave सेवा की शर्तें</translation>
+<translation id="7392539049993970338">Brave निजता सूचना</translation>
+<translation id="2677748264148917807">छोड़ें</translation>
+<translation id="5556459405103347317">फिर लोड करें</translation>
+<translation id="1623104350909869708">इस पेज को अतिरिक्त डॉयलॉग बनाने से रोकें</translation>
+<translation id="2968755619301702150">प्रमाणपत्र व्यूअर</translation>
+<translation id="1360432990279830238">साइन आउट करें और सिंक बंद करें?</translation>
+<translation id="8581481290581777242">इस डिवाइस से अपना Brave डेटा हटाएं?</translation>
+<translation id="1318865768845061710">आपके बुकमार्क, इतिहास, पासवर्ड, और Brave पर मौजूद दूसरा डेटा अब Brave Software खाते से सिंक नहीं होगा</translation>
+<translation id="3325020657155065477">इस डिवाइस से अपना Brave डेटा भी हटाएं</translation>
+<translation id="6136448902816743006">आप किसी ऐसे खाते से साइन आउट कर रहे हैं जिसे <ph name="DOMAIN_NAME"/> से प्रबंधित किया जाता है. इस वजह से, Brave पर मौजूद आपका डेटा इस डिवाइस से मिटा दिया जाएगा. हालांकि, यह डेटा आपके Brave Software खाते पर मौजूद रहेगा.</translation>
+<translation id="1853026300647876496">Brave Software से संपर्क किया जा रहा है. इसमें कुछ समय लग सकता है…</translation>
+<translation id="2328985652426384049">साइन इन नहीं कर सकते</translation>
+<translation id="7723158744459952869">Brave Software को प्रतिक्रिया देने में बहुत ज़्यादा समय लगा</translation>
+<translation id="4572422548854449519">प्रबंधित खाते में साइन इन करें</translation>
+<translation id="2689656545739939160">आप <ph name="MANAGED_DOMAIN"/> से प्रबंधित खाते में साइन इन कर रहे हैं और उसके एडमिन को अपने Brave डेटा पर नियंत्रण दे रहे हैं. आपका डेटा इस खाते से स्थायी रूप से जुड़ जाएगा. Brave से साइन आउट करने से आपका डेटा इस डिवाइस से मिट जाएगा, लेकिन वह आपके Brave Software खाते में बना रहेगा.</translation>
+<translation id="1749561566933687563">अपने बुकमार्क समन्‍वयित करें</translation>
+<translation id="4242533952199664413">सेटिंग खोलें</translation>
+<translation id="1111673857033749125">आपके अन्‍य डिवाइस पर सहेजे गए बुकमार्क यहां दिखाई देंगे.</translation>
+<translation id="8636825310635137004">अपने अन्य डिवाइस से अपने टैब पाने के लिए, सिंक करना चालू करें.</translation>
+<translation id="3269956123044984603">अपने अन्य डिवाइस से अपने टैब पाने के लिए, Android खाता सेटिंग में “डेटा अपने-आप सिंक करें” चालू करें.</translation>
+<translation id="5157964048453367290">अपने अन्य डिवाइस पर खोले गए टैब यहां दिखाई देंगे.</translation>
+<translation id="4684427112815847243">सब कुछ सिंक करें</translation>
+<translation id="2709516037105925701">ऑटोमैटिक भरना</translation>
+<translation id="8820817407110198400">बुकमार्क</translation>
+<translation id="1644574205037202324">इतिहास</translation>
+<translation id="17513872634828108">टैब खोलें</translation>
+<translation id="1320169905922104972">Brave Software Pay का इस्तेमाल करने वाले क्रेडिट कार्ड और पते</translation>
+<translation id="6337234675334993532">सुरक्षित करने का तरीका</translation>
+<translation id="6698801883190606802">सिंक किया गया डेटा प्रबंधित करें</translation>
+<translation id="3598578758776312506">Brave Software क्रेडेंशियल से पासवर्ड सुरक्षित करें</translation>
+<translation id="7810580217418711046"><ph name="TIME"/> तक का सुरक्षित किया गया किया गया डेटा 'Brave Software पासवर्ड' से सिंक करें</translation>
+<translation id="8461694314515752532">सिंक किए गए डेटा को अपने खुद के सिंक लंबे पासवर्ड से सुरक्षित करें</translation>
+<translation id="2996291259634659425">'पासफ़्रेज़' बनाएं</translation>
+<translation id="5713644099811900409">Brave Software खाता</translation>
+<translation id="8997474919031554666">लंबा पासवर्ड सुरक्षित करने के तरीके में Brave Software Pay से भुगतान करने की विधि और पते शामिल नहीं हैं. सिर्फ़ वह इंसान आपका सुरक्षित किया हुआ डेटा पढ़ सकता है जिसके पास आपका लंबा पासवर्ड है. Brave Software की ओर से लंबा पासवर्ड भेजा या संग्रहित नहीं किया जाता है. अगर आप अपना लंबा पासवर्ड भूल जाते हैं या इस सेटिंग को बदलना चाहते हैं, तो आपको सिंक रीसेट करना होगा. <ph name="BEGIN_LINK"/>ज़्यादा जानें<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">पासफ़्रेज़ (लंबा पासवर्ड)</translation>
+<translation id="7772032839648071052">'पासफ़्रेज' की पुष्टि करें</translation>
+<translation id="5304593522240415983">यह फ़ील्‍ड खाली नहीं छोड़ी जा सकती</translation>
+<translation id="321773570071367578">अगर आप अपना 'पासफ़्रेज़' भूल गए हैं या यह सेटिंग बदलना चाहते हैं, तो <ph name="BEGIN_LINK"/> सिंक रीसेट करें<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">पासफ़्रेज़ मिलान नहीं करते</translation>
+<translation id="5149495116300586333">लंबा पासवर्ड सुरक्षित करने में Brave Software Pay से भुगतान करने के तरीके और पते शामिल नहीं हैं.
+
+यह सेटिंग बदलने के लिए, <ph name="BEGIN_LINK"/>सिंक रीसेट करें<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">गलत 'पासफ़्रेज़'</translation>
+<translation id="5414836363063783498">सत्यापन हो रहा है...</translation>
+<translation id="6846298663435243399">लोड हो रहा है...</translation>
+<translation id="5517095782334947753">आपके पास <ph name="FROM_ACCOUNT"/> के बुकमार्क, इतिहास, पासवर्ड और अन्य सेटिंग हैं.</translation>
+<translation id="3928666092801078803">मेरा डेटा संयोजित करें</translation>
+<translation id="688738109438487280">मौजूदा डेटा <ph name="TO_ACCOUNT"/> में जोड़ें.</translation>
+<translation id="806745655614357130">मेरा डेटा अलग रखें</translation>
+<translation id="1145536944570833626">मौजूदा डेटा मिटाएं.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> युग्मित करना चाहता है</translation>
+<translation id="4915549754973153784">डिवाइस स्कैन करने में <ph name="BEGIN_LINK"/>सहायता पाएं<ph name="END_LINK"/>...</translation>
+<translation id="5817918615728894473">युग्‍मित करें</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>सहायता पाएं<ph name="END_LINK1"/> या <ph name="BEGIN_LINK2"/>फिर से स्कैन करें<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">कोई संगत डिवाइस नहीं मिला</translation>
+<translation id="3773755127849930740">युग्मन की अनुमति देने के लिए <ph name="BEGIN_LINK"/>ब्लूटूथ चालू करें<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave, ब्लूटूथ एडाप्टर को चालू नहीं कर सका</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>सहायता पाएं<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">डिवाइस स्‍कैन करने के लिए Brave को जगह की जानकारी का एक्‍सेस की ज़रूरत है. <ph name="BEGIN_LINK"/>अनुमतियां अपडेट करें<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">डिवाइस स्कैन करने के लिए Brave को जगह की जानकारी का एक्सेस की ज़रूरत होती है. जगह की जानकारी का एक्सेस <ph name="BEGIN_LINK"/>इस डिवाइस के लिए बंद<ph name="END_LINK"/> है.</translation>
+<translation id="2367014990350929709">डिवाइस स्कैन करने के लिए Brave को जगह की जानकारी का एक्सेस की ज़रूरत होती है. <ph name="BEGIN_LINK1"/>अनुमतियां अपडेट करें<ph name="END_LINK1"/>. जगह की जानकारी का एक्सेस <ph name="BEGIN_LINK2"/>इस डिवाइस के लिए भी बंद<ph name="END_LINK2"/> है.</translation>
+<translation id="1569387923882100876">कनेक्ट किया गया डिवाइस</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{सिग्नल सशक्तता का स्तर: # बार}one{सिग्नल सशक्तता का स्तर: # बार}other{सिग्नल सशक्तता का स्तर: # बार}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> आस-पास मौजूद ब्लूटूथ वाले डिवाइस स्कैन करना चाहती है. ये डिवाइस मिले हैं:</translation>
+<translation id="8368027906805972958">अज्ञात या काम न करने वाला डिवाइस (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">समन्वयन काम नहीं कर रहा है</translation>
+<translation id="1810845389119482123">शुरुआती सिंक सेट अप पूरा नहीं हुआ</translation>
+<translation id="3235722914093408050">Android सेटिंग खोलें और Brave सिंक शुरू करने के लिए Android सिस्टम सिंक फिर से चालू करें</translation>
+<translation id="3367813778245106622">सिंक शुरू करने के लिए फिर से साइन इन करें</translation>
+<translation id="974555521953189084">सिंक शुरू करने के लिए अपना 'पासफ़्रेज़' डालें</translation>
+<translation id="2997266899014181325">सिंक शुरू करने के लिए, "अपना Brave डेटा सिंक करें" को चालू करें.</translation>
+<translation id="8260126382462817229">फिर से प्रवेश करके देखें</translation>
+<translation id="5919204609460789179">सिंक शुरू करने के लिए <ph name="PRODUCT_NAME"/> अपडेट करें</translation>
+<translation id="397583555483684758">समन्‍वयन ने काम करना बंद कर दिया है</translation>
+<translation id="1966710179511230534">कृपया अपने साइन के विवरण अपडेट करें.</translation>
+<translation id="7063006564040364415">समन्‍वयन सर्वर से कनेक्‍ट नहीं किया जा सका.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> पुराना है.</translation>
+<translation id="4170011742729630528">सेवा उपलब्ध नहीं है; बाद में फिर से प्रयास करें.</translation>
+<translation id="7947953824732555851">स्वीकार करें और साइन इन करें</translation>
+<translation id="8583805026567836021">खाते का डेटा साफ़ हो रहा है</translation>
+<translation id="8310344678080805313">मानक टैब</translation>
+<translation id="5748802427693696783">मानक टैब पर स्विच कर दिया गया</translation>
+<translation id="7998918019931843664">बंद टैब फिर से खोलें</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, टैब</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> टैब बंद करें</translation>
+<translation id="7243308994586599757">विकल्‍प स्‍क्रीन के नीचे उपलब्‍ध हैं</translation>
+<translation id="4060598801229743805">स्क्रीन के शीर्ष भाग में मौजूद विकल्प</translation>
+<translation id="2810645512293415242">डेटा बचाने और तेज़ी से लोड करने के लिए आसान बनाया गया पेज.</translation>
+<translation id="3985215325736559418">क्या आप <ph name="FILE_NAME"/> को फिर से डाउनलोड करना चाहते हैं?</translation>
+<translation id="2450083983707403292">क्या आप <ph name="FILE_NAME"/> को डाउनलोड करना फिर से शुरू करना चाहते हैं?</translation>
+<translation id="7514365320538308">डाउनलोड करें</translation>
+<translation id="545042621069398927">आपके डाउनलोड की गति बढ़ाई जा रही है.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{फ़ाइल डाउनलोड की जा रही है.}one{# फ़ाइलें डाउनलोड की जा रही हैं.}other{# फ़ाइलें डाउनलोड की जा रही हैं.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> फ़ाइलें डाउनलोड हो रही हैं (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">फ़ाइल डाउनलोड हो रही है (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 डाउनलोड पूरा हुआ.}one{# डाउनलोड पूरे हुए.}other{# डाउनलोड पूरे हुए.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 डाउनलोड नहीं हो सका.}one{# डाउनलोड नहीं हो सके.}other{# डाउनलोड नहीं हो सके.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 डाउनलोड बाकी है.}one{# डाउनलोड बाकी हैं.}other{# डाउनलोड बाकी हैं.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> बटन</translation>
+<translation id="3205824638308738187">करीब-करीब पूरा हो गया!</translation>
+<translation id="3960299545138990065">Brave को फिर से शुरू करें</translation>
+<translation id="3771001275138982843">अपडेट डाउनलोड नहीं किया जा सका</translation>
+<translation id="3888648114124182147">Brave का अपडेट डाउनलोड हो रहा है…</translation>
+<translation id="1705567146636171298">Brave अपडेट करें</translation>
+<translation id="6195417478702700398">बेहतरीन ब्राउज़िंग अनुभव के लिए, Brave अपडेट करें</translation>
+<translation id="3512968675351418494">वेब को अपनी भाषा में देखने के लिए, Brave का नया वर्शन पाएं</translation>
+<translation id="6427112570124116297">वेब का अनुवाद करें</translation>
+<translation id="1379423114029199501">Brave के नए वर्शन में अपनी भाषा पाने के लिए अपडेट करें</translation>
+<translation id="5684874026226664614">ओह. इस पेज का अनुवाद नहीं किया जा सका.</translation>
+<translation id="6831043979455480757">अनुवाद करें</translation>
+<translation id="1285320974508926690">कभी भी इस साइट का अनुवाद न करें</translation>
+<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE"/> भाषा के पेज का हमेशा अनुवाद करें</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/> भाषा के पेज का कभी भी अनुवाद न करें</translation>
+<translation id="124116460088058876">ज़्यादा भाषाएं</translation>
+<translation id="290376772003165898">क्या पेज <ph name="LANGUAGE"/> भाषा में नहीं है?</translation>
+<translation id="4432792777822557199">अब से <ph name="SOURCE_LANGUAGE"/> भाषा के पेज का अनुवाद <ph name="TARGET_LANGUAGE"/> भाषा में किया जाएगा</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/> भाषा के पेज का अनुवाद नहीं किया जाएगा</translation>
+<translation id="5447765697759493033">इस साइट का अनुवाद नहीं किया जाएगा</translation>
+<translation id="4880127995492972015">अनुवाद करें…</translation>
+<translation id="641643625718530986">प्रिंट करें…</translation>
+<translation id="8909135823018751308">शेयर करें…</translation>
+<translation id="4996978546172906250">इससे शेयर करें</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> के द्वारा शेयर करें</translation>
+<translation id="6277522088822131679">पेज को प्रिंट करने में समस्या थी. कृपया फिर से प्रयास करें.</translation>
+<translation id="3254409185687681395">इस पेज को बुकमार्क करें</translation>
+<translation id="497421865427891073">आगे जाएं</translation>
+<translation id="813082847718468539">साइट जानकारी देखें</translation>
+<translation id="2532336938189706096">वेब व्यू</translation>
+<translation id="6005538289190791541">सुझाया गया पासवर्ड</translation>
+<translation id="4634124774493850572">पासवर्ड का इस्तेमाल करें</translation>
+<translation id="8285489906452138776">Brave को इस साइट के लिए आपका कैमरा एक्सेस करने की अनुमति चाहिए.</translation>
+<translation id="320189792589364011">Brave को इस साइट के लिए आपका माइक्रोफ़ोन एक्सेस करने की अनुमति चाहिए.</translation>
+<translation id="7988136689212463100">Brave को इस साइट के लिए आपका कैमरा और माइक्रोफ़ोन के एक्सेस करने की अनुमति चाहिए.</translation>
+<translation id="4931190655840828017">इस साइट से आपकी जगह की जानकारी शेयर करने के लिए Brave को आपकी जगह की जानकारी का एक्सेस चाहिए</translation>
+<translation id="3088191967551450609">फ़ाइलें डाउनलोड करने के लिए Brave को मेमोरी के ऐक्‍सेस की ज़रूरत होगी.</translation>
+<translation id="8942627711005830162">दूसरी विंडो में खोलें</translation>
+<translation id="4195643157523330669">नए टैब में खोलें</translation>
+<translation id="1100066534610197918">समूह में नए टैब में खोलें</translation>
+<translation id="4860895144060829044">कॉल करें</translation>
+<translation id="6896758677409633944">कॉपी बनाएं</translation>
+<translation id="8393700583063109961">संदेश भेजें</translation>
+<translation id="3557336313807607643">संपर्कों में जोड़ें</translation>
+<translation id="4269820728363426813">लिंक पते को कॉपी करें</translation>
+<translation id="1206892813135768548">लिंक लेख को कॉपी करें</translation>
+<translation id="1204037785786432551">डाउनलोड करने का लिंक</translation>
+<translation id="6864459304226931083">इमेज डाउनलोड करें</translation>
+<translation id="8209050860603202033">इमेज खोलें</translation>
+<translation id="8073388330009372546">इमेज 'नए टैब' में खोलें</translation>
+<translation id="6649642165559792194">इमेज की झलक देखें <ph name="BEGIN_NEW"/>नई<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">इमेज लोड करें</translation>
+<translation id="3845332215609790146">'Brave Software लेंस' से खोजें <ph name="BEGIN_NEW"/>नया<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">इस इमेज के लिए <ph name="SEARCH_ENGINE"/> पर खोजें</translation>
+<translation id="3384347053049321195">इमेज शेयर करें</translation>
+<translation id="5833984609253377421">लिंक शेयर करें</translation>
+<translation id="6475951671322991020">वीडियो डाउनलोड करें</translation>
+<translation id="2317945146070194624">नए Brave टैब में खोलें</translation>
+<translation id="7975379999046275268">पेज की झलक देखें <ph name="BEGIN_NEW"/>नया<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">पृष्‍ठ रीफ्रेश किया जा रहा है</translation>
+<translation id="36525718899759834">Brave Software Play स्‍टोर से ऐप्लिकेशन डाउनलोड करें: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">गहरा</translation>
+<translation id="1807246157184219062">हल्का</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">मोनोस्पेस</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">बीम के लिए टैब को चुनें</translation>
+<translation id="8719023831149562936">वर्तमान टैब को बीम नहीं किया जा सकता</translation>
+<translation id="2139186145475833000">होम स्क्रीन में जोड़ें</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> को खोलें</translation>
+<translation id="2122601567107267586">ऐप्लिकेशन नहीं खोला जा सका</translation>
+<translation id="5129038482087801250">वेब ऐप्लिकेशन इंस्टॉल करें</translation>
+<translation id="3789841737615482174">इंस्‍टॉल करें</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> को आपकी होम स्क्रीन में जोड़ा गया था</translation>
+<translation id="7333031090786104871">पिछली साइट अब भी जोड़ी जा रही है</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> जोड़ा जा रहा है...</translation>
+<translation id="3778956594442850293">होम स्‍क्रीन में जोड़ा गया</translation>
+<translation id="2146738493024040262">इंस्टैंट ऐप्लिकेशन खोलें</translation>
+<translation id="7016516562562142042">मौजूदा सर्च इंजन के लिए अनुमति दी गई है</translation>
+<translation id="6177111841848151710">मौजूदा सर्च इंजन के लिए ब्लॉक किया गया है</translation>
+<translation id="145097072038377568">Android सेटिंग में बंद कर दिया गया है</translation>
+<translation id="8007176423574883786">इस डिवाइस के लिए बंद कर दिया गया है</translation>
+<translation id="164269334534774161">आप <ph name="CREATION_TIME"/> से इस पेज की ऑफ़लाइन कॉपी देख रहे हैं</translation>
+<translation id="4594952190837476234">यह पेज <ph name="CREATION_TIME"/> का है और यह ऑनलाइन वर्शन से अलग हो सकता है.</translation>
+<translation id="8840953339110955557">यह पेज ऑनलाइन वर्शन से अलग हो सकता है.</translation>
+<translation id="6405300764336705484">यह सामग्री <ph name="DOMAIN_NAME"/> की है जिसे Brave Software के द्वारा वितरित किया गया है.</translation>
+<translation id="1006017844123154345">ऑनलाइन खोलें</translation>
+<translation id="3326636747541519688">लाइट पेज Brave Software ने मुहैया कराया है</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> से <ph name="BEGIN_LINK"/>मूल पेज लोड करें<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">अगर आपको यह बार-बार दिखाई दे रहा हो, तो इन <ph name="BEGIN_LINK"/>सुझावों<ph name="END_LINK"/> को आज़माएं.</translation>
+<translation id="8748850008226585750">छिपी हुई सामग्री</translation>
+<translation id="3810973564298564668">प्रबंधित करें</translation>
+<translation id="5199929503336119739">वर्क प्रोफ़ाइल</translation>
+<translation id="528192093759286357">फ़ुल स्क्रीन से बाहर निकलने के लिए ऊपर से खींचें और वापस जाएं स्पर्श करें.</translation>
+<translation id="2836148919159985482">फ़ुल स्क्रीन से बाहर निकलने के लिए वापस जाएं बटन स्पर्श करें.</translation>
+<translation id="3967822245660637423">डाउनलोड पूरा हुआ</translation>
+<translation id="2434158240863470628">डाउनलोड हो गया <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">डाउनलोड विफल रहा</translation>
+<translation id="1384959399684842514">डाउनलोड रोका गया</translation>
+<translation id="1671236975893690980">डाउनलोड लंबित…</translation>
+<translation id="5561549206367097665">नेटवर्क का इंतज़ार किया जा रहा है…</translation>
+<translation id="5864419784173784555">दूसरे डाउनलोड का इंतज़ार किया जा रहा है…</translation>
+<translation id="6461962085415701688">फ़ाइल नहीं खोली जा सकती</translation>
+<translation id="1178581264944972037">रोकें</translation>
+<translation id="8200772114523450471">फिर से शुरू करें</translation>
+<translation id="1409879593029778104"><ph name="FILE_NAME"/> डाउनलोड को रोका गया क्‍योंकि फ़ाइल पहले से मौजूद है.</translation>
+<translation id="3387650086002190359">सिस्‍टम त्रुटियों के कारण <ph name="FILE_NAME"/> डाउनलोड विफल रहा.</translation>
+<translation id="6482749332252372425">मेमोरी स्‍थान कम होने के कारण <ph name="FILE_NAME"/> डाउनलोड विफल रहा.</translation>
+<translation id="7619072057915878432">नेटवर्क विफलताओं के कारण <ph name="FILE_NAME"/> डाउनलोड विफल रहा.</translation>
+<translation id="1477626028522505441">सर्वर संबधी समस्‍याओं के कारण <ph name="FILE_NAME"/> डाउनलोड विफल रहा.</translation>
+<translation id="3692944402865947621"><ph name="FILE_NAME"/> डाउनलोड नहीं हो सकी क्योंकि स्टोर करने की जगह नहीं मिली.</translation>
+<translation id="604996488070107836">किसी अज्ञात गड़बड़ी के कारण <ph name="FILE_NAME"/> का डाउनलोड विफल रहा.</translation>
+<translation id="6738867403308150051">डाउनलोड हो रहे हैं...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> केबी</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> एमबी</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> जीबी</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> केबी डाउनलोड किया गया</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> एमबी डाउनलोड किया गया</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> जीबी डाउनलोड किया गया</translation>
+<translation id="9204836675896933765">1 फ़ाइल बची है</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> फ़ाइलें बची हैं</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> फ़ाइल डाउनलोड की गई}one{<ph name="FILES_DOWNLOADED_MANY"/> फ़ाइलें डाउनलोड की गईं}other{<ph name="FILES_DOWNLOADED_MANY"/> फ़ाइलें डाउनलोड की गईं}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> दिन शेष</translation>
+<translation id="8190358571722158785">1 दिन शेष</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> घंटे शेष</translation>
+<translation id="510275257476243843">1 घंटा शेष</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> मिनट शेष</translation>
+<translation id="3236059992281584593">1 मिनट शेष</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> सेकंड शेष</translation>
+<translation id="2781151931089541271">1 सेकंड शेष</translation>
+<translation id="3303414029551471755">सामग्री डाउनलोड करने के लिए आगे बढ़ें?</translation>
+<translation id="8617240290563765734">सुझाया गया वह URL खोलें जिसे डाउनलोड की गई सामग्री में बताया गया है?</translation>
+<translation id="1373696734384179344">चयनित सामग्री डाउनलोड करने के लिए मेमोरी अपर्याप्‍त है.</translation>
+<translation id="5271967389191913893">डाउनलोड की जाने वाली सामग्री को डिवाइस नहीं खोल सकता.</translation>
+<translation id="883806473910249246">सामग्री डाउनलोड करते समय कोई गड़बड़ी हुई.</translation>
+<translation id="5626134646977739690">नाम:</translation>
+<translation id="7963646190083259054">विक्रेता:</translation>
+<translation id="3414952576877147120">आकार:</translation>
+<translation id="7375125077091615385">प्रकार:</translation>
+<translation id="5765780083710877561">वर्णन:</translation>
+<translation id="4881695831933465202">खोलें</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> केबी उपलब्ध</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> एमबी उपलब्ध</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> जीबी उपलब्ध है</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/> में से <ph name="SPACE_USED"/> का इस्तेमाल किया जा रहा है</translation>
+<translation id="3587482841069643663">सभी</translation>
+<translation id="4988526792673242964">पेज</translation>
+<translation id="3810838688059735925">वीडियो</translation>
+<translation id="3616113530831147358">ऑडियो</translation>
+<translation id="9219103736887031265">इमेज</translation>
+<translation id="8250920743982581267">दस्तावेज़</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# फ़ाइल}one{# फ़ाइलें}other{# फ़ाइलें}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# इमेज}one{# इमेज}other{# इमेज}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# वीडियो}one{# वीडियो}other{# वीडियो}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ऑडियो फ़ाइल}one{# ऑडियो फ़ाइलें}other{# ऑडियो फ़ाइलें}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# पेज}one{# पेज}other{# पेज}}</translation>
+<translation id="5456381639095306749">पेज डाउनलोड करें</translation>
+<translation id="2394602618534698961">आप जिन फ़ाइलों को डाउनलोड करते हैं वे यहां दिखाई देंगी</translation>
+<translation id="7810647596859435254">इसमें खोलें…</translation>
+<translation id="5655963694829536461">अपने डाउनलोड में खोजें</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">मेरी फ़ाइलें</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">लेख यहां दिखाई देते हैं जिन्हें आप ऑफ़लाइन होने पर भी पढ़ सकते हैं.</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# घंटा}one{# घंटे}other{# घंटे}}</translation>
+<translation id="5853623416121554550">रोका गया</translation>
+<translation id="8965591936373831584">डाउनलोड बाकी है</translation>
+<translation id="2779651927720337254">डाउनलोड नहीं हो सका</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">अभी-अभी</translation>
+<translation id="4000212216660919741">ऑफ़लाइन होम</translation>
+<translation id="9133397713400217035">ऑफ़लाइन सामग्री देखें</translation>
+<translation id="968900484120156207">आप जिन पेजों पर जाएंगे वे यहां दिखाई देंगे</translation>
+<translation id="7882131421121961860">कोई इतिहास नहीं मिला</translation>
+<translation id="3549657413697417275">अपने इतिहास में खोजें</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave पहली बार चलाने का अनुभव</translation>
+<translation id="2700285883409956633">इस ऐप्‍लिकेशन का इस्तेमाल करके, आप Brave की <ph name="BEGIN_LINK1"/>सेवा की शर्तों<ph name="END_LINK1"/> और <ph name="BEGIN_LINK2"/>निजता सूचना<ph name="END_LINK2"/> से सहमत होते हैं.</translation>
+<translation id="1640714894372474981">इस ऐप्लिकेशन के इस्तेमाल का मतलब है कि आप Brave की <ph name="BEGIN_LINK1"/>सेवा की शर्तों<ph name="END_LINK1"/> और <ph name="BEGIN_LINK2"/>निजता सूचना<ph name="END_LINK2"/> और <ph name="BEGIN_LINK3"/>Family Link से प्रबंधित होने वाले Brave Software खातों के लिए निजता सूचना<ph name="END_LINK3"/> से सहमत हैं.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> Brave में खुलेगा. जारी रखकर, आप Brave की <ph name="BEGIN_LINK1"/>सेवा की शर्तों<ph name="END_LINK1"/> और <ph name="BEGIN_LINK2"/>निजता सूचना<ph name="END_LINK2"/> से सहमत होते हैं.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Brave में खुलेगा. जारी रखकर, आप Brave की <ph name="BEGIN_LINK1"/>सेवा की शर्तों<ph name="END_LINK1"/> और <ph name="BEGIN_LINK2"/>निजता सूचना<ph name="END_LINK2"/> और <ph name="BEGIN_LINK3"/>Family Link से प्रबंधित होने वाले Brave Software खातों के लिए निजता सूचना<ph name="END_LINK3"/> से सहमत होते हैं.</translation>
+<translation id="673197144963363525">Brave Software को इस्तेमाल के आंकड़े और खराबी रिपोर्ट भेजकर Brave को बेहतर बनाने में मदद करें.</translation>
+<translation id="3518985090088779359">स्‍वीकार करें और जारी रखें</translation>
+<translation id="7207456302801184289">Brave में आपका स्वागत है</translation>
+<translation id="704822250101715322">Brave Software Play सेवाएं द्वारा अपडेट खत्म किए जाने की प्रतीक्षा की जा रही है</translation>
+<translation id="1231733316453485619">क्या सिंक करना चालू करें?</translation>
+<translation id="5132942445612118989">सभी डिवाइस पर अपने पासवर्ड, इतिहास और दूसरी कई चीज़ें सिंक करें</translation>
+<translation id="5736731321935944068">खोज, विज्ञापन, और दूसरी Brave Software सेवाओं को मनमुताबिक बनाने के लिए, Brave Software आपके इतिहास का इस्तेमाल कर सकता है</translation>
+<translation id="4013614219085422040">खोज और दूसरी Brave Software सेवाओं को मनमुताबिक बनाने के लिए, Brave Software आपके इतिहास का इस्तेमाल कर सकता है</translation>
+<translation id="5581519193887989363">आप जब चाहें तब <ph name="BEGIN_LINK1"/>सेटिंग<ph name="END_LINK1"/> में जाकर किसी भी चीज़ को सिंक करने का विकल्प चुन सकते हैं.</translation>
+<translation id="741204030948306876">हां मैं सहमत हूं</translation>
+<translation id="2410754283952462441">कोई खाता चुनें</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> के रूप में जारी रखें</translation>
+<translation id="6210748933810148297">क्या <ph name="EMAIL"/> नहीं हैं?</translation>
+<translation id="8109613176066109935">अपने सभी डिवाइस पर अपने बुकमार्क पाने के लिए, 'सिंक करें' को चालू करें</translation>
+<translation id="2818669890320396765">अपने सभी डिवाइस पर अपने बुकमार्क पाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
+<translation id="6003646045106347985">Brave Software की ओर से सुझाई गई मनमुताबिक सामग्री पाने के लिए, 'सिंक करें' को चालू करें</translation>
+<translation id="8494430740943879273">Brave Software की ओर से सुझाई गई मनमुताबिक सामग्री पाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
+<translation id="5862731021271217234">अपने दूसरे डिवाइस से अपने टैब पाने के लिए, 'सिंक करें' को चालू करें</translation>
+<translation id="3568688522516854065">अपने दूसरे डिवाइस से अपने टैब पाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
+<translation id="1208340532756947324">सभी डिवाइस पर सिंक करने और मनमुताबिक बनाने के लिए, 'सिंक करें' को चालू करें</translation>
+<translation id="4472118726404937099">सभी डिवाइस पर सिंक करने और मनमुताबिक बनाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
+<translation id="2426805022920575512">दूसरा खाता चुनें</translation>
+<translation id="6790428901817661496">चलाएं</translation>
+<translation id="1272079795634619415">रोकें</translation>
+<translation id="2874939134665556319">पिछला ट्रैक</translation>
+<translation id="4046123991198612571">अगला ट्रैक</translation>
+<translation id="3859306556332390985">आगे जाएं</translation>
+<translation id="8441146129660941386">पीछे जाएं</translation>
+<translation id="6706288973712894588">फ़िलहाल, आप ऑफ़लाइन हैं.\n<ph name="BEGIN_LINK"/>अपने ऑफ़लाइन फ़ीड के बारे में और जानें.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">हाल ही के टैब</translation>
+<translation id="8497726226069778601">यहां देखने के लिए…अभी तक कुछ भी नहीं है</translation>
+<translation id="5423934151118863508">सबसे ज़्यादा देखे गए पेज यहां दिखाई देंगे</translation>
+<translation id="6127379762771434464">आइटम निकाला गया</translation>
+<translation id="4605958867780575332">आइटम निकाला गया: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">अन्य डिवाइस</translation>
+<translation id="4738836084190194332">अंतिम बार सिंक किया गया: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# मिनट पहले}one{# मिनट पहले}other{# मिनट पहले}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# घंटा पहले}one{# घंटे पहले}other{# घंटे पहले}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# दिन पहले}one{# दिन पहले}other{# दिन पहले}}</translation>
+<translation id="2762000892062317888">अभी-अभी</translation>
+<translation id="1407135791313364759">सभी बुकमार्क खोलें</translation>
+<translation id="1209206284964581585">अभी छिपाएं</translation>
+<translation id="129553762522093515">हाल ही में बंद किए गए</translation>
+<translation id="8413126021676339697">पूरा इतिहास दिखाएं</translation>
+<translation id="7876243839304621966">सभी को निकालें</translation>
+<translation id="8487700953926739672">ऑफ़लाइन उपलब्ध है</translation>
+<translation id="5224771365102442243">वीडियो के साथ</translation>
+<translation id="3493531032208478708">सुझाई गई सामग्री के बारे में <ph name="BEGIN_LINK"/>ज़्यादा जानें<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">सुझाव नहीं मिल पा रहे हैं</translation>
+<translation id="5013696553129441713">कोई नया सुझाव नहीं है</translation>
+<translation id="1736419249208073774">बेहतर जानें</translation>
+<translation id="7444811645081526538">ज़्यादा श्रेणियां</translation>
+<translation id="6709133671862442373">समाचार</translation>
+<translation id="1264974993859112054">खेल-कूद</translation>
+<translation id="9139318394846604261">शॉपिंग</translation>
+<translation id="3912508018559818924">वेब की सबसे अच्छी जानकारी ढूंढी जा रही है…</translation>
+<translation id="526421993248218238">यह पेज लोड नहीं हो पा रहा है</translation>
+<translation id="614940544461990577">यह आज़माकर देखें:</translation>
+<translation id="3288003805934695103">पेज को पुनः लोड करें</translation>
+<translation id="2353636109065292463">आपके इंटरनेट कनेक्शन की जाँच की जा रही है</translation>
+<translation id="2858138569776157458">मुख्य साइटें</translation>
+<translation id="8364299278605033898">लोकप्रिय वेबसाइटें देखें</translation>
+<translation id="1171770572613082465">"मुख्य साइटें" बटन पर टैप करके लोकप्रिय साइटें देखें</translation>
+<translation id="5233638681132016545">नया टैब</translation>
+<translation id="4521874409998847950">प्रकाशक: <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>Brave Software की ओर से डिलीवर किया गया<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">नया वर्शन उपलब्ध है</translation>
+<translation id="4058091506841967397">Brave अपडेट संभव नहीं</translation>
+<translation id="6316139424528454185">Android वर्शन काम नहीं कर रहा है</translation>
+<translation id="6989267951144302301">डाउनलोड नहीं किया जा सका</translation>
+<translation id="624789221780392884">अपडेट तैयार है</translation>
+<translation id="1549000191223877751">अन्य विंडो में ले जाएं</translation>
+<translation id="7481312909269577407">आगे जाएं</translation>
+<translation id="4084682180776658562">बुकमार्क</translation>
+<translation id="6437478888915024427">पेज की जानकारी</translation>
+<translation id="7180611975245234373">रीफ्रेश करें</translation>
+<translation id="4913169188695071480">रीफ्रेश करना बंद करें</translation>
+<translation id="1829244130665387512">पेज में ढूंढें</translation>
+<translation id="6593061639179217415">डेस्कटॉप साइट</translation>
+<translation id="9063523880881406963">अनुरोध डेस्कटॉप साइट बंद करें</translation>
+<translation id="2038563949887743358">अनुरोध डेस्कटॉप साइट चालू करें</translation>
+<translation id="2433507940547922241">प्रकटन</translation>
+<translation id="983192555821071799">सभी टैब बंद करें</translation>
+<translation id="1310482092992808703">टैब को समूह में लगाएं</translation>
+<translation id="7725024127233776428">आप जो पेज बुकमार्क करते हैं वे यहां दिखाई देंगे</translation>
+<translation id="4404568932422911380">कोई बुकमार्क नहीं</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> बुकमार्क}one{<ph name="BOOKMARKS_COUNT_MANY"/> बुकमार्क}other{<ph name="BOOKMARKS_COUNT_MANY"/> बुकमार्क}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> में बुकमार्क किया गया</translation>
+<translation id="3207960819495026254">बुकमार्क किया गया</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> में बुकमार्क किया गया</translation>
+<translation id="8063895661287329888">बुकमार्क जोड़ने में विफल रहा.</translation>
+<translation id="2842985007712546952">मूल फ़ोल्‍डर</translation>
+<translation id="9065203028668620118">बदलाव करें</translation>
+<translation id="4405224443901389797">इसमें ले जाएं…</translation>
+<translation id="5170568018924773124">फ़ोल्डर में दिखाएं</translation>
+<translation id="8035133914807600019">नया फ़ोल्‍डर…</translation>
+<translation id="4532845899244822526">फ़ोल्डर चुनें</translation>
+<translation id="6627583120233659107">फ़ोल्‍डर में बदलाव करें</translation>
+<translation id="1197267115302279827">बुकमार्क ले जाएं</translation>
+<translation id="6963766334940102469">बुकमार्क मिटाएं</translation>
+<translation id="4351244548802238354">संवाद बंद करें</translation>
+<translation id="451872707440238414">अपने बुकमार्क में खोजें</translation>
+<translation id="8901170036886848654">कोई बुकमार्क नहीं मिला</translation>
+<translation id="6404511346730675251">बुकमार्क में बदलाव करें</translation>
+<translation id="3894427358181296146">फ़ोल्डर जोड़ें</translation>
+<translation id="5327248766486351172">नाम</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">फ़ोल्डर</translation>
+<translation id="5161254044473106830">शीर्षक आवश्‍यक</translation>
+<translation id="2996809686854298943">URL ज़रूरी है</translation>
+<translation id="2536728043171574184">इस पृष्‍ठ की ऑफ़लाइन कॉपी देख रहे हैं</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> में ऑफ़लाइन देखें</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> और कई साइटें</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{तैयार होने पर Brave आपका पेज लोड करेगा}one{तैयार होने पर Brave आपके पेज लोड करेगा}other{तैयार होने पर Brave आपके पेज लोड करेगा}}</translation>
+<translation id="6811034713472274749">पेज देखने के लिए तैयार है</translation>
+<translation id="4561979708150884304">कोई कनेक्शन नहीं</translation>
+<translation id="8274165955039650276">डाउनलोड देखें</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/> में से <ph name="RESULT_NUMBER"/> परिणाम</translation>
+<translation id="4943872375798546930">कोई परिणाम नहीं</translation>
+<translation id="981121421437150478">ऑफ़लाइन</translation>
+<translation id="3298243779924642547">लाइट</translation>
+<translation id="393697183122708255">कोई चालू बोलकर खोजने की सुविधा उपलब्‍ध नहीं है</translation>
+<translation id="7191430249889272776">पृष्ठभूमि में टैब खोला गया.</translation>
+<translation id="8445059357334030806">Brave में खोलें</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/> में खोलें</translation>
+<translation id="7022756207310403729">ब्राउज़र में खोलें</translation>
+<translation id="1113597929977215864">सरल बनाया गया व्यू दिखाएं</translation>
+<translation id="1513352483775369820">बुकमार्क और वेब इतिहास</translation>
+<translation id="4939482511480190003">Brave को बेहतर बनाने में सहायता करें. <ph name="BEGIN_LINK"/>सर्वे में भाग लें<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">वापस जाएं</translation>
+<translation id="5596627076506792578">ज़्यादा विकल्प</translation>
+<translation id="3522247891732774234">अपडेट उपलब्ध है. ज़्यादा विकल्प</translation>
+<translation id="6773423637732432200">Brave अपडेट नहीं किया जा सकता. ज़्यादा विकल्प</translation>
+<translation id="3328801116991980348">साइट जानकारी</translation>
+<translation id="5391532827096253100">इस साइट से आपका कनेक्शन सुरक्षित नहीं है. साइट की जानकारी</translation>
+<translation id="6206551242102657620">कनेक्शन सुरक्षित है. साइट की जानकारी</translation>
+<translation id="6963642900430330478">यह पेज खतरनाक है. साइट की जानकारी</translation>
+<translation id="9070377983101773829">बोलकर खोज चालू करें</translation>
+<translation id="8676374126336081632">इनपुट साफ़ करें</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> टैब खुला है, एक टैब से दूसरे टैब पर जाने के लिए टैप करें}one{<ph name="OPEN_TABS_MANY"/> टैब खुले हैं, एक टैब से दूसरे टैब पर जाने के लिए टैप करें}other{<ph name="OPEN_TABS_MANY"/> टैब खुले हैं, एक टैब से दूसरे टैब पर जाने के लिए टैप करें}}</translation>
+<translation id="2369533728426058518">खुले टैब</translation>
+<translation id="7071521146534760487">खाता प्रबंधित करें</translation>
+<translation id="932327136139879170">होम बटन</translation>
+<translation id="2707726405694321444">पेज रीफ्रेश करें</translation>
+<translation id="2891154217021530873">पेज को लोड करना रोकें</translation>
+<translation id="6710213216561001401">पिछला</translation>
+<translation id="6659594942844771486">टैब</translation>
+<translation id="1933845786846280168">चयनित टैब</translation>
+<translation id="2268044343513325586">बेहतर बनाएं</translation>
+<translation id="7846076177841592234">चुना गया हटाएं</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> चुने गए.  विकल्प, स्क्रीन के ऊपरी भाग के पास उपलब्ध हैं</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> चुने गए</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 चयनित आइटम शेयर करें}one{# चयनित आइटम शेयर करें}other{# चयनित आइटम शेयर करें}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 चयनित आइटम निकालें}one{# चयनित आइटम निकालें}other{# चयनित आइटम निकालें}}</translation>
+<translation id="1283039547216852943">पूरा खोलने के लिए टैप करें</translation>
+<translation id="5962718611393537961">छोटा करने के लिए टैप करें</translation>
+<translation id="8076492880354921740">टैब</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 चुना गया}one{# चुने गए}other{# चुने गए}}</translation>
+<translation id="6818926723028410516">आइटम चुनें</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/> पर वापस लौटने के लिए स्पर्श करें</translation>
+<translation id="6766758767654711248">साइट पर जाने के लिए टैप करें</translation>
+<translation id="429312253194641664">किसी साइट पर मीडिया चल रहा है</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> आपकी स्क्रीन शेयर कर रहा है</translation>
+<translation id="8833831881926404480">एक साइट आपकी स्क्रीन शेयर कर रही है</translation>
+<translation id="9086455579313502267">नेटवर्क की एक्सेस नहीं की जा सकती है.</translation>
+<translation id="938850635132480979">गड़बड़ी: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/> में खोलें</translation>
+<translation id="548278423535722844">मैप ऐप्लिकेशन में खोलें</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> में ईमेल बनाएं</translation>
+<translation id="7875915731392087153">ईमेल बनाएं</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> में इवेंट बनाएं</translation>
+<translation id="2900528713135656174">इवेंट बनाएं</translation>
+<translation id="2111511281910874386">पेज पर जाएं</translation>
+<translation id="3988466920954086464">झटपट खोज नतीजे इस पैनल में देखें</translation>
+<translation id="2744248271121720757">इंस्टैंट सर्च या मिलती-जुलती कार्रवाई देखने के लिए किसी शब्द पर टैप करें</translation>
+<translation id="9155898266292537608">आप किसी शब्द पर बस एक टैप करके भी खोज सकते हैं</translation>
+<translation id="3232754137068452469">वेब ऐप्लिकेशन</translation>
+<translation id="1430915738399379752">प्रिंट करें</translation>
+<translation id="3775705724665058594">अपने डिवाइस पर भेजें</translation>
+<translation id="6364438453358674297">सुझाव को इतिहास से निकालें?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> बंद है</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> टैब बंद किए गए</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> मिटाया गया</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> बुकमार्क का पता लगा</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> डाउनलोड हटाए गए</translation>
+<translation id="1248710015876067820">Brave इंस्टेंस की असमर्थित संख्या.</translation>
+<translation id="4259722352634471385">मार्गदर्शक अवरोधित है: <ph name="URL"/></translation>
+<translation id="8959122750345127698">मार्गदर्शक तक नहीं पहुंचा जा सकता: <ph name="URL"/></translation>
+<translation id="5210365745912300556">टैब बंद करें</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> को बंद करें</translation>
+<translation id="1227058898775614466">नेविगेशन का इतिहास</translation>
+<translation id="9169507124922466868">नेविगेशन का इतिहास आधी स्क्रीन में खुला हुआ है</translation>
+<translation id="1327257854815634930">नेविगेशन का इतिहास अपने पूरे आकार में खुला हुआ है</translation>
+<translation id="8788265440806329501">नेविगेशन का इतिहास बंद है</translation>
+<translation id="7482656565088326534">झलक टैब</translation>
+<translation id="8427875596167638501">'झलक' टैब आधी स्क्रीन में खुला हुआ है</translation>
+<translation id="9102803872260866941">झलक टैब अपने पूरे आकार में खुला हुआ है</translation>
+<translation id="2942036813789421260">झलक टैब बंद है</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> मेमोरी</translation>
+<translation id="3822502789641063741">क्या आप साइट मेमोरी खाली करना चाहते हैं?</translation>
+<translation id="9205995714227143200">ऐसी 'साइट मेमोरी' जो Brave के हिसाब से ज़रूरी नहीं है (जैसे कि ऐसी साइट जिनमें कोई भी सेटिंग नहीं सेव की गई है या जिन पर आप अक्सर नहीं जाते हैं)</translation>
+<translation id="3997476611815694295">महत्वहीन मेमोरी</translation>
+<translation id="8493948351860045254">स्‍थान खाली करें</translation>
+<translation id="2324920234469020158">यह साइट की कुकी, कैश और अन्य डेटा निकाल देगा जो Brave के विचार में महत्वपूर्ण नहीं है.</translation>
+<translation id="5447201525962359567">सभी साइट मेमोरी, जिसमें कुकी और स्थानीय रूप से संग्रहित अन्य डेटा शामिल है</translation>
+<translation id="1376578503827013741">गणना की जा रही है…</translation>
+<translation id="583281660410589416">अज्ञात</translation>
+<translation id="2323763861024343754">साइट मेमोरी</translation>
+<translation id="3587672679800759167">Brave द्वारा उपयोग किया गया कुल डेटा, जिसमें खाते, बुकमार्क और सहेजी गईं सेटिंग शामिल हैं</translation>
+<translation id="6545017243486555795">सभी डेटा साफ़ करें</translation>
+<translation id="4095146165863963773">ऐप्लिकेशन डेटा मिटाएं?</translation>
+<translation id="53119194224775367">Brave का सभी ऐप्लिकेशन डेटा हमेशा केे लिए हटा दिया जाएगा. इसमें सभी फ़ाइलें, सेटिंग, खाते, डेटाबेस वगैरह शामिल हैं.</translation>
+<translation id="5307446750509046227">साइट की मेमोरी मिटाएं</translation>
+<translation id="300526633675317032">इससे वेबसाइट की पूरी <ph name="SIZE_IN_KB"/> मेमोरी साफ़ हो जाएगी.</translation>
+<translation id="8068648041423924542">प्रमाणपत्र चुनने में असमर्थ.</translation>
+<translation id="2315043854645842844">क्लाइंट-साइड प्रमाणपत्र चुनना ऑपरेटिंग सिस्टम से नहीं किया जा सकता है.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> कनेक्ट करना चाहती है</translation>
+<translation id="5308380583665731573">कनेक्ट करें</translation>
+<translation id="868929229000858085">अपने संपर्क खोजें</translation>
+<translation id="1919950603503897840">संपर्कों को चुनें</translation>
+<translation id="7986741934819883144">कोई संपर्क चुनें</translation>
+<translation id="3333961966071413176">सभी संपर्क</translation>
+<translation id="4994033804516042629">कोई संपर्क नहीं मिला</translation>
+<translation id="5403592356182871684">नाम</translation>
+<translation id="2717722538473713889">ईमेल पते</translation>
+<translation id="381841723434055211">फ़ोन नंबर</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 और)}one{(+ # और)}other{(+ # और)}}</translation>
+<translation id="5197729504361054390">आप जो संपर्क चुनेंगे उन्हें <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> के साथ शेयर किया जाएगा.</translation>
+<translation id="1779089405699405702">इमेज डीकोडर</translation>
+<translation id="8067883171444229417">वीडियो चलाएं</translation>
+<translation id="6560414384669816528">Sogou से खोजें</translation>
+<translation id="5406914950576900927">चीन में खोज करने के लिए Brave, <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> का इस्तेमाल कर सकता है. आप इसे <ph name="BEGIN_LINK"/>सेटिंग<ph name="END_LINK"/> में बदल सकते हैं.</translation>
+<translation id="6456271171669383967">Brave Software को डिफ़ॉल्ट बनाए रखें</translation>
+<translation id="4384468725000734951">खोज के लिए Sogou का इस्तेमाल कर रहे हैं</translation>
+<translation id="6103327872225198548">खोजने के लिए Brave Software का उपयोग किया जा रहा है</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Brave में यह ऐप्‍लि‍केशन चल रहा है</translation>
+<translation id="6143689084714664628">Brave में चल रहा है</translation>
+<translation id="7675869148432102528">Brave में <ph name="APP_NAME"/> का डेटा भी है</translation>
+<translation id="2734140769649165081">आप 'Brave सेटिंग' में डेटा हटा सकते हैं</translation>
+<translation id="8232956427053453090">डेटा रखें</translation>
+<translation id="4298388696830689168">लिंक की हुई साइटें</translation>
+<translation id="5763514718066511291">इस ऐप्लिकेशन का यूआरएल कॉपी करने के लिए टैप करें</translation>
+<translation id="6496823230996795692">पहली बार <ph name="APP_NAME"/> का उपयोग करने के लिए, कृपया इंटरनेट चालू करें.</translation>
+<translation id="751961395872307827">साइट से कनेक्ट नहीं किया जा सका</translation>
+<translation id="4878404682131129617">प्रॉक्सी सर्वर के ज़रिए सुरंग बनाना विफल रहा</translation>
+<translation id="4749960740855309258">नया टैब खोलें</translation>
+<translation id="8788968922598763114">अभी बंद किया हुआ टैब खोलें</translation>
+<translation id="7929962904089429003">मेन्यू खोलें</translation>
+<translation id="6039379616847168523">सीधे अगले टैब पर जाएं</translation>
+<translation id="5210286577605176222">सीधे पिछले टैब पर जाएं</translation>
+<translation id="124678866338384709">वर्तमान टैब को बंद करें</translation>
+<translation id="3714981814255182093">ढूंढें बार खोलें</translation>
+<translation id="5441522332038954058">सीधे पता बार पर जाएं</translation>
+<translation id="3398320232533725830">बुकमार्क प्रबंधक खोलें</translation>
+<translation id="6583199322650523874">वर्तमान पेज को बुकमार्क करें</translation>
+<translation id="8489271220582375723">इतिहास पेज खोलें</translation>
+<translation id="4837753911714442426">पेज प्रिंट करने के विकल्प खोलें</translation>
+<translation id="5726692708398506830">पेज पर सब कुछ बड़ा करें</translation>
+<translation id="3259831549858767975">पेज पर सब कुछ छोटा करें</translation>
+<translation id="8015452622527143194">पेज पर सब कुछ वापस डिफ़ॉल्ट आकार में लाएं</translation>
+<translation id="3443221991560634068">वर्तमान पेज फिर से लोड करें</translation>
+<translation id="123724288017357924">कैश सामग्री को अनदेखा कर, मौजूदा पेज फिर लोड करें</translation>
+<translation id="305870044889644984">Brave सहायता केंद्र को नए टैब में खोलें</translation>
+<translation id="3166827708714933426">टैब और विंडो शॉर्टकट</translation>
+<translation id="3169981355900570544">Brave Software Brave सुविधा शॉर्टकट</translation>
+<translation id="4558311620361989323">वेबपेज शॉर्टकट</translation>
+<translation id="1908301351964700579">Brave अब भी VR के लिए तैयारी कर रहा है. Brave को बाद में रीस्टार्ट करें.</translation>
+<translation id="8970887620466824814">कुछ गड़बड़ी हुई.</translation>
+<translation id="1875543012935658554">Brave को फिर से खोलें.</translation>
+<translation id="79859296434321399">'बढ़ी हुई वास्तविकता' की सामग्री देखने के लिए, ARCore इंस्टॉल करें</translation>
+<translation id="8558485628462305855">'बढ़ी हुई वास्तविकता' की सामग्री देखने के लिए, ARCore अपडेट करें</translation>
+<translation id="3513704683820682405">ऑगमेंटेड रिएलिटी (AR)</translation>
+<translation id="5475862044948910901">ऑगमेंटेड रिएलिटी (AR) सत्र शुरू करें?</translation>
 <translation id="7365126855094612066">इस सत्र के दौरान, साइट ये काम करेगी:
 • आपके आस-पास की जगह का 3 डी मैप बनाना
 • कैमरे की गति पर नज़र रखना
 
 साइट आपके कैमरे को ऐक्सेस नहीं करती है. कैमरे से ली गई इमेज सिर्फ़ आपको दिखाई देंगी.</translation>
-<translation id="7375125077091615385">प्रकार:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome पहली बार चलाने का अनुभव</translation>
-<translation id="741204030948306876">हां मैं सहमत हूं</translation>
-<translation id="7413229368719586778">शुरू होने की तारीख: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">पहले पूछें</translation>
-<translation id="7423538860840206698">क्लिपबोर्ड पढ़ने से ब्लॉक किया गया है</translation>
-<translation id="7431991332293347422">यह नियंत्रित करें कि खोज वगैरह को मनमुताबिक बनाने के लिए आपके ब्राउज़िंग इतिहास का इस्तेमाल कैसे किया जाए</translation>
-<translation id="7437998757836447326">Chrome से साइन आउट करें</translation>
-<translation id="7438641746574390233">लाइट मोड चालू होने पर, Chrome तेज़ी से पेज लोड करने के लिए Google के सर्वरों का इस्तेमाल करता है. लाइट मोड धीमे पेजों को फिर से लिखता है, ताकि सिर्फ़ ज़रूरी सामग्री लोड हो. लाइट मोड 'गुप्त' टैब पर लागू नहीं होता.</translation>
-<translation id="7444811645081526538">ज़्यादा श्रेणियां</translation>
-<translation id="7445411102860286510">साइटों को म्यूट किए गए वीडियो अपने आप चलाने की अनुमति दें (हम इस सेटिंग को चालू रखने का सुझाव देते हैं)</translation>
-<translation id="7453467225369441013">आपको ज़्यादातर साइटों से साइन आउट कर देता है. आप अपने Google खाते से साइन आउट नहीं होंगे.</translation>
-<translation id="7454641608352164238">जगह काफ़ी नहीं है</translation>
-<translation id="7475192538862203634">अगर आपको यह बार-बार दिखाई दे रहा हो, तो इन <ph name="BEGIN_LINK" />सुझावों<ph name="END_LINK" /> को आज़माएं.</translation>
-<translation id="7475688122056506577">SD कार्ड नहीं मिला. हो सकता है कि आपकी कुछ फ़ाइलें उपलब्ध न हों.</translation>
-<translation id="7479104141328977413">टैब प्रबंधन</translation>
-<translation id="7481312909269577407">आगे जाएं</translation>
-<translation id="7482656565088326534">झलक टैब</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (<ph name="TIME_SINCE_UPDATE" /> अपडेट किया गया)</translation>
-<translation id="7494974237137038751">डेटा बचाया गया</translation>
-<translation id="7498271377022651285">कृपया प्रतीक्षा करें...</translation>
-<translation id="7514365320538308">डाउनलोड करें</translation>
-<translation id="751961395872307827">साइट से कनेक्ट नहीं किया जा सका</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">सुझाव नहीं मिल पा रहे हैं</translation>
-<translation id="7559975015014302720">लाइट मोड बंद है</translation>
-<translation id="7562080006725997899">ब्राउज़िंग डेटा साफ़ हो रहा है</translation>
-<translation id="756809126120519699">साफ़ किया गया Chrome डेटा</translation>
-<translation id="757524316907819857">साइटों को सुरक्षित सामग्री चलाने से रोकें</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> फ़ाइल डाउनलोड की गई}one{<ph name="FILES_DOWNLOADED_MANY" /> फ़ाइलें डाउनलोड की गईं}other{<ph name="FILES_DOWNLOADED_MANY" /> फ़ाइलें डाउनलोड की गईं}}</translation>
-<translation id="7588219262685291874">आपके डिवाइस की 'बैटरी सेवर' सुविधा चालू होने पर 'गहरे रंग वाली थीम' चालू करें</translation>
-<translation id="7589445247086920869">मौजूदा सर्च इंजन के लिए ब्लॉक करें</translation>
-<translation id="7593557518625677601">Android सेटिंग खोलें और Chrome सिंक शुरू करने के लिए Android सिस्टम सिंक फिर से चालू करें</translation>
-<translation id="7596558890252710462">ऑपरेटिंग सिस्टम</translation>
-<translation id="7605594153474022051">समन्वयन काम नहीं कर रहा है</translation>
-<translation id="7606077192958116810">लाइट मोड चालू है. इसे 'सेटिंग' में जाकर प्रबंधित करें.</translation>
-<translation id="7612619742409846846">आपने Google में इस ईमेल पते से साइन इन किया है</translation>
-<translation id="7619072057915878432">नेटवर्क विफलताओं के कारण <ph name="FILE_NAME" /> डाउनलोड विफल रहा.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />सहायता पाएं<ph name="END_LINK1" /> या <ph name="BEGIN_LINK2" />फिर से स्कैन करें<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome में आपका स्वागत है</translation>
-<translation id="7638584964844754484">गलत 'पासफ़्रेज़'</translation>
-<translation id="7641339528570811325">ब्राउज़िंग डेटा साफ़ करें…</translation>
-<translation id="7648422057306047504">Google क्रेडेंशियल से पासवर्ड सुरक्षित करें</translation>
-<translation id="7649070708921625228">सहायता</translation>
-<translation id="7658239707568436148">अभी नहीं</translation>
-<translation id="7665369617277396874">खाता जोड़ें</translation>
-<translation id="766587987807204883">लेख यहां दिखाई देते हैं जिन्हें आप ऑफ़लाइन होने पर भी पढ़ सकते हैं.</translation>
-<translation id="7682724950699840886">ये सलाह आज़माएं: पक्का करें कि आपके डिवाइस पर ज़रूरी जगह उपलब्ध है, फिर दोबारा निर्यात करके देखें.</translation>
-<translation id="7685301384041462804">वीआर इस्तेमाल करने से पहले पक्का कर लें कि आप इस साइट पर भरोसा करते हैं.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> में ईमेल बनाएं</translation>
-<translation id="7704317875155739195">खोजों और यूआरएल को अपने आप पूरा करें</translation>
-<translation id="7725024127233776428">आप जो पेज बुकमार्क करते हैं वे यहां दिखाई देंगे</translation>
-<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE" /> भाषा के पेज का हमेशा अनुवाद करें</translation>
-<translation id="7746457520633464754">खतरनाक ऐप्लिकेशन और साइटों का पता लगाने के लिए, Chrome ऐसे कुछ पेज का यूआरएल Google को भेजता है जिन पर आप जाते हैं. साथ ही, वह सिस्टम की सीमित जानकारी और पेज की कुछ सामग्री भी Google को भेजता है</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> से टेक्स्ट शेयर किया गया</translation>
-<translation id="7762668264895820836">SD कार्ड <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">पता जोड़ें</translation>
-<translation id="7772032839648071052">'पासफ़्रेज' की पुष्टि करें</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> को बंद करें</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> अन्य}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> अन्य}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 और <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> अन्य}}</translation>
-<translation id="7781829728241885113">बीता कल</translation>
-<translation id="7791543448312431591">जोड़ें</translation>
-<translation id="780301667611848630">नहीं, रहने दें</translation>
-<translation id="7810647596859435254">इसमें खोलें…</translation>
-<translation id="7821588508402923572">बचाया गया डेटा यहां दिखाई देगा</translation>
-<translation id="7837721118676387834">किसी खास साइट पर म्यूट किए गए वीडियो को अपने आप चलाने की अनुमति दें.</translation>
-<translation id="7846076177841592234">चुना गया हटाएं</translation>
-<translation id="784934925303690534">समय सीमा</translation>
-<translation id="7851858861565204677">अन्य डिवाइस</translation>
-<translation id="7875915731392087153">ईमेल बनाएं</translation>
-<translation id="7876243839304621966">सभी को निकालें</translation>
-<translation id="7882131421121961860">कोई इतिहास नहीं मिला</translation>
-<translation id="7882806643839505685">किसी खास साइट के लिए आवाज़ की अनुमति दें.</translation>
-<translation id="7886917304091689118">Chrome में चल रहा है</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{फ़ाइल डाउनलोड की जा रही है.}one{# फ़ाइलें डाउनलोड की जा रही हैं.}other{# फ़ाइलें डाउनलोड की जा रही हैं.}}</translation>
-<translation id="7929962904089429003">मेन्यू खोलें</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> पुराना है.</translation>
-<translation id="7947953824732555851">स्वीकार करें और साइन इन करें</translation>
-<translation id="7963646190083259054">विक्रेता:</translation>
-<translation id="7971136598759319605">एक दिन पहले सिंक किया गया</translation>
-<translation id="7975379999046275268">पेज की झलक देखें <ph name="BEGIN_NEW" />नया<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">ज़्यादा तेज़ी से ब्राउज़ करने और खोजने के लिए पेज पहले से लोड करें</translation>
-<translation id="79859296434321399">'बढ़ी हुई वास्तविकता' की सामग्री देखने के लिए, ARCore इंस्टॉल करें</translation>
-<translation id="7986741934819883144">कोई संपर्क चुनें</translation>
-<translation id="7987073022710626672">Chrome सेवा की शर्तें</translation>
-<translation id="7998918019931843664">बंद टैब फिर से खोलें</translation>
-<translation id="7999064672810608036">क्‍या आप वाकई कुकी सहित इस वेबसाइट का सभी स्‍थानीय डेटा साफ़ करना और इसकी सभी अनुमतियों को रीसेट करना चाहते हैं?</translation>
-<translation id="8004582292198964060">ब्राउज़र</translation>
-<translation id="8007176423574883786">इस डिवाइस के लिए बंद कर दिया गया है</translation>
-<translation id="8013372441983637696">इस डिवाइस से अपना Chrome डेटा भी हटाएं</translation>
-<translation id="8015452622527143194">पेज पर सब कुछ वापस डिफ़ॉल्ट आकार में लाएं</translation>
-<translation id="802154636333426148">डाउनलोड विफल रहा</translation>
-<translation id="8026334261755873520">ब्राउज़िंग डेटा साफ़ करें</translation>
-<translation id="8035133914807600019">नया फ़ोल्‍डर…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> दिन शेष</translation>
-<translation id="804335162455518893">SD कार्ड नहीं मिला</translation>
-<translation id="805047784848435650">आपके ब्राउज़िंग इतिहास के आधार पर</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> एमबी उपलब्ध</translation>
-<translation id="8058746566562539958">नए Chrome टैब में खोलें</translation>
-<translation id="8063895661287329888">बुकमार्क जोड़ने में विफल रहा.</translation>
-<translation id="806745655614357130">मेरा डेटा अलग रखें</translation>
-<translation id="8067883171444229417">वीडियो चलाएं</translation>
-<translation id="8068648041423924542">प्रमाणपत्र चुनने में असमर्थ.</translation>
-<translation id="8073388330009372546">इमेज 'नए टैब' में खोलें</translation>
-<translation id="8076492880354921740">टैब</translation>
-<translation id="8084114998886531721">सहेजा गया पासवर्ड</translation>
-<translation id="8087000398470557479">यह सामग्री <ph name="DOMAIN_NAME" /> की है जिसे Google के द्वारा वितरित किया गया है.</translation>
-<translation id="8103578431304235997">गुप्त टैब</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">अपने सभी डिवाइस पर अपने बुकमार्क पाने के लिए, 'सिंक करें' को चालू करें</translation>
-<translation id="8110087112193408731">'डिजिटल वेलबीइंग' में अपनी Chrome गतिविधि दिखाना चाहते हैं?</translation>
-<translation id="8116925261070264013">आवाज़ बंद की गई</translation>
-<translation id="813082847718468539">साइट जानकारी देखें</translation>
-<translation id="8131740175452115882">दुबारा पूछें</translation>
-<translation id="8156139159503939589">आप किन भाषाओं में पढ़ सकते हैं?</translation>
-<translation id="8168435359814927499">सामग्री</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> फ़ाइलें बची हैं</translation>
-<translation id="8190358571722158785">1 दिन शेष</translation>
-<translation id="8200772114523450471">फिर से शुरू करें</translation>
-<translation id="8209050860603202033">इमेज खोलें</translation>
-<translation id="8218622182176210845">अपना खाता प्रबंधित करें</translation>
-<translation id="8224471946457685718">वाई-फ़ाई चालू हाेने पर अपने लिए लेख डाउनलोड करें</translation>
-<translation id="8232956427053453090">डेटा रखें</translation>
-<translation id="8249310407154411074">सबसे ऊपर ले जाएं</translation>
-<translation id="8250920743982581267">दस्तावेज़</translation>
-<translation id="825412236959742607">यह पेज बहुत ज़्यादा मेमोरी का इस्तेमाल करता है, इसलिए Chrome ने कुछ सामग्री हटा दी है.</translation>
-<translation id="8260126382462817229">फिर से प्रवेश करके देखें</translation>
-<translation id="8261506727792406068">मिटाएं</translation>
-<translation id="8266862848225348053">डाउनलोड सेव करने की जगह</translation>
-<translation id="8274165955039650276">डाउनलोड देखें</translation>
-<translation id="8284326494547611709">कैप्शन</translation>
-<translation id="8300705686683892304">ऐप्लिकेशन प्रबंधित करता है</translation>
-<translation id="8310344678080805313">मानक टैब</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> और कई साइटें</translation>
-<translation id="8327155640814342956">बेहतरीन ब्राउज़िंग अनुभव के लिए, Chrome अपडेट करें</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" /> भाषा के पेज का अनुवाद नहीं किया जाएगा</translation>
-<translation id="8349013245300336738">इस्तेमाल किए गए डेटा की मात्रा के हिसाब से क्रम में लगाएं</translation>
-<translation id="8364299278605033898">लोकप्रिय वेबसाइटें देखें</translation>
-<translation id="8368027906805972958">अज्ञात या काम न करने वाला डिवाइस (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">किसी विशिष्ट साइट के लिए पृष्ठभूमि समन्वयन की अनुमति दें.</translation>
-<translation id="8378714024927312812">आपके संगठन की ओर से प्रबंधित</translation>
-<translation id="8380167699614421159">इस साइट में तंग करने वाले या गुमराह करने वाले विज्ञापन दिखाई देते हैं</translation>
-<translation id="8393700583063109961">संदेश भेजें</translation>
-<translation id="8413126021676339697">पूरा इतिहास दिखाएं</translation>
-<translation id="8427875596167638501">'झलक' टैब आधी स्क्रीन में खुला हुआ है</translation>
-<translation id="8428213095426709021">सेटिंग</translation>
-<translation id="8438566539970814960">खोजों और ब्राउज़िंग को बेहतर बनाएं</translation>
-<translation id="8441146129660941386">पीछे जाएं</translation>
-<translation id="8443209985646068659">Chrome अपडेट संभव नहीं</translation>
-<translation id="8445448999790540984">पासवर्ड निर्यात नहीं कर सकते</translation>
-<translation id="8447861592752582886">डिवाइस अनुमति निरस्त करें</translation>
-<translation id="8461694314515752532">सिंक किए गए डेटा को अपने खुद के सिंक लंबे पासवर्ड से सुरक्षित करें</translation>
-<translation id="8466613982764129868">पक्का करें कि <ph name="TARGET_DEVICE_NAME" /> को इंटरनेट से कनेक्ट किया गया है</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ऑफ़लाइन उपलब्ध है</translation>
-<translation id="8489271220582375723">इतिहास पेज खोलें</translation>
-<translation id="8493948351860045254">स्‍थान खाली करें</translation>
-<translation id="8497726226069778601">यहां देखने के लिए…अभी तक कुछ भी नहीं है</translation>
-<translation id="8503559462189395349">Chrome पासवर्ड</translation>
-<translation id="8503813439785031346">उपयोगकर्ता नाम</translation>
-<translation id="8514477925623180633">Chrome के ज़रिए संग्रहित पासवर्ड निर्यात करें</translation>
-<translation id="8514577642972634246">गुप्त मोड में प्रवेश करें</translation>
-<translation id="851751545965956758">साइटों को डिवाइस से कनेक्ट होने से रोकें</translation>
-<translation id="8523928698583292556">स्टोर किया गया पासवर्ड मिटाएं</translation>
-<translation id="854522910157234410">यह पेज खोलें</translation>
-<translation id="8558485628462305855">'बढ़ी हुई वास्तविकता' की सामग्री देखने के लिए, ARCore अपडेट करें</translation>
-<translation id="8559990750235505898">अन्य भाषाओं में पेज का अनुवाद करना ऑफ़र करें</translation>
-<translation id="8562452229998620586">सहेजे गए पासवर्ड यहां दिखाई देंगे.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> से</translation>
-<translation id="8571213806525832805">पिछले चार हफ़्ते</translation>
-<translation id="857943718398505171">अनुमति दी गई (सुझाया गया)</translation>
-<translation id="8583805026567836021">खाते का डेटा साफ़ हो रहा है</translation>
-<translation id="860043288473659153">कार्डधारक का नाम</translation>
-<translation id="8609465669617005112">ऊपर जाएं</translation>
-<translation id="8616006591992756292">आपके Google खाते में <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> पर अन्य प्रकार के ब्राउज़िंग इतिहास हो सकतेे हैं.</translation>
-<translation id="8617240290563765734">सुझाया गया वह URL खोलें जिसे डाउनलोड की गई सामग्री में बताया गया है?</translation>
-<translation id="8636825310635137004">अपने अन्य डिवाइस से अपने टैब पाने के लिए, सिंक करना चालू करें.</translation>
-<translation id="8641930654639604085">वयस्क साइटें ब्लॉक करने की कोशिश करें</translation>
-<translation id="8655129584991699539">आप 'Chrome सेटिंग' में डेटा हटा सकते हैं</translation>
-<translation id="8662811608048051533">आपको ज़्यादातर साइट से साइन आउट कर देता है.</translation>
-<translation id="8664979001105139458">इस नाम की फ़ाइल पहले से मौजूद है</translation>
-<translation id="8676374126336081632">इनपुट साफ़ करें</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{सिग्नल सशक्तता का स्तर: # बार}one{सिग्नल सशक्तता का स्तर: # बार}other{सिग्नल सशक्तता का स्तर: # बार}}</translation>
-<translation id="868929229000858085">अपने संपर्क खोजें</translation>
-<translation id="869891660844655955">समय समाप्ति तारीख</translation>
-<translation id="8719023831149562936">वर्तमान टैब को बीम नहीं किया जा सकता</translation>
-<translation id="8725066075913043281">फिर से कोशिश करें</translation>
-<translation id="8728487861892616501">इस ऐप्लिकेशन के इस्तेमाल का मतलब है कि आप Chrome की <ph name="BEGIN_LINK1" />सेवा की शर्तों<ph name="END_LINK1" /> और <ph name="BEGIN_LINK2" />निजता सूचना<ph name="END_LINK2" /> और <ph name="BEGIN_LINK3" />Family Link से प्रबंधित होने वाले Google खातों के लिए निजता सूचना<ph name="END_LINK3" /> से सहमत हैं.</translation>
-<translation id="8730621377337864115">हो गया</translation>
-<translation id="8748850008226585750">छिपी हुई सामग्री</translation>
-<translation id="8751914237388039244">इमेज चुनें</translation>
-<translation id="8788265440806329501">नेविगेशन का इतिहास बंद है</translation>
-<translation id="8788968922598763114">अभी बंद किया हुआ टैब खोलें</translation>
-<translation id="8801436777607969138">किसी खास साइट के लिए JavaScript पर रोक लगाएं.</translation>
-<translation id="8812260976093120287">कुछ वेबसाइटों पर, आप ऊपर समर्थित भुगतान ऐप्लिकेशन के ज़रिए अपने डिवाइस पर भुगतान कर सकते हैं.</translation>
-<translation id="8816026460808729765">साइटों को सेंसर ऐक्सेस करने से रोकें</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chrome में खुलेगा. जारी रखकर, आप Chrome की <ph name="BEGIN_LINK1" />सेवा की शर्तों<ph name="END_LINK1" /> और <ph name="BEGIN_LINK2" />निजता सूचना<ph name="END_LINK2" /> और <ph name="BEGIN_LINK3" />Family Link से प्रबंधित होने वाले Google खातों के लिए निजता सूचना<ph name="END_LINK3" /> से सहमत होते हैं.</translation>
-<translation id="8820817407110198400">बुकमार्क</translation>
-<translation id="8833831881926404480">एक साइट आपकी स्क्रीन शेयर कर रही है</translation>
-<translation id="883806473910249246">सामग्री डाउनलोड करते समय कोई गड़बड़ी हुई.</translation>
-<translation id="8840953339110955557">यह पेज ऑनलाइन वर्शन से अलग हो सकता है.</translation>
-<translation id="8847988622838149491">यूएसबी</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, टैब</translation>
-<translation id="885701979325669005">मेमोरी</translation>
-<translation id="889338405075704026">Chrome की सेटिंग में जाएं</translation>
-<translation id="8901170036886848654">कोई बुकमार्क नहीं मिला</translation>
-<translation id="8909135823018751308">शेयर करें…</translation>
-<translation id="8912362522468806198">Google खाता</translation>
-<translation id="8920114477895755567">अभिभावकों के विवरण की प्रतीक्षा कर रहे हैं.</translation>
+<translation id="1188239144602654184">ऑगमेंटेड रिएलिटी (AR) सत्र शुरू करें</translation>
+<translation id="473775607612524610">अपडेट करें</translation>
+<translation id="3133489217401741157">Brave के लिए <ph name="MODULE"/> इंस्टॉल किया जा रहा है…</translation>
+<translation id="1791662854739702043">इंस्‍टॉल किया गया</translation>
+<translation id="5131234170665854056">Brave के लिए <ph name="MODULE"/> इंस्टॉल नहीं किया जा सका</translation>
+<translation id="2567385386134582609">इमेज</translation>
+<translation id="6395288395575013217">लिंक</translation>
+<translation id="7352939065658542140">वीडियो</translation>
+<translation id="4116038641877404294">पेजों को ऑफ़लाइन इस्तेमाल करने के लिए उन्हें डाउनलोड करें</translation>
 <translation id="8922289737868596582">पेज का ऑफ़लाइन उपयोग करने के लिए उन्हें ज़्यादा विकल्प बटन से डाउनलोड करें</translation>
-<translation id="8937772741022875483">'डिजिटल वेलबीइंग' से अपनी Chrome गतिविधि हटाना चाहते हैं?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">दूसरी विंडो में खोलें</translation>
-<translation id="8951232171465285730">Chrome ने आपके <ph name="MEGABYTES" /> एमबी की बचत की</translation>
-<translation id="8958424370300090006">किसी खास साइट के लिए कुकी ब्लॉक करें.</translation>
-<translation id="8959122750345127698">मार्गदर्शक तक नहीं पहुंचा जा सकता: <ph name="URL" /></translation>
-<translation id="8965591936373831584">डाउनलोड बाकी है</translation>
-<translation id="8970887620466824814">कुछ गड़बड़ी हुई.</translation>
-<translation id="8972098258593396643">डिफ़ॉल्ट फ़ोल्डर में डाउनलोड करें?</translation>
-<translation id="8986494364107987395">इस्तेमाल के आंकड़े और खराबी रिपोर्ट अपने आप Google को भेजें</translation>
-<translation id="8993760627012879038">गुप्त मोड में नया टैब खोलें</translation>
-<translation id="8998729206196772491">आप <ph name="MANAGED_DOMAIN" /> से प्रबंधित खाते में साइन इन कर रहे हैं और उसके एडमिन को अपने Chrome डेटा पर नियंत्रण दे रहे हैं. आपका डेटा इस खाते से स्थायी रूप से जुड़ जाएगा. Chrome से साइन आउट करने से आपका डेटा इस डिवाइस से मिट जाएगा, लेकिन वह आपके Google खाते में बना रहेगा.</translation>
-<translation id="9019902583201351841">आपके अभिभावकों द्वारा प्रबंधित</translation>
-<translation id="9028914725102941583">सभी डिवाइस पर शेयर करने के लिए सिंक की सुविधा चालू करें</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> को वीआर में जाने की अनुमति देना चाहते हैं?</translation>
-<translation id="9040142327097499898">सूचनाओं की अनुमति है. इस डिवाइस के लिए स्थान की जानकारी बंद है.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# वीडियो}one{# वीडियो}other{# वीडियो}}</translation>
-<translation id="9050666287014529139">पासफ़्रेज़ (लंबा पासवर्ड)</translation>
-<translation id="9063523880881406963">अनुरोध डेस्कटॉप साइट बंद करें</translation>
-<translation id="9065203028668620118">बदलाव करें</translation>
-<translation id="9070377983101773829">बोलकर खोज चालू करें</translation>
-<translation id="9074336505530349563">Google की ओर से सुझाई गई मनमुताबिक सामग्री पाने के लिए, साइन इन करें और 'सिंक करें' को चालू करें</translation>
-<translation id="9086455579313502267">नेटवर्क की एक्सेस नहीं की जा सकती है.</translation>
-<translation id="9100505651305367705">अगर सुविधा उपलब्ध है, तो लेख को सरल बनाए गए व्यू में दिखाना ऑफ़र करें</translation>
-<translation id="9100610230175265781">पासफ़्रेज़ ज़रूरी है</translation>
-<translation id="9102803872260866941">झलक टैब अपने पूरे आकार में खुला हुआ है</translation>
+<translation id="5958275228015807058">डाउनलोड में जाकर अपनी फ़ाइलें और पेज पाएं</translation>
+<translation id="5620928963363755975">ज़्यादा विकल्प बटन से डाउनलोड में जाकर अपनी फ़ाइलें और पेज पाएं</translation>
+<translation id="3341058695485821946">देखें कि आपने कितना डेटा बचाया है</translation>
+<translation id="3157842584138209013">ज़्यादा विकल्प बटन से देखें कि आपने कितना डेटा बचाया है</translation>
+<translation id="8218622182176210845">अपना खाता प्रबंधित करें</translation>
+<translation id="8090895580117672212">अपना Brave Software खाता प्रबंधित करने के लिए, "खाता प्रबंधित करें" बटन पर टैप करें</translation>
+<translation id="8856898588039823173">Brave Software की ओर से 'लाइट पेज' दिया गया. 'मूल पेज' लोड करने के लिए टैप करें.</translation>
+<translation id="8134317863207426198">लाइट पेज Brave Software ने मुहैया कराया है. मूल पेज लोड करने के लिए 'मूल पेज लोड करें' बटन पर टैप करें.</translation>
+<translation id="4961107849584082341">इस पेज का अनुवाद किसी भी भाषा में करें</translation>
+<translation id="569536719314091526">'ज़्यादा विकल्प' बटन से इस पेज का अनुवाद किसी भी भाषा में करें</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> के ज़रिए खोजें</translation>
+<translation id="1792959175193046959">डिफ़ॉल्ट डाउनलोड स्थान किसी भी समय बदलें</translation>
+<translation id="6942665639005891494">सेटिंग मेन्यू विकल्प का इस्तेमाल करके डिफ़ॉल्ट डाउनलोड स्थान किसी भी समय बदलें</translation>
+<translation id="6850409657436465440">आपका डाउनलोड अब भी जारी है</translation>
+<translation id="5817715962196959877">Brave अब ज़्यादा तेज़ी से फ़ाइलें डाउनलोड करता है</translation>
+<translation id="3976396876660209797">इस शॉर्टकट को निकालें और इसे फिर से बनाएं</translation>
+<translation id="6766622839693428701">बंद करने के लिए नीचे स्वाइप करें.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> पर भेजा जा रहा है...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> से भेजा गया</translation>
+<translation id="5357811892247919462">टैब मिला</translation>
 <translation id="9104217018994036254">टैब शेयर करने के लिए चुने जाने वाले डिवाइस की सूची.</translation>
-<translation id="9133397713400217035">ऑफ़लाइन सामग्री देखें</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">मूल दिखाएं</translation>
-<translation id="9139068048179869749">साइटों को सूचनाएं भेजने से पहले अनुमति लेना ज़रूरी बनाएं (सुझाया गया)</translation>
-<translation id="9139318394846604261">शॉपिंग</translation>
-<translation id="9155898266292537608">आप किसी शब्द पर बस एक टैप करके भी खोज सकते हैं</translation>
-<translation id="9169507124922466868">नेविगेशन का इतिहास आधी स्क्रीन में खुला हुआ है</translation>
-<translation id="9204836675896933765">1 फ़ाइल बची है</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">टैब शेयर करने के लिए चुने जाने वाले डिवाइस की सूची आधी खुली हुई है.</translation>
+<translation id="2904414404539560095">टैब शेयर करने वाले डिवाइस की सूची पूरी खुली हुई है.</translation>
+<translation id="4135200667068010335">टैब शेयर करने के लिए चुने गए डिवाइस की सूची बंद है.</translation>
+<translation id="5292796745632149097">इस पर भेजें</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/>दिन पहले सिंक किया गया</translation>
+<translation id="7971136598759319605">एक दिन पहले सिंक किया गया</translation>
+<translation id="1521774566618522728">आज सक्रिय है</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> के साथ शेयर किया जा रहा है</translation>
+<translation id="9028914725102941583">सभी डिवाइस पर शेयर करने के लिए सिंक की सुविधा चालू करें</translation>
+<translation id="6162454065885854378">अपने फ़ोन से किसी दूसरे डिवाइस पर कुछ शेयर करने के लिए, दोनों डिवाइस पर Brave की सेटिंग में जाकर सिंक की सुविधा चालू करें</translation>
+<translation id="6084271560289605378">Brave की सेटिंग में जाएं</translation>
+<translation id="2318045970523081853">कॉल करने के लिए टैप करें</translation>
 <translation id="9209888181064652401">कॉल नहीं कर पा रहे</translation>
-<translation id="9219103736887031265">इमेज</translation>
-<translation id="926205370408745186">'डिजिटल वेलबीइंग' से अपनी Chrome गतिविधि हटाएं</translation>
-<translation id="932327136139879170">होम बटन</translation>
-<translation id="938850635132480979">गड़बड़ी: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">अपना माइक्रोफ़ोन एक्सेस करें</translation>
-<translation id="95817756606698420">चीन में खोज करने के लिए Chrome, <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> का इस्तेमाल कर सकता है. आप इसे <ph name="BEGIN_LINK" />सेटिंग<ph name="END_LINK" /> में बदल सकते हैं.</translation>
-<translation id="965817943346481315">अगर साइट तंग करने वाले या गुमराह करने वाले विज्ञापन दिखाई देते हैं, तो उन्हें ब्लॉक करें (सुझाव)</translation>
-<translation id="968900484120156207">आप जिन पेजों पर जाएंगे वे यहां दिखाई देंगे</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> मिनट शेष</translation>
-<translation id="974555521953189084">सिंक शुरू करने के लिए अपना 'पासफ़्रेज़' डालें</translation>
-<translation id="981121421437150478">ऑफ़लाइन</translation>
-<translation id="982182592107339124">इससे इन सभी साइटों का डेटा साफ़ हो जाएगा:</translation>
-<translation id="983192555821071799">सभी टैब बंद करें</translation>
-<translation id="987264212798334818">सामान्य</translation>
+<translation id="2860954141821109167">पक्का करें कि इस डिवाइस पर फ़ोन ऐप्लिकेशन चालू है</translation>
+<translation id="2067805253194386918">टेक्स्ट</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> शेयर नहीं किया जा सकता</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> शेयर नहीं किया जा सका</translation>
+<translation id="8287068819750208230">पक्का करें कि <ph name="TARGET_DEVICE_NAME"/> पर Brave में सिंक करने की सुविधा चालू है</translation>
+<translation id="3016635187733453316">पक्का करें कि इस डिवाइस को इंटरनेट से कनेक्ट किया गया है</translation>
+<translation id="8466613982764129868">पक्का करें कि <ph name="TARGET_DEVICE_NAME"/> को इंटरनेट से कनेक्ट किया गया है</translation>
+<translation id="6539092367496845964">कोई गड़बड़ी हुई. बाद में कोशिश करें.</translation>
+<translation id="3389286852084373014">टेक्स्ट बहुत बड़ा है</translation>
+<translation id="2100314319871056947">टेक्स्ट को छोटे-छोटे हिस्सों में शेयर करने की कोशिश करें</translation>
+<translation id="2987620471460279764">दूसरी साइटों से शेयर किया गया टेक्स्ट</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> से टेक्स्ट शेयर किया गया</translation>
+<translation id="5193988420012215838">आपके क्लिपबोर्ड पर कॉपी की गई</translation>
+<translation id="4696983787092045100">अपने डिवाइस पर मैसेज भेजें</translation>
+<translation id="1260236875608242557">खोजें और एक्सप्लोर करें</translation>
+<translation id="6369229450655021117">यहां से, आप वेब खोज सकते हैं, दोस्तों के साथ शेयर कर सकते हैं और खुले हुए पेज देख सकते हैं</translation>
+<translation id="723171743924126238">फ़ोटो चुनें</translation>
+<translation id="8751914237388039244">इमेज चुनें</translation>
+<translation id="1989112275319619282">ब्राउज़ करें</translation>
+<translation id="7055152154916055070">रीडायरेक्ट ब्लॉक किया गया:</translation>
+<translation id="5524843473235508879">रीडायरेक्ट ब्लॉक किया गया.</translation>
+<translation id="6573096386450695060">हमेशा मंज़ूरी दें</translation>
+<translation id="5805364706385912897">यह पेज बहुत ज़्यादा मेमोरी का इस्तेमाल करता है, इसलिए Brave ने इसे रोक दिया है.</translation>
+<translation id="5138664332909611586">यह पेज बहुत ज़्यादा मेमोरी का इस्तेमाल करता है, इसलिए Brave ने कुछ सामग्री हटा दी है.</translation>
+<translation id="9137013805542155359">मूल दिखाएं</translation>
+<translation id="6361779936989026201">Brave में Brave Software Assistant</translation>
+<translation id="7291387454912369099">Assistant के ज़रिए अपने आप भरें</translation>
+<translation id="4565206163201411670">'डिजिटल वेलबीइंग' में अपनी Brave गतिविधि दिखाना चाहते हैं?</translation>
+<translation id="9055113864158719823">आप Brave में जिन साइटों पर जाते हैं उन्हें देख सकते हैं और उनके लिए टाइमर लगा सकते हैं.\n\nBrave Software उन साइटों की जानकारी लेता है जिनके लिए आप टाइमर लगाते हैं. साथ ही, यह जानकारी भी ली जाती है कि आप उन साइटों पर कितनी देर तक रहे. इस जानकारी का इस्तेमाल 'डिजिटल वेलबीइंग' को बेहतर बनाने के लिए किया जाता है.</translation>
+<translation id="4596514158372210596">'डिजिटल वेलबीइंग' से अपनी Brave गतिविधि हटाएं</translation>
+<translation id="1174893863889683998">'डिजिटल वेलबीइंग' से अपनी Brave गतिविधि हटाना चाहते हैं?</translation>
+<translation id="708829030563435351">आप Brave में जिन साइटों पर जाते हैं, वे नहीं दिखाई देंगी. साइट के सभी टाइमर मिटा दिए जाएंगे.</translation>
+<translation id="2056878612599315956">साइट रोकी गई</translation>
+<translation id="671481426037969117"><ph name="FQDN"/> इस्तेमाल करने का समय खत्म हो गया. यह कल फिर से शुरू होगा.</translation>
+<translation id="7479104141328977413">टैब प्रबंधन</translation>
+<translation id="3524138585025253783">डेवलपर यूज़र इंटरफ़ेस (यूआई)</translation>
+<translation id="6036057147555329831">कुछ और ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> को वीआर में जाने की अनुमति देना चाहते हैं?</translation>
+<translation id="7685301384041462804">वीआर इस्तेमाल करने से पहले पक्का कर लें कि आप इस साइट पर भरोसा करते हैं.</translation>
+<translation id="5033865233969348410">जब आप वीआर इस्तेमाल करते हैं, तो साइट ये बातें जान सकती है:
+  -  आपकी शारीरिक बनावट, जैसे कि लंबाई
+
+वीआर इस्तेमाल करने से पहले पक्का कर लें कि आप इस साइट पर भरोसा करते हैं.</translation>
+<translation id="5534334044554683961">जब आप वीआर इस्तेमाल करते हैं, तो साइट ये बातें जान सकती है:
+  -  आपकी शारीरिक बनावट, जैसे कि लंबाई
+ -  आपके कमरे का लेआउट
+
+वीआर इस्तेमाल करने से पहले पक्का कर लें कि आप इस साइट पर भरोसा करते हैं.</translation>
+<translation id="4169535189173047238">अनुमति न दें</translation>
+<translation id="2170088579611075216">अनुमति दें और VR चालू करें</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_hr.xtb
+++ b/android/java/strings/translations/android_chrome_strings_hr.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="hr">
-<translation id="1006017844123154345">Otvori online</translation>
-<translation id="1028699632127661925">Šalje se uređaju <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Dodavanje stavke <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">S web-lokacija</translation>
-<translation id="1049743911850919806">Anonimno</translation>
-<translation id="10614374240317010">Zaporke se nikad ne spremaju</translation>
-<translation id="1067922213147265141">Ostale Googleove usluge</translation>
-<translation id="1068672505746868501">Nikad ne prevodi <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Ako promijenite datotečni nastavak, datoteka bi se mogla otvoriti u nekoj drugoj aplikaciji i mogla bi izložiti vaš uređaj opasnosti.</translation>
-<translation id="1100066534610197918">Otvori novu karticu u grupi</translation>
-<translation id="1105960400813249514">Snimka zaslona</translation>
-<translation id="1111673857033749125">Ovdje će se prikazivati oznake koje ste spremili na drugim uređajima.</translation>
-<translation id="1113597929977215864">Prikaži pojednostavljeni prikaz</translation>
-<translation id="1121094540300013208">Izvješća o upotrebi i rušenju programa</translation>
-<translation id="1124772482545689468">Korisnik</translation>
-<translation id="1129510026454351943">Pojedinosti: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 preuzimanje na čekanju.}one{# preuzimanje na čekanju.}few{# preuzimanja na čekanju.}other{# preuzimanja na čekanju.}}</translation>
-<translation id="1145536944570833626">Brisanje postojećih podataka.</translation>
-<translation id="1146678959555564648">Pokreni VR</translation>
-<translation id="116280672541001035">Iskorišteno</translation>
-<translation id="1171770572613082465">Dodirom na gumb "Najpopularnije web-lokacije" pogledajte popularne web-lokacije</translation>
-<translation id="1173894706177603556">Preimenuj</translation>
-<translation id="1178581264944972037">Pauziraj</translation>
-<translation id="1181037720776840403">Ukloni</translation>
-<translation id="1188239144602654184">Pokreni AR</translation>
-<translation id="1197267115302279827">Premjesti oznake</translation>
-<translation id="119944043368869598">Očisti sve</translation>
-<translation id="1201402288615127009">Dalje</translation>
-<translation id="1204037785786432551">Preuzmi vezu</translation>
-<translation id="1206892813135768548">Kopiraj tekst veze</translation>
-<translation id="1208340532756947324">Da biste sinkronizirali i prilagodili više uređaja, uključite sinkronizaciju</translation>
-<translation id="1209206284964581585">Sakrij za sad</translation>
-<translation id="1227058898775614466">Povijest navigacije</translation>
-<translation id="1231733316453485619">Želite li uključiti sinkronizaciju?</translation>
-<translation id="123724288017357924">Ponovno učitavanje trenutačne stranice uz zanemarivanje sadržaja iz predmemorije</translation>
-<translation id="124116460088058876">Više jezika</translation>
-<translation id="124678866338384709">Zatvaranje trenutačne kartice</translation>
-<translation id="1258753120186372309">Googleov doodle logotip: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Pretraživanje i istraživanje</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Nije moguće podijeliti <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Zaustavi</translation>
-<translation id="1283039547216852943">Dodirnite za proširivanje</translation>
-<translation id="1285320974508926690">Nikad nemoj prevoditi ovu web-lokaciju</translation>
-<translation id="1291207594882862231">Brisanje povijesti, kolačića, podataka web-lokacija, predmemorije...</translation>
-<translation id="129382876167171263">Ovdje se prikazuju datoteke koje su spremile web-lokacije</translation>
-<translation id="129553762522093515">Nedavno zatvoreno</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – poslano s uređaja <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Grupiraj kartice</translation>
-<translation id="1327257854815634930">Otvorena je povijest navigacije</translation>
-<translation id="1331212799747679585">Chrome se ne može ažurirati. Više opcija</translation>
-<translation id="1332501820983677155">Prečaci za značajke Google Chromea</translation>
-<translation id="1360432990279830238">Odjaviti se i isključiti sinkronizaciju?</translation>
-<translation id="1369915414381695676">Dodana je web-lokacija <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Nema dovoljno memorije za preuzimanje odabranog sadržaja.</translation>
-<translation id="1376578503827013741">Izračunavanje…</translation>
-<translation id="1383876407941801731">Traži</translation>
-<translation id="1384959399684842514">Preuzimanje je pauzirano</translation>
-<translation id="1386674309198842382">Aktivan prije <ph name="LAST_UPDATED" /> dana</translation>
-<translation id="1397811292916898096">Pretraživanje pomoću usluge <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Ugrađeno u <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"Nemoj pratiti"</translation>
-<translation id="1407135791313364759">Otvori sve</translation>
-<translation id="1409426117486808224">Pojednostavljeni prikaz za otvorene kartice</translation>
-<translation id="1409879593029778104">Preuzimanje datoteke <ph name="FILE_NAME" /> nije uspjelo jer datoteka već postoji.</translation>
-<translation id="1414981605391750300">Kontaktiranje Googlea. To bi moglo potrajati…</translation>
-<translation id="1416550906796893042">Verzija aplikacije</translation>
-<translation id="1430915738399379752">Ispis</translation>
-<translation id="1446450296470737166">Omogući potpuni nadzor za MIDI</translation>
-<translation id="1450753235335490080">Nije moguće dijeliti <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Isključeno u postavkama Androida</translation>
-<translation id="1477626028522505441">Preuzimanje datoteke <ph name="FILE_NAME" /> nije uspjelo zbog poteškoća s poslužiteljem.</translation>
-<translation id="1506061864768559482">Tražilica</translation>
-<translation id="1513352483775369820">Oznake i Google povijest</translation>
-<translation id="1513858653616922153">Izbriši zaporku</translation>
-<translation id="1516229014686355813">Značajka Dodirnite za pretraživanje Google pretraživanju šalje odabranu riječ i trenutačnu stranicu kao kontekst. Možete je isključiti u <ph name="BEGIN_LINK" />Postavkama<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktivan danas</translation>
-<translation id="1544826120773021464">Da biste upravljali svojim Google računom, dodirnite gumb "Upravljanje računom"</translation>
-<translation id="1549000191223877751">Premjesti u drugi prozor</translation>
-<translation id="1553358976309200471">Ažuriraj Chrome</translation>
-<translation id="1569387923882100876">Povezani uređaj</translation>
-<translation id="1571304935088121812">Kopiraj korisničko ime</translation>
-<translation id="1612196535745283361">Chrome treba pristup lokaciji kako bi skenirao uređaje. Pristup lokaciji <ph name="BEGIN_LINK" />isključen je za ovaj uređaj<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Fotoaparat</translation>
-<translation id="1623104350909869708">Spriječi da ova stranica stvori dodatne dijaloške okvire</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Uklanjanje 1 odabrane stavke}one{Uklanjanje # odabrane stavke}few{Uklanjanje # odabranih stavki}other{Uklanjanje # odabranih stavki}}</translation>
-<translation id="164269334534774161">Prikazuje se offline kopija stranice od <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Povijest</translation>
-<translation id="1647391597548383849">Pristup fotoaparatu</translation>
-<translation id="1660204651932907780">Web-lokacije mogu reproducirati zvuk (preporučeno)</translation>
-<translation id="1670399744444387456">Osnovne</translation>
-<translation id="1671236975893690980">Preuzimanje na čekanju…</translation>
-<translation id="1672586136351118594">Ne prikazuj ponovo</translation>
-<translation id="1692118695553449118">Sinkronizacija je uključena</translation>
-<translation id="169515064810179024">Blokiranje pristupa senzorima kretanja za web-lokacije</translation>
-<translation id="1717218214683051432">Senzori kretanja</translation>
-<translation id="1718835860248848330">Zadnji sat</translation>
-<translation id="1736419249208073774">Istražite</translation>
-<translation id="1743802530341753419">Web-lokacije moraju tražiti dopuštenje za povezivanje s uređajem (preporučeno)</translation>
-<translation id="1749561566933687563">Sinkronizirajte oznake</translation>
-<translation id="17513872634828108">Otvorene kartice</translation>
-<translation id="1779089405699405702">Dekodiranje slika</translation>
-<translation id="1782483593938241562">Datum završetka: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Instalirano</translation>
-<translation id="1792959175193046959">Zadanu lokaciju preuzimanja možete promijeniti kad god želite</translation>
-<translation id="1807246157184219062">Svijetlo</translation>
-<translation id="1810845389119482123">Početno postavljanje sinkronizacije nije dovršeno</translation>
-<translation id="1821253160463689938">Upotrebljava kolačiće za pamćenje vaših postavki, čak i ako ne posjetite te stranice</translation>
-<translation id="1829244130665387512">Traži na stranici</translation>
-<translation id="1853692000353488670">Nova anonimna kartica</translation>
-<translation id="1856325424225101786">Želite li poništiti Jednostavni način?</translation>
-<translation id="1868024384445905608">Chrome sada brže preuzima datoteke</translation>
-<translation id="1883903952484604915">Moje datoteke</translation>
-<translation id="1887786770086287077">Pristup lokaciji isključen je za ovaj uređaj. Uključite ga u <ph name="BEGIN_LINK" />postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Aplikacija <ph name="APP_NAME" /> otvorit će se u Chromeu. Nastavljanjem prihvaćate Chromeove <ph name="BEGIN_LINK1" />Uvjete pružanja usluge<ph name="END_LINK1" /> i <ph name="BEGIN_LINK2" />Obavijest o privatnosti<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Oglasi</translation>
-<translation id="1919950603503897840">Odabir kontakata</translation>
-<translation id="1922076542920281912">Da bi Chrome mogao pristupiti vašoj lokaciji, uključite lokaciju i u <ph name="BEGIN_LINK" />postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Ažuriranja</translation>
-<translation id="19288952978244135">Ponovo otvorite Chrome.</translation>
-<translation id="1933845786846280168">Odabrana kartica</translation>
-<translation id="194341124344773587">Uključite dopuštenje za Chrome u <ph name="BEGIN_LINK" />Postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Spremanje zaporki</translation>
-<translation id="1952172573699511566">Web-lokacije prikazivat će tekst na željenom jeziku kad god je to moguće.</translation>
-<translation id="1960290143419248813">Chromeova ažuriranja više nisu podržana za ovu verziju Androida</translation>
-<translation id="1966710179511230534">Ažurirajte pojedinosti prijave.</translation>
-<translation id="1974060860693918893">Napredno</translation>
-<translation id="1984705450038014246">Sinkroniziraj podatke iz Chromea</translation>
-<translation id="1984937141057606926">Dopušteno, osim treće strane</translation>
-<translation id="1986685561493779662">Naziv već postoji</translation>
-<translation id="1987739130650180037">Gumb <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Pregledaj</translation>
-<translation id="1993768208584545658">Web-lokacija <ph name="SITE" /> želi se upariti</translation>
-<translation id="1994173015038366702">URL web-lokacije</translation>
-<translation id="2000419248597011803">Zadanoj tražilici šalje neke kolačiće i pretraživanja iz adresne trake i okvira za pretraživanje</translation>
-<translation id="2002537628803770967">Kreditne kartice i adrese s Google Paya</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# datoteka}one{# datoteka}few{# datoteke}other{# datoteka}}</translation>
-<translation id="2017836877785168846">Briše povijest i automatsko dovršavanje u adresnoj traci.</translation>
-<translation id="2021896219286479412">Kontrole web-lokacije na cijelom zaslonu</translation>
-<translation id="2038563949887743358">Uključivanje zahtjeva za prikaz klasične web-lokacije</translation>
-<translation id="2041019821020695769">Da bi vam Chrome mogao slati obavijesti, uključite obavijesti i u <ph name="BEGIN_LINK" />postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> ima podatke i u Chromeu</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Web-lokacija pauzirana</translation>
-<translation id="2063713494490388661">Dodirnite za pretraživanje</translation>
-<translation id="2067805253194386918">SMS</translation>
-<translation id="2079545284768500474">Poništi</translation>
-<translation id="2082238445998314030"><ph name="RESULT_NUMBER" /> od <ph name="TOTAL_RESULTS" /> rezultata</translation>
-<translation id="2091887806945687916">Zvuk</translation>
-<translation id="2096012225669085171">Sinkronizacija i prilagodba na svim uređajima</translation>
-<translation id="2100273922101894616">Automatska prijava</translation>
-<translation id="2100314319871056947">Pokušajte podijeliti tekst u manjim dijelovima</translation>
-<translation id="2107397443965016585">Web-lokacije moraju tražiti dopuštenje za reprodukciju zaštićenog sadržaja (preporučeno)</translation>
-<translation id="2111511281910874386">Idi na stranicu</translation>
-<translation id="2122601567107267586">Otvaranje aplikacije nije uspjelo</translation>
-<translation id="2126426811489709554">Omogućuje Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> spremljeno</translation>
-<translation id="213279576345780926">Zatvorena je kartica <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Dodaj na početni zaslon</translation>
-<translation id="2146738493024040262">Otvori instant aplikaciju</translation>
-<translation id="2148716181193084225">Danas</translation>
-<translation id="2154484045852737596">Uredite karticu</translation>
-<translation id="2154710561487035718">Kopiraj URL</translation>
-<translation id="2156074688469523661">Preostale web-lokacije (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Da biste dijelili sadržaj s telefona s nekim drugim uređajem, uključite sinkronizaciju u Chromeovim postavkama na oba uređaja</translation>
-<translation id="2170088579611075216">Dopusti i unesi VR</translation>
-<translation id="218608176142494674">Dijeljenje</translation>
-<translation id="2227444325776770048">Nastavite kao <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sinkronizacija i Googleove usluge</translation>
-<translation id="2259659629660284697">Izvoz zaporki...</translation>
-<translation id="2268044343513325586">Pročišćavanje</translation>
-<translation id="2286841657746966508">Adresa za naplatu</translation>
-<translation id="2289270750774289114">Prikaži upit kad web-lokacija želi tražiti Bluetooth uređaje u blizini (preporučeno)</translation>
-<translation id="230115972905494466">Nije pronađen nijedan kompatibilni uređaj</translation>
-<translation id="2315043854645842844">Operativni sustav ne podržava odabir klijentskog certifikata.</translation>
-<translation id="2318045970523081853">Dodirnite da biste uputili poziv</translation>
-<translation id="2321086116217818302">Priprema zaporki…</translation>
-<translation id="2321958826496381788">Pomičite klizač dok ne budete mogli čitati ovaj tekst bez poteškoća. Tekst bi trebao biti barem ovoliko velik nakon što dvaput dodirnete odlomak.</translation>
-<translation id="2323763861024343754">Pohrana web-lokacije</translation>
-<translation id="2328985652426384049">Prijava nije moguća</translation>
-<translation id="2330129964253841015">Upozori ako su zaporke ugrožene</translation>
-<translation id="2349710944427398404">Ukupna količina podataka koju Chrome upotrebljava, uključujući račune, oznake i spremljene postavke.</translation>
-<translation id="2353636109065292463">Provjera vaše internetske veze</translation>
-<translation id="2359808026110333948">Nastavi</translation>
-<translation id="2369533728426058518">otvorene kartice</translation>
-<translation id="2387895666653383613">Skaliranje teksta</translation>
-<translation id="2394602618534698961">Datoteke koje preuzmete prikazat će se ovdje</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Kad se prijavite na svoj Google račun, ta je značajka uključena</translation>
-<translation id="2410754283952462441">Odabir računa</translation>
-<translation id="2414886740292270097">Tamno</translation>
-<translation id="2416359993254398973">Chrome treba dopuštenje za pristup fotoaparatu za ovu web-lokaciju.</translation>
-<translation id="2426805022920575512">Odaberi drugi račun</translation>
-<translation id="2433507940547922241">Prikaz</translation>
-<translation id="2434158240863470628">Preuzimanje je dovršeno: <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Pristup lokaciji</translation>
-<translation id="2450083983707403292">Želite li ponovo pokrenuti preuzimanje datoteke <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Obavijesti</translation>
-<translation id="2490684707762498678">Upravlja: <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google asistent u Chromeu</translation>
-<translation id="2496180316473517155">Povijest pregledavanja</translation>
-<translation id="2497852260688568942">Administrator je onemogućio sinkronizaciju</translation>
-<translation id="2498359688066513246">Pomoć i povratne informacije</translation>
-<translation id="2501278716633472235">Natrag</translation>
-<translation id="2513403576141822879">Više postavki koje se odnose na privatnost, sigurnost i prikupljanje podataka dostupno je u odjeljku <ph name="BEGIN_LINK" />Sinkronizacija i prilagodba<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">U Jednostavnom načinu Chrome učitava stranice brže i smanjuje podatkovni promet do 60 posto. Chrome šalje vaš web-promet Googleu radi optimizacije stranica koje posjećujete. <ph name="BEGIN_LINK" />Saznajte više<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Šalje Googleu URL-ove stranica koje posjećujete</translation>
-<translation id="2532336938189706096">Web-prikaz</translation>
-<translation id="2534155362429831547">Broj izbrisanih stavki: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Prikaz izvanmrežne kopije stranice</translation>
-<translation id="2546283357679194313">Kolačići i podaci o web-lokacijama</translation>
-<translation id="2567385386134582609">SLIKA</translation>
-<translation id="257088987046510401">Teme</translation>
-<translation id="2570922361219980984">Pristup lokaciji isključen je i za ovaj uređaj. Uključite ga u <ph name="BEGIN_LINK" />postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Prošireno – kliknite za sažimanje.</translation>
-<translation id="2581165646603367611">Time će se izbrisati kolačići, predmemorija i ostali podaci o web-lokacijama koje Chrome ne smatra važnima.</translation>
-<translation id="2586657967955657006">Međuspremnik</translation>
-<translation id="2587052924345400782">Dostupna je novija verzija</translation>
-<translation id="2593272815202181319">Ravnomjerno raspoređeno</translation>
-<translation id="2612676031748830579">Broj kartice</translation>
-<translation id="2621115761605608342">Dopuštanje JavaScripta za određenu web-lokaciju.</translation>
-<translation id="2625189173221582860">Zaporka je kopirana</translation>
-<translation id="2631006050119455616">Spremljeno</translation>
-<translation id="2647434099613338025">Dodavanje jezika</translation>
-<translation id="2650751991977523696">Želite li ponovo preuzeti datoteku?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# audiodatoteka}one{# audiodatoteka}few{# audiodatoteke}other{# audiodatoteka}}</translation>
-<translation id="2653659639078652383">Pošalji</translation>
-<translation id="2677748264148917807">Napusti</translation>
-<translation id="2704606927547763573">Kopirano</translation>
-<translation id="2707726405694321444">Osvježavanje stranice</translation>
-<translation id="2709516037105925701">Automatsko popunjavanje</translation>
-<translation id="2717722538473713889">E-adrese</translation>
-<translation id="2728754400939377704">Poredaj po web-lokaciji</translation>
-<translation id="2744248271121720757">Dodirnite riječ da biste je odmah pretražili ili vidjeli povezane radnje</translation>
-<translation id="2760989362628427051">Uključite tamnu temu kada je na uređaju uključena tamna tema ili Štednja baterije</translation>
-<translation id="2762000892062317888">upravo sada</translation>
-<translation id="2777555524387840389">Preostalo sekundi: <ph name="SECONDS" /></translation>
-<translation id="2779651927720337254">nije uspjelo</translation>
-<translation id="2781151931089541271">Još 1 s</translation>
-<translation id="2801022321632964776">Ažurirajte Chrome na najnoviju verziju za prikaz na vašem jeziku</translation>
-<translation id="2810645512293415242">Pojednostavljena stranica štedi podatke i učitava se brže.</translation>
-<translation id="281504910091592009">Spremljene zaporke možete pregledati i upravljati njima na svojem <ph name="BEGIN_LINK" />Google računu<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Da bi se vaše oznake prikazale na svim vašim uređajima, prijavite se i uključite sinkronizaciju</translation>
-<translation id="2822354292072154809">Jeste li sigurni da želite poništiti sva dopuštenja za aplikaciju <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Dodirnite gumb Natrag da biste zatvorili prikaz na cijelom zaslonu.</translation>
-<translation id="2842985007712546952">Nadređena mapa</translation>
-<translation id="2858138569776157458">Najpopularnije web-lokacije</translation>
-<translation id="2860954141821109167">Provjerite je li na uređaju omogućena aplikacija telefona</translation>
-<translation id="2870560284913253234">Web lokacija</translation>
-<translation id="2874939134665556319">Prethodna pjesma</translation>
-<translation id="2876369937070532032">Googleu šalje URL-ove nekih stranica koje posjećujete kada je ugrožena vaša sigurnost</translation>
-<translation id="2888126860611144412">O Chromeu</translation>
-<translation id="2891154217021530873">Zaustavljanje učitavanja stranice</translation>
-<translation id="2893180576842394309">Google može upotrebljavati vašu povijest za prilagodbu Pretraživanja i drugih Googleovih usluga</translation>
-<translation id="2898264748040935573">Uredite pohranjenu zaporku</translation>
-<translation id="2900528713135656174">Stvori događaj</translation>
-<translation id="290376772003165898">Ovo nije <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Popis za odabir uređaja s kojim će se dijeliti kartica otvoren punom visinom.</translation>
-<translation id="2910701580606108292">Web-lokacije moraju tražiti dopuštenje za reprodukciju zaštićenog sadržaja</translation>
-<translation id="2913331724188855103">Dopusti web-lokacijama da spremaju i čitaju podatke kolačića (preporučeno)</translation>
-<translation id="2923908459366352541">Naziv nije važeći</translation>
-<translation id="2932150158123903946">Pohrana aplikacije Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Kartica pregleda je zatvorena</translation>
-<translation id="2956410042958133412">Računom upravljaju <ph name="PARENT_NAME_1" /> i <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Prešli ste na anonimne kartice</translation>
-<translation id="2968755619301702150">Preglednik certifikata</translation>
-<translation id="2979025552038692506">Odabrana anonimna kartica</translation>
-<translation id="2987620471460279764">Tekst podijeljen s drugog uređaja</translation>
-<translation id="2989523299700148168">Nedavno posjećeno</translation>
-<translation id="2996291259634659425">Stvaranje zaporke</translation>
-<translation id="2996809686854298943">Potreban URL</translation>
-<translation id="300526633675317032">Time će se izbrisati cijela pohrana web-lokacije veličine <ph name="SIZE_IN_KB" />.</translation>
-<translation id="3016635187733453316">Provjerite je li uređaj povezan s internetom</translation>
-<translation id="3029613699374795922">Preuzeto <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Zaporke se ne podudaraju</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Potražite pomoć<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Lokacija je isključena. Uključite je u <ph name="BEGIN_LINK" />postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Sinkronizaciju možete uključiti u bilo kojem trenutku u postavkama</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> oznaka}one{<ph name="BOOKMARKS_COUNT_MANY" /> oznaka}few{<ph name="BOOKMARKS_COUNT_MANY" /> oznake}other{<ph name="BOOKMARKS_COUNT_MANY" /> oznaka}}</translation>
-<translation id="3089395242580810162">Otvori na anonimnoj kartici</translation>
-<translation id="3115898365077584848">Prikaži informacije</translation>
-<translation id="3123473560110926937">Blokirano na nekim web-lokacijama</translation>
-<translation id="3137521801621304719">Izlaz iz anonimnog načina</translation>
-<translation id="3143515551205905069">Otkaži sinkronizaciju</translation>
-<translation id="3157842584138209013">Pogledajte količinu ušteđenih podataka pomoću gumba Više opcija</translation>
-<translation id="3166827708714933426">Prečaci kartica i prozora</translation>
-<translation id="3181954750937456830">Sigurno pregledavanje (štiti vas i vaš uređaj od opasnih web-lokacija)</translation>
-<translation id="3190152372525844641">Uključite dopuštenja za Chrome u <ph name="BEGIN_LINK" />Postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">Pohranjeni podaci: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Još samo malo!</translation>
-<translation id="3207960819495026254">Označeno</translation>
-<translation id="3211426585530211793">Izbrisano <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Ako ste zaboravili šifru ili želite promijeniti tu postavku, <ph name="BEGIN_LINK" />poništite sinkronizaciju<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Web-aplikacija</translation>
-<translation id="3236059992281584593">Još 1 min</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Označi ovu stranicu</translation>
-<translation id="3259831549858767975">Smanjivanje svega na stranici</translation>
-<translation id="3269093882174072735">Učitaj sliku</translation>
-<translation id="3269956123044984603">Da bi se prikazale kartice s vaših ostalih uređaja, uključite "Automatsku sinkronizaciju podataka" u postavkama računa na Androidu.</translation>
-<translation id="3277252321222022663">Dopuštanje pristupa senzorima za web-lokacije (preporučeno)</translation>
-<translation id="3282568296779691940">Prijavite se u Chrome</translation>
-<translation id="3288003805934695103">ponovo učitajte stranicu</translation>
-<translation id="32895400574683172">Obavijesti su dopuštene</translation>
-<translation id="3295530008794733555">Pregledavajte brže. Smanjite podatkovni promet.</translation>
-<translation id="3295602654194328831">Sakrij informacije</translation>
-<translation id="3298243779924642547">Jednostav.</translation>
-<translation id="3303414029551471755">Želite li nastaviti s preuzimanjem sadržaja?</translation>
-<translation id="3306398118552023113">Ova se aplikacija izvodi u Chromeu</translation>
-<translation id="3315103659806849044">Trenutačno prilagođavate postavke sinkronizacije i Googleovih usluga. Da biste dovršili uključivanje sinkronizacije, dodirnite gumb Potvrdi pri dnu zaslona. Natrag</translation>
-<translation id="3328801116991980348">Informacije o web-lokaciji</translation>
-<translation id="3333961966071413176">Svi kontakti</translation>
-<translation id="3334729583274622784">Promijeniti datotečni nastavak?</translation>
-<translation id="3341058695485821946">Pogledajte količinu ušteđenih podataka</translation>
-<translation id="3350687908700087792">Zatvori sve anonimne kartice</translation>
-<translation id="3353615205017136254">Jednostavnu stranicu pruža Google. Dodirnite gumb Učitaj izvornu stranicu da biste učitali izvornu stranicu.</translation>
-<translation id="3367813778245106622">Prijavite se ponovo da biste pokrenuli sinkronizaciju</translation>
-<translation id="3374023511497244703">Vaše oznake, povijest, zaporke i drugi podaci iz Chromea više se neće sinkronizirati s vašim Google računom</translation>
-<translation id="3384347053049321195">Dijeli sliku</translation>
-<translation id="3386292677130313581">Web-lokacije moraju tražiti dopuštenje za pristup lokaciji (preporučeno)</translation>
-<translation id="3387650086002190359">Preuzimanje datoteke <ph name="FILE_NAME" /> nije uspjelo zbog nepoznate pogreške sustava datoteka.</translation>
-<translation id="3389286852084373014">Tekst je prevelik</translation>
-<translation id="3398320232533725830">Otvaranje upravitelja oznaka</translation>
-<translation id="3414952576877147120">Veličina:</translation>
-<translation id="3443221991560634068">Ponovno učitavanje trenutačne stranice</translation>
-<translation id="3445014427084483498">Upravo sada</translation>
-<translation id="3478363558367712427">Možete odabrati tražilicu</translation>
+<translation id="6910211073230771657">Izbrisano</translation>
+<translation id="6965382102122355670">U redu</translation>
+<translation id="5301954838959518834">U redu, shvaćam</translation>
+<translation id="7658239707568436148">Odustani</translation>
 <translation id="3479552764303398839">Ne sada</translation>
-<translation id="3492207499832628349">Nova anonimna kartica</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Saznajte više<ph name="END_LINK" /> o predloženom sadržaju</translation>
-<translation id="3513704683820682405">Proširena stvarnost</translation>
-<translation id="3518985090088779359">Prihvati i nastavi</translation>
-<translation id="3522247891732774234">Dostupno je ažuriranje. Više opcija</translation>
-<translation id="3524138585025253783">Korisničko sučelje razvojnog programera</translation>
-<translation id="3527085408025491307">Mapa</translation>
-<translation id="3542235761944717775">Dostupno: <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Pretraži povijest</translation>
-<translation id="3557336313807607643">Dodaj u kontakte</translation>
-<translation id="3566923219790363270">Chrome se još priprema za VR. Ponovo pokrenite Chrome kasnije.</translation>
-<translation id="3568688522516854065">Da bi se prikazale kartice s vaših ostalih uređaja, prijavite se i uključite sinkronizaciju</translation>
-<translation id="3587482841069643663">Sve</translation>
-<translation id="358794129225322306">Dopusti web-lokaciji automatsko preuzimanje više datoteka.</translation>
-<translation id="3590487821116122040">Pohrana web-lokacije koju Chrome ne smatra važnom (primjerice web-lokacije koje nemaju spremljene postavke ili koje ne posjećujete često)</translation>
-<translation id="3599863153486145794">Briše povijest na svim uređajima na kojima ste prijavljeni. Na vašem Google računu možda postoje drugi oblici povijesti pregledavanja na stranici <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Isključen je zvuk na web-lokacijama koje ga reproduciraju</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Dijeljenje s uređajem <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Prikaži zaporku</translation>
-<translation id="363596933471559332">Automatski se prijavite na web-lokacije pomoću spremljenih vjerodajnica. Kada je ta značajka isključena, tražit će se potvrda prije svakog prijavljivanja na web-lokaciju.</translation>
-<translation id="3658159451045945436">Vraćanjem na zadano briše se povijest uštede podataka, uključujući popis posjećenih web-lokacija.</translation>
-<translation id="3692944402865947621">Preuzimanje datoteke <ph name="FILE_NAME" /> nije uspjelo jer lokacija pohrane nije dostupna.</translation>
-<translation id="3714981814255182093">Otvaranje Trake za traženje</translation>
-<translation id="3716182511346448902">Ova stranica upotrebljava previše memorije, pa ju je Chrome pauzirao.</translation>
-<translation id="3730075448226062617">Da bi Chrome mogao pristupiti vašem mikrofonu, uključite mikrofon i u <ph name="BEGIN_LINK" />postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Označeno u pregledniku <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sinkronizacija u pozadini</translation>
-<translation id="3771001275138982843">Preuzimanje ažuriranja nije uspjelo</translation>
-<translation id="3771033907050503522">Anonimne kartice</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Uključite Bluetooth<ph name="END_LINK" /> da biste omogućili uparivanje</translation>
-<translation id="3775705724665058594">Pošaljite na svoje uređaje</translation>
-<translation id="3778956594442850293">Dodano na početni zaslon</translation>
-<translation id="3789841737615482174">Instaliraj</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Upravljaj</translation>
-<translation id="381841723434055211">Telefonski brojevi</translation>
-<translation id="3819178904835489326">Izbrisano preuzimanja: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Izbrisati pohranu?</translation>
-<translation id="385051799172605136">Natrag</translation>
-<translation id="3859306556332390985">Traži unaprijed</translation>
-<translation id="3894427358181296146">Dodavanje mape</translation>
-<translation id="3895926599014793903">Prisilno omogućavanje zumiranja</translation>
-<translation id="3912508018559818924">Pronalazimo ono najbolje s weba…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Kombiniranje podataka</translation>
-<translation id="393697183122708255">Glasovno pretraživanje nije dostupno</translation>
-<translation id="395206256282351086">Onemogućeni su prijedlozi za pretraživanje i web-lokacije</translation>
-<translation id="3955193568934677022">Web-lokacije mogu reproducirati zaštićeni sadržaj (preporučeno)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome će učitati stranicu kad bude spreman}one{Chrome će učitati stranice kad bude spreman}few{Chrome će učitati stranice kad bude spreman}other{Chrome će učitati stranice kad bude spreman}}</translation>
-<translation id="3963007978381181125">Enkripcija šifrom ne uključuje podatke o načinima plaćanja i adresama s Google Paya. Samo osoba koja ima vašu šifru može čitati vaše kriptirane podatke. Šifra se ne šalje Googleu niti se na njemu pohranjuje. Ako zaboravite šifru ili želite promijeniti tu postavku, morate poništiti sinkronizaciju. <ph name="BEGIN_LINK" />Saznajte više<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Preuzimanje dovršeno</translation>
-<translation id="397583555483684758">Sinkronizacija je prekinuta</translation>
-<translation id="3976396876660209797">Uklonite i ponovo izradite taj prečac</translation>
-<translation id="3985215325736559418">Želite li ponovo preuzeti datoteku <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Kopiraj vezu</translation>
-<translation id="3988213473815854515">Lokacija je dopuštena</translation>
-<translation id="3988466920954086464">Na ovoj ploči pogledajte instant rezultate pretraživanja</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Nevažna pohrana</translation>
-<translation id="4000212216660919741">Početna stranica offline</translation>
+<translation id="5317780077021120954">Spremi</translation>
+<translation id="4570913071927164677">Pojedinosti</translation>
+<translation id="8730621377337864115">Gotovo</translation>
+<translation id="8261506727792406068">Izbriši</translation>
+<translation id="1181037720776840403">Ukloni</translation>
+<translation id="5939518447894949180">Ponovno postavi</translation>
 <translation id="4002066346123236978">Naslov</translation>
-<translation id="4008040567710660924">Dopusti kolačiće za određenu web-lokaciju.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}few{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Sljedeća pjesma</translation>
-<translation id="4048707525896921369">Saznajte više o temama na web-lokacijama izravno na stranici. Značajka Dodirnite za pretraživanje Google pretraživanju šalje riječ i njezin kontekst, a vraća definicije, slike, rezultate pretraživanja i druge pojedinosti.
+<translation id="5916664084637901428">Uključi</translation>
+<translation id="5860033963881614850">Isključeno</translation>
+<translation id="6165508094623778733">Saznajte više</translation>
+<translation id="6042308850641462728">Više</translation>
+<translation id="6040143037577758943">Zatvori</translation>
+<translation id="780301667611848630">Ne, hvala</translation>
+<translation id="1201402288615127009">Dalje</translation>
+<translation id="2359808026110333948">Nastavi</translation>
+<translation id="2653659639078652383">Pošalji</translation>
+<translation id="2079545284768500474">Poništi</translation>
+<translation id="7649070708921625228">Pomoć</translation>
+<translation id="2148716181193084225">Danas</translation>
+<translation id="7781829728241885113">Danas</translation>
+<translation id="6945221475159498467">Odaberi</translation>
+<translation id="7791543448312431591">Dodaj</translation>
+<translation id="6527303717912515753">Podijeli</translation>
+<translation id="1383876407941801731">Traži</translation>
+<translation id="3115898365077584848">Prikaži informacije</translation>
+<translation id="3295602654194328831">Sakrij informacije</translation>
+<translation id="3987993985790029246">Kopiraj vezu</translation>
+<translation id="2704606927547763573">Kopirano</translation>
+<translation id="8725066075913043281">Pokušajte ponovo</translation>
+<translation id="385051799172605136">Natrag</translation>
+<translation id="8131740175452115882">Potvrdi</translation>
+<translation id="5300589172476337783">Prikaži</translation>
+<translation id="1124772482545689468">Korisnik</translation>
+<translation id="8609465669617005112">Premjesti gore</translation>
+<translation id="6746124502594467657">Pomakni dolje</translation>
+<translation id="8249310407154411074">Na vrh</translation>
+<translation id="8428213095426709021">Postavke</translation>
+<translation id="2498359688066513246">Pomoć i povratne informacije</translation>
+<translation id="8378714024927312812">Pod upravljanjem vaše organizacije</translation>
+<translation id="9019902583201351841">Upravljaju tvoji roditelji</translation>
+<translation id="4645575059429386691">Upravlja tvoj roditelj</translation>
+<translation id="4883854917563148705">Upravljane postavke ne mogu se vratiti na zadano</translation>
+<translation id="4307992518367153382">Osnove</translation>
+<translation id="1974060860693918893">Napredno</translation>
+<translation id="1146678959555564648">Pokreni VR</translation>
+<translation id="987264212798334818">Općenito</translation>
+<translation id="4275663329226226506">Mediji</translation>
+<translation id="4759238208242260848">Preuzimanje</translation>
+<translation id="218608176142494674">Dijeljenje</translation>
+<translation id="8004582292198964060">Preglednik</translation>
+<translation id="1105960400813249514">Snimka zaslona</translation>
+<translation id="4875775213178255010">Prijedlozi sadržaja</translation>
+<translation id="2021896219286479412">Kontrole web-lokacije na cijelom zaslonu</translation>
+<translation id="4587589328781138893">Web-lokacije</translation>
+<translation id="4943703118917034429">Virtualna stvarnost</translation>
+<translation id="1928696683969751773">Ažuriranja</translation>
+<translation id="6064125863973209585">Dovršena preuzimanja</translation>
+<translation id="5342314432463739672">Zahtjevi za dopuštenja</translation>
+<translation id="629730747756840877">Račun</translation>
+<translation id="82609232232243542">Prijavite se u Brave</translation>
+<translation id="7956662517480676674">Sinkronizacija i Brave Softwareove usluge</translation>
+<translation id="5294439808117722387">Trenutačno prilagođavate postavke sinkronizacije i Brave Softwareovih usluga. Da biste dovršili uključivanje sinkronizacije, dodirnite gumb Potvrdi pri dnu zaslona. Natrag</translation>
+<translation id="2096012225669085171">Sinkronizacija i prilagodba na svim uređajima</translation>
+<translation id="1692118695553449118">Sinkronizacija je uključena</translation>
+<translation id="5514904542973294328">Opciju je omogućio administrator ovog uređaja</translation>
+<translation id="6447211988989208781">Kontrole aktivnosti na Brave Softwareu</translation>
+<translation id="4882831918239250449">Odredite na koji će se način vaša povijest pregledavanja upotrebljavati za prilagodbu Pretraživanja, oglasa i drugog</translation>
+<translation id="7431991332293347422">Odredite na koji će se način vaša povijest pregledavanja upotrebljavati za prilagodbu Pretraživanja i drugih značajki</translation>
+<translation id="6303969859164067831">Odjava i isključivanje sinkronizacije</translation>
+<translation id="1125261911132334651">Upravljajte svojim Brave Software računom</translation>
+<translation id="6406506848690869874">Sinkronizacija</translation>
+<translation id="714362445477979774">Sinkroniziraj podatke iz Bravea</translation>
+<translation id="4314815835985389558">Upravljanje sinkronizacijom</translation>
+<translation id="5428209950370661546">Ostale Brave Softwareove usluge</translation>
+<translation id="7704317875155739195">Samodovršavanje pretraživanja i URL-ova</translation>
+<translation id="2000419248597011803">Zadanoj tražilici šalje neke kolačiće i pretraživanja iz adresne trake i okvira za pretraživanje</translation>
+<translation id="7981313251711023384">Prethodno učitaj stranice za brže pregledavanje i pretraživanje</translation>
+<translation id="1821253160463689938">Upotrebljava kolačiće za pamćenje vaših postavki, čak i ako ne posjetite te stranice</translation>
+<translation id="6697492270171225480">Prikaži prijedloge za slične stranice kada se stranica ne može pronaći</translation>
+<translation id="8109318360573330108">Brave Softwareu se šalje URL stranice koju pokušavate otvoriti</translation>
+<translation id="8438566539970814960">Poboljšajte pretraživanje i pregledavanje</translation>
+<translation id="284843628681142937">Šalje Brave Softwareu URL-ove stranica koje posjećujete</translation>
+<translation id="7222718784508482526">Više postavki koje se odnose na privatnost, sigurnost i prikupljanje podataka dostupno je u odjeljku <ph name="BEGIN_LINK"/>Sinkronizacija i prilagodba<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Pomozite poboljšati Braveove značajke i izvedbu</translation>
+<translation id="9063160602596686558">Automatski šalje Brave Softwareu statistiku upotrebe i izvješća o rušenju</translation>
+<translation id="4824958205181053313">Otkazati sinkronizaciju?</translation>
+<translation id="3058498974290601450">Sinkronizaciju možete uključiti u bilo kojem trenutku u postavkama</translation>
+<translation id="3143515551205905069">Otkaži sinkronizaciju</translation>
+<translation id="1506061864768559482">Tražilica</translation>
+<translation id="55737423895878184">Lokacija i obavijesti su dopuštene</translation>
+<translation id="3988213473815854515">Lokacija je dopuštena</translation>
+<translation id="32895400574683172">Obavijesti su dopuštene</translation>
+<translation id="9040142327097499898">Obavijesti su dopuštene. Lokacija je isključena za ovaj uređaj.</translation>
+<translation id="305593374596241526">Lokacija je isključena. Uključite je u <ph name="BEGIN_LINK"/>postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Nedavno posjećeno</translation>
+<translation id="6433501201775827830">Odaberite tražilicu</translation>
+<translation id="7177466738963138057">Kasnije to možete promijeniti u odjeljku Postavke</translation>
+<translation id="3478363558367712427">Možete odabrati tražilicu</translation>
+<translation id="4910889077668685004">Aplikacije za plaćanje</translation>
+<translation id="5152843274749979095">Nije instalirana nijedna podržana aplikacija</translation>
+<translation id="8812260976093120287">Na nekim web-lokacijama možete plaćati pomoću podržanih aplikacija za plaćanje na uređaju.</translation>
+<translation id="7764225426217299476">Dodaj adresu</translation>
+<translation id="5595485650161345191">Uređivanje adrese</translation>
+<translation id="5087580092889165836">Dodaj karticu</translation>
+<translation id="2154484045852737596">Uredite karticu</translation>
+<translation id="6140912465461743537">Država/regija</translation>
+<translation id="5659593005791499971">E-pošta</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Ime na kartici</translation>
+<translation id="860043288473659153">Ime vlasnika kartice</translation>
+<translation id="2612676031748830579">Broj kartice</translation>
+<translation id="869891660844655955">Datum isteka</translation>
+<translation id="2286841657746966508">Adresa za naplatu</translation>
+<translation id="663059986967017181">Kopirano u Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}few{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}few{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}few{<ph name="CONTACT_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Zaporke</translation>
+<translation id="1943432128510653496">Spremanje zaporki</translation>
+<translation id="2100273922101894616">Automatska prijava</translation>
+<translation id="363596933471559332">Automatski se prijavite na web-lokacije pomoću spremljenih vjerodajnica. Kada je ta značajka isključena, tražit će se potvrda prije svakog prijavljivanja na web-lokaciju.</translation>
+<translation id="6995899638241819463">Upozori ako su zaporke ugrožene zbog povrede podataka</translation>
+<translation id="1534287762301776620">Kad se prijavite na svoj Brave Software račun, ta je značajka uključena</translation>
+<translation id="10614374240317010">Zaporke se nikad ne spremaju</translation>
+<translation id="3098842761938485917">Spremljene zaporke možete pregledati i upravljati njima na svojem <ph name="BEGIN_LINK"/>Brave Software računu<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Ovdje će se pojaviti spremljene zaporke.</translation>
+<translation id="8084114998886531721">Spremljena zaporka</translation>
+<translation id="2870560284913253234">Web lokacija</translation>
+<translation id="8503813439785031346">Korisničko ime</translation>
+<translation id="6657585470893396449">Zaporka</translation>
+<translation id="2154710561487035718">Kopiraj URL</translation>
+<translation id="1571304935088121812">Kopiraj korisničko ime</translation>
+<translation id="5005498671520578047">Kopiranje zaporke</translation>
+<translation id="3632295766818638029">Prikaži zaporku</translation>
+<translation id="1513858653616922153">Izbriši zaporku</translation>
+<translation id="543338862236136125">Uredite zaporku</translation>
+<translation id="4565377596337484307">Sakrij zaporku</translation>
+<translation id="8523928698583292556">Izbriši pohranjenu zaporku</translation>
+<translation id="2898264748040935573">Uredite pohranjenu zaporku</translation>
+<translation id="5433691172869980887">Korisničko je ime kopirano</translation>
+<translation id="5534640966246046842">Web-lokacija kopirana</translation>
+<translation id="2625189173221582860">Zaporka je kopirana</translation>
+<translation id="4550003330909367850">Da biste ovdje pregledali ili kopirali zaporku, postavite zaključavanje zaslona na uređaju.</translation>
+<translation id="6154478581116148741">Uključite zaključavanje zaslona u postavkama da biste izvezli svoje zaporke s ovog uređaja</translation>
+<translation id="4842092870884894799">Prikazuje se skočni prozor generiranja zaporke</translation>
+<translation id="2259659629660284697">Izvoz zaporki...</translation>
+<translation id="133012818630824069">Izvoz zaporki pohranjenih u Braveu</translation>
+<translation id="6914783257214138813">Vaše zaporke bit će vidljive svima koji vide izvezenu datoteku.</translation>
+<translation id="2321086116217818302">Priprema zaporki…</translation>
+<translation id="8445448999790540984">Izvoz zaporki nije moguć</translation>
+<translation id="3066461326500799725">Saznajte kako se upotrebljava Brave Software Drive</translation>
+<translation id="729975465115245577">Vaš uređaj nema aplikaciju za spremanje datoteke zaporki.</translation>
+<translation id="7682724950699840886">Pokušajte napraviti sljedeće: provjerite ima li dovoljno prostora na uređaju i pokušajte ponoviti izvoz.</translation>
+<translation id="1129510026454351943">Pojedinosti: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Otključajte za kopiranje zaporke</translation>
+<translation id="5515439363601853141">Otključajte za prikaz zaporke</translation>
+<translation id="6221633008163990886">Otključajte da biste izvezli zaporke</translation>
+<translation id="230699814587342492">Zaporke preglednika Brave</translation>
+<translation id="6075798973483050474">Uređivanje početne stranice</translation>
+<translation id="854522910157234410">Otvori tu stranicu:</translation>
+<translation id="2482878487686419369">Obavijesti</translation>
+<translation id="6255999984061454636">Prijedlozi sadržaja</translation>
+<translation id="805047784848435650">Na temelju vaše povijesti pregledavanja</translation>
+<translation id="1041308826830691739">S web-lokacija</translation>
+<translation id="395206256282351086">Onemogućeni su prijedlozi za pretraživanje i web-lokacije</translation>
+<translation id="257088987046510401">Teme</translation>
+<translation id="4650364565596261010">Zadana postavka sustava</translation>
+<translation id="7588219262685291874">Uključi tamnu temu kada je uključena Štednja baterije na uređaju</translation>
+<translation id="2760989362628427051">Uključite tamnu temu kada je na uređaju uključena tamna tema ili Štednja baterije</translation>
+<translation id="6381421346744604172">Zatamni web-lokaciju</translation>
+<translation id="5040262127954254034">Privatnost</translation>
+<translation id="4991384657077828949">Pomognite poboljšati sigurnost na Braveu</translation>
+<translation id="1943176487615318915">Radi otkrivanja opasnih aplikacija i web-lokacija Brave šalje Brave Softwareu URL-ove nekih stranica koje posjećujete, ograničene podatke o sustavu i dio sadržaja web-stranica</translation>
+<translation id="3181954750937456830">Sigurno pregledavanje (štiti vas i vaš uređaj od opasnih web-lokacija)</translation>
+<translation id="7315322926489145388">Brave Softwareu šalje URL-ove nekih stranica koje posjećujete kada je ugrožena vaša sigurnost</translation>
+<translation id="2063713494490388661">Dodirnite za pretraživanje</translation>
+<translation id="2369463299479365221">Saznajte više o temama na web-lokacijama izravno na stranici. Značajka Dodirnite za pretraživanje Brave Software pretraživanju šalje riječ i njezin kontekst, a vraća definicije, slike, rezultate pretraživanja i druge pojedinosti.
 
 Da biste prilagodili pojam za pretraživanje, odaberite ga tako što ćete ga dugo pritisnuti. Da biste precizirali pretraživanje, kliznite ploču prema gore do vrha i dodirnite okvir za pretraživanje.</translation>
-<translation id="4056223980640387499">Sepija</translation>
-<translation id="4060598801229743805">Opcije su dostupne pri vrhu zaslona</translation>
-<translation id="4062305924942672200">Pravne informacije</translation>
-<translation id="4084682180776658562">Oznaka</translation>
-<translation id="4084712963632273211">Objavio <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />omogućio Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Želite li izbrisati podatke aplikacije?</translation>
-<translation id="4099578267706723511">Poboljšajte Chrome šaljući Googleu statistike upotrebe i izvješća o rušenju.</translation>
-<translation id="410351446219883937">Automatska reprodukcija</translation>
-<translation id="4116038641877404294">Preuzmite stranice za izvanmrežnu upotrebu</translation>
-<translation id="4135200667068010335">Popis za odabir uređaja s kojim će se dijeliti kartica zatvoren je.</translation>
-<translation id="4149994727733219643">Pojednostavljeni prikaz za web-stranice</translation>
-<translation id="4165986682804962316">Postavke web-lokacije</translation>
-<translation id="4169535189173047238">Nemoj dopustiti</translation>
-<translation id="4170011742729630528">Usluga nije dostupna, pokušajte ponovo kasnije.</translation>
-<translation id="4179980317383591987">Iskorišteno <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Jezici</translation>
-<translation id="4183868528246477015">Pretraži pomoću Google objektiva <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Otvori na novoj kartici</translation>
-<translation id="4198423547019359126">Lokacije preuzimanja nisu dostupne</translation>
-<translation id="4209895695669353772">Uključite sinkronizaciju ako želite da vam Google predlaže prilagođene sadržaje</translation>
-<translation id="4226663524361240545">Obavijesti mogu uključiti vibriranje uređaja</translation>
-<translation id="423219824432660969">Kriptiraj sinkronizirane podatke pomoću Googleove zaporke od <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Otvori postavke</translation>
-<translation id="4256782883801055595">Licence otvorenog koda</translation>
-<translation id="4259722352634471385">Otvaranje je blokirano: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopiraj adresu veze</translation>
-<translation id="4275663329226226506">Mediji</translation>
-<translation id="4278390842282768270">Dopušteno</translation>
-<translation id="429312253194641664">Web-lokacija reproducira medije</translation>
-<translation id="4298388696830689168">Povezane web-lokacije</translation>
-<translation id="4307992518367153382">Osnove</translation>
-<translation id="4314815835985389558">Upravljanje sinkronizacijom</translation>
-<translation id="4351244548802238354">Zatvori dijaloški okvir</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Za pretraživanje se upotrebljava Sogou</translation>
-<translation id="4404568932422911380">Bez oznaka</translation>
-<translation id="4405224443901389797">Premjesti u…</translation>
-<translation id="4411535500181276704">Jednostavni način</translation>
-<translation id="4415276339145661267">Upravljajte svojim Google računom</translation>
-<translation id="4432792777822557199">Odsada će se <ph name="SOURCE_LANGUAGE" /> prevoditi na <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Jednostavna stranica koju pruža Google</translation>
-<translation id="4434045419905280838">Skočni prozori i preusmjeravanja</translation>
-<translation id="4440958355523780886">Jednostavnu stranicu pruža Google. Dodirnite da biste učitali izvornu stranicu.</translation>
-<translation id="4452411734226507615">Zatvori karticu <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Oznaka dodana u mapu <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Web-lokacijama je dopuštena reprodukcija zaštićenog sadržaja</translation>
-<translation id="4468959413250150279">Isključivanje zvuka za određenu web-lokaciju.</translation>
-<translation id="4472118726404937099">Ako želite sinkronizirati i prilagoditi više uređaja, prijavite se i uključite sinkronizaciju</translation>
-<translation id="447252321002412580">Pomozite poboljšati Chromeove značajke i izvedbu</translation>
-<translation id="4479647676395637221">Web-lokacije moraju tražiti dopuštenje za pristup kameri (preporučeno)</translation>
-<translation id="4479972344484327217">Instalira se <ph name="MODULE" /> za Chrome…</translation>
-<translation id="4487967297491345095">Svi Chromeovi podaci aplikacije trajno će se izbrisati. To uključuje sve datoteke, postavke, račune, baze podataka i slično.</translation>
-<translation id="4493497663118223949">Jednostavni je način uključen</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{prije # dana}one{prije # dana}few{prije # dana}other{prije # dana}}</translation>
-<translation id="451872707440238414">Pretraži oznake</translation>
-<translation id="4521489764227272523">Odabrani podaci uklonjeni su iz Chromea i sa sinkroniziranih uređaja.
-
-Vaš Google račun može sadržavati druge oblike povijesti pregledavanja, na primjer pretraživanja i aktivnosti s drugih Googleovih usluga, na stranici <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Odabir mape</translation>
-<translation id="4538018662093857852">Uključi Jednostavni način</translation>
-<translation id="4550003330909367850">Da biste ovdje pregledali ili kopirali zaporku, postavite zaključavanje zaslona na uređaju.</translation>
-<translation id="4558311620361989323">Prečaci web-stranice</translation>
-<translation id="4561979708150884304">Niste povezani</translation>
-<translation id="4565377596337484307">Sakrij zaporku</translation>
-<translation id="4570913071927164677">Pojedinosti</translation>
-<translation id="4572422548854449519">Prijava na upravljani račun</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{prije # minute}one{prije # minute}few{prije # minute}other{prije # minuta}}</translation>
-<translation id="4587589328781138893">Web-lokacije</translation>
-<translation id="4594952190837476234">Ova offline stranica nastala je <ph name="CREATION_TIME" /> i možda se razlikuje od online verzije.</translation>
-<translation id="4605958867780575332">Stavka je uklonjena: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Otvori <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Upotrijebi zaporku</translation>
-<translation id="4645575059429386691">Upravlja tvoj roditelj</translation>
-<translation id="4650364565596261010">Zadana postavka sustava</translation>
-<translation id="4663756553811254707">Oznake su izbrisane (<ph name="NUMBER_OF_BOOKMARKS" />)</translation>
-<translation id="4665282149850138822">Web-lokacija <ph name="NAME" /> dodana je na početni zaslon</translation>
-<translation id="4684427112815847243">Sinkroniziraj sve</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}few{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Pošaljite SMS na svoje uređaje</translation>
-<translation id="4698034686595694889">Pregledajte offline u aplikaciji <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Predmemorirane slike i datoteke</translation>
-<translation id="4714588616299687897">Uštedite do 60% podataka</translation>
-<translation id="4719927025381752090">Ponudi prijevod</translation>
-<translation id="4720023427747327413">Otvori u aplikaciji <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Pomognite poboljšati Chrome. <ph name="BEGIN_LINK" />Ispunite anketu<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Ažuriraj</translation>
-<translation id="4738836084190194332">Posljednja sinkronizacija: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Otvaranje nove kartice</translation>
-<translation id="4751476147751820511">Senzori pokreta ili osvjetljenja</translation>
-<translation id="4759238208242260848">Preuzimanje</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 preuzimanje dovršeno.}one{# preuzimanje dovršeno.}few{# preuzimanja dovršena.}other{# preuzimanja dovršeno.}}</translation>
-<translation id="4797039098279997504">Dodirnite da biste se vratili na <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Enkripcija šifrom ne uključuje načine plaćanja i adrese s Google Paya.
-
-Da biste promijenili tu postavku, <ph name="BEGIN_LINK" />poništite sinkronizaciju<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Ime na kartici</translation>
-<translation id="4824958205181053313">Otkazati sinkronizaciju?</translation>
-<translation id="4837753911714442426">Otvaranje opcija za ispis stranice</translation>
-<translation id="4842092870884894799">Prikazuje se skočni prozor generiranja zaporke</translation>
-<translation id="4860895144060829044">Poziv</translation>
-<translation id="4866368707455379617">Instaliranje modula <ph name="MODULE" /> za Chrome nije uspjelo</translation>
-<translation id="4875775213178255010">Prijedlozi sadržaja</translation>
-<translation id="4878404682131129617">Uspostava tunela putem proxy poslužitelja nije uspjela</translation>
-<translation id="4880127995492972015">Prevedi…</translation>
-<translation id="4881695831933465202">Otvori</translation>
-<translation id="488187801263602086">Promijenite naziv datoteke</translation>
-<translation id="4882831918239250449">Odredite na koji će se način vaša povijest pregledavanja upotrebljavati za prilagodbu Pretraživanja, oglasa i drugog</translation>
-<translation id="4883854917563148705">Upravljane postavke ne mogu se vratiti na zadano</translation>
-<translation id="4885273946141277891">Nepodržan broj različitih verzija Chromea.</translation>
-<translation id="4910889077668685004">Aplikacije za plaćanje</translation>
-<translation id="4913161338056004800">Poništi statistiku</translation>
-<translation id="4913169188695071480">Zaustavi osvježavanje</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Potražite pomoć<ph name="END_LINK" /> tijekom traženja uređaja…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stranica}one{# stranica}few{# stranice}other{# stranica}}</translation>
-<translation id="4932247056774066048">Budući da se odjavljujete s računa kojim upravlja <ph name="DOMAIN_NAME" />, vaši podaci iz Chromea izbrisat će se s ovog uređaja. Ostat će na vašem Google računu.</translation>
-<translation id="4943703118917034429">Virtualna stvarnost</translation>
-<translation id="4943872375798546930">Nema rezultata</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> dijeli vaš zaslon</translation>
-<translation id="4961107849584082341">Prevedite ovu stranicu na bilo koji jezik</translation>
-<translation id="4962975101802056554">Opoziv svih dopuštenja za uređaj</translation>
-<translation id="4970824347203572753">Nije dostupno na vašoj lokaciji</translation>
-<translation id="497421865427891073">Idi naprijed</translation>
-<translation id="4988210275050210843">Preuzimanje datoteke (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Stranice</translation>
-<translation id="4994033804516042629">Nije pronađen nijedan kontakt</translation>
-<translation id="4996978546172906250">Dijeli putem</translation>
-<translation id="5004416275253351869">Kontrole aktivnosti na Googleu</translation>
-<translation id="5005498671520578047">Kopiranje zaporke</translation>
-<translation id="5011311129201317034">Web-lokacija <ph name="SITE" /> želi se povezati</translation>
-<translation id="5013696553129441713">Nema novih prijedloga</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Ova web-lokacija možda može saznati nešto o vama dok ste u VR-u, na primjer:
-  -  vaša fizička obilježja, primjerice visina
-
-Prije nego što pokrenete VR, provjerite je li ta web-lokacija pouzdana.</translation>
+<translation id="2930742481329940825">Značajka Dodirnite za pretraživanje Brave Software pretraživanju šalje odabranu riječ i trenutačnu stranicu kao kontekst. Možete je isključiti u <ph name="BEGIN_LINK"/>Postavkama<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Dopusti</translation>
-<translation id="5040262127954254034">Privatnost</translation>
-<translation id="5048398596102334565">Dopuštanje pristupa senzorima kretanja za web-lokacije (preporučeno)</translation>
-<translation id="5063480226653192405">Upotreba</translation>
-<translation id="5087580092889165836">Dodaj karticu</translation>
-<translation id="5100237604440890931">Sažeto – kliknite za proširivanje.</translation>
-<translation id="510275257476243843">Još 1 sat</translation>
-<translation id="5123685120097942451">Anonimna kartica</translation>
-<translation id="5127805178023152808">Sinkronizacija je isključena</translation>
-<translation id="5129038482087801250">Instaliraj web-aplikaciju</translation>
-<translation id="5132942445612118989">Sinkronizirajte svoje zaporke, povijest i drugo na svim uređajima</translation>
-<translation id="5139940364318403933">Saznajte kako se upotrebljava Google Drive</translation>
-<translation id="515227803646670480">Brisanje pohranjenih podataka</translation>
-<translation id="5152843274749979095">Nije instalirana nijedna podržana aplikacija</translation>
-<translation id="5161254044473106830">Naslov je obavezan</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 preuzimanje nije uspjelo.}one{# preuzimanje nije uspjelo.}few{# preuzimanja nisu uspjela.}other{# preuzimanja nije uspjelo.}}</translation>
-<translation id="5170568018924773124">Pokaži u mapi</translation>
-<translation id="5184329579814168207">Otvori u Chromeu</translation>
-<translation id="5193988420012215838">Kopirano u međuspremnik</translation>
-<translation id="5197729504361054390">Kontakti koje odaberete podijelit će se s web-lokacijom <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Radni profil</translation>
-<translation id="5210286577605176222">Preskakanje na prethodnu karticu</translation>
-<translation id="5210365745912300556">Zatvori karticu</translation>
-<translation id="5224771365102442243">S videozapisom</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> želi potražiti Bluetooth uređaje u blizini. Pronađeni su sljedeći uređaji:</translation>
-<translation id="5233638681132016545">Nova kartica</translation>
-<translation id="526421993248218238">Učitavanje stranice nije uspjelo</translation>
-<translation id="5271967389191913893">Uređaj ne može otvoriti sadržaj za preuzimanje.</translation>
-<translation id="528192093759286357">Povucite od vrha zaslona i dodirnite gumb Natrag da biste zatvorili prikaz na cijelom zaslonu.</translation>
-<translation id="5292796745632149097">Pošalji na uređaj</translation>
-<translation id="5300589172476337783">Prikaži</translation>
-<translation id="5301954838959518834">U redu, shvaćam</translation>
-<translation id="5304593522240415983">To polje ne može biti prazno</translation>
-<translation id="5307446750509046227">Izbriši pohranu</translation>
-<translation id="5308380583665731573">Povežite se</translation>
-<translation id="5313967007315987356">Dodaj web-lokaciju</translation>
-<translation id="5317780077021120954">Spremi</translation>
-<translation id="5324858694974489420">Postavke nadređenog računa</translation>
-<translation id="5327248766486351172">Naziv</translation>
-<translation id="5335288049665977812">Web-lokacije mogu pokretati JavaScript (preporučeno)</translation>
-<translation id="5342314432463739672">Zahtjevi za dopuštenja</translation>
-<translation id="5357811892247919462">Primljena je kartica</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> otvorena kartica, dodirnite da biste prešli na drugu karticu}one{<ph name="OPEN_TABS_MANY" /> otvorena kartica, dodirnite da biste prešli na drugu karticu}few{<ph name="OPEN_TABS_MANY" /> otvorene kartice, dodirnite da biste prešli na drugu karticu}other{<ph name="OPEN_TABS_MANY" /> otvorenih kartica, dodirnite da biste prešli na drugu karticu}}</translation>
-<translation id="5391532827096253100">Veza s web-lokacijom nije sigurna. Informacije o web-lokaciji</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ još 1)}one{(+ još #)}few{(+ još #)}other{(+ još #)}}</translation>
-<translation id="5400569084694353794">Upotrebom te aplikacije prihvaćate Chromeove <ph name="BEGIN_LINK1" />Uvjete pružanja usluge<ph name="END_LINK1" /> i <ph name="BEGIN_LINK2" />Obavijest o privatnosti<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Nazivi</translation>
-<translation id="5403644198645076998">Dopusti samo određene web-lokacije</translation>
-<translation id="5414836363063783498">Potvrđivanje…</translation>
-<translation id="5423934151118863508">Najposjećenije stranice prikazivat će se ovdje</translation>
-<translation id="5424588387303617268">Dostupno: <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Uredite zaporku</translation>
-<translation id="5433691172869980887">Korisničko je ime kopirano</translation>
-<translation id="543509235395288790">Preuzimanje ovoliko datoteka: <ph name="COUNT" /> (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Preskakanje na adresnu traku</translation>
-<translation id="5447201525962359567">Cijela pohrana web-lokacije, uključujući kolačiće i druge lokalno pohranjene podatke</translation>
-<translation id="5447765697759493033">Ova web-stranica neće biti prevedena</translation>
-<translation id="545042621069398927">Ubrzavanje preuzimanja.</translation>
-<translation id="5456381639095306749">Preuzmi stranicu</translation>
-<translation id="5475862044948910901">Želite li pokrenuti sesiju proširene stvarnosti?</translation>
-<translation id="548278423535722844">Otvori u aplikaciji za karte</translation>
-<translation id="5487521232677179737">Izbriši podatke</translation>
-<translation id="5494752089476963479">Blokiraj oglase na web-lokacijama koje prikazuju ometajuće ili obmanjujuće oglase</translation>
-<translation id="5500777121964041360">Možda nije dostupno na vašoj lokaciji</translation>
-<translation id="5512137114520586844">Računom upravlja <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Opciju je omogućio administrator ovog uređaja</translation>
-<translation id="5515439363601853141">Otključajte za prikaz zaporke</translation>
-<translation id="5516455585884385570">Otvori postavke obavijesti</translation>
-<translation id="5517095782334947753">Imate oznake, povijest, zaporke i druge postavke s računa <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Preusmjeravanje je blokirano.</translation>
-<translation id="5527082711130173040">Chrome treba pristup lokaciji kako bi skenirao uređaje. <ph name="BEGIN_LINK1" />Ažurirajte dopuštenja<ph name="END_LINK1" />. Pristup lokaciji također je <ph name="BEGIN_LINK2" />isključen za ovaj uređaj<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Traži dopuštenje prije nego što se web-lokacijama dopusti čitanje teksta i slika iz međuspremnika (preporučeno)</translation>
-<translation id="5530766185686772672">Zatvori anonimne kartice</translation>
-<translation id="5534334044554683961">Ova web-lokacija možda može saznati nešto o vama dok ste u VR-u, na primjer:
-  -   vaša fizička obilježja, primjerice visina
-  -   razmještaj vaše sobe
-
-Prije nego što uđete u VR, provjerite je li ta web-lokacija pouzdana.</translation>
-<translation id="5534640966246046842">Web-lokacija kopirana</translation>
-<translation id="5556459405103347317">Ponovno učitaj</translation>
-<translation id="5561549206367097665">Čekanje na mrežu…</translation>
-<translation id="557283862590186398">Chrome treba dopuštenje za pristup mikrofonu za ovu web-lokaciju.</translation>
-<translation id="55737423895878184">Lokacija i obavijesti su dopuštene</translation>
-<translation id="5578795271662203820">Potraži sliku na usluzi <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Uvijek možete odabrati u <ph name="BEGIN_LINK1" />postavkama<ph name="END_LINK1" /> što će se sinkronizirati.</translation>
-<translation id="5595485650161345191">Uređivanje adrese</translation>
-<translation id="5596627076506792578">Više opcija</translation>
-<translation id="5599455543593328020">Anonimni način</translation>
-<translation id="5620928963363755975">Pronađite svoje datoteke i stranice u Preuzimanjima pomoću gumba Više opcija</translation>
-<translation id="5626134646977739690">Naziv:</translation>
-<translation id="5639724618331995626">Dopusti sve web-lokacije</translation>
-<translation id="5648166631817621825">Posljednjih 7 dana</translation>
-<translation id="5649053991847567735">Automatska preuzimanja</translation>
-<translation id="5655963694829536461">Pretražite preuzimanja</translation>
-<translation id="5659593005791499971">E-pošta</translation>
-<translation id="5665379678064389456">Stvorite događaj u aplikaciji <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Nadjača zahtjev web-lokacije za sprječavanje povećavanja</translation>
-<translation id="5677928146339483299">Blokirano</translation>
-<translation id="5684874026226664614">Ups. Stranicu nije bilo moguće prevesti.</translation>
-<translation id="5686790454216892815">Datoteka ima predugačak naziv</translation>
-<translation id="5689516760719285838">Lokacija</translation>
-<translation id="569536719314091526">Prevedite ovu stranicu na bilo koji jezik pomoću gumba Više opcija</translation>
-<translation id="572328651809341494">Nedavne kartice</translation>
-<translation id="5726692708398506830">Povećavanje svega na stranici</translation>
-<translation id="5748802427693696783">Prešli ste na standardne kartice</translation>
-<translation id="5749068826913805084">Chrome treba pristup pohrani radi preuzimanja datoteka.</translation>
-<translation id="5763382633136178763">Anonimne kartice</translation>
-<translation id="5763514718066511291">Dodirnite da biste kopirali URL za tu aplikaciju</translation>
-<translation id="5765780083710877561">Opis:</translation>
-<translation id="5793665092639000975">Upotrebljava se <ph name="SPACE_USED" /> od <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google može upotrebljavati vašu povijest za prilagodbu Pretraživanja, oglasa i drugih Googleovih usluga</translation>
-<translation id="5804241973901381774">Dozvoljeno</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{prije # sata}one{prije # sata}few{prije # sata}other{prije # sati}}</translation>
-<translation id="5810288467834065221">Autorska prava <ph name="YEAR" />. Google LLC. Sva prava pridržana.</translation>
-<translation id="5817918615728894473">Upari</translation>
-<translation id="583281660410589416">Nepoznato</translation>
-<translation id="5833984609253377421">Dijeli vezu</translation>
-<translation id="5836192821815272682">Preuzimanje ažuriranja Chromea…</translation>
-<translation id="5853623416121554550">pauzirano</translation>
-<translation id="5854790677617711513">Starije od 30 dana</translation>
-<translation id="5858741533101922242">Chrome ne može uključiti Bluetooth adapter</translation>
-<translation id="5860033963881614850">Isključeno</translation>
-<translation id="5862731021271217234">Da bi se prikazale kartice s vaših ostalih uređaja, uključite sinkronizaciju</translation>
-<translation id="5864174910718532887">Pojedinosti: poredano po nazivu web-lokacije</translation>
-<translation id="5864419784173784555">Čekanje na još jedno preuzimanje…</translation>
-<translation id="5865733239029070421">Automatski šalje Googleu statistiku upotrebe i izvješća o rušenju</translation>
-<translation id="5869522115854928033">Spremljene zaporke</translation>
-<translation id="5902828464777634901">Izbrisat će se svi lokalni podaci koje pohranjuje ova web-lokacija, uključujući kolačiće.</translation>
-<translation id="5916664084637901428">Uključi</translation>
-<translation id="5919204609460789179">Ažurirajte <ph name="PRODUCT_NAME" /> za pokretanje sinkronizacije</translation>
-<translation id="5937580074298050696">Spremljeno <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Ponovno postavi</translation>
-<translation id="5942872142862698679">Za pretraživanje se upotrebljava Google</translation>
-<translation id="5952764234151283551">Googleu se šalje URL stranice koju pokušavate otvoriti</translation>
-<translation id="5956665950594638604">Otvaranje Chromeovog centra za pomoć na novoj kartici</translation>
-<translation id="5958275228015807058">Pronađite svoje datoteke i stranice u Preuzimanjima</translation>
-<translation id="5962718611393537961">Dodirnite da biste saželi</translation>
-<translation id="6000066717592683814">Zadrži Google</translation>
-<translation id="6005538289190791541">Predložena zaporka</translation>
-<translation id="6036057147555329831">Dodatni ICU</translation>
-<translation id="6039379616847168523">Preskakanje na sljedeću karticu</translation>
-<translation id="6040143037577758943">Zatvori</translation>
-<translation id="6042308850641462728">Više</translation>
-<translation id="604996488070107836">Preuzimanje datoteke <ph name="FILE_NAME" /> nije uspjelo zbog nepoznate pogreške.</translation>
-<translation id="605721222689873409">GG</translation>
-<translation id="6064125863973209585">Dovršena preuzimanja</translation>
-<translation id="6075798973483050474">Uređivanje početne stranice</translation>
-<translation id="60923314841986378">Preostalo sati: <ph name="HOURS" /></translation>
-<translation id="6108923351542677676">Postavljanje je u tijeku…</translation>
-<translation id="6111020039983847643">iskorišteni podaci</translation>
-<translation id="6112702117600201073">Osvježavanje stranice</translation>
-<translation id="6127379762771434464">Stavka je uklonjena</translation>
-<translation id="6140912465461743537">Država/regija</translation>
-<translation id="614940544461990577">Pokušajte sljedeće:</translation>
-<translation id="6154478581116148741">Uključite zaključavanje zaslona u postavkama da biste izvezli svoje zaporke s ovog uređaja</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> manji podatkovni promet</translation>
-<translation id="6165508094623778733">Saznajte više</translation>
-<translation id="6177111841848151710">Blokirano za trenutačnu tražilicu</translation>
-<translation id="6181444274883918285">Dodaj iznimku za web-lokaciju</translation>
-<translation id="6192333916571137726">Preuzimanje datoteka datoteka</translation>
-<translation id="6192792657125177640">Iznimke</translation>
-<translation id="6194112207524046168">Da bi Chrome mogao pristupiti vašoj kameri, uključite kameru i u <ph name="BEGIN_LINK" />postavkama Androida<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokiraj kolačiće trećih strana</translation>
-<translation id="6206551242102657620">Veza je sigurna. Informacije o web-lokaciji</translation>
-<translation id="6210748933810148297">Niste <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Otključajte da biste izvezli zaporke</translation>
+<translation id="1406000523432664303">"Nemoj pratiti"</translation>
 <translation id="6232535412751077445">Omogućivanje opcije "Nemoj pratiti" znači da će se u promet pregledavanja uključiti zahtjev. Učinak ovisi o tome odgovara li web-lokacija na taj zahtjev i kako se zahtjev tumači.
 
 Na primjer, neke web-lokacije na taj zahtjev mogu odgovoriti tako da vam prikažu oglase koji se ne temelje na drugim web-lokacijama koje ste posjetili. Mnoge web-lokacije i dalje će prikupljati i upotrebljavati vaše podatke o pregledavanju, primjerice, za poboljšanje sigurnosti, pružanje sadržaja, oglasa i preporuka, kao i za generiranje statističkih izvješća.</translation>
-<translation id="624789221780392884">Ažuriranje je spremno</translation>
-<translation id="6255999984061454636">Prijedlozi sadržaja</translation>
-<translation id="6277522088822131679">Pojavio se problem prilikom ispisivanja stranice. Pokušajte ponovo.</translation>
-<translation id="6295158916970320988">Sve web-lokacije</translation>
-<translation id="629730747756840877">Račun</translation>
-<translation id="6303969859164067831">Odjava i isključivanje sinkronizacije</translation>
-<translation id="6316139424528454185">Verzija Androida nije podržana</translation>
-<translation id="6320088164292336938">Omogući vibraciju</translation>
-<translation id="6324034347079777476">Sinkronizacija sustava Android onemogućena</translation>
-<translation id="6333140779060797560">Dijeljenje putem aplikacije <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Enkripcija</translation>
-<translation id="6341580099087024258">Pitaj gdje spremiti datoteke</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}few{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Želite li ukloniti prijedlog iz povijesti?</translation>
-<translation id="6369229450655021117">Ovdje možete pretraživati web, dijeliti s prijateljima i vidjeti otvorene stranice</translation>
-<translation id="6378173571450987352">Pojedinosti: poredano prema količini iskorištenih podataka</translation>
-<translation id="6381421346744604172">Zatamni web-lokaciju</translation>
-<translation id="6388207532828177975">Izbriši i poništi</translation>
-<translation id="6393863479814692971">Chrome treba dopuštenje za pristup fotoaparatu i mikrofonu za ovu web-lokaciju.</translation>
-<translation id="6395288395575013217">VEZA</translation>
-<translation id="6404511346730675251">Uredi oznaku</translation>
-<translation id="6406506848690869874">Sinkronizacija</translation>
-<translation id="641643625718530986">Ispis…</translation>
-<translation id="6416782512398055893">Preuzeto <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Prijevod weba</translation>
-<translation id="6433501201775827830">Odaberite tražilicu</translation>
-<translation id="6437478888915024427">Informacije o stranici</translation>
-<translation id="6441734959916820584">Naziv je predugačak</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# slika}one{# slika}few{# slike}other{# slika}}</translation>
-<translation id="6447842834002726250">Kolačići</translation>
-<translation id="6461962085415701688">Datoteka se ne može otvoriti</translation>
-<translation id="6464977750820128603">Možete vidjeti web-lokacije koje otvorite u Chromeu i postaviti tajmere za njih.\n\nGoogle prima informacije o web-lokacijama za koje postavite tajmere i koliko dugo ih posjećujete. Te se informacije koriste za poboljšanje Digitalne ravnoteže.</translation>
-<translation id="6475951671322991020">Preuzmi videozapis</translation>
-<translation id="6482749332252372425">Preuzimanje datoteke <ph name="FILE_NAME" /> nije uspjelo zbog nedostatka prostora.</translation>
-<translation id="6496823230996795692">Za prvu upotrebu aplikacije <ph name="APP_NAME" /> povežite se s internetom.</translation>
-<translation id="6508722015517270189">Ponovo pokrenite Chrome</translation>
-<translation id="6527303717912515753">Podijeli</translation>
-<translation id="6532866250404780454">Web-lokacije koje otvorite u Chromeu neće se prikazivati. Izbrisat će se svi tajmeri za web-lokacije.</translation>
-<translation id="6534565668554028783">Googleu je bilo potrebno previše vremena za odgovor</translation>
-<translation id="6538442820324228105">Preuzeto <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Nešto nije u redu. Pokušajte ponovo kasnije.</translation>
-<translation id="654446541061731451">Odaberite karticu za emitiranje</translation>
-<translation id="6545017243486555795">Izbriši sve podatke</translation>
-<translation id="6545864417968258051">Traženje Bluetootha</translation>
-<translation id="6560414384669816528">Pretražujte na usluzi Sogou</translation>
-<translation id="6566259936974865419">Chrome vam je uštedio <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Dopusti uvijek</translation>
-<translation id="6573431926118603307">Ovdje će se prikazati kartice koje ste otvorili u Chromeu na svojim ostalim uređajima.</translation>
-<translation id="6583199322650523874">Označavanje trenutačne stranice</translation>
-<translation id="6593061639179217415">Klasični prikaz</translation>
-<translation id="6600954340915313787">Kopirano u Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Zaštićeni sadržaj</translation>
-<translation id="6627583120233659107">Uredi mapu</translation>
-<translation id="6643016212128521049">Izbriši</translation>
-<translation id="6643649862576733715">Poredaj po količini spremljenih podataka</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}few{<ph name="CONTACT_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Pregled slike <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome treba pristup lokaciji kako bi skenirao uređaje. <ph name="BEGIN_LINK" />Ažuriraj dopuštenja<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Zaporka</translation>
-<translation id="6659594942844771486">Kartica</translation>
-<translation id="666731172850799929">Otvori u aplikaciji <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Obavijest o privatnosti za Chrome</translation>
-<translation id="6676840375528380067">Želite li izbrisati svoje podatke iz Chromea s ovog uređaja?</translation>
-<translation id="6697492270171225480">Prikaži prijedloge za slične stranice kada se stranica ne može pronaći</translation>
-<translation id="6697947395630195233">Chrome treba dopuštenje za pristup vašoj lokaciji da bi je podijelio s ovom web-lokacijom.</translation>
-<translation id="6698801883190606802">Upravljanje sinkroniziranim podacima</translation>
-<translation id="6699370405921460408">Googleovi poslužitelji optimizirat će stranice koje posjećujete.</translation>
-<translation id="6706288973712894588">Trenutačno ste offline.\n<ph name="BEGIN_LINK" />Istražite svoj offline feed.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Vijesti</translation>
-<translation id="6710213216561001401">Prethodno</translation>
-<translation id="671481426037969117">Isteklo je odbrojavanje za aplikaciju <ph name="FQDN" />. Ponovo će se pokrenuti sutra.</translation>
-<translation id="6738867403308150051">Preuzimanje...</translation>
-<translation id="6746124502594467657">Pomakni dolje</translation>
-<translation id="6766622839693428701">Prijeđite prstom prema dolje da biste zatvorili.</translation>
-<translation id="6766758767654711248">Dodirnite za otvaranje web-lokacije</translation>
-<translation id="6767294960381293877">Popis za odabir uređaja s kojim će se dijeliti kartica otvoren na pola visine.</translation>
-<translation id="6782111308708962316">Onemogući web-lokacijama treće strane da spremaju i čitaju podatke kolačića.</translation>
-<translation id="6790428901817661496">Reproduciraj</translation>
-<translation id="6811034713472274749">Stranica je spremna za prikaz</translation>
-<translation id="6818926723028410516">Odaberite stavke</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Prevedi</translation>
-<translation id="6845325883481699275">Pomognite poboljšati sigurnost na Chromeu</translation>
-<translation id="6846298663435243399">Učitavanje…</translation>
-<translation id="6850409657436465440">Preuzimanje je još u tijeku</translation>
-<translation id="6850830437481525139">Kartice su zatvorene (njih <ph name="TAB_COUNT" />)</translation>
-<translation id="6864459304226931083">Preuzmi sliku</translation>
-<translation id="6865313869410766144">Automatski ispuni podatke u obrascu</translation>
-<translation id="688738109438487280">Dodavanje postojećih podataka na račun <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Otključajte za kopiranje zaporke</translation>
-<translation id="6896758677409633944">Kopiraj</translation>
-<translation id="6910211073230771657">Izbrisano</translation>
-<translation id="6912998170423641340">Blokiraj web-lokacijama čitanje teksta i slika iz međuspremnika</translation>
-<translation id="6914783257214138813">Vaše zaporke bit će vidljive svima koji vide izvezenu datoteku.</translation>
-<translation id="6942665639005891494">Zadanu lokaciju preuzimanja možete promijeniti kad god želite putem opcije u izborniku Postavke</translation>
-<translation id="6945221475159498467">Odaberi</translation>
-<translation id="6963642900430330478">Ta je stranica opasna. Informacije o web-lokaciji</translation>
-<translation id="6963766334940102469">Brisanje oznaka</translation>
-<translation id="6965382102122355670">U redu</translation>
-<translation id="6979737339423435258">Cijelo vrijeme</translation>
-<translation id="6981982820502123353">Pristupačnost</translation>
-<translation id="6989267951144302301">Preuzimanje nije moguće</translation>
-<translation id="6990079615885386641">Preuzmite aplikaciju iz Trgovine Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Web-lokacije moraju tražiti dopuštenje za upotrebu mikrofona (preporučeno)</translation>
-<translation id="7015203776128479407">Početno postavljanje sinkronizacije nije dovršeno. Sinkronizacija je isključena.</translation>
-<translation id="7016516562562142042">Dopušteno za trenutačnu tražilicu</translation>
-<translation id="7022756207310403729">Otvori u pregledniku</translation>
-<translation id="702463548815491781">Preporučuje se kada su uključeni TalkBack ili prekidač za pristup</translation>
-<translation id="7029809446516969842">Zaporke</translation>
-<translation id="7053983685419859001">Blokiraj</translation>
-<translation id="7055152154916055070">Preusmjeravanje je blokirano:</translation>
-<translation id="7063006564040364415">Nije uspjelo povezivanje s poslužiteljem za sinkronizaciju.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 odabrana stavka}one{# odabrana stavka}few{# odabrane stavke}other{# odabranih stavki}}</translation>
-<translation id="7071521146534760487">Upravljanje računom</translation>
-<translation id="7077143737582773186">SD kartica</translation>
-<translation id="7087918508125750058">Odabrano: <ph name="ITEM_COUNT" />. Opcije su dostupne pri vrhu zaslona</translation>
-<translation id="7121362699166175603">Briše povijest i automatska dovršavanja u adresnoj traci. Na vašem Google računu možda postoje drugi oblici povijesti pregledavanja na stranici <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Dopusti za trenutačnu tražilicu</translation>
-<translation id="7138678301420049075">Ostalo</translation>
-<translation id="7141896414559753902">Web-lokacijama nije dopušteno prikazivanje skočnih prozora i preusmjeravanja (preporučeno)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Učitajte izvornu stranicu<ph name="END_LINK" /> s domene <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Posljednja 24 sata</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Kasnije to možete promijeniti u odjeljku Postavke</translation>
-<translation id="7180611975245234373">Osvježi</translation>
-<translation id="7189372733857464326">Čekanje dovršetka ažuriranja Google Play usluga</translation>
-<translation id="7191430249889272776">Kartica je otvorena u pozadini.</translation>
-<translation id="723171743924126238">Odaberite slike</translation>
-<translation id="7233236755231902816">Za prikaz weba na vašem jeziku preuzmite najnoviju verziju Chromea</translation>
-<translation id="7243308994586599757">Opcije dostupne pri dnu zaslona</translation>
-<translation id="7248069434667874558">Provjerite je li na uređaju <ph name="TARGET_DEVICE_NAME" /> uključena sinkronizacija u Chromeu</translation>
-<translation id="7250468141469952378">Odabrano: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Blokirana web-lokacija</translation>
-<translation id="7290209999329137901">Promjena naziva nije dostupna</translation>
-<translation id="7291387454912369099">Naplata pomoću Asistenta</translation>
-<translation id="7293171162284876153">Da biste pokrenuli sinkronizaciju, uključite postavku "Sinkroniziraj podatke s Chromea".</translation>
-<translation id="729975465115245577">Vaš uređaj nema aplikaciju za spremanje datoteke zaporki.</translation>
-<translation id="7302081693174882195">Pojedinosti: poredano prema količini ušteđenih podataka</translation>
-<translation id="7328017930301109123">U Jednostavnom načinu Chrome učitava stranice brže i smanjuje podatkovni promet do 60 posto.</translation>
-<translation id="7333031090786104871">I dalje se dodaje prethodna web-lokacija</translation>
-<translation id="7352939065658542140">VIDEOZAPIS</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Dijeljenje 1 odabrane stavke}one{Dijeljenje # odabrane stavke}few{Dijeljenje # odabrane stavke}other{Dijeljenje # odabranih stavki}}</translation>
 <translation id="7359002509206457351">Pristup načinima plaćanja</translation>
+<translation id="8026334261755873520">Brisanje podataka o pregledavanju</translation>
+<translation id="1291207594882862231">Brisanje povijesti, kolačića, podataka web-lokacija, predmemorije...</translation>
+<translation id="7814200940910057384">Braveovi su podaci izbrisani</translation>
+<translation id="1664855196866195614">Odabrani podaci uklonjeni su iz Bravea i sa sinkroniziranih uređaja.
+
+Vaš Brave Software račun može sadržavati druge oblike povijesti pregledavanja, na primjer pretraživanja i aktivnosti s drugih Brave Softwareovih usluga, na stranici <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Predmemorirane slike i datoteke</translation>
+<translation id="2496180316473517155">Povijest pregledavanja</translation>
+<translation id="2546283357679194313">Kolačići i podaci o web-lokacijama</translation>
+<translation id="8662811608048051533">Odjavit ćete se s većine web-lokacija.</translation>
+<translation id="8218628800671693884">Odjavit ćete se s većine web-lokacija, ali se nećete odjaviti s Brave Software računa.</translation>
+<translation id="2017836877785168846">Briše povijest i automatsko dovršavanje u adresnoj traci.</translation>
+<translation id="8096327394278038498">Briše povijest i automatska dovršavanja u adresnoj traci. Na vašem Brave Software računu možda postoje drugi oblici povijesti pregledavanja na stranici <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Briše povijest na svim uređajima na kojima ste prijavljeni. Na vašem Brave Software računu možda postoje drugi oblici povijesti pregledavanja na stranici <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Spremljene zaporke</translation>
+<translation id="6865313869410766144">Automatski ispuni podatke u obrascu</translation>
+<translation id="7562080006725997899">Brisanje podataka o pregledavanju</translation>
+<translation id="5487521232677179737">Izbriši podatke</translation>
+<translation id="7498271377022651285">Pričekajte…</translation>
+<translation id="784934925303690534">Vremenski raspon</translation>
+<translation id="1718835860248848330">Zadnji sat</translation>
+<translation id="7149893636342594995">Posljednja 24 sata</translation>
+<translation id="5648166631817621825">Posljednjih 7 dana</translation>
+<translation id="8571213806525832805">Protekla 4 tjedna</translation>
+<translation id="5854790677617711513">Starije od 30 dana</translation>
+<translation id="6979737339423435258">Cijelo vrijeme</translation>
+<translation id="982182592107339124">Izbrisat će se podaci za sve web-lokacije, uključujući:</translation>
+<translation id="6643016212128521049">Izbriši</translation>
+<translation id="7641339528570811325">Izbriši podatke o pregledavanju…</translation>
+<translation id="1670399744444387456">Osnovne</translation>
+<translation id="3245261285041759672">Na vašem Brave Software računu možda postoje drugi oblici povijesti pregledavanja na stranici <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Blokirana web-lokacija</translation>
+<translation id="2534155362429831547">Broj izbrisanih stavki: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Izvješća o upotrebi i rušenju programa</translation>
+<translation id="9079153198295609735">Automatski šalji Brave Softwareu statistiku o upotrebi i izvješća o padu programa</translation>
+<translation id="6981982820502123353">Pristupačnost</translation>
+<translation id="2387895666653383613">Skaliranje teksta</translation>
+<translation id="2321958826496381788">Pomičite klizač dok ne budete mogli čitati ovaj tekst bez poteškoća. Tekst bi trebao biti barem ovoliko velik nakon što dvaput dodirnete odlomak.</translation>
+<translation id="3895926599014793903">Prisilno omogućavanje zumiranja</translation>
+<translation id="5668404140385795438">Nadjača zahtjev web-lokacije za sprječavanje povećavanja</translation>
+<translation id="4149994727733219643">Pojednostavljeni prikaz za web-stranice</translation>
+<translation id="9100505651305367705">Mogućnost prikazivanja članaka u pojednostavljenom prikazu kada je to podržano</translation>
+<translation id="1409426117486808224">Pojednostavljeni prikaz za otvorene kartice</translation>
+<translation id="702463548815491781">Preporučuje se kada su uključeni TalkBack ili prekidač za pristup</translation>
+<translation id="8284326494547611709">Titlovi</translation>
+<translation id="4165986682804962316">Postavke web-lokacije</translation>
+<translation id="6295158916970320988">Sve web-lokacije</translation>
+<translation id="8380167699614421159">Ova web-lokacija prikazuje ometajuće ili obmanjujuće oglase</translation>
+<translation id="1919345977826869612">Oglasi</translation>
+<translation id="410351446219883937">Automatska reprodukcija</translation>
+<translation id="6447842834002726250">Kolačići</translation>
+<translation id="6196640612572343990">Blokiraj kolačiće trećih strana</translation>
+<translation id="6782111308708962316">Onemogući web-lokacijama treće strane da spremaju i čitaju podatke kolačića.</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Skočni prozori i preusmjeravanja</translation>
+<translation id="4751476147751820511">Senzori pokreta ili osvjetljenja</translation>
+<translation id="1717218214683051432">Senzori kretanja</translation>
+<translation id="2091887806945687916">Zvuk</translation>
+<translation id="2586657967955657006">Međuspremnik</translation>
+<translation id="6320088164292336938">Omogući vibraciju</translation>
+<translation id="4226663524361240545">Obavijesti mogu uključiti vibriranje uređaja</translation>
+<translation id="1446450296470737166">Omogući potpuni nadzor za MIDI</translation>
+<translation id="3744111561329211289">Sinkronizacija u pozadini</translation>
+<translation id="5649053991847567735">Automatska preuzimanja</translation>
+<translation id="6181444274883918285">Dodaj iznimku za web-lokaciju</translation>
+<translation id="5313967007315987356">Dodaj web-lokaciju</translation>
+<translation id="1369915414381695676">Dodana je web-lokacija <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Dopustite automatsku reprodukciju videozapisa s isključenim tonom za određenu web-lokaciju.</translation>
+<translation id="2621115761605608342">Dopuštanje JavaScripta za određenu web-lokaciju.</translation>
+<translation id="8801436777607969138">Blokiranje JavaScripta za određenu web-lokaciju.</translation>
+<translation id="8372893542064058268">Omogućuje sinkronizaciju u pozadini za određenu web-lokaciju.</translation>
+<translation id="358794129225322306">Dopusti web-lokaciji automatsko preuzimanje više datoteka.</translation>
+<translation id="4008040567710660924">Dopusti kolačiće za određenu web-lokaciju.</translation>
+<translation id="8958424370300090006">Blokiraj kolačiće za određenu web-lokaciju.</translation>
+<translation id="7882806643839505685">Dopuštanje zvuka za određenu web-lokaciju.</translation>
+<translation id="4468959413250150279">Isključivanje zvuka za određenu web-lokaciju.</translation>
+<translation id="1994173015038366702">URL web-lokacije</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Upotreba</translation>
+<translation id="5804241973901381774">Dozvoljeno</translation>
+<translation id="4278390842282768270">Dopušteno</translation>
+<translation id="5677928146339483299">Blokirano</translation>
+<translation id="1984937141057606926">Dopušteno, osim treće strane</translation>
+<translation id="7423098979219808738">Prvo pitaj</translation>
+<translation id="8116925261070264013">Bez zvuka</translation>
+<translation id="8300705686683892304">Upravlja aplikacija</translation>
+<translation id="6192792657125177640">Iznimke</translation>
+<translation id="257931822824936280">Prošireno – kliknite za sažimanje.</translation>
+<translation id="5100237604440890931">Sažeto – kliknite za proširivanje.</translation>
+<translation id="857943718398505171">Dopušteno (preporučeno)</translation>
+<translation id="2913331724188855103">Dopusti web-lokacijama da spremaju i čitaju podatke kolačića (preporučeno)</translation>
+<translation id="7445411102860286510">Web-lokacije mogu automatski reproducirati zanemarene videozapise (preporučeno)</translation>
+<translation id="5335288049665977812">Web-lokacije mogu pokretati JavaScript (preporučeno)</translation>
+<translation id="5527111080432883924">Traži dopuštenje prije nego što se web-lokacijama dopusti čitanje teksta i slika iz međuspremnika (preporučeno)</translation>
+<translation id="6912998170423641340">Blokiraj web-lokacijama čitanje teksta i slika iz međuspremnika</translation>
+<translation id="7423538860840206698">Blokirano je čitanje međuspremnika</translation>
+<translation id="3955193568934677022">Web-lokacije mogu reproducirati zaštićeni sadržaj (preporučeno)</translation>
+<translation id="445467742685312942">Web-lokacijama je dopuštena reprodukcija zaštićenog sadržaja</translation>
+<translation id="2107397443965016585">Web-lokacije moraju tražiti dopuštenje za reprodukciju zaštićenog sadržaja (preporučeno)</translation>
+<translation id="2910701580606108292">Web-lokacije moraju tražiti dopuštenje za reprodukciju zaštićenog sadržaja</translation>
+<translation id="757524316907819857">Web-lokacijama nije dopušteno reproduciranje zaštićenog sadržaja</translation>
+<translation id="3277252321222022663">Dopuštanje pristupa senzorima za web-lokacije (preporučeno)</translation>
+<translation id="5048398596102334565">Dopuštanje pristupa senzorima kretanja za web-lokacije (preporučeno)</translation>
+<translation id="8816026460808729765">Blokiranje pristupa senzorima za web-lokacije</translation>
+<translation id="169515064810179024">Blokiranje pristupa senzorima kretanja za web-lokacije</translation>
+<translation id="1660204651932907780">Web-lokacije mogu reproducirati zvuk (preporučeno)</translation>
+<translation id="3600792891314830896">Isključen je zvuk na web-lokacijama koje ga reproduciraju</translation>
+<translation id="1743802530341753419">Web-lokacije moraju tražiti dopuštenje za povezivanje s uređajem (preporučeno)</translation>
+<translation id="851751545965956758">Blokiraj povezivanje web-lokacija s uređajima</translation>
+<translation id="7141896414559753902">Web-lokacijama nije dopušteno prikazivanje skočnih prozora i preusmjeravanja (preporučeno)</translation>
+<translation id="5494752089476963479">Blokiraj oglase na web-lokacijama koje prikazuju ometajuće ili obmanjujuće oglase</translation>
+<translation id="3123473560110926937">Blokirano na nekim web-lokacijama</translation>
+<translation id="965817943346481315">Blokiraj ako web-lokacija prikazuje ometajuće ili obmanjujuće oglase (preporučeno)</translation>
+<translation id="3386292677130313581">Web-lokacije moraju tražiti dopuštenje za pristup lokaciji (preporučeno)</translation>
+<translation id="9139068048179869749">Web-lokacije moraju tražiti dopuštenje za slanje obavijesti (preporučeno)</translation>
+<translation id="4479647676395637221">Web-lokacije moraju tražiti dopuštenje za pristup kameri (preporučeno)</translation>
+<translation id="6992289844737586249">Web-lokacije moraju tražiti dopuštenje za upotrebu mikrofona (preporučeno)</translation>
+<translation id="2289270750774289114">Prikaži upit kad web-lokacija želi tražiti Bluetooth uređaje u blizini (preporučeno)</translation>
+<translation id="7053983685419859001">Blokiraj</translation>
+<translation id="7128222689758636196">Dopusti za trenutačnu tražilicu</translation>
+<translation id="7589445247086920869">Blokiraj za trenutačnu tražilicu</translation>
+<translation id="6388207532828177975">Izbriši i poništi</translation>
+<translation id="7999064672810608036">Jeste li sigurni da želite izbrisati sve lokalne podatke, uključujući kolačiće, i poništiti sva dopuštenja za ovu web-lokaciju?</translation>
+<translation id="2822354292072154809">Jeste li sigurni da želite poništiti sva dopuštenja za aplikaciju <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Brisanje pohranjenih podataka</translation>
+<translation id="5902828464777634901">Izbrisat će se svi lokalni podaci koje pohranjuje ova web-lokacija, uključujući kolačiće.</translation>
+<translation id="119944043368869598">Očisti sve</translation>
+<translation id="2490684707762498678">Upravlja: <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Otvori postavke obavijesti</translation>
+<translation id="1404122904123200417">Ugrađeno u <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Ovdje se prikazuju datoteke koje su spremile web-lokacije</translation>
+<translation id="4181841719683918333">Jezici</translation>
+<translation id="2647434099613338025">Dodavanje jezika</translation>
+<translation id="1952172573699511566">Web-lokacije prikazivat će tekst na željenom jeziku kad god je to moguće.</translation>
+<translation id="8559990750235505898">Ponudi prevođenje stranica na druge jezike</translation>
+<translation id="4719927025381752090">Ponudi prijevod</translation>
+<translation id="8156139159503939589">Koje jezike znate čitati?</translation>
+<translation id="5689516760719285838">Lokacija</translation>
+<translation id="2440823041667407902">Pristup lokaciji</translation>
+<translation id="2023546461831060654">Uključite dopuštenja za Brave u <ph name="BEGIN_LINK"/>Postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Uključite dopuštenje za Brave u <ph name="BEGIN_LINK"/>Postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Da bi Brave mogao pristupiti vašoj lokaciji, uključite lokaciju i u <ph name="BEGIN_LINK"/>postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Da bi Brave mogao pristupiti vašoj kameri, uključite kameru i u <ph name="BEGIN_LINK"/>postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Da bi vam Brave mogao slati obavijesti, uključite obavijesti i u <ph name="BEGIN_LINK"/>postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Da bi Brave mogao pristupiti vašem mikrofonu, uključite mikrofon i u <ph name="BEGIN_LINK"/>postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Pristup lokaciji isključen je za ovaj uređaj. Uključite ga u <ph name="BEGIN_LINK"/>postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Pristup lokaciji isključen je i za ovaj uređaj. Uključite ga u <ph name="BEGIN_LINK"/>postavkama Androida<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Fotoaparat</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Pristup fotoaparatu</translation>
+<translation id="945632385593298557">Pristup mikrofonu</translation>
+<translation id="6612358246767739896">Zaštićeni sadržaj</translation>
+<translation id="885701979325669005">Prostor za pohranu</translation>
+<translation id="3198916472715691905">Pohranjeni podaci: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Opozovi odobrenje uređaja</translation>
+<translation id="4962975101802056554">Opoziv svih dopuštenja za uređaj</translation>
+<translation id="6545864417968258051">Traženje Bluetootha</translation>
+<translation id="4411535500181276704">Jednostavni način</translation>
+<translation id="7821588508402923572">Ovdje će se prikazati vaša ušteda podataka</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> spremljeno</translation>
+<translation id="8569404424186215731">od <ph name="DATE"/></translation>
+<translation id="3252158532344029638">U Jednostavnom načinu Brave učitava stranice brže i smanjuje podatkovni promet do 60 posto.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> manji podatkovni promet</translation>
+<translation id="7494974237137038751">spremljeni podaci</translation>
+<translation id="6111020039983847643">iskorišteni podaci</translation>
+<translation id="7413229368719586778">Datum početka: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Datum završetka: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Poredaj po web-lokaciji</translation>
+<translation id="5864174910718532887">Pojedinosti: poredano po nazivu web-lokacije</translation>
+<translation id="116280672541001035">Iskorišteno</translation>
+<translation id="8349013245300336738">Poredaj po količini potrošenih podataka</translation>
+<translation id="6378173571450987352">Pojedinosti: poredano prema količini iskorištenih podataka</translation>
+<translation id="2631006050119455616">Spremljeno</translation>
+<translation id="6643649862576733715">Poredaj po količini spremljenih podataka</translation>
+<translation id="7302081693174882195">Pojedinosti: poredano prema količini ušteđenih podataka</translation>
+<translation id="4179980317383591987">Iskorišteno <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Spremljeno <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Preostale web-lokacije (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Ostalo</translation>
+<translation id="4913161338056004800">Poništi statistiku</translation>
+<translation id="1856325424225101786">Želite li poništiti Jednostavni način?</translation>
+<translation id="3658159451045945436">Vraćanjem na zadano briše se povijest uštede podataka, uključujući popis posjećenih web-lokacija.</translation>
+<translation id="3295530008794733555">Pregledavajte brže. Smanjite podatkovni promet.</translation>
+<translation id="7340390500800578919">U Jednostavnom načinu Brave učitava stranice brže i smanjuje podatkovni promet do 60 posto. Brave šalje vaš web-promet Brave Softwareu radi optimizacije stranica koje posjećujete. <ph name="BEGIN_LINK"/>Saznajte više<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Uključi Jednostavni način</translation>
+<translation id="4493497663118223949">Jednostavni je način uključen</translation>
+<translation id="7559975015014302720">Jednostavni je način isključen</translation>
+<translation id="7606077192958116810">Jednostavni je način uključen. Upravljajte njime u postavkama.</translation>
+<translation id="4714588616299687897">Uštedite do 60% podataka</translation>
+<translation id="1006927014032731288">Brave Softwareovi poslužitelji optimizirat će stranice koje posjećujete.</translation>
+<translation id="3257320067425202300">Brave vam je uštedio <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave vam je uštedio <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Lokacija za preuzimanje</translation>
+<translation id="7077143737582773186">SD kartica</translation>
+<translation id="7762668264895820836">SD kartica <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Pitaj gdje spremiti datoteke</translation>
+<translation id="6192333916571137726">Preuzimanje datoteka datoteka</translation>
+<translation id="1672586136351118594">Ne prikazuj ponovo</translation>
+<translation id="2650751991977523696">Želite li ponovo preuzeti datoteku?</translation>
+<translation id="8664979001105139458">Već postoji datoteka s tim nazivom</translation>
+<translation id="488187801263602086">Promijenite naziv datoteke</translation>
+<translation id="5686790454216892815">Datoteka ima predugačak naziv</translation>
+<translation id="7454641608352164238">Nema dovoljno prostora</translation>
+<translation id="8972098258593396643">Želite li preuzeti u zadanu mapu?</translation>
+<translation id="804335162455518893">SD kartica nije pronađena</translation>
+<translation id="7475688122056506577">SD kartica nije pronađena. Neke od vaših datoteka možda nedostaju.</translation>
+<translation id="4198423547019359126">Lokacije preuzimanja nisu dostupne</translation>
+<translation id="8224471946457685718">Preuzimaj članke putem Wi-Fija</translation>
+<translation id="4970824347203572753">Nije dostupno na vašoj lokaciji</translation>
+<translation id="5500777121964041360">Možda nije dostupno na vašoj lokaciji</translation>
+<translation id="1173894706177603556">Preimenuj</translation>
+<translation id="1986685561493779662">Naziv već postoji</translation>
+<translation id="6441734959916820584">Naziv je predugačak</translation>
+<translation id="2923908459366352541">Naziv nije važeći</translation>
+<translation id="7290209999329137901">Promjena naziva nije dostupna</translation>
+<translation id="3334729583274622784">Promijeniti datotečni nastavak?</translation>
+<translation id="107147699690128016">Ako promijenite datotečni nastavak, datoteka bi se mogla otvoriti u nekoj drugoj aplikaciji i mogla bi izložiti vaš uređaj opasnosti.</translation>
+<translation id="8541922081612557424">O Braveu</translation>
+<translation id="5311273890481188673">Autorska prava <ph name="YEAR"/>. Brave Software LLC. Sva prava pridržana.</translation>
+<translation id="1416550906796893042">Verzija aplikacije</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (ažurirano <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operativni sustav</translation>
+<translation id="3968054912784331254">Braveova ažuriranja više nisu podržana za ovu verziju Androida</translation>
+<translation id="7665369617277396874">Dodaj račun</translation>
+<translation id="649070405679044769">Prijavljeni ste na Brave Software kao</translation>
+<translation id="6234515504547364178">Odjava s Bravea</translation>
+<translation id="5324858694974489420">Postavke nadređenog računa</translation>
+<translation id="8920114477895755567">Čekaju se pojedinosti o nadređenim jedinicama.</translation>
+<translation id="5512137114520586844">Računom upravlja <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Računom upravljaju <ph name="PARENT_NAME_1"/> i <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Sadržaj</translation>
+<translation id="5403644198645076998">Dopusti samo određene web-lokacije</translation>
+<translation id="8641930654639604085">Pokušaj blokirati web-lokacije za odrasle</translation>
+<translation id="5639724618331995626">Dopusti sve web-lokacije</translation>
+<translation id="796823723482603597">Omogućuje Brave</translation>
+<translation id="6324034347079777476">Sinkronizacija sustava Android onemogućena</translation>
+<translation id="5127805178023152808">Sinkronizacija je isključena</translation>
+<translation id="7015203776128479407">Početno postavljanje sinkronizacije nije dovršeno. Sinkronizacija je isključena.</translation>
+<translation id="2497852260688568942">Administrator je onemogućio sinkronizaciju</translation>
+<translation id="9100610230175265781">Potrebna je zaporka</translation>
+<translation id="6108923351542677676">Postavljanje je u tijeku…</translation>
+<translation id="4062305924942672200">Pravne informacije</translation>
+<translation id="4256782883801055595">Licence otvorenog koda</translation>
+<translation id="1138681184697033370">Braveovi uvjeti pružanja usluge</translation>
+<translation id="7392539049993970338">Obavijest o privatnosti za Brave</translation>
+<translation id="2677748264148917807">Napusti</translation>
+<translation id="5556459405103347317">Ponovno učitaj</translation>
+<translation id="1623104350909869708">Spriječi da ova stranica stvori dodatne dijaloške okvire</translation>
+<translation id="2968755619301702150">Preglednik certifikata</translation>
+<translation id="1360432990279830238">Odjaviti se i isključiti sinkronizaciju?</translation>
+<translation id="8581481290581777242">Želite li izbrisati svoje podatke iz Bravea s ovog uređaja?</translation>
+<translation id="1318865768845061710">Vaše oznake, povijest, zaporke i drugi podaci iz Bravea više se neće sinkronizirati s vašim Brave Software računom</translation>
+<translation id="3325020657155065477">Izbriši podatke iz Bravea i s ovog uređaja</translation>
+<translation id="6136448902816743006">Budući da se odjavljujete s računa kojim upravlja <ph name="DOMAIN_NAME"/>, vaši podaci iz Bravea izbrisat će se s ovog uređaja. Ostat će na vašem Brave Software računu.</translation>
+<translation id="1853026300647876496">Kontaktiranje Brave Softwarea. To bi moglo potrajati…</translation>
+<translation id="2328985652426384049">Prijava nije moguća</translation>
+<translation id="7723158744459952869">Brave Softwareu je bilo potrebno previše vremena za odgovor</translation>
+<translation id="4572422548854449519">Prijava na upravljani račun</translation>
+<translation id="2689656545739939160">Prijavljujete se računom kojim upravlja <ph name="MANAGED_DOMAIN"/> i njegovom administratoru dajete kontrolu nad svojim podacima u Braveu. Vaši će se podaci trajno povezati s tim računom. Ako se odjavite iz Bravea, vaši će se podaci izbrisati s ovog uređaja, no ostat će pohranjeni na vašem Brave Software računu.</translation>
+<translation id="1749561566933687563">Sinkronizirajte oznake</translation>
+<translation id="4242533952199664413">Otvori postavke</translation>
+<translation id="1111673857033749125">Ovdje će se prikazivati oznake koje ste spremili na drugim uređajima.</translation>
+<translation id="8636825310635137004">Da bi se prikazale kartice s vaših ostalih uređaja, uključite sinkronizaciju.</translation>
+<translation id="3269956123044984603">Da bi se prikazale kartice s vaših ostalih uređaja, uključite "Automatsku sinkronizaciju podataka" u postavkama računa na Androidu.</translation>
+<translation id="5157964048453367290">Ovdje će se prikazati kartice koje ste otvorili u Braveu na svojim ostalim uređajima.</translation>
+<translation id="4684427112815847243">Sinkroniziraj sve</translation>
+<translation id="2709516037105925701">Automatsko popunjavanje</translation>
+<translation id="8820817407110198400">Knjižne oznake</translation>
+<translation id="1644574205037202324">Povijest</translation>
+<translation id="17513872634828108">Otvorene kartice</translation>
+<translation id="1320169905922104972">Kreditne kartice i adrese s Brave Software Paya</translation>
+<translation id="6337234675334993532">Enkripcija</translation>
+<translation id="6698801883190606802">Upravljanje sinkroniziranim podacima</translation>
+<translation id="3598578758776312506">Kriptiraj zaporke Brave Softwareovim vjerodajnicama</translation>
+<translation id="7810580217418711046">Kriptiraj sinkronizirane podatke pomoću Brave Softwareove zaporke od <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Kriptiraj sinkronizirane podatke vlastitom šifrom za sinkronizaciju</translation>
+<translation id="2996291259634659425">Stvaranje zaporke</translation>
+<translation id="5713644099811900409">Brave Software Račun</translation>
+<translation id="8997474919031554666">Enkripcija šifrom ne uključuje podatke o načinima plaćanja i adresama s Brave Software Paya. Samo osoba koja ima vašu šifru može čitati vaše kriptirane podatke. Šifra se ne šalje Brave Softwareu niti se na njemu pohranjuje. Ako zaboravite šifru ili želite promijeniti tu postavku, morate poništiti sinkronizaciju. <ph name="BEGIN_LINK"/>Saznajte više<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Zaporka</translation>
+<translation id="7772032839648071052">Potvrdi zaporku</translation>
+<translation id="5304593522240415983">To polje ne može biti prazno</translation>
+<translation id="321773570071367578">Ako ste zaboravili šifru ili želite promijeniti tu postavku, <ph name="BEGIN_LINK"/>poništite sinkronizaciju<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Zaporke se ne podudaraju</translation>
+<translation id="5149495116300586333">Enkripcija šifrom ne uključuje načine plaćanja i adrese s Brave Software Paya.
+
+Da biste promijenili tu postavku, <ph name="BEGIN_LINK"/>poništite sinkronizaciju<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Pogrešna zaporka</translation>
+<translation id="5414836363063783498">Potvrđivanje…</translation>
+<translation id="6846298663435243399">Učitavanje…</translation>
+<translation id="5517095782334947753">Imate oznake, povijest, zaporke i druge postavke s računa <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Kombiniranje podataka</translation>
+<translation id="688738109438487280">Dodavanje postojećih podataka na račun <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Moje podatke čuvaj zasebno</translation>
+<translation id="1145536944570833626">Brisanje postojećih podataka.</translation>
+<translation id="1993768208584545658">Web-lokacija <ph name="SITE"/> želi se upariti</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Potražite pomoć<ph name="END_LINK"/> tijekom traženja uređaja…</translation>
+<translation id="5817918615728894473">Upari</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Potražite pomoć<ph name="END_LINK1"/> ili <ph name="BEGIN_LINK2"/>pretražite ponovo<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Nije pronađen nijedan kompatibilni uređaj</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Uključite Bluetooth<ph name="END_LINK"/> da biste omogućili uparivanje</translation>
+<translation id="998321811308652668">Brave ne može uključiti Bluetooth adapter</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Potražite pomoć<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave treba pristup lokaciji kako bi skenirao uređaje. <ph name="BEGIN_LINK"/>Ažuriraj dopuštenja<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave treba pristup lokaciji kako bi skenirao uređaje. Pristup lokaciji <ph name="BEGIN_LINK"/>isključen je za ovaj uređaj<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave treba pristup lokaciji kako bi skenirao uređaje. <ph name="BEGIN_LINK1"/>Ažurirajte dopuštenja<ph name="END_LINK1"/>. Pristup lokaciji također je <ph name="BEGIN_LINK2"/>isključen za ovaj uređaj<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Povezani uređaj</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Jačina signala: # crtica}one{Jačina signala: # crtica}few{Jačina signala: # crtice}other{Jačina signala: # crtica}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> želi potražiti Bluetooth uređaje u blizini. Pronađeni su sljedeći uređaji:</translation>
+<translation id="8368027906805972958">Nepoznati ili nepodržani uređaj (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sinkronizacija ne radi</translation>
+<translation id="1810845389119482123">Početno postavljanje sinkronizacije nije dovršeno</translation>
+<translation id="3235722914093408050">U postavkama omogućite sink. sustava Android da se pokrene Brave sinkronizacija</translation>
+<translation id="3367813778245106622">Prijavite se ponovo da biste pokrenuli sinkronizaciju</translation>
+<translation id="974555521953189084">Unesite šifru da biste pokrenuli sinkronizaciju</translation>
+<translation id="2997266899014181325">Da biste pokrenuli sinkronizaciju, uključite postavku "Sinkroniziraj podatke s Bravea".</translation>
+<translation id="8260126382462817229">Ponovo se pokušajte prijaviti</translation>
+<translation id="5919204609460789179">Ažurirajte <ph name="PRODUCT_NAME"/> za pokretanje sinkronizacije</translation>
+<translation id="397583555483684758">Sinkronizacija je prekinuta</translation>
+<translation id="1966710179511230534">Ažurirajte pojedinosti prijave.</translation>
+<translation id="7063006564040364415">Nije uspjelo povezivanje s poslužiteljem za sinkronizaciju.</translation>
+<translation id="7942131818088350342">Proizvod <ph name="PRODUCT_NAME"/> zastario je.</translation>
+<translation id="4170011742729630528">Usluga nije dostupna, pokušajte ponovo kasnije.</translation>
+<translation id="7947953824732555851">Prihv. i prijavi se</translation>
+<translation id="8583805026567836021">Brisanje podataka računa</translation>
+<translation id="8310344678080805313">Standardne kartice</translation>
+<translation id="5748802427693696783">Prešli ste na standardne kartice</translation>
+<translation id="7998918019931843664">Ponovno otvaranje zatvorene kartice</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, kartica</translation>
+<translation id="4452411734226507615">Zatvori karticu <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opcije dostupne pri dnu zaslona</translation>
+<translation id="4060598801229743805">Opcije su dostupne pri vrhu zaslona</translation>
+<translation id="2810645512293415242">Pojednostavljena stranica štedi podatke i učitava se brže.</translation>
+<translation id="3985215325736559418">Želite li ponovo preuzeti datoteku <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Želite li ponovo pokrenuti preuzimanje datoteke <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Preuzmi</translation>
+<translation id="545042621069398927">Ubrzavanje preuzimanja.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Preuzima se datoteka.}one{Preuzima se # datoteka.}few{Preuzimaju se # datoteke.}other{Preuzima se # datoteka.}}</translation>
+<translation id="543509235395288790">Preuzimanje ovoliko datoteka: <ph name="COUNT"/> (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Preuzimanje datoteke (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 preuzimanje dovršeno.}one{# preuzimanje dovršeno.}few{# preuzimanja dovršena.}other{# preuzimanja dovršeno.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 preuzimanje nije uspjelo.}one{# preuzimanje nije uspjelo.}few{# preuzimanja nisu uspjela.}other{# preuzimanja nije uspjelo.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 preuzimanje na čekanju.}one{# preuzimanje na čekanju.}few{# preuzimanja na čekanju.}other{# preuzimanja na čekanju.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Gumb <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Još samo malo!</translation>
+<translation id="3960299545138990065">Ponovo pokrenite Brave</translation>
+<translation id="3771001275138982843">Preuzimanje ažuriranja nije uspjelo</translation>
+<translation id="3888648114124182147">Preuzimanje ažuriranja Bravea…</translation>
+<translation id="1705567146636171298">Ažuriraj Brave</translation>
+<translation id="6195417478702700398">Za najbolji doživljaj pregledavanja otvorite Brave da bi se ažurirao</translation>
+<translation id="3512968675351418494">Za prikaz weba na vašem jeziku preuzmite najnoviju verziju Bravea</translation>
+<translation id="6427112570124116297">Prijevod weba</translation>
+<translation id="1379423114029199501">Ažurirajte Brave na najnoviju verziju za prikaz na vašem jeziku</translation>
+<translation id="5684874026226664614">Ups. Stranicu nije bilo moguće prevesti.</translation>
+<translation id="6831043979455480757">Prevedi</translation>
+<translation id="1285320974508926690">Nikad nemoj prevoditi ovu web-lokaciju</translation>
+<translation id="773466115871691567">Uvijek prevodi <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nikad ne prevodi <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Više jezika</translation>
+<translation id="290376772003165898">Ovo nije <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Odsada će se <ph name="SOURCE_LANGUAGE"/> prevoditi na <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Neće se prevoditi <ph name="LANGUAGE"/></translation>
+<translation id="5447765697759493033">Ova web-stranica neće biti prevedena</translation>
+<translation id="4880127995492972015">Prevedi…</translation>
+<translation id="641643625718530986">Ispis…</translation>
+<translation id="8909135823018751308">Dijeljenje…</translation>
+<translation id="4996978546172906250">Dijeli putem</translation>
+<translation id="6333140779060797560">Dijeljenje putem aplikacije <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Pojavio se problem prilikom ispisivanja stranice. Pokušajte ponovo.</translation>
+<translation id="3254409185687681395">Označi ovu stranicu</translation>
+<translation id="497421865427891073">Idi naprijed</translation>
+<translation id="813082847718468539">Prikaz informacija o web-mjestu</translation>
+<translation id="2532336938189706096">Web-prikaz</translation>
+<translation id="6005538289190791541">Predložena zaporka</translation>
+<translation id="4634124774493850572">Upotrijebi zaporku</translation>
+<translation id="8285489906452138776">Brave treba dopuštenje za pristup fotoaparatu za ovu web-lokaciju.</translation>
+<translation id="320189792589364011">Brave treba dopuštenje za pristup mikrofonu za ovu web-lokaciju.</translation>
+<translation id="7988136689212463100">Brave treba dopuštenje za pristup fotoaparatu i mikrofonu za ovu web-lokaciju.</translation>
+<translation id="4931190655840828017">Brave treba dopuštenje za pristup vašoj lokaciji da bi je podijelio s ovom web-lokacijom.</translation>
+<translation id="3088191967551450609">Brave treba pristup pohrani radi preuzimanja datoteka.</translation>
+<translation id="8942627711005830162">Otvori u drugom prozoru</translation>
+<translation id="4195643157523330669">Otvori na novoj kartici</translation>
+<translation id="1100066534610197918">Otvori novu karticu u grupi</translation>
+<translation id="4860895144060829044">Poziv</translation>
+<translation id="6896758677409633944">Kopiraj</translation>
+<translation id="8393700583063109961">Pošaljite poruku</translation>
+<translation id="3557336313807607643">Dodaj u kontakte</translation>
+<translation id="4269820728363426813">Kopiraj adresu veze</translation>
+<translation id="1206892813135768548">Kopiraj tekst veze</translation>
+<translation id="1204037785786432551">Preuzmi vezu</translation>
+<translation id="6864459304226931083">Preuzmi sliku</translation>
+<translation id="8209050860603202033">Otvori sliku</translation>
+<translation id="8073388330009372546">Otvori sliku u novoj kartici</translation>
+<translation id="6649642165559792194">Pregled slike <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Učitaj sliku</translation>
+<translation id="3845332215609790146">Pretraži pomoću Brave Software objektiva <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Potraži sliku na usluzi <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Dijeli sliku</translation>
+<translation id="5833984609253377421">Dijeli vezu</translation>
+<translation id="6475951671322991020">Preuzmi videozapis</translation>
+<translation id="2317945146070194624">Otvori u novoj Brave kartici</translation>
+<translation id="7975379999046275268">Pregled stranice <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Osvježavanje stranice</translation>
+<translation id="36525718899759834">Preuzmite aplikaciju iz Trgovine Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tamno</translation>
+<translation id="1807246157184219062">Svijetlo</translation>
+<translation id="4056223980640387499">Sepija</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Ravnomjerno raspoređeno</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Odaberite karticu za emitiranje</translation>
+<translation id="8719023831149562936">Trenutačnu karticu nije moguće emitirati</translation>
+<translation id="2139186145475833000">Dodaj na početni zaslon</translation>
+<translation id="4616150815774728855">Otvori <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Otvaranje aplikacije nije uspjelo</translation>
+<translation id="5129038482087801250">Instaliraj web-aplikaciju</translation>
+<translation id="3789841737615482174">Instaliraj</translation>
+<translation id="4665282149850138822">Web-lokacija <ph name="NAME"/> dodana je na početni zaslon</translation>
+<translation id="7333031090786104871">I dalje se dodaje prethodna web-lokacija</translation>
+<translation id="1036727731225946849">Dodavanje stavke <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Dodano na početni zaslon</translation>
+<translation id="2146738493024040262">Otvori instant aplikaciju</translation>
+<translation id="7016516562562142042">Dopušteno za trenutačnu tražilicu</translation>
+<translation id="6177111841848151710">Blokirano za trenutačnu tražilicu</translation>
+<translation id="145097072038377568">Isključeno u postavkama Androida</translation>
+<translation id="8007176423574883786">Isključeno za ovaj uređaj</translation>
+<translation id="164269334534774161">Prikazuje se offline kopija stranice od <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Ova offline stranica nastala je <ph name="CREATION_TIME"/> i možda se razlikuje od online verzije.</translation>
+<translation id="8840953339110955557">Ta se stranica možda razlikuje od online verzije.</translation>
+<translation id="6405300764336705484">Sadržaj potječe s domene <ph name="DOMAIN_NAME"/>, a omogućuje ga Brave Software.</translation>
+<translation id="1006017844123154345">Otvori online</translation>
+<translation id="3326636747541519688">Jednostavna stranica koju pruža Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Učitajte izvornu stranicu<ph name="END_LINK"/> s domene <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Ako se to često događa, isprobajte ove <ph name="BEGIN_LINK"/>prijedloge<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Sadržaj je skriven</translation>
+<translation id="3810973564298564668">Upravljaj</translation>
+<translation id="5199929503336119739">Radni profil</translation>
+<translation id="528192093759286357">Povucite od vrha zaslona i dodirnite gumb Natrag da biste zatvorili prikaz na cijelom zaslonu.</translation>
+<translation id="2836148919159985482">Dodirnite gumb Natrag da biste zatvorili prikaz na cijelom zaslonu.</translation>
+<translation id="3967822245660637423">Preuzimanje dovršeno</translation>
+<translation id="2434158240863470628">Preuzimanje je dovršeno: <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Preuzimanje nije uspjelo</translation>
+<translation id="1384959399684842514">Preuzimanje je pauzirano</translation>
+<translation id="1671236975893690980">Preuzimanje na čekanju…</translation>
+<translation id="5561549206367097665">Čekanje na mrežu…</translation>
+<translation id="5864419784173784555">Čekanje na još jedno preuzimanje…</translation>
+<translation id="6461962085415701688">Datoteka se ne može otvoriti</translation>
+<translation id="1178581264944972037">Pauziraj</translation>
+<translation id="8200772114523450471">Nastavi</translation>
+<translation id="1409879593029778104">Preuzimanje datoteke <ph name="FILE_NAME"/> nije uspjelo jer datoteka već postoji.</translation>
+<translation id="3387650086002190359">Preuzimanje datoteke <ph name="FILE_NAME"/> nije uspjelo zbog nepoznate pogreške sustava datoteka.</translation>
+<translation id="6482749332252372425">Preuzimanje datoteke <ph name="FILE_NAME"/> nije uspjelo zbog nedostatka prostora.</translation>
+<translation id="7619072057915878432">Preuzimanje datoteke <ph name="FILE_NAME"/> nije uspjelo zbog kvarova na mreži.</translation>
+<translation id="1477626028522505441">Preuzimanje datoteke <ph name="FILE_NAME"/> nije uspjelo zbog poteškoća s poslužiteljem.</translation>
+<translation id="3692944402865947621">Preuzimanje datoteke <ph name="FILE_NAME"/> nije uspjelo jer lokacija pohrane nije dostupna.</translation>
+<translation id="604996488070107836">Preuzimanje datoteke <ph name="FILE_NAME"/> nije uspjelo zbog nepoznate pogreške.</translation>
+<translation id="6738867403308150051">Preuzimanje...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Preuzeto <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Preuzeto <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Preuzeto <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Preostala je 1 datoteka</translation>
+<translation id="8186512483418048923">Preostalo datoteka: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Preuzeta je <ph name="FILES_DOWNLOADED_ONE"/> datoteka}one{Preuzeta je <ph name="FILES_DOWNLOADED_MANY"/> datoteka}few{Preuzete su <ph name="FILES_DOWNLOADED_MANY"/> datoteke}other{Preuzeto je <ph name="FILES_DOWNLOADED_MANY"/> datoteka}}</translation>
+<translation id="8037750541064988519">Preostalo dana: <ph name="DAYS"/></translation>
+<translation id="8190358571722158785">Još 1 dan</translation>
+<translation id="60923314841986378">Preostalo sati: <ph name="HOURS"/></translation>
+<translation id="510275257476243843">Još 1 sat</translation>
+<translation id="970715775301869095">Preostalo minuta: <ph name="MINUTES"/></translation>
+<translation id="3236059992281584593">Još 1 min</translation>
+<translation id="2777555524387840389">Preostalo sekundi: <ph name="SECONDS"/></translation>
+<translation id="2781151931089541271">Još 1 s</translation>
+<translation id="3303414029551471755">Želite li nastaviti s preuzimanjem sadržaja?</translation>
+<translation id="8617240290563765734">Želite li otvoriti predloženi URL naveden u preuzetom sadržaju?</translation>
+<translation id="1373696734384179344">Nema dovoljno memorije za preuzimanje odabranog sadržaja.</translation>
+<translation id="5271967389191913893">Uređaj ne može otvoriti sadržaj za preuzimanje.</translation>
+<translation id="883806473910249246">Prilikom preuzimanja sadržaja dogodila se pogreška.</translation>
+<translation id="5626134646977739690">Naziv:</translation>
+<translation id="7963646190083259054">Dobavljač:</translation>
+<translation id="3414952576877147120">Veličina:</translation>
+<translation id="7375125077091615385">Vrsta:</translation>
+<translation id="5765780083710877561">Opis:</translation>
+<translation id="4881695831933465202">Otvori</translation>
+<translation id="3542235761944717775">Dostupno: <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB dostupno</translation>
+<translation id="5424588387303617268">Dostupno: <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Upotrebljava se <ph name="SPACE_USED"/> od <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Sve</translation>
+<translation id="4988526792673242964">Stranice</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Slike</translation>
+<translation id="8250920743982581267">Dokumenti</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# datoteka}one{# datoteka}few{# datoteke}other{# datoteka}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# slika}one{# slika}few{# slike}other{# slika}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videozapis}one{# videozapis}few{# videozapisa}other{# videozapisa}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# audiodatoteka}one{# audiodatoteka}few{# audiodatoteke}other{# audiodatoteka}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stranica}one{# stranica}few{# stranice}other{# stranica}}</translation>
+<translation id="5456381639095306749">Preuzmi stranicu</translation>
+<translation id="2394602618534698961">Datoteke koje preuzmete prikazat će se ovdje</translation>
+<translation id="7810647596859435254">Otvori aplikacijom…</translation>
+<translation id="5655963694829536461">Pretražite preuzimanja</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Moje datoteke</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Ovdje će se prikazivati članci koje možete čitati i offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}few{# h}other{# h}}</translation>
+<translation id="5853623416121554550">pauzirano</translation>
+<translation id="8965591936373831584">na čekanju</translation>
+<translation id="2779651927720337254">nije uspjelo</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Upravo sada</translation>
+<translation id="4000212216660919741">Početna stranica offline</translation>
+<translation id="9133397713400217035">Istraživanje izvan mreže</translation>
+<translation id="968900484120156207">Ovdje se prikazuju stranice koje posjećujete</translation>
+<translation id="7882131421121961860">Povijest nije pronađena</translation>
+<translation id="3549657413697417275">Pretraži povijest</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">GG</translation>
+<translation id="724102042129299115">Braveov doživljaj prvog pokretanja</translation>
+<translation id="2700285883409956633">Upotrebom te aplikacije prihvaćate Braveove <ph name="BEGIN_LINK1"/>Uvjete pružanja usluge<ph name="END_LINK1"/> i <ph name="BEGIN_LINK2"/>Obavijest o privatnosti<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Upotrebom ove aplikacije prihvaćate Braveove <ph name="BEGIN_LINK1"/>uvjete pružanja usluge<ph name="END_LINK1"/> i <ph name="BEGIN_LINK2"/>obavijest o privatnosti<ph name="END_LINK2"/> te <ph name="BEGIN_LINK3"/>obavijest o privatnosti za Brave Software račune kojima se upravlja putem Family Linka<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Aplikacija <ph name="APP_NAME"/> otvorit će se u Braveu. Nastavljanjem prihvaćate Braveove <ph name="BEGIN_LINK1"/>Uvjete pružanja usluge<ph name="END_LINK1"/> i <ph name="BEGIN_LINK2"/>Obavijest o privatnosti<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659">Aplikacija <ph name="APP_NAME"/> otvorit će se u Braveu. Nastavljanjem prihvaćate Braveove <ph name="BEGIN_LINK1"/>Uvjete pružanja usluge<ph name="END_LINK1"/> i <ph name="BEGIN_LINK2"/>Obavijest o privatnosti<ph name="END_LINK2"/>, kao i <ph name="BEGIN_LINK3"/>Obavijest o privatnosti za Brave Software račune kojima se upravlja putem Family Linka<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Poboljšajte Brave šaljući Brave Softwareu statistike upotrebe i izvješća o rušenju.</translation>
+<translation id="3518985090088779359">Prihvati i nastavi</translation>
+<translation id="7207456302801184289">Dobro došli u Brave</translation>
+<translation id="704822250101715322">Čekanje dovršetka ažuriranja Brave Software Play usluga</translation>
+<translation id="1231733316453485619">Želite li uključiti sinkronizaciju?</translation>
+<translation id="5132942445612118989">Sinkronizirajte svoje zaporke, povijest i drugo na svim uređajima</translation>
+<translation id="5736731321935944068">Brave Software može upotrebljavati vašu povijest za prilagodbu Pretraživanja, oglasa i drugih Brave Softwareovih usluga</translation>
+<translation id="4013614219085422040">Brave Software može upotrebljavati vašu povijest za prilagodbu Pretraživanja i drugih Brave Softwareovih usluga</translation>
+<translation id="5581519193887989363">Uvijek možete odabrati u <ph name="BEGIN_LINK1"/>postavkama<ph name="END_LINK1"/> što će se sinkronizirati.</translation>
+<translation id="741204030948306876">Da, u redu</translation>
+<translation id="2410754283952462441">Odabir računa</translation>
+<translation id="2227444325776770048">Nastavite kao <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Niste <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Da bi se vaše oznake prikazale na svim vašim uređajima, uključite sinkronizaciju</translation>
+<translation id="2818669890320396765">Da bi se vaše oznake prikazale na svim vašim uređajima, prijavite se i uključite sinkronizaciju</translation>
+<translation id="6003646045106347985">Uključite sinkronizaciju ako želite da vam Brave Software predlaže prilagođene sadržaje</translation>
+<translation id="8494430740943879273">Prijavite se i uključite sinkronizaciju ako želite da vam Brave Software predlaže prilagođene sadržaje</translation>
+<translation id="5862731021271217234">Da bi se prikazale kartice s vaših ostalih uređaja, uključite sinkronizaciju</translation>
+<translation id="3568688522516854065">Da bi se prikazale kartice s vaših ostalih uređaja, prijavite se i uključite sinkronizaciju</translation>
+<translation id="1208340532756947324">Da biste sinkronizirali i prilagodili više uređaja, uključite sinkronizaciju</translation>
+<translation id="4472118726404937099">Ako želite sinkronizirati i prilagoditi više uređaja, prijavite se i uključite sinkronizaciju</translation>
+<translation id="2426805022920575512">Odaberi drugi račun</translation>
+<translation id="6790428901817661496">Reproduciraj</translation>
+<translation id="1272079795634619415">Zaustavi</translation>
+<translation id="2874939134665556319">Prethodna pjesma</translation>
+<translation id="4046123991198612571">Sljedeća pjesma</translation>
+<translation id="3859306556332390985">Traži unaprijed</translation>
+<translation id="8441146129660941386">Traži unatrag</translation>
+<translation id="6706288973712894588">Trenutačno ste offline.\n<ph name="BEGIN_LINK"/>Istražite svoj offline feed.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Nedavne kartice</translation>
+<translation id="8497726226069778601">Ovdje nema ničega... zasad</translation>
+<translation id="5423934151118863508">Najposjećenije stranice prikazivat će se ovdje</translation>
+<translation id="6127379762771434464">Stavka je uklonjena</translation>
+<translation id="4605958867780575332">Stavka je uklonjena: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Softwareov doodle logotip: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Ostali uređaji</translation>
+<translation id="4738836084190194332">Posljednja sinkronizacija: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{prije # minute}one{prije # minute}few{prije # minute}other{prije # minuta}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{prije # sata}one{prije # sata}few{prije # sata}other{prije # sati}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{prije # dana}one{prije # dana}few{prije # dana}other{prije # dana}}</translation>
+<translation id="2762000892062317888">upravo sada</translation>
+<translation id="1407135791313364759">Otvori sve</translation>
+<translation id="1209206284964581585">Sakrij za sad</translation>
+<translation id="129553762522093515">Nedavno zatvoreno</translation>
+<translation id="8413126021676339697">Pokaži cijelu povijest</translation>
+<translation id="7876243839304621966">Ukloni sve</translation>
+<translation id="8487700953926739672">Dostupno izvanmrežno</translation>
+<translation id="5224771365102442243">S videozapisom</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Saznajte više<ph name="END_LINK"/> o predloženom sadržaju</translation>
+<translation id="7542481630195938534">Prijedlozi se ne mogu dohvatiti</translation>
+<translation id="5013696553129441713">Nema novih prijedloga</translation>
+<translation id="1736419249208073774">Istražite</translation>
+<translation id="7444811645081526538">Više kategorija</translation>
+<translation id="6709133671862442373">Vijesti</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Kupnja</translation>
+<translation id="3912508018559818924">Pronalazimo ono najbolje s weba…</translation>
+<translation id="526421993248218238">Učitavanje stranice nije uspjelo</translation>
+<translation id="614940544461990577">Pokušajte sljedeće:</translation>
+<translation id="3288003805934695103">ponovo učitajte stranicu</translation>
+<translation id="2353636109065292463">Provjera vaše internetske veze</translation>
+<translation id="2858138569776157458">Najpopularnije web-lokacije</translation>
+<translation id="8364299278605033898">Pogledajte popularne web-lokacije</translation>
+<translation id="1171770572613082465">Dodirom na gumb "Najpopularnije web-lokacije" pogledajte popularne web-lokacije</translation>
+<translation id="5233638681132016545">Nova kartica</translation>
+<translation id="4521874409998847950">Objavio <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>omogućio Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Dostupna je novija verzija</translation>
+<translation id="4058091506841967397">Brave nije ažuriran</translation>
+<translation id="6316139424528454185">Verzija Androida nije podržana</translation>
+<translation id="6989267951144302301">Preuzimanje nije moguće</translation>
+<translation id="624789221780392884">Ažuriranje je spremno</translation>
+<translation id="1549000191223877751">Premjesti u drugi prozor</translation>
+<translation id="7481312909269577407">Naprijed</translation>
+<translation id="4084682180776658562">Oznaka</translation>
+<translation id="6437478888915024427">Informacije o stranici</translation>
+<translation id="7180611975245234373">Osvježi</translation>
+<translation id="4913169188695071480">Zaustavi osvježavanje</translation>
+<translation id="1829244130665387512">Traži na stranici</translation>
+<translation id="6593061639179217415">Klasični prikaz</translation>
+<translation id="9063523880881406963">Isključivanje zahtjeva za prikaz klasične web-lokacije</translation>
+<translation id="2038563949887743358">Uključivanje zahtjeva za prikaz klasične web-lokacije</translation>
+<translation id="2433507940547922241">Prikaz</translation>
+<translation id="983192555821071799">Zatvori sve kartice</translation>
+<translation id="1310482092992808703">Grupiraj kartice</translation>
+<translation id="7725024127233776428">Ovdje se prikazuju stranice koje označite</translation>
+<translation id="4404568932422911380">Bez oznaka</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> oznaka}one{<ph name="BOOKMARKS_COUNT_MANY"/> oznaka}few{<ph name="BOOKMARKS_COUNT_MANY"/> oznake}other{<ph name="BOOKMARKS_COUNT_MANY"/> oznaka}}</translation>
+<translation id="3739899004075612870">Označeno u pregledniku <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Označeno</translation>
+<translation id="4452548195519783679">Oznaka dodana u mapu <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Dodavanje oznake nije uspjelo.</translation>
+<translation id="2842985007712546952">Nadređena mapa</translation>
+<translation id="9065203028668620118">Uredi</translation>
+<translation id="4405224443901389797">Premjesti u…</translation>
+<translation id="5170568018924773124">Pokaži u mapi</translation>
+<translation id="8035133914807600019">Nova mapa…</translation>
+<translation id="4532845899244822526">Odabir mape</translation>
+<translation id="6627583120233659107">Uredi mapu</translation>
+<translation id="1197267115302279827">Premjesti oznake</translation>
+<translation id="6963766334940102469">Brisanje oznaka</translation>
+<translation id="4351244548802238354">Zatvori dijaloški okvir</translation>
+<translation id="451872707440238414">Pretraži oznake</translation>
+<translation id="8901170036886848654">Nije pronađena nijedna oznaka</translation>
+<translation id="6404511346730675251">Uredi oznaku</translation>
+<translation id="3894427358181296146">Dodavanje mape</translation>
+<translation id="5327248766486351172">Naziv</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Mapa</translation>
+<translation id="5161254044473106830">Naslov je obavezan</translation>
+<translation id="2996809686854298943">Potreban URL</translation>
+<translation id="2536728043171574184">Prikaz izvanmrežne kopije stranice</translation>
+<translation id="4698034686595694889">Pregledajte offline u aplikaciji <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> i druge web-lokacije</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave će učitati stranicu kad bude spreman}one{Brave će učitati stranice kad bude spreman}few{Brave će učitati stranice kad bude spreman}other{Brave će učitati stranice kad bude spreman}}</translation>
+<translation id="6811034713472274749">Stranica je spremna za prikaz</translation>
+<translation id="4561979708150884304">Niste povezani</translation>
+<translation id="8274165955039650276">Pregled preuzimanja</translation>
+<translation id="2082238445998314030"><ph name="RESULT_NUMBER"/> od <ph name="TOTAL_RESULTS"/> rezultata</translation>
+<translation id="4943872375798546930">Nema rezultata</translation>
+<translation id="981121421437150478">Izvanmrežno</translation>
+<translation id="3298243779924642547">Jednostav.</translation>
+<translation id="393697183122708255">Glasovno pretraživanje nije dostupno</translation>
+<translation id="7191430249889272776">Kartica je otvorena u pozadini.</translation>
+<translation id="8445059357334030806">Otvori u Braveu</translation>
+<translation id="4720023427747327413">Otvori u aplikaciji <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Otvori u pregledniku</translation>
+<translation id="1113597929977215864">Prikaži pojednostavljeni prikaz</translation>
+<translation id="1513352483775369820">Oznake i Brave Software povijest</translation>
+<translation id="4939482511480190003">Pomognite poboljšati Brave. <ph name="BEGIN_LINK"/>Ispunite anketu<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Natrag</translation>
+<translation id="5596627076506792578">Više opcija</translation>
+<translation id="3522247891732774234">Dostupno je ažuriranje. Više opcija</translation>
+<translation id="6773423637732432200">Brave se ne može ažurirati. Više opcija</translation>
+<translation id="3328801116991980348">Informacije o web-lokaciji</translation>
+<translation id="5391532827096253100">Veza s web-lokacijom nije sigurna. Informacije o web-lokaciji</translation>
+<translation id="6206551242102657620">Veza je sigurna. Informacije o web-lokaciji</translation>
+<translation id="6963642900430330478">Ta je stranica opasna. Informacije o web-lokaciji</translation>
+<translation id="9070377983101773829">Pokretanje glasovnog pretraživanja</translation>
+<translation id="8676374126336081632">Brisanje unosa</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> otvorena kartica, dodirnite da biste prešli na drugu karticu}one{<ph name="OPEN_TABS_MANY"/> otvorena kartica, dodirnite da biste prešli na drugu karticu}few{<ph name="OPEN_TABS_MANY"/> otvorene kartice, dodirnite da biste prešli na drugu karticu}other{<ph name="OPEN_TABS_MANY"/> otvorenih kartica, dodirnite da biste prešli na drugu karticu}}</translation>
+<translation id="2369533728426058518">otvorene kartice</translation>
+<translation id="7071521146534760487">Upravljanje računom</translation>
+<translation id="932327136139879170">Početna stranica</translation>
+<translation id="2707726405694321444">Osvježavanje stranice</translation>
+<translation id="2891154217021530873">Zaustavljanje učitavanja stranice</translation>
+<translation id="6710213216561001401">Prethodno</translation>
+<translation id="6659594942844771486">Kartica</translation>
+<translation id="1933845786846280168">Odabrana kartica</translation>
+<translation id="2268044343513325586">Pročišćavanje</translation>
+<translation id="7846076177841592234">Poništi odabir</translation>
+<translation id="7087918508125750058">Odabrano: <ph name="ITEM_COUNT"/>. Opcije su dostupne pri vrhu zaslona</translation>
+<translation id="7250468141469952378">Odabrano: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Dijeljenje 1 odabrane stavke}one{Dijeljenje # odabrane stavke}few{Dijeljenje # odabrane stavke}other{Dijeljenje # odabranih stavki}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Uklanjanje 1 odabrane stavke}one{Uklanjanje # odabrane stavke}few{Uklanjanje # odabranih stavki}other{Uklanjanje # odabranih stavki}}</translation>
+<translation id="1283039547216852943">Dodirnite za proširivanje</translation>
+<translation id="5962718611393537961">Dodirnite da biste saželi</translation>
+<translation id="8076492880354921740">Kartice</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 odabrana stavka}one{# odabrana stavka}few{# odabrane stavke}other{# odabranih stavki}}</translation>
+<translation id="6818926723028410516">Odaberite stavke</translation>
+<translation id="4797039098279997504">Dodirnite da biste se vratili na <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Dodirnite za otvaranje web-lokacije</translation>
+<translation id="429312253194641664">Web-lokacija reproducira medije</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> dijeli vaš zaslon</translation>
+<translation id="8833831881926404480">Web-lokacija dijeli vaš zaslon</translation>
+<translation id="9086455579313502267">Nije moguće pristupiti mreži</translation>
+<translation id="938850635132480979">Pogreška: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Otvori u aplikaciji <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Otvori u aplikaciji za karte</translation>
+<translation id="7698359219371678927">Izradite e-poruku u aplikaciji <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Izradite e-poruku</translation>
+<translation id="5665379678064389456">Stvorite događaj u aplikaciji <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Stvori događaj</translation>
+<translation id="2111511281910874386">Idi na stranicu</translation>
+<translation id="3988466920954086464">Na ovoj ploči pogledajte instant rezultate pretraživanja</translation>
+<translation id="2744248271121720757">Dodirnite riječ da biste je odmah pretražili ili vidjeli povezane radnje</translation>
+<translation id="9155898266292537608">Možete i kratko dodirnuti riječ da biste je pretražili</translation>
+<translation id="3232754137068452469">Web-aplikacija</translation>
+<translation id="1430915738399379752">Ispis</translation>
+<translation id="3775705724665058594">Pošaljite na svoje uređaje</translation>
+<translation id="6364438453358674297">Želite li ukloniti prijedlog iz povijesti?</translation>
+<translation id="213279576345780926">Zatvorena je kartica <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139">Kartice su zatvorene (njih <ph name="TAB_COUNT"/>)</translation>
+<translation id="3211426585530211793">Izbrisano <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">Oznake su izbrisane (<ph name="NUMBER_OF_BOOKMARKS"/>)</translation>
+<translation id="3819178904835489326">Izbrisano preuzimanja: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Nepodržan broj različitih verzija Bravea.</translation>
+<translation id="4259722352634471385">Otvaranje je blokirano: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Otvaranje je nedostupno: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Zatvori karticu</translation>
+<translation id="7772375229873196092">Zatvori aplikaciju <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Povijest navigacije</translation>
+<translation id="9169507124922466868">Povijest navigacije je poluotvorena</translation>
+<translation id="1327257854815634930">Otvorena je povijest navigacije</translation>
+<translation id="8788265440806329501">Zatvorena je povijest navigacije</translation>
+<translation id="7482656565088326534">Kartica pregleda</translation>
+<translation id="8427875596167638501">Kartica pregleda je poluotvorena</translation>
+<translation id="9102803872260866941">Kartica pregleda je otvorena</translation>
+<translation id="2942036813789421260">Kartica pregleda je zatvorena</translation>
+<translation id="6355102470683871794">Pohrana aplikacije Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Izbrisati pohranu?</translation>
+<translation id="9205995714227143200">Pohrana web-lokacije koju Brave ne smatra važnom (primjerice web-lokacije koje nemaju spremljene postavke ili koje ne posjećujete često)</translation>
+<translation id="3997476611815694295">Nevažna pohrana</translation>
+<translation id="8493948351860045254">Oslobodi prostor</translation>
+<translation id="2324920234469020158">Time će se izbrisati kolačići, predmemorija i ostali podaci o web-lokacijama koje Brave ne smatra važnima.</translation>
+<translation id="5447201525962359567">Cijela pohrana web-lokacije, uključujući kolačiće i druge lokalno pohranjene podatke</translation>
+<translation id="1376578503827013741">Izračunavanje…</translation>
+<translation id="583281660410589416">Nepoznato</translation>
+<translation id="2323763861024343754">Pohrana web-lokacije</translation>
+<translation id="3587672679800759167">Ukupna količina podataka koju Brave upotrebljava, uključujući račune, oznake i spremljene postavke.</translation>
+<translation id="6545017243486555795">Izbriši sve podatke</translation>
+<translation id="4095146165863963773">Želite li izbrisati podatke aplikacije?</translation>
+<translation id="53119194224775367">Svi Braveovi podaci aplikacije trajno će se izbrisati. To uključuje sve datoteke, postavke, račune, baze podataka i slično.</translation>
+<translation id="5307446750509046227">Izbriši pohranu</translation>
+<translation id="300526633675317032">Time će se izbrisati cijela pohrana web-lokacije veličine <ph name="SIZE_IN_KB"/>.</translation>
+<translation id="8068648041423924542">Ne može se odabrati certifikat.</translation>
+<translation id="2315043854645842844">Operativni sustav ne podržava odabir klijentskog certifikata.</translation>
+<translation id="5011311129201317034">Web-lokacija <ph name="SITE"/> želi se povezati</translation>
+<translation id="5308380583665731573">Povežite se</translation>
+<translation id="868929229000858085">Pretraživanje kontakata</translation>
+<translation id="1919950603503897840">Odabir kontakata</translation>
+<translation id="7986741934819883144">Odaberite kontakt</translation>
+<translation id="3333961966071413176">Svi kontakti</translation>
+<translation id="4994033804516042629">Nije pronađen nijedan kontakt</translation>
+<translation id="5403592356182871684">Nazivi</translation>
+<translation id="2717722538473713889">E-adrese</translation>
+<translation id="381841723434055211">Telefonski brojevi</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ još 1)}one{(+ još #)}few{(+ još #)}other{(+ još #)}}</translation>
+<translation id="5197729504361054390">Kontakti koje odaberete podijelit će se s web-lokacijom <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Dekodiranje slika</translation>
+<translation id="8067883171444229417">Reproduciraj videozapis</translation>
+<translation id="6560414384669816528">Pretražujte na usluzi Sogou</translation>
+<translation id="5406914950576900927">Brave za pretraživanje u Kini može upotrebljavati <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>. To možete promijeniti u <ph name="BEGIN_LINK"/>postavkama<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Zadrži Brave Software</translation>
+<translation id="4384468725000734951">Za pretraživanje se upotrebljava Sogou</translation>
+<translation id="6103327872225198548">Za pretraživanje se upotrebljava Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Ova se aplikacija izvodi u Braveu</translation>
+<translation id="6143689084714664628">Pokrenuto u Braveu</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> ima podatke i u Braveu</translation>
+<translation id="2734140769649165081">Podatke možete izbrisati u postavkama Bravea</translation>
+<translation id="8232956427053453090">Zadrži podatke</translation>
+<translation id="4298388696830689168">Povezane web-lokacije</translation>
+<translation id="5763514718066511291">Dodirnite da biste kopirali URL za tu aplikaciju</translation>
+<translation id="6496823230996795692">Za prvu upotrebu aplikacije <ph name="APP_NAME"/> povežite se s internetom.</translation>
+<translation id="751961395872307827">Povezivanje s web-lokacijom nije uspjelo</translation>
+<translation id="4878404682131129617">Uspostava tunela putem proxy poslužitelja nije uspjela</translation>
+<translation id="4749960740855309258">Otvaranje nove kartice</translation>
+<translation id="8788968922598763114">Ponovno otvaranje posljednje zatvorene kartice</translation>
+<translation id="7929962904089429003">Otvaranje izbornika</translation>
+<translation id="6039379616847168523">Preskakanje na sljedeću karticu</translation>
+<translation id="5210286577605176222">Preskakanje na prethodnu karticu</translation>
+<translation id="124678866338384709">Zatvaranje trenutačne kartice</translation>
+<translation id="3714981814255182093">Otvaranje Trake za traženje</translation>
+<translation id="5441522332038954058">Preskakanje na adresnu traku</translation>
+<translation id="3398320232533725830">Otvaranje upravitelja oznaka</translation>
+<translation id="6583199322650523874">Označavanje trenutačne stranice</translation>
+<translation id="8489271220582375723">Prikaz stranice povijesti</translation>
+<translation id="4837753911714442426">Otvaranje opcija za ispis stranice</translation>
+<translation id="5726692708398506830">Povećavanje svega na stranici</translation>
+<translation id="3259831549858767975">Smanjivanje svega na stranici</translation>
+<translation id="8015452622527143194">Vraćanje svega na stranici na zadanu veličinu</translation>
+<translation id="3443221991560634068">Ponovno učitavanje trenutačne stranice</translation>
+<translation id="123724288017357924">Ponovno učitavanje trenutačne stranice uz zanemarivanje sadržaja iz predmemorije</translation>
+<translation id="305870044889644984">Otvaranje Braveovog centra za pomoć na novoj kartici</translation>
+<translation id="3166827708714933426">Prečaci kartica i prozora</translation>
+<translation id="3169981355900570544">Prečaci za značajke Brave Software Bravea</translation>
+<translation id="4558311620361989323">Prečaci web-stranice</translation>
+<translation id="1908301351964700579">Brave se još priprema za VR. Ponovo pokrenite Brave kasnije.</translation>
+<translation id="8970887620466824814">Nešto nije u redu.</translation>
+<translation id="1875543012935658554">Ponovo otvorite Brave.</translation>
+<translation id="79859296434321399">Za prikaz sadržaja proširene stvarnosti instalirajte ARCore</translation>
+<translation id="8558485628462305855">Za prikaz sadržaja proširene stvarnosti ažurirajte ARCore</translation>
+<translation id="3513704683820682405">Proširena stvarnost</translation>
+<translation id="5475862044948910901">Želite li pokrenuti sesiju proširene stvarnosti?</translation>
 <translation id="7365126855094612066">Za vrijeme trajanja sesije web-lokacija moći će sljedeće:
 • izraditi 3D kartu vašeg okruženja
 • pratiti kretanje fotoaparata.
 
 Web-lokacija NE dobiva pristup fotoaparatu. Slike fotoaparata možete vidjeti samo vi.</translation>
-<translation id="7375125077091615385">Vrsta:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chromeov doživljaj prvog pokretanja</translation>
-<translation id="741204030948306876">Da, u redu</translation>
-<translation id="7413229368719586778">Datum početka: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Prvo pitaj</translation>
-<translation id="7423538860840206698">Blokirano je čitanje međuspremnika</translation>
-<translation id="7431991332293347422">Odredite na koji će se način vaša povijest pregledavanja upotrebljavati za prilagodbu Pretraživanja i drugih značajki</translation>
-<translation id="7437998757836447326">Odjava s Chromea</translation>
-<translation id="7438641746574390233">Kad je omogućen Jednostavni način, Chrome upotrebljava Googleove poslužitelje kako bi se stranice brže učitale. Jednostavni način ponovo ispisuje vrlo spore stranice kako bi se učitao samo neophodan sadržaj. Jednostavni se način ne primjenjuje na anonimne stranice.</translation>
-<translation id="7444811645081526538">Više kategorija</translation>
-<translation id="7445411102860286510">Web-lokacije mogu automatski reproducirati zanemarene videozapise (preporučeno)</translation>
-<translation id="7453467225369441013">Odjavit ćete se s većine web-lokacija, ali se nećete odjaviti s Google računa.</translation>
-<translation id="7454641608352164238">Nema dovoljno prostora</translation>
-<translation id="7475192538862203634">Ako se to često događa, isprobajte ove <ph name="BEGIN_LINK" />prijedloge<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD kartica nije pronađena. Neke od vaših datoteka možda nedostaju.</translation>
-<translation id="7479104141328977413">Upravljanje karticama</translation>
-<translation id="7481312909269577407">Naprijed</translation>
-<translation id="7482656565088326534">Kartica pregleda</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (ažurirano <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">spremljeni podaci</translation>
-<translation id="7498271377022651285">Pričekajte…</translation>
-<translation id="7514365320538308">Preuzmi</translation>
-<translation id="751961395872307827">Povezivanje s web-lokacijom nije uspjelo</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Prijedlozi se ne mogu dohvatiti</translation>
-<translation id="7559975015014302720">Jednostavni je način isključen</translation>
-<translation id="7562080006725997899">Brisanje podataka o pregledavanju</translation>
-<translation id="756809126120519699">Chromeovi su podaci izbrisani</translation>
-<translation id="757524316907819857">Web-lokacijama nije dopušteno reproduciranje zaštićenog sadržaja</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Preuzeta je <ph name="FILES_DOWNLOADED_ONE" /> datoteka}one{Preuzeta je <ph name="FILES_DOWNLOADED_MANY" /> datoteka}few{Preuzete su <ph name="FILES_DOWNLOADED_MANY" /> datoteke}other{Preuzeto je <ph name="FILES_DOWNLOADED_MANY" /> datoteka}}</translation>
-<translation id="7588219262685291874">Uključi tamnu temu kada je uključena Štednja baterije na uređaju</translation>
-<translation id="7589445247086920869">Blokiraj za trenutačnu tražilicu</translation>
-<translation id="7593557518625677601">U postavkama omogućite sink. sustava Android da se pokrene Chrome sinkronizacija</translation>
-<translation id="7596558890252710462">Operativni sustav</translation>
-<translation id="7605594153474022051">Sinkronizacija ne radi</translation>
-<translation id="7606077192958116810">Jednostavni je način uključen. Upravljajte njime u postavkama.</translation>
-<translation id="7612619742409846846">Prijavljeni ste na Google kao</translation>
-<translation id="7619072057915878432">Preuzimanje datoteke <ph name="FILE_NAME" /> nije uspjelo zbog kvarova na mreži.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Potražite pomoć<ph name="END_LINK1" /> ili <ph name="BEGIN_LINK2" />pretražite ponovo<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Dobro došli u Chrome</translation>
-<translation id="7638584964844754484">Pogrešna zaporka</translation>
-<translation id="7641339528570811325">Izbriši podatke o pregledavanju…</translation>
-<translation id="7648422057306047504">Kriptiraj zaporke Googleovim vjerodajnicama</translation>
-<translation id="7649070708921625228">Pomoć</translation>
-<translation id="7658239707568436148">Odustani</translation>
-<translation id="7665369617277396874">Dodaj račun</translation>
-<translation id="766587987807204883">Ovdje će se prikazivati članci koje možete čitati i offline</translation>
-<translation id="7682724950699840886">Pokušajte napraviti sljedeće: provjerite ima li dovoljno prostora na uređaju i pokušajte ponoviti izvoz.</translation>
-<translation id="7685301384041462804">Prije pokretanja VR-a provjerite je li riječ o pouzdanoj web-lokaciji.</translation>
-<translation id="7698359219371678927">Izradite e-poruku u aplikaciji <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Samodovršavanje pretraživanja i URL-ova</translation>
-<translation id="7725024127233776428">Ovdje se prikazuju stranice koje označite</translation>
-<translation id="773466115871691567">Uvijek prevodi <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Radi otkrivanja opasnih aplikacija i web-lokacija Chrome šalje Googleu URL-ove nekih stranica koje posjećujete, ograničene podatke o sustavu i dio sadržaja web-stranica</translation>
-<translation id="7757787379047923882">Tekst dijeljen s uređaja <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD kartica <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Dodaj adresu</translation>
-<translation id="7772032839648071052">Potvrdi zaporku</translation>
-<translation id="7772375229873196092">Zatvori aplikaciju <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}few{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i još <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Danas</translation>
-<translation id="7791543448312431591">Dodaj</translation>
-<translation id="780301667611848630">Ne, hvala</translation>
-<translation id="7810647596859435254">Otvori aplikacijom…</translation>
-<translation id="7821588508402923572">Ovdje će se prikazati vaša ušteda podataka</translation>
-<translation id="7837721118676387834">Dopustite automatsku reprodukciju videozapisa s isključenim tonom za određenu web-lokaciju.</translation>
-<translation id="7846076177841592234">Poništi odabir</translation>
-<translation id="784934925303690534">Vremenski raspon</translation>
-<translation id="7851858861565204677">Ostali uređaji</translation>
-<translation id="7875915731392087153">Izradite e-poruku</translation>
-<translation id="7876243839304621966">Ukloni sve</translation>
-<translation id="7882131421121961860">Povijest nije pronađena</translation>
-<translation id="7882806643839505685">Dopuštanje zvuka za određenu web-lokaciju.</translation>
-<translation id="7886917304091689118">Pokrenuto u Chromeu</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Preuzima se datoteka.}one{Preuzima se # datoteka.}few{Preuzimaju se # datoteke.}other{Preuzima se # datoteka.}}</translation>
-<translation id="7929962904089429003">Otvaranje izbornika</translation>
-<translation id="7942131818088350342">Proizvod <ph name="PRODUCT_NAME" /> zastario je.</translation>
-<translation id="7947953824732555851">Prihv. i prijavi se</translation>
-<translation id="7963646190083259054">Dobavljač:</translation>
-<translation id="7971136598759319605">Aktivan prije jednog dana</translation>
-<translation id="7975379999046275268">Pregled stranice <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Prethodno učitaj stranice za brže pregledavanje i pretraživanje</translation>
-<translation id="79859296434321399">Za prikaz sadržaja proširene stvarnosti instalirajte ARCore</translation>
-<translation id="7986741934819883144">Odaberite kontakt</translation>
-<translation id="7987073022710626672">Chromeovi uvjeti pružanja usluge</translation>
-<translation id="7998918019931843664">Ponovno otvaranje zatvorene kartice</translation>
-<translation id="7999064672810608036">Jeste li sigurni da želite izbrisati sve lokalne podatke, uključujući kolačiće, i poništiti sva dopuštenja za ovu web-lokaciju?</translation>
-<translation id="8004582292198964060">Preglednik</translation>
-<translation id="8007176423574883786">Isključeno za ovaj uređaj</translation>
-<translation id="8013372441983637696">Izbriši podatke iz Chromea i s ovog uređaja</translation>
-<translation id="8015452622527143194">Vraćanje svega na stranici na zadanu veličinu</translation>
-<translation id="802154636333426148">Preuzimanje nije uspjelo</translation>
-<translation id="8026334261755873520">Brisanje podataka o pregledavanju</translation>
-<translation id="8035133914807600019">Nova mapa…</translation>
-<translation id="8037750541064988519">Preostalo dana: <ph name="DAYS" /></translation>
-<translation id="804335162455518893">SD kartica nije pronađena</translation>
-<translation id="805047784848435650">Na temelju vaše povijesti pregledavanja</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB dostupno</translation>
-<translation id="8058746566562539958">Otvori u novoj Chrome kartici</translation>
-<translation id="8063895661287329888">Dodavanje oznake nije uspjelo.</translation>
-<translation id="806745655614357130">Moje podatke čuvaj zasebno</translation>
-<translation id="8067883171444229417">Reproduciraj videozapis</translation>
-<translation id="8068648041423924542">Ne može se odabrati certifikat.</translation>
-<translation id="8073388330009372546">Otvori sliku u novoj kartici</translation>
-<translation id="8076492880354921740">Kartice</translation>
-<translation id="8084114998886531721">Spremljena zaporka</translation>
-<translation id="8087000398470557479">Sadržaj potječe s domene <ph name="DOMAIN_NAME" />, a omogućuje ga Google.</translation>
-<translation id="8103578431304235997">Anonimna kartica</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Da bi se vaše oznake prikazale na svim vašim uređajima, uključite sinkronizaciju</translation>
-<translation id="8110087112193408731">Želite li da se vaša aktivnost u Chromeu prikazuje u Digitalnoj ravnoteži?</translation>
-<translation id="8116925261070264013">Bez zvuka</translation>
-<translation id="813082847718468539">Prikaz informacija o web-mjestu</translation>
-<translation id="8131740175452115882">Potvrdi</translation>
-<translation id="8156139159503939589">Koje jezike znate čitati?</translation>
-<translation id="8168435359814927499">Sadržaj</translation>
-<translation id="8186512483418048923">Preostalo datoteka: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Još 1 dan</translation>
-<translation id="8200772114523450471">Nastavi</translation>
-<translation id="8209050860603202033">Otvori sliku</translation>
-<translation id="8218622182176210845">Upravljanje računom</translation>
-<translation id="8224471946457685718">Preuzimaj članke putem Wi-Fija</translation>
-<translation id="8232956427053453090">Zadrži podatke</translation>
-<translation id="8249310407154411074">Na vrh</translation>
-<translation id="8250920743982581267">Dokumenti</translation>
-<translation id="825412236959742607">Ova stranica upotrebljava previše memorije, pa je Chrome uklonio dio sadržaja.</translation>
-<translation id="8260126382462817229">Ponovo se pokušajte prijaviti</translation>
-<translation id="8261506727792406068">Izbriši</translation>
-<translation id="8266862848225348053">Lokacija za preuzimanje</translation>
-<translation id="8274165955039650276">Pregled preuzimanja</translation>
-<translation id="8284326494547611709">Titlovi</translation>
-<translation id="8300705686683892304">Upravlja aplikacija</translation>
-<translation id="8310344678080805313">Standardne kartice</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> i druge web-lokacije</translation>
-<translation id="8327155640814342956">Za najbolji doživljaj pregledavanja otvorite Chrome da bi se ažurirao</translation>
-<translation id="8339163506404995330">Neće se prevoditi <ph name="LANGUAGE" /></translation>
-<translation id="8349013245300336738">Poredaj po količini potrošenih podataka</translation>
-<translation id="8364299278605033898">Pogledajte popularne web-lokacije</translation>
-<translation id="8368027906805972958">Nepoznati ili nepodržani uređaj (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Omogućuje sinkronizaciju u pozadini za određenu web-lokaciju.</translation>
-<translation id="8378714024927312812">Pod upravljanjem vaše organizacije</translation>
-<translation id="8380167699614421159">Ova web-lokacija prikazuje ometajuće ili obmanjujuće oglase</translation>
-<translation id="8393700583063109961">Pošaljite poruku</translation>
-<translation id="8413126021676339697">Pokaži cijelu povijest</translation>
-<translation id="8427875596167638501">Kartica pregleda je poluotvorena</translation>
-<translation id="8428213095426709021">Postavke</translation>
-<translation id="8438566539970814960">Poboljšajte pretraživanje i pregledavanje</translation>
-<translation id="8441146129660941386">Traži unatrag</translation>
-<translation id="8443209985646068659">Chrome nije ažuriran</translation>
-<translation id="8445448999790540984">Izvoz zaporki nije moguć</translation>
-<translation id="8447861592752582886">Opozovi odobrenje uređaja</translation>
-<translation id="8461694314515752532">Kriptiraj sinkronizirane podatke vlastitom šifrom za sinkronizaciju</translation>
-<translation id="8466613982764129868">Provjerite je li <ph name="TARGET_DEVICE_NAME" /> povezan s internetom</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Dostupno izvanmrežno</translation>
-<translation id="8489271220582375723">Prikaz stranice povijesti</translation>
-<translation id="8493948351860045254">Oslobodi prostor</translation>
-<translation id="8497726226069778601">Ovdje nema ničega... zasad</translation>
-<translation id="8503559462189395349">Zaporke preglednika Chrome</translation>
-<translation id="8503813439785031346">Korisničko ime</translation>
-<translation id="8514477925623180633">Izvoz zaporki pohranjenih u Chromeu</translation>
-<translation id="8514577642972634246">Ulaz u anonimni način</translation>
-<translation id="851751545965956758">Blokiraj povezivanje web-lokacija s uređajima</translation>
-<translation id="8523928698583292556">Izbriši pohranjenu zaporku</translation>
-<translation id="854522910157234410">Otvori tu stranicu:</translation>
-<translation id="8558485628462305855">Za prikaz sadržaja proširene stvarnosti ažurirajte ARCore</translation>
-<translation id="8559990750235505898">Ponudi prevođenje stranica na druge jezike</translation>
-<translation id="8562452229998620586">Ovdje će se pojaviti spremljene zaporke.</translation>
-<translation id="8569404424186215731">od <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Protekla 4 tjedna</translation>
-<translation id="857943718398505171">Dopušteno (preporučeno)</translation>
-<translation id="8583805026567836021">Brisanje podataka računa</translation>
-<translation id="860043288473659153">Ime vlasnika kartice</translation>
-<translation id="8609465669617005112">Premjesti gore</translation>
-<translation id="8616006591992756292">Na vašem Google računu možda postoje drugi oblici povijesti pregledavanja na stranici <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Želite li otvoriti predloženi URL naveden u preuzetom sadržaju?</translation>
-<translation id="8636825310635137004">Da bi se prikazale kartice s vaših ostalih uređaja, uključite sinkronizaciju.</translation>
-<translation id="8641930654639604085">Pokušaj blokirati web-lokacije za odrasle</translation>
-<translation id="8655129584991699539">Podatke možete izbrisati u postavkama Chromea</translation>
-<translation id="8662811608048051533">Odjavit ćete se s većine web-lokacija.</translation>
-<translation id="8664979001105139458">Već postoji datoteka s tim nazivom</translation>
-<translation id="8676374126336081632">Brisanje unosa</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Jačina signala: # crtica}one{Jačina signala: # crtica}few{Jačina signala: # crtice}other{Jačina signala: # crtica}}</translation>
-<translation id="868929229000858085">Pretraživanje kontakata</translation>
-<translation id="869891660844655955">Datum isteka</translation>
-<translation id="8719023831149562936">Trenutačnu karticu nije moguće emitirati</translation>
-<translation id="8725066075913043281">Pokušajte ponovo</translation>
-<translation id="8728487861892616501">Upotrebom ove aplikacije prihvaćate Chromeove <ph name="BEGIN_LINK1" />uvjete pružanja usluge<ph name="END_LINK1" /> i <ph name="BEGIN_LINK2" />obavijest o privatnosti<ph name="END_LINK2" /> te <ph name="BEGIN_LINK3" />obavijest o privatnosti za Google račune kojima se upravlja putem Family Linka<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Gotovo</translation>
-<translation id="8748850008226585750">Sadržaj je skriven</translation>
-<translation id="8751914237388039244">Odaberite sliku</translation>
-<translation id="8788265440806329501">Zatvorena je povijest navigacije</translation>
-<translation id="8788968922598763114">Ponovno otvaranje posljednje zatvorene kartice</translation>
-<translation id="8801436777607969138">Blokiranje JavaScripta za određenu web-lokaciju.</translation>
-<translation id="8812260976093120287">Na nekim web-lokacijama možete plaćati pomoću podržanih aplikacija za plaćanje na uređaju.</translation>
-<translation id="8816026460808729765">Blokiranje pristupa senzorima za web-lokacije</translation>
-<translation id="8816439037877937734">Aplikacija <ph name="APP_NAME" /> otvorit će se u Chromeu. Nastavljanjem prihvaćate Chromeove <ph name="BEGIN_LINK1" />Uvjete pružanja usluge<ph name="END_LINK1" /> i <ph name="BEGIN_LINK2" />Obavijest o privatnosti<ph name="END_LINK2" />, kao i <ph name="BEGIN_LINK3" />Obavijest o privatnosti za Google račune kojima se upravlja putem Family Linka<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Knjižne oznake</translation>
-<translation id="8833831881926404480">Web-lokacija dijeli vaš zaslon</translation>
-<translation id="883806473910249246">Prilikom preuzimanja sadržaja dogodila se pogreška.</translation>
-<translation id="8840953339110955557">Ta se stranica možda razlikuje od online verzije.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, kartica</translation>
-<translation id="885701979325669005">Prostor za pohranu</translation>
-<translation id="889338405075704026">Otvorite Chromeove postavke</translation>
-<translation id="8901170036886848654">Nije pronađena nijedna oznaka</translation>
-<translation id="8909135823018751308">Dijeljenje…</translation>
-<translation id="8912362522468806198">Google Račun</translation>
-<translation id="8920114477895755567">Čekaju se pojedinosti o nadređenim jedinicama.</translation>
+<translation id="1188239144602654184">Pokreni AR</translation>
+<translation id="473775607612524610">Ažuriraj</translation>
+<translation id="3133489217401741157">Instalira se <ph name="MODULE"/> za Brave…</translation>
+<translation id="1791662854739702043">Instalirano</translation>
+<translation id="5131234170665854056">Instaliranje modula <ph name="MODULE"/> za Brave nije uspjelo</translation>
+<translation id="2567385386134582609">SLIKA</translation>
+<translation id="6395288395575013217">VEZA</translation>
+<translation id="7352939065658542140">VIDEOZAPIS</translation>
+<translation id="4116038641877404294">Preuzmite stranice za izvanmrežnu upotrebu</translation>
 <translation id="8922289737868596582">Preuzmite stranice za izvanmrežnu upotrebu pomoću gumba Više opcija</translation>
-<translation id="8937772741022875483">Želite li ukloniti svoju aktivnost u Chromeu iz Digitalne ravnoteže?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Otvori u drugom prozoru</translation>
-<translation id="8951232171465285730">Chrome vam je uštedio <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokiraj kolačiće za određenu web-lokaciju.</translation>
-<translation id="8959122750345127698">Otvaranje je nedostupno: <ph name="URL" /></translation>
-<translation id="8965591936373831584">na čekanju</translation>
-<translation id="8970887620466824814">Nešto nije u redu.</translation>
-<translation id="8972098258593396643">Želite li preuzeti u zadanu mapu?</translation>
-<translation id="8986494364107987395">Automatski šalji Googleu statistiku o upotrebi i izvješća o padu programa</translation>
-<translation id="8993760627012879038">Otvaranje nove kartice u anonimnom načinu</translation>
-<translation id="8998729206196772491">Prijavljujete se računom kojim upravlja <ph name="MANAGED_DOMAIN" /> i njegovom administratoru dajete kontrolu nad svojim podacima u Chromeu. Vaši će se podaci trajno povezati s tim računom. Ako se odjavite iz Chromea, vaši će se podaci izbrisati s ovog uređaja, no ostat će pohranjeni na vašem Google računu.</translation>
-<translation id="9019902583201351841">Upravljaju tvoji roditelji</translation>
-<translation id="9028914725102941583">Uključite sinkronizaciju da biste dijelili na uređajima</translation>
-<translation id="9029323097866369874">Želite li dopustiti web-lokaciji <ph name="DOMAIN" /> pokretanje VR-a?</translation>
-<translation id="9040142327097499898">Obavijesti su dopuštene. Lokacija je isključena za ovaj uređaj.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videozapis}one{# videozapis}few{# videozapisa}other{# videozapisa}}</translation>
-<translation id="9050666287014529139">Zaporka</translation>
-<translation id="9063523880881406963">Isključivanje zahtjeva za prikaz klasične web-lokacije</translation>
-<translation id="9065203028668620118">Uredi</translation>
-<translation id="9070377983101773829">Pokretanje glasovnog pretraživanja</translation>
-<translation id="9074336505530349563">Prijavite se i uključite sinkronizaciju ako želite da vam Google predlaže prilagođene sadržaje</translation>
-<translation id="9086455579313502267">Nije moguće pristupiti mreži</translation>
-<translation id="9100505651305367705">Mogućnost prikazivanja članaka u pojednostavljenom prikazu kada je to podržano</translation>
-<translation id="9100610230175265781">Potrebna je zaporka</translation>
-<translation id="9102803872260866941">Kartica pregleda je otvorena</translation>
+<translation id="5958275228015807058">Pronađite svoje datoteke i stranice u Preuzimanjima</translation>
+<translation id="5620928963363755975">Pronađite svoje datoteke i stranice u Preuzimanjima pomoću gumba Više opcija</translation>
+<translation id="3341058695485821946">Pogledajte količinu ušteđenih podataka</translation>
+<translation id="3157842584138209013">Pogledajte količinu ušteđenih podataka pomoću gumba Više opcija</translation>
+<translation id="8218622182176210845">Upravljanje računom</translation>
+<translation id="8090895580117672212">Da biste upravljali svojim Brave Software računom, dodirnite gumb "Upravljanje računom"</translation>
+<translation id="8856898588039823173">Jednostavnu stranicu pruža Brave Software. Dodirnite da biste učitali izvornu stranicu.</translation>
+<translation id="8134317863207426198">Jednostavnu stranicu pruža Brave Software. Dodirnite gumb Učitaj izvornu stranicu da biste učitali izvornu stranicu.</translation>
+<translation id="4961107849584082341">Prevedite ovu stranicu na bilo koji jezik</translation>
+<translation id="569536719314091526">Prevedite ovu stranicu na bilo koji jezik pomoću gumba Više opcija</translation>
+<translation id="1397811292916898096">Pretraživanje pomoću usluge <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Zadanu lokaciju preuzimanja možete promijeniti kad god želite</translation>
+<translation id="6942665639005891494">Zadanu lokaciju preuzimanja možete promijeniti kad god želite putem opcije u izborniku Postavke</translation>
+<translation id="6850409657436465440">Preuzimanje je još u tijeku</translation>
+<translation id="5817715962196959877">Brave sada brže preuzima datoteke</translation>
+<translation id="3976396876660209797">Uklonite i ponovo izradite taj prečac</translation>
+<translation id="6766622839693428701">Prijeđite prstom prema dolje da biste zatvorili.</translation>
+<translation id="1028699632127661925">Šalje se uređaju <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – poslano s uređaja <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Primljena je kartica</translation>
 <translation id="9104217018994036254">Popis za odabir uređaja s kojim će se dijeliti kartica.</translation>
-<translation id="9133397713400217035">Istraživanje izvan mreže</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Prikaži original</translation>
-<translation id="9139068048179869749">Web-lokacije moraju tražiti dopuštenje za slanje obavijesti (preporučeno)</translation>
-<translation id="9139318394846604261">Kupnja</translation>
-<translation id="9155898266292537608">Možete i kratko dodirnuti riječ da biste je pretražili</translation>
-<translation id="9169507124922466868">Povijest navigacije je poluotvorena</translation>
-<translation id="9204836675896933765">Preostala je 1 datoteka</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Popis za odabir uređaja s kojim će se dijeliti kartica otvoren na pola visine.</translation>
+<translation id="2904414404539560095">Popis za odabir uređaja s kojim će se dijeliti kartica otvoren punom visinom.</translation>
+<translation id="4135200667068010335">Popis za odabir uređaja s kojim će se dijeliti kartica zatvoren je.</translation>
+<translation id="5292796745632149097">Pošalji na uređaj</translation>
+<translation id="1386674309198842382">Aktivan prije <ph name="LAST_UPDATED"/> dana</translation>
+<translation id="7971136598759319605">Aktivan prije jednog dana</translation>
+<translation id="1521774566618522728">Aktivan danas</translation>
+<translation id="3631987586758005671">Dijeljenje s uređajem <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Uključite sinkronizaciju da biste dijelili na uređajima</translation>
+<translation id="6162454065885854378">Da biste dijelili sadržaj s telefona s nekim drugim uređajem, uključite sinkronizaciju u Braveovim postavkama na oba uređaja</translation>
+<translation id="6084271560289605378">Otvorite Braveove postavke</translation>
+<translation id="2318045970523081853">Dodirnite da biste uputili poziv</translation>
 <translation id="9209888181064652401">Upućivanje poziva nije moguće</translation>
-<translation id="9219103736887031265">Slike</translation>
-<translation id="926205370408745186">Uklanjanje vaše aktivnosti u Chromeu iz Digitalne ravnoteže</translation>
-<translation id="932327136139879170">Početna stranica</translation>
-<translation id="938850635132480979">Pogreška: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Pristup mikrofonu</translation>
-<translation id="95817756606698420">Chrome za pretraživanje u Kini može upotrebljavati <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />. To možete promijeniti u <ph name="BEGIN_LINK" />postavkama<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokiraj ako web-lokacija prikazuje ometajuće ili obmanjujuće oglase (preporučeno)</translation>
-<translation id="968900484120156207">Ovdje se prikazuju stranice koje posjećujete</translation>
-<translation id="970715775301869095">Preostalo minuta: <ph name="MINUTES" /></translation>
-<translation id="974555521953189084">Unesite šifru da biste pokrenuli sinkronizaciju</translation>
-<translation id="981121421437150478">Izvanmrežno</translation>
-<translation id="982182592107339124">Izbrisat će se podaci za sve web-lokacije, uključujući:</translation>
-<translation id="983192555821071799">Zatvori sve kartice</translation>
-<translation id="987264212798334818">Općenito</translation>
+<translation id="2860954141821109167">Provjerite je li na uređaju omogućena aplikacija telefona</translation>
+<translation id="2067805253194386918">SMS</translation>
+<translation id="1450753235335490080">Nije moguće dijeliti <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Nije moguće podijeliti <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Provjerite je li na uređaju <ph name="TARGET_DEVICE_NAME"/> uključena sinkronizacija u Braveu</translation>
+<translation id="3016635187733453316">Provjerite je li uređaj povezan s internetom</translation>
+<translation id="8466613982764129868">Provjerite je li <ph name="TARGET_DEVICE_NAME"/> povezan s internetom</translation>
+<translation id="6539092367496845964">Nešto nije u redu. Pokušajte ponovo kasnije.</translation>
+<translation id="3389286852084373014">Tekst je prevelik</translation>
+<translation id="2100314319871056947">Pokušajte podijeliti tekst u manjim dijelovima</translation>
+<translation id="2987620471460279764">Tekst podijeljen s drugog uređaja</translation>
+<translation id="7757787379047923882">Tekst dijeljen s uređaja <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kopirano u međuspremnik</translation>
+<translation id="4696983787092045100">Pošaljite SMS na svoje uređaje</translation>
+<translation id="1260236875608242557">Pretraživanje i istraživanje</translation>
+<translation id="6369229450655021117">Ovdje možete pretraživati web, dijeliti s prijateljima i vidjeti otvorene stranice</translation>
+<translation id="723171743924126238">Odaberite slike</translation>
+<translation id="8751914237388039244">Odaberite sliku</translation>
+<translation id="1989112275319619282">Pregledaj</translation>
+<translation id="7055152154916055070">Preusmjeravanje je blokirano:</translation>
+<translation id="5524843473235508879">Preusmjeravanje je blokirano.</translation>
+<translation id="6573096386450695060">Dopusti uvijek</translation>
+<translation id="5805364706385912897">Ova stranica upotrebljava previše memorije, pa ju je Brave pauzirao.</translation>
+<translation id="5138664332909611586">Ova stranica upotrebljava previše memorije, pa je Brave uklonio dio sadržaja.</translation>
+<translation id="9137013805542155359">Prikaži original</translation>
+<translation id="6361779936989026201">Brave Software asistent u Braveu</translation>
+<translation id="7291387454912369099">Naplata pomoću Asistenta</translation>
+<translation id="4565206163201411670">Želite li da se vaša aktivnost u Braveu prikazuje u Digitalnoj ravnoteži?</translation>
+<translation id="9055113864158719823">Možete vidjeti web-lokacije koje otvorite u Braveu i postaviti tajmere za njih.\n\nBrave Software prima informacije o web-lokacijama za koje postavite tajmere i koliko dugo ih posjećujete. Te se informacije koriste za poboljšanje Digitalne ravnoteže.</translation>
+<translation id="4596514158372210596">Uklanjanje vaše aktivnosti u Braveu iz Digitalne ravnoteže</translation>
+<translation id="1174893863889683998">Želite li ukloniti svoju aktivnost u Braveu iz Digitalne ravnoteže?</translation>
+<translation id="708829030563435351">Web-lokacije koje otvorite u Braveu neće se prikazivati. Izbrisat će se svi tajmeri za web-lokacije.</translation>
+<translation id="2056878612599315956">Web-lokacija pauzirana</translation>
+<translation id="671481426037969117">Isteklo je odbrojavanje za aplikaciju <ph name="FQDN"/>. Ponovo će se pokrenuti sutra.</translation>
+<translation id="7479104141328977413">Upravljanje karticama</translation>
+<translation id="3524138585025253783">Korisničko sučelje razvojnog programera</translation>
+<translation id="6036057147555329831">Dodatni ICU</translation>
+<translation id="9029323097866369874">Želite li dopustiti web-lokaciji <ph name="DOMAIN"/> pokretanje VR-a?</translation>
+<translation id="7685301384041462804">Prije pokretanja VR-a provjerite je li riječ o pouzdanoj web-lokaciji.</translation>
+<translation id="5033865233969348410">Ova web-lokacija možda može saznati nešto o vama dok ste u VR-u, na primjer:
+  -  vaša fizička obilježja, primjerice visina
+
+Prije nego što pokrenete VR, provjerite je li ta web-lokacija pouzdana.</translation>
+<translation id="5534334044554683961">Ova web-lokacija možda može saznati nešto o vama dok ste u VR-u, na primjer:
+  -   vaša fizička obilježja, primjerice visina
+  -   razmještaj vaše sobe
+
+Prije nego što uđete u VR, provjerite je li ta web-lokacija pouzdana.</translation>
+<translation id="4169535189173047238">Nemoj dopustiti</translation>
+<translation id="2170088579611075216">Dopusti i unesi VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_hu.xtb
+++ b/android/java/strings/translations/android_chrome_strings_hu.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="hu">
-<translation id="1006017844123154345">Online megnyitás</translation>
-<translation id="1028699632127661925">Küldés a következő eszközre: <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> hozzáadása…</translation>
-<translation id="1041308826830691739">Webhelyekről</translation>
-<translation id="1049743911850919806">Inkognitómód</translation>
-<translation id="10614374240317010">Az alábbi oldalakról soha ne mentsen jelszavakat</translation>
-<translation id="1067922213147265141">Egyéb Google-szolgáltatások</translation>
-<translation id="1068672505746868501">Soha ne fordítsa le a(z) <ph name="SOURCE_LANGUAGE" /> nyelvű oldalakat</translation>
-<translation id="107147699690128016">Ha módosítja a fájl kiterjesztését, előfordulhat, hogy a fájlt másik alkalmazás nyitja meg, ami veszélyt jelenthet az eszközre.</translation>
-<translation id="1100066534610197918">Megnyitás új lapon, csoportban</translation>
-<translation id="1105960400813249514">Képernyőrögzítés</translation>
-<translation id="1111673857033749125">A más eszközökön mentett könyvjelzők itt jelennek meg.</translation>
-<translation id="1113597929977215864">Egyszerűsített nézet megjelenítése</translation>
-<translation id="1121094540300013208">Használati és hibajelentések</translation>
-<translation id="1124772482545689468">Felhasználó</translation>
-<translation id="1129510026454351943">Részletek: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 letöltés függőben.}other{# letöltés függőben.}}</translation>
-<translation id="1145536944570833626">Meglévő adatok törlése.</translation>
-<translation id="1146678959555564648">Virtuális valóság – belépés</translation>
-<translation id="116280672541001035">Használt</translation>
-<translation id="1171770572613082465">A „Népszerűek” gombra koppintva megtekintheti a népszerű webhelyeket</translation>
-<translation id="1173894706177603556">Átnevezés</translation>
-<translation id="1178581264944972037">Szünet</translation>
-<translation id="1181037720776840403">Eltávolítás</translation>
-<translation id="1188239144602654184">AR indítása</translation>
-<translation id="1197267115302279827">Könyvjelzők áthelyezése</translation>
-<translation id="119944043368869598">Összes törlése</translation>
-<translation id="1201402288615127009">Tovább</translation>
-<translation id="1204037785786432551">Link letöltése</translation>
-<translation id="1206892813135768548">Link szövegének másolása</translation>
-<translation id="1208340532756947324">Az eszközök közötti szinkronizáláshoz és személyre szabáshoz kapcsolja be a szinkronizálást</translation>
-<translation id="1209206284964581585">Elrejtés most</translation>
-<translation id="1227058898775614466">Navigációs előzmények</translation>
-<translation id="1231733316453485619">Bekapcsolja a szinkronizálást?</translation>
-<translation id="123724288017357924">Oldal újratöltése a gyorsítótárat figyelmen kívül hagyva</translation>
-<translation id="124116460088058876">További nyelvek…</translation>
-<translation id="124678866338384709">Az aktuális lap bezárása</translation>
-<translation id="1258753120186372309">Google ünnepi embléma: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Keresés és felfedezés</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Nem sikerült a(z) <ph name="CONTENT_TYPE" /> megosztása</translation>
-<translation id="1272079795634619415">Leállítás</translation>
-<translation id="1283039547216852943">Koppintson a kibontáshoz</translation>
-<translation id="1285320974508926690">Ezt a webhelyet soha ne fordítsa le</translation>
-<translation id="1291207594882862231">Előzmények, cookie-k, webhelyadatok és a gyorsítótár törlése…</translation>
-<translation id="129382876167171263">A webhelyek által elmentett fájlok itt jelennek meg</translation>
-<translation id="129553762522093515">Mostanában bezárt</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – A(z) <ph name="DEVICE_NAME" /> eszközről</translation>
-<translation id="1310482092992808703">Lapok csoportosítása</translation>
-<translation id="1327257854815634930">Megnyitotta a navigációs előzményeket</translation>
-<translation id="1331212799747679585">A Chrome frissítése nem lehetséges. További lehetőségek</translation>
-<translation id="1332501820983677155">A Google Chrome-funkciók billentyűparancsai</translation>
-<translation id="1360432990279830238">Kijelentkezik, és kikapcsolja a szinkronizálást?</translation>
-<translation id="1369915414381695676">A(z) <ph name="SITE_NAME" /> webhely hozzáadva</translation>
-<translation id="1373696734384179344">Nincs elegendő memória a kiválasztott tartalom letöltéséhez.</translation>
-<translation id="1376578503827013741">Számítás…</translation>
-<translation id="1383876407941801731">Keresés</translation>
-<translation id="1384959399684842514">A letöltés szünetel</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> napja volt aktív</translation>
-<translation id="1397811292916898096">Keresés a(z) <ph name="PRODUCT_NAME" /> keresőmotorral</translation>
-<translation id="1404122904123200417">Beágyazva itt: <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">„Nincs nyomon követés”</translation>
-<translation id="1407135791313364759">Összes megnyitása</translation>
-<translation id="1409426117486808224">A megnyitott lapok egyszerűsített nézete</translation>
-<translation id="1409879593029778104">A következő fájl letöltését a böngésző megakadályozta, mert a fájl már létezik: <ph name="FILE_NAME" />.</translation>
-<translation id="1414981605391750300">Kapcsolatfelvétel a Google-lal… ez eltarthat pár percig…</translation>
-<translation id="1416550906796893042">Alkalmazás verziószáma</translation>
-<translation id="1430915738399379752">Nyomtatás</translation>
-<translation id="1446450296470737166">MIDI-eszközök teljes vezérlése</translation>
-<translation id="1450753235335490080">Nem sikerült a(z) <ph name="CONTENT_TYPE" /> megosztása</translation>
-<translation id="145097072038377568">Kikapcsolva az Android beállításaiban</translation>
-<translation id="1477626028522505441">A következő fájl letöltése szerverproblémák miatt nem sikerült: <ph name="FILE_NAME" />.</translation>
-<translation id="1506061864768559482">Keresőmotor</translation>
-<translation id="1513352483775369820">Könyvjelzők és webes előzmények</translation>
-<translation id="1513858653616922153">Jelszó törlése</translation>
-<translation id="1516229014686355813">A Keresés koppintással funkció elküldi a kiválasztott szót és az aktuális oldalt kontextusként a Google Keresés számára. A funkciót a <ph name="BEGIN_LINK" />Beállításokban<ph name="END_LINK" /> lehet kikapcsolni.</translation>
-<translation id="1521774566618522728">Ma volt aktív</translation>
-<translation id="1544826120773021464">Google-fiókjának kezeléséhez koppintson a „Fiók kezelése” gombra</translation>
-<translation id="1549000191223877751">Áthelyezés másik ablakba</translation>
-<translation id="1553358976309200471">A Chrome böngésző frissítése</translation>
-<translation id="1569387923882100876">Csatlakoztatott eszköz</translation>
-<translation id="1571304935088121812">Felhasználónév másolása</translation>
-<translation id="1612196535745283361">A Chrome-nak hozzá kell férnie a tartózkodási helyhez, hogy eszközöket kereshessen. A tartózkodási helyhez való hozzáférés <ph name="BEGIN_LINK" />ki van kapcsolva ezen az eszközön<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Akadályozza meg, hogy ez az oldal további párbeszédablakokat hozzon létre.</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 kijelölt elem eltávolítása}other{# kijelölt elem eltávolítása}}</translation>
-<translation id="164269334534774161">Jelenleg az oldal <ph name="CREATION_TIME" />-i dátummal mentett offline példányát tekinti meg</translation>
-<translation id="1644574205037202324">Előzmények</translation>
-<translation id="1647391597548383849">Hozzáférés a fényképezőgéphez</translation>
-<translation id="1660204651932907780">A webhelyek lejátszhatnak hangokat (ajánlott)</translation>
-<translation id="1670399744444387456">Alapok</translation>
-<translation id="1671236975893690980">Letöltés függőben…</translation>
-<translation id="1672586136351118594">Ne jelenjen meg többé</translation>
-<translation id="1692118695553449118">Szinkronizálás bekapcsolva</translation>
-<translation id="169515064810179024">A mozgásérzékelőkhöz való hozzáférés letiltása a webhelyek számára</translation>
-<translation id="1717218214683051432">Mozgásérzékelők</translation>
-<translation id="1718835860248848330">Az elmúlt órából</translation>
-<translation id="1736419249208073774">Felfedezés</translation>
-<translation id="1743802530341753419">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára egy adott eszközhöz való csatlakozást (ajánlott)</translation>
-<translation id="1749561566933687563">Könyvjelzők szinkronizálása</translation>
-<translation id="17513872634828108">Megnyitott lapok</translation>
-<translation id="1779089405699405702">Képdekóder</translation>
-<translation id="1782483593938241562">Befejezés dátuma: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Telepítve</translation>
-<translation id="1792959175193046959">Az alapértelmezett letöltési helyet bármikor módosíthatja</translation>
-<translation id="1807246157184219062">Világos</translation>
-<translation id="1810845389119482123">A szinkronizálás kezdeti beállítása nem fejeződött be</translation>
-<translation id="1821253160463689938">Cookie-kat használ a preferenciák megjegyzésére még akkor is, ha Ön nem keresi fel az adott oldalakat</translation>
-<translation id="1829244130665387512">Keresés ezen az oldalon</translation>
-<translation id="1853692000353488670">Új inkognitólap</translation>
-<translation id="1856325424225101786">Visszaállítja az Egyszerűsített módot?</translation>
-<translation id="1868024384445905608">Mostantól a Chrome gyorsabban tölti le a fájlokat</translation>
-<translation id="1883903952484604915">Saját fájlok</translation>
-<translation id="1887786770086287077">A helyhozzáférés ki van kapcsolva ennél az eszköznél. A funkciót az <ph name="BEGIN_LINK" />Android-beállításokban<ph name="END_LINK" /> tudja bekapcsolni.</translation>
-<translation id="1891331835972267886">A(z) <ph name="APP_NAME" /> a Chrome-ban nyílik meg. A folytatással elfogadja a Chrome <ph name="BEGIN_LINK1" />Általános Szerződési Feltételeit<ph name="END_LINK1" /> és <ph name="BEGIN_LINK2" />Adatvédelmi közleményét<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Hirdetések</translation>
-<translation id="1919950603503897840">Névjegyek kiválasztása</translation>
-<translation id="1922076542920281912">Ahhoz, hogy a Chrome hozzáférhessen a helyadatokhoz, a helyadatokat az <ph name="BEGIN_LINK" />Android-beállítások<ph name="END_LINK" /> között is be kell kapcsolni.</translation>
-<translation id="1923695749281512248"><ph name="FILE_SIZE_WITH_UNITS" /> / <ph name="BYTES_DOWNLOADED_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Frissítések</translation>
-<translation id="19288952978244135">Nyissa meg újra a Chrome-ot.</translation>
-<translation id="1933845786846280168">Kiválasztott lap</translation>
-<translation id="194341124344773587">A Chrome-ra vonatkozó engedélyt az <ph name="BEGIN_LINK" />Android beállításaiban<ph name="END_LINK" /> lehet aktiválni.</translation>
-<translation id="1943432128510653496">Jelszavak mentése</translation>
-<translation id="1952172573699511566">A webhelyek szövege a preferált nyelven jelenik meg, ha lehetséges.</translation>
-<translation id="1960290143419248813">Az Android jelen verziója a továbbiakban már nem támogatja a Chrome-frissítéseket</translation>
-<translation id="1966710179511230534">Kérjük, frissítse bejelentkezési adatait.</translation>
-<translation id="1974060860693918893">Speciális</translation>
-<translation id="1984705450038014246">Chrome-adatok szinkronizálása</translation>
-<translation id="1984937141057606926">Engedélyezve, kivéve a harmadik felektől származó cookie-kat</translation>
-<translation id="1986685561493779662">Már van ilyen név</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> gomb</translation>
-<translation id="1989112275319619282">Böngészés</translation>
-<translation id="1993768208584545658">A(z) <ph name="SITE" /> párosítást szeretne végrehajtani</translation>
-<translation id="1994173015038366702">Webhely URL-je</translation>
-<translation id="2000419248597011803">Bizonyos cookie-kat és kereséseket küld a címsávból és a keresőmezőből az alapértelmezett keresőmotornak</translation>
-<translation id="2002537628803770967">A Google Pay szolgáltatást használó hitelkártyák és címek</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fájl}other{# fájl}}</translation>
-<translation id="2017836877785168846">Törli a címsávban található előzményeket és automatikus kiegészítéseket.</translation>
-<translation id="2021896219286479412">Teljes képernyős oldal vezérlői</translation>
-<translation id="2038563949887743358">Kapcsolja be az Asztali webhely kérése funkciót</translation>
-<translation id="2041019821020695769">Ahhoz, hogy a Chrome értesítéseket küldhessen, az értesítéseket az <ph name="BEGIN_LINK" />Android-beállítások<ph name="END_LINK" /> között is be kell kapcsolni.</translation>
-<translation id="204321170514947529">A(z) <ph name="APP_NAME" /> a Chrome-ban is rendelkezik adatokkal</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">A webhely szüneteltetve van</translation>
-<translation id="2063713494490388661">A Keresés koppintással funkció</translation>
-<translation id="2067805253194386918">szöveg</translation>
-<translation id="2079545284768500474">Visszavonás</translation>
-<translation id="2082238445998314030">Eredmény: <ph name="RESULT_NUMBER" />/<ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Hang</translation>
-<translation id="2096012225669085171">Szinkronizálás és személyre szabás az eszközök között</translation>
-<translation id="2100273922101894616">Automatikus bejelentkezés</translation>
-<translation id="2100314319871056947">Próbálja meg kisebb részletekben megosztani a szöveget</translation>
-<translation id="2107397443965016585">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára védett tartalmak lejátszását (ajánlott)</translation>
-<translation id="2111511281910874386">Ugrás az oldalhoz</translation>
-<translation id="2122601567107267586">Nem sikerült megnyitni az alkalmazást</translation>
-<translation id="2126426811489709554">A Chrome erejével</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> megtakarítva</translation>
-<translation id="213279576345780926">Bezárva: <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Kezdőképernyőre</translation>
-<translation id="2146738493024040262">Azonnali alkalmazás megnyitása</translation>
-<translation id="2148716181193084225">Ma</translation>
-<translation id="2154484045852737596">Kártya szerkesztése</translation>
-<translation id="2154710561487035718">URL másolása</translation>
-<translation id="2156074688469523661">A többi webhely (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Ha szeretne megosztani valamit a telefonjáról egy másik eszközre, kapcsolja be a szinkronizálást a Chrome beállításaiban mindkét eszközön</translation>
-<translation id="2170088579611075216">Engedélyezés, és belépés VR-módba</translation>
-<translation id="218608176142494674">Megosztás</translation>
-<translation id="2227444325776770048">Folytatás mint <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Szinkronizálás és Google</translation>
-<translation id="2259659629660284697">Jelszavak exportálása…</translation>
-<translation id="2268044343513325586">Pontosítás</translation>
-<translation id="2286841657746966508">Számlázási cím</translation>
-<translation id="2289270750774289114">Kérdezzen rá, ha valamelyik webhely szeretné felfedezni a közeli Bluetooth-eszközöket (ajánlott)</translation>
-<translation id="230115972905494466">Nem találhatók kompatibilis eszközök</translation>
-<translation id="2315043854645842844">Az ügyféloldali tanúsítványválasztást az operációs rendszer nem támogatja.</translation>
-<translation id="2318045970523081853">Koppintson a hívás indításához</translation>
-<translation id="2321086116217818302">Jelszavak előkészítése…</translation>
-<translation id="2321958826496381788">Húzza a csúszkát, amíg kényelmesen nem tudja olvasni a szöveget. A szövegnek legalább ekkorának kell lennie, miután duplán koppint egy bekezdésre.</translation>
-<translation id="2323763861024343754">Webhely tárhelye</translation>
-<translation id="2328985652426384049">Nem sikerült a bejelentkezés</translation>
-<translation id="2330129964253841015">Figyelmeztetés, ha jelszavai illetéktelen kezekbe kerülnek</translation>
-<translation id="2349710944427398404">A Chrome által használt teljes adatmennyiség, beleértve a fiókokat, könyvjelzőket és mentett beállításokat is</translation>
-<translation id="2353636109065292463">Az internetkapcsolat ellenőrzése</translation>
-<translation id="2359808026110333948">Tovább</translation>
-<translation id="2369533728426058518">megnyitott lapok</translation>
-<translation id="2387895666653383613">Szöveg nagyítása</translation>
-<translation id="2394602618534698961">Itt találhatja majd a letöltött fájlokat</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Amikor bejelentkezik Google-fiókjába, a rendszer bekapcsolja ezt a funkciót</translation>
-<translation id="2410754283952462441">Válasszon fiókot</translation>
-<translation id="2414886740292270097">Sötét</translation>
-<translation id="2416359993254398973">A Chrome számára engedély szükséges, hogy hozzáférjen a kamerához ennél a webhelynél.</translation>
-<translation id="2426805022920575512">Másik fiók választása</translation>
-<translation id="2433507940547922241">Megjelenés</translation>
-<translation id="2434158240863470628">Letöltés befejezve <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Helyhozzáférés</translation>
-<translation id="2450083983707403292">Szeretné újra elkezdeni a(z) <ph name="FILE_NAME" /> letöltését?</translation>
-<translation id="2482878487686419369">Értesítések</translation>
-<translation id="2490684707762498678">Kezelő: <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Segéd a Chrome-ban</translation>
-<translation id="2496180316473517155">Böngészés előzményei</translation>
-<translation id="2497852260688568942">A szinkronizálást letiltotta a rendszergazda</translation>
-<translation id="2498359688066513246">Súgó és visszajelzés</translation>
-<translation id="2501278716633472235">Visszalépés</translation>
-<translation id="2513403576141822879">A <ph name="BEGIN_LINK" />Szinkronizálás és Google<ph name="END_LINK" /> részben további beállításokat talál az adatvédelemre, biztonságra és adatgyűjtésre vonatkozóan</translation>
-<translation id="2518590038762162553">Lite módban a Chrome gyorsabban betölti az oldalakat, és akár 60 százalékkal kisebb adatforgalmat generál. A felkeresett oldalak optimalizálása érdekében a Chrome elküldi az internetes forgalmát a Google-nak. <ph name="BEGIN_LINK" />További információ<ph name="END_LINK" />.</translation>
-<translation id="2523184218357549926">A felkeresett oldalak URL-címének elküldése a Google-nak</translation>
-<translation id="2532336938189706096">Internetes megtekintés</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> elem törölve</translation>
-<translation id="2536728043171574184">Az oldal offline példányának megtekintése</translation>
-<translation id="2546283357679194313">Cookie-k és webhelyadatok</translation>
-<translation id="2567385386134582609">KÉP</translation>
-<translation id="257088987046510401">Témák</translation>
-<translation id="2570922361219980984">A helyhozzáférés is ki van kapcsolva ennél az eszköznél. A funkciót az <ph name="BEGIN_LINK" />Android-beállításokban<ph name="END_LINK" /> tudja bekapcsolni.</translation>
-<translation id="257931822824936280">Kibontva – kattintson az összecsukáshoz.</translation>
-<translation id="2581165646603367611">Ezzel törli a cookie-kat, a gyorsítótárat, valamint a webhelyek összes olyan adatát, amelyről a Chrome úgy véli, hogy nem fontos.</translation>
-<translation id="2586657967955657006">Vágólap</translation>
-<translation id="2587052924345400782">Rendelkezésre áll új verzió</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Kártyaszám</translation>
-<translation id="2621115761605608342">A JavaScript engedélyezése egy adott webhelyen.</translation>
-<translation id="2625189173221582860">Jelszó vágólapra másolva</translation>
-<translation id="2631006050119455616">Megtakarított</translation>
-<translation id="2647434099613338025">Nyelv hozzáadása</translation>
-<translation id="2650751991977523696">Letölti újra a fájlt?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# hangfájl}other{# hangfájl}}</translation>
-<translation id="2653659639078652383">Elküldés</translation>
-<translation id="2677748264148917807">Lap elhagyása</translation>
-<translation id="2704606927547763573">Másolt</translation>
-<translation id="2707726405694321444">Oldal frissítése</translation>
-<translation id="2709516037105925701">Automatikus kitöltés</translation>
-<translation id="2717722538473713889">E-mail-címek</translation>
-<translation id="2728754400939377704">Rendezés webhely szerint</translation>
-<translation id="2744248271121720757">Az azonnali kereséshez koppintson a kívánt szóra, vagy tekintse meg a kapcsolódó műveleteket</translation>
-<translation id="2760989362628427051">Sötét téma bekapcsolása, amikor az eszköz sötét témája vagy Akkumulátorkímélő módja be van kapcsolva</translation>
-<translation id="2762000892062317888">éppen most</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> másodperc van hátra</translation>
-<translation id="2779651927720337254">sikertelen</translation>
-<translation id="2781151931089541271">1 másodperc van hátra</translation>
-<translation id="2801022321632964776">Frissítsen, hogy a saját nyelvén használhassa a Chrome legújabb verzióját</translation>
-<translation id="2810645512293415242">Egyszerűsített oldal az alacsonyabb adathasználat és a gyorsabb betöltés érdekében.</translation>
-<translation id="281504910091592009">Mentett jelszavait megtekintheti és kezelheti <ph name="BEGIN_LINK" />Google-fiókjában<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Ha az összes eszközén szeretné elérni könyvjelzőit, jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
-<translation id="2822354292072154809">Biztosan visszaállítja a(z) <ph name="CHOSEN_OBJECT_NAME" /> minden webhelyengedélyét?</translation>
-<translation id="2836148919159985482">A teljes képernyős megjelenítésből való kilépéshez koppintson a vissza gombra.</translation>
-<translation id="2842985007712546952">Szülőmappa</translation>
-<translation id="2858138569776157458">Népszerűek</translation>
-<translation id="2860954141821109167">Győződjön meg arról, hogy van engedélyezett telefonalkalmazás ezen az eszközön</translation>
-<translation id="2870560284913253234">Webhely</translation>
-<translation id="2874939134665556319">Előző szám</translation>
-<translation id="2876369937070532032">Elküldi egyes felkeresett oldalak URL-jét a Google-nak, ha veszélyben van az Ön biztonsága</translation>
-<translation id="2888126860611144412">A Chrome névjegye</translation>
-<translation id="2891154217021530873">Oldal betöltésének leállítása</translation>
-<translation id="2893180576842394309">A Google felhasználhatja az Ön előzményeit a Keresés és más Google-szolgáltatások személyre szabására</translation>
-<translation id="2898264748040935573">Tárolt jelszó módosítása</translation>
-<translation id="2900528713135656174">Esemény létrehozása</translation>
-<translation id="290376772003165898">Az oldal nem <ph name="LANGUAGE" /> nyelvű?</translation>
-<translation id="2904414404539560095">Lap megosztására szolgáló eszközök listája teljes magasságban megnyitva.</translation>
-<translation id="2910701580606108292">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára védett tartalmak lejátszását</translation>
-<translation id="2913331724188855103">Cookie-adatok mentésének és olvasásának engedélyezése a webhelyeken (ajánlott)</translation>
-<translation id="2923908459366352541">A név érvénytelen</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" />-tárhely</translation>
-<translation id="2942036813789421260">Az előnézeti lap zárva van</translation>
-<translation id="2956410042958133412">A fiók kezelői: <ph name="PARENT_NAME_1" /> és <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Átváltva az inkognitómódban használt lapokra</translation>
-<translation id="2968755619301702150">Tanúsítványmegtekintő</translation>
-<translation id="2979025552038692506">Kiválasztott inkognitólap</translation>
-<translation id="2987620471460279764">Más eszközről megosztott szöveg</translation>
-<translation id="2989523299700148168">Legutóbb látogatott</translation>
-<translation id="2996291259634659425">Összetett jelszó létrehozása</translation>
-<translation id="2996809686854298943">URL szükséges</translation>
-<translation id="300526633675317032">Ezzel törli a webhely teljes tárhelyét: <ph name="SIZE_IN_KB" />.</translation>
-<translation id="3016635187733453316">Ellenőrizze, hogy az eszköz csatlakozik-e az internethez</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> kB letöltve</translation>
-<translation id="3029704984691124060">Az összetett jelszavak nem egyeznek</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Kérjen segítséget<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">A Helyadatok szolgáltatás ki van kapcsolva; bekapcsolhatja az <ph name="BEGIN_LINK" />Android-beállításokban<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">A szinkronizálás bármikor bekapcsolható a beállításokban</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> könyvjelző}other{<ph name="BOOKMARKS_COUNT_MANY" /> könyvjelző}}</translation>
-<translation id="3089395242580810162">Megnyitás inkognitólapon</translation>
-<translation id="3115898365077584848">Információk megjelenítése</translation>
-<translation id="3123473560110926937">Letiltva egyes webhelyeken</translation>
-<translation id="3137521801621304719">Kilépés inkognitómódból</translation>
-<translation id="3143515551205905069">Szinkronizálás megszakítása</translation>
-<translation id="3157842584138209013">A További lehetőségek gombra kattintva tekintheti meg, hogy mekkora a megtakarított adatmennyiség</translation>
-<translation id="3166827708714933426">Lapokkal és ablakokkal kapcsolatos billentyűparancsok</translation>
-<translation id="3181954750937456830">Biztonságos Böngészés (megvédi Önt és eszközét a veszélyes webhelyekkel szemben)</translation>
-<translation id="3190152372525844641">A Chrome-ra vonatkozó engedélyek aktiválása az <ph name="BEGIN_LINK" />Android beállításaiban<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> tárolt adat</translation>
-<translation id="3205824638308738187">Majdnem kész.</translation>
-<translation id="3207960819495026254">Könyvjelző rögzítve</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> törölve</translation>
-<translation id="321773570071367578">Ha elfelejtette összetett jelszavát, vagy módosítani szeretné ezt a beállítást, <ph name="BEGIN_LINK" />állítsa alaphelyzetbe a szinkronizálást<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Internetes alkalmazás</translation>
-<translation id="3236059992281584593">1 perc van hátra</translation>
-<translation id="3244271242291266297">HH</translation>
-<translation id="3254409185687681395">Könyvjelző hozzáadása ehhez az oldalhoz</translation>
-<translation id="3259831549858767975">Minden kicsinyítése az oldalon</translation>
-<translation id="3269093882174072735">Kép betöltése</translation>
-<translation id="3269956123044984603">A többi eszközéről is hozzáférhet a lapjaihoz, ha bekapcsolja az Android-fiókbeállítások között található „Adatok automatikus szinkronizálása” funkciót.</translation>
-<translation id="3277252321222022663">Az érzékelőkhöz való hozzáférés engedélyezése a webhelyek számára (ajánlott)</translation>
-<translation id="3282568296779691940">Bejelentkezés a Chrome-ba</translation>
-<translation id="3288003805934695103">Az oldal frissítése</translation>
-<translation id="32895400574683172">Értesítések engedélyezve</translation>
-<translation id="3295530008794733555">Gyorsabb böngészés. Kevesebb adathasználat.</translation>
-<translation id="3295602654194328831">Információk elrejtése…</translation>
-<translation id="3298243779924642547">Egyszerű</translation>
-<translation id="3303414029551471755">Biztosan letölti a tartalmat?</translation>
-<translation id="3306398118552023113">Ez az alkalmazás fut a Chrome-ban</translation>
-<translation id="3315103659806849044">Jelenleg a Szinkronizálás és Google beállításait szabja személyre. A szinkronizálás bekapcsolásának véglegesítéséhez koppintson a képernyő alján található Megerősítés gombra. Fel</translation>
-<translation id="3328801116991980348">Webhelyadatok</translation>
-<translation id="3333961966071413176">Összes névjegy</translation>
-<translation id="3334729583274622784">Módosítja a fájl kiterjesztését?</translation>
-<translation id="3341058695485821946">Megnézheti, mennyi adatot takarított meg</translation>
-<translation id="3350687908700087792">Az összes inkognitólap bezárása</translation>
-<translation id="3353615205017136254">Egyszerű oldal a Google-tól. Az Eredeti betöltése gombra koppintva betöltheti az eredeti oldalt.</translation>
-<translation id="3367813778245106622">A szinkronizálás megkezdéséhez jelentkezzen be újra</translation>
-<translation id="3374023511497244703">Könyvjelzői, előzményei, jelszavai és más Chrome-adatai többé nem lesznek szinkronizálva a Google-fiókjával.</translation>
-<translation id="3384347053049321195">Kép megosztása</translation>
-<translation id="3386292677130313581">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára a tartózkodási helyhez való hozzáférést (ajánlott)</translation>
-<translation id="3387650086002190359">A következő fájl letöltése a fájlrendszer hibái miatt nem sikerült: <ph name="FILE_NAME" />.</translation>
-<translation id="3389286852084373014">A szöveg túl nagy</translation>
-<translation id="3398320232533725830">A Könyvjelzőkezelő megnyitása</translation>
-<translation id="3414952576877147120">Méret:</translation>
-<translation id="3443221991560634068">Az aktuális oldal újratöltése</translation>
-<translation id="3445014427084483498">Épp most</translation>
-<translation id="3478363558367712427">Kiválaszthatja keresőmotorját</translation>
+<translation id="6910211073230771657">Törölve</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Rendben, értem</translation>
+<translation id="7658239707568436148">Mégse</translation>
 <translation id="3479552764303398839">Ne most</translation>
-<translation id="3492207499832628349">Új inkognitólap</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />További információ<ph name="END_LINK" /> a javasolt tartalomról</translation>
-<translation id="3513704683820682405">Kiterjesztett valóság</translation>
-<translation id="3518985090088779359">Elfogadás és tovább</translation>
-<translation id="3522247891732774234">Frissítés áll rendelkezésre. További lehetőségek</translation>
-<translation id="3524138585025253783">Fejlesztői kezelőfelület</translation>
-<translation id="3527085408025491307">Mappa</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB szabad</translation>
-<translation id="3549657413697417275">Keresés az előzményekben</translation>
-<translation id="3557336313807607643">Hozzáadás a névjegyekhez</translation>
-<translation id="3566923219790363270">A Chrome még mindig a VR használatára készül fel. Indítsa újra a Chrome-ot később.</translation>
-<translation id="3568688522516854065">Ha a többi eszközén is szeretné elérni lapjait, jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
-<translation id="3587482841069643663">Mind</translation>
-<translation id="358794129225322306">Engedély webhelynek több fájl automatikus letöltésére.</translation>
-<translation id="3590487821116122040">A Chrome által nem fontosnak ítélt webhelytárhely (például a mentett beállítások nélküli vagy ritkán megnyitott webhelyek)</translation>
-<translation id="3599863153486145794">Törli az előzményeket valamennyi bejelentkezett eszközről. Előfordulhat, hogy a böngészési előzmények más formái még megtalálhatók Google-fiókjában a <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> webhelyen.</translation>
-<translation id="3600792891314830896">Elnémítja a hangot lejátszó webhelyeket</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Megosztás a következővel: <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Jelszó megjelenítése</translation>
-<translation id="363596933471559332">Automatikus bejelentkezés webhelyekre a tárolt hitelesítő adatokkal. Ha ez a funkció ki van kapcsolva, mindig meg kell adnia hitelesítő adatait, amikor egy webhelyre szeretne bejelentkezni.</translation>
-<translation id="3658159451045945436">A visszaállítás törli a megtakarított adatmennyiségre vonatkozó előzményeket, így a felkeresett webhelyek listáját is.</translation>
-<translation id="3692944402865947621">A(z) <ph name="FILE_NAME" /> fájl letöltése sikertelen, mert nem lehet elérni a tárhelyet.</translation>
-<translation id="3714981814255182093">A keresősáv megnyitása</translation>
-<translation id="3716182511346448902">Ez az oldal túl sok memóriát használ, ezért a Chrome szünetelteti.</translation>
-<translation id="3730075448226062617">Ahhoz, hogy a Chrome hozzáférhessen a mikrofonhoz, a mikrofont az <ph name="BEGIN_LINK" />Android-beállítások<ph name="END_LINK" /> között is be kell kapcsolni.</translation>
-<translation id="3739899004075612870">Felvéve a(z) <ph name="PRODUCT_NAME" /> könyvjelzői közé</translation>
-<translation id="3744111561329211289">Szinkronizálás a háttérben</translation>
-<translation id="3771001275138982843">Nem sikerült letölteni a frissítést</translation>
-<translation id="3771033907050503522">Inkognitólapok</translation>
-<translation id="3773755127849930740">A párosítás engedélyezéséhez <ph name="BEGIN_LINK" />kapcsolja be a Bluetooth funkciót<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">Küldés a saját eszközökre</translation>
-<translation id="3778956594442850293">Hozzáadva a kezdőképernyőhöz</translation>
-<translation id="3789841737615482174">Telepítés</translation>
-<translation id="3810838688059735925">Videó</translation>
-<translation id="3810973564298564668">Szerkesztés</translation>
-<translation id="381841723434055211">Telefonszámok</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> letöltés törölve</translation>
-<translation id="3822502789641063741">Törli a webhely tárhelyét?</translation>
-<translation id="385051799172605136">Vissza</translation>
-<translation id="3859306556332390985">Ugrás előre</translation>
-<translation id="3894427358181296146">Mappa hozzáadása</translation>
-<translation id="3895926599014793903">A nagyítás mindig engedélyezett</translation>
-<translation id="3912508018559818924">A legjobb találatok keresése az interneten…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Adataim egyesítése</translation>
-<translation id="393697183122708255">Nincs engedélyezett hangalapú keresés</translation>
-<translation id="395206256282351086">Keresési és webhelyjavaslatok letiltva</translation>
-<translation id="3955193568934677022">Engedélyezi a webhelyek számára a védett tartalmak lejátszását (ajánlott)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{A Chrome betölti az oldalt, amint lehetséges}other{A Chrome betölti az oldalakat, amint lehetséges}}</translation>
-<translation id="3963007978381181125">Az összetett jelszavas titkosítás nem tartalmazza a Google Payben megadott fizetési módokat és címeket. Titkosított adatait csak az olvashatja el, aki rendelkezik az Ön összetett jelszavával. Az összetett jelszót a Google nem kapja meg, és nem is tárolja. Ha elfelejtette összetett jelszavát, vagy módosítaná ezt a beállítást, alaphelyzetbe kell állítania a szinkronizálást. <ph name="BEGIN_LINK" />További információ<ph name="END_LINK" />.</translation>
-<translation id="3967822245660637423">A letöltés sikeres</translation>
-<translation id="397583555483684758">A szinkronizálás leállt</translation>
-<translation id="3976396876660209797">A gyorsparancs eltávolítása és újbóli létrehozása</translation>
-<translation id="3985215325736559418">Ismét letölti a(z) <ph name="FILE_NAME" /> fájlt?</translation>
-<translation id="3987993985790029246">Link másolása</translation>
-<translation id="3988213473815854515">Hely engedélyezve</translation>
-<translation id="3988466920954086464">Azonnali keresési találatok megtekintése ezen a panelen</translation>
-<translation id="3991845972263764475">? / <ph name="BYTES_DOWNLOADED_WITH_UNITS" /></translation>
-<translation id="3997476611815694295">Nem fontos tárhely</translation>
-<translation id="4000212216660919741">Offline kezdőlap</translation>
+<translation id="5317780077021120954">Mentés</translation>
+<translation id="4570913071927164677">Részletek</translation>
+<translation id="8730621377337864115">Kész</translation>
+<translation id="8261506727792406068">Törlés</translation>
+<translation id="1181037720776840403">Eltávolítás</translation>
+<translation id="5939518447894949180">Visszaállítás</translation>
 <translation id="4002066346123236978">Cím</translation>
-<translation id="4008040567710660924">Adott webhely cookie-jainak engedélyezése.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# órája}other{# órája}}</translation>
-<translation id="4046123991198612571">Következő szám</translation>
-<translation id="4048707525896921369">Megtudhatja a webhelyek témaköreit anélkül, hogy elhagyná az oldalt. A Keresés koppintással funkció elküld egy szót és annak kontextusát a Google Keresés számára, majd meghatározásokat, képeket, keresési eredményeket és egyéb részleteket ad vissza.
+<translation id="5916664084637901428">Be</translation>
+<translation id="5860033963881614850">Kikapcsolva</translation>
+<translation id="6165508094623778733">További információ</translation>
+<translation id="6042308850641462728">Továbbiak</translation>
+<translation id="6040143037577758943">Bezárás</translation>
+<translation id="780301667611848630">Köszönöm, nem</translation>
+<translation id="1201402288615127009">Tovább</translation>
+<translation id="2359808026110333948">Tovább</translation>
+<translation id="2653659639078652383">Elküldés</translation>
+<translation id="2079545284768500474">Visszavonás</translation>
+<translation id="7649070708921625228">Súgó</translation>
+<translation id="2148716181193084225">Ma</translation>
+<translation id="7781829728241885113">Tegnap</translation>
+<translation id="6945221475159498467">Kiválasztás</translation>
+<translation id="7791543448312431591">Hozzáadás</translation>
+<translation id="6527303717912515753">Megosztás</translation>
+<translation id="1383876407941801731">Keresés</translation>
+<translation id="3115898365077584848">Információk megjelenítése</translation>
+<translation id="3295602654194328831">Információk elrejtése…</translation>
+<translation id="3987993985790029246">Link másolása</translation>
+<translation id="2704606927547763573">Másolt</translation>
+<translation id="8725066075913043281">Újrapróbálás</translation>
+<translation id="385051799172605136">Vissza</translation>
+<translation id="8131740175452115882">Megerősítés</translation>
+<translation id="5300589172476337783">Megjelenítés</translation>
+<translation id="1124772482545689468">Felhasználó</translation>
+<translation id="8609465669617005112">Mozgatás felfelé</translation>
+<translation id="6746124502594467657">Mozgatás lefelé</translation>
+<translation id="8249310407154411074">Mozgatás az elejére</translation>
+<translation id="8428213095426709021">Beállítások</translation>
+<translation id="2498359688066513246">Súgó és visszajelzés</translation>
+<translation id="8378714024927312812">Az Ön szervezete kezeli</translation>
+<translation id="9019902583201351841">Szülők által kezelt</translation>
+<translation id="4645575059429386691">A szülő kezeli</translation>
+<translation id="4883854917563148705">A kezelt beállításokat nem lehet visszaállítani</translation>
+<translation id="4307992518367153382">Alapok</translation>
+<translation id="1974060860693918893">Speciális</translation>
+<translation id="1146678959555564648">Virtuális valóság – belépés</translation>
+<translation id="987264212798334818">Általános</translation>
+<translation id="4275663329226226506">Média</translation>
+<translation id="4759238208242260848">Letöltések</translation>
+<translation id="218608176142494674">Megosztás</translation>
+<translation id="8004582292198964060">Böngésző</translation>
+<translation id="1105960400813249514">Képernyőrögzítés</translation>
+<translation id="4875775213178255010">Javasolt tartalmak</translation>
+<translation id="2021896219286479412">Teljes képernyős oldal vezérlői</translation>
+<translation id="4587589328781138893">Webhelyek</translation>
+<translation id="4943703118917034429">Virtuális valóság</translation>
+<translation id="1928696683969751773">Frissítések</translation>
+<translation id="6064125863973209585">Befejezett letöltések</translation>
+<translation id="5342314432463739672">Engedélykérések</translation>
+<translation id="629730747756840877">Fiók</translation>
+<translation id="82609232232243542">Bejelentkezés a Brave-ba</translation>
+<translation id="7956662517480676674">Szinkronizálás és Brave Software</translation>
+<translation id="5294439808117722387">Jelenleg a Szinkronizálás és Brave Software beállításait szabja személyre. A szinkronizálás bekapcsolásának véglegesítéséhez koppintson a képernyő alján található Megerősítés gombra. Fel</translation>
+<translation id="2096012225669085171">Szinkronizálás és személyre szabás az eszközök között</translation>
+<translation id="1692118695553449118">Szinkronizálás bekapcsolva</translation>
+<translation id="5514904542973294328">Letiltotta az eszköz rendszergazdája</translation>
+<translation id="6447211988989208781">Brave Software Tevékenységvezérlők</translation>
+<translation id="4882831918239250449">Beállíthatja, hogy a rendszer hogyan szabja személyre a Keresést, a hirdetéseket és egyebeket a böngészési előzmények alapján</translation>
+<translation id="7431991332293347422">Beállíthatja, hogy a rendszer hogyan szabja személyre a Keresést és egyebeket a böngészési előzmények alapján</translation>
+<translation id="6303969859164067831">Kijelentkezés, és a szinkronizálás kikapcsolása</translation>
+<translation id="1125261911132334651">Brave Software-fiók kezelése</translation>
+<translation id="6406506848690869874">Szinkronizálás</translation>
+<translation id="714362445477979774">Brave-adatok szinkronizálása</translation>
+<translation id="4314815835985389558">Szinkronizálás kezelése</translation>
+<translation id="5428209950370661546">Egyéb Brave Software-szolgáltatások</translation>
+<translation id="7704317875155739195">Keresések és URL-címek automatikus kiegészítése</translation>
+<translation id="2000419248597011803">Bizonyos cookie-kat és kereséseket küld a címsávból és a keresőmezőből az alapértelmezett keresőmotornak</translation>
+<translation id="7981313251711023384">Oldalak előtöltése a gyorsabb böngészés és keresés érdekében</translation>
+<translation id="1821253160463689938">Cookie-kat használ a preferenciák megjegyzésére még akkor is, ha Ön nem keresi fel az adott oldalakat</translation>
+<translation id="6697492270171225480">Hasonló oldalakra vonatkozó javaslatok megjelenítése, ha az oldal nem található</translation>
+<translation id="8109318360573330108">Az elérni kívánt oldal URL-címének elküldése a Brave Software-nak</translation>
+<translation id="8438566539970814960">Keresések és böngészés javítása</translation>
+<translation id="284843628681142937">A felkeresett oldalak URL-címének elküldése a Brave Software-nak</translation>
+<translation id="7222718784508482526">A <ph name="BEGIN_LINK"/>Szinkronizálás és Brave Software<ph name="END_LINK"/> részben további beállításokat talál az adatvédelemre, biztonságra és adatgyűjtésre vonatkozóan</translation>
+<translation id="918192811481327695">Segítség a Brave funkcióinak és teljesítményének javítása érdekében</translation>
+<translation id="9063160602596686558">Automatikusan elküldi a használati statisztikákat és hibajelentéseket a Brave Software-nak</translation>
+<translation id="4824958205181053313">Megszakítja a szinkronizálást?</translation>
+<translation id="3058498974290601450">A szinkronizálás bármikor bekapcsolható a beállításokban</translation>
+<translation id="3143515551205905069">Szinkronizálás megszakítása</translation>
+<translation id="1506061864768559482">Keresőmotor</translation>
+<translation id="55737423895878184">Helyadatok és értesítések engedélyezve</translation>
+<translation id="3988213473815854515">Hely engedélyezve</translation>
+<translation id="32895400574683172">Értesítések engedélyezve</translation>
+<translation id="9040142327097499898">Az értesítések engedélyezve vannak. A helyhozzáférés ki van kapcsolva az eszköznél.</translation>
+<translation id="305593374596241526">A Helyadatok szolgáltatás ki van kapcsolva; bekapcsolhatja az <ph name="BEGIN_LINK"/>Android-beállításokban<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Legutóbb látogatott</translation>
+<translation id="6433501201775827830">Keresőmotor kiválasztása</translation>
+<translation id="7177466738963138057">Ezt később módosíthatja a beállítások között.</translation>
+<translation id="3478363558367712427">Kiválaszthatja keresőmotorját</translation>
+<translation id="4910889077668685004">Fizetési alkalmazások</translation>
+<translation id="5152843274749979095">Nincs telepítve támogatott alkalmazás</translation>
+<translation id="8812260976093120287">Bizonyos webhelyeken fizethet eszközén a fenti támogatott fizetési alkalmazásokkal.</translation>
+<translation id="7764225426217299476">Cím hozzáadása</translation>
+<translation id="5595485650161345191">Cím szerkesztése</translation>
+<translation id="5087580092889165836">Kártya hozzáadása</translation>
+<translation id="2154484045852737596">Kártya szerkesztése</translation>
+<translation id="6140912465461743537">Ország/régió</translation>
+<translation id="5659593005791499971">E-mail</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">A kártyán feltüntetett név</translation>
+<translation id="860043288473659153">Kártyatulajdonos neve</translation>
+<translation id="2612676031748830579">Kártyaszám</translation>
+<translation id="869891660844655955">Lejárati dátum</translation>
+<translation id="2286841657746966508">Számlázási cím</translation>
+<translation id="663059986967017181">A Brave-ba másolva</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Jelszavak</translation>
+<translation id="1943432128510653496">Jelszavak mentése</translation>
+<translation id="2100273922101894616">Automatikus bejelentkezés</translation>
+<translation id="363596933471559332">Automatikus bejelentkezés webhelyekre a tárolt hitelesítő adatokkal. Ha ez a funkció ki van kapcsolva, mindig meg kell adnia hitelesítő adatait, amikor egy webhelyre szeretne bejelentkezni.</translation>
+<translation id="6995899638241819463">Figyelmeztetés, ha jelszavai adatvédelmi incidens során nyilvánosságra kerülnek</translation>
+<translation id="1534287762301776620">Amikor bejelentkezik Brave Software-fiókjába, a rendszer bekapcsolja ezt a funkciót</translation>
+<translation id="10614374240317010">Az alábbi oldalakról soha ne mentsen jelszavakat</translation>
+<translation id="3098842761938485917">Mentett jelszavait megtekintheti és kezelheti <ph name="BEGIN_LINK"/>Brave Software-fiókjában<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">A mentett jelszavak itt jelennek meg.</translation>
+<translation id="8084114998886531721">Mentett jelszó</translation>
+<translation id="2870560284913253234">Webhely</translation>
+<translation id="8503813439785031346">Felhasználónév</translation>
+<translation id="6657585470893396449">Jelszó</translation>
+<translation id="2154710561487035718">URL másolása</translation>
+<translation id="1571304935088121812">Felhasználónév másolása</translation>
+<translation id="5005498671520578047">Jelszó másolása</translation>
+<translation id="3632295766818638029">Jelszó megjelenítése</translation>
+<translation id="1513858653616922153">Jelszó törlése</translation>
+<translation id="543338862236136125">Jelszó módosítása</translation>
+<translation id="4565377596337484307">Jelszó elrejtése</translation>
+<translation id="8523928698583292556">Tárolt jelszó törlése</translation>
+<translation id="2898264748040935573">Tárolt jelszó módosítása</translation>
+<translation id="5433691172869980887">Felhasználónév vágólapra másolva</translation>
+<translation id="5534640966246046842">Webhely vágólapra másolva</translation>
+<translation id="2625189173221582860">Jelszó vágólapra másolva</translation>
+<translation id="4550003330909367850">A jelszó megtekintéséhez vagy idemásolásához állítson be képernyőzárat az eszközön.</translation>
+<translation id="6154478581116148741">Kapcsolja be a képernyőzárat a Beállítások menüben, hogy exportálhassa az ezen az eszközön tárolt jelszavait</translation>
+<translation id="4842092870884894799">Jelszógenerálás előugró ablakának megjelenítése</translation>
+<translation id="2259659629660284697">Jelszavak exportálása…</translation>
+<translation id="133012818630824069">A Brave-ban tárolt jelszavak exportálása</translation>
+<translation id="6914783257214138813">Jelszavai mindenki számára láthatók lesznek, aki hozzáfér az exportált fájlhoz.</translation>
+<translation id="2321086116217818302">Jelszavak előkészítése…</translation>
+<translation id="8445448999790540984">Nem sikerült a jelszavak exportálása</translation>
+<translation id="3066461326500799725">További információ a Brave Software Drive használatáról</translation>
+<translation id="729975465115245577">Az eszközön nincs olyan alkalmazás, amely tárolni tudja a jelszavakat tartalmazó fájlt.</translation>
+<translation id="7682724950699840886">Próbálkozzon a következő tippekkel: Győződjön meg arról, hogy elegendő tárhely áll rendelkezésre az eszközön, majd próbálja újra az exportálást.</translation>
+<translation id="1129510026454351943">Részletek: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Oldja fel a képernyőzárat a jelszó másolásához</translation>
+<translation id="5515439363601853141">Oldja fel a képernyőzárat a jelszó megtekintéséhez</translation>
+<translation id="6221633008163990886">A zárolás feloldásával exportálhatja a jelszavait</translation>
+<translation id="230699814587342492">Brave-jelszavak</translation>
+<translation id="6075798973483050474">Kezdőoldal szerkesztése</translation>
+<translation id="854522910157234410">Az oldal megnyitása</translation>
+<translation id="2482878487686419369">Értesítések</translation>
+<translation id="6255999984061454636">Javasolt tartalmak</translation>
+<translation id="805047784848435650">A böngészési előzményei alapján</translation>
+<translation id="1041308826830691739">Webhelyekről</translation>
+<translation id="395206256282351086">Keresési és webhelyjavaslatok letiltva</translation>
+<translation id="257088987046510401">Témák</translation>
+<translation id="4650364565596261010">Alapértelmezett</translation>
+<translation id="7588219262685291874">Sötét téma bekapcsolása, amikor az eszköz Akkumulátorkímélő módja be van kapcsolva</translation>
+<translation id="2760989362628427051">Sötét téma bekapcsolása, amikor az eszköz sötét témája vagy Akkumulátorkímélő módja be van kapcsolva</translation>
+<translation id="6381421346744604172">Webhelyek sötétítése</translation>
+<translation id="5040262127954254034">Adatvédelem</translation>
+<translation id="4991384657077828949">Segítség a Brave biztonságának továbberősítésében</translation>
+<translation id="1943176487615318915">A veszélyes alkalmazások és webhelyek észlelésének érdekében a Brave az egyes felkeresett oldalak URL-jét, valamint korlátozott rendszer-információkat és bizonyos oldaltartalmakat továbbít a Brave Software-nak.</translation>
+<translation id="3181954750937456830">Biztonságos Böngészés (megvédi Önt és eszközét a veszélyes webhelyekkel szemben)</translation>
+<translation id="7315322926489145388">Elküldi egyes felkeresett oldalak URL-jét a Brave Software-nak, ha veszélyben van az Ön biztonsága</translation>
+<translation id="2063713494490388661">A Keresés koppintással funkció</translation>
+<translation id="2369463299479365221">Megtudhatja a webhelyek témaköreit anélkül, hogy elhagyná az oldalt. A Keresés koppintással funkció elküld egy szót és annak kontextusát a Brave Software Keresés számára, majd meghatározásokat, képeket, keresési eredményeket és egyéb részleteket ad vissza.
 
 A keresési kifejezés módosításához hosszú nyomva tartással hajthat végre kiválasztást. A keresés finomításához csúsztassa a panelt teljesen fel, majd érintse meg a keresőmezőt.</translation>
-<translation id="4056223980640387499">Szépia</translation>
-<translation id="4060598801229743805">A lehetőségek a képernyő tetején találhatók</translation>
-<translation id="4062305924942672200">Jogi információk</translation>
-<translation id="4084682180776658562">Könyvjelző</translation>
-<translation id="4084712963632273211">A következőtől: <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />megjelenítette a Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Törli az alkalmazásadatokat?</translation>
-<translation id="4099578267706723511">Használati statisztikák és hibajelentések küldésével segíthet a Google-nak a Chrome fejlesztésében.</translation>
-<translation id="410351446219883937">Automatikus lejátszás</translation>
-<translation id="4116038641877404294">Töltse le az oldalakat offline használatra</translation>
-<translation id="4135200667068010335">Lap megosztására szolgáló eszközök listája bezárva.</translation>
-<translation id="4149994727733219643">Weboldalak egyszerűsített nézete</translation>
-<translation id="4165986682804962316">Webhelybeállítások</translation>
-<translation id="4169535189173047238">Tiltás</translation>
-<translation id="4170011742729630528">A szolgáltatás nem érhető el, próbálja újra később.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> felhasználva</translation>
-<translation id="4181841719683918333">Nyelvek</translation>
-<translation id="4183868528246477015">Keresés a Google Lensszel <ph name="BEGIN_NEW" />Új<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Megnyitás új lapon</translation>
-<translation id="4198423547019359126">Nem áll rendelkezésre letöltési hely</translation>
-<translation id="4209895695669353772">A Google által javasolt, személyre szabott tartalmak fogadásához kapcsolja be a szinkronizálást</translation>
-<translation id="4226663524361240545">Az értesítések miatt rezeghet az eszköz</translation>
-<translation id="423219824432660969">A szinkronizált adatok titkosítása Google-jelszóval ekkortól: <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Beállítások megnyitása</translation>
-<translation id="4256782883801055595">Nyílt forráskódú licencek</translation>
-<translation id="4259722352634471385">Le van tiltva az ide vezető navigáció: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Link másolása</translation>
-<translation id="4275663329226226506">Média</translation>
-<translation id="4278390842282768270">Engedélyezve</translation>
-<translation id="429312253194641664">Az egyik webhely médiatartalmat játszik le</translation>
-<translation id="4298388696830689168">Összekapcsolt webhelyek</translation>
-<translation id="4307992518367153382">Alapok</translation>
-<translation id="4314815835985389558">Szinkronizálás kezelése</translation>
-<translation id="4351244548802238354">Párbeszédablak bezárása</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">A Sogou használata a kereséshez</translation>
-<translation id="4404568932422911380">Nincsenek könyvjelzők</translation>
-<translation id="4405224443901389797">Áthelyezés…</translation>
-<translation id="4411535500181276704">Egyszerűsített mód</translation>
-<translation id="4415276339145661267">Google-fiók kezelése</translation>
-<translation id="4432792777822557199">A(z) <ph name="SOURCE_LANGUAGE" /> nyelvű oldalak mostantól le lesznek fordítva <ph name="TARGET_LANGUAGE" /> nyelvre</translation>
-<translation id="4433925000917964731">Egyszerű oldal a Google-tól</translation>
-<translation id="4434045419905280838">Előugró ablakok és átirányítások</translation>
-<translation id="4440958355523780886">Egyszerű oldal a Google-tól. Koppintással betöltheti az eredetit.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> lap bezárása</translation>
-<translation id="4452548195519783679">Könyvjelzők közé téve itt: <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Védett tartalmak lejátszásának engedélyezése a webhelyek számára</translation>
-<translation id="4468959413250150279">Egy adott webhely hangjának némítása.</translation>
-<translation id="4472118726404937099">Az eszközök közötti szinkronizáláshoz és személyre szabáshoz jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
-<translation id="447252321002412580">Segítség a Chrome funkcióinak és teljesítményének javítása érdekében</translation>
-<translation id="4479647676395637221">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára a kamera használatát (ajánlott)</translation>
-<translation id="4479972344484327217">A(z) <ph name="MODULE" /> telepítése a Chrome-hoz…</translation>
-<translation id="4487967297491345095">A Chrome összes alkalmazásadata véglegesen törlődik, beleértve a fájlokat, beállításokat, fiókokat, adatbázisokat stb.</translation>
-<translation id="4493497663118223949">Az Egyszerűsített mód be van kapcsolva</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# napja}other{# napja}}</translation>
-<translation id="451872707440238414">Keresés a saját könyvjelzők közt</translation>
-<translation id="4521489764227272523">A kiválasztott adatok el lettek távolítva a Chrome-ból és a szinkronizált eszközökről.
-
-Előfordulhat, hogy Google-fiókjában (a <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> címen) még szerepelnek a böngészési előzmények egyéb formái, így például a keresések és egyéb tevékenységek más Google-szolgáltatásokból.</translation>
-<translation id="4532845899244822526">Mappa kiválasztása</translation>
-<translation id="4538018662093857852">Az Egyszerűsített mód bekapcsolása</translation>
-<translation id="4550003330909367850">A jelszó megtekintéséhez vagy idemásolásához állítson be képernyőzárat az eszközön.</translation>
-<translation id="4558311620361989323">Weboldalakkal kapcsolatos billentyűparancsok</translation>
-<translation id="4561979708150884304">Nincs kapcsolat</translation>
-<translation id="4565377596337484307">Jelszó elrejtése</translation>
-<translation id="4570913071927164677">Részletek</translation>
-<translation id="4572422548854449519">Bejelentkezés a kezelt fiókba</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# perce}other{# perce}}</translation>
-<translation id="4587589328781138893">Webhelyek</translation>
-<translation id="4594952190837476234">Az offline oldal létrehozási ideje: <ph name="CREATION_TIME" />. Az oldal eltérhet az online változattól.</translation>
-<translation id="4605958867780575332">A következő elem eltávolítva: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> megnyitása</translation>
-<translation id="4634124774493850572">Jelszó használata</translation>
-<translation id="4645575059429386691">A szülő kezeli</translation>
-<translation id="4650364565596261010">Alapértelmezett</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> könyvjelző törölve</translation>
-<translation id="4665282149850138822">A(z) <ph name="NAME" /> felkerült a kezdőképernyőre</translation>
-<translation id="4684427112815847243">Az összes szinkronizálása</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">SMS küldése az eszközeire</translation>
-<translation id="4698034686595694889">Megtekintés offline állapotban itt: <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">A gyorsítótárban szereplő képek és fájlok</translation>
-<translation id="4714588616299687897">Akár 60%-kal is csökkentheti adatforgalmát</translation>
-<translation id="4719927025381752090">Fordítás felajánlása</translation>
-<translation id="4720023427747327413">Megnyitás itt: <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Segítsen a Chrome fejlesztésében. <ph name="BEGIN_LINK" />Töltse ki ezt a felmérést.<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Frissítés</translation>
-<translation id="4738836084190194332">Utolsó szinkronizálás: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Új lap megnyitása</translation>
-<translation id="4751476147751820511">Mozgás- és fényérzékelők</translation>
-<translation id="4759238208242260848">Letöltések</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 letöltés befejeződött.}other{# letöltés befejeződött.}}</translation>
-<translation id="4797039098279997504">Érintse meg, hogy visszatérjen ide: <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Az összetett jelszavas titkosítás nem tartalmazza a Google Payben megadott fizetési módokat és címeket.
-
-A beállítás módosításához <ph name="BEGIN_LINK" />állítsa vissza a szinkronizálást<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">A kártyán feltüntetett név</translation>
-<translation id="4824958205181053313">Megszakítja a szinkronizálást?</translation>
-<translation id="4837753911714442426">Oldalnyomtatási lehetőségek megnyitása</translation>
-<translation id="4842092870884894799">Jelszógenerálás előugró ablakának megjelenítése</translation>
-<translation id="4860895144060829044">Hívás</translation>
-<translation id="4866368707455379617">Nem lehetséges a(z) <ph name="MODULE" /> telepítése a Chrome-hoz</translation>
-<translation id="4875775213178255010">Javasolt tartalmak</translation>
-<translation id="4878404682131129617">Nem sikerült a proxyszerveren keresztüli alagút kialakítása</translation>
-<translation id="4880127995492972015">Fordítás…</translation>
-<translation id="4881695831933465202">Megnyitás</translation>
-<translation id="488187801263602086">Fájl átnevezése</translation>
-<translation id="4882831918239250449">Beállíthatja, hogy a rendszer hogyan szabja személyre a Keresést, a hirdetéseket és egyebeket a böngészési előzmények alapján</translation>
-<translation id="4883854917563148705">A kezelt beállításokat nem lehet visszaállítani</translation>
-<translation id="4885273946141277891">Ilyen sok Chrome-példány nem futhat egyszerre.</translation>
-<translation id="4910889077668685004">Fizetési alkalmazások</translation>
-<translation id="4913161338056004800">Statisztikák alaphelyzetbe állítása</translation>
-<translation id="4913169188695071480">Frissítés leállítása</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Kérjen segítséget<ph name="END_LINK" />, miközben eszközöket keresünk…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# oldal}other{# oldal}}</translation>
-<translation id="4932247056774066048">Mivel kijelentkezik a(z) <ph name="DOMAIN_NAME" /> által kezelt fiókból, a rendszer törli az Ön Chrome-adatait erről az eszközről. Google-fiókjában továbbra is megmaradnak ezek az adatok.</translation>
-<translation id="4943703118917034429">Virtuális valóság</translation>
-<translation id="4943872375798546930">Nincs találat</translation>
-<translation id="4958708863221495346">A(z) <ph name="URL_OF_THE_CURRENT_TAB" /> webhely megosztja az Ön képernyőjét</translation>
-<translation id="4961107849584082341">Bármely nyelvre lefordíthatja ezt az oldalt</translation>
-<translation id="4962975101802056554">Az eszköz összes engedélyének visszavonása</translation>
-<translation id="4970824347203572753">Nem áll rendelkezésre az Ön tartózkodási helyén</translation>
-<translation id="497421865427891073">Előrelépés</translation>
-<translation id="4988210275050210843">Fájl letöltése folyamatban (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Oldal</translation>
-<translation id="4994033804516042629">Nem találhatók névjegyek</translation>
-<translation id="4996978546172906250">Megosztás itt:</translation>
-<translation id="5004416275253351869">Google Tevékenységvezérlők</translation>
-<translation id="5005498671520578047">Jelszó másolása</translation>
-<translation id="5011311129201317034">A(z) <ph name="SITE" /> csatlakozni szeretne</translation>
-<translation id="5013696553129441713">Nincsenek új javaslatok</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Amíg VR-módban van, a webhely megtudhat Önről bizonyos információkat:
-  –  fizikai jellemzőit, például a magasságát.
-
-A VR-mód aktiválása előtt győződjön meg a webhely megbízhatóságáról.</translation>
+<translation id="2930742481329940825">A Keresés koppintással funkció elküldi a kiválasztott szót és az aktuális oldalt kontextusként a Brave Software Keresés számára. A funkciót a <ph name="BEGIN_LINK"/>Beállításokban<ph name="END_LINK"/> lehet kikapcsolni.</translation>
 <translation id="5039804452771397117">Engedélyezés</translation>
-<translation id="5040262127954254034">Adatvédelem</translation>
-<translation id="5048398596102334565">A mozgásérzékelőkhöz való hozzáférés engedélyezése a webhelyek számára (ajánlott)</translation>
-<translation id="5063480226653192405">Használat</translation>
-<translation id="5087580092889165836">Kártya hozzáadása</translation>
-<translation id="5100237604440890931">Összecsukva – kattintson a kibontáshoz.</translation>
-<translation id="510275257476243843">1 óra van hátra</translation>
-<translation id="5123685120097942451">Inkognitólap</translation>
-<translation id="5127805178023152808">Szinkronizálás kikapcsolva</translation>
-<translation id="5129038482087801250">Webes alkalmazás telepítése</translation>
-<translation id="5132942445612118989">Jelszavak, előzmények és egyebek szinkronizálása valamennyi eszközén</translation>
-<translation id="5139940364318403933">További információ a Google Drive használatáról</translation>
-<translation id="515227803646670480">Tárolt adatok törlése</translation>
-<translation id="5152843274749979095">Nincs telepítve támogatott alkalmazás</translation>
-<translation id="5161254044473106830">Cím megadása kötelező</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 letöltés nem sikerült.}other{# letöltés nem sikerült.}}</translation>
-<translation id="5170568018924773124">Megjelenítés mappában</translation>
-<translation id="5184329579814168207">Megnyitás Chrome-ban</translation>
-<translation id="5193988420012215838">Vágólapra másolva</translation>
-<translation id="5197729504361054390">A kiválasztott névjegyeket megosztjuk a következő webhellyel: <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Munkaprofil</translation>
-<translation id="5210286577605176222">Ugrás az előző lapra</translation>
-<translation id="5210365745912300556">Lap bezárása</translation>
-<translation id="5224771365102442243">Videóval</translation>
-<translation id="5230560987958996918">A(z) <ph name="SITE" /> szeretné megkeresni a közeli Bluetooth-eszközöket. A következő eszközöket találta:</translation>
-<translation id="5233638681132016545">Új lap</translation>
-<translation id="526421993248218238">Nem lehet betölteni az oldalt</translation>
-<translation id="5271967389191913893">Az eszköz nem tudja megnyitni a letölteni kívánt tartalmat.</translation>
-<translation id="528192093759286357">A teljes képernyős megjelenítésből való kilépéshez húzza le felülről, majd koppintson a vissza gombra.</translation>
-<translation id="5292796745632149097">Küldés a következőre:</translation>
-<translation id="5300589172476337783">Megjelenítés</translation>
-<translation id="5301954838959518834">Rendben, értem</translation>
-<translation id="5304593522240415983">Ez a mező nem lehet üres</translation>
-<translation id="5307446750509046227">Webhelytárhely törlése</translation>
-<translation id="5308380583665731573">Csatlakozás</translation>
-<translation id="5313967007315987356">Webhely hozzáadása</translation>
-<translation id="5317780077021120954">Mentés</translation>
-<translation id="5324858694974489420">Szülői beállítások</translation>
-<translation id="5327248766486351172">Név</translation>
-<translation id="5335288049665977812">Engedélyezze a webhelyek számára a JavaScript futtatását (ajánlott)</translation>
-<translation id="5342314432463739672">Engedélykérések</translation>
-<translation id="5357811892247919462">Lap fogadva</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> megnyitott lap. A lapok között koppintással válthat.}other{<ph name="OPEN_TABS_MANY" /> megnyitott lap. A lapok között koppintással válthat.}}</translation>
-<translation id="5391532827096253100">Kapcsolata a webhellyel nem biztonságos. Webhelyadatok</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 további)}other{(+ # további)}}</translation>
-<translation id="5400569084694353794">Az alkalmazás használatával Ön elfogadja a Chrome <ph name="BEGIN_LINK1" />Általános Szerződési Feltételeit<ph name="END_LINK1" /> és az <ph name="BEGIN_LINK2" />Adatvédelmi közleményt<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Nevek</translation>
-<translation id="5403644198645076998">Csak bizonyos webhelyek engedélyezése</translation>
-<translation id="5414836363063783498">Ellenőrzés...</translation>
-<translation id="5423934151118863508">A leggyakrabban látogatott oldalak fognak itt megjelenni</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB szabad</translation>
-<translation id="543338862236136125">Jelszó módosítása</translation>
-<translation id="5433691172869980887">Felhasználónév vágólapra másolva</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> fájl letöltése folyamatban (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Ugrás a címsávba</translation>
-<translation id="5447201525962359567">Összes webhelytárhely, beleértve a cookie-kat és más helyben tárolt adatokat</translation>
-<translation id="5447765697759493033">Nem fordítjuk le ezt a webhelyet</translation>
-<translation id="545042621069398927">Letöltés felgyorsítása…</translation>
-<translation id="5456381639095306749">Oldal letöltése</translation>
-<translation id="5475862044948910901">Elindítja a kiterjesztett valóságot (AR) használó munkamenetet?</translation>
-<translation id="548278423535722844">Megnyitás térképalkalmazásban</translation>
-<translation id="5487521232677179737">Adatok törlése</translation>
-<translation id="5494752089476963479">Hirdetések letiltása a tolakodó és félrevezető hirdetéseket megjelenítő webhelyeken</translation>
-<translation id="5500777121964041360">Előfordulhat, hogy ez a beállítás nem áll rendelkezésre az Ön tartózkodási helyén</translation>
-<translation id="5512137114520586844">A fiók kezelője: <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Letiltotta az eszköz rendszergazdája</translation>
-<translation id="5515439363601853141">Oldja fel a képernyőzárat a jelszó megtekintéséhez</translation>
-<translation id="5516455585884385570">Értesítési beállítások megnyitása</translation>
-<translation id="5517095782334947753">Vannak könyvjelzői, előzményei, jelszavai és más beállításai a(z) <ph name="FROM_ACCOUNT" /> fiókból.</translation>
-<translation id="5524843473235508879">Átirányítás letiltva.</translation>
-<translation id="5527082711130173040">A Chrome-nak hozzá kell férnie a tartózkodási helyhez, hogy eszközöket kereshessen. <ph name="BEGIN_LINK1" />Frissítse az engedélyeket<ph name="END_LINK1" />. A helyadatokhoz való hozzáférés is <ph name="BEGIN_LINK2" />ki van kapcsolva ezen az eszközön<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Kérdezzen rá, mielőtt engedélyezi a webhelyeknek, hogy megtekintsék a vágólapon található szövegeket és képeket (ajánlott)</translation>
-<translation id="5530766185686772672">Inkognitólapok bezárása</translation>
-<translation id="5534334044554683961">Amíg VR-módban van, a webhely megtudhat Önről bizonyos információkat:
-  –   fizikai jellemzőit, például a magasságát;
-  –   a szobája elrendezését.
-
-A VR-mód aktiválása előtt győződjön meg a webhely megbízhatóságáról.</translation>
-<translation id="5534640966246046842">Webhely vágólapra másolva</translation>
-<translation id="5556459405103347317">Újratöltés</translation>
-<translation id="5561549206367097665">Várakozás a hálózatra…</translation>
-<translation id="557283862590186398">A Chrome számára engedély szükséges, hogy hozzáférjen a mikrofonhoz ennél a webhelynél.</translation>
-<translation id="55737423895878184">Helyadatok és értesítések engedélyezve</translation>
-<translation id="5578795271662203820">A kép keresése a(z) <ph name="SEARCH_ENGINE" /> keresővel</translation>
-<translation id="5581519193887989363">A <ph name="BEGIN_LINK1" />beállítások<ph name="END_LINK1" /> között bármikor módosíthatja a szinkronizálni kívánt elemeket.</translation>
-<translation id="5595485650161345191">Cím szerkesztése</translation>
-<translation id="5596627076506792578">További lehetőségek</translation>
-<translation id="5599455543593328020">Inkognitómód</translation>
-<translation id="5620928963363755975">A fájlokat és oldalakat a További lehetőségek gomb Letöltések menüpontjában találja meg</translation>
-<translation id="5626134646977739690">Név:</translation>
-<translation id="5639724618331995626">Minden webhely engedélyezése</translation>
-<translation id="5648166631817621825">Az elmúlt 7 napból</translation>
-<translation id="5649053991847567735">Automatikus letöltések</translation>
-<translation id="5655963694829536461">Keresés a letöltések között</translation>
-<translation id="5659593005791499971">E-mail</translation>
-<translation id="5665379678064389456">Esemény létrehozása a(z) <ph name="APP_NAME" /> alkalmazásban</translation>
-<translation id="5668404140385795438">Felülbírálja a webhely kérelmét, mely megakadályozná a nagyítást</translation>
-<translation id="5677928146339483299">Letiltva</translation>
-<translation id="5684874026226664614">Hoppá! Az oldalt nem sikerült lefordítani.</translation>
-<translation id="5686790454216892815">A fájl neve túl hosszú</translation>
-<translation id="5689516760719285838">Tartózkodási hely</translation>
-<translation id="569536719314091526">Bármely nyelvre lefordíthatja ezt az oldalt a További lehetőségek gomb segítségével</translation>
-<translation id="572328651809341494">Nemrég megnyitott lapok</translation>
-<translation id="5726692708398506830">Minden nagyítása az oldalon</translation>
-<translation id="5748802427693696783">Szabványos lapokra váltva</translation>
-<translation id="5749068826913805084">A Chrome-nak tárhelyhozzáférésre van szüksége a fájlok letöltéséhez.</translation>
-<translation id="5763382633136178763">Inkognitólapok</translation>
-<translation id="5763514718066511291">Koppintson az alkalmazás URL-jének másolásához</translation>
-<translation id="5765780083710877561">Leírás:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" />/<ph name="SPACE_USED" /> használatban</translation>
-<translation id="5797070761912323120">A Google felhasználhatja az Ön előzményeit a Keresés, a hirdetések és más Google-szolgáltatások személyre szabására</translation>
-<translation id="5804241973901381774">Engedélyek</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# órája}other{# órája}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Minden jog fenntartva.</translation>
-<translation id="5817918615728894473">Párosítás</translation>
-<translation id="583281660410589416">Ismeretlen</translation>
-<translation id="5833984609253377421">Link megosztása</translation>
-<translation id="5836192821815272682">A Chrome frissítésének letöltése…</translation>
-<translation id="5853623416121554550">szüneteltetve</translation>
-<translation id="5854790677617711513">30 napnál régebbi</translation>
-<translation id="5858741533101922242">A Chrome nem tudja bekapcsolni a Bluetooth-adaptert</translation>
-<translation id="5860033963881614850">Kikapcsolva</translation>
-<translation id="5862731021271217234">Ha a többi eszközén lévő lapjait is szeretné elérni, kapcsolja be a szinkronizálást</translation>
-<translation id="5864174910718532887">Részletek: Webhelynév szerinti rendezés</translation>
-<translation id="5864419784173784555">Várakozás a másik letöltésre…</translation>
-<translation id="5865733239029070421">Automatikusan elküldi a használati statisztikákat és hibajelentéseket a Google-nak</translation>
-<translation id="5869522115854928033">Mentett jelszavak</translation>
-<translation id="5902828464777634901">A webhely által tárolt összes adat törlődik (a cookie-kat is beleértve).</translation>
-<translation id="5916664084637901428">Be</translation>
-<translation id="5919204609460789179">A szinkronizálás megkezdéséhez frissítse a következőt: <ph name="PRODUCT_NAME" /></translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> megtakarított adatmennyiség</translation>
-<translation id="5939518447894949180">Visszaállítás</translation>
-<translation id="5942872142862698679">A Google használata a kereséshez</translation>
-<translation id="5952764234151283551">Az elérni kívánt oldal URL-címének elküldése a Google-nak</translation>
-<translation id="5956665950594638604">A Chrome súgójának megnyitása új lapon</translation>
-<translation id="5958275228015807058">A fájlokat és oldalakat a Letöltések között találja meg</translation>
-<translation id="5962718611393537961">Koppintson az összecsukáshoz</translation>
-<translation id="6000066717592683814">A Google megtartása</translation>
-<translation id="6005538289190791541">Javasolt jelszó</translation>
-<translation id="6036057147555329831">További ICU</translation>
-<translation id="6039379616847168523">Ugrás a következő lapra</translation>
-<translation id="6040143037577758943">Bezárás</translation>
-<translation id="6042308850641462728">Továbbiak</translation>
-<translation id="604996488070107836">A következő fájl letöltése ismeretlen hiba miatt nem sikerült: <ph name="FILE_NAME" />.</translation>
-<translation id="605721222689873409">ÉÉ</translation>
-<translation id="6064125863973209585">Befejezett letöltések</translation>
-<translation id="6075798973483050474">Kezdőoldal szerkesztése</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> óra van hátra</translation>
-<translation id="6108923351542677676">A telepítés folyamatban...</translation>
-<translation id="6111020039983847643">használt adatmennyiség</translation>
-<translation id="6112702117600201073">Oldal frissítése</translation>
-<translation id="6127379762771434464">Elem eltávolítva</translation>
-<translation id="6140912465461743537">Ország/régió</translation>
-<translation id="614940544461990577">Próbálja ki a következőket:</translation>
-<translation id="6154478581116148741">Kapcsolja be a képernyőzárat a Beállítások menüben, hogy exportálhassa az ezen az eszközön tárolt jelszavait</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" />-os adatmegtakarítás</translation>
-<translation id="6165508094623778733">További információ</translation>
-<translation id="6177111841848151710">Tiltott a jelenlegi keresőmotor számára</translation>
-<translation id="6181444274883918285">Webhelykivétel hozzáadása</translation>
-<translation id="6192333916571137726">Fájl letöltése</translation>
-<translation id="6192792657125177640">Kivételek</translation>
-<translation id="6194112207524046168">Ahhoz, hogy a Chrome hozzáférhessen a kamerához, a kamerát az <ph name="BEGIN_LINK" />Android-beállítások<ph name="END_LINK" /> között is be kell kapcsolni.</translation>
-<translation id="6196640612572343990">Harmadik féltől származó cookie-k letiltása</translation>
-<translation id="6206551242102657620">A kapcsolat biztonságos. Webhelyadatok</translation>
-<translation id="6210748933810148297">Nem <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">A zárolás feloldásával exportálhatja a jelszavait</translation>
+<translation id="1406000523432664303">„Nincs nyomon követés”</translation>
 <translation id="6232535412751077445">A „Nincs nyomon követés” engedélyezése azt jelenti, hogy a böngészési forgalommal együtt kérelmet is küld a rendszer. Ennek hatása attól függ, hogy a webhely reagál-e a kérelemre, és hogyan értelmezi azt.
 
 Egyes webhelyek például válaszolhatnak rá úgy, hogy olyan hirdetéseket jelenítenek meg, amelyek nem a már felkeresett egyéb webhelyeken alapulnak. Számos webhely ilyenkor is gyűjti és felhasználja a böngészési adatokat (például a biztonság növelése, továbbá tartalom, hirdetések és ajánlatok biztosítása, valamint jelentésekhez használt statisztika előállítása céljából).</translation>
-<translation id="624789221780392884">A frissítés készen áll</translation>
-<translation id="6255999984061454636">Javasolt tartalmak</translation>
-<translation id="6277522088822131679">Hiba történt az oldal nyomtatásakor. Próbálja újra.</translation>
-<translation id="6295158916970320988">Az összes webhely</translation>
-<translation id="629730747756840877">Fiók</translation>
-<translation id="6303969859164067831">Kijelentkezés, és a szinkronizálás kikapcsolása</translation>
-<translation id="6316139424528454185">Nem támogatott Android-verzió</translation>
-<translation id="6320088164292336938">Rezgés</translation>
-<translation id="6324034347079777476">Az Android rendszer szinkronizálása letiltva</translation>
-<translation id="6333140779060797560">Megosztás a következőn keresztül: <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Titkosítás</translation>
-<translation id="6341580099087024258">Rákérdezés a fájlok mentésének helyére</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Eltávolítja a javaslatot az előzményekből?</translation>
-<translation id="6369229450655021117">Itt internetes kereséseket indíthat, megoszthat tartalmakat barátaival, és megtekintheti a megnyitott oldalakat</translation>
-<translation id="6378173571450987352">Részletek: Felhasznált adatmennyiség szerinti rendezés</translation>
-<translation id="6381421346744604172">Webhelyek sötétítése</translation>
-<translation id="6388207532828177975">Törlés és visszaállítás</translation>
-<translation id="6393863479814692971">A Chrome számára engedély szükséges, hogy hozzáférjen a kamerához és a mikrofonhoz ennél a webhelynél.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Könyvjelző szerkesztése</translation>
-<translation id="6406506848690869874">Szinkronizálás</translation>
-<translation id="641643625718530986">Nyomtatás…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB letöltve</translation>
-<translation id="6427112570124116297">Lefordíthatja az internetet</translation>
-<translation id="6433501201775827830">Keresőmotor kiválasztása</translation>
-<translation id="6437478888915024427">Oldaladatok</translation>
-<translation id="6441734959916820584">Túl hosszú a név</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# kép}other{# kép}}</translation>
-<translation id="6447842834002726250">Cookie-k</translation>
-<translation id="6461962085415701688">A fájlt nem lehet megnyitni</translation>
-<translation id="6464977750820128603">Megnézheti a Chrome böngészővel felkeresett webhelyeket, és beállíthat hozzájuk időzítéseket.\n\nAz időzítéssel ellátott webhelyek adatait és a látogatás hosszát megkapja a Google. Ezek az adatok a digitális jóllét funkció továbbfejlesztésére szolgálnak.</translation>
-<translation id="6475951671322991020">Videó letöltése</translation>
-<translation id="6482749332252372425">A következő fájl letöltése tárhelyhiány miatt nem sikerült: <ph name="FILE_NAME" />.</translation>
-<translation id="6496823230996795692">A(z) <ph name="APP_NAME" /> első használatakor internetkapcsolatra van szükség.</translation>
-<translation id="6508722015517270189">Indítsa újra a Chrome-ot</translation>
-<translation id="6527303717912515753">Megosztás</translation>
-<translation id="6532866250404780454">A Chrome-ban felkeresett webhelyek nem fognak megjelenni. A webhelyekkel kapcsolatos összes időzítés törlődik.</translation>
-<translation id="6534565668554028783">A Google túl hosszú ideje nem válaszol</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB letöltve</translation>
-<translation id="6539092367496845964">Hiba történt. Próbálja újra később.</translation>
-<translation id="654446541061731451">Válassza ki a sugározni kívánt lapot</translation>
-<translation id="6545017243486555795">Összes adat törlése</translation>
-<translation id="6545864417968258051">Bluetooth-alapú keresés</translation>
-<translation id="6560414384669816528">Keresés a Sogou használatával</translation>
-<translation id="6566259936974865419">A Chrome megspórolt Önnek <ph name="GIGABYTES" /> GB-ot</translation>
-<translation id="6573096386450695060">Engedélyezés mindig</translation>
-<translation id="6573431926118603307">A más eszközökön futó Chrome böngészőben megnyitott lapok itt jelennek meg.</translation>
-<translation id="6583199322650523874">Az aktuális oldal felvétele a könyvjelzők közé</translation>
-<translation id="6593061639179217415">Asztali webhely</translation>
-<translation id="6600954340915313787">A Chrome-ba másolva</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Védett tartalom</translation>
-<translation id="6627583120233659107">Mappa szerkesztése</translation>
-<translation id="6643016212128521049">Törlés</translation>
-<translation id="6643649862576733715">Rendezés a megtakarított adatmennyiség szerint</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Kép előnézete <ph name="BEGIN_NEW" />Új<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">A Chrome-nak hozzá kell férnie a tartózkodási helyhez, hogy eszközöket kereshessen. <ph name="BEGIN_LINK" />Frissítse az engedélyeket<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Jelszó</translation>
-<translation id="6659594942844771486">Lap</translation>
-<translation id="666731172850799929">Megnyitás itt: <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Chrome – Adatvédelmi közlemény</translation>
-<translation id="6676840375528380067">Törli Chrome-adatait az eszközről?</translation>
-<translation id="6697492270171225480">Hasonló oldalakra vonatkozó javaslatok megjelenítése, ha az oldal nem található</translation>
-<translation id="6697947395630195233">A Chrome-nak hozzáférésre van szüksége a helyadatokra ahhoz, hogy megoszthassa a webhellyel az Ön tartózkodási helyét.</translation>
-<translation id="6698801883190606802">Szinkronizálás kezelése</translation>
-<translation id="6699370405921460408">A Google szerverei optimalizálni fogják a megnyitott weboldalakat.</translation>
-<translation id="6706288973712894588">Jelenleg offline állapotban van.\n<ph name="BEGIN_LINK" />Fedezze fel offline hírcsatornáját.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Hírek</translation>
-<translation id="6710213216561001401">Előző</translation>
-<translation id="671481426037969117">A(z) <ph name="FQDN" /> alkalmazás időzítése lejárt. Holnap újraindul.</translation>
-<translation id="6738867403308150051">Letöltés…</translation>
-<translation id="6746124502594467657">Mozgatás lefelé</translation>
-<translation id="6766622839693428701">A bezáráshoz csúsztasson lefelé.</translation>
-<translation id="6766758767654711248">Koppintson a webhely felkereséséhez</translation>
-<translation id="6767294960381293877">Lap megosztására szolgáló eszközök listája félmagasságban megnyitva.</translation>
-<translation id="6782111308708962316">Megakadályozza, hogy harmadik felek webhelyei mentsék és olvassák a cookie-adatokat.</translation>
-<translation id="6790428901817661496">Játék</translation>
-<translation id="6811034713472274749">Az oldal megtekinthető</translation>
-<translation id="6818926723028410516">Válasszon elemeket</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Fordítás</translation>
-<translation id="6845325883481699275">Segítség a Chrome biztonságának továbberősítésében</translation>
-<translation id="6846298663435243399">Betöltés…</translation>
-<translation id="6850409657436465440">A letöltés még mindig folyamatban van</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> lap bezárva</translation>
-<translation id="6864459304226931083">Kép letöltése</translation>
-<translation id="6865313869410766144">Automatikus kitöltési űrlapadatok</translation>
-<translation id="688738109438487280">Meglévő adatok hozzáadása a(z) <ph name="TO_ACCOUNT" /> fiókhoz.</translation>
-<translation id="6891726759199484455">Oldja fel a képernyőzárat a jelszó másolásához</translation>
-<translation id="6896758677409633944">Másolás</translation>
-<translation id="6910211073230771657">Törölve</translation>
-<translation id="6912998170423641340">A vágólapon található szövegek és képek megtekintésének letiltása a webhelyek számára</translation>
-<translation id="6914783257214138813">Jelszavai mindenki számára láthatók lesznek, aki hozzáfér az exportált fájlhoz.</translation>
-<translation id="6942665639005891494">Az alapértelmezett letöltési helyet bármikor módosíthatja a Beállítások menüben</translation>
-<translation id="6945221475159498467">Kiválasztás</translation>
-<translation id="6963642900430330478">Ez az oldal veszélyes. Webhelyadatok</translation>
-<translation id="6963766334940102469">Könyvjelzők törlése</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Mindenkori</translation>
-<translation id="6981982820502123353">Kisegítő lehetőségek</translation>
-<translation id="6989267951144302301">A letöltés sikertelen</translation>
-<translation id="6990079615885386641">Alkalmazás beszerzése a Google Play Áruházból: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára a mikrofon használatát (ajánlott)</translation>
-<translation id="7015203776128479407">A szinkronizálás kezdeti beállítása nem fejeződött be. A szinkronizálás ki van kapcsolva.</translation>
-<translation id="7016516562562142042">Engedélyezett a jelenlegi keresőmotor számára</translation>
-<translation id="7022756207310403729">Megnyitás böngészőben</translation>
-<translation id="702463548815491781">Ajánlott, amikor a TalkBack vagy a Kapcsolóalapú hozzáférés be van kapcsolva</translation>
-<translation id="7029809446516969842">Jelszavak</translation>
-<translation id="7053983685419859001">Letiltás</translation>
-<translation id="7055152154916055070">Átirányítás letiltva:</translation>
-<translation id="7063006564040364415">Nem sikerült csatlakozni a szinkronizálószerverhez.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 elem kijelölve}other{# elem kijelölve}}</translation>
-<translation id="7071521146534760487">Fiók kezelése</translation>
-<translation id="7077143737582773186">SD-kártya</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> elem kiválasztva. A lehetőségek a képernyő tetején találhatók.</translation>
-<translation id="7121362699166175603">Törli a címsávban található előzményeket és automatikus kiegészítéseket. Előfordulhat, hogy a böngészési előzmények más formái még megtalálhatók Google-fiókjában a <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> webhelyen.</translation>
-<translation id="7128222689758636196">Engedélyezi a jelenlegi keresőmotor számára</translation>
-<translation id="7138678301420049075">Egyéb</translation>
-<translation id="7141896414559753902">Előugró ablakok és átirányítások letiltása a webhelyeken (ajánlott)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Eredeti oldal betöltése<ph name="END_LINK" /> innen: <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Az elmúlt 24 órából</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Ezt később módosíthatja a beállítások között.</translation>
-<translation id="7180611975245234373">Frissítés</translation>
-<translation id="7189372733857464326">Várakozás a Google Play-szolgáltatások frissítésének befejezésére</translation>
-<translation id="7191430249889272776">A lap megnyílt a háttérben.</translation>
-<translation id="723171743924126238">Képek kiválasztása</translation>
-<translation id="7233236755231902816">Ha saját nyelvén szeretné böngészni az internetet, szerezze be a Chrome legújabb verzióját</translation>
-<translation id="7243308994586599757">A beállítások a képernyő alsó részén találhatók</translation>
-<translation id="7248069434667874558">Győződjön meg arról, hogy a(z) <ph name="TARGET_DEVICE_NAME" /> szinkronizálása be van kapcsolva a Chrome-ban</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> elem kiválasztva</translation>
-<translation id="7274013316676448362">Letiltott oldal</translation>
-<translation id="7290209999329137901">Nem lehetséges az átnevezés</translation>
-<translation id="7291387454912369099">Segéd által aktivált fizetés</translation>
-<translation id="7293171162284876153">A szinkronizálás megkezdéséhez kapcsolja be a „Chrome-adatok szinkronizálása” beállítást.</translation>
-<translation id="729975465115245577">Az eszközön nincs olyan alkalmazás, amely tárolni tudja a jelszavakat tartalmazó fájlt.</translation>
-<translation id="7302081693174882195">Részletek: Megtakarított adatmennyiség szerinti rendezés</translation>
-<translation id="7328017930301109123">Lite módban a Chrome gyorsabban betölti az oldalakat, és akár 60 százalékkal kisebb adatforgalmat generál.</translation>
-<translation id="7333031090786104871">Az előző webhely hozzáadása még folyamatban van</translation>
-<translation id="7352939065658542140">VIDEÓ</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 kijelölt elem megosztása}other{# kijelölt elem megosztása}}</translation>
 <translation id="7359002509206457351">Hozzáférés a fizetési módokhoz</translation>
+<translation id="8026334261755873520">Böngészési adatok törlése</translation>
+<translation id="1291207594882862231">Előzmények, cookie-k, webhelyadatok és a gyorsítótár törlése…</translation>
+<translation id="7814200940910057384">Brave-adatok törölve</translation>
+<translation id="1664855196866195614">A kiválasztott adatok el lettek távolítva a Brave-ból és a szinkronizált eszközökről.
+
+Előfordulhat, hogy Brave Software-fiókjában (a <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> címen) még szerepelnek a böngészési előzmények egyéb formái, így például a keresések és egyéb tevékenységek más Brave Software-szolgáltatásokból.</translation>
+<translation id="4699172675775169585">A gyorsítótárban szereplő képek és fájlok</translation>
+<translation id="2496180316473517155">Böngészés előzményei</translation>
+<translation id="2546283357679194313">Cookie-k és webhelyadatok</translation>
+<translation id="8662811608048051533">A rendszer a legtöbb webhelyről kijelentkezteti Önt.</translation>
+<translation id="8218628800671693884">A rendszer a legtöbb webhelyről kijelentkezteti Önt, de Brave Software-fiókjából nem.</translation>
+<translation id="2017836877785168846">Törli a címsávban található előzményeket és automatikus kiegészítéseket.</translation>
+<translation id="8096327394278038498">Törli a címsávban található előzményeket és automatikus kiegészítéseket. Előfordulhat, hogy a böngészési előzmények más formái még megtalálhatók Brave Software-fiókjában a <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> webhelyen.</translation>
+<translation id="8122693181154564064">Törli az előzményeket valamennyi bejelentkezett eszközről. Előfordulhat, hogy a böngészési előzmények más formái még megtalálhatók Brave Software-fiókjában a <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> webhelyen.</translation>
+<translation id="5869522115854928033">Mentett jelszavak</translation>
+<translation id="6865313869410766144">Automatikus kitöltési űrlapadatok</translation>
+<translation id="7562080006725997899">Böngészési adatok törlése</translation>
+<translation id="5487521232677179737">Adatok törlése</translation>
+<translation id="7498271377022651285">Kérjük, várjon…</translation>
+<translation id="784934925303690534">Időszak</translation>
+<translation id="1718835860248848330">Az elmúlt órából</translation>
+<translation id="7149893636342594995">Az elmúlt 24 órából</translation>
+<translation id="5648166631817621825">Az elmúlt 7 napból</translation>
+<translation id="8571213806525832805">Az elmúlt négy hétből</translation>
+<translation id="5854790677617711513">30 napnál régebbi</translation>
+<translation id="6979737339423435258">Mindenkori</translation>
+<translation id="982182592107339124">Ezzel törli az összes webhely adatait, beleértve a következőket:</translation>
+<translation id="6643016212128521049">Törlés</translation>
+<translation id="7641339528570811325">Böngészési adatok törlése…</translation>
+<translation id="1670399744444387456">Alapok</translation>
+<translation id="3245261285041759672">Előfordulhat, hogy a böngészési előzmények más formái még megtalálhatók Brave Software-fiókjában a <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> webhelyen.</translation>
+<translation id="7274013316676448362">Letiltott oldal</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> elem törölve</translation>
+<translation id="1121094540300013208">Használati és hibajelentések</translation>
+<translation id="9079153198295609735">Használati statisztikák és hibajelentések automatikus küldése a Brave Software-nak</translation>
+<translation id="6981982820502123353">Kisegítő lehetőségek</translation>
+<translation id="2387895666653383613">Szöveg nagyítása</translation>
+<translation id="2321958826496381788">Húzza a csúszkát, amíg kényelmesen nem tudja olvasni a szöveget. A szövegnek legalább ekkorának kell lennie, miután duplán koppint egy bekezdésre.</translation>
+<translation id="3895926599014793903">A nagyítás mindig engedélyezett</translation>
+<translation id="5668404140385795438">Felülbírálja a webhely kérelmét, mely megakadályozná a nagyítást</translation>
+<translation id="4149994727733219643">Weboldalak egyszerűsített nézete</translation>
+<translation id="9100505651305367705">Felajánlja, hogy egyszerűsített nézetben jeleníti meg a cikkeket (ha támogatott a funkció)</translation>
+<translation id="1409426117486808224">A megnyitott lapok egyszerűsített nézete</translation>
+<translation id="702463548815491781">Ajánlott, amikor a TalkBack vagy a Kapcsolóalapú hozzáférés be van kapcsolva</translation>
+<translation id="8284326494547611709">Feliratok</translation>
+<translation id="4165986682804962316">Webhelybeállítások</translation>
+<translation id="6295158916970320988">Az összes webhely</translation>
+<translation id="8380167699614421159">Ez a webhely tolakodó vagy félrevezető hirdetéseket jelenít meg</translation>
+<translation id="1919345977826869612">Hirdetések</translation>
+<translation id="410351446219883937">Automatikus lejátszás</translation>
+<translation id="6447842834002726250">Cookie-k</translation>
+<translation id="6196640612572343990">Harmadik féltől származó cookie-k letiltása</translation>
+<translation id="6782111308708962316">Megakadályozza, hogy harmadik felek webhelyei mentsék és olvassák a cookie-adatokat.</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Előugró ablakok és átirányítások</translation>
+<translation id="4751476147751820511">Mozgás- és fényérzékelők</translation>
+<translation id="1717218214683051432">Mozgásérzékelők</translation>
+<translation id="2091887806945687916">Hang</translation>
+<translation id="2586657967955657006">Vágólap</translation>
+<translation id="6320088164292336938">Rezgés</translation>
+<translation id="4226663524361240545">Az értesítések miatt rezeghet az eszköz</translation>
+<translation id="1446450296470737166">MIDI-eszközök teljes vezérlése</translation>
+<translation id="3744111561329211289">Szinkronizálás a háttérben</translation>
+<translation id="5649053991847567735">Automatikus letöltések</translation>
+<translation id="6181444274883918285">Webhelykivétel hozzáadása</translation>
+<translation id="5313967007315987356">Webhely hozzáadása</translation>
+<translation id="1369915414381695676">A(z) <ph name="SITE_NAME"/> webhely hozzáadva</translation>
+<translation id="7837721118676387834">A némított videók automatikus lejátszásának engedélyezése az adott webhelyen.</translation>
+<translation id="2621115761605608342">A JavaScript engedélyezése egy adott webhelyen.</translation>
+<translation id="8801436777607969138">JavaScript letiltása adott webhelynél.</translation>
+<translation id="8372893542064058268">Háttérben történő szinkronizálás engedélyezése adott webhely esetében.</translation>
+<translation id="358794129225322306">Engedély webhelynek több fájl automatikus letöltésére.</translation>
+<translation id="4008040567710660924">Adott webhely cookie-jainak engedélyezése.</translation>
+<translation id="8958424370300090006">Adott webhely cookie-jainak letiltása.</translation>
+<translation id="7882806643839505685">Egy adott webhely hangjának engedélyezése.</translation>
+<translation id="4468959413250150279">Egy adott webhely hangjának némítása.</translation>
+<translation id="1994173015038366702">Webhely URL-je</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Használat</translation>
+<translation id="5804241973901381774">Engedélyek</translation>
+<translation id="4278390842282768270">Engedélyezve</translation>
+<translation id="5677928146339483299">Letiltva</translation>
+<translation id="1984937141057606926">Engedélyezve, kivéve a harmadik felektől származó cookie-kat</translation>
+<translation id="7423098979219808738">Kérdezzen rá</translation>
+<translation id="8116925261070264013">Némítva</translation>
+<translation id="8300705686683892304">Alkalmazás által kezelt</translation>
+<translation id="6192792657125177640">Kivételek</translation>
+<translation id="257931822824936280">Kibontva – kattintson az összecsukáshoz.</translation>
+<translation id="5100237604440890931">Összecsukva – kattintson a kibontáshoz.</translation>
+<translation id="857943718398505171">Engedélyezve (ajánlott)</translation>
+<translation id="2913331724188855103">Cookie-adatok mentésének és olvasásának engedélyezése a webhelyeken (ajánlott)</translation>
+<translation id="7445411102860286510">Lehetővé teszi a webhelyek számára a némított videók automatikus lejátszását (ajánlott)</translation>
+<translation id="5335288049665977812">Engedélyezze a webhelyek számára a JavaScript futtatását (ajánlott)</translation>
+<translation id="5527111080432883924">Kérdezzen rá, mielőtt engedélyezi a webhelyeknek, hogy megtekintsék a vágólapon található szövegeket és képeket (ajánlott)</translation>
+<translation id="6912998170423641340">A vágólapon található szövegek és képek megtekintésének letiltása a webhelyek számára</translation>
+<translation id="7423538860840206698">Le van tiltva a vágólap megtekintése</translation>
+<translation id="3955193568934677022">Engedélyezi a webhelyek számára a védett tartalmak lejátszását (ajánlott)</translation>
+<translation id="445467742685312942">Védett tartalmak lejátszásának engedélyezése a webhelyek számára</translation>
+<translation id="2107397443965016585">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára védett tartalmak lejátszását (ajánlott)</translation>
+<translation id="2910701580606108292">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára védett tartalmak lejátszását</translation>
+<translation id="757524316907819857">Védett tartalom lejátszásának letiltása a webhelyeken</translation>
+<translation id="3277252321222022663">Az érzékelőkhöz való hozzáférés engedélyezése a webhelyek számára (ajánlott)</translation>
+<translation id="5048398596102334565">A mozgásérzékelőkhöz való hozzáférés engedélyezése a webhelyek számára (ajánlott)</translation>
+<translation id="8816026460808729765">Az érzékelőkhöz való hozzáférés tiltása a webhelyek számára</translation>
+<translation id="169515064810179024">A mozgásérzékelőkhöz való hozzáférés letiltása a webhelyek számára</translation>
+<translation id="1660204651932907780">A webhelyek lejátszhatnak hangokat (ajánlott)</translation>
+<translation id="3600792891314830896">Elnémítja a hangot lejátszó webhelyeket</translation>
+<translation id="1743802530341753419">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára egy adott eszközhöz való csatlakozást (ajánlott)</translation>
+<translation id="851751545965956758">Az eszközökhöz való csatlakozás megtiltása a webhelyeknek</translation>
+<translation id="7141896414559753902">Előugró ablakok és átirányítások letiltása a webhelyeken (ajánlott)</translation>
+<translation id="5494752089476963479">Hirdetések letiltása a tolakodó és félrevezető hirdetéseket megjelenítő webhelyeken</translation>
+<translation id="3123473560110926937">Letiltva egyes webhelyeken</translation>
+<translation id="965817943346481315">Letiltás, ha a webhely tolakodó vagy félrevezető hirdetéseket jelenít meg (ajánlott)</translation>
+<translation id="3386292677130313581">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára a tartózkodási helyhez való hozzáférést (ajánlott)</translation>
+<translation id="9139068048179869749">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára az értesítések küldését (ajánlott)</translation>
+<translation id="4479647676395637221">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára a kamera használatát (ajánlott)</translation>
+<translation id="6992289844737586249">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára a mikrofon használatát (ajánlott)</translation>
+<translation id="2289270750774289114">Kérdezzen rá, ha valamelyik webhely szeretné felfedezni a közeli Bluetooth-eszközöket (ajánlott)</translation>
+<translation id="7053983685419859001">Letiltás</translation>
+<translation id="7128222689758636196">Engedélyezi a jelenlegi keresőmotor számára</translation>
+<translation id="7589445247086920869">Tiltja a jelenlegi keresőmotor számára</translation>
+<translation id="6388207532828177975">Törlés és visszaállítás</translation>
+<translation id="7999064672810608036">Biztosan törli a webhellyel kapcsolatos összes helyi adatot (a cookie-kkal együtt), és visszaállítja az összes engedélyt?</translation>
+<translation id="2822354292072154809">Biztosan visszaállítja a(z) <ph name="CHOSEN_OBJECT_NAME"/> minden webhelyengedélyét?</translation>
+<translation id="515227803646670480">Tárolt adatok törlése</translation>
+<translation id="5902828464777634901">A webhely által tárolt összes adat törlődik (a cookie-kat is beleértve).</translation>
+<translation id="119944043368869598">Összes törlése</translation>
+<translation id="2490684707762498678">Kezelő: <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Értesítési beállítások megnyitása</translation>
+<translation id="1404122904123200417">Beágyazva itt: <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">A webhelyek által elmentett fájlok itt jelennek meg</translation>
+<translation id="4181841719683918333">Nyelvek</translation>
+<translation id="2647434099613338025">Nyelv hozzáadása</translation>
+<translation id="1952172573699511566">A webhelyek szövege a preferált nyelven jelenik meg, ha lehetséges.</translation>
+<translation id="8559990750235505898">Más nyelvű oldalak fordításának felajánlása</translation>
+<translation id="4719927025381752090">Fordítás felajánlása</translation>
+<translation id="8156139159503939589">Milyen nyelveken olvas?</translation>
+<translation id="5689516760719285838">Tartózkodási hely</translation>
+<translation id="2440823041667407902">Helyhozzáférés</translation>
+<translation id="2023546461831060654">A Brave-ra vonatkozó engedélyek aktiválása az <ph name="BEGIN_LINK"/>Android beállításaiban<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">A Brave-ra vonatkozó engedélyt az <ph name="BEGIN_LINK"/>Android beállításaiban<ph name="END_LINK"/> lehet aktiválni.</translation>
+<translation id="2928908108430545745">Ahhoz, hogy a Brave hozzáférhessen a helyadatokhoz, a helyadatokat az <ph name="BEGIN_LINK"/>Android-beállítások<ph name="END_LINK"/> között is be kell kapcsolni.</translation>
+<translation id="1028853271388022585">Ahhoz, hogy a Brave hozzáférhessen a kamerához, a kamerát az <ph name="BEGIN_LINK"/>Android-beállítások<ph name="END_LINK"/> között is be kell kapcsolni.</translation>
+<translation id="2913721282607281710">Ahhoz, hogy a Brave értesítéseket küldhessen, az értesítéseket az <ph name="BEGIN_LINK"/>Android-beállítások<ph name="END_LINK"/> között is be kell kapcsolni.</translation>
+<translation id="8753483718490035722">Ahhoz, hogy a Brave hozzáférhessen a mikrofonhoz, a mikrofont az <ph name="BEGIN_LINK"/>Android-beállítások<ph name="END_LINK"/> között is be kell kapcsolni.</translation>
+<translation id="1887786770086287077">A helyhozzáférés ki van kapcsolva ennél az eszköznél. A funkciót az <ph name="BEGIN_LINK"/>Android-beállításokban<ph name="END_LINK"/> tudja bekapcsolni.</translation>
+<translation id="2570922361219980984">A helyhozzáférés is ki van kapcsolva ennél az eszköznél. A funkciót az <ph name="BEGIN_LINK"/>Android-beállításokban<ph name="END_LINK"/> tudja bekapcsolni.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Hozzáférés a fényképezőgéphez</translation>
+<translation id="945632385593298557">Hozzáférés a mikrofonhoz</translation>
+<translation id="6612358246767739896">Védett tartalom</translation>
+<translation id="885701979325669005">Tárolás</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> tárolt adat</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Eszközengedély visszavonása</translation>
+<translation id="4962975101802056554">Az eszköz összes engedélyének visszavonása</translation>
+<translation id="6545864417968258051">Bluetooth-alapú keresés</translation>
+<translation id="4411535500181276704">Egyszerűsített mód</translation>
+<translation id="7821588508402923572">Itt látható a megtakarított adatmennyiség</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> megtakarítva</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> óta</translation>
+<translation id="3252158532344029638">Lite módban a Brave gyorsabban betölti az oldalakat, és akár 60 százalékkal kisebb adatforgalmat generál.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/>-os adatmegtakarítás</translation>
+<translation id="7494974237137038751">megtakarított adatmennyiség</translation>
+<translation id="6111020039983847643">használt adatmennyiség</translation>
+<translation id="7413229368719586778">Kezdés dátuma: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Befejezés dátuma: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Rendezés webhely szerint</translation>
+<translation id="5864174910718532887">Részletek: Webhelynév szerinti rendezés</translation>
+<translation id="116280672541001035">Használt</translation>
+<translation id="8349013245300336738">Rendezés a felhasznált adatmennyiség szerint</translation>
+<translation id="6378173571450987352">Részletek: Felhasznált adatmennyiség szerinti rendezés</translation>
+<translation id="2631006050119455616">Megtakarított</translation>
+<translation id="6643649862576733715">Rendezés a megtakarított adatmennyiség szerint</translation>
+<translation id="7302081693174882195">Részletek: Megtakarított adatmennyiség szerinti rendezés</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> felhasználva</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> megtakarított adatmennyiség</translation>
+<translation id="2156074688469523661">A többi webhely (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Egyéb</translation>
+<translation id="4913161338056004800">Statisztikák alaphelyzetbe állítása</translation>
+<translation id="1856325424225101786">Visszaállítja az Egyszerűsített módot?</translation>
+<translation id="3658159451045945436">A visszaállítás törli a megtakarított adatmennyiségre vonatkozó előzményeket, így a felkeresett webhelyek listáját is.</translation>
+<translation id="3295530008794733555">Gyorsabb böngészés. Kevesebb adathasználat.</translation>
+<translation id="7340390500800578919">Lite módban a Brave gyorsabban betölti az oldalakat, és akár 60 százalékkal kisebb adatforgalmat generál. A felkeresett oldalak optimalizálása érdekében a Brave elküldi az internetes forgalmát a Brave Software-nak. <ph name="BEGIN_LINK"/>További információ<ph name="END_LINK"/>.</translation>
+<translation id="4538018662093857852">Az Egyszerűsített mód bekapcsolása</translation>
+<translation id="4493497663118223949">Az Egyszerűsített mód be van kapcsolva</translation>
+<translation id="7559975015014302720">Az Egyszerűsített mód ki van kapcsolva</translation>
+<translation id="7606077192958116810">Az Egyszerűsített mód be van kapcsolva. Kezelésére a Beállításokban van lehetősége.</translation>
+<translation id="4714588616299687897">Akár 60%-kal is csökkentheti adatforgalmát</translation>
+<translation id="1006927014032731288">A Brave Software szerverei optimalizálni fogják a megnyitott weboldalakat.</translation>
+<translation id="3257320067425202300">A Brave <ph name="MEGABYTES"/> MB-ot spórolt meg Önnek</translation>
+<translation id="5813223329348543512">A Brave megspórolt Önnek <ph name="GIGABYTES"/> GB-ot</translation>
+<translation id="8266862848225348053">Letöltés helye</translation>
+<translation id="7077143737582773186">SD-kártya</translation>
+<translation id="7762668264895820836">SD-kártya (<ph name="SD_CARD_NUMBER"/>)</translation>
+<translation id="6341580099087024258">Rákérdezés a fájlok mentésének helyére</translation>
+<translation id="6192333916571137726">Fájl letöltése</translation>
+<translation id="1672586136351118594">Ne jelenjen meg többé</translation>
+<translation id="2650751991977523696">Letölti újra a fájlt?</translation>
+<translation id="8664979001105139458">Már van ilyen nevű fájl</translation>
+<translation id="488187801263602086">Fájl átnevezése</translation>
+<translation id="5686790454216892815">A fájl neve túl hosszú</translation>
+<translation id="7454641608352164238">Nincs elég tárhely</translation>
+<translation id="8972098258593396643">Letölti az alapértelmezett mappába?</translation>
+<translation id="804335162455518893">Az SD-kártya nem található</translation>
+<translation id="7475688122056506577">Az SD-kártya nem található. Előfordulhat, hogy egyes fájlok hiányoznak.</translation>
+<translation id="4198423547019359126">Nem áll rendelkezésre letöltési hely</translation>
+<translation id="8224471946457685718">Cikkek letöltése Wi-Fi-kapcsolaton keresztül</translation>
+<translation id="4970824347203572753">Nem áll rendelkezésre az Ön tartózkodási helyén</translation>
+<translation id="5500777121964041360">Előfordulhat, hogy ez a beállítás nem áll rendelkezésre az Ön tartózkodási helyén</translation>
+<translation id="1173894706177603556">Átnevezés</translation>
+<translation id="1986685561493779662">Már van ilyen név</translation>
+<translation id="6441734959916820584">Túl hosszú a név</translation>
+<translation id="2923908459366352541">A név érvénytelen</translation>
+<translation id="7290209999329137901">Nem lehetséges az átnevezés</translation>
+<translation id="3334729583274622784">Módosítja a fájl kiterjesztését?</translation>
+<translation id="107147699690128016">Ha módosítja a fájl kiterjesztését, előfordulhat, hogy a fájlt másik alkalmazás nyitja meg, ami veszélyt jelenthet az eszközre.</translation>
+<translation id="8541922081612557424">A Brave névjegye</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Minden jog fenntartva.</translation>
+<translation id="1416550906796893042">Alkalmazás verziószáma</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Frissítve: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operációs rendszer</translation>
+<translation id="3968054912784331254">Az Android jelen verziója a továbbiakban már nem támogatja a Brave-frissítéseket</translation>
+<translation id="7665369617277396874">Fiók hozzáadása</translation>
+<translation id="649070405679044769">Bejelentkezve a Brave Software rendszerébe mint</translation>
+<translation id="6234515504547364178">Kijelentkezés a Brave-ból</translation>
+<translation id="5324858694974489420">Szülői beállítások</translation>
+<translation id="8920114477895755567">Várakozás a szülői adatokra.</translation>
+<translation id="5512137114520586844">A fiók kezelője: <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">A fiók kezelői: <ph name="PARENT_NAME_1"/> és <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Tartalom</translation>
+<translation id="5403644198645076998">Csak bizonyos webhelyek engedélyezése</translation>
+<translation id="8641930654639604085">Felnőtteknek szóló webhelyek letiltásának megkísérlése</translation>
+<translation id="5639724618331995626">Minden webhely engedélyezése</translation>
+<translation id="796823723482603597">A Brave erejével</translation>
+<translation id="6324034347079777476">Az Android rendszer szinkronizálása letiltva</translation>
+<translation id="5127805178023152808">Szinkronizálás kikapcsolva</translation>
+<translation id="7015203776128479407">A szinkronizálás kezdeti beállítása nem fejeződött be. A szinkronizálás ki van kapcsolva.</translation>
+<translation id="2497852260688568942">A szinkronizálást letiltotta a rendszergazda</translation>
+<translation id="9100610230175265781">Összetett jelszó szükséges</translation>
+<translation id="6108923351542677676">A telepítés folyamatban...</translation>
+<translation id="4062305924942672200">Jogi információk</translation>
+<translation id="4256782883801055595">Nyílt forráskódú licencek</translation>
+<translation id="1138681184697033370">Brave – Általános Szerződési Feltételek</translation>
+<translation id="7392539049993970338">Brave – Adatvédelmi közlemény</translation>
+<translation id="2677748264148917807">Lap elhagyása</translation>
+<translation id="5556459405103347317">Újratöltés</translation>
+<translation id="1623104350909869708">Akadályozza meg, hogy ez az oldal további párbeszédablakokat hozzon létre.</translation>
+<translation id="2968755619301702150">Tanúsítványmegtekintő</translation>
+<translation id="1360432990279830238">Kijelentkezik, és kikapcsolja a szinkronizálást?</translation>
+<translation id="8581481290581777242">Törli Brave-adatait az eszközről?</translation>
+<translation id="1318865768845061710">Könyvjelzői, előzményei, jelszavai és más Brave-adatai többé nem lesznek szinkronizálva a Brave Software-fiókjával.</translation>
+<translation id="3325020657155065477">Az Ön Brave-adatai is törlődjenek erről az eszközről</translation>
+<translation id="6136448902816743006">Mivel kijelentkezik a(z) <ph name="DOMAIN_NAME"/> által kezelt fiókból, a rendszer törli az Ön Brave-adatait erről az eszközről. Brave Software-fiókjában továbbra is megmaradnak ezek az adatok.</translation>
+<translation id="1853026300647876496">Kapcsolatfelvétel a Brave Software-lal… ez eltarthat pár percig…</translation>
+<translation id="2328985652426384049">Nem sikerült a bejelentkezés</translation>
+<translation id="7723158744459952869">A Brave Software túl hosszú ideje nem válaszol</translation>
+<translation id="4572422548854449519">Bejelentkezés a kezelt fiókba</translation>
+<translation id="2689656545739939160">Egy <ph name="MANAGED_DOMAIN"/> által felügyelt fiókkal jelentkezik be, és engedélyezi az adminisztrátor számára a Brave-adatok kezelését. Adatai állandó jelleggel ehhez a fiókhoz lesznek társítva. A Brave-ból való kijelentkezéssel törli adatait erről az eszközről, de Brave Software-fiókjában továbbra is megmaradnak.</translation>
+<translation id="1749561566933687563">Könyvjelzők szinkronizálása</translation>
+<translation id="4242533952199664413">Beállítások megnyitása</translation>
+<translation id="1111673857033749125">A más eszközökön mentett könyvjelzők itt jelennek meg.</translation>
+<translation id="8636825310635137004">Ha a többi eszközén is szeretné elérni lapjait, kapcsolja be a szinkronizálást</translation>
+<translation id="3269956123044984603">A többi eszközéről is hozzáférhet a lapjaihoz, ha bekapcsolja az Android-fiókbeállítások között található „Adatok automatikus szinkronizálása” funkciót.</translation>
+<translation id="5157964048453367290">A más eszközökön futó Brave böngészőben megnyitott lapok itt jelennek meg.</translation>
+<translation id="4684427112815847243">Az összes szinkronizálása</translation>
+<translation id="2709516037105925701">Automatikus kitöltés</translation>
+<translation id="8820817407110198400">Könyvjelzők</translation>
+<translation id="1644574205037202324">Előzmények</translation>
+<translation id="17513872634828108">Megnyitott lapok</translation>
+<translation id="1320169905922104972">A Brave Software Pay szolgáltatást használó hitelkártyák és címek</translation>
+<translation id="6337234675334993532">Titkosítás</translation>
+<translation id="6698801883190606802">Szinkronizálás kezelése</translation>
+<translation id="3598578758776312506">A jelszavak titkosítása a Brave Software hitelesítési adataival</translation>
+<translation id="7810580217418711046">A szinkronizált adatok titkosítása Brave Software-jelszóval ekkortól: <ph name="TIME"/></translation>
+<translation id="8461694314515752532">A szinkronizált adatok titkosítása saját összetett szinkronizálási jelszóval</translation>
+<translation id="2996291259634659425">Összetett jelszó létrehozása</translation>
+<translation id="5713644099811900409">Brave Software Fiókjába</translation>
+<translation id="8997474919031554666">Az összetett jelszavas titkosítás nem tartalmazza a Brave Software Payben megadott fizetési módokat és címeket. Titkosított adatait csak az olvashatja el, aki rendelkezik az Ön összetett jelszavával. Az összetett jelszót a Brave Software nem kapja meg, és nem is tárolja. Ha elfelejtette összetett jelszavát, vagy módosítaná ezt a beállítást, alaphelyzetbe kell állítania a szinkronizálást. <ph name="BEGIN_LINK"/>További információ<ph name="END_LINK"/>.</translation>
+<translation id="9050666287014529139">Összetett jelszó</translation>
+<translation id="7772032839648071052">Összetett jelszó megerősítése</translation>
+<translation id="5304593522240415983">Ez a mező nem lehet üres</translation>
+<translation id="321773570071367578">Ha elfelejtette összetett jelszavát, vagy módosítani szeretné ezt a beállítást, <ph name="BEGIN_LINK"/>állítsa alaphelyzetbe a szinkronizálást<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Az összetett jelszavak nem egyeznek</translation>
+<translation id="5149495116300586333">Az összetett jelszavas titkosítás nem tartalmazza a Brave Software Payben megadott fizetési módokat és címeket.
+
+A beállítás módosításához <ph name="BEGIN_LINK"/>állítsa vissza a szinkronizálást<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Hibás összetett jelszó</translation>
+<translation id="5414836363063783498">Ellenőrzés...</translation>
+<translation id="6846298663435243399">Betöltés…</translation>
+<translation id="5517095782334947753">Vannak könyvjelzői, előzményei, jelszavai és más beállításai a(z) <ph name="FROM_ACCOUNT"/> fiókból.</translation>
+<translation id="3928666092801078803">Adataim egyesítése</translation>
+<translation id="688738109438487280">Meglévő adatok hozzáadása a(z) <ph name="TO_ACCOUNT"/> fiókhoz.</translation>
+<translation id="806745655614357130">Maradjanak elkülönítve az adataim</translation>
+<translation id="1145536944570833626">Meglévő adatok törlése.</translation>
+<translation id="1993768208584545658">A(z) <ph name="SITE"/> párosítást szeretne végrehajtani</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Kérjen segítséget<ph name="END_LINK"/>, miközben eszközöket keresünk…</translation>
+<translation id="5817918615728894473">Párosítás</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Kérjen segítséget<ph name="END_LINK1"/>, vagy <ph name="BEGIN_LINK2"/>keressen rá újra<ph name="END_LINK2"/>.</translation>
+<translation id="230115972905494466">Nem találhatók kompatibilis eszközök</translation>
+<translation id="3773755127849930740">A párosítás engedélyezéséhez <ph name="BEGIN_LINK"/>kapcsolja be a Bluetooth funkciót<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">A Brave nem tudja bekapcsolni a Bluetooth-adaptert</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Kérjen segítséget<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">A Brave-nak hozzá kell férnie a tartózkodási helyhez, hogy eszközöket kereshessen. <ph name="BEGIN_LINK"/>Frissítse az engedélyeket<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">A Brave-nak hozzá kell férnie a tartózkodási helyhez, hogy eszközöket kereshessen. A tartózkodási helyhez való hozzáférés <ph name="BEGIN_LINK"/>ki van kapcsolva ezen az eszközön<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">A Brave-nak hozzá kell férnie a tartózkodási helyhez, hogy eszközöket kereshessen. <ph name="BEGIN_LINK1"/>Frissítse az engedélyeket<ph name="END_LINK1"/>. A helyadatokhoz való hozzáférés is <ph name="BEGIN_LINK2"/>ki van kapcsolva ezen az eszközön<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Csatlakoztatott eszköz</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Jelerősség szintje: # sáv}other{Jelerősség szintje: # sáv}}</translation>
+<translation id="5230560987958996918">A(z) <ph name="SITE"/> szeretné megkeresni a közeli Bluetooth-eszközöket. A következő eszközöket találta:</translation>
+<translation id="8368027906805972958">Ismeretlen vagy nem támogatott eszköz (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">A szinkronizálás nem működik.</translation>
+<translation id="1810845389119482123">A szinkronizálás kezdeti beállítása nem fejeződött be</translation>
+<translation id="3235722914093408050">Aktiválja újra az Android rendszer szinkronizálását a Brave-szinkronizáláshoz</translation>
+<translation id="3367813778245106622">A szinkronizálás megkezdéséhez jelentkezzen be újra</translation>
+<translation id="974555521953189084">A szinkronizálás megkezdéséhez adja meg összetett jelszavát</translation>
+<translation id="2997266899014181325">A szinkronizálás megkezdéséhez kapcsolja be a „Brave-adatok szinkronizálása” beállítást.</translation>
+<translation id="8260126382462817229">Próbáljon meg újra bejelentkezni</translation>
+<translation id="5919204609460789179">A szinkronizálás megkezdéséhez frissítse a következőt: <ph name="PRODUCT_NAME"/></translation>
+<translation id="397583555483684758">A szinkronizálás leállt</translation>
+<translation id="1966710179511230534">Kérjük, frissítse bejelentkezési adatait.</translation>
+<translation id="7063006564040364415">Nem sikerült csatlakozni a szinkronizálószerverhez.</translation>
+<translation id="7942131818088350342">A(z) <ph name="PRODUCT_NAME"/> elavult.</translation>
+<translation id="4170011742729630528">A szolgáltatás nem érhető el, próbálja újra később.</translation>
+<translation id="7947953824732555851">Elfogadás és bejelentkezés</translation>
+<translation id="8583805026567836021">Fiókadatok törlése</translation>
+<translation id="8310344678080805313">Szabványos lapok</translation>
+<translation id="5748802427693696783">Szabványos lapokra váltva</translation>
+<translation id="7998918019931843664">Bezárt lap megnyitása</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/> lap</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> lap bezárása</translation>
+<translation id="7243308994586599757">A beállítások a képernyő alsó részén találhatók</translation>
+<translation id="4060598801229743805">A lehetőségek a képernyő tetején találhatók</translation>
+<translation id="2810645512293415242">Egyszerűsített oldal az alacsonyabb adathasználat és a gyorsabb betöltés érdekében.</translation>
+<translation id="3985215325736559418">Ismét letölti a(z) <ph name="FILE_NAME"/> fájlt?</translation>
+<translation id="2450083983707403292">Szeretné újra elkezdeni a(z) <ph name="FILE_NAME"/> letöltését?</translation>
+<translation id="7514365320538308">Letöltés</translation>
+<translation id="545042621069398927">Letöltés felgyorsítása…</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Fájl letöltése…}other{# fájl letöltése…}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> fájl letöltése folyamatban (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Fájl letöltése folyamatban (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 letöltés befejeződött.}other{# letöltés befejeződött.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 letöltés nem sikerült.}other{# letöltés nem sikerült.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 letöltés függőben.}other{# letöltés függőben.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> gomb</translation>
+<translation id="3205824638308738187">Majdnem kész.</translation>
+<translation id="3960299545138990065">Indítsa újra a Brave-ot</translation>
+<translation id="3771001275138982843">Nem sikerült letölteni a frissítést</translation>
+<translation id="3888648114124182147">A Brave frissítésének letöltése…</translation>
+<translation id="1705567146636171298">A Brave böngésző frissítése</translation>
+<translation id="6195417478702700398">Nyissa meg a Brave-ot, és frissítsen a legjobb böngészési élmény érdekében</translation>
+<translation id="3512968675351418494">Ha saját nyelvén szeretné böngészni az internetet, szerezze be a Brave legújabb verzióját</translation>
+<translation id="6427112570124116297">Lefordíthatja az internetet</translation>
+<translation id="1379423114029199501">Frissítsen, hogy a saját nyelvén használhassa a Brave legújabb verzióját</translation>
+<translation id="5684874026226664614">Hoppá! Az oldalt nem sikerült lefordítani.</translation>
+<translation id="6831043979455480757">Fordítás</translation>
+<translation id="1285320974508926690">Ezt a webhelyet soha ne fordítsa le</translation>
+<translation id="773466115871691567">Mindig fordítsa le a(z) <ph name="SOURCE_LANGUAGE"/> nyelvű oldalakat</translation>
+<translation id="1068672505746868501">Soha ne fordítsa le a(z) <ph name="SOURCE_LANGUAGE"/> nyelvű oldalakat</translation>
+<translation id="124116460088058876">További nyelvek…</translation>
+<translation id="290376772003165898">Az oldal nem <ph name="LANGUAGE"/> nyelvű?</translation>
+<translation id="4432792777822557199">A(z) <ph name="SOURCE_LANGUAGE"/> nyelvű oldalak mostantól le lesznek fordítva <ph name="TARGET_LANGUAGE"/> nyelvre</translation>
+<translation id="8339163506404995330">A(z) <ph name="LANGUAGE"/> nyelvű oldalak nem lesznek lefordítva</translation>
+<translation id="5447765697759493033">Nem fordítjuk le ezt a webhelyet</translation>
+<translation id="4880127995492972015">Fordítás…</translation>
+<translation id="641643625718530986">Nyomtatás…</translation>
+<translation id="8909135823018751308">Megosztás...</translation>
+<translation id="4996978546172906250">Megosztás itt:</translation>
+<translation id="6333140779060797560">Megosztás a következőn keresztül: <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Hiba történt az oldal nyomtatásakor. Próbálja újra.</translation>
+<translation id="3254409185687681395">Könyvjelző hozzáadása ehhez az oldalhoz</translation>
+<translation id="497421865427891073">Előrelépés</translation>
+<translation id="813082847718468539">Az oldalinformációk megtekintése</translation>
+<translation id="2532336938189706096">Internetes megtekintés</translation>
+<translation id="6005538289190791541">Javasolt jelszó</translation>
+<translation id="4634124774493850572">Jelszó használata</translation>
+<translation id="8285489906452138776">A Brave számára engedély szükséges, hogy hozzáférjen a kamerához ennél a webhelynél.</translation>
+<translation id="320189792589364011">A Brave számára engedély szükséges, hogy hozzáférjen a mikrofonhoz ennél a webhelynél.</translation>
+<translation id="7988136689212463100">A Brave számára engedély szükséges, hogy hozzáférjen a kamerához és a mikrofonhoz ennél a webhelynél.</translation>
+<translation id="4931190655840828017">A Brave-nak hozzáférésre van szüksége a helyadatokra ahhoz, hogy megoszthassa a webhellyel az Ön tartózkodási helyét.</translation>
+<translation id="3088191967551450609">A Brave-nak tárhelyhozzáférésre van szüksége a fájlok letöltéséhez.</translation>
+<translation id="8942627711005830162">Megnyitás másik ablakban</translation>
+<translation id="4195643157523330669">Megnyitás új lapon</translation>
+<translation id="1100066534610197918">Megnyitás új lapon, csoportban</translation>
+<translation id="4860895144060829044">Hívás</translation>
+<translation id="6896758677409633944">Másolás</translation>
+<translation id="8393700583063109961">Üzenet küldése</translation>
+<translation id="3557336313807607643">Hozzáadás a névjegyekhez</translation>
+<translation id="4269820728363426813">Link másolása</translation>
+<translation id="1206892813135768548">Link szövegének másolása</translation>
+<translation id="1204037785786432551">Link letöltése</translation>
+<translation id="6864459304226931083">Kép letöltése</translation>
+<translation id="8209050860603202033">Kép megnyitása</translation>
+<translation id="8073388330009372546">Kép megnyitása új lapon</translation>
+<translation id="6649642165559792194">Kép előnézete <ph name="BEGIN_NEW"/>Új<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Kép betöltése</translation>
+<translation id="3845332215609790146">Keresés a Brave Software Lensszel <ph name="BEGIN_NEW"/>Új<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">A kép keresése a(z) <ph name="SEARCH_ENGINE"/> keresővel</translation>
+<translation id="3384347053049321195">Kép megosztása</translation>
+<translation id="5833984609253377421">Link megosztása</translation>
+<translation id="6475951671322991020">Videó letöltése</translation>
+<translation id="2317945146070194624">Megnyitás új Brave-lapon</translation>
+<translation id="7975379999046275268">Oldal előnézete <ph name="BEGIN_NEW"/>Új<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Oldal frissítése</translation>
+<translation id="36525718899759834">Alkalmazás beszerzése a Brave Software Play Áruházból: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Sötét</translation>
+<translation id="1807246157184219062">Világos</translation>
+<translation id="4056223980640387499">Szépia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Válassza ki a sugározni kívánt lapot</translation>
+<translation id="8719023831149562936">Nem lehet átsugározni a jelenlegi lapot</translation>
+<translation id="2139186145475833000">Kezdőképernyőre</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> megnyitása</translation>
+<translation id="2122601567107267586">Nem sikerült megnyitni az alkalmazást</translation>
+<translation id="5129038482087801250">Webes alkalmazás telepítése</translation>
+<translation id="3789841737615482174">Telepítés</translation>
+<translation id="4665282149850138822">A(z) <ph name="NAME"/> felkerült a kezdőképernyőre</translation>
+<translation id="7333031090786104871">Az előző webhely hozzáadása még folyamatban van</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> hozzáadása…</translation>
+<translation id="3778956594442850293">Hozzáadva a kezdőképernyőhöz</translation>
+<translation id="2146738493024040262">Azonnali alkalmazás megnyitása</translation>
+<translation id="7016516562562142042">Engedélyezett a jelenlegi keresőmotor számára</translation>
+<translation id="6177111841848151710">Tiltott a jelenlegi keresőmotor számára</translation>
+<translation id="145097072038377568">Kikapcsolva az Android beállításaiban</translation>
+<translation id="8007176423574883786">Kikapcsolva ezen az eszközön</translation>
+<translation id="164269334534774161">Jelenleg az oldal <ph name="CREATION_TIME"/>-i dátummal mentett offline példányát tekinti meg</translation>
+<translation id="4594952190837476234">Az offline oldal létrehozási ideje: <ph name="CREATION_TIME"/>. Az oldal eltérhet az online változattól.</translation>
+<translation id="8840953339110955557">Az oldal eltérhet az online változattól.</translation>
+<translation id="6405300764336705484">Ez a Brave Software által megjelenített tartalom a(z) <ph name="DOMAIN_NAME"/> domainről származik.</translation>
+<translation id="1006017844123154345">Online megnyitás</translation>
+<translation id="3326636747541519688">Egyszerű oldal a Brave Software-tól</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Eredeti oldal betöltése<ph name="END_LINK"/> innen: <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Ha gyakran látja ezt, próbálja ki ezeket a <ph name="BEGIN_LINK"/>javaslatokat<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Tartalom elrejtve</translation>
+<translation id="3810973564298564668">Szerkesztés</translation>
+<translation id="5199929503336119739">Munkaprofil</translation>
+<translation id="528192093759286357">A teljes képernyős megjelenítésből való kilépéshez húzza le felülről, majd koppintson a vissza gombra.</translation>
+<translation id="2836148919159985482">A teljes képernyős megjelenítésből való kilépéshez koppintson a vissza gombra.</translation>
+<translation id="3967822245660637423">A letöltés sikeres</translation>
+<translation id="2434158240863470628">Letöltés befejezve <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Nem sikerült a letöltés</translation>
+<translation id="1384959399684842514">A letöltés szünetel</translation>
+<translation id="1671236975893690980">Letöltés függőben…</translation>
+<translation id="5561549206367097665">Várakozás a hálózatra…</translation>
+<translation id="5864419784173784555">Várakozás a másik letöltésre…</translation>
+<translation id="6461962085415701688">A fájlt nem lehet megnyitni</translation>
+<translation id="1178581264944972037">Szünet</translation>
+<translation id="8200772114523450471">Folytatás</translation>
+<translation id="1409879593029778104">A következő fájl letöltését a böngésző megakadályozta, mert a fájl már létezik: <ph name="FILE_NAME"/>.</translation>
+<translation id="3387650086002190359">A következő fájl letöltése a fájlrendszer hibái miatt nem sikerült: <ph name="FILE_NAME"/>.</translation>
+<translation id="6482749332252372425">A következő fájl letöltése tárhelyhiány miatt nem sikerült: <ph name="FILE_NAME"/>.</translation>
+<translation id="7619072057915878432">A következő fájl letöltése hálózati hibák miatt nem sikerült: <ph name="FILE_NAME"/>.</translation>
+<translation id="1477626028522505441">A következő fájl letöltése szerverproblémák miatt nem sikerült: <ph name="FILE_NAME"/>.</translation>
+<translation id="3692944402865947621">A(z) <ph name="FILE_NAME"/> fájl letöltése sikertelen, mert nem lehet elérni a tárhelyet.</translation>
+<translation id="604996488070107836">A következő fájl letöltése ismeretlen hiba miatt nem sikerült: <ph name="FILE_NAME"/>.</translation>
+<translation id="6738867403308150051">Letöltés…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475">? / <ph name="BYTES_DOWNLOADED_WITH_UNITS"/></translation>
+<translation id="1923695749281512248"><ph name="FILE_SIZE_WITH_UNITS"/> / <ph name="BYTES_DOWNLOADED_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> kB letöltve</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB letöltve</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB letöltve</translation>
+<translation id="9204836675896933765">1 fájl maradt</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> fájl maradt</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fájl letöltve}other{<ph name="FILES_DOWNLOADED_MANY"/> fájl letöltve}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> nap van hátra</translation>
+<translation id="8190358571722158785">1 nap van hátra</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> óra van hátra</translation>
+<translation id="510275257476243843">1 óra van hátra</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> perc van hátra</translation>
+<translation id="3236059992281584593">1 perc van hátra</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> másodperc van hátra</translation>
+<translation id="2781151931089541271">1 másodperc van hátra</translation>
+<translation id="3303414029551471755">Biztosan letölti a tartalmat?</translation>
+<translation id="8617240290563765734">Megnyitja a letöltött tartalomban szereplő javasolt URL-t?</translation>
+<translation id="1373696734384179344">Nincs elegendő memória a kiválasztott tartalom letöltéséhez.</translation>
+<translation id="5271967389191913893">Az eszköz nem tudja megnyitni a letölteni kívánt tartalmat.</translation>
+<translation id="883806473910249246">Hiba történt a tartalom letöltésekor.</translation>
+<translation id="5626134646977739690">Név:</translation>
+<translation id="7963646190083259054">Szolgáltató:</translation>
+<translation id="3414952576877147120">Méret:</translation>
+<translation id="7375125077091615385">Típus:</translation>
+<translation id="5765780083710877561">Leírás:</translation>
+<translation id="4881695831933465202">Megnyitás</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB szabad</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB áll rendelkezésre</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB szabad</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/>/<ph name="SPACE_USED"/> használatban</translation>
+<translation id="3587482841069643663">Mind</translation>
+<translation id="4988526792673242964">Oldal</translation>
+<translation id="3810838688059735925">Videó</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Képek</translation>
+<translation id="8250920743982581267">Dokumentumok</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fájl}other{# fájl}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# kép}other{# kép}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videó}other{# videó}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# hangfájl}other{# hangfájl}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# oldal}other{# oldal}}</translation>
+<translation id="5456381639095306749">Oldal letöltése</translation>
+<translation id="2394602618534698961">Itt találhatja majd a letöltött fájlokat</translation>
+<translation id="7810647596859435254">Megnyitás ezzel:</translation>
+<translation id="5655963694829536461">Keresés a letöltések között</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Saját fájlok</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Itt jelennek meg a cikkek, amelyeket offline állapotban is olvashat</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# órája}other{# órája}}</translation>
+<translation id="5853623416121554550">szüneteltetve</translation>
+<translation id="8965591936373831584">függőben</translation>
+<translation id="2779651927720337254">sikertelen</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Épp most</translation>
+<translation id="4000212216660919741">Offline kezdőlap</translation>
+<translation id="9133397713400217035">Offline felfedezés</translation>
+<translation id="968900484120156207">Itt jelennek meg a felkeresett oldalak</translation>
+<translation id="7882131421121961860">Nincsenek előzmények</translation>
+<translation id="3549657413697417275">Keresés az előzményekben</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">HH</translation>
+<translation id="605721222689873409">ÉÉ</translation>
+<translation id="724102042129299115">Brave – Első futtatási élmény</translation>
+<translation id="2700285883409956633">Az alkalmazás használatával Ön elfogadja a Brave <ph name="BEGIN_LINK1"/>Általános Szerződési Feltételeit<ph name="END_LINK1"/> és az <ph name="BEGIN_LINK2"/>Adatvédelmi közleményt<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Az alkalmazás használatával elfogadja a Brave <ph name="BEGIN_LINK1"/>általános szerződési feltételeit<ph name="END_LINK1"/> és <ph name="BEGIN_LINK2"/>adatvédelmi közleményét<ph name="END_LINK2"/>, valamint <ph name="BEGIN_LINK3"/>a Family Link szolgáltatással kezelt Brave Software-fiókokra vonatkozó adatvédelmi közleményt<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">A(z) <ph name="APP_NAME"/> a Brave-ban nyílik meg. A folytatással elfogadja a Brave <ph name="BEGIN_LINK1"/>Általános Szerződési Feltételeit<ph name="END_LINK1"/> és <ph name="BEGIN_LINK2"/>Adatvédelmi közleményét<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659">A(z) <ph name="APP_NAME"/> a Brave-ban nyílik meg. A folytatással elfogadja a Brave <ph name="BEGIN_LINK1"/>Általános Szerződési Feltételeit<ph name="END_LINK1"/> és <ph name="BEGIN_LINK2"/>Adatvédelmi közleményét<ph name="END_LINK2"/>, valamint <ph name="BEGIN_LINK3"/>A Family Link szolgáltatással kezelt Brave Software-fiókokra vonatkozó Adatvédelmi közleményt<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Használati statisztikák és hibajelentések küldésével segíthet a Brave Software-nak a Brave fejlesztésében.</translation>
+<translation id="3518985090088779359">Elfogadás és tovább</translation>
+<translation id="7207456302801184289">A Brave üdvözli Önt!</translation>
+<translation id="704822250101715322">Várakozás a Brave Software Play-szolgáltatások frissítésének befejezésére</translation>
+<translation id="1231733316453485619">Bekapcsolja a szinkronizálást?</translation>
+<translation id="5132942445612118989">Jelszavak, előzmények és egyebek szinkronizálása valamennyi eszközén</translation>
+<translation id="5736731321935944068">A Brave Software felhasználhatja az Ön előzményeit a Keresés, a hirdetések és más Brave Software-szolgáltatások személyre szabására</translation>
+<translation id="4013614219085422040">A Brave Software felhasználhatja az Ön előzményeit a Keresés és más Brave Software-szolgáltatások személyre szabására</translation>
+<translation id="5581519193887989363">A <ph name="BEGIN_LINK1"/>beállítások<ph name="END_LINK1"/> között bármikor módosíthatja a szinkronizálni kívánt elemeket.</translation>
+<translation id="741204030948306876">Igen, folytatom</translation>
+<translation id="2410754283952462441">Válasszon fiókot</translation>
+<translation id="2227444325776770048">Folytatás mint <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Nem <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Ha az összes eszközén szeretné elérni könyvjelzőit, kapcsolja be a szinkronizálást</translation>
+<translation id="2818669890320396765">Ha az összes eszközén szeretné elérni könyvjelzőit, jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
+<translation id="6003646045106347985">A Brave Software által javasolt, személyre szabott tartalmak fogadásához kapcsolja be a szinkronizálást</translation>
+<translation id="8494430740943879273">A Brave Software által javasolt, személyre szabott tartalmak fogadásához jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
+<translation id="5862731021271217234">Ha a többi eszközén lévő lapjait is szeretné elérni, kapcsolja be a szinkronizálást</translation>
+<translation id="3568688522516854065">Ha a többi eszközén is szeretné elérni lapjait, jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
+<translation id="1208340532756947324">Az eszközök közötti szinkronizáláshoz és személyre szabáshoz kapcsolja be a szinkronizálást</translation>
+<translation id="4472118726404937099">Az eszközök közötti szinkronizáláshoz és személyre szabáshoz jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
+<translation id="2426805022920575512">Másik fiók választása</translation>
+<translation id="6790428901817661496">Játék</translation>
+<translation id="1272079795634619415">Leállítás</translation>
+<translation id="2874939134665556319">Előző szám</translation>
+<translation id="4046123991198612571">Következő szám</translation>
+<translation id="3859306556332390985">Ugrás előre</translation>
+<translation id="8441146129660941386">Ugrás visszafelé</translation>
+<translation id="6706288973712894588">Jelenleg offline állapotban van.\n<ph name="BEGIN_LINK"/>Fedezze fel offline hírcsatornáját.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Nemrég megnyitott lapok</translation>
+<translation id="8497726226069778601">Nincs itt semmi látnivaló… még</translation>
+<translation id="5423934151118863508">A leggyakrabban látogatott oldalak fognak itt megjelenni</translation>
+<translation id="6127379762771434464">Elem eltávolítva</translation>
+<translation id="4605958867780575332">A következő elem eltávolítva: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software ünnepi embléma: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Egyéb eszközök</translation>
+<translation id="4738836084190194332">Utolsó szinkronizálás: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# perce}other{# perce}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# órája}other{# órája}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# napja}other{# napja}}</translation>
+<translation id="2762000892062317888">éppen most</translation>
+<translation id="1407135791313364759">Összes megnyitása</translation>
+<translation id="1209206284964581585">Elrejtés most</translation>
+<translation id="129553762522093515">Mostanában bezárt</translation>
+<translation id="8413126021676339697">Az összes előzmény</translation>
+<translation id="7876243839304621966">Összes eltávolítása</translation>
+<translation id="8487700953926739672">Offline elérhető</translation>
+<translation id="5224771365102442243">Videóval</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>További információ<ph name="END_LINK"/> a javasolt tartalomról</translation>
+<translation id="7542481630195938534">Nem sikerült lekérni a javaslatokat</translation>
+<translation id="5013696553129441713">Nincsenek új javaslatok</translation>
+<translation id="1736419249208073774">Felfedezés</translation>
+<translation id="7444811645081526538">További kategóriák</translation>
+<translation id="6709133671862442373">Hírek</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Vásárlás</translation>
+<translation id="3912508018559818924">A legjobb találatok keresése az interneten…</translation>
+<translation id="526421993248218238">Nem lehet betölteni az oldalt</translation>
+<translation id="614940544461990577">Próbálja ki a következőket:</translation>
+<translation id="3288003805934695103">Az oldal frissítése</translation>
+<translation id="2353636109065292463">Az internetkapcsolat ellenőrzése</translation>
+<translation id="2858138569776157458">Népszerűek</translation>
+<translation id="8364299278605033898">Tekintse meg a népszerű webhelyeket</translation>
+<translation id="1171770572613082465">A „Népszerűek” gombra koppintva megtekintheti a népszerű webhelyeket</translation>
+<translation id="5233638681132016545">Új lap</translation>
+<translation id="4521874409998847950">A következőtől: <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>megjelenítette a Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Rendelkezésre áll új verzió</translation>
+<translation id="4058091506841967397">A Brave nem frissíthető</translation>
+<translation id="6316139424528454185">Nem támogatott Android-verzió</translation>
+<translation id="6989267951144302301">A letöltés sikertelen</translation>
+<translation id="624789221780392884">A frissítés készen áll</translation>
+<translation id="1549000191223877751">Áthelyezés másik ablakba</translation>
+<translation id="7481312909269577407">Előre</translation>
+<translation id="4084682180776658562">Könyvjelző</translation>
+<translation id="6437478888915024427">Oldaladatok</translation>
+<translation id="7180611975245234373">Frissítés</translation>
+<translation id="4913169188695071480">Frissítés leállítása</translation>
+<translation id="1829244130665387512">Keresés ezen az oldalon</translation>
+<translation id="6593061639179217415">Asztali webhely</translation>
+<translation id="9063523880881406963">Kapcsolja ki az Asztali webhely kérése funkciót</translation>
+<translation id="2038563949887743358">Kapcsolja be az Asztali webhely kérése funkciót</translation>
+<translation id="2433507940547922241">Megjelenés</translation>
+<translation id="983192555821071799">Az összes lap bezárása</translation>
+<translation id="1310482092992808703">Lapok csoportosítása</translation>
+<translation id="7725024127233776428">Itt jelennek meg a könyvjelzőként mentett oldalak</translation>
+<translation id="4404568932422911380">Nincsenek könyvjelzők</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> könyvjelző}other{<ph name="BOOKMARKS_COUNT_MANY"/> könyvjelző}}</translation>
+<translation id="3739899004075612870">Felvéve a(z) <ph name="PRODUCT_NAME"/> könyvjelzői közé</translation>
+<translation id="3207960819495026254">Könyvjelző rögzítve</translation>
+<translation id="4452548195519783679">Könyvjelzők közé téve itt: <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">A könyvjelző hozzáadása sikertelen volt.</translation>
+<translation id="2842985007712546952">Szülőmappa</translation>
+<translation id="9065203028668620118">Szerkesztés</translation>
+<translation id="4405224443901389797">Áthelyezés…</translation>
+<translation id="5170568018924773124">Megjelenítés mappában</translation>
+<translation id="8035133914807600019">Új mappa…</translation>
+<translation id="4532845899244822526">Mappa kiválasztása</translation>
+<translation id="6627583120233659107">Mappa szerkesztése</translation>
+<translation id="1197267115302279827">Könyvjelzők áthelyezése</translation>
+<translation id="6963766334940102469">Könyvjelzők törlése</translation>
+<translation id="4351244548802238354">Párbeszédablak bezárása</translation>
+<translation id="451872707440238414">Keresés a saját könyvjelzők közt</translation>
+<translation id="8901170036886848654">Nem találtunk könyvjelzőket</translation>
+<translation id="6404511346730675251">Könyvjelző szerkesztése</translation>
+<translation id="3894427358181296146">Mappa hozzáadása</translation>
+<translation id="5327248766486351172">Név</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Mappa</translation>
+<translation id="5161254044473106830">Cím megadása kötelező</translation>
+<translation id="2996809686854298943">URL szükséges</translation>
+<translation id="2536728043171574184">Az oldal offline példányának megtekintése</translation>
+<translation id="4698034686595694889">Megtekintés offline állapotban itt: <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> és további webhelyek</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{A Brave betölti az oldalt, amint lehetséges}other{A Brave betölti az oldalakat, amint lehetséges}}</translation>
+<translation id="6811034713472274749">Az oldal megtekinthető</translation>
+<translation id="4561979708150884304">Nincs kapcsolat</translation>
+<translation id="8274165955039650276">Letöltések megtekintése</translation>
+<translation id="2082238445998314030">Eredmény: <ph name="RESULT_NUMBER"/>/<ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Nincs találat</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Egyszerű</translation>
+<translation id="393697183122708255">Nincs engedélyezett hangalapú keresés</translation>
+<translation id="7191430249889272776">A lap megnyílt a háttérben.</translation>
+<translation id="8445059357334030806">Megnyitás Brave-ban</translation>
+<translation id="4720023427747327413">Megnyitás itt: <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Megnyitás böngészőben</translation>
+<translation id="1113597929977215864">Egyszerűsített nézet megjelenítése</translation>
+<translation id="1513352483775369820">Könyvjelzők és webes előzmények</translation>
+<translation id="4939482511480190003">Segítsen a Brave fejlesztésében. <ph name="BEGIN_LINK"/>Töltse ki ezt a felmérést.<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Visszalépés</translation>
+<translation id="5596627076506792578">További lehetőségek</translation>
+<translation id="3522247891732774234">Frissítés áll rendelkezésre. További lehetőségek</translation>
+<translation id="6773423637732432200">A Brave frissítése nem lehetséges. További lehetőségek</translation>
+<translation id="3328801116991980348">Webhelyadatok</translation>
+<translation id="5391532827096253100">Kapcsolata a webhellyel nem biztonságos. Webhelyadatok</translation>
+<translation id="6206551242102657620">A kapcsolat biztonságos. Webhelyadatok</translation>
+<translation id="6963642900430330478">Ez az oldal veszélyes. Webhelyadatok</translation>
+<translation id="9070377983101773829">Hangalapú keresés indítása</translation>
+<translation id="8676374126336081632">Beírt szöveg törlése</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> megnyitott lap. A lapok között koppintással válthat.}other{<ph name="OPEN_TABS_MANY"/> megnyitott lap. A lapok között koppintással válthat.}}</translation>
+<translation id="2369533728426058518">megnyitott lapok</translation>
+<translation id="7071521146534760487">Fiók kezelése</translation>
+<translation id="932327136139879170">Főoldal</translation>
+<translation id="2707726405694321444">Oldal frissítése</translation>
+<translation id="2891154217021530873">Oldal betöltésének leállítása</translation>
+<translation id="6710213216561001401">Előző</translation>
+<translation id="6659594942844771486">Lap</translation>
+<translation id="1933845786846280168">Kiválasztott lap</translation>
+<translation id="2268044343513325586">Pontosítás</translation>
+<translation id="7846076177841592234">Kijelölés törlése</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> elem kiválasztva. A lehetőségek a képernyő tetején találhatók.</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> elem kiválasztva</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 kijelölt elem megosztása}other{# kijelölt elem megosztása}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 kijelölt elem eltávolítása}other{# kijelölt elem eltávolítása}}</translation>
+<translation id="1283039547216852943">Koppintson a kibontáshoz</translation>
+<translation id="5962718611393537961">Koppintson az összecsukáshoz</translation>
+<translation id="8076492880354921740">Lapok</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 elem kijelölve}other{# elem kijelölve}}</translation>
+<translation id="6818926723028410516">Válasszon elemeket</translation>
+<translation id="4797039098279997504">Érintse meg, hogy visszatérjen ide: <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Koppintson a webhely felkereséséhez</translation>
+<translation id="429312253194641664">Az egyik webhely médiatartalmat játszik le</translation>
+<translation id="4958708863221495346">A(z) <ph name="URL_OF_THE_CURRENT_TAB"/> webhely megosztja az Ön képernyőjét</translation>
+<translation id="8833831881926404480">Az egyik webhely jelenleg megosztja a képernyőt</translation>
+<translation id="9086455579313502267">Nem sikerült elérni a hálózatot</translation>
+<translation id="938850635132480979">Hiba: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Megnyitás itt: <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Megnyitás térképalkalmazásban</translation>
+<translation id="7698359219371678927">E-mail létrehozása a(z) <ph name="APP_NAME"/> alkalmazásban</translation>
+<translation id="7875915731392087153">E-mail létrehozása</translation>
+<translation id="5665379678064389456">Esemény létrehozása a(z) <ph name="APP_NAME"/> alkalmazásban</translation>
+<translation id="2900528713135656174">Esemény létrehozása</translation>
+<translation id="2111511281910874386">Ugrás az oldalhoz</translation>
+<translation id="3988466920954086464">Azonnali keresési találatok megtekintése ezen a panelen</translation>
+<translation id="2744248271121720757">Az azonnali kereséshez koppintson a kívánt szóra, vagy tekintse meg a kapcsolódó műveleteket</translation>
+<translation id="9155898266292537608">Úgy is végrehajthat keresést, hogy gyorsan rákoppint valamelyik szóra</translation>
+<translation id="3232754137068452469">Internetes alkalmazás</translation>
+<translation id="1430915738399379752">Nyomtatás</translation>
+<translation id="3775705724665058594">Küldés a saját eszközökre</translation>
+<translation id="6364438453358674297">Eltávolítja a javaslatot az előzményekből?</translation>
+<translation id="213279576345780926">Bezárva: <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> lap bezárva</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> törölve</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> könyvjelző törölve</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> letöltés törölve</translation>
+<translation id="1248710015876067820">Ilyen sok Brave-példány nem futhat egyszerre.</translation>
+<translation id="4259722352634471385">Le van tiltva az ide vezető navigáció: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Nem érhető el az ide vezető navigáció: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Lap bezárása</translation>
+<translation id="7772375229873196092">A(z) <ph name="APP_NAME"/> bezárása</translation>
+<translation id="1227058898775614466">Navigációs előzmények</translation>
+<translation id="9169507124922466868">Félmagasságban megnyitott navigációs előzmények</translation>
+<translation id="1327257854815634930">Megnyitotta a navigációs előzményeket</translation>
+<translation id="8788265440806329501">Bezárta a navigációs előzményeket</translation>
+<translation id="7482656565088326534">Előnézeti lap</translation>
+<translation id="8427875596167638501">Félmagasságban megnyitott előnézeti ablak</translation>
+<translation id="9102803872260866941">Az előnézeti lap meg van nyitva</translation>
+<translation id="2942036813789421260">Az előnézeti lap zárva van</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/>-tárhely</translation>
+<translation id="3822502789641063741">Törli a webhely tárhelyét?</translation>
+<translation id="9205995714227143200">A Brave által nem fontosnak ítélt webhelytárhely (például a mentett beállítások nélküli vagy ritkán megnyitott webhelyek)</translation>
+<translation id="3997476611815694295">Nem fontos tárhely</translation>
+<translation id="8493948351860045254">Terület felszabadítása</translation>
+<translation id="2324920234469020158">Ezzel törli a cookie-kat, a gyorsítótárat, valamint a webhelyek összes olyan adatát, amelyről a Brave úgy véli, hogy nem fontos.</translation>
+<translation id="5447201525962359567">Összes webhelytárhely, beleértve a cookie-kat és más helyben tárolt adatokat</translation>
+<translation id="1376578503827013741">Számítás…</translation>
+<translation id="583281660410589416">Ismeretlen</translation>
+<translation id="2323763861024343754">Webhely tárhelye</translation>
+<translation id="3587672679800759167">A Brave által használt teljes adatmennyiség, beleértve a fiókokat, könyvjelzőket és mentett beállításokat is</translation>
+<translation id="6545017243486555795">Összes adat törlése</translation>
+<translation id="4095146165863963773">Törli az alkalmazásadatokat?</translation>
+<translation id="53119194224775367">A Brave összes alkalmazásadata véglegesen törlődik, beleértve a fájlokat, beállításokat, fiókokat, adatbázisokat stb.</translation>
+<translation id="5307446750509046227">Webhelytárhely törlése</translation>
+<translation id="300526633675317032">Ezzel törli a webhely teljes tárhelyét: <ph name="SIZE_IN_KB"/>.</translation>
+<translation id="8068648041423924542">A tanúsítvány kiválasztása nem sikerült.</translation>
+<translation id="2315043854645842844">Az ügyféloldali tanúsítványválasztást az operációs rendszer nem támogatja.</translation>
+<translation id="5011311129201317034">A(z) <ph name="SITE"/> csatlakozni szeretne</translation>
+<translation id="5308380583665731573">Csatlakozás</translation>
+<translation id="868929229000858085">Keresés a névjegyek között</translation>
+<translation id="1919950603503897840">Névjegyek kiválasztása</translation>
+<translation id="7986741934819883144">Válasszon ki egy névjegyet</translation>
+<translation id="3333961966071413176">Összes névjegy</translation>
+<translation id="4994033804516042629">Nem találhatók névjegyek</translation>
+<translation id="5403592356182871684">Nevek</translation>
+<translation id="2717722538473713889">E-mail-címek</translation>
+<translation id="381841723434055211">Telefonszámok</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 további)}other{(+ # további)}}</translation>
+<translation id="5197729504361054390">A kiválasztott névjegyeket megosztjuk a következő webhellyel: <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Képdekóder</translation>
+<translation id="8067883171444229417">Videó lejátszása</translation>
+<translation id="6560414384669816528">Keresés a Sogou használatával</translation>
+<translation id="5406914950576900927">A Brave igénybe veheti a <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> keresőszolgáltatást, hogy Kínában kereshessen. Ezt a <ph name="BEGIN_LINK"/>Beállításokban<ph name="END_LINK"/> módosíthatja.</translation>
+<translation id="6456271171669383967">A Brave Software megtartása</translation>
+<translation id="4384468725000734951">A Sogou használata a kereséshez</translation>
+<translation id="6103327872225198548">A Brave Software használata a kereséshez</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Ez az alkalmazás fut a Brave-ban</translation>
+<translation id="6143689084714664628">Fut a Brave-ban</translation>
+<translation id="7675869148432102528">A(z) <ph name="APP_NAME"/> a Brave-ban is rendelkezik adatokkal</translation>
+<translation id="2734140769649165081">Az adatokat a Brave beállításaiban módosíthatja</translation>
+<translation id="8232956427053453090">Adatok megőrzése</translation>
+<translation id="4298388696830689168">Összekapcsolt webhelyek</translation>
+<translation id="5763514718066511291">Koppintson az alkalmazás URL-jének másolásához</translation>
+<translation id="6496823230996795692">A(z) <ph name="APP_NAME"/> első használatakor internetkapcsolatra van szükség.</translation>
+<translation id="751961395872307827">Nem lehet csatlakozni a webhelyhez</translation>
+<translation id="4878404682131129617">Nem sikerült a proxyszerveren keresztüli alagút kialakítása</translation>
+<translation id="4749960740855309258">Új lap megnyitása</translation>
+<translation id="8788968922598763114">A legutóbb bezárt lap újranyitása</translation>
+<translation id="7929962904089429003">A menü megnyitása</translation>
+<translation id="6039379616847168523">Ugrás a következő lapra</translation>
+<translation id="5210286577605176222">Ugrás az előző lapra</translation>
+<translation id="124678866338384709">Az aktuális lap bezárása</translation>
+<translation id="3714981814255182093">A keresősáv megnyitása</translation>
+<translation id="5441522332038954058">Ugrás a címsávba</translation>
+<translation id="3398320232533725830">A Könyvjelzőkezelő megnyitása</translation>
+<translation id="6583199322650523874">Az aktuális oldal felvétele a könyvjelzők közé</translation>
+<translation id="8489271220582375723">Az Előzmények oldal megnyitása</translation>
+<translation id="4837753911714442426">Oldalnyomtatási lehetőségek megnyitása</translation>
+<translation id="5726692708398506830">Minden nagyítása az oldalon</translation>
+<translation id="3259831549858767975">Minden kicsinyítése az oldalon</translation>
+<translation id="8015452622527143194">Minden visszaállítása alapértelmezett méretűre</translation>
+<translation id="3443221991560634068">Az aktuális oldal újratöltése</translation>
+<translation id="123724288017357924">Oldal újratöltése a gyorsítótárat figyelmen kívül hagyva</translation>
+<translation id="305870044889644984">A Brave súgójának megnyitása új lapon</translation>
+<translation id="3166827708714933426">Lapokkal és ablakokkal kapcsolatos billentyűparancsok</translation>
+<translation id="3169981355900570544">A Brave Software Brave-funkciók billentyűparancsai</translation>
+<translation id="4558311620361989323">Weboldalakkal kapcsolatos billentyűparancsok</translation>
+<translation id="1908301351964700579">A Brave még mindig a VR használatára készül fel. Indítsa újra a Brave-ot később.</translation>
+<translation id="8970887620466824814">Hiba történt.</translation>
+<translation id="1875543012935658554">Nyissa meg újra a Brave-ot.</translation>
+<translation id="79859296434321399">A kiterjesztett valósággal kapcsolatos tartalmak megtekintéséhez telepítse az ARCore-t</translation>
+<translation id="8558485628462305855">A kiterjesztett valósággal kapcsolatos tartalmak megtekintéséhez frissítse az ARCore-t</translation>
+<translation id="3513704683820682405">Kiterjesztett valóság</translation>
+<translation id="5475862044948910901">Elindítja a kiterjesztett valóságot (AR) használó munkamenetet?</translation>
 <translation id="7365126855094612066">A jelen munkamenet során a webhely a következőkre lesz képes:
 • 3D-s térképet készíthet az Ön környezetéről;
 • követheti a kamera mozgását.
 
 A webhely NEM kap hozzáférést a kamerához. A kamera képét csak Ön láthatja.</translation>
-<translation id="7375125077091615385">Típus:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome – Első futtatási élmény</translation>
-<translation id="741204030948306876">Igen, folytatom</translation>
-<translation id="7413229368719586778">Kezdés dátuma: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Kérdezzen rá</translation>
-<translation id="7423538860840206698">Le van tiltva a vágólap megtekintése</translation>
-<translation id="7431991332293347422">Beállíthatja, hogy a rendszer hogyan szabja személyre a Keresést és egyebeket a böngészési előzmények alapján</translation>
-<translation id="7437998757836447326">Kijelentkezés a Chrome-ból</translation>
-<translation id="7438641746574390233">Amikor be van kapcsolva az Egyszerűsített mód, a Chrome a Google szervereit használja az oldalak felgyorsítására. Az Egyszerűsített mód átírja a nagyon lassú oldalakat, hogy csak a fontos tartalmakat töltsék be. Az Egyszerűsített mód nem használható inkognitólapokon.</translation>
-<translation id="7444811645081526538">További kategóriák</translation>
-<translation id="7445411102860286510">Lehetővé teszi a webhelyek számára a némított videók automatikus lejátszását (ajánlott)</translation>
-<translation id="7453467225369441013">A rendszer a legtöbb webhelyről kijelentkezteti Önt, de Google-fiókjából nem.</translation>
-<translation id="7454641608352164238">Nincs elég tárhely</translation>
-<translation id="7475192538862203634">Ha gyakran látja ezt, próbálja ki ezeket a <ph name="BEGIN_LINK" />javaslatokat<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Az SD-kártya nem található. Előfordulhat, hogy egyes fájlok hiányoznak.</translation>
-<translation id="7479104141328977413">Lapkezelés</translation>
-<translation id="7481312909269577407">Előre</translation>
-<translation id="7482656565088326534">Előnézeti lap</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Frissítve: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">megtakarított adatmennyiség</translation>
-<translation id="7498271377022651285">Kérjük, várjon…</translation>
-<translation id="7514365320538308">Letöltés</translation>
-<translation id="751961395872307827">Nem lehet csatlakozni a webhelyhez</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Nem sikerült lekérni a javaslatokat</translation>
-<translation id="7559975015014302720">Az Egyszerűsített mód ki van kapcsolva</translation>
-<translation id="7562080006725997899">Böngészési adatok törlése</translation>
-<translation id="756809126120519699">Chrome-adatok törölve</translation>
-<translation id="757524316907819857">Védett tartalom lejátszásának letiltása a webhelyeken</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fájl letöltve}other{<ph name="FILES_DOWNLOADED_MANY" /> fájl letöltve}}</translation>
-<translation id="7588219262685291874">Sötét téma bekapcsolása, amikor az eszköz Akkumulátorkímélő módja be van kapcsolva</translation>
-<translation id="7589445247086920869">Tiltja a jelenlegi keresőmotor számára</translation>
-<translation id="7593557518625677601">Aktiválja újra az Android rendszer szinkronizálását a Chrome-szinkronizáláshoz</translation>
-<translation id="7596558890252710462">Operációs rendszer</translation>
-<translation id="7605594153474022051">A szinkronizálás nem működik.</translation>
-<translation id="7606077192958116810">Az Egyszerűsített mód be van kapcsolva. Kezelésére a Beállításokban van lehetősége.</translation>
-<translation id="7612619742409846846">Bejelentkezve a Google rendszerébe mint</translation>
-<translation id="7619072057915878432">A következő fájl letöltése hálózati hibák miatt nem sikerült: <ph name="FILE_NAME" />.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Kérjen segítséget<ph name="END_LINK1" />, vagy <ph name="BEGIN_LINK2" />keressen rá újra<ph name="END_LINK2" />.</translation>
-<translation id="7626032353295482388">A Chrome üdvözli Önt!</translation>
-<translation id="7638584964844754484">Hibás összetett jelszó</translation>
-<translation id="7641339528570811325">Böngészési adatok törlése…</translation>
-<translation id="7648422057306047504">A jelszavak titkosítása a Google hitelesítési adataival</translation>
-<translation id="7649070708921625228">Súgó</translation>
-<translation id="7658239707568436148">Mégse</translation>
-<translation id="7665369617277396874">Fiók hozzáadása</translation>
-<translation id="766587987807204883">Itt jelennek meg a cikkek, amelyeket offline állapotban is olvashat</translation>
-<translation id="7682724950699840886">Próbálkozzon a következő tippekkel: Győződjön meg arról, hogy elegendő tárhely áll rendelkezésre az eszközön, majd próbálja újra az exportálást.</translation>
-<translation id="7685301384041462804">A VR-mód aktiválása előtt győződjön meg a webhely megbízhatóságáról.</translation>
-<translation id="7698359219371678927">E-mail létrehozása a(z) <ph name="APP_NAME" /> alkalmazásban</translation>
-<translation id="7704317875155739195">Keresések és URL-címek automatikus kiegészítése</translation>
-<translation id="7725024127233776428">Itt jelennek meg a könyvjelzőként mentett oldalak</translation>
-<translation id="773466115871691567">Mindig fordítsa le a(z) <ph name="SOURCE_LANGUAGE" /> nyelvű oldalakat</translation>
-<translation id="7746457520633464754">A veszélyes alkalmazások és webhelyek észlelésének érdekében a Chrome az egyes felkeresett oldalak URL-jét, valamint korlátozott rendszer-információkat és bizonyos oldaltartalmakat továbbít a Google-nak.</translation>
-<translation id="7757787379047923882">Szöveg megosztva a következő eszközről: <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-kártya (<ph name="SD_CARD_NUMBER" />)</translation>
-<translation id="7764225426217299476">Cím hozzáadása</translation>
-<translation id="7772032839648071052">Összetett jelszó megerősítése</translation>
-<translation id="7772375229873196092">A(z) <ph name="APP_NAME" /> bezárása</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 és további <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Tegnap</translation>
-<translation id="7791543448312431591">Hozzáadás</translation>
-<translation id="780301667611848630">Köszönöm, nem</translation>
-<translation id="7810647596859435254">Megnyitás ezzel:</translation>
-<translation id="7821588508402923572">Itt látható a megtakarított adatmennyiség</translation>
-<translation id="7837721118676387834">A némított videók automatikus lejátszásának engedélyezése az adott webhelyen.</translation>
-<translation id="7846076177841592234">Kijelölés törlése</translation>
-<translation id="784934925303690534">Időszak</translation>
-<translation id="7851858861565204677">Egyéb eszközök</translation>
-<translation id="7875915731392087153">E-mail létrehozása</translation>
-<translation id="7876243839304621966">Összes eltávolítása</translation>
-<translation id="7882131421121961860">Nincsenek előzmények</translation>
-<translation id="7882806643839505685">Egy adott webhely hangjának engedélyezése.</translation>
-<translation id="7886917304091689118">Fut a Chrome-ban</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Fájl letöltése…}other{# fájl letöltése…}}</translation>
-<translation id="7929962904089429003">A menü megnyitása</translation>
-<translation id="7942131818088350342">A(z) <ph name="PRODUCT_NAME" /> elavult.</translation>
-<translation id="7947953824732555851">Elfogadás és bejelentkezés</translation>
-<translation id="7963646190083259054">Szolgáltató:</translation>
-<translation id="7971136598759319605">1 napja volt aktív</translation>
-<translation id="7975379999046275268">Oldal előnézete <ph name="BEGIN_NEW" />Új<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Oldalak előtöltése a gyorsabb böngészés és keresés érdekében</translation>
-<translation id="79859296434321399">A kiterjesztett valósággal kapcsolatos tartalmak megtekintéséhez telepítse az ARCore-t</translation>
-<translation id="7986741934819883144">Válasszon ki egy névjegyet</translation>
-<translation id="7987073022710626672">Chrome – Általános Szerződési Feltételek</translation>
-<translation id="7998918019931843664">Bezárt lap megnyitása</translation>
-<translation id="7999064672810608036">Biztosan törli a webhellyel kapcsolatos összes helyi adatot (a cookie-kkal együtt), és visszaállítja az összes engedélyt?</translation>
-<translation id="8004582292198964060">Böngésző</translation>
-<translation id="8007176423574883786">Kikapcsolva ezen az eszközön</translation>
-<translation id="8013372441983637696">Az Ön Chrome-adatai is törlődjenek erről az eszközről</translation>
-<translation id="8015452622527143194">Minden visszaállítása alapértelmezett méretűre</translation>
-<translation id="802154636333426148">Nem sikerült a letöltés</translation>
-<translation id="8026334261755873520">Böngészési adatok törlése</translation>
-<translation id="8035133914807600019">Új mappa…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> nap van hátra</translation>
-<translation id="804335162455518893">Az SD-kártya nem található</translation>
-<translation id="805047784848435650">A böngészési előzményei alapján</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB áll rendelkezésre</translation>
-<translation id="8058746566562539958">Megnyitás új Chrome-lapon</translation>
-<translation id="8063895661287329888">A könyvjelző hozzáadása sikertelen volt.</translation>
-<translation id="806745655614357130">Maradjanak elkülönítve az adataim</translation>
-<translation id="8067883171444229417">Videó lejátszása</translation>
-<translation id="8068648041423924542">A tanúsítvány kiválasztása nem sikerült.</translation>
-<translation id="8073388330009372546">Kép megnyitása új lapon</translation>
-<translation id="8076492880354921740">Lapok</translation>
-<translation id="8084114998886531721">Mentett jelszó</translation>
-<translation id="8087000398470557479">Ez a Google által megjelenített tartalom a(z) <ph name="DOMAIN_NAME" /> domainről származik.</translation>
-<translation id="8103578431304235997">Inkognitólap</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Ha az összes eszközén szeretné elérni könyvjelzőit, kapcsolja be a szinkronizálást</translation>
-<translation id="8110087112193408731">Chrome-beli tevékenysége megjelenjen a digitális jóllét funkcióban?</translation>
-<translation id="8116925261070264013">Némítva</translation>
-<translation id="813082847718468539">Az oldalinformációk megtekintése</translation>
-<translation id="8131740175452115882">Megerősítés</translation>
-<translation id="8156139159503939589">Milyen nyelveken olvas?</translation>
-<translation id="8168435359814927499">Tartalom</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> fájl maradt</translation>
-<translation id="8190358571722158785">1 nap van hátra</translation>
-<translation id="8200772114523450471">Folytatás</translation>
-<translation id="8209050860603202033">Kép megnyitása</translation>
-<translation id="8218622182176210845">Fiók kezelése</translation>
-<translation id="8224471946457685718">Cikkek letöltése Wi-Fi-kapcsolaton keresztül</translation>
-<translation id="8232956427053453090">Adatok megőrzése</translation>
-<translation id="8249310407154411074">Mozgatás az elejére</translation>
-<translation id="8250920743982581267">Dokumentumok</translation>
-<translation id="825412236959742607">Ez az oldal túl sok memóriát használ, ezért a Chrome eltávolított egyes tartalmakat.</translation>
-<translation id="8260126382462817229">Próbáljon meg újra bejelentkezni</translation>
-<translation id="8261506727792406068">Törlés</translation>
-<translation id="8266862848225348053">Letöltés helye</translation>
-<translation id="8274165955039650276">Letöltések megtekintése</translation>
-<translation id="8284326494547611709">Feliratok</translation>
-<translation id="8300705686683892304">Alkalmazás által kezelt</translation>
-<translation id="8310344678080805313">Szabványos lapok</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> és további webhelyek</translation>
-<translation id="8327155640814342956">Nyissa meg a Chrome-ot, és frissítsen a legjobb böngészési élmény érdekében</translation>
-<translation id="8339163506404995330">A(z) <ph name="LANGUAGE" /> nyelvű oldalak nem lesznek lefordítva</translation>
-<translation id="8349013245300336738">Rendezés a felhasznált adatmennyiség szerint</translation>
-<translation id="8364299278605033898">Tekintse meg a népszerű webhelyeket</translation>
-<translation id="8368027906805972958">Ismeretlen vagy nem támogatott eszköz (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Háttérben történő szinkronizálás engedélyezése adott webhely esetében.</translation>
-<translation id="8378714024927312812">Az Ön szervezete kezeli</translation>
-<translation id="8380167699614421159">Ez a webhely tolakodó vagy félrevezető hirdetéseket jelenít meg</translation>
-<translation id="8393700583063109961">Üzenet küldése</translation>
-<translation id="8413126021676339697">Az összes előzmény</translation>
-<translation id="8427875596167638501">Félmagasságban megnyitott előnézeti ablak</translation>
-<translation id="8428213095426709021">Beállítások</translation>
-<translation id="8438566539970814960">Keresések és böngészés javítása</translation>
-<translation id="8441146129660941386">Ugrás visszafelé</translation>
-<translation id="8443209985646068659">A Chrome nem frissíthető</translation>
-<translation id="8445448999790540984">Nem sikerült a jelszavak exportálása</translation>
-<translation id="8447861592752582886">Eszközengedély visszavonása</translation>
-<translation id="8461694314515752532">A szinkronizált adatok titkosítása saját összetett szinkronizálási jelszóval</translation>
-<translation id="8466613982764129868">Győződjön meg arról, hogy a(z) <ph name="TARGET_DEVICE_NAME" /> eszköz csatlakozik az internethez</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Offline elérhető</translation>
-<translation id="8489271220582375723">Az Előzmények oldal megnyitása</translation>
-<translation id="8493948351860045254">Terület felszabadítása</translation>
-<translation id="8497726226069778601">Nincs itt semmi látnivaló… még</translation>
-<translation id="8503559462189395349">Chrome-jelszavak</translation>
-<translation id="8503813439785031346">Felhasználónév</translation>
-<translation id="8514477925623180633">A Chrome-ban tárolt jelszavak exportálása</translation>
-<translation id="8514577642972634246">Belépés inkognitómódba</translation>
-<translation id="851751545965956758">Az eszközökhöz való csatlakozás megtiltása a webhelyeknek</translation>
-<translation id="8523928698583292556">Tárolt jelszó törlése</translation>
-<translation id="854522910157234410">Az oldal megnyitása</translation>
-<translation id="8558485628462305855">A kiterjesztett valósággal kapcsolatos tartalmak megtekintéséhez frissítse az ARCore-t</translation>
-<translation id="8559990750235505898">Más nyelvű oldalak fordításának felajánlása</translation>
-<translation id="8562452229998620586">A mentett jelszavak itt jelennek meg.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> óta</translation>
-<translation id="8571213806525832805">Az elmúlt négy hétből</translation>
-<translation id="857943718398505171">Engedélyezve (ajánlott)</translation>
-<translation id="8583805026567836021">Fiókadatok törlése</translation>
-<translation id="860043288473659153">Kártyatulajdonos neve</translation>
-<translation id="8609465669617005112">Mozgatás felfelé</translation>
-<translation id="8616006591992756292">Előfordulhat, hogy a böngészési előzmények más formái még megtalálhatók Google-fiókjában a <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> webhelyen.</translation>
-<translation id="8617240290563765734">Megnyitja a letöltött tartalomban szereplő javasolt URL-t?</translation>
-<translation id="8636825310635137004">Ha a többi eszközén is szeretné elérni lapjait, kapcsolja be a szinkronizálást</translation>
-<translation id="8641930654639604085">Felnőtteknek szóló webhelyek letiltásának megkísérlése</translation>
-<translation id="8655129584991699539">Az adatokat a Chrome beállításaiban módosíthatja</translation>
-<translation id="8662811608048051533">A rendszer a legtöbb webhelyről kijelentkezteti Önt.</translation>
-<translation id="8664979001105139458">Már van ilyen nevű fájl</translation>
-<translation id="8676374126336081632">Beírt szöveg törlése</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Jelerősség szintje: # sáv}other{Jelerősség szintje: # sáv}}</translation>
-<translation id="868929229000858085">Keresés a névjegyek között</translation>
-<translation id="869891660844655955">Lejárati dátum</translation>
-<translation id="8719023831149562936">Nem lehet átsugározni a jelenlegi lapot</translation>
-<translation id="8725066075913043281">Újrapróbálás</translation>
-<translation id="8728487861892616501">Az alkalmazás használatával elfogadja a Chrome <ph name="BEGIN_LINK1" />általános szerződési feltételeit<ph name="END_LINK1" /> és <ph name="BEGIN_LINK2" />adatvédelmi közleményét<ph name="END_LINK2" />, valamint <ph name="BEGIN_LINK3" />a Family Link szolgáltatással kezelt Google-fiókokra vonatkozó adatvédelmi közleményt<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Kész</translation>
-<translation id="8748850008226585750">Tartalom elrejtve</translation>
-<translation id="8751914237388039244">Válasszon képet</translation>
-<translation id="8788265440806329501">Bezárta a navigációs előzményeket</translation>
-<translation id="8788968922598763114">A legutóbb bezárt lap újranyitása</translation>
-<translation id="8801436777607969138">JavaScript letiltása adott webhelynél.</translation>
-<translation id="8812260976093120287">Bizonyos webhelyeken fizethet eszközén a fenti támogatott fizetési alkalmazásokkal.</translation>
-<translation id="8816026460808729765">Az érzékelőkhöz való hozzáférés tiltása a webhelyek számára</translation>
-<translation id="8816439037877937734">A(z) <ph name="APP_NAME" /> a Chrome-ban nyílik meg. A folytatással elfogadja a Chrome <ph name="BEGIN_LINK1" />Általános Szerződési Feltételeit<ph name="END_LINK1" /> és <ph name="BEGIN_LINK2" />Adatvédelmi közleményét<ph name="END_LINK2" />, valamint <ph name="BEGIN_LINK3" />A Family Link szolgáltatással kezelt Google-fiókokra vonatkozó Adatvédelmi közleményt<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Könyvjelzők</translation>
-<translation id="8833831881926404480">Az egyik webhely jelenleg megosztja a képernyőt</translation>
-<translation id="883806473910249246">Hiba történt a tartalom letöltésekor.</translation>
-<translation id="8840953339110955557">Az oldal eltérhet az online változattól.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" /> lap</translation>
-<translation id="885701979325669005">Tárolás</translation>
-<translation id="889338405075704026">Ugrás a Chrome beállításaira</translation>
-<translation id="8901170036886848654">Nem találtunk könyvjelzőket</translation>
-<translation id="8909135823018751308">Megosztás...</translation>
-<translation id="8912362522468806198">Google Fiókjába</translation>
-<translation id="8920114477895755567">Várakozás a szülői adatokra.</translation>
+<translation id="1188239144602654184">AR indítása</translation>
+<translation id="473775607612524610">Frissítés</translation>
+<translation id="3133489217401741157">A(z) <ph name="MODULE"/> telepítése a Brave-hoz…</translation>
+<translation id="1791662854739702043">Telepítve</translation>
+<translation id="5131234170665854056">Nem lehetséges a(z) <ph name="MODULE"/> telepítése a Brave-hoz</translation>
+<translation id="2567385386134582609">KÉP</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEÓ</translation>
+<translation id="4116038641877404294">Töltse le az oldalakat offline használatra</translation>
 <translation id="8922289737868596582">A További lehetőségek gomb segítségével letölthet oldalakat offline használatra</translation>
-<translation id="8937772741022875483">Eltávolítja Chrome-beli tevékenységét a digitális jóllét funkcióból?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Megnyitás másik ablakban</translation>
-<translation id="8951232171465285730">A Chrome <ph name="MEGABYTES" /> MB-ot spórolt meg Önnek</translation>
-<translation id="8958424370300090006">Adott webhely cookie-jainak letiltása.</translation>
-<translation id="8959122750345127698">Nem érhető el az ide vezető navigáció: <ph name="URL" /></translation>
-<translation id="8965591936373831584">függőben</translation>
-<translation id="8970887620466824814">Hiba történt.</translation>
-<translation id="8972098258593396643">Letölti az alapértelmezett mappába?</translation>
-<translation id="8986494364107987395">Használati statisztikák és hibajelentések automatikus küldése a Google-nak</translation>
-<translation id="8993760627012879038">Új lap megnyitása inkognitómódban</translation>
-<translation id="8998729206196772491">Egy <ph name="MANAGED_DOMAIN" /> által felügyelt fiókkal jelentkezik be, és engedélyezi az adminisztrátor számára a Chrome-adatok kezelését. Adatai állandó jelleggel ehhez a fiókhoz lesznek társítva. A Chrome-ból való kijelentkezéssel törli adatait erről az eszközről, de Google-fiókjában továbbra is megmaradnak.</translation>
-<translation id="9019902583201351841">Szülők által kezelt</translation>
-<translation id="9028914725102941583">Szinkronizálás bekapcsolása az eszközök közötti megosztáshoz</translation>
-<translation id="9029323097866369874">Engedélyezi a(z) <ph name="DOMAIN" /> számára a VR-mód aktiválását?</translation>
-<translation id="9040142327097499898">Az értesítések engedélyezve vannak. A helyhozzáférés ki van kapcsolva az eszköznél.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videó}other{# videó}}</translation>
-<translation id="9050666287014529139">Összetett jelszó</translation>
-<translation id="9063523880881406963">Kapcsolja ki az Asztali webhely kérése funkciót</translation>
-<translation id="9065203028668620118">Szerkesztés</translation>
-<translation id="9070377983101773829">Hangalapú keresés indítása</translation>
-<translation id="9074336505530349563">A Google által javasolt, személyre szabott tartalmak fogadásához jelentkezzen be, és kapcsolja be a szinkronizálást</translation>
-<translation id="9086455579313502267">Nem sikerült elérni a hálózatot</translation>
-<translation id="9100505651305367705">Felajánlja, hogy egyszerűsített nézetben jeleníti meg a cikkeket (ha támogatott a funkció)</translation>
-<translation id="9100610230175265781">Összetett jelszó szükséges</translation>
-<translation id="9102803872260866941">Az előnézeti lap meg van nyitva</translation>
+<translation id="5958275228015807058">A fájlokat és oldalakat a Letöltések között találja meg</translation>
+<translation id="5620928963363755975">A fájlokat és oldalakat a További lehetőségek gomb Letöltések menüpontjában találja meg</translation>
+<translation id="3341058695485821946">Megnézheti, mennyi adatot takarított meg</translation>
+<translation id="3157842584138209013">A További lehetőségek gombra kattintva tekintheti meg, hogy mekkora a megtakarított adatmennyiség</translation>
+<translation id="8218622182176210845">Fiók kezelése</translation>
+<translation id="8090895580117672212">Brave Software-fiókjának kezeléséhez koppintson a „Fiók kezelése” gombra</translation>
+<translation id="8856898588039823173">Egyszerű oldal a Brave Software-tól. Koppintással betöltheti az eredetit.</translation>
+<translation id="8134317863207426198">Egyszerű oldal a Brave Software-tól. Az Eredeti betöltése gombra koppintva betöltheti az eredeti oldalt.</translation>
+<translation id="4961107849584082341">Bármely nyelvre lefordíthatja ezt az oldalt</translation>
+<translation id="569536719314091526">Bármely nyelvre lefordíthatja ezt az oldalt a További lehetőségek gomb segítségével</translation>
+<translation id="1397811292916898096">Keresés a(z) <ph name="PRODUCT_NAME"/> keresőmotorral</translation>
+<translation id="1792959175193046959">Az alapértelmezett letöltési helyet bármikor módosíthatja</translation>
+<translation id="6942665639005891494">Az alapértelmezett letöltési helyet bármikor módosíthatja a Beállítások menüben</translation>
+<translation id="6850409657436465440">A letöltés még mindig folyamatban van</translation>
+<translation id="5817715962196959877">Mostantól a Brave gyorsabban tölti le a fájlokat</translation>
+<translation id="3976396876660209797">A gyorsparancs eltávolítása és újbóli létrehozása</translation>
+<translation id="6766622839693428701">A bezáráshoz csúsztasson lefelé.</translation>
+<translation id="1028699632127661925">Küldés a következő eszközre: <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – A(z) <ph name="DEVICE_NAME"/> eszközről</translation>
+<translation id="5357811892247919462">Lap fogadva</translation>
 <translation id="9104217018994036254">Lap megosztására szolgáló eszközök listája.</translation>
-<translation id="9133397713400217035">Offline felfedezés</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Eredeti megjelenítése</translation>
-<translation id="9139068048179869749">Kérdezzen rá, mielőtt engedélyezné a webhelyek számára az értesítések küldését (ajánlott)</translation>
-<translation id="9139318394846604261">Vásárlás</translation>
-<translation id="9155898266292537608">Úgy is végrehajthat keresést, hogy gyorsan rákoppint valamelyik szóra</translation>
-<translation id="9169507124922466868">Félmagasságban megnyitott navigációs előzmények</translation>
-<translation id="9204836675896933765">1 fájl maradt</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Lap megosztására szolgáló eszközök listája félmagasságban megnyitva.</translation>
+<translation id="2904414404539560095">Lap megosztására szolgáló eszközök listája teljes magasságban megnyitva.</translation>
+<translation id="4135200667068010335">Lap megosztására szolgáló eszközök listája bezárva.</translation>
+<translation id="5292796745632149097">Küldés a következőre:</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> napja volt aktív</translation>
+<translation id="7971136598759319605">1 napja volt aktív</translation>
+<translation id="1521774566618522728">Ma volt aktív</translation>
+<translation id="3631987586758005671">Megosztás a következővel: <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Szinkronizálás bekapcsolása az eszközök közötti megosztáshoz</translation>
+<translation id="6162454065885854378">Ha szeretne megosztani valamit a telefonjáról egy másik eszközre, kapcsolja be a szinkronizálást a Brave beállításaiban mindkét eszközön</translation>
+<translation id="6084271560289605378">Ugrás a Brave beállításaira</translation>
+<translation id="2318045970523081853">Koppintson a hívás indításához</translation>
 <translation id="9209888181064652401">Nem lehet hívást indítani</translation>
-<translation id="9219103736887031265">Képek</translation>
-<translation id="926205370408745186">Chrome-beli tevékenység eltávolítása a digitális jóllét funkcióból</translation>
-<translation id="932327136139879170">Főoldal</translation>
-<translation id="938850635132480979">Hiba: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Hozzáférés a mikrofonhoz</translation>
-<translation id="95817756606698420">A Chrome igénybe veheti a <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> keresőszolgáltatást, hogy Kínában kereshessen. Ezt a <ph name="BEGIN_LINK" />Beállításokban<ph name="END_LINK" /> módosíthatja.</translation>
-<translation id="965817943346481315">Letiltás, ha a webhely tolakodó vagy félrevezető hirdetéseket jelenít meg (ajánlott)</translation>
-<translation id="968900484120156207">Itt jelennek meg a felkeresett oldalak</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> perc van hátra</translation>
-<translation id="974555521953189084">A szinkronizálás megkezdéséhez adja meg összetett jelszavát</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Ezzel törli az összes webhely adatait, beleértve a következőket:</translation>
-<translation id="983192555821071799">Az összes lap bezárása</translation>
-<translation id="987264212798334818">Általános</translation>
+<translation id="2860954141821109167">Győződjön meg arról, hogy van engedélyezett telefonalkalmazás ezen az eszközön</translation>
+<translation id="2067805253194386918">szöveg</translation>
+<translation id="1450753235335490080">Nem sikerült a(z) <ph name="CONTENT_TYPE"/> megosztása</translation>
+<translation id="1266864766717917324">Nem sikerült a(z) <ph name="CONTENT_TYPE"/> megosztása</translation>
+<translation id="8287068819750208230">Győződjön meg arról, hogy a(z) <ph name="TARGET_DEVICE_NAME"/> szinkronizálása be van kapcsolva a Brave-ban</translation>
+<translation id="3016635187733453316">Ellenőrizze, hogy az eszköz csatlakozik-e az internethez</translation>
+<translation id="8466613982764129868">Győződjön meg arról, hogy a(z) <ph name="TARGET_DEVICE_NAME"/> eszköz csatlakozik az internethez</translation>
+<translation id="6539092367496845964">Hiba történt. Próbálja újra később.</translation>
+<translation id="3389286852084373014">A szöveg túl nagy</translation>
+<translation id="2100314319871056947">Próbálja meg kisebb részletekben megosztani a szöveget</translation>
+<translation id="2987620471460279764">Más eszközről megosztott szöveg</translation>
+<translation id="7757787379047923882">Szöveg megosztva a következő eszközről: <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Vágólapra másolva</translation>
+<translation id="4696983787092045100">SMS küldése az eszközeire</translation>
+<translation id="1260236875608242557">Keresés és felfedezés</translation>
+<translation id="6369229450655021117">Itt internetes kereséseket indíthat, megoszthat tartalmakat barátaival, és megtekintheti a megnyitott oldalakat</translation>
+<translation id="723171743924126238">Képek kiválasztása</translation>
+<translation id="8751914237388039244">Válasszon képet</translation>
+<translation id="1989112275319619282">Böngészés</translation>
+<translation id="7055152154916055070">Átirányítás letiltva:</translation>
+<translation id="5524843473235508879">Átirányítás letiltva.</translation>
+<translation id="6573096386450695060">Engedélyezés mindig</translation>
+<translation id="5805364706385912897">Ez az oldal túl sok memóriát használ, ezért a Brave szünetelteti.</translation>
+<translation id="5138664332909611586">Ez az oldal túl sok memóriát használ, ezért a Brave eltávolított egyes tartalmakat.</translation>
+<translation id="9137013805542155359">Eredeti megjelenítése</translation>
+<translation id="6361779936989026201">Brave Software Segéd a Brave-ban</translation>
+<translation id="7291387454912369099">Segéd által aktivált fizetés</translation>
+<translation id="4565206163201411670">Brave-beli tevékenysége megjelenjen a digitális jóllét funkcióban?</translation>
+<translation id="9055113864158719823">Megnézheti a Brave böngészővel felkeresett webhelyeket, és beállíthat hozzájuk időzítéseket.\n\nAz időzítéssel ellátott webhelyek adatait és a látogatás hosszát megkapja a Brave Software. Ezek az adatok a digitális jóllét funkció továbbfejlesztésére szolgálnak.</translation>
+<translation id="4596514158372210596">Brave-beli tevékenység eltávolítása a digitális jóllét funkcióból</translation>
+<translation id="1174893863889683998">Eltávolítja Brave-beli tevékenységét a digitális jóllét funkcióból?</translation>
+<translation id="708829030563435351">A Brave-ban felkeresett webhelyek nem fognak megjelenni. A webhelyekkel kapcsolatos összes időzítés törlődik.</translation>
+<translation id="2056878612599315956">A webhely szüneteltetve van</translation>
+<translation id="671481426037969117">A(z) <ph name="FQDN"/> alkalmazás időzítése lejárt. Holnap újraindul.</translation>
+<translation id="7479104141328977413">Lapkezelés</translation>
+<translation id="3524138585025253783">Fejlesztői kezelőfelület</translation>
+<translation id="6036057147555329831">További ICU</translation>
+<translation id="9029323097866369874">Engedélyezi a(z) <ph name="DOMAIN"/> számára a VR-mód aktiválását?</translation>
+<translation id="7685301384041462804">A VR-mód aktiválása előtt győződjön meg a webhely megbízhatóságáról.</translation>
+<translation id="5033865233969348410">Amíg VR-módban van, a webhely megtudhat Önről bizonyos információkat:
+  –  fizikai jellemzőit, például a magasságát.
+
+A VR-mód aktiválása előtt győződjön meg a webhely megbízhatóságáról.</translation>
+<translation id="5534334044554683961">Amíg VR-módban van, a webhely megtudhat Önről bizonyos információkat:
+  –   fizikai jellemzőit, például a magasságát;
+  –   a szobája elrendezését.
+
+A VR-mód aktiválása előtt győződjön meg a webhely megbízhatóságáról.</translation>
+<translation id="4169535189173047238">Tiltás</translation>
+<translation id="2170088579611075216">Engedélyezés, és belépés VR-módba</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_id.xtb
+++ b/android/java/strings/translations/android_chrome_strings_id.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="id">
-<translation id="1006017844123154345">Buka versi Online</translation>
-<translation id="1028699632127661925">Mengirim ke <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Menambahkan <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Dari situs</translation>
-<translation id="1049743911850919806">Samaran</translation>
-<translation id="10614374240317010">Jangan pernah disimpan</translation>
-<translation id="1067922213147265141">Layanan Google lainnya</translation>
-<translation id="1068672505746868501">Jangan pernah menerjemahkan halaman dalam <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Jika ekstensi file diubah, file dapat terbuka di aplikasi lain dan berpotensi membahayakan perangkat Anda.</translation>
-<translation id="1100066534610197918">Buka pada tab baru di grup</translation>
-<translation id="1105960400813249514">Screenshot</translation>
-<translation id="1111673857033749125">Bookmark yang tersimpan di perangkat lainnya akan muncul di sini.</translation>
-<translation id="1113597929977215864">Buka tampilan sederhana</translation>
-<translation id="1121094540300013208">Laporan penggunaan dan error</translation>
-<translation id="1124772482545689468">Pengguna</translation>
-<translation id="1129510026454351943">Detail: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download tertunda.}other{# download tertunda.}}</translation>
-<translation id="1145536944570833626">Hapus data yang sudah ada.</translation>
-<translation id="1146678959555564648">Masuki VR</translation>
-<translation id="116280672541001035">Digunakan</translation>
-<translation id="1171770572613082465">Lihat situs populer dengan mengetuk tombol "Situs populer"</translation>
-<translation id="1173894706177603556">Ganti nama</translation>
-<translation id="1178581264944972037">Jeda</translation>
-<translation id="1181037720776840403">Hapus</translation>
-<translation id="1188239144602654184">Mulai AR</translation>
-<translation id="1197267115302279827">Pindahkan bookmark</translation>
-<translation id="119944043368869598">Hapus semua</translation>
-<translation id="1201402288615127009">Berikutnya</translation>
-<translation id="1204037785786432551">Download link</translation>
-<translation id="1206892813135768548">Salin teks link</translation>
-<translation id="1208340532756947324">Untuk menyinkronkan dan mempersonalisasi berbagai perangkat, aktifkan sinkronisasi</translation>
-<translation id="1209206284964581585">Sembunyikan sekarang</translation>
-<translation id="1227058898775614466">Histori navigasi</translation>
-<translation id="1231733316453485619">Aktifkan sinkronisasi?</translation>
-<translation id="123724288017357924">Memuat ulang halaman, mengabaikan konten dalam cache</translation>
-<translation id="124116460088058876">Bahasa lainnya</translation>
-<translation id="124678866338384709">Menutup tab aktif</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Telusuri &amp; jelajahi</translation>
-<translation id="1264974993859112054">Olahraga</translation>
-<translation id="1266864766717917324">Tidak dapat membagikan <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Berhenti</translation>
-<translation id="1283039547216852943">Ketuk untuk meluaskan</translation>
-<translation id="1285320974508926690">Jangan pernah terjemahkan situs ini</translation>
-<translation id="1291207594882862231">Menghapus histori, cookie, data situs, cache...</translation>
-<translation id="129382876167171263">File yang disimpan situs muncul di sini</translation>
-<translation id="129553762522093515">Baru saja ditutup</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Dikirim dari <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Kelompokkan tab</translation>
-<translation id="1327257854815634930">Histori navigasi terbuka</translation>
-<translation id="1331212799747679585">Chrome tidak dapat diupdate. Opsi lainnya</translation>
-<translation id="1332501820983677155">Pintasan fitur Google Chrome</translation>
-<translation id="1360432990279830238">Logout dan nonaktifkan sinkronisasi?</translation>
-<translation id="1369915414381695676">Situs <ph name="SITE_NAME" /> ditambahkan</translation>
-<translation id="1373696734384179344">Memori tidak cukup untuk mendownload konten yang dipilih.</translation>
-<translation id="1376578503827013741">Menghitung…</translation>
-<translation id="1383876407941801731">Telusuri</translation>
-<translation id="1384959399684842514">Download dijeda</translation>
-<translation id="1386674309198842382">Aktif <ph name="LAST_UPDATED" /> hari lalu</translation>
-<translation id="1397811292916898096">Telusuri dengan <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Tersemat dalam <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“Jangan Lacak”</translation>
-<translation id="1407135791313364759">Buka semua</translation>
-<translation id="1409426117486808224">Tampilan sederhana untuk tab yang terbuka</translation>
-<translation id="1409879593029778104">Download <ph name="FILE_NAME" /> dicegah karena file sudah ada.</translation>
-<translation id="1414981605391750300">Menghubungi Google. Tindakan ini memerlukan waktu beberapa saat…</translation>
-<translation id="1416550906796893042">Versi aplikasi</translation>
-<translation id="1430915738399379752">Cetak</translation>
-<translation id="1446450296470737166">Izinkan kontrol penuh perangkat MIDI</translation>
-<translation id="1450753235335490080">Tidak dapat membagikan <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Dinonaktifkan di Setelan Android</translation>
-<translation id="1477626028522505441">Download <ph name="FILE_NAME" /> gagal karena masalah server.</translation>
-<translation id="1506061864768559482">Mesin telusur</translation>
-<translation id="1513352483775369820">Bookmark dan histori web</translation>
-<translation id="1513858653616922153">Hapus sandi</translation>
-<translation id="1516229014686355813">Fitur Ketuk untuk Menelusuri mengirimkan kata yang dipilih dan halaman yang dibuka sebagai konteks ke Google Penelusuran. Anda dapat menonaktifkannya di <ph name="BEGIN_LINK" />Setelan<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktif hari ini</translation>
-<translation id="1544826120773021464">Untuk mengelola akun Google Anda, ketuk tombol "Kelola akun"</translation>
-<translation id="1549000191223877751">Beralih ke jendela lain</translation>
-<translation id="1553358976309200471">Perbarui browser Chrome</translation>
-<translation id="1569387923882100876">Perangkat yang Terhubung</translation>
-<translation id="1571304935088121812">Salin nama pengguna</translation>
-<translation id="1612196535745283361">Chrome memerlukan akses lokasi untuk memindai perangkat. Akses lokasi <ph name="BEGIN_LINK" />dinonaktifkan untuk perangkat ini<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Cegah dialog lain dari halaman ini.</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Hapus 1 item yang dipilih}other{Hapus # item yang dipilih}}</translation>
-<translation id="164269334534774161">Anda melihat salinan offline halaman ini dari <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Histori</translation>
-<translation id="1647391597548383849">Mengakses kamera Anda</translation>
-<translation id="1660204651932907780">Mengizinkan situs memutar suara (direkomendasikan)</translation>
-<translation id="1670399744444387456">Dasar</translation>
-<translation id="1671236975893690980">Proses download tertunda...</translation>
-<translation id="1672586136351118594">Jangan tampilkan lagi</translation>
-<translation id="1692118695553449118">Sinkronisasi aktif</translation>
-<translation id="169515064810179024">Memblokir situs agar tidak mengakses sensor gerakan</translation>
-<translation id="1717218214683051432">Sensor gerakan</translation>
-<translation id="1718835860248848330">1 jam terakhir</translation>
-<translation id="1736419249208073774">Jelajahi</translation>
-<translation id="1743802530341753419">Tanya sebelum mengizinkan situs terhubung ke perangkat (disarankan)</translation>
-<translation id="1749561566933687563">Sinkronisasikan bookmark Anda</translation>
-<translation id="17513872634828108">Buka tab</translation>
-<translation id="1779089405699405702">Pendekode gambar</translation>
-<translation id="1782483593938241562">Tanggal akhir <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Terpasang</translation>
-<translation id="1792959175193046959">Ubah lokasi download default kapan saja</translation>
-<translation id="1807246157184219062">Terang</translation>
-<translation id="1810845389119482123">Penyiapan sinkronisasi awal belum selesai</translation>
-<translation id="1821253160463689938">Menggunakan cookie untuk mengingat preferensi, meski Anda tidak membuka halaman tersebut</translation>
-<translation id="1829244130665387512">Cari di halaman</translation>
-<translation id="1853692000353488670">Tab samaran baru</translation>
-<translation id="1856325424225101786">Setel ulang Mode Ringan?</translation>
-<translation id="1868024384445905608">Chrome sekarang mendownload file lebih cepat</translation>
-<translation id="1883903952484604915">File Saya</translation>
-<translation id="1887786770086287077">Akses lokasi dinonaktifkan untuk perangkat ini. Aktifkan di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> akan terbuka di Chrome. Dengan melanjutkan, Anda menyetujui <ph name="BEGIN_LINK1" />Persyaratan Layanan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Pemberitahuan Privasi<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="1919345977826869612">Iklan</translation>
-<translation id="1919950603503897840">Pilih kontak</translation>
-<translation id="1922076542920281912">Untuk mengizinkan Chrome mengakses lokasi Anda, aktifkan juga lokasi di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Pembaruan</translation>
-<translation id="19288952978244135">Buka Chrome lagi.</translation>
-<translation id="1933845786846280168">Tab yang Dipilih</translation>
-<translation id="194341124344773587">Aktifkan izin untuk Chrome di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Simpan sandi</translation>
-<translation id="1952172573699511566">Situs akan menampilkan teks dalam bahasa pilihan Anda, jika memungkinkan.</translation>
-<translation id="1960290143419248813">Update Chrome tidak lagi didukung untuk versi Android ini</translation>
-<translation id="1966710179511230534">Perbarui detail ID masuk Anda.</translation>
-<translation id="1974060860693918893">Lanjutan</translation>
-<translation id="1984705450038014246">Sinkronkan data Chrome Anda</translation>
-<translation id="1984937141057606926">Diizinkan, kecuali pihak ketiga</translation>
-<translation id="1986685561493779662">Nama sudah ada</translation>
-<translation id="1987739130650180037">Tombol <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Jelajahi</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> ingin menyandingkan</translation>
-<translation id="1994173015038366702">URL situs</translation>
-<translation id="2000419248597011803">Mengirimkan beberapa cookie dan penelusuran dari kolom URL dan kotak penelusuran ke mesin telusur default</translation>
-<translation id="2002537628803770967">Kartu kredit dan alamat yang menggunakan Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# File}other{# File}}</translation>
-<translation id="2017836877785168846">Hapus histori dan pelengkapan otomatis di kolom URL.</translation>
-<translation id="2021896219286479412">Kontrol situs layar penuh</translation>
-<translation id="2038563949887743358">Aktifkan Ubah situs desktop</translation>
-<translation id="2041019821020695769">Untuk mengizinkan Chrome mengirimkan notifikasi, aktifkan juga notifikasi di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> juga memiliki data di Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Situs dijeda</translation>
-<translation id="2063713494490388661">Ketuk untuk Menelusuri</translation>
-<translation id="2067805253194386918">teks</translation>
-<translation id="2079545284768500474">Urungkan</translation>
-<translation id="2082238445998314030">Hasil <ph name="RESULT_NUMBER" /> dari <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Suara</translation>
-<translation id="2096012225669085171">Sinkronkan dan personalisasi di berbagai perangkat</translation>
-<translation id="2100273922101894616">Login Otomatis</translation>
-<translation id="2100314319871056947">Coba bagikan teks dalam potongan yang lebih kecil</translation>
-<translation id="2107397443965016585">Tanyakan sebelum mengizinkan situs memutar konten yang dilindungi (direkomendasikan)</translation>
-<translation id="2111511281910874386">Buka halaman</translation>
-<translation id="2122601567107267586">Tidak dapat membuka aplikasi</translation>
-<translation id="2126426811489709554">Diberdayakan oleh Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> dihemat</translation>
-<translation id="213279576345780926">Menutup <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Tambahkan ke Layar Utama</translation>
-<translation id="2146738493024040262">Buka Aplikasi Instan</translation>
-<translation id="2148716181193084225">Hari ini</translation>
-<translation id="2154484045852737596">Edit kartu</translation>
-<translation id="2154710561487035718">Salin URL</translation>
-<translation id="2156074688469523661">Situs yang tersisa (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Untuk berbagi dari ponsel Anda ke perangkat lain, aktifkan sinkronisasi di setelan Chrome pada kedua perangkat</translation>
-<translation id="2170088579611075216">Izinkan &amp; masuki VR</translation>
-<translation id="218608176142494674">Berbagi</translation>
-<translation id="2227444325776770048">Lanjutkan sebagai <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sinkronisasi dan layanan Google</translation>
-<translation id="2259659629660284697">Ekspor sandi…</translation>
-<translation id="2268044343513325586">Saring</translation>
-<translation id="2286841657746966508">Alamat penagihan</translation>
-<translation id="2289270750774289114">Tanyakan saat situs ingin menemukan perangkat Bluetooth di sekitar (direkomendasikan)</translation>
-<translation id="230115972905494466">Tidak ada perangkat yang kompatibel</translation>
-<translation id="2315043854645842844">Pilihan sertifikat sisi klien tidak didukung oleh sistem operasi.</translation>
-<translation id="2318045970523081853">Ketuk untuk melakukan panggilan</translation>
-<translation id="2321086116217818302">Mempersiapkan sandi…</translation>
-<translation id="2321958826496381788">Geser ukuran teks sampai Anda dapat membacanya dengan nyaman. Teks akan terlihat setidaknya sebesar ini setelah Anda mengetuk sebuah paragraf dua kali.</translation>
-<translation id="2323763861024343754">Penyimpanan situs</translation>
-<translation id="2328985652426384049">Tidak dapat login</translation>
-<translation id="2330129964253841015">Berikan peringatan jika sandi disusupi</translation>
-<translation id="2349710944427398404">Total data yang digunakan oleh Chrome, termasuk akun, bookmark, dan setelan yang tersimpan</translation>
-<translation id="2353636109065292463">Memeriksa sambungan internet Anda</translation>
-<translation id="2359808026110333948">Lanjutkan</translation>
-<translation id="2369533728426058518">tab terbuka</translation>
-<translation id="2387895666653383613">Ukuran teks</translation>
-<translation id="2394602618534698961">File yang Anda download muncul di sini</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Saat login ke Akun Google Anda, fitur ini akan diaktifkan</translation>
-<translation id="2410754283952462441">Pilih akun</translation>
-<translation id="2414886740292270097">Gelap</translation>
-<translation id="2416359993254398973">Chrome memerlukan izin akses ke kamera untuk situs ini.</translation>
-<translation id="2426805022920575512">Pilih akun lain</translation>
-<translation id="2433507940547922241">Tampilan</translation>
-<translation id="2434158240863470628">Download selesai <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Akses lokasi</translation>
-<translation id="2450083983707403292">Ingin mulai mendownload <ph name="FILE_NAME" /> lagi?</translation>
-<translation id="2482878487686419369">Notifikasi</translation>
-<translation id="2490684707762498678">Dikelola oleh <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Asisten Google di Chrome</translation>
-<translation id="2496180316473517155">Histori penjelajahan</translation>
-<translation id="2497852260688568942">Sinkronisasi dinonaktifkan oleh administrator</translation>
-<translation id="2498359688066513246">Bantuan &amp; masukan</translation>
-<translation id="2501278716633472235">Kembali</translation>
-<translation id="2513403576141822879">Untuk setelan lainnya yang berkaitan dengan privasi, keamanan, dan pengumpulan data, lihat <ph name="BEGIN_LINK" />Sinkronisasi dan layanan Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Dalam Mode Ringan, Chrome memuat halaman lebih cepat dan menghemat data hingga 60 persen. Untuk mengoptimalkan halaman yang Anda kunjungi, Chrome akan mengirimkan traffic web ke Google. <ph name="BEGIN_LINK" />Pelajari lebih lanjut<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Mengirimkan URL halaman yang Anda buka ke Google</translation>
-<translation id="2532336938189706096">Tampilan Web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> item dihapus</translation>
-<translation id="2536728043171574184">Melihat salinan offline halaman ini</translation>
-<translation id="2546283357679194313">Cookie dan data situs</translation>
-<translation id="2567385386134582609">GAMBAR</translation>
-<translation id="257088987046510401">Tema</translation>
-<translation id="2570922361219980984">Akses lokasi juga dinonaktifkan untuk perangkat ini. Aktifkan di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Diperluas - klik untuk menciutkan</translation>
-<translation id="2581165646603367611">Tindakan ini akan mengosongkan cache dan menghapus cookie, serta data lain dari situs yang dianggap tidak penting oleh Chrome.</translation>
-<translation id="2586657967955657006">Papan klip</translation>
-<translation id="2587052924345400782">Versi baru telah tersedia</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Nomor kartu kredit</translation>
-<translation id="2621115761605608342">Izinkan JavaScript untuk situs tertentu.</translation>
-<translation id="2625189173221582860">Sandi disalin</translation>
-<translation id="2631006050119455616">Dihemat</translation>
-<translation id="2647434099613338025">Tambah bahasa</translation>
-<translation id="2650751991977523696">Download file lagi?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# File audio}other{# File audio}}</translation>
-<translation id="2653659639078652383">Kirim</translation>
-<translation id="2677748264148917807">Keluar</translation>
-<translation id="2704606927547763573">Disalin</translation>
-<translation id="2707726405694321444">Segarkan halaman</translation>
-<translation id="2709516037105925701">Isi-Otomatis</translation>
-<translation id="2717722538473713889">Alamat email</translation>
-<translation id="2728754400939377704">Urutkan menurut situs</translation>
-<translation id="2744248271121720757">Ketuk sebuah kata untuk menelusuri secara instan atau melihat tindakan terkait</translation>
-<translation id="2760989362628427051">Mengaktifkan tema gelap ketika tema gelap perangkat atau Penghemat Baterai aktif</translation>
-<translation id="2762000892062317888">baru saja</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> detik lagi</translation>
-<translation id="2779651927720337254">gagal</translation>
-<translation id="2781151931089541271">1 detik lagi</translation>
-<translation id="2801022321632964776">Update untuk mendapatkan bahasa Anda di versi terbaru Chrome</translation>
-<translation id="2810645512293415242">Halaman disederhanakan agar data disimpan dan dimuat lebih cepat.</translation>
-<translation id="281504910091592009">Lihat dan kelola sandi tersimpan di <ph name="BEGIN_LINK" />Akun Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Untuk dapat mengakses bookmark Anda di semua perangkat, login dan aktifkan sinkronisasi</translation>
-<translation id="2822354292072154809">Yakin ingin menyetel ulang semua izin situs untuk <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Ketuk tombol kembali untuk keluar dari mode layar penuh.</translation>
-<translation id="2842985007712546952">Folder induk</translation>
-<translation id="2858138569776157458">Situs populer</translation>
-<translation id="2860954141821109167">Pastikan aplikasi telepon diaktifkan di perangkat ini</translation>
-<translation id="2870560284913253234">Situs</translation>
-<translation id="2874939134665556319">Lagu sebelumnya</translation>
-<translation id="2876369937070532032">Mengirimkan URL beberapa halaman yang Anda kunjungi ke Google, jika keamanan Anda berisiko</translation>
-<translation id="2888126860611144412">Tentang Chrome</translation>
-<translation id="2891154217021530873">Hentikan pemuatan halaman</translation>
-<translation id="2893180576842394309">Google dapat menggunakan histori Anda untuk mempersonalisasi Penelusuran dan layanan Google lainnya</translation>
-<translation id="2898264748040935573">Edit sandi yang disimpan</translation>
-<translation id="2900528713135656174">Buat acara</translation>
-<translation id="290376772003165898">Halaman tidak dalam bahasa <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Daftar perangkat yang dapat digunakan untuk berbagi tab terbuka dalam layar penuh.</translation>
-<translation id="2910701580606108292">Tanyakan sebelum mengizinkan situs untuk memutar konten yang dilindungi</translation>
-<translation id="2913331724188855103">Izinkan situs untuk menyimpan dan membaca data cookie (disarankan)</translation>
-<translation id="2923908459366352541">Nama tidak valid</translation>
-<translation id="2932150158123903946">Penyimpanan Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Tab pratinjau ditutup</translation>
-<translation id="2956410042958133412">Akun ini dikelola oleh <ph name="PARENT_NAME_1" /> dan <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Beralih ke tab samaran</translation>
-<translation id="2968755619301702150">Penampil sertifikat</translation>
-<translation id="2979025552038692506">Tab Samaran yang Dipilih</translation>
-<translation id="2987620471460279764">Teks yang dibagikan dari perangkat lain</translation>
-<translation id="2989523299700148168">Baru saja dikunjungi</translation>
-<translation id="2996291259634659425">Buat frasa sandi</translation>
-<translation id="2996809686854298943">Perlu URL</translation>
-<translation id="300526633675317032">Ini akan menghapus seluruh penyimpanan situs web, sebesar <ph name="SIZE_IN_KB" />.</translation>
-<translation id="3016635187733453316">Pastikan perangkat ini tersambung ke internet</translation>
-<translation id="3029613699374795922">Terdownload <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Frasa sandi tidak cocok</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Dapatkan bantuan<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Lokasi nonaktif, aktifkan di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Anda dapat mengaktifkan sinkronisasi kapan saja di setelan</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> bookmark}other{<ph name="BOOKMARKS_COUNT_MANY" /> bookmark}}</translation>
-<translation id="3089395242580810162">Buka di tab samaran</translation>
-<translation id="3115898365077584848">Tampilkan Info</translation>
-<translation id="3123473560110926937">Diblokir di beberapa situs</translation>
-<translation id="3137521801621304719">Tutup mode samaran</translation>
-<translation id="3143515551205905069">Batalkan sinkronisasi</translation>
-<translation id="3157842584138209013">Lihat banyaknya kuota yang Anda hemat dari tombol Opsi Lainnya</translation>
-<translation id="3166827708714933426">Pintasan tab dan jendela</translation>
-<translation id="3181954750937456830">Safe Browsing (melindungi Anda dan perangkat dari situs berbahaya)</translation>
-<translation id="3190152372525844641">Aktifkan izin untuk Chrome di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> data tersimpan</translation>
-<translation id="3205824638308738187">Hampir selesai!</translation>
-<translation id="3207960819495026254">Diberi bookmark</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> dihapus</translation>
-<translation id="321773570071367578">Jika lupa frasa sandi atau ingin mengubah setelan ini, <ph name="BEGIN_LINK" />setel ulang sinkronisasi<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Aplikasi Web</translation>
-<translation id="3236059992281584593">1 menit lagi</translation>
-<translation id="3244271242291266297">BB</translation>
-<translation id="3254409185687681395">Bookmark halaman ini</translation>
-<translation id="3259831549858767975">Memperkecil semua yang ada di halaman</translation>
-<translation id="3269093882174072735">Muat gambar</translation>
-<translation id="3269956123044984603">Untuk mengakses tab Anda dari perangkat lainnya, aktifkan "Sinkronisasi data otomatis" di setelan akun Android.</translation>
-<translation id="3277252321222022663">Mengizinkan situs untuk mengakses sensor (disarankan)</translation>
-<translation id="3282568296779691940">Login ke Chrome</translation>
-<translation id="3288003805934695103">Memuat ulang halaman</translation>
-<translation id="32895400574683172">Notifikasi diizinkan</translation>
-<translation id="3295530008794733555">Browsing lebih cepat. Gunakan lebih sedikit kuota.</translation>
-<translation id="3295602654194328831">Sembunyikan Info</translation>
-<translation id="3298243779924642547">Ringan</translation>
-<translation id="3303414029551471755">Lanjutkan untuk mendownload konten?</translation>
-<translation id="3306398118552023113">Aplikasi ini dijalankan di Chrome</translation>
-<translation id="3315103659806849044">Anda sedang menyesuaikan setelan layanan Google dan Sinkronisasi. Untuk menyelesaikan pengaktifan sinkronisasi, ketuk Konfirmasi di dekat bagian bawah layar. Kembali ke atas</translation>
-<translation id="3328801116991980348">Informasi situs</translation>
-<translation id="3333961966071413176">Semua kontak</translation>
-<translation id="3334729583274622784">Ubah ekstensi file?</translation>
-<translation id="3341058695485821946">Lihat banyaknya kuota yang Anda hemat</translation>
-<translation id="3350687908700087792">Tutup semua jendela samaran</translation>
-<translation id="3353615205017136254">Halaman ringan yang ditampilkan oleh Google. Ketuk tombol muat versi asli untuk memuat halaman asli.</translation>
-<translation id="3367813778245106622">Login lagi untuk memulai sinkronisasi</translation>
-<translation id="3374023511497244703">Bookmark, histori, sandi, dan data Chrome lainnya tidak akan disinkronkan lagi dengan Akun Google Anda.</translation>
-<translation id="3384347053049321195">Bagikan gambar</translation>
-<translation id="3386292677130313581">Minta izin sebelum memungkinkan situs mengetahui lokasi Anda (disarankan)</translation>
-<translation id="3387650086002190359">Download <ph name="FILE_NAME" /> gagal karena kesalahan sistem file.</translation>
-<translation id="3389286852084373014">Teks terlalu besar</translation>
-<translation id="3398320232533725830">Membuka pengelola bookmark</translation>
-<translation id="3414952576877147120">Ukuran:</translation>
-<translation id="3443221991560634068">Memuat ulang halaman saat ini</translation>
-<translation id="3445014427084483498">Baru Saja</translation>
-<translation id="3478363558367712427">Anda dapat memilih mesin telusur Anda</translation>
+<translation id="6910211073230771657">Dihapus</translation>
+<translation id="6965382102122355670">Oke</translation>
+<translation id="5301954838959518834">Oke, mengerti</translation>
+<translation id="7658239707568436148">Batal</translation>
 <translation id="3479552764303398839">Jangan sekarang</translation>
-<translation id="3492207499832628349">Tab samaran baru</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Pelajari lebih lanjut<ph name="END_LINK" /> konten yang disarankan</translation>
-<translation id="3513704683820682405">Augmented Reality</translation>
-<translation id="3518985090088779359">Terima &amp; lanjutkan</translation>
-<translation id="3522247891732774234">Pembaruan tersedia. Opsi lainnya</translation>
-<translation id="3524138585025253783">UI Developer</translation>
-<translation id="3527085408025491307">Folder</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB tersedia</translation>
-<translation id="3549657413697417275">Telusuri histori penggunaan</translation>
-<translation id="3557336313807607643">Tambahkan ke kontak</translation>
-<translation id="3566923219790363270">Chrome masih bersiap untuk menggunakan VR. Mulai ulang Chrome nanti.</translation>
-<translation id="3568688522516854065">Untuk membuka tab dari perangkat Anda yang lain, login dan aktifkan sinkronisasi</translation>
-<translation id="3587482841069643663">Semua</translation>
-<translation id="358794129225322306">Izinkan situs untuk otomatis mendownload beberapa file.</translation>
-<translation id="3590487821116122040">Penyimpanan situs yang dianggap tidak penting oleh Chrome (misalnya situs yang tidak memiliki setelan penyimpanan atau situs yang tidak sering Anda kunjungi)</translation>
-<translation id="3599863153486145794">Menghapus histori dari semua perangkat yang dibuat login. Akun Google Anda mungkin memiliki bentuk histori penjelajahan lainnya di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Nonaktifkan suara situs yang memutar suara</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Membagikan ke <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Tampilkan sandi</translation>
-<translation id="363596933471559332">Otomatis login ke situs web menggunakan kredensial yang tersimpan. Saat fitur dinonaktifkan, Anda akan dimintai verifikasi setiap kali hendak login ke situs web.</translation>
-<translation id="3658159451045945436">Penyetalan ulang akan menghapus histori penyimpanan data, termasuk daftar situs yang dibuka.</translation>
-<translation id="3692944402865947621">Download <ph name="FILE_NAME" /> gagal karena lokasi penyimpanan tidak dapat dijangkau.</translation>
-<translation id="3714981814255182093">Membuka Bilah Cari</translation>
-<translation id="3716182511346448902">Halaman ini menggunakan terlalu banyak memori, sehingga Chrome menjedanya.</translation>
-<translation id="3730075448226062617">Untuk mengizinkan Chrome mengakses mikrofon Anda, aktifkan juga mikrofon di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Dibookmark di <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sinkronisasi latar belakang</translation>
-<translation id="3771001275138982843">Tidak dapat mendownload update</translation>
-<translation id="3771033907050503522">Tab Samaran</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Aktifkan Bluetooth<ph name="END_LINK" /> untuk mengizinkan penyandingan</translation>
-<translation id="3775705724665058594">Kirim ke perangkat Anda</translation>
-<translation id="3778956594442850293">Ditambahkan ke Layar utama</translation>
-<translation id="3789841737615482174">Instal</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Kelola</translation>
-<translation id="381841723434055211">Nomor telepon</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> download dihapus</translation>
-<translation id="3822502789641063741">Kosongkan penyimpanan situs?</translation>
-<translation id="385051799172605136">Mundur</translation>
-<translation id="3859306556332390985">Cari maju</translation>
-<translation id="3894427358181296146">Tambah folder</translation>
-<translation id="3895926599014793903">Aktifkan zoom secara paksa</translation>
-<translation id="3912508018559818924">Menemukan yang terbaik dari web...</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Gabungkan data saya</translation>
-<translation id="393697183122708255">Tidak ada penelusuran suara yang aktif</translation>
-<translation id="395206256282351086">Saran situs dan penelusuran dinonaktifkan</translation>
-<translation id="3955193568934677022">Izinkan situs memutar konten yang dilindungi (direkomendasikan)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome akan memuat halaman Anda setelah siap}other{Chrome akan memuat halaman Anda setelah siap}}</translation>
-<translation id="3963007978381181125">Enkripsi frasa sandi tidak mencakup alamat dan metode pembayaran dari Google Pay. Hanya pengguna yang memiliki frasa sandi Anda yang dapat membaca data yang telah Anda enkripsi. Frasa sandi tidak dikirim atau disimpan oleh Google. Jika lupa frasa sandi Anda atau ingin mengubah setelan ini, Anda harus menyetel ulang sinkronisasi. <ph name="BEGIN_LINK" />Pelajari lebih lanjut<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Download selesai</translation>
-<translation id="397583555483684758">Sinkronisasi berhenti berfungsi</translation>
-<translation id="3976396876660209797">Hapus dan buat ulang pintasan ini</translation>
-<translation id="3985215325736559418">Ingin mendownload <ph name="FILE_NAME" /> lagi?</translation>
-<translation id="3987993985790029246">Salin link</translation>
-<translation id="3988213473815854515">Lokasi diaktifkan</translation>
-<translation id="3988466920954086464">Lihat hasil penelusuran instan di panel ini</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Penyimpanan tidak penting</translation>
-<translation id="4000212216660919741">Beranda Offline</translation>
+<translation id="5317780077021120954">Simpan</translation>
+<translation id="4570913071927164677">Detail</translation>
+<translation id="8730621377337864115">Selesai</translation>
+<translation id="8261506727792406068">Hapus</translation>
+<translation id="1181037720776840403">Hapus</translation>
+<translation id="5939518447894949180">Setel ulang</translation>
 <translation id="4002066346123236978">Judul</translation>
-<translation id="4008040567710660924">Izinkan cookie untuk situs tertentu.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# jam}other{# jam}}</translation>
-<translation id="4046123991198612571">Lagu berikutnya</translation>
-<translation id="4048707525896921369">Pelajari topik di situs tanpa meninggalkan halaman. Fitur Ketuk untuk Menelusuri mengirimkan kata dan konteks di sekitarnya ke Google Penelusuran, yang kemudian menampilkan definisi, gambar, hasil penelusuran, dan detail lainnya.
+<translation id="5916664084637901428">Aktif</translation>
+<translation id="5860033963881614850">Nonaktif</translation>
+<translation id="6165508094623778733">Pelajari lebih lanjut</translation>
+<translation id="6042308850641462728">Lainnya</translation>
+<translation id="6040143037577758943">Tutup</translation>
+<translation id="780301667611848630">Lain kali</translation>
+<translation id="1201402288615127009">Berikutnya</translation>
+<translation id="2359808026110333948">Lanjutkan</translation>
+<translation id="2653659639078652383">Kirim</translation>
+<translation id="2079545284768500474">Urungkan</translation>
+<translation id="7649070708921625228">Bantuan</translation>
+<translation id="2148716181193084225">Hari ini</translation>
+<translation id="7781829728241885113">Kemarin</translation>
+<translation id="6945221475159498467">Pilih</translation>
+<translation id="7791543448312431591">Tambahkan</translation>
+<translation id="6527303717912515753">Bagikan</translation>
+<translation id="1383876407941801731">Telusuri</translation>
+<translation id="3115898365077584848">Tampilkan Info</translation>
+<translation id="3295602654194328831">Sembunyikan Info</translation>
+<translation id="3987993985790029246">Salin link</translation>
+<translation id="2704606927547763573">Disalin</translation>
+<translation id="8725066075913043281">Coba lagi</translation>
+<translation id="385051799172605136">Mundur</translation>
+<translation id="8131740175452115882">Konfirmasi</translation>
+<translation id="5300589172476337783">Tampilkan</translation>
+<translation id="1124772482545689468">Pengguna</translation>
+<translation id="8609465669617005112">Berpindah ke atas</translation>
+<translation id="6746124502594467657">Berpindah ke bawah</translation>
+<translation id="8249310407154411074">Pindahkan ke atas</translation>
+<translation id="8428213095426709021">Setelan</translation>
+<translation id="2498359688066513246">Bantuan &amp; masukan</translation>
+<translation id="8378714024927312812">Dikelola oleh organisasi</translation>
+<translation id="9019902583201351841">Dikelola oleh orang tua Anda</translation>
+<translation id="4645575059429386691">Dikelola oleh orang tua Anda</translation>
+<translation id="4883854917563148705">Setelan yang dikelola tidak dapat disetel ulang</translation>
+<translation id="4307992518367153382">Dasar</translation>
+<translation id="1974060860693918893">Lanjutan</translation>
+<translation id="1146678959555564648">Masuki VR</translation>
+<translation id="987264212798334818">Umum</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Download</translation>
+<translation id="218608176142494674">Berbagi</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Screenshot</translation>
+<translation id="4875775213178255010">Saran Konten</translation>
+<translation id="2021896219286479412">Kontrol situs layar penuh</translation>
+<translation id="4587589328781138893">Situs</translation>
+<translation id="4943703118917034429">Virtual Reality</translation>
+<translation id="1928696683969751773">Pembaruan</translation>
+<translation id="6064125863973209585">Download yang selesai</translation>
+<translation id="5342314432463739672">Permintaan izin</translation>
+<translation id="629730747756840877">Akun</translation>
+<translation id="82609232232243542">Login ke Brave</translation>
+<translation id="7956662517480676674">Sinkronisasi dan layanan Brave Software</translation>
+<translation id="5294439808117722387">Anda sedang menyesuaikan setelan layanan Brave Software dan Sinkronisasi. Untuk menyelesaikan pengaktifan sinkronisasi, ketuk Konfirmasi di dekat bagian bawah layar. Kembali ke atas</translation>
+<translation id="2096012225669085171">Sinkronkan dan personalisasi di berbagai perangkat</translation>
+<translation id="1692118695553449118">Sinkronisasi aktif</translation>
+<translation id="5514904542973294328">Dinonaktifkan oleh administrator perangkat</translation>
+<translation id="6447211988989208781">Kontrol aktivitas Brave Software</translation>
+<translation id="4882831918239250449">Kontrol cara histori browsing digunakan untuk mempersonalisasi Penelusuran, iklan, dan lainnya</translation>
+<translation id="7431991332293347422">Kontrol cara histori browsing digunakan untuk mempersonalisasi Penelusuran dan lainnya</translation>
+<translation id="6303969859164067831">Logout dan nonaktifkan sinkronisasi</translation>
+<translation id="1125261911132334651">Kelola Akun Brave Software Anda</translation>
+<translation id="6406506848690869874">Sinkronisasi</translation>
+<translation id="714362445477979774">Sinkronkan data Brave Anda</translation>
+<translation id="4314815835985389558">Kelola sinkronisasi</translation>
+<translation id="5428209950370661546">Layanan Brave Software lainnya</translation>
+<translation id="7704317875155739195">Lengkapi otomatis penelusuran dan URL</translation>
+<translation id="2000419248597011803">Mengirimkan beberapa cookie dan penelusuran dari kolom URL dan kotak penelusuran ke mesin telusur default</translation>
+<translation id="7981313251711023384">Pramuat halaman agar browsing dan menelusuri lebih cepat</translation>
+<translation id="1821253160463689938">Menggunakan cookie untuk mengingat preferensi, meski Anda tidak membuka halaman tersebut</translation>
+<translation id="6697492270171225480">Tampilkan saran untuk halaman yang serupa jika halaman tidak dapat ditemukan</translation>
+<translation id="8109318360573330108">Mengirimkan URL halaman yang ingin Anda buka ke Brave Software</translation>
+<translation id="8438566539970814960">Jadikan penelusuran dan penjelajahan lebih baik</translation>
+<translation id="284843628681142937">Mengirimkan URL halaman yang Anda buka ke Brave Software</translation>
+<translation id="7222718784508482526">Untuk setelan lainnya yang berkaitan dengan privasi, keamanan, dan pengumpulan data, lihat <ph name="BEGIN_LINK"/>Sinkronisasi dan layanan Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Bantu sempurnakan fitur dan performa Brave</translation>
+<translation id="9063160602596686558">Secara otomatis mengirimkan statistik penggunaan dan laporan kerusakan ke Brave Software</translation>
+<translation id="4824958205181053313">Batalkan sinkronisasi?</translation>
+<translation id="3058498974290601450">Anda dapat mengaktifkan sinkronisasi kapan saja di setelan</translation>
+<translation id="3143515551205905069">Batalkan sinkronisasi</translation>
+<translation id="1506061864768559482">Mesin telusur</translation>
+<translation id="55737423895878184">Lokasi dan notifikasi diizinkan</translation>
+<translation id="3988213473815854515">Lokasi diaktifkan</translation>
+<translation id="32895400574683172">Notifikasi diizinkan</translation>
+<translation id="9040142327097499898">Notifikasi diizinkan. Lokasi dinonaktifkan untuk perangkat ini.</translation>
+<translation id="305593374596241526">Lokasi nonaktif, aktifkan di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Baru saja dikunjungi</translation>
+<translation id="6433501201775827830">Pilih mesin telusur Anda</translation>
+<translation id="7177466738963138057">Anda dapat mengubah ini nanti di Setelan</translation>
+<translation id="3478363558367712427">Anda dapat memilih mesin telusur Anda</translation>
+<translation id="4910889077668685004">Aplikasi pembayaran</translation>
+<translation id="5152843274749979095">Aplikasi yang didukung tidak terinstal</translation>
+<translation id="8812260976093120287">Di beberapa situs, Anda dapat membayar dengan aplikasi pembayaran yang didukung di atas pada perangkat Anda.</translation>
+<translation id="7764225426217299476">Tambahkan alamat</translation>
+<translation id="5595485650161345191">Edit alamat</translation>
+<translation id="5087580092889165836">Tambahkan kartu</translation>
+<translation id="2154484045852737596">Edit kartu</translation>
+<translation id="6140912465461743537">Negara/Wilayah</translation>
+<translation id="5659593005791499971">Email</translation>
+<translation id="4378154925671717803">Ponsel</translation>
+<translation id="4807098396393229769">Nama di kartu</translation>
+<translation id="860043288473659153">Nama pemegang kartu</translation>
+<translation id="2612676031748830579">Nomor kartu kredit</translation>
+<translation id="869891660844655955">Masa berlaku</translation>
+<translation id="2286841657746966508">Alamat penagihan</translation>
+<translation id="663059986967017181">Disalin ke Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> lainnya}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> lainnya}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> lainnya}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> lainnya}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> lainnya}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> lainnya}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> lainnya}other{<ph name="CONTACT_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> lainnya}}</translation>
+<translation id="7029809446516969842">Sandi</translation>
+<translation id="1943432128510653496">Simpan sandi</translation>
+<translation id="2100273922101894616">Login Otomatis</translation>
+<translation id="363596933471559332">Otomatis login ke situs web menggunakan kredensial yang tersimpan. Saat fitur dinonaktifkan, Anda akan dimintai verifikasi setiap kali hendak login ke situs web.</translation>
+<translation id="6995899638241819463">Berikan peringatan jika sandi terungkap saat terjadi pelanggaran data</translation>
+<translation id="1534287762301776620">Saat login ke Akun Brave Software Anda, fitur ini akan diaktifkan</translation>
+<translation id="10614374240317010">Jangan pernah disimpan</translation>
+<translation id="3098842761938485917">Lihat dan kelola sandi tersimpan di <ph name="BEGIN_LINK"/>Akun Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Sandi yang disimpan akan muncul di sini.</translation>
+<translation id="8084114998886531721">Sandi tersimpan</translation>
+<translation id="2870560284913253234">Situs</translation>
+<translation id="8503813439785031346">Nama Pengguna</translation>
+<translation id="6657585470893396449">Sandi</translation>
+<translation id="2154710561487035718">Salin URL</translation>
+<translation id="1571304935088121812">Salin nama pengguna</translation>
+<translation id="5005498671520578047">Salin sandi</translation>
+<translation id="3632295766818638029">Tampilkan sandi</translation>
+<translation id="1513858653616922153">Hapus sandi</translation>
+<translation id="543338862236136125">Edit sandi</translation>
+<translation id="4565377596337484307">Sembunyikan sandi</translation>
+<translation id="8523928698583292556">Hapus sandi tersimpan</translation>
+<translation id="2898264748040935573">Edit sandi yang disimpan</translation>
+<translation id="5433691172869980887">Nama pengguna disalin</translation>
+<translation id="5534640966246046842">Situs disalin</translation>
+<translation id="2625189173221582860">Sandi disalin</translation>
+<translation id="4550003330909367850">Untuk melihat atau menyalin sandi di sini, setel kunci layar di perangkat ini.</translation>
+<translation id="6154478581116148741">Aktifkan kunci layar di Setelan untuk mengekspor sandi dari perangkat ini</translation>
+<translation id="4842092870884894799">Menampilkan pop-up pembuatan sandi</translation>
+<translation id="2259659629660284697">Ekspor sandi…</translation>
+<translation id="133012818630824069">Ekspor sandi yang disimpan dengan Brave</translation>
+<translation id="6914783257214138813">Sandi akan terlihat oleh orang yang dapat melihat file yang diekspor.</translation>
+<translation id="2321086116217818302">Mempersiapkan sandi…</translation>
+<translation id="8445448999790540984">Tidak dapat mengekspor sandi</translation>
+<translation id="3066461326500799725">Pelajari cara menggunakan Brave Software Drive</translation>
+<translation id="729975465115245577">Perangkat Anda tidak memiliki aplikasi untuk menyimpan file sandi.</translation>
+<translation id="7682724950699840886">Coba tips berikut ini: pastikan ruang di perangkat Anda mencukupi, lalu coba ekspor lagi.</translation>
+<translation id="1129510026454351943">Detail: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Buka kunci untuk menyalin sandi Anda</translation>
+<translation id="5515439363601853141">Buka kunci untuk melihat sandi Anda</translation>
+<translation id="6221633008163990886">Buka kunci untuk mengekspor sandi</translation>
+<translation id="230699814587342492">Sandi Brave</translation>
+<translation id="6075798973483050474">Edit halaman beranda</translation>
+<translation id="854522910157234410">Buka halaman ini</translation>
+<translation id="2482878487686419369">Notifikasi</translation>
+<translation id="6255999984061454636">Saran konten</translation>
+<translation id="805047784848435650">Berdasarkan histori browsing Anda</translation>
+<translation id="1041308826830691739">Dari situs</translation>
+<translation id="395206256282351086">Saran situs dan penelusuran dinonaktifkan</translation>
+<translation id="257088987046510401">Tema</translation>
+<translation id="4650364565596261010">Default sistem</translation>
+<translation id="7588219262685291874">Mengaktifkan tema gelap saat mode Penghemat Baterai perangkat aktif</translation>
+<translation id="2760989362628427051">Mengaktifkan tema gelap ketika tema gelap perangkat atau Penghemat Baterai aktif</translation>
+<translation id="6381421346744604172">Gelapkan situs</translation>
+<translation id="5040262127954254034">Privasi</translation>
+<translation id="4991384657077828949">Bantu meningkatkan keamanan Brave</translation>
+<translation id="1943176487615318915">Untuk mendeteksi aplikasi dan situs berbahaya, Brave mengirimkan URL beberapa halaman yang Anda kunjungi, informasi sistem terbatas, dan beberapa konten halaman ke Brave Software</translation>
+<translation id="3181954750937456830">Safe Browsing (melindungi Anda dan perangkat dari situs berbahaya)</translation>
+<translation id="7315322926489145388">Mengirimkan URL beberapa halaman yang Anda kunjungi ke Brave Software, jika keamanan Anda berisiko</translation>
+<translation id="2063713494490388661">Ketuk untuk Menelusuri</translation>
+<translation id="2369463299479365221">Pelajari topik di situs tanpa meninggalkan halaman. Fitur Ketuk untuk Menelusuri mengirimkan kata dan konteks di sekitarnya ke Brave Software Penelusuran, yang kemudian menampilkan definisi, gambar, hasil penelusuran, dan detail lainnya.
 
 Untuk menyesuaikan istilah penelusuran, tekan lama untuk memilih. Untuk memerinci penelusuran, geser panel ke atas, lalu ketuk kotak penelusuran.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Opsi yang tersedia di dekat bagian atas layar</translation>
-<translation id="4062305924942672200">Informasi hukum</translation>
-<translation id="4084682180776658562">Bookmark</translation>
-<translation id="4084712963632273211">Dari <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />dikirim oleh Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Hapus data aplikasi?</translation>
-<translation id="4099578267706723511">Bantu penyempurnaan Chrome dengan mengirimkan statistik penggunaan dan laporan error ke Google.</translation>
-<translation id="410351446219883937">Putar otomatis</translation>
-<translation id="4116038641877404294">Download halaman untuk melihat secara offline</translation>
-<translation id="4135200667068010335">Daftar perangkat yang dapat digunakan untuk berbagi tab tertutup.</translation>
-<translation id="4149994727733219643">Tampilan sederhana untuk halaman web</translation>
-<translation id="4165986682804962316">Setelan situs</translation>
-<translation id="4169535189173047238">Jangan izinkan</translation>
-<translation id="4170011742729630528">Layanan tidak tersedia; coba lagi nanti.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> digunakan</translation>
-<translation id="4181841719683918333">Bahasa</translation>
-<translation id="4183868528246477015">Telusuri dgn Google Lens <ph name="BEGIN_NEW" />Baru<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Buka di tab baru</translation>
-<translation id="4198423547019359126">Tidak tersedia lokasi download</translation>
-<translation id="4209895695669353772">Untuk mendapatkan konten hasil personalisasi yang disarankan oleh Google, aktifkan sinkronisasi</translation>
-<translation id="4226663524361240545">Notifikasi dapat membuat perangkat bergetar</translation>
-<translation id="423219824432660969">Enkripsikan data yang disinkronkan dengan sandi Google mulai tanggal <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Buka setelan</translation>
-<translation id="4256782883801055595">Lisensi open source</translation>
-<translation id="4259722352634471385">Navigasi diblokir: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Salin URL</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Diizinkan</translation>
-<translation id="429312253194641664">Sebuah situs sedang memutar media</translation>
-<translation id="4298388696830689168">Situs tertaut</translation>
-<translation id="4307992518367153382">Dasar</translation>
-<translation id="4314815835985389558">Kelola sinkronisasi</translation>
-<translation id="4351244548802238354">Tutup dialog</translation>
-<translation id="4378154925671717803">Ponsel</translation>
-<translation id="4384468725000734951">Menggunakan Sogou untuk penelusuran</translation>
-<translation id="4404568932422911380">Tidak ada bookmark</translation>
-<translation id="4405224443901389797">Pindahkan ke…</translation>
-<translation id="4411535500181276704">Mode Ringan</translation>
-<translation id="4415276339145661267">Kelola Akun Google Anda</translation>
-<translation id="4432792777822557199">Mulai sekarang, halaman dalam bahasa <ph name="SOURCE_LANGUAGE" /> akan diterjemahkan ke <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Halaman ringan yang ditampilkan oleh Google.</translation>
-<translation id="4434045419905280838">Pop-up dan pengalihan</translation>
-<translation id="4440958355523780886">Halaman ringan yang ditampilkan oleh Google. Ketuk untuk memuat halaman asli.</translation>
-<translation id="4452411734226507615">Tutup tab <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Dibookmark ke <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Izinkan situs memutar konten yang dilindungi</translation>
-<translation id="4468959413250150279">Mematikan suara untuk situs tertentu.</translation>
-<translation id="4472118726404937099">Untuk menyinkronkan dan mempersonalisasi berbagai perangkat, login dan aktifkan sinkronisasi</translation>
-<translation id="447252321002412580">Bantu sempurnakan fitur dan performa Chrome</translation>
-<translation id="4479647676395637221">Minta izin terlebih dahulu sebelum memungkinkan situs menggunakan kamera Anda (disarankan)</translation>
-<translation id="4479972344484327217">Menginstal <ph name="MODULE" /> untuk Chrome…</translation>
-<translation id="4487967297491345095">Semua data aplikasi Chrome akan dihapus secara permanen. Hal ini meliputi semua file, setelan, akun, database, dll.</translation>
-<translation id="4493497663118223949">Mode Ringan aktif</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# hari yang lalu}other{# hari yang lalu}}</translation>
-<translation id="451872707440238414">Telusuri bookmark</translation>
-<translation id="4521489764227272523">Data yang dipilih telah dihapus dari Chrome dan perangkat yang disinkronkan.
-
-Akun Google Anda mungkin memiliki bentuk histori penjelajahan lain seperti penelusuran dan aktivitas dari layanan Google lainnya di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Pilih folder</translation>
-<translation id="4538018662093857852">Aktifkan Mode Ringan</translation>
-<translation id="4550003330909367850">Untuk melihat atau menyalin sandi di sini, setel kunci layar di perangkat ini.</translation>
-<translation id="4558311620361989323">Pintasan halaman web</translation>
-<translation id="4561979708150884304">Tidak ada koneksi</translation>
-<translation id="4565377596337484307">Sembunyikan sandi</translation>
-<translation id="4570913071927164677">Detail</translation>
-<translation id="4572422548854449519">Login ke akun terkelola</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# menit yang lalu}other{# menit yang lalu}}</translation>
-<translation id="4587589328781138893">Situs</translation>
-<translation id="4594952190837476234">Halaman offline ini dibuat pada <ph name="CREATION_TIME" /> dan mungkin berbeda dengan versi onlinenya.</translation>
-<translation id="4605958867780575332">Item yang dihapus: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Buka <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Gunakan sandi</translation>
-<translation id="4645575059429386691">Dikelola oleh orang tua Anda</translation>
-<translation id="4650364565596261010">Default sistem</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> bookmark dihapus</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> telah ditambahkan ke layar Utama</translation>
-<translation id="4684427112815847243">Sinkronkan semua</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> lainnya}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> lainnya}}</translation>
-<translation id="4696983787092045100">Kirim pesan teks ke Perangkat Anda</translation>
-<translation id="4698034686595694889">Lihat secara offline di <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Gambar dan file dalam cache</translation>
-<translation id="4714588616299687897">Hemat kuota hingga 60%</translation>
-<translation id="4719927025381752090">Tawarkan penerjemahan</translation>
-<translation id="4720023427747327413">Buka di <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Bantu sempurnakan Chrome. <ph name="BEGIN_LINK" />Ikuti survei<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Perbarui</translation>
-<translation id="4738836084190194332">Terakhir disinkronkan: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Membuka tab baru</translation>
-<translation id="4751476147751820511">Sensor gerakan atau cahaya</translation>
-<translation id="4759238208242260848">Download</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download selesai.}other{# download selesai.}}</translation>
-<translation id="4797039098279997504">Sentuh untuk kembali ke <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Enkripsi frasa sandi tidak mencakup alamat dan metode pembayaran dari Google Pay.
-
-Untuk mengubah setelan ini, <ph name="BEGIN_LINK" />setel ulang sinkronisasi<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Nama di kartu</translation>
-<translation id="4824958205181053313">Batalkan sinkronisasi?</translation>
-<translation id="4837753911714442426">Membuka opsi untuk mencetak halaman</translation>
-<translation id="4842092870884894799">Menampilkan pop-up pembuatan sandi</translation>
-<translation id="4860895144060829044">Telepon</translation>
-<translation id="4866368707455379617">Tidak dapat menginstal <ph name="MODULE" /> untuk Chrome</translation>
-<translation id="4875775213178255010">Saran Konten</translation>
-<translation id="4878404682131129617">Gagal membentuk saluran melalui server proxy</translation>
-<translation id="4880127995492972015">Terjemahkan…</translation>
-<translation id="4881695831933465202">Buka</translation>
-<translation id="488187801263602086">Ganti nama file</translation>
-<translation id="4882831918239250449">Kontrol cara histori browsing digunakan untuk mempersonalisasi Penelusuran, iklan, dan lainnya</translation>
-<translation id="4883854917563148705">Setelan yang dikelola tidak dapat disetel ulang</translation>
-<translation id="4885273946141277891">Jumlah kemunculan Chrome tidak didukung.</translation>
-<translation id="4910889077668685004">Aplikasi pembayaran</translation>
-<translation id="4913161338056004800">Setel ulang statistik</translation>
-<translation id="4913169188695071480">Hentikan refresh</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Dapatkan bantuan<ph name="END_LINK" /> saat memindai perangkat…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Halaman}other{# Halaman}}</translation>
-<translation id="4932247056774066048">Karena Anda logout dari akun yang dikelola oleh <ph name="DOMAIN_NAME" />, data Chrome Anda akan dihapus dari perangkat ini. Data akan tetap berada dalam Akun Google Anda.</translation>
-<translation id="4943703118917034429">Virtual Reality</translation>
-<translation id="4943872375798546930">Tidak ada hasil</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> berbagi layar Anda</translation>
-<translation id="4961107849584082341">Terjemahkan halaman ini ke bahasa apa pun</translation>
-<translation id="4962975101802056554">Cabut semua izin untuk perangkat</translation>
-<translation id="4970824347203572753">Tidak tersedia di lokasi Anda</translation>
-<translation id="497421865427891073">Maju</translation>
-<translation id="4988210275050210843">Mendownload file (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Halaman</translation>
-<translation id="4994033804516042629">Kontak tidak ditemukan</translation>
-<translation id="4996978546172906250">Bagikan dengan</translation>
-<translation id="5004416275253351869">Kontrol aktivitas Google</translation>
-<translation id="5005498671520578047">Salin sandi</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> ingin terhubung</translation>
-<translation id="5013696553129441713">Tidak ada saran baru</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Ketika Anda berada di VR, situs ini mungkin dapat mengetahui tentang:
-  -  ciri fisik Anda, seperti tinggi badan
-
-Pastikan Anda memercayai situs ini sebelum masuk ke VR.</translation>
+<translation id="2930742481329940825">Fitur Ketuk untuk Menelusuri mengirimkan kata yang dipilih dan halaman yang dibuka sebagai konteks ke Brave Software Penelusuran. Anda dapat menonaktifkannya di <ph name="BEGIN_LINK"/>Setelan<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Izinkan</translation>
-<translation id="5040262127954254034">Privasi</translation>
-<translation id="5048398596102334565">Mengizinkan situs mengakses sensor gerakan (disarankan)</translation>
-<translation id="5063480226653192405">Penggunaan</translation>
-<translation id="5087580092889165836">Tambahkan kartu</translation>
-<translation id="5100237604440890931">Diciutkan - klik untuk memperluas.</translation>
-<translation id="510275257476243843">1 jam lagi</translation>
-<translation id="5123685120097942451">Tab samaran</translation>
-<translation id="5127805178023152808">Sinkronisasi nonaktif</translation>
-<translation id="5129038482087801250">Instal aplikasi web</translation>
-<translation id="5132942445612118989">Sinkronkan sandi, histori, dan lainnya di semua perangkat</translation>
-<translation id="5139940364318403933">Pelajari cara menggunakan Google Drive</translation>
-<translation id="515227803646670480">Hapus data tersimpan</translation>
-<translation id="5152843274749979095">Aplikasi yang didukung tidak terinstal</translation>
-<translation id="5161254044473106830">Perlu judul</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download gagal.}other{# download gagal.}}</translation>
-<translation id="5170568018924773124">Tampilkan dalam folder</translation>
-<translation id="5184329579814168207">Buka di Chrome</translation>
-<translation id="5193988420012215838">Disalin ke papan klip Anda</translation>
-<translation id="5197729504361054390">Kontak yang Anda pilih akan dibagikan dengan <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Profil kerja</translation>
-<translation id="5210286577605176222">Beralih ke tab sebelumnya</translation>
-<translation id="5210365745912300556">Tutup tab</translation>
-<translation id="5224771365102442243">Dengan video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> ingin memindai perangkat Bluetooth di sekitar. Perangkat berikut telah ditemukan:</translation>
-<translation id="5233638681132016545">Tab baru</translation>
-<translation id="526421993248218238">Tidak dapat memuat halaman ini</translation>
-<translation id="5271967389191913893">Perangkat tidak dapat membuka konten untuk didownload.</translation>
-<translation id="528192093759286357">Tarik dari atas dan ketuk tombol kembali untuk keluar dari mode layar penuh.</translation>
-<translation id="5292796745632149097">Kirim ke</translation>
-<translation id="5300589172476337783">Tampilkan</translation>
-<translation id="5301954838959518834">Oke, mengerti</translation>
-<translation id="5304593522240415983">Bidang ini tidak boleh kosong</translation>
-<translation id="5307446750509046227">Hapus penyimpanan situs</translation>
-<translation id="5308380583665731573">Sambungkan</translation>
-<translation id="5313967007315987356">Tambahkan situs</translation>
-<translation id="5317780077021120954">Simpan</translation>
-<translation id="5324858694974489420">Setelan Orang Tua</translation>
-<translation id="5327248766486351172">Nama</translation>
-<translation id="5335288049665977812">Izinkan situs menjalankan JavaScript (disarankan)</translation>
-<translation id="5342314432463739672">Permintaan izin</translation>
-<translation id="5357811892247919462">Tab diterima</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> tab terbuka, ketuk untuk beralih tab}other{<ph name="OPEN_TABS_MANY" /> tab terbuka, ketuk untuk beralih tab}}</translation>
-<translation id="5391532827096253100">Sambungan ke situs ini tidak aman. Informasi situs</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 lainnya)}other{(+ # lainnya)}}</translation>
-<translation id="5400569084694353794">Dengan menggunakan aplikasi ini, Anda menyetujui <ph name="BEGIN_LINK1" />Persyaratan Layanan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Pemberitahuan Privasi<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="5403592356182871684">Nama</translation>
-<translation id="5403644198645076998">Hanya izinkan situs tertentu</translation>
-<translation id="5414836363063783498">Memverifikasi...</translation>
-<translation id="5423934151118863508">Halaman yang paling sering dikunjungi akan muncul di sini</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB tersedia</translation>
-<translation id="543338862236136125">Edit sandi</translation>
-<translation id="5433691172869980887">Nama pengguna disalin</translation>
-<translation id="543509235395288790">Mendownload <ph name="COUNT" /> file (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Beralih ke bilah alamat</translation>
-<translation id="5447201525962359567">Semua penyimpanan situs, termasuk cookie dan data lain yang tersimpan secara lokal</translation>
-<translation id="5447765697759493033">Situs ini tidak diterjemahkan</translation>
-<translation id="545042621069398927">Mempercepat download.</translation>
-<translation id="5456381639095306749">Download halaman</translation>
-<translation id="5475862044948910901">Mulai sesi Augmented Reality?</translation>
-<translation id="548278423535722844">Buka di aplikasi peta</translation>
-<translation id="5487521232677179737">Hapus data</translation>
-<translation id="5494752089476963479">Blokir iklan di situs yang menampilkan iklan yang mengganggu atau menyesatkan</translation>
-<translation id="5500777121964041360">Mungkin tidak tersedia di lokasi Anda</translation>
-<translation id="5512137114520586844">Akun ini dikelola oleh <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Dinonaktifkan oleh administrator perangkat</translation>
-<translation id="5515439363601853141">Buka kunci untuk melihat sandi Anda</translation>
-<translation id="5516455585884385570">Buka setelan notifikasi</translation>
-<translation id="5517095782334947753">Anda memiliki bookmark, histori, sandi, dan setelan lain dari <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Pengalihan diblokir.</translation>
-<translation id="5527082711130173040">Chrome memerlukan akses lokasi untuk memindai perangkat. <ph name="BEGIN_LINK1" />Perbarui izin<ph name="END_LINK1" />. Akses lokasi juga <ph name="BEGIN_LINK2" />dinonaktifkan untuk perangkat ini<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Tanya sebelum mengizinkan situs membaca teks dan gambar dari papan klip (disarankan)</translation>
-<translation id="5530766185686772672">Tutup tab samaran</translation>
-<translation id="5534334044554683961">Ketika Anda berada di VR, situs ini mungkin dapat mengetahui tentang:
-  -   ciri fisik Anda, seperti tinggi badan
-  -   tata letak ruangan Anda
-
-Pastikan Anda memercayai situs ini sebelum masuk ke VR.</translation>
-<translation id="5534640966246046842">Situs disalin</translation>
-<translation id="5556459405103347317">Muat ulang</translation>
-<translation id="5561549206367097665">Menunggu jaringan…</translation>
-<translation id="557283862590186398">Chrome memerlukan izin akses ke mikrofon untuk situs ini.</translation>
-<translation id="55737423895878184">Lokasi dan notifikasi diizinkan</translation>
-<translation id="5578795271662203820">Telusuri <ph name="SEARCH_ENGINE" /> untuk gambar ini</translation>
-<translation id="5581519193887989363">Anda dapat memilih konten apa yang akan disinkronkan di <ph name="BEGIN_LINK1" />setelan<ph name="END_LINK1" /> kapan saja.</translation>
-<translation id="5595485650161345191">Edit alamat</translation>
-<translation id="5596627076506792578">Opsi lainnya</translation>
-<translation id="5599455543593328020">Mode samaran</translation>
-<translation id="5620928963363755975">Temukan file dan halaman di Download dari tombol Opsi Lainnya</translation>
-<translation id="5626134646977739690">Nama:</translation>
-<translation id="5639724618331995626">Izinkan semua situs</translation>
-<translation id="5648166631817621825">7 hari terakhir</translation>
-<translation id="5649053991847567735">Download otomatis</translation>
-<translation id="5655963694829536461">Telusuri file download</translation>
-<translation id="5659593005791499971">Email</translation>
-<translation id="5665379678064389456">Buat acara di <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Abaikan permintaan situs web untuk mencegah zoom</translation>
-<translation id="5677928146339483299">Diblokir</translation>
-<translation id="5684874026226664614">Ups. Halaman ini tidak dapat diterjemahkan.</translation>
-<translation id="5686790454216892815">Nama file terlalu panjang</translation>
-<translation id="5689516760719285838">Lokasi</translation>
-<translation id="569536719314091526">Terjemahkan halaman ini ke bahasa apa pun dari tombol Opsi lainnya</translation>
-<translation id="572328651809341494">Tab terbaru</translation>
-<translation id="5726692708398506830">Memperbesar semua yang ada di halaman</translation>
-<translation id="5748802427693696783">Beralih ke tab standar</translation>
-<translation id="5749068826913805084">Chrome memerlukan akses penyimpanan untuk mendownload file.</translation>
-<translation id="5763382633136178763">Tab samaran</translation>
-<translation id="5763514718066511291">Ketuk untuk menyalin URL aplikasi ini</translation>
-<translation id="5765780083710877561">Deskripsi:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> terpakai dari <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google dapat menggunakan histori Anda untuk mempersonalisasi Penelusuran, iklan, dan layanan Google lainnya</translation>
-<translation id="5804241973901381774">Izin</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# jam yang lalu}other{# jam yang lalu}}</translation>
-<translation id="5810288467834065221">Hak cipta <ph name="YEAR" /> Google LLC. Semua hak dilindungi undang-undang.</translation>
-<translation id="5817918615728894473">Sandingkan</translation>
-<translation id="583281660410589416">Tidak dikenal</translation>
-<translation id="5833984609253377421">Bagikan link</translation>
-<translation id="5836192821815272682">Mendownload Update Chrome…</translation>
-<translation id="5853623416121554550">dijeda</translation>
-<translation id="5854790677617711513">Lebih dari 30 hari</translation>
-<translation id="5858741533101922242">Chrome tidak dapat mengaktifkan adaptor Bluetooth</translation>
-<translation id="5860033963881614850">Nonaktif</translation>
-<translation id="5862731021271217234">Untuk membuka tab dari perangkat Anda yang lain, aktifkan sinkronisasi</translation>
-<translation id="5864174910718532887">Detail: Diurutkan menurut nama situs</translation>
-<translation id="5864419784173784555">Menunggu proses download lain…</translation>
-<translation id="5865733239029070421">Secara otomatis mengirimkan statistik penggunaan dan laporan kerusakan ke Google</translation>
-<translation id="5869522115854928033">Sandi tersimpan</translation>
-<translation id="5902828464777634901">Semua data lokal yang disimpan oleh situs web ini, termasuk cookie, akan dihapus.</translation>
-<translation id="5916664084637901428">Aktif</translation>
-<translation id="5919204609460789179">Perbarui <ph name="PRODUCT_NAME" /> untuk memulai sinkronisasi</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> dihemat</translation>
-<translation id="5939518447894949180">Setel ulang</translation>
-<translation id="5942872142862698679">Menggunakan Google untuk penelusuran</translation>
-<translation id="5952764234151283551">Mengirimkan URL halaman yang ingin Anda buka ke Google</translation>
-<translation id="5956665950594638604">Membuka Pusat Bantuan Chrome di tab baru</translation>
-<translation id="5958275228015807058">Temukan file dan halaman di Download</translation>
-<translation id="5962718611393537961">Ketuk untuk menciutkan</translation>
-<translation id="6000066717592683814">Tetap menggunakan Google</translation>
-<translation id="6005538289190791541">Sandi yang disarankan</translation>
-<translation id="6036057147555329831">ICU tambahan</translation>
-<translation id="6039379616847168523">Beralih ke tab berikutnya</translation>
-<translation id="6040143037577758943">Tutup</translation>
-<translation id="6042308850641462728">Lainnya</translation>
-<translation id="604996488070107836">Download <ph name="FILE_NAME" /> gagal karena kesalahan tak dikenal.</translation>
-<translation id="605721222689873409">TT</translation>
-<translation id="6064125863973209585">Download yang selesai</translation>
-<translation id="6075798973483050474">Edit halaman beranda</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> jam lagi</translation>
-<translation id="6108923351542677676">Penyiapan sedang berlangsung...</translation>
-<translation id="6111020039983847643">data digunakan</translation>
-<translation id="6112702117600201073">Menyegarkan halaman</translation>
-<translation id="6127379762771434464">Item dihapus</translation>
-<translation id="6140912465461743537">Negara/Wilayah</translation>
-<translation id="614940544461990577">Coba:</translation>
-<translation id="6154478581116148741">Aktifkan kunci layar di Setelan untuk mengekspor sandi dari perangkat ini</translation>
-<translation id="6159335304067198720">Penghematan kuota <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Pelajari lebih lanjut</translation>
-<translation id="6177111841848151710">Diblokir untuk mesin telusur yang sedang digunakan</translation>
-<translation id="6181444274883918285">Tambahkan pengecualian situs</translation>
-<translation id="6192333916571137726">Download file</translation>
-<translation id="6192792657125177640">Pengecualian</translation>
-<translation id="6194112207524046168">Untuk mengizinkan Chrome mengakses kamera Anda, aktifkan juga kamera di <ph name="BEGIN_LINK" />Setelan Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokir cookie pihak ketiga</translation>
-<translation id="6206551242102657620">Sambungan aman. Informasi situs</translation>
-<translation id="6210748933810148297">Bukan <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Buka kunci untuk mengekspor sandi</translation>
+<translation id="1406000523432664303">“Jangan Lacak”</translation>
 <translation id="6232535412751077445">Jika “Jangan Lacak” diaktifkan, permintaan akan disertakan bersama traffic penjelajahan Anda. Dampaknya tergantung pada apakah situs web menanggapi permintaan itu, dan bagaimana permintaan itu diinterpretasikan.
 
 Misalnya, beberapa situs web mungkin menanggapi permintaan ini dengan menayangkan iklan yang tidak berdasarkan pada data kunjungan Anda ke situs web lainnya. Banyak situs web masih akan mengumpulkan dan menggunakan data penjelajahan Anda — misalnya, untuk meningkatkan keamanan, menyediakan konten, iklan, dan saran, serta untuk membuat statistik pelaporan.</translation>
-<translation id="624789221780392884">Pembaruan siap</translation>
-<translation id="6255999984061454636">Saran konten</translation>
-<translation id="6277522088822131679">Terjadi masalah saat mencetak halaman. Coba lagi.</translation>
-<translation id="6295158916970320988">Semua situs</translation>
-<translation id="629730747756840877">Akun</translation>
-<translation id="6303969859164067831">Logout dan nonaktifkan sinkronisasi</translation>
-<translation id="6316139424528454185">Versi Android tidak didukung</translation>
-<translation id="6320088164292336938">Getar</translation>
-<translation id="6324034347079777476">Sinkronisasi sistem Android dinonaktifkan</translation>
-<translation id="6333140779060797560">Bagikan dengan <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Enkripsi</translation>
-<translation id="6341580099087024258">Tanya lokasi menyimpan file</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> lainnya}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> lainnya}}</translation>
-<translation id="6364438453358674297">Hapus saran dari histori?</translation>
-<translation id="6369229450655021117">Dari sini, Anda dapat menelusuri web, berbagi dengan teman, dan melihat halaman yang terbuka</translation>
-<translation id="6378173571450987352">Detail: Diurutkan menurut jumlah kuota yang digunakan</translation>
-<translation id="6381421346744604172">Gelapkan situs</translation>
-<translation id="6388207532828177975">Hapus &amp; setel ulang</translation>
-<translation id="6393863479814692971">Chrome memerlukan izin akses ke kamera dan mikrofon untuk situs ini.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Edit bookmark</translation>
-<translation id="6406506848690869874">Sinkronisasi</translation>
-<translation id="641643625718530986">Cetak...</translation>
-<translation id="6416782512398055893">Terdownload <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Terjemahkan Web</translation>
-<translation id="6433501201775827830">Pilih mesin telusur Anda</translation>
-<translation id="6437478888915024427">Info halaman</translation>
-<translation id="6441734959916820584">Nama terlalu panjang</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Gambar}other{# Gambar}}</translation>
-<translation id="6447842834002726250">Cookie</translation>
-<translation id="6461962085415701688">Tidak dapat membuka file</translation>
-<translation id="6464977750820128603">Anda dapat melihat situs yang Anda kunjungi di Chrome dan menetapkan timer untuk situs tersebut.\n\nGoogle mendapatkan info tentang situs yang Anda tetapkan timer-nya dan durasi Anda mengunjunginya. Info ini digunakan untuk membuat Kesehatan Digital jadi lebih baik.</translation>
-<translation id="6475951671322991020">Download video</translation>
-<translation id="6482749332252372425">Download <ph name="FILE_NAME" /> gagal karena ruang penyimpanan tidak cukup.</translation>
-<translation id="6496823230996795692">Untuk menggunakan <ph name="APP_NAME" /> pertama kali, harap hubungkan ke internet.</translation>
-<translation id="6508722015517270189">Buka Ulang Chrome</translation>
-<translation id="6527303717912515753">Bagikan</translation>
-<translation id="6532866250404780454">Situs yang Anda kunjungi di Chrome tidak akan ditampilkan. Semua timer situs akan dihapus.</translation>
-<translation id="6534565668554028783">Google membutuhkan waktu terlalu lama untuk merespons</translation>
-<translation id="6538442820324228105">Terdownload <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Terjadi masalah. Coba lagi nanti.</translation>
-<translation id="654446541061731451">Pilih tab untuk dipancarkan</translation>
-<translation id="6545017243486555795">Hapus Semua Data</translation>
-<translation id="6545864417968258051">Pemindaian Bluetooth</translation>
-<translation id="6560414384669816528">Menelusuri menggunakan Sogou</translation>
-<translation id="6566259936974865419">Chrome telah menghemat <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Selalu izinkan</translation>
-<translation id="6573431926118603307">Tab yang telah dibuka di Chrome pada perangkat lainnya akan muncul di sini.</translation>
-<translation id="6583199322650523874">Membookmark halaman saat ini</translation>
-<translation id="6593061639179217415">Situs desktop</translation>
-<translation id="6600954340915313787">Disalin ke Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Konten dilindungi</translation>
-<translation id="6627583120233659107">Edit folder</translation>
-<translation id="6643016212128521049">Hapus</translation>
-<translation id="6643649862576733715">Urutkan menurut jumlah kuota yang dihemat</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> lainnya}other{<ph name="CONTACT_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> lainnya}}</translation>
-<translation id="6649642165559792194">Lihat pratinjau gambar <ph name="BEGIN_NEW" />Baru<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome memerlukan akses lokasi untuk memindai perangkat. <ph name="BEGIN_LINK" />Perbarui izin<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Sandi</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Buka di <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Notifikasi Privasi Chrome</translation>
-<translation id="6676840375528380067">Hapus data Chrome Anda dari perangkat ini?</translation>
-<translation id="6697492270171225480">Tampilkan saran untuk halaman yang serupa jika halaman tidak dapat ditemukan</translation>
-<translation id="6697947395630195233">Chrome memerlukan akses ke lokasi Anda untuk berbagi lokasi dengan situs ini.</translation>
-<translation id="6698801883190606802">Kelola data yang disinkronkan</translation>
-<translation id="6699370405921460408">Server Google akan mengoptimalkan halaman yang Anda kunjungi.</translation>
-<translation id="6706288973712894588">Saat ini Anda sedang offline.\n<ph name="BEGIN_LINK" />Jelajahi feed offline Anda.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Berita</translation>
-<translation id="6710213216561001401">Sebelumnya</translation>
-<translation id="671481426037969117">Timer <ph name="FQDN" /> Anda telah berakhir. Timer akan dimulai lagi besok.</translation>
-<translation id="6738867403308150051">Mendownload…</translation>
-<translation id="6746124502594467657">Berpindah ke bawah</translation>
-<translation id="6766622839693428701">Geser ke bawah untuk menutup.</translation>
-<translation id="6766758767654711248">Ketuk untuk membuka situs</translation>
-<translation id="6767294960381293877">Daftar perangkat yang dapat digunakan untuk berbagi tab terbuka dalam setengah layar.</translation>
-<translation id="6782111308708962316">Cegah situs web pihak ketiga agar tidak menyimpan dan membaca data cookie</translation>
-<translation id="6790428901817661496">Putar</translation>
-<translation id="6811034713472274749">Halaman siap ditampilkan</translation>
-<translation id="6818926723028410516">Pilih item</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Terjemahkan</translation>
-<translation id="6845325883481699275">Bantu meningkatkan keamanan Chrome</translation>
-<translation id="6846298663435243399">Memuat…</translation>
-<translation id="6850409657436465440">Download sedang berlangsung</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> tab ditutup</translation>
-<translation id="6864459304226931083">Download gambar</translation>
-<translation id="6865313869410766144">Data formulir isi-otomatis</translation>
-<translation id="688738109438487280">Menambahkan data yang sudah ada ke <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Buka kunci untuk menyalin sandi Anda</translation>
-<translation id="6896758677409633944">Salin</translation>
-<translation id="6910211073230771657">Dihapus</translation>
-<translation id="6912998170423641340">Blokir situs agar tidak membaca teks dan gambar dari papan klip</translation>
-<translation id="6914783257214138813">Sandi akan terlihat oleh orang yang dapat melihat file yang diekspor.</translation>
-<translation id="6942665639005891494">Ubah lokasi download default kapan saja menggunakan opsi menu Setelan</translation>
-<translation id="6945221475159498467">Pilih</translation>
-<translation id="6963642900430330478">Halaman ini berbahaya. Informasi situs</translation>
-<translation id="6963766334940102469">Hapus bookmark</translation>
-<translation id="6965382102122355670">Oke</translation>
-<translation id="6979737339423435258">Semua</translation>
-<translation id="6981982820502123353">Aksesibilitas</translation>
-<translation id="6989267951144302301">Tidak dapat mendownload</translation>
-<translation id="6990079615885386641">Dapatkan aplikasi dari Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Tanya terlebih dahulu sebelum mengizinkan situs menggunakan mikrofon Anda (disarankan)</translation>
-<translation id="7015203776128479407">Penyiapan sinkronisasi awal belum selesai. Sinkronisasi nonaktif.</translation>
-<translation id="7016516562562142042">Diizinkan untuk mesin telusur yang sedang digunakan</translation>
-<translation id="7022756207310403729">Buka di browser</translation>
-<translation id="702463548815491781">Disarankan saat TalkBack atau Tombol Akses aktif</translation>
-<translation id="7029809446516969842">Sandi</translation>
-<translation id="7053983685419859001">Blokir</translation>
-<translation id="7055152154916055070">Pengalihan diblokir:</translation>
-<translation id="7063006564040364415">Tidak dapat menyambung ke server sinkronisasi.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 dipilih}other{# dipilih}}</translation>
-<translation id="7071521146534760487">Kelola akun</translation>
-<translation id="7077143737582773186">Kartu Secure Digital</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> dipilih. Opsi yang tersedia di dekat bagian atas layar</translation>
-<translation id="7121362699166175603">Menghapus histori dan pelengkapan otomatis di kolom URL. Akun Google Anda mungkin memiliki bentuk histori penjelajahan lainnya di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Izinkan mesin telusur saat ini</translation>
-<translation id="7138678301420049075">Lainnya</translation>
-<translation id="7141896414559753902">Blokir situs agar tidak menampilkan pop-up dan pengalihan (disarankan)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Muat halaman asli<ph name="END_LINK" /> dari <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">24 jam terakhir</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Anda dapat mengubah ini nanti di Setelan</translation>
-<translation id="7180611975245234373">Perbarui</translation>
-<translation id="7189372733857464326">Menunggu Layanan Google Play selesai di-update</translation>
-<translation id="7191430249889272776">Tab dibuka di latar belakang.</translation>
-<translation id="723171743924126238">Pilih gambar</translation>
-<translation id="7233236755231902816">Untuk melihat web dalam bahasa Anda, dapatkan versi terbaru Chrome</translation>
-<translation id="7243308994586599757">Opsi terdapat di dekat bagian bawah layar</translation>
-<translation id="7248069434667874558">Pastikan <ph name="TARGET_DEVICE_NAME" /> telah mengaktifkan sinkronisasi di Chrome</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> dipilih</translation>
-<translation id="7274013316676448362">Situs yang diblokir</translation>
-<translation id="7290209999329137901">Ganti nama tidak tersedia</translation>
-<translation id="7291387454912369099">Pemicuan Pembayaran oleh Asisten</translation>
-<translation id="7293171162284876153">Untuk memulai sinkronisasi, aktifkan "Sinkronkan data Chrome Anda".</translation>
-<translation id="729975465115245577">Perangkat Anda tidak memiliki aplikasi untuk menyimpan file sandi.</translation>
-<translation id="7302081693174882195">Detail: Diurutkan menurut jumlah kuota yang dihemat</translation>
-<translation id="7328017930301109123">Dalam mode Ringan, Chrome memuat halaman lebih cepat dan menghemat data hingga 60 persen.</translation>
-<translation id="7333031090786104871">Masih menambahkan situs sebelumnya</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Bagikan 1 item yang dipilih}other{Bagikan # item yang dipilih}}</translation>
 <translation id="7359002509206457351">Akses metode pembayaran</translation>
+<translation id="8026334261755873520">Hapus data penjelajahan</translation>
+<translation id="1291207594882862231">Menghapus histori, cookie, data situs, cache...</translation>
+<translation id="7814200940910057384">Data Brave telah dihapus</translation>
+<translation id="1664855196866195614">Data yang dipilih telah dihapus dari Brave dan perangkat yang disinkronkan.
+
+Akun Brave Software Anda mungkin memiliki bentuk histori penjelajahan lain seperti penelusuran dan aktivitas dari layanan Brave Software lainnya di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Gambar dan file dalam cache</translation>
+<translation id="2496180316473517155">Histori penjelajahan</translation>
+<translation id="2546283357679194313">Cookie dan data situs</translation>
+<translation id="8662811608048051533">Membuat Anda logout dari sebagian besar situs.</translation>
+<translation id="8218628800671693884">Membuat Anda logout dari sebagian besar situs. Anda tidak akan logout dari Akun Brave Software.</translation>
+<translation id="2017836877785168846">Hapus histori dan pelengkapan otomatis di kolom URL.</translation>
+<translation id="8096327394278038498">Menghapus histori dan pelengkapan otomatis di kolom URL. Akun Brave Software Anda mungkin memiliki bentuk histori penjelajahan lainnya di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Menghapus histori dari semua perangkat yang dibuat login. Akun Brave Software Anda mungkin memiliki bentuk histori penjelajahan lainnya di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Sandi tersimpan</translation>
+<translation id="6865313869410766144">Data formulir isi-otomatis</translation>
+<translation id="7562080006725997899">Menghapus data penjelajahan</translation>
+<translation id="5487521232677179737">Hapus data</translation>
+<translation id="7498271377022651285">Harap tunggu...</translation>
+<translation id="784934925303690534">Rentang waktu</translation>
+<translation id="1718835860248848330">1 jam terakhir</translation>
+<translation id="7149893636342594995">24 jam terakhir</translation>
+<translation id="5648166631817621825">7 hari terakhir</translation>
+<translation id="8571213806525832805">4 minggu terakhir</translation>
+<translation id="5854790677617711513">Lebih dari 30 hari</translation>
+<translation id="6979737339423435258">Semua</translation>
+<translation id="982182592107339124">Tindakan ini akan menghapus data untuk semua situs, termasuk:</translation>
+<translation id="6643016212128521049">Hapus</translation>
+<translation id="7641339528570811325">Hapus data penjelajahan...</translation>
+<translation id="1670399744444387456">Dasar</translation>
+<translation id="3245261285041759672">Akun Brave Software Anda mungkin memiliki bentuk histori penjelajahan lainnya di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Situs yang diblokir</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> item dihapus</translation>
+<translation id="1121094540300013208">Laporan penggunaan dan error</translation>
+<translation id="9079153198295609735">Kirim statistik penggunaan dan laporan error ke Brave Software secara otomatis</translation>
+<translation id="6981982820502123353">Aksesibilitas</translation>
+<translation id="2387895666653383613">Ukuran teks</translation>
+<translation id="2321958826496381788">Geser ukuran teks sampai Anda dapat membacanya dengan nyaman. Teks akan terlihat setidaknya sebesar ini setelah Anda mengetuk sebuah paragraf dua kali.</translation>
+<translation id="3895926599014793903">Aktifkan zoom secara paksa</translation>
+<translation id="5668404140385795438">Abaikan permintaan situs web untuk mencegah zoom</translation>
+<translation id="4149994727733219643">Tampilan sederhana untuk halaman web</translation>
+<translation id="9100505651305367705">Tawarkan untuk menampilkan artikel dalam tampilan sederhana, jika didukung</translation>
+<translation id="1409426117486808224">Tampilan sederhana untuk tab yang terbuka</translation>
+<translation id="702463548815491781">Disarankan saat TalkBack atau Tombol Akses aktif</translation>
+<translation id="8284326494547611709">Teks</translation>
+<translation id="4165986682804962316">Setelan situs</translation>
+<translation id="6295158916970320988">Semua situs</translation>
+<translation id="8380167699614421159">Situs ini menampilkan iklan yang mengganggu atau menyesatkan</translation>
+<translation id="1919345977826869612">Iklan</translation>
+<translation id="410351446219883937">Putar otomatis</translation>
+<translation id="6447842834002726250">Cookie</translation>
+<translation id="6196640612572343990">Blokir cookie pihak ketiga</translation>
+<translation id="6782111308708962316">Cegah situs web pihak ketiga agar tidak menyimpan dan membaca data cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-up dan pengalihan</translation>
+<translation id="4751476147751820511">Sensor gerakan atau cahaya</translation>
+<translation id="1717218214683051432">Sensor gerakan</translation>
+<translation id="2091887806945687916">Suara</translation>
+<translation id="2586657967955657006">Papan klip</translation>
+<translation id="6320088164292336938">Getar</translation>
+<translation id="4226663524361240545">Notifikasi dapat membuat perangkat bergetar</translation>
+<translation id="1446450296470737166">Izinkan kontrol penuh perangkat MIDI</translation>
+<translation id="3744111561329211289">Sinkronisasi latar belakang</translation>
+<translation id="5649053991847567735">Download otomatis</translation>
+<translation id="6181444274883918285">Tambahkan pengecualian situs</translation>
+<translation id="5313967007315987356">Tambahkan situs</translation>
+<translation id="1369915414381695676">Situs <ph name="SITE_NAME"/> ditambahkan</translation>
+<translation id="7837721118676387834">Izinkan pemutaran otomatis video yang dibisukan untuk situs tertentu.</translation>
+<translation id="2621115761605608342">Izinkan JavaScript untuk situs tertentu.</translation>
+<translation id="8801436777607969138">Blokir JavaScript untuk situs tertentu.</translation>
+<translation id="8372893542064058268">Mengizinkan Sinkronisasi Latar Belakang untuk situs tertentu.</translation>
+<translation id="358794129225322306">Izinkan situs untuk otomatis mendownload beberapa file.</translation>
+<translation id="4008040567710660924">Izinkan cookie untuk situs tertentu.</translation>
+<translation id="8958424370300090006">Blokir cookie untuk situs tertentu.</translation>
+<translation id="7882806643839505685">Izinkan suara untuk situs tertentu.</translation>
+<translation id="4468959413250150279">Mematikan suara untuk situs tertentu.</translation>
+<translation id="1994173015038366702">URL situs</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Penggunaan</translation>
+<translation id="5804241973901381774">Izin</translation>
+<translation id="4278390842282768270">Diizinkan</translation>
+<translation id="5677928146339483299">Diblokir</translation>
+<translation id="1984937141057606926">Diizinkan, kecuali pihak ketiga</translation>
+<translation id="7423098979219808738">Tanyakan dulu</translation>
+<translation id="8116925261070264013">Dinonaktifkan</translation>
+<translation id="8300705686683892304">Dikelola oleh aplikasi</translation>
+<translation id="6192792657125177640">Pengecualian</translation>
+<translation id="257931822824936280">Diperluas - klik untuk menciutkan</translation>
+<translation id="5100237604440890931">Diciutkan - klik untuk memperluas.</translation>
+<translation id="857943718398505171">Diizinkan (disarankan)</translation>
+<translation id="2913331724188855103">Izinkan situs untuk menyimpan dan membaca data cookie (disarankan)</translation>
+<translation id="7445411102860286510">Izinkan situs untuk otomatis memutar video yang dibisukan (disarankan)</translation>
+<translation id="5335288049665977812">Izinkan situs menjalankan JavaScript (disarankan)</translation>
+<translation id="5527111080432883924">Tanya sebelum mengizinkan situs membaca teks dan gambar dari papan klip (disarankan)</translation>
+<translation id="6912998170423641340">Blokir situs agar tidak membaca teks dan gambar dari papan klip</translation>
+<translation id="7423538860840206698">Diblokir agar tidak membaca papan klip</translation>
+<translation id="3955193568934677022">Izinkan situs memutar konten yang dilindungi (direkomendasikan)</translation>
+<translation id="445467742685312942">Izinkan situs memutar konten yang dilindungi</translation>
+<translation id="2107397443965016585">Tanyakan sebelum mengizinkan situs memutar konten yang dilindungi (direkomendasikan)</translation>
+<translation id="2910701580606108292">Tanyakan sebelum mengizinkan situs untuk memutar konten yang dilindungi</translation>
+<translation id="757524316907819857">Blokir situs agar tidak memutar konten yang dilindungi</translation>
+<translation id="3277252321222022663">Mengizinkan situs untuk mengakses sensor (disarankan)</translation>
+<translation id="5048398596102334565">Mengizinkan situs mengakses sensor gerakan (disarankan)</translation>
+<translation id="8816026460808729765">Memblokir situs agar tidak mengakses sensor</translation>
+<translation id="169515064810179024">Memblokir situs agar tidak mengakses sensor gerakan</translation>
+<translation id="1660204651932907780">Mengizinkan situs memutar suara (direkomendasikan)</translation>
+<translation id="3600792891314830896">Nonaktifkan suara situs yang memutar suara</translation>
+<translation id="1743802530341753419">Tanya sebelum mengizinkan situs terhubung ke perangkat (disarankan)</translation>
+<translation id="851751545965956758">Blokir situs agar tidak terhubung ke perangkat</translation>
+<translation id="7141896414559753902">Blokir situs agar tidak menampilkan pop-up dan pengalihan (disarankan)</translation>
+<translation id="5494752089476963479">Blokir iklan di situs yang menampilkan iklan yang mengganggu atau menyesatkan</translation>
+<translation id="3123473560110926937">Diblokir di beberapa situs</translation>
+<translation id="965817943346481315">Blokir jika situs menampilkan iklan yang mengganggu atau menyesatkan (direkomendasikan)</translation>
+<translation id="3386292677130313581">Minta izin sebelum memungkinkan situs mengetahui lokasi Anda (disarankan)</translation>
+<translation id="9139068048179869749">Tanya terlebih dahulu sebelum mengizinkan situs mengirimkan notifikasi (disarankan)</translation>
+<translation id="4479647676395637221">Minta izin terlebih dahulu sebelum memungkinkan situs menggunakan kamera Anda (disarankan)</translation>
+<translation id="6992289844737586249">Tanya terlebih dahulu sebelum mengizinkan situs menggunakan mikrofon Anda (disarankan)</translation>
+<translation id="2289270750774289114">Tanyakan saat situs ingin menemukan perangkat Bluetooth di sekitar (direkomendasikan)</translation>
+<translation id="7053983685419859001">Blokir</translation>
+<translation id="7128222689758636196">Izinkan mesin telusur saat ini</translation>
+<translation id="7589445247086920869">Blokir mesin telusur saat ini</translation>
+<translation id="6388207532828177975">Hapus &amp; setel ulang</translation>
+<translation id="7999064672810608036">Yakin ingin menghapus semua data lokal, termasuk cookie, dan menyetel ulang semua izin untuk situs web ini?</translation>
+<translation id="2822354292072154809">Yakin ingin menyetel ulang semua izin situs untuk <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Hapus data tersimpan</translation>
+<translation id="5902828464777634901">Semua data lokal yang disimpan oleh situs web ini, termasuk cookie, akan dihapus.</translation>
+<translation id="119944043368869598">Hapus semua</translation>
+<translation id="2490684707762498678">Dikelola oleh <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Buka setelan notifikasi</translation>
+<translation id="1404122904123200417">Tersemat dalam <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">File yang disimpan situs muncul di sini</translation>
+<translation id="4181841719683918333">Bahasa</translation>
+<translation id="2647434099613338025">Tambah bahasa</translation>
+<translation id="1952172573699511566">Situs akan menampilkan teks dalam bahasa pilihan Anda, jika memungkinkan.</translation>
+<translation id="8559990750235505898">Tawarkan penerjemahan halaman ke dalam bahasa lain</translation>
+<translation id="4719927025381752090">Tawarkan penerjemahan</translation>
+<translation id="8156139159503939589">Anda membaca dalam bahasa apa?</translation>
+<translation id="5689516760719285838">Lokasi</translation>
+<translation id="2440823041667407902">Akses lokasi</translation>
+<translation id="2023546461831060654">Aktifkan izin untuk Brave di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Aktifkan izin untuk Brave di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Untuk mengizinkan Brave mengakses lokasi Anda, aktifkan juga lokasi di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Untuk mengizinkan Brave mengakses kamera Anda, aktifkan juga kamera di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Untuk mengizinkan Brave mengirimkan notifikasi, aktifkan juga notifikasi di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Untuk mengizinkan Brave mengakses mikrofon Anda, aktifkan juga mikrofon di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Akses lokasi dinonaktifkan untuk perangkat ini. Aktifkan di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Akses lokasi juga dinonaktifkan untuk perangkat ini. Aktifkan di <ph name="BEGIN_LINK"/>Setelan Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Mengakses kamera Anda</translation>
+<translation id="945632385593298557">Akses mikrofon Anda</translation>
+<translation id="6612358246767739896">Konten dilindungi</translation>
+<translation id="885701979325669005">Penyimpanan</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> data tersimpan</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Cabut izin perangkat</translation>
+<translation id="4962975101802056554">Cabut semua izin untuk perangkat</translation>
+<translation id="6545864417968258051">Pemindaian Bluetooth</translation>
+<translation id="4411535500181276704">Mode Ringan</translation>
+<translation id="7821588508402923572">Penghematan data Anda akan terlihat di sini</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> dihemat</translation>
+<translation id="8569404424186215731">sejak <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Dalam mode Ringan, Brave memuat halaman lebih cepat dan menghemat data hingga 60 persen.</translation>
+<translation id="6159335304067198720">Penghematan kuota <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">data dihemat</translation>
+<translation id="6111020039983847643">data digunakan</translation>
+<translation id="7413229368719586778">Tanggal mulai <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Tanggal akhir <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Urutkan menurut situs</translation>
+<translation id="5864174910718532887">Detail: Diurutkan menurut nama situs</translation>
+<translation id="116280672541001035">Digunakan</translation>
+<translation id="8349013245300336738">Urutkan menurut jumlah kuota yang digunakan</translation>
+<translation id="6378173571450987352">Detail: Diurutkan menurut jumlah kuota yang digunakan</translation>
+<translation id="2631006050119455616">Dihemat</translation>
+<translation id="6643649862576733715">Urutkan menurut jumlah kuota yang dihemat</translation>
+<translation id="7302081693174882195">Detail: Diurutkan menurut jumlah kuota yang dihemat</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> digunakan</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> dihemat</translation>
+<translation id="2156074688469523661">Situs yang tersisa (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Lainnya</translation>
+<translation id="4913161338056004800">Setel ulang statistik</translation>
+<translation id="1856325424225101786">Setel ulang Mode Ringan?</translation>
+<translation id="3658159451045945436">Penyetalan ulang akan menghapus histori penyimpanan data, termasuk daftar situs yang dibuka.</translation>
+<translation id="3295530008794733555">Browsing lebih cepat. Gunakan lebih sedikit kuota.</translation>
+<translation id="7340390500800578919">Dalam Mode Ringan, Brave memuat halaman lebih cepat dan menghemat data hingga 60 persen. Untuk mengoptimalkan halaman yang Anda kunjungi, Brave akan mengirimkan traffic web ke Brave Software. <ph name="BEGIN_LINK"/>Pelajari lebih lanjut<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Aktifkan Mode Ringan</translation>
+<translation id="4493497663118223949">Mode Ringan aktif</translation>
+<translation id="7559975015014302720">Mode Ringan nonaktif</translation>
+<translation id="7606077192958116810">Mode Ringan aktif. Kelola di Setelan.</translation>
+<translation id="4714588616299687897">Hemat kuota hingga 60%</translation>
+<translation id="1006927014032731288">Server Brave Software akan mengoptimalkan halaman yang Anda kunjungi.</translation>
+<translation id="3257320067425202300">Brave telah menghemat <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave telah menghemat <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Lokasi download</translation>
+<translation id="7077143737582773186">Kartu Secure Digital</translation>
+<translation id="7762668264895820836">Kartu SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Tanya lokasi menyimpan file</translation>
+<translation id="6192333916571137726">Download file</translation>
+<translation id="1672586136351118594">Jangan tampilkan lagi</translation>
+<translation id="2650751991977523696">Download file lagi?</translation>
+<translation id="8664979001105139458">Nama file sudah ada</translation>
+<translation id="488187801263602086">Ganti nama file</translation>
+<translation id="5686790454216892815">Nama file terlalu panjang</translation>
+<translation id="7454641608352164238">Tidak cukup ruang</translation>
+<translation id="8972098258593396643">Download ke folder default?</translation>
+<translation id="804335162455518893">Kartu SD tidak ditemukan</translation>
+<translation id="7475688122056506577">Kartu SD tidak ditemukan. Beberapa file Anda mungkin tidak tersimpan.</translation>
+<translation id="4198423547019359126">Tidak tersedia lokasi download</translation>
+<translation id="8224471946457685718">Download artikel untuk Anda pada jaringan Wi-Fi</translation>
+<translation id="4970824347203572753">Tidak tersedia di lokasi Anda</translation>
+<translation id="5500777121964041360">Mungkin tidak tersedia di lokasi Anda</translation>
+<translation id="1173894706177603556">Ganti nama</translation>
+<translation id="1986685561493779662">Nama sudah ada</translation>
+<translation id="6441734959916820584">Nama terlalu panjang</translation>
+<translation id="2923908459366352541">Nama tidak valid</translation>
+<translation id="7290209999329137901">Ganti nama tidak tersedia</translation>
+<translation id="3334729583274622784">Ubah ekstensi file?</translation>
+<translation id="107147699690128016">Jika ekstensi file diubah, file dapat terbuka di aplikasi lain dan berpotensi membahayakan perangkat Anda.</translation>
+<translation id="8541922081612557424">Tentang Brave</translation>
+<translation id="5311273890481188673">Hak cipta <ph name="YEAR"/> Brave Software LLC. Semua hak dilindungi undang-undang.</translation>
+<translation id="1416550906796893042">Versi aplikasi</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Diperbarui <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistem operasi</translation>
+<translation id="3968054912784331254">Update Brave tidak lagi didukung untuk versi Android ini</translation>
+<translation id="7665369617277396874">Tambahkan akun</translation>
+<translation id="649070405679044769">Login ke Brave Software sebagai</translation>
+<translation id="6234515504547364178">Logout dari Brave</translation>
+<translation id="5324858694974489420">Setelan Orang Tua</translation>
+<translation id="8920114477895755567">Menunggu detail orang tua.</translation>
+<translation id="5512137114520586844">Akun ini dikelola oleh <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Akun ini dikelola oleh <ph name="PARENT_NAME_1"/> dan <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Konten</translation>
+<translation id="5403644198645076998">Hanya izinkan situs tertentu</translation>
+<translation id="8641930654639604085">Coba blokir situs dewasa</translation>
+<translation id="5639724618331995626">Izinkan semua situs</translation>
+<translation id="796823723482603597">Diberdayakan oleh Brave</translation>
+<translation id="6324034347079777476">Sinkronisasi sistem Android dinonaktifkan</translation>
+<translation id="5127805178023152808">Sinkronisasi nonaktif</translation>
+<translation id="7015203776128479407">Penyiapan sinkronisasi awal belum selesai. Sinkronisasi nonaktif.</translation>
+<translation id="2497852260688568942">Sinkronisasi dinonaktifkan oleh administrator</translation>
+<translation id="9100610230175265781">Frasa sandi diwajibkan</translation>
+<translation id="6108923351542677676">Penyiapan sedang berlangsung...</translation>
+<translation id="4062305924942672200">Informasi hukum</translation>
+<translation id="4256782883801055595">Lisensi open source</translation>
+<translation id="1138681184697033370">Persyaratan Layanan Brave</translation>
+<translation id="7392539049993970338">Notifikasi Privasi Brave</translation>
+<translation id="2677748264148917807">Keluar</translation>
+<translation id="5556459405103347317">Muat ulang</translation>
+<translation id="1623104350909869708">Cegah dialog lain dari halaman ini.</translation>
+<translation id="2968755619301702150">Penampil sertifikat</translation>
+<translation id="1360432990279830238">Logout dan nonaktifkan sinkronisasi?</translation>
+<translation id="8581481290581777242">Hapus data Brave Anda dari perangkat ini?</translation>
+<translation id="1318865768845061710">Bookmark, histori, sandi, dan data Brave lainnya tidak akan disinkronkan lagi dengan Akun Brave Software Anda.</translation>
+<translation id="3325020657155065477">Hapus juga data Brave Anda dari perangkat ini</translation>
+<translation id="6136448902816743006">Karena Anda logout dari akun yang dikelola oleh <ph name="DOMAIN_NAME"/>, data Brave Anda akan dihapus dari perangkat ini. Data akan tetap berada dalam Akun Brave Software Anda.</translation>
+<translation id="1853026300647876496">Menghubungi Brave Software. Tindakan ini memerlukan waktu beberapa saat…</translation>
+<translation id="2328985652426384049">Tidak dapat login</translation>
+<translation id="7723158744459952869">Brave Software membutuhkan waktu terlalu lama untuk merespons</translation>
+<translation id="4572422548854449519">Login ke akun terkelola</translation>
+<translation id="2689656545739939160">Anda akan login dengan akun yang dikelola oleh <ph name="MANAGED_DOMAIN"/> dan memberikan kontrol data Brave kepada administratornya. Data akan terikat dengan akun ini secara permanen. Bila Anda logout dari Brave, data akan dihapus dari perangkat ini, tetapi data tetap tersimpan di Akun Brave Software.</translation>
+<translation id="1749561566933687563">Sinkronisasikan bookmark Anda</translation>
+<translation id="4242533952199664413">Buka setelan</translation>
+<translation id="1111673857033749125">Bookmark yang tersimpan di perangkat lainnya akan muncul di sini.</translation>
+<translation id="8636825310635137004">Untuk mengakses tab Anda dari perangkat lainnya, aktifkan sinkronisasi.</translation>
+<translation id="3269956123044984603">Untuk mengakses tab Anda dari perangkat lainnya, aktifkan "Sinkronisasi data otomatis" di setelan akun Android.</translation>
+<translation id="5157964048453367290">Tab yang telah dibuka di Brave pada perangkat lainnya akan muncul di sini.</translation>
+<translation id="4684427112815847243">Sinkronkan semua</translation>
+<translation id="2709516037105925701">Isi-Otomatis</translation>
+<translation id="8820817407110198400">Bookmark</translation>
+<translation id="1644574205037202324">Histori</translation>
+<translation id="17513872634828108">Buka tab</translation>
+<translation id="1320169905922104972">Kartu kredit dan alamat yang menggunakan Brave Software Pay</translation>
+<translation id="6337234675334993532">Enkripsi</translation>
+<translation id="6698801883190606802">Kelola data yang disinkronkan</translation>
+<translation id="3598578758776312506">Enkripsikan sandi dengan kredensial Brave Software</translation>
+<translation id="7810580217418711046">Enkripsikan data yang disinkronkan dengan sandi Brave Software mulai tanggal <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Enkripsikan data yang disinkronkan dengan frasa sandi sinkronisasi Anda sendiri</translation>
+<translation id="2996291259634659425">Buat frasa sandi</translation>
+<translation id="5713644099811900409">Akun Brave Software</translation>
+<translation id="8997474919031554666">Enkripsi frasa sandi tidak mencakup alamat dan metode pembayaran dari Brave Software Pay. Hanya pengguna yang memiliki frasa sandi Anda yang dapat membaca data yang telah Anda enkripsi. Frasa sandi tidak dikirim atau disimpan oleh Brave Software. Jika lupa frasa sandi Anda atau ingin mengubah setelan ini, Anda harus menyetel ulang sinkronisasi. <ph name="BEGIN_LINK"/>Pelajari lebih lanjut<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Frasa sandi</translation>
+<translation id="7772032839648071052">Konfirmasi frasa sandi</translation>
+<translation id="5304593522240415983">Bidang ini tidak boleh kosong</translation>
+<translation id="321773570071367578">Jika lupa frasa sandi atau ingin mengubah setelan ini, <ph name="BEGIN_LINK"/>setel ulang sinkronisasi<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Frasa sandi tidak cocok</translation>
+<translation id="5149495116300586333">Enkripsi frasa sandi tidak mencakup alamat dan metode pembayaran dari Brave Software Pay.
+
+Untuk mengubah setelan ini, <ph name="BEGIN_LINK"/>setel ulang sinkronisasi<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Frasa sandi salah</translation>
+<translation id="5414836363063783498">Memverifikasi...</translation>
+<translation id="6846298663435243399">Memuat…</translation>
+<translation id="5517095782334947753">Anda memiliki bookmark, histori, sandi, dan setelan lain dari <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Gabungkan data saya</translation>
+<translation id="688738109438487280">Menambahkan data yang sudah ada ke <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Tetap pisahkan data saya</translation>
+<translation id="1145536944570833626">Hapus data yang sudah ada.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> ingin menyandingkan</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Dapatkan bantuan<ph name="END_LINK"/> saat memindai perangkat…</translation>
+<translation id="5817918615728894473">Sandingkan</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Dapatkan bantuan<ph name="END_LINK1"/> atau <ph name="BEGIN_LINK2"/>pindai ulang<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Tidak ada perangkat yang kompatibel</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Aktifkan Bluetooth<ph name="END_LINK"/> untuk mengizinkan penyandingan</translation>
+<translation id="998321811308652668">Brave tidak dapat mengaktifkan adaptor Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Dapatkan bantuan<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave memerlukan akses lokasi untuk memindai perangkat. <ph name="BEGIN_LINK"/>Perbarui izin<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave memerlukan akses lokasi untuk memindai perangkat. Akses lokasi <ph name="BEGIN_LINK"/>dinonaktifkan untuk perangkat ini<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave memerlukan akses lokasi untuk memindai perangkat. <ph name="BEGIN_LINK1"/>Perbarui izin<ph name="END_LINK1"/>. Akses lokasi juga <ph name="BEGIN_LINK2"/>dinonaktifkan untuk perangkat ini<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Perangkat yang Terhubung</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Tingkat Kekuatan Sinyal: # batang}other{Tingkat Kekuatan Sinyal: # batang}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> ingin memindai perangkat Bluetooth di sekitar. Perangkat berikut telah ditemukan:</translation>
+<translation id="8368027906805972958">Perangkat tidak dikenal atau tidak didukung (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sinkronisasi tidak berfungsi</translation>
+<translation id="1810845389119482123">Penyiapan sinkronisasi awal belum selesai</translation>
+<translation id="3235722914093408050">Buka setelan Android dan aktifkan kembali sinkronisasi sistem Android untuk memulai Sinkronisasi Brave</translation>
+<translation id="3367813778245106622">Login lagi untuk memulai sinkronisasi</translation>
+<translation id="974555521953189084">Masukkan frasa sandi Anda untuk memulai sinkronisasi</translation>
+<translation id="2997266899014181325">Untuk memulai sinkronisasi, aktifkan "Sinkronkan data Brave Anda".</translation>
+<translation id="8260126382462817229">Coba masuk lagi</translation>
+<translation id="5919204609460789179">Perbarui <ph name="PRODUCT_NAME"/> untuk memulai sinkronisasi</translation>
+<translation id="397583555483684758">Sinkronisasi berhenti berfungsi</translation>
+<translation id="1966710179511230534">Perbarui detail ID masuk Anda.</translation>
+<translation id="7063006564040364415">Tidak dapat menyambung ke server sinkronisasi.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> sudah usang.</translation>
+<translation id="4170011742729630528">Layanan tidak tersedia; coba lagi nanti.</translation>
+<translation id="7947953824732555851">Terima dan masuk</translation>
+<translation id="8583805026567836021">Menghapus data akun</translation>
+<translation id="8310344678080805313">Tab standar</translation>
+<translation id="5748802427693696783">Beralih ke tab standar</translation>
+<translation id="7998918019931843664">Buka kembali tab yang ditutup</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, tab</translation>
+<translation id="4452411734226507615">Tutup tab <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opsi terdapat di dekat bagian bawah layar</translation>
+<translation id="4060598801229743805">Opsi yang tersedia di dekat bagian atas layar</translation>
+<translation id="2810645512293415242">Halaman disederhanakan agar data disimpan dan dimuat lebih cepat.</translation>
+<translation id="3985215325736559418">Ingin mendownload <ph name="FILE_NAME"/> lagi?</translation>
+<translation id="2450083983707403292">Ingin mulai mendownload <ph name="FILE_NAME"/> lagi?</translation>
+<translation id="7514365320538308">Download</translation>
+<translation id="545042621069398927">Mempercepat download.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Mendownload file.}other{Mendownload # file.}}</translation>
+<translation id="543509235395288790">Mendownload <ph name="COUNT"/> file (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Mendownload file (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download selesai.}other{# download selesai.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download gagal.}other{# download gagal.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download tertunda.}other{# download tertunda.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Tombol <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Hampir selesai!</translation>
+<translation id="3960299545138990065">Buka Ulang Brave</translation>
+<translation id="3771001275138982843">Tidak dapat mendownload update</translation>
+<translation id="3888648114124182147">Mendownload Update Brave…</translation>
+<translation id="1705567146636171298">Perbarui browser Brave</translation>
+<translation id="6195417478702700398">Untuk mendapatkan pengalaman penjelajahan terbaik, buka untuk mengupdate Brave</translation>
+<translation id="3512968675351418494">Untuk melihat web dalam bahasa Anda, dapatkan versi terbaru Brave</translation>
+<translation id="6427112570124116297">Terjemahkan Web</translation>
+<translation id="1379423114029199501">Update untuk mendapatkan bahasa Anda di versi terbaru Brave</translation>
+<translation id="5684874026226664614">Ups. Halaman ini tidak dapat diterjemahkan.</translation>
+<translation id="6831043979455480757">Terjemahkan</translation>
+<translation id="1285320974508926690">Jangan pernah terjemahkan situs ini</translation>
+<translation id="773466115871691567">Selalu terjemahkan halaman dalam bahasa <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Jangan pernah menerjemahkan halaman dalam <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Bahasa lainnya</translation>
+<translation id="290376772003165898">Halaman tidak dalam bahasa <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Mulai sekarang, halaman dalam bahasa <ph name="SOURCE_LANGUAGE"/> akan diterjemahkan ke <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Halaman dalam bahasa <ph name="LANGUAGE"/> tidak akan diterjemahkan</translation>
+<translation id="5447765697759493033">Situs ini tidak diterjemahkan</translation>
+<translation id="4880127995492972015">Terjemahkan…</translation>
+<translation id="641643625718530986">Cetak...</translation>
+<translation id="8909135823018751308">Bagikan...</translation>
+<translation id="4996978546172906250">Bagikan dengan</translation>
+<translation id="6333140779060797560">Bagikan dengan <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Terjadi masalah saat mencetak halaman. Coba lagi.</translation>
+<translation id="3254409185687681395">Bookmark halaman ini</translation>
+<translation id="497421865427891073">Maju</translation>
+<translation id="813082847718468539">Lihat informasi situs</translation>
+<translation id="2532336938189706096">Tampilan Web</translation>
+<translation id="6005538289190791541">Sandi yang disarankan</translation>
+<translation id="4634124774493850572">Gunakan sandi</translation>
+<translation id="8285489906452138776">Brave memerlukan izin akses ke kamera untuk situs ini.</translation>
+<translation id="320189792589364011">Brave memerlukan izin akses ke mikrofon untuk situs ini.</translation>
+<translation id="7988136689212463100">Brave memerlukan izin akses ke kamera dan mikrofon untuk situs ini.</translation>
+<translation id="4931190655840828017">Brave memerlukan akses ke lokasi Anda untuk berbagi lokasi dengan situs ini.</translation>
+<translation id="3088191967551450609">Brave memerlukan akses penyimpanan untuk mendownload file.</translation>
+<translation id="8942627711005830162">Buka di jendela lain</translation>
+<translation id="4195643157523330669">Buka di tab baru</translation>
+<translation id="1100066534610197918">Buka pada tab baru di grup</translation>
+<translation id="4860895144060829044">Telepon</translation>
+<translation id="6896758677409633944">Salin</translation>
+<translation id="8393700583063109961">Kirim pesan</translation>
+<translation id="3557336313807607643">Tambahkan ke kontak</translation>
+<translation id="4269820728363426813">Salin URL</translation>
+<translation id="1206892813135768548">Salin teks link</translation>
+<translation id="1204037785786432551">Download link</translation>
+<translation id="6864459304226931083">Download gambar</translation>
+<translation id="8209050860603202033">Buka gambar</translation>
+<translation id="8073388330009372546">Buka gambar di tab baru</translation>
+<translation id="6649642165559792194">Lihat pratinjau gambar <ph name="BEGIN_NEW"/>Baru<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Muat gambar</translation>
+<translation id="3845332215609790146">Telusuri dgn Brave Software Lens <ph name="BEGIN_NEW"/>Baru<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Telusuri <ph name="SEARCH_ENGINE"/> untuk gambar ini</translation>
+<translation id="3384347053049321195">Bagikan gambar</translation>
+<translation id="5833984609253377421">Bagikan link</translation>
+<translation id="6475951671322991020">Download video</translation>
+<translation id="2317945146070194624">Buka di tab Brave baru</translation>
+<translation id="7975379999046275268">Pratinjau halaman <ph name="BEGIN_NEW"/>Baru<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Menyegarkan halaman</translation>
+<translation id="36525718899759834">Dapatkan aplikasi dari Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Gelap</translation>
+<translation id="1807246157184219062">Terang</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Pilih tab untuk dipancarkan</translation>
+<translation id="8719023831149562936">Tidak dapat memancarkan tab ini</translation>
+<translation id="2139186145475833000">Tambahkan ke Layar Utama</translation>
+<translation id="4616150815774728855">Buka <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Tidak dapat membuka aplikasi</translation>
+<translation id="5129038482087801250">Instal aplikasi web</translation>
+<translation id="3789841737615482174">Instal</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> telah ditambahkan ke layar Utama</translation>
+<translation id="7333031090786104871">Masih menambahkan situs sebelumnya</translation>
+<translation id="1036727731225946849">Menambahkan <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Ditambahkan ke Layar utama</translation>
+<translation id="2146738493024040262">Buka Aplikasi Instan</translation>
+<translation id="7016516562562142042">Diizinkan untuk mesin telusur yang sedang digunakan</translation>
+<translation id="6177111841848151710">Diblokir untuk mesin telusur yang sedang digunakan</translation>
+<translation id="145097072038377568">Dinonaktifkan di Setelan Android</translation>
+<translation id="8007176423574883786">Dinonaktifkan untuk perangkat ini</translation>
+<translation id="164269334534774161">Anda melihat salinan offline halaman ini dari <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Halaman offline ini dibuat pada <ph name="CREATION_TIME"/> dan mungkin berbeda dengan versi onlinenya.</translation>
+<translation id="8840953339110955557">Halaman ini mungkin berbeda dengan versi onlinenya.</translation>
+<translation id="6405300764336705484">Konten ini dari <ph name="DOMAIN_NAME"/>, dikirimkan oleh Brave Software.</translation>
+<translation id="1006017844123154345">Buka versi Online</translation>
+<translation id="3326636747541519688">Halaman ringan yang ditampilkan oleh Brave Software.</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Muat halaman asli<ph name="END_LINK"/> dari <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Jika masalah ini sering terjadi, coba <ph name="BEGIN_LINK"/>saran<ph name="END_LINK"/> berikut.</translation>
+<translation id="8748850008226585750">Konten tersembunyi</translation>
+<translation id="3810973564298564668">Kelola</translation>
+<translation id="5199929503336119739">Profil kerja</translation>
+<translation id="528192093759286357">Tarik dari atas dan ketuk tombol kembali untuk keluar dari mode layar penuh.</translation>
+<translation id="2836148919159985482">Ketuk tombol kembali untuk keluar dari mode layar penuh.</translation>
+<translation id="3967822245660637423">Download selesai</translation>
+<translation id="2434158240863470628">Download selesai <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Download gagal</translation>
+<translation id="1384959399684842514">Download dijeda</translation>
+<translation id="1671236975893690980">Proses download tertunda...</translation>
+<translation id="5561549206367097665">Menunggu jaringan…</translation>
+<translation id="5864419784173784555">Menunggu proses download lain…</translation>
+<translation id="6461962085415701688">Tidak dapat membuka file</translation>
+<translation id="1178581264944972037">Jeda</translation>
+<translation id="8200772114523450471">Lanjutkan</translation>
+<translation id="1409879593029778104">Download <ph name="FILE_NAME"/> dicegah karena file sudah ada.</translation>
+<translation id="3387650086002190359">Download <ph name="FILE_NAME"/> gagal karena kesalahan sistem file.</translation>
+<translation id="6482749332252372425">Download <ph name="FILE_NAME"/> gagal karena ruang penyimpanan tidak cukup.</translation>
+<translation id="7619072057915878432">Download <ph name="FILE_NAME"/> gagal karena kesalahan jaringan.</translation>
+<translation id="1477626028522505441">Download <ph name="FILE_NAME"/> gagal karena masalah server.</translation>
+<translation id="3692944402865947621">Download <ph name="FILE_NAME"/> gagal karena lokasi penyimpanan tidak dapat dijangkau.</translation>
+<translation id="604996488070107836">Download <ph name="FILE_NAME"/> gagal karena kesalahan tak dikenal.</translation>
+<translation id="6738867403308150051">Mendownload…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Terdownload <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Terdownload <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Terdownload <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">1 file tersisa</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> file tersisa</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> file didownload}other{<ph name="FILES_DOWNLOADED_MANY"/> file didownload}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> hari lagi</translation>
+<translation id="8190358571722158785">1 hari lagi</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> jam lagi</translation>
+<translation id="510275257476243843">1 jam lagi</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> menit lagi</translation>
+<translation id="3236059992281584593">1 menit lagi</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> detik lagi</translation>
+<translation id="2781151931089541271">1 detik lagi</translation>
+<translation id="3303414029551471755">Lanjutkan untuk mendownload konten?</translation>
+<translation id="8617240290563765734">Buka URL yang disarankan yang ditentukan di konten download?</translation>
+<translation id="1373696734384179344">Memori tidak cukup untuk mendownload konten yang dipilih.</translation>
+<translation id="5271967389191913893">Perangkat tidak dapat membuka konten untuk didownload.</translation>
+<translation id="883806473910249246">Terjadi error saat mendownload konten.</translation>
+<translation id="5626134646977739690">Nama:</translation>
+<translation id="7963646190083259054">Vendor:</translation>
+<translation id="3414952576877147120">Ukuran:</translation>
+<translation id="7375125077091615385">Jenis:</translation>
+<translation id="5765780083710877561">Deskripsi:</translation>
+<translation id="4881695831933465202">Buka</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB tersedia</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB tersedia</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB tersedia</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> terpakai dari <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Semua</translation>
+<translation id="4988526792673242964">Halaman</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Gambar</translation>
+<translation id="8250920743982581267">Dokumen</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# File}other{# File}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Gambar}other{# Gambar}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Video}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# File audio}other{# File audio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Halaman}other{# Halaman}}</translation>
+<translation id="5456381639095306749">Download halaman</translation>
+<translation id="2394602618534698961">File yang Anda download muncul di sini</translation>
+<translation id="7810647596859435254">Buka dengan...</translation>
+<translation id="5655963694829536461">Telusuri file download</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">File Saya</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Artikel ditampilkan di sini, yang dapat Anda baca bahkan saat offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# jam}other{# jam}}</translation>
+<translation id="5853623416121554550">dijeda</translation>
+<translation id="8965591936373831584">ditunda</translation>
+<translation id="2779651927720337254">gagal</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Baru Saja</translation>
+<translation id="4000212216660919741">Beranda Offline</translation>
+<translation id="9133397713400217035">Jelajahi Offline</translation>
+<translation id="968900484120156207">Halaman yang Anda kunjungi akan muncul di sini</translation>
+<translation id="7882131421121961860">Tidak ada histori</translation>
+<translation id="3549657413697417275">Telusuri histori penggunaan</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">BB</translation>
+<translation id="605721222689873409">TT</translation>
+<translation id="724102042129299115">Pengalaman Penggunaan Pertama Brave</translation>
+<translation id="2700285883409956633">Dengan menggunakan aplikasi ini, Anda menyetujui <ph name="BEGIN_LINK1"/>Persyaratan Layanan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Pemberitahuan Privasi<ph name="END_LINK2"/> Brave.</translation>
+<translation id="1640714894372474981">Dengan menggunakan aplikasi ini, Anda menyetujui <ph name="BEGIN_LINK1"/>Persyaratan Layanan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Pemberitahuan Privasi<ph name="END_LINK2"/> Brave, serta <ph name="BEGIN_LINK3"/>Pemberitahuan Privasi untuk Akun Brave Software yang Dikelola dengan Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> akan terbuka di Brave. Dengan melanjutkan, Anda menyetujui <ph name="BEGIN_LINK1"/>Persyaratan Layanan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Pemberitahuan Privasi<ph name="END_LINK2"/> Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> akan terbuka di Brave. Dengan melanjutkan, Anda menyetujui <ph name="BEGIN_LINK1"/>Persyaratan Layanan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Pemberitahuan Notifikasi<ph name="END_LINK2"/> Brave, dan <ph name="BEGIN_LINK3"/>Pemberitahuan Privasi untuk Akun Brave Software yang Dikelola dengan Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Bantu penyempurnaan Brave dengan mengirimkan statistik penggunaan dan laporan error ke Brave Software.</translation>
+<translation id="3518985090088779359">Terima &amp; lanjutkan</translation>
+<translation id="7207456302801184289">Selamat Datang di Brave</translation>
+<translation id="704822250101715322">Menunggu Layanan Brave Software Play selesai di-update</translation>
+<translation id="1231733316453485619">Aktifkan sinkronisasi?</translation>
+<translation id="5132942445612118989">Sinkronkan sandi, histori, dan lainnya di semua perangkat</translation>
+<translation id="5736731321935944068">Brave Software dapat menggunakan histori Anda untuk mempersonalisasi Penelusuran, iklan, dan layanan Brave Software lainnya</translation>
+<translation id="4013614219085422040">Brave Software dapat menggunakan histori Anda untuk mempersonalisasi Penelusuran dan layanan Brave Software lainnya</translation>
+<translation id="5581519193887989363">Anda dapat memilih konten apa yang akan disinkronkan di <ph name="BEGIN_LINK1"/>setelan<ph name="END_LINK1"/> kapan saja.</translation>
+<translation id="741204030948306876">Ya, saya setuju</translation>
+<translation id="2410754283952462441">Pilih akun</translation>
+<translation id="2227444325776770048">Lanjutkan sebagai <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Bukan <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Untuk dapat mengakses bookmark Anda di semua perangkat, aktifkan sinkronisasi</translation>
+<translation id="2818669890320396765">Untuk dapat mengakses bookmark Anda di semua perangkat, login dan aktifkan sinkronisasi</translation>
+<translation id="6003646045106347985">Untuk mendapatkan konten hasil personalisasi yang disarankan oleh Brave Software, aktifkan sinkronisasi</translation>
+<translation id="8494430740943879273">Untuk mendapatkan konten hasil personalisasi yang disarankan oleh Brave Software, login dan aktifkan sinkronisasi</translation>
+<translation id="5862731021271217234">Untuk membuka tab dari perangkat Anda yang lain, aktifkan sinkronisasi</translation>
+<translation id="3568688522516854065">Untuk membuka tab dari perangkat Anda yang lain, login dan aktifkan sinkronisasi</translation>
+<translation id="1208340532756947324">Untuk menyinkronkan dan mempersonalisasi berbagai perangkat, aktifkan sinkronisasi</translation>
+<translation id="4472118726404937099">Untuk menyinkronkan dan mempersonalisasi berbagai perangkat, login dan aktifkan sinkronisasi</translation>
+<translation id="2426805022920575512">Pilih akun lain</translation>
+<translation id="6790428901817661496">Putar</translation>
+<translation id="1272079795634619415">Berhenti</translation>
+<translation id="2874939134665556319">Lagu sebelumnya</translation>
+<translation id="4046123991198612571">Lagu berikutnya</translation>
+<translation id="3859306556332390985">Cari maju</translation>
+<translation id="8441146129660941386">Cari mundur</translation>
+<translation id="6706288973712894588">Saat ini Anda sedang offline.\n<ph name="BEGIN_LINK"/>Jelajahi feed offline Anda.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Tab terbaru</translation>
+<translation id="8497726226069778601">Belum ada yang dapat dilihat di sini…</translation>
+<translation id="5423934151118863508">Halaman yang paling sering dikunjungi akan muncul di sini</translation>
+<translation id="6127379762771434464">Item dihapus</translation>
+<translation id="4605958867780575332">Item yang dihapus: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Perangkat lain</translation>
+<translation id="4738836084190194332">Terakhir disinkronkan: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# menit yang lalu}other{# menit yang lalu}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# jam yang lalu}other{# jam yang lalu}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# hari yang lalu}other{# hari yang lalu}}</translation>
+<translation id="2762000892062317888">baru saja</translation>
+<translation id="1407135791313364759">Buka semua</translation>
+<translation id="1209206284964581585">Sembunyikan sekarang</translation>
+<translation id="129553762522093515">Baru saja ditutup</translation>
+<translation id="8413126021676339697">Tampilkan histori lengkap</translation>
+<translation id="7876243839304621966">Hapus semua</translation>
+<translation id="8487700953926739672">Tersedia secara offline</translation>
+<translation id="5224771365102442243">Dengan video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Pelajari lebih lanjut<ph name="END_LINK"/> konten yang disarankan</translation>
+<translation id="7542481630195938534">Tidak bisa mendapatkan saran</translation>
+<translation id="5013696553129441713">Tidak ada saran baru</translation>
+<translation id="1736419249208073774">Jelajahi</translation>
+<translation id="7444811645081526538">Kategori lainnya</translation>
+<translation id="6709133671862442373">Berita</translation>
+<translation id="1264974993859112054">Olahraga</translation>
+<translation id="9139318394846604261">Belanja</translation>
+<translation id="3912508018559818924">Menemukan yang terbaik dari web...</translation>
+<translation id="526421993248218238">Tidak dapat memuat halaman ini</translation>
+<translation id="614940544461990577">Coba:</translation>
+<translation id="3288003805934695103">Memuat ulang halaman</translation>
+<translation id="2353636109065292463">Memeriksa sambungan internet Anda</translation>
+<translation id="2858138569776157458">Situs populer</translation>
+<translation id="8364299278605033898">Lihat situs yang populer</translation>
+<translation id="1171770572613082465">Lihat situs populer dengan mengetuk tombol "Situs populer"</translation>
+<translation id="5233638681132016545">Tab baru</translation>
+<translation id="4521874409998847950">Dari <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>dikirim oleh Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Versi baru telah tersedia</translation>
+<translation id="4058091506841967397">Brave tak bisa diupdate</translation>
+<translation id="6316139424528454185">Versi Android tidak didukung</translation>
+<translation id="6989267951144302301">Tidak dapat mendownload</translation>
+<translation id="624789221780392884">Pembaruan siap</translation>
+<translation id="1549000191223877751">Beralih ke jendela lain</translation>
+<translation id="7481312909269577407">Maju</translation>
+<translation id="4084682180776658562">Bookmark</translation>
+<translation id="6437478888915024427">Info halaman</translation>
+<translation id="7180611975245234373">Perbarui</translation>
+<translation id="4913169188695071480">Hentikan refresh</translation>
+<translation id="1829244130665387512">Cari di halaman</translation>
+<translation id="6593061639179217415">Situs desktop</translation>
+<translation id="9063523880881406963">Nonaktifkan Ubah situs desktop</translation>
+<translation id="2038563949887743358">Aktifkan Ubah situs desktop</translation>
+<translation id="2433507940547922241">Tampilan</translation>
+<translation id="983192555821071799">Tutup semua tab</translation>
+<translation id="1310482092992808703">Kelompokkan tab</translation>
+<translation id="7725024127233776428">Halaman yang Anda bookmark muncul di sini</translation>
+<translation id="4404568932422911380">Tidak ada bookmark</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> bookmark}other{<ph name="BOOKMARKS_COUNT_MANY"/> bookmark}}</translation>
+<translation id="3739899004075612870">Dibookmark di <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Diberi bookmark</translation>
+<translation id="4452548195519783679">Dibookmark ke <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Gagal menambahkan bookmark.</translation>
+<translation id="2842985007712546952">Folder induk</translation>
+<translation id="9065203028668620118">Edit</translation>
+<translation id="4405224443901389797">Pindahkan ke…</translation>
+<translation id="5170568018924773124">Tampilkan dalam folder</translation>
+<translation id="8035133914807600019">Folder baru…</translation>
+<translation id="4532845899244822526">Pilih folder</translation>
+<translation id="6627583120233659107">Edit folder</translation>
+<translation id="1197267115302279827">Pindahkan bookmark</translation>
+<translation id="6963766334940102469">Hapus bookmark</translation>
+<translation id="4351244548802238354">Tutup dialog</translation>
+<translation id="451872707440238414">Telusuri bookmark</translation>
+<translation id="8901170036886848654">Tidak ditemukan bookmark</translation>
+<translation id="6404511346730675251">Edit bookmark</translation>
+<translation id="3894427358181296146">Tambah folder</translation>
+<translation id="5327248766486351172">Nama</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Folder</translation>
+<translation id="5161254044473106830">Perlu judul</translation>
+<translation id="2996809686854298943">Perlu URL</translation>
+<translation id="2536728043171574184">Melihat salinan offline halaman ini</translation>
+<translation id="4698034686595694889">Lihat secara offline di <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> dan situs lainnya</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave akan memuat halaman Anda setelah siap}other{Brave akan memuat halaman Anda setelah siap}}</translation>
+<translation id="6811034713472274749">Halaman siap ditampilkan</translation>
+<translation id="4561979708150884304">Tidak ada koneksi</translation>
+<translation id="8274165955039650276">Lihat hasil download</translation>
+<translation id="2082238445998314030">Hasil <ph name="RESULT_NUMBER"/> dari <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Tidak ada hasil</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Ringan</translation>
+<translation id="393697183122708255">Tidak ada penelusuran suara yang aktif</translation>
+<translation id="7191430249889272776">Tab dibuka di latar belakang.</translation>
+<translation id="8445059357334030806">Buka di Brave</translation>
+<translation id="4720023427747327413">Buka di <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Buka di browser</translation>
+<translation id="1113597929977215864">Buka tampilan sederhana</translation>
+<translation id="1513352483775369820">Bookmark dan histori web</translation>
+<translation id="4939482511480190003">Bantu sempurnakan Brave. <ph name="BEGIN_LINK"/>Ikuti survei<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Kembali</translation>
+<translation id="5596627076506792578">Opsi lainnya</translation>
+<translation id="3522247891732774234">Pembaruan tersedia. Opsi lainnya</translation>
+<translation id="6773423637732432200">Brave tidak dapat diupdate. Opsi lainnya</translation>
+<translation id="3328801116991980348">Informasi situs</translation>
+<translation id="5391532827096253100">Sambungan ke situs ini tidak aman. Informasi situs</translation>
+<translation id="6206551242102657620">Sambungan aman. Informasi situs</translation>
+<translation id="6963642900430330478">Halaman ini berbahaya. Informasi situs</translation>
+<translation id="9070377983101773829">Mulai penelusuran suara</translation>
+<translation id="8676374126336081632">Hapus masukan</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> tab terbuka, ketuk untuk beralih tab}other{<ph name="OPEN_TABS_MANY"/> tab terbuka, ketuk untuk beralih tab}}</translation>
+<translation id="2369533728426058518">tab terbuka</translation>
+<translation id="7071521146534760487">Kelola akun</translation>
+<translation id="932327136139879170">Beranda</translation>
+<translation id="2707726405694321444">Segarkan halaman</translation>
+<translation id="2891154217021530873">Hentikan pemuatan halaman</translation>
+<translation id="6710213216561001401">Sebelumnya</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Tab yang Dipilih</translation>
+<translation id="2268044343513325586">Saring</translation>
+<translation id="7846076177841592234">Batalkan pilihan</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> dipilih. Opsi yang tersedia di dekat bagian atas layar</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> dipilih</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Bagikan 1 item yang dipilih}other{Bagikan # item yang dipilih}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Hapus 1 item yang dipilih}other{Hapus # item yang dipilih}}</translation>
+<translation id="1283039547216852943">Ketuk untuk meluaskan</translation>
+<translation id="5962718611393537961">Ketuk untuk menciutkan</translation>
+<translation id="8076492880354921740">Tab</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 dipilih}other{# dipilih}}</translation>
+<translation id="6818926723028410516">Pilih item</translation>
+<translation id="4797039098279997504">Sentuh untuk kembali ke <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Ketuk untuk membuka situs</translation>
+<translation id="429312253194641664">Sebuah situs sedang memutar media</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> berbagi layar Anda</translation>
+<translation id="8833831881926404480">Satu situs sedang membagikan layar Anda</translation>
+<translation id="9086455579313502267">Tidak dapat mengakses jaringan</translation>
+<translation id="938850635132480979">Kesalahan: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Buka di <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Buka di aplikasi peta</translation>
+<translation id="7698359219371678927">Buat email di <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Buat email</translation>
+<translation id="5665379678064389456">Buat acara di <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Buat acara</translation>
+<translation id="2111511281910874386">Buka halaman</translation>
+<translation id="3988466920954086464">Lihat hasil penelusuran instan di panel ini</translation>
+<translation id="2744248271121720757">Ketuk sebuah kata untuk menelusuri secara instan atau melihat tindakan terkait</translation>
+<translation id="9155898266292537608">Anda juga dapat menelusuri dengan mengetuk kata secara cepat</translation>
+<translation id="3232754137068452469">Aplikasi Web</translation>
+<translation id="1430915738399379752">Cetak</translation>
+<translation id="3775705724665058594">Kirim ke perangkat Anda</translation>
+<translation id="6364438453358674297">Hapus saran dari histori?</translation>
+<translation id="213279576345780926">Menutup <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> tab ditutup</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> dihapus</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> bookmark dihapus</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> download dihapus</translation>
+<translation id="1248710015876067820">Jumlah kemunculan Brave tidak didukung.</translation>
+<translation id="4259722352634471385">Navigasi diblokir: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigasi tidak dapat dijangkau: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Tutup tab</translation>
+<translation id="7772375229873196092">Tutup <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Histori navigasi</translation>
+<translation id="9169507124922466868">Histori navigasi terbuka setengah</translation>
+<translation id="1327257854815634930">Histori navigasi terbuka</translation>
+<translation id="8788265440806329501">Histori navigasi tertutup</translation>
+<translation id="7482656565088326534">Tab pratinjau</translation>
+<translation id="8427875596167638501">Tab pratinjau terbuka setengah</translation>
+<translation id="9102803872260866941">Tab pratinjau dibuka</translation>
+<translation id="2942036813789421260">Tab pratinjau ditutup</translation>
+<translation id="6355102470683871794">Penyimpanan Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Kosongkan penyimpanan situs?</translation>
+<translation id="9205995714227143200">Penyimpanan situs yang dianggap tidak penting oleh Brave (misalnya situs yang tidak memiliki setelan penyimpanan atau situs yang tidak sering Anda kunjungi)</translation>
+<translation id="3997476611815694295">Penyimpanan tidak penting</translation>
+<translation id="8493948351860045254">Kosongkan ruang</translation>
+<translation id="2324920234469020158">Tindakan ini akan mengosongkan cache dan menghapus cookie, serta data lain dari situs yang dianggap tidak penting oleh Brave.</translation>
+<translation id="5447201525962359567">Semua penyimpanan situs, termasuk cookie dan data lain yang tersimpan secara lokal</translation>
+<translation id="1376578503827013741">Menghitung…</translation>
+<translation id="583281660410589416">Tidak dikenal</translation>
+<translation id="2323763861024343754">Penyimpanan situs</translation>
+<translation id="3587672679800759167">Total data yang digunakan oleh Brave, termasuk akun, bookmark, dan setelan yang tersimpan</translation>
+<translation id="6545017243486555795">Hapus Semua Data</translation>
+<translation id="4095146165863963773">Hapus data aplikasi?</translation>
+<translation id="53119194224775367">Semua data aplikasi Brave akan dihapus secara permanen. Hal ini meliputi semua file, setelan, akun, database, dll.</translation>
+<translation id="5307446750509046227">Hapus penyimpanan situs</translation>
+<translation id="300526633675317032">Ini akan menghapus seluruh penyimpanan situs web, sebesar <ph name="SIZE_IN_KB"/>.</translation>
+<translation id="8068648041423924542">Tidak dapat memilih sertifikat.</translation>
+<translation id="2315043854645842844">Pilihan sertifikat sisi klien tidak didukung oleh sistem operasi.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> ingin terhubung</translation>
+<translation id="5308380583665731573">Sambungkan</translation>
+<translation id="868929229000858085">Telusuri kontak Anda</translation>
+<translation id="1919950603503897840">Pilih kontak</translation>
+<translation id="7986741934819883144">Pilih kontak</translation>
+<translation id="3333961966071413176">Semua kontak</translation>
+<translation id="4994033804516042629">Kontak tidak ditemukan</translation>
+<translation id="5403592356182871684">Nama</translation>
+<translation id="2717722538473713889">Alamat email</translation>
+<translation id="381841723434055211">Nomor telepon</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 lainnya)}other{(+ # lainnya)}}</translation>
+<translation id="5197729504361054390">Kontak yang Anda pilih akan dibagikan dengan <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Pendekode gambar</translation>
+<translation id="8067883171444229417">Putar video</translation>
+<translation id="6560414384669816528">Menelusuri menggunakan Sogou</translation>
+<translation id="5406914950576900927">Brave dapat menggunakan <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> sebagai mesin telusur di Tiongkok. Anda dapat mengubahnya di <ph name="BEGIN_LINK"/>Setelan<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Tetap menggunakan Brave Software</translation>
+<translation id="4384468725000734951">Menggunakan Sogou untuk penelusuran</translation>
+<translation id="6103327872225198548">Menggunakan Brave Software untuk penelusuran</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Aplikasi ini dijalankan di Brave</translation>
+<translation id="6143689084714664628">Berjalan di Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> juga memiliki data di Brave</translation>
+<translation id="2734140769649165081">Anda dapat menghapus data di Setelan Brave</translation>
+<translation id="8232956427053453090">Pertahankan data</translation>
+<translation id="4298388696830689168">Situs tertaut</translation>
+<translation id="5763514718066511291">Ketuk untuk menyalin URL aplikasi ini</translation>
+<translation id="6496823230996795692">Untuk menggunakan <ph name="APP_NAME"/> pertama kali, harap hubungkan ke internet.</translation>
+<translation id="751961395872307827">Tidak dapat terhubung ke situs</translation>
+<translation id="4878404682131129617">Gagal membentuk saluran melalui server proxy</translation>
+<translation id="4749960740855309258">Membuka tab baru</translation>
+<translation id="8788968922598763114">Membuka ulang tab yang terakhir ditutup</translation>
+<translation id="7929962904089429003">Membuka menu</translation>
+<translation id="6039379616847168523">Beralih ke tab berikutnya</translation>
+<translation id="5210286577605176222">Beralih ke tab sebelumnya</translation>
+<translation id="124678866338384709">Menutup tab aktif</translation>
+<translation id="3714981814255182093">Membuka Bilah Cari</translation>
+<translation id="5441522332038954058">Beralih ke bilah alamat</translation>
+<translation id="3398320232533725830">Membuka pengelola bookmark</translation>
+<translation id="6583199322650523874">Membookmark halaman saat ini</translation>
+<translation id="8489271220582375723">Membuka halaman histori</translation>
+<translation id="4837753911714442426">Membuka opsi untuk mencetak halaman</translation>
+<translation id="5726692708398506830">Memperbesar semua yang ada di halaman</translation>
+<translation id="3259831549858767975">Memperkecil semua yang ada di halaman</translation>
+<translation id="8015452622527143194">Mengembalikan semua di halaman ke ukuran default</translation>
+<translation id="3443221991560634068">Memuat ulang halaman saat ini</translation>
+<translation id="123724288017357924">Memuat ulang halaman, mengabaikan konten dalam cache</translation>
+<translation id="305870044889644984">Membuka Pusat Bantuan Brave di tab baru</translation>
+<translation id="3166827708714933426">Pintasan tab dan jendela</translation>
+<translation id="3169981355900570544">Pintasan fitur Brave Software Brave</translation>
+<translation id="4558311620361989323">Pintasan halaman web</translation>
+<translation id="1908301351964700579">Brave masih bersiap untuk menggunakan VR. Mulai ulang Brave nanti.</translation>
+<translation id="8970887620466824814">Terjadi error.</translation>
+<translation id="1875543012935658554">Buka Brave lagi.</translation>
+<translation id="79859296434321399">Untuk melihat konten augmented reality, instal ARCore</translation>
+<translation id="8558485628462305855">Untuk melihat konten augmented reality, update ARCore</translation>
+<translation id="3513704683820682405">Augmented Reality</translation>
+<translation id="5475862044948910901">Mulai sesi Augmented Reality?</translation>
 <translation id="7365126855094612066">Untuk durasi sesi ini, situs akan dapat:
 • membuat peta 3D untuk lingkungan Anda
 • melacak gerakan kamera
 
 Situs TIDAK mendapatkan akses ke kamera. Gambar kamera hanya dapat dilihat oleh Anda.</translation>
-<translation id="7375125077091615385">Jenis:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Pengalaman Penggunaan Pertama Chrome</translation>
-<translation id="741204030948306876">Ya, saya setuju</translation>
-<translation id="7413229368719586778">Tanggal mulai <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Tanyakan dulu</translation>
-<translation id="7423538860840206698">Diblokir agar tidak membaca papan klip</translation>
-<translation id="7431991332293347422">Kontrol cara histori browsing digunakan untuk mempersonalisasi Penelusuran dan lainnya</translation>
-<translation id="7437998757836447326">Logout dari Chrome</translation>
-<translation id="7438641746574390233">Ketika Mode Ringan dalam keadaan aktif, Chrome menggunakan server Google agar halaman lebih cepat dimuat. Mode Ringan akan menulis ulang halaman yang sangat lambat agar hanya memuat konten penting. Mode Ringan tidak berlaku untuk tab Samaran.</translation>
-<translation id="7444811645081526538">Kategori lainnya</translation>
-<translation id="7445411102860286510">Izinkan situs untuk otomatis memutar video yang dibisukan (disarankan)</translation>
-<translation id="7453467225369441013">Membuat Anda logout dari sebagian besar situs. Anda tidak akan logout dari Akun Google.</translation>
-<translation id="7454641608352164238">Tidak cukup ruang</translation>
-<translation id="7475192538862203634">Jika masalah ini sering terjadi, coba <ph name="BEGIN_LINK" />saran<ph name="END_LINK" /> berikut.</translation>
-<translation id="7475688122056506577">Kartu SD tidak ditemukan. Beberapa file Anda mungkin tidak tersimpan.</translation>
-<translation id="7479104141328977413">Pengelolaan tab</translation>
-<translation id="7481312909269577407">Maju</translation>
-<translation id="7482656565088326534">Tab pratinjau</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Diperbarui <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">data dihemat</translation>
-<translation id="7498271377022651285">Harap tunggu...</translation>
-<translation id="7514365320538308">Download</translation>
-<translation id="751961395872307827">Tidak dapat terhubung ke situs</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Tidak bisa mendapatkan saran</translation>
-<translation id="7559975015014302720">Mode Ringan nonaktif</translation>
-<translation id="7562080006725997899">Menghapus data penjelajahan</translation>
-<translation id="756809126120519699">Data Chrome telah dihapus</translation>
-<translation id="757524316907819857">Blokir situs agar tidak memutar konten yang dilindungi</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> file didownload}other{<ph name="FILES_DOWNLOADED_MANY" /> file didownload}}</translation>
-<translation id="7588219262685291874">Mengaktifkan tema gelap saat mode Penghemat Baterai perangkat aktif</translation>
-<translation id="7589445247086920869">Blokir mesin telusur saat ini</translation>
-<translation id="7593557518625677601">Buka setelan Android dan aktifkan kembali sinkronisasi sistem Android untuk memulai Sinkronisasi Chrome</translation>
-<translation id="7596558890252710462">Sistem operasi</translation>
-<translation id="7605594153474022051">Sinkronisasi tidak berfungsi</translation>
-<translation id="7606077192958116810">Mode Ringan aktif. Kelola di Setelan.</translation>
-<translation id="7612619742409846846">Login ke Google sebagai</translation>
-<translation id="7619072057915878432">Download <ph name="FILE_NAME" /> gagal karena kesalahan jaringan.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Dapatkan bantuan<ph name="END_LINK1" /> atau <ph name="BEGIN_LINK2" />pindai ulang<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Selamat Datang di Chrome</translation>
-<translation id="7638584964844754484">Frasa sandi salah</translation>
-<translation id="7641339528570811325">Hapus data penjelajahan...</translation>
-<translation id="7648422057306047504">Enkripsikan sandi dengan kredensial Google</translation>
-<translation id="7649070708921625228">Bantuan</translation>
-<translation id="7658239707568436148">Batal</translation>
-<translation id="7665369617277396874">Tambahkan akun</translation>
-<translation id="766587987807204883">Artikel ditampilkan di sini, yang dapat Anda baca bahkan saat offline</translation>
-<translation id="7682724950699840886">Coba tips berikut ini: pastikan ruang di perangkat Anda mencukupi, lalu coba ekspor lagi.</translation>
-<translation id="7685301384041462804">Pastikan Anda memercayai situs ini sebelum masuk ke VR.</translation>
-<translation id="7698359219371678927">Buat email di <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Lengkapi otomatis penelusuran dan URL</translation>
-<translation id="7725024127233776428">Halaman yang Anda bookmark muncul di sini</translation>
-<translation id="773466115871691567">Selalu terjemahkan halaman dalam bahasa <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Untuk mendeteksi aplikasi dan situs berbahaya, Chrome mengirimkan URL beberapa halaman yang Anda kunjungi, informasi sistem terbatas, dan beberapa konten halaman ke Google</translation>
-<translation id="7757787379047923882">Teks dibagikan dari <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Kartu SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Tambahkan alamat</translation>
-<translation id="7772032839648071052">Konfirmasi frasa sandi</translation>
-<translation id="7772375229873196092">Tutup <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> lainnya}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> lainnya}}</translation>
-<translation id="7781829728241885113">Kemarin</translation>
-<translation id="7791543448312431591">Tambahkan</translation>
-<translation id="780301667611848630">Lain kali</translation>
-<translation id="7810647596859435254">Buka dengan...</translation>
-<translation id="7821588508402923572">Penghematan data Anda akan terlihat di sini</translation>
-<translation id="7837721118676387834">Izinkan pemutaran otomatis video yang dibisukan untuk situs tertentu.</translation>
-<translation id="7846076177841592234">Batalkan pilihan</translation>
-<translation id="784934925303690534">Rentang waktu</translation>
-<translation id="7851858861565204677">Perangkat lain</translation>
-<translation id="7875915731392087153">Buat email</translation>
-<translation id="7876243839304621966">Hapus semua</translation>
-<translation id="7882131421121961860">Tidak ada histori</translation>
-<translation id="7882806643839505685">Izinkan suara untuk situs tertentu.</translation>
-<translation id="7886917304091689118">Berjalan di Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Mendownload file.}other{Mendownload # file.}}</translation>
-<translation id="7929962904089429003">Membuka menu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> sudah usang.</translation>
-<translation id="7947953824732555851">Terima dan masuk</translation>
-<translation id="7963646190083259054">Vendor:</translation>
-<translation id="7971136598759319605">Aktif 1 hari yang lalu</translation>
-<translation id="7975379999046275268">Pratinjau halaman <ph name="BEGIN_NEW" />Baru<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Pramuat halaman agar browsing dan menelusuri lebih cepat</translation>
-<translation id="79859296434321399">Untuk melihat konten augmented reality, instal ARCore</translation>
-<translation id="7986741934819883144">Pilih kontak</translation>
-<translation id="7987073022710626672">Persyaratan Layanan Chrome</translation>
-<translation id="7998918019931843664">Buka kembali tab yang ditutup</translation>
-<translation id="7999064672810608036">Yakin ingin menghapus semua data lokal, termasuk cookie, dan menyetel ulang semua izin untuk situs web ini?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Dinonaktifkan untuk perangkat ini</translation>
-<translation id="8013372441983637696">Hapus juga data Chrome Anda dari perangkat ini</translation>
-<translation id="8015452622527143194">Mengembalikan semua di halaman ke ukuran default</translation>
-<translation id="802154636333426148">Download gagal</translation>
-<translation id="8026334261755873520">Hapus data penjelajahan</translation>
-<translation id="8035133914807600019">Folder baru…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> hari lagi</translation>
-<translation id="804335162455518893">Kartu SD tidak ditemukan</translation>
-<translation id="805047784848435650">Berdasarkan histori browsing Anda</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB tersedia</translation>
-<translation id="8058746566562539958">Buka di tab Chrome baru</translation>
-<translation id="8063895661287329888">Gagal menambahkan bookmark.</translation>
-<translation id="806745655614357130">Tetap pisahkan data saya</translation>
-<translation id="8067883171444229417">Putar video</translation>
-<translation id="8068648041423924542">Tidak dapat memilih sertifikat.</translation>
-<translation id="8073388330009372546">Buka gambar di tab baru</translation>
-<translation id="8076492880354921740">Tab</translation>
-<translation id="8084114998886531721">Sandi tersimpan</translation>
-<translation id="8087000398470557479">Konten ini dari <ph name="DOMAIN_NAME" />, dikirimkan oleh Google.</translation>
-<translation id="8103578431304235997">Tab Samaran</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Untuk dapat mengakses bookmark Anda di semua perangkat, aktifkan sinkronisasi</translation>
-<translation id="8110087112193408731">Tampilkan aktivitas Chrome Anda di Kesehatan Digital?</translation>
-<translation id="8116925261070264013">Dinonaktifkan</translation>
-<translation id="813082847718468539">Lihat informasi situs</translation>
-<translation id="8131740175452115882">Konfirmasi</translation>
-<translation id="8156139159503939589">Anda membaca dalam bahasa apa?</translation>
-<translation id="8168435359814927499">Konten</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> file tersisa</translation>
-<translation id="8190358571722158785">1 hari lagi</translation>
-<translation id="8200772114523450471">Lanjutkan</translation>
-<translation id="8209050860603202033">Buka gambar</translation>
-<translation id="8218622182176210845">Kelola akun Anda</translation>
-<translation id="8224471946457685718">Download artikel untuk Anda pada jaringan Wi-Fi</translation>
-<translation id="8232956427053453090">Pertahankan data</translation>
-<translation id="8249310407154411074">Pindahkan ke atas</translation>
-<translation id="8250920743982581267">Dokumen</translation>
-<translation id="825412236959742607">Halaman ini menggunakan terlalu banyak memori, sehingga Chrome menghapus sebagian konten.</translation>
-<translation id="8260126382462817229">Coba masuk lagi</translation>
-<translation id="8261506727792406068">Hapus</translation>
-<translation id="8266862848225348053">Lokasi download</translation>
-<translation id="8274165955039650276">Lihat hasil download</translation>
-<translation id="8284326494547611709">Teks</translation>
-<translation id="8300705686683892304">Dikelola oleh aplikasi</translation>
-<translation id="8310344678080805313">Tab standar</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> dan situs lainnya</translation>
-<translation id="8327155640814342956">Untuk mendapatkan pengalaman penjelajahan terbaik, buka untuk mengupdate Chrome</translation>
-<translation id="8339163506404995330">Halaman dalam bahasa <ph name="LANGUAGE" /> tidak akan diterjemahkan</translation>
-<translation id="8349013245300336738">Urutkan menurut jumlah kuota yang digunakan</translation>
-<translation id="8364299278605033898">Lihat situs yang populer</translation>
-<translation id="8368027906805972958">Perangkat tidak dikenal atau tidak didukung (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Mengizinkan Sinkronisasi Latar Belakang untuk situs tertentu.</translation>
-<translation id="8378714024927312812">Dikelola oleh organisasi</translation>
-<translation id="8380167699614421159">Situs ini menampilkan iklan yang mengganggu atau menyesatkan</translation>
-<translation id="8393700583063109961">Kirim pesan</translation>
-<translation id="8413126021676339697">Tampilkan histori lengkap</translation>
-<translation id="8427875596167638501">Tab pratinjau terbuka setengah</translation>
-<translation id="8428213095426709021">Setelan</translation>
-<translation id="8438566539970814960">Jadikan penelusuran dan penjelajahan lebih baik</translation>
-<translation id="8441146129660941386">Cari mundur</translation>
-<translation id="8443209985646068659">Chrome tak bisa diupdate</translation>
-<translation id="8445448999790540984">Tidak dapat mengekspor sandi</translation>
-<translation id="8447861592752582886">Cabut izin perangkat</translation>
-<translation id="8461694314515752532">Enkripsikan data yang disinkronkan dengan frasa sandi sinkronisasi Anda sendiri</translation>
-<translation id="8466613982764129868">Pastikan <ph name="TARGET_DEVICE_NAME" /> tersambung ke internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Tersedia secara offline</translation>
-<translation id="8489271220582375723">Membuka halaman histori</translation>
-<translation id="8493948351860045254">Kosongkan ruang</translation>
-<translation id="8497726226069778601">Belum ada yang dapat dilihat di sini…</translation>
-<translation id="8503559462189395349">Sandi Chrome</translation>
-<translation id="8503813439785031346">Nama Pengguna</translation>
-<translation id="8514477925623180633">Ekspor sandi yang disimpan dengan Chrome</translation>
-<translation id="8514577642972634246">Masuki mode samaran</translation>
-<translation id="851751545965956758">Blokir situs agar tidak terhubung ke perangkat</translation>
-<translation id="8523928698583292556">Hapus sandi tersimpan</translation>
-<translation id="854522910157234410">Buka halaman ini</translation>
-<translation id="8558485628462305855">Untuk melihat konten augmented reality, update ARCore</translation>
-<translation id="8559990750235505898">Tawarkan penerjemahan halaman ke dalam bahasa lain</translation>
-<translation id="8562452229998620586">Sandi yang disimpan akan muncul di sini.</translation>
-<translation id="8569404424186215731">sejak <ph name="DATE" /></translation>
-<translation id="8571213806525832805">4 minggu terakhir</translation>
-<translation id="857943718398505171">Diizinkan (disarankan)</translation>
-<translation id="8583805026567836021">Menghapus data akun</translation>
-<translation id="860043288473659153">Nama pemegang kartu</translation>
-<translation id="8609465669617005112">Berpindah ke atas</translation>
-<translation id="8616006591992756292">Akun Google Anda mungkin memiliki bentuk histori penjelajahan lainnya di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Buka URL yang disarankan yang ditentukan di konten download?</translation>
-<translation id="8636825310635137004">Untuk mengakses tab Anda dari perangkat lainnya, aktifkan sinkronisasi.</translation>
-<translation id="8641930654639604085">Coba blokir situs dewasa</translation>
-<translation id="8655129584991699539">Anda dapat menghapus data di Setelan Chrome</translation>
-<translation id="8662811608048051533">Membuat Anda logout dari sebagian besar situs.</translation>
-<translation id="8664979001105139458">Nama file sudah ada</translation>
-<translation id="8676374126336081632">Hapus masukan</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Tingkat Kekuatan Sinyal: # batang}other{Tingkat Kekuatan Sinyal: # batang}}</translation>
-<translation id="868929229000858085">Telusuri kontak Anda</translation>
-<translation id="869891660844655955">Masa berlaku</translation>
-<translation id="8719023831149562936">Tidak dapat memancarkan tab ini</translation>
-<translation id="8725066075913043281">Coba lagi</translation>
-<translation id="8728487861892616501">Dengan menggunakan aplikasi ini, Anda menyetujui <ph name="BEGIN_LINK1" />Persyaratan Layanan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Pemberitahuan Privasi<ph name="END_LINK2" /> Chrome, serta <ph name="BEGIN_LINK3" />Pemberitahuan Privasi untuk Akun Google yang Dikelola dengan Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Selesai</translation>
-<translation id="8748850008226585750">Konten tersembunyi</translation>
-<translation id="8751914237388039244">Pilih gambar</translation>
-<translation id="8788265440806329501">Histori navigasi tertutup</translation>
-<translation id="8788968922598763114">Membuka ulang tab yang terakhir ditutup</translation>
-<translation id="8801436777607969138">Blokir JavaScript untuk situs tertentu.</translation>
-<translation id="8812260976093120287">Di beberapa situs, Anda dapat membayar dengan aplikasi pembayaran yang didukung di atas pada perangkat Anda.</translation>
-<translation id="8816026460808729765">Memblokir situs agar tidak mengakses sensor</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> akan terbuka di Chrome. Dengan melanjutkan, Anda menyetujui <ph name="BEGIN_LINK1" />Persyaratan Layanan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Pemberitahuan Notifikasi<ph name="END_LINK2" /> Chrome, dan <ph name="BEGIN_LINK3" />Pemberitahuan Privasi untuk Akun Google yang Dikelola dengan Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Bookmark</translation>
-<translation id="8833831881926404480">Satu situs sedang membagikan layar Anda</translation>
-<translation id="883806473910249246">Terjadi error saat mendownload konten.</translation>
-<translation id="8840953339110955557">Halaman ini mungkin berbeda dengan versi onlinenya.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, tab</translation>
-<translation id="885701979325669005">Penyimpanan</translation>
-<translation id="889338405075704026">Buka setelan Chrome</translation>
-<translation id="8901170036886848654">Tidak ditemukan bookmark</translation>
-<translation id="8909135823018751308">Bagikan...</translation>
-<translation id="8912362522468806198">Akun Google</translation>
-<translation id="8920114477895755567">Menunggu detail orang tua.</translation>
+<translation id="1188239144602654184">Mulai AR</translation>
+<translation id="473775607612524610">Perbarui</translation>
+<translation id="3133489217401741157">Menginstal <ph name="MODULE"/> untuk Brave…</translation>
+<translation id="1791662854739702043">Terinstal</translation>
+<translation id="5131234170665854056">Tidak dapat menginstal <ph name="MODULE"/> untuk Brave</translation>
+<translation id="2567385386134582609">GAMBAR</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Download halaman untuk melihat secara offline</translation>
 <translation id="8922289737868596582">Download halaman dari tombol opsi Lainnya untuk menggunakannya secara offline</translation>
-<translation id="8937772741022875483">Hapus aktivitas Chrome Anda dari Kesehatan Digital?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Buka di jendela lain</translation>
-<translation id="8951232171465285730">Chrome telah menghemat <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokir cookie untuk situs tertentu.</translation>
-<translation id="8959122750345127698">Navigasi tidak dapat dijangkau: <ph name="URL" /></translation>
-<translation id="8965591936373831584">ditunda</translation>
-<translation id="8970887620466824814">Terjadi error.</translation>
-<translation id="8972098258593396643">Download ke folder default?</translation>
-<translation id="8986494364107987395">Kirim statistik penggunaan dan laporan error ke Google secara otomatis</translation>
-<translation id="8993760627012879038">Membuka tab baru dalam Mode samaran</translation>
-<translation id="8998729206196772491">Anda akan login dengan akun yang dikelola oleh <ph name="MANAGED_DOMAIN" /> dan memberikan kontrol data Chrome kepada administratornya. Data akan terikat dengan akun ini secara permanen. Bila Anda logout dari Chrome, data akan dihapus dari perangkat ini, tetapi data tetap tersimpan di Akun Google.</translation>
-<translation id="9019902583201351841">Dikelola oleh orang tua Anda</translation>
-<translation id="9028914725102941583">Aktifkan sinkronisasi untuk berbagi ke seluruh perangkat</translation>
-<translation id="9029323097866369874">Izinkan <ph name="DOMAIN" /> memasuki VR?</translation>
-<translation id="9040142327097499898">Notifikasi diizinkan. Lokasi dinonaktifkan untuk perangkat ini.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Video}}</translation>
-<translation id="9050666287014529139">Frasa sandi</translation>
-<translation id="9063523880881406963">Nonaktifkan Ubah situs desktop</translation>
-<translation id="9065203028668620118">Edit</translation>
-<translation id="9070377983101773829">Mulai penelusuran suara</translation>
-<translation id="9074336505530349563">Untuk mendapatkan konten hasil personalisasi yang disarankan oleh Google, login dan aktifkan sinkronisasi</translation>
-<translation id="9086455579313502267">Tidak dapat mengakses jaringan</translation>
-<translation id="9100505651305367705">Tawarkan untuk menampilkan artikel dalam tampilan sederhana, jika didukung</translation>
-<translation id="9100610230175265781">Frasa sandi diwajibkan</translation>
-<translation id="9102803872260866941">Tab pratinjau dibuka</translation>
+<translation id="5958275228015807058">Temukan file dan halaman di Download</translation>
+<translation id="5620928963363755975">Temukan file dan halaman di Download dari tombol Opsi Lainnya</translation>
+<translation id="3341058695485821946">Lihat banyaknya kuota yang Anda hemat</translation>
+<translation id="3157842584138209013">Lihat banyaknya kuota yang Anda hemat dari tombol Opsi Lainnya</translation>
+<translation id="8218622182176210845">Kelola akun Anda</translation>
+<translation id="8090895580117672212">Untuk mengelola akun Brave Software Anda, ketuk tombol "Kelola akun"</translation>
+<translation id="8856898588039823173">Halaman ringan yang ditampilkan oleh Brave Software. Ketuk untuk memuat halaman asli.</translation>
+<translation id="8134317863207426198">Halaman ringan yang ditampilkan oleh Brave Software. Ketuk tombol muat versi asli untuk memuat halaman asli.</translation>
+<translation id="4961107849584082341">Terjemahkan halaman ini ke bahasa apa pun</translation>
+<translation id="569536719314091526">Terjemahkan halaman ini ke bahasa apa pun dari tombol Opsi lainnya</translation>
+<translation id="1397811292916898096">Telusuri dengan <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Ubah lokasi download default kapan saja</translation>
+<translation id="6942665639005891494">Ubah lokasi download default kapan saja menggunakan opsi menu Setelan</translation>
+<translation id="6850409657436465440">Download sedang berlangsung</translation>
+<translation id="5817715962196959877">Brave sekarang mendownload file lebih cepat</translation>
+<translation id="3976396876660209797">Hapus dan buat ulang pintasan ini</translation>
+<translation id="6766622839693428701">Geser ke bawah untuk menutup.</translation>
+<translation id="1028699632127661925">Mengirim ke <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Dikirim dari <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Tab diterima</translation>
 <translation id="9104217018994036254">Daftar perangkat yang dapat digunakan untuk berbagi tab.</translation>
-<translation id="9133397713400217035">Jelajahi Offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Perlihatkan halaman asli</translation>
-<translation id="9139068048179869749">Tanya terlebih dahulu sebelum mengizinkan situs mengirimkan notifikasi (disarankan)</translation>
-<translation id="9139318394846604261">Belanja</translation>
-<translation id="9155898266292537608">Anda juga dapat menelusuri dengan mengetuk kata secara cepat</translation>
-<translation id="9169507124922466868">Histori navigasi terbuka setengah</translation>
-<translation id="9204836675896933765">1 file tersisa</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Daftar perangkat yang dapat digunakan untuk berbagi tab terbuka dalam setengah layar.</translation>
+<translation id="2904414404539560095">Daftar perangkat yang dapat digunakan untuk berbagi tab terbuka dalam layar penuh.</translation>
+<translation id="4135200667068010335">Daftar perangkat yang dapat digunakan untuk berbagi tab tertutup.</translation>
+<translation id="5292796745632149097">Kirim ke</translation>
+<translation id="1386674309198842382">Aktif <ph name="LAST_UPDATED"/> hari lalu</translation>
+<translation id="7971136598759319605">Aktif 1 hari yang lalu</translation>
+<translation id="1521774566618522728">Aktif hari ini</translation>
+<translation id="3631987586758005671">Membagikan ke <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Aktifkan sinkronisasi untuk berbagi ke seluruh perangkat</translation>
+<translation id="6162454065885854378">Untuk berbagi dari ponsel Anda ke perangkat lain, aktifkan sinkronisasi di setelan Brave pada kedua perangkat</translation>
+<translation id="6084271560289605378">Buka setelan Brave</translation>
+<translation id="2318045970523081853">Ketuk untuk melakukan panggilan</translation>
 <translation id="9209888181064652401">Tidak dapat menelepon</translation>
-<translation id="9219103736887031265">Gambar</translation>
-<translation id="926205370408745186">Hapus aktivitas Chrome Anda dari Kesehatan Digital</translation>
-<translation id="932327136139879170">Beranda</translation>
-<translation id="938850635132480979">Kesalahan: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Akses mikrofon Anda</translation>
-<translation id="95817756606698420">Chrome dapat menggunakan <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> sebagai mesin telusur di Tiongkok. Anda dapat mengubahnya di <ph name="BEGIN_LINK" />Setelan<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokir jika situs menampilkan iklan yang mengganggu atau menyesatkan (direkomendasikan)</translation>
-<translation id="968900484120156207">Halaman yang Anda kunjungi akan muncul di sini</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> menit lagi</translation>
-<translation id="974555521953189084">Masukkan frasa sandi Anda untuk memulai sinkronisasi</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Tindakan ini akan menghapus data untuk semua situs, termasuk:</translation>
-<translation id="983192555821071799">Tutup semua tab</translation>
-<translation id="987264212798334818">Umum</translation>
+<translation id="2860954141821109167">Pastikan aplikasi telepon diaktifkan di perangkat ini</translation>
+<translation id="2067805253194386918">teks</translation>
+<translation id="1450753235335490080">Tidak dapat membagikan <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Tidak dapat membagikan <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Pastikan <ph name="TARGET_DEVICE_NAME"/> telah mengaktifkan sinkronisasi di Brave</translation>
+<translation id="3016635187733453316">Pastikan perangkat ini tersambung ke internet</translation>
+<translation id="8466613982764129868">Pastikan <ph name="TARGET_DEVICE_NAME"/> tersambung ke internet</translation>
+<translation id="6539092367496845964">Terjadi masalah. Coba lagi nanti.</translation>
+<translation id="3389286852084373014">Teks terlalu besar</translation>
+<translation id="2100314319871056947">Coba bagikan teks dalam potongan yang lebih kecil</translation>
+<translation id="2987620471460279764">Teks yang dibagikan dari perangkat lain</translation>
+<translation id="7757787379047923882">Teks dibagikan dari <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Disalin ke papan klip Anda</translation>
+<translation id="4696983787092045100">Kirim pesan teks ke Perangkat Anda</translation>
+<translation id="1260236875608242557">Telusuri &amp; jelajahi</translation>
+<translation id="6369229450655021117">Dari sini, Anda dapat menelusuri web, berbagi dengan teman, dan melihat halaman yang terbuka</translation>
+<translation id="723171743924126238">Pilih gambar</translation>
+<translation id="8751914237388039244">Pilih gambar</translation>
+<translation id="1989112275319619282">Jelajahi</translation>
+<translation id="7055152154916055070">Pengalihan diblokir:</translation>
+<translation id="5524843473235508879">Pengalihan diblokir.</translation>
+<translation id="6573096386450695060">Selalu izinkan</translation>
+<translation id="5805364706385912897">Halaman ini menggunakan terlalu banyak memori, sehingga Brave menjedanya.</translation>
+<translation id="5138664332909611586">Halaman ini menggunakan terlalu banyak memori, sehingga Brave menghapus sebagian konten.</translation>
+<translation id="9137013805542155359">Perlihatkan halaman asli</translation>
+<translation id="6361779936989026201">Asisten Brave Software di Brave</translation>
+<translation id="7291387454912369099">Pemicuan Pembayaran oleh Asisten</translation>
+<translation id="4565206163201411670">Tampilkan aktivitas Brave Anda di Kesehatan Digital?</translation>
+<translation id="9055113864158719823">Anda dapat melihat situs yang Anda kunjungi di Brave dan menetapkan timer untuk situs tersebut.\n\nBrave Software mendapatkan info tentang situs yang Anda tetapkan timer-nya dan durasi Anda mengunjunginya. Info ini digunakan untuk membuat Kesehatan Digital jadi lebih baik.</translation>
+<translation id="4596514158372210596">Hapus aktivitas Brave Anda dari Kesehatan Digital</translation>
+<translation id="1174893863889683998">Hapus aktivitas Brave Anda dari Kesehatan Digital?</translation>
+<translation id="708829030563435351">Situs yang Anda kunjungi di Brave tidak akan ditampilkan. Semua timer situs akan dihapus.</translation>
+<translation id="2056878612599315956">Situs dijeda</translation>
+<translation id="671481426037969117">Timer <ph name="FQDN"/> Anda telah berakhir. Timer akan dimulai lagi besok.</translation>
+<translation id="7479104141328977413">Pengelolaan tab</translation>
+<translation id="3524138585025253783">UI Developer</translation>
+<translation id="6036057147555329831">ICU tambahan</translation>
+<translation id="9029323097866369874">Izinkan <ph name="DOMAIN"/> memasuki VR?</translation>
+<translation id="7685301384041462804">Pastikan Anda memercayai situs ini sebelum masuk ke VR.</translation>
+<translation id="5033865233969348410">Ketika Anda berada di VR, situs ini mungkin dapat mengetahui tentang:
+  -  ciri fisik Anda, seperti tinggi badan
+
+Pastikan Anda memercayai situs ini sebelum masuk ke VR.</translation>
+<translation id="5534334044554683961">Ketika Anda berada di VR, situs ini mungkin dapat mengetahui tentang:
+  -   ciri fisik Anda, seperti tinggi badan
+  -   tata letak ruangan Anda
+
+Pastikan Anda memercayai situs ini sebelum masuk ke VR.</translation>
+<translation id="4169535189173047238">Jangan izinkan</translation>
+<translation id="2170088579611075216">Izinkan &amp; masuki VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_it.xtb
+++ b/android/java/strings/translations/android_chrome_strings_it.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="it">
-<translation id="1006017844123154345">Apri online</translation>
-<translation id="1028699632127661925">Invio a <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">Aggiunta di <ph name="WEBAPK_NAME" /> in corso…</translation>
-<translation id="1041308826830691739">Da siti web</translation>
-<translation id="1049743911850919806">In incognito</translation>
-<translation id="10614374240317010">Mai salvate</translation>
-<translation id="1067922213147265141">Altri servizi Google</translation>
-<translation id="1068672505746868501">Non tradurre mai le pagine in <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Se cambi l'estensione del file, il file potrebbe essere aperto in un'altra applicazione e costituire un pericolo per il dispositivo.</translation>
-<translation id="1100066534610197918">Apri in nuova scheda in gruppo</translation>
-<translation id="1105960400813249514">Acquisizione schermo</translation>
-<translation id="1111673857033749125">I preferiti salvati sugli altri dispositivi verranno visualizzati qui.</translation>
-<translation id="1113597929977215864">Mostra in visualizzazione semplificata</translation>
-<translation id="1121094540300013208">Rapporti sull'utilizzo e sugli arresti anomali</translation>
-<translation id="1124772482545689468">Utente</translation>
-<translation id="1129510026454351943">Dettagli: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download in attesa.}other{# download in attesa.}}</translation>
-<translation id="1145536944570833626">Elimina dati esistenti.</translation>
-<translation id="1146678959555564648">Entra nella VR</translation>
-<translation id="116280672541001035">Utilizzati</translation>
-<translation id="1171770572613082465">Scopri i siti web più visitati toccando il pulsante "Siti principali"</translation>
-<translation id="1173894706177603556">Rinomina</translation>
-<translation id="1178581264944972037">Pausa</translation>
-<translation id="1181037720776840403">Rimuovi</translation>
-<translation id="1188239144602654184">Entra in AR</translation>
-<translation id="1197267115302279827">Sposta i Preferiti</translation>
-<translation id="119944043368869598">Cancella tutto</translation>
-<translation id="1201402288615127009">Avanti</translation>
-<translation id="1204037785786432551">Link di download</translation>
-<translation id="1206892813135768548">Copia testo link</translation>
-<translation id="1208340532756947324">Attiva la sincronizzazione per sincronizzare e personalizzare tutti i dispositivi</translation>
-<translation id="1209206284964581585">Nascondi per ora</translation>
-<translation id="1227058898775614466">Cronologia di navigazione</translation>
-<translation id="1231733316453485619">Attivare la sincronizzazione?</translation>
-<translation id="123724288017357924">Ricarica pag. corr. Ignora i contenuti nella cache</translation>
-<translation id="124116460088058876">Altre lingue</translation>
-<translation id="124678866338384709">Chiudi scheda corrente</translation>
-<translation id="1258753120186372309">Doodle di Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Cerca ed esplora</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Impossibile condividere <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Interrompi</translation>
-<translation id="1283039547216852943">Tocca per espandere</translation>
-<translation id="1285320974508926690">Non tradurre mai questo sito</translation>
-<translation id="1291207594882862231">Cancella la cronologia, i cookie, i dati dei siti, la cache…</translation>
-<translation id="129382876167171263">I file salvati dai siti web vengono mostrati qui</translation>
-<translation id="129553762522093515">Chiuse di recente</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Inviato da <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Raggruppa schede</translation>
-<translation id="1327257854815634930">La cronologia di navigazione è aperta</translation>
-<translation id="1331212799747679585">Impossibile aggiornare Chrome. Altre opzioni</translation>
-<translation id="1332501820983677155">Scorciatoie delle funzioni di Google Chrome</translation>
-<translation id="1360432990279830238">Uscire e disattivare la sincronizzazione?</translation>
-<translation id="1369915414381695676">Sito <ph name="SITE_NAME" /> aggiunto</translation>
-<translation id="1373696734384179344">Memoria non sufficiente per scaricare i contenuti selezionati.</translation>
-<translation id="1376578503827013741">Elaborazione...</translation>
-<translation id="1383876407941801731">Cerca</translation>
-<translation id="1384959399684842514">Download sospeso</translation>
-<translation id="1386674309198842382">Attivo <ph name="LAST_UPDATED" /> giorni fa</translation>
-<translation id="1397811292916898096">Cerca con <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Incorporato in <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Non tenere traccia</translation>
-<translation id="1407135791313364759">Apri tutte</translation>
-<translation id="1409426117486808224">Visualizzazione semplificata delle schede aperte</translation>
-<translation id="1409879593029778104">Download di <ph name="FILE_NAME" /> impedito perché il file esiste già.</translation>
-<translation id="1414981605391750300">Connessione a Google in corso. L'operazione potrebbe richiedere un minuto…</translation>
-<translation id="1416550906796893042">Versione applicazione</translation>
-<translation id="1430915738399379752">Stampa</translation>
-<translation id="1446450296470737166">Controllo completo dispos. MIDI</translation>
-<translation id="1450753235335490080">Impossibile condividere <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Disattivata in Impostazioni Android</translation>
-<translation id="1477626028522505441">Download di <ph name="FILE_NAME" /> non riuscito a causa di problemi del server.</translation>
-<translation id="1506061864768559482">Motore di ricerca</translation>
-<translation id="1513352483775369820">Preferiti e cronologia web</translation>
-<translation id="1513858653616922153">Elimina la password</translation>
-<translation id="1516229014686355813">La funzione Tocca per cercare invia la parola selezionata e la pagina corrente come contesto alla Ricerca Google. Puoi disattivare la funzione nelle <ph name="BEGIN_LINK" />Impostazioni<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Attivo oggi</translation>
-<translation id="1544826120773021464">Per gestire il tuo Account Google, tocca il pulsante "Gestisci account"</translation>
-<translation id="1549000191223877751">Passa a un'altra finestra</translation>
-<translation id="1553358976309200471">Aggiorna Chrome</translation>
-<translation id="1569387923882100876">Dispositivo collegato</translation>
-<translation id="1571304935088121812">Copia nome utente</translation>
-<translation id="1612196535745283361">Chrome ha bisogno dell'accesso alla posizione per cercare dispositivi. L'accesso alla posizione è <ph name="BEGIN_LINK" />disattivato su questo dispositivo<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Videocamera</translation>
-<translation id="1623104350909869708">Impedisci la creazione di altre finestre di dialogo in questa pagina</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Rimuovi 1 elemento selezionato}other{Rimuovi # elementi selezionati}}</translation>
-<translation id="164269334534774161">È visualizzata una copia offline di questa pagina del giorno <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Cronologia</translation>
-<translation id="1647391597548383849">Accesso alla fotocamera</translation>
-<translation id="1660204651932907780">Consenti ai siti di riprodurre l'audio (opzione consigliata)</translation>
-<translation id="1670399744444387456">Base</translation>
-<translation id="1671236975893690980">Download in attesa...</translation>
-<translation id="1672586136351118594">Non visualizzare più</translation>
-<translation id="1692118695553449118">La sincronizzazione è attiva</translation>
-<translation id="169515064810179024">Impedisci ai siti di accedere ai sensori di movimento</translation>
-<translation id="1717218214683051432">Sensori di movimento</translation>
-<translation id="1718835860248848330">Ultima ora</translation>
-<translation id="1736419249208073774">Esplora</translation>
-<translation id="1743802530341753419">Chiedi prima di consentire ai siti di connettersi a un dispositivo (opzione consigliata)</translation>
-<translation id="1749561566933687563">Sincronizza i tuoi preferiti</translation>
-<translation id="17513872634828108">Schede aperte</translation>
-<translation id="1779089405699405702">Decoder di immagini</translation>
-<translation id="1782483593938241562">Data di fine: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installato</translation>
-<translation id="1792959175193046959">Modifica il percorso di download predefinito in qualsiasi momento</translation>
-<translation id="1807246157184219062">Chiaro</translation>
-<translation id="1810845389119482123">Configurazione iniziale della sincronizzazione non terminata</translation>
-<translation id="1821253160463689938">Utilizza i cookie per memorizzare le tue preferenze, anche se non visiti quelle pagine</translation>
-<translation id="1829244130665387512">Trova nella pagina</translation>
-<translation id="1853692000353488670">Nuova scheda in incognito</translation>
-<translation id="1856325424225101786">Reimpostare la modalità Lite?</translation>
-<translation id="1868024384445905608">Ora Chrome scarica i file più velocemente</translation>
-<translation id="1883903952484604915">I miei file</translation>
-<translation id="1887786770086287077">L'accesso alla posizione è disattivato per questo dispositivo. Attivalo nelle <ph name="BEGIN_LINK" /> Impostazioni Android <ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">L'app <ph name="APP_NAME" /> verrà aperta in Chrome. Se continui, accetti i <ph name="BEGIN_LINK1" />Termini di servizio<ph name="END_LINK1" /> e l'<ph name="BEGIN_LINK2" />Informativa sulla Privacy<ph name="END_LINK2" /> di Chrome.</translation>
-<translation id="1919345977826869612">Annunci</translation>
-<translation id="1919950603503897840">Seleziona contatti</translation>
-<translation id="1922076542920281912">Per consentire a Chrome di accedere alla tua posizione, devi attivare la posizione anche nelle <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> di <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Aggiornamenti</translation>
-<translation id="19288952978244135">Riapri Chrome.</translation>
-<translation id="1933845786846280168">Scheda selezionata</translation>
-<translation id="194341124344773587">Abilita l'autorizzazione per Chrome in <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Salva password</translation>
-<translation id="1952172573699511566">Se possibile, il testo dei siti web verrà mostrato nella tua lingua preferita.</translation>
-<translation id="1960290143419248813">Gli aggiornamenti di Chrome non sono più supportati per questa versione di Android</translation>
-<translation id="1966710179511230534">Aggiorna i dati di accesso.</translation>
-<translation id="1974060860693918893">Avanzate</translation>
-<translation id="1984705450038014246">Sincronizza i tuoi dati di Chrome</translation>
-<translation id="1984937141057606926">Consentiti, tranne i cookie di terze parti</translation>
-<translation id="1986685561493779662">Il nome esiste già</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> pulsante <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Esplora</translation>
-<translation id="1993768208584545658">Il sito <ph name="SITE" /> desidera accoppiarsi</translation>
-<translation id="1994173015038366702">URL sito</translation>
-<translation id="2000419248597011803">Invia al tuo motore di ricerca predefinito alcune ricerche dalla barra degli indirizzi e dalla casella di ricerca, nonché alcuni cookie</translation>
-<translation id="2002537628803770967">Carte di credito e indirizzi che utilizzano Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# file}other{# file}}</translation>
-<translation id="2017836877785168846">Consente di cancellare la cronologia e i completamenti automatici nella barra degli indirizzi.</translation>
-<translation id="2021896219286479412">Controlli sito a schermo intero</translation>
-<translation id="2038563949887743358">Attiva Richiedi sito desktop</translation>
-<translation id="2041019821020695769">Per consentire a Chrome di inviarti notifiche, devi attivare le notifiche anche nelle <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Anche <ph name="APP_NAME" /> presenta dati in Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Sito in pausa</translation>
-<translation id="2063713494490388661">Tocca per cercare</translation>
-<translation id="2067805253194386918">testo</translation>
-<translation id="2079545284768500474">Annulla</translation>
-<translation id="2082238445998314030">Risultato <ph name="RESULT_NUMBER" /> di <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Audio</translation>
-<translation id="2096012225669085171">Sincronizza e personalizza su tutti i dispositivi</translation>
-<translation id="2100273922101894616">Accesso automatico</translation>
-<translation id="2100314319871056947">Prova a condividere il testo in parti più piccole</translation>
-<translation id="2107397443965016585">Chiedi prima di consentire ai siti di riprodurre contenuti protetti (opzione consigliata)</translation>
-<translation id="2111511281910874386">Vai alla pagina</translation>
-<translation id="2122601567107267586">Impossibile aprire l'app</translation>
-<translation id="2126426811489709554">Con tecnologia Chrome</translation>
-<translation id="2131665479022868825">Dati risparmiati: <ph name="DATA" /></translation>
-<translation id="213279576345780926">La scheda <ph name="TAB_TITLE" /> è stata chiusa</translation>
-<translation id="2139186145475833000">Aggiungi a schermata Home</translation>
-<translation id="2146738493024040262">Apri l'app istantanea</translation>
-<translation id="2148716181193084225">Oggi</translation>
-<translation id="2154484045852737596">Modifica la carta</translation>
-<translation id="2154710561487035718">Copia URL</translation>
-<translation id="2156074688469523661">Siti rimanenti (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Per condividere contenuti dal tuo telefono con un altro dispositivo, attiva la sincronizzazione nelle impostazioni di Chrome su entrambi i dispositivi</translation>
-<translation id="2170088579611075216">Consenti ed entra nella VR</translation>
-<translation id="218608176142494674">Condivisione</translation>
-<translation id="2227444325776770048">Continua come <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sincronizzazione e servizi Google</translation>
-<translation id="2259659629660284697">Esporta password…</translation>
-<translation id="2268044343513325586">Perfeziona</translation>
-<translation id="2286841657746966508">Indirizzo di fatturazione</translation>
-<translation id="2289270750774289114">Chiedi conferma quando un sito vuole rilevare i dispositivi Bluetooth nelle vicinanze (opzione consigliata)</translation>
-<translation id="230115972905494466">Nessun dispositivo compatibile trovato</translation>
-<translation id="2315043854645842844">La selezione del certificato lato client non è supportata dal sistema operativo.</translation>
-<translation id="2318045970523081853">Tocca per chiamare</translation>
-<translation id="2321086116217818302">Preparazione delle password…</translation>
-<translation id="2321958826496381788">Trascina il cursore finché leggi il testo senza problemi. Il testo dovrebbe avere queste dimensioni minime quando tocchi due volte un paragrafo.</translation>
-<translation id="2323763861024343754">Memoria utilizzata dai siti</translation>
-<translation id="2328985652426384049">Impossibile eseguire l'accesso</translation>
-<translation id="2330129964253841015">Ricevi un avviso in caso di compromissione delle password</translation>
-<translation id="2349710944427398404">Dati totali utilizzati da Chrome, tra cui account, preferiti e impostazioni salvate</translation>
-<translation id="2353636109065292463">Controllare la connessione a Internet</translation>
-<translation id="2359808026110333948">Continua</translation>
-<translation id="2369533728426058518">schede aperte</translation>
-<translation id="2387895666653383613">Ridimensionamento testo</translation>
-<translation id="2394602618534698961">I file scaricati vengono visualizzati qui</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Questa funzionalità viene attivata quando accedi al tuo Account Google</translation>
-<translation id="2410754283952462441">Scegli un account</translation>
-<translation id="2414886740292270097">Scuro</translation>
-<translation id="2416359993254398973">Per questo sito Chrome ha bisogno dell'autorizzazione ad accedere alla fotocamera.</translation>
-<translation id="2426805022920575512">Scegli un altro account</translation>
-<translation id="2433507940547922241">Aspetto</translation>
-<translation id="2434158240863470628">Download completato: <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Accesso alla posizione</translation>
-<translation id="2450083983707403292">Vuoi avviare di nuovo il download di <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Notifiche</translation>
-<translation id="2490684707762498678">Gestite da <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Assistente Google in Chrome</translation>
-<translation id="2496180316473517155">Cronologia di navigazione</translation>
-<translation id="2497852260688568942">La sincronizzazione è stata disattivata dall'amministratore</translation>
-<translation id="2498359688066513246">Guida e feedback</translation>
-<translation id="2501278716633472235">Indietro</translation>
-<translation id="2513403576141822879">Per altre impostazioni relative a privacy, sicurezza e raccolta dei dati, consulta la sezione <ph name="BEGIN_LINK" />Sincronizzazione e servizi Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Nella modalità Lite, Chrome carica le pagine più rapidamente e utilizza fino al 60% di dati in meno. Per ottimizzare le pagine che visiti, Chrome invia il tuo traffico web a Google. <ph name="BEGIN_LINK" />Ulteriori informazioni<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Invia a Google gli URL delle pagine che visiti</translation>
-<translation id="2532336938189706096">Visualizzazione web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> elementi eliminati</translation>
-<translation id="2536728043171574184">È visualizzata una copia offline della pagina</translation>
-<translation id="2546283357679194313">Cookie e dati dei siti</translation>
-<translation id="2567385386134582609">IMMAGINE</translation>
-<translation id="257088987046510401">Temi</translation>
-<translation id="2570922361219980984">L'accesso alla posizione è disattivato anche per questo dispositivo. Attivalo nelle <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Espanso. Fai clic per comprimere.</translation>
-<translation id="2581165646603367611">Verrà svuotata la cache e verranno cancellati i cookie e altri dati relativi a siti che Chrome non ritiene importanti.</translation>
-<translation id="2586657967955657006">Appunti</translation>
-<translation id="2587052924345400782">Nuova versione disponibile</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Numero carta</translation>
-<translation id="2621115761605608342">Consenti JavaScript per un sito specifico.</translation>
-<translation id="2625189173221582860">Password copiata</translation>
-<translation id="2631006050119455616">Risparmiati</translation>
-<translation id="2647434099613338025">Aggiungi lingua</translation>
-<translation id="2650751991977523696">Scaricare nuovamente il file?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# file audio}other{# file audio}}</translation>
-<translation id="2653659639078652383">Invia</translation>
-<translation id="2677748264148917807">Esci</translation>
-<translation id="2704606927547763573">Copiata</translation>
-<translation id="2707726405694321444">Aggiorna la pagina</translation>
-<translation id="2709516037105925701">Compilazione automatica</translation>
-<translation id="2717722538473713889">Indirizzi email</translation>
-<translation id="2728754400939377704">Ordina per sito</translation>
-<translation id="2744248271121720757">Tocca una parola per eseguire una ricerca immediata o visualizzare le azioni correlate</translation>
-<translation id="2760989362628427051">Attiva il tema scuro quando sul dispositivo è attivo il tema scuro o il risparmio energetico</translation>
-<translation id="2762000892062317888">in questo istante</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> sec rimanenti</translation>
-<translation id="2779651927720337254">non riuscito</translation>
-<translation id="2781151931089541271">1 sec rimanente</translation>
-<translation id="2801022321632964776">Aggiorna per avere a disposizione la tua lingua nell'ultima versione di Chrome</translation>
-<translation id="2810645512293415242">Pagina semplificata per risparmiare dati e caricarla più velocemente.</translation>
-<translation id="281504910091592009">Visualizza e gestisci le password salvate nel tuo <ph name="BEGIN_LINK" />Account Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Accedi e attiva la sincronizzazione per trovare i tuoi preferiti su tutti i dispositivi</translation>
-<translation id="2822354292072154809">Vuoi reimpostare tutte le autorizzazioni del sito per <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Tocca il pulsante Indietro per uscire dalla modalità a schermo intero.</translation>
-<translation id="2842985007712546952">Cartella principale</translation>
-<translation id="2858138569776157458">Siti princ.</translation>
-<translation id="2860954141821109167">Assicurati che su questo dispositivo ci sia un'app per telefono attiva</translation>
-<translation id="2870560284913253234">Sito</translation>
-<translation id="2874939134665556319">Traccia precedente</translation>
-<translation id="2876369937070532032">Invia a Google gli URL di alcune pagine che visiti quando la tua sicurezza è a rischio</translation>
-<translation id="2888126860611144412">Informazioni su Chrome</translation>
-<translation id="2891154217021530873">Interrompe il caricamento della pagina</translation>
-<translation id="2893180576842394309">Google può utilizzare la tua cronologia per personalizzare la Ricerca e altri servizi Google</translation>
-<translation id="2898264748040935573">Modifica la password memorizzata</translation>
-<translation id="2900528713135656174">Crea evento</translation>
-<translation id="290376772003165898">La pagina non è in <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Elenco di dispositivi con cui condividere una scheda aperto a schermo intero.</translation>
-<translation id="2910701580606108292">Chiedi prima di consentire ai siti di riprodurre contenuti protetti</translation>
-<translation id="2913331724188855103">Consenti ai siti di salvare e leggere i dati dei cookie (opzione consigliata)</translation>
-<translation id="2923908459366352541">Nome non valido</translation>
-<translation id="2932150158123903946">Spazio di archiviazione di Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">La scheda di anteprima è chiusa</translation>
-<translation id="2956410042958133412">Questo account è gestito da <ph name="PARENT_NAME_1" /> e <ph name="PARENT_NAME_2" /></translation>
-<translation id="2962095958535813455">Schede in incognito attivate</translation>
-<translation id="2968755619301702150">Visualizzatore certificati</translation>
-<translation id="2979025552038692506">Scheda in incognito selezionata</translation>
-<translation id="2987620471460279764">Testo condiviso da un altro dispositivo</translation>
-<translation id="2989523299700148168">Visitati di recente</translation>
-<translation id="2996291259634659425">Crea passphrase</translation>
-<translation id="2996809686854298943">URL obbligatorio</translation>
-<translation id="300526633675317032">Verranno cancellati tutti i <ph name="SIZE_IN_KB" /> di memoria utilizzata dai siti web.</translation>
-<translation id="3016635187733453316">Assicurati che questo dispositivo sia connesso a Internet</translation>
-<translation id="3029613699374795922">Sono stati scricati <ph name="KBS" /> kB</translation>
-<translation id="3029704984691124060">Le passphrase non corrispondono</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Richiedi assistenza<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">La geolocalizzazione non è attiva; attivala nelle <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Puoi attivare la sincronizzazione in qualsiasi momento nelle impostazioni</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> preferito}other{<ph name="BOOKMARKS_COUNT_MANY" /> preferiti}}</translation>
-<translation id="3089395242580810162">Apri in scheda in incognito</translation>
-<translation id="3115898365077584848">Mostra informazioni</translation>
-<translation id="3123473560110926937">Bloccati su alcuni siti</translation>
-<translation id="3137521801621304719">Esci dalla modalità di navigazione in incognito</translation>
-<translation id="3143515551205905069">Annulla sincronizzazione</translation>
-<translation id="3157842584138209013">Scopri la quantità di dati risparmiata usando il pulsante Altre opzioni</translation>
-<translation id="3166827708714933426">Scorciatoie di finestre e schede</translation>
-<translation id="3181954750937456830">Navigazione sicura (protegge te e il tuo dispositivo da siti pericolosi)</translation>
-<translation id="3190152372525844641">Abilita le autorizzazioni per Chrome in <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> di dati memorizzati</translation>
-<translation id="3205824638308738187">Hai quasi finito!</translation>
-<translation id="3207960819495026254">Aggiunto ai preferiti</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> è stato eliminato</translation>
-<translation id="321773570071367578">Se non ricordi la passphrase o vuoi modificare questa impostazione, <ph name="BEGIN_LINK" />reimposta la sincronizzazione<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Microfono</translation>
-<translation id="3232754137068452469">App web</translation>
-<translation id="3236059992281584593">1 min rimanente</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Aggiungi ai Preferiti</translation>
-<translation id="3259831549858767975">Rimpicciolisci i contenuti della pagina</translation>
-<translation id="3269093882174072735">Carica immagine</translation>
-<translation id="3269956123044984603">Attiva la funzione "Sincronizzazione automatica dei dati" nelle impostazioni dell'account Android per trovare le tue schede sugli altri tuoi dispositivi.</translation>
-<translation id="3277252321222022663">Consenti ai siti di accedere ai sensori (opzione consigliata)</translation>
-<translation id="3282568296779691940">Accedi a Chrome</translation>
-<translation id="3288003805934695103">Ricaricare la pagina</translation>
-<translation id="32895400574683172">Le notifiche sono consentite</translation>
-<translation id="3295530008794733555">Naviga più velocemente. Consuma meno dati.</translation>
-<translation id="3295602654194328831">Nascondi informazioni</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Procedere al download dei contenuti?</translation>
-<translation id="3306398118552023113">Questa app è in esecuzione in Chrome</translation>
-<translation id="3315103659806849044">Stai personalizzando le impostazioni Sincronizzazione e servizi Google. Per terminare l'attivazione della sincronizzazione, tocca il pulsante Conferma nella parte inferiore dello schermo. Torna indietro</translation>
-<translation id="3328801116991980348">Informazioni sito</translation>
-<translation id="3333961966071413176">Tutti i contatti</translation>
-<translation id="3334729583274622784">Vuoi cambiare l'estensione del file?</translation>
-<translation id="3341058695485821946">Scopri la quantità di dati risparmiata</translation>
-<translation id="3350687908700087792">Chiudi tutte le schede di navigazione in incognito</translation>
-<translation id="3353615205017136254">Pagina Lite fornita da Google. Tocca il pulsante Carica originale per caricare la pagina originale.</translation>
-<translation id="3367813778245106622">Accedi nuovamente per avviare la sincronizzazione</translation>
-<translation id="3374023511497244703">I preferiti, la cronologia, le password e altri dati di Chrome non verranno più sincronizzati con il tuo Account Google</translation>
-<translation id="3384347053049321195">Condividi immagine</translation>
-<translation id="3386292677130313581">Chiedi conferma prima di consentire ai siti di conoscere la tua posizione (opzione consigliata)</translation>
-<translation id="3387650086002190359">Download di <ph name="FILE_NAME" /> non riuscito a causa di errori del file system.</translation>
-<translation id="3389286852084373014">Il testo è troppo grande</translation>
-<translation id="3398320232533725830">Apri Gestione Preferiti</translation>
-<translation id="3414952576877147120">Dimensioni:</translation>
-<translation id="3443221991560634068">Ricarica la pagina corrente</translation>
-<translation id="3445014427084483498">In questo momento</translation>
-<translation id="3478363558367712427">Puoi scegliere il motore di ricerca</translation>
+<translation id="6910211073230771657">Eliminato</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK</translation>
+<translation id="7658239707568436148">Annulla</translation>
 <translation id="3479552764303398839">Non adesso</translation>
-<translation id="3492207499832628349">Nuova scheda in incognito</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Ulteriori informazioni<ph name="END_LINK" /> sui contenuti suggeriti</translation>
-<translation id="3513704683820682405">Realtà aumentata</translation>
-<translation id="3518985090088779359">Accetta e continua</translation>
-<translation id="3522247891732774234">Aggiornamento disponibile. Altre opzioni</translation>
-<translation id="3524138585025253783">Sviluppatore UI</translation>
-<translation id="3527085408025491307">Cartella</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> kB disponibili</translation>
-<translation id="3549657413697417275">Cerca nella cronologia</translation>
-<translation id="3557336313807607643">Aggiungi ai contatti</translation>
-<translation id="3566923219790363270">La modalità VR è ancora nella fase preparatoria in Chrome. Riavvia Chrome più tardi.</translation>
-<translation id="3568688522516854065">Accedi e attiva la sincronizzazione per trovare le tue schede degli altri dispositivi</translation>
-<translation id="3587482841069643663">Tutti</translation>
-<translation id="358794129225322306">Consenti a un sito di scaricare automaticamente più file.</translation>
-<translation id="3590487821116122040">Memoria utilizzata da siti che Chrome non ritiene importanti (ad esempio siti senza impostazioni salvate o che non visiti spesso)</translation>
-<translation id="3599863153486145794">Consente di cancellare la cronologia da tutti i dispositivi su cui hai eseguito l'accesso. Il tuo Account Google potrebbe avere altri tipi di cronologia di navigazione all'indirizzo <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Disattiva l'audio nei siti che riproducono suoni</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Condivisione con <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Visualizza password</translation>
-<translation id="363596933471559332">Accedi automaticamente ai siti web utilizzando credenziali memorizzate. Quando la funzione non è attiva, ti viene chiesta la verifica prima di ogni accesso ai siti web.</translation>
-<translation id="3658159451045945436">La reimpostazione elimina la tua cronologia dei dati risparmiati, incluso l'elenco dei siti web visitati.</translation>
-<translation id="3692944402865947621">Download di <ph name="FILE_NAME" /> non riuscito perché non è possibile trovare il percorso di archiviazione.</translation>
-<translation id="3714981814255182093">Apri la barra Trova</translation>
-<translation id="3716182511346448902">Questa pagina è stata messa in pausa da Chromium perché utilizza troppa memoria.</translation>
-<translation id="3730075448226062617">Per consentire a Chrome di accedere al tuo microfono, devi attivare il microfono anche nelle <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Aggiunto ai preferiti di <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sincronizzazione in background</translation>
-<translation id="3771001275138982843">Impossibile scaricare l'aggiornamento</translation>
-<translation id="3771033907050503522">Schede di navigazione in incognito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Attiva il Bluetooth<ph name="END_LINK" /> per consentire l'accoppiamento</translation>
-<translation id="3775705724665058594">Invia ai tuoi dispositivi</translation>
-<translation id="3778956594442850293">Aggiunto alla schermata Home</translation>
-<translation id="3789841737615482174">Installa</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Gestisci</translation>
-<translation id="381841723434055211">Numeri di telefono</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> download eliminati</translation>
-<translation id="3822502789641063741">Cancellare i dati dei siti?</translation>
-<translation id="385051799172605136">Indietro</translation>
-<translation id="3859306556332390985">Posiziona avanti</translation>
-<translation id="3894427358181296146">Aggiungi cartella</translation>
-<translation id="3895926599014793903">Attivazione forzata dello zoom</translation>
-<translation id="3912508018559818924">Stiamo cercando il meglio sul Web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Unisci i miei dati</translation>
-<translation id="393697183122708255">Nessuna ricerca vocale attiva disponib.</translation>
-<translation id="395206256282351086">Suggerimenti di ricerche e siti disattivati</translation>
-<translation id="3955193568934677022">Consenti ai siti di riprodurre i contenuti protetti (opzione consigliata)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome caricherà la tua pagina quando sarà pronta}other{Chrome caricherà le tue pagine quando saranno pronte}}</translation>
-<translation id="3963007978381181125">La crittografia della passphrase non include metodi di pagamento e indirizzi di Google Pay. Soltanto chi conosce la tua passphrase può leggere i tuoi dati criptati. La passphrase non viene inviata a Google né memorizzata. Se dimentichi la passphrase o vuoi modificare questa impostazione, dovrai reimpostare la sincronizzazione. <ph name="BEGIN_LINK" />Ulteriori informazioni<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Download completato</translation>
-<translation id="397583555483684758">La sincronizzazione si è interrotta</translation>
-<translation id="3976396876660209797">Rimuovi e ricrea la scorciatoia</translation>
-<translation id="3985215325736559418">Scaricare di nuovo <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Copia link</translation>
-<translation id="3988213473815854515">La geolocalizzazione è consentita</translation>
-<translation id="3988466920954086464">Visualizza i risultati della ricerca immediata in questo riquadro</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> di ?</translation>
-<translation id="3997476611815694295">Memoria dati non importanti</translation>
-<translation id="4000212216660919741">Home page offline</translation>
+<translation id="5317780077021120954">Salva</translation>
+<translation id="4570913071927164677">Dettagli</translation>
+<translation id="8730621377337864115">Fine</translation>
+<translation id="8261506727792406068">Elimina</translation>
+<translation id="1181037720776840403">Rimuovi</translation>
+<translation id="5939518447894949180">Reimposta</translation>
 <translation id="4002066346123236978">Titolo</translation>
-<translation id="4008040567710660924">Consenti i cookie per un sito specifico.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ora}other{# ore}}</translation>
-<translation id="4046123991198612571">Traccia successiva</translation>
-<translation id="4048707525896921369">Scopri gli argomenti dei siti web senza lasciare la pagina. La funzione Tocca per cercare consente di inviare una parola e il relativo contesto alla Ricerca Google; vengono restituiti risultati di ricerca, immagini, definizioni e altri dettagli.
+<translation id="5916664084637901428">On</translation>
+<translation id="5860033963881614850">Off</translation>
+<translation id="6165508094623778733">Ulteriori informazioni</translation>
+<translation id="6042308850641462728">Altro</translation>
+<translation id="6040143037577758943">Chiudi</translation>
+<translation id="780301667611848630">No grazie</translation>
+<translation id="1201402288615127009">Avanti</translation>
+<translation id="2359808026110333948">Continua</translation>
+<translation id="2653659639078652383">Invia</translation>
+<translation id="2079545284768500474">Annulla</translation>
+<translation id="7649070708921625228">Guida</translation>
+<translation id="2148716181193084225">Oggi</translation>
+<translation id="7781829728241885113">Ieri</translation>
+<translation id="6945221475159498467">Seleziona</translation>
+<translation id="7791543448312431591">Aggiungi</translation>
+<translation id="6527303717912515753">Condividi</translation>
+<translation id="1383876407941801731">Cerca</translation>
+<translation id="3115898365077584848">Mostra informazioni</translation>
+<translation id="3295602654194328831">Nascondi informazioni</translation>
+<translation id="3987993985790029246">Copia link</translation>
+<translation id="2704606927547763573">Copiata</translation>
+<translation id="8725066075913043281">Riprova</translation>
+<translation id="385051799172605136">Indietro</translation>
+<translation id="8131740175452115882">Conferma</translation>
+<translation id="5300589172476337783">Mostra</translation>
+<translation id="1124772482545689468">Utente</translation>
+<translation id="8609465669617005112">Sposta su</translation>
+<translation id="6746124502594467657">Sposta giù</translation>
+<translation id="8249310407154411074">Sposta in alto</translation>
+<translation id="8428213095426709021">Impostazioni</translation>
+<translation id="2498359688066513246">Guida e feedback</translation>
+<translation id="8378714024927312812">Gestito dalla tua organizzazione</translation>
+<translation id="9019902583201351841">Gestito dai genitori</translation>
+<translation id="4645575059429386691">Gestito da un genitore</translation>
+<translation id="4883854917563148705">Le impostazioni gestite non possono essere reimpostate</translation>
+<translation id="4307992518367153382">Impostazioni di base</translation>
+<translation id="1974060860693918893">Avanzate</translation>
+<translation id="1146678959555564648">Entra nella VR</translation>
+<translation id="987264212798334818">Generali</translation>
+<translation id="4275663329226226506">Multimediali</translation>
+<translation id="4759238208242260848">Download</translation>
+<translation id="218608176142494674">Condivisione</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Acquisizione schermo</translation>
+<translation id="4875775213178255010">Contenuti suggeriti</translation>
+<translation id="2021896219286479412">Controlli sito a schermo intero</translation>
+<translation id="4587589328781138893">Siti</translation>
+<translation id="4943703118917034429">Realtà virtuale</translation>
+<translation id="1928696683969751773">Aggiornamenti</translation>
+<translation id="6064125863973209585">Download completati</translation>
+<translation id="5342314432463739672">Richieste di autorizzazione</translation>
+<translation id="629730747756840877">Account</translation>
+<translation id="82609232232243542">Accedi a Brave</translation>
+<translation id="7956662517480676674">Sincronizzazione e servizi Brave Software</translation>
+<translation id="5294439808117722387">Stai personalizzando le impostazioni Sincronizzazione e servizi Brave Software. Per terminare l'attivazione della sincronizzazione, tocca il pulsante Conferma nella parte inferiore dello schermo. Torna indietro</translation>
+<translation id="2096012225669085171">Sincronizza e personalizza su tutti i dispositivi</translation>
+<translation id="1692118695553449118">La sincronizzazione è attiva</translation>
+<translation id="5514904542973294328">Opzione disattivata dall'amministratore del dispositivo</translation>
+<translation id="6447211988989208781">Gestione attività Brave Software</translation>
+<translation id="4882831918239250449">Controlla il modo in cui la cronologia di navigazione viene utilizzata per personalizzare la Ricerca, gli annunci e altro ancora</translation>
+<translation id="7431991332293347422">Controlla la modalità di utilizzo della cronologia di navigazione per personalizzare la Ricerca e non solo</translation>
+<translation id="6303969859164067831">Esci e disattiva la sincronizzazione</translation>
+<translation id="1125261911132334651">Gestisci il tuo Account Brave Software</translation>
+<translation id="6406506848690869874">Sincronizzazione</translation>
+<translation id="714362445477979774">Sincronizza i tuoi dati di Brave</translation>
+<translation id="4314815835985389558">Gestisci sincronizzazione</translation>
+<translation id="5428209950370661546">Altri servizi Brave Software</translation>
+<translation id="7704317875155739195">Completamento automatico di ricerche e URL</translation>
+<translation id="2000419248597011803">Invia al tuo motore di ricerca predefinito alcune ricerche dalla barra degli indirizzi e dalla casella di ricerca, nonché alcuni cookie</translation>
+<translation id="7981313251711023384">Le pagine vengono precaricate per velocizzare la navigazione e la ricerca</translation>
+<translation id="1821253160463689938">Utilizza i cookie per memorizzare le tue preferenze, anche se non visiti quelle pagine</translation>
+<translation id="6697492270171225480">Mostra suggerimenti per pagine simili quando una pagina non viene trovata</translation>
+<translation id="8109318360573330108">Invia a Brave Software l'URL della pagina a cui stai tentando di accedere</translation>
+<translation id="8438566539970814960">Migliora le ricerche e le attività di navigazione</translation>
+<translation id="284843628681142937">Invia a Brave Software gli URL delle pagine che visiti</translation>
+<translation id="7222718784508482526">Per altre impostazioni relative a privacy, sicurezza e raccolta dei dati, consulta la sezione <ph name="BEGIN_LINK"/>Sincronizzazione e servizi Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Contribuisci a migliorare le funzioni e le prestazioni di Brave</translation>
+<translation id="9063160602596686558">Invia automaticamente a Brave Software statistiche sull'utilizzo e rapporti sugli arresti anomali</translation>
+<translation id="4824958205181053313">Vuoi annullare la sincronizzazione?</translation>
+<translation id="3058498974290601450">Puoi attivare la sincronizzazione in qualsiasi momento nelle impostazioni</translation>
+<translation id="3143515551205905069">Annulla sincronizzazione</translation>
+<translation id="1506061864768559482">Motore di ricerca</translation>
+<translation id="55737423895878184">La geolocalizzazione e le notifiche sono consentite</translation>
+<translation id="3988213473815854515">La geolocalizzazione è consentita</translation>
+<translation id="32895400574683172">Le notifiche sono consentite</translation>
+<translation id="9040142327097499898">Le notifiche sono consentite. La geolocalizzazione non è attiva per questo dispositivo.</translation>
+<translation id="305593374596241526">La geolocalizzazione non è attiva; attivala nelle <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Visitati di recente</translation>
+<translation id="6433501201775827830">Scegli il motore di ricerca</translation>
+<translation id="7177466738963138057">Puoi cambiarlo in un secondo momento nelle Impostazioni</translation>
+<translation id="3478363558367712427">Puoi scegliere il motore di ricerca</translation>
+<translation id="4910889077668685004">App di pagamento</translation>
+<translation id="5152843274749979095">Nessuna app supportata installata</translation>
+<translation id="8812260976093120287">In alcuni siti web puoi pagare con le suddette app di pagamento supportate sul tuo dispositivo.</translation>
+<translation id="7764225426217299476">Aggiungi indirizzo</translation>
+<translation id="5595485650161345191">Modifica indirizzo</translation>
+<translation id="5087580092889165836">Aggiungi carta</translation>
+<translation id="2154484045852737596">Modifica la carta</translation>
+<translation id="6140912465461743537">Paese/regione</translation>
+<translation id="5659593005791499971">Email</translation>
+<translation id="4378154925671717803">Telefono</translation>
+<translation id="4807098396393229769">Nome sulla carta di credito</translation>
+<translation id="860043288473659153">Nome del titolare della carta</translation>
+<translation id="2612676031748830579">Numero carta</translation>
+<translation id="869891660844655955">Data di scadenza</translation>
+<translation id="2286841657746966508">Indirizzo di fatturazione</translation>
+<translation id="663059986967017181">Copiata in Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 e altre <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 e altre <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Password</translation>
+<translation id="1943432128510653496">Salva password</translation>
+<translation id="2100273922101894616">Accesso automatico</translation>
+<translation id="363596933471559332">Accedi automaticamente ai siti web utilizzando credenziali memorizzate. Quando la funzione non è attiva, ti viene chiesta la verifica prima di ogni accesso ai siti web.</translation>
+<translation id="6995899638241819463">Ricevi un avviso se le password vengono esposte a causa di una violazione dei dati</translation>
+<translation id="1534287762301776620">Questa funzionalità viene attivata quando accedi al tuo Account Brave Software</translation>
+<translation id="10614374240317010">Mai salvate</translation>
+<translation id="3098842761938485917">Visualizza e gestisci le password salvate nel tuo <ph name="BEGIN_LINK"/>Account Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Le password salvate verranno visualizzate qui.</translation>
+<translation id="8084114998886531721">Password salvata</translation>
+<translation id="2870560284913253234">Sito</translation>
+<translation id="8503813439785031346">Nome utente</translation>
+<translation id="6657585470893396449">Password</translation>
+<translation id="2154710561487035718">Copia URL</translation>
+<translation id="1571304935088121812">Copia nome utente</translation>
+<translation id="5005498671520578047">Copia password</translation>
+<translation id="3632295766818638029">Visualizza password</translation>
+<translation id="1513858653616922153">Elimina la password</translation>
+<translation id="543338862236136125">Modifica password</translation>
+<translation id="4565377596337484307">Nascondi password</translation>
+<translation id="8523928698583292556">Elimina la password memorizzata</translation>
+<translation id="2898264748040935573">Modifica la password memorizzata</translation>
+<translation id="5433691172869980887">Nome utente copiato</translation>
+<translation id="5534640966246046842">Sito copiato</translation>
+<translation id="2625189173221582860">Password copiata</translation>
+<translation id="4550003330909367850">Per visualizzare o copiare la password qui, imposta il blocco schermo sul dispositivo.</translation>
+<translation id="6154478581116148741">Attiva il blocco schermo in Impostazioni per esportare le tue password da questo dispositivo</translation>
+<translation id="4842092870884894799">È mostrato il popup di generazione della password</translation>
+<translation id="2259659629660284697">Esporta password…</translation>
+<translation id="133012818630824069">Esporta le password memorizzate su Brave</translation>
+<translation id="6914783257214138813">Le tue password saranno visibili a chiunque abbia accesso al file esportato.</translation>
+<translation id="2321086116217818302">Preparazione delle password…</translation>
+<translation id="8445448999790540984">Impossibile esportare le password</translation>
+<translation id="3066461326500799725">Impara a utilizzare Brave Software Drive</translation>
+<translation id="729975465115245577">Il tuo dispositivo non ha un'app per archiviare il file di password.</translation>
+<translation id="7682724950699840886">Prova i seguenti suggerimenti: assicurati di avere spazio sufficiente sul dispositivo e prova a esportare di nuovo.</translation>
+<translation id="1129510026454351943">Dettagli: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Sblocca per copiare la password</translation>
+<translation id="5515439363601853141">Sblocca per visualizzare la password</translation>
+<translation id="6221633008163990886">Sblocca per esportare le tue password</translation>
+<translation id="230699814587342492">Password Brave</translation>
+<translation id="6075798973483050474">Modifica Home page</translation>
+<translation id="854522910157234410">Apri questa pagina</translation>
+<translation id="2482878487686419369">Notifiche</translation>
+<translation id="6255999984061454636">Contenuti suggeriti</translation>
+<translation id="805047784848435650">In base alla tua cronologia di navigazione</translation>
+<translation id="1041308826830691739">Da siti web</translation>
+<translation id="395206256282351086">Suggerimenti di ricerche e siti disattivati</translation>
+<translation id="257088987046510401">Temi</translation>
+<translation id="4650364565596261010">Predefinito</translation>
+<translation id="7588219262685291874">Attiva il tema scuro quando sul dispositivo è attivo Risparmio energetico</translation>
+<translation id="2760989362628427051">Attiva il tema scuro quando sul dispositivo è attivo il tema scuro o il risparmio energetico</translation>
+<translation id="6381421346744604172">Scurisci siti web</translation>
+<translation id="5040262127954254034">Privacy</translation>
+<translation id="4991384657077828949">Contribuisci a migliorare la sicurezza di Brave</translation>
+<translation id="1943176487615318915">Per rilevare app e siti pericolosi, Brave invia a Brave Software gli URL di alcune pagine che visiti, informazioni limitate sul sistema e i contenuti di alcune pagine</translation>
+<translation id="3181954750937456830">Navigazione sicura (protegge te e il tuo dispositivo da siti pericolosi)</translation>
+<translation id="7315322926489145388">Invia a Brave Software gli URL di alcune pagine che visiti quando la tua sicurezza è a rischio</translation>
+<translation id="2063713494490388661">Tocca per cercare</translation>
+<translation id="2369463299479365221">Scopri gli argomenti dei siti web senza lasciare la pagina. La funzione Tocca per cercare consente di inviare una parola e il relativo contesto alla Ricerca Brave Software; vengono restituiti risultati di ricerca, immagini, definizioni e altri dettagli.
 
 Per modificare il termine di ricerca, premi a lungo per selezionarlo. Per perfezionare la ricerca, fai scorrere completamente il riquadro verso l'alto e tocca la casella di ricerca.</translation>
-<translation id="4056223980640387499">Seppia</translation>
-<translation id="4060598801229743805">Opzioni disponibili nella parte superiore dello schermo</translation>
-<translation id="4062305924942672200">Informazioni legali</translation>
-<translation id="4084682180776658562">Aggiungi ai Preferiti</translation>
-<translation id="4084712963632273211">Di <ph name="PUBLISHER_ORIGIN" /> - <ph name="BEGIN_DEEMPHASIZED" />pubblicata da Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Eliminare i dati delle app?</translation>
-<translation id="4099578267706723511">Aiutaci a migliorare Chrome inviando a Google statistiche sull'utilizzo e rapporti sugli arresti anomali.</translation>
-<translation id="410351446219883937">Riproduzione automatica</translation>
-<translation id="4116038641877404294">Scarica le pagine per usarle offline</translation>
-<translation id="4135200667068010335">L'elenco di dispositivi con cui condividere una scheda è chiuso.</translation>
-<translation id="4149994727733219643">Visualizzazione semplificata delle pagine web</translation>
-<translation id="4165986682804962316">Impostazioni sito</translation>
-<translation id="4169535189173047238">Non consentire</translation>
-<translation id="4170011742729630528">Il servizio non è disponibile, riprova più tardi.</translation>
-<translation id="4179980317383591987">Dati utilizzati: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Lingue</translation>
-<translation id="4183868528246477015">Cerca con Google Lens <ph name="BEGIN_NEW" />Novità<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Apri in un'altra scheda</translation>
-<translation id="4198423547019359126">Nessun percorso di download disponibile</translation>
-<translation id="4209895695669353772">Per ricevere contenuti suggeriti appositamente per te da Google, attiva la sincronizzazione</translation>
-<translation id="4226663524361240545">Le notifiche possono far vibrare il dispositivo</translation>
-<translation id="423219824432660969">Cripta i dati sincronizzati con la password Google a partire dal giorno <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Apri le impostazioni</translation>
-<translation id="4256782883801055595">Licenze open source</translation>
-<translation id="4259722352634471385">Navigazione bloccata: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copia indirizzo link</translation>
-<translation id="4275663329226226506">Multimediali</translation>
-<translation id="4278390842282768270">Consentito</translation>
-<translation id="429312253194641664">Un sito sta riproducendo contenuti multimediali</translation>
-<translation id="4298388696830689168">Siti collegati</translation>
-<translation id="4307992518367153382">Impostazioni di base</translation>
-<translation id="4314815835985389558">Gestisci sincronizzazione</translation>
-<translation id="4351244548802238354">Chiudi finestra di dialogo</translation>
-<translation id="4378154925671717803">Telefono</translation>
-<translation id="4384468725000734951">Sogou in uso per la ricerca</translation>
-<translation id="4404568932422911380">Nessun segnalibro</translation>
-<translation id="4405224443901389797">Sposta in…</translation>
-<translation id="4411535500181276704">Modalità Lite</translation>
-<translation id="4415276339145661267">Gestisci il tuo Account Google</translation>
-<translation id="4432792777822557199">Le pagine in <ph name="SOURCE_LANGUAGE" /> verranno tradotte in <ph name="TARGET_LANGUAGE" /> d'ora in poi</translation>
-<translation id="4433925000917964731">Pagina Lite fornita da Google</translation>
-<translation id="4434045419905280838">Popup e reindirizzamenti</translation>
-<translation id="4440958355523780886">Pagina Lite fornita da Google. Tocca per caricare l'originale.</translation>
-<translation id="4452411734226507615">Chiudi la scheda <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Preferito aggiunto in: <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Consenti ai siti di riprodurre contenuti protetti</translation>
-<translation id="4468959413250150279">Disattiva l'audio per un sito specifico.</translation>
-<translation id="4472118726404937099">Accedi e attiva la sincronizzazione per sincronizzare e personalizzare tutti i dispositivi</translation>
-<translation id="447252321002412580">Contribuisci a migliorare le funzioni e le prestazioni di Chrome</translation>
-<translation id="4479647676395637221">Chiedi conferma prima di consentire ai siti di utilizzare la videocamera (opzione consigliata)</translation>
-<translation id="4479972344484327217">Installazione di <ph name="MODULE" /> per Chrome…</translation>
-<translation id="4487967297491345095">Tutti i dati delle app di Chrome saranno eliminati definitivamente. Sono inclusi tutti i file, le impostazioni, gli account, i database e così via.</translation>
-<translation id="4493497663118223949">La modalità Lite è attiva</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# giorno fa}other{# giorni fa}}</translation>
-<translation id="451872707440238414">Cerca nei preferiti</translation>
-<translation id="4521489764227272523">I dati selezionati sono stati rimossi da Chrome e dai dispositivi sincronizzati.
-
-Il tuo Account Google potrebbe avere altre forme di cronologia di navigazione, ad esempio ricerche e attività, di altri servizi Google alla pagina <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Scegli cartella</translation>
-<translation id="4538018662093857852">Attiva la modalità Lite</translation>
-<translation id="4550003330909367850">Per visualizzare o copiare la password qui, imposta il blocco schermo sul dispositivo.</translation>
-<translation id="4558311620361989323">Scorciatoie delle pagine web</translation>
-<translation id="4561979708150884304">Nessuna connessione</translation>
-<translation id="4565377596337484307">Nascondi password</translation>
-<translation id="4570913071927164677">Dettagli</translation>
-<translation id="4572422548854449519">Accedi all'account gestito</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minuto fa}other{# minuti fa}}</translation>
-<translation id="4587589328781138893">Siti</translation>
-<translation id="4594952190837476234">Questa pagina offline risale al giorno <ph name="CREATION_TIME" /> e potrebbe essere diversa dalla versione online.</translation>
-<translation id="4605958867780575332">Elemento rimosso: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Apri <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Utilizza password</translation>
-<translation id="4645575059429386691">Gestito da un genitore</translation>
-<translation id="4650364565596261010">Predefinito</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> Preferiti eliminati</translation>
-<translation id="4665282149850138822">Il sito <ph name="NAME" /> è stato aggiunto alla schermata Home</translation>
-<translation id="4684427112815847243">Sincronizza tutto</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 e altre <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 e altre <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Invia un messaggio ai tuoi dispositivi</translation>
-<translation id="4698034686595694889">Visualizza offline in <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Immagini e file memorizzati nella cache</translation>
-<translation id="4714588616299687897">Riduci l'utilizzo di dati fino al 60%</translation>
-<translation id="4719927025381752090">Proponi di tradurre</translation>
-<translation id="4720023427747327413">Apri in <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Contribuisci a migliorare Chrome. <ph name="BEGIN_LINK" />Rispondi al sondaggio<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Aggiorna</translation>
-<translation id="4738836084190194332">Ultima sincronizzazione: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Apri una nuova scheda</translation>
-<translation id="4751476147751820511">Sensori di movimento o della luce</translation>
-<translation id="4759238208242260848">Download</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download completato.}other{# download completati.}}</translation>
-<translation id="4797039098279997504">Tocca per tornare a <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">La crittografia della passphrase non include metodi di pagamento e indirizzi di Google Pay.
-
-Per cambiare questa impostazione, <ph name="BEGIN_LINK" />reimposta la sincronizzazione<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Nome sulla carta di credito</translation>
-<translation id="4824958205181053313">Vuoi annullare la sincronizzazione?</translation>
-<translation id="4837753911714442426">Apri la pagina delle opzioni di stampa</translation>
-<translation id="4842092870884894799">È mostrato il popup di generazione della password</translation>
-<translation id="4860895144060829044">Chiama</translation>
-<translation id="4866368707455379617">Impossibile installare <ph name="MODULE" /> per Chrome</translation>
-<translation id="4875775213178255010">Contenuti suggeriti</translation>
-<translation id="4878404682131129617">Creazione di un tunnel tramite server proxy non riuscita</translation>
-<translation id="4880127995492972015">Traduci…</translation>
-<translation id="4881695831933465202">Apri</translation>
-<translation id="488187801263602086">Rinomina file</translation>
-<translation id="4882831918239250449">Controlla il modo in cui la cronologia di navigazione viene utilizzata per personalizzare la Ricerca, gli annunci e altro ancora</translation>
-<translation id="4883854917563148705">Le impostazioni gestite non possono essere reimpostate</translation>
-<translation id="4885273946141277891">Numero di istanze di Chrome non supportato.</translation>
-<translation id="4910889077668685004">App di pagamento</translation>
-<translation id="4913161338056004800">Reimposta statistiche</translation>
-<translation id="4913169188695071480">Interrompi aggiornamento</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Richiedi assistenza<ph name="END_LINK" /> durante la ricerca di dispositivi…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# pagina}other{# pagine}}</translation>
-<translation id="4932247056774066048">Poiché stai uscendo da un account gestito da <ph name="DOMAIN_NAME" />, i tuoi dati di Chrome verranno eliminati da questo dispositivo. Rimarranno memorizzati nel tuo Account Google.</translation>
-<translation id="4943703118917034429">Realtà virtuale</translation>
-<translation id="4943872375798546930">Nessun risultato</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> sta condividendo il tuo schermo</translation>
-<translation id="4961107849584082341">Traduci questa pagina in qualsiasi lingua</translation>
-<translation id="4962975101802056554">Revoca tutte le autorizzazioni per il dispositivo</translation>
-<translation id="4970824347203572753">Non disponibile nel tuo paese</translation>
-<translation id="497421865427891073">Avanti</translation>
-<translation id="4988210275050210843">Download del file (<ph name="MEGABYTES" />) in corso.</translation>
-<translation id="4988526792673242964">Pagine</translation>
-<translation id="4994033804516042629">Nessun contatto trovato</translation>
-<translation id="4996978546172906250">Condividi tramite</translation>
-<translation id="5004416275253351869">Gestione attività Google</translation>
-<translation id="5005498671520578047">Copia password</translation>
-<translation id="5011311129201317034">Il sito <ph name="SITE" /> desidera collegarsi</translation>
-<translation id="5013696553129441713">Nessun nuovo suggerimento</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Mentre ti trovi nella VR, il sito potrebbe riuscire ad acquisire:
-  -  dati sulle tue caratteristiche fisiche, come l'altezza
-
-Prima di accedere alla VR, verifica che questo sito sia attendibile.</translation>
+<translation id="2930742481329940825">La funzione Tocca per cercare invia la parola selezionata e la pagina corrente come contesto alla Ricerca Brave Software. Puoi disattivare la funzione nelle <ph name="BEGIN_LINK"/>Impostazioni<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Consenti</translation>
-<translation id="5040262127954254034">Privacy</translation>
-<translation id="5048398596102334565">Consenti ai siti di accedere ai sensori di movimento (opzione consigliata)</translation>
-<translation id="5063480226653192405">Utilizzo</translation>
-<translation id="5087580092889165836">Aggiungi carta</translation>
-<translation id="5100237604440890931">Compresso. Fai clic per espandere.</translation>
-<translation id="510275257476243843">1 ora rimanente</translation>
-<translation id="5123685120097942451">Scheda di navigazione in incognito</translation>
-<translation id="5127805178023152808">La sincronizzazione è disattivata</translation>
-<translation id="5129038482087801250">Installa app web</translation>
-<translation id="5132942445612118989">Sincronizza le tue password, la tua cronologia e altro su tutti i tuoi dispositivi</translation>
-<translation id="5139940364318403933">Impara a utilizzare Google Drive</translation>
-<translation id="515227803646670480">Cancella dati memorizzati</translation>
-<translation id="5152843274749979095">Nessuna app supportata installata</translation>
-<translation id="5161254044473106830">Titolo obbligatorio</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download non riuscito.}other{# download non riusciti.}}</translation>
-<translation id="5170568018924773124">Mostra nella cartella</translation>
-<translation id="5184329579814168207">Apri in Chrome</translation>
-<translation id="5193988420012215838">Copiata nei tuoi appunti</translation>
-<translation id="5197729504361054390">I contatti che selezioni verranno condivisi con <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Profilo di lavoro</translation>
-<translation id="5210286577605176222">Vai alla scheda precedente</translation>
-<translation id="5210365745912300556">Chiudi scheda</translation>
-<translation id="5224771365102442243">Con video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> richiede di eseguire la scansione per rilevare dispositivi Bluetooth nelle vicinanze. Sono stati rilevati i seguenti dispositivi:</translation>
-<translation id="5233638681132016545">Nuova scheda</translation>
-<translation id="526421993248218238">Impossibile caricare la pagina</translation>
-<translation id="5271967389191913893">Non è possibile aprire i contenuti da scaricare sul dispositivo.</translation>
-<translation id="528192093759286357">Trascina dall'alto e tocca il pulsante Indietro per uscire dalla modalità a schermo intero.</translation>
-<translation id="5292796745632149097">Invia a</translation>
-<translation id="5300589172476337783">Mostra</translation>
-<translation id="5301954838959518834">OK</translation>
-<translation id="5304593522240415983">Questo campo non può essere vuoto</translation>
-<translation id="5307446750509046227">Cancella dati dei siti</translation>
-<translation id="5308380583665731573">Connessione</translation>
-<translation id="5313967007315987356">Aggiungi sito</translation>
-<translation id="5317780077021120954">Salva</translation>
-<translation id="5324858694974489420">Impostazioni controllo genitori</translation>
-<translation id="5327248766486351172">Nome</translation>
-<translation id="5335288049665977812">Consenti l'esecuzione di JavaScript nei siti (opzione consigliata)</translation>
-<translation id="5342314432463739672">Richieste di autorizzazione</translation>
-<translation id="5357811892247919462">Scheda ricevuta</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> scheda aperta, tocca per cambiare scheda}other{<ph name="OPEN_TABS_MANY" /> schede aperte, tocca per cambiare scheda}}</translation>
-<translation id="5391532827096253100">La tua connessione al sito non è sicura. Informazioni sul sito</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 altro)}other{(+ altri #)}}</translation>
-<translation id="5400569084694353794">Se utilizzi questa applicazione, accetti i <ph name="BEGIN_LINK1" />Termini di servizio<ph name="END_LINK1" /> e l'<ph name="BEGIN_LINK2" />Informativa sulla privacy<ph name="END_LINK2" /> di Chrome.</translation>
-<translation id="5403592356182871684">Nomi</translation>
-<translation id="5403644198645076998">Consenti solo siti specifici</translation>
-<translation id="5414836363063783498">Verifica…</translation>
-<translation id="5423934151118863508">Le pagine che visiti più spesso verranno visualizzate qui</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB disponibili</translation>
-<translation id="543338862236136125">Modifica password</translation>
-<translation id="5433691172869980887">Nome utente copiato</translation>
-<translation id="543509235395288790">Download di <ph name="COUNT" /> file (<ph name="MEGABYTES" />) in corso.</translation>
-<translation id="5441522332038954058">Vai alla barra degli indirizzi</translation>
-<translation id="5447201525962359567">Tutta la memoria utilizzata da siti, tra cui cookie e altri dati memorizzati in locale</translation>
-<translation id="5447765697759493033">Questo sito non verrà tradotto</translation>
-<translation id="545042621069398927">Accelerazione del download in corso.</translation>
-<translation id="5456381639095306749">Scarica la pagina</translation>
-<translation id="5475862044948910901">Vuoi avviare una sessione di realtà aumentata?</translation>
-<translation id="548278423535722844">Apri nell'app di mappe</translation>
-<translation id="5487521232677179737">Cancella dati</translation>
-<translation id="5494752089476963479">Blocca gli annunci su siti che mostrano annunci invasivi o fuorvianti</translation>
-<translation id="5500777121964041360">Potrebbe non essere disponibile nel tuo paese</translation>
-<translation id="5512137114520586844">Questo account è gestito da <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Opzione disattivata dall'amministratore del dispositivo</translation>
-<translation id="5515439363601853141">Sblocca per visualizzare la password</translation>
-<translation id="5516455585884385570">Apri le impostazioni di notifica</translation>
-<translation id="5517095782334947753">Sono presenti preferiti, cronologia, password e altre impostazioni di <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Reindirizzamento bloccato.</translation>
-<translation id="5527082711130173040">Chrome ha bisogno dell'accesso alla posizione per cercare dispositivi. <ph name="BEGIN_LINK1" />Aggiorna le autorizzazioni<ph name="END_LINK1" />. L'accesso alla posizione è <ph name="BEGIN_LINK2" />disattivato su questo dispositivo<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Chiedi conferma prima di consentire ai siti di leggere testo e immagini negli appunti (opzione consigliata)</translation>
-<translation id="5530766185686772672">Chiudi schede in incognito</translation>
-<translation id="5534334044554683961">Mentre ti trovi nella VR, il sito potrebbe riuscire ad acquisire:
-  -   dati sulle tue caratteristiche fisiche, come l'altezza
-  -   dati sulla struttura della stanza
-
-Prima di accedere alla VR, verifica che questo sito sia attendibile.</translation>
-<translation id="5534640966246046842">Sito copiato</translation>
-<translation id="5556459405103347317">Ricarica</translation>
-<translation id="5561549206367097665">In attesa della rete…</translation>
-<translation id="557283862590186398">Per questo sito Chrome ha bisogno dell'autorizzazione ad accedere al microfono.</translation>
-<translation id="55737423895878184">La geolocalizzazione e le notifiche sono consentite</translation>
-<translation id="5578795271662203820">Cerca questa immagine su <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Puoi scegliere in qualsiasi momento i dati da sincronizzare nelle <ph name="BEGIN_LINK1" />impostazioni<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Modifica indirizzo</translation>
-<translation id="5596627076506792578">Altre opzioni</translation>
-<translation id="5599455543593328020">Modalità di navigazione in incognito</translation>
-<translation id="5620928963363755975">Usa il pulsante Altre opzioni per trovare i tuoi file e le tue pagine nella cartella Download</translation>
-<translation id="5626134646977739690">Nome:</translation>
-<translation id="5639724618331995626">Consenti tutti i siti</translation>
-<translation id="5648166631817621825">Ultima settimana</translation>
-<translation id="5649053991847567735">Download automatici</translation>
-<translation id="5655963694829536461">Ricerca nei download</translation>
-<translation id="5659593005791499971">Email</translation>
-<translation id="5665379678064389456">Crea evento in <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ignora la richiesta di un sito per evitare l'aumento dello zoom</translation>
-<translation id="5677928146339483299">Bloccato</translation>
-<translation id="5684874026226664614">Spiacenti. Impossibile tradurre questa pagina.</translation>
-<translation id="5686790454216892815">Nome file troppo lungo</translation>
-<translation id="5689516760719285838">Posizione</translation>
-<translation id="569536719314091526">Traduci questa pagina in una lingua qualsiasi usando il pulsante Altre opzioni</translation>
-<translation id="572328651809341494">Schede recenti</translation>
-<translation id="5726692708398506830">Ingrandisci i contenuti della pagina</translation>
-<translation id="5748802427693696783">Schede standard attivate</translation>
-<translation id="5749068826913805084">Chrome deve avere accesso allo spazio di archiviazione per poter scaricare file.</translation>
-<translation id="5763382633136178763">Schede in incognito</translation>
-<translation id="5763514718066511291">Tocca per copiare l'URL di quest'app</translation>
-<translation id="5765780083710877561">Descrizione:</translation>
-<translation id="5793665092639000975">Spazio utilizzato: <ph name="SPACE_USED" /> di <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google può utilizzare la tua cronologia per personalizzare la Ricerca, gli annunci e altri servizi Google</translation>
-<translation id="5804241973901381774">Autorizzazioni</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# ora fa}other{# ore fa}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC Tutti i diritti riservati.</translation>
-<translation id="5817918615728894473">Accoppia</translation>
-<translation id="583281660410589416">Sconosciuto</translation>
-<translation id="5833984609253377421">Condividi link</translation>
-<translation id="5836192821815272682">Download dell'aggiornamento di Chrome…</translation>
-<translation id="5853623416121554550">in pausa</translation>
-<translation id="5854790677617711513">Oltre 30 giorni fa</translation>
-<translation id="5858741533101922242">Chrome non riesce ad attivare l'adattatore Bluetooth</translation>
-<translation id="5860033963881614850">Off</translation>
-<translation id="5862731021271217234">Attiva la sincronizzazione per trovare le tue schede degli altri dispositivi</translation>
-<translation id="5864174910718532887">Dettagli: ordinati per nome del sito</translation>
-<translation id="5864419784173784555">In attesa di un altro download…</translation>
-<translation id="5865733239029070421">Invia automaticamente a Google statistiche sull'utilizzo e rapporti sugli arresti anomali</translation>
-<translation id="5869522115854928033">Password salvate</translation>
-<translation id="5902828464777634901">Tutti i dati locali memorizzati da questo sito web, inclusi i cookie, verranno eliminati.</translation>
-<translation id="5916664084637901428">On</translation>
-<translation id="5919204609460789179">Aggiorna <ph name="PRODUCT_NAME" /> per avviare la sincronizzazione</translation>
-<translation id="5937580074298050696">Dati risparmiati: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Reimposta</translation>
-<translation id="5942872142862698679">Google in uso per la ricerca</translation>
-<translation id="5952764234151283551">Invia a Google l'URL della pagina a cui stai tentando di accedere</translation>
-<translation id="5956665950594638604">Apri Centro assistenza di Chrome in nuova scheda</translation>
-<translation id="5958275228015807058">Puoi trovare i tuoi file e le tue pagine nella cartella Download</translation>
-<translation id="5962718611393537961">Tocca per comprimere</translation>
-<translation id="6000066717592683814">Mantieni Google</translation>
-<translation id="6005538289190791541">Password consigliata</translation>
-<translation id="6036057147555329831">ICU extra</translation>
-<translation id="6039379616847168523">Vai alla scheda successiva</translation>
-<translation id="6040143037577758943">Chiudi</translation>
-<translation id="6042308850641462728">Altro</translation>
-<translation id="604996488070107836">Download del file <ph name="FILE_NAME" /> non riuscito a causa di un errore sconosciuto.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Download completati</translation>
-<translation id="6075798973483050474">Modifica Home page</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> ore rimanenti</translation>
-<translation id="6108923351542677676">Configurazione in corso…</translation>
-<translation id="6111020039983847643">di dati utilizzati</translation>
-<translation id="6112702117600201073">Aggiornamento della pagina in corso</translation>
-<translation id="6127379762771434464">Elemento rimosso</translation>
-<translation id="6140912465461743537">Paese/regione</translation>
-<translation id="614940544461990577">Prova a:</translation>
-<translation id="6154478581116148741">Attiva il blocco schermo in Impostazioni per esportare le tue password da questo dispositivo</translation>
-<translation id="6159335304067198720">Riduzioni dei dati: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Ulteriori informazioni</translation>
-<translation id="6177111841848151710">Bloccata per il motore di ricerca corrente</translation>
-<translation id="6181444274883918285">Aggiungi eccezione per un sito</translation>
-<translation id="6192333916571137726">Scarica file</translation>
-<translation id="6192792657125177640">Eccezioni</translation>
-<translation id="6194112207524046168">Per consentire a Chrome di accedere alla tua videocamera, devi attivare la videocamera anche nelle <ph name="BEGIN_LINK" />Impostazioni Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blocca cookie di terze parti</translation>
-<translation id="6206551242102657620">La connessione è sicura. Informazioni sul sito</translation>
-<translation id="6210748933810148297">Non sei <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Sblocca per esportare le tue password</translation>
+<translation id="1406000523432664303">Non tenere traccia</translation>
 <translation id="6232535412751077445">Se attivi l'opzione "Non tenere traccia", verrà inclusa una richiesta nel tuo traffico di navigazione. Gli effetti dipendono dall'eventuale risposta dei siti web alla richiesta e dall'interpretazione di quest'ultima.
 
 Ad esempio, alcuni siti web potrebbero rispondere alla richiesta mostrando annunci non basati su altri siti web visitati. Molti siti web continueranno tuttavia a raccogliere e a utilizzare i dati di navigazione, ad esempio per aumentare la sicurezza, fornire contenuti, annunci e consigli, nonché per generare statistiche sui rapporti.</translation>
-<translation id="624789221780392884">Aggiornamento pronto</translation>
-<translation id="6255999984061454636">Contenuti suggeriti</translation>
-<translation id="6277522088822131679">Si è verificato un problema durante la stampa della pagina. Riprova.</translation>
-<translation id="6295158916970320988">Tutti i siti</translation>
-<translation id="629730747756840877">Account</translation>
-<translation id="6303969859164067831">Esci e disattiva la sincronizzazione</translation>
-<translation id="6316139424528454185">Vers. Android non supportata</translation>
-<translation id="6320088164292336938">Vibrazione</translation>
-<translation id="6324034347079777476">Sincronizzazione del sistema Android non attiva</translation>
-<translation id="6333140779060797560">Condividi tramite <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Crittografia</translation>
-<translation id="6341580099087024258">Chiedi dove salvare i file</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Rimuovere il suggerimento dalla cronologia?</translation>
-<translation id="6369229450655021117">Da qui puoi eseguire ricerche sul Web, condividere contenuti con amici e vedere le pagine aperte.</translation>
-<translation id="6378173571450987352">Dettagli: ordinati per quantità di dati utilizzati</translation>
-<translation id="6381421346744604172">Scurisci siti web</translation>
-<translation id="6388207532828177975">Cancella e reimposta</translation>
-<translation id="6393863479814692971">Per questo sito Chrome ha bisogno dell'autorizzazione ad accedere alla fotocamera e al microfono.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Modifica preferito</translation>
-<translation id="6406506848690869874">Sincronizzazione</translation>
-<translation id="641643625718530986">Stampa…</translation>
-<translation id="6416782512398055893">Sono stati scaricati <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Traduci il Web</translation>
-<translation id="6433501201775827830">Scegli il motore di ricerca</translation>
-<translation id="6437478888915024427">Informazioni sulla pagina</translation>
-<translation id="6441734959916820584">Il nome è troppo lungo</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# immagine}other{# immagini}}</translation>
-<translation id="6447842834002726250">Cookie</translation>
-<translation id="6461962085415701688">Impossibile aprire il file.</translation>
-<translation id="6464977750820128603">Puoi vedere i siti che visiti in Chrome e impostare dei timer per ciascuno di essi.\n\nGoogle riceve informazioni sui siti per i quali imposti dei timer e sul tempo che trascorri a visitarli. Queste informazioni sono utilizzate al fine di migliorare Benessere digitale.</translation>
-<translation id="6475951671322991020">Scarica video</translation>
-<translation id="6482749332252372425">Download di <ph name="FILE_NAME" /> non riuscito a causa dello spazio di archiviazione insufficiente.</translation>
-<translation id="6496823230996795692">Connettiti a Internet per usare <ph name="APP_NAME" /> per la prima volta.</translation>
-<translation id="6508722015517270189">Riavvia Chrome</translation>
-<translation id="6527303717912515753">Condividi</translation>
-<translation id="6532866250404780454">I siti che visiti in Chrome non verranno mostrati. Tutti i timer dei siti saranno eliminati.</translation>
-<translation id="6534565668554028783">Google ha impiegato troppo tempo a rispondere</translation>
-<translation id="6538442820324228105">Sono stati scaricati <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Si è verificato un problema. Riprova più tardi.</translation>
-<translation id="654446541061731451">Seleziona una scheda da trasmettere</translation>
-<translation id="6545017243486555795">Cancella tutti i dati</translation>
-<translation id="6545864417968258051">Scansione Bluetooth</translation>
-<translation id="6560414384669816528">Ricerche con Sogou</translation>
-<translation id="6566259936974865419">Chrome ti ha fatto risparmiare <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Consenti sempre</translation>
-<translation id="6573431926118603307">Le schede aperte in Chrome sugli altri dispositivi verranno visualizzate qui.</translation>
-<translation id="6583199322650523874">Aggiungi la pagina corrente ai Preferiti</translation>
-<translation id="6593061639179217415">Sito desktop</translation>
-<translation id="6600954340915313787">Copiata in Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Contenuti protetti</translation>
-<translation id="6627583120233659107">Modifica cartella</translation>
-<translation id="6643016212128521049">Cancella</translation>
-<translation id="6643649862576733715">Ordina per quantità di dati risparmiati</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Anteprima immagine <ph name="BEGIN_NEW" />Novità<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome ha bisogno dell'accesso alla posizione per cercare dispositivi. <ph name="BEGIN_LINK" />Aggiorna le autorizzazioni<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Password</translation>
-<translation id="6659594942844771486">TAB</translation>
-<translation id="666731172850799929">Apri in <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Informativa sulla privacy di Chrome</translation>
-<translation id="6676840375528380067">Eliminare i dati di Chrome dal dispositivo?</translation>
-<translation id="6697492270171225480">Mostra suggerimenti per pagine simili quando una pagina non viene trovata</translation>
-<translation id="6697947395630195233">Chrome deve poter accedere alla tua posizione per condividerla con questo sito.</translation>
-<translation id="6698801883190606802">Gestisci dati sincronizzati</translation>
-<translation id="6699370405921460408">I server di Google ottimizzeranno le pagine che visiti.</translation>
-<translation id="6706288973712894588">Al momento sei offline.\n<ph name="BEGIN_LINK" />Esplora il tuo feed offline.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Notizie</translation>
-<translation id="6710213216561001401">Indietro</translation>
-<translation id="671481426037969117">Il timer di <ph name="FQDN" /> è scaduto. Verrà riavviato domani.</translation>
-<translation id="6738867403308150051">Download in corso…</translation>
-<translation id="6746124502594467657">Sposta giù</translation>
-<translation id="6766622839693428701">Fai scorrere verso il basso per chiudere.</translation>
-<translation id="6766758767654711248">Tocca per visitare il sito</translation>
-<translation id="6767294960381293877">Elenco di dispositivi con cui condividere una scheda aperto nella parte inferiore dello schermo.</translation>
-<translation id="6782111308708962316">Impedisci ai siti web di terze parti di salvare e leggere i dati dei cookie</translation>
-<translation id="6790428901817661496">Play</translation>
-<translation id="6811034713472274749">La pagina è pronta per essere visualizzata</translation>
-<translation id="6818926723028410516">Seleziona elementi</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Traduci</translation>
-<translation id="6845325883481699275">Contribuisci a migliorare la sicurezza di Chrome</translation>
-<translation id="6846298663435243399">Caricamento in corso…</translation>
-<translation id="6850409657436465440">Il download è ancora in corso</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> schede chiuse</translation>
-<translation id="6864459304226931083">Scarica immagine</translation>
-<translation id="6865313869410766144">Dati della compilazione automatica dei moduli</translation>
-<translation id="688738109438487280">Aggiungi dati esistenti a <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Sblocca per copiare la password</translation>
-<translation id="6896758677409633944">Copia</translation>
-<translation id="6910211073230771657">Eliminato</translation>
-<translation id="6912998170423641340">Impedisci ai siti di leggere testo e immagini negli appunti</translation>
-<translation id="6914783257214138813">Le tue password saranno visibili a chiunque abbia accesso al file esportato.</translation>
-<translation id="6942665639005891494">Modifica in qualsiasi momento il percorso di download predefinito utilizzando l'opzione del menu Impostazioni</translation>
-<translation id="6945221475159498467">Seleziona</translation>
-<translation id="6963642900430330478">Questa pagina è pericolosa Informazioni sul sito</translation>
-<translation id="6963766334940102469">Elimina Preferiti</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Tutto</translation>
-<translation id="6981982820502123353">Accessibilità</translation>
-<translation id="6989267951144302301">Download non riuscito</translation>
-<translation id="6990079615885386641">Scarica l'app dal Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Chiedi conferma prima di consentire ai siti di utilizzare il microfono (opzione consigliata)</translation>
-<translation id="7015203776128479407">La configurazione della sincronizzazione iniziale non è stata terminata. La sincronizzazione è disattivata.</translation>
-<translation id="7016516562562142042">Consentita per il motore di ricerca corrente</translation>
-<translation id="7022756207310403729">Apri nel browser</translation>
-<translation id="702463548815491781">Consigliata quando TalkBack o Switch Access sono attivi</translation>
-<translation id="7029809446516969842">Password</translation>
-<translation id="7053983685419859001">Blocca</translation>
-<translation id="7055152154916055070">Reindirizzamento bloccato:</translation>
-<translation id="7063006564040364415">Impossibile collegarsi al server di sincronizzazione.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 elemento selezionato}other{# elementi selezionati}}</translation>
-<translation id="7071521146534760487">Gestisci account</translation>
-<translation id="7077143737582773186">Scheda SD</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> elementi selezionati. Opzioni disponibili nella parte superiore dello schermo</translation>
-<translation id="7121362699166175603">Consente di cancellare la cronologia e i completamenti automatici nella barra degli indirizzi. Il tuo Account Google potrebbe avere altri tipi di cronologia di navigazione all'indirizzo <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Consenti per motore di ricerca corrente</translation>
-<translation id="7138678301420049075">Altro</translation>
-<translation id="7141896414559753902">Impedisci ai siti di mostrare popup e reindirizzamenti (opzione consigliata)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Carica la pagina originale<ph name="END_LINK" /> da <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Ultimo giorno</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Puoi cambiarlo in un secondo momento nelle Impostazioni</translation>
-<translation id="7180611975245234373">Aggiorna</translation>
-<translation id="7189372733857464326">In attesa che Google Play Services termini l'aggiornamento</translation>
-<translation id="7191430249889272776">Scheda aperta in background.</translation>
-<translation id="723171743924126238">Seleziona immagini</translation>
-<translation id="7233236755231902816">Per navigare sul Web nella tua lingua, scarica l'ultima versione di Chrome</translation>
-<translation id="7243308994586599757">Opzioni disponibili nella parte inferiore dello schermo</translation>
-<translation id="7248069434667874558">Assicurati che in Chrome sia attiva la sincronizzazione di <ph name="TARGET_DEVICE_NAME" /></translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> elementi selezionati</translation>
-<translation id="7274013316676448362">Sito bloccato</translation>
-<translation id="7290209999329137901">Impossibile rinominare</translation>
-<translation id="7291387454912369099">Pagamento con assistente</translation>
-<translation id="7293171162284876153">Per iniziare la sincronizzazione, attiva "Sincronizza i tuoi dati di Chrome".</translation>
-<translation id="729975465115245577">Il tuo dispositivo non ha un'app per archiviare il file di password.</translation>
-<translation id="7302081693174882195">Dettagli: ordinati per quantità di dati risparmiati</translation>
-<translation id="7328017930301109123">Nella modalità Lite, Chrome carica le pagine più rapidamente e utilizza fino al 60 percento di dati in meno.</translation>
-<translation id="7333031090786104871">Aggiunta del sito precedente ancora in corso</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Condividi 1 elemento selezionato}other{Condividi # elementi selezionati}}</translation>
 <translation id="7359002509206457351">Accedi ai metodi di pagamento</translation>
+<translation id="8026334261755873520">Cancella dati di navigazione</translation>
+<translation id="1291207594882862231">Cancella la cronologia, i cookie, i dati dei siti, la cache…</translation>
+<translation id="7814200940910057384">Dati di Brave cancellati</translation>
+<translation id="1664855196866195614">I dati selezionati sono stati rimossi da Brave e dai dispositivi sincronizzati.
+
+Il tuo Account Brave Software potrebbe avere altre forme di cronologia di navigazione, ad esempio ricerche e attività, di altri servizi Brave Software alla pagina <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Immagini e file memorizzati nella cache</translation>
+<translation id="2496180316473517155">Cronologia di navigazione</translation>
+<translation id="2546283357679194313">Cookie e dati dei siti</translation>
+<translation id="8662811608048051533">Verrai disconnesso dalla maggior parte dei siti.</translation>
+<translation id="8218628800671693884">Verrai disconnesso dalla maggior parte dei siti, ma non dal tuo Account Brave Software.</translation>
+<translation id="2017836877785168846">Consente di cancellare la cronologia e i completamenti automatici nella barra degli indirizzi.</translation>
+<translation id="8096327394278038498">Consente di cancellare la cronologia e i completamenti automatici nella barra degli indirizzi. Il tuo Account Brave Software potrebbe avere altri tipi di cronologia di navigazione all'indirizzo <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Consente di cancellare la cronologia da tutti i dispositivi su cui hai eseguito l'accesso. Il tuo Account Brave Software potrebbe avere altri tipi di cronologia di navigazione all'indirizzo <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Password salvate</translation>
+<translation id="6865313869410766144">Dati della compilazione automatica dei moduli</translation>
+<translation id="7562080006725997899">Cancellazione dei dati di navigazione in corso</translation>
+<translation id="5487521232677179737">Cancella dati</translation>
+<translation id="7498271377022651285">Attendi…</translation>
+<translation id="784934925303690534">Intervallo di tempo</translation>
+<translation id="1718835860248848330">Ultima ora</translation>
+<translation id="7149893636342594995">Ultimo giorno</translation>
+<translation id="5648166631817621825">Ultima settimana</translation>
+<translation id="8571213806525832805">Ultime 4 settimane</translation>
+<translation id="5854790677617711513">Oltre 30 giorni fa</translation>
+<translation id="6979737339423435258">Tutto</translation>
+<translation id="982182592107339124">Questa operazione cancellerà i dati di tutti i siti, inclusi:</translation>
+<translation id="6643016212128521049">Cancella</translation>
+<translation id="7641339528570811325">Cancella dati di navigazione…</translation>
+<translation id="1670399744444387456">Base</translation>
+<translation id="3245261285041759672">Il tuo Account Brave Software potrebbe avere altre forme di cronologia di navigazione all'indirizzo <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Sito bloccato</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> elementi eliminati</translation>
+<translation id="1121094540300013208">Rapporti sull'utilizzo e sugli arresti anomali</translation>
+<translation id="9079153198295609735">Invia automaticamente a Brave Software statistiche sull'utilizzo e rapporti sugli arresti anomali</translation>
+<translation id="6981982820502123353">Accessibilità</translation>
+<translation id="2387895666653383613">Ridimensionamento testo</translation>
+<translation id="2321958826496381788">Trascina il cursore finché leggi il testo senza problemi. Il testo dovrebbe avere queste dimensioni minime quando tocchi due volte un paragrafo.</translation>
+<translation id="3895926599014793903">Attivazione forzata dello zoom</translation>
+<translation id="5668404140385795438">Ignora la richiesta di un sito per evitare l'aumento dello zoom</translation>
+<translation id="4149994727733219643">Visualizzazione semplificata delle pagine web</translation>
+<translation id="9100505651305367705">Chiedi di mostrare gli articoli in visualizzazione semplificata, se supportata</translation>
+<translation id="1409426117486808224">Visualizzazione semplificata delle schede aperte</translation>
+<translation id="702463548815491781">Consigliata quando TalkBack o Switch Access sono attivi</translation>
+<translation id="8284326494547611709">Sottotitoli</translation>
+<translation id="4165986682804962316">Impostazioni sito</translation>
+<translation id="6295158916970320988">Tutti i siti</translation>
+<translation id="8380167699614421159">Questo sito mostra annunci invasivi o fuorvianti</translation>
+<translation id="1919345977826869612">Annunci</translation>
+<translation id="410351446219883937">Riproduzione automatica</translation>
+<translation id="6447842834002726250">Cookie</translation>
+<translation id="6196640612572343990">Blocca cookie di terze parti</translation>
+<translation id="6782111308708962316">Impedisci ai siti web di terze parti di salvare e leggere i dati dei cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Popup e reindirizzamenti</translation>
+<translation id="4751476147751820511">Sensori di movimento o della luce</translation>
+<translation id="1717218214683051432">Sensori di movimento</translation>
+<translation id="2091887806945687916">Audio</translation>
+<translation id="2586657967955657006">Appunti</translation>
+<translation id="6320088164292336938">Vibrazione</translation>
+<translation id="4226663524361240545">Le notifiche possono far vibrare il dispositivo</translation>
+<translation id="1446450296470737166">Controllo completo dispos. MIDI</translation>
+<translation id="3744111561329211289">Sincronizzazione in background</translation>
+<translation id="5649053991847567735">Download automatici</translation>
+<translation id="6181444274883918285">Aggiungi eccezione per un sito</translation>
+<translation id="5313967007315987356">Aggiungi sito</translation>
+<translation id="1369915414381695676">Sito <ph name="SITE_NAME"/> aggiunto</translation>
+<translation id="7837721118676387834">Consenti la riproduzione automatica dei video con audio disattivato in un sito specifico.</translation>
+<translation id="2621115761605608342">Consenti JavaScript per un sito specifico.</translation>
+<translation id="8801436777607969138">Blocca JavaScript per un sito specifico.</translation>
+<translation id="8372893542064058268">Consenti la sincronizzazione in background per un sito specifico.</translation>
+<translation id="358794129225322306">Consenti a un sito di scaricare automaticamente più file.</translation>
+<translation id="4008040567710660924">Consenti i cookie per un sito specifico.</translation>
+<translation id="8958424370300090006">Blocca i cookie per un sito specifico.</translation>
+<translation id="7882806643839505685">Consenti l'audio per un sito specifico.</translation>
+<translation id="4468959413250150279">Disattiva l'audio per un sito specifico.</translation>
+<translation id="1994173015038366702">URL sito</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Utilizzo</translation>
+<translation id="5804241973901381774">Autorizzazioni</translation>
+<translation id="4278390842282768270">Consentito</translation>
+<translation id="5677928146339483299">Bloccato</translation>
+<translation id="1984937141057606926">Consentiti, tranne i cookie di terze parti</translation>
+<translation id="7423098979219808738">Chiedi prima</translation>
+<translation id="8116925261070264013">Con audio disattivato</translation>
+<translation id="8300705686683892304">Gestiti dall'app</translation>
+<translation id="6192792657125177640">Eccezioni</translation>
+<translation id="257931822824936280">Espanso. Fai clic per comprimere.</translation>
+<translation id="5100237604440890931">Compresso. Fai clic per espandere.</translation>
+<translation id="857943718398505171">Consentita (opzione consigliata)</translation>
+<translation id="2913331724188855103">Consenti ai siti di salvare e leggere i dati dei cookie (opzione consigliata)</translation>
+<translation id="7445411102860286510">Consenti ai siti di riprodurre automaticamente i video con audio disattivato (opzione consigliata)</translation>
+<translation id="5335288049665977812">Consenti l'esecuzione di JavaScript nei siti (opzione consigliata)</translation>
+<translation id="5527111080432883924">Chiedi conferma prima di consentire ai siti di leggere testo e immagini negli appunti (opzione consigliata)</translation>
+<translation id="6912998170423641340">Impedisci ai siti di leggere testo e immagini negli appunti</translation>
+<translation id="7423538860840206698">Lettura degli appunti non consentita</translation>
+<translation id="3955193568934677022">Consenti ai siti di riprodurre i contenuti protetti (opzione consigliata)</translation>
+<translation id="445467742685312942">Consenti ai siti di riprodurre contenuti protetti</translation>
+<translation id="2107397443965016585">Chiedi prima di consentire ai siti di riprodurre contenuti protetti (opzione consigliata)</translation>
+<translation id="2910701580606108292">Chiedi prima di consentire ai siti di riprodurre contenuti protetti</translation>
+<translation id="757524316907819857">Impedisci ai siti di riprodurre contenuti protetti</translation>
+<translation id="3277252321222022663">Consenti ai siti di accedere ai sensori (opzione consigliata)</translation>
+<translation id="5048398596102334565">Consenti ai siti di accedere ai sensori di movimento (opzione consigliata)</translation>
+<translation id="8816026460808729765">Impedisci ai siti di accedere ai sensori</translation>
+<translation id="169515064810179024">Impedisci ai siti di accedere ai sensori di movimento</translation>
+<translation id="1660204651932907780">Consenti ai siti di riprodurre l'audio (opzione consigliata)</translation>
+<translation id="3600792891314830896">Disattiva l'audio nei siti che riproducono suoni</translation>
+<translation id="1743802530341753419">Chiedi prima di consentire ai siti di connettersi a un dispositivo (opzione consigliata)</translation>
+<translation id="851751545965956758">Impedisci ai siti di connettersi ai dispositivi</translation>
+<translation id="7141896414559753902">Impedisci ai siti di mostrare popup e reindirizzamenti (opzione consigliata)</translation>
+<translation id="5494752089476963479">Blocca gli annunci su siti che mostrano annunci invasivi o fuorvianti</translation>
+<translation id="3123473560110926937">Bloccati su alcuni siti</translation>
+<translation id="965817943346481315">Blocca se il sito mostra annunci invasivi o fuorvianti (consigliato)</translation>
+<translation id="3386292677130313581">Chiedi conferma prima di consentire ai siti di conoscere la tua posizione (opzione consigliata)</translation>
+<translation id="9139068048179869749">Chiedi conferma prima di consentire ai siti di inviare notifiche (opzione consigliata)</translation>
+<translation id="4479647676395637221">Chiedi conferma prima di consentire ai siti di utilizzare la videocamera (opzione consigliata)</translation>
+<translation id="6992289844737586249">Chiedi conferma prima di consentire ai siti di utilizzare il microfono (opzione consigliata)</translation>
+<translation id="2289270750774289114">Chiedi conferma quando un sito vuole rilevare i dispositivi Bluetooth nelle vicinanze (opzione consigliata)</translation>
+<translation id="7053983685419859001">Blocca</translation>
+<translation id="7128222689758636196">Consenti per motore di ricerca corrente</translation>
+<translation id="7589445247086920869">Blocca per motore di ricerca corrente</translation>
+<translation id="6388207532828177975">Cancella e reimposta</translation>
+<translation id="7999064672810608036">Vuoi cancellare tutti i dati locali, inclusi i cookie, e reimpostare tutte le autorizzazioni relative al sito web?</translation>
+<translation id="2822354292072154809">Vuoi reimpostare tutte le autorizzazioni del sito per <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Cancella dati memorizzati</translation>
+<translation id="5902828464777634901">Tutti i dati locali memorizzati da questo sito web, inclusi i cookie, verranno eliminati.</translation>
+<translation id="119944043368869598">Cancella tutto</translation>
+<translation id="2490684707762498678">Gestite da <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Apri le impostazioni di notifica</translation>
+<translation id="1404122904123200417">Incorporato in <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">I file salvati dai siti web vengono mostrati qui</translation>
+<translation id="4181841719683918333">Lingue</translation>
+<translation id="2647434099613338025">Aggiungi lingua</translation>
+<translation id="1952172573699511566">Se possibile, il testo dei siti web verrà mostrato nella tua lingua preferita.</translation>
+<translation id="8559990750235505898">Proponi di tradurre le pagine in altre lingue</translation>
+<translation id="4719927025381752090">Proponi di tradurre</translation>
+<translation id="8156139159503939589">In quali lingue sai leggere?</translation>
+<translation id="5689516760719285838">Posizione</translation>
+<translation id="2440823041667407902">Accesso alla posizione</translation>
+<translation id="2023546461831060654">Abilita le autorizzazioni per Brave in <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Abilita l'autorizzazione per Brave in <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Per consentire a Brave di accedere alla tua posizione, devi attivare la posizione anche nelle <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Per consentire a Brave di accedere alla tua videocamera, devi attivare la videocamera anche nelle <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Per consentire a Brave di inviarti notifiche, devi attivare le notifiche anche nelle <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Per consentire a Brave di accedere al tuo microfono, devi attivare il microfono anche nelle <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">L'accesso alla posizione è disattivato per questo dispositivo. Attivalo nelle <ph name="BEGIN_LINK"/> Impostazioni Android <ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">L'accesso alla posizione è disattivato anche per questo dispositivo. Attivalo nelle <ph name="BEGIN_LINK"/>Impostazioni Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Videocamera</translation>
+<translation id="3227137524299004712">Microfono</translation>
+<translation id="1647391597548383849">Accesso alla fotocamera</translation>
+<translation id="945632385593298557">Accesso al microfono</translation>
+<translation id="6612358246767739896">Contenuti protetti</translation>
+<translation id="885701979325669005">Dati memorizzati dai siti</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> di dati memorizzati</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revoca autorizzazione dispositivo</translation>
+<translation id="4962975101802056554">Revoca tutte le autorizzazioni per il dispositivo</translation>
+<translation id="6545864417968258051">Scansione Bluetooth</translation>
+<translation id="4411535500181276704">Modalità Lite</translation>
+<translation id="7821588508402923572">La quantità di dati risparmiata sarà visualizzata qui</translation>
+<translation id="2131665479022868825">Dati risparmiati: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">dal giorno <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Nella modalità Lite, Brave carica le pagine più rapidamente e utilizza fino al 60 percento di dati in meno.</translation>
+<translation id="6159335304067198720">Riduzioni dei dati: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">di dati risparmiati</translation>
+<translation id="6111020039983847643">di dati utilizzati</translation>
+<translation id="7413229368719586778">Data di inizio: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Data di fine: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Ordina per sito</translation>
+<translation id="5864174910718532887">Dettagli: ordinati per nome del sito</translation>
+<translation id="116280672541001035">Utilizzati</translation>
+<translation id="8349013245300336738">Ordina per quantità di dati utilizzati</translation>
+<translation id="6378173571450987352">Dettagli: ordinati per quantità di dati utilizzati</translation>
+<translation id="2631006050119455616">Risparmiati</translation>
+<translation id="6643649862576733715">Ordina per quantità di dati risparmiati</translation>
+<translation id="7302081693174882195">Dettagli: ordinati per quantità di dati risparmiati</translation>
+<translation id="4179980317383591987">Dati utilizzati: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Dati risparmiati: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Siti rimanenti (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Altro</translation>
+<translation id="4913161338056004800">Reimposta statistiche</translation>
+<translation id="1856325424225101786">Reimpostare la modalità Lite?</translation>
+<translation id="3658159451045945436">La reimpostazione elimina la tua cronologia dei dati risparmiati, incluso l'elenco dei siti web visitati.</translation>
+<translation id="3295530008794733555">Naviga più velocemente. Consuma meno dati.</translation>
+<translation id="7340390500800578919">Nella modalità Lite, Brave carica le pagine più rapidamente e utilizza fino al 60% di dati in meno. Per ottimizzare le pagine che visiti, Brave invia il tuo traffico web a Brave Software. <ph name="BEGIN_LINK"/>Ulteriori informazioni<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Attiva la modalità Lite</translation>
+<translation id="4493497663118223949">La modalità Lite è attiva</translation>
+<translation id="7559975015014302720">La modalità Lite non è attiva</translation>
+<translation id="7606077192958116810">La modalità Lite è attiva. Gestiscila nelle Impostazioni.</translation>
+<translation id="4714588616299687897">Riduci l'utilizzo di dati fino al 60%</translation>
+<translation id="1006927014032731288">I server di Brave Software ottimizzeranno le pagine che visiti.</translation>
+<translation id="3257320067425202300">Brave ti ha fatto risparmiare <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave ti ha fatto risparmiare <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Percorso di download</translation>
+<translation id="7077143737582773186">Scheda SD</translation>
+<translation id="7762668264895820836">Scheda SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Chiedi dove salvare i file</translation>
+<translation id="6192333916571137726">Scarica file</translation>
+<translation id="1672586136351118594">Non visualizzare più</translation>
+<translation id="2650751991977523696">Scaricare nuovamente il file?</translation>
+<translation id="8664979001105139458">Nome file già esistente</translation>
+<translation id="488187801263602086">Rinomina file</translation>
+<translation id="5686790454216892815">Nome file troppo lungo</translation>
+<translation id="7454641608352164238">Spazio insufficiente</translation>
+<translation id="8972098258593396643">Scaricare nella cartella predefinita?</translation>
+<translation id="804335162455518893">Scheda SD non trovata</translation>
+<translation id="7475688122056506577">Scheda SD non trovata. Potrebbero mancare alcuni dei tuoi file.</translation>
+<translation id="4198423547019359126">Nessun percorso di download disponibile</translation>
+<translation id="8224471946457685718">Scarica articoli per te tramite Wi-Fi</translation>
+<translation id="4970824347203572753">Non disponibile nel tuo paese</translation>
+<translation id="5500777121964041360">Potrebbe non essere disponibile nel tuo paese</translation>
+<translation id="1173894706177603556">Rinomina</translation>
+<translation id="1986685561493779662">Il nome esiste già</translation>
+<translation id="6441734959916820584">Il nome è troppo lungo</translation>
+<translation id="2923908459366352541">Nome non valido</translation>
+<translation id="7290209999329137901">Impossibile rinominare</translation>
+<translation id="3334729583274622784">Vuoi cambiare l'estensione del file?</translation>
+<translation id="107147699690128016">Se cambi l'estensione del file, il file potrebbe essere aperto in un'altra applicazione e costituire un pericolo per il dispositivo.</translation>
+<translation id="8541922081612557424">Informazioni su Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC Tutti i diritti riservati.</translation>
+<translation id="1416550906796893042">Versione applicazione</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Ultimo aggiornamento: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistema operativo</translation>
+<translation id="3968054912784331254">Gli aggiornamenti di Brave non sono più supportati per questa versione di Android</translation>
+<translation id="7665369617277396874">Aggiungi account</translation>
+<translation id="649070405679044769">Accesso effettuato a Brave Software come</translation>
+<translation id="6234515504547364178">Esci da Brave</translation>
+<translation id="5324858694974489420">Impostazioni controllo genitori</translation>
+<translation id="8920114477895755567">In attesa dei dettagli sui genitori.</translation>
+<translation id="5512137114520586844">Questo account è gestito da <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Questo account è gestito da <ph name="PARENT_NAME_1"/> e <ph name="PARENT_NAME_2"/></translation>
+<translation id="8168435359814927499">Contenuti</translation>
+<translation id="5403644198645076998">Consenti solo siti specifici</translation>
+<translation id="8641930654639604085">Prova a bloccare siti per adulti</translation>
+<translation id="5639724618331995626">Consenti tutti i siti</translation>
+<translation id="796823723482603597">Con tecnologia Brave</translation>
+<translation id="6324034347079777476">Sincronizzazione del sistema Android non attiva</translation>
+<translation id="5127805178023152808">La sincronizzazione è disattivata</translation>
+<translation id="7015203776128479407">La configurazione della sincronizzazione iniziale non è stata terminata. La sincronizzazione è disattivata.</translation>
+<translation id="2497852260688568942">La sincronizzazione è stata disattivata dall'amministratore</translation>
+<translation id="9100610230175265781">Passphrase obbligatoria</translation>
+<translation id="6108923351542677676">Configurazione in corso…</translation>
+<translation id="4062305924942672200">Informazioni legali</translation>
+<translation id="4256782883801055595">Licenze open source</translation>
+<translation id="1138681184697033370">Termini di servizio di Brave</translation>
+<translation id="7392539049993970338">Informativa sulla privacy di Brave</translation>
+<translation id="2677748264148917807">Esci</translation>
+<translation id="5556459405103347317">Ricarica</translation>
+<translation id="1623104350909869708">Impedisci la creazione di altre finestre di dialogo in questa pagina</translation>
+<translation id="2968755619301702150">Visualizzatore certificati</translation>
+<translation id="1360432990279830238">Uscire e disattivare la sincronizzazione?</translation>
+<translation id="8581481290581777242">Eliminare i dati di Brave dal dispositivo?</translation>
+<translation id="1318865768845061710">I preferiti, la cronologia, le password e altri dati di Brave non verranno più sincronizzati con il tuo Account Brave Software</translation>
+<translation id="3325020657155065477">Cancella i tuoi dati di Brave anche da questo dispositivo</translation>
+<translation id="6136448902816743006">Poiché stai uscendo da un account gestito da <ph name="DOMAIN_NAME"/>, i tuoi dati di Brave verranno eliminati da questo dispositivo. Rimarranno memorizzati nel tuo Account Brave Software.</translation>
+<translation id="1853026300647876496">Connessione a Brave Software in corso. L'operazione potrebbe richiedere un minuto…</translation>
+<translation id="2328985652426384049">Impossibile eseguire l'accesso</translation>
+<translation id="7723158744459952869">Brave Software ha impiegato troppo tempo a rispondere</translation>
+<translation id="4572422548854449519">Accedi all'account gestito</translation>
+<translation id="2689656545739939160">Stai per eseguire l'accesso con un account gestito da <ph name="MANAGED_DOMAIN"/> e consentire al relativo amministratore di avere il controllo dei tuoi dati di Brave. I tuoi dati verranno associati definitivamente a questo account. Se esci da Brave, i dati verranno eliminati da questo dispositivo, ma rimarranno memorizzati nel tuo Account Brave Software.</translation>
+<translation id="1749561566933687563">Sincronizza i tuoi preferiti</translation>
+<translation id="4242533952199664413">Apri le impostazioni</translation>
+<translation id="1111673857033749125">I preferiti salvati sugli altri dispositivi verranno visualizzati qui.</translation>
+<translation id="8636825310635137004">Attiva la sincronizzazione per trovare le tue schede degli altri dispositivi.</translation>
+<translation id="3269956123044984603">Attiva la funzione "Sincronizzazione automatica dei dati" nelle impostazioni dell'account Android per trovare le tue schede sugli altri tuoi dispositivi.</translation>
+<translation id="5157964048453367290">Le schede aperte in Brave sugli altri dispositivi verranno visualizzate qui.</translation>
+<translation id="4684427112815847243">Sincronizza tutto</translation>
+<translation id="2709516037105925701">Compilazione automatica</translation>
+<translation id="8820817407110198400">Preferiti</translation>
+<translation id="1644574205037202324">Cronologia</translation>
+<translation id="17513872634828108">Schede aperte</translation>
+<translation id="1320169905922104972">Carte di credito e indirizzi che utilizzano Brave Software Pay</translation>
+<translation id="6337234675334993532">Crittografia</translation>
+<translation id="6698801883190606802">Gestisci dati sincronizzati</translation>
+<translation id="3598578758776312506">Cripta le password con le credenziali Brave Software</translation>
+<translation id="7810580217418711046">Cripta i dati sincronizzati con la password Brave Software a partire dal giorno <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Cripta i dati sincronizzati con la tua passphrase di sincronizzazione</translation>
+<translation id="2996291259634659425">Crea passphrase</translation>
+<translation id="5713644099811900409">Brave Software Account</translation>
+<translation id="8997474919031554666">La crittografia della passphrase non include metodi di pagamento e indirizzi di Brave Software Pay. Soltanto chi conosce la tua passphrase può leggere i tuoi dati criptati. La passphrase non viene inviata a Brave Software né memorizzata. Se dimentichi la passphrase o vuoi modificare questa impostazione, dovrai reimpostare la sincronizzazione. <ph name="BEGIN_LINK"/>Ulteriori informazioni<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Passphrase</translation>
+<translation id="7772032839648071052">Conferma passphrase</translation>
+<translation id="5304593522240415983">Questo campo non può essere vuoto</translation>
+<translation id="321773570071367578">Se non ricordi la passphrase o vuoi modificare questa impostazione, <ph name="BEGIN_LINK"/>reimposta la sincronizzazione<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Le passphrase non corrispondono</translation>
+<translation id="5149495116300586333">La crittografia della passphrase non include metodi di pagamento e indirizzi di Brave Software Pay.
+
+Per cambiare questa impostazione, <ph name="BEGIN_LINK"/>reimposta la sincronizzazione<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">Passphrase sbagliata</translation>
+<translation id="5414836363063783498">Verifica…</translation>
+<translation id="6846298663435243399">Caricamento in corso…</translation>
+<translation id="5517095782334947753">Sono presenti preferiti, cronologia, password e altre impostazioni di <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Unisci i miei dati</translation>
+<translation id="688738109438487280">Aggiungi dati esistenti a <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Mantieni separati i miei dati</translation>
+<translation id="1145536944570833626">Elimina dati esistenti.</translation>
+<translation id="1993768208584545658">Il sito <ph name="SITE"/> desidera accoppiarsi</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Richiedi assistenza<ph name="END_LINK"/> durante la ricerca di dispositivi…</translation>
+<translation id="5817918615728894473">Accoppia</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Richiedi assistenza<ph name="END_LINK1"/> o <ph name="BEGIN_LINK2"/>ripeti la ricerca<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Nessun dispositivo compatibile trovato</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Attiva il Bluetooth<ph name="END_LINK"/> per consentire l'accoppiamento</translation>
+<translation id="998321811308652668">Brave non riesce ad attivare l'adattatore Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Richiedi assistenza<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave ha bisogno dell'accesso alla posizione per cercare dispositivi. <ph name="BEGIN_LINK"/>Aggiorna le autorizzazioni<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave ha bisogno dell'accesso alla posizione per cercare dispositivi. L'accesso alla posizione è <ph name="BEGIN_LINK"/>disattivato su questo dispositivo<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave ha bisogno dell'accesso alla posizione per cercare dispositivi. <ph name="BEGIN_LINK1"/>Aggiorna le autorizzazioni<ph name="END_LINK1"/>. L'accesso alla posizione è <ph name="BEGIN_LINK2"/>disattivato su questo dispositivo<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Dispositivo collegato</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Intensità del segnale: # barra}other{Intensità del segnale: # barre}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> richiede di eseguire la scansione per rilevare dispositivi Bluetooth nelle vicinanze. Sono stati rilevati i seguenti dispositivi:</translation>
+<translation id="8368027906805972958">Dispositivo sconosciuto o non supportato (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">La sincronizzazione non funziona</translation>
+<translation id="1810845389119482123">Configurazione iniziale della sincronizzazione non terminata</translation>
+<translation id="3235722914093408050">Apri le impostazioni di Android e abilita nuovamente la sincronizzazione del sistema Android per poter avviare la Sicronizzazione Brave</translation>
+<translation id="3367813778245106622">Accedi nuovamente per avviare la sincronizzazione</translation>
+<translation id="974555521953189084">Inserisci la passphrase per avviare la sincronizzazione</translation>
+<translation id="2997266899014181325">Per iniziare la sincronizzazione, attiva "Sincronizza i tuoi dati di Brave".</translation>
+<translation id="8260126382462817229">Prova ad accedere nuovamente</translation>
+<translation id="5919204609460789179">Aggiorna <ph name="PRODUCT_NAME"/> per avviare la sincronizzazione</translation>
+<translation id="397583555483684758">La sincronizzazione si è interrotta</translation>
+<translation id="1966710179511230534">Aggiorna i dati di accesso.</translation>
+<translation id="7063006564040364415">Impossibile collegarsi al server di sincronizzazione.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> è obsoleto.</translation>
+<translation id="4170011742729630528">Il servizio non è disponibile, riprova più tardi.</translation>
+<translation id="7947953824732555851">Accetta e accedi</translation>
+<translation id="8583805026567836021">Cancellazione dati dell'account</translation>
+<translation id="8310344678080805313">Schede standard</translation>
+<translation id="5748802427693696783">Schede standard attivate</translation>
+<translation id="7998918019931843664">Riapri la scheda chiusa</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, scheda</translation>
+<translation id="4452411734226507615">Chiudi la scheda <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opzioni disponibili nella parte inferiore dello schermo</translation>
+<translation id="4060598801229743805">Opzioni disponibili nella parte superiore dello schermo</translation>
+<translation id="2810645512293415242">Pagina semplificata per risparmiare dati e caricarla più velocemente.</translation>
+<translation id="3985215325736559418">Scaricare di nuovo <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Vuoi avviare di nuovo il download di <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Scarica</translation>
+<translation id="545042621069398927">Accelerazione del download in corso.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Download del file.}other{Download di # file.}}</translation>
+<translation id="543509235395288790">Download di <ph name="COUNT"/> file (<ph name="MEGABYTES"/>) in corso.</translation>
+<translation id="4988210275050210843">Download del file (<ph name="MEGABYTES"/>) in corso.</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download completato.}other{# download completati.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download non riuscito.}other{# download non riusciti.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download in attesa.}other{# download in attesa.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> pulsante <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Hai quasi finito!</translation>
+<translation id="3960299545138990065">Riavvia Brave</translation>
+<translation id="3771001275138982843">Impossibile scaricare l'aggiornamento</translation>
+<translation id="3888648114124182147">Download dell'aggiornamento di Brave…</translation>
+<translation id="1705567146636171298">Aggiorna Brave</translation>
+<translation id="6195417478702700398">Per un'esperienza di navigazione ottimale, apri per aggiornare Brave</translation>
+<translation id="3512968675351418494">Per navigare sul Web nella tua lingua, scarica l'ultima versione di Brave</translation>
+<translation id="6427112570124116297">Traduci il Web</translation>
+<translation id="1379423114029199501">Aggiorna per avere a disposizione la tua lingua nell'ultima versione di Brave</translation>
+<translation id="5684874026226664614">Spiacenti. Impossibile tradurre questa pagina.</translation>
+<translation id="6831043979455480757">Traduci</translation>
+<translation id="1285320974508926690">Non tradurre mai questo sito</translation>
+<translation id="773466115871691567">Traduci sempre le pagine in <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Non tradurre mai le pagine in <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Altre lingue</translation>
+<translation id="290376772003165898">La pagina non è in <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Le pagine in <ph name="SOURCE_LANGUAGE"/> verranno tradotte in <ph name="TARGET_LANGUAGE"/> d'ora in poi</translation>
+<translation id="8339163506404995330">Le pagine in <ph name="LANGUAGE"/> non verranno tradotte</translation>
+<translation id="5447765697759493033">Questo sito non verrà tradotto</translation>
+<translation id="4880127995492972015">Traduci…</translation>
+<translation id="641643625718530986">Stampa…</translation>
+<translation id="8909135823018751308">Condividi…</translation>
+<translation id="4996978546172906250">Condividi tramite</translation>
+<translation id="6333140779060797560">Condividi tramite <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Si è verificato un problema durante la stampa della pagina. Riprova.</translation>
+<translation id="3254409185687681395">Aggiungi ai Preferiti</translation>
+<translation id="497421865427891073">Avanti</translation>
+<translation id="813082847718468539">Visualizza informazioni sul sito</translation>
+<translation id="2532336938189706096">Visualizzazione web</translation>
+<translation id="6005538289190791541">Password consigliata</translation>
+<translation id="4634124774493850572">Utilizza password</translation>
+<translation id="8285489906452138776">Per questo sito Brave ha bisogno dell'autorizzazione ad accedere alla fotocamera.</translation>
+<translation id="320189792589364011">Per questo sito Brave ha bisogno dell'autorizzazione ad accedere al microfono.</translation>
+<translation id="7988136689212463100">Per questo sito Brave ha bisogno dell'autorizzazione ad accedere alla fotocamera e al microfono.</translation>
+<translation id="4931190655840828017">Brave deve poter accedere alla tua posizione per condividerla con questo sito.</translation>
+<translation id="3088191967551450609">Brave deve avere accesso allo spazio di archiviazione per poter scaricare file.</translation>
+<translation id="8942627711005830162">Apri nell'altra finestra</translation>
+<translation id="4195643157523330669">Apri in un'altra scheda</translation>
+<translation id="1100066534610197918">Apri in nuova scheda in gruppo</translation>
+<translation id="4860895144060829044">Chiama</translation>
+<translation id="6896758677409633944">Copia</translation>
+<translation id="8393700583063109961">Invia messaggio</translation>
+<translation id="3557336313807607643">Aggiungi ai contatti</translation>
+<translation id="4269820728363426813">Copia indirizzo link</translation>
+<translation id="1206892813135768548">Copia testo link</translation>
+<translation id="1204037785786432551">Link di download</translation>
+<translation id="6864459304226931083">Scarica immagine</translation>
+<translation id="8209050860603202033">Apri immagine</translation>
+<translation id="8073388330009372546">Immagine in nuova scheda</translation>
+<translation id="6649642165559792194">Anteprima immagine <ph name="BEGIN_NEW"/>Novità<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Carica immagine</translation>
+<translation id="3845332215609790146">Cerca con Brave Software Lens <ph name="BEGIN_NEW"/>Novità<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Cerca questa immagine su <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Condividi immagine</translation>
+<translation id="5833984609253377421">Condividi link</translation>
+<translation id="6475951671322991020">Scarica video</translation>
+<translation id="2317945146070194624">Apri in nuova scheda di Brave</translation>
+<translation id="7975379999046275268">Anteprima pagina <ph name="BEGIN_NEW"/>Novità<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Aggiornamento della pagina in corso</translation>
+<translation id="36525718899759834">Scarica l'app dal Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Scuro</translation>
+<translation id="1807246157184219062">Chiaro</translation>
+<translation id="4056223980640387499">Seppia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Seleziona una scheda da trasmettere</translation>
+<translation id="8719023831149562936">Impossibile trasmettere scheda corrente</translation>
+<translation id="2139186145475833000">Aggiungi a schermata Home</translation>
+<translation id="4616150815774728855">Apri <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Impossibile aprire l'app</translation>
+<translation id="5129038482087801250">Installa app web</translation>
+<translation id="3789841737615482174">Installa</translation>
+<translation id="4665282149850138822">Il sito <ph name="NAME"/> è stato aggiunto alla schermata Home</translation>
+<translation id="7333031090786104871">Aggiunta del sito precedente ancora in corso</translation>
+<translation id="1036727731225946849">Aggiunta di <ph name="WEBAPK_NAME"/> in corso…</translation>
+<translation id="3778956594442850293">Aggiunto alla schermata Home</translation>
+<translation id="2146738493024040262">Apri l'app istantanea</translation>
+<translation id="7016516562562142042">Consentita per il motore di ricerca corrente</translation>
+<translation id="6177111841848151710">Bloccata per il motore di ricerca corrente</translation>
+<translation id="145097072038377568">Disattivata in Impostazioni Android</translation>
+<translation id="8007176423574883786">Disattivata per questo dispositivo</translation>
+<translation id="164269334534774161">È visualizzata una copia offline di questa pagina del giorno <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Questa pagina offline risale al giorno <ph name="CREATION_TIME"/> e potrebbe essere diversa dalla versione online.</translation>
+<translation id="8840953339110955557">Questa pagina potrebbe essere diversa dalla versione online.</translation>
+<translation id="6405300764336705484">Questi contenuti derivano da <ph name="DOMAIN_NAME"/> e sono offerti da Brave Software.</translation>
+<translation id="1006017844123154345">Apri online</translation>
+<translation id="3326636747541519688">Pagina Lite fornita da Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Carica la pagina originale<ph name="END_LINK"/> da <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Se il problema si verifica di frequente, prova questi <ph name="BEGIN_LINK"/>suggerimenti<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Contenuti nascosti</translation>
+<translation id="3810973564298564668">Gestisci</translation>
+<translation id="5199929503336119739">Profilo di lavoro</translation>
+<translation id="528192093759286357">Trascina dall'alto e tocca il pulsante Indietro per uscire dalla modalità a schermo intero.</translation>
+<translation id="2836148919159985482">Tocca il pulsante Indietro per uscire dalla modalità a schermo intero.</translation>
+<translation id="3967822245660637423">Download completato</translation>
+<translation id="2434158240863470628">Download completato: <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Download non riuscito</translation>
+<translation id="1384959399684842514">Download sospeso</translation>
+<translation id="1671236975893690980">Download in attesa...</translation>
+<translation id="5561549206367097665">In attesa della rete…</translation>
+<translation id="5864419784173784555">In attesa di un altro download…</translation>
+<translation id="6461962085415701688">Impossibile aprire il file.</translation>
+<translation id="1178581264944972037">Pausa</translation>
+<translation id="8200772114523450471">Riprendi</translation>
+<translation id="1409879593029778104">Download di <ph name="FILE_NAME"/> impedito perché il file esiste già.</translation>
+<translation id="3387650086002190359">Download di <ph name="FILE_NAME"/> non riuscito a causa di errori del file system.</translation>
+<translation id="6482749332252372425">Download di <ph name="FILE_NAME"/> non riuscito a causa dello spazio di archiviazione insufficiente.</translation>
+<translation id="7619072057915878432">Download di <ph name="FILE_NAME"/> non riuscito a causa di errori di rete.</translation>
+<translation id="1477626028522505441">Download di <ph name="FILE_NAME"/> non riuscito a causa di problemi del server.</translation>
+<translation id="3692944402865947621">Download di <ph name="FILE_NAME"/> non riuscito perché non è possibile trovare il percorso di archiviazione.</translation>
+<translation id="604996488070107836">Download del file <ph name="FILE_NAME"/> non riuscito a causa di un errore sconosciuto.</translation>
+<translation id="6738867403308150051">Download in corso…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> di ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> di <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Sono stati scricati <ph name="KBS"/> kB</translation>
+<translation id="6416782512398055893">Sono stati scaricati <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Sono stati scaricati <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">1 file rimanente</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> file rimanenti</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> file scaricato}other{<ph name="FILES_DOWNLOADED_MANY"/> file scaricati}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> giorni rimanenti</translation>
+<translation id="8190358571722158785">1 giorno rimanente</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> ore rimanenti</translation>
+<translation id="510275257476243843">1 ora rimanente</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> min rimanenti</translation>
+<translation id="3236059992281584593">1 min rimanente</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> sec rimanenti</translation>
+<translation id="2781151931089541271">1 sec rimanente</translation>
+<translation id="3303414029551471755">Procedere al download dei contenuti?</translation>
+<translation id="8617240290563765734">Aprire l'URL consigliato specificato nei contenuti scaricati?</translation>
+<translation id="1373696734384179344">Memoria non sufficiente per scaricare i contenuti selezionati.</translation>
+<translation id="5271967389191913893">Non è possibile aprire i contenuti da scaricare sul dispositivo.</translation>
+<translation id="883806473910249246">Si è verificato un errore durante il download dei contenuti.</translation>
+<translation id="5626134646977739690">Nome:</translation>
+<translation id="7963646190083259054">Fornitore:</translation>
+<translation id="3414952576877147120">Dimensioni:</translation>
+<translation id="7375125077091615385">Tipo:</translation>
+<translation id="5765780083710877561">Descrizione:</translation>
+<translation id="4881695831933465202">Apri</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> kB disponibili</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB disponibili</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB disponibili</translation>
+<translation id="5793665092639000975">Spazio utilizzato: <ph name="SPACE_USED"/> di <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Tutti</translation>
+<translation id="4988526792673242964">Pagine</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Immagini</translation>
+<translation id="8250920743982581267">Documenti</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# file}other{# file}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# immagine}other{# immagini}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# video}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# file audio}other{# file audio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# pagina}other{# pagine}}</translation>
+<translation id="5456381639095306749">Scarica la pagina</translation>
+<translation id="2394602618534698961">I file scaricati vengono visualizzati qui</translation>
+<translation id="7810647596859435254">Apri con…</translation>
+<translation id="5655963694829536461">Ricerca nei download</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">I miei file</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Qui vengono visualizzati gli articoli che potrai leggere anche offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ora}other{# ore}}</translation>
+<translation id="5853623416121554550">in pausa</translation>
+<translation id="8965591936373831584">in attesa</translation>
+<translation id="2779651927720337254">non riuscito</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">In questo momento</translation>
+<translation id="4000212216660919741">Home page offline</translation>
+<translation id="9133397713400217035">Esplora offline</translation>
+<translation id="968900484120156207">Le pagine visitate saranno mostrate qui</translation>
+<translation id="7882131421121961860">Nessuna cronologia trovata</translation>
+<translation id="3549657413697417275">Cerca nella cronologia</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Esperienza prima esecuzione di Brave</translation>
+<translation id="2700285883409956633">Se utilizzi questa applicazione, accetti i <ph name="BEGIN_LINK1"/>Termini di servizio<ph name="END_LINK1"/> e l'<ph name="BEGIN_LINK2"/>Informativa sulla privacy<ph name="END_LINK2"/> di Brave.</translation>
+<translation id="1640714894372474981">Utilizzando questa applicazione, accetti i <ph name="BEGIN_LINK1"/>Termini di servizio<ph name="END_LINK1"/> di Brave, le <ph name="BEGIN_LINK2"/>Norme sulla privacy<ph name="END_LINK2"/> e le <ph name="BEGIN_LINK3"/>Norme sulla privacy per gli Account Brave Software gestiti tramite Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">L'app <ph name="APP_NAME"/> verrà aperta in Brave. Se continui, accetti i <ph name="BEGIN_LINK1"/>Termini di servizio<ph name="END_LINK1"/> e l'<ph name="BEGIN_LINK2"/>Informativa sulla Privacy<ph name="END_LINK2"/> di Brave.</translation>
+<translation id="5071615083211946659">L'app <ph name="APP_NAME"/> verrà aperta in Brave. Se continui, accetti i <ph name="BEGIN_LINK1"/>Termini di servizio<ph name="END_LINK1"/> e l'<ph name="BEGIN_LINK2"/>Informativa sulla privacy<ph name="END_LINK2"/> di Brave, nonché l'<ph name="BEGIN_LINK3"/>Informatica sulla privacy per gli Account Brave Software gestiti tramite Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Aiutaci a migliorare Brave inviando a Brave Software statistiche sull'utilizzo e rapporti sugli arresti anomali.</translation>
+<translation id="3518985090088779359">Accetta e continua</translation>
+<translation id="7207456302801184289">Benvenuto in Brave</translation>
+<translation id="704822250101715322">In attesa che Brave Software Play Services termini l'aggiornamento</translation>
+<translation id="1231733316453485619">Attivare la sincronizzazione?</translation>
+<translation id="5132942445612118989">Sincronizza le tue password, la tua cronologia e altro su tutti i tuoi dispositivi</translation>
+<translation id="5736731321935944068">Brave Software può utilizzare la tua cronologia per personalizzare la Ricerca, gli annunci e altri servizi Brave Software</translation>
+<translation id="4013614219085422040">Brave Software può utilizzare la tua cronologia per personalizzare la Ricerca e altri servizi Brave Software</translation>
+<translation id="5581519193887989363">Puoi scegliere in qualsiasi momento i dati da sincronizzare nelle <ph name="BEGIN_LINK1"/>impostazioni<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Sì, accetto</translation>
+<translation id="2410754283952462441">Scegli un account</translation>
+<translation id="2227444325776770048">Continua come <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Non sei <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Attiva la sincronizzazione per trovare i tuoi preferiti su tutti i dispositivi</translation>
+<translation id="2818669890320396765">Accedi e attiva la sincronizzazione per trovare i tuoi preferiti su tutti i dispositivi</translation>
+<translation id="6003646045106347985">Per ricevere contenuti suggeriti appositamente per te da Brave Software, attiva la sincronizzazione</translation>
+<translation id="8494430740943879273">Per ricevere contenuti suggeriti appositamente per te da Brave Software, accedi e attiva la sincronizzazione</translation>
+<translation id="5862731021271217234">Attiva la sincronizzazione per trovare le tue schede degli altri dispositivi</translation>
+<translation id="3568688522516854065">Accedi e attiva la sincronizzazione per trovare le tue schede degli altri dispositivi</translation>
+<translation id="1208340532756947324">Attiva la sincronizzazione per sincronizzare e personalizzare tutti i dispositivi</translation>
+<translation id="4472118726404937099">Accedi e attiva la sincronizzazione per sincronizzare e personalizzare tutti i dispositivi</translation>
+<translation id="2426805022920575512">Scegli un altro account</translation>
+<translation id="6790428901817661496">Play</translation>
+<translation id="1272079795634619415">Interrompi</translation>
+<translation id="2874939134665556319">Traccia precedente</translation>
+<translation id="4046123991198612571">Traccia successiva</translation>
+<translation id="3859306556332390985">Posiziona avanti</translation>
+<translation id="8441146129660941386">Posiziona indietro</translation>
+<translation id="6706288973712894588">Al momento sei offline.\n<ph name="BEGIN_LINK"/>Esplora il tuo feed offline.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Schede recenti</translation>
+<translation id="8497726226069778601">Qui non c'è ancora niente</translation>
+<translation id="5423934151118863508">Le pagine che visiti più spesso verranno visualizzate qui</translation>
+<translation id="6127379762771434464">Elemento rimosso</translation>
+<translation id="4605958867780575332">Elemento rimosso: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle di Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Altri dispositivi</translation>
+<translation id="4738836084190194332">Ultima sincronizzazione: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minuto fa}other{# minuti fa}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# ora fa}other{# ore fa}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# giorno fa}other{# giorni fa}}</translation>
+<translation id="2762000892062317888">in questo istante</translation>
+<translation id="1407135791313364759">Apri tutte</translation>
+<translation id="1209206284964581585">Nascondi per ora</translation>
+<translation id="129553762522093515">Chiuse di recente</translation>
+<translation id="8413126021676339697">Mostra cronologia completa</translation>
+<translation id="7876243839304621966">Rimuovi tutto</translation>
+<translation id="8487700953926739672">Disponibile offline</translation>
+<translation id="5224771365102442243">Con video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Ulteriori informazioni<ph name="END_LINK"/> sui contenuti suggeriti</translation>
+<translation id="7542481630195938534">Impossibile ricevere suggerimenti</translation>
+<translation id="5013696553129441713">Nessun nuovo suggerimento</translation>
+<translation id="1736419249208073774">Esplora</translation>
+<translation id="7444811645081526538">Altre categorie</translation>
+<translation id="6709133671862442373">Notizie</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Shopping</translation>
+<translation id="3912508018559818924">Stiamo cercando il meglio sul Web…</translation>
+<translation id="526421993248218238">Impossibile caricare la pagina</translation>
+<translation id="614940544461990577">Prova a:</translation>
+<translation id="3288003805934695103">Ricaricare la pagina</translation>
+<translation id="2353636109065292463">Controllare la connessione a Internet</translation>
+<translation id="2858138569776157458">Siti princ.</translation>
+<translation id="8364299278605033898">Scopri i siti web più visitati</translation>
+<translation id="1171770572613082465">Scopri i siti web più visitati toccando il pulsante "Siti principali"</translation>
+<translation id="5233638681132016545">Nuova scheda</translation>
+<translation id="4521874409998847950">Di <ph name="PUBLISHER_ORIGIN"/> - <ph name="BEGIN_DEEMPHASIZED"/>pubblicata da Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Nuova versione disponibile</translation>
+<translation id="4058091506841967397">Imp. aggiornare Brave</translation>
+<translation id="6316139424528454185">Vers. Android non supportata</translation>
+<translation id="6989267951144302301">Download non riuscito</translation>
+<translation id="624789221780392884">Aggiornamento pronto</translation>
+<translation id="1549000191223877751">Passa a un'altra finestra</translation>
+<translation id="7481312909269577407">Avanti</translation>
+<translation id="4084682180776658562">Aggiungi ai Preferiti</translation>
+<translation id="6437478888915024427">Informazioni sulla pagina</translation>
+<translation id="7180611975245234373">Aggiorna</translation>
+<translation id="4913169188695071480">Interrompi aggiornamento</translation>
+<translation id="1829244130665387512">Trova nella pagina</translation>
+<translation id="6593061639179217415">Sito desktop</translation>
+<translation id="9063523880881406963">Disattiva Richiedi sito desktop</translation>
+<translation id="2038563949887743358">Attiva Richiedi sito desktop</translation>
+<translation id="2433507940547922241">Aspetto</translation>
+<translation id="983192555821071799">Chiudi tutte le schede</translation>
+<translation id="1310482092992808703">Raggruppa schede</translation>
+<translation id="7725024127233776428">Le pagine aggiunte ai preferiti saranno mostrate qui</translation>
+<translation id="4404568932422911380">Nessun segnalibro</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> preferito}other{<ph name="BOOKMARKS_COUNT_MANY"/> preferiti}}</translation>
+<translation id="3739899004075612870">Aggiunto ai preferiti di <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Aggiunto ai preferiti</translation>
+<translation id="4452548195519783679">Preferito aggiunto in: <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Impossibile aggiungere preferito.</translation>
+<translation id="2842985007712546952">Cartella principale</translation>
+<translation id="9065203028668620118">Modifica</translation>
+<translation id="4405224443901389797">Sposta in…</translation>
+<translation id="5170568018924773124">Mostra nella cartella</translation>
+<translation id="8035133914807600019">Nuova cartella…</translation>
+<translation id="4532845899244822526">Scegli cartella</translation>
+<translation id="6627583120233659107">Modifica cartella</translation>
+<translation id="1197267115302279827">Sposta i Preferiti</translation>
+<translation id="6963766334940102469">Elimina Preferiti</translation>
+<translation id="4351244548802238354">Chiudi finestra di dialogo</translation>
+<translation id="451872707440238414">Cerca nei preferiti</translation>
+<translation id="8901170036886848654">Nessun preferito trovato</translation>
+<translation id="6404511346730675251">Modifica preferito</translation>
+<translation id="3894427358181296146">Aggiungi cartella</translation>
+<translation id="5327248766486351172">Nome</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Cartella</translation>
+<translation id="5161254044473106830">Titolo obbligatorio</translation>
+<translation id="2996809686854298943">URL obbligatorio</translation>
+<translation id="2536728043171574184">È visualizzata una copia offline della pagina</translation>
+<translation id="4698034686595694889">Visualizza offline in <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> e altri siti</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave caricherà la tua pagina quando sarà pronta}other{Brave caricherà le tue pagine quando saranno pronte}}</translation>
+<translation id="6811034713472274749">La pagina è pronta per essere visualizzata</translation>
+<translation id="4561979708150884304">Nessuna connessione</translation>
+<translation id="8274165955039650276">Visualizza i download</translation>
+<translation id="2082238445998314030">Risultato <ph name="RESULT_NUMBER"/> di <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Nessun risultato</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Nessuna ricerca vocale attiva disponib.</translation>
+<translation id="7191430249889272776">Scheda aperta in background.</translation>
+<translation id="8445059357334030806">Apri in Brave</translation>
+<translation id="4720023427747327413">Apri in <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Apri nel browser</translation>
+<translation id="1113597929977215864">Mostra in visualizzazione semplificata</translation>
+<translation id="1513352483775369820">Preferiti e cronologia web</translation>
+<translation id="4939482511480190003">Contribuisci a migliorare Brave. <ph name="BEGIN_LINK"/>Rispondi al sondaggio<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Indietro</translation>
+<translation id="5596627076506792578">Altre opzioni</translation>
+<translation id="3522247891732774234">Aggiornamento disponibile. Altre opzioni</translation>
+<translation id="6773423637732432200">Impossibile aggiornare Brave. Altre opzioni</translation>
+<translation id="3328801116991980348">Informazioni sito</translation>
+<translation id="5391532827096253100">La tua connessione al sito non è sicura. Informazioni sul sito</translation>
+<translation id="6206551242102657620">La connessione è sicura. Informazioni sul sito</translation>
+<translation id="6963642900430330478">Questa pagina è pericolosa Informazioni sul sito</translation>
+<translation id="9070377983101773829">Avvia la ricerca vocale</translation>
+<translation id="8676374126336081632">Cancella testo inserito</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> scheda aperta, tocca per cambiare scheda}other{<ph name="OPEN_TABS_MANY"/> schede aperte, tocca per cambiare scheda}}</translation>
+<translation id="2369533728426058518">schede aperte</translation>
+<translation id="7071521146534760487">Gestisci account</translation>
+<translation id="932327136139879170">Home page</translation>
+<translation id="2707726405694321444">Aggiorna la pagina</translation>
+<translation id="2891154217021530873">Interrompe il caricamento della pagina</translation>
+<translation id="6710213216561001401">Indietro</translation>
+<translation id="6659594942844771486">TAB</translation>
+<translation id="1933845786846280168">Scheda selezionata</translation>
+<translation id="2268044343513325586">Perfeziona</translation>
+<translation id="7846076177841592234">Annulla selezione</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> elementi selezionati. Opzioni disponibili nella parte superiore dello schermo</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> elementi selezionati</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Condividi 1 elemento selezionato}other{Condividi # elementi selezionati}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Rimuovi 1 elemento selezionato}other{Rimuovi # elementi selezionati}}</translation>
+<translation id="1283039547216852943">Tocca per espandere</translation>
+<translation id="5962718611393537961">Tocca per comprimere</translation>
+<translation id="8076492880354921740">Schede</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 elemento selezionato}other{# elementi selezionati}}</translation>
+<translation id="6818926723028410516">Seleziona elementi</translation>
+<translation id="4797039098279997504">Tocca per tornare a <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Tocca per visitare il sito</translation>
+<translation id="429312253194641664">Un sito sta riproducendo contenuti multimediali</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> sta condividendo il tuo schermo</translation>
+<translation id="8833831881926404480">Un sito sta condividendo il tuo schermo</translation>
+<translation id="9086455579313502267">Impossibile accedere alla rete</translation>
+<translation id="938850635132480979">Errore: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Apri in <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Apri nell'app di mappe</translation>
+<translation id="7698359219371678927">Crea email in <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Crea email</translation>
+<translation id="5665379678064389456">Crea evento in <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Crea evento</translation>
+<translation id="2111511281910874386">Vai alla pagina</translation>
+<translation id="3988466920954086464">Visualizza i risultati della ricerca immediata in questo riquadro</translation>
+<translation id="2744248271121720757">Tocca una parola per eseguire una ricerca immediata o visualizzare le azioni correlate</translation>
+<translation id="9155898266292537608">Per eseguire una ricerca, basta un rapido tocco su una parola</translation>
+<translation id="3232754137068452469">App web</translation>
+<translation id="1430915738399379752">Stampa</translation>
+<translation id="3775705724665058594">Invia ai tuoi dispositivi</translation>
+<translation id="6364438453358674297">Rimuovere il suggerimento dalla cronologia?</translation>
+<translation id="213279576345780926">La scheda <ph name="TAB_TITLE"/> è stata chiusa</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> schede chiuse</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> è stato eliminato</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> Preferiti eliminati</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> download eliminati</translation>
+<translation id="1248710015876067820">Numero di istanze di Brave non supportato.</translation>
+<translation id="4259722352634471385">Navigazione bloccata: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigazione inaccessibile: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Chiudi scheda</translation>
+<translation id="7772375229873196092">Chiudi <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Cronologia di navigazione</translation>
+<translation id="9169507124922466868">La cronologia di navigazione è aperta fino a metà</translation>
+<translation id="1327257854815634930">La cronologia di navigazione è aperta</translation>
+<translation id="8788265440806329501">La cronologia di navigazione è chiusa</translation>
+<translation id="7482656565088326534">Scheda di anteprima</translation>
+<translation id="8427875596167638501">La scheda di anteprima è aperta nella parte inferiore dello schermo</translation>
+<translation id="9102803872260866941">La scheda di anteprima è aperta</translation>
+<translation id="2942036813789421260">La scheda di anteprima è chiusa</translation>
+<translation id="6355102470683871794">Spazio di archiviazione di Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Cancellare i dati dei siti?</translation>
+<translation id="9205995714227143200">Memoria utilizzata da siti che Brave non ritiene importanti (ad esempio siti senza impostazioni salvate o che non visiti spesso)</translation>
+<translation id="3997476611815694295">Memoria dati non importanti</translation>
+<translation id="8493948351860045254">Libera spazio</translation>
+<translation id="2324920234469020158">Verrà svuotata la cache e verranno cancellati i cookie e altri dati relativi a siti che Brave non ritiene importanti.</translation>
+<translation id="5447201525962359567">Tutta la memoria utilizzata da siti, tra cui cookie e altri dati memorizzati in locale</translation>
+<translation id="1376578503827013741">Elaborazione...</translation>
+<translation id="583281660410589416">Sconosciuto</translation>
+<translation id="2323763861024343754">Memoria utilizzata dai siti</translation>
+<translation id="3587672679800759167">Dati totali utilizzati da Brave, tra cui account, preferiti e impostazioni salvate</translation>
+<translation id="6545017243486555795">Cancella tutti i dati</translation>
+<translation id="4095146165863963773">Eliminare i dati delle app?</translation>
+<translation id="53119194224775367">Tutti i dati delle app di Brave saranno eliminati definitivamente. Sono inclusi tutti i file, le impostazioni, gli account, i database e così via.</translation>
+<translation id="5307446750509046227">Cancella dati dei siti</translation>
+<translation id="300526633675317032">Verranno cancellati tutti i <ph name="SIZE_IN_KB"/> di memoria utilizzata dai siti web.</translation>
+<translation id="8068648041423924542">Impossibile selezionare il certificato.</translation>
+<translation id="2315043854645842844">La selezione del certificato lato client non è supportata dal sistema operativo.</translation>
+<translation id="5011311129201317034">Il sito <ph name="SITE"/> desidera collegarsi</translation>
+<translation id="5308380583665731573">Connessione</translation>
+<translation id="868929229000858085">Cerca nei contatti</translation>
+<translation id="1919950603503897840">Seleziona contatti</translation>
+<translation id="7986741934819883144">Seleziona un contatto</translation>
+<translation id="3333961966071413176">Tutti i contatti</translation>
+<translation id="4994033804516042629">Nessun contatto trovato</translation>
+<translation id="5403592356182871684">Nomi</translation>
+<translation id="2717722538473713889">Indirizzi email</translation>
+<translation id="381841723434055211">Numeri di telefono</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 altro)}other{(+ altri #)}}</translation>
+<translation id="5197729504361054390">I contatti che selezioni verranno condivisi con <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Decoder di immagini</translation>
+<translation id="8067883171444229417">Guarda il video</translation>
+<translation id="6560414384669816528">Ricerche con Sogou</translation>
+<translation id="5406914950576900927">Brave può usare <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> per le ricerche in Cina. Puoi modificare questa preferenza nelle <ph name="BEGIN_LINK"/>Impostazioni<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Mantieni Brave Software</translation>
+<translation id="4384468725000734951">Sogou in uso per la ricerca</translation>
+<translation id="6103327872225198548">Brave Software in uso per la ricerca</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Questa app è in esecuzione in Brave</translation>
+<translation id="6143689084714664628">In esecuzione in Brave</translation>
+<translation id="7675869148432102528">Anche <ph name="APP_NAME"/> presenta dati in Brave</translation>
+<translation id="2734140769649165081">Puoi cancellare i dati nelle Impostazioni di Brave</translation>
+<translation id="8232956427053453090">Conserva i dati</translation>
+<translation id="4298388696830689168">Siti collegati</translation>
+<translation id="5763514718066511291">Tocca per copiare l'URL di quest'app</translation>
+<translation id="6496823230996795692">Connettiti a Internet per usare <ph name="APP_NAME"/> per la prima volta.</translation>
+<translation id="751961395872307827">Impossibile connettersi al sito</translation>
+<translation id="4878404682131129617">Creazione di un tunnel tramite server proxy non riuscita</translation>
+<translation id="4749960740855309258">Apri una nuova scheda</translation>
+<translation id="8788968922598763114">Riapri l'ultima scheda chiusa</translation>
+<translation id="7929962904089429003">Apri il menu</translation>
+<translation id="6039379616847168523">Vai alla scheda successiva</translation>
+<translation id="5210286577605176222">Vai alla scheda precedente</translation>
+<translation id="124678866338384709">Chiudi scheda corrente</translation>
+<translation id="3714981814255182093">Apri la barra Trova</translation>
+<translation id="5441522332038954058">Vai alla barra degli indirizzi</translation>
+<translation id="3398320232533725830">Apri Gestione Preferiti</translation>
+<translation id="6583199322650523874">Aggiungi la pagina corrente ai Preferiti</translation>
+<translation id="8489271220582375723">Apri la pagina Cronologia</translation>
+<translation id="4837753911714442426">Apri la pagina delle opzioni di stampa</translation>
+<translation id="5726692708398506830">Ingrandisci i contenuti della pagina</translation>
+<translation id="3259831549858767975">Rimpicciolisci i contenuti della pagina</translation>
+<translation id="8015452622527143194">Ripristina le dimensioni predefinite della pagina</translation>
+<translation id="3443221991560634068">Ricarica la pagina corrente</translation>
+<translation id="123724288017357924">Ricarica pag. corr. Ignora i contenuti nella cache</translation>
+<translation id="305870044889644984">Apri Centro assistenza di Brave in nuova scheda</translation>
+<translation id="3166827708714933426">Scorciatoie di finestre e schede</translation>
+<translation id="3169981355900570544">Scorciatoie delle funzioni di Brave Software Brave</translation>
+<translation id="4558311620361989323">Scorciatoie delle pagine web</translation>
+<translation id="1908301351964700579">La modalità VR è ancora nella fase preparatoria in Brave. Riavvia Brave più tardi.</translation>
+<translation id="8970887620466824814">C'è stato un problema.</translation>
+<translation id="1875543012935658554">Riapri Brave.</translation>
+<translation id="79859296434321399">Per visualizzare i contenuti di realtà aumentata, installa ARCore</translation>
+<translation id="8558485628462305855">Per visualizzare i contenuti di realtà aumentata, aggiorna ARCore</translation>
+<translation id="3513704683820682405">Realtà aumentata</translation>
+<translation id="5475862044948910901">Vuoi avviare una sessione di realtà aumentata?</translation>
 <translation id="7365126855094612066">Per la durata di questa sessione, il sito potrà:
 • Creare una mappa 3D del tuo ambiente.
 • Monitorare il movimento della videocamera.
 
 Il sito NON ottiene l'accesso alla videocamera. Le immagini della videocamera sono visibili soltanto a te.</translation>
-<translation id="7375125077091615385">Tipo:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Esperienza prima esecuzione di Chrome</translation>
-<translation id="741204030948306876">Sì, accetto</translation>
-<translation id="7413229368719586778">Data di inizio: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Chiedi prima</translation>
-<translation id="7423538860840206698">Lettura degli appunti non consentita</translation>
-<translation id="7431991332293347422">Controlla la modalità di utilizzo della cronologia di navigazione per personalizzare la Ricerca e non solo</translation>
-<translation id="7437998757836447326">Esci da Chrome</translation>
-<translation id="7438641746574390233">Quando la modalità Lite è attiva, Chrome utilizza i server di Google per caricare più velocemente le pagine. La modalità Lite riscrive le pagine molto lente in modo che carichino solo i contenuti essenziali. La modalità Lite non si applica alle schede di navigazione in incognito.</translation>
-<translation id="7444811645081526538">Altre categorie</translation>
-<translation id="7445411102860286510">Consenti ai siti di riprodurre automaticamente i video con audio disattivato (opzione consigliata)</translation>
-<translation id="7453467225369441013">Verrai disconnesso dalla maggior parte dei siti, ma non dal tuo Account Google.</translation>
-<translation id="7454641608352164238">Spazio insufficiente</translation>
-<translation id="7475192538862203634">Se il problema si verifica di frequente, prova questi <ph name="BEGIN_LINK" />suggerimenti<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Scheda SD non trovata. Potrebbero mancare alcuni dei tuoi file.</translation>
-<translation id="7479104141328977413">Gestione schede</translation>
-<translation id="7481312909269577407">Avanti</translation>
-<translation id="7482656565088326534">Scheda di anteprima</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Ultimo aggiornamento: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">di dati risparmiati</translation>
-<translation id="7498271377022651285">Attendi…</translation>
-<translation id="7514365320538308">Scarica</translation>
-<translation id="751961395872307827">Impossibile connettersi al sito</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Impossibile ricevere suggerimenti</translation>
-<translation id="7559975015014302720">La modalità Lite non è attiva</translation>
-<translation id="7562080006725997899">Cancellazione dei dati di navigazione in corso</translation>
-<translation id="756809126120519699">Dati di Chrome cancellati</translation>
-<translation id="757524316907819857">Impedisci ai siti di riprodurre contenuti protetti</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> file scaricato}other{<ph name="FILES_DOWNLOADED_MANY" /> file scaricati}}</translation>
-<translation id="7588219262685291874">Attiva il tema scuro quando sul dispositivo è attivo Risparmio energetico</translation>
-<translation id="7589445247086920869">Blocca per motore di ricerca corrente</translation>
-<translation id="7593557518625677601">Apri le impostazioni di Android e abilita nuovamente la sincronizzazione del sistema Android per poter avviare la Sicronizzazione Chrome</translation>
-<translation id="7596558890252710462">Sistema operativo</translation>
-<translation id="7605594153474022051">La sincronizzazione non funziona</translation>
-<translation id="7606077192958116810">La modalità Lite è attiva. Gestiscila nelle Impostazioni.</translation>
-<translation id="7612619742409846846">Accesso effettuato a Google come</translation>
-<translation id="7619072057915878432">Download di <ph name="FILE_NAME" /> non riuscito a causa di errori di rete.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Richiedi assistenza<ph name="END_LINK1" /> o <ph name="BEGIN_LINK2" />ripeti la ricerca<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Benvenuto in Chrome</translation>
-<translation id="7638584964844754484">Passphrase sbagliata</translation>
-<translation id="7641339528570811325">Cancella dati di navigazione…</translation>
-<translation id="7648422057306047504">Cripta le password con le credenziali Google</translation>
-<translation id="7649070708921625228">Guida</translation>
-<translation id="7658239707568436148">Annulla</translation>
-<translation id="7665369617277396874">Aggiungi account</translation>
-<translation id="766587987807204883">Qui vengono visualizzati gli articoli che potrai leggere anche offline</translation>
-<translation id="7682724950699840886">Prova i seguenti suggerimenti: assicurati di avere spazio sufficiente sul dispositivo e prova a esportare di nuovo.</translation>
-<translation id="7685301384041462804">Prima di accedere alla VR, verifica che questo sito sia attendibile.</translation>
-<translation id="7698359219371678927">Crea email in <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Completamento automatico di ricerche e URL</translation>
-<translation id="7725024127233776428">Le pagine aggiunte ai preferiti saranno mostrate qui</translation>
-<translation id="773466115871691567">Traduci sempre le pagine in <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Per rilevare app e siti pericolosi, Chrome invia a Google gli URL di alcune pagine che visiti, informazioni limitate sul sistema e i contenuti di alcune pagine</translation>
-<translation id="7757787379047923882">Testo condiviso da <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Scheda SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Aggiungi indirizzo</translation>
-<translation id="7772032839648071052">Conferma passphrase</translation>
-<translation id="7772375229873196092">Chiudi <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 e altri <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Ieri</translation>
-<translation id="7791543448312431591">Aggiungi</translation>
-<translation id="780301667611848630">No grazie</translation>
-<translation id="7810647596859435254">Apri con…</translation>
-<translation id="7821588508402923572">La quantità di dati risparmiata sarà visualizzata qui</translation>
-<translation id="7837721118676387834">Consenti la riproduzione automatica dei video con audio disattivato in un sito specifico.</translation>
-<translation id="7846076177841592234">Annulla selezione</translation>
-<translation id="784934925303690534">Intervallo di tempo</translation>
-<translation id="7851858861565204677">Altri dispositivi</translation>
-<translation id="7875915731392087153">Crea email</translation>
-<translation id="7876243839304621966">Rimuovi tutto</translation>
-<translation id="7882131421121961860">Nessuna cronologia trovata</translation>
-<translation id="7882806643839505685">Consenti l'audio per un sito specifico.</translation>
-<translation id="7886917304091689118">In esecuzione in Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Download del file.}other{Download di # file.}}</translation>
-<translation id="7929962904089429003">Apri il menu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> è obsoleto.</translation>
-<translation id="7947953824732555851">Accetta e accedi</translation>
-<translation id="7963646190083259054">Fornitore:</translation>
-<translation id="7971136598759319605">Attivo 1 giorno fa</translation>
-<translation id="7975379999046275268">Anteprima pagina <ph name="BEGIN_NEW" />Novità<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Le pagine vengono precaricate per velocizzare la navigazione e la ricerca</translation>
-<translation id="79859296434321399">Per visualizzare i contenuti di realtà aumentata, installa ARCore</translation>
-<translation id="7986741934819883144">Seleziona un contatto</translation>
-<translation id="7987073022710626672">Termini di servizio di Chrome</translation>
-<translation id="7998918019931843664">Riapri la scheda chiusa</translation>
-<translation id="7999064672810608036">Vuoi cancellare tutti i dati locali, inclusi i cookie, e reimpostare tutte le autorizzazioni relative al sito web?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Disattivata per questo dispositivo</translation>
-<translation id="8013372441983637696">Cancella i tuoi dati di Chrome anche da questo dispositivo</translation>
-<translation id="8015452622527143194">Ripristina le dimensioni predefinite della pagina</translation>
-<translation id="802154636333426148">Download non riuscito</translation>
-<translation id="8026334261755873520">Cancella dati di navigazione</translation>
-<translation id="8035133914807600019">Nuova cartella…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> giorni rimanenti</translation>
-<translation id="804335162455518893">Scheda SD non trovata</translation>
-<translation id="805047784848435650">In base alla tua cronologia di navigazione</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB disponibili</translation>
-<translation id="8058746566562539958">Apri in nuova scheda di Chrome</translation>
-<translation id="8063895661287329888">Impossibile aggiungere preferito.</translation>
-<translation id="806745655614357130">Mantieni separati i miei dati</translation>
-<translation id="8067883171444229417">Guarda il video</translation>
-<translation id="8068648041423924542">Impossibile selezionare il certificato.</translation>
-<translation id="8073388330009372546">Immagine in nuova scheda</translation>
-<translation id="8076492880354921740">Schede</translation>
-<translation id="8084114998886531721">Password salvata</translation>
-<translation id="8087000398470557479">Questi contenuti derivano da <ph name="DOMAIN_NAME" /> e sono offerti da Google.</translation>
-<translation id="8103578431304235997">Scheda di navigazione in incognito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Attiva la sincronizzazione per trovare i tuoi preferiti su tutti i dispositivi</translation>
-<translation id="8110087112193408731">Vuoi mostrare la tua attività di Chrome in Benessere digitale?</translation>
-<translation id="8116925261070264013">Con audio disattivato</translation>
-<translation id="813082847718468539">Visualizza informazioni sul sito</translation>
-<translation id="8131740175452115882">Conferma</translation>
-<translation id="8156139159503939589">In quali lingue sai leggere?</translation>
-<translation id="8168435359814927499">Contenuti</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> file rimanenti</translation>
-<translation id="8190358571722158785">1 giorno rimanente</translation>
-<translation id="8200772114523450471">Riprendi</translation>
-<translation id="8209050860603202033">Apri immagine</translation>
-<translation id="8218622182176210845">Gestisci il tuo account</translation>
-<translation id="8224471946457685718">Scarica articoli per te tramite Wi-Fi</translation>
-<translation id="8232956427053453090">Conserva i dati</translation>
-<translation id="8249310407154411074">Sposta in alto</translation>
-<translation id="8250920743982581267">Documenti</translation>
-<translation id="825412236959742607">Questa pagina utilizza troppa memoria, pertanto Chrome ha rimosso alcuni contenuti.</translation>
-<translation id="8260126382462817229">Prova ad accedere nuovamente</translation>
-<translation id="8261506727792406068">Elimina</translation>
-<translation id="8266862848225348053">Percorso di download</translation>
-<translation id="8274165955039650276">Visualizza i download</translation>
-<translation id="8284326494547611709">Sottotitoli</translation>
-<translation id="8300705686683892304">Gestiti dall'app</translation>
-<translation id="8310344678080805313">Schede standard</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> e altri siti</translation>
-<translation id="8327155640814342956">Per un'esperienza di navigazione ottimale, apri per aggiornare Chrome</translation>
-<translation id="8339163506404995330">Le pagine in <ph name="LANGUAGE" /> non verranno tradotte</translation>
-<translation id="8349013245300336738">Ordina per quantità di dati utilizzati</translation>
-<translation id="8364299278605033898">Scopri i siti web più visitati</translation>
-<translation id="8368027906805972958">Dispositivo sconosciuto o non supportato (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Consenti la sincronizzazione in background per un sito specifico.</translation>
-<translation id="8378714024927312812">Gestito dalla tua organizzazione</translation>
-<translation id="8380167699614421159">Questo sito mostra annunci invasivi o fuorvianti</translation>
-<translation id="8393700583063109961">Invia messaggio</translation>
-<translation id="8413126021676339697">Mostra cronologia completa</translation>
-<translation id="8427875596167638501">La scheda di anteprima è aperta nella parte inferiore dello schermo</translation>
-<translation id="8428213095426709021">Impostazioni</translation>
-<translation id="8438566539970814960">Migliora le ricerche e le attività di navigazione</translation>
-<translation id="8441146129660941386">Posiziona indietro</translation>
-<translation id="8443209985646068659">Imp. aggiornare Chrome</translation>
-<translation id="8445448999790540984">Impossibile esportare le password</translation>
-<translation id="8447861592752582886">Revoca autorizzazione dispositivo</translation>
-<translation id="8461694314515752532">Cripta i dati sincronizzati con la tua passphrase di sincronizzazione</translation>
-<translation id="8466613982764129868">Assicurati che il dispositivo <ph name="TARGET_DEVICE_NAME" /> sia connesso a Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponibile offline</translation>
-<translation id="8489271220582375723">Apri la pagina Cronologia</translation>
-<translation id="8493948351860045254">Libera spazio</translation>
-<translation id="8497726226069778601">Qui non c'è ancora niente</translation>
-<translation id="8503559462189395349">Password Chrome</translation>
-<translation id="8503813439785031346">Nome utente</translation>
-<translation id="8514477925623180633">Esporta le password memorizzate su Chrome</translation>
-<translation id="8514577642972634246">Accedi alla modalità di navigazione in incognito</translation>
-<translation id="851751545965956758">Impedisci ai siti di connettersi ai dispositivi</translation>
-<translation id="8523928698583292556">Elimina la password memorizzata</translation>
-<translation id="854522910157234410">Apri questa pagina</translation>
-<translation id="8558485628462305855">Per visualizzare i contenuti di realtà aumentata, aggiorna ARCore</translation>
-<translation id="8559990750235505898">Proponi di tradurre le pagine in altre lingue</translation>
-<translation id="8562452229998620586">Le password salvate verranno visualizzate qui.</translation>
-<translation id="8569404424186215731">dal giorno <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Ultime 4 settimane</translation>
-<translation id="857943718398505171">Consentita (opzione consigliata)</translation>
-<translation id="8583805026567836021">Cancellazione dati dell'account</translation>
-<translation id="860043288473659153">Nome del titolare della carta</translation>
-<translation id="8609465669617005112">Sposta su</translation>
-<translation id="8616006591992756292">Il tuo Account Google potrebbe avere altre forme di cronologia di navigazione all'indirizzo <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Aprire l'URL consigliato specificato nei contenuti scaricati?</translation>
-<translation id="8636825310635137004">Attiva la sincronizzazione per trovare le tue schede degli altri dispositivi.</translation>
-<translation id="8641930654639604085">Prova a bloccare siti per adulti</translation>
-<translation id="8655129584991699539">Puoi cancellare i dati nelle Impostazioni di Chrome</translation>
-<translation id="8662811608048051533">Verrai disconnesso dalla maggior parte dei siti.</translation>
-<translation id="8664979001105139458">Nome file già esistente</translation>
-<translation id="8676374126336081632">Cancella testo inserito</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Intensità del segnale: # barra}other{Intensità del segnale: # barre}}</translation>
-<translation id="868929229000858085">Cerca nei contatti</translation>
-<translation id="869891660844655955">Data di scadenza</translation>
-<translation id="8719023831149562936">Impossibile trasmettere scheda corrente</translation>
-<translation id="8725066075913043281">Riprova</translation>
-<translation id="8728487861892616501">Utilizzando questa applicazione, accetti i <ph name="BEGIN_LINK1" />Termini di servizio<ph name="END_LINK1" /> di Chrome, le <ph name="BEGIN_LINK2" />Norme sulla privacy<ph name="END_LINK2" /> e le <ph name="BEGIN_LINK3" />Norme sulla privacy per gli Account Google gestiti tramite Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Fine</translation>
-<translation id="8748850008226585750">Contenuti nascosti</translation>
-<translation id="8751914237388039244">Seleziona un'immagine</translation>
-<translation id="8788265440806329501">La cronologia di navigazione è chiusa</translation>
-<translation id="8788968922598763114">Riapri l'ultima scheda chiusa</translation>
-<translation id="8801436777607969138">Blocca JavaScript per un sito specifico.</translation>
-<translation id="8812260976093120287">In alcuni siti web puoi pagare con le suddette app di pagamento supportate sul tuo dispositivo.</translation>
-<translation id="8816026460808729765">Impedisci ai siti di accedere ai sensori</translation>
-<translation id="8816439037877937734">L'app <ph name="APP_NAME" /> verrà aperta in Chrome. Se continui, accetti i <ph name="BEGIN_LINK1" />Termini di servizio<ph name="END_LINK1" /> e l'<ph name="BEGIN_LINK2" />Informativa sulla privacy<ph name="END_LINK2" /> di Chrome, nonché l'<ph name="BEGIN_LINK3" />Informatica sulla privacy per gli Account Google gestiti tramite Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Preferiti</translation>
-<translation id="8833831881926404480">Un sito sta condividendo il tuo schermo</translation>
-<translation id="883806473910249246">Si è verificato un errore durante il download dei contenuti.</translation>
-<translation id="8840953339110955557">Questa pagina potrebbe essere diversa dalla versione online.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, scheda</translation>
-<translation id="885701979325669005">Dati memorizzati dai siti</translation>
-<translation id="889338405075704026">Apri le impostazioni di Chrome</translation>
-<translation id="8901170036886848654">Nessun preferito trovato</translation>
-<translation id="8909135823018751308">Condividi…</translation>
-<translation id="8912362522468806198">Google Account</translation>
-<translation id="8920114477895755567">In attesa dei dettagli sui genitori.</translation>
+<translation id="1188239144602654184">Entra in AR</translation>
+<translation id="473775607612524610">Aggiorna</translation>
+<translation id="3133489217401741157">Installazione di <ph name="MODULE"/> per Brave…</translation>
+<translation id="1791662854739702043">Installato</translation>
+<translation id="5131234170665854056">Impossibile installare <ph name="MODULE"/> per Brave</translation>
+<translation id="2567385386134582609">IMMAGINE</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Scarica le pagine per usarle offline</translation>
 <translation id="8922289737868596582">Usa il pulsante Altre opzioni per scaricare le pagine da usare offline</translation>
-<translation id="8937772741022875483">Vuoi rimuovere la tua attività di Chrome da Benessere digitale?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Apri nell'altra finestra</translation>
-<translation id="8951232171465285730">Chrome ti ha fatto risparmiare <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blocca i cookie per un sito specifico.</translation>
-<translation id="8959122750345127698">Navigazione inaccessibile: <ph name="URL" /></translation>
-<translation id="8965591936373831584">in attesa</translation>
-<translation id="8970887620466824814">C'è stato un problema.</translation>
-<translation id="8972098258593396643">Scaricare nella cartella predefinita?</translation>
-<translation id="8986494364107987395">Invia automaticamente a Google statistiche sull'utilizzo e rapporti sugli arresti anomali</translation>
-<translation id="8993760627012879038">Apri nuova scheda in mod. di navigaz. in incognito</translation>
-<translation id="8998729206196772491">Stai per eseguire l'accesso con un account gestito da <ph name="MANAGED_DOMAIN" /> e consentire al relativo amministratore di avere il controllo dei tuoi dati di Chrome. I tuoi dati verranno associati definitivamente a questo account. Se esci da Chrome, i dati verranno eliminati da questo dispositivo, ma rimarranno memorizzati nel tuo Account Google.</translation>
-<translation id="9019902583201351841">Gestito dai genitori</translation>
-<translation id="9028914725102941583">Attiva la sincronizzazione per la condivisione tra dispositivi</translation>
-<translation id="9029323097866369874">Consentire a <ph name="DOMAIN" /> di accedere alla VR?</translation>
-<translation id="9040142327097499898">Le notifiche sono consentite. La geolocalizzazione non è attiva per questo dispositivo.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# video}}</translation>
-<translation id="9050666287014529139">Passphrase</translation>
-<translation id="9063523880881406963">Disattiva Richiedi sito desktop</translation>
-<translation id="9065203028668620118">Modifica</translation>
-<translation id="9070377983101773829">Avvia la ricerca vocale</translation>
-<translation id="9074336505530349563">Per ricevere contenuti suggeriti appositamente per te da Google, accedi e attiva la sincronizzazione</translation>
-<translation id="9086455579313502267">Impossibile accedere alla rete</translation>
-<translation id="9100505651305367705">Chiedi di mostrare gli articoli in visualizzazione semplificata, se supportata</translation>
-<translation id="9100610230175265781">Passphrase obbligatoria</translation>
-<translation id="9102803872260866941">La scheda di anteprima è aperta</translation>
+<translation id="5958275228015807058">Puoi trovare i tuoi file e le tue pagine nella cartella Download</translation>
+<translation id="5620928963363755975">Usa il pulsante Altre opzioni per trovare i tuoi file e le tue pagine nella cartella Download</translation>
+<translation id="3341058695485821946">Scopri la quantità di dati risparmiata</translation>
+<translation id="3157842584138209013">Scopri la quantità di dati risparmiata usando il pulsante Altre opzioni</translation>
+<translation id="8218622182176210845">Gestisci il tuo account</translation>
+<translation id="8090895580117672212">Per gestire il tuo Account Brave Software, tocca il pulsante "Gestisci account"</translation>
+<translation id="8856898588039823173">Pagina Lite fornita da Brave Software. Tocca per caricare l'originale.</translation>
+<translation id="8134317863207426198">Pagina Lite fornita da Brave Software. Tocca il pulsante Carica originale per caricare la pagina originale.</translation>
+<translation id="4961107849584082341">Traduci questa pagina in qualsiasi lingua</translation>
+<translation id="569536719314091526">Traduci questa pagina in una lingua qualsiasi usando il pulsante Altre opzioni</translation>
+<translation id="1397811292916898096">Cerca con <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Modifica il percorso di download predefinito in qualsiasi momento</translation>
+<translation id="6942665639005891494">Modifica in qualsiasi momento il percorso di download predefinito utilizzando l'opzione del menu Impostazioni</translation>
+<translation id="6850409657436465440">Il download è ancora in corso</translation>
+<translation id="5817715962196959877">Ora Brave scarica i file più velocemente</translation>
+<translation id="3976396876660209797">Rimuovi e ricrea la scorciatoia</translation>
+<translation id="6766622839693428701">Fai scorrere verso il basso per chiudere.</translation>
+<translation id="1028699632127661925">Invio a <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Inviato da <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Scheda ricevuta</translation>
 <translation id="9104217018994036254">Elenco di dispositivi con cui condividere una scheda.</translation>
-<translation id="9133397713400217035">Esplora offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Mostra originale</translation>
-<translation id="9139068048179869749">Chiedi conferma prima di consentire ai siti di inviare notifiche (opzione consigliata)</translation>
-<translation id="9139318394846604261">Shopping</translation>
-<translation id="9155898266292537608">Per eseguire una ricerca, basta un rapido tocco su una parola</translation>
-<translation id="9169507124922466868">La cronologia di navigazione è aperta fino a metà</translation>
-<translation id="9204836675896933765">1 file rimanente</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Elenco di dispositivi con cui condividere una scheda aperto nella parte inferiore dello schermo.</translation>
+<translation id="2904414404539560095">Elenco di dispositivi con cui condividere una scheda aperto a schermo intero.</translation>
+<translation id="4135200667068010335">L'elenco di dispositivi con cui condividere una scheda è chiuso.</translation>
+<translation id="5292796745632149097">Invia a</translation>
+<translation id="1386674309198842382">Attivo <ph name="LAST_UPDATED"/> giorni fa</translation>
+<translation id="7971136598759319605">Attivo 1 giorno fa</translation>
+<translation id="1521774566618522728">Attivo oggi</translation>
+<translation id="3631987586758005671">Condivisione con <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Attiva la sincronizzazione per la condivisione tra dispositivi</translation>
+<translation id="6162454065885854378">Per condividere contenuti dal tuo telefono con un altro dispositivo, attiva la sincronizzazione nelle impostazioni di Brave su entrambi i dispositivi</translation>
+<translation id="6084271560289605378">Apri le impostazioni di Brave</translation>
+<translation id="2318045970523081853">Tocca per chiamare</translation>
 <translation id="9209888181064652401">Impossibile effettuare chiamate</translation>
-<translation id="9219103736887031265">Immagini</translation>
-<translation id="926205370408745186">Rimuovi la tua attività di Chrome da Benessere digitale</translation>
-<translation id="932327136139879170">Home page</translation>
-<translation id="938850635132480979">Errore: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Accesso al microfono</translation>
-<translation id="95817756606698420">Chrome può usare <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> per le ricerche in Cina. Puoi modificare questa preferenza nelle <ph name="BEGIN_LINK" />Impostazioni<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blocca se il sito mostra annunci invasivi o fuorvianti (consigliato)</translation>
-<translation id="968900484120156207">Le pagine visitate saranno mostrate qui</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> min rimanenti</translation>
-<translation id="974555521953189084">Inserisci la passphrase per avviare la sincronizzazione</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Questa operazione cancellerà i dati di tutti i siti, inclusi:</translation>
-<translation id="983192555821071799">Chiudi tutte le schede</translation>
-<translation id="987264212798334818">Generali</translation>
+<translation id="2860954141821109167">Assicurati che su questo dispositivo ci sia un'app per telefono attiva</translation>
+<translation id="2067805253194386918">testo</translation>
+<translation id="1450753235335490080">Impossibile condividere <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Impossibile condividere <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Assicurati che in Brave sia attiva la sincronizzazione di <ph name="TARGET_DEVICE_NAME"/></translation>
+<translation id="3016635187733453316">Assicurati che questo dispositivo sia connesso a Internet</translation>
+<translation id="8466613982764129868">Assicurati che il dispositivo <ph name="TARGET_DEVICE_NAME"/> sia connesso a Internet</translation>
+<translation id="6539092367496845964">Si è verificato un problema. Riprova più tardi.</translation>
+<translation id="3389286852084373014">Il testo è troppo grande</translation>
+<translation id="2100314319871056947">Prova a condividere il testo in parti più piccole</translation>
+<translation id="2987620471460279764">Testo condiviso da un altro dispositivo</translation>
+<translation id="7757787379047923882">Testo condiviso da <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Copiata nei tuoi appunti</translation>
+<translation id="4696983787092045100">Invia un messaggio ai tuoi dispositivi</translation>
+<translation id="1260236875608242557">Cerca ed esplora</translation>
+<translation id="6369229450655021117">Da qui puoi eseguire ricerche sul Web, condividere contenuti con amici e vedere le pagine aperte.</translation>
+<translation id="723171743924126238">Seleziona immagini</translation>
+<translation id="8751914237388039244">Seleziona un'immagine</translation>
+<translation id="1989112275319619282">Esplora</translation>
+<translation id="7055152154916055070">Reindirizzamento bloccato:</translation>
+<translation id="5524843473235508879">Reindirizzamento bloccato.</translation>
+<translation id="6573096386450695060">Consenti sempre</translation>
+<translation id="5805364706385912897">Questa pagina è stata messa in pausa da Brave perché utilizza troppa memoria.</translation>
+<translation id="5138664332909611586">Questa pagina utilizza troppa memoria, pertanto Brave ha rimosso alcuni contenuti.</translation>
+<translation id="9137013805542155359">Mostra originale</translation>
+<translation id="6361779936989026201">Assistente Brave Software in Brave</translation>
+<translation id="7291387454912369099">Pagamento con assistente</translation>
+<translation id="4565206163201411670">Vuoi mostrare la tua attività di Brave in Benessere digitale?</translation>
+<translation id="9055113864158719823">Puoi vedere i siti che visiti in Brave e impostare dei timer per ciascuno di essi.\n\nBrave Software riceve informazioni sui siti per i quali imposti dei timer e sul tempo che trascorri a visitarli. Queste informazioni sono utilizzate al fine di migliorare Benessere digitale.</translation>
+<translation id="4596514158372210596">Rimuovi la tua attività di Brave da Benessere digitale</translation>
+<translation id="1174893863889683998">Vuoi rimuovere la tua attività di Brave da Benessere digitale?</translation>
+<translation id="708829030563435351">I siti che visiti in Brave non verranno mostrati. Tutti i timer dei siti saranno eliminati.</translation>
+<translation id="2056878612599315956">Sito in pausa</translation>
+<translation id="671481426037969117">Il timer di <ph name="FQDN"/> è scaduto. Verrà riavviato domani.</translation>
+<translation id="7479104141328977413">Gestione schede</translation>
+<translation id="3524138585025253783">Sviluppatore UI</translation>
+<translation id="6036057147555329831">ICU extra</translation>
+<translation id="9029323097866369874">Consentire a <ph name="DOMAIN"/> di accedere alla VR?</translation>
+<translation id="7685301384041462804">Prima di accedere alla VR, verifica che questo sito sia attendibile.</translation>
+<translation id="5033865233969348410">Mentre ti trovi nella VR, il sito potrebbe riuscire ad acquisire:
+  -  dati sulle tue caratteristiche fisiche, come l'altezza
+
+Prima di accedere alla VR, verifica che questo sito sia attendibile.</translation>
+<translation id="5534334044554683961">Mentre ti trovi nella VR, il sito potrebbe riuscire ad acquisire:
+  -   dati sulle tue caratteristiche fisiche, come l'altezza
+  -   dati sulla struttura della stanza
+
+Prima di accedere alla VR, verifica che questo sito sia attendibile.</translation>
+<translation id="4169535189173047238">Non consentire</translation>
+<translation id="2170088579611075216">Consenti ed entra nella VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_iw.xtb
+++ b/android/java/strings/translations/android_chrome_strings_iw.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="iw">
-<translation id="1006017844123154345">פתח גרסה מקוונת</translation>
-<translation id="1028699632127661925">הכרטיסייה נשלחת אל <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">מוסיף את <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">מאתרים</translation>
-<translation id="1049743911850919806">גלישה פרטית</translation>
-<translation id="10614374240317010">פריטים שאף פעם לא נשמרו</translation>
-<translation id="1067922213147265141">‏שירותי Google אחרים</translation>
-<translation id="1068672505746868501">אף פעם אל תתרגם דפים ב<ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">שינוי של סיומת הקובץ עשוי לגרום לכך שהקובץ ייפתח באפליקציה אחרת. מצב זה עלול לסכן את המכשיר.</translation>
-<translation id="1100066534610197918">פתיחה בכרטיסייה חדשה בקבוצה</translation>
-<translation id="1105960400813249514">צילום מסך</translation>
-<translation id="1111673857033749125">סימניות שנשמרו במכשירים האחרים שלך יופיעו כאן.</translation>
-<translation id="1113597929977215864">צפייה בתצוגה נקייה</translation>
-<translation id="1121094540300013208">דוחות קריסה ושימוש</translation>
-<translation id="1124772482545689468">משתמש</translation>
-<translation id="1129510026454351943">פרטים: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{הורדה אחת בהמתנה.}two{# הורדות בהמתנה.}many{# הורדות בהמתנה.}other{# הורדות בהמתנה.}}</translation>
-<translation id="1145536944570833626">מחק נתונים קיימים.</translation>
-<translation id="1146678959555564648">‏כניסה למצב VR</translation>
-<translation id="116280672541001035">צרכת</translation>
-<translation id="1171770572613082465">הקשה על הלחצן "אתרים נבחרים" תציג אתרים פופולריים</translation>
-<translation id="1173894706177603556">שנה שם</translation>
-<translation id="1178581264944972037">השהה</translation>
-<translation id="1181037720776840403">הסרה</translation>
-<translation id="1188239144602654184">‏כניסה ל-AR</translation>
-<translation id="1197267115302279827">העבר סימניות</translation>
-<translation id="119944043368869598">ניקוי הכל</translation>
-<translation id="1201402288615127009">הבא</translation>
-<translation id="1204037785786432551">הורדת קישור</translation>
-<translation id="1206892813135768548">העתקת טקסט קישור</translation>
-<translation id="1208340532756947324">כדי לסנכרן ולהתאים אישית את החוויה במכשירים שונים, יש להפעיל את הסנכרון</translation>
-<translation id="1209206284964581585">הסתר בינתיים</translation>
-<translation id="1227058898775614466">היסטוריית ניווט</translation>
-<translation id="1231733316453485619">להפעיל סנכרון?</translation>
-<translation id="123724288017357924">טען מחדש את הדף הנוכחי, תוך התעלמות מתוכן שמאוחסן בקובץ השמור</translation>
-<translation id="124116460088058876">שפות נוספות</translation>
-<translation id="124678866338384709">סגור את הכרטיסייה הנוכחית</translation>
-<translation id="1258753120186372309">‏דודל של Google‏: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">חיפוש ודפדוף</translation>
-<translation id="1264974993859112054">ספורט</translation>
-<translation id="1266864766717917324">לא ניתן היה לשתף את ה<ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">הפסק</translation>
-<translation id="1283039547216852943">הקש כדי להרחיב</translation>
-<translation id="1285320974508926690">איני רוצה לקבל תרגום של אתר זה</translation>
-<translation id="1291207594882862231">‏ניקוי ההיסטוריה, קובצי ה-Cookie, נתוני האתרים, המטמון…</translation>
-<translation id="129382876167171263">קבצים שנשמרו על ידי אתרים מופיעים כאן</translation>
-<translation id="129553762522093515">נסגרו לאחרונה</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> — נשלחה מ-<ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">קיבוץ כרטיסיות</translation>
-<translation id="1327257854815634930">היסטוריית הניווט פתוחה</translation>
-<translation id="1331212799747679585">‏לא ניתן לעדכן את Chrome. אפשרויות נוספות</translation>
-<translation id="1332501820983677155">‏מקשי קיצור לתכונות של Google Chrome‏</translation>
-<translation id="1360432990279830238">לצאת ולהשבית את הסנכרון?</translation>
-<translation id="1369915414381695676">האתר <ph name="SITE_NAME" /> נוסף</translation>
-<translation id="1373696734384179344">אין מספיק זיכרון להורדת התוכן הנבחר.</translation>
-<translation id="1376578503827013741">מחשב...</translation>
-<translation id="1383876407941801731">חפש</translation>
-<translation id="1384959399684842514">ההורדה הושהתה</translation>
-<translation id="1386674309198842382">פעילות אחרונה: לפני <ph name="LAST_UPDATED" /> ימים</translation>
-<translation id="1397811292916898096">חיפוש באמצעות <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">מוטבע ב-<ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">‏'לא לעקוב (DNT)'</translation>
-<translation id="1407135791313364759">פתח הכל</translation>
-<translation id="1409426117486808224">תצוגה פשוטה של כרטיסיות פתוחות</translation>
-<translation id="1409879593029778104">הורדת <ph name="FILE_NAME" /> נמנעה מכיוון שהקובץ כבר קיים.</translation>
-<translation id="1414981605391750300">‏המערכת יוצרת קשר עם Google. עוד מעט מסיימים…</translation>
-<translation id="1416550906796893042">גרסת אפליקציה</translation>
-<translation id="1430915738399379752">הדפסה</translation>
-<translation id="1446450296470737166">‏התר שליטה מלאה על מכשירי MIDI</translation>
-<translation id="1450753235335490080">לא ניתן לשתף את ה<ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">‏כבוי בהגדרות Android</translation>
-<translation id="1477626028522505441">הורדת <ph name="FILE_NAME" /> נכשלה עקב בעיות בשרת.</translation>
-<translation id="1506061864768559482">מנוע חיפוש</translation>
-<translation id="1513352483775369820">סימניות והיסטוריית אתרים</translation>
-<translation id="1513858653616922153">מחק סיסמה</translation>
-<translation id="1516229014686355813">‏התכונה 'הקשה כדי לחפש' שולחת אל חיפוש Google את המילה הנבחרת, יחד עם הדף הנוכחי בתור הקשר. ניתן לכבות תכונה זאת ב<ph name="BEGIN_LINK" />הגדרות<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">שימוש אחרון: היום</translation>
-<translation id="1544826120773021464">‏כדי לנהל את חשבון Google, יש להקיש על הלחצן "ניהול החשבון"</translation>
-<translation id="1549000191223877751">העבר לחלון האחר</translation>
-<translation id="1553358976309200471">‏כדאי לעדכן את Chrome</translation>
-<translation id="1569387923882100876">מכשיר מחובר</translation>
-<translation id="1571304935088121812">העתק שם משתמש</translation>
-<translation id="1612196535745283361">‏כדי לבצע סריקה לאיתור מכשירים, Chrome זקוק לגישה לנתוני מיקום. הגישה למיקום <ph name="BEGIN_LINK" />כבויה במכשיר הזה<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">מצלמה</translation>
-<translation id="1623104350909869708">מנע מהדף זה ליצור תיבות דו-שיח נוספות</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{הסר פריט אחד שנבחר}two{הסר # פריטים שנבחרו}many{הסר # פריטים שנבחרו}other{הסר # פריטים שנבחרו}}</translation>
-<translation id="164269334534774161">אתה מציג עותק לא מקוון של הדף הזה מ-<ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">היסטוריה</translation>
-<translation id="1647391597548383849">גישה אל המצלמה שלך</translation>
-<translation id="1660204651932907780">מתן הרשאה לאתרים להשמיע צלילים (מומלץ)</translation>
-<translation id="1670399744444387456">בסיסי</translation>
-<translation id="1671236975893690980">ההורדה תיכף תתחיל…</translation>
-<translation id="1672586136351118594">אין להציג שוב</translation>
-<translation id="1692118695553449118">סנכרון מופעל</translation>
-<translation id="169515064810179024">חסימת הגישה של אתרים אל חיישני תנועה</translation>
-<translation id="1717218214683051432">חיישני תנועה</translation>
-<translation id="1718835860248848330">מהשעה האחרונה</translation>
-<translation id="1736419249208073774">מידע נוסף</translation>
-<translation id="1743802530341753419">הצגת בקשה לפני מתן אישור לאתרים להתחבר להתקן (מומלץ)</translation>
-<translation id="1749561566933687563">סנכרון הסימניות שלך</translation>
-<translation id="17513872634828108">כרטיסיות פתוחות</translation>
-<translation id="1779089405699405702">מפענח התמונות</translation>
-<translation id="1782483593938241562">תאריך סיום <ph name="DATE" /></translation>
-<translation id="1791662854739702043">מותקן</translation>
-<translation id="1792959175193046959">אפשר תמיד לשנות את מיקום ההורדות</translation>
-<translation id="1807246157184219062">בהיר</translation>
-<translation id="1810845389119482123">ההגדרה הראשונית של הסנכרון לא הושלמה</translation>
-<translation id="1821253160463689938">‏שימוש בקובצי cookie כדי לשמור את ההעדפות שלך, גם אם לא נכנסת אל הדפים האלה</translation>
-<translation id="1829244130665387512">חיפוש בדף</translation>
-<translation id="1853692000353488670">כרטיסייה חדשה לגלישה בסתר</translation>
-<translation id="1856325424225101786">לאפס את מצב הטעינה המהירה?</translation>
-<translation id="1868024384445905608">‏הורדת קבצים ב-Chrome מתבצעת עכשיו מהר יותר</translation>
-<translation id="1883903952484604915">הקבצים שלי</translation>
-<translation id="1887786770086287077">‏הגישה למיקום כבויה בשביל המכשיר הזה. יש להפעיל אותה ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">‏האפליקציה <ph name="APP_NAME" /> תיפתח ב-Chrome. המשך השימוש מבטא את הסכמתך ל<ph name="BEGIN_LINK1" />תנאים ולהגבלות<ph name="END_LINK1" /> ול<ph name="BEGIN_LINK2" />הודעת הפרטיות<ph name="END_LINK2" /> של Chrome.</translation>
-<translation id="1919345977826869612">מודעות</translation>
-<translation id="1919950603503897840">בחירת אנשי קשר</translation>
-<translation id="1922076542920281912">‏כדי לאפשר ל-Chrome לגשת אל המיקום, צריך להפעיל את האפשרות הזו גם ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">עדכונים</translation>
-<translation id="19288952978244135">‏יש לפתוח מחדש את Chrome.</translation>
-<translation id="1933845786846280168">הכרטיסייה שנבחרה</translation>
-<translation id="194341124344773587">‏הפעלת הרשאה ל-Chrome ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">שמירת סיסמאות</translation>
-<translation id="1952172573699511566">אתרים יציגו טקסט בשפה המועדפת שלך, כשזה אפשרי.</translation>
-<translation id="1960290143419248813">‏עדכוני Chrome לא נתמכים יותר בגרסה הזו של Android</translation>
-<translation id="1966710179511230534">יש לעדכן את פרטי הכניסה שלך.</translation>
-<translation id="1974060860693918893">מתקדם</translation>
-<translation id="1984705450038014246">‏סנכרון הנתונים מ-Chrome</translation>
-<translation id="1984937141057606926">מותר, מלבד צד שלישי</translation>
-<translation id="1986685561493779662">השם כבר קיים</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> לחצן <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">דפדף</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> רוצה לבצע התאמה עם</translation>
-<translation id="1994173015038366702">כתובת אתר</translation>
-<translation id="2000419248597011803">‏שליחה של חלק מקובצי ה-Cookie והחיפושים משורת כתובת האתר ומתיבת החיפוש אל מנוע החיפוש שהוגדר כברירת מחדל</translation>
-<translation id="2002537628803770967">‏כרטיסי אשראי וכתובות דרך Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{קובץ אחד (#)}two{# קבצים}many{# קבצים}other{# קבצים}}</translation>
-<translation id="2017836877785168846">ניקוי של ההיסטוריה וההשלמות האוטומטיות בשורת כתובת האתר</translation>
-<translation id="2021896219286479412">פקדי אתר במסך מלא</translation>
-<translation id="2038563949887743358">הפעל את 'בקש אתר עבור מחשב שולחני'</translation>
-<translation id="2041019821020695769">‏כדי לאפשר ל-Chrome לשלוח לך התראות, צריך להפעיל אותן גם ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">‏ל-<ph name="APP_NAME" /> יש נתונים גם ב-Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">האתר מושהה</translation>
-<translation id="2063713494490388661">הקש כדי לחפש</translation>
-<translation id="2067805253194386918">טקסט</translation>
-<translation id="2079545284768500474">ביטול הפעולה</translation>
-<translation id="2082238445998314030">תוצאה <ph name="RESULT_NUMBER" /> מתוך <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">צליל</translation>
-<translation id="2096012225669085171">סנכרון והתאמה אישית במכשירים שונים</translation>
-<translation id="2100273922101894616">כניסה אוטומטית</translation>
-<translation id="2100314319871056947">כדאי לשתף את הטקסט במקטעים קטנים יותר</translation>
-<translation id="2107397443965016585">יש לבקש ממני אישור לפני מתן הרשאה לאתרים להציג תוכן מוגן (מומלץ)</translation>
-<translation id="2111511281910874386">מעבר לדף</translation>
-<translation id="2122601567107267586">לא ניתן היה לפתוח את היישום</translation>
-<translation id="2126426811489709554">‏מבוסס על Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> נשמרו</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> נסגר</translation>
-<translation id="2139186145475833000">הוספה לדף הבית</translation>
-<translation id="2146738493024040262">פתח אפליקציית אינסטנט</translation>
-<translation id="2148716181193084225">היום</translation>
-<translation id="2154484045852737596">עריכת כרטיס</translation>
-<translation id="2154710561487035718">העתק כתובת אתר</translation>
-<translation id="2156074688469523661">אתרים שנותרו (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">‏כדי לשתף משהו מהטלפון שלך עם מכשיר אחר, יש להפעיל את הסנכרון בהגדרות Chrome בשני המכשירים</translation>
-<translation id="2170088579611075216">‏הפעלת VR וכניסה ל-VR</translation>
-<translation id="218608176142494674">שיתוף</translation>
-<translation id="2227444325776770048">המשך בשם <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">‏סנכרון ושירותי Google</translation>
-<translation id="2259659629660284697">ייצוא סיסמאות…</translation>
-<translation id="2268044343513325586">צמצם</translation>
-<translation id="2286841657746966508">כתובת לחיוב</translation>
-<translation id="2289270750774289114">‏המערכת מבקשת אישור כשאתר רוצה לאתר התקני Bluetooth קרובים (מומלץ)</translation>
-<translation id="230115972905494466">לא נמצאו מכשירים תואמים</translation>
-<translation id="2315043854645842844">מערכת ההפעלה אינה תומכת בבחירת אישור בצד הלקוח.</translation>
-<translation id="2318045970523081853">יש להקיש כדי להתקשר</translation>
-<translation id="2321086116217818302">מכין סיסמאות…</translation>
-<translation id="2321958826496381788">יש לגרור את המחוון עד שאפשר יהיה לקרוא את הקטע הזה בצורה נוחה. לאחר הקשה פעמיים על פיסקה, הטקסט אמור להיות מוצג בגודל הזה לפחות.</translation>
-<translation id="2323763861024343754">נתוני אתר מאוחסנים</translation>
-<translation id="2328985652426384049">אי אפשר להיכנס לחשבון</translation>
-<translation id="2330129964253841015">הצגת אזהרות כשסיסמאות בסיכון</translation>
-<translation id="2349710944427398404">‏סך כל הנתונים שבהם משתמש Chrome, כולל חשבונות, סימניות והגדרות שמורות</translation>
-<translation id="2353636109065292463">בדיקת חיבור האינטרנט</translation>
-<translation id="2359808026110333948">המשך</translation>
-<translation id="2369533728426058518">כרטיסיות פתוחות</translation>
-<translation id="2387895666653383613">שינוי גודל טקסט</translation>
-<translation id="2394602618534698961">קבצים שהורדת מופיעים כאן</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">‏התכונה הזו מופעלת בעת הכניסה לחשבון Google</translation>
-<translation id="2410754283952462441">בחירת חשבון</translation>
-<translation id="2414886740292270097">כהה</translation>
-<translation id="2416359993254398973">‏Chrome זקוק להרשאה גישה אל המצלמה בשביל האתר הזה.</translation>
-<translation id="2426805022920575512">בחירת חשבון אחר</translation>
-<translation id="2433507940547922241">מראה</translation>
-<translation id="2434158240863470628">ההורדה הושלמה <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">גישה למיקום</translation>
-<translation id="2450083983707403292">להתחיל שוב את ההורדה של <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">התראות</translation>
-<translation id="2490684707762498678">מנוהלות על-ידי <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">‏Google Assistant ב-Chrome</translation>
-<translation id="2496180316473517155">היסטוריית גלישה</translation>
-<translation id="2497852260688568942">מנהל המערכת שלך השבית את הסנכרון</translation>
-<translation id="2498359688066513246">עזרה ומשוב</translation>
-<translation id="2501278716633472235">חזרה</translation>
-<translation id="2513403576141822879">‏אפשר למצוא הגדרות נוספות בנושא פרטיות, אבטחה ואיסוף נתונים בדף <ph name="BEGIN_LINK" />סנכרון ושירותי Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">‏במצב טעינה מהירה, Chrome טוען דפים מהר יותר ומפחית את השימוש בנתונים בשיעור של עד 60 אחוזים. כדי לבצע אופטימיזציה לדפים שהמשתמש נכנס אליהם, Chrome שולח אל Google את התנועה שלו באינטרנט. <ph name="BEGIN_LINK" />מידע נוסף<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">‏שליחת כתובות אתרים של דפים שבהם ביקרת ל-Google</translation>
-<translation id="2532336938189706096">תצוגת אינטרנט</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> פריטים נמחקו</translation>
-<translation id="2536728043171574184">מציג העתק לא מקוון של עמוד זה</translation>
-<translation id="2546283357679194313">‏נתוני אתר וקובצי Cookie</translation>
-<translation id="2567385386134582609">תמונה</translation>
-<translation id="257088987046510401">ערכות נושא</translation>
-<translation id="2570922361219980984">‏גם הגישה למיקום כבויה בשביל המכשיר הזה. יש להפעיל אותה ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">מורחב - לחץ כדי לכווץ.</translation>
-<translation id="2581165646603367611">‏פעולה זו תמחק את קובצי ה-Cookie, את המטמון ונתונים אחרים של אתרים ש-Chrome לא מחשיב כחשובים.</translation>
-<translation id="2586657967955657006">לוח</translation>
-<translation id="2587052924345400782">יש גרסה חדשה יותר</translation>
-<translation id="2593272815202181319">רוחב אחיד</translation>
-<translation id="2612676031748830579">מספר הכרטיס</translation>
-<translation id="2621115761605608342">‏אפשר JavaScript לאתר ספציפי.</translation>
-<translation id="2625189173221582860">הסיסמה הועתקה</translation>
-<translation id="2631006050119455616">חסכת</translation>
-<translation id="2647434099613338025">להוספת שפה</translation>
-<translation id="2650751991977523696">האם להוריד את הקובץ שוב?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{קובץ אודיו אחד (#)}two{# קובצי אודיו}many{# קובצי אודיו}other{# קובצי אודיו}}</translation>
-<translation id="2653659639078652383">שלח</translation>
-<translation id="2677748264148917807">יציאה</translation>
-<translation id="2704606927547763573">הועתק</translation>
-<translation id="2707726405694321444">רענן את הדף</translation>
-<translation id="2709516037105925701">מילוי אוטומטי</translation>
-<translation id="2717722538473713889">כתובות אימייל</translation>
-<translation id="2728754400939377704">מיון לפי אתר</translation>
-<translation id="2744248271121720757">כדי לחפש באופן מיידי או לראות פעולות קשורות, צריך להקיש על מילה</translation>
-<translation id="2760989362628427051">עיצוב כהה מופעל כשבמכשיר פועלת האפשרות 'עיצוב כהה' או 'חיסכון בסוללה'</translation>
-<translation id="2762000892062317888">ברגע זה</translation>
-<translation id="2777555524387840389">נותרו <ph name="SECONDS" /> שניות</translation>
-<translation id="2779651927720337254">נכשל</translation>
-<translation id="2781151931089541271">נותרה שניה אחת</translation>
-<translation id="2801022321632964776">‏עדכון לגרסה האחרונה של Chrome יאפשר לך לקרוא בשפה שלך</translation>
-<translation id="2810645512293415242">דף פשוט יותר שחוסך בנתונים ונטען מהר יותר.</translation>
-<translation id="281504910091592009">‏הצגה וניהול של סיסמאות שמורות ב<ph name="BEGIN_LINK" />חשבון Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">כדי לקבל גישה אל הסימניות שלך בכל המכשירים, יש להיכנס לחשבון ולהפעיל את הסנכרון</translation>
-<translation id="2822354292072154809">לאפס את כל הרשאות האתר בשביל <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">כדי לצאת ממסך מלא, גע בלחצן 'הקודם'.</translation>
-<translation id="2842985007712546952">תיקיית אב</translation>
-<translation id="2858138569776157458">אתרים נבחרים</translation>
-<translation id="2860954141821109167">יש לוודא שמופעלת במכשיר הזה אפליקציית טלפון</translation>
-<translation id="2870560284913253234">אתר</translation>
-<translation id="2874939134665556319">הרצועה הקודמת</translation>
-<translation id="2876369937070532032">‏שולחת ל-Google כתובות URL של חלק מהדפים שאליהם נכנסת, אם מתגלה סיכון אבטחה</translation>
-<translation id="2888126860611144412">‏מידע כללי על Chrome</translation>
-<translation id="2891154217021530873">הפסק את טעינת הדף</translation>
-<translation id="2893180576842394309">‏Google עשויה להשתמש בהיסטוריית הגלישה שלך לצורך התאמה אישית של החיפוש ושירותי Google אחרים</translation>
-<translation id="2898264748040935573">עריכת הסיסמה השמורה</translation>
-<translation id="2900528713135656174">צור אירוע</translation>
-<translation id="290376772003165898">הדף לא ב<ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">רשימת המכשירים שאפשר לשתף איתם כרטיסייה נפתחה בגובה המלא של המסך.</translation>
-<translation id="2910701580606108292">הצגת שאלה לפני מתן הרשאה לאתרים להפעיל תוכן מוגן</translation>
-<translation id="2913331724188855103">‏אתרים יוכלו לשמור ולקרוא נתונים של קובצי Cookie (מומלץ)</translation>
-<translation id="2923908459366352541">השם לא חוקי</translation>
-<translation id="2932150158123903946">‏נפח אחסון של <ph name="APP_NAME" />‏ Google</translation>
-<translation id="2942036813789421260">כרטיסיית התצוגה המקדימה סגורה</translation>
-<translation id="2956410042958133412">החשבון הזה מנוהל על ידי <ph name="PARENT_NAME_1" /> ו-<ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">הוחלף לכרטיסיות גלישה בסתר</translation>
-<translation id="2968755619301702150">מציג האישורים</translation>
-<translation id="2979025552038692506">כרטיסיית הגלישה בסתר שנבחרה</translation>
-<translation id="2987620471460279764">טקסט ששותף ממכשיר אחר</translation>
-<translation id="2989523299700148168">מנועי חיפוש שהשתמשת בהם לאחרונה</translation>
-<translation id="2996291259634659425">יצירת ביטוי סיסמה</translation>
-<translation id="2996809686854298943">דרושה כתובת אתר</translation>
-<translation id="300526633675317032">פעולה זו תמחק את כל נתוני האתר המאוחסנים (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">יש לוודא שהמכשיר הזה מחובר לאינטרנט</translation>
-<translation id="3029613699374795922">‏בוצעה הורדה של KB <ph name="KBS" /></translation>
-<translation id="3029704984691124060">ביטויי הסיסמה אינם תואמים</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />קבל עזרה<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">‏הגישה למיקום כבויה. יש להפעיל אותה ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">אפשר להפעיל את הסנכרון בכל זמן דרך ההגדרות</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{סימניה אחת (<ph name="BOOKMARKS_COUNT_ONE" />)}two{<ph name="BOOKMARKS_COUNT_MANY" /> סימניות}many{<ph name="BOOKMARKS_COUNT_MANY" /> סימניות}other{<ph name="BOOKMARKS_COUNT_MANY" /> סימניות}}</translation>
-<translation id="3089395242580810162">פתיחה בכרטיסיית גלישה בסתר</translation>
-<translation id="3115898365077584848">הצג פרטים</translation>
-<translation id="3123473560110926937">חסומות בחלק מהאתרים</translation>
-<translation id="3137521801621304719">צא ממצב גלישה בסתר</translation>
-<translation id="3143515551205905069">ביטול סנכרון</translation>
-<translation id="3157842584138209013">בעזרת הלחצן 'אפשרויות נוספות' אפשר לבדוק את החיסכון בצריכת נתונים</translation>
-<translation id="3166827708714933426">מקשי קיצור לכרטיסיות ולחלונות</translation>
-<translation id="3181954750937456830">גלישה בטוחה (מגנה עליך ועל המכשיר מפני אתרים מסוכנים)</translation>
-<translation id="3190152372525844641">‏הפעל הרשאות בשביל Chrome ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">נתונים מאוחסנים בנפח <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">כמעט סיימת!</translation>
-<translation id="3207960819495026254">מסומן בסימניה</translation>
-<translation id="3211426585530211793">מועד המחיקה: <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">אם שכחת את ביטוי הסיסמה או אם ברצונך לשנות את ההגדרה הזו, <ph name="BEGIN_LINK" />אפס את הסינכרון<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">מיקרופון</translation>
-<translation id="3232754137068452469">אפליקציית אינטרנט</translation>
-<translation id="3236059992281584593">נותרה דקה אחת</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">הוסף את הדף לסימניות</translation>
-<translation id="3259831549858767975">הקטן את כל מה שמופיע בדף</translation>
-<translation id="3269093882174072735">טען תמונה</translation>
-<translation id="3269956123044984603">‏כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, הפעל את האפשרות 'סנכרון אוטומטי של נתונים' בהגדרות של חשבון Android.</translation>
-<translation id="3277252321222022663">התרת גישה של אתרים אל החיישנים (מומלץ)</translation>
-<translation id="3282568296779691940">‏כניסה ל-Chrome</translation>
-<translation id="3288003805934695103">לטעון מחדש את הדף</translation>
-<translation id="32895400574683172">יש הרשאה להצגת הודעות</translation>
-<translation id="3295530008794733555">יותר מהירות. פחות נתונים.</translation>
-<translation id="3295602654194328831">הסתר פרטים</translation>
-<translation id="3298243779924642547">‏מצב Lite</translation>
-<translation id="3303414029551471755">האם להוריד את התוכן?</translation>
-<translation id="3306398118552023113">‏האפליקציה הזו פועלת ב-Chrome</translation>
-<translation id="3315103659806849044">‏מתבצעת עכשיו התאמה אישית של הגדרות הסנכרון ושירותי Google. כדי להשלים את הפעלת הסנכרון, יש להקיש על הלחצן 'אישור' קרוב לתחתית המסך. ניווט למעלה</translation>
-<translation id="3328801116991980348">פרטי אתר</translation>
-<translation id="3333961966071413176">כל אנשי הקשר</translation>
-<translation id="3334729583274622784">לשנות את סיומת הקובץ?</translation>
-<translation id="3341058695485821946">בדיקת החיסכון בצריכת נתונים</translation>
-<translation id="3350687908700087792">סגור את כל כרטיסיות הגלישה בסתר</translation>
-<translation id="3353615205017136254">‏גרסת Lite של הדף נוצרה על ידי Google. כדי לטעון את הגרסה המקורית, אפשר להקיש על לחצן טעינת המקור.</translation>
-<translation id="3367813778245106622">היכנס שוב כדי להתחיל בסנכרון</translation>
-<translation id="3374023511497244703">‏הסימניות, ההיסטוריה, הסיסמאות ונתונים אחרים ב-Chrome כבר לא יסונכרנו עם חשבון Google</translation>
-<translation id="3384347053049321195">שיתוף תמונה</translation>
-<translation id="3386292677130313581">יש לשאול לפני שמאפשרים לאתרים לדעת מה המיקום שלך (מומלץ)</translation>
-<translation id="3387650086002190359">הורדת <ph name="FILE_NAME" /> נכשלה עקב שגיאות במערכת הקבצים.</translation>
-<translation id="3389286852084373014">הטקסט ארוך מדי</translation>
-<translation id="3398320232533725830">פתח את מנהל הסימניות</translation>
-<translation id="3414952576877147120">גודל:</translation>
-<translation id="3443221991560634068">טען מחדש את הדף הנוכחי</translation>
-<translation id="3445014427084483498">ממש עכשיו</translation>
-<translation id="3478363558367712427">אפשר לבחור את מנוע החיפוש</translation>
+<translation id="6910211073230771657">נמחק</translation>
+<translation id="6965382102122355670">אישור</translation>
+<translation id="5301954838959518834">בסדר, הבנתי</translation>
+<translation id="7658239707568436148">ביטול</translation>
 <translation id="3479552764303398839">לא עכשיו</translation>
-<translation id="3492207499832628349">כרטיסייה חדשה לגלישה בסתר</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />מידע נוסף<ph name="END_LINK" /> על הצעות לתוכן</translation>
-<translation id="3513704683820682405">מציאות רבודה</translation>
-<translation id="3518985090088779359">בסדר, מקובל עליי</translation>
-<translation id="3522247891732774234">יש עדכון זמין. עוד אפשרויות</translation>
-<translation id="3524138585025253783">ממשק משתמש למפתחים</translation>
-<translation id="3527085408025491307">תיקיה</translation>
-<translation id="3542235761944717775">‏‎<ph name="KILOBYTES" /> KB זמינים</translation>
-<translation id="3549657413697417275">חיפוש בהיסטוריה שלך</translation>
-<translation id="3557336313807607643">הוסף לאנשי הקשר</translation>
-<translation id="3566923219790363270">‏Chrome עדיין מתכונן ל-VR. יש להפעיל מחדש את Chrome מאוחר יותר.</translation>
-<translation id="3568688522516854065">כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, יש להיכנס לחשבון ולהפעיל את הסנכרון</translation>
-<translation id="3587482841069643663">הכל</translation>
-<translation id="358794129225322306">מתן הרשאה לאתר להוריד קבצים מרובים באופן אוטומטי.</translation>
-<translation id="3590487821116122040">‏נתוני אתר מאוחסנים ש-Chrome לא מחשיב כחשובים (לדוגמה, אתרים ללא הגדרות שמורות או כאלה שאינך מבקר בהם לעתים קרובות)</translation>
-<translation id="3599863153486145794">‏ניקוי ההיסטוריה מכל המכשירים שבהם המשתמש נכנס לחשבון. ייתכן שלחשבון Google שלך יהיו צורות אחרות של היסטוריית גלישה בכתובת <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">השתקת אתרים שמשמיעים צלילים</translation>
-<translation id="3616113530831147358">אודיו</translation>
-<translation id="3631987586758005671">השיתוף עם <ph name="DEVICE_NAME" /> מתבצע</translation>
-<translation id="3632295766818638029">חשוף סיסמה</translation>
-<translation id="363596933471559332">כניסה אוטומטית לאתרים באמצעות פרטי כניסה מאוחסנים. כשתכונה זו כבויה, יהיה עליך לבצע אימות לפני כל כניסה לאתר.</translation>
-<translation id="3658159451045945436">האיפוס גורם למחיקת ההיסטוריה של החיסכון בנתונים, כולל רשימת האתרים שביקרת בהם.</translation>
-<translation id="3692944402865947621">ההורדה של <ph name="FILE_NAME" /> נכשלה כי מיקום האחסון לא נגיש.</translation>
-<translation id="3714981814255182093">פתח את סרגל החיפוש</translation>
-<translation id="3716182511346448902">‏הדף הזה מנצל יותר מדי זיכרון, כך שהוא הושהה על-ידי Chrome.</translation>
-<translation id="3730075448226062617">‏כדי לאפשר ל-Chrome לגשת אל המיקרופון, צריך להפעיל אותו גם ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">נוסף לסימניות ב-<ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">סינכרון ברקע</translation>
-<translation id="3771001275138982843">לא ניתן היה להוריד את העדכון</translation>
-<translation id="3771033907050503522">כרטיסיות גלישה בסתר</translation>
-<translation id="3773755127849930740">‏<ph name="BEGIN_LINK" />הפעל את Bluetooth<ph name="END_LINK" /> כדי לאפשר התאמה</translation>
-<translation id="3775705724665058594">שליחה אל המכשירים שלך</translation>
-<translation id="3778956594442850293">נוסף למסך דף הבית</translation>
-<translation id="3789841737615482174">התקן</translation>
-<translation id="3810838688059735925">וידאו</translation>
-<translation id="3810973564298564668">נהל</translation>
-<translation id="381841723434055211">מספרי טלפון</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> הורדות נמחקו</translation>
-<translation id="3822502789641063741">למחוק נתוני אתר מהאחסון?</translation>
-<translation id="385051799172605136">חזרה</translation>
-<translation id="3859306556332390985">הרץ קדימה</translation>
-<translation id="3894427358181296146">הוספת תיקייה</translation>
-<translation id="3895926599014793903">שינוי הזום בכל מקרה</translation>
-<translation id="3912508018559818924">כל הטוב שבאינטרנט…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">שילוב הנתונים שלי</translation>
-<translation id="393697183122708255">חיפוש קולי מופעל לא זמין</translation>
-<translation id="395206256282351086">ההצעות למונחי חיפוש ואתרים הושבתו</translation>
-<translation id="3955193568934677022">אתרים יוכלו להפעיל תוכן מוגן (מומלץ)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{‏Chrome יטען את הדף כשיהיה מוכן}two{‏Chrome יטען את הדפים כשיהיו מוכנים}many{‏Chrome יטען את הדפים כשיהיו מוכנים}other{‏Chrome יטען את הדפים כשיהיו מוכנים}}</translation>
-<translation id="3963007978381181125">‏הצפנה באמצעות ביטוי סיסמה לא כוללת אמצעי תשלום וכתובות מ-Google Pay. רק מי שיודע את ביטוי הסיסמה שלך יכול לקרוא את הנתונים המוצפנים. ביטוי הסיסמה לא נשלח אל Google והיא אינה מאחסנת אותו. אם שוכחים את ביטוי הסיסמה או רוצים לשנות את ההגדרה הזו, צריך לאפס את הסנכרון. <ph name="BEGIN_LINK" />מידע נוסף<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ההורדה הושלמה</translation>
-<translation id="397583555483684758">הסנכרון הפסיק לפעול</translation>
-<translation id="3976396876660209797">הסרה ויצירה מחדש של מקש הקיצור הזה</translation>
-<translation id="3985215325736559418">האם להוריד שוב את <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">העתק קישור</translation>
-<translation id="3988213473815854515">ניתנה הרשאת מיקום</translation>
-<translation id="3988466920954086464">בחלונית הזו אפשר לראות תוצאות חיפוש מיידי</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">נתונים מאוחסנים לא חשובים</translation>
-<translation id="4000212216660919741">דף הבית במצב לא מקוון</translation>
+<translation id="5317780077021120954">שמור</translation>
+<translation id="4570913071927164677">פרטים</translation>
+<translation id="8730621377337864115">בוצע</translation>
+<translation id="8261506727792406068">מחיקה</translation>
+<translation id="1181037720776840403">הסרה</translation>
+<translation id="5939518447894949180">אפס</translation>
 <translation id="4002066346123236978">כותרת</translation>
-<translation id="4008040567710660924">‏אישור קובצי Cookie של אתר מסוים.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{שעה אחת}two{שעתיים}many{# שעות}other{# שעות}}</translation>
-<translation id="4046123991198612571">הרצועה הבאה</translation>
-<translation id="4048707525896921369">‏ניתן לקבל מידע על נושאים באתרים מבלי לצאת מהדף. התכונה 'הקשה כדי לחפש' שולחת מילה ואת ההקשר שלה אל חיפוש Google, המחזיר הגדרות, תמונות, תוצאות חיפוש ופרטים אחרים.
+<translation id="5916664084637901428">פועל</translation>
+<translation id="5860033963881614850">כבוי</translation>
+<translation id="6165508094623778733">למידע נוסף</translation>
+<translation id="6042308850641462728">עוד</translation>
+<translation id="6040143037577758943">סגור</translation>
+<translation id="780301667611848630">לא תודה</translation>
+<translation id="1201402288615127009">הבא</translation>
+<translation id="2359808026110333948">המשך</translation>
+<translation id="2653659639078652383">שלח</translation>
+<translation id="2079545284768500474">ביטול הפעולה</translation>
+<translation id="7649070708921625228">עזרה</translation>
+<translation id="2148716181193084225">היום</translation>
+<translation id="7781829728241885113">אתמול</translation>
+<translation id="6945221475159498467">בחירה</translation>
+<translation id="7791543448312431591">הוספה</translation>
+<translation id="6527303717912515753">שיתוף</translation>
+<translation id="1383876407941801731">חפש</translation>
+<translation id="3115898365077584848">הצג פרטים</translation>
+<translation id="3295602654194328831">הסתר פרטים</translation>
+<translation id="3987993985790029246">העתק קישור</translation>
+<translation id="2704606927547763573">הועתק</translation>
+<translation id="8725066075913043281">נסה שוב</translation>
+<translation id="385051799172605136">חזרה</translation>
+<translation id="8131740175452115882">אישור</translation>
+<translation id="5300589172476337783">הצגה</translation>
+<translation id="1124772482545689468">משתמש</translation>
+<translation id="8609465669617005112">הזז למעלה</translation>
+<translation id="6746124502594467657">הזז למטה</translation>
+<translation id="8249310407154411074">העברה לראש הרשימה</translation>
+<translation id="8428213095426709021">הגדרות</translation>
+<translation id="2498359688066513246">עזרה ומשוב</translation>
+<translation id="8378714024927312812">מנוהל על-ידי הארגון</translation>
+<translation id="9019902583201351841">מנוהל על-ידי ההורים שלך</translation>
+<translation id="4645575059429386691">מנוהל על-ידי ההורה שלך</translation>
+<translation id="4883854917563148705">לא ניתן לאפס הגדרות מנוהלות</translation>
+<translation id="4307992518367153382">היסודות</translation>
+<translation id="1974060860693918893">מתקדם</translation>
+<translation id="1146678959555564648">‏כניסה למצב VR</translation>
+<translation id="987264212798334818">כללי</translation>
+<translation id="4275663329226226506">מדיה</translation>
+<translation id="4759238208242260848">הורדות</translation>
+<translation id="218608176142494674">שיתוף</translation>
+<translation id="8004582292198964060">דפדפן</translation>
+<translation id="1105960400813249514">צילום מסך</translation>
+<translation id="4875775213178255010">תוכן מוצע</translation>
+<translation id="2021896219286479412">פקדי אתר במסך מלא</translation>
+<translation id="4587589328781138893">אתרים</translation>
+<translation id="4943703118917034429">מציאות מדומה</translation>
+<translation id="1928696683969751773">עדכונים</translation>
+<translation id="6064125863973209585">הורדות שהושלמו</translation>
+<translation id="5342314432463739672">בקשות הרשאה</translation>
+<translation id="629730747756840877">חשבון</translation>
+<translation id="82609232232243542">‏כניסה ל-Brave</translation>
+<translation id="7956662517480676674">‏סנכרון ושירותי Brave Software</translation>
+<translation id="5294439808117722387">‏מתבצעת עכשיו התאמה אישית של הגדרות הסנכרון ושירותי Brave Software. כדי להשלים את הפעלת הסנכרון, יש להקיש על הלחצן 'אישור' קרוב לתחתית המסך. ניווט למעלה</translation>
+<translation id="2096012225669085171">סנכרון והתאמה אישית במכשירים שונים</translation>
+<translation id="1692118695553449118">סנכרון מופעל</translation>
+<translation id="5514904542973294328">האפשרות הזו הושבתה על-ידי מנהל המערכת של המכשיר</translation>
+<translation id="6447211988989208781">‏בחירת פעילויות של Brave Software</translation>
+<translation id="4882831918239250449">הגדרת השימוש בהיסטוריית הגלישה לצורך התאמה אישית של החיפוש, המודעות ועוד</translation>
+<translation id="7431991332293347422">קביעת אופן השימוש בהיסטוריית הגלישה להתאמה אישית של החיפוש ועוד</translation>
+<translation id="6303969859164067831">יציאה וכיבוי הסנכרון</translation>
+<translation id="1125261911132334651">‏ניהול חשבון Brave Software שלך</translation>
+<translation id="6406506848690869874">סנכרון</translation>
+<translation id="714362445477979774">‏סנכרון הנתונים מ-Brave</translation>
+<translation id="4314815835985389558">ניהול הסנכרון</translation>
+<translation id="5428209950370661546">‏שירותי Brave Software אחרים</translation>
+<translation id="7704317875155739195">השלמה אוטומטית של חיפושים וכתובות אתרים</translation>
+<translation id="2000419248597011803">‏שליחה של חלק מקובצי ה-Cookie והחיפושים משורת כתובת האתר ומתיבת החיפוש אל מנוע החיפוש שהוגדר כברירת מחדל</translation>
+<translation id="7981313251711023384">טעינה מראש של דפים כדי לאפשר גלישה וחיפוש מהירים יותר</translation>
+<translation id="1821253160463689938">‏שימוש בקובצי cookie כדי לשמור את ההעדפות שלך, גם אם לא נכנסת אל הדפים האלה</translation>
+<translation id="6697492270171225480">הצגת הצעות לדפים דומים אם דף מסוים לא נמצא</translation>
+<translation id="8109318360573330108">‏שליחת כתובת האתר של הדף שאליו ניסית להגיע אל Brave Software</translation>
+<translation id="8438566539970814960">שיפור החיפושים והגלישה</translation>
+<translation id="284843628681142937">‏שליחת כתובות אתרים של דפים שבהם ביקרת ל-Brave Software</translation>
+<translation id="7222718784508482526">‏אפשר למצוא הגדרות נוספות בנושא פרטיות, אבטחה ואיסוף נתונים בדף <ph name="BEGIN_LINK"/>סנכרון ושירותי Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">‏עזרה בשיפור התכונות והביצועים של Brave</translation>
+<translation id="9063160602596686558">‏שליחת דוחות קריסה וסטטיסטיקת שימוש אל Brave Software באופן אוטומטי</translation>
+<translation id="4824958205181053313">לבטל את הסנכרון?</translation>
+<translation id="3058498974290601450">אפשר להפעיל את הסנכרון בכל זמן דרך ההגדרות</translation>
+<translation id="3143515551205905069">ביטול סנכרון</translation>
+<translation id="1506061864768559482">מנוע חיפוש</translation>
+<translation id="55737423895878184">יש הרשאה לגישה אל המיקום ולהצגת הודעות</translation>
+<translation id="3988213473815854515">ניתנה הרשאת מיקום</translation>
+<translation id="32895400574683172">יש הרשאה להצגת הודעות</translation>
+<translation id="9040142327097499898">יש הרשאה להצגת הודעות. המיקום כבוי בשביל המכשיר הזה.</translation>
+<translation id="305593374596241526">‏הגישה למיקום כבויה. יש להפעיל אותה ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">מנועי חיפוש שהשתמשת בהם לאחרונה</translation>
+<translation id="6433501201775827830">בחירת מנוע החיפוש</translation>
+<translation id="7177466738963138057">אפשר לשנות את ההגדרה הזו מאוחר יותר ב'הגדרות'</translation>
+<translation id="3478363558367712427">אפשר לבחור את מנוע החיפוש</translation>
+<translation id="4910889077668685004">אפליקציות תשלום</translation>
+<translation id="5152843274749979095">לא מותקנות אפליקציות נתמכות</translation>
+<translation id="8812260976093120287">באתרים מסוימים ניתן לשלם דרך המכשיר באמצעות אפליקציות התשלום הנתמכות שמופיעות למעלה.</translation>
+<translation id="7764225426217299476">הוסף כתובת</translation>
+<translation id="5595485650161345191">עריכת כתובת</translation>
+<translation id="5087580092889165836">הוסף כרטיס</translation>
+<translation id="2154484045852737596">עריכת כרטיס</translation>
+<translation id="6140912465461743537">ארץ/אזור</translation>
+<translation id="5659593005791499971">אימייל</translation>
+<translation id="4378154925671717803">טלפון</translation>
+<translation id="4807098396393229769">שם על הכרטיס</translation>
+<translation id="860043288473659153">שם בעל הכרטיס</translation>
+<translation id="2612676031748830579">מספר הכרטיס</translation>
+<translation id="869891660844655955">תאריך תפוגה</translation>
+<translation id="2286841657746966508">כתובת לחיוב</translation>
+<translation id="663059986967017181">‏הועתק אל Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{‏<ph name="PAYMENT_METHOD_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> נוסף}two{‏<ph name="PAYMENT_METHOD_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> נוספים}many{‏<ph name="PAYMENT_METHOD_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> נוספים}other{‏<ph name="PAYMENT_METHOD_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> נוספים}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> נוספת}two{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> נוספות}many{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> נוספות}other{‏<ph name="SHIPPING_ADDRESS_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> נוספות}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{‏<ph name="SHIPPING_OPTION_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> נוספת}two{‏<ph name="SHIPPING_OPTION_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> נוספות}many{‏<ph name="SHIPPING_OPTION_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> נוספות}other{‏<ph name="SHIPPING_OPTION_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> נוספות}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{‏<ph name="CONTACT_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> נוסף}two{‏<ph name="CONTACT_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> נוספים}many{‏<ph name="CONTACT_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> נוספים}other{‏<ph name="CONTACT_PREVIEW"/>‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> נוספים}}</translation>
+<translation id="7029809446516969842">סיסמאות</translation>
+<translation id="1943432128510653496">שמירת סיסמאות</translation>
+<translation id="2100273922101894616">כניסה אוטומטית</translation>
+<translation id="363596933471559332">כניסה אוטומטית לאתרים באמצעות פרטי כניסה מאוחסנים. כשתכונה זו כבויה, יהיה עליך לבצע אימות לפני כל כניסה לאתר.</translation>
+<translation id="6995899638241819463">הצגת אזהרה אם סיסמאות נחשפות עקב פרצה באבטחת מידע</translation>
+<translation id="1534287762301776620">‏התכונה הזו מופעלת בעת הכניסה לחשבון Brave Software</translation>
+<translation id="10614374240317010">פריטים שאף פעם לא נשמרו</translation>
+<translation id="3098842761938485917">‏הצגה וניהול של סיסמאות שמורות ב<ph name="BEGIN_LINK"/>חשבון Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">הסיסמאות השמורות יופיעו כאן.</translation>
+<translation id="8084114998886531721">סיסמה שמורה</translation>
+<translation id="2870560284913253234">אתר</translation>
+<translation id="8503813439785031346">שם משתמש</translation>
+<translation id="6657585470893396449">סיסמה</translation>
+<translation id="2154710561487035718">העתק כתובת אתר</translation>
+<translation id="1571304935088121812">העתק שם משתמש</translation>
+<translation id="5005498671520578047">העתק סיסמה</translation>
+<translation id="3632295766818638029">חשוף סיסמה</translation>
+<translation id="1513858653616922153">מחק סיסמה</translation>
+<translation id="543338862236136125">עריכת סיסמה</translation>
+<translation id="4565377596337484307">הסתר סיסמה</translation>
+<translation id="8523928698583292556">מחק את הסיסמה השמורה</translation>
+<translation id="2898264748040935573">עריכת הסיסמה השמורה</translation>
+<translation id="5433691172869980887">שם המשתמש הועתק</translation>
+<translation id="5534640966246046842">האתר הועתק</translation>
+<translation id="2625189173221582860">הסיסמה הועתקה</translation>
+<translation id="4550003330909367850">כדי להציג או להעתיק את הסיסמה יש להגדיר נעילת מסך במכשיר זה.</translation>
+<translation id="6154478581116148741">יש להפעיל נעילת מסך ב'הגדרות' כדי לייצא את הסיסמאות מהמכשיר הזה</translation>
+<translation id="4842092870884894799">מציג את החלון הקופץ של יצירת סיסמה</translation>
+<translation id="2259659629660284697">ייצוא סיסמאות…</translation>
+<translation id="133012818630824069">‏ייצוא סיסמאות המאוחסנות ב-Brave</translation>
+<translation id="6914783257214138813">כל מי שיוכל לגשת אל הקובץ המיוצא יוכל לראות את הסיסמאות שלך.</translation>
+<translation id="2321086116217818302">מכין סיסמאות…</translation>
+<translation id="8445448999790540984">אי אפשר לייצא סיסמאות</translation>
+<translation id="3066461326500799725">‏איך משתמשים ב-Brave Software Drive</translation>
+<translation id="729975465115245577">אין במכשיר אפליקציה לאחסון קובץ הסיסמאות.</translation>
+<translation id="7682724950699840886">אפשר לנסות את הטיפים הבאים: צריך לוודא שיש מספיק מקום פנוי במכשיר ואז לנסות לייצא שוב.</translation>
+<translation id="1129510026454351943">פרטים: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">ביטול הנעילה יאפשר להעתיק את הסיסמה</translation>
+<translation id="5515439363601853141">ביטול הנעילה יציג את הסיסמה</translation>
+<translation id="6221633008163990886">יש לבטל את הנעילה כדי לייצא סיסמאות</translation>
+<translation id="230699814587342492">‏סיסמאות Brave</translation>
+<translation id="6075798973483050474">עריכת דף הבית</translation>
+<translation id="854522910157234410">פתח דף זה</translation>
+<translation id="2482878487686419369">התראות</translation>
+<translation id="6255999984061454636">הצעות לתוכן</translation>
+<translation id="805047784848435650">על סמך היסטוריית הגלישה שלך</translation>
+<translation id="1041308826830691739">מאתרים</translation>
+<translation id="395206256282351086">ההצעות למונחי חיפוש ואתרים הושבתו</translation>
+<translation id="257088987046510401">ערכות נושא</translation>
+<translation id="4650364565596261010">ברירת מחדל של המערכת</translation>
+<translation id="7588219262685291874">עיצוב כהה מופעל כשהמכשיר עובר לחיסכון בסוללה</translation>
+<translation id="2760989362628427051">עיצוב כהה מופעל כשבמכשיר פועלת האפשרות 'עיצוב כהה' או 'חיסכון בסוללה'</translation>
+<translation id="6381421346744604172">תצוגה כהה יותר של אתרים</translation>
+<translation id="5040262127954254034">פרטיות</translation>
+<translation id="4991384657077828949">‏עזרה בשיפור האבטחה של Brave</translation>
+<translation id="1943176487615318915">‏כדי לזהות אפליקציות ואתרים מסוכנים, Brave שולח אל Brave Software כתובות URL של חלק מהדפים שאליהם נכנסת, מידע מוגבל לגבי המערכת וחלק מתוכן הדפים</translation>
+<translation id="3181954750937456830">גלישה בטוחה (מגנה עליך ועל המכשיר מפני אתרים מסוכנים)</translation>
+<translation id="7315322926489145388">‏שולחת ל-Brave Software כתובות URL של חלק מהדפים שאליהם נכנסת, אם מתגלה סיכון אבטחה</translation>
+<translation id="2063713494490388661">הקש כדי לחפש</translation>
+<translation id="2369463299479365221">‏ניתן לקבל מידע על נושאים באתרים מבלי לצאת מהדף. התכונה 'הקשה כדי לחפש' שולחת מילה ואת ההקשר שלה אל חיפוש Brave Software, המחזיר הגדרות, תמונות, תוצאות חיפוש ופרטים אחרים.
 
 כדי לשנות את מונח החיפוש שלך, צריך ללחוץ לחיצה ארוכה במונח כדי לבחור בו. כדי לצמצם את החיפוש, מסיטים את החלונית עד למעלה ומקישים על תיבת החיפוש.</translation>
-<translation id="4056223980640387499">חום-ספיה</translation>
-<translation id="4060598801229743805">האפשרויות זמינות בחלק העליון של המסך</translation>
-<translation id="4062305924942672200">מידע משפטי</translation>
-<translation id="4084682180776658562">סימניה</translation>
-<translation id="4084712963632273211">‏מאת <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />מוגש על-ידי Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">למחוק נתוני יישומים?</translation>
-<translation id="4099578267706723511">‏אם שולחים אלינו נתוני שימוש ודוחות קריסה, עוזרים לשפר את Chrome.</translation>
-<translation id="410351446219883937">הפעלה אוטומטית</translation>
-<translation id="4116038641877404294">הורד דפים כדי להשתמש בהם במצב לא מקוון</translation>
-<translation id="4135200667068010335">רשימת המכשירים שאפשר לשתף איתם כרטיסייה נסגרה.</translation>
-<translation id="4149994727733219643">תצוגה פשוטה של דפי אינטרנט</translation>
-<translation id="4165986682804962316">הגדרות לאתרים</translation>
-<translation id="4169535189173047238">לא לאפשר</translation>
-<translation id="4170011742729630528">השירות אינו זמין. נסה שוב מאוחר יותר.</translation>
-<translation id="4179980317383591987">נעשה שימוש ב-<ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">שפות</translation>
-<translation id="4183868528246477015">‏חיפוש בעזרת Google Lens <ph name="BEGIN_NEW" />חדש<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">פתיחה בכרטיסייה חדשה</translation>
-<translation id="4198423547019359126">אין מיקומים זמינים להורדה</translation>
-<translation id="4209895695669353772">‏כדי לקבל מ-Google הצעות לתוכן מותאם אישית, יש להפעיל את הסנכרון</translation>
-<translation id="4226663524361240545">רטט של המכשיר אפשרי כשמתקבלת הודעה</translation>
-<translation id="423219824432660969">‏הצפנת נתונים מסונכרנים באמצעות סיסמת Google החל מ-<ph name="TIME" /></translation>
-<translation id="4242533952199664413">פתח את 'הגדרות'</translation>
-<translation id="4256782883801055595">רישיונות קוד פתוח</translation>
-<translation id="4259722352634471385">הניווט חסום: <ph name="URL" /></translation>
-<translation id="4269820728363426813">העתקת כתובת של קישור</translation>
-<translation id="4275663329226226506">מדיה</translation>
-<translation id="4278390842282768270">מותר</translation>
-<translation id="429312253194641664">אתר מסוים מפעיל מדיה</translation>
-<translation id="4298388696830689168">אתרים מקושרים</translation>
-<translation id="4307992518367153382">היסודות</translation>
-<translation id="4314815835985389558">ניהול הסנכרון</translation>
-<translation id="4351244548802238354">סגור את תיבת הדו-שיח</translation>
-<translation id="4378154925671717803">טלפון</translation>
-<translation id="4384468725000734951">‏שימוש ב-Sogou לחיפוש</translation>
-<translation id="4404568932422911380">ללא סימניות</translation>
-<translation id="4405224443901389797">העברה אל…</translation>
-<translation id="4411535500181276704">מצב טעינה מהירה</translation>
-<translation id="4415276339145661267">‏ניהול חשבון Google שלך</translation>
-<translation id="4432792777822557199">דפים ב<ph name="SOURCE_LANGUAGE" /> יתורגמו ל<ph name="TARGET_LANGUAGE" /> מעכשיו והלאה</translation>
-<translation id="4433925000917964731">‏גרסת Lite של הדף נוצרה על ידי Google</translation>
-<translation id="4434045419905280838">חלונות קופצים והפניות אוטומטיות</translation>
-<translation id="4440958355523780886">‏גרסת Lite של הדף נוצרה על ידי Google. אפשר להקיש כדי לטעון את הגרסה המקורית.</translation>
-<translation id="4452411734226507615">סגירת הכרטיסייה <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">התווסף לסימניות ב-<ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">מתן הרשאה לאתרים להציג תוכן מוגן</translation>
-<translation id="4468959413250150279">השתקת צלילים באתר ספציפי.</translation>
-<translation id="4472118726404937099">כדי לסנכרן ולהתאים אישית את החוויה במכשירים שונים, יש להיכנס לחשבון ולהפעיל את הסנכרון</translation>
-<translation id="447252321002412580">‏עזרה בשיפור התכונות והביצועים של Chrome</translation>
-<translation id="4479647676395637221">יש לשאול לפני שמאפשרים לאתרים להשתמש במצלמה שלך (מומלץ)</translation>
-<translation id="4479972344484327217">‏מתקין את <ph name="MODULE" /> ל-Chrome…</translation>
-<translation id="4487967297491345095">‏כל נתוני היישומים של Chrome יימחקו לצמיתות, כולל כל הקבצים, ההגדרות, החשבונות, מסדי הנתונים וכו'</translation>
-<translation id="4493497663118223949">מצב הטעינה המהירה מופעל</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{לפני יום}two{לפני יומיים}many{לפני # ימים}other{לפני # ימים}}</translation>
-<translation id="451872707440238414">חיפוש בסימניות</translation>
-<translation id="4521489764227272523">‏הנתונים שבחרת הוסרו מ-Chrome ומהמכשירים המסונכרנים.
-
-ייתכן שבכתובת <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> יש סוגים אחרים של היסטוריית גלישה בחשבון Google, כמו חיפושים ופעילות משירותי Google אחרים.</translation>
-<translation id="4532845899244822526">בחר תיקייה</translation>
-<translation id="4538018662093857852">הפעלת מצב טעינה מהירה</translation>
-<translation id="4550003330909367850">כדי להציג או להעתיק את הסיסמה יש להגדיר נעילת מסך במכשיר זה.</translation>
-<translation id="4558311620361989323">קיצורי דרך בדפי אינטרנט</translation>
-<translation id="4561979708150884304">אין חיבור</translation>
-<translation id="4565377596337484307">הסתר סיסמה</translation>
-<translation id="4570913071927164677">פרטים</translation>
-<translation id="4572422548854449519">כניסה אל חשבון מנוהל</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{לפני דקה}two{לפני # דקות}many{לפני # דקות}other{לפני # דקות}}</translation>
-<translation id="4587589328781138893">אתרים</translation>
-<translation id="4594952190837476234">הדף הלא מקוון הזה נוצר ב-<ph name="CREATION_TIME" /> ויכול להיות שהגירסה המקוונת שלו שונה.</translation>
-<translation id="4605958867780575332">פריטים שהוסרו: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">פתיחה של <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">שימוש בסיסמה</translation>
-<translation id="4645575059429386691">מנוהל על-ידי ההורה שלך</translation>
-<translation id="4650364565596261010">ברירת מחדל של המערכת</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> סימניות נמחקו</translation>
-<translation id="4665282149850138822">האתר <ph name="NAME" /> נוסף למסך דף הבית שלך</translation>
-<translation id="4684427112815847243">סנכרון הכל</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{‏<ph name="SHIPPING_OPTION_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> נוספת}two{‏<ph name="SHIPPING_OPTION_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> נוספות}many{‏<ph name="SHIPPING_OPTION_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> נוספות}other{‏<ph name="SHIPPING_OPTION_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> נוספות}}</translation>
-<translation id="4696983787092045100">שליחת הטקסט למכשירים שלך</translation>
-<translation id="4698034686595694889">הצגה לא מקוונת ב-<ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">תמונות וקבצים במטמון</translation>
-<translation id="4714588616299687897">חסוך עד 60% בשימוש בנתונים</translation>
-<translation id="4719927025381752090">הצגת הצעות לתרגום</translation>
-<translation id="4720023427747327413">פתח ב-<ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">‏נשמח לקבל עזרה בשיפור Chrome. <ph name="BEGIN_LINK" />למילוי הסקר<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">עדכן</translation>
-<translation id="4738836084190194332">סונכרן לאחרונה: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">פתח כרטיסייה חדשה</translation>
-<translation id="4751476147751820511">חיישני תנועה או אור</translation>
-<translation id="4759238208242260848">הורדות</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{הורדה אחת הושלמה.}two{# הורדות הושלמו.}many{# הורדות הושלמו.}other{# הורדות הושלמו.}}</translation>
-<translation id="4797039098279997504">גע כדי לחזור אל <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">‏הצפנה באמצעות ביטוי סיסמה לא כוללת אמצעי תשלום וכתובות מ-Google Pay
-
-כדי לשנות את ההגדרה הזו צריך <ph name="BEGIN_LINK" />לאפס את הסנכרון<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">שם על הכרטיס</translation>
-<translation id="4824958205181053313">לבטל את הסנכרון?</translation>
-<translation id="4837753911714442426">פתח אפשרויות להדפסת דפים</translation>
-<translation id="4842092870884894799">מציג את החלון הקופץ של יצירת סיסמה</translation>
-<translation id="4860895144060829044">תרימו טלפון</translation>
-<translation id="4866368707455379617">‏לא ניתן להתקין את <ph name="MODULE" /> ל-Chrome</translation>
-<translation id="4875775213178255010">תוכן מוצע</translation>
-<translation id="4878404682131129617">‏יצירת מנהרה בעזרת שרת proxy נכשלה</translation>
-<translation id="4880127995492972015">תרגום…</translation>
-<translation id="4881695831933465202">פתיחה</translation>
-<translation id="488187801263602086">שינוי שם של קובץ</translation>
-<translation id="4882831918239250449">הגדרת השימוש בהיסטוריית הגלישה לצורך התאמה אישית של החיפוש, המודעות ועוד</translation>
-<translation id="4883854917563148705">לא ניתן לאפס הגדרות מנוהלות</translation>
-<translation id="4885273946141277891">‏מספר בלתי נתמך של מופעי Chrome.</translation>
-<translation id="4910889077668685004">אפליקציות תשלום</translation>
-<translation id="4913161338056004800">איפוס הנתונים הסטטיסטיים</translation>
-<translation id="4913169188695071480">הפסק לרענן</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />קבל עזרה<ph name="END_LINK" /> בזמן חיפוש התקנים…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{דף אחד (#)}two{# דפים}many{# דפים}other{# דפים}}</translation>
-<translation id="4932247056774066048">‏מכיוון שבחרת לצאת מחשבון שמנוהל על ידי <ph name="DOMAIN_NAME" />, נתוני Chrome שלך יימחקו מהמכשיר הזה. הם יישמרו בחשבון Google שלך.</translation>
-<translation id="4943703118917034429">מציאות מדומה</translation>
-<translation id="4943872375798546930">אין תוצאות</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> משתף את המסך שלך</translation>
-<translation id="4961107849584082341">אפשר לתרגם את הדף הזה לשפה כלשהי</translation>
-<translation id="4962975101802056554">ביטול כל ההרשאות בשביל המכשיר</translation>
-<translation id="4970824347203572753">האפשרות לא זמינה במיקום שלך</translation>
-<translation id="497421865427891073">המשך קדימה</translation>
-<translation id="4988210275050210843">מתבצעת הורדה של קובץ (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">דפים</translation>
-<translation id="4994033804516042629">לא נמצאו אנשי קשר</translation>
-<translation id="4996978546172906250">שיתוף באמצעות</translation>
-<translation id="5004416275253351869">‏בחירת פעילויות של Google</translation>
-<translation id="5005498671520578047">העתק סיסמה</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> מבקש להתחבר אל</translation>
-<translation id="5013696553129441713">אין הצעות חדשות</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">‏בזמן השימוש ב-VR, ייתכן שלאתר הזה תהיה אפשרות ללמוד על:
-  -  התכונות הפיזיות שלך, כמו הגובה
-
-חשוב לוודא שהאתר מהימן לפני תחילת השימוש ב-VR.</translation>
+<translation id="2930742481329940825">‏התכונה 'הקשה כדי לחפש' שולחת אל חיפוש Brave Software את המילה הנבחרת, יחד עם הדף הנוכחי בתור הקשר. ניתן לכבות תכונה זאת ב<ph name="BEGIN_LINK"/>הגדרות<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">זה בסדר</translation>
-<translation id="5040262127954254034">פרטיות</translation>
-<translation id="5048398596102334565">התרת גישה של אתרים אל חיישני התנועה (מומלץ)</translation>
-<translation id="5063480226653192405">שימוש</translation>
-<translation id="5087580092889165836">הוסף כרטיס</translation>
-<translation id="5100237604440890931">מכווץ - לחץ כדי להרחיב.</translation>
-<translation id="510275257476243843">נותרה שעה אחת</translation>
-<translation id="5123685120097942451">כרטיסיית גלישה בסתר</translation>
-<translation id="5127805178023152808">סנכרון כבוי</translation>
-<translation id="5129038482087801250">התקן אפליקציית אינטרנט</translation>
-<translation id="5132942445612118989">סנכרון הסיסמאות, ההיסטוריה ונתונים נוספים בכל המכשירים</translation>
-<translation id="5139940364318403933">‏איך משתמשים ב-Google Drive</translation>
-<translation id="515227803646670480">ניקוי נתונים מאוחסנים</translation>
-<translation id="5152843274749979095">לא מותקנות אפליקציות נתמכות</translation>
-<translation id="5161254044473106830">יש להזין כותרת</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{הורדה אחת נכשלה.}two{# הורדות נכשלו.}many{# הורדות נכשלו.}other{# הורדות נכשלו.}}</translation>
-<translation id="5170568018924773124">הצג בתיקייה</translation>
-<translation id="5184329579814168207">‏פתח ב-Chrome</translation>
-<translation id="5193988420012215838">הועתק אל הלוח</translation>
-<translation id="5197729504361054390">אנשי הקשר שייבחרו ישותפו עם <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">פרופיל עבודה</translation>
-<translation id="5210286577605176222">חזרה לכרטיסייה הקודמת</translation>
-<translation id="5210365745912300556">סגור כרטיסייה</translation>
-<translation id="5224771365102442243">כולל סרטון</translation>
-<translation id="5230560987958996918">‏<ph name="SITE" /> מבקש לבצע סריקה כדי לאתר מכשירי Bluetooth בקרבת מקום. המכשירים הבאים נמצאו:</translation>
-<translation id="5233638681132016545">כרטיסייה חדשה</translation>
-<translation id="526421993248218238">לא ניתן לטעון את הדף</translation>
-<translation id="5271967389191913893">המכשיר לא מצליח לפתוח את התוכן להורדה.</translation>
-<translation id="528192093759286357">כדי לצאת ממסך מלא, גרור מלמעלה וגע בלחצן 'הקודם'.</translation>
-<translation id="5292796745632149097">שליחה אל</translation>
-<translation id="5300589172476337783">הצגה</translation>
-<translation id="5301954838959518834">בסדר, הבנתי</translation>
-<translation id="5304593522240415983">שדה זה לא יכול להיות ריק</translation>
-<translation id="5307446750509046227">מחיקת נתוני אתר מהאחסון</translation>
-<translation id="5308380583665731573">התחברות</translation>
-<translation id="5313967007315987356">הוסף אתר</translation>
-<translation id="5317780077021120954">שמור</translation>
-<translation id="5324858694974489420">הגדרות הורים</translation>
-<translation id="5327248766486351172">שם</translation>
-<translation id="5335288049665977812">‏אפשר לאתרים להריץ JavaScript (מומלץ)</translation>
-<translation id="5342314432463739672">בקשות הרשאה</translation>
-<translation id="5357811892247919462">התקבלה כרטיסייה</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{כרטיסייה פתוחה אחת (<ph name="OPEN_TABS_ONE" />), יש להקיש כדי להחליף כרטיסיות}two{<ph name="OPEN_TABS_MANY" /> כרטיסיות פתוחות, יש להקיש כדי להחליף כרטיסיות}many{<ph name="OPEN_TABS_MANY" /> כרטיסיות פתוחות, יש להקיש כדי להחליף כרטיסיות}other{<ph name="OPEN_TABS_MANY" /> כרטיסיות פתוחות, יש להקיש כדי להחליף כרטיסיות}}</translation>
-<translation id="5391532827096253100">החיבור שלך לאתר הזה לא מאובטח. פרטי האתר</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(ועוד 1)}two{(ועוד #)}many{(ועוד #)}other{(ועוד #)}}</translation>
-<translation id="5400569084694353794">‏השימוש באפליקציה זו מהוות את הסכמתך ל<ph name="BEGIN_LINK1" />תנאים ולהגבלות<ph name="END_LINK1" /> ול<ph name="BEGIN_LINK2" />הודעת הפרטיות<ph name="END_LINK2" /> של Chrome.</translation>
-<translation id="5403592356182871684">שמות</translation>
-<translation id="5403644198645076998">גישה רק לאתרים ספציפיים</translation>
-<translation id="5414836363063783498">מאמת…</translation>
-<translation id="5423934151118863508">הדפים שבהם אתה מבקר בתדירות הגבוהה ביותר יופיעו כאן</translation>
-<translation id="5424588387303617268">‏‎<ph name="GIGABYTES" /> GB זמינים</translation>
-<translation id="543338862236136125">עריכת סיסמה</translation>
-<translation id="5433691172869980887">שם המשתמש הועתק</translation>
-<translation id="543509235395288790">מתבצעת הורדה של <ph name="COUNT" /> קבצים (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">מעבר לשורת כתובת האתר</translation>
-<translation id="5447201525962359567">‏כל נתוני האתר המאוחסנים, כולל קובצי Cookie ונתונים אחרים המאוחסנים באופן מקומי</translation>
-<translation id="5447765697759493033">האתר הזה לא יתורגם</translation>
-<translation id="545042621069398927">הדפדפן מאיץ את ההורדה.</translation>
-<translation id="5456381639095306749">הורד דף זה</translation>
-<translation id="5475862044948910901">להתחיל פעילות של מציאות רבודה?</translation>
-<translation id="548278423535722844">פתח יישום מפות</translation>
-<translation id="5487521232677179737">ניקוי נתונים</translation>
-<translation id="5494752089476963479">חסימת מודעות באתרים שמוצגות בהם מודעות מפריעות או מטעות</translation>
-<translation id="5500777121964041360">ייתכן שהאפשרות לא זמינה במיקום שלך</translation>
-<translation id="5512137114520586844">החשבון הזה מנוהל על ידי <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">האפשרות הזו הושבתה על-ידי מנהל המערכת של המכשיר</translation>
-<translation id="5515439363601853141">ביטול הנעילה יציג את הסיסמה</translation>
-<translation id="5516455585884385570">פתיחה של הגדרות ההתראות</translation>
-<translation id="5517095782334947753">יש לך סימניות, היסטוריה, סיסמאות והגדרות נוספות מ-<ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">הפניה לכתובת אתר אחרת נחסמה.</translation>
-<translation id="5527082711130173040">‏כדי לבצע סריקה לאיתור מכשירים, Chrome זקוק לגישה לנתוני מיקום. <ph name="BEGIN_LINK1" />עדכן את ההרשאות<ph name="END_LINK1" />. כמו כן, הגישה למיקום <ph name="BEGIN_LINK2" />כבויה במכשיר הזה<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">יש לבקש הרשאה לפני מתן גישה לאתרים אל טקסט ותמונות מלוח העריכה (מומלץ)</translation>
-<translation id="5530766185686772672">סגור כרטיסיות גלישה בסתר</translation>
-<translation id="5534334044554683961">‏בזמן השימוש ב-VR, ייתכן שלאתר הזה תהיה אפשרות ללמוד על:
-  -   התכונות הפיזיות שלך, כמו הגובה
-  -   הצורה שבה החדר שלך מסודר
-
-חשוב לוודא שהאתר מהימן לפני תחילת השימוש ב-VR.</translation>
-<translation id="5534640966246046842">האתר הועתק</translation>
-<translation id="5556459405103347317">ניסיון טעינה נוסף</translation>
-<translation id="5561549206367097665">ממתין לרשת…</translation>
-<translation id="557283862590186398">‏Chrome זקוק להרשאת גישה אל המיקרופון בשביל האתר הזה.</translation>
-<translation id="55737423895878184">יש הרשאה לגישה אל המיקום ולהצגת הודעות</translation>
-<translation id="5578795271662203820">חפש את התמונה הזו ב-<ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">אפשר לבחור מה לסנכרן בכל שלב דרך <ph name="BEGIN_LINK1" />ההגדרות<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">עריכת כתובת</translation>
-<translation id="5596627076506792578">אפשרויות נוספות</translation>
-<translation id="5599455543593328020">מצב גלישה בסתר</translation>
-<translation id="5620928963363755975">איתור הקבצים והדפים שלך ב'הורדות' דרך הלחצן 'אפשרויות נוספות'</translation>
-<translation id="5626134646977739690">שם:</translation>
-<translation id="5639724618331995626">התר גישה לכל האתרים</translation>
-<translation id="5648166631817621825">מהשבוע האחרון</translation>
-<translation id="5649053991847567735">הורדות אוטומטיות</translation>
-<translation id="5655963694829536461">חיפוש ההורדות שלך</translation>
-<translation id="5659593005791499971">אימייל</translation>
-<translation id="5665379678064389456">צור אירוע ב-<ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">להתעלם מבקשה של אתר שנועדה למנוע את שינוי הזום</translation>
-<translation id="5677928146339483299">חסום</translation>
-<translation id="5684874026226664614">אופס. לא ניתן היה לתרגם את הדף הזה.</translation>
-<translation id="5686790454216892815">שם הקובץ ארוך מדי</translation>
-<translation id="5689516760719285838">מיקום</translation>
-<translation id="569536719314091526">דרך לחצן האפשרויות הנוספות אפשר לתרגם את הדף הזה לשפה כלשהי</translation>
-<translation id="572328651809341494">כרטיסיות אחרונות</translation>
-<translation id="5726692708398506830">הגדל את כל מה שמופיע בדף</translation>
-<translation id="5748802427693696783">הוחלף לכרטיסיות רגילות</translation>
-<translation id="5749068826913805084">‏לצורך הורדת קבצים, Chrome זקוק לגישה לאחסון.</translation>
-<translation id="5763382633136178763">כרטיסיות גלישה בסתר</translation>
-<translation id="5763514718066511291">הקשה מעתיקה את כתובת האתר של האפליקציה הזו</translation>
-<translation id="5765780083710877561">תיאור:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> מתוך <ph name="SPACE_AVAILABLE" /> נמצאים בשימוש</translation>
-<translation id="5797070761912323120">‏Google עשויה להשתמש בהיסטוריית הגלישה שלך לצורך התאמה אישית של החיפוש, מודעות ושירותי Google אחרים</translation>
-<translation id="5804241973901381774">הרשאות</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{לפני שעה}two{לפני שעתיים}many{לפני # שעות}other{לפני # שעות}}</translation>
-<translation id="5810288467834065221">‏Copyright <ph name="YEAR" /> Google LLC.‎ כל הזכויות שמורות.</translation>
-<translation id="5817918615728894473">התאם</translation>
-<translation id="583281660410589416">לא ידוע</translation>
-<translation id="5833984609253377421">שיתוף קישור</translation>
-<translation id="5836192821815272682">‏מוריד עדכון של Chrome…</translation>
-<translation id="5853623416121554550">מושהה</translation>
-<translation id="5854790677617711513">לפני יותר מ-30 ימים</translation>
-<translation id="5858741533101922242">‏לא ניתן להפעיל ב-Chrome את מתאם Bluetooth</translation>
-<translation id="5860033963881614850">כבוי</translation>
-<translation id="5862731021271217234">כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, יש להפעיל את הסנכרון</translation>
-<translation id="5864174910718532887">פרטים: ממוינות לפי שם האתר</translation>
-<translation id="5864419784173784555">ממתין להורדה נוספת…</translation>
-<translation id="5865733239029070421">‏שליחת דוחות קריסה וסטטיסטיקת שימוש אל Google באופן אוטומטי</translation>
-<translation id="5869522115854928033">סיסמאות שמורות</translation>
-<translation id="5902828464777634901">‏כל הנתונים המקומיים המאוחסנים על ידי האתר הזה יימחקו, כולל קובצי Cookie.</translation>
-<translation id="5916664084637901428">פועל</translation>
-<translation id="5919204609460789179">יש לעדכן את <ph name="PRODUCT_NAME" /> כדי להתחיל סנכרון</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> נחסכו</translation>
-<translation id="5939518447894949180">אפס</translation>
-<translation id="5942872142862698679">‏שימוש ב-Google לחיפוש</translation>
-<translation id="5952764234151283551">‏שליחת כתובת האתר של הדף שאליו ניסית להגיע אל Google</translation>
-<translation id="5956665950594638604">‏פתיחת מרכז העזרה של Chrome בכרטיסייה חדשה</translation>
-<translation id="5958275228015807058">הקבצים והדפים שלך נמצאים ב'הורדות'</translation>
-<translation id="5962718611393537961">הקש כדי לכווץ</translation>
-<translation id="6000066717592683814">‏המשך להשתמש ב-Google</translation>
-<translation id="6005538289190791541">הצעה לסיסמה</translation>
-<translation id="6036057147555329831">‏ICU נוסף</translation>
-<translation id="6039379616847168523">עבור לכרטיסייה הבאה</translation>
-<translation id="6040143037577758943">סגור</translation>
-<translation id="6042308850641462728">עוד</translation>
-<translation id="604996488070107836">הורדת <ph name="FILE_NAME" /> נכשלה עקב שגיאה לא ידועה.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">הורדות שהושלמו</translation>
-<translation id="6075798973483050474">עריכת דף הבית</translation>
-<translation id="60923314841986378">נותרו <ph name="HOURS" /> שעות</translation>
-<translation id="6108923351542677676">ההגדרה מתבצעת…</translation>
-<translation id="6111020039983847643">צרכת בפועל</translation>
-<translation id="6112702117600201073">מרענן את הדף</translation>
-<translation id="6127379762771434464">הפריט הוסר</translation>
-<translation id="6140912465461743537">ארץ/אזור</translation>
-<translation id="614940544461990577">כדאי לנסות:</translation>
-<translation id="6154478581116148741">יש להפעיל נעילת מסך ב'הגדרות' כדי לייצא את הסיסמאות מהמכשיר הזה</translation>
-<translation id="6159335304067198720">חיסכון בצריכת נתונים בשיעור של <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">למידע נוסף</translation>
-<translation id="6177111841848151710">חסוּם למנוע החיפוש הנוכחי</translation>
-<translation id="6181444274883918285">להוספת מקרה חריג של אתר</translation>
-<translation id="6192333916571137726">קובץ הורדה</translation>
-<translation id="6192792657125177640">יוצאי דופן</translation>
-<translation id="6194112207524046168">‏כדי לאפשר ל-Chrome לגשת אל המצלמה, צריך להפעיל אותה גם ב<ph name="BEGIN_LINK" />הגדרות Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">‏חסום קובצי Cookie של צד שלישי</translation>
-<translation id="6206551242102657620">החיבור מאובטח. פרטי האתר</translation>
-<translation id="6210748933810148297">אינך <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">יש לבטל את הנעילה כדי לייצא סיסמאות</translation>
+<translation id="1406000523432664303">‏'לא לעקוב (DNT)'</translation>
 <translation id="6232535412751077445">‏אם תופעל התכונה 'לא לעקוב (DNT), בקשה זו תיכלל בתנועת הגלישה שלך. השפעת הבקשה תלויה באופן הפעולה של כל אתר – אם הוא מגיב לבקשה או לא, וכיצד הוא מפרש אותה.
 
 לדוגמה, ייתכן שבתגובה לבקשה, אתרים מסוימים יציגו מודעות שאינן מבוססות על אתרים אחרים שבהם ביקרת. אתרים רבים ימשיכו לאסוף את נתוני הגלישה שלך ולהשתמש בהם, למשל כדי לשפר את האבטחה, כדי לספק תוכן, מודעות והמלצות וכדי ליצור נתונים סטטיסטיים לדיווח.</translation>
-<translation id="624789221780392884">העדכון מוכן</translation>
-<translation id="6255999984061454636">הצעות לתוכן</translation>
-<translation id="6277522088822131679">אירעה בעיה בעת הדפסת הדף. נסה שוב.</translation>
-<translation id="6295158916970320988">כל האתרים</translation>
-<translation id="629730747756840877">חשבון</translation>
-<translation id="6303969859164067831">יציאה וכיבוי הסנכרון</translation>
-<translation id="6316139424528454185">‏אין תמיכה בגרסת Android</translation>
-<translation id="6320088164292336938">רטט</translation>
-<translation id="6324034347079777476">‏סנכרון מערכת Android מושבת</translation>
-<translation id="6333140779060797560">שיתוף באמצעות <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">הצפנה</translation>
-<translation id="6341580099087024258">לשאול איפה לשמור קבצים</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> נוספת}two{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> נוספות}many{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> נוספות}other{‏<ph name="SHIPPING_ADDRESS_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> נוספות}}</translation>
-<translation id="6364438453358674297">האם להסיר את ההצעה מההיסטוריה?</translation>
-<translation id="6369229450655021117">מכאן אפשר לחפש באינטרנט, לשתף עם חברים ולראות דפים פתוחים</translation>
-<translation id="6378173571450987352">פרטים: מיון לפי נפח הנתונים שנצרכו</translation>
-<translation id="6381421346744604172">תצוגה כהה יותר של אתרים</translation>
-<translation id="6388207532828177975">ניקוי ואיפוס</translation>
-<translation id="6393863479814692971">‏Chrome זקוק להרשאת גישה אל המצלמה והמיקרופון בשביל האתר הזה.</translation>
-<translation id="6395288395575013217">קישור</translation>
-<translation id="6404511346730675251">ערוך סימניה</translation>
-<translation id="6406506848690869874">סנכרון</translation>
-<translation id="641643625718530986">הדפסה…</translation>
-<translation id="6416782512398055893">‏בוצעה הורדה של MB <ph name="MBS" /></translation>
-<translation id="6427112570124116297">תרגום התוכן באינטרנט</translation>
-<translation id="6433501201775827830">בחירת מנוע החיפוש</translation>
-<translation id="6437478888915024427">פרטי דף</translation>
-<translation id="6441734959916820584">השם ארוך מדי</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{תמונה אחת (#)}two{# תמונות}many{# תמונות}other{# תמונות}}</translation>
-<translation id="6447842834002726250">‏קובצי Cookie</translation>
-<translation id="6461962085415701688">לא ניתן לפתוח את הקובץ</translation>
-<translation id="6464977750820128603">‏אפשר לראות אתרים שמבקרים בהם ב-Chrome ולהגדיר טיימרים בשבילם.\n\n‏Google מקבלת מידע על האתרים שמוגדרים בשבילם טיימרים ומשך השהייה שלך באתרים האלה. המידע עוזר לשפר את 'שימוש חכם בדיגיטל'.</translation>
-<translation id="6475951671322991020">הורד סרטון</translation>
-<translation id="6482749332252372425">הורדת <ph name="FILE_NAME" /> נכשלה מאחר שחסר מקום אחסון.</translation>
-<translation id="6496823230996795692">כדי להשתמש באפליקציה <ph name="APP_NAME" /> בפעם הראשונה יש להתחבר לאינטרנט.</translation>
-<translation id="6508722015517270189">‏הפעלה מחדש של Chrome</translation>
-<translation id="6527303717912515753">שיתוף</translation>
-<translation id="6532866250404780454">‏אתרים שנכנסים אליהם ב-Chrome לא יופיעו. כל הטיימרים של האתרים יימחקו.</translation>
-<translation id="6534565668554028783">‏ל-Google נדרש זמן רב מדי להגיב</translation>
-<translation id="6538442820324228105">‏בוצעה הורדה של GB <ph name="GBS" /></translation>
-<translation id="6539092367496845964">משהו השתבש. יש לנסות שוב מאוחר יותר.</translation>
-<translation id="654446541061731451">בחר כרטיסייה להעברת התוכן שלה</translation>
-<translation id="6545017243486555795">נקה את כל הנתונים</translation>
-<translation id="6545864417968258051">‏סריקת Bluetooth</translation>
-<translation id="6560414384669816528">‏השתמש ב-Sogou לחיפוש</translation>
-<translation id="6566259936974865419">‏Chrome חסך לך ‎<ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">אני רוצה לאפשר תמיד</translation>
-<translation id="6573431926118603307">‏כרטיסיות שפתחת ב-Chrome במכשירים האחרים שלך יופיעו כאן.</translation>
-<translation id="6583199322650523874">סמן את הדף הנוכחי בסימנייה</translation>
-<translation id="6593061639179217415">לגרסה במחשב</translation>
-<translation id="6600954340915313787">‏הועתק אל Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">תוכן מוגן</translation>
-<translation id="6627583120233659107">ערוך תיקיה</translation>
-<translation id="6643016212128521049">ניקוי</translation>
-<translation id="6643649862576733715">מיון לפי כמות הנתונים שנחסכו</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{‏<ph name="CONTACT_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> נוסף}two{‏<ph name="CONTACT_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> נוספים}many{‏<ph name="CONTACT_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> נוספים}other{‏<ph name="CONTACT_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> נוספים}}</translation>
-<translation id="6649642165559792194">הצגת התמונה בתצוגה מקדימה <ph name="BEGIN_NEW" />חדש<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">‏כדי לבצע סריקה לאיתור מכשירים ב-Chrome, יש צורך בגישה לנתוני מיקום. <ph name="BEGIN_LINK" />עדכן הרשאות<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">סיסמה</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">פתח ב-<ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">‏הודעת הפרטיות של Chrome</translation>
-<translation id="6676840375528380067">‏למחוק את נתוני Chrome שלך מהמכשיר הזה?</translation>
-<translation id="6697492270171225480">הצגת הצעות לדפים דומים אם דף מסוים לא נמצא</translation>
-<translation id="6697947395630195233">‏Chrome זקוק לגישה אל המיקום שלך כדי לשתף אותו עם האתר הזה.</translation>
-<translation id="6698801883190606802">ניהול נתונים מסונכרנים</translation>
-<translation id="6699370405921460408">‏כשנכנסים לדפים בזמן הגלישה, הם עוברים אופטימיזציה על ידי השרתים של Google.</translation>
-<translation id="6706288973712894588">‏אין לך כרגע חיבור לאינטרנט.\n<ph name="BEGIN_LINK" />לעיון בפיד במצב לא מקוון.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">חדשות</translation>
-<translation id="6710213216561001401">הקודם</translation>
-<translation id="671481426037969117">זמן השימוש באפליקציה <ph name="FQDN" /> הסתיים. הטיימר יופעל מחדש מחר ואז אפשר יהיה להשתמש שוב באפליקציה.</translation>
-<translation id="6738867403308150051">מוריד...</translation>
-<translation id="6746124502594467657">הזז למטה</translation>
-<translation id="6766622839693428701">החלקה מטה סוגרת.</translation>
-<translation id="6766758767654711248">הקשה תעביר אותך אל האתר</translation>
-<translation id="6767294960381293877">רשימת המכשירים שאפשר לשתף איתם כרטיסייה נפתחה בחצי גובה המסך.</translation>
-<translation id="6782111308708962316">‏אתרים של צד שלישי לא יוכלו לשמור ולקרוא נתונים של קובצי cookie</translation>
-<translation id="6790428901817661496">הפעל</translation>
-<translation id="6811034713472274749">הדף מוכן להצגה</translation>
-<translation id="6818926723028410516">בחירת פריטים</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">תרגום</translation>
-<translation id="6845325883481699275">‏עזרה בשיפור האבטחה של Chrome</translation>
-<translation id="6846298663435243399">טוען…</translation>
-<translation id="6850409657436465440">ההורדה עדיין מתבצעת</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> כרטיסיות נסגרו</translation>
-<translation id="6864459304226931083">הורד תמונה</translation>
-<translation id="6865313869410766144">נתוני טפסים למילוי אוטומטי</translation>
-<translation id="688738109438487280">הוסף נתונים קיימים אל <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">ביטול הנעילה יאפשר להעתיק את הסיסמה</translation>
-<translation id="6896758677409633944">העתק</translation>
-<translation id="6910211073230771657">נמחק</translation>
-<translation id="6912998170423641340">חסימת היכולת של אתרים לקרוא טקסט ותמונות מלוח העריכה</translation>
-<translation id="6914783257214138813">כל מי שיוכל לגשת אל הקובץ המיוצא יוכל לראות את הסיסמאות שלך.</translation>
-<translation id="6942665639005891494">ניתן תמיד לשנות את מיקום ברירת המחדל להורדות דרך האפשרות 'הגדרות' בתפריט</translation>
-<translation id="6945221475159498467">בחירה</translation>
-<translation id="6963642900430330478">הדף הזה מסוכן. פרטי האתר</translation>
-<translation id="6963766334940102469">מחק סימניות</translation>
-<translation id="6965382102122355670">אישור</translation>
-<translation id="6979737339423435258">משחר ההיסטוריה</translation>
-<translation id="6981982820502123353">נגישות</translation>
-<translation id="6989267951144302301">ההורדה נכשלה</translation>
-<translation id="6990079615885386641">‏קבל את האפליקציה מחנות Google Play‏: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">יש לשאול לפני שמאפשרים לאתרים להשתמש במיקרופון (מומלץ)</translation>
-<translation id="7015203776128479407">הגדרת הסנכרון הראשונית לא הושלמה. הסנכרון מושבת.</translation>
-<translation id="7016516562562142042">מופעל למנוע החיפוש הנוכחי</translation>
-<translation id="7022756207310403729">פתיחה בדפדפן</translation>
-<translation id="702463548815491781">‏מומלץ אם הפעלת TalkBack או גישה באמצעות מתג</translation>
-<translation id="7029809446516969842">סיסמאות</translation>
-<translation id="7053983685419859001">חסימה</translation>
-<translation id="7055152154916055070">הפניה אוטומטית נחסמה:</translation>
-<translation id="7063006564040364415">לא ניתן היה להתחבר אל שרת הסנכרון.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{נבחר אחד}two{נבחרו #}many{נבחרו #}other{נבחרו #}}</translation>
-<translation id="7071521146534760487">ניהול חשבון</translation>
-<translation id="7077143737582773186">‏כרטיס SD</translation>
-<translation id="7087918508125750058">נבחרו <ph name="ITEM_COUNT" />. האפשרויות מוצגות בחלק העליון של המסך</translation>
-<translation id="7121362699166175603">‏ניקוי ההיסטוריה וההשלמות האוטומטיות בשורת כתובת האתר. ייתכן שלחשבון Google שלך יהיו צורות אחרות של היסטוריית גלישה בכתובת <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">יופעלו במנוע החיפוש הנוכחי</translation>
-<translation id="7138678301420049075">אחר</translation>
-<translation id="7141896414559753902">חסימה של חלונות קופצים והפניות אוטומטיות באתרים (מומלץ)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />טעינת הדף המקורי<ph name="END_LINK" /> מ-<ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">מהיום האחרון</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">אפשר לשנות את ההגדרה הזו מאוחר יותר ב'הגדרות'</translation>
-<translation id="7180611975245234373">רענון</translation>
-<translation id="7189372733857464326">‏המערכת ממתינה שיסתיים העדכון של שירותי Google Play</translation>
-<translation id="7191430249889272776">הכרטיסייה נפתחה ברקע.</translation>
-<translation id="723171743924126238">בחר תמונות</translation>
-<translation id="7233236755231902816">‏כדי לראות באינטרנט תוכן בשפה שלך, יש להוריד את הגרסה האחרונה של Chrome</translation>
-<translation id="7243308994586599757">אפשרויות הזמינות באזור החלק התחתון של המסך</translation>
-<translation id="7248069434667874558">‏יש לוודא שהסנכרון ב-Chrome הופעל ב-<ph name="TARGET_DEVICE_NAME" /></translation>
-<translation id="7250468141469952378">נבחרו <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">אתר חסום</translation>
-<translation id="7290209999329137901">לא ניתן היה לשנת את השם מפני שהפריט לא זמין</translation>
-<translation id="7291387454912369099">‏Assistant למילוי אוטומטי</translation>
-<translation id="7293171162284876153">‏כדי להתחיל לסנכרן צריך להפעיל את האפשרות "סנכרון הנתונים מ-Chrome".</translation>
-<translation id="729975465115245577">אין במכשיר אפליקציה לאחסון קובץ הסיסמאות.</translation>
-<translation id="7302081693174882195">פרטים: מיון לפי נפח הנתונים שנחסכו</translation>
-<translation id="7328017930301109123">‏במצב טעינה מהירה, Chrome טוען דפים מהר יותר ומפחית את השימוש בנתונים בשיעור של עד 60 אחוזים.</translation>
-<translation id="7333031090786104871">עדיין מוסיף את האתר הקודם</translation>
-<translation id="7352939065658542140">סרטון</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{שתף פריט אחד שנבחר}two{שתף # פריטים שנבחרו}many{שתף # פריטים שנבחרו}other{שתף # פריטים שנבחרו}}</translation>
 <translation id="7359002509206457351">גישה לאמצעי תשלום</translation>
+<translation id="8026334261755873520">ניקוי נתוני גלישה</translation>
+<translation id="1291207594882862231">‏ניקוי ההיסטוריה, קובצי ה-Cookie, נתוני האתרים, המטמון…</translation>
+<translation id="7814200940910057384">‏נתוני Brave נוקו</translation>
+<translation id="1664855196866195614">‏הנתונים שבחרת הוסרו מ-Brave ומהמכשירים המסונכרנים.
+
+ייתכן שבכתובת <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> יש סוגים אחרים של היסטוריית גלישה בחשבון Brave Software, כמו חיפושים ופעילות משירותי Brave Software אחרים.</translation>
+<translation id="4699172675775169585">תמונות וקבצים במטמון</translation>
+<translation id="2496180316473517155">היסטוריית גלישה</translation>
+<translation id="2546283357679194313">‏נתוני אתר וקובצי Cookie</translation>
+<translation id="8662811608048051533">תבוצע יציאה שלך מרוב האתרים.</translation>
+<translation id="8218628800671693884">‏הפעולה תוציא אותך מרוב האתרים אבל לא מחשבון Brave Software שלך.</translation>
+<translation id="2017836877785168846">ניקוי של ההיסטוריה וההשלמות האוטומטיות בשורת כתובת האתר</translation>
+<translation id="8096327394278038498">‏ניקוי ההיסטוריה וההשלמות האוטומטיות בשורת כתובת האתר. ייתכן שלחשבון Brave Software שלך יהיו צורות אחרות של היסטוריית גלישה בכתובת <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">‏ניקוי ההיסטוריה מכל המכשירים שבהם המשתמש נכנס לחשבון. ייתכן שלחשבון Brave Software שלך יהיו צורות אחרות של היסטוריית גלישה בכתובת <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">סיסמאות שמורות</translation>
+<translation id="6865313869410766144">נתוני טפסים למילוי אוטומטי</translation>
+<translation id="7562080006725997899">מנקה נתוני גלישה</translation>
+<translation id="5487521232677179737">ניקוי נתונים</translation>
+<translation id="7498271377022651285">המתן…</translation>
+<translation id="784934925303690534">טווח זמן</translation>
+<translation id="1718835860248848330">מהשעה האחרונה</translation>
+<translation id="7149893636342594995">מהיום האחרון</translation>
+<translation id="5648166631817621825">מהשבוע האחרון</translation>
+<translation id="8571213806525832805">מארבעת השבועות האחרונים</translation>
+<translation id="5854790677617711513">לפני יותר מ-30 ימים</translation>
+<translation id="6979737339423435258">משחר ההיסטוריה</translation>
+<translation id="982182592107339124">פעולה זו תמחק נתונים של כל האתרים, כולל:</translation>
+<translation id="6643016212128521049">ניקוי</translation>
+<translation id="7641339528570811325">מחיקת נתוני הגלישה...</translation>
+<translation id="1670399744444387456">בסיסי</translation>
+<translation id="3245261285041759672">‏ייתכן שלחשבון Brave Software שלך יהיו צורות אחרות של היסטוריית גלישה בכתובת <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">אתר חסום</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> פריטים נמחקו</translation>
+<translation id="1121094540300013208">דוחות קריסה ושימוש</translation>
+<translation id="9079153198295609735">‏שליחה אוטומטית של דוחות קריסה וסטטיסטיקות שימוש ל-Brave Software</translation>
+<translation id="6981982820502123353">נגישות</translation>
+<translation id="2387895666653383613">שינוי גודל טקסט</translation>
+<translation id="2321958826496381788">יש לגרור את המחוון עד שאפשר יהיה לקרוא את הקטע הזה בצורה נוחה. לאחר הקשה פעמיים על פיסקה, הטקסט אמור להיות מוצג בגודל הזה לפחות.</translation>
+<translation id="3895926599014793903">שינוי הזום בכל מקרה</translation>
+<translation id="5668404140385795438">להתעלם מבקשה של אתר שנועדה למנוע את שינוי הזום</translation>
+<translation id="4149994727733219643">תצוגה פשוטה של דפי אינטרנט</translation>
+<translation id="9100505651305367705">יש להציע הצגת מאמרים בתצוגה פשוטה, כשהאפשרות נתמכת</translation>
+<translation id="1409426117486808224">תצוגה פשוטה של כרטיסיות פתוחות</translation>
+<translation id="702463548815491781">‏מומלץ אם הפעלת TalkBack או גישה באמצעות מתג</translation>
+<translation id="8284326494547611709">כתוביות</translation>
+<translation id="4165986682804962316">הגדרות לאתרים</translation>
+<translation id="6295158916970320988">כל האתרים</translation>
+<translation id="8380167699614421159">באתר הזה מוצגות מודעות מפריעות או מטעות</translation>
+<translation id="1919345977826869612">מודעות</translation>
+<translation id="410351446219883937">הפעלה אוטומטית</translation>
+<translation id="6447842834002726250">‏קובצי Cookie</translation>
+<translation id="6196640612572343990">‏חסום קובצי Cookie של צד שלישי</translation>
+<translation id="6782111308708962316">‏אתרים של צד שלישי לא יוכלו לשמור ולקרוא נתונים של קובצי cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">חלונות קופצים והפניות אוטומטיות</translation>
+<translation id="4751476147751820511">חיישני תנועה או אור</translation>
+<translation id="1717218214683051432">חיישני תנועה</translation>
+<translation id="2091887806945687916">צליל</translation>
+<translation id="2586657967955657006">לוח</translation>
+<translation id="6320088164292336938">רטט</translation>
+<translation id="4226663524361240545">רטט של המכשיר אפשרי כשמתקבלת הודעה</translation>
+<translation id="1446450296470737166">‏התר שליטה מלאה על מכשירי MIDI</translation>
+<translation id="3744111561329211289">סינכרון ברקע</translation>
+<translation id="5649053991847567735">הורדות אוטומטיות</translation>
+<translation id="6181444274883918285">להוספת מקרה חריג של אתר</translation>
+<translation id="5313967007315987356">הוסף אתר</translation>
+<translation id="1369915414381695676">האתר <ph name="SITE_NAME"/> נוסף</translation>
+<translation id="7837721118676387834">אפשר הפעלה אוטומטית של סרטונים מושתקים באתר ספציפי.</translation>
+<translation id="2621115761605608342">‏אפשר JavaScript לאתר ספציפי.</translation>
+<translation id="8801436777607969138">‏חסימת JavaScript באתר ספציפי.</translation>
+<translation id="8372893542064058268">אפשר סנכרון ברקע לאתר ספציפי.</translation>
+<translation id="358794129225322306">מתן הרשאה לאתר להוריד קבצים מרובים באופן אוטומטי.</translation>
+<translation id="4008040567710660924">‏אישור קובצי Cookie של אתר מסוים.</translation>
+<translation id="8958424370300090006">‏חסימת קובצי Cookie של אתר מסוים.</translation>
+<translation id="7882806643839505685">מתן הרשאה להשמעת צלילים באתר ספציפי.</translation>
+<translation id="4468959413250150279">השתקת צלילים באתר ספציפי.</translation>
+<translation id="1994173015038366702">כתובת אתר</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">שימוש</translation>
+<translation id="5804241973901381774">הרשאות</translation>
+<translation id="4278390842282768270">מותר</translation>
+<translation id="5677928146339483299">חסום</translation>
+<translation id="1984937141057606926">מותר, מלבד צד שלישי</translation>
+<translation id="7423098979219808738">תופיע בקשת אישור</translation>
+<translation id="8116925261070264013">מושתקים</translation>
+<translation id="8300705686683892304">מנוהלים על-ידי אפליקציה</translation>
+<translation id="6192792657125177640">יוצאי דופן</translation>
+<translation id="257931822824936280">מורחב - לחץ כדי לכווץ.</translation>
+<translation id="5100237604440890931">מכווץ - לחץ כדי להרחיב.</translation>
+<translation id="857943718398505171">מותרת (מומלץ)</translation>
+<translation id="2913331724188855103">‏אתרים יוכלו לשמור ולקרוא נתונים של קובצי Cookie (מומלץ)</translation>
+<translation id="7445411102860286510">אתרים יוכלו להפעיל באופן אוטומטי סרטונים מושתקים (מומלץ)</translation>
+<translation id="5335288049665977812">‏אפשר לאתרים להריץ JavaScript (מומלץ)</translation>
+<translation id="5527111080432883924">יש לבקש הרשאה לפני מתן גישה לאתרים אל טקסט ותמונות מלוח העריכה (מומלץ)</translation>
+<translation id="6912998170423641340">חסימת היכולת של אתרים לקרוא טקסט ותמונות מלוח העריכה</translation>
+<translation id="7423538860840206698">הגישה לקריאה מלוח העריכה נחסמה</translation>
+<translation id="3955193568934677022">אתרים יוכלו להפעיל תוכן מוגן (מומלץ)</translation>
+<translation id="445467742685312942">מתן הרשאה לאתרים להציג תוכן מוגן</translation>
+<translation id="2107397443965016585">יש לבקש ממני אישור לפני מתן הרשאה לאתרים להציג תוכן מוגן (מומלץ)</translation>
+<translation id="2910701580606108292">הצגת שאלה לפני מתן הרשאה לאתרים להפעיל תוכן מוגן</translation>
+<translation id="757524316907819857">חסימה של הפעלת תוכן מוגן על-ידי אתרים</translation>
+<translation id="3277252321222022663">התרת גישה של אתרים אל החיישנים (מומלץ)</translation>
+<translation id="5048398596102334565">התרת גישה של אתרים אל חיישני התנועה (מומלץ)</translation>
+<translation id="8816026460808729765">חסימת הגישה של אתרים אל חיישנים</translation>
+<translation id="169515064810179024">חסימת הגישה של אתרים אל חיישני תנועה</translation>
+<translation id="1660204651932907780">מתן הרשאה לאתרים להשמיע צלילים (מומלץ)</translation>
+<translation id="3600792891314830896">השתקת אתרים שמשמיעים צלילים</translation>
+<translation id="1743802530341753419">הצגת בקשה לפני מתן אישור לאתרים להתחבר להתקן (מומלץ)</translation>
+<translation id="851751545965956758">חסימת התחברות של אתרים אל התקנים</translation>
+<translation id="7141896414559753902">חסימה של חלונות קופצים והפניות אוטומטיות באתרים (מומלץ)</translation>
+<translation id="5494752089476963479">חסימת מודעות באתרים שמוצגות בהם מודעות מפריעות או מטעות</translation>
+<translation id="3123473560110926937">חסומות בחלק מהאתרים</translation>
+<translation id="965817943346481315">חסימה אם באתר מוצגות מודעות מפריעות או מטעות (מומלץ)</translation>
+<translation id="3386292677130313581">יש לשאול לפני שמאפשרים לאתרים לדעת מה המיקום שלך (מומלץ)</translation>
+<translation id="9139068048179869749">יש לשאול לפני שמאפשרים לאתרים לשלוח הודעות (מומלץ)</translation>
+<translation id="4479647676395637221">יש לשאול לפני שמאפשרים לאתרים להשתמש במצלמה שלך (מומלץ)</translation>
+<translation id="6992289844737586249">יש לשאול לפני שמאפשרים לאתרים להשתמש במיקרופון (מומלץ)</translation>
+<translation id="2289270750774289114">‏המערכת מבקשת אישור כשאתר רוצה לאתר התקני Bluetooth קרובים (מומלץ)</translation>
+<translation id="7053983685419859001">חסימה</translation>
+<translation id="7128222689758636196">יופעלו במנוע החיפוש הנוכחי</translation>
+<translation id="7589445247086920869">חסימה במנוע החיפוש הנוכחי</translation>
+<translation id="6388207532828177975">ניקוי ואיפוס</translation>
+<translation id="7999064672810608036">‏האם אתה בטוח שברצונך לנקות את כל הנתונים המקומיים, כולל קובצי Cookie, ולאפס את כל ההרשאות של האתר הזה?</translation>
+<translation id="2822354292072154809">לאפס את כל הרשאות האתר בשביל <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">ניקוי נתונים מאוחסנים</translation>
+<translation id="5902828464777634901">‏כל הנתונים המקומיים המאוחסנים על ידי האתר הזה יימחקו, כולל קובצי Cookie.</translation>
+<translation id="119944043368869598">ניקוי הכל</translation>
+<translation id="2490684707762498678">מנוהלות על-ידי <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">פתיחה של הגדרות ההתראות</translation>
+<translation id="1404122904123200417">מוטבע ב-<ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">קבצים שנשמרו על ידי אתרים מופיעים כאן</translation>
+<translation id="4181841719683918333">שפות</translation>
+<translation id="2647434099613338025">להוספת שפה</translation>
+<translation id="1952172573699511566">אתרים יציגו טקסט בשפה המועדפת שלך, כשזה אפשרי.</translation>
+<translation id="8559990750235505898">הצעה לתרגם דפים בשפות אחרות</translation>
+<translation id="4719927025381752090">הצגת הצעות לתרגום</translation>
+<translation id="8156139159503939589">באילו שפות באפשרותך לקרוא?</translation>
+<translation id="5689516760719285838">מיקום</translation>
+<translation id="2440823041667407902">גישה למיקום</translation>
+<translation id="2023546461831060654">‏הפעל הרשאות בשביל Brave ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">‏הפעלת הרשאה ל-Brave ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">‏כדי לאפשר ל-Brave לגשת אל המיקום, צריך להפעיל את האפשרות הזו גם ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">‏כדי לאפשר ל-Brave לגשת אל המצלמה, צריך להפעיל אותה גם ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">‏כדי לאפשר ל-Brave לשלוח לך התראות, צריך להפעיל אותן גם ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">‏כדי לאפשר ל-Brave לגשת אל המיקרופון, צריך להפעיל אותו גם ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">‏הגישה למיקום כבויה בשביל המכשיר הזה. יש להפעיל אותה ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">‏גם הגישה למיקום כבויה בשביל המכשיר הזה. יש להפעיל אותה ב<ph name="BEGIN_LINK"/>הגדרות Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">מצלמה</translation>
+<translation id="3227137524299004712">מיקרופון</translation>
+<translation id="1647391597548383849">גישה אל המצלמה שלך</translation>
+<translation id="945632385593298557">גישה למיקרופון שלך</translation>
+<translation id="6612358246767739896">תוכן מוגן</translation>
+<translation id="885701979325669005">אחסון</translation>
+<translation id="3198916472715691905">נתונים מאוחסנים בנפח <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">שלול הרשאות מכשיר</translation>
+<translation id="4962975101802056554">ביטול כל ההרשאות בשביל המכשיר</translation>
+<translation id="6545864417968258051">‏סריקת Bluetooth</translation>
+<translation id="4411535500181276704">מצב טעינה מהירה</translation>
+<translation id="7821588508402923572">ערכי החיסכון בנתונים יופיעו כאן</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> נשמרו</translation>
+<translation id="8569404424186215731">מאז <ph name="DATE"/></translation>
+<translation id="3252158532344029638">‏במצב טעינה מהירה, Brave טוען דפים מהר יותר ומפחית את השימוש בנתונים בשיעור של עד 60 אחוזים.</translation>
+<translation id="6159335304067198720">חיסכון בצריכת נתונים בשיעור של <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">חסכון בחבילת הגלישה</translation>
+<translation id="6111020039983847643">צרכת בפועל</translation>
+<translation id="7413229368719586778">תאריך התחלה <ph name="DATE"/></translation>
+<translation id="1782483593938241562">תאריך סיום <ph name="DATE"/></translation>
+<translation id="2728754400939377704">מיון לפי אתר</translation>
+<translation id="5864174910718532887">פרטים: ממוינות לפי שם האתר</translation>
+<translation id="116280672541001035">צרכת</translation>
+<translation id="8349013245300336738">מיון לפי כמות הנתונים שבהם נעשה שימוש</translation>
+<translation id="6378173571450987352">פרטים: מיון לפי נפח הנתונים שנצרכו</translation>
+<translation id="2631006050119455616">חסכת</translation>
+<translation id="6643649862576733715">מיון לפי כמות הנתונים שנחסכו</translation>
+<translation id="7302081693174882195">פרטים: מיון לפי נפח הנתונים שנחסכו</translation>
+<translation id="4179980317383591987">נעשה שימוש ב-<ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> נחסכו</translation>
+<translation id="2156074688469523661">אתרים שנותרו (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">אחר</translation>
+<translation id="4913161338056004800">איפוס הנתונים הסטטיסטיים</translation>
+<translation id="1856325424225101786">לאפס את מצב הטעינה המהירה?</translation>
+<translation id="3658159451045945436">האיפוס גורם למחיקת ההיסטוריה של החיסכון בנתונים, כולל רשימת האתרים שביקרת בהם.</translation>
+<translation id="3295530008794733555">יותר מהירות. פחות נתונים.</translation>
+<translation id="7340390500800578919">‏במצב טעינה מהירה, Brave טוען דפים מהר יותר ומפחית את השימוש בנתונים בשיעור של עד 60 אחוזים. כדי לבצע אופטימיזציה לדפים שהמשתמש נכנס אליהם, Brave שולח אל Brave Software את התנועה שלו באינטרנט. <ph name="BEGIN_LINK"/>מידע נוסף<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">הפעלת מצב טעינה מהירה</translation>
+<translation id="4493497663118223949">מצב הטעינה המהירה מופעל</translation>
+<translation id="7559975015014302720">מצב הטעינה המהירה מושבת</translation>
+<translation id="7606077192958116810">מצב הטעינה המהירה מופעל. אפשר לנהל אותו דרך ההגדרות.</translation>
+<translation id="4714588616299687897">חסוך עד 60% בשימוש בנתונים</translation>
+<translation id="1006927014032731288">‏כשנכנסים לדפים בזמן הגלישה, הם עוברים אופטימיזציה על ידי השרתים של Brave Software.</translation>
+<translation id="3257320067425202300">‏Brave חסך לך ‎<ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">‏Brave חסך לך ‎<ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">מיקום ההורדה</translation>
+<translation id="7077143737582773186">‏כרטיס SD</translation>
+<translation id="7762668264895820836">‏כרטיס SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">לשאול איפה לשמור קבצים</translation>
+<translation id="6192333916571137726">קובץ הורדה</translation>
+<translation id="1672586136351118594">אין להציג שוב</translation>
+<translation id="2650751991977523696">האם להוריד את הקובץ שוב?</translation>
+<translation id="8664979001105139458">שם הקובץ כבר קיים</translation>
+<translation id="488187801263602086">שינוי שם של קובץ</translation>
+<translation id="5686790454216892815">שם הקובץ ארוך מדי</translation>
+<translation id="7454641608352164238">אין מספיק מקום</translation>
+<translation id="8972098258593396643">האם להוריד לתיקיית ברירת המחדל?</translation>
+<translation id="804335162455518893">‏לא נמצא כרטיס SD</translation>
+<translation id="7475688122056506577">‏לא נמצא כרטיס SD. ייתכן שחלק מהקבצים שלך חסרים.</translation>
+<translation id="4198423547019359126">אין מיקומים זמינים להורדה</translation>
+<translation id="8224471946457685718">‏הורדת מאמרים עבורך ב-Wi-Fi</translation>
+<translation id="4970824347203572753">האפשרות לא זמינה במיקום שלך</translation>
+<translation id="5500777121964041360">ייתכן שהאפשרות לא זמינה במיקום שלך</translation>
+<translation id="1173894706177603556">שנה שם</translation>
+<translation id="1986685561493779662">השם כבר קיים</translation>
+<translation id="6441734959916820584">השם ארוך מדי</translation>
+<translation id="2923908459366352541">השם לא חוקי</translation>
+<translation id="7290209999329137901">לא ניתן היה לשנת את השם מפני שהפריט לא זמין</translation>
+<translation id="3334729583274622784">לשנות את סיומת הקובץ?</translation>
+<translation id="107147699690128016">שינוי של סיומת הקובץ עשוי לגרום לכך שהקובץ ייפתח באפליקציה אחרת. מצב זה עלול לסכן את המכשיר.</translation>
+<translation id="8541922081612557424">‏מידע כללי על Brave</translation>
+<translation id="5311273890481188673">‏Copyright <ph name="YEAR"/> Brave Software LLC.‎ כל הזכויות שמורות.</translation>
+<translation id="1416550906796893042">גרסת אפליקציה</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (עודכן <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">מערכת הפעלה</translation>
+<translation id="3968054912784331254">‏עדכוני Brave לא נתמכים יותר בגרסה הזו של Android</translation>
+<translation id="7665369617277396874">חשבון חדש</translation>
+<translation id="649070405679044769">‏מחובר ל-Brave Software בשם</translation>
+<translation id="6234515504547364178">‏יציאה מ-Brave</translation>
+<translation id="5324858694974489420">הגדרות הורים</translation>
+<translation id="8920114477895755567">ממתין לפרטי ההורים.</translation>
+<translation id="5512137114520586844">החשבון הזה מנוהל על ידי <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">החשבון הזה מנוהל על ידי <ph name="PARENT_NAME_1"/> ו-<ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">תוכן</translation>
+<translation id="5403644198645076998">גישה רק לאתרים ספציפיים</translation>
+<translation id="8641930654639604085">נסה לחסום אתרים שמכילים תוכן למבוגרים</translation>
+<translation id="5639724618331995626">התר גישה לכל האתרים</translation>
+<translation id="796823723482603597">‏מבוסס על Brave</translation>
+<translation id="6324034347079777476">‏סנכרון מערכת Android מושבת</translation>
+<translation id="5127805178023152808">סנכרון כבוי</translation>
+<translation id="7015203776128479407">הגדרת הסנכרון הראשונית לא הושלמה. הסנכרון מושבת.</translation>
+<translation id="2497852260688568942">מנהל המערכת שלך השבית את הסנכרון</translation>
+<translation id="9100610230175265781">יש להזין ביטוי סיסמה</translation>
+<translation id="6108923351542677676">ההגדרה מתבצעת…</translation>
+<translation id="4062305924942672200">מידע משפטי</translation>
+<translation id="4256782883801055595">רישיונות קוד פתוח</translation>
+<translation id="1138681184697033370">‏התנאים וההגבלות של Brave</translation>
+<translation id="7392539049993970338">‏הודעת הפרטיות של Brave</translation>
+<translation id="2677748264148917807">יציאה</translation>
+<translation id="5556459405103347317">ניסיון טעינה נוסף</translation>
+<translation id="1623104350909869708">מנע מהדף זה ליצור תיבות דו-שיח נוספות</translation>
+<translation id="2968755619301702150">מציג האישורים</translation>
+<translation id="1360432990279830238">לצאת ולהשבית את הסנכרון?</translation>
+<translation id="8581481290581777242">‏למחוק את נתוני Brave שלך מהמכשיר הזה?</translation>
+<translation id="1318865768845061710">‏הסימניות, ההיסטוריה, הסיסמאות ונתונים אחרים ב-Brave כבר לא יסונכרנו עם חשבון Brave Software</translation>
+<translation id="3325020657155065477">‏יש לנקות גם את נתוני Brave מהמכשיר הזה</translation>
+<translation id="6136448902816743006">‏מכיוון שבחרת לצאת מחשבון שמנוהל על ידי <ph name="DOMAIN_NAME"/>, נתוני Brave שלך יימחקו מהמכשיר הזה. הם יישמרו בחשבון Brave Software שלך.</translation>
+<translation id="1853026300647876496">‏המערכת יוצרת קשר עם Brave Software. עוד מעט מסיימים…</translation>
+<translation id="2328985652426384049">אי אפשר להיכנס לחשבון</translation>
+<translation id="7723158744459952869">‏ל-Brave Software נדרש זמן רב מדי להגיב</translation>
+<translation id="4572422548854449519">כניסה אל חשבון מנוהל</translation>
+<translation id="2689656545739939160">‏אתה נכנס עם חשבון המנוהל על-ידי <ph name="MANAGED_DOMAIN"/> ומעניק למנהל שלו שליטה על הנתונים שלך ב-Brave. הנתונים שלך ישויכו לצמיתות אל החשבון הזה. יציאה מ-Brave תמחק את הנתונים שלך מהמכשיר הזה, אבל הם יישארו בחשבון Brave Software.</translation>
+<translation id="1749561566933687563">סנכרון הסימניות שלך</translation>
+<translation id="4242533952199664413">פתח את 'הגדרות'</translation>
+<translation id="1111673857033749125">סימניות שנשמרו במכשירים האחרים שלך יופיעו כאן.</translation>
+<translation id="8636825310635137004">כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, הפעל את הסנכרון.</translation>
+<translation id="3269956123044984603">‏כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, הפעל את האפשרות 'סנכרון אוטומטי של נתונים' בהגדרות של חשבון Android.</translation>
+<translation id="5157964048453367290">‏כרטיסיות שפתחת ב-Brave במכשירים האחרים שלך יופיעו כאן.</translation>
+<translation id="4684427112815847243">סנכרון הכל</translation>
+<translation id="2709516037105925701">מילוי אוטומטי</translation>
+<translation id="8820817407110198400">סימניות</translation>
+<translation id="1644574205037202324">היסטוריה</translation>
+<translation id="17513872634828108">כרטיסיות פתוחות</translation>
+<translation id="1320169905922104972">‏כרטיסי אשראי וכתובות דרך Brave Software Pay</translation>
+<translation id="6337234675334993532">הצפנה</translation>
+<translation id="6698801883190606802">ניהול נתונים מסונכרנים</translation>
+<translation id="3598578758776312506">‏הצפנת סיסמאות באמצעות פרטי הכניסה שלך ל-Brave Software</translation>
+<translation id="7810580217418711046">‏הצפנת נתונים מסונכרנים באמצעות סיסמת Brave Software החל מ-<ph name="TIME"/></translation>
+<translation id="8461694314515752532">הצפנת נתונים מסונכרנים בעזרת ביטוי סיסמה אישי לסנכרון</translation>
+<translation id="2996291259634659425">יצירת ביטוי סיסמה</translation>
+<translation id="5713644099811900409">‏חשבון Brave Software</translation>
+<translation id="8997474919031554666">‏הצפנה באמצעות ביטוי סיסמה לא כוללת אמצעי תשלום וכתובות מ-Brave Software Pay. רק מי שיודע את ביטוי הסיסמה שלך יכול לקרוא את הנתונים המוצפנים. ביטוי הסיסמה לא נשלח אל Brave Software והיא אינה מאחסנת אותו. אם שוכחים את ביטוי הסיסמה או רוצים לשנות את ההגדרה הזו, צריך לאפס את הסנכרון. <ph name="BEGIN_LINK"/>מידע נוסף<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">משפט-סיסמה</translation>
+<translation id="7772032839648071052">אשר משפט-סיסמה</translation>
+<translation id="5304593522240415983">שדה זה לא יכול להיות ריק</translation>
+<translation id="321773570071367578">אם שכחת את ביטוי הסיסמה או אם ברצונך לשנות את ההגדרה הזו, <ph name="BEGIN_LINK"/>אפס את הסינכרון<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">ביטויי הסיסמה אינם תואמים</translation>
+<translation id="5149495116300586333">‏הצפנה באמצעות ביטוי סיסמה לא כוללת אמצעי תשלום וכתובות מ-Brave Software Pay
+
+כדי לשנות את ההגדרה הזו צריך <ph name="BEGIN_LINK"/>לאפס את הסנכרון<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">ביטוי סיסמה שגוי</translation>
+<translation id="5414836363063783498">מאמת…</translation>
+<translation id="6846298663435243399">טוען…</translation>
+<translation id="5517095782334947753">יש לך סימניות, היסטוריה, סיסמאות והגדרות נוספות מ-<ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">שילוב הנתונים שלי</translation>
+<translation id="688738109438487280">הוסף נתונים קיימים אל <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">שמור בנפרד את הנתונים שלי</translation>
+<translation id="1145536944570833626">מחק נתונים קיימים.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> רוצה לבצע התאמה עם</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>קבל עזרה<ph name="END_LINK"/> בזמן חיפוש התקנים…</translation>
+<translation id="5817918615728894473">התאם</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>קבל עזרה<ph name="END_LINK1"/> או <ph name="BEGIN_LINK2"/>חפש שוב<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">לא נמצאו מכשירים תואמים</translation>
+<translation id="3773755127849930740">‏<ph name="BEGIN_LINK"/>הפעל את Bluetooth<ph name="END_LINK"/> כדי לאפשר התאמה</translation>
+<translation id="998321811308652668">‏לא ניתן להפעיל ב-Brave את מתאם Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>קבל עזרה<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">‏כדי לבצע סריקה לאיתור מכשירים ב-Brave, יש צורך בגישה לנתוני מיקום. <ph name="BEGIN_LINK"/>עדכן הרשאות<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">‏כדי לבצע סריקה לאיתור מכשירים, Brave זקוק לגישה לנתוני מיקום. הגישה למיקום <ph name="BEGIN_LINK"/>כבויה במכשיר הזה<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">‏כדי לבצע סריקה לאיתור מכשירים, Brave זקוק לגישה לנתוני מיקום. <ph name="BEGIN_LINK1"/>עדכן את ההרשאות<ph name="END_LINK1"/>. כמו כן, הגישה למיקום <ph name="BEGIN_LINK2"/>כבויה במכשיר הזה<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">מכשיר מחובר</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{רמת עוצמת אות: עמודה אחת}two{רמת עוצמת אות: שתי עמודות}many{רמת עוצמת אות: # עמודות}other{רמת עוצמת אות: # עמודות}}</translation>
+<translation id="5230560987958996918">‏<ph name="SITE"/> מבקש לבצע סריקה כדי לאתר מכשירי Bluetooth בקרבת מקום. המכשירים הבאים נמצאו:</translation>
+<translation id="8368027906805972958">מכשיר לא ידוע או שאינו נתמך (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">הסנכרון לא עובד</translation>
+<translation id="1810845389119482123">ההגדרה הראשונית של הסנכרון לא הושלמה</translation>
+<translation id="3235722914093408050">‏פתח את הגדרות Android והפעל מחדש את הסנכרון של מערכת Android כדי להתחיל בסנכרון של Brave</translation>
+<translation id="3367813778245106622">היכנס שוב כדי להתחיל בסנכרון</translation>
+<translation id="974555521953189084">הזן את ביטוי הסיסמה כדי להתחיל בסנכרון</translation>
+<translation id="2997266899014181325">‏כדי להתחיל לסנכרן צריך להפעיל את האפשרות "סנכרון הנתונים מ-Brave".</translation>
+<translation id="8260126382462817229">נסה להיכנס שוב</translation>
+<translation id="5919204609460789179">יש לעדכן את <ph name="PRODUCT_NAME"/> כדי להתחיל סנכרון</translation>
+<translation id="397583555483684758">הסנכרון הפסיק לפעול</translation>
+<translation id="1966710179511230534">יש לעדכן את פרטי הכניסה שלך.</translation>
+<translation id="7063006564040364415">לא ניתן היה להתחבר אל שרת הסנכרון.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> אינו מעודכן.</translation>
+<translation id="4170011742729630528">השירות אינו זמין. נסה שוב מאוחר יותר.</translation>
+<translation id="7947953824732555851">קבל והיכנס</translation>
+<translation id="8583805026567836021">מנקה נתוני חשבון</translation>
+<translation id="8310344678080805313">כרטיסיות רגילות</translation>
+<translation id="5748802427693696783">הוחלף לכרטיסיות רגילות</translation>
+<translation id="7998918019931843664">פתח מחדש כרטיסייה שנסגרה</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, כרטיסייה</translation>
+<translation id="4452411734226507615">סגירת הכרטיסייה <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">אפשרויות הזמינות באזור החלק התחתון של המסך</translation>
+<translation id="4060598801229743805">האפשרויות זמינות בחלק העליון של המסך</translation>
+<translation id="2810645512293415242">דף פשוט יותר שחוסך בנתונים ונטען מהר יותר.</translation>
+<translation id="3985215325736559418">האם להוריד שוב את <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">להתחיל שוב את ההורדה של <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">הורדה</translation>
+<translation id="545042621069398927">הדפדפן מאיץ את ההורדה.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{מתבצעת הורדה של הקובץ.}two{מתבצעת הורדה של # קבצים.}many{מתבצעת הורדה של # קבצים.}other{מתבצעת הורדה של # קבצים.}}</translation>
+<translation id="543509235395288790">מתבצעת הורדה של <ph name="COUNT"/> קבצים (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">מתבצעת הורדה של קובץ (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{הורדה אחת הושלמה.}two{# הורדות הושלמו.}many{# הורדות הושלמו.}other{# הורדות הושלמו.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{הורדה אחת נכשלה.}two{# הורדות נכשלו.}many{# הורדות נכשלו.}other{# הורדות נכשלו.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{הורדה אחת בהמתנה.}two{# הורדות בהמתנה.}many{# הורדות בהמתנה.}other{# הורדות בהמתנה.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> לחצן <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">כמעט סיימת!</translation>
+<translation id="3960299545138990065">‏הפעלה מחדש של Brave</translation>
+<translation id="3771001275138982843">לא ניתן היה להוריד את העדכון</translation>
+<translation id="3888648114124182147">‏מוריד עדכון של Brave…</translation>
+<translation id="1705567146636171298">‏כדאי לעדכן את Brave</translation>
+<translation id="6195417478702700398">‏כדי ליהנות מחוויית הגלישה הטובה ביותר, יש לפתוח את Brave כדי לעדכן אותו</translation>
+<translation id="3512968675351418494">‏כדי לראות באינטרנט תוכן בשפה שלך, יש להוריד את הגרסה האחרונה של Brave</translation>
+<translation id="6427112570124116297">תרגום התוכן באינטרנט</translation>
+<translation id="1379423114029199501">‏עדכון לגרסה האחרונה של Brave יאפשר לך לקרוא בשפה שלך</translation>
+<translation id="5684874026226664614">אופס. לא ניתן היה לתרגם את הדף הזה.</translation>
+<translation id="6831043979455480757">תרגום</translation>
+<translation id="1285320974508926690">איני רוצה לקבל תרגום של אתר זה</translation>
+<translation id="773466115871691567">ברצוני לקבל תרגום תמיד דפים ב<ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">אף פעם אל תתרגם דפים ב<ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">שפות נוספות</translation>
+<translation id="290376772003165898">הדף לא ב<ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">דפים ב<ph name="SOURCE_LANGUAGE"/> יתורגמו ל<ph name="TARGET_LANGUAGE"/> מעכשיו והלאה</translation>
+<translation id="8339163506404995330">דפים ב<ph name="LANGUAGE"/> לא יתורגמו</translation>
+<translation id="5447765697759493033">האתר הזה לא יתורגם</translation>
+<translation id="4880127995492972015">תרגום…</translation>
+<translation id="641643625718530986">הדפסה…</translation>
+<translation id="8909135823018751308">שיתוף…</translation>
+<translation id="4996978546172906250">שיתוף באמצעות</translation>
+<translation id="6333140779060797560">שיתוף באמצעות <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">אירעה בעיה בעת הדפסת הדף. נסה שוב.</translation>
+<translation id="3254409185687681395">הוסף את הדף לסימניות</translation>
+<translation id="497421865427891073">המשך קדימה</translation>
+<translation id="813082847718468539">הצג נתוני אתר</translation>
+<translation id="2532336938189706096">תצוגת אינטרנט</translation>
+<translation id="6005538289190791541">הצעה לסיסמה</translation>
+<translation id="4634124774493850572">שימוש בסיסמה</translation>
+<translation id="8285489906452138776">‏Brave זקוק להרשאה גישה אל המצלמה בשביל האתר הזה.</translation>
+<translation id="320189792589364011">‏Brave זקוק להרשאת גישה אל המיקרופון בשביל האתר הזה.</translation>
+<translation id="7988136689212463100">‏Brave זקוק להרשאת גישה אל המצלמה והמיקרופון בשביל האתר הזה.</translation>
+<translation id="4931190655840828017">‏Brave זקוק לגישה אל המיקום שלך כדי לשתף אותו עם האתר הזה.</translation>
+<translation id="3088191967551450609">‏לצורך הורדת קבצים, Brave זקוק לגישה לאחסון.</translation>
+<translation id="8942627711005830162">פתיחה בחלון האחר</translation>
+<translation id="4195643157523330669">פתיחה בכרטיסייה חדשה</translation>
+<translation id="1100066534610197918">פתיחה בכרטיסייה חדשה בקבוצה</translation>
+<translation id="4860895144060829044">תרימו טלפון</translation>
+<translation id="6896758677409633944">העתק</translation>
+<translation id="8393700583063109961">שלח הודעה</translation>
+<translation id="3557336313807607643">הוסף לאנשי הקשר</translation>
+<translation id="4269820728363426813">העתקת כתובת של קישור</translation>
+<translation id="1206892813135768548">העתקת טקסט קישור</translation>
+<translation id="1204037785786432551">הורדת קישור</translation>
+<translation id="6864459304226931083">הורד תמונה</translation>
+<translation id="8209050860603202033">פתח את התמונה</translation>
+<translation id="8073388330009372546">פתיחת התמונה בכרטיסייה חדשה</translation>
+<translation id="6649642165559792194">הצגת התמונה בתצוגה מקדימה <ph name="BEGIN_NEW"/>חדש<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">טען תמונה</translation>
+<translation id="3845332215609790146">‏חיפוש בעזרת Brave Software Lens <ph name="BEGIN_NEW"/>חדש<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">חפש את התמונה הזו ב-<ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">שיתוף תמונה</translation>
+<translation id="5833984609253377421">שיתוף קישור</translation>
+<translation id="6475951671322991020">הורד סרטון</translation>
+<translation id="2317945146070194624">‏פתיחה בכרטיסייה חדשה של Brave</translation>
+<translation id="7975379999046275268">הצגת הדף בתצוגה מקדימה<ph name="BEGIN_NEW"/>חדש<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">מרענן את הדף</translation>
+<translation id="36525718899759834">‏קבל את האפליקציה מחנות Brave Software Play‏: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">כהה</translation>
+<translation id="1807246157184219062">בהיר</translation>
+<translation id="4056223980640387499">חום-ספיה</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">רוחב אחיד</translation>
+<translation id="9206873250291191720">א</translation>
+<translation id="654446541061731451">בחר כרטיסייה להעברת התוכן שלה</translation>
+<translation id="8719023831149562936">לא ניתן להעביר תוכן מהכרטיסייה הנוכחית</translation>
+<translation id="2139186145475833000">הוספה לדף הבית</translation>
+<translation id="4616150815774728855">פתיחה של <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">לא ניתן היה לפתוח את היישום</translation>
+<translation id="5129038482087801250">התקן אפליקציית אינטרנט</translation>
+<translation id="3789841737615482174">התקן</translation>
+<translation id="4665282149850138822">האתר <ph name="NAME"/> נוסף למסך דף הבית שלך</translation>
+<translation id="7333031090786104871">עדיין מוסיף את האתר הקודם</translation>
+<translation id="1036727731225946849">מוסיף את <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">נוסף למסך דף הבית</translation>
+<translation id="2146738493024040262">פתח אפליקציית אינסטנט</translation>
+<translation id="7016516562562142042">מופעל למנוע החיפוש הנוכחי</translation>
+<translation id="6177111841848151710">חסוּם למנוע החיפוש הנוכחי</translation>
+<translation id="145097072038377568">‏כבוי בהגדרות Android</translation>
+<translation id="8007176423574883786">כבוי בשביל המכשיר הזה</translation>
+<translation id="164269334534774161">אתה מציג עותק לא מקוון של הדף הזה מ-<ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">הדף הלא מקוון הזה נוצר ב-<ph name="CREATION_TIME"/> ויכול להיות שהגירסה המקוונת שלו שונה.</translation>
+<translation id="8840953339110955557">ייתכן שהדף הזה שונה מהגירסה המקוונת.</translation>
+<translation id="6405300764336705484">‏התוכן הזה הוא מ-<ph name="DOMAIN_NAME"/>, ומוגש על-ידי Brave Software.</translation>
+<translation id="1006017844123154345">פתח גרסה מקוונת</translation>
+<translation id="3326636747541519688">‏גרסת Lite של הדף נוצרה על ידי Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>טעינת הדף המקורי<ph name="END_LINK"/> מ-<ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">אם נתקלת בזה לעתים קרובות, כדאי לנסות את <ph name="BEGIN_LINK"/>ההצעות<ph name="END_LINK"/> האלה.</translation>
+<translation id="8748850008226585750">התוכן מוסתר</translation>
+<translation id="3810973564298564668">נהל</translation>
+<translation id="5199929503336119739">פרופיל עבודה</translation>
+<translation id="528192093759286357">כדי לצאת ממסך מלא, גרור מלמעלה וגע בלחצן 'הקודם'.</translation>
+<translation id="2836148919159985482">כדי לצאת ממסך מלא, גע בלחצן 'הקודם'.</translation>
+<translation id="3967822245660637423">ההורדה הושלמה</translation>
+<translation id="2434158240863470628">ההורדה הושלמה <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">ההורדה נכשלה</translation>
+<translation id="1384959399684842514">ההורדה הושהתה</translation>
+<translation id="1671236975893690980">ההורדה תיכף תתחיל…</translation>
+<translation id="5561549206367097665">ממתין לרשת…</translation>
+<translation id="5864419784173784555">ממתין להורדה נוספת…</translation>
+<translation id="6461962085415701688">לא ניתן לפתוח את הקובץ</translation>
+<translation id="1178581264944972037">השהה</translation>
+<translation id="8200772114523450471">חדש</translation>
+<translation id="1409879593029778104">הורדת <ph name="FILE_NAME"/> נמנעה מכיוון שהקובץ כבר קיים.</translation>
+<translation id="3387650086002190359">הורדת <ph name="FILE_NAME"/> נכשלה עקב שגיאות במערכת הקבצים.</translation>
+<translation id="6482749332252372425">הורדת <ph name="FILE_NAME"/> נכשלה מאחר שחסר מקום אחסון.</translation>
+<translation id="7619072057915878432">הורדת <ph name="FILE_NAME"/> נכשלה עקב כשלים ברשת.</translation>
+<translation id="1477626028522505441">הורדת <ph name="FILE_NAME"/> נכשלה עקב בעיות בשרת.</translation>
+<translation id="3692944402865947621">ההורדה של <ph name="FILE_NAME"/> נכשלה כי מיקום האחסון לא נגיש.</translation>
+<translation id="604996488070107836">הורדת <ph name="FILE_NAME"/> נכשלה עקב שגיאה לא ידועה.</translation>
+<translation id="6738867403308150051">מוריד...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">‏בוצעה הורדה של KB <ph name="KBS"/></translation>
+<translation id="6416782512398055893">‏בוצעה הורדה של MB <ph name="MBS"/></translation>
+<translation id="6538442820324228105">‏בוצעה הורדה של GB <ph name="GBS"/></translation>
+<translation id="9204836675896933765">נותר קובץ אחד</translation>
+<translation id="8186512483418048923">נותרו עוד <ph name="FILES"/> קבצים</translation>
+<translation id="757855969265046257">{FILES,plural, =1{הורדת קובץ אחד (<ph name="FILES_DOWNLOADED_ONE"/>)}two{הורדת <ph name="FILES_DOWNLOADED_MANY"/> קבצים}many{הורדת <ph name="FILES_DOWNLOADED_MANY"/> קבצים}other{הורדת <ph name="FILES_DOWNLOADED_MANY"/> קבצים}}</translation>
+<translation id="8037750541064988519">נותרו <ph name="DAYS"/> ימים</translation>
+<translation id="8190358571722158785">נותר יום אחד</translation>
+<translation id="60923314841986378">נותרו <ph name="HOURS"/> שעות</translation>
+<translation id="510275257476243843">נותרה שעה אחת</translation>
+<translation id="970715775301869095">נותרו <ph name="MINUTES"/> דקות</translation>
+<translation id="3236059992281584593">נותרה דקה אחת</translation>
+<translation id="2777555524387840389">נותרו <ph name="SECONDS"/> שניות</translation>
+<translation id="2781151931089541271">נותרה שניה אחת</translation>
+<translation id="3303414029551471755">האם להוריד את התוכן?</translation>
+<translation id="8617240290563765734">האם לעבור אל כתובת האתר שצוינה כהצעה בתוכן שהורדת?</translation>
+<translation id="1373696734384179344">אין מספיק זיכרון להורדת התוכן הנבחר.</translation>
+<translation id="5271967389191913893">המכשיר לא מצליח לפתוח את התוכן להורדה.</translation>
+<translation id="883806473910249246">אירעה שגיאה בזמן הורדת התוכן.</translation>
+<translation id="5626134646977739690">שם:</translation>
+<translation id="7963646190083259054">ספק:</translation>
+<translation id="3414952576877147120">גודל:</translation>
+<translation id="7375125077091615385">סוג:</translation>
+<translation id="5765780083710877561">תיאור:</translation>
+<translation id="4881695831933465202">פתיחה</translation>
+<translation id="3542235761944717775">‏‎<ph name="KILOBYTES"/> KB זמינים</translation>
+<translation id="8051695050440594747">‏‎<ph name="MEGABYTES"/> MB זמינים</translation>
+<translation id="5424588387303617268">‏‎<ph name="GIGABYTES"/> GB זמינים</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> מתוך <ph name="SPACE_AVAILABLE"/> נמצאים בשימוש</translation>
+<translation id="3587482841069643663">הכל</translation>
+<translation id="4988526792673242964">דפים</translation>
+<translation id="3810838688059735925">וידאו</translation>
+<translation id="3616113530831147358">אודיו</translation>
+<translation id="9219103736887031265">תמונות</translation>
+<translation id="8250920743982581267">מסמכים</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{קובץ אחד (#)}two{# קבצים}many{# קבצים}other{# קבצים}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{תמונה אחת (#)}two{# תמונות}many{# תמונות}other{# תמונות}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{סרטון אחד (#)}two{# סרטונים}many{# סרטונים}other{# סרטונים}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{קובץ אודיו אחד (#)}two{# קובצי אודיו}many{# קובצי אודיו}other{# קובצי אודיו}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{דף אחד (#)}two{# דפים}many{# דפים}other{# דפים}}</translation>
+<translation id="5456381639095306749">הורד דף זה</translation>
+<translation id="2394602618534698961">קבצים שהורדת מופיעים כאן</translation>
+<translation id="7810647596859435254">פתח באמצעות...</translation>
+<translation id="5655963694829536461">חיפוש ההורדות שלך</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">הקבצים שלי</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">כאן יוצגו מאמרים, ואפשר לקרוא אותם גם במצב לא מקוון</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{שעה אחת}two{שעתיים}many{# שעות}other{# שעות}}</translation>
+<translation id="5853623416121554550">מושהה</translation>
+<translation id="8965591936373831584">בהמתנה</translation>
+<translation id="2779651927720337254">נכשל</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">ממש עכשיו</translation>
+<translation id="4000212216660919741">דף הבית במצב לא מקוון</translation>
+<translation id="9133397713400217035">הצעות לתוכן במצב לא מקוון</translation>
+<translation id="968900484120156207">הדפים שבהם ביקרת מופיעים כאן</translation>
+<translation id="7882131421121961860">לא נמצאה היסטוריה</translation>
+<translation id="3549657413697417275">חיפוש בהיסטוריה שלך</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">‏חוויית ההפעלה הראשונה של Brave</translation>
+<translation id="2700285883409956633">‏השימוש באפליקציה זו מהוות את הסכמתך ל<ph name="BEGIN_LINK1"/>תנאים ולהגבלות<ph name="END_LINK1"/> ול<ph name="BEGIN_LINK2"/>הודעת הפרטיות<ph name="END_LINK2"/> של Brave.</translation>
+<translation id="1640714894372474981">‏השימוש שלך באפליקציה הזו מבטא את הסכמתך ל<ph name="BEGIN_LINK1"/>תנאים ולהגבלות<ph name="END_LINK1"/> ול<ph name="BEGIN_LINK2"/>מדיניות הפרטיות<ph name="END_LINK2"/> של Brave, וכן ל<ph name="BEGIN_LINK3"/>הודעת הפרטיות לחשבונות Brave Software שמנוהלים ב-Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">‏האפליקציה <ph name="APP_NAME"/> תיפתח ב-Brave. המשך השימוש מבטא את הסכמתך ל<ph name="BEGIN_LINK1"/>תנאים ולהגבלות<ph name="END_LINK1"/> ול<ph name="BEGIN_LINK2"/>הודעת הפרטיות<ph name="END_LINK2"/> של Brave.</translation>
+<translation id="5071615083211946659">‏האפליקציה <ph name="APP_NAME"/> תיפתח ב-Brave. המשך השימוש מבטא את הסכמתך ל<ph name="BEGIN_LINK1"/>תנאים ולהגבלות<ph name="END_LINK1"/> ול<ph name="BEGIN_LINK2"/>הודעת הפרטיות<ph name="END_LINK2"/> של Brave, וכן ל<ph name="BEGIN_LINK3"/>הודעת הפרטיות לחשבונות Brave Software שמנוהלים ב-Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">‏אם שולחים אלינו נתוני שימוש ודוחות קריסה, עוזרים לשפר את Brave.</translation>
+<translation id="3518985090088779359">בסדר, מקובל עליי</translation>
+<translation id="7207456302801184289">‏ברוכים הבאים ל-Brave</translation>
+<translation id="704822250101715322">‏המערכת ממתינה שיסתיים העדכון של שירותי Brave Software Play</translation>
+<translation id="1231733316453485619">להפעיל סנכרון?</translation>
+<translation id="5132942445612118989">סנכרון הסיסמאות, ההיסטוריה ונתונים נוספים בכל המכשירים</translation>
+<translation id="5736731321935944068">‏Brave Software עשויה להשתמש בהיסטוריית הגלישה שלך לצורך התאמה אישית של החיפוש, מודעות ושירותי Brave Software אחרים</translation>
+<translation id="4013614219085422040">‏Brave Software עשויה להשתמש בהיסטוריית הגלישה שלך לצורך התאמה אישית של החיפוש ושירותי Brave Software אחרים</translation>
+<translation id="5581519193887989363">אפשר לבחור מה לסנכרן בכל שלב דרך <ph name="BEGIN_LINK1"/>ההגדרות<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">כן, אני רוצה</translation>
+<translation id="2410754283952462441">בחירת חשבון</translation>
+<translation id="2227444325776770048">המשך בשם <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">אינך <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">כדי שהסימניות יופיעו בכל המכשירים שלך, יש להפעיל את הסנכרון</translation>
+<translation id="2818669890320396765">כדי לקבל גישה אל הסימניות שלך בכל המכשירים, יש להיכנס לחשבון ולהפעיל את הסנכרון</translation>
+<translation id="6003646045106347985">‏כדי לקבל מ-Brave Software הצעות לתוכן מותאם אישית, יש להפעיל את הסנכרון</translation>
+<translation id="8494430740943879273">‏כדי לקבל מ-Brave Software הצעות לתוכן מותאם אישית, יש להיכנס ולהפעיל את הסנכרון</translation>
+<translation id="5862731021271217234">כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, יש להפעיל את הסנכרון</translation>
+<translation id="3568688522516854065">כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, יש להיכנס לחשבון ולהפעיל את הסנכרון</translation>
+<translation id="1208340532756947324">כדי לסנכרן ולהתאים אישית את החוויה במכשירים שונים, יש להפעיל את הסנכרון</translation>
+<translation id="4472118726404937099">כדי לסנכרן ולהתאים אישית את החוויה במכשירים שונים, יש להיכנס לחשבון ולהפעיל את הסנכרון</translation>
+<translation id="2426805022920575512">בחירת חשבון אחר</translation>
+<translation id="6790428901817661496">הפעל</translation>
+<translation id="1272079795634619415">הפסק</translation>
+<translation id="2874939134665556319">הרצועה הקודמת</translation>
+<translation id="4046123991198612571">הרצועה הבאה</translation>
+<translation id="3859306556332390985">הרץ קדימה</translation>
+<translation id="8441146129660941386">הרץ לאחור</translation>
+<translation id="6706288973712894588">‏אין לך כרגע חיבור לאינטרנט.\n<ph name="BEGIN_LINK"/>לעיון בפיד במצב לא מקוון.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">כרטיסיות אחרונות</translation>
+<translation id="8497726226069778601">אין מה לראות כאן… בינתיים</translation>
+<translation id="5423934151118863508">הדפים שבהם אתה מבקר בתדירות הגבוהה ביותר יופיעו כאן</translation>
+<translation id="6127379762771434464">הפריט הוסר</translation>
+<translation id="4605958867780575332">פריטים שהוסרו: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">‏דודל של Brave Software‏: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">מכשירים אחרים</translation>
+<translation id="4738836084190194332">סונכרן לאחרונה: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{לפני דקה}two{לפני # דקות}many{לפני # דקות}other{לפני # דקות}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{לפני שעה}two{לפני שעתיים}many{לפני # שעות}other{לפני # שעות}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{לפני יום}two{לפני יומיים}many{לפני # ימים}other{לפני # ימים}}</translation>
+<translation id="2762000892062317888">ברגע זה</translation>
+<translation id="1407135791313364759">פתח הכל</translation>
+<translation id="1209206284964581585">הסתר בינתיים</translation>
+<translation id="129553762522093515">נסגרו לאחרונה</translation>
+<translation id="8413126021676339697">להצגת ההיסטוריה המלאה</translation>
+<translation id="7876243839304621966">הסר הכל</translation>
+<translation id="8487700953926739672">זמין במצב לא מקוון</translation>
+<translation id="5224771365102442243">כולל סרטון</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>מידע נוסף<ph name="END_LINK"/> על הצעות לתוכן</translation>
+<translation id="7542481630195938534">לא ניתן לקבל הצעות</translation>
+<translation id="5013696553129441713">אין הצעות חדשות</translation>
+<translation id="1736419249208073774">מידע נוסף</translation>
+<translation id="7444811645081526538">קטגוריות נוספות</translation>
+<translation id="6709133671862442373">חדשות</translation>
+<translation id="1264974993859112054">ספורט</translation>
+<translation id="9139318394846604261">קניות</translation>
+<translation id="3912508018559818924">כל הטוב שבאינטרנט…</translation>
+<translation id="526421993248218238">לא ניתן לטעון את הדף</translation>
+<translation id="614940544461990577">כדאי לנסות:</translation>
+<translation id="3288003805934695103">לטעון מחדש את הדף</translation>
+<translation id="2353636109065292463">בדיקת חיבור האינטרנט</translation>
+<translation id="2858138569776157458">אתרים נבחרים</translation>
+<translation id="8364299278605033898">הצגת אתרים פופולריים</translation>
+<translation id="1171770572613082465">הקשה על הלחצן "אתרים נבחרים" תציג אתרים פופולריים</translation>
+<translation id="5233638681132016545">כרטיסייה חדשה</translation>
+<translation id="4521874409998847950">‏מאת <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>מוגש על-ידי Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">יש גרסה חדשה יותר</translation>
+<translation id="4058091506841967397">‏אי אפשר לעדכן את Brave</translation>
+<translation id="6316139424528454185">‏אין תמיכה בגרסת Android</translation>
+<translation id="6989267951144302301">ההורדה נכשלה</translation>
+<translation id="624789221780392884">העדכון מוכן</translation>
+<translation id="1549000191223877751">העבר לחלון האחר</translation>
+<translation id="7481312909269577407">קדימה</translation>
+<translation id="4084682180776658562">סימניה</translation>
+<translation id="6437478888915024427">פרטי דף</translation>
+<translation id="7180611975245234373">רענון</translation>
+<translation id="4913169188695071480">הפסק לרענן</translation>
+<translation id="1829244130665387512">חיפוש בדף</translation>
+<translation id="6593061639179217415">לגרסה במחשב</translation>
+<translation id="9063523880881406963">כבה את 'בקש אתר עבור מחשב שולחני'</translation>
+<translation id="2038563949887743358">הפעל את 'בקש אתר עבור מחשב שולחני'</translation>
+<translation id="2433507940547922241">מראה</translation>
+<translation id="983192555821071799">סגור את כל הכרטיסיות</translation>
+<translation id="1310482092992808703">קיבוץ כרטיסיות</translation>
+<translation id="7725024127233776428">הדפים שהוספת לסימניות מופיעים כאן</translation>
+<translation id="4404568932422911380">ללא סימניות</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{סימניה אחת (<ph name="BOOKMARKS_COUNT_ONE"/>)}two{<ph name="BOOKMARKS_COUNT_MANY"/> סימניות}many{<ph name="BOOKMARKS_COUNT_MANY"/> סימניות}other{<ph name="BOOKMARKS_COUNT_MANY"/> סימניות}}</translation>
+<translation id="3739899004075612870">נוסף לסימניות ב-<ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">מסומן בסימניה</translation>
+<translation id="4452548195519783679">התווסף לסימניות ב-<ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">הוספת הסימנייה נכשלה.</translation>
+<translation id="2842985007712546952">תיקיית אב</translation>
+<translation id="9065203028668620118">עריכה</translation>
+<translation id="4405224443901389797">העברה אל…</translation>
+<translation id="5170568018924773124">הצג בתיקייה</translation>
+<translation id="8035133914807600019">תיקייה חדשה…</translation>
+<translation id="4532845899244822526">בחר תיקייה</translation>
+<translation id="6627583120233659107">ערוך תיקיה</translation>
+<translation id="1197267115302279827">העבר סימניות</translation>
+<translation id="6963766334940102469">מחק סימניות</translation>
+<translation id="4351244548802238354">סגור את תיבת הדו-שיח</translation>
+<translation id="451872707440238414">חיפוש בסימניות</translation>
+<translation id="8901170036886848654">לא נמצאו סימניות</translation>
+<translation id="6404511346730675251">ערוך סימניה</translation>
+<translation id="3894427358181296146">הוספת תיקייה</translation>
+<translation id="5327248766486351172">שם</translation>
+<translation id="7400418766976504921">כתובת אתר</translation>
+<translation id="3527085408025491307">תיקיה</translation>
+<translation id="5161254044473106830">יש להזין כותרת</translation>
+<translation id="2996809686854298943">דרושה כתובת אתר</translation>
+<translation id="2536728043171574184">מציג העתק לא מקוון של עמוד זה</translation>
+<translation id="4698034686595694889">הצגה לא מקוונת ב-<ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ועוד אתרים</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{‏Brave יטען את הדף כשיהיה מוכן}two{‏Brave יטען את הדפים כשיהיו מוכנים}many{‏Brave יטען את הדפים כשיהיו מוכנים}other{‏Brave יטען את הדפים כשיהיו מוכנים}}</translation>
+<translation id="6811034713472274749">הדף מוכן להצגה</translation>
+<translation id="4561979708150884304">אין חיבור</translation>
+<translation id="8274165955039650276">הצגת הורדות</translation>
+<translation id="2082238445998314030">תוצאה <ph name="RESULT_NUMBER"/> מתוך <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">אין תוצאות</translation>
+<translation id="981121421437150478">לא מקוון</translation>
+<translation id="3298243779924642547">‏מצב Lite</translation>
+<translation id="393697183122708255">חיפוש קולי מופעל לא זמין</translation>
+<translation id="7191430249889272776">הכרטיסייה נפתחה ברקע.</translation>
+<translation id="8445059357334030806">‏פתח ב-Brave</translation>
+<translation id="4720023427747327413">פתח ב-<ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">פתיחה בדפדפן</translation>
+<translation id="1113597929977215864">צפייה בתצוגה נקייה</translation>
+<translation id="1513352483775369820">סימניות והיסטוריית אתרים</translation>
+<translation id="4939482511480190003">‏נשמח לקבל עזרה בשיפור Brave. <ph name="BEGIN_LINK"/>למילוי הסקר<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">חזרה</translation>
+<translation id="5596627076506792578">אפשרויות נוספות</translation>
+<translation id="3522247891732774234">יש עדכון זמין. עוד אפשרויות</translation>
+<translation id="6773423637732432200">‏לא ניתן לעדכן את Brave. אפשרויות נוספות</translation>
+<translation id="3328801116991980348">פרטי אתר</translation>
+<translation id="5391532827096253100">החיבור שלך לאתר הזה לא מאובטח. פרטי האתר</translation>
+<translation id="6206551242102657620">החיבור מאובטח. פרטי האתר</translation>
+<translation id="6963642900430330478">הדף הזה מסוכן. פרטי האתר</translation>
+<translation id="9070377983101773829">התחל חיפוש קולי</translation>
+<translation id="8676374126336081632">ניקוי קלט</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{כרטיסייה פתוחה אחת (<ph name="OPEN_TABS_ONE"/>), יש להקיש כדי להחליף כרטיסיות}two{<ph name="OPEN_TABS_MANY"/> כרטיסיות פתוחות, יש להקיש כדי להחליף כרטיסיות}many{<ph name="OPEN_TABS_MANY"/> כרטיסיות פתוחות, יש להקיש כדי להחליף כרטיסיות}other{<ph name="OPEN_TABS_MANY"/> כרטיסיות פתוחות, יש להקיש כדי להחליף כרטיסיות}}</translation>
+<translation id="2369533728426058518">כרטיסיות פתוחות</translation>
+<translation id="7071521146534760487">ניהול חשבון</translation>
+<translation id="932327136139879170">בית</translation>
+<translation id="2707726405694321444">רענן את הדף</translation>
+<translation id="2891154217021530873">הפסק את טעינת הדף</translation>
+<translation id="6710213216561001401">הקודם</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">הכרטיסייה שנבחרה</translation>
+<translation id="2268044343513325586">צמצם</translation>
+<translation id="7846076177841592234">בטל את הבחירה</translation>
+<translation id="7087918508125750058">נבחרו <ph name="ITEM_COUNT"/>. האפשרויות מוצגות בחלק העליון של המסך</translation>
+<translation id="7250468141469952378">נבחרו <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{שתף פריט אחד שנבחר}two{שתף # פריטים שנבחרו}many{שתף # פריטים שנבחרו}other{שתף # פריטים שנבחרו}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{הסר פריט אחד שנבחר}two{הסר # פריטים שנבחרו}many{הסר # פריטים שנבחרו}other{הסר # פריטים שנבחרו}}</translation>
+<translation id="1283039547216852943">הקש כדי להרחיב</translation>
+<translation id="5962718611393537961">הקש כדי לכווץ</translation>
+<translation id="8076492880354921740">כרטיסיות</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{נבחר אחד}two{נבחרו #}many{נבחרו #}other{נבחרו #}}</translation>
+<translation id="6818926723028410516">בחירת פריטים</translation>
+<translation id="4797039098279997504">גע כדי לחזור אל <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">הקשה תעביר אותך אל האתר</translation>
+<translation id="429312253194641664">אתר מסוים מפעיל מדיה</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> משתף את המסך שלך</translation>
+<translation id="8833831881926404480">אתר משתף את המסך שלך</translation>
+<translation id="9086455579313502267">אין אפשרות לגשת לרשת</translation>
+<translation id="938850635132480979">שגיאה: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">פתח ב-<ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">פתח יישום מפות</translation>
+<translation id="7698359219371678927">צור הודעת אימייל ב-<ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">צור הודעת אימייל</translation>
+<translation id="5665379678064389456">צור אירוע ב-<ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">צור אירוע</translation>
+<translation id="2111511281910874386">מעבר לדף</translation>
+<translation id="3988466920954086464">בחלונית הזו אפשר לראות תוצאות חיפוש מיידי</translation>
+<translation id="2744248271121720757">כדי לחפש באופן מיידי או לראות פעולות קשורות, צריך להקיש על מילה</translation>
+<translation id="9155898266292537608">אפשר גם להתחיל חיפוש על-ידי הקשה קצרה על מילה</translation>
+<translation id="3232754137068452469">אפליקציית אינטרנט</translation>
+<translation id="1430915738399379752">הדפסה</translation>
+<translation id="3775705724665058594">שליחה אל המכשירים שלך</translation>
+<translation id="6364438453358674297">האם להסיר את ההצעה מההיסטוריה?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> נסגר</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> כרטיסיות נסגרו</translation>
+<translation id="3211426585530211793">מועד המחיקה: <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> סימניות נמחקו</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> הורדות נמחקו</translation>
+<translation id="1248710015876067820">‏מספר בלתי נתמך של מופעי Brave.</translation>
+<translation id="4259722352634471385">הניווט חסום: <ph name="URL"/></translation>
+<translation id="8959122750345127698">הניווט לא אפשרי: <ph name="URL"/></translation>
+<translation id="5210365745912300556">סגור כרטיסייה</translation>
+<translation id="7772375229873196092">סגירת <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">היסטוריית ניווט</translation>
+<translation id="9169507124922466868">היסטוריית הניווט פתוחה למחצה</translation>
+<translation id="1327257854815634930">היסטוריית הניווט פתוחה</translation>
+<translation id="8788265440806329501">היסטוריית הניווט סגורה</translation>
+<translation id="7482656565088326534">כרטיסיית תצוגה מקדימה</translation>
+<translation id="8427875596167638501">כרטיסיית התצוגה המקדימה פתוחה בחצי גובה המסך</translation>
+<translation id="9102803872260866941">כרטיסיית התצוגה המקדימה נפתחה</translation>
+<translation id="2942036813789421260">כרטיסיית התצוגה המקדימה סגורה</translation>
+<translation id="6355102470683871794">‏נפח אחסון של <ph name="APP_NAME"/>‏ Brave Software</translation>
+<translation id="3822502789641063741">למחוק נתוני אתר מהאחסון?</translation>
+<translation id="9205995714227143200">‏נתוני אתר מאוחסנים ש-Brave לא מחשיב כחשובים (לדוגמה, אתרים ללא הגדרות שמורות או כאלה שאינך מבקר בהם לעתים קרובות)</translation>
+<translation id="3997476611815694295">נתונים מאוחסנים לא חשובים</translation>
+<translation id="8493948351860045254">פנה שטח אחסון</translation>
+<translation id="2324920234469020158">‏פעולה זו תמחק את קובצי ה-Cookie, את המטמון ונתונים אחרים של אתרים ש-Brave לא מחשיב כחשובים.</translation>
+<translation id="5447201525962359567">‏כל נתוני האתר המאוחסנים, כולל קובצי Cookie ונתונים אחרים המאוחסנים באופן מקומי</translation>
+<translation id="1376578503827013741">מחשב...</translation>
+<translation id="583281660410589416">לא ידוע</translation>
+<translation id="2323763861024343754">נתוני אתר מאוחסנים</translation>
+<translation id="3587672679800759167">‏סך כל הנתונים שבהם משתמש Brave, כולל חשבונות, סימניות והגדרות שמורות</translation>
+<translation id="6545017243486555795">נקה את כל הנתונים</translation>
+<translation id="4095146165863963773">למחוק נתוני יישומים?</translation>
+<translation id="53119194224775367">‏כל נתוני היישומים של Brave יימחקו לצמיתות, כולל כל הקבצים, ההגדרות, החשבונות, מסדי הנתונים וכו'</translation>
+<translation id="5307446750509046227">מחיקת נתוני אתר מהאחסון</translation>
+<translation id="300526633675317032">פעולה זו תמחק את כל נתוני האתר המאוחסנים (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">אין אפשרות לבחור אישור.</translation>
+<translation id="2315043854645842844">מערכת ההפעלה אינה תומכת בבחירת אישור בצד הלקוח.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> מבקש להתחבר אל</translation>
+<translation id="5308380583665731573">התחברות</translation>
+<translation id="868929229000858085">חיפוש באנשי הקשר</translation>
+<translation id="1919950603503897840">בחירת אנשי קשר</translation>
+<translation id="7986741934819883144">בחירת איש קשר</translation>
+<translation id="3333961966071413176">כל אנשי הקשר</translation>
+<translation id="4994033804516042629">לא נמצאו אנשי קשר</translation>
+<translation id="5403592356182871684">שמות</translation>
+<translation id="2717722538473713889">כתובות אימייל</translation>
+<translation id="381841723434055211">מספרי טלפון</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(ועוד 1)}two{(ועוד #)}many{(ועוד #)}other{(ועוד #)}}</translation>
+<translation id="5197729504361054390">אנשי הקשר שייבחרו ישותפו עם <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">מפענח התמונות</translation>
+<translation id="8067883171444229417">הפעלת הסרטון</translation>
+<translation id="6560414384669816528">‏השתמש ב-Sogou לחיפוש</translation>
+<translation id="5406914950576900927">‏דפדפן Brave יכול להשתמש ב-<ph name="BEGIN_BOLD"/>Sogou‏<ph name="END_BOLD"/> כדי לחפש בסין. אפשר לשנות את ההעדפה הזאת ב<ph name="BEGIN_LINK"/>הגדרות<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">‏המשך להשתמש ב-Brave Software</translation>
+<translation id="4384468725000734951">‏שימוש ב-Sogou לחיפוש</translation>
+<translation id="6103327872225198548">‏שימוש ב-Brave Software לחיפוש</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">‏האפליקציה הזו פועלת ב-Brave</translation>
+<translation id="6143689084714664628">‏פועל ב-Brave</translation>
+<translation id="7675869148432102528">‏ל-<ph name="APP_NAME"/> יש נתונים גם ב-Brave</translation>
+<translation id="2734140769649165081">‏אפשר לנקות את הנתונים דרך הגדרות Brave.</translation>
+<translation id="8232956427053453090">שמירת הנתונים</translation>
+<translation id="4298388696830689168">אתרים מקושרים</translation>
+<translation id="5763514718066511291">הקשה מעתיקה את כתובת האתר של האפליקציה הזו</translation>
+<translation id="6496823230996795692">כדי להשתמש באפליקציה <ph name="APP_NAME"/> בפעם הראשונה יש להתחבר לאינטרנט.</translation>
+<translation id="751961395872307827">לא ניתן להתחבר לאתר</translation>
+<translation id="4878404682131129617">‏יצירת מנהרה בעזרת שרת proxy נכשלה</translation>
+<translation id="4749960740855309258">פתח כרטיסייה חדשה</translation>
+<translation id="8788968922598763114">פתח מחדש את הכרטיסייה האחרונה שנסגרה</translation>
+<translation id="7929962904089429003">פתח את התפריט</translation>
+<translation id="6039379616847168523">עבור לכרטיסייה הבאה</translation>
+<translation id="5210286577605176222">חזרה לכרטיסייה הקודמת</translation>
+<translation id="124678866338384709">סגור את הכרטיסייה הנוכחית</translation>
+<translation id="3714981814255182093">פתח את סרגל החיפוש</translation>
+<translation id="5441522332038954058">מעבר לשורת כתובת האתר</translation>
+<translation id="3398320232533725830">פתח את מנהל הסימניות</translation>
+<translation id="6583199322650523874">סמן את הדף הנוכחי בסימנייה</translation>
+<translation id="8489271220582375723">פתח את דף ההיסטוריה</translation>
+<translation id="4837753911714442426">פתח אפשרויות להדפסת דפים</translation>
+<translation id="5726692708398506830">הגדל את כל מה שמופיע בדף</translation>
+<translation id="3259831549858767975">הקטן את כל מה שמופיע בדף</translation>
+<translation id="8015452622527143194">החזר את כל מה שמופיע בדף לגודל ברירת המחדל</translation>
+<translation id="3443221991560634068">טען מחדש את הדף הנוכחי</translation>
+<translation id="123724288017357924">טען מחדש את הדף הנוכחי, תוך התעלמות מתוכן שמאוחסן בקובץ השמור</translation>
+<translation id="305870044889644984">‏פתיחת מרכז העזרה של Brave בכרטיסייה חדשה</translation>
+<translation id="3166827708714933426">מקשי קיצור לכרטיסיות ולחלונות</translation>
+<translation id="3169981355900570544">‏מקשי קיצור לתכונות של Brave Software Brave‏</translation>
+<translation id="4558311620361989323">קיצורי דרך בדפי אינטרנט</translation>
+<translation id="1908301351964700579">‏Brave עדיין מתכונן ל-VR. יש להפעיל מחדש את Brave מאוחר יותר.</translation>
+<translation id="8970887620466824814">משהו השתבש.</translation>
+<translation id="1875543012935658554">‏יש לפתוח מחדש את Brave.</translation>
+<translation id="79859296434321399">‏כדי להציג תוכן של מציאות רבודה, צריך להתקין את ARCore</translation>
+<translation id="8558485628462305855">‏כדי להציג תוכן של מציאות רבודה, צריך לעדכן את ARCore</translation>
+<translation id="3513704683820682405">מציאות רבודה</translation>
+<translation id="5475862044948910901">להתחיל פעילות של מציאות רבודה?</translation>
 <translation id="7365126855094612066">במהלך כל הסשן, האתר יוכל:
 • ליצור מפה תלת-מימדית של הסביבה שלך
 • לעקוב אחר תנועת המצלמה
 
 האתר לא מקבל גישה למצלמה. צילומי המצלמה גלויים רק לך.</translation>
-<translation id="7375125077091615385">סוג:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">כתובת אתר</translation>
-<translation id="7403691278183511381">‏חוויית ההפעלה הראשונה של Chrome</translation>
-<translation id="741204030948306876">כן, אני רוצה</translation>
-<translation id="7413229368719586778">תאריך התחלה <ph name="DATE" /></translation>
-<translation id="7423098979219808738">תופיע בקשת אישור</translation>
-<translation id="7423538860840206698">הגישה לקריאה מלוח העריכה נחסמה</translation>
-<translation id="7431991332293347422">קביעת אופן השימוש בהיסטוריית הגלישה להתאמה אישית של החיפוש ועוד</translation>
-<translation id="7437998757836447326">‏יציאה מ-Chrome</translation>
-<translation id="7438641746574390233">‏כשמצב הטעינה המהירה מופעל, Chrome משתמש בשרתים של Google כדי להאיץ את טעינת הדפים. אם מדובר בדפים איטיים מאוד, במצב הטעינה המהירה הם עוברים שכתוב כך שרק התוכן החיוני שלהם נטען. מצב הטעינה המהירה לא חל על כרטיסיות גלישה בסתר.</translation>
-<translation id="7444811645081526538">קטגוריות נוספות</translation>
-<translation id="7445411102860286510">אתרים יוכלו להפעיל באופן אוטומטי סרטונים מושתקים (מומלץ)</translation>
-<translation id="7453467225369441013">‏הפעולה תוציא אותך מרוב האתרים אבל לא מחשבון Google שלך.</translation>
-<translation id="7454641608352164238">אין מספיק מקום</translation>
-<translation id="7475192538862203634">אם נתקלת בזה לעתים קרובות, כדאי לנסות את <ph name="BEGIN_LINK" />ההצעות<ph name="END_LINK" /> האלה.</translation>
-<translation id="7475688122056506577">‏לא נמצא כרטיס SD. ייתכן שחלק מהקבצים שלך חסרים.</translation>
-<translation id="7479104141328977413">ניהול כרטיסיות</translation>
-<translation id="7481312909269577407">קדימה</translation>
-<translation id="7482656565088326534">כרטיסיית תצוגה מקדימה</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (עודכן <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">חסכון בחבילת הגלישה</translation>
-<translation id="7498271377022651285">המתן…</translation>
-<translation id="7514365320538308">הורדה</translation>
-<translation id="751961395872307827">לא ניתן להתחבר לאתר</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">לא ניתן לקבל הצעות</translation>
-<translation id="7559975015014302720">מצב הטעינה המהירה מושבת</translation>
-<translation id="7562080006725997899">מנקה נתוני גלישה</translation>
-<translation id="756809126120519699">‏נתוני Chrome נוקו</translation>
-<translation id="757524316907819857">חסימה של הפעלת תוכן מוגן על-ידי אתרים</translation>
-<translation id="757855969265046257">{FILES,plural, =1{הורדת קובץ אחד (<ph name="FILES_DOWNLOADED_ONE" />)}two{הורדת <ph name="FILES_DOWNLOADED_MANY" /> קבצים}many{הורדת <ph name="FILES_DOWNLOADED_MANY" /> קבצים}other{הורדת <ph name="FILES_DOWNLOADED_MANY" /> קבצים}}</translation>
-<translation id="7588219262685291874">עיצוב כהה מופעל כשהמכשיר עובר לחיסכון בסוללה</translation>
-<translation id="7589445247086920869">חסימה במנוע החיפוש הנוכחי</translation>
-<translation id="7593557518625677601">‏פתח את הגדרות Android והפעל מחדש את הסנכרון של מערכת Android כדי להתחיל בסנכרון של Chrome</translation>
-<translation id="7596558890252710462">מערכת הפעלה</translation>
-<translation id="7605594153474022051">הסנכרון לא עובד</translation>
-<translation id="7606077192958116810">מצב הטעינה המהירה מופעל. אפשר לנהל אותו דרך ההגדרות.</translation>
-<translation id="7612619742409846846">‏מחובר ל-Google בשם</translation>
-<translation id="7619072057915878432">הורדת <ph name="FILE_NAME" /> נכשלה עקב כשלים ברשת.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />קבל עזרה<ph name="END_LINK1" /> או <ph name="BEGIN_LINK2" />חפש שוב<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">‏ברוכים הבאים ל-Chrome</translation>
-<translation id="7638584964844754484">ביטוי סיסמה שגוי</translation>
-<translation id="7641339528570811325">מחיקת נתוני הגלישה...</translation>
-<translation id="7648422057306047504">‏הצפנת סיסמאות באמצעות פרטי הכניסה שלך ל-Google</translation>
-<translation id="7649070708921625228">עזרה</translation>
-<translation id="7658239707568436148">ביטול</translation>
-<translation id="7665369617277396874">חשבון חדש</translation>
-<translation id="766587987807204883">כאן יוצגו מאמרים, ואפשר לקרוא אותם גם במצב לא מקוון</translation>
-<translation id="7682724950699840886">אפשר לנסות את הטיפים הבאים: צריך לוודא שיש מספיק מקום פנוי במכשיר ואז לנסות לייצא שוב.</translation>
-<translation id="7685301384041462804">‏חשוב לוודא שהאתר מהימן לפני תחילת השימוש ב-VR.</translation>
-<translation id="7698359219371678927">צור הודעת אימייל ב-<ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">השלמה אוטומטית של חיפושים וכתובות אתרים</translation>
-<translation id="7725024127233776428">הדפים שהוספת לסימניות מופיעים כאן</translation>
-<translation id="773466115871691567">ברצוני לקבל תרגום תמיד דפים ב<ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">‏כדי לזהות אפליקציות ואתרים מסוכנים, Chrome שולח אל Google כתובות URL של חלק מהדפים שאליהם נכנסת, מידע מוגבל לגבי המערכת וחלק מתוכן הדפים</translation>
-<translation id="7757787379047923882">הטקסט שותף דרך <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">‏כרטיס SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">הוסף כתובת</translation>
-<translation id="7772032839648071052">אשר משפט-סיסמה</translation>
-<translation id="7772375229873196092">סגירת <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{‏<ph name="PAYMENT_METHOD_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> נוסף}two{‏<ph name="PAYMENT_METHOD_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> נוספים}many{‏<ph name="PAYMENT_METHOD_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> נוספים}other{‏<ph name="PAYMENT_METHOD_PREVIEW" />‎\u2026‎ ו-<ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> נוספים}}</translation>
-<translation id="7781829728241885113">אתמול</translation>
-<translation id="7791543448312431591">הוספה</translation>
-<translation id="780301667611848630">לא תודה</translation>
-<translation id="7810647596859435254">פתח באמצעות...</translation>
-<translation id="7821588508402923572">ערכי החיסכון בנתונים יופיעו כאן</translation>
-<translation id="7837721118676387834">אפשר הפעלה אוטומטית של סרטונים מושתקים באתר ספציפי.</translation>
-<translation id="7846076177841592234">בטל את הבחירה</translation>
-<translation id="784934925303690534">טווח זמן</translation>
-<translation id="7851858861565204677">מכשירים אחרים</translation>
-<translation id="7875915731392087153">צור הודעת אימייל</translation>
-<translation id="7876243839304621966">הסר הכל</translation>
-<translation id="7882131421121961860">לא נמצאה היסטוריה</translation>
-<translation id="7882806643839505685">מתן הרשאה להשמעת צלילים באתר ספציפי.</translation>
-<translation id="7886917304091689118">‏פועל ב-Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{מתבצעת הורדה של הקובץ.}two{מתבצעת הורדה של # קבצים.}many{מתבצעת הורדה של # קבצים.}other{מתבצעת הורדה של # קבצים.}}</translation>
-<translation id="7929962904089429003">פתח את התפריט</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> אינו מעודכן.</translation>
-<translation id="7947953824732555851">קבל והיכנס</translation>
-<translation id="7963646190083259054">ספק:</translation>
-<translation id="7971136598759319605">פעילות אחרונה: לפני יום אחד</translation>
-<translation id="7975379999046275268">הצגת הדף בתצוגה מקדימה<ph name="BEGIN_NEW" />חדש<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">טעינה מראש של דפים כדי לאפשר גלישה וחיפוש מהירים יותר</translation>
-<translation id="79859296434321399">‏כדי להציג תוכן של מציאות רבודה, צריך להתקין את ARCore</translation>
-<translation id="7986741934819883144">בחירת איש קשר</translation>
-<translation id="7987073022710626672">‏התנאים וההגבלות של Chrome</translation>
-<translation id="7998918019931843664">פתח מחדש כרטיסייה שנסגרה</translation>
-<translation id="7999064672810608036">‏האם אתה בטוח שברצונך לנקות את כל הנתונים המקומיים, כולל קובצי Cookie, ולאפס את כל ההרשאות של האתר הזה?</translation>
-<translation id="8004582292198964060">דפדפן</translation>
-<translation id="8007176423574883786">כבוי בשביל המכשיר הזה</translation>
-<translation id="8013372441983637696">‏יש לנקות גם את נתוני Chrome מהמכשיר הזה</translation>
-<translation id="8015452622527143194">החזר את כל מה שמופיע בדף לגודל ברירת המחדל</translation>
-<translation id="802154636333426148">ההורדה נכשלה</translation>
-<translation id="8026334261755873520">ניקוי נתוני גלישה</translation>
-<translation id="8035133914807600019">תיקייה חדשה…</translation>
-<translation id="8037750541064988519">נותרו <ph name="DAYS" /> ימים</translation>
-<translation id="804335162455518893">‏לא נמצא כרטיס SD</translation>
-<translation id="805047784848435650">על סמך היסטוריית הגלישה שלך</translation>
-<translation id="8051695050440594747">‏‎<ph name="MEGABYTES" /> MB זמינים</translation>
-<translation id="8058746566562539958">‏פתיחה בכרטיסייה חדשה של Chrome</translation>
-<translation id="8063895661287329888">הוספת הסימנייה נכשלה.</translation>
-<translation id="806745655614357130">שמור בנפרד את הנתונים שלי</translation>
-<translation id="8067883171444229417">הפעלת הסרטון</translation>
-<translation id="8068648041423924542">אין אפשרות לבחור אישור.</translation>
-<translation id="8073388330009372546">פתיחת התמונה בכרטיסייה חדשה</translation>
-<translation id="8076492880354921740">כרטיסיות</translation>
-<translation id="8084114998886531721">סיסמה שמורה</translation>
-<translation id="8087000398470557479">‏התוכן הזה הוא מ-<ph name="DOMAIN_NAME" />, ומוגש על-ידי Google.</translation>
-<translation id="8103578431304235997">כרטיסיית גלישה בסתר</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">כדי שהסימניות יופיעו בכל המכשירים שלך, יש להפעיל את הסנכרון</translation>
-<translation id="8110087112193408731">‏להציג את הפעילות שלך ב-Chrome ב'שימוש חכם בדיגיטל'?</translation>
-<translation id="8116925261070264013">מושתקים</translation>
-<translation id="813082847718468539">הצג נתוני אתר</translation>
-<translation id="8131740175452115882">אישור</translation>
-<translation id="8156139159503939589">באילו שפות באפשרותך לקרוא?</translation>
-<translation id="8168435359814927499">תוכן</translation>
-<translation id="8186512483418048923">נותרו עוד <ph name="FILES" /> קבצים</translation>
-<translation id="8190358571722158785">נותר יום אחד</translation>
-<translation id="8200772114523450471">חדש</translation>
-<translation id="8209050860603202033">פתח את התמונה</translation>
-<translation id="8218622182176210845">ניהול החשבון</translation>
-<translation id="8224471946457685718">‏הורדת מאמרים עבורך ב-Wi-Fi</translation>
-<translation id="8232956427053453090">שמירת הנתונים</translation>
-<translation id="8249310407154411074">העברה לראש הרשימה</translation>
-<translation id="8250920743982581267">מסמכים</translation>
-<translation id="825412236959742607">‏הדף הזה משתמש בנפח זיכרון גדול מידי, לכן מערכת Chrome הסירה חלק מהתוכן.</translation>
-<translation id="8260126382462817229">נסה להיכנס שוב</translation>
-<translation id="8261506727792406068">מחיקה</translation>
-<translation id="8266862848225348053">מיקום ההורדה</translation>
-<translation id="8274165955039650276">הצגת הורדות</translation>
-<translation id="8284326494547611709">כתוביות</translation>
-<translation id="8300705686683892304">מנוהלים על-ידי אפליקציה</translation>
-<translation id="8310344678080805313">כרטיסיות רגילות</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ועוד אתרים</translation>
-<translation id="8327155640814342956">‏כדי ליהנות מחוויית הגלישה הטובה ביותר, יש לפתוח את Chrome כדי לעדכן אותו</translation>
-<translation id="8339163506404995330">דפים ב<ph name="LANGUAGE" /> לא יתורגמו</translation>
-<translation id="8349013245300336738">מיון לפי כמות הנתונים שבהם נעשה שימוש</translation>
-<translation id="8364299278605033898">הצגת אתרים פופולריים</translation>
-<translation id="8368027906805972958">מכשיר לא ידוע או שאינו נתמך (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">אפשר סנכרון ברקע לאתר ספציפי.</translation>
-<translation id="8378714024927312812">מנוהל על-ידי הארגון</translation>
-<translation id="8380167699614421159">באתר הזה מוצגות מודעות מפריעות או מטעות</translation>
-<translation id="8393700583063109961">שלח הודעה</translation>
-<translation id="8413126021676339697">להצגת ההיסטוריה המלאה</translation>
-<translation id="8427875596167638501">כרטיסיית התצוגה המקדימה פתוחה בחצי גובה המסך</translation>
-<translation id="8428213095426709021">הגדרות</translation>
-<translation id="8438566539970814960">שיפור החיפושים והגלישה</translation>
-<translation id="8441146129660941386">הרץ לאחור</translation>
-<translation id="8443209985646068659">‏אי אפשר לעדכן את Chrome</translation>
-<translation id="8445448999790540984">אי אפשר לייצא סיסמאות</translation>
-<translation id="8447861592752582886">שלול הרשאות מכשיר</translation>
-<translation id="8461694314515752532">הצפנת נתונים מסונכרנים בעזרת ביטוי סיסמה אישי לסנכרון</translation>
-<translation id="8466613982764129868">יש לוודא ש-<ph name="TARGET_DEVICE_NAME" /> מחובר לאינטרנט</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">זמין במצב לא מקוון</translation>
-<translation id="8489271220582375723">פתח את דף ההיסטוריה</translation>
-<translation id="8493948351860045254">פנה שטח אחסון</translation>
-<translation id="8497726226069778601">אין מה לראות כאן… בינתיים</translation>
-<translation id="8503559462189395349">‏סיסמאות Chrome</translation>
-<translation id="8503813439785031346">שם משתמש</translation>
-<translation id="8514477925623180633">‏ייצוא סיסמאות המאוחסנות ב-Chrome</translation>
-<translation id="8514577642972634246">עבור למצב גלישה בסתר</translation>
-<translation id="851751545965956758">חסימת התחברות של אתרים אל התקנים</translation>
-<translation id="8523928698583292556">מחק את הסיסמה השמורה</translation>
-<translation id="854522910157234410">פתח דף זה</translation>
-<translation id="8558485628462305855">‏כדי להציג תוכן של מציאות רבודה, צריך לעדכן את ARCore</translation>
-<translation id="8559990750235505898">הצעה לתרגם דפים בשפות אחרות</translation>
-<translation id="8562452229998620586">הסיסמאות השמורות יופיעו כאן.</translation>
-<translation id="8569404424186215731">מאז <ph name="DATE" /></translation>
-<translation id="8571213806525832805">מארבעת השבועות האחרונים</translation>
-<translation id="857943718398505171">מותרת (מומלץ)</translation>
-<translation id="8583805026567836021">מנקה נתוני חשבון</translation>
-<translation id="860043288473659153">שם בעל הכרטיס</translation>
-<translation id="8609465669617005112">הזז למעלה</translation>
-<translation id="8616006591992756292">‏ייתכן שלחשבון Google שלך יהיו צורות אחרות של היסטוריית גלישה בכתובת <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">האם לעבור אל כתובת האתר שצוינה כהצעה בתוכן שהורדת?</translation>
-<translation id="8636825310635137004">כדי לקבל את הכרטיסיות מהמכשירים האחרים שלך, הפעל את הסנכרון.</translation>
-<translation id="8641930654639604085">נסה לחסום אתרים שמכילים תוכן למבוגרים</translation>
-<translation id="8655129584991699539">‏אפשר לנקות את הנתונים דרך הגדרות Chrome.</translation>
-<translation id="8662811608048051533">תבוצע יציאה שלך מרוב האתרים.</translation>
-<translation id="8664979001105139458">שם הקובץ כבר קיים</translation>
-<translation id="8676374126336081632">ניקוי קלט</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{רמת עוצמת אות: עמודה אחת}two{רמת עוצמת אות: שתי עמודות}many{רמת עוצמת אות: # עמודות}other{רמת עוצמת אות: # עמודות}}</translation>
-<translation id="868929229000858085">חיפוש באנשי הקשר</translation>
-<translation id="869891660844655955">תאריך תפוגה</translation>
-<translation id="8719023831149562936">לא ניתן להעביר תוכן מהכרטיסייה הנוכחית</translation>
-<translation id="8725066075913043281">נסה שוב</translation>
-<translation id="8728487861892616501">‏השימוש שלך באפליקציה הזו מבטא את הסכמתך ל<ph name="BEGIN_LINK1" />תנאים ולהגבלות<ph name="END_LINK1" /> ול<ph name="BEGIN_LINK2" />מדיניות הפרטיות<ph name="END_LINK2" /> של Chrome, וכן ל<ph name="BEGIN_LINK3" />הודעת הפרטיות לחשבונות Google שמנוהלים ב-Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">בוצע</translation>
-<translation id="8748850008226585750">התוכן מוסתר</translation>
-<translation id="8751914237388039244">בחירת תמונה</translation>
-<translation id="8788265440806329501">היסטוריית הניווט סגורה</translation>
-<translation id="8788968922598763114">פתח מחדש את הכרטיסייה האחרונה שנסגרה</translation>
-<translation id="8801436777607969138">‏חסימת JavaScript באתר ספציפי.</translation>
-<translation id="8812260976093120287">באתרים מסוימים ניתן לשלם דרך המכשיר באמצעות אפליקציות התשלום הנתמכות שמופיעות למעלה.</translation>
-<translation id="8816026460808729765">חסימת הגישה של אתרים אל חיישנים</translation>
-<translation id="8816439037877937734">‏האפליקציה <ph name="APP_NAME" /> תיפתח ב-Chrome. המשך השימוש מבטא את הסכמתך ל<ph name="BEGIN_LINK1" />תנאים ולהגבלות<ph name="END_LINK1" /> ול<ph name="BEGIN_LINK2" />הודעת הפרטיות<ph name="END_LINK2" /> של Chrome, וכן ל<ph name="BEGIN_LINK3" />הודעת הפרטיות לחשבונות Google שמנוהלים ב-Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">סימניות</translation>
-<translation id="8833831881926404480">אתר משתף את המסך שלך</translation>
-<translation id="883806473910249246">אירעה שגיאה בזמן הורדת התוכן.</translation>
-<translation id="8840953339110955557">ייתכן שהדף הזה שונה מהגירסה המקוונת.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, כרטיסייה</translation>
-<translation id="885701979325669005">אחסון</translation>
-<translation id="889338405075704026">‏כניסה להגדרות Chrome</translation>
-<translation id="8901170036886848654">לא נמצאו סימניות</translation>
-<translation id="8909135823018751308">שיתוף…</translation>
-<translation id="8912362522468806198">‏חשבון Google</translation>
-<translation id="8920114477895755567">ממתין לפרטי ההורים.</translation>
+<translation id="1188239144602654184">‏כניסה ל-AR</translation>
+<translation id="473775607612524610">עדכן</translation>
+<translation id="3133489217401741157">‏מתקין את <ph name="MODULE"/> ל-Brave…</translation>
+<translation id="1791662854739702043">מותקן</translation>
+<translation id="5131234170665854056">‏לא ניתן להתקין את <ph name="MODULE"/> ל-Brave</translation>
+<translation id="2567385386134582609">תמונה</translation>
+<translation id="6395288395575013217">קישור</translation>
+<translation id="7352939065658542140">סרטון</translation>
+<translation id="4116038641877404294">הורד דפים כדי להשתמש בהם במצב לא מקוון</translation>
 <translation id="8922289737868596582">כדי להשתמש בדפים במצב לא מקוון, אפשר להוריד אותם דרך הלחצן 'אפשרויות נוספות'</translation>
-<translation id="8937772741022875483">‏האם להסיר את הפעילות שלך ב-Chrome מ'שימוש חכם בדיגיטל'?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">פתיחה בחלון האחר</translation>
-<translation id="8951232171465285730">‏Chrome חסך לך ‎<ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">‏חסימת קובצי Cookie של אתר מסוים.</translation>
-<translation id="8959122750345127698">הניווט לא אפשרי: <ph name="URL" /></translation>
-<translation id="8965591936373831584">בהמתנה</translation>
-<translation id="8970887620466824814">משהו השתבש.</translation>
-<translation id="8972098258593396643">האם להוריד לתיקיית ברירת המחדל?</translation>
-<translation id="8986494364107987395">‏שליחה אוטומטית של דוחות קריסה וסטטיסטיקות שימוש ל-Google</translation>
-<translation id="8993760627012879038">פתח חלון חדש במצב גלישה בסתר</translation>
-<translation id="8998729206196772491">‏אתה נכנס עם חשבון המנוהל על-ידי <ph name="MANAGED_DOMAIN" /> ומעניק למנהל שלו שליטה על הנתונים שלך ב-Chrome. הנתונים שלך ישויכו לצמיתות אל החשבון הזה. יציאה מ-Chrome תמחק את הנתונים שלך מהמכשיר הזה, אבל הם יישארו בחשבון Google.</translation>
-<translation id="9019902583201351841">מנוהל על-ידי ההורים שלך</translation>
-<translation id="9028914725102941583">כדי לבצע שיתוף בין מכשירים יש להפעיל את הסנכרון</translation>
-<translation id="9029323097866369874">‏לאפשר ל-<ph name="DOMAIN" /> להפעיל VR?</translation>
-<translation id="9040142327097499898">יש הרשאה להצגת הודעות. המיקום כבוי בשביל המכשיר הזה.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{סרטון אחד (#)}two{# סרטונים}many{# סרטונים}other{# סרטונים}}</translation>
-<translation id="9050666287014529139">משפט-סיסמה</translation>
-<translation id="9063523880881406963">כבה את 'בקש אתר עבור מחשב שולחני'</translation>
-<translation id="9065203028668620118">עריכה</translation>
-<translation id="9070377983101773829">התחל חיפוש קולי</translation>
-<translation id="9074336505530349563">‏כדי לקבל מ-Google הצעות לתוכן מותאם אישית, יש להיכנס ולהפעיל את הסנכרון</translation>
-<translation id="9086455579313502267">אין אפשרות לגשת לרשת</translation>
-<translation id="9100505651305367705">יש להציע הצגת מאמרים בתצוגה פשוטה, כשהאפשרות נתמכת</translation>
-<translation id="9100610230175265781">יש להזין ביטוי סיסמה</translation>
-<translation id="9102803872260866941">כרטיסיית התצוגה המקדימה נפתחה</translation>
+<translation id="5958275228015807058">הקבצים והדפים שלך נמצאים ב'הורדות'</translation>
+<translation id="5620928963363755975">איתור הקבצים והדפים שלך ב'הורדות' דרך הלחצן 'אפשרויות נוספות'</translation>
+<translation id="3341058695485821946">בדיקת החיסכון בצריכת נתונים</translation>
+<translation id="3157842584138209013">בעזרת הלחצן 'אפשרויות נוספות' אפשר לבדוק את החיסכון בצריכת נתונים</translation>
+<translation id="8218622182176210845">ניהול החשבון</translation>
+<translation id="8090895580117672212">‏כדי לנהל את חשבון Brave Software, יש להקיש על הלחצן "ניהול החשבון"</translation>
+<translation id="8856898588039823173">‏גרסת Lite של הדף נוצרה על ידי Brave Software. אפשר להקיש כדי לטעון את הגרסה המקורית.</translation>
+<translation id="8134317863207426198">‏גרסת Lite של הדף נוצרה על ידי Brave Software. כדי לטעון את הגרסה המקורית, אפשר להקיש על לחצן טעינת המקור.</translation>
+<translation id="4961107849584082341">אפשר לתרגם את הדף הזה לשפה כלשהי</translation>
+<translation id="569536719314091526">דרך לחצן האפשרויות הנוספות אפשר לתרגם את הדף הזה לשפה כלשהי</translation>
+<translation id="1397811292916898096">חיפוש באמצעות <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">אפשר תמיד לשנות את מיקום ההורדות</translation>
+<translation id="6942665639005891494">ניתן תמיד לשנות את מיקום ברירת המחדל להורדות דרך האפשרות 'הגדרות' בתפריט</translation>
+<translation id="6850409657436465440">ההורדה עדיין מתבצעת</translation>
+<translation id="5817715962196959877">‏הורדת קבצים ב-Brave מתבצעת עכשיו מהר יותר</translation>
+<translation id="3976396876660209797">הסרה ויצירה מחדש של מקש הקיצור הזה</translation>
+<translation id="6766622839693428701">החלקה מטה סוגרת.</translation>
+<translation id="1028699632127661925">הכרטיסייה נשלחת אל <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> — נשלחה מ-<ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">התקבלה כרטיסייה</translation>
 <translation id="9104217018994036254">רשימת המכשירים שאפשר לשתף איתם כרטיסייה.</translation>
-<translation id="9133397713400217035">הצעות לתוכן במצב לא מקוון</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">הצג מקור</translation>
-<translation id="9139068048179869749">יש לשאול לפני שמאפשרים לאתרים לשלוח הודעות (מומלץ)</translation>
-<translation id="9139318394846604261">קניות</translation>
-<translation id="9155898266292537608">אפשר גם להתחיל חיפוש על-ידי הקשה קצרה על מילה</translation>
-<translation id="9169507124922466868">היסטוריית הניווט פתוחה למחצה</translation>
-<translation id="9204836675896933765">נותר קובץ אחד</translation>
-<translation id="9206873250291191720">א</translation>
+<translation id="6767294960381293877">רשימת המכשירים שאפשר לשתף איתם כרטיסייה נפתחה בחצי גובה המסך.</translation>
+<translation id="2904414404539560095">רשימת המכשירים שאפשר לשתף איתם כרטיסייה נפתחה בגובה המלא של המסך.</translation>
+<translation id="4135200667068010335">רשימת המכשירים שאפשר לשתף איתם כרטיסייה נסגרה.</translation>
+<translation id="5292796745632149097">שליחה אל</translation>
+<translation id="1386674309198842382">פעילות אחרונה: לפני <ph name="LAST_UPDATED"/> ימים</translation>
+<translation id="7971136598759319605">פעילות אחרונה: לפני יום אחד</translation>
+<translation id="1521774566618522728">שימוש אחרון: היום</translation>
+<translation id="3631987586758005671">השיתוף עם <ph name="DEVICE_NAME"/> מתבצע</translation>
+<translation id="9028914725102941583">כדי לבצע שיתוף בין מכשירים יש להפעיל את הסנכרון</translation>
+<translation id="6162454065885854378">‏כדי לשתף משהו מהטלפון שלך עם מכשיר אחר, יש להפעיל את הסנכרון בהגדרות Brave בשני המכשירים</translation>
+<translation id="6084271560289605378">‏כניסה להגדרות Brave</translation>
+<translation id="2318045970523081853">יש להקיש כדי להתקשר</translation>
 <translation id="9209888181064652401">לא ניתן לבצע שיחות</translation>
-<translation id="9219103736887031265">תמונות</translation>
-<translation id="926205370408745186">‏הסרת הפעילות שלך ב-Chrome מ'שימוש חכם בדיגיטל'.</translation>
-<translation id="932327136139879170">בית</translation>
-<translation id="938850635132480979">שגיאה: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">גישה למיקרופון שלך</translation>
-<translation id="95817756606698420">‏דפדפן Chrome יכול להשתמש ב-<ph name="BEGIN_BOLD" />Sogou‏<ph name="END_BOLD" /> כדי לחפש בסין. אפשר לשנות את ההעדפה הזאת ב<ph name="BEGIN_LINK" />הגדרות<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">חסימה אם באתר מוצגות מודעות מפריעות או מטעות (מומלץ)</translation>
-<translation id="968900484120156207">הדפים שבהם ביקרת מופיעים כאן</translation>
-<translation id="970715775301869095">נותרו <ph name="MINUTES" /> דקות</translation>
-<translation id="974555521953189084">הזן את ביטוי הסיסמה כדי להתחיל בסנכרון</translation>
-<translation id="981121421437150478">לא מקוון</translation>
-<translation id="982182592107339124">פעולה זו תמחק נתונים של כל האתרים, כולל:</translation>
-<translation id="983192555821071799">סגור את כל הכרטיסיות</translation>
-<translation id="987264212798334818">כללי</translation>
+<translation id="2860954141821109167">יש לוודא שמופעלת במכשיר הזה אפליקציית טלפון</translation>
+<translation id="2067805253194386918">טקסט</translation>
+<translation id="1450753235335490080">לא ניתן לשתף את ה<ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">לא ניתן היה לשתף את ה<ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">‏יש לוודא שהסנכרון ב-Brave הופעל ב-<ph name="TARGET_DEVICE_NAME"/></translation>
+<translation id="3016635187733453316">יש לוודא שהמכשיר הזה מחובר לאינטרנט</translation>
+<translation id="8466613982764129868">יש לוודא ש-<ph name="TARGET_DEVICE_NAME"/> מחובר לאינטרנט</translation>
+<translation id="6539092367496845964">משהו השתבש. יש לנסות שוב מאוחר יותר.</translation>
+<translation id="3389286852084373014">הטקסט ארוך מדי</translation>
+<translation id="2100314319871056947">כדאי לשתף את הטקסט במקטעים קטנים יותר</translation>
+<translation id="2987620471460279764">טקסט ששותף ממכשיר אחר</translation>
+<translation id="7757787379047923882">הטקסט שותף דרך <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">הועתק אל הלוח</translation>
+<translation id="4696983787092045100">שליחת הטקסט למכשירים שלך</translation>
+<translation id="1260236875608242557">חיפוש ודפדוף</translation>
+<translation id="6369229450655021117">מכאן אפשר לחפש באינטרנט, לשתף עם חברים ולראות דפים פתוחים</translation>
+<translation id="723171743924126238">בחר תמונות</translation>
+<translation id="8751914237388039244">בחירת תמונה</translation>
+<translation id="1989112275319619282">דפדף</translation>
+<translation id="7055152154916055070">הפניה אוטומטית נחסמה:</translation>
+<translation id="5524843473235508879">הפניה לכתובת אתר אחרת נחסמה.</translation>
+<translation id="6573096386450695060">אני רוצה לאפשר תמיד</translation>
+<translation id="5805364706385912897">‏הדף הזה מנצל יותר מדי זיכרון, כך שהוא הושהה על-ידי Brave.</translation>
+<translation id="5138664332909611586">‏הדף הזה משתמש בנפח זיכרון גדול מידי, לכן מערכת Brave הסירה חלק מהתוכן.</translation>
+<translation id="9137013805542155359">הצג מקור</translation>
+<translation id="6361779936989026201">‏Brave Software Assistant ב-Brave</translation>
+<translation id="7291387454912369099">‏Assistant למילוי אוטומטי</translation>
+<translation id="4565206163201411670">‏להציג את הפעילות שלך ב-Brave ב'שימוש חכם בדיגיטל'?</translation>
+<translation id="9055113864158719823">‏אפשר לראות אתרים שמבקרים בהם ב-Brave ולהגדיר טיימרים בשבילם.\n\n‏Brave Software מקבלת מידע על האתרים שמוגדרים בשבילם טיימרים ומשך השהייה שלך באתרים האלה. המידע עוזר לשפר את 'שימוש חכם בדיגיטל'.</translation>
+<translation id="4596514158372210596">‏הסרת הפעילות שלך ב-Brave מ'שימוש חכם בדיגיטל'.</translation>
+<translation id="1174893863889683998">‏האם להסיר את הפעילות שלך ב-Brave מ'שימוש חכם בדיגיטל'?</translation>
+<translation id="708829030563435351">‏אתרים שנכנסים אליהם ב-Brave לא יופיעו. כל הטיימרים של האתרים יימחקו.</translation>
+<translation id="2056878612599315956">האתר מושהה</translation>
+<translation id="671481426037969117">זמן השימוש באפליקציה <ph name="FQDN"/> הסתיים. הטיימר יופעל מחדש מחר ואז אפשר יהיה להשתמש שוב באפליקציה.</translation>
+<translation id="7479104141328977413">ניהול כרטיסיות</translation>
+<translation id="3524138585025253783">ממשק משתמש למפתחים</translation>
+<translation id="6036057147555329831">‏ICU נוסף</translation>
+<translation id="9029323097866369874">‏לאפשר ל-<ph name="DOMAIN"/> להפעיל VR?</translation>
+<translation id="7685301384041462804">‏חשוב לוודא שהאתר מהימן לפני תחילת השימוש ב-VR.</translation>
+<translation id="5033865233969348410">‏בזמן השימוש ב-VR, ייתכן שלאתר הזה תהיה אפשרות ללמוד על:
+  -  התכונות הפיזיות שלך, כמו הגובה
+
+חשוב לוודא שהאתר מהימן לפני תחילת השימוש ב-VR.</translation>
+<translation id="5534334044554683961">‏בזמן השימוש ב-VR, ייתכן שלאתר הזה תהיה אפשרות ללמוד על:
+  -   התכונות הפיזיות שלך, כמו הגובה
+  -   הצורה שבה החדר שלך מסודר
+
+חשוב לוודא שהאתר מהימן לפני תחילת השימוש ב-VR.</translation>
+<translation id="4169535189173047238">לא לאפשר</translation>
+<translation id="2170088579611075216">‏הפעלת VR וכניסה ל-VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ja.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ja.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ja">
-<translation id="1006017844123154345">オンライン版を開く</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> に送信しています...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> を追加しています...</translation>
-<translation id="1041308826830691739">ウェブサイトから</translation>
-<translation id="1049743911850919806">シークレット モード</translation>
-<translation id="10614374240317010">常に保存しない</translation>
-<translation id="1067922213147265141">他の Google サービス</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" />のページを翻訳しない</translation>
-<translation id="107147699690128016">ファイル拡張子を変更すると、ファイルが別のアプリケーションで開かれる可能性があり、場合によってはデバイスに損害が生じます。</translation>
-<translation id="1100066534610197918">新しいタブをグループで開く</translation>
-<translation id="1105960400813249514">画面キャプチャ</translation>
-<translation id="1111673857033749125">他のデバイスに保存されているブックマークがここに表示されます。</translation>
-<translation id="1113597929977215864">簡易表示する</translation>
-<translation id="1121094540300013208">利用状況と障害レポート</translation>
-<translation id="1124772482545689468">ユーザー</translation>
-<translation id="1129510026454351943">詳細: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 件のダウンロードが保留中です。}other{# 件のダウンロードが保留中です。}}</translation>
-<translation id="1145536944570833626">既存のデータを削除します。</translation>
-<translation id="1146678959555564648">VR を入力</translation>
-<translation id="116280672541001035">使用量</translation>
-<translation id="1171770572613082465">人気のウェブサイトを表示するには、[上位のサイト] ボタンをタップします</translation>
-<translation id="1173894706177603556">名前を変更</translation>
-<translation id="1178581264944972037">一時停止</translation>
-<translation id="1181037720776840403">削除</translation>
-<translation id="1188239144602654184">AR を開始</translation>
-<translation id="1197267115302279827">ブックマークを移動</translation>
-<translation id="119944043368869598">すべて削除</translation>
-<translation id="1201402288615127009">次へ</translation>
-<translation id="1204037785786432551">リンクをダウンロード</translation>
-<translation id="1206892813135768548">リンクテキストをコピー</translation>
-<translation id="1208340532756947324">複数のデバイスで独自の設定を同期して共有するには、同期を有効にします</translation>
-<translation id="1209206284964581585">今は表示しない</translation>
-<translation id="1227058898775614466">ナビゲーション履歴</translation>
-<translation id="1231733316453485619">同期を有効にしますか？</translation>
-<translation id="123724288017357924">キャッシュ コンテンツを無視して現在のページを再読み込みする</translation>
-<translation id="124116460088058876">その他の言語</translation>
-<translation id="124678866338384709">現在のタブを閉じる</translation>
-<translation id="1258753120186372309">Google Doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">検索</translation>
-<translation id="1264974993859112054">スポーツ</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> を共有できませんでした</translation>
-<translation id="1272079795634619415">中止</translation>
-<translation id="1283039547216852943">タップして展開</translation>
-<translation id="1285320974508926690">このサイトは翻訳しない</translation>
-<translation id="1291207594882862231">履歴、Cookie、サイトデータ、キャッシュを削除…</translation>
-<translation id="129382876167171263">ウェブサイトによって保存されたファイルがここに表示されます</translation>
-<translation id="129553762522093515">最近閉じたタブ</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> から送信</translation>
-<translation id="1310482092992808703">タブをグループ化</translation>
-<translation id="1327257854815634930">ナビゲーション履歴が開いています</translation>
-<translation id="1331212799747679585">Chrome を更新できません。その他のオプション</translation>
-<translation id="1332501820983677155">Google Chrome 機能のショートカット</translation>
-<translation id="1360432990279830238">ログアウトして同期をオフにしますか？</translation>
-<translation id="1369915414381695676">サイト <ph name="SITE_NAME" /> を追加しました</translation>
-<translation id="1373696734384179344">選択したコンテンツをダウンロードするにはメモリが不足しています。</translation>
-<translation id="1376578503827013741">計算中...</translation>
-<translation id="1383876407941801731">検索</translation>
-<translation id="1384959399684842514">ダウンロードを一時停止しました</translation>
-<translation id="1386674309198842382">最終同期: <ph name="LAST_UPDATED" /> 日前</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> で検索</translation>
-<translation id="1404122904123200417">埋め込み先: <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">「トラッキング拒否」</translation>
-<translation id="1407135791313364759">すべて開く</translation>
-<translation id="1409426117486808224">開いているタブの簡易表示</translation>
-<translation id="1409879593029778104"><ph name="FILE_NAME" /> は既に存在しているためダウンロードできませんでした。</translation>
-<translation id="1414981605391750300">Google に問い合わせています。これには 1 分ほどかかる場合があります…</translation>
-<translation id="1416550906796893042">アプリケーションのバージョン</translation>
-<translation id="1430915738399379752">印刷</translation>
-<translation id="1446450296470737166">MIDI機器のフルコントロールを許可</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> を共有できません</translation>
-<translation id="145097072038377568">Android の設定で無効</translation>
-<translation id="1477626028522505441">サーバーで問題が発生したため、<ph name="FILE_NAME" /> をダウンロードできませんでした。</translation>
-<translation id="1506061864768559482">検索エンジン</translation>
-<translation id="1513352483775369820">ブックマークとウェブ履歴</translation>
-<translation id="1513858653616922153">パスワードを削除</translation>
-<translation id="1516229014686355813">「タップして検索」では選択した単語と現在のページがコンテキストとして Google 検索に送信されます。これは [<ph name="BEGIN_LINK" />設定<ph name="END_LINK" />] で無効にすることができます。</translation>
-<translation id="1521774566618522728">最終同期: 今日</translation>
-<translation id="1544826120773021464">Google アカウントを管理するには、[アカウントを管理] をタップします。</translation>
-<translation id="1549000191223877751">他のウィンドウに移動</translation>
-<translation id="1553358976309200471">Chrome を更新</translation>
-<translation id="1569387923882100876">接続しているデバイス</translation>
-<translation id="1571304935088121812">ユーザー名をコピー</translation>
-<translation id="1612196535745283361">Chrome ではデバイスをスキャンするために現在地情報にアクセスする必要があります。現在地情報へのアクセスは<ph name="BEGIN_LINK" />このデバイスでオフになっています<ph name="END_LINK" />。</translation>
-<translation id="1620510694547887537">カメラ</translation>
-<translation id="1623104350909869708">このページで追加のダイアログが作成されないようにする</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{選択された 1 件のアイテムを削除します}other{選択された # 件のアイテムを削除します}}</translation>
-<translation id="164269334534774161">このページの <ph name="CREATION_TIME" /> のオフライン コピーを表示しています</translation>
-<translation id="1644574205037202324">履歴</translation>
-<translation id="1647391597548383849">カメラへのアクセス</translation>
-<translation id="1660204651932907780">音声の再生をサイトに許可する（推奨）</translation>
-<translation id="1670399744444387456">基本設定</translation>
-<translation id="1671236975893690980">ダウンロードを待機しています...</translation>
-<translation id="1672586136351118594">次回から表示しない</translation>
-<translation id="1692118695553449118">同期は有効です</translation>
-<translation id="169515064810179024">サイトによるモーション センサーへのアクセスをブロックする</translation>
-<translation id="1717218214683051432">モーション センサー</translation>
-<translation id="1718835860248848330">1 時間以内</translation>
-<translation id="1736419249208073774">詳しく見る</translation>
-<translation id="1743802530341753419">サイトがデバイスに接続する前に確認する（推奨）</translation>
-<translation id="1749561566933687563">ブックマークの同期</translation>
-<translation id="17513872634828108">開いているタブ</translation>
-<translation id="1779089405699405702">画像デコーダー</translation>
-<translation id="1782483593938241562">終了日: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">インストール先</translation>
-<translation id="1792959175193046959">デフォルトのダウンロード保存先はいつでも変更できます</translation>
-<translation id="1807246157184219062">明</translation>
-<translation id="1810845389119482123">最初の同期設定が終了していません</translation>
-<translation id="1821253160463689938">Cookie を使って設定を保存します（これらのページにアクセスしない場合も Cookie が保持されます）</translation>
-<translation id="1829244130665387512">ページ内検索</translation>
-<translation id="1853692000353488670">新しいシークレット タブ</translation>
-<translation id="1856325424225101786">ライトモードをリセットしますか？</translation>
-<translation id="1868024384445905608">Chrome でのファイルのダウンロードがさらに速くなりました</translation>
-<translation id="1883903952484604915">マイファイル</translation>
-<translation id="1887786770086287077">位置情報へのアクセスがデバイスでオフになっています。<ph name="BEGIN_LINK" />Android の設定<ph name="END_LINK" />でオンにしてください。</translation>
-<translation id="1891331835972267886">Chrome で <ph name="APP_NAME" /> を開きます。続行すると、Chrome の<ph name="BEGIN_LINK1" />利用規約<ph name="END_LINK1" />と<ph name="BEGIN_LINK2" />プライバシーに関するお知らせ<ph name="END_LINK2" />に同意したことになります。</translation>
-<translation id="1919345977826869612">広告</translation>
-<translation id="1919950603503897840">連絡先を選択</translation>
-<translation id="1922076542920281912">Chrome に現在地へのアクセスを許可するには、<ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />でも位置情報をオンにしてください。</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">更新</translation>
-<translation id="19288952978244135">Chrome を再度開きます。</translation>
-<translation id="1933845786846280168">選択したタブ</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android の設定<ph name="END_LINK" />で Chrome の権限を有効にしてください。</translation>
-<translation id="1943432128510653496">パスワードの保存</translation>
-<translation id="1952172573699511566">可能な場合、設定した言語でウェブサイトのテキストを表示します。</translation>
-<translation id="1960290143419248813">このバージョンの Android では Chrome の更新はサポートされなくなりました</translation>
-<translation id="1966710179511230534">ログイン情報を更新してください。</translation>
-<translation id="1974060860693918893">詳細設定</translation>
-<translation id="1984705450038014246">Chrome データを同期</translation>
-<translation id="1984937141057606926">サードパーティを除いて許可する</translation>
-<translation id="1986685561493779662">この名前はすでに存在しています</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> ボタン</translation>
-<translation id="1989112275319619282">閲覧</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> がペア設定を要求しています</translation>
-<translation id="1994173015038366702">サイトの URL</translation>
-<translation id="2000419248597011803">Cookie と、アドレスバーや検索ボックスに入力した検索語句を既定の検索エンジンに送信します</translation>
-<translation id="2002537628803770967">Google Pay に登録したクレジット カードと住所</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# 件のファイル}other{# 件のファイル}}</translation>
-<translation id="2017836877785168846">アドレスバーの履歴とオートコンプリート データを削除します。</translation>
-<translation id="2021896219286479412">全画面表示時のサイトの操作項目</translation>
-<translation id="2038563949887743358">[PC 版サイトを見る] をオンにします</translation>
-<translation id="2041019821020695769">Chrome に通知の送信を許可するには、<ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />でも通知をオンにしてください。</translation>
-<translation id="204321170514947529">Chrome にも <ph name="APP_NAME" /> のデータがあります</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">サイト一時停止中</translation>
-<translation id="2063713494490388661">タップして検索</translation>
-<translation id="2067805253194386918">テキスト</translation>
-<translation id="2079545284768500474">元に戻す</translation>
-<translation id="2082238445998314030">結果 <ph name="TOTAL_RESULTS" /> 件中 <ph name="RESULT_NUMBER" /> 件目</translation>
-<translation id="2091887806945687916">音声</translation>
-<translation id="2096012225669085171">デバイス間の同期とカスタマイズ</translation>
-<translation id="2100273922101894616">自動ログイン</translation>
-<translation id="2100314319871056947">共有するテキスト ブロックを小さくしてください</translation>
-<translation id="2107397443965016585">保護されたコンテンツの再生をサイトに許可する前に確認する（推奨）</translation>
-<translation id="2111511281910874386">ページを開く</translation>
-<translation id="2122601567107267586">アプリを開けませんでした</translation>
-<translation id="2126426811489709554">Powered by Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> 削減しました</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> を閉じました</translation>
-<translation id="2139186145475833000">ホーム画面に追加</translation>
-<translation id="2146738493024040262">プレビュー アプリを開く</translation>
-<translation id="2148716181193084225">今日</translation>
-<translation id="2154484045852737596">カードを編集</translation>
-<translation id="2154710561487035718">URL をコピー</translation>
-<translation id="2156074688469523661">その他のサイト（<ph name="NUMBER_OF_SITES" /> 件）</translation>
-<translation id="2157851137955077194">お使いのスマートフォンから別のデバイスにデータを共有するには、両方のデバイスの Chrome 設定で同期をオンにしてください</translation>
-<translation id="2170088579611075216">VR を許可して開始</translation>
-<translation id="218608176142494674">共有</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> として続行</translation>
-<translation id="2234876718134438132">同期と Google サービス</translation>
-<translation id="2259659629660284697">パスワードをエクスポート…</translation>
-<translation id="2268044343513325586">絞り込み</translation>
-<translation id="2286841657746966508">請求先住所</translation>
-<translation id="2289270750774289114">サイトから近くにある Bluetooth デバイスの検出を求められたときに確認する（推奨）</translation>
-<translation id="230115972905494466">対応デバイスが見つかりませんでした</translation>
-<translation id="2315043854645842844">オペレーティング システムでサポートされていないため、クライアント側で証明書を選択することはできません。</translation>
-<translation id="2318045970523081853">タップして電話をかける</translation>
-<translation id="2321086116217818302">パスワードを準備しています…</translation>
-<translation id="2321958826496381788">読みやすくなるまでスライダをドラッグしてください。段落をダブルタップするとテキストがこれより大きくなります。</translation>
-<translation id="2323763861024343754">サイトのストレージ</translation>
-<translation id="2328985652426384049">ログインできません</translation>
-<translation id="2330129964253841015">パスワードが危険にさらされた場合に警告する</translation>
-<translation id="2349710944427398404">Chrome が使用するデータ全体（アカウント、ブックマーク、保存済みの設定など）</translation>
-<translation id="2353636109065292463">インターネット接続を確認しています</translation>
-<translation id="2359808026110333948">続行</translation>
-<translation id="2369533728426058518">開いているタブ</translation>
-<translation id="2387895666653383613">テキストの拡大と縮小</translation>
-<translation id="2394602618534698961">ダウンロードしたファイルがここに表示されます</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">この機能は Google アカウントにログインすると有効になります</translation>
-<translation id="2410754283952462441">アカウントの選択</translation>
-<translation id="2414886740292270097">暗</translation>
-<translation id="2416359993254398973">このサイトを利用するには、Chrome でカメラの使用を許可する必要があります。</translation>
-<translation id="2426805022920575512">別のアカウントを選択</translation>
-<translation id="2433507940547922241">デザイン</translation>
-<translation id="2434158240863470628">ダウンロードが完了しました<ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">位置情報へのアクセス</translation>
-<translation id="2450083983707403292"><ph name="FILE_NAME" /> のダウンロードをやり直してもよろしいですか？</translation>
-<translation id="2482878487686419369">通知</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> で管理</translation>
-<translation id="2494974097748878569">Chrome の Google アシスタント</translation>
-<translation id="2496180316473517155">閲覧履歴</translation>
-<translation id="2497852260688568942">同期は管理者により無効にされています</translation>
-<translation id="2498359688066513246">ヘルプとフィードバック</translation>
-<translation id="2501278716633472235">戻る</translation>
-<translation id="2513403576141822879">プライバシー、セキュリティ、データ収集に関連するその他の設定については、<ph name="BEGIN_LINK" />同期と Google サービス<ph name="END_LINK" />をご覧ください</translation>
-<translation id="2518590038762162553">ライトモードを使用すると、Chrome でページの読み込みが高速化され、データ使用量も最大 60% 抑えることができます。アクセスするページを最適化するため、ウェブ トラフィックが Chrome から Google に送信されます。<ph name="BEGIN_LINK" />詳細<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">アクセスしたページの URL を Google に送信します</translation>
-<translation id="2532336938189706096">ウェブ表示</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" />件の項目を削除しました</translation>
-<translation id="2536728043171574184">このページのオフライン コピーを表示しています</translation>
-<translation id="2546283357679194313">Cookie とサイトデータ</translation>
-<translation id="2567385386134582609">画像</translation>
-<translation id="257088987046510401">テーマ</translation>
-<translation id="2570922361219980984">位置情報へのアクセスがデバイスでもオフになっています。<ph name="BEGIN_LINK" />Android の設定<ph name="END_LINK" />でオンにしてください。</translation>
-<translation id="257931822824936280">展開されています - クリックすると折りたたまれます。</translation>
-<translation id="2581165646603367611">Chrome で重要度が低いと判断されるサイトの Cookie やキャッシュなどのデータを削除します。</translation>
-<translation id="2586657967955657006">クリップボード</translation>
-<translation id="2587052924345400782">新しいバージョンをご利用いただけます</translation>
-<translation id="2593272815202181319">等幅</translation>
-<translation id="2612676031748830579">カード番号</translation>
-<translation id="2621115761605608342">特定のサイトに対して JavaScript を許可します。</translation>
-<translation id="2625189173221582860">パスワードがコピーされました</translation>
-<translation id="2631006050119455616">削減量</translation>
-<translation id="2647434099613338025">言語の追加</translation>
-<translation id="2650751991977523696">ファイルをもう一度ダウンロードしますか？</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# 件の音声ファイル}other{# 件の音声ファイル}}</translation>
-<translation id="2653659639078652383">送信</translation>
-<translation id="2677748264148917807">このページを離れる</translation>
-<translation id="2704606927547763573">コピーしました</translation>
-<translation id="2707726405694321444">ページを更新</translation>
-<translation id="2709516037105925701">自動入力</translation>
-<translation id="2717722538473713889">メールアドレス</translation>
-<translation id="2728754400939377704">サイトで並べ替え</translation>
-<translation id="2744248271121720757">単語をタップすると、検索をすばやく実行したり、関連する操作メニューを確認したりできます</translation>
-<translation id="2760989362628427051">デバイスのダークテーマまたはバッテリー セーバーがオンのときにダークテーマをオンにする</translation>
-<translation id="2762000892062317888">たった今</translation>
-<translation id="2777555524387840389">残り <ph name="SECONDS" /> 秒</translation>
-<translation id="2779651927720337254">失敗</translation>
-<translation id="2781151931089541271">残り 1 秒</translation>
-<translation id="2801022321632964776">Chrome を更新し、最新バージョンでお使いの言語を入手してください</translation>
-<translation id="2810645512293415242">簡易版ページを使用してデータの保存と読み込みを高速化します。</translation>
-<translation id="281504910091592009"><ph name="BEGIN_LINK" />Google アカウント<ph name="END_LINK" />での保存パスワードの表示と管理</translation>
-<translation id="2818669890320396765">お使いのどのデバイスでも同じブックマークを使用するには、ログインして同期を有効にします</translation>
-<translation id="2822354292072154809">「<ph name="CHOSEN_OBJECT_NAME" />」に関するすべてのサイト権限をリセットしてもよろしいですか？</translation>
-<translation id="2836148919159985482">全画面表示を終了するには戻るボタンをタップします。</translation>
-<translation id="2842985007712546952">親フォルダ</translation>
-<translation id="2858138569776157458">上位のサイト</translation>
-<translation id="2860954141821109167">このデバイスで通話アプリが有効になっていることを確認してください</translation>
-<translation id="2870560284913253234">サイト</translation>
-<translation id="2874939134665556319">前のトラック</translation>
-<translation id="2876369937070532032">セキュリティ上のリスクがある場合に、アクセスした一部のページの URL が Google に送信されます</translation>
-<translation id="2888126860611144412">Chrome について</translation>
-<translation id="2891154217021530873">ページの読み込みを停止</translation>
-<translation id="2893180576842394309">検索やその他の Google サービスをカスタマイズするために、Google で履歴が使用されることがあります</translation>
-<translation id="2898264748040935573">保存したパスワードを編集します</translation>
-<translation id="2900528713135656174">予定を作成</translation>
-<translation id="290376772003165898"><ph name="LANGUAGE" />のページではない場合</translation>
-<translation id="2904414404539560095">タブを共有するデバイスのリストが画面全体に表示されました。</translation>
-<translation id="2910701580606108292">保護されたコンテンツの再生をサイトに許可する前に確認する</translation>
-<translation id="2913331724188855103">サイトに Cookie データの保存と読み取りを許可する（推奨）</translation>
-<translation id="2923908459366352541">名前が無効です</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> ストレージ</translation>
-<translation id="2942036813789421260">[プレビュー] タブは閉じられています</translation>
-<translation id="2956410042958133412">このアカウントは <ph name="PARENT_NAME_1" /> と <ph name="PARENT_NAME_2" /> によって管理されています。</translation>
-<translation id="2962095958535813455">シークレット タブに切り替えました</translation>
-<translation id="2968755619301702150">証明書ビューア</translation>
-<translation id="2979025552038692506">選択したシークレット タブ</translation>
-<translation id="2987620471460279764">他のデバイスからテキストが共有されました</translation>
-<translation id="2989523299700148168">最近のアクセス</translation>
-<translation id="2996291259634659425">パスフレーズの作成</translation>
-<translation id="2996809686854298943">URLが必要です</translation>
-<translation id="300526633675317032">ウェブサイトのストレージ <ph name="SIZE_IN_KB" /> のデータをすべて削除します。</translation>
-<translation id="3016635187733453316">このデバイスがインターネットに接続していることを確認してください</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB をダウンロード済み</translation>
-<translation id="3029704984691124060">パスフレーズが一致しません</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />ヘルプ<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">位置情報が OFF になっています。<ph name="BEGIN_LINK" />Android の設定<ph name="END_LINK" />で ON にしてください。</translation>
-<translation id="3058498974290601450">同期は設定でいつでもオンにできます。</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> 個のブックマーク}other{<ph name="BOOKMARKS_COUNT_MANY" /> 個のブックマーク}}</translation>
-<translation id="3089395242580810162">シークレット タブで開く</translation>
-<translation id="3115898365077584848">情報を表示</translation>
-<translation id="3123473560110926937">一部のサイトでブロックされています</translation>
-<translation id="3137521801621304719">シークレット モードを終了</translation>
-<translation id="3143515551205905069">同期をキャンセル</translation>
-<translation id="3157842584138209013">[その他のオプション] からデータ削減量を確認できます</translation>
-<translation id="3166827708714933426">タブとウィンドウのショートカット</translation>
-<translation id="3181954750937456830">セーフ ブラウジング（危険なサイトからユーザーとデバイスを保護します）</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android の設定<ph name="END_LINK" />で Chrome の権限を有効にしてください。</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> の保存データ</translation>
-<translation id="3205824638308738187">あと少しで完了です</translation>
-<translation id="3207960819495026254">ブックマークしました</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> を削除しました</translation>
-<translation id="321773570071367578">パスフレーズを忘れた場合や、この設定を変更する場合は、<ph name="BEGIN_LINK" />同期をリセット<ph name="END_LINK" />します</translation>
-<translation id="3227137524299004712">マイク</translation>
-<translation id="3232754137068452469">ウェブアプリ</translation>
-<translation id="3236059992281584593">残り 1 分</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">このページをブックマークに追加します</translation>
-<translation id="3259831549858767975">ページ上のすべての要素を縮小する</translation>
-<translation id="3269093882174072735">画像を読み込む</translation>
-<translation id="3269956123044984603">他のデバイスと同じタブを使用するには、Android のアカウント設定で [データの自動同期] を有効にします。</translation>
-<translation id="3277252321222022663">サイトによるセンサーへのアクセスを許可する（推奨）</translation>
-<translation id="3282568296779691940">Chrome にログイン</translation>
-<translation id="3288003805934695103">ページを再読み込みする</translation>
-<translation id="32895400574683172">通知が許可されています</translation>
-<translation id="3295530008794733555">高速ブラウジングで、データ使用量も抑えることができます。</translation>
-<translation id="3295602654194328831">情報を表示しない</translation>
-<translation id="3298243779924642547">軽量版</translation>
-<translation id="3303414029551471755">コンテンツのダウンロードに進みますか？</translation>
-<translation id="3306398118552023113">このアプリは Chrome で実行中です</translation>
-<translation id="3315103659806849044">[同期と Google サービス] の設定をカスタマイズしています。同期を有効にしたら、画面の下部にある [確認] をタップしてください。上へ移動</translation>
-<translation id="3328801116991980348">サイト情報</translation>
-<translation id="3333961966071413176">すべての連絡先</translation>
-<translation id="3334729583274622784">ファイル拡張子を変更しますか？</translation>
-<translation id="3341058695485821946">データ削減量を確認できます</translation>
-<translation id="3350687908700087792">すべてのシークレット タブを閉じます</translation>
-<translation id="3353615205017136254">Google から提供されている軽量版のページです。元のページを読み込むには [元のサイトを表示] をタップしてください。</translation>
-<translation id="3367813778245106622">同期を開始するにはもう一度ログインします</translation>
-<translation id="3374023511497244703">ブックマーク、履歴、パスワード、その他の Chrome データは、Google アカウントに同期されなくなります</translation>
-<translation id="3384347053049321195">画像を共有</translation>
-<translation id="3386292677130313581">サイトに現在地の認識を許可する前に確認する（推奨）</translation>
-<translation id="3387650086002190359">ファイル システムでエラーが発生したため、<ph name="FILE_NAME" /> をダウンロードできませんでした。</translation>
-<translation id="3389286852084373014">テキストが大きすぎます</translation>
-<translation id="3398320232533725830">ブックマーク マネージャを開く</translation>
-<translation id="3414952576877147120">サイズ:</translation>
-<translation id="3443221991560634068">現在のページを再読み込みする</translation>
-<translation id="3445014427084483498">たった今</translation>
-<translation id="3478363558367712427">検索エンジンを選択できます</translation>
+<translation id="6910211073230771657">削除済み</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK</translation>
+<translation id="7658239707568436148">キャンセル</translation>
 <translation id="3479552764303398839">後で</translation>
-<translation id="3492207499832628349">新しいシークレット タブ</translation>
-<translation id="3493531032208478708">詳しくは、<ph name="BEGIN_LINK" />おすすめのコンテンツ<ph name="END_LINK" />についての説明をご覧ください</translation>
-<translation id="3513704683820682405">拡張現実（AR）</translation>
-<translation id="3518985090088779359">同意して続行</translation>
-<translation id="3522247891732774234">アップデートが見つかりました。その他のオプション</translation>
-<translation id="3524138585025253783">デベロッパー管理画面</translation>
-<translation id="3527085408025491307">フォルダ</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB の空き</translation>
-<translation id="3549657413697417275">履歴を検索</translation>
-<translation id="3557336313807607643">連絡先に追加</translation>
-<translation id="3566923219790363270">Chrome はまだ VR の準備中です。しばらく待ってから Chrome を再起動してください。</translation>
-<translation id="3568688522516854065">他のデバイスと同じタブを使用するには、ログインして同期を有効にします</translation>
-<translation id="3587482841069643663">すべて</translation>
-<translation id="358794129225322306">複数ファイルの自動ダウンロードをサイトに許可します。</translation>
-<translation id="3590487821116122040">Chrome で重要度が低いと判断されるサイトのストレージ（設定を保存していないサイトやアクセス頻度の少ないサイトなど）</translation>
-<translation id="3599863153486145794">ログインしているすべてのデバイスの履歴を削除します。お使いの Google アカウントの <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> に、他の形式の閲覧履歴が記録されている場合があります。</translation>
-<translation id="3600792891314830896">音声が再生されるサイトをミュートする</translation>
-<translation id="3616113530831147358">音声</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> と共有しています</translation>
-<translation id="3632295766818638029">パスワードを表示</translation>
-<translation id="363596933471559332">保存されている認証情報を使用してウェブサイトに自動的にログインします。この機能がオフの場合は、ウェブサイトにログインするときに毎回確認を求められます。</translation>
-<translation id="3658159451045945436">リセットすると、アクセスしたサイトのリストなど、節約したデータの履歴が削除されます。</translation>
-<translation id="3692944402865947621">保存場所にアクセスできないため、<ph name="FILE_NAME" /> をダウンロードできませんでした。</translation>
-<translation id="3714981814255182093">検索バーを開く</translation>
-<translation id="3716182511346448902">このページは大量のメモリを使用しているため、Chrome により一時停止されました。</translation>
-<translation id="3730075448226062617">Chrome にマイクへのアクセスを許可するには、<ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />でもマイクをオンにしてください。</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> にブックマークしました</translation>
-<translation id="3744111561329211289">バックグラウンド同期</translation>
-<translation id="3771001275138982843">アップデートをダウンロードできませんでした</translation>
-<translation id="3771033907050503522">シークレットタブ</translation>
-<translation id="3773755127849930740">ペア設定するには <ph name="BEGIN_LINK" />Bluetooth をオン<ph name="END_LINK" />にしてください</translation>
-<translation id="3775705724665058594">お使いのデバイスに送信</translation>
-<translation id="3778956594442850293">ホーム画面に追加されました</translation>
-<translation id="3789841737615482174">インストール</translation>
-<translation id="3810838688059735925">動画</translation>
-<translation id="3810973564298564668">管理</translation>
-<translation id="381841723434055211">電話番号</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> 件のダウンロードを削除しました</translation>
-<translation id="3822502789641063741">サイトのストレージ データを削除しますか？</translation>
-<translation id="385051799172605136">戻る</translation>
-<translation id="3859306556332390985">前方にシーク再生</translation>
-<translation id="3894427358181296146">フォルダの追加</translation>
-<translation id="3895926599014793903">強制的にズームを有効にする</translation>
-<translation id="3912508018559818924">ウェブで最適なデータを探しています。</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">データを統合する</translation>
-<translation id="393697183122708255">有効な音声検索がありません</translation>
-<translation id="395206256282351086">検索とサイトの候補の表示が無効</translation>
-<translation id="3955193568934677022">保護されたコンテンツの再生をサイトに許可する（推奨）</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{準備ができると Chrome でページが読み込まれます}other{準備ができると Chrome でページが読み込まれます}}</translation>
-<translation id="3963007978381181125">パスフレーズ暗号化の対象に Google Pay のお支払い方法と住所は含まれません。パスフレーズを知っているユーザーだけが暗号化データを読み取ることができます。パスフレーズが Google に送信されたり Google で保存されたりすることはありません。パスフレーズを忘れた場合や、この設定を変更する場合は、同期をリセットする必要があります。<ph name="BEGIN_LINK" />詳細<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ダウンロード完了</translation>
-<translation id="397583555483684758">同期は停止されました</translation>
-<translation id="3976396876660209797">このショートカットを削除して再度作成します</translation>
-<translation id="3985215325736559418"><ph name="FILE_NAME" /> をもう一度ダウンロードしますか？</translation>
-<translation id="3987993985790029246">リンクのコピー</translation>
-<translation id="3988213473815854515">位置情報は許可</translation>
-<translation id="3988466920954086464">このパネルにインスタント検索の結果が表示されます</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ？</translation>
-<translation id="3997476611815694295">重要度の低いストレージ</translation>
-<translation id="4000212216660919741">オフライン ホーム</translation>
+<translation id="5317780077021120954">保存</translation>
+<translation id="4570913071927164677">詳細</translation>
+<translation id="8730621377337864115">完了</translation>
+<translation id="8261506727792406068">削除</translation>
+<translation id="1181037720776840403">削除</translation>
+<translation id="5939518447894949180">リセット</translation>
 <translation id="4002066346123236978">タイトル</translation>
-<translation id="4008040567710660924">特定のサイトの Cookie を許可します。</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# 時間}other{# 時間}}</translation>
-<translation id="4046123991198612571">次のトラック</translation>
-<translation id="4048707525896921369">ウェブサイト上のトピックについてページを移動せずに調べられます。「タップして検索」では、単語とその周囲のコンテキストが Google 検索に送信され、定義、画像、検索結果などの情報が返されます。
+<translation id="5916664084637901428">オン</translation>
+<translation id="5860033963881614850">オフ</translation>
+<translation id="6165508094623778733">詳細</translation>
+<translation id="6042308850641462728">もっと見る</translation>
+<translation id="6040143037577758943">閉じる</translation>
+<translation id="780301667611848630">いいえ</translation>
+<translation id="1201402288615127009">次へ</translation>
+<translation id="2359808026110333948">続行</translation>
+<translation id="2653659639078652383">送信</translation>
+<translation id="2079545284768500474">元に戻す</translation>
+<translation id="7649070708921625228">ヘルプ</translation>
+<translation id="2148716181193084225">今日</translation>
+<translation id="7781829728241885113">昨日</translation>
+<translation id="6945221475159498467">選択</translation>
+<translation id="7791543448312431591">追加</translation>
+<translation id="6527303717912515753">共有</translation>
+<translation id="1383876407941801731">検索</translation>
+<translation id="3115898365077584848">情報を表示</translation>
+<translation id="3295602654194328831">情報を表示しない</translation>
+<translation id="3987993985790029246">リンクのコピー</translation>
+<translation id="2704606927547763573">コピーしました</translation>
+<translation id="8725066075913043281">やり直し</translation>
+<translation id="385051799172605136">戻る</translation>
+<translation id="8131740175452115882">確認</translation>
+<translation id="5300589172476337783">表示</translation>
+<translation id="1124772482545689468">ユーザー</translation>
+<translation id="8609465669617005112">上に移動</translation>
+<translation id="6746124502594467657">下に移動</translation>
+<translation id="8249310407154411074">一番上に移動</translation>
+<translation id="8428213095426709021">設定</translation>
+<translation id="2498359688066513246">ヘルプとフィードバック</translation>
+<translation id="8378714024927312812">組織によって管理されています</translation>
+<translation id="9019902583201351841">保護者により管理されています</translation>
+<translation id="4645575059429386691">保護者により管理されています</translation>
+<translation id="4883854917563148705">管理者による設定はリセットできません</translation>
+<translation id="4307992518367153382">基本設定</translation>
+<translation id="1974060860693918893">詳細設定</translation>
+<translation id="1146678959555564648">VR を入力</translation>
+<translation id="987264212798334818">全般</translation>
+<translation id="4275663329226226506">メディア</translation>
+<translation id="4759238208242260848">ダウンロード</translation>
+<translation id="218608176142494674">共有</translation>
+<translation id="8004582292198964060">ブラウザ</translation>
+<translation id="1105960400813249514">画面キャプチャ</translation>
+<translation id="4875775213178255010">おすすめのコンテンツ</translation>
+<translation id="2021896219286479412">全画面表示時のサイトの操作項目</translation>
+<translation id="4587589328781138893">サイト</translation>
+<translation id="4943703118917034429">バーチャル リアリティ</translation>
+<translation id="1928696683969751773">更新</translation>
+<translation id="6064125863973209585">完了したダウンロード</translation>
+<translation id="5342314432463739672">権限のリクエスト</translation>
+<translation id="629730747756840877">アカウント</translation>
+<translation id="82609232232243542">Brave にログイン</translation>
+<translation id="7956662517480676674">同期と Brave Software サービス</translation>
+<translation id="5294439808117722387">[同期と Brave Software サービス] の設定をカスタマイズしています。同期を有効にしたら、画面の下部にある [確認] をタップしてください。上へ移動</translation>
+<translation id="2096012225669085171">デバイス間の同期とカスタマイズ</translation>
+<translation id="1692118695553449118">同期は有効です</translation>
+<translation id="5514904542973294328">このデバイスの管理者によって無効にされています</translation>
+<translation id="6447211988989208781">Brave Software アクティビティ管理</translation>
+<translation id="4882831918239250449">検索、広告などのカスタマイズを目的とした閲覧履歴の使用方法を設定</translation>
+<translation id="7431991332293347422">検索などのカスタマイズを目的とした閲覧履歴の使用方法を設定</translation>
+<translation id="6303969859164067831">ログアウトして同期をオフにする</translation>
+<translation id="1125261911132334651">Brave Software アカウントの管理</translation>
+<translation id="6406506848690869874">同期</translation>
+<translation id="714362445477979774">Brave データを同期</translation>
+<translation id="4314815835985389558">同期の管理</translation>
+<translation id="5428209950370661546">他の Brave Software サービス</translation>
+<translation id="7704317875155739195">検索語句や URL をオートコンプリートする</translation>
+<translation id="2000419248597011803">Cookie と、アドレスバーや検索ボックスに入力した検索語句を既定の検索エンジンに送信します</translation>
+<translation id="7981313251711023384">ページをプリロードして、閲覧と検索をすばやく行えるようにします</translation>
+<translation id="1821253160463689938">Cookie を使って設定を保存します（これらのページにアクセスしない場合も Cookie が保持されます）</translation>
+<translation id="6697492270171225480">ページが見つからない場合に類似のページを候補として表示する</translation>
+<translation id="8109318360573330108">アクセスしようとしているページの URL を Brave Software に送信します</translation>
+<translation id="8438566539970814960">検索とブラウジングを改善する</translation>
+<translation id="284843628681142937">アクセスしたページの URL を Brave Software に送信します</translation>
+<translation id="7222718784508482526">プライバシー、セキュリティ、データ収集に関連するその他の設定については、<ph name="BEGIN_LINK"/>同期と Brave Software サービス<ph name="END_LINK"/>をご覧ください</translation>
+<translation id="918192811481327695">Brave の機能と動作の改善に協力する</translation>
+<translation id="9063160602596686558">使用統計情報や障害レポートを Brave Software に自動送信します</translation>
+<translation id="4824958205181053313">同期をキャンセルしますか？</translation>
+<translation id="3058498974290601450">同期は設定でいつでもオンにできます。</translation>
+<translation id="3143515551205905069">同期をキャンセル</translation>
+<translation id="1506061864768559482">検索エンジン</translation>
+<translation id="55737423895878184">位置情報の使用と通知の送信が許可されています</translation>
+<translation id="3988213473815854515">位置情報は許可</translation>
+<translation id="32895400574683172">通知が許可されています</translation>
+<translation id="9040142327097499898">通知が許可されていますが、位置情報がデバイスでオフになっています。</translation>
+<translation id="305593374596241526">位置情報が OFF になっています。<ph name="BEGIN_LINK"/>Android の設定<ph name="END_LINK"/>で ON にしてください。</translation>
+<translation id="2989523299700148168">最近のアクセス</translation>
+<translation id="6433501201775827830">検索エンジンを選択</translation>
+<translation id="7177466738963138057">これは後から [設定] で変更できます</translation>
+<translation id="3478363558367712427">検索エンジンを選択できます</translation>
+<translation id="4910889077668685004">お支払いアプリ</translation>
+<translation id="5152843274749979095">サポートされているアプリがインストールされていません</translation>
+<translation id="8812260976093120287">一部のウェブサイトでは、デバイスでサポートされている上記のお支払いアプリを使って支払いができます。</translation>
+<translation id="7764225426217299476">住所を追加</translation>
+<translation id="5595485650161345191">住所の編集</translation>
+<translation id="5087580092889165836">カードを追加</translation>
+<translation id="2154484045852737596">カードを編集</translation>
+<translation id="6140912465461743537">国 / 地域</translation>
+<translation id="5659593005791499971">メール</translation>
+<translation id="4378154925671717803">電話</translation>
+<translation id="4807098396393229769">カード名義人（半角英文字）</translation>
+<translation id="860043288473659153">カード名義人</translation>
+<translation id="2612676031748830579">カード番号</translation>
+<translation id="869891660844655955">有効期限</translation>
+<translation id="2286841657746966508">請求先住所</translation>
+<translation id="663059986967017181">Brave にコピー済み</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> 件}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> 件}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> 件}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> 件}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> 件}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> 件}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> 件}other{<ph name="CONTACT_PREVIEW"/>\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> 件}}</translation>
+<translation id="7029809446516969842">パスワード</translation>
+<translation id="1943432128510653496">パスワードの保存</translation>
+<translation id="2100273922101894616">自動ログイン</translation>
+<translation id="363596933471559332">保存されている認証情報を使用してウェブサイトに自動的にログインします。この機能がオフの場合は、ウェブサイトにログインするときに毎回確認を求められます。</translation>
+<translation id="6995899638241819463">データ侵害によりパスワードが漏洩した場合に警告する</translation>
+<translation id="1534287762301776620">この機能は Brave Software アカウントにログインすると有効になります</translation>
+<translation id="10614374240317010">常に保存しない</translation>
+<translation id="3098842761938485917"><ph name="BEGIN_LINK"/>Brave Software アカウント<ph name="END_LINK"/>での保存パスワードの表示と管理</translation>
+<translation id="8562452229998620586">保存したパスワードはこちらに表示されます。</translation>
+<translation id="8084114998886531721">保存したパスワード</translation>
+<translation id="2870560284913253234">サイト</translation>
+<translation id="8503813439785031346">ユーザー名</translation>
+<translation id="6657585470893396449">パスワード</translation>
+<translation id="2154710561487035718">URL をコピー</translation>
+<translation id="1571304935088121812">ユーザー名をコピー</translation>
+<translation id="5005498671520578047">パスワードのコピー</translation>
+<translation id="3632295766818638029">パスワードを表示</translation>
+<translation id="1513858653616922153">パスワードを削除</translation>
+<translation id="543338862236136125">パスワードを編集</translation>
+<translation id="4565377596337484307">パスワードを表示しない</translation>
+<translation id="8523928698583292556">保存したパスワードを削除</translation>
+<translation id="2898264748040935573">保存したパスワードを編集します</translation>
+<translation id="5433691172869980887">ユーザー名がコピーされました</translation>
+<translation id="5534640966246046842">サイトがコピーされました</translation>
+<translation id="2625189173221582860">パスワードがコピーされました</translation>
+<translation id="4550003330909367850">ここでパスワードを表示またはコピーするには、このデバイスに画面ロックを設定してください。</translation>
+<translation id="6154478581116148741">このデバイスからパスワードをエクスポートするには、[設定] で画面ロックをオンにしてください。</translation>
+<translation id="4842092870884894799">パスワード作成のポップアップを表示しています</translation>
+<translation id="2259659629660284697">パスワードをエクスポート…</translation>
+<translation id="133012818630824069">Brave に保存されたパスワードをエクスポートします</translation>
+<translation id="6914783257214138813">エクスポートしたファイルを閲覧できるユーザーにパスワードを知られてしまう可能性があります。</translation>
+<translation id="2321086116217818302">パスワードを準備しています…</translation>
+<translation id="8445448999790540984">パスワードをエクスポートできません</translation>
+<translation id="3066461326500799725">Brave Software ドライブの使い方を見る</translation>
+<translation id="729975465115245577">お使いのデバイスにはパスワード ファイルを保存するためのアプリがインストールされていません。</translation>
+<translation id="7682724950699840886">推奨される対策: デバイスに十分な空き容量があることを確認し、再度エクスポートを試します。</translation>
+<translation id="1129510026454351943">詳細: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">パスワードをコピーするにはロックを解除してください</translation>
+<translation id="5515439363601853141">パスワードを表示するにはロックを解除してください</translation>
+<translation id="6221633008163990886">ロックを解除してパスワードをエクスポート</translation>
+<translation id="230699814587342492">Brave パスワード</translation>
+<translation id="6075798973483050474">ホームページの編集</translation>
+<translation id="854522910157234410">このページを開く</translation>
+<translation id="2482878487686419369">通知</translation>
+<translation id="6255999984061454636">おすすめのコンテンツ</translation>
+<translation id="805047784848435650">閲覧履歴から</translation>
+<translation id="1041308826830691739">ウェブサイトから</translation>
+<translation id="395206256282351086">検索とサイトの候補の表示が無効</translation>
+<translation id="257088987046510401">テーマ</translation>
+<translation id="4650364565596261010">システムのデフォルト</translation>
+<translation id="7588219262685291874">デバイスがバッテリー セーバー モードの場合にダークテーマを有効にする</translation>
+<translation id="2760989362628427051">デバイスのダークテーマまたはバッテリー セーバーがオンのときにダークテーマをオンにする</translation>
+<translation id="6381421346744604172">ウェブサイトを暗くする</translation>
+<translation id="5040262127954254034">プライバシー</translation>
+<translation id="4991384657077828949">Brave のセキュリティ改善に協力する</translation>
+<translation id="1943176487615318915">危険なアプリやサイトを検出するために、アクセスした一部のページの URL と限定的なシステム情報、一部のページ コンテンツが Brave から Brave Software に送信されます</translation>
+<translation id="3181954750937456830">セーフ ブラウジング（危険なサイトからユーザーとデバイスを保護します）</translation>
+<translation id="7315322926489145388">セキュリティ上のリスクがある場合に、アクセスした一部のページの URL が Brave Software に送信されます</translation>
+<translation id="2063713494490388661">タップして検索</translation>
+<translation id="2369463299479365221">ウェブサイト上のトピックについてページを移動せずに調べられます。「タップして検索」では、単語とその周囲のコンテキストが Brave Software 検索に送信され、定義、画像、検索結果などの情報が返されます。
 
 検索用語を長押しするとその用語が選択され、選択範囲を調整できます。検索結果を絞り込むには、パネルを上にスライドして検索ボックスをタップします。</translation>
-<translation id="4056223980640387499">セピア</translation>
-<translation id="4060598801229743805">画面の上部にあるオプション</translation>
-<translation id="4062305924942672200">法的情報</translation>
-<translation id="4084682180776658562">ブックマーク</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" /> のコンテンツ - <ph name="BEGIN_DEEMPHASIZED" />Google により配信<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">アプリデータを削除しますか？</translation>
-<translation id="4099578267706723511">使用統計情報と障害レポートを Google に送信して、Chrome の品質向上にご協力ください。</translation>
-<translation id="410351446219883937">自動再生</translation>
-<translation id="4116038641877404294">ページをダウンロードするとオフラインで使用できるようになります</translation>
-<translation id="4135200667068010335">タブを共有するデバイスのリストが閉じられました。</translation>
-<translation id="4149994727733219643">ウェブページの簡易表示</translation>
-<translation id="4165986682804962316">サイトの設定</translation>
-<translation id="4169535189173047238">許可しない</translation>
-<translation id="4170011742729630528">このサービスはご利用になれません。しばらくしてからもう一度お試しください。</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> 使用</translation>
-<translation id="4181841719683918333">言語</translation>
-<translation id="4183868528246477015">Google レンズで検索<ph name="BEGIN_NEW" />New<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">新しいタブで開く</translation>
-<translation id="4198423547019359126">ダウンロードの保存先はありません</translation>
-<translation id="4209895695669353772">ユーザーに合わせた Google からのおすすめコンテンツを表示するには、同期を有効にします</translation>
-<translation id="4226663524361240545">通知を受け取るとデバイスが振動します</translation>
-<translation id="423219824432660969"><ph name="TIME" />時点の Google パスワードで同期データを暗号化する</translation>
-<translation id="4242533952199664413">設定を開く</translation>
-<translation id="4256782883801055595">オープンソース ライセンス</translation>
-<translation id="4259722352634471385"><ph name="URL" /> へのアクセスがブロックされました</translation>
-<translation id="4269820728363426813">リンクアドレスをコピー</translation>
-<translation id="4275663329226226506">メディア</translation>
-<translation id="4278390842282768270">許可</translation>
-<translation id="429312253194641664">サイトでメディアが再生されています</translation>
-<translation id="4298388696830689168">リンク済みのサイト</translation>
-<translation id="4307992518367153382">基本設定</translation>
-<translation id="4314815835985389558">同期の管理</translation>
-<translation id="4351244548802238354">ダイアログを閉じる</translation>
-<translation id="4378154925671717803">電話</translation>
-<translation id="4384468725000734951">検索に Sogou を使用します</translation>
-<translation id="4404568932422911380">ブックマークがありません</translation>
-<translation id="4405224443901389797">移動…</translation>
-<translation id="4411535500181276704">ライトモード</translation>
-<translation id="4415276339145661267">Google アカウントの管理</translation>
-<translation id="4432792777822557199">今後、<ph name="SOURCE_LANGUAGE" />のページは<ph name="TARGET_LANGUAGE" />に翻訳されます</translation>
-<translation id="4433925000917964731">Google から提供されている軽量版のページ</translation>
-<translation id="4434045419905280838">ポップアップとリダイレクト</translation>
-<translation id="4440958355523780886">Google から提供されている軽量版のページです。元のページを読み込むにはタップしてください。</translation>
-<translation id="4452411734226507615">「<ph name="TAB_TITLE" />」タブを閉じます</translation>
-<translation id="4452548195519783679">「<ph name="FOLDER_NAME" />」にブックマークしました</translation>
-<translation id="445467742685312942">保護されたコンテンツの再生をサイトに許可する</translation>
-<translation id="4468959413250150279">特定のサイトの音声をミュートします。</translation>
-<translation id="4472118726404937099">複数のデバイスで独自の設定を同期して共有するには、ログインして同期を有効にします</translation>
-<translation id="447252321002412580">Chrome の機能と動作の改善に協力する</translation>
-<translation id="4479647676395637221">サイトにカメラの使用を許可する前に確認する（推奨）</translation>
-<translation id="4479972344484327217">Chrome 用の <ph name="MODULE" /> をインストールしています…</translation>
-<translation id="4487967297491345095">Chrome のすべてのアプリデータを完全に削除します。削除されるデータには、すべてのファイル、設定、アカウント、データベースなどが含まれます。</translation>
-<translation id="4493497663118223949">ライトモードはオンです</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# 日前}other{# 日前}}</translation>
-<translation id="451872707440238414">ブックマークを検索</translation>
-<translation id="4521489764227272523">選択したデータが Chrome から削除され、同期デバイスからも削除されました。
-
-他の Google サービスでの検索や操作など、Google アカウントの他の形式の閲覧履歴が <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> に残ることがあります。</translation>
-<translation id="4532845899244822526">フォルダの選択</translation>
-<translation id="4538018662093857852">ライトモードをオンにする</translation>
-<translation id="4550003330909367850">ここでパスワードを表示またはコピーするには、このデバイスに画面ロックを設定してください。</translation>
-<translation id="4558311620361989323">ウェブページのショートカット</translation>
-<translation id="4561979708150884304">接続されていません</translation>
-<translation id="4565377596337484307">パスワードを表示しない</translation>
-<translation id="4570913071927164677">詳細</translation>
-<translation id="4572422548854449519">管理対象アカウントにログイン</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# 分前}other{# 分前}}</translation>
-<translation id="4587589328781138893">サイト</translation>
-<translation id="4594952190837476234">このオフライン ページは <ph name="CREATION_TIME" /> 時点のものであり、オンライン版とは異なる可能性があります。</translation>
-<translation id="4605958867780575332">削除したアイテム: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> を起動</translation>
-<translation id="4634124774493850572">パスワードを使用</translation>
-<translation id="4645575059429386691">保護者により管理されています</translation>
-<translation id="4650364565596261010">システムのデフォルト</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> 件のブックマークを削除しました</translation>
-<translation id="4665282149850138822">「<ph name="NAME" />」がホーム画面に追加されました</translation>
-<translation id="4684427112815847243">すべてを同期する</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> 件}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> 件}}</translation>
-<translation id="4696983787092045100">デバイスにテキストを送信</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> でオフライン表示</translation>
-<translation id="4699172675775169585">キャッシュされた画像とファイル</translation>
-<translation id="4714588616299687897">データを最大 60% 削減できます</translation>
-<translation id="4719927025381752090">翻訳するか尋ねる</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" /> で開く</translation>
-<translation id="4720982865791209136">Chrome の品質向上にご協力ください。<ph name="BEGIN_LINK" />アンケートに回答する<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">更新</translation>
-<translation id="4738836084190194332">最終同期: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">新しいタブを開く</translation>
-<translation id="4751476147751820511">モーション センサーまたは光センサー</translation>
-<translation id="4759238208242260848">ダウンロード</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 件のダウンロードが完了しました。}other{# 件のダウンロードが完了しました。}}</translation>
-<translation id="4797039098279997504">タップすると <ph name="URL_OF_THE_CURRENT_TAB" /> に戻ります</translation>
-<translation id="4802417911091824046">パスフレーズ暗号化の対象に Google Pay のお支払い方法と住所は含まれません。
-
-この設定を変更する場合は<ph name="BEGIN_LINK" />同期をリセット<ph name="END_LINK" />してください</translation>
-<translation id="4807098396393229769">カード名義人（半角英文字）</translation>
-<translation id="4824958205181053313">同期をキャンセルしますか？</translation>
-<translation id="4837753911714442426">ページの印刷オプションを開く</translation>
-<translation id="4842092870884894799">パスワード作成のポップアップを表示しています</translation>
-<translation id="4860895144060829044">通話</translation>
-<translation id="4866368707455379617">Chrome 用の <ph name="MODULE" /> をインストールできません</translation>
-<translation id="4875775213178255010">おすすめのコンテンツ</translation>
-<translation id="4878404682131129617">プロキシ サーバー経由のトンネルを確立できませんでした</translation>
-<translation id="4880127995492972015">翻訳…</translation>
-<translation id="4881695831933465202">開く</translation>
-<translation id="488187801263602086">ファイル名を変更してください</translation>
-<translation id="4882831918239250449">検索、広告などのカスタマイズを目的とした閲覧履歴の使用方法を設定</translation>
-<translation id="4883854917563148705">管理者による設定はリセットできません</translation>
-<translation id="4885273946141277891">Chrome のインスタンス数の上限を超えています。</translation>
-<translation id="4910889077668685004">お支払いアプリ</translation>
-<translation id="4913161338056004800">統計情報をリセット</translation>
-<translation id="4913169188695071480">更新を停止</translation>
-<translation id="4915549754973153784">デバイスのスキャン中… <ph name="BEGIN_LINK" />ヘルプ<ph name="END_LINK" /></translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# ページ}other{# ページ}}</translation>
-<translation id="4932247056774066048"><ph name="DOMAIN_NAME" /> で管理されているアカウントからログアウトするにあたり、Chrome データはこのデバイスから削除されます。Google アカウントからはデータは削除されません。</translation>
-<translation id="4943703118917034429">バーチャル リアリティ</translation>
-<translation id="4943872375798546930">結果はありません</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> が画面を共有しています</translation>
-<translation id="4961107849584082341">このページを任意の言語に翻訳できます</translation>
-<translation id="4962975101802056554">デバイスのすべての権限を取り消します</translation>
-<translation id="4970824347203572753">お住まいの地域ではご利用になれません</translation>
-<translation id="497421865427891073">次に進む</translation>
-<translation id="4988210275050210843">ファイルをダウンロードしています（<ph name="MEGABYTES" />）。</translation>
-<translation id="4988526792673242964">ページ</translation>
-<translation id="4994033804516042629">連絡先が見つかりませんでした</translation>
-<translation id="4996978546172906250">共有方法</translation>
-<translation id="5004416275253351869">Google アクティビティ管理</translation>
-<translation id="5005498671520578047">パスワードのコピー</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> が接続を要求しています</translation>
-<translation id="5013696553129441713">新しいおすすめ記事はありません</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">VR の使用中、このサイトで次の情報が把握される場合があります。
-  -  あなたの身体的特徴（身長など）
-
-VR を開始する前に、信頼できるサイトかどうかを確認してください。</translation>
+<translation id="2930742481329940825">「タップして検索」では選択した単語と現在のページがコンテキストとして Brave Software 検索に送信されます。これは [<ph name="BEGIN_LINK"/>設定<ph name="END_LINK"/>] で無効にすることができます。</translation>
 <translation id="5039804452771397117">許可</translation>
-<translation id="5040262127954254034">プライバシー</translation>
-<translation id="5048398596102334565">サイトによるモーション センサーへのアクセスを許可する（推奨）</translation>
-<translation id="5063480226653192405">使用状況</translation>
-<translation id="5087580092889165836">カードを追加</translation>
-<translation id="5100237604440890931">折りたたまれています - クリックすると展開します。</translation>
-<translation id="510275257476243843">残り 1 時間</translation>
-<translation id="5123685120097942451">シークレット タブ</translation>
-<translation id="5127805178023152808">同期は無効です</translation>
-<translation id="5129038482087801250">ウェブアプリをインストール</translation>
-<translation id="5132942445612118989">すべてのデバイスでパスワード、履歴、その他の設定を同期する</translation>
-<translation id="5139940364318403933">Google ドライブの使い方を見る</translation>
-<translation id="515227803646670480">保存したデータの削除</translation>
-<translation id="5152843274749979095">サポートされているアプリがインストールされていません</translation>
-<translation id="5161254044473106830">タイトルが必要です</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 件のダウンロードが失敗しました。}other{# 件のダウンロードが失敗しました。}}</translation>
-<translation id="5170568018924773124">フォルダを開く</translation>
-<translation id="5184329579814168207">Chromeで開く</translation>
-<translation id="5193988420012215838">クリップボードにコピーされました</translation>
-<translation id="5197729504361054390">選択した連絡先が <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> と共有されます。</translation>
-<translation id="5199929503336119739">仕事用プロファイル</translation>
-<translation id="5210286577605176222">前のタブに移動する</translation>
-<translation id="5210365745912300556">タブを閉じる</translation>
-<translation id="5224771365102442243">動画あり</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> が近くの Bluetooth デバイスのスキャンを求めています。検出済みのデバイスは次のとおりです。</translation>
-<translation id="5233638681132016545">新しいタブ</translation>
-<translation id="526421993248218238">ページを読み込めません</translation>
-<translation id="5271967389191913893">デバイスでダウンロード コンテンツを開くことができません。</translation>
-<translation id="528192093759286357">全画面表示を終了するには、上からドラッグして、戻るボタンをタップします。</translation>
-<translation id="5292796745632149097">送信先</translation>
-<translation id="5300589172476337783">表示</translation>
-<translation id="5301954838959518834">OK</translation>
-<translation id="5304593522240415983">この項目は必須です</translation>
-<translation id="5307446750509046227">サイトのストレージをクリア</translation>
-<translation id="5308380583665731573">接続</translation>
-<translation id="5313967007315987356">サイトを追加</translation>
-<translation id="5317780077021120954">保存</translation>
-<translation id="5324858694974489420">保護者設定</translation>
-<translation id="5327248766486351172">名前</translation>
-<translation id="5335288049665977812">サイトに Javascript の実行を許可する（推奨）</translation>
-<translation id="5342314432463739672">権限のリクエスト</translation>
-<translation id="5357811892247919462">タブが共有されました</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> 個のタブが開いています。タブを切り替えるにはタップします}other{<ph name="OPEN_TABS_MANY" /> 個のタブが開いています。タブを切り替えるにはタップします}}</translation>
-<translation id="5391532827096253100">このサイトへの接続は保護されていません。サイト情報</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{（他 1 件）}other{（他 # 件）}}</translation>
-<translation id="5400569084694353794">このアプリケーションを使用すると、Chrome の<ph name="BEGIN_LINK1" />利用規約<ph name="END_LINK1" />と<ph name="BEGIN_LINK2" />プライバシーに関するお知らせ<ph name="END_LINK2" />に同意したことになります。</translation>
-<translation id="5403592356182871684">名前</translation>
-<translation id="5403644198645076998">特定のサイトのみを許可</translation>
-<translation id="5414836363063783498">確認しています…</translation>
-<translation id="5423934151118863508">最もアクセスの多かったページがここに表示されます</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB 使用可能</translation>
-<translation id="543338862236136125">パスワードを編集</translation>
-<translation id="5433691172869980887">ユーザー名がコピーされました</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> 件のファイルをダウンロードしています（<ph name="MEGABYTES" />）。</translation>
-<translation id="5441522332038954058">アドレスバーに移動する</translation>
-<translation id="5447201525962359567">すべてのサイトのストレージ（Cookie やローカルに保存した他のデータを含む）</translation>
-<translation id="5447765697759493033">このサイトは翻訳されません</translation>
-<translation id="545042621069398927">ダウンロード速度が向上しました。</translation>
-<translation id="5456381639095306749">ページをダウンロード</translation>
-<translation id="5475862044948910901">拡張現実セッションを開始しますか？</translation>
-<translation id="548278423535722844">マップアプリで開く</translation>
-<translation id="5487521232677179737">データを削除</translation>
-<translation id="5494752089476963479">煩わしい広告や誤解を招く広告が表示されるサイトで広告をブロックする</translation>
-<translation id="5500777121964041360">お住まいの地域ではご利用になれない可能性があります</translation>
-<translation id="5512137114520586844">このアカウントは <ph name="PARENT_NAME" /> によって管理されています。</translation>
-<translation id="5514904542973294328">このデバイスの管理者によって無効にされています</translation>
-<translation id="5515439363601853141">パスワードを表示するにはロックを解除してください</translation>
-<translation id="5516455585884385570">通知設定を開く</translation>
-<translation id="5517095782334947753"><ph name="FROM_ACCOUNT" /> のブックマーク、履歴、パスワードとその他の設定を使用できます。</translation>
-<translation id="5524843473235508879">リダイレクトがブロックされました。</translation>
-<translation id="5527082711130173040">Chrome ではデバイスをスキャンするために現在地情報にアクセスする必要があります。<ph name="BEGIN_LINK1" />権限を更新<ph name="END_LINK1" />してください。また、現在地情報へのアクセスが<ph name="BEGIN_LINK2" />このデバイスでオフになっています<ph name="END_LINK2" />。</translation>
-<translation id="5527111080432883924">サイトがクリップボードのテキストや画像を読み取る前に確認する（推奨）</translation>
-<translation id="5530766185686772672">シークレットタブを閉じる</translation>
-<translation id="5534334044554683961">VR の使用中、このサイトで次の情報が把握される場合があります。
-  -   あなたの身体的特徴（身長など）
-  -   あなたの部屋のレイアウト
-
-VR を開始する前に、信頼できるサイトかどうかを確認してください。</translation>
-<translation id="5534640966246046842">サイトがコピーされました</translation>
-<translation id="5556459405103347317">再読み込み</translation>
-<translation id="5561549206367097665">ネットワーク接続を待機しています…</translation>
-<translation id="557283862590186398">このサイトを利用するには、Chrome でマイクの使用を許可する必要があります。</translation>
-<translation id="55737423895878184">位置情報の使用と通知の送信が許可されています</translation>
-<translation id="5578795271662203820">この画像を <ph name="SEARCH_ENGINE" /> で検索</translation>
-<translation id="5581519193887989363">同期する項目はいつでも [<ph name="BEGIN_LINK1" />設定<ph name="END_LINK1" />] で選択できます。</translation>
-<translation id="5595485650161345191">住所の編集</translation>
-<translation id="5596627076506792578">その他のオプション</translation>
-<translation id="5599455543593328020">シークレット モード</translation>
-<translation id="5620928963363755975">[その他のオプション] から [ダウンロード] を開いて自分のファイルやページを探すことができます</translation>
-<translation id="5626134646977739690">名前:</translation>
-<translation id="5639724618331995626">すべてのサイトを許可</translation>
-<translation id="5648166631817621825">過去 7 日間</translation>
-<translation id="5649053991847567735">自動ダウンロード</translation>
-<translation id="5655963694829536461">ダウンロードしたアイテムを検索</translation>
-<translation id="5659593005791499971">メール</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> で予定を作成</translation>
-<translation id="5668404140385795438">ウェブサイトのズーム防止リクエストを上書きします</translation>
-<translation id="5677928146339483299">ブロック中</translation>
-<translation id="5684874026226664614">このページを翻訳できませんでした。</translation>
-<translation id="5686790454216892815">ファイル名が長すぎます</translation>
-<translation id="5689516760719285838">位置情報</translation>
-<translation id="569536719314091526">[その他のオプション] から、このページを任意の言語に翻訳できます</translation>
-<translation id="572328651809341494">最近使ったタブ</translation>
-<translation id="5726692708398506830">ページ上のすべての要素を拡大する</translation>
-<translation id="5748802427693696783">標準のタブに切り替えました</translation>
-<translation id="5749068826913805084">Chrome でファイルをダウンロードするにはストレージへのアクセス権が必要です。</translation>
-<translation id="5763382633136178763">シークレット タブ</translation>
-<translation id="5763514718066511291">タップすると、このアプリの URL がコピーされます</translation>
-<translation id="5765780083710877561">説明:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" /> 中 <ph name="SPACE_USED" /> を使用中</translation>
-<translation id="5797070761912323120">検索、広告、その他の Google サービスをカスタマイズするために、Google で履歴が使用されることがあります</translation>
-<translation id="5804241973901381774">権限</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# 時間前}other{# 時間前}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. All rights reserved.</translation>
-<translation id="5817918615728894473">ペア設定</translation>
-<translation id="583281660410589416">不明</translation>
-<translation id="5833984609253377421">リンクを共有</translation>
-<translation id="5836192821815272682">Chrome のアップデートをダウンロードしています…</translation>
-<translation id="5853623416121554550">一時停止中</translation>
-<translation id="5854790677617711513">30 日以上経過</translation>
-<translation id="5858741533101922242">Chrome から Bluetooth アダプタをオンにできません</translation>
-<translation id="5860033963881614850">オフ</translation>
-<translation id="5862731021271217234">他のデバイスと同じタブを使用するには、同期を有効にします</translation>
-<translation id="5864174910718532887">詳細: サイト名の順</translation>
-<translation id="5864419784173784555">別のダウンロードの完了待ちです…</translation>
-<translation id="5865733239029070421">使用統計情報や障害レポートを Google に自動送信します</translation>
-<translation id="5869522115854928033">保存したパスワード</translation>
-<translation id="5902828464777634901">このウェブサイトで保存したすべてのローカルデータ（Cookie を含む）を削除します。</translation>
-<translation id="5916664084637901428">オン</translation>
-<translation id="5919204609460789179">同期を開始するには <ph name="PRODUCT_NAME" /> を更新してください</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> 節約</translation>
-<translation id="5939518447894949180">リセット</translation>
-<translation id="5942872142862698679">検索に Google を使用します</translation>
-<translation id="5952764234151283551">アクセスしようとしているページの URL を Google に送信します</translation>
-<translation id="5956665950594638604">Chrome ヘルプセンターを新しいタブで開く</translation>
-<translation id="5958275228015807058">[ダウンロード] で自分のファイルやページを探すことができます</translation>
-<translation id="5962718611393537961">タップして折りたたむ</translation>
-<translation id="6000066717592683814">Google のままにする</translation>
-<translation id="6005538289190791541">推奨パスワード</translation>
-<translation id="6036057147555329831">その他の ICU</translation>
-<translation id="6039379616847168523">次のタブに移動する</translation>
-<translation id="6040143037577758943">閉じる</translation>
-<translation id="6042308850641462728">もっと見る</translation>
-<translation id="604996488070107836">不明なエラーが発生したため、<ph name="FILE_NAME" /> をダウンロードできませんでした。</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">完了したダウンロード</translation>
-<translation id="6075798973483050474">ホームページの編集</translation>
-<translation id="60923314841986378">残り <ph name="HOURS" /> 時間</translation>
-<translation id="6108923351542677676">設定しています...</translation>
-<translation id="6111020039983847643">データ使用量</translation>
-<translation id="6112702117600201073">ページを更新しています</translation>
-<translation id="6127379762771434464">アイテムを削除しました</translation>
-<translation id="6140912465461743537">国 / 地域</translation>
-<translation id="614940544461990577">次をお試しください</translation>
-<translation id="6154478581116148741">このデバイスからパスワードをエクスポートするには、[設定] で画面ロックをオンにしてください。</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> のデータを削減</translation>
-<translation id="6165508094623778733">詳細</translation>
-<translation id="6177111841848151710">現在の検索エンジンに対してはブロック</translation>
-<translation id="6181444274883918285">サイトの例外を追加</translation>
-<translation id="6192333916571137726">ダウンロード ファイル</translation>
-<translation id="6192792657125177640">例外</translation>
-<translation id="6194112207524046168">Chrome にカメラへのアクセスを許可するには、<ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />でもカメラをオンにしてください。</translation>
-<translation id="6196640612572343990">サードパーティの Cookie をブロックする</translation>
-<translation id="6206551242102657620">接続は保護されています。サイト情報</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> ではありませんか？</translation>
-<translation id="6221633008163990886">ロックを解除してパスワードをエクスポート</translation>
+<translation id="1406000523432664303">「トラッキング拒否」</translation>
 <translation id="6232535412751077445">「トラッキング拒否」を有効にすると、リクエストが閲覧トラフィックに含まれるようになります。ウェブサイトがリクエストに応答するかどうか、またリクエストがどのように解釈されるかによって、この影響は異なります。
 
 たとえば一部のウェブサイトでは、このリクエストに対して、ユーザーが過去にアクセスしたウェブサイトとは関係のない広告が表示されます。トラッキングを拒否しても、実際のところ多くのウェブサイトではユーザーの閲覧データが収集され利用されています。その用途としては、セキュリティの強化や、コンテンツ、サービス、広告、おすすめの表示、レポート統計情報の作成などが挙げられます。</translation>
-<translation id="624789221780392884">アップデート準備完了</translation>
-<translation id="6255999984061454636">おすすめのコンテンツ</translation>
-<translation id="6277522088822131679">ページの印刷中に問題が発生しました。もう一度お試しください。</translation>
-<translation id="6295158916970320988">すべてのサイト</translation>
-<translation id="629730747756840877">アカウント</translation>
-<translation id="6303969859164067831">ログアウトして同期をオフにする</translation>
-<translation id="6316139424528454185">Android のバージョンはサポートされていません</translation>
-<translation id="6320088164292336938">バイブレーション</translation>
-<translation id="6324034347079777476">Android システムの同期が無効です</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> で共有します</translation>
-<translation id="6337234675334993532">暗号化</translation>
-<translation id="6341580099087024258">ファイルの保存場所を確認する</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> 件}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> 件}}</translation>
-<translation id="6364438453358674297">履歴から候補を削除しますか？</translation>
-<translation id="6369229450655021117">ここからウェブを検索したり、友だちと共有したり、開いたページを表示したりできます</translation>
-<translation id="6378173571450987352">詳細: データ使用量の順</translation>
-<translation id="6381421346744604172">ウェブサイトを暗くする</translation>
-<translation id="6388207532828177975">データを削除してリセット</translation>
-<translation id="6393863479814692971">このサイトを利用するには、Chrome でカメラとマイクの使用を許可する必要があります。</translation>
-<translation id="6395288395575013217">リンク</translation>
-<translation id="6404511346730675251">ブックマークを編集</translation>
-<translation id="6406506848690869874">同期</translation>
-<translation id="641643625718530986">印刷...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB をダウンロード済み</translation>
-<translation id="6427112570124116297">ウェブの翻訳</translation>
-<translation id="6433501201775827830">検索エンジンを選択</translation>
-<translation id="6437478888915024427">ページ情報</translation>
-<translation id="6441734959916820584">名前が長すぎます</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# 個の画像}other{# 個の画像}}</translation>
-<translation id="6447842834002726250">Cookie</translation>
-<translation id="6461962085415701688">ファイルを開けません</translation>
-<translation id="6464977750820128603">Chrome でアクセスしたサイトを表示し、タイマーを設定できます。\n\nタイマーを設定したサイトの情報と、サイトでの滞在時間に関する情報が Google に送信されます。送信した情報は Digital Wellbeing の改善に役立てられます。</translation>
-<translation id="6475951671322991020">動画をダウンロード</translation>
-<translation id="6482749332252372425">ストレージの空き容量が不足しているため、<ph name="FILE_NAME" /> をダウンロードできませんでした。</translation>
-<translation id="6496823230996795692"><ph name="APP_NAME" /> を初めて使用する場合は、インターネットに接続してください。</translation>
-<translation id="6508722015517270189">Chrome を再起動する</translation>
-<translation id="6527303717912515753">共有</translation>
-<translation id="6532866250404780454">Chrome でアクセスしたサイトは表示されなくなり、サイトに設定したタイマーはすべて削除されます。</translation>
-<translation id="6534565668554028783">Google からの応答に時間がかかりすぎています</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB をダウンロード済み</translation>
-<translation id="6539092367496845964">エラーが発生しました。しばらくしてからもう一度お試しください。</translation>
-<translation id="654446541061731451">ビームするにはタブを選択してください</translation>
-<translation id="6545017243486555795">すべてのデータを削除</translation>
-<translation id="6545864417968258051">Bluetooth のスキャン</translation>
-<translation id="6560414384669816528">Sogou で検索します</translation>
-<translation id="6566259936974865419">Chrome で <ph name="GIGABYTES" /> GB の容量を節約しました</translation>
-<translation id="6573096386450695060">常に許可</translation>
-<translation id="6573431926118603307">他のデバイスの Chrome で開いているタブがここに表示されます。</translation>
-<translation id="6583199322650523874">現在のページをブックマークする</translation>
-<translation id="6593061639179217415">PC 版サイト</translation>
-<translation id="6600954340915313787">Chrome にコピー済み</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">保護されたコンテンツ</translation>
-<translation id="6627583120233659107">フォルダを編集</translation>
-<translation id="6643016212128521049">削除</translation>
-<translation id="6643649862576733715">データ節約量で並べ替え</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> 件}other{<ph name="CONTACT_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> 件}}</translation>
-<translation id="6649642165559792194">画像をプレビュー <ph name="BEGIN_NEW" />New<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">デバイスをスキャンするには、Chrome で位置情報にアクセスする必要があります。<ph name="BEGIN_LINK" />権限を更新<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">パスワード</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" />で開く</translation>
-<translation id="666981079809192359">Chrome のプライバシーに関するお知らせ</translation>
-<translation id="6676840375528380067">Chrome データをこのデバイスから削除しますか？</translation>
-<translation id="6697492270171225480">ページが見つからない場合に類似のページを候補として表示する</translation>
-<translation id="6697947395630195233">このサイトで現在地を共有するには、Chrome で位置情報の使用を許可する必要があります。</translation>
-<translation id="6698801883190606802">同期データを管理</translation>
-<translation id="6699370405921460408">アクセスするページを Google のサーバーで最適化します。</translation>
-<translation id="6706288973712894588">現在オフラインです。\n<ph name="BEGIN_LINK" />オフライン フィードを確認<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">ニュース</translation>
-<translation id="6710213216561001401">前へ</translation>
-<translation id="671481426037969117"><ph name="FQDN" /> のタイマーが切れました。タイマーはまた明日開始されます。</translation>
-<translation id="6738867403308150051">ダウンロードしています…</translation>
-<translation id="6746124502594467657">下に移動</translation>
-<translation id="6766622839693428701">閉じるには下にスワイプします。</translation>
-<translation id="6766758767654711248">タップしてサイトに移動する</translation>
-<translation id="6767294960381293877">タブを共有するデバイスのリストが画面の下半分に表示されました。</translation>
-<translation id="6782111308708962316">サードパーティのウェブサイトが Cookie データを保存したり読み取ったりできないようにします</translation>
-<translation id="6790428901817661496">再生</translation>
-<translation id="6811034713472274749">ページを表示できます</translation>
-<translation id="6818926723028410516">アイテムを選択</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">翻訳</translation>
-<translation id="6845325883481699275">Chrome のセキュリティ改善に協力する</translation>
-<translation id="6846298663435243399">読み込み中...</translation>
-<translation id="6850409657436465440">ダウンロードが進行中です</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> 個のタブを閉じました</translation>
-<translation id="6864459304226931083">画像をダウンロード</translation>
-<translation id="6865313869410766144">自動入力フォームのデータ</translation>
-<translation id="688738109438487280">既存のデータを <ph name="TO_ACCOUNT" /> に追加します。</translation>
-<translation id="6891726759199484455">パスワードをコピーするにはロックを解除してください</translation>
-<translation id="6896758677409633944">コピー</translation>
-<translation id="6910211073230771657">削除済み</translation>
-<translation id="6912998170423641340">サイトによるクリップボードのテキストや画像の読み取りをブロックする</translation>
-<translation id="6914783257214138813">エクスポートしたファイルを閲覧できるユーザーにパスワードを知られてしまう可能性があります。</translation>
-<translation id="6942665639005891494">デフォルトのダウンロード保存先は [設定] メニューでいつでも変更できます</translation>
-<translation id="6945221475159498467">選択</translation>
-<translation id="6963642900430330478">このページは危険です。サイト情報</translation>
-<translation id="6963766334940102469">ブックマークを削除</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">全期間</translation>
-<translation id="6981982820502123353">ユーザー補助機能</translation>
-<translation id="6989267951144302301">ダウンロードできませんでした</translation>
-<translation id="6990079615885386641">Google Play ストアからアプリを入手: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">サイトにマイクの使用を許可する前に確認する（推奨）</translation>
-<translation id="7015203776128479407">最初の同期設定が終了していません。同期は無効です。</translation>
-<translation id="7016516562562142042">現在の検索エンジンに対して許可</translation>
-<translation id="7022756207310403729">ブラウザで開く</translation>
-<translation id="702463548815491781">TalkBack またはスイッチ アクセスを有効にしている場合におすすめです</translation>
-<translation id="7029809446516969842">パスワード</translation>
-<translation id="7053983685419859001">ブロック</translation>
-<translation id="7055152154916055070">リダイレクトがブロックされました</translation>
-<translation id="7063006564040364415">同期サーバーに接続できませんでした。</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 件のアイテムを選択済み}other{# 件のアイテムを選択済み}}</translation>
-<translation id="7071521146534760487">アカウントを管理</translation>
-<translation id="7077143737582773186">SD カード</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> 件選択されています。オプションは画面上部にあります</translation>
-<translation id="7121362699166175603">アドレスバーの履歴とオートコンプリートを削除します。お使いの Google アカウントの <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> に、他の形式の閲覧履歴が記録されている場合があります。</translation>
-<translation id="7128222689758636196">現在の検索エンジンに対して許可</translation>
-<translation id="7138678301420049075">その他</translation>
-<translation id="7141896414559753902">サイトでのポップアップ表示とリダイレクトをブロックする（推奨）</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> から<ph name="BEGIN_LINK" />元のページを読み込む<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">過去 24 時間</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">これは後から [設定] で変更できます</translation>
-<translation id="7180611975245234373">更新</translation>
-<translation id="7189372733857464326">Google Play 開発者サービスの更新完了を待機しています</translation>
-<translation id="7191430249889272776">バックグラウンドでタブを開きました。</translation>
-<translation id="723171743924126238">画像を選択</translation>
-<translation id="7233236755231902816">お使いの言語でウェブを表示するには、Chrome の最新バージョンを入手してください</translation>
-<translation id="7243308994586599757">画面の下の方にオプションがあります</translation>
-<translation id="7248069434667874558">Chrome で <ph name="TARGET_DEVICE_NAME" /> の同期がオンになっていることを確認してください</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> 件選択されています</translation>
-<translation id="7274013316676448362">ブロック中のサイト</translation>
-<translation id="7290209999329137901">名前の変更はできません</translation>
-<translation id="7291387454912369099">アシスタントによる購入手続き</translation>
-<translation id="7293171162284876153">同期を開始するには、[Chrome データを同期] をオンにしてください。</translation>
-<translation id="729975465115245577">お使いのデバイスにはパスワード ファイルを保存するためのアプリがインストールされていません。</translation>
-<translation id="7302081693174882195">詳細: データ節約量の順</translation>
-<translation id="7328017930301109123">ライトモードを使用すると、Chrome でページの読み込みが高速化され、データ使用量も最大 60 パーセント抑えることができます。</translation>
-<translation id="7333031090786104871">前のサイトを追加中です</translation>
-<translation id="7352939065658542140">動画</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 件の選択されたアイテムを共有します}other{# 件の選択されたアイテムを共有します}}</translation>
 <translation id="7359002509206457351">お支払い方法へのアクセス</translation>
+<translation id="8026334261755873520">閲覧履歴データの削除</translation>
+<translation id="1291207594882862231">履歴、Cookie、サイトデータ、キャッシュを削除…</translation>
+<translation id="7814200940910057384">Brave データの消去完了</translation>
+<translation id="1664855196866195614">選択したデータが Brave から削除され、同期デバイスからも削除されました。
+
+他の Brave Software サービスでの検索や操作など、Brave Software アカウントの他の形式の閲覧履歴が <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> に残ることがあります。</translation>
+<translation id="4699172675775169585">キャッシュされた画像とファイル</translation>
+<translation id="2496180316473517155">閲覧履歴</translation>
+<translation id="2546283357679194313">Cookie とサイトデータ</translation>
+<translation id="8662811608048051533">ほとんどのサイトからログアウトします。</translation>
+<translation id="8218628800671693884">ほとんどのサイトからログアウトします。Brave Software アカウントへのログイン状態は維持されます。</translation>
+<translation id="2017836877785168846">アドレスバーの履歴とオートコンプリート データを削除します。</translation>
+<translation id="8096327394278038498">アドレスバーの履歴とオートコンプリートを削除します。お使いの Brave Software アカウントの <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> に、他の形式の閲覧履歴が記録されている場合があります。</translation>
+<translation id="8122693181154564064">ログインしているすべてのデバイスの履歴を削除します。お使いの Brave Software アカウントの <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> に、他の形式の閲覧履歴が記録されている場合があります。</translation>
+<translation id="5869522115854928033">保存したパスワード</translation>
+<translation id="6865313869410766144">自動入力フォームのデータ</translation>
+<translation id="7562080006725997899">閲覧データの消去</translation>
+<translation id="5487521232677179737">データを削除</translation>
+<translation id="7498271377022651285">お待ちください…</translation>
+<translation id="784934925303690534">期間</translation>
+<translation id="1718835860248848330">1 時間以内</translation>
+<translation id="7149893636342594995">過去 24 時間</translation>
+<translation id="5648166631817621825">過去 7 日間</translation>
+<translation id="8571213806525832805">過去 4 週間</translation>
+<translation id="5854790677617711513">30 日以上経過</translation>
+<translation id="6979737339423435258">全期間</translation>
+<translation id="982182592107339124">この操作を行うと、次を含むすべてのサイトのデータが削除されます。</translation>
+<translation id="6643016212128521049">削除</translation>
+<translation id="7641339528570811325">閲覧履歴データを削除…</translation>
+<translation id="1670399744444387456">基本設定</translation>
+<translation id="3245261285041759672">お使いの Brave Software アカウントの <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> に、他の形式の閲覧履歴が記録されている場合があります。</translation>
+<translation id="7274013316676448362">ブロック中のサイト</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/>件の項目を削除しました</translation>
+<translation id="1121094540300013208">利用状況と障害レポート</translation>
+<translation id="9079153198295609735">使用統計データと障害レポートを Brave Software に自動送信します</translation>
+<translation id="6981982820502123353">ユーザー補助機能</translation>
+<translation id="2387895666653383613">テキストの拡大と縮小</translation>
+<translation id="2321958826496381788">読みやすくなるまでスライダをドラッグしてください。段落をダブルタップするとテキストがこれより大きくなります。</translation>
+<translation id="3895926599014793903">強制的にズームを有効にする</translation>
+<translation id="5668404140385795438">ウェブサイトのズーム防止リクエストを上書きします</translation>
+<translation id="4149994727733219643">ウェブページの簡易表示</translation>
+<translation id="9100505651305367705">記事の簡易表示がサポートされている場合、簡易表示を提案します</translation>
+<translation id="1409426117486808224">開いているタブの簡易表示</translation>
+<translation id="702463548815491781">TalkBack またはスイッチ アクセスを有効にしている場合におすすめです</translation>
+<translation id="8284326494547611709">字幕</translation>
+<translation id="4165986682804962316">サイトの設定</translation>
+<translation id="6295158916970320988">すべてのサイト</translation>
+<translation id="8380167699614421159">このサイトでは煩わしい広告や誤解を招く広告が表示されます</translation>
+<translation id="1919345977826869612">広告</translation>
+<translation id="410351446219883937">自動再生</translation>
+<translation id="6447842834002726250">Cookie</translation>
+<translation id="6196640612572343990">サードパーティの Cookie をブロックする</translation>
+<translation id="6782111308708962316">サードパーティのウェブサイトが Cookie データを保存したり読み取ったりできないようにします</translation>
+<translation id="7521387064766892559">Javascript</translation>
+<translation id="4434045419905280838">ポップアップとリダイレクト</translation>
+<translation id="4751476147751820511">モーション センサーまたは光センサー</translation>
+<translation id="1717218214683051432">モーション センサー</translation>
+<translation id="2091887806945687916">音声</translation>
+<translation id="2586657967955657006">クリップボード</translation>
+<translation id="6320088164292336938">バイブレーション</translation>
+<translation id="4226663524361240545">通知を受け取るとデバイスが振動します</translation>
+<translation id="1446450296470737166">MIDI機器のフルコントロールを許可</translation>
+<translation id="3744111561329211289">バックグラウンド同期</translation>
+<translation id="5649053991847567735">自動ダウンロード</translation>
+<translation id="6181444274883918285">サイトの例外を追加</translation>
+<translation id="5313967007315987356">サイトを追加</translation>
+<translation id="1369915414381695676">サイト <ph name="SITE_NAME"/> を追加しました</translation>
+<translation id="7837721118676387834">特定のサイトに対し、ミュートされた動画の自動再生を許可します。</translation>
+<translation id="2621115761605608342">特定のサイトに対して JavaScript を許可します。</translation>
+<translation id="8801436777607969138">特定のサイトで JavaScript をブロックします。</translation>
+<translation id="8372893542064058268">特定のサイトに対してバックグラウンド同期を許可します。</translation>
+<translation id="358794129225322306">複数ファイルの自動ダウンロードをサイトに許可します。</translation>
+<translation id="4008040567710660924">特定のサイトの Cookie を許可します。</translation>
+<translation id="8958424370300090006">特定のサイトの Cookie をブロックします。</translation>
+<translation id="7882806643839505685">特定のサイトに対して音声の再生を許可します。</translation>
+<translation id="4468959413250150279">特定のサイトの音声をミュートします。</translation>
+<translation id="1994173015038366702">サイトの URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">使用状況</translation>
+<translation id="5804241973901381774">権限</translation>
+<translation id="4278390842282768270">許可</translation>
+<translation id="5677928146339483299">ブロック中</translation>
+<translation id="1984937141057606926">サードパーティを除いて許可する</translation>
+<translation id="7423098979219808738">最初に確認する</translation>
+<translation id="8116925261070264013">ミュート中</translation>
+<translation id="8300705686683892304">アプリによる管理</translation>
+<translation id="6192792657125177640">例外</translation>
+<translation id="257931822824936280">展開されています - クリックすると折りたたまれます。</translation>
+<translation id="5100237604440890931">折りたたまれています - クリックすると展開します。</translation>
+<translation id="857943718398505171">許可（推奨）</translation>
+<translation id="2913331724188855103">サイトに Cookie データの保存と読み取りを許可する（推奨）</translation>
+<translation id="7445411102860286510">ミュートされた動画の自動再生をサイトに許可する（推奨）</translation>
+<translation id="5335288049665977812">サイトに Javascript の実行を許可する（推奨）</translation>
+<translation id="5527111080432883924">サイトがクリップボードのテキストや画像を読み取る前に確認する（推奨）</translation>
+<translation id="6912998170423641340">サイトによるクリップボードのテキストや画像の読み取りをブロックする</translation>
+<translation id="7423538860840206698">クリップボードの読み取りがブロックされています</translation>
+<translation id="3955193568934677022">保護されたコンテンツの再生をサイトに許可する（推奨）</translation>
+<translation id="445467742685312942">保護されたコンテンツの再生をサイトに許可する</translation>
+<translation id="2107397443965016585">保護されたコンテンツの再生をサイトに許可する前に確認する（推奨）</translation>
+<translation id="2910701580606108292">保護されたコンテンツの再生をサイトに許可する前に確認する</translation>
+<translation id="757524316907819857">サイトでの保護されたコンテンツの再生をブロックする</translation>
+<translation id="3277252321222022663">サイトによるセンサーへのアクセスを許可する（推奨）</translation>
+<translation id="5048398596102334565">サイトによるモーション センサーへのアクセスを許可する（推奨）</translation>
+<translation id="8816026460808729765">サイトによるセンサーへのアクセスをブロックする</translation>
+<translation id="169515064810179024">サイトによるモーション センサーへのアクセスをブロックする</translation>
+<translation id="1660204651932907780">音声の再生をサイトに許可する（推奨）</translation>
+<translation id="3600792891314830896">音声が再生されるサイトをミュートする</translation>
+<translation id="1743802530341753419">サイトがデバイスに接続する前に確認する（推奨）</translation>
+<translation id="851751545965956758">サイトからデバイスへの接続をブロックする</translation>
+<translation id="7141896414559753902">サイトでのポップアップ表示とリダイレクトをブロックする（推奨）</translation>
+<translation id="5494752089476963479">煩わしい広告や誤解を招く広告が表示されるサイトで広告をブロックする</translation>
+<translation id="3123473560110926937">一部のサイトでブロックされています</translation>
+<translation id="965817943346481315">煩わしい広告や誤解を招く広告が表示されるサイトの場合にブロック（推奨）</translation>
+<translation id="3386292677130313581">サイトに現在地の認識を許可する前に確認する（推奨）</translation>
+<translation id="9139068048179869749">サイトに通知の送信を許可する前に確認する（推奨）</translation>
+<translation id="4479647676395637221">サイトにカメラの使用を許可する前に確認する（推奨）</translation>
+<translation id="6992289844737586249">サイトにマイクの使用を許可する前に確認する（推奨）</translation>
+<translation id="2289270750774289114">サイトから近くにある Bluetooth デバイスの検出を求められたときに確認する（推奨）</translation>
+<translation id="7053983685419859001">ブロック</translation>
+<translation id="7128222689758636196">現在の検索エンジンに対して許可</translation>
+<translation id="7589445247086920869">現在の検索エンジンに対してブロック</translation>
+<translation id="6388207532828177975">データを削除してリセット</translation>
+<translation id="7999064672810608036">すべてのローカルデータ（Cookie を含む）を削除して、このウェブサイトに指定したすべての権限をリセットしてもよろしいですか？</translation>
+<translation id="2822354292072154809">「<ph name="CHOSEN_OBJECT_NAME"/>」に関するすべてのサイト権限をリセットしてもよろしいですか？</translation>
+<translation id="515227803646670480">保存したデータの削除</translation>
+<translation id="5902828464777634901">このウェブサイトで保存したすべてのローカルデータ（Cookie を含む）を削除します。</translation>
+<translation id="119944043368869598">すべて削除</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> で管理</translation>
+<translation id="5516455585884385570">通知設定を開く</translation>
+<translation id="1404122904123200417">埋め込み先: <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">ウェブサイトによって保存されたファイルがここに表示されます</translation>
+<translation id="4181841719683918333">言語</translation>
+<translation id="2647434099613338025">言語の追加</translation>
+<translation id="1952172573699511566">可能な場合、設定した言語でウェブサイトのテキストを表示します。</translation>
+<translation id="8559990750235505898">他の言語のページで翻訳するかどうかを尋ねる</translation>
+<translation id="4719927025381752090">翻訳するか尋ねる</translation>
+<translation id="8156139159503939589">どの言語で閲覧しますか？</translation>
+<translation id="5689516760719285838">位置情報</translation>
+<translation id="2440823041667407902">位置情報へのアクセス</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android の設定<ph name="END_LINK"/>で Brave の権限を有効にしてください。</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android の設定<ph name="END_LINK"/>で Brave の権限を有効にしてください。</translation>
+<translation id="2928908108430545745">Brave に現在地へのアクセスを許可するには、<ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>でも位置情報をオンにしてください。</translation>
+<translation id="1028853271388022585">Brave にカメラへのアクセスを許可するには、<ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>でもカメラをオンにしてください。</translation>
+<translation id="2913721282607281710">Brave に通知の送信を許可するには、<ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>でも通知をオンにしてください。</translation>
+<translation id="8753483718490035722">Brave にマイクへのアクセスを許可するには、<ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>でもマイクをオンにしてください。</translation>
+<translation id="1887786770086287077">位置情報へのアクセスがデバイスでオフになっています。<ph name="BEGIN_LINK"/>Android の設定<ph name="END_LINK"/>でオンにしてください。</translation>
+<translation id="2570922361219980984">位置情報へのアクセスがデバイスでもオフになっています。<ph name="BEGIN_LINK"/>Android の設定<ph name="END_LINK"/>でオンにしてください。</translation>
+<translation id="1620510694547887537">カメラ</translation>
+<translation id="3227137524299004712">マイク</translation>
+<translation id="1647391597548383849">カメラへのアクセス</translation>
+<translation id="945632385593298557">マイクへのアクセス</translation>
+<translation id="6612358246767739896">保護されたコンテンツ</translation>
+<translation id="885701979325669005">ストレージ</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> の保存データ</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">デバイスの許可を取り消します</translation>
+<translation id="4962975101802056554">デバイスのすべての権限を取り消します</translation>
+<translation id="6545864417968258051">Bluetooth のスキャン</translation>
+<translation id="4411535500181276704">ライトモード</translation>
+<translation id="7821588508402923572">データ節約量がここに表示されます</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> 削減しました</translation>
+<translation id="8569404424186215731">（<ph name="DATE"/>以降）</translation>
+<translation id="3252158532344029638">ライトモードを使用すると、Brave でページの読み込みが高速化され、データ使用量も最大 60 パーセント抑えることができます。</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> のデータを削減</translation>
+<translation id="7494974237137038751">データ削減量</translation>
+<translation id="6111020039983847643">データ使用量</translation>
+<translation id="7413229368719586778">開始日: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">終了日: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">サイトで並べ替え</translation>
+<translation id="5864174910718532887">詳細: サイト名の順</translation>
+<translation id="116280672541001035">使用量</translation>
+<translation id="8349013245300336738">データ使用量で並べ替え</translation>
+<translation id="6378173571450987352">詳細: データ使用量の順</translation>
+<translation id="2631006050119455616">削減量</translation>
+<translation id="6643649862576733715">データ節約量で並べ替え</translation>
+<translation id="7302081693174882195">詳細: データ節約量の順</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> 使用</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> 節約</translation>
+<translation id="2156074688469523661">その他のサイト（<ph name="NUMBER_OF_SITES"/> 件）</translation>
+<translation id="7138678301420049075">その他</translation>
+<translation id="4913161338056004800">統計情報をリセット</translation>
+<translation id="1856325424225101786">ライトモードをリセットしますか？</translation>
+<translation id="3658159451045945436">リセットすると、アクセスしたサイトのリストなど、節約したデータの履歴が削除されます。</translation>
+<translation id="3295530008794733555">高速ブラウジングで、データ使用量も抑えることができます。</translation>
+<translation id="7340390500800578919">ライトモードを使用すると、Brave でページの読み込みが高速化され、データ使用量も最大 60% 抑えることができます。アクセスするページを最適化するため、ウェブ トラフィックが Brave から Brave Software に送信されます。<ph name="BEGIN_LINK"/>詳細<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">ライトモードをオンにする</translation>
+<translation id="4493497663118223949">ライトモードはオンです</translation>
+<translation id="7559975015014302720">ライトモードはオフです</translation>
+<translation id="7606077192958116810">ライトモードはオンです。[設定] で管理できます。</translation>
+<translation id="4714588616299687897">データを最大 60% 削減できます</translation>
+<translation id="1006927014032731288">アクセスするページを Brave Software のサーバーで最適化します。</translation>
+<translation id="3257320067425202300">Brave で <ph name="MEGABYTES"/> MB の容量を節約しました</translation>
+<translation id="5813223329348543512">Brave で <ph name="GIGABYTES"/> GB の容量を節約しました</translation>
+<translation id="8266862848225348053">ダウンロード場所</translation>
+<translation id="7077143737582773186">SD カード</translation>
+<translation id="7762668264895820836">SD カード <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">ファイルの保存場所を確認する</translation>
+<translation id="6192333916571137726">ダウンロード ファイル</translation>
+<translation id="1672586136351118594">次回から表示しない</translation>
+<translation id="2650751991977523696">ファイルをもう一度ダウンロードしますか？</translation>
+<translation id="8664979001105139458">同じ名前のファイルが存在します</translation>
+<translation id="488187801263602086">ファイル名を変更してください</translation>
+<translation id="5686790454216892815">ファイル名が長すぎます</translation>
+<translation id="7454641608352164238">空き容量が不足しています</translation>
+<translation id="8972098258593396643">デフォルトのフォルダにダウンロードしますか？</translation>
+<translation id="804335162455518893">SD カードが見つかりません</translation>
+<translation id="7475688122056506577">SD カードが見つかりません。一部のファイルが欠落している可能性があります。</translation>
+<translation id="4198423547019359126">ダウンロードの保存先はありません</translation>
+<translation id="8224471946457685718">Wi-Fi 接続時に記事をダウンロード</translation>
+<translation id="4970824347203572753">お住まいの地域ではご利用になれません</translation>
+<translation id="5500777121964041360">お住まいの地域ではご利用になれない可能性があります</translation>
+<translation id="1173894706177603556">名前を変更</translation>
+<translation id="1986685561493779662">この名前はすでに存在しています</translation>
+<translation id="6441734959916820584">名前が長すぎます</translation>
+<translation id="2923908459366352541">名前が無効です</translation>
+<translation id="7290209999329137901">名前の変更はできません</translation>
+<translation id="3334729583274622784">ファイル拡張子を変更しますか？</translation>
+<translation id="107147699690128016">ファイル拡張子を変更すると、ファイルが別のアプリケーションで開かれる可能性があり、場合によってはデバイスに損害が生じます。</translation>
+<translation id="8541922081612557424">Brave について</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. All rights reserved.</translation>
+<translation id="1416550906796893042">アプリケーションのバージョン</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/>（<ph name="TIME_SINCE_UPDATE"/>に更新）</translation>
+<translation id="7596558890252710462">オペレーティング システム</translation>
+<translation id="3968054912784331254">このバージョンの Android では Brave の更新はサポートされなくなりました</translation>
+<translation id="7665369617277396874">アカウントを追加</translation>
+<translation id="649070405679044769">次のユーザーとして Brave Software にログインしています</translation>
+<translation id="6234515504547364178">Brave からログアウト</translation>
+<translation id="5324858694974489420">保護者設定</translation>
+<translation id="8920114477895755567">保護者の情報を待っています。</translation>
+<translation id="5512137114520586844">このアカウントは <ph name="PARENT_NAME"/> によって管理されています。</translation>
+<translation id="2956410042958133412">このアカウントは <ph name="PARENT_NAME_1"/> と <ph name="PARENT_NAME_2"/> によって管理されています。</translation>
+<translation id="8168435359814927499">コンテンツ</translation>
+<translation id="5403644198645076998">特定のサイトのみを許可</translation>
+<translation id="8641930654639604085">成人向けのサイトを可能な限りブロックする</translation>
+<translation id="5639724618331995626">すべてのサイトを許可</translation>
+<translation id="796823723482603597">Powered by Brave</translation>
+<translation id="6324034347079777476">Android システムの同期が無効です</translation>
+<translation id="5127805178023152808">同期は無効です</translation>
+<translation id="7015203776128479407">最初の同期設定が終了していません。同期は無効です。</translation>
+<translation id="2497852260688568942">同期は管理者により無効にされています</translation>
+<translation id="9100610230175265781">パスフレーズを入力してください</translation>
+<translation id="6108923351542677676">設定しています...</translation>
+<translation id="4062305924942672200">法的情報</translation>
+<translation id="4256782883801055595">オープンソース ライセンス</translation>
+<translation id="1138681184697033370">Brave 利用規約</translation>
+<translation id="7392539049993970338">Brave のプライバシーに関するお知らせ</translation>
+<translation id="2677748264148917807">このページを離れる</translation>
+<translation id="5556459405103347317">再読み込み</translation>
+<translation id="1623104350909869708">このページで追加のダイアログが作成されないようにする</translation>
+<translation id="2968755619301702150">証明書ビューア</translation>
+<translation id="1360432990279830238">ログアウトして同期をオフにしますか？</translation>
+<translation id="8581481290581777242">Brave データをこのデバイスから削除しますか？</translation>
+<translation id="1318865768845061710">ブックマーク、履歴、パスワード、その他の Brave データは、Brave Software アカウントに同期されなくなります</translation>
+<translation id="3325020657155065477">Brave データもこのデバイスから削除する</translation>
+<translation id="6136448902816743006"><ph name="DOMAIN_NAME"/> で管理されているアカウントからログアウトするにあたり、Brave データはこのデバイスから削除されます。Brave Software アカウントからはデータは削除されません。</translation>
+<translation id="1853026300647876496">Brave Software に問い合わせています。これには 1 分ほどかかる場合があります…</translation>
+<translation id="2328985652426384049">ログインできません</translation>
+<translation id="7723158744459952869">Brave Software からの応答に時間がかかりすぎています</translation>
+<translation id="4572422548854449519">管理対象アカウントにログイン</translation>
+<translation id="2689656545739939160"><ph name="MANAGED_DOMAIN"/> で管理されているアカウントでログインして、Brave データの管理を管理者に委ねようとしています。この操作を行うと、データはこのアカウントに恒久的に関連付けられます。Brave からログアウトすると、データはこのデバイスから削除されますが、Brave Software アカウントには残ります。</translation>
+<translation id="1749561566933687563">ブックマークの同期</translation>
+<translation id="4242533952199664413">設定を開く</translation>
+<translation id="1111673857033749125">他のデバイスに保存されているブックマークがここに表示されます。</translation>
+<translation id="8636825310635137004">他のデバイスと同じタブを使用するには、同期を有効にします。</translation>
+<translation id="3269956123044984603">他のデバイスと同じタブを使用するには、Android のアカウント設定で [データの自動同期] を有効にします。</translation>
+<translation id="5157964048453367290">他のデバイスの Brave で開いているタブがここに表示されます。</translation>
+<translation id="4684427112815847243">すべてを同期する</translation>
+<translation id="2709516037105925701">自動入力</translation>
+<translation id="8820817407110198400">ブックマーク</translation>
+<translation id="1644574205037202324">履歴</translation>
+<translation id="17513872634828108">開いているタブ</translation>
+<translation id="1320169905922104972">Brave Software Pay に登録したクレジット カードと住所</translation>
+<translation id="6337234675334993532">暗号化</translation>
+<translation id="6698801883190606802">同期データを管理</translation>
+<translation id="3598578758776312506">Brave Software の認証情報でパスワードを暗号化する</translation>
+<translation id="7810580217418711046"><ph name="TIME"/>時点の Brave Software パスワードで同期データを暗号化する</translation>
+<translation id="8461694314515752532">同期データを同期パスフレーズで暗号化する</translation>
+<translation id="2996291259634659425">パスフレーズの作成</translation>
+<translation id="5713644099811900409">Brave Software アカウントを使用</translation>
+<translation id="8997474919031554666">パスフレーズ暗号化の対象に Brave Software Pay のお支払い方法と住所は含まれません。パスフレーズを知っているユーザーだけが暗号化データを読み取ることができます。パスフレーズが Brave Software に送信されたり Brave Software で保存されたりすることはありません。パスフレーズを忘れた場合や、この設定を変更する場合は、同期をリセットする必要があります。<ph name="BEGIN_LINK"/>詳細<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">パスフレーズ</translation>
+<translation id="7772032839648071052">パスフレーズの確認</translation>
+<translation id="5304593522240415983">この項目は必須です</translation>
+<translation id="321773570071367578">パスフレーズを忘れた場合や、この設定を変更する場合は、<ph name="BEGIN_LINK"/>同期をリセット<ph name="END_LINK"/>します</translation>
+<translation id="3029704984691124060">パスフレーズが一致しません</translation>
+<translation id="5149495116300586333">パスフレーズ暗号化の対象に Brave Software Pay のお支払い方法と住所は含まれません。
+
+この設定を変更する場合は<ph name="BEGIN_LINK"/>同期をリセット<ph name="END_LINK"/>してください</translation>
+<translation id="7638584964844754484">パスフレーズが正しくありません</translation>
+<translation id="5414836363063783498">確認しています…</translation>
+<translation id="6846298663435243399">読み込み中...</translation>
+<translation id="5517095782334947753"><ph name="FROM_ACCOUNT"/> のブックマーク、履歴、パスワードとその他の設定を使用できます。</translation>
+<translation id="3928666092801078803">データを統合する</translation>
+<translation id="688738109438487280">既存のデータを <ph name="TO_ACCOUNT"/> に追加します。</translation>
+<translation id="806745655614357130">データを別に保持する</translation>
+<translation id="1145536944570833626">既存のデータを削除します。</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> がペア設定を要求しています</translation>
+<translation id="4915549754973153784">デバイスのスキャン中… <ph name="BEGIN_LINK"/>ヘルプ<ph name="END_LINK"/></translation>
+<translation id="5817918615728894473">ペア設定</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>ヘルプ<ph name="END_LINK1"/>または<ph name="BEGIN_LINK2"/>再スキャン<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">対応デバイスが見つかりませんでした</translation>
+<translation id="3773755127849930740">ペア設定するには <ph name="BEGIN_LINK"/>Bluetooth をオン<ph name="END_LINK"/>にしてください</translation>
+<translation id="998321811308652668">Brave から Bluetooth アダプタをオンにできません</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>ヘルプ<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">デバイスをスキャンするには、Brave で位置情報にアクセスする必要があります。<ph name="BEGIN_LINK"/>権限を更新<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave ではデバイスをスキャンするために現在地情報にアクセスする必要があります。現在地情報へのアクセスは<ph name="BEGIN_LINK"/>このデバイスでオフになっています<ph name="END_LINK"/>。</translation>
+<translation id="2367014990350929709">Brave ではデバイスをスキャンするために現在地情報にアクセスする必要があります。<ph name="BEGIN_LINK1"/>権限を更新<ph name="END_LINK1"/>してください。また、現在地情報へのアクセスが<ph name="BEGIN_LINK2"/>このデバイスでオフになっています<ph name="END_LINK2"/>。</translation>
+<translation id="1569387923882100876">接続しているデバイス</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{電波強度: レベル #}other{電波強度: レベル #}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> が近くの Bluetooth デバイスのスキャンを求めています。検出済みのデバイスは次のとおりです。</translation>
+<translation id="8368027906805972958">不明またはサポートされていないデバイス（<ph name="DEVICE_ID"/>）</translation>
+<translation id="7605594153474022051">同期が機能していません</translation>
+<translation id="1810845389119482123">最初の同期設定が終了していません</translation>
+<translation id="3235722914093408050">Brave の同期を開始するには、Android の設定で Android システムの同期を再度有効にします</translation>
+<translation id="3367813778245106622">同期を開始するにはもう一度ログインします</translation>
+<translation id="974555521953189084">同期を開始するにはパスワードを入力します</translation>
+<translation id="2997266899014181325">同期を開始するには、[Brave データを同期] をオンにしてください。</translation>
+<translation id="8260126382462817229">もう一度ログインしてみてください</translation>
+<translation id="5919204609460789179">同期を開始するには <ph name="PRODUCT_NAME"/> を更新してください</translation>
+<translation id="397583555483684758">同期は停止されました</translation>
+<translation id="1966710179511230534">ログイン情報を更新してください。</translation>
+<translation id="7063006564040364415">同期サーバーに接続できませんでした。</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> は最新ではありません。</translation>
+<translation id="4170011742729630528">このサービスはご利用になれません。しばらくしてからもう一度お試しください。</translation>
+<translation id="7947953824732555851">同意してログイン</translation>
+<translation id="8583805026567836021">アカウント データをクリア中</translation>
+<translation id="8310344678080805313">標準のタブ</translation>
+<translation id="5748802427693696783">標準のタブに切り替えました</translation>
+<translation id="7998918019931843664">閉じたタブを開く</translation>
+<translation id="8853345339104747198">「<ph name="TAB_TITLE"/>」タブ</translation>
+<translation id="4452411734226507615">「<ph name="TAB_TITLE"/>」タブを閉じます</translation>
+<translation id="7243308994586599757">画面の下の方にオプションがあります</translation>
+<translation id="4060598801229743805">画面の上部にあるオプション</translation>
+<translation id="2810645512293415242">簡易版ページを使用してデータの保存と読み込みを高速化します。</translation>
+<translation id="3985215325736559418"><ph name="FILE_NAME"/> をもう一度ダウンロードしますか？</translation>
+<translation id="2450083983707403292"><ph name="FILE_NAME"/> のダウンロードをやり直してもよろしいですか？</translation>
+<translation id="7514365320538308">ダウンロード</translation>
+<translation id="545042621069398927">ダウンロード速度が向上しました。</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ファイルをダウンロードしています。}other{# 件のファイルをダウンロードしています。}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> 件のファイルをダウンロードしています（<ph name="MEGABYTES"/>）。</translation>
+<translation id="4988210275050210843">ファイルをダウンロードしています（<ph name="MEGABYTES"/>）。</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 件のダウンロードが完了しました。}other{# 件のダウンロードが完了しました。}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 件のダウンロードが失敗しました。}other{# 件のダウンロードが失敗しました。}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 件のダウンロードが保留中です。}other{# 件のダウンロードが保留中です。}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>。</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> ボタン</translation>
+<translation id="3205824638308738187">あと少しで完了です</translation>
+<translation id="3960299545138990065">Brave を再起動する</translation>
+<translation id="3771001275138982843">アップデートをダウンロードできませんでした</translation>
+<translation id="3888648114124182147">Brave のアップデートをダウンロードしています…</translation>
+<translation id="1705567146636171298">Brave を更新</translation>
+<translation id="6195417478702700398">快適にご利用いただけるよう、Brave を開いて更新することをおすすめします</translation>
+<translation id="3512968675351418494">お使いの言語でウェブを表示するには、Brave の最新バージョンを入手してください</translation>
+<translation id="6427112570124116297">ウェブの翻訳</translation>
+<translation id="1379423114029199501">Brave を更新し、最新バージョンでお使いの言語を入手してください</translation>
+<translation id="5684874026226664614">このページを翻訳できませんでした。</translation>
+<translation id="6831043979455480757">翻訳</translation>
+<translation id="1285320974508926690">このサイトは翻訳しない</translation>
+<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE"/>のページを常に翻訳する</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/>のページを翻訳しない</translation>
+<translation id="124116460088058876">その他の言語</translation>
+<translation id="290376772003165898"><ph name="LANGUAGE"/>のページではない場合</translation>
+<translation id="4432792777822557199">今後、<ph name="SOURCE_LANGUAGE"/>のページは<ph name="TARGET_LANGUAGE"/>に翻訳されます</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/>のページは翻訳されません</translation>
+<translation id="5447765697759493033">このサイトは翻訳されません</translation>
+<translation id="4880127995492972015">翻訳…</translation>
+<translation id="641643625718530986">印刷...</translation>
+<translation id="8909135823018751308">共有...</translation>
+<translation id="4996978546172906250">共有方法</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> で共有します</translation>
+<translation id="6277522088822131679">ページの印刷中に問題が発生しました。もう一度お試しください。</translation>
+<translation id="3254409185687681395">このページをブックマークに追加します</translation>
+<translation id="497421865427891073">次に進む</translation>
+<translation id="813082847718468539">サイト情報を表示</translation>
+<translation id="2532336938189706096">ウェブ表示</translation>
+<translation id="6005538289190791541">推奨パスワード</translation>
+<translation id="4634124774493850572">パスワードを使用</translation>
+<translation id="8285489906452138776">このサイトを利用するには、Brave でカメラの使用を許可する必要があります。</translation>
+<translation id="320189792589364011">このサイトを利用するには、Brave でマイクの使用を許可する必要があります。</translation>
+<translation id="7988136689212463100">このサイトを利用するには、Brave でカメラとマイクの使用を許可する必要があります。</translation>
+<translation id="4931190655840828017">このサイトで現在地を共有するには、Brave で位置情報の使用を許可する必要があります。</translation>
+<translation id="3088191967551450609">Brave でファイルをダウンロードするにはストレージへのアクセス権が必要です。</translation>
+<translation id="8942627711005830162">別のウィンドウで開く</translation>
+<translation id="4195643157523330669">新しいタブで開く</translation>
+<translation id="1100066534610197918">新しいタブをグループで開く</translation>
+<translation id="4860895144060829044">通話</translation>
+<translation id="6896758677409633944">コピー</translation>
+<translation id="8393700583063109961">メッセージを送信</translation>
+<translation id="3557336313807607643">連絡先に追加</translation>
+<translation id="4269820728363426813">リンクアドレスをコピー</translation>
+<translation id="1206892813135768548">リンクテキストをコピー</translation>
+<translation id="1204037785786432551">リンクをダウンロード</translation>
+<translation id="6864459304226931083">画像をダウンロード</translation>
+<translation id="8209050860603202033">画像を開く</translation>
+<translation id="8073388330009372546">新しいタブで画像を開く</translation>
+<translation id="6649642165559792194">画像をプレビュー <ph name="BEGIN_NEW"/>New<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">画像を読み込む</translation>
+<translation id="3845332215609790146">Brave Software レンズで検索<ph name="BEGIN_NEW"/>New<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">この画像を <ph name="SEARCH_ENGINE"/> で検索</translation>
+<translation id="3384347053049321195">画像を共有</translation>
+<translation id="5833984609253377421">リンクを共有</translation>
+<translation id="6475951671322991020">動画をダウンロード</translation>
+<translation id="2317945146070194624">新しい Brave タブで開く</translation>
+<translation id="7975379999046275268">ページをプレビュー <ph name="BEGIN_NEW"/>New<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">ページを更新しています</translation>
+<translation id="36525718899759834">Brave Software Play ストアからアプリを入手: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">暗</translation>
+<translation id="1807246157184219062">明</translation>
+<translation id="4056223980640387499">セピア</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">等幅</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">ビームするにはタブを選択してください</translation>
+<translation id="8719023831149562936">現在のタブはビームできません</translation>
+<translation id="2139186145475833000">ホーム画面に追加</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> を起動</translation>
+<translation id="2122601567107267586">アプリを開けませんでした</translation>
+<translation id="5129038482087801250">ウェブアプリをインストール</translation>
+<translation id="3789841737615482174">インストール</translation>
+<translation id="4665282149850138822">「<ph name="NAME"/>」がホーム画面に追加されました</translation>
+<translation id="7333031090786104871">前のサイトを追加中です</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> を追加しています...</translation>
+<translation id="3778956594442850293">ホーム画面に追加されました</translation>
+<translation id="2146738493024040262">プレビュー アプリを開く</translation>
+<translation id="7016516562562142042">現在の検索エンジンに対して許可</translation>
+<translation id="6177111841848151710">現在の検索エンジンに対してはブロック</translation>
+<translation id="145097072038377568">Android の設定で無効</translation>
+<translation id="8007176423574883786">このデバイスに対して無効</translation>
+<translation id="164269334534774161">このページの <ph name="CREATION_TIME"/> のオフライン コピーを表示しています</translation>
+<translation id="4594952190837476234">このオフライン ページは <ph name="CREATION_TIME"/> 時点のものであり、オンライン版とは異なる可能性があります。</translation>
+<translation id="8840953339110955557">このページはオンライン版とは異なる可能性があります。</translation>
+<translation id="6405300764336705484"><ph name="DOMAIN_NAME"/> のコンテンツを Brave Software から配信しています。</translation>
+<translation id="1006017844123154345">オンライン版を開く</translation>
+<translation id="3326636747541519688">Brave Software から提供されている軽量版のページ</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> から<ph name="BEGIN_LINK"/>元のページを読み込む<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">このメッセージが繰り返し表示される場合は、こちらの<ph name="BEGIN_LINK"/>ヒント<ph name="END_LINK"/>をお試しください。</translation>
+<translation id="8748850008226585750">メッセージは非表示です</translation>
+<translation id="3810973564298564668">管理</translation>
+<translation id="5199929503336119739">仕事用プロファイル</translation>
+<translation id="528192093759286357">全画面表示を終了するには、上からドラッグして、戻るボタンをタップします。</translation>
+<translation id="2836148919159985482">全画面表示を終了するには戻るボタンをタップします。</translation>
+<translation id="3967822245660637423">ダウンロード完了</translation>
+<translation id="2434158240863470628">ダウンロードが完了しました<ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">ダウンロード エラー</translation>
+<translation id="1384959399684842514">ダウンロードを一時停止しました</translation>
+<translation id="1671236975893690980">ダウンロードを待機しています...</translation>
+<translation id="5561549206367097665">ネットワーク接続を待機しています…</translation>
+<translation id="5864419784173784555">別のダウンロードの完了待ちです…</translation>
+<translation id="6461962085415701688">ファイルを開けません</translation>
+<translation id="1178581264944972037">一時停止</translation>
+<translation id="8200772114523450471">再開</translation>
+<translation id="1409879593029778104"><ph name="FILE_NAME"/> は既に存在しているためダウンロードできませんでした。</translation>
+<translation id="3387650086002190359">ファイル システムでエラーが発生したため、<ph name="FILE_NAME"/> をダウンロードできませんでした。</translation>
+<translation id="6482749332252372425">ストレージの空き容量が不足しているため、<ph name="FILE_NAME"/> をダウンロードできませんでした。</translation>
+<translation id="7619072057915878432">ネットワーク障害が発生したため、<ph name="FILE_NAME"/> をダウンロードできませんでした。</translation>
+<translation id="1477626028522505441">サーバーで問題が発生したため、<ph name="FILE_NAME"/> をダウンロードできませんでした。</translation>
+<translation id="3692944402865947621">保存場所にアクセスできないため、<ph name="FILE_NAME"/> をダウンロードできませんでした。</translation>
+<translation id="604996488070107836">不明なエラーが発生したため、<ph name="FILE_NAME"/> をダウンロードできませんでした。</translation>
+<translation id="6738867403308150051">ダウンロードしています…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ？</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB をダウンロード済み</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB をダウンロード済み</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB をダウンロード済み</translation>
+<translation id="9204836675896933765">残り 1 ファイル</translation>
+<translation id="8186512483418048923">残り <ph name="FILES"/> ファイル</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> 件のファイルをダウンロードしました}other{<ph name="FILES_DOWNLOADED_MANY"/> 件のファイルをダウンロードしました}}</translation>
+<translation id="8037750541064988519">残り <ph name="DAYS"/> 日</translation>
+<translation id="8190358571722158785">残り 1 日</translation>
+<translation id="60923314841986378">残り <ph name="HOURS"/> 時間</translation>
+<translation id="510275257476243843">残り 1 時間</translation>
+<translation id="970715775301869095">残り <ph name="MINUTES"/> 分</translation>
+<translation id="3236059992281584593">残り 1 分</translation>
+<translation id="2777555524387840389">残り <ph name="SECONDS"/> 秒</translation>
+<translation id="2781151931089541271">残り 1 秒</translation>
+<translation id="3303414029551471755">コンテンツのダウンロードに進みますか？</translation>
+<translation id="8617240290563765734">ダウンロード コンテンツに指定されている URL を開きますか？</translation>
+<translation id="1373696734384179344">選択したコンテンツをダウンロードするにはメモリが不足しています。</translation>
+<translation id="5271967389191913893">デバイスでダウンロード コンテンツを開くことができません。</translation>
+<translation id="883806473910249246">コンテンツのダウンロード中にエラーが発生しました。</translation>
+<translation id="5626134646977739690">名前:</translation>
+<translation id="7963646190083259054">ベンダー:</translation>
+<translation id="3414952576877147120">サイズ:</translation>
+<translation id="7375125077091615385">タイプ:</translation>
+<translation id="5765780083710877561">説明:</translation>
+<translation id="4881695831933465202">開く</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB の空き</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB 利用可</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB 使用可能</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/> 中 <ph name="SPACE_USED"/> を使用中</translation>
+<translation id="3587482841069643663">すべて</translation>
+<translation id="4988526792673242964">ページ</translation>
+<translation id="3810838688059735925">動画</translation>
+<translation id="3616113530831147358">音声</translation>
+<translation id="9219103736887031265">画像</translation>
+<translation id="8250920743982581267">ドキュメント</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# 件のファイル}other{# 件のファイル}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# 個の画像}other{# 個の画像}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# 個の動画}other{# 個の動画}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# 件の音声ファイル}other{# 件の音声ファイル}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# ページ}other{# ページ}}</translation>
+<translation id="5456381639095306749">ページをダウンロード</translation>
+<translation id="2394602618534698961">ダウンロードしたファイルがここに表示されます</translation>
+<translation id="7810647596859435254">アプリで開く…</translation>
+<translation id="5655963694829536461">ダウンロードしたアイテムを検索</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">マイファイル</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">記事がここに表示されます。これらの記事はオフラインでも読むことができます</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# 時間}other{# 時間}}</translation>
+<translation id="5853623416121554550">一時停止中</translation>
+<translation id="8965591936373831584">保留中</translation>
+<translation id="2779651927720337254">失敗</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">たった今</translation>
+<translation id="4000212216660919741">オフライン ホーム</translation>
+<translation id="9133397713400217035">オフライン コンテンツ</translation>
+<translation id="968900484120156207">アクセスしたページがここに表示されます</translation>
+<translation id="7882131421121961860">履歴が見つかりません</translation>
+<translation id="3549657413697417275">履歴を検索</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave 初回起動時の操作</translation>
+<translation id="2700285883409956633">このアプリケーションを使用すると、Brave の<ph name="BEGIN_LINK1"/>利用規約<ph name="END_LINK1"/>と<ph name="BEGIN_LINK2"/>プライバシーに関するお知らせ<ph name="END_LINK2"/>に同意したことになります。</translation>
+<translation id="1640714894372474981">このアプリケーションを使用すると、Brave の<ph name="BEGIN_LINK1"/>利用規約<ph name="END_LINK1"/>と<ph name="BEGIN_LINK2"/>プライバシーに関するお知らせ<ph name="END_LINK2"/>、および <ph name="BEGIN_LINK3"/>ファミリー リンクで管理する Brave Software アカウントのプライバシーに関するお知らせ<ph name="END_LINK3"/>に同意したことになります。</translation>
+<translation id="4218324479468769727">Brave で <ph name="APP_NAME"/> を開きます。続行すると、Brave の<ph name="BEGIN_LINK1"/>利用規約<ph name="END_LINK1"/>と<ph name="BEGIN_LINK2"/>プライバシーに関するお知らせ<ph name="END_LINK2"/>に同意したことになります。</translation>
+<translation id="5071615083211946659">Brave で <ph name="APP_NAME"/> を開きます。続行すると、Brave の<ph name="BEGIN_LINK1"/>利用規約<ph name="END_LINK1"/>と<ph name="BEGIN_LINK2"/>プライバシーに関するお知らせ<ph name="END_LINK2"/>、および <ph name="BEGIN_LINK3"/>ファミリー リンクで作成された Brave Software アカウントのプライバシーに関するお知らせ<ph name="END_LINK3"/>に同意したことになります。</translation>
+<translation id="673197144963363525">使用統計情報と障害レポートを Brave Software に送信して、Brave の品質向上にご協力ください。</translation>
+<translation id="3518985090088779359">同意して続行</translation>
+<translation id="7207456302801184289">Brave へようこそ</translation>
+<translation id="704822250101715322">Brave Software Play 開発者サービスの更新完了を待機しています</translation>
+<translation id="1231733316453485619">同期を有効にしますか？</translation>
+<translation id="5132942445612118989">すべてのデバイスでパスワード、履歴、その他の設定を同期する</translation>
+<translation id="5736731321935944068">検索、広告、その他の Brave Software サービスをカスタマイズするために、Brave Software で履歴が使用されることがあります</translation>
+<translation id="4013614219085422040">検索やその他の Brave Software サービスをカスタマイズするために、Brave Software で履歴が使用されることがあります</translation>
+<translation id="5581519193887989363">同期する項目はいつでも [<ph name="BEGIN_LINK1"/>設定<ph name="END_LINK1"/>] で選択できます。</translation>
+<translation id="741204030948306876">有効にする</translation>
+<translation id="2410754283952462441">アカウントの選択</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> として続行</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> ではありませんか？</translation>
+<translation id="8109613176066109935">お使いのどのデバイスでも同じブックマークを使用するには、同期を有効にします</translation>
+<translation id="2818669890320396765">お使いのどのデバイスでも同じブックマークを使用するには、ログインして同期を有効にします</translation>
+<translation id="6003646045106347985">ユーザーに合わせた Brave Software からのおすすめコンテンツを表示するには、同期を有効にします</translation>
+<translation id="8494430740943879273">ユーザーに合わせた Brave Software からのおすすめコンテンツを表示するには、ログインして同期を有効にします</translation>
+<translation id="5862731021271217234">他のデバイスと同じタブを使用するには、同期を有効にします</translation>
+<translation id="3568688522516854065">他のデバイスと同じタブを使用するには、ログインして同期を有効にします</translation>
+<translation id="1208340532756947324">複数のデバイスで独自の設定を同期して共有するには、同期を有効にします</translation>
+<translation id="4472118726404937099">複数のデバイスで独自の設定を同期して共有するには、ログインして同期を有効にします</translation>
+<translation id="2426805022920575512">別のアカウントを選択</translation>
+<translation id="6790428901817661496">再生</translation>
+<translation id="1272079795634619415">中止</translation>
+<translation id="2874939134665556319">前のトラック</translation>
+<translation id="4046123991198612571">次のトラック</translation>
+<translation id="3859306556332390985">前方にシーク再生</translation>
+<translation id="8441146129660941386">後方にシーク再生</translation>
+<translation id="6706288973712894588">現在オフラインです。\n<ph name="BEGIN_LINK"/>オフライン フィードを確認<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">最近使ったタブ</translation>
+<translation id="8497726226069778601">表示するものがまだありません</translation>
+<translation id="5423934151118863508">最もアクセスの多かったページがここに表示されます</translation>
+<translation id="6127379762771434464">アイテムを削除しました</translation>
+<translation id="4605958867780575332">削除したアイテム: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software Doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">他のデバイス</translation>
+<translation id="4738836084190194332">最終同期: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# 分前}other{# 分前}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# 時間前}other{# 時間前}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# 日前}other{# 日前}}</translation>
+<translation id="2762000892062317888">たった今</translation>
+<translation id="1407135791313364759">すべて開く</translation>
+<translation id="1209206284964581585">今は表示しない</translation>
+<translation id="129553762522093515">最近閉じたタブ</translation>
+<translation id="8413126021676339697">全履歴を表示</translation>
+<translation id="7876243839304621966">すべて削除</translation>
+<translation id="8487700953926739672">オフラインでの利用</translation>
+<translation id="5224771365102442243">動画あり</translation>
+<translation id="3493531032208478708">詳しくは、<ph name="BEGIN_LINK"/>おすすめのコンテンツ<ph name="END_LINK"/>についての説明をご覧ください</translation>
+<translation id="7542481630195938534">おすすめの記事を取得できません</translation>
+<translation id="5013696553129441713">新しいおすすめ記事はありません</translation>
+<translation id="1736419249208073774">詳しく見る</translation>
+<translation id="7444811645081526538">その他のカテゴリ</translation>
+<translation id="6709133671862442373">ニュース</translation>
+<translation id="1264974993859112054">スポーツ</translation>
+<translation id="9139318394846604261">ショッピング</translation>
+<translation id="3912508018559818924">ウェブで最適なデータを探しています。</translation>
+<translation id="526421993248218238">ページを読み込めません</translation>
+<translation id="614940544461990577">次をお試しください</translation>
+<translation id="3288003805934695103">ページを再読み込みする</translation>
+<translation id="2353636109065292463">インターネット接続を確認しています</translation>
+<translation id="2858138569776157458">上位のサイト</translation>
+<translation id="8364299278605033898">人気のウェブサイトを表示します</translation>
+<translation id="1171770572613082465">人気のウェブサイトを表示するには、[上位のサイト] ボタンをタップします</translation>
+<translation id="5233638681132016545">新しいタブ</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/> のコンテンツ - <ph name="BEGIN_DEEMPHASIZED"/>Brave Software により配信<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">新しいバージョンをご利用いただけます</translation>
+<translation id="4058091506841967397">Brave を更新できません</translation>
+<translation id="6316139424528454185">Android のバージョンはサポートされていません</translation>
+<translation id="6989267951144302301">ダウンロードできませんでした</translation>
+<translation id="624789221780392884">アップデート準備完了</translation>
+<translation id="1549000191223877751">他のウィンドウに移動</translation>
+<translation id="7481312909269577407">進む</translation>
+<translation id="4084682180776658562">ブックマーク</translation>
+<translation id="6437478888915024427">ページ情報</translation>
+<translation id="7180611975245234373">更新</translation>
+<translation id="4913169188695071480">更新を停止</translation>
+<translation id="1829244130665387512">ページ内検索</translation>
+<translation id="6593061639179217415">PC 版サイト</translation>
+<translation id="9063523880881406963">[PC 版サイトを見る] をオフにします</translation>
+<translation id="2038563949887743358">[PC 版サイトを見る] をオンにします</translation>
+<translation id="2433507940547922241">デザイン</translation>
+<translation id="983192555821071799">すべてのタブを閉じる</translation>
+<translation id="1310482092992808703">タブをグループ化</translation>
+<translation id="7725024127233776428">ブックマークしたページがここに表示されます</translation>
+<translation id="4404568932422911380">ブックマークがありません</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> 個のブックマーク}other{<ph name="BOOKMARKS_COUNT_MANY"/> 個のブックマーク}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> にブックマークしました</translation>
+<translation id="3207960819495026254">ブックマークしました</translation>
+<translation id="4452548195519783679">「<ph name="FOLDER_NAME"/>」にブックマークしました</translation>
+<translation id="8063895661287329888">ブックマークを追加できませんでした。</translation>
+<translation id="2842985007712546952">親フォルダ</translation>
+<translation id="9065203028668620118">編集</translation>
+<translation id="4405224443901389797">移動…</translation>
+<translation id="5170568018924773124">フォルダを開く</translation>
+<translation id="8035133914807600019">新しいフォルダ...</translation>
+<translation id="4532845899244822526">フォルダの選択</translation>
+<translation id="6627583120233659107">フォルダを編集</translation>
+<translation id="1197267115302279827">ブックマークを移動</translation>
+<translation id="6963766334940102469">ブックマークを削除</translation>
+<translation id="4351244548802238354">ダイアログを閉じる</translation>
+<translation id="451872707440238414">ブックマークを検索</translation>
+<translation id="8901170036886848654">ブックマークが見つかりません</translation>
+<translation id="6404511346730675251">ブックマークを編集</translation>
+<translation id="3894427358181296146">フォルダの追加</translation>
+<translation id="5327248766486351172">名前</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">フォルダ</translation>
+<translation id="5161254044473106830">タイトルが必要です</translation>
+<translation id="2996809686854298943">URLが必要です</translation>
+<translation id="2536728043171574184">このページのオフライン コピーを表示しています</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> でオフライン表示</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> とその他のサイト</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{準備ができると Brave でページが読み込まれます}other{準備ができると Brave でページが読み込まれます}}</translation>
+<translation id="6811034713472274749">ページを表示できます</translation>
+<translation id="4561979708150884304">接続されていません</translation>
+<translation id="8274165955039650276">ダウンロードを表示</translation>
+<translation id="2082238445998314030">結果 <ph name="TOTAL_RESULTS"/> 件中 <ph name="RESULT_NUMBER"/> 件目</translation>
+<translation id="4943872375798546930">結果はありません</translation>
+<translation id="981121421437150478">オフライン</translation>
+<translation id="3298243779924642547">軽量版</translation>
+<translation id="393697183122708255">有効な音声検索がありません</translation>
+<translation id="7191430249889272776">バックグラウンドでタブを開きました。</translation>
+<translation id="8445059357334030806">Braveで開く</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/> で開く</translation>
+<translation id="7022756207310403729">ブラウザで開く</translation>
+<translation id="1113597929977215864">簡易表示する</translation>
+<translation id="1513352483775369820">ブックマークとウェブ履歴</translation>
+<translation id="4939482511480190003">Brave の品質向上にご協力ください。<ph name="BEGIN_LINK"/>アンケートに回答する<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">戻る</translation>
+<translation id="5596627076506792578">その他のオプション</translation>
+<translation id="3522247891732774234">アップデートが見つかりました。その他のオプション</translation>
+<translation id="6773423637732432200">Brave を更新できません。その他のオプション</translation>
+<translation id="3328801116991980348">サイト情報</translation>
+<translation id="5391532827096253100">このサイトへの接続は保護されていません。サイト情報</translation>
+<translation id="6206551242102657620">接続は保護されています。サイト情報</translation>
+<translation id="6963642900430330478">このページは危険です。サイト情報</translation>
+<translation id="9070377983101773829">音声検索を開始</translation>
+<translation id="8676374126336081632">入力内容を消去</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> 個のタブが開いています。タブを切り替えるにはタップします}other{<ph name="OPEN_TABS_MANY"/> 個のタブが開いています。タブを切り替えるにはタップします}}</translation>
+<translation id="2369533728426058518">開いているタブ</translation>
+<translation id="7071521146534760487">アカウントを管理</translation>
+<translation id="932327136139879170">ホーム</translation>
+<translation id="2707726405694321444">ページを更新</translation>
+<translation id="2891154217021530873">ページの読み込みを停止</translation>
+<translation id="6710213216561001401">前へ</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">選択したタブ</translation>
+<translation id="2268044343513325586">絞り込み</translation>
+<translation id="7846076177841592234">選択解除</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> 件選択されています。オプションは画面上部にあります</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> 件選択されています</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 件の選択されたアイテムを共有します}other{# 件の選択されたアイテムを共有します}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{選択された 1 件のアイテムを削除します}other{選択された # 件のアイテムを削除します}}</translation>
+<translation id="1283039547216852943">タップして展開</translation>
+<translation id="5962718611393537961">タップして折りたたむ</translation>
+<translation id="8076492880354921740">タブ</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 件のアイテムを選択済み}other{# 件のアイテムを選択済み}}</translation>
+<translation id="6818926723028410516">アイテムを選択</translation>
+<translation id="4797039098279997504">タップすると <ph name="URL_OF_THE_CURRENT_TAB"/> に戻ります</translation>
+<translation id="6766758767654711248">タップしてサイトに移動する</translation>
+<translation id="429312253194641664">サイトでメディアが再生されています</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> が画面を共有しています</translation>
+<translation id="8833831881926404480">サイトが画面を共有しています</translation>
+<translation id="9086455579313502267">ネットワークにアクセスできません</translation>
+<translation id="938850635132480979">エラー: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/>で開く</translation>
+<translation id="548278423535722844">マップアプリで開く</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> でメールを作成</translation>
+<translation id="7875915731392087153">メールを作成</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> で予定を作成</translation>
+<translation id="2900528713135656174">予定を作成</translation>
+<translation id="2111511281910874386">ページを開く</translation>
+<translation id="3988466920954086464">このパネルにインスタント検索の結果が表示されます</translation>
+<translation id="2744248271121720757">単語をタップすると、検索をすばやく実行したり、関連する操作メニューを確認したりできます</translation>
+<translation id="9155898266292537608">単語をタップするだけでも検索できます</translation>
+<translation id="3232754137068452469">ウェブアプリ</translation>
+<translation id="1430915738399379752">印刷</translation>
+<translation id="3775705724665058594">お使いのデバイスに送信</translation>
+<translation id="6364438453358674297">履歴から候補を削除しますか？</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> を閉じました</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> 個のタブを閉じました</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> を削除しました</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> 件のブックマークを削除しました</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> 件のダウンロードを削除しました</translation>
+<translation id="1248710015876067820">Brave のインスタンス数の上限を超えています。</translation>
+<translation id="4259722352634471385"><ph name="URL"/> へのアクセスがブロックされました</translation>
+<translation id="8959122750345127698"><ph name="URL"/> にアクセスできません</translation>
+<translation id="5210365745912300556">タブを閉じる</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> を閉じる</translation>
+<translation id="1227058898775614466">ナビゲーション履歴</translation>
+<translation id="9169507124922466868">ナビゲーション履歴が半分開いています</translation>
+<translation id="1327257854815634930">ナビゲーション履歴が開いています</translation>
+<translation id="8788265440806329501">ナビゲーション履歴は閉じられています</translation>
+<translation id="7482656565088326534">[プレビュー] タブ</translation>
+<translation id="8427875596167638501">[プレビュー] タブが半分開いています</translation>
+<translation id="9102803872260866941">[プレビュー] タブが開いています</translation>
+<translation id="2942036813789421260">[プレビュー] タブは閉じられています</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> ストレージ</translation>
+<translation id="3822502789641063741">サイトのストレージ データを削除しますか？</translation>
+<translation id="9205995714227143200">Brave で重要度が低いと判断されるサイトのストレージ（設定を保存していないサイトやアクセス頻度の少ないサイトなど）</translation>
+<translation id="3997476611815694295">重要度の低いストレージ</translation>
+<translation id="8493948351860045254">容量を空ける</translation>
+<translation id="2324920234469020158">Brave で重要度が低いと判断されるサイトの Cookie やキャッシュなどのデータを削除します。</translation>
+<translation id="5447201525962359567">すべてのサイトのストレージ（Cookie やローカルに保存した他のデータを含む）</translation>
+<translation id="1376578503827013741">計算中...</translation>
+<translation id="583281660410589416">不明</translation>
+<translation id="2323763861024343754">サイトのストレージ</translation>
+<translation id="3587672679800759167">Brave が使用するデータ全体（アカウント、ブックマーク、保存済みの設定など）</translation>
+<translation id="6545017243486555795">すべてのデータを削除</translation>
+<translation id="4095146165863963773">アプリデータを削除しますか？</translation>
+<translation id="53119194224775367">Brave のすべてのアプリデータを完全に削除します。削除されるデータには、すべてのファイル、設定、アカウント、データベースなどが含まれます。</translation>
+<translation id="5307446750509046227">サイトのストレージをクリア</translation>
+<translation id="300526633675317032">ウェブサイトのストレージ <ph name="SIZE_IN_KB"/> のデータをすべて削除します。</translation>
+<translation id="8068648041423924542">証明書を選択できません</translation>
+<translation id="2315043854645842844">オペレーティング システムでサポートされていないため、クライアント側で証明書を選択することはできません。</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> が接続を要求しています</translation>
+<translation id="5308380583665731573">接続</translation>
+<translation id="868929229000858085">連絡先を検索</translation>
+<translation id="1919950603503897840">連絡先を選択</translation>
+<translation id="7986741934819883144">連絡先の選択</translation>
+<translation id="3333961966071413176">すべての連絡先</translation>
+<translation id="4994033804516042629">連絡先が見つかりませんでした</translation>
+<translation id="5403592356182871684">名前</translation>
+<translation id="2717722538473713889">メールアドレス</translation>
+<translation id="381841723434055211">電話番号</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{（他 1 件）}other{（他 # 件）}}</translation>
+<translation id="5197729504361054390">選択した連絡先が <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> と共有されます。</translation>
+<translation id="1779089405699405702">画像デコーダー</translation>
+<translation id="8067883171444229417">動画を再生します</translation>
+<translation id="6560414384669816528">Sogou で検索します</translation>
+<translation id="5406914950576900927">中国のユーザーは Brave での検索に <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> を使用できます。この設定は [<ph name="BEGIN_LINK"/>設定<ph name="END_LINK"/>] で変更可能です。</translation>
+<translation id="6456271171669383967">Brave Software のままにする</translation>
+<translation id="4384468725000734951">検索に Sogou を使用します</translation>
+<translation id="6103327872225198548">検索に Brave Software を使用します</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/>（<ph name="ITEM_ID"/>）</translation>
+<translation id="919933208285147476">このアプリは Brave で実行中です</translation>
+<translation id="6143689084714664628">Brave で実行中です</translation>
+<translation id="7675869148432102528">Brave にも <ph name="APP_NAME"/> のデータがあります</translation>
+<translation id="2734140769649165081">Brave の設定でデータを削除できます</translation>
+<translation id="8232956427053453090">データを保持</translation>
+<translation id="4298388696830689168">リンク済みのサイト</translation>
+<translation id="5763514718066511291">タップすると、このアプリの URL がコピーされます</translation>
+<translation id="6496823230996795692"><ph name="APP_NAME"/> を初めて使用する場合は、インターネットに接続してください。</translation>
+<translation id="751961395872307827">サイトに接続できません</translation>
+<translation id="4878404682131129617">プロキシ サーバー経由のトンネルを確立できませんでした</translation>
+<translation id="4749960740855309258">新しいタブを開く</translation>
+<translation id="8788968922598763114">最後に閉じたタブを開く</translation>
+<translation id="7929962904089429003">メニューを開く</translation>
+<translation id="6039379616847168523">次のタブに移動する</translation>
+<translation id="5210286577605176222">前のタブに移動する</translation>
+<translation id="124678866338384709">現在のタブを閉じる</translation>
+<translation id="3714981814255182093">検索バーを開く</translation>
+<translation id="5441522332038954058">アドレスバーに移動する</translation>
+<translation id="3398320232533725830">ブックマーク マネージャを開く</translation>
+<translation id="6583199322650523874">現在のページをブックマークする</translation>
+<translation id="8489271220582375723">履歴ページを開く</translation>
+<translation id="4837753911714442426">ページの印刷オプションを開く</translation>
+<translation id="5726692708398506830">ページ上のすべての要素を拡大する</translation>
+<translation id="3259831549858767975">ページ上のすべての要素を縮小する</translation>
+<translation id="8015452622527143194">ページ上のすべての要素をデフォルトのサイズに戻す</translation>
+<translation id="3443221991560634068">現在のページを再読み込みする</translation>
+<translation id="123724288017357924">キャッシュ コンテンツを無視して現在のページを再読み込みする</translation>
+<translation id="305870044889644984">Brave ヘルプセンターを新しいタブで開く</translation>
+<translation id="3166827708714933426">タブとウィンドウのショートカット</translation>
+<translation id="3169981355900570544">Brave Software Brave 機能のショートカット</translation>
+<translation id="4558311620361989323">ウェブページのショートカット</translation>
+<translation id="1908301351964700579">Brave はまだ VR の準備中です。しばらく待ってから Brave を再起動してください。</translation>
+<translation id="8970887620466824814">エラーが発生しました。</translation>
+<translation id="1875543012935658554">Brave を再度開きます。</translation>
+<translation id="79859296434321399">拡張現実（AR）コンテンツを表示するには ARCore をインストールしてください</translation>
+<translation id="8558485628462305855">拡張現実（AR）コンテンツを表示するには ARCore を更新してください</translation>
+<translation id="3513704683820682405">拡張現実（AR）</translation>
+<translation id="5475862044948910901">拡張現実セッションを開始しますか？</translation>
 <translation id="7365126855094612066">このセッションの間、サイトでは次の操作が可能になります。
 • 環境の 3D マップを作成する
 • カメラの動きを追跡する
 
 カメラへのアクセスがサイトに許可されることはなく、他の誰かにカメラの映像が見られることはありません。</translation>
-<translation id="7375125077091615385">タイプ:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />。</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome 初回起動時の操作</translation>
-<translation id="741204030948306876">有効にする</translation>
-<translation id="7413229368719586778">開始日: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">最初に確認する</translation>
-<translation id="7423538860840206698">クリップボードの読み取りがブロックされています</translation>
-<translation id="7431991332293347422">検索などのカスタマイズを目的とした閲覧履歴の使用方法を設定</translation>
-<translation id="7437998757836447326">Chrome からログアウト</translation>
-<translation id="7438641746574390233">ライトモードをオンにすると、Chrome では Google のサーバーを使用してページの読み込みを高速化します。特に読み込みの遅いページでは、ライトモードにより、主要コンテンツのみを読み込むようページが書き換えられます。なお、ライトモードはシークレット タブには適用されません。</translation>
-<translation id="7444811645081526538">その他のカテゴリ</translation>
-<translation id="7445411102860286510">ミュートされた動画の自動再生をサイトに許可する（推奨）</translation>
-<translation id="7453467225369441013">ほとんどのサイトからログアウトします。Google アカウントへのログイン状態は維持されます。</translation>
-<translation id="7454641608352164238">空き容量が不足しています</translation>
-<translation id="7475192538862203634">このメッセージが繰り返し表示される場合は、こちらの<ph name="BEGIN_LINK" />ヒント<ph name="END_LINK" />をお試しください。</translation>
-<translation id="7475688122056506577">SD カードが見つかりません。一部のファイルが欠落している可能性があります。</translation>
-<translation id="7479104141328977413">タブの管理</translation>
-<translation id="7481312909269577407">進む</translation>
-<translation id="7482656565088326534">[プレビュー] タブ</translation>
-<translation id="7493994139787901920"><ph name="VERSION" />（<ph name="TIME_SINCE_UPDATE" />に更新）</translation>
-<translation id="7494974237137038751">データ削減量</translation>
-<translation id="7498271377022651285">お待ちください…</translation>
-<translation id="7514365320538308">ダウンロード</translation>
-<translation id="751961395872307827">サイトに接続できません</translation>
-<translation id="7521387064766892559">Javascript</translation>
-<translation id="7542481630195938534">おすすめの記事を取得できません</translation>
-<translation id="7559975015014302720">ライトモードはオフです</translation>
-<translation id="7562080006725997899">閲覧データの消去</translation>
-<translation id="756809126120519699">Chrome データの消去完了</translation>
-<translation id="757524316907819857">サイトでの保護されたコンテンツの再生をブロックする</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> 件のファイルをダウンロードしました}other{<ph name="FILES_DOWNLOADED_MANY" /> 件のファイルをダウンロードしました}}</translation>
-<translation id="7588219262685291874">デバイスがバッテリー セーバー モードの場合にダークテーマを有効にする</translation>
-<translation id="7589445247086920869">現在の検索エンジンに対してブロック</translation>
-<translation id="7593557518625677601">Chrome の同期を開始するには、Android の設定で Android システムの同期を再度有効にします</translation>
-<translation id="7596558890252710462">オペレーティング システム</translation>
-<translation id="7605594153474022051">同期が機能していません</translation>
-<translation id="7606077192958116810">ライトモードはオンです。[設定] で管理できます。</translation>
-<translation id="7612619742409846846">次のユーザーとして Google にログインしています</translation>
-<translation id="7619072057915878432">ネットワーク障害が発生したため、<ph name="FILE_NAME" /> をダウンロードできませんでした。</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />ヘルプ<ph name="END_LINK1" />または<ph name="BEGIN_LINK2" />再スキャン<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome へようこそ</translation>
-<translation id="7638584964844754484">パスフレーズが正しくありません</translation>
-<translation id="7641339528570811325">閲覧履歴データを削除…</translation>
-<translation id="7648422057306047504">Google の認証情報でパスワードを暗号化する</translation>
-<translation id="7649070708921625228">ヘルプ</translation>
-<translation id="7658239707568436148">キャンセル</translation>
-<translation id="7665369617277396874">アカウントを追加</translation>
-<translation id="766587987807204883">記事がここに表示されます。これらの記事はオフラインでも読むことができます</translation>
-<translation id="7682724950699840886">推奨される対策: デバイスに十分な空き容量があることを確認し、再度エクスポートを試します。</translation>
-<translation id="7685301384041462804">VR を開始する前に、信頼できるサイトかどうかを確認してください。</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> でメールを作成</translation>
-<translation id="7704317875155739195">検索語句や URL をオートコンプリートする</translation>
-<translation id="7725024127233776428">ブックマークしたページがここに表示されます</translation>
-<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE" />のページを常に翻訳する</translation>
-<translation id="7746457520633464754">危険なアプリやサイトを検出するために、アクセスした一部のページの URL と限定的なシステム情報、一部のページ コンテンツが Chrome から Google に送信されます</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> からテキストが共有されました</translation>
-<translation id="7762668264895820836">SD カード <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">住所を追加</translation>
-<translation id="7772032839648071052">パスフレーズの確認</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> を閉じる</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> 件}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 他 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> 件}}</translation>
-<translation id="7781829728241885113">昨日</translation>
-<translation id="7791543448312431591">追加</translation>
-<translation id="780301667611848630">いいえ</translation>
-<translation id="7810647596859435254">アプリで開く…</translation>
-<translation id="7821588508402923572">データ節約量がここに表示されます</translation>
-<translation id="7837721118676387834">特定のサイトに対し、ミュートされた動画の自動再生を許可します。</translation>
-<translation id="7846076177841592234">選択解除</translation>
-<translation id="784934925303690534">期間</translation>
-<translation id="7851858861565204677">他のデバイス</translation>
-<translation id="7875915731392087153">メールを作成</translation>
-<translation id="7876243839304621966">すべて削除</translation>
-<translation id="7882131421121961860">履歴が見つかりません</translation>
-<translation id="7882806643839505685">特定のサイトに対して音声の再生を許可します。</translation>
-<translation id="7886917304091689118">Chrome で実行中です</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ファイルをダウンロードしています。}other{# 件のファイルをダウンロードしています。}}</translation>
-<translation id="7929962904089429003">メニューを開く</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> は最新ではありません。</translation>
-<translation id="7947953824732555851">同意してログイン</translation>
-<translation id="7963646190083259054">ベンダー:</translation>
-<translation id="7971136598759319605">最終同期: 1 日前</translation>
-<translation id="7975379999046275268">ページをプレビュー <ph name="BEGIN_NEW" />New<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">ページをプリロードして、閲覧と検索をすばやく行えるようにします</translation>
-<translation id="79859296434321399">拡張現実（AR）コンテンツを表示するには ARCore をインストールしてください</translation>
-<translation id="7986741934819883144">連絡先の選択</translation>
-<translation id="7987073022710626672">Chrome 利用規約</translation>
-<translation id="7998918019931843664">閉じたタブを開く</translation>
-<translation id="7999064672810608036">すべてのローカルデータ（Cookie を含む）を削除して、このウェブサイトに指定したすべての権限をリセットしてもよろしいですか？</translation>
-<translation id="8004582292198964060">ブラウザ</translation>
-<translation id="8007176423574883786">このデバイスに対して無効</translation>
-<translation id="8013372441983637696">Chrome データもこのデバイスから削除する</translation>
-<translation id="8015452622527143194">ページ上のすべての要素をデフォルトのサイズに戻す</translation>
-<translation id="802154636333426148">ダウンロード エラー</translation>
-<translation id="8026334261755873520">閲覧履歴データの削除</translation>
-<translation id="8035133914807600019">新しいフォルダ...</translation>
-<translation id="8037750541064988519">残り <ph name="DAYS" /> 日</translation>
-<translation id="804335162455518893">SD カードが見つかりません</translation>
-<translation id="805047784848435650">閲覧履歴から</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB 利用可</translation>
-<translation id="8058746566562539958">新しい Chrome タブで開く</translation>
-<translation id="8063895661287329888">ブックマークを追加できませんでした。</translation>
-<translation id="806745655614357130">データを別に保持する</translation>
-<translation id="8067883171444229417">動画を再生します</translation>
-<translation id="8068648041423924542">証明書を選択できません</translation>
-<translation id="8073388330009372546">新しいタブで画像を開く</translation>
-<translation id="8076492880354921740">タブ</translation>
-<translation id="8084114998886531721">保存したパスワード</translation>
-<translation id="8087000398470557479"><ph name="DOMAIN_NAME" /> のコンテンツを Google から配信しています。</translation>
-<translation id="8103578431304235997">シークレット タブ</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">お使いのどのデバイスでも同じブックマークを使用するには、同期を有効にします</translation>
-<translation id="8110087112193408731">Chrome のアクティビティを Digital Wellbeing で表示しますか？</translation>
-<translation id="8116925261070264013">ミュート中</translation>
-<translation id="813082847718468539">サイト情報を表示</translation>
-<translation id="8131740175452115882">確認</translation>
-<translation id="8156139159503939589">どの言語で閲覧しますか？</translation>
-<translation id="8168435359814927499">コンテンツ</translation>
-<translation id="8186512483418048923">残り <ph name="FILES" /> ファイル</translation>
-<translation id="8190358571722158785">残り 1 日</translation>
-<translation id="8200772114523450471">再開</translation>
-<translation id="8209050860603202033">画像を開く</translation>
-<translation id="8218622182176210845">アカウントを管理</translation>
-<translation id="8224471946457685718">Wi-Fi 接続時に記事をダウンロード</translation>
-<translation id="8232956427053453090">データを保持</translation>
-<translation id="8249310407154411074">一番上に移動</translation>
-<translation id="8250920743982581267">ドキュメント</translation>
-<translation id="825412236959742607">このページは大量のメモリを使用しているため、Chrome により一部のコンテンツが削除されました。</translation>
-<translation id="8260126382462817229">もう一度ログインしてみてください</translation>
-<translation id="8261506727792406068">削除</translation>
-<translation id="8266862848225348053">ダウンロード場所</translation>
-<translation id="8274165955039650276">ダウンロードを表示</translation>
-<translation id="8284326494547611709">字幕</translation>
-<translation id="8300705686683892304">アプリによる管理</translation>
-<translation id="8310344678080805313">標準のタブ</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> とその他のサイト</translation>
-<translation id="8327155640814342956">快適にご利用いただけるよう、Chrome を開いて更新することをおすすめします</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" />のページは翻訳されません</translation>
-<translation id="8349013245300336738">データ使用量で並べ替え</translation>
-<translation id="8364299278605033898">人気のウェブサイトを表示します</translation>
-<translation id="8368027906805972958">不明またはサポートされていないデバイス（<ph name="DEVICE_ID" />）</translation>
-<translation id="8372893542064058268">特定のサイトに対してバックグラウンド同期を許可します。</translation>
-<translation id="8378714024927312812">組織によって管理されています</translation>
-<translation id="8380167699614421159">このサイトでは煩わしい広告や誤解を招く広告が表示されます</translation>
-<translation id="8393700583063109961">メッセージを送信</translation>
-<translation id="8413126021676339697">全履歴を表示</translation>
-<translation id="8427875596167638501">[プレビュー] タブが半分開いています</translation>
-<translation id="8428213095426709021">設定</translation>
-<translation id="8438566539970814960">検索とブラウジングを改善する</translation>
-<translation id="8441146129660941386">後方にシーク再生</translation>
-<translation id="8443209985646068659">Chrome を更新できません</translation>
-<translation id="8445448999790540984">パスワードをエクスポートできません</translation>
-<translation id="8447861592752582886">デバイスの許可を取り消します</translation>
-<translation id="8461694314515752532">同期データを同期パスフレーズで暗号化する</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> がインターネットに接続していることを確認してください</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">オフラインでの利用</translation>
-<translation id="8489271220582375723">履歴ページを開く</translation>
-<translation id="8493948351860045254">容量を空ける</translation>
-<translation id="8497726226069778601">表示するものがまだありません</translation>
-<translation id="8503559462189395349">Chrome パスワード</translation>
-<translation id="8503813439785031346">ユーザー名</translation>
-<translation id="8514477925623180633">Chrome に保存されたパスワードをエクスポートします</translation>
-<translation id="8514577642972634246">シークレット モードを開始</translation>
-<translation id="851751545965956758">サイトからデバイスへの接続をブロックする</translation>
-<translation id="8523928698583292556">保存したパスワードを削除</translation>
-<translation id="854522910157234410">このページを開く</translation>
-<translation id="8558485628462305855">拡張現実（AR）コンテンツを表示するには ARCore を更新してください</translation>
-<translation id="8559990750235505898">他の言語のページで翻訳するかどうかを尋ねる</translation>
-<translation id="8562452229998620586">保存したパスワードはこちらに表示されます。</translation>
-<translation id="8569404424186215731">（<ph name="DATE" />以降）</translation>
-<translation id="8571213806525832805">過去 4 週間</translation>
-<translation id="857943718398505171">許可（推奨）</translation>
-<translation id="8583805026567836021">アカウント データをクリア中</translation>
-<translation id="860043288473659153">カード名義人</translation>
-<translation id="8609465669617005112">上に移動</translation>
-<translation id="8616006591992756292">お使いの Google アカウントの <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> に、他の形式の閲覧履歴が記録されている場合があります。</translation>
-<translation id="8617240290563765734">ダウンロード コンテンツに指定されている URL を開きますか？</translation>
-<translation id="8636825310635137004">他のデバイスと同じタブを使用するには、同期を有効にします。</translation>
-<translation id="8641930654639604085">成人向けのサイトを可能な限りブロックする</translation>
-<translation id="8655129584991699539">Chrome の設定でデータを削除できます</translation>
-<translation id="8662811608048051533">ほとんどのサイトからログアウトします。</translation>
-<translation id="8664979001105139458">同じ名前のファイルが存在します</translation>
-<translation id="8676374126336081632">入力内容を消去</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{電波強度: レベル #}other{電波強度: レベル #}}</translation>
-<translation id="868929229000858085">連絡先を検索</translation>
-<translation id="869891660844655955">有効期限</translation>
-<translation id="8719023831149562936">現在のタブはビームできません</translation>
-<translation id="8725066075913043281">やり直し</translation>
-<translation id="8728487861892616501">このアプリケーションを使用すると、Chrome の<ph name="BEGIN_LINK1" />利用規約<ph name="END_LINK1" />と<ph name="BEGIN_LINK2" />プライバシーに関するお知らせ<ph name="END_LINK2" />、および <ph name="BEGIN_LINK3" />ファミリー リンクで管理する Google アカウントのプライバシーに関するお知らせ<ph name="END_LINK3" />に同意したことになります。</translation>
-<translation id="8730621377337864115">完了</translation>
-<translation id="8748850008226585750">メッセージは非表示です</translation>
-<translation id="8751914237388039244">画像を選択</translation>
-<translation id="8788265440806329501">ナビゲーション履歴は閉じられています</translation>
-<translation id="8788968922598763114">最後に閉じたタブを開く</translation>
-<translation id="8801436777607969138">特定のサイトで JavaScript をブロックします。</translation>
-<translation id="8812260976093120287">一部のウェブサイトでは、デバイスでサポートされている上記のお支払いアプリを使って支払いができます。</translation>
-<translation id="8816026460808729765">サイトによるセンサーへのアクセスをブロックする</translation>
-<translation id="8816439037877937734">Chrome で <ph name="APP_NAME" /> を開きます。続行すると、Chrome の<ph name="BEGIN_LINK1" />利用規約<ph name="END_LINK1" />と<ph name="BEGIN_LINK2" />プライバシーに関するお知らせ<ph name="END_LINK2" />、および <ph name="BEGIN_LINK3" />ファミリー リンクで作成された Google アカウントのプライバシーに関するお知らせ<ph name="END_LINK3" />に同意したことになります。</translation>
-<translation id="8820817407110198400">ブックマーク</translation>
-<translation id="8833831881926404480">サイトが画面を共有しています</translation>
-<translation id="883806473910249246">コンテンツのダウンロード中にエラーが発生しました。</translation>
-<translation id="8840953339110955557">このページはオンライン版とは異なる可能性があります。</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">「<ph name="TAB_TITLE" />」タブ</translation>
-<translation id="885701979325669005">ストレージ</translation>
-<translation id="889338405075704026">Chrome 設定に移動</translation>
-<translation id="8901170036886848654">ブックマークが見つかりません</translation>
-<translation id="8909135823018751308">共有...</translation>
-<translation id="8912362522468806198">Google アカウントを使用</translation>
-<translation id="8920114477895755567">保護者の情報を待っています。</translation>
+<translation id="1188239144602654184">AR を開始</translation>
+<translation id="473775607612524610">更新</translation>
+<translation id="3133489217401741157">Brave 用の <ph name="MODULE"/> をインストールしています…</translation>
+<translation id="1791662854739702043">インストール先</translation>
+<translation id="5131234170665854056">Brave 用の <ph name="MODULE"/> をインストールできません</translation>
+<translation id="2567385386134582609">画像</translation>
+<translation id="6395288395575013217">リンク</translation>
+<translation id="7352939065658542140">動画</translation>
+<translation id="4116038641877404294">ページをダウンロードするとオフラインで使用できるようになります</translation>
 <translation id="8922289737868596582">[その他のオプション] からページをダウンロードするとオフラインで使用できるようになります</translation>
-<translation id="8937772741022875483">Chrome のアクティビティを Digital Wellbeing から削除しますか？</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">別のウィンドウで開く</translation>
-<translation id="8951232171465285730">Chrome で <ph name="MEGABYTES" /> MB の容量を節約しました</translation>
-<translation id="8958424370300090006">特定のサイトの Cookie をブロックします。</translation>
-<translation id="8959122750345127698"><ph name="URL" /> にアクセスできません</translation>
-<translation id="8965591936373831584">保留中</translation>
-<translation id="8970887620466824814">エラーが発生しました。</translation>
-<translation id="8972098258593396643">デフォルトのフォルダにダウンロードしますか？</translation>
-<translation id="8986494364107987395">使用統計データと障害レポートを Google に自動送信します</translation>
-<translation id="8993760627012879038">新しいタブをシークレット モードで開く</translation>
-<translation id="8998729206196772491"><ph name="MANAGED_DOMAIN" /> で管理されているアカウントでログインして、Chrome データの管理を管理者に委ねようとしています。この操作を行うと、データはこのアカウントに恒久的に関連付けられます。Chrome からログアウトすると、データはこのデバイスから削除されますが、Google アカウントには残ります。</translation>
-<translation id="9019902583201351841">保護者により管理されています</translation>
-<translation id="9028914725102941583">デバイス間で共有するには同期をオンにします</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> に VR の開始を許可しますか？</translation>
-<translation id="9040142327097499898">通知が許可されていますが、位置情報がデバイスでオフになっています。</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# 個の動画}other{# 個の動画}}</translation>
-<translation id="9050666287014529139">パスフレーズ</translation>
-<translation id="9063523880881406963">[PC 版サイトを見る] をオフにします</translation>
-<translation id="9065203028668620118">編集</translation>
-<translation id="9070377983101773829">音声検索を開始</translation>
-<translation id="9074336505530349563">ユーザーに合わせた Google からのおすすめコンテンツを表示するには、ログインして同期を有効にします</translation>
-<translation id="9086455579313502267">ネットワークにアクセスできません</translation>
-<translation id="9100505651305367705">記事の簡易表示がサポートされている場合、簡易表示を提案します</translation>
-<translation id="9100610230175265781">パスフレーズを入力してください</translation>
-<translation id="9102803872260866941">[プレビュー] タブが開いています</translation>
+<translation id="5958275228015807058">[ダウンロード] で自分のファイルやページを探すことができます</translation>
+<translation id="5620928963363755975">[その他のオプション] から [ダウンロード] を開いて自分のファイルやページを探すことができます</translation>
+<translation id="3341058695485821946">データ削減量を確認できます</translation>
+<translation id="3157842584138209013">[その他のオプション] からデータ削減量を確認できます</translation>
+<translation id="8218622182176210845">アカウントを管理</translation>
+<translation id="8090895580117672212">Brave Software アカウントを管理するには、[アカウントを管理] をタップします。</translation>
+<translation id="8856898588039823173">Brave Software から提供されている軽量版のページです。元のページを読み込むにはタップしてください。</translation>
+<translation id="8134317863207426198">Brave Software から提供されている軽量版のページです。元のページを読み込むには [元のサイトを表示] をタップしてください。</translation>
+<translation id="4961107849584082341">このページを任意の言語に翻訳できます</translation>
+<translation id="569536719314091526">[その他のオプション] から、このページを任意の言語に翻訳できます</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> で検索</translation>
+<translation id="1792959175193046959">デフォルトのダウンロード保存先はいつでも変更できます</translation>
+<translation id="6942665639005891494">デフォルトのダウンロード保存先は [設定] メニューでいつでも変更できます</translation>
+<translation id="6850409657436465440">ダウンロードが進行中です</translation>
+<translation id="5817715962196959877">Brave でのファイルのダウンロードがさらに速くなりました</translation>
+<translation id="3976396876660209797">このショートカットを削除して再度作成します</translation>
+<translation id="6766622839693428701">閉じるには下にスワイプします。</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> に送信しています...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> から送信</translation>
+<translation id="5357811892247919462">タブが共有されました</translation>
 <translation id="9104217018994036254">タブを共有するデバイスのリストです。</translation>
-<translation id="9133397713400217035">オフライン コンテンツ</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" />（<ph name="ITEM_ID" />）</translation>
-<translation id="9137013805542155359">原文のページを表示</translation>
-<translation id="9139068048179869749">サイトに通知の送信を許可する前に確認する（推奨）</translation>
-<translation id="9139318394846604261">ショッピング</translation>
-<translation id="9155898266292537608">単語をタップするだけでも検索できます</translation>
-<translation id="9169507124922466868">ナビゲーション履歴が半分開いています</translation>
-<translation id="9204836675896933765">残り 1 ファイル</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">タブを共有するデバイスのリストが画面の下半分に表示されました。</translation>
+<translation id="2904414404539560095">タブを共有するデバイスのリストが画面全体に表示されました。</translation>
+<translation id="4135200667068010335">タブを共有するデバイスのリストが閉じられました。</translation>
+<translation id="5292796745632149097">送信先</translation>
+<translation id="1386674309198842382">最終同期: <ph name="LAST_UPDATED"/> 日前</translation>
+<translation id="7971136598759319605">最終同期: 1 日前</translation>
+<translation id="1521774566618522728">最終同期: 今日</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> と共有しています</translation>
+<translation id="9028914725102941583">デバイス間で共有するには同期をオンにします</translation>
+<translation id="6162454065885854378">お使いのスマートフォンから別のデバイスにデータを共有するには、両方のデバイスの Brave 設定で同期をオンにしてください</translation>
+<translation id="6084271560289605378">Brave 設定に移動</translation>
+<translation id="2318045970523081853">タップして電話をかける</translation>
 <translation id="9209888181064652401">通話ができません</translation>
-<translation id="9219103736887031265">画像</translation>
-<translation id="926205370408745186">Chrome のアクティビティを Digital Wellbeing から削除</translation>
-<translation id="932327136139879170">ホーム</translation>
-<translation id="938850635132480979">エラー: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">マイクへのアクセス</translation>
-<translation id="95817756606698420">中国のユーザーは Chrome での検索に <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> を使用できます。この設定は [<ph name="BEGIN_LINK" />設定<ph name="END_LINK" />] で変更可能です。</translation>
-<translation id="965817943346481315">煩わしい広告や誤解を招く広告が表示されるサイトの場合にブロック（推奨）</translation>
-<translation id="968900484120156207">アクセスしたページがここに表示されます</translation>
-<translation id="970715775301869095">残り <ph name="MINUTES" /> 分</translation>
-<translation id="974555521953189084">同期を開始するにはパスワードを入力します</translation>
-<translation id="981121421437150478">オフライン</translation>
-<translation id="982182592107339124">この操作を行うと、次を含むすべてのサイトのデータが削除されます。</translation>
-<translation id="983192555821071799">すべてのタブを閉じる</translation>
-<translation id="987264212798334818">全般</translation>
+<translation id="2860954141821109167">このデバイスで通話アプリが有効になっていることを確認してください</translation>
+<translation id="2067805253194386918">テキスト</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> を共有できません</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> を共有できませんでした</translation>
+<translation id="8287068819750208230">Brave で <ph name="TARGET_DEVICE_NAME"/> の同期がオンになっていることを確認してください</translation>
+<translation id="3016635187733453316">このデバイスがインターネットに接続していることを確認してください</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> がインターネットに接続していることを確認してください</translation>
+<translation id="6539092367496845964">エラーが発生しました。しばらくしてからもう一度お試しください。</translation>
+<translation id="3389286852084373014">テキストが大きすぎます</translation>
+<translation id="2100314319871056947">共有するテキスト ブロックを小さくしてください</translation>
+<translation id="2987620471460279764">他のデバイスからテキストが共有されました</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> からテキストが共有されました</translation>
+<translation id="5193988420012215838">クリップボードにコピーされました</translation>
+<translation id="4696983787092045100">デバイスにテキストを送信</translation>
+<translation id="1260236875608242557">検索</translation>
+<translation id="6369229450655021117">ここからウェブを検索したり、友だちと共有したり、開いたページを表示したりできます</translation>
+<translation id="723171743924126238">画像を選択</translation>
+<translation id="8751914237388039244">画像を選択</translation>
+<translation id="1989112275319619282">閲覧</translation>
+<translation id="7055152154916055070">リダイレクトがブロックされました</translation>
+<translation id="5524843473235508879">リダイレクトがブロックされました。</translation>
+<translation id="6573096386450695060">常に許可</translation>
+<translation id="5805364706385912897">このページは大量のメモリを使用しているため、Brave により一時停止されました。</translation>
+<translation id="5138664332909611586">このページは大量のメモリを使用しているため、Brave により一部のコンテンツが削除されました。</translation>
+<translation id="9137013805542155359">原文のページを表示</translation>
+<translation id="6361779936989026201">Brave の Brave Software アシスタント</translation>
+<translation id="7291387454912369099">アシスタントによる購入手続き</translation>
+<translation id="4565206163201411670">Brave のアクティビティを Digital Wellbeing で表示しますか？</translation>
+<translation id="9055113864158719823">Brave でアクセスしたサイトを表示し、タイマーを設定できます。\n\nタイマーを設定したサイトの情報と、サイトでの滞在時間に関する情報が Brave Software に送信されます。送信した情報は Digital Wellbeing の改善に役立てられます。</translation>
+<translation id="4596514158372210596">Brave のアクティビティを Digital Wellbeing から削除</translation>
+<translation id="1174893863889683998">Brave のアクティビティを Digital Wellbeing から削除しますか？</translation>
+<translation id="708829030563435351">Brave でアクセスしたサイトは表示されなくなり、サイトに設定したタイマーはすべて削除されます。</translation>
+<translation id="2056878612599315956">サイト一時停止中</translation>
+<translation id="671481426037969117"><ph name="FQDN"/> のタイマーが切れました。タイマーはまた明日開始されます。</translation>
+<translation id="7479104141328977413">タブの管理</translation>
+<translation id="3524138585025253783">デベロッパー管理画面</translation>
+<translation id="6036057147555329831">その他の ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> に VR の開始を許可しますか？</translation>
+<translation id="7685301384041462804">VR を開始する前に、信頼できるサイトかどうかを確認してください。</translation>
+<translation id="5033865233969348410">VR の使用中、このサイトで次の情報が把握される場合があります。
+  -  あなたの身体的特徴（身長など）
+
+VR を開始する前に、信頼できるサイトかどうかを確認してください。</translation>
+<translation id="5534334044554683961">VR の使用中、このサイトで次の情報が把握される場合があります。
+  -   あなたの身体的特徴（身長など）
+  -   あなたの部屋のレイアウト
+
+VR を開始する前に、信頼できるサイトかどうかを確認してください。</translation>
+<translation id="4169535189173047238">許可しない</translation>
+<translation id="2170088579611075216">VR を許可して開始</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_kn.xtb
+++ b/android/java/strings/translations/android_chrome_strings_kn.xtb
@@ -1,1119 +1,1102 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="kn">
-<translation id="1006017844123154345">ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> ಗೆ ಕಳುಹಿಸಲಾಗುತ್ತಿದೆ...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> ಅನ್ನು ಸೇರಿಸಲಾಗುತ್ತಿದೆ...</translation>
-<translation id="1041308826830691739">ವೆಬ್‌ಸೈಟ್‌ಗಳ ಮೂಲಕ</translation>
-<translation id="1049743911850919806">ಅದೃಶ್ಯ</translation>
-<translation id="10614374240317010">ಉಳಿಸಿಯೇ ಇಲ್ಲ</translation>
-<translation id="1067922213147265141">ಇತರ Google ಸೇವೆಗಳು</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" /> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು ಎಂದಿಗೂ ಅನುವಾದ ಮಾಡಬೇಡಿ</translation>
-<translation id="107147699690128016">ಫೈಲ್ ವಿಸ್ತರಣೆಯನ್ನು ಬದಲಾಯಿಸಿದರೆ, ಇತರ ಅಪ್ಲಿಕೇಶನ್‌ಗಳಲ್ಲಿ ಫೈಲ್‌ ಅನ್ನು ತೆರೆಯಬಹುದು ಮತ್ತು ನಿಮ್ಮ ಸಾಧನವನ್ನು ಹಾನಿಗೊಳಿಸಬಹುದು.</translation>
-<translation id="1100066534610197918">ಗುಂಪಿನ ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆ</translation>
-<translation id="1105960400813249514">ಪರದೆ ಕ್ಯಾಪ್ಚರ್</translation>
-<translation id="1111673857033749125">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಲ್ಲಿ ಉಳಿಸಲಾದ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ.</translation>
-<translation id="1113597929977215864">ಸರಳೀಕೃತ ವೀಕ್ಷಣೆಯನ್ನು ತೋರಿಸಿ</translation>
-<translation id="1121094540300013208">ಬಳಕೆ ಮತ್ತು ಕ್ರ್ಯಾಶ್ ವರದಿಗಳು</translation>
-<translation id="1124772482545689468">ಬಳಕೆದಾರ</translation>
-<translation id="1129510026454351943">ವಿವರಗಳು: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 ಡೌನ್‌ಲೋಡ್ ಬಾಕಿ ಇದೆ.}one{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಬಾಕಿ ಇವೆ.}other{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಬಾಕಿ ಇವೆ.}}</translation>
-<translation id="1145536944570833626">ಪ್ರಸ್ತುತ ಡೇಟಾ ಅಳಿಸಿ.</translation>
-<translation id="1146678959555564648">VR ನಮೂದಿಸಿ</translation>
-<translation id="116280672541001035">ಬಳಕೆಯಾಗಿದ್ದು</translation>
-<translation id="1171770572613082465">"ಉನ್ನತ ಸೈಟ್‌ಗಳು" ಬಟನ್ ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕ ಜನಪ್ರಿಯ ವೆಬ್‌ಸೈಟ್‌ಗಳನ್ನು ನೋಡಿ</translation>
-<translation id="1173894706177603556">ಮರುಹೆಸರಿಸು</translation>
-<translation id="1178581264944972037">ವಿರಾಮ</translation>
-<translation id="1181037720776840403">ತೆಗೆದುಹಾಕು</translation>
-<translation id="1188239144602654184">AR ಅನ್ನು ನಮೂದಿಸಿ</translation>
-<translation id="1197267115302279827">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಚಲಿಸಿ</translation>
-<translation id="119944043368869598">ಎಲ್ಲವನ್ನೂ ತೆಗೆದುಹಾಕಿ</translation>
-<translation id="1201402288615127009">ಮುಂದೆ</translation>
-<translation id="1204037785786432551">ಲಿಂಕ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="1206892813135768548">ಲಿಂಕ್ ಪಠ್ಯವನ್ನು ನಕಲಿಸಿ</translation>
-<translation id="1208340532756947324">ಸಾಧನಗಳಾದ್ಯಂತ ಸಿಂಕ್ ಮಾಡಲು ಮತ್ತು ವೈಯಕ್ತೀಕರಿಸಲು, ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
-<translation id="1209206284964581585">ಸದ್ಯಕ್ಕೆ ಮರೆಮಾಡಿ</translation>
-<translation id="1227058898775614466">ನ್ಯಾವಿಗೇಶನ್ ಇತಿಹಾಸ</translation>
-<translation id="1231733316453485619">ಸಿಂಕ್ ಆನ್ ಮಾಡುವುದೇ?</translation>
-<translation id="123724288017357924">ಸಂಗ್ರಹ ಮಾಡಿದ ವಿಷಯವನ್ನು ನಿರ್ಲಕ್ಷಿಸಿ, ಪ್ರಸ್ತುತ ಪುಟ ಮರುಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="124116460088058876">ಹೆಚ್ಚಿನ ಭಾಷೆಗಳು</translation>
-<translation id="124678866338384709">ಪ್ರಸ್ತುತ ಟ್ಯಾಬ್ ಮುಚ್ಚಿ</translation>
-<translation id="1258753120186372309">Google ಡೂಡಲ್‌: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">ಹುಡುಕಿ ಮತ್ತು ಎಕ್ಸ್‌ಪ್ಲೋರ್‌‌ ಮಾಡಿ</translation>
-<translation id="1264974993859112054">ಕ್ರೀಡೆ</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
-<translation id="1272079795634619415">ನಿಲ್ಲಿಸಿ</translation>
-<translation id="1283039547216852943">ವಿಸ್ತರಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
-<translation id="1285320974508926690">ಈ ಸೈಟ್ ಅನ್ನು ಎಂದಿಗೂ ಭಾಷಾಂತರಿಸದಿರಿ</translation>
-<translation id="1291207594882862231">ಇತಿಹಾಸ, ಕುಕೀಗಳು, ಸೈಟ್‌ ಡೇಟಾ, ಕ್ಯಾಷ್ ಅನ್ನು ತೆರವುಗೊಳಿಸಿ…</translation>
-<translation id="129382876167171263">ವೆಬ್‌ಸೈಟ್‌ಗಳ ಮೂಲಕ ಉಳಿಸಲಾಗಿರುವ ಫೈಲ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ</translation>
-<translation id="129553762522093515">ಇತ್ತೀಚೆಗೆ ಮುಚ್ಚಲಾಗಿರುವುದು</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> ಸಾಧನದಿಂದ ಕಳುಹಿಸಲಾಗಿದೆ</translation>
-<translation id="1310482092992808703">ಟ್ಯಾಬ್‌ಗಳನ್ನು ಗುಂಪು ಮಾಡಿ</translation>
-<translation id="1327257854815634930">ನ್ಯಾವಿಗೇಶನ್ ಇತಿಹಾಸ ತೆರೆದಿದೆ</translation>
-<translation id="1331212799747679585">Chrome ಅಪ್‌ಡೇಟ್ ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ. ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು</translation>
-<translation id="1332501820983677155">Google Chrome ವೈಶಿಷ್ಟ್ಯ ಶಾರ್ಟ್‌ಕಟ್‌ಗಳು</translation>
-<translation id="1360432990279830238">ಸೈನ್ ಔಟ್ ಮಾಡಿ, ಸಿಂಕ್ ಆಫ್ ಮಾಡುವುದೇ?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> ಸೈಟ್ ಸೇರಿಸಲಾಗಿದೆ</translation>
-<translation id="1373696734384179344">ಆಯ್ಕೆಮಾಡಲಾದ ವಿಷಯವನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲು ಮೆಮೊರಿಯು ಸಾಕಾಗುವುದಿಲ್ಲ.</translation>
-<translation id="1376578503827013741">ಲೆಕ್ಕ ಮಾಡುತ್ತಿದೆ...</translation>
-<translation id="1383876407941801731">ಹುಡುಕಾಟ</translation>
-<translation id="1384959399684842514">ಡೌನ್‌ಲೋಡ್ ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> ದಿನಗಳ ಹಿಂದೆ ಸಕ್ರಿಯ</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> ಮೂಲಕ ಹುಡುಕಿ</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" /> ರಲ್ಲಿ ಎಂಬೆಡ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="1406000523432664303">“ಟ್ರ್ಯಾಕ್ ಮಾಡಬೇಡಿ”</translation>
-<translation id="1407135791313364759">ಎಲ್ಲವನ್ನೂ ತೆರೆಯಿರಿ</translation>
-<translation id="1409426117486808224">ತೆರೆದ ಟ್ಯಾಬ್‌ಗಳಿಗಾಗಿ ಸರಳೀಕೃತ ವೀಕ್ಷಣೆ</translation>
-<translation id="1409879593029778104">ಫೈಲ್ ಈಗಾಗಲೇ ಇರುವುದರಿಂದ <ph name="FILE_NAME" /> ಡೌನ್‌ಲೋಡ್ ತಡೆಯಲಾಗಿದೆ.</translation>
-<translation id="1414981605391750300">Google ಅನ್ನು ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ. ಇದು ಒಂದು ನಿಮಿಷದಷ್ಟು ಸಮಯ ತೆಗೆದುಕೊಳ್ಳಬಹುದು...</translation>
-<translation id="1416550906796893042">ಅಪ್ಲಿಕೇಶನ್ ಆವೃತ್ತಿ</translation>
-<translation id="1430915738399379752">ಮುದ್ರಿಸು</translation>
-<translation id="1446450296470737166">MIDI ಸಾಧನಗಳ ಪೂರ್ಣ ನಿಯಂತ್ರಣ ಅನುಮತಿಸಿ</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" />ವನ್ನು ಹಂಚಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ</translation>
-<translation id="145097072038377568">Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಆಫ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="1477626028522505441">ಸರ್ವರ್ ಸಮಸ್ಯೆಗಳ ಕಾರಣದಿಂದಾಗಿ <ph name="FILE_NAME" /> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
-<translation id="1506061864768559482">ಹುಡುಕಾಟ ಇಂಜಿನ್</translation>
-<translation id="1513352483775369820">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಮತ್ತು ವೆಬ್ ಇತಿಹಾಸ</translation>
-<translation id="1513858653616922153">ಪಾಸ್‌ವರ್ಡ್ ಅಳಿಸಿ</translation>
-<translation id="1516229014686355813">"ಹುಡುಕಲು ಟ್ಯಾಪ್‌ ಮಾಡಿ" ಮೂಲಕ ಆಯ್ಕೆಮಾಡಿದ ಪದ ಮತ್ತು ಪ್ರಸ್ತುತ ಪುಟವನ್ನು ಸಂದರ್ಭಕ್ಕೆ ತಕ್ಕಂತೆ Google ಹುಡುಕಾಟಕ್ಕೆ ಕಳುಹಿಸುತ್ತದೆ. ನೀವು ಇದನ್ನು <ph name="BEGIN_LINK" />ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಆಫ್ ಮಾಡಬಹುದು.</translation>
-<translation id="1521774566618522728">ಇಂದು ಸಕ್ರಿಯ</translation>
-<translation id="1544826120773021464">ನಿಮ್ಮ Google ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಲು, "ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ" ಬಟನ್ ಅನ್ನು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
-<translation id="1549000191223877751">ಇತರ ವಿಂಡೋಗೆ ಸರಿಸಿ</translation>
-<translation id="1553358976309200471">Chrome ಅಪ್‌ಡೇಟ್‌ ಮಾಡಿ</translation>
-<translation id="1569387923882100876">ಸಂಪರ್ಕಿಸಲಾದ ಸಾಧನ</translation>
-<translation id="1571304935088121812">ಬಳಕೆದಾರರಹೆಸರು ನಕಲಿಸಿ</translation>
-<translation id="1612196535745283361">ಸಾಧನಗಳನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಲು Chrome ಗೆ ಸ್ಥಳ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ. ಸ್ಥಳ ಪ್ರವೇಶವನ್ನು <ph name="BEGIN_LINK" />
-ಈ ಸಾಧನಕ್ಕೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">ಕ್ಯಾಮರಾ</translation>
-<translation id="1623104350909869708">ಹೆಚ್ಚುವರಿ ಸಂವಾದಗಳನ್ನು ರಚಿಸದಂತೆ ಈ ಪುಟವನ್ನು ತಡೆಯಿರಿ</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{ಆಯ್ಕೆಮಾಡಲಾದ 1 ಐಟಂ ತೆಗೆದುಹಾಕಿ}one{ಆಯ್ಕೆಮಾಡಲಾದ # ಐಟಂಗಳನ್ನು ತೆಗೆದುಹಾಕಿ}other{ಆಯ್ಕೆಮಾಡಲಾದ # ಐಟಂಗಳನ್ನು ತೆಗೆದುಹಾಕಿ}}</translation>
-<translation id="164269334534774161">ನೀವು <ph name="CREATION_TIME" /> ದಿನಾಂಕದಿಂದ ಈ ಪುಟದ ಆಫ್‌ಲೈನ್‌ ನಕಲನ್ನು ವೀಕ್ಷಿಸುತ್ತಿರುವಿರಿ</translation>
-<translation id="1644574205037202324">ಇತಿಹಾಸ</translation>
-<translation id="1647391597548383849">ನಿಮ್ಮ ಕ್ಯಾಮರಾವನ್ನು ಪ್ರವೇಶಿಸಿ</translation>
-<translation id="1660204651932907780">ಧ್ವನಿಯನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="1670399744444387456">ಮೂಲ</translation>
-<translation id="1671236975893690980">ಡೌನ್‌ಲೋಡ್ ಬಾಕಿ ಉಳಿದಿದೆ...</translation>
-<translation id="1672586136351118594">ಮತ್ತೊಮ್ಮೆ ತೋರಿಸಬೇಡಿ</translation>
-<translation id="1692118695553449118">ಸಿಂಕ್‌ ಆನ್‌ ಆಗಿದೆ</translation>
-<translation id="169515064810179024">ಚಲನಾ ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸದಂತೆ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="1717218214683051432">ಮೋಷನ್ ಸೆನ್ಸಾರ್‌ಗಳು</translation>
-<translation id="1718835860248848330">ಕೊನೆಯ ಗಂಟೆ</translation>
-<translation id="1736419249208073774">ಎಕ್ಸ್‌ಪ್ಲೋರ್ ಮಾಡಿ</translation>
-<translation id="1743802530341753419">ಸಾಧನಕ್ಕೆ ಸಂಪರ್ಕಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="1749561566933687563">ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
-<translation id="17513872634828108">ತೆರೆದ ಟ್ಯಾಬ್‌ಗಳು</translation>
-<translation id="1779089405699405702">ಚಿತ್ರದ ಡಿಕೋಡರ್</translation>
-<translation id="1782483593938241562">ಅಂತಿಮ ದಿನಾಂಕ <ph name="DATE" /></translation>
-<translation id="1791662854739702043">ಸ್ಥಾಪಿಸಲಾಗಿದೆ</translation>
-<translation id="1792959175193046959">ಡಿಫಾಲ್ಟ್ ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳವನ್ನು ಯಾವಾಗ ಬೇಕಾದರೂ ಬದಲಾಯಿಸಿ</translation>
-<translation id="1807246157184219062">ತಿಳಿ</translation>
-<translation id="1810845389119482123">ಆರಂಭಿಕ ಸಿಂಕ್ ಸೆಟಪ್ ಪೂರ್ಣಗೊಂಡಿಲ್ಲ</translation>
-<translation id="1821253160463689938">ನೀವು ಆ ಪುಟಗಳಿಗೆ ಭೇಟಿ ನೀಡದಿದ್ದರೂ, ನಿಮ್ಮ ಆದ್ಯತೆಗಳನ್ನು ನೆನಪಿಟ್ಟುಕೊಳ್ಳಲು ಕುಕೀಗಳನ್ನು ಬಳಸುತ್ತದೆ</translation>
-<translation id="1829244130665387512">ಪುಟದಲ್ಲಿ ಹುಡುಕಿ</translation>
-<translation id="1853692000353488670">ಹೊಸ ಅದೃಶ್ಯ ವಿಂಡೋ</translation>
-<translation id="1856325424225101786">ಲೈಟ್ ಮೋಡ್ ಅನ್ನು ಮರುಹೊಂದಿಸಬೇಕೇ?</translation>
-<translation id="1868024384445905608">Chrome ಈಗ ಫೈಲ್‌ಗಳನ್ನು ವೇಗವಾಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತದೆ</translation>
-<translation id="1883903952484604915">ನನ್ನ ಫೈಲ್‌ಗಳು</translation>
-<translation id="1887786770086287077">ಈ ಸಾಧನದ ಸ್ಥಳ ಪ್ರವೇಶ ಆಫ್ ಆಗಿದೆ. ಅದನ್ನು <ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಆನ್ ಮಾಡಿ.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> Chrome ನಲ್ಲಿ ತೆರೆಯುತ್ತದೆ. ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು Chrome ನ <ph name="BEGIN_LINK1" />ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1" /> ಮತ್ತು <ph name="BEGIN_LINK2" />ಗೌಪ್ಯತಾ ಸೂಚನೆ<ph name="END_LINK2" /> ಗೆ ಒಪ್ಪುತ್ತಿರುವಿರಿ.</translation>
-<translation id="1919345977826869612">ಜಾಹೀರಾತುಗಳು</translation>
-<translation id="1919950603503897840">ಸಂಪರ್ಕಗಳನ್ನು ಆಯ್ಕೆ ಮಾಡಿ</translation>
-<translation id="1922076542920281912">Chrome ನಿಮ್ಮ ಸ್ಥಳವನ್ನು ಪ್ರವೇಶಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಸ್ಥಳವನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
-<translation id="1923695749281512248"><ph name="FILE_SIZE_WITH_UNITS" /> ರಲ್ಲಿ <ph name="BYTES_DOWNLOADED_WITH_UNITS" /> ಡೌನ್‌ಲೋಡ್ ಆಗಿದೆ</translation>
-<translation id="1928696683969751773">ಅಪ್‌ಡೇಟ್‌ಗಳು</translation>
-<translation id="19288952978244135">Chrome ಮರುತೆರೆಯಿರಿ.</translation>
-<translation id="1933845786846280168">ಟ್ಯಾಬ್ ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> Chrome ಗೆ ಅನುಮತಿಯನ್ನು ಆನ್ ಮಾಡಿ.</translation>
-<translation id="1943432128510653496">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
-<translation id="1952172573699511566">ಸಾಧ್ಯವಾದಾಗ, ನೀವು ಆದ್ಯತೆ ನೀಡುವ ಭಾಷೆಯಲ್ಲಿ ವೆಬ್‌ಸೈಟ್‌ಗಳು ಪಠ್ಯವನ್ನು ತೋರಿಸುತ್ತವೆ.</translation>
-<translation id="1960290143419248813">Android ನ ಈ ಆವೃತ್ತಿಯಲ್ಲಿ ಇನ್ನು ಮುಂದೆ Chrome ಅಪ್‌ಡೇಟ್‌ಗಳನ್ನು ಬೆಂಬಲಿಸಲಾಗುವುದಿಲ್ಲ</translation>
-<translation id="1966710179511230534">ದಯವಿಟ್ಟು ನಿಮ್ಮ ಸೈನ್-ಇನ್ ವಿವರಗಳನ್ನು ಅಪ್‌ಡೇಟ್‌ ಮಾಡಿ.</translation>
-<translation id="1974060860693918893">ಸುಧಾರಿತ</translation>
-<translation id="1984705450038014246">ನಿಮ್ಮ Chrome ಡೇಟಾವನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
-<translation id="1984937141057606926">ಮೂರನೇ ವ್ಯಕ್ತಿಯನ್ನು ಹೊರತುಪಡಿಸಿ ಅನುಮತಿಸಲಾಗಿದೆ</translation>
-<translation id="1986685561493779662">ಹೆಸರು ಈಗಾಗಲೇ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> ಬಟನ್</translation>
-<translation id="1989112275319619282">ಬ್ರೌಸ್ ಮಾಡಿ</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> ಜೋಡಿಸಲು ಬಯಸುತ್ತದೆ</translation>
-<translation id="1994173015038366702">ಸೈಟ್ URL</translation>
-<translation id="2000419248597011803">ಕೆಲವು ಕುಕೀಗಳನ್ನು ಹಾಗೂ ವಿಳಾಸ ಪಟ್ಟಿ ಮತ್ತು ಹುಡುಕಾಟ ಬಾಕ್ಸ್‌ನಿಂದ ಹುಡುಕಾಟಗಳನ್ನು, ನಿಮ್ಮ ಡಿಫಾಲ್ಟ್ ಹುಡುಕಾಟದ ಎಂಜಿನ್‌ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
-<translation id="2002537628803770967">Google Pay ಬಳಸುವ ಕ್ರೆಡಿಟ್ ಕಾರ್ಡ್‌ಗಳು ಮತ್ತು ವಿಳಾಸಗಳು</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ಫೈಲ್}one{# ಫೈಲ್‌ಗಳು}other{# ಫೈಲ್‌ಗಳು}}</translation>
-<translation id="2017836877785168846">ಇತಿಹಾಸವನ್ನು ತೆರವುಗೊಳಿಸಿ ಮತ್ತು ವಿಳಾಸಪಟ್ಟಿಯಲ್ಲಿರುವುದನ್ನು ಸ್ವಯಂಪೂರ್ಣಗೊಳಿಸಿ.</translation>
-<translation id="2021896219286479412">ಪೂರ್ಣ ಪರದೆ ಸೈಟ್ ನಿಯಂತ್ರಣಗಳು</translation>
-<translation id="2038563949887743358">ಡೆಸ್ಕ್‌ಟಾಪ್ ಸೈಟ್ ವಿನಂತಿಯನ್ನು ಆನ್ ಮಾಡಿ</translation>
-<translation id="2041019821020695769">Chrome ನಿಮಗೆ ಅಧಿಸೂಚನೆಗಳನ್ನು ಕಳುಹಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಅಧಿಸೂಚನೆಗಳನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" />ಆ್ಯಪ್‌ನ ಡೇಟಾವು Chrome ನಲ್ಲಿಯೂ ಇದೆ</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">ಸೈಟ್ ಅನ್ನು ಅಮಾನತುಗೊಳಿಸಲಾಗಿದೆ</translation>
-<translation id="2063713494490388661">ಹುಡುಕಲು ಟ್ಯಾಪ್‌ ಮಾಡಿ</translation>
-<translation id="2067805253194386918">ಪಠ್ಯ</translation>
-<translation id="2079545284768500474">ರದ್ದುಮಾಡಿ</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" /> ರಲ್ಲಿ <ph name="RESULT_NUMBER" /> ಫಲಿತಾಂಶಗಳು</translation>
-<translation id="2091887806945687916">ಶಬ್ಧ</translation>
-<translation id="2096012225669085171">ಸಾಧನಗಳಾದ್ಯಂತ ಸಿಂಕ್ ಮಾಡಿ ಮತ್ತು ವೈಯಕ್ತೀಕರಿಸಿ</translation>
-<translation id="2100273922101894616">ಸ್ವಯಂ ಸೈನ್-ಇನ್</translation>
-<translation id="2100314319871056947">ಪಠ್ಯವನ್ನು ಸಣ್ಣ ಭಾಗಗಳಲ್ಲಿ ಹಂಚಿಕೊಳ್ಳಲು ಪ್ರಯತ್ನಿಸಿ.</translation>
-<translation id="2107397443965016585">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="2111511281910874386">ಪುಟಕ್ಕೆ ಹೋಗಿ</translation>
-<translation id="2122601567107267586">ಅಪ್ಲಿಕೇಶನ್ ತೆರೆಯಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
-<translation id="2126426811489709554">Chrome ನಿಂದ ಸಂಚಾಲಿತ</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> ಉಳಿತಾಯ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> ಮುಚ್ಚಲಾಗಿದೆ</translation>
-<translation id="2139186145475833000">ಹೋಮ್ ಪರದೆಗೆ ಸೇರಿಸಿ</translation>
-<translation id="2146738493024040262">ತತ್‌ಕ್ಷಣದ ಅಪ್ಲಿಕೇಶನ್ ತೆರೆಯಿರಿ</translation>
-<translation id="2148716181193084225">ಇಂದು</translation>
-<translation id="2154484045852737596">ಕಾರ್ಡ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
-<translation id="2154710561487035718">URL ನಕಲಿಸಿ</translation>
-<translation id="2156074688469523661">ಉಳಿದ ಸೈಟ್‌ಗಳು (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">ನಿಮ್ಮ ಫೋನ್‌ನಿಂದ ಮತ್ತೊಂದು ಸಾಧನಕ್ಕೆ ಏನನ್ನಾದರೂ ಹಂಚಿಕೊಳ್ಳಲು, ಎರಡೂ ಸಾಧನಗಳಲ್ಲಿರುವ, Chrome ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಸಿಂಕ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
-<translation id="2170088579611075216">VR ಪ್ರಸ್ತುತಿಯನ್ನು ಅನುಮತಿಸಿ ಮತ್ತು ಪ್ರವೇಶಿಸಿ</translation>
-<translation id="218608176142494674">ಹಂಚಿಕೆ</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> ನಂತೆ ಮುಂದುವರಿಸಿ</translation>
-<translation id="2234876718134438132">ಸಿಂಕ್ ಮತ್ತು Google ಸೇವೆಗಳು</translation>
-<translation id="2259659629660284697">ಪಾಸ್‌ವರ್ಡ್‍ಗಳನ್ನು ಎಕ್ಸ್‌ಪೋರ್ಟ್ ಮಾಡಿ…</translation>
-<translation id="2268044343513325586">ಪರಿಷ್ಕರಿಸು</translation>
-<translation id="2286841657746966508">ಬಿಲ್ಲಿಂಗ್ ವಿಳಾಸ</translation>
-<translation id="2289270750774289114">ಸೈಟ್ ಯಾವಾಗ ಸಮೀಪದ ಬ್ಲೂಟೂತ್ ಸಾಧನಗಳನ್ನು ಅನ್ವೇಷಿಸಲು ಬಯಸುತ್ತದೆಯೋ ಆಗ ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="230115972905494466">ಯಾವುದೇ ಹೊಂದಾಣಿಕೆಯಾಗುವ ಸಾಧನಗಳು ಕಂಡುಬಂದಿಲ್ಲ</translation>
-<translation id="2315043854645842844">ಕ್ಲೈಂಟ್‌ನ ಪ್ರಮಾಣಪತ್ರ ಆಯ್ಕೆಯನ್ನು ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂನಿಂದ ಬೆಂಬಲಿಸಲಾಗಿಲ್ಲ.</translation>
-<translation id="2318045970523081853">ಕರೆ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
-<translation id="2321086116217818302">ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ಸಿದ್ಧಪಡಿಸಲಾಗುತ್ತಿದೆ…</translation>
-<translation id="2321958826496381788">ನೀವು ಇದನ್ನು ಆರಾಮವಾಗಿ ಓದಲು ಸಾಧ್ಯವಾಗುವವರೆಗೆ ಸ್ಲೈಡರ್ ಎಳೆಯಿರಿ. ಪ್ಯಾರಾಗ್ರಾಫ್‌ನಲ್ಲಿ ಡಬಲ್ ಟ್ಯಾಪಿಂಗ್ ಮಾಡಿದ ನಂತರ ಪಠ್ಯವು ಕನಿಷ್ಠ ಇಷ್ಟು ದೊಡ್ಡದಾಗಿ ಕಾಣಿಸಬೇಕು.</translation>
-<translation id="2323763861024343754">ಸೈಟ್ ಸಂಗ್ರಹಣೆ</translation>
-<translation id="2328985652426384049">ಸೈನ್ ಇನ್ ಆಗಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="2330129964253841015">ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಹ್ಯಾಕ್ ಆದರೆ ನಿಮಗೆ ಎಚ್ಚರಿಕೆ ನೀಡಲಾಗುತ್ತದೆ</translation>
-<translation id="2349710944427398404">ಖಾತೆಗಳು, ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಮತ್ತು ಉಳಿಸಿದ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಒಳಗೊಂಡಂತೆ Chrome ಬಳಸಿದ ಒಟ್ಟು ಡೇಟಾ</translation>
-<translation id="2353636109065292463">ನಿಮ್ಮ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="2359808026110333948">ಮುಂದುವರೆಸಿ</translation>
-<translation id="2369533728426058518">ತೆರೆದ ಟ್ಯಾಬ್‌ಗಳು</translation>
-<translation id="2387895666653383613">ಪಠ್ಯ ಸ್ಕೇಲಿಂಗ್</translation>
-<translation id="2394602618534698961">ನೀವು ಡೌನ್‌ಲೋಡ್ ಮಾಡುವ ಫೈಲ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">ನಿಮ್ಮ Google ಖಾತೆಗೆ ನೀವು ಸೈನ್ ಇನ್ ಮಾಡಿದಾಗ, ಈ ವೈಶಿಷ್ಟ್ಯವು ಆನ್ ಆಗುತ್ತದೆ</translation>
-<translation id="2410754283952462441">ಖಾತೆಯೊಂದನ್ನು ಆರಿಸಿ</translation>
-<translation id="2414886740292270097">ಗಾಢ</translation>
-<translation id="2416359993254398973">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಕ್ಯಾಮರಾ ಪ್ರವೇಶಿಸಲು Chrome ಗೆ ಅನುಮತಿಸುವ ಅಗತ್ಯವಿದೆ.</translation>
-<translation id="2426805022920575512">ಇನ್ನೊಂದು ಖಾತೆಯನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="2433507940547922241">ಗೋಚರತೆ</translation>
-<translation id="2434158240863470628">ಡೌನ್‌ಲೋಡ್‌‌ ಪೂರ್ಣಗೊಂಡಿದೆ <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">ಸ್ಥಳ ಪ್ರವೇಶ</translation>
-<translation id="2450083983707403292">ನೀವು <ph name="FILE_NAME" /> ಅನ್ನು ಪುನಃ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಬಯಸುತ್ತೀರಾ?</translation>
-<translation id="2482878487686419369">ಸೂಚನೆಗಳು</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> ಆ್ಯಪ್ ನಿರ್ವಹಿಸುತ್ತಿದೆ</translation>
-<translation id="2494974097748878569">Chrome ನಲ್ಲಿನ Google ಅಸಿಸ್ಟೆಂಟ್</translation>
-<translation id="2496180316473517155">ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸ</translation>
-<translation id="2497852260688568942">ನಿಮ್ಮ ನಿರ್ವಾಹಕರು ಸಿಂಕ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿದ್ದಾರೆ</translation>
-<translation id="2498359688066513246">ಸಹಾಯ ಮತ್ತು ಪ್ರತಿಕ್ರಿಯೆ</translation>
-<translation id="2501278716633472235">ಹಿಂದಿರುಗಿ</translation>
-<translation id="2513403576141822879">ಗೌಪ್ಯತೆ, ಸುರಕ್ಷತೆ ಮತ್ತು ಡೇಟಾ ಸಂಗ್ರಹಕ್ಕೆ ಸಂಬಂಧಿಸಿದ ಹೆಚ್ಚಿನ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗಾಗಿ <ph name="BEGIN_LINK" />ಸಿಂಕ್ ಮತ್ತು Google ಸೇವೆಗಳನ್ನು<ph name="END_LINK" /> ನೋಡಿ</translation>
-<translation id="2518590038762162553">ಲೈಟ್ ಮೋಡ್‍ನಲ್ಲಿ, Chrome ವೇಗವಾಗಿ ಪುಟಗಳನ್ನು ಲೋಡ್ ಮಾಡುತ್ತದೆ, ಮತ್ತು ಸುಮಾರು ಶೇಕಡಾ 60 ರಷ್ಟು ಕಡಿಮೆ ಡೇಟಾವನ್ನು ಬಳಸುತ್ತದೆ. ನೀವು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳನ್ನು ಆಪ್ಟಿಮೈಸ್ ಮಾಡಲು, Chrome ನಿಮ್ಮ ವೆಬ್ ಟ್ರಾಫಿಕ್ ಕುರಿತ ಮಾಹಿತಿಯನ್ನು Google ಗೆ ಕಳುಹಿಸುತ್ತದೆ. <ph name="BEGIN_LINK" />ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">ನೀವು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳ URLಗಳನ್ನು Google ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
-<translation id="2532336938189706096">ವೆಬ್ ವೀಕ್ಷಣೆ</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> ಐಟಂಗಳನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
-<translation id="2536728043171574184">ಈ ಪುಟದ ಆಫ್‌ಲೈನ್ ನಕಲನ್ನು ವೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="2546283357679194313">ಕುಕೀಗಳು ಮತ್ತು ಸೈಟ್ ಡೇಟಾ</translation>
-<translation id="2567385386134582609">ಚಿತ್ರ</translation>
-<translation id="257088987046510401">ಥೀಮ್‌ಗಳು</translation>
-<translation id="2570922361219980984">ಈ ಸಾಧನದ ಸ್ಥಳ ಪ್ರವೇಶ ಸಹ ಆಫ್ ಆಗಿದೆ. ಅದನ್ನು <ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಆನ್ ಮಾಡಿ.</translation>
-<translation id="257931822824936280">ವಿಸ್ತರಿಸಲಾಗಿದೆ - ಕುಗ್ಗಿಸಲು ಕ್ಲಿಕ್ ಮಾಡಿ</translation>
-<translation id="2581165646603367611">ಇದು ಕುಕೀಗಳು, ಕ್ಯಾಷ್ ಮತ್ತು ಪ್ರಮುಖವಲ್ಲವೆಂದು Chrome ಭಾವಿಸುವ ಸೈಟ್‌ಗಳ ಇತರ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ.</translation>
-<translation id="2586657967955657006">ಕ್ಲಿಪ್‌ಬೋರ್ಡ್</translation>
-<translation id="2587052924345400782">ಹೊಸ ಆವೃತ್ತಿಯು ಲಭ್ಯವಿದೆ</translation>
-<translation id="2593272815202181319">ಮೊನೋಸ್ಪೇಸ್</translation>
-<translation id="2612676031748830579">ಕಾರ್ಡ್ ಸಂಖ್ಯೆ</translation>
-<translation id="2621115761605608342">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗೆ JavaScript ಅನ್ನು ಅನುಮತಿಸಿ.</translation>
-<translation id="2625189173221582860">ಪಾಸ್‌ವರ್ಡ್ ಅನ್ನು ನಕಲಿಸಲಾಗಿದೆ</translation>
-<translation id="2631006050119455616">ಉಳಿಸಲಾಗಿದೆ</translation>
-<translation id="2647434099613338025">ಭಾಷೆಯನ್ನು ಸೇರಿಸಿ</translation>
-<translation id="2650751991977523696">ಫೈಲ್‌ ಮತ್ತೆ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡುವುದೇ?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ಆಡಿಯೋ ಫೈಲ್}one{# ಆಡಿಯೋ ಫೈಲ್‌ಗಳು}other{# ಆಡಿಯೋ ಫೈಲ್‌ಗಳು}}</translation>
-<translation id="2653659639078652383">ಸಲ್ಲಿಸು</translation>
-<translation id="2677748264148917807">ತೊರೆಯಿರಿ</translation>
-<translation id="2704606927547763573">ನಕಲಿಸಲಾಗಿದೆ</translation>
-<translation id="2707726405694321444">ಪುಟವನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಿ</translation>
-<translation id="2709516037105925701">ಸ್ವಯಂತುಂಬುವಿಕೆ</translation>
-<translation id="2717722538473713889">ಇಮೇಲ್ ವಿಳಾಸಗಳು</translation>
-<translation id="2728754400939377704">ಸೈಟ್ ಪ್ರಕಾರ ವಿಂಗಡಿಸಿ</translation>
-<translation id="2744248271121720757">ತತ್‌ಕ್ಷಣ ಹುಡುಕಲು ಅಥವಾ ಸಂಬಂಧಿತ ಕ್ರಿಯೆಗಳನ್ನು ವೀಕ್ಷಿಸಲು ಪದವನ್ನು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
-<translation id="2760989362628427051">ನಿಮ್ಮ ಸಾಧನದ ಡಾರ್ಕ್ ಥೀಮ್ ಅಥವಾ ಬ್ಯಾಟರಿ ಸೇವರ್ ಆನ್ ಆಗಿರುವಾಗ, ಡಾರ್ಕ್ ಥೀಮ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
-<translation id="2762000892062317888">ಈಗತಾನೇ</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> ಸೆಕೆಂಡುಗಳು ಉಳಿದಿವೆ</translation>
-<translation id="2779651927720337254">ವಿಫಲವಾಗಿದೆ</translation>
-<translation id="2781151931089541271">1 ಸೆಕೆಂಡು ಉಳಿದಿದೆ</translation>
-<translation id="2801022321632964776">ನಿಮ್ಮ ಭಾಷೆಯನ್ನು Chrome ನ ಇತ್ತೀಚಿನ ಆವೃತ್ತಿಯಲ್ಲಿ ಪಡೆದುಕೊಳ್ಳಲು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ</translation>
-<translation id="2810645512293415242">ಡೇಟಾ ಉಳಿಸಲು ಮತ್ತು ವೇಗವಾಗಿ ಲೋಡ್ ಮಾಡಲು ಪುಟವನ್ನು ಸರಳೀಕೃತಗೊಳಿಸಲಾಗಿದೆ.</translation>
-<translation id="281504910091592009">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ನಿಮ್ಮ <ph name="BEGIN_LINK" />Google ಖಾತೆಯಲ್ಲಿ<ph name="END_LINK" /> ವೀಕ್ಷಿಸಿ ಮತ್ತು ನಿರ್ವಹಿಸಿ</translation>
-<translation id="2818669890320396765">ನಿಮ್ಮ ಎಲ್ಲಾ ಸಾಧನಗಳಲ್ಲಿ ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
-<translation id="2822354292072154809">ನೀವು <ph name="CHOSEN_OBJECT_NAME" /> ಗಾಗಿ ಎಲ್ಲಾ ಸೈಟ್ ಅನುಮತಿಗಳನ್ನು ಖಚಿತವಾಗಿಯೂ ಮರುಹೊಂದಿಸಲು ಬಯಸುತ್ತೀರಾ?</translation>
-<translation id="2836148919159985482">ಪೂರ್ಣಪರದೆಯನ್ನು ನಿರ್ಗಮಿಸಲು ಹಿಂದೆ ಬಟನ್ ಸ್ಪರ್ಶಿಸಿ.</translation>
-<translation id="2842985007712546952">ಮೂಲ ಫೋಲ್ಡರ್‌</translation>
-<translation id="2858138569776157458">ಟಾಪ್ ಸೈಟ್</translation>
-<translation id="2860954141821109167">ಈ ಸಾಧನದಲ್ಲಿ ಫೋನ್ ಆ್ಯಪ್‌ ಒಂದನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
-<translation id="2870560284913253234">ಸೈಟ್</translation>
-<translation id="2874939134665556319">ಹಿಂದಿನ ಟ್ರ್ಯಾಕ್</translation>
-<translation id="2876369937070532032">ನಿಮ್ಮ ಭದ್ರತೆಯು ಅಪಾಯದಲ್ಲಿದ್ದಾಗ, ನೀವು ಭೇಟಿ ನೀಡುವ ಕೆಲವು ಪುಟಗಳ URL ಗಳನ್ನು Google ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
-<translation id="2888126860611144412">Chrome ಕುರಿತು</translation>
-<translation id="2891154217021530873">ಪುಟ ಲೋಡ್ ಮಾಡುವುದನ್ನು ನಿಲ್ಲಿಸಿ</translation>
-<translation id="2893180576842394309">ಹುಡುಕಾಟ ಮತ್ತು ಇತರ Google ಸೇವೆಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಇತಿಹಾಸವನ್ನು Google ಬಳಸಬಹುದು.</translation>
-<translation id="2898264748040935573">ಸಂಗ್ರಹಿಸಿರುವ ಪಾಸ್‌ವರ್ಡ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
-<translation id="2900528713135656174">ಈವೆಂಟ್ ರಚಿಸು</translation>
-<translation id="290376772003165898"><ph name="LANGUAGE" /> ನಲ್ಲಿನ ಪುಟ ಇಲ್ಲವೇ?</translation>
-<translation id="2904414404539560095">ಟ್ಯಾಬ್ ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಬೇಕಾದ ಸಾಧನಗಳ ಪಟ್ಟಿಯನ್ನು ಪೂರ್ಣ ಎತ್ತರದಲ್ಲಿ ತೆರೆಯಲಾಗಿದೆ.</translation>
-<translation id="2910701580606108292">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ</translation>
-<translation id="2913331724188855103">ಕುಕೀ ಡೇಟಾವನ್ನು ಉಳಿಸಲು ಮತ್ತು ರೀಡ್ ಮಾಡಲು ಸೈಟ್‌ಗಳನ್ನು ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="2923908459366352541">ಹೆಸರು ಅಮಾನ್ಯವಾಗಿದೆ</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> ಸಂಗ್ರಹಣೆ</translation>
-<translation id="2942036813789421260">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್ ಮುಚ್ಚಿದೆ</translation>
-<translation id="2956410042958133412">ಈ ಖಾತೆಯನ್ನು <ph name="PARENT_NAME_1" /> ಮತ್ತು <ph name="PARENT_NAME_2" /> ಅವರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ.</translation>
-<translation id="2962095958535813455">ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌ಗಳಿಗೆ ಬದಲಾಯಿಸಲಾಗಿದೆ</translation>
-<translation id="2968755619301702150">ಪ್ರಮಾಣಪತ್ರ ವೀಕ್ಷಕ</translation>
-<translation id="2979025552038692506">ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌ ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</translation>
-<translation id="2987620471460279764">ಬೇರೆ ಸಾಧನದಿಂದ ಪಠ್ಯವನ್ನು ಹಂಚಿಕೊಳ್ಳಲಾಗಿದೆ</translation>
-<translation id="2989523299700148168">ಇತ್ತೀಚೆಗೆ ಭೇಟಿ ನೀಡಿದವು</translation>
-<translation id="2996291259634659425">ಪಾಸ್‌ಫ್ರೇಸ್ ರಚಿಸಿ</translation>
-<translation id="2996809686854298943">URL ಅಗತ್ಯವಿದೆ</translation>
-<translation id="300526633675317032">ಇದು ವೆಬ್‌ಸೈಟ್ ಸಂಗ್ರಹಣೆಯ ಎಲ್ಲಾ <ph name="SIZE_IN_KB" /> ಅನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ.</translation>
-<translation id="3016635187733453316">ಈ ಸಾಧನವು ಇಂಟರ್ನೆಟ್‌ಗೆ ಸಂಪರ್ಕಗೊಂಡಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="3029704984691124060">ಪಾಸ್‌ಫ್ರೇಸ್‌ಗಳು ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />ಸಹಾಯ ಪಡೆಯಿರಿ<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">ಸ್ಥಳ ಆಫ್ ಆಗಿದೆ; <ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಇದನ್ನು ಆನ್‌ ಮಾಡಿ.</translation>
-<translation id="3058498974290601450">ನೀವು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಯಾವಾಗ ಬೇಕಾದರೂ ಸಿಂಕ್ ಆನ್ ಮಾಡಬಹುದು</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> ಬುಕ್‌ಮಾರ್ಕ್‌}one{<ph name="BOOKMARKS_COUNT_MANY" /> ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು}other{<ph name="BOOKMARKS_COUNT_MANY" /> ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು}}</translation>
-<translation id="3089395242580810162">ಅಜ್ಞಾತ ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="3115898365077584848">ಮಾಹಿತಿಯನ್ನು ತೋರಿಸಿ</translation>
-<translation id="3123473560110926937">ಕೆಲವು ಸೈಟ್‌ಗಳಲ್ಲಿ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
-<translation id="3137521801621304719">ಅದೃಶ್ಯ ಮೋಡ್‌ನಿಂದ ಹೊರಬನ್ನಿ</translation>
-<translation id="3143515551205905069">ಸಿಂಕ್ ಮಾಡುವಿಕೆಯನ್ನು ರದ್ದುಪಡಿಸಿ</translation>
-<translation id="3157842584138209013">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳ ಬಟನ್ ಮೂಲಕ ನೀವು ಎಷ್ಟು ಡೇಟಾ ಉಳಿಸಿದ್ದಿರಾ ಎಂದು ನೋಡಿ</translation>
-<translation id="3166827708714933426">ಟ್ಯಾಬ್ ಮತ್ತು ವಿಂಡೋ ಶಾರ್ಟ್‌ಕಟ್‌ಗಳು</translation>
-<translation id="3181954750937456830">ಸುರಕ್ಷಿತ ಬ್ರೌಸಿಂಗ್ (ಅಪಾಯಕಾರಿ ಸೈಟ್‌ಗಳಿಂದ ನಿಮ್ಮನ್ನು ಮತ್ತು ನಿಮ್ಮ ಸಾಧನವನ್ನು ರಕ್ಷಿಸುತ್ತದೆ)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> Chrome ಗೆ ಅನುಮತಿಗಳನ್ನು ಆನ್ ಮಾಡಿ.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> ಸಂಗ್ರಹಿಸಿದ ಡೇಟಾ</translation>
-<translation id="3205824638308738187">ಬಹುತೇಕ ಮುಗಿದಿದೆ!</translation>
-<translation id="3207960819495026254">ಬುಕ್‌ಮಾರ್ಕ್‌ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> ಅನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
-<translation id="321773570071367578">ನಿಮ್ಮ ಪಾಸ್‍‍ಫ್ರೇಸ್‍‍ ಅನ್ನು ನೀವು ಮರೆತಿದ್ದರೆ ಅಥವಾ ಈ ಸೆಟ್ಟಿಂಗ್ ಬದಲಾಯಿಸಲು ಬಯಸಿದರೆ, <ph name="BEGIN_LINK" />ಸಿಂಕ್ ಮರುಹೊಂದಿಸಿ<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">ಮೈಕ್ರೋಫೋನ್</translation>
-<translation id="3232754137068452469">ವೆಬ್ ಅಪ್ಲಿಕೇಶನ್</translation>
-<translation id="3236059992281584593">1 ನಿಮಿಷ ಉಳಿದಿದೆ</translation>
-<translation id="3244271242291266297">ಮಿಮೀ</translation>
-<translation id="3254409185687681395">ಈ ಪುಟ ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಿ</translation>
-<translation id="3259831549858767975">ಪುಟದಲ್ಲಿರುವ ಪ್ರತಿಯೊಂದನ್ನೂ ಚಿಕ್ಕದಾಗಿಸಿ</translation>
-<translation id="3269093882174072735">ಚಿತ್ರ ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="3269956123044984603">ನಿಮ್ಮ ಇತರೆ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, Android ಖಾತೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ''ಸ್ವಯಂ-ಸಿಂಕ್ ಡೇಟಾ" ಆನ್ ಮಾಡಿ.</translation>
-<translation id="3277252321222022663">ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿ ನೀಡಿ (ಶಿಫಾರಸು ಮಾಡಿರುವುದು)</translation>
-<translation id="3282568296779691940">Chrome ಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
-<translation id="3288003805934695103">ಪುಟ ಮರುಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</translation>
-<translation id="32895400574683172">ಅಧಿಸೂಚನೆಗಳನ್ನು ಅನುಮತಿಸಲಾಗಿದೆ</translation>
-<translation id="3295530008794733555">ವೇಗವಾಗಿ ಬ್ರೌಸ್ ಮಾಡಿ. ಕಡಿಮೆ ಡೇಟಾವನ್ನು ಬಳಸಿ.</translation>
-<translation id="3295602654194328831">ಮಾಹಿತಿಯನ್ನು ಮರೆಮಾಡಿ</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">ವಿಷಯವನ್ನು ಡೌನ್‌ಲೊಡ್‌ ಮಾಡಲು ಮುಂದುವರಿಯುವುದೇ?</translation>
-<translation id="3306398118552023113">ಈ ಆ್ಯಪ್‌, Chrome ನಲ್ಲಿ ರನ್ ಆಗುತ್ತಿದೆ</translation>
-<translation id="3315103659806849044">ನೀವು ಪ್ರಸ್ತುತವಾಗಿ ನಿಮ್ಮ ಸಿಂಕ್ ಮತ್ತು Google ಸೇವೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಕಸ್ಟಮೈಸ್ ಮಾಡುತ್ತಿರುವಿರಿ. ಸಿಂಕ್ ಆನ್ ಮಾಡುವುದನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು, ಪರದೆಯ ಕೆಳಭಾಗದಲ್ಲಿ ಸಮೀಪದಲ್ಲಿರುವ 'ದೃಢೀಕರಿಸಿ' ಬಟನ್ ಟ್ಯಾಪ್ ಮಾಡಿ. ಮೇಲಕ್ಕೆ ನ್ಯಾವಿಗೇಟ್</translation>
-<translation id="3328801116991980348">ಸೈಟ್ ಮಾಹಿತಿ</translation>
-<translation id="3333961966071413176">ಎಲ್ಲಾ ಸಂಪರ್ಕಗಳು</translation>
-<translation id="3334729583274622784">ಫೈಲ್ ವಿಸ್ತರಣೆಯನ್ನು ಬದಲಿಸುವುದೇ?</translation>
-<translation id="3341058695485821946">ನೀವು ಎಷ್ಟು ಡೇಟಾ ಉಳಿಸಿದ್ದಿರಾ ಎಂದು ನೋಡಿ</translation>
-<translation id="3350687908700087792">ಎಲ್ಲಾ ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಮುಚ್ಚಿ</translation>
-<translation id="3353615205017136254">Lite ಪುಟವನ್ನು Google ಒದಗಿಸಿದೆ. ಮೂಲ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಲು ಮೂಲ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಿ ಎಂಬ ಬಟನ್ ಟ್ಯಾಪ್ ಮಾಡಿ.</translation>
-<translation id="3367813778245106622">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು ಮತ್ತೊಮ್ಮೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
-<translation id="3374023511497244703">ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು, ಇತಿಹಾಸ, ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಮತ್ತು ಇತರ Chrome ಡೇಟಾವನ್ನು ಇನ್ನು ಮುಂದೆ ನಿಮ್ಮ Google ಖಾತೆಗೆ ಸಿಂಕ್ ಮಾಡುವುದಿಲ್ಲ</translation>
-<translation id="3384347053049321195">ಚಿತ್ರ ಹಂಚಿಕೊಳ್ಳಿ</translation>
-<translation id="3386292677130313581">ನಿಮ್ಮ ಸ್ಥಳವನ್ನು ತಿಳಿಯಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="3387650086002190359">ಫೈಲ್ ಸಿಸ್ಟಂ ದೋಷಗಳ ಕಾರಣದಿಂದಾಗಿ <ph name="FILE_NAME" /> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
-<translation id="3389286852084373014">ಪಠ್ಯ ತುಂಬಾ ದೊಡ್ಡದಾಗಿದೆ</translation>
-<translation id="3398320232533725830">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳ ಮ್ಯಾನೇಜರ್ ತೆರೆಯಿರಿ</translation>
-<translation id="3414952576877147120">ಗಾತ್ರ:</translation>
-<translation id="3443221991560634068">ಪ್ರಸ್ತುತ ಪುಟ ಮರುಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="3445014427084483498">ಇದೀಗ</translation>
-<translation id="3478363558367712427">ನಿಮ್ಮ ಹುಡುಕಾಟ ಎಂಜಿನ್ ಅನ್ನು ನೀವು ಆಯ್ಕೆಮಾಡಬಹುದು</translation>
+<translation id="6910211073230771657">ಅಳಿಸಲಾಗಿದೆ</translation>
+<translation id="6965382102122355670">ಸರಿ</translation>
+<translation id="5301954838959518834">ಸರಿ, ಅರ್ಥವಾಯಿತು</translation>
+<translation id="7658239707568436148">ರದ್ದುಮಾಡಿ</translation>
 <translation id="3479552764303398839">ಈಗ ಬೇಡ</translation>
-<translation id="3492207499832628349">ಹೊಸ ಅದೃಶ್ಯ ಟ್ಯಾಬ್</translation>
-<translation id="3493531032208478708">ಸೂಚಿಸಲಾದ ವಿಷಯದ ಕುರಿತು <ph name="BEGIN_LINK" />ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">ವರ್ಧಿತ ವಾಸ್ತವತೆ</translation>
-<translation id="3518985090088779359">ಸಮ್ಮತಿಸು &amp; ಮುಂದುವರಿಸು</translation>
-<translation id="3522247891732774234">ಅಪ್‌ಡೇಟ್‌ ಲಭ್ಯವಿದೆ. ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು</translation>
-<translation id="3524138585025253783">ಡೆವಲಪರ್ UI</translation>
-<translation id="3527085408025491307">ಫೋಲ್ಡರ್</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB ಲಭ್ಯವಿದೆ</translation>
-<translation id="3549657413697417275">ನಿಮ್ಮ ಇತಿಹಾಸವನ್ನು ಹುಡುಕಿ</translation>
-<translation id="3557336313807607643">ಸಂಪರ್ಕಗಳಿಗೆ ಸೇರಿಸಿ</translation>
-<translation id="3566923219790363270">Chrome ಇನ್ನೂ VR ಗಾಗಿ ಸಿದ್ಧವಾಗುತ್ತಿದೆ. ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ Chrome ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ.</translation>
-<translation id="3568688522516854065">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
-<translation id="3587482841069643663">ಎಲ್ಲ</translation>
-<translation id="358794129225322306">ಬಹು ಫೈಲ್‌ಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲು ಸೈಟ್‌ ಒಂದಕ್ಕೆ ಅನುಮತಿಸುವುದು.</translation>
-<translation id="3590487821116122040">ಪ್ರಮುಖವಲ್ಲವೆಂದು Chrome ಭಾವಿಸುವ ಸೈಟ್ ಸಂಗ್ರಹಣೆ (ಉದಾ. ಯಾವುದೇ ಉಳಿಸದ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಹೊಂದಿರುವ ಅಥವಾ ನೀವು ಆಗಾಗ್ಗೆ ಭೇಟಿ ನೀಡದ ಸೈಟ್‌ಗಳು)</translation>
-<translation id="3599863153486145794">ಸೈನ್-ಇನ್ ಮಾಡಿರುವ ಎಲ್ಲ ಸಾಧನಗಳಿಂದ ಇತಿಹಾಸವನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ. ನಿಮ್ಮ Google ಖಾತೆಯು <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> ನಲ್ಲಿ ಇತರ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೊಂದಿರಬಹುದು.</translation>
-<translation id="3600792891314830896">ಕೆಲವು ಸೈಟ್‌ಗಳಲ್ಲಿ ಧ್ವನಿ ಪ್ಲೇ ಆಗುವುದನ್ನು ಮ್ಯೂಟ್ ಮಾಡಿ</translation>
-<translation id="3616113530831147358">ಆಡಿಯೋ</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> ಜೊತೆಗೆ ಹಂಚಿಕೊಳ್ಳಲಾಗುತ್ತಿದೆ</translation>
-<translation id="3632295766818638029">ಪಾಸ್‌ವರ್ಡ್ ಅನ್‌ಮಾಸ್ಕ್ ಮಾಡಿ</translation>
-<translation id="363596933471559332">ಸಂಗ್ರಹಿಸಲಾದ ರುಜುವಾತುಗಳನ್ನು ಬಳಸಿಕೊಳ್ಳುವ ಮೂಲಕ ವೆಬ್‌ಸೈಟ್‌ಗಳಿಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸೈನ್ ಇನ್ ಮಾಡಿ. ವೈಶಿಷ್ಟ್ಯವು ಆಫ್ ಆಗಿರುವಾಗ, ವೆಬ್‌ಸೈಟ್‌ಗೆ ಸೈನ್ ಇನ್ ಮಾಡುವ ಮೊದಲು ಪ್ರತಿ ಬಾರಿಯೂ ನಿಮಗೆ ಪರಿಶೀಲನೆ ಮಾಡಲು ಕೇಳಲಾಗುವುದು.</translation>
-<translation id="3658159451045945436">ಮರುಹೊಂದಿಸುವುದರಿಂದ, ಭೇಟಿ ನೀಡಿದ ಸೈಟ್‌ಗಳ ಪಟ್ಟಿ ಸೇರಿದಂತೆ ನಿಮ್ಮ ಡೇಟಾ ಉಳಿತಾಯದ ಇತಿಹಾಸವನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ.</translation>
-<translation id="3692944402865947621">ಸಂಗ್ರಹಣೆ ಸ್ಥಳವನ್ನು ತಲುಪಲು ಸಾಧ್ಯವಾಗದ ಕಾರಣ <ph name="FILE_NAME" /> ಅನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ.</translation>
-<translation id="3714981814255182093">ಹುಡುಕು ಪಟ್ಟಿಯನ್ನು ತೆರೆಯಿರಿ</translation>
-<translation id="3716182511346448902">ಈ ಪುಟವು ಅತಿ ಹೆಚ್ಚು ಮೆಮೊರಿಯನ್ನು ಬಳಸಿಕೊಳ್ಳುತ್ತದೆ, ಆದ್ದರಿಂದ Chrome ಇದನ್ನು ವಿರಾಮಗೊಳಿಸಿದೆ.</translation>
-<translation id="3730075448226062617">Chrome ನಿಮ್ಮ ಮೈಕ್ರೋಫೋನ್‌ಗೆ ಪ್ರವೇಶಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಮೈಕ್ರೋಫೋನ್ ಅನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> ನಲ್ಲಿ ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="3744111561329211289">ಹಿನ್ನೆಲೆ ಸಿಂಕ್</translation>
-<translation id="3771001275138982843">ಅಪ್‌ಡೇಟ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
-<translation id="3771033907050503522">ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌ಗಳು</translation>
-<translation id="3773755127849930740">ಜೋಡಿಸುವಿಕೆ ಅನುಮತಿಸಲು <ph name="BEGIN_LINK" />ಬ್ಲೂಟೂತ್ ಆನ್ ಮಾಡಿ<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">ನಿಮ್ಮ ಸಾಧನಗಳಿಗೆ ಕಳುಹಿಸಿ</translation>
-<translation id="3778956594442850293">ಹೋಮ್‌ನ ಪರದೆಗೆ ಸೇರಿಸಲಾಗಿದೆ</translation>
-<translation id="3789841737615482174">ಇನ್‌ಸ್ಟಾಲ್</translation>
-<translation id="3810838688059735925">ವೀಡಿಯೊ</translation>
-<translation id="3810973564298564668">ನಿರ್ವಹಿಸು</translation>
-<translation id="381841723434055211">ಫೋನ್ ಸಂಖ್ಯೆಗಳು</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> ಡೌನ್‌ಲೋಡ್‌ಗಳನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
-<translation id="3822502789641063741">ಸೈಟ್ ಸಂಗ್ರಹಣೆ ತೆರವುಗೊಳಿಸುವುದೇ?</translation>
-<translation id="385051799172605136">ಹಿಂದೆ</translation>
-<translation id="3859306556332390985">ಮುಂದಕ್ಕೆ ಸೀಕ್ ಮಾಡಿ</translation>
-<translation id="3894427358181296146">ಫೋಲ್ಡರ್ ಸೇರಿಸು</translation>
-<translation id="3895926599014793903">ಒತ್ತಾಯದ ಝೂಮ್ ಸಕ್ರಿಯಗೊಳಿಸುವಿಕೆ</translation>
-<translation id="3912508018559818924">ವೆಬ್‌ನಿಂದ ಅತ್ಯುತ್ತಮ ವಿಷಯಗಳನ್ನು ಹುಡುಕಲಾಗುತ್ತಿದೆ…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">ನನ್ನ ಡೇಟಾ ಒಂದುಗೂಡಿಸಿ</translation>
-<translation id="393697183122708255">ಯಾವುದೇ ಸಕ್ರಿಯಗೊಳಿಸಿದ ಧ್ವನಿ ಹುಡುಕಾಟ ಲಭ್ಯವಿಲ್ಲ</translation>
-<translation id="395206256282351086">ಹುಡುಕಾಟ ಹಾಗೂ ಸೈಟ್ ಕುರಿತಾದ ಸಲಹೆಗಳನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ</translation>
-<translation id="3955193568934677022">ಸಂರಕ್ಷಿಸಲಾದ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{ಸಿದ್ಧವಾದಾಗ, ನಿಮ್ಮ ಪುಟವನ್ನು Chrome ಲೋಡ್ ಮಾಡುತ್ತದೆ}one{ಸಿದ್ಧವಾದಾಗ, ನಿಮ್ಮ ಪುಟಗಳನ್ನು Chrome ಲೋಡ್ ಮಾಡುತ್ತದೆ}other{ಸಿದ್ಧವಾದಾಗ, ನಿಮ್ಮ ಪುಟಗಳನ್ನು Chrome ಲೋಡ್ ಮಾಡುತ್ತದೆ}}</translation>
-<translation id="3963007978381181125">ಪಾಸ್‌ಫ್ರೇಸ್ ಎನ್‌ಕ್ರಿಪ್ಶನ್, Google Pay ನಿಂದ ಪಾವತಿ ವಿಧಾನಗಳು ಮತ್ತು ವಿಳಾಸಗಳನ್ನು ಒಳಗೊಂಡಿರುವುದಿಲ್ಲ. ನಿಮ್ಮ ಎನ್‍‍ಕ್ರಿಪ್ಟ್ ಮಾಡಲಾದ ಡೇಟಾವನ್ನು ನಿಮ್ಮ ಪಾಸ್‌ಫ್ರೇಸ್ ಹೊಂದಿರುವ ಯಾರಾದರೂ ಮಾತ್ರ ಓದಬಹುದು. ಪಾಸ್‍‍ಫ್ರೇಸ್‍ ಅನ್ನು Google ಗೆ ಕಳುಹಿಸಲಾಗುವುದಿಲ್ಲ ಅಥವಾ ಅದನ್ನು Google ನಿಂದ ಸಂಗ್ರಹಿಸಲಾಗುವುದಿಲ್ಲ. ನಿಮ್ಮ ಪಾಸ್‍‍ಫ್ರೇಸ್ ಅನ್ನು ನೀವು ಮರೆತರೆ ಅಥವಾ ಈ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಬದಲಾಯಿಸಲು ಬಯಸಿದರೆ, ನೀವು ಸಿಂಕ್ ಅನ್ನು ಮರುಹೊಂದಿಸುವ ಅಗತ್ಯವಿರುತ್ತದೆ.<ph name="BEGIN_LINK" />ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ಡೌನ್‌ಲೋಡ್‌‌ ಪೂರ್ಣಗೊಂಡಿದೆ</translation>
-<translation id="397583555483684758">ಸಿಂಕ್ ಕಾರ್ಯನಿರ್ವಹಿಸುವುದನ್ನು ನಿಲ್ಲಿಸಿದೆ</translation>
-<translation id="3976396876660209797">ಈ ಶಾರ್ಟ್‌ಕಟ್‌ ಅನ್ನು ತೆಗೆದುಹಾಕಿ ಮತ್ತು ಮರುರಚಿಸಿ</translation>
-<translation id="3985215325736559418"><ph name="FILE_NAME" /> ಅನ್ನು ಮತ್ತೆ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ನೀವು ಬಯಸುವಿರಾ?</translation>
-<translation id="3987993985790029246">ಲಿಂಕ್ ನಕಲಿಸಿ</translation>
-<translation id="3988213473815854515">ಸ್ಥಳವನ್ನು ಅನುಮತಿಸಲಾಗಿದೆ</translation>
-<translation id="3988466920954086464">ಈ ಫಲಕದಲ್ಲಿ ತತ್‌ಕ್ಷಣ ಹುಡುಕಾಟ ಫಲಿತಾಂಶಗಳನ್ನು ನೋಡಿ</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">ಪ್ರಮುಖವಲ್ಲದ ಸಂಗ್ರಹಣೆ</translation>
-<translation id="4000212216660919741">ಆಫ್‌ಲೈನ್ ಹೋಮ್</translation>
+<translation id="5317780077021120954">ಉಳಿಸು</translation>
+<translation id="4570913071927164677">ವಿವರಗಳು</translation>
+<translation id="8730621377337864115">ಮುಗಿದಿದೆ</translation>
+<translation id="8261506727792406068">ಅಳಿಸಿ</translation>
+<translation id="1181037720776840403">ತೆಗೆದುಹಾಕು</translation>
+<translation id="5939518447894949180">ಮರುಹೊಂದಿಸು</translation>
 <translation id="4002066346123236978">ಶೀರ್ಷಿಕೆ</translation>
-<translation id="4008040567710660924">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ ಒಂದಕ್ಕೆ ಕುಕೀಗಳನ್ನು ಅನುಮತಿಸಿ.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ಗಂಟೆ}one{# ಗಂಟೆಗಳು}other{# ಗಂಟೆಗಳು}}</translation>
-<translation id="4046123991198612571">ಮುಂದಿನ ಟ್ರ್ಯಾಕ್</translation>
-<translation id="4048707525896921369">ಪುಟದಿಂದ ಹೊರಹೋಗದೆಯೇ ವೆಬ್‌ಸೈಟ್‌ನಲ್ಲಿನ ವಿಷಯಗಳ ಕುರಿತು ತಿಳಿದುಕೊಳ್ಳಿ. "ಹುಡುಕಾಟಕ್ಕಾಗಿ ಟ್ಯಾಪ್‌ ಮಾಡಿ" ಮೂಲಕ Google ಹುಡುಕಾಟಕ್ಕೆ ಪದ ಮತ್ತು ಅದರ ಹಿನ್ನೆಲೆಯನ್ನು ಕಳುಹಿಸುತ್ತದೆ ಈ ಮೂಲಕ ವ್ಯಾಖ್ಯಾನಗಳು, ಚಿತ್ರಗಳು, ಹುಡುಕಾಟ ಫಲಿತಾಂಶಗಳು, ಮತ್ತು ಇತರ ವಿವರಗಳನ್ನು ನೀಡುತ್ತದೆ.
+<translation id="5916664084637901428">ಆನ್‌</translation>
+<translation id="5860033963881614850">ಆಫ್</translation>
+<translation id="6165508094623778733">ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ</translation>
+<translation id="6042308850641462728">ಇನ್ನಷ್ಟು</translation>
+<translation id="6040143037577758943">ಮುಚ್ಚಿರಿ</translation>
+<translation id="780301667611848630">ಬೇಡ, ಧನ್ಯವಾದಗಳು</translation>
+<translation id="1201402288615127009">ಮುಂದೆ</translation>
+<translation id="2359808026110333948">ಮುಂದುವರೆಸಿ</translation>
+<translation id="2653659639078652383">ಸಲ್ಲಿಸು</translation>
+<translation id="2079545284768500474">ರದ್ದುಮಾಡಿ</translation>
+<translation id="7649070708921625228">ಸಹಾಯ</translation>
+<translation id="2148716181193084225">ಇಂದು</translation>
+<translation id="7781829728241885113">ನಿನ್ನೆ</translation>
+<translation id="6945221475159498467">ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="7791543448312431591">ಸೇರಿಸು</translation>
+<translation id="6527303717912515753">ಹಂಚಿಕೊಳ್ಳು</translation>
+<translation id="1383876407941801731">ಹುಡುಕಾಟ</translation>
+<translation id="3115898365077584848">ಮಾಹಿತಿಯನ್ನು ತೋರಿಸಿ</translation>
+<translation id="3295602654194328831">ಮಾಹಿತಿಯನ್ನು ಮರೆಮಾಡಿ</translation>
+<translation id="3987993985790029246">ಲಿಂಕ್ ನಕಲಿಸಿ</translation>
+<translation id="2704606927547763573">ನಕಲಿಸಲಾಗಿದೆ</translation>
+<translation id="8725066075913043281">ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</translation>
+<translation id="385051799172605136">ಹಿಂದೆ</translation>
+<translation id="8131740175452115882">ದೃಢೀಕರಿಸು</translation>
+<translation id="5300589172476337783">ಪ್ರದರ್ಶಿಸಿ</translation>
+<translation id="1124772482545689468">ಬಳಕೆದಾರ</translation>
+<translation id="8609465669617005112">ಮೇಲೆ ಸರಿಸು</translation>
+<translation id="6746124502594467657">ಕೆಳಗೆ ಸರಿಸು</translation>
+<translation id="8249310407154411074">ಮೇಲಕ್ಕೆ ಸರಿಸಿ</translation>
+<translation id="8428213095426709021">ಸೆಟ್ಟಿಂಗ್‌ಗಳು</translation>
+<translation id="2498359688066513246">ಸಹಾಯ ಮತ್ತು ಪ್ರತಿಕ್ರಿಯೆ</translation>
+<translation id="8378714024927312812">ನಿಮ್ಮ ಸಂಸ್ಥೆಯ ಮೂಲಕ ನಿರ್ವಹಿಸಲಾಗಿದೆ</translation>
+<translation id="9019902583201351841">ನಿಮ್ಮ ಪೋಷಕರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ</translation>
+<translation id="4645575059429386691">ನಿಮ್ಮ ಪೋಷಕರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ</translation>
+<translation id="4883854917563148705">ನಿರ್ವಹಿಸಲಾಗುವ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಮರುಹೊಂದಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="4307992518367153382">ಬೇಸಿಕ್ಸ್</translation>
+<translation id="1974060860693918893">ಸುಧಾರಿತ</translation>
+<translation id="1146678959555564648">VR ನಮೂದಿಸಿ</translation>
+<translation id="987264212798334818">ಸಾಮಾನ್ಯ</translation>
+<translation id="4275663329226226506">ಮಾದ್ಯಮ</translation>
+<translation id="4759238208242260848">ಡೌನ್‌ಲೋಡ್‌ಗಳು</translation>
+<translation id="218608176142494674">ಹಂಚಿಕೆ</translation>
+<translation id="8004582292198964060">ಬ್ರೌಸರ್</translation>
+<translation id="1105960400813249514">ಪರದೆ ಕ್ಯಾಪ್ಚರ್</translation>
+<translation id="4875775213178255010">ವಿಷಯದ ಸಲಹೆಗಳು</translation>
+<translation id="2021896219286479412">ಪೂರ್ಣ ಪರದೆ ಸೈಟ್ ನಿಯಂತ್ರಣಗಳು</translation>
+<translation id="4587589328781138893">ಸೈಟ್‌ಗಳು</translation>
+<translation id="4943703118917034429">ವರ್ಚುವಲ್ ರಿಯಾಲಿಟಿ</translation>
+<translation id="1928696683969751773">ಅಪ್‌ಡೇಟ್‌ಗಳು</translation>
+<translation id="6064125863973209585">ಪೂರ್ಣಗೊಳಿಸಿದ ಡೌನ್‌ಲೋಡ್‌ಗಳು</translation>
+<translation id="5342314432463739672">ಅನುಮತಿ ವಿನಂತಿಗಳು</translation>
+<translation id="629730747756840877">ಖಾತೆ</translation>
+<translation id="82609232232243542">Brave ಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
+<translation id="7956662517480676674">ಸಿಂಕ್ ಮತ್ತು Brave Software ಸೇವೆಗಳು</translation>
+<translation id="5294439808117722387">ನೀವು ಪ್ರಸ್ತುತವಾಗಿ ನಿಮ್ಮ ಸಿಂಕ್ ಮತ್ತು Brave Software ಸೇವೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಕಸ್ಟಮೈಸ್ ಮಾಡುತ್ತಿರುವಿರಿ. ಸಿಂಕ್ ಆನ್ ಮಾಡುವುದನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು, ಪರದೆಯ ಕೆಳಭಾಗದಲ್ಲಿ ಸಮೀಪದಲ್ಲಿರುವ 'ದೃಢೀಕರಿಸಿ' ಬಟನ್ ಟ್ಯಾಪ್ ಮಾಡಿ. ಮೇಲಕ್ಕೆ ನ್ಯಾವಿಗೇಟ್</translation>
+<translation id="2096012225669085171">ಸಾಧನಗಳಾದ್ಯಂತ ಸಿಂಕ್ ಮಾಡಿ ಮತ್ತು ವೈಯಕ್ತೀಕರಿಸಿ</translation>
+<translation id="1692118695553449118">ಸಿಂಕ್‌ ಆನ್‌ ಆಗಿದೆ</translation>
+<translation id="5514904542973294328">ಈ ಸಾಧನದ ನಿರ್ವಾಹಕರಿಂದ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ</translation>
+<translation id="6447211988989208781">Brave Software ಚಟುವಟಿಕೆ ನಿಯಂತ್ರಣಗಳು</translation>
+<translation id="4882831918239250449">ಹುಡುಕಾಟ, ಜಾಹೀರಾತುಗಳು ಮತ್ತು ಇನ್ನೂ ಹೆಚ್ಚಿನವುಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೇಗೆ ಬಳಸಲಾಗಿದೆ ಎಂಬುದನ್ನು ನಿಯಂತ್ರಿಸಿ</translation>
+<translation id="7431991332293347422">ಹುಡುಕಾಟ ಮತ್ತು ಇನ್ನೂ ಹೆಚ್ಚಿನವುಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೇಗೆ ಬಳಸಲಾಗುತ್ತದೆ ಎಂಬುದನ್ನು ನಿಯಂತ್ರಿಸಿ</translation>
+<translation id="6303969859164067831">ಸೈನ್ ಔಟ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆಫ್ ಮಾಡಿ</translation>
+<translation id="1125261911132334651">ನಿಮ್ಮ Brave Software ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ</translation>
+<translation id="6406506848690869874">ಸಿಂಕ್</translation>
+<translation id="714362445477979774">ನಿಮ್ಮ Brave ಡೇಟಾವನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
+<translation id="4314815835985389558">ಸಿಂಕ್ ಅನ್ನು ನಿರ್ವಹಿಸಿ</translation>
+<translation id="5428209950370661546">ಇತರ Brave Software ಸೇವೆಗಳು</translation>
+<translation id="7704317875155739195">ಸ್ವಯಂಪೂರ್ಣ ಹುಡುಕಾಟಗಳು ಮತ್ತು URLಗಳು</translation>
+<translation id="2000419248597011803">ಕೆಲವು ಕುಕೀಗಳನ್ನು ಹಾಗೂ ವಿಳಾಸ ಪಟ್ಟಿ ಮತ್ತು ಹುಡುಕಾಟ ಬಾಕ್ಸ್‌ನಿಂದ ಹುಡುಕಾಟಗಳನ್ನು, ನಿಮ್ಮ ಡಿಫಾಲ್ಟ್ ಹುಡುಕಾಟದ ಎಂಜಿನ್‌ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
+<translation id="7981313251711023384">ವೇಗವಾದ ಬ್ರೌಸಿಂಗ್ ಮತ್ತು ಹುಡುಕಾಟಕ್ಕಾಗಿ ಪುಟಗಳನ್ನು ಮುಂಚಿತವಾಗಿ ಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="1821253160463689938">ನೀವು ಆ ಪುಟಗಳಿಗೆ ಭೇಟಿ ನೀಡದಿದ್ದರೂ, ನಿಮ್ಮ ಆದ್ಯತೆಗಳನ್ನು ನೆನಪಿಟ್ಟುಕೊಳ್ಳಲು ಕುಕೀಗಳನ್ನು ಬಳಸುತ್ತದೆ</translation>
+<translation id="6697492270171225480">ಯಾವುದೇ ಪುಟವನ್ನು ಕಂಡುಹಿಡಿಯಲು ಸಾಧ್ಯವಾಗದಿದ್ದರೆ, ಅಂತಹುದೇ ಪುಟಗಳ ಸಲಹೆಯನ್ನು ತೋರಿಸಿ</translation>
+<translation id="8109318360573330108">ನೀವು ಸಂಪರ್ಕಿಸಲು ಪ್ರಯತ್ನಿಸುತ್ತಿರುವ ಪುಟದ URL ಅನ್ನು Brave Software ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
+<translation id="8438566539970814960">ಹುಡುಕಾಟಗಳನ್ನು ಮತ್ತು ಬ್ರೌಸಿಂಗ್ ಅನ್ನು ಉತ್ತಮಗೊಳಿಸುವಂತೆ ಮಾಡಿ</translation>
+<translation id="284843628681142937">ನೀವು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳ URLಗಳನ್ನು Brave Software ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
+<translation id="7222718784508482526">ಗೌಪ್ಯತೆ, ಸುರಕ್ಷತೆ ಮತ್ತು ಡೇಟಾ ಸಂಗ್ರಹಕ್ಕೆ ಸಂಬಂಧಿಸಿದ ಹೆಚ್ಚಿನ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗಾಗಿ <ph name="BEGIN_LINK"/>ಸಿಂಕ್ ಮತ್ತು Brave Software ಸೇವೆಗಳನ್ನು<ph name="END_LINK"/> ನೋಡಿ</translation>
+<translation id="918192811481327695">Brave ನ ವೈಶಿಷ್ಟ್ಯಗಳು ಹಾಗೂ ಕೆಲಸ ನಿರ್ವಹಣೆಯನ್ನು ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡಿ</translation>
+<translation id="9063160602596686558">ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳು ಮತ್ತು ಕ್ರ್ಯಾಶ್ ವರದಿಗಳನ್ನು Brave Software ಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಕಳುಹಿಸುತ್ತದೆ</translation>
+<translation id="4824958205181053313">ಸಿಂಕ್ ರದ್ದುಗೊಳಿಸುವುದೇ?</translation>
+<translation id="3058498974290601450">ನೀವು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಯಾವಾಗ ಬೇಕಾದರೂ ಸಿಂಕ್ ಆನ್ ಮಾಡಬಹುದು</translation>
+<translation id="3143515551205905069">ಸಿಂಕ್ ಮಾಡುವಿಕೆಯನ್ನು ರದ್ದುಪಡಿಸಿ</translation>
+<translation id="1506061864768559482">ಹುಡುಕಾಟ ಇಂಜಿನ್</translation>
+<translation id="55737423895878184">ಸ್ಥಳ ಮತ್ತು ಅಧಿಸೂಚನೆಗಳನ್ನು ಅನುಮತಿಸಲಾಗಿದೆ</translation>
+<translation id="3988213473815854515">ಸ್ಥಳವನ್ನು ಅನುಮತಿಸಲಾಗಿದೆ</translation>
+<translation id="32895400574683172">ಅಧಿಸೂಚನೆಗಳನ್ನು ಅನುಮತಿಸಲಾಗಿದೆ</translation>
+<translation id="9040142327097499898">ಅಧಿಸೂಚನೆಗಳಿಗೆ ಅನುಮತಿಯಿದೆ. ಈ ಸಾಧನದ ಸ್ಥಳ ಆಫ್ ಆಗಿದೆ.</translation>
+<translation id="305593374596241526">ಸ್ಥಳ ಆಫ್ ಆಗಿದೆ; <ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಇದನ್ನು ಆನ್‌ ಮಾಡಿ.</translation>
+<translation id="2989523299700148168">ಇತ್ತೀಚೆಗೆ ಭೇಟಿ ನೀಡಿದವು</translation>
+<translation id="6433501201775827830">ನಿಮ್ಮ ಹುಡುಕಾಟದ ಇಂಜಿನ್ ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="7177466738963138057">ನೀವು ಇದನ್ನು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ನಂತರ ಬದಲಾಯಿಸಬಹುದು</translation>
+<translation id="3478363558367712427">ನಿಮ್ಮ ಹುಡುಕಾಟ ಎಂಜಿನ್ ಅನ್ನು ನೀವು ಆಯ್ಕೆಮಾಡಬಹುದು</translation>
+<translation id="4910889077668685004">ಪಾವತಿ ಅಪ್ಲಿಕೇಶನ್‌ಗಳು</translation>
+<translation id="5152843274749979095">ಯಾವುದೇ ಬೆಂಬಲಿತ ಅಪ್ಲಿಕೇಶನ್‌ಗಳನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ</translation>
+<translation id="8812260976093120287">ಕೆಲವು ವೆಬ್‌ಸೈಟ್‌ಗಳಲ್ಲಿ, ನೀವು ಮೇಲೆ ಬೆಂಬಲಿಸಲಾದ ಪಾವತಿ ಅಪ್ಲಿಕೇಶನ್‌ಗಳನ್ನು ಬಳಸಿಕೊಂಡು ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಪಾವತಿಸಬಹುದು.</translation>
+<translation id="7764225426217299476">ವಿಳಾಸ ಸೇರಿಸಿ</translation>
+<translation id="5595485650161345191">ವಿಳಾಸ ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="5087580092889165836">ಕಾರ್ಡ್ ಸೇರಿಸಿ</translation>
+<translation id="2154484045852737596">ಕಾರ್ಡ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="6140912465461743537">ರಾಷ್ಟ್ರ/ಪ್ರದೇಶ</translation>
+<translation id="5659593005791499971">ಇಮೇಲ್</translation>
+<translation id="4378154925671717803">ಫೋನ್</translation>
+<translation id="4807098396393229769">ಕಾರ್ಡ್‌ನಲ್ಲಿರುವ ಹೆಸರು</translation>
+<translation id="860043288473659153">ಕಾರ್ಡ್‌ಹೋಲ್ಡರ್ ಹೆಸರು</translation>
+<translation id="2612676031748830579">ಕಾರ್ಡ್ ಸಂಖ್ಯೆ</translation>
+<translation id="869891660844655955">ಅವಧಿ ಮುಗಿಯುವ ದಿನಾಂಕ</translation>
+<translation id="2286841657746966508">ಬಿಲ್ಲಿಂಗ್ ವಿಳಾಸ</translation>
+<translation id="663059986967017181">Brave ಗೆ ನಕಲಿಸಲಾಗಿದೆ</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
+<translation id="1943432128510653496">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
+<translation id="2100273922101894616">ಸ್ವಯಂ ಸೈನ್-ಇನ್</translation>
+<translation id="363596933471559332">ಸಂಗ್ರಹಿಸಲಾದ ರುಜುವಾತುಗಳನ್ನು ಬಳಸಿಕೊಳ್ಳುವ ಮೂಲಕ ವೆಬ್‌ಸೈಟ್‌ಗಳಿಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಸೈನ್ ಇನ್ ಮಾಡಿ. ವೈಶಿಷ್ಟ್ಯವು ಆಫ್ ಆಗಿರುವಾಗ, ವೆಬ್‌ಸೈಟ್‌ಗೆ ಸೈನ್ ಇನ್ ಮಾಡುವ ಮೊದಲು ಪ್ರತಿ ಬಾರಿಯೂ ನಿಮಗೆ ಪರಿಶೀಲನೆ ಮಾಡಲು ಕೇಳಲಾಗುವುದು.</translation>
+<translation id="6995899638241819463">ಡೇಟಾ ಉಲ್ಲಂಘನೆಯಿಂದಾಗಿ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ಬಹಿರಂಗಪಡಿಸಿದರೆ ನಿಮಗೆ ಎಚ್ಚರಿಕೆ ನೀಡಲಾಗುತ್ತದೆ</translation>
+<translation id="1534287762301776620">ನಿಮ್ಮ Brave Software ಖಾತೆಗೆ ನೀವು ಸೈನ್ ಇನ್ ಮಾಡಿದಾಗ, ಈ ವೈಶಿಷ್ಟ್ಯವು ಆನ್ ಆಗುತ್ತದೆ</translation>
+<translation id="10614374240317010">ಉಳಿಸಿಯೇ ಇಲ್ಲ</translation>
+<translation id="3098842761938485917">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ನಿಮ್ಮ <ph name="BEGIN_LINK"/>Brave Software ಖಾತೆಯಲ್ಲಿ<ph name="END_LINK"/> ವೀಕ್ಷಿಸಿ ಮತ್ತು ನಿರ್ವಹಿಸಿ</translation>
+<translation id="8562452229998620586">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ.</translation>
+<translation id="8084114998886531721">ಉಳಿಸಿರುವ ಪಾಸ್‌ವರ್ಡ್</translation>
+<translation id="2870560284913253234">ಸೈಟ್</translation>
+<translation id="8503813439785031346">ಬಳಕೆದಾರರಹೆಸರು</translation>
+<translation id="6657585470893396449">ಪಾಸ್‌ವರ್ಡ್</translation>
+<translation id="2154710561487035718">URL ನಕಲಿಸಿ</translation>
+<translation id="1571304935088121812">ಬಳಕೆದಾರರಹೆಸರು ನಕಲಿಸಿ</translation>
+<translation id="5005498671520578047">ಪಾಸ್‌ವರ್ಡ್ ನಕಲಿಸಿ</translation>
+<translation id="3632295766818638029">ಪಾಸ್‌ವರ್ಡ್ ಅನ್‌ಮಾಸ್ಕ್ ಮಾಡಿ</translation>
+<translation id="1513858653616922153">ಪಾಸ್‌ವರ್ಡ್ ಅಳಿಸಿ</translation>
+<translation id="543338862236136125">ಪಾಸ್‌ವರ್ಡ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="4565377596337484307">ಪಾಸ್‌ವರ್ಡ್ ಮರೆಮಾಡಿ</translation>
+<translation id="8523928698583292556">ಸಂಗ್ರಹಿತ ಪಾಸ್‌ವರ್ಡ್ ಅಳಿಸಿ</translation>
+<translation id="2898264748040935573">ಸಂಗ್ರಹಿಸಿರುವ ಪಾಸ್‌ವರ್ಡ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="5433691172869980887">ಬಳಕೆದಾರರ ಹೆಸರನ್ನು ನಕಲಿಸಲಾಗಿದೆ</translation>
+<translation id="5534640966246046842">ಸೈಟ್ ಅನ್ನು ನಕಲಿಸಲಾಗಿದೆ</translation>
+<translation id="2625189173221582860">ಪಾಸ್‌ವರ್ಡ್ ಅನ್ನು ನಕಲಿಸಲಾಗಿದೆ</translation>
+<translation id="4550003330909367850">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್ ಅನ್ನು ಇಲ್ಲಿ ವೀಕ್ಷಿಸಲು ಅಥವಾ ನಕಲಿಸಲು, ಈ ಸಾಧನದಲ್ಲಿ ಪರದೆ ಲಾಕ್ ಅನ್ನು ಸೆಟ್ ಮಾಡಿ.</translation>
+<translation id="6154478581116148741">ಈ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಂದ ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ರಫ್ತುಮಾಡಲು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಸ್ಕ್ರೀನ್ ಲಾಕ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
+<translation id="4842092870884894799">ಪಾಸ್‌ವರ್ಡ್ ರಚನೆ ಪಾಪ್‌ಅಪ್ ತೋರಿಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="2259659629660284697">ಪಾಸ್‌ವರ್ಡ್‍ಗಳನ್ನು ಎಕ್ಸ್‌ಪೋರ್ಟ್ ಮಾಡಿ…</translation>
+<translation id="133012818630824069">Brave ಮೂಲಕ ಸಂಗ್ರಹಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ರಫ್ತು ಮಾಡಿ</translation>
+<translation id="6914783257214138813">ರಫ್ತು ಮಾಡಲಾದ ಫೈಲ್ ಅನ್ನು ನೋಡುವ ಯಾರಿಗಾದರೂ ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಗೋಚರಿಸುತ್ತವೆ.</translation>
+<translation id="2321086116217818302">ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ಸಿದ್ಧಪಡಿಸಲಾಗುತ್ತಿದೆ…</translation>
+<translation id="8445448999790540984">ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ಎಕ್ಸ್‌ಪೋರ್ಟ್ ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="3066461326500799725">Brave Software ಡ್ರೈವ್‌‌ ಅನ್ನು ಹೇಗೆ ಬಳಸುವುದು ಎಂದು ತಿಳಿದುಕೊಳ್ಳಿ</translation>
+<translation id="729975465115245577">ನಿಮ್ಮ ಸಾಧನವು ಪಾಸ್‌ವರ್ಡ್‌ ಫೈಲ್ ಅನ್ನು ಸಂಗ್ರಹಿಸಿಡಲು ಅಪ್ಲಿಕೇಶನ್‌ ಅನ್ನು ಹೊಂದಿಲ್ಲ.</translation>
+<translation id="7682724950699840886">ಕೆಳಗಿನ ಸಲಹೆಗಳನ್ನು ಬಳಸಿ ನೋಡಿ: ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಸಾಕಷ್ಟು ಸ್ಥಳಾವಕಾಶ ಇರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಂಡು, ಪುನಃ ಎಕ್ಸ್‌ಪೋರ್ಟ್ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ.</translation>
+<translation id="1129510026454351943">ವಿವರಗಳು: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್ ಅನ್ನು ನಕಲಿಸಲು ಅನ್‌ಲಾಕ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="5515439363601853141">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ ಅನ್ನು ವೀಕ್ಷಿಸಲು ಅನ್‌ಲಾಕ್‌ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="6221633008163990886">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ರಫ್ತುಮಾಡಲು ಅನ್‌ಲಾಕ್ ಮಾಡಿ</translation>
+<translation id="230699814587342492">Brave ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
+<translation id="6075798973483050474">ಹೋಮ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="854522910157234410">ಈ ಪುಟವನ್ನು ತೆರೆಯಿರಿ</translation>
+<translation id="2482878487686419369">ಸೂಚನೆಗಳು</translation>
+<translation id="6255999984061454636">ವಿಷಯದ ಸಲಹೆಗಳು</translation>
+<translation id="805047784848435650">ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸದ ಆಧಾರಿಸಿ</translation>
+<translation id="1041308826830691739">ವೆಬ್‌ಸೈಟ್‌ಗಳ ಮೂಲಕ</translation>
+<translation id="395206256282351086">ಹುಡುಕಾಟ ಹಾಗೂ ಸೈಟ್ ಕುರಿತಾದ ಸಲಹೆಗಳನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ</translation>
+<translation id="257088987046510401">ಥೀಮ್‌ಗಳು</translation>
+<translation id="4650364565596261010">ಸಿಸ್ಟಂ ಡಿಫಾಲ್ಟ್</translation>
+<translation id="7588219262685291874">ನಿಮ್ಮ ಸಾಧನದ ಬ್ಯಾಟರಿ ಸೇವರ್ ಆನ್ ಆಗಿರುವಾಗ, ಡಾರ್ಕ್ ಥೀಮ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
+<translation id="2760989362628427051">ನಿಮ್ಮ ಸಾಧನದ ಡಾರ್ಕ್ ಥೀಮ್ ಅಥವಾ ಬ್ಯಾಟರಿ ಸೇವರ್ ಆನ್ ಆಗಿರುವಾಗ, ಡಾರ್ಕ್ ಥೀಮ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
+<translation id="6381421346744604172">ಡಾರ್ಕನ್ ವೆಬ್‌ಸೈಟ್‌ಗಳು</translation>
+<translation id="5040262127954254034">ಗೌಪ್ಯತೆ</translation>
+<translation id="4991384657077828949">Brave ಭದ್ರತೆಯನ್ನು ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡಿ</translation>
+<translation id="1943176487615318915">ಅಪಾಯಕಾರಿ ಆ್ಯಪ್‌ಗಳು ಮತ್ತು ಸೈಟ್‌ಗಳನ್ನು ಪತ್ತೆಹಚ್ಚಲು Brave, ನೀವು ಭೇಟಿ ನೀಡುವ ಕೆಲವು ಪುಟಗಳ URL ಗಳು, ಸೀಮಿತ ಸಿಸ್ಟಂ ಮಾಹಿತಿ ಮತ್ತು ಕೆಲವು ಪುಟದ ವಿಷಯವನ್ನು Brave Software ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
+<translation id="3181954750937456830">ಸುರಕ್ಷಿತ ಬ್ರೌಸಿಂಗ್ (ಅಪಾಯಕಾರಿ ಸೈಟ್‌ಗಳಿಂದ ನಿಮ್ಮನ್ನು ಮತ್ತು ನಿಮ್ಮ ಸಾಧನವನ್ನು ರಕ್ಷಿಸುತ್ತದೆ)</translation>
+<translation id="7315322926489145388">ನಿಮ್ಮ ಭದ್ರತೆಯು ಅಪಾಯದಲ್ಲಿದ್ದಾಗ, ನೀವು ಭೇಟಿ ನೀಡುವ ಕೆಲವು ಪುಟಗಳ URL ಗಳನ್ನು Brave Software ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
+<translation id="2063713494490388661">ಹುಡುಕಲು ಟ್ಯಾಪ್‌ ಮಾಡಿ</translation>
+<translation id="2369463299479365221">ಪುಟದಿಂದ ಹೊರಹೋಗದೆಯೇ ವೆಬ್‌ಸೈಟ್‌ನಲ್ಲಿನ ವಿಷಯಗಳ ಕುರಿತು ತಿಳಿದುಕೊಳ್ಳಿ. "ಹುಡುಕಾಟಕ್ಕಾಗಿ ಟ್ಯಾಪ್‌ ಮಾಡಿ" ಮೂಲಕ Brave Software ಹುಡುಕಾಟಕ್ಕೆ ಪದ ಮತ್ತು ಅದರ ಹಿನ್ನೆಲೆಯನ್ನು ಕಳುಹಿಸುತ್ತದೆ ಈ ಮೂಲಕ ವ್ಯಾಖ್ಯಾನಗಳು, ಚಿತ್ರಗಳು, ಹುಡುಕಾಟ ಫಲಿತಾಂಶಗಳು, ಮತ್ತು ಇತರ ವಿವರಗಳನ್ನು ನೀಡುತ್ತದೆ.
 
 ನಿಮ್ಮ ಹುಡುಕಾಟ ಪದ ಹೊಂದಿಸುವುದಕ್ಕಾಗಿ ಆಯ್ಕೆಮಾಡಲು ದೀರ್ಘವಾಗಿ ಒತ್ತಿರಿ. ನಿಮ್ಮ ಹುಡುಕಾಟವನ್ನು ಸಂಸ್ಕರಿಸಲು, ಪ್ಯಾನಲ್ ಅನ್ನು ಮೇಲಕ್ಕೆ ಸ್ಲೈಡ್ ಮಾಡಿ ಮತ್ತು ಹುಡುಕಾಟ ಬಾಕ್ಸ್ ಅನ್ನು ಟ್ಯಾಪ್‌ ಮಾಡಿ.</translation>
-<translation id="4056223980640387499">ಸೆಪಿಯಾ</translation>
-<translation id="4060598801229743805">ಪರದೆಯ ಮೇಲಿನ ಭಾಗದಲ್ಲಿ ಲಭ್ಯವಿರುವ ಆಯ್ಕೆಗಳು</translation>
-<translation id="4062305924942672200">ಕಾನೂನು ಮಾಹಿತಿ</translation>
-<translation id="4084682180776658562">ಬುಕ್‌ಮಾರ್ಕ್</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" /> ಅವರಿಂದ – <ph name="BEGIN_DEEMPHASIZED" />Google ನಿಂದ ವಿತರಿಸಲಾಗಿದೆ<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">ಅಪ್ಲಿಕೇಶನ್ ಡೇಟಾ ಅಳಿಸುವುದೇ?</translation>
-<translation id="4099578267706723511">Google ಗೆ ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳು ಮತ್ತು ಕ್ರ್ಯಾಶ್ ವರದಿಗಳನ್ನು ಕಳುಹಿಸುವ ಮೂಲಕ Chrome ಅನ್ನು ಉತ್ತಮಗೊಳಿಸಲು ಸಹಾಯ ಮಾಡಿ.</translation>
-<translation id="410351446219883937">ಆಟೋಪ್ಲೇ</translation>
-<translation id="4116038641877404294">ಪುಟಗಳನ್ನು ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ಬಳಸಲು ಅವುಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="4135200667068010335">ಟ್ಯಾಬ್ ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಬೇಕಾದ ಸಾಧನಗಳ ಪಟ್ಟಿಯನ್ನು ಮುಚ್ಚಲಾಗಿದೆ.</translation>
-<translation id="4149994727733219643">ವೆಬ್ ಪುಟಗಳಿಗಾಗಿ ಸರಳೀಕೃತ ವೀಕ್ಷಣೆ</translation>
-<translation id="4165986682804962316">ಸೈಟ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು</translation>
-<translation id="4169535189173047238">ಅನುಮತಿಸಬೇಡಿ</translation>
-<translation id="4170011742729630528">ಈ ಸೇವೆಯು ಲಭ್ಯವಿಲ್ಲ; ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> ಬಳಸಲಾಗಿದೆ</translation>
-<translation id="4181841719683918333">ಭಾಷೆಗಳು</translation>
-<translation id="4183868528246477015">Google ಲೆನ್ಸ್ ಮೂಲಕ ಹುಡುಕಿ<ph name="BEGIN_NEW" />ಹೊಸತು<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="4198423547019359126">ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳಗಳು ಲಭ್ಯವಿಲ್ಲ</translation>
-<translation id="4209895695669353772">Google ಸಲಹೆ ನೀಡಿದ ವೈಯಕ್ತೀಕರಿಸಲಾದ ವಿಷಯವನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
-<translation id="4226663524361240545">ಪ್ರಕಟಣೆಗಳು ಸಾಧನವನ್ನು ವೈಬ್ರೇಟ್ ಮಾಡಬಹುದು</translation>
-<translation id="423219824432660969"><ph name="TIME" /> ರಂದು ಹೊಂದಿಸಿದ್ದ Google ಪಾಸ್‌ವರ್ಡ್‌ ಬಳಸಿಕೊಂಡು, ಸಿಂಕ್ ಮಾಡಿದ ಡೇಟಾವನ್ನು ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿ</translation>
-<translation id="4242533952199664413">ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆ</translation>
-<translation id="4256782883801055595">ಓಪನ್ ಸೋರ್ಸ್ ಪರವಾನಗಿಗಳು</translation>
-<translation id="4259722352634471385">ನ್ಯಾವಿಗೇಶನ್‌ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ: <ph name="URL" /></translation>
-<translation id="4269820728363426813">ಲಿಂಕ್ ವಿಳಾಸವನ್ನು ನಕಲಿಸಿ</translation>
-<translation id="4275663329226226506">ಮಾದ್ಯಮ</translation>
-<translation id="4278390842282768270">ಅನುಮತಿಸಲಾಗಿದೆ</translation>
-<translation id="429312253194641664">ಒಂದು ಸೈಟ್, ಮಾಧ್ಯಮವನ್ನು ಪ್ಲೇ ಮಾಡುತ್ತಿದೆ</translation>
-<translation id="4298388696830689168">ಲಿಂಕ್ ಮಾಡಿರುವ ಸೈಟ್‌ಗಳು</translation>
-<translation id="4307992518367153382">ಬೇಸಿಕ್ಸ್</translation>
-<translation id="4314815835985389558">ಸಿಂಕ್ ಅನ್ನು ನಿರ್ವಹಿಸಿ</translation>
-<translation id="4351244548802238354">ಸಂವಾದವನ್ನು ಮುಚ್ಚಿ</translation>
-<translation id="4378154925671717803">ಫೋನ್</translation>
-<translation id="4384468725000734951">ಹುಡುಕಲು Sogou ಬಳಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="4404568932422911380">ಯಾವುದೇ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಲಭ್ಯವಿಲ್ಲ</translation>
-<translation id="4405224443901389797">ಇದಕ್ಕೆ ಸರಿಸಿ…</translation>
-<translation id="4411535500181276704">ಲೈಟ್ ಮೋಡ್</translation>
-<translation id="4415276339145661267">ನಿಮ್ಮ Google ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ</translation>
-<translation id="4432792777822557199">ಈಗಿನಿಂದಲೇ <ph name="SOURCE_LANGUAGE" /> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು <ph name="TARGET_LANGUAGE" /> ಗೆ ಅನುವಾದ ಮಾಡಲಾಗುತ್ತದೆ</translation>
-<translation id="4433925000917964731">Lite ಪುಟವನ್ನು Google ಒದಗಿಸಿದೆ</translation>
-<translation id="4434045419905280838">ಪಾಪ್-ಅಪ್‌ಗಳು ಹಾಗೂ ಮರುನಿರ್ದೇಶನಗಳು</translation>
-<translation id="4440958355523780886">ಪುಟದ ಲೈಟ್ ಆವೃತ್ತಿಯನ್ನು Google ಒದಗಿಸಿದೆ. ಮೂಲ ಆವೃತ್ತಿಯನ್ನು ಲೋಡ್ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> ಟ್ಯಾಬ್‌ ಮುಚ್ಚಿ</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> ಗೆ ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="445467742685312942">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿ ನೀಡಿ</translation>
-<translation id="4468959413250150279">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ನ ಧ್ವನಿಯನ್ನು ಮ್ಯೂಟ್ ಮಾಡಿ</translation>
-<translation id="4472118726404937099">ಸಾಧನಗಳಾದ್ಯಂತ ಸಿಂಕ್ ಮಾಡಲು ಮತ್ತು ವೈಯಕ್ತೀಕರಿಸಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
-<translation id="447252321002412580">Chrome ನ ವೈಶಿಷ್ಟ್ಯಗಳು ಹಾಗೂ ಕೆಲಸ ನಿರ್ವಹಣೆಯನ್ನು ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡಿ</translation>
-<translation id="4479647676395637221">ನಿಮ್ಮ ಕ್ಯಾಮರಾ ಬಳಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="4479972344484327217">Chrome ಗಾಗಿ <ph name="MODULE" /> ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲಾಗುತ್ತಿದೆ…</translation>
-<translation id="4487967297491345095">ಎಲ್ಲಾ Chrome ಅಪ್ಲಿಕೇಶನ್ ಡೇಟಾವನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ. ಇದು ಎಲ್ಲಾ ಫೈಲ್‌ಗಳು, ಸೆಟ್ಟಿಂಗ್‌ಗಳು, ಖಾತೆಗಳು, ಡೇಟಾಬೇಸ್‌ಗಳು, ಇತ್ಯಾದಿಗಳನ್ನು ಒಳಗೊಂಡಿರುತ್ತದೆ.</translation>
-<translation id="4493497663118223949">ಲೈಟ್ ಮೋಡ್ ಆನ್ ಆಗಿದೆ</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# ದಿನದ ಹಿಂದೆ}one{# ದಿನಗಳ ಹಿಂದೆ}other{# ದಿನಗಳ ಹಿಂದೆ}}</translation>
-<translation id="451872707440238414">ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಹುಡುಕಿ</translation>
-<translation id="4521489764227272523">ಆಯ್ಕೆ ಮಾಡಿದ ಡೇಟಾವನ್ನು Chrome ನಿಂದ ಮತ್ತು ಸಿಂಕ್ ಮಾಡಿರುವ ನಿಮ್ಮ ಸಾಧನಗಳಿಂದ ತೆಗೆದುಹಾಕಲಾಗಿದೆ.
-ನಿಮ್ಮ Google ಖಾತೆಯು, ಹುಡುಕಾಟಗಳು ಮತ್ತು ಇತರ Google ಸೇವೆಗಳ ಚಟುವಟಿಕೆಗಳಂತಹ ಬೇರೆ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.ನಲ್ಲಿ ಹೊಂದಿರಬಹುದು.</translation>
-<translation id="4532845899244822526">ಫೋಲ್ಡರ್‌ ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="4538018662093857852">ಲೈಟ್ ಮೋಡ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
-<translation id="4550003330909367850">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್ ಅನ್ನು ಇಲ್ಲಿ ವೀಕ್ಷಿಸಲು ಅಥವಾ ನಕಲಿಸಲು, ಈ ಸಾಧನದಲ್ಲಿ ಪರದೆ ಲಾಕ್ ಅನ್ನು ಸೆಟ್ ಮಾಡಿ.</translation>
-<translation id="4558311620361989323">ವೆಬ್‌ಪುಟ ಶಾರ್ಟ್‌ಕಟ್‌ಗಳು</translation>
-<translation id="4561979708150884304">ಯಾವುದೇ ಸಂಪರ್ಕವಿಲ್ಲ</translation>
-<translation id="4565377596337484307">ಪಾಸ್‌ವರ್ಡ್ ಮರೆಮಾಡಿ</translation>
-<translation id="4570913071927164677">ವಿವರಗಳು</translation>
-<translation id="4572422548854449519">ನಿರ್ವಹಿಸಲ್ಪಟ್ಟ ಖಾತೆಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# ನಿಮಿಷದ ಹಿಂದೆ}one{# ನಿಮಿಷಗಳ ಹಿಂದೆ}other{# ನಿಮಿಷಗಳ ಹಿಂದೆ}}</translation>
-<translation id="4587589328781138893">ಸೈಟ್‌ಗಳು</translation>
-<translation id="4594952190837476234">ಈ ಆಫ್‍ಲೈನ್ ಪುಟವನ್ನು <ph name="CREATION_TIME" /> ರಂದು ರಚಿಸಲಾಗಿದೆ ಮತ್ತು ಇದು ಆನ್‌ಲೈನ್ ಆವೃತ್ತಿಗಿಂತ ಭಿನ್ನವಾಗಿರಬಹುದು.</translation>
-<translation id="4605958867780575332">ತೆಗೆದುಹಾಕಲಾಗಿರುವ ಐಟಂ: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> ತೆರೆಯಿರಿ</translation>
-<translation id="4634124774493850572">ಪಾಸ್‌ವರ್ಡ್ ಬಳಸಿ</translation>
-<translation id="4645575059429386691">ನಿಮ್ಮ ಪೋಷಕರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ</translation>
-<translation id="4650364565596261010">ಸಿಸ್ಟಂ ಡಿಫಾಲ್ಟ್</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> ಅನ್ನು ನಿಮ್ಮ ಹೋಮ್ ಪರದೆಗೆ ಸೇರಿಸಲಾಗಿದೆ</translation>
-<translation id="4684427112815847243">ಪ್ರತಿಯೊಂದನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">ನಿಮ್ಮ ಸಾಧನಗಳಿಗೆ ಪಠ್ಯವನ್ನು ಕಳುಹಿಸಿ</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> ನಲ್ಲಿ ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ</translation>
-<translation id="4699172675775169585">ಸಂಗ್ರಹಿಸಲಾಗಿರುವ ಚಿತ್ರಗಳು ಮತ್ತು ಫೈಲ್‌ಗಳು</translation>
-<translation id="4714588616299687897">60% ರವರೆಗೆ ನಿಮ್ಮ ಡೇಟಾ ಉಳಿಸಿ</translation>
-<translation id="4719927025381752090">ಅನುವಾದಿಸಲು ಅವಕಾಶಿಸಿ</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" /> ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="4720982865791209136">Chrome ಸುಧಾರಣೆಗೆ ಸಹಾಯ ಮಾಡಿ. <ph name="BEGIN_LINK" />ಸಮೀಕ್ಷೆಯಲ್ಲಿ ಭಾಗವಹಿಸಿ<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">ಅಪ್‌ಡೇಟ್‌‌</translation>
-<translation id="4738836084190194332">ಕೊನೆಯದಾಗಿ ಸಿಂಕ್ ಮಾಡಿರುವ ಸಮಯ: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">ಹೊಸ ಟ್ಯಾಬ್ ತೆರೆಯಿರಿ</translation>
-<translation id="4751476147751820511">ಚಲನೆ ಅಥವಾ ಬೆಳಕಿನ ಸೆನ್ಸರ್‌ಗಳು</translation>
-<translation id="4759238208242260848">ಡೌನ್‌ಲೋಡ್‌ಗಳು</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ಡೌನ್‌ಲೋಡ್‌‌ ಪೂರ್ಣಗೊಂಡಿದೆ.}one{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಪೂರ್ಣಗೊಂಡಿವೆ.}other{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಪೂರ್ಣಗೊಂಡಿವೆ.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" /> ಗೆ ಹಿಂತಿರುಗಲು ಸ್ಪರ್ಶಿಸಿ</translation>
-<translation id="4802417911091824046">ಪಾಸ್‌ಫ್ರೇಸ್ ಎನ್‌ಕ್ರಿಪ್ಶನ್, Google Pay ನಿಂದ ಪಾವತಿ ವಿಧಾನಗಳು ಮತ್ತು ವಿಳಾಸಗಳನ್ನು ಒಳಗೊಂಡಿರುವುದಿಲ್ಲ.
-
-ಈ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಬದಲಾಯಿಸಲು, <ph name="BEGIN_LINK" />ಸಿಂಕ್ ಅನ್ನು ಮರುಹೊಂದಿಸಿ<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">ಕಾರ್ಡ್‌ನಲ್ಲಿರುವ ಹೆಸರು</translation>
-<translation id="4824958205181053313">ಸಿಂಕ್ ರದ್ದುಗೊಳಿಸುವುದೇ?</translation>
-<translation id="4837753911714442426">ಪುಟವನ್ನು ಮುದ್ರಿಸಲು ಆಯ್ಕೆಗಳನ್ನು ತೆರೆಯಿರಿ</translation>
-<translation id="4842092870884894799">ಪಾಸ್‌ವರ್ಡ್ ರಚನೆ ಪಾಪ್‌ಅಪ್ ತೋರಿಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="4860895144060829044">ಕರೆ</translation>
-<translation id="4866368707455379617">Chrome ಗಾಗಿ <ph name="MODULE" /> ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
-<translation id="4875775213178255010">ವಿಷಯದ ಸಲಹೆಗಳು</translation>
-<translation id="4878404682131129617">ಪ್ರಾಕ್ಸಿ ಸರ್ವರ್ ಮೂಲಕ ಟ್ಯೂನಲ್ ಅನ್ನು ಸ್ಥಾಪಿಸುವುದು ವಿಫಲವಾಗಿದೆ</translation>
-<translation id="4880127995492972015">ಅನುವಾದಿಸಿ…</translation>
-<translation id="4881695831933465202">ತೆರೆ</translation>
-<translation id="488187801263602086">ಫೈಲ್‌ ಮರುಹೆಸರಿಸಿ</translation>
-<translation id="4882831918239250449">ಹುಡುಕಾಟ, ಜಾಹೀರಾತುಗಳು ಮತ್ತು ಇನ್ನೂ ಹೆಚ್ಚಿನವುಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೇಗೆ ಬಳಸಲಾಗಿದೆ ಎಂಬುದನ್ನು ನಿಯಂತ್ರಿಸಿ</translation>
-<translation id="4883854917563148705">ನಿರ್ವಹಿಸಲಾಗುವ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಮರುಹೊಂದಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="4885273946141277891">ಬೆಂಬಲಿಸದಿರುವ Chrome ನಿದರ್ಶನಗಳ ಸಂಖ್ಯೆ.</translation>
-<translation id="4910889077668685004">ಪಾವತಿ ಅಪ್ಲಿಕೇಶನ್‌ಗಳು</translation>
-<translation id="4913161338056004800">ಅಂಕಿ ಅಂಶಗಳನ್ನು ಮರುಹೊಂದಿಸಿ</translation>
-<translation id="4913169188695071480">ರಿಫ್ರೆಶ್ ಮಾಡುವಿಕೆ ನಿಲ್ಲಿಸಿ</translation>
-<translation id="4915549754973153784">ಸಾಧನಗಳಿಗೆ ಸ್ಕ್ಯಾನ್ ಮಾಡುವಾಗ <ph name="BEGIN_LINK" />ಸಹಾಯ ಪಡೆಯಿರಿ<ph name="END_LINK" />...</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# ಪುಟ}one{# ಪುಟಗಳು}other{# ಪುಟಗಳು}}</translation>
-<translation id="4932247056774066048">ನೀವು <ph name="DOMAIN_NAME" /> ಮೂಲಕ ನಿರ್ವಹಿಸಲಾಗುವ ಖಾತೆಯಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡುತ್ತಿರುವ ಕಾರಣ, ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ Chrome ಡೇಟಾವನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ. ಇದು ನಿಮ್ಮ Google ಖಾತೆಯಲ್ಲಿ ಉಳಿಯುತ್ತದೆ.</translation>
-<translation id="4943703118917034429">ವರ್ಚುವಲ್ ರಿಯಾಲಿಟಿ</translation>
-<translation id="4943872375798546930">ಯಾವುದೇ ಫಲಿತಾಂಶಗಳಿಲ್ಲ</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> ನಿಮ್ಮ ಪರದೆಯನ್ನು ಹಂಚಿಕೊಳ್ಳುತ್ತಿದೆ</translation>
-<translation id="4961107849584082341">ಈ ಪುಟವನ್ನು ಯಾವ ಭಾಷೆಗಾದರೂ ಅನುವಾದಿಸಿ</translation>
-<translation id="4962975101802056554">ಸಾಧನಕ್ಕೆ ನೀಡಿರುವ ಎಲ್ಲಾ ಅನುಮತಿಗಳನ್ನು ಹಿಂಪಡೆಯಿರಿ</translation>
-<translation id="4970824347203572753">ನಿಮ್ಮ ಸ್ಥಳದಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲ</translation>
-<translation id="497421865427891073">ಮುಂದಕ್ಕೆ ಹೋಗು</translation>
-<translation id="4988210275050210843">ಫೈಲ್ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗುತ್ತಿದೆ (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">ಪುಟಗಳು</translation>
-<translation id="4994033804516042629">ಯಾವುದೇ ಸಂಪರ್ಕಗಳು ಕಂಡುಬಂದಿಲ್ಲ</translation>
-<translation id="4996978546172906250">ಇದರ ಮೂಲಕ ಹಂಚಿ</translation>
-<translation id="5004416275253351869">Google ಚಟುವಟಿಕೆ ನಿಯಂತ್ರಣಗಳು</translation>
-<translation id="5005498671520578047">ಪಾಸ್‌ವರ್ಡ್ ನಕಲಿಸಿ</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> ಸಂಪರ್ಕಿಸಲು ಬಯಸುತ್ತದೆ</translation>
-<translation id="5013696553129441713">ಯಾವುದೇ ಹೊಸ ಸಲಹೆಗಳಿಲ್ಲ</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">ನೀವು VR ನಲ್ಲಿರುವಾಗ, ಈ ಸೈಟ್ ಇವುಗಳ ಕುರಿತು ತಿಳಿಯಲು ಸಾಧ್ಯವಾಗಬಹುದು:
-  -  ನಿಮ್ಮ ದೈಹಿಕ ವೈಶಿಷ್ಟ್ಯಗಳು, ಉದಾಹರಣೆಗೆ ನಿಮ್ಮ ಎತ್ತರ
-
-VR ಗೆ ಪ್ರವೇಶಿಸುವ ಮೊದಲು ನೀವು ಈ ವೆಬ್‌ಸೈಟ್‌ ಅನ್ನು ನಂಬುತ್ತೀರಾ ಎನ್ನುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.</translation>
+<translation id="2930742481329940825">"ಹುಡುಕಲು ಟ್ಯಾಪ್‌ ಮಾಡಿ" ಮೂಲಕ ಆಯ್ಕೆಮಾಡಿದ ಪದ ಮತ್ತು ಪ್ರಸ್ತುತ ಪುಟವನ್ನು ಸಂದರ್ಭಕ್ಕೆ ತಕ್ಕಂತೆ Brave Software ಹುಡುಕಾಟಕ್ಕೆ ಕಳುಹಿಸುತ್ತದೆ. ನೀವು ಇದನ್ನು <ph name="BEGIN_LINK"/>ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಆಫ್ ಮಾಡಬಹುದು.</translation>
 <translation id="5039804452771397117">ಅನುಮತಿಸಿ</translation>
-<translation id="5040262127954254034">ಗೌಪ್ಯತೆ</translation>
-<translation id="5048398596102334565">ಚಲನಾ ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿ ನೀಡಿ (ಶಿಫಾರಸು ಮಾಡಿರುವುದು)</translation>
-<translation id="5063480226653192405">ಬಳಕೆ</translation>
-<translation id="5087580092889165836">ಕಾರ್ಡ್ ಸೇರಿಸಿ</translation>
-<translation id="5100237604440890931">ಕುಗ್ಗಿಸಲಾಗಿದೆ - ವಿಸ್ತರಿಸಲು ಕ್ಲಿಕ್ ಮಾಡಿ</translation>
-<translation id="510275257476243843">1 ಗಂಟೆ ಉಳಿದಿದೆ</translation>
-<translation id="5123685120097942451">ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌</translation>
-<translation id="5127805178023152808">ಸಿಂಕ್‌ ಆಫ್‌ ಆಗಿದೆ</translation>
-<translation id="5129038482087801250">ವೆಬ್ ಆ್ಯಪ್ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ</translation>
-<translation id="5132942445612118989">ಎಲ್ಲಾ ಸಾಧನಗಳಲ್ಲೂ ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು, ಇತಿಹಾಸ ಹಾಗೂ ಇನ್ನೂ ಹೆಚ್ಚಿನವುಗಳನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
-<translation id="5139940364318403933">Google ಡ್ರೈವ್‌‌ ಅನ್ನು ಹೇಗೆ ಬಳಸುವುದು ಎಂದು ತಿಳಿದುಕೊಳ್ಳಿ</translation>
-<translation id="515227803646670480">ಸಂಗ್ರಹಿತ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಿ</translation>
-<translation id="5152843274749979095">ಯಾವುದೇ ಬೆಂಬಲಿತ ಅಪ್ಲಿಕೇಶನ್‌ಗಳನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ</translation>
-<translation id="5161254044473106830">ಶೀರ್ಷಿಕೆ ಅಗತ್ಯವಿದೆ</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ಡೌನ್‌ಲೋಡ್‌ ವಿಫಲವಾಗಿದೆ.}one{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ವಿಫಲವಾಗಿವೆ.}other{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ವಿಫಲವಾಗಿವೆ.}}</translation>
-<translation id="5170568018924773124">ಫೋಲ್ಡರ್‌ನಲ್ಲಿ ತೋರಿಸಿ</translation>
-<translation id="5184329579814168207">Chrome ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="5193988420012215838">ನಿಮ್ಮ ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಲಾಗಿದೆ</translation>
-<translation id="5197729504361054390">ನೀವು ಆಯ್ಕೆ ಮಾಡುವ ಸಂಪರ್ಕಗಳನ್ನು <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> ಜೊತೆಗೆ ಹಂಚಿಕೊಳ್ಳಲಾಗುತ್ತದೆ.</translation>
-<translation id="5199929503336119739">ಕೆಲಸದ ಪ್ರೊಫೈಲ್</translation>
-<translation id="5210286577605176222">ಹಿಂದಿನ ಟ್ಯಾಬ್‌ಗೆ ಹೋಗಿ</translation>
-<translation id="5210365745912300556">ಟ್ಯಾಬ್ ಅನ್ನು ಮುಚ್ಚಿ</translation>
-<translation id="5224771365102442243">ವೀಡಿಯೊದ ಜೊತೆಗೆ</translation>
-<translation id="5230560987958996918">ಸಮೀಪದಲ್ಲಿರುವ ಬ್ಲೂಟೂತ್ ಸಾಧನಗಳಿಗಾಗಿ ಸ್ಕ್ಯಾನ್ ಮಾಡಲು <ph name="SITE" /> ಬಯಸುತ್ತದೆ. ಈ ಕೆಳಗಿನ ಸಾಧನಗಳು ಕಂಡುಬಂದಿವೆ:</translation>
-<translation id="5233638681132016545">ಹೊಸ ಟ್ಯಾಬ್</translation>
-<translation id="526421993248218238">ಈ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="5271967389191913893">ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಬೇಕಾದ ವಿಷಯವನ್ನು ಸಾಧನಕ್ಕೆ ತೆರೆಯಲಾಗುತ್ತಿಲ್ಲ.</translation>
-<translation id="528192093759286357">ಪೂರ್ಣಪರದೆಯನ್ನು ನಿರ್ಗಮಿಸಲು ಮೇಲಿನಿಂದ ಡ್ರ್ಯಾಗ್ ಮಾಡಿ ಹಾಗೂ ಹಿಂದೆ ಬಟನ್ ಸ್ಪರ್ಶಿಸಿ.</translation>
-<translation id="5292796745632149097">ಇಲ್ಲಿಗೆ ಕಳುಹಿಸಿ</translation>
-<translation id="5300589172476337783">ಪ್ರದರ್ಶಿಸಿ</translation>
-<translation id="5301954838959518834">ಸರಿ, ಅರ್ಥವಾಯಿತು</translation>
-<translation id="5304593522240415983">ಈ ಕ್ಷೇತ್ರವು ಖಾಲಿಯಾಗಿರುವಂತಿಲ್ಲ</translation>
-<translation id="5307446750509046227">ಸೈಟ್ ಸಂಗ್ರಹಣೆಯನ್ನು ಅಳಿಸಿ</translation>
-<translation id="5308380583665731573">ಸಂಪರ್ಕಿಸು</translation>
-<translation id="5313967007315987356">ಸೈಟ್ ಸೇರಿಸಿ</translation>
-<translation id="5317780077021120954">ಉಳಿಸು</translation>
-<translation id="5324858694974489420">ಪೋಷಕ ಸೆಟ್ಟಿಂಗ್‌ಗಳು</translation>
-<translation id="5327248766486351172">ಹೆಸರು</translation>
-<translation id="5335288049665977812">JavaScript ರನ್ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="5342314432463739672">ಅನುಮತಿ ವಿನಂತಿಗಳು</translation>
-<translation id="5357811892247919462">ಟ್ಯಾಬ್ ಸ್ವೀಕರಿಸಲಾಗಿದೆ</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> ಟ್ಯಾಬ್ ತೆರೆದಿದೆ, ಟ್ಯಾಬ್‌ಗಳನ್ನು ಬದಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ}one{<ph name="OPEN_TABS_MANY" /> ಟ್ಯಾಬ್‌ಗಳು ತೆರೆದಿವೆ, ಟ್ಯಾಬ್‌ಗಳನ್ನು ಬದಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ}other{<ph name="OPEN_TABS_MANY" /> ಟ್ಯಾಬ್‌ಗಳು ತೆರೆದಿವೆ, ಟ್ಯಾಬ್‌ಗಳನ್ನು ಬದಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ}}</translation>
-<translation id="5391532827096253100">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಸಂಪರ್ಕವು ಸುರಕ್ಷಿತವಾಗಿಲ್ಲ. ಸೈಟ್ ಮಾಹಿತಿ</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ಹೆಚ್ಚು)}one{(+ # ಹೆಚ್ಚು)}other{(+ # ಹೆಚ್ಚು)}}</translation>
-<translation id="5400569084694353794">ಈ ಅಪ್ಲಿಕೇಶನ್ ಬಳಸುವ ಮೂಲಕ, ನೀವು Chrome ನ <ph name="BEGIN_LINK1" />ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1" /> ಮತ್ತು <ph name="BEGIN_LINK2" />ಗೌಪ್ಯತೆ ಪ್ರಕಟಣೆ<ph name="END_LINK2" />ಗೆ ಸಮ್ಮತಿಸುತ್ತೀರಿ.</translation>
-<translation id="5403592356182871684">ಹೆಸರುಗಳು</translation>
-<translation id="5403644198645076998">ಕೆಲವು ಸೈಟ್‌ಗಳಿಗೆ ಮಾತ್ರ ಅನುಮತಿಸಿ</translation>
-<translation id="5414836363063783498">ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ...</translation>
-<translation id="5423934151118863508">ನಿವು ಹೆಚ್ಚು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB ಲಭ್ಯವಿದೆ</translation>
-<translation id="543338862236136125">ಪಾಸ್‌ವರ್ಡ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
-<translation id="5433691172869980887">ಬಳಕೆದಾರರ ಹೆಸರನ್ನು ನಕಲಿಸಲಾಗಿದೆ</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">ವಿಳಾಸ ಪಟ್ಟಿಗೆ ಹೋಗಿ</translation>
-<translation id="5447201525962359567">ಕುಕೀಗಳು ಮತ್ತು ಇತರ ಸ್ಥಳೀಯವಾಗಿ ಸಂಗ್ರಹಿಸಿದ ಡೇಟಾ ಒಳಗೊಂಡು ಎಲ್ಲಾ ಸೈಟ್ ಸಂಗ್ರಹಣೆ</translation>
-<translation id="5447765697759493033">ಈ ಸೈಟ್ ಅನ್ನು ಅನುವಾದಿಸಲಾಗುವುದಿಲ್ಲ</translation>
-<translation id="545042621069398927">ನಿಮ್ಮ ಡೌನ್‌ಲೋಡ್‌ನ ವೇಗವನ್ನು ಹೆಚ್ಚಿಸಲಾಗುತ್ತಿದೆ.</translation>
-<translation id="5456381639095306749">ಪುಟ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="5475862044948910901">ಆಗ್‌ಮೆಂಟೆಡ್ ರಿಯಾಲಿಟಿ ಸೆಶನ್ ಪ್ರಾರಂಭಿಸುವುದೇ?</translation>
-<translation id="548278423535722844">ನಕ್ಷೆಗಳ ಅಪ್ಲಿಕೇಶನ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="5487521232677179737">ಡೇಟಾ ತೆರವುಗೊಳಿಸು</translation>
-<translation id="5494752089476963479">ಅನಪೇಕ್ಷಿತ ಅಥವಾ ತಪ್ಪುದಾರಿಗೆಳೆಯುವ ಜಾಹೀರಾತುಗಳನ್ನು ತೋರಿಸುವ ಸೈಟ್‌ಗಳಲ್ಲಿ ಜಾಹೀರಾತುಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="5500777121964041360">ನಿಮ್ಮ ಸ್ಥಳದಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲದಿರಬಹುದು</translation>
-<translation id="5512137114520586844">ಈ ಖಾತೆಯನ್ನು <ph name="PARENT_NAME" /> ಅವರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ.</translation>
-<translation id="5514904542973294328">ಈ ಸಾಧನದ ನಿರ್ವಾಹಕರಿಂದ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ</translation>
-<translation id="5515439363601853141">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ ಅನ್ನು ವೀಕ್ಷಿಸಲು ಅನ್‌ಲಾಕ್‌ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="5516455585884385570">ಅಧಿಸೂಚನೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆಯಿರಿ</translation>
-<translation id="5517095782334947753">ನೀವು <ph name="FROM_ACCOUNT" /> ರಿಂದ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು, ಇತಿಹಾಸ, ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಮತ್ತು ಇತರ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಹೊಂದಿರುವಿರಿ.</translation>
-<translation id="5524843473235508879">ಮರುನಿರ್ದೇಶಿಸುವಿಕೆಯನ್ನು ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ.</translation>
-<translation id="5527082711130173040">ಸಾಧನಗಳನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಲು, Chrome ಗೆ ಸ್ಥಳ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ. <ph name="BEGIN_LINK1" />ಅನುಮತಿಗಳನ್ನು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ<ph name="END_LINK1" />. ಸ್ಥಳ ಪ್ರವೇಶವನ್ನು ಸಹ <ph name="BEGIN_LINK2" />ಈ ಸಾಧನಕ್ಕೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಿರುವ ಪಠ್ಯ ಮತ್ತು ಚಿತ್ರಗಳನ್ನು ನೋಡಲು ಸೈಟ್‌ಗೆ ಅನುಮತಿಸುವ ಮುನ್ನ ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="5530766185686772672">ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಮುಚ್ಚಿ</translation>
-<translation id="5534334044554683961">ನೀವು VR ನಲ್ಲಿರುವಾಗ, ಈ ವೆಬ್‌ಸೈಟ್‌ಗೆ ಕೆಳಗಿನವುಗಳ ಕುರಿತು ತಿಳಿದುಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗುತ್ತದೆ:
-  -   ನಿಮ್ಮ ದೈಹಿಕ ಲಕ್ಷಣಗಳು, ಉದಾಹರಣೆಗೆ ಎತ್ತರ
-  -   ನಿಮ್ಮ ಕೊಠಡಿಯ ವಿನ್ಯಾಸ
-
-VR ಗೆ ಪ್ರವೇಶಿಸುವ ಮೊದಲು ನೀವು ಈ ವೆಬ್‌ಸೈಟ್ ಅನ್ನು ನಂಬುವಿರಾ ಎನ್ನುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.</translation>
-<translation id="5534640966246046842">ಸೈಟ್ ಅನ್ನು ನಕಲಿಸಲಾಗಿದೆ</translation>
-<translation id="5556459405103347317">ಮರುಲೋಡ್‌</translation>
-<translation id="5561549206367097665">ನೆಟ್‌ವರ್ಕ್‌ಗಾಗಿ ನಿರೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ…</translation>
-<translation id="557283862590186398">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಮೈಕ್ರೊಫೋನ್ ಪ್ರವೇಶಿಸಲು Chrome ಗೆ ಅನುಮತಿಸುವ ಅಗತ್ಯವಿದೆ.</translation>
-<translation id="55737423895878184">ಸ್ಥಳ ಮತ್ತು ಅಧಿಸೂಚನೆಗಳನ್ನು ಅನುಮತಿಸಲಾಗಿದೆ</translation>
-<translation id="5578795271662203820">ಈ ಚಿತ್ರಕ್ಕಾಗಿ <ph name="SEARCH_ENGINE" /> ನಲ್ಲಿ ಹುಡುಕಾಡಿ</translation>
-<translation id="5581519193887989363">ನೀವು ಏನನ್ನು ಸಿಂಕ್ ಮಾಡಬೇಕು ಎಂಬುದನ್ನು <ph name="BEGIN_LINK1" />ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK1" /> ಯಾವಾಗ ಬೇಕಾದರೂ ಆರಿಸಿಕೊಳ್ಳಬಹುದು.</translation>
-<translation id="5595485650161345191">ವಿಳಾಸ ಎಡಿಟ್ ಮಾಡಿ</translation>
-<translation id="5596627076506792578">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು</translation>
-<translation id="5599455543593328020">ಅಜ್ಞಾತ ಮೋಡ್</translation>
-<translation id="5620928963363755975">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳ ಬಟನ್‌ನಿಂದ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಿದ ನಿಮ್ಮ ಫೈಲ್‌ಗಳು ಮತ್ತು ಪುಟಗಳನ್ನು ಹುಡುಕಿ</translation>
-<translation id="5626134646977739690">ಹೆಸರು:</translation>
-<translation id="5639724618331995626">ಎಲ್ಲ ಸೈಟ್‌ಗಳನ್ನು ಅನುಮತಿಸಿ</translation>
-<translation id="5648166631817621825">ಕಳೆದ 7 ದಿನಗಳು</translation>
-<translation id="5649053991847567735">ಸ್ವಯಂಚಾಲಿತ ಡೌನ್‌ಲೋಡ್‌ಗಳು</translation>
-<translation id="5655963694829536461">ನಿಮ್ಮ ಡೌನ್‌ಲೋಡ್‌ಗಳನ್ನು ಹುಡುಕಿ</translation>
-<translation id="5659593005791499971">ಇಮೇಲ್</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> ನಲ್ಲಿ ಈವೆಂಟ್ ಅನ್ನು ರಚಿಸಿ</translation>
-<translation id="5668404140385795438">ಝೂಮ್‌ ಇನ್‌ ಮಾಡುವುದನ್ನು ತಡೆಗಟ್ಟಲು ವೆಬ್‌ಸೈಟ್‌ನ ವಿನಂತಿಯನ್ನು ಅತಿಕ್ರಮಿಸು</translation>
-<translation id="5677928146339483299">ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
-<translation id="5684874026226664614">ಓಹ್. ಈ ಪುಟವನ್ನು ಅನುವಾದಿಸಲಾಗುವುದಿಲ್ಲ.</translation>
-<translation id="5686790454216892815">ಫೈಲ್‌ನ ಹೆಸರು ತುಂಬಾ ಉದ್ದವಾಗಿದೆ</translation>
-<translation id="5689516760719285838">ಸ್ಥಳ</translation>
-<translation id="569536719314091526">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು ಬಟನ್ ಮೂಲಕ ಈ ಪುಟವನ್ನು ಯಾವ ಭಾಷೆಗಾದರೂ ಅನುವಾದಿಸಿ</translation>
-<translation id="572328651809341494">ಇತ್ತೀಚಿನ ಟ್ಯಾಬ್‌ಗಳು</translation>
-<translation id="5726692708398506830">ಪುಟದಲ್ಲಿರುವ ಪ್ರತಿಯೊಂದನ್ನೂ ದೊಡ್ಡದಾಗಿಸಿ</translation>
-<translation id="5748802427693696783">ಪ್ರಮಾಣಿತ ಟ್ಯಾಬ್‌ಗಳಿಗೆ ಬದಲಾಯಿಸಲಾಗಿದೆ</translation>
-<translation id="5749068826913805084">ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು Chrome ಗೆ ಸಂಗ್ರಹಣೆ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ.</translation>
-<translation id="5763382633136178763">ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌ಗಳು</translation>
-<translation id="5763514718066511291">ಈ ಅಪ್ಲಿಕೇಶನ್‌ಗಾಗಿ URL ನಕಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
-<translation id="5765780083710877561">ವಿವರಣೆ:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" /> ಯಲ್ಲಿ <ph name="SPACE_USED" /> ಬಳಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="5797070761912323120">ಹುಡುಕಾಟ, ಜಾಹೀರಾತುಗಳು ಮತ್ತು ಇತರ Google ಸೇವೆಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಇತಿಹಾಸವನ್ನು Google ಬಳಸಬಹುದು</translation>
-<translation id="5804241973901381774">ಅನುಮತಿಗಳು</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# ಗಂಟೆಯ ಹಿಂದೆ}one{# ಗಂಟೆಗಳ ಹಿಂದೆ}other{# ಗಂಟೆಗಳ ಹಿಂದೆ}}</translation>
-<translation id="5810288467834065221">ಕೃತಿಸ್ವಾಮ್ಯ <ph name="YEAR" /> Google LLC. ಎಲ್ಲ ಹಕ್ಕುಗಳನ್ನು ಕಾಯ್ದಿರಿಸಲಾಗಿದೆ.</translation>
-<translation id="5817918615728894473">ಜೋಡಿಸು</translation>
-<translation id="583281660410589416">ಅಪರಿಚಿತ</translation>
-<translation id="5833984609253377421">ಲಿಂಕ್ ಹಂಚಿಕೊಳ್ಳಿ</translation>
-<translation id="5836192821815272682">Chrome ಅಪ್‌ಡೇಟ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ…</translation>
-<translation id="5853623416121554550">ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ</translation>
-<translation id="5854790677617711513">30 ದಿನಗಳಿಗಿಂತ ಹಳೆಯದು</translation>
-<translation id="5858741533101922242">ಬ್ಲೂಟೂತ್ ಅಡಾಪ್ಟರ್ ಆನ್ ಮಾಡಲು Chrome ಗೆ ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
-<translation id="5860033963881614850">ಆಫ್</translation>
-<translation id="5862731021271217234">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್‌ ಆನ್‌ ಮಾಡಿ</translation>
-<translation id="5864174910718532887">ವಿವರಗಳು: ಸೈಟ್ ಹೆಸರಿನ ಪ್ರಕಾರ ವಿಂಗಡಿಸಲಾಗಿದೆ</translation>
-<translation id="5864419784173784555">ಇನ್ನೊಂದು ಡೌನ್‌ಲೋಡ್‌ಗಾಗಿ ಕಾಯಲಾಗುತ್ತಿದೆ…</translation>
-<translation id="5865733239029070421">ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳು ಮತ್ತು ಕ್ರ್ಯಾಶ್ ವರದಿಗಳನ್ನು Google ಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಕಳುಹಿಸುತ್ತದೆ</translation>
-<translation id="5869522115854928033">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
-<translation id="5902828464777634901">ಕುಕೀಗಳು ಸೇರಿದಂತೆ, ಈ ವೆಬ್‌ಸೈಟ್ ಮೂಲಕ ಸಂಗ್ರಹಿಸಲಾದ ಎಲ್ಲಾ ಸ್ಥಳೀಯ ಡೇಟಾವನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ.</translation>
-<translation id="5916664084637901428">ಆನ್‌</translation>
-<translation id="5919204609460789179">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು <ph name="PRODUCT_NAME" /> ಅಪ್‌ಡೇಟ್ ಮಾಡಿ</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> ಉಳಿಸಲಾಗಿದೆ</translation>
-<translation id="5939518447894949180">ಮರುಹೊಂದಿಸು</translation>
-<translation id="5942872142862698679">ಹುಡುಕಲು Google ಬಳಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="5952764234151283551">ನೀವು ಸಂಪರ್ಕಿಸಲು ಪ್ರಯತ್ನಿಸುತ್ತಿರುವ ಪುಟದ URL ಅನ್ನು Google ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
-<translation id="5956665950594638604">ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ Chrome ಸಹಾಯ ಕೇಂದ್ರ ತೆರೆಯಿರಿ</translation>
-<translation id="5958275228015807058">ಡೌನ್‌ಲೋಡ್‌ಗಳಲ್ಲಿ ನಿಮ್ಮ ಫೈಲ್‌ಗಳು ಮತ್ತು ಪುಟಗಳನ್ನು ಹುಡುಕಿ</translation>
-<translation id="5962718611393537961">ಕುಗ್ಗಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
-<translation id="6000066717592683814">Google ಇರಿಸಿಕೊಳ್ಳಿ</translation>
-<translation id="6005538289190791541">ಸೂಚಿಸಿದ ಪಾಸ್‌ವರ್ಡ್</translation>
-<translation id="6036057147555329831">ಹೆಚ್ಚುವರಿ ICU</translation>
-<translation id="6039379616847168523">ಮುಂದಿನ ಟ್ಯಾಬ್‌ಗೆ ಹೋಗಿ</translation>
-<translation id="6040143037577758943">ಮುಚ್ಚಿರಿ</translation>
-<translation id="6042308850641462728">ಇನ್ನಷ್ಟು</translation>
-<translation id="604996488070107836">ಅಪರಿಚಿತ ದೋಷದ ಕಾರಣದಿಂದ <ph name="FILE_NAME" /> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">ಪೂರ್ಣಗೊಳಿಸಿದ ಡೌನ್‌ಲೋಡ್‌ಗಳು</translation>
-<translation id="6075798973483050474">ಹೋಮ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> ಗಂಟೆಗಳು ಉಳಿದಿವೆ</translation>
-<translation id="6108923351542677676">ಸೆಟಪ್ ಪ್ರಗತಿಯಲ್ಲಿದೆ...</translation>
-<translation id="6111020039983847643">Chrome ನಿಂದ ಬಳಕೆಯಾಗಿರುವ ಡೇಟಾ</translation>
-<translation id="6112702117600201073">ಪುಟವನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಲಾಗುತ್ತಿದೆ</translation>
-<translation id="6127379762771434464">ಐಟಂ ತೆಗೆದುಹಾಕಲಾಗಿದೆ</translation>
-<translation id="6140912465461743537">ರಾಷ್ಟ್ರ/ಪ್ರದೇಶ</translation>
-<translation id="614940544461990577">ಪ್ರಯತ್ನಿಸಿ:</translation>
-<translation id="6154478581116148741">ಈ ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಂದ ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ರಫ್ತುಮಾಡಲು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಸ್ಕ್ರೀನ್ ಲಾಕ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> ಡೇಟಾ ಉಳಿತಾಯಗಳು</translation>
-<translation id="6165508094623778733">ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ</translation>
-<translation id="6177111841848151710">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್‌ಗೆ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
-<translation id="6181444274883918285">ಸೈಟ್ ವಿನಾಯಿತಿಯನ್ನು ಸೇರಿಸಿ</translation>
-<translation id="6192333916571137726">ಫೈಲ್‌ ಅನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಿ</translation>
-<translation id="6192792657125177640">ವಿನಾಯಿತಿಗಳು</translation>
-<translation id="6194112207524046168">Chrome ನಿಮ್ಮ ಕ್ಯಾಮರಾವನ್ನು ಪ್ರವೇಶಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK" />Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK" /> ಕ್ಯಾಮರಾವನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
-<translation id="6196640612572343990">ಥರ್ಡ್ ಪಾರ್ಟಿ ಕುಕೀಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="6206551242102657620">ಸಂಪರ್ಕ ಸುರಕ್ಷಿತವಾಗಿದೆ. ಸೈಟ್ ಮಾಹಿತಿ</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> ಅಲ್ಲವೇ?</translation>
-<translation id="6221633008163990886">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ರಫ್ತುಮಾಡಲು ಅನ್‌ಲಾಕ್ ಮಾಡಿ</translation>
+<translation id="1406000523432664303">“ಟ್ರ್ಯಾಕ್ ಮಾಡಬೇಡಿ”</translation>
 <translation id="6232535412751077445">‘ಟ್ರ್ಯಾಕ್ ಮಾಡಬೇಡಿ’ ಸಕ್ರಿಯಗೊಳಿಸುವುದು ಎಂದರೆ, ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್ ಟ್ರಾಫಿಕ್ ಜೊತೆ ವಿನಂತಿಯನ್ನು ಸೇರಿಸಿಕೊಳ್ಳಲಾಗುತ್ತದೆ ಎಂದಾಗಿದೆ. ವಿನಂತಿಗೆ ವೆಬ್‌ಸೈಟ್‌ ಸ್ಪಂದಿಸುತ್ತದೆಯೇ ಹಾಗೂ ವಿನಂತಿಯನ್ನು ಹೇಗೆ ಅರ್ಥೈಸಿಕೊಳ್ಳುತ್ತದೆ ಎಂಬುದರ ಮೇಲೆ ಯಾವುದೇ ಪರಿಣಾಮ ಅವಲಂಬಿಸಿರುತ್ತದೆ.
 
 ಉದಾಹರಣೆಗೆ, ಕೆಲವು ವೆಬ್‌ಸೈಟ್‌ಗಳು, ನೀವು ಭೇಟಿ ನೀಡಿದ ಇತರ ವೆಬ್‌ಸೈಟ್‌ಗಳನ್ನು ಆಧರಿಸಿಲ್ಲದ ಜಾಹೀರಾತುಗಳನ್ನು ನಿಮಗೆ ತೋರಿಸುವ ಮೂಲಕ ಈ ವಿನಂತಿಗೆ ಸ್ಪಂದಿಸಬಹುದು. ಹೆಚ್ಚಿನ ವೆಬ್‌ಸೈಟ್‌ಗಳು ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್‌ ಡೇಟಾವನ್ನು ಈಗಲೂ ಸಂಗ್ರಹಿಸುತ್ತವೆ ಹಾಗೂ ಅವುಗಳನ್ನು ಬಳಸಿಕೊಳ್ಳುತ್ತವೆ. ಉದಾಹರಣೆಗೆ, ಭದ್ರತೆಯನ್ನು ಸುಧಾರಿಸಲು, ವಿಷಯ, ಜಾಹೀರಾತುಗಳು ಮತ್ತು ಶಿಫಾರಸುಗಳನ್ನು ಒದಗಿಸಲು ಮತ್ತು ವರದಿಯ ಅಂಕಿಅಂಶಗಳನ್ನು ರಚಿಸಲು.</translation>
-<translation id="624789221780392884">ಅಪ್‌ಡೇಟ್‌‌ ಸಿದ್ಧವಾಗಿದೆ</translation>
-<translation id="6255999984061454636">ವಿಷಯದ ಸಲಹೆಗಳು</translation>
-<translation id="6277522088822131679">ಪುಟವನ್ನು ಮುದ್ರಿಸುವಲ್ಲಿ ಸಮಸ್ಯೆ ಕಂಡುಬಂದಿದೆ. ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</translation>
-<translation id="6295158916970320988">ಎಲ್ಲಾ ಸೈಟ್‌ಗಳು</translation>
-<translation id="629730747756840877">ಖಾತೆ</translation>
-<translation id="6303969859164067831">ಸೈನ್ ಔಟ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆಫ್ ಮಾಡಿ</translation>
-<translation id="6316139424528454185">Android ಆವೃತ್ತಿಗೆ ಬೆಂಬಲವಿಲ್ಲ</translation>
-<translation id="6320088164292336938">ವೈಬ್ರೇಟ್‌</translation>
-<translation id="6324034347079777476">Android ಸಿಸ್ಟಂ ಸಿಂಕ್ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> ಮೂಲಕ ಹಂಚು</translation>
-<translation id="6337234675334993532">ಎನ್‌ಕ್ರಿಪ್ಶನ್</translation>
-<translation id="6341580099087024258">ಫೈಲ್‌ಗಳನ್ನು ಎಲ್ಲಿ ಉಳಿಸಬೇಕೆಂದು ಕೇಳಿ</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">ಇತಿಹಾಸದಿಂದ ಸಲಹೆಯನ್ನು ತೆಗೆದುಹಾಕುವುದೇ?</translation>
-<translation id="6369229450655021117">ಇಲ್ಲಿಂದ, ನೀವು ವೆಬ್‌‍ನಲ್ಲಿ ಹುಡುಕಬಹುದು, ಸ್ನೇಹಿತರ ಜೊತೆ ಹಂಚಿಕೊಳ್ಳಬಹುದು ಮತ್ತು ತೆರೆದ ಪುಟಗಳನ್ನು ನೋಡಬಹುದು</translation>
-<translation id="6378173571450987352">ವಿವರಗಳು: ಡೇಟಾ ಬಳಕೆಯ ಪ್ರಮಾಣದ ಆಧಾರದಲ್ಲಿ ವಿಂಗಡಿಸಲಾಗಿದೆ</translation>
-<translation id="6381421346744604172">ಡಾರ್ಕನ್ ವೆಬ್‌ಸೈಟ್‌ಗಳು</translation>
-<translation id="6388207532828177975">ತೆರವುಗೊಳಿಸಿ &amp; ಮರುಹೊಂದಿಸಿ</translation>
-<translation id="6393863479814692971">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಕ್ಯಾಮರಾ ಮತ್ತು ಮೈಕ್ರೊಫೋನ್ ಪ್ರವೇಶಿಸಲು Chrome ಗೆ ಅನುಮತಿಸುವ ಅಗತ್ಯವಿದೆ.</translation>
-<translation id="6395288395575013217">ಲಿಂಕ್</translation>
-<translation id="6404511346730675251">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಎಡಿಟ್ ಮಾಡಿ</translation>
-<translation id="6406506848690869874">ಸಿಂಕ್</translation>
-<translation id="641643625718530986">ಮುದ್ರಿಸು...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="6427112570124116297">ವೆಬ್ ಅನ್ನು ಅನುವಾದಿಸಿ</translation>
-<translation id="6433501201775827830">ನಿಮ್ಮ ಹುಡುಕಾಟದ ಇಂಜಿನ್ ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="6437478888915024427">ಪುಟದ ಮಾಹಿತಿ</translation>
-<translation id="6441734959916820584">ಹೆಸರು ತುಂಬಾ ಉದ್ದವಾಗಿದೆ</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ಚಿತ್ರ}one{# ಚಿತ್ರಗಳು}other{# ಚಿತ್ರಗಳು}}</translation>
-<translation id="6447842834002726250">ಕುಕೀಸ್</translation>
-<translation id="6461962085415701688">ಫೈಲ್ ತೆರೆಯಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ</translation>
-<translation id="6464977750820128603">ನೀವು Chrome ನಲ್ಲಿ ಭೇಟಿ ಮಾಡಿದ ಸೈಟ್‌ಗಳನ್ನು ನೋಡಬಹುದು ಮತ್ತು ಅವುಗಳಿಗೆ ಟೈಮರ್‌ಗಳನ್ನು ಹೊಂದಿಸಬಹುದು.\n\nನೀವು ಯಾವ ಸೈಟ್‌ಗಳಿಗೆ  ಟೈಮರ್‌ಗಳನ್ನು ಹೊಂದಿಸಿದ್ದೀರಿ ಮತ್ತು  ಅವುಗಳಿಗೆ ಭೇಟಿ ಮಾಡಿ ಎಷ್ಟು ಸಮಯ ಕಳೆದಿರುವಿರಿ ಎನ್ನುವುದರ ಕುರಿತ ಮಾಹಿತಿಯನ್ನು Google ಪಡೆಯುತ್ತದೆ. ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮವನ್ನು ಉತ್ತಮಗೊಳಿಸಲು ಈ ಮಾಹಿತಿಯನ್ನು ಬಳಸಲಾಗುವುದು.</translation>
-<translation id="6475951671322991020">ವೀಡಿಯೊ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="6482749332252372425">ಸಂಗ್ರಹಣೆ ಸ್ಥಳದ ಕೊರತೆಯ ಕಾರಣದಿಂದ <ph name="FILE_NAME" /> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
-<translation id="6496823230996795692"><ph name="APP_NAME" /> ಅನ್ನು ಮೊದಲ ಬಾರಿಗೆ ಬಳಸಲು, ಇಂಟರ್‌ನೆಟ್‌ಗೆ ಸಂಪರ್ಕಸಿ.</translation>
-<translation id="6508722015517270189">Chrome ಮರುಪ್ರಾರಂಭಿಸಿ</translation>
-<translation id="6527303717912515753">ಹಂಚಿಕೊಳ್ಳು</translation>
-<translation id="6532866250404780454">Chrome ನಲ್ಲಿ ನೀವು ಭೇಟಿ ನೀಡುವ ಸೈಟ್‌ಗಳನ್ನು ತೋರಿಸುವುದಿಲ್ಲ. ಎಲ್ಲಾ ಸೈಟ್‌ ಟೈಮರ್‌ಗಳನ್ನು ಅಳಿಸಲಾಗುವುದು.</translation>
-<translation id="6534565668554028783">ಪ್ರತಿಕ್ರಿಯಿಸಲು Google ತೀರಾ ಹೆಚ್ಚು ಸಮಯ ತೆಗೆದುಕೊಂಡಿದೆ.</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="6539092367496845964">ಏನೋ ತಪ್ಪಾಗಿದೆ. ನಂತರ ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.</translation>
-<translation id="654446541061731451">ಬೀಮ್‌ ಗೆ ಟ್ಯಾಬ್ ಅನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="6545017243486555795">ಎಲ್ಲಾ ಡೇಟಾ ತೆರವುಗೊಳಿಸು</translation>
-<translation id="6545864417968258051">ಬ್ಲೂಟೂತ್ ಸ್ಕ್ಯಾನಿಂಗ್</translation>
-<translation id="6560414384669816528">Sogou ಜೊತೆಗೆ ಹುಡುಕಿ</translation>
-<translation id="6566259936974865419">ನಿಮ್ಮ <ph name="GIGABYTES" /> GB ಅನ್ನು Chrome ಉಳಿಸಿದೆ</translation>
-<translation id="6573096386450695060">ಯಾವಾಗಲೂ ಅನುಮತಿಸಿ</translation>
-<translation id="6573431926118603307">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಲ್ಲಿನ Chrome ನಲ್ಲಿ ನೀವು ತೆರೆದಿರುವಂತಹ ಟ್ಯಾಬ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ.</translation>
-<translation id="6583199322650523874">ಪ್ರಸ್ತುತ ಪುಟವನ್ನು ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಿ</translation>
-<translation id="6593061639179217415">ಡೆಸ್ಕ್‌ಟಾಪ್‌ ಸೈಟ್‌</translation>
-<translation id="6600954340915313787">Chrome ಗೆ ನಕಲಿಸಲಾಗಿದೆ</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">ಸಂರಕ್ಷಿಸಿದ ವಿಷಯ</translation>
-<translation id="6627583120233659107">ಫೋಲ್ಡರ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="7359002509206457351">ಪಾವತಿ ವಿಧಾನಗಳನ್ನು ಪ್ರವೇಶಿಸಿ</translation>
+<translation id="8026334261755873520">ಬ್ರೌಸಿಂಗ್ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಿ</translation>
+<translation id="1291207594882862231">ಇತಿಹಾಸ, ಕುಕೀಗಳು, ಸೈಟ್‌ ಡೇಟಾ, ಕ್ಯಾಷ್ ಅನ್ನು ತೆರವುಗೊಳಿಸಿ…</translation>
+<translation id="7814200940910057384">Brave ಡೇಟಾ ತೆರವುಗೊಳಿಸಲಾಗಿದೆ</translation>
+<translation id="1664855196866195614">ಆಯ್ಕೆ ಮಾಡಿದ ಡೇಟಾವನ್ನು Brave ನಿಂದ ಮತ್ತು ಸಿಂಕ್ ಮಾಡಿರುವ ನಿಮ್ಮ ಸಾಧನಗಳಿಂದ ತೆಗೆದುಹಾಕಲಾಗಿದೆ.
+ನಿಮ್ಮ Brave Software ಖಾತೆಯು, ಹುಡುಕಾಟಗಳು ಮತ್ತು ಇತರ Brave Software ಸೇವೆಗಳ ಚಟುವಟಿಕೆಗಳಂತಹ ಬೇರೆ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.ನಲ್ಲಿ ಹೊಂದಿರಬಹುದು.</translation>
+<translation id="4699172675775169585">ಸಂಗ್ರಹಿಸಲಾಗಿರುವ ಚಿತ್ರಗಳು ಮತ್ತು ಫೈಲ್‌ಗಳು</translation>
+<translation id="2496180316473517155">ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸ</translation>
+<translation id="2546283357679194313">ಕುಕೀಗಳು ಮತ್ತು ಸೈಟ್ ಡೇಟಾ</translation>
+<translation id="8662811608048051533">ಹೆಚ್ಚಿನ ವೆಬ್‌ಸೈಟ್‌ಗಳಿಂದ ಸೈನ್‌ ಔಟ್‌ ಮಾಡುತ್ತದೆ.</translation>
+<translation id="8218628800671693884">ನಿಮ್ಮನ್ನು ಬಹುತೇಕ ಸೈಟ್‌ಗಳಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡಲಾಗುತ್ತದೆ. ಆದರೆ ನಿಮ್ಮನ್ನು ನಿಮ್ಮ Brave Software ಖಾತೆಯಿಂದ ಸೈನ್‌ ಔಟ್‌ ಮಾಡುವುದಿಲ್ಲ.</translation>
+<translation id="2017836877785168846">ಇತಿಹಾಸವನ್ನು ತೆರವುಗೊಳಿಸಿ ಮತ್ತು ವಿಳಾಸಪಟ್ಟಿಯಲ್ಲಿರುವುದನ್ನು ಸ್ವಯಂಪೂರ್ಣಗೊಳಿಸಿ.</translation>
+<translation id="8096327394278038498">ವಿಳಾಸ ಪಟ್ಟಿಯ ಇತಿಹಾಸ ಮತ್ತು ಸ್ವಯಂಪೂರ್ಣಗೊಳಿಸುವಿಕೆಯನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ. ನಿಮ್ಮ Brave Software ಖಾತೆಯು <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> ನಲ್ಲಿ ಇತರ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೊಂದಿರಬಹುದು.</translation>
+<translation id="8122693181154564064">ಸೈನ್-ಇನ್ ಮಾಡಿರುವ ಎಲ್ಲ ಸಾಧನಗಳಿಂದ ಇತಿಹಾಸವನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ. ನಿಮ್ಮ Brave Software ಖಾತೆಯು <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> ನಲ್ಲಿ ಇತರ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೊಂದಿರಬಹುದು.</translation>
+<translation id="5869522115854928033">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
+<translation id="6865313869410766144">ಸ್ವಯಂತುಂಬುವಿಕೆ ಫಾರ್ಮ್ ಡೇಟಾ</translation>
+<translation id="7562080006725997899">ಬ್ರೌಸಿಂಗ್ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="5487521232677179737">ಡೇಟಾ ತೆರವುಗೊಳಿಸು</translation>
+<translation id="7498271377022651285">ದಯವಿಟ್ಟು ಕಾಯಿರಿ...</translation>
+<translation id="784934925303690534">ಸಮಯ ವ್ಯಾಪ್ತಿ</translation>
+<translation id="1718835860248848330">ಕೊನೆಯ ಗಂಟೆ</translation>
+<translation id="7149893636342594995">ಕಳೆದ 24 ಗಂಟೆಗಳು</translation>
+<translation id="5648166631817621825">ಕಳೆದ 7 ದಿನಗಳು</translation>
+<translation id="8571213806525832805">ಕಳೆದ 4 ವಾರಗಳು</translation>
+<translation id="5854790677617711513">30 ದಿನಗಳಿಗಿಂತ ಹಳೆಯದು</translation>
+<translation id="6979737339423435258">ಎಲ್ಲ ಸಮಯ</translation>
+<translation id="982182592107339124">ಇದು ಎಲ್ಲಾ ಸೈಟ್‌ಗಳಿಗೆ ಡೇಟಾ ತೆರವುಗೊಳಿಸುತ್ತದೆ, ಇವುಗಳನ್ನೂ ಒಳಗೊಂಡು:</translation>
 <translation id="6643016212128521049">ತೆರವುಗೊಳಿಸಿ</translation>
-<translation id="6643649862576733715">ಉಳಿಸಿದ ಡೇಟಾ ಪ್ರಮಾಣದ ಪ್ರಕಾರ ವಿಂಗಡಿಸಿ</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">ಚಿತ್ರವನ್ನು ಪೂರ್ವವೀಕ್ಷಿಸಿ <ph name="BEGIN_NEW" />ಹೊಸದು<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">ಸಾಧನಗಳನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಲು Chrome ಗೆ ಸ್ಥಳ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ. <ph name="BEGIN_LINK" />ಅನುಮತಿಗಳನ್ನು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">ಪಾಸ್‌ವರ್ಡ್</translation>
-<translation id="6659594942844771486">ಟ್ಯಾಬ್</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" /> ರಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="666981079809192359">Chrome ಗೌಪ್ಯತಾ ಸೂಚನೆ</translation>
-<translation id="6676840375528380067">ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ Chrome ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸುವುದೇ?</translation>
-<translation id="6697492270171225480">ಯಾವುದೇ ಪುಟವನ್ನು ಕಂಡುಹಿಡಿಯಲು ಸಾಧ್ಯವಾಗದಿದ್ದರೆ, ಅಂತಹುದೇ ಪುಟಗಳ ಸಲಹೆಯನ್ನು ತೋರಿಸಿ</translation>
-<translation id="6697947395630195233">ಈ ಸೈಟ್‌ ಮೂಲಕ ನಿಮ್ಮ ಸ್ಥಳವನ್ನು ಹಂಚಿಕೊಳ್ಳಲು Chrome ಗೆ ನಿಮ್ಮ ಸ್ಥಳದ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ.</translation>
-<translation id="6698801883190606802">ಸಿಂಕ್‌ ಮಾಡಲಾದ ಡೇಟಾವನ್ನು ನಿರ್ವಹಿಸಿ</translation>
-<translation id="6699370405921460408">ನೀವು ಭೇಟಿ ಮಾಡುವ ಪುಟಗಳನ್ನು Google ಸರ್ವರ್‌ಗಳು ಆಪ್ಟಿಮೈಸ್ ಮಾಡುತ್ತವೆ.</translation>
-<translation id="6706288973712894588">ನೀವು ಪ್ರಸ್ತುತವಾಗಿ ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿದ್ದೀರಿ.\n<ph name="BEGIN_LINK" />ನಿಮ್ಮ ಆಫ್‌ಲೈನ್ ಫೀಡ್ ಅನ್ನು ಎಕ್ಸ್‌ಪ್ಲೋರ್ ಮಾಡಿ.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">ಸುದ್ದಿ</translation>
-<translation id="6710213216561001401">ಹಿಂದೆ</translation>
-<translation id="671481426037969117">ನಿಮ್ಮ <ph name="FQDN" /> ಟೈಮರ್ ಅವಧಿ ಮುಗಿದಿದೆ. ಅದು ನಾಳೆ ಮತ್ತೊಮ್ಮೆ ಪ್ರಾರಂಭವಾಗುತ್ತದೆ.</translation>
-<translation id="6738867403308150051">ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ…</translation>
-<translation id="6746124502594467657">ಕೆಳಗೆ ಸರಿಸು</translation>
-<translation id="6766622839693428701">ಮುಚ್ಚಲು ಕೆಳಕ್ಕೆ ಸ್ವೈಪ್ ಮಾಡಿ.</translation>
-<translation id="6766758767654711248">ಸೈಟ್‌ಗೆ ಹೋಗಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
-<translation id="6767294960381293877">ಟ್ಯಾಬ್ ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಬೇಕಾದ ಸಾಧನಗಳ ಪಟ್ಟಿಯನ್ನು ಅರ್ಧ ಎತ್ತರದಲ್ಲಿ ತೆರೆಯಲಾಗಿದೆ.</translation>
+<translation id="7641339528570811325">ಬ್ರೌಸಿಂಗ್ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಿ…</translation>
+<translation id="1670399744444387456">ಮೂಲ</translation>
+<translation id="3245261285041759672">ನಿಮ್ಮ Brave Software ಖಾತೆಯು <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/> ನಲ್ಲಿ ಇತರ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೊಂದಿರಬಹುದು.</translation>
+<translation id="7274013316676448362">ನಿರ್ಬಂಧಿಸಿರುವ ಸೈಟ್</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> ಐಟಂಗಳನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
+<translation id="1121094540300013208">ಬಳಕೆ ಮತ್ತು ಕ್ರ್ಯಾಶ್ ವರದಿಗಳು</translation>
+<translation id="9079153198295609735">ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳನ್ನು ಮತ್ತು ಕ್ರಾಶ್ ವರದಿಗಳನ್ನು Brave Software ಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ರವಾನಿಸು</translation>
+<translation id="6981982820502123353">ಪ್ರವೇಶ</translation>
+<translation id="2387895666653383613">ಪಠ್ಯ ಸ್ಕೇಲಿಂಗ್</translation>
+<translation id="2321958826496381788">ನೀವು ಇದನ್ನು ಆರಾಮವಾಗಿ ಓದಲು ಸಾಧ್ಯವಾಗುವವರೆಗೆ ಸ್ಲೈಡರ್ ಎಳೆಯಿರಿ. ಪ್ಯಾರಾಗ್ರಾಫ್‌ನಲ್ಲಿ ಡಬಲ್ ಟ್ಯಾಪಿಂಗ್ ಮಾಡಿದ ನಂತರ ಪಠ್ಯವು ಕನಿಷ್ಠ ಇಷ್ಟು ದೊಡ್ಡದಾಗಿ ಕಾಣಿಸಬೇಕು.</translation>
+<translation id="3895926599014793903">ಒತ್ತಾಯದ ಝೂಮ್ ಸಕ್ರಿಯಗೊಳಿಸುವಿಕೆ</translation>
+<translation id="5668404140385795438">ಝೂಮ್‌ ಇನ್‌ ಮಾಡುವುದನ್ನು ತಡೆಗಟ್ಟಲು ವೆಬ್‌ಸೈಟ್‌ನ ವಿನಂತಿಯನ್ನು ಅತಿಕ್ರಮಿಸು</translation>
+<translation id="4149994727733219643">ವೆಬ್ ಪುಟಗಳಿಗಾಗಿ ಸರಳೀಕೃತ ವೀಕ್ಷಣೆ</translation>
+<translation id="9100505651305367705">ಬೆಂಬಲವಿದ್ದಾಗ, ಲೇಖನಗಳನ್ನು ಸರಳ ವೀಕ್ಷಣೆಯಲ್ಲಿ ತೋರಿಸುವ ಸೌಲಭ್ಯ ಒದಗಿಸಿ</translation>
+<translation id="1409426117486808224">ತೆರೆದ ಟ್ಯಾಬ್‌ಗಳಿಗಾಗಿ ಸರಳೀಕೃತ ವೀಕ್ಷಣೆ</translation>
+<translation id="702463548815491781">TalkBack ಅಥವಾ ಪ್ರವೇಶ ಬದಲಾಯಿಸಿ ಆನ್ ಆಗಿದ್ದಾಗ ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="8284326494547611709">ಶೀರ್ಷಿಕೆಗಳು</translation>
+<translation id="4165986682804962316">ಸೈಟ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು</translation>
+<translation id="6295158916970320988">ಎಲ್ಲಾ ಸೈಟ್‌ಗಳು</translation>
+<translation id="8380167699614421159">ಅತಿಕ್ರಮಣಕಾರಿಯಾಗಿರುವ ಅಥವಾ ತಪ್ಪುದಾರಿಗೆಳೆಯುವ ಜಾಹೀರಾತುಗಳನ್ನು ಈ ಸೈಟ್ ತೋರಿಸುತ್ತದೆ</translation>
+<translation id="1919345977826869612">ಜಾಹೀರಾತುಗಳು</translation>
+<translation id="410351446219883937">ಆಟೋಪ್ಲೇ</translation>
+<translation id="6447842834002726250">ಕುಕೀಸ್</translation>
+<translation id="6196640612572343990">ಥರ್ಡ್ ಪಾರ್ಟಿ ಕುಕೀಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
 <translation id="6782111308708962316">ಕುಕೀ ಡೇಟಾವನ್ನು ಮೂರನೇ ವ್ಯಕ್ತಿ ವೆಬ್‌ಸೈಟ್‌ಗಳು ಉಳಿಸದಂತೆ ಮತ್ತು 
 ಓದದಂತೆ ತಡೆಯಿರಿ.</translation>
-<translation id="6790428901817661496">ಪ್ಲೇ ಮಾಡು</translation>
-<translation id="6811034713472274749">ವೀಕ್ಷಿಸಲು ಪುಟ ಸಿದ್ಧವಾಗಿದೆ</translation>
-<translation id="6818926723028410516">ಐಟಂಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">ಅನುವಾದಿಸು</translation>
-<translation id="6845325883481699275">Chrome ಭದ್ರತೆಯನ್ನು ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡಿ</translation>
-<translation id="6846298663435243399">ಲೋಡ್ ಆಗುತ್ತಿದೆ...</translation>
-<translation id="6850409657436465440">ನಿಮ್ಮ ಡೌನ್‌ಲೋಡ್ ಇನ್ನೂ ಪ್ರಗತಿಯಲ್ಲಿದೆ</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> ಟ್ಯಾಬ್‌ಗಳನ್ನು ಮುಚ್ಚಲಾಗಿದೆ</translation>
-<translation id="6864459304226931083">ಚಿತ್ರ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="6865313869410766144">ಸ್ವಯಂತುಂಬುವಿಕೆ ಫಾರ್ಮ್ ಡೇಟಾ</translation>
-<translation id="688738109438487280">ಪ್ರಸ್ತುತ ಡೇಟಾವನ್ನು <ph name="TO_ACCOUNT" /> ಗೆ ಸೇರಿಸಿ.</translation>
-<translation id="6891726759199484455">ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್ ಅನ್ನು ನಕಲಿಸಲು ಅನ್‌ಲಾಕ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="6896758677409633944">ನಕಲಿಸು</translation>
-<translation id="6910211073230771657">ಅಳಿಸಲಾಗಿದೆ</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">ಪಾಪ್-ಅಪ್‌ಗಳು ಹಾಗೂ ಮರುನಿರ್ದೇಶನಗಳು</translation>
+<translation id="4751476147751820511">ಚಲನೆ ಅಥವಾ ಬೆಳಕಿನ ಸೆನ್ಸರ್‌ಗಳು</translation>
+<translation id="1717218214683051432">ಮೋಷನ್ ಸೆನ್ಸಾರ್‌ಗಳು</translation>
+<translation id="2091887806945687916">ಶಬ್ಧ</translation>
+<translation id="2586657967955657006">ಕ್ಲಿಪ್‌ಬೋರ್ಡ್</translation>
+<translation id="6320088164292336938">ವೈಬ್ರೇಟ್‌</translation>
+<translation id="4226663524361240545">ಪ್ರಕಟಣೆಗಳು ಸಾಧನವನ್ನು ವೈಬ್ರೇಟ್ ಮಾಡಬಹುದು</translation>
+<translation id="1446450296470737166">MIDI ಸಾಧನಗಳ ಪೂರ್ಣ ನಿಯಂತ್ರಣ ಅನುಮತಿಸಿ</translation>
+<translation id="3744111561329211289">ಹಿನ್ನೆಲೆ ಸಿಂಕ್</translation>
+<translation id="5649053991847567735">ಸ್ವಯಂಚಾಲಿತ ಡೌನ್‌ಲೋಡ್‌ಗಳು</translation>
+<translation id="6181444274883918285">ಸೈಟ್ ವಿನಾಯಿತಿಯನ್ನು ಸೇರಿಸಿ</translation>
+<translation id="5313967007315987356">ಸೈಟ್ ಸೇರಿಸಿ</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> ಸೈಟ್ ಸೇರಿಸಲಾಗಿದೆ</translation>
+<translation id="7837721118676387834">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗೆ ಮ್ಯೂಟ್ ಮಾಡಲಾದ ವೀಡಿಯೊಗಳ ಸ್ವಯಂಪ್ಲೇ ಅನುಮತಿಸಿ.</translation>
+<translation id="2621115761605608342">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗೆ JavaScript ಅನ್ನು ಅನುಮತಿಸಿ.</translation>
+<translation id="8801436777607969138">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗೆ JavaScript ಅನ್ನು ನಿರ್ಬಂಧಿಸಿ.</translation>
+<translation id="8372893542064058268">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗಾಗಿ ಹಿನ್ನೆಲೆ ಸಿಂಕ್‌ ಅನುಮತಿಸಿ.</translation>
+<translation id="358794129225322306">ಬಹು ಫೈಲ್‌ಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲು ಸೈಟ್‌ ಒಂದಕ್ಕೆ ಅನುಮತಿಸುವುದು.</translation>
+<translation id="4008040567710660924">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ ಒಂದಕ್ಕೆ ಕುಕೀಗಳನ್ನು ಅನುಮತಿಸಿ.</translation>
+<translation id="8958424370300090006">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ ಒಂದಕ್ಕೆ ಕುಕೀಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ.</translation>
+<translation id="7882806643839505685">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ನ ಧ್ವನಿಯನ್ನು ಅನುಮತಿಸಿ.</translation>
+<translation id="4468959413250150279">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ನ ಧ್ವನಿಯನ್ನು ಮ್ಯೂಟ್ ಮಾಡಿ</translation>
+<translation id="1994173015038366702">ಸೈಟ್ URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">ಬಳಕೆ</translation>
+<translation id="5804241973901381774">ಅನುಮತಿಗಳು</translation>
+<translation id="4278390842282768270">ಅನುಮತಿಸಲಾಗಿದೆ</translation>
+<translation id="5677928146339483299">ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
+<translation id="1984937141057606926">ಮೂರನೇ ವ್ಯಕ್ತಿಯನ್ನು ಹೊರತುಪಡಿಸಿ ಅನುಮತಿಸಲಾಗಿದೆ</translation>
+<translation id="7423098979219808738">ಮೊದಲು ಕೇಳಿ</translation>
+<translation id="8116925261070264013">ಮ್ಯೂಟ್‌ ಆಗಿರುವುದು</translation>
+<translation id="8300705686683892304">ಆ್ಯಪ್ ಮೂಲಕ ನಿರ್ವಹಿಸಲಾಗಿದೆ</translation>
+<translation id="6192792657125177640">ವಿನಾಯಿತಿಗಳು</translation>
+<translation id="257931822824936280">ವಿಸ್ತರಿಸಲಾಗಿದೆ - ಕುಗ್ಗಿಸಲು ಕ್ಲಿಕ್ ಮಾಡಿ</translation>
+<translation id="5100237604440890931">ಕುಗ್ಗಿಸಲಾಗಿದೆ - ವಿಸ್ತರಿಸಲು ಕ್ಲಿಕ್ ಮಾಡಿ</translation>
+<translation id="857943718398505171">ಅನುಮತಿಸಲಾಗಿದೆ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="2913331724188855103">ಕುಕೀ ಡೇಟಾವನ್ನು ಉಳಿಸಲು ಮತ್ತು ರೀಡ್ ಮಾಡಲು ಸೈಟ್‌ಗಳನ್ನು ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="7445411102860286510">ಮ್ಯೂಟ್ ಮಾಡಲಾದ ವೀಡಿಯೊಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="5335288049665977812">JavaScript ರನ್ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="5527111080432883924">ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಿರುವ ಪಠ್ಯ ಮತ್ತು ಚಿತ್ರಗಳನ್ನು ನೋಡಲು ಸೈಟ್‌ಗೆ ಅನುಮತಿಸುವ ಮುನ್ನ ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
 <translation id="6912998170423641340">ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಿರುವ ಪಠ್ಯ ಮತ್ತು ಚಿತ್ರಗಳನ್ನು ಓದದಂತೆ ಸೈಟ್ ಅನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="6914783257214138813">ರಫ್ತು ಮಾಡಲಾದ ಫೈಲ್ ಅನ್ನು ನೋಡುವ ಯಾರಿಗಾದರೂ ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಗೋಚರಿಸುತ್ತವೆ.</translation>
-<translation id="6942665639005891494">ಸೆಟ್ಟಿಂಗ್‌ಗಳ ಮೆನು ಆಯ್ಕೆಯನ್ನು ಬಳಸಿ, ಡಿಫಾಲ್ಟ್ ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳವನ್ನು ಯಾವಾಗ ಬೇಕಾದರೂ ಬದಲಾಯಿಸಿ</translation>
-<translation id="6945221475159498467">ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="6963642900430330478">ಈ ಪುಟವು ಅಪಾಯಕಾರಿಯಾಗಿದೆ. ಸೈಟ್ ಮಾಹಿತಿ</translation>
-<translation id="6963766334940102469">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಅಳಿಸಿ</translation>
-<translation id="6965382102122355670">ಸರಿ</translation>
-<translation id="6979737339423435258">ಎಲ್ಲ ಸಮಯ</translation>
-<translation id="6981982820502123353">ಪ್ರವೇಶ</translation>
-<translation id="6989267951144302301">ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ</translation>
-<translation id="6990079615885386641">Google Play Store ನಿಂದ ಅಪ್ಲಿಕೇಶನ್ ಪಡೆದುಕೊಳ್ಳಿ: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">ನಿಮ್ಮ ಮೈಕ್ರೋಫೋನ್‍ ಬಳಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="7015203776128479407">ಪ್ರಾರಂಭಿಕ ಸಿಂಕ್ ಸೆಟಪ್ ಮುಗಿದಿಲ್ಲ. ಸಿಂಕ್ ಆಫ್ ಆಗಿದೆ.</translation>
-<translation id="7016516562562142042">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್‌ಗೆ ಅನುಮತಿಸಲಾಗಿದೆ</translation>
-<translation id="7022756207310403729">ಬ್ರೌಸರ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="702463548815491781">TalkBack ಅಥವಾ ಪ್ರವೇಶ ಬದಲಾಯಿಸಿ ಆನ್ ಆಗಿದ್ದಾಗ ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="7029809446516969842">ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
-<translation id="7053983685419859001">ನಿರ್ಬಂಧಿಸು</translation>
-<translation id="7055152154916055070">ಮರುನಿರ್ದೇಶಿಸುವಿಕೆಯನ್ನು ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ:</translation>
-<translation id="7063006564040364415">ಸಿಂಕ್ ಸರ್ವರ್‌ಗೆ ಸಂಪರ್ಕ ಹೊಂದಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ}one{# ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ}other{# ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ}}</translation>
-<translation id="7071521146534760487">ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ</translation>
-<translation id="7077143737582773186">ಎಸ್‌ಡಿ ಕಾರ್ಡ್‌</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> ಅನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ. ಪರದೆಯ ಮೇಲ್ಭಾಗದಲ್ಲಿ ಲಭ್ಯವಿರುವ ಆಯ್ಕೆಗಳು</translation>
-<translation id="7121362699166175603">ವಿಳಾಸ ಪಟ್ಟಿಯ ಇತಿಹಾಸ ಮತ್ತು ಸ್ವಯಂಪೂರ್ಣಗೊಳಿಸುವಿಕೆಯನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ. ನಿಮ್ಮ Google ಖಾತೆಯು <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> ನಲ್ಲಿ ಇತರ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೊಂದಿರಬಹುದು.</translation>
-<translation id="7128222689758636196">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್‌ಗೆ ಅನುಮತಿಸಿ</translation>
-<translation id="7138678301420049075">ಇತರೆ</translation>
+<translation id="7423538860840206698">ಕ್ಲಿಪ್‌ಬೋರ್ಡ್ ಓದದಂತೆ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
+<translation id="3955193568934677022">ಸಂರಕ್ಷಿಸಲಾದ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="445467742685312942">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿ ನೀಡಿ</translation>
+<translation id="2107397443965016585">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="2910701580606108292">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ</translation>
+<translation id="757524316907819857">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡದಂತೆ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
+<translation id="3277252321222022663">ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿ ನೀಡಿ (ಶಿಫಾರಸು ಮಾಡಿರುವುದು)</translation>
+<translation id="5048398596102334565">ಚಲನಾ ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿ ನೀಡಿ (ಶಿಫಾರಸು ಮಾಡಿರುವುದು)</translation>
+<translation id="8816026460808729765">ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸದಂತೆ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
+<translation id="169515064810179024">ಚಲನಾ ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸದಂತೆ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
+<translation id="1660204651932907780">ಧ್ವನಿಯನ್ನು ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="3600792891314830896">ಕೆಲವು ಸೈಟ್‌ಗಳಲ್ಲಿ ಧ್ವನಿ ಪ್ಲೇ ಆಗುವುದನ್ನು ಮ್ಯೂಟ್ ಮಾಡಿ</translation>
+<translation id="1743802530341753419">ಸಾಧನಕ್ಕೆ ಸಂಪರ್ಕಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="851751545965956758">ಸಾಧನಗಳಿಗೆ ಸಂಪರ್ಕಿಸದಂತೆ, ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
 <translation id="7141896414559753902">ಪಾಪ್-ಅಪ್‍ಗಳು ಮತ್ತು ಮರುನಿರ್ದೇಶನಗಳನ್ನು ತೋರಿಸದಂತೆ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> ನಿಂದ <ph name="BEGIN_LINK" />ಮೂಲ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಿ<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">ಕಳೆದ 24 ಗಂಟೆಗಳು</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">ನೀವು ಇದನ್ನು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ನಂತರ ಬದಲಾಯಿಸಬಹುದು</translation>
-<translation id="7180611975245234373">ರಿಫ್ರೆಶ್ ಮಾಡಿ</translation>
-<translation id="7189372733857464326">Google Play ಸೇವೆಗಳು ಅಪ್‌ಡೇಟ್ ಮಾಡುವಿಕೆಯನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ನಿರೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="7191430249889272776">ಟ್ಯಾಬ್ ಅನ್ನು ಹಿನ್ನೆಲೆಯಲ್ಲಿ ತೆರೆಯಲಾಗಿದೆ.</translation>
-<translation id="723171743924126238">ಚಿತ್ರಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="7233236755231902816">ನಿಮ್ಮ ಭಾಷೆಯಲ್ಲಿ ವೆಬ್ ಪುಟವನ್ನು ವೀಕ್ಷಿಸಲು, ಇತ್ತೀಚಿನ Chrome ಆವೃತ್ತಿಯನ್ನು ಪಡೆಯಿರಿ</translation>
-<translation id="7243308994586599757">ಪರದೆಯ ಕೆಳಗೆ ಲಭ್ಯವಿರುವ ಆಯ್ಕೆಗಳು</translation>
-<translation id="7248069434667874558">Chrome ನಲ್ಲಿ <ph name="TARGET_DEVICE_NAME" /> ಸಾಧನದ ಸಿಂಕ್ ಆನ್ ಆಗಿದೆಯೇ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> ಅನ್ನು ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</translation>
-<translation id="7274013316676448362">ನಿರ್ಬಂಧಿಸಿರುವ ಸೈಟ್</translation>
-<translation id="7290209999329137901">ಮರುಹೆಸರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="7291387454912369099">ಅಸಿಸ್ಟೆಂಟ್ ಟ್ರಿಗರ್ ಮಾಡಿದ ಚೆಕ್ಔಟ್</translation>
-<translation id="7293171162284876153">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು, "ನಿಮ್ಮ Chrome ಡೇಟಾ ಸಿಂಕ್ ಮಾಡಿ" ಆಯ್ಕೆಯನ್ನು ಆನ್ ಮಾಡಿ.</translation>
-<translation id="729975465115245577">ನಿಮ್ಮ ಸಾಧನವು ಪಾಸ್‌ವರ್ಡ್‌ ಫೈಲ್ ಅನ್ನು ಸಂಗ್ರಹಿಸಿಡಲು ಅಪ್ಲಿಕೇಶನ್‌ ಅನ್ನು ಹೊಂದಿಲ್ಲ.</translation>
+<translation id="5494752089476963479">ಅನಪೇಕ್ಷಿತ ಅಥವಾ ತಪ್ಪುದಾರಿಗೆಳೆಯುವ ಜಾಹೀರಾತುಗಳನ್ನು ತೋರಿಸುವ ಸೈಟ್‌ಗಳಲ್ಲಿ ಜಾಹೀರಾತುಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
+<translation id="3123473560110926937">ಕೆಲವು ಸೈಟ್‌ಗಳಲ್ಲಿ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
+<translation id="965817943346481315">ಅತಿಕ್ರಮಣಕಾರಿಯಾಗಿರುವ ಅಥವಾ ತಪ್ಪುದಾರಿಗೆಳೆಯುವ ಜಾಹೀರಾತುಗಳನ್ನು ಸೈಟ್ ತೋರಿಸಿದರೆ ಅದನ್ನು ನಿರ್ಬಂಧಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="3386292677130313581">ನಿಮ್ಮ ಸ್ಥಳವನ್ನು ತಿಳಿಯಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="9139068048179869749">ಅಧಿಸೂಚನೆಗಳನ್ನು ಕಳುಹಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="4479647676395637221">ನಿಮ್ಮ ಕ್ಯಾಮರಾ ಬಳಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="6992289844737586249">ನಿಮ್ಮ ಮೈಕ್ರೋಫೋನ್‍ ಬಳಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="2289270750774289114">ಸೈಟ್ ಯಾವಾಗ ಸಮೀಪದ ಬ್ಲೂಟೂತ್ ಸಾಧನಗಳನ್ನು ಅನ್ವೇಷಿಸಲು ಬಯಸುತ್ತದೆಯೋ ಆಗ ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="7053983685419859001">ನಿರ್ಬಂಧಿಸು</translation>
+<translation id="7128222689758636196">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್‌ಗೆ ಅನುಮತಿಸಿ</translation>
+<translation id="7589445247086920869">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್ ಅನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
+<translation id="6388207532828177975">ತೆರವುಗೊಳಿಸಿ &amp; ಮರುಹೊಂದಿಸಿ</translation>
+<translation id="7999064672810608036">ಕುಕೀಗಳು ಸೇರಿದಂತೆ, ಸ್ಥಳೀಯ ಎಲ್ಲಾ ಡೇಟಾವನ್ನು ಅಳಿಸಲು ಮತ್ತು ಈ ವೆಬ್‌ಸೈಟ್‌ಗೆ ಎಲ್ಲಾ ಅನುಮತಿಗಳನ್ನು ಮರುಹೊಂದಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?</translation>
+<translation id="2822354292072154809">ನೀವು <ph name="CHOSEN_OBJECT_NAME"/> ಗಾಗಿ ಎಲ್ಲಾ ಸೈಟ್ ಅನುಮತಿಗಳನ್ನು ಖಚಿತವಾಗಿಯೂ ಮರುಹೊಂದಿಸಲು ಬಯಸುತ್ತೀರಾ?</translation>
+<translation id="515227803646670480">ಸಂಗ್ರಹಿತ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಿ</translation>
+<translation id="5902828464777634901">ಕುಕೀಗಳು ಸೇರಿದಂತೆ, ಈ ವೆಬ್‌ಸೈಟ್ ಮೂಲಕ ಸಂಗ್ರಹಿಸಲಾದ ಎಲ್ಲಾ ಸ್ಥಳೀಯ ಡೇಟಾವನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ.</translation>
+<translation id="119944043368869598">ಎಲ್ಲವನ್ನೂ ತೆಗೆದುಹಾಕಿ</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> ಆ್ಯಪ್ ನಿರ್ವಹಿಸುತ್ತಿದೆ</translation>
+<translation id="5516455585884385570">ಅಧಿಸೂಚನೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆಯಿರಿ</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/> ರಲ್ಲಿ ಎಂಬೆಡ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="129382876167171263">ವೆಬ್‌ಸೈಟ್‌ಗಳ ಮೂಲಕ ಉಳಿಸಲಾಗಿರುವ ಫೈಲ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ</translation>
+<translation id="4181841719683918333">ಭಾಷೆಗಳು</translation>
+<translation id="2647434099613338025">ಭಾಷೆಯನ್ನು ಸೇರಿಸಿ</translation>
+<translation id="1952172573699511566">ಸಾಧ್ಯವಾದಾಗ, ನೀವು ಆದ್ಯತೆ ನೀಡುವ ಭಾಷೆಯಲ್ಲಿ ವೆಬ್‌ಸೈಟ್‌ಗಳು ಪಠ್ಯವನ್ನು ತೋರಿಸುತ್ತವೆ.</translation>
+<translation id="8559990750235505898">ಪುಟಗಳನ್ನು ಇತರ ಭಾಷೆಗಳಲ್ಲಿ ಅನುವಾದಿಸಲು ಅವಕಾಶಿಸಿ</translation>
+<translation id="4719927025381752090">ಅನುವಾದಿಸಲು ಅವಕಾಶಿಸಿ</translation>
+<translation id="8156139159503939589">ನಿಮಗೆ ಯಾವ ಭಾಷೆಗಳನ್ನು ಓದಲು ಬರುತ್ತದೆ?</translation>
+<translation id="5689516760719285838">ಸ್ಥಳ</translation>
+<translation id="2440823041667407902">ಸ್ಥಳ ಪ್ರವೇಶ</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> Brave ಗೆ ಅನುಮತಿಗಳನ್ನು ಆನ್ ಮಾಡಿ.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> Brave ಗೆ ಅನುಮತಿಯನ್ನು ಆನ್ ಮಾಡಿ.</translation>
+<translation id="2928908108430545745">Brave ನಿಮ್ಮ ಸ್ಥಳವನ್ನು ಪ್ರವೇಶಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಸ್ಥಳವನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
+<translation id="1028853271388022585">Brave ನಿಮ್ಮ ಕ್ಯಾಮರಾವನ್ನು ಪ್ರವೇಶಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಕ್ಯಾಮರಾವನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
+<translation id="2913721282607281710">Brave ನಿಮಗೆ ಅಧಿಸೂಚನೆಗಳನ್ನು ಕಳುಹಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಅಧಿಸೂಚನೆಗಳನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
+<translation id="8753483718490035722">Brave ನಿಮ್ಮ ಮೈಕ್ರೋಫೋನ್‌ಗೆ ಪ್ರವೇಶಿಸುವುದಕ್ಕೆ ಅನುಮತಿಸಲು, <ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಮೈಕ್ರೋಫೋನ್ ಅನ್ನು ಕೂಡ ಆನ್ ಮಾಡಬೇಕಾಗುತ್ತದೆ.</translation>
+<translation id="1887786770086287077">ಈ ಸಾಧನದ ಸ್ಥಳ ಪ್ರವೇಶ ಆಫ್ ಆಗಿದೆ. ಅದನ್ನು <ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಆನ್ ಮಾಡಿ.</translation>
+<translation id="2570922361219980984">ಈ ಸಾಧನದ ಸ್ಥಳ ಪ್ರವೇಶ ಸಹ ಆಫ್ ಆಗಿದೆ. ಅದನ್ನು <ph name="BEGIN_LINK"/>Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK"/> ಆನ್ ಮಾಡಿ.</translation>
+<translation id="1620510694547887537">ಕ್ಯಾಮರಾ</translation>
+<translation id="3227137524299004712">ಮೈಕ್ರೋಫೋನ್</translation>
+<translation id="1647391597548383849">ನಿಮ್ಮ ಕ್ಯಾಮರಾವನ್ನು ಪ್ರವೇಶಿಸಿ</translation>
+<translation id="945632385593298557">ನಿಮ್ಮ ಮೈಕ್ರೋಫೋನ್ ಪ್ರವೇಶಿಸಿ</translation>
+<translation id="6612358246767739896">ಸಂರಕ್ಷಿಸಿದ ವಿಷಯ</translation>
+<translation id="885701979325669005">ಸಂಗ್ರಹಣೆ</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> ಸಂಗ್ರಹಿಸಿದ ಡೇಟಾ</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">ಸಾಧನ ಅನುಮತಿಯನ್ನು ಹಿಂತೆಗೆದುಕೊಳ್ಳಿ</translation>
+<translation id="4962975101802056554">ಸಾಧನಕ್ಕೆ ನೀಡಿರುವ ಎಲ್ಲಾ ಅನುಮತಿಗಳನ್ನು ಹಿಂಪಡೆಯಿರಿ</translation>
+<translation id="6545864417968258051">ಬ್ಲೂಟೂತ್ ಸ್ಕ್ಯಾನಿಂಗ್</translation>
+<translation id="4411535500181276704">ಲೈಟ್ ಮೋಡ್</translation>
+<translation id="7821588508402923572">ನಿಮ್ಮ ಡೇಟಾ ಉಳಿತಾಯಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> ಉಳಿತಾಯ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> ರಿಂದ</translation>
+<translation id="3252158532344029638">ಲೈಟ್ ಮೋಡ್‍ನಲ್ಲಿ, Brave ವೇಗವಾಗಿ ಪುಟಗಳನ್ನು ಲೋಡ್ ಮಾಡುತ್ತದೆ, ಮತ್ತು ಡೇಟಾವನ್ನು ಸುಮಾರು ಶೇಕಡಾ 60 ರಷ್ಟು ಕಡಿಮೆ ಬಳಸುತ್ತದೆ.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> ಡೇಟಾ ಉಳಿತಾಯಗಳು</translation>
+<translation id="7494974237137038751">ಉಳಿತಾಯವಾದ ಡೇಟಾ</translation>
+<translation id="6111020039983847643">Brave ನಿಂದ ಬಳಕೆಯಾಗಿರುವ ಡೇಟಾ</translation>
+<translation id="7413229368719586778">ಪ್ರಾರಂಭ ದಿನಾಂಕ <ph name="DATE"/></translation>
+<translation id="1782483593938241562">ಅಂತಿಮ ದಿನಾಂಕ <ph name="DATE"/></translation>
+<translation id="2728754400939377704">ಸೈಟ್ ಪ್ರಕಾರ ವಿಂಗಡಿಸಿ</translation>
+<translation id="5864174910718532887">ವಿವರಗಳು: ಸೈಟ್ ಹೆಸರಿನ ಪ್ರಕಾರ ವಿಂಗಡಿಸಲಾಗಿದೆ</translation>
+<translation id="116280672541001035">ಬಳಕೆಯಾಗಿದ್ದು</translation>
+<translation id="8349013245300336738">ಬಳಸಿದ ಡೇಟಾ ಪ್ರಮಾಣದ ಪ್ರಕಾರ ವಿಂಗಡಿಸಿ</translation>
+<translation id="6378173571450987352">ವಿವರಗಳು: ಡೇಟಾ ಬಳಕೆಯ ಪ್ರಮಾಣದ ಆಧಾರದಲ್ಲಿ ವಿಂಗಡಿಸಲಾಗಿದೆ</translation>
+<translation id="2631006050119455616">ಉಳಿಸಲಾಗಿದೆ</translation>
+<translation id="6643649862576733715">ಉಳಿಸಿದ ಡೇಟಾ ಪ್ರಮಾಣದ ಪ್ರಕಾರ ವಿಂಗಡಿಸಿ</translation>
 <translation id="7302081693174882195">ವಿವರಗಳು: ಉಳಿಸಿದ ಡೇಟಾ ಪ್ರಮಾಣದ ಆಧಾರದಲ್ಲಿ ವಿಂಗಡಿಸಲಾಗಿದೆ</translation>
-<translation id="7328017930301109123">ಲೈಟ್ ಮೋಡ್‍ನಲ್ಲಿ, Chrome ವೇಗವಾಗಿ ಪುಟಗಳನ್ನು ಲೋಡ್ ಮಾಡುತ್ತದೆ, ಮತ್ತು ಡೇಟಾವನ್ನು ಸುಮಾರು ಶೇಕಡಾ 60 ರಷ್ಟು ಕಡಿಮೆ ಬಳಸುತ್ತದೆ.</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> ಬಳಸಲಾಗಿದೆ</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> ಉಳಿಸಲಾಗಿದೆ</translation>
+<translation id="2156074688469523661">ಉಳಿದ ಸೈಟ್‌ಗಳು (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">ಇತರೆ</translation>
+<translation id="4913161338056004800">ಅಂಕಿ ಅಂಶಗಳನ್ನು ಮರುಹೊಂದಿಸಿ</translation>
+<translation id="1856325424225101786">ಲೈಟ್ ಮೋಡ್ ಅನ್ನು ಮರುಹೊಂದಿಸಬೇಕೇ?</translation>
+<translation id="3658159451045945436">ಮರುಹೊಂದಿಸುವುದರಿಂದ, ಭೇಟಿ ನೀಡಿದ ಸೈಟ್‌ಗಳ ಪಟ್ಟಿ ಸೇರಿದಂತೆ ನಿಮ್ಮ ಡೇಟಾ ಉಳಿತಾಯದ ಇತಿಹಾಸವನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ.</translation>
+<translation id="3295530008794733555">ವೇಗವಾಗಿ ಬ್ರೌಸ್ ಮಾಡಿ. ಕಡಿಮೆ ಡೇಟಾವನ್ನು ಬಳಸಿ.</translation>
+<translation id="7340390500800578919">ಲೈಟ್ ಮೋಡ್‍ನಲ್ಲಿ, Brave ವೇಗವಾಗಿ ಪುಟಗಳನ್ನು ಲೋಡ್ ಮಾಡುತ್ತದೆ, ಮತ್ತು ಸುಮಾರು ಶೇಕಡಾ 60 ರಷ್ಟು ಕಡಿಮೆ ಡೇಟಾವನ್ನು ಬಳಸುತ್ತದೆ. ನೀವು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳನ್ನು ಆಪ್ಟಿಮೈಸ್ ಮಾಡಲು, Brave ನಿಮ್ಮ ವೆಬ್ ಟ್ರಾಫಿಕ್ ಕುರಿತ ಮಾಹಿತಿಯನ್ನು Brave Software ಗೆ ಕಳುಹಿಸುತ್ತದೆ. <ph name="BEGIN_LINK"/>ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">ಲೈಟ್ ಮೋಡ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
+<translation id="4493497663118223949">ಲೈಟ್ ಮೋಡ್ ಆನ್ ಆಗಿದೆ</translation>
+<translation id="7559975015014302720">ಲೈಟ್ ಮೋಡ್ ಆಫ್ ಆಗಿದೆ</translation>
+<translation id="7606077192958116810">ಲೈಟ್ ಮೋಡ್ ಆನ್ ಆಗಿದೆ. ಇದನ್ನು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ನಿರ್ವಹಿಸಿ.</translation>
+<translation id="4714588616299687897">60% ರವರೆಗೆ ನಿಮ್ಮ ಡೇಟಾ ಉಳಿಸಿ</translation>
+<translation id="1006927014032731288">ನೀವು ಭೇಟಿ ಮಾಡುವ ಪುಟಗಳನ್ನು Brave Software ಸರ್ವರ್‌ಗಳು ಆಪ್ಟಿಮೈಸ್ ಮಾಡುತ್ತವೆ.</translation>
+<translation id="3257320067425202300">ನಿಮ್ಮ <ph name="MEGABYTES"/> MB ಅನ್ನು Brave ಉಳಿಸಿದೆ</translation>
+<translation id="5813223329348543512">ನಿಮ್ಮ <ph name="GIGABYTES"/> GB ಅನ್ನು Brave ಉಳಿಸಿದೆ</translation>
+<translation id="8266862848225348053">ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳ</translation>
+<translation id="7077143737582773186">ಎಸ್‌ಡಿ ಕಾರ್ಡ್‌</translation>
+<translation id="7762668264895820836">ಎಸ್‌ಡಿ ಕಾರ್ಡ್ <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">ಫೈಲ್‌ಗಳನ್ನು ಎಲ್ಲಿ ಉಳಿಸಬೇಕೆಂದು ಕೇಳಿ</translation>
+<translation id="6192333916571137726">ಫೈಲ್‌ ಅನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಿ</translation>
+<translation id="1672586136351118594">ಮತ್ತೊಮ್ಮೆ ತೋರಿಸಬೇಡಿ</translation>
+<translation id="2650751991977523696">ಫೈಲ್‌ ಮತ್ತೆ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡುವುದೇ?</translation>
+<translation id="8664979001105139458">ಫೈಲ್ ಹೆಸರು ಈಗಾಗಲೇ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ</translation>
+<translation id="488187801263602086">ಫೈಲ್‌ ಮರುಹೆಸರಿಸಿ</translation>
+<translation id="5686790454216892815">ಫೈಲ್‌ನ ಹೆಸರು ತುಂಬಾ ಉದ್ದವಾಗಿದೆ</translation>
+<translation id="7454641608352164238">ಸಾಕಷ್ಟು ಸ್ಥಳಾವಕಾಶವಿಲ್ಲ</translation>
+<translation id="8972098258593396643">ಡೀಫಾಲ್ಟ್ ಫೋಲ್ಡರ್‌ಗೆ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡುವುದೇ?</translation>
+<translation id="804335162455518893">SD ಕಾರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ</translation>
+<translation id="7475688122056506577">SD ಕಾರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ. ನಿಮ್ಮ ಕೆಲವು ಫೈಲ್‌ಗಳು ಕಾಣೆಯಾಗಿರಬಹುದು.</translation>
+<translation id="4198423547019359126">ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳಗಳು ಲಭ್ಯವಿಲ್ಲ</translation>
+<translation id="8224471946457685718">ವೈ-ಫೈಯಲ್ಲಿ ನಿಮಗಾಗಿ ಲೇಖನಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="4970824347203572753">ನಿಮ್ಮ ಸ್ಥಳದಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲ</translation>
+<translation id="5500777121964041360">ನಿಮ್ಮ ಸ್ಥಳದಲ್ಲಿ ಲಭ್ಯವಿಲ್ಲದಿರಬಹುದು</translation>
+<translation id="1173894706177603556">ಮರುಹೆಸರಿಸು</translation>
+<translation id="1986685561493779662">ಹೆಸರು ಈಗಾಗಲೇ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ</translation>
+<translation id="6441734959916820584">ಹೆಸರು ತುಂಬಾ ಉದ್ದವಾಗಿದೆ</translation>
+<translation id="2923908459366352541">ಹೆಸರು ಅಮಾನ್ಯವಾಗಿದೆ</translation>
+<translation id="7290209999329137901">ಮರುಹೆಸರಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="3334729583274622784">ಫೈಲ್ ವಿಸ್ತರಣೆಯನ್ನು ಬದಲಿಸುವುದೇ?</translation>
+<translation id="107147699690128016">ಫೈಲ್ ವಿಸ್ತರಣೆಯನ್ನು ಬದಲಾಯಿಸಿದರೆ, ಇತರ ಅಪ್ಲಿಕೇಶನ್‌ಗಳಲ್ಲಿ ಫೈಲ್‌ ಅನ್ನು ತೆರೆಯಬಹುದು ಮತ್ತು ನಿಮ್ಮ ಸಾಧನವನ್ನು ಹಾನಿಗೊಳಿಸಬಹುದು.</translation>
+<translation id="8541922081612557424">Brave ಕುರಿತು</translation>
+<translation id="5311273890481188673">ಕೃತಿಸ್ವಾಮ್ಯ <ph name="YEAR"/> Brave Software LLC. ಎಲ್ಲ ಹಕ್ಕುಗಳನ್ನು ಕಾಯ್ದಿರಿಸಲಾಗಿದೆ.</translation>
+<translation id="1416550906796893042">ಅಪ್ಲಿಕೇಶನ್ ಆವೃತ್ತಿ</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (<ph name="TIME_SINCE_UPDATE"/> ಅಪ್‌ಡೇಟ್‌ ಮಾಡಲಾಗಿದೆ)</translation>
+<translation id="7596558890252710462">ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂ</translation>
+<translation id="3968054912784331254">Android ನ ಈ ಆವೃತ್ತಿಯಲ್ಲಿ ಇನ್ನು ಮುಂದೆ Brave ಅಪ್‌ಡೇಟ್‌ಗಳನ್ನು ಬೆಂಬಲಿಸಲಾಗುವುದಿಲ್ಲ</translation>
+<translation id="7665369617277396874">ಖಾತೆಯನ್ನು ಸೇರಿಸು</translation>
+<translation id="649070405679044769">ಇದರಂತೆ Brave Software ಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
+<translation id="6234515504547364178">Brave ನಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡಿ</translation>
+<translation id="5324858694974489420">ಪೋಷಕ ಸೆಟ್ಟಿಂಗ್‌ಗಳು</translation>
+<translation id="8920114477895755567">ಪೋಷಕರ ವಿವರಗಳಿಗಾಗಿ ನಿರೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ.</translation>
+<translation id="5512137114520586844">ಈ ಖಾತೆಯನ್ನು <ph name="PARENT_NAME"/> ಅವರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ.</translation>
+<translation id="2956410042958133412">ಈ ಖಾತೆಯನ್ನು <ph name="PARENT_NAME_1"/> ಮತ್ತು <ph name="PARENT_NAME_2"/> ಅವರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ.</translation>
+<translation id="8168435359814927499">ವಿಷಯ</translation>
+<translation id="5403644198645076998">ಕೆಲವು ಸೈಟ್‌ಗಳಿಗೆ ಮಾತ್ರ ಅನುಮತಿಸಿ</translation>
+<translation id="8641930654639604085">ವಯಸ್ಕರ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಲು ಪ್ರಯತ್ನಿಸಿ</translation>
+<translation id="5639724618331995626">ಎಲ್ಲ ಸೈಟ್‌ಗಳನ್ನು ಅನುಮತಿಸಿ</translation>
+<translation id="796823723482603597">Brave ನಿಂದ ಸಂಚಾಲಿತ</translation>
+<translation id="6324034347079777476">Android ಸಿಸ್ಟಂ ಸಿಂಕ್ ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ</translation>
+<translation id="5127805178023152808">ಸಿಂಕ್‌ ಆಫ್‌ ಆಗಿದೆ</translation>
+<translation id="7015203776128479407">ಪ್ರಾರಂಭಿಕ ಸಿಂಕ್ ಸೆಟಪ್ ಮುಗಿದಿಲ್ಲ. ಸಿಂಕ್ ಆಫ್ ಆಗಿದೆ.</translation>
+<translation id="2497852260688568942">ನಿಮ್ಮ ನಿರ್ವಾಹಕರು ಸಿಂಕ್ ಅನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿದ್ದಾರೆ</translation>
+<translation id="9100610230175265781">ಪಾಸ್‌ಫ್ರೇಸ್ ಅಗತ್ಯವಿದೆ</translation>
+<translation id="6108923351542677676">ಸೆಟಪ್ ಪ್ರಗತಿಯಲ್ಲಿದೆ...</translation>
+<translation id="4062305924942672200">ಕಾನೂನು ಮಾಹಿತಿ</translation>
+<translation id="4256782883801055595">ಓಪನ್ ಸೋರ್ಸ್ ಪರವಾನಗಿಗಳು</translation>
+<translation id="1138681184697033370">Brave ಸೇವಾ ನಿಯಮಗಳು</translation>
+<translation id="7392539049993970338">Brave ಗೌಪ್ಯತಾ ಸೂಚನೆ</translation>
+<translation id="2677748264148917807">ತೊರೆಯಿರಿ</translation>
+<translation id="5556459405103347317">ಮರುಲೋಡ್‌</translation>
+<translation id="1623104350909869708">ಹೆಚ್ಚುವರಿ ಸಂವಾದಗಳನ್ನು ರಚಿಸದಂತೆ ಈ ಪುಟವನ್ನು ತಡೆಯಿರಿ</translation>
+<translation id="2968755619301702150">ಪ್ರಮಾಣಪತ್ರ ವೀಕ್ಷಕ</translation>
+<translation id="1360432990279830238">ಸೈನ್ ಔಟ್ ಮಾಡಿ, ಸಿಂಕ್ ಆಫ್ ಮಾಡುವುದೇ?</translation>
+<translation id="8581481290581777242">ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ Brave ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸುವುದೇ?</translation>
+<translation id="1318865768845061710">ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು, ಇತಿಹಾಸ, ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಮತ್ತು ಇತರ Brave ಡೇಟಾವನ್ನು ಇನ್ನು ಮುಂದೆ ನಿಮ್ಮ Brave Software ಖಾತೆಗೆ ಸಿಂಕ್ ಮಾಡುವುದಿಲ್ಲ</translation>
+<translation id="3325020657155065477">ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ Brave ಡೇಟಾವನ್ನು ಸಹ ತೆರವುಗೊಳಿಸಿ</translation>
+<translation id="6136448902816743006">ನೀವು <ph name="DOMAIN_NAME"/> ಮೂಲಕ ನಿರ್ವಹಿಸಲಾಗುವ ಖಾತೆಯಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡುತ್ತಿರುವ ಕಾರಣ, ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ Brave ಡೇಟಾವನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ. ಇದು ನಿಮ್ಮ Brave Software ಖಾತೆಯಲ್ಲಿ ಉಳಿಯುತ್ತದೆ.</translation>
+<translation id="1853026300647876496">Brave Software ಅನ್ನು ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ. ಇದು ಒಂದು ನಿಮಿಷದಷ್ಟು ಸಮಯ ತೆಗೆದುಕೊಳ್ಳಬಹುದು...</translation>
+<translation id="2328985652426384049">ಸೈನ್ ಇನ್ ಆಗಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="7723158744459952869">ಪ್ರತಿಕ್ರಿಯಿಸಲು Brave Software ತೀರಾ ಹೆಚ್ಚು ಸಮಯ ತೆಗೆದುಕೊಂಡಿದೆ.</translation>
+<translation id="4572422548854449519">ನಿರ್ವಹಿಸಲ್ಪಟ್ಟ ಖಾತೆಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
+<translation id="2689656545739939160"><ph name="MANAGED_DOMAIN"/> ನಿರ್ವಹಿಸಿದ ಖಾತೆಯ ಮೂಲಕ ನೀವು ಸೈನ್‍‍ ಇನ್ ಮಾಡುತ್ತಿರುವಿರಿ ಮತ್ತು ಅದರ ನಿರ್ವಾಹಕ ನಿಯಂತ್ರಣವನ್ನು ನಿಮ್ಮ Brave ಡೇಟಾದ ಮೂಲಕ ನೀಡುತ್ತಿರುವಿರಿ. ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಶಾಶ್ವತವಾಗಿ ಈ ಖಾತೆಯೊಂದಿಗೆ ಜೋಡಿಸಲಾಗುತ್ತದೆ. Brave ನಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡುವುದರಿಂದ ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಅಳಿಸುತ್ತದೆ, ಆದರೆ ನಿಮ್ಮ Brave Software ಖಾತೆಯಲ್ಲಿ ಸಂಗ್ರಹವಾಗಿಯೇ ಇರುತ್ತದೆ.</translation>
+<translation id="1749561566933687563">ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
+<translation id="4242533952199664413">ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆ</translation>
+<translation id="1111673857033749125">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಲ್ಲಿ ಉಳಿಸಲಾದ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ.</translation>
+<translation id="8636825310635137004">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್‌ ಆನ್‌ ಮಾಡಿ.</translation>
+<translation id="3269956123044984603">ನಿಮ್ಮ ಇತರೆ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, Android ಖಾತೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ''ಸ್ವಯಂ-ಸಿಂಕ್ ಡೇಟಾ" ಆನ್ ಮಾಡಿ.</translation>
+<translation id="5157964048453367290">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಲ್ಲಿನ Brave ನಲ್ಲಿ ನೀವು ತೆರೆದಿರುವಂತಹ ಟ್ಯಾಬ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ.</translation>
+<translation id="4684427112815847243">ಪ್ರತಿಯೊಂದನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
+<translation id="2709516037105925701">ಸ್ವಯಂತುಂಬುವಿಕೆ</translation>
+<translation id="8820817407110198400">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು</translation>
+<translation id="1644574205037202324">ಇತಿಹಾಸ</translation>
+<translation id="17513872634828108">ತೆರೆದ ಟ್ಯಾಬ್‌ಗಳು</translation>
+<translation id="1320169905922104972">Brave Software Pay ಬಳಸುವ ಕ್ರೆಡಿಟ್ ಕಾರ್ಡ್‌ಗಳು ಮತ್ತು ವಿಳಾಸಗಳು</translation>
+<translation id="6337234675334993532">ಎನ್‌ಕ್ರಿಪ್ಶನ್</translation>
+<translation id="6698801883190606802">ಸಿಂಕ್‌ ಮಾಡಲಾದ ಡೇಟಾವನ್ನು ನಿರ್ವಹಿಸಿ</translation>
+<translation id="3598578758776312506">Brave Software ರುಜುವಾತುಗಳೊಂದಿಗೆ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿ</translation>
+<translation id="7810580217418711046"><ph name="TIME"/> ರಂದು ಹೊಂದಿಸಿದ್ದ Brave Software ಪಾಸ್‌ವರ್ಡ್‌ ಬಳಸಿಕೊಂಡು, ಸಿಂಕ್ ಮಾಡಿದ ಡೇಟಾವನ್ನು ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿ</translation>
+<translation id="8461694314515752532">ನಿಮ್ಮ ಸ್ವಂತ ಸಿಂಕ್ ಪಾಸ್‌ಫ್ರೇಸ್‌ ಬಳಸಿಕೊಂಡು ಸಿಂಕ್ ಮಾಡಿದ ಡೇಟಾವನ್ನು ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿ</translation>
+<translation id="2996291259634659425">ಪಾಸ್‌ಫ್ರೇಸ್ ರಚಿಸಿ</translation>
+<translation id="5713644099811900409">Brave Software ಖಾತೆ</translation>
+<translation id="8997474919031554666">ಪಾಸ್‌ಫ್ರೇಸ್ ಎನ್‌ಕ್ರಿಪ್ಶನ್, Brave Software Pay ನಿಂದ ಪಾವತಿ ವಿಧಾನಗಳು ಮತ್ತು ವಿಳಾಸಗಳನ್ನು ಒಳಗೊಂಡಿರುವುದಿಲ್ಲ. ನಿಮ್ಮ ಎನ್‍‍ಕ್ರಿಪ್ಟ್ ಮಾಡಲಾದ ಡೇಟಾವನ್ನು ನಿಮ್ಮ ಪಾಸ್‌ಫ್ರೇಸ್ ಹೊಂದಿರುವ ಯಾರಾದರೂ ಮಾತ್ರ ಓದಬಹುದು. ಪಾಸ್‍‍ಫ್ರೇಸ್‍ ಅನ್ನು Brave Software ಗೆ ಕಳುಹಿಸಲಾಗುವುದಿಲ್ಲ ಅಥವಾ ಅದನ್ನು Brave Software ನಿಂದ ಸಂಗ್ರಹಿಸಲಾಗುವುದಿಲ್ಲ. ನಿಮ್ಮ ಪಾಸ್‍‍ಫ್ರೇಸ್ ಅನ್ನು ನೀವು ಮರೆತರೆ ಅಥವಾ ಈ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಬದಲಾಯಿಸಲು ಬಯಸಿದರೆ, ನೀವು ಸಿಂಕ್ ಅನ್ನು ಮರುಹೊಂದಿಸುವ ಅಗತ್ಯವಿರುತ್ತದೆ.<ph name="BEGIN_LINK"/>ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">ಪಾಸ್‌ಫ್ರೇಸ್</translation>
+<translation id="7772032839648071052">ಪಾಸ್‌ಫ್ರೇಸ್ ಅನ್ನು ದೃಢೀಕರಿಸಿ</translation>
+<translation id="5304593522240415983">ಈ ಕ್ಷೇತ್ರವು ಖಾಲಿಯಾಗಿರುವಂತಿಲ್ಲ</translation>
+<translation id="321773570071367578">ನಿಮ್ಮ ಪಾಸ್‍‍ಫ್ರೇಸ್‍‍ ಅನ್ನು ನೀವು ಮರೆತಿದ್ದರೆ ಅಥವಾ ಈ ಸೆಟ್ಟಿಂಗ್ ಬದಲಾಯಿಸಲು ಬಯಸಿದರೆ, <ph name="BEGIN_LINK"/>ಸಿಂಕ್ ಮರುಹೊಂದಿಸಿ<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">ಪಾಸ್‌ಫ್ರೇಸ್‌ಗಳು ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ</translation>
+<translation id="5149495116300586333">ಪಾಸ್‌ಫ್ರೇಸ್ ಎನ್‌ಕ್ರಿಪ್ಶನ್, Brave Software Pay ನಿಂದ ಪಾವತಿ ವಿಧಾನಗಳು ಮತ್ತು ವಿಳಾಸಗಳನ್ನು ಒಳಗೊಂಡಿರುವುದಿಲ್ಲ.
+
+ಈ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಬದಲಾಯಿಸಲು, <ph name="BEGIN_LINK"/>ಸಿಂಕ್ ಅನ್ನು ಮರುಹೊಂದಿಸಿ<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">ತಪ್ಪಾದ ಪಾಸ್‌ಫ್ರೇಸ್</translation>
+<translation id="5414836363063783498">ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ...</translation>
+<translation id="6846298663435243399">ಲೋಡ್ ಆಗುತ್ತಿದೆ...</translation>
+<translation id="5517095782334947753">ನೀವು <ph name="FROM_ACCOUNT"/> ರಿಂದ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು, ಇತಿಹಾಸ, ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಮತ್ತು ಇತರ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಹೊಂದಿರುವಿರಿ.</translation>
+<translation id="3928666092801078803">ನನ್ನ ಡೇಟಾ ಒಂದುಗೂಡಿಸಿ</translation>
+<translation id="688738109438487280">ಪ್ರಸ್ತುತ ಡೇಟಾವನ್ನು <ph name="TO_ACCOUNT"/> ಗೆ ಸೇರಿಸಿ.</translation>
+<translation id="806745655614357130">ನನ್ನ ಡೇಟಾ ಪ್ರತ್ಯೇಕವಾಗಿ ಇರಿಸಿಕೊಳ್ಳಿ</translation>
+<translation id="1145536944570833626">ಪ್ರಸ್ತುತ ಡೇಟಾ ಅಳಿಸಿ.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> ಜೋಡಿಸಲು ಬಯಸುತ್ತದೆ</translation>
+<translation id="4915549754973153784">ಸಾಧನಗಳಿಗೆ ಸ್ಕ್ಯಾನ್ ಮಾಡುವಾಗ <ph name="BEGIN_LINK"/>ಸಹಾಯ ಪಡೆಯಿರಿ<ph name="END_LINK"/>...</translation>
+<translation id="5817918615728894473">ಜೋಡಿಸು</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>ಸಹಾಯ ಪಡೆಯಿರಿ<ph name="END_LINK1"/> ಅಥವಾ <ph name="BEGIN_LINK2"/>ಮರು-ಸ್ಕ್ಯಾನ್‌ಮಾಡಿ<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">ಯಾವುದೇ ಹೊಂದಾಣಿಕೆಯಾಗುವ ಸಾಧನಗಳು ಕಂಡುಬಂದಿಲ್ಲ</translation>
+<translation id="3773755127849930740">ಜೋಡಿಸುವಿಕೆ ಅನುಮತಿಸಲು <ph name="BEGIN_LINK"/>ಬ್ಲೂಟೂತ್ ಆನ್ ಮಾಡಿ<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">ಬ್ಲೂಟೂತ್ ಅಡಾಪ್ಟರ್ ಆನ್ ಮಾಡಲು Brave ಗೆ ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>ಸಹಾಯ ಪಡೆಯಿರಿ<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">ಸಾಧನಗಳನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಲು Brave ಗೆ ಸ್ಥಳ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ. <ph name="BEGIN_LINK"/>ಅನುಮತಿಗಳನ್ನು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">ಸಾಧನಗಳನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಲು Brave ಗೆ ಸ್ಥಳ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ. ಸ್ಥಳ ಪ್ರವೇಶವನ್ನು <ph name="BEGIN_LINK"/>
+ಈ ಸಾಧನಕ್ಕೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">ಸಾಧನಗಳನ್ನು ಸ್ಕ್ಯಾನ್ ಮಾಡಲು, Brave ಗೆ ಸ್ಥಳ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ. <ph name="BEGIN_LINK1"/>ಅನುಮತಿಗಳನ್ನು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ<ph name="END_LINK1"/>. ಸ್ಥಳ ಪ್ರವೇಶವನ್ನು ಸಹ <ph name="BEGIN_LINK2"/>ಈ ಸಾಧನಕ್ಕೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">ಸಂಪರ್ಕಿಸಲಾದ ಸಾಧನ</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{ಸಿಗ್ನಲ್‌ ಸಾಮರ್ಥ್ಯದ ಹಂತ: # ಪಟ್ಟಿ}one{ಸಿಗ್ನಲ್‌ ಸಾಮರ್ಥ್ಯದ ಹಂತ: # ಪಟ್ಟಿಗಳು}other{ಸಿಗ್ನಲ್‌ ಸಾಮರ್ಥ್ಯದ ಹಂತ: # ಪಟ್ಟಿಗಳು}}</translation>
+<translation id="5230560987958996918">ಸಮೀಪದಲ್ಲಿರುವ ಬ್ಲೂಟೂತ್ ಸಾಧನಗಳಿಗಾಗಿ ಸ್ಕ್ಯಾನ್ ಮಾಡಲು <ph name="SITE"/> ಬಯಸುತ್ತದೆ. ಈ ಕೆಳಗಿನ ಸಾಧನಗಳು ಕಂಡುಬಂದಿವೆ:</translation>
+<translation id="8368027906805972958">ಅಪರಿಚಿತ ಅಥವಾ ಬೆಂಬಲಿತವಲ್ಲದ ಸಾಧನ (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">ಸಿಂಕ್ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿಲ್ಲ</translation>
+<translation id="1810845389119482123">ಆರಂಭಿಕ ಸಿಂಕ್ ಸೆಟಪ್ ಪೂರ್ಣಗೊಂಡಿಲ್ಲ</translation>
+<translation id="3235722914093408050">Android ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆಯಿರಿ ಮತ್ತು Brave ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು Android ಸಿಸ್ಟಂ ಸಿಂಕ್ ಮರು-ಸಕ್ರಿಯಗೊಳಿಸಿ</translation>
+<translation id="3367813778245106622">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು ಮತ್ತೊಮ್ಮೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
+<translation id="974555521953189084">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು ನಿಮ್ಮ ಪಾಸ್‌ಫ್ರೇಸ್ ನಮೂದಿಸಿ</translation>
+<translation id="2997266899014181325">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು, "ನಿಮ್ಮ Brave ಡೇಟಾ ಸಿಂಕ್ ಮಾಡಿ" ಆಯ್ಕೆಯನ್ನು ಆನ್ ಮಾಡಿ.</translation>
+<translation id="8260126382462817229">ಮತ್ತೊಮ್ಮೆ ಸೈನ್ ಇನ್ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ</translation>
+<translation id="5919204609460789179">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು <ph name="PRODUCT_NAME"/> ಅಪ್‌ಡೇಟ್ ಮಾಡಿ</translation>
+<translation id="397583555483684758">ಸಿಂಕ್ ಕಾರ್ಯನಿರ್ವಹಿಸುವುದನ್ನು ನಿಲ್ಲಿಸಿದೆ</translation>
+<translation id="1966710179511230534">ದಯವಿಟ್ಟು ನಿಮ್ಮ ಸೈನ್-ಇನ್ ವಿವರಗಳನ್ನು ಅಪ್‌ಡೇಟ್‌ ಮಾಡಿ.</translation>
+<translation id="7063006564040364415">ಸಿಂಕ್ ಸರ್ವರ್‌ಗೆ ಸಂಪರ್ಕ ಹೊಂದಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> ನ ಅವಧಿ ಮುಗಿದಿದೆ.</translation>
+<translation id="4170011742729630528">ಈ ಸೇವೆಯು ಲಭ್ಯವಿಲ್ಲ; ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</translation>
+<translation id="7947953824732555851">ಸಮ್ಮತಿಸಿ ಮತ್ತು ಸೈನ್‌ ಇನ್‌ ಮಾಡಿ</translation>
+<translation id="8583805026567836021">ಖಾತೆಯ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="8310344678080805313">ಪ್ರಮಾಣಿತ ಟ್ಯಾಬ್‌ಗಳು</translation>
+<translation id="5748802427693696783">ಪ್ರಮಾಣಿತ ಟ್ಯಾಬ್‌ಗಳಿಗೆ ಬದಲಾಯಿಸಲಾಗಿದೆ</translation>
+<translation id="7998918019931843664">ಮುಚ್ಚಿದ ಟ್ಯಾಬ್ ಮತ್ತೆ ತೆರೆಯಿರಿ</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, ಟ್ಯಾಬ್</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> ಟ್ಯಾಬ್‌ ಮುಚ್ಚಿ</translation>
+<translation id="7243308994586599757">ಪರದೆಯ ಕೆಳಗೆ ಲಭ್ಯವಿರುವ ಆಯ್ಕೆಗಳು</translation>
+<translation id="4060598801229743805">ಪರದೆಯ ಮೇಲಿನ ಭಾಗದಲ್ಲಿ ಲಭ್ಯವಿರುವ ಆಯ್ಕೆಗಳು</translation>
+<translation id="2810645512293415242">ಡೇಟಾ ಉಳಿಸಲು ಮತ್ತು ವೇಗವಾಗಿ ಲೋಡ್ ಮಾಡಲು ಪುಟವನ್ನು ಸರಳೀಕೃತಗೊಳಿಸಲಾಗಿದೆ.</translation>
+<translation id="3985215325736559418"><ph name="FILE_NAME"/> ಅನ್ನು ಮತ್ತೆ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ನೀವು ಬಯಸುವಿರಾ?</translation>
+<translation id="2450083983707403292">ನೀವು <ph name="FILE_NAME"/> ಅನ್ನು ಪುನಃ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಬಯಸುತ್ತೀರಾ?</translation>
+<translation id="7514365320538308">ಡೌನ್‌ಲೋಡ್</translation>
+<translation id="545042621069398927">ನಿಮ್ಮ ಡೌನ್‌ಲೋಡ್‌ನ ವೇಗವನ್ನು ಹೆಚ್ಚಿಸಲಾಗುತ್ತಿದೆ.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ಫೈಲ್ ಅನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.}one{# ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.}other{# ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">ಫೈಲ್ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗುತ್ತಿದೆ (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 ಡೌನ್‌ಲೋಡ್‌‌ ಪೂರ್ಣಗೊಂಡಿದೆ.}one{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಪೂರ್ಣಗೊಂಡಿವೆ.}other{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಪೂರ್ಣಗೊಂಡಿವೆ.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 ಡೌನ್‌ಲೋಡ್‌ ವಿಫಲವಾಗಿದೆ.}one{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ವಿಫಲವಾಗಿವೆ.}other{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ವಿಫಲವಾಗಿವೆ.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 ಡೌನ್‌ಲೋಡ್ ಬಾಕಿ ಇದೆ.}one{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಬಾಕಿ ಇವೆ.}other{# ಡೌನ್‌ಲೋಡ್‌ಗಳು ಬಾಕಿ ಇವೆ.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> ಬಟನ್</translation>
+<translation id="3205824638308738187">ಬಹುತೇಕ ಮುಗಿದಿದೆ!</translation>
+<translation id="3960299545138990065">Brave ಮರುಪ್ರಾರಂಭಿಸಿ</translation>
+<translation id="3771001275138982843">ಅಪ್‌ಡೇಟ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
+<translation id="3888648114124182147">Brave ಅಪ್‌ಡೇಟ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ…</translation>
+<translation id="1705567146636171298">Brave ಅಪ್‌ಡೇಟ್‌ ಮಾಡಿ</translation>
+<translation id="6195417478702700398">ಉತ್ತಮ ಬ್ರೌಸಿಂಗ್ ಅನುಭವಕ್ಕಾಗಿ, Brave ಅನ್ನು ಅಪ್‌ಡೇಟ್‌ ಮಾಡಲು ತೆರೆಯಿರಿ</translation>
+<translation id="3512968675351418494">ನಿಮ್ಮ ಭಾಷೆಯಲ್ಲಿ ವೆಬ್ ಪುಟವನ್ನು ವೀಕ್ಷಿಸಲು, ಇತ್ತೀಚಿನ Brave ಆವೃತ್ತಿಯನ್ನು ಪಡೆಯಿರಿ</translation>
+<translation id="6427112570124116297">ವೆಬ್ ಅನ್ನು ಅನುವಾದಿಸಿ</translation>
+<translation id="1379423114029199501">ನಿಮ್ಮ ಭಾಷೆಯನ್ನು Brave ನ ಇತ್ತೀಚಿನ ಆವೃತ್ತಿಯಲ್ಲಿ ಪಡೆದುಕೊಳ್ಳಲು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ</translation>
+<translation id="5684874026226664614">ಓಹ್. ಈ ಪುಟವನ್ನು ಅನುವಾದಿಸಲಾಗುವುದಿಲ್ಲ.</translation>
+<translation id="6831043979455480757">ಅನುವಾದಿಸು</translation>
+<translation id="1285320974508926690">ಈ ಸೈಟ್ ಅನ್ನು ಎಂದಿಗೂ ಭಾಷಾಂತರಿಸದಿರಿ</translation>
+<translation id="773466115871691567">ಯಾವಾಗಲು <ph name="SOURCE_LANGUAGE"/> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು ಅನುವಾದ ಮಾಡಿ</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು ಎಂದಿಗೂ ಅನುವಾದ ಮಾಡಬೇಡಿ</translation>
+<translation id="124116460088058876">ಹೆಚ್ಚಿನ ಭಾಷೆಗಳು</translation>
+<translation id="290376772003165898"><ph name="LANGUAGE"/> ನಲ್ಲಿನ ಪುಟ ಇಲ್ಲವೇ?</translation>
+<translation id="4432792777822557199">ಈಗಿನಿಂದಲೇ <ph name="SOURCE_LANGUAGE"/> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು <ph name="TARGET_LANGUAGE"/> ಗೆ ಅನುವಾದ ಮಾಡಲಾಗುತ್ತದೆ</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು ಅನುವಾದ ಮಾಡಲಾಗುವುದಿಲ್ಲ</translation>
+<translation id="5447765697759493033">ಈ ಸೈಟ್ ಅನ್ನು ಅನುವಾದಿಸಲಾಗುವುದಿಲ್ಲ</translation>
+<translation id="4880127995492972015">ಅನುವಾದಿಸಿ…</translation>
+<translation id="641643625718530986">ಮುದ್ರಿಸು...</translation>
+<translation id="8909135823018751308">ಹಂಚಿಕೊಳ್ಳು...</translation>
+<translation id="4996978546172906250">ಇದರ ಮೂಲಕ ಹಂಚಿ</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> ಮೂಲಕ ಹಂಚು</translation>
+<translation id="6277522088822131679">ಪುಟವನ್ನು ಮುದ್ರಿಸುವಲ್ಲಿ ಸಮಸ್ಯೆ ಕಂಡುಬಂದಿದೆ. ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</translation>
+<translation id="3254409185687681395">ಈ ಪುಟ ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಿ</translation>
+<translation id="497421865427891073">ಮುಂದಕ್ಕೆ ಹೋಗು</translation>
+<translation id="813082847718468539">ಸೈಟ್ ಮಾಹಿತಿಯನ್ನು ವೀಕ್ಷಿಸಿ</translation>
+<translation id="2532336938189706096">ವೆಬ್ ವೀಕ್ಷಣೆ</translation>
+<translation id="6005538289190791541">ಸೂಚಿಸಿದ ಪಾಸ್‌ವರ್ಡ್</translation>
+<translation id="4634124774493850572">ಪಾಸ್‌ವರ್ಡ್ ಬಳಸಿ</translation>
+<translation id="8285489906452138776">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಕ್ಯಾಮರಾ ಪ್ರವೇಶಿಸಲು Brave ಗೆ ಅನುಮತಿಸುವ ಅಗತ್ಯವಿದೆ.</translation>
+<translation id="320189792589364011">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಮೈಕ್ರೊಫೋನ್ ಪ್ರವೇಶಿಸಲು Brave ಗೆ ಅನುಮತಿಸುವ ಅಗತ್ಯವಿದೆ.</translation>
+<translation id="7988136689212463100">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಕ್ಯಾಮರಾ ಮತ್ತು ಮೈಕ್ರೊಫೋನ್ ಪ್ರವೇಶಿಸಲು Brave ಗೆ ಅನುಮತಿಸುವ ಅಗತ್ಯವಿದೆ.</translation>
+<translation id="4931190655840828017">ಈ ಸೈಟ್‌ ಮೂಲಕ ನಿಮ್ಮ ಸ್ಥಳವನ್ನು ಹಂಚಿಕೊಳ್ಳಲು Brave ಗೆ ನಿಮ್ಮ ಸ್ಥಳದ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ.</translation>
+<translation id="3088191967551450609">ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು Brave ಗೆ ಸಂಗ್ರಹಣೆ ಪ್ರವೇಶ ಅಗತ್ಯವಿದೆ.</translation>
+<translation id="8942627711005830162">ಇತರ ವಿಂಡೋದಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="4195643157523330669">ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="1100066534610197918">ಗುಂಪಿನ ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆ</translation>
+<translation id="4860895144060829044">ಕರೆ</translation>
+<translation id="6896758677409633944">ನಕಲಿಸು</translation>
+<translation id="8393700583063109961">ಸಂದೇಶ ಕಳುಹಿಸು</translation>
+<translation id="3557336313807607643">ಸಂಪರ್ಕಗಳಿಗೆ ಸೇರಿಸಿ</translation>
+<translation id="4269820728363426813">ಲಿಂಕ್ ವಿಳಾಸವನ್ನು ನಕಲಿಸಿ</translation>
+<translation id="1206892813135768548">ಲಿಂಕ್ ಪಠ್ಯವನ್ನು ನಕಲಿಸಿ</translation>
+<translation id="1204037785786432551">ಲಿಂಕ್ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="6864459304226931083">ಚಿತ್ರ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="8209050860603202033">ಚಿತ್ರವನ್ನು ತೆರೆಯಿರಿ</translation>
+<translation id="8073388330009372546">ಚಿತ್ರವನ್ನು ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ  ತೆರೆಯಿರಿ</translation>
+<translation id="6649642165559792194">ಚಿತ್ರವನ್ನು ಪೂರ್ವವೀಕ್ಷಿಸಿ <ph name="BEGIN_NEW"/>ಹೊಸದು<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">ಚಿತ್ರ ಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="3845332215609790146">Brave Software ಲೆನ್ಸ್ ಮೂಲಕ ಹುಡುಕಿ<ph name="BEGIN_NEW"/>ಹೊಸತು<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">ಈ ಚಿತ್ರಕ್ಕಾಗಿ <ph name="SEARCH_ENGINE"/> ನಲ್ಲಿ ಹುಡುಕಾಡಿ</translation>
+<translation id="3384347053049321195">ಚಿತ್ರ ಹಂಚಿಕೊಳ್ಳಿ</translation>
+<translation id="5833984609253377421">ಲಿಂಕ್ ಹಂಚಿಕೊಳ್ಳಿ</translation>
+<translation id="6475951671322991020">ವೀಡಿಯೊ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="2317945146070194624">ಹೊಸ Brave ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="7975379999046275268">ಪುಟ ಪೂರ್ವವೀಕ್ಷಿಸಿ <ph name="BEGIN_NEW"/>ಹೊಸದು<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">ಪುಟವನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಲಾಗುತ್ತಿದೆ</translation>
+<translation id="36525718899759834">Brave Software Play Store ನಿಂದ ಅಪ್ಲಿಕೇಶನ್ ಪಡೆದುಕೊಳ್ಳಿ: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">ಗಾಢ</translation>
+<translation id="1807246157184219062">ತಿಳಿ</translation>
+<translation id="4056223980640387499">ಸೆಪಿಯಾ</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">ಮೊನೋಸ್ಪೇಸ್</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">ಬೀಮ್‌ ಗೆ ಟ್ಯಾಬ್ ಅನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="8719023831149562936">ಪ್ರಸ್ತುತ ಟ್ಯಾಬ್ ಅನ್ನು ಬೀಮ್ ಮಾಡಲಾಗುವುದಿಲ್ಲ</translation>
+<translation id="2139186145475833000">ಹೋಮ್ ಪರದೆಗೆ ಸೇರಿಸಿ</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> ತೆರೆಯಿರಿ</translation>
+<translation id="2122601567107267586">ಅಪ್ಲಿಕೇಶನ್ ತೆರೆಯಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
+<translation id="5129038482087801250">ವೆಬ್ ಆ್ಯಪ್ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ</translation>
+<translation id="3789841737615482174">ಇನ್‌ಸ್ಟಾಲ್</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> ಅನ್ನು ನಿಮ್ಮ ಹೋಮ್ ಪರದೆಗೆ ಸೇರಿಸಲಾಗಿದೆ</translation>
 <translation id="7333031090786104871">ಇನ್ನೂ ಹಿಂದಿನ ಸೈಟ್ ಅನ್ನು ಸೇರಿಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="7352939065658542140">ವೀಡಿಯೊ</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> ಅನ್ನು ಸೇರಿಸಲಾಗುತ್ತಿದೆ...</translation>
+<translation id="3778956594442850293">ಹೋಮ್‌ನ ಪರದೆಗೆ ಸೇರಿಸಲಾಗಿದೆ</translation>
+<translation id="2146738493024040262">ತತ್‌ಕ್ಷಣದ ಅಪ್ಲಿಕೇಶನ್ ತೆರೆಯಿರಿ</translation>
+<translation id="7016516562562142042">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್‌ಗೆ ಅನುಮತಿಸಲಾಗಿದೆ</translation>
+<translation id="6177111841848151710">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್‌ಗೆ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
+<translation id="145097072038377568">Android ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಆಫ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="8007176423574883786">ಈ ಸಾಧನಕ್ಕೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="164269334534774161">ನೀವು <ph name="CREATION_TIME"/> ದಿನಾಂಕದಿಂದ ಈ ಪುಟದ ಆಫ್‌ಲೈನ್‌ ನಕಲನ್ನು ವೀಕ್ಷಿಸುತ್ತಿರುವಿರಿ</translation>
+<translation id="4594952190837476234">ಈ ಆಫ್‍ಲೈನ್ ಪುಟವನ್ನು <ph name="CREATION_TIME"/> ರಂದು ರಚಿಸಲಾಗಿದೆ ಮತ್ತು ಇದು ಆನ್‌ಲೈನ್ ಆವೃತ್ತಿಗಿಂತ ಭಿನ್ನವಾಗಿರಬಹುದು.</translation>
+<translation id="8840953339110955557">ಈ ಪುಟವು ಆನ್‌ಲೈನ್ ಆವೃತ್ತಿಗಿಂತ ಭಿನ್ನವಾಗಿರಬಹುದು.</translation>
+<translation id="6405300764336705484"><ph name="DOMAIN_NAME"/> ಡೊಮೇನ್‌‌ನ ಈ ವಿಷಯವನ್ನು Brave Software ನಿಂದ ವಿತರಿಸಲಾಗಿದೆ.</translation>
+<translation id="1006017844123154345">ಆನ್‌ಲೈನ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="3326636747541519688">Lite ಪುಟವನ್ನು Brave Software ಒದಗಿಸಿದೆ</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> ನಿಂದ <ph name="BEGIN_LINK"/>ಮೂಲ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಿ<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">ಇದನ್ನು ನೀವು ಪದೇ ಪದೇ ವೀಕ್ಷಿಸುತ್ತಿದ್ದರೆ, ಈ <ph name="BEGIN_LINK"/>ಸಲಹೆಗಳನ್ನು<ph name="END_LINK"/> ಪ್ರಯತ್ನಿಸಿ.</translation>
+<translation id="8748850008226585750">ವಿಷಯಗಳನ್ನು ಮರೆಮಾಡಲಾಗಿದೆ</translation>
+<translation id="3810973564298564668">ನಿರ್ವಹಿಸು</translation>
+<translation id="5199929503336119739">ಕೆಲಸದ ಪ್ರೊಫೈಲ್</translation>
+<translation id="528192093759286357">ಪೂರ್ಣಪರದೆಯನ್ನು ನಿರ್ಗಮಿಸಲು ಮೇಲಿನಿಂದ ಡ್ರ್ಯಾಗ್ ಮಾಡಿ ಹಾಗೂ ಹಿಂದೆ ಬಟನ್ ಸ್ಪರ್ಶಿಸಿ.</translation>
+<translation id="2836148919159985482">ಪೂರ್ಣಪರದೆಯನ್ನು ನಿರ್ಗಮಿಸಲು ಹಿಂದೆ ಬಟನ್ ಸ್ಪರ್ಶಿಸಿ.</translation>
+<translation id="3967822245660637423">ಡೌನ್‌ಲೋಡ್‌‌ ಪೂರ್ಣಗೊಂಡಿದೆ</translation>
+<translation id="2434158240863470628">ಡೌನ್‌ಲೋಡ್‌‌ ಪೂರ್ಣಗೊಂಡಿದೆ <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">ಡೌನ್‌ಲೋಡ್‌ ವಿಫಲಗೊಂಡಿದೆ</translation>
+<translation id="1384959399684842514">ಡೌನ್‌ಲೋಡ್ ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ</translation>
+<translation id="1671236975893690980">ಡೌನ್‌ಲೋಡ್ ಬಾಕಿ ಉಳಿದಿದೆ...</translation>
+<translation id="5561549206367097665">ನೆಟ್‌ವರ್ಕ್‌ಗಾಗಿ ನಿರೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ…</translation>
+<translation id="5864419784173784555">ಇನ್ನೊಂದು ಡೌನ್‌ಲೋಡ್‌ಗಾಗಿ ಕಾಯಲಾಗುತ್ತಿದೆ…</translation>
+<translation id="6461962085415701688">ಫೈಲ್ ತೆರೆಯಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ</translation>
+<translation id="1178581264944972037">ವಿರಾಮ</translation>
+<translation id="8200772114523450471">ಪುನರಾರಂಭಿಸು</translation>
+<translation id="1409879593029778104">ಫೈಲ್ ಈಗಾಗಲೇ ಇರುವುದರಿಂದ <ph name="FILE_NAME"/> ಡೌನ್‌ಲೋಡ್ ತಡೆಯಲಾಗಿದೆ.</translation>
+<translation id="3387650086002190359">ಫೈಲ್ ಸಿಸ್ಟಂ ದೋಷಗಳ ಕಾರಣದಿಂದಾಗಿ <ph name="FILE_NAME"/> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
+<translation id="6482749332252372425">ಸಂಗ್ರಹಣೆ ಸ್ಥಳದ ಕೊರತೆಯ ಕಾರಣದಿಂದ <ph name="FILE_NAME"/> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
+<translation id="7619072057915878432">ನೆಟ್‌ವರ್ಕ್ ವೈಫಲ್ಯಗಳ ಕಾರಣದಿಂದ <ph name="FILE_NAME"/> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
+<translation id="1477626028522505441">ಸರ್ವರ್ ಸಮಸ್ಯೆಗಳ ಕಾರಣದಿಂದಾಗಿ <ph name="FILE_NAME"/> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
+<translation id="3692944402865947621">ಸಂಗ್ರಹಣೆ ಸ್ಥಳವನ್ನು ತಲುಪಲು ಸಾಧ್ಯವಾಗದ ಕಾರಣ <ph name="FILE_NAME"/> ಅನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲು ಸಾಧ್ಯವಾಗಿಲ್ಲ.</translation>
+<translation id="604996488070107836">ಅಪರಿಚಿತ ದೋಷದ ಕಾರಣದಿಂದ <ph name="FILE_NAME"/> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
+<translation id="6738867403308150051">ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="FILE_SIZE_WITH_UNITS"/> ರಲ್ಲಿ <ph name="BYTES_DOWNLOADED_WITH_UNITS"/> ಡೌನ್‌ಲೋಡ್ ಆಗಿದೆ</translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="9204836675896933765">1 ಫೈಲ್ ಬಾಕಿ ಉಳಿದಿದೆ</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> ಬಾಕಿ ಉಳಿದಿರುವ ಫೈಲ್‌ಗಳು</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> ಫೈಲ್ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಿದೆ}one{<ph name="FILES_DOWNLOADED_MANY"/> ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಿದೆ}other{<ph name="FILES_DOWNLOADED_MANY"/> ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಿದೆ}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> ದಿನಗಳು ಉಳಿದಿವೆ</translation>
+<translation id="8190358571722158785">1 ದಿನ ಉಳಿದಿದೆ</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> ಗಂಟೆಗಳು ಉಳಿದಿವೆ</translation>
+<translation id="510275257476243843">1 ಗಂಟೆ ಉಳಿದಿದೆ</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> ನಿಮಿಷಗಳು ಉಳಿದಿವೆ</translation>
+<translation id="3236059992281584593">1 ನಿಮಿಷ ಉಳಿದಿದೆ</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> ಸೆಕೆಂಡುಗಳು ಉಳಿದಿವೆ</translation>
+<translation id="2781151931089541271">1 ಸೆಕೆಂಡು ಉಳಿದಿದೆ</translation>
+<translation id="3303414029551471755">ವಿಷಯವನ್ನು ಡೌನ್‌ಲೊಡ್‌ ಮಾಡಲು ಮುಂದುವರಿಯುವುದೇ?</translation>
+<translation id="8617240290563765734">ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾದ ವಿಷಯದಲ್ಲಿ ಸೂಚಿಸಲಾದ ನಿರ್ದಿಷ್ಟ URL ತೆರೆಯುವುದೇ?</translation>
+<translation id="1373696734384179344">ಆಯ್ಕೆಮಾಡಲಾದ ವಿಷಯವನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲು ಮೆಮೊರಿಯು ಸಾಕಾಗುವುದಿಲ್ಲ.</translation>
+<translation id="5271967389191913893">ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಬೇಕಾದ ವಿಷಯವನ್ನು ಸಾಧನಕ್ಕೆ ತೆರೆಯಲಾಗುತ್ತಿಲ್ಲ.</translation>
+<translation id="883806473910249246">ವಿಷಯವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತಿರುವಾಗ ದೋಷ ಸಂಭವಿಸಿದೆ.</translation>
+<translation id="5626134646977739690">ಹೆಸರು:</translation>
+<translation id="7963646190083259054">ಮಾರಾಟಗಾರ:</translation>
+<translation id="3414952576877147120">ಗಾತ್ರ:</translation>
+<translation id="7375125077091615385">ಪ್ರಕಾರ:</translation>
+<translation id="5765780083710877561">ವಿವರಣೆ:</translation>
+<translation id="4881695831933465202">ತೆರೆ</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB ಲಭ್ಯವಿದೆ</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB  ಲಭ್ಯವಿದೆ</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB ಲಭ್ಯವಿದೆ</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/> ಯಲ್ಲಿ <ph name="SPACE_USED"/> ಬಳಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="3587482841069643663">ಎಲ್ಲ</translation>
+<translation id="4988526792673242964">ಪುಟಗಳು</translation>
+<translation id="3810838688059735925">ವೀಡಿಯೊ</translation>
+<translation id="3616113530831147358">ಆಡಿಯೋ</translation>
+<translation id="9219103736887031265">ಚಿತ್ರಗಳು</translation>
+<translation id="8250920743982581267">ಡಾಕ್ಯುಮೆಂಟ್‌ಗಳು</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ಫೈಲ್}one{# ಫೈಲ್‌ಗಳು}other{# ಫೈಲ್‌ಗಳು}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ಚಿತ್ರ}one{# ಚಿತ್ರಗಳು}other{# ಚಿತ್ರಗಳು}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# ವೀಡಿಯೊ}one{# ವೀಡಿಯೊಗಳು}other{# ವೀಡಿಯೊಗಳು}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ಆಡಿಯೋ ಫೈಲ್}one{# ಆಡಿಯೋ ಫೈಲ್‌ಗಳು}other{# ಆಡಿಯೋ ಫೈಲ್‌ಗಳು}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# ಪುಟ}one{# ಪುಟಗಳು}other{# ಪುಟಗಳು}}</translation>
+<translation id="5456381639095306749">ಪುಟ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="2394602618534698961">ನೀವು ಡೌನ್‌ಲೋಡ್ ಮಾಡುವ ಫೈಲ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ</translation>
+<translation id="7810647596859435254">ಇದರೊಂದಿಗೆ ತೆರೆಯಿರಿ...</translation>
+<translation id="5655963694829536461">ನಿಮ್ಮ ಡೌನ್‌ಲೋಡ್‌ಗಳನ್ನು ಹುಡುಕಿ</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">ನನ್ನ ಫೈಲ್‌ಗಳು</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">ಲೇಖನಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ, ಅವುಗಳನ್ನು ನೀವು ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿರುವಾಗಲೂ ಸಹ ಓದಬಹುದಾಗಿದೆ</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ಗಂಟೆ}one{# ಗಂಟೆಗಳು}other{# ಗಂಟೆಗಳು}}</translation>
+<translation id="5853623416121554550">ವಿರಾಮಗೊಳಿಸಲಾಗಿದೆ</translation>
+<translation id="8965591936373831584">ಬಾಕಿ ಉಳಿದಿರುವುದು</translation>
+<translation id="2779651927720337254">ವಿಫಲವಾಗಿದೆ</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">ಇದೀಗ</translation>
+<translation id="4000212216660919741">ಆಫ್‌ಲೈನ್ ಹೋಮ್</translation>
+<translation id="9133397713400217035">ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ಎಕ್ಸ್‌ಪ್ಲೋರ್ ಮಾಡಿ</translation>
+<translation id="968900484120156207">ನೀವು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
+<translation id="7882131421121961860">ಯಾವುದೇ ಇತಿಹಾಸ ಕಂಡುಬಂದಿಲ್ಲ</translation>
+<translation id="3549657413697417275">ನಿಮ್ಮ ಇತಿಹಾಸವನ್ನು ಹುಡುಕಿ</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">ಮಿಮೀ</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave ಮೊದಲ ರನ್ ಅನುಭವ</translation>
+<translation id="2700285883409956633">ಈ ಅಪ್ಲಿಕೇಶನ್ ಬಳಸುವ ಮೂಲಕ, ನೀವು Brave ನ <ph name="BEGIN_LINK1"/>ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1"/> ಮತ್ತು <ph name="BEGIN_LINK2"/>ಗೌಪ್ಯತೆ ಪ್ರಕಟಣೆ<ph name="END_LINK2"/>ಗೆ ಸಮ್ಮತಿಸುತ್ತೀರಿ.</translation>
+<translation id="1640714894372474981">ಈ ಅಪ್ಲಿಕೇಶನ್ ಬಳಸುವ ಮೂಲಕ, ನೀವು Brave ನ <ph name="BEGIN_LINK1"/>ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1"/> ಮತ್ತು <ph name="BEGIN_LINK2"/>ಗೌಪ್ಯತೆಯ ಸೂಚನೆ<ph name="END_LINK2"/> ಗೆ ಮತ್ತು <ph name="BEGIN_LINK3"/>ಕುಟುಂಬದ ಲಿಂಕ್‌ನಲ್ಲಿ ನಿರ್ವಹಿಸಿದ Brave Software ಖಾತೆಗಳಿಗಾಗಿ ಗೌಪ್ಯತಾ ಸೂಚನೆಗಳನ್ನು<ph name="END_LINK3"/> ಸಮ್ಮತಿಸುತ್ತೀರಿ.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> Brave ನಲ್ಲಿ ತೆರೆಯುತ್ತದೆ. ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು Brave ನ <ph name="BEGIN_LINK1"/>ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1"/> ಮತ್ತು <ph name="BEGIN_LINK2"/>ಗೌಪ್ಯತಾ ಸೂಚನೆ<ph name="END_LINK2"/> ಗೆ ಒಪ್ಪುತ್ತಿರುವಿರಿ.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Brave ನಲ್ಲಿ ತೆರೆಯುತ್ತದೆ. ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು Brave ನ <ph name="BEGIN_LINK1"/>ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1"/> ಮತ್ತು <ph name="BEGIN_LINK2"/>ಗೌಪ್ಯತಾ ಸೂಚನೆ<ph name="END_LINK2"/>, ಮತ್ತು <ph name="BEGIN_LINK3"/>ಕುಟುಂಬ ಲಿಂಕ್ ಮೂಲಕ Brave Software ಖಾತೆಗಳಿಗಾಗಿ ನಿರ್ವಹಿಸಲಾದ ಗೌಪ್ಯತೆ ಸೂಚನೆ<ph name="END_LINK3"/>ಗೆ ಸಮ್ಮತಿಸುತ್ತೀರಿ.</translation>
+<translation id="673197144963363525">Brave Software ಗೆ ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳು ಮತ್ತು ಕ್ರ್ಯಾಶ್ ವರದಿಗಳನ್ನು ಕಳುಹಿಸುವ ಮೂಲಕ Brave ಅನ್ನು ಉತ್ತಮಗೊಳಿಸಲು ಸಹಾಯ ಮಾಡಿ.</translation>
+<translation id="3518985090088779359">ಸಮ್ಮತಿಸು &amp; ಮುಂದುವರಿಸು</translation>
+<translation id="7207456302801184289">Brave ಗೆ ಸ್ವಾಗತ</translation>
+<translation id="704822250101715322">Brave Software Play ಸೇವೆಗಳು ಅಪ್‌ಡೇಟ್ ಮಾಡುವಿಕೆಯನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ನಿರೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="1231733316453485619">ಸಿಂಕ್ ಆನ್ ಮಾಡುವುದೇ?</translation>
+<translation id="5132942445612118989">ಎಲ್ಲಾ ಸಾಧನಗಳಲ್ಲೂ ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು, ಇತಿಹಾಸ ಹಾಗೂ ಇನ್ನೂ ಹೆಚ್ಚಿನವುಗಳನ್ನು ಸಿಂಕ್ ಮಾಡಿ</translation>
+<translation id="5736731321935944068">ಹುಡುಕಾಟ, ಜಾಹೀರಾತುಗಳು ಮತ್ತು ಇತರ Brave Software ಸೇವೆಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಇತಿಹಾಸವನ್ನು Brave Software ಬಳಸಬಹುದು</translation>
+<translation id="4013614219085422040">ಹುಡುಕಾಟ ಮತ್ತು ಇತರ Brave Software ಸೇವೆಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಇತಿಹಾಸವನ್ನು Brave Software ಬಳಸಬಹುದು.</translation>
+<translation id="5581519193887989363">ನೀವು ಏನನ್ನು ಸಿಂಕ್ ಮಾಡಬೇಕು ಎಂಬುದನ್ನು <ph name="BEGIN_LINK1"/>ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ<ph name="END_LINK1"/> ಯಾವಾಗ ಬೇಕಾದರೂ ಆರಿಸಿಕೊಳ್ಳಬಹುದು.</translation>
+<translation id="741204030948306876">ಹೌದು, ನಾನಿದ್ದೇನೆ</translation>
+<translation id="2410754283952462441">ಖಾತೆಯೊಂದನ್ನು ಆರಿಸಿ</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> ನಂತೆ ಮುಂದುವರಿಸಿ</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> ಅಲ್ಲವೇ?</translation>
+<translation id="8109613176066109935">ನಿಮ್ಮ ಎಲ್ಲ ಸಾಧನಗಳಲ್ಲಿ ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್‌ ಆನ್‌ ಮಾಡಿ</translation>
+<translation id="2818669890320396765">ನಿಮ್ಮ ಎಲ್ಲಾ ಸಾಧನಗಳಲ್ಲಿ ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
+<translation id="6003646045106347985">Brave Software ಸಲಹೆ ನೀಡಿದ ವೈಯಕ್ತೀಕರಿಸಲಾದ ವಿಷಯವನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
+<translation id="8494430740943879273">Brave Software ಸಲಹೆ ನೀಡಿದ ವೈಯಕ್ತೀಕರಿಸಲಾದ ವಿಷಯವನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
+<translation id="5862731021271217234">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್‌ ಆನ್‌ ಮಾಡಿ</translation>
+<translation id="3568688522516854065">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
+<translation id="1208340532756947324">ಸಾಧನಗಳಾದ್ಯಂತ ಸಿಂಕ್ ಮಾಡಲು ಮತ್ತು ವೈಯಕ್ತೀಕರಿಸಲು, ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
+<translation id="4472118726404937099">ಸಾಧನಗಳಾದ್ಯಂತ ಸಿಂಕ್ ಮಾಡಲು ಮತ್ತು ವೈಯಕ್ತೀಕರಿಸಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
+<translation id="2426805022920575512">ಇನ್ನೊಂದು ಖಾತೆಯನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="6790428901817661496">ಪ್ಲೇ ಮಾಡು</translation>
+<translation id="1272079795634619415">ನಿಲ್ಲಿಸಿ</translation>
+<translation id="2874939134665556319">ಹಿಂದಿನ ಟ್ರ್ಯಾಕ್</translation>
+<translation id="4046123991198612571">ಮುಂದಿನ ಟ್ರ್ಯಾಕ್</translation>
+<translation id="3859306556332390985">ಮುಂದಕ್ಕೆ ಸೀಕ್ ಮಾಡಿ</translation>
+<translation id="8441146129660941386">ಹಿಂದಕ್ಕೆ ಸೀಕ್ ಮಾಡಿ</translation>
+<translation id="6706288973712894588">ನೀವು ಪ್ರಸ್ತುತವಾಗಿ ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿದ್ದೀರಿ.\n<ph name="BEGIN_LINK"/>ನಿಮ್ಮ ಆಫ್‌ಲೈನ್ ಫೀಡ್ ಅನ್ನು ಎಕ್ಸ್‌ಪ್ಲೋರ್ ಮಾಡಿ.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">ಇತ್ತೀಚಿನ ಟ್ಯಾಬ್‌ಗಳು</translation>
+<translation id="8497726226069778601">ಇಲ್ಲಿ ನೋಡಲು ಇನ್ನೂ ಏನೂ ಇಲ್ಲ...</translation>
+<translation id="5423934151118863508">ನಿವು ಹೆಚ್ಚು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
+<translation id="6127379762771434464">ಐಟಂ ತೆಗೆದುಹಾಕಲಾಗಿದೆ</translation>
+<translation id="4605958867780575332">ತೆಗೆದುಹಾಕಲಾಗಿರುವ ಐಟಂ: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software ಡೂಡಲ್‌: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">ಇತರ ಸಾಧನಗಳು</translation>
+<translation id="4738836084190194332">ಕೊನೆಯದಾಗಿ ಸಿಂಕ್ ಮಾಡಿರುವ ಸಮಯ: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# ನಿಮಿಷದ ಹಿಂದೆ}one{# ನಿಮಿಷಗಳ ಹಿಂದೆ}other{# ನಿಮಿಷಗಳ ಹಿಂದೆ}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# ಗಂಟೆಯ ಹಿಂದೆ}one{# ಗಂಟೆಗಳ ಹಿಂದೆ}other{# ಗಂಟೆಗಳ ಹಿಂದೆ}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# ದಿನದ ಹಿಂದೆ}one{# ದಿನಗಳ ಹಿಂದೆ}other{# ದಿನಗಳ ಹಿಂದೆ}}</translation>
+<translation id="2762000892062317888">ಈಗತಾನೇ</translation>
+<translation id="1407135791313364759">ಎಲ್ಲವನ್ನೂ ತೆರೆಯಿರಿ</translation>
+<translation id="1209206284964581585">ಸದ್ಯಕ್ಕೆ ಮರೆಮಾಡಿ</translation>
+<translation id="129553762522093515">ಇತ್ತೀಚೆಗೆ ಮುಚ್ಚಲಾಗಿರುವುದು</translation>
+<translation id="8413126021676339697">ಪೂರ್ತಿ ಇತಿಹಾಸವನ್ನು ತೋರಿಸಿ</translation>
+<translation id="7876243839304621966">ಎಲ್ಲವನ್ನೂ ತೆಗೆದುಹಾಕಿ</translation>
+<translation id="8487700953926739672">ಆಫ್‌ಲೈನ್ ಲಭ್ಯವಿದೆ</translation>
+<translation id="5224771365102442243">ವೀಡಿಯೊದ ಜೊತೆಗೆ</translation>
+<translation id="3493531032208478708">ಸೂಚಿಸಲಾದ ವಿಷಯದ ಕುರಿತು <ph name="BEGIN_LINK"/>ಇನ್ನಷ್ಟು ತಿಳಿಯಿರಿ<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">ಸಲಹೆಗಳನ್ನು ಪಡೆಯಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="5013696553129441713">ಯಾವುದೇ ಹೊಸ ಸಲಹೆಗಳಿಲ್ಲ</translation>
+<translation id="1736419249208073774">ಎಕ್ಸ್‌ಪ್ಲೋರ್ ಮಾಡಿ</translation>
+<translation id="7444811645081526538">ಇನ್ನಷ್ಟು ವರ್ಗಗಳು</translation>
+<translation id="6709133671862442373">ಸುದ್ದಿ</translation>
+<translation id="1264974993859112054">ಕ್ರೀಡೆ</translation>
+<translation id="9139318394846604261">ಶಾಪಿಂಗ್</translation>
+<translation id="3912508018559818924">ವೆಬ್‌ನಿಂದ ಅತ್ಯುತ್ತಮ ವಿಷಯಗಳನ್ನು ಹುಡುಕಲಾಗುತ್ತಿದೆ…</translation>
+<translation id="526421993248218238">ಈ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="614940544461990577">ಪ್ರಯತ್ನಿಸಿ:</translation>
+<translation id="3288003805934695103">ಪುಟ ಮರುಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</translation>
+<translation id="2353636109065292463">ನಿಮ್ಮ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="2858138569776157458">ಟಾಪ್ ಸೈಟ್</translation>
+<translation id="8364299278605033898">ಜನಪ್ರಿಯ ವೆಬ್‌ಸೈಟ್‌ಗಳನ್ನು ನೋಡಿ</translation>
+<translation id="1171770572613082465">"ಉನ್ನತ ಸೈಟ್‌ಗಳು" ಬಟನ್ ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕ ಜನಪ್ರಿಯ ವೆಬ್‌ಸೈಟ್‌ಗಳನ್ನು ನೋಡಿ</translation>
+<translation id="5233638681132016545">ಹೊಸ ಟ್ಯಾಬ್</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/> ಅವರಿಂದ – <ph name="BEGIN_DEEMPHASIZED"/>Brave Software ನಿಂದ ವಿತರಿಸಲಾಗಿದೆ<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">ಹೊಸ ಆವೃತ್ತಿಯು ಲಭ್ಯವಿದೆ</translation>
+<translation id="4058091506841967397">Brave ಅಪ್‌ಡೇಟ್ ಮಾಡಲಾಗದು</translation>
+<translation id="6316139424528454185">Android ಆವೃತ್ತಿಗೆ ಬೆಂಬಲವಿಲ್ಲ</translation>
+<translation id="6989267951144302301">ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಲಿಲ್ಲ</translation>
+<translation id="624789221780392884">ಅಪ್‌ಡೇಟ್‌‌ ಸಿದ್ಧವಾಗಿದೆ</translation>
+<translation id="1549000191223877751">ಇತರ ವಿಂಡೋಗೆ ಸರಿಸಿ</translation>
+<translation id="7481312909269577407">ಫಾರ್ವರ್ಡ್</translation>
+<translation id="4084682180776658562">ಬುಕ್‌ಮಾರ್ಕ್</translation>
+<translation id="6437478888915024427">ಪುಟದ ಮಾಹಿತಿ</translation>
+<translation id="7180611975245234373">ರಿಫ್ರೆಶ್ ಮಾಡಿ</translation>
+<translation id="4913169188695071480">ರಿಫ್ರೆಶ್ ಮಾಡುವಿಕೆ ನಿಲ್ಲಿಸಿ</translation>
+<translation id="1829244130665387512">ಪುಟದಲ್ಲಿ ಹುಡುಕಿ</translation>
+<translation id="6593061639179217415">ಡೆಸ್ಕ್‌ಟಾಪ್‌ ಸೈಟ್‌</translation>
+<translation id="9063523880881406963">ಡೆಸ್ಕ್‌ಟಾಪ್ ಸೈಟ್ ವಿನಂತಿಯನ್ನು ಆಫ್ ಮಾಡಿ</translation>
+<translation id="2038563949887743358">ಡೆಸ್ಕ್‌ಟಾಪ್ ಸೈಟ್ ವಿನಂತಿಯನ್ನು ಆನ್ ಮಾಡಿ</translation>
+<translation id="2433507940547922241">ಗೋಚರತೆ</translation>
+<translation id="983192555821071799">ಎಲ್ಲ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಮುಚ್ಚಿ</translation>
+<translation id="1310482092992808703">ಟ್ಯಾಬ್‌ಗಳನ್ನು ಗುಂಪು ಮಾಡಿ</translation>
+<translation id="7725024127233776428">ನೀವು ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡುವ ಪುಟಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
+<translation id="4404568932422911380">ಯಾವುದೇ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಲಭ್ಯವಿಲ್ಲ</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> ಬುಕ್‌ಮಾರ್ಕ್‌}one{<ph name="BOOKMARKS_COUNT_MANY"/> ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು}other{<ph name="BOOKMARKS_COUNT_MANY"/> ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> ನಲ್ಲಿ ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="3207960819495026254">ಬುಕ್‌ಮಾರ್ಕ್‌ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> ಗೆ ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಲಾಗಿದೆ</translation>
+<translation id="8063895661287329888">ಬುಕ್‌ಮಾರ್ಕ್‌ ಸೇರಿಸಲು ವಿಫಲವಾಗಿದೆ.</translation>
+<translation id="2842985007712546952">ಮೂಲ ಫೋಲ್ಡರ್‌</translation>
+<translation id="9065203028668620118">ಎಡಿಟ್</translation>
+<translation id="4405224443901389797">ಇದಕ್ಕೆ ಸರಿಸಿ…</translation>
+<translation id="5170568018924773124">ಫೋಲ್ಡರ್‌ನಲ್ಲಿ ತೋರಿಸಿ</translation>
+<translation id="8035133914807600019">ಹೊಸ ಫೋಲ್ಡರ್‌…</translation>
+<translation id="4532845899244822526">ಫೋಲ್ಡರ್‌ ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="6627583120233659107">ಫೋಲ್ಡರ್ ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="1197267115302279827">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಚಲಿಸಿ</translation>
+<translation id="6963766334940102469">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಅಳಿಸಿ</translation>
+<translation id="4351244548802238354">ಸಂವಾದವನ್ನು ಮುಚ್ಚಿ</translation>
+<translation id="451872707440238414">ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಹುಡುಕಿ</translation>
+<translation id="8901170036886848654">ಯಾವುದೇ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಕಂಡುಬಂದಿಲ್ಲ</translation>
+<translation id="6404511346730675251">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಎಡಿಟ್ ಮಾಡಿ</translation>
+<translation id="3894427358181296146">ಫೋಲ್ಡರ್ ಸೇರಿಸು</translation>
+<translation id="5327248766486351172">ಹೆಸರು</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">ಫೋಲ್ಡರ್</translation>
+<translation id="5161254044473106830">ಶೀರ್ಷಿಕೆ ಅಗತ್ಯವಿದೆ</translation>
+<translation id="2996809686854298943">URL ಅಗತ್ಯವಿದೆ</translation>
+<translation id="2536728043171574184">ಈ ಪುಟದ ಆಫ್‌ಲೈನ್ ನಕಲನ್ನು ವೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> ನಲ್ಲಿ ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ಮತ್ತು ಹೆಚ್ಚಿನ ಸೈಟ್‌ಗಳು</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{ಸಿದ್ಧವಾದಾಗ, ನಿಮ್ಮ ಪುಟವನ್ನು Brave ಲೋಡ್ ಮಾಡುತ್ತದೆ}one{ಸಿದ್ಧವಾದಾಗ, ನಿಮ್ಮ ಪುಟಗಳನ್ನು Brave ಲೋಡ್ ಮಾಡುತ್ತದೆ}other{ಸಿದ್ಧವಾದಾಗ, ನಿಮ್ಮ ಪುಟಗಳನ್ನು Brave ಲೋಡ್ ಮಾಡುತ್ತದೆ}}</translation>
+<translation id="6811034713472274749">ವೀಕ್ಷಿಸಲು ಪುಟ ಸಿದ್ಧವಾಗಿದೆ</translation>
+<translation id="4561979708150884304">ಯಾವುದೇ ಸಂಪರ್ಕವಿಲ್ಲ</translation>
+<translation id="8274165955039650276">ಡೌನ್‌ಲೋಡ್‌ಗಳನ್ನು ನೋಡಿ</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/> ರಲ್ಲಿ <ph name="RESULT_NUMBER"/> ಫಲಿತಾಂಶಗಳು</translation>
+<translation id="4943872375798546930">ಯಾವುದೇ ಫಲಿತಾಂಶಗಳಿಲ್ಲ</translation>
+<translation id="981121421437150478">ಆಫ್‌ಲೈನ್</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">ಯಾವುದೇ ಸಕ್ರಿಯಗೊಳಿಸಿದ ಧ್ವನಿ ಹುಡುಕಾಟ ಲಭ್ಯವಿಲ್ಲ</translation>
+<translation id="7191430249889272776">ಟ್ಯಾಬ್ ಅನ್ನು ಹಿನ್ನೆಲೆಯಲ್ಲಿ ತೆರೆಯಲಾಗಿದೆ.</translation>
+<translation id="8445059357334030806">Brave ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/> ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="7022756207310403729">ಬ್ರೌಸರ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="1113597929977215864">ಸರಳೀಕೃತ ವೀಕ್ಷಣೆಯನ್ನು ತೋರಿಸಿ</translation>
+<translation id="1513352483775369820">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಮತ್ತು ವೆಬ್ ಇತಿಹಾಸ</translation>
+<translation id="4939482511480190003">Brave ಸುಧಾರಣೆಗೆ ಸಹಾಯ ಮಾಡಿ. <ph name="BEGIN_LINK"/>ಸಮೀಕ್ಷೆಯಲ್ಲಿ ಭಾಗವಹಿಸಿ<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">ಹಿಂದಿರುಗಿ</translation>
+<translation id="5596627076506792578">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು</translation>
+<translation id="3522247891732774234">ಅಪ್‌ಡೇಟ್‌ ಲಭ್ಯವಿದೆ. ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು</translation>
+<translation id="6773423637732432200">Brave ಅಪ್‌ಡೇಟ್ ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ. ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು</translation>
+<translation id="3328801116991980348">ಸೈಟ್ ಮಾಹಿತಿ</translation>
+<translation id="5391532827096253100">ಈ ಸೈಟ್‌ಗೆ ನಿಮ್ಮ ಸಂಪರ್ಕವು ಸುರಕ್ಷಿತವಾಗಿಲ್ಲ. ಸೈಟ್ ಮಾಹಿತಿ</translation>
+<translation id="6206551242102657620">ಸಂಪರ್ಕ ಸುರಕ್ಷಿತವಾಗಿದೆ. ಸೈಟ್ ಮಾಹಿತಿ</translation>
+<translation id="6963642900430330478">ಈ ಪುಟವು ಅಪಾಯಕಾರಿಯಾಗಿದೆ. ಸೈಟ್ ಮಾಹಿತಿ</translation>
+<translation id="9070377983101773829">ಧ್ವನಿ ಹುಡುಕಾಟವನ್ನು ಪ್ರಾರಂಭಿಸಿ</translation>
+<translation id="8676374126336081632">ಇನ್‌ಪುಟ್‌‌ ತೆರವುಗೊಳಿಸು</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> ಟ್ಯಾಬ್ ತೆರೆದಿದೆ, ಟ್ಯಾಬ್‌ಗಳನ್ನು ಬದಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ}one{<ph name="OPEN_TABS_MANY"/> ಟ್ಯಾಬ್‌ಗಳು ತೆರೆದಿವೆ, ಟ್ಯಾಬ್‌ಗಳನ್ನು ಬದಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ}other{<ph name="OPEN_TABS_MANY"/> ಟ್ಯಾಬ್‌ಗಳು ತೆರೆದಿವೆ, ಟ್ಯಾಬ್‌ಗಳನ್ನು ಬದಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ}}</translation>
+<translation id="2369533728426058518">ತೆರೆದ ಟ್ಯಾಬ್‌ಗಳು</translation>
+<translation id="7071521146534760487">ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ</translation>
+<translation id="932327136139879170">ಹೋಮ್</translation>
+<translation id="2707726405694321444">ಪುಟವನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಿ</translation>
+<translation id="2891154217021530873">ಪುಟ ಲೋಡ್ ಮಾಡುವುದನ್ನು ನಿಲ್ಲಿಸಿ</translation>
+<translation id="6710213216561001401">ಹಿಂದೆ</translation>
+<translation id="6659594942844771486">ಟ್ಯಾಬ್</translation>
+<translation id="1933845786846280168">ಟ್ಯಾಬ್ ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</translation>
+<translation id="2268044343513325586">ಪರಿಷ್ಕರಿಸು</translation>
+<translation id="7846076177841592234">ಆಯ್ಕೆ ರದ್ದುಮಾಡಿ</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> ಅನ್ನು ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ. ಪರದೆಯ ಮೇಲ್ಭಾಗದಲ್ಲಿ ಲಭ್ಯವಿರುವ ಆಯ್ಕೆಗಳು</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> ಅನ್ನು ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</translation>
 <translation id="7353894246028566792">{NUM_SELECTED,plural, =1{ಆಯ್ಕೆಮಾಡಲಾದ 1 ಐಟಂ ಹಂಚಿಕೊಳ್ಳಿ}one{ಆಯ್ಕೆಮಾಡಲಾದ # ಐಟಂಗಳನ್ನು ಹಂಚಿಕೊಳ್ಳಿ}other{ಆಯ್ಕೆಮಾಡಲಾದ # ಐಟಂಗಳನ್ನು ಹಂಚಿಕೊಳ್ಳಿ}}</translation>
-<translation id="7359002509206457351">ಪಾವತಿ ವಿಧಾನಗಳನ್ನು ಪ್ರವೇಶಿಸಿ</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{ಆಯ್ಕೆಮಾಡಲಾದ 1 ಐಟಂ ತೆಗೆದುಹಾಕಿ}one{ಆಯ್ಕೆಮಾಡಲಾದ # ಐಟಂಗಳನ್ನು ತೆಗೆದುಹಾಕಿ}other{ಆಯ್ಕೆಮಾಡಲಾದ # ಐಟಂಗಳನ್ನು ತೆಗೆದುಹಾಕಿ}}</translation>
+<translation id="1283039547216852943">ವಿಸ್ತರಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
+<translation id="5962718611393537961">ಕುಗ್ಗಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
+<translation id="8076492880354921740">ಟ್ಯಾಬ್‌ಗಳು</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ}one{# ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ}other{# ಆಯ್ಕೆ ಮಾಡಲಾಗಿದೆ}}</translation>
+<translation id="6818926723028410516">ಐಟಂಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/> ಗೆ ಹಿಂತಿರುಗಲು ಸ್ಪರ್ಶಿಸಿ</translation>
+<translation id="6766758767654711248">ಸೈಟ್‌ಗೆ ಹೋಗಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
+<translation id="429312253194641664">ಒಂದು ಸೈಟ್, ಮಾಧ್ಯಮವನ್ನು ಪ್ಲೇ ಮಾಡುತ್ತಿದೆ</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> ನಿಮ್ಮ ಪರದೆಯನ್ನು ಹಂಚಿಕೊಳ್ಳುತ್ತಿದೆ</translation>
+<translation id="8833831881926404480">ನಿಮ್ಮ ಸ್ಕ್ರೀನ್ ಅನ್ನು ಒಂದು ಸೈಟ್ ಹಂಚಿಕೊಳ್ಳುತ್ತಿದೆ</translation>
+<translation id="9086455579313502267">ನೆಟ್‌ವರ್ಕ್ ಅನ್ನು ಪ್ರವೇಶಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="938850635132480979">ದೋಷ: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/> ರಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="548278423535722844">ನಕ್ಷೆಗಳ ಅಪ್ಲಿಕೇಶನ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> ನಲ್ಲಿ ಇಮೇಲ್ ರಚಿಸಿ</translation>
+<translation id="7875915731392087153">ಇಮೇಲ್ ರಚಿಸಿ</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> ನಲ್ಲಿ ಈವೆಂಟ್ ಅನ್ನು ರಚಿಸಿ</translation>
+<translation id="2900528713135656174">ಈವೆಂಟ್ ರಚಿಸು</translation>
+<translation id="2111511281910874386">ಪುಟಕ್ಕೆ ಹೋಗಿ</translation>
+<translation id="3988466920954086464">ಈ ಫಲಕದಲ್ಲಿ ತತ್‌ಕ್ಷಣ ಹುಡುಕಾಟ ಫಲಿತಾಂಶಗಳನ್ನು ನೋಡಿ</translation>
+<translation id="2744248271121720757">ತತ್‌ಕ್ಷಣ ಹುಡುಕಲು ಅಥವಾ ಸಂಬಂಧಿತ ಕ್ರಿಯೆಗಳನ್ನು ವೀಕ್ಷಿಸಲು ಪದವನ್ನು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
+<translation id="9155898266292537608">ನೀವು ಪದವನ್ನು ಕ್ಷಿಪ್ರವಾಗಿ ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕವೂ ಹುಡುಕಬಹುದು</translation>
+<translation id="3232754137068452469">ವೆಬ್ ಅಪ್ಲಿಕೇಶನ್</translation>
+<translation id="1430915738399379752">ಮುದ್ರಿಸು</translation>
+<translation id="3775705724665058594">ನಿಮ್ಮ ಸಾಧನಗಳಿಗೆ ಕಳುಹಿಸಿ</translation>
+<translation id="6364438453358674297">ಇತಿಹಾಸದಿಂದ ಸಲಹೆಯನ್ನು ತೆಗೆದುಹಾಕುವುದೇ?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> ಮುಚ್ಚಲಾಗಿದೆ</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> ಟ್ಯಾಬ್‌ಗಳನ್ನು ಮುಚ್ಚಲಾಗಿದೆ</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> ಅನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> ಡೌನ್‌ಲೋಡ್‌ಗಳನ್ನು ಅಳಿಸಲಾಗಿದೆ</translation>
+<translation id="1248710015876067820">ಬೆಂಬಲಿಸದಿರುವ Brave ನಿದರ್ಶನಗಳ ಸಂಖ್ಯೆ.</translation>
+<translation id="4259722352634471385">ನ್ಯಾವಿಗೇಶನ್‌ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ: <ph name="URL"/></translation>
+<translation id="8959122750345127698">ನ್ಯಾವಿಗೇಶನ್‌ ತಲುಪಲಾಗುವುದಿಲ್ಲ: <ph name="URL"/></translation>
+<translation id="5210365745912300556">ಟ್ಯಾಬ್ ಅನ್ನು ಮುಚ್ಚಿ</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> ಅನ್ನು ಮುಚ್ಚಿ</translation>
+<translation id="1227058898775614466">ನ್ಯಾವಿಗೇಶನ್ ಇತಿಹಾಸ</translation>
+<translation id="9169507124922466868">ನ್ಯಾವಿಗೇಷನ್ ಇತಿಹಾಸವು ಅರ್ಧ-ತೆರೆದಿದೆ</translation>
+<translation id="1327257854815634930">ನ್ಯಾವಿಗೇಶನ್ ಇತಿಹಾಸ ತೆರೆದಿದೆ</translation>
+<translation id="8788265440806329501">ನ್ಯಾವಿಗೇಶನ್ ಇತಿಹಾಸ ಮುಚ್ಚಿದೆ</translation>
+<translation id="7482656565088326534">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್</translation>
+<translation id="8427875596167638501">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್ ಅರ್ಧ ತೆರೆದಿದೆ</translation>
+<translation id="9102803872260866941">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್ ತೆರೆದಿದೆ</translation>
+<translation id="2942036813789421260">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್ ಮುಚ್ಚಿದೆ</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> ಸಂಗ್ರಹಣೆ</translation>
+<translation id="3822502789641063741">ಸೈಟ್ ಸಂಗ್ರಹಣೆ ತೆರವುಗೊಳಿಸುವುದೇ?</translation>
+<translation id="9205995714227143200">ಪ್ರಮುಖವಲ್ಲವೆಂದು Brave ಭಾವಿಸುವ ಸೈಟ್ ಸಂಗ್ರಹಣೆ (ಉದಾ. ಯಾವುದೇ ಉಳಿಸದ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಹೊಂದಿರುವ ಅಥವಾ ನೀವು ಆಗಾಗ್ಗೆ ಭೇಟಿ ನೀಡದ ಸೈಟ್‌ಗಳು)</translation>
+<translation id="3997476611815694295">ಪ್ರಮುಖವಲ್ಲದ ಸಂಗ್ರಹಣೆ</translation>
+<translation id="8493948351860045254">ಸ್ಥಳಾವಕಾಶವನ್ನು ಮುಕ್ತಗೊಳಿಸಿ</translation>
+<translation id="2324920234469020158">ಇದು ಕುಕೀಗಳು, ಕ್ಯಾಷ್ ಮತ್ತು ಪ್ರಮುಖವಲ್ಲವೆಂದು Brave ಭಾವಿಸುವ ಸೈಟ್‌ಗಳ ಇತರ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ.</translation>
+<translation id="5447201525962359567">ಕುಕೀಗಳು ಮತ್ತು ಇತರ ಸ್ಥಳೀಯವಾಗಿ ಸಂಗ್ರಹಿಸಿದ ಡೇಟಾ ಒಳಗೊಂಡು ಎಲ್ಲಾ ಸೈಟ್ ಸಂಗ್ರಹಣೆ</translation>
+<translation id="1376578503827013741">ಲೆಕ್ಕ ಮಾಡುತ್ತಿದೆ...</translation>
+<translation id="583281660410589416">ಅಪರಿಚಿತ</translation>
+<translation id="2323763861024343754">ಸೈಟ್ ಸಂಗ್ರಹಣೆ</translation>
+<translation id="3587672679800759167">ಖಾತೆಗಳು, ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಮತ್ತು ಉಳಿಸಿದ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಒಳಗೊಂಡಂತೆ Brave ಬಳಸಿದ ಒಟ್ಟು ಡೇಟಾ</translation>
+<translation id="6545017243486555795">ಎಲ್ಲಾ ಡೇಟಾ ತೆರವುಗೊಳಿಸು</translation>
+<translation id="4095146165863963773">ಅಪ್ಲಿಕೇಶನ್ ಡೇಟಾ ಅಳಿಸುವುದೇ?</translation>
+<translation id="53119194224775367">ಎಲ್ಲಾ Brave ಅಪ್ಲಿಕೇಶನ್ ಡೇಟಾವನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಲಾಗುತ್ತದೆ. ಇದು ಎಲ್ಲಾ ಫೈಲ್‌ಗಳು, ಸೆಟ್ಟಿಂಗ್‌ಗಳು, ಖಾತೆಗಳು, ಡೇಟಾಬೇಸ್‌ಗಳು, ಇತ್ಯಾದಿಗಳನ್ನು ಒಳಗೊಂಡಿರುತ್ತದೆ.</translation>
+<translation id="5307446750509046227">ಸೈಟ್ ಸಂಗ್ರಹಣೆಯನ್ನು ಅಳಿಸಿ</translation>
+<translation id="300526633675317032">ಇದು ವೆಬ್‌ಸೈಟ್ ಸಂಗ್ರಹಣೆಯ ಎಲ್ಲಾ <ph name="SIZE_IN_KB"/> ಅನ್ನು ತೆರವುಗೊಳಿಸುತ್ತದೆ.</translation>
+<translation id="8068648041423924542">ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.</translation>
+<translation id="2315043854645842844">ಕ್ಲೈಂಟ್‌ನ ಪ್ರಮಾಣಪತ್ರ ಆಯ್ಕೆಯನ್ನು ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂನಿಂದ ಬೆಂಬಲಿಸಲಾಗಿಲ್ಲ.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> ಸಂಪರ್ಕಿಸಲು ಬಯಸುತ್ತದೆ</translation>
+<translation id="5308380583665731573">ಸಂಪರ್ಕಿಸು</translation>
+<translation id="868929229000858085">ನಿಮ್ಮ ಸಂಪರ್ಕಗಳನ್ನು ಹುಡುಕಿ</translation>
+<translation id="1919950603503897840">ಸಂಪರ್ಕಗಳನ್ನು ಆಯ್ಕೆ ಮಾಡಿ</translation>
+<translation id="7986741934819883144">ಸಂಪರ್ಕವನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="3333961966071413176">ಎಲ್ಲಾ ಸಂಪರ್ಕಗಳು</translation>
+<translation id="4994033804516042629">ಯಾವುದೇ ಸಂಪರ್ಕಗಳು ಕಂಡುಬಂದಿಲ್ಲ</translation>
+<translation id="5403592356182871684">ಹೆಸರುಗಳು</translation>
+<translation id="2717722538473713889">ಇಮೇಲ್ ವಿಳಾಸಗಳು</translation>
+<translation id="381841723434055211">ಫೋನ್ ಸಂಖ್ಯೆಗಳು</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ಹೆಚ್ಚು)}one{(+ # ಹೆಚ್ಚು)}other{(+ # ಹೆಚ್ಚು)}}</translation>
+<translation id="5197729504361054390">ನೀವು ಆಯ್ಕೆ ಮಾಡುವ ಸಂಪರ್ಕಗಳನ್ನು <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> ಜೊತೆಗೆ ಹಂಚಿಕೊಳ್ಳಲಾಗುತ್ತದೆ.</translation>
+<translation id="1779089405699405702">ಚಿತ್ರದ ಡಿಕೋಡರ್</translation>
+<translation id="8067883171444229417">ವೀಡಿಯೊ ಪ್ಲೇ ಮಾಡಿ</translation>
+<translation id="6560414384669816528">Sogou ಜೊತೆಗೆ ಹುಡುಕಿ</translation>
+<translation id="5406914950576900927">Brave ಚೀನಾದಲ್ಲಿ ಹುಡುಕಲು <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> ಬಳಸಬಹುದು. ನೀವು ಇದನ್ನು <ph name="BEGIN_LINK"/>ಸೆಟ್ಟಿಂಗ್‌ಗಳು<ph name="END_LINK"/> ನಲ್ಲಿ ಬದಲಾಯಿಸಬಹುದು.</translation>
+<translation id="6456271171669383967">Brave Software ಇರಿಸಿಕೊಳ್ಳಿ</translation>
+<translation id="4384468725000734951">ಹುಡುಕಲು Sogou ಬಳಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="6103327872225198548">ಹುಡುಕಲು Brave Software ಬಳಸಲಾಗುತ್ತಿದೆ</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">ಈ ಆ್ಯಪ್‌, Brave ನಲ್ಲಿ ರನ್ ಆಗುತ್ತಿದೆ</translation>
+<translation id="6143689084714664628">Brave ನಲ್ಲಿ ಚಾಲನೆಯಾಗುತ್ತಿದೆ</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/>ಆ್ಯಪ್‌ನ ಡೇಟಾವು Brave ನಲ್ಲಿಯೂ ಇದೆ</translation>
+<translation id="2734140769649165081">ನೀವು ಡೇಟಾವನ್ನು Brave ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ತೆರವುಗೊಳಿಸಬಹುದು</translation>
+<translation id="8232956427053453090">ಡೇಟಾವನ್ನುಇರಿಸಿಕೊಳ್ಳಿ</translation>
+<translation id="4298388696830689168">ಲಿಂಕ್ ಮಾಡಿರುವ ಸೈಟ್‌ಗಳು</translation>
+<translation id="5763514718066511291">ಈ ಅಪ್ಲಿಕೇಶನ್‌ಗಾಗಿ URL ನಕಲಿಸಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
+<translation id="6496823230996795692"><ph name="APP_NAME"/> ಅನ್ನು ಮೊದಲ ಬಾರಿಗೆ ಬಳಸಲು, ಇಂಟರ್‌ನೆಟ್‌ಗೆ ಸಂಪರ್ಕಸಿ.</translation>
+<translation id="751961395872307827">ಸೈಟ್‌ಗೆ ಸಂಪರ್ಕಪಡಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
+<translation id="4878404682131129617">ಪ್ರಾಕ್ಸಿ ಸರ್ವರ್ ಮೂಲಕ ಟ್ಯೂನಲ್ ಅನ್ನು ಸ್ಥಾಪಿಸುವುದು ವಿಫಲವಾಗಿದೆ</translation>
+<translation id="4749960740855309258">ಹೊಸ ಟ್ಯಾಬ್ ತೆರೆಯಿರಿ</translation>
+<translation id="8788968922598763114">ಕೊನೆಯದಾಗಿ ಮುಚ್ಚಿದ ಟ್ಯಾಬ್ ಮರುತೆರೆಯಿರಿ</translation>
+<translation id="7929962904089429003">ಮೆನು ತೆರೆಯಿರಿ</translation>
+<translation id="6039379616847168523">ಮುಂದಿನ ಟ್ಯಾಬ್‌ಗೆ ಹೋಗಿ</translation>
+<translation id="5210286577605176222">ಹಿಂದಿನ ಟ್ಯಾಬ್‌ಗೆ ಹೋಗಿ</translation>
+<translation id="124678866338384709">ಪ್ರಸ್ತುತ ಟ್ಯಾಬ್ ಮುಚ್ಚಿ</translation>
+<translation id="3714981814255182093">ಹುಡುಕು ಪಟ್ಟಿಯನ್ನು ತೆರೆಯಿರಿ</translation>
+<translation id="5441522332038954058">ವಿಳಾಸ ಪಟ್ಟಿಗೆ ಹೋಗಿ</translation>
+<translation id="3398320232533725830">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳ ಮ್ಯಾನೇಜರ್ ತೆರೆಯಿರಿ</translation>
+<translation id="6583199322650523874">ಪ್ರಸ್ತುತ ಪುಟವನ್ನು ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡಿ</translation>
+<translation id="8489271220582375723">ಇತಿಹಾಸ ಪುಟ ತೆರೆಯಿರಿ</translation>
+<translation id="4837753911714442426">ಪುಟವನ್ನು ಮುದ್ರಿಸಲು ಆಯ್ಕೆಗಳನ್ನು ತೆರೆಯಿರಿ</translation>
+<translation id="5726692708398506830">ಪುಟದಲ್ಲಿರುವ ಪ್ರತಿಯೊಂದನ್ನೂ ದೊಡ್ಡದಾಗಿಸಿ</translation>
+<translation id="3259831549858767975">ಪುಟದಲ್ಲಿರುವ ಪ್ರತಿಯೊಂದನ್ನೂ ಚಿಕ್ಕದಾಗಿಸಿ</translation>
+<translation id="8015452622527143194">ಪುಟದಲ್ಲಿರುವ ಪ್ರತಿಯೊಂದನ್ನೂ ಡೀಫಾಲ್ಟ್ ಗಾತ್ರಕ್ಕೆ ಹಿಂತಿರುಗಿಸಿ</translation>
+<translation id="3443221991560634068">ಪ್ರಸ್ತುತ ಪುಟ ಮರುಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="123724288017357924">ಸಂಗ್ರಹ ಮಾಡಿದ ವಿಷಯವನ್ನು ನಿರ್ಲಕ್ಷಿಸಿ, ಪ್ರಸ್ತುತ ಪುಟ ಮರುಲೋಡ್ ಮಾಡಿ</translation>
+<translation id="305870044889644984">ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ Brave ಸಹಾಯ ಕೇಂದ್ರ ತೆರೆಯಿರಿ</translation>
+<translation id="3166827708714933426">ಟ್ಯಾಬ್ ಮತ್ತು ವಿಂಡೋ ಶಾರ್ಟ್‌ಕಟ್‌ಗಳು</translation>
+<translation id="3169981355900570544">Brave Software Brave ವೈಶಿಷ್ಟ್ಯ ಶಾರ್ಟ್‌ಕಟ್‌ಗಳು</translation>
+<translation id="4558311620361989323">ವೆಬ್‌ಪುಟ ಶಾರ್ಟ್‌ಕಟ್‌ಗಳು</translation>
+<translation id="1908301351964700579">Brave ಇನ್ನೂ VR ಗಾಗಿ ಸಿದ್ಧವಾಗುತ್ತಿದೆ. ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ Brave ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ.</translation>
+<translation id="8970887620466824814">ಏನೋ ತಪ್ಪಾಗಿದೆ.</translation>
+<translation id="1875543012935658554">Brave ಮರುತೆರೆಯಿರಿ.</translation>
+<translation id="79859296434321399">ವರ್ಧಿತ ನೈಜತೆಯ ವಿಷಯವನ್ನು ವೀಕ್ಷಿಸಲು, ARCore ಅನ್ನು ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ</translation>
+<translation id="8558485628462305855">ವರ್ಧಿತ ನೈಜತೆಯ ವಿಷಯವನ್ನು ವೀಕ್ಷಿಸಲು, ARCore ಅನ್ನು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ</translation>
+<translation id="3513704683820682405">ವರ್ಧಿತ ವಾಸ್ತವತೆ</translation>
+<translation id="5475862044948910901">ಆಗ್‌ಮೆಂಟೆಡ್ ರಿಯಾಲಿಟಿ ಸೆಶನ್ ಪ್ರಾರಂಭಿಸುವುದೇ?</translation>
 <translation id="7365126855094612066">ಈ ಸೆಶನ್‌ನ ಅವಧಿಯಲ್ಲಿ, ಸೈಟ್ ಈ ಕೆಳಗಿನವುಗಳನ್ನು ಮಾಡಲು ಸಾಧ್ಯವಾಗುತ್ತದೆ:
 • ನಿಮ್ಮ ಸುತ್ತಮುತ್ತಲಿನ ಪರಿಸರದ 3D ನಕ್ಷೆಯನ್ನು ರಚಿಸುವುದು
 • ಕ್ಯಾಮರಾ ಚಲನೆಯನ್ನು ಟ್ರ್ಯಾಕ್ ಮಾಡುವುದು
 
 ಈ ಸೈಟ್, ಕ್ಯಾಮರಾಗೆ ಪ್ರವೇಶವನ್ನು ಪಡೆದುಕೊಳ್ಳುವುದಿಲ್ಲ. ಕ್ಯಾಮರಾ ಚಿತ್ರಗಳು ನಿಮಗೆ ಮಾತ್ರ ಗೋಚರಿಸುತ್ತವೆ.</translation>
-<translation id="7375125077091615385">ಪ್ರಕಾರ:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome ಮೊದಲ ರನ್ ಅನುಭವ</translation>
-<translation id="741204030948306876">ಹೌದು, ನಾನಿದ್ದೇನೆ</translation>
-<translation id="7413229368719586778">ಪ್ರಾರಂಭ ದಿನಾಂಕ <ph name="DATE" /></translation>
-<translation id="7423098979219808738">ಮೊದಲು ಕೇಳಿ</translation>
-<translation id="7423538860840206698">ಕ್ಲಿಪ್‌ಬೋರ್ಡ್ ಓದದಂತೆ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ</translation>
-<translation id="7431991332293347422">ಹುಡುಕಾಟ ಮತ್ತು ಇನ್ನೂ ಹೆಚ್ಚಿನವುಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಲು ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೇಗೆ ಬಳಸಲಾಗುತ್ತದೆ ಎಂಬುದನ್ನು ನಿಯಂತ್ರಿಸಿ</translation>
-<translation id="7437998757836447326">Chrome ನಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡಿ</translation>
-<translation id="7438641746574390233">ಲೈಟ್ ಮೋಡ್ ಆನ್ ಆಗಿರುವಾಗ, ಪುಟಗಳು ವೇಗವಾಗಿ ಲೋಡ್ ಆಗುವಂತೆ ಮಾಡಲು, Google ಸರ್ವರ್‌ಗಳನ್ನು Chrome ಬಳಸುವುದು. ಅತ್ಯಗತ್ಯವಾದ ವಿಷಯವನ್ನು ಮಾತ್ರ ಲೋಡ್ ಮಾಡಲು, ಬಹಳ ನಿಧಾನವಾಗಿ ಲೋಡ್ ಆಗುವ ಪುಟಗಳನ್ನು ಲೈಟ್ ಮೋಡ್ ಪುನಃ ಬರೆಯುತ್ತದೆ. ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌ಗಳಿಗೆ ಲೈಟ್ ಮೋಡ್ ಅನ್ವಯಿಸುವುದಿಲ್ಲ.</translation>
-<translation id="7444811645081526538">ಇನ್ನಷ್ಟು ವರ್ಗಗಳು</translation>
-<translation id="7445411102860286510">ಮ್ಯೂಟ್ ಮಾಡಲಾದ ವೀಡಿಯೊಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಪ್ಲೇ ಮಾಡಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="7453467225369441013">ನಿಮ್ಮನ್ನು ಬಹುತೇಕ ಸೈಟ್‌ಗಳಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡಲಾಗುತ್ತದೆ. ಆದರೆ ನಿಮ್ಮನ್ನು ನಿಮ್ಮ Google ಖಾತೆಯಿಂದ ಸೈನ್‌ ಔಟ್‌ ಮಾಡುವುದಿಲ್ಲ.</translation>
-<translation id="7454641608352164238">ಸಾಕಷ್ಟು ಸ್ಥಳಾವಕಾಶವಿಲ್ಲ</translation>
-<translation id="7475192538862203634">ಇದನ್ನು ನೀವು ಪದೇ ಪದೇ ವೀಕ್ಷಿಸುತ್ತಿದ್ದರೆ, ಈ <ph name="BEGIN_LINK" />ಸಲಹೆಗಳನ್ನು<ph name="END_LINK" /> ಪ್ರಯತ್ನಿಸಿ.</translation>
-<translation id="7475688122056506577">SD ಕಾರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ. ನಿಮ್ಮ ಕೆಲವು ಫೈಲ್‌ಗಳು ಕಾಣೆಯಾಗಿರಬಹುದು.</translation>
-<translation id="7479104141328977413">ಟ್ಯಾಬ್ ನಿರ್ವಹಣೆ</translation>
-<translation id="7481312909269577407">ಫಾರ್ವರ್ಡ್</translation>
-<translation id="7482656565088326534">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (<ph name="TIME_SINCE_UPDATE" /> ಅಪ್‌ಡೇಟ್‌ ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="7494974237137038751">ಉಳಿತಾಯವಾದ ಡೇಟಾ</translation>
-<translation id="7498271377022651285">ದಯವಿಟ್ಟು ಕಾಯಿರಿ...</translation>
-<translation id="7514365320538308">ಡೌನ್‌ಲೋಡ್</translation>
-<translation id="751961395872307827">ಸೈಟ್‌ಗೆ ಸಂಪರ್ಕಪಡಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">ಸಲಹೆಗಳನ್ನು ಪಡೆಯಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="7559975015014302720">ಲೈಟ್ ಮೋಡ್ ಆಫ್ ಆಗಿದೆ</translation>
-<translation id="7562080006725997899">ಬ್ರೌಸಿಂಗ್ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="756809126120519699">Chrome ಡೇಟಾ ತೆರವುಗೊಳಿಸಲಾಗಿದೆ</translation>
-<translation id="757524316907819857">ಸಂರಕ್ಷಿತ ವಿಷಯವನ್ನು ಪ್ಲೇ ಮಾಡದಂತೆ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> ಫೈಲ್ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಿದೆ}one{<ph name="FILES_DOWNLOADED_MANY" /> ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಿದೆ}other{<ph name="FILES_DOWNLOADED_MANY" /> ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾಗಿದೆ}}</translation>
-<translation id="7588219262685291874">ನಿಮ್ಮ ಸಾಧನದ ಬ್ಯಾಟರಿ ಸೇವರ್ ಆನ್ ಆಗಿರುವಾಗ, ಡಾರ್ಕ್ ಥೀಮ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
-<translation id="7589445247086920869">ಪ್ರಸ್ತುತ ಹುಡುಕಾಟ ಇಂಜಿನ್ ಅನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="7593557518625677601">Android ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆಯಿರಿ ಮತ್ತು Chrome ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು Android ಸಿಸ್ಟಂ ಸಿಂಕ್ ಮರು-ಸಕ್ರಿಯಗೊಳಿಸಿ</translation>
-<translation id="7596558890252710462">ಆಪರೇಟಿಂಗ್ ಸಿಸ್ಟಂ</translation>
-<translation id="7605594153474022051">ಸಿಂಕ್ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಿಲ್ಲ</translation>
-<translation id="7606077192958116810">ಲೈಟ್ ಮೋಡ್ ಆನ್ ಆಗಿದೆ. ಇದನ್ನು ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ನಿರ್ವಹಿಸಿ.</translation>
-<translation id="7612619742409846846">ಇದರಂತೆ Google ಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿ</translation>
-<translation id="7619072057915878432">ನೆಟ್‌ವರ್ಕ್ ವೈಫಲ್ಯಗಳ ಕಾರಣದಿಂದ <ph name="FILE_NAME" /> ಡೌನ್‌ಲೋಡ್ ವಿಫಲವಾಗಿದೆ.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />ಸಹಾಯ ಪಡೆಯಿರಿ<ph name="END_LINK1" /> ಅಥವಾ <ph name="BEGIN_LINK2" />ಮರು-ಸ್ಕ್ಯಾನ್‌ಮಾಡಿ<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome ಗೆ ಸ್ವಾಗತ</translation>
-<translation id="7638584964844754484">ತಪ್ಪಾದ ಪಾಸ್‌ಫ್ರೇಸ್</translation>
-<translation id="7641339528570811325">ಬ್ರೌಸಿಂಗ್ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಿ…</translation>
-<translation id="7648422057306047504">Google ರುಜುವಾತುಗಳೊಂದಿಗೆ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿ</translation>
-<translation id="7649070708921625228">ಸಹಾಯ</translation>
-<translation id="7658239707568436148">ರದ್ದುಮಾಡಿ</translation>
-<translation id="7665369617277396874">ಖಾತೆಯನ್ನು ಸೇರಿಸು</translation>
-<translation id="766587987807204883">ಲೇಖನಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ, ಅವುಗಳನ್ನು ನೀವು ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿರುವಾಗಲೂ ಸಹ ಓದಬಹುದಾಗಿದೆ</translation>
-<translation id="7682724950699840886">ಕೆಳಗಿನ ಸಲಹೆಗಳನ್ನು ಬಳಸಿ ನೋಡಿ: ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಸಾಕಷ್ಟು ಸ್ಥಳಾವಕಾಶ ಇರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಂಡು, ಪುನಃ ಎಕ್ಸ್‌ಪೋರ್ಟ್ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ.</translation>
-<translation id="7685301384041462804">VR ಪ್ರವೇಶಿಸುವ ಮೊದಲು ನೀವು ಈ ವೆಬ್‌ಸೈಟ್ ಅನ್ನು ನಂಬಿದ್ದೀರಿ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> ನಲ್ಲಿ ಇಮೇಲ್ ರಚಿಸಿ</translation>
-<translation id="7704317875155739195">ಸ್ವಯಂಪೂರ್ಣ ಹುಡುಕಾಟಗಳು ಮತ್ತು URLಗಳು</translation>
-<translation id="7725024127233776428">ನೀವು ಬುಕ್‌ಮಾರ್ಕ್ ಮಾಡುವ ಪುಟಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
-<translation id="773466115871691567">ಯಾವಾಗಲು <ph name="SOURCE_LANGUAGE" /> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು ಅನುವಾದ ಮಾಡಿ</translation>
-<translation id="7746457520633464754">ಅಪಾಯಕಾರಿ ಆ್ಯಪ್‌ಗಳು ಮತ್ತು ಸೈಟ್‌ಗಳನ್ನು ಪತ್ತೆಹಚ್ಚಲು Chrome, ನೀವು ಭೇಟಿ ನೀಡುವ ಕೆಲವು ಪುಟಗಳ URL ಗಳು, ಸೀಮಿತ ಸಿಸ್ಟಂ ಮಾಹಿತಿ ಮತ್ತು ಕೆಲವು ಪುಟದ ವಿಷಯವನ್ನು Google ಗೆ ಕಳುಹಿಸುತ್ತದೆ</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> ಮೂಲಕ ಪಠ್ಯವನ್ನು ಹಂಚಲಾಗಿದೆ</translation>
-<translation id="7762668264895820836">ಎಸ್‌ಡಿ ಕಾರ್ಡ್ <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">ವಿಳಾಸ ಸೇರಿಸಿ</translation>
-<translation id="7772032839648071052">ಪಾಸ್‌ಫ್ರೇಸ್ ಅನ್ನು ದೃಢೀಕರಿಸಿ</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> ಅನ್ನು ಮುಚ್ಚಿ</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ಮತ್ತು ಇನ್ನೂ <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">ನಿನ್ನೆ</translation>
-<translation id="7791543448312431591">ಸೇರಿಸು</translation>
-<translation id="780301667611848630">ಬೇಡ, ಧನ್ಯವಾದಗಳು</translation>
-<translation id="7810647596859435254">ಇದರೊಂದಿಗೆ ತೆರೆಯಿರಿ...</translation>
-<translation id="7821588508402923572">ನಿಮ್ಮ ಡೇಟಾ ಉಳಿತಾಯಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
-<translation id="7837721118676387834">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗೆ ಮ್ಯೂಟ್ ಮಾಡಲಾದ ವೀಡಿಯೊಗಳ ಸ್ವಯಂಪ್ಲೇ ಅನುಮತಿಸಿ.</translation>
-<translation id="7846076177841592234">ಆಯ್ಕೆ ರದ್ದುಮಾಡಿ</translation>
-<translation id="784934925303690534">ಸಮಯ ವ್ಯಾಪ್ತಿ</translation>
-<translation id="7851858861565204677">ಇತರ ಸಾಧನಗಳು</translation>
-<translation id="7875915731392087153">ಇಮೇಲ್ ರಚಿಸಿ</translation>
-<translation id="7876243839304621966">ಎಲ್ಲವನ್ನೂ ತೆಗೆದುಹಾಕಿ</translation>
-<translation id="7882131421121961860">ಯಾವುದೇ ಇತಿಹಾಸ ಕಂಡುಬಂದಿಲ್ಲ</translation>
-<translation id="7882806643839505685">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ನ ಧ್ವನಿಯನ್ನು ಅನುಮತಿಸಿ.</translation>
-<translation id="7886917304091689118">Chrome ನಲ್ಲಿ ಚಾಲನೆಯಾಗುತ್ತಿದೆ</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ಫೈಲ್ ಅನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.}one{# ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.}other{# ಫೈಲ್‌ಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ.}}</translation>
-<translation id="7929962904089429003">ಮೆನು ತೆರೆಯಿರಿ</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> ನ ಅವಧಿ ಮುಗಿದಿದೆ.</translation>
-<translation id="7947953824732555851">ಸಮ್ಮತಿಸಿ ಮತ್ತು ಸೈನ್‌ ಇನ್‌ ಮಾಡಿ</translation>
-<translation id="7963646190083259054">ಮಾರಾಟಗಾರ:</translation>
-<translation id="7971136598759319605">1 ದಿನದ ಹಿಂದೆ ಸಕ್ರಿಯ</translation>
-<translation id="7975379999046275268">ಪುಟ ಪೂರ್ವವೀಕ್ಷಿಸಿ <ph name="BEGIN_NEW" />ಹೊಸದು<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">ವೇಗವಾದ ಬ್ರೌಸಿಂಗ್ ಮತ್ತು ಹುಡುಕಾಟಕ್ಕಾಗಿ ಪುಟಗಳನ್ನು ಮುಂಚಿತವಾಗಿ ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="79859296434321399">ವರ್ಧಿತ ನೈಜತೆಯ ವಿಷಯವನ್ನು ವೀಕ್ಷಿಸಲು, ARCore ಅನ್ನು ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ</translation>
-<translation id="7986741934819883144">ಸಂಪರ್ಕವನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="7987073022710626672">Chrome ಸೇವಾ ನಿಯಮಗಳು</translation>
-<translation id="7998918019931843664">ಮುಚ್ಚಿದ ಟ್ಯಾಬ್ ಮತ್ತೆ ತೆರೆಯಿರಿ</translation>
-<translation id="7999064672810608036">ಕುಕೀಗಳು ಸೇರಿದಂತೆ, ಸ್ಥಳೀಯ ಎಲ್ಲಾ ಡೇಟಾವನ್ನು ಅಳಿಸಲು ಮತ್ತು ಈ ವೆಬ್‌ಸೈಟ್‌ಗೆ ಎಲ್ಲಾ ಅನುಮತಿಗಳನ್ನು ಮರುಹೊಂದಿಸಲು ನೀವು ಖಚಿತವಾಗಿ ಬಯಸುವಿರಾ?</translation>
-<translation id="8004582292198964060">ಬ್ರೌಸರ್</translation>
-<translation id="8007176423574883786">ಈ ಸಾಧನಕ್ಕೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ</translation>
-<translation id="8013372441983637696">ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ Chrome ಡೇಟಾವನ್ನು ಸಹ ತೆರವುಗೊಳಿಸಿ</translation>
-<translation id="8015452622527143194">ಪುಟದಲ್ಲಿರುವ ಪ್ರತಿಯೊಂದನ್ನೂ ಡೀಫಾಲ್ಟ್ ಗಾತ್ರಕ್ಕೆ ಹಿಂತಿರುಗಿಸಿ</translation>
-<translation id="802154636333426148">ಡೌನ್‌ಲೋಡ್‌ ವಿಫಲಗೊಂಡಿದೆ</translation>
-<translation id="8026334261755873520">ಬ್ರೌಸಿಂಗ್ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಿ</translation>
-<translation id="8035133914807600019">ಹೊಸ ಫೋಲ್ಡರ್‌…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> ದಿನಗಳು ಉಳಿದಿವೆ</translation>
-<translation id="804335162455518893">SD ಕಾರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ</translation>
-<translation id="805047784848435650">ನಿಮ್ಮ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸದ ಆಧಾರಿಸಿ</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB  ಲಭ್ಯವಿದೆ</translation>
-<translation id="8058746566562539958">ಹೊಸ Chrome ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="8063895661287329888">ಬುಕ್‌ಮಾರ್ಕ್‌ ಸೇರಿಸಲು ವಿಫಲವಾಗಿದೆ.</translation>
-<translation id="806745655614357130">ನನ್ನ ಡೇಟಾ ಪ್ರತ್ಯೇಕವಾಗಿ ಇರಿಸಿಕೊಳ್ಳಿ</translation>
-<translation id="8067883171444229417">ವೀಡಿಯೊ ಪ್ಲೇ ಮಾಡಿ</translation>
-<translation id="8068648041423924542">ಪ್ರಮಾಣಪತ್ರವನ್ನು ಆಯ್ಕೆಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.</translation>
-<translation id="8073388330009372546">ಚಿತ್ರವನ್ನು ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ  ತೆರೆಯಿರಿ</translation>
-<translation id="8076492880354921740">ಟ್ಯಾಬ್‌ಗಳು</translation>
-<translation id="8084114998886531721">ಉಳಿಸಿರುವ ಪಾಸ್‌ವರ್ಡ್</translation>
-<translation id="8087000398470557479"><ph name="DOMAIN_NAME" /> ಡೊಮೇನ್‌‌ನ ಈ ವಿಷಯವನ್ನು Google ನಿಂದ ವಿತರಿಸಲಾಗಿದೆ.</translation>
-<translation id="8103578431304235997">ಅದೃಶ್ಯ ಟ್ಯಾಬ್‌</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">ನಿಮ್ಮ ಎಲ್ಲ ಸಾಧನಗಳಲ್ಲಿ ನಿಮ್ಮ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್‌ ಆನ್‌ ಮಾಡಿ</translation>
-<translation id="8110087112193408731">ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮದಲ್ಲಿ ನಿಮ್ಮ Chrome ಚಟುವಟಿಕೆಯನ್ನು ತೋರಿಸಲು ಬಯಸುವಿರಾ?</translation>
-<translation id="8116925261070264013">ಮ್ಯೂಟ್‌ ಆಗಿರುವುದು</translation>
-<translation id="813082847718468539">ಸೈಟ್ ಮಾಹಿತಿಯನ್ನು ವೀಕ್ಷಿಸಿ</translation>
-<translation id="8131740175452115882">ದೃಢೀಕರಿಸು</translation>
-<translation id="8156139159503939589">ನಿಮಗೆ ಯಾವ ಭಾಷೆಗಳನ್ನು ಓದಲು ಬರುತ್ತದೆ?</translation>
-<translation id="8168435359814927499">ವಿಷಯ</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> ಬಾಕಿ ಉಳಿದಿರುವ ಫೈಲ್‌ಗಳು</translation>
-<translation id="8190358571722158785">1 ದಿನ ಉಳಿದಿದೆ</translation>
-<translation id="8200772114523450471">ಪುನರಾರಂಭಿಸು</translation>
-<translation id="8209050860603202033">ಚಿತ್ರವನ್ನು ತೆರೆಯಿರಿ</translation>
-<translation id="8218622182176210845">ನಿಮ್ಮ ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ</translation>
-<translation id="8224471946457685718">ವೈ-ಫೈಯಲ್ಲಿ ನಿಮಗಾಗಿ ಲೇಖನಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
-<translation id="8232956427053453090">ಡೇಟಾವನ್ನುಇರಿಸಿಕೊಳ್ಳಿ</translation>
-<translation id="8249310407154411074">ಮೇಲಕ್ಕೆ ಸರಿಸಿ</translation>
-<translation id="8250920743982581267">ಡಾಕ್ಯುಮೆಂಟ್‌ಗಳು</translation>
-<translation id="825412236959742607">ಈ ಪುಟವು ತೀರಾ ಹೆಚ್ಚು ಮೆಮೊರಿಯನ್ನು ಬಳಸುತ್ತದೆ, ಆದ್ದರಿಂದ Chrome ಕೆಲವು ವಿಷಯಗಳನ್ನು ತೆಗೆದುಹಾಕಿದೆ.</translation>
-<translation id="8260126382462817229">ಮತ್ತೊಮ್ಮೆ ಸೈನ್ ಇನ್ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ</translation>
-<translation id="8261506727792406068">ಅಳಿಸಿ</translation>
-<translation id="8266862848225348053">ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳ</translation>
-<translation id="8274165955039650276">ಡೌನ್‌ಲೋಡ್‌ಗಳನ್ನು ನೋಡಿ</translation>
-<translation id="8284326494547611709">ಶೀರ್ಷಿಕೆಗಳು</translation>
-<translation id="8300705686683892304">ಆ್ಯಪ್ ಮೂಲಕ ನಿರ್ವಹಿಸಲಾಗಿದೆ</translation>
-<translation id="8310344678080805313">ಪ್ರಮಾಣಿತ ಟ್ಯಾಬ್‌ಗಳು</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ಮತ್ತು ಹೆಚ್ಚಿನ ಸೈಟ್‌ಗಳು</translation>
-<translation id="8327155640814342956">ಉತ್ತಮ ಬ್ರೌಸಿಂಗ್ ಅನುಭವಕ್ಕಾಗಿ, Chrome ಅನ್ನು ಅಪ್‌ಡೇಟ್‌ ಮಾಡಲು ತೆರೆಯಿರಿ</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" /> ನಲ್ಲಿನ ಪುಟಗಳನ್ನು ಅನುವಾದ ಮಾಡಲಾಗುವುದಿಲ್ಲ</translation>
-<translation id="8349013245300336738">ಬಳಸಿದ ಡೇಟಾ ಪ್ರಮಾಣದ ಪ್ರಕಾರ ವಿಂಗಡಿಸಿ</translation>
-<translation id="8364299278605033898">ಜನಪ್ರಿಯ ವೆಬ್‌ಸೈಟ್‌ಗಳನ್ನು ನೋಡಿ</translation>
-<translation id="8368027906805972958">ಅಪರಿಚಿತ ಅಥವಾ ಬೆಂಬಲಿತವಲ್ಲದ ಸಾಧನ (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗಾಗಿ ಹಿನ್ನೆಲೆ ಸಿಂಕ್‌ ಅನುಮತಿಸಿ.</translation>
-<translation id="8378714024927312812">ನಿಮ್ಮ ಸಂಸ್ಥೆಯ ಮೂಲಕ ನಿರ್ವಹಿಸಲಾಗಿದೆ</translation>
-<translation id="8380167699614421159">ಅತಿಕ್ರಮಣಕಾರಿಯಾಗಿರುವ ಅಥವಾ ತಪ್ಪುದಾರಿಗೆಳೆಯುವ ಜಾಹೀರಾತುಗಳನ್ನು ಈ ಸೈಟ್ ತೋರಿಸುತ್ತದೆ</translation>
-<translation id="8393700583063109961">ಸಂದೇಶ ಕಳುಹಿಸು</translation>
-<translation id="8413126021676339697">ಪೂರ್ತಿ ಇತಿಹಾಸವನ್ನು ತೋರಿಸಿ</translation>
-<translation id="8427875596167638501">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್ ಅರ್ಧ ತೆರೆದಿದೆ</translation>
-<translation id="8428213095426709021">ಸೆಟ್ಟಿಂಗ್‌ಗಳು</translation>
-<translation id="8438566539970814960">ಹುಡುಕಾಟಗಳನ್ನು ಮತ್ತು ಬ್ರೌಸಿಂಗ್ ಅನ್ನು ಉತ್ತಮಗೊಳಿಸುವಂತೆ ಮಾಡಿ</translation>
-<translation id="8441146129660941386">ಹಿಂದಕ್ಕೆ ಸೀಕ್ ಮಾಡಿ</translation>
-<translation id="8443209985646068659">Chrome ಅಪ್‌ಡೇಟ್ ಮಾಡಲಾಗದು</translation>
-<translation id="8445448999790540984">ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ಎಕ್ಸ್‌ಪೋರ್ಟ್ ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="8447861592752582886">ಸಾಧನ ಅನುಮತಿಯನ್ನು ಹಿಂತೆಗೆದುಕೊಳ್ಳಿ</translation>
-<translation id="8461694314515752532">ನಿಮ್ಮ ಸ್ವಂತ ಸಿಂಕ್ ಪಾಸ್‌ಫ್ರೇಸ್‌ ಬಳಸಿಕೊಂಡು ಸಿಂಕ್ ಮಾಡಿದ ಡೇಟಾವನ್ನು ಎನ್‌ಕ್ರಿಪ್ಟ್ ಮಾಡಿ</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> ಸಾಧನವು ಇಂಟರ್ನೆಟ್‌ಗೆ ಸಂಪರ್ಕಗೊಂಡಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ಆಫ್‌ಲೈನ್ ಲಭ್ಯವಿದೆ</translation>
-<translation id="8489271220582375723">ಇತಿಹಾಸ ಪುಟ ತೆರೆಯಿರಿ</translation>
-<translation id="8493948351860045254">ಸ್ಥಳಾವಕಾಶವನ್ನು ಮುಕ್ತಗೊಳಿಸಿ</translation>
-<translation id="8497726226069778601">ಇಲ್ಲಿ ನೋಡಲು ಇನ್ನೂ ಏನೂ ಇಲ್ಲ...</translation>
-<translation id="8503559462189395349">Chrome ಪಾಸ್‌ವರ್ಡ್‌ಗಳು</translation>
-<translation id="8503813439785031346">ಬಳಕೆದಾರರಹೆಸರು</translation>
-<translation id="8514477925623180633">Chrome ಮೂಲಕ ಸಂಗ್ರಹಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳನ್ನು ರಫ್ತು ಮಾಡಿ</translation>
-<translation id="8514577642972634246">ಅದೃಶ್ಯ ಮೋಡ್‌ಗೆ ಪ್ರವೇಶಿಸಿ</translation>
-<translation id="851751545965956758">ಸಾಧನಗಳಿಗೆ ಸಂಪರ್ಕಿಸದಂತೆ, ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="8523928698583292556">ಸಂಗ್ರಹಿತ ಪಾಸ್‌ವರ್ಡ್ ಅಳಿಸಿ</translation>
-<translation id="854522910157234410">ಈ ಪುಟವನ್ನು ತೆರೆಯಿರಿ</translation>
-<translation id="8558485628462305855">ವರ್ಧಿತ ನೈಜತೆಯ ವಿಷಯವನ್ನು ವೀಕ್ಷಿಸಲು, ARCore ಅನ್ನು ಅಪ್‌ಡೇಟ್ ಮಾಡಿ</translation>
-<translation id="8559990750235505898">ಪುಟಗಳನ್ನು ಇತರ ಭಾಷೆಗಳಲ್ಲಿ ಅನುವಾದಿಸಲು ಅವಕಾಶಿಸಿ</translation>
-<translation id="8562452229998620586">ಉಳಿಸಲಾದ ಪಾಸ್‌ವರ್ಡ್‌ಗಳು ಇಲ್ಲಿ ಗೋಚರಿಸುತ್ತವೆ.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> ರಿಂದ</translation>
-<translation id="8571213806525832805">ಕಳೆದ 4 ವಾರಗಳು</translation>
-<translation id="857943718398505171">ಅನುಮತಿಸಲಾಗಿದೆ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="8583805026567836021">ಖಾತೆಯ ಡೇಟಾವನ್ನು ತೆರವುಗೊಳಿಸಲಾಗುತ್ತಿದೆ</translation>
-<translation id="860043288473659153">ಕಾರ್ಡ್‌ಹೋಲ್ಡರ್ ಹೆಸರು</translation>
-<translation id="8609465669617005112">ಮೇಲೆ ಸರಿಸು</translation>
-<translation id="8616006591992756292">ನಿಮ್ಮ Google ಖಾತೆಯು <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" /> ನಲ್ಲಿ ಇತರ ವಿಧಗಳ ಬ್ರೌಸಿಂಗ್ ಇತಿಹಾಸವನ್ನು ಹೊಂದಿರಬಹುದು.</translation>
-<translation id="8617240290563765734">ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಲಾದ ವಿಷಯದಲ್ಲಿ ಸೂಚಿಸಲಾದ ನಿರ್ದಿಷ್ಟ URL ತೆರೆಯುವುದೇ?</translation>
-<translation id="8636825310635137004">ನಿಮ್ಮ ಇತರ ಸಾಧನಗಳಿಂದ ನಿಮ್ಮ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸಿಂಕ್‌ ಆನ್‌ ಮಾಡಿ.</translation>
-<translation id="8641930654639604085">ವಯಸ್ಕರ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಲು ಪ್ರಯತ್ನಿಸಿ</translation>
-<translation id="8655129584991699539">ನೀವು ಡೇಟಾವನ್ನು Chrome ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ತೆರವುಗೊಳಿಸಬಹುದು</translation>
-<translation id="8662811608048051533">ಹೆಚ್ಚಿನ ವೆಬ್‌ಸೈಟ್‌ಗಳಿಂದ ಸೈನ್‌ ಔಟ್‌ ಮಾಡುತ್ತದೆ.</translation>
-<translation id="8664979001105139458">ಫೈಲ್ ಹೆಸರು ಈಗಾಗಲೇ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ</translation>
-<translation id="8676374126336081632">ಇನ್‌ಪುಟ್‌‌ ತೆರವುಗೊಳಿಸು</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{ಸಿಗ್ನಲ್‌ ಸಾಮರ್ಥ್ಯದ ಹಂತ: # ಪಟ್ಟಿ}one{ಸಿಗ್ನಲ್‌ ಸಾಮರ್ಥ್ಯದ ಹಂತ: # ಪಟ್ಟಿಗಳು}other{ಸಿಗ್ನಲ್‌ ಸಾಮರ್ಥ್ಯದ ಹಂತ: # ಪಟ್ಟಿಗಳು}}</translation>
-<translation id="868929229000858085">ನಿಮ್ಮ ಸಂಪರ್ಕಗಳನ್ನು ಹುಡುಕಿ</translation>
-<translation id="869891660844655955">ಅವಧಿ ಮುಗಿಯುವ ದಿನಾಂಕ</translation>
-<translation id="8719023831149562936">ಪ್ರಸ್ತುತ ಟ್ಯಾಬ್ ಅನ್ನು ಬೀಮ್ ಮಾಡಲಾಗುವುದಿಲ್ಲ</translation>
-<translation id="8725066075913043281">ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</translation>
-<translation id="8728487861892616501">ಈ ಅಪ್ಲಿಕೇಶನ್ ಬಳಸುವ ಮೂಲಕ, ನೀವು Chrome ನ <ph name="BEGIN_LINK1" />ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1" /> ಮತ್ತು <ph name="BEGIN_LINK2" />ಗೌಪ್ಯತೆಯ ಸೂಚನೆ<ph name="END_LINK2" /> ಗೆ ಮತ್ತು <ph name="BEGIN_LINK3" />ಕುಟುಂಬದ ಲಿಂಕ್‌ನಲ್ಲಿ ನಿರ್ವಹಿಸಿದ Google ಖಾತೆಗಳಿಗಾಗಿ ಗೌಪ್ಯತಾ ಸೂಚನೆಗಳನ್ನು<ph name="END_LINK3" /> ಸಮ್ಮತಿಸುತ್ತೀರಿ.</translation>
-<translation id="8730621377337864115">ಮುಗಿದಿದೆ</translation>
-<translation id="8748850008226585750">ವಿಷಯಗಳನ್ನು ಮರೆಮಾಡಲಾಗಿದೆ</translation>
-<translation id="8751914237388039244">ಚಿತ್ರವನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
-<translation id="8788265440806329501">ನ್ಯಾವಿಗೇಶನ್ ಇತಿಹಾಸ ಮುಚ್ಚಿದೆ</translation>
-<translation id="8788968922598763114">ಕೊನೆಯದಾಗಿ ಮುಚ್ಚಿದ ಟ್ಯಾಬ್ ಮರುತೆರೆಯಿರಿ</translation>
-<translation id="8801436777607969138">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ಗೆ JavaScript ಅನ್ನು ನಿರ್ಬಂಧಿಸಿ.</translation>
-<translation id="8812260976093120287">ಕೆಲವು ವೆಬ್‌ಸೈಟ್‌ಗಳಲ್ಲಿ, ನೀವು ಮೇಲೆ ಬೆಂಬಲಿಸಲಾದ ಪಾವತಿ ಅಪ್ಲಿಕೇಶನ್‌ಗಳನ್ನು ಬಳಸಿಕೊಂಡು ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಪಾವತಿಸಬಹುದು.</translation>
-<translation id="8816026460808729765">ಸೆನ್ಸರ್‌ಗಳನ್ನು ಪ್ರವೇಶಿಸದಂತೆ ಸೈಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chrome ನಲ್ಲಿ ತೆರೆಯುತ್ತದೆ. ಮುಂದುವರಿಸುವ ಮೂಲಕ, ನೀವು Chrome ನ <ph name="BEGIN_LINK1" />ಸೇವಾ ನಿಯಮಗಳು<ph name="END_LINK1" /> ಮತ್ತು <ph name="BEGIN_LINK2" />ಗೌಪ್ಯತಾ ಸೂಚನೆ<ph name="END_LINK2" />, ಮತ್ತು <ph name="BEGIN_LINK3" />ಕುಟುಂಬ ಲಿಂಕ್ ಮೂಲಕ Google ಖಾತೆಗಳಿಗಾಗಿ ನಿರ್ವಹಿಸಲಾದ ಗೌಪ್ಯತೆ ಸೂಚನೆ<ph name="END_LINK3" />ಗೆ ಸಮ್ಮತಿಸುತ್ತೀರಿ.</translation>
-<translation id="8820817407110198400">ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು</translation>
-<translation id="8833831881926404480">ನಿಮ್ಮ ಸ್ಕ್ರೀನ್ ಅನ್ನು ಒಂದು ಸೈಟ್ ಹಂಚಿಕೊಳ್ಳುತ್ತಿದೆ</translation>
-<translation id="883806473910249246">ವಿಷಯವನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತಿರುವಾಗ ದೋಷ ಸಂಭವಿಸಿದೆ.</translation>
-<translation id="8840953339110955557">ಈ ಪುಟವು ಆನ್‌ಲೈನ್ ಆವೃತ್ತಿಗಿಂತ ಭಿನ್ನವಾಗಿರಬಹುದು.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, ಟ್ಯಾಬ್</translation>
-<translation id="885701979325669005">ಸಂಗ್ರಹಣೆ</translation>
-<translation id="889338405075704026">Go to Chrome ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗೆ ಹೋಗಿ</translation>
-<translation id="8901170036886848654">ಯಾವುದೇ ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳು ಕಂಡುಬಂದಿಲ್ಲ</translation>
-<translation id="8909135823018751308">ಹಂಚಿಕೊಳ್ಳು...</translation>
-<translation id="8912362522468806198">Google ಖಾತೆ</translation>
-<translation id="8920114477895755567">ಪೋಷಕರ ವಿವರಗಳಿಗಾಗಿ ನಿರೀಕ್ಷಿಸಲಾಗುತ್ತಿದೆ.</translation>
+<translation id="1188239144602654184">AR ಅನ್ನು ನಮೂದಿಸಿ</translation>
+<translation id="473775607612524610">ಅಪ್‌ಡೇಟ್‌‌</translation>
+<translation id="3133489217401741157">Brave ಗಾಗಿ <ph name="MODULE"/> ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲಾಗುತ್ತಿದೆ…</translation>
+<translation id="1791662854739702043">ಸ್ಥಾಪಿಸಲಾಗಿದೆ</translation>
+<translation id="5131234170665854056">Brave ಗಾಗಿ <ph name="MODULE"/> ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
+<translation id="2567385386134582609">ಚಿತ್ರ</translation>
+<translation id="6395288395575013217">ಲಿಂಕ್</translation>
+<translation id="7352939065658542140">ವೀಡಿಯೊ</translation>
+<translation id="4116038641877404294">ಪುಟಗಳನ್ನು ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ಬಳಸಲು ಅವುಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ</translation>
 <translation id="8922289737868596582">ಪುಟಗಳನ್ನು ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ಬಳಸಲು ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳ ಬಟನ್ ಮೂಲಕ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಿ</translation>
-<translation id="8937772741022875483">ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮದಿಂದ ನಿಮ್ಮ Chrome ಚಟುವಟಿಕೆಯನ್ನು ತೆಗೆದುಹಾಕಬೇಕೇ?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">ಇತರ ವಿಂಡೋದಲ್ಲಿ ತೆರೆಯಿರಿ</translation>
-<translation id="8951232171465285730">ನಿಮ್ಮ <ph name="MEGABYTES" /> MB ಅನ್ನು Chrome ಉಳಿಸಿದೆ</translation>
-<translation id="8958424370300090006">ನಿರ್ದಿಷ್ಟ ಸೈಟ್‌ ಒಂದಕ್ಕೆ ಕುಕೀಗಳನ್ನು ನಿರ್ಬಂಧಿಸಿ.</translation>
-<translation id="8959122750345127698">ನ್ಯಾವಿಗೇಶನ್‌ ತಲುಪಲಾಗುವುದಿಲ್ಲ: <ph name="URL" /></translation>
-<translation id="8965591936373831584">ಬಾಕಿ ಉಳಿದಿರುವುದು</translation>
-<translation id="8970887620466824814">ಏನೋ ತಪ್ಪಾಗಿದೆ.</translation>
-<translation id="8972098258593396643">ಡೀಫಾಲ್ಟ್ ಫೋಲ್ಡರ್‌ಗೆ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡುವುದೇ?</translation>
-<translation id="8986494364107987395">ಬಳಕೆಯ ಅಂಕಿಅಂಶಗಳನ್ನು ಮತ್ತು ಕ್ರಾಶ್ ವರದಿಗಳನ್ನು Google ಗೆ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ರವಾನಿಸು</translation>
-<translation id="8993760627012879038">ಅದೃಶ್ಯ ಮೋಡ್‌ನಲ್ಲಿ ಹೊಸ ವಿಂಡೋ ತೆರೆಯಿರಿ</translation>
-<translation id="8998729206196772491"><ph name="MANAGED_DOMAIN" /> ನಿರ್ವಹಿಸಿದ ಖಾತೆಯ ಮೂಲಕ ನೀವು ಸೈನ್‍‍ ಇನ್ ಮಾಡುತ್ತಿರುವಿರಿ ಮತ್ತು ಅದರ ನಿರ್ವಾಹಕ ನಿಯಂತ್ರಣವನ್ನು ನಿಮ್ಮ Chrome ಡೇಟಾದ ಮೂಲಕ ನೀಡುತ್ತಿರುವಿರಿ. ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಶಾಶ್ವತವಾಗಿ ಈ ಖಾತೆಯೊಂದಿಗೆ ಜೋಡಿಸಲಾಗುತ್ತದೆ. Chrome ನಿಂದ ಸೈನ್ ಔಟ್ ಮಾಡುವುದರಿಂದ ಈ ಸಾಧನದಿಂದ ನಿಮ್ಮ ಡೇಟಾವನ್ನು ಅಳಿಸುತ್ತದೆ, ಆದರೆ ನಿಮ್ಮ Google ಖಾತೆಯಲ್ಲಿ ಸಂಗ್ರಹವಾಗಿಯೇ ಇರುತ್ತದೆ.</translation>
-<translation id="9019902583201351841">ನಿಮ್ಮ ಪೋಷಕರು ನಿರ್ವಹಿಸುತ್ತಿದ್ದಾರೆ</translation>
-<translation id="9028914725102941583">ಸಾಧನಗಳಾದ್ಯಂತ ಹಂಚಿಕೊಳ್ಳಲು, ಸಿಂಕ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
-<translation id="9029323097866369874">VR ಗೆ ಪ್ರವೇಶಿಸಲು <ph name="DOMAIN" /> ಗೆ ಅನುಮತಿ ನೀಡಬೇಕೆ?</translation>
-<translation id="9040142327097499898">ಅಧಿಸೂಚನೆಗಳಿಗೆ ಅನುಮತಿಯಿದೆ. ಈ ಸಾಧನದ ಸ್ಥಳ ಆಫ್ ಆಗಿದೆ.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# ವೀಡಿಯೊ}one{# ವೀಡಿಯೊಗಳು}other{# ವೀಡಿಯೊಗಳು}}</translation>
-<translation id="9050666287014529139">ಪಾಸ್‌ಫ್ರೇಸ್</translation>
-<translation id="9063523880881406963">ಡೆಸ್ಕ್‌ಟಾಪ್ ಸೈಟ್ ವಿನಂತಿಯನ್ನು ಆಫ್ ಮಾಡಿ</translation>
-<translation id="9065203028668620118">ಎಡಿಟ್</translation>
-<translation id="9070377983101773829">ಧ್ವನಿ ಹುಡುಕಾಟವನ್ನು ಪ್ರಾರಂಭಿಸಿ</translation>
-<translation id="9074336505530349563">Google ಸಲಹೆ ನೀಡಿದ ವೈಯಕ್ತೀಕರಿಸಲಾದ ವಿಷಯವನ್ನು ಪಡೆದುಕೊಳ್ಳಲು, ಸೈನ್ ಇನ್ ಮಾಡಿ ಮತ್ತು ಸಿಂಕ್ ಆನ್ ಮಾಡಿ</translation>
-<translation id="9086455579313502267">ನೆಟ್‌ವರ್ಕ್ ಅನ್ನು ಪ್ರವೇಶಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="9100505651305367705">ಬೆಂಬಲವಿದ್ದಾಗ, ಲೇಖನಗಳನ್ನು ಸರಳ ವೀಕ್ಷಣೆಯಲ್ಲಿ ತೋರಿಸುವ ಸೌಲಭ್ಯ ಒದಗಿಸಿ</translation>
-<translation id="9100610230175265781">ಪಾಸ್‌ಫ್ರೇಸ್ ಅಗತ್ಯವಿದೆ</translation>
-<translation id="9102803872260866941">ಪೂರ್ವವೀಕ್ಷಣೆ ಟ್ಯಾಬ್ ತೆರೆದಿದೆ</translation>
+<translation id="5958275228015807058">ಡೌನ್‌ಲೋಡ್‌ಗಳಲ್ಲಿ ನಿಮ್ಮ ಫೈಲ್‌ಗಳು ಮತ್ತು ಪುಟಗಳನ್ನು ಹುಡುಕಿ</translation>
+<translation id="5620928963363755975">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳ ಬಟನ್‌ನಿಂದ ಡೌನ್‌ಲೋಡ್‌ ಮಾಡಿದ ನಿಮ್ಮ ಫೈಲ್‌ಗಳು ಮತ್ತು ಪುಟಗಳನ್ನು ಹುಡುಕಿ</translation>
+<translation id="3341058695485821946">ನೀವು ಎಷ್ಟು ಡೇಟಾ ಉಳಿಸಿದ್ದಿರಾ ಎಂದು ನೋಡಿ</translation>
+<translation id="3157842584138209013">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳ ಬಟನ್ ಮೂಲಕ ನೀವು ಎಷ್ಟು ಡೇಟಾ ಉಳಿಸಿದ್ದಿರಾ ಎಂದು ನೋಡಿ</translation>
+<translation id="8218622182176210845">ನಿಮ್ಮ ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ</translation>
+<translation id="8090895580117672212">ನಿಮ್ಮ Brave Software ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಲು, "ಖಾತೆಯನ್ನು ನಿರ್ವಹಿಸಿ" ಬಟನ್ ಅನ್ನು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
+<translation id="8856898588039823173">ಪುಟದ ಲೈಟ್ ಆವೃತ್ತಿಯನ್ನು Brave Software ಒದಗಿಸಿದೆ. ಮೂಲ ಆವೃತ್ತಿಯನ್ನು ಲೋಡ್ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ.</translation>
+<translation id="8134317863207426198">Lite ಪುಟವನ್ನು Brave Software ಒದಗಿಸಿದೆ. ಮೂಲ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಲು ಮೂಲ ಪುಟವನ್ನು ಲೋಡ್ ಮಾಡಿ ಎಂಬ ಬಟನ್ ಟ್ಯಾಪ್ ಮಾಡಿ.</translation>
+<translation id="4961107849584082341">ಈ ಪುಟವನ್ನು ಯಾವ ಭಾಷೆಗಾದರೂ ಅನುವಾದಿಸಿ</translation>
+<translation id="569536719314091526">ಇನ್ನಷ್ಟು ಆಯ್ಕೆಗಳು ಬಟನ್ ಮೂಲಕ ಈ ಪುಟವನ್ನು ಯಾವ ಭಾಷೆಗಾದರೂ ಅನುವಾದಿಸಿ</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> ಮೂಲಕ ಹುಡುಕಿ</translation>
+<translation id="1792959175193046959">ಡಿಫಾಲ್ಟ್ ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳವನ್ನು ಯಾವಾಗ ಬೇಕಾದರೂ ಬದಲಾಯಿಸಿ</translation>
+<translation id="6942665639005891494">ಸೆಟ್ಟಿಂಗ್‌ಗಳ ಮೆನು ಆಯ್ಕೆಯನ್ನು ಬಳಸಿ, ಡಿಫಾಲ್ಟ್ ಡೌನ್‌ಲೋಡ್ ಸ್ಥಳವನ್ನು ಯಾವಾಗ ಬೇಕಾದರೂ ಬದಲಾಯಿಸಿ</translation>
+<translation id="6850409657436465440">ನಿಮ್ಮ ಡೌನ್‌ಲೋಡ್ ಇನ್ನೂ ಪ್ರಗತಿಯಲ್ಲಿದೆ</translation>
+<translation id="5817715962196959877">Brave ಈಗ ಫೈಲ್‌ಗಳನ್ನು ವೇಗವಾಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತದೆ</translation>
+<translation id="3976396876660209797">ಈ ಶಾರ್ಟ್‌ಕಟ್‌ ಅನ್ನು ತೆಗೆದುಹಾಕಿ ಮತ್ತು ಮರುರಚಿಸಿ</translation>
+<translation id="6766622839693428701">ಮುಚ್ಚಲು ಕೆಳಕ್ಕೆ ಸ್ವೈಪ್ ಮಾಡಿ.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> ಗೆ ಕಳುಹಿಸಲಾಗುತ್ತಿದೆ...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> ಸಾಧನದಿಂದ ಕಳುಹಿಸಲಾಗಿದೆ</translation>
+<translation id="5357811892247919462">ಟ್ಯಾಬ್ ಸ್ವೀಕರಿಸಲಾಗಿದೆ</translation>
 <translation id="9104217018994036254">ಟ್ಯಾಬ್ ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಬೇಕಾದ ಸಾಧನಗಳ ಪಟ್ಟಿ.</translation>
-<translation id="9133397713400217035">ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ಎಕ್ಸ್‌ಪ್ಲೋರ್ ಮಾಡಿ</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">ಮೂಲವನ್ನು ತೋರಿಸಿ</translation>
-<translation id="9139068048179869749">ಅಧಿಸೂಚನೆಗಳನ್ನು ಕಳುಹಿಸಲು ಸೈಟ್‌ಗಳಿಗೆ ಅನುಮತಿಸುವ ಮೊದಲು ಕೇಳಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="9139318394846604261">ಶಾಪಿಂಗ್</translation>
-<translation id="9155898266292537608">ನೀವು ಪದವನ್ನು ಕ್ಷಿಪ್ರವಾಗಿ ಟ್ಯಾಪ್ ಮಾಡುವ ಮೂಲಕವೂ ಹುಡುಕಬಹುದು</translation>
-<translation id="9169507124922466868">ನ್ಯಾವಿಗೇಷನ್ ಇತಿಹಾಸವು ಅರ್ಧ-ತೆರೆದಿದೆ</translation>
-<translation id="9204836675896933765">1 ಫೈಲ್ ಬಾಕಿ ಉಳಿದಿದೆ</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">ಟ್ಯಾಬ್ ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಬೇಕಾದ ಸಾಧನಗಳ ಪಟ್ಟಿಯನ್ನು ಅರ್ಧ ಎತ್ತರದಲ್ಲಿ ತೆರೆಯಲಾಗಿದೆ.</translation>
+<translation id="2904414404539560095">ಟ್ಯಾಬ್ ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಬೇಕಾದ ಸಾಧನಗಳ ಪಟ್ಟಿಯನ್ನು ಪೂರ್ಣ ಎತ್ತರದಲ್ಲಿ ತೆರೆಯಲಾಗಿದೆ.</translation>
+<translation id="4135200667068010335">ಟ್ಯಾಬ್ ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಬೇಕಾದ ಸಾಧನಗಳ ಪಟ್ಟಿಯನ್ನು ಮುಚ್ಚಲಾಗಿದೆ.</translation>
+<translation id="5292796745632149097">ಇಲ್ಲಿಗೆ ಕಳುಹಿಸಿ</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> ದಿನಗಳ ಹಿಂದೆ ಸಕ್ರಿಯ</translation>
+<translation id="7971136598759319605">1 ದಿನದ ಹಿಂದೆ ಸಕ್ರಿಯ</translation>
+<translation id="1521774566618522728">ಇಂದು ಸಕ್ರಿಯ</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> ಜೊತೆಗೆ ಹಂಚಿಕೊಳ್ಳಲಾಗುತ್ತಿದೆ</translation>
+<translation id="9028914725102941583">ಸಾಧನಗಳಾದ್ಯಂತ ಹಂಚಿಕೊಳ್ಳಲು, ಸಿಂಕ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
+<translation id="6162454065885854378">ನಿಮ್ಮ ಫೋನ್‌ನಿಂದ ಮತ್ತೊಂದು ಸಾಧನಕ್ಕೆ ಏನನ್ನಾದರೂ ಹಂಚಿಕೊಳ್ಳಲು, ಎರಡೂ ಸಾಧನಗಳಲ್ಲಿರುವ, Brave ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ ಸಿಂಕ್ ಅನ್ನು ಆನ್ ಮಾಡಿ</translation>
+<translation id="6084271560289605378">Go to Brave ಸೆಟ್ಟಿಂಗ್‌ಗಳಿಗೆ ಹೋಗಿ</translation>
+<translation id="2318045970523081853">ಕರೆ ಮಾಡಲು ಟ್ಯಾಪ್ ಮಾಡಿ</translation>
 <translation id="9209888181064652401">ಕರೆಗಳನ್ನು ಮಾಡಲು ಸಾಧ್ಯವಿಲ್ಲ</translation>
-<translation id="9219103736887031265">ಚಿತ್ರಗಳು</translation>
-<translation id="926205370408745186">ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮದಿಂದ ನಿಮ್ಮ Chrome ಚಟುವಟಿಕೆಯನ್ನು ತೆಗೆದುಹಾಕಿ</translation>
-<translation id="932327136139879170">ಹೋಮ್</translation>
-<translation id="938850635132480979">ದೋಷ: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">ನಿಮ್ಮ ಮೈಕ್ರೋಫೋನ್ ಪ್ರವೇಶಿಸಿ</translation>
-<translation id="95817756606698420">Chrome ಚೀನಾದಲ್ಲಿ ಹುಡುಕಲು <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> ಬಳಸಬಹುದು. ನೀವು ಇದನ್ನು <ph name="BEGIN_LINK" />ಸೆಟ್ಟಿಂಗ್‌ಗಳು<ph name="END_LINK" /> ನಲ್ಲಿ ಬದಲಾಯಿಸಬಹುದು.</translation>
-<translation id="965817943346481315">ಅತಿಕ್ರಮಣಕಾರಿಯಾಗಿರುವ ಅಥವಾ ತಪ್ಪುದಾರಿಗೆಳೆಯುವ ಜಾಹೀರಾತುಗಳನ್ನು ಸೈಟ್ ತೋರಿಸಿದರೆ ಅದನ್ನು ನಿರ್ಬಂಧಿಸಿ (ಶಿಫಾರಸು ಮಾಡಲಾಗಿದೆ)</translation>
-<translation id="968900484120156207">ನೀವು ಭೇಟಿ ನೀಡುವ ಪುಟಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> ನಿಮಿಷಗಳು ಉಳಿದಿವೆ</translation>
-<translation id="974555521953189084">ಸಿಂಕ್ ಪ್ರಾರಂಭಿಸಲು ನಿಮ್ಮ ಪಾಸ್‌ಫ್ರೇಸ್ ನಮೂದಿಸಿ</translation>
-<translation id="981121421437150478">ಆಫ್‌ಲೈನ್</translation>
-<translation id="982182592107339124">ಇದು ಎಲ್ಲಾ ಸೈಟ್‌ಗಳಿಗೆ ಡೇಟಾ ತೆರವುಗೊಳಿಸುತ್ತದೆ, ಇವುಗಳನ್ನೂ ಒಳಗೊಂಡು:</translation>
-<translation id="983192555821071799">ಎಲ್ಲ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಮುಚ್ಚಿ</translation>
-<translation id="987264212798334818">ಸಾಮಾನ್ಯ</translation>
+<translation id="2860954141821109167">ಈ ಸಾಧನದಲ್ಲಿ ಫೋನ್ ಆ್ಯಪ್‌ ಒಂದನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
+<translation id="2067805253194386918">ಪಠ್ಯ</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/>ವನ್ನು ಹಂಚಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> ಅನ್ನು ಹಂಚಿಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ</translation>
+<translation id="8287068819750208230">Brave ನಲ್ಲಿ <ph name="TARGET_DEVICE_NAME"/> ಸಾಧನದ ಸಿಂಕ್ ಆನ್ ಆಗಿದೆಯೇ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
+<translation id="3016635187733453316">ಈ ಸಾಧನವು ಇಂಟರ್ನೆಟ್‌ಗೆ ಸಂಪರ್ಕಗೊಂಡಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> ಸಾಧನವು ಇಂಟರ್ನೆಟ್‌ಗೆ ಸಂಪರ್ಕಗೊಂಡಿರುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ</translation>
+<translation id="6539092367496845964">ಏನೋ ತಪ್ಪಾಗಿದೆ. ನಂತರ ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.</translation>
+<translation id="3389286852084373014">ಪಠ್ಯ ತುಂಬಾ ದೊಡ್ಡದಾಗಿದೆ</translation>
+<translation id="2100314319871056947">ಪಠ್ಯವನ್ನು ಸಣ್ಣ ಭಾಗಗಳಲ್ಲಿ ಹಂಚಿಕೊಳ್ಳಲು ಪ್ರಯತ್ನಿಸಿ.</translation>
+<translation id="2987620471460279764">ಬೇರೆ ಸಾಧನದಿಂದ ಪಠ್ಯವನ್ನು ಹಂಚಿಕೊಳ್ಳಲಾಗಿದೆ</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> ಮೂಲಕ ಪಠ್ಯವನ್ನು ಹಂಚಲಾಗಿದೆ</translation>
+<translation id="5193988420012215838">ನಿಮ್ಮ ಕ್ಲಿಪ್‌ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಲಾಗಿದೆ</translation>
+<translation id="4696983787092045100">ನಿಮ್ಮ ಸಾಧನಗಳಿಗೆ ಪಠ್ಯವನ್ನು ಕಳುಹಿಸಿ</translation>
+<translation id="1260236875608242557">ಹುಡುಕಿ ಮತ್ತು ಎಕ್ಸ್‌ಪ್ಲೋರ್‌‌ ಮಾಡಿ</translation>
+<translation id="6369229450655021117">ಇಲ್ಲಿಂದ, ನೀವು ವೆಬ್‌‍ನಲ್ಲಿ ಹುಡುಕಬಹುದು, ಸ್ನೇಹಿತರ ಜೊತೆ ಹಂಚಿಕೊಳ್ಳಬಹುದು ಮತ್ತು ತೆರೆದ ಪುಟಗಳನ್ನು ನೋಡಬಹುದು</translation>
+<translation id="723171743924126238">ಚಿತ್ರಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="8751914237388039244">ಚಿತ್ರವನ್ನು ಆಯ್ಕೆಮಾಡಿ</translation>
+<translation id="1989112275319619282">ಬ್ರೌಸ್ ಮಾಡಿ</translation>
+<translation id="7055152154916055070">ಮರುನಿರ್ದೇಶಿಸುವಿಕೆಯನ್ನು ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ:</translation>
+<translation id="5524843473235508879">ಮರುನಿರ್ದೇಶಿಸುವಿಕೆಯನ್ನು ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ.</translation>
+<translation id="6573096386450695060">ಯಾವಾಗಲೂ ಅನುಮತಿಸಿ</translation>
+<translation id="5805364706385912897">ಈ ಪುಟವು ಅತಿ ಹೆಚ್ಚು ಮೆಮೊರಿಯನ್ನು ಬಳಸಿಕೊಳ್ಳುತ್ತದೆ, ಆದ್ದರಿಂದ Brave ಇದನ್ನು ವಿರಾಮಗೊಳಿಸಿದೆ.</translation>
+<translation id="5138664332909611586">ಈ ಪುಟವು ತೀರಾ ಹೆಚ್ಚು ಮೆಮೊರಿಯನ್ನು ಬಳಸುತ್ತದೆ, ಆದ್ದರಿಂದ Brave ಕೆಲವು ವಿಷಯಗಳನ್ನು ತೆಗೆದುಹಾಕಿದೆ.</translation>
+<translation id="9137013805542155359">ಮೂಲವನ್ನು ತೋರಿಸಿ</translation>
+<translation id="6361779936989026201">Brave ನಲ್ಲಿನ Brave Software ಅಸಿಸ್ಟೆಂಟ್</translation>
+<translation id="7291387454912369099">ಅಸಿಸ್ಟೆಂಟ್ ಟ್ರಿಗರ್ ಮಾಡಿದ ಚೆಕ್ಔಟ್</translation>
+<translation id="4565206163201411670">ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮದಲ್ಲಿ ನಿಮ್ಮ Brave ಚಟುವಟಿಕೆಯನ್ನು ತೋರಿಸಲು ಬಯಸುವಿರಾ?</translation>
+<translation id="9055113864158719823">ನೀವು Brave ನಲ್ಲಿ ಭೇಟಿ ಮಾಡಿದ ಸೈಟ್‌ಗಳನ್ನು ನೋಡಬಹುದು ಮತ್ತು ಅವುಗಳಿಗೆ ಟೈಮರ್‌ಗಳನ್ನು ಹೊಂದಿಸಬಹುದು.\n\nನೀವು ಯಾವ ಸೈಟ್‌ಗಳಿಗೆ  ಟೈಮರ್‌ಗಳನ್ನು ಹೊಂದಿಸಿದ್ದೀರಿ ಮತ್ತು  ಅವುಗಳಿಗೆ ಭೇಟಿ ಮಾಡಿ ಎಷ್ಟು ಸಮಯ ಕಳೆದಿರುವಿರಿ ಎನ್ನುವುದರ ಕುರಿತ ಮಾಹಿತಿಯನ್ನು Brave Software ಪಡೆಯುತ್ತದೆ. ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮವನ್ನು ಉತ್ತಮಗೊಳಿಸಲು ಈ ಮಾಹಿತಿಯನ್ನು ಬಳಸಲಾಗುವುದು.</translation>
+<translation id="4596514158372210596">ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮದಿಂದ ನಿಮ್ಮ Brave ಚಟುವಟಿಕೆಯನ್ನು ತೆಗೆದುಹಾಕಿ</translation>
+<translation id="1174893863889683998">ಡಿಜಿಟಲ್ ಯೋಗಕ್ಷೇಮದಿಂದ ನಿಮ್ಮ Brave ಚಟುವಟಿಕೆಯನ್ನು ತೆಗೆದುಹಾಕಬೇಕೇ?</translation>
+<translation id="708829030563435351">Brave ನಲ್ಲಿ ನೀವು ಭೇಟಿ ನೀಡುವ ಸೈಟ್‌ಗಳನ್ನು ತೋರಿಸುವುದಿಲ್ಲ. ಎಲ್ಲಾ ಸೈಟ್‌ ಟೈಮರ್‌ಗಳನ್ನು ಅಳಿಸಲಾಗುವುದು.</translation>
+<translation id="2056878612599315956">ಸೈಟ್ ಅನ್ನು ಅಮಾನತುಗೊಳಿಸಲಾಗಿದೆ</translation>
+<translation id="671481426037969117">ನಿಮ್ಮ <ph name="FQDN"/> ಟೈಮರ್ ಅವಧಿ ಮುಗಿದಿದೆ. ಅದು ನಾಳೆ ಮತ್ತೊಮ್ಮೆ ಪ್ರಾರಂಭವಾಗುತ್ತದೆ.</translation>
+<translation id="7479104141328977413">ಟ್ಯಾಬ್ ನಿರ್ವಹಣೆ</translation>
+<translation id="3524138585025253783">ಡೆವಲಪರ್ UI</translation>
+<translation id="6036057147555329831">ಹೆಚ್ಚುವರಿ ICU</translation>
+<translation id="9029323097866369874">VR ಗೆ ಪ್ರವೇಶಿಸಲು <ph name="DOMAIN"/> ಗೆ ಅನುಮತಿ ನೀಡಬೇಕೆ?</translation>
+<translation id="7685301384041462804">VR ಪ್ರವೇಶಿಸುವ ಮೊದಲು ನೀವು ಈ ವೆಬ್‌ಸೈಟ್ ಅನ್ನು ನಂಬಿದ್ದೀರಿ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.</translation>
+<translation id="5033865233969348410">ನೀವು VR ನಲ್ಲಿರುವಾಗ, ಈ ಸೈಟ್ ಇವುಗಳ ಕುರಿತು ತಿಳಿಯಲು ಸಾಧ್ಯವಾಗಬಹುದು:
+  -  ನಿಮ್ಮ ದೈಹಿಕ ವೈಶಿಷ್ಟ್ಯಗಳು, ಉದಾಹರಣೆಗೆ ನಿಮ್ಮ ಎತ್ತರ
+
+VR ಗೆ ಪ್ರವೇಶಿಸುವ ಮೊದಲು ನೀವು ಈ ವೆಬ್‌ಸೈಟ್‌ ಅನ್ನು ನಂಬುತ್ತೀರಾ ಎನ್ನುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.</translation>
+<translation id="5534334044554683961">ನೀವು VR ನಲ್ಲಿರುವಾಗ, ಈ ವೆಬ್‌ಸೈಟ್‌ಗೆ ಕೆಳಗಿನವುಗಳ ಕುರಿತು ತಿಳಿದುಕೊಳ್ಳಲು ಸಾಧ್ಯವಾಗುತ್ತದೆ:
+  -   ನಿಮ್ಮ ದೈಹಿಕ ಲಕ್ಷಣಗಳು, ಉದಾಹರಣೆಗೆ ಎತ್ತರ
+  -   ನಿಮ್ಮ ಕೊಠಡಿಯ ವಿನ್ಯಾಸ
+
+VR ಗೆ ಪ್ರವೇಶಿಸುವ ಮೊದಲು ನೀವು ಈ ವೆಬ್‌ಸೈಟ್ ಅನ್ನು ನಂಬುವಿರಾ ಎನ್ನುವುದನ್ನು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಿ.</translation>
+<translation id="4169535189173047238">ಅನುಮತಿಸಬೇಡಿ</translation>
+<translation id="2170088579611075216">VR ಪ್ರಸ್ತುತಿಯನ್ನು ಅನುಮತಿಸಿ ಮತ್ತು ಪ್ರವೇಶಿಸಿ</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ko.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ko.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ko">
-<translation id="1006017844123154345">온라인 열기</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" />에 보내는 중...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> 추가 중...</translation>
-<translation id="1041308826830691739">웹사이트 알림</translation>
-<translation id="1049743911850919806">시크릿</translation>
-<translation id="10614374240317010">저장되지 않음</translation>
-<translation id="1067922213147265141">다른 Google 서비스</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" />로 된 페이지는 번역하지 않음</translation>
-<translation id="107147699690128016">파일 확장자를 변경하면 파일이 다른 애플리케이션에서 열리고 기기가 위험에 노출될 수도 있습니다.</translation>
-<translation id="1100066534610197918">새 탭을 그룹에서 열기</translation>
-<translation id="1105960400813249514">화면 캡처</translation>
-<translation id="1111673857033749125">다른 기기에서 저장한 북마크가 여기에 표시됩니다.</translation>
-<translation id="1113597929977215864">간단히 보기 표시</translation>
-<translation id="1121094540300013208">사용 및 비정상 종료 보고서</translation>
-<translation id="1124772482545689468">사용자</translation>
-<translation id="1129510026454351943">세부정보: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{다운로드 1개 대기 중}other{다운로드 #개 대기 중}}</translation>
-<translation id="1145536944570833626">기존 데이터 삭제</translation>
-<translation id="1146678959555564648">VR 시작</translation>
-<translation id="116280672541001035">사용</translation>
-<translation id="1171770572613082465">'인기 사이트' 버튼을 탭하여 인기 웹사이트를 확인하세요.</translation>
-<translation id="1173894706177603556">이름 바꾸기</translation>
-<translation id="1178581264944972037">일시중지</translation>
-<translation id="1181037720776840403">삭제</translation>
-<translation id="1188239144602654184">AR 입력</translation>
-<translation id="1197267115302279827">북마크 이동</translation>
-<translation id="119944043368869598">모두 삭제</translation>
-<translation id="1201402288615127009">다음</translation>
-<translation id="1204037785786432551">링크 다운로드</translation>
-<translation id="1206892813135768548">링크 텍스트 복사</translation>
-<translation id="1208340532756947324">모든 기기에서 동기화 및 맞춤설정하려면 동기화를 사용 설정하세요.</translation>
-<translation id="1209206284964581585">지금 숨기기</translation>
-<translation id="1227058898775614466">탐색 기록</translation>
-<translation id="1231733316453485619">동기화를 사용하시겠습니까?</translation>
-<translation id="123724288017357924">캐시된 콘텐츠를 무시하고 현재 페이지 새로고침</translation>
-<translation id="124116460088058876">다른 언어</translation>
-<translation id="124678866338384709">현재 탭 닫기</translation>
-<translation id="1258753120186372309">Google 기념일 로고: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">검색 및 탐색</translation>
-<translation id="1264974993859112054">스포츠</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> 공유할 수 없음</translation>
-<translation id="1272079795634619415">중지</translation>
-<translation id="1283039547216852943">탭하여 펼치기</translation>
-<translation id="1285320974508926690">이 사이트 번역 안함</translation>
-<translation id="1291207594882862231">방문 기록, 쿠키, 사이트 데이터, 캐시 삭제…</translation>
-<translation id="129382876167171263">웹사이트에서 저장한 파일이 여기에 표시됩니다.</translation>
-<translation id="129553762522093515">최근에 닫은 탭</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" />에서 전송</translation>
-<translation id="1310482092992808703">탭 그룹화</translation>
-<translation id="1327257854815634930">탐색 기록 열림</translation>
-<translation id="1331212799747679585">Chrome을 업데이트할 수 없습니다. 옵션 더보기</translation>
-<translation id="1332501820983677155">Chrome 기능 단축키</translation>
-<translation id="1360432990279830238">로그아웃하고 동기화를 사용 중지하시겠습니까?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> 사이트 추가됨</translation>
-<translation id="1373696734384179344">선택한 콘텐츠를 다운로드할 공간이 부족합니다.</translation>
-<translation id="1376578503827013741">계산 중...</translation>
-<translation id="1383876407941801731">검색</translation>
-<translation id="1384959399684842514">다운로드 일시중지됨</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" />일 전 동기화됨</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" />에서 검색</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" />에 포함됨</translation>
-<translation id="1406000523432664303">'추적 안함'</translation>
-<translation id="1407135791313364759">모두 열기</translation>
-<translation id="1409426117486808224">열린 탭 간단히 보기</translation>
-<translation id="1409879593029778104">파일이 이미 존재하여 <ph name="FILE_NAME" /> 다운로드가 중지되었습니다.</translation>
-<translation id="1414981605391750300">Google에 연결하는 중입니다. 잠시만 기다려 주세요...</translation>
-<translation id="1416550906796893042">애플리케이션 버전</translation>
-<translation id="1430915738399379752">인쇄</translation>
-<translation id="1446450296470737166">MIDI 기기의 전체 제어 허용</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> 공유할 수 없음</translation>
-<translation id="145097072038377568">Android 설정에서 사용이 중지됨</translation>
-<translation id="1477626028522505441">서버 문제로 인해 <ph name="FILE_NAME" />을(를) 다운로드할 수 없습니다.</translation>
-<translation id="1506061864768559482">검색엔진</translation>
-<translation id="1513352483775369820">북마크 및 방문 기록</translation>
-<translation id="1513858653616922153">비밀번호 삭제</translation>
-<translation id="1516229014686355813">탭하여 검색을 사용하면 선택한 단어와 현재 페이지가 Google 검색에 전송되어 맥락으로 사용됩니다. <ph name="BEGIN_LINK" />설정<ph name="END_LINK" />에서 이 기능을 사용 중지할 수 있습니다.</translation>
-<translation id="1521774566618522728">오늘 사용</translation>
-<translation id="1544826120773021464">Google 계정을 관리하려면 '계정 관리' 버튼을 탭하세요.</translation>
-<translation id="1549000191223877751">다른 창으로 이동</translation>
-<translation id="1553358976309200471">Chrome 업데이트</translation>
-<translation id="1569387923882100876">연결된 기기</translation>
-<translation id="1571304935088121812">사용자 이름 복사</translation>
-<translation id="1612196535745283361">기기를 스캔하려면 Chrome에서 위치 정보에 액세스해야 합니다. 위치 정보 액세스 권한이 <ph name="BEGIN_LINK" />이 기기에서 사용 중지<ph name="END_LINK" />되어 있습니다.</translation>
-<translation id="1620510694547887537">카메라</translation>
-<translation id="1623104350909869708">이 페이지가 추가적인 대화를 생성하지 않도록 차단</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{선택한 1개 항목 삭제}other{선택한 #개 항목 삭제}}</translation>
-<translation id="164269334534774161"><ph name="CREATION_TIME" />에 작성된 이 페이지의 오프라인 사본을 보는 중입니다.</translation>
-<translation id="1644574205037202324">방문 기록</translation>
-<translation id="1647391597548383849">카메라에 액세스</translation>
-<translation id="1660204651932907780">사이트에서 소리를 재생하도록 허용(권장)</translation>
-<translation id="1670399744444387456">기본</translation>
-<translation id="1671236975893690980">다운로드 대기 중...</translation>
-<translation id="1672586136351118594">다시 표시하지 않음</translation>
-<translation id="1692118695553449118">동기화 사용 중</translation>
-<translation id="169515064810179024">사이트에서 움직임 감지 센서에 액세스하지 못하도록 차단</translation>
-<translation id="1717218214683051432">움직임 감지 센서</translation>
-<translation id="1718835860248848330">지난 1시간</translation>
-<translation id="1736419249208073774">탐색</translation>
-<translation id="1743802530341753419">사이트에서 내 기기에 연결하도록 허용하기 전에 확인(권장)</translation>
-<translation id="1749561566933687563">북마크 동기화</translation>
-<translation id="17513872634828108">열린 탭</translation>
-<translation id="1779089405699405702">이미지 디코더</translation>
-<translation id="1782483593938241562">종료일: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">설치됨</translation>
-<translation id="1792959175193046959">언제든지 기본 다운로드 위치 변경 가능</translation>
-<translation id="1807246157184219062">밝게</translation>
-<translation id="1810845389119482123">초기 동기화 설정이 완료되지 않음</translation>
-<translation id="1821253160463689938">페이지를 방문하지 않더라도 쿠키를 사용하여 환경설정 저장</translation>
-<translation id="1829244130665387512">페이지에서 찾기</translation>
-<translation id="1853692000353488670">새 시크릿 탭</translation>
-<translation id="1856325424225101786">라이트 모드를 재설정하시겠습니까?</translation>
-<translation id="1868024384445905608">이제 Chrome에서 파일을 더 빠르게 다운로드합니다.</translation>
-<translation id="1883903952484604915">내 파일</translation>
-<translation id="1887786770086287077">이 기기의 위치 액세스가 사용 중지되었습니다. <ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서 사용 설정하세요.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" />이(가) Chrome에서 열립니다. 계속하면 Chrome의 <ph name="BEGIN_LINK1" />서비스 약관<ph name="END_LINK1" /> 및 <ph name="BEGIN_LINK2" />개인정보처리방침<ph name="END_LINK2" />에 동의하는 것으로 간주됩니다.</translation>
-<translation id="1919345977826869612">광고</translation>
-<translation id="1919950603503897840">연락처 선택</translation>
-<translation id="1922076542920281912">Chrome에서 위치 정보에 액세스하도록 허용하려면 <ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서도 위치를 사용 설정하세요.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">업데이트</translation>
-<translation id="19288952978244135">Chrome을 다시 여세요.</translation>
-<translation id="1933845786846280168">선택된 탭</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서 Chrome 관련 권한을 설정합니다.</translation>
-<translation id="1943432128510653496">비밀번호 저장</translation>
-<translation id="1952172573699511566">가능한 경우 웹사이트에서 텍스트를 선호하는 언어로 표시합니다.</translation>
-<translation id="1960290143419248813">이 버전의 Android에서는 더 이상 Chrome 업데이트가 지원되지 않습니다.</translation>
-<translation id="1966710179511230534">로그인 세부정보를 업데이트하세요.</translation>
-<translation id="1974060860693918893">고급</translation>
-<translation id="1984705450038014246">Chrome 데이터 동기화</translation>
-<translation id="1984937141057606926">타사 쿠키만 제외하고 허용</translation>
-<translation id="1986685561493779662">이미 사용 중인 이름입니다.</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> 버튼</translation>
-<translation id="1989112275319619282">찾아보기</translation>
-<translation id="1993768208584545658"><ph name="SITE" />에서 페어링하려고 함</translation>
-<translation id="1994173015038366702">사이트 URL</translation>
-<translation id="2000419248597011803">검색주소창 및 검색창의 검색어 및 일부 쿠키를 기본 검색엔진에 전송</translation>
-<translation id="2002537628803770967">Google Pay에 저장된 신용카드 및 주소</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{파일 #개}other{파일 #개}}</translation>
-<translation id="2017836877785168846">검색주소창의 검색 기록 및 자동 완성 항목을 삭제합니다.</translation>
-<translation id="2021896219286479412">전체화면 사이트 컨트롤</translation>
-<translation id="2038563949887743358">데스크톱 버전으로 보기 사용 설정</translation>
-<translation id="2041019821020695769">Chrome에서 알림을 전송하도록 허용하려면 <ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서도 알림을 사용 설정하세요.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" />도 Chrome에서 데이터를 보유하고 있습니다</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">사이트 일시중지됨</translation>
-<translation id="2063713494490388661">탭하여 검색</translation>
-<translation id="2067805253194386918">텍스트</translation>
-<translation id="2079545284768500474">실행취소</translation>
-<translation id="2082238445998314030">전체 결과 <ph name="TOTAL_RESULTS" />개 중 <ph name="RESULT_NUMBER" />개</translation>
-<translation id="2091887806945687916">소리</translation>
-<translation id="2096012225669085171">모든 기기 동기화 및 맞춤설정</translation>
-<translation id="2100273922101894616">자동 로그인</translation>
-<translation id="2100314319871056947">좀 더 짧은 길이로 텍스트를 줄인 다음 공유해 보세요.</translation>
-<translation id="2107397443965016585">사이트에서 보호된 콘텐츠를 재생하도록 허용하기 전에 확인(권장)</translation>
-<translation id="2111511281910874386">페이지로 이동</translation>
-<translation id="2122601567107267586">앱을 열 수 없음</translation>
-<translation id="2126426811489709554">Chrome에서 실행 중</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> 절약됨</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> 닫음</translation>
-<translation id="2139186145475833000">홈 화면에 추가</translation>
-<translation id="2146738493024040262">인스턴트 앱 열기</translation>
-<translation id="2148716181193084225">오늘</translation>
-<translation id="2154484045852737596">카드 수정</translation>
-<translation id="2154710561487035718">URL 복사</translation>
-<translation id="2156074688469523661">남은 사이트(<ph name="NUMBER_OF_SITES" />개)</translation>
-<translation id="2157851137955077194">스마트폰에서 다른 기기로 콘텐츠를 공유하려면 두 기기의 Chrome 설정에서 동기화를 사용 설정하세요.</translation>
-<translation id="2170088579611075216">허용 및 VR 시작</translation>
-<translation id="218608176142494674">공유</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" />(으)로 계속</translation>
-<translation id="2234876718134438132">동기화 및 Google 서비스</translation>
-<translation id="2259659629660284697">비밀번호 내보내기...</translation>
-<translation id="2268044343513325586">상세검색</translation>
-<translation id="2286841657746966508">결제주소</translation>
-<translation id="2289270750774289114">사이트가 주변 블루투스 기기를 조회하려고 할 때 확인(권장)</translation>
-<translation id="230115972905494466">호환되는 기기 없음</translation>
-<translation id="2315043854645842844">클라이언트측 인증서 선택이 운영체제에서 지원되지 않습니다.</translation>
-<translation id="2318045970523081853">탭하여 전화 걸기</translation>
-<translation id="2321086116217818302">비밀번호 준비 중…</translation>
-<translation id="2321958826496381788">편하게 읽을 수 있을 때까지 슬라이더를 드래그하세요. 단락을 두 번 탭하면 텍스트가 이 이상의 크기로 표시됩니다.</translation>
-<translation id="2323763861024343754">사이트 저장공간</translation>
-<translation id="2328985652426384049">로그인할 수 없음</translation>
-<translation id="2330129964253841015">비밀번호가 도용된 경우 알림</translation>
-<translation id="2349710944427398404">계정, 북마크, 저장된 설정 등 Chrome에서 사용한 전체 데이터</translation>
-<translation id="2353636109065292463">인터넷 연결 상태를 확인하세요.</translation>
-<translation id="2359808026110333948">계속</translation>
-<translation id="2369533728426058518">열린 탭</translation>
-<translation id="2387895666653383613">텍스트 크기 조정</translation>
-<translation id="2394602618534698961">다운로드한 파일이 여기 표시됩니다.</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" />MB</translation>
-<translation id="2407481962792080328">Google 계정에 로그인하면 이 기능이 사용 설정됩니다.</translation>
-<translation id="2410754283952462441">계정 선택</translation>
-<translation id="2414886740292270097">어둡게</translation>
-<translation id="2416359993254398973">Chrome이 이 사이트에서 카메라에 액세스하려면 권한이 필요합니다.</translation>
-<translation id="2426805022920575512">다른 계정 선택</translation>
-<translation id="2433507940547922241">모양</translation>
-<translation id="2434158240863470628">다운로드 완료: <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">위치 정보 액세스</translation>
-<translation id="2450083983707403292"><ph name="FILE_NAME" />의 다운로드를 다시 시작하시겠습니까?</translation>
-<translation id="2482878487686419369">알림</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" />에서 관리함</translation>
-<translation id="2494974097748878569">Chrome의 Google 어시스턴트</translation>
-<translation id="2496180316473517155">인터넷 사용 기록</translation>
-<translation id="2497852260688568942">관리자가 동기화를 사용 중지했습니다.</translation>
-<translation id="2498359688066513246">고객센터</translation>
-<translation id="2501278716633472235">뒤로 이동</translation>
-<translation id="2513403576141822879">개인정보 보호, 보안, 데이터 수집에 관한 설정을 더 보려면 <ph name="BEGIN_LINK" />동기화 및 Google 서비스<ph name="END_LINK" />를 참조하세요.</translation>
-<translation id="2518590038762162553">Chrome의 라이트 모드를 사용하면 페이지가 더 빠르게 로드되고 데이터가 최대 60퍼센트 절약됩니다. Chrome에서는 사용자가 방문하는 페이지를 최적화하기 위해 웹 트래픽을 Google에 전송합니다. <ph name="BEGIN_LINK" />자세히 알아보기<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">방문한 페이지의 URL을 Google에 전송</translation>
-<translation id="2532336938189706096">웹 보기</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" />개 항목 삭제함</translation>
-<translation id="2536728043171574184">이 페이지의 오프라인 사본 보는 중</translation>
-<translation id="2546283357679194313">쿠키 및 사이트 데이터</translation>
-<translation id="2567385386134582609">이미지</translation>
-<translation id="257088987046510401">테마</translation>
-<translation id="2570922361219980984">이 기기의 위치 정보 액세스도 사용 중지되었습니다. <ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서 사용 설정하세요.</translation>
-<translation id="257931822824936280">펼쳐짐 - 접으려면 클릭</translation>
-<translation id="2581165646603367611">이를 통해 쿠키, 캐시 및 Chrome에서 중요하다고 간주하지 않는 사이트의 기타 데이터가 삭제됩니다.</translation>
-<translation id="2586657967955657006">클립보드</translation>
-<translation id="2587052924345400782">최신 버전 사용 가능</translation>
-<translation id="2593272815202181319">고정 너비</translation>
-<translation id="2612676031748830579">카드번호</translation>
-<translation id="2621115761605608342">특정 사이트에서 자바스크립트를 허용합니다.</translation>
-<translation id="2625189173221582860">비밀번호 복사됨</translation>
-<translation id="2631006050119455616">절약</translation>
-<translation id="2647434099613338025">언어 추가</translation>
-<translation id="2650751991977523696">파일을 다시 다운로드하시겠습니까?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{오디오 파일 #개}other{오디오 파일 #개}}</translation>
-<translation id="2653659639078652383">제출</translation>
-<translation id="2677748264148917807">나가기</translation>
-<translation id="2704606927547763573">복사됨</translation>
-<translation id="2707726405694321444">페이지 새로고침</translation>
-<translation id="2709516037105925701">자동 완성</translation>
-<translation id="2717722538473713889">이메일 주소</translation>
-<translation id="2728754400939377704">사이트별 정렬</translation>
-<translation id="2744248271121720757">단어를 탭하여 즉시 검색하거나 관련 작업을 확인하세요</translation>
-<translation id="2760989362628427051">기기의 어두운 테마 또는 절전 모드가 켜지면 어두운 테마를 사용 설정합니다.</translation>
-<translation id="2762000892062317888">방금 전</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" />초 남음</translation>
-<translation id="2779651927720337254">실패</translation>
-<translation id="2781151931089541271">1초 남음</translation>
-<translation id="2801022321632964776">최신 버전의 Chrome에서 내가 사용하는 언어를 사용하려면 업데이트하세요.</translation>
-<translation id="2810645512293415242">페이지가 간소화되어 데이터가 절약되고 로드 속도가 빨라졌습니다.</translation>
-<translation id="281504910091592009"><ph name="BEGIN_LINK" />Google 계정<ph name="END_LINK" />에서 저장된 비밀번호 보기 및 관리</translation>
-<translation id="2818669890320396765">어느 기기에서나 내 북마크를 사용하려면 로그인하고 동기화를 사용 설정하세요.</translation>
-<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME" />의 모든 사이트 권한을 재설정하시겠습니까?</translation>
-<translation id="2836148919159985482">전체화면을 종료하려면 뒤로 버튼을 터치하세요.</translation>
-<translation id="2842985007712546952">상위 폴더</translation>
-<translation id="2858138569776157458">인기 사이트</translation>
-<translation id="2860954141821109167">이 기기에서 전화 앱이 사용 설정되어 있는지 확인하세요.</translation>
-<translation id="2870560284913253234">사이트</translation>
-<translation id="2874939134665556319">이전 트랙</translation>
-<translation id="2876369937070532032">보안상의 위험이 있을 때 일부 방문 페이지의 URL을 Google로 전송함</translation>
-<translation id="2888126860611144412">Chrome 정보</translation>
-<translation id="2891154217021530873">페이지 로딩 중지</translation>
-<translation id="2893180576842394309">Google에서 내 방문 기록을 사용하여 Google 검색 및 다른 Google 서비스를 맞춤설정할 수 있습니다.</translation>
-<translation id="2898264748040935573">저장된 비밀번호 수정</translation>
-<translation id="2900528713135656174">일정 만들기</translation>
-<translation id="290376772003165898">페이지 언어가 <ph name="LANGUAGE" />가 아닌가요?</translation>
-<translation id="2904414404539560095">탭을 공유할 기기 목록이 전체 높이로 열렸습니다.</translation>
-<translation id="2910701580606108292">사이트에서 보호된 콘텐츠를 재생하도록 허용하기 전에 확인</translation>
-<translation id="2913331724188855103">사이트에서 쿠키 데이터를 저장하고 읽도록 허용(권장)</translation>
-<translation id="2923908459366352541">잘못된 이름</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> 저장공간</translation>
-<translation id="2942036813789421260">미리보기 탭 닫힘</translation>
-<translation id="2956410042958133412"><ph name="PARENT_NAME_1" />님과 <ph name="PARENT_NAME_2" />님이 관리하는 계정입니다.</translation>
-<translation id="2962095958535813455">시크릿 탭으로 전환됨</translation>
-<translation id="2968755619301702150">인증서 뷰어</translation>
-<translation id="2979025552038692506">선택된 시크릿 탭</translation>
-<translation id="2987620471460279764">다른 기기에서 공유된 텍스트</translation>
-<translation id="2989523299700148168">최근 방문</translation>
-<translation id="2996291259634659425">암호 만들기</translation>
-<translation id="2996809686854298943">URL이 필요합니다.</translation>
-<translation id="300526633675317032">웹사이트 저장공간 <ph name="SIZE_IN_KB" />가 모두 삭제됩니다.</translation>
-<translation id="3016635187733453316">이 기기가 인터넷에 연결되어 있는지 확인하세요.</translation>
-<translation id="3029613699374795922"><ph name="KBS" />KB 다운로드됨</translation>
-<translation id="3029704984691124060">암호가 일치하지 않습니다.</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />도움 받기<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">위치가 사용 중지되었습니다. <ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서 사용 설정하세요.</translation>
-<translation id="3058498974290601450">언제든지 설정에서 동기화를 사용 설정할 수 있습니다.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{북마크 <ph name="BOOKMARKS_COUNT_ONE" />개}other{북마크 <ph name="BOOKMARKS_COUNT_MANY" />개}}</translation>
-<translation id="3089395242580810162">시크릿 탭에서 열기</translation>
-<translation id="3115898365077584848">정보 표시</translation>
-<translation id="3123473560110926937">일부 사이트에서 차단됨</translation>
-<translation id="3137521801621304719">시크릿 모드 나가기</translation>
-<translation id="3143515551205905069">동기화 취소</translation>
-<translation id="3157842584138209013">추가 옵션 버튼에서 저장한 데이터의 양을 확인해보세요.</translation>
-<translation id="3166827708714933426">탭 및 창 단축키</translation>
-<translation id="3181954750937456830">세이프 브라우징(사용자와 사용자의 기기를 위험한 사이트로부터 보호)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서 Chrome 관련 권한을 설정합니다.</translation>
-<translation id="3198916472715691905">저장 데이터 <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">거의 완료되었습니다.</translation>
-<translation id="3207960819495026254">북마크에 추가됨</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> 삭제됨</translation>
-<translation id="321773570071367578">암호를 잊어버렸거나 이 설정을 변경하려면 <ph name="BEGIN_LINK" />동기화를 재설정<ph name="END_LINK" />합니다.</translation>
-<translation id="3227137524299004712">마이크</translation>
-<translation id="3232754137068452469">웹 앱</translation>
-<translation id="3236059992281584593">1분 남음</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">현재 페이지를 북마크에 추가</translation>
-<translation id="3259831549858767975">페이지의 모든 항목 축소</translation>
-<translation id="3269093882174072735">이미지 로드</translation>
-<translation id="3269956123044984603">다른 기기에서 탭을 가져오려면 Android 계정 설정에서 '데이터 자동 동기화'를 사용 설정하세요.</translation>
-<translation id="3277252321222022663">사이트의 센서 액세스 허용(권장)</translation>
-<translation id="3282568296779691940">Chrome에 로그인</translation>
-<translation id="3288003805934695103">페이지 새로고침</translation>
-<translation id="32895400574683172">알림이 허용되었습니다</translation>
-<translation id="3295530008794733555">데이터를 절약하면서 웹을 더 빠르게 탐색하세요</translation>
-<translation id="3295602654194328831">정보 숨기기</translation>
-<translation id="3298243779924642547">라이트</translation>
-<translation id="3303414029551471755">콘텐츠를 다운로드하시겠습니까?</translation>
-<translation id="3306398118552023113">이 앱은 Chrome에서 실행 중입니다.</translation>
-<translation id="3315103659806849044">현재 동기화 및 Google 서비스 설정을 맞춤설정 중입니다. 동기화 켜기를 마무리하려면 화면 하단 근처에 있는 확인 버튼을 탭하세요. 위로 이동</translation>
-<translation id="3328801116991980348">사이트 정보</translation>
-<translation id="3333961966071413176">모든 연락처</translation>
-<translation id="3334729583274622784">파일 확장자를 변경하시겠습니까?</translation>
-<translation id="3341058695485821946">저장한 데이터의 양을 확인해보세요.</translation>
-<translation id="3350687908700087792">모든 시크릿 탭 닫기</translation>
-<translation id="3353615205017136254">Google에서 제공하는 라이트 페이지입니다. 원본 페이지를 로드하려면 원본 로드 버튼을 탭하세요.</translation>
-<translation id="3367813778245106622">다시 로그인하여 동기화 시작</translation>
-<translation id="3374023511497244703">북마크, 방문 기록, 비밀번호 등의 Chrome 데이터가 더 이상 Google 계정과 동기화되지 않습니다.</translation>
-<translation id="3384347053049321195">이미지 공유</translation>
-<translation id="3386292677130313581">사이트에서 내 위치를 파악하도록 허용하기 전에 확인(권장)</translation>
-<translation id="3387650086002190359">파일 시스템에 오류가 발생하여 <ph name="FILE_NAME" />을(를) 다운로드할 수 없습니다.</translation>
-<translation id="3389286852084373014">텍스트가 너무 큼</translation>
-<translation id="3398320232533725830">북마크 관리자 열기</translation>
-<translation id="3414952576877147120">크기:</translation>
-<translation id="3443221991560634068">현재 페이지 새로고침</translation>
-<translation id="3445014427084483498">방금 전</translation>
-<translation id="3478363558367712427">검색엔진을 선택할 수 있습니다.</translation>
+<translation id="6910211073230771657">삭제됨</translation>
+<translation id="6965382102122355670">확인</translation>
+<translation id="5301954838959518834">확인</translation>
+<translation id="7658239707568436148">취소</translation>
 <translation id="3479552764303398839">나중에</translation>
-<translation id="3492207499832628349">새 시크릿 탭</translation>
-<translation id="3493531032208478708">추천 콘텐츠 <ph name="BEGIN_LINK" />자세히 알아보기<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">증강 현실</translation>
-<translation id="3518985090088779359">동의하고 계속</translation>
-<translation id="3522247891732774234">업데이트할 수 있습니다. 옵션 더보기</translation>
-<translation id="3524138585025253783">개발자 UI</translation>
-<translation id="3527085408025491307">폴더</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" />KB 사용 가능</translation>
-<translation id="3549657413697417275">방문 기록 검색</translation>
-<translation id="3557336313807607643">주소록에 추가</translation>
-<translation id="3566923219790363270">Chrome에서 아직 VR을 준비하고 있습니다. 나중에 Chrome을 다시 시작하세요.</translation>
-<translation id="3568688522516854065">다른 기기에서 탭을 가져오려면 로그인하고 동기화를 사용 설정하세요.</translation>
-<translation id="3587482841069643663">전체</translation>
-<translation id="358794129225322306">사이트에서 여러 파일을 자동으로 다운로드하도록 허용합니다.</translation>
-<translation id="3590487821116122040">Chrome에서 중요하다고 간주하지 않는 사이트 저장공간(예: 저장된 설정이 없거나 사용자가 자주 방문하지 않는 사이트)</translation>
-<translation id="3599863153486145794">로그인된 모든 기기에서 방문 기록을 지웁니다. Google 계정의 내 활동(<ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />)에는 인터넷 사용 기록이 다른 형식으로 남아 있을 수도 있습니다.</translation>
-<translation id="3600792891314830896">소리를 재생하는 사이트 음소거</translation>
-<translation id="3616113530831147358">오디오</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" />에 공유하는 중</translation>
-<translation id="3632295766818638029">비밀번호 공개</translation>
-<translation id="363596933471559332">저장된 사용자 인증 정보를 사용하여 자동으로 웹사이트에 로그인합니다. 이 기능이 꺼져 있는 경우에는 웹사이트에 로그인할 때마다 인증 요청 메시지가 표시됩니다.</translation>
-<translation id="3658159451045945436">재설정하면 방문한 사이트 목록을 비롯한 데이터 절약 기록이 삭제됩니다.</translation>
-<translation id="3692944402865947621">저장 위치에 연결할 수 없어 <ph name="FILE_NAME" />을(를) 다운로드할 수 없습니다.</translation>
-<translation id="3714981814255182093">찾기 창 열기</translation>
-<translation id="3716182511346448902">페이지에서 너무 많은 메모리를 사용하므로 Chrome에서 페이지를 일시중지했습니다.</translation>
-<translation id="3730075448226062617">Chrome에서 마이크에 액세스하도록 허용하려면 <ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서도 마이크를 사용 설정하세요.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> 북마크에 추가됨</translation>
-<translation id="3744111561329211289">백그라운드 동기화</translation>
-<translation id="3771001275138982843">업데이트를 다운로드할 수 없음</translation>
-<translation id="3771033907050503522">시크릿 탭</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />블루투스를 사용 설정<ph name="END_LINK" />하여 페어링을 허용하세요.</translation>
-<translation id="3775705724665058594">기기로 전송</translation>
-<translation id="3778956594442850293">홈 화면에 추가됨</translation>
-<translation id="3789841737615482174">설치</translation>
-<translation id="3810838688059735925">동영상</translation>
-<translation id="3810973564298564668">관리</translation>
-<translation id="381841723434055211">전화번호</translation>
-<translation id="3819178904835489326">다운로드 <ph name="NUMBER_OF_DOWNLOADS" />개 삭제됨</translation>
-<translation id="3822502789641063741">사이트 저장공간을 삭제하시겠습니까?</translation>
-<translation id="385051799172605136">뒤로</translation>
-<translation id="3859306556332390985">앞으로 탐색</translation>
-<translation id="3894427358181296146">폴더 추가</translation>
-<translation id="3895926599014793903">확대/축소 강제 사용</translation>
-<translation id="3912508018559818924">웹에서 최상의 결과를 찾는 중…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">내 데이터 결합하기</translation>
-<translation id="393697183122708255">사용 가능한 음성 검색이 없습니다.</translation>
-<translation id="395206256282351086">검색 및 사이트 추천이 사용 중지됨</translation>
-<translation id="3955193568934677022">사이트에서 보호된 콘텐츠를 재생하도록 허용(권장)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{준비가 완료되면 Chrome에서 페이지를 로드합니다.}other{준비가 완료되면 Chrome에서 페이지를 로드합니다.}}</translation>
-<translation id="3963007978381181125">Google Pay 결제 수단 및 주소는 암호로 암호화되지 않습니다. 암호를 아는 사람만 암호화된 데이터를 읽을 수 있습니다. 암호는 Google로 전송되거나 Google에 저장되지 않습니다. 암호가 기억나지 않거나 이 설정을 변경하려면 동기화를 재설정해야 합니다. <ph name="BEGIN_LINK" />자세히 알아보기<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">다운로드 완료</translation>
-<translation id="397583555483684758">동기화가 중지되었습니다.</translation>
-<translation id="3976396876660209797">이 바로가기 삭제하고 다시 만들기</translation>
-<translation id="3985215325736559418"><ph name="FILE_NAME" /> 파일을 다시 다운로드하시겠습니까?</translation>
-<translation id="3987993985790029246">링크 복사</translation>
-<translation id="3988213473815854515">위치 허용됨</translation>
-<translation id="3988466920954086464">이 패널에서 순간 검색결과 보기</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">중요하지 않은 저장공간</translation>
-<translation id="4000212216660919741">오프라인 홈</translation>
+<translation id="5317780077021120954">저장</translation>
+<translation id="4570913071927164677">세부정보</translation>
+<translation id="8730621377337864115">완료</translation>
+<translation id="8261506727792406068">삭제</translation>
+<translation id="1181037720776840403">삭제</translation>
+<translation id="5939518447894949180">초기화</translation>
 <translation id="4002066346123236978">제목</translation>
-<translation id="4008040567710660924">특정 사이트의 쿠키를 허용합니다.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{#시간}other{#시간}}</translation>
-<translation id="4046123991198612571">다음 트랙</translation>
-<translation id="4048707525896921369">페이지에서 나가지 않고도 웹사이트에 언급된 주제에 관해 자세히 알아보세요. 탭하여 검색 기능은 단어와 관련 맥락을 Google 검색으로 전송하여 정의, 사진, 검색결과 및 기타 세부정보를 제공합니다.
+<translation id="5916664084637901428">사용</translation>
+<translation id="5860033963881614850">사용 안함</translation>
+<translation id="6165508094623778733">자세히 알아보기</translation>
+<translation id="6042308850641462728">더보기</translation>
+<translation id="6040143037577758943">닫기</translation>
+<translation id="780301667611848630">아니요, 괜찮습니다.</translation>
+<translation id="1201402288615127009">다음</translation>
+<translation id="2359808026110333948">계속</translation>
+<translation id="2653659639078652383">제출</translation>
+<translation id="2079545284768500474">실행취소</translation>
+<translation id="7649070708921625228">도움말</translation>
+<translation id="2148716181193084225">오늘</translation>
+<translation id="7781829728241885113">어제</translation>
+<translation id="6945221475159498467">선택</translation>
+<translation id="7791543448312431591">추가</translation>
+<translation id="6527303717912515753">공유</translation>
+<translation id="1383876407941801731">검색</translation>
+<translation id="3115898365077584848">정보 표시</translation>
+<translation id="3295602654194328831">정보 숨기기</translation>
+<translation id="3987993985790029246">링크 복사</translation>
+<translation id="2704606927547763573">복사됨</translation>
+<translation id="8725066075913043281">다시 시도하세요</translation>
+<translation id="385051799172605136">뒤로</translation>
+<translation id="8131740175452115882">확인</translation>
+<translation id="5300589172476337783">표시</translation>
+<translation id="1124772482545689468">사용자</translation>
+<translation id="8609465669617005112">위로 이동</translation>
+<translation id="6746124502594467657">아래로 이동</translation>
+<translation id="8249310407154411074">맨 위로 이동</translation>
+<translation id="8428213095426709021">설정</translation>
+<translation id="2498359688066513246">고객센터</translation>
+<translation id="8378714024927312812">조직에서 관리</translation>
+<translation id="9019902583201351841">부모님이 관리합니다.</translation>
+<translation id="4645575059429386691">부모님이 관리합니다.</translation>
+<translation id="4883854917563148705">관리 설정은 재설정할 수 없습니다.</translation>
+<translation id="4307992518367153382">기본설정</translation>
+<translation id="1974060860693918893">고급</translation>
+<translation id="1146678959555564648">VR 시작</translation>
+<translation id="987264212798334818">일반</translation>
+<translation id="4275663329226226506">미디어</translation>
+<translation id="4759238208242260848">다운로드</translation>
+<translation id="218608176142494674">공유</translation>
+<translation id="8004582292198964060">브라우저</translation>
+<translation id="1105960400813249514">화면 캡처</translation>
+<translation id="4875775213178255010">콘텐츠 추천</translation>
+<translation id="2021896219286479412">전체화면 사이트 컨트롤</translation>
+<translation id="4587589328781138893">사이트</translation>
+<translation id="4943703118917034429">가상 현실</translation>
+<translation id="1928696683969751773">업데이트</translation>
+<translation id="6064125863973209585">다운로드 완료</translation>
+<translation id="5342314432463739672">권한 요청</translation>
+<translation id="629730747756840877">계정</translation>
+<translation id="82609232232243542">Brave에 로그인</translation>
+<translation id="7956662517480676674">동기화 및 Brave Software 서비스</translation>
+<translation id="5294439808117722387">현재 동기화 및 Brave Software 서비스 설정을 맞춤설정 중입니다. 동기화 켜기를 마무리하려면 화면 하단 근처에 있는 확인 버튼을 탭하세요. 위로 이동</translation>
+<translation id="2096012225669085171">모든 기기 동기화 및 맞춤설정</translation>
+<translation id="1692118695553449118">동기화 사용 중</translation>
+<translation id="5514904542973294328">기기 관리자가 사용 중지함</translation>
+<translation id="6447211988989208781">Brave Software 활동 제어</translation>
+<translation id="4882831918239250449">검색, 광고 등을 맞춤설정하는 데 인터넷 방문 기록이 사용되는 방식 관리</translation>
+<translation id="7431991332293347422">검색 등을 맞춤설정하는 데 인터넷 방문 기록이 사용되는 방식 관리</translation>
+<translation id="6303969859164067831">로그아웃하고 동기화 사용 중지</translation>
+<translation id="1125261911132334651">Brave Software 계정 관리</translation>
+<translation id="6406506848690869874">동기화</translation>
+<translation id="714362445477979774">Brave 데이터 동기화</translation>
+<translation id="4314815835985389558">동기화 관리</translation>
+<translation id="5428209950370661546">다른 Brave Software 서비스</translation>
+<translation id="7704317875155739195">검색어 및 URL 자동 완성</translation>
+<translation id="2000419248597011803">검색주소창 및 검색창의 검색어 및 일부 쿠키를 기본 검색엔진에 전송</translation>
+<translation id="7981313251711023384">더 빠른 인터넷 사용과 검색을 위해 페이지 미리 로드</translation>
+<translation id="1821253160463689938">페이지를 방문하지 않더라도 쿠키를 사용하여 환경설정 저장</translation>
+<translation id="6697492270171225480">페이지를 찾을 수 없을 때 비슷한 페이지 제안 표시</translation>
+<translation id="8109318360573330108">접속하려는 페이지의 URL을 Brave Software에 전송</translation>
+<translation id="8438566539970814960">검색 및 탐색 기능 개선</translation>
+<translation id="284843628681142937">방문한 페이지의 URL을 Brave Software에 전송</translation>
+<translation id="7222718784508482526">개인정보 보호, 보안, 데이터 수집에 관한 설정을 더 보려면 <ph name="BEGIN_LINK"/>동기화 및 Brave Software 서비스<ph name="END_LINK"/>를 참조하세요.</translation>
+<translation id="918192811481327695">Brave의 기능 및 성능 개선에 참여</translation>
+<translation id="9063160602596686558">사용 통계 및 비정상 종료 보고서를 Brave Software로 자동 전송</translation>
+<translation id="4824958205181053313">동기화를 취소하시겠습니까?</translation>
+<translation id="3058498974290601450">언제든지 설정에서 동기화를 사용 설정할 수 있습니다.</translation>
+<translation id="3143515551205905069">동기화 취소</translation>
+<translation id="1506061864768559482">검색엔진</translation>
+<translation id="55737423895878184">위치 및 알림이 허용되었습니다</translation>
+<translation id="3988213473815854515">위치 허용됨</translation>
+<translation id="32895400574683172">알림이 허용되었습니다</translation>
+<translation id="9040142327097499898">알림이 허용되었습니다. 이 기기에서 위치가 사용 중지되었습니다.</translation>
+<translation id="305593374596241526">위치가 사용 중지되었습니다. <ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서 사용 설정하세요.</translation>
+<translation id="2989523299700148168">최근 방문</translation>
+<translation id="6433501201775827830">검색엔진 선택</translation>
+<translation id="7177466738963138057">나중에 설정에서 변경 가능</translation>
+<translation id="3478363558367712427">검색엔진을 선택할 수 있습니다.</translation>
+<translation id="4910889077668685004">결제 앱</translation>
+<translation id="5152843274749979095">지원되는 앱이 설치되어 있지 않음</translation>
+<translation id="8812260976093120287">일부 웹사이트에서는 위의 결제 앱을 사용하여 내 기기에서 결제할 수 있습니다.</translation>
+<translation id="7764225426217299476">주소 추가</translation>
+<translation id="5595485650161345191">주소 수정</translation>
+<translation id="5087580092889165836">카드 추가</translation>
+<translation id="2154484045852737596">카드 수정</translation>
+<translation id="6140912465461743537">국가/지역</translation>
+<translation id="5659593005791499971">이메일</translation>
+<translation id="4378154925671717803">전화기</translation>
+<translation id="4807098396393229769">카드 명의</translation>
+<translation id="860043288473659153">카드 명의자 이름</translation>
+<translation id="2612676031748830579">카드번호</translation>
+<translation id="869891660844655955">유효기간</translation>
+<translation id="2286841657746966508">결제주소</translation>
+<translation id="663059986967017181">Brave에 복사됨</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>개}other{<ph name="PAYMENT_METHOD_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>개}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>개}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>개}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>개}other{<ph name="SHIPPING_OPTION_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>개}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>개}other{<ph name="CONTACT_PREVIEW"/> 외 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>개}}</translation>
+<translation id="7029809446516969842">비밀번호</translation>
+<translation id="1943432128510653496">비밀번호 저장</translation>
+<translation id="2100273922101894616">자동 로그인</translation>
+<translation id="363596933471559332">저장된 사용자 인증 정보를 사용하여 자동으로 웹사이트에 로그인합니다. 이 기능이 꺼져 있는 경우에는 웹사이트에 로그인할 때마다 인증 요청 메시지가 표시됩니다.</translation>
+<translation id="6995899638241819463">데이터 유출로 인해 비밀번호가 노출된 경우 알림</translation>
+<translation id="1534287762301776620">Brave Software 계정에 로그인하면 이 기능이 사용 설정됩니다.</translation>
+<translation id="10614374240317010">저장되지 않음</translation>
+<translation id="3098842761938485917"><ph name="BEGIN_LINK"/>Brave Software 계정<ph name="END_LINK"/>에서 저장된 비밀번호 보기 및 관리</translation>
+<translation id="8562452229998620586">저장한 비밀번호가 여기에 표시됩니다.</translation>
+<translation id="8084114998886531721">저장된 비밀번호</translation>
+<translation id="2870560284913253234">사이트</translation>
+<translation id="8503813439785031346">사용자이름</translation>
+<translation id="6657585470893396449">비밀번호</translation>
+<translation id="2154710561487035718">URL 복사</translation>
+<translation id="1571304935088121812">사용자 이름 복사</translation>
+<translation id="5005498671520578047">비밀번호 복사</translation>
+<translation id="3632295766818638029">비밀번호 공개</translation>
+<translation id="1513858653616922153">비밀번호 삭제</translation>
+<translation id="543338862236136125">비밀번호 수정</translation>
+<translation id="4565377596337484307">비밀번호 감추기</translation>
+<translation id="8523928698583292556">저장된 암호 삭제</translation>
+<translation id="2898264748040935573">저장된 비밀번호 수정</translation>
+<translation id="5433691172869980887">사용자 이름 복사됨</translation>
+<translation id="5534640966246046842">사이트 복사됨</translation>
+<translation id="2625189173221582860">비밀번호 복사됨</translation>
+<translation id="4550003330909367850">여기에서 비밀번호를 보거나 복사하려면 이 기기에 화면 잠금을 설정하세요.</translation>
+<translation id="6154478581116148741">이 기기에서 비밀번호를 내보내려면 설정에서 화면 잠금을 사용 설정하세요</translation>
+<translation id="4842092870884894799">비밀번호 생성 팝업 표시</translation>
+<translation id="2259659629660284697">비밀번호 내보내기...</translation>
+<translation id="133012818630824069">Brave으로 저장한 비밀번호 내보내기</translation>
+<translation id="6914783257214138813">내보낸 파일을 볼 수 있는 모든 사용자에게 비밀번호가 표시됩니다.</translation>
+<translation id="2321086116217818302">비밀번호 준비 중…</translation>
+<translation id="8445448999790540984">비밀번호를 내보낼 수 없음</translation>
+<translation id="3066461326500799725">Brave Software 드라이브 사용 방법 알아보기</translation>
+<translation id="729975465115245577">기기에 비밀번호 파일을 저장할 수 있는 앱이 없습니다.</translation>
+<translation id="7682724950699840886">다음 방법을 시도해 보세요. 기기 저장용량이 충분한지 확인하고 다시 내보내 봅니다.</translation>
+<translation id="1129510026454351943">세부정보: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">비밀번호를 복사하려면 잠금 해제하세요</translation>
+<translation id="5515439363601853141">비밀번호를 보려면 잠금 해제하세요</translation>
+<translation id="6221633008163990886">비밀번호를 내보내려면 잠금 해제하세요</translation>
+<translation id="230699814587342492">Brave 비밀번호</translation>
+<translation id="6075798973483050474">홈 페이지 수정</translation>
+<translation id="854522910157234410">페이지 열기</translation>
+<translation id="2482878487686419369">알림</translation>
+<translation id="6255999984061454636">콘텐츠 추천</translation>
+<translation id="805047784848435650">인터넷 사용 기록에 기반해 추천됨</translation>
+<translation id="1041308826830691739">웹사이트 알림</translation>
+<translation id="395206256282351086">검색 및 사이트 추천이 사용 중지됨</translation>
+<translation id="257088987046510401">테마</translation>
+<translation id="4650364565596261010">시스템 기본값</translation>
+<translation id="7588219262685291874">기기 절전 모드 사용 시 어두운 테마 사용 설정</translation>
+<translation id="2760989362628427051">기기의 어두운 테마 또는 절전 모드가 켜지면 어두운 테마를 사용 설정합니다.</translation>
+<translation id="6381421346744604172">웹사이트 어둡게 보기</translation>
+<translation id="5040262127954254034">개인정보 보호</translation>
+<translation id="4991384657077828949">Brave 보안 강화 개선에 참여하기</translation>
+<translation id="1943176487615318915">Brave은 위험한 앱 및 사이트를 감지하기 위해 일부 방문 페이지의 URL, 제한적인 시스템 정보, 페이지 콘텐츠 일부를 Brave Software로 전송합니다.</translation>
+<translation id="3181954750937456830">세이프 브라우징(사용자와 사용자의 기기를 위험한 사이트로부터 보호)</translation>
+<translation id="7315322926489145388">보안상의 위험이 있을 때 일부 방문 페이지의 URL을 Brave Software로 전송함</translation>
+<translation id="2063713494490388661">탭하여 검색</translation>
+<translation id="2369463299479365221">페이지에서 나가지 않고도 웹사이트에 언급된 주제에 관해 자세히 알아보세요. 탭하여 검색 기능은 단어와 관련 맥락을 Brave Software 검색으로 전송하여 정의, 사진, 검색결과 및 기타 세부정보를 제공합니다.
 
 검색어를 조정하려면 길게 눌러 선택하세요. 더욱 상세히 검색하려면 패널을 위로 끝까지 슬라이드한 다음 검색창을 탭하세요.</translation>
-<translation id="4056223980640387499">세피아</translation>
-<translation id="4060598801229743805">화면 상단에서 옵션을 선택할 수 있습니다.</translation>
-<translation id="4062305924942672200">법적 정보</translation>
-<translation id="4084682180776658562">북마크</translation>
-<translation id="4084712963632273211">발신자: <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />Google 제공<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">앱 데이터를 삭제하시겠습니까?</translation>
-<translation id="4099578267706723511">사용 통계와 비정상 종료 보고서를 Google로 전송하여 Chrome을 개선하는 데 동참하세요.</translation>
-<translation id="410351446219883937">자동재생</translation>
-<translation id="4116038641877404294">페이지를 다운로드하여 오프라인에서 사용하세요.</translation>
-<translation id="4135200667068010335">탭을 공유할 기기 목록이 닫혔습니다.</translation>
-<translation id="4149994727733219643">웹페이지 간단히 보기</translation>
-<translation id="4165986682804962316">사이트 설정</translation>
-<translation id="4169535189173047238">허용 안함</translation>
-<translation id="4170011742729630528">서비스를 사용할 수 없습니다. 나중에 다시 시도해 주세요.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> 사용됨</translation>
-<translation id="4181841719683918333">언어</translation>
-<translation id="4183868528246477015">Google 렌즈로 검색 <ph name="BEGIN_NEW" />New<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">새 탭에서 열기</translation>
-<translation id="4198423547019359126">사용할 수 있는 다운로드 위치가 없음</translation>
-<translation id="4209895695669353772">Google에서 추천하는 맞춤 콘텐츠를 보려면 동기화를 사용 설정하세요.</translation>
-<translation id="4226663524361240545">알림이 있으면 진동이 울릴 수도 있습니다.</translation>
-<translation id="423219824432660969"><ph name="TIME" />에 Google 비밀번호를 사용하여 동기화된 데이터 암호화</translation>
-<translation id="4242533952199664413">설정 열기</translation>
-<translation id="4256782883801055595">오픈소스 라이선스</translation>
-<translation id="4259722352634471385">탐색이 차단됨: <ph name="URL" /></translation>
-<translation id="4269820728363426813">링크 주소 복사</translation>
-<translation id="4275663329226226506">미디어</translation>
-<translation id="4278390842282768270">허용됨</translation>
-<translation id="429312253194641664">사이트에서 미디어 재생 중</translation>
-<translation id="4298388696830689168">연결된 사이트</translation>
-<translation id="4307992518367153382">기본설정</translation>
-<translation id="4314815835985389558">동기화 관리</translation>
-<translation id="4351244548802238354">대화상자 닫기</translation>
-<translation id="4378154925671717803">전화기</translation>
-<translation id="4384468725000734951">검색할 때 Sogou 사용</translation>
-<translation id="4404568932422911380">북마크 없음</translation>
-<translation id="4405224443901389797">다음 폴더로 이동…</translation>
-<translation id="4411535500181276704">라이트 모드</translation>
-<translation id="4415276339145661267">Google 계정 관리</translation>
-<translation id="4432792777822557199">지금부터 <ph name="SOURCE_LANGUAGE" />로 된 페이지가 <ph name="TARGET_LANGUAGE" />로 번역됩니다.</translation>
-<translation id="4433925000917964731">Google에서 제공하는 라이트 페이지</translation>
-<translation id="4434045419905280838">팝업 및 리디렉션</translation>
-<translation id="4440958355523780886">Google에서 제공하는 라이트 페이지입니다. 원본 페이지를 로드하려면 탭하세요.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> 탭 닫기</translation>
-<translation id="4452548195519783679">북마크를 <ph name="FOLDER_NAME" />에 추가함</translation>
-<translation id="445467742685312942">사이트에서 보호된 콘텐츠를 재생하도록 허용</translation>
-<translation id="4468959413250150279">특정 사이트를 음소거합니다.</translation>
-<translation id="4472118726404937099">모든 기기에서 동기화하고 맞춤설정하려면 로그인하고 동기화를 사용 설정하세요.</translation>
-<translation id="447252321002412580">Chrome의 기능 및 성능 개선에 참여</translation>
-<translation id="4479647676395637221">사이트에서 카메라를 사용하도록 허용하기 전에 확인(권장)</translation>
-<translation id="4479972344484327217">Chrome에 <ph name="MODULE" />을(를) 설치하고 있습니다…</translation>
-<translation id="4487967297491345095">모든 파일, 설정, 계정, 데이터베이스 등을 포함한 Chrome의 모든 앱 데이터가 완전히 삭제됩니다.</translation>
-<translation id="4493497663118223949">라이트 모드 사용 설정됨</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{#일 전}other{#일 전}}</translation>
-<translation id="451872707440238414">북마크 검색</translation>
-<translation id="4521489764227272523">선택한 데이터가 Chrome 및 동기화된 기기에서 삭제되었습니다.
-
-<ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />에서 검색이나 기타 Google 서비스에서의 활동 등 내 Google 계정에 있는 다른 형식의 탐색 기록을 확인할 수 있습니다.</translation>
-<translation id="4532845899244822526">폴더 선택</translation>
-<translation id="4538018662093857852">라이트 모드 켜기</translation>
-<translation id="4550003330909367850">여기에서 비밀번호를 보거나 복사하려면 이 기기에 화면 잠금을 설정하세요.</translation>
-<translation id="4558311620361989323">웹페이지 단축키</translation>
-<translation id="4561979708150884304">연결되지 않음</translation>
-<translation id="4565377596337484307">비밀번호 감추기</translation>
-<translation id="4570913071927164677">세부정보</translation>
-<translation id="4572422548854449519">관리 계정에 로그인</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{#분 전}other{#분 전}}</translation>
-<translation id="4587589328781138893">사이트</translation>
-<translation id="4594952190837476234">이 오프라인 페이지는 <ph name="CREATION_TIME" />에 생성되었으며 온라인 버전과 다를 수 있습니다.</translation>
-<translation id="4605958867780575332"><ph name="ITEM_TITLE" /> 삭제됨</translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> 열기</translation>
-<translation id="4634124774493850572">비밀번호 사용</translation>
-<translation id="4645575059429386691">부모님이 관리합니다.</translation>
-<translation id="4650364565596261010">시스템 기본값</translation>
-<translation id="4663756553811254707">북마크 <ph name="NUMBER_OF_BOOKMARKS" />개 삭제됨</translation>
-<translation id="4665282149850138822"><ph name="NAME" />이(가) 홈 화면에 추가됨</translation>
-<translation id="4684427112815847243">모두 동기화</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />개}other{<ph name="SHIPPING_OPTION_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />개}}</translation>
-<translation id="4696983787092045100">기기로 SMS 전송</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" />에서 오프라인으로 보기</translation>
-<translation id="4699172675775169585">캐시된 이미지 또는 파일</translation>
-<translation id="4714588616299687897">데이터 최대 60% 절약</translation>
-<translation id="4719927025381752090">번역 옵션 제공</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" />에서 열기</translation>
-<translation id="4720982865791209136">Chrome을 개선하는 데 도움을 주세요. <ph name="BEGIN_LINK" />설문조사 참여하기<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">업데이트</translation>
-<translation id="4738836084190194332">마지막 동기화 시간: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">새 탭 열기</translation>
-<translation id="4751476147751820511">모션 또는 조도 센서</translation>
-<translation id="4759238208242260848">다운로드</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{다운로드 1개 완료}other{다운로드 #개 완료}}</translation>
-<translation id="4797039098279997504">터치하여 <ph name="URL_OF_THE_CURRENT_TAB" />(으)로 돌아가기</translation>
-<translation id="4802417911091824046">Google Pay 결제 수단 및 주소는 암호로 암호화되지 않습니다.
-
-이 설정을 변경하려면 <ph name="BEGIN_LINK" />동기화를 재설정<ph name="END_LINK" />하세요.</translation>
-<translation id="4807098396393229769">카드 명의</translation>
-<translation id="4824958205181053313">동기화를 취소하시겠습니까?</translation>
-<translation id="4837753911714442426">옵션을 열어 페이지 인쇄</translation>
-<translation id="4842092870884894799">비밀번호 생성 팝업 표시</translation>
-<translation id="4860895144060829044">전화걸기</translation>
-<translation id="4866368707455379617">Chrome에 <ph name="MODULE" />을(를) 설치할 수 없습니다.</translation>
-<translation id="4875775213178255010">콘텐츠 추천</translation>
-<translation id="4878404682131129617">프록시 서버를 통한 터널 설정에 실패했습니다</translation>
-<translation id="4880127995492972015">번역...</translation>
-<translation id="4881695831933465202">열기</translation>
-<translation id="488187801263602086">파일 이름 변경</translation>
-<translation id="4882831918239250449">검색, 광고 등을 맞춤설정하는 데 인터넷 방문 기록이 사용되는 방식 관리</translation>
-<translation id="4883854917563148705">관리 설정은 재설정할 수 없습니다.</translation>
-<translation id="4885273946141277891">지원되지 않는 Chrome 인스턴스 수입니다.</translation>
-<translation id="4910889077668685004">결제 앱</translation>
-<translation id="4913161338056004800">통계 재설정</translation>
-<translation id="4913169188695071480">새로고침 중지</translation>
-<translation id="4915549754973153784">기기를 검색할 때 <ph name="BEGIN_LINK" />도움말 보기<ph name="END_LINK" />...</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{#페이지}other{#페이지}}</translation>
-<translation id="4932247056774066048"><ph name="DOMAIN_NAME" />이(가) 관리하는 계정에서 로그아웃하면 Chrome 데이터가 이 기기에서 삭제됩니다. Google 계정에서는 데이터가 삭제되지 않습니다.</translation>
-<translation id="4943703118917034429">가상 현실</translation>
-<translation id="4943872375798546930">검색결과가 없습니다.</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" />에서 내 화면을 공유하는 중입니다.</translation>
-<translation id="4961107849584082341">이 페이지를 원하는 언어로 번역하세요.</translation>
-<translation id="4962975101802056554">기기에서 모든 권한을 취소합니다.</translation>
-<translation id="4970824347203572753">현재 위치에서 사용할 수 없습니다.</translation>
-<translation id="497421865427891073">앞으로 이동</translation>
-<translation id="4988210275050210843">파일 다운로드 중(<ph name="MEGABYTES" />MB)</translation>
-<translation id="4988526792673242964">페이지</translation>
-<translation id="4994033804516042629">연락처 없음</translation>
-<translation id="4996978546172906250">공유 방법</translation>
-<translation id="5004416275253351869">Google 활동 제어</translation>
-<translation id="5005498671520578047">비밀번호 복사</translation>
-<translation id="5011311129201317034"><ph name="SITE" />에서 연결하려고 함</translation>
-<translation id="5013696553129441713">새로운 추천 콘텐츠 없음</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">이 사이트에서는 VR 사용자에 대해 다음 내용을 학습할 수 있습니다.
-  -  키와 같은 신체적 특징
-
-VR로 들어가기 전에 이 사이트를 신뢰할 수 있는지 확인하세요.</translation>
+<translation id="2930742481329940825">탭하여 검색을 사용하면 선택한 단어와 현재 페이지가 Brave Software 검색에 전송되어 맥락으로 사용됩니다. <ph name="BEGIN_LINK"/>설정<ph name="END_LINK"/>에서 이 기능을 사용 중지할 수 있습니다.</translation>
 <translation id="5039804452771397117">허용</translation>
-<translation id="5040262127954254034">개인정보 보호</translation>
-<translation id="5048398596102334565">사이트의 움직임 감지 센서 액세스 허용(권장)</translation>
-<translation id="5063480226653192405">사용</translation>
-<translation id="5087580092889165836">카드 추가</translation>
-<translation id="5100237604440890931">접힘 - 펼치려면 클릭</translation>
-<translation id="510275257476243843">1시간 남음</translation>
-<translation id="5123685120097942451">시크릿 탭</translation>
-<translation id="5127805178023152808">동기화 사용 안함</translation>
-<translation id="5129038482087801250">웹 앱 설치</translation>
-<translation id="5132942445612118989">모든 기기의 비밀번호, 방문 기록 등 동기화</translation>
-<translation id="5139940364318403933">Google 드라이브 사용 방법 알아보기</translation>
-<translation id="515227803646670480">저장된 데이터 삭제</translation>
-<translation id="5152843274749979095">지원되는 앱이 설치되어 있지 않음</translation>
-<translation id="5161254044473106830">제목이 필요합니다.</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{다운로드 1개 실패}other{다운로드 #개 실패}}</translation>
-<translation id="5170568018924773124">폴더 열기</translation>
-<translation id="5184329579814168207">Chrome에서 열기</translation>
-<translation id="5193988420012215838">클립보드에 복사됨</translation>
-<translation id="5197729504361054390">선택한 연락처가 <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />과(와) 공유됩니다.</translation>
-<translation id="5199929503336119739">직장용 프로필</translation>
-<translation id="5210286577605176222">이전 탭으로 이동</translation>
-<translation id="5210365745912300556">탭 닫기</translation>
-<translation id="5224771365102442243">동영상 포함</translation>
-<translation id="5230560987958996918"><ph name="SITE" />에서 주변 블루투스 기기를 검색하려고 합니다. 다음 기기가 발견되었습니다.</translation>
-<translation id="5233638681132016545">새 탭</translation>
-<translation id="526421993248218238">이 페이지를 로드할 수 없습니다.</translation>
-<translation id="5271967389191913893">기기에서 다운로드하려는 콘텐츠를 열 수 없습니다.</translation>
-<translation id="528192093759286357">전체화면을 종료하려면 상단에서 드래그하여 뒤로 버튼을 터치하세요.</translation>
-<translation id="5292796745632149097">전송할 기기</translation>
-<translation id="5300589172476337783">표시</translation>
-<translation id="5301954838959518834">확인</translation>
-<translation id="5304593522240415983">필수 입력란입니다.</translation>
-<translation id="5307446750509046227">사이트 저장용량 삭제</translation>
-<translation id="5308380583665731573">연결</translation>
-<translation id="5313967007315987356">사이트 추가</translation>
-<translation id="5317780077021120954">저장</translation>
-<translation id="5324858694974489420">자녀 보호 설정</translation>
-<translation id="5327248766486351172">이름</translation>
-<translation id="5335288049665977812">사이트에서 자바스크립트를 실행하도록 허용(권장)</translation>
-<translation id="5342314432463739672">권한 요청</translation>
-<translation id="5357811892247919462">탭 수신함</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{열려 있는 탭 <ph name="OPEN_TABS_ONE" />개, 탭 간에 전환하려면 탭하세요.}other{열려 있는 탭 <ph name="OPEN_TABS_MANY" />개, 탭 간에 전환하려면 탭하세요.}}</translation>
-<translation id="5391532827096253100">이 사이트와의 연결은 안전하지 않습니다. 사이트 정보</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(외 1개)}other{(외 #개)}}</translation>
-<translation id="5400569084694353794">이 애플리케이션을 사용하면 Chrome의 <ph name="BEGIN_LINK1" />서비스 약관<ph name="END_LINK1" />과 <ph name="BEGIN_LINK2" />개인정보처리방침<ph name="END_LINK2" />에 동의하게 됩니다.</translation>
-<translation id="5403592356182871684">이름</translation>
-<translation id="5403644198645076998">특정 사이트만 허용</translation>
-<translation id="5414836363063783498">확인 중...</translation>
-<translation id="5423934151118863508">자주 방문한 페이지가 여기에 표시됩니다.</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB 사용 가능</translation>
-<translation id="543338862236136125">비밀번호 수정</translation>
-<translation id="5433691172869980887">사용자 이름 복사됨</translation>
-<translation id="543509235395288790">파일 <ph name="COUNT" />개(<ph name="MEGABYTES" />MB) 다운로드 중</translation>
-<translation id="5441522332038954058">검색주소창으로 이동</translation>
-<translation id="5447201525962359567">쿠키 및 기타 로컬에 저장된 데이터 등 모든 사이트 저장공간</translation>
-<translation id="5447765697759493033">이 사이트는 번역되지 않습니다.</translation>
-<translation id="545042621069398927">다운로드 속도 향상</translation>
-<translation id="5456381639095306749">다운로드 페이지</translation>
-<translation id="5475862044948910901">증강 현실 세션을 시작할까요?</translation>
-<translation id="548278423535722844">지도 앱에서 열기</translation>
-<translation id="5487521232677179737">인터넷 사용 기록 삭제</translation>
-<translation id="5494752089476963479">방해가 되거나 사용자를 현혹하는 광고를 표시하는 사이트의 광고 차단</translation>
-<translation id="5500777121964041360">현재 지역에서는 지원되지 않을 수도 있습니다.</translation>
-<translation id="5512137114520586844"><ph name="PARENT_NAME" />님이 관리하는 계정입니다.</translation>
-<translation id="5514904542973294328">기기 관리자가 사용 중지함</translation>
-<translation id="5515439363601853141">비밀번호를 보려면 잠금 해제하세요</translation>
-<translation id="5516455585884385570">알림 설정 열기</translation>
-<translation id="5517095782334947753"><ph name="FROM_ACCOUNT" />에서 가져온 북마크, 방문 기록, 비밀번호 및 기타 설정이 있습니다.</translation>
-<translation id="5524843473235508879">리디렉션이 차단되었습니다.</translation>
-<translation id="5527082711130173040">기기를 스캔하려면 Chrome에서 위치 정보에 액세스해야 합니다. <ph name="BEGIN_LINK1" />권한을 업데이트<ph name="END_LINK1" />하세요. 또한 <ph name="BEGIN_LINK2" />이 기기에서도 위치 정보 액세스 권한이 사용 중지<ph name="END_LINK2" />되어 있습니다.</translation>
-<translation id="5527111080432883924">사이트에서 클립보드의 텍스트 및 이미지에 액세스하도록 허용하기 전에 확인(권장)</translation>
-<translation id="5530766185686772672">시크릿 탭 닫기</translation>
-<translation id="5534334044554683961">이 사이트에서는 VR 사용자에 대해 다음 내용을 학습할 수 있습니다.
-  -   키와 같은 신체적 특징
-  -   공간의 레이아웃
-
-VR로 들어가기 전에 이 사이트를 신뢰할 수 있는지 확인하세요.</translation>
-<translation id="5534640966246046842">사이트 복사됨</translation>
-<translation id="5556459405103347317">새로고침</translation>
-<translation id="5561549206367097665">네트워크 대기 중…</translation>
-<translation id="557283862590186398">Chrome이 이 사이트에서 마이크에 액세스하려면 권한이 필요합니다.</translation>
-<translation id="55737423895878184">위치 및 알림이 허용되었습니다</translation>
-<translation id="5578795271662203820"><ph name="SEARCH_ENGINE" />에서 이 이미지 검색</translation>
-<translation id="5581519193887989363">언제든지 <ph name="BEGIN_LINK1" />설정<ph name="END_LINK1" />에서 동기화할 항목을 선택할 수 있습니다.</translation>
-<translation id="5595485650161345191">주소 수정</translation>
-<translation id="5596627076506792578">옵션 더보기</translation>
-<translation id="5599455543593328020">시크릿 모드</translation>
-<translation id="5620928963363755975">옵션 더보기 버튼을 눌러 다운로드에서 파일 및 페이지를 찾아보세요.</translation>
-<translation id="5626134646977739690">이름:</translation>
-<translation id="5639724618331995626">모든 사이트 허용</translation>
-<translation id="5648166631817621825">지난 7일</translation>
-<translation id="5649053991847567735">자동 다운로드</translation>
-<translation id="5655963694829536461">다운로드 항목 검색</translation>
-<translation id="5659593005791499971">이메일</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" />에 일정 만들기</translation>
-<translation id="5668404140385795438">웹사이트의 확대 방지 요청 무시</translation>
-<translation id="5677928146339483299">차단됨</translation>
-<translation id="5684874026226664614">죄송합니다. 이 페이지를 번역할 수 없습니다.</translation>
-<translation id="5686790454216892815">파일 이름이 너무 깁니다.</translation>
-<translation id="5689516760719285838">위치</translation>
-<translation id="569536719314091526">옵션 더보기 버튼을 눌러 이 페이지를 원하는 언어로 번역하세요</translation>
-<translation id="572328651809341494">최근 탭</translation>
-<translation id="5726692708398506830">페이지의 모든 항목 확대</translation>
-<translation id="5748802427693696783">일반 탭으로 전환됨</translation>
-<translation id="5749068826913805084">Chrome에서 파일을 다운로드하려면 저장소 액세스 권한이 있어야 합니다.</translation>
-<translation id="5763382633136178763">시크릿 탭</translation>
-<translation id="5763514718066511291">탭하여 이 앱의 URL 복사하기</translation>
-<translation id="5765780083710877561">설명:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" /> 중 <ph name="SPACE_USED" /> 사용 중</translation>
-<translation id="5797070761912323120">Google에서 내 방문 기록을 사용하여 Google 검색, 광고 및 다른 Google 서비스를 맞춤설정할 수 있습니다.</translation>
-<translation id="5804241973901381774">권한</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{#시간 전}other{#시간 전}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. All rights reserved.</translation>
-<translation id="5817918615728894473">페어링</translation>
-<translation id="583281660410589416">알 수 없음</translation>
-<translation id="5833984609253377421">링크 공유</translation>
-<translation id="5836192821815272682">Chrome 업데이트 다운로드 중…</translation>
-<translation id="5853623416121554550">일시중지</translation>
-<translation id="5854790677617711513">30일 이상 전</translation>
-<translation id="5858741533101922242">Chrome에서 블루투스 어댑터를 사용 설정할 수 없습니다.</translation>
-<translation id="5860033963881614850">사용 안함</translation>
-<translation id="5862731021271217234">다른 기기에서 탭을 가져오려면 동기화를 사용 설정하세요.</translation>
-<translation id="5864174910718532887">세부정보: 사이트 이름별로 정렬</translation>
-<translation id="5864419784173784555">다른 다운로드 대기 중…</translation>
-<translation id="5865733239029070421">사용 통계 및 비정상 종료 보고서를 Google로 자동 전송</translation>
-<translation id="5869522115854928033">저장된 비밀번호</translation>
-<translation id="5902828464777634901">쿠키를 포함하여 이 웹사이트에 의해 저장된 모든 로컬 데이터가 삭제됩니다.</translation>
-<translation id="5916664084637901428">사용</translation>
-<translation id="5919204609460789179"><ph name="PRODUCT_NAME" />을(를) 업데이트하여 동기화를 시작합니다.</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> 저장됨</translation>
-<translation id="5939518447894949180">초기화</translation>
-<translation id="5942872142862698679">검색할 때 Google 사용</translation>
-<translation id="5952764234151283551">접속하려는 페이지의 URL을 Google에 전송</translation>
-<translation id="5956665950594638604">새 탭에서 Chrome 고객센터 열기</translation>
-<translation id="5958275228015807058">다운로드에서 파일 및 페이지를 찾아보세요.</translation>
-<translation id="5962718611393537961">탭하여 접기</translation>
-<translation id="6000066717592683814">계속 Google 사용</translation>
-<translation id="6005538289190791541">추천 비밀번호</translation>
-<translation id="6036057147555329831">추가 ICU</translation>
-<translation id="6039379616847168523">다음 탭으로 이동</translation>
-<translation id="6040143037577758943">닫기</translation>
-<translation id="6042308850641462728">더보기</translation>
-<translation id="604996488070107836">알 수 없는 오류로 인해 <ph name="FILE_NAME" /> 다운로드에 실패했습니다.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">다운로드 완료</translation>
-<translation id="6075798973483050474">홈 페이지 수정</translation>
-<translation id="60923314841986378"><ph name="HOURS" />시간 남음</translation>
-<translation id="6108923351542677676">설정 진행 중...</translation>
-<translation id="6111020039983847643">데이터 사용됨</translation>
-<translation id="6112702117600201073">페이지 새로고침</translation>
-<translation id="6127379762771434464">항목 삭제됨</translation>
-<translation id="6140912465461743537">국가/지역</translation>
-<translation id="614940544461990577">다음 방법을 시도해 보세요.</translation>
-<translation id="6154478581116148741">이 기기에서 비밀번호를 내보내려면 설정에서 화면 잠금을 사용 설정하세요</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> 데이터 절약</translation>
-<translation id="6165508094623778733">자세히 알아보기</translation>
-<translation id="6177111841848151710">현재 검색엔진에는 허용되지 않음</translation>
-<translation id="6181444274883918285">사이트 예외 추가</translation>
-<translation id="6192333916571137726">다운로드 파일</translation>
-<translation id="6192792657125177640">예외</translation>
-<translation id="6194112207524046168">Chrome에서 카메라에 액세스하도록 허용하려면 <ph name="BEGIN_LINK" />Android 설정<ph name="END_LINK" />에서도 카메라를 사용 설정하세요.</translation>
-<translation id="6196640612572343990">타사 쿠키 차단</translation>
-<translation id="6206551242102657620">이 사이트와의 연결은 안전합니다. 사이트 정보</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" />이(가) 아닌가요?</translation>
-<translation id="6221633008163990886">비밀번호를 내보내려면 잠금 해제하세요</translation>
+<translation id="1406000523432664303">'추적 안함'</translation>
 <translation id="6232535412751077445">‘추적 안함’을 사용하도록 설정하면 요청이 사용자의 인터넷 사용 트래픽에 포함됩니다. 웹사이트가 요청에 응답하는지 여부와 요청이 해석되는 방법에 따라 결과가 결정됩니다.
 
 예를 들어 어떤 웹사이트는 사용자가 방문한 다른 웹사이트를 기반으로 하지 않는 광고를 표시하여 이 요청에 응답할 수 있습니다. 그러나 대부분의 웹사이트에서는 보안을 개선하거나 웹사이트에 콘텐츠, 광고, 권장사항 등을 제공하거나 보고서 통계를 생성하기 위해 사용자의 인터넷 사용 기록을 계속 수집하고 사용합니다.</translation>
-<translation id="624789221780392884">업데이트 준비 완료</translation>
-<translation id="6255999984061454636">콘텐츠 추천</translation>
-<translation id="6277522088822131679">페이지를 인쇄하는 중에 문제가 발생했습니다. 다시 시도해 주세요.</translation>
-<translation id="6295158916970320988">모든 사이트</translation>
-<translation id="629730747756840877">계정</translation>
-<translation id="6303969859164067831">로그아웃하고 동기화 사용 중지</translation>
-<translation id="6316139424528454185">지원되지 않는 Android 버전입니다.</translation>
-<translation id="6320088164292336938">진동</translation>
-<translation id="6324034347079777476">Android 시스템 동기화 사용 안함</translation>
-<translation id="6333140779060797560">공유 방법: <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">암호화</translation>
-<translation id="6341580099087024258">파일 저장 위치 묻기</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />개}other{<ph name="SHIPPING_ADDRESS_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />개}}</translation>
-<translation id="6364438453358674297">기록에서 제안을 삭제하시겠습니까?</translation>
-<translation id="6369229450655021117">여기에서 웹을 검색하고, 친구와 공유하고, 열린 페이지를 볼 수 있습니다.</translation>
-<translation id="6378173571450987352">세부정보: 사용된 데이터 양에 따라 정렬</translation>
-<translation id="6381421346744604172">웹사이트 어둡게 보기</translation>
-<translation id="6388207532828177975">삭제 및 재설정</translation>
-<translation id="6393863479814692971">Chrome이 이 사이트에서 카메라와 마이크에 액세스하려면 권한이 필요합니다.</translation>
-<translation id="6395288395575013217">링크</translation>
-<translation id="6404511346730675251">북마크 수정</translation>
-<translation id="6406506848690869874">동기화</translation>
-<translation id="641643625718530986">인쇄…</translation>
-<translation id="6416782512398055893"><ph name="MBS" />MB 다운로드됨</translation>
-<translation id="6427112570124116297">웹 번역</translation>
-<translation id="6433501201775827830">검색엔진 선택</translation>
-<translation id="6437478888915024427">페이지 정보</translation>
-<translation id="6441734959916820584">이름이 너무 깁니다.</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{이미지 #개}other{이미지 #개}}</translation>
-<translation id="6447842834002726250">쿠키</translation>
-<translation id="6461962085415701688">파일을 열 수 없습니다</translation>
-<translation id="6464977750820128603">Chrome에서 내가 방문한 사이트를 보고 사이트에 타이머를 설정할 수 있습니다.\n\nGoogle에서는 타이머가 설정된 사이트와 사이트 방문 시간 정보를 수집합니다. 이 정보는 디지털 웰빙을 개선하는 데 사용됩니다.</translation>
-<translation id="6475951671322991020">동영상 다운로드</translation>
-<translation id="6482749332252372425">저장공간이 부족하여 <ph name="FILE_NAME" />을(를) 다운로드할 수 없습니다.</translation>
-<translation id="6496823230996795692">처음으로 <ph name="APP_NAME" />을(를) 사용하는 경우 인터넷에 연결하세요.</translation>
-<translation id="6508722015517270189">Chrome 다시 시작하기</translation>
-<translation id="6527303717912515753">공유</translation>
-<translation id="6532866250404780454">Chrome에서 방문한 사이트가 표시되지 않습니다. 모든 사이트 타이머가 삭제됩니다.</translation>
-<translation id="6534565668554028783">Google에서 응답하는 데 시간이 너무 오래 걸립니다.</translation>
-<translation id="6538442820324228105"><ph name="GBS" />GB 다운로드됨</translation>
-<translation id="6539092367496845964">문제가 발생했습니다. 나중에 다시 시도해 보세요.</translation>
-<translation id="654446541061731451">공유할 탭을 선택하세요.</translation>
-<translation id="6545017243486555795">모든 데이터 삭제</translation>
-<translation id="6545864417968258051">블루투스 검색</translation>
-<translation id="6560414384669816528">Sogou로 검색</translation>
-<translation id="6566259936974865419">Chrome을 통해 <ph name="GIGABYTES" />GB를 절약했습니다.</translation>
-<translation id="6573096386450695060">항상 허용</translation>
-<translation id="6573431926118603307">다른 기기의 Chrome에서 연 탭이 여기에 표시됩니다.</translation>
-<translation id="6583199322650523874">현재 페이지 북마크</translation>
-<translation id="6593061639179217415">데스크톱 사이트</translation>
-<translation id="6600954340915313787">Chrome에 복사됨</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" />GB</translation>
-<translation id="6612358246767739896">보호된 콘텐츠</translation>
-<translation id="6627583120233659107">폴더 수정</translation>
-<translation id="6643016212128521049">삭제</translation>
-<translation id="6643649862576733715">저장된 데이터 양에 따라 정렬</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />개}other{<ph name="CONTACT_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />개}}</translation>
-<translation id="6649642165559792194">이미지 미리보기 표시 <ph name="BEGIN_NEW" />새로운 기능<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">기기를 스캔하려면 Chrome에서 위치 정보에 액세스해야 합니다. <ph name="BEGIN_LINK" />권한 업데이트<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">비밀번호</translation>
-<translation id="6659594942844771486">탭</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" />에서 열기</translation>
-<translation id="666981079809192359">Chrome 개인정보처리방침</translation>
-<translation id="6676840375528380067">기기에서 Chrome 데이터를 삭제하시겠습니까?</translation>
-<translation id="6697492270171225480">페이지를 찾을 수 없을 때 비슷한 페이지 제안 표시</translation>
-<translation id="6697947395630195233">Chrome이 이 사이트와 위치를 공유하려면 내 위치에 액세스하도록 허용해야 합니다.</translation>
-<translation id="6698801883190606802">동기화된 데이터 관리</translation>
-<translation id="6699370405921460408">Google 서버에서 내가 방문하는 페이지를 최적화합니다.</translation>
-<translation id="6706288973712894588">현재 오프라인 상태입니다.\n<ph name="BEGIN_LINK" />오프라인 피드를 둘러보세요.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">뉴스</translation>
-<translation id="6710213216561001401">이전</translation>
-<translation id="671481426037969117"><ph name="FQDN" /> 타이머가 종료되었습니다. 타이머는 내일 다시 시작됩니다.</translation>
-<translation id="6738867403308150051">다운로드 중...</translation>
-<translation id="6746124502594467657">아래로 이동</translation>
-<translation id="6766622839693428701">닫으려면 아래로 스와이프하세요.</translation>
-<translation id="6766758767654711248">탭하여 사이트로 이동</translation>
-<translation id="6767294960381293877">탭을 공유할 기기 목록이 절반 높이로 열렸습니다.</translation>
-<translation id="6782111308708962316">타사 웹사이트에서 쿠키 데이터를 저장하거나 읽을 수 없도록 방지</translation>
-<translation id="6790428901817661496">재생</translation>
-<translation id="6811034713472274749">페이지를 볼 수 있음</translation>
-<translation id="6818926723028410516">항목 선택</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">번역</translation>
-<translation id="6845325883481699275">Chrome 보안 강화 개선에 참여하기</translation>
-<translation id="6846298663435243399">로드 중...</translation>
-<translation id="6850409657436465440">아직 다운로드 중</translation>
-<translation id="6850830437481525139">탭 <ph name="TAB_COUNT" />개를 닫았습니다.</translation>
-<translation id="6864459304226931083">이미지 다운로드</translation>
-<translation id="6865313869410766144">양식 데이터 자동 완성</translation>
-<translation id="688738109438487280"><ph name="TO_ACCOUNT" />에 기존 데이터 추가</translation>
-<translation id="6891726759199484455">비밀번호를 복사하려면 잠금 해제하세요</translation>
-<translation id="6896758677409633944">복사</translation>
-<translation id="6910211073230771657">삭제됨</translation>
-<translation id="6912998170423641340">사이트에서 클립보드의 텍스트 및 이미지에 액세스하지 못하도록 차단</translation>
-<translation id="6914783257214138813">내보낸 파일을 볼 수 있는 모든 사용자에게 비밀번호가 표시됩니다.</translation>
-<translation id="6942665639005891494">언제든지 설정 메뉴 옵션으로 기본 다운로드 위치 변경 가능</translation>
-<translation id="6945221475159498467">선택</translation>
-<translation id="6963642900430330478">이 페이지는 위험합니다. 사이트 정보</translation>
-<translation id="6963766334940102469">북마크 삭제</translation>
-<translation id="6965382102122355670">확인</translation>
-<translation id="6979737339423435258">전체 기간</translation>
-<translation id="6981982820502123353">접근성</translation>
-<translation id="6989267951144302301">다운로드할 수 없음</translation>
-<translation id="6990079615885386641">Google Play 스토어에서 앱 다운로드: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">사이트에서 마이크를 사용하기 전에 확인(권장)</translation>
-<translation id="7015203776128479407">초기 동기화 설정이 완료되지 않았습니다. 동기화가 사용 중지되었습니다.</translation>
-<translation id="7016516562562142042">현재 검색엔진에 허용됨</translation>
-<translation id="7022756207310403729">브라우저에서 열기</translation>
-<translation id="702463548815491781">음성 안내 지원 또는 스위치 제어를 사용 중일 때 권장됩니다.</translation>
-<translation id="7029809446516969842">비밀번호</translation>
-<translation id="7053983685419859001">차단</translation>
-<translation id="7055152154916055070">다음 주소로의 리디렉션이 차단됨:</translation>
-<translation id="7063006564040364415">동기화 서버에 연결할 수 없습니다.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1개 선택됨}other{#개 선택됨}}</translation>
-<translation id="7071521146534760487">계정 관리</translation>
-<translation id="7077143737582773186">SD 카드</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" />개 선택됨. 화면 상단에서 옵션 선택 가능</translation>
-<translation id="7121362699166175603">검색주소창에 저장된 방문 기록과 자동 완성 내역을 지웁니다. Google 계정의 내 활동(<ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />)에는 인터넷 사용 기록이 다른 형식으로 남아 있을 수도 있습니다.</translation>
-<translation id="7128222689758636196">현재 검색엔진에 허용</translation>
-<translation id="7138678301420049075">기타</translation>
-<translation id="7141896414559753902">사이트에서 팝업 및 리디렉션을 표시하지 못하도록 차단(권장)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" />에서 <ph name="BEGIN_LINK" />원본 페이지 로드<ph name="END_LINK" />하기</translation>
-<translation id="7149893636342594995">지난 24시간</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" />KB</translation>
-<translation id="7177466738963138057">나중에 설정에서 변경 가능</translation>
-<translation id="7180611975245234373">새로고침</translation>
-<translation id="7189372733857464326">Google Play 서비스 업데이트 완료 대기 중</translation>
-<translation id="7191430249889272776">탭이 백그라운드에 열림</translation>
-<translation id="723171743924126238">이미지 선택</translation>
-<translation id="7233236755231902816">내가 사용하는 언어로 웹을 보려면 최신 버전의 Chrome을 사용하세요.</translation>
-<translation id="7243308994586599757">화면 하단에서 옵션 선택 가능</translation>
-<translation id="7248069434667874558"><ph name="TARGET_DEVICE_NAME" />에서 Chrome 동기화가 사용 설정되어 있는지 확인하세요.</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" />개 선택됨</translation>
-<translation id="7274013316676448362">차단된 사이트</translation>
-<translation id="7290209999329137901">이름 변경 불가</translation>
-<translation id="7291387454912369099">어시스턴트 트리거 확인</translation>
-<translation id="7293171162284876153">동기화를 시작하려면 'Chrome 데이터 동기화'를 사용 설정하세요.</translation>
-<translation id="729975465115245577">기기에 비밀번호 파일을 저장할 수 있는 앱이 없습니다.</translation>
-<translation id="7302081693174882195">세부정보: 저장된 데이터 양에 따라 정렬</translation>
-<translation id="7328017930301109123">Chrome의 라이트 모드를 사용하면 페이지가 더 빠르게 로드되고 데이터가 최대 60퍼센트 절약됩니다.</translation>
-<translation id="7333031090786104871">아직 이전 사이트 추가 중</translation>
-<translation id="7352939065658542140">동영상</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{선택한 1개 항목 공유}other{선택한 #개 항목 공유}}</translation>
 <translation id="7359002509206457351">결제 수단 액세스</translation>
+<translation id="8026334261755873520">인터넷 사용 기록 삭제</translation>
+<translation id="1291207594882862231">방문 기록, 쿠키, 사이트 데이터, 캐시 삭제…</translation>
+<translation id="7814200940910057384">Brave 데이터 삭제됨</translation>
+<translation id="1664855196866195614">선택한 데이터가 Brave 및 동기화된 기기에서 삭제되었습니다.
+
+<ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>에서 검색이나 기타 Brave Software 서비스에서의 활동 등 내 Brave Software 계정에 있는 다른 형식의 탐색 기록을 확인할 수 있습니다.</translation>
+<translation id="4699172675775169585">캐시된 이미지 또는 파일</translation>
+<translation id="2496180316473517155">인터넷 사용 기록</translation>
+<translation id="2546283357679194313">쿠키 및 사이트 데이터</translation>
+<translation id="8662811608048051533">대부분의 사이트에서 로그아웃됩니다.</translation>
+<translation id="8218628800671693884">대부분의 사이트에서 로그아웃됩니다. Brave Software 계정에서는 로그아웃되지 않습니다.</translation>
+<translation id="2017836877785168846">검색주소창의 검색 기록 및 자동 완성 항목을 삭제합니다.</translation>
+<translation id="8096327394278038498">검색주소창에 저장된 방문 기록과 자동 완성 내역을 지웁니다. Brave Software 계정의 내 활동(<ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>)에는 인터넷 사용 기록이 다른 형식으로 남아 있을 수도 있습니다.</translation>
+<translation id="8122693181154564064">로그인된 모든 기기에서 방문 기록을 지웁니다. Brave Software 계정의 내 활동(<ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>)에는 인터넷 사용 기록이 다른 형식으로 남아 있을 수도 있습니다.</translation>
+<translation id="5869522115854928033">저장된 비밀번호</translation>
+<translation id="6865313869410766144">양식 데이터 자동 완성</translation>
+<translation id="7562080006725997899">인터넷 사용 기록 삭제</translation>
+<translation id="5487521232677179737">인터넷 사용 기록 삭제</translation>
+<translation id="7498271377022651285">잠시 기다려 주세요…</translation>
+<translation id="784934925303690534">기간</translation>
+<translation id="1718835860248848330">지난 1시간</translation>
+<translation id="7149893636342594995">지난 24시간</translation>
+<translation id="5648166631817621825">지난 7일</translation>
+<translation id="8571213806525832805">지난 4주</translation>
+<translation id="5854790677617711513">30일 이상 전</translation>
+<translation id="6979737339423435258">전체 기간</translation>
+<translation id="982182592107339124">다음을 포함한 모든 사이트의 데이터가 삭제됩니다.</translation>
+<translation id="6643016212128521049">삭제</translation>
+<translation id="7641339528570811325">인터넷 사용 기록 삭제...</translation>
+<translation id="1670399744444387456">기본</translation>
+<translation id="3245261285041759672">Brave Software 계정의 내 활동(<ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>)에는 인터넷 사용 기록이 다른 형식으로 남아 있을 수도 있습니다.</translation>
+<translation id="7274013316676448362">차단된 사이트</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/>개 항목 삭제함</translation>
+<translation id="1121094540300013208">사용 및 비정상 종료 보고서</translation>
+<translation id="9079153198295609735">사용 통계 및 비정상 종료 보고서를 Brave Software에 자동으로 전송합니다.</translation>
+<translation id="6981982820502123353">접근성</translation>
+<translation id="2387895666653383613">텍스트 크기 조정</translation>
+<translation id="2321958826496381788">편하게 읽을 수 있을 때까지 슬라이더를 드래그하세요. 단락을 두 번 탭하면 텍스트가 이 이상의 크기로 표시됩니다.</translation>
+<translation id="3895926599014793903">확대/축소 강제 사용</translation>
+<translation id="5668404140385795438">웹사이트의 확대 방지 요청 무시</translation>
+<translation id="4149994727733219643">웹페이지 간단히 보기</translation>
+<translation id="9100505651305367705">지원되는 경우 간단히 보기로 기사를 표시하는 기능 제공</translation>
+<translation id="1409426117486808224">열린 탭 간단히 보기</translation>
+<translation id="702463548815491781">음성 안내 지원 또는 스위치 제어를 사용 중일 때 권장됩니다.</translation>
+<translation id="8284326494547611709">자막</translation>
+<translation id="4165986682804962316">사이트 설정</translation>
+<translation id="6295158916970320988">모든 사이트</translation>
+<translation id="8380167699614421159">이 사이트에서는 방해가 되거나 사용자를 현혹하는 광고를 표시합니다.</translation>
+<translation id="1919345977826869612">광고</translation>
+<translation id="410351446219883937">자동재생</translation>
+<translation id="6447842834002726250">쿠키</translation>
+<translation id="6196640612572343990">타사 쿠키 차단</translation>
+<translation id="6782111308708962316">타사 웹사이트에서 쿠키 데이터를 저장하거나 읽을 수 없도록 방지</translation>
+<translation id="7521387064766892559">자바스크립트</translation>
+<translation id="4434045419905280838">팝업 및 리디렉션</translation>
+<translation id="4751476147751820511">모션 또는 조도 센서</translation>
+<translation id="1717218214683051432">움직임 감지 센서</translation>
+<translation id="2091887806945687916">소리</translation>
+<translation id="2586657967955657006">클립보드</translation>
+<translation id="6320088164292336938">진동</translation>
+<translation id="4226663524361240545">알림이 있으면 진동이 울릴 수도 있습니다.</translation>
+<translation id="1446450296470737166">MIDI 기기의 전체 제어 허용</translation>
+<translation id="3744111561329211289">백그라운드 동기화</translation>
+<translation id="5649053991847567735">자동 다운로드</translation>
+<translation id="6181444274883918285">사이트 예외 추가</translation>
+<translation id="5313967007315987356">사이트 추가</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> 사이트 추가됨</translation>
+<translation id="7837721118676387834">특정 사이트에서 음소거된 동영상이 자동재생되도록 허용합니다.</translation>
+<translation id="2621115761605608342">특정 사이트에서 자바스크립트를 허용합니다.</translation>
+<translation id="8801436777607969138">특정 사이트의 자바스크립트를 차단합니다.</translation>
+<translation id="8372893542064058268">특정 사이트에서 백그라운드 동기화를 허용합니다.</translation>
+<translation id="358794129225322306">사이트에서 여러 파일을 자동으로 다운로드하도록 허용합니다.</translation>
+<translation id="4008040567710660924">특정 사이트의 쿠키를 허용합니다.</translation>
+<translation id="8958424370300090006">특정 사이트의 쿠키를 차단합니다.</translation>
+<translation id="7882806643839505685">특정 사이트에서 소리를 재생하도록 허용합니다.</translation>
+<translation id="4468959413250150279">특정 사이트를 음소거합니다.</translation>
+<translation id="1994173015038366702">사이트 URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">사용</translation>
+<translation id="5804241973901381774">권한</translation>
+<translation id="4278390842282768270">허용됨</translation>
+<translation id="5677928146339483299">차단됨</translation>
+<translation id="1984937141057606926">타사 쿠키만 제외하고 허용</translation>
+<translation id="7423098979219808738">우선 확인</translation>
+<translation id="8116925261070264013">음소거됨</translation>
+<translation id="8300705686683892304">앱에서 관리함</translation>
+<translation id="6192792657125177640">예외</translation>
+<translation id="257931822824936280">펼쳐짐 - 접으려면 클릭</translation>
+<translation id="5100237604440890931">접힘 - 펼치려면 클릭</translation>
+<translation id="857943718398505171">허용(권장)</translation>
+<translation id="2913331724188855103">사이트에서 쿠키 데이터를 저장하고 읽도록 허용(권장)</translation>
+<translation id="7445411102860286510">사이트에서 음소거된 동영상을 자동재생하도록 허용(권장)</translation>
+<translation id="5335288049665977812">사이트에서 자바스크립트를 실행하도록 허용(권장)</translation>
+<translation id="5527111080432883924">사이트에서 클립보드의 텍스트 및 이미지에 액세스하도록 허용하기 전에 확인(권장)</translation>
+<translation id="6912998170423641340">사이트에서 클립보드의 텍스트 및 이미지에 액세스하지 못하도록 차단</translation>
+<translation id="7423538860840206698">클립보드 액세스가 차단됨</translation>
+<translation id="3955193568934677022">사이트에서 보호된 콘텐츠를 재생하도록 허용(권장)</translation>
+<translation id="445467742685312942">사이트에서 보호된 콘텐츠를 재생하도록 허용</translation>
+<translation id="2107397443965016585">사이트에서 보호된 콘텐츠를 재생하도록 허용하기 전에 확인(권장)</translation>
+<translation id="2910701580606108292">사이트에서 보호된 콘텐츠를 재생하도록 허용하기 전에 확인</translation>
+<translation id="757524316907819857">사이트에서 보호된 콘텐츠를 재생하지 못하도록 차단</translation>
+<translation id="3277252321222022663">사이트의 센서 액세스 허용(권장)</translation>
+<translation id="5048398596102334565">사이트의 움직임 감지 센서 액세스 허용(권장)</translation>
+<translation id="8816026460808729765">사이트에서 센서에 액세스하지 못하도록 차단</translation>
+<translation id="169515064810179024">사이트에서 움직임 감지 센서에 액세스하지 못하도록 차단</translation>
+<translation id="1660204651932907780">사이트에서 소리를 재생하도록 허용(권장)</translation>
+<translation id="3600792891314830896">소리를 재생하는 사이트 음소거</translation>
+<translation id="1743802530341753419">사이트에서 내 기기에 연결하도록 허용하기 전에 확인(권장)</translation>
+<translation id="851751545965956758">사이트에서 기기에 연결하지 못하도록 차단</translation>
+<translation id="7141896414559753902">사이트에서 팝업 및 리디렉션을 표시하지 못하도록 차단(권장)</translation>
+<translation id="5494752089476963479">방해가 되거나 사용자를 현혹하는 광고를 표시하는 사이트의 광고 차단</translation>
+<translation id="3123473560110926937">일부 사이트에서 차단됨</translation>
+<translation id="965817943346481315">사이트에서 방해가 되거나 사용자를 현혹하는 광고를 표시하는 경우 광고 차단(권장)</translation>
+<translation id="3386292677130313581">사이트에서 내 위치를 파악하도록 허용하기 전에 확인(권장)</translation>
+<translation id="9139068048179869749">사이트에서 알림을 보내도록 허용하기 전에 확인(권장)</translation>
+<translation id="4479647676395637221">사이트에서 카메라를 사용하도록 허용하기 전에 확인(권장)</translation>
+<translation id="6992289844737586249">사이트에서 마이크를 사용하기 전에 확인(권장)</translation>
+<translation id="2289270750774289114">사이트가 주변 블루투스 기기를 조회하려고 할 때 확인(권장)</translation>
+<translation id="7053983685419859001">차단</translation>
+<translation id="7128222689758636196">현재 검색엔진에 허용</translation>
+<translation id="7589445247086920869">현재 검색엔진에 허용 안함</translation>
+<translation id="6388207532828177975">삭제 및 재설정</translation>
+<translation id="7999064672810608036">쿠키를 포함하여 이 웹사이트의 모든 로컬 데이터를 삭제하고 모든 권한을 재설정하시겠습니까?</translation>
+<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME"/>의 모든 사이트 권한을 재설정하시겠습니까?</translation>
+<translation id="515227803646670480">저장된 데이터 삭제</translation>
+<translation id="5902828464777634901">쿠키를 포함하여 이 웹사이트에 의해 저장된 모든 로컬 데이터가 삭제됩니다.</translation>
+<translation id="119944043368869598">모두 삭제</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/>에서 관리함</translation>
+<translation id="5516455585884385570">알림 설정 열기</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/>에 포함됨</translation>
+<translation id="129382876167171263">웹사이트에서 저장한 파일이 여기에 표시됩니다.</translation>
+<translation id="4181841719683918333">언어</translation>
+<translation id="2647434099613338025">언어 추가</translation>
+<translation id="1952172573699511566">가능한 경우 웹사이트에서 텍스트를 선호하는 언어로 표시합니다.</translation>
+<translation id="8559990750235505898">다른 언어로 된 페이지의 번역 옵션 제공</translation>
+<translation id="4719927025381752090">번역 옵션 제공</translation>
+<translation id="8156139159503939589">어떤 언어로 읽을 수 있으신가요?</translation>
+<translation id="5689516760719285838">위치</translation>
+<translation id="2440823041667407902">위치 정보 액세스</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서 Brave 관련 권한을 설정합니다.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서 Brave 관련 권한을 설정합니다.</translation>
+<translation id="2928908108430545745">Brave에서 위치 정보에 액세스하도록 허용하려면 <ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서도 위치를 사용 설정하세요.</translation>
+<translation id="1028853271388022585">Brave에서 카메라에 액세스하도록 허용하려면 <ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서도 카메라를 사용 설정하세요.</translation>
+<translation id="2913721282607281710">Brave에서 알림을 전송하도록 허용하려면 <ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서도 알림을 사용 설정하세요.</translation>
+<translation id="8753483718490035722">Brave에서 마이크에 액세스하도록 허용하려면 <ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서도 마이크를 사용 설정하세요.</translation>
+<translation id="1887786770086287077">이 기기의 위치 액세스가 사용 중지되었습니다. <ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서 사용 설정하세요.</translation>
+<translation id="2570922361219980984">이 기기의 위치 정보 액세스도 사용 중지되었습니다. <ph name="BEGIN_LINK"/>Android 설정<ph name="END_LINK"/>에서 사용 설정하세요.</translation>
+<translation id="1620510694547887537">카메라</translation>
+<translation id="3227137524299004712">마이크</translation>
+<translation id="1647391597548383849">카메라에 액세스</translation>
+<translation id="945632385593298557">마이크에 액세스</translation>
+<translation id="6612358246767739896">보호된 콘텐츠</translation>
+<translation id="885701979325669005">저장소</translation>
+<translation id="3198916472715691905">저장 데이터 <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">기기 액세스 권한 취소</translation>
+<translation id="4962975101802056554">기기에서 모든 권한을 취소합니다.</translation>
+<translation id="6545864417968258051">블루투스 검색</translation>
+<translation id="4411535500181276704">라이트 모드</translation>
+<translation id="7821588508402923572">절약한 데이터 양이 여기에 표시됩니다</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> 절약됨</translation>
+<translation id="8569404424186215731"><ph name="DATE"/>부터</translation>
+<translation id="3252158532344029638">Brave의 라이트 모드를 사용하면 페이지가 더 빠르게 로드되고 데이터가 최대 60퍼센트 절약됩니다.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> 데이터 절약</translation>
+<translation id="7494974237137038751">데이터 절약됨</translation>
+<translation id="6111020039983847643">데이터 사용됨</translation>
+<translation id="7413229368719586778">시작일: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">종료일: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">사이트별 정렬</translation>
+<translation id="5864174910718532887">세부정보: 사이트 이름별로 정렬</translation>
+<translation id="116280672541001035">사용</translation>
+<translation id="8349013245300336738">사용된 데이터 양에 따라 정렬</translation>
+<translation id="6378173571450987352">세부정보: 사용된 데이터 양에 따라 정렬</translation>
+<translation id="2631006050119455616">절약</translation>
+<translation id="6643649862576733715">저장된 데이터 양에 따라 정렬</translation>
+<translation id="7302081693174882195">세부정보: 저장된 데이터 양에 따라 정렬</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> 사용됨</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> 저장됨</translation>
+<translation id="2156074688469523661">남은 사이트(<ph name="NUMBER_OF_SITES"/>개)</translation>
+<translation id="7138678301420049075">기타</translation>
+<translation id="4913161338056004800">통계 재설정</translation>
+<translation id="1856325424225101786">라이트 모드를 재설정하시겠습니까?</translation>
+<translation id="3658159451045945436">재설정하면 방문한 사이트 목록을 비롯한 데이터 절약 기록이 삭제됩니다.</translation>
+<translation id="3295530008794733555">데이터를 절약하면서 웹을 더 빠르게 탐색하세요</translation>
+<translation id="7340390500800578919">Brave의 라이트 모드를 사용하면 페이지가 더 빠르게 로드되고 데이터가 최대 60퍼센트 절약됩니다. Brave에서는 사용자가 방문하는 페이지를 최적화하기 위해 웹 트래픽을 Brave Software에 전송합니다. <ph name="BEGIN_LINK"/>자세히 알아보기<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">라이트 모드 켜기</translation>
+<translation id="4493497663118223949">라이트 모드 사용 설정됨</translation>
+<translation id="7559975015014302720">라이트 모드 사용 중지됨</translation>
+<translation id="7606077192958116810">라이트 모드가 켜져 있습니다. 설정에서 기능을 관리하세요.</translation>
+<translation id="4714588616299687897">데이터 최대 60% 절약</translation>
+<translation id="1006927014032731288">Brave Software 서버에서 내가 방문하는 페이지를 최적화합니다.</translation>
+<translation id="3257320067425202300">Brave을 통해 <ph name="MEGABYTES"/>MB를 절약했습니다.</translation>
+<translation id="5813223329348543512">Brave을 통해 <ph name="GIGABYTES"/>GB를 절약했습니다.</translation>
+<translation id="8266862848225348053">다운로드 위치</translation>
+<translation id="7077143737582773186">SD 카드</translation>
+<translation id="7762668264895820836">SD 카드 <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">파일 저장 위치 묻기</translation>
+<translation id="6192333916571137726">다운로드 파일</translation>
+<translation id="1672586136351118594">다시 표시하지 않음</translation>
+<translation id="2650751991977523696">파일을 다시 다운로드하시겠습니까?</translation>
+<translation id="8664979001105139458">이미 존재하는 이름입니다.</translation>
+<translation id="488187801263602086">파일 이름 변경</translation>
+<translation id="5686790454216892815">파일 이름이 너무 깁니다.</translation>
+<translation id="7454641608352164238">저장공간 부족</translation>
+<translation id="8972098258593396643">기본 폴더에 다운로드하시겠습니까?</translation>
+<translation id="804335162455518893">SD 카드가 없음</translation>
+<translation id="7475688122056506577">SD 카드가 없습니다. 일부 파일이 누락되었을 수 있습니다.</translation>
+<translation id="4198423547019359126">사용할 수 있는 다운로드 위치가 없음</translation>
+<translation id="8224471946457685718">Wi-Fi로 추천 기사 다운로드</translation>
+<translation id="4970824347203572753">현재 위치에서 사용할 수 없습니다.</translation>
+<translation id="5500777121964041360">현재 지역에서는 지원되지 않을 수도 있습니다.</translation>
+<translation id="1173894706177603556">이름 바꾸기</translation>
+<translation id="1986685561493779662">이미 사용 중인 이름입니다.</translation>
+<translation id="6441734959916820584">이름이 너무 깁니다.</translation>
+<translation id="2923908459366352541">잘못된 이름</translation>
+<translation id="7290209999329137901">이름 변경 불가</translation>
+<translation id="3334729583274622784">파일 확장자를 변경하시겠습니까?</translation>
+<translation id="107147699690128016">파일 확장자를 변경하면 파일이 다른 애플리케이션에서 열리고 기기가 위험에 노출될 수도 있습니다.</translation>
+<translation id="8541922081612557424">Brave 정보</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. All rights reserved.</translation>
+<translation id="1416550906796893042">애플리케이션 버전</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/>(<ph name="TIME_SINCE_UPDATE"/>에 업데이트됨)</translation>
+<translation id="7596558890252710462">운영체제</translation>
+<translation id="3968054912784331254">이 버전의 Android에서는 더 이상 Brave 업데이트가 지원되지 않습니다.</translation>
+<translation id="7665369617277396874">계정 추가</translation>
+<translation id="649070405679044769">다음 계정으로 Brave Software에 로그인함:</translation>
+<translation id="6234515504547364178">Brave에서 로그아웃</translation>
+<translation id="5324858694974489420">자녀 보호 설정</translation>
+<translation id="8920114477895755567">부모님의 세부정보를 기다리는 중</translation>
+<translation id="5512137114520586844"><ph name="PARENT_NAME"/>님이 관리하는 계정입니다.</translation>
+<translation id="2956410042958133412"><ph name="PARENT_NAME_1"/>님과 <ph name="PARENT_NAME_2"/>님이 관리하는 계정입니다.</translation>
+<translation id="8168435359814927499">콘텐츠</translation>
+<translation id="5403644198645076998">특정 사이트만 허용</translation>
+<translation id="8641930654639604085">성인용 사이트 차단 시도</translation>
+<translation id="5639724618331995626">모든 사이트 허용</translation>
+<translation id="796823723482603597">Brave에서 실행 중</translation>
+<translation id="6324034347079777476">Android 시스템 동기화 사용 안함</translation>
+<translation id="5127805178023152808">동기화 사용 안함</translation>
+<translation id="7015203776128479407">초기 동기화 설정이 완료되지 않았습니다. 동기화가 사용 중지되었습니다.</translation>
+<translation id="2497852260688568942">관리자가 동기화를 사용 중지했습니다.</translation>
+<translation id="9100610230175265781">암호를 입력해야 합니다.</translation>
+<translation id="6108923351542677676">설정 진행 중...</translation>
+<translation id="4062305924942672200">법적 정보</translation>
+<translation id="4256782883801055595">오픈소스 라이선스</translation>
+<translation id="1138681184697033370">Brave 서비스 약관</translation>
+<translation id="7392539049993970338">Brave 개인정보처리방침</translation>
+<translation id="2677748264148917807">나가기</translation>
+<translation id="5556459405103347317">새로고침</translation>
+<translation id="1623104350909869708">이 페이지가 추가적인 대화를 생성하지 않도록 차단</translation>
+<translation id="2968755619301702150">인증서 뷰어</translation>
+<translation id="1360432990279830238">로그아웃하고 동기화를 사용 중지하시겠습니까?</translation>
+<translation id="8581481290581777242">기기에서 Brave 데이터를 삭제하시겠습니까?</translation>
+<translation id="1318865768845061710">북마크, 방문 기록, 비밀번호 등의 Brave 데이터가 더 이상 Brave Software 계정과 동기화되지 않습니다.</translation>
+<translation id="3325020657155065477">이 기기에서 내 Brave 데이터 삭제</translation>
+<translation id="6136448902816743006"><ph name="DOMAIN_NAME"/>이(가) 관리하는 계정에서 로그아웃하면 Brave 데이터가 이 기기에서 삭제됩니다. Brave Software 계정에서는 데이터가 삭제되지 않습니다.</translation>
+<translation id="1853026300647876496">Brave Software에 연결하는 중입니다. 잠시만 기다려 주세요...</translation>
+<translation id="2328985652426384049">로그인할 수 없음</translation>
+<translation id="7723158744459952869">Brave Software에서 응답하는 데 시간이 너무 오래 걸립니다.</translation>
+<translation id="4572422548854449519">관리 계정에 로그인</translation>
+<translation id="2689656545739939160"><ph name="MANAGED_DOMAIN"/>에서 관리하는 계정으로 로그인합니다. 계정 관리자가 내 Brave 데이터를 관리하게 되며 데이터는 이 계정에 영구적으로 연결됩니다. Brave에서 로그아웃하면 데이터가 이 기기에서 삭제되지만 Brave Software 계정에는 그대로 유지됩니다.</translation>
+<translation id="1749561566933687563">북마크 동기화</translation>
+<translation id="4242533952199664413">설정 열기</translation>
+<translation id="1111673857033749125">다른 기기에서 저장한 북마크가 여기에 표시됩니다.</translation>
+<translation id="8636825310635137004">다른 기기에서 탭을 가져오려면 동기화를 사용 설정하세요.</translation>
+<translation id="3269956123044984603">다른 기기에서 탭을 가져오려면 Android 계정 설정에서 '데이터 자동 동기화'를 사용 설정하세요.</translation>
+<translation id="5157964048453367290">다른 기기의 Brave에서 연 탭이 여기에 표시됩니다.</translation>
+<translation id="4684427112815847243">모두 동기화</translation>
+<translation id="2709516037105925701">자동 완성</translation>
+<translation id="8820817407110198400">북마크</translation>
+<translation id="1644574205037202324">방문 기록</translation>
+<translation id="17513872634828108">열린 탭</translation>
+<translation id="1320169905922104972">Brave Software Pay에 저장된 신용카드 및 주소</translation>
+<translation id="6337234675334993532">암호화</translation>
+<translation id="6698801883190606802">동기화된 데이터 관리</translation>
+<translation id="3598578758776312506">비밀번호를 Brave Software 사용자 인증 정보로 암호화</translation>
+<translation id="7810580217418711046"><ph name="TIME"/>에 Brave Software 비밀번호를 사용하여 동기화된 데이터 암호화</translation>
+<translation id="8461694314515752532">나만의 동기화 암호로 동기화된 데이터 암호화</translation>
+<translation id="2996291259634659425">암호 만들기</translation>
+<translation id="5713644099811900409">Brave Software 계정</translation>
+<translation id="8997474919031554666">Brave Software Pay 결제 수단 및 주소는 암호로 암호화되지 않습니다. 암호를 아는 사람만 암호화된 데이터를 읽을 수 있습니다. 암호는 Brave Software로 전송되거나 Brave Software에 저장되지 않습니다. 암호가 기억나지 않거나 이 설정을 변경하려면 동기화를 재설정해야 합니다. <ph name="BEGIN_LINK"/>자세히 알아보기<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">암호</translation>
+<translation id="7772032839648071052">암호 확인</translation>
+<translation id="5304593522240415983">필수 입력란입니다.</translation>
+<translation id="321773570071367578">암호를 잊어버렸거나 이 설정을 변경하려면 <ph name="BEGIN_LINK"/>동기화를 재설정<ph name="END_LINK"/>합니다.</translation>
+<translation id="3029704984691124060">암호가 일치하지 않습니다.</translation>
+<translation id="5149495116300586333">Brave Software Pay 결제 수단 및 주소는 암호로 암호화되지 않습니다.
+
+이 설정을 변경하려면 <ph name="BEGIN_LINK"/>동기화를 재설정<ph name="END_LINK"/>하세요.</translation>
+<translation id="7638584964844754484">암호가 잘못되었습니다.</translation>
+<translation id="5414836363063783498">확인 중...</translation>
+<translation id="6846298663435243399">로드 중...</translation>
+<translation id="5517095782334947753"><ph name="FROM_ACCOUNT"/>에서 가져온 북마크, 방문 기록, 비밀번호 및 기타 설정이 있습니다.</translation>
+<translation id="3928666092801078803">내 데이터 결합하기</translation>
+<translation id="688738109438487280"><ph name="TO_ACCOUNT"/>에 기존 데이터 추가</translation>
+<translation id="806745655614357130">내 데이터 별도로 유지</translation>
+<translation id="1145536944570833626">기존 데이터 삭제</translation>
+<translation id="1993768208584545658"><ph name="SITE"/>에서 페어링하려고 함</translation>
+<translation id="4915549754973153784">기기를 검색할 때 <ph name="BEGIN_LINK"/>도움말 보기<ph name="END_LINK"/>...</translation>
+<translation id="5817918615728894473">페어링</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>도움말 보기<ph name="END_LINK1"/> 또는 <ph name="BEGIN_LINK2"/>다시 검색하기<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">호환되는 기기 없음</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>블루투스를 사용 설정<ph name="END_LINK"/>하여 페어링을 허용하세요.</translation>
+<translation id="998321811308652668">Brave에서 블루투스 어댑터를 사용 설정할 수 없습니다.</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>도움 받기<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">기기를 스캔하려면 Brave에서 위치 정보에 액세스해야 합니다. <ph name="BEGIN_LINK"/>권한 업데이트<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">기기를 스캔하려면 Brave에서 위치 정보에 액세스해야 합니다. 위치 정보 액세스 권한이 <ph name="BEGIN_LINK"/>이 기기에서 사용 중지<ph name="END_LINK"/>되어 있습니다.</translation>
+<translation id="2367014990350929709">기기를 스캔하려면 Brave에서 위치 정보에 액세스해야 합니다. <ph name="BEGIN_LINK1"/>권한을 업데이트<ph name="END_LINK1"/>하세요. 또한 <ph name="BEGIN_LINK2"/>이 기기에서도 위치 정보 액세스 권한이 사용 중지<ph name="END_LINK2"/>되어 있습니다.</translation>
+<translation id="1569387923882100876">연결된 기기</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{신호 강도: 막대 #개}other{신호 강도: 막대 #개}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/>에서 주변 블루투스 기기를 검색하려고 합니다. 다음 기기가 발견되었습니다.</translation>
+<translation id="8368027906805972958">알 수 없거나 지원되지 않는 기기(<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">동기화가 작동하지 않음</translation>
+<translation id="1810845389119482123">초기 동기화 설정이 완료되지 않음</translation>
+<translation id="3235722914093408050">Android 설정을 열고 Android 시스템 동기화를 다시 사용 설정하여 Brave 동기화를 시작합니다.</translation>
+<translation id="3367813778245106622">다시 로그인하여 동기화 시작</translation>
+<translation id="974555521953189084">암호를 입력하여 동기화를 시작합니다.</translation>
+<translation id="2997266899014181325">동기화를 시작하려면 'Brave 데이터 동기화'를 사용 설정하세요.</translation>
+<translation id="8260126382462817229">다시 로그인해 주세요.</translation>
+<translation id="5919204609460789179"><ph name="PRODUCT_NAME"/>을(를) 업데이트하여 동기화를 시작합니다.</translation>
+<translation id="397583555483684758">동기화가 중지되었습니다.</translation>
+<translation id="1966710179511230534">로그인 세부정보를 업데이트하세요.</translation>
+<translation id="7063006564040364415">동기화 서버에 연결할 수 없습니다.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/>이(가) 이전 버전입니다.</translation>
+<translation id="4170011742729630528">서비스를 사용할 수 없습니다. 나중에 다시 시도해 주세요.</translation>
+<translation id="7947953824732555851">수락 및 로그인</translation>
+<translation id="8583805026567836021">계정 데이터 지우기</translation>
+<translation id="8310344678080805313">일반 탭</translation>
+<translation id="5748802427693696783">일반 탭으로 전환됨</translation>
+<translation id="7998918019931843664">닫은 탭 다시 열기</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, 탭</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> 탭 닫기</translation>
+<translation id="7243308994586599757">화면 하단에서 옵션 선택 가능</translation>
+<translation id="4060598801229743805">화면 상단에서 옵션을 선택할 수 있습니다.</translation>
+<translation id="2810645512293415242">페이지가 간소화되어 데이터가 절약되고 로드 속도가 빨라졌습니다.</translation>
+<translation id="3985215325736559418"><ph name="FILE_NAME"/> 파일을 다시 다운로드하시겠습니까?</translation>
+<translation id="2450083983707403292"><ph name="FILE_NAME"/>의 다운로드를 다시 시작하시겠습니까?</translation>
+<translation id="7514365320538308">다운로드</translation>
+<translation id="545042621069398927">다운로드 속도 향상</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{파일 다운로드 중}other{파일 #개 다운로드 중}}</translation>
+<translation id="543509235395288790">파일 <ph name="COUNT"/>개(<ph name="MEGABYTES"/>) 다운로드 중</translation>
+<translation id="4988210275050210843">파일 다운로드 중(<ph name="MEGABYTES"/>)</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{다운로드 1개 완료}other{다운로드 #개 완료}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{다운로드 1개 실패}other{다운로드 #개 실패}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{다운로드 1개 대기 중}other{다운로드 #개 대기 중}}</translation>
+<translation id="7396940094317457632">파일(<ph name="FILE_NAME"/>)이 다운로드되었습니다.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> 버튼</translation>
+<translation id="3205824638308738187">거의 완료되었습니다.</translation>
+<translation id="3960299545138990065">Brave 다시 시작하기</translation>
+<translation id="3771001275138982843">업데이트를 다운로드할 수 없음</translation>
+<translation id="3888648114124182147">Brave 업데이트 다운로드 중…</translation>
+<translation id="1705567146636171298">Brave 업데이트</translation>
+<translation id="6195417478702700398">최고의 탐색 환경을 사용하려면 Brave을 열고 업데이트하세요.</translation>
+<translation id="3512968675351418494">내가 사용하는 언어로 웹을 보려면 최신 버전의 Brave을 사용하세요.</translation>
+<translation id="6427112570124116297">웹 번역</translation>
+<translation id="1379423114029199501">최신 버전의 Brave에서 내가 사용하는 언어를 사용하려면 업데이트하세요.</translation>
+<translation id="5684874026226664614">죄송합니다. 이 페이지를 번역할 수 없습니다.</translation>
+<translation id="6831043979455480757">번역</translation>
+<translation id="1285320974508926690">이 사이트 번역 안함</translation>
+<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE"/>로 된 페이지를 항상 번역</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/>로 된 페이지는 번역하지 않음</translation>
+<translation id="124116460088058876">다른 언어</translation>
+<translation id="290376772003165898">페이지 언어가 <ph name="LANGUAGE"/>가 아닌가요?</translation>
+<translation id="4432792777822557199">지금부터 <ph name="SOURCE_LANGUAGE"/>로 된 페이지가 <ph name="TARGET_LANGUAGE"/>로 번역됩니다.</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/>로 된 페이지를 번역하지 않습니다.</translation>
+<translation id="5447765697759493033">이 사이트는 번역되지 않습니다.</translation>
+<translation id="4880127995492972015">번역...</translation>
+<translation id="641643625718530986">인쇄…</translation>
+<translation id="8909135823018751308">공유…</translation>
+<translation id="4996978546172906250">공유 방법</translation>
+<translation id="6333140779060797560">공유 방법: <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">페이지를 인쇄하는 중에 문제가 발생했습니다. 다시 시도해 주세요.</translation>
+<translation id="3254409185687681395">현재 페이지를 북마크에 추가</translation>
+<translation id="497421865427891073">앞으로 이동</translation>
+<translation id="813082847718468539">사이트 정보 보기</translation>
+<translation id="2532336938189706096">웹 보기</translation>
+<translation id="6005538289190791541">추천 비밀번호</translation>
+<translation id="4634124774493850572">비밀번호 사용</translation>
+<translation id="8285489906452138776">Brave이 이 사이트에서 카메라에 액세스하려면 권한이 필요합니다.</translation>
+<translation id="320189792589364011">Brave이 이 사이트에서 마이크에 액세스하려면 권한이 필요합니다.</translation>
+<translation id="7988136689212463100">Brave이 이 사이트에서 카메라와 마이크에 액세스하려면 권한이 필요합니다.</translation>
+<translation id="4931190655840828017">Brave이 이 사이트와 위치를 공유하려면 내 위치에 액세스하도록 허용해야 합니다.</translation>
+<translation id="3088191967551450609">Brave에서 파일을 다운로드하려면 저장소 액세스 권한이 있어야 합니다.</translation>
+<translation id="8942627711005830162">다른 창에서 열기</translation>
+<translation id="4195643157523330669">새 탭에서 열기</translation>
+<translation id="1100066534610197918">새 탭을 그룹에서 열기</translation>
+<translation id="4860895144060829044">전화걸기</translation>
+<translation id="6896758677409633944">복사</translation>
+<translation id="8393700583063109961">메시지 보내기</translation>
+<translation id="3557336313807607643">주소록에 추가</translation>
+<translation id="4269820728363426813">링크 주소 복사</translation>
+<translation id="1206892813135768548">링크 텍스트 복사</translation>
+<translation id="1204037785786432551">링크 다운로드</translation>
+<translation id="6864459304226931083">이미지 다운로드</translation>
+<translation id="8209050860603202033">이미지 열기</translation>
+<translation id="8073388330009372546">새 탭에서 이미지 열기</translation>
+<translation id="6649642165559792194">이미지 미리보기 표시 <ph name="BEGIN_NEW"/>새로운 기능<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">이미지 로드</translation>
+<translation id="3845332215609790146">Brave Software 렌즈로 검색 <ph name="BEGIN_NEW"/>New<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820"><ph name="SEARCH_ENGINE"/>에서 이 이미지 검색</translation>
+<translation id="3384347053049321195">이미지 공유</translation>
+<translation id="5833984609253377421">링크 공유</translation>
+<translation id="6475951671322991020">동영상 다운로드</translation>
+<translation id="2317945146070194624">새 Brave 탭에서 열기</translation>
+<translation id="7975379999046275268">페이지 미리보기 표시 <ph name="BEGIN_NEW"/>새로운 기능<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">페이지 새로고침</translation>
+<translation id="36525718899759834">Brave Software Play 스토어에서 앱 다운로드: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">어둡게</translation>
+<translation id="1807246157184219062">밝게</translation>
+<translation id="4056223980640387499">세피아</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">고정 너비</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">공유할 탭을 선택하세요.</translation>
+<translation id="8719023831149562936">현재 탭을 공유할 수 없습니다.</translation>
+<translation id="2139186145475833000">홈 화면에 추가</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> 열기</translation>
+<translation id="2122601567107267586">앱을 열 수 없음</translation>
+<translation id="5129038482087801250">웹 앱 설치</translation>
+<translation id="3789841737615482174">설치</translation>
+<translation id="4665282149850138822"><ph name="NAME"/>이(가) 홈 화면에 추가됨</translation>
+<translation id="7333031090786104871">아직 이전 사이트 추가 중</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> 추가 중...</translation>
+<translation id="3778956594442850293">홈 화면에 추가됨</translation>
+<translation id="2146738493024040262">인스턴트 앱 열기</translation>
+<translation id="7016516562562142042">현재 검색엔진에 허용됨</translation>
+<translation id="6177111841848151710">현재 검색엔진에는 허용되지 않음</translation>
+<translation id="145097072038377568">Android 설정에서 사용이 중지됨</translation>
+<translation id="8007176423574883786">기기에 대해 사용 중지됨</translation>
+<translation id="164269334534774161"><ph name="CREATION_TIME"/>에 작성된 이 페이지의 오프라인 사본을 보는 중입니다.</translation>
+<translation id="4594952190837476234">이 오프라인 페이지는 <ph name="CREATION_TIME"/>에 생성되었으며 온라인 버전과 다를 수 있습니다.</translation>
+<translation id="8840953339110955557">이 페이지는 온라인 버전과 다를 수 있습니다.</translation>
+<translation id="6405300764336705484">이 콘텐츠의 출처는 Brave Software에서 제공하는 <ph name="DOMAIN_NAME"/>입니다.</translation>
+<translation id="1006017844123154345">온라인 열기</translation>
+<translation id="3326636747541519688">Brave Software에서 제공하는 라이트 페이지</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/>에서 <ph name="BEGIN_LINK"/>원본 페이지 로드<ph name="END_LINK"/>하기</translation>
+<translation id="7475192538862203634">이 메시지가 자주 표시된다면 다음 <ph name="BEGIN_LINK"/>권장사항<ph name="END_LINK"/>을 시도해 보세요.</translation>
+<translation id="8748850008226585750">숨겨진 콘텐츠</translation>
+<translation id="3810973564298564668">관리</translation>
+<translation id="5199929503336119739">직장용 프로필</translation>
+<translation id="528192093759286357">전체화면을 종료하려면 상단에서 드래그하여 뒤로 버튼을 터치하세요.</translation>
+<translation id="2836148919159985482">전체화면을 종료하려면 뒤로 버튼을 터치하세요.</translation>
+<translation id="3967822245660637423">다운로드 완료</translation>
+<translation id="2434158240863470628">다운로드 완료: <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">다운로드 실패</translation>
+<translation id="1384959399684842514">다운로드 일시중지됨</translation>
+<translation id="1671236975893690980">다운로드 대기 중...</translation>
+<translation id="5561549206367097665">네트워크 대기 중…</translation>
+<translation id="5864419784173784555">다른 다운로드 대기 중…</translation>
+<translation id="6461962085415701688">파일을 열 수 없습니다</translation>
+<translation id="1178581264944972037">일시중지</translation>
+<translation id="8200772114523450471">다시 시작</translation>
+<translation id="1409879593029778104">파일이 이미 존재하여 <ph name="FILE_NAME"/> 다운로드가 중지되었습니다.</translation>
+<translation id="3387650086002190359">파일 시스템에 오류가 발생하여 <ph name="FILE_NAME"/>을(를) 다운로드할 수 없습니다.</translation>
+<translation id="6482749332252372425">저장공간이 부족하여 <ph name="FILE_NAME"/>을(를) 다운로드할 수 없습니다.</translation>
+<translation id="7619072057915878432">네트워크에 문제가 발생하여 <ph name="FILE_NAME"/>을(를) 다운로드할 수 없습니다.</translation>
+<translation id="1477626028522505441">서버 문제로 인해 <ph name="FILE_NAME"/>을(를) 다운로드할 수 없습니다.</translation>
+<translation id="3692944402865947621">저장 위치에 연결할 수 없어 <ph name="FILE_NAME"/>을(를) 다운로드할 수 없습니다.</translation>
+<translation id="604996488070107836">알 수 없는 오류로 인해 <ph name="FILE_NAME"/> 다운로드에 실패했습니다.</translation>
+<translation id="6738867403308150051">다운로드 중...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/>KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/>MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/>GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/>KB 다운로드됨</translation>
+<translation id="6416782512398055893"><ph name="MBS"/>MB 다운로드됨</translation>
+<translation id="6538442820324228105"><ph name="GBS"/>GB 다운로드됨</translation>
+<translation id="9204836675896933765">파일 1개가 남았습니다.</translation>
+<translation id="8186512483418048923">파일 <ph name="FILES"/>개가 남았습니다.</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/>개 파일 다운로드됨}other{<ph name="FILES_DOWNLOADED_MANY"/>개 파일 다운로드됨}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/>일 남음</translation>
+<translation id="8190358571722158785">1일 남음</translation>
+<translation id="60923314841986378"><ph name="HOURS"/>시간 남음</translation>
+<translation id="510275257476243843">1시간 남음</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/>분 남음</translation>
+<translation id="3236059992281584593">1분 남음</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/>초 남음</translation>
+<translation id="2781151931089541271">1초 남음</translation>
+<translation id="3303414029551471755">콘텐츠를 다운로드하시겠습니까?</translation>
+<translation id="8617240290563765734">다운로드한 콘텐츠에 지정된 추천 URL을 여시겠습니까?</translation>
+<translation id="1373696734384179344">선택한 콘텐츠를 다운로드할 공간이 부족합니다.</translation>
+<translation id="5271967389191913893">기기에서 다운로드하려는 콘텐츠를 열 수 없습니다.</translation>
+<translation id="883806473910249246">콘텐츠를 다운로드하는 중에 오류가 발생했습니다.</translation>
+<translation id="5626134646977739690">이름:</translation>
+<translation id="7963646190083259054">공급업체:</translation>
+<translation id="3414952576877147120">크기:</translation>
+<translation id="7375125077091615385">유형:</translation>
+<translation id="5765780083710877561">설명:</translation>
+<translation id="4881695831933465202">열기</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/>KB 사용 가능</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/>MB 사용 가능</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB 사용 가능</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/> 중 <ph name="SPACE_USED"/> 사용 중</translation>
+<translation id="3587482841069643663">전체</translation>
+<translation id="4988526792673242964">페이지</translation>
+<translation id="3810838688059735925">동영상</translation>
+<translation id="3616113530831147358">오디오</translation>
+<translation id="9219103736887031265">이미지</translation>
+<translation id="8250920743982581267">문서</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{파일 #개}other{파일 #개}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{이미지 #개}other{이미지 #개}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{동영상 #개}other{동영상 #개}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{오디오 파일 #개}other{오디오 파일 #개}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{#페이지}other{#페이지}}</translation>
+<translation id="5456381639095306749">다운로드 페이지</translation>
+<translation id="2394602618534698961">다운로드한 파일이 여기 표시됩니다.</translation>
+<translation id="7810647596859435254">연결 프로그램...</translation>
+<translation id="5655963694829536461">다운로드 항목 검색</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">내 파일</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">기사가 여기 표시되며 오프라인 상태에서도 읽을 수 있습니다.</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{#시간}other{#시간}}</translation>
+<translation id="5853623416121554550">일시중지</translation>
+<translation id="8965591936373831584">보류 중</translation>
+<translation id="2779651927720337254">실패</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">방금 전</translation>
+<translation id="4000212216660919741">오프라인 홈</translation>
+<translation id="9133397713400217035">오프라인 탐색</translation>
+<translation id="968900484120156207">방문한 페이지가 여기에 표시됩니다.</translation>
+<translation id="7882131421121961860">방문 기록이 없습니다.</translation>
+<translation id="3549657413697417275">방문 기록 검색</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave 첫 실행</translation>
+<translation id="2700285883409956633">이 애플리케이션을 사용하면 Brave의 <ph name="BEGIN_LINK1"/>서비스 약관<ph name="END_LINK1"/>과 <ph name="BEGIN_LINK2"/>개인정보처리방침<ph name="END_LINK2"/>에 동의하게 됩니다.</translation>
+<translation id="1640714894372474981">이 애플리케이션을 사용하면 Brave의 <ph name="BEGIN_LINK1"/>서비스 약관<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>개인정보처리방침<ph name="END_LINK2"/>, <ph name="BEGIN_LINK3"/>Family Link로 관리되는 Brave Software 계정용 개인정보처리방침<ph name="END_LINK3"/>에 동의하게 됩니다.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/>이(가) Brave에서 열립니다. 계속하면 Brave의 <ph name="BEGIN_LINK1"/>서비스 약관<ph name="END_LINK1"/> 및 <ph name="BEGIN_LINK2"/>개인정보처리방침<ph name="END_LINK2"/>에 동의하는 것으로 간주됩니다.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/>이(가) Brave에서 열립니다. 계속하면 Brave의 <ph name="BEGIN_LINK1"/>서비스 약관<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>개인정보처리방침<ph name="END_LINK2"/> 및 <ph name="BEGIN_LINK3"/>Family Link로 관리되는 Brave Software 계정용 개인정보처리방침<ph name="END_LINK3"/>에 동의하는 것으로 간주됩니다.</translation>
+<translation id="673197144963363525">사용 통계와 비정상 종료 보고서를 Brave Software로 전송하여 Brave을 개선하는 데 동참하세요.</translation>
+<translation id="3518985090088779359">동의하고 계속</translation>
+<translation id="7207456302801184289">Brave에 오신 것을 환영합니다</translation>
+<translation id="704822250101715322">Brave Software Play 서비스 업데이트 완료 대기 중</translation>
+<translation id="1231733316453485619">동기화를 사용하시겠습니까?</translation>
+<translation id="5132942445612118989">모든 기기의 비밀번호, 방문 기록 등 동기화</translation>
+<translation id="5736731321935944068">Brave Software에서 내 방문 기록을 사용하여 Brave Software 검색, 광고 및 다른 Brave Software 서비스를 맞춤설정할 수 있습니다.</translation>
+<translation id="4013614219085422040">Brave Software에서 내 방문 기록을 사용하여 Brave Software 검색 및 다른 Brave Software 서비스를 맞춤설정할 수 있습니다.</translation>
+<translation id="5581519193887989363">언제든지 <ph name="BEGIN_LINK1"/>설정<ph name="END_LINK1"/>에서 동기화할 항목을 선택할 수 있습니다.</translation>
+<translation id="741204030948306876">사용</translation>
+<translation id="2410754283952462441">계정 선택</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/>(으)로 계속</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/>이(가) 아닌가요?</translation>
+<translation id="8109613176066109935">어느 기기에서나 내 북마크를 사용하려면 동기화를 사용 설정하세요.</translation>
+<translation id="2818669890320396765">어느 기기에서나 내 북마크를 사용하려면 로그인하고 동기화를 사용 설정하세요.</translation>
+<translation id="6003646045106347985">Brave Software에서 추천하는 맞춤 콘텐츠를 보려면 동기화를 사용 설정하세요.</translation>
+<translation id="8494430740943879273">Brave Software에서 추천하는 맞춤 콘텐츠를 보려면 로그인하고 동기화를 사용 설정하세요.</translation>
+<translation id="5862731021271217234">다른 기기에서 탭을 가져오려면 동기화를 사용 설정하세요.</translation>
+<translation id="3568688522516854065">다른 기기에서 탭을 가져오려면 로그인하고 동기화를 사용 설정하세요.</translation>
+<translation id="1208340532756947324">모든 기기에서 동기화 및 맞춤설정하려면 동기화를 사용 설정하세요.</translation>
+<translation id="4472118726404937099">모든 기기에서 동기화하고 맞춤설정하려면 로그인하고 동기화를 사용 설정하세요.</translation>
+<translation id="2426805022920575512">다른 계정 선택</translation>
+<translation id="6790428901817661496">재생</translation>
+<translation id="1272079795634619415">중지</translation>
+<translation id="2874939134665556319">이전 트랙</translation>
+<translation id="4046123991198612571">다음 트랙</translation>
+<translation id="3859306556332390985">앞으로 탐색</translation>
+<translation id="8441146129660941386">뒤로 탐색</translation>
+<translation id="6706288973712894588">현재 오프라인 상태입니다.\n<ph name="BEGIN_LINK"/>오프라인 피드를 둘러보세요.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">최근 탭</translation>
+<translation id="8497726226069778601">아직 표시할 내용 없음</translation>
+<translation id="5423934151118863508">자주 방문한 페이지가 여기에 표시됩니다.</translation>
+<translation id="6127379762771434464">항목 삭제됨</translation>
+<translation id="4605958867780575332"><ph name="ITEM_TITLE"/> 삭제됨</translation>
+<translation id="1996480094660735607">Brave Software 기념일 로고: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">다른 기기</translation>
+<translation id="4738836084190194332">마지막 동기화 시간: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{#분 전}other{#분 전}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{#시간 전}other{#시간 전}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{#일 전}other{#일 전}}</translation>
+<translation id="2762000892062317888">방금 전</translation>
+<translation id="1407135791313364759">모두 열기</translation>
+<translation id="1209206284964581585">지금 숨기기</translation>
+<translation id="129553762522093515">최근에 닫은 탭</translation>
+<translation id="8413126021676339697">방문 기록 전체 보기</translation>
+<translation id="7876243839304621966">모두 삭제</translation>
+<translation id="8487700953926739672">오프라인으로 사용 가능</translation>
+<translation id="5224771365102442243">동영상 포함</translation>
+<translation id="3493531032208478708">추천 콘텐츠 <ph name="BEGIN_LINK"/>자세히 알아보기<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">추천을 받을 수 없음</translation>
+<translation id="5013696553129441713">새로운 추천 콘텐츠 없음</translation>
+<translation id="1736419249208073774">탐색</translation>
+<translation id="7444811645081526538">카테고리 더보기</translation>
+<translation id="6709133671862442373">뉴스</translation>
+<translation id="1264974993859112054">스포츠</translation>
+<translation id="9139318394846604261">쇼핑</translation>
+<translation id="3912508018559818924">웹에서 최상의 결과를 찾는 중…</translation>
+<translation id="526421993248218238">이 페이지를 로드할 수 없습니다.</translation>
+<translation id="614940544461990577">다음 방법을 시도해 보세요.</translation>
+<translation id="3288003805934695103">페이지 새로고침</translation>
+<translation id="2353636109065292463">인터넷 연결 상태를 확인하세요.</translation>
+<translation id="2858138569776157458">인기 사이트</translation>
+<translation id="8364299278605033898">인기 웹사이트 보기</translation>
+<translation id="1171770572613082465">'인기 사이트' 버튼을 탭하여 인기 웹사이트를 확인하세요.</translation>
+<translation id="5233638681132016545">새 탭</translation>
+<translation id="4521874409998847950">발신자: <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>Brave Software 제공<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">최신 버전 사용 가능</translation>
+<translation id="4058091506841967397">Brave을 업데이트할 수 없습니다.</translation>
+<translation id="6316139424528454185">지원되지 않는 Android 버전입니다.</translation>
+<translation id="6989267951144302301">다운로드할 수 없음</translation>
+<translation id="624789221780392884">업데이트 준비 완료</translation>
+<translation id="1549000191223877751">다른 창으로 이동</translation>
+<translation id="7481312909269577407">앞으로</translation>
+<translation id="4084682180776658562">북마크</translation>
+<translation id="6437478888915024427">페이지 정보</translation>
+<translation id="7180611975245234373">새로고침</translation>
+<translation id="4913169188695071480">새로고침 중지</translation>
+<translation id="1829244130665387512">페이지에서 찾기</translation>
+<translation id="6593061639179217415">데스크톱 사이트</translation>
+<translation id="9063523880881406963">데스크톱 버전으로 보기 사용 중지</translation>
+<translation id="2038563949887743358">데스크톱 버전으로 보기 사용 설정</translation>
+<translation id="2433507940547922241">모양</translation>
+<translation id="983192555821071799">탭 모두 닫기</translation>
+<translation id="1310482092992808703">탭 그룹화</translation>
+<translation id="7725024127233776428">북마크한 페이지가 여기에 표시됩니다.</translation>
+<translation id="4404568932422911380">북마크 없음</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{북마크 <ph name="BOOKMARKS_COUNT_ONE"/>개}other{북마크 <ph name="BOOKMARKS_COUNT_MANY"/>개}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> 북마크에 추가됨</translation>
+<translation id="3207960819495026254">북마크에 추가됨</translation>
+<translation id="4452548195519783679">북마크를 <ph name="FOLDER_NAME"/>에 추가함</translation>
+<translation id="8063895661287329888">북마크를 추가하지 못했습니다.</translation>
+<translation id="2842985007712546952">상위 폴더</translation>
+<translation id="9065203028668620118">수정</translation>
+<translation id="4405224443901389797">다음 폴더로 이동…</translation>
+<translation id="5170568018924773124">폴더 열기</translation>
+<translation id="8035133914807600019">새 폴더…</translation>
+<translation id="4532845899244822526">폴더 선택</translation>
+<translation id="6627583120233659107">폴더 수정</translation>
+<translation id="1197267115302279827">북마크 이동</translation>
+<translation id="6963766334940102469">북마크 삭제</translation>
+<translation id="4351244548802238354">대화상자 닫기</translation>
+<translation id="451872707440238414">북마크 검색</translation>
+<translation id="8901170036886848654">북마크가 없습니다.</translation>
+<translation id="6404511346730675251">북마크 수정</translation>
+<translation id="3894427358181296146">폴더 추가</translation>
+<translation id="5327248766486351172">이름</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">폴더</translation>
+<translation id="5161254044473106830">제목이 필요합니다.</translation>
+<translation id="2996809686854298943">URL이 필요합니다.</translation>
+<translation id="2536728043171574184">이 페이지의 오프라인 사본 보는 중</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/>에서 오프라인으로 보기</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> 및 그 외 사이트</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{준비가 완료되면 Brave에서 페이지를 로드합니다.}other{준비가 완료되면 Brave에서 페이지를 로드합니다.}}</translation>
+<translation id="6811034713472274749">페이지를 볼 수 있음</translation>
+<translation id="4561979708150884304">연결되지 않음</translation>
+<translation id="8274165955039650276">다운로드 항목 보기</translation>
+<translation id="2082238445998314030">전체 결과 <ph name="TOTAL_RESULTS"/>개 중 <ph name="RESULT_NUMBER"/>개</translation>
+<translation id="4943872375798546930">검색결과가 없습니다.</translation>
+<translation id="981121421437150478">오프라인</translation>
+<translation id="3298243779924642547">라이트</translation>
+<translation id="393697183122708255">사용 가능한 음성 검색이 없습니다.</translation>
+<translation id="7191430249889272776">탭이 백그라운드에 열림</translation>
+<translation id="8445059357334030806">Brave에서 열기</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/>에서 열기</translation>
+<translation id="7022756207310403729">브라우저에서 열기</translation>
+<translation id="1113597929977215864">간단히 보기 표시</translation>
+<translation id="1513352483775369820">북마크 및 방문 기록</translation>
+<translation id="4939482511480190003">Brave을 개선하는 데 도움을 주세요. <ph name="BEGIN_LINK"/>설문조사 참여하기<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">뒤로 이동</translation>
+<translation id="5596627076506792578">옵션 더보기</translation>
+<translation id="3522247891732774234">업데이트할 수 있습니다. 옵션 더보기</translation>
+<translation id="6773423637732432200">Brave을 업데이트할 수 없습니다. 옵션 더보기</translation>
+<translation id="3328801116991980348">사이트 정보</translation>
+<translation id="5391532827096253100">이 사이트와의 연결은 안전하지 않습니다. 사이트 정보</translation>
+<translation id="6206551242102657620">이 사이트와의 연결은 안전합니다. 사이트 정보</translation>
+<translation id="6963642900430330478">이 페이지는 위험합니다. 사이트 정보</translation>
+<translation id="9070377983101773829">음성 검색 시작</translation>
+<translation id="8676374126336081632">입력내용 지우기</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{열려 있는 탭 <ph name="OPEN_TABS_ONE"/>개, 탭 간에 전환하려면 탭하세요.}other{열려 있는 탭 <ph name="OPEN_TABS_MANY"/>개, 탭 간에 전환하려면 탭하세요.}}</translation>
+<translation id="2369533728426058518">열린 탭</translation>
+<translation id="7071521146534760487">계정 관리</translation>
+<translation id="932327136139879170">홈</translation>
+<translation id="2707726405694321444">페이지 새로고침</translation>
+<translation id="2891154217021530873">페이지 로딩 중지</translation>
+<translation id="6710213216561001401">이전</translation>
+<translation id="6659594942844771486">탭</translation>
+<translation id="1933845786846280168">선택된 탭</translation>
+<translation id="2268044343513325586">상세검색</translation>
+<translation id="7846076177841592234">선택 취소</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/>개 선택됨. 화면 상단에서 옵션 선택 가능</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/>개 선택됨</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{선택한 1개 항목 공유}other{선택한 #개 항목 공유}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{선택한 1개 항목 삭제}other{선택한 #개 항목 삭제}}</translation>
+<translation id="1283039547216852943">탭하여 펼치기</translation>
+<translation id="5962718611393537961">탭하여 접기</translation>
+<translation id="8076492880354921740">탭</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1개 선택됨}other{#개 선택됨}}</translation>
+<translation id="6818926723028410516">항목 선택</translation>
+<translation id="4797039098279997504">터치하여 <ph name="URL_OF_THE_CURRENT_TAB"/>(으)로 돌아가기</translation>
+<translation id="6766758767654711248">탭하여 사이트로 이동</translation>
+<translation id="429312253194641664">사이트에서 미디어 재생 중</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/>에서 내 화면을 공유하는 중입니다.</translation>
+<translation id="8833831881926404480">사이트에서 화면을 공유하는 중입니다.</translation>
+<translation id="9086455579313502267">네트워크에 액세스할 수 없습니다.</translation>
+<translation id="938850635132480979">오류: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/>에서 열기</translation>
+<translation id="548278423535722844">지도 앱에서 열기</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/>에서 이메일 만들기</translation>
+<translation id="7875915731392087153">이메일 만들기</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/>에 일정 만들기</translation>
+<translation id="2900528713135656174">일정 만들기</translation>
+<translation id="2111511281910874386">페이지로 이동</translation>
+<translation id="3988466920954086464">이 패널에서 순간 검색결과 보기</translation>
+<translation id="2744248271121720757">단어를 탭하여 즉시 검색하거나 관련 작업을 확인하세요</translation>
+<translation id="9155898266292537608">단어를 살짝 탭하여 검색할 수도 있습니다</translation>
+<translation id="3232754137068452469">웹 앱</translation>
+<translation id="1430915738399379752">인쇄</translation>
+<translation id="3775705724665058594">기기로 전송</translation>
+<translation id="6364438453358674297">기록에서 제안을 삭제하시겠습니까?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> 닫음</translation>
+<translation id="6850830437481525139">탭 <ph name="TAB_COUNT"/>개를 닫았습니다.</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> 삭제됨</translation>
+<translation id="4663756553811254707">북마크 <ph name="NUMBER_OF_BOOKMARKS"/>개 삭제됨</translation>
+<translation id="3819178904835489326">다운로드 <ph name="NUMBER_OF_DOWNLOADS"/>개 삭제됨</translation>
+<translation id="1248710015876067820">지원되지 않는 Brave 인스턴스 수입니다.</translation>
+<translation id="4259722352634471385">탐색이 차단됨: <ph name="URL"/></translation>
+<translation id="8959122750345127698">탐색할 수 없음: <ph name="URL"/></translation>
+<translation id="5210365745912300556">탭 닫기</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> 닫기</translation>
+<translation id="1227058898775614466">탐색 기록</translation>
+<translation id="9169507124922466868">탐색 기록이 절반 높이로 열림</translation>
+<translation id="1327257854815634930">탐색 기록 열림</translation>
+<translation id="8788265440806329501">탐색 기록 닫힘</translation>
+<translation id="7482656565088326534">미리보기 탭</translation>
+<translation id="8427875596167638501">미리보기 탭이 절반 높이로 열림</translation>
+<translation id="9102803872260866941">미리보기 탭 열림</translation>
+<translation id="2942036813789421260">미리보기 탭 닫힘</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> 저장공간</translation>
+<translation id="3822502789641063741">사이트 저장공간을 삭제하시겠습니까?</translation>
+<translation id="9205995714227143200">Brave에서 중요하다고 간주하지 않는 사이트 저장공간(예: 저장된 설정이 없거나 사용자가 자주 방문하지 않는 사이트)</translation>
+<translation id="3997476611815694295">중요하지 않은 저장공간</translation>
+<translation id="8493948351860045254">저장 공간 확보하기</translation>
+<translation id="2324920234469020158">이를 통해 쿠키, 캐시 및 Brave에서 중요하다고 간주하지 않는 사이트의 기타 데이터가 삭제됩니다.</translation>
+<translation id="5447201525962359567">쿠키 및 기타 로컬에 저장된 데이터 등 모든 사이트 저장공간</translation>
+<translation id="1376578503827013741">계산 중...</translation>
+<translation id="583281660410589416">알 수 없음</translation>
+<translation id="2323763861024343754">사이트 저장공간</translation>
+<translation id="3587672679800759167">계정, 북마크, 저장된 설정 등 Brave에서 사용한 전체 데이터</translation>
+<translation id="6545017243486555795">모든 데이터 삭제</translation>
+<translation id="4095146165863963773">앱 데이터를 삭제하시겠습니까?</translation>
+<translation id="53119194224775367">모든 파일, 설정, 계정, 데이터베이스 등을 포함한 Brave의 모든 앱 데이터가 완전히 삭제됩니다.</translation>
+<translation id="5307446750509046227">사이트 저장용량 삭제</translation>
+<translation id="300526633675317032">웹사이트 저장공간 <ph name="SIZE_IN_KB"/>가 모두 삭제됩니다.</translation>
+<translation id="8068648041423924542">인증서를 선택할 수 없습니다.</translation>
+<translation id="2315043854645842844">클라이언트측 인증서 선택이 운영체제에서 지원되지 않습니다.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/>에서 연결하려고 함</translation>
+<translation id="5308380583665731573">연결</translation>
+<translation id="868929229000858085">연락처 검색</translation>
+<translation id="1919950603503897840">연락처 선택</translation>
+<translation id="7986741934819883144">연락처 선택</translation>
+<translation id="3333961966071413176">모든 연락처</translation>
+<translation id="4994033804516042629">연락처 없음</translation>
+<translation id="5403592356182871684">이름</translation>
+<translation id="2717722538473713889">이메일 주소</translation>
+<translation id="381841723434055211">전화번호</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(외 1개)}other{(외 #개)}}</translation>
+<translation id="5197729504361054390">선택한 연락처가 <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>과(와) 공유됩니다.</translation>
+<translation id="1779089405699405702">이미지 디코더</translation>
+<translation id="8067883171444229417">동영상 재생</translation>
+<translation id="6560414384669816528">Sogou로 검색</translation>
+<translation id="5406914950576900927">중국에서 검색할 때 Brave에서 <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>를 사용할 수 있습니다. <ph name="BEGIN_LINK"/>설정<ph name="END_LINK"/>에서 변경할 수 있습니다.</translation>
+<translation id="6456271171669383967">계속 Brave Software 사용</translation>
+<translation id="4384468725000734951">검색할 때 Sogou 사용</translation>
+<translation id="6103327872225198548">검색할 때 Brave Software 사용</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/>(<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">이 앱은 Brave에서 실행 중입니다.</translation>
+<translation id="6143689084714664628">Brave에서 실행 중</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/>도 Brave에서 데이터를 보유하고 있습니다</translation>
+<translation id="2734140769649165081">Brave 설정에서 데이터를 삭제할 수 있습니다.</translation>
+<translation id="8232956427053453090">데이터 보관</translation>
+<translation id="4298388696830689168">연결된 사이트</translation>
+<translation id="5763514718066511291">탭하여 이 앱의 URL 복사하기</translation>
+<translation id="6496823230996795692">처음으로 <ph name="APP_NAME"/>을(를) 사용하는 경우 인터넷에 연결하세요.</translation>
+<translation id="751961395872307827">사이트에 연결할 수 없습니다</translation>
+<translation id="4878404682131129617">프록시 서버를 통한 터널 설정에 실패했습니다</translation>
+<translation id="4749960740855309258">새 탭 열기</translation>
+<translation id="8788968922598763114">마지막으로 닫은 탭 다시 열기</translation>
+<translation id="7929962904089429003">메뉴 열기</translation>
+<translation id="6039379616847168523">다음 탭으로 이동</translation>
+<translation id="5210286577605176222">이전 탭으로 이동</translation>
+<translation id="124678866338384709">현재 탭 닫기</translation>
+<translation id="3714981814255182093">찾기 창 열기</translation>
+<translation id="5441522332038954058">검색주소창으로 이동</translation>
+<translation id="3398320232533725830">북마크 관리자 열기</translation>
+<translation id="6583199322650523874">현재 페이지 북마크</translation>
+<translation id="8489271220582375723">방문 기록 페이지 열기</translation>
+<translation id="4837753911714442426">옵션을 열어 페이지 인쇄</translation>
+<translation id="5726692708398506830">페이지의 모든 항목 확대</translation>
+<translation id="3259831549858767975">페이지의 모든 항목 축소</translation>
+<translation id="8015452622527143194">페이지의 모든 항목을 기본 크기로 되돌리기</translation>
+<translation id="3443221991560634068">현재 페이지 새로고침</translation>
+<translation id="123724288017357924">캐시된 콘텐츠를 무시하고 현재 페이지 새로고침</translation>
+<translation id="305870044889644984">새 탭에서 Brave 고객센터 열기</translation>
+<translation id="3166827708714933426">탭 및 창 단축키</translation>
+<translation id="3169981355900570544">Brave 기능 단축키</translation>
+<translation id="4558311620361989323">웹페이지 단축키</translation>
+<translation id="1908301351964700579">Brave에서 아직 VR을 준비하고 있습니다. 나중에 Brave을 다시 시작하세요.</translation>
+<translation id="8970887620466824814">문제 발생</translation>
+<translation id="1875543012935658554">Brave을 다시 여세요.</translation>
+<translation id="79859296434321399">증강 현실 콘텐츠를 보려면 ARCore를 설치하세요.</translation>
+<translation id="8558485628462305855">증강 현실 콘텐츠를 보려면 ARCore를 업데이트하세요.</translation>
+<translation id="3513704683820682405">증강 현실</translation>
+<translation id="5475862044948910901">증강 현실 세션을 시작할까요?</translation>
 <translation id="7365126855094612066">세션이 실행되는 동안 사이트에서 다음을 실행할 수 있습니다.
 • 사용자 환경을 3D 지도로 작성
 • 카메라 모션 추적
 
 사이트에서 카메라 액세스 권한을 요구하지 않습니다. 카메라 이미지는 나에게만 표시됩니다.</translation>
-<translation id="7375125077091615385">유형:</translation>
-<translation id="7396940094317457632">파일(<ph name="FILE_NAME" />)이 다운로드되었습니다.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome 첫 실행</translation>
-<translation id="741204030948306876">사용</translation>
-<translation id="7413229368719586778">시작일: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">우선 확인</translation>
-<translation id="7423538860840206698">클립보드 액세스가 차단됨</translation>
-<translation id="7431991332293347422">검색 등을 맞춤설정하는 데 인터넷 방문 기록이 사용되는 방식 관리</translation>
-<translation id="7437998757836447326">Chrome에서 로그아웃</translation>
-<translation id="7438641746574390233">라이트 모드가 사용 설정되어 있으면 Chrome이 Google 서버를 사용하여 페이지를 더 빠르게 로드합니다. 라이트 모드에서는 속도가 아주 느린 페이지를 다시 작성하여 꼭 필요한 콘텐츠만 로드합니다. 시크릿 탭에는 라이트 모드가 적용되지 않습니다.</translation>
-<translation id="7444811645081526538">카테고리 더보기</translation>
-<translation id="7445411102860286510">사이트에서 음소거된 동영상을 자동재생하도록 허용(권장)</translation>
-<translation id="7453467225369441013">대부분의 사이트에서 로그아웃됩니다. Google 계정에서는 로그아웃되지 않습니다.</translation>
-<translation id="7454641608352164238">저장공간 부족</translation>
-<translation id="7475192538862203634">이 메시지가 자주 표시된다면 다음 <ph name="BEGIN_LINK" />권장사항<ph name="END_LINK" />을 시도해 보세요.</translation>
-<translation id="7475688122056506577">SD 카드가 없습니다. 일부 파일이 누락되었을 수 있습니다.</translation>
-<translation id="7479104141328977413">탭 관리</translation>
-<translation id="7481312909269577407">앞으로</translation>
-<translation id="7482656565088326534">미리보기 탭</translation>
-<translation id="7493994139787901920"><ph name="VERSION" />(<ph name="TIME_SINCE_UPDATE" />에 업데이트됨)</translation>
-<translation id="7494974237137038751">데이터 절약됨</translation>
-<translation id="7498271377022651285">잠시 기다려 주세요…</translation>
-<translation id="7514365320538308">다운로드</translation>
-<translation id="751961395872307827">사이트에 연결할 수 없습니다</translation>
-<translation id="7521387064766892559">자바스크립트</translation>
-<translation id="7542481630195938534">추천을 받을 수 없음</translation>
-<translation id="7559975015014302720">라이트 모드 사용 중지됨</translation>
-<translation id="7562080006725997899">인터넷 사용 기록 삭제</translation>
-<translation id="756809126120519699">Chrome 데이터 삭제됨</translation>
-<translation id="757524316907819857">사이트에서 보호된 콘텐츠를 재생하지 못하도록 차단</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" />개 파일 다운로드됨}other{<ph name="FILES_DOWNLOADED_MANY" />개 파일 다운로드됨}}</translation>
-<translation id="7588219262685291874">기기 절전 모드 사용 시 어두운 테마 사용 설정</translation>
-<translation id="7589445247086920869">현재 검색엔진에 허용 안함</translation>
-<translation id="7593557518625677601">Android 설정을 열고 Android 시스템 동기화를 다시 사용 설정하여 Chrome 동기화를 시작합니다.</translation>
-<translation id="7596558890252710462">운영체제</translation>
-<translation id="7605594153474022051">동기화가 작동하지 않음</translation>
-<translation id="7606077192958116810">라이트 모드가 켜져 있습니다. 설정에서 기능을 관리하세요.</translation>
-<translation id="7612619742409846846">다음 계정으로 Google에 로그인함:</translation>
-<translation id="7619072057915878432">네트워크에 문제가 발생하여 <ph name="FILE_NAME" />을(를) 다운로드할 수 없습니다.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />도움말 보기<ph name="END_LINK1" /> 또는 <ph name="BEGIN_LINK2" />다시 검색하기<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome에 오신 것을 환영합니다</translation>
-<translation id="7638584964844754484">암호가 잘못되었습니다.</translation>
-<translation id="7641339528570811325">인터넷 사용 기록 삭제...</translation>
-<translation id="7648422057306047504">비밀번호를 Google 사용자 인증 정보로 암호화</translation>
-<translation id="7649070708921625228">도움말</translation>
-<translation id="7658239707568436148">취소</translation>
-<translation id="7665369617277396874">계정 추가</translation>
-<translation id="766587987807204883">기사가 여기 표시되며 오프라인 상태에서도 읽을 수 있습니다.</translation>
-<translation id="7682724950699840886">다음 방법을 시도해 보세요. 기기 저장용량이 충분한지 확인하고 다시 내보내 봅니다.</translation>
-<translation id="7685301384041462804">VR로 들어가기 전에 이 사이트를 신뢰할 수 있는지 확인하세요.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" />에서 이메일 만들기</translation>
-<translation id="7704317875155739195">검색어 및 URL 자동 완성</translation>
-<translation id="7725024127233776428">북마크한 페이지가 여기에 표시됩니다.</translation>
-<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE" />로 된 페이지를 항상 번역</translation>
-<translation id="7746457520633464754">Chrome은 위험한 앱 및 사이트를 감지하기 위해 일부 방문 페이지의 URL, 제한적인 시스템 정보, 페이지 콘텐츠 일부를 Google로 전송합니다.</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" />에서 공유된 텍스트</translation>
-<translation id="7762668264895820836">SD 카드 <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">주소 추가</translation>
-<translation id="7772032839648071052">암호 확인</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> 닫기</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />개}other{<ph name="PAYMENT_METHOD_PREVIEW" /> 외 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />개}}</translation>
-<translation id="7781829728241885113">어제</translation>
-<translation id="7791543448312431591">추가</translation>
-<translation id="780301667611848630">아니요, 괜찮습니다.</translation>
-<translation id="7810647596859435254">연결 프로그램...</translation>
-<translation id="7821588508402923572">절약한 데이터 양이 여기에 표시됩니다</translation>
-<translation id="7837721118676387834">특정 사이트에서 음소거된 동영상이 자동재생되도록 허용합니다.</translation>
-<translation id="7846076177841592234">선택 취소</translation>
-<translation id="784934925303690534">기간</translation>
-<translation id="7851858861565204677">다른 기기</translation>
-<translation id="7875915731392087153">이메일 만들기</translation>
-<translation id="7876243839304621966">모두 삭제</translation>
-<translation id="7882131421121961860">방문 기록이 없습니다.</translation>
-<translation id="7882806643839505685">특정 사이트에서 소리를 재생하도록 허용합니다.</translation>
-<translation id="7886917304091689118">Chrome에서 실행 중</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{파일 다운로드 중}other{파일 #개 다운로드 중}}</translation>
-<translation id="7929962904089429003">메뉴 열기</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" />이(가) 이전 버전입니다.</translation>
-<translation id="7947953824732555851">수락 및 로그인</translation>
-<translation id="7963646190083259054">공급업체:</translation>
-<translation id="7971136598759319605">1일 전 동기화됨</translation>
-<translation id="7975379999046275268">페이지 미리보기 표시 <ph name="BEGIN_NEW" />새로운 기능<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">더 빠른 인터넷 사용과 검색을 위해 페이지 미리 로드</translation>
-<translation id="79859296434321399">증강 현실 콘텐츠를 보려면 ARCore를 설치하세요.</translation>
-<translation id="7986741934819883144">연락처 선택</translation>
-<translation id="7987073022710626672">Chrome 서비스 약관</translation>
-<translation id="7998918019931843664">닫은 탭 다시 열기</translation>
-<translation id="7999064672810608036">쿠키를 포함하여 이 웹사이트의 모든 로컬 데이터를 삭제하고 모든 권한을 재설정하시겠습니까?</translation>
-<translation id="8004582292198964060">브라우저</translation>
-<translation id="8007176423574883786">기기에 대해 사용 중지됨</translation>
-<translation id="8013372441983637696">이 기기에서 내 Chrome 데이터 삭제</translation>
-<translation id="8015452622527143194">페이지의 모든 항목을 기본 크기로 되돌리기</translation>
-<translation id="802154636333426148">다운로드 실패</translation>
-<translation id="8026334261755873520">인터넷 사용 기록 삭제</translation>
-<translation id="8035133914807600019">새 폴더…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" />일 남음</translation>
-<translation id="804335162455518893">SD 카드가 없음</translation>
-<translation id="805047784848435650">인터넷 사용 기록에 기반해 추천됨</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" />MB 사용 가능</translation>
-<translation id="8058746566562539958">새 Chrome 탭에서 열기</translation>
-<translation id="8063895661287329888">북마크를 추가하지 못했습니다.</translation>
-<translation id="806745655614357130">내 데이터 별도로 유지</translation>
-<translation id="8067883171444229417">동영상 재생</translation>
-<translation id="8068648041423924542">인증서를 선택할 수 없습니다.</translation>
-<translation id="8073388330009372546">새 탭에서 이미지 열기</translation>
-<translation id="8076492880354921740">탭</translation>
-<translation id="8084114998886531721">저장된 비밀번호</translation>
-<translation id="8087000398470557479">이 콘텐츠의 출처는 Google에서 제공하는 <ph name="DOMAIN_NAME" />입니다.</translation>
-<translation id="8103578431304235997">시크릿 탭</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">어느 기기에서나 내 북마크를 사용하려면 동기화를 사용 설정하세요.</translation>
-<translation id="8110087112193408731">디지털 웰빙에서 Chrome 활동을 표시할까요?</translation>
-<translation id="8116925261070264013">음소거됨</translation>
-<translation id="813082847718468539">사이트 정보 보기</translation>
-<translation id="8131740175452115882">확인</translation>
-<translation id="8156139159503939589">어떤 언어로 읽을 수 있으신가요?</translation>
-<translation id="8168435359814927499">콘텐츠</translation>
-<translation id="8186512483418048923">파일 <ph name="FILES" />개가 남았습니다.</translation>
-<translation id="8190358571722158785">1일 남음</translation>
-<translation id="8200772114523450471">다시 시작</translation>
-<translation id="8209050860603202033">이미지 열기</translation>
-<translation id="8218622182176210845">계정 관리</translation>
-<translation id="8224471946457685718">Wi-Fi로 추천 기사 다운로드</translation>
-<translation id="8232956427053453090">데이터 보관</translation>
-<translation id="8249310407154411074">맨 위로 이동</translation>
-<translation id="8250920743982581267">문서</translation>
-<translation id="825412236959742607">페이지에서 너무 많은 메모리를 사용하므로 Chrome에서 일부 콘텐츠를 삭제했습니다.</translation>
-<translation id="8260126382462817229">다시 로그인해 주세요.</translation>
-<translation id="8261506727792406068">삭제</translation>
-<translation id="8266862848225348053">다운로드 위치</translation>
-<translation id="8274165955039650276">다운로드 항목 보기</translation>
-<translation id="8284326494547611709">자막</translation>
-<translation id="8300705686683892304">앱에서 관리함</translation>
-<translation id="8310344678080805313">일반 탭</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> 및 그 외 사이트</translation>
-<translation id="8327155640814342956">최고의 탐색 환경을 사용하려면 Chrome을 열고 업데이트하세요.</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" />로 된 페이지를 번역하지 않습니다.</translation>
-<translation id="8349013245300336738">사용된 데이터 양에 따라 정렬</translation>
-<translation id="8364299278605033898">인기 웹사이트 보기</translation>
-<translation id="8368027906805972958">알 수 없거나 지원되지 않는 기기(<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">특정 사이트에서 백그라운드 동기화를 허용합니다.</translation>
-<translation id="8378714024927312812">조직에서 관리</translation>
-<translation id="8380167699614421159">이 사이트에서는 방해가 되거나 사용자를 현혹하는 광고를 표시합니다.</translation>
-<translation id="8393700583063109961">메시지 보내기</translation>
-<translation id="8413126021676339697">방문 기록 전체 보기</translation>
-<translation id="8427875596167638501">미리보기 탭이 절반 높이로 열림</translation>
-<translation id="8428213095426709021">설정</translation>
-<translation id="8438566539970814960">검색 및 탐색 기능 개선</translation>
-<translation id="8441146129660941386">뒤로 탐색</translation>
-<translation id="8443209985646068659">Chrome을 업데이트할 수 없습니다.</translation>
-<translation id="8445448999790540984">비밀번호를 내보낼 수 없음</translation>
-<translation id="8447861592752582886">기기 액세스 권한 취소</translation>
-<translation id="8461694314515752532">나만의 동기화 암호로 동기화된 데이터 암호화</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" />이(가) 인터넷에 연결되어 있는지 확인하세요.</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">오프라인으로 사용 가능</translation>
-<translation id="8489271220582375723">방문 기록 페이지 열기</translation>
-<translation id="8493948351860045254">저장 공간 확보하기</translation>
-<translation id="8497726226069778601">아직 표시할 내용 없음</translation>
-<translation id="8503559462189395349">Chrome 비밀번호</translation>
-<translation id="8503813439785031346">사용자이름</translation>
-<translation id="8514477925623180633">Chrome으로 저장한 비밀번호 내보내기</translation>
-<translation id="8514577642972634246">시크릿 모드로 들어가기</translation>
-<translation id="851751545965956758">사이트에서 기기에 연결하지 못하도록 차단</translation>
-<translation id="8523928698583292556">저장된 암호 삭제</translation>
-<translation id="854522910157234410">페이지 열기</translation>
-<translation id="8558485628462305855">증강 현실 콘텐츠를 보려면 ARCore를 업데이트하세요.</translation>
-<translation id="8559990750235505898">다른 언어로 된 페이지의 번역 옵션 제공</translation>
-<translation id="8562452229998620586">저장한 비밀번호가 여기에 표시됩니다.</translation>
-<translation id="8569404424186215731"><ph name="DATE" />부터</translation>
-<translation id="8571213806525832805">지난 4주</translation>
-<translation id="857943718398505171">허용(권장)</translation>
-<translation id="8583805026567836021">계정 데이터 지우기</translation>
-<translation id="860043288473659153">카드 명의자 이름</translation>
-<translation id="8609465669617005112">위로 이동</translation>
-<translation id="8616006591992756292">Google 계정의 내 활동(<ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />)에는 인터넷 사용 기록이 다른 형식으로 남아 있을 수도 있습니다.</translation>
-<translation id="8617240290563765734">다운로드한 콘텐츠에 지정된 추천 URL을 여시겠습니까?</translation>
-<translation id="8636825310635137004">다른 기기에서 탭을 가져오려면 동기화를 사용 설정하세요.</translation>
-<translation id="8641930654639604085">성인용 사이트 차단 시도</translation>
-<translation id="8655129584991699539">Chrome 설정에서 데이터를 삭제할 수 있습니다.</translation>
-<translation id="8662811608048051533">대부분의 사이트에서 로그아웃됩니다.</translation>
-<translation id="8664979001105139458">이미 존재하는 이름입니다.</translation>
-<translation id="8676374126336081632">입력내용 지우기</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{신호 강도: 막대 #개}other{신호 강도: 막대 #개}}</translation>
-<translation id="868929229000858085">연락처 검색</translation>
-<translation id="869891660844655955">유효기간</translation>
-<translation id="8719023831149562936">현재 탭을 공유할 수 없습니다.</translation>
-<translation id="8725066075913043281">다시 시도하세요</translation>
-<translation id="8728487861892616501">이 애플리케이션을 사용하면 Chrome의 <ph name="BEGIN_LINK1" />서비스 약관<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />개인정보처리방침<ph name="END_LINK2" />, <ph name="BEGIN_LINK3" />Family Link로 관리되는 Google 계정용 개인정보처리방침<ph name="END_LINK3" />에 동의하게 됩니다.</translation>
-<translation id="8730621377337864115">완료</translation>
-<translation id="8748850008226585750">숨겨진 콘텐츠</translation>
-<translation id="8751914237388039244">이미지 선택</translation>
-<translation id="8788265440806329501">탐색 기록 닫힘</translation>
-<translation id="8788968922598763114">마지막으로 닫은 탭 다시 열기</translation>
-<translation id="8801436777607969138">특정 사이트의 자바스크립트를 차단합니다.</translation>
-<translation id="8812260976093120287">일부 웹사이트에서는 위의 결제 앱을 사용하여 내 기기에서 결제할 수 있습니다.</translation>
-<translation id="8816026460808729765">사이트에서 센서에 액세스하지 못하도록 차단</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" />이(가) Chrome에서 열립니다. 계속하면 Chrome의 <ph name="BEGIN_LINK1" />서비스 약관<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />개인정보처리방침<ph name="END_LINK2" /> 및 <ph name="BEGIN_LINK3" />Family Link로 관리되는 Google 계정용 개인정보처리방침<ph name="END_LINK3" />에 동의하는 것으로 간주됩니다.</translation>
-<translation id="8820817407110198400">북마크</translation>
-<translation id="8833831881926404480">사이트에서 화면을 공유하는 중입니다.</translation>
-<translation id="883806473910249246">콘텐츠를 다운로드하는 중에 오류가 발생했습니다.</translation>
-<translation id="8840953339110955557">이 페이지는 온라인 버전과 다를 수 있습니다.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, 탭</translation>
-<translation id="885701979325669005">저장소</translation>
-<translation id="889338405075704026">Chrome 설정으로 이동</translation>
-<translation id="8901170036886848654">북마크가 없습니다.</translation>
-<translation id="8909135823018751308">공유…</translation>
-<translation id="8912362522468806198">Google 계정</translation>
-<translation id="8920114477895755567">부모님의 세부정보를 기다리는 중</translation>
+<translation id="1188239144602654184">AR 입력</translation>
+<translation id="473775607612524610">업데이트</translation>
+<translation id="3133489217401741157">Brave에 <ph name="MODULE"/>을(를) 설치하고 있습니다…</translation>
+<translation id="1791662854739702043">설치됨</translation>
+<translation id="5131234170665854056">Brave에 <ph name="MODULE"/>을(를) 설치할 수 없습니다.</translation>
+<translation id="2567385386134582609">이미지</translation>
+<translation id="6395288395575013217">링크</translation>
+<translation id="7352939065658542140">동영상</translation>
+<translation id="4116038641877404294">페이지를 다운로드하여 오프라인에서 사용하세요.</translation>
 <translation id="8922289737868596582">옵션 더보기 버튼을 눌러 페이지를 다운로드하여 오프라인에서 사용하세요.</translation>
-<translation id="8937772741022875483">디지털 웰빙에서 Chrome 활동을 삭제할까요?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">다른 창에서 열기</translation>
-<translation id="8951232171465285730">Chrome을 통해 <ph name="MEGABYTES" />MB를 절약했습니다.</translation>
-<translation id="8958424370300090006">특정 사이트의 쿠키를 차단합니다.</translation>
-<translation id="8959122750345127698">탐색할 수 없음: <ph name="URL" /></translation>
-<translation id="8965591936373831584">보류 중</translation>
-<translation id="8970887620466824814">문제 발생</translation>
-<translation id="8972098258593396643">기본 폴더에 다운로드하시겠습니까?</translation>
-<translation id="8986494364107987395">사용 통계 및 비정상 종료 보고서를 Google에 자동으로 전송합니다.</translation>
-<translation id="8993760627012879038">시크릿 모드로 새 탭 열기</translation>
-<translation id="8998729206196772491"><ph name="MANAGED_DOMAIN" />에서 관리하는 계정으로 로그인합니다. 계정 관리자가 내 Chrome 데이터를 관리하게 되며 데이터는 이 계정에 영구적으로 연결됩니다. Chrome에서 로그아웃하면 데이터가 이 기기에서 삭제되지만 Google 계정에는 그대로 유지됩니다.</translation>
-<translation id="9019902583201351841">부모님이 관리합니다.</translation>
-<translation id="9028914725102941583">동기화를 사용 설정하여 기기간 공유하기</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" />에서 VR로 들어가도록 허용하시겠습니까?</translation>
-<translation id="9040142327097499898">알림이 허용되었습니다. 이 기기에서 위치가 사용 중지되었습니다.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{동영상 #개}other{동영상 #개}}</translation>
-<translation id="9050666287014529139">암호</translation>
-<translation id="9063523880881406963">데스크톱 버전으로 보기 사용 중지</translation>
-<translation id="9065203028668620118">수정</translation>
-<translation id="9070377983101773829">음성 검색 시작</translation>
-<translation id="9074336505530349563">Google에서 추천하는 맞춤 콘텐츠를 보려면 로그인하고 동기화를 사용 설정하세요.</translation>
-<translation id="9086455579313502267">네트워크에 액세스할 수 없습니다.</translation>
-<translation id="9100505651305367705">지원되는 경우 간단히 보기로 기사를 표시하는 기능 제공</translation>
-<translation id="9100610230175265781">암호를 입력해야 합니다.</translation>
-<translation id="9102803872260866941">미리보기 탭 열림</translation>
+<translation id="5958275228015807058">다운로드에서 파일 및 페이지를 찾아보세요.</translation>
+<translation id="5620928963363755975">옵션 더보기 버튼을 눌러 다운로드에서 파일 및 페이지를 찾아보세요.</translation>
+<translation id="3341058695485821946">저장한 데이터의 양을 확인해보세요.</translation>
+<translation id="3157842584138209013">추가 옵션 버튼에서 저장한 데이터의 양을 확인해보세요.</translation>
+<translation id="8218622182176210845">계정 관리</translation>
+<translation id="8090895580117672212">Brave Software 계정을 관리하려면 '계정 관리' 버튼을 탭하세요.</translation>
+<translation id="8856898588039823173">Brave Software에서 제공하는 라이트 페이지입니다. 원본 페이지를 로드하려면 탭하세요.</translation>
+<translation id="8134317863207426198">Brave Software에서 제공하는 라이트 페이지입니다. 원본 페이지를 로드하려면 원본 로드 버튼을 탭하세요.</translation>
+<translation id="4961107849584082341">이 페이지를 원하는 언어로 번역하세요.</translation>
+<translation id="569536719314091526">옵션 더보기 버튼을 눌러 이 페이지를 원하는 언어로 번역하세요</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/>에서 검색</translation>
+<translation id="1792959175193046959">언제든지 기본 다운로드 위치 변경 가능</translation>
+<translation id="6942665639005891494">언제든지 설정 메뉴 옵션으로 기본 다운로드 위치 변경 가능</translation>
+<translation id="6850409657436465440">아직 다운로드 중</translation>
+<translation id="5817715962196959877">이제 Brave에서 파일을 더 빠르게 다운로드합니다.</translation>
+<translation id="3976396876660209797">이 바로가기 삭제하고 다시 만들기</translation>
+<translation id="6766622839693428701">닫으려면 아래로 스와이프하세요.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/>에 보내는 중...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/>에서 전송</translation>
+<translation id="5357811892247919462">탭 수신함</translation>
 <translation id="9104217018994036254">탭을 공유할 기기 목록입니다.</translation>
-<translation id="9133397713400217035">오프라인 탐색</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" />(<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">원본 보기</translation>
-<translation id="9139068048179869749">사이트에서 알림을 보내도록 허용하기 전에 확인(권장)</translation>
-<translation id="9139318394846604261">쇼핑</translation>
-<translation id="9155898266292537608">단어를 살짝 탭하여 검색할 수도 있습니다</translation>
-<translation id="9169507124922466868">탐색 기록이 절반 높이로 열림</translation>
-<translation id="9204836675896933765">파일 1개가 남았습니다.</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">탭을 공유할 기기 목록이 절반 높이로 열렸습니다.</translation>
+<translation id="2904414404539560095">탭을 공유할 기기 목록이 전체 높이로 열렸습니다.</translation>
+<translation id="4135200667068010335">탭을 공유할 기기 목록이 닫혔습니다.</translation>
+<translation id="5292796745632149097">전송할 기기</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/>일 전 동기화됨</translation>
+<translation id="7971136598759319605">1일 전 동기화됨</translation>
+<translation id="1521774566618522728">오늘 사용</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/>에 공유하는 중</translation>
+<translation id="9028914725102941583">동기화를 사용 설정하여 기기간 공유하기</translation>
+<translation id="6162454065885854378">스마트폰에서 다른 기기로 콘텐츠를 공유하려면 두 기기의 Brave 설정에서 동기화를 사용 설정하세요.</translation>
+<translation id="6084271560289605378">Brave 설정으로 이동</translation>
+<translation id="2318045970523081853">탭하여 전화 걸기</translation>
 <translation id="9209888181064652401">전화를 걸 수 없음</translation>
-<translation id="9219103736887031265">이미지</translation>
-<translation id="926205370408745186">디지털 웰빙에서 Chrome 활동 삭제</translation>
-<translation id="932327136139879170">홈</translation>
-<translation id="938850635132480979">오류: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">마이크에 액세스</translation>
-<translation id="95817756606698420">중국에서 검색할 때 Chrome에서 <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />를 사용할 수 있습니다. <ph name="BEGIN_LINK" />설정<ph name="END_LINK" />에서 변경할 수 있습니다.</translation>
-<translation id="965817943346481315">사이트에서 방해가 되거나 사용자를 현혹하는 광고를 표시하는 경우 광고 차단(권장)</translation>
-<translation id="968900484120156207">방문한 페이지가 여기에 표시됩니다.</translation>
-<translation id="970715775301869095"><ph name="MINUTES" />분 남음</translation>
-<translation id="974555521953189084">암호를 입력하여 동기화를 시작합니다.</translation>
-<translation id="981121421437150478">오프라인</translation>
-<translation id="982182592107339124">다음을 포함한 모든 사이트의 데이터가 삭제됩니다.</translation>
-<translation id="983192555821071799">탭 모두 닫기</translation>
-<translation id="987264212798334818">일반</translation>
+<translation id="2860954141821109167">이 기기에서 전화 앱이 사용 설정되어 있는지 확인하세요.</translation>
+<translation id="2067805253194386918">텍스트</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> 공유할 수 없음</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> 공유할 수 없음</translation>
+<translation id="8287068819750208230"><ph name="TARGET_DEVICE_NAME"/>에서 Brave 동기화가 사용 설정되어 있는지 확인하세요.</translation>
+<translation id="3016635187733453316">이 기기가 인터넷에 연결되어 있는지 확인하세요.</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/>이(가) 인터넷에 연결되어 있는지 확인하세요.</translation>
+<translation id="6539092367496845964">문제가 발생했습니다. 나중에 다시 시도해 보세요.</translation>
+<translation id="3389286852084373014">텍스트가 너무 큼</translation>
+<translation id="2100314319871056947">좀 더 짧은 길이로 텍스트를 줄인 다음 공유해 보세요.</translation>
+<translation id="2987620471460279764">다른 기기에서 공유된 텍스트</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/>에서 공유된 텍스트</translation>
+<translation id="5193988420012215838">클립보드에 복사됨</translation>
+<translation id="4696983787092045100">기기로 SMS 전송</translation>
+<translation id="1260236875608242557">검색 및 탐색</translation>
+<translation id="6369229450655021117">여기에서 웹을 검색하고, 친구와 공유하고, 열린 페이지를 볼 수 있습니다.</translation>
+<translation id="723171743924126238">이미지 선택</translation>
+<translation id="8751914237388039244">이미지 선택</translation>
+<translation id="1989112275319619282">찾아보기</translation>
+<translation id="7055152154916055070">다음 주소로의 리디렉션이 차단됨:</translation>
+<translation id="5524843473235508879">리디렉션이 차단되었습니다.</translation>
+<translation id="6573096386450695060">항상 허용</translation>
+<translation id="5805364706385912897">페이지에서 너무 많은 메모리를 사용하므로 Brave에서 페이지를 일시중지했습니다.</translation>
+<translation id="5138664332909611586">페이지에서 너무 많은 메모리를 사용하므로 Brave에서 일부 콘텐츠를 삭제했습니다.</translation>
+<translation id="9137013805542155359">원본 보기</translation>
+<translation id="6361779936989026201">Brave의 Brave Software 어시스턴트</translation>
+<translation id="7291387454912369099">어시스턴트 트리거 확인</translation>
+<translation id="4565206163201411670">디지털 웰빙에서 Brave 활동을 표시할까요?</translation>
+<translation id="9055113864158719823">Brave에서 내가 방문한 사이트를 보고 사이트에 타이머를 설정할 수 있습니다.\n\nBrave Software에서는 타이머가 설정된 사이트와 사이트 방문 시간 정보를 수집합니다. 이 정보는 디지털 웰빙을 개선하는 데 사용됩니다.</translation>
+<translation id="4596514158372210596">디지털 웰빙에서 Brave 활동 삭제</translation>
+<translation id="1174893863889683998">디지털 웰빙에서 Brave 활동을 삭제할까요?</translation>
+<translation id="708829030563435351">Brave에서 방문한 사이트가 표시되지 않습니다. 모든 사이트 타이머가 삭제됩니다.</translation>
+<translation id="2056878612599315956">사이트 일시중지됨</translation>
+<translation id="671481426037969117"><ph name="FQDN"/> 타이머가 종료되었습니다. 타이머는 내일 다시 시작됩니다.</translation>
+<translation id="7479104141328977413">탭 관리</translation>
+<translation id="3524138585025253783">개발자 UI</translation>
+<translation id="6036057147555329831">추가 ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/>에서 VR로 들어가도록 허용하시겠습니까?</translation>
+<translation id="7685301384041462804">VR로 들어가기 전에 이 사이트를 신뢰할 수 있는지 확인하세요.</translation>
+<translation id="5033865233969348410">이 사이트에서는 VR 사용자에 대해 다음 내용을 학습할 수 있습니다.
+  -  키와 같은 신체적 특징
+
+VR로 들어가기 전에 이 사이트를 신뢰할 수 있는지 확인하세요.</translation>
+<translation id="5534334044554683961">이 사이트에서는 VR 사용자에 대해 다음 내용을 학습할 수 있습니다.
+  -   키와 같은 신체적 특징
+  -   공간의 레이아웃
+
+VR로 들어가기 전에 이 사이트를 신뢰할 수 있는지 확인하세요.</translation>
+<translation id="4169535189173047238">허용 안함</translation>
+<translation id="2170088579611075216">허용 및 VR 시작</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_lt.xtb
+++ b/android/java/strings/translations/android_chrome_strings_lt.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="lt">
-<translation id="1006017844123154345">Atidaryti prisijungus</translation>
-<translation id="1028699632127661925">Siunčiama į „<ph name="DEVICE_NAME" />“...</translation>
-<translation id="1036727731225946849">Pridedamas APK „<ph name="WEBAPK_NAME" />“...</translation>
-<translation id="1041308826830691739">Iš svetainių</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Niekada neišsaugota</translation>
-<translation id="1067922213147265141">Kitos „Google“ paslaugos</translation>
-<translation id="1068672505746868501">Niekada neversti puslapių, parašytų <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Jei pakeisite failo plėtinį, failas gali būti atidaromas naudojant kitą programą ir galimai pakenkti įrenginiui.</translation>
-<translation id="1100066534610197918">Atidar. naujame grup. skirtuke</translation>
-<translation id="1105960400813249514">Ekrano fiksavimas</translation>
-<translation id="1111673857033749125">Čia bus rodomos kituose įrenginiuose išsaugotos žymės.</translation>
-<translation id="1113597929977215864">Rodyti supaprastintą rodinį</translation>
-<translation id="1121094540300013208">Naudojimo ir strigčių ataskaitos</translation>
-<translation id="1124772482545689468">Naudotojas</translation>
-<translation id="1129510026454351943">Išsami informacija: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Laukiama 1 atsisiuntimo.}one{Laukiama # atsisiuntimo.}few{Laukiama # atsisiuntimų.}many{Laukiama # atsisiuntimo.}other{Laukiama # atsisiuntimų.}}</translation>
-<translation id="1145536944570833626">Ištrinti esamus duomenis.</translation>
-<translation id="1146678959555564648">Įgalinti VR</translation>
-<translation id="116280672541001035">Naudojama</translation>
-<translation id="1171770572613082465">Žr. populiarias svetaines palietę mygtuką „Populiariausios svetainės“</translation>
-<translation id="1173894706177603556">Pervadinti</translation>
-<translation id="1178581264944972037">Pristabdyti</translation>
-<translation id="1181037720776840403">Pašalinti</translation>
-<translation id="1188239144602654184">Įveskite AR</translation>
-<translation id="1197267115302279827">Perkelti žymes</translation>
-<translation id="119944043368869598">Valyti viską</translation>
-<translation id="1201402288615127009">Kitas</translation>
-<translation id="1204037785786432551">Atsisiųsti nuorodą</translation>
-<translation id="1206892813135768548">Kopijuoti nuorodos tekstą</translation>
-<translation id="1208340532756947324">Kad turinys būtų sinchronizuojamas visuose įrenginiuose, įjunkite sinchronizavimą</translation>
-<translation id="1209206284964581585">Slėpti dabar</translation>
-<translation id="1227058898775614466">Naršymo istorija</translation>
-<translation id="1231733316453485619">Įjungti sinchronizavimą?</translation>
-<translation id="123724288017357924">Įk. šį puslapį iš naujo, nepais. talp. es. turinio</translation>
-<translation id="124116460088058876">Daugiau kalbų</translation>
-<translation id="124678866338384709">Uždaryti dabartinį skirtuką</translation>
-<translation id="1258753120186372309">„Google“ papuoštas logotipas: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Paieška ir naršymas</translation>
-<translation id="1264974993859112054">Sportas</translation>
-<translation id="1266864766717917324">Nepavyko bendrinti turinio: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Sustabdyti</translation>
-<translation id="1283039547216852943">Palieskite ir išskleiskite</translation>
-<translation id="1285320974508926690">Niekada neversti šios svetainės</translation>
-<translation id="1291207594882862231">Išvalykite istoriją, slapukus, svetainės duomenis, talpyklą…</translation>
-<translation id="129382876167171263">Svetainių išsaugoti failai rodomi čia</translation>
-<translation id="129553762522093515">Neseniai uždarytas</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – išsiųsta iš „<ph name="DEVICE_NAME" />“</translation>
-<translation id="1310482092992808703">Grupuoti skirtukus</translation>
-<translation id="1327257854815634930">Naršymo istorija atidaryta</translation>
-<translation id="1331212799747679585">Nepavyksta atnaujinti „Chrome“. Daugiau parinkčių.</translation>
-<translation id="1332501820983677155">„Google Chrome“ funkcijų spartieji klavišai</translation>
-<translation id="1360432990279830238">Atsijungti ir išjungti sinchronizavimą?</translation>
-<translation id="1369915414381695676">Pridėta svetainė <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Nepakanka atminties pasirinktam turiniui atsisiųsti.</translation>
-<translation id="1376578503827013741">Apskaičiuojama...</translation>
-<translation id="1383876407941801731">Ieškoti</translation>
-<translation id="1384959399684842514">Atsisiuntimas pristabdytas</translation>
-<translation id="1386674309198842382">Aktyvus prieš <ph name="LAST_UPDATED" /> d.</translation>
-<translation id="1397811292916898096">Paieška su „<ph name="PRODUCT_NAME" />“</translation>
-<translation id="1404122904123200417">Įterpta į <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Funkcija „Nestebėti“</translation>
-<translation id="1407135791313364759">Atidaryti viską</translation>
-<translation id="1409426117486808224">Supaprastinta atidarytų skirtukų peržiūra</translation>
-<translation id="1409879593029778104">Neleidžiama atsisiųsti „<ph name="FILE_NAME" />“, nes failas jau yra.</translation>
-<translation id="1414981605391750300">Susisiekiama su „Google“. Tai gali šiek tiek užtrukti…</translation>
-<translation id="1416550906796893042">Programos versija</translation>
-<translation id="1430915738399379752">Spausdinti</translation>
-<translation id="1446450296470737166">Leisti visiškai valdyti MIDI įr.</translation>
-<translation id="1450753235335490080">Nepavyko bendrinti turinio: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Išjungta „Android“ nustatymuose</translation>
-<translation id="1477626028522505441">Nepavyko atsisiųsti „<ph name="FILE_NAME" />“ dėl serverio problemų.</translation>
-<translation id="1506061864768559482">Paieškos variklis</translation>
-<translation id="1513352483775369820">Žymių ir žiniatinklio istorija</translation>
-<translation id="1513858653616922153">Ištrinti slaptažodį</translation>
-<translation id="1516229014686355813">Naudojant Paiešką palietus siunčiamas žodis ir jo kontekstas „Google“ paieškai. Šią funkciją galite išjungti skiltyje <ph name="BEGIN_LINK" />„Nustatymai“<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktyvus šiandien</translation>
-<translation id="1544826120773021464">Jei norite tvarkyti „Google“ paskyrą, palieskite mygtuką „Tvarkyti“</translation>
-<translation id="1549000191223877751">Perkelti į kitą langą</translation>
-<translation id="1553358976309200471">Atnaujinkite „Chrome“</translation>
-<translation id="1569387923882100876">Prijungtas įrenginys</translation>
-<translation id="1571304935088121812">Kopijuoti naudotojo vardą</translation>
-<translation id="1612196535745283361">„Chrome“ reikalinga prieiga prie informacijos apie vietovę, kad galėtų nuskaityti įrenginius. Galimybė pasiekti informaciją apie vietovę <ph name="BEGIN_LINK" />išjungta šiame įrenginyje<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Neleisti šiam puslapiui kurti papildomų dialogo langų</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Pašalinti 1 pasirinktą elementą}one{Pašalinti # pasirinktą elementą}few{Pašalinti # pasirinktus elementus}many{Pašalinti # pasirinkto elemento}other{Pašalinti # pasirinktų elementų}}</translation>
-<translation id="164269334534774161">Peržiūrite neprisijungus pasiekiamą šio puslapio kopiją (<ph name="CREATION_TIME" />)</translation>
-<translation id="1644574205037202324">Istorija</translation>
-<translation id="1647391597548383849">Prieiga prie fotoaparato</translation>
-<translation id="1660204651932907780">Leisti svetainėms leisti garsą (rekomenduojama)</translation>
-<translation id="1670399744444387456">Bendrieji</translation>
-<translation id="1671236975893690980">Laukiama atsisiuntimo...</translation>
-<translation id="1672586136351118594">Daugiau neberodyti</translation>
-<translation id="1692118695553449118">Sinchronizavimas įjungtas</translation>
-<translation id="169515064810179024">Svetainės užblokuotos, kad nepasiektų judesio jutiklių</translation>
-<translation id="1717218214683051432">Judesių jutikliai</translation>
-<translation id="1718835860248848330">Paskutinė valanda</translation>
-<translation id="1736419249208073774">Naršyti</translation>
-<translation id="1743802530341753419">Paklausti prieš leidžiant svetainėms prisijungti prie įrenginio (rekomenduojama)</translation>
-<translation id="1749561566933687563">Sinchronizuokite žymes</translation>
-<translation id="17513872634828108">Atidaryti skirtukai</translation>
-<translation id="1779089405699405702">Vaizdų dekoderis</translation>
-<translation id="1782483593938241562">Pabaigos data: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Įdiegta</translation>
-<translation id="1792959175193046959">Numatytąją atsisiuntimo vietą galite bet kada pakeisti</translation>
-<translation id="1807246157184219062">Šviesi</translation>
-<translation id="1810845389119482123">Pradinė sinchronizavimo sąranka nebaigta</translation>
-<translation id="1821253160463689938">Naudojami slapukai, siekiant įsiminti jūsų nuostatas, net jei nesilankote tuose puslapiuose</translation>
-<translation id="1829244130665387512">Surasti puslapyje</translation>
-<translation id="1853692000353488670">Naujas inkognito skirtukas</translation>
-<translation id="1856325424225101786">Nustatyti supaprastintąjį režimą iš naujo?</translation>
-<translation id="1868024384445905608">Dabar „Chrome“ failus atsisiunčia greičiau</translation>
-<translation id="1883903952484604915">Mano failai</translation>
-<translation id="1887786770086287077">Vietos prieiga išjungta šiame įrenginyje. Įjunkite ją skiltyje <ph name="BEGIN_LINK" />„Android“ nustatymai“<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Programa „<ph name="APP_NAME" />“ bus atidaryta naršyklėje „Chrome“. Tęsdami sutinkate su „Chrome“ <ph name="BEGIN_LINK1" />paslaugų teikimo sąlygomis<ph name="END_LINK1" /> ir <ph name="BEGIN_LINK2" />privatumo pranešimu<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Skelbimai</translation>
-<translation id="1919950603503897840">Kontaktų pasirinkimas</translation>
-<translation id="1922076542920281912">Norėdami leisti „Chrome“ pasiekti jūsų vietovę, taip pat įjunkite ją <ph name="BEGIN_LINK" />„Android“ nustatymuose<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> iš <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Atnaujinimas</translation>
-<translation id="19288952978244135">Iš naujo atidarykite „Chrome“.</translation>
-<translation id="1933845786846280168">Pasirinktas skirtukas</translation>
-<translation id="194341124344773587">Įjunkite „Chrome“ leidimą <ph name="BEGIN_LINK" />„Android“ nustatymuose<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Slaptažodžių išsaugojimas</translation>
-<translation id="1952172573699511566">Kai bus įmanoma, svetainėje tekstas bus rodomas pasirinkta kalba.</translation>
-<translation id="1960290143419248813">„Chrome“ naujiniai nebepalaikomi naudojant šios versijos „Android“.</translation>
-<translation id="1966710179511230534">Atnaujinkite išsamią prisijungimo informaciją.</translation>
-<translation id="1974060860693918893">Išplėstiniai</translation>
-<translation id="1984705450038014246">„Chrome“ duomenų sinchronizavimas</translation>
-<translation id="1984937141057606926">Leidžiama (išskyrus trečiąsias šalis)</translation>
-<translation id="1986685561493779662">Toks pavadinimas jau yra</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> mygtukas</translation>
-<translation id="1989112275319619282">Naršyti</translation>
-<translation id="1993768208584545658">Svetainė <ph name="SITE" /> nori būti susieta su</translation>
-<translation id="1994173015038366702">Svetainės URL</translation>
-<translation id="2000419248597011803">Numatytajam paieškos varikliui siunčiami kai kurie slapukai ir į adreso juostą bei paieškos laukelį įvestos paieškos</translation>
-<translation id="2002537628803770967">„Google Pay“ naudojamos kredito kortelės ir adresai</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# failas}one{# failas}few{# failai}many{# failo}other{# failų}}</translation>
-<translation id="2017836877785168846">Išvaloma istorija ir automatiniai užbaigimai adreso juostoje.</translation>
-<translation id="2021896219286479412">Viso ekrano svetainės valdikliai</translation>
-<translation id="2038563949887743358">Įjungti stalinio kompiuterio svetainės užklausą</translation>
-<translation id="2041019821020695769">Norėdami leisti „Chrome“ siųsti pranešimus, taip pat įjunkite juos <ph name="BEGIN_LINK" />„Android“ nustatymuose<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">„<ph name="APP_NAME" />“ duomenų taip pat yra naršyklėje „Chrome“</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Svetainė pristabdyta</translation>
-<translation id="2063713494490388661">Paliesti ir ieškoti</translation>
-<translation id="2067805253194386918">teksto pranešimas</translation>
-<translation id="2079545284768500474">Anuliuoti</translation>
-<translation id="2082238445998314030">Rezultatų: <ph name="RESULT_NUMBER" /> iš <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Garsas</translation>
-<translation id="2096012225669085171">Sinchronizuoti ir suasmeninti įrenginiuose</translation>
-<translation id="2100273922101894616">Automatinis prisijungimas</translation>
-<translation id="2100314319871056947">Pabandykite bendrinti tekstą mažesnėmis dalimis</translation>
-<translation id="2107397443965016585">Paklausti prieš leidžiant svetainėms leisti saugomą turinį (rekomenduojama)</translation>
-<translation id="2111511281910874386">Eiti į puslapį</translation>
-<translation id="2122601567107267586">Nepavyko atidaryti programos</translation>
-<translation id="2126426811489709554">Teikia „Chrome“</translation>
-<translation id="2131665479022868825">Išsaugota: <ph name="DATA" /></translation>
-<translation id="213279576345780926">„<ph name="TAB_TITLE" />“ uždaryta</translation>
-<translation id="2139186145475833000">Pridėti prie pagr. ekrano</translation>
-<translation id="2146738493024040262">Atidaryti akimirksniu įkeliamą programėlę</translation>
-<translation id="2148716181193084225">Šiandien</translation>
-<translation id="2154484045852737596">Kortelės informacijos redagavimas</translation>
-<translation id="2154710561487035718">Kopijuoti URL adresą</translation>
-<translation id="2156074688469523661">Likusios svetainės (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Norėdami bendrinti turinį iš savo telefono į kitą įrenginį, įjunkite sinchronizavimą abiejų įrenginių „Chrome“ nustatymuose</translation>
-<translation id="2170088579611075216">Leisti ir įvesti VR</translation>
-<translation id="218608176142494674">Bendrinimas</translation>
-<translation id="2227444325776770048">Tęsti kaip <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sinchron. ir „Google“ paslaugos</translation>
-<translation id="2259659629660284697">Eksportuoti slaptažodžius…</translation>
-<translation id="2268044343513325586">Patikslinti</translation>
-<translation id="2286841657746966508">Atsiskaitymo adresas</translation>
-<translation id="2289270750774289114">Paklausti, kai svetainė nori atrasti netoliese esančius „Bluetooth“ įrenginius (rekomenduojama)</translation>
-<translation id="230115972905494466">Nerasta jokių suderinamų įrenginių</translation>
-<translation id="2315043854645842844">Kliento pasirinkto sertifikato nepalaiko operacinė sistema.</translation>
-<translation id="2318045970523081853">Palieskite ir skambinkite</translation>
-<translation id="2321086116217818302">Ruošiami slaptažodžiai…</translation>
-<translation id="2321958826496381788">Vilkite šliaužiklį, kol bus patogu skaityti šį tekstą. Du kartus palietus pastraipą, tekstas turėtų būti mažiausiai tokio dydžio.</translation>
-<translation id="2323763861024343754">Svetainės saugykla</translation>
-<translation id="2328985652426384049">Nepavyksta prisijungti</translation>
-<translation id="2330129964253841015">Įspėti jus, jei slaptažodžiai buvo pažeisti</translation>
-<translation id="2349710944427398404">Bendras „Chrome“ naudojamų duomenų kiekis, įskaitant paskyras, žymes ir išsaugotus nustatymus</translation>
-<translation id="2353636109065292463">Tikrinamas interneto ryšys</translation>
-<translation id="2359808026110333948">Tęskite</translation>
-<translation id="2369533728426058518">atidaryti skirtukus</translation>
-<translation id="2387895666653383613">Teksto mastelio keitimas</translation>
-<translation id="2394602618534698961">Čia rodomi atsisiųsti failai</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Prisijungus prie „Google“ paskyros, ši funkcija yra įjungta</translation>
-<translation id="2410754283952462441">Pasirinkite paskyrą</translation>
-<translation id="2414886740292270097">Tamsi</translation>
-<translation id="2416359993254398973">„Chrome“ reikia leidimo, kad galėtų naudoti jūsų fotoaparatą šioje svetainėje.</translation>
-<translation id="2426805022920575512">Pasirinkti kitą paskyrą</translation>
-<translation id="2433507940547922241">Išvaizda</translation>
-<translation id="2434158240863470628">Atsisiųsta: <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Prieiga prie vietovės</translation>
-<translation id="2450083983707403292">Ar norite vėl pradėti <ph name="FILE_NAME" /> atsisiuntimą?</translation>
-<translation id="2482878487686419369">Pranešimai</translation>
-<translation id="2490684707762498678">Tvarko „<ph name="APP_NAME" />“</translation>
-<translation id="2494974097748878569">„Google Assistant“ sistemoje</translation>
-<translation id="2496180316473517155">Naršymo istorija</translation>
-<translation id="2497852260688568942">Sinchronizavimą išjungė jūsų administratorius</translation>
-<translation id="2498359688066513246">Pagalba ir atsiliepimai</translation>
-<translation id="2501278716633472235">Grįžti</translation>
-<translation id="2513403576141822879">Daugiau nustatymų, susijusių su privatumu, sauga ir duomenų rinkimu, žr. skiltyje <ph name="BEGIN_LINK" />„Sinchronizavimas ir „Google“ paslaugos“<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Kai įjungtas supaprastintasis režimas, „Chrome“ sparčiau įkelia puslapius ir sunaudoja iki 60 proc. mažiau duomenų. „Chrome“ siunčia žiniatinklio srauto duomenis sistemai „Google“, kad optimizuotų puslapius, kuriuose lankotės. <ph name="BEGIN_LINK" />Sužinokite daugiau<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Siunčiami „Google“ puslapių, kuriuose lankotės, URL</translation>
-<translation id="2532336938189706096">Žiniatinklio rodinys</translation>
-<translation id="2534155362429831547">Ištrinta elementų: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Žiūrima neprisijungus naudojama šio puslapio kopija</translation>
-<translation id="2546283357679194313">Slapukai ir svetainės duomenys</translation>
-<translation id="2567385386134582609">VAIZDAS</translation>
-<translation id="257088987046510401">Temos</translation>
-<translation id="2570922361219980984">Vietos prieiga taip pat išjungta šiame įrenginyje. Įjunkite ją skiltyje <ph name="BEGIN_LINK" />„Android“ nustatymai“<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Išskleista – spustelėkite, kad sutrauktumėte</translation>
-<translation id="2581165646603367611">Bus išvalyti slapukai, talpykla ir kiti svetainių duomenys, kurių „Chrome“ nelaiko svarbiais.</translation>
-<translation id="2586657967955657006">Iškarpinė</translation>
-<translation id="2587052924345400782">Pasiekiama naujesnė versija</translation>
-<translation id="2593272815202181319">Lygiaplotis</translation>
-<translation id="2612676031748830579">Kortelės numeris</translation>
-<translation id="2621115761605608342">Leisti „JavaScript“ konkrečioje svetainėje.</translation>
-<translation id="2625189173221582860">Slaptažodis nukopijuotas</translation>
-<translation id="2631006050119455616">Išsaugota</translation>
-<translation id="2647434099613338025">Pridėti kalbą</translation>
-<translation id="2650751991977523696">Atsisiųsti failą dar kartą?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# garso įrašo failas}one{# garso įrašo failas}few{# garso įrašo failai}many{# garso įrašo failo}other{# garso įrašo failų}}</translation>
-<translation id="2653659639078652383">Pateikti</translation>
-<translation id="2677748264148917807">Išeiti</translation>
-<translation id="2704606927547763573">Nukopij.</translation>
-<translation id="2707726405694321444">Atnaujinti puslapį</translation>
-<translation id="2709516037105925701">Automatinis pildymas</translation>
-<translation id="2717722538473713889">El. pašto adresai</translation>
-<translation id="2728754400939377704">Rūšiuoti pagal svetainę</translation>
-<translation id="2744248271121720757">Palieskite žodį ir ieškokite akimirksniu arba peržiūrėkite susijusius veiksmus</translation>
-<translation id="2760989362628427051">Įjungti tamsiąją temą, kai įjungta įrenginio tamsioji tema arba akumuliatoriaus tausojimo priemonė</translation>
-<translation id="2762000892062317888">ką tik</translation>
-<translation id="2777555524387840389">Liko <ph name="SECONDS" /> sek.</translation>
-<translation id="2779651927720337254">nepavyko</translation>
-<translation id="2781151931089541271">Liko 1 sek.</translation>
-<translation id="2801022321632964776">Norėdami gauti naujausią versiją su įdiegta savo kalba, atnaujinkite „Chrome“</translation>
-<translation id="2810645512293415242">Supaprastintas puslapis, kad būtų galima saugoti duomenis ir greičiau įkelti.</translation>
-<translation id="281504910091592009">Peržiūrėkite ir tvarkykite išsaugotus slaptažodžius <ph name="BEGIN_LINK" />„Google“ paskyroje<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Jei norite pasiekti žymes visuose įrenginiuose, prisijunkite ir įjunkite sinchronizavimą</translation>
-<translation id="2822354292072154809">Ar tikrai norite iš naujo nustatyti visus „<ph name="CHOSEN_OBJECT_NAME" />“ svetainės leidimus?</translation>
-<translation id="2836148919159985482">Palieskite mygtuką „Atgal“, kad išeitumėte iš viso ekrano režimo.</translation>
-<translation id="2842985007712546952">Viršaplankis</translation>
-<translation id="2858138569776157458">Popul. svet.</translation>
-<translation id="2860954141821109167">Įsitikinkite, kad šiame įrenginyje įgalinta telefono programa</translation>
-<translation id="2870560284913253234">Svetainė</translation>
-<translation id="2874939134665556319">Ankstesnis takelis</translation>
-<translation id="2876369937070532032">Siunčia „Google“ kai kurių puslapių, kuriuose lankotės, URL, kai kyla pavojus jūsų saugai</translation>
-<translation id="2888126860611144412">Apie „Chrome“</translation>
-<translation id="2891154217021530873">Sustabdyti puslapio įkėlimą</translation>
-<translation id="2893180576842394309">„Google“ gali naudoti jūsų istoriją, kad suasmenintų Paiešką ir kitas „Google“ paslaugas</translation>
-<translation id="2898264748040935573">Redaguoti išsaugotus slaptažodžius</translation>
-<translation id="2900528713135656174">Sukurti įvykį</translation>
-<translation id="290376772003165898">Puslapis parašytas ne <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Įrenginių, su kuriais reikia bendrinti skirtuką, sąrašas atidarytas (visas aukštis).</translation>
-<translation id="2910701580606108292">Paklausti prieš leidžiant svetainėms leisti saugomą turinį</translation>
-<translation id="2913331724188855103">Leisti svetainėms išsaugoti ir nuskaityti slapukų duomenis (rekomenduojama)</translation>
-<translation id="2923908459366352541">Netinkamas pavadinimas</translation>
-<translation id="2932150158123903946">„Google <ph name="APP_NAME" />“ saugykla</translation>
-<translation id="2942036813789421260">Peržiūros skirtukas uždarytas</translation>
-<translation id="2956410042958133412">Šią paskyrą tvarko <ph name="PARENT_NAME_1" /> ir <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Perjungta į inkognito skirtukus</translation>
-<translation id="2968755619301702150">Sertifikato peržiūros priemonė</translation>
-<translation id="2979025552038692506">Pasirinktas inkognito skirtukas</translation>
-<translation id="2987620471460279764">Tekstas, bendrinamas iš kito įrenginio</translation>
-<translation id="2989523299700148168">Neseniai lankyta</translation>
-<translation id="2996291259634659425">Kurkite slaptafrazę</translation>
-<translation id="2996809686854298943">Reikalingas URL</translation>
-<translation id="300526633675317032">Bus išvalyta visa <ph name="SIZE_IN_KB" /> svetainės saugykla.</translation>
-<translation id="3016635187733453316">Įsitikinkite, kad šis įrenginys prijungtas prie interneto</translation>
-<translation id="3029613699374795922">Atsisiųsta <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Slaptafrazės neatitinka</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Gaukite pagalbos<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Vieta išjungta; įjunkite <ph name="BEGIN_LINK" />„Android“ nustatymuose<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Galite bet kada įjungti sinchronizavimą „Nustatymų“ skiltyje</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> žymė}one{<ph name="BOOKMARKS_COUNT_MANY" /> žymė}few{<ph name="BOOKMARKS_COUNT_MANY" /> žymės}many{<ph name="BOOKMARKS_COUNT_MANY" /> žymės}other{<ph name="BOOKMARKS_COUNT_MANY" /> žymių}}</translation>
-<translation id="3089395242580810162">Atidaryti inkognito skirtuko lape</translation>
-<translation id="3115898365077584848">Rodyti informaciją</translation>
-<translation id="3123473560110926937">Užblokuota kai kuriose svetainėse</translation>
-<translation id="3137521801621304719">Išjungti inkognito režimą</translation>
-<translation id="3143515551205905069">Atšaukti sinchronizavimą</translation>
-<translation id="3157842584138209013">Žr., kiek duomenų sutaupėte, spustelėję mygtuką „Daugiau parinkčių“</translation>
-<translation id="3166827708714933426">Skirtukų ir langų spartieji klavišai</translation>
-<translation id="3181954750937456830">Saugus naršymas (apsaugo jus ir jūsų įrenginį nuo pavojingų svetainių)</translation>
-<translation id="3190152372525844641">Įjunkite „Chrome“ leidimus <ph name="BEGIN_LINK" />„Android“ nustatymuose<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">Išsaugota duomenų: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Beveik baigta!</translation>
-<translation id="3207960819495026254">Pažymėta</translation>
-<translation id="3211426585530211793">Ištrinta „<ph name="ITEM_TITLE" />“</translation>
-<translation id="321773570071367578">Jei pamiršote slaptafrazę arba norite pakeisti šį nustatymą, <ph name="BEGIN_LINK" />iš naujo nustatykite sinchronizavimą<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofonas</translation>
-<translation id="3232754137068452469">Žiniatinklio programa</translation>
-<translation id="3236059992281584593">Liko 1 min.</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Įtraukti šį puslapį į žymes</translation>
-<translation id="3259831549858767975">Sumažinti visą puslapio turinį</translation>
-<translation id="3269093882174072735">Įkelti vaizdą</translation>
-<translation id="3269956123044984603">Jei norite pasiekti skirtukus iš kitų įrenginių, „Android“ paskyros nustatymuose įjunkite parinktį „Automatiškai sinchronizuoti duomenis“.</translation>
-<translation id="3277252321222022663">Leidžiama svetainėms pasiekti jutiklius (rekomenduojama)</translation>
-<translation id="3282568296779691940">Prisijungti prie „Chrome“</translation>
-<translation id="3288003805934695103">Iš naujo įkelti puslapį</translation>
-<translation id="32895400574683172">Pranešimai leidžiami</translation>
-<translation id="3295530008794733555">Naršykite greičiau. Naudokite mažiau duomenų.</translation>
-<translation id="3295602654194328831">Slėpti informaciją</translation>
-<translation id="3298243779924642547">Supapr.</translation>
-<translation id="3303414029551471755">Tęsti turinio atsisiuntimo procesą?</translation>
-<translation id="3306398118552023113">Ši programa veikia naršyklėje „Chrome“</translation>
-<translation id="3315103659806849044">Šiuo metu tinkinate savo sinchronizavimo ir „Google“ paslaugų nustatymus. Jei norite užbaigti sinchronizavimo įjungimo procesą, palieskite mygtuką „Patvirtinti“ netoli ekrano apačios. Eiti į viršų</translation>
-<translation id="3328801116991980348">Svetainės informacija</translation>
-<translation id="3333961966071413176">Visi kontaktai</translation>
-<translation id="3334729583274622784">Pakeisti failo plėtinį?</translation>
-<translation id="3341058695485821946">Žr., kiek duomenų sutaupėte</translation>
-<translation id="3350687908700087792">Uždaryti visus inkognito skirtukų lapus</translation>
-<translation id="3353615205017136254">Supaprastintasis puslapis, kurį teikia „Google“. Palieskite mygtuką „Įkelti pradinį“, kad būtų įkeltas pradinis puslapis.</translation>
-<translation id="3367813778245106622">Prisijunkite dar kartą, kad pradėtumėte sinchronizavimą</translation>
-<translation id="3374023511497244703">Su jūsų „Google“ paskyra nebebus sinchronizuojamos žymės, istorija, slaptažodžiai ir kiti „Chrome“ duomenys</translation>
-<translation id="3384347053049321195">Bendrinti vaizdą</translation>
-<translation id="3386292677130313581">Klausti prieš leidžiant svetainėms žinoti vietą (rekomenduojama)</translation>
-<translation id="3387650086002190359">Nepavyko atsisiųsti „<ph name="FILE_NAME" />“ dėl failų sistemos klaidų.</translation>
-<translation id="3389286852084373014">Teksto pranešimas per didelis</translation>
-<translation id="3398320232533725830">Atidaryti žymių tvarkytuvę</translation>
-<translation id="3414952576877147120">Dydis:</translation>
-<translation id="3443221991560634068">Iš naujo įkelti dabartinį puslapį</translation>
-<translation id="3445014427084483498">Ką tik</translation>
-<translation id="3478363558367712427">Galite pasirinkti paieškos variklį</translation>
+<translation id="6910211073230771657">Ištrintas</translation>
+<translation id="6965382102122355670">Gerai</translation>
+<translation id="5301954838959518834">Gerai, supratau</translation>
+<translation id="7658239707568436148">Atšaukti</translation>
 <translation id="3479552764303398839">Ne dabar</translation>
-<translation id="3492207499832628349">Naujas inkognito skirtukas</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Sužinokite daugiau<ph name="END_LINK" /> apie siūlomą turinį</translation>
-<translation id="3513704683820682405">Išplėstoji realybė</translation>
-<translation id="3518985090088779359">Sutikti ir tęsti</translation>
-<translation id="3522247891732774234">Pasiekiamas naujinys. Daugiau parinkčių</translation>
-<translation id="3524138585025253783">Kūrėjo NS</translation>
-<translation id="3527085408025491307">Aplankas</translation>
-<translation id="3542235761944717775">Pasiekiama <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Ieškokite savo istorijoje</translation>
-<translation id="3557336313807607643">Pridėti prie kontaktų</translation>
-<translation id="3566923219790363270">„Chrome“ vis dar ruošiama naudoti įjungus VR. Vėliau iš naujo paleiskite „Chrome“.</translation>
-<translation id="3568688522516854065">Jei norite pasiekti skirtukus iš kitų įrenginių, prisijunkite ir įjunkite sinchronizavimą</translation>
-<translation id="3587482841069643663">Visi</translation>
-<translation id="358794129225322306">Leisti svetainei automatiškai atsisiųsti kelis failus.</translation>
-<translation id="3590487821116122040">Svetainės saugykla, kurios „Chrome“ nelaiko svarbia (pvz., svetainės be išsaugotų nustatymų arba tos, kuriose retai lankotės)</translation>
-<translation id="3599863153486145794">Išvaloma visų įrenginių, prie kurių prisijungta, istorija. „Google“ paskyroje gali būti kito tipo naršymo istorijos, kuri pasiekiama adresu <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Nutildyti svetaines, kurios leidžia garsą</translation>
-<translation id="3616113530831147358">Garsas</translation>
-<translation id="3631987586758005671">Bendrinama su „<ph name="DEVICE_NAME" />“</translation>
-<translation id="3632295766818638029">Rodyti slaptažodį</translation>
-<translation id="363596933471559332">Automatiškai prisijungti prie svetainių naudojant išsaugotus prisijungimo duomenis. Kai funkcija išjungta, kaskart prisijungiant prie svetainės prašoma patvirtinti.</translation>
-<translation id="3658159451045945436">Nustačius iš naujo, bus ištrinta sutaupytų duomenų istorija, įskaitant aplankytų svetainių sąrašą.</translation>
-<translation id="3692944402865947621">Nepavyko atsisiųsti „<ph name="FILE_NAME" />“, nes saugyklos vieta nepasiekiama.</translation>
-<translation id="3714981814255182093">Atidaryti radimo juostą</translation>
-<translation id="3716182511346448902">Šis puslapis naudoja per daug atminties, todėl „Chrome“ jį pristabdė.</translation>
-<translation id="3730075448226062617">Norėdami leisti „Chrome“ pasiekti jūsų mikrofoną, taip pat įjunkite jį <ph name="BEGIN_LINK" />„Android“ nustatymuose<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Pažymėta naršyklėje „<ph name="PRODUCT_NAME" />“</translation>
-<translation id="3744111561329211289">Fono sinchronizavimas</translation>
-<translation id="3771001275138982843">Nepavyko atsisiųsti naujinio</translation>
-<translation id="3771033907050503522">Inkognito skirt.</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Įjunkite „Bluetooth“<ph name="END_LINK" />, kad būtų leidžiama susieti</translation>
-<translation id="3775705724665058594">Išsiųsta į jūsų įrenginius</translation>
-<translation id="3778956594442850293">Pridėta prie pagrindinio ekrano</translation>
-<translation id="3789841737615482174">Įdiegti</translation>
-<translation id="3810838688059735925">Vaizdo</translation>
-<translation id="3810973564298564668">Valdyti</translation>
-<translation id="381841723434055211">Telefono numeriai</translation>
-<translation id="3819178904835489326">Ištrinta atsisiuntimų: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Išvalyti svet. saugyklą?</translation>
-<translation id="385051799172605136">Atgal</translation>
-<translation id="3859306556332390985">Eiti pirmyn</translation>
-<translation id="3894427358181296146">Aplanko pridėjimas</translation>
-<translation id="3895926599014793903">Priverstinai įgalinti mastelio keitimą</translation>
-<translation id="3912508018559818924">Ieškoma geriausio žiniatinklio turinio…</translation>
-<translation id="3927692899758076493">Be užraitų</translation>
-<translation id="3928666092801078803">Sujungti duomenis</translation>
-<translation id="393697183122708255">Neįgalinta paieška balsu</translation>
-<translation id="395206256282351086">Paieškos ir svetainių pasiūlymai išjungti</translation>
-<translation id="3955193568934677022">Leisti svetainėms paleisti apsaugotą turinį (rekomenduojama)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{„Chrome“ įkels puslapį, kai bus paruošta}one{„Chrome“ įkels puslapius, kai bus paruošta}few{„Chrome“ įkels puslapius, kai bus paruošta}many{„Chrome“ įkels puslapius, kai bus paruošta}other{„Chrome“ įkels puslapius, kai bus paruošta}}</translation>
-<translation id="3963007978381181125">Slaptafrazės šifruotė neapima mokėjimo metodų ir adresų iš „Google Pay“. Tik jūsų slaptafrazę žinantis asmuo gali skaityti šifruotus duomenis. Slaptafrazė nesiunčiama į sistemą „Google“ ir joje nesaugoma. Pamiršę slaptafrazę arba norėdami pakeisti šį nustatymą turėsite iš naujo nustatyti sinchronizavimą. <ph name="BEGIN_LINK" />Sužinokite daugiau<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Atsisiuntimas baigtas</translation>
-<translation id="397583555483684758">Sinchronizavimas nebeveikia</translation>
-<translation id="3976396876660209797">Pašalinkite šį spartųjį klavišą ir sukurkite jį iš naujo</translation>
-<translation id="3985215325736559418">Ar norite dar kartą atsisiųsti <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Kop. nuor.</translation>
-<translation id="3988213473815854515">Vietovės informacija leidžiama</translation>
-<translation id="3988466920954086464">Žiūrėkite tiesioginius paieškos rezultatus šiame skydelyje</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> iš ?</translation>
-<translation id="3997476611815694295">Nesvarbi saugykla</translation>
-<translation id="4000212216660919741">„Home“ neprisijungus</translation>
+<translation id="5317780077021120954">Išsaugoti</translation>
+<translation id="4570913071927164677">Išsami informacija</translation>
+<translation id="8730621377337864115">Atlikta</translation>
+<translation id="8261506727792406068">Ištrinti</translation>
+<translation id="1181037720776840403">Pašalinti</translation>
+<translation id="5939518447894949180">Nustatyti iš naujo</translation>
 <translation id="4002066346123236978">Pavadinimas</translation>
-<translation id="4008040567710660924">Leisti konkrečios svetainės slapukus.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# val.}one{# val.}few{# val.}many{# val.}other{# val.}}</translation>
-<translation id="4046123991198612571">Kitas takelis</translation>
-<translation id="4048707525896921369">Sužinokite apie temas svetainėse neišėję iš puslapio. Naudojant Paiešką palietus siunčiamas žodis ir jo kontekstas „Google“ paieškai, kuri pateikia apibrėžimų, nuotraukų, paieškos rezultatų ir kitos išsamios informacijos.
+<translation id="5916664084637901428">Įjungta</translation>
+<translation id="5860033963881614850">Išjungta</translation>
+<translation id="6165508094623778733">Sužinokite daugiau</translation>
+<translation id="6042308850641462728">Daugiau</translation>
+<translation id="6040143037577758943">Uždaryti</translation>
+<translation id="780301667611848630">Ačiū, ne</translation>
+<translation id="1201402288615127009">Kitas</translation>
+<translation id="2359808026110333948">Tęskite</translation>
+<translation id="2653659639078652383">Pateikti</translation>
+<translation id="2079545284768500474">Anuliuoti</translation>
+<translation id="7649070708921625228">Žinynas</translation>
+<translation id="2148716181193084225">Šiandien</translation>
+<translation id="7781829728241885113">Vakar</translation>
+<translation id="6945221475159498467">Pasirinkti</translation>
+<translation id="7791543448312431591">Pridėti</translation>
+<translation id="6527303717912515753">Bendrinti</translation>
+<translation id="1383876407941801731">Ieškoti</translation>
+<translation id="3115898365077584848">Rodyti informaciją</translation>
+<translation id="3295602654194328831">Slėpti informaciją</translation>
+<translation id="3987993985790029246">Kop. nuor.</translation>
+<translation id="2704606927547763573">Nukopij.</translation>
+<translation id="8725066075913043281">Bandyti dar kartą</translation>
+<translation id="385051799172605136">Atgal</translation>
+<translation id="8131740175452115882">Patvirtinti</translation>
+<translation id="5300589172476337783">Rodyti</translation>
+<translation id="1124772482545689468">Naudotojas</translation>
+<translation id="8609465669617005112">Perkelti į viršų</translation>
+<translation id="6746124502594467657">Perkelti žemyn</translation>
+<translation id="8249310407154411074">Perkelti į viršų</translation>
+<translation id="8428213095426709021">Nustatymai</translation>
+<translation id="2498359688066513246">Pagalba ir atsiliepimai</translation>
+<translation id="8378714024927312812">Tvarko jūsų organizacija</translation>
+<translation id="9019902583201351841">Tvarko jūsų tėvai</translation>
+<translation id="4645575059429386691">Tvarko vienas iš jūsų tėvų</translation>
+<translation id="4883854917563148705">Tvarkomų nustatymų negalima nustatyti iš naujo</translation>
+<translation id="4307992518367153382">Pagrindai</translation>
+<translation id="1974060860693918893">Išplėstiniai</translation>
+<translation id="1146678959555564648">Įgalinti VR</translation>
+<translation id="987264212798334818">Bendra</translation>
+<translation id="4275663329226226506">Medija</translation>
+<translation id="4759238208242260848">Atsisiuntimai</translation>
+<translation id="218608176142494674">Bendrinimas</translation>
+<translation id="8004582292198964060">Naršyklė</translation>
+<translation id="1105960400813249514">Ekrano fiksavimas</translation>
+<translation id="4875775213178255010">Turinio pasiūlymai</translation>
+<translation id="2021896219286479412">Viso ekrano svetainės valdikliai</translation>
+<translation id="4587589328781138893">Svetainės</translation>
+<translation id="4943703118917034429">Virtualioji realybė</translation>
+<translation id="1928696683969751773">Atnaujinimas</translation>
+<translation id="6064125863973209585">Baigti atsisiuntimai</translation>
+<translation id="5342314432463739672">Leidimų užklausos</translation>
+<translation id="629730747756840877">Paskyra</translation>
+<translation id="82609232232243542">Prisijungti prie „Brave“</translation>
+<translation id="7956662517480676674">Sinchron. ir „Brave Software“ paslaugos</translation>
+<translation id="5294439808117722387">Šiuo metu tinkinate savo sinchronizavimo ir „Brave Software“ paslaugų nustatymus. Jei norite užbaigti sinchronizavimo įjungimo procesą, palieskite mygtuką „Patvirtinti“ netoli ekrano apačios. Eiti į viršų</translation>
+<translation id="2096012225669085171">Sinchronizuoti ir suasmeninti įrenginiuose</translation>
+<translation id="1692118695553449118">Sinchronizavimas įjungtas</translation>
+<translation id="5514904542973294328">Išjungė šio įrenginio administratorius</translation>
+<translation id="6447211988989208781">„Brave Software“ veiklos valdikliai</translation>
+<translation id="4882831918239250449">Naršymo istorijos naudojimo paieškai, skelbimams ir kitoms funkcijoms suasmeninti valdymas</translation>
+<translation id="7431991332293347422">Naršymo istorijos naudojimo paieškai ir kitoms funkcijoms suasmeninti valdymas</translation>
+<translation id="6303969859164067831">Atsijungti ir išjungti sinchronizavimą</translation>
+<translation id="1125261911132334651">„Brave Software“ paskyros tvarkymas</translation>
+<translation id="6406506848690869874">Sinchronizavimas</translation>
+<translation id="714362445477979774">„Brave“ duomenų sinchronizavimas</translation>
+<translation id="4314815835985389558">Sinchronizavimo tvarkymas</translation>
+<translation id="5428209950370661546">Kitos „Brave Software“ paslaugos</translation>
+<translation id="7704317875155739195">Automatiškai užbaigti paieškas ir URL</translation>
+<translation id="2000419248597011803">Numatytajam paieškos varikliui siunčiami kai kurie slapukai ir į adreso juostą bei paieškos laukelį įvestos paieškos</translation>
+<translation id="7981313251711023384">Iš anksto įkelti puslapius, kad naršymo ir paieškos procesai vyktų greičiau</translation>
+<translation id="1821253160463689938">Naudojami slapukai, siekiant įsiminti jūsų nuostatas, net jei nesilankote tuose puslapiuose</translation>
+<translation id="6697492270171225480">Rodyti panašių puslapių pasiūlymus, kai nepavyksta rasti puslapio</translation>
+<translation id="8109318360573330108">Siunčiamas „Brave Software“ puslapio, kurį bandote pasiekti, URL</translation>
+<translation id="8438566539970814960">Tobulinti paieškas ir naršymą</translation>
+<translation id="284843628681142937">Siunčiami „Brave Software“ puslapių, kuriuose lankotės, URL</translation>
+<translation id="7222718784508482526">Daugiau nustatymų, susijusių su privatumu, sauga ir duomenų rinkimu, žr. skiltyje <ph name="BEGIN_LINK"/>„Sinchronizavimas ir „Brave Software“ paslaugos“<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Padėti tobulinti „Brave“ funkcijas ir našumą</translation>
+<translation id="9063160602596686558">Automatiškai siunčia naudojimo statistiką ir strigčių ataskaitas „Brave Software“</translation>
+<translation id="4824958205181053313">Atšaukti sinchronizavimą?</translation>
+<translation id="3058498974290601450">Galite bet kada įjungti sinchronizavimą „Nustatymų“ skiltyje</translation>
+<translation id="3143515551205905069">Atšaukti sinchronizavimą</translation>
+<translation id="1506061864768559482">Paieškos variklis</translation>
+<translation id="55737423895878184">Vieta ir pranešimai leidžiami</translation>
+<translation id="3988213473815854515">Vietovės informacija leidžiama</translation>
+<translation id="32895400574683172">Pranešimai leidžiami</translation>
+<translation id="9040142327097499898">Pranešimai leidžiami. Vieta išjungta šiame įrenginyje.</translation>
+<translation id="305593374596241526">Vieta išjungta; įjunkite <ph name="BEGIN_LINK"/>„Android“ nustatymuose<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Neseniai lankyta</translation>
+<translation id="6433501201775827830">Paieškos variklio pasirinkimas</translation>
+<translation id="7177466738963138057">Tai vėliau galėsite pakeisti „Nustatymų“ skiltyje</translation>
+<translation id="3478363558367712427">Galite pasirinkti paieškos variklį</translation>
+<translation id="4910889077668685004">Mokėjimo programos</translation>
+<translation id="5152843274749979095">Neįdiegta jokių palaikomų programų</translation>
+<translation id="8812260976093120287">Kai kuriose svetainėse galite mokėti naudodami įrenginyje įdiegtas anksčiau nurodytas palaikomas mokėjimo programas.</translation>
+<translation id="7764225426217299476">Pridėti adresą</translation>
+<translation id="5595485650161345191">Adreso redagavimas</translation>
+<translation id="5087580092889165836">Pridėti kortelę</translation>
+<translation id="2154484045852737596">Kortelės informacijos redagavimas</translation>
+<translation id="6140912465461743537">Šalis / regionas</translation>
+<translation id="5659593005791499971">El. paštas</translation>
+<translation id="4378154925671717803">Telefonas</translation>
+<translation id="4807098396393229769">Kortelėje nurodytas vardas ir pavardė</translation>
+<translation id="860043288473659153">Kortelės savininko vardas</translation>
+<translation id="2612676031748830579">Kortelės numeris</translation>
+<translation id="869891660844655955">Galiojimo data</translation>
+<translation id="2286841657746966508">Atsiskaitymo adresas</translation>
+<translation id="663059986967017181">Nukopijuota į „Brave“</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}few{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}many{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}many{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}few{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}many{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}few{<ph name="CONTACT_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}many{<ph name="CONTACT_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Slaptažodžiai</translation>
+<translation id="1943432128510653496">Slaptažodžių išsaugojimas</translation>
+<translation id="2100273922101894616">Automatinis prisijungimas</translation>
+<translation id="363596933471559332">Automatiškai prisijungti prie svetainių naudojant išsaugotus prisijungimo duomenis. Kai funkcija išjungta, kaskart prisijungiant prie svetainės prašoma patvirtinti.</translation>
+<translation id="6995899638241819463">Įspėti, jei slaptažodžiai buvo atskleisti įvykus duomenų saugos pažeidimui</translation>
+<translation id="1534287762301776620">Prisijungus prie „Brave Software“ paskyros, ši funkcija yra įjungta</translation>
+<translation id="10614374240317010">Niekada neišsaugota</translation>
+<translation id="3098842761938485917">Peržiūrėkite ir tvarkykite išsaugotus slaptažodžius <ph name="BEGIN_LINK"/>„Brave Software“ paskyroje<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Čia bus rodomi išsaugoti slaptažodžiai.</translation>
+<translation id="8084114998886531721">Išsaugotas slaptažodis</translation>
+<translation id="2870560284913253234">Svetainė</translation>
+<translation id="8503813439785031346">Vartotojo vardas</translation>
+<translation id="6657585470893396449">Slaptažodis</translation>
+<translation id="2154710561487035718">Kopijuoti URL adresą</translation>
+<translation id="1571304935088121812">Kopijuoti naudotojo vardą</translation>
+<translation id="5005498671520578047">Kopijuoti slaptažodį</translation>
+<translation id="3632295766818638029">Rodyti slaptažodį</translation>
+<translation id="1513858653616922153">Ištrinti slaptažodį</translation>
+<translation id="543338862236136125">Redaguoti slaptažodį</translation>
+<translation id="4565377596337484307">Slėpti slaptažodį</translation>
+<translation id="8523928698583292556">Ištrinti išsaugotą slaptažodį</translation>
+<translation id="2898264748040935573">Redaguoti išsaugotus slaptažodžius</translation>
+<translation id="5433691172869980887">Naudotojo vardas nukopijuotas</translation>
+<translation id="5534640966246046842">Svetainė nukopijuota</translation>
+<translation id="2625189173221582860">Slaptažodis nukopijuotas</translation>
+<translation id="4550003330909367850">Jei norite čia peržiūrėti ar nukopijuoti slaptažodį, nustatykite ekrano užraktą šiame įrenginyje.</translation>
+<translation id="6154478581116148741">Norėdami iš šio įrenginio eksportuoti slaptažodžius, nustatymuose įjunkite ekrano užraktą</translation>
+<translation id="4842092870884894799">Rodomas slaptažodžio generavimo iššokantysis langas</translation>
+<translation id="2259659629660284697">Eksportuoti slaptažodžius…</translation>
+<translation id="133012818630824069">Eksportuoti sistemoje „Brave“ saugomus slaptažodžius</translation>
+<translation id="6914783257214138813">Jūsų slaptažodžiai bus matomi visiems, kurie gali peržiūrėti eksportuotą failą.</translation>
+<translation id="2321086116217818302">Ruošiami slaptažodžiai…</translation>
+<translation id="8445448999790540984">Nepavyksta eksportuoti slaptažodžių</translation>
+<translation id="3066461326500799725">Sužinokite, kaip naudoti „Brave Software Drive“</translation>
+<translation id="729975465115245577">Įrenginyje nėra slaptažodžių failo saugojimo programos.</translation>
+<translation id="7682724950699840886">Išbandykite nurodytus patarimus: įsitikinkite, kad įrenginyje yra pakankamai vietos, ir bandykite eksportuoti dar kartą.</translation>
+<translation id="1129510026454351943">Išsami informacija: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Atrakinkite, kad galėtumėte kopijuoti slaptažodį</translation>
+<translation id="5515439363601853141">Atrakinkite, kad galėtumėte peržiūrėti slaptažodį</translation>
+<translation id="6221633008163990886">Atrakinkite, kad galėtumėte eksportuoti slaptažodžius</translation>
+<translation id="230699814587342492">„Brave“ slaptažodžiai</translation>
+<translation id="6075798973483050474">Redaguoti pagrindinį puslapį</translation>
+<translation id="854522910157234410">Atidaryti šį puslapį</translation>
+<translation id="2482878487686419369">Pranešimai</translation>
+<translation id="6255999984061454636">Turinio pasiūlymai</translation>
+<translation id="805047784848435650">Pagal naršymo istoriją</translation>
+<translation id="1041308826830691739">Iš svetainių</translation>
+<translation id="395206256282351086">Paieškos ir svetainių pasiūlymai išjungti</translation>
+<translation id="257088987046510401">Temos</translation>
+<translation id="4650364565596261010">Sistemos numatytasis nustatymas</translation>
+<translation id="7588219262685291874">Įjungti tamsiąją temą, kai įjungta įrenginio akumuliatoriaus tausojimo priemonė</translation>
+<translation id="2760989362628427051">Įjungti tamsiąją temą, kai įjungta įrenginio tamsioji tema arba akumuliatoriaus tausojimo priemonė</translation>
+<translation id="6381421346744604172">Patamsinti svetaines</translation>
+<translation id="5040262127954254034">Privatumas</translation>
+<translation id="4991384657077828949">Padėkite tobulinti „Brave“ saugą</translation>
+<translation id="1943176487615318915">Tam, kad būtų aptiktos pavojingos programos ir svetainės, „Brave“ siunčia „Brave Software“ kai kurių puslapių, kuriuose lankotės, URL, ribotą sistemos informaciją ir kai kurių puslapių turinį</translation>
+<translation id="3181954750937456830">Saugus naršymas (apsaugo jus ir jūsų įrenginį nuo pavojingų svetainių)</translation>
+<translation id="7315322926489145388">Siunčia „Brave Software“ kai kurių puslapių, kuriuose lankotės, URL, kai kyla pavojus jūsų saugai</translation>
+<translation id="2063713494490388661">Paliesti ir ieškoti</translation>
+<translation id="2369463299479365221">Sužinokite apie temas svetainėse neišėję iš puslapio. Naudojant Paiešką palietus siunčiamas žodis ir jo kontekstas „Brave Software“ paieškai, kuri pateikia apibrėžimų, nuotraukų, paieškos rezultatų ir kitos išsamios informacijos.
 
 Jei norite koreguoti paieškos terminą, paspauskite ir laikykite, kad jį pasirinktumėte. Kad patikslintumėte paiešką, slinkite skydeliu į viršų ir palieskite paieškos laukelį.</translation>
-<translation id="4056223980640387499">Sepija</translation>
-<translation id="4060598801229743805">Parinktys pasiekiamos netoli ekrano viršaus</translation>
-<translation id="4062305924942672200">Teisinė informacija</translation>
-<translation id="4084682180776658562">Žymė</translation>
-<translation id="4084712963632273211">Nuo <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />pateikė „Google“<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Ištrinti programos duomenis?</translation>
-<translation id="4099578267706723511">Padėkite tobulinti „Chrome“ siųsdami „Google“ naudojimo statistiką ir strigčių ataskaitas.</translation>
-<translation id="410351446219883937">Automatinis paleidimas</translation>
-<translation id="4116038641877404294">Atsisiųskite puslapius, kad galėtumėte naudoti juos neprisijungę</translation>
-<translation id="4135200667068010335">Įrenginių, su kuriais reikia bendrinti skirtuką, sąrašas uždarytas.</translation>
-<translation id="4149994727733219643">Supaprastinta tinklalapių peržiūra</translation>
-<translation id="4165986682804962316">Svetainės nustatymai</translation>
-<translation id="4169535189173047238">Neleisti</translation>
-<translation id="4170011742729630528">Paslauga nepasiekiama; vėliau bandykite dar kartą.</translation>
-<translation id="4179980317383591987">Naudojama <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Kalbos</translation>
-<translation id="4183868528246477015">Ieškoti su „Google Lens“ <ph name="BEGIN_NEW" />Nauja<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Atidaryti naujame skirtuke</translation>
-<translation id="4198423547019359126">Nėra pasiekiamų atsisiuntimo vietų</translation>
-<translation id="4209895695669353772">Jei norite gauti „Google“ siūlomo suasmeninto turinio, įjunkite sinchronizavimą</translation>
-<translation id="4226663524361240545">Gavus pranešimą įrenginys gali vibruoti</translation>
-<translation id="423219824432660969">Šifruoti sinchronizuotus duomenis nuo <ph name="TIME" /> taikant „Google“ slaptažodį</translation>
-<translation id="4242533952199664413">Atidaryti nustatymus</translation>
-<translation id="4256782883801055595">Atvirojo šaltinio licencijos</translation>
-<translation id="4259722352634471385">Naršymas užblokuotas: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopijuoti nuorodos adresą</translation>
-<translation id="4275663329226226506">Medija</translation>
-<translation id="4278390842282768270">Leidžiama</translation>
-<translation id="429312253194641664">Svetainėje leidžiama medija</translation>
-<translation id="4298388696830689168">Susietos svetainės</translation>
-<translation id="4307992518367153382">Pagrindai</translation>
-<translation id="4314815835985389558">Sinchronizavimo tvarkymas</translation>
-<translation id="4351244548802238354">Uždaryti dialogo langą</translation>
-<translation id="4378154925671717803">Telefonas</translation>
-<translation id="4384468725000734951">Atliekant paiešką naudojama „Sogou“</translation>
-<translation id="4404568932422911380">Nėra jokių žymių</translation>
-<translation id="4405224443901389797">Perkelti į…</translation>
-<translation id="4411535500181276704">Supaprastintasis režimas</translation>
-<translation id="4415276339145661267">„Google“ paskyros tvarkymas</translation>
-<translation id="4432792777822557199">Puslapiai, parašyti <ph name="SOURCE_LANGUAGE" />, nuo dabar bus verčiami į <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Supaprastintasis puslapis, kurį teikia „Google“</translation>
-<translation id="4434045419905280838">Iššok. langai ir peradresavimai</translation>
-<translation id="4440958355523780886">Supaprastintasis puslapis, kurį teikia „Google“. Palieskite, kad būtų įkeltas pradinis puslapis.</translation>
-<translation id="4452411734226507615">Uždaryti skirtuką „<ph name="TAB_TITLE" />“</translation>
-<translation id="4452548195519783679">Sukurta „<ph name="FOLDER_NAME" />“ žymė</translation>
-<translation id="445467742685312942">Leisti svetainėms leisti saugomą turinį</translation>
-<translation id="4468959413250150279">Konkrečios svetainės garso išjungimas.</translation>
-<translation id="4472118726404937099">Jei norite sinchronizuoti ir suasmeninti turinį visuose įrenginiuose, prisijunkite ir įjunkite sinchronizavimą</translation>
-<translation id="447252321002412580">Padėti tobulinti „Chrome“ funkcijas ir našumą</translation>
-<translation id="4479647676395637221">Pirmiausia klausti prieš leidžiant svetainėms naudoti kamerą (rekomenduojama)</translation>
-<translation id="4479972344484327217">Įdiegiamas „Chrome“ skirtas modulis „<ph name="MODULE" />“…</translation>
-<translation id="4487967297491345095">Visi „Chrome“ duomenys bus ištrinti visam laikui. Tai apima visus failus, nustatymus, paskyras, duomenų bazes ir kt.</translation>
-<translation id="4493497663118223949">Supaprastintasis režimas įjungtas</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Prieš # dieną}one{Prieš # dieną}few{Prieš # dienas}many{Prieš # dienos}other{Prieš # dienų}}</translation>
-<translation id="451872707440238414">Ieškoti žymėse</translation>
-<translation id="4521489764227272523">Pasirinkti duomenys pašalinti iš „Chrome“ ir sinchronizuojamų įrenginių.
-
-Adresu <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> gali būti pateikta kitų formų jūsų „Google“ paskyros naršymo istorija, pvz., paieškos ir veikla kitose „Google“ paslaugose.</translation>
-<translation id="4532845899244822526">Pasirinkti aplanką</translation>
-<translation id="4538018662093857852">Įjungti supaprastintąjį režimą</translation>
-<translation id="4550003330909367850">Jei norite čia peržiūrėti ar nukopijuoti slaptažodį, nustatykite ekrano užraktą šiame įrenginyje.</translation>
-<translation id="4558311620361989323">Tinklalapių spartieji klavišai</translation>
-<translation id="4561979708150884304">Nėra ryšio</translation>
-<translation id="4565377596337484307">Slėpti slaptažodį</translation>
-<translation id="4570913071927164677">Išsami informacija</translation>
-<translation id="4572422548854449519">Prisijungimas prie tvarkomos paskyros</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Prieš 1 minutę}one{Prieš # minutę}few{Prieš # minutes}many{Prieš # minutės}other{Prieš # minučių}}</translation>
-<translation id="4587589328781138893">Svetainės</translation>
-<translation id="4594952190837476234">Šis neprisijungus naudojamas puslapis sukurtas <ph name="CREATION_TIME" />, todėl gali skirtis nuo prisijungus pateiktos versijos.</translation>
-<translation id="4605958867780575332">Pašalintas elementas: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Atidaryti „<ph name="WEBAPK_NAME" />“</translation>
-<translation id="4634124774493850572">Naudoti slaptažodį</translation>
-<translation id="4645575059429386691">Tvarko vienas iš jūsų tėvų</translation>
-<translation id="4650364565596261010">Sistemos numatytasis nustatymas</translation>
-<translation id="4663756553811254707">Ištrinta žymių: <ph name="NUMBER_OF_BOOKMARKS" /></translation>
-<translation id="4665282149850138822">Svetainė „<ph name="NAME" />“ pridėta prie pagrindinio ekrano</translation>
-<translation id="4684427112815847243">Viską sinchronizuoti</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}few{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}many{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Siųsti teksto pranešimą savo įrenginiams</translation>
-<translation id="4698034686595694889">Žr. neprisijungus programoje „<ph name="APP_NAME" />“</translation>
-<translation id="4699172675775169585">Talpykloje esantys vaizdai ir failai</translation>
-<translation id="4714588616299687897">Sutaupykite iki 60 proc. duomenų</translation>
-<translation id="4719927025381752090">Siūlyti versti</translation>
-<translation id="4720023427747327413">Atidaryti naudojant „<ph name="PRODUCT_NAME" />“</translation>
-<translation id="4720982865791209136">Padėkite tobulinti „Chrome“. <ph name="BEGIN_LINK" />Dalyvaukite apklausoje<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Atnaujinti</translation>
-<translation id="4738836084190194332">Paskutinį kartą sinchronizuota: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Atidaryti naują skirtuką</translation>
-<translation id="4751476147751820511">Judesio arba šviesos jutikliai</translation>
-<translation id="4759238208242260848">Atsisiuntimai</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Baigtas 1 atsisiuntimas.}one{Baigtas # atsisiuntimas.}few{Baigti # atsisiuntimai.}many{Baigta # atsisiuntimo.}other{Baigta # atsisiuntimų.}}</translation>
-<translation id="4797039098279997504">Palieskite, kad grįžtumėte į <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Slaptafrazės šifruotė neapima mokėjimo metodų ir adresų iš „Google Pay“.
-
-Jei norite pakeisti šį nustatymą, <ph name="BEGIN_LINK" />iš naujo nustatykite sinchronizavimą<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Kortelėje nurodytas vardas ir pavardė</translation>
-<translation id="4824958205181053313">Atšaukti sinchronizavimą?</translation>
-<translation id="4837753911714442426">Atidaryti puslapio spausdinimo parinktis</translation>
-<translation id="4842092870884894799">Rodomas slaptažodžio generavimo iššokantysis langas</translation>
-<translation id="4860895144060829044">Skambinti</translation>
-<translation id="4866368707455379617">Nepavyko įdiegti „Chrome“ skirto modulio „<ph name="MODULE" />“</translation>
-<translation id="4875775213178255010">Turinio pasiūlymai</translation>
-<translation id="4878404682131129617">Nepavyko užmegzti tunelinio ryšio per tarpinį serverį</translation>
-<translation id="4880127995492972015">Versti…</translation>
-<translation id="4881695831933465202">Atidaryti</translation>
-<translation id="488187801263602086">Failo pervardijimas</translation>
-<translation id="4882831918239250449">Naršymo istorijos naudojimo paieškai, skelbimams ir kitoms funkcijoms suasmeninti valdymas</translation>
-<translation id="4883854917563148705">Tvarkomų nustatymų negalima nustatyti iš naujo</translation>
-<translation id="4885273946141277891">Nepalaikomas „Chrome“ atvejų skaičius.</translation>
-<translation id="4910889077668685004">Mokėjimo programos</translation>
-<translation id="4913161338056004800">Iš naujo nustatyti statistiką</translation>
-<translation id="4913169188695071480">Sustabdyti atnaujinimą</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Gaukite pagalbos<ph name="END_LINK" />, kol ieškoma įrenginių…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# puslapis}one{# puslapis}few{# puslapiai}many{# puslapio}other{# puslapių}}</translation>
-<translation id="4932247056774066048">Atsijungiate nuo paskyros, kurią valdo <ph name="DOMAIN_NAME" />, todėl jūsų „Chrome“ duomenys bus ištrinti iš šio įrenginio. Duomenys liks „Google“ paskyroje.</translation>
-<translation id="4943703118917034429">Virtualioji realybė</translation>
-<translation id="4943872375798546930">Rezultatų nėra</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> bendrina jūsų ekrano vaizdą</translation>
-<translation id="4961107849584082341">Išverskite šį puslapį į bet kokią kalbą</translation>
-<translation id="4962975101802056554">Anuliuoti visus įrenginio leidimus</translation>
-<translation id="4970824347203572753">Nepasiekiama jūsų vietovėje</translation>
-<translation id="497421865427891073">Eiti pirmyn</translation>
-<translation id="4988210275050210843">Atsisiunčiamas failas (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Psl.</translation>
-<translation id="4994033804516042629">Kontaktų nerasta</translation>
-<translation id="4996978546172906250">Bendrinti per</translation>
-<translation id="5004416275253351869">„Google“ veiklos valdikliai</translation>
-<translation id="5005498671520578047">Kopijuoti slaptažodį</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> nori prisijungti</translation>
-<translation id="5013696553129441713">Nėra jokių naujų pasiūlymų</translation>
-<translation id="5016205925109358554">Su užraitais</translation>
-<translation id="5033865233969348410">VR režimu ši svetainė gali sužinoti apie jus tam tikros informacijos:
-  –  jūsų fizines savybes, pvz., ūgį.
-
-Prieš aktyvindami VR režimą įsitikinkite, kad ši svetainė patikima.</translation>
+<translation id="2930742481329940825">Naudojant Paiešką palietus siunčiamas žodis ir jo kontekstas „Brave Software“ paieškai. Šią funkciją galite išjungti skiltyje <ph name="BEGIN_LINK"/>„Nustatymai“<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Leisti</translation>
-<translation id="5040262127954254034">Privatumas</translation>
-<translation id="5048398596102334565">Leidžiama svetainėms pasiekti judesio jutiklius (rekomenduojama)</translation>
-<translation id="5063480226653192405">Naudojimas</translation>
-<translation id="5087580092889165836">Pridėti kortelę</translation>
-<translation id="5100237604440890931">Sutraukta – spustelėkite, kad išskleistumėte</translation>
-<translation id="510275257476243843">Liko 1 val.</translation>
-<translation id="5123685120097942451">Inkognito skirtukas</translation>
-<translation id="5127805178023152808">Sinchronizavimas išjungtas</translation>
-<translation id="5129038482087801250">Įdiegti žiniatinklio progr.</translation>
-<translation id="5132942445612118989">Sinchronizuokite slaptažodžius, istoriją ir daugiau visuose įrenginiuose</translation>
-<translation id="5139940364318403933">Sužinokite, kaip naudoti „Google Drive“</translation>
-<translation id="515227803646670480">Valyti išsaugotus duomenis</translation>
-<translation id="5152843274749979095">Neįdiegta jokių palaikomų programų</translation>
-<translation id="5161254044473106830">Būtina nurodyti pavadinimą</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Nepavyko atlikti 1 atsisiuntimo.}one{Nepavyko atlikti # atsisiuntimo.}few{Nepavyko atlikti # atsisiuntimų.}many{Nepavyko atlikti # atsisiuntimo.}other{Nepavyko atlikti # atsisiuntimų.}}</translation>
-<translation id="5170568018924773124">Rodyti aplanke</translation>
-<translation id="5184329579814168207">Atidaryti naudojant „Chrome“</translation>
-<translation id="5193988420012215838">Nukopijuota į iškarpinę</translation>
-<translation id="5197729504361054390">Pasirinkti kontaktai bus bendrinami su <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Darbo profilis</translation>
-<translation id="5210286577605176222">Pereiti prie ankstesnio skirtuko</translation>
-<translation id="5210365745912300556">Uždaryti skirtuką</translation>
-<translation id="5224771365102442243">Su vaizdo įrašu</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> nori nuskaityti netoliese esančius „Bluetooth“ įrenginius. Rasti šie įrenginiai:</translation>
-<translation id="5233638681132016545">Naujas skirtukas</translation>
-<translation id="526421993248218238">Nepavyko įkelti šio puslapio</translation>
-<translation id="5271967389191913893">Įrenginyje nepavyksta atidaryti norimo atsisiųsti turinio.</translation>
-<translation id="528192093759286357">Vilkite žymeklį nuo viršaus ir palieskite mygtuką „Atgal“, kad išeitumėte iš viso ekrano režimo.</translation>
-<translation id="5292796745632149097">Siųsti į</translation>
-<translation id="5300589172476337783">Rodyti</translation>
-<translation id="5301954838959518834">Gerai, supratau</translation>
-<translation id="5304593522240415983">Šis laukas negali būti tuščias</translation>
-<translation id="5307446750509046227">Išvalyti svetainės saug.</translation>
-<translation id="5308380583665731573">Prisijungti</translation>
-<translation id="5313967007315987356">Pridėti svetainę</translation>
-<translation id="5317780077021120954">Išsaugoti</translation>
-<translation id="5324858694974489420">Tėvų nustatymai</translation>
-<translation id="5327248766486351172">Pavadinimas</translation>
-<translation id="5335288049665977812">Leisti svetainėms paleisti „JavaScript“ (rekomenduojama)</translation>
-<translation id="5342314432463739672">Leidimų užklausos</translation>
-<translation id="5357811892247919462">Skirtukas gautas</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> atidarytas skirtukas; palieskite, kad perjungtumėte skirtukus}one{<ph name="OPEN_TABS_MANY" /> atidarytas skirtukas; palieskite, kad perjungtumėte skirtukus}few{<ph name="OPEN_TABS_MANY" /> atidaryti skirtukai; palieskite, kad perjungtumėte skirtukus}many{<ph name="OPEN_TABS_MANY" /> atidaryto skirtuko; palieskite, kad perjungtumėte skirtukus}other{<ph name="OPEN_TABS_MANY" /> atidarytų skirtukų; palieskite, kad perjungtumėte skirtukus}}</translation>
-<translation id="5391532827096253100">Ryšys su šia svetaine nėra saugus. Svetainės informacija</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(ir dar 1)}one{(ir dar #)}few{(ir dar #)}many{(ir dar #)}other{(ir dar #)}}</translation>
-<translation id="5400569084694353794">Naudodami šią programą sutinkate su „Chrome“ <ph name="BEGIN_LINK1" />paslaugų teikimo sąlygomis<ph name="END_LINK1" /> ir <ph name="BEGIN_LINK2" />privatumo pranešimo<ph name="END_LINK2" /> sąlygomis.</translation>
-<translation id="5403592356182871684">Pavadinimai</translation>
-<translation id="5403644198645076998">Leisti tik konkrečias svetaines</translation>
-<translation id="5414836363063783498">Patvirtinama…</translation>
-<translation id="5423934151118863508">Puslapiai, kuriuose lankomasi dažniausiai, bus rodomi čia</translation>
-<translation id="5424588387303617268">Pasiekiama: <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Redaguoti slaptažodį</translation>
-<translation id="5433691172869980887">Naudotojo vardas nukopijuotas</translation>
-<translation id="543509235395288790">Atsisiunčiami failai: <ph name="COUNT" /> (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Pereiti prie adreso juostos</translation>
-<translation id="5447201525962359567">Visa svetainės saugykla, įskaitant slapukus ir kitus vietoje saugomus duomenis</translation>
-<translation id="5447765697759493033">Ši svetainė nebus verčiama</translation>
-<translation id="545042621069398927">Paspartinamas atsisiuntimas.</translation>
-<translation id="5456381639095306749">Atsisiųsti puslapį</translation>
-<translation id="5475862044948910901">Pradėti išplėstosios realybės seansą?</translation>
-<translation id="548278423535722844">Atidaryti Žemėlapių programoje</translation>
-<translation id="5487521232677179737">Išvalyti duomenis</translation>
-<translation id="5494752089476963479">Blokuoti skelbimus svetainėse, kuriose rodomi nepageidaujami arba klaidinantys skelbimai</translation>
-<translation id="5500777121964041360">Gali būti nepasiekiama jūsų vietovėje</translation>
-<translation id="5512137114520586844">Šią paskyrą tvarko <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Išjungė šio įrenginio administratorius</translation>
-<translation id="5515439363601853141">Atrakinkite, kad galėtumėte peržiūrėti slaptažodį</translation>
-<translation id="5516455585884385570">Atidaryti pranešimų nustatymus</translation>
-<translation id="5517095782334947753">Turite žymių, istorijos duomenų, slaptažodžių ir kitų nustatymų iš <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Peradresavimas užblokuotas.</translation>
-<translation id="5527082711130173040">„Chrome“ reikalinga prieiga prie informacijos apie vietovę, kad galėtų nuskaityti įrenginius. <ph name="BEGIN_LINK1" />Atnaujinkite leidimus<ph name="END_LINK1" />. Be to, galimybė pasiekti informaciją apie vietovę <ph name="BEGIN_LINK2" />išjungta šiame įrenginyje<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Klausti, prieš leidžiant svetainėms skaityti tekstą ir vaizdus iš iškarpinės (rekomenduojama)</translation>
-<translation id="5530766185686772672">Užd. inkognito skirt. lapus</translation>
-<translation id="5534334044554683961">VR režimu ši svetainė gali sužinoti apie jus tam tikros informacijos:
-  –   jūsų fizines savybes, pvz., ūgį;
-  –   patalpos išdėstymą.
-
-Prieš aktyvindami VR, įsitikinkite, kad ši svetainė patikima.</translation>
-<translation id="5534640966246046842">Svetainė nukopijuota</translation>
-<translation id="5556459405103347317">Įkelti iš naujo</translation>
-<translation id="5561549206367097665">Laukiama tinklo…</translation>
-<translation id="557283862590186398">„Chrome“ reikia leidimo, kad galėtų naudoti jūsų mikrofoną šioje svetainėje.</translation>
-<translation id="55737423895878184">Vieta ir pranešimai leidžiami</translation>
-<translation id="5578795271662203820">Ieškoti „<ph name="SEARCH_ENGINE" />“ šio vaizdo</translation>
-<translation id="5581519193887989363">Bet kada galite pasirinkti, ką norite sinchronizuoti, skiltyje <ph name="BEGIN_LINK1" />„Nustatymai“<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Adreso redagavimas</translation>
-<translation id="5596627076506792578">Daugiau parinkčių</translation>
-<translation id="5599455543593328020">Inkognito režimas</translation>
-<translation id="5620928963363755975">Suraskite failus ir puslapius „Atsisiuntimų“ skiltyje spustelėję mygtuką „Daugiau parinkčių“</translation>
-<translation id="5626134646977739690">Pavadinimas:</translation>
-<translation id="5639724618331995626">Leisti visas svetaines</translation>
-<translation id="5648166631817621825">Pastarosios 7 dienos</translation>
-<translation id="5649053991847567735">Automatiškai atsisiųsti</translation>
-<translation id="5655963694829536461">Ieškokite atsisiųstų elementų</translation>
-<translation id="5659593005791499971">El. paštas</translation>
-<translation id="5665379678064389456">Sukurti įvykį naudojant „<ph name="APP_NAME" />“</translation>
-<translation id="5668404140385795438">Nepaisyti svetainės mastelio keitimo vengimo užklausos</translation>
-<translation id="5677928146339483299">Užblokuoti</translation>
-<translation id="5684874026226664614">Oi, nepavyko išversti šio puslapio.</translation>
-<translation id="5686790454216892815">Failo pavadinimas per ilgas</translation>
-<translation id="5689516760719285838">Vieta</translation>
-<translation id="569536719314091526">Išverskite šį puslapį į bet kokią kalbą spustelėję mygtuką „Daugiau parinkčių“</translation>
-<translation id="572328651809341494">Naujausi skirtukai</translation>
-<translation id="5726692708398506830">Padidinti visą puslapio turinį</translation>
-<translation id="5748802427693696783">Perjungta į įprastus skirtukus</translation>
-<translation id="5749068826913805084">„Chrome“ reikia prieigos prie saugyklos failams atsisiųsti.</translation>
-<translation id="5763382633136178763">Inkognito skirtukai</translation>
-<translation id="5763514718066511291">Palieskite, jei norite nukopijuoti šios programos URL</translation>
-<translation id="5765780083710877561">Aprašas:</translation>
-<translation id="5793665092639000975">Naudojama <ph name="SPACE_USED" /> iš <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">„Google“ gali naudoti jūsų istoriją, kad suasmenintų Paiešką, skelbimus ir kitas „Google“ paslaugas</translation>
-<translation id="5804241973901381774">Leidimai</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Prieš 1 valandą}one{Prieš # valandą}few{Prieš # valandas}many{Prieš # valandos}other{Prieš # valandų}}</translation>
-<translation id="5810288467834065221">Autorių teisės „Google LLC.“, <ph name="YEAR" /> m. Visos teisės saugomos.</translation>
-<translation id="5817918615728894473">Susieti</translation>
-<translation id="583281660410589416">Nežinoma</translation>
-<translation id="5833984609253377421">Bendrinti nuorodą</translation>
-<translation id="5836192821815272682">Atsisiunčiamas „Chrome“ naujinys…</translation>
-<translation id="5853623416121554550">pristabdyta</translation>
-<translation id="5854790677617711513">Senesni nei 30 dienų</translation>
-<translation id="5858741533101922242">„Chrome“ nepavyksta įjungti „Bluetooth“ adapterio</translation>
-<translation id="5860033963881614850">Išjungta</translation>
-<translation id="5862731021271217234">Jei norite pasiekti skirtukus iš kitų įrenginių, įjunkite sinchronizavimą</translation>
-<translation id="5864174910718532887">Išsami informacija: surūšiuota pagal svetainės pavadinimą</translation>
-<translation id="5864419784173784555">Laukiama kito atsisiuntimo…</translation>
-<translation id="5865733239029070421">Automatiškai siunčia naudojimo statistiką ir strigčių ataskaitas „Google“</translation>
-<translation id="5869522115854928033">Išsaugoti slaptažodžiai</translation>
-<translation id="5902828464777634901">Visi šioje svetainėje saugomi vietiniai duomenys, įskaitant slapukus, bus ištrinti.</translation>
-<translation id="5916664084637901428">Įjungta</translation>
-<translation id="5919204609460789179">Atnaujinkite „<ph name="PRODUCT_NAME" />“, kad galėtumėte pradėti sinchronizuoti</translation>
-<translation id="5937580074298050696">Išsaugota <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Nustatyti iš naujo</translation>
-<translation id="5942872142862698679">Atliekant paiešką naudojama „Google“</translation>
-<translation id="5952764234151283551">Siunčiamas „Google“ puslapio, kurį bandote pasiekti, URL</translation>
-<translation id="5956665950594638604">Atidaryti „Chrome“ pagalb. centrą naujame skirtuke</translation>
-<translation id="5958275228015807058">Suraskite failus ir puslapius „Atsisiuntimų“ skiltyje</translation>
-<translation id="5962718611393537961">Palieskite ir sutraukite</translation>
-<translation id="6000066717592683814">Palikti „Google“</translation>
-<translation id="6005538289190791541">Siūlomas slaptažodis</translation>
-<translation id="6036057147555329831">Papildomas ICU</translation>
-<translation id="6039379616847168523">Pereiti prie kito skirtuko</translation>
-<translation id="6040143037577758943">Uždaryti</translation>
-<translation id="6042308850641462728">Daugiau</translation>
-<translation id="604996488070107836">Nepavyko atsisiųsti „<ph name="FILE_NAME" />“ dėl nežinomos klaidos.</translation>
-<translation id="605721222689873409">MM</translation>
-<translation id="6064125863973209585">Baigti atsisiuntimai</translation>
-<translation id="6075798973483050474">Redaguoti pagrindinį puslapį</translation>
-<translation id="60923314841986378">Liko <ph name="HOURS" /> val.</translation>
-<translation id="6108923351542677676">Nustatoma…</translation>
-<translation id="6111020039983847643">išnaudoti duomenys</translation>
-<translation id="6112702117600201073">Puslapio atnaujinimas</translation>
-<translation id="6127379762771434464">Elementas pašalintas</translation>
-<translation id="6140912465461743537">Šalis / regionas</translation>
-<translation id="614940544461990577">Pabandykite atlikti toliau nurodytus veiksmus.</translation>
-<translation id="6154478581116148741">Norėdami iš šio įrenginio eksportuoti slaptažodžius, nustatymuose įjunkite ekrano užraktą</translation>
-<translation id="6159335304067198720">Sutaupyta duomenų: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Sužinokite daugiau</translation>
-<translation id="6177111841848151710">Užblokuota dabartiniam paieškos varikliui</translation>
-<translation id="6181444274883918285">Pridėti svetainės išimtį</translation>
-<translation id="6192333916571137726">Atsisiųsti failą</translation>
-<translation id="6192792657125177640">Išimtys</translation>
-<translation id="6194112207524046168">Norėdami leisti „Chrome“ pasiekti jūsų kamerą, taip pat įjunkite ją <ph name="BEGIN_LINK" />„Android“ nustatymuose<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokuoti trečiosios šalies slapukus</translation>
-<translation id="6206551242102657620">Ryšys yra saugus. Svetainės informacija</translation>
-<translation id="6210748933810148297">Ne <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Atrakinkite, kad galėtumėte eksportuoti slaptažodžius</translation>
+<translation id="1406000523432664303">Funkcija „Nestebėti“</translation>
 <translation id="6232535412751077445">Įgalinus funkciją „Nestebėti“, užklausa bus įtraukta į naršymo srautą. Poveikis priklauso nuo to, ar svetainė atsako į užklausą ir kaip užklausa interpretuojama.
 
 Pavyzdžiui, kai kurios svetainės gali atsakyti į šią užklausą rodydamos jums skelbimus, nepagrįstus kitomis svetainėmis, kuriose lankėtės. Daugelis svetainių vis tiek rinks ir naudos jūsų naršymo duomenis, kad, pvz., patobulintų saugą, teiktų turinį, skelbimus bei rekomendacijas ir sugeneruotų ataskaitų teikimo statistiką.</translation>
-<translation id="624789221780392884">Naujinys paruoštas</translation>
-<translation id="6255999984061454636">Turinio pasiūlymai</translation>
-<translation id="6277522088822131679">Spausdinant puslapį kilo problema. Bandykite dar kartą.</translation>
-<translation id="6295158916970320988">Visos svetainės</translation>
-<translation id="629730747756840877">Paskyra</translation>
-<translation id="6303969859164067831">Atsijungti ir išjungti sinchronizavimą</translation>
-<translation id="6316139424528454185">„Android“ versija nepalaikoma</translation>
-<translation id="6320088164292336938">Vibruoti</translation>
-<translation id="6324034347079777476">„Android“ sistemos sinchronizavimas išjungtas</translation>
-<translation id="6333140779060797560">Bendrinti per „<ph name="APPLICATION" />“</translation>
-<translation id="6337234675334993532">Šifruotė</translation>
-<translation id="6341580099087024258">Klausti, kur saugoti failus</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}few{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}many{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Pašalinti pasiūlymą iš istorijos?</translation>
-<translation id="6369229450655021117">Iš čia galite ieškoti žiniatinklyje, bendrinti su draugais ir peržiūrėti atidarytus puslapius</translation>
-<translation id="6378173571450987352">Išsami informacija: surūšiuota pagal naudojamų duomenų kiekį</translation>
-<translation id="6381421346744604172">Patamsinti svetaines</translation>
-<translation id="6388207532828177975">Išvalyti ir nustatyti iš naujo</translation>
-<translation id="6393863479814692971">„Chrome“ reikia leidimo, kad galėtų naudoti jūsų fotoaparatą ir mikrofoną šioje svetainėje.</translation>
-<translation id="6395288395575013217">NUORODA</translation>
-<translation id="6404511346730675251">Redaguoti žymę</translation>
-<translation id="6406506848690869874">Sinchronizavimas</translation>
-<translation id="641643625718530986">Spausdinti…</translation>
-<translation id="6416782512398055893">Atsisiųsta <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Žiniatinklio vertimas</translation>
-<translation id="6433501201775827830">Paieškos variklio pasirinkimas</translation>
-<translation id="6437478888915024427">Puslapio informacija</translation>
-<translation id="6441734959916820584">Pavadinimas yra per ilgas</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# vaizdas}one{# vaizdas}few{# vaizdai}many{# vaizdo}other{# vaizdų}}</translation>
-<translation id="6447842834002726250">Slapukai</translation>
-<translation id="6461962085415701688">Nepavyksta atidaryti failo</translation>
-<translation id="6464977750820128603">Galite peržiūrėti svetaines, kuriose lankotės naudodami „Chrome“, ir nustatyti jų laikmačius.\n\n„Google“ gauna informaciją apie svetaines, kurių laikmačius nustatote, ir apie apsilankymų jose trukmę. Ši informacija naudojama norint patobulinti Skaitmeninės gerovės funkcijas.</translation>
-<translation id="6475951671322991020">Atsisiųsti vaizdo įrašą</translation>
-<translation id="6482749332252372425">Nepavyko atsisiųsti „<ph name="FILE_NAME" />“ dėl trūkstamos vietos saugykloje.</translation>
-<translation id="6496823230996795692">Jei „<ph name="APP_NAME" />“ norite naudoti pirmą kartą, prisijunkite prie interneto.</translation>
-<translation id="6508722015517270189">Iš naujo paleiskite „Chrome“</translation>
-<translation id="6527303717912515753">Bendrinti</translation>
-<translation id="6532866250404780454">Svetainės, kuriose lankotės naudodami „Chrome“, nebus rodomos. Visi svetainių laikmačiai bus ištrinti.</translation>
-<translation id="6534565668554028783">Per ilgai laukta „Google“ atsako</translation>
-<translation id="6538442820324228105">Atsisiųsta <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Įvyko klaida. Vėliau bandykite dar kartą.</translation>
-<translation id="654446541061731451">Kad perduotumėte, pasirinkite skirtuką</translation>
-<translation id="6545017243486555795">Išvalyti visus duomenis</translation>
-<translation id="6545864417968258051">„Bluetooth“ nuskaitymas</translation>
-<translation id="6560414384669816528">Atlikti paiešką naudojant „Sogou“</translation>
-<translation id="6566259936974865419">„Chrome“ sutaupė jums <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Visada leisti</translation>
-<translation id="6573431926118603307">Čia bus rodomi kituose įrenginiuose atidaryti „Chrome“ skirtukai.</translation>
-<translation id="6583199322650523874">Pažymėti dabartinį puslapį</translation>
-<translation id="6593061639179217415">Svetainė kompiuteriams</translation>
-<translation id="6600954340915313787">Nukopijuota į „Chrome“</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Apsaugotas turinys</translation>
-<translation id="6627583120233659107">Redaguoti aplanką</translation>
-<translation id="6643016212128521049">Išvalyti</translation>
-<translation id="6643649862576733715">Rūšiuoti pagal išsaugotų duomenų kiekį</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}few{<ph name="CONTACT_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}many{<ph name="CONTACT_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Peržiūrėti vaizdą <ph name="BEGIN_NEW" />Naujas<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">„Chrome“ reikalinga prieiga prie vietos, kad galėtų nuskaityti įrenginius. <ph name="BEGIN_LINK" />Atnaujinkite leidimus<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Slaptažodis</translation>
-<translation id="6659594942844771486">Skirtukas</translation>
-<translation id="666731172850799929">Atidaryti naudojant „<ph name="APP_NAME" />“</translation>
-<translation id="666981079809192359">„Chrome“ privatumo pranešimas</translation>
-<translation id="6676840375528380067">Išvalyti jūsų „Chrome“ duomenis iš šio įrenginio?</translation>
-<translation id="6697492270171225480">Rodyti panašių puslapių pasiūlymus, kai nepavyksta rasti puslapio</translation>
-<translation id="6697947395630195233">„Chrome“ reikia leidimo, kad galėtų naudoti jūsų vietovės informaciją ir bendrinti ją su šia svetaine.</translation>
-<translation id="6698801883190606802">Tvarkykite sinchronizuotus duomenis</translation>
-<translation id="6699370405921460408">„Google“ serveriai optimizuos puslapius, kuriuose lankotės.</translation>
-<translation id="6706288973712894588">Šiuo metu esate neprisijungę.\n<ph name="BEGIN_LINK" />Naršykite neprisijungus pasiekiamą sklaidos kanalą.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Naujienos</translation>
-<translation id="6710213216561001401">Ankstesnis</translation>
-<translation id="671481426037969117"><ph name="FQDN" /> laikmatis sustojo. Jis vėl bus paleistas rytoj.</translation>
-<translation id="6738867403308150051">Atsisiunčiama...</translation>
-<translation id="6746124502594467657">Perkelti žemyn</translation>
-<translation id="6766622839693428701">Perbraukite žemyn, kad uždarytumėte.</translation>
-<translation id="6766758767654711248">Palieskite, kad apsilankytumėte svetainėje</translation>
-<translation id="6767294960381293877">Įrenginių, su kuriais reikia bendrinti skirtuką, sąrašas atidarytas (pusė aukščio).</translation>
-<translation id="6782111308708962316">Neleisti trečiosios šalies svetainėms išsaugoti ir skaityti slapukų duomenų</translation>
-<translation id="6790428901817661496">Žaisti</translation>
-<translation id="6811034713472274749">Puslapis paruoštas peržiūrėti</translation>
-<translation id="6818926723028410516">Pasirinkite elementus</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Vertėjas</translation>
-<translation id="6845325883481699275">Padėkite tobulinti „Chrome“ saugą</translation>
-<translation id="6846298663435243399">Įkeliama…</translation>
-<translation id="6850409657436465440">Atsisiuntimas vis dar vykdomas</translation>
-<translation id="6850830437481525139">Uždaryta skirtukų lapų: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Atsisiųsti vaizdą</translation>
-<translation id="6865313869410766144">Automatinio pildymo formos duomenys</translation>
-<translation id="688738109438487280">Pridėti esamus duomenis prie <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Atrakinkite, kad galėtumėte kopijuoti slaptažodį</translation>
-<translation id="6896758677409633944">Kopijuoti</translation>
-<translation id="6910211073230771657">Ištrintas</translation>
-<translation id="6912998170423641340">Neleisti svetainėms skaityti teksto ir vaizdų iš iškarpinės</translation>
-<translation id="6914783257214138813">Jūsų slaptažodžiai bus matomi visiems, kurie gali peržiūrėti eksportuotą failą.</translation>
-<translation id="6942665639005891494">Numatytąją atsisiuntimo vietą galite bet kada pakeisti naudodami nustatymų meniu parinktį</translation>
-<translation id="6945221475159498467">Pasirinkti</translation>
-<translation id="6963642900430330478">Šis puslapis yra pavojingas. Svetainės informacija</translation>
-<translation id="6963766334940102469">Ištrinti žymes</translation>
-<translation id="6965382102122355670">Gerai</translation>
-<translation id="6979737339423435258">Visas laikotarpis</translation>
-<translation id="6981982820502123353">Pritaikymas neįgaliesiems</translation>
-<translation id="6989267951144302301">Nepavyko atsisiųsti</translation>
-<translation id="6990079615885386641">Gauti programą iš „Google Play“ parduotuvės: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Pirmiausia klausti prieš leidžiant svetainėms naudoti mikrofoną (rekomenduojama)</translation>
-<translation id="7015203776128479407">Pradinis sinchronizavimo nustatymas nebaigtas. Sinchronizavimas išjungtas.</translation>
-<translation id="7016516562562142042">Leidžiama dabartiniam paieškos varikliui</translation>
-<translation id="7022756207310403729">Atidaryti naršyklėje</translation>
-<translation id="702463548815491781">Rekomenduojama, kai įjungta „TalkBack“ arba prieiga jungikliu</translation>
-<translation id="7029809446516969842">Slaptažodžiai</translation>
-<translation id="7053983685419859001">Blokuoti</translation>
-<translation id="7055152154916055070">Peradresavimas užblokuotas:</translation>
-<translation id="7063006564040364415">Nepavyko prisijungti prie sinchronizavimo serverio.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Pasirinktas 1 elementas}one{Pasirinktas # elementas}few{Pasirinkti # elementai}many{Pasirinkta # elemento}other{Pasirinkta # elementų}}</translation>
-<translation id="7071521146534760487">Tvarkyti paskyrą</translation>
-<translation id="7077143737582773186">SD kortelė</translation>
-<translation id="7087918508125750058">Pasirinkta: <ph name="ITEM_COUNT" />. Parinktys pasiekiamos netoli ekrano viršaus</translation>
-<translation id="7121362699166175603">Išvaloma istorija ir automatiniai užbaigimai adreso juostoje. „Google“ paskyroje gali būti kito tipo naršymo istorijos, kuri pasiekiama adresu <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Leisti dabartiniam paieškos varikliui</translation>
-<translation id="7138678301420049075">Kitas</translation>
-<translation id="7141896414559753902">Blokuoti, kad svetainėse nebūtų rodomi iššokantieji langai ir peradresavimai (rekomenduojama)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Įkelti pradinį puslapį<ph name="END_LINK" /> iš <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Pastarosios 24 valandos</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Tai vėliau galėsite pakeisti „Nustatymų“ skiltyje</translation>
-<translation id="7180611975245234373">Atnaujinti</translation>
-<translation id="7189372733857464326">Laukiama, kol bus baigtas „Google Play“ paslaugų atnaujinimas</translation>
-<translation id="7191430249889272776">Skirtuko lapas atidarytas fone.</translation>
-<translation id="723171743924126238">Pasirinkti vaizdus</translation>
-<translation id="7233236755231902816">Jei norite matyti žiniatinklį savo kalba, gaukite naujausią „Chrome“ versiją</translation>
-<translation id="7243308994586599757">Parinktys pasiekiamos netoli ekrano apačios</translation>
-<translation id="7248069434667874558">Įsitikinkite, kad įrenginyje „<ph name="TARGET_DEVICE_NAME" />“ įjungtas sinchronizavimas sistemoje „Chrome“</translation>
-<translation id="7250468141469952378">Pasirinkta: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Užblokuota svetainė</translation>
-<translation id="7290209999329137901">Pavadinimo pakeisti nepavyko</translation>
-<translation id="7291387454912369099">„Assistant“ suaktyvin. mokėjimas</translation>
-<translation id="7293171162284876153">Norėdami pradėti sinchronizuoti, įjunkite parinktį „Chrome“ duomenų sinchronizavimas“.</translation>
-<translation id="729975465115245577">Įrenginyje nėra slaptažodžių failo saugojimo programos.</translation>
-<translation id="7302081693174882195">Išsami informacija: surūšiuota pagal išsaugotų duomenų kiekį</translation>
-<translation id="7328017930301109123">Kai įjungtas supaprastintasis režimas, sistemoje „Chrome“ puslapiai įkeliami sparčiau ir naudojama iki 60 proc. mažiau duomenų.</translation>
-<translation id="7333031090786104871">Vis dar pridedama ankstesnė svetainė</translation>
-<translation id="7352939065658542140">VAIZDO ĮRAŠAS</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Bendrinti 1 pasirinktą elementą}one{Bendrinti # pasirinktą elementą}few{Bendrinti # pasirinktus elementus}many{Bendrinti # pasirinkto elemento}other{Bendrinti # pasirinktų elementų}}</translation>
 <translation id="7359002509206457351">Prieiga prie mokėjimo metodų</translation>
+<translation id="8026334261755873520">Išvalyti naršymo duomenis</translation>
+<translation id="1291207594882862231">Išvalykite istoriją, slapukus, svetainės duomenis, talpyklą…</translation>
+<translation id="7814200940910057384">Išvalyti „Brave“ duomenys</translation>
+<translation id="1664855196866195614">Pasirinkti duomenys pašalinti iš „Brave“ ir sinchronizuojamų įrenginių.
+
+Adresu <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> gali būti pateikta kitų formų jūsų „Brave Software“ paskyros naršymo istorija, pvz., paieškos ir veikla kitose „Brave Software“ paslaugose.</translation>
+<translation id="4699172675775169585">Talpykloje esantys vaizdai ir failai</translation>
+<translation id="2496180316473517155">Naršymo istorija</translation>
+<translation id="2546283357679194313">Slapukai ir svetainės duomenys</translation>
+<translation id="8662811608048051533">Būsite atjungti nuo daugelio svetainių.</translation>
+<translation id="8218628800671693884">Būsite atjungti nuo daugelio svetainių. Nebūsite atjungti nuo „Brave Software“ paskyros.</translation>
+<translation id="2017836877785168846">Išvaloma istorija ir automatiniai užbaigimai adreso juostoje.</translation>
+<translation id="8096327394278038498">Išvaloma istorija ir automatiniai užbaigimai adreso juostoje. „Brave Software“ paskyroje gali būti kito tipo naršymo istorijos, kuri pasiekiama adresu <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Išvaloma visų įrenginių, prie kurių prisijungta, istorija. „Brave Software“ paskyroje gali būti kito tipo naršymo istorijos, kuri pasiekiama adresu <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Išsaugoti slaptažodžiai</translation>
+<translation id="6865313869410766144">Automatinio pildymo formos duomenys</translation>
+<translation id="7562080006725997899">Naršymo duomenų išvalymas</translation>
+<translation id="5487521232677179737">Išvalyti duomenis</translation>
+<translation id="7498271377022651285">Palaukite…</translation>
+<translation id="784934925303690534">Laikotarpis</translation>
+<translation id="1718835860248848330">Paskutinė valanda</translation>
+<translation id="7149893636342594995">Pastarosios 24 valandos</translation>
+<translation id="5648166631817621825">Pastarosios 7 dienos</translation>
+<translation id="8571213806525832805">Pastarosios 4 savaitės</translation>
+<translation id="5854790677617711513">Senesni nei 30 dienų</translation>
+<translation id="6979737339423435258">Visas laikotarpis</translation>
+<translation id="982182592107339124">Bus išvalyti visų svetainių duomenys, įskaitant:</translation>
+<translation id="6643016212128521049">Išvalyti</translation>
+<translation id="7641339528570811325">Valyti naršymo duomenis...</translation>
+<translation id="1670399744444387456">Bendrieji</translation>
+<translation id="3245261285041759672">„Brave Software“ paskyroje gali būti kito tipo naršymo istorijos, kuri pasiekiama adresu <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Užblokuota svetainė</translation>
+<translation id="2534155362429831547">Ištrinta elementų: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Naudojimo ir strigčių ataskaitos</translation>
+<translation id="9079153198295609735">Automatiškai siųsti naudojimo statistiką ir strigčių ataskaitas „Brave Software“</translation>
+<translation id="6981982820502123353">Pritaikymas neįgaliesiems</translation>
+<translation id="2387895666653383613">Teksto mastelio keitimas</translation>
+<translation id="2321958826496381788">Vilkite šliaužiklį, kol bus patogu skaityti šį tekstą. Du kartus palietus pastraipą, tekstas turėtų būti mažiausiai tokio dydžio.</translation>
+<translation id="3895926599014793903">Priverstinai įgalinti mastelio keitimą</translation>
+<translation id="5668404140385795438">Nepaisyti svetainės mastelio keitimo vengimo užklausos</translation>
+<translation id="4149994727733219643">Supaprastinta tinklalapių peržiūra</translation>
+<translation id="9100505651305367705">Siūlyti rodyti straipsnius supaprastintame rodinyje, kai palaikoma</translation>
+<translation id="1409426117486808224">Supaprastinta atidarytų skirtukų peržiūra</translation>
+<translation id="702463548815491781">Rekomenduojama, kai įjungta „TalkBack“ arba prieiga jungikliu</translation>
+<translation id="8284326494547611709">Subtitrai</translation>
+<translation id="4165986682804962316">Svetainės nustatymai</translation>
+<translation id="6295158916970320988">Visos svetainės</translation>
+<translation id="8380167699614421159">Šioje svetainėje rodomi nepageidaujami arba klaidinantys skelbimai</translation>
+<translation id="1919345977826869612">Skelbimai</translation>
+<translation id="410351446219883937">Automatinis paleidimas</translation>
+<translation id="6447842834002726250">Slapukai</translation>
+<translation id="6196640612572343990">Blokuoti trečiosios šalies slapukus</translation>
+<translation id="6782111308708962316">Neleisti trečiosios šalies svetainėms išsaugoti ir skaityti slapukų duomenų</translation>
+<translation id="7521387064766892559">„JavaScript“</translation>
+<translation id="4434045419905280838">Iššok. langai ir peradresavimai</translation>
+<translation id="4751476147751820511">Judesio arba šviesos jutikliai</translation>
+<translation id="1717218214683051432">Judesių jutikliai</translation>
+<translation id="2091887806945687916">Garsas</translation>
+<translation id="2586657967955657006">Iškarpinė</translation>
+<translation id="6320088164292336938">Vibruoti</translation>
+<translation id="4226663524361240545">Gavus pranešimą įrenginys gali vibruoti</translation>
+<translation id="1446450296470737166">Leisti visiškai valdyti MIDI įr.</translation>
+<translation id="3744111561329211289">Fono sinchronizavimas</translation>
+<translation id="5649053991847567735">Automatiškai atsisiųsti</translation>
+<translation id="6181444274883918285">Pridėti svetainės išimtį</translation>
+<translation id="5313967007315987356">Pridėti svetainę</translation>
+<translation id="1369915414381695676">Pridėta svetainė <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Leisti automatiškai paleisti nutildytus vaizdo įrašus konkrečioje svetainėje</translation>
+<translation id="2621115761605608342">Leisti „JavaScript“ konkrečioje svetainėje.</translation>
+<translation id="8801436777607969138">Blokuoti „JavaScript“ konkrečioje svetainėje.</translation>
+<translation id="8372893542064058268">Leisti fono sinchronizavimą konkrečioje svetainėje.</translation>
+<translation id="358794129225322306">Leisti svetainei automatiškai atsisiųsti kelis failus.</translation>
+<translation id="4008040567710660924">Leisti konkrečios svetainės slapukus.</translation>
+<translation id="8958424370300090006">Blokuoti konkrečios svetainės slapukus.</translation>
+<translation id="7882806643839505685">Konkrečios svetainės garso leidimas.</translation>
+<translation id="4468959413250150279">Konkrečios svetainės garso išjungimas.</translation>
+<translation id="1994173015038366702">Svetainės URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Naudojimas</translation>
+<translation id="5804241973901381774">Leidimai</translation>
+<translation id="4278390842282768270">Leidžiama</translation>
+<translation id="5677928146339483299">Užblokuoti</translation>
+<translation id="1984937141057606926">Leidžiama (išskyrus trečiąsias šalis)</translation>
+<translation id="7423098979219808738">Pirmiausia paklausti</translation>
+<translation id="8116925261070264013">Išjungta</translation>
+<translation id="8300705686683892304">Valdo programa</translation>
+<translation id="6192792657125177640">Išimtys</translation>
+<translation id="257931822824936280">Išskleista – spustelėkite, kad sutrauktumėte</translation>
+<translation id="5100237604440890931">Sutraukta – spustelėkite, kad išskleistumėte</translation>
+<translation id="857943718398505171">Leidžiama (rekomenduojama)</translation>
+<translation id="2913331724188855103">Leisti svetainėms išsaugoti ir nuskaityti slapukų duomenis (rekomenduojama)</translation>
+<translation id="7445411102860286510">Leisti svetainėms automatiškai leisti nutildytus vaizdo įrašus (rekomenduojama)</translation>
+<translation id="5335288049665977812">Leisti svetainėms paleisti „JavaScript“ (rekomenduojama)</translation>
+<translation id="5527111080432883924">Klausti, prieš leidžiant svetainėms skaityti tekstą ir vaizdus iš iškarpinės (rekomenduojama)</translation>
+<translation id="6912998170423641340">Neleisti svetainėms skaityti teksto ir vaizdų iš iškarpinės</translation>
+<translation id="7423538860840206698">Neleidžiama skaityti iškarpinės</translation>
+<translation id="3955193568934677022">Leisti svetainėms paleisti apsaugotą turinį (rekomenduojama)</translation>
+<translation id="445467742685312942">Leisti svetainėms leisti saugomą turinį</translation>
+<translation id="2107397443965016585">Paklausti prieš leidžiant svetainėms leisti saugomą turinį (rekomenduojama)</translation>
+<translation id="2910701580606108292">Paklausti prieš leidžiant svetainėms leisti saugomą turinį</translation>
+<translation id="757524316907819857">Užblokuoti svetaines, kad neleistų apsaugoto turinio</translation>
+<translation id="3277252321222022663">Leidžiama svetainėms pasiekti jutiklius (rekomenduojama)</translation>
+<translation id="5048398596102334565">Leidžiama svetainėms pasiekti judesio jutiklius (rekomenduojama)</translation>
+<translation id="8816026460808729765">Svetainės blokuojamos, kad nepasiektų jutiklių</translation>
+<translation id="169515064810179024">Svetainės užblokuotos, kad nepasiektų judesio jutiklių</translation>
+<translation id="1660204651932907780">Leisti svetainėms leisti garsą (rekomenduojama)</translation>
+<translation id="3600792891314830896">Nutildyti svetaines, kurios leidžia garsą</translation>
+<translation id="1743802530341753419">Paklausti prieš leidžiant svetainėms prisijungti prie įrenginio (rekomenduojama)</translation>
+<translation id="851751545965956758">Blokuoti svetaines, kad nebūtų galima prisijungti prie įrenginių</translation>
+<translation id="7141896414559753902">Blokuoti, kad svetainėse nebūtų rodomi iššokantieji langai ir peradresavimai (rekomenduojama)</translation>
+<translation id="5494752089476963479">Blokuoti skelbimus svetainėse, kuriose rodomi nepageidaujami arba klaidinantys skelbimai</translation>
+<translation id="3123473560110926937">Užblokuota kai kuriose svetainėse</translation>
+<translation id="965817943346481315">Blokuoti, jei svetainėje rodomi nepageidaujami arba klaidinantys skelbimai (rekomenduojama)</translation>
+<translation id="3386292677130313581">Klausti prieš leidžiant svetainėms žinoti vietą (rekomenduojama)</translation>
+<translation id="9139068048179869749">Klausti prieš leidžiant svetainėms siųsti pranešimus (rekomenduojama)</translation>
+<translation id="4479647676395637221">Pirmiausia klausti prieš leidžiant svetainėms naudoti kamerą (rekomenduojama)</translation>
+<translation id="6992289844737586249">Pirmiausia klausti prieš leidžiant svetainėms naudoti mikrofoną (rekomenduojama)</translation>
+<translation id="2289270750774289114">Paklausti, kai svetainė nori atrasti netoliese esančius „Bluetooth“ įrenginius (rekomenduojama)</translation>
+<translation id="7053983685419859001">Blokuoti</translation>
+<translation id="7128222689758636196">Leisti dabartiniam paieškos varikliui</translation>
+<translation id="7589445247086920869">Blokuoti dabartiniam paieškos varikliui</translation>
+<translation id="6388207532828177975">Išvalyti ir nustatyti iš naujo</translation>
+<translation id="7999064672810608036">Ar tikrai norite išvalyti visus šios svetainės vietinius duomenis, įskaitant slapukus, ir iš naujo nustatyti visus leidimus?</translation>
+<translation id="2822354292072154809">Ar tikrai norite iš naujo nustatyti visus „<ph name="CHOSEN_OBJECT_NAME"/>“ svetainės leidimus?</translation>
+<translation id="515227803646670480">Valyti išsaugotus duomenis</translation>
+<translation id="5902828464777634901">Visi šioje svetainėje saugomi vietiniai duomenys, įskaitant slapukus, bus ištrinti.</translation>
+<translation id="119944043368869598">Valyti viską</translation>
+<translation id="2490684707762498678">Tvarko „<ph name="APP_NAME"/>“</translation>
+<translation id="5516455585884385570">Atidaryti pranešimų nustatymus</translation>
+<translation id="1404122904123200417">Įterpta į <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Svetainių išsaugoti failai rodomi čia</translation>
+<translation id="4181841719683918333">Kalbos</translation>
+<translation id="2647434099613338025">Pridėti kalbą</translation>
+<translation id="1952172573699511566">Kai bus įmanoma, svetainėje tekstas bus rodomas pasirinkta kalba.</translation>
+<translation id="8559990750235505898">Siūlyti versti puslapius į kitas kalbas</translation>
+<translation id="4719927025381752090">Siūlyti versti</translation>
+<translation id="8156139159503939589">Kokiomis kalbomis skaitote?</translation>
+<translation id="5689516760719285838">Vieta</translation>
+<translation id="2440823041667407902">Prieiga prie vietovės</translation>
+<translation id="2023546461831060654">Įjunkite „Brave“ leidimus <ph name="BEGIN_LINK"/>„Android“ nustatymuose<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Įjunkite „Brave“ leidimą <ph name="BEGIN_LINK"/>„Android“ nustatymuose<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Norėdami leisti „Brave“ pasiekti jūsų vietovę, taip pat įjunkite ją <ph name="BEGIN_LINK"/>„Android“ nustatymuose<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Norėdami leisti „Brave“ pasiekti jūsų kamerą, taip pat įjunkite ją <ph name="BEGIN_LINK"/>„Android“ nustatymuose<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Norėdami leisti „Brave“ siųsti pranešimus, taip pat įjunkite juos <ph name="BEGIN_LINK"/>„Android“ nustatymuose<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Norėdami leisti „Brave“ pasiekti jūsų mikrofoną, taip pat įjunkite jį <ph name="BEGIN_LINK"/>„Android“ nustatymuose<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Vietos prieiga išjungta šiame įrenginyje. Įjunkite ją skiltyje <ph name="BEGIN_LINK"/>„Android“ nustatymai“<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Vietos prieiga taip pat išjungta šiame įrenginyje. Įjunkite ją skiltyje <ph name="BEGIN_LINK"/>„Android“ nustatymai“<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofonas</translation>
+<translation id="1647391597548383849">Prieiga prie fotoaparato</translation>
+<translation id="945632385593298557">Prieiga prie mikrofono</translation>
+<translation id="6612358246767739896">Apsaugotas turinys</translation>
+<translation id="885701979325669005">Saugykla</translation>
+<translation id="3198916472715691905">Išsaugota duomenų: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Anuliuoti įrenginio leidimą</translation>
+<translation id="4962975101802056554">Anuliuoti visus įrenginio leidimus</translation>
+<translation id="6545864417968258051">„Bluetooth“ nuskaitymas</translation>
+<translation id="4411535500181276704">Supaprastintasis režimas</translation>
+<translation id="7821588508402923572">Čia bus rodoma informacija apie sutaupytus duomenis</translation>
+<translation id="2131665479022868825">Išsaugota: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">nuo <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Kai įjungtas supaprastintasis režimas, sistemoje „Brave“ puslapiai įkeliami sparčiau ir naudojama iki 60 proc. mažiau duomenų.</translation>
+<translation id="6159335304067198720">Sutaupyta duomenų: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">sutaupyti duomenys</translation>
+<translation id="6111020039983847643">išnaudoti duomenys</translation>
+<translation id="7413229368719586778">Pradžios data: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Pabaigos data: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Rūšiuoti pagal svetainę</translation>
+<translation id="5864174910718532887">Išsami informacija: surūšiuota pagal svetainės pavadinimą</translation>
+<translation id="116280672541001035">Naudojama</translation>
+<translation id="8349013245300336738">Rūšiuoti pagal naudojamų duomenų kiekį</translation>
+<translation id="6378173571450987352">Išsami informacija: surūšiuota pagal naudojamų duomenų kiekį</translation>
+<translation id="2631006050119455616">Išsaugota</translation>
+<translation id="6643649862576733715">Rūšiuoti pagal išsaugotų duomenų kiekį</translation>
+<translation id="7302081693174882195">Išsami informacija: surūšiuota pagal išsaugotų duomenų kiekį</translation>
+<translation id="4179980317383591987">Naudojama <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Išsaugota <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Likusios svetainės (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Kitas</translation>
+<translation id="4913161338056004800">Iš naujo nustatyti statistiką</translation>
+<translation id="1856325424225101786">Nustatyti supaprastintąjį režimą iš naujo?</translation>
+<translation id="3658159451045945436">Nustačius iš naujo, bus ištrinta sutaupytų duomenų istorija, įskaitant aplankytų svetainių sąrašą.</translation>
+<translation id="3295530008794733555">Naršykite greičiau. Naudokite mažiau duomenų.</translation>
+<translation id="7340390500800578919">Kai įjungtas supaprastintasis režimas, „Brave“ sparčiau įkelia puslapius ir sunaudoja iki 60 proc. mažiau duomenų. „Brave“ siunčia žiniatinklio srauto duomenis sistemai „Brave Software“, kad optimizuotų puslapius, kuriuose lankotės. <ph name="BEGIN_LINK"/>Sužinokite daugiau<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Įjungti supaprastintąjį režimą</translation>
+<translation id="4493497663118223949">Supaprastintasis režimas įjungtas</translation>
+<translation id="7559975015014302720">Supaprastintasis režimas išjungtas</translation>
+<translation id="7606077192958116810">Supaprastintasis režimas nustatytas. Tvarkyti skiltyje „Nustatymai“.</translation>
+<translation id="4714588616299687897">Sutaupykite iki 60 proc. duomenų</translation>
+<translation id="1006927014032731288">„Brave Software“ serveriai optimizuos puslapius, kuriuose lankotės.</translation>
+<translation id="3257320067425202300">„Brave“ sutaupė jums <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">„Brave“ sutaupė jums <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Atsisiuntimo vieta</translation>
+<translation id="7077143737582773186">SD kortelė</translation>
+<translation id="7762668264895820836">SD kortelė Nr. <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Klausti, kur saugoti failus</translation>
+<translation id="6192333916571137726">Atsisiųsti failą</translation>
+<translation id="1672586136351118594">Daugiau neberodyti</translation>
+<translation id="2650751991977523696">Atsisiųsti failą dar kartą?</translation>
+<translation id="8664979001105139458">Failas pavadinimas jau yra</translation>
+<translation id="488187801263602086">Failo pervardijimas</translation>
+<translation id="5686790454216892815">Failo pavadinimas per ilgas</translation>
+<translation id="7454641608352164238">Nepakanka vietos</translation>
+<translation id="8972098258593396643">Atsisiųsti į numatytąjį aplanką?</translation>
+<translation id="804335162455518893">SD kortelė nerasta</translation>
+<translation id="7475688122056506577">SD kortelė nerasta. Gali trūkti kai kurių failų.</translation>
+<translation id="4198423547019359126">Nėra pasiekiamų atsisiuntimo vietų</translation>
+<translation id="8224471946457685718">Atsisiųsti jums skirtus straipsnius naudojant „Wi-Fi“</translation>
+<translation id="4970824347203572753">Nepasiekiama jūsų vietovėje</translation>
+<translation id="5500777121964041360">Gali būti nepasiekiama jūsų vietovėje</translation>
+<translation id="1173894706177603556">Pervadinti</translation>
+<translation id="1986685561493779662">Toks pavadinimas jau yra</translation>
+<translation id="6441734959916820584">Pavadinimas yra per ilgas</translation>
+<translation id="2923908459366352541">Netinkamas pavadinimas</translation>
+<translation id="7290209999329137901">Pavadinimo pakeisti nepavyko</translation>
+<translation id="3334729583274622784">Pakeisti failo plėtinį?</translation>
+<translation id="107147699690128016">Jei pakeisite failo plėtinį, failas gali būti atidaromas naudojant kitą programą ir galimai pakenkti įrenginiui.</translation>
+<translation id="8541922081612557424">Apie „Brave“</translation>
+<translation id="5311273890481188673">Autorių teisės „Brave Software LLC.“, <ph name="YEAR"/> m. Visos teisės saugomos.</translation>
+<translation id="1416550906796893042">Programos versija</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (atnaujinta <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operacinė sistema</translation>
+<translation id="3968054912784331254">„Brave“ naujiniai nebepalaikomi naudojant šios versijos „Android“.</translation>
+<translation id="7665369617277396874">Pridėti paskyrą</translation>
+<translation id="649070405679044769">Prisijungta prie „Brave Software“ kaip</translation>
+<translation id="6234515504547364178">Atsijungimas nuo „Brave“</translation>
+<translation id="5324858694974489420">Tėvų nustatymai</translation>
+<translation id="8920114477895755567">Laukiama išsamios tėvų informacijos.</translation>
+<translation id="5512137114520586844">Šią paskyrą tvarko <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Šią paskyrą tvarko <ph name="PARENT_NAME_1"/> ir <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Turinys</translation>
+<translation id="5403644198645076998">Leisti tik konkrečias svetaines</translation>
+<translation id="8641930654639604085">Bandyti užblokuoti suaugusiesiems skirtas svetaines</translation>
+<translation id="5639724618331995626">Leisti visas svetaines</translation>
+<translation id="796823723482603597">Teikia „Brave“</translation>
+<translation id="6324034347079777476">„Android“ sistemos sinchronizavimas išjungtas</translation>
+<translation id="5127805178023152808">Sinchronizavimas išjungtas</translation>
+<translation id="7015203776128479407">Pradinis sinchronizavimo nustatymas nebaigtas. Sinchronizavimas išjungtas.</translation>
+<translation id="2497852260688568942">Sinchronizavimą išjungė jūsų administratorius</translation>
+<translation id="9100610230175265781">Būtina slaptafrazė</translation>
+<translation id="6108923351542677676">Nustatoma…</translation>
+<translation id="4062305924942672200">Teisinė informacija</translation>
+<translation id="4256782883801055595">Atvirojo šaltinio licencijos</translation>
+<translation id="1138681184697033370">„Brave“ paslaugų teikimo sąlygos</translation>
+<translation id="7392539049993970338">„Brave“ privatumo pranešimas</translation>
+<translation id="2677748264148917807">Išeiti</translation>
+<translation id="5556459405103347317">Įkelti iš naujo</translation>
+<translation id="1623104350909869708">Neleisti šiam puslapiui kurti papildomų dialogo langų</translation>
+<translation id="2968755619301702150">Sertifikato peržiūros priemonė</translation>
+<translation id="1360432990279830238">Atsijungti ir išjungti sinchronizavimą?</translation>
+<translation id="8581481290581777242">Išvalyti jūsų „Brave“ duomenis iš šio įrenginio?</translation>
+<translation id="1318865768845061710">Su jūsų „Brave Software“ paskyra nebebus sinchronizuojamos žymės, istorija, slaptažodžiai ir kiti „Brave“ duomenys</translation>
+<translation id="3325020657155065477">Taip pat išvalyti jūsų „Brave“ duomenis iš šio įrenginio</translation>
+<translation id="6136448902816743006">Atsijungiate nuo paskyros, kurią valdo <ph name="DOMAIN_NAME"/>, todėl jūsų „Brave“ duomenys bus ištrinti iš šio įrenginio. Duomenys liks „Brave Software“ paskyroje.</translation>
+<translation id="1853026300647876496">Susisiekiama su „Brave Software“. Tai gali šiek tiek užtrukti…</translation>
+<translation id="2328985652426384049">Nepavyksta prisijungti</translation>
+<translation id="7723158744459952869">Per ilgai laukta „Brave Software“ atsako</translation>
+<translation id="4572422548854449519">Prisijungimas prie tvarkomos paskyros</translation>
+<translation id="2689656545739939160">Prisijungiate naudodami „<ph name="MANAGED_DOMAIN"/>“ tvarkomą paskyrą ir suteikiate jos administratoriui galimybę valdyti jūsų „Brave“ duomenis. Duomenys bus visam laikui susieti su šia paskyra. Atsijungę nuo „Brave“ ištrinsite duomenis iš šio įrenginio, bet jie ir toliau bus saugomi „Brave Software“ paskyroje.</translation>
+<translation id="1749561566933687563">Sinchronizuokite žymes</translation>
+<translation id="4242533952199664413">Atidaryti nustatymus</translation>
+<translation id="1111673857033749125">Čia bus rodomos kituose įrenginiuose išsaugotos žymės.</translation>
+<translation id="8636825310635137004">Jei norite pasiekti skirtukus iš kitų įrenginių, įjunkite sinchronizavimą.</translation>
+<translation id="3269956123044984603">Jei norite pasiekti skirtukus iš kitų įrenginių, „Android“ paskyros nustatymuose įjunkite parinktį „Automatiškai sinchronizuoti duomenis“.</translation>
+<translation id="5157964048453367290">Čia bus rodomi kituose įrenginiuose atidaryti „Brave“ skirtukai.</translation>
+<translation id="4684427112815847243">Viską sinchronizuoti</translation>
+<translation id="2709516037105925701">Automatinis pildymas</translation>
+<translation id="8820817407110198400">Žymės</translation>
+<translation id="1644574205037202324">Istorija</translation>
+<translation id="17513872634828108">Atidaryti skirtukai</translation>
+<translation id="1320169905922104972">„Brave Software Pay“ naudojamos kredito kortelės ir adresai</translation>
+<translation id="6337234675334993532">Šifruotė</translation>
+<translation id="6698801883190606802">Tvarkykite sinchronizuotus duomenis</translation>
+<translation id="3598578758776312506">Šifruoti slaptažodžius naudojant „Brave Software“ prisijungimo duomenis</translation>
+<translation id="7810580217418711046">Šifruoti sinchronizuotus duomenis nuo <ph name="TIME"/> taikant „Brave Software“ slaptažodį</translation>
+<translation id="8461694314515752532">Šifruokite sinchronizuojamus duomenis taikydami savo sinchronizavimo slaptafrazę</translation>
+<translation id="2996291259634659425">Kurkite slaptafrazę</translation>
+<translation id="5713644099811900409">„Brave Software“ paskyra</translation>
+<translation id="8997474919031554666">Slaptafrazės šifruotė neapima mokėjimo metodų ir adresų iš „Brave Software Pay“. Tik jūsų slaptafrazę žinantis asmuo gali skaityti šifruotus duomenis. Slaptafrazė nesiunčiama į sistemą „Brave Software“ ir joje nesaugoma. Pamiršę slaptafrazę arba norėdami pakeisti šį nustatymą turėsite iš naujo nustatyti sinchronizavimą. <ph name="BEGIN_LINK"/>Sužinokite daugiau<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Slaptafrazė</translation>
+<translation id="7772032839648071052">Patvirtinti slaptafrazę</translation>
+<translation id="5304593522240415983">Šis laukas negali būti tuščias</translation>
+<translation id="321773570071367578">Jei pamiršote slaptafrazę arba norite pakeisti šį nustatymą, <ph name="BEGIN_LINK"/>iš naujo nustatykite sinchronizavimą<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Slaptafrazės neatitinka</translation>
+<translation id="5149495116300586333">Slaptafrazės šifruotė neapima mokėjimo metodų ir adresų iš „Brave Software Pay“.
+
+Jei norite pakeisti šį nustatymą, <ph name="BEGIN_LINK"/>iš naujo nustatykite sinchronizavimą<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Neteisinga slaptafrazė</translation>
+<translation id="5414836363063783498">Patvirtinama…</translation>
+<translation id="6846298663435243399">Įkeliama…</translation>
+<translation id="5517095782334947753">Turite žymių, istorijos duomenų, slaptažodžių ir kitų nustatymų iš <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Sujungti duomenis</translation>
+<translation id="688738109438487280">Pridėti esamus duomenis prie <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Duomenis laikyti atskirai</translation>
+<translation id="1145536944570833626">Ištrinti esamus duomenis.</translation>
+<translation id="1993768208584545658">Svetainė <ph name="SITE"/> nori būti susieta su</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Gaukite pagalbos<ph name="END_LINK"/>, kol ieškoma įrenginių…</translation>
+<translation id="5817918615728894473">Susieti</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Gaukite pagalbos<ph name="END_LINK1"/> arba <ph name="BEGIN_LINK2"/>ieškokite iš naujo<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Nerasta jokių suderinamų įrenginių</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Įjunkite „Bluetooth“<ph name="END_LINK"/>, kad būtų leidžiama susieti</translation>
+<translation id="998321811308652668">„Brave“ nepavyksta įjungti „Bluetooth“ adapterio</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Gaukite pagalbos<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">„Brave“ reikalinga prieiga prie vietos, kad galėtų nuskaityti įrenginius. <ph name="BEGIN_LINK"/>Atnaujinkite leidimus<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">„Brave“ reikalinga prieiga prie informacijos apie vietovę, kad galėtų nuskaityti įrenginius. Galimybė pasiekti informaciją apie vietovę <ph name="BEGIN_LINK"/>išjungta šiame įrenginyje<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">„Brave“ reikalinga prieiga prie informacijos apie vietovę, kad galėtų nuskaityti įrenginius. <ph name="BEGIN_LINK1"/>Atnaujinkite leidimus<ph name="END_LINK1"/>. Be to, galimybė pasiekti informaciją apie vietovę <ph name="BEGIN_LINK2"/>išjungta šiame įrenginyje<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Prijungtas įrenginys</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signalo stiprumo lygis: # juosta}one{Signalo stiprumo lygis: # juosta}few{Signalo stiprumo lygis: # juostos}many{Signalo stiprumo lygis: # juostos}other{Signalo stiprumo lygis: # juostų}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> nori nuskaityti netoliese esančius „Bluetooth“ įrenginius. Rasti šie įrenginiai:</translation>
+<translation id="8368027906805972958">Nežinomas arba nepalaikomas įrenginys (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sinchronizavimas neveikia</translation>
+<translation id="1810845389119482123">Pradinė sinchronizavimo sąranka nebaigta</translation>
+<translation id="3235722914093408050">Atid. „Android“ nust. ir iš n. įgal. „Android“ sist., kad prad. „Brave“ sinchr.</translation>
+<translation id="3367813778245106622">Prisijunkite dar kartą, kad pradėtumėte sinchronizavimą</translation>
+<translation id="974555521953189084">Įveskite slaptafrazę, kad pradėtumėte sinchronizavimą</translation>
+<translation id="2997266899014181325">Norėdami pradėti sinchronizuoti, įjunkite parinktį „Brave“ duomenų sinchronizavimas“.</translation>
+<translation id="8260126382462817229">Bandykite prisijungti dar kartą</translation>
+<translation id="5919204609460789179">Atnaujinkite „<ph name="PRODUCT_NAME"/>“, kad galėtumėte pradėti sinchronizuoti</translation>
+<translation id="397583555483684758">Sinchronizavimas nebeveikia</translation>
+<translation id="1966710179511230534">Atnaujinkite išsamią prisijungimo informaciją.</translation>
+<translation id="7063006564040364415">Nepavyko prisijungti prie sinchronizavimo serverio.</translation>
+<translation id="7942131818088350342">„<ph name="PRODUCT_NAME"/>“ pasenęs.</translation>
+<translation id="4170011742729630528">Paslauga nepasiekiama; vėliau bandykite dar kartą.</translation>
+<translation id="7947953824732555851">Sutikti ir prisij.</translation>
+<translation id="8583805026567836021">Valomi paskyros duomenys</translation>
+<translation id="8310344678080805313">Įprasti skirtukai</translation>
+<translation id="5748802427693696783">Perjungta į įprastus skirtukus</translation>
+<translation id="7998918019931843664">Iš naujo atidarykite uždarytą skirtuko lapą</translation>
+<translation id="8853345339104747198">„<ph name="TAB_TITLE"/>“, skirtukas</translation>
+<translation id="4452411734226507615">Uždaryti skirtuką „<ph name="TAB_TITLE"/>“</translation>
+<translation id="7243308994586599757">Parinktys pasiekiamos netoli ekrano apačios</translation>
+<translation id="4060598801229743805">Parinktys pasiekiamos netoli ekrano viršaus</translation>
+<translation id="2810645512293415242">Supaprastintas puslapis, kad būtų galima saugoti duomenis ir greičiau įkelti.</translation>
+<translation id="3985215325736559418">Ar norite dar kartą atsisiųsti <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Ar norite vėl pradėti <ph name="FILE_NAME"/> atsisiuntimą?</translation>
+<translation id="7514365320538308">Atsisiųsti</translation>
+<translation id="545042621069398927">Paspartinamas atsisiuntimas.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Atsisiunčiamas failas.}one{Atsisiunčiamas # failas.}few{Atsisiunčiami # failai.}many{Atsisiunčiama # failo.}other{Atsisiunčiama # failų.}}</translation>
+<translation id="543509235395288790">Atsisiunčiami failai: <ph name="COUNT"/> (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Atsisiunčiamas failas (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Baigtas 1 atsisiuntimas.}one{Baigtas # atsisiuntimas.}few{Baigti # atsisiuntimai.}many{Baigta # atsisiuntimo.}other{Baigta # atsisiuntimų.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Nepavyko atlikti 1 atsisiuntimo.}one{Nepavyko atlikti # atsisiuntimo.}few{Nepavyko atlikti # atsisiuntimų.}many{Nepavyko atlikti # atsisiuntimo.}other{Nepavyko atlikti # atsisiuntimų.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Laukiama 1 atsisiuntimo.}one{Laukiama # atsisiuntimo.}few{Laukiama # atsisiuntimų.}many{Laukiama # atsisiuntimo.}other{Laukiama # atsisiuntimų.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> mygtukas</translation>
+<translation id="3205824638308738187">Beveik baigta!</translation>
+<translation id="3960299545138990065">Iš naujo paleiskite „Brave“</translation>
+<translation id="3771001275138982843">Nepavyko atsisiųsti naujinio</translation>
+<translation id="3888648114124182147">Atsisiunčiamas „Brave“ naujinys…</translation>
+<translation id="1705567146636171298">Atnaujinkite „Brave“</translation>
+<translation id="6195417478702700398">Kad būtų teikiamos geriausios naršymo funkcijos, atidarykite ir atnaujinkite „Brave“</translation>
+<translation id="3512968675351418494">Jei norite matyti žiniatinklį savo kalba, gaukite naujausią „Brave“ versiją</translation>
+<translation id="6427112570124116297">Žiniatinklio vertimas</translation>
+<translation id="1379423114029199501">Norėdami gauti naujausią versiją su įdiegta savo kalba, atnaujinkite „Brave“</translation>
+<translation id="5684874026226664614">Oi, nepavyko išversti šio puslapio.</translation>
+<translation id="6831043979455480757">Vertėjas</translation>
+<translation id="1285320974508926690">Niekada neversti šios svetainės</translation>
+<translation id="773466115871691567">Visada versti puslapius, parašytus <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Niekada neversti puslapių, parašytų <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Daugiau kalbų</translation>
+<translation id="290376772003165898">Puslapis parašytas ne <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Puslapiai, parašyti <ph name="SOURCE_LANGUAGE"/>, nuo dabar bus verčiami į <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Puslapiai, parašyti <ph name="LANGUAGE"/>, verčiami nebus</translation>
+<translation id="5447765697759493033">Ši svetainė nebus verčiama</translation>
+<translation id="4880127995492972015">Versti…</translation>
+<translation id="641643625718530986">Spausdinti…</translation>
+<translation id="8909135823018751308">Bendrinti…</translation>
+<translation id="4996978546172906250">Bendrinti per</translation>
+<translation id="6333140779060797560">Bendrinti per „<ph name="APPLICATION"/>“</translation>
+<translation id="6277522088822131679">Spausdinant puslapį kilo problema. Bandykite dar kartą.</translation>
+<translation id="3254409185687681395">Įtraukti šį puslapį į žymes</translation>
+<translation id="497421865427891073">Eiti pirmyn</translation>
+<translation id="813082847718468539">Žiūrėti svetainės informaciją</translation>
+<translation id="2532336938189706096">Žiniatinklio rodinys</translation>
+<translation id="6005538289190791541">Siūlomas slaptažodis</translation>
+<translation id="4634124774493850572">Naudoti slaptažodį</translation>
+<translation id="8285489906452138776">„Brave“ reikia leidimo, kad galėtų naudoti jūsų fotoaparatą šioje svetainėje.</translation>
+<translation id="320189792589364011">„Brave“ reikia leidimo, kad galėtų naudoti jūsų mikrofoną šioje svetainėje.</translation>
+<translation id="7988136689212463100">„Brave“ reikia leidimo, kad galėtų naudoti jūsų fotoaparatą ir mikrofoną šioje svetainėje.</translation>
+<translation id="4931190655840828017">„Brave“ reikia leidimo, kad galėtų naudoti jūsų vietovės informaciją ir bendrinti ją su šia svetaine.</translation>
+<translation id="3088191967551450609">„Brave“ reikia prieigos prie saugyklos failams atsisiųsti.</translation>
+<translation id="8942627711005830162">Atidaryti kitame lange</translation>
+<translation id="4195643157523330669">Atidaryti naujame skirtuke</translation>
+<translation id="1100066534610197918">Atidar. naujame grup. skirtuke</translation>
+<translation id="4860895144060829044">Skambinti</translation>
+<translation id="6896758677409633944">Kopijuoti</translation>
+<translation id="8393700583063109961">Siųsti pranešimą</translation>
+<translation id="3557336313807607643">Pridėti prie kontaktų</translation>
+<translation id="4269820728363426813">Kopijuoti nuorodos adresą</translation>
+<translation id="1206892813135768548">Kopijuoti nuorodos tekstą</translation>
+<translation id="1204037785786432551">Atsisiųsti nuorodą</translation>
+<translation id="6864459304226931083">Atsisiųsti vaizdą</translation>
+<translation id="8209050860603202033">Atidaryti vaizdą</translation>
+<translation id="8073388330009372546">Atid. vaizdą nauj. skirt. lap.</translation>
+<translation id="6649642165559792194">Peržiūrėti vaizdą <ph name="BEGIN_NEW"/>Naujas<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Įkelti vaizdą</translation>
+<translation id="3845332215609790146">Ieškoti su „Brave Software Lens“ <ph name="BEGIN_NEW"/>Nauja<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Ieškoti „<ph name="SEARCH_ENGINE"/>“ šio vaizdo</translation>
+<translation id="3384347053049321195">Bendrinti vaizdą</translation>
+<translation id="5833984609253377421">Bendrinti nuorodą</translation>
+<translation id="6475951671322991020">Atsisiųsti vaizdo įrašą</translation>
+<translation id="2317945146070194624">Atidaryti naujame „Brave“ skirtuke</translation>
+<translation id="7975379999046275268">Peržiūrėti puslapį <ph name="BEGIN_NEW"/>Naujas<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Puslapio atnaujinimas</translation>
+<translation id="36525718899759834">Gauti programą iš „Brave Software Play“ parduotuvės: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tamsi</translation>
+<translation id="1807246157184219062">Šviesi</translation>
+<translation id="4056223980640387499">Sepija</translation>
+<translation id="3927692899758076493">Be užraitų</translation>
+<translation id="5016205925109358554">Su užraitais</translation>
+<translation id="2593272815202181319">Lygiaplotis</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Kad perduotumėte, pasirinkite skirtuką</translation>
+<translation id="8719023831149562936">Negalima perduoti esamo skirtuko</translation>
+<translation id="2139186145475833000">Pridėti prie pagr. ekrano</translation>
+<translation id="4616150815774728855">Atidaryti „<ph name="WEBAPK_NAME"/>“</translation>
+<translation id="2122601567107267586">Nepavyko atidaryti programos</translation>
+<translation id="5129038482087801250">Įdiegti žiniatinklio progr.</translation>
+<translation id="3789841737615482174">Įdiegti</translation>
+<translation id="4665282149850138822">Svetainė „<ph name="NAME"/>“ pridėta prie pagrindinio ekrano</translation>
+<translation id="7333031090786104871">Vis dar pridedama ankstesnė svetainė</translation>
+<translation id="1036727731225946849">Pridedamas APK „<ph name="WEBAPK_NAME"/>“...</translation>
+<translation id="3778956594442850293">Pridėta prie pagrindinio ekrano</translation>
+<translation id="2146738493024040262">Atidaryti akimirksniu įkeliamą programėlę</translation>
+<translation id="7016516562562142042">Leidžiama dabartiniam paieškos varikliui</translation>
+<translation id="6177111841848151710">Užblokuota dabartiniam paieškos varikliui</translation>
+<translation id="145097072038377568">Išjungta „Android“ nustatymuose</translation>
+<translation id="8007176423574883786">Išjungta šiame įrenginyje</translation>
+<translation id="164269334534774161">Peržiūrite neprisijungus pasiekiamą šio puslapio kopiją (<ph name="CREATION_TIME"/>)</translation>
+<translation id="4594952190837476234">Šis neprisijungus naudojamas puslapis sukurtas <ph name="CREATION_TIME"/>, todėl gali skirtis nuo prisijungus pateiktos versijos.</translation>
+<translation id="8840953339110955557">Šis puslapis gali skirtis nuo prisijungus pateiktos versijos.</translation>
+<translation id="6405300764336705484">Šis turinys yra iš domeno <ph name="DOMAIN_NAME"/>, kurį teikia „Brave Software“.</translation>
+<translation id="1006017844123154345">Atidaryti prisijungus</translation>
+<translation id="3326636747541519688">Supaprastintasis puslapis, kurį teikia „Brave Software“</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Įkelti pradinį puslapį<ph name="END_LINK"/> iš <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Jei tai rodoma dažnai, peržiūrėkite šiuos <ph name="BEGIN_LINK"/>pasiūlymus<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Turinys paslėptas</translation>
+<translation id="3810973564298564668">Valdyti</translation>
+<translation id="5199929503336119739">Darbo profilis</translation>
+<translation id="528192093759286357">Vilkite žymeklį nuo viršaus ir palieskite mygtuką „Atgal“, kad išeitumėte iš viso ekrano režimo.</translation>
+<translation id="2836148919159985482">Palieskite mygtuką „Atgal“, kad išeitumėte iš viso ekrano režimo.</translation>
+<translation id="3967822245660637423">Atsisiuntimas baigtas</translation>
+<translation id="2434158240863470628">Atsisiųsta: <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Įvyko atsisiuntimo klaida</translation>
+<translation id="1384959399684842514">Atsisiuntimas pristabdytas</translation>
+<translation id="1671236975893690980">Laukiama atsisiuntimo...</translation>
+<translation id="5561549206367097665">Laukiama tinklo…</translation>
+<translation id="5864419784173784555">Laukiama kito atsisiuntimo…</translation>
+<translation id="6461962085415701688">Nepavyksta atidaryti failo</translation>
+<translation id="1178581264944972037">Pristabdyti</translation>
+<translation id="8200772114523450471">Atnaujinti</translation>
+<translation id="1409879593029778104">Neleidžiama atsisiųsti „<ph name="FILE_NAME"/>“, nes failas jau yra.</translation>
+<translation id="3387650086002190359">Nepavyko atsisiųsti „<ph name="FILE_NAME"/>“ dėl failų sistemos klaidų.</translation>
+<translation id="6482749332252372425">Nepavyko atsisiųsti „<ph name="FILE_NAME"/>“ dėl trūkstamos vietos saugykloje.</translation>
+<translation id="7619072057915878432">Nepavyko atsisiųsti „<ph name="FILE_NAME"/>“ dėl tinklo trikčių.</translation>
+<translation id="1477626028522505441">Nepavyko atsisiųsti „<ph name="FILE_NAME"/>“ dėl serverio problemų.</translation>
+<translation id="3692944402865947621">Nepavyko atsisiųsti „<ph name="FILE_NAME"/>“, nes saugyklos vieta nepasiekiama.</translation>
+<translation id="604996488070107836">Nepavyko atsisiųsti „<ph name="FILE_NAME"/>“ dėl nežinomos klaidos.</translation>
+<translation id="6738867403308150051">Atsisiunčiama...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> iš ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> iš <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Atsisiųsta <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Atsisiųsta <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Atsisiųsta <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Liko failų: 1</translation>
+<translation id="8186512483418048923">Liko failų: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Atsisiųstas <ph name="FILES_DOWNLOADED_ONE"/> failas}one{Atsisiųstas <ph name="FILES_DOWNLOADED_MANY"/> failas}few{Atsisiųsti <ph name="FILES_DOWNLOADED_MANY"/> failai}many{Atsisiųsta <ph name="FILES_DOWNLOADED_MANY"/> failo}other{Atsisiųsta <ph name="FILES_DOWNLOADED_MANY"/> failų}}</translation>
+<translation id="8037750541064988519">Liko <ph name="DAYS"/> d.</translation>
+<translation id="8190358571722158785">Liko 1 d.</translation>
+<translation id="60923314841986378">Liko <ph name="HOURS"/> val.</translation>
+<translation id="510275257476243843">Liko 1 val.</translation>
+<translation id="970715775301869095">Liko <ph name="MINUTES"/> min.</translation>
+<translation id="3236059992281584593">Liko 1 min.</translation>
+<translation id="2777555524387840389">Liko <ph name="SECONDS"/> sek.</translation>
+<translation id="2781151931089541271">Liko 1 sek.</translation>
+<translation id="3303414029551471755">Tęsti turinio atsisiuntimo procesą?</translation>
+<translation id="8617240290563765734">Atidaryti atsisiųstame turinyje nurodytą siūlomą URL?</translation>
+<translation id="1373696734384179344">Nepakanka atminties pasirinktam turiniui atsisiųsti.</translation>
+<translation id="5271967389191913893">Įrenginyje nepavyksta atidaryti norimo atsisiųsti turinio.</translation>
+<translation id="883806473910249246">Atsisiunčiant turinį įvyko klaida.</translation>
+<translation id="5626134646977739690">Pavadinimas:</translation>
+<translation id="7963646190083259054">Paslaugos teikėjas:</translation>
+<translation id="3414952576877147120">Dydis:</translation>
+<translation id="7375125077091615385">Tipas:</translation>
+<translation id="5765780083710877561">Aprašas:</translation>
+<translation id="4881695831933465202">Atidaryti</translation>
+<translation id="3542235761944717775">Pasiekiama <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747">Galima <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268">Pasiekiama: <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Naudojama <ph name="SPACE_USED"/> iš <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Visi</translation>
+<translation id="4988526792673242964">Psl.</translation>
+<translation id="3810838688059735925">Vaizdo</translation>
+<translation id="3616113530831147358">Garsas</translation>
+<translation id="9219103736887031265">Vaizdai</translation>
+<translation id="8250920743982581267">Dokumentai</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# failas}one{# failas}few{# failai}many{# failo}other{# failų}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# vaizdas}one{# vaizdas}few{# vaizdai}many{# vaizdo}other{# vaizdų}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vaizdo įrašas}one{# vaizdo įrašas}few{# vaizdo įrašai}many{# vaizdo įrašo}other{# vaizdo įrašų}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# garso įrašo failas}one{# garso įrašo failas}few{# garso įrašo failai}many{# garso įrašo failo}other{# garso įrašo failų}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# puslapis}one{# puslapis}few{# puslapiai}many{# puslapio}other{# puslapių}}</translation>
+<translation id="5456381639095306749">Atsisiųsti puslapį</translation>
+<translation id="2394602618534698961">Čia rodomi atsisiųsti failai</translation>
+<translation id="7810647596859435254">Atidaryti naudojant...</translation>
+<translation id="5655963694829536461">Ieškokite atsisiųstų elementų</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mano failai</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Čia rodomi straipsniai, kuriuos galima skaityti net neprisijungus</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# val.}one{# val.}few{# val.}many{# val.}other{# val.}}</translation>
+<translation id="5853623416121554550">pristabdyta</translation>
+<translation id="8965591936373831584">laukiama</translation>
+<translation id="2779651927720337254">nepavyko</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Ką tik</translation>
+<translation id="4000212216660919741">„Home“ neprisijungus</translation>
+<translation id="9133397713400217035">Naršyti neprisijungus</translation>
+<translation id="968900484120156207">Jūsų aplankomi puslapiai rodomi čia</translation>
+<translation id="7882131421121961860">Nerasta istorijos</translation>
+<translation id="3549657413697417275">Ieškokite savo istorijoje</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">MM</translation>
+<translation id="724102042129299115">„Brave“ pirmosios paleisties patirtis</translation>
+<translation id="2700285883409956633">Naudodami šią programą sutinkate su „Brave“ <ph name="BEGIN_LINK1"/>paslaugų teikimo sąlygomis<ph name="END_LINK1"/> ir <ph name="BEGIN_LINK2"/>privatumo pranešimo<ph name="END_LINK2"/> sąlygomis.</translation>
+<translation id="1640714894372474981">Naudodami šią programą sutinkate su „Brave“ <ph name="BEGIN_LINK1"/>paslaugų teikimo sąlygomis<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>privatumo pranešimu<ph name="END_LINK2"/> ir <ph name="BEGIN_LINK3"/>privatumo pranešimu, skirtu „Brave Software“ paskyroms, tvarkomoms naudojant „Family Link“<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Programa „<ph name="APP_NAME"/>“ bus atidaryta naršyklėje „Brave“. Tęsdami sutinkate su „Brave“ <ph name="BEGIN_LINK1"/>paslaugų teikimo sąlygomis<ph name="END_LINK1"/> ir <ph name="BEGIN_LINK2"/>privatumo pranešimu<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659">Programa „<ph name="APP_NAME"/>“ bus atidaryta naršyklėje „Brave“. Tęsdami sutinkate su „Brave“ <ph name="BEGIN_LINK1"/>paslaugų teikimo sąlygomis<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>privatumo pranešimu<ph name="END_LINK2"/> ir <ph name="BEGIN_LINK3"/>privatumo pranešimu, skirtu „Brave Software“ paskyroms, tvarkomoms naudojant „Family Link“<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Padėkite tobulinti „Brave“ siųsdami „Brave Software“ naudojimo statistiką ir strigčių ataskaitas.</translation>
+<translation id="3518985090088779359">Sutikti ir tęsti</translation>
+<translation id="7207456302801184289">Sveiki, tai „Brave“</translation>
+<translation id="704822250101715322">Laukiama, kol bus baigtas „Brave Software Play“ paslaugų atnaujinimas</translation>
+<translation id="1231733316453485619">Įjungti sinchronizavimą?</translation>
+<translation id="5132942445612118989">Sinchronizuokite slaptažodžius, istoriją ir daugiau visuose įrenginiuose</translation>
+<translation id="5736731321935944068">„Brave Software“ gali naudoti jūsų istoriją, kad suasmenintų Paiešką, skelbimus ir kitas „Brave Software“ paslaugas</translation>
+<translation id="4013614219085422040">„Brave Software“ gali naudoti jūsų istoriją, kad suasmenintų Paiešką ir kitas „Brave Software“ paslaugas</translation>
+<translation id="5581519193887989363">Bet kada galite pasirinkti, ką norite sinchronizuoti, skiltyje <ph name="BEGIN_LINK1"/>„Nustatymai“<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Taip, sutinku</translation>
+<translation id="2410754283952462441">Pasirinkite paskyrą</translation>
+<translation id="2227444325776770048">Tęsti kaip <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Ne <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Jei norite pasiekti žymes visuose įrenginiuose, įjunkite sinchronizavimą</translation>
+<translation id="2818669890320396765">Jei norite pasiekti žymes visuose įrenginiuose, prisijunkite ir įjunkite sinchronizavimą</translation>
+<translation id="6003646045106347985">Jei norite gauti „Brave Software“ siūlomo suasmeninto turinio, įjunkite sinchronizavimą</translation>
+<translation id="8494430740943879273">Jei norite gauti „Brave Software“ siūlomo suasmeninto turinio, prisijunkite ir įjunkite sinchronizavimą</translation>
+<translation id="5862731021271217234">Jei norite pasiekti skirtukus iš kitų įrenginių, įjunkite sinchronizavimą</translation>
+<translation id="3568688522516854065">Jei norite pasiekti skirtukus iš kitų įrenginių, prisijunkite ir įjunkite sinchronizavimą</translation>
+<translation id="1208340532756947324">Kad turinys būtų sinchronizuojamas visuose įrenginiuose, įjunkite sinchronizavimą</translation>
+<translation id="4472118726404937099">Jei norite sinchronizuoti ir suasmeninti turinį visuose įrenginiuose, prisijunkite ir įjunkite sinchronizavimą</translation>
+<translation id="2426805022920575512">Pasirinkti kitą paskyrą</translation>
+<translation id="6790428901817661496">Žaisti</translation>
+<translation id="1272079795634619415">Sustabdyti</translation>
+<translation id="2874939134665556319">Ankstesnis takelis</translation>
+<translation id="4046123991198612571">Kitas takelis</translation>
+<translation id="3859306556332390985">Eiti pirmyn</translation>
+<translation id="8441146129660941386">Ieškoti einant atgal</translation>
+<translation id="6706288973712894588">Šiuo metu esate neprisijungę.\n<ph name="BEGIN_LINK"/>Naršykite neprisijungus pasiekiamą sklaidos kanalą.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Naujausi skirtukai</translation>
+<translation id="8497726226069778601">Čia dar nėra nieko, ką galėtumėte peržiūrėti…</translation>
+<translation id="5423934151118863508">Puslapiai, kuriuose lankomasi dažniausiai, bus rodomi čia</translation>
+<translation id="6127379762771434464">Elementas pašalintas</translation>
+<translation id="4605958867780575332">Pašalintas elementas: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">„Brave Software“ papuoštas logotipas: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Kiti įrenginiai</translation>
+<translation id="4738836084190194332">Paskutinį kartą sinchronizuota: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Prieš 1 minutę}one{Prieš # minutę}few{Prieš # minutes}many{Prieš # minutės}other{Prieš # minučių}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Prieš 1 valandą}one{Prieš # valandą}few{Prieš # valandas}many{Prieš # valandos}other{Prieš # valandų}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Prieš # dieną}one{Prieš # dieną}few{Prieš # dienas}many{Prieš # dienos}other{Prieš # dienų}}</translation>
+<translation id="2762000892062317888">ką tik</translation>
+<translation id="1407135791313364759">Atidaryti viską</translation>
+<translation id="1209206284964581585">Slėpti dabar</translation>
+<translation id="129553762522093515">Neseniai uždarytas</translation>
+<translation id="8413126021676339697">Rodyti visą istoriją</translation>
+<translation id="7876243839304621966">Pašalinti viską</translation>
+<translation id="8487700953926739672">Pasiekiama neprisijungus</translation>
+<translation id="5224771365102442243">Su vaizdo įrašu</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Sužinokite daugiau<ph name="END_LINK"/> apie siūlomą turinį</translation>
+<translation id="7542481630195938534">Nepavyksta gauti pasiūlymų</translation>
+<translation id="5013696553129441713">Nėra jokių naujų pasiūlymų</translation>
+<translation id="1736419249208073774">Naršyti</translation>
+<translation id="7444811645081526538">Daugiau kategorijų</translation>
+<translation id="6709133671862442373">Naujienos</translation>
+<translation id="1264974993859112054">Sportas</translation>
+<translation id="9139318394846604261">Apsipirkimas</translation>
+<translation id="3912508018559818924">Ieškoma geriausio žiniatinklio turinio…</translation>
+<translation id="526421993248218238">Nepavyko įkelti šio puslapio</translation>
+<translation id="614940544461990577">Pabandykite atlikti toliau nurodytus veiksmus.</translation>
+<translation id="3288003805934695103">Iš naujo įkelti puslapį</translation>
+<translation id="2353636109065292463">Tikrinamas interneto ryšys</translation>
+<translation id="2858138569776157458">Popul. svet.</translation>
+<translation id="8364299278605033898">Žr. populiarias svetaines</translation>
+<translation id="1171770572613082465">Žr. populiarias svetaines palietę mygtuką „Populiariausios svetainės“</translation>
+<translation id="5233638681132016545">Naujas skirtukas</translation>
+<translation id="4521874409998847950">Nuo <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>pateikė „Brave Software“<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Pasiekiama naujesnė versija</translation>
+<translation id="4058091506841967397">Nepav. atnauj. „Brave“</translation>
+<translation id="6316139424528454185">„Android“ versija nepalaikoma</translation>
+<translation id="6989267951144302301">Nepavyko atsisiųsti</translation>
+<translation id="624789221780392884">Naujinys paruoštas</translation>
+<translation id="1549000191223877751">Perkelti į kitą langą</translation>
+<translation id="7481312909269577407">Persiųsti</translation>
+<translation id="4084682180776658562">Žymė</translation>
+<translation id="6437478888915024427">Puslapio informacija</translation>
+<translation id="7180611975245234373">Atnaujinti</translation>
+<translation id="4913169188695071480">Sustabdyti atnaujinimą</translation>
+<translation id="1829244130665387512">Surasti puslapyje</translation>
+<translation id="6593061639179217415">Svetainė kompiuteriams</translation>
+<translation id="9063523880881406963">Išjungti stalinio kompiuterio svetainės užklausą</translation>
+<translation id="2038563949887743358">Įjungti stalinio kompiuterio svetainės užklausą</translation>
+<translation id="2433507940547922241">Išvaizda</translation>
+<translation id="983192555821071799">Uždar. visų skirtukų lapus</translation>
+<translation id="1310482092992808703">Grupuoti skirtukus</translation>
+<translation id="7725024127233776428">Pažymėti puslapiai rodomi čia</translation>
+<translation id="4404568932422911380">Nėra jokių žymių</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> žymė}one{<ph name="BOOKMARKS_COUNT_MANY"/> žymė}few{<ph name="BOOKMARKS_COUNT_MANY"/> žymės}many{<ph name="BOOKMARKS_COUNT_MANY"/> žymės}other{<ph name="BOOKMARKS_COUNT_MANY"/> žymių}}</translation>
+<translation id="3739899004075612870">Pažymėta naršyklėje „<ph name="PRODUCT_NAME"/>“</translation>
+<translation id="3207960819495026254">Pažymėta</translation>
+<translation id="4452548195519783679">Sukurta „<ph name="FOLDER_NAME"/>“ žymė</translation>
+<translation id="8063895661287329888">Nepavyko pridėti žymės.</translation>
+<translation id="2842985007712546952">Viršaplankis</translation>
+<translation id="9065203028668620118">Redaguoti</translation>
+<translation id="4405224443901389797">Perkelti į…</translation>
+<translation id="5170568018924773124">Rodyti aplanke</translation>
+<translation id="8035133914807600019">Naujas aplankas…</translation>
+<translation id="4532845899244822526">Pasirinkti aplanką</translation>
+<translation id="6627583120233659107">Redaguoti aplanką</translation>
+<translation id="1197267115302279827">Perkelti žymes</translation>
+<translation id="6963766334940102469">Ištrinti žymes</translation>
+<translation id="4351244548802238354">Uždaryti dialogo langą</translation>
+<translation id="451872707440238414">Ieškoti žymėse</translation>
+<translation id="8901170036886848654">Žymių nerasta</translation>
+<translation id="6404511346730675251">Redaguoti žymę</translation>
+<translation id="3894427358181296146">Aplanko pridėjimas</translation>
+<translation id="5327248766486351172">Pavadinimas</translation>
+<translation id="7400418766976504921">URL adresas</translation>
+<translation id="3527085408025491307">Aplankas</translation>
+<translation id="5161254044473106830">Būtina nurodyti pavadinimą</translation>
+<translation id="2996809686854298943">Reikalingas URL</translation>
+<translation id="2536728043171574184">Žiūrima neprisijungus naudojama šio puslapio kopija</translation>
+<translation id="4698034686595694889">Žr. neprisijungus programoje „<ph name="APP_NAME"/>“</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ir daugiau svetainių</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{„Brave“ įkels puslapį, kai bus paruošta}one{„Brave“ įkels puslapius, kai bus paruošta}few{„Brave“ įkels puslapius, kai bus paruošta}many{„Brave“ įkels puslapius, kai bus paruošta}other{„Brave“ įkels puslapius, kai bus paruošta}}</translation>
+<translation id="6811034713472274749">Puslapis paruoštas peržiūrėti</translation>
+<translation id="4561979708150884304">Nėra ryšio</translation>
+<translation id="8274165955039650276">Peržiūrėti atsisiuntimus</translation>
+<translation id="2082238445998314030">Rezultatų: <ph name="RESULT_NUMBER"/> iš <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Rezultatų nėra</translation>
+<translation id="981121421437150478">Neprisijungus</translation>
+<translation id="3298243779924642547">Supapr.</translation>
+<translation id="393697183122708255">Neįgalinta paieška balsu</translation>
+<translation id="7191430249889272776">Skirtuko lapas atidarytas fone.</translation>
+<translation id="8445059357334030806">Atidaryti naudojant „Brave“</translation>
+<translation id="4720023427747327413">Atidaryti naudojant „<ph name="PRODUCT_NAME"/>“</translation>
+<translation id="7022756207310403729">Atidaryti naršyklėje</translation>
+<translation id="1113597929977215864">Rodyti supaprastintą rodinį</translation>
+<translation id="1513352483775369820">Žymių ir žiniatinklio istorija</translation>
+<translation id="4939482511480190003">Padėkite tobulinti „Brave“. <ph name="BEGIN_LINK"/>Dalyvaukite apklausoje<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Grįžti</translation>
+<translation id="5596627076506792578">Daugiau parinkčių</translation>
+<translation id="3522247891732774234">Pasiekiamas naujinys. Daugiau parinkčių</translation>
+<translation id="6773423637732432200">Nepavyksta atnaujinti „Brave“. Daugiau parinkčių.</translation>
+<translation id="3328801116991980348">Svetainės informacija</translation>
+<translation id="5391532827096253100">Ryšys su šia svetaine nėra saugus. Svetainės informacija</translation>
+<translation id="6206551242102657620">Ryšys yra saugus. Svetainės informacija</translation>
+<translation id="6963642900430330478">Šis puslapis yra pavojingas. Svetainės informacija</translation>
+<translation id="9070377983101773829">Pradėti paiešką balsu</translation>
+<translation id="8676374126336081632">Išvalyti įvestą tekstą</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> atidarytas skirtukas; palieskite, kad perjungtumėte skirtukus}one{<ph name="OPEN_TABS_MANY"/> atidarytas skirtukas; palieskite, kad perjungtumėte skirtukus}few{<ph name="OPEN_TABS_MANY"/> atidaryti skirtukai; palieskite, kad perjungtumėte skirtukus}many{<ph name="OPEN_TABS_MANY"/> atidaryto skirtuko; palieskite, kad perjungtumėte skirtukus}other{<ph name="OPEN_TABS_MANY"/> atidarytų skirtukų; palieskite, kad perjungtumėte skirtukus}}</translation>
+<translation id="2369533728426058518">atidaryti skirtukus</translation>
+<translation id="7071521146534760487">Tvarkyti paskyrą</translation>
+<translation id="932327136139879170">Kontaktinė namų informacija</translation>
+<translation id="2707726405694321444">Atnaujinti puslapį</translation>
+<translation id="2891154217021530873">Sustabdyti puslapio įkėlimą</translation>
+<translation id="6710213216561001401">Ankstesnis</translation>
+<translation id="6659594942844771486">Skirtukas</translation>
+<translation id="1933845786846280168">Pasirinktas skirtukas</translation>
+<translation id="2268044343513325586">Patikslinti</translation>
+<translation id="7846076177841592234">Atšaukti pasirinkimą</translation>
+<translation id="7087918508125750058">Pasirinkta: <ph name="ITEM_COUNT"/>. Parinktys pasiekiamos netoli ekrano viršaus</translation>
+<translation id="7250468141469952378">Pasirinkta: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Bendrinti 1 pasirinktą elementą}one{Bendrinti # pasirinktą elementą}few{Bendrinti # pasirinktus elementus}many{Bendrinti # pasirinkto elemento}other{Bendrinti # pasirinktų elementų}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Pašalinti 1 pasirinktą elementą}one{Pašalinti # pasirinktą elementą}few{Pašalinti # pasirinktus elementus}many{Pašalinti # pasirinkto elemento}other{Pašalinti # pasirinktų elementų}}</translation>
+<translation id="1283039547216852943">Palieskite ir išskleiskite</translation>
+<translation id="5962718611393537961">Palieskite ir sutraukite</translation>
+<translation id="8076492880354921740">Skirtukai</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Pasirinktas 1 elementas}one{Pasirinktas # elementas}few{Pasirinkti # elementai}many{Pasirinkta # elemento}other{Pasirinkta # elementų}}</translation>
+<translation id="6818926723028410516">Pasirinkite elementus</translation>
+<translation id="4797039098279997504">Palieskite, kad grįžtumėte į <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Palieskite, kad apsilankytumėte svetainėje</translation>
+<translation id="429312253194641664">Svetainėje leidžiama medija</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> bendrina jūsų ekrano vaizdą</translation>
+<translation id="8833831881926404480">Svetainė bendrina jūsų ekraną</translation>
+<translation id="9086455579313502267">Nepavyko pasiekti tinklo</translation>
+<translation id="938850635132480979">Klaida: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Atidaryti naudojant „<ph name="APP_NAME"/>“</translation>
+<translation id="548278423535722844">Atidaryti Žemėlapių programoje</translation>
+<translation id="7698359219371678927">Kurti el. laišką naudojant „<ph name="APP_NAME"/>“</translation>
+<translation id="7875915731392087153">Kurti el. laišką</translation>
+<translation id="5665379678064389456">Sukurti įvykį naudojant „<ph name="APP_NAME"/>“</translation>
+<translation id="2900528713135656174">Sukurti įvykį</translation>
+<translation id="2111511281910874386">Eiti į puslapį</translation>
+<translation id="3988466920954086464">Žiūrėkite tiesioginius paieškos rezultatus šiame skydelyje</translation>
+<translation id="2744248271121720757">Palieskite žodį ir ieškokite akimirksniu arba peržiūrėkite susijusius veiksmus</translation>
+<translation id="9155898266292537608">Taip pat galite ieškoti greitai paliesdami žodį</translation>
+<translation id="3232754137068452469">Žiniatinklio programa</translation>
+<translation id="1430915738399379752">Spausdinti</translation>
+<translation id="3775705724665058594">Išsiųsta į jūsų įrenginius</translation>
+<translation id="6364438453358674297">Pašalinti pasiūlymą iš istorijos?</translation>
+<translation id="213279576345780926">„<ph name="TAB_TITLE"/>“ uždaryta</translation>
+<translation id="6850830437481525139">Uždaryta skirtukų lapų: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Ištrinta „<ph name="ITEM_TITLE"/>“</translation>
+<translation id="4663756553811254707">Ištrinta žymių: <ph name="NUMBER_OF_BOOKMARKS"/></translation>
+<translation id="3819178904835489326">Ištrinta atsisiuntimų: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Nepalaikomas „Brave“ atvejų skaičius.</translation>
+<translation id="4259722352634471385">Naršymas užblokuotas: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Naršymas nepasiekiamas: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Uždaryti skirtuką</translation>
+<translation id="7772375229873196092">Uždaryti „<ph name="APP_NAME"/>“</translation>
+<translation id="1227058898775614466">Naršymo istorija</translation>
+<translation id="9169507124922466868">Naršymo istorija atidaryta puse aukščio</translation>
+<translation id="1327257854815634930">Naršymo istorija atidaryta</translation>
+<translation id="8788265440806329501">Naršymo istorija uždaryta</translation>
+<translation id="7482656565088326534">Peržiūros skirtukas</translation>
+<translation id="8427875596167638501">Peržiūros skirtukas atidarytas iki pusės ekrano</translation>
+<translation id="9102803872260866941">Peržiūros skirtukas atidarytas</translation>
+<translation id="2942036813789421260">Peržiūros skirtukas uždarytas</translation>
+<translation id="6355102470683871794">„Brave Software <ph name="APP_NAME"/>“ saugykla</translation>
+<translation id="3822502789641063741">Išvalyti svet. saugyklą?</translation>
+<translation id="9205995714227143200">Svetainės saugykla, kurios „Brave“ nelaiko svarbia (pvz., svetainės be išsaugotų nustatymų arba tos, kuriose retai lankotės)</translation>
+<translation id="3997476611815694295">Nesvarbi saugykla</translation>
+<translation id="8493948351860045254">Atlaisvinti vietos</translation>
+<translation id="2324920234469020158">Bus išvalyti slapukai, talpykla ir kiti svetainių duomenys, kurių „Brave“ nelaiko svarbiais.</translation>
+<translation id="5447201525962359567">Visa svetainės saugykla, įskaitant slapukus ir kitus vietoje saugomus duomenis</translation>
+<translation id="1376578503827013741">Apskaičiuojama...</translation>
+<translation id="583281660410589416">Nežinoma</translation>
+<translation id="2323763861024343754">Svetainės saugykla</translation>
+<translation id="3587672679800759167">Bendras „Brave“ naudojamų duomenų kiekis, įskaitant paskyras, žymes ir išsaugotus nustatymus</translation>
+<translation id="6545017243486555795">Išvalyti visus duomenis</translation>
+<translation id="4095146165863963773">Ištrinti programos duomenis?</translation>
+<translation id="53119194224775367">Visi „Brave“ duomenys bus ištrinti visam laikui. Tai apima visus failus, nustatymus, paskyras, duomenų bazes ir kt.</translation>
+<translation id="5307446750509046227">Išvalyti svetainės saug.</translation>
+<translation id="300526633675317032">Bus išvalyta visa <ph name="SIZE_IN_KB"/> svetainės saugykla.</translation>
+<translation id="8068648041423924542">Nepavyko pasirinkti sertifikato.</translation>
+<translation id="2315043854645842844">Kliento pasirinkto sertifikato nepalaiko operacinė sistema.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> nori prisijungti</translation>
+<translation id="5308380583665731573">Prisijungti</translation>
+<translation id="868929229000858085">Ieškokite savo kontaktuose</translation>
+<translation id="1919950603503897840">Kontaktų pasirinkimas</translation>
+<translation id="7986741934819883144">Pasirinkite kontaktą</translation>
+<translation id="3333961966071413176">Visi kontaktai</translation>
+<translation id="4994033804516042629">Kontaktų nerasta</translation>
+<translation id="5403592356182871684">Pavadinimai</translation>
+<translation id="2717722538473713889">El. pašto adresai</translation>
+<translation id="381841723434055211">Telefono numeriai</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(ir dar 1)}one{(ir dar #)}few{(ir dar #)}many{(ir dar #)}other{(ir dar #)}}</translation>
+<translation id="5197729504361054390">Pasirinkti kontaktai bus bendrinami su <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Vaizdų dekoderis</translation>
+<translation id="8067883171444229417">Leisti vaizdo įrašą</translation>
+<translation id="6560414384669816528">Atlikti paiešką naudojant „Sogou“</translation>
+<translation id="5406914950576900927">„Brave“ gali naudoti <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>, kai paieškos atliekamos Kinijoje. Šį nustatymą galite pakeisti skiltyje <ph name="BEGIN_LINK"/>„Nustatymai“<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Palikti „Brave Software“</translation>
+<translation id="4384468725000734951">Atliekant paiešką naudojama „Sogou“</translation>
+<translation id="6103327872225198548">Atliekant paiešką naudojama „Brave Software“</translation>
+<translation id="9133703968756164531">„<ph name="ITEM_NAME"/>“ (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Ši programa veikia naršyklėje „Brave“</translation>
+<translation id="6143689084714664628">Paleista naršyklėje „Brave“</translation>
+<translation id="7675869148432102528">„<ph name="APP_NAME"/>“ duomenų taip pat yra naršyklėje „Brave“</translation>
+<translation id="2734140769649165081">Duomenis galite išvalyti „Brave“ nustatymų“ skiltyje</translation>
+<translation id="8232956427053453090">Palikti duomenis</translation>
+<translation id="4298388696830689168">Susietos svetainės</translation>
+<translation id="5763514718066511291">Palieskite, jei norite nukopijuoti šios programos URL</translation>
+<translation id="6496823230996795692">Jei „<ph name="APP_NAME"/>“ norite naudoti pirmą kartą, prisijunkite prie interneto.</translation>
+<translation id="751961395872307827">Nepavyksta prisijungti prie svetainės</translation>
+<translation id="4878404682131129617">Nepavyko užmegzti tunelinio ryšio per tarpinį serverį</translation>
+<translation id="4749960740855309258">Atidaryti naują skirtuką</translation>
+<translation id="8788968922598763114">Iš naujo atidaryti paskutinį uždarytą skirtuką</translation>
+<translation id="7929962904089429003">Atidaryti meniu</translation>
+<translation id="6039379616847168523">Pereiti prie kito skirtuko</translation>
+<translation id="5210286577605176222">Pereiti prie ankstesnio skirtuko</translation>
+<translation id="124678866338384709">Uždaryti dabartinį skirtuką</translation>
+<translation id="3714981814255182093">Atidaryti radimo juostą</translation>
+<translation id="5441522332038954058">Pereiti prie adreso juostos</translation>
+<translation id="3398320232533725830">Atidaryti žymių tvarkytuvę</translation>
+<translation id="6583199322650523874">Pažymėti dabartinį puslapį</translation>
+<translation id="8489271220582375723">Atidaryti istorijos puslapį</translation>
+<translation id="4837753911714442426">Atidaryti puslapio spausdinimo parinktis</translation>
+<translation id="5726692708398506830">Padidinti visą puslapio turinį</translation>
+<translation id="3259831549858767975">Sumažinti visą puslapio turinį</translation>
+<translation id="8015452622527143194">Grąžinti numatytąjį puslapio turinio dydį</translation>
+<translation id="3443221991560634068">Iš naujo įkelti dabartinį puslapį</translation>
+<translation id="123724288017357924">Įk. šį puslapį iš naujo, nepais. talp. es. turinio</translation>
+<translation id="305870044889644984">Atidaryti „Brave“ pagalb. centrą naujame skirtuke</translation>
+<translation id="3166827708714933426">Skirtukų ir langų spartieji klavišai</translation>
+<translation id="3169981355900570544">„Brave Software Brave“ funkcijų spartieji klavišai</translation>
+<translation id="4558311620361989323">Tinklalapių spartieji klavišai</translation>
+<translation id="1908301351964700579">„Brave“ vis dar ruošiama naudoti įjungus VR. Vėliau iš naujo paleiskite „Brave“.</translation>
+<translation id="8970887620466824814">Kažkas ne taip.</translation>
+<translation id="1875543012935658554">Iš naujo atidarykite „Brave“.</translation>
+<translation id="79859296434321399">Norėdami peržiūrėti išplėstosios realybės turinį įdiekite „ARCore“</translation>
+<translation id="8558485628462305855">Norėdami peržiūrėti išplėstosios realybės turinį atnaujinkite „ARCore“</translation>
+<translation id="3513704683820682405">Išplėstoji realybė</translation>
+<translation id="5475862044948910901">Pradėti išplėstosios realybės seansą?</translation>
 <translation id="7365126855094612066">Vykstant šiam seansui svetainė galės:
 • kurti jūsų aplinkos 3D žemėlapį;
 • stebėti fotoaparato judesį.
 
 Svetainė NETURI prieigos prie fotoaparato. Fotoaparato vaizdai matomi tik jums.</translation>
-<translation id="7375125077091615385">Tipas:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL adresas</translation>
-<translation id="7403691278183511381">„Chrome“ pirmosios paleisties patirtis</translation>
-<translation id="741204030948306876">Taip, sutinku</translation>
-<translation id="7413229368719586778">Pradžios data: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Pirmiausia paklausti</translation>
-<translation id="7423538860840206698">Neleidžiama skaityti iškarpinės</translation>
-<translation id="7431991332293347422">Naršymo istorijos naudojimo paieškai ir kitoms funkcijoms suasmeninti valdymas</translation>
-<translation id="7437998757836447326">Atsijungimas nuo „Chrome“</translation>
-<translation id="7438641746574390233">Kai įjungtas supaprastintasis režimas, „Chrome“ naudoja „Google“ serverius, kad puslapiai būtų įkeliami greičiau. Kai įjungtas supaprastintasis režimas, itin lėti puslapiai perrašomi, kad būtų įkeliamas tik svarbiausias turinys. Supaprastintasis režimas netaikomas inkognito skirtukams.</translation>
-<translation id="7444811645081526538">Daugiau kategorijų</translation>
-<translation id="7445411102860286510">Leisti svetainėms automatiškai leisti nutildytus vaizdo įrašus (rekomenduojama)</translation>
-<translation id="7453467225369441013">Būsite atjungti nuo daugelio svetainių. Nebūsite atjungti nuo „Google“ paskyros.</translation>
-<translation id="7454641608352164238">Nepakanka vietos</translation>
-<translation id="7475192538862203634">Jei tai rodoma dažnai, peržiūrėkite šiuos <ph name="BEGIN_LINK" />pasiūlymus<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD kortelė nerasta. Gali trūkti kai kurių failų.</translation>
-<translation id="7479104141328977413">Skirtuko valdymas</translation>
-<translation id="7481312909269577407">Persiųsti</translation>
-<translation id="7482656565088326534">Peržiūros skirtukas</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (atnaujinta <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">sutaupyti duomenys</translation>
-<translation id="7498271377022651285">Palaukite…</translation>
-<translation id="7514365320538308">Atsisiųsti</translation>
-<translation id="751961395872307827">Nepavyksta prisijungti prie svetainės</translation>
-<translation id="7521387064766892559">„JavaScript“</translation>
-<translation id="7542481630195938534">Nepavyksta gauti pasiūlymų</translation>
-<translation id="7559975015014302720">Supaprastintasis režimas išjungtas</translation>
-<translation id="7562080006725997899">Naršymo duomenų išvalymas</translation>
-<translation id="756809126120519699">Išvalyti „Chrome“ duomenys</translation>
-<translation id="757524316907819857">Užblokuoti svetaines, kad neleistų apsaugoto turinio</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Atsisiųstas <ph name="FILES_DOWNLOADED_ONE" /> failas}one{Atsisiųstas <ph name="FILES_DOWNLOADED_MANY" /> failas}few{Atsisiųsti <ph name="FILES_DOWNLOADED_MANY" /> failai}many{Atsisiųsta <ph name="FILES_DOWNLOADED_MANY" /> failo}other{Atsisiųsta <ph name="FILES_DOWNLOADED_MANY" /> failų}}</translation>
-<translation id="7588219262685291874">Įjungti tamsiąją temą, kai įjungta įrenginio akumuliatoriaus tausojimo priemonė</translation>
-<translation id="7589445247086920869">Blokuoti dabartiniam paieškos varikliui</translation>
-<translation id="7593557518625677601">Atid. „Android“ nust. ir iš n. įgal. „Android“ sist., kad prad. „Chrome“ sinchr.</translation>
-<translation id="7596558890252710462">Operacinė sistema</translation>
-<translation id="7605594153474022051">Sinchronizavimas neveikia</translation>
-<translation id="7606077192958116810">Supaprastintasis režimas nustatytas. Tvarkyti skiltyje „Nustatymai“.</translation>
-<translation id="7612619742409846846">Prisijungta prie „Google“ kaip</translation>
-<translation id="7619072057915878432">Nepavyko atsisiųsti „<ph name="FILE_NAME" />“ dėl tinklo trikčių.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Gaukite pagalbos<ph name="END_LINK1" /> arba <ph name="BEGIN_LINK2" />ieškokite iš naujo<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Sveiki, tai „Chrome“</translation>
-<translation id="7638584964844754484">Neteisinga slaptafrazė</translation>
-<translation id="7641339528570811325">Valyti naršymo duomenis...</translation>
-<translation id="7648422057306047504">Šifruoti slaptažodžius naudojant „Google“ prisijungimo duomenis</translation>
-<translation id="7649070708921625228">Žinynas</translation>
-<translation id="7658239707568436148">Atšaukti</translation>
-<translation id="7665369617277396874">Pridėti paskyrą</translation>
-<translation id="766587987807204883">Čia rodomi straipsniai, kuriuos galima skaityti net neprisijungus</translation>
-<translation id="7682724950699840886">Išbandykite nurodytus patarimus: įsitikinkite, kad įrenginyje yra pakankamai vietos, ir bandykite eksportuoti dar kartą.</translation>
-<translation id="7685301384041462804">Prieš aktyvindami VR režimą, įsitikinkite, kad ši svetainė patikima.</translation>
-<translation id="7698359219371678927">Kurti el. laišką naudojant „<ph name="APP_NAME" />“</translation>
-<translation id="7704317875155739195">Automatiškai užbaigti paieškas ir URL</translation>
-<translation id="7725024127233776428">Pažymėti puslapiai rodomi čia</translation>
-<translation id="773466115871691567">Visada versti puslapius, parašytus <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Tam, kad būtų aptiktos pavojingos programos ir svetainės, „Chrome“ siunčia „Google“ kai kurių puslapių, kuriuose lankotės, URL, ribotą sistemos informaciją ir kai kurių puslapių turinį</translation>
-<translation id="7757787379047923882">Tekstas bendrinamas iš „<ph name="DEVICE_NAME" />“</translation>
-<translation id="7762668264895820836">SD kortelė Nr. <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Pridėti adresą</translation>
-<translation id="7772032839648071052">Patvirtinti slaptafrazę</translation>
-<translation id="7772375229873196092">Uždaryti „<ph name="APP_NAME" />“</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}few{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}many{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ir dar <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Vakar</translation>
-<translation id="7791543448312431591">Pridėti</translation>
-<translation id="780301667611848630">Ačiū, ne</translation>
-<translation id="7810647596859435254">Atidaryti naudojant...</translation>
-<translation id="7821588508402923572">Čia bus rodoma informacija apie sutaupytus duomenis</translation>
-<translation id="7837721118676387834">Leisti automatiškai paleisti nutildytus vaizdo įrašus konkrečioje svetainėje</translation>
-<translation id="7846076177841592234">Atšaukti pasirinkimą</translation>
-<translation id="784934925303690534">Laikotarpis</translation>
-<translation id="7851858861565204677">Kiti įrenginiai</translation>
-<translation id="7875915731392087153">Kurti el. laišką</translation>
-<translation id="7876243839304621966">Pašalinti viską</translation>
-<translation id="7882131421121961860">Nerasta istorijos</translation>
-<translation id="7882806643839505685">Konkrečios svetainės garso leidimas.</translation>
-<translation id="7886917304091689118">Paleista naršyklėje „Chrome“</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Atsisiunčiamas failas.}one{Atsisiunčiamas # failas.}few{Atsisiunčiami # failai.}many{Atsisiunčiama # failo.}other{Atsisiunčiama # failų.}}</translation>
-<translation id="7929962904089429003">Atidaryti meniu</translation>
-<translation id="7942131818088350342">„<ph name="PRODUCT_NAME" />“ pasenęs.</translation>
-<translation id="7947953824732555851">Sutikti ir prisij.</translation>
-<translation id="7963646190083259054">Paslaugos teikėjas:</translation>
-<translation id="7971136598759319605">Aktyvus prieš 1 d.</translation>
-<translation id="7975379999046275268">Peržiūrėti puslapį <ph name="BEGIN_NEW" />Naujas<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Iš anksto įkelti puslapius, kad naršymo ir paieškos procesai vyktų greičiau</translation>
-<translation id="79859296434321399">Norėdami peržiūrėti išplėstosios realybės turinį įdiekite „ARCore“</translation>
-<translation id="7986741934819883144">Pasirinkite kontaktą</translation>
-<translation id="7987073022710626672">„Chrome“ paslaugų teikimo sąlygos</translation>
-<translation id="7998918019931843664">Iš naujo atidarykite uždarytą skirtuko lapą</translation>
-<translation id="7999064672810608036">Ar tikrai norite išvalyti visus šios svetainės vietinius duomenis, įskaitant slapukus, ir iš naujo nustatyti visus leidimus?</translation>
-<translation id="8004582292198964060">Naršyklė</translation>
-<translation id="8007176423574883786">Išjungta šiame įrenginyje</translation>
-<translation id="8013372441983637696">Taip pat išvalyti jūsų „Chrome“ duomenis iš šio įrenginio</translation>
-<translation id="8015452622527143194">Grąžinti numatytąjį puslapio turinio dydį</translation>
-<translation id="802154636333426148">Įvyko atsisiuntimo klaida</translation>
-<translation id="8026334261755873520">Išvalyti naršymo duomenis</translation>
-<translation id="8035133914807600019">Naujas aplankas…</translation>
-<translation id="8037750541064988519">Liko <ph name="DAYS" /> d.</translation>
-<translation id="804335162455518893">SD kortelė nerasta</translation>
-<translation id="805047784848435650">Pagal naršymo istoriją</translation>
-<translation id="8051695050440594747">Galima <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">Atidaryti naujame „Chrome“ skirtuke</translation>
-<translation id="8063895661287329888">Nepavyko pridėti žymės.</translation>
-<translation id="806745655614357130">Duomenis laikyti atskirai</translation>
-<translation id="8067883171444229417">Leisti vaizdo įrašą</translation>
-<translation id="8068648041423924542">Nepavyko pasirinkti sertifikato.</translation>
-<translation id="8073388330009372546">Atid. vaizdą nauj. skirt. lap.</translation>
-<translation id="8076492880354921740">Skirtukai</translation>
-<translation id="8084114998886531721">Išsaugotas slaptažodis</translation>
-<translation id="8087000398470557479">Šis turinys yra iš domeno <ph name="DOMAIN_NAME" />, kurį teikia „Google“.</translation>
-<translation id="8103578431304235997">Inkognito skirtukas</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Jei norite pasiekti žymes visuose įrenginiuose, įjunkite sinchronizavimą</translation>
-<translation id="8110087112193408731">Rodyti „Chrome“ veiklą Skaitmeninės gerovės programoje?</translation>
-<translation id="8116925261070264013">Išjungta</translation>
-<translation id="813082847718468539">Žiūrėti svetainės informaciją</translation>
-<translation id="8131740175452115882">Patvirtinti</translation>
-<translation id="8156139159503939589">Kokiomis kalbomis skaitote?</translation>
-<translation id="8168435359814927499">Turinys</translation>
-<translation id="8186512483418048923">Liko failų: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Liko 1 d.</translation>
-<translation id="8200772114523450471">Atnaujinti</translation>
-<translation id="8209050860603202033">Atidaryti vaizdą</translation>
-<translation id="8218622182176210845">Paskyros tvarkymas</translation>
-<translation id="8224471946457685718">Atsisiųsti jums skirtus straipsnius naudojant „Wi-Fi“</translation>
-<translation id="8232956427053453090">Palikti duomenis</translation>
-<translation id="8249310407154411074">Perkelti į viršų</translation>
-<translation id="8250920743982581267">Dokumentai</translation>
-<translation id="825412236959742607">Šis puslapis naudoja per daug atminties, todėl „Chrome“ pašalino šiek tiek turinio.</translation>
-<translation id="8260126382462817229">Bandykite prisijungti dar kartą</translation>
-<translation id="8261506727792406068">Ištrinti</translation>
-<translation id="8266862848225348053">Atsisiuntimo vieta</translation>
-<translation id="8274165955039650276">Peržiūrėti atsisiuntimus</translation>
-<translation id="8284326494547611709">Subtitrai</translation>
-<translation id="8300705686683892304">Valdo programa</translation>
-<translation id="8310344678080805313">Įprasti skirtukai</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ir daugiau svetainių</translation>
-<translation id="8327155640814342956">Kad būtų teikiamos geriausios naršymo funkcijos, atidarykite ir atnaujinkite „Chrome“</translation>
-<translation id="8339163506404995330">Puslapiai, parašyti <ph name="LANGUAGE" />, verčiami nebus</translation>
-<translation id="8349013245300336738">Rūšiuoti pagal naudojamų duomenų kiekį</translation>
-<translation id="8364299278605033898">Žr. populiarias svetaines</translation>
-<translation id="8368027906805972958">Nežinomas arba nepalaikomas įrenginys (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Leisti fono sinchronizavimą konkrečioje svetainėje.</translation>
-<translation id="8378714024927312812">Tvarko jūsų organizacija</translation>
-<translation id="8380167699614421159">Šioje svetainėje rodomi nepageidaujami arba klaidinantys skelbimai</translation>
-<translation id="8393700583063109961">Siųsti pranešimą</translation>
-<translation id="8413126021676339697">Rodyti visą istoriją</translation>
-<translation id="8427875596167638501">Peržiūros skirtukas atidarytas iki pusės ekrano</translation>
-<translation id="8428213095426709021">Nustatymai</translation>
-<translation id="8438566539970814960">Tobulinti paieškas ir naršymą</translation>
-<translation id="8441146129660941386">Ieškoti einant atgal</translation>
-<translation id="8443209985646068659">Nepav. atnauj. „Chrome“</translation>
-<translation id="8445448999790540984">Nepavyksta eksportuoti slaptažodžių</translation>
-<translation id="8447861592752582886">Anuliuoti įrenginio leidimą</translation>
-<translation id="8461694314515752532">Šifruokite sinchronizuojamus duomenis taikydami savo sinchronizavimo slaptafrazę</translation>
-<translation id="8466613982764129868">Įsitikinkite, kad įrenginys „<ph name="TARGET_DEVICE_NAME" />“ prijungtas prie interneto</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Pasiekiama neprisijungus</translation>
-<translation id="8489271220582375723">Atidaryti istorijos puslapį</translation>
-<translation id="8493948351860045254">Atlaisvinti vietos</translation>
-<translation id="8497726226069778601">Čia dar nėra nieko, ką galėtumėte peržiūrėti…</translation>
-<translation id="8503559462189395349">„Chrome“ slaptažodžiai</translation>
-<translation id="8503813439785031346">Vartotojo vardas</translation>
-<translation id="8514477925623180633">Eksportuoti sistemoje „Chrome“ saugomus slaptažodžius</translation>
-<translation id="8514577642972634246">Įjungti inkognito režimą</translation>
-<translation id="851751545965956758">Blokuoti svetaines, kad nebūtų galima prisijungti prie įrenginių</translation>
-<translation id="8523928698583292556">Ištrinti išsaugotą slaptažodį</translation>
-<translation id="854522910157234410">Atidaryti šį puslapį</translation>
-<translation id="8558485628462305855">Norėdami peržiūrėti išplėstosios realybės turinį atnaujinkite „ARCore“</translation>
-<translation id="8559990750235505898">Siūlyti versti puslapius į kitas kalbas</translation>
-<translation id="8562452229998620586">Čia bus rodomi išsaugoti slaptažodžiai.</translation>
-<translation id="8569404424186215731">nuo <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Pastarosios 4 savaitės</translation>
-<translation id="857943718398505171">Leidžiama (rekomenduojama)</translation>
-<translation id="8583805026567836021">Valomi paskyros duomenys</translation>
-<translation id="860043288473659153">Kortelės savininko vardas</translation>
-<translation id="8609465669617005112">Perkelti į viršų</translation>
-<translation id="8616006591992756292">„Google“ paskyroje gali būti kito tipo naršymo istorijos, kuri pasiekiama adresu <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Atidaryti atsisiųstame turinyje nurodytą siūlomą URL?</translation>
-<translation id="8636825310635137004">Jei norite pasiekti skirtukus iš kitų įrenginių, įjunkite sinchronizavimą.</translation>
-<translation id="8641930654639604085">Bandyti užblokuoti suaugusiesiems skirtas svetaines</translation>
-<translation id="8655129584991699539">Duomenis galite išvalyti „Chrome“ nustatymų“ skiltyje</translation>
-<translation id="8662811608048051533">Būsite atjungti nuo daugelio svetainių.</translation>
-<translation id="8664979001105139458">Failas pavadinimas jau yra</translation>
-<translation id="8676374126336081632">Išvalyti įvestą tekstą</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signalo stiprumo lygis: # juosta}one{Signalo stiprumo lygis: # juosta}few{Signalo stiprumo lygis: # juostos}many{Signalo stiprumo lygis: # juostos}other{Signalo stiprumo lygis: # juostų}}</translation>
-<translation id="868929229000858085">Ieškokite savo kontaktuose</translation>
-<translation id="869891660844655955">Galiojimo data</translation>
-<translation id="8719023831149562936">Negalima perduoti esamo skirtuko</translation>
-<translation id="8725066075913043281">Bandyti dar kartą</translation>
-<translation id="8728487861892616501">Naudodami šią programą sutinkate su „Chrome“ <ph name="BEGIN_LINK1" />paslaugų teikimo sąlygomis<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />privatumo pranešimu<ph name="END_LINK2" /> ir <ph name="BEGIN_LINK3" />privatumo pranešimu, skirtu „Google“ paskyroms, tvarkomoms naudojant „Family Link“<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Atlikta</translation>
-<translation id="8748850008226585750">Turinys paslėptas</translation>
-<translation id="8751914237388039244">Pasirinkti vaizdą</translation>
-<translation id="8788265440806329501">Naršymo istorija uždaryta</translation>
-<translation id="8788968922598763114">Iš naujo atidaryti paskutinį uždarytą skirtuką</translation>
-<translation id="8801436777607969138">Blokuoti „JavaScript“ konkrečioje svetainėje.</translation>
-<translation id="8812260976093120287">Kai kuriose svetainėse galite mokėti naudodami įrenginyje įdiegtas anksčiau nurodytas palaikomas mokėjimo programas.</translation>
-<translation id="8816026460808729765">Svetainės blokuojamos, kad nepasiektų jutiklių</translation>
-<translation id="8816439037877937734">Programa „<ph name="APP_NAME" />“ bus atidaryta naršyklėje „Chrome“. Tęsdami sutinkate su „Chrome“ <ph name="BEGIN_LINK1" />paslaugų teikimo sąlygomis<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />privatumo pranešimu<ph name="END_LINK2" /> ir <ph name="BEGIN_LINK3" />privatumo pranešimu, skirtu „Google“ paskyroms, tvarkomoms naudojant „Family Link“<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Žymės</translation>
-<translation id="8833831881926404480">Svetainė bendrina jūsų ekraną</translation>
-<translation id="883806473910249246">Atsisiunčiant turinį įvyko klaida.</translation>
-<translation id="8840953339110955557">Šis puslapis gali skirtis nuo prisijungus pateiktos versijos.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">„<ph name="TAB_TITLE" />“, skirtukas</translation>
-<translation id="885701979325669005">Saugykla</translation>
-<translation id="889338405075704026">Eiti į „Chrome“ nustatymus</translation>
-<translation id="8901170036886848654">Žymių nerasta</translation>
-<translation id="8909135823018751308">Bendrinti…</translation>
-<translation id="8912362522468806198">„Google“ paskyra</translation>
-<translation id="8920114477895755567">Laukiama išsamios tėvų informacijos.</translation>
+<translation id="1188239144602654184">Įveskite AR</translation>
+<translation id="473775607612524610">Atnaujinti</translation>
+<translation id="3133489217401741157">Įdiegiamas „Brave“ skirtas modulis „<ph name="MODULE"/>“…</translation>
+<translation id="1791662854739702043">Įdiegta</translation>
+<translation id="5131234170665854056">Nepavyko įdiegti „Brave“ skirto modulio „<ph name="MODULE"/>“</translation>
+<translation id="2567385386134582609">VAIZDAS</translation>
+<translation id="6395288395575013217">NUORODA</translation>
+<translation id="7352939065658542140">VAIZDO ĮRAŠAS</translation>
+<translation id="4116038641877404294">Atsisiųskite puslapius, kad galėtumėte naudoti juos neprisijungę</translation>
 <translation id="8922289737868596582">Atsisiųskite puslapius spustelėję mygtuką „Daugiau parinkčių“, kad galėtumėte naudoti juos neprisijungę</translation>
-<translation id="8937772741022875483">Pašalinti „Chrome“ veiklą iš Skaitmeninės gerovės programos?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Atidaryti kitame lange</translation>
-<translation id="8951232171465285730">„Chrome“ sutaupė jums <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokuoti konkrečios svetainės slapukus.</translation>
-<translation id="8959122750345127698">Naršymas nepasiekiamas: <ph name="URL" /></translation>
-<translation id="8965591936373831584">laukiama</translation>
-<translation id="8970887620466824814">Kažkas ne taip.</translation>
-<translation id="8972098258593396643">Atsisiųsti į numatytąjį aplanką?</translation>
-<translation id="8986494364107987395">Automatiškai siųsti naudojimo statistiką ir strigčių ataskaitas „Google“</translation>
-<translation id="8993760627012879038">Atidaryti naują skirtuką inkognito režimu</translation>
-<translation id="8998729206196772491">Prisijungiate naudodami „<ph name="MANAGED_DOMAIN" />“ tvarkomą paskyrą ir suteikiate jos administratoriui galimybę valdyti jūsų „Chrome“ duomenis. Duomenys bus visam laikui susieti su šia paskyra. Atsijungę nuo „Chrome“ ištrinsite duomenis iš šio įrenginio, bet jie ir toliau bus saugomi „Google“ paskyroje.</translation>
-<translation id="9019902583201351841">Tvarko jūsų tėvai</translation>
-<translation id="9028914725102941583">Įjunkite sinchronizavimą, kad galėtumėte bendrinti turinį įrenginiuose</translation>
-<translation id="9029323097866369874">Leisti <ph name="DOMAIN" /> aktyvinti VR režimą?</translation>
-<translation id="9040142327097499898">Pranešimai leidžiami. Vieta išjungta šiame įrenginyje.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vaizdo įrašas}one{# vaizdo įrašas}few{# vaizdo įrašai}many{# vaizdo įrašo}other{# vaizdo įrašų}}</translation>
-<translation id="9050666287014529139">Slaptafrazė</translation>
-<translation id="9063523880881406963">Išjungti stalinio kompiuterio svetainės užklausą</translation>
-<translation id="9065203028668620118">Redaguoti</translation>
-<translation id="9070377983101773829">Pradėti paiešką balsu</translation>
-<translation id="9074336505530349563">Jei norite gauti „Google“ siūlomo suasmeninto turinio, prisijunkite ir įjunkite sinchronizavimą</translation>
-<translation id="9086455579313502267">Nepavyko pasiekti tinklo</translation>
-<translation id="9100505651305367705">Siūlyti rodyti straipsnius supaprastintame rodinyje, kai palaikoma</translation>
-<translation id="9100610230175265781">Būtina slaptafrazė</translation>
-<translation id="9102803872260866941">Peržiūros skirtukas atidarytas</translation>
+<translation id="5958275228015807058">Suraskite failus ir puslapius „Atsisiuntimų“ skiltyje</translation>
+<translation id="5620928963363755975">Suraskite failus ir puslapius „Atsisiuntimų“ skiltyje spustelėję mygtuką „Daugiau parinkčių“</translation>
+<translation id="3341058695485821946">Žr., kiek duomenų sutaupėte</translation>
+<translation id="3157842584138209013">Žr., kiek duomenų sutaupėte, spustelėję mygtuką „Daugiau parinkčių“</translation>
+<translation id="8218622182176210845">Paskyros tvarkymas</translation>
+<translation id="8090895580117672212">Jei norite tvarkyti „Brave Software“ paskyrą, palieskite mygtuką „Tvarkyti“</translation>
+<translation id="8856898588039823173">Supaprastintasis puslapis, kurį teikia „Brave Software“. Palieskite, kad būtų įkeltas pradinis puslapis.</translation>
+<translation id="8134317863207426198">Supaprastintasis puslapis, kurį teikia „Brave Software“. Palieskite mygtuką „Įkelti pradinį“, kad būtų įkeltas pradinis puslapis.</translation>
+<translation id="4961107849584082341">Išverskite šį puslapį į bet kokią kalbą</translation>
+<translation id="569536719314091526">Išverskite šį puslapį į bet kokią kalbą spustelėję mygtuką „Daugiau parinkčių“</translation>
+<translation id="1397811292916898096">Paieška su „<ph name="PRODUCT_NAME"/>“</translation>
+<translation id="1792959175193046959">Numatytąją atsisiuntimo vietą galite bet kada pakeisti</translation>
+<translation id="6942665639005891494">Numatytąją atsisiuntimo vietą galite bet kada pakeisti naudodami nustatymų meniu parinktį</translation>
+<translation id="6850409657436465440">Atsisiuntimas vis dar vykdomas</translation>
+<translation id="5817715962196959877">Dabar „Brave“ failus atsisiunčia greičiau</translation>
+<translation id="3976396876660209797">Pašalinkite šį spartųjį klavišą ir sukurkite jį iš naujo</translation>
+<translation id="6766622839693428701">Perbraukite žemyn, kad uždarytumėte.</translation>
+<translation id="1028699632127661925">Siunčiama į „<ph name="DEVICE_NAME"/>“...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – išsiųsta iš „<ph name="DEVICE_NAME"/>“</translation>
+<translation id="5357811892247919462">Skirtukas gautas</translation>
 <translation id="9104217018994036254">Įrenginių, su kuriais reikia bendrinti skirtuką, sąrašas.</translation>
-<translation id="9133397713400217035">Naršyti neprisijungus</translation>
-<translation id="9133703968756164531">„<ph name="ITEM_NAME" />“ (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Rodyti originalą</translation>
-<translation id="9139068048179869749">Klausti prieš leidžiant svetainėms siųsti pranešimus (rekomenduojama)</translation>
-<translation id="9139318394846604261">Apsipirkimas</translation>
-<translation id="9155898266292537608">Taip pat galite ieškoti greitai paliesdami žodį</translation>
-<translation id="9169507124922466868">Naršymo istorija atidaryta puse aukščio</translation>
-<translation id="9204836675896933765">Liko failų: 1</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Įrenginių, su kuriais reikia bendrinti skirtuką, sąrašas atidarytas (pusė aukščio).</translation>
+<translation id="2904414404539560095">Įrenginių, su kuriais reikia bendrinti skirtuką, sąrašas atidarytas (visas aukštis).</translation>
+<translation id="4135200667068010335">Įrenginių, su kuriais reikia bendrinti skirtuką, sąrašas uždarytas.</translation>
+<translation id="5292796745632149097">Siųsti į</translation>
+<translation id="1386674309198842382">Aktyvus prieš <ph name="LAST_UPDATED"/> d.</translation>
+<translation id="7971136598759319605">Aktyvus prieš 1 d.</translation>
+<translation id="1521774566618522728">Aktyvus šiandien</translation>
+<translation id="3631987586758005671">Bendrinama su „<ph name="DEVICE_NAME"/>“</translation>
+<translation id="9028914725102941583">Įjunkite sinchronizavimą, kad galėtumėte bendrinti turinį įrenginiuose</translation>
+<translation id="6162454065885854378">Norėdami bendrinti turinį iš savo telefono į kitą įrenginį, įjunkite sinchronizavimą abiejų įrenginių „Brave“ nustatymuose</translation>
+<translation id="6084271560289605378">Eiti į „Brave“ nustatymus</translation>
+<translation id="2318045970523081853">Palieskite ir skambinkite</translation>
 <translation id="9209888181064652401">Nepavyksta skambinti</translation>
-<translation id="9219103736887031265">Vaizdai</translation>
-<translation id="926205370408745186">„Chrome“ veiklos pašalinimas iš Skaitmeninės gerovės</translation>
-<translation id="932327136139879170">Kontaktinė namų informacija</translation>
-<translation id="938850635132480979">Klaida: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Prieiga prie mikrofono</translation>
-<translation id="95817756606698420">„Chrome“ gali naudoti <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />, kai paieškos atliekamos Kinijoje. Šį nustatymą galite pakeisti skiltyje <ph name="BEGIN_LINK" />„Nustatymai“<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokuoti, jei svetainėje rodomi nepageidaujami arba klaidinantys skelbimai (rekomenduojama)</translation>
-<translation id="968900484120156207">Jūsų aplankomi puslapiai rodomi čia</translation>
-<translation id="970715775301869095">Liko <ph name="MINUTES" /> min.</translation>
-<translation id="974555521953189084">Įveskite slaptafrazę, kad pradėtumėte sinchronizavimą</translation>
-<translation id="981121421437150478">Neprisijungus</translation>
-<translation id="982182592107339124">Bus išvalyti visų svetainių duomenys, įskaitant:</translation>
-<translation id="983192555821071799">Uždar. visų skirtukų lapus</translation>
-<translation id="987264212798334818">Bendra</translation>
+<translation id="2860954141821109167">Įsitikinkite, kad šiame įrenginyje įgalinta telefono programa</translation>
+<translation id="2067805253194386918">teksto pranešimas</translation>
+<translation id="1450753235335490080">Nepavyko bendrinti turinio: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Nepavyko bendrinti turinio: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Įsitikinkite, kad įrenginyje „<ph name="TARGET_DEVICE_NAME"/>“ įjungtas sinchronizavimas sistemoje „Brave“</translation>
+<translation id="3016635187733453316">Įsitikinkite, kad šis įrenginys prijungtas prie interneto</translation>
+<translation id="8466613982764129868">Įsitikinkite, kad įrenginys „<ph name="TARGET_DEVICE_NAME"/>“ prijungtas prie interneto</translation>
+<translation id="6539092367496845964">Įvyko klaida. Vėliau bandykite dar kartą.</translation>
+<translation id="3389286852084373014">Teksto pranešimas per didelis</translation>
+<translation id="2100314319871056947">Pabandykite bendrinti tekstą mažesnėmis dalimis</translation>
+<translation id="2987620471460279764">Tekstas, bendrinamas iš kito įrenginio</translation>
+<translation id="7757787379047923882">Tekstas bendrinamas iš „<ph name="DEVICE_NAME"/>“</translation>
+<translation id="5193988420012215838">Nukopijuota į iškarpinę</translation>
+<translation id="4696983787092045100">Siųsti teksto pranešimą savo įrenginiams</translation>
+<translation id="1260236875608242557">Paieška ir naršymas</translation>
+<translation id="6369229450655021117">Iš čia galite ieškoti žiniatinklyje, bendrinti su draugais ir peržiūrėti atidarytus puslapius</translation>
+<translation id="723171743924126238">Pasirinkti vaizdus</translation>
+<translation id="8751914237388039244">Pasirinkti vaizdą</translation>
+<translation id="1989112275319619282">Naršyti</translation>
+<translation id="7055152154916055070">Peradresavimas užblokuotas:</translation>
+<translation id="5524843473235508879">Peradresavimas užblokuotas.</translation>
+<translation id="6573096386450695060">Visada leisti</translation>
+<translation id="5805364706385912897">Šis puslapis naudoja per daug atminties, todėl „Brave“ jį pristabdė.</translation>
+<translation id="5138664332909611586">Šis puslapis naudoja per daug atminties, todėl „Brave“ pašalino šiek tiek turinio.</translation>
+<translation id="9137013805542155359">Rodyti originalą</translation>
+<translation id="6361779936989026201">„Brave Software Assistant“ sistemoje</translation>
+<translation id="7291387454912369099">„Assistant“ suaktyvin. mokėjimas</translation>
+<translation id="4565206163201411670">Rodyti „Brave“ veiklą Skaitmeninės gerovės programoje?</translation>
+<translation id="9055113864158719823">Galite peržiūrėti svetaines, kuriose lankotės naudodami „Brave“, ir nustatyti jų laikmačius.\n\n„Brave Software“ gauna informaciją apie svetaines, kurių laikmačius nustatote, ir apie apsilankymų jose trukmę. Ši informacija naudojama norint patobulinti Skaitmeninės gerovės funkcijas.</translation>
+<translation id="4596514158372210596">„Brave“ veiklos pašalinimas iš Skaitmeninės gerovės</translation>
+<translation id="1174893863889683998">Pašalinti „Brave“ veiklą iš Skaitmeninės gerovės programos?</translation>
+<translation id="708829030563435351">Svetainės, kuriose lankotės naudodami „Brave“, nebus rodomos. Visi svetainių laikmačiai bus ištrinti.</translation>
+<translation id="2056878612599315956">Svetainė pristabdyta</translation>
+<translation id="671481426037969117"><ph name="FQDN"/> laikmatis sustojo. Jis vėl bus paleistas rytoj.</translation>
+<translation id="7479104141328977413">Skirtuko valdymas</translation>
+<translation id="3524138585025253783">Kūrėjo NS</translation>
+<translation id="6036057147555329831">Papildomas ICU</translation>
+<translation id="9029323097866369874">Leisti <ph name="DOMAIN"/> aktyvinti VR režimą?</translation>
+<translation id="7685301384041462804">Prieš aktyvindami VR režimą, įsitikinkite, kad ši svetainė patikima.</translation>
+<translation id="5033865233969348410">VR režimu ši svetainė gali sužinoti apie jus tam tikros informacijos:
+  –  jūsų fizines savybes, pvz., ūgį.
+
+Prieš aktyvindami VR režimą įsitikinkite, kad ši svetainė patikima.</translation>
+<translation id="5534334044554683961">VR režimu ši svetainė gali sužinoti apie jus tam tikros informacijos:
+  –   jūsų fizines savybes, pvz., ūgį;
+  –   patalpos išdėstymą.
+
+Prieš aktyvindami VR, įsitikinkite, kad ši svetainė patikima.</translation>
+<translation id="4169535189173047238">Neleisti</translation>
+<translation id="2170088579611075216">Leisti ir įvesti VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_lv.xtb
+++ b/android/java/strings/translations/android_chrome_strings_lv.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="lv">
-<translation id="1006017844123154345">Atvērt tiešsaistē</translation>
-<translation id="1028699632127661925">Notiek sūtīšana uz: <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Tiek pievienots <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">No vietnēm</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Netiek saglabātas</translation>
-<translation id="1067922213147265141">Citi Google pakalpojumi</translation>
-<translation id="1068672505746868501">Nekad netulkot lapas šādā valodā: <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Ja mainīsiet faila paplašinājumu, fails var tikt atvērts citā lietojumprogrammā un potenciāli apdraudēt jūsu ierīci.</translation>
-<translation id="1100066534610197918">Atvērt jaunu cilni grupā</translation>
-<translation id="1105960400813249514">Ekrāna tveršana</translation>
-<translation id="1111673857033749125">Šeit būs redzamas grāmatzīmes, kuras esat saglabājis citās ierīcēs.</translation>
-<translation id="1113597929977215864">Rādīt vienkāršoto skatu</translation>
-<translation id="1121094540300013208">Lietojuma un avāriju pārskati</translation>
-<translation id="1124772482545689468">Lietotājs</translation>
-<translation id="1129510026454351943">Informācija: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 neapstiprināta lejupielāde.}zero{# neapstiprinātu lejupielāžu.}one{# neapstiprināta lejupielāde.}other{# neapstiprinātas lejupielādes.}}</translation>
-<translation id="1145536944570833626">Dzēst esošos datus.</translation>
-<translation id="1146678959555564648">Ieiet virtuālajā realitātē</translation>
-<translation id="116280672541001035">Izmantots</translation>
-<translation id="1171770572613082465">Lai skatītu populāras tīmekļa vietnes, pieskarieties pogai “Populāras”</translation>
-<translation id="1173894706177603556">Pārdēvēt</translation>
-<translation id="1178581264944972037">Pauzēt</translation>
-<translation id="1181037720776840403">Noņemt</translation>
-<translation id="1188239144602654184">Ievadīt PR</translation>
-<translation id="1197267115302279827">Pārvietot grāmatzīmes</translation>
-<translation id="119944043368869598">Notīrīt visu</translation>
-<translation id="1201402288615127009">Tālāk</translation>
-<translation id="1204037785786432551">Lejupielādēt saiti</translation>
-<translation id="1206892813135768548">Kopēt saites tekstu</translation>
-<translation id="1208340532756947324">Lai sinhronizētu un personalizētu saturu dažādās ierīcēs, ieslēdziet sinhronizāciju.</translation>
-<translation id="1209206284964581585">Pagaidām slēpt</translation>
-<translation id="1227058898775614466">Navigācijas vēsture</translation>
-<translation id="1231733316453485619">Vai ieslēgt sinhronizāciju?</translation>
-<translation id="123724288017357924">Atkārtoti ielādēt lapu, ignorējot saturu kešatmiņā</translation>
-<translation id="124116460088058876">Citas valodas…</translation>
-<translation id="124678866338384709">Aizvērt pašreizējo cilni</translation>
-<translation id="1258753120186372309">Google svētku logotips: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Meklēšana un izpēte</translation>
-<translation id="1264974993859112054">Sports</translation>
-<translation id="1266864766717917324">Nevarēja kopīgot: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Apturēt</translation>
-<translation id="1283039547216852943">Pieskarties, lai izvērstu</translation>
-<translation id="1285320974508926690">Nekad netulkot šo vietni</translation>
-<translation id="1291207594882862231">Dzēst vēsturi, sīkfailus, vietnes datus, kešatmiņu…</translation>
-<translation id="129382876167171263">Šeit tiek rādīti tīmekļa vietņu saglabātie faili</translation>
-<translation id="129553762522093515">Nesen aizvērtas</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> — nosūtīts no ierīces <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Grupēt cilnes</translation>
-<translation id="1327257854815634930">Navigācijas vēsture ir atvērta</translation>
-<translation id="1331212799747679585">Nevar atjaunināt Chrome — citas opcijas</translation>
-<translation id="1332501820983677155">Google Chrome funkciju īsinājumtaustiņi</translation>
-<translation id="1360432990279830238">Izrakstīties un izslēgt sinhronizēšanu?</translation>
-<translation id="1369915414381695676">Tika pievienota vietne <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Nepietiek vietas, lai lejupielādētu atlasīto saturu.</translation>
-<translation id="1376578503827013741">Notiek aprēķināšana...</translation>
-<translation id="1383876407941801731">Meklēt</translation>
-<translation id="1384959399684842514">Lejupielāde pārtraukta</translation>
-<translation id="1386674309198842382">Aktīvs pirms <ph name="LAST_UPDATED" /> dienām</translation>
-<translation id="1397811292916898096">Meklēt, izmantojot meklētājprogramu <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Iegults vietnē <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“Nesekot”</translation>
-<translation id="1407135791313364759">Atvērt visas</translation>
-<translation id="1409426117486808224">Vienkāršots atvērtu ciļņu skatījums</translation>
-<translation id="1409879593029778104">Fails <ph name="FILE_NAME" /> netika lejupielādēts, jo tas jau pastāv.</translation>
-<translation id="1414981605391750300">Notiek sazināšanās ar Google. Tas var ilgt kādu minūti...</translation>
-<translation id="1416550906796893042">Lietojumprogrammas versija</translation>
-<translation id="1430915738399379752">Drukāt</translation>
-<translation id="1446450296470737166">Pilnīga MIDI ierīču pārvaldība</translation>
-<translation id="1450753235335490080">Nevar kopīgot: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Izslēgts Android iestatījumos</translation>
-<translation id="1477626028522505441">Neizdevās lejupielādēt failu <ph name="FILE_NAME" />, jo radās servera problēmas.</translation>
-<translation id="1506061864768559482">Meklētājprogramma</translation>
-<translation id="1513352483775369820">Grāmatzīmes un tīmekļa vēsture</translation>
-<translation id="1513858653616922153">Dzēst paroli</translation>
-<translation id="1516229014686355813">Izmantojot funkciju “Pieskarties, lai meklētu”, atlasītais vārds tiek nosūtīts pakalpojumam Google meklēšana, pievienojot pašreiz skatīto lapu kā kontekstu. Varat to izslēgt lapā <ph name="BEGIN_LINK" />Iestatījumi<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktīvs šodien</translation>
-<translation id="1544826120773021464">Lai pārvaldītu savu Google kontu, pieskarieties pogai “Konta pārvaldība”</translation>
-<translation id="1549000191223877751">Pārvietot uz citu logu</translation>
-<translation id="1553358976309200471">Atjaunināt Chrome</translation>
-<translation id="1569387923882100876">Pievienota ierīce</translation>
-<translation id="1571304935088121812">Kopēt lietotājvārdu</translation>
-<translation id="1612196535745283361">Lai meklētu ierīces, pārlūkam Chrome ir nepieciešama piekļuve atrašanās vietas datiem. <ph name="BEGIN_LINK" />Šajā ierīcē ir izslēgta piekļuve atrašanās vietas datiem<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Neļaut šai lapai veidot papildu dialoglodziņus</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Noņemt 1 atlasīto vienumu}zero{Noņemt # atlasītos vienumus}one{Noņemt # atlasīto vienumu}other{Noņemt # atlasītos vienumus}}</translation>
-<translation id="164269334534774161">Jūs skatāt šīs lapas bezsaistes kopiju, kas tika izveidota šādā datumā: <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Vēsture</translation>
-<translation id="1647391597548383849">Piekļuve kamerai</translation>
-<translation id="1660204651932907780">Atļaut vietnēm atskaņot skaņu (ieteicams)</translation>
-<translation id="1670399744444387456">Pamata</translation>
-<translation id="1671236975893690980">Lejupielāde tiek gaidīta...</translation>
-<translation id="1672586136351118594">Vairs nerādīt</translation>
-<translation id="1692118695553449118">Sinhronizācija ieslēgta</translation>
-<translation id="169515064810179024">Bloķēt vietņu piekļuvi kustību sensoriem</translation>
-<translation id="1717218214683051432">Kustību sensori</translation>
-<translation id="1718835860248848330">Pēdējā stunda</translation>
-<translation id="1736419249208073774">Izpētīt</translation>
-<translation id="1743802530341753419">Jautāt, pirms atļaut vietnēm izveidot savienojumu ar ierīci (ieteicams)</translation>
-<translation id="1749561566933687563">Sinhronizējiet grāmatzīmes</translation>
-<translation id="17513872634828108">Atvērt cilnes</translation>
-<translation id="1779089405699405702">Attēlu dekodētājs</translation>
-<translation id="1782483593938241562">Beigu datums: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Instalēts</translation>
-<translation id="1792959175193046959">Noklusējuma lejupielādes vietu var mainīt jebkurā laikā.</translation>
-<translation id="1807246157184219062">Gaišs</translation>
-<translation id="1810845389119482123">Sākotnējā sinhronizācijas iestatīšana nav pabeigta</translation>
-<translation id="1821253160463689938">Izmanto sīkfailus, lai iegaumētu jūsu preferences, pat ja neapmeklējāt šīs lapas</translation>
-<translation id="1829244130665387512">Atrast lapā</translation>
-<translation id="1853692000353488670">Jauna inkognito cilne</translation>
-<translation id="1856325424225101786">Vai atiestatīt vienkāršoto režīmu?</translation>
-<translation id="1868024384445905608">Tagad pārlūkā Chrome faili tiek lejupielādēti ātrāk.</translation>
-<translation id="1883903952484604915">Mani faili</translation>
-<translation id="1887786770086287077">Piekļuve šīs ierīces atrašanās vietai ir izslēgta. Ieslēdziet to <ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Lietotne <ph name="APP_NAME" /> tiks atvērta pārlūkā Chrome. Turpinot jūs piekrītat Chrome <ph name="BEGIN_LINK1" />pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1" /> un <ph name="BEGIN_LINK2" />konfidencialitātes paziņojumam<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Reklāmas</translation>
-<translation id="1919950603503897840">Kontaktpersonu atlase</translation>
-<translation id="1922076542920281912">Lai atļautu pārlūkprogrammai Chrome piekļūt jūsu atrašanās vietas datiem, ieslēdziet atrašanās vietas noteikšanu arī <ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> no <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Atjaunināšana</translation>
-<translation id="19288952978244135">Atkārtoti atveriet pārlūku Chrome.</translation>
-<translation id="1933845786846280168">Atlasītā cilne</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" /> ieslēdziet atļauju pārlūkam Chrome.</translation>
-<translation id="1943432128510653496">Paroļu saglabāšana</translation>
-<translation id="1952172573699511566">Kad vien iespējams, vietnēs tiks rādīts teksts atlasītajā valodā.</translation>
-<translation id="1960290143419248813">Chrome atjauninājumi vairs netiek atbalstīti šajā Android versijā</translation>
-<translation id="1966710179511230534">Lūdzu, atjauniniet pierakstīšanās informāciju.</translation>
-<translation id="1974060860693918893">Papildu</translation>
-<translation id="1984705450038014246">Jūsu Chrome datu sinhronizācija</translation>
-<translation id="1984937141057606926">Atļauti, izņemot trešo pušu sīkfailus</translation>
-<translation id="1986685561493779662">Nosaukums jau pastāv</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> poga</translation>
-<translation id="1989112275319619282">Pārlūkot</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> vēlas savienot pārī</translation>
-<translation id="1994173015038366702">Vietnes URL</translation>
-<translation id="2000419248597011803">Nosūta dažus sīkfailus un meklēšanas vaicājumus no adreses joslas un meklēšanas lodziņa uz jūsu noklusējuma meklētājprogrammu.</translation>
-<translation id="2002537628803770967">Kredītkartes un adreses no pakalpojuma Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fails}zero{# faili}one{# fails}other{# faili}}</translation>
-<translation id="2017836877785168846">Notīra vēsturi un automātiskās pabeigšanas ierakstus adreses joslā.</translation>
-<translation id="2021896219286479412">Pilnekrāna vietnes vadīklas</translation>
-<translation id="2038563949887743358">Ieslēgt iestatījumu “Pieprasīt datora vietni”</translation>
-<translation id="2041019821020695769">Lai atļautu pārlūkprogrammai Chrome sūtīt jums paziņojumus, ieslēdziet paziņojumus arī <ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Pārlūkā Chrome ir arī “<ph name="APP_NAME" />” dati</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Vietne apturēta</translation>
-<translation id="2063713494490388661">Pieskarties, lai meklētu</translation>
-<translation id="2067805253194386918">teksts</translation>
-<translation id="2079545284768500474">Atsaukt</translation>
-<translation id="2082238445998314030"><ph name="RESULT_NUMBER" />. rezultāts no <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Signāls</translation>
-<translation id="2096012225669085171">Sinhronizējiet un personalizējiet vairākās ierīcēs</translation>
-<translation id="2100273922101894616">Automātiski pierakstīties</translation>
-<translation id="2100314319871056947">Kopīgojiet mazākus teksta fragmentus</translation>
-<translation id="2107397443965016585">Vaicāt, pirms atļaut vietnēm atskaņot aizsargātu saturu (ieteicams)</translation>
-<translation id="2111511281910874386">Doties uz lapu</translation>
-<translation id="2122601567107267586">Nevarēja atvērt lietotni</translation>
-<translation id="2126426811489709554">Nodrošina Chrome</translation>
-<translation id="2131665479022868825">Ietaupījums: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Tika aizvērta cilne <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Pievienot sākuma ekrānam</translation>
-<translation id="2146738493024040262">Atvērt tūlītējo lietotni</translation>
-<translation id="2148716181193084225">Šodien</translation>
-<translation id="2154484045852737596">Kartes informācijas rediģēšana</translation>
-<translation id="2154710561487035718">Kopēt URL</translation>
-<translation id="2156074688469523661">Pārējās vietnes (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Lai kopīgotu sava tālruņa saturu ar citu ierīci, ieslēdziet sinhronizāciju abu ierīču Chrome iestatījumos.</translation>
-<translation id="2170088579611075216">Atļaut un ieiet virtuālajā realitātē</translation>
-<translation id="218608176142494674">Kopīgošana</translation>
-<translation id="2227444325776770048">Turpināt kā: <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sinhronizēšana un Google pakalp.</translation>
-<translation id="2259659629660284697">Paroļu eksportēšana…</translation>
-<translation id="2268044343513325586">Uzlabot</translation>
-<translation id="2286841657746966508">Norēķinu adrese</translation>
-<translation id="2289270750774289114">Vaicāt, ja vietne vēlas redzēt tuvumā esošās Bluetooth ierīces (ieteicams)</translation>
-<translation id="230115972905494466">Netika atrastas saderīgas ierīces.</translation>
-<translation id="2315043854645842844">Operētājsistēma neatbalsta klienta puses sertifikāta atlasi.</translation>
-<translation id="2318045970523081853">Pieskarieties, lai zvanītu</translation>
-<translation id="2321086116217818302">Notiek paroļu sagatavošana…</translation>
-<translation id="2321958826496381788">Velciet slīdni, kamēr varat ērti lasīt. Pēc dubultskāriena rindkopai tekstam ir jābūt vismaz šādā lielumā.</translation>
-<translation id="2323763861024343754">Vietnes krātuve</translation>
-<translation id="2328985652426384049">Nevar pierakstīties</translation>
-<translation id="2330129964253841015">Brīdināt, ja paroles tiek apdraudētas</translation>
-<translation id="2349710944427398404">Kopējais pārlūkā Chrome izmantoto datu apjoms, ieskaitot kontus, grāmatzīmes un saglabātos iestatījumus</translation>
-<translation id="2353636109065292463">Notiek interneta savienojuma pārbaude</translation>
-<translation id="2359808026110333948">Turpināt</translation>
-<translation id="2369533728426058518">atvērt cilnes</translation>
-<translation id="2387895666653383613">Teksta mērogošana</translation>
-<translation id="2394602618534698961">Šeit tiek rādīti jūsu lejupielādētie faili</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Kad pierakstāties savā Google kontā, šī funkcija ir ieslēgta.</translation>
-<translation id="2410754283952462441">Konta izvēle</translation>
-<translation id="2414886740292270097">Tumšs</translation>
-<translation id="2416359993254398973">Pārlūkam Chrome ir nepieciešama atļauja piekļūt jūsu kamerai šajā vietnē.</translation>
-<translation id="2426805022920575512">Izvēlēties citu kontu</translation>
-<translation id="2433507940547922241">Izskats</translation>
-<translation id="2434158240863470628">Lejupielāde pabeigta: <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Piekļuve atrašanās vietai</translation>
-<translation id="2450083983707403292">Vai vēlaties vēlreiz sākt faila <ph name="FILE_NAME" /> lejupielādi?</translation>
-<translation id="2482878487686419369">Paziņojumi</translation>
-<translation id="2490684707762498678">Pārvalda <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google asistents pārlūkprogrammā Chrome</translation>
-<translation id="2496180316473517155">Pārlūkošanas vēsture</translation>
-<translation id="2497852260688568942">Administrators ir atspējojis sinhronizēšanu.</translation>
-<translation id="2498359688066513246">Palīdzība un atsauksmes</translation>
-<translation id="2501278716633472235">Doties atpakaļ</translation>
-<translation id="2513403576141822879">Papildu iestatījumus, kas attiecas uz konfidencialitāti, drošību un datu apkopošanu, skatiet lapā <ph name="BEGIN_LINK" />Sinhronizēšana un Google pakalpojumi<ph name="END_LINK" />.</translation>
-<translation id="2518590038762162553">Pārlūka Chrome vienkāršotajā režīmā lapas tiek ielādētas ātrāk un tiek patērēts pat par 60 procentiem mazāk datu. Lai optimizētu jūsu apmeklētās lapas, no pārlūka Chrome tiek nosūtīta jūsu tīmekļa datplūsma uzņēmumam Google. <ph name="BEGIN_LINK" />Uzziniet vairāk<ph name="END_LINK" />.</translation>
-<translation id="2523184218357549926">Nosūta Google serveriem apmeklēto lapu vietrāžus URL</translation>
-<translation id="2532336938189706096">Tīmekļa skatījums</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> vienumi tika izdzēsti</translation>
-<translation id="2536728043171574184">Skata šīs lapas kopiju bezsaistē</translation>
-<translation id="2546283357679194313">Sīkfaili un vietņu dati</translation>
-<translation id="2567385386134582609">ATTĒLS</translation>
-<translation id="257088987046510401">Motīvi</translation>
-<translation id="2570922361219980984">Arī piekļuve šīs ierīces atrašanās vietai ir izslēgta. Ieslēdziet to <ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Izvērsts — noklikšķiniet, lai sakļautu.</translation>
-<translation id="2581165646603367611">Tādējādi tiks dzēsti sīkfaili, kešatmiņa un citi vietņu dati, kas pārlūkā Chrome netiek uzskatīti par svarīgiem.</translation>
-<translation id="2586657967955657006">Starpliktuve</translation>
-<translation id="2587052924345400782">Pieejama jaunāka versija</translation>
-<translation id="2593272815202181319">Vienplatuma</translation>
-<translation id="2612676031748830579">Kartes numurs</translation>
-<translation id="2621115761605608342">Atļaut JavaScript konkrētai vietnei</translation>
-<translation id="2625189173221582860">Parole ir nokopēta.</translation>
-<translation id="2631006050119455616">Saglabāts</translation>
-<translation id="2647434099613338025">Pievienot valodu</translation>
-<translation id="2650751991977523696">Vai lejupielādēt failu vēlreiz?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# audio fails}zero{# audio faili}one{# audio fails}other{# audio faili}}</translation>
-<translation id="2653659639078652383">Iesniegt</translation>
-<translation id="2677748264148917807">Iziet</translation>
-<translation id="2704606927547763573">Nokopēts</translation>
-<translation id="2707726405694321444">Atsvaidzināt lapu</translation>
-<translation id="2709516037105925701">Automātiskā aizpilde</translation>
-<translation id="2717722538473713889">E-pasta adreses</translation>
-<translation id="2728754400939377704">Kārtot pēc vietnes</translation>
-<translation id="2744248271121720757">Pieskarieties vārdam, lai meklētu tūlīt vai skatītu saistītas darbības.</translation>
-<translation id="2760989362628427051">Ieslēgt tumšo motīvu, kad ierīcē ir ieslēgts tumšais motīvs vai akumulatora jaudas taupīšanas režīms</translation>
-<translation id="2762000892062317888">tikko</translation>
-<translation id="2777555524387840389">Atlikušas <ph name="SECONDS" /> s</translation>
-<translation id="2779651927720337254">neizdevās</translation>
-<translation id="2781151931089541271">Atlikusi 1 s</translation>
-<translation id="2801022321632964776">Veiciet atjaunināšanu, lai varētu lasīt savā valodā jaunākajā pārlūka Chrome versijā</translation>
-<translation id="2810645512293415242">Lapa tika vienkāršota, lai samazinātu datu lietojumu un paātrinātu ielādi.</translation>
-<translation id="281504910091592009">Skatiet un pārvaldiet saglabātās paroles savā <ph name="BEGIN_LINK" />Google kontā<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Lai grāmatzīmes būtu pieejamas visās jūsu ierīcēs, pierakstieties un ieslēdziet sinhronizāciju.</translation>
-<translation id="2822354292072154809">Vai tiešām vēlaties atiestatīt visas vietņu atļaujas, kas piešķirtas šim objektam: <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Lai izietu no pilnekrāna režīma, pieskarieties pogai Atpakaļ.</translation>
-<translation id="2842985007712546952">Vecākmape</translation>
-<translation id="2858138569776157458">Populāras</translation>
-<translation id="2860954141821109167">Šajā ierīcē jābūt iespējotai tālruņa lietotnei</translation>
-<translation id="2870560284913253234">Vietne</translation>
-<translation id="2874939134665556319">Iepriekšējais ieraksts</translation>
-<translation id="2876369937070532032">Nosūta Google serveriem dažu apmeklēto lapu vietrāžus URL, ja jūsu drošība ir apdraudēta</translation>
-<translation id="2888126860611144412">Par Chrome</translation>
-<translation id="2891154217021530873">Pārtraukt lapas ielādi</translation>
-<translation id="2893180576842394309">Google var izmantot jūsu vēsturi, lai personalizētu Meklēšanu un citus Google pakalpojumus.</translation>
-<translation id="2898264748040935573">Rediģēt saglabāto paroli</translation>
-<translation id="2900528713135656174">Izveidot pasākumu</translation>
-<translation id="290376772003165898">Vai lapa nav šajā valodā: <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Ierīču saraksts, ar ko kopīgot cilni, ir atvērts pilna ekrāna augstumā.</translation>
-<translation id="2910701580606108292">Jautāt, pirms atļaut vietnēm atskaņot aizsargātu saturu</translation>
-<translation id="2913331724188855103">Atļaut vietnēm saglabāt un lasīt sīkfailu datus (ieteicams)</translation>
-<translation id="2923908459366352541">Vārds nav derīgs</translation>
-<translation id="2932150158123903946">Lietotnes Google <ph name="APP_NAME" /> krātuve</translation>
-<translation id="2942036813789421260">Priekšskatījuma cilne ir aizvērta</translation>
-<translation id="2956410042958133412">Šo kontu pārvalda <ph name="PARENT_NAME_1" /> un <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Notika pārslēgšanās uz inkognito režīma cilnēm</translation>
-<translation id="2968755619301702150">Sertifikātu skatītājs</translation>
-<translation id="2979025552038692506">Atlasītā inkognito cilne</translation>
-<translation id="2987620471460279764">No citas ierīces kopīgotais teksts</translation>
-<translation id="2989523299700148168">Nesen apmeklētās</translation>
-<translation id="2996291259634659425">Ieejas frāzes izveide</translation>
-<translation id="2996809686854298943">URL ir jānorāda obligāti.</translation>
-<translation id="300526633675317032">Tādējādi tiks notīrīti visi vietnes krātuves dati (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">Pārbaudiet, vai šajā ierīcē ir izveidots interneta savienojums</translation>
-<translation id="3029613699374795922">Lejupielādēts: <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Ieejas frāzes neatbilst.</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Saņemt palīdzību<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Atrašanās vietu noteikšana ir izslēgta. Ieslēdziet to <ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Jebkurā brīdī varat ieslēgt sinhronizāciju iestatījumos.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> grāmatzīme}zero{<ph name="BOOKMARKS_COUNT_MANY" /> grāmatzīmju}one{<ph name="BOOKMARKS_COUNT_MANY" /> grāmatzīme}other{<ph name="BOOKMARKS_COUNT_MANY" /> grāmatzīmes}}</translation>
-<translation id="3089395242580810162">Atvērt inkognito režīma cilnē</translation>
-<translation id="3115898365077584848">Rādīt informāciju</translation>
-<translation id="3123473560110926937">Bloķētas dažās vietnēs</translation>
-<translation id="3137521801621304719">Iziet no inkognito režīma</translation>
-<translation id="3143515551205905069">Atcelt sinhronizāciju</translation>
-<translation id="3157842584138209013">Izmantojiet pogu Vairāk opciju, lai uzzinātu ietaupīto datu apjomu</translation>
-<translation id="3166827708714933426">Ciļņu un logu īsinājumtaustiņi</translation>
-<translation id="3181954750937456830">Droša pārlūkošana (aizsargā jūs un ierīci pret bīstamām vietnēm)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" /> ieslēdziet atļaujas pārlūkam Chrome.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> saglabātu datu</translation>
-<translation id="3205824638308738187">Gandrīz pabeigts!</translation>
-<translation id="3207960819495026254">Atzīmēts kā grāmatzīme</translation>
-<translation id="3211426585530211793">Vienums <ph name="ITEM_TITLE" /> tika izdzēsts</translation>
-<translation id="321773570071367578">Ja esat aizmirsis ieejas frāzi vai vēlaties mainīt šo iestatījumu, <ph name="BEGIN_LINK" />atiestatiet sinhronizāciju<ph name="END_LINK" />.</translation>
-<translation id="3227137524299004712">Mikrofons</translation>
-<translation id="3232754137068452469">Tīmekļa lietotne</translation>
-<translation id="3236059992281584593">Atlikusi 1 min</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Grāmatot šo lapu</translation>
-<translation id="3259831549858767975">Samazināt visu lapas saturu</translation>
-<translation id="3269093882174072735">Ielādēt attēlu</translation>
-<translation id="3269956123044984603">Lai būtu pieejamas cilnes no citām jūsu ierīcēm, Android konta iestatījumos ieslēdziet iestatījumu “Automātiski sinhronizēt datus”.</translation>
-<translation id="3277252321222022663">Atļaut vietnēm piekļūt sensoriem (ieteicams)</translation>
-<translation id="3282568296779691940">Pierakstīties pārlūkā Chrome</translation>
-<translation id="3288003805934695103">Atkārtoti ielādējiet lapu.</translation>
-<translation id="32895400574683172">Paziņojumi ir atļauti.</translation>
-<translation id="3295530008794733555">Ietaupiet laiku. Samaziniet datu lietojumu.</translation>
-<translation id="3295602654194328831">Slēpt informāciju</translation>
-<translation id="3298243779924642547">Vienkāršota</translation>
-<translation id="3303414029551471755">Vai turpināt ar satura lejupielādi?</translation>
-<translation id="3306398118552023113">Šī lietotne darbojas pārlūkā Chrome</translation>
-<translation id="3315103659806849044">Šobrīd jūs pielāgojat sinhronizēšanas un Google pakalpojuma iestatījumus. Lai pabeigtu sinhronizēšanas ieslēgšanu, pieskarieties pogai Apstiprināt, kas atrodas ekrāna apakšdaļā. Pārvietoties augšup</translation>
-<translation id="3328801116991980348">Vietnes informācija</translation>
-<translation id="3333961966071413176">Visas kontaktpersonas</translation>
-<translation id="3334729583274622784">Vai mainīt faila paplašinājumu?</translation>
-<translation id="3341058695485821946">Uzziniet ietaupīto datu apjomu</translation>
-<translation id="3350687908700087792">Aizvērt visas inkognito režīma cilnes</translation>
-<translation id="3353615205017136254">Vienkāršota lapa, ko nodrošina Google. Pieskarieties pogai “Ielādēt sākotnējo”, lai ielādētu sākotnējo lapu.</translation>
-<translation id="3367813778245106622">Lai sāktu sinhronizēšanu, pierakstieties vēlreiz</translation>
-<translation id="3374023511497244703">Jūsu grāmatzīmes, vēsture, paroles un citi Chrome dati vairs netiks sinhronizēti ar jūsu Google kontu</translation>
-<translation id="3384347053049321195">Kopīgot attēlu</translation>
-<translation id="3386292677130313581">Jautāt, pirms atļaut vietnēm uzzināt jūsu atrašanās vietu (ieteicams)</translation>
-<translation id="3387650086002190359">Neizdevās lejupielādēt failu <ph name="FILE_NAME" />, jo radās failu sistēmas kļūdas.</translation>
-<translation id="3389286852084373014">Teksts ir pārāk liels</translation>
-<translation id="3398320232533725830">Atvērt grāmatzīmju pārvaldnieku</translation>
-<translation id="3414952576877147120">Lielums:</translation>
-<translation id="3443221991560634068">Atkārtoti ielādēt pašreizējo lapu</translation>
-<translation id="3445014427084483498">Tikko</translation>
-<translation id="3478363558367712427">Varat izvēlēties savu meklētājprogrammu.</translation>
+<translation id="6910211073230771657">Dzēsts</translation>
+<translation id="6965382102122355670">Labi</translation>
+<translation id="5301954838959518834">Labi, sapratu</translation>
+<translation id="7658239707568436148">Atcelt</translation>
 <translation id="3479552764303398839">Vēlāk</translation>
-<translation id="3492207499832628349">Jauna inkognito cilne</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Uzziniet vairāk<ph name="END_LINK" /> par ieteikto saturu.</translation>
-<translation id="3513704683820682405">Papildinātā realitāte</translation>
-<translation id="3518985090088779359">Piekrist un turpināt</translation>
-<translation id="3522247891732774234">Pieejams atjauninājums. Citas iespējas</translation>
-<translation id="3524138585025253783">Izstrādātāja lietotājsaskarne</translation>
-<translation id="3527085408025491307">Mape</translation>
-<translation id="3542235761944717775">Pieejami <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Meklēt savā vēsturē</translation>
-<translation id="3557336313807607643">Pievienot kontaktpersonām</translation>
-<translation id="3566923219790363270">Chrome joprojām gatavojas virtuālajai realitātei. Vēlāk restartējiet pārlūku Chrome.</translation>
-<translation id="3568688522516854065">Lai varētu piekļūt cilnēm no citām ierīcēm, pierakstieties un ieslēdziet sinhronizāciju.</translation>
-<translation id="3587482841069643663">Visi</translation>
-<translation id="358794129225322306">Atļaut vietnei automātiski lejupielādēt vairākus failus.</translation>
-<translation id="3590487821116122040">Vietnes krātuve, kura pārlūkā Chrome netiek uzskatīta par svarīgu (piemēram, vietnes bez saglabātiem iestatījumiem vai vietnes, kuras neapmeklējat bieži)</translation>
-<translation id="3599863153486145794">Notīra vēsturi no visām ierīcēm, kurās esat pierakstījies. Jūsu Google kontam vietnē <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> var būt citu veidu pārlūkošanas vēstures dati.</translation>
-<translation id="3600792891314830896">Izslēgt skaņu vietnēm, kurās tiek atskaņota skaņa</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Notiek kopīgošana ar ierīci <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Parādīt paroli</translation>
-<translation id="363596933471559332">Automātiski pierakstīties vietnēs, izmantojot saglabātos akreditācijas datus. Ja funkcija ir izslēgta, verifikācija būs jāveic ikreiz, kad pierakstīsieties vietnē.</translation>
-<translation id="3658159451045945436">Veicot atiestatīšanu, tiek dzēsta saglabāto datu vēsture, tostarp apmeklēto vietņu saraksts.</translation>
-<translation id="3692944402865947621">Faila <ph name="FILE_NAME" /> lejupielāde neizdevās, jo krātuves vieta nav sasniedzama.</translation>
-<translation id="3714981814255182093">Atvērt atrašanas joslu</translation>
-<translation id="3716182511346448902">Šī lapa izmanto pārāk daudz atmiņas, tādēļ Chrome to apturēja.</translation>
-<translation id="3730075448226062617">Lai atļautu pārlūkprogrammai Chrome piekļūt jūsu mikrofonam, ieslēdziet mikrofonu arī <ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Pievienota grāmatzīme pārlūkā <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sinhronizācija fonā</translation>
-<translation id="3771001275138982843">Nevarēja lejupielādēt atjauninājumu</translation>
-<translation id="3771033907050503522">Inkognito režīma cilnes</translation>
-<translation id="3773755127849930740">Lai atļautu savienošanu pārī, <ph name="BEGIN_LINK" />ieslēdziet Bluetooth<ph name="END_LINK" />.</translation>
-<translation id="3775705724665058594">Sūtīšana uz jūsu ierīcēm</translation>
-<translation id="3778956594442850293">Pievienots sākuma ekrānam</translation>
-<translation id="3789841737615482174">Instalēt</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Pārvaldīt</translation>
-<translation id="381841723434055211">Tālruņa numuri</translation>
-<translation id="3819178904835489326">Izdzēsti <ph name="NUMBER_OF_DOWNLOADS" /> lejupielādētie vienumi</translation>
-<translation id="3822502789641063741">Vai notīrīt vietnes krātuvi?</translation>
-<translation id="385051799172605136">Atpakaļ</translation>
-<translation id="3859306556332390985">Pārtīt uz priekšu</translation>
-<translation id="3894427358181296146">Mapes pievienošana</translation>
-<translation id="3895926599014793903">Tālummaiņas piespiedu iespējošana</translation>
-<translation id="3912508018559818924">Notiek vislabākā tīmekļa satura meklēšana</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Datu apvienošana</translation>
-<translation id="393697183122708255">Nav iespējota meklēšana ar balsi.</translation>
-<translation id="395206256282351086">Meklēšanas un vietņu ieteikumi atspējoti</translation>
-<translation id="3955193568934677022">Atļaut vietnēm atskaņot aizsargātu saturu (ieteicams)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Kad ierīce būs gatava, jūsu lapa tiks ielādēta pārlūkā Chrome}zero{Kad ierīce būs gatava, jūsu lapas tiks ielādētas pārlūkā Chrome}one{Kad ierīce būs gatava, jūsu lapas tiks ielādētas pārlūkā Chrome}other{Kad ierīce būs gatava, jūsu lapas tiks ielādētas pārlūkā Chrome}}</translation>
-<translation id="3963007978381181125">Ieejas frāzes šifrējumā nav iekļauti maksājumu veidi un adreses no pakalpojuma Google Pay. Jūsu šifrētos datus var lasīt tikai personas, kurām ir zināma jūsu ieejas frāze. Ieejas frāze netiek sūtīta Google serveriem un netiek tajos glabāta. Ja aizmirsīsiet ieejas frāzi vai vēlēsieties mainīt šo iestatījumu, jums būs jāatiestata sinhronizācija. <ph name="BEGIN_LINK" />Uzziniet vairāk<ph name="END_LINK" />.</translation>
-<translation id="3967822245660637423">Lejupielāde pabeigta</translation>
-<translation id="397583555483684758">Sinhronizācija vairs nedarbojas</translation>
-<translation id="3976396876660209797">Noņemt un atkārtoti izveidot šo saīsni</translation>
-<translation id="3985215325736559418">Vai vēlaties vēlreiz lejupielādēt failu <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Saites kopēšana</translation>
-<translation id="3988213473815854515">Atļauta piekļuve atrašanās vietas informācijai</translation>
-<translation id="3988466920954086464">Skatīt tūlītējus meklēšanas rezultātus šajā panelī</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> no ?</translation>
-<translation id="3997476611815694295">Nesvarīga krātuve</translation>
-<translation id="4000212216660919741">Bezsaistes sākums</translation>
+<translation id="5317780077021120954">Saglabāt</translation>
+<translation id="4570913071927164677">Detalizēta informācija</translation>
+<translation id="8730621377337864115">Gatavs</translation>
+<translation id="8261506727792406068">Dzēst</translation>
+<translation id="1181037720776840403">Noņemt</translation>
+<translation id="5939518447894949180">Atiestatīt</translation>
 <translation id="4002066346123236978">Nosaukums</translation>
-<translation id="4008040567710660924">Atļaut sīkfailus konkrētai vietnei.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}zero{# h}one{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Nākamais ieraksts</translation>
-<translation id="4048707525896921369">Uzziniet par vietņu tēmām, neizejot no lapas. Izmantojot funkciju “Pieskarties, lai meklētu”, vārds un tā konteksts tiek nosūtīts pakalpojumam Google meklēšana, un tiek parādītas definīcijas, attēli, meklēšanas rezultāti un cita informācija.
+<translation id="5916664084637901428">Iesl.</translation>
+<translation id="5860033963881614850">Izsl.</translation>
+<translation id="6165508094623778733">Uzziniet vairāk</translation>
+<translation id="6042308850641462728">Vairāk</translation>
+<translation id="6040143037577758943">Aizvērt</translation>
+<translation id="780301667611848630">Nē, paldies</translation>
+<translation id="1201402288615127009">Tālāk</translation>
+<translation id="2359808026110333948">Turpināt</translation>
+<translation id="2653659639078652383">Iesniegt</translation>
+<translation id="2079545284768500474">Atsaukt</translation>
+<translation id="7649070708921625228">Palīdzība</translation>
+<translation id="2148716181193084225">Šodien</translation>
+<translation id="7781829728241885113">Vakar</translation>
+<translation id="6945221475159498467">Atlasīt</translation>
+<translation id="7791543448312431591">Pievienot</translation>
+<translation id="6527303717912515753">Kopīgot</translation>
+<translation id="1383876407941801731">Meklēt</translation>
+<translation id="3115898365077584848">Rādīt informāciju</translation>
+<translation id="3295602654194328831">Slēpt informāciju</translation>
+<translation id="3987993985790029246">Saites kopēšana</translation>
+<translation id="2704606927547763573">Nokopēts</translation>
+<translation id="8725066075913043281">Mēģināt vēlreiz</translation>
+<translation id="385051799172605136">Atpakaļ</translation>
+<translation id="8131740175452115882">Apstiprināt</translation>
+<translation id="5300589172476337783">Rādīt</translation>
+<translation id="1124772482545689468">Lietotājs</translation>
+<translation id="8609465669617005112">Virziet uz augšu</translation>
+<translation id="6746124502594467657">Pārvietot uz leju</translation>
+<translation id="8249310407154411074">Pārvietot uz augšdaļu</translation>
+<translation id="8428213095426709021">Iestatījumi</translation>
+<translation id="2498359688066513246">Palīdzība un atsauksmes</translation>
+<translation id="8378714024927312812">Pārvalda jūsu organizācija</translation>
+<translation id="9019902583201351841">Pārvalda jūsu vecāki</translation>
+<translation id="4645575059429386691">Pārvalda viens no jūsu vecākiem</translation>
+<translation id="4883854917563148705">Pārvaldītos iestatījumus nevar atiestatīt</translation>
+<translation id="4307992518367153382">Pamata</translation>
+<translation id="1974060860693918893">Papildu</translation>
+<translation id="1146678959555564648">Ieiet virtuālajā realitātē</translation>
+<translation id="987264212798334818">Vispārīgi</translation>
+<translation id="4275663329226226506">Multivide</translation>
+<translation id="4759238208242260848">Lejupielādes</translation>
+<translation id="218608176142494674">Kopīgošana</translation>
+<translation id="8004582292198964060">Pārlūkprogramma</translation>
+<translation id="1105960400813249514">Ekrāna tveršana</translation>
+<translation id="4875775213178255010">Satura ieteikumi</translation>
+<translation id="2021896219286479412">Pilnekrāna vietnes vadīklas</translation>
+<translation id="4587589328781138893">Vietnes</translation>
+<translation id="4943703118917034429">Virtuālā realitāte</translation>
+<translation id="1928696683969751773">Atjaunināšana</translation>
+<translation id="6064125863973209585">Pabeigtās lejupielādes</translation>
+<translation id="5342314432463739672">Atļauju pieprasījumi</translation>
+<translation id="629730747756840877">Konts</translation>
+<translation id="82609232232243542">Pierakstīties pārlūkā Brave</translation>
+<translation id="7956662517480676674">Sinhronizēšana un Brave Software pakalp.</translation>
+<translation id="5294439808117722387">Šobrīd jūs pielāgojat sinhronizēšanas un Brave Software pakalpojuma iestatījumus. Lai pabeigtu sinhronizēšanas ieslēgšanu, pieskarieties pogai Apstiprināt, kas atrodas ekrāna apakšdaļā. Pārvietoties augšup</translation>
+<translation id="2096012225669085171">Sinhronizējiet un personalizējiet vairākās ierīcēs</translation>
+<translation id="1692118695553449118">Sinhronizācija ieslēgta</translation>
+<translation id="5514904542973294328">Atspējoja šīs ierīces administrators</translation>
+<translation id="6447211988989208781">Brave Software aktivitātes vadīklas</translation>
+<translation id="4882831918239250449">Kontrolējiet, kā jūsu pārlūkošanas vēsture tiek izmantota Meklēšanas, reklāmu un cita satura personalizēšanai</translation>
+<translation id="7431991332293347422">Kontrolējiet, kā jūsu pārlūkošanas vēsture tiek izmantota Meklēšanas un cita satura personalizēšanai</translation>
+<translation id="6303969859164067831">Izrakstīties un izslēgt sinhronizēšanu</translation>
+<translation id="1125261911132334651">Brave Software konta pārvaldība</translation>
+<translation id="6406506848690869874">Sinhronizācija</translation>
+<translation id="714362445477979774">Jūsu Brave datu sinhronizācija</translation>
+<translation id="4314815835985389558">Sinhronizācijas pārvaldība</translation>
+<translation id="5428209950370661546">Citi Brave Software pakalpojumi</translation>
+<translation id="7704317875155739195">Automātiski pabeigt meklēšanas vaicājumus un vietrāžus URL</translation>
+<translation id="2000419248597011803">Nosūta dažus sīkfailus un meklēšanas vaicājumus no adreses joslas un meklēšanas lodziņa uz jūsu noklusējuma meklētājprogrammu.</translation>
+<translation id="7981313251711023384">Veikt lapu pirmsielādi, lai paātrinātu pārlūkošanu un meklēšanu</translation>
+<translation id="1821253160463689938">Izmanto sīkfailus, lai iegaumētu jūsu preferences, pat ja neapmeklējāt šīs lapas</translation>
+<translation id="6697492270171225480">Ja lapu neizdotas atrast, rāda ieteikumus par līdzīgām lapām</translation>
+<translation id="8109318360573330108">Sūta Brave Software serveriem tās lapas URL, kuru mēģināt sasniegt</translation>
+<translation id="8438566539970814960">Uzlabot meklēšanu un pārlūkošanu</translation>
+<translation id="284843628681142937">Nosūta Brave Software serveriem apmeklēto lapu vietrāžus URL</translation>
+<translation id="7222718784508482526">Papildu iestatījumus, kas attiecas uz konfidencialitāti, drošību un datu apkopošanu, skatiet lapā <ph name="BEGIN_LINK"/>Sinhronizēšana un Brave Software pakalpojumi<ph name="END_LINK"/>.</translation>
+<translation id="918192811481327695">Palīdzēt uzlabot Brave funkcijas un veiktspēju</translation>
+<translation id="9063160602596686558">Automātiski sūtīt lietojuma statistiku un avāriju pārskatus Brave Software serveriem</translation>
+<translation id="4824958205181053313">Vai atcelt sinhronizāciju?</translation>
+<translation id="3058498974290601450">Jebkurā brīdī varat ieslēgt sinhronizāciju iestatījumos.</translation>
+<translation id="3143515551205905069">Atcelt sinhronizāciju</translation>
+<translation id="1506061864768559482">Meklētājprogramma</translation>
+<translation id="55737423895878184">Atrašanās vietas noteikšana un paziņojumi ir atļauti.</translation>
+<translation id="3988213473815854515">Atļauta piekļuve atrašanās vietas informācijai</translation>
+<translation id="32895400574683172">Paziņojumi ir atļauti.</translation>
+<translation id="9040142327097499898">Paziņojumi ir atļauti. Atrašanās vietas noteikšana šai ierīcei ir izslēgta.</translation>
+<translation id="305593374596241526">Atrašanās vietu noteikšana ir izslēgta. Ieslēdziet to <ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Nesen apmeklētās</translation>
+<translation id="6433501201775827830">Meklētājprogrammas izvēle</translation>
+<translation id="7177466738963138057">Vēlāk varēsiet to mainīt iestatījumos</translation>
+<translation id="3478363558367712427">Varat izvēlēties savu meklētājprogrammu.</translation>
+<translation id="4910889077668685004">Maksājumu lietotnes</translation>
+<translation id="5152843274749979095">Nav instalēta neviena atbalstīta lietotne</translation>
+<translation id="8812260976093120287">Dažās vietnēs var norēķināties, ierīcē izmantojot iepriekš norādītās atbalstītās maksājumu lietotnes.</translation>
+<translation id="7764225426217299476">Pievienot adresi</translation>
+<translation id="5595485650161345191">Rediģēt adresi</translation>
+<translation id="5087580092889165836">Pievienot karti</translation>
+<translation id="2154484045852737596">Kartes informācijas rediģēšana</translation>
+<translation id="6140912465461743537">Valsts/reģions</translation>
+<translation id="5659593005791499971">E-pasts</translation>
+<translation id="4378154925671717803">Tālrunis</translation>
+<translation id="4807098396393229769">Vārds uz kartes</translation>
+<translation id="860043288473659153">Bankas kartes īpašnieka vārds</translation>
+<translation id="2612676031748830579">Kartes numurs</translation>
+<translation id="869891660844655955">Derīguma termiņš</translation>
+<translation id="2286841657746966508">Norēķinu adrese</translation>
+<translation id="663059986967017181">Nokopēta pārlūkā Brave.</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}zero{<ph name="PAYMENT_METHOD_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}zero{<ph name="SHIPPING_ADDRESS_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}zero{<ph name="SHIPPING_OPTION_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}zero{<ph name="CONTACT_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Paroles</translation>
+<translation id="1943432128510653496">Paroļu saglabāšana</translation>
+<translation id="2100273922101894616">Automātiski pierakstīties</translation>
+<translation id="363596933471559332">Automātiski pierakstīties vietnēs, izmantojot saglabātos akreditācijas datus. Ja funkcija ir izslēgta, verifikācija būs jāveic ikreiz, kad pierakstīsieties vietnē.</translation>
+<translation id="6995899638241819463">Brīdināt, ja paroles tiek atklātas datu noplūdes dēļ</translation>
+<translation id="1534287762301776620">Kad pierakstāties savā Brave Software kontā, šī funkcija ir ieslēgta.</translation>
+<translation id="10614374240317010">Netiek saglabātas</translation>
+<translation id="3098842761938485917">Skatiet un pārvaldiet saglabātās paroles savā <ph name="BEGIN_LINK"/>Brave Software kontā<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Šeit tiks parādītas saglabātās paroles.</translation>
+<translation id="8084114998886531721">Saglabātā parole</translation>
+<translation id="2870560284913253234">Vietne</translation>
+<translation id="8503813439785031346">Lietotājvārds</translation>
+<translation id="6657585470893396449">Parole</translation>
+<translation id="2154710561487035718">Kopēt URL</translation>
+<translation id="1571304935088121812">Kopēt lietotājvārdu</translation>
+<translation id="5005498671520578047">Paroles kopēšana</translation>
+<translation id="3632295766818638029">Parādīt paroli</translation>
+<translation id="1513858653616922153">Dzēst paroli</translation>
+<translation id="543338862236136125">Rediģēt paroli</translation>
+<translation id="4565377596337484307">Slēpt paroli</translation>
+<translation id="8523928698583292556">Dzēst saglabāto paroli</translation>
+<translation id="2898264748040935573">Rediģēt saglabāto paroli</translation>
+<translation id="5433691172869980887">Lietotājvārds ir nokopēts.</translation>
+<translation id="5534640966246046842">Vietne ir nokopēta.</translation>
+<translation id="2625189173221582860">Parole ir nokopēta.</translation>
+<translation id="4550003330909367850">Lai skatītu vai kopētu savu paroli šeit, iestatiet ekrāna bloķēšanu šajā ierīcē.</translation>
+<translation id="6154478581116148741">Lai eksportētu paroles no šīs ierīces, sadaļā “Iestatījumi” ieslēdziet ekrāna bloķēšanu.</translation>
+<translation id="4842092870884894799">Tiek rādīts paroles ģenerēšanas uznirstošais logs</translation>
+<translation id="2259659629660284697">Paroļu eksportēšana…</translation>
+<translation id="133012818630824069">Eksportēt pārlūkā Brave saglabātās paroles</translation>
+<translation id="6914783257214138813">Jūsu paroles būs redzamas ikvienam, kas var skatīt eksportēto failu.</translation>
+<translation id="2321086116217818302">Notiek paroļu sagatavošana…</translation>
+<translation id="8445448999790540984">Nevar eksportēt paroles</translation>
+<translation id="3066461326500799725">Uzzināt, kā izmantot Brave Software disku</translation>
+<translation id="729975465115245577">Ierīcē nav lietotnes, kurā uzglabāt paroļu failu.</translation>
+<translation id="7682724950699840886">Ņemiet vērā šos ieteikumus: atbrīvojiet ierīcē vietu un mēģiniet eksportēt vēlreiz.</translation>
+<translation id="1129510026454351943">Informācija: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Atbloķējiet, lai kopētu paroli</translation>
+<translation id="5515439363601853141">Atbloķējiet, lai skatītu paroli</translation>
+<translation id="6221633008163990886">Atbloķējiet, lai eksportētu paroles.</translation>
+<translation id="230699814587342492">Brave paroles</translation>
+<translation id="6075798973483050474">Sākumlapas rediģēšana</translation>
+<translation id="854522910157234410">Atvērt šo lapu</translation>
+<translation id="2482878487686419369">Paziņojumi</translation>
+<translation id="6255999984061454636">Satura ieteikumi</translation>
+<translation id="805047784848435650">Pamatā ir jūsu pārlūkošanas vēsture</translation>
+<translation id="1041308826830691739">No vietnēm</translation>
+<translation id="395206256282351086">Meklēšanas un vietņu ieteikumi atspējoti</translation>
+<translation id="257088987046510401">Motīvi</translation>
+<translation id="4650364565596261010">Sistēmas noklusējums</translation>
+<translation id="7588219262685291874">Ieslēgt tumšo motīvu, kad ierīcē ir ieslēgts akumulatora jaudas taupīšanas režīms</translation>
+<translation id="2760989362628427051">Ieslēgt tumšo motīvu, kad ierīcē ir ieslēgts tumšais motīvs vai akumulatora jaudas taupīšanas režīms</translation>
+<translation id="6381421346744604172">Aptumšot vietnes</translation>
+<translation id="5040262127954254034">Konfidencialitāte</translation>
+<translation id="4991384657077828949">Palīdzēt uzlabot Brave drošību</translation>
+<translation id="1943176487615318915">Lai noteiktu bīstamas lietotnes un vietnes, pārlūkā Brave dažu jūsu apmeklēto lapu saturs, ierobežots sistēmas informācijas apjoms un daļa lapu satura tiek nosūtīta uzņēmumam Brave Software</translation>
+<translation id="3181954750937456830">Droša pārlūkošana (aizsargā jūs un ierīci pret bīstamām vietnēm)</translation>
+<translation id="7315322926489145388">Nosūta Brave Software serveriem dažu apmeklēto lapu vietrāžus URL, ja jūsu drošība ir apdraudēta</translation>
+<translation id="2063713494490388661">Pieskarties, lai meklētu</translation>
+<translation id="2369463299479365221">Uzziniet par vietņu tēmām, neizejot no lapas. Izmantojot funkciju “Pieskarties, lai meklētu”, vārds un tā konteksts tiek nosūtīts pakalpojumam Brave Software meklēšana, un tiek parādītas definīcijas, attēli, meklēšanas rezultāti un cita informācija.
 
 Lai pielāgotu meklēšanas vienumu, nospiediet un turiet to. Lai veiktu precīzāku meklēšanu, velciet paneli augšup līdz galam un pieskarieties meklēšanas lodziņam.</translation>
-<translation id="4056223980640387499">Sēpija</translation>
-<translation id="4060598801229743805">Opcijas, kas pieejamas ekrāna augšdaļā</translation>
-<translation id="4062305924942672200">Juridiskā informācija</translation>
-<translation id="4084682180776658562">Grāmatzīme</translation>
-<translation id="4084712963632273211">No izdevēja <ph name="PUBLISHER_ORIGIN" /> — <ph name="BEGIN_DEEMPHASIZED" />nodrošina Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Vai dzēst lietotnes datus?</translation>
-<translation id="4099578267706723511">Uzlabojiet pārlūku Chrome, uzņēmumam Google sūtot lietojuma statistiku un avāriju pārskatus.</translation>
-<translation id="410351446219883937">Automātiskā atskaņošana</translation>
-<translation id="4116038641877404294">Lejupielādējiet lapas, lai izmantotu tās bezsaistē</translation>
-<translation id="4135200667068010335">Ierīču saraksts, ar ko kopīgot cilni, ir aizvērts.</translation>
-<translation id="4149994727733219643">Vienkāršots tīmekļa lapu skatījums</translation>
-<translation id="4165986682804962316">Vietnes iestatījumi</translation>
-<translation id="4169535189173047238">Neatļaut</translation>
-<translation id="4170011742729630528">Pakalpojums nav pieejams. Vēlāk mēģiniet vēlreiz.</translation>
-<translation id="4179980317383591987">Izmantots: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Valodas</translation>
-<translation id="4183868528246477015">Meklēšana ar Google Lens <ph name="BEGIN_NEW" />Jauns<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Atvērt jaunā cilnē</translation>
-<translation id="4198423547019359126">Nav pieejamu lejupielādes atrašanās vietu.</translation>
-<translation id="4209895695669353772">Lai saņemtu Google ieteikto personalizēto saturu, ieslēdziet sinhronizāciju.</translation>
-<translation id="4226663524361240545">Saņemot paziņojumu, ierīce var vibrēt.</translation>
-<translation id="423219824432660969">Šifrēt sinhronizētos datus ar Google paroli, sākot no: <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Atvērt iestatījumus</translation>
-<translation id="4256782883801055595">Atklātā pirmkoda licences</translation>
-<translation id="4259722352634471385">Navigācija ir bloķēta: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopēt saites adresi</translation>
-<translation id="4275663329226226506">Multivide</translation>
-<translation id="4278390842282768270">Atļauts</translation>
-<translation id="429312253194641664">Vietne atskaņo multivides saturu</translation>
-<translation id="4298388696830689168">Saistītās vietnes</translation>
-<translation id="4307992518367153382">Pamata</translation>
-<translation id="4314815835985389558">Sinhronizācijas pārvaldība</translation>
-<translation id="4351244548802238354">Aizvērt dialoglodziņu</translation>
-<translation id="4378154925671717803">Tālrunis</translation>
-<translation id="4384468725000734951">Tiek izmantota meklētājprogramma Sogou</translation>
-<translation id="4404568932422911380">Nav grāmatzīmju</translation>
-<translation id="4405224443901389797">Pārvietot uz…</translation>
-<translation id="4411535500181276704">Vienkāršais režīms</translation>
-<translation id="4415276339145661267">Google konta pārvaldība</translation>
-<translation id="4432792777822557199">Turpmāk lapas šādā valodā: <ph name="SOURCE_LANGUAGE" /> tiks tulkotas šādā valodā: <ph name="TARGET_LANGUAGE" />.</translation>
-<translation id="4433925000917964731">Vienkāršota lapa, ko nodrošina Google</translation>
-<translation id="4434045419905280838">Uznirstošie elem. un novirzīšana</translation>
-<translation id="4440958355523780886">Vienkāršota lapa, ko nodrošina Google. Lai ielādētu sākotnējo lapu, pieskarieties.</translation>
-<translation id="4452411734226507615">Aizvērt cilni <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Grāmatzīme saglabāta mapē <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Ļaut vietnēm atskaņot aizsargātu saturu</translation>
-<translation id="4468959413250150279">Izslēgt skaņu noteiktai vietnei</translation>
-<translation id="4472118726404937099">Lai sinhronizētu un personalizētu saturu dažādās ierīcēs, pierakstieties un ieslēdziet sinhronizāciju.</translation>
-<translation id="447252321002412580">Palīdzēt uzlabot Chrome funkcijas un veiktspēju</translation>
-<translation id="4479647676395637221">Jautāt, pirms atļaut vietnēm izmantot jūsu kameru (ieteicams)</translation>
-<translation id="4479972344484327217">Notiek moduļa <ph name="MODULE" /> instalēšana pārlūkprogrammai Chrome…</translation>
-<translation id="4487967297491345095">Visi lietotnes Chrome dati tiks neatgriezeniski izdzēsti. Tas attiecas uz visiem failiem, iestatījumiem, kontiem, datu bāzēm un citiem datiem.</translation>
-<translation id="4493497663118223949">Vienkāršotais režīms ir ieslēgts</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{pirms # dienas}zero{pirms # dienām}one{pirms # dienas}other{pirms # dienām}}</translation>
-<translation id="451872707440238414">Meklēt grāmatzīmēs</translation>
-<translation id="4521489764227272523">Atlasītie dati ir noņemti no pārlūka Chrome un jūsu sinhronizētajām ierīcēm.
-
-Jūsu Google kontam vietnē <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> var būt citu veidu pārlūkošanas vēstures dati, piemēram, meklēšanas vaicājumi un darbības citos Google pakalpojumos.</translation>
-<translation id="4532845899244822526">Mapes izvēlēšanās</translation>
-<translation id="4538018662093857852">Ieslēgt vienkāršoto režīmu</translation>
-<translation id="4550003330909367850">Lai skatītu vai kopētu savu paroli šeit, iestatiet ekrāna bloķēšanu šajā ierīcē.</translation>
-<translation id="4558311620361989323">Tīmekļa lapu īsinājumtaustiņi</translation>
-<translation id="4561979708150884304">Nav savienojuma</translation>
-<translation id="4565377596337484307">Slēpt paroli</translation>
-<translation id="4570913071927164677">Detalizēta informācija</translation>
-<translation id="4572422548854449519">Pierakstīšanās pārvaldītā kontā</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{pirms # minūtes}zero{pirms # minūtēm}one{pirms # minūtes}other{pirms # minūtēm}}</translation>
-<translation id="4587589328781138893">Vietnes</translation>
-<translation id="4594952190837476234">Šī lapas bezsaistes versija (izveidota: <ph name="CREATION_TIME" />) var atšķirties no tiešsaistes versijas.</translation>
-<translation id="4605958867780575332">Vienums noņemts: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Atvērt <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Izmantot paroli</translation>
-<translation id="4645575059429386691">Pārvalda viens no jūsu vecākiem</translation>
-<translation id="4650364565596261010">Sistēmas noklusējums</translation>
-<translation id="4663756553811254707">Dzēstas <ph name="NUMBER_OF_BOOKMARKS" /> grāmatzīmes</translation>
-<translation id="4665282149850138822">Vietne <ph name="NAME" /> tika pievienota sākuma ekrānam.</translation>
-<translation id="4684427112815847243">Sinhronizēt visu</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}zero{<ph name="SHIPPING_OPTION_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Sūtīt īsziņu uz manām ierīcēm</translation>
-<translation id="4698034686595694889">Skatīšana bezsaistē lietotnē <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Kešatmiņā ievietotie attēli un faili</translation>
-<translation id="4714588616299687897">Saglabājiet līdz pat 60% datu</translation>
-<translation id="4719927025381752090">Piedāvāt tulkot</translation>
-<translation id="4720023427747327413">Atvērt, izmantojot <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Palīdziet uzlabot pārlūku Chrome. <ph name="BEGIN_LINK" />Atbildiet uz aptaujas jautājumiem<ph name="END_LINK" />.</translation>
-<translation id="473775607612524610">Atjaunināt</translation>
-<translation id="4738836084190194332">Pēdējoreiz sinhronizēts: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Atvērt jaunu cilni</translation>
-<translation id="4751476147751820511">Kustību vai gaismas sensori</translation>
-<translation id="4759238208242260848">Lejupielādes</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 lejupielāde ir pabeigta.}zero{# lejupielādes ir pabeigtas.}one{# lejupielāde ir pabeigta.}other{# lejupielādes ir pabeigtas.}}</translation>
-<translation id="4797039098279997504">Pieskarieties, lai atgrieztos cilnē <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Ieejas frāzes šifrējumā nav iekļauti maksājumu veidi un adreses no pakalpojuma Google Pay.
-
-Lai mainītu šo iestatījumu, <ph name="BEGIN_LINK" />atiestatiet sinhronizāciju<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Vārds uz kartes</translation>
-<translation id="4824958205181053313">Vai atcelt sinhronizāciju?</translation>
-<translation id="4837753911714442426">Atvērt iespējas, lai izdrukātu lapu</translation>
-<translation id="4842092870884894799">Tiek rādīts paroles ģenerēšanas uznirstošais logs</translation>
-<translation id="4860895144060829044">Zvanīt</translation>
-<translation id="4866368707455379617">Nevar instalēt moduli <ph name="MODULE" /> pārlūkprogrammai Chrome.</translation>
-<translation id="4875775213178255010">Satura ieteikumi</translation>
-<translation id="4878404682131129617">Neizdevās iestatīt porta pārsūtīšanu, izmantojot starpniekserveri.</translation>
-<translation id="4880127995492972015">Notiek tulkošana...</translation>
-<translation id="4881695831933465202">Atvērt</translation>
-<translation id="488187801263602086">Faila pārdēvēšana</translation>
-<translation id="4882831918239250449">Kontrolējiet, kā jūsu pārlūkošanas vēsture tiek izmantota Meklēšanas, reklāmu un cita satura personalizēšanai</translation>
-<translation id="4883854917563148705">Pārvaldītos iestatījumus nevar atiestatīt</translation>
-<translation id="4885273946141277891">Neatbalstīts Chrome instanču skaits</translation>
-<translation id="4910889077668685004">Maksājumu lietotnes</translation>
-<translation id="4913161338056004800">Atiestatīt statistikas datus</translation>
-<translation id="4913169188695071480">Pārtraukt atsvaidzināšanu</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Saņemiet palīdzību<ph name="END_LINK" />, meklējot ierīces…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# lapa}zero{# lapas}one{# lapa}other{# lapas}}</translation>
-<translation id="4932247056774066048">Jūs izrakstāties no konta, ko pārvalda <ph name="DOMAIN_NAME" />, tāpēc jūsu Chrome dati tiks izdzēsti no šīs ierīces. Tie joprojām būs pieejami jūsu Google kontā.</translation>
-<translation id="4943703118917034429">Virtuālā realitāte</translation>
-<translation id="4943872375798546930">Nav rezultātu</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> kopīgo jūsu ekrānu</translation>
-<translation id="4961107849584082341">Tulkojiet šīs lapas saturu jebkurā valodā.</translation>
-<translation id="4962975101802056554">Atsaukt visas atļaujas, kas piešķirtas ierīcei</translation>
-<translation id="4970824347203572753">Nav pieejams jūsu atrašanās vietā</translation>
-<translation id="497421865427891073">Doties uz priekšu</translation>
-<translation id="4988210275050210843">Notiek faila lejupielāde (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Lapas</translation>
-<translation id="4994033804516042629">Nav atrasta neviena kontaktpersona</translation>
-<translation id="4996978546172906250">Kopīgošanas veids:</translation>
-<translation id="5004416275253351869">Google aktivitātes vadīklas</translation>
-<translation id="5005498671520578047">Paroles kopēšana</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> vēlas izveidot savienojumu</translation>
-<translation id="5013696553129441713">Nav jaunu ieteikumu</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Ja ir aktivizēts VR režīms, vietne var iegūt šādus datus:
-  – jūsu fiziskās īpašības, piemēram, augumu.
-
-Aktivizējiet VR režīmu tikai tad, ja esat pārliecināts, ka šī vietne ir uzticama.</translation>
+<translation id="2930742481329940825">Izmantojot funkciju “Pieskarties, lai meklētu”, atlasītais vārds tiek nosūtīts pakalpojumam Brave Software meklēšana, pievienojot pašreiz skatīto lapu kā kontekstu. Varat to izslēgt lapā <ph name="BEGIN_LINK"/>Iestatījumi<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Atļaut</translation>
-<translation id="5040262127954254034">Konfidencialitāte</translation>
-<translation id="5048398596102334565">Atļaut vietnēm piekļūt kustību sensoriem (ieteicams)</translation>
-<translation id="5063480226653192405">Lietojums</translation>
-<translation id="5087580092889165836">Pievienot karti</translation>
-<translation id="5100237604440890931">Sakļauts — noklikšķiniet, lai izvērstu.</translation>
-<translation id="510275257476243843">Atlikusi 1 h</translation>
-<translation id="5123685120097942451">Inkognito cilne</translation>
-<translation id="5127805178023152808">Sinhronizācija izslēgta</translation>
-<translation id="5129038482087801250">Instalēt tīmekļa lietotni</translation>
-<translation id="5132942445612118989">Sinhronizējiet paroles, vēsturi un citu saturu visās ierīcēs</translation>
-<translation id="5139940364318403933">Uzzināt, kā izmantot Google disku</translation>
-<translation id="515227803646670480">Saglabāto datu notīrīšana</translation>
-<translation id="5152843274749979095">Nav instalēta neviena atbalstīta lietotne</translation>
-<translation id="5161254044473106830">Jānorāda nosaukums</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 lejupielāde neizdevās.}zero{# lejupielādes neizdevās.}one{# lejupielāde neizdevās.}other{# lejupielādes neizdevās.}}</translation>
-<translation id="5170568018924773124">Rādīt mapē</translation>
-<translation id="5184329579814168207">Atvērt pārlūkā Chrome</translation>
-<translation id="5193988420012215838">Kopēts jūsu starpliktuvē</translation>
-<translation id="5197729504361054390">Atlasīto kontaktpersonu dati tiks kopīgoti ar vietni <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Darba profils</translation>
-<translation id="5210286577605176222">Pāriet uz iepriekšējo cilni</translation>
-<translation id="5210365745912300556">Aizvērt cilni</translation>
-<translation id="5224771365102442243">Ar video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> vēlas meklēt tuvumā esošas Bluetooth ierīces. Ir atrastas šīs ierīces:</translation>
-<translation id="5233638681132016545">Jauna cilne</translation>
-<translation id="526421993248218238">Šo lapu nevar ielādēt</translation>
-<translation id="5271967389191913893">Ierīcē nevar atvērt lejupielādējamo saturu.</translation>
-<translation id="528192093759286357">Lai izietu no pilnekrāna režīma, velciet no augšas un pieskarieties pogai Atpakaļ.</translation>
-<translation id="5292796745632149097">Sūtīt uz:</translation>
-<translation id="5300589172476337783">Rādīt</translation>
-<translation id="5301954838959518834">Labi, sapratu</translation>
-<translation id="5304593522240415983">Šis lauks nevar būt tukšs.</translation>
-<translation id="5307446750509046227">Notīrīt vietnes krātuvi</translation>
-<translation id="5308380583665731573">Pievienošana</translation>
-<translation id="5313967007315987356">Pievienot vietni</translation>
-<translation id="5317780077021120954">Saglabāt</translation>
-<translation id="5324858694974489420">Vecāku iestatījumi</translation>
-<translation id="5327248766486351172">Nosaukums</translation>
-<translation id="5335288049665977812">Atļaut vietnēm izmantot JavaScript (ieteicams)</translation>
-<translation id="5342314432463739672">Atļauju pieprasījumi</translation>
-<translation id="5357811892247919462">Saņemta cilne</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> atvērta cilne. Pieskarieties, lai pārslēgtu cilnes.}zero{<ph name="OPEN_TABS_MANY" /> atvērtu ciļņu. Pieskarieties, lai pārslēgtu cilnes.}one{<ph name="OPEN_TABS_MANY" /> atvērta cilne. Pieskarieties, lai pārslēgtu cilnes.}other{<ph name="OPEN_TABS_MANY" /> atvērtas cilnes. Pieskarieties, lai pārslēgtu cilnes.}}</translation>
-<translation id="5391532827096253100">Savienojums ar šo vietni nav drošs. Vietnes informācija</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(un vēl 1)}zero{(un vēl #)}one{(un vēl #)}other{(un vēl #)}}</translation>
-<translation id="5400569084694353794">Izmantojot šo lietojumprogrammu, jūs piekrītat Chrome <ph name="BEGIN_LINK1" />pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1" /> un <ph name="BEGIN_LINK2" />konfidencialitātes paziņojumam<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Nosaukumi</translation>
-<translation id="5403644198645076998">Atļaut apmeklēt tikai konkrētas vietnes</translation>
-<translation id="5414836363063783498">Notiek verifikācija...</translation>
-<translation id="5423934151118863508">Šeit tiks parādītas jūsu visvairāk apmeklētās lapas.</translation>
-<translation id="5424588387303617268">Pieejami <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Rediģēt paroli</translation>
-<translation id="5433691172869980887">Lietotājvārds ir nokopēts.</translation>
-<translation id="543509235395288790">Notiek <ph name="COUNT" /> faila(-u) lejupielāde (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Pāriet uz adreses joslu</translation>
-<translation id="5447201525962359567">Visa vietnes krātuve, tostarp sīkfaili un citi lokāli saglabāti dati</translation>
-<translation id="5447765697759493033">Šī vietne netiks tulkota</translation>
-<translation id="545042621069398927">Lejupielāde tiek paātrināta.</translation>
-<translation id="5456381639095306749">Lejupielādēt lapu</translation>
-<translation id="5475862044948910901">Vai sākt papildinātās realitātes sesiju?</translation>
-<translation id="548278423535722844">Atvērt karšu lietotnē</translation>
-<translation id="5487521232677179737">Notīrīt datus</translation>
-<translation id="5494752089476963479">Bloķēt reklāmas vietnēs, kurās tiek rādītas traucējošas vai maldinošas reklāmas</translation>
-<translation id="5500777121964041360">Tas var nebūt pieejams jūsu atrašanās vietā</translation>
-<translation id="5512137114520586844">Šo kontu pārvalda <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Atspējoja šīs ierīces administrators</translation>
-<translation id="5515439363601853141">Atbloķējiet, lai skatītu paroli</translation>
-<translation id="5516455585884385570">Atvērt paziņojumu iestatījumus</translation>
-<translation id="5517095782334947753">Ir pieejamas grāmatzīmes, vēsture, paroles un citi iestatījumi no konta <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Novirzīšana ir bloķēta.</translation>
-<translation id="5527082711130173040">Lai meklētu ierīces, pārlūkam Chrome ir nepieciešama piekļuve atrašanās vietas datiem. <ph name="BEGIN_LINK1" />Atjauniniet atļaujas<ph name="END_LINK1" />. Piekļuve atrašanās vietas datiem ir arī <ph name="BEGIN_LINK2" />izslēgta šai ierīcei<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Vaicāt, pirms atļaut vietnēm lasīt tekstu un attēlus no starpliktuves (ieteicams)</translation>
-<translation id="5530766185686772672">Aizvērt inkognito cilnes</translation>
-<translation id="5534334044554683961">Ja ir aktivizēts VR režīms, vietne var iegūt šādus datus:
-  – jūsu fiziskās īpašības, piemēram, augumu;
-  – telpas izkārtojumu.
-
-Aktivizējiet VR režīmu tikai tad, ja esat pārliecināts, ka šī vietne ir uzticama.</translation>
-<translation id="5534640966246046842">Vietne ir nokopēta.</translation>
-<translation id="5556459405103347317">Pārlādēt</translation>
-<translation id="5561549206367097665">Tiek gaidīts savienojums ar tīklu…</translation>
-<translation id="557283862590186398">Pārlūkam Chrome ir nepieciešama atļauja piekļūt jūsu mikrofonam šajā vietnē.</translation>
-<translation id="55737423895878184">Atrašanās vietas noteikšana un paziņojumi ir atļauti.</translation>
-<translation id="5578795271662203820">Meklēt šo attēlu ar <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Jūs jebkurā laikā <ph name="BEGIN_LINK1" />iestatījumos<ph name="END_LINK1" /> varat izvēlēties, ko sinhronizēt.</translation>
-<translation id="5595485650161345191">Rediģēt adresi</translation>
-<translation id="5596627076506792578">Citas opcijas</translation>
-<translation id="5599455543593328020">Inkognito režīms</translation>
-<translation id="5620928963363755975">Atrodiet savus failus un lapas sadaļā Lejupielādes, nospiežot pogu Vairāk opciju</translation>
-<translation id="5626134646977739690">Nosaukums:</translation>
-<translation id="5639724618331995626">Atļaut apmeklēt visas vietnes</translation>
-<translation id="5648166631817621825">Pēdējās 7 dienas</translation>
-<translation id="5649053991847567735">Automātiskās lejupielādes</translation>
-<translation id="5655963694829536461">Meklējiet savas lejupielādes</translation>
-<translation id="5659593005791499971">E-pasts</translation>
-<translation id="5665379678064389456">Izveidojiet pasākumu lietotnē <ph name="APP_NAME" />.</translation>
-<translation id="5668404140385795438">Ignorēt vietnes pieprasījumu, lai novērstu tuvināšanu</translation>
-<translation id="5677928146339483299">Bloķēts</translation>
-<translation id="5684874026226664614">Hmm... Šo lapu nevarēja iztulkot.</translation>
-<translation id="5686790454216892815">Faila nosaukums ir pārāk garš</translation>
-<translation id="5689516760719285838">Atrašanās vieta</translation>
-<translation id="569536719314091526">Tulkojiet šīs lapas saturu jebkurā valodā, izmantojot pogu Vairāk opciju.</translation>
-<translation id="572328651809341494">Nesen atvērtas cilnes</translation>
-<translation id="5726692708398506830">Palielināt visu lapas saturu</translation>
-<translation id="5748802427693696783">Notika pārslēgšanās uz standarta cilnēm</translation>
-<translation id="5749068826913805084">Chrome ir nepieciešama piekļuve krātuvei, lai varētu lejupielādēt failus.</translation>
-<translation id="5763382633136178763">Inkognito režīma cilnes</translation>
-<translation id="5763514718066511291">Pieskarieties, lai kopētu šīs lietotnes URL.</translation>
-<translation id="5765780083710877561">Apraksts:</translation>
-<translation id="5793665092639000975">Izmantotais apjoms: <ph name="SPACE_USED" /> no <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google var izmantot jūsu vēsturi, lai personalizētu Meklēšanu, reklāmas un citus Google pakalpojumus.</translation>
-<translation id="5804241973901381774">Atļaujas</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{pirms # stundas}zero{pirms # stundām}one{pirms # stundas}other{pirms # stundām}}</translation>
-<translation id="5810288467834065221">Autortiesības: <ph name="YEAR" /> Google LLC. Visas tiesības paturētas.</translation>
-<translation id="5817918615728894473">Savienot pārī</translation>
-<translation id="583281660410589416">Nezināms</translation>
-<translation id="5833984609253377421">Kopīgot saiti</translation>
-<translation id="5836192821815272682">Lejupielādē Chrome atjauninājumu…</translation>
-<translation id="5853623416121554550">apturēta</translation>
-<translation id="5854790677617711513">Vecāki par 30 dienām</translation>
-<translation id="5858741533101922242">Chrome nevar ieslēgt Bluetooth adapteri.</translation>
-<translation id="5860033963881614850">Izsl.</translation>
-<translation id="5862731021271217234">Lai varētu piekļūt cilnēm no citām ierīcēm, ieslēdziet sinhronizāciju.</translation>
-<translation id="5864174910718532887">Detalizēta informācija: kārtota pēc vietnes nosaukuma</translation>
-<translation id="5864419784173784555">Tiek gaidīta cita lejupielāde…</translation>
-<translation id="5865733239029070421">Automātiski sūtīt lietojuma statistiku un avāriju pārskatus Google serveriem</translation>
-<translation id="5869522115854928033">Saglabātās paroles</translation>
-<translation id="5902828464777634901">Visi šīs vietnes saglabātie lokālie dati, tostarp sīkfaili, tiks dzēsti.</translation>
-<translation id="5916664084637901428">Iesl.</translation>
-<translation id="5919204609460789179">Lai sāktu sinhronizēšanu, atjauniniet <ph name="PRODUCT_NAME" /></translation>
-<translation id="5937580074298050696">Saglabāts: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Atiestatīt</translation>
-<translation id="5942872142862698679">Tiek izmantota meklētājprogramma Google</translation>
-<translation id="5952764234151283551">Sūta Google serveriem tās lapas URL, kuru mēģināt sasniegt</translation>
-<translation id="5956665950594638604">Atvērt Chrome palīdzības centru jaunā cilnē</translation>
-<translation id="5958275228015807058">Atrodiet savus failus un lapas sadaļā Lejupielādes</translation>
-<translation id="5962718611393537961">Pieskarties, lai sakļautu</translation>
-<translation id="6000066717592683814">Arī turpmāk izmantot Google</translation>
-<translation id="6005538289190791541">Ieteiktā parole</translation>
-<translation id="6036057147555329831">Citi ICU</translation>
-<translation id="6039379616847168523">Pāriet uz nākamo cilni</translation>
-<translation id="6040143037577758943">Aizvērt</translation>
-<translation id="6042308850641462728">Vairāk</translation>
-<translation id="604996488070107836">Neizdevās lejupielādēt failu <ph name="FILE_NAME" />, jo radās nezināma kļūda.</translation>
-<translation id="605721222689873409">GG</translation>
-<translation id="6064125863973209585">Pabeigtās lejupielādes</translation>
-<translation id="6075798973483050474">Sākumlapas rediģēšana</translation>
-<translation id="60923314841986378">Atlikušas <ph name="HOURS" /> h</translation>
-<translation id="6108923351542677676">Notiek iestatīšana...</translation>
-<translation id="6111020039983847643">Izmantotie dati</translation>
-<translation id="6112702117600201073">Lapas atsvaidzināšana</translation>
-<translation id="6127379762771434464">Vienums ir noņemts</translation>
-<translation id="6140912465461743537">Valsts/reģions</translation>
-<translation id="614940544461990577">Veiciet tālāk norādītās darbības.</translation>
-<translation id="6154478581116148741">Lai eksportētu paroles no šīs ierīces, sadaļā “Iestatījumi” ieslēdziet ekrāna bloķēšanu.</translation>
-<translation id="6159335304067198720">Datu lietojuma samazinājums: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Uzziniet vairāk</translation>
-<translation id="6177111841848151710">Bloķēta pašreizējai meklētājprogrammai</translation>
-<translation id="6181444274883918285">Pievienot vietnes izņēmumu</translation>
-<translation id="6192333916571137726">Lejupielāde fails</translation>
-<translation id="6192792657125177640">Izņēmumi</translation>
-<translation id="6194112207524046168">Lai atļautu pārlūkprogrammai Chrome piekļūt jūsu kamerai, ieslēdziet kameru arī <ph name="BEGIN_LINK" />Android iestatījumos<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Bloķēt trešo pušu sīkfailus</translation>
-<translation id="6206551242102657620">Savienojums ir drošs. Vietnes informācija</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> nav mana e-pasta adrese</translation>
-<translation id="6221633008163990886">Atbloķējiet, lai eksportētu paroles.</translation>
+<translation id="1406000523432664303">“Nesekot”</translation>
 <translation id="6232535412751077445">Iespējojot funkciju “Nesekot”, jūsu pārlūkošanas datplūsmā tiks iekļauts pieprasījums. Rezultāts būs atkarīgs no tā, vai vietne nodrošinās atbildi uz pieprasījumu un kā pieprasījums tiks interpretēts.
 
 Piemēram, dažas vietnes, reaģējot uz šo pieprasījumu, var rādīt jums reklāmas, kuru pamatā nav citas jūsu apmeklētās vietnes. Tomēr daudzas vietnes apkopos un izmantos jūsu pārlūkošanas datus, piemēram, lai uzlabotu drošību, nodrošinātu saturu, reklāmas un ieteikumus un ģenerētu pārskatu statistiku.</translation>
-<translation id="624789221780392884">Var veikt atjaunināšanu</translation>
-<translation id="6255999984061454636">Satura ieteikumi</translation>
-<translation id="6277522088822131679">Drukājot lapu, radās problēma. Lūdzu, mēģiniet vēlreiz.</translation>
-<translation id="6295158916970320988">Visas vietnes</translation>
-<translation id="629730747756840877">Konts</translation>
-<translation id="6303969859164067831">Izrakstīties un izslēgt sinhronizēšanu</translation>
-<translation id="6316139424528454185">Neatbalstīta Android versija</translation>
-<translation id="6320088164292336938">Vibrācija</translation>
-<translation id="6324034347079777476">Android sistēmas sinhronizācija atspējota</translation>
-<translation id="6333140779060797560">Kopīgot, izmantojot <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Šifrēšana</translation>
-<translation id="6341580099087024258">Vaicāt, kur saglabāt failus</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}zero{<ph name="SHIPPING_ADDRESS_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Vai noņemt ieteikumu no vēstures?</translation>
-<translation id="6369229450655021117">Šeit varat veikt meklēšanu tīmeklī, kopīgot saturu ar draugiem un skatīt atvērtās lapas.</translation>
-<translation id="6378173571450987352">Detalizēta informācija: kārtota pēc izmantoto datu apjoma</translation>
-<translation id="6381421346744604172">Aptumšot vietnes</translation>
-<translation id="6388207532828177975">Notīrīt un atiestatīt</translation>
-<translation id="6393863479814692971">Pārlūkam Chrome ir nepieciešama atļauja piekļūt jūsu kamerai un mikrofonam šajā vietnē.</translation>
-<translation id="6395288395575013217">SAITE</translation>
-<translation id="6404511346730675251">Rediģēt grāmatzīmi</translation>
-<translation id="6406506848690869874">Sinhronizācija</translation>
-<translation id="641643625718530986">Drukāt...</translation>
-<translation id="6416782512398055893">Lejupielādēts: <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Iztulkojiet tīmekli</translation>
-<translation id="6433501201775827830">Meklētājprogrammas izvēle</translation>
-<translation id="6437478888915024427">Lapas informācija</translation>
-<translation id="6441734959916820584">Vārds ir pārāk garš</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# attēls}zero{# attēli}one{# attēls}other{# attēli}}</translation>
-<translation id="6447842834002726250">Sīkfaili</translation>
-<translation id="6461962085415701688">Nevar atvērt failu.</translation>
-<translation id="6464977750820128603">Varat skatīt pārlūkā Chrome apmeklētās vietnes un iestatīt tām taimerus.\n\nGoogle saņem informāciju par vietnēm, kurām iestatāt taimerus, kā arī šo vietņu apmeklēšanas ilgumu. Šī informācija tiek izmantota, lai uzlabotu Digitālo labjutību.</translation>
-<translation id="6475951671322991020">Lejupielādēt videoklipu</translation>
-<translation id="6482749332252372425">Neizdevās lejupielādēt failu <ph name="FILE_NAME" />, jo krātuvē nav pietiekami daudz vietas.</translation>
-<translation id="6496823230996795692">Lai pirmo reizi izmantotu lietotni <ph name="APP_NAME" />, lūdzu, izveidojiet savienojumu ar internetu.</translation>
-<translation id="6508722015517270189">Restartējiet pārlūku Chrome</translation>
-<translation id="6527303717912515753">Kopīgot</translation>
-<translation id="6532866250404780454">Netiks rādītas vietnes, ko apmeklējat pārlūkā Chrome. Tiks izdzēsti visi vietņu taimeri.</translation>
-<translation id="6534565668554028783">Google pārāk ilgi nereaģēja</translation>
-<translation id="6538442820324228105">Lejupielādēts: <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Radās kļūda. Vēlāk mēģiniet vēlreiz.</translation>
-<translation id="654446541061731451">Atlasiet cilni, ko kopīgot.</translation>
-<translation id="6545017243486555795">Notīrīt visus datus</translation>
-<translation id="6545864417968258051">Bluetooth meklēšana</translation>
-<translation id="6560414384669816528">Meklēšana, izmantojot Sogou</translation>
-<translation id="6566259936974865419">Pārlūkā Chrome esat ietaupījis <ph name="GIGABYTES" /> GB.</translation>
-<translation id="6573096386450695060">Vienmēr atļaut</translation>
-<translation id="6573431926118603307">Šeit būs redzamas cilnes, kuras esat atvēris pārlūkā Chrome citās ierīcēs.</translation>
-<translation id="6583199322650523874">Pievienot pašreizējo lapu grāmatzīmēm</translation>
-<translation id="6593061639179217415">Vietne datoriem</translation>
-<translation id="6600954340915313787">Nokopēta pārlūkā Chrome.</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Aizsargāts saturs</translation>
-<translation id="6627583120233659107">Rediģēt mapi</translation>
-<translation id="6643016212128521049">Notīrīt</translation>
-<translation id="6643649862576733715">Kārtot pēc saglabāto datu apjoma</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}zero{<ph name="CONTACT_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Priekšskatīt attēlu <ph name="BEGIN_NEW" />Jauns<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Lai meklētu ierīces, pārlūkam Chrome ir nepieciešama piekļuve atrašanās vietai. <ph name="BEGIN_LINK" />Atjauniniet atļaujas<ph name="END_LINK" />.</translation>
-<translation id="6657585470893396449">Parole</translation>
-<translation id="6659594942844771486">Cilne</translation>
-<translation id="666731172850799929">Atvērt lietotnē <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Chrome konfidencialitātes paziņojums</translation>
-<translation id="6676840375528380067">Vai dzēst jūsu Chrome datus no šīs ierīces?</translation>
-<translation id="6697492270171225480">Ja lapu neizdotas atrast, rāda ieteikumus par līdzīgām lapām</translation>
-<translation id="6697947395630195233">Pārlūkam Chrome ir nepieciešama piekļuve jūsu atrašanās vietas datiem, lai varētu tos kopīgot ar šo vietni.</translation>
-<translation id="6698801883190606802">Pārvaldīt sinhronizētos datus</translation>
-<translation id="6699370405921460408">Google serveri optimizēs jūsu apmeklētās lapas.</translation>
-<translation id="6706288973712894588">Jūs šobrīd esat bezsaistē.\n<ph name="BEGIN_LINK" />Izpētiet savu bezsaistes plūsmu.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Ziņas</translation>
-<translation id="6710213216561001401">Iepriekšējais</translation>
-<translation id="671481426037969117">Jūsu lietotnes <ph name="FQDN" /> taimera laiks ir beidzies. Tas atkal sāksies rīt.</translation>
-<translation id="6738867403308150051">Notiek lejupielāde…</translation>
-<translation id="6746124502594467657">Pārvietot uz leju</translation>
-<translation id="6766622839693428701">Velciet uz leju, lai aizvērtu.</translation>
-<translation id="6766758767654711248">Pieskarieties, lai atvērtu vietni</translation>
-<translation id="6767294960381293877">Ierīču saraksts, ar ko kopīgot cilni, ir atvērts pusekrāna augstumā.</translation>
-<translation id="6782111308708962316">Neļaut trešo pušu vietnēm saglabāt un nolasīt sīkfailu datus</translation>
-<translation id="6790428901817661496">Atskaņot</translation>
-<translation id="6811034713472274749">Lapu var skatīt</translation>
-<translation id="6818926723028410516">Vienumu atlase</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Tulkot</translation>
-<translation id="6845325883481699275">Palīdzēt uzlabot Chrome drošību</translation>
-<translation id="6846298663435243399">Notiek ielāde…</translation>
-<translation id="6850409657436465440">Joprojām notiek lejupielāde</translation>
-<translation id="6850830437481525139">Aizvērtas <ph name="TAB_COUNT" /> cilnes</translation>
-<translation id="6864459304226931083">Lejupielādēt attēlu</translation>
-<translation id="6865313869410766144">Automātiskās aizpildes veidlapas dati</translation>
-<translation id="688738109438487280">Pievienot esošos datus kontam <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Atbloķējiet, lai kopētu paroli</translation>
-<translation id="6896758677409633944">Kopēt</translation>
-<translation id="6910211073230771657">Dzēsts</translation>
-<translation id="6912998170423641340">Bloķēt vietņu piekļuvi teksta un attēlu lasīšanai no starpliktuves</translation>
-<translation id="6914783257214138813">Jūsu paroles būs redzamas ikvienam, kas var skatīt eksportēto failu.</translation>
-<translation id="6942665639005891494">Noklusējuma lejupielādes vietu var mainīt jebkurā laikā, izmantojot izvēlnes Iestatījumi opciju.</translation>
-<translation id="6945221475159498467">Atlasīt</translation>
-<translation id="6963642900430330478">Šī lapa ir bīstama. Vietnes informācija</translation>
-<translation id="6963766334940102469">Dzēst grāmatzīmes</translation>
-<translation id="6965382102122355670">Labi</translation>
-<translation id="6979737339423435258">Visā periodā</translation>
-<translation id="6981982820502123353">Pieejamība</translation>
-<translation id="6989267951144302301">Nevarēja lejupielādēt</translation>
-<translation id="6990079615885386641">Iegūstiet lietotni Google Play veikalā: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Jautāt, pirms atļaut vietnēm izmantot jūsu mikrofonu (ieteicams)</translation>
-<translation id="7015203776128479407">Sākotnējā sinhronizācijas iestatīšana netika pabeigta. Sinhronizācija ir izslēgta.</translation>
-<translation id="7016516562562142042">Atļauta pašreizējai meklētājprogrammai</translation>
-<translation id="7022756207310403729">Atvērt pārlūkā</translation>
-<translation id="702463548815491781">Ieteicams, ja ir ieslēgta lietotne TalkBack vai slēdžu piekļuves funkcija.</translation>
-<translation id="7029809446516969842">Paroles</translation>
-<translation id="7053983685419859001">Bloķēt</translation>
-<translation id="7055152154916055070">Novirzīšana ir bloķēta:</translation>
-<translation id="7063006564040364415">Nevarēja izveidot savienojumu ar sinhronizācijas serveri.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Atlasīts 1 vienums}zero{Atlasīti # vienumi}one{Atlasīts # vienums}other{Atlasīti # vienumi}}</translation>
-<translation id="7071521146534760487">Pārvaldīt kontu</translation>
-<translation id="7077143737582773186">SD karte</translation>
-<translation id="7087918508125750058">Atlasīti vienumi: <ph name="ITEM_COUNT" />. Opcijas ir pieejamas ekrāna augšdaļā.</translation>
-<translation id="7121362699166175603">Notīra vēsturi un automātiskās pabeigšanas datus adreses joslā. Jūsu Google kontam var būt cita veida pārlūkošanas vēstures dati vietnē <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Atļaut pašreizējai meklētājprogrammai</translation>
-<translation id="7138678301420049075">Cits</translation>
-<translation id="7141896414559753902">Neļaut vietnēm novirzīt un rādīt uznirstošos elementus (ieteicams)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Ielādēt sākotnējo lapu<ph name="END_LINK" /> no <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Pēdējās 24 stundas</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Vēlāk varēsiet to mainīt iestatījumos</translation>
-<translation id="7180611975245234373">Atsvaidzināt</translation>
-<translation id="7189372733857464326">Gaida, kad tiks pabeigta Google Play pakalpojumu atjaunināšana</translation>
-<translation id="7191430249889272776">Cilne tika atvērta fonā.</translation>
-<translation id="723171743924126238">Atlasīt attēlus</translation>
-<translation id="7233236755231902816">Lai skatītu tīmekli savā valodā, iegūstiet jaunāko Chrome versiju</translation>
-<translation id="7243308994586599757">Opcijas, kas pieejamas ekrāna apakšējā daļā</translation>
-<translation id="7248069434667874558">Ierīcē <ph name="TARGET_DEVICE_NAME" /> ieslēdziet Chrome sinhronizāciju</translation>
-<translation id="7250468141469952378">Atlasīti vienumi: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Bloķēta vietne</translation>
-<translation id="7290209999329137901">Pārdēvēšana nav pieejama</translation>
-<translation id="7291387454912369099">Asistenta aktivizēta norēķināšanās</translation>
-<translation id="7293171162284876153">Lai sāktu sinhronizāciju, ieslēdziet iestatījumu “Jūsu Chrome datu sinhronizācija”.</translation>
-<translation id="729975465115245577">Ierīcē nav lietotnes, kurā uzglabāt paroļu failu.</translation>
-<translation id="7302081693174882195">Detalizēta informācija: kārtota pēc ietaupīto datu apjoma</translation>
-<translation id="7328017930301109123">Vienkāršotajā režīmā Chrome ielādē lapas ātrāk un patērē pat par 60 procentiem mazāk datu.</translation>
-<translation id="7333031090786104871">Joprojām notiek iepriekšējās vietnes pievienošana</translation>
-<translation id="7352939065658542140">VIDEOKLIPS</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Kopīgot 1 atlasīto vienumu}zero{Kopīgot # atlasītos vienumus}one{Kopīgot # atlasīto vienumu}other{Kopīgot # atlasītos vienumus}}</translation>
 <translation id="7359002509206457351">Piekļuve maksājumu veidiem</translation>
+<translation id="8026334261755873520">Notīrīt pārlūkošanas datus</translation>
+<translation id="1291207594882862231">Dzēst vēsturi, sīkfailus, vietnes datus, kešatmiņu…</translation>
+<translation id="7814200940910057384">Brave dati tika notīrīti</translation>
+<translation id="1664855196866195614">Atlasītie dati ir noņemti no pārlūka Brave un jūsu sinhronizētajām ierīcēm.
+
+Jūsu Brave Software kontam vietnē <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> var būt citu veidu pārlūkošanas vēstures dati, piemēram, meklēšanas vaicājumi un darbības citos Brave Software pakalpojumos.</translation>
+<translation id="4699172675775169585">Kešatmiņā ievietotie attēli un faili</translation>
+<translation id="2496180316473517155">Pārlūkošanas vēsture</translation>
+<translation id="2546283357679194313">Sīkfaili un vietņu dati</translation>
+<translation id="8662811608048051533">Jūs tiksiet izrakstīts no lielākās daļas vietņu.</translation>
+<translation id="8218628800671693884">Jūs tiksiet izrakstīts no lielākās daļas vietņu. Jūs netiksiet izrakstīts no Brave Software konta.</translation>
+<translation id="2017836877785168846">Notīra vēsturi un automātiskās pabeigšanas ierakstus adreses joslā.</translation>
+<translation id="8096327394278038498">Notīra vēsturi un automātiskās pabeigšanas datus adreses joslā. Jūsu Brave Software kontam var būt cita veida pārlūkošanas vēstures dati vietnē <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Notīra vēsturi no visām ierīcēm, kurās esat pierakstījies. Jūsu Brave Software kontam vietnē <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> var būt citu veidu pārlūkošanas vēstures dati.</translation>
+<translation id="5869522115854928033">Saglabātās paroles</translation>
+<translation id="6865313869410766144">Automātiskās aizpildes veidlapas dati</translation>
+<translation id="7562080006725997899">Notiek pārlūkošanas datu notīrīšana</translation>
+<translation id="5487521232677179737">Notīrīt datus</translation>
+<translation id="7498271377022651285">Lūdzu, uzgaidiet...</translation>
+<translation id="784934925303690534">Laika periods</translation>
+<translation id="1718835860248848330">Pēdējā stunda</translation>
+<translation id="7149893636342594995">Pēdējās 24 stundas</translation>
+<translation id="5648166631817621825">Pēdējās 7 dienas</translation>
+<translation id="8571213806525832805">Pēdējās 4 nedēļas</translation>
+<translation id="5854790677617711513">Vecāki par 30 dienām</translation>
+<translation id="6979737339423435258">Visā periodā</translation>
+<translation id="982182592107339124">Tādējādi tiks dzēsti dati no visām vietnēm, tostarp:</translation>
+<translation id="6643016212128521049">Notīrīt</translation>
+<translation id="7641339528570811325">Pārlūkošanas datu notīrīšana…</translation>
+<translation id="1670399744444387456">Pamata</translation>
+<translation id="3245261285041759672">Jūsu Brave Software kontam var būt citu veidu pārlūkošanas vēstures dati vietnē <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Bloķēta vietne</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> vienumi tika izdzēsti</translation>
+<translation id="1121094540300013208">Lietojuma un avāriju pārskati</translation>
+<translation id="9079153198295609735">Automātiski sūtīt lietošanas statistiku un avāriju pārskatus uzņēmumam Brave Software</translation>
+<translation id="6981982820502123353">Pieejamība</translation>
+<translation id="2387895666653383613">Teksta mērogošana</translation>
+<translation id="2321958826496381788">Velciet slīdni, kamēr varat ērti lasīt. Pēc dubultskāriena rindkopai tekstam ir jābūt vismaz šādā lielumā.</translation>
+<translation id="3895926599014793903">Tālummaiņas piespiedu iespējošana</translation>
+<translation id="5668404140385795438">Ignorēt vietnes pieprasījumu, lai novērstu tuvināšanu</translation>
+<translation id="4149994727733219643">Vienkāršots tīmekļa lapu skatījums</translation>
+<translation id="9100505651305367705">Piedāvāt rādīt rakstus vienkāršotā skatā, ja tāds tiek atbalstīts</translation>
+<translation id="1409426117486808224">Vienkāršots atvērtu ciļņu skatījums</translation>
+<translation id="702463548815491781">Ieteicams, ja ir ieslēgta lietotne TalkBack vai slēdžu piekļuves funkcija.</translation>
+<translation id="8284326494547611709">Paraksti</translation>
+<translation id="4165986682804962316">Vietnes iestatījumi</translation>
+<translation id="6295158916970320988">Visas vietnes</translation>
+<translation id="8380167699614421159">Šajā vietnē tiek rādītas traucējošas vai maldinošas reklāmas</translation>
+<translation id="1919345977826869612">Reklāmas</translation>
+<translation id="410351446219883937">Automātiskā atskaņošana</translation>
+<translation id="6447842834002726250">Sīkfaili</translation>
+<translation id="6196640612572343990">Bloķēt trešo pušu sīkfailus</translation>
+<translation id="6782111308708962316">Neļaut trešo pušu vietnēm saglabāt un nolasīt sīkfailu datus</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Uznirstošie elem. un novirzīšana</translation>
+<translation id="4751476147751820511">Kustību vai gaismas sensori</translation>
+<translation id="1717218214683051432">Kustību sensori</translation>
+<translation id="2091887806945687916">Signāls</translation>
+<translation id="2586657967955657006">Starpliktuve</translation>
+<translation id="6320088164292336938">Vibrācija</translation>
+<translation id="4226663524361240545">Saņemot paziņojumu, ierīce var vibrēt.</translation>
+<translation id="1446450296470737166">Pilnīga MIDI ierīču pārvaldība</translation>
+<translation id="3744111561329211289">Sinhronizācija fonā</translation>
+<translation id="5649053991847567735">Automātiskās lejupielādes</translation>
+<translation id="6181444274883918285">Pievienot vietnes izņēmumu</translation>
+<translation id="5313967007315987356">Pievienot vietni</translation>
+<translation id="1369915414381695676">Tika pievienota vietne <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Atļaut automātisku atskaņošanu videoklipiem ar izslēgtu skaņu konkrētā vietnē.</translation>
+<translation id="2621115761605608342">Atļaut JavaScript konkrētai vietnei</translation>
+<translation id="8801436777607969138">Bloķēt JavaScript konkrētai vietnei.</translation>
+<translation id="8372893542064058268">Atļaut sinhronizāciju fonā konkrētai vietnei</translation>
+<translation id="358794129225322306">Atļaut vietnei automātiski lejupielādēt vairākus failus.</translation>
+<translation id="4008040567710660924">Atļaut sīkfailus konkrētai vietnei.</translation>
+<translation id="8958424370300090006">Bloķēt sīkfailus konkrētai vietnei.</translation>
+<translation id="7882806643839505685">Atļaut skaņu konkrētai vietnei</translation>
+<translation id="4468959413250150279">Izslēgt skaņu noteiktai vietnei</translation>
+<translation id="1994173015038366702">Vietnes URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Lietojums</translation>
+<translation id="5804241973901381774">Atļaujas</translation>
+<translation id="4278390842282768270">Atļauts</translation>
+<translation id="5677928146339483299">Bloķēts</translation>
+<translation id="1984937141057606926">Atļauti, izņemot trešo pušu sīkfailus</translation>
+<translation id="7423098979219808738">Vispirms jautāt</translation>
+<translation id="8116925261070264013">Izslēgta skaņa</translation>
+<translation id="8300705686683892304">Pārvalda lietotne</translation>
+<translation id="6192792657125177640">Izņēmumi</translation>
+<translation id="257931822824936280">Izvērsts — noklikšķiniet, lai sakļautu.</translation>
+<translation id="5100237604440890931">Sakļauts — noklikšķiniet, lai izvērstu.</translation>
+<translation id="857943718398505171">Atļauta (ieteicams)</translation>
+<translation id="2913331724188855103">Atļaut vietnēm saglabāt un lasīt sīkfailu datus (ieteicams)</translation>
+<translation id="7445411102860286510">Atļaut vietnēm automātiski atskaņot videoklipus ar izslēgtu skaņu (ieteicams)</translation>
+<translation id="5335288049665977812">Atļaut vietnēm izmantot JavaScript (ieteicams)</translation>
+<translation id="5527111080432883924">Vaicāt, pirms atļaut vietnēm lasīt tekstu un attēlus no starpliktuves (ieteicams)</translation>
+<translation id="6912998170423641340">Bloķēt vietņu piekļuvi teksta un attēlu lasīšanai no starpliktuves</translation>
+<translation id="7423538860840206698">Bloķēta starpliktuves satura lasīšana</translation>
+<translation id="3955193568934677022">Atļaut vietnēm atskaņot aizsargātu saturu (ieteicams)</translation>
+<translation id="445467742685312942">Ļaut vietnēm atskaņot aizsargātu saturu</translation>
+<translation id="2107397443965016585">Vaicāt, pirms atļaut vietnēm atskaņot aizsargātu saturu (ieteicams)</translation>
+<translation id="2910701580606108292">Jautāt, pirms atļaut vietnēm atskaņot aizsargātu saturu</translation>
+<translation id="757524316907819857">Neļaut vietnēm atskaņot aizsargātu saturu</translation>
+<translation id="3277252321222022663">Atļaut vietnēm piekļūt sensoriem (ieteicams)</translation>
+<translation id="5048398596102334565">Atļaut vietnēm piekļūt kustību sensoriem (ieteicams)</translation>
+<translation id="8816026460808729765">Bloķēt vietņu piekļuvi sensoriem</translation>
+<translation id="169515064810179024">Bloķēt vietņu piekļuvi kustību sensoriem</translation>
+<translation id="1660204651932907780">Atļaut vietnēm atskaņot skaņu (ieteicams)</translation>
+<translation id="3600792891314830896">Izslēgt skaņu vietnēm, kurās tiek atskaņota skaņa</translation>
+<translation id="1743802530341753419">Jautāt, pirms atļaut vietnēm izveidot savienojumu ar ierīci (ieteicams)</translation>
+<translation id="851751545965956758">Neļaut vietnēm izveidot savienojumu ar ierīci</translation>
+<translation id="7141896414559753902">Neļaut vietnēm novirzīt un rādīt uznirstošos elementus (ieteicams)</translation>
+<translation id="5494752089476963479">Bloķēt reklāmas vietnēs, kurās tiek rādītas traucējošas vai maldinošas reklāmas</translation>
+<translation id="3123473560110926937">Bloķētas dažās vietnēs</translation>
+<translation id="965817943346481315">Bloķēt, ja vietnē tiek rādītas traucējošas vai maldinošas reklāmas (ieteicams)</translation>
+<translation id="3386292677130313581">Jautāt, pirms atļaut vietnēm uzzināt jūsu atrašanās vietu (ieteicams)</translation>
+<translation id="9139068048179869749">Jautāt, pirms atļaut vietnēm sūtīt paziņojumus (ieteicams)</translation>
+<translation id="4479647676395637221">Jautāt, pirms atļaut vietnēm izmantot jūsu kameru (ieteicams)</translation>
+<translation id="6992289844737586249">Jautāt, pirms atļaut vietnēm izmantot jūsu mikrofonu (ieteicams)</translation>
+<translation id="2289270750774289114">Vaicāt, ja vietne vēlas redzēt tuvumā esošās Bluetooth ierīces (ieteicams)</translation>
+<translation id="7053983685419859001">Bloķēt</translation>
+<translation id="7128222689758636196">Atļaut pašreizējai meklētājprogrammai</translation>
+<translation id="7589445247086920869">Aizliegšana pašreizējai meklētājprogrammai</translation>
+<translation id="6388207532828177975">Notīrīt un atiestatīt</translation>
+<translation id="7999064672810608036">Vai tiešām vēlaties notīrīt visus ar šo vietni saistītos lokālos datus, tostarp sīkfailus, un atiestatīt visas atļaujas?</translation>
+<translation id="2822354292072154809">Vai tiešām vēlaties atiestatīt visas vietņu atļaujas, kas piešķirtas šim objektam: <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Saglabāto datu notīrīšana</translation>
+<translation id="5902828464777634901">Visi šīs vietnes saglabātie lokālie dati, tostarp sīkfaili, tiks dzēsti.</translation>
+<translation id="119944043368869598">Notīrīt visu</translation>
+<translation id="2490684707762498678">Pārvalda <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Atvērt paziņojumu iestatījumus</translation>
+<translation id="1404122904123200417">Iegults vietnē <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Šeit tiek rādīti tīmekļa vietņu saglabātie faili</translation>
+<translation id="4181841719683918333">Valodas</translation>
+<translation id="2647434099613338025">Pievienot valodu</translation>
+<translation id="1952172573699511566">Kad vien iespējams, vietnēs tiks rādīts teksts atlasītajā valodā.</translation>
+<translation id="8559990750235505898">Piedāvāt tulkot lapas citās valodās</translation>
+<translation id="4719927025381752090">Piedāvāt tulkot</translation>
+<translation id="8156139159503939589">Kādā valodā jūs lasāt?</translation>
+<translation id="5689516760719285838">Atrašanās vieta</translation>
+<translation id="2440823041667407902">Piekļuve atrašanās vietai</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/> ieslēdziet atļaujas pārlūkam Brave.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/> ieslēdziet atļauju pārlūkam Brave.</translation>
+<translation id="2928908108430545745">Lai atļautu pārlūkprogrammai Brave piekļūt jūsu atrašanās vietas datiem, ieslēdziet atrašanās vietas noteikšanu arī <ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Lai atļautu pārlūkprogrammai Brave piekļūt jūsu kamerai, ieslēdziet kameru arī <ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Lai atļautu pārlūkprogrammai Brave sūtīt jums paziņojumus, ieslēdziet paziņojumus arī <ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Lai atļautu pārlūkprogrammai Brave piekļūt jūsu mikrofonam, ieslēdziet mikrofonu arī <ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Piekļuve šīs ierīces atrašanās vietai ir izslēgta. Ieslēdziet to <ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Arī piekļuve šīs ierīces atrašanās vietai ir izslēgta. Ieslēdziet to <ph name="BEGIN_LINK"/>Android iestatījumos<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofons</translation>
+<translation id="1647391597548383849">Piekļuve kamerai</translation>
+<translation id="945632385593298557">Piekļuve mikrofonam</translation>
+<translation id="6612358246767739896">Aizsargāts saturs</translation>
+<translation id="885701979325669005">Krātuve</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> saglabātu datu</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Atsaukt ierīces atļauju</translation>
+<translation id="4962975101802056554">Atsaukt visas atļaujas, kas piešķirtas ierīcei</translation>
+<translation id="6545864417968258051">Bluetooth meklēšana</translation>
+<translation id="4411535500181276704">Vienkāršais režīms</translation>
+<translation id="7821588508402923572">Šeit tiks parādīts ietaupīto datu apjoms.</translation>
+<translation id="2131665479022868825">Ietaupījums: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">kopš šāda datuma: <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Vienkāršotajā režīmā Brave ielādē lapas ātrāk un patērē pat par 60 procentiem mazāk datu.</translation>
+<translation id="6159335304067198720">Datu lietojuma samazinājums: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">Saglabātie dati</translation>
+<translation id="6111020039983847643">Izmantotie dati</translation>
+<translation id="7413229368719586778">Sākuma datums: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Beigu datums: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Kārtot pēc vietnes</translation>
+<translation id="5864174910718532887">Detalizēta informācija: kārtota pēc vietnes nosaukuma</translation>
+<translation id="116280672541001035">Izmantots</translation>
+<translation id="8349013245300336738">Kārtot pēc izmantoto datu apjoma</translation>
+<translation id="6378173571450987352">Detalizēta informācija: kārtota pēc izmantoto datu apjoma</translation>
+<translation id="2631006050119455616">Saglabāts</translation>
+<translation id="6643649862576733715">Kārtot pēc saglabāto datu apjoma</translation>
+<translation id="7302081693174882195">Detalizēta informācija: kārtota pēc ietaupīto datu apjoma</translation>
+<translation id="4179980317383591987">Izmantots: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Saglabāts: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Pārējās vietnes (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Cits</translation>
+<translation id="4913161338056004800">Atiestatīt statistikas datus</translation>
+<translation id="1856325424225101786">Vai atiestatīt vienkāršoto režīmu?</translation>
+<translation id="3658159451045945436">Veicot atiestatīšanu, tiek dzēsta saglabāto datu vēsture, tostarp apmeklēto vietņu saraksts.</translation>
+<translation id="3295530008794733555">Ietaupiet laiku. Samaziniet datu lietojumu.</translation>
+<translation id="7340390500800578919">Pārlūka Brave vienkāršotajā režīmā lapas tiek ielādētas ātrāk un tiek patērēts pat par 60 procentiem mazāk datu. Lai optimizētu jūsu apmeklētās lapas, no pārlūka Brave tiek nosūtīta jūsu tīmekļa datplūsma uzņēmumam Brave Software. <ph name="BEGIN_LINK"/>Uzziniet vairāk<ph name="END_LINK"/>.</translation>
+<translation id="4538018662093857852">Ieslēgt vienkāršoto režīmu</translation>
+<translation id="4493497663118223949">Vienkāršotais režīms ir ieslēgts</translation>
+<translation id="7559975015014302720">Vienkāršotais režīms ir izslēgts</translation>
+<translation id="7606077192958116810">Vienkāršotais režīms ir ieslēgts. Pārvaldiet to iestatījumos.</translation>
+<translation id="4714588616299687897">Saglabājiet līdz pat 60% datu</translation>
+<translation id="1006927014032731288">Brave Software serveri optimizēs jūsu apmeklētās lapas.</translation>
+<translation id="3257320067425202300">Pārlūkā Brave esat ietaupījis <ph name="MEGABYTES"/> MB.</translation>
+<translation id="5813223329348543512">Pārlūkā Brave esat ietaupījis <ph name="GIGABYTES"/> GB.</translation>
+<translation id="8266862848225348053">Lejupielādes atrašanās vieta</translation>
+<translation id="7077143737582773186">SD karte</translation>
+<translation id="7762668264895820836">SD karte <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Vaicāt, kur saglabāt failus</translation>
+<translation id="6192333916571137726">Lejupielāde fails</translation>
+<translation id="1672586136351118594">Vairs nerādīt</translation>
+<translation id="2650751991977523696">Vai lejupielādēt failu vēlreiz?</translation>
+<translation id="8664979001105139458">Faila nosaukums jau pastāv</translation>
+<translation id="488187801263602086">Faila pārdēvēšana</translation>
+<translation id="5686790454216892815">Faila nosaukums ir pārāk garš</translation>
+<translation id="7454641608352164238">Nepietiek vietas</translation>
+<translation id="8972098258593396643">Vai lejupielādēt noklusējuma mapē?</translation>
+<translation id="804335162455518893">SD karte nav atrasta</translation>
+<translation id="7475688122056506577">SD karte nav atrasta. Iespējams, trūkst kādi jūsu faili.</translation>
+<translation id="4198423547019359126">Nav pieejamu lejupielādes atrašanās vietu.</translation>
+<translation id="8224471946457685718">Rakstu lejupielāde tikai pa Wi-Fi</translation>
+<translation id="4970824347203572753">Nav pieejams jūsu atrašanās vietā</translation>
+<translation id="5500777121964041360">Tas var nebūt pieejams jūsu atrašanās vietā</translation>
+<translation id="1173894706177603556">Pārdēvēt</translation>
+<translation id="1986685561493779662">Nosaukums jau pastāv</translation>
+<translation id="6441734959916820584">Vārds ir pārāk garš</translation>
+<translation id="2923908459366352541">Vārds nav derīgs</translation>
+<translation id="7290209999329137901">Pārdēvēšana nav pieejama</translation>
+<translation id="3334729583274622784">Vai mainīt faila paplašinājumu?</translation>
+<translation id="107147699690128016">Ja mainīsiet faila paplašinājumu, fails var tikt atvērts citā lietojumprogrammā un potenciāli apdraudēt jūsu ierīci.</translation>
+<translation id="8541922081612557424">Par Brave</translation>
+<translation id="5311273890481188673">Autortiesības: <ph name="YEAR"/> Brave Software LLC. Visas tiesības paturētas.</translation>
+<translation id="1416550906796893042">Lietojumprogrammas versija</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (atjaunināts: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operētājsistēma</translation>
+<translation id="3968054912784331254">Brave atjauninājumi vairs netiek atbalstīti šajā Android versijā</translation>
+<translation id="7665369617277396874">Pievienot kontu</translation>
+<translation id="649070405679044769">Pierakstījies Brave Software kontā kā</translation>
+<translation id="6234515504547364178">Izrakstīšanās no pārlūka Brave</translation>
+<translation id="5324858694974489420">Vecāku iestatījumi</translation>
+<translation id="8920114477895755567">Gaida vecāku informāciju.</translation>
+<translation id="5512137114520586844">Šo kontu pārvalda <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Šo kontu pārvalda <ph name="PARENT_NAME_1"/> un <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Saturs</translation>
+<translation id="5403644198645076998">Atļaut apmeklēt tikai konkrētas vietnes</translation>
+<translation id="8641930654639604085">Pēc iespējas bloķēt vietnes ar pieaugušajiem paredzētu saturu</translation>
+<translation id="5639724618331995626">Atļaut apmeklēt visas vietnes</translation>
+<translation id="796823723482603597">Nodrošina Brave</translation>
+<translation id="6324034347079777476">Android sistēmas sinhronizācija atspējota</translation>
+<translation id="5127805178023152808">Sinhronizācija izslēgta</translation>
+<translation id="7015203776128479407">Sākotnējā sinhronizācijas iestatīšana netika pabeigta. Sinhronizācija ir izslēgta.</translation>
+<translation id="2497852260688568942">Administrators ir atspējojis sinhronizēšanu.</translation>
+<translation id="9100610230175265781">Jāievada ieejas frāze.</translation>
+<translation id="6108923351542677676">Notiek iestatīšana...</translation>
+<translation id="4062305924942672200">Juridiskā informācija</translation>
+<translation id="4256782883801055595">Atklātā pirmkoda licences</translation>
+<translation id="1138681184697033370">Lietošanas noteikumi</translation>
+<translation id="7392539049993970338">Brave konfidencialitātes paziņojums</translation>
+<translation id="2677748264148917807">Iziet</translation>
+<translation id="5556459405103347317">Pārlādēt</translation>
+<translation id="1623104350909869708">Neļaut šai lapai veidot papildu dialoglodziņus</translation>
+<translation id="2968755619301702150">Sertifikātu skatītājs</translation>
+<translation id="1360432990279830238">Izrakstīties un izslēgt sinhronizēšanu?</translation>
+<translation id="8581481290581777242">Vai dzēst jūsu Brave datus no šīs ierīces?</translation>
+<translation id="1318865768845061710">Jūsu grāmatzīmes, vēsture, paroles un citi Brave dati vairs netiks sinhronizēti ar jūsu Brave Software kontu</translation>
+<translation id="3325020657155065477">Arī noņemt jūsu Brave datus no šīs ierīces</translation>
+<translation id="6136448902816743006">Jūs izrakstāties no konta, ko pārvalda <ph name="DOMAIN_NAME"/>, tāpēc jūsu Brave dati tiks izdzēsti no šīs ierīces. Tie joprojām būs pieejami jūsu Brave Software kontā.</translation>
+<translation id="1853026300647876496">Notiek sazināšanās ar Brave Software. Tas var ilgt kādu minūti...</translation>
+<translation id="2328985652426384049">Nevar pierakstīties</translation>
+<translation id="7723158744459952869">Brave Software pārāk ilgi nereaģēja</translation>
+<translation id="4572422548854449519">Pierakstīšanās pārvaldītā kontā</translation>
+<translation id="2689656545739939160">Jūs pierakstāties kontā, kas tiek pārvaldīts domēnā <ph name="MANAGED_DOMAIN"/>, un sniedzat tā administratoram kontroli pār saviem Brave datiem. Jūsu dati tiks neatgriezeniski saistīti ar šo kontu. Izrakstoties no pārlūka Brave, jūsu dati tiks dzēsti no šīs ierīces, taču tie tiks saglabāti jūsu Brave Software kontā.</translation>
+<translation id="1749561566933687563">Sinhronizējiet grāmatzīmes</translation>
+<translation id="4242533952199664413">Atvērt iestatījumus</translation>
+<translation id="1111673857033749125">Šeit būs redzamas grāmatzīmes, kuras esat saglabājis citās ierīcēs.</translation>
+<translation id="8636825310635137004">Ieslēdziet sinhronizāciju, lai būtu pieejamas cilnes no citām jūsu ierīcēm.</translation>
+<translation id="3269956123044984603">Lai būtu pieejamas cilnes no citām jūsu ierīcēm, Android konta iestatījumos ieslēdziet iestatījumu “Automātiski sinhronizēt datus”.</translation>
+<translation id="5157964048453367290">Šeit būs redzamas cilnes, kuras esat atvēris pārlūkā Brave citās ierīcēs.</translation>
+<translation id="4684427112815847243">Sinhronizēt visu</translation>
+<translation id="2709516037105925701">Automātiskā aizpilde</translation>
+<translation id="8820817407110198400">Grāmatzīmes</translation>
+<translation id="1644574205037202324">Vēsture</translation>
+<translation id="17513872634828108">Atvērt cilnes</translation>
+<translation id="1320169905922104972">Kredītkartes un adreses no pakalpojuma Brave Software Pay</translation>
+<translation id="6337234675334993532">Šifrēšana</translation>
+<translation id="6698801883190606802">Pārvaldīt sinhronizētos datus</translation>
+<translation id="3598578758776312506">Šifrēt paroles, izmantojot Brave Software akreditācijas datus</translation>
+<translation id="7810580217418711046">Šifrēt sinhronizētos datus ar Brave Software paroli, sākot no: <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Šifrējiet sinhronizētos datus, izmantojot savu sinhronizācijas ieejas frāzi</translation>
+<translation id="2996291259634659425">Ieejas frāzes izveide</translation>
+<translation id="5713644099811900409">Brave Software konts</translation>
+<translation id="8997474919031554666">Ieejas frāzes šifrējumā nav iekļauti maksājumu veidi un adreses no pakalpojuma Brave Software Pay. Jūsu šifrētos datus var lasīt tikai personas, kurām ir zināma jūsu ieejas frāze. Ieejas frāze netiek sūtīta Brave Software serveriem un netiek tajos glabāta. Ja aizmirsīsiet ieejas frāzi vai vēlēsieties mainīt šo iestatījumu, jums būs jāatiestata sinhronizācija. <ph name="BEGIN_LINK"/>Uzziniet vairāk<ph name="END_LINK"/>.</translation>
+<translation id="9050666287014529139">Ieejas frāze</translation>
+<translation id="7772032839648071052">Apstipriniet ieejas frāzi</translation>
+<translation id="5304593522240415983">Šis lauks nevar būt tukšs.</translation>
+<translation id="321773570071367578">Ja esat aizmirsis ieejas frāzi vai vēlaties mainīt šo iestatījumu, <ph name="BEGIN_LINK"/>atiestatiet sinhronizāciju<ph name="END_LINK"/>.</translation>
+<translation id="3029704984691124060">Ieejas frāzes neatbilst.</translation>
+<translation id="5149495116300586333">Ieejas frāzes šifrējumā nav iekļauti maksājumu veidi un adreses no pakalpojuma Brave Software Pay.
+
+Lai mainītu šo iestatījumu, <ph name="BEGIN_LINK"/>atiestatiet sinhronizāciju<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Nepareiza ieejas frāze</translation>
+<translation id="5414836363063783498">Notiek verifikācija...</translation>
+<translation id="6846298663435243399">Notiek ielāde…</translation>
+<translation id="5517095782334947753">Ir pieejamas grāmatzīmes, vēsture, paroles un citi iestatījumi no konta <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Datu apvienošana</translation>
+<translation id="688738109438487280">Pievienot esošos datus kontam <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Glabāt datus atsevišķi</translation>
+<translation id="1145536944570833626">Dzēst esošos datus.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> vēlas savienot pārī</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Saņemiet palīdzību<ph name="END_LINK"/>, meklējot ierīces…</translation>
+<translation id="5817918615728894473">Savienot pārī</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Saņemiet palīdzību<ph name="END_LINK1"/> vai <ph name="BEGIN_LINK2"/>meklējiet ierīces atkārtoti<ph name="END_LINK2"/>.</translation>
+<translation id="230115972905494466">Netika atrastas saderīgas ierīces.</translation>
+<translation id="3773755127849930740">Lai atļautu savienošanu pārī, <ph name="BEGIN_LINK"/>ieslēdziet Bluetooth<ph name="END_LINK"/>.</translation>
+<translation id="998321811308652668">Brave nevar ieslēgt Bluetooth adapteri.</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Saņemt palīdzību<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Lai meklētu ierīces, pārlūkam Brave ir nepieciešama piekļuve atrašanās vietai. <ph name="BEGIN_LINK"/>Atjauniniet atļaujas<ph name="END_LINK"/>.</translation>
+<translation id="852740676285943527">Lai meklētu ierīces, pārlūkam Brave ir nepieciešama piekļuve atrašanās vietas datiem. <ph name="BEGIN_LINK"/>Šajā ierīcē ir izslēgta piekļuve atrašanās vietas datiem<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Lai meklētu ierīces, pārlūkam Brave ir nepieciešama piekļuve atrašanās vietas datiem. <ph name="BEGIN_LINK1"/>Atjauniniet atļaujas<ph name="END_LINK1"/>. Piekļuve atrašanās vietas datiem ir arī <ph name="BEGIN_LINK2"/>izslēgta šai ierīcei<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Pievienota ierīce</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signāla stipruma līmenis: # josla}zero{Signāla stipruma līmenis: # joslu}one{Signāla stipruma līmenis: # josla}other{Signāla stipruma līmenis: # joslas}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> vēlas meklēt tuvumā esošas Bluetooth ierīces. Ir atrastas šīs ierīces:</translation>
+<translation id="8368027906805972958">Nezināma vai neatbalstīta ierīce (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sinhronizācija nedarbojas</translation>
+<translation id="1810845389119482123">Sākotnējā sinhronizācijas iestatīšana nav pabeigta</translation>
+<translation id="3235722914093408050">Lai sāktu Brave sinhronizēšanu, atveriet Android iestatījumus un atkārtoti iespējojiet Android sistēmas sinhronizēšanu</translation>
+<translation id="3367813778245106622">Lai sāktu sinhronizēšanu, pierakstieties vēlreiz</translation>
+<translation id="974555521953189084">Lai sāktu sinhronizēšanu, ievadiet ieejas frāzi</translation>
+<translation id="2997266899014181325">Lai sāktu sinhronizāciju, ieslēdziet iestatījumu “Jūsu Brave datu sinhronizācija”.</translation>
+<translation id="8260126382462817229">Mēģiniet pierakstīties vēlreiz</translation>
+<translation id="5919204609460789179">Lai sāktu sinhronizēšanu, atjauniniet <ph name="PRODUCT_NAME"/></translation>
+<translation id="397583555483684758">Sinhronizācija vairs nedarbojas</translation>
+<translation id="1966710179511230534">Lūdzu, atjauniniet pierakstīšanās informāciju.</translation>
+<translation id="7063006564040364415">Nevarēja izveidot savienojumu ar sinhronizācijas serveri.</translation>
+<translation id="7942131818088350342">Spraudnis <ph name="PRODUCT_NAME"/> ir novecojis.</translation>
+<translation id="4170011742729630528">Pakalpojums nav pieejams. Vēlāk mēģiniet vēlreiz.</translation>
+<translation id="7947953824732555851">Pieņemt un pierakst.</translation>
+<translation id="8583805026567836021">Konta datu dzēšana</translation>
+<translation id="8310344678080805313">Standarta cilnes</translation>
+<translation id="5748802427693696783">Notika pārslēgšanās uz standarta cilnēm</translation>
+<translation id="7998918019931843664">Vēlreiz atvērt aizvērto cilni</translation>
+<translation id="8853345339104747198">Cilne <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Aizvērt cilni <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opcijas, kas pieejamas ekrāna apakšējā daļā</translation>
+<translation id="4060598801229743805">Opcijas, kas pieejamas ekrāna augšdaļā</translation>
+<translation id="2810645512293415242">Lapa tika vienkāršota, lai samazinātu datu lietojumu un paātrinātu ielādi.</translation>
+<translation id="3985215325736559418">Vai vēlaties vēlreiz lejupielādēt failu <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Vai vēlaties vēlreiz sākt faila <ph name="FILE_NAME"/> lejupielādi?</translation>
+<translation id="7514365320538308">Lejupielādēt</translation>
+<translation id="545042621069398927">Lejupielāde tiek paātrināta.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Notiek faila lejupielāde.}zero{Notiek # failu lejupielāde.}one{Notiek # faila lejupielāde.}other{Notiek # failu lejupielāde.}}</translation>
+<translation id="543509235395288790">Notiek <ph name="COUNT"/> faila(-u) lejupielāde (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Notiek faila lejupielāde (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 lejupielāde ir pabeigta.}zero{# lejupielādes ir pabeigtas.}one{# lejupielāde ir pabeigta.}other{# lejupielādes ir pabeigtas.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 lejupielāde neizdevās.}zero{# lejupielādes neizdevās.}one{# lejupielāde neizdevās.}other{# lejupielādes neizdevās.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 neapstiprināta lejupielāde.}zero{# neapstiprinātu lejupielāžu.}one{# neapstiprināta lejupielāde.}other{# neapstiprinātas lejupielādes.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> poga</translation>
+<translation id="3205824638308738187">Gandrīz pabeigts!</translation>
+<translation id="3960299545138990065">Restartējiet pārlūku Brave</translation>
+<translation id="3771001275138982843">Nevarēja lejupielādēt atjauninājumu</translation>
+<translation id="3888648114124182147">Lejupielādē Brave atjauninājumu…</translation>
+<translation id="1705567146636171298">Atjaunināt Brave</translation>
+<translation id="6195417478702700398">Atveriet, lai uzlabotu pārlūkošanas ērtības, atjauninot pārlūku Brave</translation>
+<translation id="3512968675351418494">Lai skatītu tīmekli savā valodā, iegūstiet jaunāko Brave versiju</translation>
+<translation id="6427112570124116297">Iztulkojiet tīmekli</translation>
+<translation id="1379423114029199501">Veiciet atjaunināšanu, lai varētu lasīt savā valodā jaunākajā pārlūka Brave versijā</translation>
+<translation id="5684874026226664614">Hmm... Šo lapu nevarēja iztulkot.</translation>
+<translation id="6831043979455480757">Tulkot</translation>
+<translation id="1285320974508926690">Nekad netulkot šo vietni</translation>
+<translation id="773466115871691567">Vienmēr tulkot lapas šādā valodā: <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nekad netulkot lapas šādā valodā: <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Citas valodas…</translation>
+<translation id="290376772003165898">Vai lapa nav šajā valodā: <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Turpmāk lapas šādā valodā: <ph name="SOURCE_LANGUAGE"/> tiks tulkotas šādā valodā: <ph name="TARGET_LANGUAGE"/>.</translation>
+<translation id="8339163506404995330">Lapas šādā valodā: <ph name="LANGUAGE"/> netiks tulkotas.</translation>
+<translation id="5447765697759493033">Šī vietne netiks tulkota</translation>
+<translation id="4880127995492972015">Notiek tulkošana...</translation>
+<translation id="641643625718530986">Drukāt...</translation>
+<translation id="8909135823018751308">Kopīgot...</translation>
+<translation id="4996978546172906250">Kopīgošanas veids:</translation>
+<translation id="6333140779060797560">Kopīgot, izmantojot <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Drukājot lapu, radās problēma. Lūdzu, mēģiniet vēlreiz.</translation>
+<translation id="3254409185687681395">Grāmatot šo lapu</translation>
+<translation id="497421865427891073">Doties uz priekšu</translation>
+<translation id="813082847718468539">Skatīt informāciju par vietni</translation>
+<translation id="2532336938189706096">Tīmekļa skatījums</translation>
+<translation id="6005538289190791541">Ieteiktā parole</translation>
+<translation id="4634124774493850572">Izmantot paroli</translation>
+<translation id="8285489906452138776">Pārlūkam Brave ir nepieciešama atļauja piekļūt jūsu kamerai šajā vietnē.</translation>
+<translation id="320189792589364011">Pārlūkam Brave ir nepieciešama atļauja piekļūt jūsu mikrofonam šajā vietnē.</translation>
+<translation id="7988136689212463100">Pārlūkam Brave ir nepieciešama atļauja piekļūt jūsu kamerai un mikrofonam šajā vietnē.</translation>
+<translation id="4931190655840828017">Pārlūkam Brave ir nepieciešama piekļuve jūsu atrašanās vietas datiem, lai varētu tos kopīgot ar šo vietni.</translation>
+<translation id="3088191967551450609">Brave ir nepieciešama piekļuve krātuvei, lai varētu lejupielādēt failus.</translation>
+<translation id="8942627711005830162">Atvērt citā logā</translation>
+<translation id="4195643157523330669">Atvērt jaunā cilnē</translation>
+<translation id="1100066534610197918">Atvērt jaunu cilni grupā</translation>
+<translation id="4860895144060829044">Zvanīt</translation>
+<translation id="6896758677409633944">Kopēt</translation>
+<translation id="8393700583063109961">Sūtīt ziņojumu</translation>
+<translation id="3557336313807607643">Pievienot kontaktpersonām</translation>
+<translation id="4269820728363426813">Kopēt saites adresi</translation>
+<translation id="1206892813135768548">Kopēt saites tekstu</translation>
+<translation id="1204037785786432551">Lejupielādēt saiti</translation>
+<translation id="6864459304226931083">Lejupielādēt attēlu</translation>
+<translation id="8209050860603202033">Atvērt attēlu</translation>
+<translation id="8073388330009372546">Atvērt attēlu jaunā cilnē</translation>
+<translation id="6649642165559792194">Priekšskatīt attēlu <ph name="BEGIN_NEW"/>Jauns<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Ielādēt attēlu</translation>
+<translation id="3845332215609790146">Meklēšana ar Brave Software Lens <ph name="BEGIN_NEW"/>Jauns<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Meklēt šo attēlu ar <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Kopīgot attēlu</translation>
+<translation id="5833984609253377421">Kopīgot saiti</translation>
+<translation id="6475951671322991020">Lejupielādēt videoklipu</translation>
+<translation id="2317945146070194624">Atvērt jaunā Brave cilnē</translation>
+<translation id="7975379999046275268">Priekšskatīt lapu <ph name="BEGIN_NEW"/>Jauna<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Lapas atsvaidzināšana</translation>
+<translation id="36525718899759834">Iegūstiet lietotni Brave Software Play veikalā: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tumšs</translation>
+<translation id="1807246157184219062">Gaišs</translation>
+<translation id="4056223980640387499">Sēpija</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Vienplatuma</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Atlasiet cilni, ko kopīgot.</translation>
+<translation id="8719023831149562936">Nevar kopīgot šo cilni, izmantojot Beam.</translation>
+<translation id="2139186145475833000">Pievienot sākuma ekrānam</translation>
+<translation id="4616150815774728855">Atvērt <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Nevarēja atvērt lietotni</translation>
+<translation id="5129038482087801250">Instalēt tīmekļa lietotni</translation>
+<translation id="3789841737615482174">Instalēt</translation>
+<translation id="4665282149850138822">Vietne <ph name="NAME"/> tika pievienota sākuma ekrānam.</translation>
+<translation id="7333031090786104871">Joprojām notiek iepriekšējās vietnes pievienošana</translation>
+<translation id="1036727731225946849">Tiek pievienots <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Pievienots sākuma ekrānam</translation>
+<translation id="2146738493024040262">Atvērt tūlītējo lietotni</translation>
+<translation id="7016516562562142042">Atļauta pašreizējai meklētājprogrammai</translation>
+<translation id="6177111841848151710">Bloķēta pašreizējai meklētājprogrammai</translation>
+<translation id="145097072038377568">Izslēgts Android iestatījumos</translation>
+<translation id="8007176423574883786">Izslēgts šai ierīcei</translation>
+<translation id="164269334534774161">Jūs skatāt šīs lapas bezsaistes kopiju, kas tika izveidota šādā datumā: <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Šī lapas bezsaistes versija (izveidota: <ph name="CREATION_TIME"/>) var atšķirties no tiešsaistes versijas.</translation>
+<translation id="8840953339110955557">Šī lapas versija var atšķirties no tiešsaises versijas.</translation>
+<translation id="6405300764336705484">Šis saturs ir no vietnes <ph name="DOMAIN_NAME"/>, ko nodrošina Brave Software.</translation>
+<translation id="1006017844123154345">Atvērt tiešsaistē</translation>
+<translation id="3326636747541519688">Vienkāršota lapa, ko nodrošina Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Ielādēt sākotnējo lapu<ph name="END_LINK"/> no <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Ja šis ziņojums tiek rādīts bieži, izmēģiniet šos <ph name="BEGIN_LINK"/>ieteikumus<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Saturs paslēpts</translation>
+<translation id="3810973564298564668">Pārvaldīt</translation>
+<translation id="5199929503336119739">Darba profils</translation>
+<translation id="528192093759286357">Lai izietu no pilnekrāna režīma, velciet no augšas un pieskarieties pogai Atpakaļ.</translation>
+<translation id="2836148919159985482">Lai izietu no pilnekrāna režīma, pieskarieties pogai Atpakaļ.</translation>
+<translation id="3967822245660637423">Lejupielāde pabeigta</translation>
+<translation id="2434158240863470628">Lejupielāde pabeigta: <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Lejupielāde neizdevās</translation>
+<translation id="1384959399684842514">Lejupielāde pārtraukta</translation>
+<translation id="1671236975893690980">Lejupielāde tiek gaidīta...</translation>
+<translation id="5561549206367097665">Tiek gaidīts savienojums ar tīklu…</translation>
+<translation id="5864419784173784555">Tiek gaidīta cita lejupielāde…</translation>
+<translation id="6461962085415701688">Nevar atvērt failu.</translation>
+<translation id="1178581264944972037">Pauzēt</translation>
+<translation id="8200772114523450471">Kopsavilkums</translation>
+<translation id="1409879593029778104">Fails <ph name="FILE_NAME"/> netika lejupielādēts, jo tas jau pastāv.</translation>
+<translation id="3387650086002190359">Neizdevās lejupielādēt failu <ph name="FILE_NAME"/>, jo radās failu sistēmas kļūdas.</translation>
+<translation id="6482749332252372425">Neizdevās lejupielādēt failu <ph name="FILE_NAME"/>, jo krātuvē nav pietiekami daudz vietas.</translation>
+<translation id="7619072057915878432">Neizdevās lejupielādēt failu <ph name="FILE_NAME"/>, jo radās tīkla kļūdas.</translation>
+<translation id="1477626028522505441">Neizdevās lejupielādēt failu <ph name="FILE_NAME"/>, jo radās servera problēmas.</translation>
+<translation id="3692944402865947621">Faila <ph name="FILE_NAME"/> lejupielāde neizdevās, jo krātuves vieta nav sasniedzama.</translation>
+<translation id="604996488070107836">Neizdevās lejupielādēt failu <ph name="FILE_NAME"/>, jo radās nezināma kļūda.</translation>
+<translation id="6738867403308150051">Notiek lejupielāde…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> no ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> no <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Lejupielādēts: <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Lejupielādēts: <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Lejupielādēts: <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Atlicis 1 fails</translation>
+<translation id="8186512483418048923">Atlikuši faili: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Lejupielādēts <ph name="FILES_DOWNLOADED_ONE"/> fails}zero{Lejupielādēti <ph name="FILES_DOWNLOADED_MANY"/> faili}one{Lejupielādēts <ph name="FILES_DOWNLOADED_MANY"/> fails}other{Lejupielādēti <ph name="FILES_DOWNLOADED_MANY"/> faili}}</translation>
+<translation id="8037750541064988519">Atlikušas <ph name="DAYS"/> dienas</translation>
+<translation id="8190358571722158785">Atlikusi 1 diena</translation>
+<translation id="60923314841986378">Atlikušas <ph name="HOURS"/> h</translation>
+<translation id="510275257476243843">Atlikusi 1 h</translation>
+<translation id="970715775301869095">Atlikušas <ph name="MINUTES"/> min</translation>
+<translation id="3236059992281584593">Atlikusi 1 min</translation>
+<translation id="2777555524387840389">Atlikušas <ph name="SECONDS"/> s</translation>
+<translation id="2781151931089541271">Atlikusi 1 s</translation>
+<translation id="3303414029551471755">Vai turpināt ar satura lejupielādi?</translation>
+<translation id="8617240290563765734">Vai atvērt lejupielādētajā saturā norādīto ieteikto URL?</translation>
+<translation id="1373696734384179344">Nepietiek vietas, lai lejupielādētu atlasīto saturu.</translation>
+<translation id="5271967389191913893">Ierīcē nevar atvērt lejupielādējamo saturu.</translation>
+<translation id="883806473910249246">Lejupielādējot saturu, radās kļūda.</translation>
+<translation id="5626134646977739690">Nosaukums:</translation>
+<translation id="7963646190083259054">Nodrošina:</translation>
+<translation id="3414952576877147120">Lielums:</translation>
+<translation id="7375125077091615385">Veids:</translation>
+<translation id="5765780083710877561">Apraksts:</translation>
+<translation id="4881695831933465202">Atvērt</translation>
+<translation id="3542235761944717775">Pieejami <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747">Ir pieejami <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268">Pieejami <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Izmantotais apjoms: <ph name="SPACE_USED"/> no <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Visi</translation>
+<translation id="4988526792673242964">Lapas</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Attēli</translation>
+<translation id="8250920743982581267">Dokumenti</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fails}zero{# faili}one{# fails}other{# faili}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# attēls}zero{# attēli}one{# attēls}other{# attēli}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videoklips}zero{# videoklipi}one{# videoklips}other{# videoklipi}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# audio fails}zero{# audio faili}one{# audio fails}other{# audio faili}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# lapa}zero{# lapas}one{# lapa}other{# lapas}}</translation>
+<translation id="5456381639095306749">Lejupielādēt lapu</translation>
+<translation id="2394602618534698961">Šeit tiek rādīti jūsu lejupielādētie faili</translation>
+<translation id="7810647596859435254">Atvērt ar…</translation>
+<translation id="5655963694829536461">Meklējiet savas lejupielādes</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mani faili</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Šeit tiek rādīti raksti, kurus varat lasīt arī bezsaistē</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}zero{# h}one{# h}other{# h}}</translation>
+<translation id="5853623416121554550">apturēta</translation>
+<translation id="8965591936373831584">gaida</translation>
+<translation id="2779651927720337254">neizdevās</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Tikko</translation>
+<translation id="4000212216660919741">Bezsaistes sākums</translation>
+<translation id="9133397713400217035">Izpētīt bezsaisti</translation>
+<translation id="968900484120156207">Šeit tiek rādītas jūsu apmeklētās lapas</translation>
+<translation id="7882131421121961860">Vēsture nav atrasta</translation>
+<translation id="3549657413697417275">Meklēt savā vēsturē</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">GG</translation>
+<translation id="724102042129299115">Brave pirmās palaišanas pieredze</translation>
+<translation id="2700285883409956633">Izmantojot šo lietojumprogrammu, jūs piekrītat Brave <ph name="BEGIN_LINK1"/>pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1"/> un <ph name="BEGIN_LINK2"/>konfidencialitātes paziņojumam<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Izmantojot šo lietojumprogrammu, jūs piekrītat Brave <ph name="BEGIN_LINK1"/>pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>paziņojumam par konfidencialitāti<ph name="END_LINK2"/> un <ph name="BEGIN_LINK3"/>paziņojumam par konfidencialitāti Brave Software kontiem, kas tiek pārvaldīti lietotnē Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Lietotne <ph name="APP_NAME"/> tiks atvērta pārlūkā Brave. Turpinot jūs piekrītat Brave <ph name="BEGIN_LINK1"/>pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1"/> un <ph name="BEGIN_LINK2"/>konfidencialitātes paziņojumam<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659">Lietotne <ph name="APP_NAME"/> tiks atvērta pārlūkā Brave. Turpinot jūs piekrītat Brave <ph name="BEGIN_LINK1"/>pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1"/> un <ph name="BEGIN_LINK2"/>konfidencialitātes paziņojumam<ph name="END_LINK2"/>, kā arī <ph name="BEGIN_LINK3"/>konfidencialitātes paziņojumam Brave Software kontiem, kas tiek pārvaldīti lietotnē Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Uzlabojiet pārlūku Brave, uzņēmumam Brave Software sūtot lietojuma statistiku un avāriju pārskatus.</translation>
+<translation id="3518985090088779359">Piekrist un turpināt</translation>
+<translation id="7207456302801184289">Laipni lūdzam pārlūkā Brave</translation>
+<translation id="704822250101715322">Gaida, kad tiks pabeigta Brave Software Play pakalpojumu atjaunināšana</translation>
+<translation id="1231733316453485619">Vai ieslēgt sinhronizāciju?</translation>
+<translation id="5132942445612118989">Sinhronizējiet paroles, vēsturi un citu saturu visās ierīcēs</translation>
+<translation id="5736731321935944068">Brave Software var izmantot jūsu vēsturi, lai personalizētu Meklēšanu, reklāmas un citus Brave Software pakalpojumus.</translation>
+<translation id="4013614219085422040">Brave Software var izmantot jūsu vēsturi, lai personalizētu Meklēšanu un citus Brave Software pakalpojumus.</translation>
+<translation id="5581519193887989363">Jūs jebkurā laikā <ph name="BEGIN_LINK1"/>iestatījumos<ph name="END_LINK1"/> varat izvēlēties, ko sinhronizēt.</translation>
+<translation id="741204030948306876">Jā, piekrītu</translation>
+<translation id="2410754283952462441">Konta izvēle</translation>
+<translation id="2227444325776770048">Turpināt kā: <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> nav mana e-pasta adrese</translation>
+<translation id="8109613176066109935">Lai grāmatzīmes būtu pieejamas visās jūsu ierīcēs, ieslēdziet sinhronizāciju.</translation>
+<translation id="2818669890320396765">Lai grāmatzīmes būtu pieejamas visās jūsu ierīcēs, pierakstieties un ieslēdziet sinhronizāciju.</translation>
+<translation id="6003646045106347985">Lai saņemtu Brave Software ieteikto personalizēto saturu, ieslēdziet sinhronizāciju.</translation>
+<translation id="8494430740943879273">Lai saņemtu Brave Software ieteikto personalizēto saturu, pierakstieties un ieslēdziet sinhronizāciju.</translation>
+<translation id="5862731021271217234">Lai varētu piekļūt cilnēm no citām ierīcēm, ieslēdziet sinhronizāciju.</translation>
+<translation id="3568688522516854065">Lai varētu piekļūt cilnēm no citām ierīcēm, pierakstieties un ieslēdziet sinhronizāciju.</translation>
+<translation id="1208340532756947324">Lai sinhronizētu un personalizētu saturu dažādās ierīcēs, ieslēdziet sinhronizāciju.</translation>
+<translation id="4472118726404937099">Lai sinhronizētu un personalizētu saturu dažādās ierīcēs, pierakstieties un ieslēdziet sinhronizāciju.</translation>
+<translation id="2426805022920575512">Izvēlēties citu kontu</translation>
+<translation id="6790428901817661496">Atskaņot</translation>
+<translation id="1272079795634619415">Apturēt</translation>
+<translation id="2874939134665556319">Iepriekšējais ieraksts</translation>
+<translation id="4046123991198612571">Nākamais ieraksts</translation>
+<translation id="3859306556332390985">Pārtīt uz priekšu</translation>
+<translation id="8441146129660941386">Pārtīt atpakaļ</translation>
+<translation id="6706288973712894588">Jūs šobrīd esat bezsaistē.\n<ph name="BEGIN_LINK"/>Izpētiet savu bezsaistes plūsmu.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Nesen atvērtas cilnes</translation>
+<translation id="8497726226069778601">Šeit vēl nekā nav...</translation>
+<translation id="5423934151118863508">Šeit tiks parādītas jūsu visvairāk apmeklētās lapas.</translation>
+<translation id="6127379762771434464">Vienums ir noņemts</translation>
+<translation id="4605958867780575332">Vienums noņemts: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software svētku logotips: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Citas ierīces</translation>
+<translation id="4738836084190194332">Pēdējoreiz sinhronizēts: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{pirms # minūtes}zero{pirms # minūtēm}one{pirms # minūtes}other{pirms # minūtēm}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{pirms # stundas}zero{pirms # stundām}one{pirms # stundas}other{pirms # stundām}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{pirms # dienas}zero{pirms # dienām}one{pirms # dienas}other{pirms # dienām}}</translation>
+<translation id="2762000892062317888">tikko</translation>
+<translation id="1407135791313364759">Atvērt visas</translation>
+<translation id="1209206284964581585">Pagaidām slēpt</translation>
+<translation id="129553762522093515">Nesen aizvērtas</translation>
+<translation id="8413126021676339697">Rādīt pilnu vēsturi</translation>
+<translation id="7876243839304621966">Noņemt visu</translation>
+<translation id="8487700953926739672">Pieejams bezsaistē</translation>
+<translation id="5224771365102442243">Ar video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Uzziniet vairāk<ph name="END_LINK"/> par ieteikto saturu.</translation>
+<translation id="7542481630195938534">Nevar iegūt ieteikumus.</translation>
+<translation id="5013696553129441713">Nav jaunu ieteikumu</translation>
+<translation id="1736419249208073774">Izpētīt</translation>
+<translation id="7444811645081526538">Vairāk kategoriju</translation>
+<translation id="6709133671862442373">Ziņas</translation>
+<translation id="1264974993859112054">Sports</translation>
+<translation id="9139318394846604261">Pirkumi</translation>
+<translation id="3912508018559818924">Notiek vislabākā tīmekļa satura meklēšana</translation>
+<translation id="526421993248218238">Šo lapu nevar ielādēt</translation>
+<translation id="614940544461990577">Veiciet tālāk norādītās darbības.</translation>
+<translation id="3288003805934695103">Atkārtoti ielādējiet lapu.</translation>
+<translation id="2353636109065292463">Notiek interneta savienojuma pārbaude</translation>
+<translation id="2858138569776157458">Populāras</translation>
+<translation id="8364299278605033898">Skatīt populāras vietnes</translation>
+<translation id="1171770572613082465">Lai skatītu populāras tīmekļa vietnes, pieskarieties pogai “Populāras”</translation>
+<translation id="5233638681132016545">Jauna cilne</translation>
+<translation id="4521874409998847950">No izdevēja <ph name="PUBLISHER_ORIGIN"/> — <ph name="BEGIN_DEEMPHASIZED"/>nodrošina Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Pieejama jaunāka versija</translation>
+<translation id="4058091506841967397">Nevar atjaunināt Brave</translation>
+<translation id="6316139424528454185">Neatbalstīta Android versija</translation>
+<translation id="6989267951144302301">Nevarēja lejupielādēt</translation>
+<translation id="624789221780392884">Var veikt atjaunināšanu</translation>
+<translation id="1549000191223877751">Pārvietot uz citu logu</translation>
+<translation id="7481312909269577407">Pārsūtīt</translation>
+<translation id="4084682180776658562">Grāmatzīme</translation>
+<translation id="6437478888915024427">Lapas informācija</translation>
+<translation id="7180611975245234373">Atsvaidzināt</translation>
+<translation id="4913169188695071480">Pārtraukt atsvaidzināšanu</translation>
+<translation id="1829244130665387512">Atrast lapā</translation>
+<translation id="6593061639179217415">Vietne datoriem</translation>
+<translation id="9063523880881406963">Izslēgt iestatījumu “Pieprasīt datora vietni”</translation>
+<translation id="2038563949887743358">Ieslēgt iestatījumu “Pieprasīt datora vietni”</translation>
+<translation id="2433507940547922241">Izskats</translation>
+<translation id="983192555821071799">Aizvērt visas cilnes</translation>
+<translation id="1310482092992808703">Grupēt cilnes</translation>
+<translation id="7725024127233776428">Šeit tiek rādītas ar grāmatzīmēm atzīmētās lapas</translation>
+<translation id="4404568932422911380">Nav grāmatzīmju</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> grāmatzīme}zero{<ph name="BOOKMARKS_COUNT_MANY"/> grāmatzīmju}one{<ph name="BOOKMARKS_COUNT_MANY"/> grāmatzīme}other{<ph name="BOOKMARKS_COUNT_MANY"/> grāmatzīmes}}</translation>
+<translation id="3739899004075612870">Pievienota grāmatzīme pārlūkā <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Atzīmēts kā grāmatzīme</translation>
+<translation id="4452548195519783679">Grāmatzīme saglabāta mapē <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Neizdevās pievienot grāmatzīmi.</translation>
+<translation id="2842985007712546952">Vecākmape</translation>
+<translation id="9065203028668620118">Labot</translation>
+<translation id="4405224443901389797">Pārvietot uz…</translation>
+<translation id="5170568018924773124">Rādīt mapē</translation>
+<translation id="8035133914807600019">Jauna mape…</translation>
+<translation id="4532845899244822526">Mapes izvēlēšanās</translation>
+<translation id="6627583120233659107">Rediģēt mapi</translation>
+<translation id="1197267115302279827">Pārvietot grāmatzīmes</translation>
+<translation id="6963766334940102469">Dzēst grāmatzīmes</translation>
+<translation id="4351244548802238354">Aizvērt dialoglodziņu</translation>
+<translation id="451872707440238414">Meklēt grāmatzīmēs</translation>
+<translation id="8901170036886848654">Nav atrasta neviena grāmatzīme</translation>
+<translation id="6404511346730675251">Rediģēt grāmatzīmi</translation>
+<translation id="3894427358181296146">Mapes pievienošana</translation>
+<translation id="5327248766486351172">Nosaukums</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Mape</translation>
+<translation id="5161254044473106830">Jānorāda nosaukums</translation>
+<translation id="2996809686854298943">URL ir jānorāda obligāti.</translation>
+<translation id="2536728043171574184">Skata šīs lapas kopiju bezsaistē</translation>
+<translation id="4698034686595694889">Skatīšana bezsaistē lietotnē <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> un citas vietnes</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Kad ierīce būs gatava, jūsu lapa tiks ielādēta pārlūkā Brave}zero{Kad ierīce būs gatava, jūsu lapas tiks ielādētas pārlūkā Brave}one{Kad ierīce būs gatava, jūsu lapas tiks ielādētas pārlūkā Brave}other{Kad ierīce būs gatava, jūsu lapas tiks ielādētas pārlūkā Brave}}</translation>
+<translation id="6811034713472274749">Lapu var skatīt</translation>
+<translation id="4561979708150884304">Nav savienojuma</translation>
+<translation id="8274165955039650276">Skatīt lejupielādes</translation>
+<translation id="2082238445998314030"><ph name="RESULT_NUMBER"/>. rezultāts no <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Nav rezultātu</translation>
+<translation id="981121421437150478">Bezsaistē</translation>
+<translation id="3298243779924642547">Vienkāršota</translation>
+<translation id="393697183122708255">Nav iespējota meklēšana ar balsi.</translation>
+<translation id="7191430249889272776">Cilne tika atvērta fonā.</translation>
+<translation id="8445059357334030806">Atvērt pārlūkā Brave</translation>
+<translation id="4720023427747327413">Atvērt, izmantojot <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Atvērt pārlūkā</translation>
+<translation id="1113597929977215864">Rādīt vienkāršoto skatu</translation>
+<translation id="1513352483775369820">Grāmatzīmes un tīmekļa vēsture</translation>
+<translation id="4939482511480190003">Palīdziet uzlabot pārlūku Brave. <ph name="BEGIN_LINK"/>Atbildiet uz aptaujas jautājumiem<ph name="END_LINK"/>.</translation>
+<translation id="2501278716633472235">Doties atpakaļ</translation>
+<translation id="5596627076506792578">Citas opcijas</translation>
+<translation id="3522247891732774234">Pieejams atjauninājums. Citas iespējas</translation>
+<translation id="6773423637732432200">Nevar atjaunināt Brave — citas opcijas</translation>
+<translation id="3328801116991980348">Vietnes informācija</translation>
+<translation id="5391532827096253100">Savienojums ar šo vietni nav drošs. Vietnes informācija</translation>
+<translation id="6206551242102657620">Savienojums ir drošs. Vietnes informācija</translation>
+<translation id="6963642900430330478">Šī lapa ir bīstama. Vietnes informācija</translation>
+<translation id="9070377983101773829">Sākt meklēšanu ar balsi</translation>
+<translation id="8676374126336081632">Notīrīt ievadi</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> atvērta cilne. Pieskarieties, lai pārslēgtu cilnes.}zero{<ph name="OPEN_TABS_MANY"/> atvērtu ciļņu. Pieskarieties, lai pārslēgtu cilnes.}one{<ph name="OPEN_TABS_MANY"/> atvērta cilne. Pieskarieties, lai pārslēgtu cilnes.}other{<ph name="OPEN_TABS_MANY"/> atvērtas cilnes. Pieskarieties, lai pārslēgtu cilnes.}}</translation>
+<translation id="2369533728426058518">atvērt cilnes</translation>
+<translation id="7071521146534760487">Pārvaldīt kontu</translation>
+<translation id="932327136139879170">Sākums</translation>
+<translation id="2707726405694321444">Atsvaidzināt lapu</translation>
+<translation id="2891154217021530873">Pārtraukt lapas ielādi</translation>
+<translation id="6710213216561001401">Iepriekšējais</translation>
+<translation id="6659594942844771486">Cilne</translation>
+<translation id="1933845786846280168">Atlasītā cilne</translation>
+<translation id="2268044343513325586">Uzlabot</translation>
+<translation id="7846076177841592234">Atcelt atlasi</translation>
+<translation id="7087918508125750058">Atlasīti vienumi: <ph name="ITEM_COUNT"/>. Opcijas ir pieejamas ekrāna augšdaļā.</translation>
+<translation id="7250468141469952378">Atlasīti vienumi: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Kopīgot 1 atlasīto vienumu}zero{Kopīgot # atlasītos vienumus}one{Kopīgot # atlasīto vienumu}other{Kopīgot # atlasītos vienumus}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Noņemt 1 atlasīto vienumu}zero{Noņemt # atlasītos vienumus}one{Noņemt # atlasīto vienumu}other{Noņemt # atlasītos vienumus}}</translation>
+<translation id="1283039547216852943">Pieskarties, lai izvērstu</translation>
+<translation id="5962718611393537961">Pieskarties, lai sakļautu</translation>
+<translation id="8076492880354921740">Cilnes</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Atlasīts 1 vienums}zero{Atlasīti # vienumi}one{Atlasīts # vienums}other{Atlasīti # vienumi}}</translation>
+<translation id="6818926723028410516">Vienumu atlase</translation>
+<translation id="4797039098279997504">Pieskarieties, lai atgrieztos cilnē <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Pieskarieties, lai atvērtu vietni</translation>
+<translation id="429312253194641664">Vietne atskaņo multivides saturu</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> kopīgo jūsu ekrānu</translation>
+<translation id="8833831881926404480">Vietne kopīgo jūsu ekrānu</translation>
+<translation id="9086455579313502267">Nevar piekļūt tīklam</translation>
+<translation id="938850635132480979">Kļūda: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Atvērt lietotnē <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Atvērt karšu lietotnē</translation>
+<translation id="7698359219371678927">Izveidojiet e-pasta ziņojumu lietotnē <ph name="APP_NAME"/>.</translation>
+<translation id="7875915731392087153">Izveidojiet e-pasta ziņojumu.</translation>
+<translation id="5665379678064389456">Izveidojiet pasākumu lietotnē <ph name="APP_NAME"/>.</translation>
+<translation id="2900528713135656174">Izveidot pasākumu</translation>
+<translation id="2111511281910874386">Doties uz lapu</translation>
+<translation id="3988466920954086464">Skatīt tūlītējus meklēšanas rezultātus šajā panelī</translation>
+<translation id="2744248271121720757">Pieskarieties vārdam, lai meklētu tūlīt vai skatītu saistītas darbības.</translation>
+<translation id="9155898266292537608">Varat arī meklēt, ātri pieskaroties vārdam</translation>
+<translation id="3232754137068452469">Tīmekļa lietotne</translation>
+<translation id="1430915738399379752">Drukāt</translation>
+<translation id="3775705724665058594">Sūtīšana uz jūsu ierīcēm</translation>
+<translation id="6364438453358674297">Vai noņemt ieteikumu no vēstures?</translation>
+<translation id="213279576345780926">Tika aizvērta cilne <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139">Aizvērtas <ph name="TAB_COUNT"/> cilnes</translation>
+<translation id="3211426585530211793">Vienums <ph name="ITEM_TITLE"/> tika izdzēsts</translation>
+<translation id="4663756553811254707">Dzēstas <ph name="NUMBER_OF_BOOKMARKS"/> grāmatzīmes</translation>
+<translation id="3819178904835489326">Izdzēsti <ph name="NUMBER_OF_DOWNLOADS"/> lejupielādētie vienumi</translation>
+<translation id="1248710015876067820">Neatbalstīts Brave instanču skaits</translation>
+<translation id="4259722352634471385">Navigācija ir bloķēta: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigācija nav sasniedzama: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Aizvērt cilni</translation>
+<translation id="7772375229873196092">Aizvērt <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Navigācijas vēsture</translation>
+<translation id="9169507124922466868">Navigācijas vēsture ir atvērta līdz pusei.</translation>
+<translation id="1327257854815634930">Navigācijas vēsture ir atvērta</translation>
+<translation id="8788265440806329501">Navigācijas vēsture ir aizvērta</translation>
+<translation id="7482656565088326534">Priekšskatījuma cilne</translation>
+<translation id="8427875596167638501">Priekšskatījuma cilne ir daļēji atvērta</translation>
+<translation id="9102803872260866941">Priekšskatījuma cilne ir atvērta</translation>
+<translation id="2942036813789421260">Priekšskatījuma cilne ir aizvērta</translation>
+<translation id="6355102470683871794">Lietotnes Brave Software <ph name="APP_NAME"/> krātuve</translation>
+<translation id="3822502789641063741">Vai notīrīt vietnes krātuvi?</translation>
+<translation id="9205995714227143200">Vietnes krātuve, kura pārlūkā Brave netiek uzskatīta par svarīgu (piemēram, vietnes bez saglabātiem iestatījumiem vai vietnes, kuras neapmeklējat bieži)</translation>
+<translation id="3997476611815694295">Nesvarīga krātuve</translation>
+<translation id="8493948351860045254">Atbrīvot vietu</translation>
+<translation id="2324920234469020158">Tādējādi tiks dzēsti sīkfaili, kešatmiņa un citi vietņu dati, kas pārlūkā Brave netiek uzskatīti par svarīgiem.</translation>
+<translation id="5447201525962359567">Visa vietnes krātuve, tostarp sīkfaili un citi lokāli saglabāti dati</translation>
+<translation id="1376578503827013741">Notiek aprēķināšana...</translation>
+<translation id="583281660410589416">Nezināms</translation>
+<translation id="2323763861024343754">Vietnes krātuve</translation>
+<translation id="3587672679800759167">Kopējais pārlūkā Brave izmantoto datu apjoms, ieskaitot kontus, grāmatzīmes un saglabātos iestatījumus</translation>
+<translation id="6545017243486555795">Notīrīt visus datus</translation>
+<translation id="4095146165863963773">Vai dzēst lietotnes datus?</translation>
+<translation id="53119194224775367">Visi lietotnes Brave dati tiks neatgriezeniski izdzēsti. Tas attiecas uz visiem failiem, iestatījumiem, kontiem, datu bāzēm un citiem datiem.</translation>
+<translation id="5307446750509046227">Notīrīt vietnes krātuvi</translation>
+<translation id="300526633675317032">Tādējādi tiks notīrīti visi vietnes krātuves dati (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">Nevar atlasīt sertifikātu.</translation>
+<translation id="2315043854645842844">Operētājsistēma neatbalsta klienta puses sertifikāta atlasi.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> vēlas izveidot savienojumu</translation>
+<translation id="5308380583665731573">Pievienošana</translation>
+<translation id="868929229000858085">Meklējiet kontaktpersonas</translation>
+<translation id="1919950603503897840">Kontaktpersonu atlase</translation>
+<translation id="7986741934819883144">Kontaktpersonas atlase</translation>
+<translation id="3333961966071413176">Visas kontaktpersonas</translation>
+<translation id="4994033804516042629">Nav atrasta neviena kontaktpersona</translation>
+<translation id="5403592356182871684">Nosaukumi</translation>
+<translation id="2717722538473713889">E-pasta adreses</translation>
+<translation id="381841723434055211">Tālruņa numuri</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(un vēl 1)}zero{(un vēl #)}one{(un vēl #)}other{(un vēl #)}}</translation>
+<translation id="5197729504361054390">Atlasīto kontaktpersonu dati tiks kopīgoti ar vietni <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Attēlu dekodētājs</translation>
+<translation id="8067883171444229417">Atskaņot videoklipu</translation>
+<translation id="6560414384669816528">Meklēšana, izmantojot Sogou</translation>
+<translation id="5406914950576900927">Pārlūkā Brave var izmantot meklētājprogrammu <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>, lai veiktu meklēšanu Ķīnā. Varat to mainīt sadaļā <ph name="BEGIN_LINK"/>Iestatījumi<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Arī turpmāk izmantot Brave Software</translation>
+<translation id="4384468725000734951">Tiek izmantota meklētājprogramma Sogou</translation>
+<translation id="6103327872225198548">Tiek izmantota meklētājprogramma Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Šī lietotne darbojas pārlūkā Brave</translation>
+<translation id="6143689084714664628">Atvērta pārlūkā Brave</translation>
+<translation id="7675869148432102528">Pārlūkā Brave ir arī “<ph name="APP_NAME"/>” dati</translation>
+<translation id="2734140769649165081">Varat notīrīt datus Brave iestatījumos</translation>
+<translation id="8232956427053453090">Paturēt datus</translation>
+<translation id="4298388696830689168">Saistītās vietnes</translation>
+<translation id="5763514718066511291">Pieskarieties, lai kopētu šīs lietotnes URL.</translation>
+<translation id="6496823230996795692">Lai pirmo reizi izmantotu lietotni <ph name="APP_NAME"/>, lūdzu, izveidojiet savienojumu ar internetu.</translation>
+<translation id="751961395872307827">Nevar izveidot savienojumu ar vietni.</translation>
+<translation id="4878404682131129617">Neizdevās iestatīt porta pārsūtīšanu, izmantojot starpniekserveri.</translation>
+<translation id="4749960740855309258">Atvērt jaunu cilni</translation>
+<translation id="8788968922598763114">Atkārtoti atvērt pēdējo aizvērto cilni</translation>
+<translation id="7929962904089429003">Atvērt izvēlni</translation>
+<translation id="6039379616847168523">Pāriet uz nākamo cilni</translation>
+<translation id="5210286577605176222">Pāriet uz iepriekšējo cilni</translation>
+<translation id="124678866338384709">Aizvērt pašreizējo cilni</translation>
+<translation id="3714981814255182093">Atvērt atrašanas joslu</translation>
+<translation id="5441522332038954058">Pāriet uz adreses joslu</translation>
+<translation id="3398320232533725830">Atvērt grāmatzīmju pārvaldnieku</translation>
+<translation id="6583199322650523874">Pievienot pašreizējo lapu grāmatzīmēm</translation>
+<translation id="8489271220582375723">Atvērt vēstures lapu</translation>
+<translation id="4837753911714442426">Atvērt iespējas, lai izdrukātu lapu</translation>
+<translation id="5726692708398506830">Palielināt visu lapas saturu</translation>
+<translation id="3259831549858767975">Samazināt visu lapas saturu</translation>
+<translation id="8015452622527143194">Atjaunot visam lapas saturam noklusējuma lielumu</translation>
+<translation id="3443221991560634068">Atkārtoti ielādēt pašreizējo lapu</translation>
+<translation id="123724288017357924">Atkārtoti ielādēt lapu, ignorējot saturu kešatmiņā</translation>
+<translation id="305870044889644984">Atvērt Brave palīdzības centru jaunā cilnē</translation>
+<translation id="3166827708714933426">Ciļņu un logu īsinājumtaustiņi</translation>
+<translation id="3169981355900570544">Brave Software Brave funkciju īsinājumtaustiņi</translation>
+<translation id="4558311620361989323">Tīmekļa lapu īsinājumtaustiņi</translation>
+<translation id="1908301351964700579">Brave joprojām gatavojas virtuālajai realitātei. Vēlāk restartējiet pārlūku Brave.</translation>
+<translation id="8970887620466824814">Radās kļūda.</translation>
+<translation id="1875543012935658554">Atkārtoti atveriet pārlūku Brave.</translation>
+<translation id="79859296434321399">Lai skatītu papildinātās realitātes saturu, instalējiet ARCore</translation>
+<translation id="8558485628462305855">Lai skatītu papildinātās realitātes saturu, atjauniniet ARCore</translation>
+<translation id="3513704683820682405">Papildinātā realitāte</translation>
+<translation id="5475862044948910901">Vai sākt papildinātās realitātes sesiju?</translation>
 <translation id="7365126855094612066">Šīs sesijas laikā vietne varēs:
 • izveidot jūsu vides 3D karti;
 • izsekot kameras kustību.
 
 Vietnei NAV piekļuves kamerai. Kameras attēli ir redzami tikai jums.</translation>
-<translation id="7375125077091615385">Veids:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome pirmās palaišanas pieredze</translation>
-<translation id="741204030948306876">Jā, piekrītu</translation>
-<translation id="7413229368719586778">Sākuma datums: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Vispirms jautāt</translation>
-<translation id="7423538860840206698">Bloķēta starpliktuves satura lasīšana</translation>
-<translation id="7431991332293347422">Kontrolējiet, kā jūsu pārlūkošanas vēsture tiek izmantota Meklēšanas un cita satura personalizēšanai</translation>
-<translation id="7437998757836447326">Izrakstīšanās no pārlūka Chrome</translation>
-<translation id="7438641746574390233">Ja ir ieslēgts vienkāršotais režīms, pārlūkā Chrome tiek izmantoti Google serveri, lai ielādētu lapas ātrāk. Vienkāršotajā režīmā ļoti lēnas lapas tiek pārrakstītas, lai tās ielādētu tikai nepieciešamo saturu. Vienkāršotais režīms netiek piemērots inkognito režīma cilnēm.</translation>
-<translation id="7444811645081526538">Vairāk kategoriju</translation>
-<translation id="7445411102860286510">Atļaut vietnēm automātiski atskaņot videoklipus ar izslēgtu skaņu (ieteicams)</translation>
-<translation id="7453467225369441013">Jūs tiksiet izrakstīts no lielākās daļas vietņu. Jūs netiksiet izrakstīts no Google konta.</translation>
-<translation id="7454641608352164238">Nepietiek vietas</translation>
-<translation id="7475192538862203634">Ja šis ziņojums tiek rādīts bieži, izmēģiniet šos <ph name="BEGIN_LINK" />ieteikumus<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD karte nav atrasta. Iespējams, trūkst kādi jūsu faili.</translation>
-<translation id="7479104141328977413">Ciļņu pārvaldība</translation>
-<translation id="7481312909269577407">Pārsūtīt</translation>
-<translation id="7482656565088326534">Priekšskatījuma cilne</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (atjaunināts: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">Saglabātie dati</translation>
-<translation id="7498271377022651285">Lūdzu, uzgaidiet...</translation>
-<translation id="7514365320538308">Lejupielādēt</translation>
-<translation id="751961395872307827">Nevar izveidot savienojumu ar vietni.</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Nevar iegūt ieteikumus.</translation>
-<translation id="7559975015014302720">Vienkāršotais režīms ir izslēgts</translation>
-<translation id="7562080006725997899">Notiek pārlūkošanas datu notīrīšana</translation>
-<translation id="756809126120519699">Chrome dati tika notīrīti</translation>
-<translation id="757524316907819857">Neļaut vietnēm atskaņot aizsargātu saturu</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Lejupielādēts <ph name="FILES_DOWNLOADED_ONE" /> fails}zero{Lejupielādēti <ph name="FILES_DOWNLOADED_MANY" /> faili}one{Lejupielādēts <ph name="FILES_DOWNLOADED_MANY" /> fails}other{Lejupielādēti <ph name="FILES_DOWNLOADED_MANY" /> faili}}</translation>
-<translation id="7588219262685291874">Ieslēgt tumšo motīvu, kad ierīcē ir ieslēgts akumulatora jaudas taupīšanas režīms</translation>
-<translation id="7589445247086920869">Aizliegšana pašreizējai meklētājprogrammai</translation>
-<translation id="7593557518625677601">Lai sāktu Chrome sinhronizēšanu, atveriet Android iestatījumus un atkārtoti iespējojiet Android sistēmas sinhronizēšanu</translation>
-<translation id="7596558890252710462">Operētājsistēma</translation>
-<translation id="7605594153474022051">Sinhronizācija nedarbojas</translation>
-<translation id="7606077192958116810">Vienkāršotais režīms ir ieslēgts. Pārvaldiet to iestatījumos.</translation>
-<translation id="7612619742409846846">Pierakstījies Google kontā kā</translation>
-<translation id="7619072057915878432">Neizdevās lejupielādēt failu <ph name="FILE_NAME" />, jo radās tīkla kļūdas.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Saņemiet palīdzību<ph name="END_LINK1" /> vai <ph name="BEGIN_LINK2" />meklējiet ierīces atkārtoti<ph name="END_LINK2" />.</translation>
-<translation id="7626032353295482388">Laipni lūdzam pārlūkā Chrome</translation>
-<translation id="7638584964844754484">Nepareiza ieejas frāze</translation>
-<translation id="7641339528570811325">Pārlūkošanas datu notīrīšana…</translation>
-<translation id="7648422057306047504">Šifrēt paroles, izmantojot Google akreditācijas datus</translation>
-<translation id="7649070708921625228">Palīdzība</translation>
-<translation id="7658239707568436148">Atcelt</translation>
-<translation id="7665369617277396874">Pievienot kontu</translation>
-<translation id="766587987807204883">Šeit tiek rādīti raksti, kurus varat lasīt arī bezsaistē</translation>
-<translation id="7682724950699840886">Ņemiet vērā šos ieteikumus: atbrīvojiet ierīcē vietu un mēģiniet eksportēt vēlreiz.</translation>
-<translation id="7685301384041462804">Aktivizējiet VR režīmu tikai tad, ja esat pārliecināts, ka šī vietne ir uzticama.</translation>
-<translation id="7698359219371678927">Izveidojiet e-pasta ziņojumu lietotnē <ph name="APP_NAME" />.</translation>
-<translation id="7704317875155739195">Automātiski pabeigt meklēšanas vaicājumus un vietrāžus URL</translation>
-<translation id="7725024127233776428">Šeit tiek rādītas ar grāmatzīmēm atzīmētās lapas</translation>
-<translation id="773466115871691567">Vienmēr tulkot lapas šādā valodā: <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Lai noteiktu bīstamas lietotnes un vietnes, pārlūkā Chrome dažu jūsu apmeklēto lapu saturs, ierobežots sistēmas informācijas apjoms un daļa lapu satura tiek nosūtīta uzņēmumam Google</translation>
-<translation id="7757787379047923882">Kopīgots teksts no ierīces <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD karte <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Pievienot adresi</translation>
-<translation id="7772032839648071052">Apstipriniet ieejas frāzi</translation>
-<translation id="7772375229873196092">Aizvērt <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}zero{<ph name="PAYMENT_METHOD_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />… un vēl <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Vakar</translation>
-<translation id="7791543448312431591">Pievienot</translation>
-<translation id="780301667611848630">Nē, paldies</translation>
-<translation id="7810647596859435254">Atvērt ar…</translation>
-<translation id="7821588508402923572">Šeit tiks parādīts ietaupīto datu apjoms.</translation>
-<translation id="7837721118676387834">Atļaut automātisku atskaņošanu videoklipiem ar izslēgtu skaņu konkrētā vietnē.</translation>
-<translation id="7846076177841592234">Atcelt atlasi</translation>
-<translation id="784934925303690534">Laika periods</translation>
-<translation id="7851858861565204677">Citas ierīces</translation>
-<translation id="7875915731392087153">Izveidojiet e-pasta ziņojumu.</translation>
-<translation id="7876243839304621966">Noņemt visu</translation>
-<translation id="7882131421121961860">Vēsture nav atrasta</translation>
-<translation id="7882806643839505685">Atļaut skaņu konkrētai vietnei</translation>
-<translation id="7886917304091689118">Atvērta pārlūkā Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Notiek faila lejupielāde.}zero{Notiek # failu lejupielāde.}one{Notiek # faila lejupielāde.}other{Notiek # failu lejupielāde.}}</translation>
-<translation id="7929962904089429003">Atvērt izvēlni</translation>
-<translation id="7942131818088350342">Spraudnis <ph name="PRODUCT_NAME" /> ir novecojis.</translation>
-<translation id="7947953824732555851">Pieņemt un pierakst.</translation>
-<translation id="7963646190083259054">Nodrošina:</translation>
-<translation id="7971136598759319605">Aktīva pirms 1 dienas</translation>
-<translation id="7975379999046275268">Priekšskatīt lapu <ph name="BEGIN_NEW" />Jauna<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Veikt lapu pirmsielādi, lai paātrinātu pārlūkošanu un meklēšanu</translation>
-<translation id="79859296434321399">Lai skatītu papildinātās realitātes saturu, instalējiet ARCore</translation>
-<translation id="7986741934819883144">Kontaktpersonas atlase</translation>
-<translation id="7987073022710626672">Lietošanas noteikumi</translation>
-<translation id="7998918019931843664">Vēlreiz atvērt aizvērto cilni</translation>
-<translation id="7999064672810608036">Vai tiešām vēlaties notīrīt visus ar šo vietni saistītos lokālos datus, tostarp sīkfailus, un atiestatīt visas atļaujas?</translation>
-<translation id="8004582292198964060">Pārlūkprogramma</translation>
-<translation id="8007176423574883786">Izslēgts šai ierīcei</translation>
-<translation id="8013372441983637696">Arī noņemt jūsu Chrome datus no šīs ierīces</translation>
-<translation id="8015452622527143194">Atjaunot visam lapas saturam noklusējuma lielumu</translation>
-<translation id="802154636333426148">Lejupielāde neizdevās</translation>
-<translation id="8026334261755873520">Notīrīt pārlūkošanas datus</translation>
-<translation id="8035133914807600019">Jauna mape…</translation>
-<translation id="8037750541064988519">Atlikušas <ph name="DAYS" /> dienas</translation>
-<translation id="804335162455518893">SD karte nav atrasta</translation>
-<translation id="805047784848435650">Pamatā ir jūsu pārlūkošanas vēsture</translation>
-<translation id="8051695050440594747">Ir pieejami <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">Atvērt jaunā Chrome cilnē</translation>
-<translation id="8063895661287329888">Neizdevās pievienot grāmatzīmi.</translation>
-<translation id="806745655614357130">Glabāt datus atsevišķi</translation>
-<translation id="8067883171444229417">Atskaņot videoklipu</translation>
-<translation id="8068648041423924542">Nevar atlasīt sertifikātu.</translation>
-<translation id="8073388330009372546">Atvērt attēlu jaunā cilnē</translation>
-<translation id="8076492880354921740">Cilnes</translation>
-<translation id="8084114998886531721">Saglabātā parole</translation>
-<translation id="8087000398470557479">Šis saturs ir no vietnes <ph name="DOMAIN_NAME" />, ko nodrošina Google.</translation>
-<translation id="8103578431304235997">Inkognito cilne</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Lai grāmatzīmes būtu pieejamas visās jūsu ierīcēs, ieslēdziet sinhronizāciju.</translation>
-<translation id="8110087112193408731">Vai rādīt jūsu Chrome darbības Digitālajā labjutībā?</translation>
-<translation id="8116925261070264013">Izslēgta skaņa</translation>
-<translation id="813082847718468539">Skatīt informāciju par vietni</translation>
-<translation id="8131740175452115882">Apstiprināt</translation>
-<translation id="8156139159503939589">Kādā valodā jūs lasāt?</translation>
-<translation id="8168435359814927499">Saturs</translation>
-<translation id="8186512483418048923">Atlikuši faili: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Atlikusi 1 diena</translation>
-<translation id="8200772114523450471">Kopsavilkums</translation>
-<translation id="8209050860603202033">Atvērt attēlu</translation>
-<translation id="8218622182176210845">Konta pārvaldība</translation>
-<translation id="8224471946457685718">Rakstu lejupielāde tikai pa Wi-Fi</translation>
-<translation id="8232956427053453090">Paturēt datus</translation>
-<translation id="8249310407154411074">Pārvietot uz augšdaļu</translation>
-<translation id="8250920743982581267">Dokumenti</translation>
-<translation id="825412236959742607">Šī lapa izmanto pārāk daudz atmiņas, tādēļ pārlūks Chrome noņēma daļu satura.</translation>
-<translation id="8260126382462817229">Mēģiniet pierakstīties vēlreiz</translation>
-<translation id="8261506727792406068">Dzēst</translation>
-<translation id="8266862848225348053">Lejupielādes atrašanās vieta</translation>
-<translation id="8274165955039650276">Skatīt lejupielādes</translation>
-<translation id="8284326494547611709">Paraksti</translation>
-<translation id="8300705686683892304">Pārvalda lietotne</translation>
-<translation id="8310344678080805313">Standarta cilnes</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> un citas vietnes</translation>
-<translation id="8327155640814342956">Atveriet, lai uzlabotu pārlūkošanas ērtības, atjauninot pārlūku Chrome</translation>
-<translation id="8339163506404995330">Lapas šādā valodā: <ph name="LANGUAGE" /> netiks tulkotas.</translation>
-<translation id="8349013245300336738">Kārtot pēc izmantoto datu apjoma</translation>
-<translation id="8364299278605033898">Skatīt populāras vietnes</translation>
-<translation id="8368027906805972958">Nezināma vai neatbalstīta ierīce (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Atļaut sinhronizāciju fonā konkrētai vietnei</translation>
-<translation id="8378714024927312812">Pārvalda jūsu organizācija</translation>
-<translation id="8380167699614421159">Šajā vietnē tiek rādītas traucējošas vai maldinošas reklāmas</translation>
-<translation id="8393700583063109961">Sūtīt ziņojumu</translation>
-<translation id="8413126021676339697">Rādīt pilnu vēsturi</translation>
-<translation id="8427875596167638501">Priekšskatījuma cilne ir daļēji atvērta</translation>
-<translation id="8428213095426709021">Iestatījumi</translation>
-<translation id="8438566539970814960">Uzlabot meklēšanu un pārlūkošanu</translation>
-<translation id="8441146129660941386">Pārtīt atpakaļ</translation>
-<translation id="8443209985646068659">Nevar atjaunināt Chrome</translation>
-<translation id="8445448999790540984">Nevar eksportēt paroles</translation>
-<translation id="8447861592752582886">Atsaukt ierīces atļauju</translation>
-<translation id="8461694314515752532">Šifrējiet sinhronizētos datus, izmantojot savu sinhronizācijas ieejas frāzi</translation>
-<translation id="8466613982764129868">Ierīcē <ph name="TARGET_DEVICE_NAME" /> ir jābūt izveidotam interneta savienojumam</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Pieejams bezsaistē</translation>
-<translation id="8489271220582375723">Atvērt vēstures lapu</translation>
-<translation id="8493948351860045254">Atbrīvot vietu</translation>
-<translation id="8497726226069778601">Šeit vēl nekā nav...</translation>
-<translation id="8503559462189395349">Chrome paroles</translation>
-<translation id="8503813439785031346">Lietotājvārds</translation>
-<translation id="8514477925623180633">Eksportēt pārlūkā Chrome saglabātās paroles</translation>
-<translation id="8514577642972634246">Atvērt inkognito režīmā</translation>
-<translation id="851751545965956758">Neļaut vietnēm izveidot savienojumu ar ierīci</translation>
-<translation id="8523928698583292556">Dzēst saglabāto paroli</translation>
-<translation id="854522910157234410">Atvērt šo lapu</translation>
-<translation id="8558485628462305855">Lai skatītu papildinātās realitātes saturu, atjauniniet ARCore</translation>
-<translation id="8559990750235505898">Piedāvāt tulkot lapas citās valodās</translation>
-<translation id="8562452229998620586">Šeit tiks parādītas saglabātās paroles.</translation>
-<translation id="8569404424186215731">kopš šāda datuma: <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Pēdējās 4 nedēļas</translation>
-<translation id="857943718398505171">Atļauta (ieteicams)</translation>
-<translation id="8583805026567836021">Konta datu dzēšana</translation>
-<translation id="860043288473659153">Bankas kartes īpašnieka vārds</translation>
-<translation id="8609465669617005112">Virziet uz augšu</translation>
-<translation id="8616006591992756292">Jūsu Google kontam var būt citu veidu pārlūkošanas vēstures dati vietnē <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Vai atvērt lejupielādētajā saturā norādīto ieteikto URL?</translation>
-<translation id="8636825310635137004">Ieslēdziet sinhronizāciju, lai būtu pieejamas cilnes no citām jūsu ierīcēm.</translation>
-<translation id="8641930654639604085">Pēc iespējas bloķēt vietnes ar pieaugušajiem paredzētu saturu</translation>
-<translation id="8655129584991699539">Varat notīrīt datus Chrome iestatījumos</translation>
-<translation id="8662811608048051533">Jūs tiksiet izrakstīts no lielākās daļas vietņu.</translation>
-<translation id="8664979001105139458">Faila nosaukums jau pastāv</translation>
-<translation id="8676374126336081632">Notīrīt ievadi</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signāla stipruma līmenis: # josla}zero{Signāla stipruma līmenis: # joslu}one{Signāla stipruma līmenis: # josla}other{Signāla stipruma līmenis: # joslas}}</translation>
-<translation id="868929229000858085">Meklējiet kontaktpersonas</translation>
-<translation id="869891660844655955">Derīguma termiņš</translation>
-<translation id="8719023831149562936">Nevar kopīgot šo cilni, izmantojot Beam.</translation>
-<translation id="8725066075913043281">Mēģināt vēlreiz</translation>
-<translation id="8728487861892616501">Izmantojot šo lietojumprogrammu, jūs piekrītat Chrome <ph name="BEGIN_LINK1" />pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />paziņojumam par konfidencialitāti<ph name="END_LINK2" /> un <ph name="BEGIN_LINK3" />paziņojumam par konfidencialitāti Google kontiem, kas tiek pārvaldīti lietotnē Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Gatavs</translation>
-<translation id="8748850008226585750">Saturs paslēpts</translation>
-<translation id="8751914237388039244">Attēla atlase</translation>
-<translation id="8788265440806329501">Navigācijas vēsture ir aizvērta</translation>
-<translation id="8788968922598763114">Atkārtoti atvērt pēdējo aizvērto cilni</translation>
-<translation id="8801436777607969138">Bloķēt JavaScript konkrētai vietnei.</translation>
-<translation id="8812260976093120287">Dažās vietnēs var norēķināties, ierīcē izmantojot iepriekš norādītās atbalstītās maksājumu lietotnes.</translation>
-<translation id="8816026460808729765">Bloķēt vietņu piekļuvi sensoriem</translation>
-<translation id="8816439037877937734">Lietotne <ph name="APP_NAME" /> tiks atvērta pārlūkā Chrome. Turpinot jūs piekrītat Chrome <ph name="BEGIN_LINK1" />pakalpojumu sniegšanas noteikumiem<ph name="END_LINK1" /> un <ph name="BEGIN_LINK2" />konfidencialitātes paziņojumam<ph name="END_LINK2" />, kā arī <ph name="BEGIN_LINK3" />konfidencialitātes paziņojumam Google kontiem, kas tiek pārvaldīti lietotnē Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Grāmatzīmes</translation>
-<translation id="8833831881926404480">Vietne kopīgo jūsu ekrānu</translation>
-<translation id="883806473910249246">Lejupielādējot saturu, radās kļūda.</translation>
-<translation id="8840953339110955557">Šī lapas versija var atšķirties no tiešsaises versijas.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Cilne <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Krātuve</translation>
-<translation id="889338405075704026">Pāriet uz Chrome iestatījumiem</translation>
-<translation id="8901170036886848654">Nav atrasta neviena grāmatzīme</translation>
-<translation id="8909135823018751308">Kopīgot...</translation>
-<translation id="8912362522468806198">Google konts</translation>
-<translation id="8920114477895755567">Gaida vecāku informāciju.</translation>
+<translation id="1188239144602654184">Ievadīt PR</translation>
+<translation id="473775607612524610">Atjaunināt</translation>
+<translation id="3133489217401741157">Notiek moduļa <ph name="MODULE"/> instalēšana pārlūkprogrammai Brave…</translation>
+<translation id="1791662854739702043">Instalēts</translation>
+<translation id="5131234170665854056">Nevar instalēt moduli <ph name="MODULE"/> pārlūkprogrammai Brave.</translation>
+<translation id="2567385386134582609">ATTĒLS</translation>
+<translation id="6395288395575013217">SAITE</translation>
+<translation id="7352939065658542140">VIDEOKLIPS</translation>
+<translation id="4116038641877404294">Lejupielādējiet lapas, lai izmantotu tās bezsaistē</translation>
 <translation id="8922289737868596582">Izmantojiet pogu Vairāk opciju, lai lejupielādētu lapas un piekļūtu tām bezsaistē</translation>
-<translation id="8937772741022875483">Vai noņemt jūsu Chrome darbības no Digitālās labjutības?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Atvērt citā logā</translation>
-<translation id="8951232171465285730">Pārlūkā Chrome esat ietaupījis <ph name="MEGABYTES" /> MB.</translation>
-<translation id="8958424370300090006">Bloķēt sīkfailus konkrētai vietnei.</translation>
-<translation id="8959122750345127698">Navigācija nav sasniedzama: <ph name="URL" /></translation>
-<translation id="8965591936373831584">gaida</translation>
-<translation id="8970887620466824814">Radās kļūda.</translation>
-<translation id="8972098258593396643">Vai lejupielādēt noklusējuma mapē?</translation>
-<translation id="8986494364107987395">Automātiski sūtīt lietošanas statistiku un avāriju pārskatus uzņēmumam Google</translation>
-<translation id="8993760627012879038">Atvērt jaunu cilni inkognito režīmā</translation>
-<translation id="8998729206196772491">Jūs pierakstāties kontā, kas tiek pārvaldīts domēnā <ph name="MANAGED_DOMAIN" />, un sniedzat tā administratoram kontroli pār saviem Chrome datiem. Jūsu dati tiks neatgriezeniski saistīti ar šo kontu. Izrakstoties no pārlūka Chrome, jūsu dati tiks dzēsti no šīs ierīces, taču tie tiks saglabāti jūsu Google kontā.</translation>
-<translation id="9019902583201351841">Pārvalda jūsu vecāki</translation>
-<translation id="9028914725102941583">Sinhronizācijas ieslēgšana, lai kopīgotu saturu vairākās ierīcēs</translation>
-<translation id="9029323097866369874">Vai atļaut <ph name="DOMAIN" /> aktivizēt VR režīmu?</translation>
-<translation id="9040142327097499898">Paziņojumi ir atļauti. Atrašanās vietas noteikšana šai ierīcei ir izslēgta.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videoklips}zero{# videoklipi}one{# videoklips}other{# videoklipi}}</translation>
-<translation id="9050666287014529139">Ieejas frāze</translation>
-<translation id="9063523880881406963">Izslēgt iestatījumu “Pieprasīt datora vietni”</translation>
-<translation id="9065203028668620118">Labot</translation>
-<translation id="9070377983101773829">Sākt meklēšanu ar balsi</translation>
-<translation id="9074336505530349563">Lai saņemtu Google ieteikto personalizēto saturu, pierakstieties un ieslēdziet sinhronizāciju.</translation>
-<translation id="9086455579313502267">Nevar piekļūt tīklam</translation>
-<translation id="9100505651305367705">Piedāvāt rādīt rakstus vienkāršotā skatā, ja tāds tiek atbalstīts</translation>
-<translation id="9100610230175265781">Jāievada ieejas frāze.</translation>
-<translation id="9102803872260866941">Priekšskatījuma cilne ir atvērta</translation>
+<translation id="5958275228015807058">Atrodiet savus failus un lapas sadaļā Lejupielādes</translation>
+<translation id="5620928963363755975">Atrodiet savus failus un lapas sadaļā Lejupielādes, nospiežot pogu Vairāk opciju</translation>
+<translation id="3341058695485821946">Uzziniet ietaupīto datu apjomu</translation>
+<translation id="3157842584138209013">Izmantojiet pogu Vairāk opciju, lai uzzinātu ietaupīto datu apjomu</translation>
+<translation id="8218622182176210845">Konta pārvaldība</translation>
+<translation id="8090895580117672212">Lai pārvaldītu savu Brave Software kontu, pieskarieties pogai “Konta pārvaldība”</translation>
+<translation id="8856898588039823173">Vienkāršota lapa, ko nodrošina Brave Software. Lai ielādētu sākotnējo lapu, pieskarieties.</translation>
+<translation id="8134317863207426198">Vienkāršota lapa, ko nodrošina Brave Software. Pieskarieties pogai “Ielādēt sākotnējo”, lai ielādētu sākotnējo lapu.</translation>
+<translation id="4961107849584082341">Tulkojiet šīs lapas saturu jebkurā valodā.</translation>
+<translation id="569536719314091526">Tulkojiet šīs lapas saturu jebkurā valodā, izmantojot pogu Vairāk opciju.</translation>
+<translation id="1397811292916898096">Meklēt, izmantojot meklētājprogramu <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Noklusējuma lejupielādes vietu var mainīt jebkurā laikā.</translation>
+<translation id="6942665639005891494">Noklusējuma lejupielādes vietu var mainīt jebkurā laikā, izmantojot izvēlnes Iestatījumi opciju.</translation>
+<translation id="6850409657436465440">Joprojām notiek lejupielāde</translation>
+<translation id="5817715962196959877">Tagad pārlūkā Brave faili tiek lejupielādēti ātrāk.</translation>
+<translation id="3976396876660209797">Noņemt un atkārtoti izveidot šo saīsni</translation>
+<translation id="6766622839693428701">Velciet uz leju, lai aizvērtu.</translation>
+<translation id="1028699632127661925">Notiek sūtīšana uz: <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> — nosūtīts no ierīces <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Saņemta cilne</translation>
 <translation id="9104217018994036254">Ierīču saraksts, ar ko kopīgot cilni.</translation>
-<translation id="9133397713400217035">Izpētīt bezsaisti</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Rādīt oriģinālo</translation>
-<translation id="9139068048179869749">Jautāt, pirms atļaut vietnēm sūtīt paziņojumus (ieteicams)</translation>
-<translation id="9139318394846604261">Pirkumi</translation>
-<translation id="9155898266292537608">Varat arī meklēt, ātri pieskaroties vārdam</translation>
-<translation id="9169507124922466868">Navigācijas vēsture ir atvērta līdz pusei.</translation>
-<translation id="9204836675896933765">Atlicis 1 fails</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Ierīču saraksts, ar ko kopīgot cilni, ir atvērts pusekrāna augstumā.</translation>
+<translation id="2904414404539560095">Ierīču saraksts, ar ko kopīgot cilni, ir atvērts pilna ekrāna augstumā.</translation>
+<translation id="4135200667068010335">Ierīču saraksts, ar ko kopīgot cilni, ir aizvērts.</translation>
+<translation id="5292796745632149097">Sūtīt uz:</translation>
+<translation id="1386674309198842382">Aktīvs pirms <ph name="LAST_UPDATED"/> dienām</translation>
+<translation id="7971136598759319605">Aktīva pirms 1 dienas</translation>
+<translation id="1521774566618522728">Aktīvs šodien</translation>
+<translation id="3631987586758005671">Notiek kopīgošana ar ierīci <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Sinhronizācijas ieslēgšana, lai kopīgotu saturu vairākās ierīcēs</translation>
+<translation id="6162454065885854378">Lai kopīgotu sava tālruņa saturu ar citu ierīci, ieslēdziet sinhronizāciju abu ierīču Brave iestatījumos.</translation>
+<translation id="6084271560289605378">Pāriet uz Brave iestatījumiem</translation>
+<translation id="2318045970523081853">Pieskarieties, lai zvanītu</translation>
 <translation id="9209888181064652401">Nevar zvanīt</translation>
-<translation id="9219103736887031265">Attēli</translation>
-<translation id="926205370408745186">Chrome darbību noņemšana no Digitālās labjutības</translation>
-<translation id="932327136139879170">Sākums</translation>
-<translation id="938850635132480979">Kļūda: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Piekļuve mikrofonam</translation>
-<translation id="95817756606698420">Pārlūkā Chrome var izmantot meklētājprogrammu <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />, lai veiktu meklēšanu Ķīnā. Varat to mainīt sadaļā <ph name="BEGIN_LINK" />Iestatījumi<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloķēt, ja vietnē tiek rādītas traucējošas vai maldinošas reklāmas (ieteicams)</translation>
-<translation id="968900484120156207">Šeit tiek rādītas jūsu apmeklētās lapas</translation>
-<translation id="970715775301869095">Atlikušas <ph name="MINUTES" /> min</translation>
-<translation id="974555521953189084">Lai sāktu sinhronizēšanu, ievadiet ieejas frāzi</translation>
-<translation id="981121421437150478">Bezsaistē</translation>
-<translation id="982182592107339124">Tādējādi tiks dzēsti dati no visām vietnēm, tostarp:</translation>
-<translation id="983192555821071799">Aizvērt visas cilnes</translation>
-<translation id="987264212798334818">Vispārīgi</translation>
+<translation id="2860954141821109167">Šajā ierīcē jābūt iespējotai tālruņa lietotnei</translation>
+<translation id="2067805253194386918">teksts</translation>
+<translation id="1450753235335490080">Nevar kopīgot: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Nevarēja kopīgot: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Ierīcē <ph name="TARGET_DEVICE_NAME"/> ieslēdziet Brave sinhronizāciju</translation>
+<translation id="3016635187733453316">Pārbaudiet, vai šajā ierīcē ir izveidots interneta savienojums</translation>
+<translation id="8466613982764129868">Ierīcē <ph name="TARGET_DEVICE_NAME"/> ir jābūt izveidotam interneta savienojumam</translation>
+<translation id="6539092367496845964">Radās kļūda. Vēlāk mēģiniet vēlreiz.</translation>
+<translation id="3389286852084373014">Teksts ir pārāk liels</translation>
+<translation id="2100314319871056947">Kopīgojiet mazākus teksta fragmentus</translation>
+<translation id="2987620471460279764">No citas ierīces kopīgotais teksts</translation>
+<translation id="7757787379047923882">Kopīgots teksts no ierīces <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kopēts jūsu starpliktuvē</translation>
+<translation id="4696983787092045100">Sūtīt īsziņu uz manām ierīcēm</translation>
+<translation id="1260236875608242557">Meklēšana un izpēte</translation>
+<translation id="6369229450655021117">Šeit varat veikt meklēšanu tīmeklī, kopīgot saturu ar draugiem un skatīt atvērtās lapas.</translation>
+<translation id="723171743924126238">Atlasīt attēlus</translation>
+<translation id="8751914237388039244">Attēla atlase</translation>
+<translation id="1989112275319619282">Pārlūkot</translation>
+<translation id="7055152154916055070">Novirzīšana ir bloķēta:</translation>
+<translation id="5524843473235508879">Novirzīšana ir bloķēta.</translation>
+<translation id="6573096386450695060">Vienmēr atļaut</translation>
+<translation id="5805364706385912897">Šī lapa izmanto pārāk daudz atmiņas, tādēļ Brave to apturēja.</translation>
+<translation id="5138664332909611586">Šī lapa izmanto pārāk daudz atmiņas, tādēļ pārlūks Brave noņēma daļu satura.</translation>
+<translation id="9137013805542155359">Rādīt oriģinālo</translation>
+<translation id="6361779936989026201">Brave Software asistents pārlūkprogrammā Brave</translation>
+<translation id="7291387454912369099">Asistenta aktivizēta norēķināšanās</translation>
+<translation id="4565206163201411670">Vai rādīt jūsu Brave darbības Digitālajā labjutībā?</translation>
+<translation id="9055113864158719823">Varat skatīt pārlūkā Brave apmeklētās vietnes un iestatīt tām taimerus.\n\nBrave Software saņem informāciju par vietnēm, kurām iestatāt taimerus, kā arī šo vietņu apmeklēšanas ilgumu. Šī informācija tiek izmantota, lai uzlabotu Digitālo labjutību.</translation>
+<translation id="4596514158372210596">Brave darbību noņemšana no Digitālās labjutības</translation>
+<translation id="1174893863889683998">Vai noņemt jūsu Brave darbības no Digitālās labjutības?</translation>
+<translation id="708829030563435351">Netiks rādītas vietnes, ko apmeklējat pārlūkā Brave. Tiks izdzēsti visi vietņu taimeri.</translation>
+<translation id="2056878612599315956">Vietne apturēta</translation>
+<translation id="671481426037969117">Jūsu lietotnes <ph name="FQDN"/> taimera laiks ir beidzies. Tas atkal sāksies rīt.</translation>
+<translation id="7479104141328977413">Ciļņu pārvaldība</translation>
+<translation id="3524138585025253783">Izstrādātāja lietotājsaskarne</translation>
+<translation id="6036057147555329831">Citi ICU</translation>
+<translation id="9029323097866369874">Vai atļaut <ph name="DOMAIN"/> aktivizēt VR režīmu?</translation>
+<translation id="7685301384041462804">Aktivizējiet VR režīmu tikai tad, ja esat pārliecināts, ka šī vietne ir uzticama.</translation>
+<translation id="5033865233969348410">Ja ir aktivizēts VR režīms, vietne var iegūt šādus datus:
+  – jūsu fiziskās īpašības, piemēram, augumu.
+
+Aktivizējiet VR režīmu tikai tad, ja esat pārliecināts, ka šī vietne ir uzticama.</translation>
+<translation id="5534334044554683961">Ja ir aktivizēts VR režīms, vietne var iegūt šādus datus:
+  – jūsu fiziskās īpašības, piemēram, augumu;
+  – telpas izkārtojumu.
+
+Aktivizējiet VR režīmu tikai tad, ja esat pārliecināts, ka šī vietne ir uzticama.</translation>
+<translation id="4169535189173047238">Neatļaut</translation>
+<translation id="2170088579611075216">Atļaut un ieiet virtuālajā realitātē</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ml.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ml.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ml">
-<translation id="1006017844123154345">ഓൺലൈനായി തുറക്കുക</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> എന്നതിലേക്ക് അയ‌യ്‌ക്കുന്നു...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> ചേർക്കുന്നു...</translation>
-<translation id="1041308826830691739">വെബ്‌സൈറ്റുകളിൽ നിന്ന്</translation>
-<translation id="1049743911850919806">ആള്‍‌മാറാട്ടം</translation>
-<translation id="10614374240317010">ഒരിക്കലും സംരക്ഷിച്ചില്ല</translation>
-<translation id="1067922213147265141">മറ്റ് Google സേവനങ്ങള്‍‌</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" /> ഭാഷയിലുള്ള പേജുകൾ ഒരിക്കലും വിവർത്തനം ചെയ്യരുത്</translation>
-<translation id="107147699690128016">ഫയൽ എക്സ്റ്റൻഷൻ മാറ്റിയാൽ, ഫയൽ വ്യത്യസ്ത ആപ്പിൽ തുറന്നേക്കാം, ഒപ്പം അത് നിങ്ങളുടെ ഉപകരണത്തിന് ദോഷകരമാവാൻ സാധ്യതയുണ്ട്.</translation>
-<translation id="1100066534610197918">ഗ്രൂപ്പിലെ പുതിയ ടാബിൽ തുറക്കൂ</translation>
-<translation id="1105960400813249514">സ്‌ക്രീൻ ക്യാപ്‌ചർ</translation>
-<translation id="1111673857033749125">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ സംരക്ഷിച്ച ബുക്ക്‌മാർക്കുകൾ ഇവിടെ ദൃശ്യമാകും.</translation>
-<translation id="1113597929977215864">ലളിതവൽക്കരിച്ച കാഴ്‌ച കാണിക്കുക</translation>
-<translation id="1121094540300013208">ഉപയോഗ, ക്രാഷ് റിപ്പോർട്ടുകൾ</translation>
-<translation id="1124772482545689468">ഉപയോക്താവ്</translation>
-<translation id="1129510026454351943">വിശദാംശങ്ങള്‍: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{ഒരു ഡൗൺലോഡ് ശേഷിക്കുന്നു.}other{# ഡൗൺലോഡുകൾ ശേഷിക്കുന്നു.}}</translation>
-<translation id="1145536944570833626">നിലവിലുള്ള വിവരങ്ങൾ ഇല്ലാതാക്കുക.</translation>
-<translation id="1146678959555564648">VR-ൽ പ്രവേശിക്കുക</translation>
-<translation id="116280672541001035">ഉപയോഗിച്ചത്</translation>
-<translation id="1171770572613082465">"മികച്ച സൈറ്റുകൾ" ബട്ടൺ ടാപ്പ് ചെയ്‌ത് ജനപ്രിയ വെബ്‌സൈറ്റുകൾ കാണുക</translation>
-<translation id="1173894706177603556">പേരുമാറ്റുക</translation>
-<translation id="1178581264944972037">അല്പംനിര്‍ത്തൂ</translation>
-<translation id="1181037720776840403">നീക്കംചെയ്യൂ</translation>
-<translation id="1188239144602654184">AR ആരംഭിക്കുക</translation>
-<translation id="1197267115302279827">ബു‌ക്ക്‌മാർക്കുകൾ നീക്കുക</translation>
-<translation id="119944043368869598">എല്ലാം നീക്കുക</translation>
-<translation id="1201402288615127009">അടുത്തത്</translation>
-<translation id="1204037785786432551">ലിങ്ക് ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="1206892813135768548">ലിങ്ക് വാചകം പകർത്തുക</translation>
-<translation id="1208340532756947324">ഉപകരണങ്ങളിൽ ഉടനീളം സമന്വയിപ്പിക്കാനും വ്യക്തിപരമാക്കാനും, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="1209206284964581585">ഇപ്പോഴത്തേയ്‌ക്ക് മറയ്‌ക്കുക</translation>
-<translation id="1227058898775614466">നാവിഗേഷന്‍ ചരിത്രം</translation>
-<translation id="1231733316453485619">സമന്വയിപ്പിക്കൽ ഓണാക്കണോ?</translation>
-<translation id="123724288017357924">കാഷെ ചെയ്‌ത ഉള്ളടക്കം ഒഴിവാക്കി കൊണ്ട്, നിലവിലെ പേജ് റീലോഡ് ചെയ്യുക</translation>
-<translation id="124116460088058876">കൂടുതൽ ഭാഷകൾ</translation>
-<translation id="124678866338384709">നിലവിലെ ടാബ് അടയ്‌ക്കുക</translation>
-<translation id="1258753120186372309">Google ഡൂഡിൽ: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">തിരയുക, അടുത്തറിയുക</translation>
-<translation id="1264974993859112054">കായികം</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> പങ്കിടാനായില്ല</translation>
-<translation id="1272079795634619415">നിര്‍ത്തുക</translation>
-<translation id="1283039547216852943">വികസിപ്പിക്കാൻ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="1285320974508926690">ഈ സൈറ്റ് ഒരിക്കലും വിവര്‍‌ത്തനം ചെയ്യരുത്</translation>
-<translation id="1291207594882862231">ചരിത്രവും കുക്കികളും സൈറ്റ് വിവരവും കാഷെയും മായ്‌ക്കുക...</translation>
-<translation id="129382876167171263">വെബ്സൈറ്റുകൾ സംരക്ഷിച്ചിട്ടുള്ള ഫയലുകള്‍ ഇവിടെ ദൃശ്യമാവും</translation>
-<translation id="129553762522093515">സമീപകാലത്ത് അടച്ചവ</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" />-ൽ നിന്ന് അയച്ചത്</translation>
-<translation id="1310482092992808703">ടാബുകൾ ഗ്രൂപ്പ് ചെയ്യൂ</translation>
-<translation id="1327257854815634930">നാവിഗേഷൻ ചരിത്രം തുറന്നിരിക്കുന്നു</translation>
-<translation id="1331212799747679585">Chrome അപ്‌ഡേറ്റ് ചെയ്യാനാവില്ല. കൂടുതൽ ഓപ്‌ഷനുകൾ</translation>
-<translation id="1332501820983677155">Google Chrome ഫീച്ചർ കുറുക്കുവഴികൾ</translation>
-<translation id="1360432990279830238">സൈൻ ഔട്ട് ചെയ്‌ത് സമന്വയം ഓഫാക്കണോ?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> എന്ന സൈറ്റ് ചേർത്തൂ</translation>
-<translation id="1373696734384179344">തിരഞ്ഞെടുത്ത ഉള്ളടക്കം ഡൗൺലോഡ് ചെയ്യുന്നതിന് ആവശ്യമായ മെമ്മറിയില്ല.</translation>
-<translation id="1376578503827013741">കണക്കാക്കുന്നു…</translation>
-<translation id="1383876407941801731">തിരയുക</translation>
-<translation id="1384959399684842514">ഡൗൺലോഡ് താൽക്കാലികമായി നിർത്തി</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> ദിവസം മുമ്പ് സജീവമായിരുന്നു</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> ഉപയോഗിച്ച് തിരയുക</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" /> എന്നതിൽ ഉൾപ്പെടുത്തി</translation>
-<translation id="1406000523432664303">“ട്രാക്ക് ചെയ്യരുത്”</translation>
-<translation id="1407135791313364759">എല്ലാം തുറക്കുക</translation>
-<translation id="1409426117486808224">തുറന്ന ടാബുകൾക്കായി ലളിതവൽക്കരിച്ച കാഴ്ച</translation>
-<translation id="1409879593029778104">ഫയൽ ഇതിനകം തന്നെ ഉള്ളതിനാൽ <ph name="FILE_NAME" /> ഡൗൺലോഡ് തടഞ്ഞു.</translation>
-<translation id="1414981605391750300">Google-നെ ബന്ധപ്പെടുന്നു. ഇതിന് ഒരു മിനിറ്റ് എടുത്തേക്കാം…</translation>
-<translation id="1416550906796893042">ആപ്പ് പതിപ്പ്</translation>
-<translation id="1430915738399379752">അച്ചടിക്കുക</translation>
-<translation id="1446450296470737166">MIDI ഉപകരണങ്ങളുടെ പൂർണ്ണ നിയന്ത്രണം അനുവദിക്കുക</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> പങ്കിടാനാവുന്നില്ല</translation>
-<translation id="145097072038377568">Android ക്രമീകരണത്തിൽ ഓഫാക്കിയിരിക്കുന്നു</translation>
-<translation id="1477626028522505441">സെർവർ പ്രശ്‌നങ്ങൾ കാരണം <ph name="FILE_NAME" /> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
-<translation id="1506061864768559482">തിരയൽ യന്ത്രം</translation>
-<translation id="1513352483775369820">ബുക്ക്‌മാർക്കുകളും വെബ് ചരിത്രവും</translation>
-<translation id="1513858653616922153">പാസ്‌വേഡ് ഇല്ലാതാക്കുക</translation>
-<translation id="1516229014686355813">Google തിരയലിന് സന്ദർഭം വ്യക്തമാക്കാൻ തിരഞ്ഞെടുത്ത വാക്കും നിലവിലെ പേജും, 'തിരയാൻ സ്‌പർശിക്കുക' അയയ്‌ക്കും. <ph name="BEGIN_LINK" />ക്രമീകരണത്തിൽ<ph name="END_LINK" /> നിന്ന് നിങ്ങൾക്കിത് ഓഫാക്കാം.</translation>
-<translation id="1521774566618522728">ഇന്ന് സജീവമായിരുന്നു</translation>
-<translation id="1544826120773021464">നിങ്ങളുടെ Google അക്കൗണ്ട് മാനേജ് ചെയ്യാൻ, "അക്കൗണ്ട് മാനേജ് ചെയ്യുക" ബട്ടണിൽ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="1549000191223877751">മറ്റൊരു വിൻഡോയിലേക്ക് നീക്കുക</translation>
-<translation id="1553358976309200471">Chrome അപ്‌ഡേറ്റുചെയ്യുക</translation>
-<translation id="1569387923882100876">കണക്റ്റ് ചെയ്‌തിരിക്കുന്ന ഉപകരണം</translation>
-<translation id="1571304935088121812">ഉപയോക്തൃനാമം പകർത്തുക</translation>
-<translation id="1612196535745283361">ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യാൻ Chrome-ന് ലൊക്കേഷൻ ആക്‌സസ് ആവശ്യമാണ്. ഈ ഉപകരണത്തിന്റെ <ph name="BEGIN_LINK" />ലൊക്കേഷൻ ആക്‌സസ് ഓഫാണ്<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">ക്യാമറ</translation>
-<translation id="1623104350909869708">കൂടുതൽ ഡയലോഗുകൾ സൃഷ്‌ടിക്കുന്നതിൽ നിന്നും ഈ പേജിനെ തടയുക</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{തിരഞ്ഞെടുത്ത ഒരു ഇനം നീക്കംചെയ്യുക}other{തിരഞ്ഞെടുത്ത # ഇനങ്ങൾ നീക്കംചെയ്യുക}}</translation>
-<translation id="164269334534774161">നിങ്ങൾ ഈ പേജിന്‍റെ <ph name="CREATION_TIME" /> മുതലുള്ള ഓഫ്‌ലൈൻ പകർപ്പാണ് കാണുന്നത്</translation>
-<translation id="1644574205037202324">ചരിത്രം</translation>
-<translation id="1647391597548383849">നിങ്ങളുടെ ക്യാമറ ആക്‌സസ് ചെയ്യുക</translation>
-<translation id="1660204651932907780">ശബ്‌ദം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്യുന്നു)</translation>
-<translation id="1670399744444387456">അടിസ്ഥാനം</translation>
-<translation id="1671236975893690980">ഡൗൺലോഡ് തീർച്ചപ്പെടുത്തിയിട്ടില്ല...</translation>
-<translation id="1672586136351118594">വീണ്ടും കാണിക്കരുത്</translation>
-<translation id="1692118695553449118">സമന്വയം ഓണാണ്</translation>
-<translation id="169515064810179024">ചലന സെൻസറുകൾ ആക്‌സസ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
-<translation id="1717218214683051432">ചലന സെൻസറുകൾ</translation>
-<translation id="1718835860248848330">കഴിഞ്ഞ മണിക്കൂര്‍‌</translation>
-<translation id="1736419249208073774">അടുത്തറിയുക</translation>
-<translation id="1743802530341753419">ഒരു ഉപകരണത്തിലേക്ക് കണക്‌റ്റ് ചെയ്യുന്നതിന് സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശ ചെയ്തിരിക്കുന്നു)</translation>
-<translation id="1749561566933687563">നിങ്ങളുടെ ബുക്ക്മാർക്കുകൾ സമന്വയിപ്പിക്കുക</translation>
-<translation id="17513872634828108">ഓപ്പൺ ടാബുകൾ</translation>
-<translation id="1779089405699405702">ഇമേജ് ഡീകോഡർ</translation>
-<translation id="1782483593938241562">അവസാന തീയതി <ph name="DATE" /></translation>
-<translation id="1791662854739702043">ഇന്‍സ്റ്റാളുചെയ്തു</translation>
-<translation id="1792959175193046959">ഏതുസമയത്തും ഡിഫോൾട്ട് ഡൗൺലോഡ് ലൊക്കേഷൻ മാറ്റുക</translation>
-<translation id="1807246157184219062">ലൈറ്റ്</translation>
-<translation id="1810845389119482123">പ്രാഥമിക സമന്വയ സജ്ജീകരണം പൂർത്തിയാക്കിയിട്ടില്ല</translation>
-<translation id="1821253160463689938">നിങ്ങൾ ആ പേജുകൾ സന്ദർശിക്കുന്നില്ലെങ്കിൽ പോലും, നിങ്ങളുടെ മുൻഗണനകൾ ഓർമ്മിക്കുന്നതിന് കുക്കികളെ ഉപയോഗിക്കുന്നു</translation>
-<translation id="1829244130665387512">പേജില്‍ കണ്ടുപിടിക്കുക</translation>
-<translation id="1853692000353488670">പുതിയ അദൃശ്യ ടാബ്</translation>
-<translation id="1856325424225101786">ലൈറ്റ് മോഡ് പുനഃസജ്ജീകരിക്കണോ?</translation>
-<translation id="1868024384445905608">Chrome ഇപ്പോൾ വേഗത്തിൽ ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യുന്നു</translation>
-<translation id="1883903952484604915">എന്റെ ഫയലുകൾ</translation>
-<translation id="1887786770086287077">ഈ ഉപകരണത്തിന്‍റെ ലൊക്കേഷൻ ആക്‌സസ് ഓഫാണ്; <ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> അത് ഓണാക്കുക.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> Chrome-ൽ തുറക്കും. തുടരുന്നതിലൂടെ, നിങ്ങൾ Chrome-ന്റെ <ph name="BEGIN_LINK1" />സേവന നിബന്ധനകളും<ph name="END_LINK1" /> <ph name="BEGIN_LINK2" />സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK2" /> അംഗീകരിക്കുന്നു.</translation>
-<translation id="1919345977826869612">പരസ്യങ്ങള്‍</translation>
-<translation id="1919950603503897840">കോൺടാക്റ്റുകൾ തിരഞ്ഞെടുക്കുക</translation>
-<translation id="1922076542920281912">നിങ്ങളുടെ ലൊക്കേഷൻ ആക്‌സസ് ചെയ്യാൻ Chrome-നെ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> ലൊക്കേഷനും ഓണാക്കുക.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">അപ്‌ഡേറ്റുചെയ്യുന്നു</translation>
-<translation id="19288952978244135">Chrome വീണ്ടും തുറക്കുക.</translation>
-<translation id="1933845786846280168">തിരഞ്ഞെടുത്ത ടാബ്</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> Chrome-നായി അനുമതി ഓണാക്കുക.</translation>
-<translation id="1943432128510653496">സംരക്ഷിച്ച പാസ്‌വേഡുകള്‍</translation>
-<translation id="1952172573699511566">വെബ്സൈറ്റുകൾ, സാധ്യമാകുന്നിടത്തെല്ലാം, നിങ്ങൾ തിരഞ്ഞെടുത്ത ഭാഷയിൽ ടെക്‌സ്‌റ്റ് കാണിക്കും.</translation>
-<translation id="1960290143419248813">Android-ന്റെ ഈ പതിപ്പിൽ ഇനിയങ്ങോട്ട് Chrome-ന്റെ അപ്‌ഡേറ്റുകൾ പിന്തുണയ്‌ക്കില്ല</translation>
-<translation id="1966710179511230534">നിങ്ങളുടെ സൈൻ ഇൻ വിശദാംശങ്ങൾ അപ്‌ഡേറ്റ് ചെയ്യുക.</translation>
-<translation id="1974060860693918893">നൂതനം</translation>
-<translation id="1984705450038014246">നിങ്ങളുടെ Chrome ഡാറ്റ സമന്വയിപ്പിക്കുക</translation>
-<translation id="1984937141057606926">മൂന്നാം കക്ഷി ഒഴികെയുള്ളവയെ അനുവദിച്ചിരിക്കുന്നു</translation>
-<translation id="1986685561493779662">പേര് ഇതിനകം നിലവിലുണ്ട്</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> ബട്ടൺ</translation>
-<translation id="1989112275319619282">ബ്രൗസ് ചെയ്യുക</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> ജോടിയാക്കാൻ താൽപ്പര്യപ്പെടുന്നു</translation>
-<translation id="1994173015038366702">സൈറ്റ് URL</translation>
-<translation id="2000419248597011803">നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനിലേക്ക് വിലാസ ബാറിൽ നിന്നും തിരയൽ ബോക്‌സിൽ നിന്നുമുള്ള തിരയലുകളും കുറച്ച് കുക്കികളും അയയ്ക്കുന്നു</translation>
-<translation id="2002537628803770967">Google Pay ഉപയോഗിക്കുന്ന ക്രെഡിറ്റ് കാർഡുകളും വിലാസങ്ങളും</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ഫയല്‍}other{# ഫയലുകൾ}}</translation>
-<translation id="2017836877785168846">വിലാസ ബാറിലെ ചരിത്രവും സ്വയം പൂർത്തീകരണങ്ങളും മായ്ക്കുന്നു.</translation>
-<translation id="2021896219286479412">പൂർണ്ണ സ്ക്രീൻ സൈറ്റ് നിയന്ത്രണങ്ങൾ</translation>
-<translation id="2038563949887743358">'ഡെസ്‌ക്‌ടോപ്പ് സൈറ്റ് അഭ്യർത്ഥിക്കുക' ഓണാക്കുക</translation>
-<translation id="2041019821020695769">അറിയിപ്പുകൾ അയയ്ക്കാൻ Chrome-നെ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> അറിയിപ്പുകളും ഓണാക്കുക.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> എന്നതിനും Chrome-ൽ ഡാറ്റയുണ്ടായിരുന്നു</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">സൈറ്റ് താൽക്കാലികമായി നിർത്തി</translation>
-<translation id="2063713494490388661">തിരയാൻ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="2067805253194386918">ടെക്‌സ്‌റ്റ്</translation>
-<translation id="2079545284768500474">പഴയപടിയാക്കുക</translation>
-<translation id="2082238445998314030"><ph name="RESULT_NUMBER" /> / <ph name="TOTAL_RESULTS" /> ഫലം</translation>
-<translation id="2091887806945687916">ശബ്‌ദം</translation>
-<translation id="2096012225669085171">ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിക്കലും വ്യക്തിപരമാക്കലും നടത്തുക.</translation>
-<translation id="2100273922101894616">സ്വയമേവയുള്ള സൈൻ ഇൻ</translation>
-<translation id="2100314319871056947">ചെറിയ ഭാഗങ്ങളായി ടെക്‌സ്‌റ്റ് പങ്കിടാൻ ശ്രമിക്കൂ</translation>
-<translation id="2107397443965016585">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശചെയ്‌തത്)</translation>
-<translation id="2111511281910874386">പേജിലേക്ക് പോകുക</translation>
-<translation id="2122601567107267586">ആപ്പ് തുറക്കാനായില്ല</translation>
-<translation id="2126426811489709554">Chrome നൽകുന്നത്</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> ലാഭിച്ചു</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> അടച്ചു</translation>
-<translation id="2139186145475833000">ഹോംസ്‌ക്രീനിൽ ചേർക്കുക</translation>
-<translation id="2146738493024040262">ഇൻസ്റ്റന്‍റ് ആപ്പ് തുറക്കുക</translation>
-<translation id="2148716181193084225">ഇന്ന്</translation>
-<translation id="2154484045852737596">കാർഡ് എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="2154710561487035718">URL പകര്‍ത്തുക</translation>
-<translation id="2156074688469523661">ശേഷിക്കുന്ന സൈറ്റുകൾ (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">നിങ്ങളുടെ ഫോണിൽ നിന്നും മറ്റൊരു ഉപകരണത്തിലേക്ക് എന്തെങ്കിലും പങ്കിടാൻ, രണ്ട് ഉപകരണങ്ങളിലെയും Chrome ക്രമീകരണത്തിൽ സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="2170088579611075216">VR അനുവദിച്ച് അതിൽ പ്രവേശിക്കുക</translation>
-<translation id="218608176142494674">പങ്കിടൽ</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> എന്ന പേരിൽ തുടരുക</translation>
-<translation id="2234876718134438132">സമന്വയവും Google സേവനങ്ങളും</translation>
-<translation id="2259659629660284697">പാസ്‌വേഡുകൾ എക്‌സ്‌പോർട്ട് ചെയ്യുക...</translation>
-<translation id="2268044343513325586">പരിഷ്‌ക്കരിക്കുക</translation>
-<translation id="2286841657746966508">ബില്ലിംഗ് വിലാസം</translation>
-<translation id="2289270750774289114">സമീപത്തുള്ള Bluetooth ഉപകരണങ്ങൾ കണ്ടെത്താൻ ഒരു സൈറ്റ് താൽപ്പര്യപ്പെടുമ്പോൾ ചോദിക്കുക (ശുപാർശചെയ്‌തത്)</translation>
-<translation id="230115972905494466">അനുയോജ്യമായ ഉപകരണങ്ങളൊന്നും കണ്ടെത്തിയില്ല</translation>
-<translation id="2315043854645842844">ഓപ്പറേറ്റിംഗ് സിസ്റ്റം ക്ലയന്റിന്റെ സർട്ടിഫിക്കറ്റ് തിരഞ്ഞെടുക്കലിനെ പിന്തുണയ്‌ക്കുന്നില്ല.</translation>
-<translation id="2318045970523081853">കോൾ ചെയ്യാൻ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="2321086116217818302">പാസ്‍വേഡുകൾ തയ്യാറാക്കുന്നു…</translation>
-<translation id="2321958826496381788">നിങ്ങൾക്ക് ഇത് സൗകര്യപ്രദമായി വായിക്കാൻ കഴിയുന്നതുവരെ സ്ലൈഡർ വലിക്കുക. ഒരു ഖണ്ഡികയിൽ ഇരട്ട-ടാപ്പുചെയ്‌തതിനുശേഷം ടെക്‌സ്റ്റിന് ഈ വലുപ്പമെങ്കിലും ഉണ്ടായിരിക്കണം.</translation>
-<translation id="2323763861024343754">സൈറ്റ് സ്‌റ്റോറേജ്</translation>
-<translation id="2328985652426384049">സൈൻ ഇൻ ചെയ്യാനാകില്ല</translation>
-<translation id="2330129964253841015">പാസ്‌വേഡ് അപഹരിക്കപ്പെട്ടാൽ നിങ്ങൾക്ക് മുന്നറിയിപ്പ് നൽകുന്നു</translation>
-<translation id="2349710944427398404">അക്കൗണ്ടുകളും ബുക്ക്‌മാർക്കുകളും സംരക്ഷിച്ച ക്രമീകരണവും ഉൾപ്പെടെ Chrome ഉപയോഗിക്കുന്ന മൊത്തം വിവരങ്ങൾ</translation>
-<translation id="2353636109065292463">നിങ്ങളുടെ ഇന്‍റർനെറ്റ് കണക്ഷൻ പരിശോധിക്കുന്നു</translation>
-<translation id="2359808026110333948">തുടരുക</translation>
-<translation id="2369533728426058518">ഓപ്പൺ ടാബുകൾ</translation>
-<translation id="2387895666653383613">ടെക്‌സ്റ്റ് സ്‌കെയിലിംഗ്</translation>
-<translation id="2394602618534698961">നിങ്ങൾ ഡൗൺലോഡ് ചെയ്യുന്ന ഫയലുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">നിങ്ങൾ Google അക്കൗണ്ടിൽ സൈൻ ഇൻ ചെയ്യുമ്പോൾ ഈ ഫീച്ചർ ഓണാകും</translation>
-<translation id="2410754283952462441">ഒരു അക്കൗണ്ട് തിരഞ്ഞെടുക്കൂ</translation>
-<translation id="2414886740292270097">ഇരുണ്ടത്</translation>
-<translation id="2416359993254398973">Chrome-ന് ഈ സൈറ്റിനായി നിങ്ങളുടെ ക്യാമറ ആക്‌സസ് ചെയ്യാനുള്ള അനുമതി ആവശ്യമാണ്.</translation>
-<translation id="2426805022920575512">മറ്റൊരു അക്കൗണ്ട് തിരഞ്ഞെടുക്കൂ</translation>
-<translation id="2433507940547922241">കാഴ്ച്ച</translation>
-<translation id="2434158240863470628">ഡൗൺലോഡ് പൂർത്തിയായി <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">ലൊക്കേഷൻ ആക്‌സസ്</translation>
-<translation id="2450083983707403292"><ph name="FILE_NAME" /> വീണ്ടും ഡൗൺലോഡുചെയ്യാൻ തുടങ്ങണോ?</translation>
-<translation id="2482878487686419369">വിജ്ഞാപനങ്ങള്‍‌</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> ആണ് മാനേജ് ചെയ്യുന്നത്</translation>
-<translation id="2494974097748878569">Chrome സ്വമേധയാ പൂരിപ്പിക്കലിലെ Google അസിസ്‌റ്റന്റ് സാന്നിധ്യം</translation>
-<translation id="2496180316473517155">ബ്രൌസിംഗ് ചരിത്രം</translation>
-<translation id="2497852260688568942">നിങ്ങളുടെ അഡ്‌മിനിസ്‌ട്രേറ്റർ സമന്വയിപ്പിക്കൽ പ്രവർത്തനരഹിതമാക്കി</translation>
-<translation id="2498359688066513246">സഹായവും ഫീഡ്ബാക്കും</translation>
-<translation id="2501278716633472235">പിന്നോട്ട് പോകുക</translation>
-<translation id="2513403576141822879">സ്വകാര്യത, സുരക്ഷ, ഡാറ്റാ ശേഖരണം എന്നിവയുമായി ബന്ധപ്പെട്ട കൂടുതൽ ക്രമീകരണത്തിന്, <ph name="BEGIN_LINK" />സമന്വയവും Google സേവനങ്ങളും<ph name="END_LINK" /> കാണുക</translation>
-<translation id="2518590038762162553">ലൈറ്റ് മോഡിൽ Chrome, പേജുകൾ വേഗത്തിൽ ലോഡ് ചെയ്യുകയും 60 ശതമാനം വരെ കുറവ് ഡാറ്റ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾ സന്ദർശിക്കുന്ന പേജുകൾ ഓപ്‌റ്റിമൈസ് ചെയ്യാൻ Chrome നിങ്ങളുടെ വെബ് ട്രാഫിക് Google-ന് അയയ്ക്കുന്നു. <ph name="BEGIN_LINK" />കൂടുതലറിയുക<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Google-ൽ നിങ്ങൾ സന്ദർശിക്കുന്ന പേജുകളുടെ URL-കൾ അയയ്ക്കുന്നു</translation>
-<translation id="2532336938189706096">വെബ് കാഴ്‌ച</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> ഇനങ്ങൾ ഇല്ലാതാക്കി</translation>
-<translation id="2536728043171574184">ഈ പേജിന്‍റെ ഒരു ഓഫ്‌ലൈൻ പതിപ്പ് കാണുന്നു</translation>
-<translation id="2546283357679194313">കുക്കികളും സൈറ്റ് ഡാറ്റയും</translation>
-<translation id="2567385386134582609">ചിത്രം</translation>
-<translation id="257088987046510401">തീമുകള്‍‌</translation>
-<translation id="2570922361219980984">ഈ ഉപകരണത്തിന്‍റെ ലൊക്കേഷൻ ആക്‌സസും ഓഫാണ്; <ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> അത് ഓണാക്കുക.</translation>
-<translation id="257931822824936280">വിപുലീകരിച്ചത് - ചുരുക്കാൻ ക്ലിക്ക് ചെയ്യുക</translation>
-<translation id="2581165646603367611">ഇത്, Chrome പ്രധാനമായി കണക്കാക്കാത്ത സൈറ്റുകളുടെ കുക്കികളും കാഷെയും മറ്റ് വിവരങ്ങളും മായ്‌ക്കും.</translation>
-<translation id="2586657967955657006">ക്ലിപ്പ്ബോർഡ്</translation>
-<translation id="2587052924345400782">ഏറ്റവും പുതിയ പതിപ്പ് ലഭ്യമാണ്</translation>
-<translation id="2593272815202181319">മോണോസ്പെ‌യ്‌സ്</translation>
-<translation id="2612676031748830579">കാർഡ് നമ്പർ</translation>
-<translation id="2621115761605608342">ഒരു നിർദ്ദിഷ്‌ട സൈറ്റിന് വേണ്ടി JavaScript അനുവദിക്കുക.</translation>
-<translation id="2625189173221582860">പാസ്‌വേഡ് പകർത്തി</translation>
-<translation id="2631006050119455616">ലാഭിച്ചത്</translation>
-<translation id="2647434099613338025">ഭാഷ ചേര്‍ക്കുക</translation>
-<translation id="2650751991977523696">ഫയൽ വീണ്ടും ഡൗൺലോഡ് ചെയ്യണോ?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ഓഡിയോ ഫയൽ}other{# ഓഡിയോ ഫയലുകള്‍}}</translation>
-<translation id="2653659639078652383">സമര്‍പ്പിക്കൂ</translation>
-<translation id="2677748264148917807">ഉപേക്ഷിക്കുക</translation>
-<translation id="2704606927547763573">പകർത്തി</translation>
-<translation id="2707726405694321444">പേജ് പുതുക്കുക</translation>
-<translation id="2709516037105925701">സ്വയമേവ പൂരിപ്പിക്കൽ</translation>
-<translation id="2717722538473713889">ഇമെയിൽ വിലാസങ്ങൾ</translation>
-<translation id="2728754400939377704">സൈറ്റ് അനുസരിച്ച് അടുക്കുക</translation>
-<translation id="2744248271121720757">പെട്ടെന്ന് തിരയാനോ ബന്ധപ്പെട്ട പ്രവർത്തനങ്ങൾ കാണാനോ ഒരു വാക്കിൽ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="2760989362628427051">നിങ്ങളുടെ ഉപകരണത്തിന്റെ ഇരുണ്ട തീമോ ബാറ്ററി ലാഭിക്കലോ ഓണായിരിക്കുമ്പോൾ ഇരുണ്ട തീം ഓണാക്കുക</translation>
-<translation id="2762000892062317888">ഇപ്പോൾ</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> സെക്കൻഡ് ശേഷിക്കുന്നു</translation>
-<translation id="2779651927720337254">പരാജയപ്പെട്ടു</translation>
-<translation id="2781151931089541271">ഒരു സെക്കൻഡ് ശേഷിക്കുന്നു</translation>
-<translation id="2801022321632964776">Chrome-ൻ്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ നിങ്ങളുടെ ഭാഷ ലഭ്യമാക്കാൻ അപ്‌ഡേറ്റ് ചെയ്യൂ</translation>
-<translation id="2810645512293415242">ഡാറ്റ ലാഭിക്കുന്നതിനും വേഗത്തിൽ ലോഡ് ചെയ്യുന്നതിനുമായി ലളിതവൽക്കരിച്ചിരിക്കുന്ന പേജ്.</translation>
-<translation id="281504910091592009">നിങ്ങളുടെ <ph name="BEGIN_LINK" />Google അക്കൗണ്ടിൽ<ph name="END_LINK" /> സംരക്ഷിച്ച പാസ്‌വേഡുകൾ കാണുക, മാനേജ് ചെയ്യുക</translation>
-<translation id="2818669890320396765">നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ബുക്ക്‌മാർക്കുകൾ ലഭിക്കാൻ, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME" /> എന്നതിനുള്ള എല്ലാ സൈറ്റ് അനുമതികളും പുനഃസജ്ജീകരിക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ?</translation>
-<translation id="2836148919159985482">പൂർണസ്‌ക്രീനിൽനിന്ന് പുറത്തുകടക്കാൻ ബാക്ക് ബട്ടണിൽ സ്‌പർശിക്കുക.</translation>
-<translation id="2842985007712546952">പാരന്റ് ഫോൾഡർ</translation>
-<translation id="2858138569776157458">മികച്ച സൈറ്റുകൾ</translation>
-<translation id="2860954141821109167">ഈ ഉപകരണത്തിൽ ഫോൺ ആപ്പ് പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
-<translation id="2870560284913253234">സൈറ്റ്</translation>
-<translation id="2874939134665556319">മുമ്പത്തെ ട്രാക്ക്</translation>
-<translation id="2876369937070532032">നിങ്ങളുടെ സുരക്ഷ അപകടത്തിലാകുമ്പോൾ നിങ്ങൾ സന്ദർശിക്കുന്ന ചില പേജുകളുടെ URL-കൾ Google-ലേക്ക് അയയ്ക്കുന്നു</translation>
-<translation id="2888126860611144412">Chrome-നെ കുറിച്ച്</translation>
-<translation id="2891154217021530873">പേജ് ലോഡുചെയ്യുന്നത് നിർത്തുക</translation>
-<translation id="2893180576842394309">തിരയലും മറ്റ് Google സേവനങ്ങളും വ്യക്തിപരമാക്കാൻ Google നിങ്ങളുടെ ചരിത്രം ഉപയോഗിച്ചേക്കാം</translation>
-<translation id="2898264748040935573">സംഭരിച്ചിരിക്കുന്ന പാസ്‌വേഡ് എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="2900528713135656174">ഇവന്റ് സൃഷ്‌ടിക്കുക</translation>
-<translation id="290376772003165898">പേജ് <ph name="LANGUAGE" /> ഭാഷയിലല്ലേ?</translation>
-<translation id="2904414404539560095">പൂർണ്ണ ഉയരത്തിൽ ടാബ് പങ്കിടാനാകുന്ന ഉപകരണങ്ങളുടെ ലിസ്‌റ്റ്.</translation>
-<translation id="2910701580606108292">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക</translation>
-<translation id="2913331724188855103">കുക്കി ഡാറ്റ സംരക്ഷിക്കുന്നതിനും വായിക്കുന്നതിനും സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശചെയ്‌തത്)</translation>
-<translation id="2923908459366352541">പേര് അസാധുവാണ്</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> സ്‌റ്റോറേജ്</translation>
-<translation id="2942036813789421260">പ്രിവ്യു ടാബ് അടച്ചു</translation>
-<translation id="2956410042958133412"><ph name="PARENT_NAME_1" />, <ph name="PARENT_NAME_2" /> എന്നിവരാണ് ഈ അക്കൗണ്ട് നിയന്ത്രിക്കുന്നത്.</translation>
-<translation id="2962095958535813455">ആൾമാറാട്ട ടാബുകളിലേക്ക് മാറി</translation>
-<translation id="2968755619301702150">സർട്ടിഫിക്കറ്റ് വ്യൂവർ</translation>
-<translation id="2979025552038692506">തിരഞ്ഞെടുത്ത അദൃശ്യ ടാബ്</translation>
-<translation id="2987620471460279764">മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് പങ്കിട്ട ടെക്‌സ്‌റ്റ്</translation>
-<translation id="2989523299700148168">അടുത്തിടെ സന്ദർശിച്ചവ</translation>
-<translation id="2996291259634659425">പാസ്‌ഫ്രെയ്‌സ് സൃഷ്‌ടിക്കുക</translation>
-<translation id="2996809686854298943">URL ആവശ്യമാണ്</translation>
-<translation id="300526633675317032">ഇത് വെബ്‌സൈറ്റ് സ്‌റ്റോറേജിലെ <ph name="SIZE_IN_KB" /> പൂർണ്ണമായും മായ്‌ക്കും.</translation>
-<translation id="3016635187733453316">ഈ ഉപകരണം ഇന്റർനെറ്റിലേക്ക് കണക്‌റ്റ് ചെയ്‌തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB ഡൗൺലോഡ് ചെയ്‌തു</translation>
-<translation id="3029704984691124060">പാസ്‌ഫ്രെയ്‌സുകൾ പൊരുത്തപ്പെടുന്നില്ല</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />സഹായം തേടുക<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">ലൊക്കേഷൻ ഓഫാണ്; <ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> അത് ഓണാക്കുക.</translation>
-<translation id="3058498974290601450">നിങ്ങൾക്ക് ഏത് സമയത്തും ക്രമീകരണത്തിൽ സമന്വയം ഓണാക്കാവുന്നതാണ്</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> ബുക്ക്‌മാർക്ക്}other{<ph name="BOOKMARKS_COUNT_MANY" /> ബുക്ക്‌മാർക്കുകൾ}}</translation>
-<translation id="3089395242580810162">അദൃശ്യ ടാബിൽ തുറക്കുക</translation>
-<translation id="3115898365077584848">വിവരങ്ങൾ കാണിക്കുക</translation>
-<translation id="3123473560110926937">ചില സൈറ്റുകളിൽ ബ്ലോക്ക് ചെയ്‌തിരിക്കുന്നു</translation>
-<translation id="3137521801621304719">അദൃശ്യ മോഡ് വിടുക</translation>
-<translation id="3143515551205905069">സമന്വയം റദ്ദാക്കുക</translation>
-<translation id="3157842584138209013">'കൂടുതൽ ഓപ്ഷനുകൾ' ബട്ടണിൽ നിങ്ങൾ എത്ര ഡാറ്റ ലാഭിച്ചെന്ന് കാണുക</translation>
-<translation id="3166827708714933426">ടാബ്, വിൻഡോ കുറുക്കുവഴികൾ</translation>
-<translation id="3181954750937456830">സുരക്ഷിത ബ്രൗസിംഗ് (അപകടകരമായ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളെയും ഉപകരണത്തെയും പരിരക്ഷിക്കുന്നു)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> Chrome-നായി അനുമതികൾ ഓണാക്കുക.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> സംഭരിച്ച വിവരം</translation>
-<translation id="3205824638308738187">ഏതാണ്ട് പൂർത്തിയായി!</translation>
-<translation id="3207960819495026254">ബുക്ക്‌മാർക്കുചെയ്‌തു</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> ഇല്ലാതാക്കി</translation>
-<translation id="321773570071367578">നിങ്ങൾ പാസ്‌ഫ്രെയ്‌സ് മറന്നുപോയെങ്കിലോ ഈ ക്രമീകരണം മാറ്റണമെങ്കിലോ, <ph name="BEGIN_LINK" />സമന്വയം റീസെറ്റ് ചെയ്യുക<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">മൈക്രോഫോൺ</translation>
-<translation id="3232754137068452469">വെബ് ആപ്പ്</translation>
-<translation id="3236059992281584593">ഒരു മിനിറ്റ് ശേഷിക്കുന്നു</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">ഈ പേജ് ബുക്‌മാര്‍ക്ക് ചെയ്യുക</translation>
-<translation id="3259831549858767975">പേജിൽ എല്ലാം ചെറുതായി നൽകുക</translation>
-<translation id="3269093882174072735">ചിത്രം ലോഡ് ചെയ്യുക</translation>
-<translation id="3269956123044984603">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, Android അക്കൗണ്ട് ക്രമീകരണത്തിൽ "ഡാറ്റ സ്വയം സമന്വയിപ്പിക്കുക" ഓണാക്കുക.</translation>
-<translation id="3277252321222022663">സെൻസറുകൾ ആക്‌സസ് ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്യുന്നത്)</translation>
-<translation id="3282568296779691940">Chrome-ലേക്ക് സൈൻ ഇൻ ചെയ്യുക</translation>
-<translation id="3288003805934695103">പേജ് റീലോഡുചെയ്യുന്നു</translation>
-<translation id="32895400574683172">അറിയിപ്പുകൾ അനുവദിച്ചിരിക്കുന്നു</translation>
-<translation id="3295530008794733555">വേഗത്തിൽ ബ്രൗസ് ചെയ്യൂ. കുറച്ച് ഡാറ്റ ഉപയോഗിക്കൂ.</translation>
-<translation id="3295602654194328831">വിവരങ്ങൾ മറയ്‌ക്കുക</translation>
-<translation id="3298243779924642547">ലൈറ്റ്</translation>
-<translation id="3303414029551471755">ഉള്ളടക്കം ഡൗൺലോഡ് ചെയ്യുന്നതിലേക്ക് തുടരണോ?</translation>
-<translation id="3306398118552023113">Chrome-ൽ ഈ ആപ്പ് റൺ ചെയ്യുന്നു</translation>
-<translation id="3315103659806849044">നിലവിൽ നിങ്ങൾ സമന്വയ, Google സേവന ക്രമീകരണം ഇഷ്‌ടാനുസൃതമാക്കുന്നു. സമന്വയിപ്പിക്കൽ ഓണാക്കുന്നത് പൂർത്തിയാക്കാൻ, സ്‌ക്രീനിൻ്റെ ചുവടുവശത്തിന് സമീപമുള്ള 'സ്ഥിരീകരിക്കുക' ടാപ്പ് ചെയ്യുക. മുകളിലേക്ക് നാവിഗേറ്റ് ചെയ്യുക</translation>
-<translation id="3328801116991980348">സൈറ്റ് വിവരങ്ങള്‍</translation>
-<translation id="3333961966071413176">എല്ലാ കോൺടാക്റ്റുകളും</translation>
-<translation id="3334729583274622784">ഫയൽ എക്സ്റ്റൻഷൻ മാറ്റണോ?</translation>
-<translation id="3341058695485821946">നിങ്ങൾ എത്ര ഡാറ്റ ലാഭിച്ചെന്ന് കാണുക</translation>
-<translation id="3350687908700087792">എല്ലാ ആൾമാറാട്ട ടാബുകളും അടയ്‌ക്കുക</translation>
-<translation id="3353615205017136254">Google നല്‍കുന്ന ലൈറ്റ് പേജ്. അസ്സല്‍ പേജ് ലോഡ് ചെയ്യാന്‍ 'അസ്സൽ ലോഡ് ചെയ്യൽ' ബട്ടണ്‍ ടാപ്പ് ചെയ്യുക.</translation>
-<translation id="3367813778245106622">സമന്വയിപ്പിക്കാൻ തുടങ്ങുന്നതിന്, വീണ്ടും സൈൻ ഇൻ ചെയ്യുക</translation>
-<translation id="3374023511497244703">നിങ്ങളുടെ ബുക്ക്‌മാർക്കുകൾ, ചരിത്രം, പാസ്‌വേഡുകൾ എന്നിവയും മറ്റ് Chrome ഡാറ്റയും ഇനി Google അക്കൗണ്ടുമായി സമന്വയിപ്പിക്കില്ല</translation>
-<translation id="3384347053049321195">ചിത്രം പങ്കിടുക</translation>
-<translation id="3386292677130313581">നിങ്ങളുടെ ലൊക്കേഷൻ അറിയാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="3387650086002190359">ഫയൽ സിസ്‌റ്റം പിശകുകൾ കാരണം <ph name="FILE_NAME" /> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
-<translation id="3389286852084373014">ടെക്‌സ്‌റ്റ് വളരെ വലുതാണ്</translation>
-<translation id="3398320232533725830">ബുക്ക്‌മാർക്കുകൾ മാനേജർ തുറക്കുക</translation>
-<translation id="3414952576877147120">വലുപ്പം:</translation>
-<translation id="3443221991560634068">നിലവിലെ പേജ് റീലോഡുചെയ്യുക</translation>
-<translation id="3445014427084483498">ഇപ്പോൾ</translation>
-<translation id="3478363558367712427">നിങ്ങളുടെ തിരയല്‍ യന്ത്രം നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം</translation>
-<translation id="3479552764303398839">ഇപ്പോഴല്ല</translation>
-<translation id="3492207499832628349">പുതിയ അദൃശ്യ ടാബ്</translation>
-<translation id="3493531032208478708">നിർദ്ദേശിച്ച ഉള്ളടക്കത്തെക്കുറിച്ച് <ph name="BEGIN_LINK" />കൂടുതലറിയുക<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">അനുബന്ധയാഥാർത്ഥ്യം</translation>
-<translation id="3518985090088779359">അംഗീകരിച്ച് തുടരുക</translation>
-<translation id="3522247891732774234">അപ്‌ഡേറ്റ് ലഭ്യമല്ല. കൂടുതൽ ഓപ്‌ഷനുകൾ</translation>
-<translation id="3524138585025253783">ഡെവലപ്പർ UI</translation>
-<translation id="3527085408025491307">ഫോൾഡർ</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB ലഭ്യമാണ്</translation>
-<translation id="3549657413697417275">ചരിത്രം തിരയുക</translation>
-<translation id="3557336313807607643">കോൺടാക്‌റ്റുകളിലേക്ക് ചേർക്കുക</translation>
-<translation id="3566923219790363270">Chrome ഇപ്പോഴും VR-നായി തയ്യാറെടുത്തുകൊണ്ടിരിക്കുകയാണ്. Chrome പിന്നീട് റീസ്‌റ്റാർട്ട് ചെയ്യുക.</translation>
-<translation id="3568688522516854065">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="3587482841069643663">എല്ലാം</translation>
-<translation id="358794129225322306">ഒന്നിലേറെ ഫയലുകള്‍ സ്വമേധയാ ഡൗണ്‍‌ലോഡ് ചെയ്യാന്‍ സൈറ്റിനെ അനുവദിക്കുക.</translation>
-<translation id="3590487821116122040">Chrome, സൈറ്റ് സ്‌റ്റോറേജിനെ പ്രധാനപ്പെട്ടതായി കണക്കാക്കുന്നില്ല (ഉദാ: ക്രമീകരണം സംരക്ഷിച്ചിട്ടില്ലാത്തതോ നിങ്ങൾ ഇടയ്‌ക്കിടെ സന്ദർശിക്കാത്തതോ ആയ സൈറ്റുകൾ)</translation>
-<translation id="3599863153486145794">സൈൻ ഇൻ ചെയ്‌ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ചരിത്രം മായ്ക്കുന്നു. നിങ്ങളുടെ Google അക്കൗണ്ടിന് <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> എന്നതിൽ മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രങ്ങളുണ്ടായിരിക്കാം.</translation>
-<translation id="3600792891314830896">ശബ്‌ദം പ്ലേ ചെയ്യുന്ന സൈറ്റുകളെ മ്യൂട്ട് ചെയ്യുക</translation>
-<translation id="3616113530831147358">ഓഡിയോ</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> എന്നതിലേക്ക് പങ്കിടുന്നു</translation>
-<translation id="3632295766818638029">പാസ്‌വേഡ് വെളിപ്പെടുത്തുക</translation>
-<translation id="363596933471559332">സൂക്ഷിച്ചിരിക്കുന്ന ക്രെഡൻഷ്യലുകൾ ഉപയോഗിച്ച് വെബ്‌സൈറ്റുകളിലേക്ക് സ്വയമേവ സൈൻ ഇൻ ചെയ്യുക. ഫീച്ചർ ഓഫായിരിക്കുമ്പോൾ, ഒരു വെബ്‌സൈറ്റിലേക്ക് സൈൻ ഇൻ ചെയ്യുന്നതിനുമുമ്പ് പരിശോധിച്ചുറപ്പിക്കാൻ ഓരോ തവണയും നിങ്ങളോടാവശ്യപ്പെടും.</translation>
-<translation id="3658159451045945436">പുനഃസജ്ജീകരിക്കുന്നത്, സന്ദർശിച്ച സൈറ്റുകളുടെ ലിസ്‌റ്റ് അടക്കമുള്ള ഡാറ്റ ലാഭിക്കൽ ചരിത്രത്തെ മായ്ക്കുന്നു.</translation>
-<translation id="3692944402865947621">സ്റ്റോറേജ് ലൊക്കേഷൻ കണ്ടെത്താനാകാത്തതിനാൽ <ph name="FILE_NAME" /> ഡൗൺലോഡ് ചെയ്യുന്നത് പരാജയപ്പെട്ടു.</translation>
-<translation id="3714981814255182093">കണ്ടെത്തൽ ബാർ തുറക്കുക</translation>
-<translation id="3716182511346448902">ഈ പേജ് ഒരുപാട് മെമ്മറി ഉപയോഗിക്കുന്നു, അതിനാൽ Chrome ഇത് താൽക്കാലികമായി അവസാനിപ്പിച്ചു.</translation>
-<translation id="3730075448226062617">Chrome-നെ നിങ്ങളുടെ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> മൈക്രോഫോണും ഓണാക്കുക.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> എന്നതിൽ ബുക്ക്‌മാർക്ക് ചെയ്‌തു</translation>
-<translation id="3744111561329211289">പശ്ചാത്തല സമന്വയിപ്പിക്കൽ</translation>
-<translation id="3771001275138982843">അപ്‌ഡേറ്റ് ഡൗൺലോഡ് ചെയ്യാനായില്ല</translation>
-<translation id="3771033907050503522">ആൾമാറാട്ട ടാബുകൾ</translation>
-<translation id="3773755127849930740">ജോടിയാക്കാൻ, <ph name="BEGIN_LINK" />Bluetooth ഓണാക്കുക<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് അയയ്‌ക്കുക</translation>
-<translation id="3778956594442850293">ഹോം സ്‌ക്രീനിലേക്ക് ചേർത്തു</translation>
-<translation id="3789841737615482174">ഇന്‍സ്റ്റാൾ ചെയ്യുക</translation>
-<translation id="3810838688059735925">വീഡിയോ</translation>
-<translation id="3810973564298564668">മാനേജ് ചെയ്യുക</translation>
-<translation id="381841723434055211">ഫോൺ നമ്പറുകൾ</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> ഡൗൺലോഡുകൾ ഇല്ലാതാക്കി</translation>
-<translation id="3822502789641063741">സൈറ്റ് സ്‌റ്റോറേജ് മായ്‌ക്കണോ?</translation>
-<translation id="385051799172605136">പിന്നോട്ട്</translation>
-<translation id="3859306556332390985">മുന്നോട്ട് നീക്കുക</translation>
-<translation id="3894427358181296146">ഫോൾഡർ ചേർക്കുക</translation>
-<translation id="3895926599014793903">നിർബന്ധിത സൂം തയ്യാറാക്കുക</translation>
-<translation id="3912508018559818924">വെബിൽ നിന്നുള്ള ഏറ്റവും മികച്ചത് കണ്ടെത്തുന്നു…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">എന്റെ വിവരങ്ങൾ സംയോജിപ്പിക്കുക</translation>
-<translation id="393697183122708255">പ്രവർത്തനക്ഷമമാക്കിയ വോയ്‌സ് തിരയലുകൾ ഒന്നും ലഭ്യമല്ല</translation>
-<translation id="395206256282351086">തിരയലും സൈറ്റ് നിർദ്ദേശങ്ങളും പ്രവർത്തനരഹിതമാക്കി</translation>
-<translation id="3955193568934677022">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{നിങ്ങളുടെ പേജ് തയ്യാറാകുമ്പോൾ Chrome ലോഡ് ചെയ്യും}other{നിങ്ങളുടെ പേജുകൾ തയ്യാറാകുമ്പോൾ Chrome ലോഡ് ചെയ്യും}}</translation>
-<translation id="3963007978381181125">പാസ്‌ഫ്രെയ്‌സ് എൻക്രിപ്ഷനിൽ, Google Pay-ൽ നിന്നുള്ള പേയ്മെന്‍റ് രീതികളും വിലാസങ്ങളും ഉൾപ്പെടുന്നില്ല. നിങ്ങളുടെ പാസ്‌ഫ്രെയ്‌സുള്ള വ്യക്തിക്ക് മാത്രമേ എൻക്രി‌പ്‌റ്റ് ചെയ്‌ത ഡാറ്റ വായിക്കാനാവൂ. പാസ്‌ഫ്രെയ്‌സ് Google-ലേക്ക് അയയ്‌ക്കുകയോ സംഭരിക്കുകയോ ചെയ്യുന്നില്ല. പാസ്‌ഫ്രെയ്‌സ് മറന്നുപോവുകയോ ഈ ക്രമീകരണം മാറ്റുകയോ ചെയ്യണമെങ്കിൽ, സമന്വയം പുനഃക്രമീകരിക്കേണ്ടി വരും. <ph name="BEGIN_LINK" />കൂടുതലറിയുക<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ഡൗൺലോഡ് പൂർത്തിയായി</translation>
-<translation id="397583555483684758">'സമന്വയം' പ്രവർത്തനം നിർത്തി</translation>
-<translation id="3976396876660209797">ഈ കുറുക്കുവഴി നീക്കംചെയ്‌ത് പുനസൃഷ്‌ടിക്കുക</translation>
-<translation id="3985215325736559418">നിങ്ങൾക്ക് വീണ്ടും <ph name="FILE_NAME" /> ഡൗൺലോഡ് ചെയ്യണോ?</translation>
-<translation id="3987993985790029246">ലിങ്ക് പകർത്തുക</translation>
-<translation id="3988213473815854515">ലൊക്കേഷൻ അനുവദനീയം</translation>
-<translation id="3988466920954086464">വേഗത്തിലുള്ള തിരയൽ ഫലങ്ങൾ ഈ പാനലിൽ കാണുക</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">പ്രധാനമല്ലാത്ത സ്‌റ്റോറേജ്</translation>
-<translation id="4000212216660919741">ഓഫ്‌ലൈൻ ഹോം</translation>
-<translation id="4002066346123236978">ശീർഷകം</translation>
-<translation id="4008040567710660924">ഒരു പ്രത്യേക സൈറ്റിനായി കുക്കികൾ അനുവദിക്കുക.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# മണിക്കൂർ}other{# മണിക്കൂർ}}</translation>
-<translation id="4046123991198612571">അടുത്ത ട്രാക്ക്</translation>
-<translation id="4048707525896921369">പേജ് വിട്ടുപോകാതെ തന്നെ വെബ്‌സൈറ്റുകളിലെ വിഷയങ്ങളെക്കുറിച്ച് അറിയുക. 'തിരയാൻ സ്‌പർശിക്കുക' എന്നത് ഒരു പദവും അതിന്റെ സന്ദർഭവും Google തിരയലിലേക്ക് അയച്ച്, നിർവചനങ്ങളും ചിത്രങ്ങളും തിരയൽ ഫലങ്ങളും മറ്റ് വിശദാംശങ്ങളും ലഭ്യമാക്കുന്നു.
-
-നിങ്ങളുടെ തിരയൽ പദം ക്രമീകരിക്കാൻ, തിരഞ്ഞെടുക്കുന്നതിനായി ദീർഘനേരം അമർത്തിപ്പിടിക്കുക. തിരയൽ പരിഷ്‌ക്കരിക്കാൻ, നേരെ മുകളിലേക്ക് പാനൽ നീക്കി, തിരയൽ ബോക്‌സ് സ്‌പർശിക്കുക.</translation>
-<translation id="4056223980640387499">സിപിയ</translation>
-<translation id="4060598801229743805">സ്‌ക്രീനിന്റെ മുകളിൽ ഓപ്‌ഷനുകൾ ലഭ്യമാണ്</translation>
-<translation id="4062305924942672200">നിയമ വിവരങ്ങൾ</translation>
-<translation id="4084682180776658562">ബുക്മാര്‍ക്ക്</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" />-ൽ നിന്ന് – <ph name="BEGIN_DEEMPHASIZED" />Google നൽകുന്നത്<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">ആപ്പ് ഡാറ്റ ഇല്ലാതാക്കണോ?</translation>
-<translation id="4099578267706723511">Google-ലേക്ക് ഉപയോഗ വിവരക്കണക്കുകളും ക്രാഷ് റിപ്പോർട്ടുകളും അയയ്‌ക്കുന്നതിലൂടെ Chrome-നെ മികച്ചതാക്കാൻ സഹായിക്കുക.</translation>
-<translation id="410351446219883937">സ്വയം പ്ലേചെയ്യൽ</translation>
-<translation id="4116038641877404294">ഓഫ്‌ലൈനായി ഉപയോഗിക്കാൻ പേജുകൾ ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="4135200667068010335">ടാബ് പങ്കിടാനാകുന്ന ഉപകരണങ്ങളുടെ ലിസ്‌റ്റ് അടച്ചിരിക്കുന്നു.</translation>
-<translation id="4149994727733219643">വെബ് പേജുകൾക്കായി ലളിതവൽക്കരിച്ച കാഴ്ച</translation>
-<translation id="4165986682804962316">സൈറ്റ് ക്രമീകരണങ്ങൾ</translation>
-<translation id="4169535189173047238">അനുവദിക്കരുത്</translation>
-<translation id="4170011742729630528">സേവനം ലഭ്യമല്ല; പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> ഉപയോഗിച്ചു</translation>
-<translation id="4181841719683918333">ഭാഷകൾ‌</translation>
-<translation id="4183868528246477015">Google ലെൻസ് ഉപയോഗിച്ച് തിരയൂ <ph name="BEGIN_NEW" />പുതിയത്<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">പുതിയ ടാബില്‍ തുറക്കുക</translation>
-<translation id="4198423547019359126">ലഭ്യമായ ഡൗൺലോഡ് ലൊക്കേഷനുകളൊന്നും ഇല്ല</translation>
-<translation id="4209895695669353772">Google നിർദ്ദേശിക്കുന്ന വ്യക്തിപരമാക്കിയ ഉള്ളടക്കം ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="4226663524361240545">അറിയിപ്പുകൾ ലഭിക്കുമ്പോൾ ഉപകരണം വൈബ്രേറ്റ് ചെയ്‌തേക്കാം</translation>
-<translation id="423219824432660969">Google പാസ്‌വേഡ് ഉപയോഗിച്ച് <ph name="TIME" /> മുതൽ സമന്വയിപ്പിച്ച ഡാറ്റ എൻക്രി‌പ്‌റ്റ് ചെയ്യുക</translation>
-<translation id="4242533952199664413">ക്രമീകരണം തുറക്കുക</translation>
-<translation id="4256782883801055595">ഓപ്പൺ സോഴ്‌സ് ലൈസൻസുകൾ</translation>
-<translation id="4259722352634471385">നാവിഗേഷൻ തടഞ്ഞിരിക്കുന്നു: <ph name="URL" /></translation>
-<translation id="4269820728363426813">ലിങ്ക് വിലാസം പകർത്തുക</translation>
-<translation id="4275663329226226506">മീഡിയ</translation>
-<translation id="4278390842282768270">അനുവദനീയം</translation>
-<translation id="429312253194641664">സൈറ്റ്, മീഡിയ പ്ലേ ചെയ്യുന്നു</translation>
-<translation id="4298388696830689168">ലിങ്ക് ചെയ്‌ത സൈറ്റുകൾ</translation>
-<translation id="4307992518367153382">അടിസ്ഥാനങ്ങള്‍</translation>
-<translation id="4314815835985389558">സമന്വയിപ്പിക്കൽ മാനേജ് ചെയ്യുക</translation>
-<translation id="4351244548802238354">ഡയലോഗ് അടയ്‌ക്കുക</translation>
-<translation id="4378154925671717803">ഫോൺ</translation>
-<translation id="4384468725000734951">തിരയാൻ Sogou ഉപയോഗിക്കുന്നു</translation>
-<translation id="4404568932422911380">ബുക്ക്‌മാർക്കുകളൊന്നുമില്ല</translation>
-<translation id="4405224443901389797">ഇതിലേക്ക് നീക്കുക…</translation>
-<translation id="4411535500181276704">ലൈറ്റ് മോഡ്</translation>
-<translation id="4415276339145661267">നിങ്ങളുടെ Google അക്കൗണ്ട് മാനേജ് ചെയ്യുക</translation>
-<translation id="4432792777822557199">ഇനിമുതൽ <ph name="SOURCE_LANGUAGE" /> ഭാഷയിലുള്ള പേജുകൾ <ph name="TARGET_LANGUAGE" /> ഭാഷയിലേക്ക് വിവർത്തനം ചെയ്യപ്പെടും</translation>
-<translation id="4433925000917964731">Google നല്‍കുന്ന ലൈറ്റ് പേജ്</translation>
-<translation id="4434045419905280838">പോപ്-അപ്പുകളും റീഡയറക്‌റ്റുകളും</translation>
-<translation id="4440958355523780886">Google നൽകുന്ന ലൈറ്റ് പേജ്. യഥാർത്ഥ പേജ് ലോഡ് ചെയ്യാൻ ടാപ്പ് ചെയ്യുക.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> ടാബ് അടയ്ക്കുക</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> ഫോൾഡറിലേക്ക് ബുക്ക്മാർക്ക് ചെയ്‌തു</translation>
-<translation id="445467742685312942">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക</translation>
-<translation id="4468959413250150279">ഒരു പ്രത്യേക സൈറ്റിനായി ശബ്‌ദം മ്യൂട്ട് ചെയ്യുക.</translation>
-<translation id="4472118726404937099">ഉപകരണങ്ങളിൽ ഉടനീളം സമന്വയിപ്പിക്കാനും വ്യക്തിപരമാക്കാനും, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="447252321002412580">Chrome-ന്റെ ഫീച്ചറുകളും പ്രകടനവും മെച്ചപ്പെടുത്താൻ സഹായിക്കുക</translation>
-<translation id="4479647676395637221">നിങ്ങളുടെ ക്യാമറ ഉപയോഗിക്കാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ആദ്യം ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="4479972344484327217">Chrome-നുള്ള <ph name="MODULE" /> ഇൻസ്‌റ്റാൾ ചെയ്യുന്നു…</translation>
-<translation id="4487967297491345095">Chrome-ന്റെ എല്ലാ ആപ്പ് വിവരങ്ങളും ശാശ്വതമായി ഇല്ലാതാക്കും. ഇതിൽ എല്ലാ ഫയലുകളും ക്രമീകരണവും അക്കൗണ്ടുകളും ഡാറ്റാബേസുകളും മറ്റും ഉൾപ്പെടുന്നു.</translation>
-<translation id="4493497663118223949">ലൈറ്റ് മോഡ് ഓണാണ്</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# ദിവസം മുമ്പ്}other{# ദിവസം മുമ്പ്}}</translation>
-<translation id="451872707440238414">നിങ്ങളുടെ ബുക്ക്‌മാർക്കുകൾ തിരയുക</translation>
-<translation id="4521489764227272523">തിരഞ്ഞെടുത്ത ഡാറ്റയെ Chrome-ൽ നിന്നും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഉപകരണങ്ങളിൽ നിന്നും നീക്കം ചെയ്‌തു.
-
-തിരയലുകൾ, പ്രവൃത്തി എന്നിവ പോലെ <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> എന്നതിലെ മറ്റ് Google സേവനങ്ങളിൽ നിന്നുള്ള മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രവും നിങ്ങളുടെ Google അക്കൗണ്ടിൽ ഉണ്ടായേക്കാം.</translation>
-<translation id="4532845899244822526">ഫോൾഡർ തിരഞ്ഞെടുക്കുക</translation>
-<translation id="4538018662093857852">ലൈറ്റ് മോഡ് ഓണാക്കുക</translation>
-<translation id="4550003330909367850">ഇവിടെ ‌നിങ്ങളുടെ ‌പാസ്‌വേഡ് കാണാനും പകർത്താനും കഴിയും, ഈ ഉപകരണത്തിൽ സ്‌ക്രീൻ ലോക്ക് ‌സജ്ജമാക്കുക.</translation>
-<translation id="4558311620361989323">വെബ്‌പേജ് കുറുക്കുവഴികൾ</translation>
-<translation id="4561979708150884304">കണക്ഷൻ ഇല്ല</translation>
-<translation id="4565377596337484307">പാസ്‌വേഡ് മറയ്ക്കുക</translation>
-<translation id="4570913071927164677">വിശദാംശങ്ങൾ</translation>
-<translation id="4572422548854449519">മാനേജ് ചെയ്‌ത അക്കൗണ്ടിലേക്ക് സൈൻ ഇൻ ചെയ്യുക</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# മിനിറ്റ് മുമ്പ്}other{# മിനിറ്റ് മുമ്പ്}}</translation>
-<translation id="4587589328781138893">സൈറ്റുകള്‍</translation>
-<translation id="4594952190837476234">ഈ ഓഫ്‌ലൈൻ പേജ് <ph name="CREATION_TIME" /> -ന് സൃഷ്‌ടിച്ചതാണ്, അതിനാൽ ഓൺലൈൻ പതിപ്പിൽ നിന്ന് വ്യത്യസ്തമായിരിക്കാം.</translation>
-<translation id="4605958867780575332">നീക്കംചെയ്‌ത ഇനം: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> തുറക്കുക</translation>
-<translation id="4634124774493850572">പാസ്‌വേഡ് ഉപയോഗിക്കുക</translation>
-<translation id="4645575059429386691">നിങ്ങളുടെ രക്ഷിതാവ് നിയന്ത്രിക്കുന്നു</translation>
-<translation id="4650364565596261010">സിസ്‌റ്റം ഡിഫോൾട്ട്</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> ബുക്ക്‌മാർക്കുകൾ ഇല്ലാതാക്കി</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> എന്നയാളെ നിങ്ങളുടെ ഹോം സ്‌ക്രീനിൽ ചേർത്തു</translation>
-<translation id="4684427112815847243">എല്ലാം സമന്വയിപ്പിക്കുക</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> പേയ്‌മെന്റ് രീതികളും}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> പേയ്‌മെന്റ് രീതികളും}}</translation>
-<translation id="4696983787092045100">നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് ടെക്‌സ്‌റ്റ് അയയ്‌ക്കുക</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> ആപ്പിൽ ഓഫ്‌ലൈനായി കാണുക</translation>
-<translation id="4699172675775169585">കാഷെ ചെയ്‌ത ചിത്രങ്ങളും ഫയലുകളും</translation>
-<translation id="4714588616299687897">നിങ്ങളുടെ ഡാറ്റ 60% വരെ ലാഭിക്കൂ</translation>
-<translation id="4719927025381752090">വിവർത്തനം ചെയ്യാനുള്ള ഓഫർ</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" />-ൽ തുറക്കുക</translation>
-<translation id="4720982865791209136">Chrome മെച്ചപ്പെടുത്താൻ സഹായിക്കുക. <ph name="BEGIN_LINK" />സർവേയിൽ പങ്കെടുക്കുക.<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">അപ്ഡേറ്റ് ചെയ്യുക</translation>
-<translation id="4738836084190194332">അവസാനം സമന്വയിപ്പിച്ചത്: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">പുതിയൊരു ടാബ് തുറക്കുക</translation>
-<translation id="4751476147751820511">ചലന അല്ലെങ്കിൽ വെളിച്ച സെൻസറുകൾ</translation>
-<translation id="4759238208242260848">ഡൌണ്‍ലോഡുകള്‍</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{ഒരു ഡൗൺലോഡ് പൂർത്തിയായി.}other{# ഡൗൺലോഡുകൾ പൂർത്തിയായി.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" /> എന്നതിലേക്ക് മടങ്ങാൻ സ്‌പർശിക്കുക</translation>
-<translation id="4802417911091824046">പാസ്‌ഫ്രെയ്‌സ് എൻക്രി‌പ്ഷനിൽ, Google Pay-ൽ നിന്നുള്ള പേയ്മെന്‍റ് രീതികളും വിലാസങ്ങളും ഉൾപ്പെടുന്നില്ല.
-
-ഈ ക്രമീകരണം മാറ്റാൻ, <ph name="BEGIN_LINK" />സമന്വയം പുനഃക്രമീകരിക്കുക<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">കാര്‍‌ഡിലെ നാമം</translation>
-<translation id="4824958205181053313">സമന്വയം റദ്ദാക്കണോ?</translation>
-<translation id="4837753911714442426">പേജ് അച്ചടിക്കുന്നതിനുള്ള ഓപ്‌ഷനുകൾ തുറക്കുക</translation>
-<translation id="4842092870884894799">പാസ്‌വേഡ് സൃഷ്ടിക്കൽ പോപ്പ് അപ്പ് കാണിക്കുന്നു</translation>
-<translation id="4860895144060829044">വിളിക്കുക</translation>
-<translation id="4866368707455379617">Chrome-നായി <ph name="MODULE" /> ഇൻസ്‌റ്റാൾ ചെയ്യാനായില്ല</translation>
-<translation id="4875775213178255010">ഉള്ളടക്ക നിർദ്ദേശങ്ങൾ</translation>
-<translation id="4878404682131129617">പ്രോക്‌സി സെർവർ മുഖേന ഒരു ടണൽ രൂപപ്പെടുത്താനായില്ല</translation>
-<translation id="4880127995492972015">വിവർത്തനം ചെയ്യുക…</translation>
-<translation id="4881695831933465202">തുറക്കുക</translation>
-<translation id="488187801263602086">ഫയലിന്റെ പേര് മാറ്റുക</translation>
-<translation id="4882831918239250449">തിരയൽ, പരസ്യങ്ങൾ എന്നിവയും മറ്റും വ്യക്തിപരമാക്കുന്നതിനായി നിങ്ങളുടെ ബ്രൗസിംഗ് ചരിത്രം ഉപയോഗിക്കുന്ന വിധം നിയന്ത്രിക്കുക</translation>
-<translation id="4883854917563148705">മാനേജ് ചെയ്യുന്ന ക്രമീകരണം പുനഃസജ്ജീകരിക്കാനാവില്ല</translation>
-<translation id="4885273946141277891">പിന്തുണയ്‌ക്കാത്തത്ര Chrome പതിപ്പുകൾ</translation>
-<translation id="4910889077668685004">പേയ്‌മെന്റ് ആപ്പുകൾ</translation>
-<translation id="4913161338056004800">സ്ഥിതിവിവരക്കണക്കുകൾ റീസെറ്റ് ചെയ്യുക</translation>
-<translation id="4913169188695071480">പുതുക്കിയെടുക്കുന്നത് നിർത്തുക</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />ഉപകരണങ്ങൾ<ph name="END_LINK" /> സ്‌കാൻ ചെയ്യുമ്പോൾ സഹായം തേടുക…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# പേജ്}other{# പേജുകൾ}}</translation>
-<translation id="4932247056774066048"><ph name="DOMAIN_NAME" /> മാനേജ് ചെയ്യുന്ന അക്കൗണ്ടിൽ നിന്ന് സൈൻ ഔട്ട് ചെയ്യുന്നതിനാൽ, ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ Chrome ഡാറ്റ ഇല്ലാതാക്കപ്പെടും. അത് തുടർന്നും നിങ്ങളുടെ Google അക്കൗണ്ടിൽ ഉണ്ടായിരിക്കുന്നതാണ്.</translation>
-<translation id="4943703118917034429">വെർച്വൽ റിയാലിറ്റി</translation>
-<translation id="4943872375798546930">ഫലങ്ങളൊന്നുമില്ല</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> നിങ്ങളുടെ സ്‌ക്രീൻ പങ്കിടുന്നു</translation>
-<translation id="4961107849584082341">ഈ പേജ് ഏത് ഭാഷയിലേക്കും വിവര്‍ത്തനം ചെയ്യുക</translation>
-<translation id="4962975101802056554">ഉപകരണത്തിനുള്ള എല്ലാ അനുമതികളും അസാധുവാക്കുക</translation>
-<translation id="4970824347203572753">നിങ്ങളുടെ ലൊക്കേഷനിൽ ലഭ്യമല്ല</translation>
-<translation id="497421865427891073">മുന്നോട്ട് പോകുക</translation>
-<translation id="4988210275050210843">ഫയൽ ഡൗൺലോഡ് ചെയ്യുന്നു (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">പേജുകള്‍</translation>
-<translation id="4994033804516042629">കോൺടാക്റ്റുകളൊന്നും കണ്ടെത്തിയില്ല</translation>
-<translation id="4996978546172906250">ഇതുവഴി പങ്കിടുക</translation>
-<translation id="5004416275253351869">Google പ്രവർത്തന നിയന്ത്രണങ്ങൾ</translation>
-<translation id="5005498671520578047">പാസ്‌വേഡ് പകർത്തുക</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> കണക്‌റ്റുചെയ്യാൻ താൽപ്പര്യപ്പെടുന്നു</translation>
-<translation id="5013696553129441713">പുതിയ നിർദ്ദേശങ്ങളൊന്നുമില്ല</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">നിങ്ങൾ VR-ൽ ആയിരിക്കുമ്പോൾ, ഈ സൈറ്റിന് ഇനിപ്പറയുന്ന കാര്യങ്ങളെക്കുറിച്ച് മനസ്സിലാക്കാൻ കഴിഞ്ഞേക്കും:
-  -  ഉയരം പോലെയുള്ള നിങ്ങളുടെ ശാരീരിക സവിശേഷതകൾ
-
-VR-ൽ പ്രവേശിക്കുന്നതിന് മുമ്പ് നിങ്ങൾ ഈ സൈറ്റിനെ വിശ്വസിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കുക.</translation>
-<translation id="5039804452771397117">അനുവദിക്കൂ</translation>
-<translation id="5040262127954254034">സ്വകാര്യത</translation>
-<translation id="5048398596102334565">നിങ്ങളുടെ ചലന സെൻസറുകൾ ആക്‌സസ് ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്യുന്നത്)</translation>
-<translation id="5063480226653192405">ഉപയോഗം</translation>
-<translation id="5087580092889165836">കാർഡ് ചേർക്കുക</translation>
-<translation id="5100237604440890931">ചുരുക്കിയത് - വിപുലീകരിക്കാൻ ക്ലിക്ക് ചെയ്യുക</translation>
-<translation id="510275257476243843">ഒരു മണിക്കൂർ ശേഷിക്കുന്നു</translation>
-<translation id="5123685120097942451">അദൃശ്യ ടാബ്</translation>
-<translation id="5127805178023152808">സമന്വയം ഓഫാണ്</translation>
-<translation id="5129038482087801250">വെബ്ആപ്പ് ഇൻസ്‌റ്റാൾ ചെയ്യൂ</translation>
-<translation id="5132942445612118989">നിങ്ങളുടെ പാസ്‌വേഡുകളും ചരിത്രവും മറ്റും എല്ലാ ഉപകരണങ്ങളിലും സമന്വയിപ്പിക്കുക</translation>
-<translation id="5139940364318403933">Google ഡ്രൈവ് എങ്ങനെ ഉപയോഗിക്കണമെന്ന് അറിയുക</translation>
-<translation id="515227803646670480">സംഭരിച്ച വിവരം മായ്‌ക്കുക</translation>
-<translation id="5152843274749979095">ഉപയോഗിക്കാനാവുന്ന ആപ്‌സൊന്നും ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല</translation>
-<translation id="5161254044473106830">പേര് ആവശ്യമാണ്</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{ഒരു ഡൗൺലോഡ് പരാജയപ്പെട്ടു.}other{# ഡൗൺലോഡുകൾ പരാജയപ്പെട്ടു.}}</translation>
-<translation id="5170568018924773124">ഫോള്‍ഡറില്‍ കാണിക്കുക</translation>
-<translation id="5184329579814168207">Chrome-ൽ തുറക്കുക</translation>
-<translation id="5193988420012215838">നിങ്ങളുടെ ക്ലിപ്പ്ബോർഡിലേക്ക് പകർത്തി</translation>
-<translation id="5197729504361054390">നിങ്ങൾ തിരഞ്ഞെടുക്കുന്ന കോൺടാക്‌റ്റുകൾ <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> എന്ന സൈറ്റുമായി പങ്കിടും.</translation>
-<translation id="5199929503336119739">ഔദ്യോഗിക പ്രൊഫൈൽ</translation>
-<translation id="5210286577605176222">മുമ്പത്തെ ടാബിലേക്ക് പോകുക</translation>
-<translation id="5210365745912300556">ടാബ് അടയ്ക്കൂക</translation>
-<translation id="5224771365102442243">വീഡിയോ ഉണ്ട്</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> എന്നതിന് സമീപമുള്ള Bluetooth ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യണമെന്നുണ്ട്. ഇനിപ്പറയുന്ന ഉപകരണങ്ങൾ കണ്ടെത്തി:</translation>
-<translation id="5233638681132016545">പുതിയ ടാബ്</translation>
-<translation id="526421993248218238">ഈ പേജ് ലോഡ് ചെയ്യാനായില്ല</translation>
-<translation id="5271967389191913893">ഡൗൺലോഡ് ചെയ്യേണ്ട ഉള്ളടക്കം ഉപകരണത്തിന് തുറക്കാനാവില്ല.</translation>
-<translation id="528192093759286357">പൂർണ്ണ സ്‌ക്രീനിൽ നിന്ന് പുറത്തുകടക്കാൻ, മുകളിൽ നിന്ന് വലിച്ചിട്ട് ബാക്ക് ബട്ടണിൽ സ്‌പർശിക്കുക.</translation>
-<translation id="5292796745632149097">ഇതിലേക്ക് അയയ്ക്കുക</translation>
-<translation id="5300589172476337783">കാണിക്കുക</translation>
+<translation id="6910211073230771657">ഇല്ലാതാക്കി</translation>
+<translation id="6965382102122355670">ശരി</translation>
 <translation id="5301954838959518834">മനസ്സിലായി</translation>
-<translation id="5304593522240415983">ഈ ഫീൽഡ് ശൂന്യമായിടാൻ കഴിയില്ല</translation>
-<translation id="5307446750509046227">സൈറ്റ് സംഭരണം മായ്ക്കൂ</translation>
-<translation id="5308380583665731573">കണക്‌റ്റുചെയ്യുക</translation>
-<translation id="5313967007315987356">സൈറ്റ് ചേർക്കുക</translation>
+<translation id="7658239707568436148">റദ്ദാക്കൂ</translation>
+<translation id="3479552764303398839">ഇപ്പോഴല്ല</translation>
 <translation id="5317780077021120954">സംരക്ഷിക്കുക</translation>
-<translation id="5324858694974489420">രക്ഷാകർതൃ ക്രമീകരണം</translation>
-<translation id="5327248766486351172">പേര്</translation>
-<translation id="5335288049665977812">JavaScript റൺ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="5342314432463739672">അനുമതി അഭ്യർത്ഥനകൾ</translation>
-<translation id="5357811892247919462">ടാബ് സ്വീകരിച്ചു</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> ടാബ് തുറന്നിരിക്കുന്നു, ടാബുകൾ മാറാനായി ടാപ്പ് ചെയ്യുക}other{<ph name="OPEN_TABS_MANY" /> ടാബുകൾ തുറന്നിരിക്കുന്നു, മാറാനായി ടാപ്പ് ചെയ്യുക}}</translation>
-<translation id="5391532827096253100">ഈ സൈറ്റിലേക്കുള്ള നിങ്ങളുടെ കണക്ഷൻ സുരക്ഷിതമല്ല. സൈറ്റ് വിവരങ്ങള്‍</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ ഒരെണ്ണം കൂടി)}other{(+ # എണ്ണം കൂടി)}}</translation>
-<translation id="5400569084694353794">ഈ ആപ്പ് ഉപയോഗിക്കുന്നതിലൂടെ, നിങ്ങൾ Chrome-ന്റെ <ph name="BEGIN_LINK1" />സേവന നിബന്ധനകളും<ph name="END_LINK1" /> <ph name="BEGIN_LINK2" />സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK2" /> അംഗീകരിക്കുന്നു.</translation>
-<translation id="5403592356182871684">പേരുകൾ</translation>
-<translation id="5403644198645076998">ചില സൈറ്റുകളെ മാത്രം അനുവദിക്കുക</translation>
-<translation id="5414836363063783498">പരിശോധിച്ചുറപ്പിക്കുന്നു...</translation>
-<translation id="5423934151118863508">നിങ്ങളുടെ ഏറ്റവുമധികം സന്ദർശിച്ച പേജുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB ലഭ്യമാണ്</translation>
-<translation id="543338862236136125">പാസ്‌വേഡ് എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="5433691172869980887">ഉപയോക്തൃനാമം പകർത്തി</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യുന്നു (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">വിലാസ ബാറിലേക്ക് പോകുക</translation>
-<translation id="5447201525962359567">കുക്കികളും പ്രാദേശികമായി സംഭരിച്ച മറ്റ് വിവരങ്ങളും ഉൾപ്പെടെയുള്ള എല്ലാ സൈറ്റ് സ്‌റ്റോറേജും</translation>
-<translation id="5447765697759493033">ഈ സൈറ്റ് വിവർത്തനം ചെയ്യപ്പെടില്ല</translation>
-<translation id="545042621069398927">നിങ്ങളുടെ ഡൗൺലോഡ് വേഗത്തിലാക്കുന്നു.</translation>
-<translation id="5456381639095306749">പേജ് ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="5475862044948910901">അനുബന്ധയാഥാർത്ഥ്യ സെഷൻ ആരംഭിക്കണോ?</translation>
-<translation id="548278423535722844">മാപ്‌സ് ആപ്പിൽ തുറക്കുക</translation>
-<translation id="5487521232677179737">ഡാറ്റ മായ്‌ക്കുക</translation>
-<translation id="5494752089476963479">അനാവശ്യമോ തെറ്റിദ്ധരിപ്പിക്കുന്നതോ ആയ പരസ്യങ്ങള്‍ കാണിക്കുന്ന സൈറ്റുകളിലെ പരസ്യങ്ങൾ ബ്ലോക്ക് ചെയ്യുക</translation>
-<translation id="5500777121964041360">നിങ്ങളുടെ ലൊക്കേഷനിൽ ലഭ്യമായിരിക്കില്ല</translation>
-<translation id="5512137114520586844"><ph name="PARENT_NAME" /> ആണ് ഈ അക്കൗണ്ട് നിയന്ത്രിക്കുന്നത്.</translation>
-<translation id="5514904542973294328">ഈ ഉപകരണത്തിന്റെ അഡ്‌മിൻ പ്രവർത്തനരഹിതമാക്കി</translation>
-<translation id="5515439363601853141">നിങ്ങളുടെ പാസ്‍വേഡ് കാണാൻ അൺലോക്ക് ചെയ്യുക</translation>
-<translation id="5516455585884385570">അറിയിപ്പ് ക്രമീകരണം തുറക്കുക</translation>
-<translation id="5517095782334947753">നിങ്ങൾക്ക് <ph name="FROM_ACCOUNT" /> എന്നയാളിൽ നിന്നുള്ള ബുക്ക്‌മാർക്കുകളും ചരിത്രവും പാസ്‌വേഡുകളും മറ്റ് ക്രമീകരണവുമുണ്ട്.</translation>
-<translation id="5524843473235508879">റീഡയറക്ട് ചെയ്യുന്നത് ബ്ലോക്ക് ചെയ്തു.</translation>
-<translation id="5527082711130173040">ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യാൻ Chrome-ന് ലൊക്കേഷൻ ആക്‌സസ് ആവശ്യമാണ്. <ph name="BEGIN_LINK1" />അനുമതികൾ അപ്‌ഡേറ്റ് ചെയ്യുക<ph name="END_LINK1" />. ഈ ഉപകരണത്തിന്റെ <ph name="BEGIN_LINK2" />ലൊക്കേഷൻ ആക്‌സസും ഓഫാക്കിയിരിക്കുകയാണ്<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">ക്ലിപ്പ്ബോർഡിൽ നിന്ന് ചിത്രങ്ങളും ടെക്‌സ്‌റ്റും റീഡ് ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശ ചെയ്‌തത്)</translation>
-<translation id="5530766185686772672">ആൾമാറാട്ട ടാബുകൾ അടയ്‌ക്കുക</translation>
-<translation id="5534334044554683961">നിങ്ങൾ VR-ൽ ആയിരിക്കുമ്പോൾ, ഈ സൈറ്റിന് ഇനിപ്പറയുന്ന കാര്യങ്ങളെക്കുറിച്ച് മനസ്സിലാക്കാൻ കഴിഞ്ഞേക്കും:
-  -   ഉയരം പോലെയുള്ള നിങ്ങളുടെ ശാരീരിക സവിശേഷതകൾ
-  -   നിങ്ങളുടെ മുറിയുടെ ലേഔട്ട്
-
-VR-ൽ പ്രവേശിക്കുന്നതിന് മുമ്പ് നിങ്ങൾ ഈ സൈറ്റിനെ വിശ്വസിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കുക.</translation>
-<translation id="5534640966246046842">സൈറ്റ് ‌പകർത്തി</translation>
-<translation id="5556459405103347317">വീണ്ടും ലോഡുചെയ്യുക</translation>
-<translation id="5561549206367097665">നെറ്റ്‌വർക്കിനായി കാത്തിരിക്കുന്നു...</translation>
-<translation id="557283862590186398">Chrome-ന് ഈ സൈറ്റിനായി നിങ്ങളുടെ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാനുള്ള അനുമതി ആവശ്യമാണ്.</translation>
-<translation id="55737423895878184">ലൊക്കേഷനും അറിയിപ്പുകളും അനുവദിച്ചിരിക്കുന്നു</translation>
-<translation id="5578795271662203820">ഈ ചിത്രത്തിനായി <ph name="SEARCH_ENGINE" />-ൽ തിരയുക</translation>
-<translation id="5581519193887989363">എന്തൊക്കെ സമന്വയിക്കണമെന്നത് <ph name="BEGIN_LINK1" />ക്രമീകരണത്തിൽ<ph name="END_LINK1" /> നിങ്ങൾക്ക് എപ്പോഴും തിരഞ്ഞെടുക്കാം.</translation>
-<translation id="5595485650161345191">വിലാസം എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="5596627076506792578">കൂടുതൽ‍ ഓപ്‌ഷനുകൾ</translation>
-<translation id="5599455543593328020">അദൃശ്യ മോഡ്</translation>
-<translation id="5620928963363755975">'കൂടുതൽ ഓപ്‌ഷനുകൾ' ബട്ടണിൽ നിന്നും, ഡൗൺലോഡുകളിൽ നിന്നും നിങ്ങളുടെ ഫയലുകളും ‌പേജുകളും കണ്ടെത്തുക</translation>
-<translation id="5626134646977739690">നാമം:</translation>
-<translation id="5639724618331995626">എല്ലാ സൈറ്റുകളെയും അനുവദിക്കുക</translation>
-<translation id="5648166631817621825">കഴിഞ്ഞ 7 ദിവസം</translation>
-<translation id="5649053991847567735">യാന്ത്രിക ഡൗൺലോഡുകൾ</translation>
-<translation id="5655963694829536461">നിങ്ങളുടെ ഡൗൺലോഡുകൾ തിരയുക</translation>
-<translation id="5659593005791499971">ഇമെയില്‍</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> ആപ്പിൽ ഇവന്റ് സൃഷ്‌ടിക്കുക</translation>
-<translation id="5668404140385795438">സൂം ഇൻ ചെയ്യുന്നത് തടയുന്നതിനുള്ള ഒരു വെബ്സൈറ്റിന്റെ അഭ്യർത്ഥന അസാധുവാക്കുക</translation>
-<translation id="5677928146339483299">തടഞ്ഞു</translation>
-<translation id="5684874026226664614">ക്ഷമിക്കണം. ഈ പേജ് വിവർത്തനം ചെയ്യാനായില്ല.</translation>
-<translation id="5686790454216892815">ഫയലിന്റെ പേര് ദൈർഘ്യമേറിയതാണ്</translation>
-<translation id="5689516760719285838">ലൊക്കേഷൻ</translation>
-<translation id="569536719314091526">'കൂടുതൽ ഓപ്‌ഷനുകൾ' ബട്ടണിൽ നിന്ന്, ഈ പേജ് ഏത് ഭാഷയിലേക്കും വിവർത്തനം ചെയ്യുക</translation>
-<translation id="572328651809341494">അടുത്തിടെയുള്ള ടാബുകൾ</translation>
-<translation id="5726692708398506830">പേജിൽ എല്ലാം വലുതായി നൽകുക</translation>
-<translation id="5748802427693696783">സ്റ്റാൻഡേർഡ് ടാബുകളിലേക്ക് മാറി</translation>
-<translation id="5749068826913805084">ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യാൻ Chrome-ന് സ്റ്റോറേജ് ആക്‌സസ് ആവശ്യമുണ്ട്.</translation>
-<translation id="5763382633136178763">ആൾമാറാട്ട ടാബുകൾ</translation>
-<translation id="5763514718066511291">ഈ ആപ്പിനായുള്ള URL പകർത്താൻ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="5765780083710877561">വിവരണം:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> / <ph name="SPACE_AVAILABLE" /> ഉപയോഗിക്കുന്നു</translation>
-<translation id="5797070761912323120">തിരയലും പരസ്യവും മറ്റ് Google സേവനങ്ങളും വ്യക്തിപരമാക്കാൻ Google നിങ്ങളുടെ ചരിത്രം ഉപയോഗിച്ചേക്കാം</translation>
-<translation id="5804241973901381774">അനുമതികൾ</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# മണിക്കൂര്‍ മുമ്പ്}other{# മണിക്കൂര്‍ മുമ്പ്}}</translation>
-<translation id="5810288467834065221">പകർപ്പവകാശം <ph name="YEAR" /> Google LLC. എല്ലാ അവകാശങ്ങളും നിക്ഷിപ്‍തം.</translation>
-<translation id="5817918615728894473">ജോടിയാക്കുക</translation>
-<translation id="583281660410589416">അജ്ഞാതം</translation>
-<translation id="5833984609253377421">ലിങ്ക് പങ്കിടുക</translation>
-<translation id="5836192821815272682">Chrome അപ്‌ഡേറ്റ് ഡൗൺലോഡ് ചെയ്യുന്നു…</translation>
-<translation id="5853623416121554550">താൽക്കാലികമായി നിർത്തി</translation>
-<translation id="5854790677617711513">30 ദിവസത്തിൽ കൂടുതൽ പഴക്കമുള്ളത്</translation>
-<translation id="5858741533101922242">Chrome-ന് Bluetooth അഡാപ്‌റ്റർ ഓണാക്കാനാവുന്നില്ല</translation>
-<translation id="5860033963881614850">ഓഫാക്കുക</translation>
-<translation id="5862731021271217234">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="5864174910718532887">വിശദാംശങ്ങൾ: സൈറ്റിൻ്റെ പേരനുസരിച്ച് അടുക്കിയത്</translation>
-<translation id="5864419784173784555">മറ്റൊരു ഡൗൺലോഡിനായി കാത്തിരിക്കുന്നു…</translation>
-<translation id="5865733239029070421">Google-ലേക്ക് സ്വയമേവ ഉപയോഗ വിവരക്കണക്കുകളും ക്രാഷ് റിപ്പോര്‍ട്ടുകളും അയയ്ക്കുന്നു</translation>
-<translation id="5869522115854928033">സംരക്ഷിച്ച പാസ്‌വേഡുകള്‍</translation>
-<translation id="5902828464777634901">കുക്കികൾ ഉൾപ്പെടെ ഈ വെബ്‌സൈറ്റ് സംഭരിക്കുന്ന എല്ലാ പ്രാദേശിക വിവരവും ഇല്ലാതാക്കും.</translation>
+<translation id="4570913071927164677">വിശദാംശങ്ങൾ</translation>
+<translation id="8730621377337864115">പൂർത്തിയാക്കി</translation>
+<translation id="8261506727792406068">ഇല്ലാതാക്കുക</translation>
+<translation id="1181037720776840403">നീക്കംചെയ്യൂ</translation>
+<translation id="5939518447894949180">റീസെറ്റ് ചെയ്യുക</translation>
+<translation id="4002066346123236978">ശീർഷകം</translation>
 <translation id="5916664084637901428">ഓൺ ചെയ്യുക</translation>
-<translation id="5919204609460789179">സമന്വയിപ്പിക്കാൻ തുടങ്ങുന്നതിന്, <ph name="PRODUCT_NAME" /> അപ്‌ഡേറ്റ് ചെയ്യുക</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> സംരക്ഷിച്ചു</translation>
-<translation id="5939518447894949180">വീണ്ടും സജ്ജീകരിക്കുക</translation>
-<translation id="5942872142862698679">തിരയാൻ Google ഉപയോഗിക്കുന്നു</translation>
-<translation id="5952764234151283551">നിങ്ങൾ എത്തിച്ചേരാൻ ശ്രമിക്കുന്ന പേജിന്റെ URL Google-ലേക്ക് അയയ്ക്കുന്നു</translation>
-<translation id="5956665950594638604">പുതിയ ടാബിൽ Chrome സഹായ കേന്ദ്രം തുറക്കുക</translation>
-<translation id="5958275228015807058">ഡൗൺലോഡുകളിൽ നിന്നും നിങ്ങളുടെ ഫയലുകളും ‌പേജുകളും കണ്ടെത്തുക</translation>
-<translation id="5962718611393537961">ചുരുക്കാൻ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="6000066717592683814">Google ഉപയോഗിക്കുക</translation>
-<translation id="6005538289190791541">നിർദ്ദേശിച്ച പാസ്‌വേഡ്</translation>
-<translation id="6036057147555329831">അധിക ICU</translation>
-<translation id="6039379616847168523">അടുത്ത ടാബിലേക്ക് പോകുക</translation>
-<translation id="6040143037577758943">അടയ്ക്കുക</translation>
-<translation id="6042308850641462728">കൂടുതൽ</translation>
-<translation id="604996488070107836">ഒരു അജ്ഞാതമായ പിശക് കാരണം <ph name="FILE_NAME" /> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">പൂർത്തിയാക്കിയ ഡൗൺലോഡുകൾ</translation>
-<translation id="6075798973483050474">ഹോം പേജ് എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> മണിക്കൂർ ശേഷിക്കുന്നു</translation>
-<translation id="6108923351542677676">സജ്ജീകരണം പുരോഗതിയിലാണ്...</translation>
-<translation id="6111020039983847643">ഉപയോഗിച്ച ഡാറ്റ</translation>
-<translation id="6112702117600201073">പേജ് പുതുക്കുന്നു</translation>
-<translation id="6127379762771434464">ഇനം നീക്കംചെയ്‌തു</translation>
-<translation id="6140912465461743537">രാജ്യം/പ്രദേശം</translation>
-<translation id="614940544461990577">പരീക്ഷിച്ചുനോക്കൂ:</translation>
-<translation id="6154478581116148741">ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ പാസ്‌വേഡുകൾ എക്‌സ്‌പോർട്ട് ചെയ്യാൻ ക്രമീകരണത്തിൽ സ്‌ക്രീൻ ലോക്ക് ഓണാക്കുക</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> ഡാറ്റ ലാഭിക്കൽ</translation>
+<translation id="5860033963881614850">ഓഫാക്കുക</translation>
 <translation id="6165508094623778733">കൂടുതലറിയുക</translation>
-<translation id="6177111841848151710">നിലവിലെ തിരയൽ യന്ത്രത്തിൽ ബ്ലോക്ക് ചെയ്‌തിരിക്കുന്നു</translation>
-<translation id="6181444274883918285">സൈറ്റിനെ ഒഴിവാക്കൽ ലിസ്‌റ്റിൽ ചേർക്കുക</translation>
-<translation id="6192333916571137726">ഫയൽ ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="6192792657125177640">അപവാദങ്ങള്‍</translation>
-<translation id="6194112207524046168">Chrome-നെ നിങ്ങളുടെ ക്യാമറ ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK" />Android ക്രമീകരണത്തിൽ<ph name="END_LINK" /> ക്യാമറയും ഓണാക്കുക.</translation>
-<translation id="6196640612572343990">മൂന്നാം കക്ഷി കുക്കികള്‍ ബ്ലോക്കുചെയ്യുക</translation>
-<translation id="6206551242102657620">കണക്ഷൻ സുരക്ഷിതമാണ്. സൈറ്റ് വിവരങ്ങള്‍</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> അല്ലേ?</translation>
+<translation id="6042308850641462728">കൂടുതൽ</translation>
+<translation id="6040143037577758943">അടയ്ക്കുക</translation>
+<translation id="780301667611848630">വേണ്ട നന്ദി</translation>
+<translation id="1201402288615127009">അടുത്തത്</translation>
+<translation id="2359808026110333948">തുടരുക</translation>
+<translation id="2653659639078652383">സമര്‍പ്പിക്കൂ</translation>
+<translation id="2079545284768500474">പഴയപടിയാക്കുക</translation>
+<translation id="7649070708921625228">സഹായം</translation>
+<translation id="2148716181193084225">ഇന്ന്</translation>
+<translation id="7781829728241885113">ഇന്നലെ</translation>
+<translation id="6945221475159498467">തിരഞ്ഞെടുക്കുക</translation>
+<translation id="7791543448312431591">ചേര്‍ക്കൂ</translation>
+<translation id="6527303717912515753">പങ്കിടുക</translation>
+<translation id="1383876407941801731">തിരയുക</translation>
+<translation id="3115898365077584848">വിവരങ്ങൾ കാണിക്കുക</translation>
+<translation id="3295602654194328831">വിവരങ്ങൾ മറയ്‌ക്കുക</translation>
+<translation id="3987993985790029246">ലിങ്ക് പകർത്തുക</translation>
+<translation id="2704606927547763573">പകർത്തി</translation>
+<translation id="8725066075913043281">വീണ്ടും ശ്രമിക്കുക</translation>
+<translation id="385051799172605136">പിന്നോട്ട്</translation>
+<translation id="8131740175452115882">സ്ഥിരീകരിക്കുക</translation>
+<translation id="5300589172476337783">കാണിക്കുക</translation>
+<translation id="1124772482545689468">ഉപയോക്താവ്</translation>
+<translation id="8609465669617005112">മുകളിലേക്ക് നീക്കുക</translation>
+<translation id="6746124502594467657">താഴേക്ക് നീക്കുക</translation>
+<translation id="8249310407154411074">മുകളിലേക്ക് നീക്കുക</translation>
+<translation id="8428213095426709021">ക്രമീകരണങ്ങള്‍</translation>
+<translation id="2498359688066513246">സഹായവും ഫീഡ്ബാക്കും</translation>
+<translation id="8378714024927312812">നിങ്ങളുടെ സ്ഥാപനം മാനേജ് ചെയ്യുന്നത്</translation>
+<translation id="9019902583201351841">നിങ്ങളുടെ രക്ഷിതാക്കൾ നിയന്ത്രിക്കുന്നു</translation>
+<translation id="4645575059429386691">നിങ്ങളുടെ രക്ഷിതാവ് നിയന്ത്രിക്കുന്നു</translation>
+<translation id="4883854917563148705">മാനേജ് ചെയ്യുന്ന ക്രമീകരണം പുനഃസജ്ജീകരിക്കാനാവില്ല</translation>
+<translation id="4307992518367153382">അടിസ്ഥാനങ്ങള്‍</translation>
+<translation id="1974060860693918893">നൂതനം</translation>
+<translation id="1146678959555564648">VR-ൽ പ്രവേശിക്കുക</translation>
+<translation id="987264212798334818">പൊതുവായ</translation>
+<translation id="4275663329226226506">മീഡിയ</translation>
+<translation id="4759238208242260848">ഡൌണ്‍ലോഡുകള്‍</translation>
+<translation id="218608176142494674">പങ്കിടൽ</translation>
+<translation id="8004582292198964060">ബ്രൗസര്‍</translation>
+<translation id="1105960400813249514">സ്‌ക്രീൻ ക്യാപ്‌ചർ</translation>
+<translation id="4875775213178255010">ഉള്ളടക്ക നിർദ്ദേശങ്ങൾ</translation>
+<translation id="2021896219286479412">പൂർണ്ണ സ്ക്രീൻ സൈറ്റ് നിയന്ത്രണങ്ങൾ</translation>
+<translation id="4587589328781138893">സൈറ്റുകള്‍</translation>
+<translation id="4943703118917034429">വെർച്വൽ റിയാലിറ്റി</translation>
+<translation id="1928696683969751773">അപ്‌ഡേറ്റുചെയ്യുന്നു</translation>
+<translation id="6064125863973209585">പൂർത്തിയാക്കിയ ഡൗൺലോഡുകൾ</translation>
+<translation id="5342314432463739672">അനുമതി അഭ്യർത്ഥനകൾ</translation>
+<translation id="629730747756840877">അക്കൗണ്ട്</translation>
+<translation id="82609232232243542">Brave-ലേക്ക് സൈൻ ഇൻ ചെയ്യുക</translation>
+<translation id="7956662517480676674">സമന്വയവും Brave Software സേവനങ്ങളും</translation>
+<translation id="5294439808117722387">നിലവിൽ നിങ്ങൾ സമന്വയ, Brave Software സേവന ക്രമീകരണം ഇഷ്‌ടാനുസൃതമാക്കുന്നു. സമന്വയിപ്പിക്കൽ ഓണാക്കുന്നത് പൂർത്തിയാക്കാൻ, സ്‌ക്രീനിൻ്റെ ചുവടുവശത്തിന് സമീപമുള്ള 'സ്ഥിരീകരിക്കുക' ടാപ്പ് ചെയ്യുക. മുകളിലേക്ക് നാവിഗേറ്റ് ചെയ്യുക</translation>
+<translation id="2096012225669085171">ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിക്കലും വ്യക്തിപരമാക്കലും നടത്തുക.</translation>
+<translation id="1692118695553449118">സമന്വയം ഓണാണ്</translation>
+<translation id="5514904542973294328">ഈ ഉപകരണത്തിന്റെ അഡ്‌മിൻ പ്രവർത്തനരഹിതമാക്കി</translation>
+<translation id="6447211988989208781">Brave Software പ്രവർത്തന നിയന്ത്രണങ്ങൾ</translation>
+<translation id="4882831918239250449">തിരയൽ, പരസ്യങ്ങൾ എന്നിവയും മറ്റും വ്യക്തിപരമാക്കുന്നതിനായി നിങ്ങളുടെ ബ്രൗസിംഗ് ചരിത്രം ഉപയോഗിക്കുന്ന വിധം നിയന്ത്രിക്കുക</translation>
+<translation id="7431991332293347422">തിരയലും മറ്റും വ്യക്തിപരമാക്കുന്നതിന് നിങ്ങളുടെ ബ്രൗസിംഗ് ചരിത്രം ഉപയോഗിക്കുന്ന വിധം നിയന്ത്രിക്കുക</translation>
+<translation id="6303969859164067831">സൈൻ ഔട്ട് ചെയ്‌ത് സമന്വയം ഓഫാക്കുക</translation>
+<translation id="1125261911132334651">നിങ്ങളുടെ Brave Software അക്കൗണ്ട് മാനേജ് ചെയ്യുക</translation>
+<translation id="6406506848690869874">Sync</translation>
+<translation id="714362445477979774">നിങ്ങളുടെ Brave ഡാറ്റ സമന്വയിപ്പിക്കുക</translation>
+<translation id="4314815835985389558">സമന്വയിപ്പിക്കൽ മാനേജ് ചെയ്യുക</translation>
+<translation id="5428209950370661546">മറ്റ് Brave Software സേവനങ്ങള്‍‌</translation>
+<translation id="7704317875155739195">സ്വമേധയാ പൂർത്തിയാക്കുന്ന തിരയലുകളും URL-കളും</translation>
+<translation id="2000419248597011803">നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനിലേക്ക് വിലാസ ബാറിൽ നിന്നും തിരയൽ ബോക്‌സിൽ നിന്നുമുള്ള തിരയലുകളും കുറച്ച് കുക്കികളും അയയ്ക്കുന്നു</translation>
+<translation id="7981313251711023384">കൂടുതൽ വേഗത്തിൽ ബ്രൗസ് ചെയ്യാനും തിരയാനും പേജുകൾ റീലോഡ് ചെയ്യുക</translation>
+<translation id="1821253160463689938">നിങ്ങൾ ആ പേജുകൾ സന്ദർശിക്കുന്നില്ലെങ്കിൽ പോലും, നിങ്ങളുടെ മുൻഗണനകൾ ഓർമ്മിക്കുന്നതിന് കുക്കികളെ ഉപയോഗിക്കുന്നു</translation>
+<translation id="6697492270171225480">ഒരു പേജ് കണ്ടെത്താനാകുന്നില്ലെങ്കിൽ, സമാന പേജുകൾക്കായുള്ള നിർദ്ദേശങ്ങൾ കാണിക്കുക</translation>
+<translation id="8109318360573330108">നിങ്ങൾ എത്തിച്ചേരാൻ ശ്രമിക്കുന്ന പേജിന്റെ URL Brave Software-ലേക്ക് അയയ്ക്കുന്നു</translation>
+<translation id="8438566539970814960">തിരയലുകളും ബ്രൗസിംഗും മികച്ചതാക്കുക</translation>
+<translation id="284843628681142937">Brave Software-ൽ നിങ്ങൾ സന്ദർശിക്കുന്ന പേജുകളുടെ URL-കൾ അയയ്ക്കുന്നു</translation>
+<translation id="7222718784508482526">സ്വകാര്യത, സുരക്ഷ, ഡാറ്റാ ശേഖരണം എന്നിവയുമായി ബന്ധപ്പെട്ട കൂടുതൽ ക്രമീകരണത്തിന്, <ph name="BEGIN_LINK"/>സമന്വയവും Brave Software സേവനങ്ങളും<ph name="END_LINK"/> കാണുക</translation>
+<translation id="918192811481327695">Brave-ന്റെ ഫീച്ചറുകളും പ്രകടനവും മെച്ചപ്പെടുത്താൻ സഹായിക്കുക</translation>
+<translation id="9063160602596686558">Brave Software-ലേക്ക് സ്വയമേവ ഉപയോഗ വിവരക്കണക്കുകളും ക്രാഷ് റിപ്പോര്‍ട്ടുകളും അയയ്ക്കുന്നു</translation>
+<translation id="4824958205181053313">സമന്വയം റദ്ദാക്കണോ?</translation>
+<translation id="3058498974290601450">നിങ്ങൾക്ക് ഏത് സമയത്തും ക്രമീകരണത്തിൽ സമന്വയം ഓണാക്കാവുന്നതാണ്</translation>
+<translation id="3143515551205905069">സമന്വയം റദ്ദാക്കുക</translation>
+<translation id="1506061864768559482">തിരയൽ യന്ത്രം</translation>
+<translation id="55737423895878184">ലൊക്കേഷനും അറിയിപ്പുകളും അനുവദിച്ചിരിക്കുന്നു</translation>
+<translation id="3988213473815854515">ലൊക്കേഷൻ അനുവദനീയം</translation>
+<translation id="32895400574683172">അറിയിപ്പുകൾ അനുവദിച്ചിരിക്കുന്നു</translation>
+<translation id="9040142327097499898">അറിയിപ്പുകൾ അനുവദിക്കപ്പെട്ടിരിക്കുന്നു. ഈ ഉപകരണത്തിന്‍റെ ലൊക്കേഷൻ ഓഫാണ്.</translation>
+<translation id="305593374596241526">ലൊക്കേഷൻ ഓഫാണ്; <ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> അത് ഓണാക്കുക.</translation>
+<translation id="2989523299700148168">അടുത്തിടെ സന്ദർശിച്ചവ</translation>
+<translation id="6433501201775827830">നിങ്ങളുടെ തിരയൽ യന്ത്രം തിരഞ്ഞെടുക്കുക</translation>
+<translation id="7177466738963138057">നിങ്ങൾക്കിത് പിന്നീട് ക്രമീകരണങ്ങളിൽ മാറ്റാനാവും</translation>
+<translation id="3478363558367712427">നിങ്ങളുടെ തിരയല്‍ യന്ത്രം നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം</translation>
+<translation id="4910889077668685004">പേയ്‌മെന്റ് ആപ്പുകൾ</translation>
+<translation id="5152843274749979095">ഉപയോഗിക്കാനാവുന്ന ആപ്‌സൊന്നും ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല</translation>
+<translation id="8812260976093120287">ചില വെബ്‌സൈറ്റുകളിൽ, നിങ്ങളുടെ ഉപകരണത്തിൽ ഉപയോഗിക്കാവുന്നതും മുകളിൽ പറഞ്ഞിരിക്കുന്നതുമായ പേയ്‌മെന്റ് ആപ്പുകൾ വഴി പണമടയ്‌ക്കാം.</translation>
+<translation id="7764225426217299476">വിലാസം ചേർക്കുക</translation>
+<translation id="5595485650161345191">വിലാസം എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="5087580092889165836">കാർഡ് ചേർക്കുക</translation>
+<translation id="2154484045852737596">കാർഡ് എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="6140912465461743537">രാജ്യം/പ്രദേശം</translation>
+<translation id="5659593005791499971">ഇമെയില്‍</translation>
+<translation id="4378154925671717803">ഫോൺ</translation>
+<translation id="4807098396393229769">കാര്‍‌ഡിലെ നാമം</translation>
+<translation id="860043288473659153">കാർഡിന്റെ ഉടമയുടെ പേര്</translation>
+<translation id="2612676031748830579">കാർഡ് നമ്പർ</translation>
+<translation id="869891660844655955">കാലഹരണപ്പെടല്‍‌ തീയതി</translation>
+<translation id="2286841657746966508">ബില്ലിംഗ് വിലാസം</translation>
+<translation id="663059986967017181">Brave-ലേക്ക് പ്കർത്തി</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> പേയ്‌മെന്റ് രീതികളും}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> പേയ്‌മെന്റ് രീതികളും}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> പേയ്‌മെന്റ് രീതികളും}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> പേയ്‌മെന്റ് രീതികളും}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> പേയ്‌മെന്റ് രീതികളും}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> പേയ്‌മെന്റ് രീതികളും}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> പേയ്‌മെന്റ് രീതികളും}other{<ph name="CONTACT_PREVIEW"/>\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> പേയ്‌മെന്റ് രീതികളും}}</translation>
+<translation id="7029809446516969842">പാസ്‌വേഡുകള്‍</translation>
+<translation id="1943432128510653496">സംരക്ഷിച്ച പാസ്‌വേഡുകള്‍</translation>
+<translation id="2100273922101894616">സ്വയമേവയുള്ള സൈൻ ഇൻ</translation>
+<translation id="363596933471559332">സൂക്ഷിച്ചിരിക്കുന്ന ക്രെഡൻഷ്യലുകൾ ഉപയോഗിച്ച് വെബ്‌സൈറ്റുകളിലേക്ക് സ്വയമേവ സൈൻ ഇൻ ചെയ്യുക. ഫീച്ചർ ഓഫായിരിക്കുമ്പോൾ, ഒരു വെബ്‌സൈറ്റിലേക്ക് സൈൻ ഇൻ ചെയ്യുന്നതിനുമുമ്പ് പരിശോധിച്ചുറപ്പിക്കാൻ ഓരോ തവണയും നിങ്ങളോടാവശ്യപ്പെടും.</translation>
+<translation id="6995899638241819463">പാസ്‌വേഡുകൾ, ഡാറ്റാ ലംഘനത്തിന്റെ ഭാഗമായി വെളിപ്പെട്ടാൽ നിങ്ങൾക്ക് മുന്നറിയിപ്പ് നൽകുന്നു</translation>
+<translation id="1534287762301776620">നിങ്ങൾ Brave Software അക്കൗണ്ടിൽ സൈൻ ഇൻ ചെയ്യുമ്പോൾ ഈ ഫീച്ചർ ഓണാകും</translation>
+<translation id="10614374240317010">ഒരിക്കലും സംരക്ഷിച്ചില്ല</translation>
+<translation id="3098842761938485917">നിങ്ങളുടെ <ph name="BEGIN_LINK"/>Brave Software അക്കൗണ്ടിൽ<ph name="END_LINK"/> സംരക്ഷിച്ച പാസ്‌വേഡുകൾ കാണുക, മാനേജ് ചെയ്യുക</translation>
+<translation id="8562452229998620586">സംരക്ഷിച്ച പാസ്‌വേഡുകൾ ഇവിടെ ദൃശ്യമാകും.</translation>
+<translation id="8084114998886531721">സംരക്ഷിച്ച പാസ്‌വേഡ്</translation>
+<translation id="2870560284913253234">സൈറ്റ്</translation>
+<translation id="8503813439785031346">ഉപയോക്തൃനാമം</translation>
+<translation id="6657585470893396449">പാസ്‌വേഡ്</translation>
+<translation id="2154710561487035718">URL പകര്‍ത്തുക</translation>
+<translation id="1571304935088121812">ഉപയോക്തൃനാമം പകർത്തുക</translation>
+<translation id="5005498671520578047">പാസ്‌വേഡ് പകർത്തുക</translation>
+<translation id="3632295766818638029">പാസ്‌വേഡ് വെളിപ്പെടുത്തുക</translation>
+<translation id="1513858653616922153">പാസ്‌വേഡ് ഇല്ലാതാക്കുക</translation>
+<translation id="543338862236136125">പാസ്‌വേഡ് എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="4565377596337484307">പാസ്‌വേഡ് മറയ്ക്കുക</translation>
+<translation id="8523928698583292556">സംഭരിച്ചിരിക്കുന്ന പാസ്‌വേഡ് ഇല്ലാതാക്കുക</translation>
+<translation id="2898264748040935573">സംഭരിച്ചിരിക്കുന്ന പാസ്‌വേഡ് എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="5433691172869980887">ഉപയോക്തൃനാമം പകർത്തി</translation>
+<translation id="5534640966246046842">സൈറ്റ് ‌പകർത്തി</translation>
+<translation id="2625189173221582860">പാസ്‌വേഡ് പകർത്തി</translation>
+<translation id="4550003330909367850">ഇവിടെ ‌നിങ്ങളുടെ ‌പാസ്‌വേഡ് കാണാനും പകർത്താനും കഴിയും, ഈ ഉപകരണത്തിൽ സ്‌ക്രീൻ ലോക്ക് ‌സജ്ജമാക്കുക.</translation>
+<translation id="6154478581116148741">ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ പാസ്‌വേഡുകൾ എക്‌സ്‌പോർട്ട് ചെയ്യാൻ ക്രമീകരണത്തിൽ സ്‌ക്രീൻ ലോക്ക് ഓണാക്കുക</translation>
+<translation id="4842092870884894799">പാസ്‌വേഡ് സൃഷ്ടിക്കൽ പോപ്പ് അപ്പ് കാണിക്കുന്നു</translation>
+<translation id="2259659629660284697">പാസ്‌വേഡുകൾ എക്‌സ്‌പോർട്ട് ചെയ്യുക...</translation>
+<translation id="133012818630824069">Brave ഉപയോഗിച്ച് സംഭരിച്ചിട്ടുള്ള പാസ്‍വേഡുകൾ എക്സ്പോർട്ട് ചെയ്യുക</translation>
+<translation id="6914783257214138813">എക്‌സ്പോർട്ട് ചെയ്ത ഫയൽ കാണാനാകുന്ന ഏതൊരാൾക്കും നിങ്ങളുടെ പാസ്‌വേഡും കാണാനാകും.</translation>
+<translation id="2321086116217818302">പാസ്‍വേഡുകൾ തയ്യാറാക്കുന്നു…</translation>
+<translation id="8445448999790540984">പാസ്‌വേഡുകൾ എക്‌സ്‌പോർട്ട് ചെയ്യാനാവുന്നില്ല</translation>
+<translation id="3066461326500799725">Brave Software ഡ്രൈവ് എങ്ങനെ ഉപയോഗിക്കണമെന്ന് അറിയുക</translation>
+<translation id="729975465115245577">നിങ്ങളുടെ ഉപകരണത്തിൽ പാസ്‍വേഡ് ഫയൽ സംഭരിക്കാനുള്ള ആപ്പ് ഇല്ല.</translation>
+<translation id="7682724950699840886">ഈ നുറുങ്ങുകൾ പരീക്ഷിക്കൂ: നിങ്ങളുടെ ഉപകരണത്തിൽ ആവശ്യമായ ഇടം ഉണ്ടെന്ന് ഉറപ്പാക്കി, വീണ്ടും എക്‌സ്‌പോർട്ട് ചെയ്യാൻ ശ്രമിക്കുക.</translation>
+<translation id="1129510026454351943">വിശദാംശങ്ങള്‍: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">പാസ്‍വേഡ് പകർത്താൻ അൺലോക്ക് ചെയ്യുക</translation>
+<translation id="5515439363601853141">നിങ്ങളുടെ പാസ്‍വേഡ് കാണാൻ അൺലോക്ക് ചെയ്യുക</translation>
 <translation id="6221633008163990886">നിങ്ങളുടെ പാസ്‌വേഡുകൾ എക്‌സ്‌പോർട്ട് ചെയ്യാൻ അൺലോക്ക് ചെയ്യുക</translation>
+<translation id="230699814587342492">Brave പാസ്‌വേഡുകൾ</translation>
+<translation id="6075798973483050474">ഹോം പേജ് എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="854522910157234410">ഈ പേജ് തുറക്കുക</translation>
+<translation id="2482878487686419369">വിജ്ഞാപനങ്ങള്‍‌</translation>
+<translation id="6255999984061454636">ഉള്ളടക്ക നിർദ്ദേശങ്ങൾ</translation>
+<translation id="805047784848435650">നിങ്ങളുടെ ബ്രൗസിംഗ്‌ ചരിത്രം അടിസ്ഥാനമാക്കിയുള്ളത്</translation>
+<translation id="1041308826830691739">വെബ്‌സൈറ്റുകളിൽ നിന്ന്</translation>
+<translation id="395206256282351086">തിരയലും സൈറ്റ് നിർദ്ദേശങ്ങളും പ്രവർത്തനരഹിതമാക്കി</translation>
+<translation id="257088987046510401">തീമുകള്‍‌</translation>
+<translation id="4650364565596261010">സിസ്‌റ്റം ഡിഫോൾട്ട്</translation>
+<translation id="7588219262685291874">ഉപകരണത്തിൻ്റെ ബാറ്ററി ലാഭിക്കൽ ഓണായിരിക്കുമ്പോൾ ഇരുണ്ട തീം ഓണാക്കുക</translation>
+<translation id="2760989362628427051">നിങ്ങളുടെ ഉപകരണത്തിന്റെ ഇരുണ്ട തീമോ ബാറ്ററി ലാഭിക്കലോ ഓണായിരിക്കുമ്പോൾ ഇരുണ്ട തീം ഓണാക്കുക</translation>
+<translation id="6381421346744604172">വെബ്‌സൈറ്റുകൾ ഇരുണ്ടതാക്കുക</translation>
+<translation id="5040262127954254034">സ്വകാര്യത</translation>
+<translation id="4991384657077828949">Brave സുരക്ഷ മെച്ചപ്പെടുത്താൻ സഹായിക്കുക</translation>
+<translation id="1943176487615318915">അപകടകരമായ ആപ്പുകളും സൈറ്റുകളും കണ്ടെത്തുന്നതിന്, നിങ്ങൾ സന്ദർശിക്കുന്ന ചില പേജുകളുടെ URL, പരിമിത സിസ്റ്റം വിവരങ്ങൾ, ചില പേജ് ഉള്ളടക്കം എന്നിവ Brave Brave Software-ന് അയയ്ക്കുന്നു</translation>
+<translation id="3181954750937456830">സുരക്ഷിത ബ്രൗസിംഗ് (അപകടകരമായ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളെയും ഉപകരണത്തെയും പരിരക്ഷിക്കുന്നു)</translation>
+<translation id="7315322926489145388">നിങ്ങളുടെ സുരക്ഷ അപകടത്തിലാകുമ്പോൾ നിങ്ങൾ സന്ദർശിക്കുന്ന ചില പേജുകളുടെ URL-കൾ Brave Software-ലേക്ക് അയയ്ക്കുന്നു</translation>
+<translation id="2063713494490388661">തിരയാൻ ടാപ്പ് ചെയ്യുക</translation>
+<translation id="2369463299479365221">പേജ് വിട്ടുപോകാതെ തന്നെ വെബ്‌സൈറ്റുകളിലെ വിഷയങ്ങളെക്കുറിച്ച് അറിയുക. തിരയാൻ ടാപ്പ് ചെയ്യുക എന്നത് പദവും അതിന്റെ സന്ദർഭവും Brave Software തിരയലിലേക്ക് അയച്ച്, നിർവചനങ്ങളും ചിത്രങ്ങളും തിരയൽ ഫലങ്ങളും മറ്റ് വിശദാംശങ്ങളും ലഭ്യമാക്കുന്നു.
+
+നിങ്ങളുടെ തിരയൽ പദം ക്രമീകരിക്കാൻ, തിരഞ്ഞെടുക്കുന്നതിനായി ദീർഘനേരം അമർത്തിപ്പിടിക്കുക. തിരയൽ പരിഷ്‌ക്കരിക്കാൻ, നേരെ മുകളിലേക്ക് പാനൽ നീക്കി, തിരയൽ ബോക്‌സ് ടാപ്പ് ചെയ്യുക.</translation>
+<translation id="2930742481329940825">Brave Software തിരയലിന് സന്ദർഭം വ്യക്തമാക്കാൻ തിരഞ്ഞെടുത്ത വാക്കും നിലവിലെ പേജും, 'തിരയാൻ സ്‌പർശിക്കുക' അയയ്‌ക്കും. <ph name="BEGIN_LINK"/>ക്രമീകരണത്തിൽ<ph name="END_LINK"/> നിന്ന് നിങ്ങൾക്കിത് ഓഫാക്കാം.</translation>
+<translation id="5039804452771397117">അനുവദിക്കൂ</translation>
+<translation id="1406000523432664303">“ട്രാക്ക് ചെയ്യരുത്”</translation>
 <translation id="6232535412751077445">നിങ്ങളുടെ ബ്രൗസിംഗ് ട്രാഫിക്കിൽ ഒരു അഭ്യർത്ഥന ഉൾപ്പെടുത്തുമെന്നാണ് 'ട്രാക്ക് ചെയ്യരുത്' ഫീച്ചർ പ്രവർത്തനക്ഷമമാക്കുക എന്നത് അർത്ഥമാക്കുന്നത്. അതിനെ തുടർന്നുള്ള ഏതൊരു കാര്യവും, ഒരു വെബ്‌സൈറ്റ് അഭ്യർത്ഥനയിന്മേൽ പ്രതികരിക്കുന്നുണ്ടോ എന്നതിനെയും അഭ്യർത്ഥന വ്യാഖ്യാനിക്കുന്നതെങ്ങനെ എന്നതിനെയും ആശ്രയിച്ചിരിക്കും.
 
 ഉദാഹരണത്തിന്, ചില വെബ്‌സൈറ്റുകൾ നിങ്ങൾ സന്ദർശിച്ച മറ്റ് വെബ്‌സൈറ്റുകളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ലാത്ത പരസ്യങ്ങൾ കാണിച്ച് ഈ അഭ്യർത്ഥനയോട് പ്രതികരിക്കാം. മിക്ക വെബ്‌സൈറ്റുകളും തുടർന്നും നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ ശേഖരിക്കുകയും ഉപയോഗിക്കുകയും ചെയ്യും - ഉദാഹരണത്തിന് അവരുടെ വെബ്‌സൈറ്റുകളിൽ സുരക്ഷ മെച്ചപ്പെടുത്തുന്നതിനും ഉള്ളടക്കവും പരസ്യങ്ങളും ശുപാർശകളും നൽകുന്നതിനും റിപ്പോർട്ടിംഗ് സ്ഥിതിവിവരക്കണക്കുകൾ സൃഷ്‌ടിക്കുന്നതിനും.</translation>
-<translation id="624789221780392884">അപ്‌ഡേറ്റ് തയ്യാറാണ്</translation>
-<translation id="6255999984061454636">ഉള്ളടക്ക നിർദ്ദേശങ്ങൾ</translation>
-<translation id="6277522088822131679">പേജ് പ്രിന്റുചെയ്യുന്നതിൽ ഒരു പ്രശ്‌നമുണ്ടായി. വീണ്ടും ശ്രമിക്കുക.</translation>
-<translation id="6295158916970320988">എല്ലാ സൈറ്റുകളും</translation>
-<translation id="629730747756840877">അക്കൗണ്ട്</translation>
-<translation id="6303969859164067831">സൈൻ ഔട്ട് ചെയ്‌ത് സമന്വയം ഓഫാക്കുക</translation>
-<translation id="6316139424528454185">Android പതിപ്പ് പിന്തുണയ്‌ക്കുന്നതല്ല</translation>
-<translation id="6320088164292336938">വൈബ്രേറ്റുചെയ്യുക</translation>
-<translation id="6324034347079777476">Android സിസ്‌റ്റം സമന്വയിപ്പിക്കൽ പ്രവർത്തനരഹിതമാക്കി</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> വഴി പങ്കിടുക</translation>
-<translation id="6337234675334993532">എന്‍ക്രിപ്ഷന്‍</translation>
-<translation id="6341580099087024258">ഫയലുകൾ എവിടെയാണ് സംരക്ഷിക്കേണ്ടതെന്ന് ചോദിക്കുക</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> പേയ്‌മെന്റ് രീതികളും}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> പേയ്‌മെന്റ് രീതികളും}}</translation>
-<translation id="6364438453358674297">ചരിത്രത്തിൽ നിന്ന് നിർദ്ദേശം നീക്കംചെയ്യണോ?</translation>
-<translation id="6369229450655021117">ഇവിടെ നിന്ന്, വെബ്ബിൽ തിരയാനും സുഹൃത്തുക്കളുമായി പങ്കിടാനും തുറന്ന പേജുകൾ കാണാനുമാവും</translation>
-<translation id="6378173571450987352">വിശദാംശങ്ങൾ: ഉപയോഗിച്ച ഡാറ്റയുടെ അളവനുസരിച്ച് അടുക്കിയത്</translation>
-<translation id="6381421346744604172">വെബ്‌സൈറ്റുകൾ ഇരുണ്ടതാക്കുക</translation>
-<translation id="6388207532828177975">മായ്‌ച്ച് റീസെറ്റ് ചെയ്യുക</translation>
-<translation id="6393863479814692971">Chrome-ന് ഈ സൈറ്റിനായി നിങ്ങളുടെ ക്യാമറയും മൈക്രോഫോണും ആക്‌സസ് ചെയ്യാനുള്ള അനുമതി ആവശ്യമാണ്.</translation>
-<translation id="6395288395575013217">ലിങ്ക്</translation>
-<translation id="6404511346730675251">ബുക്ക്‌മാർക്ക് എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="6406506848690869874">Sync</translation>
-<translation id="641643625718530986">പ്രിന്‍റ് ചെയ്യുക…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB ഡൗൺലോഡ് ചെയ്‌തു</translation>
-<translation id="6427112570124116297">വെബ് വിവർത്തനം ചെയ്യുക</translation>
-<translation id="6433501201775827830">നിങ്ങളുടെ തിരയൽ യന്ത്രം തിരഞ്ഞെടുക്കുക</translation>
-<translation id="6437478888915024427">പേജ് വിവരം</translation>
-<translation id="6441734959916820584">പേര് വളരെ വലുതാണ്</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ചിത്രം}other{# ചിത്രങ്ങൾ}}</translation>
-<translation id="6447842834002726250">കുക്കികള്‍</translation>
-<translation id="6461962085415701688">ഫയൽ തുറക്കാൻ കഴിയില്ല</translation>
-<translation id="6464977750820128603">നിങ്ങൾ Chrome- ൽ സന്ദർശിക്കുന്ന സൈറ്റുകൾ കാണാനും അവയ്ക്ക് ടൈമറുകൾ സജ്ജീകരിക്കാനുമാവും.\n\nനിങ്ങൾ ടൈമറുകൾ സജ്ജീകരിക്കുന്ന സൈറ്റുകളെക്കുറിച്ചും നിങ്ങൾ എത്ര സമയം അവ സന്ദർശിക്കുന്നു എന്നതിനെക്കുറിച്ചും Google ന് വിവരങ്ങൾ ലഭിക്കുന്നു. ഡിജിറ്റൽ ആരോഗ്യം മെച്ചപ്പെടുത്താൻ ഈ വിവരം ഉപയോഗിക്കുന്നു.</translation>
-<translation id="6475951671322991020">വീഡിയോ ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="6482749332252372425">സ്‌റ്റോറേജ് ഇടമില്ലാത്തതിനാൽ <ph name="FILE_NAME" /> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
-<translation id="6496823230996795692"><ph name="APP_NAME" /> ആദ്യമായി ഉപയോഗിക്കാൻ, ഇന്‍റര്‍നെറ്റിലേക്ക് കണക്റ്റുചെയ്യുക.</translation>
-<translation id="6508722015517270189">Chrome റീസ്‌റ്റാർട്ടുചെയ്യുക</translation>
-<translation id="6527303717912515753">പങ്കിടുക</translation>
-<translation id="6532866250404780454">നിങ്ങൾ Chrome-ൽ സന്ദർശിക്കുന്ന സൈറ്റുകൾ കാണിക്കില്ല. എല്ലാ സൈറ്റ് ടൈമറുകളും ഇല്ലാതാക്കപ്പെടും.</translation>
-<translation id="6534565668554028783">Google പ്രതികരിക്കാൻ കൂടുതൽ സമയമെടുത്തു</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB ഡൗൺലോഡുചെയ്‌തു</translation>
-<translation id="6539092367496845964">എന്തോ കുഴപ്പം സംഭവിച്ചു. പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</translation>
-<translation id="654446541061731451">ബീം ചെയ്യാൻ ടാബ് തിരഞ്ഞെടുക്കുക</translation>
-<translation id="6545017243486555795">എല്ലാ വിവരങ്ങളും മായ്‌ക്കുക</translation>
-<translation id="6545864417968258051">Bluetooth സ്‌കാനിംഗ്</translation>
-<translation id="6560414384669816528">Sogou ഉപയോഗിച്ച് തിരയുക</translation>
-<translation id="6566259936974865419">Chrome നിങ്ങളുടെ <ph name="GIGABYTES" /> GB ലാഭിച്ചു</translation>
-<translation id="6573096386450695060">എല്ലായ്‌പ്പോഴും അനുവദിക്കുക</translation>
-<translation id="6573431926118603307">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിലെ Chrome-ൽ തുറന്ന ടാബുകൾ ഇവിടെ ദൃശ്യമാകും.</translation>
-<translation id="6583199322650523874">നിലവിലെ പേജ് ബുക്ക്‌മാർക്ക് ചെയ്യുക</translation>
-<translation id="6593061639179217415">ഡെസ്‌ക്‌ടോപ്പ് സൈറ്റ്</translation>
-<translation id="6600954340915313787">Chrome-ലേക്ക് പ്കർത്തി</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">പരിരക്ഷിത ഉള്ളടക്കം</translation>
-<translation id="6627583120233659107">ഫോൾഡർ എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="6643016212128521049">മായ്‌ക്കുക</translation>
-<translation id="6643649862576733715">സംരക്ഷിച്ച ഡാറ്റയുടെ അളവിനനുസരിച്ച് അടുക്കുക</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> പേയ്‌മെന്റ് രീതികളും}other{<ph name="CONTACT_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> പേയ്‌മെന്റ് രീതികളും}}</translation>
-<translation id="6649642165559792194"><ph name="BEGIN_NEW" />പുതിയ<ph name="END_NEW" /> ചിത്രം പ്രിവ്യൂ ചെയ്യുക</translation>
-<translation id="6656545060687952787">ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യുന്നതിന് Chrome-ന് ലൊക്കേഷൻ ആക്‌സസ് ആവശ്യമാണ്. <ph name="BEGIN_LINK" />അനുമതികൾ അപ്‌ഡേറ്റ് ചെയ്യുക<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">പാസ്‌വേഡ്</translation>
-<translation id="6659594942844771486">ടാബ്</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" />-ൽ തുറക്കുക</translation>
-<translation id="666981079809192359">Chrome സ്വകാര്യതാ അറിയിപ്പ്</translation>
-<translation id="6676840375528380067">ഉപകരണത്തില്‍ നിന്ന് Chrome ഡാറ്റ മായ്ക്കണോ?</translation>
-<translation id="6697492270171225480">ഒരു പേജ് കണ്ടെത്താനാകുന്നില്ലെങ്കിൽ, സമാന പേജുകൾക്കായുള്ള നിർദ്ദേശങ്ങൾ കാണിക്കുക</translation>
-<translation id="6697947395630195233">Chrome-ന് ഈ സൈറ്റുമായി ലൊക്കേഷൻ പങ്കിടാൻ നിങ്ങളുടെ ലൊക്കേഷനിലേക്കുള്ള ആക്‌സസ് ആവശ്യമാണ്.</translation>
-<translation id="6698801883190606802">സമന്വിത ഡാറ്റ നിയന്ത്രിക്കുക</translation>
-<translation id="6699370405921460408">നിങ്ങള്‍ സന്ദര്‍ശിക്കുന്ന പേജുകള്‍ Google സെര്‍‌വറുകള്‍ ഒപ്‌റ്റിമൈസ് ചെയ്യും.</translation>
-<translation id="6706288973712894588">നിങ്ങൾ നിലവിൽ ഓഫ്‍ലൈനാണ്.\n<ph name="BEGIN_LINK" />നിങ്ങളുടെ ഓഫ്‍ലൈൻ ഫീഡ് അടുത്തറിയൂ.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">വാർത്ത</translation>
-<translation id="6710213216561001401">കഴിഞ്ഞ</translation>
-<translation id="671481426037969117">നിങ്ങളുടെ <ph name="FQDN" /> ടൈമർ അവസാനിച്ചു. ഇത് നാളെ വീണ്ടും ആരംഭിക്കും.</translation>
-<translation id="6738867403308150051">ഡൗൺലോഡുചെയ്യുന്നു...</translation>
-<translation id="6746124502594467657">താഴേക്ക് നീക്കുക</translation>
-<translation id="6766622839693428701">അവസാനിപ്പിക്കാൻ താഴേക്ക് സ്വൈപ്പ് ചെയ്യുക.</translation>
-<translation id="6766758767654711248">സൈറ്റിലേക്ക് പോകാൻ ടാപ്പ് ചെയ്യുക</translation>
-<translation id="6767294960381293877">പകുതി ഉയരത്തിൽ ടാബ് പങ്കിടാനാകുന്ന ഉപകരണങ്ങളുടെ ലിസ്‌റ്റ്.</translation>
-<translation id="6782111308708962316">കുക്കി വിവരം സംരക്ഷിക്കുകയും വായിക്കുകയും ചെയ്യുന്നതിൽ നിന്ന് മൂന്നാംകക്ഷി വെബ്‌സൈറ്റുകളെ തടയുക</translation>
-<translation id="6790428901817661496">പ്ലേചെയ്യുക</translation>
-<translation id="6811034713472274749">പേജ്, കാണാൻ തയ്യാറാണ്</translation>
-<translation id="6818926723028410516">ഇനങ്ങൾ തിരഞ്ഞെടുക്കുക</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">വിവർത്തനം ചെയ്യുക</translation>
-<translation id="6845325883481699275">Chrome സുരക്ഷ മെച്ചപ്പെടുത്താൻ സഹായിക്കുക</translation>
-<translation id="6846298663435243399">ലോഡുചെയ്യുന്നു...</translation>
-<translation id="6850409657436465440">നിങ്ങളുടെ ഡൗൺലോഡ് ഇപ്പോഴും പുരോഗതിയിലാണ്</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> ടാബുകൾ അടച്ചു</translation>
-<translation id="6864459304226931083">ചിത്രം ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="6865313869410766144">സ്വയമേവ പൂരിപ്പിക്കൽ ഫോം ഡാറ്റ</translation>
-<translation id="688738109438487280">നിലവിലുള്ള വിവരങ്ങളെ <ph name="TO_ACCOUNT" /> അക്കൗണ്ടിലേക്ക് ചേർക്കുക</translation>
-<translation id="6891726759199484455">പാസ്‍വേഡ് പകർത്താൻ അൺലോക്ക് ചെയ്യുക</translation>
-<translation id="6896758677409633944">പകര്‍ത്തുക</translation>
-<translation id="6910211073230771657">ഇല്ലാതാക്കി</translation>
-<translation id="6912998170423641340">ക്ലിപ്പ്ബോർഡിൽ നിന്ന് ചിത്രങ്ങളും ടെക്‌സ്‌റ്റും റീഡ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
-<translation id="6914783257214138813">എക്‌സ്പോർട്ട് ചെയ്ത ഫയൽ കാണാനാകുന്ന ഏതൊരാൾക്കും നിങ്ങളുടെ പാസ്‌വേഡും കാണാനാകും.</translation>
-<translation id="6942665639005891494">ക്രമീകരണ മെനു ഓപ്‌ഷൻ ഉപയോഗിച്ച്, ഏതുസമയത്തും ഡിഫോൾട്ട് ഡൗൺലോഡ് ലൊക്കേഷൻ മാറ്റുക.</translation>
-<translation id="6945221475159498467">തിരഞ്ഞെടുക്കുക</translation>
-<translation id="6963642900430330478">ഈ പേജ് അപകടകരമാണ്. സൈറ്റ് വിവരങ്ങള്‍</translation>
-<translation id="6963766334940102469">ബുക്ക്‌മാർക്കുകൾ ഇല്ലാതാക്കുക</translation>
-<translation id="6965382102122355670">ശരി</translation>
-<translation id="6979737339423435258">എല്ലാ സമയത്തും</translation>
-<translation id="6981982820502123353">ഉപയോഗസഹായി</translation>
-<translation id="6989267951144302301">ഡൗൺലോഡ് ചെയ്യാനായില്ല</translation>
-<translation id="6990079615885386641">Google Play സ്റ്റോറിൽ നിന്ന് ആപ്പ് സ്വീകരിക്കുക: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">നിങ്ങളുടെ മൈക്രോഫോൺ ഉപയോഗിക്കാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ആദ്യം ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="7015203776128479407">പ്രാഥമിക സമന്വയ സജ്ജീകരണം പൂർത്തിയാക്കിയിട്ടില്ല. സമന്വയം ഓഫാണ്.</translation>
-<translation id="7016516562562142042">നിലവിലെ തിരയൽ യന്ത്രത്തിൽ അനുവദിച്ചിരിക്കുന്നു</translation>
-<translation id="7022756207310403729">ബ്രൗസറിൽ തുറക്കുക</translation>
-<translation id="702463548815491781">TalkBack അല്ലെങ്കിൽ ആക്‌സസ് മാറുക ഓണായിരിക്കുമ്പോൾ ശുപാർശ ചെയ്യുന്നു</translation>
-<translation id="7029809446516969842">പാസ്‌വേഡുകള്‍</translation>
-<translation id="7053983685419859001">തടയുക</translation>
-<translation id="7055152154916055070">റീഡയറക്‌റ്റ് ചെയ്യുന്നത് ബ്ലോക്ക് ചെയ്തു</translation>
-<translation id="7063006564040364415">സമന്വയ സെർവറിലേക്ക് കണക്‌റ്റ് ചെയ്യാനായില്ല.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 തിരഞ്ഞെടുത്തു}other{# തിരഞ്ഞെടുത്തു}}</translation>
-<translation id="7071521146534760487">അക്കൗണ്ട് മാനേജ് ചെയ്യുക</translation>
-<translation id="7077143737582773186">SD കാർഡ്</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> എണ്ണം തിരഞ്ഞെടുത്തു. സ്‌ക്രീനിന്റെ മുകളിലുള്ള ഭാഗത്തിന് സമീപം ഓപ്‌ഷനുകൾ ലഭ്യമാണ്</translation>
-<translation id="7121362699166175603">ചരിത്രവും വിലാസ ബാറിലെ സ്വയം പൂർത്തീകരണങ്ങളും മായ്ക്കുന്നു. നിങ്ങളുടെ Google അക്കൗണ്ടിന് <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" /> എന്നതിൽ മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രമുണ്ടായിരിക്കാം.</translation>
-<translation id="7128222689758636196">നിലവിലെ തിരയൽ യന്ത്രത്തിന് അനുവദിക്കുക</translation>
-<translation id="7138678301420049075">മറ്റുള്ളവ</translation>
-<translation id="7141896414559753902">പോപ്പ് അപ്പുകളും റീഡയറക്‌റ്റുകളും കാണിക്കുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക (ശുപാർശ ചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" />-ല്‍ നിന്ന് <ph name="BEGIN_LINK" />യഥാര്‍ത്ഥ പേജ് ലോഡ് ചെയ്യുക<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">അവസാന 24 മണിക്കൂർ</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">നിങ്ങൾക്കിത് പിന്നീട് ക്രമീകരണങ്ങളിൽ മാറ്റാനാവും</translation>
-<translation id="7180611975245234373">പുതുക്കുക</translation>
-<translation id="7189372733857464326">Google Play സേവനങ്ങൾ അപ്‌ഡേറ്റുചെയ്യുന്നത് പൂർത്തിയാക്കാൻ കാത്തിരിക്കുന്നു</translation>
-<translation id="7191430249889272776">ടാബ് പശ്ചാത്തലത്തിൽ തുറന്നു.</translation>
-<translation id="723171743924126238">ചിത്രങ്ങൾ തിരഞ്ഞെടുക്കുക</translation>
-<translation id="7233236755231902816">നിങ്ങളുടെ ഭാഷയിൽ വെബ് കാണാൻ Chrome-ൻ്റെ ഏറ്റവും പുതിയ പതിപ്പ് നേടൂ</translation>
-<translation id="7243308994586599757">സ്‌ക്രീനിന്റെ ചുവടെ ഓപ്‌ഷനുകൾ ലഭ്യമാണ്</translation>
-<translation id="7248069434667874558">Chrome-ൽ <ph name="TARGET_DEVICE_NAME" /> ഉപകരണത്തിലെ സമന്വയിപ്പിക്കൽ ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> എണ്ണം തിരഞ്ഞെടുത്തു</translation>
-<translation id="7274013316676448362">സൈറ്റ് ബ്ലോക്ക് ചെയ്‌തു</translation>
-<translation id="7290209999329137901">പേര് മാറ്റൽ ലഭ്യമല്ല</translation>
-<translation id="7291387454912369099">അസിസ്‌റ്റന്റ് ചെക്ക് ഔട്ട് ചെയ്യാൻ പ്രേരിപ്പിച്ചു</translation>
-<translation id="7293171162284876153">സമന്വയം ആരംഭിക്കാൻ, "നിങ്ങളുടെ Chrome ഡാറ്റാ സമന്വയിപ്പിക്കൽ" ഓണാക്കുക.</translation>
-<translation id="729975465115245577">നിങ്ങളുടെ ഉപകരണത്തിൽ പാസ്‍വേഡ് ഫയൽ സംഭരിക്കാനുള്ള ആപ്പ് ഇല്ല.</translation>
-<translation id="7302081693174882195">വിശദാംശങ്ങൾ: സംരക്ഷിച്ച ഡാറ്റയുടെ അളവനുസരിച്ച് അടുക്കിയത്</translation>
-<translation id="7328017930301109123">ലൈറ്റ് മോഡിൽ, Chrome 60 ശതമാനം വരെ കുറവ് ഡാറ്റ ഉപയോഗിക്കുകയും പേജുകൾ വേഗത്തിൽ ലോഡ് ചെയ്യുകയും ചെയ്യുന്നു.</translation>
-<translation id="7333031090786104871">ഇപ്പോഴും മുമ്പത്തെ സൈറ്റ് ചേർത്തുകൊണ്ടിരിക്കുകയാണ്</translation>
-<translation id="7352939065658542140">വീഡിയോ</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{തിരഞ്ഞെടുത്ത ഒരു ഇനം പങ്കിടുക}other{തിരഞ്ഞെടുത്ത # ഇനങ്ങൾ പങ്കിടുക}}</translation>
 <translation id="7359002509206457351">പേയ്മെന്റ് രീതികൾ ആക്‌സസ് ചെയ്യുക</translation>
+<translation id="8026334261755873520">ബ്രൌസിംഗ് ഡാറ്റ മായ്‌ക്കുക</translation>
+<translation id="1291207594882862231">ചരിത്രവും കുക്കികളും സൈറ്റ് വിവരവും കാഷെയും മായ്‌ക്കുക...</translation>
+<translation id="7814200940910057384">Brave ഡാറ്റ മായ്‌ച്ചു</translation>
+<translation id="1664855196866195614">തിരഞ്ഞെടുത്ത ഡാറ്റയെ Brave-ൽ നിന്നും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഉപകരണങ്ങളിൽ നിന്നും നീക്കം ചെയ്‌തു.
+
+തിരയലുകൾ, പ്രവൃത്തി എന്നിവ പോലെ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> എന്നതിലെ മറ്റ് Brave Software സേവനങ്ങളിൽ നിന്നുള്ള മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രവും നിങ്ങളുടെ Brave Software അക്കൗണ്ടിൽ ഉണ്ടായേക്കാം.</translation>
+<translation id="4699172675775169585">കാഷെ ചെയ്‌ത ചിത്രങ്ങളും ഫയലുകളും</translation>
+<translation id="2496180316473517155">ബ്രൌസിംഗ് ചരിത്രം</translation>
+<translation id="2546283357679194313">കുക്കികളും സൈറ്റ് ഡാറ്റയും</translation>
+<translation id="8662811608048051533">നിങ്ങൾ മിക്ക സൈറ്റുകളിൽ നിന്നും സൈൻ ഔട്ടാകും.</translation>
+<translation id="8218628800671693884">നിങ്ങൾ മിക്ക സൈറ്റുകളിൽ നിന്നും സൈൻ ഔട്ടാകും. നിങ്ങൾ Brave Software അക്കൗണ്ടിൽ നിന്ന് സൈൻ ഔട്ട് ആകില്ല.</translation>
+<translation id="2017836877785168846">വിലാസ ബാറിലെ ചരിത്രവും സ്വയം പൂർത്തീകരണങ്ങളും മായ്ക്കുന്നു.</translation>
+<translation id="8096327394278038498">ചരിത്രവും വിലാസ ബാറിലെ സ്വയം പൂർത്തീകരണങ്ങളും മായ്ക്കുന്നു. നിങ്ങളുടെ Brave Software അക്കൗണ്ടിന് <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/> എന്നതിൽ മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രമുണ്ടായിരിക്കാം.</translation>
+<translation id="8122693181154564064">സൈൻ ഇൻ ചെയ്‌ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ചരിത്രം മായ്ക്കുന്നു. നിങ്ങളുടെ Brave Software അക്കൗണ്ടിന് <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> എന്നതിൽ മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രങ്ങളുണ്ടായിരിക്കാം.</translation>
+<translation id="5869522115854928033">സംരക്ഷിച്ച പാസ്‌വേഡുകള്‍</translation>
+<translation id="6865313869410766144">ഓട്ടോഫിൽ ഫോം ഡാറ്റ</translation>
+<translation id="7562080006725997899">ബ്രൗസിംഗ് ഡാറ്റ മായ്‌ക്കൽ</translation>
+<translation id="5487521232677179737">ഡാറ്റ മായ്‌ക്കുക</translation>
+<translation id="7498271377022651285">കാത്തിരിക്കുക...</translation>
+<translation id="784934925303690534">സമയ ശ്രേണി</translation>
+<translation id="1718835860248848330">കഴിഞ്ഞ മണിക്കൂര്‍‌</translation>
+<translation id="7149893636342594995">അവസാന 24 മണിക്കൂർ</translation>
+<translation id="5648166631817621825">കഴിഞ്ഞ 7 ദിവസം</translation>
+<translation id="8571213806525832805">കഴിഞ്ഞ 4 ആഴ്ച</translation>
+<translation id="5854790677617711513">30 ദിവസത്തിൽ കൂടുതൽ പഴക്കമുള്ളത്</translation>
+<translation id="6979737339423435258">എല്ലാ സമയത്തും</translation>
+<translation id="982182592107339124">ഇത് ഇനിപ്പറയുന്നവ ഉൾപ്പെടെയുള്ള എല്ലാ സൈറ്റുകളുടെയും വിവരങ്ങൾ മായ്‌ക്കുന്നതിനിടയാക്കും:</translation>
+<translation id="6643016212128521049">മായ്‌ക്കുക</translation>
+<translation id="7641339528570811325">ബ്രൗസിംഗ് ഡാറ്റ മായ്‌ക്കുക...</translation>
+<translation id="1670399744444387456">അടിസ്ഥാനം</translation>
+<translation id="3245261285041759672">നിങ്ങളുടെ Brave Software അക്കൗണ്ടിന് <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/> എന്നതിൽ മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രമുണ്ടായിരിക്കാം.</translation>
+<translation id="7274013316676448362">സൈറ്റ് ബ്ലോക്ക് ചെയ്‌തു</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> ഇനങ്ങൾ ഇല്ലാതാക്കി</translation>
+<translation id="1121094540300013208">ഉപയോഗ, ക്രാഷ് റിപ്പോർട്ടുകൾ</translation>
+<translation id="9079153198295609735">Brave Software ലേക്ക് സ്വയമേവ ഉപയോഗ വിവരക്കണക്കുകളും ക്രാഷ് റിപ്പോര്‍ട്ടുകളും അയയ്ക്കുക</translation>
+<translation id="6981982820502123353">ഉപയോഗസഹായി</translation>
+<translation id="2387895666653383613">ടെക്‌സ്റ്റ് സ്‌കെയിലിംഗ്</translation>
+<translation id="2321958826496381788">നിങ്ങൾക്ക് ഇത് സൗകര്യപ്രദമായി വായിക്കാൻ കഴിയുന്നതുവരെ സ്ലൈഡർ വലിക്കുക. ഒരു ഖണ്ഡികയിൽ ഇരട്ട-ടാപ്പ് ചെയ്‌തതിനുശേഷം ടെക്‌സ്റ്റിന് ഈ വലുപ്പമെങ്കിലും ഉണ്ടായിരിക്കണം.</translation>
+<translation id="3895926599014793903">നിർബന്ധിത സൂം പ്രവർത്തനക്ഷമമാക്കുക</translation>
+<translation id="5668404140385795438">സൂം ഇൻ ചെയ്യുന്നത് തടയുന്നതിനുള്ള ഒരു വെബ്സൈറ്റിന്റെ അഭ്യർത്ഥന അസാധുവാക്കുക</translation>
+<translation id="4149994727733219643">വെബ് പേജുകൾക്കായി ലളിതവൽക്കരിച്ച കാഴ്ച</translation>
+<translation id="9100505651305367705">പിന്തുണയുള്ളപ്പോൾ, ലളിതമാക്കിയ കാഴ്ചയിൽ ലേഖനങ്ങൾ കാണിക്കുന്ന സൗകര്യം നൽകുക</translation>
+<translation id="1409426117486808224">തുറന്ന ടാബുകൾക്കായി ലളിതവൽക്കരിച്ച കാഴ്ച</translation>
+<translation id="702463548815491781">TalkBack അല്ലെങ്കിൽ ആക്‌സസ് മാറുക ഓണായിരിക്കുമ്പോൾ ശുപാർശ ചെയ്യുന്നു</translation>
+<translation id="8284326494547611709">അടിക്കുറിപ്പുകൾ</translation>
+<translation id="4165986682804962316">സൈറ്റ് ക്രമീകരണങ്ങൾ</translation>
+<translation id="6295158916970320988">എല്ലാ സൈറ്റുകളും</translation>
+<translation id="8380167699614421159">ഈ സൈറ്റ്, അനാവശ്യമോ തെറ്റിദ്ധരിപ്പിക്കുന്നതോ ആയ പരസ്യങ്ങള്‍ കാണിക്കുന്നു</translation>
+<translation id="1919345977826869612">പരസ്യങ്ങള്‍</translation>
+<translation id="410351446219883937">സ്വയം പ്ലേചെയ്യൽ</translation>
+<translation id="6447842834002726250">കുക്കികള്‍</translation>
+<translation id="6196640612572343990">മൂന്നാം കക്ഷി കുക്കികള്‍ ബ്ലോക്കുചെയ്യുക</translation>
+<translation id="6782111308708962316">കുക്കി വിവരം സംരക്ഷിക്കുകയും വായിക്കുകയും ചെയ്യുന്നതിൽ നിന്ന് മൂന്നാംകക്ഷി വെബ്‌സൈറ്റുകളെ തടയുക</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">പോപ്-അപ്പുകളും റീഡയറക്‌റ്റുകളും</translation>
+<translation id="4751476147751820511">ചലന അല്ലെങ്കിൽ വെളിച്ച സെൻസറുകൾ</translation>
+<translation id="1717218214683051432">ചലന സെൻസറുകൾ</translation>
+<translation id="2091887806945687916">ശബ്‌ദം</translation>
+<translation id="2586657967955657006">ക്ലിപ്പ്ബോർഡ്</translation>
+<translation id="6320088164292336938">വൈബ്രേറ്റുചെയ്യുക</translation>
+<translation id="4226663524361240545">അറിയിപ്പുകൾ ലഭിക്കുമ്പോൾ ഉപകരണം വൈബ്രേറ്റ് ചെയ്‌തേക്കാം</translation>
+<translation id="1446450296470737166">MIDI ഉപകരണങ്ങളുടെ പൂർണ്ണ നിയന്ത്രണം അനുവദിക്കുക</translation>
+<translation id="3744111561329211289">പശ്ചാത്തല സമന്വയിപ്പിക്കൽ</translation>
+<translation id="5649053991847567735">യാന്ത്രിക ഡൗൺലോഡുകൾ</translation>
+<translation id="6181444274883918285">സൈറ്റിനെ ഒഴിവാക്കൽ ലിസ്‌റ്റിൽ ചേർക്കുക</translation>
+<translation id="5313967007315987356">സൈറ്റ് ചേർക്കുക</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> എന്ന സൈറ്റ് ചേർത്തൂ</translation>
+<translation id="7837721118676387834">ഒരു നിർദ്ദിഷ്‌ട സൈറ്റിന്റെ മ്യൂട്ട് ചെയ്‌ത വീഡിയോകൾ സ്വയം പ്ലേ ചെയ്യാൻ അനുവദിക്കുക.</translation>
+<translation id="2621115761605608342">ഒരു നിർദ്ദിഷ്‌ട സൈറ്റിന് വേണ്ടി JavaScript അനുവദിക്കുക.</translation>
+<translation id="8801436777607969138">ഒരു നിർദ്ദിഷ്‌ട സൈറ്റിനായി JavaScript ബ്ലോക്ക് ചെയ്യുക.</translation>
+<translation id="8372893542064058268">ഒരു പ്രത്യേക സൈറ്റിന് വേണ്ടി പശ്ചാത്തലം സമന്വയിപ്പിക്കൽ അനുവദിക്കുക.</translation>
+<translation id="358794129225322306">ഒന്നിലേറെ ഫയലുകള്‍ സ്വമേധയാ ഡൗണ്‍‌ലോഡ് ചെയ്യാന്‍ സൈറ്റിനെ അനുവദിക്കുക.</translation>
+<translation id="4008040567710660924">ഒരു പ്രത്യേക സൈറ്റിനായി കുക്കികൾ അനുവദിക്കുക.</translation>
+<translation id="8958424370300090006">ഒരു പ്രത്യേക സൈറ്റിനായി കുക്കികൾ ബ്ലോക്ക് ചെയ്യുക.</translation>
+<translation id="7882806643839505685">ഒരു പ്രത്യേക സൈറ്റിനായി ശബ്‌ദം അനുവദിക്കുക.</translation>
+<translation id="4468959413250150279">ഒരു പ്രത്യേക സൈറ്റിനായി ശബ്‌ദം മ്യൂട്ട് ചെയ്യുക.</translation>
+<translation id="1994173015038366702">സൈറ്റ് URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">ഉപയോഗം</translation>
+<translation id="5804241973901381774">അനുമതികൾ</translation>
+<translation id="4278390842282768270">അനുവദനീയം</translation>
+<translation id="5677928146339483299">തടഞ്ഞു</translation>
+<translation id="1984937141057606926">മൂന്നാം കക്ഷി ഒഴികെയുള്ളവയെ അനുവദിച്ചിരിക്കുന്നു</translation>
+<translation id="7423098979219808738">ആദ്യതവണ ചോദിക്കുക</translation>
+<translation id="8116925261070264013">മ്യൂട്ടുചെയ്‌തു</translation>
+<translation id="8300705686683892304">ആപ്പ് മാനേജ് ചെയ്യുന്നത്</translation>
+<translation id="6192792657125177640">അപവാദങ്ങള്‍</translation>
+<translation id="257931822824936280">വിപുലീകരിച്ചത് - ചുരുക്കാൻ ക്ലിക്ക് ചെയ്യുക</translation>
+<translation id="5100237604440890931">ചുരുക്കിയത് - വിപുലീകരിക്കാൻ ക്ലിക്ക് ചെയ്യുക</translation>
+<translation id="857943718398505171">അനുവദിച്ചിരിക്കുന്നു (ശുപാർശചെയ്‌തത്)</translation>
+<translation id="2913331724188855103">കുക്കി ഡാറ്റ സംരക്ഷിക്കുന്നതിനും വായിക്കുന്നതിനും സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശചെയ്‌തത്)</translation>
+<translation id="7445411102860286510">മ്യൂട്ടുചെയ്‌ത വീഡിയോകൾ സ്വയം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="5335288049665977812">JavaScript റൺ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="5527111080432883924">ക്ലിപ്പ്ബോർഡിൽ നിന്ന് ചിത്രങ്ങളും ടെക്‌സ്‌റ്റും റീഡ് ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശ ചെയ്‌തത്)</translation>
+<translation id="6912998170423641340">ക്ലിപ്പ്ബോർഡിൽ നിന്ന് ചിത്രങ്ങളും ടെക്‌സ്‌റ്റും റീഡ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
+<translation id="7423538860840206698">ക്ലിപ്പ്ബോർഡ് റീഡ് ചെയ്യുന്നതിൽ നിന്ന് ബ്ലോക്ക് ചെയ്‌തു</translation>
+<translation id="3955193568934677022">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="445467742685312942">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക</translation>
+<translation id="2107397443965016585">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശചെയ്‌തത്)</translation>
+<translation id="2910701580606108292">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക</translation>
+<translation id="757524316907819857">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
+<translation id="3277252321222022663">സെൻസറുകൾ ആക്‌സസ് ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്യുന്നത്)</translation>
+<translation id="5048398596102334565">നിങ്ങളുടെ ചലന സെൻസറുകൾ ആക്‌സസ് ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്യുന്നത്)</translation>
+<translation id="8816026460808729765">സെൻസറുകൾ ആക്‌സസ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
+<translation id="169515064810179024">ചലന സെൻസറുകൾ ആക്‌സസ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
+<translation id="1660204651932907780">ശബ്‌ദം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശ ചെയ്യുന്നു)</translation>
+<translation id="3600792891314830896">ശബ്‌ദം പ്ലേ ചെയ്യുന്ന സൈറ്റുകളെ മ്യൂട്ട് ചെയ്യുക</translation>
+<translation id="1743802530341753419">ഒരു ഉപകരണത്തിലേക്ക് കണക്‌റ്റ് ചെയ്യുന്നതിന് സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശ ചെയ്തിരിക്കുന്നു)</translation>
+<translation id="851751545965956758">ഉപകരണങ്ങളിലേക്ക് കണക്‌റ്റ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
+<translation id="7141896414559753902">പോപ്പ് അപ്പുകളും റീഡയറക്‌റ്റുകളും കാണിക്കുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക (ശുപാർശ ചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="5494752089476963479">അനാവശ്യമോ തെറ്റിദ്ധരിപ്പിക്കുന്നതോ ആയ പരസ്യങ്ങള്‍ കാണിക്കുന്ന സൈറ്റുകളിലെ പരസ്യങ്ങൾ ബ്ലോക്ക് ചെയ്യുക</translation>
+<translation id="3123473560110926937">ചില സൈറ്റുകളിൽ ബ്ലോക്ക് ചെയ്‌തിരിക്കുന്നു</translation>
+<translation id="965817943346481315">സൈറ്റ്, അനാവശ്യമോ തെറ്റിദ്ധരിപ്പിക്കുന്നതോ ആയ പരസ്യങ്ങള്‍ കാണിക്കുന്നുണ്ടെങ്കില്‍ ബ്ലോക്ക് ചെയ്യുക (ശുപാര്‍ശ ചെയ്യുന്നു)</translation>
+<translation id="3386292677130313581">നിങ്ങളുടെ ലൊക്കേഷൻ അറിയാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="9139068048179869749">അറിയിപ്പുകൾ അയയ്‌ക്കാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="4479647676395637221">നിങ്ങളുടെ ക്യാമറ ഉപയോഗിക്കാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ആദ്യം ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="6992289844737586249">നിങ്ങളുടെ മൈക്രോഫോൺ ഉപയോഗിക്കാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ആദ്യം ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
+<translation id="2289270750774289114">സമീപത്തുള്ള Bluetooth ഉപകരണങ്ങൾ കണ്ടെത്താൻ ഒരു സൈറ്റ് താൽപ്പര്യപ്പെടുമ്പോൾ ചോദിക്കുക (ശുപാർശചെയ്‌തത്)</translation>
+<translation id="7053983685419859001">തടയുക</translation>
+<translation id="7128222689758636196">നിലവിലെ തിരയൽ യന്ത്രത്തിന് അനുവദിക്കുക</translation>
+<translation id="7589445247086920869">നിലവിലെ തിരയൽ യന്ത്രത്തിന് ബ്ലോക്ക് ചെയ്യുക</translation>
+<translation id="6388207532828177975">മായ്‌ച്ച് റീസെറ്റ് ചെയ്യുക</translation>
+<translation id="7999064672810608036">കുക്കികൾ ഉൾപ്പെടെ എല്ലാ പ്രാദേശിക വിവരവും മായ്‌ച്ച് ഈ വെബ്‌സൈറ്റിനായുള്ള എല്ലാ അനുമതികളും റീസെറ്റ് ചെയ്യാൻ താൽപ്പര്യമുണ്ടോ?</translation>
+<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME"/> എന്നതിനുള്ള എല്ലാ സൈറ്റ് അനുമതികളും പുനഃസജ്ജീകരിക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ?</translation>
+<translation id="515227803646670480">സംഭരിച്ച വിവരം മായ്‌ക്കുക</translation>
+<translation id="5902828464777634901">കുക്കികൾ ഉൾപ്പെടെ ഈ വെബ്‌സൈറ്റ് സംഭരിക്കുന്ന എല്ലാ പ്രാദേശിക വിവരവും ഇല്ലാതാക്കും.</translation>
+<translation id="119944043368869598">എല്ലാം നീക്കുക</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> ആണ് മാനേജ് ചെയ്യുന്നത്</translation>
+<translation id="5516455585884385570">അറിയിപ്പ് ക്രമീകരണം തുറക്കുക</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/> എന്നതിൽ ഉൾപ്പെടുത്തി</translation>
+<translation id="129382876167171263">വെബ്സൈറ്റുകൾ സംരക്ഷിച്ചിട്ടുള്ള ഫയലുകള്‍ ഇവിടെ ദൃശ്യമാവും</translation>
+<translation id="4181841719683918333">ഭാഷകൾ‌</translation>
+<translation id="2647434099613338025">ഭാഷ ചേര്‍ക്കുക</translation>
+<translation id="1952172573699511566">വെബ്സൈറ്റുകൾ, സാധ്യമാകുന്നിടത്തെല്ലാം, നിങ്ങൾ തിരഞ്ഞെടുത്ത ഭാഷയിൽ ടെക്‌സ്‌റ്റ് കാണിക്കും.</translation>
+<translation id="8559990750235505898">പേജുകൾ മറ്റ് ഭാഷകളിലേക്ക് വിവർത്തനം ചെയ്യാനുള്ള ഓഫർ</translation>
+<translation id="4719927025381752090">വിവർത്തനം ചെയ്യാനുള്ള ഓഫർ</translation>
+<translation id="8156139159503939589">ഏതൊക്കെ ഭാഷകൾ നിങ്ങൾക്ക് വായിക്കാനാകും?</translation>
+<translation id="5689516760719285838">ലൊക്കേഷൻ</translation>
+<translation id="2440823041667407902">ലൊക്കേഷൻ ആക്‌സസ്</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> Brave-നായി അനുമതികൾ ഓണാക്കുക.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> Brave-നായി അനുമതി ഓണാക്കുക.</translation>
+<translation id="2928908108430545745">നിങ്ങളുടെ ലൊക്കേഷൻ ആക്‌സസ് ചെയ്യാൻ Brave-നെ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> ലൊക്കേഷനും ഓണാക്കുക.</translation>
+<translation id="1028853271388022585">Brave-നെ നിങ്ങളുടെ ക്യാമറ ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> ക്യാമറയും ഓണാക്കുക.</translation>
+<translation id="2913721282607281710">അറിയിപ്പുകൾ അയയ്ക്കാൻ Brave-നെ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> അറിയിപ്പുകളും ഓണാക്കുക.</translation>
+<translation id="8753483718490035722">Brave-നെ നിങ്ങളുടെ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുന്നതിന്, <ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> മൈക്രോഫോണും ഓണാക്കുക.</translation>
+<translation id="1887786770086287077">ഈ ഉപകരണത്തിന്‍റെ ലൊക്കേഷൻ ആക്‌സസ് ഓഫാണ്; <ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> അത് ഓണാക്കുക.</translation>
+<translation id="2570922361219980984">ഈ ഉപകരണത്തിന്‍റെ ലൊക്കേഷൻ ആക്‌സസും ഓഫാണ്; <ph name="BEGIN_LINK"/>Android ക്രമീകരണത്തിൽ<ph name="END_LINK"/> അത് ഓണാക്കുക.</translation>
+<translation id="1620510694547887537">ക്യാമറ</translation>
+<translation id="3227137524299004712">മൈക്രോഫോൺ</translation>
+<translation id="1647391597548383849">നിങ്ങളുടെ ക്യാമറ ആക്‌സസ് ചെയ്യുക</translation>
+<translation id="945632385593298557">നിങ്ങളുടെ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യുക</translation>
+<translation id="6612358246767739896">പരിരക്ഷിത ഉള്ളടക്കം</translation>
+<translation id="885701979325669005">സംഭരണം</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> സംഭരിച്ച വിവരം</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">ഉപകരണ അനുമതി റദ്ദാക്കുക</translation>
+<translation id="4962975101802056554">ഉപകരണത്തിനുള്ള എല്ലാ അനുമതികളും അസാധുവാക്കുക</translation>
+<translation id="6545864417968258051">Bluetooth സ്‌കാനിംഗ്</translation>
+<translation id="4411535500181276704">ലൈറ്റ് മോഡ്</translation>
+<translation id="7821588508402923572">നിങ്ങൾ ലാഭിച്ച ഡാറ്റ ഇവിടെ ദൃശ്യമാവും</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> ലാഭിച്ചു</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> മുതൽ</translation>
+<translation id="3252158532344029638">ലൈറ്റ് മോഡിൽ, Brave 60 ശതമാനം വരെ കുറവ് ഡാറ്റ ഉപയോഗിക്കുകയും പേജുകൾ വേഗത്തിൽ ലോഡ് ചെയ്യുകയും ചെയ്യുന്നു.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> ഡാറ്റ ലാഭിക്കൽ</translation>
+<translation id="7494974237137038751">ലാഭിച്ച ഡാറ്റ</translation>
+<translation id="6111020039983847643">ഉപയോഗിച്ച ഡാറ്റ</translation>
+<translation id="7413229368719586778">ആരംഭിക്കുന്ന തീയതി <ph name="DATE"/></translation>
+<translation id="1782483593938241562">അവസാന തീയതി <ph name="DATE"/></translation>
+<translation id="2728754400939377704">സൈറ്റ് അനുസരിച്ച് അടുക്കുക</translation>
+<translation id="5864174910718532887">വിശദാംശങ്ങൾ: സൈറ്റിൻ്റെ പേരനുസരിച്ച് അടുക്കിയത്</translation>
+<translation id="116280672541001035">ഉപയോഗിച്ചത്</translation>
+<translation id="8349013245300336738">ഉപയോഗിച്ച ഡാറ്റയുടെ അളവിനനുസരിച്ച് അടുക്കുക</translation>
+<translation id="6378173571450987352">വിശദാംശങ്ങൾ: ഉപയോഗിച്ച ഡാറ്റയുടെ അളവനുസരിച്ച് അടുക്കിയത്</translation>
+<translation id="2631006050119455616">ലാഭിച്ചത്</translation>
+<translation id="6643649862576733715">സംരക്ഷിച്ച ഡാറ്റയുടെ അളവിനനുസരിച്ച് അടുക്കുക</translation>
+<translation id="7302081693174882195">വിശദാംശങ്ങൾ: സംരക്ഷിച്ച ഡാറ്റയുടെ അളവനുസരിച്ച് അടുക്കിയത്</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> ഉപയോഗിച്ചു</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> സംരക്ഷിച്ചു</translation>
+<translation id="2156074688469523661">ശേഷിക്കുന്ന സൈറ്റുകൾ (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">മറ്റുള്ളവ</translation>
+<translation id="4913161338056004800">സ്ഥിതിവിവരക്കണക്കുകൾ റീസെറ്റ് ചെയ്യുക</translation>
+<translation id="1856325424225101786">ലൈറ്റ് മോഡ് പുനഃസജ്ജീകരിക്കണോ?</translation>
+<translation id="3658159451045945436">പുനഃസജ്ജീകരിക്കുന്നത്, സന്ദർശിച്ച സൈറ്റുകളുടെ ലിസ്‌റ്റ് അടക്കമുള്ള ഡാറ്റ ലാഭിക്കൽ ചരിത്രത്തെ മായ്ക്കുന്നു.</translation>
+<translation id="3295530008794733555">വേഗത്തിൽ ബ്രൗസ് ചെയ്യൂ. കുറച്ച് ഡാറ്റ ഉപയോഗിക്കൂ.</translation>
+<translation id="7340390500800578919">ലൈറ്റ് മോഡിൽ Brave, പേജുകൾ വേഗത്തിൽ ലോഡ് ചെയ്യുകയും 60 ശതമാനം വരെ കുറവ് ഡാറ്റ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾ സന്ദർശിക്കുന്ന പേജുകൾ ഓപ്‌റ്റിമൈസ് ചെയ്യാൻ Brave നിങ്ങളുടെ വെബ് ട്രാഫിക് Brave Software-ന് അയയ്ക്കുന്നു. <ph name="BEGIN_LINK"/>കൂടുതലറിയുക<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">ലൈറ്റ് മോഡ് ഓണാക്കുക</translation>
+<translation id="4493497663118223949">ലൈറ്റ് മോഡ് ഓണാണ്</translation>
+<translation id="7559975015014302720">ലൈറ്റ് മോഡ് ഓഫാണ്</translation>
+<translation id="7606077192958116810">ലൈറ്റ് മോഡ് ഓണാണ്. ഇത് ക്രമീകരണത്തിൽ മാനേജ് ചെയ്യുക.</translation>
+<translation id="4714588616299687897">നിങ്ങളുടെ ഡാറ്റ 60% വരെ ലാഭിക്കൂ</translation>
+<translation id="1006927014032731288">നിങ്ങള്‍ സന്ദര്‍ശിക്കുന്ന പേജുകള്‍ Brave Software സെര്‍‌വറുകള്‍ ഒപ്‌റ്റിമൈസ് ചെയ്യും.</translation>
+<translation id="3257320067425202300">Brave നിങ്ങളുടെ <ph name="MEGABYTES"/> MB ലാഭിച്ചു</translation>
+<translation id="5813223329348543512">Brave നിങ്ങളുടെ <ph name="GIGABYTES"/> GB ലാഭിച്ചു</translation>
+<translation id="8266862848225348053">ഡൗൺലോഡ് ലൊക്കേഷൻ</translation>
+<translation id="7077143737582773186">SD കാർഡ്</translation>
+<translation id="7762668264895820836">SD കാർഡ് <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">ഫയലുകൾ എവിടെയാണ് സംരക്ഷിക്കേണ്ടതെന്ന് ചോദിക്കുക</translation>
+<translation id="6192333916571137726">ഫയൽ ഡൗൺലോഡ് ചെയ്യുക</translation>
+<translation id="1672586136351118594">വീണ്ടും കാണിക്കരുത്</translation>
+<translation id="2650751991977523696">ഫയൽ വീണ്ടും ഡൗൺലോഡ് ചെയ്യണോ?</translation>
+<translation id="8664979001105139458">ഫയലിന്റെ പേര് ഇതിനകം നിലവിലുണ്ട്</translation>
+<translation id="488187801263602086">ഫയലിന്റെ പേര് മാറ്റുക</translation>
+<translation id="5686790454216892815">ഫയലിന്റെ പേര് ദൈർഘ്യമേറിയതാണ്</translation>
+<translation id="7454641608352164238">വേണ്ടത്ര ഇടമില്ല</translation>
+<translation id="8972098258593396643">ഡിഫോൾട്ട് ഫോൾഡറിലേക്ക് ഡൗൺലോഡ് ചെയ്യണോ?</translation>
+<translation id="804335162455518893">SD കാർഡ് കണ്ടെത്തിയില്ല</translation>
+<translation id="7475688122056506577">SD കാർഡ് കണ്ടെത്തിയില്ല. നിങ്ങളുടെ ചില ഫയലുകൾ നഷ്‌ടപ്പെട്ടേക്കാം.</translation>
+<translation id="4198423547019359126">ലഭ്യമായ ഡൗൺലോഡ് ലൊക്കേഷനുകളൊന്നും ഇല്ല</translation>
+<translation id="8224471946457685718">വൈഫൈ ഉപയോഗിച്ച് നിങ്ങൾക്കായി ലേഖനങ്ങൾ ഡൗൺലോഡ് ചെയ്യുക</translation>
+<translation id="4970824347203572753">നിങ്ങളുടെ ലൊക്കേഷനിൽ ലഭ്യമല്ല</translation>
+<translation id="5500777121964041360">നിങ്ങളുടെ ലൊക്കേഷനിൽ ലഭ്യമായിരിക്കില്ല</translation>
+<translation id="1173894706177603556">പേരുമാറ്റുക</translation>
+<translation id="1986685561493779662">പേര് ഇതിനകം നിലവിലുണ്ട്</translation>
+<translation id="6441734959916820584">പേര് വളരെ വലുതാണ്</translation>
+<translation id="2923908459366352541">പേര് അസാധുവാണ്</translation>
+<translation id="7290209999329137901">പേര് മാറ്റൽ ലഭ്യമല്ല</translation>
+<translation id="3334729583274622784">ഫയൽ എക്സ്റ്റൻഷൻ മാറ്റണോ?</translation>
+<translation id="107147699690128016">ഫയൽ എക്സ്റ്റൻഷൻ മാറ്റിയാൽ, ഫയൽ വ്യത്യസ്ത ആപ്പിൽ തുറന്നേക്കാം, ഒപ്പം അത് നിങ്ങളുടെ ഉപകരണത്തിന് ദോഷകരമാവാൻ സാധ്യതയുണ്ട്.</translation>
+<translation id="8541922081612557424">Brave-നെ കുറിച്ച്</translation>
+<translation id="5311273890481188673">പകർപ്പവകാശം <ph name="YEAR"/> Brave Software LLC. എല്ലാ അവകാശങ്ങളും നിക്ഷിപ്‍തം.</translation>
+<translation id="1416550906796893042">ആപ്പ് പതിപ്പ്</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (അപ്‌ഡേറ്റുചെയ്‌തു, <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">ഓപ്പറേറ്റിംഗ് സിസ്റ്റം</translation>
+<translation id="3968054912784331254">Android-ന്റെ ഈ പതിപ്പിൽ ഇനിയങ്ങോട്ട് Brave-ന്റെ അപ്‌ഡേറ്റുകൾ പിന്തുണയ്‌ക്കില്ല</translation>
+<translation id="7665369617277396874">അക്കൗണ്ട് ചേർക്കുക</translation>
+<translation id="649070405679044769">ഇനി പറയുന്നതിൽ നിന്നും Brave Software-ലേക്ക് സൈൻ ഇൻ ചെയ്‌തു</translation>
+<translation id="6234515504547364178">Brave-ൽ നിന്നും സൈൻ ഔട്ട് ചെയ്യുക</translation>
+<translation id="5324858694974489420">രക്ഷാകർതൃ ക്രമീകരണം</translation>
+<translation id="8920114477895755567">രക്ഷകർത്താക്കളുടെ വിശദാംശങ്ങൾക്കായി കാത്തിരിക്കുന്നു.</translation>
+<translation id="5512137114520586844"><ph name="PARENT_NAME"/> ആണ് ഈ അക്കൗണ്ട് നിയന്ത്രിക്കുന്നത്.</translation>
+<translation id="2956410042958133412"><ph name="PARENT_NAME_1"/>, <ph name="PARENT_NAME_2"/> എന്നിവരാണ് ഈ അക്കൗണ്ട് നിയന്ത്രിക്കുന്നത്.</translation>
+<translation id="8168435359814927499">ഉള്ളടക്കം</translation>
+<translation id="5403644198645076998">ചില സൈറ്റുകളെ മാത്രം അനുവദിക്കുക</translation>
+<translation id="8641930654639604085">മുതിർന്നവർക്കുള്ള സൈറ്റുകൾ ബ്ലോക്കുചെയ്യുന്നത് പരീക്ഷിച്ചുനോക്കൂ</translation>
+<translation id="5639724618331995626">എല്ലാ സൈറ്റുകളെയും അനുവദിക്കുക</translation>
+<translation id="796823723482603597">Brave നൽകുന്നത്</translation>
+<translation id="6324034347079777476">Android സിസ്‌റ്റം സമന്വയിപ്പിക്കൽ പ്രവർത്തനരഹിതമാക്കി</translation>
+<translation id="5127805178023152808">സമന്വയം ഓഫാണ്</translation>
+<translation id="7015203776128479407">പ്രാഥമിക സമന്വയ സജ്ജീകരണം പൂർത്തിയാക്കിയിട്ടില്ല. സമന്വയം ഓഫാണ്.</translation>
+<translation id="2497852260688568942">നിങ്ങളുടെ അഡ്‌മിനിസ്‌ട്രേറ്റർ സമന്വയിപ്പിക്കൽ പ്രവർത്തനരഹിതമാക്കി</translation>
+<translation id="9100610230175265781">പാസ്‌ഫ്രെയ്‌സ് ആവശ്യമാണ്</translation>
+<translation id="6108923351542677676">സജ്ജീകരണം പുരോഗതിയിലാണ്...</translation>
+<translation id="4062305924942672200">നിയമ വിവരങ്ങൾ</translation>
+<translation id="4256782883801055595">ഓപ്പൺ സോഴ്‌സ് ലൈസൻസുകൾ</translation>
+<translation id="1138681184697033370">Brave സേവന നിബന്ധനകൾ</translation>
+<translation id="7392539049993970338">Brave സ്വകാര്യതാ അറിയിപ്പ്</translation>
+<translation id="2677748264148917807">ഉപേക്ഷിക്കുക</translation>
+<translation id="5556459405103347317">വീണ്ടും ലോഡ് ചെയ്യുക</translation>
+<translation id="1623104350909869708">കൂടുതൽ ഡയലോഗുകൾ സൃഷ്‌ടിക്കുന്നതിൽ നിന്നും ഈ പേജിനെ തടയുക</translation>
+<translation id="2968755619301702150">സർട്ടിഫിക്കറ്റ് വ്യൂവർ</translation>
+<translation id="1360432990279830238">സൈൻ ഔട്ട് ചെയ്‌ത് സമന്വയം ഓഫാക്കണോ?</translation>
+<translation id="8581481290581777242">ഉപകരണത്തില്‍ നിന്ന് Brave ഡാറ്റ മായ്ക്കണോ?</translation>
+<translation id="1318865768845061710">നിങ്ങളുടെ ബുക്ക്‌മാർക്കുകൾ, ചരിത്രം, പാസ്‌വേഡുകൾ എന്നിവയും മറ്റ് Brave ഡാറ്റയും ഇനി Brave Software അക്കൗണ്ടുമായി സമന്വയിപ്പിക്കില്ല</translation>
+<translation id="3325020657155065477">കൂടാതെ ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ Brave ഡാറ്റ മായ്ക്കുക</translation>
+<translation id="6136448902816743006"><ph name="DOMAIN_NAME"/> മാനേജ് ചെയ്യുന്ന അക്കൗണ്ടിൽ നിന്ന് സൈൻ ഔട്ട് ചെയ്യുന്നതിനാൽ, ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ Brave ഡാറ്റ ഇല്ലാതാക്കപ്പെടും. അത് തുടർന്നും നിങ്ങളുടെ Brave Software അക്കൗണ്ടിൽ ഉണ്ടായിരിക്കുന്നതാണ്.</translation>
+<translation id="1853026300647876496">Brave Software-നെ ബന്ധപ്പെടുന്നു. ഇതിന് ഒരു മിനിറ്റ് എടുത്തേക്കാം…</translation>
+<translation id="2328985652426384049">സൈൻ ഇൻ ചെയ്യാനാകില്ല</translation>
+<translation id="7723158744459952869">Brave Software പ്രതികരിക്കാൻ കൂടുതൽ സമയമെടുത്തു</translation>
+<translation id="4572422548854449519">മാനേജ് ചെയ്‌ത അക്കൗണ്ടിലേക്ക് സൈൻ ഇൻ ചെയ്യുക</translation>
+<translation id="2689656545739939160"><ph name="MANAGED_DOMAIN"/> മാനേജ് ചെയ്യുന്ന ഒരു അക്കൗണ്ട് ഉപയോഗിച്ച് നിങ്ങൾ സൈൻ ഇൻ ചെയ്യുകയും ഇതിന്റെ അഡ്‌മിനിസ്‌ട്രേറ്റർക്ക് നിങ്ങളുടെ Brave വിവരങ്ങളിന്മേൽ നിയന്ത്രണം നൽകുകയും ചെയ്യുന്നു. വിവരങ്ങളെ ഈ അക്കൗണ്ടുമായി ശാശ്വതമായി ബന്ധിപ്പിക്കും. Brave-ൽ നിന്ന് സൈൻ ഔട്ട് ചെയ്യുന്നത് ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ വിവരങ്ങളെ ഇല്ലാതാക്കുമെങ്കിലും, Brave Software അക്കൗണ്ടിൽ തുടർന്നും അവയെ സൂക്ഷിക്കുന്നതാണ്.</translation>
+<translation id="1749561566933687563">നിങ്ങളുടെ ബുക്ക്മാർക്കുകൾ സമന്വയിപ്പിക്കുക</translation>
+<translation id="4242533952199664413">ക്രമീകരണം തുറക്കുക</translation>
+<translation id="1111673857033749125">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ സംരക്ഷിച്ച ബുക്ക്‌മാർക്കുകൾ ഇവിടെ ദൃശ്യമാകും.</translation>
+<translation id="8636825310635137004">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക.</translation>
+<translation id="3269956123044984603">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, Android അക്കൗണ്ട് ക്രമീകരണത്തിൽ "ഡാറ്റ സ്വയം സമന്വയിപ്പിക്കുക" ഓണാക്കുക.</translation>
+<translation id="5157964048453367290">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിലെ Brave-ൽ തുറന്ന ടാബുകൾ ഇവിടെ ദൃശ്യമാകും.</translation>
+<translation id="4684427112815847243">എല്ലാം സമന്വയിപ്പിക്കുക</translation>
+<translation id="2709516037105925701">സ്വയമേവ പൂരിപ്പിക്കൽ</translation>
+<translation id="8820817407110198400">ബുക്ക്‌മാര്‍ക്കുകള്‍</translation>
+<translation id="1644574205037202324">ചരിത്രം</translation>
+<translation id="17513872634828108">ഓപ്പൺ ടാബുകൾ</translation>
+<translation id="1320169905922104972">Brave Software Pay ഉപയോഗിക്കുന്ന ക്രെഡിറ്റ് കാർഡുകളും വിലാസങ്ങളും</translation>
+<translation id="6337234675334993532">എന്‍ക്രിപ്ഷന്‍</translation>
+<translation id="6698801883190606802">സമന്വിത ഡാറ്റ നിയന്ത്രിക്കുക</translation>
+<translation id="3598578758776312506">Brave Software ക്രെഡെൻഷ്യലുകൾ ഉപയോഗിച്ച് പാസ്‌വേഡുകൾ എൻക്രിപ്റ്റ് ചെയ്യുക</translation>
+<translation id="7810580217418711046">Brave Software പാസ്‌വേഡ് ഉപയോഗിച്ച് <ph name="TIME"/> മുതൽ സമന്വയിപ്പിച്ച ഡാറ്റ എൻക്രി‌പ്‌റ്റ് ചെയ്യുക</translation>
+<translation id="8461694314515752532">നിങ്ങളുടെ സമന്വയ പാസ്‌ഫ്രെയ്‌സ് ഉപയോഗിച്ച്, സമന്വയിപ്പിച്ച ഡാറ്റ എൻക്രി‌പ്‌റ്റ് ചെയ്യുക</translation>
+<translation id="2996291259634659425">പാസ്‌ഫ്രെയ്‌സ് സൃഷ്‌ടിക്കുക</translation>
+<translation id="5713644099811900409">Brave Software അക്കൗണ്ട്</translation>
+<translation id="8997474919031554666">പാസ്‌ഫ്രെയ്‌സ് എൻക്രിപ്ഷനിൽ, Brave Software Pay-ൽ നിന്നുള്ള പേയ്മെന്‍റ് രീതികളും വിലാസങ്ങളും ഉൾപ്പെടുന്നില്ല. നിങ്ങളുടെ പാസ്‌ഫ്രെയ്‌സുള്ള വ്യക്തിക്ക് മാത്രമേ എൻക്രി‌പ്‌റ്റ് ചെയ്‌ത ഡാറ്റ വായിക്കാനാവൂ. പാസ്‌ഫ്രെയ്‌സ് Brave Software-ലേക്ക് അയയ്‌ക്കുകയോ സംഭരിക്കുകയോ ചെയ്യുന്നില്ല. പാസ്‌ഫ്രെയ്‌സ് മറന്നുപോവുകയോ ഈ ക്രമീകരണം മാറ്റുകയോ ചെയ്യണമെങ്കിൽ, സമന്വയം പുനഃക്രമീകരിക്കേണ്ടി വരും. <ph name="BEGIN_LINK"/>കൂടുതലറിയുക<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">പാസ്ഫ്രെയ്‍സ്</translation>
+<translation id="7772032839648071052">പാസ്ഫ്രേസ് സ്ഥിരീകരിക്കുക</translation>
+<translation id="5304593522240415983">ഈ ഫീൽഡ് ശൂന്യമായിടാൻ കഴിയില്ല</translation>
+<translation id="321773570071367578">നിങ്ങൾ പാസ്‌ഫ്രെയ്‌സ് മറന്നുപോയെങ്കിലോ ഈ ക്രമീകരണം മാറ്റണമെങ്കിലോ, <ph name="BEGIN_LINK"/>സമന്വയം റീസെറ്റ് ചെയ്യുക<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">പാസ്‌ഫ്രെയ്‌സുകൾ പൊരുത്തപ്പെടുന്നില്ല</translation>
+<translation id="5149495116300586333">പാസ്‌ഫ്രെയ്‌സ് എൻക്രി‌പ്ഷനിൽ, Brave Software Pay-ൽ നിന്നുള്ള പേയ്മെന്‍റ് രീതികളും വിലാസങ്ങളും ഉൾപ്പെടുന്നില്ല.
+
+ഈ ക്രമീകരണം മാറ്റാൻ, <ph name="BEGIN_LINK"/>സമന്വയം പുനഃക്രമീകരിക്കുക<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">പാസ്‌ഫ്രെയ്‌സ് തെറ്റാണ്</translation>
+<translation id="5414836363063783498">പരിശോധിച്ചുറപ്പിക്കുന്നു...</translation>
+<translation id="6846298663435243399">ലോഡുചെയ്യുന്നു...</translation>
+<translation id="5517095782334947753">നിങ്ങൾക്ക് <ph name="FROM_ACCOUNT"/> എന്നയാളിൽ നിന്നുള്ള ബുക്ക്‌മാർക്കുകളും ചരിത്രവും പാസ്‌വേഡുകളും മറ്റ് ക്രമീകരണവുമുണ്ട്.</translation>
+<translation id="3928666092801078803">എന്റെ വിവരങ്ങൾ സംയോജിപ്പിക്കുക</translation>
+<translation id="688738109438487280">നിലവിലുള്ള വിവരങ്ങളെ <ph name="TO_ACCOUNT"/> അക്കൗണ്ടിലേക്ക് ചേർക്കുക</translation>
+<translation id="806745655614357130">എന്റെ വിവരങ്ങൾ പ്രത്യേകം വേർതിരിച്ച് സൂക്ഷിക്കുക</translation>
+<translation id="1145536944570833626">നിലവിലുള്ള വിവരങ്ങൾ ഇല്ലാതാക്കുക.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> ജോടിയാക്കാൻ താൽപ്പര്യപ്പെടുന്നു</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>ഉപകരണങ്ങൾ<ph name="END_LINK"/> സ്‌കാൻ ചെയ്യുമ്പോൾ സഹായം തേടുക…</translation>
+<translation id="5817918615728894473">ജോടിയാക്കുക</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>സഹായം തേടുക<ph name="END_LINK1"/> അല്ലെങ്കിൽ <ph name="BEGIN_LINK2"/>വീണ്ടും സ്‌കാൻ ചെയ്യുക<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">അനുയോജ്യമായ ഉപകരണങ്ങളൊന്നും കണ്ടെത്തിയില്ല</translation>
+<translation id="3773755127849930740">ജോടിയാക്കാൻ, <ph name="BEGIN_LINK"/>Bluetooth ഓണാക്കുക<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave-ന് Bluetooth അഡാപ്‌റ്റർ ഓണാക്കാനാവുന്നില്ല</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>സഹായം തേടുക<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യുന്നതിന് Brave-ന് ലൊക്കേഷൻ ആക്‌സസ് ആവശ്യമാണ്. <ph name="BEGIN_LINK"/>അനുമതികൾ അപ്‌ഡേറ്റ് ചെയ്യുക<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യാൻ Brave-ന് ലൊക്കേഷൻ ആക്‌സസ് ആവശ്യമാണ്. ഈ ഉപകരണത്തിന്റെ <ph name="BEGIN_LINK"/>ലൊക്കേഷൻ ആക്‌സസ് ഓഫാണ്<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യാൻ Brave-ന് ലൊക്കേഷൻ ആക്‌സസ് ആവശ്യമാണ്. <ph name="BEGIN_LINK1"/>അനുമതികൾ അപ്‌ഡേറ്റ് ചെയ്യുക<ph name="END_LINK1"/>. ഈ ഉപകരണത്തിന്റെ <ph name="BEGIN_LINK2"/>ലൊക്കേഷൻ ആക്‌സസും ഓഫാക്കിയിരിക്കുകയാണ്<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">കണക്റ്റ് ചെയ്‌തിരിക്കുന്ന ഉപകരണം</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{സിഗ്‌നൽ സ്‌ട്രെംഗ്‌ത്ത് ലെവൽ # ബാർ}other{സിഗ്‌നൽ സ്‌ട്രെംഗ്‌ത്ത് ലെവൽ # ബാറുകൾ}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> എന്നതിന് സമീപമുള്ള Bluetooth ഉപകരണങ്ങൾ സ്‌കാൻ ചെയ്യണമെന്നുണ്ട്. ഇനിപ്പറയുന്ന ഉപകരണങ്ങൾ കണ്ടെത്തി:</translation>
+<translation id="8368027906805972958">പരിചിതമല്ലാത്തതോ പിന്തുണയ്‌ക്കാത്തതോ ആയ ഉപകരണം (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">സമന്വയിപ്പിക്കൽ പ്രവർത്തിക്കുന്നില്ല</translation>
+<translation id="1810845389119482123">പ്രാഥമിക സമന്വയ സജ്ജീകരണം പൂർത്തിയാക്കിയിട്ടില്ല</translation>
+<translation id="3235722914093408050">Brave സമന്വയം ആരംഭിക്കാൻ Android ക്രമീകരണം തുറന്ന് Android സിസ്‌റ്റം സമന്വയിപ്പിക്കൽ വീണ്ടും പ്രവർത്തനക്ഷമമാക്കുക</translation>
+<translation id="3367813778245106622">സമന്വയിപ്പിക്കാൻ തുടങ്ങുന്നതിന്, വീണ്ടും സൈൻ ഇൻ ചെയ്യുക</translation>
+<translation id="974555521953189084">സമന്വയിപ്പിക്കൽ തുടങ്ങുന്നതിന് പാസ്‌ഫ്രെയ്‌സ് നൽകുക</translation>
+<translation id="2997266899014181325">സമന്വയം ആരംഭിക്കാൻ, "നിങ്ങളുടെ Brave ഡാറ്റാ സമന്വയിപ്പിക്കൽ" ഓണാക്കുക.</translation>
+<translation id="8260126382462817229">വീണ്ടും സൈൻ ഇൻ ചെയ്യാൻ ശ്രമിക്കുക</translation>
+<translation id="5919204609460789179">സമന്വയിപ്പിക്കാൻ തുടങ്ങുന്നതിന്, <ph name="PRODUCT_NAME"/> അപ്‌ഡേറ്റ് ചെയ്യുക</translation>
+<translation id="397583555483684758">'സമന്വയം' പ്രവർത്തനം നിർത്തി</translation>
+<translation id="1966710179511230534">നിങ്ങളുടെ സൈൻ ഇൻ വിശദാംശങ്ങൾ അപ്‌ഡേറ്റ് ചെയ്യുക.</translation>
+<translation id="7063006564040364415">സമന്വയ സെർവറിലേക്ക് കണക്‌റ്റ് ചെയ്യാനായില്ല.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> കാലഹരണപ്പെട്ടതാണ്.</translation>
+<translation id="4170011742729630528">സേവനം ലഭ്യമല്ല; പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</translation>
+<translation id="7947953824732555851">അംഗീകരിച്ച് സൈൻ ഇൻ ചെയ്യുക</translation>
+<translation id="8583805026567836021">അക്കൗണ്ട് ഡാറ്റ മായ്‌ക്കുന്നു</translation>
+<translation id="8310344678080805313">സ്റ്റാൻഡേർഡ് ടാബുകൾ</translation>
+<translation id="5748802427693696783">സ്റ്റാൻഡേർഡ് ടാബുകളിലേക്ക് മാറി</translation>
+<translation id="7998918019931843664">അടച്ച ടാബ് വീണ്ടും തുറക്കുക</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, ടാബ്</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> ടാബ് അടയ്ക്കുക</translation>
+<translation id="7243308994586599757">സ്‌ക്രീനിന്റെ ചുവടെ ഓപ്‌ഷനുകൾ ലഭ്യമാണ്</translation>
+<translation id="4060598801229743805">സ്‌ക്രീനിന്റെ മുകളിൽ ഓപ്‌ഷനുകൾ ലഭ്യമാണ്</translation>
+<translation id="2810645512293415242">ഡാറ്റ ലാഭിക്കുന്നതിനും വേഗത്തിൽ ലോഡ് ചെയ്യുന്നതിനുമായി ലളിതവൽക്കരിച്ചിരിക്കുന്ന പേജ്.</translation>
+<translation id="3985215325736559418">നിങ്ങൾക്ക് വീണ്ടും <ph name="FILE_NAME"/> ഡൗൺലോഡ് ചെയ്യണോ?</translation>
+<translation id="2450083983707403292"><ph name="FILE_NAME"/> വീണ്ടും ഡൗൺലോഡുചെയ്യാൻ തുടങ്ങണോ?</translation>
+<translation id="7514365320538308">ഡൗൺലോഡ് ചെയ്യുക</translation>
+<translation id="545042621069398927">നിങ്ങളുടെ ഡൗൺലോഡ് വേഗത്തിലാക്കുന്നു.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ഫയൽ ഡൗൺലോഡ് ചെയ്യുന്നു.}other{# ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യുന്നു.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യുന്നു (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">ഫയൽ ഡൗൺലോഡ് ചെയ്യുന്നു (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{ഒരു ഡൗൺലോഡ് പൂർത്തിയായി.}other{# ഡൗൺലോഡുകൾ പൂർത്തിയായി.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{ഒരു ഡൗൺലോഡ് പരാജയപ്പെട്ടു.}other{# ഡൗൺലോഡുകൾ പരാജയപ്പെട്ടു.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{ഒരു ഡൗൺലോഡ് ശേഷിക്കുന്നു.}other{# ഡൗൺലോഡുകൾ ശേഷിക്കുന്നു.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> ബട്ടൺ</translation>
+<translation id="3205824638308738187">ഏതാണ്ട് പൂർത്തിയായി!</translation>
+<translation id="3960299545138990065">Brave റീസ്‌റ്റാർട്ടുചെയ്യുക</translation>
+<translation id="3771001275138982843">അപ്‌ഡേറ്റ് ഡൗൺലോഡ് ചെയ്യാനായില്ല</translation>
+<translation id="3888648114124182147">Brave അപ്‌ഡേറ്റ് ഡൗൺലോഡ് ചെയ്യുന്നു…</translation>
+<translation id="1705567146636171298">Brave അപ്‌ഡേറ്റുചെയ്യുക</translation>
+<translation id="6195417478702700398">മികച്ച ബ്രൗസിംഗ് അനുഭവത്തിന് Brave അപ്‌ഡേറ്റ് ചെയ്യുക</translation>
+<translation id="3512968675351418494">നിങ്ങളുടെ ഭാഷയിൽ വെബ് കാണാൻ Brave-ൻ്റെ ഏറ്റവും പുതിയ പതിപ്പ് നേടൂ</translation>
+<translation id="6427112570124116297">വെബ് വിവർത്തനം ചെയ്യുക</translation>
+<translation id="1379423114029199501">Brave-ൻ്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ നിങ്ങളുടെ ഭാഷ ലഭ്യമാക്കാൻ അപ്‌ഡേറ്റ് ചെയ്യൂ</translation>
+<translation id="5684874026226664614">ക്ഷമിക്കണം. ഈ പേജ് വിവർത്തനം ചെയ്യാനായില്ല.</translation>
+<translation id="6831043979455480757">വിവർത്തനം ചെയ്യുക</translation>
+<translation id="1285320974508926690">ഈ സൈറ്റ് ഒരിക്കലും വിവര്‍‌ത്തനം ചെയ്യരുത്</translation>
+<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE"/> ഭാഷയിലുള്ള പേജുകൾ എപ്പോഴും വിവർത്തനം ചെയ്യുക</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/> ഭാഷയിലുള്ള പേജുകൾ ഒരിക്കലും വിവർത്തനം ചെയ്യരുത്</translation>
+<translation id="124116460088058876">കൂടുതൽ ഭാഷകൾ</translation>
+<translation id="290376772003165898">പേജ് <ph name="LANGUAGE"/> ഭാഷയിലല്ലേ?</translation>
+<translation id="4432792777822557199">ഇനിമുതൽ <ph name="SOURCE_LANGUAGE"/> ഭാഷയിലുള്ള പേജുകൾ <ph name="TARGET_LANGUAGE"/> ഭാഷയിലേക്ക് വിവർത്തനം ചെയ്യപ്പെടും</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/> ഭാഷയിലുള്ള പേജുകൾ വിവർത്തനം ചെയ്യില്ല</translation>
+<translation id="5447765697759493033">ഈ സൈറ്റ് വിവർത്തനം ചെയ്യപ്പെടില്ല</translation>
+<translation id="4880127995492972015">വിവർത്തനം ചെയ്യുക…</translation>
+<translation id="641643625718530986">പ്രിന്‍റ് ചെയ്യുക…</translation>
+<translation id="8909135823018751308">പങ്കിടുക...</translation>
+<translation id="4996978546172906250">ഇതുവഴി പങ്കിടുക</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> വഴി പങ്കിടുക</translation>
+<translation id="6277522088822131679">പേജ് പ്രിന്റുചെയ്യുന്നതിൽ ഒരു പ്രശ്‌നമുണ്ടായി. വീണ്ടും ശ്രമിക്കുക.</translation>
+<translation id="3254409185687681395">ഈ പേജ് ബുക്‌മാര്‍ക്ക് ചെയ്യുക</translation>
+<translation id="497421865427891073">മുന്നോട്ട് പോകുക</translation>
+<translation id="813082847718468539">സൈറ്റ് വിവരങ്ങള്‍ കാണുക</translation>
+<translation id="2532336938189706096">വെബ് കാഴ്‌ച</translation>
+<translation id="6005538289190791541">നിർദ്ദേശിച്ച പാസ്‌വേഡ്</translation>
+<translation id="4634124774493850572">പാസ്‌വേഡ് ഉപയോഗിക്കുക</translation>
+<translation id="8285489906452138776">Brave-ന് ഈ സൈറ്റിനായി നിങ്ങളുടെ ക്യാമറ ആക്‌സസ് ചെയ്യാനുള്ള അനുമതി ആവശ്യമാണ്.</translation>
+<translation id="320189792589364011">Brave-ന് ഈ സൈറ്റിനായി നിങ്ങളുടെ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാനുള്ള അനുമതി ആവശ്യമാണ്.</translation>
+<translation id="7988136689212463100">Brave-ന് ഈ സൈറ്റിനായി നിങ്ങളുടെ ക്യാമറയും മൈക്രോഫോണും ആക്‌സസ് ചെയ്യാനുള്ള അനുമതി ആവശ്യമാണ്.</translation>
+<translation id="4931190655840828017">Brave-ന് ഈ സൈറ്റുമായി ലൊക്കേഷൻ പങ്കിടാൻ നിങ്ങളുടെ ലൊക്കേഷനിലേക്കുള്ള ആക്‌സസ് ആവശ്യമാണ്.</translation>
+<translation id="3088191967551450609">ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യാൻ Brave-ന് സ്റ്റോറേജ് ആക്‌സസ് ആവശ്യമുണ്ട്.</translation>
+<translation id="8942627711005830162">മറ്റൊരു വിൻഡോയിൽ തുറക്കുക</translation>
+<translation id="4195643157523330669">പുതിയ ടാബില്‍ തുറക്കുക</translation>
+<translation id="1100066534610197918">ഗ്രൂപ്പിലെ പുതിയ ടാബിൽ തുറക്കൂ</translation>
+<translation id="4860895144060829044">വിളിക്കുക</translation>
+<translation id="6896758677409633944">പകര്‍ത്തുക</translation>
+<translation id="8393700583063109961">സന്ദേശം അയയ്ക്കുക</translation>
+<translation id="3557336313807607643">കോൺടാക്‌റ്റുകളിലേക്ക് ചേർക്കുക</translation>
+<translation id="4269820728363426813">ലിങ്ക് വിലാസം പകർത്തുക</translation>
+<translation id="1206892813135768548">ലിങ്ക് വാചകം പകർത്തുക</translation>
+<translation id="1204037785786432551">ലിങ്ക് ഡൗൺലോഡ് ചെയ്യുക</translation>
+<translation id="6864459304226931083">ചിത്രം ഡൗൺലോഡ് ചെയ്യുക</translation>
+<translation id="8209050860603202033">ചിത്രം തുറക്കുക</translation>
+<translation id="8073388330009372546">ചിത്രം പുതിയ ടാബിൽ തുറക്കുക</translation>
+<translation id="6649642165559792194"><ph name="BEGIN_NEW"/>പുതിയ<ph name="END_NEW"/> ചിത്രം പ്രിവ്യൂ ചെയ്യുക</translation>
+<translation id="3269093882174072735">ചിത്രം ലോഡ് ചെയ്യുക</translation>
+<translation id="3845332215609790146">Brave Software ലെൻസ് ഉപയോഗിച്ച് തിരയൂ <ph name="BEGIN_NEW"/>പുതിയത്<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">ഈ ചിത്രത്തിനായി <ph name="SEARCH_ENGINE"/>-ൽ തിരയുക</translation>
+<translation id="3384347053049321195">ചിത്രം പങ്കിടുക</translation>
+<translation id="5833984609253377421">ലിങ്ക് പങ്കിടുക</translation>
+<translation id="6475951671322991020">വീഡിയോ ഡൗൺലോഡ് ചെയ്യുക</translation>
+<translation id="2317945146070194624">പുതിയ Brave ടാബിൽ തുറക്കുക</translation>
+<translation id="7975379999046275268"><ph name="BEGIN_NEW"/>പുതിയ<ph name="END_NEW"/> പേജ് പ്രിവ്യൂ ചെയ്യുക</translation>
+<translation id="6112702117600201073">പേജ് പുതുക്കുന്നു</translation>
+<translation id="36525718899759834">Brave Software Play സ്റ്റോറിൽ നിന്ന് ആപ്പ് സ്വീകരിക്കുക: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">ഇരുണ്ടത്</translation>
+<translation id="1807246157184219062">ലൈറ്റ്</translation>
+<translation id="4056223980640387499">സിപിയ</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">മോണോസ്പെ‌യ്‌സ്</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">ബീം ചെയ്യാൻ ടാബ് തിരഞ്ഞെടുക്കുക</translation>
+<translation id="8719023831149562936">നിലവിലെ ടാബ് ബീം ചെയ്യാനാകില്ല</translation>
+<translation id="2139186145475833000">ഹോംസ്‌ക്രീനിൽ ചേർക്കുക</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> തുറക്കുക</translation>
+<translation id="2122601567107267586">ആപ്പ് തുറക്കാനായില്ല</translation>
+<translation id="5129038482087801250">വെബ്ആപ്പ് ഇൻസ്‌റ്റാൾ ചെയ്യൂ</translation>
+<translation id="3789841737615482174">ഇന്‍സ്റ്റാൾ ചെയ്യുക</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> എന്നയാളെ നിങ്ങളുടെ ഹോം സ്‌ക്രീനിൽ ചേർത്തു</translation>
+<translation id="7333031090786104871">ഇപ്പോഴും മുമ്പത്തെ സൈറ്റ് ചേർത്തുകൊണ്ടിരിക്കുകയാണ്</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> ചേർക്കുന്നു...</translation>
+<translation id="3778956594442850293">ഹോം സ്‌ക്രീനിലേക്ക് ചേർത്തു</translation>
+<translation id="2146738493024040262">ഇൻസ്റ്റന്‍റ് ആപ്പ് തുറക്കുക</translation>
+<translation id="7016516562562142042">നിലവിലെ തിരയൽ യന്ത്രത്തിൽ അനുവദിച്ചിരിക്കുന്നു</translation>
+<translation id="6177111841848151710">നിലവിലെ തിരയൽ യന്ത്രത്തിൽ ബ്ലോക്ക് ചെയ്‌തിരിക്കുന്നു</translation>
+<translation id="145097072038377568">Android ക്രമീകരണത്തിൽ ഓഫാക്കിയിരിക്കുന്നു</translation>
+<translation id="8007176423574883786">ഈ ഉപകരണത്തിനായി ഓഫാക്കി</translation>
+<translation id="164269334534774161">നിങ്ങൾ ഈ പേജിന്റെ <ph name="CREATION_TIME"/> മുതലുള്ള ഓഫ്‌ലൈൻ പകർപ്പാണ് കാണുന്നത്</translation>
+<translation id="4594952190837476234">ഈ ഓഫ്‌ലൈൻ പേജ് <ph name="CREATION_TIME"/> -ന് സൃഷ്‌ടിച്ചതാണ്, അതിനാൽ ഓൺലൈൻ പതിപ്പിൽ നിന്ന് വ്യത്യസ്തമായിരിക്കാം.</translation>
+<translation id="8840953339110955557">ഈ പേജ് ഓൺലൈൻ പതിപ്പിൽ നിന്ന് വ്യത്യസ്തമായിരിക്കാം.</translation>
+<translation id="6405300764336705484">ഈ ഉള്ളടക്കം Brave Software-ൽ നിന്നുള്ള <ph name="DOMAIN_NAME"/> ഡൊമെയ്‌നിൽ നിന്നുള്ളതാണ്.</translation>
+<translation id="1006017844123154345">ഓൺലൈനായി തുറക്കുക</translation>
+<translation id="3326636747541519688">Brave Software നല്‍കുന്ന ലൈറ്റ് പേജ്</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/>-ല്‍ നിന്ന് <ph name="BEGIN_LINK"/>യഥാര്‍ത്ഥ പേജ് ലോഡ് ചെയ്യുക<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">നിങ്ങൾ ഇത് പതിവായി കാണുന്നുണ്ടെങ്കിൽ, ഈ <ph name="BEGIN_LINK"/>നിർദ്ദേശങ്ങൾ<ph name="END_LINK"/> പരീക്ഷിക്കൂ.</translation>
+<translation id="8748850008226585750">കോൺടാക്‌റ്റുകൾ മറച്ചു</translation>
+<translation id="3810973564298564668">മാനേജ് ചെയ്യുക</translation>
+<translation id="5199929503336119739">ഔദ്യോഗിക പ്രൊഫൈൽ</translation>
+<translation id="528192093759286357">പൂർണ്ണ സ്‌ക്രീനിൽ നിന്ന് പുറത്തുകടക്കാൻ, മുകളിൽ നിന്ന് വലിച്ചിട്ട് ബാക്ക് ബട്ടണിൽ സ്‌പർശിക്കുക.</translation>
+<translation id="2836148919159985482">പൂർണസ്‌ക്രീനിൽനിന്ന് പുറത്തുകടക്കാൻ ബാക്ക് ബട്ടണിൽ സ്‌പർശിക്കുക.</translation>
+<translation id="3967822245660637423">ഡൗൺലോഡ് പൂർത്തിയായി</translation>
+<translation id="2434158240863470628">ഡൗൺലോഡ് പൂർത്തിയായി <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">ഡൗൺലോഡ് പരാജയപ്പെട്ടു</translation>
+<translation id="1384959399684842514">ഡൗൺലോഡ് താൽക്കാലികമായി നിർത്തി</translation>
+<translation id="1671236975893690980">ഡൗൺലോഡ് തീർച്ചപ്പെടുത്തിയിട്ടില്ല...</translation>
+<translation id="5561549206367097665">നെറ്റ്‌വർക്കിനായി കാത്തിരിക്കുന്നു...</translation>
+<translation id="5864419784173784555">മറ്റൊരു ഡൗൺലോഡിനായി കാത്തിരിക്കുന്നു…</translation>
+<translation id="6461962085415701688">ഫയൽ തുറക്കാൻ കഴിയില്ല</translation>
+<translation id="1178581264944972037">അല്പംനിര്‍ത്തൂ</translation>
+<translation id="8200772114523450471">പുനരാരംഭിക്കുക</translation>
+<translation id="1409879593029778104">ഫയൽ ഇതിനകം തന്നെ ഉള്ളതിനാൽ <ph name="FILE_NAME"/> ഡൗൺലോഡ് തടഞ്ഞു.</translation>
+<translation id="3387650086002190359">ഫയൽ സിസ്‌റ്റം പിശകുകൾ കാരണം <ph name="FILE_NAME"/> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
+<translation id="6482749332252372425">സ്‌റ്റോറേജ് ഇടമില്ലാത്തതിനാൽ <ph name="FILE_NAME"/> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
+<translation id="7619072057915878432">നെറ്റ്‌വർക്ക് പരാജയം കാരണം <ph name="FILE_NAME"/> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
+<translation id="1477626028522505441">സെർവർ പ്രശ്‌നങ്ങൾ കാരണം <ph name="FILE_NAME"/> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
+<translation id="3692944402865947621">സ്റ്റോറേജ് ലൊക്കേഷൻ കണ്ടെത്താനാകാത്തതിനാൽ <ph name="FILE_NAME"/> ഡൗൺലോഡ് ചെയ്യുന്നത് പരാജയപ്പെട്ടു.</translation>
+<translation id="604996488070107836">ഒരു അജ്ഞാതമായ പിശക് കാരണം <ph name="FILE_NAME"/> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
+<translation id="6738867403308150051">ഡൗൺലോഡുചെയ്യുന്നു...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB ഡൗൺലോഡ് ചെയ്‌തു</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB ഡൗൺലോഡ് ചെയ്‌തു</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB ഡൗൺലോഡുചെയ്‌തു</translation>
+<translation id="9204836675896933765">ഒരു ഫയൽ ശേഷിക്കുന്നു</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> ഫയലുകൾ ശേഷിക്കുന്നു</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> ഫയൽ ഡൗൺലോഡ് ചെയ്‌തു}other{<ph name="FILES_DOWNLOADED_MANY"/> ഫയലുകൾ ഡൗൺലോഡ് ചെയ്‌തു}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> ദിവസം ശേഷിക്കുന്നു</translation>
+<translation id="8190358571722158785">ഒരു ദിവസം ശേഷിക്കുന്നു</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> മണിക്കൂർ ശേഷിക്കുന്നു</translation>
+<translation id="510275257476243843">ഒരു മണിക്കൂർ ശേഷിക്കുന്നു</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> മിനിറ്റ് ശേഷിക്കുന്നു</translation>
+<translation id="3236059992281584593">ഒരു മിനിറ്റ് ശേഷിക്കുന്നു</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> സെക്കൻഡ് ശേഷിക്കുന്നു</translation>
+<translation id="2781151931089541271">ഒരു സെക്കൻഡ് ശേഷിക്കുന്നു</translation>
+<translation id="3303414029551471755">ഉള്ളടക്കം ഡൗൺലോഡ് ചെയ്യുന്നതിലേക്ക് തുടരണോ?</translation>
+<translation id="8617240290563765734">ഡൗൺലോഡ് ചെയ്‌ത ഉള്ളടക്കത്തിൽ നിർദ്ദേശിച്ചിട്ടുള്ള URL തുറക്കണോ?</translation>
+<translation id="1373696734384179344">തിരഞ്ഞെടുത്ത ഉള്ളടക്കം ഡൗൺലോഡ് ചെയ്യുന്നതിന് ആവശ്യമായ മെമ്മറിയില്ല.</translation>
+<translation id="5271967389191913893">ഡൗൺലോഡ് ചെയ്യേണ്ട ഉള്ളടക്കം ഉപകരണത്തിന് തുറക്കാനാവില്ല.</translation>
+<translation id="883806473910249246">ഉള്ളടക്കം ഡൗൺലോഡ് ചെയ്യുമ്പോൾ ഒരു പിശകുണ്ടായി.</translation>
+<translation id="5626134646977739690">നാമം:</translation>
+<translation id="7963646190083259054">വെണ്ടർ:</translation>
+<translation id="3414952576877147120">വലുപ്പം:</translation>
+<translation id="7375125077091615385">തരം:</translation>
+<translation id="5765780083710877561">വിവരണം:</translation>
+<translation id="4881695831933465202">തുറക്കുക</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB ലഭ്യമാണ്</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB ലഭ്യമാണ്</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB ലഭ്യമാണ്</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> / <ph name="SPACE_AVAILABLE"/> ഉപയോഗിക്കുന്നു</translation>
+<translation id="3587482841069643663">എല്ലാം</translation>
+<translation id="4988526792673242964">പേജുകള്‍</translation>
+<translation id="3810838688059735925">വീഡിയോ</translation>
+<translation id="3616113530831147358">ഓഡിയോ</translation>
+<translation id="9219103736887031265">ചിത്രങ്ങൾ‌</translation>
+<translation id="8250920743982581267">ഡോക്യുമെന്റുകൾ</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ഫയല്‍}other{# ഫയലുകൾ}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ചിത്രം}other{# ചിത്രങ്ങൾ}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# വീഡിയോ}other{# വീഡിയോകൾ}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ഓഡിയോ ഫയൽ}other{# ഓഡിയോ ഫയലുകള്‍}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# പേജ്}other{# പേജുകൾ}}</translation>
+<translation id="5456381639095306749">പേജ് ഡൗൺലോഡ് ചെയ്യുക</translation>
+<translation id="2394602618534698961">നിങ്ങൾ ഡൗൺലോഡ് ചെയ്യുന്ന ഫയലുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
+<translation id="7810647596859435254">ഇത് ഉപയോഗിച്ച് തുറക്കുക...</translation>
+<translation id="5655963694829536461">നിങ്ങളുടെ ഡൗൺലോഡുകൾ തിരയുക</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">എന്റെ ഫയലുകൾ</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">ഇവിടെ ദൃശ്യമാകുന്ന ലേഖനങ്ങൾ നിങ്ങൾ ഓഫ്‌ലൈൻ ആകുന്ന സമയത്ത് പോലും വായിക്കാം</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# മണിക്കൂർ}other{# മണിക്കൂർ}}</translation>
+<translation id="5853623416121554550">താൽക്കാലികമായി നിർത്തി</translation>
+<translation id="8965591936373831584">തീർച്ചപ്പെടുത്താത്തവ</translation>
+<translation id="2779651927720337254">പരാജയപ്പെട്ടു</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">ഇപ്പോൾ</translation>
+<translation id="4000212216660919741">ഓഫ്‌ലൈൻ ഹോം</translation>
+<translation id="9133397713400217035">ഓഫ്‍ലൈൻ ഉള്ളടക്കങ്ങൾ അടുത്തറിയൂ</translation>
+<translation id="968900484120156207">നിങ്ങൾ സന്ദർശിക്കുന്ന പേജുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
+<translation id="7882131421121961860">ചരിത്രം കണ്ടില്ല</translation>
+<translation id="3549657413697417275">ചരിത്രം തിരയുക</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave ആദ്യ പ്രവർത്തന അനുഭവം</translation>
+<translation id="2700285883409956633">ഈ ആപ്പ് ഉപയോഗിക്കുന്നതിലൂടെ, നിങ്ങൾ Brave-ന്റെ <ph name="BEGIN_LINK1"/>സേവന നിബന്ധനകളും<ph name="END_LINK1"/> <ph name="BEGIN_LINK2"/>സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK2"/> അംഗീകരിക്കുന്നു.</translation>
+<translation id="1640714894372474981">ഈ ആപ്പ് ഉപയോഗിക്കുന്നതിലൂടെ, നിങ്ങൾ Brave-ന്‍റെ <ph name="BEGIN_LINK1"/>സേവന നിബന്ധനകൾ<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>സ്വകാര്യതാ അറിയിപ്പ്<ph name="END_LINK2"/>, <ph name="BEGIN_LINK3"/>Family Link ഉപയോഗിച്ച് നിയന്ത്രിക്കുന്ന Brave Software അക്കൗണ്ടുകളുടെ സ്വകാര്യതാ അറിയിപ്പ്<ph name="END_LINK3"/> എന്നിവ അംഗീകരിക്കുന്നു.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> Brave-ൽ തുറക്കും. തുടരുന്നതിലൂടെ, നിങ്ങൾ Brave-ന്റെ <ph name="BEGIN_LINK1"/>സേവന നിബന്ധനകളും<ph name="END_LINK1"/> <ph name="BEGIN_LINK2"/>സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK2"/> അംഗീകരിക്കുന്നു.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Brave-ൽ തുറക്കും. തുടരുന്നതിലൂടെ, നിങ്ങൾ Brave-ന്റെ <ph name="BEGIN_LINK1"/>സേവന നിബന്ധനകളും<ph name="END_LINK1"/> <ph name="BEGIN_LINK2"/>സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK2"/> <ph name="BEGIN_LINK3"/>Family Link ഉപയോഗിച്ച് മാനേജ് ചെയ്യപ്പെടുന്ന Brave Software അക്കൗണ്ടുകളുടെ സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK3"/> അംഗീകരിക്കുന്നു.</translation>
+<translation id="673197144963363525">Brave Software-ലേക്ക് ഉപയോഗ വിവരക്കണക്കുകളും ക്രാഷ് റിപ്പോർട്ടുകളും അയയ്‌ക്കുന്നതിലൂടെ Brave-നെ മികച്ചതാക്കാൻ സഹായിക്കുക.</translation>
+<translation id="3518985090088779359">അംഗീകരിച്ച് തുടരുക</translation>
+<translation id="7207456302801184289">Brave-ലേക്ക് സ്വാഗതം</translation>
+<translation id="704822250101715322">Brave Software Play സേവനങ്ങൾ അപ്‌ഡേറ്റുചെയ്യുന്നത് പൂർത്തിയാക്കാൻ കാത്തിരിക്കുന്നു</translation>
+<translation id="1231733316453485619">സമന്വയിപ്പിക്കൽ ഓണാക്കണോ?</translation>
+<translation id="5132942445612118989">നിങ്ങളുടെ പാസ്‌വേഡുകളും ചരിത്രവും മറ്റും എല്ലാ ഉപകരണങ്ങളിലും സമന്വയിപ്പിക്കുക</translation>
+<translation id="5736731321935944068">തിരയലും പരസ്യവും മറ്റ് Brave Software സേവനങ്ങളും വ്യക്തിപരമാക്കാൻ Brave Software നിങ്ങളുടെ ചരിത്രം ഉപയോഗിച്ചേക്കാം</translation>
+<translation id="4013614219085422040">തിരയലും മറ്റ് Brave Software സേവനങ്ങളും വ്യക്തിപരമാക്കാൻ Brave Software നിങ്ങളുടെ ചരിത്രം ഉപയോഗിച്ചേക്കാം</translation>
+<translation id="5581519193887989363">എന്തൊക്കെ സമന്വയിക്കണമെന്നത് <ph name="BEGIN_LINK1"/>ക്രമീകരണത്തിൽ<ph name="END_LINK1"/> നിങ്ങൾക്ക് എപ്പോഴും തിരഞ്ഞെടുക്കാം.</translation>
+<translation id="741204030948306876">ഞാൻ തയ്യാറാണ്</translation>
+<translation id="2410754283952462441">ഒരു അക്കൗണ്ട് തിരഞ്ഞെടുക്കൂ</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> എന്ന പേരിൽ തുടരുക</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> അല്ലേ?</translation>
+<translation id="8109613176066109935">നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ബുക്ക്‌മാർക്കുകൾ ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="2818669890320396765">നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ബുക്ക്‌മാർക്കുകൾ ലഭിക്കാൻ, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="6003646045106347985">Brave Software നിർദ്ദേശിക്കുന്ന വ്യക്തിപരമാക്കിയ ഉള്ളടക്കം ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="8494430740943879273">Brave Software നിർദേശിക്കുന്ന വ്യക്തിപരമാക്കിയ ഉള്ളടക്കം ലഭിക്കാൻ, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="5862731021271217234">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="3568688522516854065">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="1208340532756947324">ഉപകരണങ്ങളിൽ ഉടനീളം സമന്വയിപ്പിക്കാനും വ്യക്തിപരമാക്കാനും, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="4472118726404937099">ഉപകരണങ്ങളിൽ ഉടനീളം സമന്വയിപ്പിക്കാനും വ്യക്തിപരമാക്കാനും, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="2426805022920575512">മറ്റൊരു അക്കൗണ്ട് തിരഞ്ഞെടുക്കൂ</translation>
+<translation id="6790428901817661496">പ്ലേചെയ്യുക</translation>
+<translation id="1272079795634619415">നിര്‍ത്തുക</translation>
+<translation id="2874939134665556319">മുമ്പത്തെ ട്രാക്ക്</translation>
+<translation id="4046123991198612571">അടുത്ത ട്രാക്ക്</translation>
+<translation id="3859306556332390985">മുന്നോട്ട് നീക്കുക</translation>
+<translation id="8441146129660941386">പുറകിലേക്ക് സീക്കുചെയ്യുക</translation>
+<translation id="6706288973712894588">നിങ്ങൾ നിലവിൽ ഓഫ്‍ലൈനാണ്.\n<ph name="BEGIN_LINK"/>നിങ്ങളുടെ ഓഫ്‍ലൈൻ ഫീഡ് അടുത്തറിയൂ.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">അടുത്തിടെയുള്ള ടാബുകൾ</translation>
+<translation id="8497726226069778601">ഇതുവരെയും ഇവിടെ കാണാനായി ഒന്നുമില്ല...</translation>
+<translation id="5423934151118863508">നിങ്ങളുടെ ഏറ്റവുമധികം സന്ദർശിച്ച പേജുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
+<translation id="6127379762771434464">ഇനം നീക്കംചെയ്‌തു</translation>
+<translation id="4605958867780575332">നീക്കംചെയ്‌ത ഇനം: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software ഡൂഡിൽ: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">മറ്റ് ഉപകരണങ്ങൾ</translation>
+<translation id="4738836084190194332">അവസാനം സമന്വയിപ്പിച്ചത്: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# മിനിറ്റ് മുമ്പ്}other{# മിനിറ്റ് മുമ്പ്}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# മണിക്കൂര്‍ മുമ്പ്}other{# മണിക്കൂര്‍ മുമ്പ്}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# ദിവസം മുമ്പ്}other{# ദിവസം മുമ്പ്}}</translation>
+<translation id="2762000892062317888">ഇപ്പോൾ</translation>
+<translation id="1407135791313364759">എല്ലാം തുറക്കുക</translation>
+<translation id="1209206284964581585">ഇപ്പോഴത്തേയ്‌ക്ക് മറയ്‌ക്കുക</translation>
+<translation id="129553762522093515">സമീപകാലത്ത് അടച്ചവ</translation>
+<translation id="8413126021676339697">മുഴുവന്‍ ചരിത്രവും കാണിക്കുക</translation>
+<translation id="7876243839304621966">എല്ലാം നീക്കംചെയ്യുക</translation>
+<translation id="8487700953926739672">ഓഫ്‌ലൈനില്‍ ലഭ്യമാണ്</translation>
+<translation id="5224771365102442243">വീഡിയോ ഉണ്ട്</translation>
+<translation id="3493531032208478708">നിർദ്ദേശിച്ച ഉള്ളടക്കത്തെക്കുറിച്ച് <ph name="BEGIN_LINK"/>കൂടുതലറിയുക<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">നിർദ്ദേശങ്ങൾ സ്വീകരിക്കാനാവില്ല</translation>
+<translation id="5013696553129441713">പുതിയ നിർദ്ദേശങ്ങളൊന്നുമില്ല</translation>
+<translation id="1736419249208073774">അടുത്തറിയുക</translation>
+<translation id="7444811645081526538">കൂടുതൽ‍ വിഭാഗങ്ങള്‍</translation>
+<translation id="6709133671862442373">വാർത്ത</translation>
+<translation id="1264974993859112054">കായികം</translation>
+<translation id="9139318394846604261">ഷോപ്പിംഗ്</translation>
+<translation id="3912508018559818924">വെബിൽ നിന്നുള്ള ഏറ്റവും മികച്ചത് കണ്ടെത്തുന്നു…</translation>
+<translation id="526421993248218238">ഈ പേജ് ലോഡ് ചെയ്യാനായില്ല</translation>
+<translation id="614940544461990577">പരീക്ഷിച്ചുനോക്കൂ:</translation>
+<translation id="3288003805934695103">പേജ് റീലോഡുചെയ്യുന്നു</translation>
+<translation id="2353636109065292463">നിങ്ങളുടെ ഇന്‍റർനെറ്റ് കണക്ഷൻ പരിശോധിക്കുന്നു</translation>
+<translation id="2858138569776157458">മികച്ച സൈറ്റുകൾ</translation>
+<translation id="8364299278605033898">ജനപ്രിയ വെബ്‌സൈറ്റുകൾ കാണുക</translation>
+<translation id="1171770572613082465">"മികച്ച സൈറ്റുകൾ" ബട്ടൺ ടാപ്പ് ചെയ്‌ത് ജനപ്രിയ വെബ്‌സൈറ്റുകൾ കാണുക</translation>
+<translation id="5233638681132016545">പുതിയ ടാബ്</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/>-ൽ നിന്ന് – <ph name="BEGIN_DEEMPHASIZED"/>Brave Software നൽകുന്നത്<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">ഏറ്റവും പുതിയ പതിപ്പ് ലഭ്യമാണ്</translation>
+<translation id="4058091506841967397">Brave അപ്‌ഡേറ്റ് ചെയ്യാനാവില്ല</translation>
+<translation id="6316139424528454185">Android പതിപ്പ് പിന്തുണയ്‌ക്കുന്നതല്ല</translation>
+<translation id="6989267951144302301">ഡൗൺലോഡ് ചെയ്യാനായില്ല</translation>
+<translation id="624789221780392884">അപ്‌ഡേറ്റ് തയ്യാറാണ്</translation>
+<translation id="1549000191223877751">മറ്റൊരു വിൻഡോയിലേക്ക് നീക്കുക</translation>
+<translation id="7481312909269577407">മുന്നോട്ട്</translation>
+<translation id="4084682180776658562">ബുക്മാര്‍ക്ക്</translation>
+<translation id="6437478888915024427">പേജ് വിവരം</translation>
+<translation id="7180611975245234373">പുതുക്കുക</translation>
+<translation id="4913169188695071480">പുതുക്കിയെടുക്കുന്നത് നിർത്തുക</translation>
+<translation id="1829244130665387512">പേജില്‍ കണ്ടുപിടിക്കുക</translation>
+<translation id="6593061639179217415">ഡെസ്‌ക്‌ടോപ്പ് സൈറ്റ്</translation>
+<translation id="9063523880881406963">'ഡെസ്‌ക്‌ടോപ്പ് സൈറ്റ് അഭ്യർത്ഥിക്കുക' ഓഫാക്കുക</translation>
+<translation id="2038563949887743358">'ഡെസ്‌ക്‌ടോപ്പ് സൈറ്റ് അഭ്യർത്ഥിക്കുക' ഓണാക്കുക</translation>
+<translation id="2433507940547922241">കാഴ്ച്ച</translation>
+<translation id="983192555821071799">എല്ലാ ടാബുകളും അടയ്‌ക്കുക</translation>
+<translation id="1310482092992808703">ടാബുകൾ ഗ്രൂപ്പ് ചെയ്യൂ</translation>
+<translation id="7725024127233776428">നിങ്ങൾ ബുക്ക്‌മാർക്ക് ചെയ്യുന്ന പേജുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
+<translation id="4404568932422911380">ബുക്ക്‌മാർക്കുകളൊന്നുമില്ല</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> ബുക്ക്‌മാർക്ക്}other{<ph name="BOOKMARKS_COUNT_MANY"/> ബുക്ക്‌മാർക്കുകൾ}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> എന്നതിൽ ബുക്ക്‌മാർക്ക് ചെയ്‌തു</translation>
+<translation id="3207960819495026254">ബുക്ക്‌മാർക്കുചെയ്‌തു</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> ഫോൾഡറിലേക്ക് ബുക്ക്മാർക്ക് ചെയ്‌തു</translation>
+<translation id="8063895661287329888">ബുക്ക്മാർക്ക് ചേർക്കാനായില്ല.</translation>
+<translation id="2842985007712546952">പാരന്റ് ഫോൾഡർ</translation>
+<translation id="9065203028668620118">എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="4405224443901389797">ഇതിലേക്ക് നീക്കുക…</translation>
+<translation id="5170568018924773124">ഫോള്‍ഡറില്‍ കാണിക്കുക</translation>
+<translation id="8035133914807600019">പുതിയ ഫോൾഡർ…</translation>
+<translation id="4532845899244822526">ഫോൾഡർ തിരഞ്ഞെടുക്കുക</translation>
+<translation id="6627583120233659107">ഫോൾഡർ എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="1197267115302279827">ബു‌ക്ക്‌മാർക്കുകൾ നീക്കുക</translation>
+<translation id="6963766334940102469">ബുക്ക്‌മാർക്കുകൾ ഇല്ലാതാക്കുക</translation>
+<translation id="4351244548802238354">ഡയലോഗ് അടയ്‌ക്കുക</translation>
+<translation id="451872707440238414">ബുക്ക്‌മാർക്കുകൾ തിരയുക</translation>
+<translation id="8901170036886848654">ബുക്ക്‌മാർക്കുകളൊന്നും കണ്ടെത്തിയില്ല</translation>
+<translation id="6404511346730675251">ബുക്ക്‌മാർക്ക് എഡിറ്റ് ചെയ്യുക</translation>
+<translation id="3894427358181296146">ഫോൾഡർ ചേർക്കുക</translation>
+<translation id="5327248766486351172">പേര്</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">ഫോൾഡർ</translation>
+<translation id="5161254044473106830">പേര് ആവശ്യമാണ്</translation>
+<translation id="2996809686854298943">URL ആവശ്യമാണ്</translation>
+<translation id="2536728043171574184">ഈ പേജിന്റെ ഒരു ഓഫ്‌ലൈൻ പതിപ്പ് കാണുന്നു</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> ആപ്പിൽ ഓഫ്‌ലൈനായി കാണുക</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ഡൊമെയ്‌നും കൂടുതൽ സൈറ്റുകളും</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{നിങ്ങളുടെ പേജ് തയ്യാറാകുമ്പോൾ Brave ലോഡ് ചെയ്യും}other{നിങ്ങളുടെ പേജുകൾ തയ്യാറാകുമ്പോൾ Brave ലോഡ് ചെയ്യും}}</translation>
+<translation id="6811034713472274749">പേജ്, കാണാൻ തയ്യാറാണ്</translation>
+<translation id="4561979708150884304">കണക്ഷൻ ഇല്ല</translation>
+<translation id="8274165955039650276">ഡൗൺലോഡുകൾ കാണുക</translation>
+<translation id="2082238445998314030"><ph name="RESULT_NUMBER"/> / <ph name="TOTAL_RESULTS"/> ഫലം</translation>
+<translation id="4943872375798546930">ഫലങ്ങളൊന്നുമില്ല</translation>
+<translation id="981121421437150478">ഓഫ്‌ലൈൻ</translation>
+<translation id="3298243779924642547">ലൈറ്റ്</translation>
+<translation id="393697183122708255">പ്രവർത്തനക്ഷമമാക്കിയ വോയ്‌സ് തിരയലുകൾ ഒന്നും ലഭ്യമല്ല</translation>
+<translation id="7191430249889272776">ടാബ് പശ്ചാത്തലത്തിൽ തുറന്നു.</translation>
+<translation id="8445059357334030806">Brave-ൽ തുറക്കുക</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/>-ൽ തുറക്കുക</translation>
+<translation id="7022756207310403729">ബ്രൗസറിൽ തുറക്കുക</translation>
+<translation id="1113597929977215864">ലളിതവൽക്കരിച്ച കാഴ്‌ച കാണിക്കുക</translation>
+<translation id="1513352483775369820">ബുക്ക്‌മാർക്കുകളും വെബ് ചരിത്രവും</translation>
+<translation id="4939482511480190003">Brave മെച്ചപ്പെടുത്താൻ സഹായിക്കുക. <ph name="BEGIN_LINK"/>സർവേയിൽ പങ്കെടുക്കുക.<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">പിന്നോട്ട് പോകുക</translation>
+<translation id="5596627076506792578">കൂടുതൽ‍ ഓപ്‌ഷനുകൾ</translation>
+<translation id="3522247891732774234">അപ്‌ഡേറ്റ് ലഭ്യമല്ല. കൂടുതൽ ഓപ്‌ഷനുകൾ</translation>
+<translation id="6773423637732432200">Brave അപ്‌ഡേറ്റ് ചെയ്യാനാവില്ല. കൂടുതൽ ഓപ്‌ഷനുകൾ</translation>
+<translation id="3328801116991980348">സൈറ്റ് വിവരങ്ങള്‍</translation>
+<translation id="5391532827096253100">ഈ സൈറ്റിലേക്കുള്ള നിങ്ങളുടെ കണക്ഷൻ സുരക്ഷിതമല്ല. സൈറ്റ് വിവരങ്ങള്‍</translation>
+<translation id="6206551242102657620">കണക്ഷൻ സുരക്ഷിതമാണ്. സൈറ്റ് വിവരങ്ങള്‍</translation>
+<translation id="6963642900430330478">ഈ പേജ് അപകടകരമാണ്. സൈറ്റ് വിവരങ്ങള്‍</translation>
+<translation id="9070377983101773829">ശബ്ദ തിരയൽ ആരംഭിക്കുക</translation>
+<translation id="8676374126336081632">ഇൻപുട്ട് മായ്‌ക്കുക</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> ടാബ് തുറന്നിരിക്കുന്നു, ടാബുകൾ മാറാനായി ടാപ്പ് ചെയ്യുക}other{<ph name="OPEN_TABS_MANY"/> ടാബുകൾ തുറന്നിരിക്കുന്നു, മാറാനായി ടാപ്പ് ചെയ്യുക}}</translation>
+<translation id="2369533728426058518">ഓപ്പൺ ടാബുകൾ</translation>
+<translation id="7071521146534760487">അക്കൗണ്ട് മാനേജ് ചെയ്യുക</translation>
+<translation id="932327136139879170">ഹോം</translation>
+<translation id="2707726405694321444">പേജ് പുതുക്കുക</translation>
+<translation id="2891154217021530873">പേജ് ലോഡുചെയ്യുന്നത് നിർത്തുക</translation>
+<translation id="6710213216561001401">മുമ്പത്തേത്</translation>
+<translation id="6659594942844771486">ടാബ്</translation>
+<translation id="1933845786846280168">തിരഞ്ഞെടുത്ത ടാബ്</translation>
+<translation id="2268044343513325586">പരിഷ്‌ക്കരിക്കുക</translation>
+<translation id="7846076177841592234">തിരഞ്ഞെടുത്തത് റദ്ദാക്കുക</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> എണ്ണം തിരഞ്ഞെടുത്തു. സ്‌ക്രീനിന്റെ മുകളിലുള്ള ഭാഗത്തിന് സമീപം ഓപ്‌ഷനുകൾ ലഭ്യമാണ്</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> എണ്ണം തിരഞ്ഞെടുത്തു</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{തിരഞ്ഞെടുത്ത ഒരു ഇനം പങ്കിടുക}other{തിരഞ്ഞെടുത്ത # ഇനങ്ങൾ പങ്കിടുക}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{തിരഞ്ഞെടുത്ത ഒരു ഇനം നീക്കംചെയ്യുക}other{തിരഞ്ഞെടുത്ത # ഇനങ്ങൾ നീക്കംചെയ്യുക}}</translation>
+<translation id="1283039547216852943">വികസിപ്പിക്കാൻ ടാപ്പ് ചെയ്യുക</translation>
+<translation id="5962718611393537961">ചുരുക്കാൻ ടാപ്പ് ചെയ്യുക</translation>
+<translation id="8076492880354921740">ടാബുകള്‍‌</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 തിരഞ്ഞെടുത്തു}other{# തിരഞ്ഞെടുത്തു}}</translation>
+<translation id="6818926723028410516">ഇനങ്ങൾ തിരഞ്ഞെടുക്കുക</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/> എന്നതിലേക്ക് മടങ്ങാൻ സ്‌പർശിക്കുക</translation>
+<translation id="6766758767654711248">സൈറ്റിലേക്ക് പോകാൻ ടാപ്പ് ചെയ്യുക</translation>
+<translation id="429312253194641664">സൈറ്റ്, മീഡിയ പ്ലേ ചെയ്യുന്നു</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> നിങ്ങളുടെ സ്‌ക്രീൻ പങ്കിടുന്നു</translation>
+<translation id="8833831881926404480">ഒരു സൈറ്റ് നിങ്ങളുടെ സ്‌ക്രീൻ പങ്കിടുന്നു</translation>
+<translation id="9086455579313502267">നെറ്റ്‌വർക്ക് ആക്സസ് ചെയ്യാനാകുന്നില്ല</translation>
+<translation id="938850635132480979">പിശക്: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/>-ൽ തുറക്കുക</translation>
+<translation id="548278423535722844">മാപ്‌സ് ആപ്പിൽ തുറക്കുക</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> ആപ്പിൽ ഇമെയിൽ സൃഷ്‌ടിക്കുക</translation>
+<translation id="7875915731392087153">ഇമെയിൽ സൃഷ്‌ടിക്കുക</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> ആപ്പിൽ ഇവന്റ് സൃഷ്‌ടിക്കുക</translation>
+<translation id="2900528713135656174">ഇവന്റ് സൃഷ്‌ടിക്കുക</translation>
+<translation id="2111511281910874386">പേജിലേക്ക് പോകുക</translation>
+<translation id="3988466920954086464">വേഗത്തിലുള്ള തിരയൽ ഫലങ്ങൾ ഈ പാനലിൽ കാണുക</translation>
+<translation id="2744248271121720757">പെട്ടെന്ന് തിരയാനോ ബന്ധപ്പെട്ട പ്രവർത്തനങ്ങൾ കാണാനോ ഒരു വാക്കിൽ ടാപ്പ് ചെയ്യുക</translation>
+<translation id="9155898266292537608">ഒരു വാക്കിൽ പെട്ടെന്ന് ടാപ്പ് ചെയ്‌തും നിങ്ങൾക്ക് തിരയാൻ കഴിയും</translation>
+<translation id="3232754137068452469">വെബ് ആപ്പ്</translation>
+<translation id="1430915738399379752">അച്ചടിക്കുക</translation>
+<translation id="3775705724665058594">നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് അയയ്‌ക്കുക</translation>
+<translation id="6364438453358674297">ചരിത്രത്തിൽ നിന്ന് നിർദ്ദേശം നീക്കംചെയ്യണോ?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> അടച്ചു</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> ടാബുകൾ അടച്ചു</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> ഇല്ലാതാക്കി</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> ബുക്ക്‌മാർക്കുകൾ ഇല്ലാതാക്കി</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> ഡൗൺലോഡുകൾ ഇല്ലാതാക്കി</translation>
+<translation id="1248710015876067820">പിന്തുണയ്‌ക്കാത്തത്ര Brave പതിപ്പുകൾ</translation>
+<translation id="4259722352634471385">നാവിഗേഷൻ തടഞ്ഞിരിക്കുന്നു: <ph name="URL"/></translation>
+<translation id="8959122750345127698">നാവിഗേഷൻ ലഭ്യമല്ല: <ph name="URL"/></translation>
+<translation id="5210365745912300556">ടാബ് അടയ്ക്കൂക</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> അടയ്‌ക്കുക</translation>
+<translation id="1227058898775614466">നാവിഗേഷന്‍ ചരിത്രം</translation>
+<translation id="9169507124922466868">നാവിഗേഷൻ ചരിത്രം പകുതിയായി തുറന്നിരിക്കുന്നു</translation>
+<translation id="1327257854815634930">നാവിഗേഷൻ ചരിത്രം തുറന്നിരിക്കുന്നു</translation>
+<translation id="8788265440806329501">നാവിഗേഷന്‍ ചരിത്രം അടച്ചു</translation>
+<translation id="7482656565088326534">പ്രിവ്യു ടാബ്</translation>
+<translation id="8427875596167638501">പ്രിവ്യു ടാബ് പാതി തുറന്നിരിക്കുന്നു</translation>
+<translation id="9102803872260866941">പ്രിവ്യു ടാബ് തുറന്നു</translation>
+<translation id="2942036813789421260">പ്രിവ്യു ടാബ് അടച്ചു</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> സ്‌റ്റോറേജ്</translation>
+<translation id="3822502789641063741">സൈറ്റ് സ്‌റ്റോറേജ് മായ്‌ക്കണോ?</translation>
+<translation id="9205995714227143200">Brave, സൈറ്റ് സ്‌റ്റോറേജിനെ പ്രധാനപ്പെട്ടതായി കണക്കാക്കുന്നില്ല (ഉദാ: ക്രമീകരണം സംരക്ഷിച്ചിട്ടില്ലാത്തതോ നിങ്ങൾ ഇടയ്‌ക്കിടെ സന്ദർശിക്കാത്തതോ ആയ സൈറ്റുകൾ)</translation>
+<translation id="3997476611815694295">പ്രധാനമല്ലാത്ത സ്‌റ്റോറേജ്</translation>
+<translation id="8493948351860045254">ഇടം സൃഷ്‌ടിക്കുക</translation>
+<translation id="2324920234469020158">ഇത്, Brave പ്രധാനമായി കണക്കാക്കാത്ത സൈറ്റുകളുടെ കുക്കികളും കാഷെയും മറ്റ് വിവരങ്ങളും മായ്‌ക്കും.</translation>
+<translation id="5447201525962359567">കുക്കികളും പ്രാദേശികമായി സംഭരിച്ച മറ്റ് വിവരങ്ങളും ഉൾപ്പെടെയുള്ള എല്ലാ സൈറ്റ് സ്‌റ്റോറേജും</translation>
+<translation id="1376578503827013741">കണക്കാക്കുന്നു…</translation>
+<translation id="583281660410589416">അജ്ഞാതം</translation>
+<translation id="2323763861024343754">സൈറ്റ് സ്‌റ്റോറേജ്</translation>
+<translation id="3587672679800759167">അക്കൗണ്ടുകളും ബുക്ക്‌മാർക്കുകളും സംരക്ഷിച്ച ക്രമീകരണവും ഉൾപ്പെടെ Brave ഉപയോഗിക്കുന്ന മൊത്തം വിവരങ്ങൾ</translation>
+<translation id="6545017243486555795">എല്ലാ വിവരങ്ങളും മായ്‌ക്കുക</translation>
+<translation id="4095146165863963773">ആപ്പ് ഡാറ്റ ഇല്ലാതാക്കണോ?</translation>
+<translation id="53119194224775367">Brave-ന്റെ എല്ലാ ആപ്പ് വിവരങ്ങളും ശാശ്വതമായി ഇല്ലാതാക്കും. ഇതിൽ എല്ലാ ഫയലുകളും ക്രമീകരണവും അക്കൗണ്ടുകളും ഡാറ്റാബേസുകളും മറ്റും ഉൾപ്പെടുന്നു.</translation>
+<translation id="5307446750509046227">സൈറ്റ് സംഭരണം മായ്ക്കൂ</translation>
+<translation id="300526633675317032">ഇത് വെബ്‌സൈറ്റ് സ്‌റ്റോറേജിലെ <ph name="SIZE_IN_KB"/> പൂർണ്ണമായും മായ്‌ക്കും.</translation>
+<translation id="8068648041423924542">സർട്ടിഫിക്കറ്റ് തിരഞ്ഞെടുക്കാനാവുന്നില്ല.</translation>
+<translation id="2315043854645842844">ഓപ്പറേറ്റിംഗ് സിസ്റ്റം ക്ലയന്റിന്റെ സർട്ടിഫിക്കറ്റ് തിരഞ്ഞെടുക്കലിനെ പിന്തുണയ്‌ക്കുന്നില്ല.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> കണക്‌റ്റുചെയ്യാൻ താൽപ്പര്യപ്പെടുന്നു</translation>
+<translation id="5308380583665731573">കണക്‌റ്റുചെയ്യുക</translation>
+<translation id="868929229000858085">നിങ്ങളുടെ കോൺടാക്‌റ്റുകൾ തിരയുക</translation>
+<translation id="1919950603503897840">കോൺടാക്റ്റുകൾ തിരഞ്ഞെടുക്കുക</translation>
+<translation id="7986741934819883144">ഒരു കോൺടാക്റ്റ് തിരഞ്ഞെടുക്കുക</translation>
+<translation id="3333961966071413176">എല്ലാ കോൺടാക്റ്റുകളും</translation>
+<translation id="4994033804516042629">കോൺടാക്റ്റുകളൊന്നും കണ്ടെത്തിയില്ല</translation>
+<translation id="5403592356182871684">പേരുകൾ</translation>
+<translation id="2717722538473713889">ഇമെയിൽ വിലാസങ്ങൾ</translation>
+<translation id="381841723434055211">ഫോൺ നമ്പറുകൾ</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ ഒരെണ്ണം കൂടി)}other{(+ # എണ്ണം കൂടി)}}</translation>
+<translation id="5197729504361054390">നിങ്ങൾ തിരഞ്ഞെടുക്കുന്ന കോൺടാക്‌റ്റുകൾ <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> എന്ന സൈറ്റുമായി പങ്കിടും.</translation>
+<translation id="1779089405699405702">ഇമേജ് ഡീകോഡർ</translation>
+<translation id="8067883171444229417">വീഡിയോ പ്ലേ ചെയ്യുക</translation>
+<translation id="6560414384669816528">Sogou ഉപയോഗിച്ച് തിരയുക</translation>
+<translation id="5406914950576900927"><ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> ഉപയോഗിച്ച് Brave-ന് ചൈനയിൽ തിരയാനാവും. നിങ്ങൾക്കിത്‌ <ph name="BEGIN_LINK"/>ക്രമീകരണത്തിൽ<ph name="END_LINK"/> മാറ്റാനാവും.</translation>
+<translation id="6456271171669383967">Brave Software ഉപയോഗിക്കുക</translation>
+<translation id="4384468725000734951">തിരയാൻ Sogou ഉപയോഗിക്കുന്നു</translation>
+<translation id="6103327872225198548">തിരയാൻ Brave Software ഉപയോഗിക്കുന്നു</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Brave-ൽ ഈ ആപ്പ് റൺ ചെയ്യുന്നു</translation>
+<translation id="6143689084714664628">Brave-ൽ റൺ ചെയ്യുന്നു</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> എന്നതിനും Brave-ൽ ഡാറ്റയുണ്ടായിരുന്നു</translation>
+<translation id="2734140769649165081">Brave ക്രമീകരണത്തിൽ നിങ്ങൾക്ക് ഈ ഡാറ്റ മായ്‌ക്കാം</translation>
+<translation id="8232956427053453090">ഡാറ്റ സൂക്ഷിക്കുക</translation>
+<translation id="4298388696830689168">ലിങ്ക് ചെയ്‌ത സൈറ്റുകൾ</translation>
+<translation id="5763514718066511291">ഈ ആപ്പിനായുള്ള URL പകർത്താൻ ടാപ്പ് ചെയ്യുക</translation>
+<translation id="6496823230996795692"><ph name="APP_NAME"/> ആദ്യമായി ഉപയോഗിക്കാൻ, ഇന്‍റര്‍നെറ്റിലേക്ക് കണക്റ്റുചെയ്യുക.</translation>
+<translation id="751961395872307827">സൈറ്റിലേക്ക് കണ‌ക്‌റ്റ് ചെയ്യാനാവുന്നില്ല</translation>
+<translation id="4878404682131129617">പ്രോക്‌സി സെർവർ മുഖേന ഒരു ടണൽ രൂപപ്പെടുത്താനായില്ല</translation>
+<translation id="4749960740855309258">പുതിയൊരു ടാബ് തുറക്കുക</translation>
+<translation id="8788968922598763114">അവസാനം അടച്ച ടാബ് വീണ്ടും തുറക്കുക</translation>
+<translation id="7929962904089429003">മെനു തുറക്കുക</translation>
+<translation id="6039379616847168523">അടുത്ത ടാബിലേക്ക് പോകുക</translation>
+<translation id="5210286577605176222">മുമ്പത്തെ ടാബിലേക്ക് പോകുക</translation>
+<translation id="124678866338384709">നിലവിലെ ടാബ് അടയ്‌ക്കുക</translation>
+<translation id="3714981814255182093">കണ്ടെത്തൽ ബാർ തുറക്കുക</translation>
+<translation id="5441522332038954058">വിലാസ ബാറിലേക്ക് പോകുക</translation>
+<translation id="3398320232533725830">ബുക്ക്‌മാർക്കുകൾ മാനേജർ തുറക്കുക</translation>
+<translation id="6583199322650523874">നിലവിലെ പേജ് ബുക്ക്‌മാർക്ക് ചെയ്യുക</translation>
+<translation id="8489271220582375723">ചരിത്ര പേജ് തുറക്കുക</translation>
+<translation id="4837753911714442426">പേജ് അച്ചടിക്കുന്നതിനുള്ള ഓപ്‌ഷനുകൾ തുറക്കുക</translation>
+<translation id="5726692708398506830">പേജിൽ എല്ലാം വലുതായി നൽകുക</translation>
+<translation id="3259831549858767975">പേജിൽ എല്ലാം ചെറുതായി നൽകുക</translation>
+<translation id="8015452622527143194">പേജിലുള്ളതെല്ലാം ഡിഫോൾട്ട് വലുപ്പത്തിലേക്ക് മാറ്റുക</translation>
+<translation id="3443221991560634068">നിലവിലെ പേജ് റീലോഡ് ചെയ്യുക</translation>
+<translation id="123724288017357924">കാഷെ ചെയ്‌ത ഉള്ളടക്കം ഒഴിവാക്കി കൊണ്ട്, നിലവിലെ പേജ് റീലോഡ് ചെയ്യുക</translation>
+<translation id="305870044889644984">പുതിയ ടാബിൽ Brave സഹായകേന്ദ്രം തുറക്കുക</translation>
+<translation id="3166827708714933426">ടാബ്, വിൻഡോ കുറുക്കുവഴികൾ</translation>
+<translation id="3169981355900570544">Brave Software Brave ഫീച്ചർ കുറുക്കുവഴികൾ</translation>
+<translation id="4558311620361989323">വെബ്‌പേജ് കുറുക്കുവഴികൾ</translation>
+<translation id="1908301351964700579">Brave ഇപ്പോഴും VR-നായി തയ്യാറെടുത്തുകൊണ്ടിരിക്കുകയാണ്. Brave പിന്നീട് റീസ്‌റ്റാർട്ട് ചെയ്യുക.</translation>
+<translation id="8970887620466824814">എന്തോ കുഴപ്പമുണ്ടായി.</translation>
+<translation id="1875543012935658554">Brave വീണ്ടും തുറക്കുക.</translation>
+<translation id="79859296434321399">അനുബന്ധ യാഥാർത്ഥ്യ ഉള്ളടക്കം കാണാൻ, ARCore ഇൻസ്‌റ്റാൾ ചെയ്യൂ</translation>
+<translation id="8558485628462305855">അനുബന്ധ യാഥാർത്ഥ്യ ഉള്ളടക്കം കാണാൻ, ARCore അപ്‌ഡേറ്റ് ചെയ്യൂ</translation>
+<translation id="3513704683820682405">അനുബന്ധയാഥാർത്ഥ്യം</translation>
+<translation id="5475862044948910901">അനുബന്ധയാഥാർത്ഥ്യ സെഷൻ ആരംഭിക്കണോ?</translation>
 <translation id="7365126855094612066">ഈ സെഷൻ്റെ ദൈർഘ്യത്തിനായി സൈറ്റിന് ഇവ ചെയ്യാനാകും:
 • നിങ്ങളുടെ പരിതസ്ഥിതിയുടെ ഒരു 3D മാപ്പ് സൃഷ്‌ടിക്കുക
 • ക്യാമറയുടെ ചലനം ട്രാക്ക് ചെയ്യുക
 
 സൈറ്റ് ക്യാമറയിലേക്ക് ആക്‌സസ് നേടില്ല. ക്യാമറയിലെ ചിത്രങ്ങൾ നിങ്ങൾക്ക് മാത്രമേ ദൃശ്യമാകൂ.</translation>
-<translation id="7375125077091615385">തരം:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome ആദ്യ പ്രവർത്തന അനുഭവം</translation>
-<translation id="741204030948306876">ഞാൻ തയ്യാറാണ്</translation>
-<translation id="7413229368719586778">ആരംഭിക്കുന്ന തീയതി <ph name="DATE" /></translation>
-<translation id="7423098979219808738">ആദ്യതവണ ചോദിക്കുക</translation>
-<translation id="7423538860840206698">ക്ലിപ്പ്ബോർഡ് റീഡ് ചെയ്യുന്നതിൽ നിന്ന് ബ്ലോക്ക് ചെയ്‌തു</translation>
-<translation id="7431991332293347422">തിരയലും മറ്റും വ്യക്തിപരമാക്കുന്നതിന് നിങ്ങളുടെ ബ്രൗസിംഗ് ചരിത്രം ഉപയോഗിക്കുന്ന വിധം നിയന്ത്രിക്കുക</translation>
-<translation id="7437998757836447326">Chrome-ൽ നിന്നും സൈൻ ഔട്ട് ചെയ്യുക</translation>
-<translation id="7438641746574390233">ലൈറ്റ് മോഡ് ഓണായിരിക്കുമ്പോൾ, പേജുകൾ കൂടുതൽ വേഗത്തിൽ ലോഡ് ചെയ്യുന്ന തരത്തിലാക്കാൻ Google സെര്‍വറുകൾ Chrome ഉപയോഗിക്കുന്നു. വേഗത വളരെ കുറഞ്ഞ പേജുകളിൽ അത്യാവശ്യ ഉള്ളടക്കം മാത്രം ലോഡ് ചെയ്യാൻ, ലൈറ്റ് മോഡ് പേജ് മാറ്റി എഴുതുന്നു. അദൃശ്യ ടാബുകളിൽ ലൈറ്റ് മോഡ് ബാധകമാവില്ല.</translation>
-<translation id="7444811645081526538">കൂടുതൽ‍ വിഭാഗങ്ങള്‍</translation>
-<translation id="7445411102860286510">മ്യൂട്ടുചെയ്‌ത വീഡിയോകൾ സ്വയം പ്ലേ ചെയ്യാൻ സൈറ്റുകളെ അനുവദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="7453467225369441013">നിങ്ങൾ മിക്ക സൈറ്റുകളിൽ നിന്നും സൈൻ ഔട്ടാകും. നിങ്ങൾ Google അക്കൗണ്ടിൽ നിന്ന് സൈൻ ഔട്ട് ആകില്ല.</translation>
-<translation id="7454641608352164238">വേണ്ടത്ര ഇടമില്ല</translation>
-<translation id="7475192538862203634">നിങ്ങൾ ഇത് പതിവായി കാണുന്നുണ്ടെങ്കിൽ, ഈ <ph name="BEGIN_LINK" />നിർദ്ദേശങ്ങൾ<ph name="END_LINK" /> പരീക്ഷിക്കൂ.</translation>
-<translation id="7475688122056506577">SD കാർഡ് കണ്ടെത്തിയില്ല. നിങ്ങളുടെ ചില ഫയലുകൾ നഷ്‌ടപ്പെട്ടേക്കാം.</translation>
-<translation id="7479104141328977413">ടാബ് മാനേജ്മെൻ്റ്</translation>
-<translation id="7481312909269577407">മുന്നോട്ട്</translation>
-<translation id="7482656565088326534">പ്രിവ്യു ടാബ്</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (അപ്‌ഡേറ്റുചെയ്‌തു, <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">ലാഭിച്ച ഡാറ്റ</translation>
-<translation id="7498271377022651285">കാത്തിരിക്കുക...</translation>
-<translation id="7514365320538308">ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="751961395872307827">സൈറ്റിലേക്ക് കണ‌ക്‌റ്റ് ചെയ്യാനാവുന്നില്ല</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">നിർദ്ദേശങ്ങൾ സ്വീകരിക്കാനാവില്ല</translation>
-<translation id="7559975015014302720">ലൈറ്റ് മോഡ് ഓഫാണ്</translation>
-<translation id="7562080006725997899">ബ്രൗസിംഗ് ഡാറ്റ മായ്‌ക്കൽ</translation>
-<translation id="756809126120519699">Chrome ഡാറ്റ മായ്‌ച്ചു</translation>
-<translation id="757524316907819857">പരിരക്ഷിത ഉള്ളടക്കം പ്ലേ ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> ഫയൽ ഡൗൺലോഡ് ചെയ്‌തു}other{<ph name="FILES_DOWNLOADED_MANY" /> ഫയലുകൾ ഡൗൺലോഡ് ചെയ്‌തു}}</translation>
-<translation id="7588219262685291874">ഉപകരണത്തിൻ്റെ ബാറ്ററി ലാഭിക്കൽ ഓണായിരിക്കുമ്പോൾ ഇരുണ്ട തീം ഓണാക്കുക</translation>
-<translation id="7589445247086920869">നിലവിലെ തിരയൽ യന്ത്രത്തിന് ബ്ലോക്ക് ചെയ്യുക</translation>
-<translation id="7593557518625677601">Chrome സമന്വയം ആരംഭിക്കാൻ Android ക്രമീകരണം തുറന്ന് Android സിസ്‌റ്റം സമന്വയിപ്പിക്കൽ വീണ്ടും പ്രവർത്തനക്ഷമമാക്കുക</translation>
-<translation id="7596558890252710462">ഓപ്പറേറ്റിംഗ് സിസ്റ്റം</translation>
-<translation id="7605594153474022051">സമന്വയിപ്പിക്കൽ പ്രവർത്തിക്കുന്നില്ല</translation>
-<translation id="7606077192958116810">ലൈറ്റ് മോഡ് ഓണാണ്. ഇത് ക്രമീകരണത്തിൽ മാനേജ് ചെയ്യുക.</translation>
-<translation id="7612619742409846846">ഇനി പറയുന്നതിൽ നിന്നും Google-ലേക്ക് സൈൻ ഇൻ ചെയ്‌തു</translation>
-<translation id="7619072057915878432">നെറ്റ്‌വർക്ക് പരാജയം കാരണം <ph name="FILE_NAME" /> ഡൗൺലോഡ് ചെയ്യാനായില്ല.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />സഹായം തേടുക<ph name="END_LINK1" /> അല്ലെങ്കിൽ <ph name="BEGIN_LINK2" />വീണ്ടും സ്‌കാൻ ചെയ്യുക<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome-ലേക്ക് സ്വാഗതം</translation>
-<translation id="7638584964844754484">പാസ്‌ഫ്രെയ്‌സ് തെറ്റാണ്</translation>
-<translation id="7641339528570811325">ബ്രൗസിംഗ് ഡാറ്റ മായ്‌ക്കുക...</translation>
-<translation id="7648422057306047504">Google ക്രെഡെൻഷ്യലുകൾ ഉപയോഗിച്ച് പാസ്‌വേഡുകൾ എൻക്രിപ്റ്റ് ചെയ്യുക</translation>
-<translation id="7649070708921625228">സഹായം</translation>
-<translation id="7658239707568436148">റദ്ദാക്കൂ</translation>
-<translation id="7665369617277396874">അക്കൗണ്ട് ചേർക്കുക</translation>
-<translation id="766587987807204883">ഇവിടെ ദൃശ്യമാകുന്ന ലേഖനങ്ങൾ നിങ്ങൾ ഓഫ്‌ലൈൻ ആകുന്ന സമയത്ത് പോലും വായിക്കാം</translation>
-<translation id="7682724950699840886">ഈ നുറുങ്ങുകൾ പരീക്ഷിക്കൂ: നിങ്ങളുടെ ഉപകരണത്തിൽ ആവശ്യമായ ഇടം ഉണ്ടെന്ന് ഉറപ്പാക്കി, വീണ്ടും എക്‌സ്‌പോർട്ട് ചെയ്യാൻ ശ്രമിക്കുക.</translation>
-<translation id="7685301384041462804">VR-ൽ പ്രവേശിക്കുന്നതിന് മുമ്പ് ഈ സൈറ്റിനെ നിങ്ങൾ വിശ്വസിക്കുന്നുണ്ടെന്ന് തീർച്ചപ്പെടുത്തുക.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> ആപ്പിൽ ഇമെയിൽ സൃഷ്‌ടിക്കുക</translation>
-<translation id="7704317875155739195">സ്വമേധയാ പൂർത്തിയാക്കുന്ന തിരയലുകളും URL-കളും</translation>
-<translation id="7725024127233776428">നിങ്ങൾ ബുക്ക്‌മാർക്ക് ചെയ്യുന്ന പേജുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
-<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE" /> ഭാഷയിലുള്ള പേജുകൾ എപ്പോഴും വിവർത്തനം ചെയ്യുക</translation>
-<translation id="7746457520633464754">അപകടകരമായ ആപ്പുകളും സൈറ്റുകളും കണ്ടെത്തുന്നതിന്, നിങ്ങൾ സന്ദർശിക്കുന്ന ചില പേജുകളുടെ URL, പരിമിത സിസ്റ്റം വിവരങ്ങൾ, ചില പേജ് ഉള്ളടക്കം എന്നിവ Chrome Google-ന് അയയ്ക്കുന്നു</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> ഉപകരണത്തിൽ നിന്ന് പങ്കിട്ട ടെക്‌സ്റ്റ്</translation>
-<translation id="7762668264895820836">SD കാർഡ് <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">വിലാസം ചേർക്കുക</translation>
-<translation id="7772032839648071052">പാസ്ഫ്രേസ് സ്ഥിരീകരിക്കുക</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> അടയ്‌ക്കുക</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> പേയ്‌മെന്റ് രീതികളും}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 എന്നതും ‌മറ്റ് <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> പേയ്‌മെന്റ് രീതികളും}}</translation>
-<translation id="7781829728241885113">ഇന്നലെ</translation>
-<translation id="7791543448312431591">ചേര്‍ക്കൂ</translation>
-<translation id="780301667611848630">വേണ്ട നന്ദി</translation>
-<translation id="7810647596859435254">ഇത് ഉപയോഗിച്ച് തുറക്കുക...</translation>
-<translation id="7821588508402923572">നിങ്ങൾ ലാഭിച്ച ഡാറ്റ ഇവിടെ ദൃശ്യമാവും</translation>
-<translation id="7837721118676387834">ഒരു നിർദ്ദിഷ്‌ട സൈറ്റിന്റെ മ്യൂട്ട് ചെയ്‌ത വീഡിയോകൾ സ്വയം പ്ലേ ചെയ്യാൻ അനുവദിക്കുക.</translation>
-<translation id="7846076177841592234">തിരഞ്ഞെടുത്തത് റദ്ദാക്കുക</translation>
-<translation id="784934925303690534">സമയ ശ്രേണി</translation>
-<translation id="7851858861565204677">മറ്റ് ഉപകരണങ്ങൾ</translation>
-<translation id="7875915731392087153">ഇമെയിൽ സൃഷ്‌ടിക്കുക</translation>
-<translation id="7876243839304621966">എല്ലാം നീക്കംചെയ്യുക</translation>
-<translation id="7882131421121961860">ചരിത്രം കണ്ടില്ല</translation>
-<translation id="7882806643839505685">ഒരു പ്രത്യേക സൈറ്റിനായി ശബ്‌ദം അനുവദിക്കുക.</translation>
-<translation id="7886917304091689118">Chrome-ൽ റൺ ചെയ്യുന്നു</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ഫയൽ ഡൗൺലോഡ് ചെയ്യുന്നു.}other{# ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യുന്നു.}}</translation>
-<translation id="7929962904089429003">മെനു തുറക്കുക</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> കാലഹരണപ്പെട്ടതാണ്.</translation>
-<translation id="7947953824732555851">അംഗീകരിച്ച് സൈൻ ഇൻ ചെയ്യുക</translation>
-<translation id="7963646190083259054">വെണ്ടർ:</translation>
-<translation id="7971136598759319605">ഒരു ദിവസം മുമ്പ് സജീവമായിരുന്നു</translation>
-<translation id="7975379999046275268"><ph name="BEGIN_NEW" />പുതിയ<ph name="END_NEW" /> പേജ് പ്രിവ്യൂ ചെയ്യുക</translation>
-<translation id="7981313251711023384">കൂടുതൽ വേഗത്തിൽ ബ്രൗസ് ചെയ്യാനും തിരയാനും പേജുകൾ റീലോഡ് ചെയ്യുക</translation>
-<translation id="79859296434321399">അനുബന്ധ യാഥാർത്ഥ്യ ഉള്ളടക്കം കാണാൻ, ARCore ഇൻസ്‌റ്റാൾ ചെയ്യൂ</translation>
-<translation id="7986741934819883144">ഒരു കോൺടാക്റ്റ് തിരഞ്ഞെടുക്കുക</translation>
-<translation id="7987073022710626672">Chrome സേവന നിബന്ധനകൾ</translation>
-<translation id="7998918019931843664">അടച്ച ടാബ് വീണ്ടും തുറക്കുക</translation>
-<translation id="7999064672810608036">കുക്കികൾ ഉൾപ്പെടെ എല്ലാ പ്രാദേശിക വിവരവും മായ്‌ച്ച് ഈ വെബ്‌സൈറ്റിനായുള്ള എല്ലാ അനുമതികളും റീസെറ്റ് ചെയ്യാൻ താൽപ്പര്യമുണ്ടോ?</translation>
-<translation id="8004582292198964060">ബ്രൗസര്‍</translation>
-<translation id="8007176423574883786">ഈ ഉപകരണത്തിനായി ഓഫാക്കി</translation>
-<translation id="8013372441983637696">കൂടാതെ ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ Chrome ഡാറ്റ മായ്ക്കുക</translation>
-<translation id="8015452622527143194">പേജിലുള്ളതെല്ലാം ഡിഫോൾട്ട് വലുപ്പത്തിലേക്ക് മാറ്റുക</translation>
-<translation id="802154636333426148">ഡൗൺലോഡ് പരാജയപ്പെട്ടു</translation>
-<translation id="8026334261755873520">ബ്രൌസിംഗ് ഡാറ്റ മായ്‌ക്കുക</translation>
-<translation id="8035133914807600019">പുതിയ ഫോൾഡർ…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> ദിവസം ശേഷിക്കുന്നു</translation>
-<translation id="804335162455518893">SD കാർഡ് കണ്ടെത്തിയില്ല</translation>
-<translation id="805047784848435650">നിങ്ങളുടെ ബ്രൗസിംഗ്‌ ചരിത്രം അടിസ്ഥാനമാക്കിയുള്ളത്</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB ലഭ്യമാണ്</translation>
-<translation id="8058746566562539958">പുതിയ Chrome ടാബിൽ തുറക്കുക</translation>
-<translation id="8063895661287329888">ബുക്ക്മാർക്ക് ചേർക്കാനായില്ല.</translation>
-<translation id="806745655614357130">എന്റെ വിവരങ്ങൾ പ്രത്യേകം വേർതിരിച്ച് സൂക്ഷിക്കുക</translation>
-<translation id="8067883171444229417">വീഡിയോ പ്ലേ ചെയ്യുക</translation>
-<translation id="8068648041423924542">സർട്ടിഫിക്കറ്റ് തിരഞ്ഞെടുക്കാനാവുന്നില്ല.</translation>
-<translation id="8073388330009372546">പുതിയ ടാബിൽ ചിത്രം തുറക്കുക</translation>
-<translation id="8076492880354921740">ടാബുകള്‍‌</translation>
-<translation id="8084114998886531721">സംരക്ഷിച്ച പാസ്‌വേഡ്</translation>
-<translation id="8087000398470557479">ഈ ഉള്ളടക്കം Google-ൽ നിന്നുള്ള <ph name="DOMAIN_NAME" /> ഡൊമെയ്‌നിൽ നിന്നുള്ളതാണ്.</translation>
-<translation id="8103578431304235997">അദൃശ്യ ടാബ്</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ബുക്ക്‌മാർക്കുകൾ ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="8110087112193408731">ഡിജിറ്റൽ ആരോഗ്യത്തിൽ നിങ്ങളുടെ Chrome ആക്റ്റിവിറ്റി കാണിക്കണോ?</translation>
-<translation id="8116925261070264013">മ്യൂട്ടുചെയ്‌തു</translation>
-<translation id="813082847718468539">സൈറ്റ് വിവരങ്ങള്‍ കാണുക</translation>
-<translation id="8131740175452115882">സ്ഥിരീകരിക്കുക</translation>
-<translation id="8156139159503939589">ഏതൊക്കെ ഭാഷകൾ നിങ്ങൾക്ക് വായിക്കാനാകും?</translation>
-<translation id="8168435359814927499">ഉള്ളടക്കം</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> ഫയലുകൾ ശേഷിക്കുന്നു</translation>
-<translation id="8190358571722158785">ഒരു ദിവസം ശേഷിക്കുന്നു</translation>
-<translation id="8200772114523450471">പുനരാരംഭിക്കുക</translation>
-<translation id="8209050860603202033">ചിത്രം തുറക്കുക</translation>
-<translation id="8218622182176210845">നിങ്ങളുടെ അക്കൗണ്ട് മാനേജ് ചെയ്യുക</translation>
-<translation id="8224471946457685718">വൈഫൈ ഉപയോഗിച്ച് നിങ്ങൾക്കായി ലേഖനങ്ങൾ ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="8232956427053453090">ഡാറ്റ സൂക്ഷിക്കുക</translation>
-<translation id="8249310407154411074">മുകളിലേക്ക് നീക്കുക</translation>
-<translation id="8250920743982581267">ഡോക്യുമെന്റുകൾ</translation>
-<translation id="825412236959742607">ഈ പേജ് കൂടുതൽ മെമ്മറി ഉപയോഗിക്കുന്നു, അതിനാൽ Chrome കുറച്ച് ഉള്ളടക്കം നീക്കം ചെയ്‌തു.</translation>
-<translation id="8260126382462817229">വീണ്ടും സൈൻ ഇൻ ചെയ്യാൻ ശ്രമിക്കുക</translation>
-<translation id="8261506727792406068">ഇല്ലാതാക്കുക</translation>
-<translation id="8266862848225348053">ഡൗൺലോഡ് ലൊക്കേഷൻ</translation>
-<translation id="8274165955039650276">ഡൗൺലോഡുകൾ കാണുക</translation>
-<translation id="8284326494547611709">അടിക്കുറിപ്പുകൾ</translation>
-<translation id="8300705686683892304">ആപ്പ് മാനേജ് ചെയ്യുന്നത്</translation>
-<translation id="8310344678080805313">സ്റ്റാൻഡേർഡ് ടാബുകൾ</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ഡൊമെയ്‌നും കൂടുതൽ സൈറ്റുകളും</translation>
-<translation id="8327155640814342956">മികച്ച ബ്രൗസിംഗ് അനുഭവത്തിന് Chrome അപ്‌ഡേറ്റ് ചെയ്യുക</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" /> ഭാഷയിലുള്ള പേജുകൾ വിവർത്തനം ചെയ്യില്ല</translation>
-<translation id="8349013245300336738">ഉപയോഗിച്ച ഡാറ്റയുടെ അളവിനനുസരിച്ച് അടുക്കുക</translation>
-<translation id="8364299278605033898">ജനപ്രിയ വെബ്‌സൈറ്റുകൾ കാണുക</translation>
-<translation id="8368027906805972958">പരിചിതമല്ലാത്തതോ പിന്തുണയ്‌ക്കാത്തതോ ആയ ഉപകരണം (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">ഒരു പ്രത്യേക സൈറ്റിന് വേണ്ടി പശ്ചാത്തലം സമന്വയിപ്പിക്കൽ അനുവദിക്കുക.</translation>
-<translation id="8378714024927312812">നിങ്ങളുടെ സ്ഥാപനം മാനേജ് ചെയ്യുന്നത്</translation>
-<translation id="8380167699614421159">ഈ സൈറ്റ്, അനാവശ്യമോ തെറ്റിദ്ധരിപ്പിക്കുന്നതോ ആയ പരസ്യങ്ങള്‍ കാണിക്കുന്നു</translation>
-<translation id="8393700583063109961">സന്ദേശം അയയ്ക്കുക</translation>
-<translation id="8413126021676339697">മുഴുവന്‍ ചരിത്രവും കാണിക്കുക</translation>
-<translation id="8427875596167638501">പ്രിവ്യു ടാബ് പാതി തുറന്നിരിക്കുന്നു</translation>
-<translation id="8428213095426709021">ക്രമീകരണങ്ങള്‍</translation>
-<translation id="8438566539970814960">തിരയലുകളും ബ്രൗസിംഗും മികച്ചതാക്കുക</translation>
-<translation id="8441146129660941386">പുറകിലേക്ക് സീക്കുചെയ്യുക</translation>
-<translation id="8443209985646068659">Chrome അപ്‌ഡേറ്റ് ചെയ്യാനാവില്ല</translation>
-<translation id="8445448999790540984">പാസ്‌വേഡുകൾ എക്‌സ്‌പോർട്ട് ചെയ്യാനാവുന്നില്ല</translation>
-<translation id="8447861592752582886">ഉപകരണ അനുമതി റദ്ദാക്കുക</translation>
-<translation id="8461694314515752532">നിങ്ങളുടെ സമന്വയ പാസ്‌ഫ്രെയ്‌സ് ഉപയോഗിച്ച്, സമന്വയിപ്പിച്ച ഡാറ്റ എൻക്രി‌പ്‌റ്റ് ചെയ്യുക</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> ഉപകരണം ഇന്റർനെറ്റിലേക്ക് കണക്‌റ്റ് ചെയ്‌തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ഓഫ്‌ലൈനില്‍ ലഭ്യമാണ്</translation>
-<translation id="8489271220582375723">ചരിത്ര പേജ് തുറക്കുക</translation>
-<translation id="8493948351860045254">ഇടം സൃഷ്‌ടിക്കുക</translation>
-<translation id="8497726226069778601">ഇതുവരെയും ഇവിടെ കാണാനായി ഒന്നുമില്ല...</translation>
-<translation id="8503559462189395349">Chrome പാസ്‌വേഡുകൾ</translation>
-<translation id="8503813439785031346">ഉപയോക്തൃനാമം</translation>
-<translation id="8514477925623180633">Chrome ഉപയോഗിച്ച് സംഭരിച്ചിട്ടുള്ള പാസ്‍വേഡുകൾ എക്സ്പോർട്ട് ചെയ്യുക</translation>
-<translation id="8514577642972634246">അദൃശ്യ മോഡ് നൽകുക</translation>
-<translation id="851751545965956758">ഉപകരണങ്ങളിലേക്ക് കണക്‌റ്റ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
-<translation id="8523928698583292556">സംഭരിച്ചിരിക്കുന്ന പാസ്‌വേഡ് ഇല്ലാതാക്കുക</translation>
-<translation id="854522910157234410">ഈ പേജ് തുറക്കുക</translation>
-<translation id="8558485628462305855">അനുബന്ധ യാഥാർത്ഥ്യ ഉള്ളടക്കം കാണാൻ, ARCore അപ്‌ഡേറ്റ് ചെയ്യൂ</translation>
-<translation id="8559990750235505898">പേജുകൾ മറ്റ് ഭാഷകളിലേക്ക് വിവർത്തനം ചെയ്യാനുള്ള ഓഫർ</translation>
-<translation id="8562452229998620586">സംരക്ഷിച്ച പാസ്‌വേഡുകൾ ഇവിടെ ദൃശ്യമാകും.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> മുതൽ</translation>
-<translation id="8571213806525832805">കഴിഞ്ഞ 4 ആഴ്ച</translation>
-<translation id="857943718398505171">അനുവദിച്ചിരിക്കുന്നു (ശുപാർശചെയ്‌തത്)</translation>
-<translation id="8583805026567836021">അക്കൗണ്ട് ഡാറ്റ മായ്‌ക്കുന്നു</translation>
-<translation id="860043288473659153">കാർഡിന്റെ ഉടമയുടെ പേര്</translation>
-<translation id="8609465669617005112">മുകളിലേക്ക് നീക്കുക</translation>
-<translation id="8616006591992756292">നിങ്ങളുടെ Google അക്കൗണ്ടിന് <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" /> എന്നതിൽ മറ്റ് തരത്തിലുള്ള ബ്രൗസിംഗ് ചരിത്രമുണ്ടായിരിക്കാം.</translation>
-<translation id="8617240290563765734">ഡൗൺലോഡ് ചെയ്‌ത ഉള്ളടക്കത്തിൽ നിർദ്ദേശിച്ചിട്ടുള്ള URL തുറക്കണോ?</translation>
-<translation id="8636825310635137004">നിങ്ങളുടെ മറ്റ് ഉപകരണങ്ങളിൽ നിന്നുള്ള ടാബുകൾ ലഭിക്കാൻ, സമന്വയിപ്പിക്കൽ ഓണാക്കുക.</translation>
-<translation id="8641930654639604085">മുതിർന്നവർക്കുള്ള സൈറ്റുകൾ ബ്ലോക്കുചെയ്യുന്നത് പരീക്ഷിച്ചുനോക്കൂ</translation>
-<translation id="8655129584991699539">Chrome ക്രമീകരണത്തിൽ നിങ്ങൾക്ക് ഈ ഡാറ്റ മായ്‌ക്കാം</translation>
-<translation id="8662811608048051533">നിങ്ങൾ മിക്ക സൈറ്റുകളിൽ നിന്നും സൈൻ ഔട്ടാകും.</translation>
-<translation id="8664979001105139458">ഫയലിന്റെ പേര് ഇതിനകം നിലവിലുണ്ട്</translation>
-<translation id="8676374126336081632">ഇൻപുട്ട് മായ്‌ക്കുക</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{സിഗ്‌നൽ സ്‌ട്രെംഗ്‌ത്ത് ലെവൽ # ബാർ}other{സിഗ്‌നൽ സ്‌ട്രെംഗ്‌ത്ത് ലെവൽ # ബാറുകൾ}}</translation>
-<translation id="868929229000858085">നിങ്ങളുടെ കോൺടാക്‌റ്റുകൾ തിരയുക</translation>
-<translation id="869891660844655955">കാലഹരണപ്പെടല്‍‌ തീയതി</translation>
-<translation id="8719023831149562936">നിലവിലെ ടാബ് ബീം ചെയ്യാനാകില്ല</translation>
-<translation id="8725066075913043281">വീണ്ടും ശ്രമിക്കുക</translation>
-<translation id="8728487861892616501">ഈ ആപ്പ് ഉപയോഗിക്കുന്നതിലൂടെ, നിങ്ങൾ Chrome-ന്‍റെ <ph name="BEGIN_LINK1" />സേവന നിബന്ധനകൾ<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />സ്വകാര്യതാ അറിയിപ്പ്<ph name="END_LINK2" />, <ph name="BEGIN_LINK3" />Family Link ഉപയോഗിച്ച് നിയന്ത്രിക്കുന്ന Google അക്കൗണ്ടുകളുടെ സ്വകാര്യതാ അറിയിപ്പ്<ph name="END_LINK3" /> എന്നിവ അംഗീകരിക്കുന്നു.</translation>
-<translation id="8730621377337864115">പൂർത്തിയാക്കി</translation>
-<translation id="8748850008226585750">കോൺടാക്‌റ്റുകൾ മറച്ചു</translation>
-<translation id="8751914237388039244">ഒരു ചിത്രം തിരഞ്ഞെടുക്കുക</translation>
-<translation id="8788265440806329501">നാവിഗേഷന്‍ ചരിത്രം അടച്ചു</translation>
-<translation id="8788968922598763114">അവസാനം അടച്ച ടാബ് വീണ്ടും തുറക്കുക</translation>
-<translation id="8801436777607969138">ഒരു നിർദ്ദിഷ്‌ട സൈറ്റിനായി JavaScript ബ്ലോക്ക് ചെയ്യുക.</translation>
-<translation id="8812260976093120287">ചില വെബ്‌സൈറ്റുകളിൽ, നിങ്ങളുടെ ഉപകരണത്തിൽ ഉപയോഗിക്കാവുന്നതും മുകളിൽ പറഞ്ഞിരിക്കുന്നതുമായ പേയ്‌മെന്റ് ആപ്പുകൾ വഴി പണമടയ്‌ക്കാം.</translation>
-<translation id="8816026460808729765">സെൻസറുകൾ ആക്‌സസ് ചെയ്യുന്നതിൽ നിന്ന് സൈറ്റുകളെ ബ്ലോക്ക് ചെയ്യുക</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chrome-ൽ തുറക്കും. തുടരുന്നതിലൂടെ, നിങ്ങൾ Chrome-ന്റെ <ph name="BEGIN_LINK1" />സേവന നിബന്ധനകളും<ph name="END_LINK1" /> <ph name="BEGIN_LINK2" />സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK2" /> <ph name="BEGIN_LINK3" />Family Link ഉപയോഗിച്ച് മാനേജ് ചെയ്യപ്പെടുന്ന Google അക്കൗണ്ടുകളുടെ സ്വകാര്യതാ അറിയിപ്പും<ph name="END_LINK3" /> അംഗീകരിക്കുന്നു.</translation>
-<translation id="8820817407110198400">ബുക്ക്‌മാര്‍ക്കുകള്‍</translation>
-<translation id="8833831881926404480">ഒരു സൈറ്റ് നിങ്ങളുടെ സ്‌ക്രീൻ പങ്കിടുന്നു</translation>
-<translation id="883806473910249246">ഉള്ളടക്കം ഡൗൺലോഡ് ചെയ്യുമ്പോൾ ഒരു പിശകുണ്ടായി.</translation>
-<translation id="8840953339110955557">ഈ പേജ് ഓൺലൈൻ പതിപ്പിൽ നിന്ന് വ്യത്യസ്തമായിരിക്കാം.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, ടാബ്</translation>
-<translation id="885701979325669005">സംഭരണം</translation>
-<translation id="889338405075704026">Chrome ക്രമീകരണത്തിലേക്ക് പോകുക</translation>
-<translation id="8901170036886848654">ബുക്ക്‌മാർക്കുകളൊന്നും കണ്ടെത്തിയില്ല</translation>
-<translation id="8909135823018751308">പങ്കിടുക...</translation>
-<translation id="8912362522468806198">Google അക്കൗണ്ട്</translation>
-<translation id="8920114477895755567">രക്ഷകർത്താക്കളുടെ വിശദാംശങ്ങൾക്കായി കാത്തിരിക്കുന്നു.</translation>
+<translation id="1188239144602654184">AR ആരംഭിക്കുക</translation>
+<translation id="473775607612524610">അപ്ഡേറ്റ് ചെയ്യുക</translation>
+<translation id="3133489217401741157">Brave-നുള്ള <ph name="MODULE"/> ഇൻസ്‌റ്റാൾ ചെയ്യുന്നു…</translation>
+<translation id="1791662854739702043">ഇന്‍സ്റ്റാളുചെയ്തു</translation>
+<translation id="5131234170665854056">Brave-നായി <ph name="MODULE"/> ഇൻസ്‌റ്റാൾ ചെയ്യാനായില്ല</translation>
+<translation id="2567385386134582609">ചിത്രം</translation>
+<translation id="6395288395575013217">ലിങ്ക്</translation>
+<translation id="7352939065658542140">വീഡിയോ</translation>
+<translation id="4116038641877404294">ഓഫ്‌ലൈനായി ഉപയോഗിക്കാൻ പേജുകൾ ഡൗൺലോഡ് ചെയ്യുക</translation>
 <translation id="8922289737868596582">ഓഫ്‌ലൈനായി ഉപയോഗിക്കാൻ 'കൂടുതൽ ഓപ്ഷനുകൾ' ബട്ടണിൽ നിന്ന് പേജുകൾ ഡൗൺലോഡ് ചെയ്യുക</translation>
-<translation id="8937772741022875483">ഡിജിറ്റൽ ആരോഗ്യത്തിൽ നിന്ന് നിങ്ങളുടെ Chrome ആക്റ്റിവിറ്റി നീക്കം ചെയ്യണോ?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">മറ്റൊരു വിൻഡോയിൽ തുറക്കുക</translation>
-<translation id="8951232171465285730">Chrome നിങ്ങളുടെ <ph name="MEGABYTES" /> MB ലാഭിച്ചു</translation>
-<translation id="8958424370300090006">ഒരു പ്രത്യേക സൈറ്റിനായി കുക്കികൾ ബ്ലോക്ക് ചെയ്യുക.</translation>
-<translation id="8959122750345127698">നാവിഗേഷൻ ലഭ്യമല്ല: <ph name="URL" /></translation>
-<translation id="8965591936373831584">തീർച്ചപ്പെടുത്താത്തവ</translation>
-<translation id="8970887620466824814">എന്തോ കുഴപ്പമുണ്ടായി.</translation>
-<translation id="8972098258593396643">ഡിഫോൾട്ട് ഫോൾഡറിലേക്ക് ഡൗൺലോഡ് ചെയ്യണോ?</translation>
-<translation id="8986494364107987395">Google ലേക്ക് സ്വയമേവ ഉപയോഗ വിവരക്കണക്കുകളും ക്രാഷ് റിപ്പോര്‍ട്ടുകളും അയയ്ക്കുക</translation>
-<translation id="8993760627012879038">അദൃശ്യ മോഡിൽ ഒരു പുതിയ വിൻഡോ തുറക്കുക</translation>
-<translation id="8998729206196772491"><ph name="MANAGED_DOMAIN" /> മാനേജ് ചെയ്യുന്ന ഒരു അക്കൗണ്ട് ഉപയോഗിച്ച് നിങ്ങൾ സൈൻ ഇൻ ചെയ്യുകയും ഇതിന്റെ അഡ്‌മിനിസ്‌ട്രേറ്റർക്ക് നിങ്ങളുടെ Chrome വിവരങ്ങളിന്മേൽ നിയന്ത്രണം നൽകുകയും ചെയ്യുന്നു. വിവരങ്ങളെ ഈ അക്കൗണ്ടുമായി ശാശ്വതമായി ബന്ധിപ്പിക്കും. Chrome-ൽ നിന്ന് സൈൻ ഔട്ട് ചെയ്യുന്നത് ഈ ഉപകരണത്തിൽ നിന്ന് നിങ്ങളുടെ വിവരങ്ങളെ ഇല്ലാതാക്കുമെങ്കിലും, Google അക്കൗണ്ടിൽ തുടർന്നും അവയെ സൂക്ഷിക്കുന്നതാണ്.</translation>
-<translation id="9019902583201351841">നിങ്ങളുടെ രക്ഷിതാക്കൾ നിയന്ത്രിക്കുന്നു</translation>
-<translation id="9028914725102941583">ഉപകരണങ്ങളിലുടനീളം പങ്കിടാൻ സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="9029323097866369874">VR-ൽ പ്രവേശിക്കാൻ <ph name="DOMAIN" /> എന്നതിനെ അനുവദിക്കണോ?</translation>
-<translation id="9040142327097499898">അറിയിപ്പുകൾ അനുവദിക്കപ്പെട്ടിരിക്കുന്നു. ഈ ഉപകരണത്തിന്‍റെ ലൊക്കേഷൻ ഓഫാണ്.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# വീഡിയോ}other{# വീഡിയോകൾ}}</translation>
-<translation id="9050666287014529139">പാസ്ഫ്രെയ്‍സ്</translation>
-<translation id="9063523880881406963">'ഡെസ്‌ക്‌ടോപ്പ് സൈറ്റ് അഭ്യർത്ഥിക്കുക' ഓഫാക്കുക</translation>
-<translation id="9065203028668620118">എഡിറ്റ് ചെയ്യുക</translation>
-<translation id="9070377983101773829">ശബ്ദ തിരയൽ ആരംഭിക്കുക</translation>
-<translation id="9074336505530349563">Google നിർദേശിക്കുന്ന വ്യക്തിപരമാക്കിയ ഉള്ളടക്കം ലഭിക്കാൻ, സൈൻ ഇൻ ചെയ്‌ത് സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
-<translation id="9086455579313502267">നെറ്റ്‌വർക്ക് ആക്സസ് ചെയ്യാനാകുന്നില്ല</translation>
-<translation id="9100505651305367705">പിന്തുണയുള്ളപ്പോൾ, ലളിതമാക്കിയ കാഴ്ചയിൽ ലേഖനങ്ങൾ കാണിക്കുന്ന സൗകര്യം നൽകുക</translation>
-<translation id="9100610230175265781">പാസ്‌ഫ്രെയ്‌സ് ആവശ്യമാണ്</translation>
-<translation id="9102803872260866941">പ്രിവ്യു ടാബ് തുറന്നു</translation>
+<translation id="5958275228015807058">ഡൗൺലോഡുകളിൽ നിന്നും നിങ്ങളുടെ ഫയലുകളും ‌പേജുകളും കണ്ടെത്തുക</translation>
+<translation id="5620928963363755975">'കൂടുതൽ ഓപ്‌ഷനുകൾ' ബട്ടണിൽ നിന്നും, ഡൗൺലോഡുകളിൽ നിന്നും നിങ്ങളുടെ ഫയലുകളും ‌പേജുകളും കണ്ടെത്തുക</translation>
+<translation id="3341058695485821946">നിങ്ങൾ എത്ര ഡാറ്റ ലാഭിച്ചെന്ന് കാണുക</translation>
+<translation id="3157842584138209013">'കൂടുതൽ ഓപ്ഷനുകൾ' ബട്ടണിൽ നിങ്ങൾ എത്ര ഡാറ്റ ലാഭിച്ചെന്ന് കാണുക</translation>
+<translation id="8218622182176210845">നിങ്ങളുടെ അക്കൗണ്ട് മാനേജ് ചെയ്യുക</translation>
+<translation id="8090895580117672212">നിങ്ങളുടെ Brave Software അക്കൗണ്ട് മാനേജ് ചെയ്യാൻ, "അക്കൗണ്ട് മാനേജ് ചെയ്യുക" ബട്ടണിൽ ടാപ്പ് ചെയ്യുക</translation>
+<translation id="8856898588039823173">Brave Software നൽകുന്ന ലൈറ്റ് പേജ്. യഥാർത്ഥ പേജ് ലോഡ് ചെയ്യാൻ ടാപ്പ് ചെയ്യുക.</translation>
+<translation id="8134317863207426198">Brave Software നല്‍കുന്ന ലൈറ്റ് പേജ്. അസ്സല്‍ പേജ് ലോഡ് ചെയ്യാന്‍ 'അസ്സൽ ലോഡ് ചെയ്യൽ' ബട്ടണ്‍ ടാപ്പ് ചെയ്യുക.</translation>
+<translation id="4961107849584082341">ഈ പേജ് ഏത് ഭാഷയിലേക്കും വിവര്‍ത്തനം ചെയ്യുക</translation>
+<translation id="569536719314091526">'കൂടുതൽ ഓപ്‌ഷനുകൾ' ബട്ടണിൽ നിന്ന്, ഈ പേജ് ഏത് ഭാഷയിലേക്കും വിവർത്തനം ചെയ്യുക</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> ഉപയോഗിച്ച് തിരയുക</translation>
+<translation id="1792959175193046959">ഏതുസമയത്തും ഡിഫോൾട്ട് ഡൗൺലോഡ് ലൊക്കേഷൻ മാറ്റുക</translation>
+<translation id="6942665639005891494">ക്രമീകരണ മെനു ഓപ്‌ഷൻ ഉപയോഗിച്ച്, ഏതുസമയത്തും ഡിഫോൾട്ട് ഡൗൺലോഡ് ലൊക്കേഷൻ മാറ്റുക.</translation>
+<translation id="6850409657436465440">നിങ്ങളുടെ ഡൗൺലോഡ് ഇപ്പോഴും പുരോഗതിയിലാണ്</translation>
+<translation id="5817715962196959877">Brave ഇപ്പോൾ വേഗത്തിൽ ഫയലുകൾ ഡൗൺലോഡ് ചെയ്യുന്നു</translation>
+<translation id="3976396876660209797">ഈ കുറുക്കുവഴി നീക്കംചെയ്‌ത് പുനസൃഷ്‌ടിക്കുക</translation>
+<translation id="6766622839693428701">അവസാനിപ്പിക്കാൻ താഴേക്ക് സ്വൈപ്പ് ചെയ്യുക.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> എന്നതിലേക്ക് അയ‌യ്‌ക്കുന്നു...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/>-ൽ നിന്ന് അയച്ചത്</translation>
+<translation id="5357811892247919462">ടാബ് സ്വീകരിച്ചു</translation>
 <translation id="9104217018994036254">ടാബ് പങ്കിടാനാകുന്ന ഉപകരണങ്ങളുടെ ലിസ്‌റ്റ്.</translation>
-<translation id="9133397713400217035">ഓഫ്‍ലൈൻ ഉള്ളടക്കങ്ങൾ അടുത്തറിയൂ</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">യഥാര്‍ത്ഥമായത് കാണിക്കുക</translation>
-<translation id="9139068048179869749">അറിയിപ്പുകൾ അയയ്‌ക്കാൻ സൈറ്റുകളെ അനുവദിക്കുന്നതിന് മുമ്പ് ചോദിക്കുക (ശുപാർശചെയ്‌തിരിക്കുന്നു)</translation>
-<translation id="9139318394846604261">ഷോപ്പിംഗ്</translation>
-<translation id="9155898266292537608">ഒരു വാക്കിൽ പെട്ടെന്ന് ടാപ്പ് ചെയ്‌തും നിങ്ങൾക്ക് തിരയാൻ കഴിയും</translation>
-<translation id="9169507124922466868">നാവിഗേഷൻ ചരിത്രം പകുതിയായി തുറന്നിരിക്കുന്നു</translation>
-<translation id="9204836675896933765">ഒരു ഫയൽ ശേഷിക്കുന്നു</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">പകുതി ഉയരത്തിൽ ടാബ് പങ്കിടാനാകുന്ന ഉപകരണങ്ങളുടെ ലിസ്‌റ്റ്.</translation>
+<translation id="2904414404539560095">പൂർണ്ണ ഉയരത്തിൽ ടാബ് പങ്കിടാനാകുന്ന ഉപകരണങ്ങളുടെ ലിസ്‌റ്റ്.</translation>
+<translation id="4135200667068010335">ടാബ് പങ്കിടാനാകുന്ന ഉപകരണങ്ങളുടെ ലിസ്‌റ്റ് അടച്ചിരിക്കുന്നു.</translation>
+<translation id="5292796745632149097">ഇതിലേക്ക് അയയ്ക്കുക</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> ദിവസം മുമ്പ് സജീവമായിരുന്നു</translation>
+<translation id="7971136598759319605">ഒരു ദിവസം മുമ്പ് സജീവമായിരുന്നു</translation>
+<translation id="1521774566618522728">ഇന്ന് സജീവമായിരുന്നു</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> എന്നതിലേക്ക് പങ്കിടുന്നു</translation>
+<translation id="9028914725102941583">ഉപകരണങ്ങളിലുടനീളം പങ്കിടാൻ സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="6162454065885854378">നിങ്ങളുടെ ഫോണിൽ നിന്നും മറ്റൊരു ഉപകരണത്തിലേക്ക് എന്തെങ്കിലും പങ്കിടാൻ, രണ്ട് ഉപകരണങ്ങളിലെയും Brave ക്രമീകരണത്തിൽ സമന്വയിപ്പിക്കൽ ഓണാക്കുക</translation>
+<translation id="6084271560289605378">Brave ക്രമീകരണത്തിലേക്ക് പോകുക</translation>
+<translation id="2318045970523081853">കോൾ ചെയ്യാൻ ടാപ്പ് ചെയ്യുക</translation>
 <translation id="9209888181064652401">കോളുകൾ ചെയ്യാനാവില്ല</translation>
-<translation id="9219103736887031265">ചിത്രങ്ങൾ‌</translation>
-<translation id="926205370408745186">ഡിജിറ്റൽ ആരോഗ്യത്തിൽ നിന്ന് നിങ്ങളുടെ Chrome ആക്റ്റിവിറ്റി നീക്കം ചെയ്യുക</translation>
-<translation id="932327136139879170">ഹോം</translation>
-<translation id="938850635132480979">പിശക്: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">നിങ്ങളുടെ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യുക</translation>
-<translation id="95817756606698420"><ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> ഉപയോഗിച്ച് Chrome-ന് ചൈനയിൽ തിരയാനാവും. നിങ്ങൾക്കിത്‌ <ph name="BEGIN_LINK" />ക്രമീകരണത്തിൽ<ph name="END_LINK" /> മാറ്റാനാവും.</translation>
-<translation id="965817943346481315">സൈറ്റ്, അനാവശ്യമോ തെറ്റിദ്ധരിപ്പിക്കുന്നതോ ആയ പരസ്യങ്ങള്‍ കാണിക്കുന്നുണ്ടെങ്കില്‍ ബ്ലോക്ക് ചെയ്യുക (ശുപാര്‍ശ ചെയ്യുന്നു)</translation>
-<translation id="968900484120156207">നിങ്ങൾ സന്ദർശിക്കുന്ന പേജുകൾ ഇവിടെ ദൃശ്യമാകും</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> മിനിറ്റ് ശേഷിക്കുന്നു</translation>
-<translation id="974555521953189084">സമന്വയിപ്പിക്കൽ തുടങ്ങുന്നതിന് പാസ്‌ഫ്രെയ്‌സ് നൽകുക</translation>
-<translation id="981121421437150478">ഓഫ്‌ലൈൻ</translation>
-<translation id="982182592107339124">ഇത് ഇനിപ്പറയുന്നവ ഉൾപ്പെടെയുള്ള എല്ലാ സൈറ്റുകളുടെയും വിവരങ്ങൾ മായ്‌ക്കുന്നതിനിടയാക്കും:</translation>
-<translation id="983192555821071799">എല്ലാ ടാബുകളും അടയ്‌ക്കുക</translation>
-<translation id="987264212798334818">പൊതുവായ</translation>
+<translation id="2860954141821109167">ഈ ഉപകരണത്തിൽ ഫോൺ ആപ്പ് പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
+<translation id="2067805253194386918">ടെക്‌സ്‌റ്റ്</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> പങ്കിടാനാവുന്നില്ല</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> പങ്കിടാനായില്ല</translation>
+<translation id="8287068819750208230">Brave-ൽ <ph name="TARGET_DEVICE_NAME"/> ഉപകരണത്തിലെ സമന്വയിപ്പിക്കൽ ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
+<translation id="3016635187733453316">ഈ ഉപകരണം ഇന്റർനെറ്റിലേക്ക് കണക്‌റ്റ് ചെയ്‌തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> ഉപകരണം ഇന്റർനെറ്റിലേക്ക് കണക്‌റ്റ് ചെയ്‌തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക</translation>
+<translation id="6539092367496845964">എന്തോ കുഴപ്പം സംഭവിച്ചു. പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</translation>
+<translation id="3389286852084373014">ടെക്‌സ്‌റ്റ് വളരെ വലുതാണ്</translation>
+<translation id="2100314319871056947">ചെറിയ ഭാഗങ്ങളായി ടെക്‌സ്‌റ്റ് പങ്കിടാൻ ശ്രമിക്കൂ</translation>
+<translation id="2987620471460279764">മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് പങ്കിട്ട ടെക്‌സ്‌റ്റ്</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> ഉപകരണത്തിൽ നിന്ന് പങ്കിട്ട ടെക്‌സ്റ്റ്</translation>
+<translation id="5193988420012215838">നിങ്ങളുടെ ക്ലിപ്പ്ബോർഡിലേക്ക് പകർത്തി</translation>
+<translation id="4696983787092045100">നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് ടെക്‌സ്‌റ്റ് അയയ്‌ക്കുക</translation>
+<translation id="1260236875608242557">തിരയുക, അടുത്തറിയുക</translation>
+<translation id="6369229450655021117">ഇവിടെ നിന്ന്, വെബ്ബിൽ തിരയാനും സുഹൃത്തുക്കളുമായി പങ്കിടാനും തുറന്ന പേജുകൾ കാണാനുമാവും</translation>
+<translation id="723171743924126238">ചിത്രങ്ങൾ തിരഞ്ഞെടുക്കുക</translation>
+<translation id="8751914237388039244">ഒരു ചിത്രം തിരഞ്ഞെടുക്കുക</translation>
+<translation id="1989112275319619282">ബ്രൗസ് ചെയ്യുക</translation>
+<translation id="7055152154916055070">റീഡയറക്‌റ്റ് ചെയ്യുന്നത് ബ്ലോക്ക് ചെയ്തു</translation>
+<translation id="5524843473235508879">റീഡയറക്ട് ചെയ്യുന്നത് ബ്ലോക്ക് ചെയ്തു.</translation>
+<translation id="6573096386450695060">എല്ലായ്‌പ്പോഴും അനുവദിക്കുക</translation>
+<translation id="5805364706385912897">ഈ പേജ് ഒരുപാട് മെമ്മറി ഉപയോഗിക്കുന്നു, അതിനാൽ Brave ഇത് താൽക്കാലികമായി അവസാനിപ്പിച്ചു.</translation>
+<translation id="5138664332909611586">ഈ പേജ് കൂടുതൽ മെമ്മറി ഉപയോഗിക്കുന്നു, അതിനാൽ Brave കുറച്ച് ഉള്ളടക്കം നീക്കം ചെയ്‌തു.</translation>
+<translation id="9137013805542155359">യഥാര്‍ത്ഥമായത് കാണിക്കുക</translation>
+<translation id="6361779936989026201">Brave സ്വമേധയാ പൂരിപ്പിക്കലിലെ Brave Software അസിസ്‌റ്റന്റ് സാന്നിധ്യം</translation>
+<translation id="7291387454912369099">അസിസ്‌റ്റന്റ് ചെക്ക് ഔട്ട് ചെയ്യാൻ പ്രേരിപ്പിച്ചു</translation>
+<translation id="4565206163201411670">ഡിജിറ്റൽ ആരോഗ്യത്തിൽ നിങ്ങളുടെ Brave ആക്റ്റിവിറ്റി കാണിക്കണോ?</translation>
+<translation id="9055113864158719823">നിങ്ങൾ Brave- ൽ സന്ദർശിക്കുന്ന സൈറ്റുകൾ കാണാനും അവയ്ക്ക് ടൈമറുകൾ സജ്ജീകരിക്കാനുമാവും.\n\nനിങ്ങൾ ടൈമറുകൾ സജ്ജീകരിക്കുന്ന സൈറ്റുകളെക്കുറിച്ചും നിങ്ങൾ എത്ര സമയം അവ സന്ദർശിക്കുന്നു എന്നതിനെക്കുറിച്ചും Brave Software ന് വിവരങ്ങൾ ലഭിക്കുന്നു. ഡിജിറ്റൽ ആരോഗ്യം മെച്ചപ്പെടുത്താൻ ഈ വിവരം ഉപയോഗിക്കുന്നു.</translation>
+<translation id="4596514158372210596">ഡിജിറ്റൽ ആരോഗ്യത്തിൽ നിന്ന് നിങ്ങളുടെ Brave ആക്റ്റിവിറ്റി നീക്കം ചെയ്യുക</translation>
+<translation id="1174893863889683998">ഡിജിറ്റൽ ആരോഗ്യത്തിൽ നിന്ന് നിങ്ങളുടെ Brave ആക്റ്റിവിറ്റി നീക്കം ചെയ്യണോ?</translation>
+<translation id="708829030563435351">നിങ്ങൾ Brave-ൽ സന്ദർശിക്കുന്ന സൈറ്റുകൾ കാണിക്കില്ല. എല്ലാ സൈറ്റ് ടൈമറുകളും ഇല്ലാതാക്കപ്പെടും.</translation>
+<translation id="2056878612599315956">സൈറ്റ് താൽക്കാലികമായി നിർത്തി</translation>
+<translation id="671481426037969117">നിങ്ങളുടെ <ph name="FQDN"/> ടൈമർ അവസാനിച്ചു. ഇത് നാളെ വീണ്ടും ആരംഭിക്കും.</translation>
+<translation id="7479104141328977413">ടാബ് മാനേജ്മെൻ്റ്</translation>
+<translation id="3524138585025253783">ഡെവലപ്പർ UI</translation>
+<translation id="6036057147555329831">അധിക ICU</translation>
+<translation id="9029323097866369874">VR-ൽ പ്രവേശിക്കാൻ <ph name="DOMAIN"/> എന്നതിനെ അനുവദിക്കണോ?</translation>
+<translation id="7685301384041462804">VR-ൽ പ്രവേശിക്കുന്നതിന് മുമ്പ് ഈ സൈറ്റിനെ നിങ്ങൾ വിശ്വസിക്കുന്നുണ്ടെന്ന് തീർച്ചപ്പെടുത്തുക.</translation>
+<translation id="5033865233969348410">നിങ്ങൾ VR-ൽ ആയിരിക്കുമ്പോൾ, ഈ സൈറ്റിന് ഇനിപ്പറയുന്ന കാര്യങ്ങളെക്കുറിച്ച് മനസ്സിലാക്കാൻ കഴിഞ്ഞേക്കും:
+  -  ഉയരം പോലെയുള്ള നിങ്ങളുടെ ശാരീരിക സവിശേഷതകൾ
+
+VR-ൽ പ്രവേശിക്കുന്നതിന് മുമ്പ് നിങ്ങൾ ഈ സൈറ്റിനെ വിശ്വസിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കുക.</translation>
+<translation id="5534334044554683961">നിങ്ങൾ VR-ൽ ആയിരിക്കുമ്പോൾ, ഈ സൈറ്റിന് ഇനിപ്പറയുന്ന കാര്യങ്ങളെക്കുറിച്ച് മനസ്സിലാക്കാൻ കഴിഞ്ഞേക്കും:
+  -   ഉയരം പോലെയുള്ള നിങ്ങളുടെ ശാരീരിക സവിശേഷതകൾ
+  -   നിങ്ങളുടെ മുറിയുടെ ലേഔട്ട്
+
+VR-ൽ പ്രവേശിക്കുന്നതിന് മുമ്പ് നിങ്ങൾ ഈ സൈറ്റിനെ വിശ്വസിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കുക.</translation>
+<translation id="4169535189173047238">അനുവദിക്കരുത്</translation>
+<translation id="2170088579611075216">VR അനുവദിച്ച് അതിൽ പ്രവേശിക്കുക</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_mr.xtb
+++ b/android/java/strings/translations/android_chrome_strings_mr.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="mr">
-<translation id="1006017844123154345">ऑनलाइन उघडा</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> ला पाठवत आहे…</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> जोडत आहे…</translation>
-<translation id="1041308826830691739">वेबसाइटवरून</translation>
-<translation id="1049743911850919806">गुप्त</translation>
-<translation id="10614374240317010">कधीही सेव्ह न केलेले</translation>
-<translation id="1067922213147265141">इतर Google सेवा</translation>
-<translation id="1068672505746868501">पेज <ph name="SOURCE_LANGUAGE" /> मध्ये कधीही भाषांतरित करू नका</translation>
-<translation id="107147699690128016">तुम्ही फाइल एक्स्टेंशन बदलल्यास, फाइल कदाचित दुसऱ्या ॲप्लिकेशनमध्ये उघडू शकते आणि यामुळे तुमच्या डिव्हाइसला संभाव्य धोका असू शकतो.</translation>
-<translation id="1100066534610197918">गटामधील नवीन टॅबमध्ये उघडा</translation>
-<translation id="1105960400813249514">स्‍क्रीन कॅप्‍चर</translation>
-<translation id="1111673857033749125">आपल्या इतर डिव्हाइसेेसवर सेव्ह केलेले बुकमार्क येथे दिसतील.</translation>
-<translation id="1113597929977215864">सिंप्लिफाइड व्ह्यू दाखवा</translation>
-<translation id="1121094540300013208">वापर आणि क्रॅश अहवाल</translation>
-<translation id="1124772482545689468">वापरकर्ता</translation>
-<translation id="1129510026454351943">तपशील: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{एक डाउनलोड प्रलंबित आहे.}other{# डाउनलोड प्रलंबित आहेत.}}</translation>
-<translation id="1145536944570833626">विद्यमान डेटा हटवा.</translation>
-<translation id="1146678959555564648">VR एंटर करा</translation>
-<translation id="116280672541001035">वापरला</translation>
-<translation id="1171770572613082465">"टॉप साइट" बटणावर टॅप करून लोकप्रिय वेबसाइट पाहा</translation>
-<translation id="1173894706177603556">नाव बदला</translation>
-<translation id="1178581264944972037">विराम द्या</translation>
-<translation id="1181037720776840403">काढून टाका</translation>
-<translation id="1188239144602654184">AR सुरू करा</translation>
-<translation id="1197267115302279827">बुकर्माक हलवा</translation>
-<translation id="119944043368869598">सर्व साफ करा</translation>
-<translation id="1201402288615127009">पुढील</translation>
-<translation id="1204037785786432551">लिंक डाउनलोड करा</translation>
-<translation id="1206892813135768548">लिंक मजकूर कॉपी करा</translation>
-<translation id="1208340532756947324">सर्व डिव्हाइसवर सिंक आणि पर्सनलाइझ करण्यासाठी, सिंक सुरू करा</translation>
-<translation id="1209206284964581585">आतासाठी लपवा</translation>
-<translation id="1227058898775614466">नेव्हिगेशन इतिहास</translation>
-<translation id="1231733316453485619">सिंक सुरू करायचे का?</translation>
-<translation id="123724288017357924">कॅश केलेला आशय दुर्लक्षित करून, सद्य पेज रीलोड करा</translation>
-<translation id="124116460088058876">आणखी भाषा...</translation>
-<translation id="124678866338384709">वर्तमान टॅब बंद करा</translation>
-<translation id="1258753120186372309">Google डूडल: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">शोधा आणि एक्सप्लोर करा</translation>
-<translation id="1264974993859112054">क्रीडा</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> शेअर करू शकलो नाही</translation>
-<translation id="1272079795634619415">थांबा</translation>
-<translation id="1283039547216852943">विस्तृत करण्यासाठी टॅप करा</translation>
-<translation id="1285320974508926690">या साइटचा कधीही भाषांतर करु नका</translation>
-<translation id="1291207594882862231">इतिहास, कुकी, साइट डेटा, कॅशे साफ करा…</translation>
-<translation id="129382876167171263">वेबसाइटद्वारे सेव्ह केलेल्या फाइल येथे दिसतील</translation>
-<translation id="129553762522093515">अलीकडे बंद केलेले</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> वरून पाठवले</translation>
-<translation id="1310482092992808703">टॅबची गटामध्ये विभागणी करा</translation>
-<translation id="1327257854815634930">नेव्हिगेशन इतिहास उघडलेला आहे</translation>
-<translation id="1331212799747679585">Chrome अपडेट होऊ शकत नाही. आणखी पर्याय</translation>
-<translation id="1332501820983677155">Google Chrome वैशिष्ट्य शॉर्टकट</translation>
-<translation id="1360432990279830238">साइन आउट करून सिंक बंद करायचे आहे का?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> साइट जोडली</translation>
-<translation id="1373696734384179344">निवडलेला आशय डाउनलोड करण्यासाठी अपुरी मेमरी.</translation>
-<translation id="1376578503827013741">गणना करत आहे...</translation>
-<translation id="1383876407941801731">शोधा</translation>
-<translation id="1384959399684842514">डाउनलोडला विराम दिला</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> दिवसांपूर्वी ॲक्टिव्ह होते</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> सह शोधा</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" /> मध्ये एम्बेड केले</translation>
-<translation id="1406000523432664303">“Do Not Track”</translation>
-<translation id="1407135791313364759">सर्व उघडा</translation>
-<translation id="1409426117486808224">उघड्या टॅबसाठी सोपा केलेला व्ह्यू</translation>
-<translation id="1409879593029778104">फाइल आधीपासून अस्तित्वात असल्याने <ph name="FILE_NAME" /> डाउनलोड करणे प्रतिबंधित केले.</translation>
-<translation id="1414981605391750300">Google शी संपर्क साधत आहे. याला एखादे मिनिट लागेल…</translation>
-<translation id="1416550906796893042">ॲप्लिकेशन आवृत्ती</translation>
-<translation id="1430915738399379752">प्रिंट</translation>
-<translation id="1446450296470737166">MIDI डिव्हाइसेसच्या पूर्ण नियंत्रणास अनुमती द्या</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> शेअर करू शकत नाही</translation>
-<translation id="145097072038377568">Android सेटिंग्ज मध्‍ये बंद करा</translation>
-<translation id="1477626028522505441">सर्व्हर समस्यांमुळे <ph name="FILE_NAME" /> डाउनलोड अयशस्वी झाले.</translation>
-<translation id="1506061864768559482">शोध इंजिन</translation>
-<translation id="1513352483775369820">बुकमार्क आणि वेब इतिहास</translation>
-<translation id="1513858653616922153">पासवर्ड हटवा</translation>
-<translation id="1516229014686355813">शोधण्यासाठी टॅप करा निवडलेला शब्द आणि सद्य पेज संदर्भ म्हणून Google शोध ला पाठवते. तुम्ही ते <ph name="BEGIN_LINK" />सेटिंग्ज<ph name="END_LINK" /> मध्ये सुरू किंवा बंद करू शकता.</translation>
-<translation id="1521774566618522728">आज ॲक्टिव्ह होते</translation>
-<translation id="1544826120773021464">तुमचे Google खाते व्यवस्थापित करण्यासाठी, "खाते व्यवस्थापित करा" बटणावर टॅप करा</translation>
-<translation id="1549000191223877751">अन्य विंडोवर हलवा</translation>
-<translation id="1553358976309200471">Chrome अपडेट करा</translation>
-<translation id="1569387923882100876">कनेक्‍ट केलेले डिव्हाइस</translation>
-<translation id="1571304935088121812">वापरकर्तानाव कॉपी करा</translation>
-<translation id="1612196535745283361">डिव्हाइस स्कॅन करण्‍यासाठी Chrome ला स्थान ॲक्सेसची आवश्यकता असते. स्थान ॲक्सेस <ph name="BEGIN_LINK" />या डिव्हाइसाठी बंद केला आहे<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">कॅमेरा</translation>
-<translation id="1623104350909869708">या पृष्ठास अतिरिक्त संवाद तयार करण्यापासून प्रतिबंधित करा</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 निवडलेला आयटम काढून टाका}other{# निवडलेले आयटम काढून टाका}}</translation>
-<translation id="164269334534774161">तुम्ही <ph name="CREATION_TIME" /> पासून या पेजची ऑफलाइन प्रत पाहत आहात</translation>
-<translation id="1644574205037202324">इतिहास</translation>
-<translation id="1647391597548383849">तुमचा कॅमेरा ॲक्सेस करा</translation>
-<translation id="1660204651932907780">साइटना ध्वनी प्ले करण्याची परवानगी द्या (शिफारस केलेले)</translation>
-<translation id="1670399744444387456">मूलभूत</translation>
-<translation id="1671236975893690980">डाउनलोड प्रलंबित आहे</translation>
-<translation id="1672586136351118594">पुन्हा दाखवू नका</translation>
-<translation id="1692118695553449118">संकालन चालू आहे</translation>
-<translation id="169515064810179024">साइटना मोशन सेन्सर ॲक्सेसपासून ब्लॉक करा</translation>
-<translation id="1717218214683051432">मोशन सेन्सर</translation>
-<translation id="1718835860248848330">शेवटच्या तासामधील</translation>
-<translation id="1736419249208073774">एक्सप्लोर करा</translation>
-<translation id="1743802530341753419">साइटना डिव्हाइसशी कनेक्ट करण्यासाठी अनुमती देण्यापूर्वी विचारा (शिफारस केलेले आहे)</translation>
-<translation id="1749561566933687563">तुमचे बुकमार्क सिंक करा</translation>
-<translation id="17513872634828108">खुले टॅब</translation>
-<translation id="1779089405699405702">इमेज डीकोडर</translation>
-<translation id="1782483593938241562">संपण्याची तारीख <ph name="DATE" /></translation>
-<translation id="1791662854739702043">इंस्टॉल केले</translation>
-<translation id="1792959175193046959">डीफॉल्ट डाउनलोडचे स्थान केव्हाही बदला</translation>
-<translation id="1807246157184219062">फिकट</translation>
-<translation id="1810845389119482123">सुरुवातीचे सिंक सेट करणे पूर्ण झाले नाही</translation>
-<translation id="1821253160463689938">तुम्ही त्या पेजना भेट दिली नसली तरीही, तुमची प्राधान्ये लक्षात ठेवण्यासाठी कुकीचा वापर करते</translation>
-<translation id="1829244130665387512">या पृष्ठामध्ये शोधा</translation>
-<translation id="1853692000353488670">नवीन गुप्त टॅब</translation>
-<translation id="1856325424225101786">लाइट मोड रीसेट करायचा?</translation>
-<translation id="1868024384445905608">Chrome आता फायली वेगाने डाउनलोड करते</translation>
-<translation id="1883903952484604915">माझ्या फायली</translation>
-<translation id="1887786770086287077">या डिव्हाइसाठी स्थान अ‍ॅक्सेस बंद आहे, <ph name="BEGIN_LINK" />Android सेटिंग्‍ज<ph name="END_LINK" /> मध्‍ये हे चालू करा.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> हे Chrome मध्ये उघडेल. सुरू ठेवण्याने, तुम्ही Chrome च्या <ph name="BEGIN_LINK1" />सेवा अटी<ph name="END_LINK1" /> आणि <ph name="BEGIN_LINK2" />गोपनीयता सूचनां<ph name="END_LINK2" /> शी सहमती दाखवता.</translation>
-<translation id="1919345977826869612">जाहिराती</translation>
-<translation id="1919950603503897840">संपर्क निवडा</translation>
-<translation id="1922076542920281912">Chrome ला तुमच्या स्थानाचा अ‍ॅक्सेस द्या, <ph name="BEGIN_LINK" />Android सेटिंग्ज<ph name="END_LINK" /> मध्ये देखील स्थान सुरू करा.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">अपडेट</translation>
-<translation id="19288952978244135">Chrome पुन्हा उघडा.</translation>
-<translation id="1933845786846280168">निवडलेला टॅब</translation>
-<translation id="194341124344773587">Chrome साठी परवानगी <ph name="BEGIN_LINK" />Android सेटिंग्ज<ph name="END_LINK" /> मध्‍ये चालू करा.</translation>
-<translation id="1943432128510653496">पासवर्ड सेव्ह करा</translation>
-<translation id="1952172573699511566">वेबसाइट शक्य असताना तुमच्या प्राधान्य असलेल्‍या भाषेमध्ये मजकूर दाखवेल.</translation>
-<translation id="1960290143419248813">Android च्या या आवृत्तीसाठी Chrome अपडेटना सपोर्ट नाही</translation>
-<translation id="1966710179511230534">कृपया साइन इन तपशील अपडेट करा.</translation>
-<translation id="1974060860693918893">प्रगत</translation>
-<translation id="1984705450038014246">तुमचा Chrome डेटा सिंक करा</translation>
-<translation id="1984937141057606926">तृतीय-पक्षाशिवाय, अनुमती असलेले</translation>
-<translation id="1986685561493779662">नाव आधीपासून अस्तित्वात आहे</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> बटण</translation>
-<translation id="1989112275319619282">ब्राउझ करा</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> जोडू इच्छिते</translation>
-<translation id="1994173015038366702">साइट URL</translation>
-<translation id="2000419248597011803">ॲड्रेस बार आणि सर्च बॉक्समधून तुमच्या डीफॉल्ट शोध इंजिनला काही कुकीज आणि शोध पाठवते</translation>
-<translation id="2002537628803770967">Google Pay वापरून क्रेडिट कार्ड आणि पत्ते</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# फाइल}other{# फायली}}</translation>
-<translation id="2017836877785168846">ॲड्रेस बारमधील इतिहास आणि आपोआप पूर्ण केलेले साफ करते.</translation>
-<translation id="2021896219286479412">फुल स्क्रीन साइट नियंत्रणे</translation>
-<translation id="2038563949887743358">डेस्कटॉप साइट विनंती चालू करा</translation>
-<translation id="2041019821020695769">Chrome ने तुम्हाला सूचना पाठवण्यासाठी, <ph name="BEGIN_LINK" />Android सेटिंग्ज<ph name="END_LINK" /> मध्ये देखील सूचना सुरू करा.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" />चा Chrome मध्ये देखील डेटा आहे</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">साइट थांबवली</translation>
-<translation id="2063713494490388661">शोधण्यासाठी टॅप करा</translation>
-<translation id="2067805253194386918">मजकूर</translation>
-<translation id="2079545284768500474">पहिल्यासारखे करा</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" /> पैकी <ph name="RESULT_NUMBER" /> परिणाम</translation>
-<translation id="2091887806945687916">ध्वनी</translation>
-<translation id="2096012225669085171">डिव्हाइसवर सिंक आणि पर्सनलाइझ करा</translation>
-<translation id="2100273922101894616">ऑटो साइन इन करा</translation>
-<translation id="2100314319871056947">मजकूर लहान भागांमध्ये शेअर करून पाहा</translation>
-<translation id="2107397443965016585">साइटना संरक्षित आशय प्ले करू देण्याआधी विचारा (शिफारस केली जाते)</translation>
-<translation id="2111511281910874386">पेजवर जा</translation>
-<translation id="2122601567107267586">ॲप उघडता आले नाही</translation>
-<translation id="2126426811489709554">Chrome द्वारे समर्थित</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> बचत केली</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> बंद केले</translation>
-<translation id="2139186145475833000">होम स्क्रीनवर जोडा</translation>
-<translation id="2146738493024040262">झटपट ॲप्स उघडा</translation>
-<translation id="2148716181193084225">आज</translation>
-<translation id="2154484045852737596">कार्ड संपादित करा</translation>
-<translation id="2154710561487035718">URL कॉपी करा</translation>
-<translation id="2156074688469523661">उर्वरित साइट (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">तुमच्या फोनवरून दुसऱ्या डिव्हाइसवर शेअर करण्यासाठी, दोन्ही डिव्हाइसवरील Chrome सेटिंग्जमध्ये सिंक सुरू करा</translation>
-<translation id="2170088579611075216">VR ला अनुमती द्या आणि एंटर करा</translation>
-<translation id="218608176142494674">शेअर करत आहे</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> म्हणून सुरू ठेवा</translation>
-<translation id="2234876718134438132">सिंक आणि Google सेवा</translation>
-<translation id="2259659629660284697">पासवर्ड एक्सपोर्ट करा…</translation>
-<translation id="2268044343513325586">सुधारित करा</translation>
-<translation id="2286841657746966508">बिलिंग पत्ता</translation>
-<translation id="2289270750774289114">साइटला केव्हा जवळपासचे ब्लूटूथ डिव्हाइस शोधायचे आहे हे विचारा (शिफारस केलेले)</translation>
-<translation id="230115972905494466">कोणतीही कंपॅटिबल डिव्हाइस आढळली नाहीत</translation>
-<translation id="2315043854645842844">क्लायंट साइड प्रमाणपत्र निवडीला ऑपरेटिंग सिस्टमचा सपोर्ट नाही.</translation>
-<translation id="2318045970523081853">कॉल करण्यासाठी टॅप करा</translation>
-<translation id="2321086116217818302">पासवर्ड तयार करत आहे…</translation>
-<translation id="2321958826496381788">तुम्ही हे व्यवस्थित वाचू शकण्यापार्यंत स्लायडर ड्रॅग करा. परिच्छेदावर डबल-टॅपिंग केल्यानंतर मजकूर कमीत कमी यापेक्षा मोठा दिसावा.</translation>
-<translation id="2323763861024343754">साइट स्टोरेज</translation>
-<translation id="2328985652426384049">साइन इन करू शकत नाही</translation>
-<translation id="2330129964253841015">तुमचे पासवर्ड धोक्यात आल्यास तुम्हाला चेतावणी द्यायची</translation>
-<translation id="2349710944427398404">खाती, बुकमार्क आणि सेव्ह केलेल्या सेटिंग्जसह, Chrome ने वापरलेला एकूण डेटा</translation>
-<translation id="2353636109065292463">तुमचे इंटरनेट कनेक्शन तपासत आहे</translation>
-<translation id="2359808026110333948">सुरू ठेवा</translation>
-<translation id="2369533728426058518">खुले टॅब</translation>
-<translation id="2387895666653383613">मजकूर स्केलिग</translation>
-<translation id="2394602618534698961">तुम्ही डाउनलोड केलेल्या फायली येथे दिसतात</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">तुम्ही तुमच्या Google खात्यामध्ये साइन इन केल्यावर, हे वैशिष्ट्य सुरू केले जाते</translation>
-<translation id="2410754283952462441">एक खाते निवडा</translation>
-<translation id="2414886740292270097">गडद</translation>
-<translation id="2416359993254398973">या साइटसाठी Chromeला तुमचा कॅमेरा ॲक्सेस करण्याची परवानगी आवश्यक आहे.</translation>
-<translation id="2426805022920575512">दुसरे खाते निवडा</translation>
-<translation id="2433507940547922241">स्वरूप</translation>
-<translation id="2434158240863470628">डाउनलोड पूर्ण झाले <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">स्थान ॲक्सेस</translation>
-<translation id="2450083983707403292">तुम्हाला <ph name="FILE_NAME" /> चे डाउनलोड पुन्हा सुरू करायचे आहे का?</translation>
-<translation id="2482878487686419369">सूचना</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> द्वारे व्यवस्थापित केले आहे</translation>
-<translation id="2494974097748878569">Chrome मधील Google असिस्टंट</translation>
-<translation id="2496180316473517155">ब्राउझिंग इतिहास</translation>
-<translation id="2497852260688568942">तुमच्या ॲडमिनिस्ट्रेटरने सिंक अक्षम केले आहे</translation>
-<translation id="2498359688066513246">मदत आणि अभिप्राय</translation>
-<translation id="2501278716633472235">परत जा</translation>
-<translation id="2513403576141822879">गोपनीयता, सुरक्षितता आणि डेटा संकलनाशी संबंधित अधिक सेटिंग्जसाठी, <ph name="BEGIN_LINK" />सिंक आणि Google सेवा<ph name="END_LINK" /> पाहा</translation>
-<translation id="2518590038762162553">लाइट मोडमध्ये, Chrome पेज आणखी जलद लोड करते आणि ६० टक्के कमी डेटा वापरते. तुम्ही भेट दिलेली पेज ऑप्टिमाइझ करण्यासाठी, Chrome तुमचे वेब ट्रॅफिक Google ला पाठवते. <ph name="BEGIN_LINK" />अधिक जाणून घ्या<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">तुम्ही भेट दिलेल्या पेजच्या URL Google ला पाठवते</translation>
-<translation id="2532336938189706096">वेब दृश्य</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> आयटम हटवले</translation>
-<translation id="2536728043171574184">या पेजची ऑफलाइन प्रत पाहत आहे</translation>
-<translation id="2546283357679194313">कुकीज आणि साइट डेटा</translation>
-<translation id="2567385386134582609">इमेज</translation>
-<translation id="257088987046510401">थीम</translation>
-<translation id="2570922361219980984">या डिव्हाइसाठी स्थान अ‍ॅक्सेस देखील बंद आहे, <ph name="BEGIN_LINK" />Android सेटिंग्‍ज<ph name="END_LINK" /> मध्‍ये हे सुरू करा.</translation>
-<translation id="257931822824936280">विस्‍तृत केले - संकुचित करण्‍यासाठी क्‍लिक करा.</translation>
-<translation id="2581165646603367611">हे सर्व कुकी, कॅशे आणि साइटचा अन्य डेटा साफ करेल जो Chrome ला महत्त्वाचा वाटत नाही.</translation>
-<translation id="2586657967955657006">क्लिपबोर्ड</translation>
-<translation id="2587052924345400782">अधिक नवीन आवृत्ती उपलब्ध आहे</translation>
-<translation id="2593272815202181319">मोनोस्पेस</translation>
-<translation id="2612676031748830579">कार्ड नंबर</translation>
-<translation id="2621115761605608342">विशिष्ट साइटसाठी JavaScript ला अनुमती द्या.</translation>
-<translation id="2625189173221582860">पासवर्ड कॉपी केला</translation>
-<translation id="2631006050119455616">वाचवला</translation>
-<translation id="2647434099613338025">भाषा जोडा</translation>
-<translation id="2650751991977523696">फाइल पुन्हा डाउनलोड करायची?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ऑडिओ फाइल}other{# ऑडिओ फायली}}</translation>
-<translation id="2653659639078652383">सबमिट करा</translation>
-<translation id="2677748264148917807">सोडा</translation>
-<translation id="2704606927547763573">कॉपी केले</translation>
-<translation id="2707726405694321444">पृष्ठ रिफ्रेश करा</translation>
-<translation id="2709516037105925701">ऑटोफिल</translation>
-<translation id="2717722538473713889">ईमेल ॲड्रेस</translation>
-<translation id="2728754400939377704">साइटनुसार क्रमाने लावा</translation>
-<translation id="2744248271121720757">झटपट शोधण्यासाठी किंवा संबंधित ॲक्‍शन पाहण्यासाठी एखाद्या शब्दावर टॅप करा</translation>
-<translation id="2760989362628427051">तुमच्या डिव्हाइसची गडद थीम किंवा बॅटरी सेव्हर सुरू असताना गडद थीम सुरू करा</translation>
-<translation id="2762000892062317888">आत्ताच</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> सेकंद शिल्लक</translation>
-<translation id="2779651927720337254">अयशस्वी झाले</translation>
-<translation id="2781151931089541271">1 सेकंद शिल्लक</translation>
-<translation id="2801022321632964776">Chrome च्या नवीनतम आवृत्तीमध्ये तुमची भाषा मिळवण्यासाठी अपडेट करा</translation>
-<translation id="2810645512293415242">डेटा सेव्ह करण्यासाठी आणि तो लवकर लोड होण्यासाठी पेज सुलभ केले.</translation>
-<translation id="281504910091592009">तुमच्या <ph name="BEGIN_LINK" />Google खात्यामध्ये<ph name="END_LINK" /> सेव्ह केलेले पासवर्ड पाहा आणि व्यवस्थापित करा</translation>
-<translation id="2818669890320396765">तुमच्या सर्व डिव्हाइसवर तुमचे बुकमार्क मिळवण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
-<translation id="2822354292072154809">तुम्हाला नक्की <ph name="CHOSEN_OBJECT_NAME" /> साठी सर्व साइट परवानग्या रीसेट करायच्या आहेत का?</translation>
-<translation id="2836148919159985482">फुलस्क्रीन मधून बाहेर पडण्यासाठी परत बटणास स्पर्श करा.</translation>
-<translation id="2842985007712546952">मुख्य फोल्डर</translation>
-<translation id="2858138569776157458">टॉप साइट</translation>
-<translation id="2860954141821109167">या डिव्हाइसवर फोन ॲप सुरू केले असल्याची खात्री करा</translation>
-<translation id="2870560284913253234">साइट</translation>
-<translation id="2874939134665556319">मागील ट्रॅक</translation>
-<translation id="2876369937070532032">तुमची सुरक्षा धोक्यात असते तेव्हा, तुम्ही भेट दिलेल्या काही पेजचे URL Google ला पाठवते</translation>
-<translation id="2888126860611144412">Chrome बद्दल</translation>
-<translation id="2891154217021530873">पृष्ठ लोड करणे थांबवा</translation>
-<translation id="2893180576842394309">शोध आणि इतर Google सेवा पर्सनलाइझ करण्यासाठी Google कदाचित तुमच्या इतिहासाचा वापर करू शकते.</translation>
-<translation id="2898264748040935573">स्टोअर केलेला पासवर्ड संपादित करा</translation>
-<translation id="2900528713135656174">इव्हेंट तयार करा</translation>
-<translation id="290376772003165898">पेज <ph name="LANGUAGE" />मध्ये नाही?</translation>
-<translation id="2904414404539560095">पूर्ण उंचीवर उघडलेल्या टॅबसह शेअर करण्यासाठी डिव्हाइसची सूची.</translation>
-<translation id="2910701580606108292">सायटींना संरक्षित आशय प्ले करू देण्याआधी विचारा</translation>
-<translation id="2913331724188855103">कुकी डेटा सेव्ह करणे आणि वाचण्यासाठी साइटना अनुमती द्या (शिफारस केलेले)</translation>
-<translation id="2923908459366352541">नाव अवैध आहे</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> स्टोरेज</translation>
-<translation id="2942036813789421260">पूर्वावलोकन टॅब बंद आहे</translation>
-<translation id="2956410042958133412">हे खाते <ph name="PARENT_NAME_1" /> आणि <ph name="PARENT_NAME_2" /> द्वारे व्यवस्थापित केले आहे.</translation>
-<translation id="2962095958535813455">गुप्त टॅबवर स्विच केले</translation>
-<translation id="2968755619301702150">सर्टिफिकेट दर्शक</translation>
-<translation id="2979025552038692506">निवडलेला गुप्त टॅब</translation>
-<translation id="2987620471460279764">मजकूर इतर डिव्हाइसवरून शेअर केला आहे</translation>
-<translation id="2989523299700148168">अलीकडे भेट दिलेले</translation>
-<translation id="2996291259634659425">सांकेतिक पासफ्रेझ तयार करा</translation>
-<translation id="2996809686854298943">URL आवश्यक आहे</translation>
-<translation id="300526633675317032">हे सर्व <ph name="SIZE_IN_KB" /> वेबसाइट स्टोरेज साफ करेल.</translation>
-<translation id="3016635187733453316">हे डिव्हाइस इंटरनेटशी कनेक्ट केले असल्याची खात्री करा</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB डाउनलोड केले</translation>
-<translation id="3029704984691124060">सांकेतिक वाक्यांश जुळत नाहीत</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />मदत मिळवा<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">स्‍थान बंद आहे; <ph name="BEGIN_LINK" />Android सेटिंग्‍ज<ph name="END_LINK" /> मध्‍ये हे चालू करा.</translation>
-<translation id="3058498974290601450">तुम्ही सेटिंग्जमध्ये कधीही सिंक सुरू करू शकता</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> बुकमार्क}other{<ph name="BOOKMARKS_COUNT_MANY" /> बुकमार्क}}</translation>
-<translation id="3089395242580810162">गुप्त टॅबमध्ये उघडा</translation>
-<translation id="3115898365077584848">माहिती दाखवा</translation>
-<translation id="3123473560110926937">काही साइटवर ब्लॉक केले आहे</translation>
-<translation id="3137521801621304719">गुप्त मोड सोडा</translation>
-<translation id="3143515551205905069">सिंक रद्द करा</translation>
-<translation id="3157842584138209013">आणिखी पर्याय बटणावरून तुम्ही किती डेटा सेव्ह केला आहे ते पहा</translation>
-<translation id="3166827708714933426">टॅब आणि विंडो शॉर्टकट</translation>
-<translation id="3181954750937456830">सुरक्षित ब्राउझिंग (तुम्हाला आणि तुमच्या डिव्हाइसना धोकादायक साइटपासून सुरक्षित ठेवते)</translation>
-<translation id="3190152372525844641">Chrome साठी परवानग्या <ph name="BEGIN_LINK" />Android सेटिंग्ज<ph name="END_LINK" /> मध्‍ये चालू करा.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> संचयित केलेला डेटा</translation>
-<translation id="3205824638308738187">जवळजवळ पूर्ण झाले!</translation>
-<translation id="3207960819495026254">बुकमार्क केलेली</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> हटवले</translation>
-<translation id="321773570071367578">तुमचा सांकेतिक पासफ्रेझ विसरल्यास किंवा हे सेटिंग बदलू इच्छित असल्यास, <ph name="BEGIN_LINK" />सिंक रीसेट करा<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">मायक्रोफोन</translation>
-<translation id="3232754137068452469">वेब ॲप</translation>
-<translation id="3236059992281584593">1 मिनिट शिल्लक</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">या पृष्ठास बुकमार्क करा</translation>
-<translation id="3259831549858767975">पृष्ठावरील प्रत्येकगोष्ट आणखी लहान बनवा</translation>
-<translation id="3269093882174072735">इमेज लोड करा</translation>
-<translation id="3269956123044984603">तुमच्या अन्य डिव्हाइसवरून तुमचे टॅब मिळविण्यासाठी, Android खाते सेटिंग्ज मधील “डेटा ऑटो-सिंक करा” चालू करा.</translation>
-<translation id="3277252321222022663">साइटना सेन्सर ॲक्सेस करण्याची अनुमती द्या (शिफारस केलेले)</translation>
-<translation id="3282568296779691940">Chrome वर साइन इन करा</translation>
-<translation id="3288003805934695103">पृष्ठ रीलोड करणे</translation>
-<translation id="32895400574683172">सूचनांना अनुमती आहे</translation>
-<translation id="3295530008794733555">आणखी जलद ब्राउझ करा. कमी डेटा वापरा.</translation>
-<translation id="3295602654194328831">माहिती लपवा</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">आशय डाउनलोड करणे सुरु ठेवायचे?</translation>
-<translation id="3306398118552023113">हे अ‍ॅप Chrome मध्‍‍‍ये रन होत आहे</translation>
-<translation id="3315103659806849044">तुम्ही सध्या तुमचे सिंक आणि Google सेवा सेटिंग्ज कस्टमाइझ करत आहात. सिंक सुरू करणे पूर्ण करण्यासाठी, स्क्रीनच्या खालच्या बाजूला निश्चित करा बटणावर टॅप करा. वर नेव्‍हिगेट करा</translation>
-<translation id="3328801116991980348">साइट माहिती</translation>
-<translation id="3333961966071413176">सर्व संपर्क</translation>
-<translation id="3334729583274622784">फाइल एक्स्टेंशन बदलायचे आहे का?</translation>
-<translation id="3341058695485821946">तुम्ही किती डेटा सेव्ह केला ते पहा</translation>
-<translation id="3350687908700087792">सर्व गुप्त टॅब बंद करा</translation>
-<translation id="3353615205017136254">Google द्वारे पुरवलेले लाइट पेज. मूळ पेज लोड करण्यासाठी मूळ लोड करा बटणावर टॅप करा.</translation>
-<translation id="3367813778245106622">संकालन प्रारंभ करण्‍यासाठी पुन्हा साइन इन करा</translation>
-<translation id="3374023511497244703">तुमचे बुकमार्क, इतिहास, पासवर्ड आणि इतर Chrome डेटा आता तुमच्या Google खात्यामध्ये सिंक केला जाणार नाही</translation>
-<translation id="3384347053049321195">इमेज शेअर करा</translation>
-<translation id="3386292677130313581">साइटना तुमचे स्थान जाणून घेण्याची अनुमती देण्यापूर्वी विचारा (शिफारस केलेले)</translation>
-<translation id="3387650086002190359">फाइल सिस्टम एररमुळे <ph name="FILE_NAME" /> डाउनलोड अयशस्वी झाले.</translation>
-<translation id="3389286852084373014">मजकूर खूप मोठा आहे</translation>
-<translation id="3398320232533725830">बुकमार्क व्यवस्थापक उघडा</translation>
-<translation id="3414952576877147120">आकार:</translation>
-<translation id="3443221991560634068">वर्तमान पृष्‍ठ रीलोड करा</translation>
-<translation id="3445014427084483498">आताच</translation>
-<translation id="3478363558367712427">तुम्ही तुमचे शोध इंजिन निवडू शकता</translation>
+<translation id="6910211073230771657">हटवला</translation>
+<translation id="6965382102122355670">ठीक आहे</translation>
+<translation id="5301954838959518834">ठीक आहे, समजले</translation>
+<translation id="7658239707568436148">रद्द करा</translation>
 <translation id="3479552764303398839">सध्या नाही</translation>
-<translation id="3492207499832628349">नवीन गुप्त टॅब</translation>
-<translation id="3493531032208478708">सूचित केलेल्या आशयविषयी <ph name="BEGIN_LINK" />अधिक जाणून घ्या<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">ऑगमेंटेड रिअ‍ॅलिटी</translation>
-<translation id="3518985090088779359">स्वीकारा आणि सुरु ठेवा</translation>
-<translation id="3522247891732774234">अपडेट उपलब्ध आहे. आणखी पर्याय</translation>
-<translation id="3524138585025253783">डेव्हलपर UI</translation>
-<translation id="3527085408025491307">फोल्डर</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB उपलब्ध</translation>
-<translation id="3549657413697417275">तुमचा इतिहास शोधा</translation>
-<translation id="3557336313807607643">संपर्कांमध्ये जोडा</translation>
-<translation id="3566923219790363270">Chrome अजूनही VR ची तयारी करत आहे. Chrome नंतर रीस्टार्ट करा.</translation>
-<translation id="3568688522516854065">तुमच्या इतर डिव्हाइसवरून तुमचे टॅब मिळविण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
-<translation id="3587482841069643663">सर्व</translation>
-<translation id="358794129225322306">साइटला एकाहून अधिक फायली आपोआप डाउनलोड करू द्या.</translation>
-<translation id="3590487821116122040">Chrome साइट स्टोरेज यास महत्त्व देत नाही (उदा. ज्या साइटमध्ये सेटिंग्ज सेव्ह केलेल्या नसतात किंवा तुम्ही सहसा भेट देत नाही अशा साइट)</translation>
-<translation id="3599863153486145794">साइन-इन केलेल्या सर्व डिव्हाइसमधून इतिहास साफ करते. तुमच्या Google खात्यामध्ये <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> वर कदाचित ब्राउझिंगचे इतर फॉर्म असतील.</translation>
-<translation id="3600792891314830896">ध्वनी प्ले करणाऱ्या साइट म्यूट करा</translation>
-<translation id="3616113530831147358">ऑडिओ</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> शी शेअर करत आहे</translation>
-<translation id="3632295766818638029">पासवर्ड पहा</translation>
-<translation id="363596933471559332">स्टोअर क्रेडेंशियल वापरून वेबसाइटवर आपोआप साइन इन करा. वैशिष्ट्य बंद असते तेव्हा, वेबसाइटवर साइन इन करण्यापूर्वी दरवेळी तुम्हाला पडताळणीसाठी विचारले जाईल.</translation>
-<translation id="3658159451045945436">रीसेट केल्याने तुमचा डेटा सेव्हिंग इतिहास, भेट दिलेल्या साइटच्या सूचीसह, मिटवला जातो.</translation>
-<translation id="3692944402865947621"><ph name="FILE_NAME" /> download failed because storage location is not reachable.</translation>
-<translation id="3714981814255182093">शोध बार उघडा</translation>
-<translation id="3716182511346448902">हे पेज खूपच जास्त मेमरी वापरत असल्यामुळे Chrome ने ते थांबवून ठेवलेले आहे.</translation>
-<translation id="3730075448226062617">Chrome ला तुमच्या मायक्रोफोनचा ॲक्सेस द्या, <ph name="BEGIN_LINK" />Android सेटिंग्ज<ph name="END_LINK" /> मध्ये देखील मायक्रोफोन सुरू करा.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> मध्ये बुकमार्क केले</translation>
-<translation id="3744111561329211289">पार्श्वभूमी संकालन</translation>
-<translation id="3771001275138982843">अपडेट डाउनलोड करता आले नाही</translation>
-<translation id="3771033907050503522">गुप्त टॅब</translation>
-<translation id="3773755127849930740">पेअरिंगला अनुमती देण्‍यासाठी <ph name="BEGIN_LINK" />ब्लूटूथ सुरू करा<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">तुमच्या डिव्हाइसवर पाठवा</translation>
-<translation id="3778956594442850293">होम स्क्रीनवर जोडले</translation>
-<translation id="3789841737615482174">स्थापना करा</translation>
-<translation id="3810838688059735925">व्हिडिओ</translation>
-<translation id="3810973564298564668">व्यवस्थापित करा</translation>
-<translation id="381841723434055211">फोन नंबर</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> डाउनलोड हटविले</translation>
-<translation id="3822502789641063741">साइट स्टोरेज साफ करायचे?</translation>
-<translation id="385051799172605136">मागील</translation>
-<translation id="3859306556332390985">पुढे शोधा</translation>
-<translation id="3894427358181296146">फोल्डर जोडा</translation>
-<translation id="3895926599014793903">झूम सुरू करण्याची सक्ती</translation>
-<translation id="3912508018559818924">वेबवरून सर्वोत्तम शोधत आहे…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">माझा डेटा एकत्र करा</translation>
-<translation id="393697183122708255">सक्षम केलेला कोणताही व्हॉइस शोध उपलब्ध नाही</translation>
-<translation id="395206256282351086">शोध आणि साइट सूचना बंद आहेत</translation>
-<translation id="3955193568934677022">संरक्षित आशय प्ले करण्यासाठी साइटना अनुमती द्या (शिफारस केलेले)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{तयार झाल्यावर, Chrome तुमचे पेज लोड करेल}other{तयार झाल्यावर, Chrome तुमची पेज लोड करेल}}</translation>
-<translation id="3963007978381181125">पासफ्रेज एंक्रिप्शनमध्ये Google Pay वरील पेमेंट पद्धतींचा आणि पत्त्यांचा समावेश नसतो. फक्त तुमचा पासफ्रेज असलेली एखादी व्यक्ती तुमचा एंक्रिप्ट केलेला डेटा वाचू शकते. पासफ्रेज Google कडे पाठवला किंवा त्याद्वारे स्टोअर केला जात नाही. तुम्ही तुमचा पासफ्रेज विसरल्यास किंवा तुम्हाला हे सेटिंग बदलायचे असल्यास, तुम्हाला सिंक रीसेट करण्याची आवश्यकता असेल. <ph name="BEGIN_LINK" />अधिक जाणून घ्या<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">पूर्ण डाउनलोड करा</translation>
-<translation id="397583555483684758">संकालनाने कार्य करणे थांबविले आहे</translation>
-<translation id="3976396876660209797">हा शॉर्टकट काढून टाका आणि पुन्हा तयार करा</translation>
-<translation id="3985215325736559418">तुम्ही <ph name="FILE_NAME" /> पुन्हा डाउनलोड करू इच्छिता?</translation>
-<translation id="3987993985790029246">लिंक कॉपी करा</translation>
-<translation id="3988213473815854515">स्थानास अनुमती आहे</translation>
-<translation id="3988466920954086464">या पॅनलमध्ये इंस्टंट शोध परिणाम पहा</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">महत्त्वाचा नसलेले स्टोरेज</translation>
-<translation id="4000212216660919741">ऑफलाइन होम</translation>
+<translation id="5317780077021120954">सेव्ह करा</translation>
+<translation id="4570913071927164677">तपशील</translation>
+<translation id="8730621377337864115">पूर्ण झाले</translation>
+<translation id="8261506727792406068">हटवा</translation>
+<translation id="1181037720776840403">काढून टाका</translation>
+<translation id="5939518447894949180">रीसेट करा</translation>
 <translation id="4002066346123236978">शीर्षक</translation>
-<translation id="4008040567710660924">विशिष्ट साइटसाठी कुकीना अनुमती द्या.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# तास}other{# तास}}</translation>
-<translation id="4046123991198612571">पुढील ट्रॅक</translation>
-<translation id="4048707525896921369">पेज न सोडता वेबसाइटवरील विषयांबद्दल जाणून घ्या. शोधण्यासाठी टॅप करा शब्द आणि त्याच्या आसपासचा संदर्भ Google शोध ला पाठवते आणि व्याख्या, चित्रे, शोध परिणाम आणि इतर तपशील मिळवते.
+<translation id="5916664084637901428">चालू</translation>
+<translation id="5860033963881614850">बंद</translation>
+<translation id="6165508094623778733">अधिक जाणून घ्या</translation>
+<translation id="6042308850641462728">अधिक</translation>
+<translation id="6040143037577758943">बंद करा</translation>
+<translation id="780301667611848630">नाही, नको</translation>
+<translation id="1201402288615127009">पुढील</translation>
+<translation id="2359808026110333948">सुरू ठेवा</translation>
+<translation id="2653659639078652383">सबमिट करा</translation>
+<translation id="2079545284768500474">पहिल्यासारखे करा</translation>
+<translation id="7649070708921625228">मदत</translation>
+<translation id="2148716181193084225">आज</translation>
+<translation id="7781829728241885113">काल</translation>
+<translation id="6945221475159498467">निवडा</translation>
+<translation id="7791543448312431591">जोडा</translation>
+<translation id="6527303717912515753">शेअर करा</translation>
+<translation id="1383876407941801731">शोधा</translation>
+<translation id="3115898365077584848">माहिती दाखवा</translation>
+<translation id="3295602654194328831">माहिती लपवा</translation>
+<translation id="3987993985790029246">लिंक कॉपी करा</translation>
+<translation id="2704606927547763573">कॉपी केले</translation>
+<translation id="8725066075913043281">पुन्हा प्रयत्न करा</translation>
+<translation id="385051799172605136">मागील</translation>
+<translation id="8131740175452115882">पुष्टी करा</translation>
+<translation id="5300589172476337783">दर्शवा</translation>
+<translation id="1124772482545689468">वापरकर्ता</translation>
+<translation id="8609465669617005112">वर हलवा</translation>
+<translation id="6746124502594467657">खाली हलवा</translation>
+<translation id="8249310407154411074">वर न्या</translation>
+<translation id="8428213095426709021">सेटिंग्ज</translation>
+<translation id="2498359688066513246">मदत आणि अभिप्राय</translation>
+<translation id="8378714024927312812">तुमच्या संस्थेकडून व्यवस्थापित केलेले</translation>
+<translation id="9019902583201351841">आपल्या पालकांद्वारे व्यवस्थापित करण्यात आले</translation>
+<translation id="4645575059429386691">आपल्या पालकांद्वारे व्यवस्थापित करण्यात आले</translation>
+<translation id="4883854917563148705">व्यवस्थापित केलेल्या सेटिंग्ज रीसेट करता येत नाहीत</translation>
+<translation id="4307992518367153382">मूलभूत</translation>
+<translation id="1974060860693918893">प्रगत</translation>
+<translation id="1146678959555564648">VR एंटर करा</translation>
+<translation id="987264212798334818">सामान्य</translation>
+<translation id="4275663329226226506">माध्यम</translation>
+<translation id="4759238208242260848">डाउनलोड</translation>
+<translation id="218608176142494674">शेअर करत आहे</translation>
+<translation id="8004582292198964060">ब्राउझर</translation>
+<translation id="1105960400813249514">स्‍क्रीन कॅप्‍चर</translation>
+<translation id="4875775213178255010">आशय सूचना</translation>
+<translation id="2021896219286479412">फुल स्क्रीन साइट नियंत्रणे</translation>
+<translation id="4587589328781138893">साइट</translation>
+<translation id="4943703118917034429">आभासी वास्तविकता</translation>
+<translation id="1928696683969751773">अपडेट</translation>
+<translation id="6064125863973209585">डाउनलोड पूर्ण झाले</translation>
+<translation id="5342314432463739672">परवानगीच्या विनंत्या</translation>
+<translation id="629730747756840877">खाते</translation>
+<translation id="82609232232243542">Brave वर साइन इन करा</translation>
+<translation id="7956662517480676674">सिंक आणि Brave Software सेवा</translation>
+<translation id="5294439808117722387">तुम्ही सध्या तुमचे सिंक आणि Brave Software सेवा सेटिंग्ज कस्टमाइझ करत आहात. सिंक सुरू करणे पूर्ण करण्यासाठी, स्क्रीनच्या खालच्या बाजूला निश्चित करा बटणावर टॅप करा. वर नेव्‍हिगेट करा</translation>
+<translation id="2096012225669085171">डिव्हाइसवर सिंक आणि पर्सनलाइझ करा</translation>
+<translation id="1692118695553449118">संकालन चालू आहे</translation>
+<translation id="5514904542973294328">या डिव्हाइसच्या ॲडमिनिस्ट्रेटरने बंद केले आहे.</translation>
+<translation id="6447211988989208781">Brave Software ॲक्टिव्हिटी नियंत्रणे</translation>
+<translation id="4882831918239250449">तुम्ही ब्राउझ करत असलेला इतिहास पर्सनलाइझ शोध, जाहिराती आणि बरेच काही करण्यासाठी कसा वापरला जातो ते नियंत्रित करा</translation>
+<translation id="7431991332293347422">शोध पर्सनलाइझ करण्यासाठी तुमचा ब्राउझिंग इतिहास कसा वापरला जातो ते आणि बरेच काही नियंत्रित करा</translation>
+<translation id="6303969859164067831">साइन आउट करा आणि सिंक बंद करा</translation>
+<translation id="1125261911132334651">तुमचे Brave Software खाते व्यवस्थापित करा</translation>
+<translation id="6406506848690869874">Sync</translation>
+<translation id="714362445477979774">तुमचा Brave डेटा सिंक करा</translation>
+<translation id="4314815835985389558">सिंक व्यवस्थापित करा</translation>
+<translation id="5428209950370661546">इतर Brave Software सेवा</translation>
+<translation id="7704317875155739195">ऑटोकंप्लीट शोध आणि URL</translation>
+<translation id="2000419248597011803">ॲड्रेस बार आणि सर्च बॉक्समधून तुमच्या डीफॉल्ट शोध इंजिनला काही कुकीज आणि शोध पाठवते</translation>
+<translation id="7981313251711023384">जलद ब्राउझिंग आणि शोधाकरता पेज आधीच लोड करा</translation>
+<translation id="1821253160463689938">तुम्ही त्या पेजना भेट दिली नसली तरीही, तुमची प्राधान्ये लक्षात ठेवण्यासाठी कुकीचा वापर करते</translation>
+<translation id="6697492270171225480">जेव्हा एखादे पेज सापडत नाही तेव्हा त्यासारख्या पेजच्या सूचना दाखवा</translation>
+<translation id="8109318360573330108">तुम्ही ज्या पेजवर पोहोचण्याचा प्रयत्न करत आहात त्याची URL Brave Software ला पाठवते</translation>
+<translation id="8438566539970814960">शोध आणि ब्राउझ करणे चांगले करा</translation>
+<translation id="284843628681142937">तुम्ही भेट दिलेल्या पेजच्या URL Brave Software ला पाठवते</translation>
+<translation id="7222718784508482526">गोपनीयता, सुरक्षितता आणि डेटा संकलनाशी संबंधित अधिक सेटिंग्जसाठी, <ph name="BEGIN_LINK"/>सिंक आणि Brave Software सेवा<ph name="END_LINK"/> पाहा</translation>
+<translation id="918192811481327695">Brave ची वैशिष्ट्ये आणि परफॉर्मन्स सुधारण्यात मदत करा</translation>
+<translation id="9063160602596686558">Brave Software ला वापर आकडेवारी आणि क्रॅश अहवाल आपोआप पाठवते</translation>
+<translation id="4824958205181053313">सिंक रद्द करायचे?</translation>
+<translation id="3058498974290601450">तुम्ही सेटिंग्जमध्ये कधीही सिंक सुरू करू शकता</translation>
+<translation id="3143515551205905069">सिंक रद्द करा</translation>
+<translation id="1506061864768559482">शोध इंजिन</translation>
+<translation id="55737423895878184">स्‍थान आणि सूचनांना अनुमती आहे</translation>
+<translation id="3988213473815854515">स्थानास अनुमती आहे</translation>
+<translation id="32895400574683172">सूचनांना अनुमती आहे</translation>
+<translation id="9040142327097499898">सूचनांना अनुमती आहे. या डिव्हाइससाठी स्‍थान बंद आहे.</translation>
+<translation id="305593374596241526">स्‍थान बंद आहे; <ph name="BEGIN_LINK"/>Android सेटिंग्‍ज<ph name="END_LINK"/> मध्‍ये हे चालू करा.</translation>
+<translation id="2989523299700148168">अलीकडे भेट दिलेले</translation>
+<translation id="6433501201775827830">तुमचे शोध इंजिन निवडा</translation>
+<translation id="7177466738963138057">तुम्ही हे नंतर सेटिंग्ज मध्ये बदलू शकता.</translation>
+<translation id="3478363558367712427">तुम्ही तुमचे शोध इंजिन निवडू शकता</translation>
+<translation id="4910889077668685004">पेमेंट ॲप्स</translation>
+<translation id="5152843274749979095">कोणतेही समर्थित ॲप्स इंस्टॉल केले नाहीत</translation>
+<translation id="8812260976093120287">काही वेबसाइटवर, तुम्ही आपल्या डिव्हाइसवर वरील समर्थित पेमेंट ॲप्ससह पेमेंट देऊ शकता.</translation>
+<translation id="7764225426217299476">पत्ता जोडा</translation>
+<translation id="5595485650161345191">पत्ता संपादित करा</translation>
+<translation id="5087580092889165836">कार्ड जोडा</translation>
+<translation id="2154484045852737596">कार्ड संपादित करा</translation>
+<translation id="6140912465461743537">देश/प्रदेश</translation>
+<translation id="5659593005791499971">ईमेल</translation>
+<translation id="4378154925671717803">फोन</translation>
+<translation id="4807098396393229769">कार्डवरील नाव</translation>
+<translation id="860043288473659153">कार्डधारकाचे नाव</translation>
+<translation id="2612676031748830579">कार्ड नंबर</translation>
+<translation id="869891660844655955">कालावधी समाप्ती तारीख</translation>
+<translation id="2286841657746966508">बिलिंग पत्ता</translation>
+<translation id="663059986967017181">Brave वर कॉपी केले</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> अधिक}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> अधिक}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> अधिक}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> अधिक}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> अधिक}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> अधिक}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> अधिक}other{<ph name="CONTACT_PREVIEW"/>\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> अधिक}}</translation>
+<translation id="7029809446516969842">पासवर्ड</translation>
+<translation id="1943432128510653496">पासवर्ड सेव्ह करा</translation>
+<translation id="2100273922101894616">ऑटो साइन इन करा</translation>
+<translation id="363596933471559332">स्टोअर क्रेडेंशियल वापरून वेबसाइटवर आपोआप साइन इन करा. वैशिष्ट्य बंद असते तेव्हा, वेबसाइटवर साइन इन करण्यापूर्वी दरवेळी तुम्हाला पडताळणीसाठी विचारले जाईल.</translation>
+<translation id="6995899638241819463">डेटा भंगामध्ये पासवर्ड उघड झाल्यास, तुम्हाला चेतावणी द्या</translation>
+<translation id="1534287762301776620">तुम्ही तुमच्या Brave Software खात्यामध्ये साइन इन केल्यावर, हे वैशिष्ट्य सुरू केले जाते</translation>
+<translation id="10614374240317010">कधीही सेव्ह न केलेले</translation>
+<translation id="3098842761938485917">तुमच्या <ph name="BEGIN_LINK"/>Brave Software खात्यामध्ये<ph name="END_LINK"/> सेव्ह केलेले पासवर्ड पाहा आणि व्यवस्थापित करा</translation>
+<translation id="8562452229998620586">सेव्ह केलेले पासवर्ड येथे दिसून येतील.</translation>
+<translation id="8084114998886531721">सेव्ह केलेले पासवर्ड</translation>
+<translation id="2870560284913253234">साइट</translation>
+<translation id="8503813439785031346">वापरकर्तानाव</translation>
+<translation id="6657585470893396449">पासवर्ड</translation>
+<translation id="2154710561487035718">URL कॉपी करा</translation>
+<translation id="1571304935088121812">वापरकर्तानाव कॉपी करा</translation>
+<translation id="5005498671520578047">पासवर्ड कॉपी करा</translation>
+<translation id="3632295766818638029">पासवर्ड पहा</translation>
+<translation id="1513858653616922153">पासवर्ड हटवा</translation>
+<translation id="543338862236136125">पासवर्ड संपादित करा</translation>
+<translation id="4565377596337484307">पासवर्ड लपवा</translation>
+<translation id="8523928698583292556">स्टोअर केलेला पासवर्ड हटवा</translation>
+<translation id="2898264748040935573">स्टोअर केलेला पासवर्ड संपादित करा</translation>
+<translation id="5433691172869980887">वापरकर्तानाव कॉपी केले</translation>
+<translation id="5534640966246046842">साइट कॉपी केली</translation>
+<translation id="2625189173221582860">पासवर्ड कॉपी केला</translation>
+<translation id="4550003330909367850">तुमचा पासवर्ड येथे पाहण्यासाठी किंवा कॉपी करण्यासाठी या डीव्हाइसवर स्क्रीन लॉक सेट करा.</translation>
+<translation id="6154478581116148741">तुमचे पासवर्ड या डिव्हाइसवरून एक्सपोर्ट करण्यासाठी सेटिंग्जमधील लॉक स्क्रीन चालू करा</translation>
+<translation id="4842092870884894799">पासवर्ड निर्मिती पॉपअप दाखवत आहे</translation>
+<translation id="2259659629660284697">पासवर्ड एक्सपोर्ट करा…</translation>
+<translation id="133012818630824069">Brave सह स्टोअर केलेला पासवर्ड पाठवा</translation>
+<translation id="6914783257214138813">एक्सपोर्ट करण्यात आलेली फाइल दिसणार्‍या प्रत्येकाला, तुमचा पासवर्ड दिसेल.</translation>
+<translation id="2321086116217818302">पासवर्ड तयार करत आहे…</translation>
+<translation id="8445448999790540984">पासवर्ड एक्सपोर्ट करू शकत नाही</translation>
+<translation id="3066461326500799725">Brave Software ड्राइव्ह कसे वापरावे ते जाणून घ्या</translation>
+<translation id="729975465115245577">पासवर्ड फाइल स्टोअर करण्यासाठी तुमच्या डिव्हाइसमध्ये अ‍ॅप नाही.</translation>
+<translation id="7682724950699840886">खालील टिपा वापरून पहा: तुमच्या डिव्हाइसवर पुरेशी जागा असल्याची खात्री करा, पुन्हा एक्सपोर्ट करण्याचा प्रयत्न करा.</translation>
+<translation id="1129510026454351943">तपशील: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">तुमचा पासवर्ड कॉपी करण्यासाठी अनलॉक करा</translation>
+<translation id="5515439363601853141">तुमचा पासवर्ड पाहण्यासाठी अनलॉक करा</translation>
+<translation id="6221633008163990886">तुमचे पासवर्ड एक्सपोर्ट करण्यासाठी अनलॉक करा</translation>
+<translation id="230699814587342492">Brave पासवर्ड</translation>
+<translation id="6075798973483050474">होम पेज संपादित करा</translation>
+<translation id="854522910157234410">हे पृष्ठ उघडा</translation>
+<translation id="2482878487686419369">सूचना</translation>
+<translation id="6255999984061454636">आशय सूचना</translation>
+<translation id="805047784848435650">तुमच्या ब्राउझ करण्याच्या इतिहासावर आधारित</translation>
+<translation id="1041308826830691739">वेबसाइटवरून</translation>
+<translation id="395206256282351086">शोध आणि साइट सूचना बंद आहेत</translation>
+<translation id="257088987046510401">थीम</translation>
+<translation id="4650364565596261010">सिस्टम डीफॉल्ट</translation>
+<translation id="7588219262685291874">तुमच्या डिव्हाइसचे बॅटरी सेव्हर सुरू असेल तेव्हा गडद थीम सुरू करा</translation>
+<translation id="2760989362628427051">तुमच्या डिव्हाइसची गडद थीम किंवा बॅटरी सेव्हर सुरू असताना गडद थीम सुरू करा</translation>
+<translation id="6381421346744604172">डार्कन वेबसाइट</translation>
+<translation id="5040262127954254034">गोपनीयता</translation>
+<translation id="4991384657077828949">Brave सुरक्षेमध्ये सुधारणा करण्यात मदत करा</translation>
+<translation id="1943176487615318915">धोकादायक ॲप्स आणि साइट शोधण्यासाठी, Brave तुम्ही भेट दिलेल्या काही पेजचे URL, मर्यादित सिस्टमची माहिती आणि काही पेजचा आशय Brave Software कडे पाठवतो</translation>
+<translation id="3181954750937456830">सुरक्षित ब्राउझिंग (तुम्हाला आणि तुमच्या डिव्हाइसना धोकादायक साइटपासून सुरक्षित ठेवते)</translation>
+<translation id="7315322926489145388">तुमची सुरक्षा धोक्यात असते तेव्हा, तुम्ही भेट दिलेल्या काही पेजचे URL Brave Software ला पाठवते</translation>
+<translation id="2063713494490388661">शोधण्यासाठी टॅप करा</translation>
+<translation id="2369463299479365221">पेज न सोडता वेबसाइटवरील विषयांबद्दल जाणून घ्या. शोधण्यासाठी टॅप करा शब्द आणि त्याच्या आसपासचा संदर्भ Brave Software शोध ला पाठवते आणि व्याख्या, चित्रे, शोध परिणाम आणि इतर तपशील मिळवते.
 
 तुमची शोध संज्ञा ॲडजस्ट करण्यासाठी, निवडण्याकरिता दाबून ठेवा. तुमचा शोध रिफाइन करण्यासाठी, पॅनल पूर्णपणे वर स्लाइड करा आणि सर्च बॉक्सवर टॅप करा.</translation>
-<translation id="4056223980640387499">सेपिया</translation>
-<translation id="4060598801229743805">स्क्रीनच्या शीर्षावर पर्याय उपलब्ध आहेत</translation>
-<translation id="4062305924942672200">कायदेशीर माहिती</translation>
-<translation id="4084682180776658562">बुकमार्क</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" /> कडून – <ph name="BEGIN_DEEMPHASIZED" />Google ने वितरित केले<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">ॲप डेटा हटवायचा?</translation>
-<translation id="4099578267706723511">वापर आकडेवारी आणि क्रॅश अहवाल Google कडे पाठवून Chrome अधिक चांगले करण्यास मदत करा.</translation>
-<translation id="410351446219883937">ऑटोप्ले</translation>
-<translation id="4116038641877404294">पेज ऑफलाइन वापरण्यासाठी ती डाउनलोड करा</translation>
-<translation id="4135200667068010335">बंद केलेल्या टॅबसह शेअर करण्यासाठी डिव्हाइसची सूची.</translation>
-<translation id="4149994727733219643">वेब पेजसाठी सोपा केलेला व्ह्यू</translation>
-<translation id="4165986682804962316">साइट सेटिंग्ज</translation>
-<translation id="4169535189173047238">अनुमती देऊ नका</translation>
-<translation id="4170011742729630528">सेवा उपलब्ध नाही; नंतर पुन्हा प्रयत्न करा.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> वापरला</translation>
-<translation id="4181841719683918333">भाषा</translation>
-<translation id="4183868528246477015"><ph name="BEGIN_NEW" />नवीन<ph name="END_NEW" /> Google लेन्स वापरून शोधा</translation>
-<translation id="4195643157523330669">नवीन टॅबमध्ये उघडा</translation>
-<translation id="4198423547019359126">कोणतीही डाउनलोड स्थाने उपलब्ध नाहीत</translation>
-<translation id="4209895695669353772">Google ने सुचवलेला पर्सनलाइझ केलेला आशय मिळवण्यासाठी, सिंक सुरू करा</translation>
-<translation id="4226663524361240545">सूचनांमुळे डिव्हाइसचे कंपन होऊ शकते</translation>
-<translation id="423219824432660969"><ph name="TIME" /> पर्यंत Google पासवर्डसह सिंक केलेला डेटा एंक्रिप्ट करा</translation>
-<translation id="4242533952199664413">सेटिंग्ज उघडा</translation>
-<translation id="4256782883801055595">मुक्त स्रोत परवाने</translation>
-<translation id="4259722352634471385">नेव्हिगेशन अवरोधित केले आहे: <ph name="URL" /></translation>
-<translation id="4269820728363426813">लिंकचा पत्ता कॉपी करा</translation>
-<translation id="4275663329226226506">माध्यम</translation>
-<translation id="4278390842282768270">अनुमत</translation>
-<translation id="429312253194641664">साइट मीडिया प्ले करत आहे</translation>
-<translation id="4298388696830689168">लिंक केलेल्या साइट</translation>
-<translation id="4307992518367153382">मूलभूत</translation>
-<translation id="4314815835985389558">सिंक व्यवस्थापित करा</translation>
-<translation id="4351244548802238354">डायलॉग बंद करा</translation>
-<translation id="4378154925671717803">फोन</translation>
-<translation id="4384468725000734951">शोध करण्‍यासाठी Sogou वापरत आहे</translation>
-<translation id="4404568932422911380">कोणतेही बुकमार्क नाहीत</translation>
-<translation id="4405224443901389797">यामध्ये हलवा…</translation>
-<translation id="4411535500181276704">लाइट मोड</translation>
-<translation id="4415276339145661267">तुमचे Google खाते व्यवस्थापित करा</translation>
-<translation id="4432792777822557199">आतापासून पेज <ph name="SOURCE_LANGUAGE" />मधून <ph name="TARGET_LANGUAGE" />मध्ये भाषांतरित केली जातील</translation>
-<translation id="4433925000917964731">Google द्वारे पुरवलेले लाइट पेज</translation>
-<translation id="4434045419905280838">पॉप-अप आणि रीडिरेक्ट</translation>
-<translation id="4440958355523780886">Google ने पुरवलेले लाइट पेज. मूळ पेज लोड करण्यासाठी टॅप करा.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> टॅब बंद करा</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> ला बुकमार्क केले</translation>
-<translation id="445467742685312942">साइटना संरक्षित आशय प्ले करू द्या</translation>
-<translation id="4468959413250150279">विशिष्ट साइटसाठी ध्वनी म्यूट करा.</translation>
-<translation id="4472118726404937099">सर्व डिव्हाइसवर सिंक आणि पर्सनलाइझ करण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
-<translation id="447252321002412580">Chrome ची वैशिष्ट्ये आणि परफॉर्मन्स सुधारण्यात मदत करा</translation>
-<translation id="4479647676395637221">साइटना तुमचा कॅमेरा वापरण्याची अनुमती देण्यापूर्वी प्रथम विचारा (शिफारस केलेले)</translation>
-<translation id="4479972344484327217">Chrome साठी <ph name="MODULE" /> इंस्टॉल करत आहे…</translation>
-<translation id="4487967297491345095">Chrome चा सर्व ॲप डेटा कायमचा हटवला जाईल. यामध्ये सर्व फायली, सेटिंग्ज, खाती, डेटाबेस, इ. चा समावेश होतो.</translation>
-<translation id="4493497663118223949">लाइट मोड सुरू आहे</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# दिवसापूर्वी}other{# दिवसांपूर्वी}}</translation>
-<translation id="451872707440238414">तुमचे बुकमार्क शोधा</translation>
-<translation id="4521489764227272523">निवडलेला डेटा Chrome वरून आणि तुमच्या सिंक केलेल्या डिव्हाइसवरून काढला गेला आहे.
-
-तुमच्या Google खात्यात <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> येथील इतर Google सेवांवरील शोध आणि अ‍ॅक्टिव्हिटी यांसारखा इतर स्वरूपातील ब्राउझिंग इतिहास असू शकतो.</translation>
-<translation id="4532845899244822526">फोल्डर निवडा</translation>
-<translation id="4538018662093857852">लाइट मोड सुरू करा</translation>
-<translation id="4550003330909367850">तुमचा पासवर्ड येथे पाहण्यासाठी किंवा कॉपी करण्यासाठी या डीव्हाइसवर स्क्रीन लॉक सेट करा.</translation>
-<translation id="4558311620361989323">वेबपेज शॉर्टकट</translation>
-<translation id="4561979708150884304">कनेक्शन नाही</translation>
-<translation id="4565377596337484307">पासवर्ड लपवा</translation>
-<translation id="4570913071927164677">तपशील</translation>
-<translation id="4572422548854449519">व्यवस्थापित केलेल्या खात्यामध्ये साइन इन करा</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# मिनिटापूर्वी}other{# मिनिटांपूर्वी}}</translation>
-<translation id="4587589328781138893">साइट</translation>
-<translation id="4594952190837476234">हे <ph name="CREATION_TIME" /> पासूनचे ऑफलाइन पेज आहे आणि ऑनलाइन आवृत्तीपेक्षा वेगळे असू शकते.</translation>
-<translation id="4605958867780575332">आयटम काढला: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> उघडा</translation>
-<translation id="4634124774493850572">पासवर्ड वापरा</translation>
-<translation id="4645575059429386691">आपल्या पालकांद्वारे व्यवस्थापित करण्यात आले</translation>
-<translation id="4650364565596261010">सिस्टम डीफॉल्ट</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> बुकमार्क हटविले</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> ला तुमच्या होम स्क्रीनवर पेअरिंग आले</translation>
-<translation id="4684427112815847243">सर्वकाही संंकालित करा</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> अधिक}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> अधिक}}</translation>
-<translation id="4696983787092045100">तुमच्या डिव्हाइसवर एसएमएस पाठवा</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> मध्ये ऑफलाइन पाहा</translation>
-<translation id="4699172675775169585">कॅश   इमेज आणि फायली</translation>
-<translation id="4714588616299687897">तुमचा सुमारे 60% डेटा वाचवा</translation>
-<translation id="4719927025381752090">भाषांतर करण्यास ऑफर करा</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" /> मध्‍ये उघडा</translation>
-<translation id="4720982865791209136">Chrome सुधारण्यात मदत करा. <ph name="BEGIN_LINK" />सर्वेक्षण करा<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">अपडेट करा</translation>
-<translation id="4738836084190194332">अखेरचे संकालित: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">एक नवीन टॅब उघडा</translation>
-<translation id="4751476147751820511">मोशन किंवा प्रकाश सेन्सर</translation>
-<translation id="4759238208242260848">डाउनलोड</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{एक डाउनलोड पूर्ण झाला आहे.}other{# डाउनलोड पूर्ण झाले आहेत.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" /> वर परत येण्‍यासाठी स्पर्श करा</translation>
-<translation id="4802417911091824046">पासफ्रेज एंक्रिप्शनमध्ये Google Pay वरील पेमेंट पद्धतींचा आणि पत्त्यांचा समावेश नसतो.
-
-हे सेटिंग बदलण्यासाठी, <ph name="BEGIN_LINK" />सिंक रीसेट करा<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">कार्डवरील नाव</translation>
-<translation id="4824958205181053313">सिंक रद्द करायचे?</translation>
-<translation id="4837753911714442426">पेज प्रिंट करण्‍यासाठी पर्याय उघडा</translation>
-<translation id="4842092870884894799">पासवर्ड निर्मिती पॉपअप दाखवत आहे</translation>
-<translation id="4860895144060829044">कॉल करा</translation>
-<translation id="4866368707455379617">Chrome साठी <ph name="MODULE" /> इंस्टॉल करू शकत नाही</translation>
-<translation id="4875775213178255010">आशय सूचना</translation>
-<translation id="4878404682131129617">प्रॉक्सी सर्व्हर मार्फत टनेल स्थापन करणे अयशस्वी झाले</translation>
-<translation id="4880127995492972015">भाषांतर करा…</translation>
-<translation id="4881695831933465202">उघडा</translation>
-<translation id="488187801263602086">फाइलला पुन्हा नाव द्या</translation>
-<translation id="4882831918239250449">तुम्ही ब्राउझ करत असलेला इतिहास पर्सनलाइझ शोध, जाहिराती आणि बरेच काही करण्यासाठी कसा वापरला जातो ते नियंत्रित करा</translation>
-<translation id="4883854917563148705">व्यवस्थापित केलेल्या सेटिंग्ज रीसेट करता येत नाहीत</translation>
-<translation id="4885273946141277891">Chrome उदाहरणांची असमर्थित संख्या.</translation>
-<translation id="4910889077668685004">पेमेंट ॲप्स</translation>
-<translation id="4913161338056004800">आकडेवारी रीसेट करा</translation>
-<translation id="4913169188695071480">रिफ्रेश करणे थांबवा</translation>
-<translation id="4915549754973153784">डिव्हाइस स्कॅन करत असताना <ph name="BEGIN_LINK" />मदत मिळवा<ph name="END_LINK" />…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# पेज}other{# पेज}}</translation>
-<translation id="4932247056774066048"><ph name="DOMAIN_NAME" /> द्वारे व्यवस्थापित केलेल्या खात्यामधून तुम्ही साइन आउट करत असल्यामुळे, या डिव्हाइसवरून Chrome डेटा हटवला जाईल. तो तुमच्या Google खात्यामध्ये तसाच राहिल.</translation>
-<translation id="4943703118917034429">आभासी वास्तविकता</translation>
-<translation id="4943872375798546930">परिणाम नाहीत</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> तुमची स्क्रीन शेअर करत आहे</translation>
-<translation id="4961107849584082341">या पेजचे कोणत्याही भाषेत भाषांतर करा</translation>
-<translation id="4962975101802056554">डिव्हाइससाठीच्या सर्व परवानग्या रद्द करा</translation>
-<translation id="4970824347203572753">तुमच्या स्थानामध्ये उपलब्ध नाही</translation>
-<translation id="497421865427891073">पुढे जा</translation>
-<translation id="4988210275050210843">(<ph name="MEGABYTES" />) ची फाइल डाउनलोड करत आहे.</translation>
-<translation id="4988526792673242964">पेज</translation>
-<translation id="4994033804516042629">संपर्क सापडले नाहीत</translation>
-<translation id="4996978546172906250">याद्वारे शेअर करा</translation>
-<translation id="5004416275253351869">Google ॲक्टिव्हिटी नियंत्रणे</translation>
-<translation id="5005498671520578047">पासवर्ड कॉपी करा</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> कनेक्ट करू इच्छिते</translation>
-<translation id="5013696553129441713">कोणत्याही नवीन सूचना नाहीत</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">तुम्ही VR वापरत असताना, ही साइट कदाचित पुढील गोष्टींबद्दल अधिक माहिती मिळवू शकेल:
-- तुमची शारीरिक वैशिष्‍ट्ये, जसे की, उंची
-
-VR मध्ये एंटर करण्यापूर्वी तुमचा या साइटवर विश्वास आहे याची खात्री करा.</translation>
+<translation id="2930742481329940825">शोधण्यासाठी टॅप करा निवडलेला शब्द आणि सद्य पेज संदर्भ म्हणून Brave Software शोध ला पाठवते. तुम्ही ते <ph name="BEGIN_LINK"/>सेटिंग्ज<ph name="END_LINK"/> मध्ये सुरू किंवा बंद करू शकता.</translation>
 <translation id="5039804452771397117">परवानगी द्या</translation>
-<translation id="5040262127954254034">गोपनीयता</translation>
-<translation id="5048398596102334565">साइटना मोशन सेन्सर ॲक्सेस करण्याची अनुमती द्या (शिफारस केलेले)</translation>
-<translation id="5063480226653192405">वापर</translation>
-<translation id="5087580092889165836">कार्ड जोडा</translation>
-<translation id="5100237604440890931">संकुचित केले - विस्तृत करण्यासाठी क्लिक करा.</translation>
-<translation id="510275257476243843">1 तास शिल्लक</translation>
-<translation id="5123685120097942451">गुप्त टॅब</translation>
-<translation id="5127805178023152808">संकालन बंद आहे</translation>
-<translation id="5129038482087801250">वेब अ‍ॅप इंस्टॉल करा</translation>
-<translation id="5132942445612118989">सर्व डिव्हाइसवर तुमचे पासवर्ड, इतिहास आणि बरेच काही सिंक करा</translation>
-<translation id="5139940364318403933">Google ड्राइव्ह कसे वापरावे ते जाणून घ्या</translation>
-<translation id="515227803646670480">संचयित डेटा साफ करा</translation>
-<translation id="5152843274749979095">कोणतेही समर्थित ॲप्स इंस्टॉल केले नाहीत</translation>
-<translation id="5161254044473106830">शीर्षक आवश्यक</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{एक डाउनलोड होऊ शकला नाही.}other{# डाउनलोड होऊ शकले नाहीत.}}</translation>
-<translation id="5170568018924773124">फोल्डरमध्ये दर्शवा</translation>
-<translation id="5184329579814168207">Chrome मध्ये उघडा</translation>
-<translation id="5193988420012215838">तुमच्या क्लिपबोर्डवर कॉपी केले</translation>
-<translation id="5197729504361054390">तुम्ही निवडलेले संपर्क <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />सोबत शेअर केले जातील.</translation>
-<translation id="5199929503336119739">कार्य प्रोफाइल</translation>
-<translation id="5210286577605176222">मागील टॅबवर जा</translation>
-<translation id="5210365745912300556">टॅब बंद करा</translation>
-<translation id="5224771365102442243">व्हिडिओसह</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> ला जवळपासची ब्लूटूथ डिव्हाइस स्कॅन करायची आहेत. खालील डिव्हाइस आढळली:</translation>
-<translation id="5233638681132016545">नवीन टॅब</translation>
-<translation id="526421993248218238">हे पेज लोड करू शकत नाही</translation>
-<translation id="5271967389191913893">डाउनलोड केली जाण्यासाठी डिव्हाइस आशय उघडू शकत नाही.</translation>
-<translation id="528192093759286357">शीर्ष पासून ड्रॅग करा आणि फुलस्क्रीन मधून बाहेर पडण्यासाठी परत बटणास स्पर्श करा.</translation>
-<translation id="5292796745632149097">यांना पाठवा</translation>
-<translation id="5300589172476337783">दर्शवा</translation>
-<translation id="5301954838959518834">ठीक आहे, समजले</translation>
-<translation id="5304593522240415983">हे फील्ड रिक्त ठेवता येणार नाही</translation>
-<translation id="5307446750509046227">साइट स्टोरेज साफ करा</translation>
-<translation id="5308380583665731573">कनेक्‍ट करा</translation>
-<translation id="5313967007315987356">साइट जोडा</translation>
-<translation id="5317780077021120954">सेव्ह करा</translation>
-<translation id="5324858694974489420">पालक सेटिंग्ज</translation>
-<translation id="5327248766486351172">नाव</translation>
-<translation id="5335288049665977812">साइटना JavaScript रन करण्याची अनुमती द्या (शिफारस केलेले)</translation>
-<translation id="5342314432463739672">परवानगीच्या विनंत्या</translation>
-<translation id="5357811892247919462">टॅब मिळाला</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> खुला टॅब, टॅब स्विच करण्यासाठी टॅप करा}other{<ph name="OPEN_TABS_MANY" /> खुला टॅब, टॅब स्विच करण्यासाठी टॅप करा}}</translation>
-<translation id="5391532827096253100">या साइटवरील तुमचे कनेक्शन सुरक्षित नाही. साइट माहिती</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ आणखी एक)}other{(+ आणखी #)}}</translation>
-<translation id="5400569084694353794">हे ॲप्लिकेशन वापरून, तुम्ही Chrome च्या <ph name="BEGIN_LINK1" />सेवा अटी<ph name="END_LINK1" /> आणि <ph name="BEGIN_LINK2" />गोपनीयता सूचना<ph name="END_LINK2" /> ला सहमती देता.</translation>
-<translation id="5403592356182871684">नावे</translation>
-<translation id="5403644198645076998">केवळ काही साइटना अनुमती द्या</translation>
-<translation id="5414836363063783498">सत्यापित करत आहे...</translation>
-<translation id="5423934151118863508">तुमची सर्वाधिक भेट दिलेली पेज येथे दिसतील</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB उपलब्ध आहे</translation>
-<translation id="543338862236136125">पासवर्ड संपादित करा</translation>
-<translation id="5433691172869980887">वापरकर्तानाव कॉपी केले</translation>
-<translation id="543509235395288790">(<ph name="MEGABYTES" />) च्या <ph name="COUNT" /> फायली डाउनलोड करत आहे.</translation>
-<translation id="5441522332038954058">अ‍ॅड्रेस बारवर जा</translation>
-<translation id="5447201525962359567">कुकीज आणि इतर स्थानिकरित्या स्टोरेज डेटासह, सर्व साइट स्टोरेज</translation>
-<translation id="5447765697759493033">या साइटचे भाषांतर होणार नाही</translation>
-<translation id="545042621069398927">तुमच्या डाउनलोडचा वेग वाढवत आहे.</translation>
-<translation id="5456381639095306749">पेज डाउनलोड करा</translation>
-<translation id="5475862044948910901">ऑगमेंटेड रीअ‍ॅलिटी सेशन सुरू करायचे का?</translation>
-<translation id="548278423535722844">नकाशे ॲपमध्ये उघडा</translation>
-<translation id="5487521232677179737">डेटा साफ करा</translation>
-<translation id="5494752089476963479">अनाहूत किंवा दिशाभूल करणाऱ्या जाहिराती दाखवणाऱ्या साइटवरील जाहिराती ब्लॉक करा</translation>
-<translation id="5500777121964041360">तुमच्या स्थानामध्ये उपलब्ध नसू शकते</translation>
-<translation id="5512137114520586844">हे खाते <ph name="PARENT_NAME" /> द्वारे व्यवस्थापित केले आहे.</translation>
-<translation id="5514904542973294328">या डिव्हाइसच्या ॲडमिनिस्ट्रेटरने बंद केले आहे.</translation>
-<translation id="5515439363601853141">तुमचा पासवर्ड पाहण्यासाठी अनलॉक करा</translation>
-<translation id="5516455585884385570">सूचना सेटिंग्ज उघडा</translation>
-<translation id="5517095782334947753">आपल्याकडे <ph name="FROM_ACCOUNT" /> मधील बुकमार्क, इतिहास, पासवर्ड आणि अन्य सेटिंग्ज आहेत.</translation>
-<translation id="5524843473235508879">रीडिरेक्‍ट ब्लॉक केले.</translation>
-<translation id="5527082711130173040">डिव्हाइस स्कॅन करण्‍यासाठी Chrome ला स्थान ॲक्सेसची आवश्यकता असते. <ph name="BEGIN_LINK1" />परवानग्या अपडेट करा<ph name="END_LINK1" />. स्थान ॲक्सेस देखील <ph name="BEGIN_LINK2" />या डिव्हाइसाठी बंद केला आहे<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">साइटला क्लिपबोर्डमधून मजकूर आणि इमेज रीड करण्याची अनुमती देण्यापूर्वी विचारा (शिफारस केली)</translation>
-<translation id="5530766185686772672">गुप्त टॅब बंद करा</translation>
-<translation id="5534334044554683961">तुम्ही VR वापरत असताना, ही साइट कदाचित पुढील गोष्टींबद्दल अधिक माहिती मिळवू शकेल:
-- तुमची शारीरिक वैशिष्‍ट्ये, जसे की, उंची
-- तुमच्या रूमचा लेआउट
-
-VR मध्ये एंटर करण्यापूर्वी तुमचा या साइटवर विश्वास आहे खात्री करा.</translation>
-<translation id="5534640966246046842">साइट कॉपी केली</translation>
-<translation id="5556459405103347317">रीलोड करा</translation>
-<translation id="5561549206367097665">नेटवर्कची वाट पाहत आहे…</translation>
-<translation id="557283862590186398">या साइटसाठी Chromeला तुमचा मायक्रोफोन ॲक्सेस करण्याची परवानगी आवश्यक आहे.</translation>
-<translation id="55737423895878184">स्‍थान आणि सूचनांना अनुमती आहे</translation>
-<translation id="5578795271662203820">या इमेजसाठी <ph name="SEARCH_ENGINE" /> शोधा</translation>
-<translation id="5581519193887989363">तुम्ही काय सिंक करायचे हे <ph name="BEGIN_LINK1" />सेटिंग्ज<ph name="END_LINK1" /> मध्ये कधीही निवडू शकता.</translation>
-<translation id="5595485650161345191">पत्ता संपादित करा</translation>
-<translation id="5596627076506792578">अधिक पर्याय</translation>
-<translation id="5599455543593328020">गुप्त मोड</translation>
-<translation id="5620928963363755975">तुमच्या फायली आणि पेज अधिक पर्याय बटणावरील डाउनलोडमध्ये शोधा</translation>
-<translation id="5626134646977739690">नाव:</translation>
-<translation id="5639724618331995626">सर्व साइटना अनुमती द्या</translation>
-<translation id="5648166631817621825">अखेरच्या 7 दिवसांमधील</translation>
-<translation id="5649053991847567735">स्वयंचलित डाउनलोड</translation>
-<translation id="5655963694829536461">तुमचे डाउनलोड शोधा</translation>
-<translation id="5659593005791499971">ईमेल</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> मध्ये इव्हेंट तयार करा</translation>
-<translation id="5668404140385795438">झूम वाढविणे निर्बंधित करण्याची वेबसाइटची विनंती ओव्हरराइड करा</translation>
-<translation id="5677928146339483299">अवरोधित</translation>
-<translation id="5684874026226664614">अरेरे. हे पृष्‍ठ भाषांतरित केले जाऊ शकले नाही.</translation>
-<translation id="5686790454216892815">फाइलचे नाव खूप लांब आहे</translation>
-<translation id="5689516760719285838">स्थान</translation>
-<translation id="569536719314091526">अधिक पर्याय बटणावरून या पेजचे कोणत्याही भाषेत भाषांतर करा</translation>
-<translation id="572328651809341494">अलीकडील टॅब</translation>
-<translation id="5726692708398506830">पृष्ठावरील प्रत्येकगोष्ट आणखी मोठी करा</translation>
-<translation id="5748802427693696783">मानक टॅबवर स्विच केले</translation>
-<translation id="5749068826913805084">Chrome ला फायली डाउनलोड करण्यासाठी स्टोरेज ॲक्सेस आवश्यक आहे.</translation>
-<translation id="5763382633136178763">गुप्त टॅब</translation>
-<translation id="5763514718066511291">या ॲपची URL कॉपी करण्यासाठी टॅप करा</translation>
-<translation id="5765780083710877561">वर्णन:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" /> पैकी <ph name="SPACE_USED" /> वापरत आहे</translation>
-<translation id="5797070761912323120">शोध, जाहिरात आणि इतर Google सेवा पर्सनलाइझ करण्यासाठी Google कदाचित तुमच्या इतिहासाचा वापर करू शकते</translation>
-<translation id="5804241973901381774">परवानग्या</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# तासापूर्वी}other{# तासांपूर्वी}}</translation>
-<translation id="5810288467834065221">कॉपीराइट <ph name="YEAR" /> Google LLC. सर्व हक्क राखीव.</translation>
-<translation id="5817918615728894473">जोडा</translation>
-<translation id="583281660410589416">अज्ञात</translation>
-<translation id="5833984609253377421">लिंक शेअर करा</translation>
-<translation id="5836192821815272682">Chrome अपडेट डाउनलोड करत आहे…</translation>
-<translation id="5853623416121554550">थांबवले</translation>
-<translation id="5854790677617711513">30 दिवसांपेक्षा जुना</translation>
-<translation id="5858741533101922242">ब्लूटूथ अडॅप्टर सुरू करण्यात Chrome अक्षम आहे</translation>
-<translation id="5860033963881614850">बंद</translation>
-<translation id="5862731021271217234">तुमच्या इतर डिव्हाइसवरून तुमचे टॅब मिळवण्यासाठी, सिंक सुरू करा</translation>
-<translation id="5864174910718532887">तपशील: साइटच्या नावानुसार क्रमाने लावलेले</translation>
-<translation id="5864419784173784555">दुसर्‍या डाउनलोडची वाट पाहत आहे…</translation>
-<translation id="5865733239029070421">Google ला वापर आकडेवारी आणि क्रॅश अहवाल आपोआप पाठवते</translation>
-<translation id="5869522115854928033">सेव्ह केलेले पासवर्ड</translation>
-<translation id="5902828464777634901">कुकीजसह, या वेबसाइटवर संचयित केलेला डेटा, हटवला जाईल.</translation>
-<translation id="5916664084637901428">चालू</translation>
-<translation id="5919204609460789179">सिंक सुरू करण्यासाठी <ph name="PRODUCT_NAME" /> अपडेट करा</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> वाचवला</translation>
-<translation id="5939518447894949180">रीसेट करा</translation>
-<translation id="5942872142862698679">शोध करण्‍यासाठी Google वापरत आहे</translation>
-<translation id="5952764234151283551">तुम्ही ज्या पेजवर पोहोचण्याचा प्रयत्न करत आहात त्याची URL Google ला पाठवते</translation>
-<translation id="5956665950594638604">नवीन टॅबमध्ये Chrome मदत केंद्र उघडा</translation>
-<translation id="5958275228015807058">तुमच्या फायली आणि पेज डाउनलोडमध्ये शोधा</translation>
-<translation id="5962718611393537961">संकुचित करण्‍यासाठी टॅप करा</translation>
-<translation id="6000066717592683814">Google ठेवा</translation>
-<translation id="6005538289190791541">सुचवलेला पासवर्ड</translation>
-<translation id="6036057147555329831">अतिरिक्त ICU</translation>
-<translation id="6039379616847168523">पुढील टॅबवर जा</translation>
-<translation id="6040143037577758943">बंद करा</translation>
-<translation id="6042308850641462728">अधिक</translation>
-<translation id="604996488070107836">अज्ञात एररमुळे <ph name="FILE_NAME" /> डाउनलोड करणे अयशस्वी झाले.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">डाउनलोड पूर्ण झाले</translation>
-<translation id="6075798973483050474">होम पेज संपादित करा</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> तास शिल्लक</translation>
-<translation id="6108923351542677676">सेटअप प्रगती पथावर आहे...</translation>
-<translation id="6111020039983847643">डेटा वापरला</translation>
-<translation id="6112702117600201073">पृष्ठ रिफ्रेश करीत आहे</translation>
-<translation id="6127379762771434464">आयटम काढला</translation>
-<translation id="6140912465461743537">देश/प्रदेश</translation>
-<translation id="614940544461990577">हे करून पहा:</translation>
-<translation id="6154478581116148741">तुमचे पासवर्ड या डिव्हाइसवरून एक्सपोर्ट करण्यासाठी सेटिंग्जमधील लॉक स्क्रीन चालू करा</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> डेटा बचत</translation>
-<translation id="6165508094623778733">अधिक जाणून घ्या</translation>
-<translation id="6177111841848151710">वर्तमान शोध इंजिनसाठी अवरोधित केले</translation>
-<translation id="6181444274883918285">साइट एक्सेप्शन जोडा</translation>
-<translation id="6192333916571137726">फाइल डाउनलोड करा</translation>
-<translation id="6192792657125177640">अपवाद</translation>
-<translation id="6194112207524046168">Chrome ला तुमच्या कॅमेराचा ॲक्सेस द्या, <ph name="BEGIN_LINK" />Android सेटिंग्ज<ph name="END_LINK" /> मध्ये देखील कॅमेरा सुरू करा.</translation>
-<translation id="6196640612572343990">तृतीय-पक्ष कुकीज अवरोधित करा</translation>
-<translation id="6206551242102657620">कनेक्शन सुरक्षित आहे. साइट माहिती</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> नाही?</translation>
-<translation id="6221633008163990886">तुमचे पासवर्ड एक्सपोर्ट करण्यासाठी अनलॉक करा</translation>
+<translation id="1406000523432664303">“Do Not Track”</translation>
 <translation id="6232535412751077445">'Do Not Track' सक्षम करणे अर्थात आपल्‍या ब्राउझिंग ट्रॅफिकमध्‍ये एक विनंती समाविष्‍ट केली जाईल. वेबसाइट विनंतीस प्रतिसाद देते किंवा नाही आणि विनंतीचा निष्‍कर्ष कसा काढला जातो यावर कोणताही प्रभाव अवलंबून असतो.
 
 उदाहरणार्थ, काही वेबसाइट तुम्ही भेट दिलेल्‍या इतर वेबसाइटवर आधारित नसलेल्‍या जाहिराती तुम्हाला दर्शवून या विनंतीस प्रतिसाद देऊ शकतात. अनेक वेबसाइट अद्यापही तुमचा ब्राउझिंग डेटा संकलित करून त्‍याचा वापर करतील - उदाहरणार्थ त्‍यांच्‍या वेबसाइटवर सुरक्षितता सुधारणे, आशय, जाहिराती आणि शिफारशी देऊ करणे आणि अहवाल आकडेवारी व्‍युत्‍पन्न करणे.</translation>
-<translation id="624789221780392884">अपडेट तयार</translation>
-<translation id="6255999984061454636">आशय सूचना</translation>
-<translation id="6277522088822131679">पृष्‍ठ प्रिंट करण्‍यात एक समस्‍या होती. कृपया पुन्‍हा प्रयत्न करा.</translation>
-<translation id="6295158916970320988">सर्व साइट</translation>
-<translation id="629730747756840877">खाते</translation>
-<translation id="6303969859164067831">साइन आउट करा आणि सिंक बंद करा</translation>
-<translation id="6316139424528454185">Android आवृत्तीला सपोर्ट नाही</translation>
-<translation id="6320088164292336938">कंपन</translation>
-<translation id="6324034347079777476">Android सिस्‍टीम संकालन अक्षम केले</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> द्वारे शेअर करा</translation>
-<translation id="6337234675334993532">एंक्रिप्शन</translation>
-<translation id="6341580099087024258">फायली कुठे सेव्ह करायच्या ते विचारा</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> अधिक}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> अधिक}}</translation>
-<translation id="6364438453358674297">इतिहासातून सूचना काढून टाकायची?</translation>
-<translation id="6369229450655021117">येथून तुम्ही वेबवर शोधू शकता, मित्रमैत्रिणींसोबत शेअर करू शकता आणि उघडी असलेली पेज पाहू शकता</translation>
-<translation id="6378173571450987352">तपशील: वापरलेल्या डेटाच्या प्रमाणानुसार क्रमाने लावलेला</translation>
-<translation id="6381421346744604172">डार्कन वेबसाइट</translation>
-<translation id="6388207532828177975">साफ आणि रीसेट करा</translation>
-<translation id="6393863479814692971">या साइटसाठी Chromeला तुमचा कॅमेरा आणि मायक्रोफोन ॲक्सेस करण्याची परवानगी आवश्यक आहे.</translation>
-<translation id="6395288395575013217">लिंक</translation>
-<translation id="6404511346730675251">बुकमार्क संपादित करा</translation>
-<translation id="6406506848690869874">Sync</translation>
-<translation id="641643625718530986">प्रिंट करा...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB डाउनलोड केले</translation>
-<translation id="6427112570124116297">वेबचे भाषांतर करा</translation>
-<translation id="6433501201775827830">तुमचे शोध इंजिन निवडा</translation>
-<translation id="6437478888915024427">पेज माहिती</translation>
-<translation id="6441734959916820584">नाव खूपच मोठे आहे</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# इमेज}other{# इमेज}}</translation>
-<translation id="6447842834002726250">कुकीज</translation>
-<translation id="6461962085415701688">फाइल उघडू शकत नाही</translation>
-<translation id="6464977750820128603">तुम्ही Chrome मध्ये भेट दिलेल्या साइट पाहू शकता आणि त्यांच्यासाठी टायमर सेट करू शकता.\n\nGoogle ला तुम्ही ज्या साइटसाठी टायमर सेट केला आणि त्यांना किती वेळ भेट दिली याबद्दलची माहिती मिळते. ही माहिती डिजिटल संतुलन चांगले करण्यास वापरली जाते.</translation>
-<translation id="6475951671322991020">व्हिडिओ डाउनलोड करा</translation>
-<translation id="6482749332252372425">स्टोरेज स्थानाच्या अभावामुळे <ph name="FILE_NAME" /> डाउनलोड अयशस्वी झाले.</translation>
-<translation id="6496823230996795692"><ph name="APP_NAME" /> पहिल्यांदा वापरण्यासाठी, कृपया इंटरनेटशी कनेक्ट करा.</translation>
-<translation id="6508722015517270189">Chrome रीस्टार्ट करा</translation>
-<translation id="6527303717912515753">शेअर करा</translation>
-<translation id="6532866250404780454">तुम्ही Chrome मध्ये भेट दिलेल्या साइट दाखवणार नाही. सर्व साइट टायमर हटवले जातील.</translation>
-<translation id="6534565668554028783">Google ने प्रतिसाद देण्यास बराच वेळ घेतला</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB डाउलोड केले</translation>
-<translation id="6539092367496845964">काहीतरी चूक झाली. पुन्हा प्रयत्न करा.</translation>
-<translation id="654446541061731451">बीममध्ये एक टॅब निवडा</translation>
-<translation id="6545017243486555795">सर्व डेटा साफ करा</translation>
-<translation id="6545864417968258051">ब्लूटूथ स्कॅन करत आहे</translation>
-<translation id="6560414384669816528">Sogou सह शोध करा</translation>
-<translation id="6566259936974865419">Chrome ने तुमच्यासाठी <ph name="GIGABYTES" /> GB सेव्ह केले आहे</translation>
-<translation id="6573096386450695060">नेहमी अनुमती द्या</translation>
-<translation id="6573431926118603307">आपल्या अन्य डिव्हाइसेसवर तुम्ही Chrome मध्ये उघडलेले टॅब येथे दिसतील.</translation>
-<translation id="6583199322650523874">वर्तमान पृष्ठ बुकमार्क करा</translation>
-<translation id="6593061639179217415">डेस्कटॉप साइट</translation>
-<translation id="6600954340915313787">Chrome वर कॉपी केले</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">संरक्षित आशय</translation>
-<translation id="6627583120233659107">फोल्डर संपादित करा</translation>
-<translation id="6643016212128521049">साफ करा</translation>
-<translation id="6643649862576733715">वाचवलेल्या डेटानुसार क्रमाने लावा</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> अधिक}other{<ph name="CONTACT_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> अधिक}}</translation>
-<translation id="6649642165559792194">इमेज <ph name="BEGIN_NEW" />नवीन<ph name="END_NEW" /> चे पूर्वावलोकन करा</translation>
-<translation id="6656545060687952787">डिव्हाइस स्कॅन करण्‍यासाठी Chrome ला स्थान ॲक्सेसची आवश्‍यकता असते. <ph name="BEGIN_LINK" />परवानग्या अपडेट करा<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">पासवर्ड</translation>
-<translation id="6659594942844771486">टॅब</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" /> मध्ये उघडा</translation>
-<translation id="666981079809192359">Chrome गोपनीयता सूचना</translation>
-<translation id="6676840375528380067">या डिव्हाइसवरून तुमचा Chrom डेटा साफ करायचा?</translation>
-<translation id="6697492270171225480">जेव्हा एखादे पेज सापडत नाही तेव्हा त्यासारख्या पेजच्या सूचना दाखवा</translation>
-<translation id="6697947395630195233">तुमचे स्थान या साइटसोबत शेअर करण्यासाठी Chromeला तुमच्या स्थानाचा अ‍ॅक्सेस हवा आहे.</translation>
-<translation id="6698801883190606802">संकालित केलेला डेटा व्यवस्थापित करा</translation>
-<translation id="6699370405921460408">Google सर्व्हर तुम्ही भेट देत असलेली पेज ऑप्टिमाइझ करतील.</translation>
-<translation id="6706288973712894588">तुम्ही सध्या ऑफलाइन आहात.\n<ph name="BEGIN_LINK" />तुमचे ऑफलाइन फीड एक्सप्लोर करा.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">News</translation>
-<translation id="6710213216561001401">मागील</translation>
-<translation id="671481426037969117">तुमचा <ph name="FQDN" /> टायमर झाला आहे. तो उद्या पुन्हा सुरू होईल.</translation>
-<translation id="6738867403308150051">डाउनलोड करीत आहे…</translation>
-<translation id="6746124502594467657">खाली हलवा</translation>
-<translation id="6766622839693428701">बंद करण्यासाठी खाली स्वाइप करा.</translation>
-<translation id="6766758767654711248">साइटवर जाण्यासाठी टॅप करा</translation>
-<translation id="6767294960381293877">अर्ध्या उंचीवर उघडलेल्या टॅबसह शेअर करण्यासाठी डिव्हाइसची सूची.</translation>
-<translation id="6782111308708962316">तृतीय-पक्ष वेबसाइटना कुकी डेटा सेव्ह करण्यास आणि वाचण्यास प्रतिबंधित करा</translation>
-<translation id="6790428901817661496">प्ले करा</translation>
-<translation id="6811034713472274749">पेज पाहाण्यासाठी तयार आहे</translation>
-<translation id="6818926723028410516">आयटम निवडा</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">भाषांतर करा</translation>
-<translation id="6845325883481699275">Chrome सुरक्षेमध्ये सुधारणा करण्यात मदत करा</translation>
-<translation id="6846298663435243399">लोड करीत आहे...</translation>
-<translation id="6850409657436465440">तुमचे डाउनलोड अजून प्रगतीपथावर आहे</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> टॅब बंद केले</translation>
-<translation id="6864459304226931083">इमेज डाउनलोड करा</translation>
-<translation id="6865313869410766144">ऑटोफिल फॉर्म डेटा</translation>
-<translation id="688738109438487280">विद्यमान डेटा <ph name="TO_ACCOUNT" /> मध्ये जोडा.</translation>
-<translation id="6891726759199484455">तुमचा पासवर्ड कॉपी करण्यासाठी अनलॉक करा</translation>
-<translation id="6896758677409633944">कॉपी करा</translation>
-<translation id="6910211073230771657">हटवला</translation>
-<translation id="6912998170423641340">साइटचे क्लिपबोर्डवरील मजकूर आणि इमेज रीड करणे ब्लॉक करा</translation>
-<translation id="6914783257214138813">एक्सपोर्ट करण्यात आलेली फाइल दिसणार्‍या प्रत्येकाला, तुमचा पासवर्ड दिसेल.</translation>
-<translation id="6942665639005891494">सेटिंग्ज मेनू पर्याय वापरून केव्हाही डीफॉल्ट डाउनलोड स्थान बदला</translation>
-<translation id="6945221475159498467">निवडा</translation>
-<translation id="6963642900430330478">हे पेज धोकादायक आहे. साइट माहिती</translation>
-<translation id="6963766334940102469">बुकमार्क हटवा</translation>
-<translation id="6965382102122355670">ठीक आहे</translation>
-<translation id="6979737339423435258">पूर्णवेळ</translation>
-<translation id="6981982820502123353">ॲक्सेसिबिलिटी</translation>
-<translation id="6989267951144302301">डाउनलोड करता आले नाही</translation>
-<translation id="6990079615885386641">Google Play Store मधून ॲप मिळवा: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">साइटना तुमचा मायक्रोफोन वापरण्याची अनुमती देण्यापूर्वी प्रथम विचारा (शिफारस केलेले)</translation>
-<translation id="7015203776128479407">सुरुवातीचे सिंक सेट करणे पूर्ण झाले नाही. सिंक बंद आहे.</translation>
-<translation id="7016516562562142042">वर्तमान शोध इंजिनसाठी अनुमती दिली</translation>
-<translation id="7022756207310403729">ब्राउझरमध्ये उघडा</translation>
-<translation id="702463548815491781">TalkBack किंवा स्विच ॲक्सेस सुरू असताना शिफारस केलेले</translation>
-<translation id="7029809446516969842">पासवर्ड</translation>
-<translation id="7053983685419859001">अवरोधित करा</translation>
-<translation id="7055152154916055070">रीडिरेक्ट ब्लॉक केले:</translation>
-<translation id="7063006564040364415">संकालित सर्व्हरशी कनेक्ट करू शकलो नाही.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 निवडला}other{# निवडले}}</translation>
-<translation id="7071521146534760487">खाते व्यवस्थापित करा</translation>
-<translation id="7077143737582773186">SD कार्ड</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> निवडले.  स्क्रीनच्या वरच्या बाजूला पर्याय उपलब्ध आहेत</translation>
-<translation id="7121362699166175603">अ‍ॅड्रेस बारवरील इतिहास आणि आपोआप पूर्ण करण्याचे दाखले साफ करते. तुमच्या Google खात्यामध्ये <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> वर कदाचित ब्राउझिंगचे इतर फॉर्म असतील.</translation>
-<translation id="7128222689758636196">वर्तमान शोध इंजिनसाठी अनुमती द्या</translation>
-<translation id="7138678301420049075">इतर</translation>
-<translation id="7141896414559753902">साइट पॉप-अप आणि रीडिरेक्ट दाखवण्यापासून ब्लॉक करा (शिफारस केलेले)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> वरून <ph name="BEGIN_LINK" />मुळचे पेज लोड करा<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">शेवटच्या 72 तासांमधील</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">तुम्ही हे नंतर सेटिंग्ज मध्ये बदलू शकता.</translation>
-<translation id="7180611975245234373">रिफ्रेश करा</translation>
-<translation id="7189372733857464326">Google Play सेवांंनी अपडेट करणे समाप्त करण्याची प्रतीक्षा करीत आहे</translation>
-<translation id="7191430249889272776">पार्श्वभूमीवर उघडा असलेला टॅब.</translation>
-<translation id="723171743924126238">इमेज निवडा</translation>
-<translation id="7233236755231902816">तुमच्या भाषेत वेब पाहण्यासाठी, Chrome ची नवीनतम आवृत्ती मिळवा</translation>
-<translation id="7243308994586599757">स्क्रीनच्या तळाशी पर्याय उपलब्ध आहेत</translation>
-<translation id="7248069434667874558"><ph name="TARGET_DEVICE_NAME" /> ने Chrome मध्ये सिंक सुरू केले असल्याची खात्री करा</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> निवडले</translation>
-<translation id="7274013316676448362">अवरोधित केलेली साइट</translation>
-<translation id="7290209999329137901">नाव बदलणे उपलब्ध नाही</translation>
-<translation id="7291387454912369099">असिस्टंटने ट्रिगर केलेला चेकआउट</translation>
-<translation id="7293171162284876153">सिंक सुरू करण्यासाठी, "तुमचा Chrome डेटा सिंक करा" सुरू करा.</translation>
-<translation id="729975465115245577">पासवर्ड फाइल स्टोअर करण्यासाठी तुमच्या डिव्हाइसमध्ये अ‍ॅप नाही.</translation>
-<translation id="7302081693174882195">तपशील: सेव्ह केलेल्या डेटाच्या प्रमाणानुसार क्रमाने लावलेले</translation>
-<translation id="7328017930301109123">लाइट मोडमध्ये, Chrome पेज आणखी जलद लोड करते आणि ६० टक्के पर्यंत कमी डेटा वापरते.</translation>
-<translation id="7333031090786104871">अद्याप मागील साइट जोडत आहे</translation>
-<translation id="7352939065658542140">व्हिडिओ</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 निवडलेला आयटम शेअर करा}other{# निवडलेले आयटम शेअर करा}}</translation>
 <translation id="7359002509206457351">पेमेंट पद्धती अ‍ॅक्सेस करा</translation>
+<translation id="8026334261755873520">ब्राउझिंग डेटा साफ करा</translation>
+<translation id="1291207594882862231">इतिहास, कुकी, साइट डेटा, कॅशे साफ करा…</translation>
+<translation id="7814200940910057384">Brave डेटा साफ केला</translation>
+<translation id="1664855196866195614">निवडलेला डेटा Brave वरून आणि तुमच्या सिंक केलेल्या डिव्हाइसवरून काढला गेला आहे.
+
+तुमच्या Brave Software खात्यात <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> येथील इतर Brave Software सेवांवरील शोध आणि अ‍ॅक्टिव्हिटी यांसारखा इतर स्वरूपातील ब्राउझिंग इतिहास असू शकतो.</translation>
+<translation id="4699172675775169585">कॅश   इमेज आणि फायली</translation>
+<translation id="2496180316473517155">ब्राउझिंग इतिहास</translation>
+<translation id="2546283357679194313">कुकीज आणि साइट डेटा</translation>
+<translation id="8662811608048051533">तुम्हाला बहुतांश साइटवरून साइन आउट करते.</translation>
+<translation id="8218628800671693884">तुम्हाला बहुतांश साइटमधून साइन आउट करते. तुम्हाला तुमच्या Brave Software खात्यामधून साइन आउट केले जाणार नाही.</translation>
+<translation id="2017836877785168846">ॲड्रेस बारमधील इतिहास आणि आपोआप पूर्ण केलेले साफ करते.</translation>
+<translation id="8096327394278038498">अ‍ॅड्रेस बारवरील इतिहास आणि आपोआप पूर्ण करण्याचे दाखले साफ करते. तुमच्या Brave Software खात्यामध्ये <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> वर कदाचित ब्राउझिंगचे इतर फॉर्म असतील.</translation>
+<translation id="8122693181154564064">साइन-इन केलेल्या सर्व डिव्हाइसमधून इतिहास साफ करते. तुमच्या Brave Software खात्यामध्ये <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> वर कदाचित ब्राउझिंगचे इतर फॉर्म असतील.</translation>
+<translation id="5869522115854928033">सेव्ह केलेले पासवर्ड</translation>
+<translation id="6865313869410766144">ऑटोफिल फॉर्म डेटा</translation>
+<translation id="7562080006725997899">ब्राउझिंग डेटा साफ करत आहे</translation>
+<translation id="5487521232677179737">डेटा साफ करा</translation>
+<translation id="7498271377022651285">कृपया प्रतीक्षा करा...</translation>
+<translation id="784934925303690534">वेळ वर्गवारी</translation>
+<translation id="1718835860248848330">शेवटच्या तासामधील</translation>
+<translation id="7149893636342594995">शेवटच्या 72 तासांमधील</translation>
+<translation id="5648166631817621825">अखेरच्या 7 दिवसांमधील</translation>
+<translation id="8571213806525832805">मागील 4 आठवड्यांमधील</translation>
+<translation id="5854790677617711513">30 दिवसांपेक्षा जुना</translation>
+<translation id="6979737339423435258">पूर्णवेळ</translation>
+<translation id="982182592107339124">हे यासह सर्व साइटसाठी डेटा साफ करेल:</translation>
+<translation id="6643016212128521049">साफ करा</translation>
+<translation id="7641339528570811325">ब्राउझिंग डेटा साफ करा...</translation>
+<translation id="1670399744444387456">मूलभूत</translation>
+<translation id="3245261285041759672">तुमच्या Brave Software खात्यात <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> वर ब्राउझिंग इतिहासाची अन्य स्वरूपे असू शकतात.</translation>
+<translation id="7274013316676448362">अवरोधित केलेली साइट</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> आयटम हटवले</translation>
+<translation id="1121094540300013208">वापर आणि क्रॅश अहवाल</translation>
+<translation id="9079153198295609735">Brave Software ला वापर आकडेवारी आणि क्रॅश अहवाल आपोआप पाठवा</translation>
+<translation id="6981982820502123353">ॲक्सेसिबिलिटी</translation>
+<translation id="2387895666653383613">मजकूर स्केलिग</translation>
+<translation id="2321958826496381788">तुम्ही हे व्यवस्थित वाचू शकण्यापार्यंत स्लायडर ड्रॅग करा. परिच्छेदावर डबल-टॅपिंग केल्यानंतर मजकूर कमीत कमी यापेक्षा मोठा दिसावा.</translation>
+<translation id="3895926599014793903">झूम सुरू करण्याची सक्ती</translation>
+<translation id="5668404140385795438">झूम वाढविणे निर्बंधित करण्याची वेबसाइटची विनंती ओव्हरराइड करा</translation>
+<translation id="4149994727733219643">वेब पेजसाठी सोपा केलेला व्ह्यू</translation>
+<translation id="9100505651305367705">सपोर्ट असताना सोप्या पद्धतीने लेख दाखवण्याची ऑफर</translation>
+<translation id="1409426117486808224">उघड्या टॅबसाठी सोपा केलेला व्ह्यू</translation>
+<translation id="702463548815491781">TalkBack किंवा स्विच ॲक्सेस सुरू असताना शिफारस केलेले</translation>
+<translation id="8284326494547611709">मथळे</translation>
+<translation id="4165986682804962316">साइट सेटिंग्ज</translation>
+<translation id="6295158916970320988">सर्व साइट</translation>
+<translation id="8380167699614421159">ही साइट अनाहूत किंवा दिशाभूल करणाऱ्या जाहिराती दाखवते</translation>
+<translation id="1919345977826869612">जाहिराती</translation>
+<translation id="410351446219883937">ऑटोप्ले</translation>
+<translation id="6447842834002726250">कुकीज</translation>
+<translation id="6196640612572343990">तृतीय-पक्ष कुकीज अवरोधित करा</translation>
+<translation id="6782111308708962316">तृतीय-पक्ष वेबसाइटना कुकी डेटा सेव्ह करण्यास आणि वाचण्यास प्रतिबंधित करा</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">पॉप-अप आणि रीडिरेक्ट</translation>
+<translation id="4751476147751820511">मोशन किंवा प्रकाश सेन्सर</translation>
+<translation id="1717218214683051432">मोशन सेन्सर</translation>
+<translation id="2091887806945687916">ध्वनी</translation>
+<translation id="2586657967955657006">क्लिपबोर्ड</translation>
+<translation id="6320088164292336938">कंपन</translation>
+<translation id="4226663524361240545">सूचनांमुळे डिव्हाइसचे कंपन होऊ शकते</translation>
+<translation id="1446450296470737166">MIDI डिव्हाइसेसच्या पूर्ण नियंत्रणास अनुमती द्या</translation>
+<translation id="3744111561329211289">पार्श्वभूमी संकालन</translation>
+<translation id="5649053991847567735">स्वयंचलित डाउनलोड</translation>
+<translation id="6181444274883918285">साइट एक्सेप्शन जोडा</translation>
+<translation id="5313967007315987356">साइट जोडा</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> साइट जोडली</translation>
+<translation id="7837721118676387834">एका विशिष्ट साइटकरिता नि:शब्द केलेल्या व्हिडिओंच्या ऑटोप्ले ला अनुमती द्या.</translation>
+<translation id="2621115761605608342">विशिष्ट साइटसाठी JavaScript ला अनुमती द्या.</translation>
+<translation id="8801436777607969138">विशिष्ट साइटसाठी JavaScript ब्लॉक करा.</translation>
+<translation id="8372893542064058268">विशिष्ट साइटसाठी पार्श्वभूमी संकालनासाठी अनुमती द्या.</translation>
+<translation id="358794129225322306">साइटला एकाहून अधिक फायली आपोआप डाउनलोड करू द्या.</translation>
+<translation id="4008040567710660924">विशिष्ट साइटसाठी कुकीना अनुमती द्या.</translation>
+<translation id="8958424370300090006">विशिष्ट साइटसाठी कुकी ब्लॉक करा.</translation>
+<translation id="7882806643839505685">विशिष्ट साइटसाठी ध्वनीची परवानगी द्या.</translation>
+<translation id="4468959413250150279">विशिष्ट साइटसाठी ध्वनी म्यूट करा.</translation>
+<translation id="1994173015038366702">साइट URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">वापर</translation>
+<translation id="5804241973901381774">परवानग्या</translation>
+<translation id="4278390842282768270">अनुमत</translation>
+<translation id="5677928146339483299">अवरोधित</translation>
+<translation id="1984937141057606926">तृतीय-पक्षाशिवाय, अनुमती असलेले</translation>
+<translation id="7423098979219808738">प्रथम विचारा</translation>
+<translation id="8116925261070264013">म्यूट केले</translation>
+<translation id="8300705686683892304">ॲपद्वारे व्यवस्थापित</translation>
+<translation id="6192792657125177640">अपवाद</translation>
+<translation id="257931822824936280">विस्‍तृत केले - संकुचित करण्‍यासाठी क्‍लिक करा.</translation>
+<translation id="5100237604440890931">संकुचित केले - विस्तृत करण्यासाठी क्लिक करा.</translation>
+<translation id="857943718398505171">अनुमती दिली (शिफारस केलेले)</translation>
+<translation id="2913331724188855103">कुकी डेटा सेव्ह करणे आणि वाचण्यासाठी साइटना अनुमती द्या (शिफारस केलेले)</translation>
+<translation id="7445411102860286510">साइटना स्वयंचलितपणे नि:शब्द केलेले व्हिडिओ प्ले करण्याची अनुमती द्या (शिफारस केलेले)</translation>
+<translation id="5335288049665977812">साइटना JavaScript रन करण्याची अनुमती द्या (शिफारस केलेले)</translation>
+<translation id="5527111080432883924">साइटला क्लिपबोर्डमधून मजकूर आणि इमेज रीड करण्याची अनुमती देण्यापूर्वी विचारा (शिफारस केली)</translation>
+<translation id="6912998170423641340">साइटचे क्लिपबोर्डवरील मजकूर आणि इमेज रीड करणे ब्लॉक करा</translation>
+<translation id="7423538860840206698">क्लिपबोर्ड वाचणे ब्लॉक केले</translation>
+<translation id="3955193568934677022">संरक्षित आशय प्ले करण्यासाठी साइटना अनुमती द्या (शिफारस केलेले)</translation>
+<translation id="445467742685312942">साइटना संरक्षित आशय प्ले करू द्या</translation>
+<translation id="2107397443965016585">साइटना संरक्षित आशय प्ले करू देण्याआधी विचारा (शिफारस केली जाते)</translation>
+<translation id="2910701580606108292">सायटींना संरक्षित आशय प्ले करू देण्याआधी विचारा</translation>
+<translation id="757524316907819857">संरक्षित आशय प्ले करण्यापासून सायटी ब्लॉक करा</translation>
+<translation id="3277252321222022663">साइटना सेन्सर ॲक्सेस करण्याची अनुमती द्या (शिफारस केलेले)</translation>
+<translation id="5048398596102334565">साइटना मोशन सेन्सर ॲक्सेस करण्याची अनुमती द्या (शिफारस केलेले)</translation>
+<translation id="8816026460808729765">साइटना सेन्सर ॲक्सेस करण्यापासून ब्लॉक करा</translation>
+<translation id="169515064810179024">साइटना मोशन सेन्सर ॲक्सेसपासून ब्लॉक करा</translation>
+<translation id="1660204651932907780">साइटना ध्वनी प्ले करण्याची परवानगी द्या (शिफारस केलेले)</translation>
+<translation id="3600792891314830896">ध्वनी प्ले करणाऱ्या साइट म्यूट करा</translation>
+<translation id="1743802530341753419">साइटना डिव्हाइसशी कनेक्ट करण्यासाठी अनुमती देण्यापूर्वी विचारा (शिफारस केलेले आहे)</translation>
+<translation id="851751545965956758">डिव्हाइसेसशी कनेक्ट करण्यापासून साइटना ब्लॉक करा</translation>
+<translation id="7141896414559753902">साइट पॉप-अप आणि रीडिरेक्ट दाखवण्यापासून ब्लॉक करा (शिफारस केलेले)</translation>
+<translation id="5494752089476963479">अनाहूत किंवा दिशाभूल करणाऱ्या जाहिराती दाखवणाऱ्या साइटवरील जाहिराती ब्लॉक करा</translation>
+<translation id="3123473560110926937">काही साइटवर ब्लॉक केले आहे</translation>
+<translation id="965817943346481315">साइट अनाहूत किंवा दिशाभूल करणाऱ्या जाहिराती दाखवत असल्यास ब्लॉक करा (शिफारस केलेले)</translation>
+<translation id="3386292677130313581">साइटना तुमचे स्थान जाणून घेण्याची अनुमती देण्यापूर्वी विचारा (शिफारस केलेले)</translation>
+<translation id="9139068048179869749">साइटना सूचना पाठविण्याची अनुमती देण्यापूर्वी प्रथम विचारा (शिफारस केलेले)</translation>
+<translation id="4479647676395637221">साइटना तुमचा कॅमेरा वापरण्याची अनुमती देण्यापूर्वी प्रथम विचारा (शिफारस केलेले)</translation>
+<translation id="6992289844737586249">साइटना तुमचा मायक्रोफोन वापरण्याची अनुमती देण्यापूर्वी प्रथम विचारा (शिफारस केलेले)</translation>
+<translation id="2289270750774289114">साइटला केव्हा जवळपासचे ब्लूटूथ डिव्हाइस शोधायचे आहे हे विचारा (शिफारस केलेले)</translation>
+<translation id="7053983685419859001">अवरोधित करा</translation>
+<translation id="7128222689758636196">वर्तमान शोध इंजिनसाठी अनुमती द्या</translation>
+<translation id="7589445247086920869">वर्तमान शोध इंजिनसाठी अवरोधित करा</translation>
+<translation id="6388207532828177975">साफ आणि रीसेट करा</translation>
+<translation id="7999064672810608036">तुम्ही कुकीजसह, सर्व स्थानिक डेटा साफ करू इच्छिता आणि या वेबसाइटसाठी सर्व परवानग्या रीसेट करू इच्छिता?</translation>
+<translation id="2822354292072154809">तुम्हाला नक्की <ph name="CHOSEN_OBJECT_NAME"/> साठी सर्व साइट परवानग्या रीसेट करायच्या आहेत का?</translation>
+<translation id="515227803646670480">संचयित डेटा साफ करा</translation>
+<translation id="5902828464777634901">कुकीजसह, या वेबसाइटवर संचयित केलेला डेटा, हटवला जाईल.</translation>
+<translation id="119944043368869598">सर्व साफ करा</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> द्वारे व्यवस्थापित केले आहे</translation>
+<translation id="5516455585884385570">सूचना सेटिंग्ज उघडा</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/> मध्ये एम्बेड केले</translation>
+<translation id="129382876167171263">वेबसाइटद्वारे सेव्ह केलेल्या फाइल येथे दिसतील</translation>
+<translation id="4181841719683918333">भाषा</translation>
+<translation id="2647434099613338025">भाषा जोडा</translation>
+<translation id="1952172573699511566">वेबसाइट शक्य असताना तुमच्या प्राधान्य असलेल्‍या भाषेमध्ये मजकूर दाखवेल.</translation>
+<translation id="8559990750235505898">पेज अन्य भाषांमध्ये भाषांतरित करण्यास ऑफर करा</translation>
+<translation id="4719927025381752090">भाषांतर करण्यास ऑफर करा</translation>
+<translation id="8156139159503939589">तुम्ही कोणत्या भाषा वाचू शकता?</translation>
+<translation id="5689516760719285838">स्थान</translation>
+<translation id="2440823041667407902">स्थान ॲक्सेस</translation>
+<translation id="2023546461831060654">Brave साठी परवानग्या <ph name="BEGIN_LINK"/>Android सेटिंग्ज<ph name="END_LINK"/> मध्‍ये चालू करा.</translation>
+<translation id="6665548517310046133">Brave साठी परवानगी <ph name="BEGIN_LINK"/>Android सेटिंग्ज<ph name="END_LINK"/> मध्‍ये चालू करा.</translation>
+<translation id="2928908108430545745">Brave ला तुमच्या स्थानाचा अ‍ॅक्सेस द्या, <ph name="BEGIN_LINK"/>Android सेटिंग्ज<ph name="END_LINK"/> मध्ये देखील स्थान सुरू करा.</translation>
+<translation id="1028853271388022585">Brave ला तुमच्या कॅमेराचा ॲक्सेस द्या, <ph name="BEGIN_LINK"/>Android सेटिंग्ज<ph name="END_LINK"/> मध्ये देखील कॅमेरा सुरू करा.</translation>
+<translation id="2913721282607281710">Brave ने तुम्हाला सूचना पाठवण्यासाठी, <ph name="BEGIN_LINK"/>Android सेटिंग्ज<ph name="END_LINK"/> मध्ये देखील सूचना सुरू करा.</translation>
+<translation id="8753483718490035722">Brave ला तुमच्या मायक्रोफोनचा ॲक्सेस द्या, <ph name="BEGIN_LINK"/>Android सेटिंग्ज<ph name="END_LINK"/> मध्ये देखील मायक्रोफोन सुरू करा.</translation>
+<translation id="1887786770086287077">या डिव्हाइसाठी स्थान अ‍ॅक्सेस बंद आहे, <ph name="BEGIN_LINK"/>Android सेटिंग्‍ज<ph name="END_LINK"/> मध्‍ये हे चालू करा.</translation>
+<translation id="2570922361219980984">या डिव्हाइसाठी स्थान अ‍ॅक्सेस देखील बंद आहे, <ph name="BEGIN_LINK"/>Android सेटिंग्‍ज<ph name="END_LINK"/> मध्‍ये हे सुरू करा.</translation>
+<translation id="1620510694547887537">कॅमेरा</translation>
+<translation id="3227137524299004712">मायक्रोफोन</translation>
+<translation id="1647391597548383849">तुमचा कॅमेरा ॲक्सेस करा</translation>
+<translation id="945632385593298557">तुमचा मायक्रोफोन ॲक्सेस करा</translation>
+<translation id="6612358246767739896">संरक्षित आशय</translation>
+<translation id="885701979325669005">स्टोरेज</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> संचयित केलेला डेटा</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">डिव्हाइस परवानगी रद्द करा</translation>
+<translation id="4962975101802056554">डिव्हाइससाठीच्या सर्व परवानग्या रद्द करा</translation>
+<translation id="6545864417968258051">ब्लूटूथ स्कॅन करत आहे</translation>
+<translation id="4411535500181276704">लाइट मोड</translation>
+<translation id="7821588508402923572">तुमची डेटा बचत येथे दिसेल</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> बचत केली</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> पासून</translation>
+<translation id="3252158532344029638">लाइट मोडमध्ये, Brave पेज आणखी जलद लोड करते आणि ६० टक्के पर्यंत कमी डेटा वापरते.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> डेटा बचत</translation>
+<translation id="7494974237137038751">डेटा वाचवला</translation>
+<translation id="6111020039983847643">डेटा वापरला</translation>
+<translation id="7413229368719586778">सुरू होण्याची तारीख <ph name="DATE"/></translation>
+<translation id="1782483593938241562">संपण्याची तारीख <ph name="DATE"/></translation>
+<translation id="2728754400939377704">साइटनुसार क्रमाने लावा</translation>
+<translation id="5864174910718532887">तपशील: साइटच्या नावानुसार क्रमाने लावलेले</translation>
+<translation id="116280672541001035">वापरला</translation>
+<translation id="8349013245300336738">वापरलेल्या डेटानुसार क्रमाने लावा</translation>
+<translation id="6378173571450987352">तपशील: वापरलेल्या डेटाच्या प्रमाणानुसार क्रमाने लावलेला</translation>
+<translation id="2631006050119455616">वाचवला</translation>
+<translation id="6643649862576733715">वाचवलेल्या डेटानुसार क्रमाने लावा</translation>
+<translation id="7302081693174882195">तपशील: सेव्ह केलेल्या डेटाच्या प्रमाणानुसार क्रमाने लावलेले</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> वापरला</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> वाचवला</translation>
+<translation id="2156074688469523661">उर्वरित साइट (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">इतर</translation>
+<translation id="4913161338056004800">आकडेवारी रीसेट करा</translation>
+<translation id="1856325424225101786">लाइट मोड रीसेट करायचा?</translation>
+<translation id="3658159451045945436">रीसेट केल्याने तुमचा डेटा सेव्हिंग इतिहास, भेट दिलेल्या साइटच्या सूचीसह, मिटवला जातो.</translation>
+<translation id="3295530008794733555">आणखी जलद ब्राउझ करा. कमी डेटा वापरा.</translation>
+<translation id="7340390500800578919">लाइट मोडमध्ये, Brave पेज आणखी जलद लोड करते आणि ६० टक्के कमी डेटा वापरते. तुम्ही भेट दिलेली पेज ऑप्टिमाइझ करण्यासाठी, Brave तुमचे वेब ट्रॅफिक Brave Software ला पाठवते. <ph name="BEGIN_LINK"/>अधिक जाणून घ्या<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">लाइट मोड सुरू करा</translation>
+<translation id="4493497663118223949">लाइट मोड सुरू आहे</translation>
+<translation id="7559975015014302720">लाइट मोड बंद आहे</translation>
+<translation id="7606077192958116810">लाइट मोड सुरू आहे. ते सेटिंग्जमध्ये व्यवस्थापित करा.</translation>
+<translation id="4714588616299687897">तुमचा सुमारे 60% डेटा वाचवा</translation>
+<translation id="1006927014032731288">Brave Software सर्व्हर तुम्ही भेट देत असलेली पेज ऑप्टिमाइझ करतील.</translation>
+<translation id="3257320067425202300">Brave ने तुमच्यासाठी <ph name="MEGABYTES"/> MB सेव्ह केले</translation>
+<translation id="5813223329348543512">Brave ने तुमच्यासाठी <ph name="GIGABYTES"/> GB सेव्ह केले आहे</translation>
+<translation id="8266862848225348053">डाउनलोड करण्याचे स्थान</translation>
+<translation id="7077143737582773186">SD कार्ड</translation>
+<translation id="7762668264895820836">SD कार्ड <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">फायली कुठे सेव्ह करायच्या ते विचारा</translation>
+<translation id="6192333916571137726">फाइल डाउनलोड करा</translation>
+<translation id="1672586136351118594">पुन्हा दाखवू नका</translation>
+<translation id="2650751991977523696">फाइल पुन्हा डाउनलोड करायची?</translation>
+<translation id="8664979001105139458">फाइलचे नाव आधीपासून अस्तित्वात आहे</translation>
+<translation id="488187801263602086">फाइलला पुन्हा नाव द्या</translation>
+<translation id="5686790454216892815">फाइलचे नाव खूप लांब आहे</translation>
+<translation id="7454641608352164238">पुरेशी जागा उरलेली नाही</translation>
+<translation id="8972098258593396643">डीफॉल्ट फोल्डरमध्ये डाउनलोड करायचे?</translation>
+<translation id="804335162455518893">SD कार्ड आढळले नाही</translation>
+<translation id="7475688122056506577">SD कार्ड आढळले नाही. तुमच्या काही फायली गहाळ झालेल्या असू शकतात.</translation>
+<translation id="4198423547019359126">कोणतीही डाउनलोड स्थाने उपलब्ध नाहीत</translation>
+<translation id="8224471946457685718">वाय-फायवर तुमच्यासाठी लेख डाउनलोड करा</translation>
+<translation id="4970824347203572753">तुमच्या स्थानामध्ये उपलब्ध नाही</translation>
+<translation id="5500777121964041360">तुमच्या स्थानामध्ये उपलब्ध नसू शकते</translation>
+<translation id="1173894706177603556">नाव बदला</translation>
+<translation id="1986685561493779662">नाव आधीपासून अस्तित्वात आहे</translation>
+<translation id="6441734959916820584">नाव खूपच मोठे आहे</translation>
+<translation id="2923908459366352541">नाव अवैध आहे</translation>
+<translation id="7290209999329137901">नाव बदलणे उपलब्ध नाही</translation>
+<translation id="3334729583274622784">फाइल एक्स्टेंशन बदलायचे आहे का?</translation>
+<translation id="107147699690128016">तुम्ही फाइल एक्स्टेंशन बदलल्यास, फाइल कदाचित दुसऱ्या ॲप्लिकेशनमध्ये उघडू शकते आणि यामुळे तुमच्या डिव्हाइसला संभाव्य धोका असू शकतो.</translation>
+<translation id="8541922081612557424">Brave बद्दल</translation>
+<translation id="5311273890481188673">कॉपीराइट <ph name="YEAR"/> Brave Software LLC. सर्व हक्क राखीव.</translation>
+<translation id="1416550906796893042">ॲप्लिकेशन आवृत्ती</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (<ph name="TIME_SINCE_UPDATE"/> वाजता अपडेट केले)</translation>
+<translation id="7596558890252710462">ऑपरेटिंग सिस्टम</translation>
+<translation id="3968054912784331254">Android च्या या आवृत्तीसाठी Brave अपडेटना सपोर्ट नाही</translation>
+<translation id="7665369617277396874">खाते जोडा</translation>
+<translation id="649070405679044769">Brave Software मध्ये हे म्हणून साइन इन केले</translation>
+<translation id="6234515504547364178">Brave मधून साइन आउट करा</translation>
+<translation id="5324858694974489420">पालक सेटिंग्ज</translation>
+<translation id="8920114477895755567">पालकांच्या तपशीलांसाठी प्रतीक्षा करत आहोत.</translation>
+<translation id="5512137114520586844">हे खाते <ph name="PARENT_NAME"/> द्वारे व्यवस्थापित केले आहे.</translation>
+<translation id="2956410042958133412">हे खाते <ph name="PARENT_NAME_1"/> आणि <ph name="PARENT_NAME_2"/> द्वारे व्यवस्थापित केले आहे.</translation>
+<translation id="8168435359814927499">आशय</translation>
+<translation id="5403644198645076998">केवळ काही साइटना अनुमती द्या</translation>
+<translation id="8641930654639604085">प्रौढ सामग्री असलेल्या साइटना अवरोधित करण्‍याचा प्रयत्न करा</translation>
+<translation id="5639724618331995626">सर्व साइटना अनुमती द्या</translation>
+<translation id="796823723482603597">Brave द्वारे समर्थित</translation>
+<translation id="6324034347079777476">Android सिस्‍टीम संकालन अक्षम केले</translation>
+<translation id="5127805178023152808">संकालन बंद आहे</translation>
+<translation id="7015203776128479407">सुरुवातीचे सिंक सेट करणे पूर्ण झाले नाही. सिंक बंद आहे.</translation>
+<translation id="2497852260688568942">तुमच्या ॲडमिनिस्ट्रेटरने सिंक अक्षम केले आहे</translation>
+<translation id="9100610230175265781">सांकेतिक पासफ्रेझ आवश्यक</translation>
+<translation id="6108923351542677676">सेटअप प्रगती पथावर आहे...</translation>
+<translation id="4062305924942672200">कायदेशीर माहिती</translation>
+<translation id="4256782883801055595">मुक्त स्रोत परवाने</translation>
+<translation id="1138681184697033370">Brave सेवा अटी</translation>
+<translation id="7392539049993970338">Brave गोपनीयता सूचना</translation>
+<translation id="2677748264148917807">सोडा</translation>
+<translation id="5556459405103347317">रीलोड करा</translation>
+<translation id="1623104350909869708">या पृष्ठास अतिरिक्त संवाद तयार करण्यापासून प्रतिबंधित करा</translation>
+<translation id="2968755619301702150">सर्टिफिकेट दर्शक</translation>
+<translation id="1360432990279830238">साइन आउट करून सिंक बंद करायचे आहे का?</translation>
+<translation id="8581481290581777242">या डिव्हाइसवरून तुमचा Chrom डेटा साफ करायचा?</translation>
+<translation id="1318865768845061710">तुमचे बुकमार्क, इतिहास, पासवर्ड आणि इतर Brave डेटा आता तुमच्या Brave Software खात्यामध्ये सिंक केला जाणार नाही</translation>
+<translation id="3325020657155065477">तुमचा या डिव्हाइसवरील Brave डेटा देखील साफ करा</translation>
+<translation id="6136448902816743006"><ph name="DOMAIN_NAME"/> द्वारे व्यवस्थापित केलेल्या खात्यामधून तुम्ही साइन आउट करत असल्यामुळे, या डिव्हाइसवरून Brave डेटा हटवला जाईल. तो तुमच्या Brave Software खात्यामध्ये तसाच राहिल.</translation>
+<translation id="1853026300647876496">Brave Software शी संपर्क साधत आहे. याला एखादे मिनिट लागेल…</translation>
+<translation id="2328985652426384049">साइन इन करू शकत नाही</translation>
+<translation id="7723158744459952869">Brave Software ने प्रतिसाद देण्यास बराच वेळ घेतला</translation>
+<translation id="4572422548854449519">व्यवस्थापित केलेल्या खात्यामध्ये साइन इन करा</translation>
+<translation id="2689656545739939160">तुम्ही <ph name="MANAGED_DOMAIN"/> ने व्यवस्थापित केलेल्या खात्यासह साइन इन करत आहात आणि त्याच्या ॲडमिनिस्ट्रेटरला तुमच्या Brave डेटाचे नियंत्रण देत आहात. तुमचा डेटा कायमचा या खात्यामध्ये असेल. Brave मधून साइन आउट केल्याने तुमचा डेटा या डिव्हाइस वरून हटवला जाईल परंतु तो तुमच्या Brave Software खात्यामध्ये स्टोअर केलेला असेल.</translation>
+<translation id="1749561566933687563">तुमचे बुकमार्क सिंक करा</translation>
+<translation id="4242533952199664413">सेटिंग्ज उघडा</translation>
+<translation id="1111673857033749125">आपल्या इतर डिव्हाइसेेसवर सेव्ह केलेले बुकमार्क येथे दिसतील.</translation>
+<translation id="8636825310635137004">आपल्या इतर डिव्हाइसेस मधून तुमचे टॅब प्राप्त करण्यासाठी, संकालन चालू करा</translation>
+<translation id="3269956123044984603">तुमच्या अन्य डिव्हाइसवरून तुमचे टॅब मिळविण्यासाठी, Android खाते सेटिंग्ज मधील “डेटा ऑटो-सिंक करा” चालू करा.</translation>
+<translation id="5157964048453367290">आपल्या अन्य डिव्हाइसेसवर तुम्ही Brave मध्ये उघडलेले टॅब येथे दिसतील.</translation>
+<translation id="4684427112815847243">सर्वकाही संंकालित करा</translation>
+<translation id="2709516037105925701">ऑटोफिल</translation>
+<translation id="8820817407110198400">Bookmarks</translation>
+<translation id="1644574205037202324">इतिहास</translation>
+<translation id="17513872634828108">खुले टॅब</translation>
+<translation id="1320169905922104972">Brave Software Pay वापरून क्रेडिट कार्ड आणि पत्ते</translation>
+<translation id="6337234675334993532">एंक्रिप्शन</translation>
+<translation id="6698801883190606802">संकालित केलेला डेटा व्यवस्थापित करा</translation>
+<translation id="3598578758776312506">Brave Software क्रेडेंशियलसह पासवर्ड एंक्रिप्ट करा</translation>
+<translation id="7810580217418711046"><ph name="TIME"/> पर्यंत Brave Software पासवर्डसह सिंक केलेला डेटा एंक्रिप्ट करा</translation>
+<translation id="8461694314515752532">तुमच्या स्वतःच्या सिंक पासफ्रेजसह सिंक केलेला डेटा एंक्रिप्ट करा</translation>
+<translation id="2996291259634659425">सांकेतिक पासफ्रेझ तयार करा</translation>
+<translation id="5713644099811900409">Brave Software खाते</translation>
+<translation id="8997474919031554666">पासफ्रेज एंक्रिप्शनमध्ये Brave Software Pay वरील पेमेंट पद्धतींचा आणि पत्त्यांचा समावेश नसतो. फक्त तुमचा पासफ्रेज असलेली एखादी व्यक्ती तुमचा एंक्रिप्ट केलेला डेटा वाचू शकते. पासफ्रेज Brave Software कडे पाठवला किंवा त्याद्वारे स्टोअर केला जात नाही. तुम्ही तुमचा पासफ्रेज विसरल्यास किंवा तुम्हाला हे सेटिंग बदलायचे असल्यास, तुम्हाला सिंक रीसेट करण्याची आवश्यकता असेल. <ph name="BEGIN_LINK"/>अधिक जाणून घ्या<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">सांकेतिक पासफ्रेझ</translation>
+<translation id="7772032839648071052">सांकेतिक पासफ्रेझ निश्चित करा</translation>
+<translation id="5304593522240415983">हे फील्ड रिक्त ठेवता येणार नाही</translation>
+<translation id="321773570071367578">तुमचा सांकेतिक पासफ्रेझ विसरल्यास किंवा हे सेटिंग बदलू इच्छित असल्यास, <ph name="BEGIN_LINK"/>सिंक रीसेट करा<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">सांकेतिक वाक्यांश जुळत नाहीत</translation>
+<translation id="5149495116300586333">पासफ्रेज एंक्रिप्शनमध्ये Brave Software Pay वरील पेमेंट पद्धतींचा आणि पत्त्यांचा समावेश नसतो.
+
+हे सेटिंग बदलण्यासाठी, <ph name="BEGIN_LINK"/>सिंक रीसेट करा<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">अयोग्य सांकेतिक पासफ्रेझ</translation>
+<translation id="5414836363063783498">सत्यापित करत आहे...</translation>
+<translation id="6846298663435243399">लोड करीत आहे...</translation>
+<translation id="5517095782334947753">आपल्याकडे <ph name="FROM_ACCOUNT"/> मधील बुकमार्क, इतिहास, पासवर्ड आणि अन्य सेटिंग्ज आहेत.</translation>
+<translation id="3928666092801078803">माझा डेटा एकत्र करा</translation>
+<translation id="688738109438487280">विद्यमान डेटा <ph name="TO_ACCOUNT"/> मध्ये जोडा.</translation>
+<translation id="806745655614357130">माझा डेटा स्वतंत्र ठेवा</translation>
+<translation id="1145536944570833626">विद्यमान डेटा हटवा.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> जोडू इच्छिते</translation>
+<translation id="4915549754973153784">डिव्हाइस स्कॅन करत असताना <ph name="BEGIN_LINK"/>मदत मिळवा<ph name="END_LINK"/>…</translation>
+<translation id="5817918615728894473">जोडा</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>मदत मिळवा<ph name="END_LINK1"/> किंवा <ph name="BEGIN_LINK2"/>पुन्हा स्कॅन करा<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">कोणतीही कंपॅटिबल डिव्हाइस आढळली नाहीत</translation>
+<translation id="3773755127849930740">पेअरिंगला अनुमती देण्‍यासाठी <ph name="BEGIN_LINK"/>ब्लूटूथ सुरू करा<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">ब्लूटूथ अडॅप्टर सुरू करण्यात Brave अक्षम आहे</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>मदत मिळवा<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">डिव्हाइस स्कॅन करण्‍यासाठी Brave ला स्थान ॲक्सेसची आवश्‍यकता असते. <ph name="BEGIN_LINK"/>परवानग्या अपडेट करा<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">डिव्हाइस स्कॅन करण्‍यासाठी Brave ला स्थान ॲक्सेसची आवश्यकता असते. स्थान ॲक्सेस <ph name="BEGIN_LINK"/>या डिव्हाइसाठी बंद केला आहे<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">डिव्हाइस स्कॅन करण्‍यासाठी Brave ला स्थान ॲक्सेसची आवश्यकता असते. <ph name="BEGIN_LINK1"/>परवानग्या अपडेट करा<ph name="END_LINK1"/>. स्थान ॲक्सेस देखील <ph name="BEGIN_LINK2"/>या डिव्हाइसाठी बंद केला आहे<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">कनेक्‍ट केलेले डिव्हाइस</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{सिग्नल क्षमता पातळी: # बार}other{सिग्नल क्षमता पातळी: # बार}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> ला जवळपासची ब्लूटूथ डिव्हाइस स्कॅन करायची आहेत. खालील डिव्हाइस आढळली:</translation>
+<translation id="8368027906805972958">अज्ञात किंवा सपोर्ट नसलेले डिव्हाइस (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">संकालन कार्य करत नाही</translation>
+<translation id="1810845389119482123">सुरुवातीचे सिंक सेट करणे पूर्ण झाले नाही</translation>
+<translation id="3235722914093408050">Brave सिंक सुरू करण्यासाठी Android सेटिंग्ज उघडा आणि Android सिस्टम सिंक पुन्हा सक्षम करा</translation>
+<translation id="3367813778245106622">संकालन प्रारंभ करण्‍यासाठी पुन्हा साइन इन करा</translation>
+<translation id="974555521953189084">सिंक सुरू करण्यासाठी तुमचा सांकेतिक पासफ्रेझ एंटर करा</translation>
+<translation id="2997266899014181325">सिंक सुरू करण्यासाठी, "तुमचा Brave डेटा सिंक करा" सुरू करा.</translation>
+<translation id="8260126382462817229">पुन्हा साइन इन करण्याचा प्रयत्न करा</translation>
+<translation id="5919204609460789179">सिंक सुरू करण्यासाठी <ph name="PRODUCT_NAME"/> अपडेट करा</translation>
+<translation id="397583555483684758">संकालनाने कार्य करणे थांबविले आहे</translation>
+<translation id="1966710179511230534">कृपया साइन इन तपशील अपडेट करा.</translation>
+<translation id="7063006564040364415">संकालित सर्व्हरशी कनेक्ट करू शकलो नाही.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> कालबाह्य झाले आहे.</translation>
+<translation id="4170011742729630528">सेवा उपलब्ध नाही; नंतर पुन्हा प्रयत्न करा.</translation>
+<translation id="7947953824732555851">स्वीकार करा आणि साइन इन करा</translation>
+<translation id="8583805026567836021">खाते डेटा साफ करत आहे</translation>
+<translation id="8310344678080805313">मानक टॅब</translation>
+<translation id="5748802427693696783">मानक टॅबवर स्विच केले</translation>
+<translation id="7998918019931843664">बंद केलेले टॅब पुन्हा उघडा</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, टॅब</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> टॅब बंद करा</translation>
+<translation id="7243308994586599757">स्क्रीनच्या तळाशी पर्याय उपलब्ध आहेत</translation>
+<translation id="4060598801229743805">स्क्रीनच्या शीर्षावर पर्याय उपलब्ध आहेत</translation>
+<translation id="2810645512293415242">डेटा सेव्ह करण्यासाठी आणि तो लवकर लोड होण्यासाठी पेज सुलभ केले.</translation>
+<translation id="3985215325736559418">तुम्ही <ph name="FILE_NAME"/> पुन्हा डाउनलोड करू इच्छिता?</translation>
+<translation id="2450083983707403292">तुम्हाला <ph name="FILE_NAME"/> चे डाउनलोड पुन्हा सुरू करायचे आहे का?</translation>
+<translation id="7514365320538308">डाउनलोड करा</translation>
+<translation id="545042621069398927">तुमच्या डाउनलोडचा वेग वाढवत आहे.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{फाइल डाऊनलोड करत आहे.}other{# फायली डाउनलोड करत आहे.}}</translation>
+<translation id="543509235395288790">(<ph name="MEGABYTES"/>) च्या <ph name="COUNT"/> फायली डाउनलोड करत आहे.</translation>
+<translation id="4988210275050210843">(<ph name="MEGABYTES"/>) ची फाइल डाउनलोड करत आहे.</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{एक डाउनलोड पूर्ण झाला आहे.}other{# डाउनलोड पूर्ण झाले आहेत.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{एक डाउनलोड होऊ शकला नाही.}other{# डाउनलोड होऊ शकले नाहीत.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{एक डाउनलोड प्रलंबित आहे.}other{# डाउनलोड प्रलंबित आहेत.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> बटण</translation>
+<translation id="3205824638308738187">जवळजवळ पूर्ण झाले!</translation>
+<translation id="3960299545138990065">Brave रीस्टार्ट करा</translation>
+<translation id="3771001275138982843">अपडेट डाउनलोड करता आले नाही</translation>
+<translation id="3888648114124182147">Brave अपडेट डाउनलोड करत आहे…</translation>
+<translation id="1705567146636171298">Brave अपडेट करा</translation>
+<translation id="6195417478702700398">उत्तम ब्राउझिंग अनुभव मिळवण्याकरीता, Brave अपडेट करण्यासाठी उघडा</translation>
+<translation id="3512968675351418494">तुमच्या भाषेत वेब पाहण्यासाठी, Brave ची नवीनतम आवृत्ती मिळवा</translation>
+<translation id="6427112570124116297">वेबचे भाषांतर करा</translation>
+<translation id="1379423114029199501">Brave च्या नवीनतम आवृत्तीमध्ये तुमची भाषा मिळवण्यासाठी अपडेट करा</translation>
+<translation id="5684874026226664614">अरेरे. हे पृष्‍ठ भाषांतरित केले जाऊ शकले नाही.</translation>
+<translation id="6831043979455480757">भाषांतर करा</translation>
+<translation id="1285320974508926690">या साइटचा कधीही भाषांतर करु नका</translation>
+<translation id="773466115871691567">नेहमी पेज <ph name="SOURCE_LANGUAGE"/>मध्ये भाषांतरित करा</translation>
+<translation id="1068672505746868501">पेज <ph name="SOURCE_LANGUAGE"/> मध्ये कधीही भाषांतरित करू नका</translation>
+<translation id="124116460088058876">आणखी भाषा...</translation>
+<translation id="290376772003165898">पेज <ph name="LANGUAGE"/>मध्ये नाही?</translation>
+<translation id="4432792777822557199">आतापासून पेज <ph name="SOURCE_LANGUAGE"/>मधून <ph name="TARGET_LANGUAGE"/>मध्ये भाषांतरित केली जातील</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/>मधील पेज भाषांतरीत केले जाणार नाही</translation>
+<translation id="5447765697759493033">या साइटचे भाषांतर होणार नाही</translation>
+<translation id="4880127995492972015">भाषांतर करा…</translation>
+<translation id="641643625718530986">प्रिंट करा...</translation>
+<translation id="8909135823018751308">शेअर करा...</translation>
+<translation id="4996978546172906250">याद्वारे शेअर करा</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> द्वारे शेअर करा</translation>
+<translation id="6277522088822131679">पृष्‍ठ प्रिंट करण्‍यात एक समस्‍या होती. कृपया पुन्‍हा प्रयत्न करा.</translation>
+<translation id="3254409185687681395">या पृष्ठास बुकमार्क करा</translation>
+<translation id="497421865427891073">पुढे जा</translation>
+<translation id="813082847718468539">साइटची माहिती पहा</translation>
+<translation id="2532336938189706096">वेब दृश्य</translation>
+<translation id="6005538289190791541">सुचवलेला पासवर्ड</translation>
+<translation id="4634124774493850572">पासवर्ड वापरा</translation>
+<translation id="8285489906452138776">या साइटसाठी Braveला तुमचा कॅमेरा ॲक्सेस करण्याची परवानगी आवश्यक आहे.</translation>
+<translation id="320189792589364011">या साइटसाठी Braveला तुमचा मायक्रोफोन ॲक्सेस करण्याची परवानगी आवश्यक आहे.</translation>
+<translation id="7988136689212463100">या साइटसाठी Braveला तुमचा कॅमेरा आणि मायक्रोफोन ॲक्सेस करण्याची परवानगी आवश्यक आहे.</translation>
+<translation id="4931190655840828017">तुमचे स्थान या साइटसोबत शेअर करण्यासाठी Braveला तुमच्या स्थानाचा अ‍ॅक्सेस हवा आहे.</translation>
+<translation id="3088191967551450609">Brave ला फायली डाउनलोड करण्यासाठी स्टोरेज ॲक्सेस आवश्यक आहे.</translation>
+<translation id="8942627711005830162">इतर विंडोमध्ये उघडा</translation>
+<translation id="4195643157523330669">नवीन टॅबमध्ये उघडा</translation>
+<translation id="1100066534610197918">गटामधील नवीन टॅबमध्ये उघडा</translation>
+<translation id="4860895144060829044">कॉल करा</translation>
+<translation id="6896758677409633944">कॉपी करा</translation>
+<translation id="8393700583063109961">संदेश पाठवा</translation>
+<translation id="3557336313807607643">संपर्कांमध्ये जोडा</translation>
+<translation id="4269820728363426813">लिंकचा पत्ता कॉपी करा</translation>
+<translation id="1206892813135768548">लिंक मजकूर कॉपी करा</translation>
+<translation id="1204037785786432551">लिंक डाउनलोड करा</translation>
+<translation id="6864459304226931083">इमेज डाउनलोड करा</translation>
+<translation id="8209050860603202033">इमेज उघडा</translation>
+<translation id="8073388330009372546">नवीन टॅबमध्ये इमेज उघडा</translation>
+<translation id="6649642165559792194">इमेज <ph name="BEGIN_NEW"/>नवीन<ph name="END_NEW"/> चे पूर्वावलोकन करा</translation>
+<translation id="3269093882174072735">इमेज लोड करा</translation>
+<translation id="3845332215609790146"><ph name="BEGIN_NEW"/>नवीन<ph name="END_NEW"/> Brave Software लेन्स वापरून शोधा</translation>
+<translation id="5578795271662203820">या इमेजसाठी <ph name="SEARCH_ENGINE"/> शोधा</translation>
+<translation id="3384347053049321195">इमेज शेअर करा</translation>
+<translation id="5833984609253377421">लिंक शेअर करा</translation>
+<translation id="6475951671322991020">व्हिडिओ डाउनलोड करा</translation>
+<translation id="2317945146070194624">नवीन Brave टॅबमध्‍ये उघडा</translation>
+<translation id="7975379999046275268">पेज <ph name="BEGIN_NEW"/>नवीन<ph name="END_NEW"/> चे पूर्वावलोकन करा</translation>
+<translation id="6112702117600201073">पृष्ठ रिफ्रेश करीत आहे</translation>
+<translation id="36525718899759834">Brave Software Play Store मधून ॲप मिळवा: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">गडद</translation>
+<translation id="1807246157184219062">फिकट</translation>
+<translation id="4056223980640387499">सेपिया</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">मोनोस्पेस</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">बीममध्ये एक टॅब निवडा</translation>
+<translation id="8719023831149562936">वर्तमान टॅब बीम करू शकत नाही</translation>
+<translation id="2139186145475833000">होम स्क्रीनवर जोडा</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> उघडा</translation>
+<translation id="2122601567107267586">ॲप उघडता आले नाही</translation>
+<translation id="5129038482087801250">वेब अ‍ॅप इंस्टॉल करा</translation>
+<translation id="3789841737615482174">स्थापना करा</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> ला तुमच्या होम स्क्रीनवर पेअरिंग आले</translation>
+<translation id="7333031090786104871">अद्याप मागील साइट जोडत आहे</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> जोडत आहे…</translation>
+<translation id="3778956594442850293">होम स्क्रीनवर जोडले</translation>
+<translation id="2146738493024040262">झटपट ॲप्स उघडा</translation>
+<translation id="7016516562562142042">वर्तमान शोध इंजिनसाठी अनुमती दिली</translation>
+<translation id="6177111841848151710">वर्तमान शोध इंजिनसाठी अवरोधित केले</translation>
+<translation id="145097072038377568">Android सेटिंग्ज मध्‍ये बंद करा</translation>
+<translation id="8007176423574883786">या डिव्हाइससाठी बंद करा</translation>
+<translation id="164269334534774161">तुम्ही <ph name="CREATION_TIME"/> पासून या पेजची ऑफलाइन प्रत पाहत आहात</translation>
+<translation id="4594952190837476234">हे <ph name="CREATION_TIME"/> पासूनचे ऑफलाइन पेज आहे आणि ऑनलाइन आवृत्तीपेक्षा वेगळे असू शकते.</translation>
+<translation id="8840953339110955557">हे पेज ऑनलाइन आवृत्तीपेक्षा वेगळे असू शकते.</translation>
+<translation id="6405300764336705484">Brave Software ने वितरित केलेली ही आशय, <ph name="DOMAIN_NAME"/> मधील आहे.</translation>
+<translation id="1006017844123154345">ऑनलाइन उघडा</translation>
+<translation id="3326636747541519688">Brave Software द्वारे पुरवलेले लाइट पेज</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> वरून <ph name="BEGIN_LINK"/>मुळचे पेज लोड करा<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">तुम्ही हे वारंवार पहात असल्यास, या <ph name="BEGIN_LINK"/>सूचना<ph name="END_LINK"/> वापरून पहा.</translation>
+<translation id="8748850008226585750">सामग्री लपविली</translation>
+<translation id="3810973564298564668">व्यवस्थापित करा</translation>
+<translation id="5199929503336119739">कार्य प्रोफाइल</translation>
+<translation id="528192093759286357">शीर्ष पासून ड्रॅग करा आणि फुलस्क्रीन मधून बाहेर पडण्यासाठी परत बटणास स्पर्श करा.</translation>
+<translation id="2836148919159985482">फुलस्क्रीन मधून बाहेर पडण्यासाठी परत बटणास स्पर्श करा.</translation>
+<translation id="3967822245660637423">पूर्ण डाउनलोड करा</translation>
+<translation id="2434158240863470628">डाउनलोड पूर्ण झाले <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">डाउनलोड अयशस्वी झाले</translation>
+<translation id="1384959399684842514">डाउनलोडला विराम दिला</translation>
+<translation id="1671236975893690980">डाउनलोड प्रलंबित आहे</translation>
+<translation id="5561549206367097665">नेटवर्कची वाट पाहत आहे…</translation>
+<translation id="5864419784173784555">दुसर्‍या डाउनलोडची वाट पाहत आहे…</translation>
+<translation id="6461962085415701688">फाइल उघडू शकत नाही</translation>
+<translation id="1178581264944972037">विराम द्या</translation>
+<translation id="8200772114523450471">रेझ्युमे</translation>
+<translation id="1409879593029778104">फाइल आधीपासून अस्तित्वात असल्याने <ph name="FILE_NAME"/> डाउनलोड करणे प्रतिबंधित केले.</translation>
+<translation id="3387650086002190359">फाइल सिस्टम एररमुळे <ph name="FILE_NAME"/> डाउनलोड अयशस्वी झाले.</translation>
+<translation id="6482749332252372425">स्टोरेज स्थानाच्या अभावामुळे <ph name="FILE_NAME"/> डाउनलोड अयशस्वी झाले.</translation>
+<translation id="7619072057915878432">नेटवर्क बिघाडामुळे <ph name="FILE_NAME"/> डाउनलोड अयशस्वी झाले.</translation>
+<translation id="1477626028522505441">सर्व्हर समस्यांमुळे <ph name="FILE_NAME"/> डाउनलोड अयशस्वी झाले.</translation>
+<translation id="3692944402865947621"><ph name="FILE_NAME"/> download failed because storage location is not reachable.</translation>
+<translation id="604996488070107836">अज्ञात एररमुळे <ph name="FILE_NAME"/> डाउनलोड करणे अयशस्वी झाले.</translation>
+<translation id="6738867403308150051">डाउनलोड करीत आहे…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB डाउनलोड केले</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB डाउनलोड केले</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB डाउलोड केले</translation>
+<translation id="9204836675896933765">1 फाइल शिल्लक</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> फायली शिल्लक</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> फाइल डाउनलोड केली}other{<ph name="FILES_DOWNLOADED_MANY"/> फायली डाउनलोड केल्या}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> दिवस शिल्लक</translation>
+<translation id="8190358571722158785">1 दिवस शिल्लक</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> तास शिल्लक</translation>
+<translation id="510275257476243843">1 तास शिल्लक</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> मिनिटे शिल्लक</translation>
+<translation id="3236059992281584593">1 मिनिट शिल्लक</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> सेकंद शिल्लक</translation>
+<translation id="2781151931089541271">1 सेकंद शिल्लक</translation>
+<translation id="3303414029551471755">आशय डाउनलोड करणे सुरु ठेवायचे?</translation>
+<translation id="8617240290563765734">डाउनलोड केलेल्या आशयमध्ये नमूद केलेली सुचविलेली URL उघडायची?</translation>
+<translation id="1373696734384179344">निवडलेला आशय डाउनलोड करण्यासाठी अपुरी मेमरी.</translation>
+<translation id="5271967389191913893">डाउनलोड केली जाण्यासाठी डिव्हाइस आशय उघडू शकत नाही.</translation>
+<translation id="883806473910249246">आशय डाउनलोड करताना एरर आली.</translation>
+<translation id="5626134646977739690">नाव:</translation>
+<translation id="7963646190083259054">विक्रेता:</translation>
+<translation id="3414952576877147120">आकार:</translation>
+<translation id="7375125077091615385">प्रकार:</translation>
+<translation id="5765780083710877561">वर्णन:</translation>
+<translation id="4881695831933465202">उघडा</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB उपलब्ध</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB उपलब्ध</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB उपलब्ध आहे</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/> पैकी <ph name="SPACE_USED"/> वापरत आहे</translation>
+<translation id="3587482841069643663">सर्व</translation>
+<translation id="4988526792673242964">पेज</translation>
+<translation id="3810838688059735925">व्हिडिओ</translation>
+<translation id="3616113530831147358">ऑडिओ</translation>
+<translation id="9219103736887031265">इमेज</translation>
+<translation id="8250920743982581267">दस्तऐवज</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# फाइल}other{# फायली}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# इमेज}other{# इमेज}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# व्हिडिओ}other{# व्हिडिओ}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ऑडिओ फाइल}other{# ऑडिओ फायली}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# पेज}other{# पेज}}</translation>
+<translation id="5456381639095306749">पेज डाउनलोड करा</translation>
+<translation id="2394602618534698961">तुम्ही डाउनलोड केलेल्या फायली येथे दिसतात</translation>
+<translation id="7810647596859435254">यासह उघडा...</translation>
+<translation id="5655963694829536461">तुमचे डाउनलोड शोधा</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">माझ्या फायली</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">तुम्ही ऑफलाइन असताना देखील तुम्ही वाचू शकता असे लेख येथे दिसतात</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# तास}other{# तास}}</translation>
+<translation id="5853623416121554550">थांबवले</translation>
+<translation id="8965591936373831584">प्रलंबित</translation>
+<translation id="2779651927720337254">अयशस्वी झाले</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">आताच</translation>
+<translation id="4000212216660919741">ऑफलाइन होम</translation>
+<translation id="9133397713400217035">ऑफलाइन असताना एक्सप्लोर करा</translation>
+<translation id="968900484120156207">तुम्ही भेट देता ती पेज येथे दिसतील</translation>
+<translation id="7882131421121961860">कोणताही इतिहास सापडला नाही</translation>
+<translation id="3549657413697417275">तुमचा इतिहास शोधा</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave फर्स्ट रन अनुभव</translation>
+<translation id="2700285883409956633">हे ॲप्लिकेशन वापरून, तुम्ही Brave च्या <ph name="BEGIN_LINK1"/>सेवा अटी<ph name="END_LINK1"/> आणि <ph name="BEGIN_LINK2"/>गोपनीयता सूचना<ph name="END_LINK2"/> ला सहमती देता.</translation>
+<translation id="1640714894372474981">हे अ‍ॅप्लिकेशन वापरून, तुम्ही Brave च्या <ph name="BEGIN_LINK1"/>सेवा अटी<ph name="END_LINK1"/> आणि <ph name="BEGIN_LINK2"/>गोपनीयता सूचना<ph name="END_LINK2"/> आणि <ph name="BEGIN_LINK3"/>Family Link ने व्यवस्थापित केलेल्या Brave Software खात्यांसाठी गोपनीयता सूचना<ph name="END_LINK3"/> यांना सहमती दर्शवता.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> हे Brave मध्ये उघडेल. सुरू ठेवण्याने, तुम्ही Brave च्या <ph name="BEGIN_LINK1"/>सेवा अटी<ph name="END_LINK1"/> आणि <ph name="BEGIN_LINK2"/>गोपनीयता सूचनां<ph name="END_LINK2"/> शी सहमती दाखवता.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Brave मध्ये उघडेल. सुरू ठेवण्याने तुम्ही Brave च्या <ph name="BEGIN_LINK1"/>सेवा अटी<ph name="END_LINK1"/> आणि <ph name="BEGIN_LINK2"/>गोपनीयता सूचना<ph name="END_LINK2"/>, तसेच <ph name="BEGIN_LINK3"/>Family Link सह व्यवस्थापित Brave Software खात्यांच्या गोपनीयता सूचनां<ph name="END_LINK3"/> शी तुम्ही सहमती दाखवता.</translation>
+<translation id="673197144963363525">वापर आकडेवारी आणि क्रॅश अहवाल Brave Software कडे पाठवून Brave अधिक चांगले करण्यास मदत करा.</translation>
+<translation id="3518985090088779359">स्वीकारा आणि सुरु ठेवा</translation>
+<translation id="7207456302801184289">Brave मध्ये स्वागत आहे</translation>
+<translation id="704822250101715322">Brave Software Play सेवांंनी अपडेट करणे समाप्त करण्याची प्रतीक्षा करीत आहे</translation>
+<translation id="1231733316453485619">सिंक सुरू करायचे का?</translation>
+<translation id="5132942445612118989">सर्व डिव्हाइसवर तुमचे पासवर्ड, इतिहास आणि बरेच काही सिंक करा</translation>
+<translation id="5736731321935944068">शोध, जाहिरात आणि इतर Brave Software सेवा पर्सनलाइझ करण्यासाठी Brave Software कदाचित तुमच्या इतिहासाचा वापर करू शकते</translation>
+<translation id="4013614219085422040">शोध आणि इतर Brave Software सेवा पर्सनलाइझ करण्यासाठी Brave Software कदाचित तुमच्या इतिहासाचा वापर करू शकते.</translation>
+<translation id="5581519193887989363">तुम्ही काय सिंक करायचे हे <ph name="BEGIN_LINK1"/>सेटिंग्ज<ph name="END_LINK1"/> मध्ये कधीही निवडू शकता.</translation>
+<translation id="741204030948306876">होय, मला मान्य आहे</translation>
+<translation id="2410754283952462441">एक खाते निवडा</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> म्हणून सुरू ठेवा</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> नाही?</translation>
+<translation id="8109613176066109935">तुमच्या सर्व डिव्हाइसवरील तुमचे बुकमार्क मिळवण्यासाठी, सिंक सुरू करा</translation>
+<translation id="2818669890320396765">तुमच्या सर्व डिव्हाइसवर तुमचे बुकमार्क मिळवण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
+<translation id="6003646045106347985">Brave Software ने सुचवलेला पर्सनलाइझ केलेला आशय मिळवण्यासाठी, सिंक सुरू करा</translation>
+<translation id="8494430740943879273">Brave Software ने सुचवलेला पर्सनलाइझ केलेला आशय मिळवण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
+<translation id="5862731021271217234">तुमच्या इतर डिव्हाइसवरून तुमचे टॅब मिळवण्यासाठी, सिंक सुरू करा</translation>
+<translation id="3568688522516854065">तुमच्या इतर डिव्हाइसवरून तुमचे टॅब मिळविण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
+<translation id="1208340532756947324">सर्व डिव्हाइसवर सिंक आणि पर्सनलाइझ करण्यासाठी, सिंक सुरू करा</translation>
+<translation id="4472118726404937099">सर्व डिव्हाइसवर सिंक आणि पर्सनलाइझ करण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
+<translation id="2426805022920575512">दुसरे खाते निवडा</translation>
+<translation id="6790428901817661496">प्ले करा</translation>
+<translation id="1272079795634619415">थांबा</translation>
+<translation id="2874939134665556319">मागील ट्रॅक</translation>
+<translation id="4046123991198612571">पुढील ट्रॅक</translation>
+<translation id="3859306556332390985">पुढे शोधा</translation>
+<translation id="8441146129660941386">मागे शोधा</translation>
+<translation id="6706288973712894588">तुम्ही सध्या ऑफलाइन आहात.\n<ph name="BEGIN_LINK"/>तुमचे ऑफलाइन फीड एक्सप्लोर करा.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">अलीकडील टॅब</translation>
+<translation id="8497726226069778601">अद्याप… येथे पाहण्यासाठी काहीही नाही</translation>
+<translation id="5423934151118863508">तुमची सर्वाधिक भेट दिलेली पेज येथे दिसतील</translation>
+<translation id="6127379762771434464">आयटम काढला</translation>
+<translation id="4605958867780575332">आयटम काढला: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software डूडल: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">इतर डिव्हाइसेस</translation>
+<translation id="4738836084190194332">अखेरचे संकालित: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# मिनिटापूर्वी}other{# मिनिटांपूर्वी}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# तासापूर्वी}other{# तासांपूर्वी}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# दिवसापूर्वी}other{# दिवसांपूर्वी}}</translation>
+<translation id="2762000892062317888">आत्ताच</translation>
+<translation id="1407135791313364759">सर्व उघडा</translation>
+<translation id="1209206284964581585">आतासाठी लपवा</translation>
+<translation id="129553762522093515">अलीकडे बंद केलेले</translation>
+<translation id="8413126021676339697">संपूर्ण इतिहास दर्शवा</translation>
+<translation id="7876243839304621966">सर्व काढून टाका</translation>
+<translation id="8487700953926739672">ऑफलाइन उपलब्ध</translation>
+<translation id="5224771365102442243">व्हिडिओसह</translation>
+<translation id="3493531032208478708">सूचित केलेल्या आशयविषयी <ph name="BEGIN_LINK"/>अधिक जाणून घ्या<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">सूचना मिळवू शकत नाही</translation>
+<translation id="5013696553129441713">कोणत्याही नवीन सूचना नाहीत</translation>
+<translation id="1736419249208073774">एक्सप्लोर करा</translation>
+<translation id="7444811645081526538">अधिक वर्गवाऱ्या</translation>
+<translation id="6709133671862442373">News</translation>
+<translation id="1264974993859112054">क्रीडा</translation>
+<translation id="9139318394846604261">खरेदी</translation>
+<translation id="3912508018559818924">वेबवरून सर्वोत्तम शोधत आहे…</translation>
+<translation id="526421993248218238">हे पेज लोड करू शकत नाही</translation>
+<translation id="614940544461990577">हे करून पहा:</translation>
+<translation id="3288003805934695103">पृष्ठ रीलोड करणे</translation>
+<translation id="2353636109065292463">तुमचे इंटरनेट कनेक्शन तपासत आहे</translation>
+<translation id="2858138569776157458">टॉप साइट</translation>
+<translation id="8364299278605033898">लोकप्रिय वेबसाइट पाहा</translation>
+<translation id="1171770572613082465">"टॉप साइट" बटणावर टॅप करून लोकप्रिय वेबसाइट पाहा</translation>
+<translation id="5233638681132016545">नवीन टॅब</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/> कडून – <ph name="BEGIN_DEEMPHASIZED"/>Brave Software ने वितरित केले<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">अधिक नवीन आवृत्ती उपलब्ध आहे</translation>
+<translation id="4058091506841967397">Brave अपडेट होऊ शकत नाही</translation>
+<translation id="6316139424528454185">Android आवृत्तीला सपोर्ट नाही</translation>
+<translation id="6989267951144302301">डाउनलोड करता आले नाही</translation>
+<translation id="624789221780392884">अपडेट तयार</translation>
+<translation id="1549000191223877751">अन्य विंडोवर हलवा</translation>
+<translation id="7481312909269577407">पुढील</translation>
+<translation id="4084682180776658562">बुकमार्क</translation>
+<translation id="6437478888915024427">पेज माहिती</translation>
+<translation id="7180611975245234373">रिफ्रेश करा</translation>
+<translation id="4913169188695071480">रिफ्रेश करणे थांबवा</translation>
+<translation id="1829244130665387512">या पृष्ठामध्ये शोधा</translation>
+<translation id="6593061639179217415">डेस्कटॉप साइट</translation>
+<translation id="9063523880881406963">डेस्कटॉप साइट विनंती बंद करा</translation>
+<translation id="2038563949887743358">डेस्कटॉप साइट विनंती चालू करा</translation>
+<translation id="2433507940547922241">स्वरूप</translation>
+<translation id="983192555821071799">सर्व टॅब बंद करा</translation>
+<translation id="1310482092992808703">टॅबची गटामध्ये विभागणी करा</translation>
+<translation id="7725024127233776428">तुम्ही बुकमार्क केलेली पेज येथे दिसतील</translation>
+<translation id="4404568932422911380">कोणतेही बुकमार्क नाहीत</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> बुकमार्क}other{<ph name="BOOKMARKS_COUNT_MANY"/> बुकमार्क}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> मध्ये बुकमार्क केले</translation>
+<translation id="3207960819495026254">बुकमार्क केलेली</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> ला बुकमार्क केले</translation>
+<translation id="8063895661287329888">बुकमार्क जोडण्यात अयशस्वी झाले.</translation>
+<translation id="2842985007712546952">मुख्य फोल्डर</translation>
+<translation id="9065203028668620118">संपादन</translation>
+<translation id="4405224443901389797">यामध्ये हलवा…</translation>
+<translation id="5170568018924773124">फोल्डरमध्ये दर्शवा</translation>
+<translation id="8035133914807600019">नवीन फोल्डर…</translation>
+<translation id="4532845899244822526">फोल्डर निवडा</translation>
+<translation id="6627583120233659107">फोल्डर संपादित करा</translation>
+<translation id="1197267115302279827">बुकर्माक हलवा</translation>
+<translation id="6963766334940102469">बुकमार्क हटवा</translation>
+<translation id="4351244548802238354">डायलॉग बंद करा</translation>
+<translation id="451872707440238414">तुमचे बुकमार्क शोधा</translation>
+<translation id="8901170036886848654">कोणतेही बुकमार्क आढळले नाहीत</translation>
+<translation id="6404511346730675251">बुकमार्क संपादित करा</translation>
+<translation id="3894427358181296146">फोल्डर जोडा</translation>
+<translation id="5327248766486351172">नाव</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">फोल्डर</translation>
+<translation id="5161254044473106830">शीर्षक आवश्यक</translation>
+<translation id="2996809686854298943">URL आवश्यक आहे</translation>
+<translation id="2536728043171574184">या पेजची ऑफलाइन प्रत पाहत आहे</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> मध्ये ऑफलाइन पाहा</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> आणि आणखी साइट</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{तयार झाल्यावर, Brave तुमचे पेज लोड करेल}other{तयार झाल्यावर, Brave तुमची पेज लोड करेल}}</translation>
+<translation id="6811034713472274749">पेज पाहाण्यासाठी तयार आहे</translation>
+<translation id="4561979708150884304">कनेक्शन नाही</translation>
+<translation id="8274165955039650276">डाउनलोड पाहा</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/> पैकी <ph name="RESULT_NUMBER"/> परिणाम</translation>
+<translation id="4943872375798546930">परिणाम नाहीत</translation>
+<translation id="981121421437150478">ऑफलाइन</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">सक्षम केलेला कोणताही व्हॉइस शोध उपलब्ध नाही</translation>
+<translation id="7191430249889272776">पार्श्वभूमीवर उघडा असलेला टॅब.</translation>
+<translation id="8445059357334030806">Brave मध्ये उघडा</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/> मध्‍ये उघडा</translation>
+<translation id="7022756207310403729">ब्राउझरमध्ये उघडा</translation>
+<translation id="1113597929977215864">सिंप्लिफाइड व्ह्यू दाखवा</translation>
+<translation id="1513352483775369820">बुकमार्क आणि वेब इतिहास</translation>
+<translation id="4939482511480190003">Brave सुधारण्यात मदत करा. <ph name="BEGIN_LINK"/>सर्वेक्षण करा<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">परत जा</translation>
+<translation id="5596627076506792578">अधिक पर्याय</translation>
+<translation id="3522247891732774234">अपडेट उपलब्ध आहे. आणखी पर्याय</translation>
+<translation id="6773423637732432200">Brave अपडेट होऊ शकत नाही. आणखी पर्याय</translation>
+<translation id="3328801116991980348">साइट माहिती</translation>
+<translation id="5391532827096253100">या साइटवरील तुमचे कनेक्शन सुरक्षित नाही. साइट माहिती</translation>
+<translation id="6206551242102657620">कनेक्शन सुरक्षित आहे. साइट माहिती</translation>
+<translation id="6963642900430330478">हे पेज धोकादायक आहे. साइट माहिती</translation>
+<translation id="9070377983101773829">व्हॉइस शोध प्रारंभ करा</translation>
+<translation id="8676374126336081632">इनपुट साफ करा</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> खुला टॅब, टॅब स्विच करण्यासाठी टॅप करा}other{<ph name="OPEN_TABS_MANY"/> खुला टॅब, टॅब स्विच करण्यासाठी टॅप करा}}</translation>
+<translation id="2369533728426058518">खुले टॅब</translation>
+<translation id="7071521146534760487">खाते व्यवस्थापित करा</translation>
+<translation id="932327136139879170">होम</translation>
+<translation id="2707726405694321444">पृष्ठ रिफ्रेश करा</translation>
+<translation id="2891154217021530873">पृष्ठ लोड करणे थांबवा</translation>
+<translation id="6710213216561001401">मागील</translation>
+<translation id="6659594942844771486">टॅब</translation>
+<translation id="1933845786846280168">निवडलेला टॅब</translation>
+<translation id="2268044343513325586">सुधारित करा</translation>
+<translation id="7846076177841592234">निवड रद्द करा</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> निवडले.  स्क्रीनच्या वरच्या बाजूला पर्याय उपलब्ध आहेत</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> निवडले</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 निवडलेला आयटम शेअर करा}other{# निवडलेले आयटम शेअर करा}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 निवडलेला आयटम काढून टाका}other{# निवडलेले आयटम काढून टाका}}</translation>
+<translation id="1283039547216852943">विस्तृत करण्यासाठी टॅप करा</translation>
+<translation id="5962718611393537961">संकुचित करण्‍यासाठी टॅप करा</translation>
+<translation id="8076492880354921740">टॅब</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 निवडला}other{# निवडले}}</translation>
+<translation id="6818926723028410516">आयटम निवडा</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/> वर परत येण्‍यासाठी स्पर्श करा</translation>
+<translation id="6766758767654711248">साइटवर जाण्यासाठी टॅप करा</translation>
+<translation id="429312253194641664">साइट मीडिया प्ले करत आहे</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> तुमची स्क्रीन शेअर करत आहे</translation>
+<translation id="8833831881926404480">साइट तुमची स्क्रीन शेअर करत आहे</translation>
+<translation id="9086455579313502267">नेटवर्क ॲक्सेस करण्यात अक्षम</translation>
+<translation id="938850635132480979">एरर: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/> मध्ये उघडा</translation>
+<translation id="548278423535722844">नकाशे ॲपमध्ये उघडा</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> मध्ये ईमेल तयार करा</translation>
+<translation id="7875915731392087153">ईमेल तयार करा</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> मध्ये इव्हेंट तयार करा</translation>
+<translation id="2900528713135656174">इव्हेंट तयार करा</translation>
+<translation id="2111511281910874386">पेजवर जा</translation>
+<translation id="3988466920954086464">या पॅनलमध्ये इंस्टंट शोध परिणाम पहा</translation>
+<translation id="2744248271121720757">झटपट शोधण्यासाठी किंवा संबंधित ॲक्‍शन पाहण्यासाठी एखाद्या शब्दावर टॅप करा</translation>
+<translation id="9155898266292537608">तुम्ही शब्दावर जलद टॅप करूनदेखील शोधू शकता</translation>
+<translation id="3232754137068452469">वेब ॲप</translation>
+<translation id="1430915738399379752">प्रिंट</translation>
+<translation id="3775705724665058594">तुमच्या डिव्हाइसवर पाठवा</translation>
+<translation id="6364438453358674297">इतिहासातून सूचना काढून टाकायची?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> बंद केले</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> टॅब बंद केले</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> हटवले</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> बुकमार्क हटविले</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> डाउनलोड हटविले</translation>
+<translation id="1248710015876067820">Brave उदाहरणांची असमर्थित संख्या.</translation>
+<translation id="4259722352634471385">नेव्हिगेशन अवरोधित केले आहे: <ph name="URL"/></translation>
+<translation id="8959122750345127698">नेव्हिगेशन आवाक्याबाहेर आहे: <ph name="URL"/></translation>
+<translation id="5210365745912300556">टॅब बंद करा</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> बंद करा</translation>
+<translation id="1227058898775614466">नेव्हिगेशन इतिहास</translation>
+<translation id="9169507124922466868">नेव्हिगेशन इतिहास अर्धा उघडा आहे</translation>
+<translation id="1327257854815634930">नेव्हिगेशन इतिहास उघडलेला आहे</translation>
+<translation id="8788265440806329501">नेव्हिगेशन इतिहास बंद आहे</translation>
+<translation id="7482656565088326534">पूर्वावलोकन टॅब</translation>
+<translation id="8427875596167638501">पूर्वावलोकन टॅब अर्धा उघडा आहे</translation>
+<translation id="9102803872260866941">पूर्वावलोकन टॅब उघडला आहे</translation>
+<translation id="2942036813789421260">पूर्वावलोकन टॅब बंद आहे</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> स्टोरेज</translation>
+<translation id="3822502789641063741">साइट स्टोरेज साफ करायचे?</translation>
+<translation id="9205995714227143200">Brave साइट स्टोरेज यास महत्त्व देत नाही (उदा. ज्या साइटमध्ये सेटिंग्ज सेव्ह केलेल्या नसतात किंवा तुम्ही सहसा भेट देत नाही अशा साइट)</translation>
+<translation id="3997476611815694295">महत्त्वाचा नसलेले स्टोरेज</translation>
+<translation id="8493948351860045254">जागा मोकळी करा</translation>
+<translation id="2324920234469020158">हे सर्व कुकी, कॅशे आणि साइटचा अन्य डेटा साफ करेल जो Brave ला महत्त्वाचा वाटत नाही.</translation>
+<translation id="5447201525962359567">कुकीज आणि इतर स्थानिकरित्या स्टोरेज डेटासह, सर्व साइट स्टोरेज</translation>
+<translation id="1376578503827013741">गणना करत आहे...</translation>
+<translation id="583281660410589416">अज्ञात</translation>
+<translation id="2323763861024343754">साइट स्टोरेज</translation>
+<translation id="3587672679800759167">खाती, बुकमार्क आणि सेव्ह केलेल्या सेटिंग्जसह, Brave ने वापरलेला एकूण डेटा</translation>
+<translation id="6545017243486555795">सर्व डेटा साफ करा</translation>
+<translation id="4095146165863963773">ॲप डेटा हटवायचा?</translation>
+<translation id="53119194224775367">Brave चा सर्व ॲप डेटा कायमचा हटवला जाईल. यामध्ये सर्व फायली, सेटिंग्ज, खाती, डेटाबेस, इ. चा समावेश होतो.</translation>
+<translation id="5307446750509046227">साइट स्टोरेज साफ करा</translation>
+<translation id="300526633675317032">हे सर्व <ph name="SIZE_IN_KB"/> वेबसाइट स्टोरेज साफ करेल.</translation>
+<translation id="8068648041423924542">सर्टिफिकेट निवडण्यास अक्षम.</translation>
+<translation id="2315043854645842844">क्लायंट साइड प्रमाणपत्र निवडीला ऑपरेटिंग सिस्टमचा सपोर्ट नाही.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> कनेक्ट करू इच्छिते</translation>
+<translation id="5308380583665731573">कनेक्‍ट करा</translation>
+<translation id="868929229000858085">तुमचे संपर्क शोधा</translation>
+<translation id="1919950603503897840">संपर्क निवडा</translation>
+<translation id="7986741934819883144">संपर्क निवडा</translation>
+<translation id="3333961966071413176">सर्व संपर्क</translation>
+<translation id="4994033804516042629">संपर्क सापडले नाहीत</translation>
+<translation id="5403592356182871684">नावे</translation>
+<translation id="2717722538473713889">ईमेल ॲड्रेस</translation>
+<translation id="381841723434055211">फोन नंबर</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ आणखी एक)}other{(+ आणखी #)}}</translation>
+<translation id="5197729504361054390">तुम्ही निवडलेले संपर्क <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>सोबत शेअर केले जातील.</translation>
+<translation id="1779089405699405702">इमेज डीकोडर</translation>
+<translation id="8067883171444229417">व्हिडिओ प्ले करा</translation>
+<translation id="6560414384669816528">Sogou सह शोध करा</translation>
+<translation id="5406914950576900927">Brave चीनमध्ये शोध करण्‍यासाठी <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> चा वापर करू शकते. तुम्ही हे <ph name="BEGIN_LINK"/>सेटिंग्जमध्ये<ph name="END_LINK"/> बदलू शकता.</translation>
+<translation id="6456271171669383967">Brave Software ठेवा</translation>
+<translation id="4384468725000734951">शोध करण्‍यासाठी Sogou वापरत आहे</translation>
+<translation id="6103327872225198548">शोध करण्‍यासाठी Brave Software वापरत आहे</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">हे अ‍ॅप Brave मध्‍‍‍ये रन होत आहे</translation>
+<translation id="6143689084714664628">Brave मध्ये चालत आहे</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/>चा Brave मध्ये देखील डेटा आहे</translation>
+<translation id="2734140769649165081">तुम्ही Brave सेटिंग्जमध्ये डेटा साफ करू शकता</translation>
+<translation id="8232956427053453090">स्टोअर करायचा असलेला डेटा</translation>
+<translation id="4298388696830689168">लिंक केलेल्या साइट</translation>
+<translation id="5763514718066511291">या ॲपची URL कॉपी करण्यासाठी टॅप करा</translation>
+<translation id="6496823230996795692"><ph name="APP_NAME"/> पहिल्यांदा वापरण्यासाठी, कृपया इंटरनेटशी कनेक्ट करा.</translation>
+<translation id="751961395872307827">साइटशी कनेक्ट करु शकत नाही</translation>
+<translation id="4878404682131129617">प्रॉक्सी सर्व्हर मार्फत टनेल स्थापन करणे अयशस्वी झाले</translation>
+<translation id="4749960740855309258">एक नवीन टॅब उघडा</translation>
+<translation id="8788968922598763114">अखेरीस बंद केलेला टॅब पुन्हा उघडा</translation>
+<translation id="7929962904089429003">मेनू उघडा</translation>
+<translation id="6039379616847168523">पुढील टॅबवर जा</translation>
+<translation id="5210286577605176222">मागील टॅबवर जा</translation>
+<translation id="124678866338384709">वर्तमान टॅब बंद करा</translation>
+<translation id="3714981814255182093">शोध बार उघडा</translation>
+<translation id="5441522332038954058">अ‍ॅड्रेस बारवर जा</translation>
+<translation id="3398320232533725830">बुकमार्क व्यवस्थापक उघडा</translation>
+<translation id="6583199322650523874">वर्तमान पृष्ठ बुकमार्क करा</translation>
+<translation id="8489271220582375723">इतिहास पृष्ठ उघडा</translation>
+<translation id="4837753911714442426">पेज प्रिंट करण्‍यासाठी पर्याय उघडा</translation>
+<translation id="5726692708398506830">पृष्ठावरील प्रत्येकगोष्ट आणखी मोठी करा</translation>
+<translation id="3259831549858767975">पृष्ठावरील प्रत्येकगोष्ट आणखी लहान बनवा</translation>
+<translation id="8015452622527143194">पेजवरील प्रत्येक गोष्ट डीफॉल्ट आकारमानावर परत करा</translation>
+<translation id="3443221991560634068">वर्तमान पृष्‍ठ रीलोड करा</translation>
+<translation id="123724288017357924">कॅश केलेला आशय दुर्लक्षित करून, सद्य पेज रीलोड करा</translation>
+<translation id="305870044889644984">नवीन टॅबमध्ये Brave मदत केंद्र उघडा</translation>
+<translation id="3166827708714933426">टॅब आणि विंडो शॉर्टकट</translation>
+<translation id="3169981355900570544">Brave Software Brave वैशिष्ट्य शॉर्टकट</translation>
+<translation id="4558311620361989323">वेबपेज शॉर्टकट</translation>
+<translation id="1908301351964700579">Brave अजूनही VR ची तयारी करत आहे. Brave नंतर रीस्टार्ट करा.</translation>
+<translation id="8970887620466824814">काहीतरी चूक झाली.</translation>
+<translation id="1875543012935658554">Brave पुन्हा उघडा.</translation>
+<translation id="79859296434321399">ऑगमेंटेड रीअ‍ॅलिटी आशय पाहण्यासाठी, ARCore इंस्टॉल करा</translation>
+<translation id="8558485628462305855">ऑगमेंटेड रीअ‍ॅलिटी आशय पाहण्यासाठी, ARCore अपडेट करा</translation>
+<translation id="3513704683820682405">ऑगमेंटेड रिअ‍ॅलिटी</translation>
+<translation id="5475862044948910901">ऑगमेंटेड रीअ‍ॅलिटी सेशन सुरू करायचे का?</translation>
 <translation id="7365126855094612066">या सेशनच्या कालावधी दरम्यान, साइट हे करू शकेल:
 • तुमच्या सभोवतालचा 3D नकाशा तयार करणे
 • कॅमेरा मोशन ट्रॅक करणे
 
 या साइटला कॅमेराचा अ‍ॅक्सेस मिळणार नाही. कॅमेऱ्याने घेतलेले फोटो फक्त तुम्हाला दृश्यमान आहेत.</translation>
-<translation id="7375125077091615385">प्रकार:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome फर्स्ट रन अनुभव</translation>
-<translation id="741204030948306876">होय, मला मान्य आहे</translation>
-<translation id="7413229368719586778">सुरू होण्याची तारीख <ph name="DATE" /></translation>
-<translation id="7423098979219808738">प्रथम विचारा</translation>
-<translation id="7423538860840206698">क्लिपबोर्ड वाचणे ब्लॉक केले</translation>
-<translation id="7431991332293347422">शोध पर्सनलाइझ करण्यासाठी तुमचा ब्राउझिंग इतिहास कसा वापरला जातो ते आणि बरेच काही नियंत्रित करा</translation>
-<translation id="7437998757836447326">Chrome मधून साइन आउट करा</translation>
-<translation id="7438641746574390233">लाइट मोड सुरू असताना, Chrome पेज आणखी जलद लोड होण्यासाठी Google सर्व्हर वापरते. फक्त अत्यावश्यक आशय लोड होण्यासाठी लाइट मोड खूप धीमी पेज पुनर्लिखित करते. लाइट मोड गुप्त टॅबना लागू होत नाही.</translation>
-<translation id="7444811645081526538">अधिक वर्गवाऱ्या</translation>
-<translation id="7445411102860286510">साइटना स्वयंचलितपणे नि:शब्द केलेले व्हिडिओ प्ले करण्याची अनुमती द्या (शिफारस केलेले)</translation>
-<translation id="7453467225369441013">तुम्हाला बहुतांश साइटमधून साइन आउट करते. तुम्हाला तुमच्या Google खात्यामधून साइन आउट केले जाणार नाही.</translation>
-<translation id="7454641608352164238">पुरेशी जागा उरलेली नाही</translation>
-<translation id="7475192538862203634">तुम्ही हे वारंवार पहात असल्यास, या <ph name="BEGIN_LINK" />सूचना<ph name="END_LINK" /> वापरून पहा.</translation>
-<translation id="7475688122056506577">SD कार्ड आढळले नाही. तुमच्या काही फायली गहाळ झालेल्या असू शकतात.</translation>
-<translation id="7479104141328977413">टॅब व्यवस्थापन</translation>
-<translation id="7481312909269577407">पुढील</translation>
-<translation id="7482656565088326534">पूर्वावलोकन टॅब</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (<ph name="TIME_SINCE_UPDATE" /> वाजता अपडेट केले)</translation>
-<translation id="7494974237137038751">डेटा वाचवला</translation>
-<translation id="7498271377022651285">कृपया प्रतीक्षा करा...</translation>
-<translation id="7514365320538308">डाउनलोड करा</translation>
-<translation id="751961395872307827">साइटशी कनेक्ट करु शकत नाही</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">सूचना मिळवू शकत नाही</translation>
-<translation id="7559975015014302720">लाइट मोड बंद आहे</translation>
-<translation id="7562080006725997899">ब्राउझिंग डेटा साफ करत आहे</translation>
-<translation id="756809126120519699">Chrome डेटा साफ केला</translation>
-<translation id="757524316907819857">संरक्षित आशय प्ले करण्यापासून सायटी ब्लॉक करा</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> फाइल डाउनलोड केली}other{<ph name="FILES_DOWNLOADED_MANY" /> फायली डाउनलोड केल्या}}</translation>
-<translation id="7588219262685291874">तुमच्या डिव्हाइसचे बॅटरी सेव्हर सुरू असेल तेव्हा गडद थीम सुरू करा</translation>
-<translation id="7589445247086920869">वर्तमान शोध इंजिनसाठी अवरोधित करा</translation>
-<translation id="7593557518625677601">Chrome सिंक सुरू करण्यासाठी Android सेटिंग्ज उघडा आणि Android सिस्टम सिंक पुन्हा सक्षम करा</translation>
-<translation id="7596558890252710462">ऑपरेटिंग सिस्टम</translation>
-<translation id="7605594153474022051">संकालन कार्य करत नाही</translation>
-<translation id="7606077192958116810">लाइट मोड सुरू आहे. ते सेटिंग्जमध्ये व्यवस्थापित करा.</translation>
-<translation id="7612619742409846846">Google मध्ये हे म्हणून साइन इन केले</translation>
-<translation id="7619072057915878432">नेटवर्क बिघाडामुळे <ph name="FILE_NAME" /> डाउनलोड अयशस्वी झाले.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />मदत मिळवा<ph name="END_LINK1" /> किंवा <ph name="BEGIN_LINK2" />पुन्हा स्कॅन करा<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome मध्ये स्वागत आहे</translation>
-<translation id="7638584964844754484">अयोग्य सांकेतिक पासफ्रेझ</translation>
-<translation id="7641339528570811325">ब्राउझिंग डेटा साफ करा...</translation>
-<translation id="7648422057306047504">Google क्रेडेंशियलसह पासवर्ड एंक्रिप्ट करा</translation>
-<translation id="7649070708921625228">मदत</translation>
-<translation id="7658239707568436148">रद्द करा</translation>
-<translation id="7665369617277396874">खाते जोडा</translation>
-<translation id="766587987807204883">तुम्ही ऑफलाइन असताना देखील तुम्ही वाचू शकता असे लेख येथे दिसतात</translation>
-<translation id="7682724950699840886">खालील टिपा वापरून पहा: तुमच्या डिव्हाइसवर पुरेशी जागा असल्याची खात्री करा, पुन्हा एक्सपोर्ट करण्याचा प्रयत्न करा.</translation>
-<translation id="7685301384041462804">VR मध्ये एंटर करण्यापूर्वी तुमचा या साइटवर विश्वास असल्याची खात्री करा.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> मध्ये ईमेल तयार करा</translation>
-<translation id="7704317875155739195">ऑटोकंप्लीट शोध आणि URL</translation>
-<translation id="7725024127233776428">तुम्ही बुकमार्क केलेली पेज येथे दिसतील</translation>
-<translation id="773466115871691567">नेहमी पेज <ph name="SOURCE_LANGUAGE" />मध्ये भाषांतरित करा</translation>
-<translation id="7746457520633464754">धोकादायक ॲप्स आणि साइट शोधण्यासाठी, Chrome तुम्ही भेट दिलेल्या काही पेजचे URL, मर्यादित सिस्टमची माहिती आणि काही पेजचा आशय Google कडे पाठवतो</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> वरून शेअर केलेला मजकूर</translation>
-<translation id="7762668264895820836">SD कार्ड <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">पत्ता जोडा</translation>
-<translation id="7772032839648071052">सांकेतिक पासफ्रेझ निश्चित करा</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> बंद करा</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> अधिक}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 आणि <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> अधिक}}</translation>
-<translation id="7781829728241885113">काल</translation>
-<translation id="7791543448312431591">जोडा</translation>
-<translation id="780301667611848630">नाही, नको</translation>
-<translation id="7810647596859435254">यासह उघडा...</translation>
-<translation id="7821588508402923572">तुमची डेटा बचत येथे दिसेल</translation>
-<translation id="7837721118676387834">एका विशिष्ट साइटकरिता नि:शब्द केलेल्या व्हिडिओंच्या ऑटोप्ले ला अनुमती द्या.</translation>
-<translation id="7846076177841592234">निवड रद्द करा</translation>
-<translation id="784934925303690534">वेळ वर्गवारी</translation>
-<translation id="7851858861565204677">इतर डिव्हाइसेस</translation>
-<translation id="7875915731392087153">ईमेल तयार करा</translation>
-<translation id="7876243839304621966">सर्व काढून टाका</translation>
-<translation id="7882131421121961860">कोणताही इतिहास सापडला नाही</translation>
-<translation id="7882806643839505685">विशिष्ट साइटसाठी ध्वनीची परवानगी द्या.</translation>
-<translation id="7886917304091689118">Chrome मध्ये चालत आहे</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{फाइल डाऊनलोड करत आहे.}other{# फायली डाउनलोड करत आहे.}}</translation>
-<translation id="7929962904089429003">मेनू उघडा</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> कालबाह्य झाले आहे.</translation>
-<translation id="7947953824732555851">स्वीकार करा आणि साइन इन करा</translation>
-<translation id="7963646190083259054">विक्रेता:</translation>
-<translation id="7971136598759319605">एका दिवसापूर्वी ॲक्टिव्ह होते</translation>
-<translation id="7975379999046275268">पेज <ph name="BEGIN_NEW" />नवीन<ph name="END_NEW" /> चे पूर्वावलोकन करा</translation>
-<translation id="7981313251711023384">जलद ब्राउझिंग आणि शोधाकरता पेज आधीच लोड करा</translation>
-<translation id="79859296434321399">ऑगमेंटेड रीअ‍ॅलिटी आशय पाहण्यासाठी, ARCore इंस्टॉल करा</translation>
-<translation id="7986741934819883144">संपर्क निवडा</translation>
-<translation id="7987073022710626672">Chrome सेवा अटी</translation>
-<translation id="7998918019931843664">बंद केलेले टॅब पुन्हा उघडा</translation>
-<translation id="7999064672810608036">तुम्ही कुकीजसह, सर्व स्थानिक डेटा साफ करू इच्छिता आणि या वेबसाइटसाठी सर्व परवानग्या रीसेट करू इच्छिता?</translation>
-<translation id="8004582292198964060">ब्राउझर</translation>
-<translation id="8007176423574883786">या डिव्हाइससाठी बंद करा</translation>
-<translation id="8013372441983637696">तुमचा या डिव्हाइसवरील Chrome डेटा देखील साफ करा</translation>
-<translation id="8015452622527143194">पेजवरील प्रत्येक गोष्ट डीफॉल्ट आकारमानावर परत करा</translation>
-<translation id="802154636333426148">डाउनलोड अयशस्वी झाले</translation>
-<translation id="8026334261755873520">ब्राउझिंग डेटा साफ करा</translation>
-<translation id="8035133914807600019">नवीन फोल्डर…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> दिवस शिल्लक</translation>
-<translation id="804335162455518893">SD कार्ड आढळले नाही</translation>
-<translation id="805047784848435650">तुमच्या ब्राउझ करण्याच्या इतिहासावर आधारित</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB उपलब्ध</translation>
-<translation id="8058746566562539958">नवीन Chrome टॅबमध्‍ये उघडा</translation>
-<translation id="8063895661287329888">बुकमार्क जोडण्यात अयशस्वी झाले.</translation>
-<translation id="806745655614357130">माझा डेटा स्वतंत्र ठेवा</translation>
-<translation id="8067883171444229417">व्हिडिओ प्ले करा</translation>
-<translation id="8068648041423924542">सर्टिफिकेट निवडण्यास अक्षम.</translation>
-<translation id="8073388330009372546">नवीन टॅबमध्ये इमेज उघडा</translation>
-<translation id="8076492880354921740">टॅब</translation>
-<translation id="8084114998886531721">सेव्ह केलेले पासवर्ड</translation>
-<translation id="8087000398470557479">Google ने वितरित केलेली ही आशय, <ph name="DOMAIN_NAME" /> मधील आहे.</translation>
-<translation id="8103578431304235997">गुप्त टॅब</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">तुमच्या सर्व डिव्हाइसवरील तुमचे बुकमार्क मिळवण्यासाठी, सिंक सुरू करा</translation>
-<translation id="8110087112193408731">डिजिटल संतुलन मध्ये तुमची Chrome ॲक्टिव्हिटी दाखवायची का?</translation>
-<translation id="8116925261070264013">म्यूट केले</translation>
-<translation id="813082847718468539">साइटची माहिती पहा</translation>
-<translation id="8131740175452115882">पुष्टी करा</translation>
-<translation id="8156139159503939589">तुम्ही कोणत्या भाषा वाचू शकता?</translation>
-<translation id="8168435359814927499">आशय</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> फायली शिल्लक</translation>
-<translation id="8190358571722158785">1 दिवस शिल्लक</translation>
-<translation id="8200772114523450471">रेझ्युमे</translation>
-<translation id="8209050860603202033">इमेज उघडा</translation>
-<translation id="8218622182176210845">तुमचे खाते व्यवस्थापित करा</translation>
-<translation id="8224471946457685718">वाय-फायवर तुमच्यासाठी लेख डाउनलोड करा</translation>
-<translation id="8232956427053453090">स्टोअर करायचा असलेला डेटा</translation>
-<translation id="8249310407154411074">वर न्या</translation>
-<translation id="8250920743982581267">दस्तऐवज</translation>
-<translation id="825412236959742607">हे पेज खूप जास्त मेमरी वापरत असल्यामुळे, Chrome ने काही आशय काढून टाकला आहे.</translation>
-<translation id="8260126382462817229">पुन्हा साइन इन करण्याचा प्रयत्न करा</translation>
-<translation id="8261506727792406068">हटवा</translation>
-<translation id="8266862848225348053">डाउनलोड करण्याचे स्थान</translation>
-<translation id="8274165955039650276">डाउनलोड पाहा</translation>
-<translation id="8284326494547611709">मथळे</translation>
-<translation id="8300705686683892304">ॲपद्वारे व्यवस्थापित</translation>
-<translation id="8310344678080805313">मानक टॅब</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> आणि आणखी साइट</translation>
-<translation id="8327155640814342956">उत्तम ब्राउझिंग अनुभव मिळवण्याकरीता, Chrome अपडेट करण्यासाठी उघडा</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" />मधील पेज भाषांतरीत केले जाणार नाही</translation>
-<translation id="8349013245300336738">वापरलेल्या डेटानुसार क्रमाने लावा</translation>
-<translation id="8364299278605033898">लोकप्रिय वेबसाइट पाहा</translation>
-<translation id="8368027906805972958">अज्ञात किंवा सपोर्ट नसलेले डिव्हाइस (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">विशिष्ट साइटसाठी पार्श्वभूमी संकालनासाठी अनुमती द्या.</translation>
-<translation id="8378714024927312812">तुमच्या संस्थेकडून व्यवस्थापित केलेले</translation>
-<translation id="8380167699614421159">ही साइट अनाहूत किंवा दिशाभूल करणाऱ्या जाहिराती दाखवते</translation>
-<translation id="8393700583063109961">संदेश पाठवा</translation>
-<translation id="8413126021676339697">संपूर्ण इतिहास दर्शवा</translation>
-<translation id="8427875596167638501">पूर्वावलोकन टॅब अर्धा उघडा आहे</translation>
-<translation id="8428213095426709021">सेटिंग्ज</translation>
-<translation id="8438566539970814960">शोध आणि ब्राउझ करणे चांगले करा</translation>
-<translation id="8441146129660941386">मागे शोधा</translation>
-<translation id="8443209985646068659">Chrome अपडेट होऊ शकत नाही</translation>
-<translation id="8445448999790540984">पासवर्ड एक्सपोर्ट करू शकत नाही</translation>
-<translation id="8447861592752582886">डिव्हाइस परवानगी रद्द करा</translation>
-<translation id="8461694314515752532">तुमच्या स्वतःच्या सिंक पासफ्रेजसह सिंक केलेला डेटा एंक्रिप्ट करा</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> इंटरनेटशी कनेक्ट केले असल्याची खात्री करा</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ऑफलाइन उपलब्ध</translation>
-<translation id="8489271220582375723">इतिहास पृष्ठ उघडा</translation>
-<translation id="8493948351860045254">जागा मोकळी करा</translation>
-<translation id="8497726226069778601">अद्याप… येथे पाहण्यासाठी काहीही नाही</translation>
-<translation id="8503559462189395349">Chrome पासवर्ड</translation>
-<translation id="8503813439785031346">वापरकर्तानाव</translation>
-<translation id="8514477925623180633">Chrome सह स्टोअर केलेला पासवर्ड पाठवा</translation>
-<translation id="8514577642972634246">गुप्त मोडमध्ये प्रवेश करा</translation>
-<translation id="851751545965956758">डिव्हाइसेसशी कनेक्ट करण्यापासून साइटना ब्लॉक करा</translation>
-<translation id="8523928698583292556">स्टोअर केलेला पासवर्ड हटवा</translation>
-<translation id="854522910157234410">हे पृष्ठ उघडा</translation>
-<translation id="8558485628462305855">ऑगमेंटेड रीअ‍ॅलिटी आशय पाहण्यासाठी, ARCore अपडेट करा</translation>
-<translation id="8559990750235505898">पेज अन्य भाषांमध्ये भाषांतरित करण्यास ऑफर करा</translation>
-<translation id="8562452229998620586">सेव्ह केलेले पासवर्ड येथे दिसून येतील.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> पासून</translation>
-<translation id="8571213806525832805">मागील 4 आठवड्यांमधील</translation>
-<translation id="857943718398505171">अनुमती दिली (शिफारस केलेले)</translation>
-<translation id="8583805026567836021">खाते डेटा साफ करत आहे</translation>
-<translation id="860043288473659153">कार्डधारकाचे नाव</translation>
-<translation id="8609465669617005112">वर हलवा</translation>
-<translation id="8616006591992756292">तुमच्या Google खात्यात <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> वर ब्राउझिंग इतिहासाची अन्य स्वरूपे असू शकतात.</translation>
-<translation id="8617240290563765734">डाउनलोड केलेल्या आशयमध्ये नमूद केलेली सुचविलेली URL उघडायची?</translation>
-<translation id="8636825310635137004">आपल्या इतर डिव्हाइसेस मधून तुमचे टॅब प्राप्त करण्यासाठी, संकालन चालू करा</translation>
-<translation id="8641930654639604085">प्रौढ सामग्री असलेल्या साइटना अवरोधित करण्‍याचा प्रयत्न करा</translation>
-<translation id="8655129584991699539">तुम्ही Chrome सेटिंग्जमध्ये डेटा साफ करू शकता</translation>
-<translation id="8662811608048051533">तुम्हाला बहुतांश साइटवरून साइन आउट करते.</translation>
-<translation id="8664979001105139458">फाइलचे नाव आधीपासून अस्तित्वात आहे</translation>
-<translation id="8676374126336081632">इनपुट साफ करा</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{सिग्नल क्षमता पातळी: # बार}other{सिग्नल क्षमता पातळी: # बार}}</translation>
-<translation id="868929229000858085">तुमचे संपर्क शोधा</translation>
-<translation id="869891660844655955">कालावधी समाप्ती तारीख</translation>
-<translation id="8719023831149562936">वर्तमान टॅब बीम करू शकत नाही</translation>
-<translation id="8725066075913043281">पुन्हा प्रयत्न करा</translation>
-<translation id="8728487861892616501">हे अ‍ॅप्लिकेशन वापरून, तुम्ही Chrome च्या <ph name="BEGIN_LINK1" />सेवा अटी<ph name="END_LINK1" /> आणि <ph name="BEGIN_LINK2" />गोपनीयता सूचना<ph name="END_LINK2" /> आणि <ph name="BEGIN_LINK3" />Family Link ने व्यवस्थापित केलेल्या Google खात्यांसाठी गोपनीयता सूचना<ph name="END_LINK3" /> यांना सहमती दर्शवता.</translation>
-<translation id="8730621377337864115">पूर्ण झाले</translation>
-<translation id="8748850008226585750">सामग्री लपविली</translation>
-<translation id="8751914237388039244">इमेज निवडा</translation>
-<translation id="8788265440806329501">नेव्हिगेशन इतिहास बंद आहे</translation>
-<translation id="8788968922598763114">अखेरीस बंद केलेला टॅब पुन्हा उघडा</translation>
-<translation id="8801436777607969138">विशिष्ट साइटसाठी JavaScript ब्लॉक करा.</translation>
-<translation id="8812260976093120287">काही वेबसाइटवर, तुम्ही आपल्या डिव्हाइसवर वरील समर्थित पेमेंट ॲप्ससह पेमेंट देऊ शकता.</translation>
-<translation id="8816026460808729765">साइटना सेन्सर ॲक्सेस करण्यापासून ब्लॉक करा</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chrome मध्ये उघडेल. सुरू ठेवण्याने तुम्ही Chrome च्या <ph name="BEGIN_LINK1" />सेवा अटी<ph name="END_LINK1" /> आणि <ph name="BEGIN_LINK2" />गोपनीयता सूचना<ph name="END_LINK2" />, तसेच <ph name="BEGIN_LINK3" />Family Link सह व्यवस्थापित Google खात्यांच्या गोपनीयता सूचनां<ph name="END_LINK3" /> शी तुम्ही सहमती दाखवता.</translation>
-<translation id="8820817407110198400">Bookmarks</translation>
-<translation id="8833831881926404480">साइट तुमची स्क्रीन शेअर करत आहे</translation>
-<translation id="883806473910249246">आशय डाउनलोड करताना एरर आली.</translation>
-<translation id="8840953339110955557">हे पेज ऑनलाइन आवृत्तीपेक्षा वेगळे असू शकते.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, टॅब</translation>
-<translation id="885701979325669005">स्टोरेज</translation>
-<translation id="889338405075704026">Chrome सेटिंग्जवर जा</translation>
-<translation id="8901170036886848654">कोणतेही बुकमार्क आढळले नाहीत</translation>
-<translation id="8909135823018751308">शेअर करा...</translation>
-<translation id="8912362522468806198">Google खाते</translation>
-<translation id="8920114477895755567">पालकांच्या तपशीलांसाठी प्रतीक्षा करत आहोत.</translation>
+<translation id="1188239144602654184">AR सुरू करा</translation>
+<translation id="473775607612524610">अपडेट करा</translation>
+<translation id="3133489217401741157">Brave साठी <ph name="MODULE"/> इंस्टॉल करत आहे…</translation>
+<translation id="1791662854739702043">इंस्टॉल केले</translation>
+<translation id="5131234170665854056">Brave साठी <ph name="MODULE"/> इंस्टॉल करू शकत नाही</translation>
+<translation id="2567385386134582609">इमेज</translation>
+<translation id="6395288395575013217">लिंक</translation>
+<translation id="7352939065658542140">व्हिडिओ</translation>
+<translation id="4116038641877404294">पेज ऑफलाइन वापरण्यासाठी ती डाउनलोड करा</translation>
 <translation id="8922289737868596582">पेज ऑफलाइन वापरता येण्यासाठी ती अधिक पर्यायांमधून डाउनलोड करा</translation>
-<translation id="8937772741022875483">डिजिटल संतुलन वरून तुमची Chrome ॲक्टिव्हिटी काढून टाकायची का?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">इतर विंडोमध्ये उघडा</translation>
-<translation id="8951232171465285730">Chrome ने तुमच्यासाठी <ph name="MEGABYTES" /> MB सेव्ह केले</translation>
-<translation id="8958424370300090006">विशिष्ट साइटसाठी कुकी ब्लॉक करा.</translation>
-<translation id="8959122750345127698">नेव्हिगेशन आवाक्याबाहेर आहे: <ph name="URL" /></translation>
-<translation id="8965591936373831584">प्रलंबित</translation>
-<translation id="8970887620466824814">काहीतरी चूक झाली.</translation>
-<translation id="8972098258593396643">डीफॉल्ट फोल्डरमध्ये डाउनलोड करायचे?</translation>
-<translation id="8986494364107987395">Google ला वापर आकडेवारी आणि क्रॅश अहवाल आपोआप पाठवा</translation>
-<translation id="8993760627012879038">गुप्त मोडमध्ये एक नवीन टॅब उघडा</translation>
-<translation id="8998729206196772491">तुम्ही <ph name="MANAGED_DOMAIN" /> ने व्यवस्थापित केलेल्या खात्यासह साइन इन करत आहात आणि त्याच्या ॲडमिनिस्ट्रेटरला तुमच्या Chrome डेटाचे नियंत्रण देत आहात. तुमचा डेटा कायमचा या खात्यामध्ये असेल. Chrome मधून साइन आउट केल्याने तुमचा डेटा या डिव्हाइस वरून हटवला जाईल परंतु तो तुमच्या Google खात्यामध्ये स्टोअर केलेला असेल.</translation>
-<translation id="9019902583201351841">आपल्या पालकांद्वारे व्यवस्थापित करण्यात आले</translation>
-<translation id="9028914725102941583">संपूर्ण डिव्हाइसवर शेअर करण्यासाठी सिंक सुरू करा</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> ला VR मध्ये एंटर करण्याची अनुमती द्यायची आहे का?</translation>
-<translation id="9040142327097499898">सूचनांना अनुमती आहे. या डिव्हाइससाठी स्‍थान बंद आहे.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# व्हिडिओ}other{# व्हिडिओ}}</translation>
-<translation id="9050666287014529139">सांकेतिक पासफ्रेझ</translation>
-<translation id="9063523880881406963">डेस्कटॉप साइट विनंती बंद करा</translation>
-<translation id="9065203028668620118">संपादन</translation>
-<translation id="9070377983101773829">व्हॉइस शोध प्रारंभ करा</translation>
-<translation id="9074336505530349563">Google ने सुचवलेला पर्सनलाइझ केलेला आशय मिळवण्यासाठी, साइन इन करा आणि सिंक सुरू करा</translation>
-<translation id="9086455579313502267">नेटवर्क ॲक्सेस करण्यात अक्षम</translation>
-<translation id="9100505651305367705">सपोर्ट असताना सोप्या पद्धतीने लेख दाखवण्याची ऑफर</translation>
-<translation id="9100610230175265781">सांकेतिक पासफ्रेझ आवश्यक</translation>
-<translation id="9102803872260866941">पूर्वावलोकन टॅब उघडला आहे</translation>
+<translation id="5958275228015807058">तुमच्या फायली आणि पेज डाउनलोडमध्ये शोधा</translation>
+<translation id="5620928963363755975">तुमच्या फायली आणि पेज अधिक पर्याय बटणावरील डाउनलोडमध्ये शोधा</translation>
+<translation id="3341058695485821946">तुम्ही किती डेटा सेव्ह केला ते पहा</translation>
+<translation id="3157842584138209013">आणिखी पर्याय बटणावरून तुम्ही किती डेटा सेव्ह केला आहे ते पहा</translation>
+<translation id="8218622182176210845">तुमचे खाते व्यवस्थापित करा</translation>
+<translation id="8090895580117672212">तुमचे Brave Software खाते व्यवस्थापित करण्यासाठी, "खाते व्यवस्थापित करा" बटणावर टॅप करा</translation>
+<translation id="8856898588039823173">Brave Software ने पुरवलेले लाइट पेज. मूळ पेज लोड करण्यासाठी टॅप करा.</translation>
+<translation id="8134317863207426198">Brave Software द्वारे पुरवलेले लाइट पेज. मूळ पेज लोड करण्यासाठी मूळ लोड करा बटणावर टॅप करा.</translation>
+<translation id="4961107849584082341">या पेजचे कोणत्याही भाषेत भाषांतर करा</translation>
+<translation id="569536719314091526">अधिक पर्याय बटणावरून या पेजचे कोणत्याही भाषेत भाषांतर करा</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> सह शोधा</translation>
+<translation id="1792959175193046959">डीफॉल्ट डाउनलोडचे स्थान केव्हाही बदला</translation>
+<translation id="6942665639005891494">सेटिंग्ज मेनू पर्याय वापरून केव्हाही डीफॉल्ट डाउनलोड स्थान बदला</translation>
+<translation id="6850409657436465440">तुमचे डाउनलोड अजून प्रगतीपथावर आहे</translation>
+<translation id="5817715962196959877">Brave आता फायली वेगाने डाउनलोड करते</translation>
+<translation id="3976396876660209797">हा शॉर्टकट काढून टाका आणि पुन्हा तयार करा</translation>
+<translation id="6766622839693428701">बंद करण्यासाठी खाली स्वाइप करा.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> ला पाठवत आहे…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> वरून पाठवले</translation>
+<translation id="5357811892247919462">टॅब मिळाला</translation>
 <translation id="9104217018994036254">टॅबसह शेअर करण्यासाठी डिव्हाइसची सूची.</translation>
-<translation id="9133397713400217035">ऑफलाइन असताना एक्सप्लोर करा</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">मूळ दर्शवा</translation>
-<translation id="9139068048179869749">साइटना सूचना पाठविण्याची अनुमती देण्यापूर्वी प्रथम विचारा (शिफारस केलेले)</translation>
-<translation id="9139318394846604261">खरेदी</translation>
-<translation id="9155898266292537608">तुम्ही शब्दावर जलद टॅप करूनदेखील शोधू शकता</translation>
-<translation id="9169507124922466868">नेव्हिगेशन इतिहास अर्धा उघडा आहे</translation>
-<translation id="9204836675896933765">1 फाइल शिल्लक</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">अर्ध्या उंचीवर उघडलेल्या टॅबसह शेअर करण्यासाठी डिव्हाइसची सूची.</translation>
+<translation id="2904414404539560095">पूर्ण उंचीवर उघडलेल्या टॅबसह शेअर करण्यासाठी डिव्हाइसची सूची.</translation>
+<translation id="4135200667068010335">बंद केलेल्या टॅबसह शेअर करण्यासाठी डिव्हाइसची सूची.</translation>
+<translation id="5292796745632149097">यांना पाठवा</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> दिवसांपूर्वी ॲक्टिव्ह होते</translation>
+<translation id="7971136598759319605">एका दिवसापूर्वी ॲक्टिव्ह होते</translation>
+<translation id="1521774566618522728">आज ॲक्टिव्ह होते</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> शी शेअर करत आहे</translation>
+<translation id="9028914725102941583">संपूर्ण डिव्हाइसवर शेअर करण्यासाठी सिंक सुरू करा</translation>
+<translation id="6162454065885854378">तुमच्या फोनवरून दुसऱ्या डिव्हाइसवर शेअर करण्यासाठी, दोन्ही डिव्हाइसवरील Brave सेटिंग्जमध्ये सिंक सुरू करा</translation>
+<translation id="6084271560289605378">Brave सेटिंग्जवर जा</translation>
+<translation id="2318045970523081853">कॉल करण्यासाठी टॅप करा</translation>
 <translation id="9209888181064652401">कॉल करू शकत नाही</translation>
-<translation id="9219103736887031265">इमेज</translation>
-<translation id="926205370408745186">डिजिटल संतुलन वरून तुमची Chrome ॲक्टिव्हिटी काढून टाका</translation>
-<translation id="932327136139879170">होम</translation>
-<translation id="938850635132480979">एरर: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">तुमचा मायक्रोफोन ॲक्सेस करा</translation>
-<translation id="95817756606698420">Chrome चीनमध्ये शोध करण्‍यासाठी <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> चा वापर करू शकते. तुम्ही हे <ph name="BEGIN_LINK" />सेटिंग्जमध्ये<ph name="END_LINK" /> बदलू शकता.</translation>
-<translation id="965817943346481315">साइट अनाहूत किंवा दिशाभूल करणाऱ्या जाहिराती दाखवत असल्यास ब्लॉक करा (शिफारस केलेले)</translation>
-<translation id="968900484120156207">तुम्ही भेट देता ती पेज येथे दिसतील</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> मिनिटे शिल्लक</translation>
-<translation id="974555521953189084">सिंक सुरू करण्यासाठी तुमचा सांकेतिक पासफ्रेझ एंटर करा</translation>
-<translation id="981121421437150478">ऑफलाइन</translation>
-<translation id="982182592107339124">हे यासह सर्व साइटसाठी डेटा साफ करेल:</translation>
-<translation id="983192555821071799">सर्व टॅब बंद करा</translation>
-<translation id="987264212798334818">सामान्य</translation>
+<translation id="2860954141821109167">या डिव्हाइसवर फोन ॲप सुरू केले असल्याची खात्री करा</translation>
+<translation id="2067805253194386918">मजकूर</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> शेअर करू शकत नाही</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> शेअर करू शकलो नाही</translation>
+<translation id="8287068819750208230"><ph name="TARGET_DEVICE_NAME"/> ने Brave मध्ये सिंक सुरू केले असल्याची खात्री करा</translation>
+<translation id="3016635187733453316">हे डिव्हाइस इंटरनेटशी कनेक्ट केले असल्याची खात्री करा</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> इंटरनेटशी कनेक्ट केले असल्याची खात्री करा</translation>
+<translation id="6539092367496845964">काहीतरी चूक झाली. पुन्हा प्रयत्न करा.</translation>
+<translation id="3389286852084373014">मजकूर खूप मोठा आहे</translation>
+<translation id="2100314319871056947">मजकूर लहान भागांमध्ये शेअर करून पाहा</translation>
+<translation id="2987620471460279764">मजकूर इतर डिव्हाइसवरून शेअर केला आहे</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> वरून शेअर केलेला मजकूर</translation>
+<translation id="5193988420012215838">तुमच्या क्लिपबोर्डवर कॉपी केले</translation>
+<translation id="4696983787092045100">तुमच्या डिव्हाइसवर एसएमएस पाठवा</translation>
+<translation id="1260236875608242557">शोधा आणि एक्सप्लोर करा</translation>
+<translation id="6369229450655021117">येथून तुम्ही वेबवर शोधू शकता, मित्रमैत्रिणींसोबत शेअर करू शकता आणि उघडी असलेली पेज पाहू शकता</translation>
+<translation id="723171743924126238">इमेज निवडा</translation>
+<translation id="8751914237388039244">इमेज निवडा</translation>
+<translation id="1989112275319619282">ब्राउझ करा</translation>
+<translation id="7055152154916055070">रीडिरेक्ट ब्लॉक केले:</translation>
+<translation id="5524843473235508879">रीडिरेक्‍ट ब्लॉक केले.</translation>
+<translation id="6573096386450695060">नेहमी अनुमती द्या</translation>
+<translation id="5805364706385912897">हे पेज खूपच जास्त मेमरी वापरत असल्यामुळे Brave ने ते थांबवून ठेवलेले आहे.</translation>
+<translation id="5138664332909611586">हे पेज खूप जास्त मेमरी वापरत असल्यामुळे, Brave ने काही आशय काढून टाकला आहे.</translation>
+<translation id="9137013805542155359">मूळ दर्शवा</translation>
+<translation id="6361779936989026201">Brave मधील Brave Software असिस्टंट</translation>
+<translation id="7291387454912369099">असिस्टंटने ट्रिगर केलेला चेकआउट</translation>
+<translation id="4565206163201411670">डिजिटल संतुलन मध्ये तुमची Brave ॲक्टिव्हिटी दाखवायची का?</translation>
+<translation id="9055113864158719823">तुम्ही Brave मध्ये भेट दिलेल्या साइट पाहू शकता आणि त्यांच्यासाठी टायमर सेट करू शकता.\n\nBrave Software ला तुम्ही ज्या साइटसाठी टायमर सेट केला आणि त्यांना किती वेळ भेट दिली याबद्दलची माहिती मिळते. ही माहिती डिजिटल संतुलन चांगले करण्यास वापरली जाते.</translation>
+<translation id="4596514158372210596">डिजिटल संतुलन वरून तुमची Brave ॲक्टिव्हिटी काढून टाका</translation>
+<translation id="1174893863889683998">डिजिटल संतुलन वरून तुमची Brave ॲक्टिव्हिटी काढून टाकायची का?</translation>
+<translation id="708829030563435351">तुम्ही Brave मध्ये भेट दिलेल्या साइट दाखवणार नाही. सर्व साइट टायमर हटवले जातील.</translation>
+<translation id="2056878612599315956">साइट थांबवली</translation>
+<translation id="671481426037969117">तुमचा <ph name="FQDN"/> टायमर झाला आहे. तो उद्या पुन्हा सुरू होईल.</translation>
+<translation id="7479104141328977413">टॅब व्यवस्थापन</translation>
+<translation id="3524138585025253783">डेव्हलपर UI</translation>
+<translation id="6036057147555329831">अतिरिक्त ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> ला VR मध्ये एंटर करण्याची अनुमती द्यायची आहे का?</translation>
+<translation id="7685301384041462804">VR मध्ये एंटर करण्यापूर्वी तुमचा या साइटवर विश्वास असल्याची खात्री करा.</translation>
+<translation id="5033865233969348410">तुम्ही VR वापरत असताना, ही साइट कदाचित पुढील गोष्टींबद्दल अधिक माहिती मिळवू शकेल:
+- तुमची शारीरिक वैशिष्‍ट्ये, जसे की, उंची
+
+VR मध्ये एंटर करण्यापूर्वी तुमचा या साइटवर विश्वास आहे याची खात्री करा.</translation>
+<translation id="5534334044554683961">तुम्ही VR वापरत असताना, ही साइट कदाचित पुढील गोष्टींबद्दल अधिक माहिती मिळवू शकेल:
+- तुमची शारीरिक वैशिष्‍ट्ये, जसे की, उंची
+- तुमच्या रूमचा लेआउट
+
+VR मध्ये एंटर करण्यापूर्वी तुमचा या साइटवर विश्वास आहे खात्री करा.</translation>
+<translation id="4169535189173047238">अनुमती देऊ नका</translation>
+<translation id="2170088579611075216">VR ला अनुमती द्या आणि एंटर करा</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ms.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ms.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ms">
-<translation id="1006017844123154345">Buka Dalam Talian</translation>
-<translation id="1028699632127661925">Menghantar ke <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Menambahkan <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Daripada tapak web</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Tidak pernah disimpan</translation>
-<translation id="1067922213147265141">Perkhidmatan Google yang lain</translation>
-<translation id="1068672505746868501">Jangan sekali-kali terjemahkan halaman dalam <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Jika anda menukar sambungan fail, fail itu mungkin akan dibuka dalam aplikasi lain dan berkemungkinan mendatangkan bahaya kepada peranti anda.</translation>
-<translation id="1100066534610197918">Buka dlm tab baru dlm kumpulan</translation>
-<translation id="1105960400813249514">Tangkapan Skrin</translation>
-<translation id="1111673857033749125">Penanda halaman yang disimpan pada peranti anda yang lain akan dipaparkan di sini.</translation>
-<translation id="1113597929977215864">Tunjukkan paparan ringkas</translation>
-<translation id="1121094540300013208">Laporan penggunaan dan keranapan</translation>
-<translation id="1124772482545689468">Pengguna</translation>
-<translation id="1129510026454351943">Butiran: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 muat turun belum selesai.}other{# muat turun belum selesai.}}</translation>
-<translation id="1145536944570833626">Padam data sedia ada.</translation>
-<translation id="1146678959555564648">Masukkan VR</translation>
-<translation id="116280672541001035">Digunakan</translation>
-<translation id="1171770572613082465">Lihat tapak web popular dengan mengetik butang "Tapak popular"</translation>
-<translation id="1173894706177603556">Namakan semula</translation>
-<translation id="1178581264944972037">Jeda</translation>
-<translation id="1181037720776840403">Alih keluar</translation>
-<translation id="1188239144602654184">Masuk ke AR</translation>
-<translation id="1197267115302279827">Alihkan penanda halaman</translation>
-<translation id="119944043368869598">Kosongkan semua</translation>
-<translation id="1201402288615127009">Seterusnya</translation>
-<translation id="1204037785786432551">Muat turun pautan</translation>
-<translation id="1206892813135768548">Salin teks pautan</translation>
-<translation id="1208340532756947324">Hidupkan penyegerakan untuk melakukan penyegerakan dan pemperibadian pada semua peranti</translation>
-<translation id="1209206284964581585">Sorok sementara</translation>
-<translation id="1227058898775614466">Sejarah navigasi</translation>
-<translation id="1231733316453485619">Hidupkan penyegerakan?</translation>
-<translation id="123724288017357924">Muat semula laman semasa dan abaikan kdgn dicache</translation>
-<translation id="124116460088058876">Lagi bahasa</translation>
-<translation id="124678866338384709">Tutup tab semasa</translation>
-<translation id="1258753120186372309">Coretan Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Cari &amp; teroka</translation>
-<translation id="1264974993859112054">Sukan</translation>
-<translation id="1266864766717917324">Tidak dapat berkongsi <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Berhenti</translation>
-<translation id="1283039547216852943">Ketik untuk kembangkan</translation>
-<translation id="1285320974508926690">Jangan sekali-kali menterjemahkan tapak ini</translation>
-<translation id="1291207594882862231">Hapuskan sejarah, kuki, data tapak, cache...</translation>
-<translation id="129382876167171263">Fail yang disimpan oleh tapak web akan dipaparkan di sini</translation>
-<translation id="129553762522093515">Ditutup baru-baru ini</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Dihantar daripada <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Himpunkan tab.</translation>
-<translation id="1327257854815634930">Sejarah navigasi dibuka</translation>
-<translation id="1331212799747679585">Chrome tidak dapat dikemas kini. Lagi pilihan</translation>
-<translation id="1332501820983677155">Pintasan ciri Google Chrome</translation>
-<translation id="1360432990279830238">Log keluar dan matikan penyegerakan?</translation>
-<translation id="1369915414381695676">Tapak <ph name="SITE_NAME" /> telah ditambahkan</translation>
-<translation id="1373696734384179344">Memori tidak mencukupi untuk memuat turun kandungan yang dipilih.</translation>
-<translation id="1376578503827013741">Mengira...</translation>
-<translation id="1383876407941801731">Carian</translation>
-<translation id="1384959399684842514">Muat turun dijeda</translation>
-<translation id="1386674309198842382">Aktif <ph name="LAST_UPDATED" /> hari lalu</translation>
-<translation id="1397811292916898096">Cari dengan <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Dibenamkan dalam <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“Jangan Kesan”</translation>
-<translation id="1407135791313364759">Buka semua</translation>
-<translation id="1409426117486808224">Paparan ringkas bagi tab terbuka</translation>
-<translation id="1409879593029778104">Muat turun <ph name="FILE_NAME" /> dihalang kerana fail ini sudah wujud.</translation>
-<translation id="1414981605391750300">Menghubungi Google. Mungkin mengambil sedikit masa…</translation>
-<translation id="1416550906796893042">Versi aplikasi</translation>
-<translation id="1430915738399379752">Cetak</translation>
-<translation id="1446450296470737166">Benarkan kawalan penuh peranti MIDI</translation>
-<translation id="1450753235335490080">Tidak dapat berkongsi <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Dimatikan dalam Tetapan Android</translation>
-<translation id="1477626028522505441">Muat turun <ph name="FILE_NAME" /> gagal disebabkan oleh masalah pelayan.</translation>
-<translation id="1506061864768559482">Enjin carian</translation>
-<translation id="1513352483775369820">Penanda halaman dan sejarah web</translation>
-<translation id="1513858653616922153">Padam kata laluan</translation>
-<translation id="1516229014686355813">Ketik untuk Mencari menghantar perkataan yang dipilih dan halaman semasa sebagai konteks kepada Carian Google. Anda boleh mematikannya dalam <ph name="BEGIN_LINK" />Tetapan<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktif hari ini</translation>
-<translation id="1544826120773021464">Untuk mengurus akaun Google anda, ketik butang "Urus akaun"</translation>
-<translation id="1549000191223877751">Alihkan ke tetingkap lain</translation>
-<translation id="1553358976309200471">Kemas Kini Chrome</translation>
-<translation id="1569387923882100876">Peranti Bersambung</translation>
-<translation id="1571304935088121812">Salin nama pengguna</translation>
-<translation id="1612196535745283361">Chrome memerlukan akses lokasi untuk mengimbas peranti. Akses lokasi <ph name="BEGIN_LINK" />dimatikan untuk peranti ini<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Halang halaman ini daripada mencipta dialog tambahan</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Alih keluar 1 item yang dipilih}other{Alih keluar # item yang dipilih}}</translation>
-<translation id="164269334534774161">Anda sedang melihat salinan luar talian halaman ini dari <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Sejarah</translation>
-<translation id="1647391597548383849">Akses kamera anda</translation>
-<translation id="1660204651932907780">Benarkan tapak untuk memainkan bunyi (disyorkan)</translation>
-<translation id="1670399744444387456">Asas</translation>
-<translation id="1671236975893690980">Muat turun belum selesai...</translation>
-<translation id="1672586136351118594">Jangan tunjukkan lagi</translation>
-<translation id="1692118695553449118">Penyegerakan dihidupkan</translation>
-<translation id="169515064810179024">Sekat tapak daripada mengakses penderia gerakan</translation>
-<translation id="1717218214683051432">Penderia gerakan</translation>
-<translation id="1718835860248848330">Jam terakhir</translation>
-<translation id="1736419249208073774">Teroka</translation>
-<translation id="1743802530341753419">Tanya sebelum membenarkan tapak menyambung ke peranti (disyorkan)</translation>
-<translation id="1749561566933687563">Segerakkan penanda halaman anda</translation>
-<translation id="17513872634828108">Buka tab</translation>
-<translation id="1779089405699405702">Penyahkod imej</translation>
-<translation id="1782483593938241562">Tarikh tamat <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Dipasang</translation>
-<translation id="1792959175193046959">Tukar lokasi muat turun lalai pada bila-bila masa</translation>
-<translation id="1807246157184219062">Cahaya</translation>
-<translation id="1810845389119482123">Penyediaan penyegerakan permulaan belum selesai</translation>
-<translation id="1821253160463689938">Menggunakan kuki untuk mengingati pilihan anda, walaupun anda tidak melawati halaman tersebut</translation>
-<translation id="1829244130665387512">Cari dalam halaman</translation>
-<translation id="1853692000353488670">Tab inkognito baharu</translation>
-<translation id="1856325424225101786">Tetapkan semula mod Ringkas?</translation>
-<translation id="1868024384445905608">Chrome kini memuat turun fail dengan lebih pantas</translation>
-<translation id="1883903952484604915">Fail Saya</translation>
-<translation id="1887786770086287077">Akses lokasi dimatikan untuk peranti ini. Hidupkannya dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> akan dibuka dalam Chrome. Dengan meneruskan penggunaan, anda bersetuju menerima <ph name="BEGIN_LINK1" />Terma Perkhidmatan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Notis Privasi<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="1919345977826869612">Iklan</translation>
-<translation id="1919950603503897840">Pilih kenalan</translation>
-<translation id="1922076542920281912">Untuk membenarkan Chrome mengakses lokasi anda, hidupkan lokasi dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" /> juga.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Kemas kini</translation>
-<translation id="19288952978244135">Buka semula Chrome.</translation>
-<translation id="1933845786846280168">Tab yang Dipilih</translation>
-<translation id="194341124344773587">Hidupkan kebenaran untuk Chrome dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Simpan kata laluan</translation>
-<translation id="1952172573699511566">Tapak web akan menunjukkan teks dalam bahasa pilihan anda, jika boleh.</translation>
-<translation id="1960290143419248813">Kemas kini Chrome tidak disokong untuk versi Android ini lagi</translation>
-<translation id="1966710179511230534">Sila kemas kini butiran log masuk anda.</translation>
-<translation id="1974060860693918893">Lanjutan</translation>
-<translation id="1984705450038014246">Segerakkan data Chrome anda</translation>
-<translation id="1984937141057606926">Dibenarkan, kecuali pihak ketiga</translation>
-<translation id="1986685561493779662">Nama sudah wujud</translation>
-<translation id="1987739130650180037">Butang <ph name="LINK_NAME" /> <ph name="MESSAGE" /></translation>
-<translation id="1989112275319619282">Semak Imbas</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> mahu digandingkan</translation>
-<translation id="1994173015038366702">URL tapak</translation>
-<translation id="2000419248597011803">Menghantar beberapa kuki dan carian daripada bar alamat dan kotak carian ke enjin carian lalai anda</translation>
-<translation id="2002537628803770967">Kad kredit dan alamat yang menggunakan Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Fail}other{# Fail}}</translation>
-<translation id="2017836877785168846">Kosongkan sejarah dan pelengkapan automatik dalam bar alamat.</translation>
-<translation id="2021896219286479412">Kawalan tapak skrin penuh</translation>
-<translation id="2038563949887743358">Hidupkan Minta tapak desktop</translation>
-<translation id="2041019821020695769">Untuk membenarkan Chrome menghantar pemberitahuan kepada anda, hidupkan pemberitahuan dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" /> juga.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> juga mempunyai data dalam Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Tapak dijeda</translation>
-<translation id="2063713494490388661">Ketik untuk Mencari</translation>
-<translation id="2067805253194386918">teks</translation>
-<translation id="2079545284768500474">Buat asal</translation>
-<translation id="2082238445998314030">Hasil carian <ph name="RESULT_NUMBER" /> daripada <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Bunyi</translation>
-<translation id="2096012225669085171">Segerakkan dan peribadikan pada semua peranti</translation>
-<translation id="2100273922101894616">Auto Log masuk</translation>
-<translation id="2100314319871056947">Cuba kongsikan teks itu dalam bahagian yang lebih kecil</translation>
-<translation id="2107397443965016585">Tanya sebelum membenarkan tapak memainkan kandungan yang dilindungi (disyorkan)</translation>
-<translation id="2111511281910874386">Pergi ke halaman</translation>
-<translation id="2122601567107267586">Tidak dapat membuka apl</translation>
-<translation id="2126426811489709554">Dikuasakan oleh Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> disimpan</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> tertutup</translation>
-<translation id="2139186145475833000">Tambahkan kepada Skrin utama</translation>
-<translation id="2146738493024040262">Buka Apl Segera</translation>
-<translation id="2148716181193084225">Hari ini</translation>
-<translation id="2154484045852737596">Edit kad</translation>
-<translation id="2154710561487035718">Salin URL</translation>
-<translation id="2156074688469523661">Baki tapak (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Untuk berkongsi sesuatu daripada telefon anda kepada peranti lain, hidupkan penyegerakan dalam tetapan Chrome pada kedua-dua peranti</translation>
-<translation id="2170088579611075216">Benarkan &amp; masuk ke VR</translation>
-<translation id="218608176142494674">Perkongsian</translation>
-<translation id="2227444325776770048">Teruskan sebagai <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Segerak dan perkhidmatan Google</translation>
-<translation id="2259659629660284697">Eksport kata laluan…</translation>
-<translation id="2268044343513325586">Perhalusi</translation>
-<translation id="2286841657746966508">Alamat pengebilan</translation>
-<translation id="2289270750774289114">Tanya apabila tapak mahu mencari peranti Bluetooth berdekatan (disyorkan)</translation>
-<translation id="230115972905494466">Tiada peranti yang serasi ditemui</translation>
-<translation id="2315043854645842844">Pemilihan sijil pihak pelanggan tidak disokong oleh sistem pengendalian ini.</translation>
-<translation id="2318045970523081853">Ketik untuk membuat panggilan</translation>
-<translation id="2321086116217818302">Menyediakan kata laluan…</translation>
-<translation id="2321958826496381788">Seret gelangsar sehingga anda selesa membaca teks ini. Teks harus kelihatan sekurang-kurangnya sebesar ini selepas mengetik dua kali pada perenggan.</translation>
-<translation id="2323763861024343754">Storan tapak</translation>
-<translation id="2328985652426384049">Tidak dapat log masuk</translation>
-<translation id="2330129964253841015">Beri amaran kepada anda jika kata laluan terjejas</translation>
-<translation id="2349710944427398404">Jumlah data yang digunakan oleh Chrome, termasuk akaun, penanda halaman dan tetapan yang disimpan</translation>
-<translation id="2353636109065292463">Memeriksa sambungan Internet anda</translation>
-<translation id="2359808026110333948">Teruskan</translation>
-<translation id="2369533728426058518">tab terbuka</translation>
-<translation id="2387895666653383613">Penskalaan teks</translation>
-<translation id="2394602618534698961">Fail yang anda muat turun dipaparkan di sini</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Apabila anda log masuk ke Akaun Google anda, ciri ini akan dihidupkan</translation>
-<translation id="2410754283952462441">Pilih akaun</translation>
-<translation id="2414886740292270097">Gelap</translation>
-<translation id="2416359993254398973">Chrome memerlukan kebenaran untuk mengakses kamera anda bagi tapak ini.</translation>
-<translation id="2426805022920575512">Pilih akaun lain</translation>
-<translation id="2433507940547922241">Tampilan</translation>
-<translation id="2434158240863470628">Muat turun selesai: <ph name="SEPARATOR" /><ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Akses lokasi</translation>
-<translation id="2450083983707403292">Adakah anda mahu mula memuat turun <ph name="FILE_NAME" /> sekali lagi?</translation>
-<translation id="2482878487686419369">Pemberitahuan</translation>
-<translation id="2490684707762498678">Diurus oleh <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Assistant dalam Chrome</translation>
-<translation id="2496180316473517155">Sejarah penyemakan imbas</translation>
-<translation id="2497852260688568942">Penyegerakan dilumpuhkan oleh pentadbir anda</translation>
-<translation id="2498359688066513246">Bantuan &amp; maklum balas</translation>
-<translation id="2501278716633472235">Kembali</translation>
-<translation id="2513403576141822879">Untuk mendapatkan lebih banyak tetapan yang berkaitan dengan privasi, keselamatan dan pengumpulan data, lihat <ph name="BEGIN_LINK" />Penyegerakan dan perkhidmatan Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Dalam mod Ringkas, Chrome memuatkan halaman lebih pantas dan mengurangkan penggunaan data sehingga 60 peratus. Untuk mengoptimumkan halaman yang anda lawati, Chrome menghantar trafik web anda kepada Google. <ph name="BEGIN_LINK" />Ketahui lebih lanjut<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Menghantar URL halaman yang anda lawati kepada Google</translation>
-<translation id="2532336938189706096">Paparan Web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> item dipadamkan</translation>
-<translation id="2536728043171574184">Melihat salinan luar talian halaman ini</translation>
-<translation id="2546283357679194313">Kuki dan data tapak</translation>
-<translation id="2567385386134582609">IMEJ</translation>
-<translation id="257088987046510401">Tema</translation>
-<translation id="2570922361219980984">Akses lokasi turut dimatikan untuk peranti ini. Hidupkannya dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Dikembangkan - klik untuk meruntuhkan.</translation>
-<translation id="2581165646603367611">Tindakan ini akan menghapuskan kuki, cache dan data tapak yang lain yang Chrome anggap tidak penting.</translation>
-<translation id="2586657967955657006">Papan Keratan</translation>
-<translation id="2587052924345400782">Versi lebih baharu tersedia</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Nombor kad</translation>
-<translation id="2621115761605608342">Benarkan JavaScript untuk tapak tertentu.</translation>
-<translation id="2625189173221582860">Kata laluan disalin</translation>
-<translation id="2631006050119455616">Disimpan</translation>
-<translation id="2647434099613338025">Tambah bahasa</translation>
-<translation id="2650751991977523696">Muat turun fail sekali lagi?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Fail audio}other{# Fail audio}}</translation>
-<translation id="2653659639078652383">Serah</translation>
-<translation id="2677748264148917807">Tinggalkan</translation>
-<translation id="2704606927547763573">Disalin</translation>
-<translation id="2707726405694321444">Muat semula halaman</translation>
-<translation id="2709516037105925701">Autoisi</translation>
-<translation id="2717722538473713889">Alamat e-mel</translation>
-<translation id="2728754400939377704">Isih mengikut tapak</translation>
-<translation id="2744248271121720757">Ketik perkataan untuk mencari dengan serta-merta atau melihat tindakan yang berkaitan</translation>
-<translation id="2760989362628427051">Hidupkan tema gelap apabila tema gelap atau Penjimat Bateri peranti anda dihidupkan</translation>
-<translation id="2762000892062317888">sebentar tadi</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> saat lagi</translation>
-<translation id="2779651927720337254">gagal</translation>
-<translation id="2781151931089541271">1 saat lagi</translation>
-<translation id="2801022321632964776">Kemas kini untuk mendapatkan bahasa anda dalam versi terkini Chrome</translation>
-<translation id="2810645512293415242">Halaman diringkaskan untuk menjimatkan data dan memuatkan dengan lebih cepat.</translation>
-<translation id="281504910091592009">Lihat dan urus kata laluan yang disimpan dalam <ph name="BEGIN_LINK" />Akaun Google<ph name="END_LINK" /> anda</translation>
-<translation id="2818669890320396765">Log masuk dan hidupkan penyegerakan untuk mendapatkan penanda halaman pada semua peranti anda</translation>
-<translation id="2822354292072154809">Adakah anda pasti mahu menetapkan semula semua kebenaran tapak untuk <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Sentuh butang kembali untuk keluar daripada skrin penuh.</translation>
-<translation id="2842985007712546952">Folder induk</translation>
-<translation id="2858138569776157458">Tapak popular</translation>
-<translation id="2860954141821109167">Pastikan apl telefon didayakan pada peranti ini</translation>
-<translation id="2870560284913253234">Tapak</translation>
-<translation id="2874939134665556319">Lagu sebelumnya</translation>
-<translation id="2876369937070532032">Menghantar URL sesetengah halaman yang anda lawati kepada Google, apabila keselamatan anda terancam</translation>
-<translation id="2888126860611144412">Perihal Chrome</translation>
-<translation id="2891154217021530873">Hentikan pemuatan halaman</translation>
-<translation id="2893180576842394309">Google boleh menggunakan sejarah anda untuk memperibadikan Carian dan perkhidmatan Google yang lain</translation>
-<translation id="2898264748040935573">Edit kata laluan yang disimpan</translation>
-<translation id="2900528713135656174">Buat acara</translation>
-<translation id="290376772003165898">Halaman bukan dalam <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Senarai peranti untuk berkongsi tab dibuka pada ketinggian penuh.</translation>
-<translation id="2910701580606108292">Tanya sebelum membenarkan tapak memainkan kandungan yang dilindungi</translation>
-<translation id="2913331724188855103">Benarkan tapak untuk menyimpan dan membaca data kuki (disyorkan)</translation>
-<translation id="2923908459366352541">Nama tidak sah</translation>
-<translation id="2932150158123903946">Storan Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Tab pratonton ditutup</translation>
-<translation id="2956410042958133412">Akaun ini diurus oleh <ph name="PARENT_NAME_1" /> dan <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Beralih ke tab inkognito</translation>
-<translation id="2968755619301702150">Pemapar sijil</translation>
-<translation id="2979025552038692506">Tab Inkognito yang Dipilih</translation>
-<translation id="2987620471460279764">Teks yang dikongsi daripada peranti lain</translation>
-<translation id="2989523299700148168">Dilawati baru-baru ini</translation>
-<translation id="2996291259634659425">Buat ungkapan laluan</translation>
-<translation id="2996809686854298943">URL yang diperlukan</translation>
-<translation id="300526633675317032">Tindakan ini akan menghapuskan semua <ph name="SIZE_IN_KB" /> daripada storan tapak web.</translation>
-<translation id="3016635187733453316">Pastikan peranti ini disambungkan ke Internet</translation>
-<translation id="3029613699374795922">Dimuat turun <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Frasa laluan tidak sepadan</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Dapatkan bantuan<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Lokasi dimatikan, hidupkannya dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Anda boleh mematikan penyegerakan pada bila-bila masa dalam tetapan</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> penanda halaman}other{<ph name="BOOKMARKS_COUNT_MANY" /> penanda halaman}}</translation>
-<translation id="3089395242580810162">Buka dalam tab inkognito</translation>
-<translation id="3115898365077584848">Tunjukkan Maklumat</translation>
-<translation id="3123473560110926937">Disekat di sesetengah tapak</translation>
-<translation id="3137521801621304719">Tinggalkan mod inkognito</translation>
-<translation id="3143515551205905069">Batalkan penyegerakan</translation>
-<translation id="3157842584138209013">Lihat jumlah data yang dapat dijimatkan daripada butang Lagi Pilihan</translation>
-<translation id="3166827708714933426">Pintasan tab dan tetingkap</translation>
-<translation id="3181954750937456830">Penyemakan Imbas Selamat (melindungi anda dan peranti anda daripada tapak yang berbahaya)</translation>
-<translation id="3190152372525844641">Hidupkan kebenaran untuk Chrome dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> data disimpan</translation>
-<translation id="3205824638308738187">Hampir selesai!</translation>
-<translation id="3207960819495026254">Ditandai halaman</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> dipadamkan</translation>
-<translation id="321773570071367578">Jika anda terlupa ungkapan laluan atau ingin menukar tetapan ini, <ph name="BEGIN_LINK" />tetapkan semula penyegerakan<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Apl Web</translation>
-<translation id="3236059992281584593">1 minit lagi</translation>
-<translation id="3244271242291266297">BB</translation>
-<translation id="3254409185687681395">Tanda halaman ini</translation>
-<translation id="3259831549858767975">Jadikan semua yang ada pada halaman lebih kecil</translation>
-<translation id="3269093882174072735">Muatkan imej</translation>
-<translation id="3269956123044984603">Untuk mendapatkan tab daripada peranti anda yang lain, hidupkan "Auto segerak data" dalam tetapan akaun Android.</translation>
-<translation id="3277252321222022663">Benarkan tapak mengakses penderia (disyorkan)</translation>
-<translation id="3282568296779691940">Log masuk ke Chrome</translation>
-<translation id="3288003805934695103">Memuatkan semula halaman</translation>
-<translation id="32895400574683172">Pemberitahuan dibenarkan</translation>
-<translation id="3295530008794733555">Semak imbas lebih pantas. Gunakan kurang data.</translation>
-<translation id="3295602654194328831">Sembunyikan Maklumat</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Teruskan memuat turun kandungan?</translation>
-<translation id="3306398118552023113">Apl ini sedang dijalankan dalam Chrome</translation>
-<translation id="3315103659806849044">Anda sedang menyesuaikan tetapan Penyegerakan dan perkhidmatan Google anda. Untuk menyelesaikan tindakan menghidupkan penyegerakan, ketik butang Sahkan berdekatan bahagian bawah skrin. Navigasi ke atas</translation>
-<translation id="3328801116991980348">Maklumat tapak</translation>
-<translation id="3333961966071413176">Semua kenalan</translation>
-<translation id="3334729583274622784">Tukar sambungan fail?</translation>
-<translation id="3341058695485821946">Lihat jumlah data yang dapat dijimatkan</translation>
-<translation id="3350687908700087792">Tutup semua tab inkognito</translation>
-<translation id="3353615205017136254">Halaman Lite disediakan oleh Google. Ketik butang muatkan halaman asal untuk memuatkan halaman asal.</translation>
-<translation id="3367813778245106622">Log masuk semula untuk memulakan penyegerakan</translation>
-<translation id="3374023511497244703">Penanda halaman, sejarah, kata laluan dan data Chrome yang lain tidak akan disegerakkan ke Akaun Google anda lagi</translation>
-<translation id="3384347053049321195">Kongsi imej</translation>
-<translation id="3386292677130313581">Tanya sebelum membenarkan tapak mengetahui lokasi anda (disyorkan)</translation>
-<translation id="3387650086002190359">Muat turun <ph name="FILE_NAME" /> gagal disebabkan oleh ralat sistem fail.</translation>
-<translation id="3389286852084373014">Teks terlalu besar</translation>
-<translation id="3398320232533725830">Buka pengurus penanda halaman</translation>
-<translation id="3414952576877147120">Saiz:</translation>
-<translation id="3443221991560634068">Muat semula halaman semasa</translation>
-<translation id="3445014427084483498">Sebentar Tadi</translation>
-<translation id="3478363558367712427">Anda boleh memilih enjin carian anda</translation>
+<translation id="6910211073230771657">Dipadamkan</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, faham</translation>
+<translation id="7658239707568436148">Batal</translation>
 <translation id="3479552764303398839">Bukan sekarang</translation>
-<translation id="3492207499832628349">Tab inkognito baharu</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Ketahui lebih lanjut<ph name="END_LINK" /> tentang kandungan yang disyorkan</translation>
-<translation id="3513704683820682405">Realiti Tambahan</translation>
-<translation id="3518985090088779359">Terima &amp; teruskan</translation>
-<translation id="3522247891732774234">Kemas kini tersedia. Lagi pilihan</translation>
-<translation id="3524138585025253783">UI Pembangun</translation>
-<translation id="3527085408025491307">Folder</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB tersedia</translation>
-<translation id="3549657413697417275">Cari sejarah anda</translation>
-<translation id="3557336313807607643">Tambahkan pada kenalan</translation>
-<translation id="3566923219790363270">Chrome masih bersiap bersedia untuk VR. Mulakan semula Chrome kemudian.</translation>
-<translation id="3568688522516854065">Log masuk dan hidupkan penyegerakan untuk mendapatkan tab daripada peranti anda yang lain</translation>
-<translation id="3587482841069643663">Semua</translation>
-<translation id="358794129225322306">Benarkan tapak memuat turun berbilang fail secara automatik.</translation>
-<translation id="3590487821116122040">Storan tapak yang Chrome anggap tidak penting (misalnya tapak yang tiada tetapan yang disimpan atau yang jarang anda lawati)</translation>
-<translation id="3599863153486145794">Mengosongkan sejarah daripada semua peranti yang dilog masuk. Akaun Google anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Redam tapak yang memainkan bunyi</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Berkongsi ke <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Buka topeng kata laluan</translation>
-<translation id="363596933471559332">Log masuk secara automatik ke tapak web menggunakan bukti kelayakan yang disimpan. Apabila ciri ini dimatikan, anda akan diminta memberikan pengesahan setiap kali sebelum log masuk ke tapak web.</translation>
-<translation id="3658159451045945436">Penetapan semula akan memadamkan sejarah penjimatan data anda, termasuk senarai tapak yang dilawati.</translation>
-<translation id="3692944402865947621">Muat turun <ph name="FILE_NAME" /> gagal kerana lokasi storan tidak dapat dicapai.</translation>
-<translation id="3714981814255182093">Buka Bar Cari</translation>
-<translation id="3716182511346448902">Halaman ini menggunakan terlalu banyak memori, jadi Chrome menjeda halaman ini.</translation>
-<translation id="3730075448226062617">Untuk membenarkan Chrome mengakses mikrofon anda, hidupkan mikrofon dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" /> juga.</translation>
-<translation id="3739899004075612870">Ditandai halaman dalam <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Penyegerakan latar belakang</translation>
-<translation id="3771001275138982843">Tidak dapat memuat turun kemas kini</translation>
-<translation id="3771033907050503522">Tab Inkognito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Hidupkan Bluetooth<ph name="END_LINK" /> untuk membenarkan penggandingan</translation>
-<translation id="3775705724665058594">Hantar ke peranti anda</translation>
-<translation id="3778956594442850293">Ditambahkan pada Skrin utama</translation>
-<translation id="3789841737615482174">Pasang</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Urus</translation>
-<translation id="381841723434055211">Nombor telefon</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> muat turun dipadamkan</translation>
-<translation id="3822502789641063741">Hapuskan storan tapak?</translation>
-<translation id="385051799172605136">Kembali</translation>
-<translation id="3859306556332390985">Cari ke hadapan</translation>
-<translation id="3894427358181296146">Tambah folder</translation>
-<translation id="3895926599014793903">Zum didaya paksa</translation>
-<translation id="3912508018559818924">Mencari maklumat terbaik daripada web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Gabungkan data saya</translation>
-<translation id="393697183122708255">Tiada carian suara yg didayakan tersedia</translation>
-<translation id="395206256282351086">Cadangan carian dan tapak dilumpuhkan</translation>
-<translation id="3955193568934677022">Benarkan tapak untuk memainkan kandungan yang dilindungi (disyorkan)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome akan memuatkan halaman anda apabila sudah sedia}other{Chrome akan memuatkan halaman anda apabila sudah sedia}}</translation>
-<translation id="3963007978381181125">Penyulitan ungkapan laluan tidak termasuk kaedah pembayaran dan alamat daripada Google Pay. Hanya orang yang mempunyai ungkapan laluan anda boleh membaca data anda yang disulitkan. Ungkapan laluan tidak dihantar atau disimpan oleh Google. Jika anda terlupa ungkapan laluan atau ingin menukar tetapan ini, anda perlu menetapkan semula penyegerakan. <ph name="BEGIN_LINK" />Ketahui lebih lanjut<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Muat turun selesai</translation>
-<translation id="397583555483684758">Penyegerakan telah berhenti berfungsi</translation>
-<translation id="3976396876660209797">Alih keluar dan buat semula pintasan ini</translation>
-<translation id="3985215325736559418">Adakah anda ingin memuat turun <ph name="FILE_NAME" /> semula?</translation>
-<translation id="3987993985790029246">Salin pautan</translation>
-<translation id="3988213473815854515">Lokasi dibenarkan</translation>
-<translation id="3988466920954086464">Lihat hasil carian segera dalam panel ini</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Storan tidak penting</translation>
-<translation id="4000212216660919741">Rumah Luar Talian</translation>
+<translation id="5317780077021120954">Simpan</translation>
+<translation id="4570913071927164677">Butiran</translation>
+<translation id="8730621377337864115">Selesai</translation>
+<translation id="8261506727792406068">Padam</translation>
+<translation id="1181037720776840403">Alih keluar</translation>
+<translation id="5939518447894949180">Tetapkan semula</translation>
 <translation id="4002066346123236978">Tajuk</translation>
-<translation id="4008040567710660924">Benarkan kuki untuk tapak tertentu.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# jam}other{# jam}}</translation>
-<translation id="4046123991198612571">Lagu seterusnya</translation>
-<translation id="4048707525896921369">Ketahui tentang topik berkenaan tapak web tanpa meninggalkan halaman. Ketik untuk Mencari akan menghantar perkataan dan konteks sekitarnya kepada Carian Google, mengembalikan takrif, gambar, hasil carian dan butiran lain.
+<translation id="5916664084637901428">Hidupkan</translation>
+<translation id="5860033963881614850">Dimatikan</translation>
+<translation id="6165508094623778733">Ketahui lebih lanjut</translation>
+<translation id="6042308850641462728">Lagi</translation>
+<translation id="6040143037577758943">Tutup</translation>
+<translation id="780301667611848630">Tidak, terima kasih</translation>
+<translation id="1201402288615127009">Seterusnya</translation>
+<translation id="2359808026110333948">Teruskan</translation>
+<translation id="2653659639078652383">Serah</translation>
+<translation id="2079545284768500474">Buat asal</translation>
+<translation id="7649070708921625228">Bantuan</translation>
+<translation id="2148716181193084225">Hari ini</translation>
+<translation id="7781829728241885113">Semalam</translation>
+<translation id="6945221475159498467">Pilih</translation>
+<translation id="7791543448312431591">Tambah</translation>
+<translation id="6527303717912515753">Kongsi</translation>
+<translation id="1383876407941801731">Carian</translation>
+<translation id="3115898365077584848">Tunjukkan Maklumat</translation>
+<translation id="3295602654194328831">Sembunyikan Maklumat</translation>
+<translation id="3987993985790029246">Salin pautan</translation>
+<translation id="2704606927547763573">Disalin</translation>
+<translation id="8725066075913043281">Cuba lagi</translation>
+<translation id="385051799172605136">Kembali</translation>
+<translation id="8131740175452115882">Sahkan</translation>
+<translation id="5300589172476337783">Paparkan</translation>
+<translation id="1124772482545689468">Pengguna</translation>
+<translation id="8609465669617005112">Alihkan ke atas</translation>
+<translation id="6746124502594467657">Alihkan ke bawah</translation>
+<translation id="8249310407154411074">Alihkan ke atas</translation>
+<translation id="8428213095426709021">Tetapan</translation>
+<translation id="2498359688066513246">Bantuan &amp; maklum balas</translation>
+<translation id="8378714024927312812">Diurus oleh organisasi anda</translation>
+<translation id="9019902583201351841">Diurus oleh ibu bapa anda</translation>
+<translation id="4645575059429386691">Diurus oleh ibu bapa anda</translation>
+<translation id="4883854917563148705">Tetapan yang diurus tidak dapat ditetapkan semula</translation>
+<translation id="4307992518367153382">Asas</translation>
+<translation id="1974060860693918893">Lanjutan</translation>
+<translation id="1146678959555564648">Masukkan VR</translation>
+<translation id="987264212798334818">Umum</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Muat turun</translation>
+<translation id="218608176142494674">Perkongsian</translation>
+<translation id="8004582292198964060">Penyemak Imbas</translation>
+<translation id="1105960400813249514">Tangkapan Skrin</translation>
+<translation id="4875775213178255010">Cadangan Kandungan</translation>
+<translation id="2021896219286479412">Kawalan tapak skrin penuh</translation>
+<translation id="4587589328781138893">Tapak</translation>
+<translation id="4943703118917034429">Realiti Maya</translation>
+<translation id="1928696683969751773">Kemas kini</translation>
+<translation id="6064125863973209585">Muat turun yang telah selesai</translation>
+<translation id="5342314432463739672">Permintaan kebenaran</translation>
+<translation id="629730747756840877">Akaun</translation>
+<translation id="82609232232243542">Log masuk ke Brave</translation>
+<translation id="7956662517480676674">Segerak dan perkhidmatan Brave Software</translation>
+<translation id="5294439808117722387">Anda sedang menyesuaikan tetapan Penyegerakan dan perkhidmatan Brave Software anda. Untuk menyelesaikan tindakan menghidupkan penyegerakan, ketik butang Sahkan berdekatan bahagian bawah skrin. Navigasi ke atas</translation>
+<translation id="2096012225669085171">Segerakkan dan peribadikan pada semua peranti</translation>
+<translation id="1692118695553449118">Penyegerakan dihidupkan</translation>
+<translation id="5514904542973294328">Dilumpuhkan oleh pentadbir peranti ini</translation>
+<translation id="6447211988989208781">Kawalan aktiviti Brave Software</translation>
+<translation id="4882831918239250449">Kawal cara sejarah penyemakan imbas anda digunakan untuk memperibadikan Carian, iklan dan pelbagai lagi</translation>
+<translation id="7431991332293347422">Kawal cara sejarah penyemakan imbas anda digunakan untuk memperibadikan Carian dan pelbagai lagi</translation>
+<translation id="6303969859164067831">Log keluar dan matikan penyegerakan</translation>
+<translation id="1125261911132334651">Urus Akaun Brave Software anda</translation>
+<translation id="6406506848690869874">Segerak</translation>
+<translation id="714362445477979774">Segerakkan data Brave anda</translation>
+<translation id="4314815835985389558">Urus penyegerakan</translation>
+<translation id="5428209950370661546">Perkhidmatan Brave Software yang lain</translation>
+<translation id="7704317875155739195">Autolengkap carian dan URL</translation>
+<translation id="2000419248597011803">Menghantar beberapa kuki dan carian daripada bar alamat dan kotak carian ke enjin carian lalai anda</translation>
+<translation id="7981313251711023384">Pramuat halaman untuk penyemakan imbas dan pencarian yang lebih cepat</translation>
+<translation id="1821253160463689938">Menggunakan kuki untuk mengingati pilihan anda, walaupun anda tidak melawati halaman tersebut</translation>
+<translation id="6697492270171225480">Tunjukkan cadangan untuk halaman yang serupa apabila halaman tidak ditemui</translation>
+<translation id="8109318360573330108">Menghantar URL halaman yang cuba anda capai kepada Brave Software</translation>
+<translation id="8438566539970814960">Mempertingkatkan carian dan penyemakan imbas</translation>
+<translation id="284843628681142937">Menghantar URL halaman yang anda lawati kepada Brave Software</translation>
+<translation id="7222718784508482526">Untuk mendapatkan lebih banyak tetapan yang berkaitan dengan privasi, keselamatan dan pengumpulan data, lihat <ph name="BEGIN_LINK"/>Penyegerakan dan perkhidmatan Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Bantu meningkatkan ciri dan prestasi Brave</translation>
+<translation id="9063160602596686558">Menghantar perangkaan penggunaan dan laporan ranap sistem secara automatik kepada Brave Software</translation>
+<translation id="4824958205181053313">Batalkan penyegerakan?</translation>
+<translation id="3058498974290601450">Anda boleh mematikan penyegerakan pada bila-bila masa dalam tetapan</translation>
+<translation id="3143515551205905069">Batalkan penyegerakan</translation>
+<translation id="1506061864768559482">Enjin carian</translation>
+<translation id="55737423895878184">Lokasi dan pemberitahuan dibenarkan</translation>
+<translation id="3988213473815854515">Lokasi dibenarkan</translation>
+<translation id="32895400574683172">Pemberitahuan dibenarkan</translation>
+<translation id="9040142327097499898">Pemberitahuan dibenarkan. Lokasi dimatikan untuk peranti ini.</translation>
+<translation id="305593374596241526">Lokasi dimatikan, hidupkannya dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Dilawati baru-baru ini</translation>
+<translation id="6433501201775827830">Pilih enjin carian anda</translation>
+<translation id="7177466738963138057">Anda boleh menukar perkara ini selepas ini dalam Tetapan</translation>
+<translation id="3478363558367712427">Anda boleh memilih enjin carian anda</translation>
+<translation id="4910889077668685004">Apl pembayaran</translation>
+<translation id="5152843274749979095">Tiada apl yang disokong dipasang</translation>
+<translation id="8812260976093120287">Pada sesetengah tapak web, anda boleh membayar menggunakan apl pembayaran yang disokong di atas pada peranti anda.</translation>
+<translation id="7764225426217299476">Tambahkan alamat</translation>
+<translation id="5595485650161345191">Edit alamat</translation>
+<translation id="5087580092889165836">Tambah kad</translation>
+<translation id="2154484045852737596">Edit kad</translation>
+<translation id="6140912465461743537">Negara/Rantau</translation>
+<translation id="5659593005791499971">E-mel</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Nama pada kad</translation>
+<translation id="860043288473659153">Nama pemegang kad</translation>
+<translation id="2612676031748830579">Nombor kad</translation>
+<translation id="869891660844655955">Tarikh tamat tempoh</translation>
+<translation id="2286841657746966508">Alamat pengebilan</translation>
+<translation id="663059986967017181">Disalin ke Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> lagi}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> lagi}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> lagi}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> lagi}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> lagi}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> lagi}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> lagi}other{<ph name="CONTACT_PREVIEW"/>\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> lagi}}</translation>
+<translation id="7029809446516969842">Kata laluan</translation>
+<translation id="1943432128510653496">Simpan kata laluan</translation>
+<translation id="2100273922101894616">Auto Log masuk</translation>
+<translation id="363596933471559332">Log masuk secara automatik ke tapak web menggunakan bukti kelayakan yang disimpan. Apabila ciri ini dimatikan, anda akan diminta memberikan pengesahan setiap kali sebelum log masuk ke tapak web.</translation>
+<translation id="6995899638241819463">Beri amaran kepada anda jika kata laluan terdedah dalam pelanggaran data</translation>
+<translation id="1534287762301776620">Apabila anda log masuk ke Akaun Brave Software anda, ciri ini akan dihidupkan</translation>
+<translation id="10614374240317010">Tidak pernah disimpan</translation>
+<translation id="3098842761938485917">Lihat dan urus kata laluan yang disimpan dalam <ph name="BEGIN_LINK"/>Akaun Brave Software<ph name="END_LINK"/> anda</translation>
+<translation id="8562452229998620586">Kata laluan yang disimpan akan kelihatan di sini.</translation>
+<translation id="8084114998886531721">Kata laluan disimpan</translation>
+<translation id="2870560284913253234">Tapak</translation>
+<translation id="8503813439785031346">Nama pengguna</translation>
+<translation id="6657585470893396449">Kata laluan</translation>
+<translation id="2154710561487035718">Salin URL</translation>
+<translation id="1571304935088121812">Salin nama pengguna</translation>
+<translation id="5005498671520578047">Salin kata laluan</translation>
+<translation id="3632295766818638029">Buka topeng kata laluan</translation>
+<translation id="1513858653616922153">Padam kata laluan</translation>
+<translation id="543338862236136125">Edit kata laluan</translation>
+<translation id="4565377596337484307">Sembunyikan kata laluan</translation>
+<translation id="8523928698583292556">Padam kata laluan yang disimpan</translation>
+<translation id="2898264748040935573">Edit kata laluan yang disimpan</translation>
+<translation id="5433691172869980887">Nama pengguna disalin</translation>
+<translation id="5534640966246046842">Tapak disalin</translation>
+<translation id="2625189173221582860">Kata laluan disalin</translation>
+<translation id="4550003330909367850">Untuk melihat atau menyalin kata laluan anda di sini, tetapkan kunci skrin pada peranti ini.</translation>
+<translation id="6154478581116148741">Hidupkan kunci skrin dalam Tetapan untuk mengeksport kata laluan anda daripada peranti ini</translation>
+<translation id="4842092870884894799">Menunjukkan tetingkap timbul penjanaan kata laluan</translation>
+<translation id="2259659629660284697">Eksport kata laluan…</translation>
+<translation id="133012818630824069">Eksport kata laluan yang disimpan dengan menggunakan Brave</translation>
+<translation id="6914783257214138813">Kata laluan anda akan kelihatan kepada sesiapa yang dapat melihat fail yang dieksport.</translation>
+<translation id="2321086116217818302">Menyediakan kata laluan…</translation>
+<translation id="8445448999790540984">Tidak dapat mengeskport kata laluan</translation>
+<translation id="3066461326500799725">Ketahui cara menggunakan Brave Software Drive</translation>
+<translation id="729975465115245577">Peranti anda tiada apl untuk menyimpan fail kata laluan.</translation>
+<translation id="7682724950699840886">Cuba petua berikut: pastikan ruang pada peranti anda mencukupi, cuba eksport sekali lagi.</translation>
+<translation id="1129510026454351943">Butiran: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Buka kunci untuk menyalin kata laluan anda</translation>
+<translation id="5515439363601853141">Buka kunci untuk melihat kata laluan anda</translation>
+<translation id="6221633008163990886">Buka kunci untuk mengeksport kata laluan anda</translation>
+<translation id="230699814587342492">Kata Laluan Brave</translation>
+<translation id="6075798973483050474">Edit laman utama</translation>
+<translation id="854522910157234410">Buka halaman ini</translation>
+<translation id="2482878487686419369">Pemberitahuan</translation>
+<translation id="6255999984061454636">Cadangan kandungan</translation>
+<translation id="805047784848435650">Berdasarkan sejarah penyemakan imbas anda</translation>
+<translation id="1041308826830691739">Daripada tapak web</translation>
+<translation id="395206256282351086">Cadangan carian dan tapak dilumpuhkan</translation>
+<translation id="257088987046510401">Tema</translation>
+<translation id="4650364565596261010">Lalai sistem</translation>
+<translation id="7588219262685291874">Hidupkan tema gelap apabila Penjimat Bateri peranti anda dihidupkan</translation>
+<translation id="2760989362628427051">Hidupkan tema gelap apabila tema gelap atau Penjimat Bateri peranti anda dihidupkan</translation>
+<translation id="6381421346744604172">Tapak web digelapkan</translation>
+<translation id="5040262127954254034">Privasi</translation>
+<translation id="4991384657077828949">Bantu tingkatkan keselamatan Brave</translation>
+<translation id="1943176487615318915">Untuk mengesan apl dan tapak berbahaya, Brave menghantar URL sesetengah halaman yang anda lawati, maklumat sistem yang terhad dan sesetengah kandungan halaman kepada Brave Software</translation>
+<translation id="3181954750937456830">Penyemakan Imbas Selamat (melindungi anda dan peranti anda daripada tapak yang berbahaya)</translation>
+<translation id="7315322926489145388">Menghantar URL sesetengah halaman yang anda lawati kepada Brave Software, apabila keselamatan anda terancam</translation>
+<translation id="2063713494490388661">Ketik untuk Mencari</translation>
+<translation id="2369463299479365221">Ketahui tentang topik berkenaan tapak web tanpa meninggalkan halaman. Ketik untuk Mencari akan menghantar perkataan dan konteks sekitarnya kepada Carian Brave Software, mengembalikan takrif, gambar, hasil carian dan butiran lain.
 
 Untuk melaraskan istilah carian anda, tekan lama untuk memilih. Untuk memperhalusi carian anda, luncurkan panel ke atas dan ketik kotak carian.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Pilihan tersedia berhampiran bahagian atas skrin</translation>
-<translation id="4062305924942672200">Maklumat undang-undang</translation>
-<translation id="4084682180776658562">Penanda halaman</translation>
-<translation id="4084712963632273211">Daripada <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />disampaikan oleh Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Padam data apl?</translation>
-<translation id="4099578267706723511">Bantu jadikan Chrome lebih baik dengan menghantar laporan perangkaan penggunaan dan ranap sistem kepada Google.</translation>
-<translation id="410351446219883937">Automain</translation>
-<translation id="4116038641877404294">Muat turun halaman untuk digunakan di luar talian</translation>
-<translation id="4135200667068010335">Senarai peranti untuk berkongsi tab ditutup.</translation>
-<translation id="4149994727733219643">Paparan ringkas bagi halaman web</translation>
-<translation id="4165986682804962316">Tetapan tapak</translation>
-<translation id="4169535189173047238">Jangan benarkan</translation>
-<translation id="4170011742729630528">Perkhidmatan tidak tersedia; cuba lagi kemudian.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> digunakan</translation>
-<translation id="4181841719683918333">Bahasa</translation>
-<translation id="4183868528246477015">Cari dengan Google Lens <ph name="BEGIN_NEW" />Baharu<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Buka dalam tab baharu</translation>
-<translation id="4198423547019359126">Tiada lokasi muat turun tersedia</translation>
-<translation id="4209895695669353772">Hidupkan penyegerakan untuk mendapatkan kandungan diperibadikan yang dicadangkan oleh Google</translation>
-<translation id="4226663524361240545">Pemberitahuan boleh menggetarkan peranti</translation>
-<translation id="423219824432660969">Sulitkan data yang disegerakkan dengan kata laluan Google bermula dari <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Buka tetapan</translation>
-<translation id="4256782883801055595">Lesen sumber terbuka</translation>
-<translation id="4259722352634471385">Navigasi disekat: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Salin alamat pautan</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Dibenarkan</translation>
-<translation id="429312253194641664">Tapak sedang memainkan media</translation>
-<translation id="4298388696830689168">Tapak terpaut</translation>
-<translation id="4307992518367153382">Asas</translation>
-<translation id="4314815835985389558">Urus penyegerakan</translation>
-<translation id="4351244548802238354">Tutup dialog</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Menggunakan Sogou untuk carian</translation>
-<translation id="4404568932422911380">Tiada penanda halaman</translation>
-<translation id="4405224443901389797">Alihkan ke…</translation>
-<translation id="4411535500181276704">Mod Ringkas</translation>
-<translation id="4415276339145661267">Urus Akaun Google anda</translation>
-<translation id="4432792777822557199">Halaman dalam <ph name="SOURCE_LANGUAGE" /> akan diterjemahkan kepada <ph name="TARGET_LANGUAGE" /> bermula dari sekarang</translation>
-<translation id="4433925000917964731">Halaman Lite disediakan oleh Google</translation>
-<translation id="4434045419905280838">Tetingkap timbul dan ubah hala</translation>
-<translation id="4440958355523780886">Halaman Lite disediakan oleh Google. Ketik untuk memuatkan halaman asal.</translation>
-<translation id="4452411734226507615">Tutup tab <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Ditandai halaman ke <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Benarkan tapak memainkan kandungan yang dilindungi</translation>
-<translation id="4468959413250150279">Redam bunyi untuk tapak tertentu.</translation>
-<translation id="4472118726404937099">Log masuk dan hidupkan penyegerakan untuk melakukan penyegerakan dan pemperibadian pada semua peranti</translation>
-<translation id="447252321002412580">Bantu meningkatkan ciri dan prestasi Chrome</translation>
-<translation id="4479647676395637221">Tanya dahulu sebelum membenarkan tapak menggunakan kamera anda (disyorkan)</translation>
-<translation id="4479972344484327217">Memasang <ph name="MODULE" /> untuk Chrome…</translation>
-<translation id="4487967297491345095">Semua data apl Chrome akan dipadamkan selama-lamanya. Ini termasuk semua fail, tetapan, akaun, pangkalan data dan sebagainya.</translation>
-<translation id="4493497663118223949">Mod Ringkas dihidupkan</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# hari yang lalu}other{# hari yang lalu}}</translation>
-<translation id="451872707440238414">Cari penanda halaman anda</translation>
-<translation id="4521489764227272523">Data yang dipilih telah dialih keluar daripada Chrome dan peranti anda yang disegerakkan.
-
-Akaun Google anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain seperti carian dan aktiviti daripada perkhidmatan Google yang lain di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Pilih folder</translation>
-<translation id="4538018662093857852">Hidupkan mod Ringkas</translation>
-<translation id="4550003330909367850">Untuk melihat atau menyalin kata laluan anda di sini, tetapkan kunci skrin pada peranti ini.</translation>
-<translation id="4558311620361989323">Pintasan halaman web</translation>
-<translation id="4561979708150884304">Tiada sambungan</translation>
-<translation id="4565377596337484307">Sembunyikan kata laluan</translation>
-<translation id="4570913071927164677">Butiran</translation>
-<translation id="4572422548854449519">Log masuk ke akaun terurus</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minit yang lalu}other{# minit yang lalu}}</translation>
-<translation id="4587589328781138893">Tapak</translation>
-<translation id="4594952190837476234">Halaman luar talian ini dari <ph name="CREATION_TIME" /> dan mungkin berbeza daripada versi dalam talian.</translation>
-<translation id="4605958867780575332">Item dialih keluar: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Buka <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Gunakan kata laluan</translation>
-<translation id="4645575059429386691">Diurus oleh ibu bapa anda</translation>
-<translation id="4650364565596261010">Lalai sistem</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> penanda halaman dipadamkan</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> telah ditambahkan ke skrin Utama anda</translation>
-<translation id="4684427112815847243">Segerakkan semua</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> lagi}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> lagi}}</translation>
-<translation id="4696983787092045100">Hantar teks ke Peranti Anda</translation>
-<translation id="4698034686595694889">Lihat di luar talian dalam <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Imej dan fail dicache</translation>
-<translation id="4714588616299687897">Jimat sehingga 60% daripada data anda</translation>
-<translation id="4719927025381752090">Tawaran untuk menterjemah</translation>
-<translation id="4720023427747327413">Buka dalam <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Bantu meningkatkan Chrome. <ph name="BEGIN_LINK" />Jawab tinjauan<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Kemas kini</translation>
-<translation id="4738836084190194332">Kali terakhir disegerakkan: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Buka tab baharu</translation>
-<translation id="4751476147751820511">Penderia gerakan atau cahaya</translation>
-<translation id="4759238208242260848">Muat turun</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 muat turun selesai.}other{# muat turun selesai.}}</translation>
-<translation id="4797039098279997504">Sentuh untuk kembali ke <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Penyulitan ungkapan laluan tidak termasuk kaedah pembayaran dan alamat daripada Google Pay.
-
-Untuk menukar tetapan ini, <ph name="BEGIN_LINK" />tetapkan semula penyegerakan<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Nama pada kad</translation>
-<translation id="4824958205181053313">Batalkan penyegerakan?</translation>
-<translation id="4837753911714442426">Buka pilihan untuk mencetak halaman</translation>
-<translation id="4842092870884894799">Menunjukkan tetingkap timbul penjanaan kata laluan</translation>
-<translation id="4860895144060829044">Hubungi</translation>
-<translation id="4866368707455379617">Tidak dapat memasang <ph name="MODULE" /> untuk Chrome</translation>
-<translation id="4875775213178255010">Cadangan Kandungan</translation>
-<translation id="4878404682131129617">Gagal mewujudkan terowong melalui pelayan proksi</translation>
-<translation id="4880127995492972015">Terjemah…</translation>
-<translation id="4881695831933465202">Buka</translation>
-<translation id="488187801263602086">Namakan semula fail</translation>
-<translation id="4882831918239250449">Kawal cara sejarah penyemakan imbas anda digunakan untuk memperibadikan Carian, iklan dan pelbagai lagi</translation>
-<translation id="4883854917563148705">Tetapan yang diurus tidak dapat ditetapkan semula</translation>
-<translation id="4885273946141277891">Bilangan kejadian Chrome tidak disokong.</translation>
-<translation id="4910889077668685004">Apl pembayaran</translation>
-<translation id="4913161338056004800">Tetapkan semula perangkaan</translation>
-<translation id="4913169188695071480">Berhenti memuat semula</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Dapatkan bantuan<ph name="END_LINK" /> semasa mengimbas peranti…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Halaman}other{# Halaman}}</translation>
-<translation id="4932247056774066048">Oleh sebab anda log keluar daripada akaun yang diurus oleh <ph name="DOMAIN_NAME" />, data Chrome anda akan dipadamkan daripada peranti ini. Data tersebut akan kekal dalam Akaun Google anda.</translation>
-<translation id="4943703118917034429">Realiti Maya</translation>
-<translation id="4943872375798546930">Tiada hasil carian</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> berkongsi skrin anda</translation>
-<translation id="4961107849584082341">Terjemahkan halaman ini ke sebarang bahasa</translation>
-<translation id="4962975101802056554">Batalkan semua kebenaran untuk peranti</translation>
-<translation id="4970824347203572753">Tidak tersedia di lokasi anda</translation>
-<translation id="497421865427891073">Ke hadapan</translation>
-<translation id="4988210275050210843">Memuat turun fail (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Halaman</translation>
-<translation id="4994033804516042629">Tiada kenalan ditemui</translation>
-<translation id="4996978546172906250">Kongsi melalui</translation>
-<translation id="5004416275253351869">Kawalan aktiviti Google</translation>
-<translation id="5005498671520578047">Salin kata laluan</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> ingin menyambung</translation>
-<translation id="5013696553129441713">Tiada cadangan baharu</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Semasa anda berada dalam VR, tapak ini mungkin dapat mengetahui tentang:
-  -  ciri fizikal anda, seperti ketinggian
-
-Pastikan anda mempercayai tapak ini sebelum memasuki VR.</translation>
+<translation id="2930742481329940825">Ketik untuk Mencari menghantar perkataan yang dipilih dan halaman semasa sebagai konteks kepada Carian Brave Software. Anda boleh mematikannya dalam <ph name="BEGIN_LINK"/>Tetapan<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Benarkan</translation>
-<translation id="5040262127954254034">Privasi</translation>
-<translation id="5048398596102334565">Benarkan tapak mengakses penderia gerakan (disyorkan)</translation>
-<translation id="5063480226653192405">Penggunaan</translation>
-<translation id="5087580092889165836">Tambah kad</translation>
-<translation id="5100237604440890931">Diruntuhkan - klik untuk mengembangkan.</translation>
-<translation id="510275257476243843">1 jam lagi</translation>
-<translation id="5123685120097942451">Tab Inkognito</translation>
-<translation id="5127805178023152808">Penyegerakan dimatikan</translation>
-<translation id="5129038482087801250">Pasang apl web</translation>
-<translation id="5132942445612118989">Segerakkan kata laluan, sejarah &amp; pelbagai lagi pada semua peranti</translation>
-<translation id="5139940364318403933">Ketahui cara menggunakan Google Drive</translation>
-<translation id="515227803646670480">Buang data yg disimpan</translation>
-<translation id="5152843274749979095">Tiada apl yang disokong dipasang</translation>
-<translation id="5161254044473106830">Tajuk diperlukan</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 muat turun gagal.}other{# muat turun gagal.}}</translation>
-<translation id="5170568018924773124">Paparkan dalam folder</translation>
-<translation id="5184329579814168207">Buka dalam Chrome</translation>
-<translation id="5193988420012215838">Disalin ke papan keratan anda</translation>
-<translation id="5197729504361054390">Kenalan yang anda pilih akan dikongsi dengan <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Profil kerja</translation>
-<translation id="5210286577605176222">Lompat ke halaman sebelumnya</translation>
-<translation id="5210365745912300556">Tutup tab</translation>
-<translation id="5224771365102442243">Dengan video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> mahu mengimbas untuk mengesan peranti Bluetooth berdekatan. Peranti berikut telah dijumpai:</translation>
-<translation id="5233638681132016545">Tab baharu</translation>
-<translation id="526421993248218238">Tidak dapat memuatkan halaman ini</translation>
-<translation id="5271967389191913893">Peranti tidak dapat membuka kandungan yang hendak dimuat turun.</translation>
-<translation id="528192093759286357">Seret dari atas dan sentuh butang kembali untuk keluar daripada skrin penuh.</translation>
-<translation id="5292796745632149097">Hantar ke</translation>
-<translation id="5300589172476337783">Paparkan</translation>
-<translation id="5301954838959518834">OK, faham</translation>
-<translation id="5304593522240415983">Medan ini tidak boleh kosong</translation>
-<translation id="5307446750509046227">Kosongkan storan tapak</translation>
-<translation id="5308380583665731573">Sambung</translation>
-<translation id="5313967007315987356">Tambahkan tapak</translation>
-<translation id="5317780077021120954">Simpan</translation>
-<translation id="5324858694974489420">Tetapan Ibu Bapa</translation>
-<translation id="5327248766486351172">Nama</translation>
-<translation id="5335288049665977812">Benarkan tapak menjalankan JavaScript (disyorkan)</translation>
-<translation id="5342314432463739672">Permintaan kebenaran</translation>
-<translation id="5357811892247919462">Tab diterima</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> tab terbuka, ketik untuk beralih antara tab}other{<ph name="OPEN_TABS_MANY" /> tab terbuka, ketik untuk beralih antara tab}}</translation>
-<translation id="5391532827096253100">Sambungan anda ke tapak web ini tidak selamat. Maklumat tapak</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 lagi)}other{(+ # lagi)}}</translation>
-<translation id="5400569084694353794">Dengan menggunakan aplikasi ini, anda bersetuju menerima <ph name="BEGIN_LINK1" />Syarat Perkhidmatan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Notis Privasi<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="5403592356182871684">Nama</translation>
-<translation id="5403644198645076998">Benarkan tapak tertentu sahaja</translation>
-<translation id="5414836363063783498">Mengesahkan…</translation>
-<translation id="5423934151118863508">Halaman yang paling kerap anda kunjungi akan muncul di sini</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB tersedia</translation>
-<translation id="543338862236136125">Edit kata laluan</translation>
-<translation id="5433691172869980887">Nama pengguna disalin</translation>
-<translation id="543509235395288790">Memuat turun <ph name="COUNT" /> fail (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Lompat ke bar alamat</translation>
-<translation id="5447201525962359567">Semua storan tapak, termasuk kuki dan data lain yang disimpan setempat</translation>
-<translation id="5447765697759493033">Tapak ini tidak akan diterjemah</translation>
-<translation id="545042621069398927">Mempercepatkan muat turun anda.</translation>
-<translation id="5456381639095306749">Muat turun halaman</translation>
-<translation id="5475862044948910901">Mulakan sesi Realiti Tambahan?</translation>
-<translation id="548278423535722844">Buka dalam apl peta</translation>
-<translation id="5487521232677179737">Kosongkan data</translation>
-<translation id="5494752089476963479">Sekat iklan di tapak yang menyiarkan iklan yang mengganggu atau mengelirukan</translation>
-<translation id="5500777121964041360">Mungkin tidak tersedia di lokasi anda</translation>
-<translation id="5512137114520586844">Akaun ini diurus oleh <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Dilumpuhkan oleh pentadbir peranti ini</translation>
-<translation id="5515439363601853141">Buka kunci untuk melihat kata laluan anda</translation>
-<translation id="5516455585884385570">Buka tetapan pemberitahuan</translation>
-<translation id="5517095782334947753">Anda mempunyai penanda halaman, sejarah, kata laluan dan tetapan lain daripada <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Ubah hala disekat.</translation>
-<translation id="5527082711130173040">Chrome memerlukan akses lokasi untuk mengimbas peranti. <ph name="BEGIN_LINK1" />Kemas kini kebenaran<ph name="END_LINK1" />. Akses lokasi turut <ph name="BEGIN_LINK2" />dimatikan untuk peranti ini<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Tanya sebelum membenarkan tapak membaca teks dan imej daripada papan keratan (disyorkan)</translation>
-<translation id="5530766185686772672">Tutup tab inkognito</translation>
-<translation id="5534334044554683961">Semasa anda berada dalam VR, tapak ini mungkin dapat mengetahui tentang:
-  -   ciri fizikal anda, seperti ketinggian
-  -   susun atur bilik anda
-
-Pastikan anda mempercayai tapak ini sebelum memasuki VR.</translation>
-<translation id="5534640966246046842">Tapak disalin</translation>
-<translation id="5556459405103347317">Muat Semula</translation>
-<translation id="5561549206367097665">Menunggu rangkaian…</translation>
-<translation id="557283862590186398">Chrome memerlukan kebenaran untuk mengakses mikrofon anda bagi tapak ini.</translation>
-<translation id="55737423895878184">Lokasi dan pemberitahuan dibenarkan</translation>
-<translation id="5578795271662203820">Cari imej ini di <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Anda boleh memilih item yang hendak disegerakkan dalam <ph name="BEGIN_LINK1" />tetapan<ph name="END_LINK1" /> pada bila-bila masa.</translation>
-<translation id="5595485650161345191">Edit alamat</translation>
-<translation id="5596627076506792578">Lagi pilihan</translation>
-<translation id="5599455543593328020">Mod inkognito</translation>
-<translation id="5620928963363755975">Cari fail dan halaman anda dalam Muat Turun daripada butang Lagi Pilihan</translation>
-<translation id="5626134646977739690">Nama:</translation>
-<translation id="5639724618331995626">Benarkan semua tapak</translation>
-<translation id="5648166631817621825">7 hari terakhir</translation>
-<translation id="5649053991847567735">Muat turun automatik</translation>
-<translation id="5655963694829536461">Cari muat turun anda</translation>
-<translation id="5659593005791499971">E-mel</translation>
-<translation id="5665379678064389456">Buat acara dalam <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Mengatasi permintaan tapak web untuk menghalang zum masuk</translation>
-<translation id="5677928146339483299">Disekat</translation>
-<translation id="5684874026226664614">Op. Halaman ini tidak dapat diterjemahkan.</translation>
-<translation id="5686790454216892815">Nama fail terlalu panjang</translation>
-<translation id="5689516760719285838">Lokasi</translation>
-<translation id="569536719314091526">Terjemahkan halaman ini ke dalam sebarang bahasa lain daripada butang Lagi pilihan</translation>
-<translation id="572328651809341494">Tab terbaharu</translation>
-<translation id="5726692708398506830">Jadikan semua yang ada pada halaman lebih besar</translation>
-<translation id="5748802427693696783">Beralih ke tab standard</translation>
-<translation id="5749068826913805084">Chrome memerlukan akses storan untuk memuat turun fail.</translation>
-<translation id="5763382633136178763">Tab inkognito</translation>
-<translation id="5763514718066511291">Ketik untuk menyalin URL apl ini</translation>
-<translation id="5765780083710877561">Huraian:</translation>
-<translation id="5793665092639000975">Menggunakan <ph name="SPACE_USED" /> daripada <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google boleh menggunakan sejarah anda untuk memperibadikan Carian, iklan dan perkhidmatan Google yang lain</translation>
-<translation id="5804241973901381774">Kebenaran</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# jam yang lalu}other{# jam yang lalu}}</translation>
-<translation id="5810288467834065221">Hak Cipta <ph name="YEAR" /> Google LLC. Hak cipta terpelihara.</translation>
-<translation id="5817918615728894473">Gandingkan</translation>
-<translation id="583281660410589416">Tidak diketahui</translation>
-<translation id="5833984609253377421">Kongsi pautan</translation>
-<translation id="5836192821815272682">Memuat Turun Kemas Kini Chrome…</translation>
-<translation id="5853623416121554550">dijeda</translation>
-<translation id="5854790677617711513">Lebih lama daripada 30 hari</translation>
-<translation id="5858741533101922242">Chrome tidak dapat menghidupkan penyesuai Bluetooth</translation>
-<translation id="5860033963881614850">Dimatikan</translation>
-<translation id="5862731021271217234">Hidupkan penyegerakan untuk mendapatkan tab daripada peranti anda yang lain</translation>
-<translation id="5864174910718532887">Butiran: Diisih mengikut nama tapak</translation>
-<translation id="5864419784173784555">Menunggu muat turun lain…</translation>
-<translation id="5865733239029070421">Menghantar perangkaan penggunaan dan laporan ranap sistem secara automatik kepada Google</translation>
-<translation id="5869522115854928033">Kata laluan disimpan</translation>
-<translation id="5902828464777634901">Semua data setempat yang disimpan oleh tapak web ini, termasuk kuki, akan dipadamkan.</translation>
-<translation id="5916664084637901428">Hidupkan</translation>
-<translation id="5919204609460789179">Kemas kini <ph name="PRODUCT_NAME" /> untuk memulakan penyegerakan</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> disimpan</translation>
-<translation id="5939518447894949180">Tetapkan semula</translation>
-<translation id="5942872142862698679">Menggunakan Google untuk carian</translation>
-<translation id="5952764234151283551">Menghantar URL halaman yang cuba anda capai kepada Google</translation>
-<translation id="5956665950594638604">Buka Pusat Bantuan Chrome dalam tab baharu</translation>
-<translation id="5958275228015807058">Cari fail dan halaman anda dalam Muat Turun</translation>
-<translation id="5962718611393537961">Ketik untuk runtuhkan</translation>
-<translation id="6000066717592683814">Kekalkan Google</translation>
-<translation id="6005538289190791541">Kata laluan yang disyorkan</translation>
-<translation id="6036057147555329831">ICU tambahan</translation>
-<translation id="6039379616847168523">Lompat ke tab seterusnya</translation>
-<translation id="6040143037577758943">Tutup</translation>
-<translation id="6042308850641462728">Lagi</translation>
-<translation id="604996488070107836">Muat turun <ph name="FILE_NAME" /> gagal disebabkan oleh ralat yang tidak diketahui.</translation>
-<translation id="605721222689873409">TT</translation>
-<translation id="6064125863973209585">Muat turun yang telah selesai</translation>
-<translation id="6075798973483050474">Edit laman utama</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> jam lagi</translation>
-<translation id="6108923351542677676">Persediaan sedang berjalan...</translation>
-<translation id="6111020039983847643">data digunakan</translation>
-<translation id="6112702117600201073">Memuat semula halaman</translation>
-<translation id="6127379762771434464">Item dialih keluar</translation>
-<translation id="6140912465461743537">Negara/Rantau</translation>
-<translation id="614940544461990577">Cuba:</translation>
-<translation id="6154478581116148741">Hidupkan kunci skrin dalam Tetapan untuk mengeksport kata laluan anda daripada peranti ini</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> penjimatan data</translation>
-<translation id="6165508094623778733">Ketahui lebih lanjut</translation>
-<translation id="6177111841848151710">Disekat untuk enjin carian semasa</translation>
-<translation id="6181444274883918285">Tambah pengecualian tapak</translation>
-<translation id="6192333916571137726">Muat turun fail</translation>
-<translation id="6192792657125177640">Pengecualian</translation>
-<translation id="6194112207524046168">Untuk membenarkan Chrome mengakses kamera anda, hidupkan kamera dalam <ph name="BEGIN_LINK" />Tetapan Android<ph name="END_LINK" /> juga.</translation>
-<translation id="6196640612572343990">Sekat kuki pihak ketiga</translation>
-<translation id="6206551242102657620">Sambungan selamat. Maklumat tapak</translation>
-<translation id="6210748933810148297">Bukan <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Buka kunci untuk mengeksport kata laluan anda</translation>
+<translation id="1406000523432664303">“Jangan Kesan”</translation>
 <translation id="6232535412751077445">Tindakan mendayakan "Jangan Kesan" bermaksud permintaan akan disertakan dengan trafik penyemakan imbas anda. Sebarang kesan bergantung pada sama ada tapak web memberi respons kepada permintaan dan cara permintaan ditafsirkan.
 
 Sebagai contoh, sesetengah tapak web mungkin memberi respons kepada permintaan ini dengan memaparkan iklan yang tidak berdasarkan tapak web lain yang anda lawati. Pelbagai tapak web masih akan mengumpul dan menggunakan data penyemakan imbas anda — contohnya, untuk meningkatkan keselamatan, untuk menyediakan kandungan, iklan dan cadangan serta untuk menjana statistik pelaporan.</translation>
-<translation id="624789221780392884">Kemaskini bersedia</translation>
-<translation id="6255999984061454636">Cadangan kandungan</translation>
-<translation id="6277522088822131679">Terdapat masalah semasa mencetak halaman. Sila cuba sekali lagi.</translation>
-<translation id="6295158916970320988">Semua tapak</translation>
-<translation id="629730747756840877">Akaun</translation>
-<translation id="6303969859164067831">Log keluar dan matikan penyegerakan</translation>
-<translation id="6316139424528454185">Versi Android tidak disokong</translation>
-<translation id="6320088164292336938">Getar</translation>
-<translation id="6324034347079777476">Penyegerakan sistem Android dilumpuhkan</translation>
-<translation id="6333140779060797560">Kongsi melalui <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Penyulitan</translation>
-<translation id="6341580099087024258">Tanya tempat fail hendak disimpan</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> lagi}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> lagi}}</translation>
-<translation id="6364438453358674297">Alih keluar cadangan daripada sejarah?</translation>
-<translation id="6369229450655021117">Dari sini, anda boleh membuat carian di web, berkongsi dengan rakan dan melihat halaman yang terbuka</translation>
-<translation id="6378173571450987352">Butiran: Diisih mengikut jumlah data yang digunakan</translation>
-<translation id="6381421346744604172">Tapak web digelapkan</translation>
-<translation id="6388207532828177975">Kosongkan &amp; tetapkan semula</translation>
-<translation id="6393863479814692971">Chrome memerlukan kebenaran untuk mengakses kamera dan mikrofon anda bagi tapak ini.</translation>
-<translation id="6395288395575013217">PAUTAN</translation>
-<translation id="6404511346730675251">Edit penanda halaman</translation>
-<translation id="6406506848690869874">Segerak</translation>
-<translation id="641643625718530986">Cetak…</translation>
-<translation id="6416782512398055893">Dimuat turun <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Terjemah Web</translation>
-<translation id="6433501201775827830">Pilih enjin carian anda</translation>
-<translation id="6437478888915024427">Maklumat halaman</translation>
-<translation id="6441734959916820584">Nama terlalu panjang</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Imej}other{# Imej}}</translation>
-<translation id="6447842834002726250">Kuki</translation>
-<translation id="6461962085415701688">Tidak dapat membuka fail</translation>
-<translation id="6464977750820128603">Anda dapat melihat tapak yang anda lawati dalam Chrome dan menetapkan pemasa untuk tapak tersebut.\n\nGoogle menerima maklumat tentang tapak yang pemasanya telah anda tetapkan dan tempoh anda berada di tapak itu. Maklumat ini digunakan untuk menambah baik Kesejahteraan Digital.</translation>
-<translation id="6475951671322991020">Muat turun video</translation>
-<translation id="6482749332252372425">Muat turun <ph name="FILE_NAME" /> gagal kerana ruang storan tidak mencukupi.</translation>
-<translation id="6496823230996795692">Untuk menggunakan <ph name="APP_NAME" /> buat kali pertama, sila bersambung ke Internet.</translation>
-<translation id="6508722015517270189">Mulakan semula Chrome</translation>
-<translation id="6527303717912515753">Kongsi</translation>
-<translation id="6532866250404780454">Tapak yang anda lawati dalam Chrome tidak akan dipaparkan. Semua pemasa tapak akan dipadamkan.</translation>
-<translation id="6534565668554028783">Google mengambil masa terlalu lama untuk bertindak balas</translation>
-<translation id="6538442820324228105">Dimuat turun <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Kesilapan telah berlaku. Cuba sebentar lagi.</translation>
-<translation id="654446541061731451">Pilih tab untuk dipancarkan</translation>
-<translation id="6545017243486555795">Hapuskan Semua Data</translation>
-<translation id="6545864417968258051">Pengimbasan Bluetooth</translation>
-<translation id="6560414384669816528">Cari dengan Sogou</translation>
-<translation id="6566259936974865419">Chrome telah menjimatkan data anda sebanyak <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Sentiasa benarkan</translation>
-<translation id="6573431926118603307">Tab yang telah anda buka dalam Chrome pada peranti anda yang lain akan dipaparkan di sini.</translation>
-<translation id="6583199322650523874">Tandai halaman semasa</translation>
-<translation id="6593061639179217415">Tapak desktop</translation>
-<translation id="6600954340915313787">Disalin ke Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Kandungan yang dilindungi</translation>
-<translation id="6627583120233659107">Edit folder</translation>
-<translation id="6643016212128521049">Kosongkan</translation>
-<translation id="6643649862576733715">Isih mengikut jumlah penjimatan data</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> lagi}other{<ph name="CONTACT_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> lagi}}</translation>
-<translation id="6649642165559792194">Pratonton imej <ph name="BEGIN_NEW" />Baharu<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome memerlukan akses lokasi untuk mengimbas peranti. <ph name="BEGIN_LINK" />Kemaskinikan kebenaran<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Kata laluan</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Buka dalam <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Notis Privasi Chrome</translation>
-<translation id="6676840375528380067">Kosongkan data Chrome anda daripada peranti ini?</translation>
-<translation id="6697492270171225480">Tunjukkan cadangan untuk halaman yang serupa apabila halaman tidak ditemui</translation>
-<translation id="6697947395630195233">Chrome memerlukan akses kepada lokasi anda untuk berkongsi lokasi dengan tapak ini.</translation>
-<translation id="6698801883190606802">Urus data yang disegerakkan</translation>
-<translation id="6699370405921460408">Pelayan Google akan mengoptimumkan halaman yang anda lawati.</translation>
-<translation id="6706288973712894588">Anda luar talian sekarang.\n<ph name="BEGIN_LINK" />Terokai suapan luar talian anda.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Berita</translation>
-<translation id="6710213216561001401">Sebelumnya</translation>
-<translation id="671481426037969117">Pemasa <ph name="FQDN" /> anda sudah tamat. Pemasa akan bermula lagi esok.</translation>
-<translation id="6738867403308150051">Memuat turun…</translation>
-<translation id="6746124502594467657">Alihkan ke bawah</translation>
-<translation id="6766622839693428701">Leret ke bawah untuk tutup.</translation>
-<translation id="6766758767654711248">Ketik untuk pergi ke tapak</translation>
-<translation id="6767294960381293877">Senarai peranti untuk berkongsi tab dibuka pada ketinggian separuh.</translation>
-<translation id="6782111308708962316">Halang tapak web pihak ketiga daripada menyimpan dan membaca data kuki</translation>
-<translation id="6790428901817661496">Mainkan</translation>
-<translation id="6811034713472274749">Halaman sedia untuk dipaparkan</translation>
-<translation id="6818926723028410516">Pilih item</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Terjemah</translation>
-<translation id="6845325883481699275">Bantu tingkatkan keselamatan Chrome</translation>
-<translation id="6846298663435243399">Memuatkan…</translation>
-<translation id="6850409657436465440">Muat turun anda masih berlangsung</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> tab telah ditutup</translation>
-<translation id="6864459304226931083">Muat turun imej</translation>
-<translation id="6865313869410766144">Autolengkap data borang</translation>
-<translation id="688738109438487280">Tambahkan data sedia ada pada <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Buka kunci untuk menyalin kata laluan anda</translation>
-<translation id="6896758677409633944">Salin</translation>
-<translation id="6910211073230771657">Dipadamkan</translation>
-<translation id="6912998170423641340">Sekat tapak daripada membaca teks dan imej daripada papan keratan</translation>
-<translation id="6914783257214138813">Kata laluan anda akan kelihatan kepada sesiapa yang dapat melihat fail yang dieksport.</translation>
-<translation id="6942665639005891494">Tukar lokasi muat turun lalai pada bila-bila masa menggunakan pilihan menu Tetapan</translation>
-<translation id="6945221475159498467">Pilih</translation>
-<translation id="6963642900430330478">Halaman ini berbahaya. Maklumat tapak</translation>
-<translation id="6963766334940102469">Padamkan penanda halaman</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Sepanjang masa</translation>
-<translation id="6981982820502123353">Kebolehcapaian</translation>
-<translation id="6989267951144302301">Tidak dapat memuat turun</translation>
-<translation id="6990079615885386641">Dapatkan apl daripada Gedung Play Google: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Tanya dahulu sebelum membenarkan tapak menggunakan mikrofon anda (disyorkan)</translation>
-<translation id="7015203776128479407">Penyediaan penyegerakan awal tidak diselesaikan. Penyegerakan dimatikan.</translation>
-<translation id="7016516562562142042">Dibenarkan untuk enjin carian semasa</translation>
-<translation id="7022756207310403729">Buka dalam penyemak imbas</translation>
-<translation id="702463548815491781">Disyorkan apabila TalkBack atau Akses Suis dihidupkan</translation>
-<translation id="7029809446516969842">Kata laluan</translation>
-<translation id="7053983685419859001">Sekat</translation>
-<translation id="7055152154916055070">Ubah hala disekat:</translation>
-<translation id="7063006564040364415">Tidak dapat bersambung ke pelayan yang disegerakkan.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 dipilih}other{# dipilih}}</translation>
-<translation id="7071521146534760487">Urus akaun</translation>
-<translation id="7077143737582773186">Kad SD</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> dipilih. Pilihan tersedia berhampiran bahagian atas skrin</translation>
-<translation id="7121362699166175603">Mengosongkan sejarah dan autoselesai dalam bar alamat. Akaun Google anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Benarkan untuk enjin carian semasa</translation>
-<translation id="7138678301420049075">Lain-lain</translation>
-<translation id="7141896414559753902">Sekat tapak daripada memaparkan tetingkap timbul dan ubah hala (disyorkan)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Muatkan halaman asal<ph name="END_LINK" /> daripada <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">24 jam yang lalu</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Anda boleh menukar perkara ini selepas ini dalam Tetapan</translation>
-<translation id="7180611975245234373">Muat semula</translation>
-<translation id="7189372733857464326">Menunggu Perkhidmatan Google Play selesai mengemas kini</translation>
-<translation id="7191430249889272776">Tab dibuka di latar belakang.</translation>
-<translation id="723171743924126238">Pilih imej</translation>
-<translation id="7233236755231902816">Untuk melihat web dalam bahasa anda, dapatkan versi terkini Chrome</translation>
-<translation id="7243308994586599757">Pilihan tersedia berhampiran bahagian bawah skrin</translation>
-<translation id="7248069434667874558">Pastikan penyegerakan telah dihidupkan dalam Chrome pada <ph name="TARGET_DEVICE_NAME" /></translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> dipilih</translation>
-<translation id="7274013316676448362">Tapak yang disekat</translation>
-<translation id="7290209999329137901">Penamaan semula tidak tersedia</translation>
-<translation id="7291387454912369099">Assistant Mencetuskan Pembayaran</translation>
-<translation id="7293171162284876153">Untuk memulakan penyegerakan, hidupkan "Segerakkan data Chrome anda".</translation>
-<translation id="729975465115245577">Peranti anda tiada apl untuk menyimpan fail kata laluan.</translation>
-<translation id="7302081693174882195">Butiran: Diisih mengikut jumlah penjimatan data</translation>
-<translation id="7328017930301109123">Dalam mod Ringkas, Chrome memuatkan halaman lebih pantas dan mengurangkan penggunaan data sehingga 60 peratus.</translation>
-<translation id="7333031090786104871">Masih menambahkan tapak yang terdahulu</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Kongsi 1 item yang dipilih}other{Kongsi # item yang dipilih}}</translation>
 <translation id="7359002509206457351">Akses kaedah pembayaran</translation>
+<translation id="8026334261755873520">Kosongkan data semakan imbas</translation>
+<translation id="1291207594882862231">Hapuskan sejarah, kuki, data tapak, cache...</translation>
+<translation id="7814200940910057384">Data Brave dikosongkan</translation>
+<translation id="1664855196866195614">Data yang dipilih telah dialih keluar daripada Brave dan peranti anda yang disegerakkan.
+
+Akaun Brave Software anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain seperti carian dan aktiviti daripada perkhidmatan Brave Software yang lain di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Imej dan fail dicache</translation>
+<translation id="2496180316473517155">Sejarah penyemakan imbas</translation>
+<translation id="2546283357679194313">Kuki dan data tapak</translation>
+<translation id="8662811608048051533">Mengelog anda keluar daripada kebanyakan tapak.</translation>
+<translation id="8218628800671693884">Mengelog anda keluar daripada kebanyakan tapak. Anda tidak akan dilog keluar daripada Akaun Brave Software anda.</translation>
+<translation id="2017836877785168846">Kosongkan sejarah dan pelengkapan automatik dalam bar alamat.</translation>
+<translation id="8096327394278038498">Mengosongkan sejarah dan autoselesai dalam bar alamat. Akaun Brave Software anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Mengosongkan sejarah daripada semua peranti yang dilog masuk. Akaun Brave Software anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Kata laluan disimpan</translation>
+<translation id="6865313869410766144">Autolengkap data borang</translation>
+<translation id="7562080006725997899">Mengosongkan data penyemakan imbas</translation>
+<translation id="5487521232677179737">Kosongkan data</translation>
+<translation id="7498271377022651285">Sila tunggu…</translation>
+<translation id="784934925303690534">Julat masa</translation>
+<translation id="1718835860248848330">Jam terakhir</translation>
+<translation id="7149893636342594995">24 jam yang lalu</translation>
+<translation id="5648166631817621825">7 hari terakhir</translation>
+<translation id="8571213806525832805">4 minggu terakhir</translation>
+<translation id="5854790677617711513">Lebih lama daripada 30 hari</translation>
+<translation id="6979737339423435258">Sepanjang masa</translation>
+<translation id="982182592107339124">Ini akan memadamkan data untuk semua tapak web, termasuk:</translation>
+<translation id="6643016212128521049">Kosongkan</translation>
+<translation id="7641339528570811325">Kosongkan data semakan imbas...</translation>
+<translation id="1670399744444387456">Asas</translation>
+<translation id="3245261285041759672">Akaun Brave Software anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain di <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Tapak yang disekat</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> item dipadamkan</translation>
+<translation id="1121094540300013208">Laporan penggunaan dan keranapan</translation>
+<translation id="9079153198295609735">Hantar statistik penggunaan dan laporan nahas kepada Brave Software secara automatik</translation>
+<translation id="6981982820502123353">Kebolehcapaian</translation>
+<translation id="2387895666653383613">Penskalaan teks</translation>
+<translation id="2321958826496381788">Seret gelangsar sehingga anda selesa membaca teks ini. Teks harus kelihatan sekurang-kurangnya sebesar ini selepas mengetik dua kali pada perenggan.</translation>
+<translation id="3895926599014793903">Zum didaya paksa</translation>
+<translation id="5668404140385795438">Mengatasi permintaan tapak web untuk menghalang zum masuk</translation>
+<translation id="4149994727733219643">Paparan ringkas bagi halaman web</translation>
+<translation id="9100505651305367705">Tawarkan untuk memaparkan artikel dalam paparan mudah apabila disokong</translation>
+<translation id="1409426117486808224">Paparan ringkas bagi tab terbuka</translation>
+<translation id="702463548815491781">Disyorkan apabila TalkBack atau Akses Suis dihidupkan</translation>
+<translation id="8284326494547611709">Kapsyen</translation>
+<translation id="4165986682804962316">Tetapan tapak</translation>
+<translation id="6295158916970320988">Semua tapak</translation>
+<translation id="8380167699614421159">Tapak ini menyiarkan iklan yang mengganggu atau mengelirukan</translation>
+<translation id="1919345977826869612">Iklan</translation>
+<translation id="410351446219883937">Automain</translation>
+<translation id="6447842834002726250">Kuki</translation>
+<translation id="6196640612572343990">Sekat kuki pihak ketiga</translation>
+<translation id="6782111308708962316">Halang tapak web pihak ketiga daripada menyimpan dan membaca data kuki</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Tetingkap timbul dan ubah hala</translation>
+<translation id="4751476147751820511">Penderia gerakan atau cahaya</translation>
+<translation id="1717218214683051432">Penderia gerakan</translation>
+<translation id="2091887806945687916">Bunyi</translation>
+<translation id="2586657967955657006">Papan Keratan</translation>
+<translation id="6320088164292336938">Getar</translation>
+<translation id="4226663524361240545">Pemberitahuan boleh menggetarkan peranti</translation>
+<translation id="1446450296470737166">Benarkan kawalan penuh peranti MIDI</translation>
+<translation id="3744111561329211289">Penyegerakan latar belakang</translation>
+<translation id="5649053991847567735">Muat turun automatik</translation>
+<translation id="6181444274883918285">Tambah pengecualian tapak</translation>
+<translation id="5313967007315987356">Tambahkan tapak</translation>
+<translation id="1369915414381695676">Tapak <ph name="SITE_NAME"/> telah ditambahkan</translation>
+<translation id="7837721118676387834">Benarkan video yang diredamkan dimainkan secara automatik untuk tapak web tertentu.</translation>
+<translation id="2621115761605608342">Benarkan JavaScript untuk tapak tertentu.</translation>
+<translation id="8801436777607969138">Sekat JavaScript untuk tapak tertentu.</translation>
+<translation id="8372893542064058268">Benarkan Penyegerakan Latar Belakang untuk tapak tertentu</translation>
+<translation id="358794129225322306">Benarkan tapak memuat turun berbilang fail secara automatik.</translation>
+<translation id="4008040567710660924">Benarkan kuki untuk tapak tertentu.</translation>
+<translation id="8958424370300090006">Sekat kuki untuk tapak tertentu.</translation>
+<translation id="7882806643839505685">Benarkan bunyi untuk tapak tertentu.</translation>
+<translation id="4468959413250150279">Redam bunyi untuk tapak tertentu.</translation>
+<translation id="1994173015038366702">URL tapak</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Penggunaan</translation>
+<translation id="5804241973901381774">Kebenaran</translation>
+<translation id="4278390842282768270">Dibenarkan</translation>
+<translation id="5677928146339483299">Disekat</translation>
+<translation id="1984937141057606926">Dibenarkan, kecuali pihak ketiga</translation>
+<translation id="7423098979219808738">Tanya dahulu</translation>
+<translation id="8116925261070264013">Diredam</translation>
+<translation id="8300705686683892304">Diurus oleh apl</translation>
+<translation id="6192792657125177640">Pengecualian</translation>
+<translation id="257931822824936280">Dikembangkan - klik untuk meruntuhkan.</translation>
+<translation id="5100237604440890931">Diruntuhkan - klik untuk mengembangkan.</translation>
+<translation id="857943718398505171">Dibenarkan (disyorkan)</translation>
+<translation id="2913331724188855103">Benarkan tapak untuk menyimpan dan membaca data kuki (disyorkan)</translation>
+<translation id="7445411102860286510">Benarkan tapak untuk memainkan video yang diredam secara automatik (disyorkan)</translation>
+<translation id="5335288049665977812">Benarkan tapak menjalankan JavaScript (disyorkan)</translation>
+<translation id="5527111080432883924">Tanya sebelum membenarkan tapak membaca teks dan imej daripada papan keratan (disyorkan)</translation>
+<translation id="6912998170423641340">Sekat tapak daripada membaca teks dan imej daripada papan keratan</translation>
+<translation id="7423538860840206698">Disekat daripada membaca papan keratan</translation>
+<translation id="3955193568934677022">Benarkan tapak untuk memainkan kandungan yang dilindungi (disyorkan)</translation>
+<translation id="445467742685312942">Benarkan tapak memainkan kandungan yang dilindungi</translation>
+<translation id="2107397443965016585">Tanya sebelum membenarkan tapak memainkan kandungan yang dilindungi (disyorkan)</translation>
+<translation id="2910701580606108292">Tanya sebelum membenarkan tapak memainkan kandungan yang dilindungi</translation>
+<translation id="757524316907819857">Sekat tapak daripada memainkan kandungan yang dilindungi</translation>
+<translation id="3277252321222022663">Benarkan tapak mengakses penderia (disyorkan)</translation>
+<translation id="5048398596102334565">Benarkan tapak mengakses penderia gerakan (disyorkan)</translation>
+<translation id="8816026460808729765">Sekat tapak daripada mengakses penderia</translation>
+<translation id="169515064810179024">Sekat tapak daripada mengakses penderia gerakan</translation>
+<translation id="1660204651932907780">Benarkan tapak untuk memainkan bunyi (disyorkan)</translation>
+<translation id="3600792891314830896">Redam tapak yang memainkan bunyi</translation>
+<translation id="1743802530341753419">Tanya sebelum membenarkan tapak menyambung ke peranti (disyorkan)</translation>
+<translation id="851751545965956758">Sekat tapak daripada menyambung ke peranti</translation>
+<translation id="7141896414559753902">Sekat tapak daripada memaparkan tetingkap timbul dan ubah hala (disyorkan)</translation>
+<translation id="5494752089476963479">Sekat iklan di tapak yang menyiarkan iklan yang mengganggu atau mengelirukan</translation>
+<translation id="3123473560110926937">Disekat di sesetengah tapak</translation>
+<translation id="965817943346481315">Sekat jika tapak menyiarkan iklan yang mengganggu atau mengelirukan (disyorkan)</translation>
+<translation id="3386292677130313581">Tanya sebelum membenarkan tapak mengetahui lokasi anda (disyorkan)</translation>
+<translation id="9139068048179869749">Tanya sebelum membenarkan tapak menghantar pemberitahuan (disyorkan)</translation>
+<translation id="4479647676395637221">Tanya dahulu sebelum membenarkan tapak menggunakan kamera anda (disyorkan)</translation>
+<translation id="6992289844737586249">Tanya dahulu sebelum membenarkan tapak menggunakan mikrofon anda (disyorkan)</translation>
+<translation id="2289270750774289114">Tanya apabila tapak mahu mencari peranti Bluetooth berdekatan (disyorkan)</translation>
+<translation id="7053983685419859001">Sekat</translation>
+<translation id="7128222689758636196">Benarkan untuk enjin carian semasa</translation>
+<translation id="7589445247086920869">Sekat untuk enjin carian semasa</translation>
+<translation id="6388207532828177975">Kosongkan &amp; tetapkan semula</translation>
+<translation id="7999064672810608036">Anda pasti ingin mengosongkan semua data setempat, termasuk kuki dan menetapkan semula semua kebenaran untuk tapak web ini?</translation>
+<translation id="2822354292072154809">Adakah anda pasti mahu menetapkan semula semua kebenaran tapak untuk <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Buang data yg disimpan</translation>
+<translation id="5902828464777634901">Semua data setempat yang disimpan oleh tapak web ini, termasuk kuki, akan dipadamkan.</translation>
+<translation id="119944043368869598">Kosongkan semua</translation>
+<translation id="2490684707762498678">Diurus oleh <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Buka tetapan pemberitahuan</translation>
+<translation id="1404122904123200417">Dibenamkan dalam <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Fail yang disimpan oleh tapak web akan dipaparkan di sini</translation>
+<translation id="4181841719683918333">Bahasa</translation>
+<translation id="2647434099613338025">Tambah bahasa</translation>
+<translation id="1952172573699511566">Tapak web akan menunjukkan teks dalam bahasa pilihan anda, jika boleh.</translation>
+<translation id="8559990750235505898">Tawaran untuk menterjemah halaman dalam bahasa lain</translation>
+<translation id="4719927025381752090">Tawaran untuk menterjemah</translation>
+<translation id="8156139159503939589">Apakah bahasa yang anda gunakan untuk membaca?</translation>
+<translation id="5689516760719285838">Lokasi</translation>
+<translation id="2440823041667407902">Akses lokasi</translation>
+<translation id="2023546461831060654">Hidupkan kebenaran untuk Brave dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Hidupkan kebenaran untuk Brave dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Untuk membenarkan Brave mengakses lokasi anda, hidupkan lokasi dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/> juga.</translation>
+<translation id="1028853271388022585">Untuk membenarkan Brave mengakses kamera anda, hidupkan kamera dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/> juga.</translation>
+<translation id="2913721282607281710">Untuk membenarkan Brave menghantar pemberitahuan kepada anda, hidupkan pemberitahuan dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/> juga.</translation>
+<translation id="8753483718490035722">Untuk membenarkan Brave mengakses mikrofon anda, hidupkan mikrofon dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/> juga.</translation>
+<translation id="1887786770086287077">Akses lokasi dimatikan untuk peranti ini. Hidupkannya dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Akses lokasi turut dimatikan untuk peranti ini. Hidupkannya dalam <ph name="BEGIN_LINK"/>Tetapan Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Akses kamera anda</translation>
+<translation id="945632385593298557">Akses mikrofon anda</translation>
+<translation id="6612358246767739896">Kandungan yang dilindungi</translation>
+<translation id="885701979325669005">Storan</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> data disimpan</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Batalkan kebenaran peranti</translation>
+<translation id="4962975101802056554">Batalkan semua kebenaran untuk peranti</translation>
+<translation id="6545864417968258051">Pengimbasan Bluetooth</translation>
+<translation id="4411535500181276704">Mod Ringkas</translation>
+<translation id="7821588508402923572">Penjimatan data anda akan dipaparkan di sini</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> disimpan</translation>
+<translation id="8569404424186215731">sejak <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Dalam mod Ringkas, Brave memuatkan halaman lebih pantas dan mengurangkan penggunaan data sehingga 60 peratus.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> penjimatan data</translation>
+<translation id="7494974237137038751">data disimpan</translation>
+<translation id="6111020039983847643">data digunakan</translation>
+<translation id="7413229368719586778">Tarikh mula <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Tarikh tamat <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Isih mengikut tapak</translation>
+<translation id="5864174910718532887">Butiran: Diisih mengikut nama tapak</translation>
+<translation id="116280672541001035">Digunakan</translation>
+<translation id="8349013245300336738">Isih mengikut jumlah data yang digunakan</translation>
+<translation id="6378173571450987352">Butiran: Diisih mengikut jumlah data yang digunakan</translation>
+<translation id="2631006050119455616">Disimpan</translation>
+<translation id="6643649862576733715">Isih mengikut jumlah penjimatan data</translation>
+<translation id="7302081693174882195">Butiran: Diisih mengikut jumlah penjimatan data</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> digunakan</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> disimpan</translation>
+<translation id="2156074688469523661">Baki tapak (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Lain-lain</translation>
+<translation id="4913161338056004800">Tetapkan semula perangkaan</translation>
+<translation id="1856325424225101786">Tetapkan semula mod Ringkas?</translation>
+<translation id="3658159451045945436">Penetapan semula akan memadamkan sejarah penjimatan data anda, termasuk senarai tapak yang dilawati.</translation>
+<translation id="3295530008794733555">Semak imbas lebih pantas. Gunakan kurang data.</translation>
+<translation id="7340390500800578919">Dalam mod Ringkas, Brave memuatkan halaman lebih pantas dan mengurangkan penggunaan data sehingga 60 peratus. Untuk mengoptimumkan halaman yang anda lawati, Brave menghantar trafik web anda kepada Brave Software. <ph name="BEGIN_LINK"/>Ketahui lebih lanjut<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Hidupkan mod Ringkas</translation>
+<translation id="4493497663118223949">Mod Ringkas dihidupkan</translation>
+<translation id="7559975015014302720">Mod Ringkas dimatikan</translation>
+<translation id="7606077192958116810">Mod Ringkas dihidupkan. Urus dalam Tetapan.</translation>
+<translation id="4714588616299687897">Jimat sehingga 60% daripada data anda</translation>
+<translation id="1006927014032731288">Pelayan Brave Software akan mengoptimumkan halaman yang anda lawati.</translation>
+<translation id="3257320067425202300">Brave telah menjimatkan data anda sebanyak <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave telah menjimatkan data anda sebanyak <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Lokasi muat turun</translation>
+<translation id="7077143737582773186">Kad SD</translation>
+<translation id="7762668264895820836">Kad SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Tanya tempat fail hendak disimpan</translation>
+<translation id="6192333916571137726">Muat turun fail</translation>
+<translation id="1672586136351118594">Jangan tunjukkan lagi</translation>
+<translation id="2650751991977523696">Muat turun fail sekali lagi?</translation>
+<translation id="8664979001105139458">Nama fail sudah wujud</translation>
+<translation id="488187801263602086">Namakan semula fail</translation>
+<translation id="5686790454216892815">Nama fail terlalu panjang</translation>
+<translation id="7454641608352164238">Tidak cukup ruang</translation>
+<translation id="8972098258593396643">Muat turun ke folder lalai?</translation>
+<translation id="804335162455518893">Kad SD tidak ditemui</translation>
+<translation id="7475688122056506577">Kad SD tidak ditemui. Sesetengah fail anda mungkin tiada.</translation>
+<translation id="4198423547019359126">Tiada lokasi muat turun tersedia</translation>
+<translation id="8224471946457685718">Muat turun artikel untuk anda apabila menggunakan Wi-Fi</translation>
+<translation id="4970824347203572753">Tidak tersedia di lokasi anda</translation>
+<translation id="5500777121964041360">Mungkin tidak tersedia di lokasi anda</translation>
+<translation id="1173894706177603556">Namakan semula</translation>
+<translation id="1986685561493779662">Nama sudah wujud</translation>
+<translation id="6441734959916820584">Nama terlalu panjang</translation>
+<translation id="2923908459366352541">Nama tidak sah</translation>
+<translation id="7290209999329137901">Penamaan semula tidak tersedia</translation>
+<translation id="3334729583274622784">Tukar sambungan fail?</translation>
+<translation id="107147699690128016">Jika anda menukar sambungan fail, fail itu mungkin akan dibuka dalam aplikasi lain dan berkemungkinan mendatangkan bahaya kepada peranti anda.</translation>
+<translation id="8541922081612557424">Perihal Brave</translation>
+<translation id="5311273890481188673">Hak Cipta <ph name="YEAR"/> Brave Software LLC. Hak cipta terpelihara.</translation>
+<translation id="1416550906796893042">Versi aplikasi</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Dikemas kini <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistem pengendalian</translation>
+<translation id="3968054912784331254">Kemas kini Brave tidak disokong untuk versi Android ini lagi</translation>
+<translation id="7665369617277396874">Tambah akaun</translation>
+<translation id="649070405679044769">Dilog masuk ke Brave Software sebagai</translation>
+<translation id="6234515504547364178">Log keluar dari Brave</translation>
+<translation id="5324858694974489420">Tetapan Ibu Bapa</translation>
+<translation id="8920114477895755567">Menunggu butiran ibu bapa.</translation>
+<translation id="5512137114520586844">Akaun ini diurus oleh <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Akaun ini diurus oleh <ph name="PARENT_NAME_1"/> dan <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Kandungan</translation>
+<translation id="5403644198645076998">Benarkan tapak tertentu sahaja</translation>
+<translation id="8641930654639604085">Cuba menyekat tapak dewasa</translation>
+<translation id="5639724618331995626">Benarkan semua tapak</translation>
+<translation id="796823723482603597">Dikuasakan oleh Brave</translation>
+<translation id="6324034347079777476">Penyegerakan sistem Android dilumpuhkan</translation>
+<translation id="5127805178023152808">Penyegerakan dimatikan</translation>
+<translation id="7015203776128479407">Penyediaan penyegerakan awal tidak diselesaikan. Penyegerakan dimatikan.</translation>
+<translation id="2497852260688568942">Penyegerakan dilumpuhkan oleh pentadbir anda</translation>
+<translation id="9100610230175265781">Frasa laluan diperlukan</translation>
+<translation id="6108923351542677676">Persediaan sedang berjalan...</translation>
+<translation id="4062305924942672200">Maklumat undang-undang</translation>
+<translation id="4256782883801055595">Lesen sumber terbuka</translation>
+<translation id="1138681184697033370">Syarat Perkhidmatan Brave</translation>
+<translation id="7392539049993970338">Notis Privasi Brave</translation>
+<translation id="2677748264148917807">Tinggalkan</translation>
+<translation id="5556459405103347317">Muat Semula</translation>
+<translation id="1623104350909869708">Halang halaman ini daripada mencipta dialog tambahan</translation>
+<translation id="2968755619301702150">Pemapar sijil</translation>
+<translation id="1360432990279830238">Log keluar dan matikan penyegerakan?</translation>
+<translation id="8581481290581777242">Kosongkan data Brave anda daripada peranti ini?</translation>
+<translation id="1318865768845061710">Penanda halaman, sejarah, kata laluan dan data Brave yang lain tidak akan disegerakkan ke Akaun Brave Software anda lagi</translation>
+<translation id="3325020657155065477">Selain itu, kosongkan data Brave anda daripada peranti ini</translation>
+<translation id="6136448902816743006">Oleh sebab anda log keluar daripada akaun yang diurus oleh <ph name="DOMAIN_NAME"/>, data Brave anda akan dipadamkan daripada peranti ini. Data tersebut akan kekal dalam Akaun Brave Software anda.</translation>
+<translation id="1853026300647876496">Menghubungi Brave Software. Mungkin mengambil sedikit masa…</translation>
+<translation id="2328985652426384049">Tidak dapat log masuk</translation>
+<translation id="7723158744459952869">Brave Software mengambil masa terlalu lama untuk bertindak balas</translation>
+<translation id="4572422548854449519">Log masuk ke akaun terurus</translation>
+<translation id="2689656545739939160">Anda log masuk dengan akaun yang diurus oleh <ph name="MANAGED_DOMAIN"/> dan memberikan kawalan terhadap data Brave anda kepada pentadbirnya. Data anda akan terikat secara kekal kepada akaun ini. Tindakan log keluar daripada Brave akan memadamkan data anda daripada peranti ini, tetapi data itu akan kekal disimpan dalam Akaun Brave Software anda.</translation>
+<translation id="1749561566933687563">Segerakkan penanda halaman anda</translation>
+<translation id="4242533952199664413">Buka tetapan</translation>
+<translation id="1111673857033749125">Penanda halaman yang disimpan pada peranti anda yang lain akan dipaparkan di sini.</translation>
+<translation id="8636825310635137004">Hidupkan penyegerakan untuk mendapatkan tab daripada peranti anda yang lain.</translation>
+<translation id="3269956123044984603">Untuk mendapatkan tab daripada peranti anda yang lain, hidupkan "Auto segerak data" dalam tetapan akaun Android.</translation>
+<translation id="5157964048453367290">Tab yang telah anda buka dalam Brave pada peranti anda yang lain akan dipaparkan di sini.</translation>
+<translation id="4684427112815847243">Segerakkan semua</translation>
+<translation id="2709516037105925701">Autoisi</translation>
+<translation id="8820817407110198400">Penanda buku</translation>
+<translation id="1644574205037202324">Sejarah</translation>
+<translation id="17513872634828108">Buka tab</translation>
+<translation id="1320169905922104972">Kad kredit dan alamat yang menggunakan Brave Software Pay</translation>
+<translation id="6337234675334993532">Penyulitan</translation>
+<translation id="6698801883190606802">Urus data yang disegerakkan</translation>
+<translation id="3598578758776312506">Sulitkan kata laluan dengan bukti kelayakan Brave Software</translation>
+<translation id="7810580217418711046">Sulitkan data yang disegerakkan dengan kata laluan Brave Software bermula dari <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Sulitkan data yang disegerakkan dengan ungkapan laluan penyegerakan anda sendiri</translation>
+<translation id="2996291259634659425">Buat ungkapan laluan</translation>
+<translation id="5713644099811900409">Akaun Brave Software</translation>
+<translation id="8997474919031554666">Penyulitan ungkapan laluan tidak termasuk kaedah pembayaran dan alamat daripada Brave Software Pay. Hanya orang yang mempunyai ungkapan laluan anda boleh membaca data anda yang disulitkan. Ungkapan laluan tidak dihantar atau disimpan oleh Brave Software. Jika anda terlupa ungkapan laluan atau ingin menukar tetapan ini, anda perlu menetapkan semula penyegerakan. <ph name="BEGIN_LINK"/>Ketahui lebih lanjut<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Frasa laluan</translation>
+<translation id="7772032839648071052">Sahkan frasa laluan</translation>
+<translation id="5304593522240415983">Medan ini tidak boleh kosong</translation>
+<translation id="321773570071367578">Jika anda terlupa ungkapan laluan atau ingin menukar tetapan ini, <ph name="BEGIN_LINK"/>tetapkan semula penyegerakan<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Frasa laluan tidak sepadan</translation>
+<translation id="5149495116300586333">Penyulitan ungkapan laluan tidak termasuk kaedah pembayaran dan alamat daripada Brave Software Pay.
+
+Untuk menukar tetapan ini, <ph name="BEGIN_LINK"/>tetapkan semula penyegerakan<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Frasa laluan tidak betul</translation>
+<translation id="5414836363063783498">Mengesahkan…</translation>
+<translation id="6846298663435243399">Memuatkan…</translation>
+<translation id="5517095782334947753">Anda mempunyai penanda halaman, sejarah, kata laluan dan tetapan lain daripada <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Gabungkan data saya</translation>
+<translation id="688738109438487280">Tambahkan data sedia ada pada <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Biarkan data saya diasingkan</translation>
+<translation id="1145536944570833626">Padam data sedia ada.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> mahu digandingkan</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Dapatkan bantuan<ph name="END_LINK"/> semasa mengimbas peranti…</translation>
+<translation id="5817918615728894473">Gandingkan</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Dapatkan bantuan<ph name="END_LINK1"/> atau <ph name="BEGIN_LINK2"/>imbas semula<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Tiada peranti yang serasi ditemui</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Hidupkan Bluetooth<ph name="END_LINK"/> untuk membenarkan penggandingan</translation>
+<translation id="998321811308652668">Brave tidak dapat menghidupkan penyesuai Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Dapatkan bantuan<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave memerlukan akses lokasi untuk mengimbas peranti. <ph name="BEGIN_LINK"/>Kemaskinikan kebenaran<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave memerlukan akses lokasi untuk mengimbas peranti. Akses lokasi <ph name="BEGIN_LINK"/>dimatikan untuk peranti ini<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave memerlukan akses lokasi untuk mengimbas peranti. <ph name="BEGIN_LINK1"/>Kemas kini kebenaran<ph name="END_LINK1"/>. Akses lokasi turut <ph name="BEGIN_LINK2"/>dimatikan untuk peranti ini<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Peranti Bersambung</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Tahap Kekuatan Isyarat: # bar}other{Tahap Kekuatan Isyarat: # bar}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> mahu mengimbas untuk mengesan peranti Bluetooth berdekatan. Peranti berikut telah dijumpai:</translation>
+<translation id="8368027906805972958">Peranti tidak diketahui atau tidak disokong (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Penyegerakan tidak berfungsi</translation>
+<translation id="1810845389119482123">Penyediaan penyegerakan permulaan belum selesai</translation>
+<translation id="3235722914093408050">Buka ttpn Android dan dayakan smla pnyegerakan sistem Android utk mulakan pnyegerakan Brave</translation>
+<translation id="3367813778245106622">Log masuk semula untuk memulakan penyegerakan</translation>
+<translation id="974555521953189084">Masukkan ungkapan laluan anda untuk memulakan penyegerakan</translation>
+<translation id="2997266899014181325">Untuk memulakan penyegerakan, hidupkan "Segerakkan data Brave anda".</translation>
+<translation id="8260126382462817229">Cuba log masuk semula</translation>
+<translation id="5919204609460789179">Kemas kini <ph name="PRODUCT_NAME"/> untuk memulakan penyegerakan</translation>
+<translation id="397583555483684758">Penyegerakan telah berhenti berfungsi</translation>
+<translation id="1966710179511230534">Sila kemas kini butiran log masuk anda.</translation>
+<translation id="7063006564040364415">Tidak dapat bersambung ke pelayan yang disegerakkan.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> telah lapuk.</translation>
+<translation id="4170011742729630528">Perkhidmatan tidak tersedia; cuba lagi kemudian.</translation>
+<translation id="7947953824732555851">Terima dan log masuk</translation>
+<translation id="8583805026567836021">Menghapuskan data akaun</translation>
+<translation id="8310344678080805313">Tab standard</translation>
+<translation id="5748802427693696783">Beralih ke tab standard</translation>
+<translation id="7998918019931843664">Buka semula tab yang ditutup</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, tab</translation>
+<translation id="4452411734226507615">Tutup tab <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Pilihan tersedia berhampiran bahagian bawah skrin</translation>
+<translation id="4060598801229743805">Pilihan tersedia berhampiran bahagian atas skrin</translation>
+<translation id="2810645512293415242">Halaman diringkaskan untuk menjimatkan data dan memuatkan dengan lebih cepat.</translation>
+<translation id="3985215325736559418">Adakah anda ingin memuat turun <ph name="FILE_NAME"/> semula?</translation>
+<translation id="2450083983707403292">Adakah anda mahu mula memuat turun <ph name="FILE_NAME"/> sekali lagi?</translation>
+<translation id="7514365320538308">Muat Turun</translation>
+<translation id="545042621069398927">Mempercepatkan muat turun anda.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Memuat turun fail.}other{Memuat turun # fail.}}</translation>
+<translation id="543509235395288790">Memuat turun <ph name="COUNT"/> fail (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Memuat turun fail (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 muat turun selesai.}other{# muat turun selesai.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 muat turun gagal.}other{# muat turun gagal.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 muat turun belum selesai.}other{# muat turun belum selesai.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Butang <ph name="LINK_NAME"/> <ph name="MESSAGE"/></translation>
+<translation id="3205824638308738187">Hampir selesai!</translation>
+<translation id="3960299545138990065">Mulakan semula Brave</translation>
+<translation id="3771001275138982843">Tidak dapat memuat turun kemas kini</translation>
+<translation id="3888648114124182147">Memuat Turun Kemas Kini Brave…</translation>
+<translation id="1705567146636171298">Kemas Kini Brave</translation>
+<translation id="6195417478702700398">Untuk mendapatkan pengalaman penyemakan imbas yang terbaik, buka untuk mengemas kini Brave</translation>
+<translation id="3512968675351418494">Untuk melihat web dalam bahasa anda, dapatkan versi terkini Brave</translation>
+<translation id="6427112570124116297">Terjemah Web</translation>
+<translation id="1379423114029199501">Kemas kini untuk mendapatkan bahasa anda dalam versi terkini Brave</translation>
+<translation id="5684874026226664614">Op. Halaman ini tidak dapat diterjemahkan.</translation>
+<translation id="6831043979455480757">Terjemah</translation>
+<translation id="1285320974508926690">Jangan sekali-kali menterjemahkan tapak ini</translation>
+<translation id="773466115871691567">Sentiasa terjemahkan halaman dalam <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Jangan sekali-kali terjemahkan halaman dalam <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Lagi bahasa</translation>
+<translation id="290376772003165898">Halaman bukan dalam <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Halaman dalam <ph name="SOURCE_LANGUAGE"/> akan diterjemahkan kepada <ph name="TARGET_LANGUAGE"/> bermula dari sekarang</translation>
+<translation id="8339163506404995330">Halaman dalam <ph name="LANGUAGE"/> tidak akan diterjemahkan</translation>
+<translation id="5447765697759493033">Tapak ini tidak akan diterjemah</translation>
+<translation id="4880127995492972015">Terjemah…</translation>
+<translation id="641643625718530986">Cetak…</translation>
+<translation id="8909135823018751308">Kongsi…</translation>
+<translation id="4996978546172906250">Kongsi melalui</translation>
+<translation id="6333140779060797560">Kongsi melalui <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Terdapat masalah semasa mencetak halaman. Sila cuba sekali lagi.</translation>
+<translation id="3254409185687681395">Tanda halaman ini</translation>
+<translation id="497421865427891073">Ke hadapan</translation>
+<translation id="813082847718468539">Lihat maklumat tapak</translation>
+<translation id="2532336938189706096">Paparan Web</translation>
+<translation id="6005538289190791541">Kata laluan yang disyorkan</translation>
+<translation id="4634124774493850572">Gunakan kata laluan</translation>
+<translation id="8285489906452138776">Brave memerlukan kebenaran untuk mengakses kamera anda bagi tapak ini.</translation>
+<translation id="320189792589364011">Brave memerlukan kebenaran untuk mengakses mikrofon anda bagi tapak ini.</translation>
+<translation id="7988136689212463100">Brave memerlukan kebenaran untuk mengakses kamera dan mikrofon anda bagi tapak ini.</translation>
+<translation id="4931190655840828017">Brave memerlukan akses kepada lokasi anda untuk berkongsi lokasi dengan tapak ini.</translation>
+<translation id="3088191967551450609">Brave memerlukan akses storan untuk memuat turun fail.</translation>
+<translation id="8942627711005830162">Buka dalam tetingkap lain</translation>
+<translation id="4195643157523330669">Buka dalam tab baharu</translation>
+<translation id="1100066534610197918">Buka dlm tab baru dlm kumpulan</translation>
+<translation id="4860895144060829044">Hubungi</translation>
+<translation id="6896758677409633944">Salin</translation>
+<translation id="8393700583063109961">Hantar mesej</translation>
+<translation id="3557336313807607643">Tambahkan pada kenalan</translation>
+<translation id="4269820728363426813">Salin alamat pautan</translation>
+<translation id="1206892813135768548">Salin teks pautan</translation>
+<translation id="1204037785786432551">Muat turun pautan</translation>
+<translation id="6864459304226931083">Muat turun imej</translation>
+<translation id="8209050860603202033">Buka imej</translation>
+<translation id="8073388330009372546">Buka imej dalam tab baharu</translation>
+<translation id="6649642165559792194">Pratonton imej <ph name="BEGIN_NEW"/>Baharu<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Muatkan imej</translation>
+<translation id="3845332215609790146">Cari dengan Brave Software Lens <ph name="BEGIN_NEW"/>Baharu<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Cari imej ini di <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Kongsi imej</translation>
+<translation id="5833984609253377421">Kongsi pautan</translation>
+<translation id="6475951671322991020">Muat turun video</translation>
+<translation id="2317945146070194624">Buka dalam tab Brave baharu</translation>
+<translation id="7975379999046275268">Pratonton halaman <ph name="BEGIN_NEW"/>Baharu<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Memuat semula halaman</translation>
+<translation id="36525718899759834">Dapatkan apl daripada Gedung Play Brave Software: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Gelap</translation>
+<translation id="1807246157184219062">Cahaya</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Pilih tab untuk dipancarkan</translation>
+<translation id="8719023831149562936">Tidak dapat memancarkan tab semasa</translation>
+<translation id="2139186145475833000">Tambahkan kepada Skrin utama</translation>
+<translation id="4616150815774728855">Buka <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Tidak dapat membuka apl</translation>
+<translation id="5129038482087801250">Pasang apl web</translation>
+<translation id="3789841737615482174">Pasang</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> telah ditambahkan ke skrin Utama anda</translation>
+<translation id="7333031090786104871">Masih menambahkan tapak yang terdahulu</translation>
+<translation id="1036727731225946849">Menambahkan <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Ditambahkan pada Skrin utama</translation>
+<translation id="2146738493024040262">Buka Apl Segera</translation>
+<translation id="7016516562562142042">Dibenarkan untuk enjin carian semasa</translation>
+<translation id="6177111841848151710">Disekat untuk enjin carian semasa</translation>
+<translation id="145097072038377568">Dimatikan dalam Tetapan Android</translation>
+<translation id="8007176423574883786">Dimatikan untuk peranti ini</translation>
+<translation id="164269334534774161">Anda sedang melihat salinan luar talian halaman ini dari <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Halaman luar talian ini dari <ph name="CREATION_TIME"/> dan mungkin berbeza daripada versi dalam talian.</translation>
+<translation id="8840953339110955557">Halaman ini mungkin berbeza daripada versi dalam talian.</translation>
+<translation id="6405300764336705484">Kandungan ini adalah daripada <ph name="DOMAIN_NAME"/>, disampaikan oleh Brave Software.</translation>
+<translation id="1006017844123154345">Buka Dalam Talian</translation>
+<translation id="3326636747541519688">Halaman Lite disediakan oleh Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Muatkan halaman asal<ph name="END_LINK"/> daripada <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Jika anda kerap melihatnya, cuba <ph name="BEGIN_LINK"/>cadangan<ph name="END_LINK"/> ini.</translation>
+<translation id="8748850008226585750">Kandungan tersembunyi</translation>
+<translation id="3810973564298564668">Urus</translation>
+<translation id="5199929503336119739">Profil kerja</translation>
+<translation id="528192093759286357">Seret dari atas dan sentuh butang kembali untuk keluar daripada skrin penuh.</translation>
+<translation id="2836148919159985482">Sentuh butang kembali untuk keluar daripada skrin penuh.</translation>
+<translation id="3967822245660637423">Muat turun selesai</translation>
+<translation id="2434158240863470628">Muat turun selesai: <ph name="SEPARATOR"/><ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Muat turun gagal</translation>
+<translation id="1384959399684842514">Muat turun dijeda</translation>
+<translation id="1671236975893690980">Muat turun belum selesai...</translation>
+<translation id="5561549206367097665">Menunggu rangkaian…</translation>
+<translation id="5864419784173784555">Menunggu muat turun lain…</translation>
+<translation id="6461962085415701688">Tidak dapat membuka fail</translation>
+<translation id="1178581264944972037">Jeda</translation>
+<translation id="8200772114523450471">Sambung semula</translation>
+<translation id="1409879593029778104">Muat turun <ph name="FILE_NAME"/> dihalang kerana fail ini sudah wujud.</translation>
+<translation id="3387650086002190359">Muat turun <ph name="FILE_NAME"/> gagal disebabkan oleh ralat sistem fail.</translation>
+<translation id="6482749332252372425">Muat turun <ph name="FILE_NAME"/> gagal kerana ruang storan tidak mencukupi.</translation>
+<translation id="7619072057915878432">Muat turun <ph name="FILE_NAME"/> gagal kerana kegagalan rangkaian.</translation>
+<translation id="1477626028522505441">Muat turun <ph name="FILE_NAME"/> gagal disebabkan oleh masalah pelayan.</translation>
+<translation id="3692944402865947621">Muat turun <ph name="FILE_NAME"/> gagal kerana lokasi storan tidak dapat dicapai.</translation>
+<translation id="604996488070107836">Muat turun <ph name="FILE_NAME"/> gagal disebabkan oleh ralat yang tidak diketahui.</translation>
+<translation id="6738867403308150051">Memuat turun…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Dimuat turun <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Dimuat turun <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Dimuat turun <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">1 fail lagi</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> fail lagi</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fail dimuat turun}other{<ph name="FILES_DOWNLOADED_MANY"/> fail dimuat turun}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> hari lagi</translation>
+<translation id="8190358571722158785">1 hari lagi</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> jam lagi</translation>
+<translation id="510275257476243843">1 jam lagi</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minit lagi</translation>
+<translation id="3236059992281584593">1 minit lagi</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> saat lagi</translation>
+<translation id="2781151931089541271">1 saat lagi</translation>
+<translation id="3303414029551471755">Teruskan memuat turun kandungan?</translation>
+<translation id="8617240290563765734">Buka URL yang dicadangkan yang dinyatakan dalam kandungan yang dimuat turun?</translation>
+<translation id="1373696734384179344">Memori tidak mencukupi untuk memuat turun kandungan yang dipilih.</translation>
+<translation id="5271967389191913893">Peranti tidak dapat membuka kandungan yang hendak dimuat turun.</translation>
+<translation id="883806473910249246">Ralat berlaku semasa memuat turun kandungan.</translation>
+<translation id="5626134646977739690">Nama:</translation>
+<translation id="7963646190083259054">Vendor:</translation>
+<translation id="3414952576877147120">Saiz:</translation>
+<translation id="7375125077091615385">Jenis:</translation>
+<translation id="5765780083710877561">Huraian:</translation>
+<translation id="4881695831933465202">Buka</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB tersedia</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB tersedia</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB tersedia</translation>
+<translation id="5793665092639000975">Menggunakan <ph name="SPACE_USED"/> daripada <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Semua</translation>
+<translation id="4988526792673242964">Halaman</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Imej</translation>
+<translation id="8250920743982581267">Dokumen</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Fail}other{# Fail}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Imej}other{# Imej}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Video}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Fail audio}other{# Fail audio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Halaman}other{# Halaman}}</translation>
+<translation id="5456381639095306749">Muat turun halaman</translation>
+<translation id="2394602618534698961">Fail yang anda muat turun dipaparkan di sini</translation>
+<translation id="7810647596859435254">Buka dengan...</translation>
+<translation id="5655963694829536461">Cari muat turun anda</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Fail Saya</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Artikel dipaparkan di sini, yang boleh anda baca walaupun semasa anda luar talian</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# jam}other{# jam}}</translation>
+<translation id="5853623416121554550">dijeda</translation>
+<translation id="8965591936373831584">belum selesai</translation>
+<translation id="2779651927720337254">gagal</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Sebentar Tadi</translation>
+<translation id="4000212216660919741">Rumah Luar Talian</translation>
+<translation id="9133397713400217035">Teroka Luar Talian</translation>
+<translation id="968900484120156207">Halaman yang anda lawati dipaparkan di sini</translation>
+<translation id="7882131421121961860">Tiada sejarah ditemui</translation>
+<translation id="3549657413697417275">Cari sejarah anda</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">BB</translation>
+<translation id="605721222689873409">TT</translation>
+<translation id="724102042129299115">Pengalaman First Run Brave</translation>
+<translation id="2700285883409956633">Dengan menggunakan aplikasi ini, anda bersetuju menerima <ph name="BEGIN_LINK1"/>Syarat Perkhidmatan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Notis Privasi<ph name="END_LINK2"/> Brave.</translation>
+<translation id="1640714894372474981">Apabila menggunakan aplikasi ini, anda bersetuju menerima <ph name="BEGIN_LINK1"/>Syarat Perkhidmatan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Notis Privasi<ph name="END_LINK2"/> Brave serta <ph name="BEGIN_LINK3"/>Notis Privasi untuk Akaun Brave Software yang Diurus dengan Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> akan dibuka dalam Brave. Dengan meneruskan penggunaan, anda bersetuju menerima <ph name="BEGIN_LINK1"/>Terma Perkhidmatan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Notis Privasi<ph name="END_LINK2"/> Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> akan dibuka dalam Brave. Dengan meneruskan penggunaan, anda bersetuju menerima <ph name="BEGIN_LINK1"/>Syarat Perkhidmatan<ph name="END_LINK1"/> dan <ph name="BEGIN_LINK2"/>Notis Privasi<ph name="END_LINK2"/> Brave serta <ph name="BEGIN_LINK3"/>Notis Privasi untuk Akaun Brave Software yang Diurus menggunakan Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Bantu jadikan Brave lebih baik dengan menghantar laporan perangkaan penggunaan dan ranap sistem kepada Brave Software.</translation>
+<translation id="3518985090088779359">Terima &amp; teruskan</translation>
+<translation id="7207456302801184289">Selamat Datang ke Brave</translation>
+<translation id="704822250101715322">Menunggu Perkhidmatan Brave Software Play selesai mengemas kini</translation>
+<translation id="1231733316453485619">Hidupkan penyegerakan?</translation>
+<translation id="5132942445612118989">Segerakkan kata laluan, sejarah &amp; pelbagai lagi pada semua peranti</translation>
+<translation id="5736731321935944068">Brave Software boleh menggunakan sejarah anda untuk memperibadikan Carian, iklan dan perkhidmatan Brave Software yang lain</translation>
+<translation id="4013614219085422040">Brave Software boleh menggunakan sejarah anda untuk memperibadikan Carian dan perkhidmatan Brave Software yang lain</translation>
+<translation id="5581519193887989363">Anda boleh memilih item yang hendak disegerakkan dalam <ph name="BEGIN_LINK1"/>tetapan<ph name="END_LINK1"/> pada bila-bila masa.</translation>
+<translation id="741204030948306876">Ya, saya setuju</translation>
+<translation id="2410754283952462441">Pilih akaun</translation>
+<translation id="2227444325776770048">Teruskan sebagai <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Bukan <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Hidupkan penyegerakan untuk mendapatkan penanda halaman pada semua peranti anda</translation>
+<translation id="2818669890320396765">Log masuk dan hidupkan penyegerakan untuk mendapatkan penanda halaman pada semua peranti anda</translation>
+<translation id="6003646045106347985">Hidupkan penyegerakan untuk mendapatkan kandungan diperibadikan yang dicadangkan oleh Brave Software</translation>
+<translation id="8494430740943879273">Log masuk dan hidupkan penyegerakan untuk mendapatkan kandungan diperibadikan yang dicadangkan oleh Brave Software</translation>
+<translation id="5862731021271217234">Hidupkan penyegerakan untuk mendapatkan tab daripada peranti anda yang lain</translation>
+<translation id="3568688522516854065">Log masuk dan hidupkan penyegerakan untuk mendapatkan tab daripada peranti anda yang lain</translation>
+<translation id="1208340532756947324">Hidupkan penyegerakan untuk melakukan penyegerakan dan pemperibadian pada semua peranti</translation>
+<translation id="4472118726404937099">Log masuk dan hidupkan penyegerakan untuk melakukan penyegerakan dan pemperibadian pada semua peranti</translation>
+<translation id="2426805022920575512">Pilih akaun lain</translation>
+<translation id="6790428901817661496">Mainkan</translation>
+<translation id="1272079795634619415">Berhenti</translation>
+<translation id="2874939134665556319">Lagu sebelumnya</translation>
+<translation id="4046123991198612571">Lagu seterusnya</translation>
+<translation id="3859306556332390985">Cari ke hadapan</translation>
+<translation id="8441146129660941386">Cari ke belakang</translation>
+<translation id="6706288973712894588">Anda luar talian sekarang.\n<ph name="BEGIN_LINK"/>Terokai suapan luar talian anda.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Tab terbaharu</translation>
+<translation id="8497726226069778601">Belum ada apa-apa untuk dilihat di sini... lagi</translation>
+<translation id="5423934151118863508">Halaman yang paling kerap anda kunjungi akan muncul di sini</translation>
+<translation id="6127379762771434464">Item dialih keluar</translation>
+<translation id="4605958867780575332">Item dialih keluar: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Coretan Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Peranti lain</translation>
+<translation id="4738836084190194332">Kali terakhir disegerakkan: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minit yang lalu}other{# minit yang lalu}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# jam yang lalu}other{# jam yang lalu}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# hari yang lalu}other{# hari yang lalu}}</translation>
+<translation id="2762000892062317888">sebentar tadi</translation>
+<translation id="1407135791313364759">Buka semua</translation>
+<translation id="1209206284964581585">Sorok sementara</translation>
+<translation id="129553762522093515">Ditutup baru-baru ini</translation>
+<translation id="8413126021676339697">Paparkan sejarah penuh</translation>
+<translation id="7876243839304621966">Buangkan semua</translation>
+<translation id="8487700953926739672">Tersedia di luar talian</translation>
+<translation id="5224771365102442243">Dengan video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Ketahui lebih lanjut<ph name="END_LINK"/> tentang kandungan yang disyorkan</translation>
+<translation id="7542481630195938534">Tidak boleh mendapatkan cadangan</translation>
+<translation id="5013696553129441713">Tiada cadangan baharu</translation>
+<translation id="1736419249208073774">Teroka</translation>
+<translation id="7444811645081526538">Lagi kategori</translation>
+<translation id="6709133671862442373">Berita</translation>
+<translation id="1264974993859112054">Sukan</translation>
+<translation id="9139318394846604261">Beli-belah</translation>
+<translation id="3912508018559818924">Mencari maklumat terbaik daripada web…</translation>
+<translation id="526421993248218238">Tidak dapat memuatkan halaman ini</translation>
+<translation id="614940544461990577">Cuba:</translation>
+<translation id="3288003805934695103">Memuatkan semula halaman</translation>
+<translation id="2353636109065292463">Memeriksa sambungan Internet anda</translation>
+<translation id="2858138569776157458">Tapak popular</translation>
+<translation id="8364299278605033898">Lihat tapak web popular</translation>
+<translation id="1171770572613082465">Lihat tapak web popular dengan mengetik butang "Tapak popular"</translation>
+<translation id="5233638681132016545">Tab baharu</translation>
+<translation id="4521874409998847950">Daripada <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>disampaikan oleh Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Versi lebih baharu tersedia</translation>
+<translation id="4058091506841967397">Gagal kemas kini Brave</translation>
+<translation id="6316139424528454185">Versi Android tidak disokong</translation>
+<translation id="6989267951144302301">Tidak dapat memuat turun</translation>
+<translation id="624789221780392884">Kemaskini bersedia</translation>
+<translation id="1549000191223877751">Alihkan ke tetingkap lain</translation>
+<translation id="7481312909269577407">Majukan</translation>
+<translation id="4084682180776658562">Penanda halaman</translation>
+<translation id="6437478888915024427">Maklumat halaman</translation>
+<translation id="7180611975245234373">Muat semula</translation>
+<translation id="4913169188695071480">Berhenti memuat semula</translation>
+<translation id="1829244130665387512">Cari dalam halaman</translation>
+<translation id="6593061639179217415">Tapak desktop</translation>
+<translation id="9063523880881406963">Matikan Minta tapak desktop</translation>
+<translation id="2038563949887743358">Hidupkan Minta tapak desktop</translation>
+<translation id="2433507940547922241">Tampilan</translation>
+<translation id="983192555821071799">Tutup semua tab</translation>
+<translation id="1310482092992808703">Himpunkan tab.</translation>
+<translation id="7725024127233776428">Halaman yang anda tandai halaman dipaparkan di sini</translation>
+<translation id="4404568932422911380">Tiada penanda halaman</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> penanda halaman}other{<ph name="BOOKMARKS_COUNT_MANY"/> penanda halaman}}</translation>
+<translation id="3739899004075612870">Ditandai halaman dalam <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Ditandai halaman</translation>
+<translation id="4452548195519783679">Ditandai halaman ke <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Gagal menambah penanda halaman.</translation>
+<translation id="2842985007712546952">Folder induk</translation>
+<translation id="9065203028668620118">Edit</translation>
+<translation id="4405224443901389797">Alihkan ke…</translation>
+<translation id="5170568018924773124">Paparkan dalam folder</translation>
+<translation id="8035133914807600019">Folder baharu...</translation>
+<translation id="4532845899244822526">Pilih folder</translation>
+<translation id="6627583120233659107">Edit folder</translation>
+<translation id="1197267115302279827">Alihkan penanda halaman</translation>
+<translation id="6963766334940102469">Padamkan penanda halaman</translation>
+<translation id="4351244548802238354">Tutup dialog</translation>
+<translation id="451872707440238414">Cari penanda halaman anda</translation>
+<translation id="8901170036886848654">Tiada penanda halaman ditemui</translation>
+<translation id="6404511346730675251">Edit penanda halaman</translation>
+<translation id="3894427358181296146">Tambah folder</translation>
+<translation id="5327248766486351172">Nama</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Folder</translation>
+<translation id="5161254044473106830">Tajuk diperlukan</translation>
+<translation id="2996809686854298943">URL yang diperlukan</translation>
+<translation id="2536728043171574184">Melihat salinan luar talian halaman ini</translation>
+<translation id="4698034686595694889">Lihat di luar talian dalam <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> dan lebih banyak tapak</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave akan memuatkan halaman anda apabila sudah sedia}other{Brave akan memuatkan halaman anda apabila sudah sedia}}</translation>
+<translation id="6811034713472274749">Halaman sedia untuk dipaparkan</translation>
+<translation id="4561979708150884304">Tiada sambungan</translation>
+<translation id="8274165955039650276">Lihat muat turun</translation>
+<translation id="2082238445998314030">Hasil carian <ph name="RESULT_NUMBER"/> daripada <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Tiada hasil carian</translation>
+<translation id="981121421437150478">Luar talian</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Tiada carian suara yg didayakan tersedia</translation>
+<translation id="7191430249889272776">Tab dibuka di latar belakang.</translation>
+<translation id="8445059357334030806">Buka dalam Brave</translation>
+<translation id="4720023427747327413">Buka dalam <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Buka dalam penyemak imbas</translation>
+<translation id="1113597929977215864">Tunjukkan paparan ringkas</translation>
+<translation id="1513352483775369820">Penanda halaman dan sejarah web</translation>
+<translation id="4939482511480190003">Bantu meningkatkan Brave. <ph name="BEGIN_LINK"/>Jawab tinjauan<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Kembali</translation>
+<translation id="5596627076506792578">Lagi pilihan</translation>
+<translation id="3522247891732774234">Kemas kini tersedia. Lagi pilihan</translation>
+<translation id="6773423637732432200">Brave tidak dapat dikemas kini. Lagi pilihan</translation>
+<translation id="3328801116991980348">Maklumat tapak</translation>
+<translation id="5391532827096253100">Sambungan anda ke tapak web ini tidak selamat. Maklumat tapak</translation>
+<translation id="6206551242102657620">Sambungan selamat. Maklumat tapak</translation>
+<translation id="6963642900430330478">Halaman ini berbahaya. Maklumat tapak</translation>
+<translation id="9070377983101773829">Mulakan carian suara</translation>
+<translation id="8676374126336081632">Kosongkan input</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> tab terbuka, ketik untuk beralih antara tab}other{<ph name="OPEN_TABS_MANY"/> tab terbuka, ketik untuk beralih antara tab}}</translation>
+<translation id="2369533728426058518">tab terbuka</translation>
+<translation id="7071521146534760487">Urus akaun</translation>
+<translation id="932327136139879170">Laman Utama</translation>
+<translation id="2707726405694321444">Muat semula halaman</translation>
+<translation id="2891154217021530873">Hentikan pemuatan halaman</translation>
+<translation id="6710213216561001401">Sebelumnya</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Tab yang Dipilih</translation>
+<translation id="2268044343513325586">Perhalusi</translation>
+<translation id="7846076177841592234">Batalkan pilihan</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> dipilih. Pilihan tersedia berhampiran bahagian atas skrin</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> dipilih</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Kongsi 1 item yang dipilih}other{Kongsi # item yang dipilih}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Alih keluar 1 item yang dipilih}other{Alih keluar # item yang dipilih}}</translation>
+<translation id="1283039547216852943">Ketik untuk kembangkan</translation>
+<translation id="5962718611393537961">Ketik untuk runtuhkan</translation>
+<translation id="8076492880354921740">Tab</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 dipilih}other{# dipilih}}</translation>
+<translation id="6818926723028410516">Pilih item</translation>
+<translation id="4797039098279997504">Sentuh untuk kembali ke <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Ketik untuk pergi ke tapak</translation>
+<translation id="429312253194641664">Tapak sedang memainkan media</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> berkongsi skrin anda</translation>
+<translation id="8833831881926404480">Satu tapak sedang berkongsi skrin anda</translation>
+<translation id="9086455579313502267">Tidak dapat mengakses rangkaian</translation>
+<translation id="938850635132480979">Ralat: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Buka dalam <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Buka dalam apl peta</translation>
+<translation id="7698359219371678927">Buat e-mel dalam <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Buat e-mel</translation>
+<translation id="5665379678064389456">Buat acara dalam <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Buat acara</translation>
+<translation id="2111511281910874386">Pergi ke halaman</translation>
+<translation id="3988466920954086464">Lihat hasil carian segera dalam panel ini</translation>
+<translation id="2744248271121720757">Ketik perkataan untuk mencari dengan serta-merta atau melihat tindakan yang berkaitan</translation>
+<translation id="9155898266292537608">Anda juga boleh mencari dengan mengetik pantas pada perkataan</translation>
+<translation id="3232754137068452469">Apl Web</translation>
+<translation id="1430915738399379752">Cetak</translation>
+<translation id="3775705724665058594">Hantar ke peranti anda</translation>
+<translation id="6364438453358674297">Alih keluar cadangan daripada sejarah?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> tertutup</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> tab telah ditutup</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> dipadamkan</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> penanda halaman dipadamkan</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> muat turun dipadamkan</translation>
+<translation id="1248710015876067820">Bilangan kejadian Brave tidak disokong.</translation>
+<translation id="4259722352634471385">Navigasi disekat: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Tidak dapat mencapai navigasi: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Tutup tab</translation>
+<translation id="7772375229873196092">Tutup <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Sejarah navigasi</translation>
+<translation id="9169507124922466868">Sejarah navigasi separa terbuka</translation>
+<translation id="1327257854815634930">Sejarah navigasi dibuka</translation>
+<translation id="8788265440806329501">Sejarah navigasi ditutup</translation>
+<translation id="7482656565088326534">Tab pratonton</translation>
+<translation id="8427875596167638501">Tab pratonton separa terbuka</translation>
+<translation id="9102803872260866941">Tab pratonton dibuka</translation>
+<translation id="2942036813789421260">Tab pratonton ditutup</translation>
+<translation id="6355102470683871794">Storan Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Hapuskan storan tapak?</translation>
+<translation id="9205995714227143200">Storan tapak yang Brave anggap tidak penting (misalnya tapak yang tiada tetapan yang disimpan atau yang jarang anda lawati)</translation>
+<translation id="3997476611815694295">Storan tidak penting</translation>
+<translation id="8493948351860045254">Kosongkan ruang</translation>
+<translation id="2324920234469020158">Tindakan ini akan menghapuskan kuki, cache dan data tapak yang lain yang Brave anggap tidak penting.</translation>
+<translation id="5447201525962359567">Semua storan tapak, termasuk kuki dan data lain yang disimpan setempat</translation>
+<translation id="1376578503827013741">Mengira...</translation>
+<translation id="583281660410589416">Tidak diketahui</translation>
+<translation id="2323763861024343754">Storan tapak</translation>
+<translation id="3587672679800759167">Jumlah data yang digunakan oleh Brave, termasuk akaun, penanda halaman dan tetapan yang disimpan</translation>
+<translation id="6545017243486555795">Hapuskan Semua Data</translation>
+<translation id="4095146165863963773">Padam data apl?</translation>
+<translation id="53119194224775367">Semua data apl Brave akan dipadamkan selama-lamanya. Ini termasuk semua fail, tetapan, akaun, pangkalan data dan sebagainya.</translation>
+<translation id="5307446750509046227">Kosongkan storan tapak</translation>
+<translation id="300526633675317032">Tindakan ini akan menghapuskan semua <ph name="SIZE_IN_KB"/> daripada storan tapak web.</translation>
+<translation id="8068648041423924542">Tidak dapat memilih sijil.</translation>
+<translation id="2315043854645842844">Pemilihan sijil pihak pelanggan tidak disokong oleh sistem pengendalian ini.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> ingin menyambung</translation>
+<translation id="5308380583665731573">Sambung</translation>
+<translation id="868929229000858085">Cari dalam kenalan anda</translation>
+<translation id="1919950603503897840">Pilih kenalan</translation>
+<translation id="7986741934819883144">Pilih kenalan</translation>
+<translation id="3333961966071413176">Semua kenalan</translation>
+<translation id="4994033804516042629">Tiada kenalan ditemui</translation>
+<translation id="5403592356182871684">Nama</translation>
+<translation id="2717722538473713889">Alamat e-mel</translation>
+<translation id="381841723434055211">Nombor telefon</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 lagi)}other{(+ # lagi)}}</translation>
+<translation id="5197729504361054390">Kenalan yang anda pilih akan dikongsi dengan <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Penyahkod imej</translation>
+<translation id="8067883171444229417">Mainkan video</translation>
+<translation id="6560414384669816528">Cari dengan Sogou</translation>
+<translation id="5406914950576900927">Brave boleh menggunakan <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> untuk melakukan carian di China. Anda boleh menukarnya dalam <ph name="BEGIN_LINK"/>Tetapan<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Kekalkan Brave Software</translation>
+<translation id="4384468725000734951">Menggunakan Sogou untuk carian</translation>
+<translation id="6103327872225198548">Menggunakan Brave Software untuk carian</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Apl ini sedang dijalankan dalam Brave</translation>
+<translation id="6143689084714664628">Sedang berjalan dalam Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> juga mempunyai data dalam Brave</translation>
+<translation id="2734140769649165081">Anda boleh mengosongkan data dalam Tetapan Brave</translation>
+<translation id="8232956427053453090">Kekalkan data</translation>
+<translation id="4298388696830689168">Tapak terpaut</translation>
+<translation id="5763514718066511291">Ketik untuk menyalin URL apl ini</translation>
+<translation id="6496823230996795692">Untuk menggunakan <ph name="APP_NAME"/> buat kali pertama, sila bersambung ke Internet.</translation>
+<translation id="751961395872307827">Tidak dapat menyambung ke tapak</translation>
+<translation id="4878404682131129617">Gagal mewujudkan terowong melalui pelayan proksi</translation>
+<translation id="4749960740855309258">Buka tab baharu</translation>
+<translation id="8788968922598763114">Buka semula tab yang terakhir ditutup</translation>
+<translation id="7929962904089429003">Buka menu</translation>
+<translation id="6039379616847168523">Lompat ke tab seterusnya</translation>
+<translation id="5210286577605176222">Lompat ke halaman sebelumnya</translation>
+<translation id="124678866338384709">Tutup tab semasa</translation>
+<translation id="3714981814255182093">Buka Bar Cari</translation>
+<translation id="5441522332038954058">Lompat ke bar alamat</translation>
+<translation id="3398320232533725830">Buka pengurus penanda halaman</translation>
+<translation id="6583199322650523874">Tandai halaman semasa</translation>
+<translation id="8489271220582375723">Buka halaman sejarah</translation>
+<translation id="4837753911714442426">Buka pilihan untuk mencetak halaman</translation>
+<translation id="5726692708398506830">Jadikan semua yang ada pada halaman lebih besar</translation>
+<translation id="3259831549858767975">Jadikan semua yang ada pada halaman lebih kecil</translation>
+<translation id="8015452622527143194">Kembalikan semua yg ada pd halaman kpd saiz lalai</translation>
+<translation id="3443221991560634068">Muat semula halaman semasa</translation>
+<translation id="123724288017357924">Muat semula laman semasa dan abaikan kdgn dicache</translation>
+<translation id="305870044889644984">Buka Pusat Bantuan Brave dalam tab baharu</translation>
+<translation id="3166827708714933426">Pintasan tab dan tetingkap</translation>
+<translation id="3169981355900570544">Pintasan ciri Brave Software Brave</translation>
+<translation id="4558311620361989323">Pintasan halaman web</translation>
+<translation id="1908301351964700579">Brave masih bersiap bersedia untuk VR. Mulakan semula Brave kemudian.</translation>
+<translation id="8970887620466824814">Kesilapan telah berlaku.</translation>
+<translation id="1875543012935658554">Buka semula Brave.</translation>
+<translation id="79859296434321399">Untuk melihat kandungan realiti tambahan, pasang ARCore</translation>
+<translation id="8558485628462305855">Untuk melihat kandungan realiti tambahan, kemas kini ARCore</translation>
+<translation id="3513704683820682405">Realiti Tambahan</translation>
+<translation id="5475862044948910901">Mulakan sesi Realiti Tambahan?</translation>
 <translation id="7365126855094612066">Sepanjang tempoh sesi ini, tapak akan dapat:
 • membuat peta 3D persekitaran anda
 • menjejak pergerakan kamera
 
 Tapak TIDAK memperoleh akses kepada kamera. Hanya anda dapat melihat imej kamera.</translation>
-<translation id="7375125077091615385">Jenis:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Pengalaman First Run Chrome</translation>
-<translation id="741204030948306876">Ya, saya setuju</translation>
-<translation id="7413229368719586778">Tarikh mula <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Tanya dahulu</translation>
-<translation id="7423538860840206698">Disekat daripada membaca papan keratan</translation>
-<translation id="7431991332293347422">Kawal cara sejarah penyemakan imbas anda digunakan untuk memperibadikan Carian dan pelbagai lagi</translation>
-<translation id="7437998757836447326">Log keluar dari Chrome</translation>
-<translation id="7438641746574390233">Apabila mod Ringkas dihidupkan, Chrome menggunakan pelayan Google untuk memuatkan halaman dengan lebih pantas. Mod Ringkas menulis semula halaman yang sangat perlahan untuk memuatkan kandungan yang penting sahaja. Mod Ringkas tidak digunakan pada tab Incognito.</translation>
-<translation id="7444811645081526538">Lagi kategori</translation>
-<translation id="7445411102860286510">Benarkan tapak untuk memainkan video yang diredam secara automatik (disyorkan)</translation>
-<translation id="7453467225369441013">Mengelog anda keluar daripada kebanyakan tapak. Anda tidak akan dilog keluar daripada Akaun Google anda.</translation>
-<translation id="7454641608352164238">Tidak cukup ruang</translation>
-<translation id="7475192538862203634">Jika anda kerap melihatnya, cuba <ph name="BEGIN_LINK" />cadangan<ph name="END_LINK" /> ini.</translation>
-<translation id="7475688122056506577">Kad SD tidak ditemui. Sesetengah fail anda mungkin tiada.</translation>
-<translation id="7479104141328977413">Pengurusan tab</translation>
-<translation id="7481312909269577407">Majukan</translation>
-<translation id="7482656565088326534">Tab pratonton</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Dikemas kini <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">data disimpan</translation>
-<translation id="7498271377022651285">Sila tunggu…</translation>
-<translation id="7514365320538308">Muat Turun</translation>
-<translation id="751961395872307827">Tidak dapat menyambung ke tapak</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Tidak boleh mendapatkan cadangan</translation>
-<translation id="7559975015014302720">Mod Ringkas dimatikan</translation>
-<translation id="7562080006725997899">Mengosongkan data penyemakan imbas</translation>
-<translation id="756809126120519699">Data Chrome dikosongkan</translation>
-<translation id="757524316907819857">Sekat tapak daripada memainkan kandungan yang dilindungi</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fail dimuat turun}other{<ph name="FILES_DOWNLOADED_MANY" /> fail dimuat turun}}</translation>
-<translation id="7588219262685291874">Hidupkan tema gelap apabila Penjimat Bateri peranti anda dihidupkan</translation>
-<translation id="7589445247086920869">Sekat untuk enjin carian semasa</translation>
-<translation id="7593557518625677601">Buka ttpn Android dan dayakan smla pnyegerakan sistem Android utk mulakan pnyegerakan Chrome</translation>
-<translation id="7596558890252710462">Sistem pengendalian</translation>
-<translation id="7605594153474022051">Penyegerakan tidak berfungsi</translation>
-<translation id="7606077192958116810">Mod Ringkas dihidupkan. Urus dalam Tetapan.</translation>
-<translation id="7612619742409846846">Dilog masuk ke Google sebagai</translation>
-<translation id="7619072057915878432">Muat turun <ph name="FILE_NAME" /> gagal kerana kegagalan rangkaian.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Dapatkan bantuan<ph name="END_LINK1" /> atau <ph name="BEGIN_LINK2" />imbas semula<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Selamat Datang ke Chrome</translation>
-<translation id="7638584964844754484">Frasa laluan tidak betul</translation>
-<translation id="7641339528570811325">Kosongkan data semakan imbas...</translation>
-<translation id="7648422057306047504">Sulitkan kata laluan dengan bukti kelayakan Google</translation>
-<translation id="7649070708921625228">Bantuan</translation>
-<translation id="7658239707568436148">Batal</translation>
-<translation id="7665369617277396874">Tambah akaun</translation>
-<translation id="766587987807204883">Artikel dipaparkan di sini, yang boleh anda baca walaupun semasa anda luar talian</translation>
-<translation id="7682724950699840886">Cuba petua berikut: pastikan ruang pada peranti anda mencukupi, cuba eksport sekali lagi.</translation>
-<translation id="7685301384041462804">Pastikan anda mempercayai tapak ini sebelum memasuki VR.</translation>
-<translation id="7698359219371678927">Buat e-mel dalam <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Autolengkap carian dan URL</translation>
-<translation id="7725024127233776428">Halaman yang anda tandai halaman dipaparkan di sini</translation>
-<translation id="773466115871691567">Sentiasa terjemahkan halaman dalam <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Untuk mengesan apl dan tapak berbahaya, Chrome menghantar URL sesetengah halaman yang anda lawati, maklumat sistem yang terhad dan sesetengah kandungan halaman kepada Google</translation>
-<translation id="7757787379047923882">Teks dikongsi daripada <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Kad SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Tambahkan alamat</translation>
-<translation id="7772032839648071052">Sahkan frasa laluan</translation>
-<translation id="7772375229873196092">Tutup <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> lagi}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 dan <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> lagi}}</translation>
-<translation id="7781829728241885113">Semalam</translation>
-<translation id="7791543448312431591">Tambah</translation>
-<translation id="780301667611848630">Tidak, terima kasih</translation>
-<translation id="7810647596859435254">Buka dengan...</translation>
-<translation id="7821588508402923572">Penjimatan data anda akan dipaparkan di sini</translation>
-<translation id="7837721118676387834">Benarkan video yang diredamkan dimainkan secara automatik untuk tapak web tertentu.</translation>
-<translation id="7846076177841592234">Batalkan pilihan</translation>
-<translation id="784934925303690534">Julat masa</translation>
-<translation id="7851858861565204677">Peranti lain</translation>
-<translation id="7875915731392087153">Buat e-mel</translation>
-<translation id="7876243839304621966">Buangkan semua</translation>
-<translation id="7882131421121961860">Tiada sejarah ditemui</translation>
-<translation id="7882806643839505685">Benarkan bunyi untuk tapak tertentu.</translation>
-<translation id="7886917304091689118">Sedang berjalan dalam Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Memuat turun fail.}other{Memuat turun # fail.}}</translation>
-<translation id="7929962904089429003">Buka menu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> telah lapuk.</translation>
-<translation id="7947953824732555851">Terima dan log masuk</translation>
-<translation id="7963646190083259054">Vendor:</translation>
-<translation id="7971136598759319605">Aktif 1 hari yang lalu</translation>
-<translation id="7975379999046275268">Pratonton halaman <ph name="BEGIN_NEW" />Baharu<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Pramuat halaman untuk penyemakan imbas dan pencarian yang lebih cepat</translation>
-<translation id="79859296434321399">Untuk melihat kandungan realiti tambahan, pasang ARCore</translation>
-<translation id="7986741934819883144">Pilih kenalan</translation>
-<translation id="7987073022710626672">Syarat Perkhidmatan Chrome</translation>
-<translation id="7998918019931843664">Buka semula tab yang ditutup</translation>
-<translation id="7999064672810608036">Anda pasti ingin mengosongkan semua data setempat, termasuk kuki dan menetapkan semula semua kebenaran untuk tapak web ini?</translation>
-<translation id="8004582292198964060">Penyemak Imbas</translation>
-<translation id="8007176423574883786">Dimatikan untuk peranti ini</translation>
-<translation id="8013372441983637696">Selain itu, kosongkan data Chrome anda daripada peranti ini</translation>
-<translation id="8015452622527143194">Kembalikan semua yg ada pd halaman kpd saiz lalai</translation>
-<translation id="802154636333426148">Muat turun gagal</translation>
-<translation id="8026334261755873520">Kosongkan data semakan imbas</translation>
-<translation id="8035133914807600019">Folder baharu...</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> hari lagi</translation>
-<translation id="804335162455518893">Kad SD tidak ditemui</translation>
-<translation id="805047784848435650">Berdasarkan sejarah penyemakan imbas anda</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB tersedia</translation>
-<translation id="8058746566562539958">Buka dalam tab Chrome baharu</translation>
-<translation id="8063895661287329888">Gagal menambah penanda halaman.</translation>
-<translation id="806745655614357130">Biarkan data saya diasingkan</translation>
-<translation id="8067883171444229417">Mainkan video</translation>
-<translation id="8068648041423924542">Tidak dapat memilih sijil.</translation>
-<translation id="8073388330009372546">Buka imej dalam tab baharu</translation>
-<translation id="8076492880354921740">Tab</translation>
-<translation id="8084114998886531721">Kata laluan disimpan</translation>
-<translation id="8087000398470557479">Kandungan ini adalah daripada <ph name="DOMAIN_NAME" />, disampaikan oleh Google.</translation>
-<translation id="8103578431304235997">Tab Inkognito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Hidupkan penyegerakan untuk mendapatkan penanda halaman pada semua peranti anda</translation>
-<translation id="8110087112193408731">Tunjukkan aktiviti Chrome anda dalam Kesejahteraan Digital?</translation>
-<translation id="8116925261070264013">Diredam</translation>
-<translation id="813082847718468539">Lihat maklumat tapak</translation>
-<translation id="8131740175452115882">Sahkan</translation>
-<translation id="8156139159503939589">Apakah bahasa yang anda gunakan untuk membaca?</translation>
-<translation id="8168435359814927499">Kandungan</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> fail lagi</translation>
-<translation id="8190358571722158785">1 hari lagi</translation>
-<translation id="8200772114523450471">Sambung semula</translation>
-<translation id="8209050860603202033">Buka imej</translation>
-<translation id="8218622182176210845">Urus akaun anda</translation>
-<translation id="8224471946457685718">Muat turun artikel untuk anda apabila menggunakan Wi-Fi</translation>
-<translation id="8232956427053453090">Kekalkan data</translation>
-<translation id="8249310407154411074">Alihkan ke atas</translation>
-<translation id="8250920743982581267">Dokumen</translation>
-<translation id="825412236959742607">Halaman ini menggunakan terlalu banyak memori, jadi Chrome mengalih keluar sesetengah kandungan.</translation>
-<translation id="8260126382462817229">Cuba log masuk semula</translation>
-<translation id="8261506727792406068">Padam</translation>
-<translation id="8266862848225348053">Lokasi muat turun</translation>
-<translation id="8274165955039650276">Lihat muat turun</translation>
-<translation id="8284326494547611709">Kapsyen</translation>
-<translation id="8300705686683892304">Diurus oleh apl</translation>
-<translation id="8310344678080805313">Tab standard</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> dan lebih banyak tapak</translation>
-<translation id="8327155640814342956">Untuk mendapatkan pengalaman penyemakan imbas yang terbaik, buka untuk mengemas kini Chrome</translation>
-<translation id="8339163506404995330">Halaman dalam <ph name="LANGUAGE" /> tidak akan diterjemahkan</translation>
-<translation id="8349013245300336738">Isih mengikut jumlah data yang digunakan</translation>
-<translation id="8364299278605033898">Lihat tapak web popular</translation>
-<translation id="8368027906805972958">Peranti tidak diketahui atau tidak disokong (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Benarkan Penyegerakan Latar Belakang untuk tapak tertentu</translation>
-<translation id="8378714024927312812">Diurus oleh organisasi anda</translation>
-<translation id="8380167699614421159">Tapak ini menyiarkan iklan yang mengganggu atau mengelirukan</translation>
-<translation id="8393700583063109961">Hantar mesej</translation>
-<translation id="8413126021676339697">Paparkan sejarah penuh</translation>
-<translation id="8427875596167638501">Tab pratonton separa terbuka</translation>
-<translation id="8428213095426709021">Tetapan</translation>
-<translation id="8438566539970814960">Mempertingkatkan carian dan penyemakan imbas</translation>
-<translation id="8441146129660941386">Cari ke belakang</translation>
-<translation id="8443209985646068659">Gagal kemas kini Chrome</translation>
-<translation id="8445448999790540984">Tidak dapat mengeskport kata laluan</translation>
-<translation id="8447861592752582886">Batalkan kebenaran peranti</translation>
-<translation id="8461694314515752532">Sulitkan data yang disegerakkan dengan ungkapan laluan penyegerakan anda sendiri</translation>
-<translation id="8466613982764129868">Pastikan <ph name="TARGET_DEVICE_NAME" /> disambungkan ke Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Tersedia di luar talian</translation>
-<translation id="8489271220582375723">Buka halaman sejarah</translation>
-<translation id="8493948351860045254">Kosongkan ruang</translation>
-<translation id="8497726226069778601">Belum ada apa-apa untuk dilihat di sini... lagi</translation>
-<translation id="8503559462189395349">Kata Laluan Chrome</translation>
-<translation id="8503813439785031346">Nama pengguna</translation>
-<translation id="8514477925623180633">Eksport kata laluan yang disimpan dengan menggunakan Chrome</translation>
-<translation id="8514577642972634246">Masuk ke mod inkognito</translation>
-<translation id="851751545965956758">Sekat tapak daripada menyambung ke peranti</translation>
-<translation id="8523928698583292556">Padam kata laluan yang disimpan</translation>
-<translation id="854522910157234410">Buka halaman ini</translation>
-<translation id="8558485628462305855">Untuk melihat kandungan realiti tambahan, kemas kini ARCore</translation>
-<translation id="8559990750235505898">Tawaran untuk menterjemah halaman dalam bahasa lain</translation>
-<translation id="8562452229998620586">Kata laluan yang disimpan akan kelihatan di sini.</translation>
-<translation id="8569404424186215731">sejak <ph name="DATE" /></translation>
-<translation id="8571213806525832805">4 minggu terakhir</translation>
-<translation id="857943718398505171">Dibenarkan (disyorkan)</translation>
-<translation id="8583805026567836021">Menghapuskan data akaun</translation>
-<translation id="860043288473659153">Nama pemegang kad</translation>
-<translation id="8609465669617005112">Alihkan ke atas</translation>
-<translation id="8616006591992756292">Akaun Google anda mungkin mempunyai sejarah penyemakan imbas dalam bentuk lain di <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Buka URL yang dicadangkan yang dinyatakan dalam kandungan yang dimuat turun?</translation>
-<translation id="8636825310635137004">Hidupkan penyegerakan untuk mendapatkan tab daripada peranti anda yang lain.</translation>
-<translation id="8641930654639604085">Cuba menyekat tapak dewasa</translation>
-<translation id="8655129584991699539">Anda boleh mengosongkan data dalam Tetapan Chrome</translation>
-<translation id="8662811608048051533">Mengelog anda keluar daripada kebanyakan tapak.</translation>
-<translation id="8664979001105139458">Nama fail sudah wujud</translation>
-<translation id="8676374126336081632">Kosongkan input</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Tahap Kekuatan Isyarat: # bar}other{Tahap Kekuatan Isyarat: # bar}}</translation>
-<translation id="868929229000858085">Cari dalam kenalan anda</translation>
-<translation id="869891660844655955">Tarikh tamat tempoh</translation>
-<translation id="8719023831149562936">Tidak dapat memancarkan tab semasa</translation>
-<translation id="8725066075913043281">Cuba lagi</translation>
-<translation id="8728487861892616501">Apabila menggunakan aplikasi ini, anda bersetuju menerima <ph name="BEGIN_LINK1" />Syarat Perkhidmatan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Notis Privasi<ph name="END_LINK2" /> Chrome serta <ph name="BEGIN_LINK3" />Notis Privasi untuk Akaun Google yang Diurus dengan Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Selesai</translation>
-<translation id="8748850008226585750">Kandungan tersembunyi</translation>
-<translation id="8751914237388039244">Pilih imej</translation>
-<translation id="8788265440806329501">Sejarah navigasi ditutup</translation>
-<translation id="8788968922598763114">Buka semula tab yang terakhir ditutup</translation>
-<translation id="8801436777607969138">Sekat JavaScript untuk tapak tertentu.</translation>
-<translation id="8812260976093120287">Pada sesetengah tapak web, anda boleh membayar menggunakan apl pembayaran yang disokong di atas pada peranti anda.</translation>
-<translation id="8816026460808729765">Sekat tapak daripada mengakses penderia</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> akan dibuka dalam Chrome. Dengan meneruskan penggunaan, anda bersetuju menerima <ph name="BEGIN_LINK1" />Syarat Perkhidmatan<ph name="END_LINK1" /> dan <ph name="BEGIN_LINK2" />Notis Privasi<ph name="END_LINK2" /> Chrome serta <ph name="BEGIN_LINK3" />Notis Privasi untuk Akaun Google yang Diurus menggunakan Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Penanda buku</translation>
-<translation id="8833831881926404480">Satu tapak sedang berkongsi skrin anda</translation>
-<translation id="883806473910249246">Ralat berlaku semasa memuat turun kandungan.</translation>
-<translation id="8840953339110955557">Halaman ini mungkin berbeza daripada versi dalam talian.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, tab</translation>
-<translation id="885701979325669005">Storan</translation>
-<translation id="889338405075704026">Pergi ke tetapan Chrome</translation>
-<translation id="8901170036886848654">Tiada penanda halaman ditemui</translation>
-<translation id="8909135823018751308">Kongsi…</translation>
-<translation id="8912362522468806198">Akaun Google</translation>
-<translation id="8920114477895755567">Menunggu butiran ibu bapa.</translation>
+<translation id="1188239144602654184">Masuk ke AR</translation>
+<translation id="473775607612524610">Kemas kini</translation>
+<translation id="3133489217401741157">Memasang <ph name="MODULE"/> untuk Brave…</translation>
+<translation id="1791662854739702043">Dipasang</translation>
+<translation id="5131234170665854056">Tidak dapat memasang <ph name="MODULE"/> untuk Brave</translation>
+<translation id="2567385386134582609">IMEJ</translation>
+<translation id="6395288395575013217">PAUTAN</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Muat turun halaman untuk digunakan di luar talian</translation>
 <translation id="8922289737868596582">Muat turun halaman daripada butang Lagi pilihan untuk digunakan di luar talian</translation>
-<translation id="8937772741022875483">Alih keluar aktiviti Chrome anda daripada Kesejahteraan Digital?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Buka dalam tetingkap lain</translation>
-<translation id="8951232171465285730">Chrome telah menjimatkan data anda sebanyak <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Sekat kuki untuk tapak tertentu.</translation>
-<translation id="8959122750345127698">Tidak dapat mencapai navigasi: <ph name="URL" /></translation>
-<translation id="8965591936373831584">belum selesai</translation>
-<translation id="8970887620466824814">Kesilapan telah berlaku.</translation>
-<translation id="8972098258593396643">Muat turun ke folder lalai?</translation>
-<translation id="8986494364107987395">Hantar statistik penggunaan dan laporan nahas kepada Google secara automatik</translation>
-<translation id="8993760627012879038">Buka tetingkap baharu dalam mod Inkognito</translation>
-<translation id="8998729206196772491">Anda log masuk dengan akaun yang diurus oleh <ph name="MANAGED_DOMAIN" /> dan memberikan kawalan terhadap data Chrome anda kepada pentadbirnya. Data anda akan terikat secara kekal kepada akaun ini. Tindakan log keluar daripada Chrome akan memadamkan data anda daripada peranti ini, tetapi data itu akan kekal disimpan dalam Akaun Google anda.</translation>
-<translation id="9019902583201351841">Diurus oleh ibu bapa anda</translation>
-<translation id="9028914725102941583">Hidupkan penyegerakan untuk berkongsi merentas peranti</translation>
-<translation id="9029323097866369874">Benarkan <ph name="DOMAIN" /> untuk memasuki VR?</translation>
-<translation id="9040142327097499898">Pemberitahuan dibenarkan. Lokasi dimatikan untuk peranti ini.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Video}}</translation>
-<translation id="9050666287014529139">Frasa laluan</translation>
-<translation id="9063523880881406963">Matikan Minta tapak desktop</translation>
-<translation id="9065203028668620118">Edit</translation>
-<translation id="9070377983101773829">Mulakan carian suara</translation>
-<translation id="9074336505530349563">Log masuk dan hidupkan penyegerakan untuk mendapatkan kandungan diperibadikan yang dicadangkan oleh Google</translation>
-<translation id="9086455579313502267">Tidak dapat mengakses rangkaian</translation>
-<translation id="9100505651305367705">Tawarkan untuk memaparkan artikel dalam paparan mudah apabila disokong</translation>
-<translation id="9100610230175265781">Frasa laluan diperlukan</translation>
-<translation id="9102803872260866941">Tab pratonton dibuka</translation>
+<translation id="5958275228015807058">Cari fail dan halaman anda dalam Muat Turun</translation>
+<translation id="5620928963363755975">Cari fail dan halaman anda dalam Muat Turun daripada butang Lagi Pilihan</translation>
+<translation id="3341058695485821946">Lihat jumlah data yang dapat dijimatkan</translation>
+<translation id="3157842584138209013">Lihat jumlah data yang dapat dijimatkan daripada butang Lagi Pilihan</translation>
+<translation id="8218622182176210845">Urus akaun anda</translation>
+<translation id="8090895580117672212">Untuk mengurus akaun Brave Software anda, ketik butang "Urus akaun"</translation>
+<translation id="8856898588039823173">Halaman Lite disediakan oleh Brave Software. Ketik untuk memuatkan halaman asal.</translation>
+<translation id="8134317863207426198">Halaman Lite disediakan oleh Brave Software. Ketik butang muatkan halaman asal untuk memuatkan halaman asal.</translation>
+<translation id="4961107849584082341">Terjemahkan halaman ini ke sebarang bahasa</translation>
+<translation id="569536719314091526">Terjemahkan halaman ini ke dalam sebarang bahasa lain daripada butang Lagi pilihan</translation>
+<translation id="1397811292916898096">Cari dengan <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Tukar lokasi muat turun lalai pada bila-bila masa</translation>
+<translation id="6942665639005891494">Tukar lokasi muat turun lalai pada bila-bila masa menggunakan pilihan menu Tetapan</translation>
+<translation id="6850409657436465440">Muat turun anda masih berlangsung</translation>
+<translation id="5817715962196959877">Brave kini memuat turun fail dengan lebih pantas</translation>
+<translation id="3976396876660209797">Alih keluar dan buat semula pintasan ini</translation>
+<translation id="6766622839693428701">Leret ke bawah untuk tutup.</translation>
+<translation id="1028699632127661925">Menghantar ke <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Dihantar daripada <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Tab diterima</translation>
 <translation id="9104217018994036254">Senarai peranti untuk berkongsi tab.</translation>
-<translation id="9133397713400217035">Teroka Luar Talian</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Paparkan asal</translation>
-<translation id="9139068048179869749">Tanya sebelum membenarkan tapak menghantar pemberitahuan (disyorkan)</translation>
-<translation id="9139318394846604261">Beli-belah</translation>
-<translation id="9155898266292537608">Anda juga boleh mencari dengan mengetik pantas pada perkataan</translation>
-<translation id="9169507124922466868">Sejarah navigasi separa terbuka</translation>
-<translation id="9204836675896933765">1 fail lagi</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Senarai peranti untuk berkongsi tab dibuka pada ketinggian separuh.</translation>
+<translation id="2904414404539560095">Senarai peranti untuk berkongsi tab dibuka pada ketinggian penuh.</translation>
+<translation id="4135200667068010335">Senarai peranti untuk berkongsi tab ditutup.</translation>
+<translation id="5292796745632149097">Hantar ke</translation>
+<translation id="1386674309198842382">Aktif <ph name="LAST_UPDATED"/> hari lalu</translation>
+<translation id="7971136598759319605">Aktif 1 hari yang lalu</translation>
+<translation id="1521774566618522728">Aktif hari ini</translation>
+<translation id="3631987586758005671">Berkongsi ke <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Hidupkan penyegerakan untuk berkongsi merentas peranti</translation>
+<translation id="6162454065885854378">Untuk berkongsi sesuatu daripada telefon anda kepada peranti lain, hidupkan penyegerakan dalam tetapan Brave pada kedua-dua peranti</translation>
+<translation id="6084271560289605378">Pergi ke tetapan Brave</translation>
+<translation id="2318045970523081853">Ketik untuk membuat panggilan</translation>
 <translation id="9209888181064652401">Tidak dapat membuat panggilan</translation>
-<translation id="9219103736887031265">Imej</translation>
-<translation id="926205370408745186">Alih keluar aktiviti Chrome anda daripada Kesejahteraan Digital</translation>
-<translation id="932327136139879170">Laman Utama</translation>
-<translation id="938850635132480979">Ralat: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Akses mikrofon anda</translation>
-<translation id="95817756606698420">Chrome boleh menggunakan <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> untuk melakukan carian di China. Anda boleh menukarnya dalam <ph name="BEGIN_LINK" />Tetapan<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Sekat jika tapak menyiarkan iklan yang mengganggu atau mengelirukan (disyorkan)</translation>
-<translation id="968900484120156207">Halaman yang anda lawati dipaparkan di sini</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minit lagi</translation>
-<translation id="974555521953189084">Masukkan ungkapan laluan anda untuk memulakan penyegerakan</translation>
-<translation id="981121421437150478">Luar talian</translation>
-<translation id="982182592107339124">Ini akan memadamkan data untuk semua tapak web, termasuk:</translation>
-<translation id="983192555821071799">Tutup semua tab</translation>
-<translation id="987264212798334818">Umum</translation>
+<translation id="2860954141821109167">Pastikan apl telefon didayakan pada peranti ini</translation>
+<translation id="2067805253194386918">teks</translation>
+<translation id="1450753235335490080">Tidak dapat berkongsi <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Tidak dapat berkongsi <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Pastikan penyegerakan telah dihidupkan dalam Brave pada <ph name="TARGET_DEVICE_NAME"/></translation>
+<translation id="3016635187733453316">Pastikan peranti ini disambungkan ke Internet</translation>
+<translation id="8466613982764129868">Pastikan <ph name="TARGET_DEVICE_NAME"/> disambungkan ke Internet</translation>
+<translation id="6539092367496845964">Kesilapan telah berlaku. Cuba sebentar lagi.</translation>
+<translation id="3389286852084373014">Teks terlalu besar</translation>
+<translation id="2100314319871056947">Cuba kongsikan teks itu dalam bahagian yang lebih kecil</translation>
+<translation id="2987620471460279764">Teks yang dikongsi daripada peranti lain</translation>
+<translation id="7757787379047923882">Teks dikongsi daripada <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Disalin ke papan keratan anda</translation>
+<translation id="4696983787092045100">Hantar teks ke Peranti Anda</translation>
+<translation id="1260236875608242557">Cari &amp; teroka</translation>
+<translation id="6369229450655021117">Dari sini, anda boleh membuat carian di web, berkongsi dengan rakan dan melihat halaman yang terbuka</translation>
+<translation id="723171743924126238">Pilih imej</translation>
+<translation id="8751914237388039244">Pilih imej</translation>
+<translation id="1989112275319619282">Semak Imbas</translation>
+<translation id="7055152154916055070">Ubah hala disekat:</translation>
+<translation id="5524843473235508879">Ubah hala disekat.</translation>
+<translation id="6573096386450695060">Sentiasa benarkan</translation>
+<translation id="5805364706385912897">Halaman ini menggunakan terlalu banyak memori, jadi Brave menjeda halaman ini.</translation>
+<translation id="5138664332909611586">Halaman ini menggunakan terlalu banyak memori, jadi Brave mengalih keluar sesetengah kandungan.</translation>
+<translation id="9137013805542155359">Paparkan asal</translation>
+<translation id="6361779936989026201">Brave Software Assistant dalam Brave</translation>
+<translation id="7291387454912369099">Assistant Mencetuskan Pembayaran</translation>
+<translation id="4565206163201411670">Tunjukkan aktiviti Brave anda dalam Kesejahteraan Digital?</translation>
+<translation id="9055113864158719823">Anda dapat melihat tapak yang anda lawati dalam Brave dan menetapkan pemasa untuk tapak tersebut.\n\nBrave Software menerima maklumat tentang tapak yang pemasanya telah anda tetapkan dan tempoh anda berada di tapak itu. Maklumat ini digunakan untuk menambah baik Kesejahteraan Digital.</translation>
+<translation id="4596514158372210596">Alih keluar aktiviti Brave anda daripada Kesejahteraan Digital</translation>
+<translation id="1174893863889683998">Alih keluar aktiviti Brave anda daripada Kesejahteraan Digital?</translation>
+<translation id="708829030563435351">Tapak yang anda lawati dalam Brave tidak akan dipaparkan. Semua pemasa tapak akan dipadamkan.</translation>
+<translation id="2056878612599315956">Tapak dijeda</translation>
+<translation id="671481426037969117">Pemasa <ph name="FQDN"/> anda sudah tamat. Pemasa akan bermula lagi esok.</translation>
+<translation id="7479104141328977413">Pengurusan tab</translation>
+<translation id="3524138585025253783">UI Pembangun</translation>
+<translation id="6036057147555329831">ICU tambahan</translation>
+<translation id="9029323097866369874">Benarkan <ph name="DOMAIN"/> untuk memasuki VR?</translation>
+<translation id="7685301384041462804">Pastikan anda mempercayai tapak ini sebelum memasuki VR.</translation>
+<translation id="5033865233969348410">Semasa anda berada dalam VR, tapak ini mungkin dapat mengetahui tentang:
+  -  ciri fizikal anda, seperti ketinggian
+
+Pastikan anda mempercayai tapak ini sebelum memasuki VR.</translation>
+<translation id="5534334044554683961">Semasa anda berada dalam VR, tapak ini mungkin dapat mengetahui tentang:
+  -   ciri fizikal anda, seperti ketinggian
+  -   susun atur bilik anda
+
+Pastikan anda mempercayai tapak ini sebelum memasuki VR.</translation>
+<translation id="4169535189173047238">Jangan benarkan</translation>
+<translation id="2170088579611075216">Benarkan &amp; masuk ke VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_nl.xtb
+++ b/android/java/strings/translations/android_chrome_strings_nl.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="nl">
-<translation id="1006017844123154345">Online openen</translation>
-<translation id="1028699632127661925">Verzenden naar <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> toevoegen...</translation>
-<translation id="1041308826830691739">Van websites</translation>
-<translation id="1049743911850919806">Incognito</translation>
-<translation id="10614374240317010">Nooit opgeslagen</translation>
-<translation id="1067922213147265141">Andere Google-services</translation>
-<translation id="1068672505746868501">Pagina's in het <ph name="SOURCE_LANGUAGE" /> nooit vertalen</translation>
-<translation id="107147699690128016">Als je de bestandsextensie wijzigt, wordt het bestand mogelijk in een andere app geopend. Daardoor kan het een gevaar vormen voor je apparaat.</translation>
-<translation id="1100066534610197918">Open in nieuw tabblad in groep</translation>
-<translation id="1105960400813249514">Schermopname</translation>
-<translation id="1111673857033749125">Bladwijzers die je op andere apparaten hebt opgeslagen, worden hier weergegeven.</translation>
-<translation id="1113597929977215864">Vereenvoudigde weergave tonen</translation>
-<translation id="1121094540300013208">Gebruiks- en crashrapporten</translation>
-<translation id="1124772482545689468">Gebruiker</translation>
-<translation id="1129510026454351943">Details: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download in behandeling.}other{# downloads in behandeling.}}</translation>
-<translation id="1145536944570833626">Bestaande gegevens verwijderen.</translation>
-<translation id="1146678959555564648">VR activeren</translation>
-<translation id="116280672541001035">Gebruikt</translation>
-<translation id="1171770572613082465">Bekijk populaire websites door op de knop Topsites te tikken</translation>
-<translation id="1173894706177603556">Naam wijzigen</translation>
-<translation id="1178581264944972037">Onderbreken</translation>
-<translation id="1181037720776840403">Verwijderen</translation>
-<translation id="1188239144602654184">AR starten</translation>
-<translation id="1197267115302279827">Bladwijzers verplaatsen</translation>
-<translation id="119944043368869598">Alles wissen</translation>
-<translation id="1201402288615127009">Volgende</translation>
-<translation id="1204037785786432551">Link downloaden</translation>
-<translation id="1206892813135768548">Linktekst kopiëren</translation>
-<translation id="1208340532756947324">Schakel synchronisatie in om verschillende apparaten te synchroniseren en te personaliseren</translation>
-<translation id="1209206284964581585">Voorlopig verbergen</translation>
-<translation id="1227058898775614466">Navigatiegeschiedenis</translation>
-<translation id="1231733316453485619">Synchronisatie inschakelen?</translation>
-<translation id="123724288017357924">De pagina opnieuw laden, gecachte content negeren</translation>
-<translation id="124116460088058876">Meer talen</translation>
-<translation id="124678866338384709">Huidig tabblad sluiten</translation>
-<translation id="1258753120186372309">Google-doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Zoeken en verkennen</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Kan <ph name="CONTENT_TYPE" /> niet delen</translation>
-<translation id="1272079795634619415">Stop</translation>
-<translation id="1283039547216852943">Tik om uit te vouwen</translation>
-<translation id="1285320974508926690">Deze site nooit vertalen</translation>
-<translation id="1291207594882862231">Geschiedenis, cookies, sitegegevens, cachegeheugen wissen</translation>
-<translation id="129382876167171263">Bestanden die worden opgeslagen door websites, worden hier weergegeven</translation>
-<translation id="129553762522093515">Recent gesloten</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" />: verzonden vanaf <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Tabbladen groeperen</translation>
-<translation id="1327257854815634930">Navigatiegeschiedenis is geopend</translation>
-<translation id="1331212799747679585">Chrome kan niet updaten. Meer opties</translation>
-<translation id="1332501820983677155">Functiesneltoetsen in Google Chrome</translation>
-<translation id="1360432990279830238">Uitloggen en synchroniseren uitschakelen?</translation>
-<translation id="1369915414381695676">Site <ph name="SITE_NAME" /> toegevoegd</translation>
-<translation id="1373696734384179344">Onvoldoende geheugen om de geselecteerde content te downloaden.</translation>
-<translation id="1376578503827013741">Berekenen…</translation>
-<translation id="1383876407941801731">Zoeken</translation>
-<translation id="1384959399684842514">Download onderbroken</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> dagen geleden actief</translation>
-<translation id="1397811292916898096">Zoeken met <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Ingesloten in <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Niet bijhouden</translation>
-<translation id="1407135791313364759">Alles openen</translation>
-<translation id="1409426117486808224">Vereenvoudigde weergave voor geopende tabbladen</translation>
-<translation id="1409879593029778104">Downloaden van <ph name="FILE_NAME" /> is voorkomen omdat het bestand al bestaat.</translation>
-<translation id="1414981605391750300">Contact opnemen met Google. Dit kan even duren…</translation>
-<translation id="1416550906796893042">Appversie</translation>
-<translation id="1430915738399379752">Afdrukken</translation>
-<translation id="1446450296470737166">Volledig beheer van MIDI-apparaten toestaan</translation>
-<translation id="1450753235335490080">Kan <ph name="CONTENT_TYPE" /> niet delen</translation>
-<translation id="145097072038377568">Uitgeschakeld in Android-instellingen</translation>
-<translation id="1477626028522505441">Downloaden van <ph name="FILE_NAME" /> is mislukt door serverproblemen.</translation>
-<translation id="1506061864768559482">Zoekmachine</translation>
-<translation id="1513352483775369820">Bladwijzers en webgeschiedenis</translation>
-<translation id="1513858653616922153">Wachtwoord verwijderen</translation>
-<translation id="1516229014686355813">Met 'Tikken om te zoeken' worden het geselecteerde woord en de huidige pagina als context naar Google Zoeken verzonden. Je kunt deze functie uitschakelen bij <ph name="BEGIN_LINK" />Instellingen<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Vandaag actief</translation>
-<translation id="1544826120773021464">Tik op de knop 'Account beheren' om je Google-account te beheren</translation>
-<translation id="1549000191223877751">Naar ander venster</translation>
-<translation id="1553358976309200471">Chrome updaten</translation>
-<translation id="1569387923882100876">Gekoppeld apparaat</translation>
-<translation id="1571304935088121812">Gebruikersnaam kopiëren</translation>
-<translation id="1612196535745283361">Chrome heeft locatietoegang nodig om naar apparaten te scannen. Locatietoegang is <ph name="BEGIN_LINK" />uitgeschakeld voor dit apparaat<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Camera</translation>
-<translation id="1623104350909869708">Voorkomen dat deze pagina extra dialoogvensters weergeeft</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 geselecteerd item verwijderen}other{# geselecteerde items verwijderen}}</translation>
-<translation id="164269334534774161">Je bekijkt een offline exemplaar van deze pagina van <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Geschiedenis</translation>
-<translation id="1647391597548383849">Toegang tot camera</translation>
-<translation id="1660204651932907780">Toestaan dat sites geluid afspelen (aanbevolen)</translation>
-<translation id="1670399744444387456">Basis</translation>
-<translation id="1671236975893690980">Download in behandeling…</translation>
-<translation id="1672586136351118594">Niet opnieuw weergeven</translation>
-<translation id="1692118695553449118">Synchronisatie is ingeschakeld</translation>
-<translation id="169515064810179024">Sites geen toegang tot bewegingssensoren geven</translation>
-<translation id="1717218214683051432">Bewegingssensoren</translation>
-<translation id="1718835860248848330">Afgelopen uur</translation>
-<translation id="1736419249208073774">Verkennen</translation>
-<translation id="1743802530341753419">Vragen of sites verbinding mogen maken met een apparaat (aanbevolen)</translation>
-<translation id="1749561566933687563">Synchroniseer je bladwijzers</translation>
-<translation id="17513872634828108">Geopende tabbladen</translation>
-<translation id="1779089405699405702">Image Decoder</translation>
-<translation id="1782483593938241562">Einddatum: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Geïnstalleerd</translation>
-<translation id="1792959175193046959">Je kunt op elk gewenst moment de standaard downloadlocatie wijzigen</translation>
-<translation id="1807246157184219062">Licht</translation>
-<translation id="1810845389119482123">Eerste synchronisatieconfiguratie niet voltooid</translation>
-<translation id="1821253160463689938">Maakt gebruik van cookies om je voorkeuren te onthouden, zelfs als je deze pagina's niet bezoekt</translation>
-<translation id="1829244130665387512">Zoeken op pagina</translation>
-<translation id="1853692000353488670">Nieuw incognitotabblad</translation>
-<translation id="1856325424225101786">Lite-versie resetten?</translation>
-<translation id="1868024384445905608">Chrome downloadt bestanden nu sneller</translation>
-<translation id="1883903952484604915">Mijn bestanden</translation>
-<translation id="1887786770086287077">Locatietoegang is uitgeschakeld voor dit apparaat. Schakel dit in via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> wordt geopend in Chrome. Als je doorgaat, ga je akkoord met de <ph name="BEGIN_LINK1" />Servicevoorwaarden<ph name="END_LINK1" /> en het <ph name="BEGIN_LINK2" />Privacybeleid<ph name="END_LINK2" /> van Chrome.</translation>
-<translation id="1919345977826869612">Advertenties</translation>
-<translation id="1919950603503897840">Contacten selecteren</translation>
-<translation id="1922076542920281912">Als je Chrome toegang wilt geven tot je locatie, moet je locatie ook inschakelen via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> van <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Updates</translation>
-<translation id="19288952978244135">Open Chrome opnieuw.</translation>
-<translation id="1933845786846280168">Geselecteerd tabblad</translation>
-<translation id="194341124344773587">Geef Chrome toestemming via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Wachtwoorden opslaan</translation>
-<translation id="1952172573699511566">Websites worden indien mogelijk weergegeven in je voorkeurstaal.</translation>
-<translation id="1960290143419248813">Updates van Chrome worden niet meer ondersteund voor deze versie van Android</translation>
-<translation id="1966710179511230534">Update je inloggegevens.</translation>
-<translation id="1974060860693918893">Geavanceerd</translation>
-<translation id="1984705450038014246">Je Chrome-gegevens synchroniseren</translation>
-<translation id="1984937141057606926">Toegestaan, behalve van derden</translation>
-<translation id="1986685561493779662">Naam bestaat al</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" />-knop</translation>
-<translation id="1989112275319619282">Browsen</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> wil koppelen</translation>
-<translation id="1994173015038366702">Site-URL</translation>
-<translation id="2000419248597011803">Hiermee worden bepaalde cookies en de zoekopdrachten in de adresbalk en in het zoekvak verzonden naar je standaard zoekmachine</translation>
-<translation id="2002537628803770967">Creditcards en adressen die Google Pay gebruiken</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# bestand}other{# bestanden}}</translation>
-<translation id="2017836877785168846">Wist de geschiedenis en automatische aanvullingen in de adresbalk.</translation>
-<translation id="2021896219286479412">Siteopties op volledig scherm</translation>
-<translation id="2038563949887743358">'Desktopsite aanvragen' inschakelen</translation>
-<translation id="2041019821020695769">Als je wilt dat Chrome je meldingen stuurt, moet je meldingen ook inschakelen via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> heeft ook gegevens in Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Site onderbroken</translation>
-<translation id="2063713494490388661">Tikken om te zoeken</translation>
-<translation id="2067805253194386918">sms</translation>
-<translation id="2079545284768500474">Ongedaan maken</translation>
-<translation id="2082238445998314030">Resultaat <ph name="RESULT_NUMBER" /> van <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Geluid</translation>
-<translation id="2096012225669085171">Synchronisatie en personalisatie op meerdere apparaten</translation>
-<translation id="2100273922101894616">Automatisch inloggen</translation>
-<translation id="2100314319871056947">Verdeel de tekst in kleinere stukken en deel in meerdere keren.</translation>
-<translation id="2107397443965016585">Vragen voordat sites beschermde content mogen afspelen (aanbevolen)</translation>
-<translation id="2111511281910874386">Ga naar pagina</translation>
-<translation id="2122601567107267586">Kan app niet openen</translation>
-<translation id="2126426811489709554">Mogelijk gemaakt door Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> bespaard</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> gesloten</translation>
-<translation id="2139186145475833000">Toevoegen aan startscherm</translation>
-<translation id="2146738493024040262">Instant-app openen</translation>
-<translation id="2148716181193084225">Vandaag</translation>
-<translation id="2154484045852737596">Pas bewerken</translation>
-<translation id="2154710561487035718">URL kopiëren</translation>
-<translation id="2156074688469523661">Resterende sites (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Als je iets op je telefoon wilt delen met een ander apparaat, schakel je de synchronisatie in de Chrome-instellingen op beide apparaten in</translation>
-<translation id="2170088579611075216">VR toestaan en openen</translation>
-<translation id="218608176142494674">Delen</translation>
-<translation id="2227444325776770048">Doorgaan als <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synchronisatie &amp; Google-services</translation>
-<translation id="2259659629660284697">Wachtwoorden exporteren…</translation>
-<translation id="2268044343513325586">Verfijnen</translation>
-<translation id="2286841657746966508">Factuuradres</translation>
-<translation id="2289270750774289114">Vragen wanneer een site Bluetooth-apparaten in de buurt wilt detecteren (aanbevolen)</translation>
-<translation id="230115972905494466">Geen geschikte apparaten gevonden</translation>
-<translation id="2315043854645842844">Certificaatselectie aan clientzijde wordt niet ondersteund door het besturingssysteem.</translation>
-<translation id="2318045970523081853">Tik om te bellen</translation>
-<translation id="2321086116217818302">Wachtwoorden voorbereiden…</translation>
-<translation id="2321958826496381788">Sleep de schuifknop tot je deze tekst prettig kunt lezen. De tekst moet minimaal deze grootte hebben nadat je op een alinea hebt gedubbeltikt.</translation>
-<translation id="2323763861024343754">Site-opslag</translation>
-<translation id="2328985652426384049">Kan niet inloggen</translation>
-<translation id="2330129964253841015">Waarschuwen als je wachtwoorden niet meer veilig zijn</translation>
-<translation id="2349710944427398404">Totale gegevens gebruikt door Chrome, inclusief accounts, bladwijzers en opgeslagen instellingen</translation>
-<translation id="2353636109065292463">Je internetverbinding controleren…</translation>
-<translation id="2359808026110333948">Doorgaan</translation>
-<translation id="2369533728426058518">geopende tabbladen</translation>
-<translation id="2387895666653383613">Tekstschaal</translation>
-<translation id="2394602618534698961">Bestanden die je downloadt, worden hier weergegeven</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Als je inlogt op je Google-account, wordt deze functie ingeschakeld</translation>
-<translation id="2410754283952462441">Een account selecteren</translation>
-<translation id="2414886740292270097">Donker</translation>
-<translation id="2416359993254398973">Chrome heeft toegangsrechten voor je camera nodig voor deze site.</translation>
-<translation id="2426805022920575512">Een ander account kiezen</translation>
-<translation id="2433507940547922241">Vormgeving</translation>
-<translation id="2434158240863470628">Download voltooid <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Locatietoegang</translation>
-<translation id="2450083983707403292">Wil je het downloaden van <ph name="FILE_NAME" /> opnieuw starten?</translation>
-<translation id="2482878487686419369">Meldingen</translation>
-<translation id="2490684707762498678">Beheerd door <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">De Google Assistent in Chrome</translation>
-<translation id="2496180316473517155">Browsegeschiedenis</translation>
-<translation id="2497852260688568942">Synchronisatie is uitgeschakeld door je beheerder</translation>
-<translation id="2498359688066513246">Hulp en feedback</translation>
-<translation id="2501278716633472235">Terug</translation>
-<translation id="2513403576141822879">Bekijk <ph name="BEGIN_LINK" />Synchronisatie en Google-services<ph name="END_LINK" /> voor meer instellingen die verband houden met privacy, beveiliging en gegevensverzameling.</translation>
-<translation id="2518590038762162553">In de Lite-versie van Chrome worden pagina's sneller geladen en wordt tot wel 60 procent minder data verbruikt. Chrome stuurt je webverkeer naar Google om de pagina's te optimaliseren die je bezoekt. <ph name="BEGIN_LINK" />Meer informatie<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Hiermee worden de URL's van pagina's die je bezoekt, verzonden naar Google</translation>
-<translation id="2532336938189706096">Webweergave</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> items verwijderd</translation>
-<translation id="2536728043171574184">Een offline exemplaar van deze pagina bekijken</translation>
-<translation id="2546283357679194313">Cookies en sitegegevens</translation>
-<translation id="2567385386134582609">AFBEELDING</translation>
-<translation id="257088987046510401">Thema's</translation>
-<translation id="2570922361219980984">Locatietoegang is ook uitgeschakeld voor dit apparaat. Schakel dit in via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Uitgevouwen; klik om samen te vouwen.</translation>
-<translation id="2581165646603367611">Hiermee worden cookies, het cachegeheugen en andere gegevens gewist van sites waarvan Chrome denkt dat deze niet belangrijk zijn.</translation>
-<translation id="2586657967955657006">Klembord</translation>
-<translation id="2587052924345400782">Nieuwere versie beschikbaar</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Kaartnummer</translation>
-<translation id="2621115761605608342">JavaScript toestaan voor een specfieke site.</translation>
-<translation id="2625189173221582860">Wachtwoord gekopieerd</translation>
-<translation id="2631006050119455616">Bespaard</translation>
-<translation id="2647434099613338025">Taal toevoegen</translation>
-<translation id="2650751991977523696">Bestand opnieuw downloaden?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# audiobestand}other{# audiobestanden}}</translation>
-<translation id="2653659639078652383">Verzenden</translation>
-<translation id="2677748264148917807">Verlaten</translation>
-<translation id="2704606927547763573">Gekopieerd</translation>
-<translation id="2707726405694321444">Pagina vernieuwen</translation>
-<translation id="2709516037105925701">Automatisch aanvullen</translation>
-<translation id="2717722538473713889">E-mailadressen</translation>
-<translation id="2728754400939377704">Sorteren op site</translation>
-<translation id="2744248271121720757">Tik op een woord om meteen te zoeken of gerelateerde acties te bekijken</translation>
-<translation id="2760989362628427051">Het donkere thema inschakelen wanneer het donkere thema of de batterijbesparing van je apparaat is ingeschakeld</translation>
-<translation id="2762000892062317888">zojuist</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> seconden resterend</translation>
-<translation id="2779651927720337254">mislukt</translation>
-<translation id="2781151931089541271">1 seconde resterend</translation>
-<translation id="2801022321632964776">Voer een update uit om jouw taal te gebruiken in de nieuwste versie van Chrome</translation>
-<translation id="2810645512293415242">Vereenvoudigde pagina om data te besparen en sneller te laden.</translation>
-<translation id="281504910091592009">Bekijk en beheer opgeslagen wachtwoorden in je <ph name="BEGIN_LINK" />Google-account<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Log in en schakel synchronisatie in om op al je apparaten toegang tot je bladwijzers te hebben</translation>
-<translation id="2822354292072154809">Weet je zeker dat je alle siterechten voor <ph name="CHOSEN_OBJECT_NAME" /> wilt resetten?</translation>
-<translation id="2836148919159985482">Tik op de knop Terug om het volledige scherm te sluiten.</translation>
-<translation id="2842985007712546952">Bovenliggende map</translation>
-<translation id="2858138569776157458">Topsites</translation>
-<translation id="2860954141821109167">Zorg ervoor dat een telefoon-app is ingeschakeld op dit apparaat</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Vorig nummer</translation>
-<translation id="2876369937070532032">Verzendt URL's van bepaalde pagina's die je bezoekt naar Google wanneer je beveiliging risico loopt</translation>
-<translation id="2888126860611144412">Over Chrome</translation>
-<translation id="2891154217021530873">Stoppen met het laden van de pagina</translation>
-<translation id="2893180576842394309">Google kan je geschiedenis gebruiken om Google Zoeken en andere Google-services te personaliseren</translation>
-<translation id="2898264748040935573">Opgeslagen wachtwoord bewerken</translation>
-<translation id="2900528713135656174">Afspraak maken</translation>
-<translation id="290376772003165898">Is deze pagina niet in het <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">De lijst met apparaten om een tabblad mee te delen, is op volledige hoogte geopend.</translation>
-<translation id="2910701580606108292">Vragen voordat sites beschermde content mogen afspelen</translation>
-<translation id="2913331724188855103">Sites toestaan cookiegegevens op te slaan en te lezen (aanbevolen)</translation>
-<translation id="2923908459366352541">Naam is ongeldig</translation>
-<translation id="2932150158123903946">Opslag van Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Voorbeeldtabblad is gesloten</translation>
-<translation id="2956410042958133412">Dit account wordt beheerd door <ph name="PARENT_NAME_1" /> en <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Overgeschakeld naar incognitotabbladen</translation>
-<translation id="2968755619301702150">Certificaatviewer</translation>
-<translation id="2979025552038692506">Geselecteerd incognitotabblad</translation>
-<translation id="2987620471460279764">Gedeelde tekst van ander apparaat</translation>
-<translation id="2989523299700148168">Onlangs bezocht</translation>
-<translation id="2996291259634659425">Wachtwoordzin maken</translation>
-<translation id="2996809686854298943">URL vereist</translation>
-<translation id="300526633675317032">Hiermee wordt de volledige <ph name="SIZE_IN_KB" /> aan site-opslag gewist.</translation>
-<translation id="3016635187733453316">Controleer of dit apparaat verbinding heeft met internet</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB gedownload</translation>
-<translation id="3029704984691124060">Wachtwoordzinnen komen niet overeen</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Hulp krijgen<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Locatie is uitgeschakeld. Je kunt dit inschakelen in de <ph name="BEGIN_LINK" />instellingen van Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Je kunt synchronisatie op elk gewenst moment inschakelen via de instellingen</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> bladwijzer}other{<ph name="BOOKMARKS_COUNT_MANY" /> bladwijzers}}</translation>
-<translation id="3089395242580810162">Openen op incognitotabblad</translation>
-<translation id="3115898365077584848">Informatie weergeven</translation>
-<translation id="3123473560110926937">Geblokkeerd op bepaalde sites</translation>
-<translation id="3137521801621304719">Incognitomodus verlaten</translation>
-<translation id="3143515551205905069">Synchronisatie annuleren</translation>
-<translation id="3157842584138209013">Via de knop 'Meer opties' kun je zien hoeveel data je hebt bespaard</translation>
-<translation id="3166827708714933426">Sneltoetsen voor tabbladen en vensters</translation>
-<translation id="3181954750937456830">Safe Browsing (hiermee worden jij en je apparaat beschermd tegen gevaarlijke sites)</translation>
-<translation id="3190152372525844641">Schakel rechten in voor Chrome via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> opgeslagen gegevens</translation>
-<translation id="3205824638308738187">Bijna klaar</translation>
-<translation id="3207960819495026254">Toegevoegd aan 'Bladwijzers'</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> is verwijderd</translation>
-<translation id="321773570071367578">Als je je wachtwoordzin bent vergeten of deze instelling wilt wijzigen, <ph name="BEGIN_LINK" />stel je de synchronisatie opnieuw in<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Microfoon</translation>
-<translation id="3232754137068452469">Webapp</translation>
-<translation id="3236059992281584593">1 minuut resterend</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Bladwijzer instellen voor deze pagina</translation>
-<translation id="3259831549858767975">Alles op de pagina verkleinen</translation>
-<translation id="3269093882174072735">Afbeelding laden</translation>
-<translation id="3269956123044984603">Schakel in je account bij de instellingen van Android 'Gegevens automatisch synchroniseren' in om de tabbladen op je andere apparaten te bekijken.</translation>
-<translation id="3277252321222022663">Sites toegang geven tot sensoren (aanbevolen)</translation>
-<translation id="3282568296779691940">Inloggen bij Chrome</translation>
-<translation id="3288003805934695103">Laad de pagina opnieuw</translation>
-<translation id="32895400574683172">Meldingen zijn toegestaan</translation>
-<translation id="3295530008794733555">Surf sneller en verbruik minder data</translation>
-<translation id="3295602654194328831">Informatie verbergen</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Doorgaan met het downloaden van de content?</translation>
-<translation id="3306398118552023113">Deze app wordt uitgevoerd in Chrome</translation>
-<translation id="3315103659806849044">Je past op dit moment je instellingen voor synchronisatie en Google-services aan. Als je synchronisatie wilt inschakelen, tik je op Bevestigen onderaan het scherm. Omhoog navigeren</translation>
-<translation id="3328801116991980348">Site-informatie</translation>
-<translation id="3333961966071413176">Alle contacten</translation>
-<translation id="3334729583274622784">Bestandsextensie wijzigen?</translation>
-<translation id="3341058695485821946">Bekijk hoeveel data je hebt bespaard</translation>
-<translation id="3350687908700087792">Alle incognitotabbladen sluiten</translation>
-<translation id="3353615205017136254">Lite-pagina geleverd door Google. Tik om de knop 'Origineel laden' om de originele pagina te laden.</translation>
-<translation id="3367813778245106622">Log opnieuw in om de synchronisatie te starten</translation>
-<translation id="3374023511497244703">Je bladwijzers, geschiedenis, wachtwoorden en andere Chrome-gegevens worden niet meer gesynchroniseerd met je Google-account</translation>
-<translation id="3384347053049321195">Afbeelding delen</translation>
-<translation id="3386292677130313581">Vragen of je sites toegang wilt verlenen tot je locatie (aanbevolen)</translation>
-<translation id="3387650086002190359">Downloaden van <ph name="FILE_NAME" /> is mislukt door fouten in het bestandssysteem.</translation>
-<translation id="3389286852084373014">Tekst is te groot</translation>
-<translation id="3398320232533725830">Bladwijzerbeheer openen</translation>
-<translation id="3414952576877147120">Grootte:</translation>
-<translation id="3443221991560634068">De huidige pagina opnieuw laden</translation>
-<translation id="3445014427084483498">Zojuist</translation>
-<translation id="3478363558367712427">Je kunt je zoekmachine kiezen</translation>
+<translation id="6910211073230771657">Verwijderd</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, begrepen</translation>
+<translation id="7658239707568436148">Annuleren</translation>
 <translation id="3479552764303398839">Niet nu</translation>
-<translation id="3492207499832628349">Nieuw incognitotabblad</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Meer informatie<ph name="END_LINK" /> over voorgestelde content</translation>
-<translation id="3513704683820682405">Augmented reality</translation>
-<translation id="3518985090088779359">Accept. en doorgaan</translation>
-<translation id="3522247891732774234">Update beschikbaar. Meer opties</translation>
-<translation id="3524138585025253783">UI voor ontwikkelaars</translation>
-<translation id="3527085408025491307">Map</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB beschikbaar</translation>
-<translation id="3549657413697417275">Zoek in je geschiedenis</translation>
-<translation id="3557336313807607643">Toevoegen aan contacten</translation>
-<translation id="3566923219790363270">Chrome wordt nog voorbereid voor VR. Start Chrome later opnieuw op.</translation>
-<translation id="3568688522516854065">Log in en schakel synchronisatie in om de tabbladen van je andere apparaten te bekijken</translation>
-<translation id="3587482841069643663">Alles</translation>
-<translation id="358794129225322306">Een site toestaan automatisch meerdere bestanden te downloaden.</translation>
-<translation id="3590487821116122040">Site-opslag waarvan Chrome denkt dat deze niet belangrijk is (bijvoorbeeld sites zonder opgeslagen instellingen of sites die je niet vaak bezoekt)</translation>
-<translation id="3599863153486145794">Hiermee wordt de geschiedenis van alle ingelogde apparaten gewist. Er kunnen andere vormen van browsegeschiedenis zijn opgeslagen voor je Google-account op <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Sites dempen die geluid afspelen</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Delen met <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Maskering van wachtwoord ongedaan maken</translation>
-<translation id="363596933471559332">Automatisch inloggen bij websites met de opgeslagen inloggegevens. Wanneer de functie is uitgeschakeld, word je elke keer om verificatie gevraagd voordat je wordt ingelogd bij een website.</translation>
-<translation id="3658159451045945436">Als je reset, wordt je databesparingsgeschiedenis gewist, waaronder de lijst met bezochte sites.</translation>
-<translation id="3692944402865947621">Downloaden van <ph name="FILE_NAME" /> mislukt omdat de opslaglocatie niet bereikbaar is.</translation>
-<translation id="3714981814255182093">De zoekbalk openen</translation>
-<translation id="3716182511346448902">Omdat deze pagina te veel geheugen gebruikt, heeft Chrome de pagina onderbroken.</translation>
-<translation id="3730075448226062617">Als je Chrome ook toegang wilt geven tot je microfoon, moet je de microfoon ook inschakelen via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Bladwijzer toegevoegd in <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Synchronisatie op de achtergrond</translation>
-<translation id="3771001275138982843">Kan de update niet downloaden</translation>
-<translation id="3771033907050503522">Incognitotabbladen</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Schakel Bluetooth in<ph name="END_LINK" /> om te koppelen</translation>
-<translation id="3775705724665058594">Verzenden naar je apparaten</translation>
-<translation id="3778956594442850293">Toegevoegd aan startscherm</translation>
-<translation id="3789841737615482174">Installeren</translation>
-<translation id="3810838688059735925">Videobestanden</translation>
-<translation id="3810973564298564668">Beheren</translation>
-<translation id="381841723434055211">Telefoonnummers</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> downloads verwijderd</translation>
-<translation id="3822502789641063741">Site-opslag wissen?</translation>
-<translation id="385051799172605136">Vorige</translation>
-<translation id="3859306556332390985">Vooruit zoeken</translation>
-<translation id="3894427358181296146">Map toevoegen</translation>
-<translation id="3895926599014793903">Zoom inschakelen forceren</translation>
-<translation id="3912508018559818924">We zoeken naar het beste op internet…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Mijn gegevens combineren</translation>
-<translation id="393697183122708255">Gesproken zoekopdracht niet beschikbaar</translation>
-<translation id="395206256282351086">Zoek- en sitesuggesties uitgeschakeld</translation>
-<translation id="3955193568934677022">Toestaan dat sites beschermde content afspelen (aanbevolen)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome laadt de pagina wanneer deze gereed is}other{Chrome laadt de pagina's wanneer deze gereed zijn}}</translation>
-<translation id="3963007978381181125">Wachtwoordzinversleuteling is niet van toepassing op betaalmethoden en adressen van Google Pay. Alleen iemand met je wachtwoordzin kan je versleutelde gegevens lezen. De wachtwoordzin wordt niet verzonden naar of opgeslagen door Google. Als je je wachtwoordzin vergeet of deze instelling wilt wijzigen, moet je de synchronisatie resetten. <ph name="BEGIN_LINK" />Meer informatie<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Downloaden voltooid</translation>
-<translation id="397583555483684758">Synchronisatie werkt niet meer</translation>
-<translation id="3976396876660209797">Verwijder de snelkoppeling en maak deze opnieuw</translation>
-<translation id="3985215325736559418">Wil je <ph name="FILE_NAME" /> opnieuw downloaden?</translation>
-<translation id="3987993985790029246">Link kop.</translation>
-<translation id="3988213473815854515">Locatie is toegestaan</translation>
-<translation id="3988466920954086464">Instant-zoekresultaten weergeven in dit venster</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> van ?</translation>
-<translation id="3997476611815694295">Onbelangrijke opslag</translation>
-<translation id="4000212216660919741">Homepage voor offline</translation>
+<translation id="5317780077021120954">Opslaan</translation>
+<translation id="4570913071927164677">Details</translation>
+<translation id="8730621377337864115">Gereed</translation>
+<translation id="8261506727792406068">Verwijderen</translation>
+<translation id="1181037720776840403">Verwijderen</translation>
+<translation id="5939518447894949180">Resetten</translation>
 <translation id="4002066346123236978">Titel</translation>
-<translation id="4008040567710660924">Cookies voor een specifieke site toestaan.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# uur}other{# uur}}</translation>
-<translation id="4046123991198612571">Volgend nummer</translation>
-<translation id="4048707525896921369">Meer informatie over onderwerpen op websites zonder dat je de pagina hoeft te verlaten. 'Tikken om te zoeken' stuurt een woord en contextuele informatie voor het woord naar Google Zoeken, waarna er definities, afbeeldingen, zoekresultaten en andere gegevens worden weergegeven.
+<translation id="5916664084637901428">Aan</translation>
+<translation id="5860033963881614850">Uit</translation>
+<translation id="6165508094623778733">Meer informatie</translation>
+<translation id="6042308850641462728">Meer</translation>
+<translation id="6040143037577758943">Sluiten</translation>
+<translation id="780301667611848630">Nee, bedankt</translation>
+<translation id="1201402288615127009">Volgende</translation>
+<translation id="2359808026110333948">Doorgaan</translation>
+<translation id="2653659639078652383">Verzenden</translation>
+<translation id="2079545284768500474">Ongedaan maken</translation>
+<translation id="7649070708921625228">Hulp</translation>
+<translation id="2148716181193084225">Vandaag</translation>
+<translation id="7781829728241885113">Gisteren</translation>
+<translation id="6945221475159498467">Selecteren</translation>
+<translation id="7791543448312431591">Toevoegen</translation>
+<translation id="6527303717912515753">Delen</translation>
+<translation id="1383876407941801731">Zoeken</translation>
+<translation id="3115898365077584848">Informatie weergeven</translation>
+<translation id="3295602654194328831">Informatie verbergen</translation>
+<translation id="3987993985790029246">Link kop.</translation>
+<translation id="2704606927547763573">Gekopieerd</translation>
+<translation id="8725066075913043281">Opnieuw proberen</translation>
+<translation id="385051799172605136">Vorige</translation>
+<translation id="8131740175452115882">Bevestigen</translation>
+<translation id="5300589172476337783">Weergeven</translation>
+<translation id="1124772482545689468">Gebruiker</translation>
+<translation id="8609465669617005112">Omhoog</translation>
+<translation id="6746124502594467657">Omlaag</translation>
+<translation id="8249310407154411074">Bovenaan zetten</translation>
+<translation id="8428213095426709021">Instellingen</translation>
+<translation id="2498359688066513246">Hulp en feedback</translation>
+<translation id="8378714024927312812">Beheerd door je organisatie</translation>
+<translation id="9019902583201351841">Beheerd door je ouders</translation>
+<translation id="4645575059429386691">Beheerd door je ouder</translation>
+<translation id="4883854917563148705">Beheerde instellingen kunnen niet worden gereset</translation>
+<translation id="4307992518367153382">Basisinstellingen</translation>
+<translation id="1974060860693918893">Geavanceerd</translation>
+<translation id="1146678959555564648">VR activeren</translation>
+<translation id="987264212798334818">Algemeen</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Downloads</translation>
+<translation id="218608176142494674">Delen</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Schermopname</translation>
+<translation id="4875775213178255010">Contentsuggesties</translation>
+<translation id="2021896219286479412">Siteopties op volledig scherm</translation>
+<translation id="4587589328781138893">Sites</translation>
+<translation id="4943703118917034429">Virtual reality</translation>
+<translation id="1928696683969751773">Updates</translation>
+<translation id="6064125863973209585">Voltooide downloads</translation>
+<translation id="5342314432463739672">Rechtenverzoeken</translation>
+<translation id="629730747756840877">Account</translation>
+<translation id="82609232232243542">Inloggen bij Brave</translation>
+<translation id="7956662517480676674">Synchronisatie &amp; Brave Software-services</translation>
+<translation id="5294439808117722387">Je past op dit moment je instellingen voor synchronisatie en Brave Software-services aan. Als je synchronisatie wilt inschakelen, tik je op Bevestigen onderaan het scherm. Omhoog navigeren</translation>
+<translation id="2096012225669085171">Synchronisatie en personalisatie op meerdere apparaten</translation>
+<translation id="1692118695553449118">Synchronisatie is ingeschakeld</translation>
+<translation id="5514904542973294328">Uitgeschakeld door de beheerder van dit apparaat</translation>
+<translation id="6447211988989208781">Brave Software-activiteitsopties</translation>
+<translation id="4882831918239250449">Beheren hoe je browsegeschiedenis wordt gebruikt om Brave Software Zoeken, advertenties en meer te personaliseren</translation>
+<translation id="7431991332293347422">Beheren hoe je browsegeschiedenis wordt gebruikt om Brave Software Zoeken en meer te personaliseren</translation>
+<translation id="6303969859164067831">Uitloggen en synchronisatie uitschakelen</translation>
+<translation id="1125261911132334651">Je Brave Software-account beheren</translation>
+<translation id="6406506848690869874">Synchronisatie</translation>
+<translation id="714362445477979774">Je Brave-gegevens synchroniseren</translation>
+<translation id="4314815835985389558">Synchronisatie beheren</translation>
+<translation id="5428209950370661546">Andere Brave Software-services</translation>
+<translation id="7704317875155739195">Zoekopdrachten en URL's automatisch aanvullen</translation>
+<translation id="2000419248597011803">Hiermee worden bepaalde cookies en de zoekopdrachten in de adresbalk en in het zoekvak verzonden naar je standaard zoekmachine</translation>
+<translation id="7981313251711023384">Pagina's vooraf laden voor sneller browsen en zoeken</translation>
+<translation id="1821253160463689938">Maakt gebruik van cookies om je voorkeuren te onthouden, zelfs als je deze pagina's niet bezoekt</translation>
+<translation id="6697492270171225480">Suggesties voor vergelijkbare pagina's weergeven wanneer een pagina niet wordt gevonden</translation>
+<translation id="8109318360573330108">Hiermee wordt de URL van de pagina die je probeert te openen, verzonden naar Brave Software</translation>
+<translation id="8438566539970814960">Zoekopdrachten en browsefunctionaliteit verbeteren</translation>
+<translation id="284843628681142937">Hiermee worden de URL's van pagina's die je bezoekt, verzonden naar Brave Software</translation>
+<translation id="7222718784508482526">Bekijk <ph name="BEGIN_LINK"/>Synchronisatie en Brave Software-services<ph name="END_LINK"/> voor meer instellingen die verband houden met privacy, beveiliging en gegevensverzameling.</translation>
+<translation id="918192811481327695">Help de functies en prestaties van Brave verbeteren</translation>
+<translation id="9063160602596686558">Hiermee worden automatisch gebruiksstatistieken en crashrapporten naar Brave Software verzonden</translation>
+<translation id="4824958205181053313">Synchronisatie annuleren?</translation>
+<translation id="3058498974290601450">Je kunt synchronisatie op elk gewenst moment inschakelen via de instellingen</translation>
+<translation id="3143515551205905069">Synchronisatie annuleren</translation>
+<translation id="1506061864768559482">Zoekmachine</translation>
+<translation id="55737423895878184">Locatie en meldingen zijn toegestaan</translation>
+<translation id="3988213473815854515">Locatie is toegestaan</translation>
+<translation id="32895400574683172">Meldingen zijn toegestaan</translation>
+<translation id="9040142327097499898">Meldingen zijn toegestaan. Locatie is uitgeschakeld voor dit apparaat.</translation>
+<translation id="305593374596241526">Locatie is uitgeschakeld. Je kunt dit inschakelen in de <ph name="BEGIN_LINK"/>instellingen van Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Onlangs bezocht</translation>
+<translation id="6433501201775827830">Je zoekmachine kiezen</translation>
+<translation id="7177466738963138057">Je kunt dit later wijzigen in Instellingen</translation>
+<translation id="3478363558367712427">Je kunt je zoekmachine kiezen</translation>
+<translation id="4910889077668685004">Betaal-apps</translation>
+<translation id="5152843274749979095">Geen ondersteunde apps geïnstalleerd</translation>
+<translation id="8812260976093120287">Op sommige websites kun je betalen met de bovenstaande ondersteunde betaal-apps op je apparaat.</translation>
+<translation id="7764225426217299476">Adres toevoegen</translation>
+<translation id="5595485650161345191">Adres bewerken</translation>
+<translation id="5087580092889165836">Pas toevoegen</translation>
+<translation id="2154484045852737596">Pas bewerken</translation>
+<translation id="6140912465461743537">Land/regio</translation>
+<translation id="5659593005791499971">E-mailadres</translation>
+<translation id="4378154925671717803">Telefoon</translation>
+<translation id="4807098396393229769">Naam op pas</translation>
+<translation id="860043288473659153">Naam kaarthouder</translation>
+<translation id="2612676031748830579">Kaartnummer</translation>
+<translation id="869891660844655955">Vervaldatum</translation>
+<translation id="2286841657746966508">Factuuradres</translation>
+<translation id="663059986967017181">Gekopieerd naar Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> andere}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> andere}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> andere}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> andere}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> andere}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> andere}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> andere}other{<ph name="CONTACT_PREVIEW"/>\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> andere}}</translation>
+<translation id="7029809446516969842">Wachtwoorden</translation>
+<translation id="1943432128510653496">Wachtwoorden opslaan</translation>
+<translation id="2100273922101894616">Automatisch inloggen</translation>
+<translation id="363596933471559332">Automatisch inloggen bij websites met de opgeslagen inloggegevens. Wanneer de functie is uitgeschakeld, word je elke keer om verificatie gevraagd voordat je wordt ingelogd bij een website.</translation>
+<translation id="6995899638241819463">Waarschuwen als je wachtwoorden zijn gelekt bij een gegevenslek</translation>
+<translation id="1534287762301776620">Als je inlogt op je Brave Software-account, wordt deze functie ingeschakeld</translation>
+<translation id="10614374240317010">Nooit opgeslagen</translation>
+<translation id="3098842761938485917">Bekijk en beheer opgeslagen wachtwoorden in je <ph name="BEGIN_LINK"/>Brave Software-account<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Opgeslagen wachtwoorden worden hier weergegeven.</translation>
+<translation id="8084114998886531721">Opgeslagen wachtwoord</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Gebruikersnaam</translation>
+<translation id="6657585470893396449">Wachtwoord</translation>
+<translation id="2154710561487035718">URL kopiëren</translation>
+<translation id="1571304935088121812">Gebruikersnaam kopiëren</translation>
+<translation id="5005498671520578047">Wachtwoord kopiëren</translation>
+<translation id="3632295766818638029">Maskering van wachtwoord ongedaan maken</translation>
+<translation id="1513858653616922153">Wachtwoord verwijderen</translation>
+<translation id="543338862236136125">Wachtwoord bewerken</translation>
+<translation id="4565377596337484307">Wachtwoord verbergen</translation>
+<translation id="8523928698583292556">Opgeslagen wachtwoord verwijderen</translation>
+<translation id="2898264748040935573">Opgeslagen wachtwoord bewerken</translation>
+<translation id="5433691172869980887">Gebruikersnaam gekopieerd</translation>
+<translation id="5534640966246046842">Site gekopieerd</translation>
+<translation id="2625189173221582860">Wachtwoord gekopieerd</translation>
+<translation id="4550003330909367850">Als je hier je wachtwoord wilt bekijken of kopiëren, stel je schermvergrendeling in op dit apparaat.</translation>
+<translation id="6154478581116148741">Schakel schermvergrendeling in via Instellingen om je wachtwoorden te exporteren vanaf dit apparaat</translation>
+<translation id="4842092870884894799">Pop-upvenster voor wachtwoord genereren wordt weergegeven</translation>
+<translation id="2259659629660284697">Wachtwoorden exporteren…</translation>
+<translation id="133012818630824069">Wachtwoorden exporteren die zijn opgeslagen in Brave</translation>
+<translation id="6914783257214138813">Je wachtwoorden zijn zichtbaar voor iedereen die het geëxporteerde bestand kan bekijken.</translation>
+<translation id="2321086116217818302">Wachtwoorden voorbereiden…</translation>
+<translation id="8445448999790540984">Wachtwoorden kunnen niet worden geëxporteerd</translation>
+<translation id="3066461326500799725">Meer informatie over het gebruik van Brave Software Drive</translation>
+<translation id="729975465115245577">Je apparaat bevat geen app om het wachtwoordbestand in op te slaan.</translation>
+<translation id="7682724950699840886">Probeer de volgende tips: zorg dat er voldoende ruimte op je apparaat beschikbaar is, probeer opnieuw te exporteren.</translation>
+<translation id="1129510026454351943">Details: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Ontgrendelen om je wachtwoord te kopiëren</translation>
+<translation id="5515439363601853141">Ontgrendelen om je wachtwoord te bekijken</translation>
+<translation id="6221633008163990886">Ontgrendel het apparaat om je wachtwoorden te exporteren</translation>
+<translation id="230699814587342492">Brave-wachtwoorden</translation>
+<translation id="6075798973483050474">Homepage bewerken</translation>
+<translation id="854522910157234410">Deze pagina openen</translation>
+<translation id="2482878487686419369">Meldingen</translation>
+<translation id="6255999984061454636">Contentsuggesties</translation>
+<translation id="805047784848435650">Op basis van je browsegeschiedenis</translation>
+<translation id="1041308826830691739">Van websites</translation>
+<translation id="395206256282351086">Zoek- en sitesuggesties uitgeschakeld</translation>
+<translation id="257088987046510401">Thema's</translation>
+<translation id="4650364565596261010">Systeemstandaard</translation>
+<translation id="7588219262685291874">Het donkere thema inschakelen wanneer de batterijbesparing van je apparaat is ingeschakeld</translation>
+<translation id="2760989362628427051">Het donkere thema inschakelen wanneer het donkere thema of de batterijbesparing van je apparaat is ingeschakeld</translation>
+<translation id="6381421346744604172">Websites donkerder maken</translation>
+<translation id="5040262127954254034">Privacy</translation>
+<translation id="4991384657077828949">Help de beveiliging van Brave te verbeteren</translation>
+<translation id="1943176487615318915">Brave verzendt de URL's van sommige pagina's die je bezoekt, beperkte systeemgegevens en bepaalde paginacontent naar Brave Software om gevaarlijke apps en sites te detecteren</translation>
+<translation id="3181954750937456830">Safe Browsing (hiermee worden jij en je apparaat beschermd tegen gevaarlijke sites)</translation>
+<translation id="7315322926489145388">Verzendt URL's van bepaalde pagina's die je bezoekt naar Brave Software wanneer je beveiliging risico loopt</translation>
+<translation id="2063713494490388661">Tikken om te zoeken</translation>
+<translation id="2369463299479365221">Meer informatie over onderwerpen op websites zonder dat je de pagina hoeft te verlaten. 'Tikken om te zoeken' stuurt een woord en contextuele informatie voor het woord naar Brave Software Zoeken, waarna er definities, afbeeldingen, zoekresultaten en andere gegevens worden weergegeven.
 
 Als je de zoekterm wilt aanpassen, houd je deze aangeraakt om de term te selecteren. Als je je zoekopdracht wilt verfijnen, veeg je het deelvenster helemaal naar boven en tik je op het zoekvak.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Opties beschikbaar boven aan het scherm</translation>
-<translation id="4062305924942672200">Juridische informatie</translation>
-<translation id="4084682180776658562">Bladwijzer maken</translation>
-<translation id="4084712963632273211">Van <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />geleverd door Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">App-gegevens verwijderen?</translation>
-<translation id="4099578267706723511">Verzend automatisch gebruiksstatistieken en crashmeldingen naar Google.</translation>
-<translation id="410351446219883937">Automatisch afspelen</translation>
-<translation id="4116038641877404294">Download pagina's om ze offline te gebruiken</translation>
-<translation id="4135200667068010335">De lijst met apparaten om een tabblad mee te delen is gesloten.</translation>
-<translation id="4149994727733219643">Vereenvoudigde weergave voor webpagina's</translation>
-<translation id="4165986682804962316">Site-instellingen</translation>
-<translation id="4169535189173047238">Niet toestaan</translation>
-<translation id="4170011742729630528">De service is niet beschikbaar. Probeer het later opnieuw.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> gebruikt</translation>
-<translation id="4181841719683918333">Talen</translation>
-<translation id="4183868528246477015">Zoeken met Google Lens <ph name="BEGIN_NEW" />Nieuw<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Openen op nieuw tabblad</translation>
-<translation id="4198423547019359126">Geen beschikbare downloadlocaties</translation>
-<translation id="4209895695669353772">Schakel synchronisatie in om suggesties voor gepersonaliseerde content van Google te ontvangen</translation>
-<translation id="4226663524361240545">Het apparaat kan trillen bij meldingen</translation>
-<translation id="423219824432660969">Gesynchroniseerde gegevens versleutelen met Google-wachtwoord vanaf <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Instellingen openen</translation>
-<translation id="4256782883801055595">Open-sourcelicenties</translation>
-<translation id="4259722352634471385">Navigatie is geblokkeerd: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Linkadres kopiëren</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Toegestaan</translation>
-<translation id="429312253194641664">Een site speelt media af</translation>
-<translation id="4298388696830689168">Gekoppelde sites</translation>
-<translation id="4307992518367153382">Basisinstellingen</translation>
-<translation id="4314815835985389558">Synchronisatie beheren</translation>
-<translation id="4351244548802238354">Dialoogvenster sluiten</translation>
-<translation id="4378154925671717803">Telefoon</translation>
-<translation id="4384468725000734951">Sogou wordt gebruikt om te zoeken</translation>
-<translation id="4404568932422911380">Geen bladwijzers</translation>
-<translation id="4405224443901389797">Verplaatsen naar…</translation>
-<translation id="4411535500181276704">Lite-versie</translation>
-<translation id="4415276339145661267">Je Google-account beheren</translation>
-<translation id="4432792777822557199">Pagina's in het <ph name="SOURCE_LANGUAGE" /> worden vanaf nu vertaald naar het <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Lite-pagina geleverd door Google</translation>
-<translation id="4434045419905280838">Pop-ups en omleidingen</translation>
-<translation id="4440958355523780886">Lite-pagina weergegeven door Google. Tik om het origineel te laden.</translation>
-<translation id="4452411734226507615">Tabblad <ph name="TAB_TITLE" /> sluiten</translation>
-<translation id="4452548195519783679">Bladwijzer gemaakt in <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Sites toestaan om beschermde content af te spelen</translation>
-<translation id="4468959413250150279">Geluid dempen voor een specifieke site.</translation>
-<translation id="4472118726404937099">Log in en schakel synchronisatie in om verschillende apparaten te synchroniseren en te personaliseren</translation>
-<translation id="447252321002412580">Help de functies en prestaties van Chrome verbeteren</translation>
-<translation id="4479647676395637221">Eerst vragen voordat sites je camera mogen gebruiken (aanbevolen)</translation>
-<translation id="4479972344484327217"><ph name="MODULE" /> installeren voor Chrome…</translation>
-<translation id="4487967297491345095">Alle app-gegevens voor Chrome worden definitief verwijderd. Dit omvat alle bestanden, instellingen, accounts, databases, enzovoort.</translation>
-<translation id="4493497663118223949">Lite-versie is ingeschakeld</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# dag geleden}other{# dagen geleden}}</translation>
-<translation id="451872707440238414">Zoek in je bladwijzers</translation>
-<translation id="4521489764227272523">De geselecteerde gegevens zijn verwijderd uit Chrome en van je gesynchroniseerde apparaten.
-
-Voor je Google-account kunnen andere vormen van browsegeschiedenis (zoals zoekopdrachten en activiteit uit andere Google-services) beschikbaar zijn via <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Map kiezen</translation>
-<translation id="4538018662093857852">Lite-versie inschakelen</translation>
-<translation id="4550003330909367850">Als je hier je wachtwoord wilt bekijken of kopiëren, stel je schermvergrendeling in op dit apparaat.</translation>
-<translation id="4558311620361989323">Sneltoetsen voor webpagina's</translation>
-<translation id="4561979708150884304">Geen verbinding</translation>
-<translation id="4565377596337484307">Wachtwoord verbergen</translation>
-<translation id="4570913071927164677">Details</translation>
-<translation id="4572422548854449519">Inloggen bij een beheerd account</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minuut geleden}other{# minuten geleden}}</translation>
-<translation id="4587589328781138893">Sites</translation>
-<translation id="4594952190837476234">Deze offline pagina is van <ph name="CREATION_TIME" /> en kan afwijken van de online versie.</translation>
-<translation id="4605958867780575332">Item verwijderd: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> openen</translation>
-<translation id="4634124774493850572">Wachtwoord gebruiken</translation>
-<translation id="4645575059429386691">Beheerd door je ouder</translation>
-<translation id="4650364565596261010">Systeemstandaard</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> bladwijzers verwijderd</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> is toegevoegd aan je startscherm</translation>
-<translation id="4684427112815847243">Alles synchroniseren</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> andere}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> andere}}</translation>
-<translation id="4696983787092045100">Tekst naar je apparaten verzenden</translation>
-<translation id="4698034686595694889">Offline bekijken in <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Gecachte afbeeldingen en bestanden</translation>
-<translation id="4714588616299687897">Bespaar tot 60% van je gegevens</translation>
-<translation id="4719927025381752090">Aanbieden om te vertalen</translation>
-<translation id="4720023427747327413">Openen in <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Help bij het verbeteren van Chrome. <ph name="BEGIN_LINK" />Enquête invullen<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Updaten</translation>
-<translation id="4738836084190194332">Laatst gesynchroniseerd: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Een nieuw tabblad openen</translation>
-<translation id="4751476147751820511">Bewegings- of lichtsensoren</translation>
-<translation id="4759238208242260848">Downloads</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download voltooid.}other{# downloads voltooid.}}</translation>
-<translation id="4797039098279997504">Tik om terug te gaan naar <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Wachtwoordzinversleuteling is niet van toepassing op betaalmethoden en adressen van Google Pay.
-
-<ph name="BEGIN_LINK" />Reset de synchronisatie<ph name="END_LINK" /> als je deze instelling wilt wijzigen.</translation>
-<translation id="4807098396393229769">Naam op pas</translation>
-<translation id="4824958205181053313">Synchronisatie annuleren?</translation>
-<translation id="4837753911714442426">Afdrukopties voor de pagina openen</translation>
-<translation id="4842092870884894799">Pop-upvenster voor wachtwoord genereren wordt weergegeven</translation>
-<translation id="4860895144060829044">Bellen</translation>
-<translation id="4866368707455379617">Kan <ph name="MODULE" /> niet installeren voor Chrome</translation>
-<translation id="4875775213178255010">Contentsuggesties</translation>
-<translation id="4878404682131129617">Kan geen tunnel tot stand brengen via de proxyserver</translation>
-<translation id="4880127995492972015">Vertalen…</translation>
-<translation id="4881695831933465202">Openen</translation>
-<translation id="488187801263602086">Naam van bestand wijzigen</translation>
-<translation id="4882831918239250449">Beheren hoe je browsegeschiedenis wordt gebruikt om Google Zoeken, advertenties en meer te personaliseren</translation>
-<translation id="4883854917563148705">Beheerde instellingen kunnen niet worden gereset</translation>
-<translation id="4885273946141277891">Niet-ondersteund aantal Chrome-instanties.</translation>
-<translation id="4910889077668685004">Betaal-apps</translation>
-<translation id="4913161338056004800">Statistieken resetten</translation>
-<translation id="4913169188695071480">Vernieuwen stopzetten</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Hulp<ph name="END_LINK" /> bij het zoeken naar apparaten…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# pagina}other{# pagina's}}</translation>
-<translation id="4932247056774066048">Omdat je uitlogt van een account dat wordt beheerd door <ph name="DOMAIN_NAME" />, worden je Chrome-gegevens verwijderd. De gegevens blijven in je Google-account staan.</translation>
-<translation id="4943703118917034429">Virtual reality</translation>
-<translation id="4943872375798546930">Geen resultaten</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> heeft toegang tot je scherm</translation>
-<translation id="4961107849584082341">Vertaal deze pagina in een andere taal</translation>
-<translation id="4962975101802056554">Alle rechten voor apparaat intrekken</translation>
-<translation id="4970824347203572753">Niet beschikbaar op jouw locatie</translation>
-<translation id="497421865427891073">Naar voren gaan</translation>
-<translation id="4988210275050210843">Bestand downloaden (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Pagina's</translation>
-<translation id="4994033804516042629">Geen contacten gevonden</translation>
-<translation id="4996978546172906250">Delen via</translation>
-<translation id="5004416275253351869">Google-activiteitsopties</translation>
-<translation id="5005498671520578047">Wachtwoord kopiëren</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> wil verbinding maken</translation>
-<translation id="5013696553129441713">Geen nieuwe suggesties</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">De site kan mogelijk informatie over je verzamelen wanneer VR actief is, zoals:
-  -  je fysieke kenmerken, bijvoorbeeld je lengte
-
-Controleer of je de site vertrouwt voordat je VR activeert.</translation>
+<translation id="2930742481329940825">Met 'Tikken om te zoeken' worden het geselecteerde woord en de huidige pagina als context naar Brave Software Zoeken verzonden. Je kunt deze functie uitschakelen bij <ph name="BEGIN_LINK"/>Instellingen<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Toestaan</translation>
-<translation id="5040262127954254034">Privacy</translation>
-<translation id="5048398596102334565">Sites toegang geven tot bewegingssensoren (aanbevolen)</translation>
-<translation id="5063480226653192405">Gebruik</translation>
-<translation id="5087580092889165836">Pas toevoegen</translation>
-<translation id="5100237604440890931">Samengevouwen; klik om uit te vouwen.</translation>
-<translation id="510275257476243843">1 uur resterend</translation>
-<translation id="5123685120097942451">Incognitotabblad</translation>
-<translation id="5127805178023152808">Synchronisatie is uitgeschakeld</translation>
-<translation id="5129038482087801250">Web-app installeren</translation>
-<translation id="5132942445612118989">Je wachtwoorden, geschiedenis en meer synchroniseren op al je apparaten</translation>
-<translation id="5139940364318403933">Meer informatie over het gebruik van Google Drive</translation>
-<translation id="515227803646670480">Opgeslagen gegevens wissen</translation>
-<translation id="5152843274749979095">Geen ondersteunde apps geïnstalleerd</translation>
-<translation id="5161254044473106830">Titel is vereist</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download mislukt.}other{# downloads mislukt.}}</translation>
-<translation id="5170568018924773124">Weergeven in map</translation>
-<translation id="5184329579814168207">Openen in Chrome</translation>
-<translation id="5193988420012215838">Naar klembord gekopieerd</translation>
-<translation id="5197729504361054390">De contacten die je selecteert, worden gedeeld met <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Werkprofiel</translation>
-<translation id="5210286577605176222">Naar het vorige tabblad gaan</translation>
-<translation id="5210365745912300556">Tabblad sluiten</translation>
-<translation id="5224771365102442243">Met video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> wil scannen naar Bluetooth-apparaten in de buurt. De volgende apparaten zijn gevonden:</translation>
-<translation id="5233638681132016545">Nieuw tabblad</translation>
-<translation id="526421993248218238">Kan deze pagina niet laden</translation>
-<translation id="5271967389191913893">Het apparaat kan de content niet openen die moet worden gedownload.</translation>
-<translation id="528192093759286357">Sleep vanaf de bovenkant en tik op de knop Terug om het volledige scherm te sluiten.</translation>
-<translation id="5292796745632149097">Verzenden naar</translation>
-<translation id="5300589172476337783">Weergeven</translation>
-<translation id="5301954838959518834">OK, begrepen</translation>
-<translation id="5304593522240415983">Dit veld mag niet leeg zijn</translation>
-<translation id="5307446750509046227">Site-opslag wissen</translation>
-<translation id="5308380583665731573">Verbinding maken</translation>
-<translation id="5313967007315987356">Site toevoegen</translation>
-<translation id="5317780077021120954">Opslaan</translation>
-<translation id="5324858694974489420">Instellingen voor ouders</translation>
-<translation id="5327248766486351172">Naam</translation>
-<translation id="5335288049665977812">Sites toestaan JavaScript uit te voeren (aanbevolen)</translation>
-<translation id="5342314432463739672">Rechtenverzoeken</translation>
-<translation id="5357811892247919462">Tabblad ontvangen</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> geopend tabblad, tik om tussen tabbladen te schakelen}other{<ph name="OPEN_TABS_MANY" /> geopende tabbladen, tik om tussen tabbladen te schakelen}}</translation>
-<translation id="5391532827096253100">Je verbinding met deze site is niet beveiligd. Site-informatie</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(en nog 1)}other{(en nog #)}}</translation>
-<translation id="5400569084694353794">Als je deze app gebruikt, ga je akkoord met de <ph name="BEGIN_LINK1" />servicevoorwaarden<ph name="END_LINK1" /> en het <ph name="BEGIN_LINK2" />privacybeleid<ph name="END_LINK2" /> van Chrome.</translation>
-<translation id="5403592356182871684">Namen</translation>
-<translation id="5403644198645076998">Alleen bepaalde sites toestaan</translation>
-<translation id="5414836363063783498">Verifiëren…</translation>
-<translation id="5423934151118863508">Je meest bezochte pagina's worden hier weergegeven</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB beschikbaar</translation>
-<translation id="543338862236136125">Wachtwoord bewerken</translation>
-<translation id="5433691172869980887">Gebruikersnaam gekopieerd</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> bestanden downloaden (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Naar de adresbalk gaan</translation>
-<translation id="5447201525962359567">Alle site-opslag, inclusief cookies en andere lokaal opgeslagen gegevens</translation>
-<translation id="5447765697759493033">Deze site wordt niet vertaald</translation>
-<translation id="545042621069398927">Je download wordt versneld.</translation>
-<translation id="5456381639095306749">Pagina downloaden</translation>
-<translation id="5475862044948910901">Augmented reality-sessie starten?</translation>
-<translation id="548278423535722844">Openen in app voor passen</translation>
-<translation id="5487521232677179737">Gegevens wissen</translation>
-<translation id="5494752089476963479">Advertenties blokkeren op sites die opdringerige of misleidende advertenties weergeven</translation>
-<translation id="5500777121964041360">Mogelijk niet beschikbaar op jouw locatie</translation>
-<translation id="5512137114520586844">Dit account wordt beheerd door <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Uitgeschakeld door de beheerder van dit apparaat</translation>
-<translation id="5515439363601853141">Ontgrendelen om je wachtwoord te bekijken</translation>
-<translation id="5516455585884385570">Instellingen voor meldingen openen</translation>
-<translation id="5517095782334947753">Je hebt bladwijzers, geschiedenis, wachtwoorden en andere instellingen van <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Omleiding geblokkeerd.</translation>
-<translation id="5527082711130173040">Chrome heeft locatietoegang nodig om naar apparaten te scannen. <ph name="BEGIN_LINK1" />Rechten updaten<ph name="END_LINK1" />. Locatietoegang is ook <ph name="BEGIN_LINK2" />uitgeschakeld voor dit apparaat<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Vragen voordat sites toestemming krijgen om tekst en afbeeldingen vanaf het klembord te lezen (aanbevolen)</translation>
-<translation id="5530766185686772672">Incognitotabbladen sluiten</translation>
-<translation id="5534334044554683961">De site kan mogelijk informatie over je verzamelen wanneer VR actief is, zoals:
-  -   je fysieke kenmerken, bijvoorbeeld je lengte
-  -   de indeling van je kamer
-
-Controleer of je de site vertrouwt voordat je VR activeert.</translation>
-<translation id="5534640966246046842">Site gekopieerd</translation>
-<translation id="5556459405103347317">Opnieuw laden</translation>
-<translation id="5561549206367097665">Wachten op netwerk…</translation>
-<translation id="557283862590186398">Chrome heeft toegangsrechten voor je microfoon nodig voor deze site.</translation>
-<translation id="55737423895878184">Locatie en meldingen zijn toegestaan</translation>
-<translation id="5578795271662203820">Zoeken op <ph name="SEARCH_ENGINE" /> naar afbeelding</translation>
-<translation id="5581519193887989363">Je kunt altijd in de <ph name="BEGIN_LINK1" />instellingen<ph name="END_LINK1" /> bepalen wat je wilt synchroniseren.</translation>
-<translation id="5595485650161345191">Adres bewerken</translation>
-<translation id="5596627076506792578">Meer opties</translation>
-<translation id="5599455543593328020">Incognitomodus</translation>
-<translation id="5620928963363755975">Vind je bestanden en pagina's in 'Downloads' via de knop 'Meer opties'</translation>
-<translation id="5626134646977739690">Naam:</translation>
-<translation id="5639724618331995626">Alle sites toestaan</translation>
-<translation id="5648166631817621825">Afgelopen 7 dagen</translation>
-<translation id="5649053991847567735">Automatische downloads</translation>
-<translation id="5655963694829536461">Zoek in je downloads</translation>
-<translation id="5659593005791499971">E-mailadres</translation>
-<translation id="5665379678064389456">Afspraak maken in <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Negeer verzoek van website om inzoomen te voorkomen</translation>
-<translation id="5677928146339483299">Geblokkeerd</translation>
-<translation id="5684874026226664614">Deze pagina kan niet worden vertaald.</translation>
-<translation id="5686790454216892815">Bestandsnaam te lang</translation>
-<translation id="5689516760719285838">Locatie</translation>
-<translation id="569536719314091526">Vertaal deze pagina in een andere taal via de knop 'Meer opties'</translation>
-<translation id="572328651809341494">Recente tabbladen</translation>
-<translation id="5726692708398506830">Alles op de pagina vergroten</translation>
-<translation id="5748802427693696783">Overgeschakeld naar standaardtabbladen</translation>
-<translation id="5749068826913805084">Chrome heeft toegang tot de opslag nodig om deze bestanden te kunnen downloaden.</translation>
-<translation id="5763382633136178763">Incognitotabbladen</translation>
-<translation id="5763514718066511291">Tik om de URL voor deze app te kopiëren</translation>
-<translation id="5765780083710877561">Beschrijving:</translation>
-<translation id="5793665092639000975">Er wordt <ph name="SPACE_USED" /> van de <ph name="SPACE_AVAILABLE" /> gebruikt</translation>
-<translation id="5797070761912323120">Google kan je geschiedenis gebruiken om Google Zoeken, advertenties en andere Google-services te personaliseren</translation>
-<translation id="5804241973901381774">Rechten</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# uur geleden}other{# uur geleden}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Alle rechten voorbehouden.</translation>
-<translation id="5817918615728894473">Koppelen</translation>
-<translation id="583281660410589416">Onbekend</translation>
-<translation id="5833984609253377421">Link delen</translation>
-<translation id="5836192821815272682">Chrome-update downloaden…</translation>
-<translation id="5853623416121554550">onderbroken</translation>
-<translation id="5854790677617711513">Ouder dan 30 dagen</translation>
-<translation id="5858741533101922242">Chrome kan de Bluetooth-adapter niet inschakelen</translation>
-<translation id="5860033963881614850">Uit</translation>
-<translation id="5862731021271217234">Schakel synchronisatie in om de tabbladen van je andere apparaten te bekijken</translation>
-<translation id="5864174910718532887">Details: gesorteerd op sitenaam</translation>
-<translation id="5864419784173784555">Wachten op andere download…</translation>
-<translation id="5865733239029070421">Hiermee worden automatisch gebruiksstatistieken en crashrapporten naar Google verzonden</translation>
-<translation id="5869522115854928033">Opgeslagen wachtwoorden</translation>
-<translation id="5902828464777634901">Alle lokale gegevens die zijn opgeslagen door deze website, inclusief cookies, worden verwijderd.</translation>
-<translation id="5916664084637901428">Aan</translation>
-<translation id="5919204609460789179">Update <ph name="PRODUCT_NAME" /> om de synchronisatie te starten</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> bespaard</translation>
-<translation id="5939518447894949180">Resetten</translation>
-<translation id="5942872142862698679">Google wordt gebruikt om te zoeken</translation>
-<translation id="5952764234151283551">Hiermee wordt de URL van de pagina die je probeert te openen, verzonden naar Google</translation>
-<translation id="5956665950594638604">Helpcentrum van Chrome openen in een nieuw tabblad</translation>
-<translation id="5958275228015807058">Vind je bestanden en pagina's in Downloads</translation>
-<translation id="5962718611393537961">Tik om samen te vouwen</translation>
-<translation id="6000066717592683814">Google blijven gebruiken</translation>
-<translation id="6005538289190791541">Voorgesteld wachtwoord</translation>
-<translation id="6036057147555329831">Extra ICU</translation>
-<translation id="6039379616847168523">Naar het volgende tabblad gaan</translation>
-<translation id="6040143037577758943">Sluiten</translation>
-<translation id="6042308850641462728">Meer</translation>
-<translation id="604996488070107836">Download van <ph name="FILE_NAME" /> mislukt vanwege een onbekende fout.</translation>
-<translation id="605721222689873409">JJ</translation>
-<translation id="6064125863973209585">Voltooide downloads</translation>
-<translation id="6075798973483050474">Homepage bewerken</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> uur resterend</translation>
-<translation id="6108923351542677676">Instellen wordt uitgevoerd...</translation>
-<translation id="6111020039983847643">data gebruikt</translation>
-<translation id="6112702117600201073">Pagina vernieuwen</translation>
-<translation id="6127379762771434464">Item verwijderd</translation>
-<translation id="6140912465461743537">Land/regio</translation>
-<translation id="614940544461990577">Probeer dit eens:</translation>
-<translation id="6154478581116148741">Schakel schermvergrendeling in via Instellingen om je wachtwoorden te exporteren vanaf dit apparaat</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> data bespaard</translation>
-<translation id="6165508094623778733">Meer informatie</translation>
-<translation id="6177111841848151710">Geblokkeerd voor de huidige zoekmachine</translation>
-<translation id="6181444274883918285">Site-uitzondering toevoegen</translation>
-<translation id="6192333916571137726">Bestand downloaden</translation>
-<translation id="6192792657125177640">Uitzonderingen</translation>
-<translation id="6194112207524046168">Als je Chrome toegang wilt geven tot je camera, moet je de camera ook inschakelen via de <ph name="BEGIN_LINK" />Android-instellingen<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Indirecte cookies blokkeren</translation>
-<translation id="6206551242102657620">De verbinding is beveiligd. Site-informatie</translation>
-<translation id="6210748933810148297">Niet <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Ontgrendel het apparaat om je wachtwoorden te exporteren</translation>
+<translation id="1406000523432664303">Niet bijhouden</translation>
 <translation id="6232535412751077445">Als je 'Niet bijhouden' inschakelt, wordt hiervoor een verzoek opgenomen in je browseverkeer. Het resultaat daarvan hangt af van of een website reageert op het verzoek en hoe het verzoek wordt geïnterpreteerd.
 
 Zo kunnen sommige websites op dit verzoek reageren door advertenties weer te geven die niet zijn gebaseerd op andere websites die je hebt bezocht. Toch blijven veel websites je browsegegevens nog verzamelen en gebruiken, bijvoorbeeld om de beveiliging te verbeteren, om content, services, advertenties en aanbevelingen te leveren en om rapportagestatistieken te genereren.</translation>
-<translation id="624789221780392884">Update gereed</translation>
-<translation id="6255999984061454636">Contentsuggesties</translation>
-<translation id="6277522088822131679">Er is een fout opgetreden bij het afdrukken van de pagina. Probeer het opnieuw.</translation>
-<translation id="6295158916970320988">Alle sites</translation>
-<translation id="629730747756840877">Account</translation>
-<translation id="6303969859164067831">Uitloggen en synchronisatie uitschakelen</translation>
-<translation id="6316139424528454185">Android-versie wordt niet ondersteund</translation>
-<translation id="6320088164292336938">Trillen</translation>
-<translation id="6324034347079777476">Systeemsynchronisatie van Android uitgeschakeld</translation>
-<translation id="6333140779060797560">Delen via <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Versleuteling</translation>
-<translation id="6341580099087024258">Vragen waar bestanden moeten worden opgeslagen</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> andere}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> andere}}</translation>
-<translation id="6364438453358674297">Suggestie verwijderen uit geschiedenis?</translation>
-<translation id="6369229450655021117">Hier kun je op internet zoeken, content delen met vrienden en geopende pagina's bekijken</translation>
-<translation id="6378173571450987352">Details: gesorteerd op hoeveelheid gebruikte data</translation>
-<translation id="6381421346744604172">Websites donkerder maken</translation>
-<translation id="6388207532828177975">Wissen en opnieuw instellen</translation>
-<translation id="6393863479814692971">Chrome heeft toegangsrechten voor je camera en microfoon nodig voor deze site.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Bladwijzer bewerken</translation>
-<translation id="6406506848690869874">Synchronisatie</translation>
-<translation id="641643625718530986">Afdrukken…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB gedownload</translation>
-<translation id="6427112570124116297">Laat webpagina's vertalen</translation>
-<translation id="6433501201775827830">Je zoekmachine kiezen</translation>
-<translation id="6437478888915024427">Pagina-informatie</translation>
-<translation id="6441734959916820584">Naam is te lang</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# afbeelding}other{# afbeeldingen}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Kan bestand niet openen</translation>
-<translation id="6464977750820128603">Je kunt sites bekijken die je in Chrome bezoekt en timers hiervoor instellen.\n\nGoogle ontvangt informatie over de sites waarvoor je timers instelt en hoelang je ze bezoekt. Deze informatie wordt gebruikt om Digitaal welzijn te verbeteren.</translation>
-<translation id="6475951671322991020">Video downloaden</translation>
-<translation id="6482749332252372425">Downloaden van <ph name="FILE_NAME" /> is mislukt door te weinig opslagruimte.</translation>
-<translation id="6496823230996795692">Maak verbinding met internet als je <ph name="APP_NAME" /> voor het eerst wilt gebruiken.</translation>
-<translation id="6508722015517270189">Chrome opnieuw starten</translation>
-<translation id="6527303717912515753">Delen</translation>
-<translation id="6532866250404780454">Sites die je in Chrome bezoekt, worden niet weergegeven. Alle sitetimers worden verwijderd.</translation>
-<translation id="6534565668554028783">Het duurt te lang voordat Google reageert</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB gedownload</translation>
-<translation id="6539092367496845964">Er is iets misgegaan. Probeer het later opnieuw.</translation>
-<translation id="654446541061731451">Selecteer een tabblad om te beamen</translation>
-<translation id="6545017243486555795">Alle gegevens wissen</translation>
-<translation id="6545864417968258051">Bluetooth-scannen</translation>
-<translation id="6560414384669816528">Zoeken met Sogou</translation>
-<translation id="6566259936974865419">Chrome bespaart je <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Altijd toestaan</translation>
-<translation id="6573431926118603307">Tabbladen die je op andere apparaten in Chrome hebt geopend, worden hier weergegeven.</translation>
-<translation id="6583199322650523874">Een bladwijzer toevoegen voor de huidige pagina</translation>
-<translation id="6593061639179217415">Desktopsite</translation>
-<translation id="6600954340915313787">Gekopieerd naar Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Beschermde content</translation>
-<translation id="6627583120233659107">Map bewerken</translation>
-<translation id="6643016212128521049">Wissen</translation>
-<translation id="6643649862576733715">Sorteren op hoeveelheid bespaarde data</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> andere}other{<ph name="CONTACT_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> andere}}</translation>
-<translation id="6649642165559792194">Afbeelding bekijken <ph name="BEGIN_NEW" />Nieuw<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome heeft locatietoegang nodig om naar apparaten te zoeken. <ph name="BEGIN_LINK" />Rechten updaten<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Wachtwoord</translation>
-<translation id="6659594942844771486">Tabblad</translation>
-<translation id="666731172850799929">Openen in <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Privacybeleid van Chrome</translation>
-<translation id="6676840375528380067">Je Chrome-gegevens van dit apparaat wissen?</translation>
-<translation id="6697492270171225480">Suggesties voor vergelijkbare pagina's weergeven wanneer een pagina niet wordt gevonden</translation>
-<translation id="6697947395630195233">Chrome heeft toegang tot je locatie nodig om je locatie met deze site te delen.</translation>
-<translation id="6698801883190606802">Gesynchroniseerde gegevens beheren</translation>
-<translation id="6699370405921460408">De Google-servers optimaliseren de pagina's die je bezoekt.</translation>
-<translation id="6706288973712894588">Je bent op dit moment offline.\n<ph name="BEGIN_LINK" />Bekijk je offline feed.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Nieuws</translation>
-<translation id="6710213216561001401">Vorige</translation>
-<translation id="671481426037969117">Je <ph name="FQDN" />-timer is afgelopen. Deze begint morgen opnieuw.</translation>
-<translation id="6738867403308150051">Downloaden...</translation>
-<translation id="6746124502594467657">Omlaag</translation>
-<translation id="6766622839693428701">Veeg omlaag om te sluiten.</translation>
-<translation id="6766758767654711248">Tik om naar de site te gaan</translation>
-<translation id="6767294960381293877">De lijst met apparaten om een tabblad mee te delen, is op halve hoogte geopend.</translation>
-<translation id="6782111308708962316">Voorkomen dat websites van derden cookiegegevens opslaan en lezen</translation>
-<translation id="6790428901817661496">Spelen</translation>
-<translation id="6811034713472274749">Pagina kan nu worden bekeken</translation>
-<translation id="6818926723028410516">Items selecteren</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Vertalen</translation>
-<translation id="6845325883481699275">Help de beveiliging van Chrome te verbeteren</translation>
-<translation id="6846298663435243399">Laden…</translation>
-<translation id="6850409657436465440">Je download wordt nog uitgevoerd</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> tabbladen gesloten</translation>
-<translation id="6864459304226931083">Afbeelding downloaden</translation>
-<translation id="6865313869410766144">Formuliergegevens voor Automatisch aanvullen</translation>
-<translation id="688738109438487280">Bestaande gegevens toevoegen aan <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Ontgrendelen om je wachtwoord te kopiëren</translation>
-<translation id="6896758677409633944">Kopieer</translation>
-<translation id="6910211073230771657">Verwijderd</translation>
-<translation id="6912998170423641340">Voorkomen dat sites tekst en afbeeldingen vanaf het klembord kunnen lezen</translation>
-<translation id="6914783257214138813">Je wachtwoorden zijn zichtbaar voor iedereen die het geëxporteerde bestand kan bekijken.</translation>
-<translation id="6942665639005891494">Je kunt via de menuoptie Instellingen op elk gewenst moment de standaard downloadlocatie wijzigen</translation>
-<translation id="6945221475159498467">Selecteren</translation>
-<translation id="6963642900430330478">Deze pagina is gevaarlijk. Site-informatie</translation>
-<translation id="6963766334940102469">Bladwijzers verwijderen</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Alles</translation>
-<translation id="6981982820502123353">Toegankelijkheid</translation>
-<translation id="6989267951144302301">Kan niet downloaden</translation>
-<translation id="6990079615885386641">Download de app uit de Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Eerst vragen voordat sites je microfoon mogen gebruiken (aanbevolen)</translation>
-<translation id="7015203776128479407">Aanvankelijke synchronisatie-instelling is niet voltooid. Synchronisatie is uitgeschakeld.</translation>
-<translation id="7016516562562142042">Toegestaan voor huidige zoekmachine</translation>
-<translation id="7022756207310403729">Openen in browser</translation>
-<translation id="702463548815491781">Aanbevolen wanneer TalkBack of 'Toegang via schakelaar' is ingeschakeld</translation>
-<translation id="7029809446516969842">Wachtwoorden</translation>
-<translation id="7053983685419859001">Blokkeren</translation>
-<translation id="7055152154916055070">Omleiding geblokkeerd:</translation>
-<translation id="7063006564040364415">Kan geen verbinding maken met synchronisatieserver.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 geselecteerd}other{# geselecteerd}}</translation>
-<translation id="7071521146534760487">Account beheren</translation>
-<translation id="7077143737582773186">SD-kaart</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> geselecteerd. Opties beschikbaar bovenaan het scherm.</translation>
-<translation id="7121362699166175603">Hiermee worden de geschiedenis en automatische aanvullingen voor de adresbalk gewist. Er kunnen andere vormen van browsegeschiedenis zijn opgeslagen voor je Google-account op <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Toestaan voor huidige zoekmachine</translation>
-<translation id="7138678301420049075">Overige</translation>
-<translation id="7141896414559753902">Sites niet toestaan pop-ups weer te geven en omleidingen uit te voeren (aanbevolen)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Oorspronkelijke pagina laden <ph name="END_LINK" /> van <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Afgelopen 24 uur</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Je kunt dit later wijzigen in Instellingen</translation>
-<translation id="7180611975245234373">Vernieuwen</translation>
-<translation id="7189372733857464326">Wachten tot Google Play-services is geüpdatet</translation>
-<translation id="7191430249889272776">Tabblad op de achtergrond geopend.</translation>
-<translation id="723171743924126238">Afbeeldingen selecteren</translation>
-<translation id="7233236755231902816">Als je webpagina's in je eigen taal wilt kunnen lezen, download je de nieuwste versie van Chrome</translation>
-<translation id="7243308994586599757">Opties beschikbaar onder aan het scherm</translation>
-<translation id="7248069434667874558">Zorg dat synchronisatie in Chrome is ingeschakeld voor <ph name="TARGET_DEVICE_NAME" /></translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> geselecteerd</translation>
-<translation id="7274013316676448362">Geblokkeerde site</translation>
-<translation id="7290209999329137901">Naam wijzigen niet beschikbaar</translation>
-<translation id="7291387454912369099">Assistent voor automatisch invullen</translation>
-<translation id="7293171162284876153">Schakel 'Je Chrome-gegevens synchroniseren' in om de synchronisatie te starten.</translation>
-<translation id="729975465115245577">Je apparaat bevat geen app om het wachtwoordbestand in op te slaan.</translation>
-<translation id="7302081693174882195">Details: gesorteerd op de hoeveelheid bespaarde data</translation>
-<translation id="7328017930301109123">In de Lite-versie van Chrome worden pagina's sneller geladen en wordt tot wel 60 procent minder data verbruikt.</translation>
-<translation id="7333031090786104871">Nog steeds bezig met toevoegen van vorige site</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 geselecteerd item delen}other{# geselecteerde items delen}}</translation>
 <translation id="7359002509206457351">Toegang tot betaalmethoden</translation>
+<translation id="8026334261755873520">Browsegegevens wissen</translation>
+<translation id="1291207594882862231">Geschiedenis, cookies, sitegegevens, cachegeheugen wissen</translation>
+<translation id="7814200940910057384">Brave-gegevens gewist</translation>
+<translation id="1664855196866195614">De geselecteerde gegevens zijn verwijderd uit Brave en van je gesynchroniseerde apparaten.
+
+Voor je Brave Software-account kunnen andere vormen van browsegeschiedenis (zoals zoekopdrachten en activiteit uit andere Brave Software-services) beschikbaar zijn via <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Gecachte afbeeldingen en bestanden</translation>
+<translation id="2496180316473517155">Browsegeschiedenis</translation>
+<translation id="2546283357679194313">Cookies en sitegegevens</translation>
+<translation id="8662811608048051533">Hiermee word je uitgelogd van de meeste sites.</translation>
+<translation id="8218628800671693884">Hiermee word je uitgelogd van de meeste sites. Je wordt niet uitgelogd van je Brave Software-account.</translation>
+<translation id="2017836877785168846">Wist de geschiedenis en automatische aanvullingen in de adresbalk.</translation>
+<translation id="8096327394278038498">Hiermee worden de geschiedenis en automatische aanvullingen voor de adresbalk gewist. Er kunnen andere vormen van browsegeschiedenis zijn opgeslagen voor je Brave Software-account op <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Hiermee wordt de geschiedenis van alle ingelogde apparaten gewist. Er kunnen andere vormen van browsegeschiedenis zijn opgeslagen voor je Brave Software-account op <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Opgeslagen wachtwoorden</translation>
+<translation id="6865313869410766144">Formuliergegevens voor Automatisch aanvullen</translation>
+<translation id="7562080006725997899">Browsegegevens wissen</translation>
+<translation id="5487521232677179737">Gegevens wissen</translation>
+<translation id="7498271377022651285">Een ogenblik geduld…</translation>
+<translation id="784934925303690534">Periode</translation>
+<translation id="1718835860248848330">Afgelopen uur</translation>
+<translation id="7149893636342594995">Afgelopen 24 uur</translation>
+<translation id="5648166631817621825">Afgelopen 7 dagen</translation>
+<translation id="8571213806525832805">Afgelopen 4 weken</translation>
+<translation id="5854790677617711513">Ouder dan 30 dagen</translation>
+<translation id="6979737339423435258">Alles</translation>
+<translation id="982182592107339124">Hiermee worden de gegevens voor alle sites gewist, inclusief:</translation>
+<translation id="6643016212128521049">Wissen</translation>
+<translation id="7641339528570811325">Browsegegevens wissen</translation>
+<translation id="1670399744444387456">Basis</translation>
+<translation id="3245261285041759672">Er kunnen andere vormen van browsegeschiedenis zijn opgeslagen voor je Brave Software-account op <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Geblokkeerde site</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> items verwijderd</translation>
+<translation id="1121094540300013208">Gebruiks- en crashrapporten</translation>
+<translation id="9079153198295609735">Automatisch gebruiksstatistieken en crashrapporten naar Brave Software verzenden</translation>
+<translation id="6981982820502123353">Toegankelijkheid</translation>
+<translation id="2387895666653383613">Tekstschaal</translation>
+<translation id="2321958826496381788">Sleep de schuifknop tot je deze tekst prettig kunt lezen. De tekst moet minimaal deze grootte hebben nadat je op een alinea hebt gedubbeltikt.</translation>
+<translation id="3895926599014793903">Zoom inschakelen forceren</translation>
+<translation id="5668404140385795438">Negeer verzoek van website om inzoomen te voorkomen</translation>
+<translation id="4149994727733219643">Vereenvoudigde weergave voor webpagina's</translation>
+<translation id="9100505651305367705">Aanbieden om artikelen weer te geven in een vereenvoudigde weergave (indien ondersteund)</translation>
+<translation id="1409426117486808224">Vereenvoudigde weergave voor geopende tabbladen</translation>
+<translation id="702463548815491781">Aanbevolen wanneer TalkBack of 'Toegang via schakelaar' is ingeschakeld</translation>
+<translation id="8284326494547611709">Ondertiteling</translation>
+<translation id="4165986682804962316">Site-instellingen</translation>
+<translation id="6295158916970320988">Alle sites</translation>
+<translation id="8380167699614421159">Deze site geeft opdringerige of misleidende advertenties weer</translation>
+<translation id="1919345977826869612">Advertenties</translation>
+<translation id="410351446219883937">Automatisch afspelen</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Indirecte cookies blokkeren</translation>
+<translation id="6782111308708962316">Voorkomen dat websites van derden cookiegegevens opslaan en lezen</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-ups en omleidingen</translation>
+<translation id="4751476147751820511">Bewegings- of lichtsensoren</translation>
+<translation id="1717218214683051432">Bewegingssensoren</translation>
+<translation id="2091887806945687916">Geluid</translation>
+<translation id="2586657967955657006">Klembord</translation>
+<translation id="6320088164292336938">Trillen</translation>
+<translation id="4226663524361240545">Het apparaat kan trillen bij meldingen</translation>
+<translation id="1446450296470737166">Volledig beheer van MIDI-apparaten toestaan</translation>
+<translation id="3744111561329211289">Synchronisatie op de achtergrond</translation>
+<translation id="5649053991847567735">Automatische downloads</translation>
+<translation id="6181444274883918285">Site-uitzondering toevoegen</translation>
+<translation id="5313967007315987356">Site toevoegen</translation>
+<translation id="1369915414381695676">Site <ph name="SITE_NAME"/> toegevoegd</translation>
+<translation id="7837721118676387834">Automatisch afspelen van gedempte video's toestaan voor een specifieke site.</translation>
+<translation id="2621115761605608342">JavaScript toestaan voor een specfieke site.</translation>
+<translation id="8801436777607969138">Blokkeer JavaScript voor een specifieke site.</translation>
+<translation id="8372893542064058268">Synchronisatie op de achtergrond toestaan voor een specifieke site.</translation>
+<translation id="358794129225322306">Een site toestaan automatisch meerdere bestanden te downloaden.</translation>
+<translation id="4008040567710660924">Cookies voor een specifieke site toestaan.</translation>
+<translation id="8958424370300090006">Cookies voor een specifieke site blokkeren.</translation>
+<translation id="7882806643839505685">Geluid toestaan voor een specifieke site.</translation>
+<translation id="4468959413250150279">Geluid dempen voor een specifieke site.</translation>
+<translation id="1994173015038366702">Site-URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Gebruik</translation>
+<translation id="5804241973901381774">Rechten</translation>
+<translation id="4278390842282768270">Toegestaan</translation>
+<translation id="5677928146339483299">Geblokkeerd</translation>
+<translation id="1984937141057606926">Toegestaan, behalve van derden</translation>
+<translation id="7423098979219808738">Eerst vragen</translation>
+<translation id="8116925261070264013">Gedempt</translation>
+<translation id="8300705686683892304">Beheerd door app</translation>
+<translation id="6192792657125177640">Uitzonderingen</translation>
+<translation id="257931822824936280">Uitgevouwen; klik om samen te vouwen.</translation>
+<translation id="5100237604440890931">Samengevouwen; klik om uit te vouwen.</translation>
+<translation id="857943718398505171">Toegestaan (aanbevolen)</translation>
+<translation id="2913331724188855103">Sites toestaan cookiegegevens op te slaan en te lezen (aanbevolen)</translation>
+<translation id="7445411102860286510">Sites toestaan gedempte video's automatisch af te spelen (aanbevolen)</translation>
+<translation id="5335288049665977812">Sites toestaan JavaScript uit te voeren (aanbevolen)</translation>
+<translation id="5527111080432883924">Vragen voordat sites toestemming krijgen om tekst en afbeeldingen vanaf het klembord te lezen (aanbevolen)</translation>
+<translation id="6912998170423641340">Voorkomen dat sites tekst en afbeeldingen vanaf het klembord kunnen lezen</translation>
+<translation id="7423538860840206698">Lezen van het klembord geblokkeerd</translation>
+<translation id="3955193568934677022">Toestaan dat sites beschermde content afspelen (aanbevolen)</translation>
+<translation id="445467742685312942">Sites toestaan om beschermde content af te spelen</translation>
+<translation id="2107397443965016585">Vragen voordat sites beschermde content mogen afspelen (aanbevolen)</translation>
+<translation id="2910701580606108292">Vragen voordat sites beschermde content mogen afspelen</translation>
+<translation id="757524316907819857">Blokkeren dat sites beschermde content kunnen afspelen</translation>
+<translation id="3277252321222022663">Sites toegang geven tot sensoren (aanbevolen)</translation>
+<translation id="5048398596102334565">Sites toegang geven tot bewegingssensoren (aanbevolen)</translation>
+<translation id="8816026460808729765">Sites geen toegang tot sensoren geven</translation>
+<translation id="169515064810179024">Sites geen toegang tot bewegingssensoren geven</translation>
+<translation id="1660204651932907780">Toestaan dat sites geluid afspelen (aanbevolen)</translation>
+<translation id="3600792891314830896">Sites dempen die geluid afspelen</translation>
+<translation id="1743802530341753419">Vragen of sites verbinding mogen maken met een apparaat (aanbevolen)</translation>
+<translation id="851751545965956758">Voorkomen dat sites verbinding maken met apparaten</translation>
+<translation id="7141896414559753902">Sites niet toestaan pop-ups weer te geven en omleidingen uit te voeren (aanbevolen)</translation>
+<translation id="5494752089476963479">Advertenties blokkeren op sites die opdringerige of misleidende advertenties weergeven</translation>
+<translation id="3123473560110926937">Geblokkeerd op bepaalde sites</translation>
+<translation id="965817943346481315">Blokkeren als site opdringerige of misleidende advertenties weergeeft (aanbevolen)</translation>
+<translation id="3386292677130313581">Vragen of je sites toegang wilt verlenen tot je locatie (aanbevolen)</translation>
+<translation id="9139068048179869749">Vragen voordat sites meldingen mogen verzenden (aanbevolen)</translation>
+<translation id="4479647676395637221">Eerst vragen voordat sites je camera mogen gebruiken (aanbevolen)</translation>
+<translation id="6992289844737586249">Eerst vragen voordat sites je microfoon mogen gebruiken (aanbevolen)</translation>
+<translation id="2289270750774289114">Vragen wanneer een site Bluetooth-apparaten in de buurt wilt detecteren (aanbevolen)</translation>
+<translation id="7053983685419859001">Blokkeren</translation>
+<translation id="7128222689758636196">Toestaan voor huidige zoekmachine</translation>
+<translation id="7589445247086920869">Blokkeren voor huidige zoekmachine</translation>
+<translation id="6388207532828177975">Wissen en opnieuw instellen</translation>
+<translation id="7999064672810608036">Weet je zeker dat je alle gegevens, inclusief cookies, voor deze website wilt wissen en alle rechten opnieuw wilt instellen?</translation>
+<translation id="2822354292072154809">Weet je zeker dat je alle siterechten voor <ph name="CHOSEN_OBJECT_NAME"/> wilt resetten?</translation>
+<translation id="515227803646670480">Opgeslagen gegevens wissen</translation>
+<translation id="5902828464777634901">Alle lokale gegevens die zijn opgeslagen door deze website, inclusief cookies, worden verwijderd.</translation>
+<translation id="119944043368869598">Alles wissen</translation>
+<translation id="2490684707762498678">Beheerd door <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Instellingen voor meldingen openen</translation>
+<translation id="1404122904123200417">Ingesloten in <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Bestanden die worden opgeslagen door websites, worden hier weergegeven</translation>
+<translation id="4181841719683918333">Talen</translation>
+<translation id="2647434099613338025">Taal toevoegen</translation>
+<translation id="1952172573699511566">Websites worden indien mogelijk weergegeven in je voorkeurstaal.</translation>
+<translation id="8559990750235505898">Aanbieden pagina's in andere talen te vertalen</translation>
+<translation id="4719927025381752090">Aanbieden om te vertalen</translation>
+<translation id="8156139159503939589">Welke talen lees je?</translation>
+<translation id="5689516760719285838">Locatie</translation>
+<translation id="2440823041667407902">Locatietoegang</translation>
+<translation id="2023546461831060654">Schakel rechten in voor Brave via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Geef Brave toestemming via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Als je Brave toegang wilt geven tot je locatie, moet je locatie ook inschakelen via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Als je Brave toegang wilt geven tot je camera, moet je de camera ook inschakelen via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Als je wilt dat Brave je meldingen stuurt, moet je meldingen ook inschakelen via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Als je Brave ook toegang wilt geven tot je microfoon, moet je de microfoon ook inschakelen via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Locatietoegang is uitgeschakeld voor dit apparaat. Schakel dit in via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Locatietoegang is ook uitgeschakeld voor dit apparaat. Schakel dit in via de <ph name="BEGIN_LINK"/>Android-instellingen<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Camera</translation>
+<translation id="3227137524299004712">Microfoon</translation>
+<translation id="1647391597548383849">Toegang tot camera</translation>
+<translation id="945632385593298557">Toegang tot je microfoon</translation>
+<translation id="6612358246767739896">Beschermde content</translation>
+<translation id="885701979325669005">Opslag</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> opgeslagen gegevens</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Toegang tot apparaat intrekken</translation>
+<translation id="4962975101802056554">Alle rechten voor apparaat intrekken</translation>
+<translation id="6545864417968258051">Bluetooth-scannen</translation>
+<translation id="4411535500181276704">Lite-versie</translation>
+<translation id="7821588508402923572">Hier wordt getoond hoeveel data je bespaart</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> bespaard</translation>
+<translation id="8569404424186215731">sinds <ph name="DATE"/></translation>
+<translation id="3252158532344029638">In de Lite-versie van Brave worden pagina's sneller geladen en wordt tot wel 60 procent minder data verbruikt.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> data bespaard</translation>
+<translation id="7494974237137038751">data bespaard</translation>
+<translation id="6111020039983847643">data gebruikt</translation>
+<translation id="7413229368719586778">Begindatum: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Einddatum: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sorteren op site</translation>
+<translation id="5864174910718532887">Details: gesorteerd op sitenaam</translation>
+<translation id="116280672541001035">Gebruikt</translation>
+<translation id="8349013245300336738">Sorteren op hoeveelheid gebruikte data</translation>
+<translation id="6378173571450987352">Details: gesorteerd op hoeveelheid gebruikte data</translation>
+<translation id="2631006050119455616">Bespaard</translation>
+<translation id="6643649862576733715">Sorteren op hoeveelheid bespaarde data</translation>
+<translation id="7302081693174882195">Details: gesorteerd op de hoeveelheid bespaarde data</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> gebruikt</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> bespaard</translation>
+<translation id="2156074688469523661">Resterende sites (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Overige</translation>
+<translation id="4913161338056004800">Statistieken resetten</translation>
+<translation id="1856325424225101786">Lite-versie resetten?</translation>
+<translation id="3658159451045945436">Als je reset, wordt je databesparingsgeschiedenis gewist, waaronder de lijst met bezochte sites.</translation>
+<translation id="3295530008794733555">Surf sneller en verbruik minder data</translation>
+<translation id="7340390500800578919">In de Lite-versie van Brave worden pagina's sneller geladen en wordt tot wel 60 procent minder data verbruikt. Brave stuurt je webverkeer naar Brave Software om de pagina's te optimaliseren die je bezoekt. <ph name="BEGIN_LINK"/>Meer informatie<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Lite-versie inschakelen</translation>
+<translation id="4493497663118223949">Lite-versie is ingeschakeld</translation>
+<translation id="7559975015014302720">Lite-versie is uitgeschakeld</translation>
+<translation id="7606077192958116810">Lite-versie is ingeschakeld. Je kunt dit beheren via de instellingen.</translation>
+<translation id="4714588616299687897">Bespaar tot 60% van je gegevens</translation>
+<translation id="1006927014032731288">De Brave Software-servers optimaliseren de pagina's die je bezoekt.</translation>
+<translation id="3257320067425202300">Brave bespaart je <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave bespaart je <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Downloadlocatie</translation>
+<translation id="7077143737582773186">SD-kaart</translation>
+<translation id="7762668264895820836">SD-kaart <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Vragen waar bestanden moeten worden opgeslagen</translation>
+<translation id="6192333916571137726">Bestand downloaden</translation>
+<translation id="1672586136351118594">Niet opnieuw weergeven</translation>
+<translation id="2650751991977523696">Bestand opnieuw downloaden?</translation>
+<translation id="8664979001105139458">Bestandsnaam bestaat al</translation>
+<translation id="488187801263602086">Naam van bestand wijzigen</translation>
+<translation id="5686790454216892815">Bestandsnaam te lang</translation>
+<translation id="7454641608352164238">Onvoldoende ruimte</translation>
+<translation id="8972098258593396643">Downloaden naar standaardmap?</translation>
+<translation id="804335162455518893">SD-kaart niet gevonden</translation>
+<translation id="7475688122056506577">SD-kaart niet gevonden. Sommige van je bestanden kunnen ontbreken.</translation>
+<translation id="4198423547019359126">Geen beschikbare downloadlocaties</translation>
+<translation id="8224471946457685718">Artikelen voor je downloaden bij verbinding via wifi</translation>
+<translation id="4970824347203572753">Niet beschikbaar op jouw locatie</translation>
+<translation id="5500777121964041360">Mogelijk niet beschikbaar op jouw locatie</translation>
+<translation id="1173894706177603556">Naam wijzigen</translation>
+<translation id="1986685561493779662">Naam bestaat al</translation>
+<translation id="6441734959916820584">Naam is te lang</translation>
+<translation id="2923908459366352541">Naam is ongeldig</translation>
+<translation id="7290209999329137901">Naam wijzigen niet beschikbaar</translation>
+<translation id="3334729583274622784">Bestandsextensie wijzigen?</translation>
+<translation id="107147699690128016">Als je de bestandsextensie wijzigt, wordt het bestand mogelijk in een andere app geopend. Daardoor kan het een gevaar vormen voor je apparaat.</translation>
+<translation id="8541922081612557424">Over Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Alle rechten voorbehouden.</translation>
+<translation id="1416550906796893042">Appversie</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (geüpdatet: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Besturingssysteem</translation>
+<translation id="3968054912784331254">Updates van Brave worden niet meer ondersteund voor deze versie van Android</translation>
+<translation id="7665369617277396874">Account toevoegen</translation>
+<translation id="649070405679044769">Ingelogd bij Brave Software als</translation>
+<translation id="6234515504547364178">Uitloggen bij Brave</translation>
+<translation id="5324858694974489420">Instellingen voor ouders</translation>
+<translation id="8920114477895755567">Wachten op gegevens van ouders.</translation>
+<translation id="5512137114520586844">Dit account wordt beheerd door <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Dit account wordt beheerd door <ph name="PARENT_NAME_1"/> en <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Content</translation>
+<translation id="5403644198645076998">Alleen bepaalde sites toestaan</translation>
+<translation id="8641930654639604085">Sites met content voor volwassenen proberen te blokkeren</translation>
+<translation id="5639724618331995626">Alle sites toestaan</translation>
+<translation id="796823723482603597">Mogelijk gemaakt door Brave</translation>
+<translation id="6324034347079777476">Systeemsynchronisatie van Android uitgeschakeld</translation>
+<translation id="5127805178023152808">Synchronisatie is uitgeschakeld</translation>
+<translation id="7015203776128479407">Aanvankelijke synchronisatie-instelling is niet voltooid. Synchronisatie is uitgeschakeld.</translation>
+<translation id="2497852260688568942">Synchronisatie is uitgeschakeld door je beheerder</translation>
+<translation id="9100610230175265781">Wachtwoordzin vereist</translation>
+<translation id="6108923351542677676">Instellen wordt uitgevoerd...</translation>
+<translation id="4062305924942672200">Juridische informatie</translation>
+<translation id="4256782883801055595">Open-sourcelicenties</translation>
+<translation id="1138681184697033370">Servicevoorwaarden van Brave</translation>
+<translation id="7392539049993970338">Privacybeleid van Brave</translation>
+<translation id="2677748264148917807">Verlaten</translation>
+<translation id="5556459405103347317">Opnieuw laden</translation>
+<translation id="1623104350909869708">Voorkomen dat deze pagina extra dialoogvensters weergeeft</translation>
+<translation id="2968755619301702150">Certificaatviewer</translation>
+<translation id="1360432990279830238">Uitloggen en synchroniseren uitschakelen?</translation>
+<translation id="8581481290581777242">Je Brave-gegevens van dit apparaat wissen?</translation>
+<translation id="1318865768845061710">Je bladwijzers, geschiedenis, wachtwoorden en andere Brave-gegevens worden niet meer gesynchroniseerd met je Brave Software-account</translation>
+<translation id="3325020657155065477">Je Brave-gegevens ook wissen op dit apparaat</translation>
+<translation id="6136448902816743006">Omdat je uitlogt van een account dat wordt beheerd door <ph name="DOMAIN_NAME"/>, worden je Brave-gegevens verwijderd. De gegevens blijven in je Brave Software-account staan.</translation>
+<translation id="1853026300647876496">Contact opnemen met Brave Software. Dit kan even duren…</translation>
+<translation id="2328985652426384049">Kan niet inloggen</translation>
+<translation id="7723158744459952869">Het duurt te lang voordat Brave Software reageert</translation>
+<translation id="4572422548854449519">Inloggen bij een beheerd account</translation>
+<translation id="2689656545739939160">Je logt in met een account dat wordt beheerd door <ph name="MANAGED_DOMAIN"/> waarmee je de eigenaar beheer geeft over je Brave-gegevens. Je gegevens worden permanent gekoppeld aan dit account. Als je uitlogt van Brave, worden je gegevens van dit apparaat verwijderd. Ze blijven echter opgeslagen in je Brave Software-account.</translation>
+<translation id="1749561566933687563">Synchroniseer je bladwijzers</translation>
+<translation id="4242533952199664413">Instellingen openen</translation>
+<translation id="1111673857033749125">Bladwijzers die je op andere apparaten hebt opgeslagen, worden hier weergegeven.</translation>
+<translation id="8636825310635137004">Schakel synchronisatie in om de tabbladen op je andere apparaten te bekijken</translation>
+<translation id="3269956123044984603">Schakel in je account bij de instellingen van Android 'Gegevens automatisch synchroniseren' in om de tabbladen op je andere apparaten te bekijken.</translation>
+<translation id="5157964048453367290">Tabbladen die je op andere apparaten in Brave hebt geopend, worden hier weergegeven.</translation>
+<translation id="4684427112815847243">Alles synchroniseren</translation>
+<translation id="2709516037105925701">Automatisch aanvullen</translation>
+<translation id="8820817407110198400">Bladwijzers</translation>
+<translation id="1644574205037202324">Geschiedenis</translation>
+<translation id="17513872634828108">Geopende tabbladen</translation>
+<translation id="1320169905922104972">Creditcards en adressen die Brave Software Pay gebruiken</translation>
+<translation id="6337234675334993532">Versleuteling</translation>
+<translation id="6698801883190606802">Gesynchroniseerde gegevens beheren</translation>
+<translation id="3598578758776312506">Wachtwoorden versleutelen met Brave Software-inloggegevens</translation>
+<translation id="7810580217418711046">Gesynchroniseerde gegevens versleutelen met Brave Software-wachtwoord vanaf <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Gesynchroniseerde gegevens versleutelen met een eigen wachtwoordzin</translation>
+<translation id="2996291259634659425">Wachtwoordzin maken</translation>
+<translation id="5713644099811900409">Brave Software-account</translation>
+<translation id="8997474919031554666">Wachtwoordzinversleuteling is niet van toepassing op betaalmethoden en adressen van Brave Software Pay. Alleen iemand met je wachtwoordzin kan je versleutelde gegevens lezen. De wachtwoordzin wordt niet verzonden naar of opgeslagen door Brave Software. Als je je wachtwoordzin vergeet of deze instelling wilt wijzigen, moet je de synchronisatie resetten. <ph name="BEGIN_LINK"/>Meer informatie<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Wachtwoordzin</translation>
+<translation id="7772032839648071052">Bevestig de wachtwoordzin</translation>
+<translation id="5304593522240415983">Dit veld mag niet leeg zijn</translation>
+<translation id="321773570071367578">Als je je wachtwoordzin bent vergeten of deze instelling wilt wijzigen, <ph name="BEGIN_LINK"/>stel je de synchronisatie opnieuw in<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Wachtwoordzinnen komen niet overeen</translation>
+<translation id="5149495116300586333">Wachtwoordzinversleuteling is niet van toepassing op betaalmethoden en adressen van Brave Software Pay.
+
+<ph name="BEGIN_LINK"/>Reset de synchronisatie<ph name="END_LINK"/> als je deze instelling wilt wijzigen.</translation>
+<translation id="7638584964844754484">Onjuiste wachtwoordzin</translation>
+<translation id="5414836363063783498">Verifiëren…</translation>
+<translation id="6846298663435243399">Laden…</translation>
+<translation id="5517095782334947753">Je hebt bladwijzers, geschiedenis, wachtwoorden en andere instellingen van <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Mijn gegevens combineren</translation>
+<translation id="688738109438487280">Bestaande gegevens toevoegen aan <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Mijn gegevens gescheiden houden</translation>
+<translation id="1145536944570833626">Bestaande gegevens verwijderen.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> wil koppelen</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Hulp<ph name="END_LINK"/> bij het zoeken naar apparaten…</translation>
+<translation id="5817918615728894473">Koppelen</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Hulp vragen<ph name="END_LINK1"/> of <ph name="BEGIN_LINK2"/>opnieuw scannen<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Geen geschikte apparaten gevonden</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Schakel Bluetooth in<ph name="END_LINK"/> om te koppelen</translation>
+<translation id="998321811308652668">Brave kan de Bluetooth-adapter niet inschakelen</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Hulp krijgen<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave heeft locatietoegang nodig om naar apparaten te zoeken. <ph name="BEGIN_LINK"/>Rechten updaten<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave heeft locatietoegang nodig om naar apparaten te scannen. Locatietoegang is <ph name="BEGIN_LINK"/>uitgeschakeld voor dit apparaat<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave heeft locatietoegang nodig om naar apparaten te scannen. <ph name="BEGIN_LINK1"/>Rechten updaten<ph name="END_LINK1"/>. Locatietoegang is ook <ph name="BEGIN_LINK2"/>uitgeschakeld voor dit apparaat<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Gekoppeld apparaat</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signaalsterkte: # streepje}other{Signaalsterkte: # streepjes}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> wil scannen naar Bluetooth-apparaten in de buurt. De volgende apparaten zijn gevonden:</translation>
+<translation id="8368027906805972958">Onbekend of niet-ondersteund apparaat (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synchronisatie werkt niet</translation>
+<translation id="1810845389119482123">Eerste synchronisatieconfiguratie niet voltooid</translation>
+<translation id="3235722914093408050">Open Android-instellingen en schakel Android-systeemsynchronisatie weer in om Brave-synchronisatie te starten</translation>
+<translation id="3367813778245106622">Log opnieuw in om de synchronisatie te starten</translation>
+<translation id="974555521953189084">Voer je wachtwoordzin in om de synchronisatie te starten</translation>
+<translation id="2997266899014181325">Schakel 'Je Brave-gegevens synchroniseren' in om de synchronisatie te starten.</translation>
+<translation id="8260126382462817229">Probeer opnieuw in te loggen</translation>
+<translation id="5919204609460789179">Update <ph name="PRODUCT_NAME"/> om de synchronisatie te starten</translation>
+<translation id="397583555483684758">Synchronisatie werkt niet meer</translation>
+<translation id="1966710179511230534">Update je inloggegevens.</translation>
+<translation id="7063006564040364415">Kan geen verbinding maken met synchronisatieserver.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> is verouderd.</translation>
+<translation id="4170011742729630528">De service is niet beschikbaar. Probeer het later opnieuw.</translation>
+<translation id="7947953824732555851">Accepteren en inloggen</translation>
+<translation id="8583805026567836021">Accountgegevens wissen</translation>
+<translation id="8310344678080805313">Standaardtabbladen</translation>
+<translation id="5748802427693696783">Overgeschakeld naar standaardtabbladen</translation>
+<translation id="7998918019931843664">Gesloten tabblad opnieuw openen</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, tabblad</translation>
+<translation id="4452411734226507615">Tabblad <ph name="TAB_TITLE"/> sluiten</translation>
+<translation id="7243308994586599757">Opties beschikbaar onder aan het scherm</translation>
+<translation id="4060598801229743805">Opties beschikbaar boven aan het scherm</translation>
+<translation id="2810645512293415242">Vereenvoudigde pagina om data te besparen en sneller te laden.</translation>
+<translation id="3985215325736559418">Wil je <ph name="FILE_NAME"/> opnieuw downloaden?</translation>
+<translation id="2450083983707403292">Wil je het downloaden van <ph name="FILE_NAME"/> opnieuw starten?</translation>
+<translation id="7514365320538308">Downloaden</translation>
+<translation id="545042621069398927">Je download wordt versneld.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Bestand downloaden.}other{# bestanden downloaden.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> bestanden downloaden (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Bestand downloaden (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download voltooid.}other{# downloads voltooid.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 download mislukt.}other{# downloads mislukt.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download in behandeling.}other{# downloads in behandeling.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/>-knop</translation>
+<translation id="3205824638308738187">Bijna klaar</translation>
+<translation id="3960299545138990065">Brave opnieuw starten</translation>
+<translation id="3771001275138982843">Kan de update niet downloaden</translation>
+<translation id="3888648114124182147">Brave-update downloaden…</translation>
+<translation id="1705567146636171298">Brave updaten</translation>
+<translation id="6195417478702700398">Update Brave om optimaal te kunnen browsen op internet</translation>
+<translation id="3512968675351418494">Als je webpagina's in je eigen taal wilt kunnen lezen, download je de nieuwste versie van Brave</translation>
+<translation id="6427112570124116297">Laat webpagina's vertalen</translation>
+<translation id="1379423114029199501">Voer een update uit om jouw taal te gebruiken in de nieuwste versie van Brave</translation>
+<translation id="5684874026226664614">Deze pagina kan niet worden vertaald.</translation>
+<translation id="6831043979455480757">Vertalen</translation>
+<translation id="1285320974508926690">Deze site nooit vertalen</translation>
+<translation id="773466115871691567">Pagina's in het <ph name="SOURCE_LANGUAGE"/> altijd vertalen</translation>
+<translation id="1068672505746868501">Pagina's in het <ph name="SOURCE_LANGUAGE"/> nooit vertalen</translation>
+<translation id="124116460088058876">Meer talen</translation>
+<translation id="290376772003165898">Is deze pagina niet in het <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Pagina's in het <ph name="SOURCE_LANGUAGE"/> worden vanaf nu vertaald naar het <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Pagina's in het <ph name="LANGUAGE"/> worden niet vertaald</translation>
+<translation id="5447765697759493033">Deze site wordt niet vertaald</translation>
+<translation id="4880127995492972015">Vertalen…</translation>
+<translation id="641643625718530986">Afdrukken…</translation>
+<translation id="8909135823018751308">Delen</translation>
+<translation id="4996978546172906250">Delen via</translation>
+<translation id="6333140779060797560">Delen via <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Er is een fout opgetreden bij het afdrukken van de pagina. Probeer het opnieuw.</translation>
+<translation id="3254409185687681395">Bladwijzer instellen voor deze pagina</translation>
+<translation id="497421865427891073">Naar voren gaan</translation>
+<translation id="813082847718468539">Sitegegevens bekijken</translation>
+<translation id="2532336938189706096">Webweergave</translation>
+<translation id="6005538289190791541">Voorgesteld wachtwoord</translation>
+<translation id="4634124774493850572">Wachtwoord gebruiken</translation>
+<translation id="8285489906452138776">Brave heeft toegangsrechten voor je camera nodig voor deze site.</translation>
+<translation id="320189792589364011">Brave heeft toegangsrechten voor je microfoon nodig voor deze site.</translation>
+<translation id="7988136689212463100">Brave heeft toegangsrechten voor je camera en microfoon nodig voor deze site.</translation>
+<translation id="4931190655840828017">Brave heeft toegang tot je locatie nodig om je locatie met deze site te delen.</translation>
+<translation id="3088191967551450609">Brave heeft toegang tot de opslag nodig om deze bestanden te kunnen downloaden.</translation>
+<translation id="8942627711005830162">Openen in een ander venster</translation>
+<translation id="4195643157523330669">Openen op nieuw tabblad</translation>
+<translation id="1100066534610197918">Open in nieuw tabblad in groep</translation>
+<translation id="4860895144060829044">Bellen</translation>
+<translation id="6896758677409633944">Kopieer</translation>
+<translation id="8393700583063109961">Bericht verzenden</translation>
+<translation id="3557336313807607643">Toevoegen aan contacten</translation>
+<translation id="4269820728363426813">Linkadres kopiëren</translation>
+<translation id="1206892813135768548">Linktekst kopiëren</translation>
+<translation id="1204037785786432551">Link downloaden</translation>
+<translation id="6864459304226931083">Afbeelding downloaden</translation>
+<translation id="8209050860603202033">Afbeelding openen</translation>
+<translation id="8073388330009372546">Openen op nieuw tabblad</translation>
+<translation id="6649642165559792194">Afbeelding bekijken <ph name="BEGIN_NEW"/>Nieuw<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Afbeelding laden</translation>
+<translation id="3845332215609790146">Zoeken met Brave Software Lens <ph name="BEGIN_NEW"/>Nieuw<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Zoeken op <ph name="SEARCH_ENGINE"/> naar afbeelding</translation>
+<translation id="3384347053049321195">Afbeelding delen</translation>
+<translation id="5833984609253377421">Link delen</translation>
+<translation id="6475951671322991020">Video downloaden</translation>
+<translation id="2317945146070194624">Openen op nieuw Brave-tabblad</translation>
+<translation id="7975379999046275268">Pagina bekijken <ph name="BEGIN_NEW"/>Nieuw<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Pagina vernieuwen</translation>
+<translation id="36525718899759834">Download de app uit de Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Donker</translation>
+<translation id="1807246157184219062">Licht</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Selecteer een tabblad om te beamen</translation>
+<translation id="8719023831149562936">Kan huidig tabblad niet beamen</translation>
+<translation id="2139186145475833000">Toevoegen aan startscherm</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> openen</translation>
+<translation id="2122601567107267586">Kan app niet openen</translation>
+<translation id="5129038482087801250">Web-app installeren</translation>
+<translation id="3789841737615482174">Installeren</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> is toegevoegd aan je startscherm</translation>
+<translation id="7333031090786104871">Nog steeds bezig met toevoegen van vorige site</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> toevoegen...</translation>
+<translation id="3778956594442850293">Toegevoegd aan startscherm</translation>
+<translation id="2146738493024040262">Instant-app openen</translation>
+<translation id="7016516562562142042">Toegestaan voor huidige zoekmachine</translation>
+<translation id="6177111841848151710">Geblokkeerd voor de huidige zoekmachine</translation>
+<translation id="145097072038377568">Uitgeschakeld in Android-instellingen</translation>
+<translation id="8007176423574883786">Uitgeschakeld voor dit apparaat</translation>
+<translation id="164269334534774161">Je bekijkt een offline exemplaar van deze pagina van <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Deze offline pagina is van <ph name="CREATION_TIME"/> en kan afwijken van de online versie.</translation>
+<translation id="8840953339110955557">Deze pagina kan afwijken van de online versie.</translation>
+<translation id="6405300764336705484">Deze content is afkomstig van <ph name="DOMAIN_NAME"/>, geleverd door Brave Software.</translation>
+<translation id="1006017844123154345">Online openen</translation>
+<translation id="3326636747541519688">Lite-pagina geleverd door Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Oorspronkelijke pagina laden <ph name="END_LINK"/> van <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Als je deze melding vaker ziet, kun je deze <ph name="BEGIN_LINK"/>suggesties<ph name="END_LINK"/> proberen.</translation>
+<translation id="8748850008226585750">Content verborgen</translation>
+<translation id="3810973564298564668">Beheren</translation>
+<translation id="5199929503336119739">Werkprofiel</translation>
+<translation id="528192093759286357">Sleep vanaf de bovenkant en tik op de knop Terug om het volledige scherm te sluiten.</translation>
+<translation id="2836148919159985482">Tik op de knop Terug om het volledige scherm te sluiten.</translation>
+<translation id="3967822245660637423">Downloaden voltooid</translation>
+<translation id="2434158240863470628">Download voltooid <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Downloaden mislukt</translation>
+<translation id="1384959399684842514">Download onderbroken</translation>
+<translation id="1671236975893690980">Download in behandeling…</translation>
+<translation id="5561549206367097665">Wachten op netwerk…</translation>
+<translation id="5864419784173784555">Wachten op andere download…</translation>
+<translation id="6461962085415701688">Kan bestand niet openen</translation>
+<translation id="1178581264944972037">Onderbreken</translation>
+<translation id="8200772114523450471">Doorgaan</translation>
+<translation id="1409879593029778104">Downloaden van <ph name="FILE_NAME"/> is voorkomen omdat het bestand al bestaat.</translation>
+<translation id="3387650086002190359">Downloaden van <ph name="FILE_NAME"/> is mislukt door fouten in het bestandssysteem.</translation>
+<translation id="6482749332252372425">Downloaden van <ph name="FILE_NAME"/> is mislukt door te weinig opslagruimte.</translation>
+<translation id="7619072057915878432">Downloaden van <ph name="FILE_NAME"/> is mislukt door netwerkfouten.</translation>
+<translation id="1477626028522505441">Downloaden van <ph name="FILE_NAME"/> is mislukt door serverproblemen.</translation>
+<translation id="3692944402865947621">Downloaden van <ph name="FILE_NAME"/> mislukt omdat de opslaglocatie niet bereikbaar is.</translation>
+<translation id="604996488070107836">Download van <ph name="FILE_NAME"/> mislukt vanwege een onbekende fout.</translation>
+<translation id="6738867403308150051">Downloaden...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> van ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> van <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB gedownload</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB gedownload</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB gedownload</translation>
+<translation id="9204836675896933765">1 bestand over</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> bestanden over</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> bestand gedownload}other{<ph name="FILES_DOWNLOADED_MANY"/> bestanden gedownload}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> dagen resterend</translation>
+<translation id="8190358571722158785">1 dag resterend</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> uur resterend</translation>
+<translation id="510275257476243843">1 uur resterend</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minuten resterend</translation>
+<translation id="3236059992281584593">1 minuut resterend</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> seconden resterend</translation>
+<translation id="2781151931089541271">1 seconde resterend</translation>
+<translation id="3303414029551471755">Doorgaan met het downloaden van de content?</translation>
+<translation id="8617240290563765734">De voorgestelde URL in de gedownloade content openen?</translation>
+<translation id="1373696734384179344">Onvoldoende geheugen om de geselecteerde content te downloaden.</translation>
+<translation id="5271967389191913893">Het apparaat kan de content niet openen die moet worden gedownload.</translation>
+<translation id="883806473910249246">Er is een fout opgetreden tijdens het downloaden van de content.</translation>
+<translation id="5626134646977739690">Naam:</translation>
+<translation id="7963646190083259054">Leverancier:</translation>
+<translation id="3414952576877147120">Grootte:</translation>
+<translation id="7375125077091615385">Type:</translation>
+<translation id="5765780083710877561">Beschrijving:</translation>
+<translation id="4881695831933465202">Openen</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB beschikbaar</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB beschikbaar</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB beschikbaar</translation>
+<translation id="5793665092639000975">Er wordt <ph name="SPACE_USED"/> van de <ph name="SPACE_AVAILABLE"/> gebruikt</translation>
+<translation id="3587482841069643663">Alles</translation>
+<translation id="4988526792673242964">Pagina's</translation>
+<translation id="3810838688059735925">Videobestanden</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Afbeeldingen</translation>
+<translation id="8250920743982581267">Documenten</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# bestand}other{# bestanden}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# afbeelding}other{# afbeeldingen}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# video's}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# audiobestand}other{# audiobestanden}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# pagina}other{# pagina's}}</translation>
+<translation id="5456381639095306749">Pagina downloaden</translation>
+<translation id="2394602618534698961">Bestanden die je downloadt, worden hier weergegeven</translation>
+<translation id="7810647596859435254">Openen met…</translation>
+<translation id="5655963694829536461">Zoek in je downloads</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mijn bestanden</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Hier worden artikelen weergegeven die je zelfs kunt lezen wanneer je offline bent</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# uur}other{# uur}}</translation>
+<translation id="5853623416121554550">onderbroken</translation>
+<translation id="8965591936373831584">in behandeling</translation>
+<translation id="2779651927720337254">mislukt</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Zojuist</translation>
+<translation id="4000212216660919741">Homepage voor offline</translation>
+<translation id="9133397713400217035">Offline ontdekken</translation>
+<translation id="968900484120156207">Pagina's die je bezoekt, worden hier weergegeven</translation>
+<translation id="7882131421121961860">Geen geschiedenis gevonden</translation>
+<translation id="3549657413697417275">Zoek in je geschiedenis</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">JJ</translation>
+<translation id="724102042129299115">Functionaliteit bij eerste uitvoering van Brave</translation>
+<translation id="2700285883409956633">Als je deze app gebruikt, ga je akkoord met de <ph name="BEGIN_LINK1"/>servicevoorwaarden<ph name="END_LINK1"/> en het <ph name="BEGIN_LINK2"/>privacybeleid<ph name="END_LINK2"/> van Brave.</translation>
+<translation id="1640714894372474981">Door deze app te gebruiken, ga je akkoord met de <ph name="BEGIN_LINK1"/>Servicevoorwaarden<ph name="END_LINK1"/> en het <ph name="BEGIN_LINK2"/>Privacybeleid<ph name="END_LINK2"/> van Brave en het <ph name="BEGIN_LINK3"/>Privacyverklaring voor Brave Software-accounts die worden beheerd met Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> wordt geopend in Brave. Als je doorgaat, ga je akkoord met de <ph name="BEGIN_LINK1"/>Servicevoorwaarden<ph name="END_LINK1"/> en het <ph name="BEGIN_LINK2"/>Privacybeleid<ph name="END_LINK2"/> van Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> wordt geopend in Brave. Als je doorgaat, ga je akkoord met de <ph name="BEGIN_LINK1"/>Servicevoorwaarden<ph name="END_LINK1"/> en het <ph name="BEGIN_LINK2"/>Privacybeleid<ph name="END_LINK2"/> van Brave en het <ph name="BEGIN_LINK3"/>Privacyverklaring voor Brave Software-accounts die worden beheerd met Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Verzend automatisch gebruiksstatistieken en crashmeldingen naar Brave Software.</translation>
+<translation id="3518985090088779359">Accept. en doorgaan</translation>
+<translation id="7207456302801184289">Welkom bij Brave</translation>
+<translation id="704822250101715322">Wachten tot Brave Software Play-services is geüpdatet</translation>
+<translation id="1231733316453485619">Synchronisatie inschakelen?</translation>
+<translation id="5132942445612118989">Je wachtwoorden, geschiedenis en meer synchroniseren op al je apparaten</translation>
+<translation id="5736731321935944068">Brave Software kan je geschiedenis gebruiken om Brave Software Zoeken, advertenties en andere Brave Software-services te personaliseren</translation>
+<translation id="4013614219085422040">Brave Software kan je geschiedenis gebruiken om Brave Software Zoeken en andere Brave Software-services te personaliseren</translation>
+<translation id="5581519193887989363">Je kunt altijd in de <ph name="BEGIN_LINK1"/>instellingen<ph name="END_LINK1"/> bepalen wat je wilt synchroniseren.</translation>
+<translation id="741204030948306876">Ja, inschakelen</translation>
+<translation id="2410754283952462441">Een account selecteren</translation>
+<translation id="2227444325776770048">Doorgaan als <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Niet <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Schakel synchronisatie in om op al je apparaten toegang tot je bladwijzers te hebben</translation>
+<translation id="2818669890320396765">Log in en schakel synchronisatie in om op al je apparaten toegang tot je bladwijzers te hebben</translation>
+<translation id="6003646045106347985">Schakel synchronisatie in om suggesties voor gepersonaliseerde content van Brave Software te ontvangen</translation>
+<translation id="8494430740943879273">Log in en schakel synchronisatie in om suggesties voor gepersonaliseerde content van Brave Software te ontvangen</translation>
+<translation id="5862731021271217234">Schakel synchronisatie in om de tabbladen van je andere apparaten te bekijken</translation>
+<translation id="3568688522516854065">Log in en schakel synchronisatie in om de tabbladen van je andere apparaten te bekijken</translation>
+<translation id="1208340532756947324">Schakel synchronisatie in om verschillende apparaten te synchroniseren en te personaliseren</translation>
+<translation id="4472118726404937099">Log in en schakel synchronisatie in om verschillende apparaten te synchroniseren en te personaliseren</translation>
+<translation id="2426805022920575512">Een ander account kiezen</translation>
+<translation id="6790428901817661496">Spelen</translation>
+<translation id="1272079795634619415">Stop</translation>
+<translation id="2874939134665556319">Vorig nummer</translation>
+<translation id="4046123991198612571">Volgend nummer</translation>
+<translation id="3859306556332390985">Vooruit zoeken</translation>
+<translation id="8441146129660941386">Achteruit zoeken</translation>
+<translation id="6706288973712894588">Je bent op dit moment offline.\n<ph name="BEGIN_LINK"/>Bekijk je offline feed.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Recente tabbladen</translation>
+<translation id="8497726226069778601">Hier is nog niets te zien</translation>
+<translation id="5423934151118863508">Je meest bezochte pagina's worden hier weergegeven</translation>
+<translation id="6127379762771434464">Item verwijderd</translation>
+<translation id="4605958867780575332">Item verwijderd: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software-doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Andere apparaten</translation>
+<translation id="4738836084190194332">Laatst gesynchroniseerd: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minuut geleden}other{# minuten geleden}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# uur geleden}other{# uur geleden}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# dag geleden}other{# dagen geleden}}</translation>
+<translation id="2762000892062317888">zojuist</translation>
+<translation id="1407135791313364759">Alles openen</translation>
+<translation id="1209206284964581585">Voorlopig verbergen</translation>
+<translation id="129553762522093515">Recent gesloten</translation>
+<translation id="8413126021676339697">Hele geschiedenis bekijken</translation>
+<translation id="7876243839304621966">Alles verwijderen</translation>
+<translation id="8487700953926739672">Offline beschikbaar</translation>
+<translation id="5224771365102442243">Met video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Meer informatie<ph name="END_LINK"/> over voorgestelde content</translation>
+<translation id="7542481630195938534">Kan suggesties niet ophalen</translation>
+<translation id="5013696553129441713">Geen nieuwe suggesties</translation>
+<translation id="1736419249208073774">Verkennen</translation>
+<translation id="7444811645081526538">Meer categorieën</translation>
+<translation id="6709133671862442373">Nieuws</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Winkelen</translation>
+<translation id="3912508018559818924">We zoeken naar het beste op internet…</translation>
+<translation id="526421993248218238">Kan deze pagina niet laden</translation>
+<translation id="614940544461990577">Probeer dit eens:</translation>
+<translation id="3288003805934695103">Laad de pagina opnieuw</translation>
+<translation id="2353636109065292463">Je internetverbinding controleren…</translation>
+<translation id="2858138569776157458">Topsites</translation>
+<translation id="8364299278605033898">Bekijk populaire websites</translation>
+<translation id="1171770572613082465">Bekijk populaire websites door op de knop Topsites te tikken</translation>
+<translation id="5233638681132016545">Nieuw tabblad</translation>
+<translation id="4521874409998847950">Van <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>geleverd door Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Nieuwere versie beschikbaar</translation>
+<translation id="4058091506841967397">Brave kan niet updaten</translation>
+<translation id="6316139424528454185">Android-versie wordt niet ondersteund</translation>
+<translation id="6989267951144302301">Kan niet downloaden</translation>
+<translation id="624789221780392884">Update gereed</translation>
+<translation id="1549000191223877751">Naar ander venster</translation>
+<translation id="7481312909269577407">Vooruit</translation>
+<translation id="4084682180776658562">Bladwijzer maken</translation>
+<translation id="6437478888915024427">Pagina-informatie</translation>
+<translation id="7180611975245234373">Vernieuwen</translation>
+<translation id="4913169188695071480">Vernieuwen stopzetten</translation>
+<translation id="1829244130665387512">Zoeken op pagina</translation>
+<translation id="6593061639179217415">Desktopsite</translation>
+<translation id="9063523880881406963">'Desktopsite opvragen' uitschakelen</translation>
+<translation id="2038563949887743358">'Desktopsite aanvragen' inschakelen</translation>
+<translation id="2433507940547922241">Vormgeving</translation>
+<translation id="983192555821071799">Alle tabbladen sluiten</translation>
+<translation id="1310482092992808703">Tabbladen groeperen</translation>
+<translation id="7725024127233776428">Pagina's waaraan je een bladwijzer toevoegt, worden hier weergegeven</translation>
+<translation id="4404568932422911380">Geen bladwijzers</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> bladwijzer}other{<ph name="BOOKMARKS_COUNT_MANY"/> bladwijzers}}</translation>
+<translation id="3739899004075612870">Bladwijzer toegevoegd in <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Toegevoegd aan 'Bladwijzers'</translation>
+<translation id="4452548195519783679">Bladwijzer gemaakt in <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Kan bladwijzer niet toevoegen.</translation>
+<translation id="2842985007712546952">Bovenliggende map</translation>
+<translation id="9065203028668620118">Bewerken</translation>
+<translation id="4405224443901389797">Verplaatsen naar…</translation>
+<translation id="5170568018924773124">Weergeven in map</translation>
+<translation id="8035133914807600019">Nieuwe map…</translation>
+<translation id="4532845899244822526">Map kiezen</translation>
+<translation id="6627583120233659107">Map bewerken</translation>
+<translation id="1197267115302279827">Bladwijzers verplaatsen</translation>
+<translation id="6963766334940102469">Bladwijzers verwijderen</translation>
+<translation id="4351244548802238354">Dialoogvenster sluiten</translation>
+<translation id="451872707440238414">Zoek in je bladwijzers</translation>
+<translation id="8901170036886848654">Geen bladwijzers gevonden</translation>
+<translation id="6404511346730675251">Bladwijzer bewerken</translation>
+<translation id="3894427358181296146">Map toevoegen</translation>
+<translation id="5327248766486351172">Naam</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Map</translation>
+<translation id="5161254044473106830">Titel is vereist</translation>
+<translation id="2996809686854298943">URL vereist</translation>
+<translation id="2536728043171574184">Een offline exemplaar van deze pagina bekijken</translation>
+<translation id="4698034686595694889">Offline bekijken in <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> en meer sites</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave laadt de pagina wanneer deze gereed is}other{Brave laadt de pagina's wanneer deze gereed zijn}}</translation>
+<translation id="6811034713472274749">Pagina kan nu worden bekeken</translation>
+<translation id="4561979708150884304">Geen verbinding</translation>
+<translation id="8274165955039650276">Downloads bekijken</translation>
+<translation id="2082238445998314030">Resultaat <ph name="RESULT_NUMBER"/> van <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Geen resultaten</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Gesproken zoekopdracht niet beschikbaar</translation>
+<translation id="7191430249889272776">Tabblad op de achtergrond geopend.</translation>
+<translation id="8445059357334030806">Openen in Brave</translation>
+<translation id="4720023427747327413">Openen in <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Openen in browser</translation>
+<translation id="1113597929977215864">Vereenvoudigde weergave tonen</translation>
+<translation id="1513352483775369820">Bladwijzers en webgeschiedenis</translation>
+<translation id="4939482511480190003">Help bij het verbeteren van Brave. <ph name="BEGIN_LINK"/>Enquête invullen<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Terug</translation>
+<translation id="5596627076506792578">Meer opties</translation>
+<translation id="3522247891732774234">Update beschikbaar. Meer opties</translation>
+<translation id="6773423637732432200">Brave kan niet updaten. Meer opties</translation>
+<translation id="3328801116991980348">Site-informatie</translation>
+<translation id="5391532827096253100">Je verbinding met deze site is niet beveiligd. Site-informatie</translation>
+<translation id="6206551242102657620">De verbinding is beveiligd. Site-informatie</translation>
+<translation id="6963642900430330478">Deze pagina is gevaarlijk. Site-informatie</translation>
+<translation id="9070377983101773829">Gesproken zoekopdracht starten</translation>
+<translation id="8676374126336081632">Invoer wissen</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> geopend tabblad, tik om tussen tabbladen te schakelen}other{<ph name="OPEN_TABS_MANY"/> geopende tabbladen, tik om tussen tabbladen te schakelen}}</translation>
+<translation id="2369533728426058518">geopende tabbladen</translation>
+<translation id="7071521146534760487">Account beheren</translation>
+<translation id="932327136139879170">Homepage</translation>
+<translation id="2707726405694321444">Pagina vernieuwen</translation>
+<translation id="2891154217021530873">Stoppen met het laden van de pagina</translation>
+<translation id="6710213216561001401">Vorige</translation>
+<translation id="6659594942844771486">Tabblad</translation>
+<translation id="1933845786846280168">Geselecteerd tabblad</translation>
+<translation id="2268044343513325586">Verfijnen</translation>
+<translation id="7846076177841592234">Selectie opheffen</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> geselecteerd. Opties beschikbaar bovenaan het scherm.</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> geselecteerd</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 geselecteerd item delen}other{# geselecteerde items delen}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 geselecteerd item verwijderen}other{# geselecteerde items verwijderen}}</translation>
+<translation id="1283039547216852943">Tik om uit te vouwen</translation>
+<translation id="5962718611393537961">Tik om samen te vouwen</translation>
+<translation id="8076492880354921740">Tabbladen</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 geselecteerd}other{# geselecteerd}}</translation>
+<translation id="6818926723028410516">Items selecteren</translation>
+<translation id="4797039098279997504">Tik om terug te gaan naar <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Tik om naar de site te gaan</translation>
+<translation id="429312253194641664">Een site speelt media af</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> heeft toegang tot je scherm</translation>
+<translation id="8833831881926404480">Een site deelt je scherm</translation>
+<translation id="9086455579313502267">Geen toegang tot het netwerk</translation>
+<translation id="938850635132480979">Fout: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Openen in <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Openen in app voor passen</translation>
+<translation id="7698359219371678927">E-mail in <ph name="APP_NAME"/> maken</translation>
+<translation id="7875915731392087153">E-mail maken</translation>
+<translation id="5665379678064389456">Afspraak maken in <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Afspraak maken</translation>
+<translation id="2111511281910874386">Ga naar pagina</translation>
+<translation id="3988466920954086464">Instant-zoekresultaten weergeven in dit venster</translation>
+<translation id="2744248271121720757">Tik op een woord om meteen te zoeken of gerelateerde acties te bekijken</translation>
+<translation id="9155898266292537608">Je kunt ook zoeken door kort op een woord te tikken</translation>
+<translation id="3232754137068452469">Webapp</translation>
+<translation id="1430915738399379752">Afdrukken</translation>
+<translation id="3775705724665058594">Verzenden naar je apparaten</translation>
+<translation id="6364438453358674297">Suggestie verwijderen uit geschiedenis?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> gesloten</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> tabbladen gesloten</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> is verwijderd</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> bladwijzers verwijderd</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> downloads verwijderd</translation>
+<translation id="1248710015876067820">Niet-ondersteund aantal Brave-instanties.</translation>
+<translation id="4259722352634471385">Navigatie is geblokkeerd: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigatie is onbereikbaar: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Tabblad sluiten</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> sluiten</translation>
+<translation id="1227058898775614466">Navigatiegeschiedenis</translation>
+<translation id="9169507124922466868">Navigatiegeschiedenis is half geopend</translation>
+<translation id="1327257854815634930">Navigatiegeschiedenis is geopend</translation>
+<translation id="8788265440806329501">Navigatiegeschiedenis is gesloten</translation>
+<translation id="7482656565088326534">Voorbeeldtabblad</translation>
+<translation id="8427875596167638501">Voorbeeldtabblad is half geopend</translation>
+<translation id="9102803872260866941">Voorbeeldtabblad is geopend</translation>
+<translation id="2942036813789421260">Voorbeeldtabblad is gesloten</translation>
+<translation id="6355102470683871794">Opslag van Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Site-opslag wissen?</translation>
+<translation id="9205995714227143200">Site-opslag waarvan Brave denkt dat deze niet belangrijk is (bijvoorbeeld sites zonder opgeslagen instellingen of sites die je niet vaak bezoekt)</translation>
+<translation id="3997476611815694295">Onbelangrijke opslag</translation>
+<translation id="8493948351860045254">Ruimte vrijmaken</translation>
+<translation id="2324920234469020158">Hiermee worden cookies, het cachegeheugen en andere gegevens gewist van sites waarvan Brave denkt dat deze niet belangrijk zijn.</translation>
+<translation id="5447201525962359567">Alle site-opslag, inclusief cookies en andere lokaal opgeslagen gegevens</translation>
+<translation id="1376578503827013741">Berekenen…</translation>
+<translation id="583281660410589416">Onbekend</translation>
+<translation id="2323763861024343754">Site-opslag</translation>
+<translation id="3587672679800759167">Totale gegevens gebruikt door Brave, inclusief accounts, bladwijzers en opgeslagen instellingen</translation>
+<translation id="6545017243486555795">Alle gegevens wissen</translation>
+<translation id="4095146165863963773">App-gegevens verwijderen?</translation>
+<translation id="53119194224775367">Alle app-gegevens voor Brave worden definitief verwijderd. Dit omvat alle bestanden, instellingen, accounts, databases, enzovoort.</translation>
+<translation id="5307446750509046227">Site-opslag wissen</translation>
+<translation id="300526633675317032">Hiermee wordt de volledige <ph name="SIZE_IN_KB"/> aan site-opslag gewist.</translation>
+<translation id="8068648041423924542">Kan certificaat niet selecteren.</translation>
+<translation id="2315043854645842844">Certificaatselectie aan clientzijde wordt niet ondersteund door het besturingssysteem.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> wil verbinding maken</translation>
+<translation id="5308380583665731573">Verbinding maken</translation>
+<translation id="868929229000858085">Zoek in je contacten</translation>
+<translation id="1919950603503897840">Contacten selecteren</translation>
+<translation id="7986741934819883144">Een contact selecteren</translation>
+<translation id="3333961966071413176">Alle contacten</translation>
+<translation id="4994033804516042629">Geen contacten gevonden</translation>
+<translation id="5403592356182871684">Namen</translation>
+<translation id="2717722538473713889">E-mailadressen</translation>
+<translation id="381841723434055211">Telefoonnummers</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(en nog 1)}other{(en nog #)}}</translation>
+<translation id="5197729504361054390">De contacten die je selecteert, worden gedeeld met <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Image Decoder</translation>
+<translation id="8067883171444229417">Video afspelen</translation>
+<translation id="6560414384669816528">Zoeken met Sogou</translation>
+<translation id="5406914950576900927">Brave kan <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> gebruiken voor zoekopdrachten in China. Je kunt dit wijzigen in <ph name="BEGIN_LINK"/>Instellingen<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Brave Software blijven gebruiken</translation>
+<translation id="4384468725000734951">Sogou wordt gebruikt om te zoeken</translation>
+<translation id="6103327872225198548">Brave Software wordt gebruikt om te zoeken</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Deze app wordt uitgevoerd in Brave</translation>
+<translation id="6143689084714664628">Actief in Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> heeft ook gegevens in Brave</translation>
+<translation id="2734140769649165081">Je kunt de gegevens wissen in de Brave-instellingen</translation>
+<translation id="8232956427053453090">Gegevens behouden</translation>
+<translation id="4298388696830689168">Gekoppelde sites</translation>
+<translation id="5763514718066511291">Tik om de URL voor deze app te kopiëren</translation>
+<translation id="6496823230996795692">Maak verbinding met internet als je <ph name="APP_NAME"/> voor het eerst wilt gebruiken.</translation>
+<translation id="751961395872307827">Kan geen verbinding maken met de site</translation>
+<translation id="4878404682131129617">Kan geen tunnel tot stand brengen via de proxyserver</translation>
+<translation id="4749960740855309258">Een nieuw tabblad openen</translation>
+<translation id="8788968922598763114">Het laatst gesloten tabblad opnieuw openen</translation>
+<translation id="7929962904089429003">Het menu openen</translation>
+<translation id="6039379616847168523">Naar het volgende tabblad gaan</translation>
+<translation id="5210286577605176222">Naar het vorige tabblad gaan</translation>
+<translation id="124678866338384709">Huidig tabblad sluiten</translation>
+<translation id="3714981814255182093">De zoekbalk openen</translation>
+<translation id="5441522332038954058">Naar de adresbalk gaan</translation>
+<translation id="3398320232533725830">Bladwijzerbeheer openen</translation>
+<translation id="6583199322650523874">Een bladwijzer toevoegen voor de huidige pagina</translation>
+<translation id="8489271220582375723">De pagina Geschiedenis openen</translation>
+<translation id="4837753911714442426">Afdrukopties voor de pagina openen</translation>
+<translation id="5726692708398506830">Alles op de pagina vergroten</translation>
+<translation id="3259831549858767975">Alles op de pagina verkleinen</translation>
+<translation id="8015452622527143194">Standaardgrootte van alles op de pagina herstellen</translation>
+<translation id="3443221991560634068">De huidige pagina opnieuw laden</translation>
+<translation id="123724288017357924">De pagina opnieuw laden, gecachte content negeren</translation>
+<translation id="305870044889644984">Helpcentrum van Brave openen in een nieuw tabblad</translation>
+<translation id="3166827708714933426">Sneltoetsen voor tabbladen en vensters</translation>
+<translation id="3169981355900570544">Functiesneltoetsen in Brave Software Brave</translation>
+<translation id="4558311620361989323">Sneltoetsen voor webpagina's</translation>
+<translation id="1908301351964700579">Brave wordt nog voorbereid voor VR. Start Brave later opnieuw op.</translation>
+<translation id="8970887620466824814">Er is iets misgegaan.</translation>
+<translation id="1875543012935658554">Open Brave opnieuw.</translation>
+<translation id="79859296434321399">Installeer ARCore om augmented reality-content te bekijken</translation>
+<translation id="8558485628462305855">Update ARCore om augmented reality-content te bekijken</translation>
+<translation id="3513704683820682405">Augmented reality</translation>
+<translation id="5475862044948910901">Augmented reality-sessie starten?</translation>
 <translation id="7365126855094612066">Gedurende deze sessie kan de site het volgende doen:
 • Een 3D-kaart van je omgeving maken.
 • De beweging van de camera volgen.
 
 De site krijgt GEEN toegang tot de camera. De camerabeelden zijn alleen zichtbaar voor jou.</translation>
-<translation id="7375125077091615385">Type:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Functionaliteit bij eerste uitvoering van Chrome</translation>
-<translation id="741204030948306876">Ja, inschakelen</translation>
-<translation id="7413229368719586778">Begindatum: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Eerst vragen</translation>
-<translation id="7423538860840206698">Lezen van het klembord geblokkeerd</translation>
-<translation id="7431991332293347422">Beheren hoe je browsegeschiedenis wordt gebruikt om Google Zoeken en meer te personaliseren</translation>
-<translation id="7437998757836447326">Uitloggen bij Chrome</translation>
-<translation id="7438641746574390233">Wanneer de Lite-modus is ingeschakeld, gebruikt Chrome Google-servers om pagina's sneller te laden. In de Lite-versie worden erg trage pagina's herschreven zodat alleen essentiële content wordt geladen. De Lite-modus werkt niet op incognitotabbladen.</translation>
-<translation id="7444811645081526538">Meer categorieën</translation>
-<translation id="7445411102860286510">Sites toestaan gedempte video's automatisch af te spelen (aanbevolen)</translation>
-<translation id="7453467225369441013">Hiermee word je uitgelogd van de meeste sites. Je wordt niet uitgelogd van je Google-account.</translation>
-<translation id="7454641608352164238">Onvoldoende ruimte</translation>
-<translation id="7475192538862203634">Als je deze melding vaker ziet, kun je deze <ph name="BEGIN_LINK" />suggesties<ph name="END_LINK" /> proberen.</translation>
-<translation id="7475688122056506577">SD-kaart niet gevonden. Sommige van je bestanden kunnen ontbreken.</translation>
-<translation id="7479104141328977413">Tabbladbeheer</translation>
-<translation id="7481312909269577407">Vooruit</translation>
-<translation id="7482656565088326534">Voorbeeldtabblad</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (geüpdatet: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">data bespaard</translation>
-<translation id="7498271377022651285">Een ogenblik geduld…</translation>
-<translation id="7514365320538308">Downloaden</translation>
-<translation id="751961395872307827">Kan geen verbinding maken met de site</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Kan suggesties niet ophalen</translation>
-<translation id="7559975015014302720">Lite-versie is uitgeschakeld</translation>
-<translation id="7562080006725997899">Browsegegevens wissen</translation>
-<translation id="756809126120519699">Chrome-gegevens gewist</translation>
-<translation id="757524316907819857">Blokkeren dat sites beschermde content kunnen afspelen</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> bestand gedownload}other{<ph name="FILES_DOWNLOADED_MANY" /> bestanden gedownload}}</translation>
-<translation id="7588219262685291874">Het donkere thema inschakelen wanneer de batterijbesparing van je apparaat is ingeschakeld</translation>
-<translation id="7589445247086920869">Blokkeren voor huidige zoekmachine</translation>
-<translation id="7593557518625677601">Open Android-instellingen en schakel Android-systeemsynchronisatie weer in om Chrome-synchronisatie te starten</translation>
-<translation id="7596558890252710462">Besturingssysteem</translation>
-<translation id="7605594153474022051">Synchronisatie werkt niet</translation>
-<translation id="7606077192958116810">Lite-versie is ingeschakeld. Je kunt dit beheren via de instellingen.</translation>
-<translation id="7612619742409846846">Ingelogd bij Google als</translation>
-<translation id="7619072057915878432">Downloaden van <ph name="FILE_NAME" /> is mislukt door netwerkfouten.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Hulp vragen<ph name="END_LINK1" /> of <ph name="BEGIN_LINK2" />opnieuw scannen<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Welkom bij Chrome</translation>
-<translation id="7638584964844754484">Onjuiste wachtwoordzin</translation>
-<translation id="7641339528570811325">Browsegegevens wissen</translation>
-<translation id="7648422057306047504">Wachtwoorden versleutelen met Google-inloggegevens</translation>
-<translation id="7649070708921625228">Hulp</translation>
-<translation id="7658239707568436148">Annuleren</translation>
-<translation id="7665369617277396874">Account toevoegen</translation>
-<translation id="766587987807204883">Hier worden artikelen weergegeven die je zelfs kunt lezen wanneer je offline bent</translation>
-<translation id="7682724950699840886">Probeer de volgende tips: zorg dat er voldoende ruimte op je apparaat beschikbaar is, probeer opnieuw te exporteren.</translation>
-<translation id="7685301384041462804">Controleer of je deze site vertrouwt voordat je VR activeert.</translation>
-<translation id="7698359219371678927">E-mail in <ph name="APP_NAME" /> maken</translation>
-<translation id="7704317875155739195">Zoekopdrachten en URL's automatisch aanvullen</translation>
-<translation id="7725024127233776428">Pagina's waaraan je een bladwijzer toevoegt, worden hier weergegeven</translation>
-<translation id="773466115871691567">Pagina's in het <ph name="SOURCE_LANGUAGE" /> altijd vertalen</translation>
-<translation id="7746457520633464754">Chrome verzendt de URL's van sommige pagina's die je bezoekt, beperkte systeemgegevens en bepaalde paginacontent naar Google om gevaarlijke apps en sites te detecteren</translation>
-<translation id="7757787379047923882">Tekst gedeeld vanaf <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-kaart <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Adres toevoegen</translation>
-<translation id="7772032839648071052">Bevestig de wachtwoordzin</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> sluiten</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> andere}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 en nog <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> andere}}</translation>
-<translation id="7781829728241885113">Gisteren</translation>
-<translation id="7791543448312431591">Toevoegen</translation>
-<translation id="780301667611848630">Nee, bedankt</translation>
-<translation id="7810647596859435254">Openen met…</translation>
-<translation id="7821588508402923572">Hier wordt getoond hoeveel data je bespaart</translation>
-<translation id="7837721118676387834">Automatisch afspelen van gedempte video's toestaan voor een specifieke site.</translation>
-<translation id="7846076177841592234">Selectie opheffen</translation>
-<translation id="784934925303690534">Periode</translation>
-<translation id="7851858861565204677">Andere apparaten</translation>
-<translation id="7875915731392087153">E-mail maken</translation>
-<translation id="7876243839304621966">Alles verwijderen</translation>
-<translation id="7882131421121961860">Geen geschiedenis gevonden</translation>
-<translation id="7882806643839505685">Geluid toestaan voor een specifieke site.</translation>
-<translation id="7886917304091689118">Actief in Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Bestand downloaden.}other{# bestanden downloaden.}}</translation>
-<translation id="7929962904089429003">Het menu openen</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> is verouderd.</translation>
-<translation id="7947953824732555851">Accepteren en inloggen</translation>
-<translation id="7963646190083259054">Leverancier:</translation>
-<translation id="7971136598759319605">1 dag geleden actief</translation>
-<translation id="7975379999046275268">Pagina bekijken <ph name="BEGIN_NEW" />Nieuw<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Pagina's vooraf laden voor sneller browsen en zoeken</translation>
-<translation id="79859296434321399">Installeer ARCore om augmented reality-content te bekijken</translation>
-<translation id="7986741934819883144">Een contact selecteren</translation>
-<translation id="7987073022710626672">Servicevoorwaarden van Chrome</translation>
-<translation id="7998918019931843664">Gesloten tabblad opnieuw openen</translation>
-<translation id="7999064672810608036">Weet je zeker dat je alle gegevens, inclusief cookies, voor deze website wilt wissen en alle rechten opnieuw wilt instellen?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Uitgeschakeld voor dit apparaat</translation>
-<translation id="8013372441983637696">Je Chrome-gegevens ook wissen op dit apparaat</translation>
-<translation id="8015452622527143194">Standaardgrootte van alles op de pagina herstellen</translation>
-<translation id="802154636333426148">Downloaden mislukt</translation>
-<translation id="8026334261755873520">Browsegegevens wissen</translation>
-<translation id="8035133914807600019">Nieuwe map…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> dagen resterend</translation>
-<translation id="804335162455518893">SD-kaart niet gevonden</translation>
-<translation id="805047784848435650">Op basis van je browsegeschiedenis</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB beschikbaar</translation>
-<translation id="8058746566562539958">Openen op nieuw Chrome-tabblad</translation>
-<translation id="8063895661287329888">Kan bladwijzer niet toevoegen.</translation>
-<translation id="806745655614357130">Mijn gegevens gescheiden houden</translation>
-<translation id="8067883171444229417">Video afspelen</translation>
-<translation id="8068648041423924542">Kan certificaat niet selecteren.</translation>
-<translation id="8073388330009372546">Openen op nieuw tabblad</translation>
-<translation id="8076492880354921740">Tabbladen</translation>
-<translation id="8084114998886531721">Opgeslagen wachtwoord</translation>
-<translation id="8087000398470557479">Deze content is afkomstig van <ph name="DOMAIN_NAME" />, geleverd door Google.</translation>
-<translation id="8103578431304235997">Incognitotabblad</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Schakel synchronisatie in om op al je apparaten toegang tot je bladwijzers te hebben</translation>
-<translation id="8110087112193408731">Je Chrome-activiteit weergeven in Digitaal welzijn?</translation>
-<translation id="8116925261070264013">Gedempt</translation>
-<translation id="813082847718468539">Sitegegevens bekijken</translation>
-<translation id="8131740175452115882">Bevestigen</translation>
-<translation id="8156139159503939589">Welke talen lees je?</translation>
-<translation id="8168435359814927499">Content</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> bestanden over</translation>
-<translation id="8190358571722158785">1 dag resterend</translation>
-<translation id="8200772114523450471">Doorgaan</translation>
-<translation id="8209050860603202033">Afbeelding openen</translation>
-<translation id="8218622182176210845">Je account beheren</translation>
-<translation id="8224471946457685718">Artikelen voor je downloaden bij verbinding via wifi</translation>
-<translation id="8232956427053453090">Gegevens behouden</translation>
-<translation id="8249310407154411074">Bovenaan zetten</translation>
-<translation id="8250920743982581267">Documenten</translation>
-<translation id="825412236959742607">Omdat deze pagina te veel geheugen gebruikt, heeft Chrome wat content verwijderd.</translation>
-<translation id="8260126382462817229">Probeer opnieuw in te loggen</translation>
-<translation id="8261506727792406068">Verwijderen</translation>
-<translation id="8266862848225348053">Downloadlocatie</translation>
-<translation id="8274165955039650276">Downloads bekijken</translation>
-<translation id="8284326494547611709">Ondertiteling</translation>
-<translation id="8300705686683892304">Beheerd door app</translation>
-<translation id="8310344678080805313">Standaardtabbladen</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> en meer sites</translation>
-<translation id="8327155640814342956">Update Chrome om optimaal te kunnen browsen op internet</translation>
-<translation id="8339163506404995330">Pagina's in het <ph name="LANGUAGE" /> worden niet vertaald</translation>
-<translation id="8349013245300336738">Sorteren op hoeveelheid gebruikte data</translation>
-<translation id="8364299278605033898">Bekijk populaire websites</translation>
-<translation id="8368027906805972958">Onbekend of niet-ondersteund apparaat (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Synchronisatie op de achtergrond toestaan voor een specifieke site.</translation>
-<translation id="8378714024927312812">Beheerd door je organisatie</translation>
-<translation id="8380167699614421159">Deze site geeft opdringerige of misleidende advertenties weer</translation>
-<translation id="8393700583063109961">Bericht verzenden</translation>
-<translation id="8413126021676339697">Hele geschiedenis bekijken</translation>
-<translation id="8427875596167638501">Voorbeeldtabblad is half geopend</translation>
-<translation id="8428213095426709021">Instellingen</translation>
-<translation id="8438566539970814960">Zoekopdrachten en browsefunctionaliteit verbeteren</translation>
-<translation id="8441146129660941386">Achteruit zoeken</translation>
-<translation id="8443209985646068659">Chrome kan niet updaten</translation>
-<translation id="8445448999790540984">Wachtwoorden kunnen niet worden geëxporteerd</translation>
-<translation id="8447861592752582886">Toegang tot apparaat intrekken</translation>
-<translation id="8461694314515752532">Gesynchroniseerde gegevens versleutelen met een eigen wachtwoordzin</translation>
-<translation id="8466613982764129868">Zorg dat <ph name="TARGET_DEVICE_NAME" /> is verbonden met internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Offline beschikbaar</translation>
-<translation id="8489271220582375723">De pagina Geschiedenis openen</translation>
-<translation id="8493948351860045254">Ruimte vrijmaken</translation>
-<translation id="8497726226069778601">Hier is nog niets te zien</translation>
-<translation id="8503559462189395349">Chrome-wachtwoorden</translation>
-<translation id="8503813439785031346">Gebruikersnaam</translation>
-<translation id="8514477925623180633">Wachtwoorden exporteren die zijn opgeslagen in Chrome</translation>
-<translation id="8514577642972634246">Incognitomodus starten</translation>
-<translation id="851751545965956758">Voorkomen dat sites verbinding maken met apparaten</translation>
-<translation id="8523928698583292556">Opgeslagen wachtwoord verwijderen</translation>
-<translation id="854522910157234410">Deze pagina openen</translation>
-<translation id="8558485628462305855">Update ARCore om augmented reality-content te bekijken</translation>
-<translation id="8559990750235505898">Aanbieden pagina's in andere talen te vertalen</translation>
-<translation id="8562452229998620586">Opgeslagen wachtwoorden worden hier weergegeven.</translation>
-<translation id="8569404424186215731">sinds <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Afgelopen 4 weken</translation>
-<translation id="857943718398505171">Toegestaan (aanbevolen)</translation>
-<translation id="8583805026567836021">Accountgegevens wissen</translation>
-<translation id="860043288473659153">Naam kaarthouder</translation>
-<translation id="8609465669617005112">Omhoog</translation>
-<translation id="8616006591992756292">Er kunnen andere vormen van browsegeschiedenis zijn opgeslagen voor je Google-account op <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">De voorgestelde URL in de gedownloade content openen?</translation>
-<translation id="8636825310635137004">Schakel synchronisatie in om de tabbladen op je andere apparaten te bekijken</translation>
-<translation id="8641930654639604085">Sites met content voor volwassenen proberen te blokkeren</translation>
-<translation id="8655129584991699539">Je kunt de gegevens wissen in de Chrome-instellingen</translation>
-<translation id="8662811608048051533">Hiermee word je uitgelogd van de meeste sites.</translation>
-<translation id="8664979001105139458">Bestandsnaam bestaat al</translation>
-<translation id="8676374126336081632">Invoer wissen</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signaalsterkte: # streepje}other{Signaalsterkte: # streepjes}}</translation>
-<translation id="868929229000858085">Zoek in je contacten</translation>
-<translation id="869891660844655955">Vervaldatum</translation>
-<translation id="8719023831149562936">Kan huidig tabblad niet beamen</translation>
-<translation id="8725066075913043281">Opnieuw proberen</translation>
-<translation id="8728487861892616501">Door deze app te gebruiken, ga je akkoord met de <ph name="BEGIN_LINK1" />Servicevoorwaarden<ph name="END_LINK1" /> en het <ph name="BEGIN_LINK2" />Privacybeleid<ph name="END_LINK2" /> van Chrome en het <ph name="BEGIN_LINK3" />Privacyverklaring voor Google-accounts die worden beheerd met Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Gereed</translation>
-<translation id="8748850008226585750">Content verborgen</translation>
-<translation id="8751914237388039244">Een afbeelding selecteren</translation>
-<translation id="8788265440806329501">Navigatiegeschiedenis is gesloten</translation>
-<translation id="8788968922598763114">Het laatst gesloten tabblad opnieuw openen</translation>
-<translation id="8801436777607969138">Blokkeer JavaScript voor een specifieke site.</translation>
-<translation id="8812260976093120287">Op sommige websites kun je betalen met de bovenstaande ondersteunde betaal-apps op je apparaat.</translation>
-<translation id="8816026460808729765">Sites geen toegang tot sensoren geven</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> wordt geopend in Chrome. Als je doorgaat, ga je akkoord met de <ph name="BEGIN_LINK1" />Servicevoorwaarden<ph name="END_LINK1" /> en het <ph name="BEGIN_LINK2" />Privacybeleid<ph name="END_LINK2" /> van Chrome en het <ph name="BEGIN_LINK3" />Privacyverklaring voor Google-accounts die worden beheerd met Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Bladwijzers</translation>
-<translation id="8833831881926404480">Een site deelt je scherm</translation>
-<translation id="883806473910249246">Er is een fout opgetreden tijdens het downloaden van de content.</translation>
-<translation id="8840953339110955557">Deze pagina kan afwijken van de online versie.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, tabblad</translation>
-<translation id="885701979325669005">Opslag</translation>
-<translation id="889338405075704026">Naar Chrome-instellingen</translation>
-<translation id="8901170036886848654">Geen bladwijzers gevonden</translation>
-<translation id="8909135823018751308">Delen</translation>
-<translation id="8912362522468806198">Google-account</translation>
-<translation id="8920114477895755567">Wachten op gegevens van ouders.</translation>
+<translation id="1188239144602654184">AR starten</translation>
+<translation id="473775607612524610">Updaten</translation>
+<translation id="3133489217401741157"><ph name="MODULE"/> installeren voor Brave…</translation>
+<translation id="1791662854739702043">Geïnstalleerd</translation>
+<translation id="5131234170665854056">Kan <ph name="MODULE"/> niet installeren voor Brave</translation>
+<translation id="2567385386134582609">AFBEELDING</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Download pagina's om ze offline te gebruiken</translation>
 <translation id="8922289737868596582">Download pagina's via de knop 'Meer opties' om ze offline te gebruiken</translation>
-<translation id="8937772741022875483">Je Chrome-activiteit verwijderen uit Digitaal welzijn?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Openen in een ander venster</translation>
-<translation id="8951232171465285730">Chrome bespaart je <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Cookies voor een specifieke site blokkeren.</translation>
-<translation id="8959122750345127698">Navigatie is onbereikbaar: <ph name="URL" /></translation>
-<translation id="8965591936373831584">in behandeling</translation>
-<translation id="8970887620466824814">Er is iets misgegaan.</translation>
-<translation id="8972098258593396643">Downloaden naar standaardmap?</translation>
-<translation id="8986494364107987395">Automatisch gebruiksstatistieken en crashrapporten naar Google verzenden</translation>
-<translation id="8993760627012879038">Een nieuw venster openen in de incognitomodus</translation>
-<translation id="8998729206196772491">Je logt in met een account dat wordt beheerd door <ph name="MANAGED_DOMAIN" /> waarmee je de eigenaar beheer geeft over je Chrome-gegevens. Je gegevens worden permanent gekoppeld aan dit account. Als je uitlogt van Chrome, worden je gegevens van dit apparaat verwijderd. Ze blijven echter opgeslagen in je Google-account.</translation>
-<translation id="9019902583201351841">Beheerd door je ouders</translation>
-<translation id="9028914725102941583">Schakel de synchronisatie in om content op apparaten te delen</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> toestaan om VR te activeren?</translation>
-<translation id="9040142327097499898">Meldingen zijn toegestaan. Locatie is uitgeschakeld voor dit apparaat.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# video's}}</translation>
-<translation id="9050666287014529139">Wachtwoordzin</translation>
-<translation id="9063523880881406963">'Desktopsite opvragen' uitschakelen</translation>
-<translation id="9065203028668620118">Bewerken</translation>
-<translation id="9070377983101773829">Gesproken zoekopdracht starten</translation>
-<translation id="9074336505530349563">Log in en schakel synchronisatie in om suggesties voor gepersonaliseerde content van Google te ontvangen</translation>
-<translation id="9086455579313502267">Geen toegang tot het netwerk</translation>
-<translation id="9100505651305367705">Aanbieden om artikelen weer te geven in een vereenvoudigde weergave (indien ondersteund)</translation>
-<translation id="9100610230175265781">Wachtwoordzin vereist</translation>
-<translation id="9102803872260866941">Voorbeeldtabblad is geopend</translation>
+<translation id="5958275228015807058">Vind je bestanden en pagina's in Downloads</translation>
+<translation id="5620928963363755975">Vind je bestanden en pagina's in 'Downloads' via de knop 'Meer opties'</translation>
+<translation id="3341058695485821946">Bekijk hoeveel data je hebt bespaard</translation>
+<translation id="3157842584138209013">Via de knop 'Meer opties' kun je zien hoeveel data je hebt bespaard</translation>
+<translation id="8218622182176210845">Je account beheren</translation>
+<translation id="8090895580117672212">Tik op de knop 'Account beheren' om je Brave Software-account te beheren</translation>
+<translation id="8856898588039823173">Lite-pagina weergegeven door Brave Software. Tik om het origineel te laden.</translation>
+<translation id="8134317863207426198">Lite-pagina geleverd door Brave Software. Tik om de knop 'Origineel laden' om de originele pagina te laden.</translation>
+<translation id="4961107849584082341">Vertaal deze pagina in een andere taal</translation>
+<translation id="569536719314091526">Vertaal deze pagina in een andere taal via de knop 'Meer opties'</translation>
+<translation id="1397811292916898096">Zoeken met <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Je kunt op elk gewenst moment de standaard downloadlocatie wijzigen</translation>
+<translation id="6942665639005891494">Je kunt via de menuoptie Instellingen op elk gewenst moment de standaard downloadlocatie wijzigen</translation>
+<translation id="6850409657436465440">Je download wordt nog uitgevoerd</translation>
+<translation id="5817715962196959877">Brave downloadt bestanden nu sneller</translation>
+<translation id="3976396876660209797">Verwijder de snelkoppeling en maak deze opnieuw</translation>
+<translation id="6766622839693428701">Veeg omlaag om te sluiten.</translation>
+<translation id="1028699632127661925">Verzenden naar <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/>: verzonden vanaf <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Tabblad ontvangen</translation>
 <translation id="9104217018994036254">Lijst met apparaten om een tabblad mee te delen.</translation>
-<translation id="9133397713400217035">Offline ontdekken</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Origineel weergeven</translation>
-<translation id="9139068048179869749">Vragen voordat sites meldingen mogen verzenden (aanbevolen)</translation>
-<translation id="9139318394846604261">Winkelen</translation>
-<translation id="9155898266292537608">Je kunt ook zoeken door kort op een woord te tikken</translation>
-<translation id="9169507124922466868">Navigatiegeschiedenis is half geopend</translation>
-<translation id="9204836675896933765">1 bestand over</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">De lijst met apparaten om een tabblad mee te delen, is op halve hoogte geopend.</translation>
+<translation id="2904414404539560095">De lijst met apparaten om een tabblad mee te delen, is op volledige hoogte geopend.</translation>
+<translation id="4135200667068010335">De lijst met apparaten om een tabblad mee te delen is gesloten.</translation>
+<translation id="5292796745632149097">Verzenden naar</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> dagen geleden actief</translation>
+<translation id="7971136598759319605">1 dag geleden actief</translation>
+<translation id="1521774566618522728">Vandaag actief</translation>
+<translation id="3631987586758005671">Delen met <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Schakel de synchronisatie in om content op apparaten te delen</translation>
+<translation id="6162454065885854378">Als je iets op je telefoon wilt delen met een ander apparaat, schakel je de synchronisatie in de Brave-instellingen op beide apparaten in</translation>
+<translation id="6084271560289605378">Naar Brave-instellingen</translation>
+<translation id="2318045970523081853">Tik om te bellen</translation>
 <translation id="9209888181064652401">Kan niet bellen</translation>
-<translation id="9219103736887031265">Afbeeldingen</translation>
-<translation id="926205370408745186">Je Chrome-activiteit verwijderen uit Digitaal welzijn</translation>
-<translation id="932327136139879170">Homepage</translation>
-<translation id="938850635132480979">Fout: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Toegang tot je microfoon</translation>
-<translation id="95817756606698420">Chrome kan <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> gebruiken voor zoekopdrachten in China. Je kunt dit wijzigen in <ph name="BEGIN_LINK" />Instellingen<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokkeren als site opdringerige of misleidende advertenties weergeeft (aanbevolen)</translation>
-<translation id="968900484120156207">Pagina's die je bezoekt, worden hier weergegeven</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minuten resterend</translation>
-<translation id="974555521953189084">Voer je wachtwoordzin in om de synchronisatie te starten</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Hiermee worden de gegevens voor alle sites gewist, inclusief:</translation>
-<translation id="983192555821071799">Alle tabbladen sluiten</translation>
-<translation id="987264212798334818">Algemeen</translation>
+<translation id="2860954141821109167">Zorg ervoor dat een telefoon-app is ingeschakeld op dit apparaat</translation>
+<translation id="2067805253194386918">sms</translation>
+<translation id="1450753235335490080">Kan <ph name="CONTENT_TYPE"/> niet delen</translation>
+<translation id="1266864766717917324">Kan <ph name="CONTENT_TYPE"/> niet delen</translation>
+<translation id="8287068819750208230">Zorg dat synchronisatie in Brave is ingeschakeld voor <ph name="TARGET_DEVICE_NAME"/></translation>
+<translation id="3016635187733453316">Controleer of dit apparaat verbinding heeft met internet</translation>
+<translation id="8466613982764129868">Zorg dat <ph name="TARGET_DEVICE_NAME"/> is verbonden met internet</translation>
+<translation id="6539092367496845964">Er is iets misgegaan. Probeer het later opnieuw.</translation>
+<translation id="3389286852084373014">Tekst is te groot</translation>
+<translation id="2100314319871056947">Verdeel de tekst in kleinere stukken en deel in meerdere keren.</translation>
+<translation id="2987620471460279764">Gedeelde tekst van ander apparaat</translation>
+<translation id="7757787379047923882">Tekst gedeeld vanaf <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Naar klembord gekopieerd</translation>
+<translation id="4696983787092045100">Tekst naar je apparaten verzenden</translation>
+<translation id="1260236875608242557">Zoeken en verkennen</translation>
+<translation id="6369229450655021117">Hier kun je op internet zoeken, content delen met vrienden en geopende pagina's bekijken</translation>
+<translation id="723171743924126238">Afbeeldingen selecteren</translation>
+<translation id="8751914237388039244">Een afbeelding selecteren</translation>
+<translation id="1989112275319619282">Browsen</translation>
+<translation id="7055152154916055070">Omleiding geblokkeerd:</translation>
+<translation id="5524843473235508879">Omleiding geblokkeerd.</translation>
+<translation id="6573096386450695060">Altijd toestaan</translation>
+<translation id="5805364706385912897">Omdat deze pagina te veel geheugen gebruikt, heeft Brave de pagina onderbroken.</translation>
+<translation id="5138664332909611586">Omdat deze pagina te veel geheugen gebruikt, heeft Brave wat content verwijderd.</translation>
+<translation id="9137013805542155359">Origineel weergeven</translation>
+<translation id="6361779936989026201">De Brave Software Assistent in Brave</translation>
+<translation id="7291387454912369099">Assistent voor automatisch invullen</translation>
+<translation id="4565206163201411670">Je Brave-activiteit weergeven in Digitaal welzijn?</translation>
+<translation id="9055113864158719823">Je kunt sites bekijken die je in Brave bezoekt en timers hiervoor instellen.\n\nBrave Software ontvangt informatie over de sites waarvoor je timers instelt en hoelang je ze bezoekt. Deze informatie wordt gebruikt om Digitaal welzijn te verbeteren.</translation>
+<translation id="4596514158372210596">Je Brave-activiteit verwijderen uit Digitaal welzijn</translation>
+<translation id="1174893863889683998">Je Brave-activiteit verwijderen uit Digitaal welzijn?</translation>
+<translation id="708829030563435351">Sites die je in Brave bezoekt, worden niet weergegeven. Alle sitetimers worden verwijderd.</translation>
+<translation id="2056878612599315956">Site onderbroken</translation>
+<translation id="671481426037969117">Je <ph name="FQDN"/>-timer is afgelopen. Deze begint morgen opnieuw.</translation>
+<translation id="7479104141328977413">Tabbladbeheer</translation>
+<translation id="3524138585025253783">UI voor ontwikkelaars</translation>
+<translation id="6036057147555329831">Extra ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> toestaan om VR te activeren?</translation>
+<translation id="7685301384041462804">Controleer of je deze site vertrouwt voordat je VR activeert.</translation>
+<translation id="5033865233969348410">De site kan mogelijk informatie over je verzamelen wanneer VR actief is, zoals:
+  -  je fysieke kenmerken, bijvoorbeeld je lengte
+
+Controleer of je de site vertrouwt voordat je VR activeert.</translation>
+<translation id="5534334044554683961">De site kan mogelijk informatie over je verzamelen wanneer VR actief is, zoals:
+  -   je fysieke kenmerken, bijvoorbeeld je lengte
+  -   de indeling van je kamer
+
+Controleer of je de site vertrouwt voordat je VR activeert.</translation>
+<translation id="4169535189173047238">Niet toestaan</translation>
+<translation id="2170088579611075216">VR toestaan en openen</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_no.xtb
+++ b/android/java/strings/translations/android_chrome_strings_no.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="no">
-<translation id="1006017844123154345">Åpne på nettet</translation>
-<translation id="1028699632127661925">Sender til <ph name="DEVICE_NAME" /> …</translation>
-<translation id="1036727731225946849">Legger til <ph name="WEBAPK_NAME" /> …</translation>
-<translation id="1041308826830691739">Fra nettsteder</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Aldri lagret</translation>
-<translation id="1067922213147265141">Andre Google-tjenester</translation>
-<translation id="1068672505746868501">Oversett aldri sider på <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Hvis du endrer filetternavnet, kan filen bli åpnet i et annet program og muligens utgjøre en fare for enheten.</translation>
-<translation id="1100066534610197918">Åpne i en ny fane i en gruppe</translation>
-<translation id="1105960400813249514">Skjermdump</translation>
-<translation id="1111673857033749125">Bokmerker som er lagret på de andre enhetene dine, vises her.</translation>
-<translation id="1113597929977215864">Vis forenklet visning</translation>
-<translation id="1121094540300013208">Bruks- og programstopprapporter</translation>
-<translation id="1124772482545689468">Bruker</translation>
-<translation id="1129510026454351943">Detaljer: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 nedlasting venter.}other{# nedlastinger venter.}}</translation>
-<translation id="1145536944570833626">Slett eksisterende data.</translation>
-<translation id="1146678959555564648">Slå på VR-modus</translation>
-<translation id="116280672541001035">Brukt</translation>
-<translation id="1171770572613082465">Se populære nettsteder ved å trykke på «Populært»-knappen</translation>
-<translation id="1173894706177603556">Gi nytt navn</translation>
-<translation id="1178581264944972037">Stans midlertidig</translation>
-<translation id="1181037720776840403">Fjern</translation>
-<translation id="1188239144602654184">Start utvidet virkelighet</translation>
-<translation id="1197267115302279827">Flytt bokmerker</translation>
-<translation id="119944043368869598">Fjern alle</translation>
-<translation id="1201402288615127009">Neste</translation>
-<translation id="1204037785786432551">Last ned linken</translation>
-<translation id="1206892813135768548">Kopiér linkteksten</translation>
-<translation id="1208340532756947324">For å synkronisere og gi et personlig preg på alle enhetene, slå på synkronisering</translation>
-<translation id="1209206284964581585">Skjul for øyeblikket</translation>
-<translation id="1227058898775614466">Navigeringslogg</translation>
-<translation id="1231733316453485619">Vil du slå på synkronisering?</translation>
-<translation id="123724288017357924">Last inn siden på nytt, men ignorer bufret innhold</translation>
-<translation id="124116460088058876">Flere språk</translation>
-<translation id="124678866338384709">Lukk den aktive fanen</translation>
-<translation id="1258753120186372309">Google-doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Søk og utforsk</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Kunne ikke dele <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Stopp</translation>
-<translation id="1283039547216852943">Trykk for å vise</translation>
-<translation id="1285320974508926690">Oversett aldri dette nettstedet</translation>
-<translation id="1291207594882862231">Slett loggoppføringer, informasjonskapsler, nettstedsdata, bufferen …</translation>
-<translation id="129382876167171263">Filer som nettsteder har lagret, vises her</translation>
-<translation id="129553762522093515">Nylig lukket</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – sendt fra <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Gruppér faner</translation>
-<translation id="1327257854815634930">Navigasjonsloggen er åpnet</translation>
-<translation id="1331212799747679585">Kan ikke oppdatere Chrome. Flere alternativer</translation>
-<translation id="1332501820983677155">Hurtigtaster for funksjoner i Google Chrome.</translation>
-<translation id="1360432990279830238">Vil du logge av og slå av synkronisering?</translation>
-<translation id="1369915414381695676">Nettstedet <ph name="SITE_NAME" /> er lagt til</translation>
-<translation id="1373696734384179344">Det er ikke nok ledig minne til å laste ned det valgte innholdet.</translation>
-<translation id="1376578503827013741">Beregner …</translation>
-<translation id="1383876407941801731">Søk</translation>
-<translation id="1384959399684842514">Nedlastingen er satt på pause</translation>
-<translation id="1386674309198842382">Aktiv for <ph name="LAST_UPDATED" /> dager siden</translation>
-<translation id="1397811292916898096">Søk med <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Innbygd i <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">«Ingen sporing»</translation>
-<translation id="1407135791313364759">Åpne alle</translation>
-<translation id="1409426117486808224">Forenklet visning for åpne faner</translation>
-<translation id="1409879593029778104">Nedlastingen av <ph name="FILE_NAME" /> ble avbrutt fordi filen finnes allerede.</translation>
-<translation id="1414981605391750300">Kontakter Google. Dette kan ta en liten stund.</translation>
-<translation id="1416550906796893042">Programversjon</translation>
-<translation id="1430915738399379752">Skriv ut</translation>
-<translation id="1446450296470737166">Full kontroll over MIDI-enheter</translation>
-<translation id="1450753235335490080">Kan ikke dele <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Slått av i Android-innstillingene</translation>
-<translation id="1477626028522505441">Nedlastingen av <ph name="FILE_NAME" /> ble avbrutt på grunn av tjenerproblemer.</translation>
-<translation id="1506061864768559482">Søkemotor</translation>
-<translation id="1513352483775369820">Bokmerker og nettlogg</translation>
-<translation id="1513858653616922153">Slett passordet</translation>
-<translation id="1516229014686355813">«Trykk for å søke» sender det valgte ordet og den aktive siden som kontekst til Google Søk. Du kan slå av dette i <ph name="BEGIN_LINK" />Innstillinger<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktiv i dag</translation>
-<translation id="1544826120773021464">For å administrere Google-kontoen din, trykk på «Administrer kontoen»-knappen</translation>
-<translation id="1549000191223877751">Flytt til det andre vinduet</translation>
-<translation id="1553358976309200471">Oppdater Chrome</translation>
-<translation id="1569387923882100876">Tilkoblet enhet</translation>
-<translation id="1571304935088121812">Kopiér brukernavnet</translation>
-<translation id="1612196535745283361">Chrome trenger posisjonstilgang for å søke etter enheter. Posisjonstilgang er <ph name="BEGIN_LINK" />slått av for denne enheten<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Hindre denne siden i å opprette flere dialogruter</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Fjern 1 valgt element}other{Fjern # valgte elementer}}</translation>
-<translation id="164269334534774161">Du ser en lokal kopi av denne siden fra <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Logg</translation>
-<translation id="1647391597548383849">Tilgang til kameraet ditt</translation>
-<translation id="1660204651932907780">Tillat nettsteder å spille av lyd (anbefalt)</translation>
-<translation id="1670399744444387456">Enkle</translation>
-<translation id="1671236975893690980">Nedlasting venter</translation>
-<translation id="1672586136351118594">Ikke vis igjen</translation>
-<translation id="1692118695553449118">Synkronisering er slått på.</translation>
-<translation id="169515064810179024">Blokkér nettsteder fra å få tilgang til bevegelsessensorer</translation>
-<translation id="1717218214683051432">Bevegelsessensorer</translation>
-<translation id="1718835860248848330">Siste time</translation>
-<translation id="1736419249208073774">Utforsk</translation>
-<translation id="1743802530341753419">Spør før nettsteder kan koble til en enhet (anbefales)</translation>
-<translation id="1749561566933687563">Synkroniser bokmerkene dine</translation>
-<translation id="17513872634828108">Åpne faner</translation>
-<translation id="1779089405699405702">Bildedekoder</translation>
-<translation id="1782483593938241562">Sluttdato <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installert</translation>
-<translation id="1792959175193046959">Endre standard nedlastingssted når som helst</translation>
-<translation id="1807246157184219062">Lys</translation>
-<translation id="1810845389119482123">Det innledende synkroniseringsoppsettet er ikke fullført</translation>
-<translation id="1821253160463689938">Bruker informasjonskapsler til å huske preferansene dine, selv om du ikke går til de sidene</translation>
-<translation id="1829244130665387512">Finn på side</translation>
-<translation id="1853692000353488670">Ny inkognitofane</translation>
-<translation id="1856325424225101786">Vil du tilbakestille forenklet modus?</translation>
-<translation id="1868024384445905608">Chrome laster ned filer raskere nå</translation>
-<translation id="1883903952484604915">Mine filer</translation>
-<translation id="1887786770086287077">Posisjonstilgang er slått av for denne enheten. Slå den på i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> åpnes i Chrome. Ved å fortsette godtar du <ph name="BEGIN_LINK1" />vilkårene for bruk<ph name="END_LINK1" /> av Chrome og <ph name="BEGIN_LINK2" />merknaden om personvern<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Annonser</translation>
-<translation id="1919950603503897840">Velg kontakter</translation>
-<translation id="1922076542920281912">For å gi Chrome tilgang til posisjonen din må du også slå på posisjon i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Oppdateringer</translation>
-<translation id="19288952978244135">Åpne Chrome på nytt.</translation>
-<translation id="1933845786846280168">Valgt fane</translation>
-<translation id="194341124344773587">Slå på tillatelsen for Chrome i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Lagring av passord</translation>
-<translation id="1952172573699511566">Nettsteder viser tekst på språket du foretrekker, der dette er mulig.</translation>
-<translation id="1960290143419248813">Denne Android-versjonen støtter ikke lenger Chrome-oppdateringer</translation>
-<translation id="1966710179511230534">Oppdater påloggingsinformasjonen din.</translation>
-<translation id="1974060860693918893">Avansert</translation>
-<translation id="1984705450038014246">Synkroniser Chrome-dataene dine</translation>
-<translation id="1984937141057606926">Tillatt – unntatt fra tredjeparter.</translation>
-<translation id="1986685561493779662">Navnet finnes allerede</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" />-knapp</translation>
-<translation id="1989112275319619282">Bla gjennom</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> vil koble til</translation>
-<translation id="1994173015038366702">Nettadressen til nettstedet</translation>
-<translation id="2000419248597011803">Sender noen informasjonskapsler og søk fra adressefeltet og søkefeltet samt noen informasjonskapsler til standardsøkemotoren din</translation>
-<translation id="2002537628803770967">Kredittkort og adresser ved bruk av Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fil}other{# filer}}</translation>
-<translation id="2017836877785168846">Tømmer loggen og fjerner automatiske fullføringer fra adressefeltet.</translation>
-<translation id="2021896219286479412">Navigering i full skjerm</translation>
-<translation id="2038563949887743358">Slå på Bruk skrivebordsversjon</translation>
-<translation id="2041019821020695769">For at Chrome skal kunne sende deg varsler, må du også slå på varsler i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> har også data i Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Nettstedet er satt på pause</translation>
-<translation id="2063713494490388661">Trykk for å søke</translation>
-<translation id="2067805253194386918">tekst</translation>
-<translation id="2079545284768500474">Angre</translation>
-<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER" /> av <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Lyd</translation>
-<translation id="2096012225669085171">Synkronisering og personlig tilpasning på alle enheter</translation>
-<translation id="2100273922101894616">Automatisk pålogging</translation>
-<translation id="2100314319871056947">Prøv å dele teksten i mindre deler</translation>
-<translation id="2107397443965016585">Spør før nettsteder får tillatelse til å spille beskyttet innhold (anbefalt)</translation>
-<translation id="2111511281910874386">Gå til side</translation>
-<translation id="2122601567107267586">Kunne ikke åpne appen</translation>
-<translation id="2126426811489709554">Drevet av Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> spart</translation>
-<translation id="213279576345780926">Lukket <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Legg til på startsiden</translation>
-<translation id="2146738493024040262">Åpne instant-appen</translation>
-<translation id="2148716181193084225">I dag</translation>
-<translation id="2154484045852737596">Endre kortet</translation>
-<translation id="2154710561487035718">Kopier nettadresse</translation>
-<translation id="2156074688469523661">Andre nettsteder (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">For å dele noe på telefonen med en annen enhet, slå på synkronisering i Chrome-innstillingene på begge enhetene</translation>
-<translation id="2170088579611075216">Tillat og start VR</translation>
-<translation id="218608176142494674">Deling</translation>
-<translation id="2227444325776770048">Fortsett som <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synkronisering/Google-tjenester</translation>
-<translation id="2259659629660284697">Eksportér passord</translation>
-<translation id="2268044343513325586">Finstem</translation>
-<translation id="2286841657746966508">Faktureringsadresse</translation>
-<translation id="2289270750774289114">Spør når nettsteder vil oppdage Bluetooth-enheter i nærheten (anbefales)</translation>
-<translation id="230115972905494466">Fant ingen kompatible enheter</translation>
-<translation id="2315043854645842844">Operativsystemet har ikke støtte for sertifikatvalg på klientsiden.</translation>
-<translation id="2318045970523081853">Trykk for å ringe</translation>
-<translation id="2321086116217818302">Klargjør passordene …</translation>
-<translation id="2321958826496381788">Dra glidebryteren til du kan lese dette uten problemer. Når du har dobbelttrykket på et avsnitt, bør teksten være minst like stor som dette.</translation>
-<translation id="2323763861024343754">Nettstedslagring</translation>
-<translation id="2328985652426384049">Kan ikke logge på</translation>
-<translation id="2330129964253841015">Advar deg hvis passord utsettes for sikkerhetsbrudd</translation>
-<translation id="2349710944427398404">Total datamengde som brukes av Chrome, deriblant kontoer, bokmerker og lagrede innstillinger</translation>
-<translation id="2353636109065292463">Sjekker internettilkoblingen din</translation>
-<translation id="2359808026110333948">Fortsett</translation>
-<translation id="2369533728426058518">åpne faner</translation>
-<translation id="2387895666653383613">Tekstskalering</translation>
-<translation id="2394602618534698961">Filer du laster ned, vises her</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Når du logger på Google-kontoen din, blir denne funksjonen slått på</translation>
-<translation id="2410754283952462441">Velg en konto</translation>
-<translation id="2414886740292270097">Mørk</translation>
-<translation id="2416359993254398973">Chrome trenger tilgang til kameraet ditt for dette nettstedet.</translation>
-<translation id="2426805022920575512">Velg en annen konto</translation>
-<translation id="2433507940547922241">Utseende</translation>
-<translation id="2434158240863470628">Nedlasting fullført <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Posisjonstilgang</translation>
-<translation id="2450083983707403292">Vil du laste ned <ph name="FILE_NAME" /> på nytt?</translation>
-<translation id="2482878487686419369">Varsler</translation>
-<translation id="2490684707762498678">Administreres av <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google-assistenten i Chrome</translation>
-<translation id="2496180316473517155">Nettleserlogg</translation>
-<translation id="2497852260688568942">Administratoren din har slått av synkronisering</translation>
-<translation id="2498359688066513246">Hjelp og tilbakemelding</translation>
-<translation id="2501278716633472235">Gå tilbake</translation>
-<translation id="2513403576141822879">Se <ph name="BEGIN_LINK" />Synkronisering og Google tjenester<ph name="END_LINK" /> for flere innstillinger knyttet til personvern, sikkerhet og datainnsamling.</translation>
-<translation id="2518590038762162553">I forenklet modus laster Chrome inn sider raskere og bruker opptil 60 prosent mindre data. For å optimalisere sidene du besøker, sender Chrome nettrafikken din til Google. <ph name="BEGIN_LINK" />Finn ut mer<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Sender Google nettadressene til sider du besøker</translation>
-<translation id="2532336938189706096">Nettvisning</translation>
-<translation id="2534155362429831547">Slettet <ph name="NUMBER_OF_ITEMS" /> elementer</translation>
-<translation id="2536728043171574184">Ser på en lokalt lagret versjon av denne siden</translation>
-<translation id="2546283357679194313">Informasjonskapsler og data fra nettsteder</translation>
-<translation id="2567385386134582609">BILDE</translation>
-<translation id="257088987046510401">Temaer</translation>
-<translation id="2570922361219980984">Posisjonstilgang er også slått av for denne enheten. Slå den på i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Utvidet – klikk for å minimere.</translation>
-<translation id="2581165646603367611">Dette sletter informasjonskapsler, buffere og annen data fra nettsteder Chrome ikke tror er viktige.</translation>
-<translation id="2586657967955657006">Utklippstavle</translation>
-<translation id="2587052924345400782">En nyere versjon er tilgjengelig</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Kortnummer</translation>
-<translation id="2621115761605608342">Tillat JavaScript for et bestemt nettsted.</translation>
-<translation id="2625189173221582860">Passordet er kopiert</translation>
-<translation id="2631006050119455616">Spart</translation>
-<translation id="2647434099613338025">Legg til språk</translation>
-<translation id="2650751991977523696">Vil du laste ned filen på nytt?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# lydfil}other{# lydfiler}}</translation>
-<translation id="2653659639078652383">Send</translation>
-<translation id="2677748264148917807">Gå ut</translation>
-<translation id="2704606927547763573">Kopiert</translation>
-<translation id="2707726405694321444">Last inn siden på nytt</translation>
-<translation id="2709516037105925701">Autofyll</translation>
-<translation id="2717722538473713889">E-postadresser</translation>
-<translation id="2728754400939377704">Sortér etter nettsted</translation>
-<translation id="2744248271121720757">Trykk på et ord for å søke umiddelbart eller se relaterte handlinger</translation>
-<translation id="2760989362628427051">Slå på mørkt tema når batterisparing eller enhetsinnstillingen for mørkt tema er på</translation>
-<translation id="2762000892062317888">akkurat nå</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> sekunder igjen</translation>
-<translation id="2779651927720337254">mislyktes</translation>
-<translation id="2781151931089541271">1 sekund igjen</translation>
-<translation id="2801022321632964776">Oppdater for å få språket ditt i den nyeste versjonen av Chrome</translation>
-<translation id="2810645512293415242">Siden er forenklet for å spare data og laste den inn raskere.</translation>
-<translation id="281504910091592009">Se og administrer lagrede passord i <ph name="BEGIN_LINK" />Google-kontoen<ph name="END_LINK" /> din</translation>
-<translation id="2818669890320396765">For å få bokmerkene dine på alle enhetene dine, logg på og slå på synkronisering</translation>
-<translation id="2822354292072154809">Er du sikker på at du vil tilbakestille alle nettstedstillatelser for <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Trykk på tilbakeknappen for å avslutte fullskjerm.</translation>
-<translation id="2842985007712546952">Overordnet mappe</translation>
-<translation id="2858138569776157458">Populært</translation>
-<translation id="2860954141821109167">Kontrollér at en telefon-app er påslått på denne enheten</translation>
-<translation id="2870560284913253234">Nettsted</translation>
-<translation id="2874939134665556319">Forrige spor</translation>
-<translation id="2876369937070532032">Sender Google nettadressene til noen av sidene du besøker, når sikkerheten din står i fare</translation>
-<translation id="2888126860611144412">Om Chrome</translation>
-<translation id="2891154217021530873">Stopp innlastingen av siden</translation>
-<translation id="2893180576842394309">Google kan bruke loggen din for å gi Søk og andre Google-tjenester et personlig preg</translation>
-<translation id="2898264748040935573">Endre det lagrede passordet</translation>
-<translation id="2900528713135656174">Opprett hendelse</translation>
-<translation id="290376772003165898">Er ikke siden på <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Listen over enheter du kan dele faner med, er åpnet i full høyde.</translation>
-<translation id="2910701580606108292">Spør før nettsteder kan spille av beskyttet innhold</translation>
-<translation id="2913331724188855103">Tillat at nettsteder lagrer og leser data i informasjonskapsler (anbefales).</translation>
-<translation id="2923908459366352541">Navnet er ugyldig</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" />-lagring</translation>
-<translation id="2942036813789421260">Fanen for forhåndsvisning er lukket</translation>
-<translation id="2956410042958133412">Denne kontoen er administrert av <ph name="PARENT_NAME_1" /> og <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Byttet til inkognitofaner</translation>
-<translation id="2968755619301702150">Visningsprogram for sertifikater</translation>
-<translation id="2979025552038692506">Valgt inkognitofane</translation>
-<translation id="2987620471460279764">En annen enhet har delt tekst</translation>
-<translation id="2989523299700148168">Nylig besøkte</translation>
-<translation id="2996291259634659425">Opprett en passordfrase</translation>
-<translation id="2996809686854298943">Nettadresse kreves</translation>
-<translation id="300526633675317032">Dette sletter alle dataene (<ph name="SIZE_IN_KB" />) fra nettstedslagringen.</translation>
-<translation id="3016635187733453316">Kontrollér at enheten er koblet til internett</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> kB er lastet ned</translation>
-<translation id="3029704984691124060">Passordfrasene stemmer ikke overens</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Få hjelp<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Posisjon er slått av. Slå den på i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Du kan når som helst slå på synkronisering i innstillingene</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> bokmerke}other{<ph name="BOOKMARKS_COUNT_MANY" /> bokmerker}}</translation>
-<translation id="3089395242580810162">Åpne i inkognitofane</translation>
-<translation id="3115898365077584848">Vis informasjon</translation>
-<translation id="3123473560110926937">Blokkert på enkelte nettsteder</translation>
-<translation id="3137521801621304719">Avslutt inkognitomodus</translation>
-<translation id="3143515551205905069">Avbryt synkronisering</translation>
-<translation id="3157842584138209013">Se hvor mye data du har spart, via Flere alternativer-knappen</translation>
-<translation id="3166827708714933426">Hurtigtaster for vinduer og faner</translation>
-<translation id="3181954750937456830">Safe Browsing (beskytter deg og enheten din mot farlige nettsteder)</translation>
-<translation id="3190152372525844641">Slå på tillatelsene for Chrome i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> lagrede data</translation>
-<translation id="3205824638308738187">Nesten ferdig!</translation>
-<translation id="3207960819495026254">Bokmerket</translation>
-<translation id="3211426585530211793">Slettet <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Hvis du har glemt passordfrasen din eller vil endre denne innstillingen, må du <ph name="BEGIN_LINK" />tilbakestille synkroniseringen<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Nettprogram</translation>
-<translation id="3236059992281584593">1 minutt igjen</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Legg til bokmerke for denne siden</translation>
-<translation id="3259831549858767975">Gjør alt på siden mindre</translation>
-<translation id="3269093882174072735">Last inn bildet</translation>
-<translation id="3269956123044984603">For å få fanene dine fra de andre enhetene du bruker, slå på «Synkroniser data automatisk» i kontoinnstillingene for Android.</translation>
-<translation id="3277252321222022663">Gi nettsteder tilgang til sensorer (anbefalt)</translation>
-<translation id="3282568296779691940">Logg på Chrome</translation>
-<translation id="3288003805934695103">Last inn siden på nytt</translation>
-<translation id="32895400574683172">Varsler er tillatt</translation>
-<translation id="3295530008794733555">Surf raskere. Bruk mindre data.</translation>
-<translation id="3295602654194328831">Skjul informasjonen</translation>
-<translation id="3298243779924642547">Forenklet</translation>
-<translation id="3303414029551471755">Vil du gå videre med å laste ned innholdet?</translation>
-<translation id="3306398118552023113">Denne appen kjører i Chrome</translation>
-<translation id="3315103659806849044">Du holder på å tilpasse innstillingene for Synkronisering og Google-tjenester. For å gjøre deg ferdig med å slå på synkronisering, trykk på Bekreft-knappen nederst på skjermen. Gå opp</translation>
-<translation id="3328801116991980348">Informasjon om nettstedet</translation>
-<translation id="3333961966071413176">Alle kontakter</translation>
-<translation id="3334729583274622784">Vil du endre filetternavnet?</translation>
-<translation id="3341058695485821946">Se hvor mye data du har spart</translation>
-<translation id="3350687908700087792">Lukk alle inkognitofaner</translation>
-<translation id="3353615205017136254">Forenklet versjon av siden levert av Google. Trykk på knappen for å laste inn den opprinnelige siden.</translation>
-<translation id="3367813778245106622">Logg på igjen for å starte synkroniseringen</translation>
-<translation id="3374023511497244703">Bokmerker, logg, passord og andre Chrome-data synkroniseres ikke lenger med Google-kontoen din.</translation>
-<translation id="3384347053049321195">Del bildet</translation>
-<translation id="3386292677130313581">Spør før nettsteder får vite posisjonen min (anbefales)</translation>
-<translation id="3387650086002190359">Nedlastingen av <ph name="FILE_NAME" /> ble avbrutt på grunn av filsystemfeil.</translation>
-<translation id="3389286852084373014">Teksten er for stor</translation>
-<translation id="3398320232533725830">Åpne bokmerkebehandlingen</translation>
-<translation id="3414952576877147120">Størrelse:</translation>
-<translation id="3443221991560634068">Last inn den aktive siden på nytt</translation>
-<translation id="3445014427084483498">Nå nettopp</translation>
-<translation id="3478363558367712427">Du kan velge søkemotor</translation>
+<translation id="6910211073230771657">Slettet</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Greit</translation>
+<translation id="7658239707568436148">Avbryt</translation>
 <translation id="3479552764303398839">Ikke nå</translation>
-<translation id="3492207499832628349">Ny inkognitofane</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Finn ut mer<ph name="END_LINK" /> om foreslått innhold</translation>
-<translation id="3513704683820682405">Utvidet virkelighet</translation>
-<translation id="3518985090088779359">Godta og fortsett</translation>
-<translation id="3522247891732774234">En oppdatering er tilgjengelig. Flere alternativer</translation>
-<translation id="3524138585025253783">Utvikler-UI</translation>
-<translation id="3527085408025491307">Mappe</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> kB er tilgjengelig</translation>
-<translation id="3549657413697417275">Søk i loggen</translation>
-<translation id="3557336313807607643">Legg til i kontakter</translation>
-<translation id="3566923219790363270">Chrome klargjør fremdeles for VR. Start Chrome på nytt senere.</translation>
-<translation id="3568688522516854065">For å få fanene dine fra de andre enhetene du bruker, logg på og slå på synkronisering.</translation>
-<translation id="3587482841069643663">Alle</translation>
-<translation id="358794129225322306">Tillat at et nettsted kan laste ned flere filer automatisk.</translation>
-<translation id="3590487821116122040">Nettstedslagring Chrome ikke tror er viktig (for eksempel områder uten lagrede innstillinger eller som du ikke besøker ofte)</translation>
-<translation id="3599863153486145794">Tømmer loggen på alle påloggede enheter. Det kan hende Google-kontoen din har andre typer nettleserlogger på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Kutt lyden for nettsteder som spiller av lyd</translation>
-<translation id="3616113530831147358">Lyd</translation>
-<translation id="3631987586758005671">Deler med <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Vis passordet</translation>
-<translation id="363596933471559332">Du logges på nettsteder automatisk ved hjelp av lagret legitimasjon. Når funksjonen er slått av, blir du bedt om å oppgi legitimasjonen din hver gang du logger på et nettsted.</translation>
-<translation id="3658159451045945436">Tilbakestilling fjerner historikken for datasparing, inkludert listen over besøkte nettsteder.</translation>
-<translation id="3692944402865947621">Nedlastingen av <ph name="FILE_NAME" /> ble avbrutt fordi lagringsstedet ikke kan nås.</translation>
-<translation id="3714981814255182093">Åpne søkeraden</translation>
-<translation id="3716182511346448902">Denne siden bruker for mye minne, så Chrome har satt den på pause.</translation>
-<translation id="3730075448226062617">For å gi Chrome tilgang til mikrofonen må du også slå på mikrofonen i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Satt som bokmerke i <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Bakgrunnssynkronisering</translation>
-<translation id="3771001275138982843">Kunne ikke laste ned oppdateringen</translation>
-<translation id="3771033907050503522">Inkognitofaner</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Slå på Bluetooth<ph name="END_LINK" /> for å tillate tilkobling</translation>
-<translation id="3775705724665058594">Send til enhetene dine</translation>
-<translation id="3778956594442850293">Lagt til på startskjermen</translation>
-<translation id="3789841737615482174">Installer</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Administrer</translation>
-<translation id="381841723434055211">Telefonnumre</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> nedlastinger er slettet</translation>
-<translation id="3822502789641063741">Slette nettstedslagring?</translation>
-<translation id="385051799172605136">Tilbake</translation>
-<translation id="3859306556332390985">Spol fremover</translation>
-<translation id="3894427358181296146">Legg til en mappe</translation>
-<translation id="3895926599014793903">Tving zoom på</translation>
-<translation id="3912508018559818924">Vi finner det beste fra nettet …</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Kombiner dataene mine</translation>
-<translation id="393697183122708255">Ingen aktiverte talesøk er tilgjengelige</translation>
-<translation id="395206256282351086">Nettsteds- og søkeforslag er slått av</translation>
-<translation id="3955193568934677022">Gi nettsteder tillatelse til å spille av beskyttet innhold (anbefales)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome laster inn siden når den er klar}other{Chrome laster inn sidene når de er klare}}</translation>
-<translation id="3963007978381181125">Kryptering av passordfraser inkluderer ikke betalingsmåter og adresser fra Google Pay. Bare personer som har passordfrasen din, kan lese de krypterte dataene dine. Passordfrasen blir verken sendt til Google eller lagret. Hvis du glemmer den, må du tilbakestille synkroniseringen. <ph name="BEGIN_LINK" />Finn ut mer<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Nedlasting fullført</translation>
-<translation id="397583555483684758">Synkroniseringen har sluttet å fungere</translation>
-<translation id="3976396876660209797">Fjern denne snarveien, og opprett den på nytt</translation>
-<translation id="3985215325736559418">Vil du laste ned <ph name="FILE_NAME" /> igjen?</translation>
-<translation id="3987993985790029246">Kopiér link</translation>
-<translation id="3988213473815854515">Posisjon er tillatt</translation>
-<translation id="3988466920954086464">Se umiddelbare søkeresultater i dette panelet</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Uviktig lagring</translation>
-<translation id="4000212216660919741">Hjem uten nett</translation>
+<translation id="5317780077021120954">Lagre</translation>
+<translation id="4570913071927164677">Detaljer</translation>
+<translation id="8730621377337864115">Ferdig</translation>
+<translation id="8261506727792406068">Slett</translation>
+<translation id="1181037720776840403">Fjern</translation>
+<translation id="5939518447894949180">Tilbakestill</translation>
 <translation id="4002066346123236978">Tittel</translation>
-<translation id="4008040567710660924">Tillat informasjonskapsler for et spesifikt nettsted.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# t}other{# t}}</translation>
-<translation id="4046123991198612571">Neste spor</translation>
-<translation id="4048707525896921369">Finn ut om emner på nettsteder uten å forlate siden. «Trykk for å søke» sender et ord og omkringliggende kontekst til Google Søk, slik at definisjoner, bilder, søkeresultater og annen informasjon returneres.
+<translation id="5916664084637901428">På</translation>
+<translation id="5860033963881614850">Av</translation>
+<translation id="6165508094623778733">Finn ut mer</translation>
+<translation id="6042308850641462728">Mer</translation>
+<translation id="6040143037577758943">Lukk</translation>
+<translation id="780301667611848630">Nei takk</translation>
+<translation id="1201402288615127009">Neste</translation>
+<translation id="2359808026110333948">Fortsett</translation>
+<translation id="2653659639078652383">Send</translation>
+<translation id="2079545284768500474">Angre</translation>
+<translation id="7649070708921625228">Hjelp</translation>
+<translation id="2148716181193084225">I dag</translation>
+<translation id="7781829728241885113">I går</translation>
+<translation id="6945221475159498467">Velg</translation>
+<translation id="7791543448312431591">Legg til</translation>
+<translation id="6527303717912515753">Del</translation>
+<translation id="1383876407941801731">Søk</translation>
+<translation id="3115898365077584848">Vis informasjon</translation>
+<translation id="3295602654194328831">Skjul informasjonen</translation>
+<translation id="3987993985790029246">Kopiér link</translation>
+<translation id="2704606927547763573">Kopiert</translation>
+<translation id="8725066075913043281">Prøv igjen</translation>
+<translation id="385051799172605136">Tilbake</translation>
+<translation id="8131740175452115882">Bekreft</translation>
+<translation id="5300589172476337783">Vis</translation>
+<translation id="1124772482545689468">Bruker</translation>
+<translation id="8609465669617005112">Flytt opp</translation>
+<translation id="6746124502594467657">Flytt ned</translation>
+<translation id="8249310407154411074">Flytt til toppen</translation>
+<translation id="8428213095426709021">Innstillinger</translation>
+<translation id="2498359688066513246">Hjelp og tilbakemelding</translation>
+<translation id="8378714024927312812">Administreres av organisasjonen din</translation>
+<translation id="9019902583201351841">Administrert av foreldrene dine</translation>
+<translation id="4645575059429386691">Administreres av foreldrene dine</translation>
+<translation id="4883854917563148705">Administrerte innstillinger kan ikke tilbakestilles</translation>
+<translation id="4307992518367153382">Generelt</translation>
+<translation id="1974060860693918893">Avansert</translation>
+<translation id="1146678959555564648">Slå på VR-modus</translation>
+<translation id="987264212798334818">Generelt</translation>
+<translation id="4275663329226226506">Medier</translation>
+<translation id="4759238208242260848">Nedlastinger</translation>
+<translation id="218608176142494674">Deling</translation>
+<translation id="8004582292198964060">Nettleser</translation>
+<translation id="1105960400813249514">Skjermdump</translation>
+<translation id="4875775213178255010">Innholdsforslag</translation>
+<translation id="2021896219286479412">Navigering i full skjerm</translation>
+<translation id="4587589328781138893">Nettsteder</translation>
+<translation id="4943703118917034429">Virtuell virkelighet</translation>
+<translation id="1928696683969751773">Oppdateringer</translation>
+<translation id="6064125863973209585">Fullførte nedlastinger</translation>
+<translation id="5342314432463739672">Tillatelsesforespørsler</translation>
+<translation id="629730747756840877">Konto</translation>
+<translation id="82609232232243542">Logg på Brave</translation>
+<translation id="7956662517480676674">Synkronisering/Brave Software-tjenester</translation>
+<translation id="5294439808117722387">Du holder på å tilpasse innstillingene for Synkronisering og Brave Software-tjenester. For å gjøre deg ferdig med å slå på synkronisering, trykk på Bekreft-knappen nederst på skjermen. Gå opp</translation>
+<translation id="2096012225669085171">Synkronisering og personlig tilpasning på alle enheter</translation>
+<translation id="1692118695553449118">Synkronisering er slått på.</translation>
+<translation id="5514904542973294328">Deaktivert av administratoren for denne enheten</translation>
+<translation id="6447211988989208781">Brave Software Aktivitetslagring</translation>
+<translation id="4882831918239250449">Kontrollér hvordan nettleserloggen din brukes til personlig tilpasning av søk, annonser med mer</translation>
+<translation id="7431991332293347422">Kontrollér hvordan nettleserloggen din brukes til blant annet personlig tilpasning av søk</translation>
+<translation id="6303969859164067831">Logg av og slå av synkronisering</translation>
+<translation id="1125261911132334651">Administrer Brave Software-kontoen din</translation>
+<translation id="6406506848690869874">Synkroniser</translation>
+<translation id="714362445477979774">Synkroniser Brave-dataene dine</translation>
+<translation id="4314815835985389558">Administrer synkronisering</translation>
+<translation id="5428209950370661546">Andre Brave Software-tjenester</translation>
+<translation id="7704317875155739195">Autofullfør søk og nettadresser</translation>
+<translation id="2000419248597011803">Sender noen informasjonskapsler og søk fra adressefeltet og søkefeltet samt noen informasjonskapsler til standardsøkemotoren din</translation>
+<translation id="7981313251711023384">Last inn sider på forhånd for raskere nettlesing og søk</translation>
+<translation id="1821253160463689938">Bruker informasjonskapsler til å huske preferansene dine, selv om du ikke går til de sidene</translation>
+<translation id="6697492270171225480">Viser forslag for lignende sider når en side ikke kan finnes</translation>
+<translation id="8109318360573330108">Sender Brave Software nettadressen til siden du prøver å åpne</translation>
+<translation id="8438566539970814960">Gjør søking og surfing bedre</translation>
+<translation id="284843628681142937">Sender Brave Software nettadressene til sider du besøker</translation>
+<translation id="7222718784508482526">Se <ph name="BEGIN_LINK"/>Synkronisering og Brave Software tjenester<ph name="END_LINK"/> for flere innstillinger knyttet til personvern, sikkerhet og datainnsamling.</translation>
+<translation id="918192811481327695">Hjelp til med å forbedre funksjonene og ytelsen til Brave</translation>
+<translation id="9063160602596686558">Sender automatisk brukerstatistikk og programstopprapporter til Brave Software</translation>
+<translation id="4824958205181053313">Vil du avbryte synkroniseringen?</translation>
+<translation id="3058498974290601450">Du kan når som helst slå på synkronisering i innstillingene</translation>
+<translation id="3143515551205905069">Avbryt synkronisering</translation>
+<translation id="1506061864768559482">Søkemotor</translation>
+<translation id="55737423895878184">Posisjon og varsler er tillatt</translation>
+<translation id="3988213473815854515">Posisjon er tillatt</translation>
+<translation id="32895400574683172">Varsler er tillatt</translation>
+<translation id="9040142327097499898">Varsler er tillatt. Posisjon er slått av for denne enheten.</translation>
+<translation id="305593374596241526">Posisjon er slått av. Slå den på i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Nylig besøkte</translation>
+<translation id="6433501201775827830">Velg søkemotor</translation>
+<translation id="7177466738963138057">Du kan endre dette senere i Innstillinger</translation>
+<translation id="3478363558367712427">Du kan velge søkemotor</translation>
+<translation id="4910889077668685004">Betalingsapper</translation>
+<translation id="5152843274749979095">Ingen støttede apper er installert</translation>
+<translation id="8812260976093120287">På noen nettsteder kan du betale med de støttede betalingsappene ovenfor på enheten din.</translation>
+<translation id="7764225426217299476">Legg til adresse</translation>
+<translation id="5595485650161345191">Rediger adresse</translation>
+<translation id="5087580092889165836">Legg til et kort</translation>
+<translation id="2154484045852737596">Endre kortet</translation>
+<translation id="6140912465461743537">Land/område</translation>
+<translation id="5659593005791499971">E-post</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Navn som er oppført på kortet</translation>
+<translation id="860043288473659153">Kortinnehavers navn</translation>
+<translation id="2612676031748830579">Kortnummer</translation>
+<translation id="869891660844655955">Utløpsdato</translation>
+<translation id="2286841657746966508">Faktureringsadresse</translation>
+<translation id="663059986967017181">Kopiert til Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> til}other{<ph name="PAYMENT_METHOD_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> til}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> til}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> til}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> til}other{<ph name="SHIPPING_OPTION_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> til}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> til}other{<ph name="CONTACT_PREVIEW"/> og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> til}}</translation>
+<translation id="7029809446516969842">Passord</translation>
+<translation id="1943432128510653496">Lagring av passord</translation>
+<translation id="2100273922101894616">Automatisk pålogging</translation>
+<translation id="363596933471559332">Du logges på nettsteder automatisk ved hjelp av lagret legitimasjon. Når funksjonen er slått av, blir du bedt om å oppgi legitimasjonen din hver gang du logger på et nettsted.</translation>
+<translation id="6995899638241819463">Få en advarsel hvis passord blir avdekket i databrudd</translation>
+<translation id="1534287762301776620">Når du logger på Brave Software-kontoen din, blir denne funksjonen slått på</translation>
+<translation id="10614374240317010">Aldri lagret</translation>
+<translation id="3098842761938485917">Se og administrer lagrede passord i <ph name="BEGIN_LINK"/>Brave Software-kontoen<ph name="END_LINK"/> din</translation>
+<translation id="8562452229998620586">Lagrede passord listes opp her.</translation>
+<translation id="8084114998886531721">Lagret passord</translation>
+<translation id="2870560284913253234">Nettsted</translation>
+<translation id="8503813439785031346">Brukernavn</translation>
+<translation id="6657585470893396449">Passord</translation>
+<translation id="2154710561487035718">Kopier nettadresse</translation>
+<translation id="1571304935088121812">Kopiér brukernavnet</translation>
+<translation id="5005498671520578047">Kopiér passordet</translation>
+<translation id="3632295766818638029">Vis passordet</translation>
+<translation id="1513858653616922153">Slett passordet</translation>
+<translation id="543338862236136125">Endre passordet</translation>
+<translation id="4565377596337484307">Skjul passord</translation>
+<translation id="8523928698583292556">Slett lagrede passord</translation>
+<translation id="2898264748040935573">Endre det lagrede passordet</translation>
+<translation id="5433691172869980887">Brukernavnet er kopiert</translation>
+<translation id="5534640966246046842">Nettstedet er kopiert</translation>
+<translation id="2625189173221582860">Passordet er kopiert</translation>
+<translation id="4550003330909367850">For å se eller kopiere passordet ditt her, angi skjermlås på denne enheten.</translation>
+<translation id="6154478581116148741">Slå på skjermlåsen i Innstillinger for å eksportere passordene dine fra denne enheten</translation>
+<translation id="4842092870884894799">Viser forgrunnsvinduet for passordgenerering</translation>
+<translation id="2259659629660284697">Eksportér passord</translation>
+<translation id="133012818630824069">Eksportér passord som er lagret med Brave</translation>
+<translation id="6914783257214138813">Passordene dine blir synlige for alle som kan se den eksporterte filen.</translation>
+<translation id="2321086116217818302">Klargjør passordene …</translation>
+<translation id="8445448999790540984">Kan ikke eksportere passordene</translation>
+<translation id="3066461326500799725">Finn ut hvordan du bruker Brave Software Disk</translation>
+<translation id="729975465115245577">Enheten din har ingen app som kan lagre passordfilen.</translation>
+<translation id="7682724950699840886">Prøv dette: Sørg for at det er nok plass på enheten, og prøv å eksportere på nytt.</translation>
+<translation id="1129510026454351943">Detaljer: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Lås opp for å kopiere passordet ditt</translation>
+<translation id="5515439363601853141">Lås opp for å se passordet ditt</translation>
+<translation id="6221633008163990886">Lås opp for å eksportere passordene dine</translation>
+<translation id="230699814587342492">Brave-passord</translation>
+<translation id="6075798973483050474">Endre startsiden</translation>
+<translation id="854522910157234410">Åpne denne siden</translation>
+<translation id="2482878487686419369">Varsler</translation>
+<translation id="6255999984061454636">Innholdsforslag</translation>
+<translation id="805047784848435650">Basert på nettlesingsloggen din</translation>
+<translation id="1041308826830691739">Fra nettsteder</translation>
+<translation id="395206256282351086">Nettsteds- og søkeforslag er slått av</translation>
+<translation id="257088987046510401">Temaer</translation>
+<translation id="4650364565596261010">Systemstandard</translation>
+<translation id="7588219262685291874">Slå på mørkt tema når batterisparing er på</translation>
+<translation id="2760989362628427051">Slå på mørkt tema når batterisparing eller enhetsinnstillingen for mørkt tema er på</translation>
+<translation id="6381421346744604172">Formørk nettsteder</translation>
+<translation id="5040262127954254034">Personvern</translation>
+<translation id="4991384657077828949">Bidra til å gjøre Brave sikrere</translation>
+<translation id="1943176487615318915">For å oppdage farlige apper og nettsteder sender Brave nettadressene til noen av sidene du besøker, begrenset systeminformasjon og noe sideinnhold til Brave Software.</translation>
+<translation id="3181954750937456830">Safe Browsing (beskytter deg og enheten din mot farlige nettsteder)</translation>
+<translation id="7315322926489145388">Sender Brave Software nettadressene til noen av sidene du besøker, når sikkerheten din står i fare</translation>
+<translation id="2063713494490388661">Trykk for å søke</translation>
+<translation id="2369463299479365221">Finn ut om emner på nettsteder uten å forlate siden. «Trykk for å søke» sender et ord og omkringliggende kontekst til Brave Software Søk, slik at definisjoner, bilder, søkeresultater og annen informasjon returneres.
 
 Hvis du vil endre søkeordet, kan du trykke og holde inne for å merke. Hvis du vil avgrense søket, drar du panelet hele veien opp og trykker på søkeboksen.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Du finner alternativene oppe på skjermen</translation>
-<translation id="4062305924942672200">Juridisk informasjon</translation>
-<translation id="4084682180776658562">Legg til bokmerke</translation>
-<translation id="4084712963632273211">Fra <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />levert av Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Slette appdataene?</translation>
-<translation id="4099578267706723511">Gjør Chrome bedre ved å sende bruksstatistikk og programstopprapporter til Google.</translation>
-<translation id="410351446219883937">Autoavspilling</translation>
-<translation id="4116038641877404294">Last ned sidene for å bruke dem uten nett</translation>
-<translation id="4135200667068010335">Listen over enheter du kan dele faner med, er lukket.</translation>
-<translation id="4149994727733219643">Forenklet visning av nettsider</translation>
-<translation id="4165986682804962316">Nettstedsinnstillinger</translation>
-<translation id="4169535189173047238">Ikke tillat</translation>
-<translation id="4170011742729630528">Tjenesten er ikke tilgjengelig. Prøv på nytt senere.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> brukt</translation>
-<translation id="4181841719683918333">Språk</translation>
-<translation id="4183868528246477015">Søk med Google Lens <ph name="BEGIN_NEW" />Nyhet<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Åpne i ny fane</translation>
-<translation id="4198423547019359126">Ingen tilgjengelige nedlastingssteder</translation>
-<translation id="4209895695669353772">For å få forslag om personlig tilpasset innhold fra Google, slå på synkronisering</translation>
-<translation id="4226663524361240545">Varsler kan gjøre at enheten vibrerer</translation>
-<translation id="423219824432660969">Kryptér synkroniserte data med Google-passord fra og med <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Åpne innstillingene</translation>
-<translation id="4256782883801055595">Lisenser for åpen kildekode</translation>
-<translation id="4259722352634471385">Nettadressen er blokkert: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopiér linkadressen</translation>
-<translation id="4275663329226226506">Medier</translation>
-<translation id="4278390842282768270">Tillatt</translation>
-<translation id="429312253194641664">Et nettsted spiller av medier</translation>
-<translation id="4298388696830689168">Tilknyttede nettsteder</translation>
-<translation id="4307992518367153382">Generelt</translation>
-<translation id="4314815835985389558">Administrer synkronisering</translation>
-<translation id="4351244548802238354">Lukk dialogboks</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Bruker Sogou til å søke</translation>
-<translation id="4404568932422911380">Ingen bokmerker</translation>
-<translation id="4405224443901389797">Flytt til …</translation>
-<translation id="4411535500181276704">Forenklet modus</translation>
-<translation id="4415276339145661267">Administrer Google-kontoen din</translation>
-<translation id="4432792777822557199">Fra nå av oversettes sider på <ph name="SOURCE_LANGUAGE" /> til <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Forenklet versjon av siden levert av Google</translation>
-<translation id="4434045419905280838">Forgrunnsvinduer/viderekoblinger</translation>
-<translation id="4440958355523780886">Forenklet versjon av siden levert av Google. Trykk for å laste inn den opprinnelige siden.</translation>
-<translation id="4452411734226507615">Lukk <ph name="TAB_TITLE" />-fanen</translation>
-<translation id="4452548195519783679">Satt som bokmerke i <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Tillat at nettsteder kan spille beskyttet innhold</translation>
-<translation id="4468959413250150279">Kutt lyden for et bestemt nettsted.</translation>
-<translation id="4472118726404937099">For å synkronisere og gi et personlig preg på alle enhetene, slå på synkronisering</translation>
-<translation id="447252321002412580">Hjelp til med å forbedre funksjonene og ytelsen til Chrome</translation>
-<translation id="4479647676395637221">Spør før nettsteder får bruke kameraet (anbefales)</translation>
-<translation id="4479972344484327217">Installerer <ph name="MODULE" /> for Chrome …</translation>
-<translation id="4487967297491345095">Alle appdataene for Chrome slettes permanent. Dette omfatter alle filer, innstillinger, kontoer, databaser osv.</translation>
-<translation id="4493497663118223949">Forenklet modus er på</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{for # dag siden}other{for # dager siden}}</translation>
-<translation id="451872707440238414">Søk i bokmerkene dine</translation>
-<translation id="4521489764227272523">De valgte dataene er er fjernet fra Chrome og de synkroniserte enhetene dine.
-
-Google-kontoen din kan ha andre former for nettleserlogger, for eksempel søk og aktivitet fra andre Google-tjenester, på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Velg en mappe</translation>
-<translation id="4538018662093857852">Slå på forenklet modus</translation>
-<translation id="4550003330909367850">For å se eller kopiere passordet ditt her, angi skjermlås på denne enheten.</translation>
-<translation id="4558311620361989323">Hurtigtaster for nettsider</translation>
-<translation id="4561979708150884304">Ingen tilkobling</translation>
-<translation id="4565377596337484307">Skjul passord</translation>
-<translation id="4570913071927164677">Detaljer</translation>
-<translation id="4572422548854449519">Logg på en administrert konto</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{for # minutt siden}other{for # minutter siden}}</translation>
-<translation id="4587589328781138893">Nettsteder</translation>
-<translation id="4594952190837476234">Denne siden uten nett er fra <ph name="CREATION_TIME" /> og kan avvike fra nettversjonen.</translation>
-<translation id="4605958867780575332">Elementet er fjernet: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Åpne <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Bruk passord</translation>
-<translation id="4645575059429386691">Administreres av foreldrene dine</translation>
-<translation id="4650364565596261010">Systemstandard</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> bokmerker ble slettet</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> ble lagt til på startskjermen</translation>
-<translation id="4684427112815847243">Synkroniser alt</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> til}other{<ph name="SHIPPING_OPTION_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> til}}</translation>
-<translation id="4696983787092045100">Send tekst til enhetene dine</translation>
-<translation id="4698034686595694889">Se uten nett i <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Bufrede bilder og filer</translation>
-<translation id="4714588616299687897">Reduser databruken med opptil 60 %</translation>
-<translation id="4719927025381752090">Tilby å oversette</translation>
-<translation id="4720023427747327413">Åpne i <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Hjelp til med å forbedre Chrome. <ph name="BEGIN_LINK" />Delta i undersøkelsen<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Oppdater</translation>
-<translation id="4738836084190194332">Sist synkronisert: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Åpne en ny fane</translation>
-<translation id="4751476147751820511">Bevegelses- eller lyssensorer</translation>
-<translation id="4759238208242260848">Nedlastinger</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 nedlasting er fullført.}other{# nedlastinger er fullført.}}</translation>
-<translation id="4797039098279997504">Trykk for å gå tilbake til <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Kryptering av passordfraser inkluderer ikke betalingsmåter og adresser fra Google Pay.
-
-For å endre denne innstillingen, <ph name="BEGIN_LINK" />tilbakestill synkroniseringen<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Navn som er oppført på kortet</translation>
-<translation id="4824958205181053313">Vil du avbryte synkroniseringen?</translation>
-<translation id="4837753911714442426">Åpne alternativene for å skrive ut siden</translation>
-<translation id="4842092870884894799">Viser forgrunnsvinduet for passordgenerering</translation>
-<translation id="4860895144060829044">Ring</translation>
-<translation id="4866368707455379617">Kan ikke installere <ph name="MODULE" /> for Chrome</translation>
-<translation id="4875775213178255010">Innholdsforslag</translation>
-<translation id="4878404682131129617">Kunne ikke opprette tunnel via proxy-tjener.</translation>
-<translation id="4880127995492972015">Oversett</translation>
-<translation id="4881695831933465202">Åpne</translation>
-<translation id="488187801263602086">Endre navnet på filen</translation>
-<translation id="4882831918239250449">Kontrollér hvordan nettleserloggen din brukes til personlig tilpasning av søk, annonser med mer</translation>
-<translation id="4883854917563148705">Administrerte innstillinger kan ikke tilbakestilles</translation>
-<translation id="4885273946141277891">For mange Chrome-forekomster.</translation>
-<translation id="4910889077668685004">Betalingsapper</translation>
-<translation id="4913161338056004800">Tilbakestill statistikken</translation>
-<translation id="4913169188695071480">Slutt å laste inn på nytt</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Få hjelp<ph name="END_LINK" /> mens du skanner etter enheter …</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# side}other{# sider}}</translation>
-<translation id="4932247056774066048">Fordi du logger av en konto som administreres av <ph name="DOMAIN_NAME" />, slettes Chrome-dataene dine fra denne enheten. De blir værende i Google-kontoen din.</translation>
-<translation id="4943703118917034429">Virtuell virkelighet</translation>
-<translation id="4943872375798546930">Ingen resultater</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> deler skjermen din</translation>
-<translation id="4961107849584082341">Oversett denne siden til hvilket som helst språk</translation>
-<translation id="4962975101802056554">Opphev alle tillatelser for enheten</translation>
-<translation id="4970824347203572753">Ikke tilgjengelig der du er</translation>
-<translation id="497421865427891073">Gå til neste</translation>
-<translation id="4988210275050210843">Laster ned fil (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Sider</translation>
-<translation id="4994033804516042629">Fant ingen kontakter</translation>
-<translation id="4996978546172906250">Del via</translation>
-<translation id="5004416275253351869">Google Aktivitetslagring</translation>
-<translation id="5005498671520578047">Kopiér passordet</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> vil koble til</translation>
-<translation id="5013696553129441713">Ingen nye forslag</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Når du er i VR, kan dette nettstedet finne ut mer om følgende:
-    – fysiske kjennetegn, som hvor høy du er
-
-    Forsikre deg om at du stoler på dette nettstedet før du går inn i VR.</translation>
+<translation id="2930742481329940825">«Trykk for å søke» sender det valgte ordet og den aktive siden som kontekst til Brave Software Søk. Du kan slå av dette i <ph name="BEGIN_LINK"/>Innstillinger<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Tillat</translation>
-<translation id="5040262127954254034">Personvern</translation>
-<translation id="5048398596102334565">Gi nettsteder tilgang til bevegelsessensorer (anbefalt)</translation>
-<translation id="5063480226653192405">Bruk</translation>
-<translation id="5087580092889165836">Legg til et kort</translation>
-<translation id="5100237604440890931">Minimert – klikk for å utvide</translation>
-<translation id="510275257476243843">1 time igjen</translation>
-<translation id="5123685120097942451">Inkognitofane</translation>
-<translation id="5127805178023152808">Synkronisering er slått av</translation>
-<translation id="5129038482087801250">Installer nettprogram</translation>
-<translation id="5132942445612118989">Synkroniser passordene dine, loggen din med mer på alle enheter</translation>
-<translation id="5139940364318403933">Finn ut hvordan du bruker Google Disk</translation>
-<translation id="515227803646670480">Sletting av alle lagrede data</translation>
-<translation id="5152843274749979095">Ingen støttede apper er installert</translation>
-<translation id="5161254044473106830">Du må oppgi en tittel</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 nedlasting mislyktes.}other{# nedlastinger mislyktes.}}</translation>
-<translation id="5170568018924773124">Vis i mappen</translation>
-<translation id="5184329579814168207">Åpne i Chrome</translation>
-<translation id="5193988420012215838">Kopiert til utklippstavlen</translation>
-<translation id="5197729504361054390">Kontaktene du velger, deles med <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Jobbprofil</translation>
-<translation id="5210286577605176222">Gå til den forrige fanen</translation>
-<translation id="5210365745912300556">Lukk fanen</translation>
-<translation id="5224771365102442243">Med video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> vil søke etter Bluetooth-enheter i nærheten. Fant disse enhetene:</translation>
-<translation id="5233638681132016545">Ny fane</translation>
-<translation id="526421993248218238">Kan ikke laste inn denne siden</translation>
-<translation id="5271967389191913893">Enheten kan ikke åpne innholdet som skal lastes ned.</translation>
-<translation id="528192093759286357">Dra ned fra toppen og trykk på tilbakeknappen for å avslutte fullskjerm.</translation>
-<translation id="5292796745632149097">Send til</translation>
-<translation id="5300589172476337783">Vis</translation>
-<translation id="5301954838959518834">Greit</translation>
-<translation id="5304593522240415983">Dette feltet må fylles ut</translation>
-<translation id="5307446750509046227">Slett nettstedslagring</translation>
-<translation id="5308380583665731573">Koble til</translation>
-<translation id="5313967007315987356">Legg til et nettsted</translation>
-<translation id="5317780077021120954">Lagre</translation>
-<translation id="5324858694974489420">Foreldreinnstillinger</translation>
-<translation id="5327248766486351172">Navn</translation>
-<translation id="5335288049665977812">Tillat nettsteder å kjøre JavaScript (anbefales)</translation>
-<translation id="5342314432463739672">Tillatelsesforespørsler</translation>
-<translation id="5357811892247919462">Fane er mottatt</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> åpen fane – trykk for å bytte fane}other{<ph name="OPEN_TABS_MANY" /> åpne faner – trykk for å bytte fane}}</translation>
-<translation id="5391532827096253100">Tilkoblingen din til dette nettstedet er ikke sikker. Informasjon om nettstedet</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 til)}other{(+ # til)}}</translation>
-<translation id="5400569084694353794">Ved å bruke dette programmet samtykker du i Chromes <ph name="BEGIN_LINK1" />vilkår for bruk<ph name="END_LINK1" /> og <ph name="BEGIN_LINK2" />merknad om personvern<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Navn</translation>
-<translation id="5403644198645076998">Tillat bare visse nettsteder</translation>
-<translation id="5414836363063783498">Bekrefter …</translation>
-<translation id="5423934151118863508">Sidene du besøker mest, vises her</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB er tilgjengelig</translation>
-<translation id="543338862236136125">Endre passordet</translation>
-<translation id="5433691172869980887">Brukernavnet er kopiert</translation>
-<translation id="543509235395288790">Laster ned <ph name="COUNT" /> filer (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Gå til adressefeltet</translation>
-<translation id="5447201525962359567">All nettstedslagring, inkludert informasjonskapsler og andre lokalt lagrede data</translation>
-<translation id="5447765697759493033">Dette nettstedet oversettes ikke</translation>
-<translation id="545042621069398927">Øker hastigheten på nedlastingen.</translation>
-<translation id="5456381639095306749">Last ned siden</translation>
-<translation id="5475862044948910901">Vil du starte en økt med utvidet virkelighet?</translation>
-<translation id="548278423535722844">Åpne i en kartapp</translation>
-<translation id="5487521232677179737">Slett data</translation>
-<translation id="5494752089476963479">Blokkér annonser på nettsteder som ofte viser forstyrrende eller villedende annonser</translation>
-<translation id="5500777121964041360">Funksjonen er kanskje ikke tilgjengelig der du er</translation>
-<translation id="5512137114520586844">Denne kontoen er administrert av <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Deaktivert av administratoren for denne enheten</translation>
-<translation id="5515439363601853141">Lås opp for å se passordet ditt</translation>
-<translation id="5516455585884385570">Åpne innstillingene for varsler</translation>
-<translation id="5517095782334947753">Du har bokmerker, loggen, passord og andre innstillinger fra <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Viderekobling blokkert.</translation>
-<translation id="5527082711130173040">Chrome trenger posisjonstilgang for å søke etter enheter. <ph name="BEGIN_LINK1" />Oppdater tillatelsene<ph name="END_LINK1" />. Posisjonstilgang er også <ph name="BEGIN_LINK2" />slått av for denne enheten<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Spør før nettsteder får tilgang til tekst og bilder fra utklipptavlen (anbefalt)</translation>
-<translation id="5530766185686772672">Lukk inkognitofaner</translation>
-<translation id="5534334044554683961">Når du er i VR, kan dette nettstedet finne ut mer om følgende:
-    – fysiske kjennetegn, som hvor høy du er
-    – hvordan rommet ditt ser ut
-
-    Forsikre deg om at du stoler på dette nettstedet før du går inn i VR.</translation>
-<translation id="5534640966246046842">Nettstedet er kopiert</translation>
-<translation id="5556459405103347317">Last inn på nytt</translation>
-<translation id="5561549206367097665">Venter på nettverket …</translation>
-<translation id="557283862590186398">Chrome trenger tilgang til mikrofonen din for dette nettstedet.</translation>
-<translation id="55737423895878184">Posisjon og varsler er tillatt</translation>
-<translation id="5578795271662203820">Søk etter dette bildet i <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Du kan når som helst velge hva du vil synkronisere, i <ph name="BEGIN_LINK1" />innstillingene<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Rediger adresse</translation>
-<translation id="5596627076506792578">Flere alternativer</translation>
-<translation id="5599455543593328020">Inkognitomodus</translation>
-<translation id="5620928963363755975">Du finner filene og sidene dine under Nedlastinger via Flere alternativer-knappen</translation>
-<translation id="5626134646977739690">Navn:</translation>
-<translation id="5639724618331995626">Tillat alle nettsteder</translation>
-<translation id="5648166631817621825">Siste 7 dager</translation>
-<translation id="5649053991847567735">Automatiske nedlastinger</translation>
-<translation id="5655963694829536461">Søk i nedlastingene dine</translation>
-<translation id="5659593005791499971">E-post</translation>
-<translation id="5665379678064389456">Opprett en aktivitet i <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Overstyr nettstedets forespørsel om å forhindre zooming</translation>
-<translation id="5677928146339483299">Blokkert</translation>
-<translation id="5684874026226664614">Beklager. Denne siden kunne ikke oversettes.</translation>
-<translation id="5686790454216892815">Filnavnet er for langt</translation>
-<translation id="5689516760719285838">Sted</translation>
-<translation id="569536719314091526">Oversett denne siden til hvilket som helst språk via Flere alternativer-knappen</translation>
-<translation id="572328651809341494">Nylige faner</translation>
-<translation id="5726692708398506830">Gjør alt på siden større</translation>
-<translation id="5748802427693696783">Byttet til standardfaner</translation>
-<translation id="5749068826913805084">Chrome må ha lagringstilgang for å laste ned filer.</translation>
-<translation id="5763382633136178763">Inkognitofaner</translation>
-<translation id="5763514718066511291">Trykk for å kopiere nettadressen for denne appen</translation>
-<translation id="5765780083710877561">Beskrivelse:</translation>
-<translation id="5793665092639000975">Bruker <ph name="SPACE_USED" /> av <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google kan bruke loggen din for å gi Søk, annonser og andre Google-tjenester et personlig preg</translation>
-<translation id="5804241973901381774">Tillatelser</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{for # time siden}other{for # timer siden}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Med enerett.</translation>
-<translation id="5817918615728894473">Koble sammen</translation>
-<translation id="583281660410589416">Ukjent</translation>
-<translation id="5833984609253377421">Del en link</translation>
-<translation id="5836192821815272682">Laster ned en Chrome-oppdatering …</translation>
-<translation id="5853623416121554550">på pause</translation>
-<translation id="5854790677617711513">Eldre enn 30 dager</translation>
-<translation id="5858741533101922242">Chrome kan ikke slå på Bluetooth-adapteren</translation>
-<translation id="5860033963881614850">Av</translation>
-<translation id="5862731021271217234">For å få fanene dine fra de andre enhetene du bruker, slå på synkronisering</translation>
-<translation id="5864174910718532887">Informasjon: Sortert etter nettstedsnavn</translation>
-<translation id="5864419784173784555">Venter på en annen nedlasting …</translation>
-<translation id="5865733239029070421">Sender automatisk brukerstatistikk og programstopprapporter til Google</translation>
-<translation id="5869522115854928033">Lagrede passord</translation>
-<translation id="5902828464777634901">Alle data som er lagret lokalt av dette nettstedet, inkludert informasjonskapsler, blir slettet.</translation>
-<translation id="5916664084637901428">På</translation>
-<translation id="5919204609460789179">Oppdater <ph name="PRODUCT_NAME" /> for å starte synkroniseringen</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> spart</translation>
-<translation id="5939518447894949180">Tilbakestill</translation>
-<translation id="5942872142862698679">Bruker Google til å søke</translation>
-<translation id="5952764234151283551">Sender Google nettadressen til siden du prøver å åpne</translation>
-<translation id="5956665950594638604">Åpne brukerstøtten for Chrome i en ny fane</translation>
-<translation id="5958275228015807058">Du finner filene og sidene dine under Nedlastinger</translation>
-<translation id="5962718611393537961">Trykk for å skjule</translation>
-<translation id="6000066717592683814">Behold Google</translation>
-<translation id="6005538289190791541">Foreslått passord</translation>
-<translation id="6036057147555329831">Ekstra ICU</translation>
-<translation id="6039379616847168523">Gå til den neste fanen</translation>
-<translation id="6040143037577758943">Lukk</translation>
-<translation id="6042308850641462728">Mer</translation>
-<translation id="604996488070107836">Nedlastingen av <ph name="FILE_NAME" /> ble avbrutt på grunn av en ukjent feil.</translation>
-<translation id="605721222689873409">ÅÅ</translation>
-<translation id="6064125863973209585">Fullførte nedlastinger</translation>
-<translation id="6075798973483050474">Endre startsiden</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> timer igjen</translation>
-<translation id="6108923351542677676">Konfigurasjon pågår …</translation>
-<translation id="6111020039983847643">data brukt</translation>
-<translation id="6112702117600201073">Oppdaterer siden.</translation>
-<translation id="6127379762771434464">Elementet er fjernet</translation>
-<translation id="6140912465461743537">Land/område</translation>
-<translation id="614940544461990577">Prøv dette:</translation>
-<translation id="6154478581116148741">Slå på skjermlåsen i Innstillinger for å eksportere passordene dine fra denne enheten</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> datasparing</translation>
-<translation id="6165508094623778733">Finn ut mer</translation>
-<translation id="6177111841848151710">Blokkert for den aktive søkemotoren</translation>
-<translation id="6181444274883918285">Legg til et nettsted som unntak</translation>
-<translation id="6192333916571137726">Last ned filen</translation>
-<translation id="6192792657125177640">Unntak</translation>
-<translation id="6194112207524046168">For å gi Chrome tilgang til kameraet må du også slå på kameraet i <ph name="BEGIN_LINK" />Android-innstillingene<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokkér informasjonskapsler fra tredjeparter</translation>
-<translation id="6206551242102657620">Tilkoblingen er sikker. Informasjon om nettstedet</translation>
-<translation id="6210748933810148297">Ikke <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Lås opp for å eksportere passordene dine</translation>
+<translation id="1406000523432664303">«Ingen sporing»</translation>
 <translation id="6232535412751077445">Hvis du slår på «Deaktivering av sporing», blir det sendt en forespørsel sammen med nettrafikken din. Hvilke virkninger dette eventuelt får, avhenger av om det aktuelle nettstedet svarer på forespørselen eller ikke, samt hvordan forespørselen tolkes.
 
 Noen nettsteder kan for eksempel svare på denne forespørselen ved å vise deg annonser som ikke er basert på andre nettsteder du har besøkt. Mange nettsteder samler likevel inn og bruker nettlesingsdataene dine – for eksempel for å forbedre sikkerheten, for å levere innhold, annonser og anbefalinger og for å generere rapporteringsstatistikk.</translation>
-<translation id="624789221780392884">Oppdateringen er klar</translation>
-<translation id="6255999984061454636">Innholdsforslag</translation>
-<translation id="6277522088822131679">Det oppsto et problem med å skrive ut siden. Prøv på nytt.</translation>
-<translation id="6295158916970320988">Alle nettsteder</translation>
-<translation id="629730747756840877">Konto</translation>
-<translation id="6303969859164067831">Logg av og slå av synkronisering</translation>
-<translation id="6316139424528454185">Android-versjonen støttes ikke</translation>
-<translation id="6320088164292336938">Vibrering</translation>
-<translation id="6324034347079777476">Synkronisering for Android-systemet er slått av</translation>
-<translation id="6333140779060797560">Del via <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Kryptering</translation>
-<translation id="6341580099087024258">Spør hvor filer skal lagres</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> til}other{<ph name="SHIPPING_ADDRESS_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> til}}</translation>
-<translation id="6364438453358674297">Vil du fjerne forslaget fra loggen?</translation>
-<translation id="6369229450655021117">Her kan du søke på nettet, dele ting med venner og se åpne sider.</translation>
-<translation id="6378173571450987352">Informasjon: Sortert etter mengden data som er brukt</translation>
-<translation id="6381421346744604172">Formørk nettsteder</translation>
-<translation id="6388207532828177975">Slett alt og tilbakestill</translation>
-<translation id="6393863479814692971">Chrome trenger tilgang til kameraet ditt og mikrofonen din for dette nettstedet.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Rediger bokmerket</translation>
-<translation id="6406506848690869874">Synkroniser</translation>
-<translation id="641643625718530986">Skriv ut</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB er lastet ned</translation>
-<translation id="6427112570124116297">Oversett nettet</translation>
-<translation id="6433501201775827830">Velg søkemotor</translation>
-<translation id="6437478888915024427">Sideinformasjon</translation>
-<translation id="6441734959916820584">Navnet er for langt</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# bilde}other{# bilder}}</translation>
-<translation id="6447842834002726250">Informasjonskapsler</translation>
-<translation id="6461962085415701688">Kan ikke åpne filen</translation>
-<translation id="6464977750820128603">Du kan se nettstedene du besøker i Chrome, og angi tidtakere for dem.\n\nGoogle får informasjon om nettstedene du angir tidtakere for, og hvor lenge du besøker dem. Denne informasjonen brukes til å gjøre Digital balanse bedre.</translation>
-<translation id="6475951671322991020">Last ned videoen</translation>
-<translation id="6482749332252372425">Nedlastingen av <ph name="FILE_NAME" /> ble avbrutt på grunn av mangel på lagringsplass.</translation>
-<translation id="6496823230996795692">For å bruke <ph name="APP_NAME" /> for første gang, koble til Internett.</translation>
-<translation id="6508722015517270189">Start Chrome på nytt</translation>
-<translation id="6527303717912515753">Del</translation>
-<translation id="6532866250404780454">Nettsteder du besøker i Chrome, vises ikke. Alle tidtakere for nettsteder blir slettet.</translation>
-<translation id="6534565668554028783">Google brukte for lang tid på å svare</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB er lastet ned</translation>
-<translation id="6539092367496845964">Noe gikk galt. Prøv på nytt senere.</translation>
-<translation id="654446541061731451">Velg en fane for beaming</translation>
-<translation id="6545017243486555795">Slett alle data</translation>
-<translation id="6545864417968258051">Bluetooth-skanning</translation>
-<translation id="6560414384669816528">Søk med Sogou</translation>
-<translation id="6566259936974865419">Chrome har spart deg for <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Tillat alltid</translation>
-<translation id="6573431926118603307">Faner du har åpnet i Chrome på de andre enhetene dine, vises her.</translation>
-<translation id="6583199322650523874">Sett den aktive siden som bokmerke</translation>
-<translation id="6593061639179217415">Side for datamaskiner</translation>
-<translation id="6600954340915313787">Kopiert til Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Beskyttet innhold</translation>
-<translation id="6627583120233659107">Rediger mappen</translation>
-<translation id="6643016212128521049">Tøm</translation>
-<translation id="6643649862576733715">Sortér etter mengden data som er spart</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> til}other{<ph name="CONTACT_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> til}}</translation>
-<translation id="6649642165559792194">Forhåndsvis bildet <ph name="BEGIN_NEW" />Nyhet<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome trenger posisjonstilgang for å søke etter enheter. <ph name="BEGIN_LINK" />Oppdater tillatelsene<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Passord</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Åpne i <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Merknad om personvern for Chrome</translation>
-<translation id="6676840375528380067">Vil du fjerne Chrome-dataene dine fra denne enheten?</translation>
-<translation id="6697492270171225480">Viser forslag for lignende sider når en side ikke kan finnes</translation>
-<translation id="6697947395630195233">Chrome trenger tilgang til posisjonen din for å kunne dele den med dette nettstedet.</translation>
-<translation id="6698801883190606802">Administrer synkroniserte data</translation>
-<translation id="6699370405921460408">Google-tjenere optimaliserer sidene du besøker.</translation>
-<translation id="6706288973712894588">Du er uten nett akkurat nå.\n<ph name="BEGIN_LINK" />Utforsk feeden din uten nett.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Nyheter</translation>
-<translation id="6710213216561001401">Forrige</translation>
-<translation id="671481426037969117">Tidtakeren for <ph name="FQDN" /> gikk ut. Den starter igjen i morgen.</translation>
-<translation id="6738867403308150051">Laster ned …</translation>
-<translation id="6746124502594467657">Flytt ned</translation>
-<translation id="6766622839693428701">Sveip ned for å lukke.</translation>
-<translation id="6766758767654711248">Trykk for å gå til nettstedet</translation>
-<translation id="6767294960381293877">Listen over enheter du kan dele faner med, er åpnet i halv høyde.</translation>
-<translation id="6782111308708962316">Forhindrer at nettsteder fra tredjeparter lagrer og leser data i informasjonskapsler</translation>
-<translation id="6790428901817661496">Spill av</translation>
-<translation id="6811034713472274749">Siden er klar til å vises</translation>
-<translation id="6818926723028410516">Velg elementer</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Oversett</translation>
-<translation id="6845325883481699275">Bidra til å gjøre Chrome sikrere</translation>
-<translation id="6846298663435243399">Laster inn …</translation>
-<translation id="6850409657436465440">Nedlastingen din pågår fremdeles</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> faner ble lukket</translation>
-<translation id="6864459304226931083">Last ned bildet</translation>
-<translation id="6865313869410766144">Skjemadata lagret med autofyll</translation>
-<translation id="688738109438487280">Legg til eksisterende data i <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Lås opp for å kopiere passordet ditt</translation>
-<translation id="6896758677409633944">Kopiér</translation>
-<translation id="6910211073230771657">Slettet</translation>
-<translation id="6912998170423641340">Blokkér nettsteder fra å få tilgang til tekst og bilder fra utklippstavlen</translation>
-<translation id="6914783257214138813">Passordene dine blir synlige for alle som kan se den eksporterte filen.</translation>
-<translation id="6942665639005891494">Endre standard nedlastingssted når som helst via menyalternativet Innstillinger</translation>
-<translation id="6945221475159498467">Velg</translation>
-<translation id="6963642900430330478">Denne siden er farlig. Informasjon om nettstedet</translation>
-<translation id="6963766334940102469">Slett bokmerker</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Alle datoer</translation>
-<translation id="6981982820502123353">Tilgjengelighet</translation>
-<translation id="6989267951144302301">Kunne ikke laste ned</translation>
-<translation id="6990079615885386641">Last ned appen fra Google Play Butikk: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Spør før nettsteder får bruke mikrofonen (anbefales)</translation>
-<translation id="7015203776128479407">Innledende synkroniseringsoppsett ble ikke fullført. Synkronisering er slått av.</translation>
-<translation id="7016516562562142042">tillatt for den aktive søkemotoren</translation>
-<translation id="7022756207310403729">Åpne i nettleseren</translation>
-<translation id="702463548815491781">Anbefalt når TalkBack eller brytertilgang er på</translation>
-<translation id="7029809446516969842">Passord</translation>
-<translation id="7053983685419859001">Blokkér</translation>
-<translation id="7055152154916055070">Viderekoblingen er blokkert:</translation>
-<translation id="7063006564040364415">Kunne ikke koble til synkroniseringstjeneren.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 er valgt}other{# er valgt}}</translation>
-<translation id="7071521146534760487">Administrer kontoen</translation>
-<translation id="7077143737582773186">SD-kort</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> er valgt. Du finner alternativer oppe på skjermen</translation>
-<translation id="7121362699166175603">Tømmer loggen og fjerner autofullføringer i adressefeltet. Det kan hende Google-kontoen din har andre typer nettleserlogger på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Tillat for den aktive søkemotoren</translation>
-<translation id="7138678301420049075">Annet</translation>
-<translation id="7141896414559753902">Blokkér nettsteder fra å vise forgrunnsvinduer og viderekoblinger (anbefales)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Last inn original side<ph name="END_LINK" /> fra <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Siste døgn</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Du kan endre dette senere i Innstillinger</translation>
-<translation id="7180611975245234373">Last inn på nytt</translation>
-<translation id="7189372733857464326">Venter på at Google Play Tjenester fullfører oppdateringen</translation>
-<translation id="7191430249889272776">En fane ble åpnet i bakgrunnen.</translation>
-<translation id="723171743924126238">Velg bilder</translation>
-<translation id="7233236755231902816">For å se nettet på ditt eget språk, skaff den nyeste versjonen av Chrome</translation>
-<translation id="7243308994586599757">Du finner alternativer ved bunnen av skjermen</translation>
-<translation id="7248069434667874558">Kontrollér at <ph name="TARGET_DEVICE_NAME" /> har synkronisering påslått i Chrome</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> er valgt</translation>
-<translation id="7274013316676448362">Blokkert nettsted</translation>
-<translation id="7290209999329137901">Du kan ikke endre navn</translation>
-<translation id="7291387454912369099">Assistent-aktivert betaling</translation>
-<translation id="7293171162284876153">For å starte synkronisering, slå på «Synkroniser Chrome-dataene dine».</translation>
-<translation id="729975465115245577">Enheten din har ingen app som kan lagre passordfilen.</translation>
-<translation id="7302081693174882195">Informasjon: Sortert etter mengden data som er lagret</translation>
-<translation id="7328017930301109123">I forenklet modus laster Chrome inn sider raskere og bruker opptil 60 prosent mindre data.</translation>
-<translation id="7333031090786104871">Holder fortsatt på å legge til det forrige nettstedet</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Del 1 valgt element}other{Del # valgte elementer}}</translation>
 <translation id="7359002509206457351">Gå til betalingsmåter</translation>
+<translation id="8026334261755873520">Slett nettleserdata</translation>
+<translation id="1291207594882862231">Slett loggoppføringer, informasjonskapsler, nettstedsdata, bufferen …</translation>
+<translation id="7814200940910057384">Brave-dataene er slettet</translation>
+<translation id="1664855196866195614">De valgte dataene er er fjernet fra Brave og de synkroniserte enhetene dine.
+
+Brave Software-kontoen din kan ha andre former for nettleserlogger, for eksempel søk og aktivitet fra andre Brave Software-tjenester, på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Bufrede bilder og filer</translation>
+<translation id="2496180316473517155">Nettleserlogg</translation>
+<translation id="2546283357679194313">Informasjonskapsler og data fra nettsteder</translation>
+<translation id="8662811608048051533">Logger deg av de fleste nettsteder.</translation>
+<translation id="8218628800671693884">Logger deg av de fleste nettsteder. Du blir ikke logget av Brave Software-kontoen din.</translation>
+<translation id="2017836877785168846">Tømmer loggen og fjerner automatiske fullføringer fra adressefeltet.</translation>
+<translation id="8096327394278038498">Tømmer loggen og fjerner autofullføringer i adressefeltet. Det kan hende Brave Software-kontoen din har andre typer nettleserlogger på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Tømmer loggen på alle påloggede enheter. Det kan hende Brave Software-kontoen din har andre typer nettleserlogger på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Lagrede passord</translation>
+<translation id="6865313869410766144">Skjemadata lagret med autofyll</translation>
+<translation id="7562080006725997899">Sletter nettlesingsdata</translation>
+<translation id="5487521232677179737">Slett data</translation>
+<translation id="7498271377022651285">Vent litt</translation>
+<translation id="784934925303690534">Tidsperiode</translation>
+<translation id="1718835860248848330">Siste time</translation>
+<translation id="7149893636342594995">Siste døgn</translation>
+<translation id="5648166631817621825">Siste 7 dager</translation>
+<translation id="8571213806525832805">Siste 4 uker</translation>
+<translation id="5854790677617711513">Eldre enn 30 dager</translation>
+<translation id="6979737339423435258">Alle datoer</translation>
+<translation id="982182592107339124">Dette fører til at dataene for alle nettsteder slettes, deriblant disse:</translation>
+<translation id="6643016212128521049">Tøm</translation>
+<translation id="7641339528570811325">Slett nettleserdata</translation>
+<translation id="1670399744444387456">Enkle</translation>
+<translation id="3245261285041759672">Det kan hende Brave Software-kontoen din har andre typer nettleserlogger på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Blokkert nettsted</translation>
+<translation id="2534155362429831547">Slettet <ph name="NUMBER_OF_ITEMS"/> elementer</translation>
+<translation id="1121094540300013208">Bruks- og programstopprapporter</translation>
+<translation id="9079153198295609735">Send bruksstatistikk og programstopprapporter automatisk til Brave Software</translation>
+<translation id="6981982820502123353">Tilgjengelighet</translation>
+<translation id="2387895666653383613">Tekstskalering</translation>
+<translation id="2321958826496381788">Dra glidebryteren til du kan lese dette uten problemer. Når du har dobbelttrykket på et avsnitt, bør teksten være minst like stor som dette.</translation>
+<translation id="3895926599014793903">Tving zoom på</translation>
+<translation id="5668404140385795438">Overstyr nettstedets forespørsel om å forhindre zooming</translation>
+<translation id="4149994727733219643">Forenklet visning av nettsider</translation>
+<translation id="9100505651305367705">Tilby å vise artikler i forenklet visning, når det støttes</translation>
+<translation id="1409426117486808224">Forenklet visning for åpne faner</translation>
+<translation id="702463548815491781">Anbefalt når TalkBack eller brytertilgang er på</translation>
+<translation id="8284326494547611709">Teksting</translation>
+<translation id="4165986682804962316">Nettstedsinnstillinger</translation>
+<translation id="6295158916970320988">Alle nettsteder</translation>
+<translation id="8380167699614421159">Dette nettstedet viser forstyrrende eller villedende annonser</translation>
+<translation id="1919345977826869612">Annonser</translation>
+<translation id="410351446219883937">Autoavspilling</translation>
+<translation id="6447842834002726250">Informasjonskapsler</translation>
+<translation id="6196640612572343990">Blokkér informasjonskapsler fra tredjeparter</translation>
+<translation id="6782111308708962316">Forhindrer at nettsteder fra tredjeparter lagrer og leser data i informasjonskapsler</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Forgrunnsvinduer/viderekoblinger</translation>
+<translation id="4751476147751820511">Bevegelses- eller lyssensorer</translation>
+<translation id="1717218214683051432">Bevegelsessensorer</translation>
+<translation id="2091887806945687916">Lyd</translation>
+<translation id="2586657967955657006">Utklippstavle</translation>
+<translation id="6320088164292336938">Vibrering</translation>
+<translation id="4226663524361240545">Varsler kan gjøre at enheten vibrerer</translation>
+<translation id="1446450296470737166">Full kontroll over MIDI-enheter</translation>
+<translation id="3744111561329211289">Bakgrunnssynkronisering</translation>
+<translation id="5649053991847567735">Automatiske nedlastinger</translation>
+<translation id="6181444274883918285">Legg til et nettsted som unntak</translation>
+<translation id="5313967007315987356">Legg til et nettsted</translation>
+<translation id="1369915414381695676">Nettstedet <ph name="SITE_NAME"/> er lagt til</translation>
+<translation id="7837721118676387834">Tillat automatisk avspilling av videoer med dempet lyd for et bestemt nettsted.</translation>
+<translation id="2621115761605608342">Tillat JavaScript for et bestemt nettsted.</translation>
+<translation id="8801436777607969138">Blokkér JavaScript for et bestemt nettsted.</translation>
+<translation id="8372893542064058268">Tillat bakgrunnssynkronisering for et bestemt nettsted.</translation>
+<translation id="358794129225322306">Tillat at et nettsted kan laste ned flere filer automatisk.</translation>
+<translation id="4008040567710660924">Tillat informasjonskapsler for et spesifikt nettsted.</translation>
+<translation id="8958424370300090006">Blokkér informasjonskapsler for et spesifikt nettsted.</translation>
+<translation id="7882806643839505685">Tillat lyd for et bestemt nettsted.</translation>
+<translation id="4468959413250150279">Kutt lyden for et bestemt nettsted.</translation>
+<translation id="1994173015038366702">Nettadressen til nettstedet</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Bruk</translation>
+<translation id="5804241973901381774">Tillatelser</translation>
+<translation id="4278390842282768270">Tillatt</translation>
+<translation id="5677928146339483299">Blokkert</translation>
+<translation id="1984937141057606926">Tillatt – unntatt fra tredjeparter.</translation>
+<translation id="7423098979219808738">Spør først.</translation>
+<translation id="8116925261070264013">Kuttet lyd</translation>
+<translation id="8300705686683892304">Administreres av app</translation>
+<translation id="6192792657125177640">Unntak</translation>
+<translation id="257931822824936280">Utvidet – klikk for å minimere.</translation>
+<translation id="5100237604440890931">Minimert – klikk for å utvide</translation>
+<translation id="857943718398505171">Tillatt (anbefales)</translation>
+<translation id="2913331724188855103">Tillat at nettsteder lagrer og leser data i informasjonskapsler (anbefales).</translation>
+<translation id="7445411102860286510">Gi nettsteder tillatelse til automatisk avspilling av videoer med kuttet lyd (anbefales)</translation>
+<translation id="5335288049665977812">Tillat nettsteder å kjøre JavaScript (anbefales)</translation>
+<translation id="5527111080432883924">Spør før nettsteder får tilgang til tekst og bilder fra utklipptavlen (anbefalt)</translation>
+<translation id="6912998170423641340">Blokkér nettsteder fra å få tilgang til tekst og bilder fra utklippstavlen</translation>
+<translation id="7423538860840206698">Blokkert fra å lese utklippstavlen</translation>
+<translation id="3955193568934677022">Gi nettsteder tillatelse til å spille av beskyttet innhold (anbefales)</translation>
+<translation id="445467742685312942">Tillat at nettsteder kan spille beskyttet innhold</translation>
+<translation id="2107397443965016585">Spør før nettsteder får tillatelse til å spille beskyttet innhold (anbefalt)</translation>
+<translation id="2910701580606108292">Spør før nettsteder kan spille av beskyttet innhold</translation>
+<translation id="757524316907819857">Blokkér nettsteder fra å spille av beskyttet innhold</translation>
+<translation id="3277252321222022663">Gi nettsteder tilgang til sensorer (anbefalt)</translation>
+<translation id="5048398596102334565">Gi nettsteder tilgang til bevegelsessensorer (anbefalt)</translation>
+<translation id="8816026460808729765">Blokkér nettsteder fra å få tilgang til sensorer</translation>
+<translation id="169515064810179024">Blokkér nettsteder fra å få tilgang til bevegelsessensorer</translation>
+<translation id="1660204651932907780">Tillat nettsteder å spille av lyd (anbefalt)</translation>
+<translation id="3600792891314830896">Kutt lyden for nettsteder som spiller av lyd</translation>
+<translation id="1743802530341753419">Spør før nettsteder kan koble til en enhet (anbefales)</translation>
+<translation id="851751545965956758">Blokkér at nettsteder kobler til enheter</translation>
+<translation id="7141896414559753902">Blokkér nettsteder fra å vise forgrunnsvinduer og viderekoblinger (anbefales)</translation>
+<translation id="5494752089476963479">Blokkér annonser på nettsteder som ofte viser forstyrrende eller villedende annonser</translation>
+<translation id="3123473560110926937">Blokkert på enkelte nettsteder</translation>
+<translation id="965817943346481315">Blokkér hvis nettstedet viser forstyrrende eller villedende annonser (anbefalt)</translation>
+<translation id="3386292677130313581">Spør før nettsteder får vite posisjonen min (anbefales)</translation>
+<translation id="9139068048179869749">Spør før nettsteder får sende varsler (anbefales)</translation>
+<translation id="4479647676395637221">Spør før nettsteder får bruke kameraet (anbefales)</translation>
+<translation id="6992289844737586249">Spør før nettsteder får bruke mikrofonen (anbefales)</translation>
+<translation id="2289270750774289114">Spør når nettsteder vil oppdage Bluetooth-enheter i nærheten (anbefales)</translation>
+<translation id="7053983685419859001">Blokkér</translation>
+<translation id="7128222689758636196">Tillat for den aktive søkemotoren</translation>
+<translation id="7589445247086920869">Blokkert for den aktive søkemotoren</translation>
+<translation id="6388207532828177975">Slett alt og tilbakestill</translation>
+<translation id="7999064672810608036">Er du sikker på at du vil slette alle lokale data, deriblant informasjonskapsler, og tilbakestille alle tillatelser for dette nettstedet?</translation>
+<translation id="2822354292072154809">Er du sikker på at du vil tilbakestille alle nettstedstillatelser for <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Sletting av alle lagrede data</translation>
+<translation id="5902828464777634901">Alle data som er lagret lokalt av dette nettstedet, inkludert informasjonskapsler, blir slettet.</translation>
+<translation id="119944043368869598">Fjern alle</translation>
+<translation id="2490684707762498678">Administreres av <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Åpne innstillingene for varsler</translation>
+<translation id="1404122904123200417">Innbygd i <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Filer som nettsteder har lagret, vises her</translation>
+<translation id="4181841719683918333">Språk</translation>
+<translation id="2647434099613338025">Legg til språk</translation>
+<translation id="1952172573699511566">Nettsteder viser tekst på språket du foretrekker, der dette er mulig.</translation>
+<translation id="8559990750235505898">Tilby å oversette sider på andre språk</translation>
+<translation id="4719927025381752090">Tilby å oversette</translation>
+<translation id="8156139159503939589">Hvilke språk kan du lese?</translation>
+<translation id="5689516760719285838">Sted</translation>
+<translation id="2440823041667407902">Posisjonstilgang</translation>
+<translation id="2023546461831060654">Slå på tillatelsene for Brave i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Slå på tillatelsen for Brave i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">For å gi Brave tilgang til posisjonen din må du også slå på posisjon i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">For å gi Brave tilgang til kameraet må du også slå på kameraet i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">For at Brave skal kunne sende deg varsler, må du også slå på varsler i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">For å gi Brave tilgang til mikrofonen må du også slå på mikrofonen i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Posisjonstilgang er slått av for denne enheten. Slå den på i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Posisjonstilgang er også slått av for denne enheten. Slå den på i <ph name="BEGIN_LINK"/>Android-innstillingene<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Tilgang til kameraet ditt</translation>
+<translation id="945632385593298557">Tilgang til mikrofonen din</translation>
+<translation id="6612358246767739896">Beskyttet innhold</translation>
+<translation id="885701979325669005">Lagring</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> lagrede data</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Opphev tillatelsen til enhetstilgang</translation>
+<translation id="4962975101802056554">Opphev alle tillatelser for enheten</translation>
+<translation id="6545864417968258051">Bluetooth-skanning</translation>
+<translation id="4411535500181276704">Forenklet modus</translation>
+<translation id="7821588508402923572">Datasparingen din vises her</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> spart</translation>
+<translation id="8569404424186215731">siden <ph name="DATE"/></translation>
+<translation id="3252158532344029638">I forenklet modus laster Brave inn sider raskere og bruker opptil 60 prosent mindre data.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> datasparing</translation>
+<translation id="7494974237137038751">data spart</translation>
+<translation id="6111020039983847643">data brukt</translation>
+<translation id="7413229368719586778">Startdato <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Sluttdato <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sortér etter nettsted</translation>
+<translation id="5864174910718532887">Informasjon: Sortert etter nettstedsnavn</translation>
+<translation id="116280672541001035">Brukt</translation>
+<translation id="8349013245300336738">Sortér etter mengden data som er brukt</translation>
+<translation id="6378173571450987352">Informasjon: Sortert etter mengden data som er brukt</translation>
+<translation id="2631006050119455616">Spart</translation>
+<translation id="6643649862576733715">Sortér etter mengden data som er spart</translation>
+<translation id="7302081693174882195">Informasjon: Sortert etter mengden data som er lagret</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> brukt</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> spart</translation>
+<translation id="2156074688469523661">Andre nettsteder (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Annet</translation>
+<translation id="4913161338056004800">Tilbakestill statistikken</translation>
+<translation id="1856325424225101786">Vil du tilbakestille forenklet modus?</translation>
+<translation id="3658159451045945436">Tilbakestilling fjerner historikken for datasparing, inkludert listen over besøkte nettsteder.</translation>
+<translation id="3295530008794733555">Surf raskere. Bruk mindre data.</translation>
+<translation id="7340390500800578919">I forenklet modus laster Brave inn sider raskere og bruker opptil 60 prosent mindre data. For å optimalisere sidene du besøker, sender Brave nettrafikken din til Brave Software. <ph name="BEGIN_LINK"/>Finn ut mer<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Slå på forenklet modus</translation>
+<translation id="4493497663118223949">Forenklet modus er på</translation>
+<translation id="7559975015014302720">Forenklet modus er av</translation>
+<translation id="7606077192958116810">Forenklet modus er på. Du kan endre dette i Innstillinger.</translation>
+<translation id="4714588616299687897">Reduser databruken med opptil 60 %</translation>
+<translation id="1006927014032731288">Brave Software-tjenere optimaliserer sidene du besøker.</translation>
+<translation id="3257320067425202300">Brave har spart deg for <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave har spart deg for <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Nedlastingssted</translation>
+<translation id="7077143737582773186">SD-kort</translation>
+<translation id="7762668264895820836">SD-kort <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Spør hvor filer skal lagres</translation>
+<translation id="6192333916571137726">Last ned filen</translation>
+<translation id="1672586136351118594">Ikke vis igjen</translation>
+<translation id="2650751991977523696">Vil du laste ned filen på nytt?</translation>
+<translation id="8664979001105139458">Filnavnet finnes allerede</translation>
+<translation id="488187801263602086">Endre navnet på filen</translation>
+<translation id="5686790454216892815">Filnavnet er for langt</translation>
+<translation id="7454641608352164238">Det er ikke nok plass</translation>
+<translation id="8972098258593396643">Vil du laste ned til standardmappen?</translation>
+<translation id="804335162455518893">Finner ikke SD-kort</translation>
+<translation id="7475688122056506577">Finner ikke SD-kort. Noen av filene dine kan mangle.</translation>
+<translation id="4198423547019359126">Ingen tilgjengelige nedlastingssteder</translation>
+<translation id="8224471946457685718">Last ned artikler for deg via Wi-Fi</translation>
+<translation id="4970824347203572753">Ikke tilgjengelig der du er</translation>
+<translation id="5500777121964041360">Funksjonen er kanskje ikke tilgjengelig der du er</translation>
+<translation id="1173894706177603556">Gi nytt navn</translation>
+<translation id="1986685561493779662">Navnet finnes allerede</translation>
+<translation id="6441734959916820584">Navnet er for langt</translation>
+<translation id="2923908459366352541">Navnet er ugyldig</translation>
+<translation id="7290209999329137901">Du kan ikke endre navn</translation>
+<translation id="3334729583274622784">Vil du endre filetternavnet?</translation>
+<translation id="107147699690128016">Hvis du endrer filetternavnet, kan filen bli åpnet i et annet program og muligens utgjøre en fare for enheten.</translation>
+<translation id="8541922081612557424">Om Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Med enerett.</translation>
+<translation id="1416550906796893042">Programversjon</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (oppdatert <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operativsystem</translation>
+<translation id="3968054912784331254">Denne Android-versjonen støtter ikke lenger Brave-oppdateringer</translation>
+<translation id="7665369617277396874">Legg til konto</translation>
+<translation id="649070405679044769">Logget på Brave Software som</translation>
+<translation id="6234515504547364178">Logg av Brave</translation>
+<translation id="5324858694974489420">Foreldreinnstillinger</translation>
+<translation id="8920114477895755567">Venter på informasjon om foreldre.</translation>
+<translation id="5512137114520586844">Denne kontoen er administrert av <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Denne kontoen er administrert av <ph name="PARENT_NAME_1"/> og <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Innhold</translation>
+<translation id="5403644198645076998">Tillat bare visse nettsteder</translation>
+<translation id="8641930654639604085">Prøv å blokkere nettsteder med voksent innhold</translation>
+<translation id="5639724618331995626">Tillat alle nettsteder</translation>
+<translation id="796823723482603597">Drevet av Brave</translation>
+<translation id="6324034347079777476">Synkronisering for Android-systemet er slått av</translation>
+<translation id="5127805178023152808">Synkronisering er slått av</translation>
+<translation id="7015203776128479407">Innledende synkroniseringsoppsett ble ikke fullført. Synkronisering er slått av.</translation>
+<translation id="2497852260688568942">Administratoren din har slått av synkronisering</translation>
+<translation id="9100610230175265781">Det kreves en passordfrase</translation>
+<translation id="6108923351542677676">Konfigurasjon pågår …</translation>
+<translation id="4062305924942672200">Juridisk informasjon</translation>
+<translation id="4256782883801055595">Lisenser for åpen kildekode</translation>
+<translation id="1138681184697033370">Vilkår for bruk av Brave</translation>
+<translation id="7392539049993970338">Merknad om personvern for Brave</translation>
+<translation id="2677748264148917807">Gå ut</translation>
+<translation id="5556459405103347317">Last inn på nytt</translation>
+<translation id="1623104350909869708">Hindre denne siden i å opprette flere dialogruter</translation>
+<translation id="2968755619301702150">Visningsprogram for sertifikater</translation>
+<translation id="1360432990279830238">Vil du logge av og slå av synkronisering?</translation>
+<translation id="8581481290581777242">Vil du fjerne Brave-dataene dine fra denne enheten?</translation>
+<translation id="1318865768845061710">Bokmerker, logg, passord og andre Brave-data synkroniseres ikke lenger med Brave Software-kontoen din.</translation>
+<translation id="3325020657155065477">Fjern også Brave-dataene dine fra denne enheten</translation>
+<translation id="6136448902816743006">Fordi du logger av en konto som administreres av <ph name="DOMAIN_NAME"/>, slettes Brave-dataene dine fra denne enheten. De blir værende i Brave Software-kontoen din.</translation>
+<translation id="1853026300647876496">Kontakter Brave Software. Dette kan ta en liten stund.</translation>
+<translation id="2328985652426384049">Kan ikke logge på</translation>
+<translation id="7723158744459952869">Brave Software brukte for lang tid på å svare</translation>
+<translation id="4572422548854449519">Logg på en administrert konto</translation>
+<translation id="2689656545739939160">Du logger på med en konto som administreres av <ph name="MANAGED_DOMAIN"/>, og du gir administratoren for dette domenet kontroll over Brave-dataene dine. Dataene dine blir permanent knyttet til denne kontoen. Når du logger av Brave, slettes dataene dine fra denne enheten, men de fortsetter å være lagret i Brave Software-kontoen din.</translation>
+<translation id="1749561566933687563">Synkroniser bokmerkene dine</translation>
+<translation id="4242533952199664413">Åpne innstillingene</translation>
+<translation id="1111673857033749125">Bokmerker som er lagret på de andre enhetene dine, vises her.</translation>
+<translation id="8636825310635137004">For å få fanene dine fra de andre enhetene du bruker, slå på synkronisering.</translation>
+<translation id="3269956123044984603">For å få fanene dine fra de andre enhetene du bruker, slå på «Synkroniser data automatisk» i kontoinnstillingene for Android.</translation>
+<translation id="5157964048453367290">Faner du har åpnet i Brave på de andre enhetene dine, vises her.</translation>
+<translation id="4684427112815847243">Synkroniser alt</translation>
+<translation id="2709516037105925701">Autofyll</translation>
+<translation id="8820817407110198400">Bokmerker</translation>
+<translation id="1644574205037202324">Logg</translation>
+<translation id="17513872634828108">Åpne faner</translation>
+<translation id="1320169905922104972">Kredittkort og adresser ved bruk av Brave Software Pay</translation>
+<translation id="6337234675334993532">Kryptering</translation>
+<translation id="6698801883190606802">Administrer synkroniserte data</translation>
+<translation id="3598578758776312506">Kryptér passord med Brave Software-legitimasjonen din</translation>
+<translation id="7810580217418711046">Kryptér synkroniserte data med Brave Software-passord fra og med <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Kryptér synkroniserte data med din egen passordfrase for synkronisering</translation>
+<translation id="2996291259634659425">Opprett en passordfrase</translation>
+<translation id="5713644099811900409">Brave Software-konto</translation>
+<translation id="8997474919031554666">Kryptering av passordfraser inkluderer ikke betalingsmåter og adresser fra Brave Software Pay. Bare personer som har passordfrasen din, kan lese de krypterte dataene dine. Passordfrasen blir verken sendt til Brave Software eller lagret. Hvis du glemmer den, må du tilbakestille synkroniseringen. <ph name="BEGIN_LINK"/>Finn ut mer<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Passordfrase</translation>
+<translation id="7772032839648071052">Bekreft passord</translation>
+<translation id="5304593522240415983">Dette feltet må fylles ut</translation>
+<translation id="321773570071367578">Hvis du har glemt passordfrasen din eller vil endre denne innstillingen, må du <ph name="BEGIN_LINK"/>tilbakestille synkroniseringen<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Passordfrasene stemmer ikke overens</translation>
+<translation id="5149495116300586333">Kryptering av passordfraser inkluderer ikke betalingsmåter og adresser fra Brave Software Pay.
+
+For å endre denne innstillingen, <ph name="BEGIN_LINK"/>tilbakestill synkroniseringen<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Feil passordfrase</translation>
+<translation id="5414836363063783498">Bekrefter …</translation>
+<translation id="6846298663435243399">Laster inn …</translation>
+<translation id="5517095782334947753">Du har bokmerker, loggen, passord og andre innstillinger fra <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Kombiner dataene mine</translation>
+<translation id="688738109438487280">Legg til eksisterende data i <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Hold dataene mine adskilt</translation>
+<translation id="1145536944570833626">Slett eksisterende data.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> vil koble til</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Få hjelp<ph name="END_LINK"/> mens du skanner etter enheter …</translation>
+<translation id="5817918615728894473">Koble sammen</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Få hjelp<ph name="END_LINK1"/> eller <ph name="BEGIN_LINK2"/>skann på nytt<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Fant ingen kompatible enheter</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Slå på Bluetooth<ph name="END_LINK"/> for å tillate tilkobling</translation>
+<translation id="998321811308652668">Brave kan ikke slå på Bluetooth-adapteren</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Få hjelp<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave trenger posisjonstilgang for å søke etter enheter. <ph name="BEGIN_LINK"/>Oppdater tillatelsene<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave trenger posisjonstilgang for å søke etter enheter. Posisjonstilgang er <ph name="BEGIN_LINK"/>slått av for denne enheten<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave trenger posisjonstilgang for å søke etter enheter. <ph name="BEGIN_LINK1"/>Oppdater tillatelsene<ph name="END_LINK1"/>. Posisjonstilgang er også <ph name="BEGIN_LINK2"/>slått av for denne enheten<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Tilkoblet enhet</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstyrkenivå: # stolpe}other{Signalstyrkenivå: # stolper}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> vil søke etter Bluetooth-enheter i nærheten. Fant disse enhetene:</translation>
+<translation id="8368027906805972958">Ukjent eller ikke-støttet enhet (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synkronisering fungerer ikke</translation>
+<translation id="1810845389119482123">Det innledende synkroniseringsoppsettet er ikke fullført</translation>
+<translation id="3235722914093408050">Start Brave-synkronisering ved å slå på synkronisering i Android-innstillingene</translation>
+<translation id="3367813778245106622">Logg på igjen for å starte synkroniseringen</translation>
+<translation id="974555521953189084">Skriv inn passordfrasen din for å starte synkroniseringen</translation>
+<translation id="2997266899014181325">For å starte synkronisering, slå på «Synkroniser Brave-dataene dine».</translation>
+<translation id="8260126382462817229">Prøv å logge på igjen</translation>
+<translation id="5919204609460789179">Oppdater <ph name="PRODUCT_NAME"/> for å starte synkroniseringen</translation>
+<translation id="397583555483684758">Synkroniseringen har sluttet å fungere</translation>
+<translation id="1966710179511230534">Oppdater påloggingsinformasjonen din.</translation>
+<translation id="7063006564040364415">Kunne ikke koble til synkroniseringstjeneren.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> er utdatert.</translation>
+<translation id="4170011742729630528">Tjenesten er ikke tilgjengelig. Prøv på nytt senere.</translation>
+<translation id="7947953824732555851">Godta og logg på</translation>
+<translation id="8583805026567836021">Fjerner kontodata …</translation>
+<translation id="8310344678080805313">Standardfaner</translation>
+<translation id="5748802427693696783">Byttet til standardfaner</translation>
+<translation id="7998918019931843664">Åpne lukkede faner igjen</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/> – fane</translation>
+<translation id="4452411734226507615">Lukk <ph name="TAB_TITLE"/>-fanen</translation>
+<translation id="7243308994586599757">Du finner alternativer ved bunnen av skjermen</translation>
+<translation id="4060598801229743805">Du finner alternativene oppe på skjermen</translation>
+<translation id="2810645512293415242">Siden er forenklet for å spare data og laste den inn raskere.</translation>
+<translation id="3985215325736559418">Vil du laste ned <ph name="FILE_NAME"/> igjen?</translation>
+<translation id="2450083983707403292">Vil du laste ned <ph name="FILE_NAME"/> på nytt?</translation>
+<translation id="7514365320538308">Last ned</translation>
+<translation id="545042621069398927">Øker hastigheten på nedlastingen.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Laster ned filen.}other{Laster ned # filer.}}</translation>
+<translation id="543509235395288790">Laster ned <ph name="COUNT"/> filer (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Laster ned fil (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 nedlasting er fullført.}other{# nedlastinger er fullført.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 nedlasting mislyktes.}other{# nedlastinger mislyktes.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 nedlasting venter.}other{# nedlastinger venter.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/>-knapp</translation>
+<translation id="3205824638308738187">Nesten ferdig!</translation>
+<translation id="3960299545138990065">Start Brave på nytt</translation>
+<translation id="3771001275138982843">Kunne ikke laste ned oppdateringen</translation>
+<translation id="3888648114124182147">Laster ned en Brave-oppdatering …</translation>
+<translation id="1705567146636171298">Oppdater Brave</translation>
+<translation id="6195417478702700398">For å få den beste surfeopplevelsen, åpne for å oppdatere Brave</translation>
+<translation id="3512968675351418494">For å se nettet på ditt eget språk, skaff den nyeste versjonen av Brave</translation>
+<translation id="6427112570124116297">Oversett nettet</translation>
+<translation id="1379423114029199501">Oppdater for å få språket ditt i den nyeste versjonen av Brave</translation>
+<translation id="5684874026226664614">Beklager. Denne siden kunne ikke oversettes.</translation>
+<translation id="6831043979455480757">Oversett</translation>
+<translation id="1285320974508926690">Oversett aldri dette nettstedet</translation>
+<translation id="773466115871691567">Oversett alltid sider på <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Oversett aldri sider på <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Flere språk</translation>
+<translation id="290376772003165898">Er ikke siden på <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Fra nå av oversettes sider på <ph name="SOURCE_LANGUAGE"/> til <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Sider på <ph name="LANGUAGE"/> oversettes ikke</translation>
+<translation id="5447765697759493033">Dette nettstedet oversettes ikke</translation>
+<translation id="4880127995492972015">Oversett</translation>
+<translation id="641643625718530986">Skriv ut</translation>
+<translation id="8909135823018751308">Del</translation>
+<translation id="4996978546172906250">Del via</translation>
+<translation id="6333140779060797560">Del via <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Det oppsto et problem med å skrive ut siden. Prøv på nytt.</translation>
+<translation id="3254409185687681395">Legg til bokmerke for denne siden</translation>
+<translation id="497421865427891073">Gå til neste</translation>
+<translation id="813082847718468539">Vis nettstedsinformasjon</translation>
+<translation id="2532336938189706096">Nettvisning</translation>
+<translation id="6005538289190791541">Foreslått passord</translation>
+<translation id="4634124774493850572">Bruk passord</translation>
+<translation id="8285489906452138776">Brave trenger tilgang til kameraet ditt for dette nettstedet.</translation>
+<translation id="320189792589364011">Brave trenger tilgang til mikrofonen din for dette nettstedet.</translation>
+<translation id="7988136689212463100">Brave trenger tilgang til kameraet ditt og mikrofonen din for dette nettstedet.</translation>
+<translation id="4931190655840828017">Brave trenger tilgang til posisjonen din for å kunne dele den med dette nettstedet.</translation>
+<translation id="3088191967551450609">Brave må ha lagringstilgang for å laste ned filer.</translation>
+<translation id="8942627711005830162">Åpne i et annet vindu</translation>
+<translation id="4195643157523330669">Åpne i ny fane</translation>
+<translation id="1100066534610197918">Åpne i en ny fane i en gruppe</translation>
+<translation id="4860895144060829044">Ring</translation>
+<translation id="6896758677409633944">Kopiér</translation>
+<translation id="8393700583063109961">Send melding</translation>
+<translation id="3557336313807607643">Legg til i kontakter</translation>
+<translation id="4269820728363426813">Kopiér linkadressen</translation>
+<translation id="1206892813135768548">Kopiér linkteksten</translation>
+<translation id="1204037785786432551">Last ned linken</translation>
+<translation id="6864459304226931083">Last ned bildet</translation>
+<translation id="8209050860603202033">Åpne bildet</translation>
+<translation id="8073388330009372546">Åpne bildet i en ny fane</translation>
+<translation id="6649642165559792194">Forhåndsvis bildet <ph name="BEGIN_NEW"/>Nyhet<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Last inn bildet</translation>
+<translation id="3845332215609790146">Søk med Brave Software Lens <ph name="BEGIN_NEW"/>Nyhet<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Søk etter dette bildet i <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Del bildet</translation>
+<translation id="5833984609253377421">Del en link</translation>
+<translation id="6475951671322991020">Last ned videoen</translation>
+<translation id="2317945146070194624">Åpne i en ny Brave-fane</translation>
+<translation id="7975379999046275268">Forhåndsvis siden <ph name="BEGIN_NEW"/>Nyhet<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Oppdaterer siden.</translation>
+<translation id="36525718899759834">Last ned appen fra Brave Software Play Butikk: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Mørk</translation>
+<translation id="1807246157184219062">Lys</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Velg en fane for beaming</translation>
+<translation id="8719023831149562936">Kan ikke beame gjeldende fane</translation>
+<translation id="2139186145475833000">Legg til på startsiden</translation>
+<translation id="4616150815774728855">Åpne <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Kunne ikke åpne appen</translation>
+<translation id="5129038482087801250">Installer nettprogram</translation>
+<translation id="3789841737615482174">Installer</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> ble lagt til på startskjermen</translation>
+<translation id="7333031090786104871">Holder fortsatt på å legge til det forrige nettstedet</translation>
+<translation id="1036727731225946849">Legger til <ph name="WEBAPK_NAME"/> …</translation>
+<translation id="3778956594442850293">Lagt til på startskjermen</translation>
+<translation id="2146738493024040262">Åpne instant-appen</translation>
+<translation id="7016516562562142042">tillatt for den aktive søkemotoren</translation>
+<translation id="6177111841848151710">Blokkert for den aktive søkemotoren</translation>
+<translation id="145097072038377568">Slått av i Android-innstillingene</translation>
+<translation id="8007176423574883786">Slått av for denne enheten</translation>
+<translation id="164269334534774161">Du ser en lokal kopi av denne siden fra <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Denne siden uten nett er fra <ph name="CREATION_TIME"/> og kan avvike fra nettversjonen.</translation>
+<translation id="8840953339110955557">Denne siden kan avvike fra nettversjonen.</translation>
+<translation id="6405300764336705484">Dette innholdet er fra <ph name="DOMAIN_NAME"/> og er levert av Brave Software.</translation>
+<translation id="1006017844123154345">Åpne på nettet</translation>
+<translation id="3326636747541519688">Forenklet versjon av siden levert av Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Last inn original side<ph name="END_LINK"/> fra <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Hvis du ser dette ofte, kan du prøve disse <ph name="BEGIN_LINK"/>forslagene<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Innholdet er skjult</translation>
+<translation id="3810973564298564668">Administrer</translation>
+<translation id="5199929503336119739">Jobbprofil</translation>
+<translation id="528192093759286357">Dra ned fra toppen og trykk på tilbakeknappen for å avslutte fullskjerm.</translation>
+<translation id="2836148919159985482">Trykk på tilbakeknappen for å avslutte fullskjerm.</translation>
+<translation id="3967822245660637423">Nedlasting fullført</translation>
+<translation id="2434158240863470628">Nedlasting fullført <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Nedlastingen mislyktes</translation>
+<translation id="1384959399684842514">Nedlastingen er satt på pause</translation>
+<translation id="1671236975893690980">Nedlasting venter</translation>
+<translation id="5561549206367097665">Venter på nettverket …</translation>
+<translation id="5864419784173784555">Venter på en annen nedlasting …</translation>
+<translation id="6461962085415701688">Kan ikke åpne filen</translation>
+<translation id="1178581264944972037">Stans midlertidig</translation>
+<translation id="8200772114523450471">Fortsett</translation>
+<translation id="1409879593029778104">Nedlastingen av <ph name="FILE_NAME"/> ble avbrutt fordi filen finnes allerede.</translation>
+<translation id="3387650086002190359">Nedlastingen av <ph name="FILE_NAME"/> ble avbrutt på grunn av filsystemfeil.</translation>
+<translation id="6482749332252372425">Nedlastingen av <ph name="FILE_NAME"/> ble avbrutt på grunn av mangel på lagringsplass.</translation>
+<translation id="7619072057915878432">Nedlastingen av <ph name="FILE_NAME"/> ble avbrutt på grunn av nettverksproblemer.</translation>
+<translation id="1477626028522505441">Nedlastingen av <ph name="FILE_NAME"/> ble avbrutt på grunn av tjenerproblemer.</translation>
+<translation id="3692944402865947621">Nedlastingen av <ph name="FILE_NAME"/> ble avbrutt fordi lagringsstedet ikke kan nås.</translation>
+<translation id="604996488070107836">Nedlastingen av <ph name="FILE_NAME"/> ble avbrutt på grunn av en ukjent feil.</translation>
+<translation id="6738867403308150051">Laster ned …</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> kB er lastet ned</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB er lastet ned</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB er lastet ned</translation>
+<translation id="9204836675896933765">1 fil gjenstår</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> filer gjenstår</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fil er lastet ned}other{<ph name="FILES_DOWNLOADED_MANY"/> filer er lastet ned}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> dager igjen</translation>
+<translation id="8190358571722158785">1 dag igjen</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> timer igjen</translation>
+<translation id="510275257476243843">1 time igjen</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minutter igjen</translation>
+<translation id="3236059992281584593">1 minutt igjen</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> sekunder igjen</translation>
+<translation id="2781151931089541271">1 sekund igjen</translation>
+<translation id="3303414029551471755">Vil du gå videre med å laste ned innholdet?</translation>
+<translation id="8617240290563765734">Vil du åpne den foreslåtte nettadressen som er spesifisert i det nedlastede innholdet?</translation>
+<translation id="1373696734384179344">Det er ikke nok ledig minne til å laste ned det valgte innholdet.</translation>
+<translation id="5271967389191913893">Enheten kan ikke åpne innholdet som skal lastes ned.</translation>
+<translation id="883806473910249246">Det oppsto en feil under nedlastingen av innholdet.</translation>
+<translation id="5626134646977739690">Navn:</translation>
+<translation id="7963646190083259054">Leverandør:</translation>
+<translation id="3414952576877147120">Størrelse:</translation>
+<translation id="7375125077091615385">Type:</translation>
+<translation id="5765780083710877561">Beskrivelse:</translation>
+<translation id="4881695831933465202">Åpne</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> kB er tilgjengelig</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB tilgjengelig</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB er tilgjengelig</translation>
+<translation id="5793665092639000975">Bruker <ph name="SPACE_USED"/> av <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Alle</translation>
+<translation id="4988526792673242964">Sider</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Lyd</translation>
+<translation id="9219103736887031265">Bilder</translation>
+<translation id="8250920743982581267">Dokumenter</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fil}other{# filer}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# bilde}other{# bilder}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videoer}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# lydfil}other{# lydfiler}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# side}other{# sider}}</translation>
+<translation id="5456381639095306749">Last ned siden</translation>
+<translation id="2394602618534698961">Filer du laster ned, vises her</translation>
+<translation id="7810647596859435254">Åpne med…</translation>
+<translation id="5655963694829536461">Søk i nedlastingene dine</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mine filer</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Her vises artikler, som du kan lese selv om du er uten nett</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# t}other{# t}}</translation>
+<translation id="5853623416121554550">på pause</translation>
+<translation id="8965591936373831584">venter</translation>
+<translation id="2779651927720337254">mislyktes</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Nå nettopp</translation>
+<translation id="4000212216660919741">Hjem uten nett</translation>
+<translation id="9133397713400217035">Utforsk uten nett</translation>
+<translation id="968900484120156207">Sider du besøker, vises her</translation>
+<translation id="7882131421121961860">Fant ingen logg</translation>
+<translation id="3549657413697417275">Søk i loggen</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">ÅÅ</translation>
+<translation id="724102042129299115">Førsteinntrykk ved bruk av Brave</translation>
+<translation id="2700285883409956633">Ved å bruke dette programmet samtykker du i Braves <ph name="BEGIN_LINK1"/>vilkår for bruk<ph name="END_LINK1"/> og <ph name="BEGIN_LINK2"/>merknad om personvern<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Når du bruker denne appen, godtar du <ph name="BEGIN_LINK1"/>vilkårene for bruk<ph name="END_LINK1"/> av Brave, <ph name="BEGIN_LINK2"/>merknaden om personvern<ph name="END_LINK2"/> og <ph name="BEGIN_LINK3"/>merknaden om personvern for Brave Software-kontoer som administreres med Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> åpnes i Brave. Ved å fortsette godtar du <ph name="BEGIN_LINK1"/>vilkårene for bruk<ph name="END_LINK1"/> av Brave og <ph name="BEGIN_LINK2"/>merknaden om personvern<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> åpnes i Brave. Ved å fortsette godtar du <ph name="BEGIN_LINK1"/>vilkårene for bruk<ph name="END_LINK1"/> av Brave og <ph name="BEGIN_LINK2"/>merknaden om personvern<ph name="END_LINK2"/> samt <ph name="BEGIN_LINK3"/>merknaden om personvern for Brave Software-kontoer som administreres med Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Gjør Brave bedre ved å sende bruksstatistikk og programstopprapporter til Brave Software.</translation>
+<translation id="3518985090088779359">Godta og fortsett</translation>
+<translation id="7207456302801184289">Velkommen til Brave</translation>
+<translation id="704822250101715322">Venter på at Brave Software Play Tjenester fullfører oppdateringen</translation>
+<translation id="1231733316453485619">Vil du slå på synkronisering?</translation>
+<translation id="5132942445612118989">Synkroniser passordene dine, loggen din med mer på alle enheter</translation>
+<translation id="5736731321935944068">Brave Software kan bruke loggen din for å gi Søk, annonser og andre Brave Software-tjenester et personlig preg</translation>
+<translation id="4013614219085422040">Brave Software kan bruke loggen din for å gi Søk og andre Brave Software-tjenester et personlig preg</translation>
+<translation id="5581519193887989363">Du kan når som helst velge hva du vil synkronisere, i <ph name="BEGIN_LINK1"/>innstillingene<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Ja, jeg er med</translation>
+<translation id="2410754283952462441">Velg en konto</translation>
+<translation id="2227444325776770048">Fortsett som <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Ikke <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">For å få bokmerkene dine på alle enhetene dine, slå på synkronisering</translation>
+<translation id="2818669890320396765">For å få bokmerkene dine på alle enhetene dine, logg på og slå på synkronisering</translation>
+<translation id="6003646045106347985">For å få forslag om personlig tilpasset innhold fra Brave Software, slå på synkronisering</translation>
+<translation id="8494430740943879273">For å få forslag om personlig tilpasset innhold fra Brave Software, slå på synkronisering</translation>
+<translation id="5862731021271217234">For å få fanene dine fra de andre enhetene du bruker, slå på synkronisering</translation>
+<translation id="3568688522516854065">For å få fanene dine fra de andre enhetene du bruker, logg på og slå på synkronisering.</translation>
+<translation id="1208340532756947324">For å synkronisere og gi et personlig preg på alle enhetene, slå på synkronisering</translation>
+<translation id="4472118726404937099">For å synkronisere og gi et personlig preg på alle enhetene, slå på synkronisering</translation>
+<translation id="2426805022920575512">Velg en annen konto</translation>
+<translation id="6790428901817661496">Spill av</translation>
+<translation id="1272079795634619415">Stopp</translation>
+<translation id="2874939134665556319">Forrige spor</translation>
+<translation id="4046123991198612571">Neste spor</translation>
+<translation id="3859306556332390985">Spol fremover</translation>
+<translation id="8441146129660941386">Spol bakover</translation>
+<translation id="6706288973712894588">Du er uten nett akkurat nå.\n<ph name="BEGIN_LINK"/>Utforsk feeden din uten nett.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Nylige faner</translation>
+<translation id="8497726226069778601">Det er ikke noe her foreløpig</translation>
+<translation id="5423934151118863508">Sidene du besøker mest, vises her</translation>
+<translation id="6127379762771434464">Elementet er fjernet</translation>
+<translation id="4605958867780575332">Elementet er fjernet: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software-doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Andre enheter</translation>
+<translation id="4738836084190194332">Sist synkronisert: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{for # minutt siden}other{for # minutter siden}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{for # time siden}other{for # timer siden}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{for # dag siden}other{for # dager siden}}</translation>
+<translation id="2762000892062317888">akkurat nå</translation>
+<translation id="1407135791313364759">Åpne alle</translation>
+<translation id="1209206284964581585">Skjul for øyeblikket</translation>
+<translation id="129553762522093515">Nylig lukket</translation>
+<translation id="8413126021676339697">Vis fullstendig logg</translation>
+<translation id="7876243839304621966">Fjern alle</translation>
+<translation id="8487700953926739672">Tilgjengelig utenfor nettet</translation>
+<translation id="5224771365102442243">Med video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Finn ut mer<ph name="END_LINK"/> om foreslått innhold</translation>
+<translation id="7542481630195938534">Kan ikke hente forslag</translation>
+<translation id="5013696553129441713">Ingen nye forslag</translation>
+<translation id="1736419249208073774">Utforsk</translation>
+<translation id="7444811645081526538">Flere kategorier</translation>
+<translation id="6709133671862442373">Nyheter</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Shopping</translation>
+<translation id="3912508018559818924">Vi finner det beste fra nettet …</translation>
+<translation id="526421993248218238">Kan ikke laste inn denne siden</translation>
+<translation id="614940544461990577">Prøv dette:</translation>
+<translation id="3288003805934695103">Last inn siden på nytt</translation>
+<translation id="2353636109065292463">Sjekker internettilkoblingen din</translation>
+<translation id="2858138569776157458">Populært</translation>
+<translation id="8364299278605033898">Se populære nettsteder</translation>
+<translation id="1171770572613082465">Se populære nettsteder ved å trykke på «Populært»-knappen</translation>
+<translation id="5233638681132016545">Ny fane</translation>
+<translation id="4521874409998847950">Fra <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>levert av Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">En nyere versjon er tilgjengelig</translation>
+<translation id="4058091506841967397">Kan ikke oppdatere Brave</translation>
+<translation id="6316139424528454185">Android-versjonen støttes ikke</translation>
+<translation id="6989267951144302301">Kunne ikke laste ned</translation>
+<translation id="624789221780392884">Oppdateringen er klar</translation>
+<translation id="1549000191223877751">Flytt til det andre vinduet</translation>
+<translation id="7481312909269577407">Frem</translation>
+<translation id="4084682180776658562">Legg til bokmerke</translation>
+<translation id="6437478888915024427">Sideinformasjon</translation>
+<translation id="7180611975245234373">Last inn på nytt</translation>
+<translation id="4913169188695071480">Slutt å laste inn på nytt</translation>
+<translation id="1829244130665387512">Finn på side</translation>
+<translation id="6593061639179217415">Side for datamaskiner</translation>
+<translation id="9063523880881406963">Slå av Bruk skrivebordsversjon</translation>
+<translation id="2038563949887743358">Slå på Bruk skrivebordsversjon</translation>
+<translation id="2433507940547922241">Utseende</translation>
+<translation id="983192555821071799">Lukk alle faner</translation>
+<translation id="1310482092992808703">Gruppér faner</translation>
+<translation id="7725024127233776428">Sider du setter som bokmerker, vises her</translation>
+<translation id="4404568932422911380">Ingen bokmerker</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> bokmerke}other{<ph name="BOOKMARKS_COUNT_MANY"/> bokmerker}}</translation>
+<translation id="3739899004075612870">Satt som bokmerke i <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Bokmerket</translation>
+<translation id="4452548195519783679">Satt som bokmerke i <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Kunne ikke legge til bokmerket.</translation>
+<translation id="2842985007712546952">Overordnet mappe</translation>
+<translation id="9065203028668620118">Endre</translation>
+<translation id="4405224443901389797">Flytt til …</translation>
+<translation id="5170568018924773124">Vis i mappen</translation>
+<translation id="8035133914807600019">Ny mappe</translation>
+<translation id="4532845899244822526">Velg en mappe</translation>
+<translation id="6627583120233659107">Rediger mappen</translation>
+<translation id="1197267115302279827">Flytt bokmerker</translation>
+<translation id="6963766334940102469">Slett bokmerker</translation>
+<translation id="4351244548802238354">Lukk dialogboks</translation>
+<translation id="451872707440238414">Søk i bokmerkene dine</translation>
+<translation id="8901170036886848654">Fant ingen bokmerker</translation>
+<translation id="6404511346730675251">Rediger bokmerket</translation>
+<translation id="3894427358181296146">Legg til en mappe</translation>
+<translation id="5327248766486351172">Navn</translation>
+<translation id="7400418766976504921">Nettadresse</translation>
+<translation id="3527085408025491307">Mappe</translation>
+<translation id="5161254044473106830">Du må oppgi en tittel</translation>
+<translation id="2996809686854298943">Nettadresse kreves</translation>
+<translation id="2536728043171574184">Ser på en lokalt lagret versjon av denne siden</translation>
+<translation id="4698034686595694889">Se uten nett i <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> og flere nettsteder</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave laster inn siden når den er klar}other{Brave laster inn sidene når de er klare}}</translation>
+<translation id="6811034713472274749">Siden er klar til å vises</translation>
+<translation id="4561979708150884304">Ingen tilkobling</translation>
+<translation id="8274165955039650276">Se nedlastinger</translation>
+<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER"/> av <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Ingen resultater</translation>
+<translation id="981121421437150478">Uten nett</translation>
+<translation id="3298243779924642547">Forenklet</translation>
+<translation id="393697183122708255">Ingen aktiverte talesøk er tilgjengelige</translation>
+<translation id="7191430249889272776">En fane ble åpnet i bakgrunnen.</translation>
+<translation id="8445059357334030806">Åpne i Brave</translation>
+<translation id="4720023427747327413">Åpne i <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Åpne i nettleseren</translation>
+<translation id="1113597929977215864">Vis forenklet visning</translation>
+<translation id="1513352483775369820">Bokmerker og nettlogg</translation>
+<translation id="4939482511480190003">Hjelp til med å forbedre Brave. <ph name="BEGIN_LINK"/>Delta i undersøkelsen<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Gå tilbake</translation>
+<translation id="5596627076506792578">Flere alternativer</translation>
+<translation id="3522247891732774234">En oppdatering er tilgjengelig. Flere alternativer</translation>
+<translation id="6773423637732432200">Kan ikke oppdatere Brave. Flere alternativer</translation>
+<translation id="3328801116991980348">Informasjon om nettstedet</translation>
+<translation id="5391532827096253100">Tilkoblingen din til dette nettstedet er ikke sikker. Informasjon om nettstedet</translation>
+<translation id="6206551242102657620">Tilkoblingen er sikker. Informasjon om nettstedet</translation>
+<translation id="6963642900430330478">Denne siden er farlig. Informasjon om nettstedet</translation>
+<translation id="9070377983101773829">Start talesøk</translation>
+<translation id="8676374126336081632">Slett teksten</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> åpen fane – trykk for å bytte fane}other{<ph name="OPEN_TABS_MANY"/> åpne faner – trykk for å bytte fane}}</translation>
+<translation id="2369533728426058518">åpne faner</translation>
+<translation id="7071521146534760487">Administrer kontoen</translation>
+<translation id="932327136139879170">Gå til startsiden</translation>
+<translation id="2707726405694321444">Last inn siden på nytt</translation>
+<translation id="2891154217021530873">Stopp innlastingen av siden</translation>
+<translation id="6710213216561001401">Forrige</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Valgt fane</translation>
+<translation id="2268044343513325586">Finstem</translation>
+<translation id="7846076177841592234">Opphev valget</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> er valgt. Du finner alternativer oppe på skjermen</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> er valgt</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Del 1 valgt element}other{Del # valgte elementer}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Fjern 1 valgt element}other{Fjern # valgte elementer}}</translation>
+<translation id="1283039547216852943">Trykk for å vise</translation>
+<translation id="5962718611393537961">Trykk for å skjule</translation>
+<translation id="8076492880354921740">Faner</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 er valgt}other{# er valgt}}</translation>
+<translation id="6818926723028410516">Velg elementer</translation>
+<translation id="4797039098279997504">Trykk for å gå tilbake til <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Trykk for å gå til nettstedet</translation>
+<translation id="429312253194641664">Et nettsted spiller av medier</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> deler skjermen din</translation>
+<translation id="8833831881926404480">Et nettsted deler skjermen din</translation>
+<translation id="9086455579313502267">Fikk ikke tilgang til nettverket</translation>
+<translation id="938850635132480979">Feil: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Åpne i <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Åpne i en kartapp</translation>
+<translation id="7698359219371678927">Opprett en e-post i <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Opprett e-post</translation>
+<translation id="5665379678064389456">Opprett en aktivitet i <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Opprett hendelse</translation>
+<translation id="2111511281910874386">Gå til side</translation>
+<translation id="3988466920954086464">Se umiddelbare søkeresultater i dette panelet</translation>
+<translation id="2744248271121720757">Trykk på et ord for å søke umiddelbart eller se relaterte handlinger</translation>
+<translation id="9155898266292537608">Du kan også søke med et kjapt trykk på et ord</translation>
+<translation id="3232754137068452469">Nettprogram</translation>
+<translation id="1430915738399379752">Skriv ut</translation>
+<translation id="3775705724665058594">Send til enhetene dine</translation>
+<translation id="6364438453358674297">Vil du fjerne forslaget fra loggen?</translation>
+<translation id="213279576345780926">Lukket <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> faner ble lukket</translation>
+<translation id="3211426585530211793">Slettet <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> bokmerker ble slettet</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> nedlastinger er slettet</translation>
+<translation id="1248710015876067820">For mange Brave-forekomster.</translation>
+<translation id="4259722352634471385">Nettadressen er blokkert: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Nettadressen er utilgjengelig: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Lukk fanen</translation>
+<translation id="7772375229873196092">Lukk <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Navigeringslogg</translation>
+<translation id="9169507124922466868">Navigasjonshistorikken er halvveis åpnet</translation>
+<translation id="1327257854815634930">Navigasjonsloggen er åpnet</translation>
+<translation id="8788265440806329501">Navigasjonsloggen er lukket</translation>
+<translation id="7482656565088326534">Fane for forhåndsvisning</translation>
+<translation id="8427875596167638501">Fanen for forhåndsvisning er halvveis åpnet</translation>
+<translation id="9102803872260866941">Fanen for forhåndsvisning er åpnet</translation>
+<translation id="2942036813789421260">Fanen for forhåndsvisning er lukket</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/>-lagring</translation>
+<translation id="3822502789641063741">Slette nettstedslagring?</translation>
+<translation id="9205995714227143200">Nettstedslagring Brave ikke tror er viktig (for eksempel områder uten lagrede innstillinger eller som du ikke besøker ofte)</translation>
+<translation id="3997476611815694295">Uviktig lagring</translation>
+<translation id="8493948351860045254">Frigjør plass</translation>
+<translation id="2324920234469020158">Dette sletter informasjonskapsler, buffere og annen data fra nettsteder Brave ikke tror er viktige.</translation>
+<translation id="5447201525962359567">All nettstedslagring, inkludert informasjonskapsler og andre lokalt lagrede data</translation>
+<translation id="1376578503827013741">Beregner …</translation>
+<translation id="583281660410589416">Ukjent</translation>
+<translation id="2323763861024343754">Nettstedslagring</translation>
+<translation id="3587672679800759167">Total datamengde som brukes av Brave, deriblant kontoer, bokmerker og lagrede innstillinger</translation>
+<translation id="6545017243486555795">Slett alle data</translation>
+<translation id="4095146165863963773">Slette appdataene?</translation>
+<translation id="53119194224775367">Alle appdataene for Brave slettes permanent. Dette omfatter alle filer, innstillinger, kontoer, databaser osv.</translation>
+<translation id="5307446750509046227">Slett nettstedslagring</translation>
+<translation id="300526633675317032">Dette sletter alle dataene (<ph name="SIZE_IN_KB"/>) fra nettstedslagringen.</translation>
+<translation id="8068648041423924542">Kan ikke velge sertifikat.</translation>
+<translation id="2315043854645842844">Operativsystemet har ikke støtte for sertifikatvalg på klientsiden.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> vil koble til</translation>
+<translation id="5308380583665731573">Koble til</translation>
+<translation id="868929229000858085">Søk i kontaktene dine</translation>
+<translation id="1919950603503897840">Velg kontakter</translation>
+<translation id="7986741934819883144">Velg en kontakt</translation>
+<translation id="3333961966071413176">Alle kontakter</translation>
+<translation id="4994033804516042629">Fant ingen kontakter</translation>
+<translation id="5403592356182871684">Navn</translation>
+<translation id="2717722538473713889">E-postadresser</translation>
+<translation id="381841723434055211">Telefonnumre</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 til)}other{(+ # til)}}</translation>
+<translation id="5197729504361054390">Kontaktene du velger, deles med <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Bildedekoder</translation>
+<translation id="8067883171444229417">Spill av videoen</translation>
+<translation id="6560414384669816528">Søk med Sogou</translation>
+<translation id="5406914950576900927">Brave kan bruke <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> for søk i Kina. Du kan endre dette i <ph name="BEGIN_LINK"/>Innstillinger<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Behold Brave Software</translation>
+<translation id="4384468725000734951">Bruker Sogou til å søke</translation>
+<translation id="6103327872225198548">Bruker Brave Software til å søke</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Denne appen kjører i Brave</translation>
+<translation id="6143689084714664628">Kjører i Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> har også data i Brave</translation>
+<translation id="2734140769649165081">Du kan slette dataene i Brave-innstillingene</translation>
+<translation id="8232956427053453090">Behold dataene</translation>
+<translation id="4298388696830689168">Tilknyttede nettsteder</translation>
+<translation id="5763514718066511291">Trykk for å kopiere nettadressen for denne appen</translation>
+<translation id="6496823230996795692">For å bruke <ph name="APP_NAME"/> for første gang, koble til Internett.</translation>
+<translation id="751961395872307827">Kan ikke koble til nettstedet</translation>
+<translation id="4878404682131129617">Kunne ikke opprette tunnel via proxy-tjener.</translation>
+<translation id="4749960740855309258">Åpne en ny fane</translation>
+<translation id="8788968922598763114">Åpne den sist lukkede fanen på nytt</translation>
+<translation id="7929962904089429003">Åpne menyen</translation>
+<translation id="6039379616847168523">Gå til den neste fanen</translation>
+<translation id="5210286577605176222">Gå til den forrige fanen</translation>
+<translation id="124678866338384709">Lukk den aktive fanen</translation>
+<translation id="3714981814255182093">Åpne søkeraden</translation>
+<translation id="5441522332038954058">Gå til adressefeltet</translation>
+<translation id="3398320232533725830">Åpne bokmerkebehandlingen</translation>
+<translation id="6583199322650523874">Sett den aktive siden som bokmerke</translation>
+<translation id="8489271220582375723">Åpne loggsiden</translation>
+<translation id="4837753911714442426">Åpne alternativene for å skrive ut siden</translation>
+<translation id="5726692708398506830">Gjør alt på siden større</translation>
+<translation id="3259831549858767975">Gjør alt på siden mindre</translation>
+<translation id="8015452622527143194">Tilbakestill alt på siden til standardstørrelsen</translation>
+<translation id="3443221991560634068">Last inn den aktive siden på nytt</translation>
+<translation id="123724288017357924">Last inn siden på nytt, men ignorer bufret innhold</translation>
+<translation id="305870044889644984">Åpne brukerstøtten for Brave i en ny fane</translation>
+<translation id="3166827708714933426">Hurtigtaster for vinduer og faner</translation>
+<translation id="3169981355900570544">Hurtigtaster for funksjoner i Brave Software Brave.</translation>
+<translation id="4558311620361989323">Hurtigtaster for nettsider</translation>
+<translation id="1908301351964700579">Brave klargjør fremdeles for VR. Start Brave på nytt senere.</translation>
+<translation id="8970887620466824814">Noe gikk galt.</translation>
+<translation id="1875543012935658554">Åpne Brave på nytt.</translation>
+<translation id="79859296434321399">Du må installere ARCore for å se innhold med utvidet virkelighet</translation>
+<translation id="8558485628462305855">Du må oppdatere ARCore for å se innhold med utvidet virkelighet</translation>
+<translation id="3513704683820682405">Utvidet virkelighet</translation>
+<translation id="5475862044948910901">Vil du starte en økt med utvidet virkelighet?</translation>
 <translation id="7365126855094612066">Så lenge denne økten pågår, kan dette nettstedet
 • lage et 3D-kart av omgivelsene dine
 • spore kamerabevegelser
 
 Nettstedet får IKKE tilgang til kameraet. Kamerabildene er kun synlige for deg.</translation>
-<translation id="7375125077091615385">Type:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">Nettadresse</translation>
-<translation id="7403691278183511381">Førsteinntrykk ved bruk av Chrome</translation>
-<translation id="741204030948306876">Ja, jeg er med</translation>
-<translation id="7413229368719586778">Startdato <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Spør først.</translation>
-<translation id="7423538860840206698">Blokkert fra å lese utklippstavlen</translation>
-<translation id="7431991332293347422">Kontrollér hvordan nettleserloggen din brukes til blant annet personlig tilpasning av søk</translation>
-<translation id="7437998757836447326">Logg av Chrome</translation>
-<translation id="7438641746574390233">Når forenklet modus er på, bruker Chrome Google-tjenere slik at sidene lastes inn raskere. Forenklet modus omskriver svært trege sider, slik at kun vesentlig innhold lastes inn. Forenklet modus brukes ikke på inkognitofaner.</translation>
-<translation id="7444811645081526538">Flere kategorier</translation>
-<translation id="7445411102860286510">Gi nettsteder tillatelse til automatisk avspilling av videoer med kuttet lyd (anbefales)</translation>
-<translation id="7453467225369441013">Logger deg av de fleste nettsteder. Du blir ikke logget av Google-kontoen din.</translation>
-<translation id="7454641608352164238">Det er ikke nok plass</translation>
-<translation id="7475192538862203634">Hvis du ser dette ofte, kan du prøve disse <ph name="BEGIN_LINK" />forslagene<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Finner ikke SD-kort. Noen av filene dine kan mangle.</translation>
-<translation id="7479104141328977413">Faneadministrering</translation>
-<translation id="7481312909269577407">Frem</translation>
-<translation id="7482656565088326534">Fane for forhåndsvisning</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (oppdatert <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">data spart</translation>
-<translation id="7498271377022651285">Vent litt</translation>
-<translation id="7514365320538308">Last ned</translation>
-<translation id="751961395872307827">Kan ikke koble til nettstedet</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Kan ikke hente forslag</translation>
-<translation id="7559975015014302720">Forenklet modus er av</translation>
-<translation id="7562080006725997899">Sletter nettlesingsdata</translation>
-<translation id="756809126120519699">Chrome-dataene er slettet</translation>
-<translation id="757524316907819857">Blokkér nettsteder fra å spille av beskyttet innhold</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fil er lastet ned}other{<ph name="FILES_DOWNLOADED_MANY" /> filer er lastet ned}}</translation>
-<translation id="7588219262685291874">Slå på mørkt tema når batterisparing er på</translation>
-<translation id="7589445247086920869">Blokkert for den aktive søkemotoren</translation>
-<translation id="7593557518625677601">Start Chrome-synkronisering ved å slå på synkronisering i Android-innstillingene</translation>
-<translation id="7596558890252710462">Operativsystem</translation>
-<translation id="7605594153474022051">Synkronisering fungerer ikke</translation>
-<translation id="7606077192958116810">Forenklet modus er på. Du kan endre dette i Innstillinger.</translation>
-<translation id="7612619742409846846">Logget på Google som</translation>
-<translation id="7619072057915878432">Nedlastingen av <ph name="FILE_NAME" /> ble avbrutt på grunn av nettverksproblemer.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Få hjelp<ph name="END_LINK1" /> eller <ph name="BEGIN_LINK2" />skann på nytt<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Velkommen til Chrome</translation>
-<translation id="7638584964844754484">Feil passordfrase</translation>
-<translation id="7641339528570811325">Slett nettleserdata</translation>
-<translation id="7648422057306047504">Kryptér passord med Google-legitimasjonen din</translation>
-<translation id="7649070708921625228">Hjelp</translation>
-<translation id="7658239707568436148">Avbryt</translation>
-<translation id="7665369617277396874">Legg til konto</translation>
-<translation id="766587987807204883">Her vises artikler, som du kan lese selv om du er uten nett</translation>
-<translation id="7682724950699840886">Prøv dette: Sørg for at det er nok plass på enheten, og prøv å eksportere på nytt.</translation>
-<translation id="7685301384041462804">Forsikre deg om at du stoler på dette nettstedet før du går inn i VR.</translation>
-<translation id="7698359219371678927">Opprett en e-post i <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Autofullfør søk og nettadresser</translation>
-<translation id="7725024127233776428">Sider du setter som bokmerker, vises her</translation>
-<translation id="773466115871691567">Oversett alltid sider på <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">For å oppdage farlige apper og nettsteder sender Chrome nettadressene til noen av sidene du besøker, begrenset systeminformasjon og noe sideinnhold til Google.</translation>
-<translation id="7757787379047923882">Tekst delt fra <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-kort <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Legg til adresse</translation>
-<translation id="7772032839648071052">Bekreft passord</translation>
-<translation id="7772375229873196092">Lukk <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> til}other{<ph name="PAYMENT_METHOD_PREVIEW" /> og <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> til}}</translation>
-<translation id="7781829728241885113">I går</translation>
-<translation id="7791543448312431591">Legg til</translation>
-<translation id="780301667611848630">Nei takk</translation>
-<translation id="7810647596859435254">Åpne med…</translation>
-<translation id="7821588508402923572">Datasparingen din vises her</translation>
-<translation id="7837721118676387834">Tillat automatisk avspilling av videoer med dempet lyd for et bestemt nettsted.</translation>
-<translation id="7846076177841592234">Opphev valget</translation>
-<translation id="784934925303690534">Tidsperiode</translation>
-<translation id="7851858861565204677">Andre enheter</translation>
-<translation id="7875915731392087153">Opprett e-post</translation>
-<translation id="7876243839304621966">Fjern alle</translation>
-<translation id="7882131421121961860">Fant ingen logg</translation>
-<translation id="7882806643839505685">Tillat lyd for et bestemt nettsted.</translation>
-<translation id="7886917304091689118">Kjører i Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Laster ned filen.}other{Laster ned # filer.}}</translation>
-<translation id="7929962904089429003">Åpne menyen</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> er utdatert.</translation>
-<translation id="7947953824732555851">Godta og logg på</translation>
-<translation id="7963646190083259054">Leverandør:</translation>
-<translation id="7971136598759319605">Aktiv for én dag siden</translation>
-<translation id="7975379999046275268">Forhåndsvis siden <ph name="BEGIN_NEW" />Nyhet<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Last inn sider på forhånd for raskere nettlesing og søk</translation>
-<translation id="79859296434321399">Du må installere ARCore for å se innhold med utvidet virkelighet</translation>
-<translation id="7986741934819883144">Velg en kontakt</translation>
-<translation id="7987073022710626672">Vilkår for bruk av Chrome</translation>
-<translation id="7998918019931843664">Åpne lukkede faner igjen</translation>
-<translation id="7999064672810608036">Er du sikker på at du vil slette alle lokale data, deriblant informasjonskapsler, og tilbakestille alle tillatelser for dette nettstedet?</translation>
-<translation id="8004582292198964060">Nettleser</translation>
-<translation id="8007176423574883786">Slått av for denne enheten</translation>
-<translation id="8013372441983637696">Fjern også Chrome-dataene dine fra denne enheten</translation>
-<translation id="8015452622527143194">Tilbakestill alt på siden til standardstørrelsen</translation>
-<translation id="802154636333426148">Nedlastingen mislyktes</translation>
-<translation id="8026334261755873520">Slett nettleserdata</translation>
-<translation id="8035133914807600019">Ny mappe</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> dager igjen</translation>
-<translation id="804335162455518893">Finner ikke SD-kort</translation>
-<translation id="805047784848435650">Basert på nettlesingsloggen din</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB tilgjengelig</translation>
-<translation id="8058746566562539958">Åpne i en ny Chrome-fane</translation>
-<translation id="8063895661287329888">Kunne ikke legge til bokmerket.</translation>
-<translation id="806745655614357130">Hold dataene mine adskilt</translation>
-<translation id="8067883171444229417">Spill av videoen</translation>
-<translation id="8068648041423924542">Kan ikke velge sertifikat.</translation>
-<translation id="8073388330009372546">Åpne bildet i en ny fane</translation>
-<translation id="8076492880354921740">Faner</translation>
-<translation id="8084114998886531721">Lagret passord</translation>
-<translation id="8087000398470557479">Dette innholdet er fra <ph name="DOMAIN_NAME" /> og er levert av Google.</translation>
-<translation id="8103578431304235997">Inkognitofane</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">For å få bokmerkene dine på alle enhetene dine, slå på synkronisering</translation>
-<translation id="8110087112193408731">Vil du vise Chrome-aktiviteten din i Digital balanse?</translation>
-<translation id="8116925261070264013">Kuttet lyd</translation>
-<translation id="813082847718468539">Vis nettstedsinformasjon</translation>
-<translation id="8131740175452115882">Bekreft</translation>
-<translation id="8156139159503939589">Hvilke språk kan du lese?</translation>
-<translation id="8168435359814927499">Innhold</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> filer gjenstår</translation>
-<translation id="8190358571722158785">1 dag igjen</translation>
-<translation id="8200772114523450471">Fortsett</translation>
-<translation id="8209050860603202033">Åpne bildet</translation>
-<translation id="8218622182176210845">Administrer kontoen din</translation>
-<translation id="8224471946457685718">Last ned artikler for deg via Wi-Fi</translation>
-<translation id="8232956427053453090">Behold dataene</translation>
-<translation id="8249310407154411074">Flytt til toppen</translation>
-<translation id="8250920743982581267">Dokumenter</translation>
-<translation id="825412236959742607">Denne siden bruker for mye minne, så Chrome har fjernet noe av innholdet.</translation>
-<translation id="8260126382462817229">Prøv å logge på igjen</translation>
-<translation id="8261506727792406068">Slett</translation>
-<translation id="8266862848225348053">Nedlastingssted</translation>
-<translation id="8274165955039650276">Se nedlastinger</translation>
-<translation id="8284326494547611709">Teksting</translation>
-<translation id="8300705686683892304">Administreres av app</translation>
-<translation id="8310344678080805313">Standardfaner</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> og flere nettsteder</translation>
-<translation id="8327155640814342956">For å få den beste surfeopplevelsen, åpne for å oppdatere Chrome</translation>
-<translation id="8339163506404995330">Sider på <ph name="LANGUAGE" /> oversettes ikke</translation>
-<translation id="8349013245300336738">Sortér etter mengden data som er brukt</translation>
-<translation id="8364299278605033898">Se populære nettsteder</translation>
-<translation id="8368027906805972958">Ukjent eller ikke-støttet enhet (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Tillat bakgrunnssynkronisering for et bestemt nettsted.</translation>
-<translation id="8378714024927312812">Administreres av organisasjonen din</translation>
-<translation id="8380167699614421159">Dette nettstedet viser forstyrrende eller villedende annonser</translation>
-<translation id="8393700583063109961">Send melding</translation>
-<translation id="8413126021676339697">Vis fullstendig logg</translation>
-<translation id="8427875596167638501">Fanen for forhåndsvisning er halvveis åpnet</translation>
-<translation id="8428213095426709021">Innstillinger</translation>
-<translation id="8438566539970814960">Gjør søking og surfing bedre</translation>
-<translation id="8441146129660941386">Spol bakover</translation>
-<translation id="8443209985646068659">Kan ikke oppdatere Chrome</translation>
-<translation id="8445448999790540984">Kan ikke eksportere passordene</translation>
-<translation id="8447861592752582886">Opphev tillatelsen til enhetstilgang</translation>
-<translation id="8461694314515752532">Kryptér synkroniserte data med din egen passordfrase for synkronisering</translation>
-<translation id="8466613982764129868">Kontrollér at <ph name="TARGET_DEVICE_NAME" /> er koblet til internett</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Tilgjengelig utenfor nettet</translation>
-<translation id="8489271220582375723">Åpne loggsiden</translation>
-<translation id="8493948351860045254">Frigjør plass</translation>
-<translation id="8497726226069778601">Det er ikke noe her foreløpig</translation>
-<translation id="8503559462189395349">Chrome-passord</translation>
-<translation id="8503813439785031346">Brukernavn</translation>
-<translation id="8514477925623180633">Eksportér passord som er lagret med Chrome</translation>
-<translation id="8514577642972634246">Slå på inkognitomodus</translation>
-<translation id="851751545965956758">Blokkér at nettsteder kobler til enheter</translation>
-<translation id="8523928698583292556">Slett lagrede passord</translation>
-<translation id="854522910157234410">Åpne denne siden</translation>
-<translation id="8558485628462305855">Du må oppdatere ARCore for å se innhold med utvidet virkelighet</translation>
-<translation id="8559990750235505898">Tilby å oversette sider på andre språk</translation>
-<translation id="8562452229998620586">Lagrede passord listes opp her.</translation>
-<translation id="8569404424186215731">siden <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Siste 4 uker</translation>
-<translation id="857943718398505171">Tillatt (anbefales)</translation>
-<translation id="8583805026567836021">Fjerner kontodata …</translation>
-<translation id="860043288473659153">Kortinnehavers navn</translation>
-<translation id="8609465669617005112">Flytt opp</translation>
-<translation id="8616006591992756292">Det kan hende Google-kontoen din har andre typer nettleserlogger på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Vil du åpne den foreslåtte nettadressen som er spesifisert i det nedlastede innholdet?</translation>
-<translation id="8636825310635137004">For å få fanene dine fra de andre enhetene du bruker, slå på synkronisering.</translation>
-<translation id="8641930654639604085">Prøv å blokkere nettsteder med voksent innhold</translation>
-<translation id="8655129584991699539">Du kan slette dataene i Chrome-innstillingene</translation>
-<translation id="8662811608048051533">Logger deg av de fleste nettsteder.</translation>
-<translation id="8664979001105139458">Filnavnet finnes allerede</translation>
-<translation id="8676374126336081632">Slett teksten</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstyrkenivå: # stolpe}other{Signalstyrkenivå: # stolper}}</translation>
-<translation id="868929229000858085">Søk i kontaktene dine</translation>
-<translation id="869891660844655955">Utløpsdato</translation>
-<translation id="8719023831149562936">Kan ikke beame gjeldende fane</translation>
-<translation id="8725066075913043281">Prøv igjen</translation>
-<translation id="8728487861892616501">Når du bruker denne appen, godtar du <ph name="BEGIN_LINK1" />vilkårene for bruk<ph name="END_LINK1" /> av Chrome, <ph name="BEGIN_LINK2" />merknaden om personvern<ph name="END_LINK2" /> og <ph name="BEGIN_LINK3" />merknaden om personvern for Google-kontoer som administreres med Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Ferdig</translation>
-<translation id="8748850008226585750">Innholdet er skjult</translation>
-<translation id="8751914237388039244">Velg et bilde</translation>
-<translation id="8788265440806329501">Navigasjonsloggen er lukket</translation>
-<translation id="8788968922598763114">Åpne den sist lukkede fanen på nytt</translation>
-<translation id="8801436777607969138">Blokkér JavaScript for et bestemt nettsted.</translation>
-<translation id="8812260976093120287">På noen nettsteder kan du betale med de støttede betalingsappene ovenfor på enheten din.</translation>
-<translation id="8816026460808729765">Blokkér nettsteder fra å få tilgang til sensorer</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> åpnes i Chrome. Ved å fortsette godtar du <ph name="BEGIN_LINK1" />vilkårene for bruk<ph name="END_LINK1" /> av Chrome og <ph name="BEGIN_LINK2" />merknaden om personvern<ph name="END_LINK2" /> samt <ph name="BEGIN_LINK3" />merknaden om personvern for Google-kontoer som administreres med Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Bokmerker</translation>
-<translation id="8833831881926404480">Et nettsted deler skjermen din</translation>
-<translation id="883806473910249246">Det oppsto en feil under nedlastingen av innholdet.</translation>
-<translation id="8840953339110955557">Denne siden kan avvike fra nettversjonen.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" /> – fane</translation>
-<translation id="885701979325669005">Lagring</translation>
-<translation id="889338405075704026">Gå til Chrome-innstillingene</translation>
-<translation id="8901170036886848654">Fant ingen bokmerker</translation>
-<translation id="8909135823018751308">Del</translation>
-<translation id="8912362522468806198">Google-konto</translation>
-<translation id="8920114477895755567">Venter på informasjon om foreldre.</translation>
+<translation id="1188239144602654184">Start utvidet virkelighet</translation>
+<translation id="473775607612524610">Oppdater</translation>
+<translation id="3133489217401741157">Installerer <ph name="MODULE"/> for Brave …</translation>
+<translation id="1791662854739702043">Installert</translation>
+<translation id="5131234170665854056">Kan ikke installere <ph name="MODULE"/> for Brave</translation>
+<translation id="2567385386134582609">BILDE</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Last ned sidene for å bruke dem uten nett</translation>
 <translation id="8922289737868596582">Last ned sider via Flere alternativer-knappen for å bruke dem uten nett</translation>
-<translation id="8937772741022875483">Vil du fjerne Chrome-aktiviteten din fra Digital balanse?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Åpne i et annet vindu</translation>
-<translation id="8951232171465285730">Chrome har spart deg for <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokkér informasjonskapsler for et spesifikt nettsted.</translation>
-<translation id="8959122750345127698">Nettadressen er utilgjengelig: <ph name="URL" /></translation>
-<translation id="8965591936373831584">venter</translation>
-<translation id="8970887620466824814">Noe gikk galt.</translation>
-<translation id="8972098258593396643">Vil du laste ned til standardmappen?</translation>
-<translation id="8986494364107987395">Send bruksstatistikk og programstopprapporter automatisk til Google</translation>
-<translation id="8993760627012879038">Åpne en ny fane i inkognitomodus</translation>
-<translation id="8998729206196772491">Du logger på med en konto som administreres av <ph name="MANAGED_DOMAIN" />, og du gir administratoren for dette domenet kontroll over Chrome-dataene dine. Dataene dine blir permanent knyttet til denne kontoen. Når du logger av Chrome, slettes dataene dine fra denne enheten, men de fortsetter å være lagret i Google-kontoen din.</translation>
-<translation id="9019902583201351841">Administrert av foreldrene dine</translation>
-<translation id="9028914725102941583">Slå på synkronisering for å dele på tvers av enheter</translation>
-<translation id="9029323097866369874">Vil du tillate <ph name="DOMAIN" /> å gå inn i VR?</translation>
-<translation id="9040142327097499898">Varsler er tillatt. Posisjon er slått av for denne enheten.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videoer}}</translation>
-<translation id="9050666287014529139">Passordfrase</translation>
-<translation id="9063523880881406963">Slå av Bruk skrivebordsversjon</translation>
-<translation id="9065203028668620118">Endre</translation>
-<translation id="9070377983101773829">Start talesøk</translation>
-<translation id="9074336505530349563">For å få forslag om personlig tilpasset innhold fra Google, slå på synkronisering</translation>
-<translation id="9086455579313502267">Fikk ikke tilgang til nettverket</translation>
-<translation id="9100505651305367705">Tilby å vise artikler i forenklet visning, når det støttes</translation>
-<translation id="9100610230175265781">Det kreves en passordfrase</translation>
-<translation id="9102803872260866941">Fanen for forhåndsvisning er åpnet</translation>
+<translation id="5958275228015807058">Du finner filene og sidene dine under Nedlastinger</translation>
+<translation id="5620928963363755975">Du finner filene og sidene dine under Nedlastinger via Flere alternativer-knappen</translation>
+<translation id="3341058695485821946">Se hvor mye data du har spart</translation>
+<translation id="3157842584138209013">Se hvor mye data du har spart, via Flere alternativer-knappen</translation>
+<translation id="8218622182176210845">Administrer kontoen din</translation>
+<translation id="8090895580117672212">For å administrere Brave Software-kontoen din, trykk på «Administrer kontoen»-knappen</translation>
+<translation id="8856898588039823173">Forenklet versjon av siden levert av Brave Software. Trykk for å laste inn den opprinnelige siden.</translation>
+<translation id="8134317863207426198">Forenklet versjon av siden levert av Brave Software. Trykk på knappen for å laste inn den opprinnelige siden.</translation>
+<translation id="4961107849584082341">Oversett denne siden til hvilket som helst språk</translation>
+<translation id="569536719314091526">Oversett denne siden til hvilket som helst språk via Flere alternativer-knappen</translation>
+<translation id="1397811292916898096">Søk med <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Endre standard nedlastingssted når som helst</translation>
+<translation id="6942665639005891494">Endre standard nedlastingssted når som helst via menyalternativet Innstillinger</translation>
+<translation id="6850409657436465440">Nedlastingen din pågår fremdeles</translation>
+<translation id="5817715962196959877">Brave laster ned filer raskere nå</translation>
+<translation id="3976396876660209797">Fjern denne snarveien, og opprett den på nytt</translation>
+<translation id="6766622839693428701">Sveip ned for å lukke.</translation>
+<translation id="1028699632127661925">Sender til <ph name="DEVICE_NAME"/> …</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – sendt fra <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Fane er mottatt</translation>
 <translation id="9104217018994036254">Liste over enheter du kan dele faner med.</translation>
-<translation id="9133397713400217035">Utforsk uten nett</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Vis original</translation>
-<translation id="9139068048179869749">Spør før nettsteder får sende varsler (anbefales)</translation>
-<translation id="9139318394846604261">Shopping</translation>
-<translation id="9155898266292537608">Du kan også søke med et kjapt trykk på et ord</translation>
-<translation id="9169507124922466868">Navigasjonshistorikken er halvveis åpnet</translation>
-<translation id="9204836675896933765">1 fil gjenstår</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Listen over enheter du kan dele faner med, er åpnet i halv høyde.</translation>
+<translation id="2904414404539560095">Listen over enheter du kan dele faner med, er åpnet i full høyde.</translation>
+<translation id="4135200667068010335">Listen over enheter du kan dele faner med, er lukket.</translation>
+<translation id="5292796745632149097">Send til</translation>
+<translation id="1386674309198842382">Aktiv for <ph name="LAST_UPDATED"/> dager siden</translation>
+<translation id="7971136598759319605">Aktiv for én dag siden</translation>
+<translation id="1521774566618522728">Aktiv i dag</translation>
+<translation id="3631987586758005671">Deler med <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Slå på synkronisering for å dele på tvers av enheter</translation>
+<translation id="6162454065885854378">For å dele noe på telefonen med en annen enhet, slå på synkronisering i Brave-innstillingene på begge enhetene</translation>
+<translation id="6084271560289605378">Gå til Brave-innstillingene</translation>
+<translation id="2318045970523081853">Trykk for å ringe</translation>
 <translation id="9209888181064652401">Kan ikke ringe</translation>
-<translation id="9219103736887031265">Bilder</translation>
-<translation id="926205370408745186">Fjerne Chrome-aktiviteten din fra Digital balanse</translation>
-<translation id="932327136139879170">Gå til startsiden</translation>
-<translation id="938850635132480979">Feil: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Tilgang til mikrofonen din</translation>
-<translation id="95817756606698420">Chrome kan bruke <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> for søk i Kina. Du kan endre dette i <ph name="BEGIN_LINK" />Innstillinger<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokkér hvis nettstedet viser forstyrrende eller villedende annonser (anbefalt)</translation>
-<translation id="968900484120156207">Sider du besøker, vises her</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minutter igjen</translation>
-<translation id="974555521953189084">Skriv inn passordfrasen din for å starte synkroniseringen</translation>
-<translation id="981121421437150478">Uten nett</translation>
-<translation id="982182592107339124">Dette fører til at dataene for alle nettsteder slettes, deriblant disse:</translation>
-<translation id="983192555821071799">Lukk alle faner</translation>
-<translation id="987264212798334818">Generelt</translation>
+<translation id="2860954141821109167">Kontrollér at en telefon-app er påslått på denne enheten</translation>
+<translation id="2067805253194386918">tekst</translation>
+<translation id="1450753235335490080">Kan ikke dele <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Kunne ikke dele <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Kontrollér at <ph name="TARGET_DEVICE_NAME"/> har synkronisering påslått i Brave</translation>
+<translation id="3016635187733453316">Kontrollér at enheten er koblet til internett</translation>
+<translation id="8466613982764129868">Kontrollér at <ph name="TARGET_DEVICE_NAME"/> er koblet til internett</translation>
+<translation id="6539092367496845964">Noe gikk galt. Prøv på nytt senere.</translation>
+<translation id="3389286852084373014">Teksten er for stor</translation>
+<translation id="2100314319871056947">Prøv å dele teksten i mindre deler</translation>
+<translation id="2987620471460279764">En annen enhet har delt tekst</translation>
+<translation id="7757787379047923882">Tekst delt fra <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kopiert til utklippstavlen</translation>
+<translation id="4696983787092045100">Send tekst til enhetene dine</translation>
+<translation id="1260236875608242557">Søk og utforsk</translation>
+<translation id="6369229450655021117">Her kan du søke på nettet, dele ting med venner og se åpne sider.</translation>
+<translation id="723171743924126238">Velg bilder</translation>
+<translation id="8751914237388039244">Velg et bilde</translation>
+<translation id="1989112275319619282">Bla gjennom</translation>
+<translation id="7055152154916055070">Viderekoblingen er blokkert:</translation>
+<translation id="5524843473235508879">Viderekobling blokkert.</translation>
+<translation id="6573096386450695060">Tillat alltid</translation>
+<translation id="5805364706385912897">Denne siden bruker for mye minne, så Brave har satt den på pause.</translation>
+<translation id="5138664332909611586">Denne siden bruker for mye minne, så Brave har fjernet noe av innholdet.</translation>
+<translation id="9137013805542155359">Vis original</translation>
+<translation id="6361779936989026201">Brave Software-assistenten i Brave</translation>
+<translation id="7291387454912369099">Assistent-aktivert betaling</translation>
+<translation id="4565206163201411670">Vil du vise Brave-aktiviteten din i Digital balanse?</translation>
+<translation id="9055113864158719823">Du kan se nettstedene du besøker i Brave, og angi tidtakere for dem.\n\nBrave Software får informasjon om nettstedene du angir tidtakere for, og hvor lenge du besøker dem. Denne informasjonen brukes til å gjøre Digital balanse bedre.</translation>
+<translation id="4596514158372210596">Fjerne Brave-aktiviteten din fra Digital balanse</translation>
+<translation id="1174893863889683998">Vil du fjerne Brave-aktiviteten din fra Digital balanse?</translation>
+<translation id="708829030563435351">Nettsteder du besøker i Brave, vises ikke. Alle tidtakere for nettsteder blir slettet.</translation>
+<translation id="2056878612599315956">Nettstedet er satt på pause</translation>
+<translation id="671481426037969117">Tidtakeren for <ph name="FQDN"/> gikk ut. Den starter igjen i morgen.</translation>
+<translation id="7479104141328977413">Faneadministrering</translation>
+<translation id="3524138585025253783">Utvikler-UI</translation>
+<translation id="6036057147555329831">Ekstra ICU</translation>
+<translation id="9029323097866369874">Vil du tillate <ph name="DOMAIN"/> å gå inn i VR?</translation>
+<translation id="7685301384041462804">Forsikre deg om at du stoler på dette nettstedet før du går inn i VR.</translation>
+<translation id="5033865233969348410">Når du er i VR, kan dette nettstedet finne ut mer om følgende:
+    – fysiske kjennetegn, som hvor høy du er
+
+    Forsikre deg om at du stoler på dette nettstedet før du går inn i VR.</translation>
+<translation id="5534334044554683961">Når du er i VR, kan dette nettstedet finne ut mer om følgende:
+    – fysiske kjennetegn, som hvor høy du er
+    – hvordan rommet ditt ser ut
+
+    Forsikre deg om at du stoler på dette nettstedet før du går inn i VR.</translation>
+<translation id="4169535189173047238">Ikke tillat</translation>
+<translation id="2170088579611075216">Tillat og start VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_pl.xtb
+++ b/android/java/strings/translations/android_chrome_strings_pl.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="pl">
-<translation id="1006017844123154345">Otwórz online</translation>
-<translation id="1028699632127661925">Przesyłam na: <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">Dodaję aplikację <ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">Ze stron internetowych</translation>
-<translation id="1049743911850919806">Incognito</translation>
-<translation id="10614374240317010">Nigdy nie zapisane</translation>
-<translation id="1067922213147265141">Inne usługi Google</translation>
-<translation id="1068672505746868501">Nigdy nie tłumacz stron, których językiem jest <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Jeśli zmienisz rozszerzenie pliku, będzie mogła go otworzyć inna aplikacja, co może nie być bezpieczne dla Twojego urządzenia.</translation>
-<translation id="1100066534610197918">Otwórz w nowej karcie w grupie</translation>
-<translation id="1105960400813249514">Zrzut ekranu</translation>
-<translation id="1111673857033749125">Tutaj wyświetlą się zakładki z innych urządzeń.</translation>
-<translation id="1113597929977215864">Pokaż widok uproszczony</translation>
-<translation id="1121094540300013208">Raporty o użytkowaniu i awariach</translation>
-<translation id="1124772482545689468">Użytkownik</translation>
-<translation id="1129510026454351943">Szczegóły: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 plik oczekuje na pobranie.}few{# pliki oczekują na pobranie.}many{# plików oczekuje na pobranie.}other{# pliku oczekuje na pobranie.}}</translation>
-<translation id="1145536944570833626">Usuń istniejące dane.</translation>
-<translation id="1146678959555564648">Włącz tryb VR</translation>
-<translation id="116280672541001035">Użyto</translation>
-<translation id="1171770572613082465">Zobacz najpopularniejsze strony, klikając przycisk „Popularne”</translation>
-<translation id="1173894706177603556">Zmień nazwę</translation>
-<translation id="1178581264944972037">Wstrzymaj</translation>
-<translation id="1181037720776840403">Usuń</translation>
-<translation id="1188239144602654184">Włącz AR</translation>
-<translation id="1197267115302279827">Przenieś zakładki</translation>
-<translation id="119944043368869598">Wyczyść wszystko</translation>
-<translation id="1201402288615127009">Dalej</translation>
-<translation id="1204037785786432551">Pobierz link</translation>
-<translation id="1206892813135768548">Kopiuj tekst linku</translation>
-<translation id="1208340532756947324">Aby synchronizować i personalizować wszystkie swoje urządzenia, włącz synchronizację</translation>
-<translation id="1209206284964581585">Na razie ukryj</translation>
-<translation id="1227058898775614466">Historia nawigacji</translation>
-<translation id="1231733316453485619">Włączyć synchronizację?</translation>
-<translation id="123724288017357924">Ponowie załaduj stronę, bez pamięci podręcznej</translation>
-<translation id="124116460088058876">Więcej języków</translation>
-<translation id="124678866338384709">Zamknij bieżącą kartę</translation>
-<translation id="1258753120186372309">Doodle Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Szukaj i przeglądaj</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> – nie udało się udostępnić</translation>
-<translation id="1272079795634619415">Zatrzymaj</translation>
-<translation id="1283039547216852943">Kliknij, by rozwinąć</translation>
-<translation id="1285320974508926690">Nigdy nie tłumacz tej witryny</translation>
-<translation id="1291207594882862231">Wyczyść historię, pliki cookie, dane witryn, pamięć podręczną…</translation>
-<translation id="129382876167171263">W tym miejscu pojawiają się pliki zapisane przez witryny</translation>
-<translation id="129553762522093515">Ostatnio zamknięte</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – wysłane z: <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Grupuj karty</translation>
-<translation id="1327257854815634930">Historia nawigacji jest otwarta</translation>
-<translation id="1331212799747679585">Nie udało się zaktualizować Chrome. Więcej opcji</translation>
-<translation id="1332501820983677155">Skróty do funkcji Google Chrome</translation>
-<translation id="1360432990279830238">Wylogować i wyłączyć synchronizację?</translation>
-<translation id="1369915414381695676">Strona <ph name="SITE_NAME" /> została dodana</translation>
-<translation id="1373696734384179344">Za mało pamięci, by pobrać te treści.</translation>
-<translation id="1376578503827013741">Obliczam…</translation>
-<translation id="1383876407941801731">Szukaj</translation>
-<translation id="1384959399684842514">Pobieranie wstrzymane</translation>
-<translation id="1386674309198842382">Aktywność <ph name="LAST_UPDATED" /> dni temu</translation>
-<translation id="1397811292916898096">Szukaj w <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Umieszczone na <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">„Bez śledzenia”</translation>
-<translation id="1407135791313364759">Otwórz wszystkie</translation>
-<translation id="1409426117486808224">Uproszczony widok otwartych kart</translation>
-<translation id="1409879593029778104">Plik <ph name="FILE_NAME" /> nie został pobrany, bo już istnieje.</translation>
-<translation id="1414981605391750300">Łączę się z Google. Może to chwilę potrwać…</translation>
-<translation id="1416550906796893042">Wersja aplikacji</translation>
-<translation id="1430915738399379752">Drukuj</translation>
-<translation id="1446450296470737166">Pełne sterowanie urządzeniami MIDI</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" />: nie udało się udostępnić</translation>
-<translation id="145097072038377568">Wyłączone w ustawieniach Androida</translation>
-<translation id="1477626028522505441">Nie udało się pobrać pliku <ph name="FILE_NAME" /> z powodu problemów z serwerem.</translation>
-<translation id="1506061864768559482">Wyszukiwarka</translation>
-<translation id="1513352483775369820">Zakładki i historia online</translation>
-<translation id="1513858653616922153">Usuń hasło</translation>
-<translation id="1516229014686355813">Funkcja Kliknij, by wyszukać wysyła zaznaczone słowo i bieżącą stronę jako kontekst do wyszukiwarki Google. Możesz ją wyłączyć w <ph name="BEGIN_LINK" />ustawieniach<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktywność: dzisiaj</translation>
-<translation id="1544826120773021464">Aby zarządzać kontem Google, kliknij przycisk „Zarządzaj kontem”</translation>
-<translation id="1549000191223877751">Przenieś do innego okna</translation>
-<translation id="1553358976309200471">Zaktualizuj Chrome</translation>
-<translation id="1569387923882100876">Połączone urządzenie</translation>
-<translation id="1571304935088121812">Kopiuj nazwę użytkownika</translation>
-<translation id="1612196535745283361">Aby wyszukać urządzenia, Chrome potrzebuje dostępu do lokalizacji. Dostęp jest <ph name="BEGIN_LINK" />wyłączony na tym urządzeniu<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Zapobiegaj wyświetlaniu dodatkowych okien dialogowych na tej stronie</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Usuń 1 wybrany element}few{Usuń # wybrane elementy}many{Usuń # wybranych elementów}other{Usuń # wybranego elementu}}</translation>
-<translation id="164269334534774161">Oglądasz kopię offline tej strony z <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historia</translation>
-<translation id="1647391597548383849">Dostęp do kamery</translation>
-<translation id="1660204651932907780">Zezwalaj na odtwarzanie dźwięku na stronach internetowych (zalecane)</translation>
-<translation id="1670399744444387456">Podstawowe</translation>
-<translation id="1671236975893690980">Oczekuję na pobranie…</translation>
-<translation id="1672586136351118594">Nie pokazuj ponownie</translation>
-<translation id="1692118695553449118">Synchronizacja jest włączona</translation>
-<translation id="169515064810179024">Blokuj stronom dostęp do czujników ruchu</translation>
-<translation id="1717218214683051432">Czujniki ruchu</translation>
-<translation id="1718835860248848330">Ostatnia godzina</translation>
-<translation id="1736419249208073774">Odkrywaj</translation>
-<translation id="1743802530341753419">Pytaj, zanim zezwolisz stronom na połączenie z urządzeniem (zalecane)</translation>
-<translation id="1749561566933687563">Synchronizuj swoje zakładki</translation>
-<translation id="17513872634828108">Otwarte karty</translation>
-<translation id="1779089405699405702">Dekoder obrazów</translation>
-<translation id="1782483593938241562">Data zakończenia: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Zainstalowano</translation>
-<translation id="1792959175193046959">W dowolnej chwili możesz zmienić domyślną lokalizację pobierania</translation>
-<translation id="1807246157184219062">Jasny</translation>
-<translation id="1810845389119482123">Nie dokończono wstępnego konfigurowania synchronizacji</translation>
-<translation id="1821253160463689938">Twoje ustawienia będą zapisywane w plikach cookie, nawet jeśli nie odwiedzisz tych stron</translation>
-<translation id="1829244130665387512">Znajdź na stronie</translation>
-<translation id="1853692000353488670">Nowa karta incognito</translation>
-<translation id="1856325424225101786">Zresetować wersję uproszczoną?</translation>
-<translation id="1868024384445905608">Chrome pobiera pliki jeszcze szybciej</translation>
-<translation id="1883903952484604915">Moje pliki</translation>
-<translation id="1887786770086287077">Dostęp do lokalizacji jest wyłączony na tym urządzeniu. Włącz go w <ph name="BEGIN_LINK" />Ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> otworzy się w Chrome. Przechodząc dalej, akceptujesz <ph name="BEGIN_LINK1" />Warunki korzystania z usługi<ph name="END_LINK1" /> Chrome i <ph name="BEGIN_LINK2" />Informacje na temat ochrony prywatności<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Reklamy</translation>
-<translation id="1919950603503897840">Wybierz kontakty</translation>
-<translation id="1922076542920281912">Aby zezwolić Chrome na dostęp do lokalizacji, musisz ją też włączyć w <ph name="BEGIN_LINK" />Ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Aktualizacje</translation>
-<translation id="19288952978244135">Uruchom ponownie Chrome.</translation>
-<translation id="1933845786846280168">Wybrana karta</translation>
-<translation id="194341124344773587">Przyznaj Chrome uprawnienie w <ph name="BEGIN_LINK" />ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Zapisuj hasła</translation>
-<translation id="1952172573699511566">Gdy będzie to możliwe, tekst na stronach internetowych będzie się wyświetlać w Twoim preferowanym języku.</translation>
-<translation id="1960290143419248813">Aktualizacje Chrome nie są już dostępne w tej wersji Androida</translation>
-<translation id="1966710179511230534">Zaktualizuj swoje dane logowania.</translation>
-<translation id="1974060860693918893">Zaawansowane</translation>
-<translation id="1984705450038014246">Synchronizuj dane Chrome</translation>
-<translation id="1984937141057606926">Dozwolone, z wyjątkiem witryn innych firm</translation>
-<translation id="1986685561493779662">Nazwa już istnieje</translation>
-<translation id="1987739130650180037">Przycisk <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Przeglądaj</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> chce się sparować</translation>
-<translation id="1994173015038366702">URL strony</translation>
-<translation id="2000419248597011803">Niektóre pliki cookie oraz zapytania wpisane na pasku adresu i w polu wyszukiwania zostaną wysłane do domyślnej wyszukiwarki</translation>
-<translation id="2002537628803770967">Karty kredytowe i adresy z Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# plik}few{# pliki}many{# plików}other{# pliku}}</translation>
-<translation id="2017836877785168846">Usuwa historię i wpisy autouzupełniania w pasku adresu.</translation>
-<translation id="2021896219286479412">Elementy sterowania stroną na pełnym ekranie</translation>
-<translation id="2038563949887743358">Włącz opcję „Wersja na komputer”</translation>
-<translation id="2041019821020695769">Aby zezwolić Chrome na wysyłanie Ci powiadomień, musisz je też włączyć w <ph name="BEGIN_LINK" />Ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Dane aplikacji <ph name="APP_NAME" /> znajdują się też w Chrome</translation>
-<translation id="2049574241039454490"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE_OF_TOTAL" /></translation>
-<translation id="2056878612599315956">Strona wstrzymana</translation>
-<translation id="2063713494490388661">Kliknij, by wyszukać</translation>
-<translation id="2067805253194386918">Tekst</translation>
-<translation id="2079545284768500474">Cofnij</translation>
-<translation id="2082238445998314030">Wynik <ph name="RESULT_NUMBER" /> z <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Dźwięk</translation>
-<translation id="2096012225669085171">Synchronizacja i personalizacja na urządzeniach</translation>
-<translation id="2100273922101894616">Automatyczne logowanie</translation>
-<translation id="2100314319871056947">Spróbuj udostępnić mniejsze fragmenty tekstu</translation>
-<translation id="2107397443965016585">Pytaj, zanim pozwolisz stronom na odtwarzanie treści chronionej (zalecane)</translation>
-<translation id="2111511281910874386">Przejdź do strony</translation>
-<translation id="2122601567107267586">Nie udało się otworzyć aplikacji</translation>
-<translation id="2126426811489709554">Technologia Chrome</translation>
-<translation id="2131665479022868825">Zaoszczędzono <ph name="DATA" /></translation>
-<translation id="213279576345780926">Zamknięto <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Dodaj do ekranu głównego</translation>
-<translation id="2146738493024040262">Otwórz aplikację błyskawiczną</translation>
-<translation id="2148716181193084225">Dzisiaj</translation>
-<translation id="2154484045852737596">Edytowanie karty</translation>
-<translation id="2154710561487035718">Kopiuj adres URL</translation>
-<translation id="2156074688469523661">Pozostałe strony (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Jeśli chcesz udostępnić coś z telefonu na innym urządzeniu, w ustawieniach Chrome na obu urządzeniach włącz synchronizację</translation>
-<translation id="2170088579611075216">Zezwól na tryb VR i włącz go</translation>
-<translation id="218608176142494674">Udostępnianie</translation>
-<translation id="2227444325776770048">Kontynuuj jako <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synchronizacja i usługi Google</translation>
-<translation id="2259659629660284697">Eksportuj hasła…</translation>
-<translation id="2268044343513325586">Zawęź</translation>
-<translation id="2286841657746966508">Adres rozliczeniowy</translation>
-<translation id="2289270750774289114">Pytaj, gdy strona chce wykryć urządzenia Bluetooth w pobliżu (zalecane)</translation>
-<translation id="230115972905494466">Nie znaleziono zgodnych urządzeń</translation>
-<translation id="2315043854645842844">Wybieranie certyfikatu klienta nie jest obsługiwane przez ten system operacyjny.</translation>
-<translation id="2318045970523081853">Kliknij, by zadzwonić</translation>
-<translation id="2321086116217818302">Przygotowuję hasła…</translation>
-<translation id="2321958826496381788">Przeciągaj suwak, by umożliwić wygodne czytanie. Gdy dwukrotnie klikniesz akapit, tekst powiększy się co najmniej do tej wielkości.</translation>
-<translation id="2323763861024343754">Dane witryn:</translation>
-<translation id="2328985652426384049">Nie można się zalogować</translation>
-<translation id="2330129964253841015">Ostrzegaj, jeśli hasła dostały się w niepowołane ręce</translation>
-<translation id="2349710944427398404">Łączna ilość danych używanych przez Chrome, w tym konta, zakładki i zapisane ustawienia</translation>
-<translation id="2353636109065292463">Sprawdzanie połączenia z internetem</translation>
-<translation id="2359808026110333948">Dalej</translation>
-<translation id="2369533728426058518">otwarte karty</translation>
-<translation id="2387895666653383613">Skalowanie tekstu</translation>
-<translation id="2394602618534698961">Tutaj pojawią się pobrane pliki</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Ta funkcja zostanie włączona, gdy zalogujesz się na swoje konto Google</translation>
-<translation id="2410754283952462441">Wybierz konto</translation>
-<translation id="2414886740292270097">Ciemny</translation>
-<translation id="2416359993254398973">Chrome potrzebuje uprawnień dostępu do aparatu na tej stronie.</translation>
-<translation id="2426805022920575512">Wybierz inne konto</translation>
-<translation id="2433507940547922241">Wygląd</translation>
-<translation id="2434158240863470628">Ukończono pobieranie <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Dostęp do lokalizacji</translation>
-<translation id="2450083983707403292">Czy chcesz jeszcze raz rozpocząć pobieranie pliku <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Powiadomienia</translation>
-<translation id="2490684707762498678">Zarządzane przez <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Asystent Google w Chrome</translation>
-<translation id="2496180316473517155">Historia przeglądania</translation>
-<translation id="2497852260688568942">Synchronizację wyłączył administrator</translation>
-<translation id="2498359688066513246">Pomoc i opinie</translation>
-<translation id="2501278716633472235">Wróć</translation>
-<translation id="2513403576141822879">Więcej ustawień związanych z prywatnością, bezpieczeństwem i zbieraniem danych znajdziesz w sekcji <ph name="BEGIN_LINK" />Synchronizacja i usługi Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">W wersji uproszczonej Chrome szybciej ładuje strony, używając nawet o 60% mniej danych. Aby optymalizować strony, które odwiedzasz, Chrome przesyła informacje o historii przeglądania do Google. <ph name="BEGIN_LINK" />Więcej informacji<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Adresy URL odwiedzanych stron będą wysyłane do Google</translation>
-<translation id="2532336938189706096">Widok sieci</translation>
-<translation id="2534155362429831547">Usunięte elementy: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Oglądasz kopię offline tej strony</translation>
-<translation id="2546283357679194313">Pliki cookie i dane stron</translation>
-<translation id="2567385386134582609">OBRAZ</translation>
-<translation id="257088987046510401">Motywy</translation>
-<translation id="2570922361219980984">Dostęp do lokalizacji jest wyłączony też na tym urządzeniu. Włącz go w <ph name="BEGIN_LINK" />Ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Rozwinięty – kliknij, by zwinąć.</translation>
-<translation id="2581165646603367611">Spowoduje to skasowanie plików cookie, pamięci podręcznej i innych danych witryn, które Chrome uzna za nieistotne.</translation>
-<translation id="2586657967955657006">Schowek</translation>
-<translation id="2587052924345400782">Dostępna jest nowsza wersja</translation>
-<translation id="2593272815202181319">Stała szerokość znaków</translation>
-<translation id="2612676031748830579">Numer karty</translation>
-<translation id="2621115761605608342">Zezwól na użycie JavaScriptu w określonej witrynie.</translation>
-<translation id="2625189173221582860">Hasło zostało skopiowane</translation>
-<translation id="2631006050119455616">Zaoszczędzono</translation>
-<translation id="2647434099613338025">Dodaj język</translation>
-<translation id="2650751991977523696">Czy pobrać plik ponownie?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# plik dźwiękowy}few{# pliki dźwiękowe}many{# plików dźwiękowych}other{# pliku dźwiękowego}}</translation>
-<translation id="2653659639078652383">Prześlij</translation>
-<translation id="2677748264148917807">Wyjdź</translation>
-<translation id="2704606927547763573">Skopiowane</translation>
-<translation id="2707726405694321444">Odśwież stronę</translation>
-<translation id="2709516037105925701">Autouzupełnianie</translation>
-<translation id="2717722538473713889">Adresy e-mail</translation>
-<translation id="2728754400939377704">Sortuj według witryny</translation>
-<translation id="2744248271121720757">Kliknij słowo, by szybko je wyszukać lub wyświetlić powiązane czynności</translation>
-<translation id="2760989362628427051">Włącz tryb ciemny, gdy urządzenie ma włączony tryb ciemny lub oszczędzanie baterii</translation>
-<translation id="2762000892062317888">przed chwilą</translation>
-<translation id="2777555524387840389">Pozostało: <ph name="SECONDS" /> s</translation>
-<translation id="2779651927720337254">Nie pobrano</translation>
-<translation id="2781151931089541271">Pozostała sekunda</translation>
-<translation id="2801022321632964776">Zaktualizuj Chrome do najnowszej wersji, by mieć w nim dostępny swój język</translation>
-<translation id="2810645512293415242">Uproszczona wersja strony pozwala szybciej zapisywać i wczytywać dane.</translation>
-<translation id="281504910091592009">Zapisane hasła znajdziesz na swoim <ph name="BEGIN_LINK" />koncie Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Aby korzystać ze swoich zakładek na wszystkich urządzeniach, zaloguj się i włącz synchronizację</translation>
-<translation id="2822354292072154809">Czy na pewno chcesz zresetować wszystkie uprawnienia witryny dla obiektu <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Kliknij przycisk Wstecz, by wyjść z trybu pełnoekranowego.</translation>
-<translation id="2842985007712546952">Folder nadrzędny</translation>
-<translation id="2858138569776157458">Popularne</translation>
-<translation id="2860954141821109167">Sprawdź, czy na urządzeniu jest włączona aplikacja telefonu</translation>
-<translation id="2870560284913253234">Witryna</translation>
-<translation id="2874939134665556319">Poprzedni utwór</translation>
-<translation id="2876369937070532032">Gdy Twoje bezpieczeństwo jest zagrożone, wysyła do Google adresy URL odwiedzanych stron</translation>
-<translation id="2888126860611144412">Chrome – informacje</translation>
-<translation id="2891154217021530873">Zatrzymaj wczytywanie strony</translation>
-<translation id="2893180576842394309">Google może korzystać z Twojej historii, by personalizować wyniki wyszukiwania i działanie innych usług.</translation>
-<translation id="2898264748040935573">Edytuj zapisane hasło</translation>
-<translation id="2900528713135656174">Utwórz wydarzenie</translation>
-<translation id="290376772003165898">Język tej strony to nie <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Lista urządzeń, którym udostępnisz kartę, jest otwarta na pełną wysokość.</translation>
-<translation id="2910701580606108292">Pytaj, zanim zezwolisz stronom na odtwarzanie treści chronionej</translation>
-<translation id="2913331724188855103">Zezwalaj witrynom na zapisywanie danych w plikach cookie i ich odczytywanie (zalecane)</translation>
-<translation id="2923908459366352541">Nazwa jest nieprawidłowa.</translation>
-<translation id="2932150158123903946">Dane aplikacji Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Karta podglądu jest zamknięta</translation>
-<translation id="2956410042958133412">Tym kontem zarządzają <ph name="PARENT_NAME_1" /> i <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Przełączono na karty incognito</translation>
-<translation id="2968755619301702150">Przeglądarka certyfikatów</translation>
-<translation id="2979025552038692506">Wybrana karta incognito</translation>
-<translation id="2987620471460279764">Tekst udostępniany przez inne urządzenia</translation>
-<translation id="2989523299700148168">Ostatnio odwiedzone</translation>
-<translation id="2996291259634659425">Utwórz hasło</translation>
-<translation id="2996809686854298943">Wymagany adres URL</translation>
-<translation id="300526633675317032">Spowoduje to usunięcie <ph name="SIZE_IN_KB" /> danych witryn.</translation>
-<translation id="3016635187733453316">Sprawdź, czy to urządzenie jest połączone z internetem</translation>
-<translation id="3029613699374795922">Pobrano <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Hasła nie pasują do siebie</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Poproś o pomoc<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Lokalizacja jest wyłączona. Włącz ją w <ph name="BEGIN_LINK" />Ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">W każdej chwili możesz włączyć synchronizację w ustawieniach</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> zakładka}few{<ph name="BOOKMARKS_COUNT_MANY" /> zakładki}many{<ph name="BOOKMARKS_COUNT_MANY" /> zakładek}other{<ph name="BOOKMARKS_COUNT_MANY" /> zakładki}}</translation>
-<translation id="3089395242580810162">Otwórz w karcie incognito</translation>
-<translation id="3115898365077584848">Pokaż informacje</translation>
-<translation id="3123473560110926937">Blokowane na niektórych stronach</translation>
-<translation id="3137521801621304719">Wyłącz tryb incognito</translation>
-<translation id="3143515551205905069">Anuluj synchronizację</translation>
-<translation id="3157842584138209013">Sprawdź ilość zaoszczędzonych danych, używając przycisku Więcej opcji</translation>
-<translation id="3166827708714933426">Skróty kart i okien</translation>
-<translation id="3181954750937456830">Bezpieczne przeglądanie (chroni Ciebie i Twoje urządzenie przed niebezpiecznymi witrynami)</translation>
-<translation id="3190152372525844641">Przyznaj Chrome uprawnienia w <ph name="BEGIN_LINK" />ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> zapisanych danych</translation>
-<translation id="3205824638308738187">Prawie gotowe!</translation>
-<translation id="3207960819495026254">Dodano do zakładek</translation>
-<translation id="3211426585530211793">Usunięto: <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Jeśli nie pamiętasz hasła lub chcesz zmienić to ustawienie, <ph name="BEGIN_LINK" />zresetuj synchronizację<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Aplikacja internetowa</translation>
-<translation id="3236059992281584593">Pozostała minuta</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Dodaj stronę do zakładek</translation>
-<translation id="3259831549858767975">Pomniejsz całą zawartość strony</translation>
-<translation id="3269093882174072735">Wczytaj obraz</translation>
-<translation id="3269956123044984603">Aby korzystać z kart ze swoich pozostałych urządzeń, włącz opcję „Autosynchronizacja danych” w ustawieniach konta na urządzeniu z Androidem.</translation>
-<translation id="3277252321222022663">Zezwalaj stronom na dostęp do czujników (zalecane)</translation>
-<translation id="3282568296779691940">Zaloguj się w Chrome</translation>
-<translation id="3288003805934695103">Odśwież stronę</translation>
-<translation id="32895400574683172">Powiadomienia są włączone</translation>
-<translation id="3295530008794733555">Szybsze przeglądanie. Mniejsze zużycie danych.</translation>
-<translation id="3295602654194328831">Ukryj informacje</translation>
-<translation id="3298243779924642547">Lżejsza</translation>
-<translation id="3303414029551471755">Przejść do pobrania treści?</translation>
-<translation id="3306398118552023113">Ta aplikacja działa w Chrome</translation>
-<translation id="3315103659806849044">Teraz dostosowujesz ustawienia synchronizacji i usług Google. Aby zakończyć włączanie synchronizacji, na dole ekranu kliknij przycisk Potwierdź. Przejdź wyżej</translation>
-<translation id="3328801116991980348">Informacje o witrynie</translation>
-<translation id="3333961966071413176">Wszystkie kontakty</translation>
-<translation id="3334729583274622784">Zmienić rozszerzenie pliku?</translation>
-<translation id="3341058695485821946">Sprawdź ilość zaoszczędzonych danych</translation>
-<translation id="3350687908700087792">Zamknij wszystkie karty incognito</translation>
-<translation id="3353615205017136254">Lżejsza wersja strony dostarczona przez Google. Aby wczytać oryginalną wersję, kliknij przycisk Załaduj oryginał.</translation>
-<translation id="3367813778245106622">Zaloguj się ponownie, by rozpocząć synchronizację</translation>
-<translation id="3374023511497244703">Twoje zakładki, historia, hasła i inne dane z Chrome nie będą już synchronizowane z kontem Google</translation>
-<translation id="3384347053049321195">Udostępnij zdjęcie</translation>
-<translation id="3386292677130313581">Pytaj, zanim udostępnisz stronom swoją lokalizację (zalecane)</translation>
-<translation id="3387650086002190359">Nie udało się pobrać pliku <ph name="FILE_NAME" /> z powodu błędów systemu plików.</translation>
-<translation id="3389286852084373014">Tekst jest za długi</translation>
-<translation id="3398320232533725830">Otwórz menedżera zakładek</translation>
-<translation id="3414952576877147120">Rozmiar:</translation>
-<translation id="3443221991560634068">Ponownie załaduj bieżącą stronę</translation>
-<translation id="3445014427084483498">Przed chwilą</translation>
-<translation id="3478363558367712427">Możesz wybrać wyszukiwarkę</translation>
+<translation id="6910211073230771657">Usunięto</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Rozumiem</translation>
+<translation id="7658239707568436148">Anuluj</translation>
 <translation id="3479552764303398839">Nie teraz</translation>
-<translation id="3492207499832628349">Nowa karta incognito</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Dowiedz się więcej<ph name="END_LINK" /> o proponowanej treści</translation>
-<translation id="3513704683820682405">Rzeczywistość rozszerzona</translation>
-<translation id="3518985090088779359">Akceptuj i kontynuuj</translation>
-<translation id="3522247891732774234">Dostępna jest aktualizacja. Więcej opcji</translation>
-<translation id="3524138585025253783">Interfejs dewelopera</translation>
-<translation id="3527085408025491307">Folder</translation>
-<translation id="3542235761944717775">Dostępne: <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Przeszukaj historię</translation>
-<translation id="3557336313807607643">Dodaj do kontaktów</translation>
-<translation id="3566923219790363270">Wirtualna rzeczywistość w Chrome nie jest jeszcze gotowa. Uruchom Chrome ponownie później.</translation>
-<translation id="3568688522516854065">Aby korzystać z kart ze swoich innych urządzeń, zaloguj się i włącz synchronizację</translation>
-<translation id="3587482841069643663">Wszystkie</translation>
-<translation id="358794129225322306">Zezwól stronie na automatyczne pobieranie wielu plików.</translation>
-<translation id="3590487821116122040">Dane witryn, które Chrome uznaje za nieistotne (np. witryny, które rzadko odwiedzasz lub które nie mają zapisanych ustawień)</translation>
-<translation id="3599863153486145794">Usuwa historię ze wszystkich urządzeń, na których jesteś zalogowany. Inne rodzaje historii przeglądania mogą być nadal dostępne na Twoim koncie Google na <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Wycisz strony, które odtwarzają dźwięk</translation>
-<translation id="3616113530831147358">Dźwięk</translation>
-<translation id="3631987586758005671">Udostępniam urządzeniu <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Pokaż hasło</translation>
-<translation id="363596933471559332">Automatycznie loguj się na stronach, używając zapisanych danych logowania. Gdy ta funkcja jest wyłączona, przed każdym zalogowaniem się zobaczysz prośbę o weryfikację.</translation>
-<translation id="3658159451045945436">Resetowanie usuwa historię oszczędzania danych, w tym listę odwiedzonych stron.</translation>
-<translation id="3692944402865947621">Nie udało się pobrać pliku <ph name="FILE_NAME" /> z powodu niedostępności pamięci.</translation>
-<translation id="3714981814255182093">Otwórz pasek wyszukiwania</translation>
-<translation id="3716182511346448902">Ta strona używa zbyt dużo pamięci, dlatego została wstrzymana w Chrome.</translation>
-<translation id="3730075448226062617">Aby zezwolić Chrome na dostęp do mikrofonu, musisz też włączyć mikrofon w <ph name="BEGIN_LINK" />Ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Utworzono zakładkę w: <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Synchronizacja w tle</translation>
-<translation id="3771001275138982843">Nie udało się pobrać aktualizacji</translation>
-<translation id="3771033907050503522">Karty incognito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Włącz Bluetooth<ph name="END_LINK" />, by umożliwić parowanie</translation>
-<translation id="3775705724665058594">Wyślij na swoje urządzenia</translation>
-<translation id="3778956594442850293">Dodano do ekranu głównego</translation>
-<translation id="3789841737615482174">Zainstaluj</translation>
-<translation id="3810838688059735925">Wideo</translation>
-<translation id="3810973564298564668">Zarządzaj</translation>
-<translation id="381841723434055211">Numery telefonów</translation>
-<translation id="3819178904835489326">Usunięte pobrane pliki: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Wyczyścić dane witryn?</translation>
-<translation id="385051799172605136">Wstecz</translation>
-<translation id="3859306556332390985">Przewiń do przodu</translation>
-<translation id="3894427358181296146">Dodaj folder</translation>
-<translation id="3895926599014793903">Wymuś powiększenie</translation>
-<translation id="3912508018559818924">Szukam najlepszych treści w internecie…</translation>
-<translation id="3927692899758076493">Bezszeryfowa</translation>
-<translation id="3928666092801078803">Połącz moje dane</translation>
-<translation id="393697183122708255">Brak włączonego wyszukiwania głosowego</translation>
-<translation id="395206256282351086">Podpowiadanie stron internetowych i wyszukiwanych słów jest wyłączone</translation>
-<translation id="3955193568934677022">Zezwalaj witrynom na odtwarzanie treści chronionej (zalecane)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome wczyta stronę, gdy będzie gotowa}few{Chrome wczyta strony, gdy będą gotowe}many{Chrome wczyta strony, gdy będą gotowe}other{Chrome wczyta strony, gdy będą gotowe}}</translation>
-<translation id="3963007978381181125">Szyfrowanie hasłem nie obejmuje form płatności ani adresów w Google Pay. Twoje zaszyfrowane dane może odczytać tylko ktoś znający hasło. Google nie otrzyma Twojego hasła ani nie będzie go przechowywać. Jeśli je zapomnisz lub zechcesz zmienić to ustawienie, konieczne będzie zresetowanie synchronizacji. <ph name="BEGIN_LINK" />Więcej informacji<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Pobieranie zakończone</translation>
-<translation id="397583555483684758">Synchronizacja przestała działać</translation>
-<translation id="3976396876660209797">Usuń i utwórz ponownie ten skrót</translation>
-<translation id="3985215325736559418">Czy chcesz ponownie pobrać plik <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Kopiuj link</translation>
-<translation id="3988213473815854515">Lokalizacja jest dozwolona</translation>
-<translation id="3988466920954086464">Zobacz wyniki wyszukiwania dynamicznego w tym panelu</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Nieistotne dane</translation>
-<translation id="4000212216660919741">Ekran główny offline</translation>
+<translation id="5317780077021120954">Zapisz</translation>
+<translation id="4570913071927164677">Szczegóły</translation>
+<translation id="8730621377337864115">Gotowe</translation>
+<translation id="8261506727792406068">Usuń</translation>
+<translation id="1181037720776840403">Usuń</translation>
+<translation id="5939518447894949180">Resetuj</translation>
 <translation id="4002066346123236978">Tytuł</translation>
-<translation id="4008040567710660924">Zezwalaj na pliki cookie z określonej strony internetowej.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# godzina}few{# godziny}many{# godzin}other{# godziny}}</translation>
-<translation id="4046123991198612571">Następny utwór</translation>
-<translation id="4048707525896921369">Poznaj tematy w witrynach bez opuszczania strony. Funkcja Kliknij, by wyszukać kopiuje słowo wraz z kontekstem i wkleja je w wyszukiwarce Google. Dzięki temu otrzymujesz definicje, grafiki, wyniki wyszukiwania i inne informacje.
+<translation id="5916664084637901428">Włączone</translation>
+<translation id="5860033963881614850">Wyłączone</translation>
+<translation id="6165508094623778733">Więcej informacji</translation>
+<translation id="6042308850641462728">Więcej</translation>
+<translation id="6040143037577758943">Zamknij</translation>
+<translation id="780301667611848630">Nie, dziękuję</translation>
+<translation id="1201402288615127009">Dalej</translation>
+<translation id="2359808026110333948">Dalej</translation>
+<translation id="2653659639078652383">Prześlij</translation>
+<translation id="2079545284768500474">Cofnij</translation>
+<translation id="7649070708921625228">Pomoc</translation>
+<translation id="2148716181193084225">Dzisiaj</translation>
+<translation id="7781829728241885113">Wczoraj</translation>
+<translation id="6945221475159498467">Wybierz</translation>
+<translation id="7791543448312431591">Dodaj</translation>
+<translation id="6527303717912515753">Udostępnij</translation>
+<translation id="1383876407941801731">Szukaj</translation>
+<translation id="3115898365077584848">Pokaż informacje</translation>
+<translation id="3295602654194328831">Ukryj informacje</translation>
+<translation id="3987993985790029246">Kopiuj link</translation>
+<translation id="2704606927547763573">Skopiowane</translation>
+<translation id="8725066075913043281">Spróbuj ponownie</translation>
+<translation id="385051799172605136">Wstecz</translation>
+<translation id="8131740175452115882">Potwierdź</translation>
+<translation id="5300589172476337783">Pokaż</translation>
+<translation id="1124772482545689468">Użytkownik</translation>
+<translation id="8609465669617005112">W górę</translation>
+<translation id="6746124502594467657">W dół</translation>
+<translation id="8249310407154411074">Przenieś na początek</translation>
+<translation id="8428213095426709021">Ustawienia</translation>
+<translation id="2498359688066513246">Pomoc i opinie</translation>
+<translation id="8378714024927312812">Zarządzane przez Twoją organizację</translation>
+<translation id="9019902583201351841">Zarządzany przez Twoich rodziców</translation>
+<translation id="4645575059429386691">Zarządzany przez Twojego rodzica</translation>
+<translation id="4883854917563148705">Ustawień zarządzanych nie można zresetować</translation>
+<translation id="4307992518367153382">Podstawowe</translation>
+<translation id="1974060860693918893">Zaawansowane</translation>
+<translation id="1146678959555564648">Włącz tryb VR</translation>
+<translation id="987264212798334818">Ogólne</translation>
+<translation id="4275663329226226506">Multimedia</translation>
+<translation id="4759238208242260848">Pobrane pliki</translation>
+<translation id="218608176142494674">Udostępnianie</translation>
+<translation id="8004582292198964060">Przeglądarka</translation>
+<translation id="1105960400813249514">Zrzut ekranu</translation>
+<translation id="4875775213178255010">Polecane treści</translation>
+<translation id="2021896219286479412">Elementy sterowania stroną na pełnym ekranie</translation>
+<translation id="4587589328781138893">Witryny</translation>
+<translation id="4943703118917034429">Rzeczywistość wirtualna</translation>
+<translation id="1928696683969751773">Aktualizacje</translation>
+<translation id="6064125863973209585">Ukończenie pobierania plików</translation>
+<translation id="5342314432463739672">Prośby o uprawnienia</translation>
+<translation id="629730747756840877">Konto</translation>
+<translation id="82609232232243542">Zaloguj się w Brave</translation>
+<translation id="7956662517480676674">Synchronizacja i usługi Brave Software</translation>
+<translation id="5294439808117722387">Teraz dostosowujesz ustawienia synchronizacji i usług Brave Software. Aby zakończyć włączanie synchronizacji, na dole ekranu kliknij przycisk Potwierdź. Przejdź wyżej</translation>
+<translation id="2096012225669085171">Synchronizacja i personalizacja na urządzeniach</translation>
+<translation id="1692118695553449118">Synchronizacja jest włączona</translation>
+<translation id="5514904542973294328">Wyłączone przez administratora tego urządzenia</translation>
+<translation id="6447211988989208781">Zarządzanie aktywnością w Brave Software</translation>
+<translation id="4882831918239250449">Zarządzaj personalizacją wyszukiwarki, reklam i innych funkcji na podstawie historii przeglądania</translation>
+<translation id="7431991332293347422">Zarządzaj personalizacją wyszukiwarki i innych funkcji na podstawie historii przeglądania</translation>
+<translation id="6303969859164067831">Wyloguj się i wyłącz synchronizację</translation>
+<translation id="1125261911132334651">Zarządzaj kontem Brave Software</translation>
+<translation id="6406506848690869874">Synchronizacja</translation>
+<translation id="714362445477979774">Synchronizuj dane Brave</translation>
+<translation id="4314815835985389558">Zarządzanie synchronizacją</translation>
+<translation id="5428209950370661546">Inne usługi Brave Software</translation>
+<translation id="7704317875155739195">Autouzupełniaj wyszukiwania i adresy URL</translation>
+<translation id="2000419248597011803">Niektóre pliki cookie oraz zapytania wpisane na pasku adresu i w polu wyszukiwania zostaną wysłane do domyślnej wyszukiwarki</translation>
+<translation id="7981313251711023384">Ładuj wstępnie strony, by przyspieszyć przeglądanie i wyszukiwanie</translation>
+<translation id="1821253160463689938">Twoje ustawienia będą zapisywane w plikach cookie, nawet jeśli nie odwiedzisz tych stron</translation>
+<translation id="6697492270171225480">Gdy nie można odnaleźć strony, pokazuj sugestie podobnych stron</translation>
+<translation id="8109318360573330108">Adres URL strony, którą próbujesz otworzyć, zostanie wysłany do Brave Software</translation>
+<translation id="8438566539970814960">Ulepsz wyszukiwanie i przeglądanie</translation>
+<translation id="284843628681142937">Adresy URL odwiedzanych stron będą wysyłane do Brave Software</translation>
+<translation id="7222718784508482526">Więcej ustawień związanych z prywatnością, bezpieczeństwem i zbieraniem danych znajdziesz w sekcji <ph name="BEGIN_LINK"/>Synchronizacja i usługi Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Pomóż w ulepszaniu funkcji i działania Brave</translation>
+<translation id="9063160602596686558">Automatycznie przesyła do Brave Software statystyki użytkowania i raporty o awariach</translation>
+<translation id="4824958205181053313">Anulować synchronizację?</translation>
+<translation id="3058498974290601450">W każdej chwili możesz włączyć synchronizację w ustawieniach</translation>
+<translation id="3143515551205905069">Anuluj synchronizację</translation>
+<translation id="1506061864768559482">Wyszukiwarka</translation>
+<translation id="55737423895878184">Lokalizacja i powiadomienia są włączone</translation>
+<translation id="3988213473815854515">Lokalizacja jest dozwolona</translation>
+<translation id="32895400574683172">Powiadomienia są włączone</translation>
+<translation id="9040142327097499898">Powiadomienia są włączone. Lokalizacja jest wyłączona na tym urządzeniu.</translation>
+<translation id="305593374596241526">Lokalizacja jest wyłączona. Włącz ją w <ph name="BEGIN_LINK"/>Ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Ostatnio odwiedzone</translation>
+<translation id="6433501201775827830">Wybierz wyszukiwarkę</translation>
+<translation id="7177466738963138057">Możesz zmienić to później w Ustawieniach</translation>
+<translation id="3478363558367712427">Możesz wybrać wyszukiwarkę</translation>
+<translation id="4910889077668685004">Aplikacje do płatności</translation>
+<translation id="5152843274749979095">Nie zainstalowano obsługiwanych aplikacji</translation>
+<translation id="8812260976093120287">Używając swojego urządzenia, na niektórych stronach możesz płacić za pomocą powyższych obsługiwanych aplikacji do płatności.</translation>
+<translation id="7764225426217299476">Dodaj adres</translation>
+<translation id="5595485650161345191">Edytuj adres</translation>
+<translation id="5087580092889165836">Dodaj kartę</translation>
+<translation id="2154484045852737596">Edytowanie karty</translation>
+<translation id="6140912465461743537">Kraj/region</translation>
+<translation id="5659593005791499971">E-mail</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Imię i nazwisko na karcie</translation>
+<translation id="860043288473659153">Imię i nazwisko posiadacza karty</translation>
+<translation id="2612676031748830579">Numer karty</translation>
+<translation id="869891660844655955">Data wygaśnięcia</translation>
+<translation id="2286841657746966508">Adres rozliczeniowy</translation>
+<translation id="663059986967017181">Skopiowana do Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}few{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}many{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}many{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}few{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}many{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}few{<ph name="CONTACT_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}many{<ph name="CONTACT_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Hasła</translation>
+<translation id="1943432128510653496">Zapisuj hasła</translation>
+<translation id="2100273922101894616">Automatyczne logowanie</translation>
+<translation id="363596933471559332">Automatycznie loguj się na stronach, używając zapisanych danych logowania. Gdy ta funkcja jest wyłączona, przed każdym zalogowaniem się zobaczysz prośbę o weryfikację.</translation>
+<translation id="6995899638241819463">Ostrzegaj, jeśli wskutek naruszenia bezpieczeństwa danych doszło do ujawnienia haseł</translation>
+<translation id="1534287762301776620">Ta funkcja zostanie włączona, gdy zalogujesz się na swoje konto Brave Software</translation>
+<translation id="10614374240317010">Nigdy nie zapisane</translation>
+<translation id="3098842761938485917">Zapisane hasła znajdziesz na swoim <ph name="BEGIN_LINK"/>koncie Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Tutaj pojawią się zapisane hasła.</translation>
+<translation id="8084114998886531721">Zapisane hasło</translation>
+<translation id="2870560284913253234">Witryna</translation>
+<translation id="8503813439785031346">Nazwa użytkownika</translation>
+<translation id="6657585470893396449">Hasło</translation>
+<translation id="2154710561487035718">Kopiuj adres URL</translation>
+<translation id="1571304935088121812">Kopiuj nazwę użytkownika</translation>
+<translation id="5005498671520578047">Skopiuj hasło</translation>
+<translation id="3632295766818638029">Pokaż hasło</translation>
+<translation id="1513858653616922153">Usuń hasło</translation>
+<translation id="543338862236136125">Edytuj hasło</translation>
+<translation id="4565377596337484307">Ukryj hasło</translation>
+<translation id="8523928698583292556">Usuń zapisane hasło</translation>
+<translation id="2898264748040935573">Edytuj zapisane hasło</translation>
+<translation id="5433691172869980887">Nazwa użytkownika została skopiowana</translation>
+<translation id="5534640966246046842">Strona została skopiowana</translation>
+<translation id="2625189173221582860">Hasło zostało skopiowane</translation>
+<translation id="4550003330909367850">Aby wyświetlić lub skopiować hasło, ustaw blokadę ekranu na urządzeniu.</translation>
+<translation id="6154478581116148741">Włącz blokadę ekranu w ustawieniach, by wyeksportować hasła z urządzenia</translation>
+<translation id="4842092870884894799">Pokazuję wyskakujące okienko generowania hasła</translation>
+<translation id="2259659629660284697">Eksportuj hasła…</translation>
+<translation id="133012818630824069">Eksportuj hasła zapisane w Brave</translation>
+<translation id="6914783257214138813">Twoje hasła będą widoczne dla każdego, kto może zobaczyć wyeksportowany plik.</translation>
+<translation id="2321086116217818302">Przygotowuję hasła…</translation>
+<translation id="8445448999790540984">Nie można wyeksportować haseł</translation>
+<translation id="3066461326500799725">Dowiedz się, jak używać Dysku Brave Software</translation>
+<translation id="729975465115245577">Na urządzeniu nie ma aplikacji umożliwiającej zapisanie pliku z hasłami.</translation>
+<translation id="7682724950699840886">Skorzystaj z tych wskazówek: upewnij się, że masz wystarczająco dużo miejsca na urządzeniu, i ponownie spróbuj wyeksportować hasła.</translation>
+<translation id="1129510026454351943">Szczegóły: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Odblokuj, by skopiować hasło</translation>
+<translation id="5515439363601853141">Odblokuj, by wyświetlić hasło</translation>
+<translation id="6221633008163990886">Odblokuj, by wyeksportować hasła</translation>
+<translation id="230699814587342492">Hasła w Brave</translation>
+<translation id="6075798973483050474">Edytuj stronę główną</translation>
+<translation id="854522910157234410">Otwórz tę stronę</translation>
+<translation id="2482878487686419369">Powiadomienia</translation>
+<translation id="6255999984061454636">Polecane treści</translation>
+<translation id="805047784848435650">Na podstawie Twojej historii przeglądania</translation>
+<translation id="1041308826830691739">Ze stron internetowych</translation>
+<translation id="395206256282351086">Podpowiadanie stron internetowych i wyszukiwanych słów jest wyłączone</translation>
+<translation id="257088987046510401">Motywy</translation>
+<translation id="4650364565596261010">Ustawienie domyślne</translation>
+<translation id="7588219262685291874">Włącz tryb ciemny, gdy na urządzeniu jest aktywne oszczędzanie baterii</translation>
+<translation id="2760989362628427051">Włącz tryb ciemny, gdy urządzenie ma włączony tryb ciemny lub oszczędzanie baterii</translation>
+<translation id="6381421346744604172">Przyciemnij strony internetowe</translation>
+<translation id="5040262127954254034">Prywatność</translation>
+<translation id="4991384657077828949">Pomóż zwiększyć bezpieczeństwo Brave</translation>
+<translation id="1943176487615318915">Aby wykrywać niebezpieczne aplikacje i witryny, Brave wysyła do Brave Software adresy URL i część zawartości niektórych odwiedzanych przez Ciebie stron, a także niektóre informacje o systemie</translation>
+<translation id="3181954750937456830">Bezpieczne przeglądanie (chroni Ciebie i Twoje urządzenie przed niebezpiecznymi witrynami)</translation>
+<translation id="7315322926489145388">Gdy Twoje bezpieczeństwo jest zagrożone, wysyła do Brave Software adresy URL odwiedzanych stron</translation>
+<translation id="2063713494490388661">Kliknij, by wyszukać</translation>
+<translation id="2369463299479365221">Poznaj tematy w witrynach bez opuszczania strony. Funkcja Kliknij, by wyszukać kopiuje słowo wraz z kontekstem i wkleja je w wyszukiwarce Brave Software. Dzięki temu otrzymujesz definicje, grafiki, wyniki wyszukiwania i inne informacje.
 
 Jeśli chcesz dostosować wyszukiwane hasło, naciśnij je i przytrzymaj, by je zaznaczyć. Aby doprecyzować wyszukiwanie, przesuń panel do samej góry i kliknij pole wyszukiwania.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Opcje dostępne na górze ekranu</translation>
-<translation id="4062305924942672200">Informacje prawne</translation>
-<translation id="4084682180776658562">Dodaj do zakładek</translation>
-<translation id="4084712963632273211">Opublikowane na <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />wyświetlone przez Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Usunąć dane aplikacji?</translation>
-<translation id="4099578267706723511">Pomóż ulepszyć Chrome, wysyłając do Google statystyki użytkowania i raporty o awariach.</translation>
-<translation id="410351446219883937">Autoodtwarzanie</translation>
-<translation id="4116038641877404294">Pobierz strony, by przeglądać je w trybie offline</translation>
-<translation id="4135200667068010335">Lista urządzeń, którym udostępnisz kartę, jest zamknięta.</translation>
-<translation id="4149994727733219643">Uproszczony widok stron internetowych</translation>
-<translation id="4165986682804962316">Ustawienia witryn</translation>
-<translation id="4169535189173047238">Nie zezwalaj</translation>
-<translation id="4170011742729630528">Usługa jest niedostępna. Spróbuj ponownie później.</translation>
-<translation id="4179980317383591987">Wykorzystano <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Języki</translation>
-<translation id="4183868528246477015">Szukaj z Obiektywem Google <ph name="BEGIN_NEW" />Nowość<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Otwórz w nowej karcie</translation>
-<translation id="4198423547019359126">Brak dostępnych miejsc zapisu pobieranych plików</translation>
-<translation id="4209895695669353772">Aby uzyskać dostęp do spersonalizowanej treści proponowanej przez Google, włącz synchronizację</translation>
-<translation id="4226663524361240545">Powiadomienia będą sygnalizowane wibracjami</translation>
-<translation id="423219824432660969">Zaszyfruj synchronizowane dane hasłem Google z <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Otwórz ustawienia</translation>
-<translation id="4256782883801055595">Licencje open source</translation>
-<translation id="4259722352634471385">Adres zablokowany: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopiuj adres linku</translation>
-<translation id="4275663329226226506">Multimedia</translation>
-<translation id="4278390842282768270">Dopuszczone</translation>
-<translation id="429312253194641664">Strona odtwarza multimedia</translation>
-<translation id="4298388696830689168">Połączone strony</translation>
-<translation id="4307992518367153382">Podstawowe</translation>
-<translation id="4314815835985389558">Zarządzanie synchronizacją</translation>
-<translation id="4351244548802238354">Zamknij okno</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Korzystam z wyszukiwarki Sogou</translation>
-<translation id="4404568932422911380">Brak zakładek</translation>
-<translation id="4405224443901389797">Przenieś do…</translation>
-<translation id="4411535500181276704">Wersja uproszczona</translation>
-<translation id="4415276339145661267">Zarządzaj kontem Google</translation>
-<translation id="4432792777822557199">Od teraz strony, których językiem jest <ph name="SOURCE_LANGUAGE" />, będą tłumaczone na <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Lżejsza wersja strony dostarczona przez Google</translation>
-<translation id="4434045419905280838">Pop-upy i przekierowania</translation>
-<translation id="4440958355523780886">Lżejsza wersja strony dostarczona przez Google. Kliknij, by załadować wersję oryginalną.</translation>
-<translation id="4452411734226507615">Zamknij kartę <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Utworzono zakładkę w folderze <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Zezwalaj stronom na odtwarzanie treści chronionych</translation>
-<translation id="4468959413250150279">Wycisz dźwięk na konkretnej stronie.</translation>
-<translation id="4472118726404937099">Aby synchronizować i personalizować wszystkie swoje urządzenia, zaloguj się i włącz synchronizację</translation>
-<translation id="447252321002412580">Pomóż w ulepszaniu funkcji i działania Chrome</translation>
-<translation id="4479647676395637221">Pytaj, zanim zezwolisz stronom na korzystanie z kamery (zalecane)</translation>
-<translation id="4479972344484327217">Instaluję moduł <ph name="MODULE" /> do Chrome…</translation>
-<translation id="4487967297491345095">Wszystkie dane aplikacji Chrome zostaną trwale usunięte. Dotyczy to wszystkich plików, ustawień, kont, baz danych itp.</translation>
-<translation id="4493497663118223949">Wersja uproszczona jest włączona</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# dzień temu}few{# dni temu}many{# dni temu}other{# dnia temu}}</translation>
-<translation id="451872707440238414">Szukaj zakładek</translation>
-<translation id="4521489764227272523">Wybrane dane zostały usunięte z Chrome i ze zsynchronizowanych urządzeń.
-
-Na stronie <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> na Twoim koncie Google mogą być zapisane inne rodzaje historii przeglądania, takie jak wyszukiwania lub aktywność z innych usług Google.</translation>
-<translation id="4532845899244822526">Wybierz folder</translation>
-<translation id="4538018662093857852">Włącz wersję uproszczoną</translation>
-<translation id="4550003330909367850">Aby wyświetlić lub skopiować hasło, ustaw blokadę ekranu na urządzeniu.</translation>
-<translation id="4558311620361989323">Skróty stron internetowych</translation>
-<translation id="4561979708150884304">Brak połączenia</translation>
-<translation id="4565377596337484307">Ukryj hasło</translation>
-<translation id="4570913071927164677">Szczegóły</translation>
-<translation id="4572422548854449519">Zaloguj się na konto zarządzane</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minutę temu}few{# minuty temu}many{# minut temu}other{# minuty temu}}</translation>
-<translation id="4587589328781138893">Witryny</translation>
-<translation id="4594952190837476234">Ta strona offline jest z <ph name="CREATION_TIME" /> i może różnić się od wersji online.</translation>
-<translation id="4605958867780575332">Usunięto element: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Otwórz <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Użyj hasła</translation>
-<translation id="4645575059429386691">Zarządzany przez Twojego rodzica</translation>
-<translation id="4650364565596261010">Ustawienie domyślne</translation>
-<translation id="4663756553811254707">Usunięte zakładki: <ph name="NUMBER_OF_BOOKMARKS" /></translation>
-<translation id="4665282149850138822">Strona <ph name="NAME" /> została dodana do ekranu głównego</translation>
-<translation id="4684427112815847243">Synchronizuj wszystko</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}few{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}many{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Wyślij tekst na swoje urządzenia</translation>
-<translation id="4698034686595694889">Zobacz offline w <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Obrazy i pliki zapisane w pamięci podręcznej</translation>
-<translation id="4714588616299687897">Zaoszczędź nawet 60% na transmisji danych</translation>
-<translation id="4719927025381752090">Proponuj tłumaczenie</translation>
-<translation id="4720023427747327413">Otwórz w: <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Pomóż w ulepszaniu Chrome. <ph name="BEGIN_LINK" />Wypełnij ankietę<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Aktualizuj</translation>
-<translation id="4738836084190194332">Ostatnia synchronizacja: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Otwórz nową kartę</translation>
-<translation id="4751476147751820511">Czujniki ruchu lub światła</translation>
-<translation id="4759238208242260848">Pobrane pliki</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Ukończono pobieranie 1 pliku.}few{Ukończono pobieranie # plików.}many{Ukończono pobieranie # plików.}other{Ukończono pobieranie # pliku.}}</translation>
-<translation id="4797039098279997504">Kliknij, by wrócić na <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Szyfrowanie hasłem nie obejmuje form płatności ani adresów w Google Pay.
-
-Aby zmienić to ustawienie, <ph name="BEGIN_LINK" />zresetuj synchronizację<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Imię i nazwisko na karcie</translation>
-<translation id="4824958205181053313">Anulować synchronizację?</translation>
-<translation id="4837753911714442426">Otwórz opcje drukowania strony</translation>
-<translation id="4842092870884894799">Pokazuję wyskakujące okienko generowania hasła</translation>
-<translation id="4860895144060829044">Zadzwoń</translation>
-<translation id="4866368707455379617">Nie można zainstalować modułu <ph name="MODULE" /> do Chrome</translation>
-<translation id="4875775213178255010">Polecane treści</translation>
-<translation id="4878404682131129617">Nie udało się utworzyć tunelu przez serwer proxy</translation>
-<translation id="4880127995492972015">Przetłumacz…</translation>
-<translation id="4881695831933465202">Otwórz</translation>
-<translation id="488187801263602086">Zmień nazwę pliku</translation>
-<translation id="4882831918239250449">Zarządzaj personalizacją wyszukiwarki, reklam i innych funkcji na podstawie historii przeglądania</translation>
-<translation id="4883854917563148705">Ustawień zarządzanych nie można zresetować</translation>
-<translation id="4885273946141277891">Nieobsługiwana liczba wystąpień Chrome.</translation>
-<translation id="4910889077668685004">Aplikacje do płatności</translation>
-<translation id="4913161338056004800">Resetuj statystyki</translation>
-<translation id="4913169188695071480">Zatrzymaj odświeżanie</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Pomoc<ph name="END_LINK" /> w trakcie wyszukiwania urządzeń…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# strona}few{# strony}many{# stron}other{# strony}}</translation>
-<translation id="4932247056774066048">Wylogowujesz się z konta zarządzanego w domenie <ph name="DOMAIN_NAME" />, więc Twoje dane w Chrome zostaną usunięte z tego urządzenia. Pozostaną one na Twoim koncie Google.</translation>
-<translation id="4943703118917034429">Rzeczywistość wirtualna</translation>
-<translation id="4943872375798546930">Brak wyników</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> udostępnia Twój ekran</translation>
-<translation id="4961107849584082341">Możesz przetłumaczyć tę stronę na dowolny język</translation>
-<translation id="4962975101802056554">Anuluj wszystkie uprawnienia urządzenia</translation>
-<translation id="4970824347203572753">Funkcja niedostępna w Twojej lokalizacji</translation>
-<translation id="497421865427891073">Dalej</translation>
-<translation id="4988210275050210843">Pobieram plik (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Strony</translation>
-<translation id="4994033804516042629">Nie znaleziono kontaktów</translation>
-<translation id="4996978546172906250">Udostępnij przez</translation>
-<translation id="5004416275253351869">Zarządzanie aktywnością w Google</translation>
-<translation id="5005498671520578047">Skopiuj hasło</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> chce się połączyć</translation>
-<translation id="5013696553129441713">Brak nowych sugestii</translation>
-<translation id="5016205925109358554">Szeryfowa</translation>
-<translation id="5033865233969348410">Gdy używasz VR, ta strona może poznać te informacje:
-  –  Twoje cechy fizyczne, np. wzrost.
-
-Zanim włączysz VR na tej stronie, sprawdź, czy można uznać ją za zaufaną.</translation>
+<translation id="2930742481329940825">Funkcja Kliknij, by wyszukać wysyła zaznaczone słowo i bieżącą stronę jako kontekst do wyszukiwarki Brave Software. Możesz ją wyłączyć w <ph name="BEGIN_LINK"/>ustawieniach<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Zezwalaj</translation>
-<translation id="5040262127954254034">Prywatność</translation>
-<translation id="5048398596102334565">Zezwalaj stronom na dostęp do czujników ruchu (zalecane)</translation>
-<translation id="5063480226653192405">Wykorzystanie</translation>
-<translation id="5087580092889165836">Dodaj kartę</translation>
-<translation id="5100237604440890931">Zwinięty – kliknij, by rozwinąć.</translation>
-<translation id="510275257476243843">Pozostała godzina</translation>
-<translation id="5123685120097942451">Karta incognito</translation>
-<translation id="5127805178023152808">Synchronizacja jest wyłączona</translation>
-<translation id="5129038482087801250">Zainstaluj aplikację internetową</translation>
-<translation id="5132942445612118989">Synchronizuj swoje hasła, historię i inne dane na wszystkich swoich urządzeniach</translation>
-<translation id="5139940364318403933">Dowiedz się, jak używać Dysku Google</translation>
-<translation id="515227803646670480">Wyczyść zapisane dane</translation>
-<translation id="5152843274749979095">Nie zainstalowano obsługiwanych aplikacji</translation>
-<translation id="5161254044473106830">Tytuł jest wymagany</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Nie udało się pobrać 1 pliku.}few{Nie udało się pobrać # plików.}many{Nie udało się pobrać # plików.}other{Nie udało się pobrać # pliku.}}</translation>
-<translation id="5170568018924773124">Pokaż w folderze</translation>
-<translation id="5184329579814168207">Otwórz w Chrome</translation>
-<translation id="5193988420012215838">Skopiowane do schowka</translation>
-<translation id="5197729504361054390">Wybrane kontakty zostaną udostępnione witrynie <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Profil służbowy</translation>
-<translation id="5210286577605176222">Przejdź do poprzedniej karty</translation>
-<translation id="5210365745912300556">Zamknij kartę</translation>
-<translation id="5224771365102442243">Z wideo</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> chce wyszukać urządzenia Bluetooth w pobliżu. Znaleziono te urządzenia:</translation>
-<translation id="5233638681132016545">Nowa karta</translation>
-<translation id="526421993248218238">Nie udało się wczytać tej strony</translation>
-<translation id="5271967389191913893">Na tym urządzeniu nie można otworzyć treści, które chcesz pobrać.</translation>
-<translation id="528192093759286357">Przeciągnij od góry i kliknij przycisk Wstecz, by wyjść z trybu pełnoekranowego.</translation>
-<translation id="5292796745632149097">Wyślij na</translation>
-<translation id="5300589172476337783">Pokaż</translation>
-<translation id="5301954838959518834">Rozumiem</translation>
-<translation id="5304593522240415983">To pole nie może być puste</translation>
-<translation id="5307446750509046227">Wyczyść dane witryn</translation>
-<translation id="5308380583665731573">Połącz</translation>
-<translation id="5313967007315987356">Dodaj stronę</translation>
-<translation id="5317780077021120954">Zapisz</translation>
-<translation id="5324858694974489420">Ustawienia rodzicielskie</translation>
-<translation id="5327248766486351172">Nazwa</translation>
-<translation id="5335288049665977812">Zezwalaj na wykonywanie kodu JavaScript w witrynach (zalecane)</translation>
-<translation id="5342314432463739672">Prośby o uprawnienia</translation>
-<translation id="5357811892247919462">Odebrano kartę</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> otwarta karta. Kliknij, by przełączyć się między kartami}few{<ph name="OPEN_TABS_MANY" /> otwarte karty. Kliknij, by przełączyć się między kartami}many{<ph name="OPEN_TABS_MANY" /> otwartych kart. Kliknij, by przełączyć się między kartami}other{<ph name="OPEN_TABS_MANY" /> otwartej karty. Kliknij, by przełączyć się między kartami}}</translation>
-<translation id="5391532827096253100">Twoje połączenie z tą witryną nie jest bezpieczne. Informacje o witrynie</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(i jeszcze 1)}few{(i jeszcze #)}many{(i jeszcze #)}other{(i jeszcze #)}}</translation>
-<translation id="5400569084694353794">Korzystając z tej aplikacji, akceptujesz <ph name="BEGIN_LINK1" />Warunki korzystania z Chrome<ph name="END_LINK1" /> oraz <ph name="BEGIN_LINK2" />Informacje na temat ochrony prywatności w Chrome<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Nazwy</translation>
-<translation id="5403644198645076998">Pozwól na otwieranie tylko wybranych stron</translation>
-<translation id="5414836363063783498">Weryfikuję…</translation>
-<translation id="5423934151118863508">Tu pojawią się strony, na które najczęściej wchodzisz</translation>
-<translation id="5424588387303617268">Dostępne <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Edytuj hasło</translation>
-<translation id="5433691172869980887">Nazwa użytkownika została skopiowana</translation>
-<translation id="543509235395288790">Pobieram pliki: <ph name="COUNT" /> (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Przejdź do paska adresu</translation>
-<translation id="5447201525962359567">Wszystkie dane witryn, w tym pliki cookie i inne dane lokalne</translation>
-<translation id="5447765697759493033">Ta strona nie zostanie przetłumaczona</translation>
-<translation id="545042621069398927">Przyspieszam pobieranie.</translation>
-<translation id="5456381639095306749">Pobierz stronę</translation>
-<translation id="5475862044948910901">Rozpocząć sesję rzeczywistości rozszerzonej?</translation>
-<translation id="548278423535722844">Otwórz w aplikacji z mapami</translation>
-<translation id="5487521232677179737">Wyczyść dane</translation>
-<translation id="5494752089476963479">Blokuj reklamy na stronach, które wyświetlają reklamy uciążliwe lub wprowadzające w błąd</translation>
-<translation id="5500777121964041360">Funkcja może być niedostępna w Twojej lokalizacji</translation>
-<translation id="5512137114520586844">Tym kontem zarządza <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Wyłączone przez administratora tego urządzenia</translation>
-<translation id="5515439363601853141">Odblokuj, by wyświetlić hasło</translation>
-<translation id="5516455585884385570">Otwórz ustawienia powiadomień</translation>
-<translation id="5517095782334947753">Masz zakładki, historię, hasła i inne ustawienia z konta <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Przekierowanie zostało zablokowane.</translation>
-<translation id="5527082711130173040">Aby wyszukać urządzenia, Chrome potrzebuje dostępu do lokalizacji. <ph name="BEGIN_LINK1" />Zwiększ uprawnienia<ph name="END_LINK1" />. Dostęp do lokalizacji jest <ph name="BEGIN_LINK2" />wyłączony na tym urządzeniu<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Pytaj, czy zezwolić stronom na odczytywanie tekstu i obrazów ze schowka (zalecane)</translation>
-<translation id="5530766185686772672">Zamknij karty incognito</translation>
-<translation id="5534334044554683961">Gdy używasz VR, ta strona może poznać te informacje:
-  –   Twoje cechy fizyczne, np wzrost;
-  –   układ Twojego pokoju.
-
-Zanim włączysz VR na tej stronie, sprawdź, czy można uznać ją za zaufaną.</translation>
-<translation id="5534640966246046842">Strona została skopiowana</translation>
-<translation id="5556459405103347317">Odśwież</translation>
-<translation id="5561549206367097665">Czekam na sieć…</translation>
-<translation id="557283862590186398">Chrome potrzebuje uprawnień dostępu do mikrofonu na tej stronie.</translation>
-<translation id="55737423895878184">Lokalizacja i powiadomienia są włączone</translation>
-<translation id="5578795271662203820">Szukaj tej grafiki w <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">W <ph name="BEGIN_LINK1" />ustawieniach<ph name="END_LINK1" /> możesz wybrać, co chcesz synchronizować.</translation>
-<translation id="5595485650161345191">Edytuj adres</translation>
-<translation id="5596627076506792578">Więcej opcji</translation>
-<translation id="5599455543593328020">Tryb incognito</translation>
-<translation id="5620928963363755975">Znajdź pliki i strony w Pobranych plikach, używając przycisku Więcej opcji</translation>
-<translation id="5626134646977739690">Nazwa:</translation>
-<translation id="5639724618331995626">Pozwól na otwieranie wszystkich stron</translation>
-<translation id="5648166631817621825">Ostatnie 7 dni</translation>
-<translation id="5649053991847567735">Pobieranie automatyczne</translation>
-<translation id="5655963694829536461">Przeszukaj pobrane pliki</translation>
-<translation id="5659593005791499971">E-mail</translation>
-<translation id="5665379678064389456">Utwórz wydarzenie w aplikacji <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Zignoruj żądanie strony, gdy chce zapobiec powiększeniu widoku</translation>
-<translation id="5677928146339483299">Zablokowane</translation>
-<translation id="5684874026226664614">Nie można przetłumaczyć tej strony.</translation>
-<translation id="5686790454216892815">Nazwa pliku jest za długa</translation>
-<translation id="5689516760719285838">Lokalizacja</translation>
-<translation id="569536719314091526">Możesz przetłumaczyć tę stronę na dowolny język, używając przycisku Więcej opcji</translation>
-<translation id="572328651809341494">Ostatnie karty</translation>
-<translation id="5726692708398506830">Powiększ całą zawartość strony</translation>
-<translation id="5748802427693696783">Przełączono na karty standardowe</translation>
-<translation id="5749068826913805084">Chrome musi mieć dostęp do pamięci, by pobierać pliki.</translation>
-<translation id="5763382633136178763">Karty incognito</translation>
-<translation id="5763514718066511291">Kliknij, by skopiować URL tej aplikacji</translation>
-<translation id="5765780083710877561">Opis:</translation>
-<translation id="5793665092639000975">Zajmują <ph name="SPACE_USED" /> z <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google może korzystać z Twojej historii, by personalizować wyniki wyszukiwania, reklamy i działanie innych usług</translation>
-<translation id="5804241973901381774">Uprawnienia</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# godzinę temu}few{# godziny temu}many{# godzin temu}other{# godziny temu}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Wszelkie prawa zastrzeżone.</translation>
-<translation id="5817918615728894473">Sparuj</translation>
-<translation id="583281660410589416">Nieznany</translation>
-<translation id="5833984609253377421">Udostępnij link</translation>
-<translation id="5836192821815272682">Pobieram aktualizację Chrome…</translation>
-<translation id="5853623416121554550">Wstrzymano</translation>
-<translation id="5854790677617711513">Sprzed ponad 30 dni</translation>
-<translation id="5858741533101922242">Chrome nie może włączyć adaptera Bluetooth</translation>
-<translation id="5860033963881614850">Wyłączone</translation>
-<translation id="5862731021271217234">Aby korzystać z kart ze swoich innych urządzeń, włącz synchronizację</translation>
-<translation id="5864174910718532887">Szczegóły: posortowane według nazwy witryny</translation>
-<translation id="5864419784173784555">Czekam na inny plik do pobrania…</translation>
-<translation id="5865733239029070421">Automatycznie przesyła do Google statystyki użytkowania i raporty o awariach</translation>
-<translation id="5869522115854928033">Zapisane hasła</translation>
-<translation id="5902828464777634901">Wszystkie dane lokalne zapisane przez tę witrynę (w tym pliki cookie) zostaną usunięte.</translation>
-<translation id="5916664084637901428">Włączone</translation>
-<translation id="5919204609460789179">Zaktualizuj przeglądarkę <ph name="PRODUCT_NAME" />, by rozpocząć synchronizację</translation>
-<translation id="5937580074298050696">Zaoszczędzono <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Resetuj</translation>
-<translation id="5942872142862698679">Korzystam z wyszukiwarki Google</translation>
-<translation id="5952764234151283551">Adres URL strony, którą próbujesz otworzyć, zostanie wysłany do Google</translation>
-<translation id="5956665950594638604">Otwórz Centrum pomocy Chrome w nowej karcie</translation>
-<translation id="5958275228015807058">Znajdź pliki i strony w Pobranych plikach</translation>
-<translation id="5962718611393537961">Kliknij, by zwinąć</translation>
-<translation id="6000066717592683814">Zachowaj Google</translation>
-<translation id="6005538289190791541">Proponowane hasło</translation>
-<translation id="6036057147555329831">Dodatkowy moduł ICU</translation>
-<translation id="6039379616847168523">Przejdź do następnej karty</translation>
-<translation id="6040143037577758943">Zamknij</translation>
-<translation id="6042308850641462728">Więcej</translation>
-<translation id="604996488070107836">Nie udało się pobrać pliku <ph name="FILE_NAME" /> z powodu nieznanego błędu.</translation>
-<translation id="605721222689873409">RR</translation>
-<translation id="6064125863973209585">Ukończenie pobierania plików</translation>
-<translation id="6075798973483050474">Edytuj stronę główną</translation>
-<translation id="60923314841986378">Pozostało: <ph name="HOURS" /> godz.</translation>
-<translation id="6108923351542677676">Trwa konfigurowanie…</translation>
-<translation id="6111020039983847643">użytych danych</translation>
-<translation id="6112702117600201073">Odświeżam stronę</translation>
-<translation id="6127379762771434464">Element został usunięty</translation>
-<translation id="6140912465461743537">Kraj/region</translation>
-<translation id="614940544461990577">Wypróbuj te rozwiązania:</translation>
-<translation id="6154478581116148741">Włącz blokadę ekranu w ustawieniach, by wyeksportować hasła z urządzenia</translation>
-<translation id="6159335304067198720">Oszczędność danych: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Więcej informacji</translation>
-<translation id="6177111841848151710">Zablokowano dostęp obecnej wyszukiwarce</translation>
-<translation id="6181444274883918285">Dodaj witrynę do wyjątków</translation>
-<translation id="6192333916571137726">Pobranie pliku</translation>
-<translation id="6192792657125177640">Wyjątki</translation>
-<translation id="6194112207524046168">Aby zezwolić Chrome na dostęp do aparatu, musisz też włączyć aparat w <ph name="BEGIN_LINK" />Ustawieniach Androida<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokuj pliki cookie innych firm</translation>
-<translation id="6206551242102657620">Połączenie jest bezpieczne. Informacje o witrynie</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> to nie Ty?</translation>
-<translation id="6221633008163990886">Odblokuj, by wyeksportować hasła</translation>
+<translation id="1406000523432664303">„Bez śledzenia”</translation>
 <translation id="6232535412751077445">Włączenie opcji „Bez śledzenia” oznacza, że podczas przeglądania będzie wysyłane żądanie. Jego wynik zależy od tego, czy strona na nie odpowie oraz jak zostanie ono zinterpretowane.
 
 Na przykład niektóre strony mogą na nie zareagować, wyświetlając reklamy bez związku ze stronami odwiedzonymi przez Ciebie wcześniej. Wiele stron będzie nadal gromadzić dane przeglądania i używać ich na przykład do poprawy bezpieczeństwa, pokazywania treści, reklam i rekomendacji oraz do generowania statystyk.</translation>
-<translation id="624789221780392884">Aktualizacja jest gotowa</translation>
-<translation id="6255999984061454636">Polecane treści</translation>
-<translation id="6277522088822131679">Podczas drukowania strony wystąpił problem. Spróbuj ponownie.</translation>
-<translation id="6295158916970320988">Wszystkie witryny</translation>
-<translation id="629730747756840877">Konto</translation>
-<translation id="6303969859164067831">Wyloguj się i wyłącz synchronizację</translation>
-<translation id="6316139424528454185">Ta wersja Androida jest nieobsługiwana</translation>
-<translation id="6320088164292336938">Wibracje</translation>
-<translation id="6324034347079777476">Synchronizacja systemu Android jest wyłączona</translation>
-<translation id="6333140779060797560">Udostępnij przez: <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Szyfrowanie</translation>
-<translation id="6341580099087024258">Pytaj, gdzie zapisać pliki</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}few{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}many{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Usunąć sugestię z historii?</translation>
-<translation id="6369229450655021117">Tutaj możesz wyszukiwać informacje w internecie, udostępniać treści znajomym i przeglądać otwarte strony</translation>
-<translation id="6378173571450987352">Szczegóły: posortowane według wykorzystanych danych</translation>
-<translation id="6381421346744604172">Przyciemnij strony internetowe</translation>
-<translation id="6388207532828177975">Wyczyść i zresetuj</translation>
-<translation id="6393863479814692971">Chrome potrzebuje uprawnień dostępu do aparatu i mikrofonu na tej stronie.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Edytuj zakładkę</translation>
-<translation id="6406506848690869874">Synchronizacja</translation>
-<translation id="641643625718530986">Drukuj…</translation>
-<translation id="6416782512398055893">Pobrano <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Tłumacz internet</translation>
-<translation id="6433501201775827830">Wybierz wyszukiwarkę</translation>
-<translation id="6437478888915024427">Informacje o stronie</translation>
-<translation id="6441734959916820584">Nazwa jest zbyt długa</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# obraz}few{# obrazy}many{# obrazów}other{# obrazu}}</translation>
-<translation id="6447842834002726250">Pliki cookie</translation>
-<translation id="6461962085415701688">Nie można otworzyć pliku</translation>
-<translation id="6464977750820128603">Możesz wyświetlić strony otwierane w Chrome i ustawić dla nich liczniki czasu.\n\nGoogle otrzymuje informacje o stronach, dla których masz ustawione liczniki czasu, i o tym, jak długo je przeglądasz. Używamy tych informacji do udoskonalania Cyfrowej równowagi.</translation>
-<translation id="6475951671322991020">Pobierz film</translation>
-<translation id="6482749332252372425">Nie udało się pobrać pliku <ph name="FILE_NAME" /> z powodu braku miejsca.</translation>
-<translation id="6496823230996795692">Aby pierwszy raz skorzystać z aplikacji <ph name="APP_NAME" />, połącz się z internetem.</translation>
-<translation id="6508722015517270189">Uruchom ponownie Chrome</translation>
-<translation id="6527303717912515753">Udostępnij</translation>
-<translation id="6532866250404780454">Strony, które otwierasz w Chrome, nie będą widoczne. Wszystkie liczniki czasu dotyczące stron zostaną usunięte.</translation>
-<translation id="6534565668554028783">Google zbyt długo nie odpowiada</translation>
-<translation id="6538442820324228105">Pobrano <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Coś poszło nie tak. Spróbuj później.</translation>
-<translation id="654446541061731451">Wybierz kartę do przesłania</translation>
-<translation id="6545017243486555795">Wyczyść wszystkie dane</translation>
-<translation id="6545864417968258051">Skanowanie Bluetooth</translation>
-<translation id="6560414384669816528">Szukaj w Sogou</translation>
-<translation id="6566259936974865419">Chrome pozwolił Ci zaoszczędzić <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Zawsze zezwalaj</translation>
-<translation id="6573431926118603307">Tutaj wyświetlą się karty otwarte w Chrome na innych urządzeniach.</translation>
-<translation id="6583199322650523874">Dodaj bieżącą stronę do zakładek</translation>
-<translation id="6593061639179217415">Wersja na komputer</translation>
-<translation id="6600954340915313787">Skopiowana do Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Treść chroniona</translation>
-<translation id="6627583120233659107">Edytuj folder</translation>
-<translation id="6643016212128521049">Wyczyść</translation>
-<translation id="6643649862576733715">Sortuj według ilości zaoszczędzonych danych</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}few{<ph name="CONTACT_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}many{<ph name="CONTACT_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Wyświetl podgląd obrazu <ph name="BEGIN_NEW" />Nowość<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Aby wyszukać urządzenia, Chrome potrzebuje dostępu do lokalizacji. <ph name="BEGIN_LINK" />Zwiększ uprawnienia<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Hasło</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Otwórz w <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Informacje na temat ochrony prywatności w Chrome</translation>
-<translation id="6676840375528380067">Usunąć dane Chrome z tego urządzenia?</translation>
-<translation id="6697492270171225480">Gdy nie można odnaleźć strony, pokazuj sugestie podobnych stron</translation>
-<translation id="6697947395630195233">Chrome musi mieć dostęp do Twojej lokalizacji, by udostępnić ją tej stronie.</translation>
-<translation id="6698801883190606802">Zarządzaj synchronizowanymi danymi</translation>
-<translation id="6699370405921460408">Serwery Google będą optymalizować otwierane strony.</translation>
-<translation id="6706288973712894588">Teraz jesteś offline.\n<ph name="BEGIN_LINK" />Przeglądaj swój kanał offline<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Wiadomości</translation>
-<translation id="6710213216561001401">Wstecz</translation>
-<translation id="671481426037969117">Licznik czasu w aplikacji <ph name="FQDN" /> dobiegł końca. Jutro zacznie działać od nowa.</translation>
-<translation id="6738867403308150051">Pobieram…</translation>
-<translation id="6746124502594467657">W dół</translation>
-<translation id="6766622839693428701">Przesuń w dół, by zamknąć.</translation>
-<translation id="6766758767654711248">Kliknij, by przejść do strony</translation>
-<translation id="6767294960381293877">Lista urządzeń, którym udostępnisz kartę, jest otwarta na połowę wysokości.</translation>
-<translation id="6782111308708962316">Nie pozwalaj witrynom innych firm zapisywać ani odczytywać danych z plików cookie</translation>
-<translation id="6790428901817661496">Odtwórz</translation>
-<translation id="6811034713472274749">Strona jest gotowa do wyświetlenia</translation>
-<translation id="6818926723028410516">Wybierz elementy</translation>
-<translation id="6820686453637990663">Kod CVC</translation>
-<translation id="6831043979455480757">Tłumacz</translation>
-<translation id="6845325883481699275">Pomóż zwiększyć bezpieczeństwo Chrome</translation>
-<translation id="6846298663435243399">Wczytuję…</translation>
-<translation id="6850409657436465440">Pobieranie wciąż trwa</translation>
-<translation id="6850830437481525139">Zamknięte karty: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Pobierz obraz</translation>
-<translation id="6865313869410766144">Autouzupełnianie danych formularzy</translation>
-<translation id="688738109438487280">Dodaj istniejące dane do konta <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Odblokuj, by skopiować hasło</translation>
-<translation id="6896758677409633944">Kopiuj</translation>
-<translation id="6910211073230771657">Usunięto</translation>
-<translation id="6912998170423641340">Zablokuj stronom możliwość odczytywania tekstu i obrazów ze schowka</translation>
-<translation id="6914783257214138813">Twoje hasła będą widoczne dla każdego, kto może zobaczyć wyeksportowany plik.</translation>
-<translation id="6942665639005891494">W dowolnej chwili w Ustawieniach możesz zmienić domyślną lokalizację pobierania</translation>
-<translation id="6945221475159498467">Wybierz</translation>
-<translation id="6963642900430330478">Ta strona jest niebezpieczna. Informacje o witrynie</translation>
-<translation id="6963766334940102469">Usuń zakładki</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Od początku</translation>
-<translation id="6981982820502123353">Ułatwienia dostępu</translation>
-<translation id="6989267951144302301">Nie udało się pobrać</translation>
-<translation id="6990079615885386641">Pobierz aplikację ze sklepu Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Pytaj, zanim zezwolisz stronom na korzystanie z mikrofonu (zalecane)</translation>
-<translation id="7015203776128479407">Nie ukończono początkowej konfiguracji synchronizacji. Synchronizacja jest wyłączona.</translation>
-<translation id="7016516562562142042">Zezwolono na dostęp obecnej wyszukiwarce</translation>
-<translation id="7022756207310403729">Otwórz w przeglądarce</translation>
-<translation id="702463548815491781">Zalecane, gdy włączono TalkBack lub Switch Access</translation>
-<translation id="7029809446516969842">Hasła</translation>
-<translation id="7053983685419859001">Blokuj</translation>
-<translation id="7055152154916055070">Zablokowano przekierowanie:</translation>
-<translation id="7063006564040364415">Nie udało się nawiązać połączenia z serwerem synchronizacji.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Wybrano 1}few{Wybrano #}many{Wybrano #}other{Wybrano #}}</translation>
-<translation id="7071521146534760487">Zarządzaj kontem</translation>
-<translation id="7077143737582773186">Karta SD</translation>
-<translation id="7087918508125750058">Wybrano <ph name="ITEM_COUNT" />. Opcje dostępne na górze ekranu</translation>
-<translation id="7121362699166175603">Usuwa historię i pamięć autouzupełniania na pasku adresu. Inne rodzaje historii przeglądania mogą być nadal dostępne na Twoim koncie Google na <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Zezwalaj na dostęp obecnej wyszukiwarce</translation>
-<translation id="7138678301420049075">Inne</translation>
-<translation id="7141896414559753902">Blokuj wyskakujące okienka i przekierowania na stronach (zalecane)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Załaduj oryginalną stronę<ph name="END_LINK" /> z domeny <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Ostatnie 24 godziny</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Możesz zmienić to później w Ustawieniach</translation>
-<translation id="7180611975245234373">Odśwież</translation>
-<translation id="7189372733857464326">Czekam na zakończenie aktualizacji Usług Google Play</translation>
-<translation id="7191430249889272776">Karta otwarta w tle.</translation>
-<translation id="723171743924126238">Wybierz zdjęcia</translation>
-<translation id="7233236755231902816">Aby wyświetlać strony internetowe w swoim języku, pobierz najnowszą wersję Chrome</translation>
-<translation id="7243308994586599757">Opcje dostępne u dołu ekranu</translation>
-<translation id="7248069434667874558">Sprawdź, czy <ph name="TARGET_DEVICE_NAME" /> ma włączoną synchronizację w Chrome</translation>
-<translation id="7250468141469952378">Wybrano <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Zablokowana witryna</translation>
-<translation id="7290209999329137901">Nie można zmienić nazwy</translation>
-<translation id="7291387454912369099">Płatność przez Asystenta</translation>
-<translation id="7293171162284876153">Aby rozpocząć synchronizację, włącz „Synchronizuj dane Chrome”.</translation>
-<translation id="729975465115245577">Na urządzeniu nie ma aplikacji umożliwiającej zapisanie pliku z hasłami.</translation>
-<translation id="7302081693174882195">Szczegóły: posortowane według zaoszczędzonych danych</translation>
-<translation id="7328017930301109123">Chrome szybciej ładuje strony w wersji uproszczonej, przesyłając nawet o 60 procent mniej danych.</translation>
-<translation id="7333031090786104871">Nadal dodaję poprzednią stronę</translation>
-<translation id="7352939065658542140">FILM</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Udostępnij 1 wybrany element}few{Udostępnij # wybrane elementy}many{Udostępnij # wybranych elementów}other{Udostępnij # wybranego elementu}}</translation>
 <translation id="7359002509206457351">Dostęp do form płatności</translation>
+<translation id="8026334261755873520">Wyczyść dane przeglądania</translation>
+<translation id="1291207594882862231">Wyczyść historię, pliki cookie, dane witryn, pamięć podręczną…</translation>
+<translation id="7814200940910057384">Wyczyszczono dane Brave</translation>
+<translation id="1664855196866195614">Wybrane dane zostały usunięte z Brave i ze zsynchronizowanych urządzeń.
+
+Na stronie <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> na Twoim koncie Brave Software mogą być zapisane inne rodzaje historii przeglądania, takie jak wyszukiwania lub aktywność z innych usług Brave Software.</translation>
+<translation id="4699172675775169585">Obrazy i pliki zapisane w pamięci podręcznej</translation>
+<translation id="2496180316473517155">Historia przeglądania</translation>
+<translation id="2546283357679194313">Pliki cookie i dane stron</translation>
+<translation id="8662811608048051533">Wylogowuje z większości stron internetowych.</translation>
+<translation id="8218628800671693884">Wylogowuje z większości stron internetowych. Nie wyloguje Cię z konta Brave Software.</translation>
+<translation id="2017836877785168846">Usuwa historię i wpisy autouzupełniania w pasku adresu.</translation>
+<translation id="8096327394278038498">Usuwa historię i pamięć autouzupełniania na pasku adresu. Inne rodzaje historii przeglądania mogą być nadal dostępne na Twoim koncie Brave Software na <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Usuwa historię ze wszystkich urządzeń, na których jesteś zalogowany. Inne rodzaje historii przeglądania mogą być nadal dostępne na Twoim koncie Brave Software na <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Zapisane hasła</translation>
+<translation id="6865313869410766144">Autouzupełnianie danych formularzy</translation>
+<translation id="7562080006725997899">Czyszczenie danych przeglądania</translation>
+<translation id="5487521232677179737">Wyczyść dane</translation>
+<translation id="7498271377022651285">Czekaj…</translation>
+<translation id="784934925303690534">Zakres czasu</translation>
+<translation id="1718835860248848330">Ostatnia godzina</translation>
+<translation id="7149893636342594995">Ostatnie 24 godziny</translation>
+<translation id="5648166631817621825">Ostatnie 7 dni</translation>
+<translation id="8571213806525832805">Ostatnie 4 tygodnie</translation>
+<translation id="5854790677617711513">Sprzed ponad 30 dni</translation>
+<translation id="6979737339423435258">Od początku</translation>
+<translation id="982182592107339124">Spowoduje to usunięcie danych wszystkich witryn, w tym:</translation>
+<translation id="6643016212128521049">Wyczyść</translation>
+<translation id="7641339528570811325">Wyczyść dane przeglądania…</translation>
+<translation id="1670399744444387456">Podstawowe</translation>
+<translation id="3245261285041759672">Inne rodzaje historii przeglądania mogą być nadal dostępne na Twoim koncie Brave Software na <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Zablokowana witryna</translation>
+<translation id="2534155362429831547">Usunięte elementy: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Raporty o użytkowaniu i awariach</translation>
+<translation id="9079153198295609735">Automatycznie przesyłaj do Brave Software statystyki użytkowania i raporty o awariach</translation>
+<translation id="6981982820502123353">Ułatwienia dostępu</translation>
+<translation id="2387895666653383613">Skalowanie tekstu</translation>
+<translation id="2321958826496381788">Przeciągaj suwak, by umożliwić wygodne czytanie. Gdy dwukrotnie klikniesz akapit, tekst powiększy się co najmniej do tej wielkości.</translation>
+<translation id="3895926599014793903">Wymuś powiększenie</translation>
+<translation id="5668404140385795438">Zignoruj żądanie strony, gdy chce zapobiec powiększeniu widoku</translation>
+<translation id="4149994727733219643">Uproszczony widok stron internetowych</translation>
+<translation id="9100505651305367705">Proponuj wyświetlanie artykułów w widoku uproszczonym, gdy jest obsługiwany</translation>
+<translation id="1409426117486808224">Uproszczony widok otwartych kart</translation>
+<translation id="702463548815491781">Zalecane, gdy włączono TalkBack lub Switch Access</translation>
+<translation id="8284326494547611709">Napisy</translation>
+<translation id="4165986682804962316">Ustawienia witryn</translation>
+<translation id="6295158916970320988">Wszystkie witryny</translation>
+<translation id="8380167699614421159">Na tej stronie wyświetlają się uciążliwe lub wprowadzające w błąd reklamy</translation>
+<translation id="1919345977826869612">Reklamy</translation>
+<translation id="410351446219883937">Autoodtwarzanie</translation>
+<translation id="6447842834002726250">Pliki cookie</translation>
+<translation id="6196640612572343990">Blokuj pliki cookie innych firm</translation>
+<translation id="6782111308708962316">Nie pozwalaj witrynom innych firm zapisywać ani odczytywać danych z plików cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-upy i przekierowania</translation>
+<translation id="4751476147751820511">Czujniki ruchu lub światła</translation>
+<translation id="1717218214683051432">Czujniki ruchu</translation>
+<translation id="2091887806945687916">Dźwięk</translation>
+<translation id="2586657967955657006">Schowek</translation>
+<translation id="6320088164292336938">Wibracje</translation>
+<translation id="4226663524361240545">Powiadomienia będą sygnalizowane wibracjami</translation>
+<translation id="1446450296470737166">Pełne sterowanie urządzeniami MIDI</translation>
+<translation id="3744111561329211289">Synchronizacja w tle</translation>
+<translation id="5649053991847567735">Pobieranie automatyczne</translation>
+<translation id="6181444274883918285">Dodaj witrynę do wyjątków</translation>
+<translation id="5313967007315987356">Dodaj stronę</translation>
+<translation id="1369915414381695676">Strona <ph name="SITE_NAME"/> została dodana</translation>
+<translation id="7837721118676387834">Zezwalaj określonej stronie na automatyczne odtwarzanie wyciszonych filmów.</translation>
+<translation id="2621115761605608342">Zezwól na użycie JavaScriptu w określonej witrynie.</translation>
+<translation id="8801436777607969138">Zablokuj JavaScript w określonej witrynie.</translation>
+<translation id="8372893542064058268">Zezwalaj na synchronizowanie w tle z określoną stroną.</translation>
+<translation id="358794129225322306">Zezwól stronie na automatyczne pobieranie wielu plików.</translation>
+<translation id="4008040567710660924">Zezwalaj na pliki cookie z określonej strony internetowej.</translation>
+<translation id="8958424370300090006">Blokuj pliki cookie z określonej strony internetowej.</translation>
+<translation id="7882806643839505685">Zezwalaj na dźwięk na określonej stronie.</translation>
+<translation id="4468959413250150279">Wycisz dźwięk na konkretnej stronie.</translation>
+<translation id="1994173015038366702">URL strony</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Wykorzystanie</translation>
+<translation id="5804241973901381774">Uprawnienia</translation>
+<translation id="4278390842282768270">Dopuszczone</translation>
+<translation id="5677928146339483299">Zablokowane</translation>
+<translation id="1984937141057606926">Dozwolone, z wyjątkiem witryn innych firm</translation>
+<translation id="7423098979219808738">Najpierw zapytaj</translation>
+<translation id="8116925261070264013">Wyciszone</translation>
+<translation id="8300705686683892304">Zarządzane przez aplikację</translation>
+<translation id="6192792657125177640">Wyjątki</translation>
+<translation id="257931822824936280">Rozwinięty – kliknij, by zwinąć.</translation>
+<translation id="5100237604440890931">Zwinięty – kliknij, by rozwinąć.</translation>
+<translation id="857943718398505171">Dozwolone (zalecane)</translation>
+<translation id="2913331724188855103">Zezwalaj witrynom na zapisywanie danych w plikach cookie i ich odczytywanie (zalecane)</translation>
+<translation id="7445411102860286510">Zezwalaj witrynom na automatyczne odtwarzanie wyciszonych filmów (zalecane)</translation>
+<translation id="5335288049665977812">Zezwalaj na wykonywanie kodu JavaScript w witrynach (zalecane)</translation>
+<translation id="5527111080432883924">Pytaj, czy zezwolić stronom na odczytywanie tekstu i obrazów ze schowka (zalecane)</translation>
+<translation id="6912998170423641340">Zablokuj stronom możliwość odczytywania tekstu i obrazów ze schowka</translation>
+<translation id="7423538860840206698">Zablokowano odczytywanie schowka</translation>
+<translation id="3955193568934677022">Zezwalaj witrynom na odtwarzanie treści chronionej (zalecane)</translation>
+<translation id="445467742685312942">Zezwalaj stronom na odtwarzanie treści chronionych</translation>
+<translation id="2107397443965016585">Pytaj, zanim pozwolisz stronom na odtwarzanie treści chronionej (zalecane)</translation>
+<translation id="2910701580606108292">Pytaj, zanim zezwolisz stronom na odtwarzanie treści chronionej</translation>
+<translation id="757524316907819857">Blokuj odtwarzanie treści chronionej na stronach</translation>
+<translation id="3277252321222022663">Zezwalaj stronom na dostęp do czujników (zalecane)</translation>
+<translation id="5048398596102334565">Zezwalaj stronom na dostęp do czujników ruchu (zalecane)</translation>
+<translation id="8816026460808729765">Blokuj stronom dostęp do czujników</translation>
+<translation id="169515064810179024">Blokuj stronom dostęp do czujników ruchu</translation>
+<translation id="1660204651932907780">Zezwalaj na odtwarzanie dźwięku na stronach internetowych (zalecane)</translation>
+<translation id="3600792891314830896">Wycisz strony, które odtwarzają dźwięk</translation>
+<translation id="1743802530341753419">Pytaj, zanim zezwolisz stronom na połączenie z urządzeniem (zalecane)</translation>
+<translation id="851751545965956758">Nie zezwalaj stronom na łączenie się z urządzeniami</translation>
+<translation id="7141896414559753902">Blokuj wyskakujące okienka i przekierowania na stronach (zalecane)</translation>
+<translation id="5494752089476963479">Blokuj reklamy na stronach, które wyświetlają reklamy uciążliwe lub wprowadzające w błąd</translation>
+<translation id="3123473560110926937">Blokowane na niektórych stronach</translation>
+<translation id="965817943346481315">Zablokuj, jeśli na stronie wyświetlają się uciążliwe lub wprowadzające w błąd reklamy (zalecane)</translation>
+<translation id="3386292677130313581">Pytaj, zanim udostępnisz stronom swoją lokalizację (zalecane)</translation>
+<translation id="9139068048179869749">Pytaj, zanim zezwolisz stronom na wysyłanie powiadomień (zalecane)</translation>
+<translation id="4479647676395637221">Pytaj, zanim zezwolisz stronom na korzystanie z kamery (zalecane)</translation>
+<translation id="6992289844737586249">Pytaj, zanim zezwolisz stronom na korzystanie z mikrofonu (zalecane)</translation>
+<translation id="2289270750774289114">Pytaj, gdy strona chce wykryć urządzenia Bluetooth w pobliżu (zalecane)</translation>
+<translation id="7053983685419859001">Blokuj</translation>
+<translation id="7128222689758636196">Zezwalaj na dostęp obecnej wyszukiwarce</translation>
+<translation id="7589445247086920869">Blokuj dostęp obecnej wyszukiwarce</translation>
+<translation id="6388207532828177975">Wyczyść i zresetuj</translation>
+<translation id="7999064672810608036">Na pewno chcesz usunąć wszystkie dane lokalne (w tym pliki cookie) i zresetować uprawnienia tej witryny?</translation>
+<translation id="2822354292072154809">Czy na pewno chcesz zresetować wszystkie uprawnienia witryny dla obiektu <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Wyczyść zapisane dane</translation>
+<translation id="5902828464777634901">Wszystkie dane lokalne zapisane przez tę witrynę (w tym pliki cookie) zostaną usunięte.</translation>
+<translation id="119944043368869598">Wyczyść wszystko</translation>
+<translation id="2490684707762498678">Zarządzane przez <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Otwórz ustawienia powiadomień</translation>
+<translation id="1404122904123200417">Umieszczone na <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">W tym miejscu pojawiają się pliki zapisane przez witryny</translation>
+<translation id="4181841719683918333">Języki</translation>
+<translation id="2647434099613338025">Dodaj język</translation>
+<translation id="1952172573699511566">Gdy będzie to możliwe, tekst na stronach internetowych będzie się wyświetlać w Twoim preferowanym języku.</translation>
+<translation id="8559990750235505898">Proponuj tłumaczenie stron w innych językach</translation>
+<translation id="4719927025381752090">Proponuj tłumaczenie</translation>
+<translation id="8156139159503939589">W jakich językach umiesz czytać?</translation>
+<translation id="5689516760719285838">Lokalizacja</translation>
+<translation id="2440823041667407902">Dostęp do lokalizacji</translation>
+<translation id="2023546461831060654">Przyznaj Brave uprawnienia w <ph name="BEGIN_LINK"/>ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Przyznaj Brave uprawnienie w <ph name="BEGIN_LINK"/>ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Aby zezwolić Brave na dostęp do lokalizacji, musisz ją też włączyć w <ph name="BEGIN_LINK"/>Ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Aby zezwolić Brave na dostęp do aparatu, musisz też włączyć aparat w <ph name="BEGIN_LINK"/>Ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Aby zezwolić Brave na wysyłanie Ci powiadomień, musisz je też włączyć w <ph name="BEGIN_LINK"/>Ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Aby zezwolić Brave na dostęp do mikrofonu, musisz też włączyć mikrofon w <ph name="BEGIN_LINK"/>Ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Dostęp do lokalizacji jest wyłączony na tym urządzeniu. Włącz go w <ph name="BEGIN_LINK"/>Ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Dostęp do lokalizacji jest wyłączony też na tym urządzeniu. Włącz go w <ph name="BEGIN_LINK"/>Ustawieniach Androida<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Dostęp do kamery</translation>
+<translation id="945632385593298557">Dostęp do mikrofonu</translation>
+<translation id="6612358246767739896">Treść chroniona</translation>
+<translation id="885701979325669005">Pamięć</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> zapisanych danych</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Cofnij zgodę na dostęp do urządzenia</translation>
+<translation id="4962975101802056554">Anuluj wszystkie uprawnienia urządzenia</translation>
+<translation id="6545864417968258051">Skanowanie Bluetooth</translation>
+<translation id="4411535500181276704">Wersja uproszczona</translation>
+<translation id="7821588508402923572">Tutaj będą widoczne informacje o zaoszczędzonych danych</translation>
+<translation id="2131665479022868825">Zaoszczędzono <ph name="DATA"/></translation>
+<translation id="8569404424186215731">od <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Brave szybciej ładuje strony w wersji uproszczonej, przesyłając nawet o 60 procent mniej danych.</translation>
+<translation id="6159335304067198720">Oszczędność danych: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">zaoszczędzonych danych</translation>
+<translation id="6111020039983847643">użytych danych</translation>
+<translation id="7413229368719586778">Data rozpoczęcia: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Data zakończenia: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sortuj według witryny</translation>
+<translation id="5864174910718532887">Szczegóły: posortowane według nazwy witryny</translation>
+<translation id="116280672541001035">Użyto</translation>
+<translation id="8349013245300336738">Sortuj według ilości wykorzystanych danych</translation>
+<translation id="6378173571450987352">Szczegóły: posortowane według wykorzystanych danych</translation>
+<translation id="2631006050119455616">Zaoszczędzono</translation>
+<translation id="6643649862576733715">Sortuj według ilości zaoszczędzonych danych</translation>
+<translation id="7302081693174882195">Szczegóły: posortowane według zaoszczędzonych danych</translation>
+<translation id="4179980317383591987">Wykorzystano <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Zaoszczędzono <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Pozostałe strony (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Inne</translation>
+<translation id="4913161338056004800">Resetuj statystyki</translation>
+<translation id="1856325424225101786">Zresetować wersję uproszczoną?</translation>
+<translation id="3658159451045945436">Resetowanie usuwa historię oszczędzania danych, w tym listę odwiedzonych stron.</translation>
+<translation id="3295530008794733555">Szybsze przeglądanie. Mniejsze zużycie danych.</translation>
+<translation id="7340390500800578919">W wersji uproszczonej Brave szybciej ładuje strony, używając nawet o 60% mniej danych. Aby optymalizować strony, które odwiedzasz, Brave przesyła informacje o historii przeglądania do Brave Software. <ph name="BEGIN_LINK"/>Więcej informacji<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Włącz wersję uproszczoną</translation>
+<translation id="4493497663118223949">Wersja uproszczona jest włączona</translation>
+<translation id="7559975015014302720">Wersja uproszczona jest wyłączona</translation>
+<translation id="7606077192958116810">Wersja uproszczona jest włączona. Możesz nią zarządzać w Ustawieniach.</translation>
+<translation id="4714588616299687897">Zaoszczędź nawet 60% na transmisji danych</translation>
+<translation id="1006927014032731288">Serwery Brave Software będą optymalizować otwierane strony.</translation>
+<translation id="3257320067425202300">Brave pozwolił Ci zaoszczędzić <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave pozwolił Ci zaoszczędzić <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Miejsce zapisywania pobranych plików</translation>
+<translation id="7077143737582773186">Karta SD</translation>
+<translation id="7762668264895820836">Karta SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Pytaj, gdzie zapisać pliki</translation>
+<translation id="6192333916571137726">Pobranie pliku</translation>
+<translation id="1672586136351118594">Nie pokazuj ponownie</translation>
+<translation id="2650751991977523696">Czy pobrać plik ponownie?</translation>
+<translation id="8664979001105139458">Ta nazwa pliku już istnieje</translation>
+<translation id="488187801263602086">Zmień nazwę pliku</translation>
+<translation id="5686790454216892815">Nazwa pliku jest za długa</translation>
+<translation id="7454641608352164238">Za mało miejsca</translation>
+<translation id="8972098258593396643">Czy pobrać do folderu domyślnego?</translation>
+<translation id="804335162455518893">Nie znaleziono karty SD</translation>
+<translation id="7475688122056506577">Nie znaleziono karty SD. Może brakować niektórych Twoich plików.</translation>
+<translation id="4198423547019359126">Brak dostępnych miejsc zapisu pobieranych plików</translation>
+<translation id="8224471946457685718">Pobieranie artykułów dla Ciebie przez Wi-Fi</translation>
+<translation id="4970824347203572753">Funkcja niedostępna w Twojej lokalizacji</translation>
+<translation id="5500777121964041360">Funkcja może być niedostępna w Twojej lokalizacji</translation>
+<translation id="1173894706177603556">Zmień nazwę</translation>
+<translation id="1986685561493779662">Nazwa już istnieje</translation>
+<translation id="6441734959916820584">Nazwa jest zbyt długa</translation>
+<translation id="2923908459366352541">Nazwa jest nieprawidłowa.</translation>
+<translation id="7290209999329137901">Nie można zmienić nazwy</translation>
+<translation id="3334729583274622784">Zmienić rozszerzenie pliku?</translation>
+<translation id="107147699690128016">Jeśli zmienisz rozszerzenie pliku, będzie mogła go otworzyć inna aplikacja, co może nie być bezpieczne dla Twojego urządzenia.</translation>
+<translation id="8541922081612557424">Brave – informacje</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Wszelkie prawa zastrzeżone.</translation>
+<translation id="1416550906796893042">Wersja aplikacji</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (zaktualizowana <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">System operacyjny</translation>
+<translation id="3968054912784331254">Aktualizacje Brave nie są już dostępne w tej wersji Androida</translation>
+<translation id="7665369617277396874">Dodaj konto</translation>
+<translation id="649070405679044769">Jesteś zalogowany w Brave Software jako</translation>
+<translation id="6234515504547364178">Wyloguj się z Brave</translation>
+<translation id="5324858694974489420">Ustawienia rodzicielskie</translation>
+<translation id="8920114477895755567">Oczekiwanie na informacje o rodzicach.</translation>
+<translation id="5512137114520586844">Tym kontem zarządza <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Tym kontem zarządzają <ph name="PARENT_NAME_1"/> i <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Treści</translation>
+<translation id="5403644198645076998">Pozwól na otwieranie tylko wybranych stron</translation>
+<translation id="8641930654639604085">Próbuj blokować strony dla dorosłych</translation>
+<translation id="5639724618331995626">Pozwól na otwieranie wszystkich stron</translation>
+<translation id="796823723482603597">Technologia Brave</translation>
+<translation id="6324034347079777476">Synchronizacja systemu Android jest wyłączona</translation>
+<translation id="5127805178023152808">Synchronizacja jest wyłączona</translation>
+<translation id="7015203776128479407">Nie ukończono początkowej konfiguracji synchronizacji. Synchronizacja jest wyłączona.</translation>
+<translation id="2497852260688568942">Synchronizację wyłączył administrator</translation>
+<translation id="9100610230175265781">Wymagane jest hasło</translation>
+<translation id="6108923351542677676">Trwa konfigurowanie…</translation>
+<translation id="4062305924942672200">Informacje prawne</translation>
+<translation id="4256782883801055595">Licencje open source</translation>
+<translation id="1138681184697033370">Warunki korzystania z Brave</translation>
+<translation id="7392539049993970338">Informacje na temat ochrony prywatności w Brave</translation>
+<translation id="2677748264148917807">Wyjdź</translation>
+<translation id="5556459405103347317">Odśwież</translation>
+<translation id="1623104350909869708">Zapobiegaj wyświetlaniu dodatkowych okien dialogowych na tej stronie</translation>
+<translation id="2968755619301702150">Przeglądarka certyfikatów</translation>
+<translation id="1360432990279830238">Wylogować i wyłączyć synchronizację?</translation>
+<translation id="8581481290581777242">Usunąć dane Brave z tego urządzenia?</translation>
+<translation id="1318865768845061710">Twoje zakładki, historia, hasła i inne dane z Brave nie będą już synchronizowane z kontem Brave Software</translation>
+<translation id="3325020657155065477">Usuń też swoje dane Brave z tego urządzenia</translation>
+<translation id="6136448902816743006">Wylogowujesz się z konta zarządzanego w domenie <ph name="DOMAIN_NAME"/>, więc Twoje dane w Brave zostaną usunięte z tego urządzenia. Pozostaną one na Twoim koncie Brave Software.</translation>
+<translation id="1853026300647876496">Łączę się z Brave Software. Może to chwilę potrwać…</translation>
+<translation id="2328985652426384049">Nie można się zalogować</translation>
+<translation id="7723158744459952869">Brave Software zbyt długo nie odpowiada</translation>
+<translation id="4572422548854449519">Zaloguj się na konto zarządzane</translation>
+<translation id="2689656545739939160">Logujesz się na konto, którym zarządza <ph name="MANAGED_DOMAIN"/>, i przekazujesz jego administratorowi kontrolę nad Twoimi danymi Brave. Zostaną one trwale przypisane do tego konta. Gdy się wylogujesz, znikną one z tego urządzenia, ale pozostaną zapisane na Twoim koncie Brave Software.</translation>
+<translation id="1749561566933687563">Synchronizuj swoje zakładki</translation>
+<translation id="4242533952199664413">Otwórz ustawienia</translation>
+<translation id="1111673857033749125">Tutaj wyświetlą się zakładki z innych urządzeń.</translation>
+<translation id="8636825310635137004">Aby korzystać z kart ze swoich innych urządzeń, włącz synchronizację</translation>
+<translation id="3269956123044984603">Aby korzystać z kart ze swoich pozostałych urządzeń, włącz opcję „Autosynchronizacja danych” w ustawieniach konta na urządzeniu z Androidem.</translation>
+<translation id="5157964048453367290">Tutaj wyświetlą się karty otwarte w Brave na innych urządzeniach.</translation>
+<translation id="4684427112815847243">Synchronizuj wszystko</translation>
+<translation id="2709516037105925701">Autouzupełnianie</translation>
+<translation id="8820817407110198400">Zakładki</translation>
+<translation id="1644574205037202324">Historia</translation>
+<translation id="17513872634828108">Otwarte karty</translation>
+<translation id="1320169905922104972">Karty kredytowe i adresy z Brave Software Pay</translation>
+<translation id="6337234675334993532">Szyfrowanie</translation>
+<translation id="6698801883190606802">Zarządzaj synchronizowanymi danymi</translation>
+<translation id="3598578758776312506">Zaszyfruj hasła za pomocą danych logowania Brave Software</translation>
+<translation id="7810580217418711046">Zaszyfruj synchronizowane dane hasłem Brave Software z <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Szyfruj synchronizowane dane własnym hasłem synchronizacji</translation>
+<translation id="2996291259634659425">Utwórz hasło</translation>
+<translation id="5713644099811900409">Konta Brave Software</translation>
+<translation id="8997474919031554666">Szyfrowanie hasłem nie obejmuje form płatności ani adresów w Brave Software Pay. Twoje zaszyfrowane dane może odczytać tylko ktoś znający hasło. Brave Software nie otrzyma Twojego hasła ani nie będzie go przechowywać. Jeśli je zapomnisz lub zechcesz zmienić to ustawienie, konieczne będzie zresetowanie synchronizacji. <ph name="BEGIN_LINK"/>Więcej informacji<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Hasło</translation>
+<translation id="7772032839648071052">Potwierdź hasło</translation>
+<translation id="5304593522240415983">To pole nie może być puste</translation>
+<translation id="321773570071367578">Jeśli nie pamiętasz hasła lub chcesz zmienić to ustawienie, <ph name="BEGIN_LINK"/>zresetuj synchronizację<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Hasła nie pasują do siebie</translation>
+<translation id="5149495116300586333">Szyfrowanie hasłem nie obejmuje form płatności ani adresów w Brave Software Pay.
+
+Aby zmienić to ustawienie, <ph name="BEGIN_LINK"/>zresetuj synchronizację<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">Nieprawidłowe hasło</translation>
+<translation id="5414836363063783498">Weryfikuję…</translation>
+<translation id="6846298663435243399">Wczytuję…</translation>
+<translation id="5517095782334947753">Masz zakładki, historię, hasła i inne ustawienia z konta <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Połącz moje dane</translation>
+<translation id="688738109438487280">Dodaj istniejące dane do konta <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Przechowuj dane oddzielnie</translation>
+<translation id="1145536944570833626">Usuń istniejące dane.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> chce się sparować</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Pomoc<ph name="END_LINK"/> w trakcie wyszukiwania urządzeń…</translation>
+<translation id="5817918615728894473">Sparuj</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Skorzystaj z pomocy<ph name="END_LINK1"/> lub <ph name="BEGIN_LINK2"/>skanuj ponownie<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Nie znaleziono zgodnych urządzeń</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Włącz Bluetooth<ph name="END_LINK"/>, by umożliwić parowanie</translation>
+<translation id="998321811308652668">Brave nie może włączyć adaptera Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Poproś o pomoc<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Aby wyszukać urządzenia, Brave potrzebuje dostępu do lokalizacji. <ph name="BEGIN_LINK"/>Zwiększ uprawnienia<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Aby wyszukać urządzenia, Brave potrzebuje dostępu do lokalizacji. Dostęp jest <ph name="BEGIN_LINK"/>wyłączony na tym urządzeniu<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Aby wyszukać urządzenia, Brave potrzebuje dostępu do lokalizacji. <ph name="BEGIN_LINK1"/>Zwiększ uprawnienia<ph name="END_LINK1"/>. Dostęp do lokalizacji jest <ph name="BEGIN_LINK2"/>wyłączony na tym urządzeniu<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Połączone urządzenie</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Poziom siły sygnału: # słupek}few{Poziom siły sygnału: # słupki}many{Poziom siły sygnału: # słupków}other{Poziom siły sygnału: # słupka}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> chce wyszukać urządzenia Bluetooth w pobliżu. Znaleziono te urządzenia:</translation>
+<translation id="8368027906805972958">Nieznane lub nieobsługiwane urządzenie (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synchronizacja nie działa</translation>
+<translation id="1810845389119482123">Nie dokończono wstępnego konfigurowania synchronizacji</translation>
+<translation id="3235722914093408050">Otwórz ustawienia Androida i ponownie włącz jego synchronizację, by uruchomić Synchronizację Brave</translation>
+<translation id="3367813778245106622">Zaloguj się ponownie, by rozpocząć synchronizację</translation>
+<translation id="974555521953189084">Wpisz hasło, by rozpocząć synchronizację</translation>
+<translation id="2997266899014181325">Aby rozpocząć synchronizację, włącz „Synchronizuj dane Brave”.</translation>
+<translation id="8260126382462817229">Spróbuj zalogować się jeszcze raz</translation>
+<translation id="5919204609460789179">Zaktualizuj przeglądarkę <ph name="PRODUCT_NAME"/>, by rozpocząć synchronizację</translation>
+<translation id="397583555483684758">Synchronizacja przestała działać</translation>
+<translation id="1966710179511230534">Zaktualizuj swoje dane logowania.</translation>
+<translation id="7063006564040364415">Nie udało się nawiązać połączenia z serwerem synchronizacji.</translation>
+<translation id="7942131818088350342">Przeglądarka <ph name="PRODUCT_NAME"/> jest nieaktualna.</translation>
+<translation id="4170011742729630528">Usługa jest niedostępna. Spróbuj ponownie później.</translation>
+<translation id="7947953824732555851">Zaakceptuj i zaloguj się</translation>
+<translation id="8583805026567836021">Usuwam dane konta</translation>
+<translation id="8310344678080805313">Karty standardowe</translation>
+<translation id="5748802427693696783">Przełączono na karty standardowe</translation>
+<translation id="7998918019931843664">Otwórz ponownie zamkniętą kartę</translation>
+<translation id="8853345339104747198">Karta <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Zamknij kartę <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opcje dostępne u dołu ekranu</translation>
+<translation id="4060598801229743805">Opcje dostępne na górze ekranu</translation>
+<translation id="2810645512293415242">Uproszczona wersja strony pozwala szybciej zapisywać i wczytywać dane.</translation>
+<translation id="3985215325736559418">Czy chcesz ponownie pobrać plik <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Czy chcesz jeszcze raz rozpocząć pobieranie pliku <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Pobierz</translation>
+<translation id="545042621069398927">Przyspieszam pobieranie.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Pobieram plik.}few{Pobieram # pliki.}many{Pobieram # plików.}other{Pobieram # pliku.}}</translation>
+<translation id="543509235395288790">Pobieram pliki: <ph name="COUNT"/> (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Pobieram plik (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Ukończono pobieranie 1 pliku.}few{Ukończono pobieranie # plików.}many{Ukończono pobieranie # plików.}other{Ukończono pobieranie # pliku.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Nie udało się pobrać 1 pliku.}few{Nie udało się pobrać # plików.}many{Nie udało się pobrać # plików.}other{Nie udało się pobrać # pliku.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 plik oczekuje na pobranie.}few{# pliki oczekują na pobranie.}many{# plików oczekuje na pobranie.}other{# pliku oczekuje na pobranie.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Przycisk <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Prawie gotowe!</translation>
+<translation id="3960299545138990065">Uruchom ponownie Brave</translation>
+<translation id="3771001275138982843">Nie udało się pobrać aktualizacji</translation>
+<translation id="3888648114124182147">Pobieram aktualizację Brave…</translation>
+<translation id="1705567146636171298">Zaktualizuj Brave</translation>
+<translation id="6195417478702700398">Aby komfortowo przeglądać internet, otwórz tę stronę i zaktualizuj Brave</translation>
+<translation id="3512968675351418494">Aby wyświetlać strony internetowe w swoim języku, pobierz najnowszą wersję Brave</translation>
+<translation id="6427112570124116297">Tłumacz internet</translation>
+<translation id="1379423114029199501">Zaktualizuj Brave do najnowszej wersji, by mieć w nim dostępny swój język</translation>
+<translation id="5684874026226664614">Nie można przetłumaczyć tej strony.</translation>
+<translation id="6831043979455480757">Tłumacz</translation>
+<translation id="1285320974508926690">Nigdy nie tłumacz tej witryny</translation>
+<translation id="773466115871691567">Zawsze tłumacz strony, których językiem jest <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nigdy nie tłumacz stron, których językiem jest <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Więcej języków</translation>
+<translation id="290376772003165898">Język tej strony to nie <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Od teraz strony, których językiem jest <ph name="SOURCE_LANGUAGE"/>, będą tłumaczone na <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Strony, których językiem jest <ph name="LANGUAGE"/>, nie będą tłumaczone</translation>
+<translation id="5447765697759493033">Ta strona nie zostanie przetłumaczona</translation>
+<translation id="4880127995492972015">Przetłumacz…</translation>
+<translation id="641643625718530986">Drukuj…</translation>
+<translation id="8909135823018751308">Udostępnij…</translation>
+<translation id="4996978546172906250">Udostępnij przez</translation>
+<translation id="6333140779060797560">Udostępnij przez: <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Podczas drukowania strony wystąpił problem. Spróbuj ponownie.</translation>
+<translation id="3254409185687681395">Dodaj stronę do zakładek</translation>
+<translation id="497421865427891073">Dalej</translation>
+<translation id="813082847718468539">Wyświetl informacje o witrynie</translation>
+<translation id="2532336938189706096">Widok sieci</translation>
+<translation id="6005538289190791541">Proponowane hasło</translation>
+<translation id="4634124774493850572">Użyj hasła</translation>
+<translation id="8285489906452138776">Brave potrzebuje uprawnień dostępu do aparatu na tej stronie.</translation>
+<translation id="320189792589364011">Brave potrzebuje uprawnień dostępu do mikrofonu na tej stronie.</translation>
+<translation id="7988136689212463100">Brave potrzebuje uprawnień dostępu do aparatu i mikrofonu na tej stronie.</translation>
+<translation id="4931190655840828017">Brave musi mieć dostęp do Twojej lokalizacji, by udostępnić ją tej stronie.</translation>
+<translation id="3088191967551450609">Brave musi mieć dostęp do pamięci, by pobierać pliki.</translation>
+<translation id="8942627711005830162">Otwórz w innym oknie</translation>
+<translation id="4195643157523330669">Otwórz w nowej karcie</translation>
+<translation id="1100066534610197918">Otwórz w nowej karcie w grupie</translation>
+<translation id="4860895144060829044">Zadzwoń</translation>
+<translation id="6896758677409633944">Kopiuj</translation>
+<translation id="8393700583063109961">Wyślij wiadomość</translation>
+<translation id="3557336313807607643">Dodaj do kontaktów</translation>
+<translation id="4269820728363426813">Kopiuj adres linku</translation>
+<translation id="1206892813135768548">Kopiuj tekst linku</translation>
+<translation id="1204037785786432551">Pobierz link</translation>
+<translation id="6864459304226931083">Pobierz obraz</translation>
+<translation id="8209050860603202033">Otwórz grafikę</translation>
+<translation id="8073388330009372546">Otwórz grafikę w nowej karcie</translation>
+<translation id="6649642165559792194">Wyświetl podgląd obrazu <ph name="BEGIN_NEW"/>Nowość<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Wczytaj obraz</translation>
+<translation id="3845332215609790146">Szukaj z Obiektywem Brave Software <ph name="BEGIN_NEW"/>Nowość<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Szukaj tej grafiki w <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Udostępnij zdjęcie</translation>
+<translation id="5833984609253377421">Udostępnij link</translation>
+<translation id="6475951671322991020">Pobierz film</translation>
+<translation id="2317945146070194624">Otwórz w nowej karcie Brave</translation>
+<translation id="7975379999046275268">Wyświetl podgląd strony <ph name="BEGIN_NEW"/>Nowość<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Odświeżam stronę</translation>
+<translation id="36525718899759834">Pobierz aplikację ze sklepu Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Ciemny</translation>
+<translation id="1807246157184219062">Jasny</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Bezszeryfowa</translation>
+<translation id="5016205925109358554">Szeryfowa</translation>
+<translation id="2593272815202181319">Stała szerokość znaków</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Wybierz kartę do przesłania</translation>
+<translation id="8719023831149562936">Nie można przesłać bieżącej karty</translation>
+<translation id="2139186145475833000">Dodaj do ekranu głównego</translation>
+<translation id="4616150815774728855">Otwórz <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Nie udało się otworzyć aplikacji</translation>
+<translation id="5129038482087801250">Zainstaluj aplikację internetową</translation>
+<translation id="3789841737615482174">Zainstaluj</translation>
+<translation id="4665282149850138822">Strona <ph name="NAME"/> została dodana do ekranu głównego</translation>
+<translation id="7333031090786104871">Nadal dodaję poprzednią stronę</translation>
+<translation id="1036727731225946849">Dodaję aplikację <ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">Dodano do ekranu głównego</translation>
+<translation id="2146738493024040262">Otwórz aplikację błyskawiczną</translation>
+<translation id="7016516562562142042">Zezwolono na dostęp obecnej wyszukiwarce</translation>
+<translation id="6177111841848151710">Zablokowano dostęp obecnej wyszukiwarce</translation>
+<translation id="145097072038377568">Wyłączone w ustawieniach Androida</translation>
+<translation id="8007176423574883786">Wyłączona na tym urządzeniu</translation>
+<translation id="164269334534774161">Oglądasz kopię offline tej strony z <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Ta strona offline jest z <ph name="CREATION_TIME"/> i może różnić się od wersji online.</translation>
+<translation id="8840953339110955557">Ta strona może różnić się od wersji online.</translation>
+<translation id="6405300764336705484">Treść z <ph name="DOMAIN_NAME"/> dostarczana przez Brave Software.</translation>
+<translation id="1006017844123154345">Otwórz online</translation>
+<translation id="3326636747541519688">Lżejsza wersja strony dostarczona przez Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Załaduj oryginalną stronę<ph name="END_LINK"/> z domeny <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Jeśli często widzisz ten komunikat, przeczytaj te <ph name="BEGIN_LINK"/>wskazówki<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Treści ukryte</translation>
+<translation id="3810973564298564668">Zarządzaj</translation>
+<translation id="5199929503336119739">Profil służbowy</translation>
+<translation id="528192093759286357">Przeciągnij od góry i kliknij przycisk Wstecz, by wyjść z trybu pełnoekranowego.</translation>
+<translation id="2836148919159985482">Kliknij przycisk Wstecz, by wyjść z trybu pełnoekranowego.</translation>
+<translation id="3967822245660637423">Pobieranie zakończone</translation>
+<translation id="2434158240863470628">Ukończono pobieranie <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Nie udało się pobrać</translation>
+<translation id="1384959399684842514">Pobieranie wstrzymane</translation>
+<translation id="1671236975893690980">Oczekuję na pobranie…</translation>
+<translation id="5561549206367097665">Czekam na sieć…</translation>
+<translation id="5864419784173784555">Czekam na inny plik do pobrania…</translation>
+<translation id="6461962085415701688">Nie można otworzyć pliku</translation>
+<translation id="1178581264944972037">Wstrzymaj</translation>
+<translation id="8200772114523450471">Wznów</translation>
+<translation id="1409879593029778104">Plik <ph name="FILE_NAME"/> nie został pobrany, bo już istnieje.</translation>
+<translation id="3387650086002190359">Nie udało się pobrać pliku <ph name="FILE_NAME"/> z powodu błędów systemu plików.</translation>
+<translation id="6482749332252372425">Nie udało się pobrać pliku <ph name="FILE_NAME"/> z powodu braku miejsca.</translation>
+<translation id="7619072057915878432">Nie udało się pobrać pliku <ph name="FILE_NAME"/> z powodu problemów z siecią.</translation>
+<translation id="1477626028522505441">Nie udało się pobrać pliku <ph name="FILE_NAME"/> z powodu problemów z serwerem.</translation>
+<translation id="3692944402865947621">Nie udało się pobrać pliku <ph name="FILE_NAME"/> z powodu niedostępności pamięci.</translation>
+<translation id="604996488070107836">Nie udało się pobrać pliku <ph name="FILE_NAME"/> z powodu nieznanego błędu.</translation>
+<translation id="6738867403308150051">Pobieram…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Pobrano <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Pobrano <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Pobrano <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Pozostał jeden plik</translation>
+<translation id="8186512483418048923">Pozostałe pliki: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Pobrano <ph name="FILES_DOWNLOADED_ONE"/> plik}few{Pobrano <ph name="FILES_DOWNLOADED_MANY"/> pliki}many{Pobrano <ph name="FILES_DOWNLOADED_MANY"/> plików}other{Pobrano <ph name="FILES_DOWNLOADED_MANY"/> pliku}}</translation>
+<translation id="8037750541064988519">Pozostało: <ph name="DAYS"/> dni</translation>
+<translation id="8190358571722158785">Pozostał dzień</translation>
+<translation id="60923314841986378">Pozostało: <ph name="HOURS"/> godz.</translation>
+<translation id="510275257476243843">Pozostała godzina</translation>
+<translation id="970715775301869095">Pozostało: <ph name="MINUTES"/> min</translation>
+<translation id="3236059992281584593">Pozostała minuta</translation>
+<translation id="2777555524387840389">Pozostało: <ph name="SECONDS"/> s</translation>
+<translation id="2781151931089541271">Pozostała sekunda</translation>
+<translation id="3303414029551471755">Przejść do pobrania treści?</translation>
+<translation id="8617240290563765734">Otworzyć sugerowany URL określony w pobranych materiałach?</translation>
+<translation id="1373696734384179344">Za mało pamięci, by pobrać te treści.</translation>
+<translation id="5271967389191913893">Na tym urządzeniu nie można otworzyć treści, które chcesz pobrać.</translation>
+<translation id="883806473910249246">Podczas pobierania treści wystąpił błąd.</translation>
+<translation id="5626134646977739690">Nazwa:</translation>
+<translation id="7963646190083259054">Dostawca:</translation>
+<translation id="3414952576877147120">Rozmiar:</translation>
+<translation id="7375125077091615385">Typ:</translation>
+<translation id="5765780083710877561">Opis:</translation>
+<translation id="4881695831933465202">Otwórz</translation>
+<translation id="3542235761944717775">Dostępne: <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747">Dostępne: <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268">Dostępne <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Zajmują <ph name="SPACE_USED"/> z <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Wszystkie</translation>
+<translation id="4988526792673242964">Strony</translation>
+<translation id="3810838688059735925">Wideo</translation>
+<translation id="3616113530831147358">Dźwięk</translation>
+<translation id="9219103736887031265">Grafika</translation>
+<translation id="8250920743982581267">Dokumenty</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# plik}few{# pliki}many{# plików}other{# pliku}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# obraz}few{# obrazy}many{# obrazów}other{# obrazu}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# film}few{# filmy}many{# filmów}other{# filmu}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# plik dźwiękowy}few{# pliki dźwiękowe}many{# plików dźwiękowych}other{# pliku dźwiękowego}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# strona}few{# strony}many{# stron}other{# strony}}</translation>
+<translation id="5456381639095306749">Pobierz stronę</translation>
+<translation id="2394602618534698961">Tutaj pojawią się pobrane pliki</translation>
+<translation id="7810647596859435254">Otwórz za pomocą…</translation>
+<translation id="5655963694829536461">Przeszukaj pobrane pliki</translation>
+<translation id="8485434340281759656"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="1883903952484604915">Moje pliki</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Tutaj pojawiają się artykuły, które możesz czytać, nawet gdy jesteś offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# godzina}few{# godziny}many{# godzin}other{# godziny}}</translation>
+<translation id="5853623416121554550">Wstrzymano</translation>
+<translation id="8965591936373831584">Oczekiwanie</translation>
+<translation id="2779651927720337254">Nie pobrano</translation>
+<translation id="2049574241039454490"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE_OF_TOTAL"/></translation>
+<translation id="3445014427084483498">Przed chwilą</translation>
+<translation id="4000212216660919741">Ekran główny offline</translation>
+<translation id="9133397713400217035">Przeglądaj offline</translation>
+<translation id="968900484120156207">Tutaj pojawią się strony, które odwiedzisz</translation>
+<translation id="7882131421121961860">Brak historii</translation>
+<translation id="3549657413697417275">Przeszukaj historię</translation>
+<translation id="6820686453637990663">Kod CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">RR</translation>
+<translation id="724102042129299115">Pierwsze uruchomienie Brave</translation>
+<translation id="2700285883409956633">Korzystając z tej aplikacji, akceptujesz <ph name="BEGIN_LINK1"/>Warunki korzystania z Brave<ph name="END_LINK1"/> oraz <ph name="BEGIN_LINK2"/>Informacje na temat ochrony prywatności w Brave<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Używając tej aplikacji, akceptujesz <ph name="BEGIN_LINK1"/>Warunki korzystania z usługi<ph name="END_LINK1"/> i <ph name="BEGIN_LINK2"/>Politykę prywatności<ph name="END_LINK2"/> Brave oraz <ph name="BEGIN_LINK3"/>Informacje na temat ochrony prywatności dotyczące kont Brave Software zarządzanych przez Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> otworzy się w Brave. Przechodząc dalej, akceptujesz <ph name="BEGIN_LINK1"/>Warunki korzystania z usługi<ph name="END_LINK1"/> Brave i <ph name="BEGIN_LINK2"/>Informacje na temat ochrony prywatności<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> otworzy się w Brave. Przechodząc dalej, akceptujesz <ph name="BEGIN_LINK1"/>Warunki korzystania z usługi<ph name="END_LINK1"/> Brave, <ph name="BEGIN_LINK2"/>Informacje na temat ochrony prywatności<ph name="END_LINK2"/> i <ph name="BEGIN_LINK3"/>Informacje na temat ochrony prywatności dotyczące kont Brave Software zarządzanych przez Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Pomóż ulepszyć Brave, wysyłając do Brave Software statystyki użytkowania i raporty o awariach.</translation>
+<translation id="3518985090088779359">Akceptuj i kontynuuj</translation>
+<translation id="7207456302801184289">Witamy w Brave</translation>
+<translation id="704822250101715322">Czekam na zakończenie aktualizacji Usług Brave Software Play</translation>
+<translation id="1231733316453485619">Włączyć synchronizację?</translation>
+<translation id="5132942445612118989">Synchronizuj swoje hasła, historię i inne dane na wszystkich swoich urządzeniach</translation>
+<translation id="5736731321935944068">Brave Software może korzystać z Twojej historii, by personalizować wyniki wyszukiwania, reklamy i działanie innych usług</translation>
+<translation id="4013614219085422040">Brave Software może korzystać z Twojej historii, by personalizować wyniki wyszukiwania i działanie innych usług.</translation>
+<translation id="5581519193887989363">W <ph name="BEGIN_LINK1"/>ustawieniach<ph name="END_LINK1"/> możesz wybrać, co chcesz synchronizować.</translation>
+<translation id="741204030948306876">Tak</translation>
+<translation id="2410754283952462441">Wybierz konto</translation>
+<translation id="2227444325776770048">Kontynuuj jako <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> to nie Ty?</translation>
+<translation id="8109613176066109935">Aby korzystać ze swoich zakładek na wszystkich urządzeniach, włącz synchronizację</translation>
+<translation id="2818669890320396765">Aby korzystać ze swoich zakładek na wszystkich urządzeniach, zaloguj się i włącz synchronizację</translation>
+<translation id="6003646045106347985">Aby uzyskać dostęp do spersonalizowanej treści proponowanej przez Brave Software, włącz synchronizację</translation>
+<translation id="8494430740943879273">Aby uzyskać dostęp do spersonalizowanej treści proponowanej przez Brave Software, zaloguj się i włącz synchronizację</translation>
+<translation id="5862731021271217234">Aby korzystać z kart ze swoich innych urządzeń, włącz synchronizację</translation>
+<translation id="3568688522516854065">Aby korzystać z kart ze swoich innych urządzeń, zaloguj się i włącz synchronizację</translation>
+<translation id="1208340532756947324">Aby synchronizować i personalizować wszystkie swoje urządzenia, włącz synchronizację</translation>
+<translation id="4472118726404937099">Aby synchronizować i personalizować wszystkie swoje urządzenia, zaloguj się i włącz synchronizację</translation>
+<translation id="2426805022920575512">Wybierz inne konto</translation>
+<translation id="6790428901817661496">Odtwórz</translation>
+<translation id="1272079795634619415">Zatrzymaj</translation>
+<translation id="2874939134665556319">Poprzedni utwór</translation>
+<translation id="4046123991198612571">Następny utwór</translation>
+<translation id="3859306556332390985">Przewiń do przodu</translation>
+<translation id="8441146129660941386">Przewiń do tyłu</translation>
+<translation id="6706288973712894588">Teraz jesteś offline.\n<ph name="BEGIN_LINK"/>Przeglądaj swój kanał offline<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Ostatnie karty</translation>
+<translation id="8497726226069778601">Tu jeszcze niczego nie ma</translation>
+<translation id="5423934151118863508">Tu pojawią się strony, na które najczęściej wchodzisz</translation>
+<translation id="6127379762771434464">Element został usunięty</translation>
+<translation id="4605958867780575332">Usunięto element: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Inne urządzenia</translation>
+<translation id="4738836084190194332">Ostatnia synchronizacja: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minutę temu}few{# minuty temu}many{# minut temu}other{# minuty temu}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# godzinę temu}few{# godziny temu}many{# godzin temu}other{# godziny temu}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# dzień temu}few{# dni temu}many{# dni temu}other{# dnia temu}}</translation>
+<translation id="2762000892062317888">przed chwilą</translation>
+<translation id="1407135791313364759">Otwórz wszystkie</translation>
+<translation id="1209206284964581585">Na razie ukryj</translation>
+<translation id="129553762522093515">Ostatnio zamknięte</translation>
+<translation id="8413126021676339697">Wyświetl całą historię</translation>
+<translation id="7876243839304621966">Usuń wszystkie</translation>
+<translation id="8487700953926739672">Dostępny offline</translation>
+<translation id="5224771365102442243">Z wideo</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Dowiedz się więcej<ph name="END_LINK"/> o proponowanej treści</translation>
+<translation id="7542481630195938534">Nie można uzyskać sugestii</translation>
+<translation id="5013696553129441713">Brak nowych sugestii</translation>
+<translation id="1736419249208073774">Odkrywaj</translation>
+<translation id="7444811645081526538">Więcej kategorii</translation>
+<translation id="6709133671862442373">Wiadomości</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Zakupy</translation>
+<translation id="3912508018559818924">Szukam najlepszych treści w internecie…</translation>
+<translation id="526421993248218238">Nie udało się wczytać tej strony</translation>
+<translation id="614940544461990577">Wypróbuj te rozwiązania:</translation>
+<translation id="3288003805934695103">Odśwież stronę</translation>
+<translation id="2353636109065292463">Sprawdzanie połączenia z internetem</translation>
+<translation id="2858138569776157458">Popularne</translation>
+<translation id="8364299278605033898">Zobacz najpopularniejsze strony</translation>
+<translation id="1171770572613082465">Zobacz najpopularniejsze strony, klikając przycisk „Popularne”</translation>
+<translation id="5233638681132016545">Nowa karta</translation>
+<translation id="4521874409998847950">Opublikowane na <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>wyświetlone przez Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Dostępna jest nowsza wersja</translation>
+<translation id="4058091506841967397">Nie można zaktualizować</translation>
+<translation id="6316139424528454185">Ta wersja Androida jest nieobsługiwana</translation>
+<translation id="6989267951144302301">Nie udało się pobrać</translation>
+<translation id="624789221780392884">Aktualizacja jest gotowa</translation>
+<translation id="1549000191223877751">Przenieś do innego okna</translation>
+<translation id="7481312909269577407">Dalej</translation>
+<translation id="4084682180776658562">Dodaj do zakładek</translation>
+<translation id="6437478888915024427">Informacje o stronie</translation>
+<translation id="7180611975245234373">Odśwież</translation>
+<translation id="4913169188695071480">Zatrzymaj odświeżanie</translation>
+<translation id="1829244130665387512">Znajdź na stronie</translation>
+<translation id="6593061639179217415">Wersja na komputer</translation>
+<translation id="9063523880881406963">Wyłącz opcję „Wersja na komputer”</translation>
+<translation id="2038563949887743358">Włącz opcję „Wersja na komputer”</translation>
+<translation id="2433507940547922241">Wygląd</translation>
+<translation id="983192555821071799">Zamknij wszystkie karty</translation>
+<translation id="1310482092992808703">Grupuj karty</translation>
+<translation id="7725024127233776428">Tutaj pojawią się strony, które dodasz do zakładek</translation>
+<translation id="4404568932422911380">Brak zakładek</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> zakładka}few{<ph name="BOOKMARKS_COUNT_MANY"/> zakładki}many{<ph name="BOOKMARKS_COUNT_MANY"/> zakładek}other{<ph name="BOOKMARKS_COUNT_MANY"/> zakładki}}</translation>
+<translation id="3739899004075612870">Utworzono zakładkę w: <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Dodano do zakładek</translation>
+<translation id="4452548195519783679">Utworzono zakładkę w folderze <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Nie udało się dodać zakładki.</translation>
+<translation id="2842985007712546952">Folder nadrzędny</translation>
+<translation id="9065203028668620118">Edytuj</translation>
+<translation id="4405224443901389797">Przenieś do…</translation>
+<translation id="5170568018924773124">Pokaż w folderze</translation>
+<translation id="8035133914807600019">Nowy folder…</translation>
+<translation id="4532845899244822526">Wybierz folder</translation>
+<translation id="6627583120233659107">Edytuj folder</translation>
+<translation id="1197267115302279827">Przenieś zakładki</translation>
+<translation id="6963766334940102469">Usuń zakładki</translation>
+<translation id="4351244548802238354">Zamknij okno</translation>
+<translation id="451872707440238414">Szukaj zakładek</translation>
+<translation id="8901170036886848654">Nie znaleziono zakładek</translation>
+<translation id="6404511346730675251">Edytuj zakładkę</translation>
+<translation id="3894427358181296146">Dodaj folder</translation>
+<translation id="5327248766486351172">Nazwa</translation>
+<translation id="7400418766976504921">Adres URL</translation>
+<translation id="3527085408025491307">Folder</translation>
+<translation id="5161254044473106830">Tytuł jest wymagany</translation>
+<translation id="2996809686854298943">Wymagany adres URL</translation>
+<translation id="2536728043171574184">Oglądasz kopię offline tej strony</translation>
+<translation id="4698034686595694889">Zobacz offline w <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> i więcej stron</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave wczyta stronę, gdy będzie gotowa}few{Brave wczyta strony, gdy będą gotowe}many{Brave wczyta strony, gdy będą gotowe}other{Brave wczyta strony, gdy będą gotowe}}</translation>
+<translation id="6811034713472274749">Strona jest gotowa do wyświetlenia</translation>
+<translation id="4561979708150884304">Brak połączenia</translation>
+<translation id="8274165955039650276">Zobacz pobrane</translation>
+<translation id="2082238445998314030">Wynik <ph name="RESULT_NUMBER"/> z <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Brak wyników</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lżejsza</translation>
+<translation id="393697183122708255">Brak włączonego wyszukiwania głosowego</translation>
+<translation id="7191430249889272776">Karta otwarta w tle.</translation>
+<translation id="8445059357334030806">Otwórz w Brave</translation>
+<translation id="4720023427747327413">Otwórz w: <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Otwórz w przeglądarce</translation>
+<translation id="1113597929977215864">Pokaż widok uproszczony</translation>
+<translation id="1513352483775369820">Zakładki i historia online</translation>
+<translation id="4939482511480190003">Pomóż w ulepszaniu Brave. <ph name="BEGIN_LINK"/>Wypełnij ankietę<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Wróć</translation>
+<translation id="5596627076506792578">Więcej opcji</translation>
+<translation id="3522247891732774234">Dostępna jest aktualizacja. Więcej opcji</translation>
+<translation id="6773423637732432200">Nie udało się zaktualizować Brave. Więcej opcji</translation>
+<translation id="3328801116991980348">Informacje o witrynie</translation>
+<translation id="5391532827096253100">Twoje połączenie z tą witryną nie jest bezpieczne. Informacje o witrynie</translation>
+<translation id="6206551242102657620">Połączenie jest bezpieczne. Informacje o witrynie</translation>
+<translation id="6963642900430330478">Ta strona jest niebezpieczna. Informacje o witrynie</translation>
+<translation id="9070377983101773829">Rozpocznij wyszukiwanie głosowe</translation>
+<translation id="8676374126336081632">Wyczyść wpisany tekst</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> otwarta karta. Kliknij, by przełączyć się między kartami}few{<ph name="OPEN_TABS_MANY"/> otwarte karty. Kliknij, by przełączyć się między kartami}many{<ph name="OPEN_TABS_MANY"/> otwartych kart. Kliknij, by przełączyć się między kartami}other{<ph name="OPEN_TABS_MANY"/> otwartej karty. Kliknij, by przełączyć się między kartami}}</translation>
+<translation id="2369533728426058518">otwarte karty</translation>
+<translation id="7071521146534760487">Zarządzaj kontem</translation>
+<translation id="932327136139879170">Strona główna</translation>
+<translation id="2707726405694321444">Odśwież stronę</translation>
+<translation id="2891154217021530873">Zatrzymaj wczytywanie strony</translation>
+<translation id="6710213216561001401">Wstecz</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Wybrana karta</translation>
+<translation id="2268044343513325586">Zawęź</translation>
+<translation id="7846076177841592234">Anuluj wybór</translation>
+<translation id="7087918508125750058">Wybrano <ph name="ITEM_COUNT"/>. Opcje dostępne na górze ekranu</translation>
+<translation id="7250468141469952378">Wybrano <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Udostępnij 1 wybrany element}few{Udostępnij # wybrane elementy}many{Udostępnij # wybranych elementów}other{Udostępnij # wybranego elementu}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Usuń 1 wybrany element}few{Usuń # wybrane elementy}many{Usuń # wybranych elementów}other{Usuń # wybranego elementu}}</translation>
+<translation id="1283039547216852943">Kliknij, by rozwinąć</translation>
+<translation id="5962718611393537961">Kliknij, by zwinąć</translation>
+<translation id="8076492880354921740">Karty</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Wybrano 1}few{Wybrano #}many{Wybrano #}other{Wybrano #}}</translation>
+<translation id="6818926723028410516">Wybierz elementy</translation>
+<translation id="4797039098279997504">Kliknij, by wrócić na <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Kliknij, by przejść do strony</translation>
+<translation id="429312253194641664">Strona odtwarza multimedia</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> udostępnia Twój ekran</translation>
+<translation id="8833831881926404480">Strona udostępnia Twój ekran</translation>
+<translation id="9086455579313502267">Nie można uzyskać dostępu do sieci</translation>
+<translation id="938850635132480979">Błąd: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Otwórz w <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Otwórz w aplikacji z mapami</translation>
+<translation id="7698359219371678927">Utwórz e-maila w aplikacji <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Utwórz e-maila</translation>
+<translation id="5665379678064389456">Utwórz wydarzenie w aplikacji <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Utwórz wydarzenie</translation>
+<translation id="2111511281910874386">Przejdź do strony</translation>
+<translation id="3988466920954086464">Zobacz wyniki wyszukiwania dynamicznego w tym panelu</translation>
+<translation id="2744248271121720757">Kliknij słowo, by szybko je wyszukać lub wyświetlić powiązane czynności</translation>
+<translation id="9155898266292537608">Możesz też wyszukiwać szybkim kliknięciem słowa</translation>
+<translation id="3232754137068452469">Aplikacja internetowa</translation>
+<translation id="1430915738399379752">Drukuj</translation>
+<translation id="3775705724665058594">Wyślij na swoje urządzenia</translation>
+<translation id="6364438453358674297">Usunąć sugestię z historii?</translation>
+<translation id="213279576345780926">Zamknięto <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139">Zamknięte karty: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Usunięto: <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">Usunięte zakładki: <ph name="NUMBER_OF_BOOKMARKS"/></translation>
+<translation id="3819178904835489326">Usunięte pobrane pliki: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Nieobsługiwana liczba wystąpień Brave.</translation>
+<translation id="4259722352634471385">Adres zablokowany: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Adres nieosiągalny: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Zamknij kartę</translation>
+<translation id="7772375229873196092">Zamknij aplikację <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Historia nawigacji</translation>
+<translation id="9169507124922466868">Historia nawigacji jest otwarta w połowie</translation>
+<translation id="1327257854815634930">Historia nawigacji jest otwarta</translation>
+<translation id="8788265440806329501">Historia nawigacji jest zamknięta</translation>
+<translation id="7482656565088326534">Karta podglądu</translation>
+<translation id="8427875596167638501">Karta podglądu jest otwarta w połowie</translation>
+<translation id="9102803872260866941">Karta podglądu jest otwarta</translation>
+<translation id="2942036813789421260">Karta podglądu jest zamknięta</translation>
+<translation id="6355102470683871794">Dane aplikacji Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Wyczyścić dane witryn?</translation>
+<translation id="9205995714227143200">Dane witryn, które Brave uznaje za nieistotne (np. witryny, które rzadko odwiedzasz lub które nie mają zapisanych ustawień)</translation>
+<translation id="3997476611815694295">Nieistotne dane</translation>
+<translation id="8493948351860045254">Zwolnij miejsce</translation>
+<translation id="2324920234469020158">Spowoduje to skasowanie plików cookie, pamięci podręcznej i innych danych witryn, które Brave uzna za nieistotne.</translation>
+<translation id="5447201525962359567">Wszystkie dane witryn, w tym pliki cookie i inne dane lokalne</translation>
+<translation id="1376578503827013741">Obliczam…</translation>
+<translation id="583281660410589416">Nieznany</translation>
+<translation id="2323763861024343754">Dane witryn:</translation>
+<translation id="3587672679800759167">Łączna ilość danych używanych przez Brave, w tym konta, zakładki i zapisane ustawienia</translation>
+<translation id="6545017243486555795">Wyczyść wszystkie dane</translation>
+<translation id="4095146165863963773">Usunąć dane aplikacji?</translation>
+<translation id="53119194224775367">Wszystkie dane aplikacji Brave zostaną trwale usunięte. Dotyczy to wszystkich plików, ustawień, kont, baz danych itp.</translation>
+<translation id="5307446750509046227">Wyczyść dane witryn</translation>
+<translation id="300526633675317032">Spowoduje to usunięcie <ph name="SIZE_IN_KB"/> danych witryn.</translation>
+<translation id="8068648041423924542">Nie można wybrać certyfikatu.</translation>
+<translation id="2315043854645842844">Wybieranie certyfikatu klienta nie jest obsługiwane przez ten system operacyjny.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> chce się połączyć</translation>
+<translation id="5308380583665731573">Połącz</translation>
+<translation id="868929229000858085">Wyszukaj w kontaktach</translation>
+<translation id="1919950603503897840">Wybierz kontakty</translation>
+<translation id="7986741934819883144">Wybierz kontakt</translation>
+<translation id="3333961966071413176">Wszystkie kontakty</translation>
+<translation id="4994033804516042629">Nie znaleziono kontaktów</translation>
+<translation id="5403592356182871684">Nazwy</translation>
+<translation id="2717722538473713889">Adresy e-mail</translation>
+<translation id="381841723434055211">Numery telefonów</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(i jeszcze 1)}few{(i jeszcze #)}many{(i jeszcze #)}other{(i jeszcze #)}}</translation>
+<translation id="5197729504361054390">Wybrane kontakty zostaną udostępnione witrynie <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Dekoder obrazów</translation>
+<translation id="8067883171444229417">Odtwórz film</translation>
+<translation id="6560414384669816528">Szukaj w Sogou</translation>
+<translation id="5406914950576900927">Brave może używać <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> do wyszukiwania w Chinach. Możesz to zmienić w <ph name="BEGIN_LINK"/>Ustawieniach<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Zachowaj Brave Software</translation>
+<translation id="4384468725000734951">Korzystam z wyszukiwarki Sogou</translation>
+<translation id="6103327872225198548">Korzystam z wyszukiwarki Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Ta aplikacja działa w Brave</translation>
+<translation id="6143689084714664628">Otwarta w Brave</translation>
+<translation id="7675869148432102528">Dane aplikacji <ph name="APP_NAME"/> znajdują się też w Brave</translation>
+<translation id="2734140769649165081">Dane możesz usunąć w Ustawieniach Brave</translation>
+<translation id="8232956427053453090">Zachowaj dane</translation>
+<translation id="4298388696830689168">Połączone strony</translation>
+<translation id="5763514718066511291">Kliknij, by skopiować URL tej aplikacji</translation>
+<translation id="6496823230996795692">Aby pierwszy raz skorzystać z aplikacji <ph name="APP_NAME"/>, połącz się z internetem.</translation>
+<translation id="751961395872307827">Nie można połączyć się ze stroną</translation>
+<translation id="4878404682131129617">Nie udało się utworzyć tunelu przez serwer proxy</translation>
+<translation id="4749960740855309258">Otwórz nową kartę</translation>
+<translation id="8788968922598763114">Ponownie otwórz ostatnio zamknięte karty</translation>
+<translation id="7929962904089429003">Otwórz menu</translation>
+<translation id="6039379616847168523">Przejdź do następnej karty</translation>
+<translation id="5210286577605176222">Przejdź do poprzedniej karty</translation>
+<translation id="124678866338384709">Zamknij bieżącą kartę</translation>
+<translation id="3714981814255182093">Otwórz pasek wyszukiwania</translation>
+<translation id="5441522332038954058">Przejdź do paska adresu</translation>
+<translation id="3398320232533725830">Otwórz menedżera zakładek</translation>
+<translation id="6583199322650523874">Dodaj bieżącą stronę do zakładek</translation>
+<translation id="8489271220582375723">Otwórz stronę historii</translation>
+<translation id="4837753911714442426">Otwórz opcje drukowania strony</translation>
+<translation id="5726692708398506830">Powiększ całą zawartość strony</translation>
+<translation id="3259831549858767975">Pomniejsz całą zawartość strony</translation>
+<translation id="8015452622527143194">Powróć do normalnego rozmiaru całej treści strony</translation>
+<translation id="3443221991560634068">Ponownie załaduj bieżącą stronę</translation>
+<translation id="123724288017357924">Ponowie załaduj stronę, bez pamięci podręcznej</translation>
+<translation id="305870044889644984">Otwórz Centrum pomocy Brave w nowej karcie</translation>
+<translation id="3166827708714933426">Skróty kart i okien</translation>
+<translation id="3169981355900570544">Skróty do funkcji Brave Software Brave</translation>
+<translation id="4558311620361989323">Skróty stron internetowych</translation>
+<translation id="1908301351964700579">Wirtualna rzeczywistość w Brave nie jest jeszcze gotowa. Uruchom Brave ponownie później.</translation>
+<translation id="8970887620466824814">Coś poszło nie tak.</translation>
+<translation id="1875543012935658554">Uruchom ponownie Brave.</translation>
+<translation id="79859296434321399">Aby oglądać treści rzeczywistości rozszerzonej, zainstaluj ARCore</translation>
+<translation id="8558485628462305855">Aby oglądać treści rzeczywistości rozszerzonej, zaktualizuj ARCore</translation>
+<translation id="3513704683820682405">Rzeczywistość rozszerzona</translation>
+<translation id="5475862044948910901">Rozpocząć sesję rzeczywistości rozszerzonej?</translation>
 <translation id="7365126855094612066">W czasie trwania sesji strona będzie mogła:
 • tworzyć mapę 3D Twojego otoczenia,
 • śledzić ruch kamery.
 
 Witryna NIE uzyskuje dostępu do kamery. Tylko Ty widzisz rejestrowany obraz.</translation>
-<translation id="7375125077091615385">Typ:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">Adres URL</translation>
-<translation id="7403691278183511381">Pierwsze uruchomienie Chrome</translation>
-<translation id="741204030948306876">Tak</translation>
-<translation id="7413229368719586778">Data rozpoczęcia: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Najpierw zapytaj</translation>
-<translation id="7423538860840206698">Zablokowano odczytywanie schowka</translation>
-<translation id="7431991332293347422">Zarządzaj personalizacją wyszukiwarki i innych funkcji na podstawie historii przeglądania</translation>
-<translation id="7437998757836447326">Wyloguj się z Chrome</translation>
-<translation id="7438641746574390233">W wersji uproszczonej Chrome korzysta z serwerów Google, by szybciej wczytywać strony. W wersji uproszczonej bardzo wolne strony są przepisywane na nowo, by ładowały się tylko najważniejsze treści. Wersja uproszczona nie działa na kartach incognito.</translation>
-<translation id="7444811645081526538">Więcej kategorii</translation>
-<translation id="7445411102860286510">Zezwalaj witrynom na automatyczne odtwarzanie wyciszonych filmów (zalecane)</translation>
-<translation id="7453467225369441013">Wylogowuje z większości stron internetowych. Nie wyloguje Cię z konta Google.</translation>
-<translation id="7454641608352164238">Za mało miejsca</translation>
-<translation id="7475192538862203634">Jeśli często widzisz ten komunikat, przeczytaj te <ph name="BEGIN_LINK" />wskazówki<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Nie znaleziono karty SD. Może brakować niektórych Twoich plików.</translation>
-<translation id="7479104141328977413">Zarządzanie kartami</translation>
-<translation id="7481312909269577407">Dalej</translation>
-<translation id="7482656565088326534">Karta podglądu</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (zaktualizowana <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">zaoszczędzonych danych</translation>
-<translation id="7498271377022651285">Czekaj…</translation>
-<translation id="7514365320538308">Pobierz</translation>
-<translation id="751961395872307827">Nie można połączyć się ze stroną</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Nie można uzyskać sugestii</translation>
-<translation id="7559975015014302720">Wersja uproszczona jest wyłączona</translation>
-<translation id="7562080006725997899">Czyszczenie danych przeglądania</translation>
-<translation id="756809126120519699">Wyczyszczono dane Chrome</translation>
-<translation id="757524316907819857">Blokuj odtwarzanie treści chronionej na stronach</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Pobrano <ph name="FILES_DOWNLOADED_ONE" /> plik}few{Pobrano <ph name="FILES_DOWNLOADED_MANY" /> pliki}many{Pobrano <ph name="FILES_DOWNLOADED_MANY" /> plików}other{Pobrano <ph name="FILES_DOWNLOADED_MANY" /> pliku}}</translation>
-<translation id="7588219262685291874">Włącz tryb ciemny, gdy na urządzeniu jest aktywne oszczędzanie baterii</translation>
-<translation id="7589445247086920869">Blokuj dostęp obecnej wyszukiwarce</translation>
-<translation id="7593557518625677601">Otwórz ustawienia Androida i ponownie włącz jego synchronizację, by uruchomić Synchronizację Chrome</translation>
-<translation id="7596558890252710462">System operacyjny</translation>
-<translation id="7605594153474022051">Synchronizacja nie działa</translation>
-<translation id="7606077192958116810">Wersja uproszczona jest włączona. Możesz nią zarządzać w Ustawieniach.</translation>
-<translation id="7612619742409846846">Jesteś zalogowany w Google jako</translation>
-<translation id="7619072057915878432">Nie udało się pobrać pliku <ph name="FILE_NAME" /> z powodu problemów z siecią.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Skorzystaj z pomocy<ph name="END_LINK1" /> lub <ph name="BEGIN_LINK2" />skanuj ponownie<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Witamy w Chrome</translation>
-<translation id="7638584964844754484">Nieprawidłowe hasło</translation>
-<translation id="7641339528570811325">Wyczyść dane przeglądania…</translation>
-<translation id="7648422057306047504">Zaszyfruj hasła za pomocą danych logowania Google</translation>
-<translation id="7649070708921625228">Pomoc</translation>
-<translation id="7658239707568436148">Anuluj</translation>
-<translation id="7665369617277396874">Dodaj konto</translation>
-<translation id="766587987807204883">Tutaj pojawiają się artykuły, które możesz czytać, nawet gdy jesteś offline</translation>
-<translation id="7682724950699840886">Skorzystaj z tych wskazówek: upewnij się, że masz wystarczająco dużo miejsca na urządzeniu, i ponownie spróbuj wyeksportować hasła.</translation>
-<translation id="7685301384041462804">Zanim włączysz VR na tej stronie, sprawdź, czy można uznać ją za zaufaną.</translation>
-<translation id="7698359219371678927">Utwórz e-maila w aplikacji <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Autouzupełniaj wyszukiwania i adresy URL</translation>
-<translation id="7725024127233776428">Tutaj pojawią się strony, które dodasz do zakładek</translation>
-<translation id="773466115871691567">Zawsze tłumacz strony, których językiem jest <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Aby wykrywać niebezpieczne aplikacje i witryny, Chrome wysyła do Google adresy URL i część zawartości niektórych odwiedzanych przez Ciebie stron, a także niektóre informacje o systemie</translation>
-<translation id="7757787379047923882">Tekst udostępniony z urządzenia <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Karta SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Dodaj adres</translation>
-<translation id="7772032839648071052">Potwierdź hasło</translation>
-<translation id="7772375229873196092">Zamknij aplikację <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}few{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}many{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 i jeszcze <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Wczoraj</translation>
-<translation id="7791543448312431591">Dodaj</translation>
-<translation id="780301667611848630">Nie, dziękuję</translation>
-<translation id="7810647596859435254">Otwórz za pomocą…</translation>
-<translation id="7821588508402923572">Tutaj będą widoczne informacje o zaoszczędzonych danych</translation>
-<translation id="7837721118676387834">Zezwalaj określonej stronie na automatyczne odtwarzanie wyciszonych filmów.</translation>
-<translation id="7846076177841592234">Anuluj wybór</translation>
-<translation id="784934925303690534">Zakres czasu</translation>
-<translation id="7851858861565204677">Inne urządzenia</translation>
-<translation id="7875915731392087153">Utwórz e-maila</translation>
-<translation id="7876243839304621966">Usuń wszystkie</translation>
-<translation id="7882131421121961860">Brak historii</translation>
-<translation id="7882806643839505685">Zezwalaj na dźwięk na określonej stronie.</translation>
-<translation id="7886917304091689118">Otwarta w Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Pobieram plik.}few{Pobieram # pliki.}many{Pobieram # plików.}other{Pobieram # pliku.}}</translation>
-<translation id="7929962904089429003">Otwórz menu</translation>
-<translation id="7942131818088350342">Przeglądarka <ph name="PRODUCT_NAME" /> jest nieaktualna.</translation>
-<translation id="7947953824732555851">Zaakceptuj i zaloguj się</translation>
-<translation id="7963646190083259054">Dostawca:</translation>
-<translation id="7971136598759319605">Aktywność 1 dzień temu</translation>
-<translation id="7975379999046275268">Wyświetl podgląd strony <ph name="BEGIN_NEW" />Nowość<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Ładuj wstępnie strony, by przyspieszyć przeglądanie i wyszukiwanie</translation>
-<translation id="79859296434321399">Aby oglądać treści rzeczywistości rozszerzonej, zainstaluj ARCore</translation>
-<translation id="7986741934819883144">Wybierz kontakt</translation>
-<translation id="7987073022710626672">Warunki korzystania z Chrome</translation>
-<translation id="7998918019931843664">Otwórz ponownie zamkniętą kartę</translation>
-<translation id="7999064672810608036">Na pewno chcesz usunąć wszystkie dane lokalne (w tym pliki cookie) i zresetować uprawnienia tej witryny?</translation>
-<translation id="8004582292198964060">Przeglądarka</translation>
-<translation id="8007176423574883786">Wyłączona na tym urządzeniu</translation>
-<translation id="8013372441983637696">Usuń też swoje dane Chrome z tego urządzenia</translation>
-<translation id="8015452622527143194">Powróć do normalnego rozmiaru całej treści strony</translation>
-<translation id="802154636333426148">Nie udało się pobrać</translation>
-<translation id="8026334261755873520">Wyczyść dane przeglądania</translation>
-<translation id="8035133914807600019">Nowy folder…</translation>
-<translation id="8037750541064988519">Pozostało: <ph name="DAYS" /> dni</translation>
-<translation id="804335162455518893">Nie znaleziono karty SD</translation>
-<translation id="805047784848435650">Na podstawie Twojej historii przeglądania</translation>
-<translation id="8051695050440594747">Dostępne: <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">Otwórz w nowej karcie Chrome</translation>
-<translation id="8063895661287329888">Nie udało się dodać zakładki.</translation>
-<translation id="806745655614357130">Przechowuj dane oddzielnie</translation>
-<translation id="8067883171444229417">Odtwórz film</translation>
-<translation id="8068648041423924542">Nie można wybrać certyfikatu.</translation>
-<translation id="8073388330009372546">Otwórz grafikę w nowej karcie</translation>
-<translation id="8076492880354921740">Karty</translation>
-<translation id="8084114998886531721">Zapisane hasło</translation>
-<translation id="8087000398470557479">Treść z <ph name="DOMAIN_NAME" /> dostarczana przez Google.</translation>
-<translation id="8103578431304235997">Karta incognito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Aby korzystać ze swoich zakładek na wszystkich urządzeniach, włącz synchronizację</translation>
-<translation id="8110087112193408731">Pokazywać Twoją aktywność w Chrome w Cyfrowej równowadze?</translation>
-<translation id="8116925261070264013">Wyciszone</translation>
-<translation id="813082847718468539">Wyświetl informacje o witrynie</translation>
-<translation id="8131740175452115882">Potwierdź</translation>
-<translation id="8156139159503939589">W jakich językach umiesz czytać?</translation>
-<translation id="8168435359814927499">Treści</translation>
-<translation id="8186512483418048923">Pozostałe pliki: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Pozostał dzień</translation>
-<translation id="8200772114523450471">Wznów</translation>
-<translation id="8209050860603202033">Otwórz grafikę</translation>
-<translation id="8218622182176210845">Zarządzaj kontem</translation>
-<translation id="8224471946457685718">Pobieranie artykułów dla Ciebie przez Wi-Fi</translation>
-<translation id="8232956427053453090">Zachowaj dane</translation>
-<translation id="8249310407154411074">Przenieś na początek</translation>
-<translation id="8250920743982581267">Dokumenty</translation>
-<translation id="825412236959742607">Ta strona używa zbyt dużo pamięci, dlatego Chrome usunął część jej zawartości.</translation>
-<translation id="8260126382462817229">Spróbuj zalogować się jeszcze raz</translation>
-<translation id="8261506727792406068">Usuń</translation>
-<translation id="8266862848225348053">Miejsce zapisywania pobranych plików</translation>
-<translation id="8274165955039650276">Zobacz pobrane</translation>
-<translation id="8284326494547611709">Napisy</translation>
-<translation id="8300705686683892304">Zarządzane przez aplikację</translation>
-<translation id="8310344678080805313">Karty standardowe</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> i więcej stron</translation>
-<translation id="8327155640814342956">Aby komfortowo przeglądać internet, otwórz tę stronę i zaktualizuj Chrome</translation>
-<translation id="8339163506404995330">Strony, których językiem jest <ph name="LANGUAGE" />, nie będą tłumaczone</translation>
-<translation id="8349013245300336738">Sortuj według ilości wykorzystanych danych</translation>
-<translation id="8364299278605033898">Zobacz najpopularniejsze strony</translation>
-<translation id="8368027906805972958">Nieznane lub nieobsługiwane urządzenie (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Zezwalaj na synchronizowanie w tle z określoną stroną.</translation>
-<translation id="8378714024927312812">Zarządzane przez Twoją organizację</translation>
-<translation id="8380167699614421159">Na tej stronie wyświetlają się uciążliwe lub wprowadzające w błąd reklamy</translation>
-<translation id="8393700583063109961">Wyślij wiadomość</translation>
-<translation id="8413126021676339697">Wyświetl całą historię</translation>
-<translation id="8427875596167638501">Karta podglądu jest otwarta w połowie</translation>
-<translation id="8428213095426709021">Ustawienia</translation>
-<translation id="8438566539970814960">Ulepsz wyszukiwanie i przeglądanie</translation>
-<translation id="8441146129660941386">Przewiń do tyłu</translation>
-<translation id="8443209985646068659">Nie można zaktualizować</translation>
-<translation id="8445448999790540984">Nie można wyeksportować haseł</translation>
-<translation id="8447861592752582886">Cofnij zgodę na dostęp do urządzenia</translation>
-<translation id="8461694314515752532">Szyfruj synchronizowane dane własnym hasłem synchronizacji</translation>
-<translation id="8466613982764129868">Sprawdź, czy <ph name="TARGET_DEVICE_NAME" /> ma połączenie z internetem</translation>
-<translation id="8485434340281759656"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8487700953926739672">Dostępny offline</translation>
-<translation id="8489271220582375723">Otwórz stronę historii</translation>
-<translation id="8493948351860045254">Zwolnij miejsce</translation>
-<translation id="8497726226069778601">Tu jeszcze niczego nie ma</translation>
-<translation id="8503559462189395349">Hasła w Chrome</translation>
-<translation id="8503813439785031346">Nazwa użytkownika</translation>
-<translation id="8514477925623180633">Eksportuj hasła zapisane w Chrome</translation>
-<translation id="8514577642972634246">Włącz tryb incognito</translation>
-<translation id="851751545965956758">Nie zezwalaj stronom na łączenie się z urządzeniami</translation>
-<translation id="8523928698583292556">Usuń zapisane hasło</translation>
-<translation id="854522910157234410">Otwórz tę stronę</translation>
-<translation id="8558485628462305855">Aby oglądać treści rzeczywistości rozszerzonej, zaktualizuj ARCore</translation>
-<translation id="8559990750235505898">Proponuj tłumaczenie stron w innych językach</translation>
-<translation id="8562452229998620586">Tutaj pojawią się zapisane hasła.</translation>
-<translation id="8569404424186215731">od <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Ostatnie 4 tygodnie</translation>
-<translation id="857943718398505171">Dozwolone (zalecane)</translation>
-<translation id="8583805026567836021">Usuwam dane konta</translation>
-<translation id="860043288473659153">Imię i nazwisko posiadacza karty</translation>
-<translation id="8609465669617005112">W górę</translation>
-<translation id="8616006591992756292">Inne rodzaje historii przeglądania mogą być nadal dostępne na Twoim koncie Google na <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Otworzyć sugerowany URL określony w pobranych materiałach?</translation>
-<translation id="8636825310635137004">Aby korzystać z kart ze swoich innych urządzeń, włącz synchronizację</translation>
-<translation id="8641930654639604085">Próbuj blokować strony dla dorosłych</translation>
-<translation id="8655129584991699539">Dane możesz usunąć w Ustawieniach Chrome</translation>
-<translation id="8662811608048051533">Wylogowuje z większości stron internetowych.</translation>
-<translation id="8664979001105139458">Ta nazwa pliku już istnieje</translation>
-<translation id="8676374126336081632">Wyczyść wpisany tekst</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Poziom siły sygnału: # słupek}few{Poziom siły sygnału: # słupki}many{Poziom siły sygnału: # słupków}other{Poziom siły sygnału: # słupka}}</translation>
-<translation id="868929229000858085">Wyszukaj w kontaktach</translation>
-<translation id="869891660844655955">Data wygaśnięcia</translation>
-<translation id="8719023831149562936">Nie można przesłać bieżącej karty</translation>
-<translation id="8725066075913043281">Spróbuj ponownie</translation>
-<translation id="8728487861892616501">Używając tej aplikacji, akceptujesz <ph name="BEGIN_LINK1" />Warunki korzystania z usługi<ph name="END_LINK1" /> i <ph name="BEGIN_LINK2" />Politykę prywatności<ph name="END_LINK2" /> Chrome oraz <ph name="BEGIN_LINK3" />Informacje na temat ochrony prywatności dotyczące kont Google zarządzanych przez Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Gotowe</translation>
-<translation id="8748850008226585750">Treści ukryte</translation>
-<translation id="8751914237388039244">Wybierz obraz</translation>
-<translation id="8788265440806329501">Historia nawigacji jest zamknięta</translation>
-<translation id="8788968922598763114">Ponownie otwórz ostatnio zamknięte karty</translation>
-<translation id="8801436777607969138">Zablokuj JavaScript w określonej witrynie.</translation>
-<translation id="8812260976093120287">Używając swojego urządzenia, na niektórych stronach możesz płacić za pomocą powyższych obsługiwanych aplikacji do płatności.</translation>
-<translation id="8816026460808729765">Blokuj stronom dostęp do czujników</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> otworzy się w Chrome. Przechodząc dalej, akceptujesz <ph name="BEGIN_LINK1" />Warunki korzystania z usługi<ph name="END_LINK1" /> Chrome, <ph name="BEGIN_LINK2" />Informacje na temat ochrony prywatności<ph name="END_LINK2" /> i <ph name="BEGIN_LINK3" />Informacje na temat ochrony prywatności dotyczące kont Google zarządzanych przez Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Zakładki</translation>
-<translation id="8833831881926404480">Strona udostępnia Twój ekran</translation>
-<translation id="883806473910249246">Podczas pobierania treści wystąpił błąd.</translation>
-<translation id="8840953339110955557">Ta strona może różnić się od wersji online.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Karta <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Pamięć</translation>
-<translation id="889338405075704026">Otwórz ustawienia Chrome</translation>
-<translation id="8901170036886848654">Nie znaleziono zakładek</translation>
-<translation id="8909135823018751308">Udostępnij…</translation>
-<translation id="8912362522468806198">Konta Google</translation>
-<translation id="8920114477895755567">Oczekiwanie na informacje o rodzicach.</translation>
+<translation id="1188239144602654184">Włącz AR</translation>
+<translation id="473775607612524610">Aktualizuj</translation>
+<translation id="3133489217401741157">Instaluję moduł <ph name="MODULE"/> do Brave…</translation>
+<translation id="1791662854739702043">Zainstalowano</translation>
+<translation id="5131234170665854056">Nie można zainstalować modułu <ph name="MODULE"/> do Brave</translation>
+<translation id="2567385386134582609">OBRAZ</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">FILM</translation>
+<translation id="4116038641877404294">Pobierz strony, by przeglądać je w trybie offline</translation>
 <translation id="8922289737868596582">Pobierz strony, używając przycisku Więcej opcji, by korzystać z nich w trybie offline</translation>
-<translation id="8937772741022875483">Usunąć Twoją aktywność w Chrome z Cyfrowej równowagi?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Otwórz w innym oknie</translation>
-<translation id="8951232171465285730">Chrome pozwolił Ci zaoszczędzić <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokuj pliki cookie z określonej strony internetowej.</translation>
-<translation id="8959122750345127698">Adres nieosiągalny: <ph name="URL" /></translation>
-<translation id="8965591936373831584">Oczekiwanie</translation>
-<translation id="8970887620466824814">Coś poszło nie tak.</translation>
-<translation id="8972098258593396643">Czy pobrać do folderu domyślnego?</translation>
-<translation id="8986494364107987395">Automatycznie przesyłaj do Google statystyki użytkowania i raporty o awariach</translation>
-<translation id="8993760627012879038">Otwórz nową kartę w trybie incognito</translation>
-<translation id="8998729206196772491">Logujesz się na konto, którym zarządza <ph name="MANAGED_DOMAIN" />, i przekazujesz jego administratorowi kontrolę nad Twoimi danymi Chrome. Zostaną one trwale przypisane do tego konta. Gdy się wylogujesz, znikną one z tego urządzenia, ale pozostaną zapisane na Twoim koncie Google.</translation>
-<translation id="9019902583201351841">Zarządzany przez Twoich rodziców</translation>
-<translation id="9028914725102941583">Aby udostępniać treści między urządzeniami, włącz synchronizację</translation>
-<translation id="9029323097866369874">Zezwolić domenie <ph name="DOMAIN" /> na uruchamianie VR?</translation>
-<translation id="9040142327097499898">Powiadomienia są włączone. Lokalizacja jest wyłączona na tym urządzeniu.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# film}few{# filmy}many{# filmów}other{# filmu}}</translation>
-<translation id="9050666287014529139">Hasło</translation>
-<translation id="9063523880881406963">Wyłącz opcję „Wersja na komputer”</translation>
-<translation id="9065203028668620118">Edytuj</translation>
-<translation id="9070377983101773829">Rozpocznij wyszukiwanie głosowe</translation>
-<translation id="9074336505530349563">Aby uzyskać dostęp do spersonalizowanej treści proponowanej przez Google, zaloguj się i włącz synchronizację</translation>
-<translation id="9086455579313502267">Nie można uzyskać dostępu do sieci</translation>
-<translation id="9100505651305367705">Proponuj wyświetlanie artykułów w widoku uproszczonym, gdy jest obsługiwany</translation>
-<translation id="9100610230175265781">Wymagane jest hasło</translation>
-<translation id="9102803872260866941">Karta podglądu jest otwarta</translation>
+<translation id="5958275228015807058">Znajdź pliki i strony w Pobranych plikach</translation>
+<translation id="5620928963363755975">Znajdź pliki i strony w Pobranych plikach, używając przycisku Więcej opcji</translation>
+<translation id="3341058695485821946">Sprawdź ilość zaoszczędzonych danych</translation>
+<translation id="3157842584138209013">Sprawdź ilość zaoszczędzonych danych, używając przycisku Więcej opcji</translation>
+<translation id="8218622182176210845">Zarządzaj kontem</translation>
+<translation id="8090895580117672212">Aby zarządzać kontem Brave Software, kliknij przycisk „Zarządzaj kontem”</translation>
+<translation id="8856898588039823173">Lżejsza wersja strony dostarczona przez Brave Software. Kliknij, by załadować wersję oryginalną.</translation>
+<translation id="8134317863207426198">Lżejsza wersja strony dostarczona przez Brave Software. Aby wczytać oryginalną wersję, kliknij przycisk Załaduj oryginał.</translation>
+<translation id="4961107849584082341">Możesz przetłumaczyć tę stronę na dowolny język</translation>
+<translation id="569536719314091526">Możesz przetłumaczyć tę stronę na dowolny język, używając przycisku Więcej opcji</translation>
+<translation id="1397811292916898096">Szukaj w <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">W dowolnej chwili możesz zmienić domyślną lokalizację pobierania</translation>
+<translation id="6942665639005891494">W dowolnej chwili w Ustawieniach możesz zmienić domyślną lokalizację pobierania</translation>
+<translation id="6850409657436465440">Pobieranie wciąż trwa</translation>
+<translation id="5817715962196959877">Brave pobiera pliki jeszcze szybciej</translation>
+<translation id="3976396876660209797">Usuń i utwórz ponownie ten skrót</translation>
+<translation id="6766622839693428701">Przesuń w dół, by zamknąć.</translation>
+<translation id="1028699632127661925">Przesyłam na: <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – wysłane z: <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Odebrano kartę</translation>
 <translation id="9104217018994036254">Lista urządzeń, którym udostępnisz kartę.</translation>
-<translation id="9133397713400217035">Przeglądaj offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Pokaż tekst oryginalny</translation>
-<translation id="9139068048179869749">Pytaj, zanim zezwolisz stronom na wysyłanie powiadomień (zalecane)</translation>
-<translation id="9139318394846604261">Zakupy</translation>
-<translation id="9155898266292537608">Możesz też wyszukiwać szybkim kliknięciem słowa</translation>
-<translation id="9169507124922466868">Historia nawigacji jest otwarta w połowie</translation>
-<translation id="9204836675896933765">Pozostał jeden plik</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Lista urządzeń, którym udostępnisz kartę, jest otwarta na połowę wysokości.</translation>
+<translation id="2904414404539560095">Lista urządzeń, którym udostępnisz kartę, jest otwarta na pełną wysokość.</translation>
+<translation id="4135200667068010335">Lista urządzeń, którym udostępnisz kartę, jest zamknięta.</translation>
+<translation id="5292796745632149097">Wyślij na</translation>
+<translation id="1386674309198842382">Aktywność <ph name="LAST_UPDATED"/> dni temu</translation>
+<translation id="7971136598759319605">Aktywność 1 dzień temu</translation>
+<translation id="1521774566618522728">Aktywność: dzisiaj</translation>
+<translation id="3631987586758005671">Udostępniam urządzeniu <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Aby udostępniać treści między urządzeniami, włącz synchronizację</translation>
+<translation id="6162454065885854378">Jeśli chcesz udostępnić coś z telefonu na innym urządzeniu, w ustawieniach Brave na obu urządzeniach włącz synchronizację</translation>
+<translation id="6084271560289605378">Otwórz ustawienia Brave</translation>
+<translation id="2318045970523081853">Kliknij, by zadzwonić</translation>
 <translation id="9209888181064652401">Nie można wykonywać połączeń</translation>
-<translation id="9219103736887031265">Grafika</translation>
-<translation id="926205370408745186">Usuwa Twoją aktywność w Chrome z Cyfrowej równowagi</translation>
-<translation id="932327136139879170">Strona główna</translation>
-<translation id="938850635132480979">Błąd: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Dostęp do mikrofonu</translation>
-<translation id="95817756606698420">Chrome może używać <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> do wyszukiwania w Chinach. Możesz to zmienić w <ph name="BEGIN_LINK" />Ustawieniach<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Zablokuj, jeśli na stronie wyświetlają się uciążliwe lub wprowadzające w błąd reklamy (zalecane)</translation>
-<translation id="968900484120156207">Tutaj pojawią się strony, które odwiedzisz</translation>
-<translation id="970715775301869095">Pozostało: <ph name="MINUTES" /> min</translation>
-<translation id="974555521953189084">Wpisz hasło, by rozpocząć synchronizację</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Spowoduje to usunięcie danych wszystkich witryn, w tym:</translation>
-<translation id="983192555821071799">Zamknij wszystkie karty</translation>
-<translation id="987264212798334818">Ogólne</translation>
+<translation id="2860954141821109167">Sprawdź, czy na urządzeniu jest włączona aplikacja telefonu</translation>
+<translation id="2067805253194386918">Tekst</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/>: nie udało się udostępnić</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> – nie udało się udostępnić</translation>
+<translation id="8287068819750208230">Sprawdź, czy <ph name="TARGET_DEVICE_NAME"/> ma włączoną synchronizację w Brave</translation>
+<translation id="3016635187733453316">Sprawdź, czy to urządzenie jest połączone z internetem</translation>
+<translation id="8466613982764129868">Sprawdź, czy <ph name="TARGET_DEVICE_NAME"/> ma połączenie z internetem</translation>
+<translation id="6539092367496845964">Coś poszło nie tak. Spróbuj później.</translation>
+<translation id="3389286852084373014">Tekst jest za długi</translation>
+<translation id="2100314319871056947">Spróbuj udostępnić mniejsze fragmenty tekstu</translation>
+<translation id="2987620471460279764">Tekst udostępniany przez inne urządzenia</translation>
+<translation id="7757787379047923882">Tekst udostępniony z urządzenia <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Skopiowane do schowka</translation>
+<translation id="4696983787092045100">Wyślij tekst na swoje urządzenia</translation>
+<translation id="1260236875608242557">Szukaj i przeglądaj</translation>
+<translation id="6369229450655021117">Tutaj możesz wyszukiwać informacje w internecie, udostępniać treści znajomym i przeglądać otwarte strony</translation>
+<translation id="723171743924126238">Wybierz zdjęcia</translation>
+<translation id="8751914237388039244">Wybierz obraz</translation>
+<translation id="1989112275319619282">Przeglądaj</translation>
+<translation id="7055152154916055070">Zablokowano przekierowanie:</translation>
+<translation id="5524843473235508879">Przekierowanie zostało zablokowane.</translation>
+<translation id="6573096386450695060">Zawsze zezwalaj</translation>
+<translation id="5805364706385912897">Ta strona używa zbyt dużo pamięci, dlatego została wstrzymana w Brave.</translation>
+<translation id="5138664332909611586">Ta strona używa zbyt dużo pamięci, dlatego Brave usunął część jej zawartości.</translation>
+<translation id="9137013805542155359">Pokaż tekst oryginalny</translation>
+<translation id="6361779936989026201">Asystent Brave Software w Brave</translation>
+<translation id="7291387454912369099">Płatność przez Asystenta</translation>
+<translation id="4565206163201411670">Pokazywać Twoją aktywność w Brave w Cyfrowej równowadze?</translation>
+<translation id="9055113864158719823">Możesz wyświetlić strony otwierane w Brave i ustawić dla nich liczniki czasu.\n\nBrave Software otrzymuje informacje o stronach, dla których masz ustawione liczniki czasu, i o tym, jak długo je przeglądasz. Używamy tych informacji do udoskonalania Cyfrowej równowagi.</translation>
+<translation id="4596514158372210596">Usuwa Twoją aktywność w Brave z Cyfrowej równowagi</translation>
+<translation id="1174893863889683998">Usunąć Twoją aktywność w Brave z Cyfrowej równowagi?</translation>
+<translation id="708829030563435351">Strony, które otwierasz w Brave, nie będą widoczne. Wszystkie liczniki czasu dotyczące stron zostaną usunięte.</translation>
+<translation id="2056878612599315956">Strona wstrzymana</translation>
+<translation id="671481426037969117">Licznik czasu w aplikacji <ph name="FQDN"/> dobiegł końca. Jutro zacznie działać od nowa.</translation>
+<translation id="7479104141328977413">Zarządzanie kartami</translation>
+<translation id="3524138585025253783">Interfejs dewelopera</translation>
+<translation id="6036057147555329831">Dodatkowy moduł ICU</translation>
+<translation id="9029323097866369874">Zezwolić domenie <ph name="DOMAIN"/> na uruchamianie VR?</translation>
+<translation id="7685301384041462804">Zanim włączysz VR na tej stronie, sprawdź, czy można uznać ją za zaufaną.</translation>
+<translation id="5033865233969348410">Gdy używasz VR, ta strona może poznać te informacje:
+  –  Twoje cechy fizyczne, np. wzrost.
+
+Zanim włączysz VR na tej stronie, sprawdź, czy można uznać ją za zaufaną.</translation>
+<translation id="5534334044554683961">Gdy używasz VR, ta strona może poznać te informacje:
+  –   Twoje cechy fizyczne, np wzrost;
+  –   układ Twojego pokoju.
+
+Zanim włączysz VR na tej stronie, sprawdź, czy można uznać ją za zaufaną.</translation>
+<translation id="4169535189173047238">Nie zezwalaj</translation>
+<translation id="2170088579611075216">Zezwól na tryb VR i włącz go</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_pt-BR.xtb
+++ b/android/java/strings/translations/android_chrome_strings_pt-BR.xtb
@@ -1,1119 +1,1102 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="pt-BR">
-<translation id="1006017844123154345">Abrir on-line</translation>
-<translation id="1028699632127661925">Enviando para este dispositivo: <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">Adicionando <ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">De sites</translation>
-<translation id="1049743911850919806">Modo anônimo</translation>
-<translation id="10614374240317010">Nunca salvas</translation>
-<translation id="1067922213147265141">Outros serviços do Google</translation>
-<translation id="1068672505746868501">Nunca traduzir páginas em <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Se você mudar a extensão do arquivo, ele poderá ser aberto em um aplicativo diferente e colocar em risco seu dispositivo.</translation>
-<translation id="1100066534610197918">Abrir em nova guia no grupo</translation>
-<translation id="1105960400813249514">Captura de tela</translation>
-<translation id="1111673857033749125">Favoritos salvos nos seus outros dispositivos serão exibidos aqui.</translation>
-<translation id="1113597929977215864">Mostrar a versão simplificada</translation>
-<translation id="1121094540300013208">Relatórios de uso e falhas</translation>
-<translation id="1124772482545689468">Usuário</translation>
-<translation id="1129510026454351943">Detalhes: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download pendente.}one{# download pendente.}other{# downloads pendentes.}}</translation>
-<translation id="1145536944570833626">Excluir dados já existentes.</translation>
-<translation id="1146678959555564648">Entrar na RV</translation>
-<translation id="116280672541001035">Dados usados</translation>
-<translation id="1171770572613082465">Toque no botão "Sites famosos" para ver os sites muito acessados</translation>
-<translation id="1173894706177603556">Renomear</translation>
-<translation id="1178581264944972037">Pausar</translation>
-<translation id="1181037720776840403">Remover</translation>
-<translation id="1188239144602654184">Entrar na RA</translation>
-<translation id="1197267115302279827">Mover favoritos</translation>
-<translation id="119944043368869598">Limpar tudo</translation>
-<translation id="1201402288615127009">Próxima</translation>
-<translation id="1204037785786432551">Fazer o download do link</translation>
-<translation id="1206892813135768548">Copiar texto do link</translation>
-<translation id="1208340532756947324">Para sincronizar e personalizar vários dispositivos, ative a sincronização</translation>
-<translation id="1209206284964581585">Ocultar por enquanto</translation>
-<translation id="1227058898775614466">Histórico de navegação</translation>
-<translation id="1231733316453485619">Ativar sincronização?</translation>
-<translation id="123724288017357924">Atualizar página atual e ignorar conteúdo em cache</translation>
-<translation id="124116460088058876">Mais idiomas</translation>
-<translation id="124678866338384709">Fechar a guia atual</translation>
-<translation id="1258753120186372309">Doodle do Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Pesquisar e explorar</translation>
-<translation id="1264974993859112054">Esportes</translation>
-<translation id="1266864766717917324">Falha no compartilhamento de <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Parar</translation>
-<translation id="1283039547216852943">Toque para expandir</translation>
-<translation id="1285320974508926690">Nunca traduzir este site</translation>
-<translation id="1291207594882862231">Limpar histórico, cookies, dados do site, cache…</translation>
-<translation id="129382876167171263">Os arquivos salvos por sites são exibidos aqui</translation>
-<translation id="129553762522093515">Recentemente fechadas</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" />: enviado de <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Agrupar guias</translation>
-<translation id="1327257854815634930">O histórico de navegação está aberto</translation>
-<translation id="1331212799747679585">Não é possível atualizar o Chrome. Mais opções</translation>
-<translation id="1332501820983677155">Atalhos de recursos do Google Chrome</translation>
-<translation id="1360432990279830238">Sair e desativar a sincronização?</translation>
-<translation id="1369915414381695676">Site <ph name="SITE_NAME" /> adicionado</translation>
-<translation id="1373696734384179344">Memória insuficiente para fazer o download do conteúdo selecionado.</translation>
-<translation id="1376578503827013741">Calculando…</translation>
-<translation id="1383876407941801731">Pesquisar</translation>
-<translation id="1384959399684842514">Download pausado</translation>
-<translation id="1386674309198842382">Ativado há <ph name="LAST_UPDATED" /> dias</translation>
-<translation id="1397811292916898096">Pesquisar com o <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Incorporado em <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"Não rastrear"</translation>
-<translation id="1407135791313364759">Abrir todas</translation>
-<translation id="1409426117486808224">Versão simplificada das guias abertas</translation>
-<translation id="1409879593029778104">O download de <ph name="FILE_NAME" /> foi impedido porque o arquivo já existe.</translation>
-<translation id="1414981605391750300">Entrando em contato com o Google. Isso pode levar um minuto…</translation>
-<translation id="1416550906796893042">Versão do aplicativo</translation>
-<translation id="1430915738399379752">Imprimir</translation>
-<translation id="1446450296470737166">Permitir controle total de dispositivos MIDI</translation>
-<translation id="1450753235335490080">Falha no compartilhamento de <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Desativada nas configurações do Android</translation>
-<translation id="1477626028522505441">Falha no download do arquivo <ph name="FILE_NAME" /> devido a problemas de servidor.</translation>
-<translation id="1506061864768559482">Mecanismo de pesquisa</translation>
-<translation id="1513352483775369820">Favoritos e histórico da Web</translation>
-<translation id="1513858653616922153">Excluir senha</translation>
-<translation id="1516229014686355813">O recurso "Tocar para pesquisar" envia a palavra selecionada e a página atual como contexto para a Pesquisa Google. É possível desativá-lo em <ph name="BEGIN_LINK" />Configurações<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Ativado hoje</translation>
-<translation id="1544826120773021464">Para gerenciar sua Conta do Google, toque no botão "Gerenciar conta".</translation>
-<translation id="1549000191223877751">Mover para outra janela</translation>
-<translation id="1553358976309200471">Atualizar o Google Chrome</translation>
-<translation id="1569387923882100876">Dispositivo conectado</translation>
-<translation id="1571304935088121812">Copiar nome de usuário</translation>
-<translation id="1612196535745283361">O Chrome precisa ter acesso ao local para verificar dispositivos. O acesso ao local está <ph name="BEGIN_LINK" />desativado neste dispositivo<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Câmera</translation>
-<translation id="1623104350909869708">Impedir que esta página crie caixas de diálogo adicionais</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Remover 1 item selecionado}one{Remover # item selecionado}other{Remover # itens selecionados}}</translation>
-<translation id="164269334534774161">Você está vendo uma cópia off-line desta página de <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Histórico</translation>
-<translation id="1647391597548383849">Acessar sua câmera</translation>
-<translation id="1660204651932907780">Permitir o áudio dos sites (recomendado)</translation>
-<translation id="1670399744444387456">Básico</translation>
-<translation id="1671236975893690980">Download pendente…</translation>
-<translation id="1672586136351118594">Não mostrar novamente</translation>
-<translation id="1692118695553449118">A sincronização está ativada</translation>
-<translation id="169515064810179024">Impedir que sites acessem os sensores de movimento</translation>
-<translation id="1717218214683051432">Sensores de movimento</translation>
-<translation id="1718835860248848330">Última hora</translation>
-<translation id="1736419249208073774">Explorar</translation>
-<translation id="1743802530341753419">Perguntar antes de permitir a conexão de sites a um dispositivo (recomendado)</translation>
-<translation id="1749561566933687563">Sincronize seus favoritos</translation>
-<translation id="17513872634828108">Guias abertas</translation>
-<translation id="1779089405699405702">Decodificador de imagem</translation>
-<translation id="1782483593938241562">Data de término: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Instalado</translation>
-<translation id="1792959175193046959">Altere o local padrão de download a qualquer momento</translation>
-<translation id="1807246157184219062">Claro</translation>
-<translation id="1810845389119482123">Configuração de sincronização inicial não concluída</translation>
-<translation id="1821253160463689938">Utiliza cookies para lembrar suas preferências, mesmo se você não acessar essas páginas</translation>
-<translation id="1829244130665387512">Encontrar na página</translation>
-<translation id="1853692000353488670">Nova guia anônima</translation>
-<translation id="1856325424225101786">Redefinir o Modo Lite?</translation>
-<translation id="1868024384445905608">Agora o Chrome faz o download de arquivos mais rapidamente</translation>
-<translation id="1883903952484604915">Meus arquivos</translation>
-<translation id="1887786770086287077">O acesso ao local está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK" />Configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">O app <ph name="APP_NAME" /> será aberto no Chrome. Ao continuar, você concorda com os <ph name="BEGIN_LINK1" />Termos de Serviço<ph name="END_LINK1" /> e o <ph name="BEGIN_LINK2" />Aviso de Privacidade<ph name="END_LINK2" /> do Chrome.</translation>
-<translation id="1919345977826869612">Anúncios</translation>
-<translation id="1919950603503897840">Selecionar contatos</translation>
-<translation id="1922076542920281912">Para permitir que o Chrome acesse sua localização, ative-a nas <ph name="BEGIN_LINK" />configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Atualizações</translation>
-<translation id="19288952978244135">Reabra o Chrome.</translation>
-<translation id="1933845786846280168">Guia selecionada</translation>
-<translation id="194341124344773587">Ative a permissão para o Chrome nas <ph name="BEGIN_LINK" />configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Salvar senhas</translation>
-<translation id="1952172573699511566">Os sites exibirão textos no idioma de sua preferência, quando for possível.</translation>
-<translation id="1960290143419248813">As atualizações do Chrome não são mais compatíveis com esta versão do Android</translation>
-<translation id="1966710179511230534">Atualize seus detalhes de login.</translation>
-<translation id="1974060860693918893">Avançado</translation>
-<translation id="1984705450038014246">Sincronizar seus dados do Chrome</translation>
-<translation id="1984937141057606926">Permitidos, exceto de terceiros</translation>
-<translation id="1986685561493779662">Esse nome já existe</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> botão <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Procurar</translation>
-<translation id="1993768208584545658">O <ph name="SITE" /> deseja realizar o pareamento</translation>
-<translation id="1994173015038366702">URL do site</translation>
-<translation id="2000419248597011803">Envia alguns cookies e pesquisas da barra de endereço e da caixa de pesquisa para seu mecanismo de pesquisa padrão.</translation>
-<translation id="2002537628803770967">Cartões de crédito e endereços que usam o Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# arquivo}one{# arquivo}other{# arquivos}}</translation>
-<translation id="2017836877785168846">Limpa o histórico e o preenchimento automático na barra de endereço.</translation>
-<translation id="2021896219286479412">Controles de site em tela cheia</translation>
-<translation id="2038563949887743358">Ativar "Ver versão para computador"</translation>
-<translation id="2041019821020695769">Para permitir que o Chrome envie notificações, ative-as também nas <ph name="BEGIN_LINK" />configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">O app <ph name="APP_NAME" /> também tem dados no Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Site pausado</translation>
-<translation id="2063713494490388661">Tocar para pesquisar</translation>
-<translation id="2067805253194386918">texto</translation>
-<translation id="2079545284768500474">Desfazer</translation>
-<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER" /> de <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Som</translation>
-<translation id="2096012225669085171">Sincronizar e personalizar entre dispositivos</translation>
-<translation id="2100273922101894616">Login automático</translation>
-<translation id="2100314319871056947">Tente compartilhar o texto em segmentos menores</translation>
-<translation id="2107397443965016585">Perguntar antes de permitir que sites reproduzam conteúdo protegido (recomendado)</translation>
-<translation id="2111511281910874386">Ir para a página</translation>
-<translation id="2122601567107267586">Não foi possível abrir o aplicativo</translation>
-<translation id="2126426811489709554">Em execução no Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> salvo(s)</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> fechada</translation>
-<translation id="2139186145475833000">Adicionar à tela inicial</translation>
-<translation id="2146738493024040262">Abrir Instant App</translation>
-<translation id="2148716181193084225">Hoje</translation>
-<translation id="2154484045852737596">Editar cartão</translation>
-<translation id="2154710561487035718">Copiar URL</translation>
-<translation id="2156074688469523661">Sites restantes (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Para compartilhar conteúdo do seu smartphone com outro dispositivo, ative a sincronização nas configurações do Chrome nos dois dispositivos</translation>
-<translation id="2170088579611075216">Permitir e entrar na RV</translation>
-<translation id="218608176142494674">Compartilhamento</translation>
-<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Serviços do Google e de sincronização</translation>
-<translation id="2259659629660284697">Exportar senhas…</translation>
-<translation id="2268044343513325586">Refinar</translation>
-<translation id="2286841657746966508">Endereço de faturamento</translation>
-<translation id="2289270750774289114">Perguntar quando um site quer descobrir dispositivos Bluetooth nas proximidades (recomendado)</translation>
-<translation id="230115972905494466">Nenhum dispositivo compatível encontrado</translation>
-<translation id="2315043854645842844">A seleção de certificado do cliente não é compatível com o sistema operacional.</translation>
-<translation id="2318045970523081853">Toque para ligar</translation>
-<translation id="2321086116217818302">Preparando senhas…</translation>
-<translation id="2321958826496381788">Arraste o controle deslizante até a leitura ficar confortável. Com o toque duplo em um parágrafo, o texto ficará pelo menos deste tamanho.</translation>
-<translation id="2323763861024343754">Armazenamento do site</translation>
-<translation id="2328985652426384049">Não consigo fazer login</translation>
-<translation id="2330129964253841015">Avisar sobre senhas comprometidas</translation>
-<translation id="2349710944427398404">Total de dados utilizados pelo Chrome, incluindo contas, favoritos e configurações salvas</translation>
-<translation id="2353636109065292463">Verificando sua conexão de Internet</translation>
-<translation id="2359808026110333948">Continuar</translation>
-<translation id="2369533728426058518">abrir guias</translation>
-<translation id="2387895666653383613">Escala do texto</translation>
-<translation id="2394602618534698961">Os arquivos salvos por download são exibidos aqui</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Quando você faz login na sua Conta do Google, este recurso é ativado</translation>
-<translation id="2410754283952462441">Escolher uma conta</translation>
-<translation id="2414886740292270097">Escuro</translation>
-<translation id="2416359993254398973">O Chrome precisa de permissão para este site acessar sua câmera.</translation>
-<translation id="2426805022920575512">Escolher outra conta</translation>
-<translation id="2433507940547922241">Aparência</translation>
-<translation id="2434158240863470628">Download concluído <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Acesso ao local</translation>
-<translation id="2450083983707403292">Quer recomeçar o download de <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Notificações</translation>
-<translation id="2490684707762498678">Gerenciadas por <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Assistente no Chrome</translation>
-<translation id="2496180316473517155">Histórico de navegação</translation>
-<translation id="2497852260688568942">A sincronização foi desativada pelo administrador</translation>
-<translation id="2498359688066513246">Ajuda e feedback</translation>
-<translation id="2501278716633472235">Voltar</translation>
-<translation id="2513403576141822879">Para ver mais configurações relacionadas à privacidade, segurança e coleta de dados, acesse <ph name="BEGIN_LINK" />Serviços do Google e de sincronização<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Com o Modo Lite, as páginas são carregadas mais rapidamente no Chrome, e há uma economia de dados de até 60%. Para otimizar as páginas visitadas, o Chrome envia seu tráfego da Web para o Google. <ph name="BEGIN_LINK" />Saiba mais<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Envia URLs das páginas que você visita para o Google</translation>
-<translation id="2532336938189706096">Visualização da Web</translation>
-<translation id="2534155362429831547">Itens excluídos: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Vendo uma cópia off-line desta página</translation>
-<translation id="2546283357679194313">Cookies e dados do site</translation>
-<translation id="2567385386134582609">IMAGEM</translation>
-<translation id="257088987046510401">Temas</translation>
-<translation id="2570922361219980984">O acesso ao local também está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK" />Configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Visualização expandida. Clique para recolher</translation>
-<translation id="2581165646603367611">Essa ação limpará os cookies, cache e outros dados de sites que o Chrome não acredita serem importantes.</translation>
-<translation id="2586657967955657006">Área de transferência</translation>
-<translation id="2587052924345400782">Versão mais recente disponível</translation>
-<translation id="2593272815202181319">Espaçamento uniforme</translation>
-<translation id="2612676031748830579">Número do cartão</translation>
-<translation id="2621115761605608342">Permitir JavaScript para um site específico.</translation>
-<translation id="2625189173221582860">Senha copiada</translation>
-<translation id="2631006050119455616">Salvo</translation>
-<translation id="2647434099613338025">Adicionar idioma</translation>
-<translation id="2650751991977523696">Fazer o download do arquivo novamente?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# arquivo de áudio}one{# arquivo de áudio}other{# arquivos de áudio}}</translation>
-<translation id="2653659639078652383">Enviar</translation>
-<translation id="2677748264148917807">Sair</translation>
-<translation id="2704606927547763573">Copiado</translation>
-<translation id="2707726405694321444">Atualizar página</translation>
-<translation id="2709516037105925701">Preenchimento automático</translation>
-<translation id="2717722538473713889">Endereços de e-mail</translation>
-<translation id="2728754400939377704">Classificar por site</translation>
-<translation id="2744248271121720757">Toque em uma palavra para pesquisar instantaneamente ou ver as ações relacionadas</translation>
-<translation id="2760989362628427051">Ativa o tema escuro quando essa opção ou a "Economia de bateria" do dispositivo está ativada</translation>
-<translation id="2762000892062317888">agora mesmo</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> segundos restantes</translation>
-<translation id="2779651927720337254">falha</translation>
-<translation id="2781151931089541271">Um segundo restante</translation>
-<translation id="2801022321632964776">Faça a atualização para usar a versão mais recente do Chrome no seu idioma</translation>
-<translation id="2810645512293415242">Página simplificada para economizar dados e carregar mais rapidamente.</translation>
-<translation id="281504910091592009">Ver e gerenciar as senhas salvas na sua <ph name="BEGIN_LINK" />Conta do Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Para ter seus favoritos em todos os seus dispositivos, faça login e ative a sincronização</translation>
-<translation id="2822354292072154809">Tem certeza de que quer redefinir todas as permissões de site para <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Toque no botão "Voltar" para sair da tela cheia.</translation>
-<translation id="2842985007712546952">Pasta mãe</translation>
-<translation id="2858138569776157458">Sites famosos</translation>
-<translation id="2860954141821109167">Verifique se há um aplicativo para telefones ativado neste dispositivo</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Faixa anterior</translation>
-<translation id="2876369937070532032">Quando há risco de segurança, envia para o Google os URLs de algumas páginas que você visita</translation>
-<translation id="2888126860611144412">Sobre o Google Chrome</translation>
-<translation id="2891154217021530873">Para de carregar a página</translation>
-<translation id="2893180576842394309">O Google pode usar seu histórico para personalizar a Pesquisa e outros serviços que ele oferece</translation>
-<translation id="2898264748040935573">Editar senha armazenada</translation>
-<translation id="2900528713135656174">Criar evento</translation>
-<translation id="290376772003165898">A página não está em <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Lista de dispositivos com os quais é possível compartilhar uma guia aberta no tamanho máximo.</translation>
-<translation id="2910701580606108292">Perguntar antes de permitir que sites reproduzam conteúdo protegido</translation>
-<translation id="2913331724188855103">Permitir que os sites salvem e leiam os dados de arquivos "cookies" - que armazenam temporariamente o que você visitou na rede. (Recomendado)</translation>
-<translation id="2923908459366352541">O nome é inválido</translation>
-<translation id="2932150158123903946">Armazenamento do Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">A guia "Visualizar" está fechada</translation>
-<translation id="2956410042958133412">Esta conta é gerenciada por <ph name="PARENT_NAME_1" /> e <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Alternada para guias anônimas</translation>
-<translation id="2968755619301702150">Leitor de certificados</translation>
-<translation id="2979025552038692506">Guia anônima selecionada</translation>
-<translation id="2987620471460279764">Texto compartilhado de outro dispositivo</translation>
-<translation id="2989523299700148168">Visitados recentemente</translation>
-<translation id="2996291259634659425">Criar senha longa</translation>
-<translation id="2996809686854298943">O URL é obrigatório</translation>
-<translation id="300526633675317032">Essa ação limpará tudo, <ph name="SIZE_IN_KB" /> de dados de armazenamento de sites.</translation>
-<translation id="3016635187733453316">Verifique se o dispositivo está conectado à Internet</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB transferido(s) por download</translation>
-<translation id="3029704984691124060">As senhas não correspondem</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Receber ajuda<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">A Localização está desativada. Ative-a nas <ph name="BEGIN_LINK" />configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Ative a sincronização quando quiser nas configurações</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> favorito}one{<ph name="BOOKMARKS_COUNT_MANY" /> favorito}other{<ph name="BOOKMARKS_COUNT_MANY" /> favoritos}}</translation>
-<translation id="3089395242580810162">Abrir em guia anônima</translation>
-<translation id="3115898365077584848">Mostrar informações</translation>
-<translation id="3123473560110926937">Bloqueados em alguns sites</translation>
-<translation id="3137521801621304719">Sair do modo de navegação anônima</translation>
-<translation id="3143515551205905069">Cancelar sincronização</translation>
-<translation id="3157842584138209013">Veja o volume de dados que você economizou no botão Mais opções</translation>
-<translation id="3166827708714933426">Atalhos de guias e janelas</translation>
-<translation id="3181954750937456830">Navegação segura: protege você e seu dispositivo de sites perigosos</translation>
-<translation id="3190152372525844641">Ative as permissões para o Chrome nas <ph name="BEGIN_LINK" />configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> de dados armazenados</translation>
-<translation id="3205824638308738187">Quase lá.</translation>
-<translation id="3207960819495026254">Adicionado aos favoritos</translation>
-<translation id="3211426585530211793">Item excluído: <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Se você esqueceu sua senha longa ou deseja alterar essa configuração, <ph name="BEGIN_LINK" />redefina a sincronização<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Microfone</translation>
-<translation id="3232754137068452469">App da Web</translation>
-<translation id="3236059992281584593">Um minuto restante</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Adicionar esta página aos favoritos</translation>
-<translation id="3259831549858767975">Diminuir tudo na página.</translation>
-<translation id="3269093882174072735">Carregar imagem</translation>
-<translation id="3269956123044984603">Para ver as guias dos seus outros dispositivos, ative a opção "Sincronizar dados automaticamente" nas configurações de conta do Android.</translation>
-<translation id="3277252321222022663">Permitir que sites acessem os sensores (recomendado)</translation>
-<translation id="3282568296779691940">Fazer login no Google Chrome</translation>
-<translation id="3288003805934695103">Atualizar a página</translation>
-<translation id="32895400574683172">Notificações são permitidas</translation>
-<translation id="3295530008794733555">Navegue com mais rapidez. Use menos dados.</translation>
-<translation id="3295602654194328831">Ocultar informações</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Continuar com o download do conteúdo?</translation>
-<translation id="3306398118552023113">Este app está sendo executado no Chrome</translation>
-<translation id="3315103659806849044">No momento, você está personalizando suas configurações de sincronização e de serviço do Google. Para terminar de ativar a sincronização, toque no botão "Confirmar" na parte inferior da tela. Navegar para cima</translation>
-<translation id="3328801116991980348">Informações do site</translation>
-<translation id="3333961966071413176">Todos os contatos</translation>
-<translation id="3334729583274622784">Mudar extensão do arquivo?</translation>
-<translation id="3341058695485821946">Veja o volume de dados que você economizou</translation>
-<translation id="3350687908700087792">Fechar todas as guias anônimas</translation>
-<translation id="3353615205017136254">Página Lite exibida pelo Google. Toque no botão "Carregar original" para carregar a página original.</translation>
-<translation id="3367813778245106622">Faça login novamente para começar a sincronizar</translation>
-<translation id="3374023511497244703">Seus favoritos, histórico, senhas e outros dados do Chrome não serão mais sincronizados com sua Conta do Google</translation>
-<translation id="3384347053049321195">Compartilhar imagem</translation>
-<translation id="3386292677130313581">Perguntar antes de permitir que sites saibam seu local (recomendado)</translation>
-<translation id="3387650086002190359">Falha no download de <ph name="FILE_NAME" /> devido a erros do sistema de arquivos.</translation>
-<translation id="3389286852084373014">O texto está grande demais</translation>
-<translation id="3398320232533725830">Abrir o gerenciador de favoritos</translation>
-<translation id="3414952576877147120">Tamanho:</translation>
-<translation id="3443221991560634068">Atualizar a página atual</translation>
-<translation id="3445014427084483498">Agora</translation>
-<translation id="3478363558367712427">Você pode escolher seu mecanismo de pesquisa</translation>
+<translation id="6910211073230771657">Excluído</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Ok, entendi</translation>
+<translation id="7658239707568436148">Cancelar</translation>
 <translation id="3479552764303398839">Não agora</translation>
-<translation id="3492207499832628349">Nova guia anônima</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Saiba mais<ph name="END_LINK" /> sobre o conteúdo sugerido</translation>
-<translation id="3513704683820682405">Realidade aumentada</translation>
-<translation id="3518985090088779359">Aceitar e continuar</translation>
-<translation id="3522247891732774234">Atualização disponível. Mais opções</translation>
-<translation id="3524138585025253783">IU do desenvolvedor</translation>
-<translation id="3527085408025491307">Pasta</translation>
-<translation id="3542235761944717775">Disponíveis: <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Pesquise o seu histórico</translation>
-<translation id="3557336313807607643">Adicionar aos contatos</translation>
-<translation id="3566923219790363270">O Chrome ainda está se preparando para a RV. Reinicie-o mais tarde.</translation>
-<translation id="3568688522516854065">Para ver as guias dos seus outros dispositivos, faça login e ative a sincronização</translation>
-<translation id="3587482841069643663">Tudo</translation>
-<translation id="358794129225322306">Permite que um site faça o download de vários arquivos automaticamente.</translation>
-<translation id="3590487821116122040">Dados de armazenamento de site que o Chrome não acredita serem importantes (por exemplo, sites sem configurações salvas ou que você não visita com frequência)</translation>
-<translation id="3599863153486145794">Limpa o histórico de todos os dispositivos conectados. Sua Conta do Google pode ter outras formas de histórico de navegação em <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Silenciar sites com áudio</translation>
-<translation id="3616113530831147358">Áudio</translation>
-<translation id="3631987586758005671">Compartilhando com <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Reautenticar para ver senha</translation>
-<translation id="363596933471559332">Faça login automaticamente nos websites usando as credenciais armazenadas. Se o recurso estiver desativado, será preciso fazer a verificação sempre antes de fazer login em um website.</translation>
-<translation id="3658159451045945436">A redefinição limpa o histórico da economia de dados, incluindo a lista de sites visitados.</translation>
-<translation id="3692944402865947621">Falha no download do arquivo <ph name="FILE_NAME" /> porque não foi possível acessar o local do armazenamento.</translation>
-<translation id="3714981814255182093">Abrir a barra Localizar</translation>
-<translation id="3716182511346448902">Como esta página usa muita memória, o Chrome a pausou.</translation>
-<translation id="3730075448226062617">Para permitir que o Chrome acesse seu microfone, ative-o nas <ph name="BEGIN_LINK" />configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Adicionado aos favoritos no <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sincronização em segundo plano</translation>
-<translation id="3771001275138982843">Não foi possível fazer o download da atualização</translation>
-<translation id="3771033907050503522">Guias anônimas</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Ativar o Bluetooth<ph name="END_LINK" /> para permitir o pareamento</translation>
-<translation id="3775705724665058594">Enviar para seus dispositivos</translation>
-<translation id="3778956594442850293">Adicionado à tela inicial</translation>
-<translation id="3789841737615482174">Instalar</translation>
-<translation id="3810838688059735925">Vídeo</translation>
-<translation id="3810973564298564668">Gerenciar</translation>
-<translation id="381841723434055211">Números de telefone</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> downloads excluídos</translation>
-<translation id="3822502789641063741">Limpar armazenamento de sites?</translation>
-<translation id="385051799172605136">Voltar</translation>
-<translation id="3859306556332390985">Avançar</translation>
-<translation id="3894427358181296146">Adicionar pasta</translation>
-<translation id="3895926599014793903">Forçar zoom</translation>
-<translation id="3912508018559818924">Procurando o melhor da Web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combinar meus dados</translation>
-<translation id="393697183122708255">Nenhuma pesq. por voz ativada disponível</translation>
-<translation id="395206256282351086">Sugestões de pesquisa e sites desativadas</translation>
-<translation id="3955193568934677022">Permitir que os sites reproduzam conteúdo protegido (recomendado)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{O Chrome carregará sua página quando ela estiver pronta}one{O Chrome carregará sua página quando ela estiver pronta}other{O Chrome carregará suas páginas quando elas estiverem prontas}}</translation>
-<translation id="3963007978381181125">A criptografia por senha longa não inclui formas de pagamento e endereços do Google Pay. Apenas uma pessoa que tenha sua senha longa pode ler seus dados criptografados. Essa senha não é enviada ou armazenada pelo Google. Se você esquecer a senha longa ou quiser alterar essa configuração, será necessário redefinir a sincronização. <ph name="BEGIN_LINK" />Saiba mais<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Download concluído</translation>
-<translation id="397583555483684758">A sincronização parou de funcionar</translation>
-<translation id="3976396876660209797">Remova e recrie este atalho</translation>
-<translation id="3985215325736559418">Quer fazer o download do arquivo <ph name="FILE_NAME" /> novamente?</translation>
-<translation id="3987993985790029246">Copiar link</translation>
-<translation id="3988213473815854515">Está autorizado a usar informações de localização</translation>
-<translation id="3988466920954086464">Veja neste painel resultados da pesquisa instantâneos</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Armazenamento sem importância</translation>
-<translation id="4000212216660919741">Página inicial off-line</translation>
+<translation id="5317780077021120954">Salvar</translation>
+<translation id="4570913071927164677">Detalhes</translation>
+<translation id="8730621377337864115">Concluído</translation>
+<translation id="8261506727792406068">Excluir</translation>
+<translation id="1181037720776840403">Remover</translation>
+<translation id="5939518447894949180">Redefinir</translation>
 <translation id="4002066346123236978">Título</translation>
-<translation id="4008040567710660924">Permita cookies para um site específico.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Próxima faixa</translation>
-<translation id="4048707525896921369">Saiba mais sobre um determinado assunto de um site sem sair da página. Com o recurso "Tocar para pesquisar", você toca na palavra e o contexto relacionado é enviado para a Pesquisa Google, que então mostra definições, imagens, resultados da pesquisa e outros detalhes relacionados para você.
+<translation id="5916664084637901428">Ativado</translation>
+<translation id="5860033963881614850">Desativado</translation>
+<translation id="6165508094623778733">Saiba mais</translation>
+<translation id="6042308850641462728">Mais</translation>
+<translation id="6040143037577758943">Fechar</translation>
+<translation id="780301667611848630">Não</translation>
+<translation id="1201402288615127009">Próxima</translation>
+<translation id="2359808026110333948">Continuar</translation>
+<translation id="2653659639078652383">Enviar</translation>
+<translation id="2079545284768500474">Desfazer</translation>
+<translation id="7649070708921625228">Ajuda</translation>
+<translation id="2148716181193084225">Hoje</translation>
+<translation id="7781829728241885113">Ontem</translation>
+<translation id="6945221475159498467">Selecionar</translation>
+<translation id="7791543448312431591">Adicionar</translation>
+<translation id="6527303717912515753">Compartilhar</translation>
+<translation id="1383876407941801731">Pesquisar</translation>
+<translation id="3115898365077584848">Mostrar informações</translation>
+<translation id="3295602654194328831">Ocultar informações</translation>
+<translation id="3987993985790029246">Copiar link</translation>
+<translation id="2704606927547763573">Copiado</translation>
+<translation id="8725066075913043281">Tentar novamente</translation>
+<translation id="385051799172605136">Voltar</translation>
+<translation id="8131740175452115882">Confirmar</translation>
+<translation id="5300589172476337783">Mostrar</translation>
+<translation id="1124772482545689468">Usuário</translation>
+<translation id="8609465669617005112">Mover para cima</translation>
+<translation id="6746124502594467657">Mover para baixo</translation>
+<translation id="8249310407154411074">Mover para o início</translation>
+<translation id="8428213095426709021">Configurações</translation>
+<translation id="2498359688066513246">Ajuda e feedback</translation>
+<translation id="8378714024927312812">Gerenciado pela sua organização</translation>
+<translation id="9019902583201351841">Gerenciado pelos seus pais</translation>
+<translation id="4645575059429386691">Gerenciado pelos seus pais</translation>
+<translation id="4883854917563148705">Não é possível redefinir as configurações gerenciadas</translation>
+<translation id="4307992518367153382">Básico</translation>
+<translation id="1974060860693918893">Avançado</translation>
+<translation id="1146678959555564648">Entrar na RV</translation>
+<translation id="987264212798334818">Geral</translation>
+<translation id="4275663329226226506">Mídia</translation>
+<translation id="4759238208242260848">Downloads</translation>
+<translation id="218608176142494674">Compartilhamento</translation>
+<translation id="8004582292198964060">Navegador</translation>
+<translation id="1105960400813249514">Captura de tela</translation>
+<translation id="4875775213178255010">Sugestões de conteúdo</translation>
+<translation id="2021896219286479412">Controles de site em tela cheia</translation>
+<translation id="4587589328781138893">Sites</translation>
+<translation id="4943703118917034429">Realidade virtual</translation>
+<translation id="1928696683969751773">Atualizações</translation>
+<translation id="6064125863973209585">Downloads concluídos</translation>
+<translation id="5342314432463739672">Solicitações de permissão</translation>
+<translation id="629730747756840877">Conta</translation>
+<translation id="82609232232243542">Fazer login no Brave Software Brave</translation>
+<translation id="7956662517480676674">Serviços do Brave Software e de sincronização</translation>
+<translation id="5294439808117722387">No momento, você está personalizando suas configurações de sincronização e de serviço do Brave Software. Para terminar de ativar a sincronização, toque no botão "Confirmar" na parte inferior da tela. Navegar para cima</translation>
+<translation id="2096012225669085171">Sincronizar e personalizar entre dispositivos</translation>
+<translation id="1692118695553449118">A sincronização está ativada</translation>
+<translation id="5514904542973294328">Opção desativada pelo administrador deste dispositivo</translation>
+<translation id="6447211988989208781">Controles de atividade do Brave Software</translation>
+<translation id="4882831918239250449">Controlar como o histórico de navegação é usado para personalizar a Pesquisa, os anúncios e muito mais</translation>
+<translation id="7431991332293347422">Controlar como o histórico de navegação é usado para personalizar a Pesquisa e muito mais</translation>
+<translation id="6303969859164067831">Sair e desativar a sincronização</translation>
+<translation id="1125261911132334651">Gerenciar sua Conta do Brave Software</translation>
+<translation id="6406506848690869874">Sincronizar</translation>
+<translation id="714362445477979774">Sincronizar seus dados do Brave</translation>
+<translation id="4314815835985389558">Gerenciar sincronização</translation>
+<translation id="5428209950370661546">Outros serviços do Brave Software</translation>
+<translation id="7704317875155739195">Preencher automaticamente pesquisas e URLs</translation>
+<translation id="2000419248597011803">Envia alguns cookies e pesquisas da barra de endereço e da caixa de pesquisa para seu mecanismo de pesquisa padrão.</translation>
+<translation id="7981313251711023384">Pré-carregar páginas para possibilitar navegação e pesquisa mais rápidas</translation>
+<translation id="1821253160463689938">Utiliza cookies para lembrar suas preferências, mesmo se você não acessar essas páginas</translation>
+<translation id="6697492270171225480">Mostrar sugestões de páginas semelhantes quando uma página não for encontrada</translation>
+<translation id="8109318360573330108">Envia ao Brave Software o URL de uma página que você está tentando acessar</translation>
+<translation id="8438566539970814960">Melhorar as pesquisas e a navegação</translation>
+<translation id="284843628681142937">Envia URLs das páginas que você visita para o Brave Software</translation>
+<translation id="7222718784508482526">Para ver mais configurações relacionadas à privacidade, segurança e coleta de dados, acesse <ph name="BEGIN_LINK"/>Serviços do Brave Software e de sincronização<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Ajude a melhorar os recursos e o desempenho do Brave</translation>
+<translation id="9063160602596686558">Envia estatísticas de uso e relatórios de erros automaticamente para o Brave Software</translation>
+<translation id="4824958205181053313">Cancelar sincronização?</translation>
+<translation id="3058498974290601450">Ative a sincronização quando quiser nas configurações</translation>
+<translation id="3143515551205905069">Cancelar sincronização</translation>
+<translation id="1506061864768559482">Mecanismo de pesquisa</translation>
+<translation id="55737423895878184">A localização e as notificações são permitidas</translation>
+<translation id="3988213473815854515">Está autorizado a usar informações de localização</translation>
+<translation id="32895400574683172">Notificações são permitidas</translation>
+<translation id="9040142327097499898">As notificações são permitidas. A localização está desativada neste dispositivo.</translation>
+<translation id="305593374596241526">A Localização está desativada. Ative-a nas <ph name="BEGIN_LINK"/>configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Visitados recentemente</translation>
+<translation id="6433501201775827830">Escolha seu mecanismo de pesquisa</translation>
+<translation id="7177466738963138057">Você poderá alterar isso mais tarde nas configurações</translation>
+<translation id="3478363558367712427">Você pode escolher seu mecanismo de pesquisa</translation>
+<translation id="4910889077668685004">Apps de pagamento</translation>
+<translation id="5152843274749979095">Nenhum app compatível instalado</translation>
+<translation id="8812260976093120287">Em alguns websites, é possível pagar no seu dispositivo com os apps de pagamento compatíveis acima.</translation>
+<translation id="7764225426217299476">Adicionar endereço</translation>
+<translation id="5595485650161345191">Editar endereço</translation>
+<translation id="5087580092889165836">Adicionar cartão</translation>
+<translation id="2154484045852737596">Editar cartão</translation>
+<translation id="6140912465461743537">País/região</translation>
+<translation id="5659593005791499971">E-mail</translation>
+<translation id="4378154925671717803">Telefone</translation>
+<translation id="4807098396393229769">Nome no cartão de crédito</translation>
+<translation id="860043288473659153">Nome do titular do cartão</translation>
+<translation id="2612676031748830579">Número do cartão</translation>
+<translation id="869891660844655955">Validade</translation>
+<translation id="2286841657746966508">Endereço de faturamento</translation>
+<translation id="663059986967017181">Copiado no Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Senhas</translation>
+<translation id="1943432128510653496">Salvar senhas</translation>
+<translation id="2100273922101894616">Login automático</translation>
+<translation id="363596933471559332">Faça login automaticamente nos websites usando as credenciais armazenadas. Se o recurso estiver desativado, será preciso fazer a verificação sempre antes de fazer login em um website.</translation>
+<translation id="6995899638241819463">Avisar se suas senhas forem expostas em uma violação de dados</translation>
+<translation id="1534287762301776620">Quando você faz login na sua Conta do Brave Software, este recurso é ativado</translation>
+<translation id="10614374240317010">Nunca salvas</translation>
+<translation id="3098842761938485917">Ver e gerenciar as senhas salvas na sua <ph name="BEGIN_LINK"/>Conta do Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">As senhas salvas aparecerão aqui.</translation>
+<translation id="8084114998886531721">Senha salva</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Nome de usuário</translation>
+<translation id="6657585470893396449">Senha</translation>
+<translation id="2154710561487035718">Copiar URL</translation>
+<translation id="1571304935088121812">Copiar nome de usuário</translation>
+<translation id="5005498671520578047">Copiar senha</translation>
+<translation id="3632295766818638029">Reautenticar para ver senha</translation>
+<translation id="1513858653616922153">Excluir senha</translation>
+<translation id="543338862236136125">Editar senha</translation>
+<translation id="4565377596337484307">Ocultar senha</translation>
+<translation id="8523928698583292556">Excluir senha armazenada</translation>
+<translation id="2898264748040935573">Editar senha armazenada</translation>
+<translation id="5433691172869980887">Nome de usuário copiado</translation>
+<translation id="5534640966246046842">Site copiado</translation>
+<translation id="2625189173221582860">Senha copiada</translation>
+<translation id="4550003330909367850">Para ver ou copiar sua senha aqui, defina um bloqueio de tela nesse dispositivo.</translation>
+<translation id="6154478581116148741">Ative o bloqueio da tela em Configurações para exportar suas senhas deste dispositivo</translation>
+<translation id="4842092870884894799">Mostrando pop-up da criação de senhas</translation>
+<translation id="2259659629660284697">Exportar senhas…</translation>
+<translation id="133012818630824069">Exportar senhas armazenadas com o Brave</translation>
+<translation id="6914783257214138813">Suas senhas ficarão visíveis para qualquer pessoa que tiver acesso ao arquivo exportado.</translation>
+<translation id="2321086116217818302">Preparando senhas…</translation>
+<translation id="8445448999790540984">Não é possível exportar senhas</translation>
+<translation id="3066461326500799725">Saber como usar o Brave Software Drive</translation>
+<translation id="729975465115245577">Seu dispositivo não tem um app para armazenar o arquivo de senhas.</translation>
+<translation id="7682724950699840886">Experimente as seguintes dicas: verifique se há espaço suficiente no dispositivo e tente exportar novamente.</translation>
+<translation id="1129510026454351943">Detalhes: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Desbloqueie para copiar sua senha</translation>
+<translation id="5515439363601853141">Desbloqueie para ver sua senha</translation>
+<translation id="6221633008163990886">Desbloqueie para exportar suas senhas</translation>
+<translation id="230699814587342492">Senhas do Brave</translation>
+<translation id="6075798973483050474">Editar página inicial</translation>
+<translation id="854522910157234410">Abrir esta página</translation>
+<translation id="2482878487686419369">Notificações</translation>
+<translation id="6255999984061454636">Sugestões de conteúdo</translation>
+<translation id="805047784848435650">Com base no seu histórico de navegação</translation>
+<translation id="1041308826830691739">De sites</translation>
+<translation id="395206256282351086">Sugestões de pesquisa e sites desativadas</translation>
+<translation id="257088987046510401">Temas</translation>
+<translation id="4650364565596261010">Padrão do sistema</translation>
+<translation id="7588219262685291874">Ativar o tema escuro quando a Economia de bateria do seu dispositivo estiver ativada</translation>
+<translation id="2760989362628427051">Ativa o tema escuro quando essa opção ou a "Economia de bateria" do dispositivo está ativada</translation>
+<translation id="6381421346744604172">Escurecer sites</translation>
+<translation id="5040262127954254034">Privacidade</translation>
+<translation id="4991384657077828949">Ajudar a melhorar a segurança do Brave</translation>
+<translation id="1943176487615318915">Para detectar apps e sites perigosos, o Brave envia para o Brave Software URLs de algumas páginas visitadas, informações limitadas do sistema e um pouco do conteúdo da página</translation>
+<translation id="3181954750937456830">Navegação segura: protege você e seu dispositivo de sites perigosos</translation>
+<translation id="7315322926489145388">Quando há risco de segurança, envia para o Brave Software os URLs de algumas páginas que você visita</translation>
+<translation id="2063713494490388661">Tocar para pesquisar</translation>
+<translation id="2369463299479365221">Saiba mais sobre um determinado assunto de um site sem sair da página. Com o recurso "Tocar para pesquisar", você toca na palavra e o contexto relacionado é enviado para a Pesquisa Brave Software, que então mostra definições, imagens, resultados da pesquisa e outros detalhes relacionados para você.
 
 Para ajustar o termo de pesquisa, toque nele e mantenha-o pressionado. Para refinar a pesquisa, deslize o painel totalmente para cima e toque na caixa de pesquisa.</translation>
-<translation id="4056223980640387499">Sépia</translation>
-<translation id="4060598801229743805">Opções disponíveis perto da parte superior da tela</translation>
-<translation id="4062305924942672200">Informações legais</translation>
-<translation id="4084682180776658562">Favorito</translation>
-<translation id="4084712963632273211">De <ph name="PUBLISHER_ORIGIN" />: <ph name="BEGIN_DEEMPHASIZED" />veiculado pelo Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Excluir dados de apps?</translation>
-<translation id="4099578267706723511">Ajude a melhorar o Chrome. Envie estatísticas de uso e relatórios de falhas ao Google.</translation>
-<translation id="410351446219883937">Reprodução automática</translation>
-<translation id="4116038641877404294">Faça o download de páginas e acesse off-line</translation>
-<translation id="4135200667068010335">A lista de dispositivos com os quais é possível compartilhar uma guia está fechada.</translation>
-<translation id="4149994727733219643">Versão simplificada das páginas da Web</translation>
-<translation id="4165986682804962316">Configurações do site</translation>
-<translation id="4169535189173047238">Não permitir</translation>
-<translation id="4170011742729630528">O serviço não está disponível. Tente novamente mais tarde.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> usado(s)</translation>
-<translation id="4181841719683918333">Idiomas</translation>
-<translation id="4183868528246477015">Pesquisar com Google Lens <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Abrir em uma nova guia</translation>
-<translation id="4198423547019359126">Não há locais de download disponíveis</translation>
-<translation id="4209895695669353772">Para receber conteúdo personalizado sugerido pelo Google, ative a sincronização</translation>
-<translation id="4226663524361240545">É possível que as notificações façam o dispositivo vibrar</translation>
-<translation id="423219824432660969">Criptografar dados sincronizados com a senha do Google a partir de <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Abrir configurações.</translation>
-<translation id="4256782883801055595">Licenças de código aberto</translation>
-<translation id="4259722352634471385">A Navegação GPS está bloqueada: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copiar endereço do link</translation>
-<translation id="4275663329226226506">Mídia</translation>
-<translation id="4278390842282768270">Permitido</translation>
-<translation id="429312253194641664">Um site está com mídia aberta</translation>
-<translation id="4298388696830689168">Sites vinculados</translation>
-<translation id="4307992518367153382">Básico</translation>
-<translation id="4314815835985389558">Gerenciar sincronização</translation>
-<translation id="4351244548802238354">Fechar caixa de diálogo</translation>
-<translation id="4378154925671717803">Telefone</translation>
-<translation id="4384468725000734951">Usando o Sogou para pesquisar</translation>
-<translation id="4404568932422911380">Nenhum favorito</translation>
-<translation id="4405224443901389797">Mover para…</translation>
-<translation id="4411535500181276704">Modo Lite</translation>
-<translation id="4415276339145661267">Gerenciar sua Conta do Google</translation>
-<translation id="4432792777822557199">Páginas em <ph name="SOURCE_LANGUAGE" /> serão traduzidas para <ph name="TARGET_LANGUAGE" /> de agora em diante</translation>
-<translation id="4433925000917964731">Página Lite exibida pelo Google</translation>
-<translation id="4434045419905280838">Pop-ups e redirecionamentos</translation>
-<translation id="4440958355523780886">Página Lite exibida pelo Google. Toque para carregar a original.</translation>
-<translation id="4452411734226507615">Fechar guia <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Adicionado como favorito em <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Permitir que sites reproduzam conteúdo protegido</translation>
-<translation id="4468959413250150279">Desative o som de um site específico.</translation>
-<translation id="4472118726404937099">Para sincronizar e personalizar vários dispositivos, faça login e ative a sincronização</translation>
-<translation id="447252321002412580">Ajude a melhorar os recursos e o desempenho do Chrome</translation>
-<translation id="4479647676395637221">Perguntar antes de permitir que sites usem sua câmera (recomendado)</translation>
-<translation id="4479972344484327217">Instalando <ph name="MODULE" /> para o Chrome…</translation>
-<translation id="4487967297491345095">Todos os dados de app Chrome serão excluídos permanentemente. Isso inclui todos os arquivos, configurações, contas, bancos de dados etc.</translation>
-<translation id="4493497663118223949">Modo Lite ativado</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# dia atrás}one{# dias atrás}other{# dias atrás}}</translation>
-<translation id="451872707440238414">Pesquisar favoritos</translation>
-<translation id="4521489764227272523">Os dados selecionados foram removidos do Chrome e dos seus dispositivos sincronizados.
-
-É possível que sua Conta do Google tenha outras formas de histórico de navegação, como pesquisas e atividades de outros serviços do Google em 
- <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Escolher pasta</translation>
-<translation id="4538018662093857852">Ativar Modo Lite</translation>
-<translation id="4550003330909367850">Para ver ou copiar sua senha aqui, defina um bloqueio de tela nesse dispositivo.</translation>
-<translation id="4558311620361989323">Atalhos de páginas da Web</translation>
-<translation id="4561979708150884304">Sem conexão</translation>
-<translation id="4565377596337484307">Ocultar senha</translation>
-<translation id="4570913071927164677">Detalhes</translation>
-<translation id="4572422548854449519">Fazer login em conta gerenciada</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# minuto atrás}one{# minutos atrás}other{# minutos atrás}}</translation>
-<translation id="4587589328781138893">Sites</translation>
-<translation id="4594952190837476234">Esta página off-line é de <ph name="CREATION_TIME" /> e pode ser diferente da versão on-line.</translation>
-<translation id="4605958867780575332">Item removido: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Usar senha</translation>
-<translation id="4645575059429386691">Gerenciado pelos seus pais</translation>
-<translation id="4650364565596261010">Padrão do sistema</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> favoritos excluídos</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> foi adicionado à sua tela inicial</translation>
-<translation id="4684427112815847243">Sincronizar tudo</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Enviar texto para seus dispositivos</translation>
-<translation id="4698034686595694889">Ver off-line no app <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Imagens e arquivos armazenados em cache</translation>
-<translation id="4714588616299687897">Economize até 60% dos seus dados</translation>
-<translation id="4719927025381752090">Oferecer para traduzir</translation>
-<translation id="4720023427747327413">Abrir no <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Ajude a melhorar o Chrome. <ph name="BEGIN_LINK" />Responda à pesquisa.<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Atualizar</translation>
-<translation id="4738836084190194332">Última sincronização: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Abrir uma nova guia</translation>
-<translation id="4751476147751820511">Sensores de luz ou movimento</translation>
-<translation id="4759238208242260848">Downloads</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download concluído.}one{# download concluído.}other{# downloads concluídos.}}</translation>
-<translation id="4797039098279997504">Toque para voltar a <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">A criptografia por senha longa não inclui formas de pagamento e endereços do Google Pay.
-
-Para alterar essa configuração, <ph name="BEGIN_LINK" />redefina a sincronização<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Nome no cartão de crédito</translation>
-<translation id="4824958205181053313">Cancelar sincronização?</translation>
-<translation id="4837753911714442426">Abrir opções de impressão de página</translation>
-<translation id="4842092870884894799">Mostrando pop-up da criação de senhas</translation>
-<translation id="4860895144060829044">Ligar</translation>
-<translation id="4866368707455379617">Não é possível instalar <ph name="MODULE" /> para o Chrome</translation>
-<translation id="4875775213178255010">Sugestões de conteúdo</translation>
-<translation id="4878404682131129617">Falha ao estabelecer encapsulamento via servidor proxy</translation>
-<translation id="4880127995492972015">Traduzir…</translation>
-<translation id="4881695831933465202">Abrir</translation>
-<translation id="488187801263602086">Renomear arquivo</translation>
-<translation id="4882831918239250449">Controlar como o histórico de navegação é usado para personalizar a Pesquisa, os anúncios e muito mais</translation>
-<translation id="4883854917563148705">Não é possível redefinir as configurações gerenciadas</translation>
-<translation id="4885273946141277891">Número de instâncias do Google Chrome não suportado.</translation>
-<translation id="4910889077668685004">Apps de pagamento</translation>
-<translation id="4913161338056004800">Redefinir estatísticas</translation>
-<translation id="4913169188695071480">Parar de atualizar</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Receber ajuda<ph name="END_LINK" /> ao procurar dispositivos…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}one{# página}other{# páginas}}</translation>
-<translation id="4932247056774066048">Você está saindo de uma conta gerenciada por <ph name="DOMAIN_NAME" />, por isso seus dados do Chrome serão excluídos deste dispositivo. No entanto, eles permanecerão na sua Conta do Google.</translation>
-<translation id="4943703118917034429">Realidade virtual</translation>
-<translation id="4943872375798546930">Nenhum resultado</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> está compartilhando sua tela</translation>
-<translation id="4961107849584082341">Traduza esta página para qualquer idioma</translation>
-<translation id="4962975101802056554">Revogar todas as permissões para o dispositivo</translation>
-<translation id="4970824347203572753">Indisponível no seu local</translation>
-<translation id="497421865427891073">Avançar</translation>
-<translation id="4988210275050210843">Fazendo o download do arquivo (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Páginas</translation>
-<translation id="4994033804516042629">Nenhum contato encontrado</translation>
-<translation id="4996978546172906250">Compartilhar via</translation>
-<translation id="5004416275253351869">Controles de atividade do Google</translation>
-<translation id="5005498671520578047">Copiar senha</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> deseja se conectar</translation>
-<translation id="5013696553129441713">Nenhuma nova sugestão</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Enquanto você estiver em RV, o site poderá receber dados sobre:
-  -  suas características físicas, como altura
-
-Verifique se você confia neste site antes de entrar na RV.</translation>
+<translation id="2930742481329940825">O recurso "Tocar para pesquisar" envia a palavra selecionada e a página atual como contexto para a Pesquisa Brave Software. É possível desativá-lo em <ph name="BEGIN_LINK"/>Configurações<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Permitir</translation>
-<translation id="5040262127954254034">Privacidade</translation>
-<translation id="5048398596102334565">Permitir o acesso de sites aos seus sensores de movimento (recomendado)</translation>
-<translation id="5063480226653192405">Uso</translation>
-<translation id="5087580092889165836">Adicionar cartão</translation>
-<translation id="5100237604440890931">Visualização recolhida. Clique para expandir</translation>
-<translation id="510275257476243843">Uma hora restante</translation>
-<translation id="5123685120097942451">Guia anônima</translation>
-<translation id="5127805178023152808">A sincronização está desativada</translation>
-<translation id="5129038482087801250">Instalar app da Web</translation>
-<translation id="5132942445612118989">Sincronize suas senhas, seu histórico e muito mais em todos os dispositivos</translation>
-<translation id="5139940364318403933">Saber como usar o Google Drive</translation>
-<translation id="515227803646670480">Limpar dados armazenados</translation>
-<translation id="5152843274749979095">Nenhum app compatível instalado</translation>
-<translation id="5161254044473106830">O título é obrigatório</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Falha em 1 download.}one{Falha em # download.}other{Falha em # downloads.}}</translation>
-<translation id="5170568018924773124">Mostrar na pasta</translation>
-<translation id="5184329579814168207">Abrir no Google Chrome</translation>
-<translation id="5193988420012215838">Copiado para a área de transferência</translation>
-<translation id="5197729504361054390">Os contatos selecionados serão compartilhados com <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Perfil de trabalho</translation>
-<translation id="5210286577605176222">Ir para a guia anterior</translation>
-<translation id="5210365745912300556">Fechar guia</translation>
-<translation id="5224771365102442243">Com vídeo</translation>
-<translation id="5230560987958996918">Solicitação de <ph name="SITE" /> para procurar dispositivos Bluetooth próximos. Os seguintes dispositivos foram encontrados:</translation>
-<translation id="5233638681132016545">Nova guia</translation>
-<translation id="526421993248218238">Não foi possível carregar a página</translation>
-<translation id="5271967389191913893">Não é possível abrir no dispositivo o conteúdo a ser transferido por download.</translation>
-<translation id="528192093759286357">Arraste a partir da parte superior e toque no botão "Voltar" para sair da tela cheia.</translation>
-<translation id="5292796745632149097">Enviar para</translation>
-<translation id="5300589172476337783">Mostrar</translation>
-<translation id="5301954838959518834">Ok, entendi</translation>
-<translation id="5304593522240415983">Este campo não pode ficar em branco</translation>
-<translation id="5307446750509046227">Limpar armazen. de site</translation>
-<translation id="5308380583665731573">Conectar</translation>
-<translation id="5313967007315987356">Adicionar site</translation>
-<translation id="5317780077021120954">Salvar</translation>
-<translation id="5324858694974489420">Configurações dos pais</translation>
-<translation id="5327248766486351172">Nome</translation>
-<translation id="5335288049665977812">Permitir que sites executem o JavaScript (recomendado)</translation>
-<translation id="5342314432463739672">Solicitações de permissão</translation>
-<translation id="5357811892247919462">Guia recebida</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> guia aberta, toque para alternar}one{<ph name="OPEN_TABS_MANY" /> guia aberta, toque para alternar}other{<ph name="OPEN_TABS_MANY" /> guias abertas, toque para alternar}}</translation>
-<translation id="5391532827096253100">Sua conexão com este site não é segura. Informações do site</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(mais 1)}one{(mais #)}other{(mais #)}}</translation>
-<translation id="5400569084694353794">Ao usar este aplicativo, você concorda com os <ph name="BEGIN_LINK1" />Termos de Serviço<ph name="END_LINK1" /> e com o <ph name="BEGIN_LINK2" />Aviso de Privacidade<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Nomes</translation>
-<translation id="5403644198645076998">Permitir apenas determinados sites</translation>
-<translation id="5414836363063783498">Verificando...</translation>
-<translation id="5423934151118863508">Suas páginas mais visitadas aparecerão aqui</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB disponível(is)</translation>
-<translation id="543338862236136125">Editar senha</translation>
-<translation id="5433691172869980887">Nome de usuário copiado</translation>
-<translation id="543509235395288790">Fazendo o download de <ph name="COUNT" /> arquivos (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Ir para a barra de endereço</translation>
-<translation id="5447201525962359567">Todos os dados de armazenamento de sites, incluindo cookies e outros dados armazenados localmente</translation>
-<translation id="5447765697759493033">Este site não será traduzido</translation>
-<translation id="545042621069398927">Acelerando seu download.</translation>
-<translation id="5456381639095306749">Fazer o download da página</translation>
-<translation id="5475862044948910901">Iniciar sessão de realidade aumentada?</translation>
-<translation id="548278423535722844">Abrir no app de mapa</translation>
-<translation id="5487521232677179737">Limpar dados</translation>
-<translation id="5494752089476963479">Bloquear anúncios em sites com publicidade invasiva ou enganosa</translation>
-<translation id="5500777121964041360">Pode não estar disponível no seu local</translation>
-<translation id="5512137114520586844">Esta conta é gerenciada por <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Opção desativada pelo administrador deste dispositivo</translation>
-<translation id="5515439363601853141">Desbloqueie para ver sua senha</translation>
-<translation id="5516455585884385570">Abrir configurações de notificação</translation>
-<translation id="5517095782334947753">Você tem favoritos, histórico, senhas e outras configurações da conta <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Redirecionamento bloqueado.</translation>
-<translation id="5527082711130173040">O Chrome precisa ter acesso ao local para procurar dispositivos. <ph name="BEGIN_LINK1" />Atualize as permissões<ph name="END_LINK1" />. O acesso ao local também está <ph name="BEGIN_LINK2" />desativado neste dispositivo<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Perguntar antes de permitir que sites leiam textos e imagens da área de transferência (recomendado)</translation>
-<translation id="5530766185686772672">Fechar guias anônimas</translation>
-<translation id="5534334044554683961">Enquanto você estiver em RV, este site poderá receber dados sobre:
-  -   suas características físicas, como altura
-  -   o layout da sua sala
-
-Verifique se você confia neste site antes de entrar na RV.</translation>
-<translation id="5534640966246046842">Site copiado</translation>
-<translation id="5556459405103347317">Recarregar</translation>
-<translation id="5561549206367097665">Aguardando a rede…</translation>
-<translation id="557283862590186398">O Chrome precisa de permissão para este site acessar seu microfone.</translation>
-<translation id="55737423895878184">A localização e as notificações são permitidas</translation>
-<translation id="5578795271662203820">Pesquisar imagem no <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Nas <ph name="BEGIN_LINK1" />configurações<ph name="END_LINK1" />, é possível escolher a qualquer momento o que é sincronizado.</translation>
-<translation id="5595485650161345191">Editar endereço</translation>
-<translation id="5596627076506792578">Mais opções</translation>
-<translation id="5599455543593328020">Modo de navegação anônima</translation>
-<translation id="5620928963363755975">Procure seus arquivos e páginas em Downloads, usando o botão Mais opções</translation>
-<translation id="5626134646977739690">Nome:</translation>
-<translation id="5639724618331995626">Permitir todos os sites</translation>
-<translation id="5648166631817621825">Últimos sete dias</translation>
-<translation id="5649053991847567735">Downloads automáticos</translation>
-<translation id="5655963694829536461">Pesquisar seus downloads</translation>
-<translation id="5659593005791499971">E-mail</translation>
-<translation id="5665379678064389456">Criar evento no <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Aplicar zoom mesmo que o site tente impedir.</translation>
-<translation id="5677928146339483299">Bloqueado</translation>
-<translation id="5684874026226664614">Não foi possível traduzir esta página.</translation>
-<translation id="5686790454216892815">Nome do arquivo muito longo</translation>
-<translation id="5689516760719285838">Local</translation>
-<translation id="569536719314091526">Traduza esta página para qualquer idioma com o botão "Mais opções"</translation>
-<translation id="572328651809341494">Guias recentes</translation>
-<translation id="5726692708398506830">Aumentar tudo na página</translation>
-<translation id="5748802427693696783">Alternada para guias padrão</translation>
-<translation id="5749068826913805084">O Chrome precisa de acesso para fazer o download e armazenar arquivos.</translation>
-<translation id="5763382633136178763">Guias anônimas</translation>
-<translation id="5763514718066511291">Toque para copiar o URL desse app</translation>
-<translation id="5765780083710877561">Descrição:</translation>
-<translation id="5793665092639000975">Usando <ph name="SPACE_USED" /> de <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">O Google pode usar seu histórico para personalizar a Pesquisa, os anúncios e outros serviços que ele oferece</translation>
-<translation id="5804241973901381774">Permissões</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# hora atrás}one{# horas atrás}other{# horas atrás}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Todos os direitos reservados.</translation>
-<translation id="5817918615728894473">Parear</translation>
-<translation id="583281660410589416">Desconhecido</translation>
-<translation id="5833984609253377421">Compartilhar link</translation>
-<translation id="5836192821815272682">Fazendo o download da atualização do Chrome…</translation>
-<translation id="5853623416121554550">pausado</translation>
-<translation id="5854790677617711513">Com mais de 30 dias</translation>
-<translation id="5858741533101922242">O Chrome não pôde ativar o adaptador Bluetooth</translation>
-<translation id="5860033963881614850">Desativado</translation>
-<translation id="5862731021271217234">Para ver as guias dos seus outros dispositivos, ative a sincronização</translation>
-<translation id="5864174910718532887">Detalhes: classificados por nome do site</translation>
-<translation id="5864419784173784555">Aguardando outro download…</translation>
-<translation id="5865733239029070421">Envia estatísticas de uso e relatórios de erros automaticamente para o Google</translation>
-<translation id="5869522115854928033">Senhas salvas</translation>
-<translation id="5902828464777634901">Os dados locais armazenados por este site serão excluídos, inclusive os cookies.</translation>
-<translation id="5916664084637901428">Ativado</translation>
-<translation id="5919204609460789179">Atualize <ph name="PRODUCT_NAME" /> para iniciar a sincronização</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> economizado(s)</translation>
-<translation id="5939518447894949180">Redefinir</translation>
-<translation id="5942872142862698679">Usando o Google para pesquisar</translation>
-<translation id="5952764234151283551">Envia ao Google o URL de uma página que você está tentando acessar</translation>
-<translation id="5956665950594638604">Abrir Central de Ajuda do Chrome em uma nova guia</translation>
-<translation id="5958275228015807058">Encontre seus arquivos e páginas em Downloads</translation>
-<translation id="5962718611393537961">Toque para recolher</translation>
-<translation id="6000066717592683814">Continuar usando o Google</translation>
-<translation id="6005538289190791541">Senha sugerida</translation>
-<translation id="6036057147555329831">ICU extra</translation>
-<translation id="6039379616847168523">Ir para a próxima guia</translation>
-<translation id="6040143037577758943">Fechar</translation>
-<translation id="6042308850641462728">Mais</translation>
-<translation id="604996488070107836">Falha no download do arquivo <ph name="FILE_NAME" /> devido a um erro desconhecido.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Downloads concluídos</translation>
-<translation id="6075798973483050474">Editar página inicial</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> horas restantes</translation>
-<translation id="6108923351542677676">Configuração em andamento...</translation>
-<translation id="6111020039983847643">dados usados</translation>
-<translation id="6112702117600201073">Atualizando página</translation>
-<translation id="6127379762771434464">Item removido</translation>
-<translation id="6140912465461743537">País/região</translation>
-<translation id="614940544461990577">Tente:</translation>
-<translation id="6154478581116148741">Ative o bloqueio da tela em Configurações para exportar suas senhas deste dispositivo</translation>
-<translation id="6159335304067198720">Economia de dados de <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Saiba mais</translation>
-<translation id="6177111841848151710">Bloqueado para o mecanismo de pesquisa atual</translation>
-<translation id="6181444274883918285">Adicionar site às exceções</translation>
-<translation id="6192333916571137726">Fazer o download do arquivo</translation>
-<translation id="6192792657125177640">Exceções</translation>
-<translation id="6194112207524046168">Para permitir que o Chrome acesse sua câmera, ative-a também nas <ph name="BEGIN_LINK" />configurações do Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Bloquear cookies de terceiros</translation>
-<translation id="6206551242102657620">A conexão é segura. Informações do site</translation>
-<translation id="6210748933810148297">Não é <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Desbloqueie para exportar suas senhas</translation>
+<translation id="1406000523432664303">"Não rastrear"</translation>
 <translation id="6232535412751077445">Ao ativar o recurso "Não rastrear" uma solicitação é incluída no tráfego de navegação. O resultado depende da resposta de um site à solicitação e de como a solicitação é interpretada.
 
 Por exemplo, alguns sites podem responder a esse pedido mostrando anúncios que não têm qualquer relação com os sites que você costuma visitar. Mesmo assim, alguns websites ainda vão coletar e usar seus dados de navegação para, por exemplo, melhorar a segurança, gerar conteúdo, anúncios, recomendações e relatórios de estatística.</translation>
-<translation id="624789221780392884">Atualização pronta</translation>
-<translation id="6255999984061454636">Sugestões de conteúdo</translation>
-<translation id="6277522088822131679">Ocorreu um problema ao imprimir a página. Tente novamente.</translation>
-<translation id="6295158916970320988">Todos os sites</translation>
-<translation id="629730747756840877">Conta</translation>
-<translation id="6303969859164067831">Sair e desativar a sincronização</translation>
-<translation id="6316139424528454185">Versão Android não compatível</translation>
-<translation id="6320088164292336938">Vibrar</translation>
-<translation id="6324034347079777476">Sincronização do sistema Android desativada</translation>
-<translation id="6333140779060797560">Compartilhar via <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Criptografia</translation>
-<translation id="6341580099087024258">Perguntar onde salvar os arquivos</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Remover sugestão do histórico?</translation>
-<translation id="6369229450655021117">Aqui, é possível pesquisar na Web, compartilhar itens com os amigos e ver as páginas abertas</translation>
-<translation id="6378173571450987352">Detalhes: classificados pela quantidade de dados usados</translation>
-<translation id="6381421346744604172">Escurecer sites</translation>
-<translation id="6388207532828177975">Limpar e redefinir</translation>
-<translation id="6393863479814692971">O Chrome precisa de permissão para este site acessar sua câmera e seu microfone.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Editar favorito</translation>
-<translation id="6406506848690869874">Sincronizar</translation>
-<translation id="641643625718530986">Imprimir...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB transferido(s) por download</translation>
-<translation id="6427112570124116297">Traduzir página da Web</translation>
-<translation id="6433501201775827830">Escolha seu mecanismo de pesquisa</translation>
-<translation id="6437478888915024427">Informações sobre a página</translation>
-<translation id="6441734959916820584">O nome é muito longo</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagem}one{# imagem}other{# imagens}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Não é possível abrir o arquivo</translation>
-<translation id="6464977750820128603">Você pode ver os sites que visita no Chrome e definir timers para eles.\n\nO Google recebe informações sobre os sites para os quais você definiu timers e sobre o tempo que você passa neles. Essas informações são usadas para melhorar o Bem-estar digital.</translation>
-<translation id="6475951671322991020">Fazer o download do vídeo</translation>
-<translation id="6482749332252372425">Falha no download do arquivo <ph name="FILE_NAME" /> devido à falta de espaço de armazenamento.</translation>
-<translation id="6496823230996795692">Para usar o app <ph name="APP_NAME" /> pela primeira vez, conecte-se à Internet</translation>
-<translation id="6508722015517270189">Reiniciar o Chrome</translation>
-<translation id="6527303717912515753">Compartilhar</translation>
-<translation id="6532866250404780454">Os sites que você visita no Chrome não serão exibidos. Todos os timers do site serão excluídos.</translation>
-<translation id="6534565668554028783">O Google demorou muito para responder</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB transferido(s) por download</translation>
-<translation id="6539092367496845964">Algo deu errado. Tente novamente mais tarde.</translation>
-<translation id="654446541061731451">Selecione uma guia para transferir</translation>
-<translation id="6545017243486555795">Limpar todos os dados</translation>
-<translation id="6545864417968258051">Verificação de Bluetooth</translation>
-<translation id="6560414384669816528">Pesquisar usando o Sogou</translation>
-<translation id="6566259936974865419">O Chrome economizou <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Sempre permitir</translation>
-<translation id="6573431926118603307">As guias que você abriu no Chrome nos seus outros dispositivos serão exibidas aqui.</translation>
-<translation id="6583199322650523874">Adicionar a página atual aos favoritos</translation>
-<translation id="6593061639179217415">Versão para computador</translation>
-<translation id="6600954340915313787">Copiado no Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Conteúdo protegido</translation>
-<translation id="6627583120233659107">Editar pasta</translation>
-<translation id="6643016212128521049">Limpar</translation>
-<translation id="6643649862576733715">Classificar pelo volume de dados economizados</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Visualizar imagem <ph name="BEGIN_NEW" />Novidade<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">O Chrome precisa de acesso ao local para procurar por dispositivos. <ph name="BEGIN_LINK" />Atualizar permissões<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Senha</translation>
-<translation id="6659594942844771486">Guia</translation>
-<translation id="666731172850799929">Abrir no <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Aviso de Privacidade do Chrome</translation>
-<translation id="6676840375528380067">Limpar seus dados do Chrome deste dispositivo?</translation>
-<translation id="6697492270171225480">Mostrar sugestões de páginas semelhantes quando uma página não for encontrada</translation>
-<translation id="6697947395630195233">O Chrome precisa acessar sua localização para compartilhá-la com este site.</translation>
-<translation id="6698801883190606802">Gerenciar dados sincronizados</translation>
-<translation id="6699370405921460408">Os servidores do Google otimizarão as páginas visitadas.</translation>
-<translation id="6706288973712894588">Não há conexão no momento.\n<ph name="BEGIN_LINK" />Navegue no seu feed off-line.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Notícias</translation>
-<translation id="6710213216561001401">Anterior</translation>
-<translation id="671481426037969117">Seu timer para <ph name="FQDN" /> chegou ao fim. Ele será iniciado novamente amanhã.</translation>
-<translation id="6738867403308150051">Fazendo o download...</translation>
-<translation id="6746124502594467657">Mover para baixo</translation>
-<translation id="6766622839693428701">Deslize para baixo para fechar.</translation>
-<translation id="6766758767654711248">Toque acessar o site</translation>
-<translation id="6767294960381293877">Lista de dispositivos com os quais é possível compartilhar uma guia aberta na metade da altura.</translation>
-<translation id="6782111308708962316">Impedir sites de terceiros de salvar e ler dados de cookies</translation>
-<translation id="6790428901817661496">Reproduzir</translation>
-<translation id="6811034713472274749">A página já pode ser visualizada</translation>
-<translation id="6818926723028410516">Selecionar itens</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Traduzir</translation>
-<translation id="6845325883481699275">Ajudar a melhorar a segurança do Chrome</translation>
-<translation id="6846298663435243399">Carregando…</translation>
-<translation id="6850409657436465440">Seu download ainda está em andamento</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> guias fechadas</translation>
-<translation id="6864459304226931083">Fazer o download da imagem</translation>
-<translation id="6865313869410766144">Preenchimento automático de dados de formulário</translation>
-<translation id="688738109438487280">Adicionar dados já existentes à conta <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Desbloqueie para copiar sua senha</translation>
-<translation id="6896758677409633944">Copiar</translation>
-<translation id="6910211073230771657">Excluído</translation>
-<translation id="6912998170423641340">Impedir que sites leiam textos e imagens da área de transferência</translation>
-<translation id="6914783257214138813">Suas senhas ficarão visíveis para qualquer pessoa que tiver acesso ao arquivo exportado.</translation>
-<translation id="6942665639005891494">Altere o local padrão de download a qualquer momento usando a opção do menu "Configurações"</translation>
-<translation id="6945221475159498467">Selecionar</translation>
-<translation id="6963642900430330478">Esta página é perigosa. Informações do site</translation>
-<translation id="6963766334940102469">Excluir favoritos</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Todo o período</translation>
-<translation id="6981982820502123353">Acessibilidade</translation>
-<translation id="6989267951144302301">Falha no download</translation>
-<translation id="6990079615885386641">Comprar aplicativo na Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Perguntar antes de permitir que sites usem o microfone (recomendado)</translation>
-<translation id="7015203776128479407">A configuração de sincronização inicial não foi concluída. A sincronização está desativada.</translation>
-<translation id="7016516562562142042">Permitido para o mecanismo de pesquisa atual</translation>
-<translation id="7022756207310403729">Abrir no navegador</translation>
-<translation id="702463548815491781">Recomendado quando o TalkBack ou o acesso com interruptor estão ativados</translation>
-<translation id="7029809446516969842">Senhas</translation>
-<translation id="7053983685419859001">Bloquear</translation>
-<translation id="7055152154916055070">Redirecionamento bloqueado:</translation>
-<translation id="7063006564040364415">Não foi possível conectar ao servidor de sincronização.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selecionado}one{# selecionado}other{# selecionados}}</translation>
-<translation id="7071521146534760487">Gerenciar conta</translation>
-<translation id="7077143737582773186">Cartão SD</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> itens selecionados. Opções disponíveis perto da parte superior da tela</translation>
-<translation id="7121362699166175603">Limpa o histórico e os preenchimentos automáticos na barra de endereço. Sua Conta do Google pode ter outras formas de histórico de navegação em <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Permitir o mecanismo de pesquisa atual</translation>
-<translation id="7138678301420049075">Outro</translation>
-<translation id="7141896414559753902">Impedir que sites exibam pop-ups e façam redirecionamentos (recomendado)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Carregar página original<ph name="END_LINK" /> de <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Últimas 24 horas</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Você poderá alterar isso mais tarde nas configurações</translation>
-<translation id="7180611975245234373">Atualizar</translation>
-<translation id="7189372733857464326">Aguardando o fim da atualização do Google Play Services</translation>
-<translation id="7191430249889272776">Guia aberta no plano de fundo.</translation>
-<translation id="723171743924126238">Selecionar imagens</translation>
-<translation id="7233236755231902816">Para ver as páginas da Web no seu idioma, instale a versão mais recente do Chrome</translation>
-<translation id="7243308994586599757">Opções disponíveis perto da parte inferior da tela</translation>
-<translation id="7248069434667874558">Verifique se a sincronização do <ph name="TARGET_DEVICE_NAME" /> está ativada no Chrome</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> itens selecionados</translation>
-<translation id="7274013316676448362">Site bloqueado</translation>
-<translation id="7290209999329137901">Ação de renomear indisponível</translation>
-<translation id="7291387454912369099">Finalizar compras com o Assistente</translation>
-<translation id="7293171162284876153">Para iniciar a sincronização, ative a opção "Sincronizar seus dados do Chrome".</translation>
-<translation id="729975465115245577">Seu dispositivo não tem um app para armazenar o arquivo de senhas.</translation>
-<translation id="7302081693174882195">Detalhes: classificados pela quantidade de dados economizados</translation>
-<translation id="7328017930301109123">Com o Modo Lite, as páginas são carregadas mais rapidamente no Chrome, e há uma economia de dados de até 60 por cento.</translation>
-<translation id="7333031090786104871">Ainda adicionando o site anterior</translation>
-<translation id="7352939065658542140">VÍDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Compartilhar 1 item selecionado}one{Compartilhar # item selecionado}other{Compartilhar # itens selecionados}}</translation>
 <translation id="7359002509206457351">Acessar formas de pagamento</translation>
+<translation id="8026334261755873520">Limpar dados de navegação</translation>
+<translation id="1291207594882862231">Limpar histórico, cookies, dados do site, cache…</translation>
+<translation id="7814200940910057384">Dados do Brave apagados</translation>
+<translation id="1664855196866195614">Os dados selecionados foram removidos do Brave e dos seus dispositivos sincronizados.
+
+É possível que sua Conta do Brave Software tenha outras formas de histórico de navegação, como pesquisas e atividades de outros serviços do Brave Software em 
+ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Imagens e arquivos armazenados em cache</translation>
+<translation id="2496180316473517155">Histórico de navegação</translation>
+<translation id="2546283357679194313">Cookies e dados do site</translation>
+<translation id="8662811608048051533">Desconecta você da maioria dos sites.</translation>
+<translation id="8218628800671693884">Desconecta você da maioria dos sites, mas não da sua Conta do Brave Software.</translation>
+<translation id="2017836877785168846">Limpa o histórico e o preenchimento automático na barra de endereço.</translation>
+<translation id="8096327394278038498">Limpa o histórico e os preenchimentos automáticos na barra de endereço. Sua Conta do Brave Software pode ter outras formas de histórico de navegação em <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Limpa o histórico de todos os dispositivos conectados. Sua Conta do Brave Software pode ter outras formas de histórico de navegação em <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Senhas salvas</translation>
+<translation id="6865313869410766144">Preenchimento automático de dados de formulário</translation>
+<translation id="7562080006725997899">Limpando dados de navegação</translation>
+<translation id="5487521232677179737">Limpar dados</translation>
+<translation id="7498271377022651285">Aguarde...</translation>
+<translation id="784934925303690534">Período</translation>
+<translation id="1718835860248848330">Última hora</translation>
+<translation id="7149893636342594995">Últimas 24 horas</translation>
+<translation id="5648166631817621825">Últimos sete dias</translation>
+<translation id="8571213806525832805">Últimas quatro semanas</translation>
+<translation id="5854790677617711513">Com mais de 30 dias</translation>
+<translation id="6979737339423435258">Todo o período</translation>
+<translation id="982182592107339124">Essa ação limpará os dados de todos os sites, incluindo:</translation>
+<translation id="6643016212128521049">Limpar</translation>
+<translation id="7641339528570811325">Limpar dados de navegação…</translation>
+<translation id="1670399744444387456">Básico</translation>
+<translation id="3245261285041759672">Sua Conta do Brave Software pode ter outras formas de histórico de navegação em <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Site bloqueado</translation>
+<translation id="2534155362429831547">Itens excluídos: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Relatórios de uso e falhas</translation>
+<translation id="9079153198295609735">Envia estatísticas de uso e relatórios de erros ao Brave Software automaticamente</translation>
+<translation id="6981982820502123353">Acessibilidade</translation>
+<translation id="2387895666653383613">Escala do texto</translation>
+<translation id="2321958826496381788">Arraste o controle deslizante até a leitura ficar confortável. Com o toque duplo em um parágrafo, o texto ficará pelo menos deste tamanho.</translation>
+<translation id="3895926599014793903">Forçar zoom</translation>
+<translation id="5668404140385795438">Aplicar zoom mesmo que o site tente impedir.</translation>
+<translation id="4149994727733219643">Versão simplificada das páginas da Web</translation>
+<translation id="9100505651305367705">Oferecer para mostrar artigos em uma versão simplificada, quando compatível.</translation>
+<translation id="1409426117486808224">Versão simplificada das guias abertas</translation>
+<translation id="702463548815491781">Recomendado quando o TalkBack ou o acesso com interruptor estão ativados</translation>
+<translation id="8284326494547611709">Legendas</translation>
+<translation id="4165986682804962316">Configurações do site</translation>
+<translation id="6295158916970320988">Todos os sites</translation>
+<translation id="8380167699614421159">Neste site, há exibição de anúncios invasivos ou enganosos</translation>
+<translation id="1919345977826869612">Anúncios</translation>
+<translation id="410351446219883937">Reprodução automática</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Bloquear cookies de terceiros</translation>
+<translation id="6782111308708962316">Impedir sites de terceiros de salvar e ler dados de cookies</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-ups e redirecionamentos</translation>
+<translation id="4751476147751820511">Sensores de luz ou movimento</translation>
+<translation id="1717218214683051432">Sensores de movimento</translation>
+<translation id="2091887806945687916">Som</translation>
+<translation id="2586657967955657006">Área de transferência</translation>
+<translation id="6320088164292336938">Vibrar</translation>
+<translation id="4226663524361240545">É possível que as notificações façam o dispositivo vibrar</translation>
+<translation id="1446450296470737166">Permitir controle total de dispositivos MIDI</translation>
+<translation id="3744111561329211289">Sincronização em segundo plano</translation>
+<translation id="5649053991847567735">Downloads automáticos</translation>
+<translation id="6181444274883918285">Adicionar site às exceções</translation>
+<translation id="5313967007315987356">Adicionar site</translation>
+<translation id="1369915414381695676">Site <ph name="SITE_NAME"/> adicionado</translation>
+<translation id="7837721118676387834">Permite que um determinado site mostre vídeos sem som automaticamente.</translation>
+<translation id="2621115761605608342">Permitir JavaScript para um site específico.</translation>
+<translation id="8801436777607969138">Bloquear JavaScript para um site específico.</translation>
+<translation id="8372893542064058268">Permite a sincronização em segundo plano para um site específico.</translation>
+<translation id="358794129225322306">Permite que um site faça o download de vários arquivos automaticamente.</translation>
+<translation id="4008040567710660924">Permita cookies para um site específico.</translation>
+<translation id="8958424370300090006">Bloqueie cookies de um site específico.</translation>
+<translation id="7882806643839505685">Permitir o som de um site específico.</translation>
+<translation id="4468959413250150279">Desative o som de um site específico.</translation>
+<translation id="1994173015038366702">URL do site</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Uso</translation>
+<translation id="5804241973901381774">Permissões</translation>
+<translation id="4278390842282768270">Permitido</translation>
+<translation id="5677928146339483299">Bloqueado</translation>
+<translation id="1984937141057606926">Permitidos, exceto de terceiros</translation>
+<translation id="7423098979219808738">Perguntar primeiro</translation>
+<translation id="8116925261070264013">Com som desativado</translation>
+<translation id="8300705686683892304">Gerenciados por app</translation>
+<translation id="6192792657125177640">Exceções</translation>
+<translation id="257931822824936280">Visualização expandida. Clique para recolher</translation>
+<translation id="5100237604440890931">Visualização recolhida. Clique para expandir</translation>
+<translation id="857943718398505171">Permitido (recomendado)</translation>
+<translation id="2913331724188855103">Permitir que os sites salvem e leiam os dados de arquivos "cookies" - que armazenam temporariamente o que você visitou na rede. (Recomendado)</translation>
+<translation id="7445411102860286510">Permite que os sites mostrem vídeos sem som automaticamente (recomendado)</translation>
+<translation id="5335288049665977812">Permitir que sites executem o JavaScript (recomendado)</translation>
+<translation id="5527111080432883924">Perguntar antes de permitir que sites leiam textos e imagens da área de transferência (recomendado)</translation>
+<translation id="6912998170423641340">Impedir que sites leiam textos e imagens da área de transferência</translation>
+<translation id="7423538860840206698">Leitura da área de transferência bloqueada</translation>
+<translation id="3955193568934677022">Permitir que os sites reproduzam conteúdo protegido (recomendado)</translation>
+<translation id="445467742685312942">Permitir que sites reproduzam conteúdo protegido</translation>
+<translation id="2107397443965016585">Perguntar antes de permitir que sites reproduzam conteúdo protegido (recomendado)</translation>
+<translation id="2910701580606108292">Perguntar antes de permitir que sites reproduzam conteúdo protegido</translation>
+<translation id="757524316907819857">Impedir que sites reproduzam conteúdos protegidos</translation>
+<translation id="3277252321222022663">Permitir que sites acessem os sensores (recomendado)</translation>
+<translation id="5048398596102334565">Permitir o acesso de sites aos seus sensores de movimento (recomendado)</translation>
+<translation id="8816026460808729765">Impedir que sites acessem os sensores</translation>
+<translation id="169515064810179024">Impedir que sites acessem os sensores de movimento</translation>
+<translation id="1660204651932907780">Permitir o áudio dos sites (recomendado)</translation>
+<translation id="3600792891314830896">Silenciar sites com áudio</translation>
+<translation id="1743802530341753419">Perguntar antes de permitir a conexão de sites a um dispositivo (recomendado)</translation>
+<translation id="851751545965956758">Impedir a conexão de sites a dispositivos</translation>
+<translation id="7141896414559753902">Impedir que sites exibam pop-ups e façam redirecionamentos (recomendado)</translation>
+<translation id="5494752089476963479">Bloquear anúncios em sites com publicidade invasiva ou enganosa</translation>
+<translation id="3123473560110926937">Bloqueados em alguns sites</translation>
+<translation id="965817943346481315">Bloquear se o site mostrar anúncios invasivos ou enganosos (recomendado)</translation>
+<translation id="3386292677130313581">Perguntar antes de permitir que sites saibam seu local (recomendado)</translation>
+<translation id="9139068048179869749">Perguntar antes de permitir que sites enviem notificações (recomendado)</translation>
+<translation id="4479647676395637221">Perguntar antes de permitir que sites usem sua câmera (recomendado)</translation>
+<translation id="6992289844737586249">Perguntar antes de permitir que sites usem o microfone (recomendado)</translation>
+<translation id="2289270750774289114">Perguntar quando um site quer descobrir dispositivos Bluetooth nas proximidades (recomendado)</translation>
+<translation id="7053983685419859001">Bloquear</translation>
+<translation id="7128222689758636196">Permitir o mecanismo de pesquisa atual</translation>
+<translation id="7589445247086920869">Bloquear o mecanismo de pesquisa atual</translation>
+<translation id="6388207532828177975">Limpar e redefinir</translation>
+<translation id="7999064672810608036">Tem certeza que quer apagar todos os dados locais, inclusive os cookies, e redefinir todas as permissões para este website?</translation>
+<translation id="2822354292072154809">Tem certeza de que quer redefinir todas as permissões de site para <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Limpar dados armazenados</translation>
+<translation id="5902828464777634901">Os dados locais armazenados por este site serão excluídos, inclusive os cookies.</translation>
+<translation id="119944043368869598">Limpar tudo</translation>
+<translation id="2490684707762498678">Gerenciadas por <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Abrir configurações de notificação</translation>
+<translation id="1404122904123200417">Incorporado em <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Os arquivos salvos por sites são exibidos aqui</translation>
+<translation id="4181841719683918333">Idiomas</translation>
+<translation id="2647434099613338025">Adicionar idioma</translation>
+<translation id="1952172573699511566">Os sites exibirão textos no idioma de sua preferência, quando for possível.</translation>
+<translation id="8559990750235505898">Oferecer para traduzir páginas em outros idiomas</translation>
+<translation id="4719927025381752090">Oferecer para traduzir</translation>
+<translation id="8156139159503939589">Quais idiomas você lê?</translation>
+<translation id="5689516760719285838">Local</translation>
+<translation id="2440823041667407902">Acesso ao local</translation>
+<translation id="2023546461831060654">Ative as permissões para o Brave nas <ph name="BEGIN_LINK"/>configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Ative a permissão para o Brave nas <ph name="BEGIN_LINK"/>configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Para permitir que o Brave acesse sua localização, ative-a nas <ph name="BEGIN_LINK"/>configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Para permitir que o Brave acesse sua câmera, ative-a também nas <ph name="BEGIN_LINK"/>configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Para permitir que o Brave envie notificações, ative-as também nas <ph name="BEGIN_LINK"/>configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Para permitir que o Brave acesse seu microfone, ative-o nas <ph name="BEGIN_LINK"/>configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">O acesso ao local está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK"/>Configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">O acesso ao local também está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK"/>Configurações do Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Câmera</translation>
+<translation id="3227137524299004712">Microfone</translation>
+<translation id="1647391597548383849">Acessar sua câmera</translation>
+<translation id="945632385593298557">Acessar seu microfone</translation>
+<translation id="6612358246767739896">Conteúdo protegido</translation>
+<translation id="885701979325669005">Armazenamento</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> de dados armazenados</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revogar permissão do dispositivo</translation>
+<translation id="4962975101802056554">Revogar todas as permissões para o dispositivo</translation>
+<translation id="6545864417968258051">Verificação de Bluetooth</translation>
+<translation id="4411535500181276704">Modo Lite</translation>
+<translation id="7821588508402923572">Sua economia de dados será exibida aqui</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> salvo(s)</translation>
+<translation id="8569404424186215731">desde <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Com o Modo Lite, as páginas são carregadas mais rapidamente no Brave, e há uma economia de dados de até 60 por cento.</translation>
+<translation id="6159335304067198720">Economia de dados de <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">de dados economizados</translation>
+<translation id="6111020039983847643">dados usados</translation>
+<translation id="7413229368719586778">Data de início: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Data de término: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Classificar por site</translation>
+<translation id="5864174910718532887">Detalhes: classificados por nome do site</translation>
+<translation id="116280672541001035">Dados usados</translation>
+<translation id="8349013245300336738">Classificar por quantidade de dados usados</translation>
+<translation id="6378173571450987352">Detalhes: classificados pela quantidade de dados usados</translation>
+<translation id="2631006050119455616">Salvo</translation>
+<translation id="6643649862576733715">Classificar pelo volume de dados economizados</translation>
+<translation id="7302081693174882195">Detalhes: classificados pela quantidade de dados economizados</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> usado(s)</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> economizado(s)</translation>
+<translation id="2156074688469523661">Sites restantes (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Outro</translation>
+<translation id="4913161338056004800">Redefinir estatísticas</translation>
+<translation id="1856325424225101786">Redefinir o Modo Lite?</translation>
+<translation id="3658159451045945436">A redefinição limpa o histórico da economia de dados, incluindo a lista de sites visitados.</translation>
+<translation id="3295530008794733555">Navegue com mais rapidez. Use menos dados.</translation>
+<translation id="7340390500800578919">Com o Modo Lite, as páginas são carregadas mais rapidamente no Brave, e há uma economia de dados de até 60%. Para otimizar as páginas visitadas, o Brave envia seu tráfego da Web para o Brave Software. <ph name="BEGIN_LINK"/>Saiba mais<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Ativar Modo Lite</translation>
+<translation id="4493497663118223949">Modo Lite ativado</translation>
+<translation id="7559975015014302720">Modo Lite desativado</translation>
+<translation id="7606077192958116810">Modo Lite ativado. Gerencie-o nas configurações.</translation>
+<translation id="4714588616299687897">Economize até 60% dos seus dados</translation>
+<translation id="1006927014032731288">Os servidores do Brave Software otimizarão as páginas visitadas.</translation>
+<translation id="3257320067425202300">O Brave economizou <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">O Brave economizou <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Local de download</translation>
+<translation id="7077143737582773186">Cartão SD</translation>
+<translation id="7762668264895820836">Cartão SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Perguntar onde salvar os arquivos</translation>
+<translation id="6192333916571137726">Fazer o download do arquivo</translation>
+<translation id="1672586136351118594">Não mostrar novamente</translation>
+<translation id="2650751991977523696">Fazer o download do arquivo novamente?</translation>
+<translation id="8664979001105139458">O nome do arquivo já existe</translation>
+<translation id="488187801263602086">Renomear arquivo</translation>
+<translation id="5686790454216892815">Nome do arquivo muito longo</translation>
+<translation id="7454641608352164238">Espaço insuficiente</translation>
+<translation id="8972098258593396643">Fazer o download para a pasta padrão?</translation>
+<translation id="804335162455518893">Cartão SD não encontrado</translation>
+<translation id="7475688122056506577">Cartão SD não encontrado. Alguns arquivos podem estar faltando.</translation>
+<translation id="4198423547019359126">Não há locais de download disponíveis</translation>
+<translation id="8224471946457685718">Fazer o download de "Artigos para você" quando houver conexão Wi-Fi</translation>
+<translation id="4970824347203572753">Indisponível no seu local</translation>
+<translation id="5500777121964041360">Pode não estar disponível no seu local</translation>
+<translation id="1173894706177603556">Renomear</translation>
+<translation id="1986685561493779662">Esse nome já existe</translation>
+<translation id="6441734959916820584">O nome é muito longo</translation>
+<translation id="2923908459366352541">O nome é inválido</translation>
+<translation id="7290209999329137901">Ação de renomear indisponível</translation>
+<translation id="3334729583274622784">Mudar extensão do arquivo?</translation>
+<translation id="107147699690128016">Se você mudar a extensão do arquivo, ele poderá ser aberto em um aplicativo diferente e colocar em risco seu dispositivo.</translation>
+<translation id="8541922081612557424">Sobre o Brave Software Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Todos os direitos reservados.</translation>
+<translation id="1416550906796893042">Versão do aplicativo</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (atualizada <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistema operacional</translation>
+<translation id="3968054912784331254">As atualizações do Brave não são mais compatíveis com esta versão do Android</translation>
+<translation id="7665369617277396874">Adicionar conta</translation>
+<translation id="649070405679044769">Conectado ao Brave Software como</translation>
+<translation id="6234515504547364178">Sair do Brave Software Brave</translation>
+<translation id="5324858694974489420">Configurações dos pais</translation>
+<translation id="8920114477895755567">Aguardando detalhes dos pais.</translation>
+<translation id="5512137114520586844">Esta conta é gerenciada por <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Esta conta é gerenciada por <ph name="PARENT_NAME_1"/> e <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Conteúdo</translation>
+<translation id="5403644198645076998">Permitir apenas determinados sites</translation>
+<translation id="8641930654639604085">Tentar bloquear sites com conteúdo para adultos</translation>
+<translation id="5639724618331995626">Permitir todos os sites</translation>
+<translation id="796823723482603597">Em execução no Brave</translation>
+<translation id="6324034347079777476">Sincronização do sistema Android desativada</translation>
+<translation id="5127805178023152808">A sincronização está desativada</translation>
+<translation id="7015203776128479407">A configuração de sincronização inicial não foi concluída. A sincronização está desativada.</translation>
+<translation id="2497852260688568942">A sincronização foi desativada pelo administrador</translation>
+<translation id="9100610230175265781">Senha necessária</translation>
+<translation id="6108923351542677676">Configuração em andamento...</translation>
+<translation id="4062305924942672200">Informações legais</translation>
+<translation id="4256782883801055595">Licenças de código aberto</translation>
+<translation id="1138681184697033370">Termos de Serviço do Brave</translation>
+<translation id="7392539049993970338">Aviso de Privacidade do Brave</translation>
+<translation id="2677748264148917807">Sair</translation>
+<translation id="5556459405103347317">Recarregar</translation>
+<translation id="1623104350909869708">Impedir que esta página crie caixas de diálogo adicionais</translation>
+<translation id="2968755619301702150">Leitor de certificados</translation>
+<translation id="1360432990279830238">Sair e desativar a sincronização?</translation>
+<translation id="8581481290581777242">Limpar seus dados do Brave deste dispositivo?</translation>
+<translation id="1318865768845061710">Seus favoritos, histórico, senhas e outros dados do Brave não serão mais sincronizados com sua Conta do Brave Software</translation>
+<translation id="3325020657155065477">Limpar também seus dados do Brave deste dispositivo</translation>
+<translation id="6136448902816743006">Você está saindo de uma conta gerenciada por <ph name="DOMAIN_NAME"/>, por isso seus dados do Brave serão excluídos deste dispositivo. No entanto, eles permanecerão na sua Conta do Brave Software.</translation>
+<translation id="1853026300647876496">Entrando em contato com o Brave Software. Isso pode levar um minuto…</translation>
+<translation id="2328985652426384049">Não consigo fazer login</translation>
+<translation id="7723158744459952869">O Brave Software demorou muito para responder</translation>
+<translation id="4572422548854449519">Fazer login em conta gerenciada</translation>
+<translation id="2689656545739939160">Você está fazendo login com uma conta gerenciada por <ph name="MANAGED_DOMAIN"/> e dando ao administrador dela o controle sobre seus dados do Brave, os quais ficarão permanentemente vinculados a essa conta. Se você sair do Brave, seus dados serão excluídos desse dispositivo, mas permanecerão armazenados na sua Conta do Brave Software.</translation>
+<translation id="1749561566933687563">Sincronize seus favoritos</translation>
+<translation id="4242533952199664413">Abrir configurações.</translation>
+<translation id="1111673857033749125">Favoritos salvos nos seus outros dispositivos serão exibidos aqui.</translation>
+<translation id="8636825310635137004">Para ver suas guias abertas em outros dispositivos, ative a sincronização.</translation>
+<translation id="3269956123044984603">Para ver as guias dos seus outros dispositivos, ative a opção "Sincronizar dados automaticamente" nas configurações de conta do Android.</translation>
+<translation id="5157964048453367290">As guias que você abriu no Brave nos seus outros dispositivos serão exibidas aqui.</translation>
+<translation id="4684427112815847243">Sincronizar tudo</translation>
+<translation id="2709516037105925701">Preenchimento automático</translation>
+<translation id="8820817407110198400">Favoritos</translation>
+<translation id="1644574205037202324">Histórico</translation>
+<translation id="17513872634828108">Guias abertas</translation>
+<translation id="1320169905922104972">Cartões de crédito e endereços que usam o Brave Software Pay</translation>
+<translation id="6337234675334993532">Criptografia</translation>
+<translation id="6698801883190606802">Gerenciar dados sincronizados</translation>
+<translation id="3598578758776312506">Usar as credenciais do Brave Software para criptografar e proteger minhas senhas</translation>
+<translation id="7810580217418711046">Criptografar dados sincronizados com a senha do Brave Software a partir de <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Criptografar dados sincronizados com sua senha de sincronização</translation>
+<translation id="2996291259634659425">Criar senha longa</translation>
+<translation id="5713644099811900409">Conta do Brave Software</translation>
+<translation id="8997474919031554666">A criptografia por senha longa não inclui formas de pagamento e endereços do Brave Software Pay. Apenas uma pessoa que tenha sua senha longa pode ler seus dados criptografados. Essa senha não é enviada ou armazenada pelo Brave Software. Se você esquecer a senha longa ou quiser alterar essa configuração, será necessário redefinir a sincronização. <ph name="BEGIN_LINK"/>Saiba mais<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Senha</translation>
+<translation id="7772032839648071052">Confirmar senha</translation>
+<translation id="5304593522240415983">Este campo não pode ficar em branco</translation>
+<translation id="321773570071367578">Se você esqueceu sua senha longa ou deseja alterar essa configuração, <ph name="BEGIN_LINK"/>redefina a sincronização<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">As senhas não correspondem</translation>
+<translation id="5149495116300586333">A criptografia por senha longa não inclui formas de pagamento e endereços do Brave Software Pay.
+
+Para alterar essa configuração, <ph name="BEGIN_LINK"/>redefina a sincronização<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Senha incorreta</translation>
+<translation id="5414836363063783498">Verificando...</translation>
+<translation id="6846298663435243399">Carregando…</translation>
+<translation id="5517095782334947753">Você tem favoritos, histórico, senhas e outras configurações da conta <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combinar meus dados</translation>
+<translation id="688738109438487280">Adicionar dados já existentes à conta <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Manter meus dados separados</translation>
+<translation id="1145536944570833626">Excluir dados já existentes.</translation>
+<translation id="1993768208584545658">O <ph name="SITE"/> deseja realizar o pareamento</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Receber ajuda<ph name="END_LINK"/> ao procurar dispositivos…</translation>
+<translation id="5817918615728894473">Parear</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Receber ajuda<ph name="END_LINK1"/> ou <ph name="BEGIN_LINK2"/>verificar novamente<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Nenhum dispositivo compatível encontrado</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Ativar o Bluetooth<ph name="END_LINK"/> para permitir o pareamento</translation>
+<translation id="998321811308652668">O Brave não pôde ativar o adaptador Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Receber ajuda<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">O Brave precisa de acesso ao local para procurar por dispositivos. <ph name="BEGIN_LINK"/>Atualizar permissões<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">O Brave precisa ter acesso ao local para verificar dispositivos. O acesso ao local está <ph name="BEGIN_LINK"/>desativado neste dispositivo<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">O Brave precisa ter acesso ao local para procurar dispositivos. <ph name="BEGIN_LINK1"/>Atualize as permissões<ph name="END_LINK1"/>. O acesso ao local também está <ph name="BEGIN_LINK2"/>desativado neste dispositivo<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Dispositivo conectado</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Nível de intensidade do sinal: de # barra}one{Nível de intensidade do sinal: de # barra}other{Nível de intensidade do sinal: de # barras}}</translation>
+<translation id="5230560987958996918">Solicitação de <ph name="SITE"/> para procurar dispositivos Bluetooth próximos. Os seguintes dispositivos foram encontrados:</translation>
+<translation id="8368027906805972958">Dispositivo desconhecido ou incompatível (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">A sincronização não está funcionando</translation>
+<translation id="1810845389119482123">Configuração de sincronização inicial não concluída</translation>
+<translation id="3235722914093408050">Abrir configs. Android e reativar sincronização do Android p/ sincronizar Brave</translation>
+<translation id="3367813778245106622">Faça login novamente para começar a sincronizar</translation>
+<translation id="974555521953189084">Digite sua senha longa para iniciar a sincronização</translation>
+<translation id="2997266899014181325">Para iniciar a sincronização, ative a opção "Sincronizar seus dados do Brave".</translation>
+<translation id="8260126382462817229">Tente fazer login novamente</translation>
+<translation id="5919204609460789179">Atualize <ph name="PRODUCT_NAME"/> para iniciar a sincronização</translation>
+<translation id="397583555483684758">A sincronização parou de funcionar</translation>
+<translation id="1966710179511230534">Atualize seus detalhes de login.</translation>
+<translation id="7063006564040364415">Não foi possível conectar ao servidor de sincronização.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> está desatualizado.</translation>
+<translation id="4170011742729630528">O serviço não está disponível. Tente novamente mais tarde.</translation>
+<translation id="7947953824732555851">Aceitar/fazer login</translation>
+<translation id="8583805026567836021">Limpando os dados da conta</translation>
+<translation id="8310344678080805313">Guias padrão</translation>
+<translation id="5748802427693696783">Alternada para guias padrão</translation>
+<translation id="7998918019931843664">Reabrir guia fechada</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, guia</translation>
+<translation id="4452411734226507615">Fechar guia <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opções disponíveis perto da parte inferior da tela</translation>
+<translation id="4060598801229743805">Opções disponíveis perto da parte superior da tela</translation>
+<translation id="2810645512293415242">Página simplificada para economizar dados e carregar mais rapidamente.</translation>
+<translation id="3985215325736559418">Quer fazer o download do arquivo <ph name="FILE_NAME"/> novamente?</translation>
+<translation id="2450083983707403292">Quer recomeçar o download de <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Fazer o download</translation>
+<translation id="545042621069398927">Acelerando seu download.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Fazendo o download do arquivo.}one{Fazendo o download de # arquivo.}other{Fazendo o download de # arquivos.}}</translation>
+<translation id="543509235395288790">Fazendo o download de <ph name="COUNT"/> arquivos (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Fazendo o download do arquivo (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 download concluído.}one{# download concluído.}other{# downloads concluídos.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Falha em 1 download.}one{Falha em # download.}other{Falha em # downloads.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 download pendente.}one{# download pendente.}other{# downloads pendentes.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> botão <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Quase lá.</translation>
+<translation id="3960299545138990065">Reiniciar o Brave</translation>
+<translation id="3771001275138982843">Não foi possível fazer o download da atualização</translation>
+<translation id="3888648114124182147">Fazendo o download da atualização do Brave…</translation>
+<translation id="1705567146636171298">Atualizar o Brave Software Brave</translation>
+<translation id="6195417478702700398">Para ter a melhor experiência de navegação, abra para atualizar o Brave</translation>
+<translation id="3512968675351418494">Para ver as páginas da Web no seu idioma, instale a versão mais recente do Brave</translation>
+<translation id="6427112570124116297">Traduzir página da Web</translation>
+<translation id="1379423114029199501">Faça a atualização para usar a versão mais recente do Brave no seu idioma</translation>
+<translation id="5684874026226664614">Não foi possível traduzir esta página.</translation>
+<translation id="6831043979455480757">Traduzir</translation>
+<translation id="1285320974508926690">Nunca traduzir este site</translation>
+<translation id="773466115871691567">Sempre traduzir páginas em <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nunca traduzir páginas em <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Mais idiomas</translation>
+<translation id="290376772003165898">A página não está em <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Páginas em <ph name="SOURCE_LANGUAGE"/> serão traduzidas para <ph name="TARGET_LANGUAGE"/> de agora em diante</translation>
+<translation id="8339163506404995330">Páginas em <ph name="LANGUAGE"/> não serão traduzidas</translation>
+<translation id="5447765697759493033">Este site não será traduzido</translation>
+<translation id="4880127995492972015">Traduzir…</translation>
+<translation id="641643625718530986">Imprimir...</translation>
+<translation id="8909135823018751308">Compartilhar...</translation>
+<translation id="4996978546172906250">Compartilhar via</translation>
+<translation id="6333140779060797560">Compartilhar via <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Ocorreu um problema ao imprimir a página. Tente novamente.</translation>
+<translation id="3254409185687681395">Adicionar esta página aos favoritos</translation>
+<translation id="497421865427891073">Avançar</translation>
+<translation id="813082847718468539">Visualizar informações do site</translation>
+<translation id="2532336938189706096">Visualização da Web</translation>
+<translation id="6005538289190791541">Senha sugerida</translation>
+<translation id="4634124774493850572">Usar senha</translation>
+<translation id="8285489906452138776">O Brave precisa de permissão para este site acessar sua câmera.</translation>
+<translation id="320189792589364011">O Brave precisa de permissão para este site acessar seu microfone.</translation>
+<translation id="7988136689212463100">O Brave precisa de permissão para este site acessar sua câmera e seu microfone.</translation>
+<translation id="4931190655840828017">O Brave precisa acessar sua localização para compartilhá-la com este site.</translation>
+<translation id="3088191967551450609">O Brave precisa de acesso para fazer o download e armazenar arquivos.</translation>
+<translation id="8942627711005830162">Abrir em outra janela</translation>
+<translation id="4195643157523330669">Abrir em uma nova guia</translation>
+<translation id="1100066534610197918">Abrir em nova guia no grupo</translation>
+<translation id="4860895144060829044">Ligar</translation>
+<translation id="6896758677409633944">Copiar</translation>
+<translation id="8393700583063109961">Enviar mensagem</translation>
+<translation id="3557336313807607643">Adicionar aos contatos</translation>
+<translation id="4269820728363426813">Copiar endereço do link</translation>
+<translation id="1206892813135768548">Copiar texto do link</translation>
+<translation id="1204037785786432551">Fazer o download do link</translation>
+<translation id="6864459304226931083">Fazer o download da imagem</translation>
+<translation id="8209050860603202033">Abrir imagem</translation>
+<translation id="8073388330009372546">Abrir imagem em nova guia</translation>
+<translation id="6649642165559792194">Visualizar imagem <ph name="BEGIN_NEW"/>Novidade<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Carregar imagem</translation>
+<translation id="3845332215609790146">Pesquisar com Brave Software Lens <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Pesquisar imagem no <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Compartilhar imagem</translation>
+<translation id="5833984609253377421">Compartilhar link</translation>
+<translation id="6475951671322991020">Fazer o download do vídeo</translation>
+<translation id="2317945146070194624">Abrir em nova guia do Brave</translation>
+<translation id="7975379999046275268">Visualizar página <ph name="BEGIN_NEW"/>Novidade<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Atualizando página</translation>
+<translation id="36525718899759834">Comprar aplicativo na Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Escuro</translation>
+<translation id="1807246157184219062">Claro</translation>
+<translation id="4056223980640387499">Sépia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Espaçamento uniforme</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Selecione uma guia para transferir</translation>
+<translation id="8719023831149562936">Não é possível enviar a guia atual</translation>
+<translation id="2139186145475833000">Adicionar à tela inicial</translation>
+<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Não foi possível abrir o aplicativo</translation>
+<translation id="5129038482087801250">Instalar app da Web</translation>
+<translation id="3789841737615482174">Instalar</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> foi adicionado à sua tela inicial</translation>
+<translation id="7333031090786104871">Ainda adicionando o site anterior</translation>
+<translation id="1036727731225946849">Adicionando <ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">Adicionado à tela inicial</translation>
+<translation id="2146738493024040262">Abrir Instant App</translation>
+<translation id="7016516562562142042">Permitido para o mecanismo de pesquisa atual</translation>
+<translation id="6177111841848151710">Bloqueado para o mecanismo de pesquisa atual</translation>
+<translation id="145097072038377568">Desativada nas configurações do Android</translation>
+<translation id="8007176423574883786">Desativado neste dispositivo</translation>
+<translation id="164269334534774161">Você está vendo uma cópia off-line desta página de <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Esta página off-line é de <ph name="CREATION_TIME"/> e pode ser diferente da versão on-line.</translation>
+<translation id="8840953339110955557">Esta página pode ser diferente da versão on-line.</translation>
+<translation id="6405300764336705484">Este conteúdo é de <ph name="DOMAIN_NAME"/>, veiculado pelo Brave Software.</translation>
+<translation id="1006017844123154345">Abrir on-line</translation>
+<translation id="3326636747541519688">Página Lite exibida pelo Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Carregar página original<ph name="END_LINK"/> de <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Se estiver vendo isso com frequência, tente estas <ph name="BEGIN_LINK"/>sugestões<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Conteúdo oculto</translation>
+<translation id="3810973564298564668">Gerenciar</translation>
+<translation id="5199929503336119739">Perfil de trabalho</translation>
+<translation id="528192093759286357">Arraste a partir da parte superior e toque no botão "Voltar" para sair da tela cheia.</translation>
+<translation id="2836148919159985482">Toque no botão "Voltar" para sair da tela cheia.</translation>
+<translation id="3967822245660637423">Download concluído</translation>
+<translation id="2434158240863470628">Download concluído <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Falha no download</translation>
+<translation id="1384959399684842514">Download pausado</translation>
+<translation id="1671236975893690980">Download pendente…</translation>
+<translation id="5561549206367097665">Aguardando a rede…</translation>
+<translation id="5864419784173784555">Aguardando outro download…</translation>
+<translation id="6461962085415701688">Não é possível abrir o arquivo</translation>
+<translation id="1178581264944972037">Pausar</translation>
+<translation id="8200772114523450471">Retomar</translation>
+<translation id="1409879593029778104">O download de <ph name="FILE_NAME"/> foi impedido porque o arquivo já existe.</translation>
+<translation id="3387650086002190359">Falha no download de <ph name="FILE_NAME"/> devido a erros do sistema de arquivos.</translation>
+<translation id="6482749332252372425">Falha no download do arquivo <ph name="FILE_NAME"/> devido à falta de espaço de armazenamento.</translation>
+<translation id="7619072057915878432">Falha no download do arquivo <ph name="FILE_NAME"/> devido a falhas na rede.</translation>
+<translation id="1477626028522505441">Falha no download do arquivo <ph name="FILE_NAME"/> devido a problemas de servidor.</translation>
+<translation id="3692944402865947621">Falha no download do arquivo <ph name="FILE_NAME"/> porque não foi possível acessar o local do armazenamento.</translation>
+<translation id="604996488070107836">Falha no download do arquivo <ph name="FILE_NAME"/> devido a um erro desconhecido.</translation>
+<translation id="6738867403308150051">Fazendo o download...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB transferido(s) por download</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB transferido(s) por download</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB transferido(s) por download</translation>
+<translation id="9204836675896933765">1 arquivo restante</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> arquivos restantes</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> arquivo transferido por download}one{<ph name="FILES_DOWNLOADED_MANY"/> arquivo transferido por download}other{<ph name="FILES_DOWNLOADED_MANY"/> arquivos transferidos por download}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> dias restantes</translation>
+<translation id="8190358571722158785">Um dia restante</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> horas restantes</translation>
+<translation id="510275257476243843">Uma hora restante</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minutos restantes</translation>
+<translation id="3236059992281584593">Um minuto restante</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> segundos restantes</translation>
+<translation id="2781151931089541271">Um segundo restante</translation>
+<translation id="3303414029551471755">Continuar com o download do conteúdo?</translation>
+<translation id="8617240290563765734">Abrir o URL sugerido especificado no conteúdo transferido por download?</translation>
+<translation id="1373696734384179344">Memória insuficiente para fazer o download do conteúdo selecionado.</translation>
+<translation id="5271967389191913893">Não é possível abrir no dispositivo o conteúdo a ser transferido por download.</translation>
+<translation id="883806473910249246">Ocorreu um erro durante o download do conteúdo.</translation>
+<translation id="5626134646977739690">Nome:</translation>
+<translation id="7963646190083259054">Fornecedor:</translation>
+<translation id="3414952576877147120">Tamanho:</translation>
+<translation id="7375125077091615385">Tipo:</translation>
+<translation id="5765780083710877561">Descrição:</translation>
+<translation id="4881695831933465202">Abrir</translation>
+<translation id="3542235761944717775">Disponíveis: <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB disponíveis</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB disponível(is)</translation>
+<translation id="5793665092639000975">Usando <ph name="SPACE_USED"/> de <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Tudo</translation>
+<translation id="4988526792673242964">Páginas</translation>
+<translation id="3810838688059735925">Vídeo</translation>
+<translation id="3616113530831147358">Áudio</translation>
+<translation id="9219103736887031265">Imagens</translation>
+<translation id="8250920743982581267">Documentos</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# arquivo}one{# arquivo}other{# arquivos}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagem}one{# imagem}other{# imagens}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}one{# vídeo}other{# vídeos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# arquivo de áudio}one{# arquivo de áudio}other{# arquivos de áudio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}one{# página}other{# páginas}}</translation>
+<translation id="5456381639095306749">Fazer o download da página</translation>
+<translation id="2394602618534698961">Os arquivos salvos por download são exibidos aqui</translation>
+<translation id="7810647596859435254">Abrir com…</translation>
+<translation id="5655963694829536461">Pesquisar seus downloads</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Meus arquivos</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Os artigos são exibidos aqui e podem ser lidos até quando você está off-line</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}other{# h}}</translation>
+<translation id="5853623416121554550">pausado</translation>
+<translation id="8965591936373831584">pendente</translation>
+<translation id="2779651927720337254">falha</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Agora</translation>
+<translation id="4000212216660919741">Página inicial off-line</translation>
+<translation id="9133397713400217035">Navegar off-line</translation>
+<translation id="968900484120156207">As páginas visitadas são exibidas aqui</translation>
+<translation id="7882131421121961860">Nenhum histórico encontrado</translation>
+<translation id="3549657413697417275">Pesquise o seu histórico</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Tela de apresentação do Brave</translation>
+<translation id="2700285883409956633">Ao usar este aplicativo, você concorda com os <ph name="BEGIN_LINK1"/>Termos de Serviço<ph name="END_LINK1"/> e com o <ph name="BEGIN_LINK2"/>Aviso de Privacidade<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Ao usar este aplicativo, você concorda com os <ph name="BEGIN_LINK1"/>Termos de Serviço<ph name="END_LINK1"/> e o <ph name="BEGIN_LINK2"/>Aviso de Privacidade<ph name="END_LINK2"/> do Brave, bem como o <ph name="BEGIN_LINK3"/>Aviso de Privacidade de Contas do Brave Software gerenciadas com o Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">O app <ph name="APP_NAME"/> será aberto no Brave. Ao continuar, você concorda com os <ph name="BEGIN_LINK1"/>Termos de Serviço<ph name="END_LINK1"/> e o <ph name="BEGIN_LINK2"/>Aviso de Privacidade<ph name="END_LINK2"/> do Brave.</translation>
+<translation id="5071615083211946659">O app <ph name="APP_NAME"/> será aberto no Brave. Ao continuar, você concorda com os <ph name="BEGIN_LINK1"/>Termos de Serviço<ph name="END_LINK1"/> e o <ph name="BEGIN_LINK2"/>Aviso de Privacidade do Brave<ph name="END_LINK2"/>, assim como o <ph name="BEGIN_LINK3"/>Aviso de Privacidade de Contas do Brave Software gerenciadas com o Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Ajude a melhorar o Brave. Envie estatísticas de uso e relatórios de falhas ao Brave Software.</translation>
+<translation id="3518985090088779359">Aceitar e continuar</translation>
+<translation id="7207456302801184289">Bem-vindo ao Brave Software Brave</translation>
+<translation id="704822250101715322">Aguardando o fim da atualização do Brave Software Play Services</translation>
+<translation id="1231733316453485619">Ativar sincronização?</translation>
+<translation id="5132942445612118989">Sincronize suas senhas, seu histórico e muito mais em todos os dispositivos</translation>
+<translation id="5736731321935944068">O Brave Software pode usar seu histórico para personalizar a Pesquisa, os anúncios e outros serviços que ele oferece</translation>
+<translation id="4013614219085422040">O Brave Software pode usar seu histórico para personalizar a Pesquisa e outros serviços que ele oferece</translation>
+<translation id="5581519193887989363">Nas <ph name="BEGIN_LINK1"/>configurações<ph name="END_LINK1"/>, é possível escolher a qualquer momento o que é sincronizado.</translation>
+<translation id="741204030948306876">Sim</translation>
+<translation id="2410754283952462441">Escolher uma conta</translation>
+<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Não é <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Para ter seus favoritos em todos os seus dispositivos, ative a sincronização</translation>
+<translation id="2818669890320396765">Para ter seus favoritos em todos os seus dispositivos, faça login e ative a sincronização</translation>
+<translation id="6003646045106347985">Para receber conteúdo personalizado sugerido pelo Brave Software, ative a sincronização</translation>
+<translation id="8494430740943879273">Para receber conteúdo personalizado sugerido pelo Brave Software, ative a sincronização</translation>
+<translation id="5862731021271217234">Para ver as guias dos seus outros dispositivos, ative a sincronização</translation>
+<translation id="3568688522516854065">Para ver as guias dos seus outros dispositivos, faça login e ative a sincronização</translation>
+<translation id="1208340532756947324">Para sincronizar e personalizar vários dispositivos, ative a sincronização</translation>
+<translation id="4472118726404937099">Para sincronizar e personalizar vários dispositivos, faça login e ative a sincronização</translation>
+<translation id="2426805022920575512">Escolher outra conta</translation>
+<translation id="6790428901817661496">Reproduzir</translation>
+<translation id="1272079795634619415">Parar</translation>
+<translation id="2874939134665556319">Faixa anterior</translation>
+<translation id="4046123991198612571">Próxima faixa</translation>
+<translation id="3859306556332390985">Avançar</translation>
+<translation id="8441146129660941386">Retroceder</translation>
+<translation id="6706288973712894588">Não há conexão no momento.\n<ph name="BEGIN_LINK"/>Navegue no seu feed off-line.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Guias recentes</translation>
+<translation id="8497726226069778601">Não há nada para ver aqui... ainda</translation>
+<translation id="5423934151118863508">Suas páginas mais visitadas aparecerão aqui</translation>
+<translation id="6127379762771434464">Item removido</translation>
+<translation id="4605958867780575332">Item removido: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle do Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Outros dispositivos</translation>
+<translation id="4738836084190194332">Última sincronização: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# minuto atrás}one{# minutos atrás}other{# minutos atrás}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# hora atrás}one{# horas atrás}other{# horas atrás}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# dia atrás}one{# dias atrás}other{# dias atrás}}</translation>
+<translation id="2762000892062317888">agora mesmo</translation>
+<translation id="1407135791313364759">Abrir todas</translation>
+<translation id="1209206284964581585">Ocultar por enquanto</translation>
+<translation id="129553762522093515">Recentemente fechadas</translation>
+<translation id="8413126021676339697">Mostrar histórico completo</translation>
+<translation id="7876243839304621966">Remover tudo</translation>
+<translation id="8487700953926739672">Disponível off-line</translation>
+<translation id="5224771365102442243">Com vídeo</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Saiba mais<ph name="END_LINK"/> sobre o conteúdo sugerido</translation>
+<translation id="7542481630195938534">Não é possível exibir as sugestões</translation>
+<translation id="5013696553129441713">Nenhuma nova sugestão</translation>
+<translation id="1736419249208073774">Explorar</translation>
+<translation id="7444811645081526538">Mais categorias</translation>
+<translation id="6709133671862442373">Notícias</translation>
+<translation id="1264974993859112054">Esportes</translation>
+<translation id="9139318394846604261">Compras</translation>
+<translation id="3912508018559818924">Procurando o melhor da Web…</translation>
+<translation id="526421993248218238">Não foi possível carregar a página</translation>
+<translation id="614940544461990577">Tente:</translation>
+<translation id="3288003805934695103">Atualizar a página</translation>
+<translation id="2353636109065292463">Verificando sua conexão de Internet</translation>
+<translation id="2858138569776157458">Sites famosos</translation>
+<translation id="8364299278605033898">Ver sites conhecidos</translation>
+<translation id="1171770572613082465">Toque no botão "Sites famosos" para ver os sites muito acessados</translation>
+<translation id="5233638681132016545">Nova guia</translation>
+<translation id="4521874409998847950">De <ph name="PUBLISHER_ORIGIN"/>: <ph name="BEGIN_DEEMPHASIZED"/>veiculado pelo Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Versão mais recente disponível</translation>
+<translation id="4058091506841967397">Erro ao atualizar Brave</translation>
+<translation id="6316139424528454185">Versão Android não compatível</translation>
+<translation id="6989267951144302301">Falha no download</translation>
+<translation id="624789221780392884">Atualização pronta</translation>
+<translation id="1549000191223877751">Mover para outra janela</translation>
+<translation id="7481312909269577407">Avançar</translation>
+<translation id="4084682180776658562">Favorito</translation>
+<translation id="6437478888915024427">Informações sobre a página</translation>
+<translation id="7180611975245234373">Atualizar</translation>
+<translation id="4913169188695071480">Parar de atualizar</translation>
+<translation id="1829244130665387512">Encontrar na página</translation>
+<translation id="6593061639179217415">Versão para computador</translation>
+<translation id="9063523880881406963">Desativar "Ver versão para computador"</translation>
+<translation id="2038563949887743358">Ativar "Ver versão para computador"</translation>
+<translation id="2433507940547922241">Aparência</translation>
+<translation id="983192555821071799">Fechar todas as guias</translation>
+<translation id="1310482092992808703">Agrupar guias</translation>
+<translation id="7725024127233776428">As páginas favoritadas são exibidas aqui</translation>
+<translation id="4404568932422911380">Nenhum favorito</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> favorito}one{<ph name="BOOKMARKS_COUNT_MANY"/> favorito}other{<ph name="BOOKMARKS_COUNT_MANY"/> favoritos}}</translation>
+<translation id="3739899004075612870">Adicionado aos favoritos no <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Adicionado aos favoritos</translation>
+<translation id="4452548195519783679">Adicionado como favorito em <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Falha ao adicionar favorito.</translation>
+<translation id="2842985007712546952">Pasta mãe</translation>
+<translation id="9065203028668620118">Editar</translation>
+<translation id="4405224443901389797">Mover para…</translation>
+<translation id="5170568018924773124">Mostrar na pasta</translation>
+<translation id="8035133914807600019">Nova pasta...</translation>
+<translation id="4532845899244822526">Escolher pasta</translation>
+<translation id="6627583120233659107">Editar pasta</translation>
+<translation id="1197267115302279827">Mover favoritos</translation>
+<translation id="6963766334940102469">Excluir favoritos</translation>
+<translation id="4351244548802238354">Fechar caixa de diálogo</translation>
+<translation id="451872707440238414">Pesquisar favoritos</translation>
+<translation id="8901170036886848654">Nenhum favorito encontrado</translation>
+<translation id="6404511346730675251">Editar favorito</translation>
+<translation id="3894427358181296146">Adicionar pasta</translation>
+<translation id="5327248766486351172">Nome</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Pasta</translation>
+<translation id="5161254044473106830">O título é obrigatório</translation>
+<translation id="2996809686854298943">O URL é obrigatório</translation>
+<translation id="2536728043171574184">Vendo uma cópia off-line desta página</translation>
+<translation id="4698034686595694889">Ver off-line no app <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> e outros sites</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{O Brave carregará sua página quando ela estiver pronta}one{O Brave carregará sua página quando ela estiver pronta}other{O Brave carregará suas páginas quando elas estiverem prontas}}</translation>
+<translation id="6811034713472274749">A página já pode ser visualizada</translation>
+<translation id="4561979708150884304">Sem conexão</translation>
+<translation id="8274165955039650276">Ver downloads</translation>
+<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER"/> de <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Nenhum resultado</translation>
+<translation id="981121421437150478">Off-line</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Nenhuma pesq. por voz ativada disponível</translation>
+<translation id="7191430249889272776">Guia aberta no plano de fundo.</translation>
+<translation id="8445059357334030806">Abrir no Brave Software Brave</translation>
+<translation id="4720023427747327413">Abrir no <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Abrir no navegador</translation>
+<translation id="1113597929977215864">Mostrar a versão simplificada</translation>
+<translation id="1513352483775369820">Favoritos e histórico da Web</translation>
+<translation id="4939482511480190003">Ajude a melhorar o Brave. <ph name="BEGIN_LINK"/>Responda à pesquisa.<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Voltar</translation>
+<translation id="5596627076506792578">Mais opções</translation>
+<translation id="3522247891732774234">Atualização disponível. Mais opções</translation>
+<translation id="6773423637732432200">Não é possível atualizar o Brave. Mais opções</translation>
+<translation id="3328801116991980348">Informações do site</translation>
+<translation id="5391532827096253100">Sua conexão com este site não é segura. Informações do site</translation>
+<translation id="6206551242102657620">A conexão é segura. Informações do site</translation>
+<translation id="6963642900430330478">Esta página é perigosa. Informações do site</translation>
+<translation id="9070377983101773829">Iniciar pesquisa por voz</translation>
+<translation id="8676374126336081632">Limpar entrada</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> guia aberta, toque para alternar}one{<ph name="OPEN_TABS_MANY"/> guia aberta, toque para alternar}other{<ph name="OPEN_TABS_MANY"/> guias abertas, toque para alternar}}</translation>
+<translation id="2369533728426058518">abrir guias</translation>
+<translation id="7071521146534760487">Gerenciar conta</translation>
+<translation id="932327136139879170">Início</translation>
+<translation id="2707726405694321444">Atualizar página</translation>
+<translation id="2891154217021530873">Para de carregar a página</translation>
+<translation id="6710213216561001401">Anterior</translation>
+<translation id="6659594942844771486">Guia</translation>
+<translation id="1933845786846280168">Guia selecionada</translation>
+<translation id="2268044343513325586">Refinar</translation>
+<translation id="7846076177841592234">Cancelar seleção</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> itens selecionados. Opções disponíveis perto da parte superior da tela</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> itens selecionados</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Compartilhar 1 item selecionado}one{Compartilhar # item selecionado}other{Compartilhar # itens selecionados}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Remover 1 item selecionado}one{Remover # item selecionado}other{Remover # itens selecionados}}</translation>
+<translation id="1283039547216852943">Toque para expandir</translation>
+<translation id="5962718611393537961">Toque para recolher</translation>
+<translation id="8076492880354921740">Guias</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selecionado}one{# selecionado}other{# selecionados}}</translation>
+<translation id="6818926723028410516">Selecionar itens</translation>
+<translation id="4797039098279997504">Toque para voltar a <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Toque acessar o site</translation>
+<translation id="429312253194641664">Um site está com mídia aberta</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> está compartilhando sua tela</translation>
+<translation id="8833831881926404480">Um site está compartilhando sua tela</translation>
+<translation id="9086455579313502267">Não foi possível acessar a rede</translation>
+<translation id="938850635132480979">Erro: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Abrir no <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Abrir no app de mapa</translation>
+<translation id="7698359219371678927">Criar e-mail no <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Criar e-mail</translation>
+<translation id="5665379678064389456">Criar evento no <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Criar evento</translation>
+<translation id="2111511281910874386">Ir para a página</translation>
+<translation id="3988466920954086464">Veja neste painel resultados da pesquisa instantâneos</translation>
+<translation id="2744248271121720757">Toque em uma palavra para pesquisar instantaneamente ou ver as ações relacionadas</translation>
+<translation id="9155898266292537608">Você também pode pesquisar com um toque rápido em uma palavra</translation>
+<translation id="3232754137068452469">App da Web</translation>
+<translation id="1430915738399379752">Imprimir</translation>
+<translation id="3775705724665058594">Enviar para seus dispositivos</translation>
+<translation id="6364438453358674297">Remover sugestão do histórico?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> fechada</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> guias fechadas</translation>
+<translation id="3211426585530211793">Item excluído: <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> favoritos excluídos</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> downloads excluídos</translation>
+<translation id="1248710015876067820">Número de instâncias do Brave Software Brave não suportado.</translation>
+<translation id="4259722352634471385">A Navegação GPS está bloqueada: <ph name="URL"/></translation>
+<translation id="8959122750345127698">A Navegação GPS está inacessível: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Fechar guia</translation>
+<translation id="7772375229873196092">Fechar <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Histórico de navegação</translation>
+<translation id="9169507124922466868">Histórico de navegação parcialmente aberto</translation>
+<translation id="1327257854815634930">O histórico de navegação está aberto</translation>
+<translation id="8788265440806329501">O histórico de navegação está fechado</translation>
+<translation id="7482656565088326534">Guia "Visualizar"</translation>
+<translation id="8427875596167638501">A guia "Visualizar" está parcialmente aberta</translation>
+<translation id="9102803872260866941">A guia "Visualizar" está aberta</translation>
+<translation id="2942036813789421260">A guia "Visualizar" está fechada</translation>
+<translation id="6355102470683871794">Armazenamento do Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Limpar armazenamento de sites?</translation>
+<translation id="9205995714227143200">Dados de armazenamento de site que o Brave não acredita serem importantes (por exemplo, sites sem configurações salvas ou que você não visita com frequência)</translation>
+<translation id="3997476611815694295">Armazenamento sem importância</translation>
+<translation id="8493948351860045254">Liberar espaço</translation>
+<translation id="2324920234469020158">Essa ação limpará os cookies, cache e outros dados de sites que o Brave não acredita serem importantes.</translation>
+<translation id="5447201525962359567">Todos os dados de armazenamento de sites, incluindo cookies e outros dados armazenados localmente</translation>
+<translation id="1376578503827013741">Calculando…</translation>
+<translation id="583281660410589416">Desconhecido</translation>
+<translation id="2323763861024343754">Armazenamento do site</translation>
+<translation id="3587672679800759167">Total de dados utilizados pelo Brave, incluindo contas, favoritos e configurações salvas</translation>
+<translation id="6545017243486555795">Limpar todos os dados</translation>
+<translation id="4095146165863963773">Excluir dados de apps?</translation>
+<translation id="53119194224775367">Todos os dados de app Brave serão excluídos permanentemente. Isso inclui todos os arquivos, configurações, contas, bancos de dados etc.</translation>
+<translation id="5307446750509046227">Limpar armazen. de site</translation>
+<translation id="300526633675317032">Essa ação limpará tudo, <ph name="SIZE_IN_KB"/> de dados de armazenamento de sites.</translation>
+<translation id="8068648041423924542">Não foi possível selecionar certificado.</translation>
+<translation id="2315043854645842844">A seleção de certificado do cliente não é compatível com o sistema operacional.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> deseja se conectar</translation>
+<translation id="5308380583665731573">Conectar</translation>
+<translation id="868929229000858085">Pesquisar seus contatos</translation>
+<translation id="1919950603503897840">Selecionar contatos</translation>
+<translation id="7986741934819883144">Selecione um contato</translation>
+<translation id="3333961966071413176">Todos os contatos</translation>
+<translation id="4994033804516042629">Nenhum contato encontrado</translation>
+<translation id="5403592356182871684">Nomes</translation>
+<translation id="2717722538473713889">Endereços de e-mail</translation>
+<translation id="381841723434055211">Números de telefone</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(mais 1)}one{(mais #)}other{(mais #)}}</translation>
+<translation id="5197729504361054390">Os contatos selecionados serão compartilhados com <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Decodificador de imagem</translation>
+<translation id="8067883171444229417">Assistir vídeo</translation>
+<translation id="6560414384669816528">Pesquisar usando o Sogou</translation>
+<translation id="5406914950576900927">O Brave pode usar o <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> para fazer pesquisas na China. É possível alterar essa opção nas <ph name="BEGIN_LINK"/>Configurações<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Continuar usando o Brave Software</translation>
+<translation id="4384468725000734951">Usando o Sogou para pesquisar</translation>
+<translation id="6103327872225198548">Usando o Brave Software para pesquisar</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Este app está sendo executado no Brave</translation>
+<translation id="6143689084714664628">Executando no Brave</translation>
+<translation id="7675869148432102528">O app <ph name="APP_NAME"/> também tem dados no Brave</translation>
+<translation id="2734140769649165081">É possível limpar os dados nas configurações do Brave</translation>
+<translation id="8232956427053453090">Manter dados</translation>
+<translation id="4298388696830689168">Sites vinculados</translation>
+<translation id="5763514718066511291">Toque para copiar o URL desse app</translation>
+<translation id="6496823230996795692">Para usar o app <ph name="APP_NAME"/> pela primeira vez, conecte-se à Internet</translation>
+<translation id="751961395872307827">Não foi possível se conectar ao site</translation>
+<translation id="4878404682131129617">Falha ao estabelecer encapsulamento via servidor proxy</translation>
+<translation id="4749960740855309258">Abrir uma nova guia</translation>
+<translation id="8788968922598763114">Reabrir a última guia fechada</translation>
+<translation id="7929962904089429003">Abrir o menu</translation>
+<translation id="6039379616847168523">Ir para a próxima guia</translation>
+<translation id="5210286577605176222">Ir para a guia anterior</translation>
+<translation id="124678866338384709">Fechar a guia atual</translation>
+<translation id="3714981814255182093">Abrir a barra Localizar</translation>
+<translation id="5441522332038954058">Ir para a barra de endereço</translation>
+<translation id="3398320232533725830">Abrir o gerenciador de favoritos</translation>
+<translation id="6583199322650523874">Adicionar a página atual aos favoritos</translation>
+<translation id="8489271220582375723">Abrir Histórico</translation>
+<translation id="4837753911714442426">Abrir opções de impressão de página</translation>
+<translation id="5726692708398506830">Aumentar tudo na página</translation>
+<translation id="3259831549858767975">Diminuir tudo na página.</translation>
+<translation id="8015452622527143194">Retornar tudo na página para o tamanho padrão</translation>
+<translation id="3443221991560634068">Atualizar a página atual</translation>
+<translation id="123724288017357924">Atualizar página atual e ignorar conteúdo em cache</translation>
+<translation id="305870044889644984">Abrir Central de Ajuda do Brave em uma nova guia</translation>
+<translation id="3166827708714933426">Atalhos de guias e janelas</translation>
+<translation id="3169981355900570544">Atalhos de recursos do Brave Software Brave</translation>
+<translation id="4558311620361989323">Atalhos de páginas da Web</translation>
+<translation id="1908301351964700579">O Brave ainda está se preparando para a RV. Reinicie-o mais tarde.</translation>
+<translation id="8970887620466824814">Algo deu errado.</translation>
+<translation id="1875543012935658554">Reabra o Brave.</translation>
+<translation id="79859296434321399">Para ver conteúdo de realidade aumentada, instale o ARCore</translation>
+<translation id="8558485628462305855">Para ver conteúdo de realidade aumentada, atualize o ARCore</translation>
+<translation id="3513704683820682405">Realidade aumentada</translation>
+<translation id="5475862044948910901">Iniciar sessão de realidade aumentada?</translation>
 <translation id="7365126855094612066">No decorrer desta sessão, o site poderá:
 • criar um mapa 3D do seu ambiente;
 • rastrear o movimento da câmera.
 
 O site NÃO terá acesso à câmera. As imagens da câmera são visíveis apenas para você.</translation>
-<translation id="7375125077091615385">Tipo:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Tela de apresentação do Chrome</translation>
-<translation id="741204030948306876">Sim</translation>
-<translation id="7413229368719586778">Data de início: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Perguntar primeiro</translation>
-<translation id="7423538860840206698">Leitura da área de transferência bloqueada</translation>
-<translation id="7431991332293347422">Controlar como o histórico de navegação é usado para personalizar a Pesquisa e muito mais</translation>
-<translation id="7437998757836447326">Sair do Google Chrome</translation>
-<translation id="7438641746574390233">Quando o Modo Lite está ativado, o Chrome usa os servidores do Google para carregar páginas mais rapidamente. O Modo Lite reescreve páginas muito lentas de forma a carregar apenas o conteúdo essencial. O Modo Lite não se aplica a guias anônimas.</translation>
-<translation id="7444811645081526538">Mais categorias</translation>
-<translation id="7445411102860286510">Permite que os sites mostrem vídeos sem som automaticamente (recomendado)</translation>
-<translation id="7453467225369441013">Desconecta você da maioria dos sites, mas não da sua Conta do Google.</translation>
-<translation id="7454641608352164238">Espaço insuficiente</translation>
-<translation id="7475192538862203634">Se estiver vendo isso com frequência, tente estas <ph name="BEGIN_LINK" />sugestões<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Cartão SD não encontrado. Alguns arquivos podem estar faltando.</translation>
-<translation id="7479104141328977413">Gerenciamento de guias</translation>
-<translation id="7481312909269577407">Avançar</translation>
-<translation id="7482656565088326534">Guia "Visualizar"</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (atualizada <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">de dados economizados</translation>
-<translation id="7498271377022651285">Aguarde...</translation>
-<translation id="7514365320538308">Fazer o download</translation>
-<translation id="751961395872307827">Não foi possível se conectar ao site</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Não é possível exibir as sugestões</translation>
-<translation id="7559975015014302720">Modo Lite desativado</translation>
-<translation id="7562080006725997899">Limpando dados de navegação</translation>
-<translation id="756809126120519699">Dados do Chrome apagados</translation>
-<translation id="757524316907819857">Impedir que sites reproduzam conteúdos protegidos</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> arquivo transferido por download}one{<ph name="FILES_DOWNLOADED_MANY" /> arquivo transferido por download}other{<ph name="FILES_DOWNLOADED_MANY" /> arquivos transferidos por download}}</translation>
-<translation id="7588219262685291874">Ativar o tema escuro quando a Economia de bateria do seu dispositivo estiver ativada</translation>
-<translation id="7589445247086920869">Bloquear o mecanismo de pesquisa atual</translation>
-<translation id="7593557518625677601">Abrir configs. Android e reativar sincronização do Android p/ sincronizar Chrome</translation>
-<translation id="7596558890252710462">Sistema operacional</translation>
-<translation id="7605594153474022051">A sincronização não está funcionando</translation>
-<translation id="7606077192958116810">Modo Lite ativado. Gerencie-o nas configurações.</translation>
-<translation id="7612619742409846846">Conectado ao Google como</translation>
-<translation id="7619072057915878432">Falha no download do arquivo <ph name="FILE_NAME" /> devido a falhas na rede.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Receber ajuda<ph name="END_LINK1" /> ou <ph name="BEGIN_LINK2" />verificar novamente<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Bem-vindo ao Google Chrome</translation>
-<translation id="7638584964844754484">Senha incorreta</translation>
-<translation id="7641339528570811325">Limpar dados de navegação…</translation>
-<translation id="7648422057306047504">Usar as credenciais do Google para criptografar e proteger minhas senhas</translation>
-<translation id="7649070708921625228">Ajuda</translation>
-<translation id="7658239707568436148">Cancelar</translation>
-<translation id="7665369617277396874">Adicionar conta</translation>
-<translation id="766587987807204883">Os artigos são exibidos aqui e podem ser lidos até quando você está off-line</translation>
-<translation id="7682724950699840886">Experimente as seguintes dicas: verifique se há espaço suficiente no dispositivo e tente exportar novamente.</translation>
-<translation id="7685301384041462804">Verifique se você confia neste site antes de entrar na RV.</translation>
-<translation id="7698359219371678927">Criar e-mail no <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Preencher automaticamente pesquisas e URLs</translation>
-<translation id="7725024127233776428">As páginas favoritadas são exibidas aqui</translation>
-<translation id="773466115871691567">Sempre traduzir páginas em <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Para detectar apps e sites perigosos, o Chrome envia para o Google URLs de algumas páginas visitadas, informações limitadas do sistema e um pouco do conteúdo da página</translation>
-<translation id="7757787379047923882">Texto compartilhado por <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Cartão SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Adicionar endereço</translation>
-<translation id="7772032839648071052">Confirmar senha</translation>
-<translation id="7772375229873196092">Fechar <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Ontem</translation>
-<translation id="7791543448312431591">Adicionar</translation>
-<translation id="780301667611848630">Não</translation>
-<translation id="7810647596859435254">Abrir com…</translation>
-<translation id="7821588508402923572">Sua economia de dados será exibida aqui</translation>
-<translation id="7837721118676387834">Permite que um determinado site mostre vídeos sem som automaticamente.</translation>
-<translation id="7846076177841592234">Cancelar seleção</translation>
-<translation id="784934925303690534">Período</translation>
-<translation id="7851858861565204677">Outros dispositivos</translation>
-<translation id="7875915731392087153">Criar e-mail</translation>
-<translation id="7876243839304621966">Remover tudo</translation>
-<translation id="7882131421121961860">Nenhum histórico encontrado</translation>
-<translation id="7882806643839505685">Permitir o som de um site específico.</translation>
-<translation id="7886917304091689118">Executando no Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Fazendo o download do arquivo.}one{Fazendo o download de # arquivo.}other{Fazendo o download de # arquivos.}}</translation>
-<translation id="7929962904089429003">Abrir o menu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> está desatualizado.</translation>
-<translation id="7947953824732555851">Aceitar/fazer login</translation>
-<translation id="7963646190083259054">Fornecedor:</translation>
-<translation id="7971136598759319605">Ativado há um dia</translation>
-<translation id="7975379999046275268">Visualizar página <ph name="BEGIN_NEW" />Novidade<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Pré-carregar páginas para possibilitar navegação e pesquisa mais rápidas</translation>
-<translation id="79859296434321399">Para ver conteúdo de realidade aumentada, instale o ARCore</translation>
-<translation id="7986741934819883144">Selecione um contato</translation>
-<translation id="7987073022710626672">Termos de Serviço do Chrome</translation>
-<translation id="7998918019931843664">Reabrir guia fechada</translation>
-<translation id="7999064672810608036">Tem certeza que quer apagar todos os dados locais, inclusive os cookies, e redefinir todas as permissões para este website?</translation>
-<translation id="8004582292198964060">Navegador</translation>
-<translation id="8007176423574883786">Desativado neste dispositivo</translation>
-<translation id="8013372441983637696">Limpar também seus dados do Chrome deste dispositivo</translation>
-<translation id="8015452622527143194">Retornar tudo na página para o tamanho padrão</translation>
-<translation id="802154636333426148">Falha no download</translation>
-<translation id="8026334261755873520">Limpar dados de navegação</translation>
-<translation id="8035133914807600019">Nova pasta...</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> dias restantes</translation>
-<translation id="804335162455518893">Cartão SD não encontrado</translation>
-<translation id="805047784848435650">Com base no seu histórico de navegação</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB disponíveis</translation>
-<translation id="8058746566562539958">Abrir em nova guia do Chrome</translation>
-<translation id="8063895661287329888">Falha ao adicionar favorito.</translation>
-<translation id="806745655614357130">Manter meus dados separados</translation>
-<translation id="8067883171444229417">Assistir vídeo</translation>
-<translation id="8068648041423924542">Não foi possível selecionar certificado.</translation>
-<translation id="8073388330009372546">Abrir imagem em nova guia</translation>
-<translation id="8076492880354921740">Guias</translation>
-<translation id="8084114998886531721">Senha salva</translation>
-<translation id="8087000398470557479">Este conteúdo é de <ph name="DOMAIN_NAME" />, veiculado pelo Google.</translation>
-<translation id="8103578431304235997">Guia anônima</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Para ter seus favoritos em todos os seus dispositivos, ative a sincronização</translation>
-<translation id="8110087112193408731">Mostrar sua atividade do Chrome no Bem-estar digital?</translation>
-<translation id="8116925261070264013">Com som desativado</translation>
-<translation id="813082847718468539">Visualizar informações do site</translation>
-<translation id="8131740175452115882">Confirmar</translation>
-<translation id="8156139159503939589">Quais idiomas você lê?</translation>
-<translation id="8168435359814927499">Conteúdo</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> arquivos restantes</translation>
-<translation id="8190358571722158785">Um dia restante</translation>
-<translation id="8200772114523450471">Retomar</translation>
-<translation id="8209050860603202033">Abrir imagem</translation>
-<translation id="8218622182176210845">Gerenciar sua conta</translation>
-<translation id="8224471946457685718">Fazer o download de "Artigos para você" quando houver conexão Wi-Fi</translation>
-<translation id="8232956427053453090">Manter dados</translation>
-<translation id="8249310407154411074">Mover para o início</translation>
-<translation id="8250920743982581267">Documentos</translation>
-<translation id="825412236959742607">Como esta página usa muita memória, o Chrome removeu parte do conteúdo.</translation>
-<translation id="8260126382462817229">Tente fazer login novamente</translation>
-<translation id="8261506727792406068">Excluir</translation>
-<translation id="8266862848225348053">Local de download</translation>
-<translation id="8274165955039650276">Ver downloads</translation>
-<translation id="8284326494547611709">Legendas</translation>
-<translation id="8300705686683892304">Gerenciados por app</translation>
-<translation id="8310344678080805313">Guias padrão</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> e outros sites</translation>
-<translation id="8327155640814342956">Para ter a melhor experiência de navegação, abra para atualizar o Chrome</translation>
-<translation id="8339163506404995330">Páginas em <ph name="LANGUAGE" /> não serão traduzidas</translation>
-<translation id="8349013245300336738">Classificar por quantidade de dados usados</translation>
-<translation id="8364299278605033898">Ver sites conhecidos</translation>
-<translation id="8368027906805972958">Dispositivo desconhecido ou incompatível (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Permite a sincronização em segundo plano para um site específico.</translation>
-<translation id="8378714024927312812">Gerenciado pela sua organização</translation>
-<translation id="8380167699614421159">Neste site, há exibição de anúncios invasivos ou enganosos</translation>
-<translation id="8393700583063109961">Enviar mensagem</translation>
-<translation id="8413126021676339697">Mostrar histórico completo</translation>
-<translation id="8427875596167638501">A guia "Visualizar" está parcialmente aberta</translation>
-<translation id="8428213095426709021">Configurações</translation>
-<translation id="8438566539970814960">Melhorar as pesquisas e a navegação</translation>
-<translation id="8441146129660941386">Retroceder</translation>
-<translation id="8443209985646068659">Erro ao atualizar Chrome</translation>
-<translation id="8445448999790540984">Não é possível exportar senhas</translation>
-<translation id="8447861592752582886">Revogar permissão do dispositivo</translation>
-<translation id="8461694314515752532">Criptografar dados sincronizados com sua senha de sincronização</translation>
-<translation id="8466613982764129868">Verifique se o <ph name="TARGET_DEVICE_NAME" /> está conectado à Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponível off-line</translation>
-<translation id="8489271220582375723">Abrir Histórico</translation>
-<translation id="8493948351860045254">Liberar espaço</translation>
-<translation id="8497726226069778601">Não há nada para ver aqui... ainda</translation>
-<translation id="8503559462189395349">Senhas do Chrome</translation>
-<translation id="8503813439785031346">Nome de usuário</translation>
-<translation id="8514477925623180633">Exportar senhas armazenadas com o Chrome</translation>
-<translation id="8514577642972634246">Entrar no modo de navegação anônima</translation>
-<translation id="851751545965956758">Impedir a conexão de sites a dispositivos</translation>
-<translation id="8523928698583292556">Excluir senha armazenada</translation>
-<translation id="854522910157234410">Abrir esta página</translation>
-<translation id="8558485628462305855">Para ver conteúdo de realidade aumentada, atualize o ARCore</translation>
-<translation id="8559990750235505898">Oferecer para traduzir páginas em outros idiomas</translation>
-<translation id="8562452229998620586">As senhas salvas aparecerão aqui.</translation>
-<translation id="8569404424186215731">desde <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Últimas quatro semanas</translation>
-<translation id="857943718398505171">Permitido (recomendado)</translation>
-<translation id="8583805026567836021">Limpando os dados da conta</translation>
-<translation id="860043288473659153">Nome do titular do cartão</translation>
-<translation id="8609465669617005112">Mover para cima</translation>
-<translation id="8616006591992756292">Sua Conta do Google pode ter outras formas de histórico de navegação em <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Abrir o URL sugerido especificado no conteúdo transferido por download?</translation>
-<translation id="8636825310635137004">Para ver suas guias abertas em outros dispositivos, ative a sincronização.</translation>
-<translation id="8641930654639604085">Tentar bloquear sites com conteúdo para adultos</translation>
-<translation id="8655129584991699539">É possível limpar os dados nas configurações do Chrome</translation>
-<translation id="8662811608048051533">Desconecta você da maioria dos sites.</translation>
-<translation id="8664979001105139458">O nome do arquivo já existe</translation>
-<translation id="8676374126336081632">Limpar entrada</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Nível de intensidade do sinal: de # barra}one{Nível de intensidade do sinal: de # barra}other{Nível de intensidade do sinal: de # barras}}</translation>
-<translation id="868929229000858085">Pesquisar seus contatos</translation>
-<translation id="869891660844655955">Validade</translation>
-<translation id="8719023831149562936">Não é possível enviar a guia atual</translation>
-<translation id="8725066075913043281">Tentar novamente</translation>
-<translation id="8728487861892616501">Ao usar este aplicativo, você concorda com os <ph name="BEGIN_LINK1" />Termos de Serviço<ph name="END_LINK1" /> e o <ph name="BEGIN_LINK2" />Aviso de Privacidade<ph name="END_LINK2" /> do Chrome, bem como o <ph name="BEGIN_LINK3" />Aviso de Privacidade de Contas do Google gerenciadas com o Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Concluído</translation>
-<translation id="8748850008226585750">Conteúdo oculto</translation>
-<translation id="8751914237388039244">Selecione uma imagem</translation>
-<translation id="8788265440806329501">O histórico de navegação está fechado</translation>
-<translation id="8788968922598763114">Reabrir a última guia fechada</translation>
-<translation id="8801436777607969138">Bloquear JavaScript para um site específico.</translation>
-<translation id="8812260976093120287">Em alguns websites, é possível pagar no seu dispositivo com os apps de pagamento compatíveis acima.</translation>
-<translation id="8816026460808729765">Impedir que sites acessem os sensores</translation>
-<translation id="8816439037877937734">O app <ph name="APP_NAME" /> será aberto no Chrome. Ao continuar, você concorda com os <ph name="BEGIN_LINK1" />Termos de Serviço<ph name="END_LINK1" /> e o <ph name="BEGIN_LINK2" />Aviso de Privacidade do Chrome<ph name="END_LINK2" />, assim como o <ph name="BEGIN_LINK3" />Aviso de Privacidade de Contas do Google gerenciadas com o Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Favoritos</translation>
-<translation id="8833831881926404480">Um site está compartilhando sua tela</translation>
-<translation id="883806473910249246">Ocorreu um erro durante o download do conteúdo.</translation>
-<translation id="8840953339110955557">Esta página pode ser diferente da versão on-line.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, guia</translation>
-<translation id="885701979325669005">Armazenamento</translation>
-<translation id="889338405075704026">Acesse as configurações do Chrome</translation>
-<translation id="8901170036886848654">Nenhum favorito encontrado</translation>
-<translation id="8909135823018751308">Compartilhar...</translation>
-<translation id="8912362522468806198">Conta do Google</translation>
-<translation id="8920114477895755567">Aguardando detalhes dos pais.</translation>
+<translation id="1188239144602654184">Entrar na RA</translation>
+<translation id="473775607612524610">Atualizar</translation>
+<translation id="3133489217401741157">Instalando <ph name="MODULE"/> para o Brave…</translation>
+<translation id="1791662854739702043">Instalado</translation>
+<translation id="5131234170665854056">Não é possível instalar <ph name="MODULE"/> para o Brave</translation>
+<translation id="2567385386134582609">IMAGEM</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VÍDEO</translation>
+<translation id="4116038641877404294">Faça o download de páginas e acesse off-line</translation>
 <translation id="8922289737868596582">Use o botão Mais opções para fazer o download de páginas e acessá-las off-line</translation>
-<translation id="8937772741022875483">Remover sua atividade do Chrome do Bem-estar digital?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Abrir em outra janela</translation>
-<translation id="8951232171465285730">O Chrome economizou <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Bloqueie cookies de um site específico.</translation>
-<translation id="8959122750345127698">A Navegação GPS está inacessível: <ph name="URL" /></translation>
-<translation id="8965591936373831584">pendente</translation>
-<translation id="8970887620466824814">Algo deu errado.</translation>
-<translation id="8972098258593396643">Fazer o download para a pasta padrão?</translation>
-<translation id="8986494364107987395">Envia estatísticas de uso e relatórios de erros ao Google automaticamente</translation>
-<translation id="8993760627012879038">Abrir uma nova guia no modo de navegação anônima</translation>
-<translation id="8998729206196772491">Você está fazendo login com uma conta gerenciada por <ph name="MANAGED_DOMAIN" /> e dando ao administrador dela o controle sobre seus dados do Chrome, os quais ficarão permanentemente vinculados a essa conta. Se você sair do Chrome, seus dados serão excluídos desse dispositivo, mas permanecerão armazenados na sua Conta do Google.</translation>
-<translation id="9019902583201351841">Gerenciado pelos seus pais</translation>
-<translation id="9028914725102941583">Ative a sincronização para compartilhar entre dispositivos</translation>
-<translation id="9029323097866369874">Permitir que <ph name="DOMAIN" /> entre na RV?</translation>
-<translation id="9040142327097499898">As notificações são permitidas. A localização está desativada neste dispositivo.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}one{# vídeo}other{# vídeos}}</translation>
-<translation id="9050666287014529139">Senha</translation>
-<translation id="9063523880881406963">Desativar "Ver versão para computador"</translation>
-<translation id="9065203028668620118">Editar</translation>
-<translation id="9070377983101773829">Iniciar pesquisa por voz</translation>
-<translation id="9074336505530349563">Para receber conteúdo personalizado sugerido pelo Google, ative a sincronização</translation>
-<translation id="9086455579313502267">Não foi possível acessar a rede</translation>
-<translation id="9100505651305367705">Oferecer para mostrar artigos em uma versão simplificada, quando compatível.</translation>
-<translation id="9100610230175265781">Senha necessária</translation>
-<translation id="9102803872260866941">A guia "Visualizar" está aberta</translation>
+<translation id="5958275228015807058">Encontre seus arquivos e páginas em Downloads</translation>
+<translation id="5620928963363755975">Procure seus arquivos e páginas em Downloads, usando o botão Mais opções</translation>
+<translation id="3341058695485821946">Veja o volume de dados que você economizou</translation>
+<translation id="3157842584138209013">Veja o volume de dados que você economizou no botão Mais opções</translation>
+<translation id="8218622182176210845">Gerenciar sua conta</translation>
+<translation id="8090895580117672212">Para gerenciar sua Conta do Brave Software, toque no botão "Gerenciar conta".</translation>
+<translation id="8856898588039823173">Página Lite exibida pelo Brave Software. Toque para carregar a original.</translation>
+<translation id="8134317863207426198">Página Lite exibida pelo Brave Software. Toque no botão "Carregar original" para carregar a página original.</translation>
+<translation id="4961107849584082341">Traduza esta página para qualquer idioma</translation>
+<translation id="569536719314091526">Traduza esta página para qualquer idioma com o botão "Mais opções"</translation>
+<translation id="1397811292916898096">Pesquisar com o <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Altere o local padrão de download a qualquer momento</translation>
+<translation id="6942665639005891494">Altere o local padrão de download a qualquer momento usando a opção do menu "Configurações"</translation>
+<translation id="6850409657436465440">Seu download ainda está em andamento</translation>
+<translation id="5817715962196959877">Agora o Brave faz o download de arquivos mais rapidamente</translation>
+<translation id="3976396876660209797">Remova e recrie este atalho</translation>
+<translation id="6766622839693428701">Deslize para baixo para fechar.</translation>
+<translation id="1028699632127661925">Enviando para este dispositivo: <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/>: enviado de <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Guia recebida</translation>
 <translation id="9104217018994036254">Lista de dispositivos com os quais é possível compartilhar uma guia.</translation>
-<translation id="9133397713400217035">Navegar off-line</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Mostrar original</translation>
-<translation id="9139068048179869749">Perguntar antes de permitir que sites enviem notificações (recomendado)</translation>
-<translation id="9139318394846604261">Compras</translation>
-<translation id="9155898266292537608">Você também pode pesquisar com um toque rápido em uma palavra</translation>
-<translation id="9169507124922466868">Histórico de navegação parcialmente aberto</translation>
-<translation id="9204836675896933765">1 arquivo restante</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Lista de dispositivos com os quais é possível compartilhar uma guia aberta na metade da altura.</translation>
+<translation id="2904414404539560095">Lista de dispositivos com os quais é possível compartilhar uma guia aberta no tamanho máximo.</translation>
+<translation id="4135200667068010335">A lista de dispositivos com os quais é possível compartilhar uma guia está fechada.</translation>
+<translation id="5292796745632149097">Enviar para</translation>
+<translation id="1386674309198842382">Ativado há <ph name="LAST_UPDATED"/> dias</translation>
+<translation id="7971136598759319605">Ativado há um dia</translation>
+<translation id="1521774566618522728">Ativado hoje</translation>
+<translation id="3631987586758005671">Compartilhando com <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Ative a sincronização para compartilhar entre dispositivos</translation>
+<translation id="6162454065885854378">Para compartilhar conteúdo do seu smartphone com outro dispositivo, ative a sincronização nas configurações do Brave nos dois dispositivos</translation>
+<translation id="6084271560289605378">Acesse as configurações do Brave</translation>
+<translation id="2318045970523081853">Toque para ligar</translation>
 <translation id="9209888181064652401">Não é possível fazer chamadas</translation>
-<translation id="9219103736887031265">Imagens</translation>
-<translation id="926205370408745186">Remover sua atividade do Chorme do Bem-estar digital</translation>
-<translation id="932327136139879170">Início</translation>
-<translation id="938850635132480979">Erro: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Acessar seu microfone</translation>
-<translation id="95817756606698420">O Chrome pode usar o <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> para fazer pesquisas na China. É possível alterar essa opção nas <ph name="BEGIN_LINK" />Configurações<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloquear se o site mostrar anúncios invasivos ou enganosos (recomendado)</translation>
-<translation id="968900484120156207">As páginas visitadas são exibidas aqui</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minutos restantes</translation>
-<translation id="974555521953189084">Digite sua senha longa para iniciar a sincronização</translation>
-<translation id="981121421437150478">Off-line</translation>
-<translation id="982182592107339124">Essa ação limpará os dados de todos os sites, incluindo:</translation>
-<translation id="983192555821071799">Fechar todas as guias</translation>
-<translation id="987264212798334818">Geral</translation>
+<translation id="2860954141821109167">Verifique se há um aplicativo para telefones ativado neste dispositivo</translation>
+<translation id="2067805253194386918">texto</translation>
+<translation id="1450753235335490080">Falha no compartilhamento de <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Falha no compartilhamento de <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Verifique se a sincronização do <ph name="TARGET_DEVICE_NAME"/> está ativada no Brave</translation>
+<translation id="3016635187733453316">Verifique se o dispositivo está conectado à Internet</translation>
+<translation id="8466613982764129868">Verifique se o <ph name="TARGET_DEVICE_NAME"/> está conectado à Internet</translation>
+<translation id="6539092367496845964">Algo deu errado. Tente novamente mais tarde.</translation>
+<translation id="3389286852084373014">O texto está grande demais</translation>
+<translation id="2100314319871056947">Tente compartilhar o texto em segmentos menores</translation>
+<translation id="2987620471460279764">Texto compartilhado de outro dispositivo</translation>
+<translation id="7757787379047923882">Texto compartilhado por <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Copiado para a área de transferência</translation>
+<translation id="4696983787092045100">Enviar texto para seus dispositivos</translation>
+<translation id="1260236875608242557">Pesquisar e explorar</translation>
+<translation id="6369229450655021117">Aqui, é possível pesquisar na Web, compartilhar itens com os amigos e ver as páginas abertas</translation>
+<translation id="723171743924126238">Selecionar imagens</translation>
+<translation id="8751914237388039244">Selecione uma imagem</translation>
+<translation id="1989112275319619282">Procurar</translation>
+<translation id="7055152154916055070">Redirecionamento bloqueado:</translation>
+<translation id="5524843473235508879">Redirecionamento bloqueado.</translation>
+<translation id="6573096386450695060">Sempre permitir</translation>
+<translation id="5805364706385912897">Como esta página usa muita memória, o Brave a pausou.</translation>
+<translation id="5138664332909611586">Como esta página usa muita memória, o Brave removeu parte do conteúdo.</translation>
+<translation id="9137013805542155359">Mostrar original</translation>
+<translation id="6361779936989026201">Brave Software Assistente no Brave</translation>
+<translation id="7291387454912369099">Finalizar compras com o Assistente</translation>
+<translation id="4565206163201411670">Mostrar sua atividade do Brave no Bem-estar digital?</translation>
+<translation id="9055113864158719823">Você pode ver os sites que visita no Brave e definir timers para eles.\n\nO Brave Software recebe informações sobre os sites para os quais você definiu timers e sobre o tempo que você passa neles. Essas informações são usadas para melhorar o Bem-estar digital.</translation>
+<translation id="4596514158372210596">Remover sua atividade do Chorme do Bem-estar digital</translation>
+<translation id="1174893863889683998">Remover sua atividade do Brave do Bem-estar digital?</translation>
+<translation id="708829030563435351">Os sites que você visita no Brave não serão exibidos. Todos os timers do site serão excluídos.</translation>
+<translation id="2056878612599315956">Site pausado</translation>
+<translation id="671481426037969117">Seu timer para <ph name="FQDN"/> chegou ao fim. Ele será iniciado novamente amanhã.</translation>
+<translation id="7479104141328977413">Gerenciamento de guias</translation>
+<translation id="3524138585025253783">IU do desenvolvedor</translation>
+<translation id="6036057147555329831">ICU extra</translation>
+<translation id="9029323097866369874">Permitir que <ph name="DOMAIN"/> entre na RV?</translation>
+<translation id="7685301384041462804">Verifique se você confia neste site antes de entrar na RV.</translation>
+<translation id="5033865233969348410">Enquanto você estiver em RV, o site poderá receber dados sobre:
+  -  suas características físicas, como altura
+
+Verifique se você confia neste site antes de entrar na RV.</translation>
+<translation id="5534334044554683961">Enquanto você estiver em RV, este site poderá receber dados sobre:
+  -   suas características físicas, como altura
+  -   o layout da sua sala
+
+Verifique se você confia neste site antes de entrar na RV.</translation>
+<translation id="4169535189173047238">Não permitir</translation>
+<translation id="2170088579611075216">Permitir e entrar na RV</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_pt-PT.xtb
+++ b/android/java/strings/translations/android_chrome_strings_pt-PT.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="pt-PT">
-<translation id="1006017844123154345">Abrir online</translation>
-<translation id="1028699632127661925">A enviar para <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">A adicionar <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">De Websites</translation>
-<translation id="1049743911850919806">Navegação anónima</translation>
-<translation id="10614374240317010">Nunca guardadas</translation>
-<translation id="1067922213147265141">Outros serviços Google</translation>
-<translation id="1068672505746868501">Nunca traduzir páginas em <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Se alterar a extensão do ficheiro, este pode ser aberto numa aplicação diferente e representar um risco para o seu dispositivo.</translation>
-<translation id="1100066534610197918">Abrir num novo sep. no grupo</translation>
-<translation id="1105960400813249514">Ecrã a ser capturado...</translation>
-<translation id="1111673857033749125">Os marcadores guardados nos seus outros dispositivos são apresentados aqui.</translation>
-<translation id="1113597929977215864">Mostrar vista simplificada</translation>
-<translation id="1121094540300013208">Relatórios de utilização e falhas</translation>
-<translation id="1124772482545689468">Utilizador</translation>
-<translation id="1129510026454351943">Detalhes: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 transferência pendente.}other{# transferências pendentes.}}</translation>
-<translation id="1145536944570833626">Eliminar dados existentes.</translation>
-<translation id="1146678959555564648">Entrar na RV</translation>
-<translation id="116280672541001035">Utilizados</translation>
-<translation id="1171770572613082465">Veja Websites populares ao tocar no botão "Principais sites"</translation>
-<translation id="1173894706177603556">Mudar nome</translation>
-<translation id="1178581264944972037">Pausa</translation>
-<translation id="1181037720776840403">Remover</translation>
-<translation id="1188239144602654184">Aceder à realidade aumentada</translation>
-<translation id="1197267115302279827">Mover marcadores</translation>
-<translation id="119944043368869598">Limpar tudo</translation>
-<translation id="1201402288615127009">Seguinte</translation>
-<translation id="1204037785786432551">Transferir link</translation>
-<translation id="1206892813135768548">Copiar texto do link</translation>
-<translation id="1208340532756947324">Para sincronizar e personalizar entre dispositivos, ative a sincronização.</translation>
-<translation id="1209206284964581585">Ocultar para já</translation>
-<translation id="1227058898775614466">Histórico de navegação</translation>
-<translation id="1231733316453485619">Pretende ativar a sincronização?</translation>
-<translation id="123724288017357924">Atualizar página atual e ignorar conteúdo em cache</translation>
-<translation id="124116460088058876">Mais idiomas</translation>
-<translation id="124678866338384709">Fechar o separador atual</translation>
-<translation id="1258753120186372309">Doodle da Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Pesquisar e explorar</translation>
-<translation id="1264974993859112054">Desporto</translation>
-<translation id="1266864766717917324">Não foi possível partilhar <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Parar</translation>
-<translation id="1283039547216852943">Toque para expandir</translation>
-<translation id="1285320974508926690">Nunca traduzir este site</translation>
-<translation id="1291207594882862231">Limpar histórico, cookies, dados de sites, cache…</translation>
-<translation id="129382876167171263">Os ficheiros guardados por Websites são apresentados aqui.</translation>
-<translation id="129553762522093515">Fechados recentemente</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Enviado de <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Agrupar separadores</translation>
-<translation id="1327257854815634930">O histórico de navegação está aberto.</translation>
-<translation id="1331212799747679585">Não é possível atualizar o Chrome. Mais opções.</translation>
-<translation id="1332501820983677155">Atalhos das funcionalidades do Google Chrome</translation>
-<translation id="1360432990279830238">Terminar sessão e desativar a sincronização?</translation>
-<translation id="1369915414381695676">Site <ph name="SITE_NAME" /> adicionado</translation>
-<translation id="1373696734384179344">Memória insuficiente para transferir o conteúdo selecionado.</translation>
-<translation id="1376578503827013741">A calcular…</translation>
-<translation id="1383876407941801731">Pesquisar</translation>
-<translation id="1384959399684842514">Transferência interrompida</translation>
-<translation id="1386674309198842382">Ativo há <ph name="LAST_UPDATED" /> dias</translation>
-<translation id="1397811292916898096">Pesquisar com o <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Incorporado em <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"Não monitorizar"</translation>
-<translation id="1407135791313364759">Abrir tudo</translation>
-<translation id="1409426117486808224">Vista simplificada dos separadores abertos</translation>
-<translation id="1409879593029778104">A transferência de <ph name="FILE_NAME" /> foi impedida porque o ficheiro já existe.</translation>
-<translation id="1414981605391750300">A contactar a Google… Isto pode demorar um pouco…</translation>
-<translation id="1416550906796893042">Versão da aplicação</translation>
-<translation id="1430915738399379752">Imprimir</translation>
-<translation id="1446450296470737166">Perm. controlo total dispo. MIDI</translation>
-<translation id="1450753235335490080">Não é possível partilhar <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Desativada nas Definições do Android</translation>
-<translation id="1477626028522505441">A transferência de <ph name="FILE_NAME" /> falhou devido a problemas do servidor.</translation>
-<translation id="1506061864768559482">Motor de pesquisa</translation>
-<translation id="1513352483775369820">Marcadores e histórico da Web</translation>
-<translation id="1513858653616922153">Eliminar palavra-passe</translation>
-<translation id="1516229014686355813">A funcionalidade Tocar para pesquisar envia a palavra selecionada e a página atual como contexto para a Pesquisa Google. Pode desativá-la nas <ph name="BEGIN_LINK" />Definições<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Ativo hoje</translation>
-<translation id="1544826120773021464">Para gerir a sua Conta Google, toque no botão "Gerir conta".</translation>
-<translation id="1549000191223877751">Mover para outra janela</translation>
-<translation id="1553358976309200471">Atualizar o Chrome</translation>
-<translation id="1569387923882100876">Dispositivo ligado</translation>
-<translation id="1571304935088121812">Copiar nome de utilizador</translation>
-<translation id="1612196535745283361">O Chrome precisa de acesso à localização para procurar dispositivos. O acesso à localização está <ph name="BEGIN_LINK" />desativado para este dispositivo<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Câmara</translation>
-<translation id="1623104350909869708">Evitar que esta página crie caixas de diálogo adicionais</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Remover 1 item selecionado}other{Remover # itens selecionados}}</translation>
-<translation id="164269334534774161">Está a visualizar uma cópia offline desta página de <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Histórico</translation>
-<translation id="1647391597548383849">Aceder à câmara</translation>
-<translation id="1660204651932907780">Permitir que os sites reproduzam som (recomendado)</translation>
-<translation id="1670399744444387456">Básico</translation>
-<translation id="1671236975893690980">Transferência pendente…</translation>
-<translation id="1672586136351118594">Não mostrar de novo</translation>
-<translation id="1692118695553449118">A sincronização está ativada</translation>
-<translation id="169515064810179024">Impedir que os sites acedam aos sensores de movimentos</translation>
-<translation id="1717218214683051432">Sensores de movimento</translation>
-<translation id="1718835860248848330">Última hora</translation>
-<translation id="1736419249208073774">Explorar</translation>
-<translation id="1743802530341753419">Perguntar antes de permitir a ligação de sites a um dispositivo (recomendado)</translation>
-<translation id="1749561566933687563">Sincronizar os marcadores</translation>
-<translation id="17513872634828108">Separadores abertos</translation>
-<translation id="1779089405699405702">Descodificador de imagem</translation>
-<translation id="1782483593938241562">Data de conclusão: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Instalado</translation>
-<translation id="1792959175193046959">Altere a localização de transferência predefinida em qualquer altura.</translation>
-<translation id="1807246157184219062">Claro</translation>
-<translation id="1810845389119482123">A configuração da sincronização inicial não está concluída</translation>
-<translation id="1821253160463689938">Utiliza cookies para memorizar as suas preferências, mesmo que não visite essas páginas.</translation>
-<translation id="1829244130665387512">Localizar na página</translation>
-<translation id="1853692000353488670">Novo separador anónimo</translation>
-<translation id="1856325424225101786">Pretende repor o Modo Lite?</translation>
-<translation id="1868024384445905608">O Chrome agora transfere os ficheiros mais rapidamente.</translation>
-<translation id="1883903952484604915">Os meus ficheiros</translation>
-<translation id="1887786770086287077">O acesso à localização está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">A aplicação <ph name="APP_NAME" /> será aberta no Chrome. Ao continuar, aceita os <ph name="BEGIN_LINK1" />Termos de Utilização<ph name="END_LINK1" /> e o <ph name="BEGIN_LINK2" />Aviso de Privacidade<ph name="END_LINK2" /> do Chrome.</translation>
-<translation id="1919345977826869612">Anúncios</translation>
-<translation id="1919950603503897840">Selecionar contactos</translation>
-<translation id="1922076542920281912">Para permitir que o Chrome aceda à sua localização, ative também a localização nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Atualizações</translation>
-<translation id="19288952978244135">Reabra o Chrome.</translation>
-<translation id="1933845786846280168">Separador selecionado</translation>
-<translation id="194341124344773587">Ative a autorização para o Chrome nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Guardar palavras-passe</translation>
-<translation id="1952172573699511566">Quando possível, os Websites apresentam o texto no seu idioma preferido.</translation>
-<translation id="1960290143419248813">As atualizações do Chrome já não são suportadas para esta versão do Android.</translation>
-<translation id="1966710179511230534">Atualize os detalhes de início de sessão.</translation>
-<translation id="1974060860693918893">Avançadas</translation>
-<translation id="1984705450038014246">Sincronizar dados do Chrome</translation>
-<translation id="1984937141057606926">Permitidos, exceto de terceiros</translation>
-<translation id="1986685561493779662">O nome já existe</translation>
-<translation id="1987739130650180037">Botão <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Procurar</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> pretende sincronizar</translation>
-<translation id="1994173015038366702">URL do site</translation>
-<translation id="2000419248597011803">Envia alguns cookies e pesquisas da barra de endereço e da caixa de pesquisa para o motor de pesquisa predefinido.</translation>
-<translation id="2002537628803770967">Cartões de crédito e endereços com o Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ficheiro}other{# ficheiros}}</translation>
-<translation id="2017836877785168846">Limpa o histórico e os preenchimentos automáticos da barra de endereço.</translation>
-<translation id="2021896219286479412">Controlos de site em ecrã int.</translation>
-<translation id="2038563949887743358">Ativar Pedir site para computador</translation>
-<translation id="2041019821020695769">Para permitir que o Chrome lhe envie notificações, ative também as notificações nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">A aplicação <ph name="APP_NAME" /> também tem dados no Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Site em pausa</translation>
-<translation id="2063713494490388661">Tocar para pesquisar</translation>
-<translation id="2067805253194386918">texto</translation>
-<translation id="2079545284768500474">Anular</translation>
-<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER" /> de <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Som</translation>
-<translation id="2096012225669085171">Sincronizar e personalizar entre dispositivos</translation>
-<translation id="2100273922101894616">Início de sessão automático</translation>
-<translation id="2100314319871056947">Experimente partilhar o texto em partes mais pequenas.</translation>
-<translation id="2107397443965016585">Perguntar antes de permitir que os sites reproduzam conteúdos protegidos (recomendado)</translation>
-<translation id="2111511281910874386">Ir para a página</translation>
-<translation id="2122601567107267586">Não foi possível abrir a aplicação.</translation>
-<translation id="2126426811489709554">Com tecnologia do Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> guardado(s)</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> fechado</translation>
-<translation id="2139186145475833000">Adicionar ao ecrã principal</translation>
-<translation id="2146738493024040262">Abrir aplicação instantânea</translation>
-<translation id="2148716181193084225">Hoje</translation>
-<translation id="2154484045852737596">Editar cartão</translation>
-<translation id="2154710561487035718">Copiar URL</translation>
-<translation id="2156074688469523661">Sites restantes (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Para partilhar conteúdos do seu telemóvel com outro dispositivo, ative a sincronização nas definições do Chrome em ambos os dispositivos.</translation>
-<translation id="2170088579611075216">Permitir e iniciar RV</translation>
-<translation id="218608176142494674">Partilha</translation>
-<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sincronização e serviços Google</translation>
-<translation id="2259659629660284697">Exportar palavras-passe</translation>
-<translation id="2268044343513325586">Refinar</translation>
-<translation id="2286841657746966508">Endereço de facturação</translation>
-<translation id="2289270750774289114">Perguntar quando um site pretende detetar dispositivos Bluetooth próximos (recomendado)</translation>
-<translation id="230115972905494466">Não foram encontrados dispositivos compatíveis.</translation>
-<translation id="2315043854645842844">O sistema operativo não suporta a seleção do certificado do lado do cliente.</translation>
-<translation id="2318045970523081853">Toque para efetuar uma chamada</translation>
-<translation id="2321086116217818302">A preparar palavras-passe…</translation>
-<translation id="2321958826496381788">Arraste o controlo de deslize até conseguir ler confortavelmente. O texto deve ter, pelo menos, este tamanho depois de tocar duas vezes num parágrafo.</translation>
-<translation id="2323763861024343754">Armazenamento do site</translation>
-<translation id="2328985652426384049">Não é possível iniciar sessão</translation>
-<translation id="2330129964253841015">Enviar-lhe um aviso se as palavras-passe forem comprometidas</translation>
-<translation id="2349710944427398404">Total de dados utilizados pelo Chrome, incluindo contas, marcadores e definições guardadas</translation>
-<translation id="2353636109065292463">A verificar a sua ligação à Internet...</translation>
-<translation id="2359808026110333948">Continuar</translation>
-<translation id="2369533728426058518">abrir separadores</translation>
-<translation id="2387895666653383613">Escala do texto</translation>
-<translation id="2394602618534698961">Os ficheiros que transferir aparecem aqui.</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Quando inicia sessão na sua Conta Google, esta funcionalidade está ativada.</translation>
-<translation id="2410754283952462441">Selecione uma conta</translation>
-<translation id="2414886740292270097">Escuro</translation>
-<translation id="2416359993254398973">O Chrome necessita de autorização de acesso à câmara para este site.</translation>
-<translation id="2426805022920575512">Selecionar outra conta</translation>
-<translation id="2433507940547922241">Aspeto</translation>
-<translation id="2434158240863470628">Transferência concluída: <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Acesso à localização</translation>
-<translation id="2450083983707403292">Pretende começar a transferir <ph name="FILE_NAME" /> novamente?</translation>
-<translation id="2482878487686419369">Notificações</translation>
-<translation id="2490684707762498678">Gerido por <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Assistente Google no Chrome</translation>
-<translation id="2496180316473517155">Histórico de navegação</translation>
-<translation id="2497852260688568942">A sincronização foi desativada pelo gestor</translation>
-<translation id="2498359688066513246">Ajuda e comentários</translation>
-<translation id="2501278716633472235">Voltar</translation>
-<translation id="2513403576141822879">Para obter mais definições relacionadas com privacidade, segurança e recolha de dados, consulte <ph name="BEGIN_LINK" />Sincronização e serviços Google<ph name="END_LINK" />.</translation>
-<translation id="2518590038762162553">No Modo Lite, o Chrome carrega páginas mais rapidamente e utiliza até menos 60 por cento de dados. Para otimizar as páginas que vista, o Chrome envia o seu tráfego da Web para a Google. <ph name="BEGIN_LINK" />Saiba mais<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Envia para a Google os URLs das páginas que visita.</translation>
-<translation id="2532336938189706096">Visualização na Web</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> itens eliminados</translation>
-<translation id="2536728043171574184">Visualização de uma cópia offline desta página</translation>
-<translation id="2546283357679194313">Cookies e dados de Web sites</translation>
-<translation id="2567385386134582609">IMAGEM</translation>
-<translation id="257088987046510401">Temas</translation>
-<translation id="2570922361219980984">O acesso à localização também está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Expandido. Clique para reduzir.</translation>
-<translation id="2581165646603367611">Esta ação elimina os cookies, a cache e outros dados de sites que o Chrome não considera importantes.</translation>
-<translation id="2586657967955657006">Área de transferência</translation>
-<translation id="2587052924345400782">Versão mais recente dispon.</translation>
-<translation id="2593272815202181319">Monoespaço</translation>
-<translation id="2612676031748830579">Número do cartão</translation>
-<translation id="2621115761605608342">Permitir JavaScript num site específico.</translation>
-<translation id="2625189173221582860">Palavra-passe copiada</translation>
-<translation id="2631006050119455616">Guardado</translation>
-<translation id="2647434099613338025">Adicionar idioma</translation>
-<translation id="2650751991977523696">Pretende transferir o ficheiro novamente?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ficheiro de áudio}other{# ficheiros de áudio}}</translation>
-<translation id="2653659639078652383">Submeter</translation>
-<translation id="2677748264148917807">Sair</translation>
-<translation id="2704606927547763573">Copiado</translation>
-<translation id="2707726405694321444">Atualizar página</translation>
-<translation id="2709516037105925701">Preenchimento automático</translation>
-<translation id="2717722538473713889">Endereços de email</translation>
-<translation id="2728754400939377704">Ordenar por site</translation>
-<translation id="2744248271121720757">Toque numa palavra para pesquisar instantaneamente ou ver as ações relacionadas.</translation>
-<translation id="2760989362628427051">Ative o tema escuro quando a Poupança de bateria ou o tema escuro do dispositivo estiver ativado(a).</translation>
-<translation id="2762000892062317888">agora mesmo</translation>
-<translation id="2777555524387840389">Faltam <ph name="SECONDS" /> segundos</translation>
-<translation id="2779651927720337254">falhou</translation>
-<translation id="2781151931089541271">Falta 1 segundo</translation>
-<translation id="2801022321632964776">Atualize o Chrome para a versão mais recente de modo a obter o seu idioma.</translation>
-<translation id="2810645512293415242">Página simplificada para poupar dados e carregar mais rapidamente.</translation>
-<translation id="281504910091592009">Veja e faça a gestão das palavras-passe guardadas na sua <ph name="BEGIN_LINK" />Conta Google<ph name="END_LINK" />.</translation>
-<translation id="2818669890320396765">Para obter os seus marcadores em todos os dispositivos, inicie sessão e ative a sincronização.</translation>
-<translation id="2822354292072154809">Tem a certeza de que pretende repor todas as autorizações do site para <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Toque no botão de retrocesso para sair do ecrã inteiro.</translation>
-<translation id="2842985007712546952">Pasta superior</translation>
-<translation id="2858138569776157458">Princ. sites</translation>
-<translation id="2860954141821109167">Certifique-se de que uma aplicação de telefone está ativada neste dispositivo.</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Faixa anterior</translation>
-<translation id="2876369937070532032">Quando a sua segurança está em risco, envia para a Google URLs de algumas páginas que visita.</translation>
-<translation id="2888126860611144412">Acerca do Chrome</translation>
-<translation id="2891154217021530873">Parar carregamento da página</translation>
-<translation id="2893180576842394309">A Google pode utilizar o seu histórico para personalizar a Pesquisa e outros serviços Google.</translation>
-<translation id="2898264748040935573">Editar a palavra-passe armazenada</translation>
-<translation id="2900528713135656174">Criar evento</translation>
-<translation id="290376772003165898">A página não está em <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Lista de dispositivos com os quais pretende partilhar um separador aberta à altura total.</translation>
-<translation id="2910701580606108292">Perguntar antes de permitir que os sites reproduzam conteúdos protegidos</translation>
-<translation id="2913331724188855103">Permitir que os sites guardem e leiam dados de cookies (recomendado)</translation>
-<translation id="2923908459366352541">O nome é inválido</translation>
-<translation id="2932150158123903946">Armazenamento do Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">O separador Pré-visualização está fechado</translation>
-<translation id="2956410042958133412">Esta conta é gerida por <ph name="PARENT_NAME_1" /> e por <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Mudado para separadores de navegação anónima</translation>
-<translation id="2968755619301702150">Visualizador de certificados</translation>
-<translation id="2979025552038692506">Separador de navegação anónima selecionado</translation>
-<translation id="2987620471460279764">Texto partilhado de outro dispositivo</translation>
-<translation id="2989523299700148168">Visitados recentemente</translation>
-<translation id="2996291259634659425">Criar frase de acesso</translation>
-<translation id="2996809686854298943">URL obrigatório</translation>
-<translation id="300526633675317032">Esta ação elimina os <ph name="SIZE_IN_KB" /> de armazenamento do Website.</translation>
-<translation id="3016635187733453316">Certifique-se de que este dispositivo está ligado à Internet.</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB transferido(s)</translation>
-<translation id="3029704984691124060">As frases de acesso não coincidem</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Obter ajuda<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">A localização está desativada. Ative-a nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Pode ativar a sincronização em qualquer altura nas definições.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> marcador}other{<ph name="BOOKMARKS_COUNT_MANY" /> marcadores}}</translation>
-<translation id="3089395242580810162">Abrir no separador anónimo</translation>
-<translation id="3115898365077584848">Mostrar informações</translation>
-<translation id="3123473560110926937">Bloqueado em alguns sites.</translation>
-<translation id="3137521801621304719">Sair do modo de navegação anónima</translation>
-<translation id="3143515551205905069">Cancelar sincronização</translation>
-<translation id="3157842584138209013">Veja a quantidade de dados que poupou através do botão Mais opções.</translation>
-<translation id="3166827708714933426">Atalhos de separadores e de janelas</translation>
-<translation id="3181954750937456830">Navegação segura (protege o utilizador e o seu dispositivo contra sites perigosos)</translation>
-<translation id="3190152372525844641">Ative as autorizações para o Chrome nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> de dados armazenados</translation>
-<translation id="3205824638308738187">Quase concluído!</translation>
-<translation id="3207960819495026254">Adicionado aos marcadores</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> eliminado</translation>
-<translation id="321773570071367578">Se se esquecer da frase de acesso ou pretender alterar esta definição, <ph name="BEGIN_LINK" />reponha a sincronização<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Microfone</translation>
-<translation id="3232754137068452469">Aplicação Web</translation>
-<translation id="3236059992281584593">Falta 1 minuto</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Marcar esta página</translation>
-<translation id="3259831549858767975">Reduzir o tamanho de todos os itens na página</translation>
-<translation id="3269093882174072735">Carregar imagem</translation>
-<translation id="3269956123044984603">Para obter os separadores dos seus outros dispositivos, ative a opção "Sincronizar automaticamente os dados" nas definições da conta do Android.</translation>
-<translation id="3277252321222022663">Permitir que os sites acedam aos sensores (recomendado)</translation>
-<translation id="3282568296779691940">Iniciar sessão no Chrome</translation>
-<translation id="3288003805934695103">Atualizar a página</translation>
-<translation id="32895400574683172">As notificações são permitidas.</translation>
-<translation id="3295530008794733555">Navegue mais depressa. Utilize menos dados.</translation>
-<translation id="3295602654194328831">Ocultar informações</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Pretende transferir o conteúdo?</translation>
-<translation id="3306398118552023113">Esta aplicação está a ser executada no Chrome</translation>
-<translation id="3315103659806849044">Está atualmente a personalizar as definições de Sincronização e dos serviços Google. Para concluir a ativação da sincronização, toque no botão Confirmar junto à parte inferior do ecrã. Navegar para cima</translation>
-<translation id="3328801116991980348">Informações do site</translation>
-<translation id="3333961966071413176">Todos os contactos</translation>
-<translation id="3334729583274622784">Pretende alterar a extensão de ficheiro?</translation>
-<translation id="3341058695485821946">Veja a quantidade de dados que poupou.</translation>
-<translation id="3350687908700087792">Fechar todos os separadores de navegação anónima</translation>
-<translation id="3353615205017136254">Página em modo lite fornecida pela Google. Toque no botão Carregar original para carregar a página original.</translation>
-<translation id="3367813778245106622">Iniciar sessão novamente para iniciar a sincronização</translation>
-<translation id="3374023511497244703">Os marcadores, o histórico, as palavras-passe e outros dados do Chrome deixarão de ser sincronizados com a sua Conta Google.</translation>
-<translation id="3384347053049321195">Partilhar imagem</translation>
-<translation id="3386292677130313581">Perguntar antes de permitir que os sites conheçam a sua localização (recomendado)</translation>
-<translation id="3387650086002190359">A transferência de <ph name="FILE_NAME" /> falhou devido a erros do sistema de ficheiros.</translation>
-<translation id="3389286852084373014">O texto é demasiado grande</translation>
-<translation id="3398320232533725830">Abrir o gestor de marcadores</translation>
-<translation id="3414952576877147120">Tamanho:</translation>
-<translation id="3443221991560634068">Atualizar a página atual</translation>
-<translation id="3445014427084483498">Agora mesmo</translation>
-<translation id="3478363558367712427">Pode escolher o seu motor de pesquisa.</translation>
+<translation id="6910211073230771657">Eliminado</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, compreendi</translation>
+<translation id="7658239707568436148">Cancelar</translation>
 <translation id="3479552764303398839">Agora não</translation>
-<translation id="3492207499832628349">Novo separador anónimo</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Saiba mais<ph name="END_LINK" /> acerca do conteúdo sugerido</translation>
-<translation id="3513704683820682405">Realidade aumentada</translation>
-<translation id="3518985090088779359">Aceitar e continuar</translation>
-<translation id="3522247891732774234">Atualização disponível. Mais opções</translation>
-<translation id="3524138585025253783">IU do programador</translation>
-<translation id="3527085408025491307">Pasta</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB disponível(eis)</translation>
-<translation id="3549657413697417275">Pesquisar no histórico</translation>
-<translation id="3557336313807607643">Adicionar aos contactos</translation>
-<translation id="3566923219790363270">O Chrome ainda se está a preparar para a RV. Reinicie o Chrome mais tarde.</translation>
-<translation id="3568688522516854065">Para obter os separadores dos seus outros dispositivos, inicie sessão e ative a sincronização.</translation>
-<translation id="3587482841069643663">Tudo</translation>
-<translation id="358794129225322306">Permitir que um site transfira vários ficheiros automaticamente.</translation>
-<translation id="3590487821116122040">Armazenamento do site que o Chrome não considera importante (por exemplo, sites sem definições guardadas ou aos quais não acede com frequência)</translation>
-<translation id="3599863153486145794">Limpa o histórico de todos os dispositivos com sessão iniciada. A sua Conta Google pode ter outras formas do histórico de navegação em <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Desativar o som dos sites que reproduzem som</translation>
-<translation id="3616113530831147358">Áudio</translation>
-<translation id="3631987586758005671">A partilhar com <ph name="DEVICE_NAME" />…</translation>
-<translation id="3632295766818638029">Desmascarar palavra-passe</translation>
-<translation id="363596933471559332">Inicie automaticamente sessão em Sites com as credenciais armazenadas. Quando a funcionalidade está desativada, é-lhe sempre pedida validação antes de iniciar sessão num Website.</translation>
-<translation id="3658159451045945436">A reposição apaga o histórico da poupança de dados, incluindo a lista de sites visitados.</translation>
-<translation id="3692944402865947621">A transferência de <ph name="FILE_NAME" /> falhou porque o local de armazenamento está fora do alcance.</translation>
-<translation id="3714981814255182093">Abrir a barra Localizar</translation>
-<translation id="3716182511346448902">Esta página utiliza demasiada memória, pelo que o Chrome a colocou em pausa.</translation>
-<translation id="3730075448226062617">Para permitir que o Chrome aceda ao microfone, ative também o microfone nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Adicionado aos marcadores no <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sincronização em segundo plano</translation>
-<translation id="3771001275138982843">Não foi possível transferir a atualização.</translation>
-<translation id="3771033907050503522">Sep. nav. anónima</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Ative o Bluetooth<ph name="END_LINK" /> para permitir a sincronização</translation>
-<translation id="3775705724665058594">Envie para os seus dispositivos</translation>
-<translation id="3778956594442850293">Adicionado ao ecrã principal</translation>
-<translation id="3789841737615482174">Instalar</translation>
-<translation id="3810838688059735925">Vídeo</translation>
-<translation id="3810973564298564668">Gerir</translation>
-<translation id="381841723434055211">Números de telefone</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> transferências eliminadas</translation>
-<translation id="3822502789641063741">Limpar armazenamento do site?</translation>
-<translation id="385051799172605136">Anterior</translation>
-<translation id="3859306556332390985">Procurar para a frente</translation>
-<translation id="3894427358181296146">Adicionar pasta</translation>
-<translation id="3895926599014793903">Forçar ativação do zoom</translation>
-<translation id="3912508018559818924">A procurar o melhor da Web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combinar os meus dados</translation>
-<translation id="393697183122708255">Nenhuma pesq. por voz ativada disponível</translation>
-<translation id="395206256282351086">Sugestões de pesquisa e de sites desativadas</translation>
-<translation id="3955193568934677022">Permitir que os sites reproduzam conteúdo protegido (recomendado)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{O Chrome irá carregar a página quando estiver pronta.}other{O Chrome irá carregar as páginas quando estiverem prontas.}}</translation>
-<translation id="3963007978381181125">A encriptação da frase de acesso não inclui métodos de pagamento nem endereços do Google Pay. Apenas alguém que conheça a sua frase de acesso pode ler os seus dados encriptados. A frase de acesso não é enviada para a Google nem armazenada pela mesma. Se se esquecer da frase de acesso ou pretender alterar esta definição, tem de repor a sincronização. <ph name="BEGIN_LINK" />Saiba mais<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Transferência concluída</translation>
-<translation id="397583555483684758">A sincronização deixou de funcionar</translation>
-<translation id="3976396876660209797">Remova este atalho e crie-o novamente</translation>
-<translation id="3985215325736559418">Pretende transferir <ph name="FILE_NAME" /> novamente?</translation>
-<translation id="3987993985790029246">Cop. link</translation>
-<translation id="3988213473815854515">A localização é permitida</translation>
-<translation id="3988466920954086464">Veja resultados da pesquisa instantâneos neste painel.</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Armazenamento desnecessário</translation>
-<translation id="4000212216660919741">Em casa offline</translation>
+<translation id="5317780077021120954">Guardar</translation>
+<translation id="4570913071927164677">Detalhes</translation>
+<translation id="8730621377337864115">Concluído</translation>
+<translation id="8261506727792406068">Eliminar</translation>
+<translation id="1181037720776840403">Remover</translation>
+<translation id="5939518447894949180">Repor</translation>
 <translation id="4002066346123236978">Título</translation>
-<translation id="4008040567710660924">Permita cookies para um site específico.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Faixa seguinte</translation>
-<translation id="4048707525896921369">Saiba mais acerca dos tópicos nos Websites sem sair da página. A funcionalidade Tocar para pesquisar envia uma palavra e o contexto circundante para a Pesquisa Google, que devolve definições, imagens, resultados da pesquisa e outros detalhes.
+<translation id="5916664084637901428">Ativado</translation>
+<translation id="5860033963881614850">Desativado</translation>
+<translation id="6165508094623778733">Saiba mais</translation>
+<translation id="6042308850641462728">Mais</translation>
+<translation id="6040143037577758943">Fechar</translation>
+<translation id="780301667611848630">Não, obrigado</translation>
+<translation id="1201402288615127009">Seguinte</translation>
+<translation id="2359808026110333948">Continuar</translation>
+<translation id="2653659639078652383">Submeter</translation>
+<translation id="2079545284768500474">Anular</translation>
+<translation id="7649070708921625228">Ajuda</translation>
+<translation id="2148716181193084225">Hoje</translation>
+<translation id="7781829728241885113">Ontem</translation>
+<translation id="6945221475159498467">Selecionar</translation>
+<translation id="7791543448312431591">Adicionar</translation>
+<translation id="6527303717912515753">Partilhar</translation>
+<translation id="1383876407941801731">Pesquisar</translation>
+<translation id="3115898365077584848">Mostrar informações</translation>
+<translation id="3295602654194328831">Ocultar informações</translation>
+<translation id="3987993985790029246">Cop. link</translation>
+<translation id="2704606927547763573">Copiado</translation>
+<translation id="8725066075913043281">Tentar novamente</translation>
+<translation id="385051799172605136">Anterior</translation>
+<translation id="8131740175452115882">Confirmar</translation>
+<translation id="5300589172476337783">Mostrar</translation>
+<translation id="1124772482545689468">Utilizador</translation>
+<translation id="8609465669617005112">Mover para cima</translation>
+<translation id="6746124502594467657">Mover para baixo</translation>
+<translation id="8249310407154411074">Mover para o início</translation>
+<translation id="8428213095426709021">Definições</translation>
+<translation id="2498359688066513246">Ajuda e comentários</translation>
+<translation id="8378714024927312812">Gerido pela sua entidade</translation>
+<translation id="9019902583201351841">Gerido pelos teus pais</translation>
+<translation id="4645575059429386691">Gerido pelos teus pais</translation>
+<translation id="4883854917563148705">As definições geridas não podem ser repostas</translation>
+<translation id="4307992518367153382">Noções básicas</translation>
+<translation id="1974060860693918893">Avançadas</translation>
+<translation id="1146678959555564648">Entrar na RV</translation>
+<translation id="987264212798334818">Geral</translation>
+<translation id="4275663329226226506">Multimédia</translation>
+<translation id="4759238208242260848">Transferências</translation>
+<translation id="218608176142494674">Partilha</translation>
+<translation id="8004582292198964060">Navegador</translation>
+<translation id="1105960400813249514">Ecrã a ser capturado...</translation>
+<translation id="4875775213178255010">Sugestões de conteúdo</translation>
+<translation id="2021896219286479412">Controlos de site em ecrã int.</translation>
+<translation id="4587589328781138893">Sites</translation>
+<translation id="4943703118917034429">Realidade virtual</translation>
+<translation id="1928696683969751773">Atualizações</translation>
+<translation id="6064125863973209585">Transferências concluídas</translation>
+<translation id="5342314432463739672">Pedidos de autorização</translation>
+<translation id="629730747756840877">Conta</translation>
+<translation id="82609232232243542">Iniciar sessão no Brave</translation>
+<translation id="7956662517480676674">Sincronização e serviços Brave Software</translation>
+<translation id="5294439808117722387">Está atualmente a personalizar as definições de Sincronização e dos serviços Brave Software. Para concluir a ativação da sincronização, toque no botão Confirmar junto à parte inferior do ecrã. Navegar para cima</translation>
+<translation id="2096012225669085171">Sincronizar e personalizar entre dispositivos</translation>
+<translation id="1692118695553449118">A sincronização está ativada</translation>
+<translation id="5514904542973294328">Desativada pelo gestor do dispositivo</translation>
+<translation id="6447211988989208781">Controlos da atividade Brave Software</translation>
+<translation id="4882831918239250449">Controlar a forma como o histórico de navegação é utilizado para personalizar a Pesquisa, os anúncios e muito mais</translation>
+<translation id="7431991332293347422">Controle a forma como o histórico de navegação é utilizado para personalizar a Pesquisa e muito mais.</translation>
+<translation id="6303969859164067831">Terminar sessão e desativar a sincronização</translation>
+<translation id="1125261911132334651">Gerir a sua Conta Brave Software</translation>
+<translation id="6406506848690869874">Sincronização</translation>
+<translation id="714362445477979774">Sincronizar dados do Brave</translation>
+<translation id="4314815835985389558">Gerir sincronização</translation>
+<translation id="5428209950370661546">Outros serviços Brave Software</translation>
+<translation id="7704317875155739195">Pesquisas de preenchimento automático e URLs</translation>
+<translation id="2000419248597011803">Envia alguns cookies e pesquisas da barra de endereço e da caixa de pesquisa para o motor de pesquisa predefinido.</translation>
+<translation id="7981313251711023384">Pré-carregar as páginas para uma navegação e uma pesquisa mais rápidas</translation>
+<translation id="1821253160463689938">Utiliza cookies para memorizar as suas preferências, mesmo que não visite essas páginas.</translation>
+<translation id="6697492270171225480">Mostrar sugestões de páginas semelhantes se não for possível encontrar uma página</translation>
+<translation id="8109318360573330108">Envia para a Brave Software o URL de uma página à qual esteja a tentar aceder.</translation>
+<translation id="8438566539970814960">Melhorar as pesquisas e a navegação</translation>
+<translation id="284843628681142937">Envia para a Brave Software os URLs das páginas que visita.</translation>
+<translation id="7222718784508482526">Para obter mais definições relacionadas com privacidade, segurança e recolha de dados, consulte <ph name="BEGIN_LINK"/>Sincronização e serviços Brave Software<ph name="END_LINK"/>.</translation>
+<translation id="918192811481327695">Ajudar a melhorar as funcionalidades e o desempenho do Brave</translation>
+<translation id="9063160602596686558">Envia automaticamente estatísticas de utilização e relatórios de falhas para a Brave Software.</translation>
+<translation id="4824958205181053313">Pretende cancelar a sincronização?</translation>
+<translation id="3058498974290601450">Pode ativar a sincronização em qualquer altura nas definições.</translation>
+<translation id="3143515551205905069">Cancelar sincronização</translation>
+<translation id="1506061864768559482">Motor de pesquisa</translation>
+<translation id="55737423895878184">A localização e as notificações são permitidas.</translation>
+<translation id="3988213473815854515">A localização é permitida</translation>
+<translation id="32895400574683172">As notificações são permitidas.</translation>
+<translation id="9040142327097499898">As notificações são permitidas. A localização está desativada para este dispositivo.</translation>
+<translation id="305593374596241526">A localização está desativada. Ative-a nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Visitados recentemente</translation>
+<translation id="6433501201775827830">Escolher o motor de pesquisa</translation>
+<translation id="7177466738963138057">Pode alterar esta opção mais tarde nas Definições</translation>
+<translation id="3478363558367712427">Pode escolher o seu motor de pesquisa.</translation>
+<translation id="4910889077668685004">Aplicações de pagamento</translation>
+<translation id="5152843274749979095">Nenhuma aplicação compatível instalada</translation>
+<translation id="8812260976093120287">Nalguns Sites, é possível pagar com as aplicações de pagamento compatíveis acima no dispositivo.</translation>
+<translation id="7764225426217299476">Adicionar endereço</translation>
+<translation id="5595485650161345191">Editar morada</translation>
+<translation id="5087580092889165836">Adicionar cartão</translation>
+<translation id="2154484045852737596">Editar cartão</translation>
+<translation id="6140912465461743537">País/região</translation>
+<translation id="5659593005791499971">Email</translation>
+<translation id="4378154925671717803">Telemóvel</translation>
+<translation id="4807098396393229769">Nome no cartão</translation>
+<translation id="860043288473659153">Nome do titular do cartão</translation>
+<translation id="2612676031748830579">Número do cartão</translation>
+<translation id="869891660844655955">Data de expiração</translation>
+<translation id="2286841657746966508">Endereço de facturação</translation>
+<translation id="663059986967017181">Copiado para o Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Palavras-passe</translation>
+<translation id="1943432128510653496">Guardar palavras-passe</translation>
+<translation id="2100273922101894616">Início de sessão automático</translation>
+<translation id="363596933471559332">Inicie automaticamente sessão em Sites com as credenciais armazenadas. Quando a funcionalidade está desativada, é-lhe sempre pedida validação antes de iniciar sessão num Website.</translation>
+<translation id="6995899638241819463">Enviar-lhe um aviso se as palavras-passe forem expostas numa violação de dados</translation>
+<translation id="1534287762301776620">Quando inicia sessão na sua Conta Brave Software, esta funcionalidade está ativada.</translation>
+<translation id="10614374240317010">Nunca guardadas</translation>
+<translation id="3098842761938485917">Veja e faça a gestão das palavras-passe guardadas na sua <ph name="BEGIN_LINK"/>Conta Brave Software<ph name="END_LINK"/>.</translation>
+<translation id="8562452229998620586">As palavras-passe guardadas aparecem aqui.</translation>
+<translation id="8084114998886531721">Palavra-passe guardada</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Nome de utilizador</translation>
+<translation id="6657585470893396449">Palavra-passe</translation>
+<translation id="2154710561487035718">Copiar URL</translation>
+<translation id="1571304935088121812">Copiar nome de utilizador</translation>
+<translation id="5005498671520578047">Copiar palavra-passe</translation>
+<translation id="3632295766818638029">Desmascarar palavra-passe</translation>
+<translation id="1513858653616922153">Eliminar palavra-passe</translation>
+<translation id="543338862236136125">Editar palavra-passe</translation>
+<translation id="4565377596337484307">Ocultar palavra-passe</translation>
+<translation id="8523928698583292556">Eliminar palavra-passe armazenada</translation>
+<translation id="2898264748040935573">Editar a palavra-passe armazenada</translation>
+<translation id="5433691172869980887">Nome de utilizador copiado</translation>
+<translation id="5534640966246046842">Site copiado</translation>
+<translation id="2625189173221582860">Palavra-passe copiada</translation>
+<translation id="4550003330909367850">Para ver ou copiar a sua palavra-passe aqui, defina o bloqueio de ecrã neste dispositivo.</translation>
+<translation id="6154478581116148741">Ative o bloqueio de ecrã nas Definições para exportar as suas palavras-passe a partir deste dispositivo.</translation>
+<translation id="4842092870884894799">A mostrar pop-up de geração de palavra-passe</translation>
+<translation id="2259659629660284697">Exportar palavras-passe</translation>
+<translation id="133012818630824069">Exportar palavras-passe armazenadas com o Brave</translation>
+<translation id="6914783257214138813">As suas palavras-passe serão visíveis para todas as pessoas que consigam ver o ficheiro exportado.</translation>
+<translation id="2321086116217818302">A preparar palavras-passe…</translation>
+<translation id="8445448999790540984">Não é possível exportar as palavras-passe</translation>
+<translation id="3066461326500799725">Saiba como utilizar o Brave Software Drive</translation>
+<translation id="729975465115245577">O dispositivo não tem uma aplicação para armazenar o ficheiro de palavras-passe.</translation>
+<translation id="7682724950699840886">Experimente as seguintes sugestões: certifique-se de que existe espaço suficiente no dispositivo e tente exportar novamente.</translation>
+<translation id="1129510026454351943">Detalhes: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Desbloqueie para copiar a palavra-passe.</translation>
+<translation id="5515439363601853141">Desbloqueie para ver a palavra-passe.</translation>
+<translation id="6221633008163990886">Desbloqueie para exportar as palavras-passe.</translation>
+<translation id="230699814587342492">Palavras-passe do Brave</translation>
+<translation id="6075798973483050474">Editar página inicial</translation>
+<translation id="854522910157234410">Abrir esta página</translation>
+<translation id="2482878487686419369">Notificações</translation>
+<translation id="6255999984061454636">Sugestões de conteúdo</translation>
+<translation id="805047784848435650">Baseado no seu histórico de navegação</translation>
+<translation id="1041308826830691739">De Websites</translation>
+<translation id="395206256282351086">Sugestões de pesquisa e de sites desativadas</translation>
+<translation id="257088987046510401">Temas</translation>
+<translation id="4650364565596261010">Predefinição do sistema</translation>
+<translation id="7588219262685291874">Ativar o tema escuro quando a Poupança de bateria do dispositivo estiver ativada.</translation>
+<translation id="2760989362628427051">Ative o tema escuro quando a Poupança de bateria ou o tema escuro do dispositivo estiver ativado(a).</translation>
+<translation id="6381421346744604172">Escurecer Websites</translation>
+<translation id="5040262127954254034">Privacidade</translation>
+<translation id="4991384657077828949">Ajudar a melhorar a segurança do Brave</translation>
+<translation id="1943176487615318915">Para detetar aplicações e sites perigosos, o Brave envia para a Brave Software URLs de algumas páginas que visita, informações limitadas do sistema e algum conteúdo das páginas.</translation>
+<translation id="3181954750937456830">Navegação segura (protege o utilizador e o seu dispositivo contra sites perigosos)</translation>
+<translation id="7315322926489145388">Quando a sua segurança está em risco, envia para a Brave Software URLs de algumas páginas que visita.</translation>
+<translation id="2063713494490388661">Tocar para pesquisar</translation>
+<translation id="2369463299479365221">Saiba mais acerca dos tópicos nos Websites sem sair da página. A funcionalidade Tocar para pesquisar envia uma palavra e o contexto circundante para a Pesquisa Brave Software, que devolve definições, imagens, resultados da pesquisa e outros detalhes.
 
 Para ajustar o termo de pesquisa, mantenha-o premido para selecionar. Para refinar a pesquisa, deslize lentamente o painel totalmente para cima e toque na caixa de pesquisa.</translation>
-<translation id="4056223980640387499">Sépia</translation>
-<translation id="4060598801229743805">Opções disponíveis junto à parte superior do ecrã</translation>
-<translation id="4062305924942672200">Informações legais</translation>
-<translation id="4084682180776658562">Marcar</translation>
-<translation id="4084712963632273211">De <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />fornecido pela Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Pretende eliminar os dados da aplicação?</translation>
-<translation id="4099578267706723511">Ajude a melhorar o Chrome ao enviar estatísticas de utilização e relatórios de falhas para a Google.</translation>
-<translation id="410351446219883937">Reprodução automática</translation>
-<translation id="4116038641877404294">Transfira páginas para as utilizar offline.</translation>
-<translation id="4135200667068010335">A lista de dispositivos com os quais pretende partilhar um separador está fechada.</translation>
-<translation id="4149994727733219643">Vista simplificada de páginas Web</translation>
-<translation id="4165986682804962316">Definições de sites</translation>
-<translation id="4169535189173047238">Não permitir</translation>
-<translation id="4170011742729630528">O serviço não está disponível. Tente novamente mais tarde.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> utilizado(s)</translation>
-<translation id="4181841719683918333">Idiomas</translation>
-<translation id="4183868528246477015">Pesquisar com Google Lens <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Abrir num novo separador</translation>
-<translation id="4198423547019359126">Não existem localizações de transferência disponíveis.</translation>
-<translation id="4209895695669353772">Para obter conteúdo personalizado sugerido pelo Google, ative a sincronização.</translation>
-<translation id="4226663524361240545">As notificações podem fazer com que o dispositivo vibre</translation>
-<translation id="423219824432660969">Encriptar dados sincronizados com a palavra-passe do Google a partir de <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Abrir definições</translation>
-<translation id="4256782883801055595">Licenças de código aberto</translation>
-<translation id="4259722352634471385">A navegação está bloqueada: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copiar endereço do link</translation>
-<translation id="4275663329226226506">Multimédia</translation>
-<translation id="4278390842282768270">Permitido</translation>
-<translation id="429312253194641664">Um site está a reproduzir multimédia.</translation>
-<translation id="4298388696830689168">Sites associados</translation>
-<translation id="4307992518367153382">Noções básicas</translation>
-<translation id="4314815835985389558">Gerir sincronização</translation>
-<translation id="4351244548802238354">Fechar caixa de diálogo</translation>
-<translation id="4378154925671717803">Telemóvel</translation>
-<translation id="4384468725000734951">A utilizar o Sogou para pesquisa</translation>
-<translation id="4404568932422911380">Sem marcadores</translation>
-<translation id="4405224443901389797">Mover para…</translation>
-<translation id="4411535500181276704">Modo Lite</translation>
-<translation id="4415276339145661267">Gerir a sua Conta Google</translation>
-<translation id="4432792777822557199">As páginas em <ph name="SOURCE_LANGUAGE" /> serão traduzidas para <ph name="TARGET_LANGUAGE" /> a partir de agora</translation>
-<translation id="4433925000917964731">Página em modo lite fornecida pela Google</translation>
-<translation id="4434045419905280838">Pop-ups e redirecionamentos</translation>
-<translation id="4440958355523780886">Página em modo lite fornecida pela Google. Toque para carregar a página original.</translation>
-<translation id="4452411734226507615">Fechar o separador <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Adicionado aos marcadores em <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Permitir que os sites reproduzam conteúdos protegidos</translation>
-<translation id="4468959413250150279">Desative o som de um site específico.</translation>
-<translation id="4472118726404937099">Para sincronizar e personalizar entre dispositivos, inicie sessão e ative a sincronização.</translation>
-<translation id="447252321002412580">Ajudar a melhorar as funcionalidades e o desempenho do Chrome</translation>
-<translation id="4479647676395637221">Perguntar antes de permitir que os sites utilizem a câmara (recomendado)</translation>
-<translation id="4479972344484327217">A instalar o módulo <ph name="MODULE" /> para o Chrome…</translation>
-<translation id="4487967297491345095">Todos os dados de aplicações do Chrome são eliminados permanentemente, incluindo todos os ficheiros, definições, contas, bases de dados, etc.</translation>
-<translation id="4493497663118223949">O Modo Lite está ativado.</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Há # dia}other{Há # dias}}</translation>
-<translation id="451872707440238414">Pesquisar os marcadores</translation>
-<translation id="4521489764227272523">Os dados selecionados foram removidos do Chrome e dos dispositivos sincronizados.
-
-A sua Conta Google pode ter outras formas do histórico de navegação, como pesquisas e atividade de outros serviços Google, em <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Escolher pasta</translation>
-<translation id="4538018662093857852">Ativar o Modo Lite</translation>
-<translation id="4550003330909367850">Para ver ou copiar a sua palavra-passe aqui, defina o bloqueio de ecrã neste dispositivo.</translation>
-<translation id="4558311620361989323">Atalhos da página Web</translation>
-<translation id="4561979708150884304">Sem ligação</translation>
-<translation id="4565377596337484307">Ocultar palavra-passe</translation>
-<translation id="4570913071927164677">Detalhes</translation>
-<translation id="4572422548854449519">Iniciar sessão na conta gerida</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Há # minuto}other{Há # minutos}}</translation>
-<translation id="4587589328781138893">Sites</translation>
-<translation id="4594952190837476234">Esta página foi criada a <ph name="CREATION_TIME" /> e pode ser diferente da versão online.</translation>
-<translation id="4605958867780575332">Item removido: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Utilizar palavra-passe</translation>
-<translation id="4645575059429386691">Gerido pelos teus pais</translation>
-<translation id="4650364565596261010">Predefinição do sistema</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> marcadores eliminados</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> foi adicionado ao seu Ecrã principal</translation>
-<translation id="4684427112815847243">Sincronizar tudo</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Envie uma mensagem de texto para os seus dispositivos</translation>
-<translation id="4698034686595694889">Ver offline no <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Imagens e ficheiros em cache</translation>
-<translation id="4714588616299687897">Poupe até 60% dos seus dados</translation>
-<translation id="4719927025381752090">Propor tradução</translation>
-<translation id="4720023427747327413">Abrir no <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Ajude a melhorar o Chrome. <ph name="BEGIN_LINK" />Responder ao inquérito<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Atualizar</translation>
-<translation id="4738836084190194332">Última sincronização: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Abrir um novo separador</translation>
-<translation id="4751476147751820511">Sensores de movimento ou de luz</translation>
-<translation id="4759238208242260848">Transferências</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 transferência concluída.}other{# transferências concluídas.}}</translation>
-<translation id="4797039098279997504">Toque para voltar a <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">A encriptação da frase de acesso não inclui métodos de pagamento nem endereços do Google Pay.
-
-Para alterar esta definição, <ph name="BEGIN_LINK" />reponha a sincronização<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Nome no cartão</translation>
-<translation id="4824958205181053313">Pretende cancelar a sincronização?</translation>
-<translation id="4837753911714442426">Abrir opções para imprimir página</translation>
-<translation id="4842092870884894799">A mostrar pop-up de geração de palavra-passe</translation>
-<translation id="4860895144060829044">Telefonar</translation>
-<translation id="4866368707455379617">Não é possível instalar o módulo <ph name="MODULE" /> para o Chrome.</translation>
-<translation id="4875775213178255010">Sugestões de conteúdo</translation>
-<translation id="4878404682131129617">Falha ao estabelecer um túnel através do servidor proxy.</translation>
-<translation id="4880127995492972015">Traduzir…</translation>
-<translation id="4881695831933465202">Abrir</translation>
-<translation id="488187801263602086">Mudar o nome do ficheiro</translation>
-<translation id="4882831918239250449">Controlar a forma como o histórico de navegação é utilizado para personalizar a Pesquisa, os anúncios e muito mais</translation>
-<translation id="4883854917563148705">As definições geridas não podem ser repostas</translation>
-<translation id="4885273946141277891">Número não suportado de instâncias do Chrome.</translation>
-<translation id="4910889077668685004">Aplicações de pagamento</translation>
-<translation id="4913161338056004800">Repor estatísticas</translation>
-<translation id="4913169188695071480">Parar a atualização</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Obter ajuda<ph name="END_LINK" /> enquanto procura dispositivos…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}other{# páginas}}</translation>
-<translation id="4932247056774066048">Uma vez que está a terminar sessão numa conta gerida pelo domínio <ph name="DOMAIN_NAME" />, os dados do Chrome serão eliminados deste dispositivo. Estes irão permanecer na sua Conta Google.</translation>
-<translation id="4943703118917034429">Realidade virtual</translation>
-<translation id="4943872375798546930">Nenhum resultado</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> está a partilhar o seu ecrã</translation>
-<translation id="4961107849584082341">Traduzir esta página para qualquer idioma</translation>
-<translation id="4962975101802056554">Revogar todas as autorizações do dispositivo</translation>
-<translation id="4970824347203572753">Não disponível na sua localização</translation>
-<translation id="497421865427891073">Avançar</translation>
-<translation id="4988210275050210843">A transferir ficheiro (<ph name="MEGABYTES" />)…</translation>
-<translation id="4988526792673242964">Páginas </translation>
-<translation id="4994033804516042629">Não foram encontrados contactos</translation>
-<translation id="4996978546172906250">Partilhar através de</translation>
-<translation id="5004416275253351869">Controlos da atividade Google</translation>
-<translation id="5005498671520578047">Copiar palavra-passe</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> pretende estabelecer ligação</translation>
-<translation id="5013696553129441713">Não existem novas sugestões.</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Enquanto estiver na RV, este site consegue saber:
-  -  as suas caraterísticas físicas, como a altura.
-
-Certifique-se de que confia neste site antes de entrar na RV.</translation>
+<translation id="2930742481329940825">A funcionalidade Tocar para pesquisar envia a palavra selecionada e a página atual como contexto para a Pesquisa Brave Software. Pode desativá-la nas <ph name="BEGIN_LINK"/>Definições<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Permitir</translation>
-<translation id="5040262127954254034">Privacidade</translation>
-<translation id="5048398596102334565">Permitir que os sites acedam aos sensores de movimentos (recomendado)</translation>
-<translation id="5063480226653192405">Utilização</translation>
-<translation id="5087580092889165836">Adicionar cartão</translation>
-<translation id="5100237604440890931">Reduzido. Clique para expandir.</translation>
-<translation id="510275257476243843">Falta 1 hora</translation>
-<translation id="5123685120097942451">Separador de navegação anónima</translation>
-<translation id="5127805178023152808">A sincronização está desativada</translation>
-<translation id="5129038482087801250">Instalar aplicação Web</translation>
-<translation id="5132942445612118989">Sincronize as suas palavras-passe, o histórico e muito mais em todos os dispositivos</translation>
-<translation id="5139940364318403933">Saiba como utilizar o Google Drive</translation>
-<translation id="515227803646670480">Limpar dados armazenados</translation>
-<translation id="5152843274749979095">Nenhuma aplicação compatível instalada</translation>
-<translation id="5161254044473106830">Título obrigatório</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 transferência com falha.}other{# transferências com falha.}}</translation>
-<translation id="5170568018924773124">Mostrar numa pasta</translation>
-<translation id="5184329579814168207">Abrir no Chrome</translation>
-<translation id="5193988420012215838">Copiado para a área de transferência.</translation>
-<translation id="5197729504361054390">Os contactos que selecionar serão partilhados com <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Perfil de trabalho</translation>
-<translation id="5210286577605176222">Ir para o separador anterior</translation>
-<translation id="5210365745912300556">Fechar separador</translation>
-<translation id="5224771365102442243">Com vídeo</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> pretende procurar dispositivos Bluetooth próximos. Foram encontrados os seguintes dispositivos:</translation>
-<translation id="5233638681132016545">Novo separador</translation>
-<translation id="526421993248218238">Não é possível carregar esta página.</translation>
-<translation id="5271967389191913893">O dispositivo não consegue abrir o conteúdo a transferir.</translation>
-<translation id="528192093759286357">Arraste a partir da parte superior e toque no botão de retrocesso para sair do ecrã inteiro.</translation>
-<translation id="5292796745632149097">Enviar para</translation>
-<translation id="5300589172476337783">Mostrar</translation>
-<translation id="5301954838959518834">OK, compreendi</translation>
-<translation id="5304593522240415983">Este campo não pode estar em branco</translation>
-<translation id="5307446750509046227">Limpar armazen. do site</translation>
-<translation id="5308380583665731573">Ligar</translation>
-<translation id="5313967007315987356">Adicionar site</translation>
-<translation id="5317780077021120954">Guardar</translation>
-<translation id="5324858694974489420">Definições parentais</translation>
-<translation id="5327248766486351172">Nome</translation>
-<translation id="5335288049665977812">Permitir que os sites executem JavaScript (recomendado)</translation>
-<translation id="5342314432463739672">Pedidos de autorização</translation>
-<translation id="5357811892247919462">Separador recebido</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> separador aberto, toque para alternar entre separadores}other{<ph name="OPEN_TABS_MANY" /> separadores abertos, toque para alternar entre separadores}}</translation>
-<translation id="5391532827096253100">A sua ligação a este site não é segura. Informações do site</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(mais 1)}other{(mais #)}}</translation>
-<translation id="5400569084694353794">Ao utilizar esta aplicação, concorda com os <ph name="BEGIN_LINK1" />Termos de Utilização<ph name="END_LINK1" /> e o <ph name="BEGIN_LINK2" />Aviso de Privacidade<ph name="END_LINK2" /> do Chrome.</translation>
-<translation id="5403592356182871684">Nomes</translation>
-<translation id="5403644198645076998">Permitir apenas determinados sites</translation>
-<translation id="5414836363063783498">A validar…</translation>
-<translation id="5423934151118863508">As páginas mais visitadas aparecem aqui</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB disponíveis</translation>
-<translation id="543338862236136125">Editar palavra-passe</translation>
-<translation id="5433691172869980887">Nome de utilizador copiado</translation>
-<translation id="543509235395288790">A transferir <ph name="COUNT" /> ficheiros (<ph name="MEGABYTES" />)…</translation>
-<translation id="5441522332038954058">Ir para a barra de endereço</translation>
-<translation id="5447201525962359567">Todo o armazenamento de sites, incluindo cookies e outros dados armazenados localmente</translation>
-<translation id="5447765697759493033">Este site não será traduzido.</translation>
-<translation id="545042621069398927">A acelerar a transferência…</translation>
-<translation id="5456381639095306749">Transferir página</translation>
-<translation id="5475862044948910901">Pretende iniciar a sessão de realidade aumentada?</translation>
-<translation id="548278423535722844">Abrir na aplicação de mapas</translation>
-<translation id="5487521232677179737">Limpar dados</translation>
-<translation id="5494752089476963479">Bloquear anúncios em sites que apresentam anúncios intrusivos ou enganadores</translation>
-<translation id="5500777121964041360">Pode não estar disponível na sua localização</translation>
-<translation id="5512137114520586844">Esta conta é gerida por <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Desativada pelo gestor do dispositivo</translation>
-<translation id="5515439363601853141">Desbloqueie para ver a palavra-passe.</translation>
-<translation id="5516455585884385570">Abrir definições de notificação</translation>
-<translation id="5517095782334947753">Tem marcadores, histórico, palavras-passe e outras definições de <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Redirecionamento bloqueado.</translation>
-<translation id="5527082711130173040">O Chrome precisa de acesso à localização para procurar dispositivos. <ph name="BEGIN_LINK1" />Atualize as autorizações<ph name="END_LINK1" />. O acesso à localização também está <ph name="BEGIN_LINK2" />desativado para este dispositivo<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Perguntar antes de autorizar os sites a ler texto e imagens da área de transferência (recomendado).</translation>
-<translation id="5530766185686772672">Fechar sep. de naveg. anón.</translation>
-<translation id="5534334044554683961">Enquanto estiver na RV, este site consegue saber:
-  -   as suas caraterísticas físicas, como a altura;
-  -   a disposição do seu quarto.
-
-Certifique-se de que confia neste site antes de entrar na RV.</translation>
-<translation id="5534640966246046842">Site copiado</translation>
-<translation id="5556459405103347317">Recarregar</translation>
-<translation id="5561549206367097665">A aguardar pela rede...</translation>
-<translation id="557283862590186398">O Chrome necessita de autorização de acesso ao microfone para este site.</translation>
-<translation id="55737423895878184">A localização e as notificações são permitidas.</translation>
-<translation id="5578795271662203820">Pesquisar a imagem no <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Pode escolher o que pretende sincronizar nas <ph name="BEGIN_LINK1" />definições<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Editar morada</translation>
-<translation id="5596627076506792578">Mais opções</translation>
-<translation id="5599455543593328020">Modo de navegação anónima</translation>
-<translation id="5620928963363755975">Encontre os seus ficheiros e páginas nas Transferências através do botão Mais opções.</translation>
-<translation id="5626134646977739690">Nome:</translation>
-<translation id="5639724618331995626">Permitir todos os sites</translation>
-<translation id="5648166631817621825">Últimos 7 dias</translation>
-<translation id="5649053991847567735">Transferências automáticas</translation>
-<translation id="5655963694829536461">Pesquisar as suas transferências</translation>
-<translation id="5659593005791499971">Email</translation>
-<translation id="5665379678064389456">Criar evento no <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Substituir pedido de um Website para evitar aumentar o zoom</translation>
-<translation id="5677928146339483299">Bloqueado</translation>
-<translation id="5684874026226664614">Ups! Não foi possível traduzir esta página.</translation>
-<translation id="5686790454216892815">O nome do ficheiro é demasiado longo</translation>
-<translation id="5689516760719285838">Local</translation>
-<translation id="569536719314091526">Traduzir esta página para qualquer idioma a partir do botão Mais opções</translation>
-<translation id="572328651809341494">Separadores recentes</translation>
-<translation id="5726692708398506830">Aumentar o tamanho de todos os itens na página</translation>
-<translation id="5748802427693696783">Mudado para separadores padrão</translation>
-<translation id="5749068826913805084">O Chrome necessita de acesso ao armazenamento para transferir ficheiros.</translation>
-<translation id="5763382633136178763">Separadores de navegação anónima</translation>
-<translation id="5763514718066511291">Toque para copiar o URL desta aplicação.</translation>
-<translation id="5765780083710877561">Descrição:</translation>
-<translation id="5793665092639000975">A utilizar <ph name="SPACE_USED" /> de <ph name="SPACE_AVAILABLE" />.</translation>
-<translation id="5797070761912323120">A Google pode utilizar o seu histórico para personalizar a Pesquisa, os anúncios e outros serviços Google.</translation>
-<translation id="5804241973901381774">Permissões</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Há # hora}other{Há # horas}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Todos os direitos reservados.</translation>
-<translation id="5817918615728894473">Sincronizar</translation>
-<translation id="583281660410589416">Desconhecido</translation>
-<translation id="5833984609253377421">Partilhar link</translation>
-<translation id="5836192821815272682">A transferir a atualização do Chrome…</translation>
-<translation id="5853623416121554550">em pausa</translation>
-<translation id="5854790677617711513">Com mais de 30 dias</translation>
-<translation id="5858741533101922242">O Chrome não consegue ativar o adaptador Bluetooth</translation>
-<translation id="5860033963881614850">Desativado</translation>
-<translation id="5862731021271217234">Para obter os separadores dos seus outros dispositivos, ative a sincronização.</translation>
-<translation id="5864174910718532887">Detalhes: ordenado por nome do site</translation>
-<translation id="5864419784173784555">A aguardar por outra transferência…</translation>
-<translation id="5865733239029070421">Envia automaticamente estatísticas de utilização e relatórios de falhas para a Google.</translation>
-<translation id="5869522115854928033">Palavras-passe guardadas</translation>
-<translation id="5902828464777634901">Todos os dados armazenados por este Website, incluindo cookies, são eliminados.</translation>
-<translation id="5916664084637901428">Ativado</translation>
-<translation id="5919204609460789179">Atualizar <ph name="PRODUCT_NAME" /> para iniciar a sincronização</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> poupado(s)</translation>
-<translation id="5939518447894949180">Repor</translation>
-<translation id="5942872142862698679">A utilizar o Google para pesquisa</translation>
-<translation id="5952764234151283551">Envia para a Google o URL de uma página à qual esteja a tentar aceder.</translation>
-<translation id="5956665950594638604">Abrir Centro de Ajuda do Chrome num novo separador</translation>
-<translation id="5958275228015807058">Encontre os seus ficheiros e páginas nas Transferências.</translation>
-<translation id="5962718611393537961">Toque para reduzir</translation>
-<translation id="6000066717592683814">Manter o Google</translation>
-<translation id="6005538289190791541">Palavra-passe sugerida</translation>
-<translation id="6036057147555329831">ICU extra</translation>
-<translation id="6039379616847168523">Ir para o próximo separador</translation>
-<translation id="6040143037577758943">Fechar</translation>
-<translation id="6042308850641462728">Mais</translation>
-<translation id="604996488070107836">A transferência de <ph name="FILE_NAME" /> falhou devido a um erro desconhecido.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Transferências concluídas</translation>
-<translation id="6075798973483050474">Editar página inicial</translation>
-<translation id="60923314841986378">Faltam <ph name="HOURS" /> horas</translation>
-<translation id="6108923351542677676">Configuração em curso…</translation>
-<translation id="6111020039983847643">dados utilizados</translation>
-<translation id="6112702117600201073">A atualizar a página</translation>
-<translation id="6127379762771434464">Item removido</translation>
-<translation id="6140912465461743537">País/região</translation>
-<translation id="614940544461990577">Experimente:</translation>
-<translation id="6154478581116148741">Ative o bloqueio de ecrã nas Definições para exportar as suas palavras-passe a partir deste dispositivo.</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> de poupança de dados</translation>
-<translation id="6165508094623778733">Saiba mais</translation>
-<translation id="6177111841848151710">Bloqueado para o motor de pesquisa atual</translation>
-<translation id="6181444274883918285">Adicionar exceção de site</translation>
-<translation id="6192333916571137726">Transferir ficheiro</translation>
-<translation id="6192792657125177640">Excepções</translation>
-<translation id="6194112207524046168">Para permitir que o Chrome aceda à câmara, ative também a câmara nas <ph name="BEGIN_LINK" />Definições do Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Bloquear cookies de terceiros</translation>
-<translation id="6206551242102657620">A ligação é segura. Informações do site</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> não é o seu email?</translation>
-<translation id="6221633008163990886">Desbloqueie para exportar as palavras-passe.</translation>
+<translation id="1406000523432664303">"Não monitorizar"</translation>
 <translation id="6232535412751077445">A ativação da funcionalidade "Não Monitorizar" significa que é incluído um pedido no seu tráfego de navegação. Qualquer efeito depende de um Website responder ou não ao pedido e do modo como o pedido é interpretado.
 
 Por exemplo, alguns Sites podem responder a este pedido ao mostrar-lhe anúncios que não são baseados noutros Sites que tenha visitado. Ainda assim, muitos Sites continuam a recolher e a utilizar os seus dados de navegação para, por exemplo, melhorar a segurança, fornecer conteúdo, anúncios e recomendações, e gerar estatísticas de relatórios.</translation>
-<translation id="624789221780392884">Atualização pronta</translation>
-<translation id="6255999984061454636">Sugestões de conteúdo</translation>
-<translation id="6277522088822131679">Ocorreu um problema ao imprimir a página. Tente novamente.</translation>
-<translation id="6295158916970320988">Todos os sites</translation>
-<translation id="629730747756840877">Conta</translation>
-<translation id="6303969859164067831">Terminar sessão e desativar a sincronização</translation>
-<translation id="6316139424528454185">Versão Android não suportada.</translation>
-<translation id="6320088164292336938">Vibrar</translation>
-<translation id="6324034347079777476">Sincronização do sistema Android desativada</translation>
-<translation id="6333140779060797560">Partilhar através de <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Encriptação</translation>
-<translation id="6341580099087024258">Perguntar onde guardar os ficheiros</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Pretende remover a sugestão do histórico?</translation>
-<translation id="6369229450655021117">A partir daqui, pode pesquisar na Web, partilhar com amigos e ver as páginas abertas.</translation>
-<translation id="6378173571450987352">Detalhes: ordenado por quantidade de dados utilizados</translation>
-<translation id="6381421346744604172">Escurecer Websites</translation>
-<translation id="6388207532828177975">Limpar e repor</translation>
-<translation id="6393863479814692971">O Chrome necessita de autorização de acesso à câmara e ao microfone para este site.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Editar marcador</translation>
-<translation id="6406506848690869874">Sincronização</translation>
-<translation id="641643625718530986">Imprimir…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB transferido(s)</translation>
-<translation id="6427112570124116297">Traduzir a Web</translation>
-<translation id="6433501201775827830">Escolher o motor de pesquisa</translation>
-<translation id="6437478888915024427">Informações da página</translation>
-<translation id="6441734959916820584">O nome é demasiado longo</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagem}other{# imagens}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Não é possível abrir o ficheiro</translation>
-<translation id="6464977750820128603">Pode ver os sites que visita no Chrome e definir temporizadores para os mesmos.\n\nA Google obtém informações sobre os sites para os quais define temporizadores e durante quanto tempo os visita. Estas informações são utilizadas para melhorar o Bem-estar digital.</translation>
-<translation id="6475951671322991020">Transferir vídeo</translation>
-<translation id="6482749332252372425">A transferência de <ph name="FILE_NAME" /> falhou devido à falta de espaço de armazenamento.</translation>
-<translation id="6496823230996795692">Para utilizar a aplicação <ph name="APP_NAME" /> pela primeira vez, ligue-se à Internet.</translation>
-<translation id="6508722015517270189">Reiniciar o Chrome</translation>
-<translation id="6527303717912515753">Partilhar</translation>
-<translation id="6532866250404780454">Os sites que visitar no Chrome não serão apresentados. Todos os temporizadores do site serão eliminados.</translation>
-<translation id="6534565668554028783">A Google demorou demasiado tempo a responder</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB transferido(s)</translation>
-<translation id="6539092367496845964">Ocorreu um erro. Tente novamente mais tarde.</translation>
-<translation id="654446541061731451">Selecione um separador a transmitir</translation>
-<translation id="6545017243486555795">Limpar todos os dados</translation>
-<translation id="6545864417968258051">Procura de Bluetooth</translation>
-<translation id="6560414384669816528">Pesquisar com o Sogou</translation>
-<translation id="6566259936974865419">O Chrome permitiu-lhe poupar <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Permitir sempre</translation>
-<translation id="6573431926118603307">Os separadores que abriu no Chrome nos seus outros dispositivos são apresentados aqui.</translation>
-<translation id="6583199322650523874">Adicionar a página atual aos marcadores</translation>
-<translation id="6593061639179217415">Site para computador</translation>
-<translation id="6600954340915313787">Copiado para o Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Conteúdo protegido</translation>
-<translation id="6627583120233659107">Editar pasta</translation>
-<translation id="6643016212128521049">Limpar</translation>
-<translation id="6643649862576733715">Ordenar por quantidade de dados poupados</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Pré-visualizar imagem <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">O Chrome necessita de acesso à localização para procurar dispositivos. <ph name="BEGIN_LINK" />Atualizar autorizações<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Palavra-passe</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Abrir no <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Aviso de privacidade do Chrome</translation>
-<translation id="6676840375528380067">Pretende limpar os dados do Chrome deste dispositivo?</translation>
-<translation id="6697492270171225480">Mostrar sugestões de páginas semelhantes se não for possível encontrar uma página</translation>
-<translation id="6697947395630195233">O Chrome precisa de acesso à sua localização para a partilhar com este site.</translation>
-<translation id="6698801883190606802">Gerir dados sincronizados</translation>
-<translation id="6699370405921460408">Os servidores da Google vão otimizar as páginas que visitar.</translation>
-<translation id="6706288973712894588">De momento, está offline.\n<ph name="BEGIN_LINK" />Explore o seu feed offline.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Notícias</translation>
-<translation id="6710213216561001401">Anterior</translation>
-<translation id="671481426037969117">O temporizador da aplicação <ph name="FQDN" /> terminou. Recomeça amanhã.</translation>
-<translation id="6738867403308150051">A transferir...</translation>
-<translation id="6746124502594467657">Mover para baixo</translation>
-<translation id="6766622839693428701">Deslize rapidamente para baixo para fechar.</translation>
-<translation id="6766758767654711248">Toque para aceder ao site.</translation>
-<translation id="6767294960381293877">Lista de dispositivos com os quais pretende partilhar um separador aberta a meia altura.</translation>
-<translation id="6782111308708962316">Impedir que os Sites de terceiros guardem e leiam dados de cookies</translation>
-<translation id="6790428901817661496">Reproduzir</translation>
-<translation id="6811034713472274749">A página está preparada para ser visualizada</translation>
-<translation id="6818926723028410516">Selecionar itens</translation>
-<translation id="6820686453637990663">Código de segurança</translation>
-<translation id="6831043979455480757">Traduzir</translation>
-<translation id="6845325883481699275">Ajudar a melhorar a segurança do Chrome</translation>
-<translation id="6846298663435243399">A carregar…</translation>
-<translation id="6850409657436465440">A transferência ainda está em curso.</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> separadores fechados</translation>
-<translation id="6864459304226931083">Transferir imagem</translation>
-<translation id="6865313869410766144">Dados de formulário de Preenchimento automático</translation>
-<translation id="688738109438487280">Adicionar dados existentes a <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Desbloqueie para copiar a palavra-passe.</translation>
-<translation id="6896758677409633944">Copiar</translation>
-<translation id="6910211073230771657">Eliminado</translation>
-<translation id="6912998170423641340">Impedir sites de lerem texto e imagens da área de transferência</translation>
-<translation id="6914783257214138813">As suas palavras-passe serão visíveis para todas as pessoas que consigam ver o ficheiro exportado.</translation>
-<translation id="6942665639005891494">Altere a localização de transferência predefinida em qualquer altura ao utilizar a opção do menu Definições.</translation>
-<translation id="6945221475159498467">Selecionar</translation>
-<translation id="6963642900430330478">Esta página é perigosa. Informações do site</translation>
-<translation id="6963766334940102469">Eliminar marcadores</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Sempre</translation>
-<translation id="6981982820502123353">Acessibilidade</translation>
-<translation id="6989267951144302301">Impossível transferir.</translation>
-<translation id="6990079615885386641">Obter a aplicação na Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Perguntar antes de permitir que os sites utilizem o microfone (recomendado)</translation>
-<translation id="7015203776128479407">A configuração da sincronização inicial não foi concluída. A sincronização está desativada.</translation>
-<translation id="7016516562562142042">Permitido para o motor de pesquisa atual</translation>
-<translation id="7022756207310403729">Abrir no navegador</translation>
-<translation id="702463548815491781">Recomendado quando o TalkBack ou o Acesso por comutador estão ativados.</translation>
-<translation id="7029809446516969842">Palavras-passe</translation>
-<translation id="7053983685419859001">Bloquear</translation>
-<translation id="7055152154916055070">Redirecionamento bloqueado:</translation>
-<translation id="7063006564040364415">Não foi possível estabelecer ligação ao servidor de sincronização.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selecionado}other{# selecionados}}</translation>
-<translation id="7071521146534760487">Gerir conta</translation>
-<translation id="7077143737582773186">Cartão SD</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> selecionado(s). Opções disponíveis junto à parte superior do ecrã.</translation>
-<translation id="7121362699166175603">Limpa o histórico e os preenchimentos automáticos na barra de endereço. A sua Conta Google pode ter outras formas do histórico de navegação em <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Permitir o motor de pesquisa atual</translation>
-<translation id="7138678301420049075">Outros</translation>
-<translation id="7141896414559753902">Impedir que os sites apresentem pop-ups e redirecionamentos (recomendado).</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Carregar página original<ph name="END_LINK" /> do domínio <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Últimas 24 horas</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Pode alterar esta opção mais tarde nas Definições</translation>
-<translation id="7180611975245234373">Atualizar</translation>
-<translation id="7189372733857464326">A aguardar pela conclusão da atualização dos Serviços do Google Play…</translation>
-<translation id="7191430249889272776">Separador aberto em segundo plano.</translation>
-<translation id="723171743924126238">Selecionar imagens</translation>
-<translation id="7233236755231902816">Para ver a Web no seu idioma, obtenha a versão mais recente do Chrome.</translation>
-<translation id="7243308994586599757">Opções disponíveis junto à parte inferior do ecrã</translation>
-<translation id="7248069434667874558">Certifique-se de que o <ph name="TARGET_DEVICE_NAME" /> tem a sincronização ativada no Chrome.</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> selecionado(s).</translation>
-<translation id="7274013316676448362">Site bloqueado</translation>
-<translation id="7290209999329137901">Opção de mudar o nome não disponível</translation>
-<translation id="7291387454912369099">Assistente para o Preenchimento automático</translation>
-<translation id="7293171162284876153">Para iniciar a sincronização, ative a opção "Sincronizar dados do Chrome".</translation>
-<translation id="729975465115245577">O dispositivo não tem uma aplicação para armazenar o ficheiro de palavras-passe.</translation>
-<translation id="7302081693174882195">Detalhes: ordenado por quantidade de dados guardados</translation>
-<translation id="7328017930301109123">No Modo Lite, o Chrome carrega páginas mais rapidamente e utiliza até menos 60 por cento de dados.</translation>
-<translation id="7333031090786104871">Ainda a adicionar o site anterior…</translation>
-<translation id="7352939065658542140">VÍDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Partilhar 1 item selecionado}other{Partilhar # itens selecionados}}</translation>
 <translation id="7359002509206457351">Aceder aos métodos de pagamento</translation>
+<translation id="8026334261755873520">Limpar dados de navegação</translation>
+<translation id="1291207594882862231">Limpar histórico, cookies, dados de sites, cache…</translation>
+<translation id="7814200940910057384">Dados do Brave limpos</translation>
+<translation id="1664855196866195614">Os dados selecionados foram removidos do Brave e dos dispositivos sincronizados.
+
+A sua Conta Brave Software pode ter outras formas do histórico de navegação, como pesquisas e atividade de outros serviços Brave Software, em <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Imagens e ficheiros em cache</translation>
+<translation id="2496180316473517155">Histórico de navegação</translation>
+<translation id="2546283357679194313">Cookies e dados de Web sites</translation>
+<translation id="8662811608048051533">A sua sessão é terminada na maioria dos sites.</translation>
+<translation id="8218628800671693884">A sua sessão é terminada na maioria dos sites. A sessão na sua Conta Brave Software não é terminada.</translation>
+<translation id="2017836877785168846">Limpa o histórico e os preenchimentos automáticos da barra de endereço.</translation>
+<translation id="8096327394278038498">Limpa o histórico e os preenchimentos automáticos na barra de endereço. A sua Conta Brave Software pode ter outras formas do histórico de navegação em <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Limpa o histórico de todos os dispositivos com sessão iniciada. A sua Conta Brave Software pode ter outras formas do histórico de navegação em <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Palavras-passe guardadas</translation>
+<translation id="6865313869410766144">Dados de formulário de Preenchimento automático</translation>
+<translation id="7562080006725997899">A limpar dados de navegação</translation>
+<translation id="5487521232677179737">Limpar dados</translation>
+<translation id="7498271377022651285">Aguarde…</translation>
+<translation id="784934925303690534">Intervalo de tempo</translation>
+<translation id="1718835860248848330">Última hora</translation>
+<translation id="7149893636342594995">Últimas 24 horas</translation>
+<translation id="5648166631817621825">Últimos 7 dias</translation>
+<translation id="8571213806525832805">Últimas 4 semanas</translation>
+<translation id="5854790677617711513">Com mais de 30 dias</translation>
+<translation id="6979737339423435258">Sempre</translation>
+<translation id="982182592107339124">Esta ação limpa os dados de todos os sites, incluindo:</translation>
+<translation id="6643016212128521049">Limpar</translation>
+<translation id="7641339528570811325">Limpar dados de navegação…</translation>
+<translation id="1670399744444387456">Básico</translation>
+<translation id="3245261285041759672">A sua Conta Brave Software pode ter outras formas do histórico de navegação em <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Site bloqueado</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> itens eliminados</translation>
+<translation id="1121094540300013208">Relatórios de utilização e falhas</translation>
+<translation id="9079153198295609735">Enviar automaticamente estatísticas de utilização e relatórios de falhas para a Brave Software</translation>
+<translation id="6981982820502123353">Acessibilidade</translation>
+<translation id="2387895666653383613">Escala do texto</translation>
+<translation id="2321958826496381788">Arraste o controlo de deslize até conseguir ler confortavelmente. O texto deve ter, pelo menos, este tamanho depois de tocar duas vezes num parágrafo.</translation>
+<translation id="3895926599014793903">Forçar ativação do zoom</translation>
+<translation id="5668404140385795438">Substituir pedido de um Website para evitar aumentar o zoom</translation>
+<translation id="4149994727733219643">Vista simplificada de páginas Web</translation>
+<translation id="9100505651305367705">Sugerir a apresentação de artigos na vista simplificada, quando suportada</translation>
+<translation id="1409426117486808224">Vista simplificada dos separadores abertos</translation>
+<translation id="702463548815491781">Recomendado quando o TalkBack ou o Acesso por comutador estão ativados.</translation>
+<translation id="8284326494547611709">Legendas</translation>
+<translation id="4165986682804962316">Definições de sites</translation>
+<translation id="6295158916970320988">Todos os sites</translation>
+<translation id="8380167699614421159">Este site apresenta anúncios intrusivos ou enganadores.</translation>
+<translation id="1919345977826869612">Anúncios</translation>
+<translation id="410351446219883937">Reprodução automática</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Bloquear cookies de terceiros</translation>
+<translation id="6782111308708962316">Impedir que os Sites de terceiros guardem e leiam dados de cookies</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-ups e redirecionamentos</translation>
+<translation id="4751476147751820511">Sensores de movimento ou de luz</translation>
+<translation id="1717218214683051432">Sensores de movimento</translation>
+<translation id="2091887806945687916">Som</translation>
+<translation id="2586657967955657006">Área de transferência</translation>
+<translation id="6320088164292336938">Vibrar</translation>
+<translation id="4226663524361240545">As notificações podem fazer com que o dispositivo vibre</translation>
+<translation id="1446450296470737166">Perm. controlo total dispo. MIDI</translation>
+<translation id="3744111561329211289">Sincronização em segundo plano</translation>
+<translation id="5649053991847567735">Transferências automáticas</translation>
+<translation id="6181444274883918285">Adicionar exceção de site</translation>
+<translation id="5313967007315987356">Adicionar site</translation>
+<translation id="1369915414381695676">Site <ph name="SITE_NAME"/> adicionado</translation>
+<translation id="7837721118676387834">Permitir a reprodução automática dos vídeos ignorados para um site específico.</translation>
+<translation id="2621115761605608342">Permitir JavaScript num site específico.</translation>
+<translation id="8801436777607969138">Bloqueie JavaScript num site específico.</translation>
+<translation id="8372893542064058268">Permitir Sincronização em segundo plano num site específico.</translation>
+<translation id="358794129225322306">Permitir que um site transfira vários ficheiros automaticamente.</translation>
+<translation id="4008040567710660924">Permita cookies para um site específico.</translation>
+<translation id="8958424370300090006">Bloqueie cookies para um site específico.</translation>
+<translation id="7882806643839505685">Permita a reprodução de som de um site específico.</translation>
+<translation id="4468959413250150279">Desative o som de um site específico.</translation>
+<translation id="1994173015038366702">URL do site</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Utilização</translation>
+<translation id="5804241973901381774">Permissões</translation>
+<translation id="4278390842282768270">Permitido</translation>
+<translation id="5677928146339483299">Bloqueado</translation>
+<translation id="1984937141057606926">Permitidos, exceto de terceiros</translation>
+<translation id="7423098979219808738">Perguntar primeiro</translation>
+<translation id="8116925261070264013">Com som desativado</translation>
+<translation id="8300705686683892304">Geridos por aplicação</translation>
+<translation id="6192792657125177640">Excepções</translation>
+<translation id="257931822824936280">Expandido. Clique para reduzir.</translation>
+<translation id="5100237604440890931">Reduzido. Clique para expandir.</translation>
+<translation id="857943718398505171">Permitido (recomendado)</translation>
+<translation id="2913331724188855103">Permitir que os sites guardem e leiam dados de cookies (recomendado)</translation>
+<translation id="7445411102860286510">Permitir que os sites reproduzam automaticamente vídeos com o som desativado (recomendado)</translation>
+<translation id="5335288049665977812">Permitir que os sites executem JavaScript (recomendado)</translation>
+<translation id="5527111080432883924">Perguntar antes de autorizar os sites a ler texto e imagens da área de transferência (recomendado).</translation>
+<translation id="6912998170423641340">Impedir sites de lerem texto e imagens da área de transferência</translation>
+<translation id="7423538860840206698">Leitura da área de transferência bloqueada</translation>
+<translation id="3955193568934677022">Permitir que os sites reproduzam conteúdo protegido (recomendado)</translation>
+<translation id="445467742685312942">Permitir que os sites reproduzam conteúdos protegidos</translation>
+<translation id="2107397443965016585">Perguntar antes de permitir que os sites reproduzam conteúdos protegidos (recomendado)</translation>
+<translation id="2910701580606108292">Perguntar antes de permitir que os sites reproduzam conteúdos protegidos</translation>
+<translation id="757524316907819857">Impedir que os sites reproduzam conteúdos protegidos</translation>
+<translation id="3277252321222022663">Permitir que os sites acedam aos sensores (recomendado)</translation>
+<translation id="5048398596102334565">Permitir que os sites acedam aos sensores de movimentos (recomendado)</translation>
+<translation id="8816026460808729765">Impedir que os sites acedam aos sensores</translation>
+<translation id="169515064810179024">Impedir que os sites acedam aos sensores de movimentos</translation>
+<translation id="1660204651932907780">Permitir que os sites reproduzam som (recomendado)</translation>
+<translation id="3600792891314830896">Desativar o som dos sites que reproduzem som</translation>
+<translation id="1743802530341753419">Perguntar antes de permitir a ligação de sites a um dispositivo (recomendado)</translation>
+<translation id="851751545965956758">Impedir a ligação de sites a dispositivos</translation>
+<translation id="7141896414559753902">Impedir que os sites apresentem pop-ups e redirecionamentos (recomendado).</translation>
+<translation id="5494752089476963479">Bloquear anúncios em sites que apresentam anúncios intrusivos ou enganadores</translation>
+<translation id="3123473560110926937">Bloqueado em alguns sites.</translation>
+<translation id="965817943346481315">Bloquear se o site apresentar anúncios intrusivos ou enganadores (recomendado)</translation>
+<translation id="3386292677130313581">Perguntar antes de permitir que os sites conheçam a sua localização (recomendado)</translation>
+<translation id="9139068048179869749">Perguntar antes de permitir que os sites enviem notificações (recomendado)</translation>
+<translation id="4479647676395637221">Perguntar antes de permitir que os sites utilizem a câmara (recomendado)</translation>
+<translation id="6992289844737586249">Perguntar antes de permitir que os sites utilizem o microfone (recomendado)</translation>
+<translation id="2289270750774289114">Perguntar quando um site pretende detetar dispositivos Bluetooth próximos (recomendado)</translation>
+<translation id="7053983685419859001">Bloquear</translation>
+<translation id="7128222689758636196">Permitir o motor de pesquisa atual</translation>
+<translation id="7589445247086920869">Bloquear o motor de pesquisa atual</translation>
+<translation id="6388207532828177975">Limpar e repor</translation>
+<translation id="7999064672810608036">Tem a certeza de que pretende limpar todos os dados locais, incluindo cookies, e repor todas as autorizações para este Website?</translation>
+<translation id="2822354292072154809">Tem a certeza de que pretende repor todas as autorizações do site para <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Limpar dados armazenados</translation>
+<translation id="5902828464777634901">Todos os dados armazenados por este Website, incluindo cookies, são eliminados.</translation>
+<translation id="119944043368869598">Limpar tudo</translation>
+<translation id="2490684707762498678">Gerido por <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Abrir definições de notificação</translation>
+<translation id="1404122904123200417">Incorporado em <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Os ficheiros guardados por Websites são apresentados aqui.</translation>
+<translation id="4181841719683918333">Idiomas</translation>
+<translation id="2647434099613338025">Adicionar idioma</translation>
+<translation id="1952172573699511566">Quando possível, os Websites apresentam o texto no seu idioma preferido.</translation>
+<translation id="8559990750235505898">Propor a tradução de páginas noutros idiomas</translation>
+<translation id="4719927025381752090">Propor tradução</translation>
+<translation id="8156139159503939589">Que idiomas lê?</translation>
+<translation id="5689516760719285838">Local</translation>
+<translation id="2440823041667407902">Acesso à localização</translation>
+<translation id="2023546461831060654">Ative as autorizações para o Brave nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Ative a autorização para o Brave nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Para permitir que o Brave aceda à sua localização, ative também a localização nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Para permitir que o Brave aceda à câmara, ative também a câmara nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Para permitir que o Brave lhe envie notificações, ative também as notificações nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Para permitir que o Brave aceda ao microfone, ative também o microfone nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">O acesso à localização está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">O acesso à localização também está desativado para este dispositivo. Ative-o nas <ph name="BEGIN_LINK"/>Definições do Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Câmara</translation>
+<translation id="3227137524299004712">Microfone</translation>
+<translation id="1647391597548383849">Aceder à câmara</translation>
+<translation id="945632385593298557">Aceder ao microfone</translation>
+<translation id="6612358246767739896">Conteúdo protegido</translation>
+<translation id="885701979325669005">Armazenamento</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> de dados armazenados</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revogar autorização do dispositivo</translation>
+<translation id="4962975101802056554">Revogar todas as autorizações do dispositivo</translation>
+<translation id="6545864417968258051">Procura de Bluetooth</translation>
+<translation id="4411535500181276704">Modo Lite</translation>
+<translation id="7821588508402923572">A sua poupança de dados é apresentada aqui</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> guardado(s)</translation>
+<translation id="8569404424186215731">desde <ph name="DATE"/></translation>
+<translation id="3252158532344029638">No Modo Lite, o Brave carrega páginas mais rapidamente e utiliza até menos 60 por cento de dados.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> de poupança de dados</translation>
+<translation id="7494974237137038751">dados guardados</translation>
+<translation id="6111020039983847643">dados utilizados</translation>
+<translation id="7413229368719586778">Data de início: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Data de conclusão: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Ordenar por site</translation>
+<translation id="5864174910718532887">Detalhes: ordenado por nome do site</translation>
+<translation id="116280672541001035">Utilizados</translation>
+<translation id="8349013245300336738">Ordenar por quantidade de dados utilizados</translation>
+<translation id="6378173571450987352">Detalhes: ordenado por quantidade de dados utilizados</translation>
+<translation id="2631006050119455616">Guardado</translation>
+<translation id="6643649862576733715">Ordenar por quantidade de dados poupados</translation>
+<translation id="7302081693174882195">Detalhes: ordenado por quantidade de dados guardados</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> utilizado(s)</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> poupado(s)</translation>
+<translation id="2156074688469523661">Sites restantes (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Outros</translation>
+<translation id="4913161338056004800">Repor estatísticas</translation>
+<translation id="1856325424225101786">Pretende repor o Modo Lite?</translation>
+<translation id="3658159451045945436">A reposição apaga o histórico da poupança de dados, incluindo a lista de sites visitados.</translation>
+<translation id="3295530008794733555">Navegue mais depressa. Utilize menos dados.</translation>
+<translation id="7340390500800578919">No Modo Lite, o Brave carrega páginas mais rapidamente e utiliza até menos 60 por cento de dados. Para otimizar as páginas que vista, o Brave envia o seu tráfego da Web para a Brave Software. <ph name="BEGIN_LINK"/>Saiba mais<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Ativar o Modo Lite</translation>
+<translation id="4493497663118223949">O Modo Lite está ativado.</translation>
+<translation id="7559975015014302720">O Modo Lite está desativado.</translation>
+<translation id="7606077192958116810">O Modo Lite está ativado. Pode geri-lo nas Definições.</translation>
+<translation id="4714588616299687897">Poupe até 60% dos seus dados</translation>
+<translation id="1006927014032731288">Os servidores da Brave Software vão otimizar as páginas que visitar.</translation>
+<translation id="3257320067425202300">O Brave permitiu-lhe poupar <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">O Brave permitiu-lhe poupar <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Localização da transferência</translation>
+<translation id="7077143737582773186">Cartão SD</translation>
+<translation id="7762668264895820836">Cartão SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Perguntar onde guardar os ficheiros</translation>
+<translation id="6192333916571137726">Transferir ficheiro</translation>
+<translation id="1672586136351118594">Não mostrar de novo</translation>
+<translation id="2650751991977523696">Pretende transferir o ficheiro novamente?</translation>
+<translation id="8664979001105139458">O nome do ficheiro já existe</translation>
+<translation id="488187801263602086">Mudar o nome do ficheiro</translation>
+<translation id="5686790454216892815">O nome do ficheiro é demasiado longo</translation>
+<translation id="7454641608352164238">Espaço insuficiente</translation>
+<translation id="8972098258593396643">Pretende transferir para a pasta predefinida?</translation>
+<translation id="804335162455518893">Cartão SD não encontrado.</translation>
+<translation id="7475688122056506577">Cartão SD não encontrado. Alguns dos seus ficheiros poderão estar em falta.</translation>
+<translation id="4198423547019359126">Não existem localizações de transferência disponíveis.</translation>
+<translation id="8224471946457685718">Transferir artigos para si com Wi-Fi</translation>
+<translation id="4970824347203572753">Não disponível na sua localização</translation>
+<translation id="5500777121964041360">Pode não estar disponível na sua localização</translation>
+<translation id="1173894706177603556">Mudar nome</translation>
+<translation id="1986685561493779662">O nome já existe</translation>
+<translation id="6441734959916820584">O nome é demasiado longo</translation>
+<translation id="2923908459366352541">O nome é inválido</translation>
+<translation id="7290209999329137901">Opção de mudar o nome não disponível</translation>
+<translation id="3334729583274622784">Pretende alterar a extensão de ficheiro?</translation>
+<translation id="107147699690128016">Se alterar a extensão do ficheiro, este pode ser aberto numa aplicação diferente e representar um risco para o seu dispositivo.</translation>
+<translation id="8541922081612557424">Acerca do Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Todos os direitos reservados.</translation>
+<translation id="1416550906796893042">Versão da aplicação</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (atualizado há <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistema operativo</translation>
+<translation id="3968054912784331254">As atualizações do Brave já não são suportadas para esta versão do Android.</translation>
+<translation id="7665369617277396874">Adicionar conta</translation>
+<translation id="649070405679044769">Iniciou sessão no Brave Software como</translation>
+<translation id="6234515504547364178">Terminar sessão no Brave</translation>
+<translation id="5324858694974489420">Definições parentais</translation>
+<translation id="8920114477895755567">A aguardar os detalhes dos pais.</translation>
+<translation id="5512137114520586844">Esta conta é gerida por <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Esta conta é gerida por <ph name="PARENT_NAME_1"/> e por <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Conteúdo</translation>
+<translation id="5403644198645076998">Permitir apenas determinados sites</translation>
+<translation id="8641930654639604085">Tentar bloquear sites para adultos</translation>
+<translation id="5639724618331995626">Permitir todos os sites</translation>
+<translation id="796823723482603597">Com tecnologia do Brave</translation>
+<translation id="6324034347079777476">Sincronização do sistema Android desativada</translation>
+<translation id="5127805178023152808">A sincronização está desativada</translation>
+<translation id="7015203776128479407">A configuração da sincronização inicial não foi concluída. A sincronização está desativada.</translation>
+<translation id="2497852260688568942">A sincronização foi desativada pelo gestor</translation>
+<translation id="9100610230175265781">Frase de acesso obrigatória</translation>
+<translation id="6108923351542677676">Configuração em curso…</translation>
+<translation id="4062305924942672200">Informações legais</translation>
+<translation id="4256782883801055595">Licenças de código aberto</translation>
+<translation id="1138681184697033370">Termos de Utilização do Brave</translation>
+<translation id="7392539049993970338">Aviso de privacidade do Brave</translation>
+<translation id="2677748264148917807">Sair</translation>
+<translation id="5556459405103347317">Recarregar</translation>
+<translation id="1623104350909869708">Evitar que esta página crie caixas de diálogo adicionais</translation>
+<translation id="2968755619301702150">Visualizador de certificados</translation>
+<translation id="1360432990279830238">Terminar sessão e desativar a sincronização?</translation>
+<translation id="8581481290581777242">Pretende limpar os dados do Brave deste dispositivo?</translation>
+<translation id="1318865768845061710">Os marcadores, o histórico, as palavras-passe e outros dados do Brave deixarão de ser sincronizados com a sua Conta Brave Software.</translation>
+<translation id="3325020657155065477">Limpar também os dados do Brave deste dispositivo</translation>
+<translation id="6136448902816743006">Uma vez que está a terminar sessão numa conta gerida pelo domínio <ph name="DOMAIN_NAME"/>, os dados do Brave serão eliminados deste dispositivo. Estes irão permanecer na sua Conta Brave Software.</translation>
+<translation id="1853026300647876496">A contactar a Brave Software… Isto pode demorar um pouco…</translation>
+<translation id="2328985652426384049">Não é possível iniciar sessão</translation>
+<translation id="7723158744459952869">A Brave Software demorou demasiado tempo a responder</translation>
+<translation id="4572422548854449519">Iniciar sessão na conta gerida</translation>
+<translation id="2689656545739939160">Está a iniciar sessão com uma conta gerida por <ph name="MANAGED_DOMAIN"/> e a conceder ao respetivo gestor o controlo dos seus dados do Brave. Os dados ficarão permanentemente associados a esta conta. Terminar sessão no Brave elimina os seus dados deste dispositivo, embora permaneçam armazenados na Conta Brave Software.</translation>
+<translation id="1749561566933687563">Sincronizar os marcadores</translation>
+<translation id="4242533952199664413">Abrir definições</translation>
+<translation id="1111673857033749125">Os marcadores guardados nos seus outros dispositivos são apresentados aqui.</translation>
+<translation id="8636825310635137004">Para obter os separadores dos seus outros dispositivos, ative a sincronização.</translation>
+<translation id="3269956123044984603">Para obter os separadores dos seus outros dispositivos, ative a opção "Sincronizar automaticamente os dados" nas definições da conta do Android.</translation>
+<translation id="5157964048453367290">Os separadores que abriu no Brave nos seus outros dispositivos são apresentados aqui.</translation>
+<translation id="4684427112815847243">Sincronizar tudo</translation>
+<translation id="2709516037105925701">Preenchimento automático</translation>
+<translation id="8820817407110198400">Marcadores</translation>
+<translation id="1644574205037202324">Histórico</translation>
+<translation id="17513872634828108">Separadores abertos</translation>
+<translation id="1320169905922104972">Cartões de crédito e endereços com o Brave Software Pay</translation>
+<translation id="6337234675334993532">Encriptação</translation>
+<translation id="6698801883190606802">Gerir dados sincronizados</translation>
+<translation id="3598578758776312506">Encriptar palavras-passe com credenciais Brave Software</translation>
+<translation id="7810580217418711046">Encriptar dados sincronizados com a palavra-passe do Brave Software a partir de <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Encriptar dados sincronizados com a sua própria frase de acesso de sincronização</translation>
+<translation id="2996291259634659425">Criar frase de acesso</translation>
+<translation id="5713644099811900409">Conta Brave Software</translation>
+<translation id="8997474919031554666">A encriptação da frase de acesso não inclui métodos de pagamento nem endereços do Brave Software Pay. Apenas alguém que conheça a sua frase de acesso pode ler os seus dados encriptados. A frase de acesso não é enviada para a Brave Software nem armazenada pela mesma. Se se esquecer da frase de acesso ou pretender alterar esta definição, tem de repor a sincronização. <ph name="BEGIN_LINK"/>Saiba mais<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Frase de acesso</translation>
+<translation id="7772032839648071052">Confirmar frase de acesso</translation>
+<translation id="5304593522240415983">Este campo não pode estar em branco</translation>
+<translation id="321773570071367578">Se se esquecer da frase de acesso ou pretender alterar esta definição, <ph name="BEGIN_LINK"/>reponha a sincronização<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">As frases de acesso não coincidem</translation>
+<translation id="5149495116300586333">A encriptação da frase de acesso não inclui métodos de pagamento nem endereços do Brave Software Pay.
+
+Para alterar esta definição, <ph name="BEGIN_LINK"/>reponha a sincronização<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">Frase de acesso incorreta</translation>
+<translation id="5414836363063783498">A validar…</translation>
+<translation id="6846298663435243399">A carregar…</translation>
+<translation id="5517095782334947753">Tem marcadores, histórico, palavras-passe e outras definições de <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combinar os meus dados</translation>
+<translation id="688738109438487280">Adicionar dados existentes a <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Manter os meus dados separados</translation>
+<translation id="1145536944570833626">Eliminar dados existentes.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> pretende sincronizar</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Obter ajuda<ph name="END_LINK"/> enquanto procura dispositivos…</translation>
+<translation id="5817918615728894473">Sincronizar</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Obter ajuda<ph name="END_LINK1"/> ou <ph name="BEGIN_LINK2"/>voltar a procurar<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Não foram encontrados dispositivos compatíveis.</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Ative o Bluetooth<ph name="END_LINK"/> para permitir a sincronização</translation>
+<translation id="998321811308652668">O Brave não consegue ativar o adaptador Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Obter ajuda<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">O Brave necessita de acesso à localização para procurar dispositivos. <ph name="BEGIN_LINK"/>Atualizar autorizações<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">O Brave precisa de acesso à localização para procurar dispositivos. O acesso à localização está <ph name="BEGIN_LINK"/>desativado para este dispositivo<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">O Brave precisa de acesso à localização para procurar dispositivos. <ph name="BEGIN_LINK1"/>Atualize as autorizações<ph name="END_LINK1"/>. O acesso à localização também está <ph name="BEGIN_LINK2"/>desativado para este dispositivo<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Dispositivo ligado</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Nível de intensidade do sinal: # barra}other{Nível de intensidade do sinal: # barras}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> pretende procurar dispositivos Bluetooth próximos. Foram encontrados os seguintes dispositivos:</translation>
+<translation id="8368027906805972958">Dispositivo desconhecido ou não suportado (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">A sincronização não está a funcionar</translation>
+<translation id="1810845389119482123">A configuração da sincronização inicial não está concluída</translation>
+<translation id="3235722914093408050">Abrir definiç. Android e reativar sinc. sistema Android p/ iniciar sinc. Brave</translation>
+<translation id="3367813778245106622">Iniciar sessão novamente para iniciar a sincronização</translation>
+<translation id="974555521953189084">Introduza a frase de acesso para iniciar a sincronização</translation>
+<translation id="2997266899014181325">Para iniciar a sincronização, ative a opção "Sincronizar dados do Brave".</translation>
+<translation id="8260126382462817229">Experimente iniciar sessão novamente</translation>
+<translation id="5919204609460789179">Atualizar <ph name="PRODUCT_NAME"/> para iniciar a sincronização</translation>
+<translation id="397583555483684758">A sincronização deixou de funcionar</translation>
+<translation id="1966710179511230534">Atualize os detalhes de início de sessão.</translation>
+<translation id="7063006564040364415">Não foi possível estabelecer ligação ao servidor de sincronização.</translation>
+<translation id="7942131818088350342">O <ph name="PRODUCT_NAME"/> está desatualizado.</translation>
+<translation id="4170011742729630528">O serviço não está disponível. Tente novamente mais tarde.</translation>
+<translation id="7947953824732555851">Aceitar e in. sessão</translation>
+<translation id="8583805026567836021">A limpar os dados da conta</translation>
+<translation id="8310344678080805313">Separadores padrão</translation>
+<translation id="5748802427693696783">Mudado para separadores padrão</translation>
+<translation id="7998918019931843664">Reabrir separador fechado</translation>
+<translation id="8853345339104747198">Separador <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Fechar o separador <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opções disponíveis junto à parte inferior do ecrã</translation>
+<translation id="4060598801229743805">Opções disponíveis junto à parte superior do ecrã</translation>
+<translation id="2810645512293415242">Página simplificada para poupar dados e carregar mais rapidamente.</translation>
+<translation id="3985215325736559418">Pretende transferir <ph name="FILE_NAME"/> novamente?</translation>
+<translation id="2450083983707403292">Pretende começar a transferir <ph name="FILE_NAME"/> novamente?</translation>
+<translation id="7514365320538308">Transferir</translation>
+<translation id="545042621069398927">A acelerar a transferência…</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{A transferir o ficheiro…}other{A transferir # ficheiros…}}</translation>
+<translation id="543509235395288790">A transferir <ph name="COUNT"/> ficheiros (<ph name="MEGABYTES"/>)…</translation>
+<translation id="4988210275050210843">A transferir ficheiro (<ph name="MEGABYTES"/>)…</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 transferência concluída.}other{# transferências concluídas.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 transferência com falha.}other{# transferências com falha.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 transferência pendente.}other{# transferências pendentes.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Botão <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Quase concluído!</translation>
+<translation id="3960299545138990065">Reiniciar o Brave</translation>
+<translation id="3771001275138982843">Não foi possível transferir a atualização.</translation>
+<translation id="3888648114124182147">A transferir a atualização do Brave…</translation>
+<translation id="1705567146636171298">Atualizar o Brave</translation>
+<translation id="6195417478702700398">Para obter a melhor experiência de navegação, abra o Brave para o atualizar.</translation>
+<translation id="3512968675351418494">Para ver a Web no seu idioma, obtenha a versão mais recente do Brave.</translation>
+<translation id="6427112570124116297">Traduzir a Web</translation>
+<translation id="1379423114029199501">Atualize o Brave para a versão mais recente de modo a obter o seu idioma.</translation>
+<translation id="5684874026226664614">Ups! Não foi possível traduzir esta página.</translation>
+<translation id="6831043979455480757">Traduzir</translation>
+<translation id="1285320974508926690">Nunca traduzir este site</translation>
+<translation id="773466115871691567">Traduza sempre páginas em <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nunca traduzir páginas em <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Mais idiomas</translation>
+<translation id="290376772003165898">A página não está em <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">As páginas em <ph name="SOURCE_LANGUAGE"/> serão traduzidas para <ph name="TARGET_LANGUAGE"/> a partir de agora</translation>
+<translation id="8339163506404995330">As páginas em <ph name="LANGUAGE"/> não serão traduzidas</translation>
+<translation id="5447765697759493033">Este site não será traduzido.</translation>
+<translation id="4880127995492972015">Traduzir…</translation>
+<translation id="641643625718530986">Imprimir…</translation>
+<translation id="8909135823018751308">Partilhar…</translation>
+<translation id="4996978546172906250">Partilhar através de</translation>
+<translation id="6333140779060797560">Partilhar através de <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Ocorreu um problema ao imprimir a página. Tente novamente.</translation>
+<translation id="3254409185687681395">Marcar esta página</translation>
+<translation id="497421865427891073">Avançar</translation>
+<translation id="813082847718468539">Ver informações do Website</translation>
+<translation id="2532336938189706096">Visualização na Web</translation>
+<translation id="6005538289190791541">Palavra-passe sugerida</translation>
+<translation id="4634124774493850572">Utilizar palavra-passe</translation>
+<translation id="8285489906452138776">O Brave necessita de autorização de acesso à câmara para este site.</translation>
+<translation id="320189792589364011">O Brave necessita de autorização de acesso ao microfone para este site.</translation>
+<translation id="7988136689212463100">O Brave necessita de autorização de acesso à câmara e ao microfone para este site.</translation>
+<translation id="4931190655840828017">O Brave precisa de acesso à sua localização para a partilhar com este site.</translation>
+<translation id="3088191967551450609">O Brave necessita de acesso ao armazenamento para transferir ficheiros.</translation>
+<translation id="8942627711005830162">Abrir noutra janela</translation>
+<translation id="4195643157523330669">Abrir num novo separador</translation>
+<translation id="1100066534610197918">Abrir num novo sep. no grupo</translation>
+<translation id="4860895144060829044">Telefonar</translation>
+<translation id="6896758677409633944">Copiar</translation>
+<translation id="8393700583063109961">Enviar mensagem</translation>
+<translation id="3557336313807607643">Adicionar aos contactos</translation>
+<translation id="4269820728363426813">Copiar endereço do link</translation>
+<translation id="1206892813135768548">Copiar texto do link</translation>
+<translation id="1204037785786432551">Transferir link</translation>
+<translation id="6864459304226931083">Transferir imagem</translation>
+<translation id="8209050860603202033">Abrir imagem</translation>
+<translation id="8073388330009372546">Abrir imagem num novo separad.</translation>
+<translation id="6649642165559792194">Pré-visualizar imagem <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Carregar imagem</translation>
+<translation id="3845332215609790146">Pesquisar com Brave Software Lens <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Pesquisar a imagem no <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Partilhar imagem</translation>
+<translation id="5833984609253377421">Partilhar link</translation>
+<translation id="6475951671322991020">Transferir vídeo</translation>
+<translation id="2317945146070194624">Abrir num novo sep. do Brave</translation>
+<translation id="7975379999046275268">Pré-visualizar página <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">A atualizar a página</translation>
+<translation id="36525718899759834">Obter a aplicação na Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Escuro</translation>
+<translation id="1807246157184219062">Claro</translation>
+<translation id="4056223980640387499">Sépia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monoespaço</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Selecione um separador a transmitir</translation>
+<translation id="8719023831149562936">Impossível transmitir o separador atual</translation>
+<translation id="2139186145475833000">Adicionar ao ecrã principal</translation>
+<translation id="4616150815774728855">Abrir <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Não foi possível abrir a aplicação.</translation>
+<translation id="5129038482087801250">Instalar aplicação Web</translation>
+<translation id="3789841737615482174">Instalar</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> foi adicionado ao seu Ecrã principal</translation>
+<translation id="7333031090786104871">Ainda a adicionar o site anterior…</translation>
+<translation id="1036727731225946849">A adicionar <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Adicionado ao ecrã principal</translation>
+<translation id="2146738493024040262">Abrir aplicação instantânea</translation>
+<translation id="7016516562562142042">Permitido para o motor de pesquisa atual</translation>
+<translation id="6177111841848151710">Bloqueado para o motor de pesquisa atual</translation>
+<translation id="145097072038377568">Desativada nas Definições do Android</translation>
+<translation id="8007176423574883786">Desativada para este dispositivo</translation>
+<translation id="164269334534774161">Está a visualizar uma cópia offline desta página de <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Esta página foi criada a <ph name="CREATION_TIME"/> e pode ser diferente da versão online.</translation>
+<translation id="8840953339110955557">Esta página pode ser diferente da versão online.</translation>
+<translation id="6405300764336705484">Este conteúdo é proveniente de <ph name="DOMAIN_NAME"/>, fornecido pela Brave Software.</translation>
+<translation id="1006017844123154345">Abrir online</translation>
+<translation id="3326636747541519688">Página em modo lite fornecida pela Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Carregar página original<ph name="END_LINK"/> do domínio <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Se vê isto com frequência, experimente estas <ph name="BEGIN_LINK"/>sugestões<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Conteúdo ocultado</translation>
+<translation id="3810973564298564668">Gerir</translation>
+<translation id="5199929503336119739">Perfil de trabalho</translation>
+<translation id="528192093759286357">Arraste a partir da parte superior e toque no botão de retrocesso para sair do ecrã inteiro.</translation>
+<translation id="2836148919159985482">Toque no botão de retrocesso para sair do ecrã inteiro.</translation>
+<translation id="3967822245660637423">Transferência concluída</translation>
+<translation id="2434158240863470628">Transferência concluída: <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Falha ao transferir</translation>
+<translation id="1384959399684842514">Transferência interrompida</translation>
+<translation id="1671236975893690980">Transferência pendente…</translation>
+<translation id="5561549206367097665">A aguardar pela rede...</translation>
+<translation id="5864419784173784555">A aguardar por outra transferência…</translation>
+<translation id="6461962085415701688">Não é possível abrir o ficheiro</translation>
+<translation id="1178581264944972037">Pausa</translation>
+<translation id="8200772114523450471">Continuar</translation>
+<translation id="1409879593029778104">A transferência de <ph name="FILE_NAME"/> foi impedida porque o ficheiro já existe.</translation>
+<translation id="3387650086002190359">A transferência de <ph name="FILE_NAME"/> falhou devido a erros do sistema de ficheiros.</translation>
+<translation id="6482749332252372425">A transferência de <ph name="FILE_NAME"/> falhou devido à falta de espaço de armazenamento.</translation>
+<translation id="7619072057915878432">A transferência de <ph name="FILE_NAME"/> falhou devido a falhas de rede.</translation>
+<translation id="1477626028522505441">A transferência de <ph name="FILE_NAME"/> falhou devido a problemas do servidor.</translation>
+<translation id="3692944402865947621">A transferência de <ph name="FILE_NAME"/> falhou porque o local de armazenamento está fora do alcance.</translation>
+<translation id="604996488070107836">A transferência de <ph name="FILE_NAME"/> falhou devido a um erro desconhecido.</translation>
+<translation id="6738867403308150051">A transferir...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB transferido(s)</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB transferido(s)</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB transferido(s)</translation>
+<translation id="9204836675896933765">Falta 1 ficheiro</translation>
+<translation id="8186512483418048923">Faltam <ph name="FILES"/> ficheiros</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> ficheiro transferido}other{<ph name="FILES_DOWNLOADED_MANY"/> ficheiros transferidos}}</translation>
+<translation id="8037750541064988519">Faltam <ph name="DAYS"/> dias</translation>
+<translation id="8190358571722158785">Falta 1 dia</translation>
+<translation id="60923314841986378">Faltam <ph name="HOURS"/> horas</translation>
+<translation id="510275257476243843">Falta 1 hora</translation>
+<translation id="970715775301869095">Faltam <ph name="MINUTES"/> minutos</translation>
+<translation id="3236059992281584593">Falta 1 minuto</translation>
+<translation id="2777555524387840389">Faltam <ph name="SECONDS"/> segundos</translation>
+<translation id="2781151931089541271">Falta 1 segundo</translation>
+<translation id="3303414029551471755">Pretende transferir o conteúdo?</translation>
+<translation id="8617240290563765734">Pretende abrir o URL sugerido que é especificado no conteúdo transferido?</translation>
+<translation id="1373696734384179344">Memória insuficiente para transferir o conteúdo selecionado.</translation>
+<translation id="5271967389191913893">O dispositivo não consegue abrir o conteúdo a transferir.</translation>
+<translation id="883806473910249246">Ocorreu um erro ao transferir o conteúdo.</translation>
+<translation id="5626134646977739690">Nome:</translation>
+<translation id="7963646190083259054">Fornecedor:</translation>
+<translation id="3414952576877147120">Tamanho:</translation>
+<translation id="7375125077091615385">Tipo:</translation>
+<translation id="5765780083710877561">Descrição:</translation>
+<translation id="4881695831933465202">Abrir</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB disponível(eis)</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB disponíveis</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB disponíveis</translation>
+<translation id="5793665092639000975">A utilizar <ph name="SPACE_USED"/> de <ph name="SPACE_AVAILABLE"/>.</translation>
+<translation id="3587482841069643663">Tudo</translation>
+<translation id="4988526792673242964">Páginas</translation>
+<translation id="3810838688059735925">Vídeo</translation>
+<translation id="3616113530831147358">Áudio</translation>
+<translation id="9219103736887031265">Imagens</translation>
+<translation id="8250920743982581267">Docs</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ficheiro}other{# ficheiros}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# imagem}other{# imagens}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}other{# vídeos}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ficheiro de áudio}other{# ficheiros de áudio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# página}other{# páginas}}</translation>
+<translation id="5456381639095306749">Transferir página</translation>
+<translation id="2394602618534698961">Os ficheiros que transferir aparecem aqui.</translation>
+<translation id="7810647596859435254">Abrir com…</translation>
+<translation id="5655963694829536461">Pesquisar as suas transferências</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Os meus ficheiros</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Os artigos são apresentados aqui e pode lê-los mesmo quando está offline.</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}other{# h}}</translation>
+<translation id="5853623416121554550">em pausa</translation>
+<translation id="8965591936373831584">pendente</translation>
+<translation id="2779651927720337254">falhou</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Agora mesmo</translation>
+<translation id="4000212216660919741">Em casa offline</translation>
+<translation id="9133397713400217035">Explorar offline</translation>
+<translation id="968900484120156207">As páginas que visita aparecem aqui.</translation>
+<translation id="7882131421121961860">Nenhum histórico encontrado</translation>
+<translation id="3549657413697417275">Pesquisar no histórico</translation>
+<translation id="6820686453637990663">Código de segurança</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Experiência de primeira execução do Brave</translation>
+<translation id="2700285883409956633">Ao utilizar esta aplicação, concorda com os <ph name="BEGIN_LINK1"/>Termos de Utilização<ph name="END_LINK1"/> e o <ph name="BEGIN_LINK2"/>Aviso de Privacidade<ph name="END_LINK2"/> do Brave.</translation>
+<translation id="1640714894372474981">Ao utilizar esta aplicação, está a concordar com os <ph name="BEGIN_LINK1"/>Termos de Utilização<ph name="END_LINK1"/> e o <ph name="BEGIN_LINK2"/>Aviso de Privacidade<ph name="END_LINK2"/> do Brave, bem como com o <ph name="BEGIN_LINK3"/>Aviso de Privacidade para Contas Brave Software Geridas com o Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">A aplicação <ph name="APP_NAME"/> será aberta no Brave. Ao continuar, aceita os <ph name="BEGIN_LINK1"/>Termos de Utilização<ph name="END_LINK1"/> e o <ph name="BEGIN_LINK2"/>Aviso de Privacidade<ph name="END_LINK2"/> do Brave.</translation>
+<translation id="5071615083211946659">A aplicação <ph name="APP_NAME"/> será aberta no Brave. Ao continuar, aceita os <ph name="BEGIN_LINK1"/>Termos de Utilização<ph name="END_LINK1"/> e o <ph name="BEGIN_LINK2"/>Aviso de Privacidade<ph name="END_LINK2"/> do Brave, bem como o <ph name="BEGIN_LINK3"/>Aviso de Privacidade para Contas Brave Software Geridas com o Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Ajude a melhorar o Brave ao enviar estatísticas de utilização e relatórios de falhas para a Brave Software.</translation>
+<translation id="3518985090088779359">Aceitar e continuar</translation>
+<translation id="7207456302801184289">Bem-vindo ao Brave</translation>
+<translation id="704822250101715322">A aguardar pela conclusão da atualização dos Serviços do Brave Software Play…</translation>
+<translation id="1231733316453485619">Pretende ativar a sincronização?</translation>
+<translation id="5132942445612118989">Sincronize as suas palavras-passe, o histórico e muito mais em todos os dispositivos</translation>
+<translation id="5736731321935944068">A Brave Software pode utilizar o seu histórico para personalizar a Pesquisa, os anúncios e outros serviços Brave Software.</translation>
+<translation id="4013614219085422040">A Brave Software pode utilizar o seu histórico para personalizar a Pesquisa e outros serviços Brave Software.</translation>
+<translation id="5581519193887989363">Pode escolher o que pretende sincronizar nas <ph name="BEGIN_LINK1"/>definições<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Sim, aceito</translation>
+<translation id="2410754283952462441">Selecione uma conta</translation>
+<translation id="2227444325776770048">Continuar como <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> não é o seu email?</translation>
+<translation id="8109613176066109935">Para obter os seus marcadores em todos os dispositivos, ative a sincronização.</translation>
+<translation id="2818669890320396765">Para obter os seus marcadores em todos os dispositivos, inicie sessão e ative a sincronização.</translation>
+<translation id="6003646045106347985">Para obter conteúdo personalizado sugerido pelo Brave Software, ative a sincronização.</translation>
+<translation id="8494430740943879273">Para obter conteúdo personalizado sugerido pelo Brave Software, inicie sessão e ative a sincronização.</translation>
+<translation id="5862731021271217234">Para obter os separadores dos seus outros dispositivos, ative a sincronização.</translation>
+<translation id="3568688522516854065">Para obter os separadores dos seus outros dispositivos, inicie sessão e ative a sincronização.</translation>
+<translation id="1208340532756947324">Para sincronizar e personalizar entre dispositivos, ative a sincronização.</translation>
+<translation id="4472118726404937099">Para sincronizar e personalizar entre dispositivos, inicie sessão e ative a sincronização.</translation>
+<translation id="2426805022920575512">Selecionar outra conta</translation>
+<translation id="6790428901817661496">Reproduzir</translation>
+<translation id="1272079795634619415">Parar</translation>
+<translation id="2874939134665556319">Faixa anterior</translation>
+<translation id="4046123991198612571">Faixa seguinte</translation>
+<translation id="3859306556332390985">Procurar para a frente</translation>
+<translation id="8441146129660941386">Procurar para trás</translation>
+<translation id="6706288973712894588">De momento, está offline.\n<ph name="BEGIN_LINK"/>Explore o seu feed offline.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Separadores recentes</translation>
+<translation id="8497726226069778601">Ainda não há nada para ver aqui</translation>
+<translation id="5423934151118863508">As páginas mais visitadas aparecem aqui</translation>
+<translation id="6127379762771434464">Item removido</translation>
+<translation id="4605958867780575332">Item removido: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle da Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Outros aparelhos</translation>
+<translation id="4738836084190194332">Última sincronização: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Há # minuto}other{Há # minutos}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Há # hora}other{Há # horas}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Há # dia}other{Há # dias}}</translation>
+<translation id="2762000892062317888">agora mesmo</translation>
+<translation id="1407135791313364759">Abrir tudo</translation>
+<translation id="1209206284964581585">Ocultar para já</translation>
+<translation id="129553762522093515">Fechados recentemente</translation>
+<translation id="8413126021676339697">Mostrar histórico completo</translation>
+<translation id="7876243839304621966">Remover tudo</translation>
+<translation id="8487700953926739672">Disponível offline</translation>
+<translation id="5224771365102442243">Com vídeo</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Saiba mais<ph name="END_LINK"/> acerca do conteúdo sugerido</translation>
+<translation id="7542481630195938534">Não é possível obter sugestões</translation>
+<translation id="5013696553129441713">Não existem novas sugestões.</translation>
+<translation id="1736419249208073774">Explorar</translation>
+<translation id="7444811645081526538">Mais categorias</translation>
+<translation id="6709133671862442373">Notícias</translation>
+<translation id="1264974993859112054">Desporto</translation>
+<translation id="9139318394846604261">Compras</translation>
+<translation id="3912508018559818924">A procurar o melhor da Web…</translation>
+<translation id="526421993248218238">Não é possível carregar esta página.</translation>
+<translation id="614940544461990577">Experimente:</translation>
+<translation id="3288003805934695103">Atualizar a página</translation>
+<translation id="2353636109065292463">A verificar a sua ligação à Internet...</translation>
+<translation id="2858138569776157458">Princ. sites</translation>
+<translation id="8364299278605033898">Veja Websites populares</translation>
+<translation id="1171770572613082465">Veja Websites populares ao tocar no botão "Principais sites"</translation>
+<translation id="5233638681132016545">Novo separador</translation>
+<translation id="4521874409998847950">De <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>fornecido pela Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Versão mais recente dispon.</translation>
+<translation id="4058091506841967397">Não é possível atualizar</translation>
+<translation id="6316139424528454185">Versão Android não suportada.</translation>
+<translation id="6989267951144302301">Impossível transferir.</translation>
+<translation id="624789221780392884">Atualização pronta</translation>
+<translation id="1549000191223877751">Mover para outra janela</translation>
+<translation id="7481312909269577407">Avançar</translation>
+<translation id="4084682180776658562">Marcar</translation>
+<translation id="6437478888915024427">Informações da página</translation>
+<translation id="7180611975245234373">Atualizar</translation>
+<translation id="4913169188695071480">Parar a atualização</translation>
+<translation id="1829244130665387512">Localizar na página</translation>
+<translation id="6593061639179217415">Site para computador</translation>
+<translation id="9063523880881406963">Desativar Pedir site para computador</translation>
+<translation id="2038563949887743358">Ativar Pedir site para computador</translation>
+<translation id="2433507940547922241">Aspeto</translation>
+<translation id="983192555821071799">Fechar todos os separadores</translation>
+<translation id="1310482092992808703">Agrupar separadores</translation>
+<translation id="7725024127233776428">As páginas que adiciona aos marcadores aparecem aqui.</translation>
+<translation id="4404568932422911380">Sem marcadores</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> marcador}other{<ph name="BOOKMARKS_COUNT_MANY"/> marcadores}}</translation>
+<translation id="3739899004075612870">Adicionado aos marcadores no <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Adicionado aos marcadores</translation>
+<translation id="4452548195519783679">Adicionado aos marcadores em <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Falha ao adicionar marcador.</translation>
+<translation id="2842985007712546952">Pasta superior</translation>
+<translation id="9065203028668620118">Editar</translation>
+<translation id="4405224443901389797">Mover para…</translation>
+<translation id="5170568018924773124">Mostrar numa pasta</translation>
+<translation id="8035133914807600019">Nova pasta…</translation>
+<translation id="4532845899244822526">Escolher pasta</translation>
+<translation id="6627583120233659107">Editar pasta</translation>
+<translation id="1197267115302279827">Mover marcadores</translation>
+<translation id="6963766334940102469">Eliminar marcadores</translation>
+<translation id="4351244548802238354">Fechar caixa de diálogo</translation>
+<translation id="451872707440238414">Pesquisar os marcadores</translation>
+<translation id="8901170036886848654">Nenhum marcador encontrado</translation>
+<translation id="6404511346730675251">Editar marcador</translation>
+<translation id="3894427358181296146">Adicionar pasta</translation>
+<translation id="5327248766486351172">Nome</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Pasta</translation>
+<translation id="5161254044473106830">Título obrigatório</translation>
+<translation id="2996809686854298943">URL obrigatório</translation>
+<translation id="2536728043171574184">Visualização de uma cópia offline desta página</translation>
+<translation id="4698034686595694889">Ver offline no <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408">De <ph name="DOMAIN_NAME"/> e de mais sites</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{O Brave irá carregar a página quando estiver pronta.}other{O Brave irá carregar as páginas quando estiverem prontas.}}</translation>
+<translation id="6811034713472274749">A página está preparada para ser visualizada</translation>
+<translation id="4561979708150884304">Sem ligação</translation>
+<translation id="8274165955039650276">Ver transferências</translation>
+<translation id="2082238445998314030">Resultado <ph name="RESULT_NUMBER"/> de <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Nenhum resultado</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Nenhuma pesq. por voz ativada disponível</translation>
+<translation id="7191430249889272776">Separador aberto em segundo plano.</translation>
+<translation id="8445059357334030806">Abrir no Brave</translation>
+<translation id="4720023427747327413">Abrir no <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Abrir no navegador</translation>
+<translation id="1113597929977215864">Mostrar vista simplificada</translation>
+<translation id="1513352483775369820">Marcadores e histórico da Web</translation>
+<translation id="4939482511480190003">Ajude a melhorar o Brave. <ph name="BEGIN_LINK"/>Responder ao inquérito<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Voltar</translation>
+<translation id="5596627076506792578">Mais opções</translation>
+<translation id="3522247891732774234">Atualização disponível. Mais opções</translation>
+<translation id="6773423637732432200">Não é possível atualizar o Brave. Mais opções.</translation>
+<translation id="3328801116991980348">Informações do site</translation>
+<translation id="5391532827096253100">A sua ligação a este site não é segura. Informações do site</translation>
+<translation id="6206551242102657620">A ligação é segura. Informações do site</translation>
+<translation id="6963642900430330478">Esta página é perigosa. Informações do site</translation>
+<translation id="9070377983101773829">Iniciar pesquisa por voz</translation>
+<translation id="8676374126336081632">Limpar texto</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> separador aberto, toque para alternar entre separadores}other{<ph name="OPEN_TABS_MANY"/> separadores abertos, toque para alternar entre separadores}}</translation>
+<translation id="2369533728426058518">abrir separadores</translation>
+<translation id="7071521146534760487">Gerir conta</translation>
+<translation id="932327136139879170">Página inicial</translation>
+<translation id="2707726405694321444">Atualizar página</translation>
+<translation id="2891154217021530873">Parar carregamento da página</translation>
+<translation id="6710213216561001401">Anterior</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Separador selecionado</translation>
+<translation id="2268044343513325586">Refinar</translation>
+<translation id="7846076177841592234">Cancelar seleção</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> selecionado(s). Opções disponíveis junto à parte superior do ecrã.</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> selecionado(s).</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Partilhar 1 item selecionado}other{Partilhar # itens selecionados}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Remover 1 item selecionado}other{Remover # itens selecionados}}</translation>
+<translation id="1283039547216852943">Toque para expandir</translation>
+<translation id="5962718611393537961">Toque para reduzir</translation>
+<translation id="8076492880354921740">Separadores</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selecionado}other{# selecionados}}</translation>
+<translation id="6818926723028410516">Selecionar itens</translation>
+<translation id="4797039098279997504">Toque para voltar a <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Toque para aceder ao site.</translation>
+<translation id="429312253194641664">Um site está a reproduzir multimédia.</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> está a partilhar o seu ecrã</translation>
+<translation id="8833831881926404480">Um site está a partilhar o seu ecrã</translation>
+<translation id="9086455579313502267">Não é possível aceder à rede</translation>
+<translation id="938850635132480979">Erro: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Abrir no <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Abrir na aplicação de mapas</translation>
+<translation id="7698359219371678927">Criar email no <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Criar email</translation>
+<translation id="5665379678064389456">Criar evento no <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Criar evento</translation>
+<translation id="2111511281910874386">Ir para a página</translation>
+<translation id="3988466920954086464">Veja resultados da pesquisa instantâneos neste painel.</translation>
+<translation id="2744248271121720757">Toque numa palavra para pesquisar instantaneamente ou ver as ações relacionadas.</translation>
+<translation id="9155898266292537608">Também pode pesquisar ao tocar rapidamente numa palavra.</translation>
+<translation id="3232754137068452469">Aplicação Web</translation>
+<translation id="1430915738399379752">Imprimir</translation>
+<translation id="3775705724665058594">Envie para os seus dispositivos</translation>
+<translation id="6364438453358674297">Pretende remover a sugestão do histórico?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> fechado</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> separadores fechados</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> eliminado</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> marcadores eliminados</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> transferências eliminadas</translation>
+<translation id="1248710015876067820">Número não suportado de instâncias do Brave.</translation>
+<translation id="4259722352634471385">A navegação está bloqueada: <ph name="URL"/></translation>
+<translation id="8959122750345127698">A navegação está inacessível: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Fechar separador</translation>
+<translation id="7772375229873196092">Fechar <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Histórico de navegação</translation>
+<translation id="9169507124922466868">O histórico de navegação está aberto até meio.</translation>
+<translation id="1327257854815634930">O histórico de navegação está aberto.</translation>
+<translation id="8788265440806329501">O histórico de navegação está fechado.</translation>
+<translation id="7482656565088326534">Separador Pré-visualização</translation>
+<translation id="8427875596167638501">O separador Pré-visualização está aberto até meio.</translation>
+<translation id="9102803872260866941">O separador Pré-visualização está aberto</translation>
+<translation id="2942036813789421260">O separador Pré-visualização está fechado</translation>
+<translation id="6355102470683871794">Armazenamento do Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Limpar armazenamento do site?</translation>
+<translation id="9205995714227143200">Armazenamento do site que o Brave não considera importante (por exemplo, sites sem definições guardadas ou aos quais não acede com frequência)</translation>
+<translation id="3997476611815694295">Armazenamento desnecessário</translation>
+<translation id="8493948351860045254">Libertar espaço</translation>
+<translation id="2324920234469020158">Esta ação elimina os cookies, a cache e outros dados de sites que o Brave não considera importantes.</translation>
+<translation id="5447201525962359567">Todo o armazenamento de sites, incluindo cookies e outros dados armazenados localmente</translation>
+<translation id="1376578503827013741">A calcular…</translation>
+<translation id="583281660410589416">Desconhecido</translation>
+<translation id="2323763861024343754">Armazenamento do site</translation>
+<translation id="3587672679800759167">Total de dados utilizados pelo Brave, incluindo contas, marcadores e definições guardadas</translation>
+<translation id="6545017243486555795">Limpar todos os dados</translation>
+<translation id="4095146165863963773">Pretende eliminar os dados da aplicação?</translation>
+<translation id="53119194224775367">Todos os dados de aplicações do Brave são eliminados permanentemente, incluindo todos os ficheiros, definições, contas, bases de dados, etc.</translation>
+<translation id="5307446750509046227">Limpar armazen. do site</translation>
+<translation id="300526633675317032">Esta ação elimina os <ph name="SIZE_IN_KB"/> de armazenamento do Website.</translation>
+<translation id="8068648041423924542">Não é possível selecionar o certificado.</translation>
+<translation id="2315043854645842844">O sistema operativo não suporta a seleção do certificado do lado do cliente.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> pretende estabelecer ligação</translation>
+<translation id="5308380583665731573">Ligar</translation>
+<translation id="868929229000858085">Pesquise os seus contactos</translation>
+<translation id="1919950603503897840">Selecionar contactos</translation>
+<translation id="7986741934819883144">Selecionar um contacto</translation>
+<translation id="3333961966071413176">Todos os contactos</translation>
+<translation id="4994033804516042629">Não foram encontrados contactos</translation>
+<translation id="5403592356182871684">Nomes</translation>
+<translation id="2717722538473713889">Endereços de email</translation>
+<translation id="381841723434055211">Números de telefone</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(mais 1)}other{(mais #)}}</translation>
+<translation id="5197729504361054390">Os contactos que selecionar serão partilhados com <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Descodificador de imagem</translation>
+<translation id="8067883171444229417">Reproduzir vídeo</translation>
+<translation id="6560414384669816528">Pesquisar com o Sogou</translation>
+<translation id="5406914950576900927">O Brave pode utilizar o <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> para pesquisar na China. Pode alterar esta opção nas <ph name="BEGIN_LINK"/>Definições<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Manter o Brave Software</translation>
+<translation id="4384468725000734951">A utilizar o Sogou para pesquisa</translation>
+<translation id="6103327872225198548">A utilizar o Brave Software para pesquisa</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Esta aplicação está a ser executada no Brave</translation>
+<translation id="6143689084714664628">Em execução no Brave.</translation>
+<translation id="7675869148432102528">A aplicação <ph name="APP_NAME"/> também tem dados no Brave</translation>
+<translation id="2734140769649165081">Pode limpar os dados nas Definições do Brave.</translation>
+<translation id="8232956427053453090">Manter os dados</translation>
+<translation id="4298388696830689168">Sites associados</translation>
+<translation id="5763514718066511291">Toque para copiar o URL desta aplicação.</translation>
+<translation id="6496823230996795692">Para utilizar a aplicação <ph name="APP_NAME"/> pela primeira vez, ligue-se à Internet.</translation>
+<translation id="751961395872307827">Não é possível estabelecer ligação ao site.</translation>
+<translation id="4878404682131129617">Falha ao estabelecer um túnel através do servidor proxy.</translation>
+<translation id="4749960740855309258">Abrir um novo separador</translation>
+<translation id="8788968922598763114">Reabrir o último separador fechado</translation>
+<translation id="7929962904089429003">Abrir o menu</translation>
+<translation id="6039379616847168523">Ir para o próximo separador</translation>
+<translation id="5210286577605176222">Ir para o separador anterior</translation>
+<translation id="124678866338384709">Fechar o separador atual</translation>
+<translation id="3714981814255182093">Abrir a barra Localizar</translation>
+<translation id="5441522332038954058">Ir para a barra de endereço</translation>
+<translation id="3398320232533725830">Abrir o gestor de marcadores</translation>
+<translation id="6583199322650523874">Adicionar a página atual aos marcadores</translation>
+<translation id="8489271220582375723">Abrir a página do histórico</translation>
+<translation id="4837753911714442426">Abrir opções para imprimir página</translation>
+<translation id="5726692708398506830">Aumentar o tamanho de todos os itens na página</translation>
+<translation id="3259831549858767975">Reduzir o tamanho de todos os itens na página</translation>
+<translation id="8015452622527143194">Repor tamanho predefinido dos itens na página</translation>
+<translation id="3443221991560634068">Atualizar a página atual</translation>
+<translation id="123724288017357924">Atualizar página atual e ignorar conteúdo em cache</translation>
+<translation id="305870044889644984">Abrir Centro de Ajuda do Brave num novo separador</translation>
+<translation id="3166827708714933426">Atalhos de separadores e de janelas</translation>
+<translation id="3169981355900570544">Atalhos das funcionalidades do Brave Software Brave</translation>
+<translation id="4558311620361989323">Atalhos da página Web</translation>
+<translation id="1908301351964700579">O Brave ainda se está a preparar para a RV. Reinicie o Brave mais tarde.</translation>
+<translation id="8970887620466824814">Ocorreu um erro.</translation>
+<translation id="1875543012935658554">Reabra o Brave.</translation>
+<translation id="79859296434321399">Para ver conteúdo de realidade aumentada, instale o ARCore.</translation>
+<translation id="8558485628462305855">Para ver conteúdo de realidade aumentada, atualize o ARCore.</translation>
+<translation id="3513704683820682405">Realidade aumentada</translation>
+<translation id="5475862044948910901">Pretende iniciar a sessão de realidade aumentada?</translation>
 <translation id="7365126855094612066">Durante esta sessão, o site será capaz de:
 • criar um mapa 3D do seu ambiente
 • monitorizar movimentos da câmara
 
 O site NÃO fica com acesso à câmara. As imagens da câmara estão visíveis apenas para si.</translation>
-<translation id="7375125077091615385">Tipo:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Experiência de primeira execução do Chrome</translation>
-<translation id="741204030948306876">Sim, aceito</translation>
-<translation id="7413229368719586778">Data de início: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Perguntar primeiro</translation>
-<translation id="7423538860840206698">Leitura da área de transferência bloqueada</translation>
-<translation id="7431991332293347422">Controle a forma como o histórico de navegação é utilizado para personalizar a Pesquisa e muito mais.</translation>
-<translation id="7437998757836447326">Terminar sessão no Chrome</translation>
-<translation id="7438641746574390233">Quando o Modo Lite está ativado, o Chrome utiliza os servidores Google para carregar as páginas mais rapidamente. O Modo Lite reescreve páginas muito lentas para carregar apenas o conteúdo essencial. O Modo Lite não se aplica aos separadores de navegação anónima.</translation>
-<translation id="7444811645081526538">Mais categorias</translation>
-<translation id="7445411102860286510">Permitir que os sites reproduzam automaticamente vídeos com o som desativado (recomendado)</translation>
-<translation id="7453467225369441013">A sua sessão é terminada na maioria dos sites. A sessão na sua Conta Google não é terminada.</translation>
-<translation id="7454641608352164238">Espaço insuficiente</translation>
-<translation id="7475192538862203634">Se vê isto com frequência, experimente estas <ph name="BEGIN_LINK" />sugestões<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Cartão SD não encontrado. Alguns dos seus ficheiros poderão estar em falta.</translation>
-<translation id="7479104141328977413">Gestão de separadores</translation>
-<translation id="7481312909269577407">Avançar</translation>
-<translation id="7482656565088326534">Separador Pré-visualização</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (atualizado há <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">dados guardados</translation>
-<translation id="7498271377022651285">Aguarde…</translation>
-<translation id="7514365320538308">Transferir</translation>
-<translation id="751961395872307827">Não é possível estabelecer ligação ao site.</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Não é possível obter sugestões</translation>
-<translation id="7559975015014302720">O Modo Lite está desativado.</translation>
-<translation id="7562080006725997899">A limpar dados de navegação</translation>
-<translation id="756809126120519699">Dados do Chrome limpos</translation>
-<translation id="757524316907819857">Impedir que os sites reproduzam conteúdos protegidos</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> ficheiro transferido}other{<ph name="FILES_DOWNLOADED_MANY" /> ficheiros transferidos}}</translation>
-<translation id="7588219262685291874">Ativar o tema escuro quando a Poupança de bateria do dispositivo estiver ativada.</translation>
-<translation id="7589445247086920869">Bloquear o motor de pesquisa atual</translation>
-<translation id="7593557518625677601">Abrir definiç. Android e reativar sinc. sistema Android p/ iniciar sinc. Chrome</translation>
-<translation id="7596558890252710462">Sistema operativo</translation>
-<translation id="7605594153474022051">A sincronização não está a funcionar</translation>
-<translation id="7606077192958116810">O Modo Lite está ativado. Pode geri-lo nas Definições.</translation>
-<translation id="7612619742409846846">Iniciou sessão no Google como</translation>
-<translation id="7619072057915878432">A transferência de <ph name="FILE_NAME" /> falhou devido a falhas de rede.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Obter ajuda<ph name="END_LINK1" /> ou <ph name="BEGIN_LINK2" />voltar a procurar<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Bem-vindo ao Chrome</translation>
-<translation id="7638584964844754484">Frase de acesso incorreta</translation>
-<translation id="7641339528570811325">Limpar dados de navegação…</translation>
-<translation id="7648422057306047504">Encriptar palavras-passe com credenciais Google</translation>
-<translation id="7649070708921625228">Ajuda</translation>
-<translation id="7658239707568436148">Cancelar</translation>
-<translation id="7665369617277396874">Adicionar conta</translation>
-<translation id="766587987807204883">Os artigos são apresentados aqui e pode lê-los mesmo quando está offline.</translation>
-<translation id="7682724950699840886">Experimente as seguintes sugestões: certifique-se de que existe espaço suficiente no dispositivo e tente exportar novamente.</translation>
-<translation id="7685301384041462804">Certifique-se de que este site é de confiança antes de entrar na RV.</translation>
-<translation id="7698359219371678927">Criar email no <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Pesquisas de preenchimento automático e URLs</translation>
-<translation id="7725024127233776428">As páginas que adiciona aos marcadores aparecem aqui.</translation>
-<translation id="773466115871691567">Traduza sempre páginas em <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Para detetar aplicações e sites perigosos, o Chrome envia para a Google URLs de algumas páginas que visita, informações limitadas do sistema e algum conteúdo das páginas.</translation>
-<translation id="7757787379047923882">Texto partilhado a partir do dispositivo <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Cartão SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Adicionar endereço</translation>
-<translation id="7772032839648071052">Confirmar frase de acesso</translation>
-<translation id="7772375229873196092">Fechar <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 e mais <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Ontem</translation>
-<translation id="7791543448312431591">Adicionar</translation>
-<translation id="780301667611848630">Não, obrigado</translation>
-<translation id="7810647596859435254">Abrir com…</translation>
-<translation id="7821588508402923572">A sua poupança de dados é apresentada aqui</translation>
-<translation id="7837721118676387834">Permitir a reprodução automática dos vídeos ignorados para um site específico.</translation>
-<translation id="7846076177841592234">Cancelar seleção</translation>
-<translation id="784934925303690534">Intervalo de tempo</translation>
-<translation id="7851858861565204677">Outros aparelhos</translation>
-<translation id="7875915731392087153">Criar email</translation>
-<translation id="7876243839304621966">Remover tudo</translation>
-<translation id="7882131421121961860">Nenhum histórico encontrado</translation>
-<translation id="7882806643839505685">Permita a reprodução de som de um site específico.</translation>
-<translation id="7886917304091689118">Em execução no Chrome.</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{A transferir o ficheiro…}other{A transferir # ficheiros…}}</translation>
-<translation id="7929962904089429003">Abrir o menu</translation>
-<translation id="7942131818088350342">O <ph name="PRODUCT_NAME" /> está desatualizado.</translation>
-<translation id="7947953824732555851">Aceitar e in. sessão</translation>
-<translation id="7963646190083259054">Fornecedor:</translation>
-<translation id="7971136598759319605">Ativo há 1 dia</translation>
-<translation id="7975379999046275268">Pré-visualizar página <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Pré-carregar as páginas para uma navegação e uma pesquisa mais rápidas</translation>
-<translation id="79859296434321399">Para ver conteúdo de realidade aumentada, instale o ARCore.</translation>
-<translation id="7986741934819883144">Selecionar um contacto</translation>
-<translation id="7987073022710626672">Termos de Utilização do Chrome</translation>
-<translation id="7998918019931843664">Reabrir separador fechado</translation>
-<translation id="7999064672810608036">Tem a certeza de que pretende limpar todos os dados locais, incluindo cookies, e repor todas as autorizações para este Website?</translation>
-<translation id="8004582292198964060">Navegador</translation>
-<translation id="8007176423574883786">Desativada para este dispositivo</translation>
-<translation id="8013372441983637696">Limpar também os dados do Chrome deste dispositivo</translation>
-<translation id="8015452622527143194">Repor tamanho predefinido dos itens na página</translation>
-<translation id="802154636333426148">Falha ao transferir</translation>
-<translation id="8026334261755873520">Limpar dados de navegação</translation>
-<translation id="8035133914807600019">Nova pasta…</translation>
-<translation id="8037750541064988519">Faltam <ph name="DAYS" /> dias</translation>
-<translation id="804335162455518893">Cartão SD não encontrado.</translation>
-<translation id="805047784848435650">Baseado no seu histórico de navegação</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB disponíveis</translation>
-<translation id="8058746566562539958">Abrir num novo sep. do Chrome</translation>
-<translation id="8063895661287329888">Falha ao adicionar marcador.</translation>
-<translation id="806745655614357130">Manter os meus dados separados</translation>
-<translation id="8067883171444229417">Reproduzir vídeo</translation>
-<translation id="8068648041423924542">Não é possível selecionar o certificado.</translation>
-<translation id="8073388330009372546">Abrir imagem num novo separad.</translation>
-<translation id="8076492880354921740">Separadores</translation>
-<translation id="8084114998886531721">Palavra-passe guardada</translation>
-<translation id="8087000398470557479">Este conteúdo é proveniente de <ph name="DOMAIN_NAME" />, fornecido pela Google.</translation>
-<translation id="8103578431304235997">Separador de navegação anónima</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Para obter os seus marcadores em todos os dispositivos, ative a sincronização.</translation>
-<translation id="8110087112193408731">Pretende apresentar a sua atividade do Chrome no Bem-estar digital?</translation>
-<translation id="8116925261070264013">Com som desativado</translation>
-<translation id="813082847718468539">Ver informações do Website</translation>
-<translation id="8131740175452115882">Confirmar</translation>
-<translation id="8156139159503939589">Que idiomas lê?</translation>
-<translation id="8168435359814927499">Conteúdo</translation>
-<translation id="8186512483418048923">Faltam <ph name="FILES" /> ficheiros</translation>
-<translation id="8190358571722158785">Falta 1 dia</translation>
-<translation id="8200772114523450471">Continuar</translation>
-<translation id="8209050860603202033">Abrir imagem</translation>
-<translation id="8218622182176210845">Efetue a gestão da sua conta</translation>
-<translation id="8224471946457685718">Transferir artigos para si com Wi-Fi</translation>
-<translation id="8232956427053453090">Manter os dados</translation>
-<translation id="8249310407154411074">Mover para o início</translation>
-<translation id="8250920743982581267">Docs</translation>
-<translation id="825412236959742607">Esta página utiliza demasiada memória, pelo que o Chrome removeu algum conteúdo.</translation>
-<translation id="8260126382462817229">Experimente iniciar sessão novamente</translation>
-<translation id="8261506727792406068">Eliminar</translation>
-<translation id="8266862848225348053">Localização da transferência</translation>
-<translation id="8274165955039650276">Ver transferências</translation>
-<translation id="8284326494547611709">Legendas</translation>
-<translation id="8300705686683892304">Geridos por aplicação</translation>
-<translation id="8310344678080805313">Separadores padrão</translation>
-<translation id="8316092324682955408">De <ph name="DOMAIN_NAME" /> e de mais sites</translation>
-<translation id="8327155640814342956">Para obter a melhor experiência de navegação, abra o Chrome para o atualizar.</translation>
-<translation id="8339163506404995330">As páginas em <ph name="LANGUAGE" /> não serão traduzidas</translation>
-<translation id="8349013245300336738">Ordenar por quantidade de dados utilizados</translation>
-<translation id="8364299278605033898">Veja Websites populares</translation>
-<translation id="8368027906805972958">Dispositivo desconhecido ou não suportado (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Permitir Sincronização em segundo plano num site específico.</translation>
-<translation id="8378714024927312812">Gerido pela sua entidade</translation>
-<translation id="8380167699614421159">Este site apresenta anúncios intrusivos ou enganadores.</translation>
-<translation id="8393700583063109961">Enviar mensagem</translation>
-<translation id="8413126021676339697">Mostrar histórico completo</translation>
-<translation id="8427875596167638501">O separador Pré-visualização está aberto até meio.</translation>
-<translation id="8428213095426709021">Definições</translation>
-<translation id="8438566539970814960">Melhorar as pesquisas e a navegação</translation>
-<translation id="8441146129660941386">Procurar para trás</translation>
-<translation id="8443209985646068659">Não é possível atualizar</translation>
-<translation id="8445448999790540984">Não é possível exportar as palavras-passe</translation>
-<translation id="8447861592752582886">Revogar autorização do dispositivo</translation>
-<translation id="8461694314515752532">Encriptar dados sincronizados com a sua própria frase de acesso de sincronização</translation>
-<translation id="8466613982764129868">Certifique-se de que o <ph name="TARGET_DEVICE_NAME" /> está ligado à Internet.</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponível offline</translation>
-<translation id="8489271220582375723">Abrir a página do histórico</translation>
-<translation id="8493948351860045254">Libertar espaço</translation>
-<translation id="8497726226069778601">Ainda não há nada para ver aqui</translation>
-<translation id="8503559462189395349">Palavras-passe do Chrome</translation>
-<translation id="8503813439785031346">Nome de utilizador</translation>
-<translation id="8514477925623180633">Exportar palavras-passe armazenadas com o Chrome</translation>
-<translation id="8514577642972634246">Entrar no modo de navegação anónima</translation>
-<translation id="851751545965956758">Impedir a ligação de sites a dispositivos</translation>
-<translation id="8523928698583292556">Eliminar palavra-passe armazenada</translation>
-<translation id="854522910157234410">Abrir esta página</translation>
-<translation id="8558485628462305855">Para ver conteúdo de realidade aumentada, atualize o ARCore.</translation>
-<translation id="8559990750235505898">Propor a tradução de páginas noutros idiomas</translation>
-<translation id="8562452229998620586">As palavras-passe guardadas aparecem aqui.</translation>
-<translation id="8569404424186215731">desde <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Últimas 4 semanas</translation>
-<translation id="857943718398505171">Permitido (recomendado)</translation>
-<translation id="8583805026567836021">A limpar os dados da conta</translation>
-<translation id="860043288473659153">Nome do titular do cartão</translation>
-<translation id="8609465669617005112">Mover para cima</translation>
-<translation id="8616006591992756292">A sua Conta Google pode ter outras formas do histórico de navegação em <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Pretende abrir o URL sugerido que é especificado no conteúdo transferido?</translation>
-<translation id="8636825310635137004">Para obter os separadores dos seus outros dispositivos, ative a sincronização.</translation>
-<translation id="8641930654639604085">Tentar bloquear sites para adultos</translation>
-<translation id="8655129584991699539">Pode limpar os dados nas Definições do Chrome.</translation>
-<translation id="8662811608048051533">A sua sessão é terminada na maioria dos sites.</translation>
-<translation id="8664979001105139458">O nome do ficheiro já existe</translation>
-<translation id="8676374126336081632">Limpar texto</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Nível de intensidade do sinal: # barra}other{Nível de intensidade do sinal: # barras}}</translation>
-<translation id="868929229000858085">Pesquise os seus contactos</translation>
-<translation id="869891660844655955">Data de expiração</translation>
-<translation id="8719023831149562936">Impossível transmitir o separador atual</translation>
-<translation id="8725066075913043281">Tentar novamente</translation>
-<translation id="8728487861892616501">Ao utilizar esta aplicação, está a concordar com os <ph name="BEGIN_LINK1" />Termos de Utilização<ph name="END_LINK1" /> e o <ph name="BEGIN_LINK2" />Aviso de Privacidade<ph name="END_LINK2" /> do Chrome, bem como com o <ph name="BEGIN_LINK3" />Aviso de Privacidade para Contas Google Geridas com o Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Concluído</translation>
-<translation id="8748850008226585750">Conteúdo ocultado</translation>
-<translation id="8751914237388039244">Selecionar uma imagem</translation>
-<translation id="8788265440806329501">O histórico de navegação está fechado.</translation>
-<translation id="8788968922598763114">Reabrir o último separador fechado</translation>
-<translation id="8801436777607969138">Bloqueie JavaScript num site específico.</translation>
-<translation id="8812260976093120287">Nalguns Sites, é possível pagar com as aplicações de pagamento compatíveis acima no dispositivo.</translation>
-<translation id="8816026460808729765">Impedir que os sites acedam aos sensores</translation>
-<translation id="8816439037877937734">A aplicação <ph name="APP_NAME" /> será aberta no Chrome. Ao continuar, aceita os <ph name="BEGIN_LINK1" />Termos de Utilização<ph name="END_LINK1" /> e o <ph name="BEGIN_LINK2" />Aviso de Privacidade<ph name="END_LINK2" /> do Chrome, bem como o <ph name="BEGIN_LINK3" />Aviso de Privacidade para Contas Google Geridas com o Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Marcadores</translation>
-<translation id="8833831881926404480">Um site está a partilhar o seu ecrã</translation>
-<translation id="883806473910249246">Ocorreu um erro ao transferir o conteúdo.</translation>
-<translation id="8840953339110955557">Esta página pode ser diferente da versão online.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Separador <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Armazenamento</translation>
-<translation id="889338405075704026">Aceder às definições do Chrome</translation>
-<translation id="8901170036886848654">Nenhum marcador encontrado</translation>
-<translation id="8909135823018751308">Partilhar…</translation>
-<translation id="8912362522468806198">Conta Google</translation>
-<translation id="8920114477895755567">A aguardar os detalhes dos pais.</translation>
+<translation id="1188239144602654184">Aceder à realidade aumentada</translation>
+<translation id="473775607612524610">Atualizar</translation>
+<translation id="3133489217401741157">A instalar o módulo <ph name="MODULE"/> para o Brave…</translation>
+<translation id="1791662854739702043">Instalado</translation>
+<translation id="5131234170665854056">Não é possível instalar o módulo <ph name="MODULE"/> para o Brave.</translation>
+<translation id="2567385386134582609">IMAGEM</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VÍDEO</translation>
+<translation id="4116038641877404294">Transfira páginas para as utilizar offline.</translation>
 <translation id="8922289737868596582">Transfira páginas através do botão Mais opções para as utilizar offline.</translation>
-<translation id="8937772741022875483">Pretende remover a sua atividade do Chrome do Bem-estar digital?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Abrir noutra janela</translation>
-<translation id="8951232171465285730">O Chrome permitiu-lhe poupar <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Bloqueie cookies para um site específico.</translation>
-<translation id="8959122750345127698">A navegação está inacessível: <ph name="URL" /></translation>
-<translation id="8965591936373831584">pendente</translation>
-<translation id="8970887620466824814">Ocorreu um erro.</translation>
-<translation id="8972098258593396643">Pretende transferir para a pasta predefinida?</translation>
-<translation id="8986494364107987395">Enviar automaticamente estatísticas de utilização e relatórios de falhas para a Google</translation>
-<translation id="8993760627012879038">Abrir novo separador no modo de navegação anónima</translation>
-<translation id="8998729206196772491">Está a iniciar sessão com uma conta gerida por <ph name="MANAGED_DOMAIN" /> e a conceder ao respetivo gestor o controlo dos seus dados do Chrome. Os dados ficarão permanentemente associados a esta conta. Terminar sessão no Chrome elimina os seus dados deste dispositivo, embora permaneçam armazenados na Conta Google.</translation>
-<translation id="9019902583201351841">Gerido pelos teus pais</translation>
-<translation id="9028914725102941583">Ative a sincronização para partilhar entre dispositivos</translation>
-<translation id="9029323097866369874">Pretende permitir que <ph name="DOMAIN" /> entre na RV?</translation>
-<translation id="9040142327097499898">As notificações são permitidas. A localização está desativada para este dispositivo.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# vídeo}other{# vídeos}}</translation>
-<translation id="9050666287014529139">Frase de acesso</translation>
-<translation id="9063523880881406963">Desativar Pedir site para computador</translation>
-<translation id="9065203028668620118">Editar</translation>
-<translation id="9070377983101773829">Iniciar pesquisa por voz</translation>
-<translation id="9074336505530349563">Para obter conteúdo personalizado sugerido pelo Google, inicie sessão e ative a sincronização.</translation>
-<translation id="9086455579313502267">Não é possível aceder à rede</translation>
-<translation id="9100505651305367705">Sugerir a apresentação de artigos na vista simplificada, quando suportada</translation>
-<translation id="9100610230175265781">Frase de acesso obrigatória</translation>
-<translation id="9102803872260866941">O separador Pré-visualização está aberto</translation>
+<translation id="5958275228015807058">Encontre os seus ficheiros e páginas nas Transferências.</translation>
+<translation id="5620928963363755975">Encontre os seus ficheiros e páginas nas Transferências através do botão Mais opções.</translation>
+<translation id="3341058695485821946">Veja a quantidade de dados que poupou.</translation>
+<translation id="3157842584138209013">Veja a quantidade de dados que poupou através do botão Mais opções.</translation>
+<translation id="8218622182176210845">Efetue a gestão da sua conta</translation>
+<translation id="8090895580117672212">Para gerir a sua Conta Brave Software, toque no botão "Gerir conta".</translation>
+<translation id="8856898588039823173">Página em modo lite fornecida pela Brave Software. Toque para carregar a página original.</translation>
+<translation id="8134317863207426198">Página em modo lite fornecida pela Brave Software. Toque no botão Carregar original para carregar a página original.</translation>
+<translation id="4961107849584082341">Traduzir esta página para qualquer idioma</translation>
+<translation id="569536719314091526">Traduzir esta página para qualquer idioma a partir do botão Mais opções</translation>
+<translation id="1397811292916898096">Pesquisar com o <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Altere a localização de transferência predefinida em qualquer altura.</translation>
+<translation id="6942665639005891494">Altere a localização de transferência predefinida em qualquer altura ao utilizar a opção do menu Definições.</translation>
+<translation id="6850409657436465440">A transferência ainda está em curso.</translation>
+<translation id="5817715962196959877">O Brave agora transfere os ficheiros mais rapidamente.</translation>
+<translation id="3976396876660209797">Remova este atalho e crie-o novamente</translation>
+<translation id="6766622839693428701">Deslize rapidamente para baixo para fechar.</translation>
+<translation id="1028699632127661925">A enviar para <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Enviado de <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Separador recebido</translation>
 <translation id="9104217018994036254">Lista de dispositivos com os quais pretende partilhar um separador.</translation>
-<translation id="9133397713400217035">Explorar offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Mostrar original</translation>
-<translation id="9139068048179869749">Perguntar antes de permitir que os sites enviem notificações (recomendado)</translation>
-<translation id="9139318394846604261">Compras</translation>
-<translation id="9155898266292537608">Também pode pesquisar ao tocar rapidamente numa palavra.</translation>
-<translation id="9169507124922466868">O histórico de navegação está aberto até meio.</translation>
-<translation id="9204836675896933765">Falta 1 ficheiro</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Lista de dispositivos com os quais pretende partilhar um separador aberta a meia altura.</translation>
+<translation id="2904414404539560095">Lista de dispositivos com os quais pretende partilhar um separador aberta à altura total.</translation>
+<translation id="4135200667068010335">A lista de dispositivos com os quais pretende partilhar um separador está fechada.</translation>
+<translation id="5292796745632149097">Enviar para</translation>
+<translation id="1386674309198842382">Ativo há <ph name="LAST_UPDATED"/> dias</translation>
+<translation id="7971136598759319605">Ativo há 1 dia</translation>
+<translation id="1521774566618522728">Ativo hoje</translation>
+<translation id="3631987586758005671">A partilhar com <ph name="DEVICE_NAME"/>…</translation>
+<translation id="9028914725102941583">Ative a sincronização para partilhar entre dispositivos</translation>
+<translation id="6162454065885854378">Para partilhar conteúdos do seu telemóvel com outro dispositivo, ative a sincronização nas definições do Brave em ambos os dispositivos.</translation>
+<translation id="6084271560289605378">Aceder às definições do Brave</translation>
+<translation id="2318045970523081853">Toque para efetuar uma chamada</translation>
 <translation id="9209888181064652401">Não é possível efetuar chamadas</translation>
-<translation id="9219103736887031265">Imagens</translation>
-<translation id="926205370408745186">Remova a atividade do Chrome do Bem-estar digital</translation>
-<translation id="932327136139879170">Página inicial</translation>
-<translation id="938850635132480979">Erro: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Aceder ao microfone</translation>
-<translation id="95817756606698420">O Chrome pode utilizar o <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> para pesquisar na China. Pode alterar esta opção nas <ph name="BEGIN_LINK" />Definições<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Bloquear se o site apresentar anúncios intrusivos ou enganadores (recomendado)</translation>
-<translation id="968900484120156207">As páginas que visita aparecem aqui.</translation>
-<translation id="970715775301869095">Faltam <ph name="MINUTES" /> minutos</translation>
-<translation id="974555521953189084">Introduza a frase de acesso para iniciar a sincronização</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Esta ação limpa os dados de todos os sites, incluindo:</translation>
-<translation id="983192555821071799">Fechar todos os separadores</translation>
-<translation id="987264212798334818">Geral</translation>
+<translation id="2860954141821109167">Certifique-se de que uma aplicação de telefone está ativada neste dispositivo.</translation>
+<translation id="2067805253194386918">texto</translation>
+<translation id="1450753235335490080">Não é possível partilhar <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Não foi possível partilhar <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Certifique-se de que o <ph name="TARGET_DEVICE_NAME"/> tem a sincronização ativada no Brave.</translation>
+<translation id="3016635187733453316">Certifique-se de que este dispositivo está ligado à Internet.</translation>
+<translation id="8466613982764129868">Certifique-se de que o <ph name="TARGET_DEVICE_NAME"/> está ligado à Internet.</translation>
+<translation id="6539092367496845964">Ocorreu um erro. Tente novamente mais tarde.</translation>
+<translation id="3389286852084373014">O texto é demasiado grande</translation>
+<translation id="2100314319871056947">Experimente partilhar o texto em partes mais pequenas.</translation>
+<translation id="2987620471460279764">Texto partilhado de outro dispositivo</translation>
+<translation id="7757787379047923882">Texto partilhado a partir do dispositivo <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Copiado para a área de transferência.</translation>
+<translation id="4696983787092045100">Envie uma mensagem de texto para os seus dispositivos</translation>
+<translation id="1260236875608242557">Pesquisar e explorar</translation>
+<translation id="6369229450655021117">A partir daqui, pode pesquisar na Web, partilhar com amigos e ver as páginas abertas.</translation>
+<translation id="723171743924126238">Selecionar imagens</translation>
+<translation id="8751914237388039244">Selecionar uma imagem</translation>
+<translation id="1989112275319619282">Procurar</translation>
+<translation id="7055152154916055070">Redirecionamento bloqueado:</translation>
+<translation id="5524843473235508879">Redirecionamento bloqueado.</translation>
+<translation id="6573096386450695060">Permitir sempre</translation>
+<translation id="5805364706385912897">Esta página utiliza demasiada memória, pelo que o Brave a colocou em pausa.</translation>
+<translation id="5138664332909611586">Esta página utiliza demasiada memória, pelo que o Brave removeu algum conteúdo.</translation>
+<translation id="9137013805542155359">Mostrar original</translation>
+<translation id="6361779936989026201">Assistente Brave Software no Brave</translation>
+<translation id="7291387454912369099">Assistente para o Preenchimento automático</translation>
+<translation id="4565206163201411670">Pretende apresentar a sua atividade do Brave no Bem-estar digital?</translation>
+<translation id="9055113864158719823">Pode ver os sites que visita no Brave e definir temporizadores para os mesmos.\n\nA Brave Software obtém informações sobre os sites para os quais define temporizadores e durante quanto tempo os visita. Estas informações são utilizadas para melhorar o Bem-estar digital.</translation>
+<translation id="4596514158372210596">Remova a atividade do Brave do Bem-estar digital</translation>
+<translation id="1174893863889683998">Pretende remover a sua atividade do Brave do Bem-estar digital?</translation>
+<translation id="708829030563435351">Os sites que visitar no Brave não serão apresentados. Todos os temporizadores do site serão eliminados.</translation>
+<translation id="2056878612599315956">Site em pausa</translation>
+<translation id="671481426037969117">O temporizador da aplicação <ph name="FQDN"/> terminou. Recomeça amanhã.</translation>
+<translation id="7479104141328977413">Gestão de separadores</translation>
+<translation id="3524138585025253783">IU do programador</translation>
+<translation id="6036057147555329831">ICU extra</translation>
+<translation id="9029323097866369874">Pretende permitir que <ph name="DOMAIN"/> entre na RV?</translation>
+<translation id="7685301384041462804">Certifique-se de que este site é de confiança antes de entrar na RV.</translation>
+<translation id="5033865233969348410">Enquanto estiver na RV, este site consegue saber:
+  -  as suas caraterísticas físicas, como a altura.
+
+Certifique-se de que confia neste site antes de entrar na RV.</translation>
+<translation id="5534334044554683961">Enquanto estiver na RV, este site consegue saber:
+  -   as suas caraterísticas físicas, como a altura;
+  -   a disposição do seu quarto.
+
+Certifique-se de que confia neste site antes de entrar na RV.</translation>
+<translation id="4169535189173047238">Não permitir</translation>
+<translation id="2170088579611075216">Permitir e iniciar RV</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ro.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ro.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ro">
-<translation id="1006017844123154345">Deschide online</translation>
-<translation id="1028699632127661925">Se trimite la <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Se adaugă <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">De la site-uri</translation>
-<translation id="1049743911850919806">Incognito</translation>
-<translation id="10614374240317010">Nu se salvează niciodată</translation>
-<translation id="1067922213147265141">Alte servicii Google</translation>
-<translation id="1068672505746868501">Nu traduce niciodată paginile în <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Dacă modifici extensia de fișier, fișierul poate să se deschidă în altă aplicație și să dăuneze dispozitivului.</translation>
-<translation id="1100066534610197918">Deschide în filă nouă în grup</translation>
-<translation id="1105960400813249514">Captură de ecran</translation>
-<translation id="1111673857033749125">Marcajele salvate pe alte dispozitive vor apărea aici.</translation>
-<translation id="1113597929977215864">Arată afișarea simplificată</translation>
-<translation id="1121094540300013208">Statistici de utilizare și rapoarte de blocare</translation>
-<translation id="1124772482545689468">Utilizator</translation>
-<translation id="1129510026454351943">Detalii: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{O descărcare în așteptare.}few{# descărcări în așteptare.}other{# de descărcări în așteptare.}}</translation>
-<translation id="1145536944570833626">Șterge datele existente.</translation>
-<translation id="1146678959555564648">Intră în RV</translation>
-<translation id="116280672541001035">Utilizate</translation>
-<translation id="1171770572613082465">Vezi site-uri populare atingând butonul „Site-uri de top”</translation>
-<translation id="1173894706177603556">Redenumește</translation>
-<translation id="1178581264944972037">Întrerupe</translation>
-<translation id="1181037720776840403">Elimină</translation>
-<translation id="1188239144602654184">Intră în RA</translation>
-<translation id="1197267115302279827">Mută marcaje</translation>
-<translation id="119944043368869598">Șterge-le pe toate</translation>
-<translation id="1201402288615127009">Înainte</translation>
-<translation id="1204037785786432551">Descarcă linkul</translation>
-<translation id="1206892813135768548">Copiază textul linkului</translation>
-<translation id="1208340532756947324">Pentru a sincroniza și a personaliza pe toate dispozitivele, activează sincronizarea</translation>
-<translation id="1209206284964581585">Ascunde momentan</translation>
-<translation id="1227058898775614466">Istoric de navigare</translation>
-<translation id="1231733316453485619">Activezi sincronizarea?</translation>
-<translation id="123724288017357924">Reîncarcă pagina, ignorând conținutul din cache</translation>
-<translation id="124116460088058876">Mai multe limbi</translation>
-<translation id="124678866338384709">Închide fila actuală</translation>
-<translation id="1258753120186372309">Doodle Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Caută și explorează</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Nu s-a trimis <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Oprește</translation>
-<translation id="1283039547216852943">Atinge pentru a extinde</translation>
-<translation id="1285320974508926690">Nu traduce niciodată acest site</translation>
-<translation id="1291207594882862231">Șterge istoricul, cookie-urile, datele privind site-urile și memoria cache…</translation>
-<translation id="129382876167171263">Fișierele salvate de site-uri apar aici</translation>
-<translation id="129553762522093515">Închise recent</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Trimis de la <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Grupează file</translation>
-<translation id="1327257854815634930">Istoricul de navigare este deschis</translation>
-<translation id="1331212799747679585">Chrome nu se poate actualiza. Mai multe opțiuni</translation>
-<translation id="1332501820983677155">Comenzi rapide pentru funcțiile Google Chrome</translation>
-<translation id="1360432990279830238">Te deconectezi și dezactivezi sincronizarea?</translation>
-<translation id="1369915414381695676">Site-ul <ph name="SITE_NAME" /> a fost adăugat</translation>
-<translation id="1373696734384179344">Memorie insuficientă pentru descărcarea conținutului selectat.</translation>
-<translation id="1376578503827013741">Se calculează…</translation>
-<translation id="1383876407941801731">Caută</translation>
-<translation id="1384959399684842514">Descărcare întreruptă</translation>
-<translation id="1386674309198842382">Activ acum <ph name="LAST_UPDATED" /> zile</translation>
-<translation id="1397811292916898096">Caută folosind <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Încorporat în <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">„Nu urmări”</translation>
-<translation id="1407135791313364759">Deschideți-le pe toate</translation>
-<translation id="1409426117486808224">Afișare simplificată pentru filele deschise</translation>
-<translation id="1409879593029778104">Descărcarea fișierului <ph name="FILE_NAME" /> a fost împiedicată, deoarece fișierul există deja.</translation>
-<translation id="1414981605391750300">Se contactează Google. Poate dura un minut...</translation>
-<translation id="1416550906796893042">Versiunea aplicației</translation>
-<translation id="1430915738399379752">Printează</translation>
-<translation id="1446450296470737166">Control complet dispozitive MIDI</translation>
-<translation id="1450753235335490080">Nu se poate trimite <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Dezactivată din Setări Android</translation>
-<translation id="1477626028522505441">Descărcarea fișierului <ph name="FILE_NAME" /> nu a reușit din cauza unor probleme de server.</translation>
-<translation id="1506061864768559482">Motor de căutare</translation>
-<translation id="1513352483775369820">Marcaje și istoric web</translation>
-<translation id="1513858653616922153">Șterge parola</translation>
-<translation id="1516229014686355813">Funcția Atinge pentru a căuta trimite cuvântul selectat și pagina actuală drept context către Căutarea Google. Poți dezactiva această funcție din <ph name="BEGIN_LINK" />Setări<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Activ astăzi</translation>
-<translation id="1544826120773021464">Pentru a gestiona contul Google, atinge butonul „Gestionează contul”</translation>
-<translation id="1549000191223877751">Mută în altă fereastră</translation>
-<translation id="1553358976309200471">Actualizează Chrome</translation>
-<translation id="1569387923882100876">Dispozitiv conectat</translation>
-<translation id="1571304935088121812">Copiază numele de utilizator</translation>
-<translation id="1612196535745283361">Chrome necesită accesul la locație pentru a căuta dispozitive. Accesul la locație este <ph name="BEGIN_LINK" />dezactivat pentru acest dispozitiv<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Cameră</translation>
-<translation id="1623104350909869708">Restricționați capacitatea acestei pagini de a crea casete de dialog suplimentare</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Elimină un element selectat}few{Elimină # elemente selectate}other{Elimină # de elemente selectate}}</translation>
-<translation id="164269334534774161">Se afișează o versiune offline a acestei pagini de pe <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Istoric</translation>
-<translation id="1647391597548383849">Accesează camera foto</translation>
-<translation id="1660204651932907780">Permite site-urilor să redea sunet (recomandat)</translation>
-<translation id="1670399744444387456">De bază</translation>
-<translation id="1671236975893690980">Descărcare în așteptare…</translation>
-<translation id="1672586136351118594">Nu mai afișa</translation>
-<translation id="1692118695553449118">Sincronizarea este activată</translation>
-<translation id="169515064810179024">Împiedică site-urile să acceseze senzorii de mișcare</translation>
-<translation id="1717218214683051432">Senzori de mișcare</translation>
-<translation id="1718835860248848330">Ultima oră</translation>
-<translation id="1736419249208073774">Explorează</translation>
-<translation id="1743802530341753419">Întreabă înainte de a permite site-urilor să se conecteze la un dispozitiv (recomandat)</translation>
-<translation id="1749561566933687563">Sincronizează marcajele</translation>
-<translation id="17513872634828108">File deschise</translation>
-<translation id="1779089405699405702">Decodor de imagini</translation>
-<translation id="1782483593938241562">Data de încheiere <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Instalat</translation>
-<translation id="1792959175193046959">Schimbă oricând locația de descărcare prestabilită</translation>
-<translation id="1807246157184219062">Luminos</translation>
-<translation id="1810845389119482123">Configurarea inițială a sincronizării nu este finalizată</translation>
-<translation id="1821253160463689938">Folosește cookie-uri pentru a-ți reține preferințele, chiar dacă nu accesezi paginile respective</translation>
-<translation id="1829244130665387512">Găsește în pagină</translation>
-<translation id="1853692000353488670">Filă incognito nouă</translation>
-<translation id="1856325424225101786">Resetezi modul Lite?</translation>
-<translation id="1868024384445905608">Acum Chrome descarcă mai rapid fișierele</translation>
-<translation id="1883903952484604915">Fișierele mele</translation>
-<translation id="1887786770086287077">Accesul la locație este dezactivat pentru acest dispozitiv. Activează-l în <ph name="BEGIN_LINK" />Setări Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> se va deschide în Chrome. Continuând, ești de acord cu <ph name="BEGIN_LINK1" />Termenii și condițiile<ph name="END_LINK1" /> și <ph name="BEGIN_LINK2" />Notificarea privind confidențialitatea<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="1919345977826869612">Anunțuri</translation>
-<translation id="1919950603503897840">Selectează persoane de contact</translation>
-<translation id="1922076542920281912">Pentru a permite Chrome să acceseze locația, activează locația și în <ph name="BEGIN_LINK" />Setările Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Actualizări</translation>
-<translation id="19288952978244135">Redeschide Chrome.</translation>
-<translation id="1933845786846280168">Fila selectată</translation>
-<translation id="194341124344773587">Activează permisiunea pentru Chrome din <ph name="BEGIN_LINK" />Setări Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Parole salvate</translation>
-<translation id="1952172573699511566">Site-urile vor afișa textul în limba ta preferată, dacă este posibil.</translation>
-<translation id="1960290143419248813">Actualizările Chrome nu mai sunt acceptate pentru această versiune de Android</translation>
-<translation id="1966710179511230534">Actualizați detaliile de conectare.</translation>
-<translation id="1974060860693918893">Avansate</translation>
-<translation id="1984705450038014246">Sincronizează datele din Chrome</translation>
-<translation id="1984937141057606926">Permise, cu excepția celor terță parte</translation>
-<translation id="1986685561493779662">Numele există deja</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> Butonul <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Răsfoiește</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> dorește să se asocieze</translation>
-<translation id="1994173015038366702">Adresa URL a site-ului</translation>
-<translation id="2000419248597011803">Trimite anumite cookie-uri și căutări din bara de adrese și din caseta de căutare în motorul de căutare prestabilit</translation>
-<translation id="2002537628803770967">Carduri de credit și adrese care folosesc Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{Un fișier}few{# fișiere}other{# de fișiere}}</translation>
-<translation id="2017836877785168846">Șterge istoricul și completările automate din bara de adrese.</translation>
-<translation id="2021896219286479412">Comenzi site în ecran complet</translation>
-<translation id="2038563949887743358">Activează opțiunea Versiune site pentru desktop</translation>
-<translation id="2041019821020695769">Pentru a permite Chrome să îți trimită notificări, activează notificările și în <ph name="BEGIN_LINK" />Setările Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Și <ph name="APP_NAME" /> are date în Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Site-ul a fost întrerupt</translation>
-<translation id="2063713494490388661">Atinge pentru a căuta</translation>
-<translation id="2067805253194386918">text</translation>
-<translation id="2079545284768500474">Anulează</translation>
-<translation id="2082238445998314030">Rezultatul <ph name="RESULT_NUMBER" /> din <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Sunet</translation>
-<translation id="2096012225669085171">Sincronizează și personalizează pe toate dispozitivele</translation>
-<translation id="2100273922101894616">Conectare automată</translation>
-<translation id="2100314319871056947">Împarte textul în fragmente mai mici</translation>
-<translation id="2107397443965016585">Întreabă înainte de a permite site-urilor să redea conținut protejat (recomandat)</translation>
-<translation id="2111511281910874386">Accesează pagina</translation>
-<translation id="2122601567107267586">Aplicația nu poate fi deschisă</translation>
-<translation id="2126426811489709554">Afișată de Chrome</translation>
-<translation id="2131665479022868825">Date economisite: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Fila <ph name="TAB_TITLE" /> a fost închisă</translation>
-<translation id="2139186145475833000">Adaugă pe ecran pornire</translation>
-<translation id="2146738493024040262">Deschide aplicația instantanee</translation>
-<translation id="2148716181193084225">Astăzi</translation>
-<translation id="2154484045852737596">Editează cardul</translation>
-<translation id="2154710561487035718">Copiați adresa URL</translation>
-<translation id="2156074688469523661">Site-uri rămase (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Ca să trimiți ceva de pe telefon pe alt dispozitiv, activează sincronizarea în setările Chrome pe ambele dispozitive</translation>
-<translation id="2170088579611075216">Permite și intră în RV</translation>
-<translation id="218608176142494674">Trimitere</translation>
-<translation id="2227444325776770048">Continuă ca <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sincronizarea și serviciile Google</translation>
-<translation id="2259659629660284697">Exportă parolele…</translation>
-<translation id="2268044343513325586">Rafinează</translation>
-<translation id="2286841657746966508">Adresa de facturare</translation>
-<translation id="2289270750774289114">Întreabă-mă când un site dorește să descopere dispozitive Bluetooth din apropiere (recomandat)</translation>
-<translation id="230115972905494466">Nu s-au găsit dispozitive compatibile</translation>
-<translation id="2315043854645842844">Selectarea certificatelor pe partea de client nu este acceptată de sistemul de operare.</translation>
-<translation id="2318045970523081853">Atinge pentru a apela</translation>
-<translation id="2321086116217818302">Se pregătesc parolele…</translation>
-<translation id="2321958826496381788">Trage cursorul până poți citi textul cu ușurință. Textul trebuie să fie cel puțin la fel de mare ca acesta după o atingere dublă pe un paragraf.</translation>
-<translation id="2323763861024343754">Stocarea site-urilor</translation>
-<translation id="2328985652426384049">Nu se poate conecta</translation>
-<translation id="2330129964253841015">Avertizează-mă dacă parolele au fost compromise</translation>
-<translation id="2349710944427398404">Totalul datelor folosite de Chrome, inclusiv conturile, marcajele și setările salvate</translation>
-<translation id="2353636109065292463">Se verifică conexiunea la internet</translation>
-<translation id="2359808026110333948">Continuă</translation>
-<translation id="2369533728426058518">file deschise</translation>
-<translation id="2387895666653383613">Scalarea textului</translation>
-<translation id="2394602618534698961">Fișierele pe care le descarci apar aici</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Când te conectezi la Contul Google, această funcție este activată</translation>
-<translation id="2410754283952462441">Alege un cont</translation>
-<translation id="2414886740292270097">Întunecat</translation>
-<translation id="2416359993254398973">Chrome are nevoie de permisiune ca să acceseze camera foto pentru acest site.</translation>
-<translation id="2426805022920575512">Alege alt cont</translation>
-<translation id="2433507940547922241">Aspect</translation>
-<translation id="2434158240863470628">Descărcare finalizată <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Accesul la locație</translation>
-<translation id="2450083983707403292">Dorești să se înceapă din nou descărcarea pentru <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Notificări</translation>
-<translation id="2490684707762498678">Gestionate de <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Asistentul Google în Chrome</translation>
-<translation id="2496180316473517155">Istoricul de navigare</translation>
-<translation id="2497852260688568942">Sincronizarea este dezactivată de administrator</translation>
-<translation id="2498359688066513246">Ajutor și feedback</translation>
-<translation id="2501278716633472235">Înapoi</translation>
-<translation id="2513403576141822879">Pentru mai multe setări privind confidențialitatea, securitatea și colectarea datelor, consultă <ph name="BEGIN_LINK" />Sincronizare și servicii Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">În modul Lite, Chrome încarcă mai repede paginile și folosește cu până la 60 % mai puține date. Pentru a optimiza paginile pe care le accesezi, Chrome trimite traficul tău web la Google. <ph name="BEGIN_LINK" />Află mai multe<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Trimite la Google adresele URL ale paginilor pe care le accesezi</translation>
-<translation id="2532336938189706096">Vizualizare pe web</translation>
-<translation id="2534155362429831547">Elemente șterse: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Se afișează o versiune offline a acestei pagini</translation>
-<translation id="2546283357679194313">Cookie-uri și date privind site-ul</translation>
-<translation id="2567385386134582609">IMAGINE</translation>
-<translation id="257088987046510401">Teme</translation>
-<translation id="2570922361219980984">Accesul la locație este dezactivat și pentru acest dispozitiv. Activează-l în <ph name="BEGIN_LINK" />Setări Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Afișare extinsă – dă clic pentru a restrânge.</translation>
-<translation id="2581165646603367611">Astfel, vor fi șterse cookie-urile, memoria cache și alte date ale site-urilor pe care Chrome nu le consideră importante.</translation>
-<translation id="2586657967955657006">Clipboard</translation>
-<translation id="2587052924345400782">Este disponibilă o versiune mai nouă</translation>
-<translation id="2593272815202181319">Un singur spațiu</translation>
-<translation id="2612676031748830579">Număr card</translation>
-<translation id="2621115761605608342">Permite JavaScript pentru un anumit site.</translation>
-<translation id="2625189173221582860">Parola a fost copiată</translation>
-<translation id="2631006050119455616">Economisite</translation>
-<translation id="2647434099613338025">Adaugă o limbă</translation>
-<translation id="2650751991977523696">Descarci din nou fișierul?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{Un fișier audio}few{# fișiere audio}other{# de fișiere audio}}</translation>
-<translation id="2653659639078652383">Trimite</translation>
-<translation id="2677748264148917807">Ieși</translation>
-<translation id="2704606927547763573">Copiat</translation>
-<translation id="2707726405694321444">Actualizează pagina</translation>
-<translation id="2709516037105925701">Completare automată</translation>
-<translation id="2717722538473713889">Adrese de e-mail</translation>
-<translation id="2728754400939377704">Sortează după site</translation>
-<translation id="2744248271121720757">Atinge un cuvânt pentru a căuta instantaneu sau pentru a vedea acțiuni conexe</translation>
-<translation id="2760989362628427051">Activează tema întunecată când este activată tema întunecată sau Economisirea bateriei pentru dispozitiv</translation>
-<translation id="2762000892062317888">adineauri</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> sec. rămase</translation>
-<translation id="2779651927720337254">nereușită</translation>
-<translation id="2781151931089541271">1 sec. rămasă</translation>
-<translation id="2801022321632964776">Actualizează pentru a descărca limba ta în cea mai recentă versiune de Chrome</translation>
-<translation id="2810645512293415242">Pagină simplificată pentru economie de date și încărcare mai rapidă.</translation>
-<translation id="281504910091592009">Vezi și gestionează parolele salvate în <ph name="BEGIN_LINK" />Contul Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Pentru a accesa marcajele pe toate dispozitivele, conectează-te și activează sincronizarea</translation>
-<translation id="2822354292072154809">Sigur dorești să resetezi toate permisiunile la nivel de site pentru <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Atinge butonul Înapoi pentru a ieși din ecranul complet.</translation>
-<translation id="2842985007712546952">Dosar părinte</translation>
-<translation id="2858138569776157458">Site-uri de top</translation>
-<translation id="2860954141821109167">Verifică dacă pe dispozitiv este activată o aplicație de telefon</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Melodia anterioară</translation>
-<translation id="2876369937070532032">Trimite la Google adrese URL ale unor pagini pe care le accesezi, când securitatea este în pericol</translation>
-<translation id="2888126860611144412">Despre Chrome</translation>
-<translation id="2891154217021530873">Oprește încărcarea paginii</translation>
-<translation id="2893180576842394309">Google poate folosi istoricul pentru a personaliza Căutarea și alte servicii Google</translation>
-<translation id="2898264748040935573">Editează parola stocată</translation>
-<translation id="2900528713135656174">Creează un eveniment</translation>
-<translation id="290376772003165898">Pagina nu este în <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Lista de dispozitive pe care să trimiți o filă este deschisă la înălțimea completă.</translation>
-<translation id="2910701580606108292">Întreabă înainte de a permite site-urilor să redea conținut protejat</translation>
-<translation id="2913331724188855103">Permite site-urilor să salveze și să citească datele asociate cookie-urilor (recomandat)</translation>
-<translation id="2923908459366352541">Numele nu este valid</translation>
-<translation id="2932150158123903946">Stocarea Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Fila de previzualizare este închisă</translation>
-<translation id="2956410042958133412">Acest cont este gestionat de <ph name="PARENT_NAME_1" /> și de <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Ai comutat la filele incognito</translation>
-<translation id="2968755619301702150">Vizualizator de certificate</translation>
-<translation id="2979025552038692506">Fila incognito selectată</translation>
-<translation id="2987620471460279764">Text trimis de pe alt dispozitiv</translation>
-<translation id="2989523299700148168">Accesate recent</translation>
-<translation id="2996291259634659425">Creează o expresie de acces</translation>
-<translation id="2996809686854298943">Adresă URL obligatorie</translation>
-<translation id="300526633675317032">Astfel, se vor șterge <ph name="SIZE_IN_KB" /> din stocarea site-urilor.</translation>
-<translation id="3016635187733453316">Verifică dacă dispozitivul este conectat la internet</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB descărcați</translation>
-<translation id="3029704984691124060">Expresiile de acces nu corespund</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Obține ajutor<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Locația este dezactivată; activeaz-o în <ph name="BEGIN_LINK" />Setări Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Poți să activezi sincronizarea oricând în setări</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> marcaj}few{<ph name="BOOKMARKS_COUNT_MANY" /> marcaje}other{<ph name="BOOKMARKS_COUNT_MANY" /> de marcaje}}</translation>
-<translation id="3089395242580810162">Deschide într-o filă incognito</translation>
-<translation id="3115898365077584848">Afișează informațiile</translation>
-<translation id="3123473560110926937">Blocate pe anumite site-uri</translation>
-<translation id="3137521801621304719">Ieși din modul incognito</translation>
-<translation id="3143515551205905069">Anulează sincronizarea</translation>
-<translation id="3157842584138209013">Vezi ce volum de date ai economisit folosind butonul Mai multe opțiuni</translation>
-<translation id="3166827708714933426">Comenzi rapide pentru file și ferestre</translation>
-<translation id="3181954750937456830">Navigare sigură (protecție împotriva site-urilor periculoase)</translation>
-<translation id="3190152372525844641">Activează permisiunile pentru Chrome din <ph name="BEGIN_LINK" />Setări Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">Date stocate: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Aproape gata!</translation>
-<translation id="3207960819495026254">Marcată</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> a fost șters</translation>
-<translation id="321773570071367578">Dacă ai uitat expresia de acces sau dorești să modifici această setare, <ph name="BEGIN_LINK" />resetează sincronizarea<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Microfon</translation>
-<translation id="3232754137068452469">Aplicație web</translation>
-<translation id="3236059992281584593">1 min. rămas</translation>
-<translation id="3244271242291266297">LL</translation>
-<translation id="3254409185687681395">Marcați această pagină</translation>
-<translation id="3259831549858767975">Micșorează întregul conținut al paginii</translation>
-<translation id="3269093882174072735">Încarcă imaginea</translation>
-<translation id="3269956123044984603">Pentru a accesa filele de pe alte dispozitive, activează opțiunea „Sincronizează automat datele” în setările Android din Contul Google.</translation>
-<translation id="3277252321222022663">Permite accesul site-urilor la senzori (recomandat)</translation>
-<translation id="3282568296779691940">Conectează-te la Chrome</translation>
-<translation id="3288003805934695103">să reîncarci pagina;</translation>
-<translation id="32895400574683172">Notificările sunt permise</translation>
-<translation id="3295530008794733555">Navighează mai rapid. Folosește mai puține date.</translation>
-<translation id="3295602654194328831">Ascunde informațiile</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Continui pentru descărcarea conținutului?</translation>
-<translation id="3306398118552023113">Această aplicație rulează în Chrome</translation>
-<translation id="3315103659806849044">Acum personalizezi setările pentru sincronizare și serviciul Google. Pentru a finaliza activarea sincronizării, atinge butonul Confirmă din partea de jos a ecranului. Navighează în sus</translation>
-<translation id="3328801116991980348">Informații despre site</translation>
-<translation id="3333961966071413176">Toată agenda</translation>
-<translation id="3334729583274622784">Modifici extensia de fișier?</translation>
-<translation id="3341058695485821946">Vezi ce volum de date ai economisit</translation>
-<translation id="3350687908700087792">Închide toate filele incognito</translation>
-<translation id="3353615205017136254">Pagină Lite oferită de Google. Atinge butonul de încărcare a originalului pentru a încărca pagina originală.</translation>
-<translation id="3367813778245106622">Conectează-te din nou pentru a începe sincronizarea</translation>
-<translation id="3374023511497244703">Marcajele, istoricul, parolele și alte date Chrome nu vor mai fi sincronizate cu Contul Google</translation>
-<translation id="3384347053049321195">Trimite imaginea</translation>
-<translation id="3386292677130313581">Întreabă înainte de a permite site-urilor să afle locația (recomandat)</translation>
-<translation id="3387650086002190359">Descărcarea fișierului <ph name="FILE_NAME" /> nu a reușit din cauza unor erori privind sistemul de fișiere.</translation>
-<translation id="3389286852084373014">Textul este prea mare</translation>
-<translation id="3398320232533725830">Deschide managerul de marcaje</translation>
-<translation id="3414952576877147120">Dimensiune:</translation>
-<translation id="3443221991560634068">Reîncarcă pagina curentă</translation>
-<translation id="3445014427084483498">Adineauri</translation>
-<translation id="3478363558367712427">Poți alege motorul de căutare</translation>
+<translation id="6910211073230771657">Șters</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK, am înțeles</translation>
+<translation id="7658239707568436148">Anulează</translation>
 <translation id="3479552764303398839">Nu acum</translation>
-<translation id="3492207499832628349">Filă incognito nouă</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Află mai multe<ph name="END_LINK" /> despre conținutul sugerat</translation>
-<translation id="3513704683820682405">Realitate augmentată</translation>
-<translation id="3518985090088779359">Acceptă și continuă</translation>
-<translation id="3522247891732774234">Actualizare disponibilă. Mai multe opțiuni</translation>
-<translation id="3524138585025253783">IU pentru dezvoltatori</translation>
-<translation id="3527085408025491307">Dosar</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB disponibili</translation>
-<translation id="3549657413697417275">Caută în istoricul tău</translation>
-<translation id="3557336313807607643">Adaugă în Agendă</translation>
-<translation id="3566923219790363270">Chrome încă se pregătește pentru RV. Repornește Chrome mai târziu.</translation>
-<translation id="3568688522516854065">Pentru a accesa filele de pe alte dispozitive, conectează-te și activează sincronizarea</translation>
-<translation id="3587482841069643663">Toate</translation>
-<translation id="358794129225322306">Permite unui site să descarce automat mai multe fișiere.</translation>
-<translation id="3590487821116122040">Stocare a site-urilor pe care Chrome nu o consideră importantă (de ex., site-uri care nu au setări salvate sau pe care nu le accesezi frecvent)</translation>
-<translation id="3599863153486145794">Șterge istoricul de pe toate dispozitivele conectate. Contul Google poate să ofere alte forme ale istoricului de navigare la <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Dezactivează sunetul pentru site-urile care îl redau</translation>
-<translation id="3616113530831147358">Audio</translation>
-<translation id="3631987586758005671">Se trimite la <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Afișează parola</translation>
-<translation id="363596933471559332">Te conectezi automat la site-uri folosind datele de conectare stocate. Când funcția este dezactivată, ți se va solicita verificarea de fiecare dată înainte de a te conecta la un site.</translation>
-<translation id="3658159451045945436">Prin resetare se șterge istoricul economisirii de date, inclusiv lista site-urilor vizitate.</translation>
-<translation id="3692944402865947621">Descărcarea fișierului <ph name="FILE_NAME" /> nu a reușit, deoarece nu se poate contacta locația de stocare.</translation>
-<translation id="3714981814255182093">Deschide Bara de căutare</translation>
-<translation id="3716182511346448902">Această pagină folosește prea multă memorie, prin urmare Chrome a întrerupt-o.</translation>
-<translation id="3730075448226062617">Ca să permiți Chrome să acceseze microfonul, activează microfonul și în <ph name="BEGIN_LINK" />Setările Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Marcat în <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sincronizare în fundal</translation>
-<translation id="3771001275138982843">Nu s-a putut descărca actualizarea</translation>
-<translation id="3771033907050503522">File incognito</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Activează Bluetooth<ph name="END_LINK" /> pentru a permite asocierea</translation>
-<translation id="3775705724665058594">Trimite pe dispozitivele tale</translation>
-<translation id="3778956594442850293">S-a adăugat pe ecranul de pornire</translation>
-<translation id="3789841737615482174">Instalează</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Gestionează</translation>
-<translation id="381841723434055211">Numere de telefon</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> descărcări șterse</translation>
-<translation id="3822502789641063741">Ștergi stocarea site-urilor?</translation>
-<translation id="385051799172605136">Înapoi</translation>
-<translation id="3859306556332390985">Derulează înainte</translation>
-<translation id="3894427358181296146">Adaugă un dosar</translation>
-<translation id="3895926599014793903">Forțează activarea zoomului</translation>
-<translation id="3912508018559818924">Se caută tot ce e mai bun de pe web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Combină datele</translation>
-<translation id="393697183122708255">Nu există căutare vocală activată</translation>
-<translation id="395206256282351086">Sugestiile de căutare și de site-uri sunt dezactivate</translation>
-<translation id="3955193568934677022">Permite site-urilor să redea conținutul protejat (recomandat)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome va încărca pagina când este gata}few{Chrome va încărca paginile când este gata}other{Chrome va încărca paginile când este gata}}</translation>
-<translation id="3963007978381181125">Criptarea expresiei de acces nu include metodele de plată și adresele din Google Pay. Numai cine are expresia ta de acces poate citi datele tale criptate. Expresia de acces nu este trimisă sau stocată la Google. Dacă îți uiți expresia de acces sau vrei să modifici această setare, va trebui să resetezi sincronizarea. <ph name="BEGIN_LINK" />Află mai multe<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Descărcare finalizată</translation>
-<translation id="397583555483684758">Sincronizarea nu mai funcționează</translation>
-<translation id="3976396876660209797">Elimină și recreează această comandă rapidă</translation>
-<translation id="3985215325736559418">Dorești să descarci <ph name="FILE_NAME" /> din nou?</translation>
-<translation id="3987993985790029246">Copiază linkul</translation>
-<translation id="3988213473815854515">Accesul la locație este permis</translation>
-<translation id="3988466920954086464">Afișează rezultatele căutării instantanee în acest panou</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Stocare neimportantă</translation>
-<translation id="4000212216660919741">Pagina de pornire offline</translation>
+<translation id="5317780077021120954">Salvează</translation>
+<translation id="4570913071927164677">Detalii</translation>
+<translation id="8730621377337864115">Terminat</translation>
+<translation id="8261506727792406068">Șterge</translation>
+<translation id="1181037720776840403">Elimină</translation>
+<translation id="5939518447894949180">Resetează</translation>
 <translation id="4002066346123236978">Titlu</translation>
-<translation id="4008040567710660924">Permite cookie-uri pentru un anumit site.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{O oră}few{# ore}other{# de ore}}</translation>
-<translation id="4046123991198612571">Melodia următoare</translation>
-<translation id="4048707525896921369">Află despre subiectele de pe site-uri fără să părăsești pagina. Funcția Atinge pentru a căuta trimite un cuvânt și contextul aferent către Căutarea Google și returnează definiții, imagini, rezultate ale căutării și alte detalii.
+<translation id="5916664084637901428">Activat</translation>
+<translation id="5860033963881614850">Dezactivat</translation>
+<translation id="6165508094623778733">Află mai multe</translation>
+<translation id="6042308850641462728">Mai multe</translation>
+<translation id="6040143037577758943">Închide</translation>
+<translation id="780301667611848630">Nu, mulțumesc</translation>
+<translation id="1201402288615127009">Înainte</translation>
+<translation id="2359808026110333948">Continuă</translation>
+<translation id="2653659639078652383">Trimite</translation>
+<translation id="2079545284768500474">Anulează</translation>
+<translation id="7649070708921625228">Ajutor</translation>
+<translation id="2148716181193084225">Astăzi</translation>
+<translation id="7781829728241885113">Ieri</translation>
+<translation id="6945221475159498467">Selectează</translation>
+<translation id="7791543448312431591">Adaugă</translation>
+<translation id="6527303717912515753">Trimite</translation>
+<translation id="1383876407941801731">Caută</translation>
+<translation id="3115898365077584848">Afișează informațiile</translation>
+<translation id="3295602654194328831">Ascunde informațiile</translation>
+<translation id="3987993985790029246">Copiază linkul</translation>
+<translation id="2704606927547763573">Copiat</translation>
+<translation id="8725066075913043281">Încearcă din nou</translation>
+<translation id="385051799172605136">Înapoi</translation>
+<translation id="8131740175452115882">Confirmați</translation>
+<translation id="5300589172476337783">Afișează</translation>
+<translation id="1124772482545689468">Utilizator</translation>
+<translation id="8609465669617005112">Mutați mai sus</translation>
+<translation id="6746124502594467657">Mutați în jos</translation>
+<translation id="8249310407154411074">Mută la început</translation>
+<translation id="8428213095426709021">Setări</translation>
+<translation id="2498359688066513246">Ajutor și feedback</translation>
+<translation id="8378714024927312812">Gestionat de organizația ta</translation>
+<translation id="9019902583201351841">Gestionat de părinții tăi</translation>
+<translation id="4645575059429386691">Gestionat de părintele tău</translation>
+<translation id="4883854917563148705">Setările gestionate nu pot fi resetate</translation>
+<translation id="4307992518367153382">Elemente de bază</translation>
+<translation id="1974060860693918893">Avansate</translation>
+<translation id="1146678959555564648">Intră în RV</translation>
+<translation id="987264212798334818">General</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Descărcări</translation>
+<translation id="218608176142494674">Trimitere</translation>
+<translation id="8004582292198964060">Browser</translation>
+<translation id="1105960400813249514">Captură de ecran</translation>
+<translation id="4875775213178255010">Sugestii de conținut</translation>
+<translation id="2021896219286479412">Comenzi site în ecran complet</translation>
+<translation id="4587589328781138893">Site-uri</translation>
+<translation id="4943703118917034429">Realitate virtuală</translation>
+<translation id="1928696683969751773">Actualizări</translation>
+<translation id="6064125863973209585">Descărcări finalizate</translation>
+<translation id="5342314432463739672">Solicitări de permisiuni</translation>
+<translation id="629730747756840877">Cont</translation>
+<translation id="82609232232243542">Conectează-te la Brave</translation>
+<translation id="7956662517480676674">Sincronizarea și serviciile Brave Software</translation>
+<translation id="5294439808117722387">Acum personalizezi setările pentru sincronizare și serviciul Brave Software. Pentru a finaliza activarea sincronizării, atinge butonul Confirmă din partea de jos a ecranului. Navighează în sus</translation>
+<translation id="2096012225669085171">Sincronizează și personalizează pe toate dispozitivele</translation>
+<translation id="1692118695553449118">Sincronizarea este activată</translation>
+<translation id="5514904542973294328">Dezactivată de administratorul dispozitivului</translation>
+<translation id="6447211988989208781">Opțiuni privind activitatea Brave Software</translation>
+<translation id="4882831918239250449">Controlează modul în care istoricul de navigare este folosit pentru a personaliza Căutarea, anunțurile și alte servicii</translation>
+<translation id="7431991332293347422">Controlează modul în care istoricul de navigare este folosit pentru a personaliza Căutarea și alte servicii</translation>
+<translation id="6303969859164067831">Deconectează-te și dezactivează sincronizarea</translation>
+<translation id="1125261911132334651">Gestionează-ți Contul Brave Software</translation>
+<translation id="6406506848690869874">Sincronizare</translation>
+<translation id="714362445477979774">Sincronizează datele din Brave</translation>
+<translation id="4314815835985389558">Gestionează sincronizarea</translation>
+<translation id="5428209950370661546">Alte servicii Brave Software</translation>
+<translation id="7704317875155739195">Completează automat căutările și adresele URL</translation>
+<translation id="2000419248597011803">Trimite anumite cookie-uri și căutări din bara de adrese și din caseta de căutare în motorul de căutare prestabilit</translation>
+<translation id="7981313251711023384">Preîncarcă paginile pentru navigare și căutare mai rapide</translation>
+<translation id="1821253160463689938">Folosește cookie-uri pentru a-ți reține preferințele, chiar dacă nu accesezi paginile respective</translation>
+<translation id="6697492270171225480">Afișează sugestii pentru pagini similare atunci când o pagină nu poate fi găsită</translation>
+<translation id="8109318360573330108">Trimite la Brave Software adresa URL a unei pagini pe care încerci să o accesezi</translation>
+<translation id="8438566539970814960">Îmbunătățește căutările și navigarea</translation>
+<translation id="284843628681142937">Trimite la Brave Software adresele URL ale paginilor pe care le accesezi</translation>
+<translation id="7222718784508482526">Pentru mai multe setări privind confidențialitatea, securitatea și colectarea datelor, consultă <ph name="BEGIN_LINK"/>Sincronizare și servicii Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Contribuie la îmbunătățirea funcțiilor și performanței Brave</translation>
+<translation id="9063160602596686558">Trimite automat statistici de utilizare și rapoarte de blocare la Brave Software</translation>
+<translation id="4824958205181053313">Anulezi sincronizarea?</translation>
+<translation id="3058498974290601450">Poți să activezi sincronizarea oricând în setări</translation>
+<translation id="3143515551205905069">Anulează sincronizarea</translation>
+<translation id="1506061864768559482">Motor de căutare</translation>
+<translation id="55737423895878184">Locația și notificările sunt permise</translation>
+<translation id="3988213473815854515">Accesul la locație este permis</translation>
+<translation id="32895400574683172">Notificările sunt permise</translation>
+<translation id="9040142327097499898">Notificările sunt permise. Locația este dezactivată pentru acest dispozitiv.</translation>
+<translation id="305593374596241526">Locația este dezactivată; activeaz-o în <ph name="BEGIN_LINK"/>Setări Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Accesate recent</translation>
+<translation id="6433501201775827830">Alege motorul de căutare</translation>
+<translation id="7177466738963138057">Poți modifica ulterior această opțiune în Setări</translation>
+<translation id="3478363558367712427">Poți alege motorul de căutare</translation>
+<translation id="4910889077668685004">Aplicații pentru plăți</translation>
+<translation id="5152843274749979095">Nu sunt instalate aplicații acceptate</translation>
+<translation id="8812260976093120287">Pe unele site-uri, poți plăti folosind aplicațiile acceptate pentru plăți de mai sus de pe dispozitiv.</translation>
+<translation id="7764225426217299476">Adaugă o adresă</translation>
+<translation id="5595485650161345191">Editează adresa</translation>
+<translation id="5087580092889165836">Adaugă un card</translation>
+<translation id="2154484045852737596">Editează cardul</translation>
+<translation id="6140912465461743537">Țară/Regiune</translation>
+<translation id="5659593005791499971">Adresă de e-mail</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Numele de pe card</translation>
+<translation id="860043288473659153">Nume titular de card</translation>
+<translation id="2612676031748830579">Număr card</translation>
+<translation id="869891660844655955">Dată de expirare</translation>
+<translation id="2286841657746966508">Adresa de facturare</translation>
+<translation id="663059986967017181">Copiat în Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}few{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}few{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}few{<ph name="CONTACT_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Parole</translation>
+<translation id="1943432128510653496">Parole salvate</translation>
+<translation id="2100273922101894616">Conectare automată</translation>
+<translation id="363596933471559332">Te conectezi automat la site-uri folosind datele de conectare stocate. Când funcția este dezactivată, ți se va solicita verificarea de fiecare dată înainte de a te conecta la un site.</translation>
+<translation id="6995899638241819463">Avertizează-mă dacă parolele au fost expuse în urma încălcării securității datelor</translation>
+<translation id="1534287762301776620">Când te conectezi la Contul Brave Software, această funcție este activată</translation>
+<translation id="10614374240317010">Nu se salvează niciodată</translation>
+<translation id="3098842761938485917">Vezi și gestionează parolele salvate în <ph name="BEGIN_LINK"/>Contul Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Parolele salvate vor fi afișate aici.</translation>
+<translation id="8084114998886531721">Parola a fost salvată</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Nume utilizator</translation>
+<translation id="6657585470893396449">Parolă</translation>
+<translation id="2154710561487035718">Copiați adresa URL</translation>
+<translation id="1571304935088121812">Copiază numele de utilizator</translation>
+<translation id="5005498671520578047">Copiază parola</translation>
+<translation id="3632295766818638029">Afișează parola</translation>
+<translation id="1513858653616922153">Șterge parola</translation>
+<translation id="543338862236136125">Editează parola</translation>
+<translation id="4565377596337484307">Ascunde parola</translation>
+<translation id="8523928698583292556">Șterge parola stocată</translation>
+<translation id="2898264748040935573">Editează parola stocată</translation>
+<translation id="5433691172869980887">Numele de utilizator a fost copiat</translation>
+<translation id="5534640966246046842">Site-ul a fost copiat</translation>
+<translation id="2625189173221582860">Parola a fost copiată</translation>
+<translation id="4550003330909367850">Ca să vezi sau să copiezi parola aici, setează blocarea ecranului pe acest dispozitiv.</translation>
+<translation id="6154478581116148741">Pentru a-ți exporta parolele de pe acest dispozitiv, activează blocarea ecranului în Setări.</translation>
+<translation id="4842092870884894799">Fereastra pop-up pentru generarea parolelor este afișată</translation>
+<translation id="2259659629660284697">Exportă parolele…</translation>
+<translation id="133012818630824069">Exportă parolele stocate în Brave</translation>
+<translation id="6914783257214138813">Parolele vor fi vizibile pentru toți cei care pot vedea fișierul exportat.</translation>
+<translation id="2321086116217818302">Se pregătesc parolele…</translation>
+<translation id="8445448999790540984">Nu se pot exporta parole</translation>
+<translation id="3066461326500799725">Află cum să folosești Brave Software Drive</translation>
+<translation id="729975465115245577">Dispozitivul nu are o aplicație pentru stocarea fișierului parolelor.</translation>
+<translation id="7682724950699840886">Încearcă următoarele sfaturi: asigură-te că există spațiu suficient pe dispozitiv, încearcă să exporți din nou.</translation>
+<translation id="1129510026454351943">Detalii: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Deblochează pentru a copia parola</translation>
+<translation id="5515439363601853141">Deblochează pentru a vedea parola</translation>
+<translation id="6221633008163990886">Deblochează pentru a-ți exporta parolele.</translation>
+<translation id="230699814587342492">Parole Brave</translation>
+<translation id="6075798973483050474">Editează pagina de pornire</translation>
+<translation id="854522910157234410">Deschide această pagină</translation>
+<translation id="2482878487686419369">Notificări</translation>
+<translation id="6255999984061454636">Sugestii de conținut</translation>
+<translation id="805047784848435650">Pe baza istoricului de navigare</translation>
+<translation id="1041308826830691739">De la site-uri</translation>
+<translation id="395206256282351086">Sugestiile de căutare și de site-uri sunt dezactivate</translation>
+<translation id="257088987046510401">Teme</translation>
+<translation id="4650364565596261010">Setare prestabilită a sistemului</translation>
+<translation id="7588219262685291874">Activează tema întunecată când este activată Economisirea bateriei pentru dispozitiv</translation>
+<translation id="2760989362628427051">Activează tema întunecată când este activată tema întunecată sau Economisirea bateriei pentru dispozitiv</translation>
+<translation id="6381421346744604172">Întunecă site-urile</translation>
+<translation id="5040262127954254034">Confidențialitate</translation>
+<translation id="4991384657077828949">Contribuie la îmbunătățirea securității pentru Brave</translation>
+<translation id="1943176487615318915">Pentru a detecta aplicațiile și site-urile periculoase, Brave trimite la Brave Software adresele URL ale unor pagini pe care le accesezi, informații de sistem limitate și o parte din conținutul paginii</translation>
+<translation id="3181954750937456830">Navigare sigură (protecție împotriva site-urilor periculoase)</translation>
+<translation id="7315322926489145388">Trimite la Brave Software adrese URL ale unor pagini pe care le accesezi, când securitatea este în pericol</translation>
+<translation id="2063713494490388661">Atinge pentru a căuta</translation>
+<translation id="2369463299479365221">Află despre subiectele de pe site-uri fără să părăsești pagina. Funcția Atinge pentru a căuta trimite un cuvânt și contextul aferent către Căutarea Brave Software și returnează definiții, imagini, rezultate ale căutării și alte detalii.
 
 Pentru a ajusta termenul de căutare, apasă lung pentru a selecta. Pentru a rafina căutarea, glisează panoul până în partea de sus și atinge caseta de căutare.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Opțiunile sunt disponibile în partea de sus a ecranului</translation>
-<translation id="4062305924942672200">Informații juridice</translation>
-<translation id="4084682180776658562">Marcaj</translation>
-<translation id="4084712963632273211">De la <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />livrată de Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Ștergi datele aplicației?</translation>
-<translation id="4099578267706723511">Contribuie la îmbunătățirea Chrome trimițând statistici de utilizare și rapoarte de blocare la Google.</translation>
-<translation id="410351446219883937">Redare automată</translation>
-<translation id="4116038641877404294">Descarcă paginile pentru a le folosi offline</translation>
-<translation id="4135200667068010335">Lista de dispozitive pe care să trimiți o filă este închisă.</translation>
-<translation id="4149994727733219643">Afișare simplificată pentru paginile web</translation>
-<translation id="4165986682804962316">Setări pentru site-uri</translation>
-<translation id="4169535189173047238">Nu permite</translation>
-<translation id="4170011742729630528">Serviciul nu este disponibil. Încercați din nou mai târziu.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> folosiți</translation>
-<translation id="4181841719683918333">Limbi</translation>
-<translation id="4183868528246477015">Caută folosind Google Lens <ph name="BEGIN_NEW" />Nou<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Deschide în filă nouă</translation>
-<translation id="4198423547019359126">Nu există locații de descărcare disponibile</translation>
-<translation id="4209895695669353772">Pentru a obține sugestii de conținut personalizat de la Google, activează sincronizarea</translation>
-<translation id="4226663524361240545">Notificările pot face dispozitivul să vibreze</translation>
-<translation id="423219824432660969">Criptează datele sincronizate cu parola Google începând cu <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Deschide setările</translation>
-<translation id="4256782883801055595">Licențe open source</translation>
-<translation id="4259722352634471385">Navigarea este blocată: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Copiază adresa linkului</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Se permite</translation>
-<translation id="429312253194641664">Un site redă fișiere media</translation>
-<translation id="4298388696830689168">Site-uri conectate</translation>
-<translation id="4307992518367153382">Elemente de bază</translation>
-<translation id="4314815835985389558">Gestionează sincronizarea</translation>
-<translation id="4351244548802238354">Închide caseta de dialog</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Pentru căutare se folosește Sogou</translation>
-<translation id="4404568932422911380">Niciun marcaj</translation>
-<translation id="4405224443901389797">Mută în…</translation>
-<translation id="4411535500181276704">Modul Lite</translation>
-<translation id="4415276339145661267">Gestionează-ți Contul Google</translation>
-<translation id="4432792777822557199">Paginile în <ph name="SOURCE_LANGUAGE" /> vor fi traduse în <ph name="TARGET_LANGUAGE" /> de acum înainte</translation>
-<translation id="4433925000917964731">Pagină Lite oferită de Google</translation>
-<translation id="4434045419905280838">Ferestre pop-up și redirecționări</translation>
-<translation id="4440958355523780886">Pagină Lite oferită de Google. Atinge pentru a încărca versiunea originală.</translation>
-<translation id="4452411734226507615">Închide fila <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Marcaj adăugat în <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Permite site-urilor să redea conținut protejat</translation>
-<translation id="4468959413250150279">Dezactivează sunetul pentru un anumit site.</translation>
-<translation id="4472118726404937099">Pentru a sincroniza și a personaliza pe toate dispozitivele, conectează-te și activează sincronizarea</translation>
-<translation id="447252321002412580">Contribuie la îmbunătățirea funcțiilor și performanței Chrome</translation>
-<translation id="4479647676395637221">Întreabă înainte de a permite site-urilor să folosească camera foto (recomandat)</translation>
-<translation id="4479972344484327217">Se instalează <ph name="MODULE" /> pentru Chrome…</translation>
-<translation id="4487967297491345095">Toate datele aplicației Chrome vor fi șterse definitiv. Sunt incluse toate fișierele, setările, conturile, bazele de date etc.</translation>
-<translation id="4493497663118223949">Modul Lite este activat</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Acum # zi}few{Acum # zile}other{Acum # de zile}}</translation>
-<translation id="451872707440238414">Caută în marcaje</translation>
-<translation id="4521489764227272523">Datele selectate au fost eliminate din Chrome și de pe dispozitivele sincronizate.
-
-Contul Google poate să ofere alte forme ale istoricului de navigare, cum ar fi căutările și activitatea din alte servicii Google, la <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Alege dosarul</translation>
-<translation id="4538018662093857852">Activează modul Lite</translation>
-<translation id="4550003330909367850">Ca să vezi sau să copiezi parola aici, setează blocarea ecranului pe acest dispozitiv.</translation>
-<translation id="4558311620361989323">Comenzi rapide pentru pagini web</translation>
-<translation id="4561979708150884304">Nicio conexiune</translation>
-<translation id="4565377596337484307">Ascunde parola</translation>
-<translation id="4570913071927164677">Detalii</translation>
-<translation id="4572422548854449519">Conectează-te la contul gestionat</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Acum # minut}few{Acum # minute}other{Acum # de minute}}</translation>
-<translation id="4587589328781138893">Site-uri</translation>
-<translation id="4594952190837476234">Această pagină offline este din data de <ph name="CREATION_TIME" /> și poate fi diferită de versiunea online.</translation>
-<translation id="4605958867780575332">Element eliminat: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Deschide <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Folosește parola</translation>
-<translation id="4645575059429386691">Gestionat de părintele tău</translation>
-<translation id="4650364565596261010">Setare prestabilită a sistemului</translation>
-<translation id="4663756553811254707">S-au șters <ph name="NUMBER_OF_BOOKMARKS" /> (de) marcaje</translation>
-<translation id="4665282149850138822">Site-ul <ph name="NAME" /> a fost adăugat pe ecranul de pornire</translation>
-<translation id="4684427112815847243">Sincronizează tot</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}few{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Trimite text pe dispozitivele tale</translation>
-<translation id="4698034686595694889">Vezi offline în <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Imaginile și fișierele memorate în cache</translation>
-<translation id="4714588616299687897">Economisește până la 60% din date</translation>
-<translation id="4719927025381752090">Oferă traducerea</translation>
-<translation id="4720023427747327413">Deschide în <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Contribuie la îmbunătățirea browserului Chrome. <ph name="BEGIN_LINK" />Participă la sondaj.<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Actualizează</translation>
-<translation id="4738836084190194332">Ultima sincronizare: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Deschide o filă nouă</translation>
-<translation id="4751476147751820511">Senzori de mișcare sau de lumină</translation>
-<translation id="4759238208242260848">Descărcări</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{O descărcare finalizată.}few{# descărcări finalizate.}other{# de descărcări finalizate.}}</translation>
-<translation id="4797039098279997504">Atinge pentru a reveni la <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Criptarea expresiei de acces nu include metodele de plată și adresele din Google Pay.
-
-Pentru a modifica această setare, <ph name="BEGIN_LINK" />resetează sincronizarea<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Numele de pe card</translation>
-<translation id="4824958205181053313">Anulezi sincronizarea?</translation>
-<translation id="4837753911714442426">Deschide opțiunile pentru a printa pagina</translation>
-<translation id="4842092870884894799">Fereastra pop-up pentru generarea parolelor este afișată</translation>
-<translation id="4860895144060829044">Apelează</translation>
-<translation id="4866368707455379617">Nu se poate instala <ph name="MODULE" /> pentru Chrome</translation>
-<translation id="4875775213178255010">Sugestii de conținut</translation>
-<translation id="4878404682131129617">Nu s-a putut stabili un tunel prin serverul proxy</translation>
-<translation id="4880127995492972015">Tradu…</translation>
-<translation id="4881695831933465202">Deschide</translation>
-<translation id="488187801263602086">Redenumește fișierul</translation>
-<translation id="4882831918239250449">Controlează modul în care istoricul de navigare este folosit pentru a personaliza Căutarea, anunțurile și alte servicii</translation>
-<translation id="4883854917563148705">Setările gestionate nu pot fi resetate</translation>
-<translation id="4885273946141277891">Număr de instanțe Chrome neacceptat.</translation>
-<translation id="4910889077668685004">Aplicații pentru plăți</translation>
-<translation id="4913161338056004800">Resetează statisticile</translation>
-<translation id="4913169188695071480">Oprește actualizarea</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Obține ajutor<ph name="END_LINK" /> în timp ce se caută dispozitive…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{O pagină}few{# pagini}other{# pagini}}</translation>
-<translation id="4932247056774066048">Întrucât te deconectezi de la un cont gestionat de <ph name="DOMAIN_NAME" />, datele Chrome vor fi șterse de pe dispozitiv. Acestea vor fi păstrate în Contul tău Google.</translation>
-<translation id="4943703118917034429">Realitate virtuală</translation>
-<translation id="4943872375798546930">Nu există rezultate</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> accesează conținutul de pe ecran</translation>
-<translation id="4961107849584082341">Tradu această pagină în orice limbă</translation>
-<translation id="4962975101802056554">Revocă toate permisiunile pentru dispozitiv</translation>
-<translation id="4970824347203572753">Nu este disponibil în locația ta</translation>
-<translation id="497421865427891073">Înainte</translation>
-<translation id="4988210275050210843">Fișierul se descarcă (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Pagini</translation>
-<translation id="4994033804516042629">Nu s-a găsit nicio persoană de contact</translation>
-<translation id="4996978546172906250">Trimite prin</translation>
-<translation id="5004416275253351869">Opțiuni privind activitatea Google</translation>
-<translation id="5005498671520578047">Copiază parola</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> dorește să se conecteze</translation>
-<translation id="5013696553129441713">Nicio sugestie nouă</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">În RV, acest site ar putea afla:
-  -  trăsăturile tale fizice, cum ar fi înălțimea.
-
-Asigură-te că site-ul este de încredere înainte să intri în RV.</translation>
+<translation id="2930742481329940825">Funcția Atinge pentru a căuta trimite cuvântul selectat și pagina actuală drept context către Căutarea Brave Software. Poți dezactiva această funcție din <ph name="BEGIN_LINK"/>Setări<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Permite</translation>
-<translation id="5040262127954254034">Confidențialitate</translation>
-<translation id="5048398596102334565">Permite accesul site-urilor la senzorii de mișcare (recomandat)</translation>
-<translation id="5063480226653192405">Utilizare</translation>
-<translation id="5087580092889165836">Adaugă un card</translation>
-<translation id="5100237604440890931">Afișare restrânsă – dă clic pentru a extinde.</translation>
-<translation id="510275257476243843">1 oră rămasă</translation>
-<translation id="5123685120097942451">Filă incognito</translation>
-<translation id="5127805178023152808">Sincronizarea este dezactivată</translation>
-<translation id="5129038482087801250">Instalează aplicația web</translation>
-<translation id="5132942445612118989">Sincronizează parolele, istoricul și alte date pe toate dispozitivele</translation>
-<translation id="5139940364318403933">Află cum să folosești Google Drive</translation>
-<translation id="515227803646670480">Șterge datele stocate</translation>
-<translation id="5152843274749979095">Nu sunt instalate aplicații acceptate</translation>
-<translation id="5161254044473106830">Titlul este obligatoriu</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{O descărcare nu a reușit.}few{# descărcări nu au reușit.}other{# de descărcări nu au reușit.}}</translation>
-<translation id="5170568018924773124">Afișează în dosar</translation>
-<translation id="5184329579814168207">Deschide în Chrome</translation>
-<translation id="5193988420012215838">Copiat în clipboard</translation>
-<translation id="5197729504361054390">Persoanele de contact pe care le selectezi vor fi trimise site-ului <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Profilul de serviciu</translation>
-<translation id="5210286577605176222">Accesează fila anterioară</translation>
-<translation id="5210365745912300556">Închide fila</translation>
-<translation id="5224771365102442243">Cu videoclip</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> vrea să caute dispozitive Bluetooth în apropiere. Următoarele dispozitive au fost găsite:</translation>
-<translation id="5233638681132016545">Filă nouă</translation>
-<translation id="526421993248218238">Această pagină nu poate fi încărcată.</translation>
-<translation id="5271967389191913893">Dispozitivul nu poate deschide conținutul de descărcat.</translation>
-<translation id="528192093759286357">Trage din partea de sus și atinge butonul Înapoi pentru a ieși din ecranul complet.</translation>
-<translation id="5292796745632149097">Trimite la</translation>
-<translation id="5300589172476337783">Afișează</translation>
-<translation id="5301954838959518834">OK, am înțeles</translation>
-<translation id="5304593522240415983">Acest câmp trebuie completat</translation>
-<translation id="5307446750509046227">Șterge stocare site-uri</translation>
-<translation id="5308380583665731573">Conectează-te</translation>
-<translation id="5313967007315987356">Adaugă un site</translation>
-<translation id="5317780077021120954">Salvează</translation>
-<translation id="5324858694974489420">Setări parentale</translation>
-<translation id="5327248766486351172">Nume</translation>
-<translation id="5335288049665977812">Permite site-urilor să ruleze JavaScript (recomandat)</translation>
-<translation id="5342314432463739672">Solicitări de permisiuni</translation>
-<translation id="5357811892247919462">Fila a fost primită</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> filă deschisă, atinge pentru a comuta filele}few{<ph name="OPEN_TABS_MANY" /> file deschise, atinge pentru a comuta filele}other{<ph name="OPEN_TABS_MANY" /> de file deschise, atinge pentru a comuta filele}}</translation>
-<translation id="5391532827096253100">Conexiunea la acest site nu este sigură. Informații despre site</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ încă 1)}few{(+ încă #)}other{(+ încă #)}}</translation>
-<translation id="5400569084694353794">Folosind această aplicație, accepți <ph name="BEGIN_LINK1" />Termenii și condițiile<ph name="END_LINK1" /> și <ph name="BEGIN_LINK2" />Notificarea privind confidențialitatea<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="5403592356182871684">Nume</translation>
-<translation id="5403644198645076998">Permite numai anumite site-uri</translation>
-<translation id="5414836363063783498">Se verifică...</translation>
-<translation id="5423934151118863508">Cele mai accesate pagini vor apărea aici</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB disponibili</translation>
-<translation id="543338862236136125">Editează parola</translation>
-<translation id="5433691172869980887">Numele de utilizator a fost copiat</translation>
-<translation id="543509235395288790">Se descarcă <ph name="COUNT" /> fișiere (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Accesează bara de adrese</translation>
-<translation id="5447201525962359567">Toată stocarea site-urilor, inclusiv cookie-urile și alte date stocate local</translation>
-<translation id="5447765697759493033">Acest site nu va fi tradus</translation>
-<translation id="545042621069398927">Se accelerează descărcarea.</translation>
-<translation id="5456381639095306749">Descarcă pagina</translation>
-<translation id="5475862044948910901">Pornești sesiunea de realitate augmentată?</translation>
-<translation id="548278423535722844">Deschide în aplicația Maps</translation>
-<translation id="5487521232677179737">Șterge datele</translation>
-<translation id="5494752089476963479">Blochează anunțurile pe site-urile care afișează anunțuri deranjante sau înșelătoare</translation>
-<translation id="5500777121964041360">Este posibil să nu fie disponibil în locația ta</translation>
-<translation id="5512137114520586844">Acest cont este gestionat de <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Dezactivată de administratorul dispozitivului</translation>
-<translation id="5515439363601853141">Deblochează pentru a vedea parola</translation>
-<translation id="5516455585884385570">Deschide setările pentru notificări</translation>
-<translation id="5517095782334947753">Ai marcajele, istoricul, parolele și alte setări din <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Redirecționarea a fost blocată.</translation>
-<translation id="5527082711130173040">Chrome necesită accesul la locație pentru a căuta dispozitive. <ph name="BEGIN_LINK1" />Actualizează permisiunile<ph name="END_LINK1" />. Accesul la locație este <ph name="BEGIN_LINK2" />dezactivat pentru acest dispozitiv<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Întreabă-mă înainte de a permite site-urilor să citească textul și imaginile din clipboard (recomandat)</translation>
-<translation id="5530766185686772672">Închide filele incognito</translation>
-<translation id="5534334044554683961">În RV, acest site ar putea afla:
-  -   trăsăturile tale fizice, cum ar fi înălțimea,
-  -   configurația camerei în care te afli.
-
-Asigură-te că site-ul este de încredere înainte să intri în RV.</translation>
-<translation id="5534640966246046842">Site-ul a fost copiat</translation>
-<translation id="5556459405103347317">Reîncarcă</translation>
-<translation id="5561549206367097665">Se așteaptă rețeaua…</translation>
-<translation id="557283862590186398">Chrome are nevoie de permisiune ca să acceseze microfonul pentru acest site.</translation>
-<translation id="55737423895878184">Locația și notificările sunt permise</translation>
-<translation id="5578795271662203820">Caută imaginea cu <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Poți să alegi oricând ce să sincronizezi în <ph name="BEGIN_LINK1" />setări<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Editează adresa</translation>
-<translation id="5596627076506792578">Mai multe opțiuni</translation>
-<translation id="5599455543593328020">Modul incognito</translation>
-<translation id="5620928963363755975">Găsește fișierele și paginile în Descărcări folosind butonul Mai multe opțiuni</translation>
-<translation id="5626134646977739690">Nume:</translation>
-<translation id="5639724618331995626">Permite toate site-urile</translation>
-<translation id="5648166631817621825">Ultimele 7 zile</translation>
-<translation id="5649053991847567735">Descărcări automate</translation>
-<translation id="5655963694829536461">Caută în descărcări</translation>
-<translation id="5659593005791499971">Adresă de e-mail</translation>
-<translation id="5665379678064389456">Creează un eveniment în <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ignoră solicitarea unui site de a împiedica mărirea</translation>
-<translation id="5677928146339483299">Blocat</translation>
-<translation id="5684874026226664614">Hopa. Această pagină nu a putut fi tradusă.</translation>
-<translation id="5686790454216892815">Numele fișierului este prea lung</translation>
-<translation id="5689516760719285838">Locație</translation>
-<translation id="569536719314091526">Tradu această pagină în orice limbă folosind butonul Mai multe opțiuni</translation>
-<translation id="572328651809341494">File recente</translation>
-<translation id="5726692708398506830">Mărește întregul conținut al paginii</translation>
-<translation id="5748802427693696783">Ai comutat la filele standard</translation>
-<translation id="5749068826913805084">Pentru a descărca fișiere, Chrome necesită acces la stocare.</translation>
-<translation id="5763382633136178763">File incognito</translation>
-<translation id="5763514718066511291">Atinge pentru a copia adresa URL pentru această aplicație</translation>
-<translation id="5765780083710877561">Descriere:</translation>
-<translation id="5793665092639000975">Se utilizează <ph name="SPACE_USED" /> din <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google poate folosi istoricul pentru a personaliza Căutarea, anunțurile și alte servicii Google</translation>
-<translation id="5804241973901381774">Permisiuni</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Acum # oră}few{Acum # ore}other{Acum # de ore}}</translation>
-<translation id="5810288467834065221">Drept de autor <ph name="YEAR" /> Google LLC. Toate drepturile rezervate.</translation>
-<translation id="5817918615728894473">Asociază</translation>
-<translation id="583281660410589416">Necunoscut</translation>
-<translation id="5833984609253377421">Trimite linkul</translation>
-<translation id="5836192821815272682">Se descarcă actualizarea Chrome…</translation>
-<translation id="5853623416121554550">întreruptă</translation>
-<translation id="5854790677617711513">Mai vechi de 30 de zile</translation>
-<translation id="5858741533101922242">Chrome nu poate activa adaptorul Bluetooth</translation>
-<translation id="5860033963881614850">Dezactivat</translation>
-<translation id="5862731021271217234">Pentru a accesa filele de pe alte dispozitive, activează sincronizarea</translation>
-<translation id="5864174910718532887">Detalii: sortate după numele site-ului</translation>
-<translation id="5864419784173784555">Se așteaptă altă descărcare…</translation>
-<translation id="5865733239029070421">Trimite automat statistici de utilizare și rapoarte de blocare la Google</translation>
-<translation id="5869522115854928033">Parole salvate</translation>
-<translation id="5902828464777634901">Toate datele stocate de site, inclusiv cookie-urile vor fi șterse.</translation>
-<translation id="5916664084637901428">Activat</translation>
-<translation id="5919204609460789179">Actualizează <ph name="PRODUCT_NAME" /> pentru a începe sincronizarea</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> salvați</translation>
-<translation id="5939518447894949180">Resetează</translation>
-<translation id="5942872142862698679">Pentru căutare se folosește Google</translation>
-<translation id="5952764234151283551">Trimite la Google adresa URL a unei pagini pe care încerci să o accesezi</translation>
-<translation id="5956665950594638604">Deschide Centrul de ajutor Chrome într-o filă nouă</translation>
-<translation id="5958275228015807058">Găsește fișierele și paginile în Descărcări</translation>
-<translation id="5962718611393537961">Atinge pentru a restrânge</translation>
-<translation id="6000066717592683814">Păstrează Google</translation>
-<translation id="6005538289190791541">Parola sugerată</translation>
-<translation id="6036057147555329831">ICU suplimentar</translation>
-<translation id="6039379616847168523">Accesează fila următoare</translation>
-<translation id="6040143037577758943">Închide</translation>
-<translation id="6042308850641462728">Mai multe</translation>
-<translation id="604996488070107836">Fișierul <ph name="FILE_NAME" /> nu a fost descărcat din cauza unei erori necunoscute.</translation>
-<translation id="605721222689873409">AA</translation>
-<translation id="6064125863973209585">Descărcări finalizate</translation>
-<translation id="6075798973483050474">Editează pagina de pornire</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> ore rămase</translation>
-<translation id="6108923351542677676">Configurare în curs...</translation>
-<translation id="6111020039983847643">date utilizate</translation>
-<translation id="6112702117600201073">Se actualizează pagina</translation>
-<translation id="6127379762771434464">Elementul a fost eliminat</translation>
-<translation id="6140912465461743537">Țară/Regiune</translation>
-<translation id="614940544461990577">Încearcă:</translation>
-<translation id="6154478581116148741">Pentru a-ți exporta parolele de pe acest dispozitiv, activează blocarea ecranului în Setări.</translation>
-<translation id="6159335304067198720">Economie de date de <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Află mai multe</translation>
-<translation id="6177111841848151710">Blocată pentru motorul de căutare actual</translation>
-<translation id="6181444274883918285">Adaugă o excepție privind site-urile</translation>
-<translation id="6192333916571137726">Descarcă fișierul</translation>
-<translation id="6192792657125177640">Excepții</translation>
-<translation id="6194112207524046168">Pentru a permite Chrome să acceseze camera, activează camera și în <ph name="BEGIN_LINK" />Setările Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blochează cookie-urile terță parte</translation>
-<translation id="6206551242102657620">Conexiunea este sigură. Informații despre site</translation>
-<translation id="6210748933810148297">Nu ești <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Deblochează pentru a-ți exporta parolele.</translation>
+<translation id="1406000523432664303">„Nu urmări”</translation>
 <translation id="6232535412751077445">Dacă activezi opțiunea „Nu urmări”, o solicitare va fi inclusă împreună cu traficul de navigare. Efectul variază în funcție de răspunsul site-ului la solicitare și în funcție de modul în care este interpretată solicitarea.
 
 De exemplu, unele site-uri pot răspunde la această solicitare afișând anunțuri care nu se bazează pe alte site-uri accesate de tine. Numeroase site-uri vor culege și vor utiliza în continuare datele de navigare. De exemplu, pentru a îmbunătăți securitatea, pentru a oferi conținut, anunțuri și recomandări și pentru a genera statistici de raportare.</translation>
-<translation id="624789221780392884">Actualizarea este pregătită</translation>
-<translation id="6255999984061454636">Sugestii de conținut</translation>
-<translation id="6277522088822131679">A apărut o problemă la printarea paginii. Încercați din nou.</translation>
-<translation id="6295158916970320988">Toate site-urile</translation>
-<translation id="629730747756840877">Cont</translation>
-<translation id="6303969859164067831">Deconectează-te și dezactivează sincronizarea</translation>
-<translation id="6316139424528454185">Versiunea Android nu este acceptată</translation>
-<translation id="6320088164292336938">Vibrații</translation>
-<translation id="6324034347079777476">Sincronizarea de sistem Android este dezactivată</translation>
-<translation id="6333140779060797560">Trimite prin <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Criptare</translation>
-<translation id="6341580099087024258">Întreabă unde să fie salvate fișierele</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}few{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Elimini sugestia din istoric?</translation>
-<translation id="6369229450655021117">De aici, poți să cauți pe web, să trimiți fișiere prietenilor și să vezi paginile deschise</translation>
-<translation id="6378173571450987352">Detalii: sortate după volumul de date folosite</translation>
-<translation id="6381421346744604172">Întunecă site-urile</translation>
-<translation id="6388207532828177975">Șterge și resetează</translation>
-<translation id="6393863479814692971">Chrome are nevoie de permisiune ca să acceseze camera foto și microfonul pentru acest site.</translation>
-<translation id="6395288395575013217">LINK</translation>
-<translation id="6404511346730675251">Modifică marcajul</translation>
-<translation id="6406506848690869874">Sincronizare</translation>
-<translation id="641643625718530986">Printați...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB descărcați</translation>
-<translation id="6427112570124116297">Tradu pe web</translation>
-<translation id="6433501201775827830">Alege motorul de căutare</translation>
-<translation id="6437478888915024427">Informații despre pagină</translation>
-<translation id="6441734959916820584">Numele este prea lung</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{O imagine}few{# imagini}other{# de imagini}}</translation>
-<translation id="6447842834002726250">Cookie-uri</translation>
-<translation id="6461962085415701688">Fișierul nu poate fi deschis</translation>
-<translation id="6464977750820128603">Poți vedea site-urile pe care le vizitezi în Chrome și să setezi temporizatoare pentru ele.\n\nGoogle obține informații cu privire la site-urile pentru care setezi temporizatoare și la durata de accesare. Aceste informații sunt folosite pentru a îmbunătăți Bunăstarea digitală.</translation>
-<translation id="6475951671322991020">Descarcă videoclipul</translation>
-<translation id="6482749332252372425">Descărcarea fișierului <ph name="FILE_NAME" /> nu a reușit din cauza spațiului de stocare insuficient.</translation>
-<translation id="6496823230996795692">Ca să folosești <ph name="APP_NAME" /> pentru prima dată, conectează-te la internet.</translation>
-<translation id="6508722015517270189">repornește Chrome;</translation>
-<translation id="6527303717912515753">Trimite</translation>
-<translation id="6532866250404780454">Site-urile pe care le vizitezi în Chrome nu se vor afișa. Toate temporizatoarele site-urilor vor fi șterse.</translation>
-<translation id="6534565668554028783">Google a răspuns prea târziu</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB descărcați</translation>
-<translation id="6539092367496845964">A apărut o eroare. Încearcă din nou mai târziu.</translation>
-<translation id="654446541061731451">Selectează o filă pentru transmitere</translation>
-<translation id="6545017243486555795">Șterge toate datele</translation>
-<translation id="6545864417968258051">Căutare Bluetooth</translation>
-<translation id="6560414384669816528">Caută cu Sogou</translation>
-<translation id="6566259936974865419">Chrome a economisit <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Permite întotdeauna</translation>
-<translation id="6573431926118603307">Filele deschise în Chrome pe alte dispozitive vor apărea aici.</translation>
-<translation id="6583199322650523874">Marchează pagina curentă</translation>
-<translation id="6593061639179217415">Versiune site desktop</translation>
-<translation id="6600954340915313787">Copiat în Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Conținut protejat</translation>
-<translation id="6627583120233659107">Editați dosarul</translation>
-<translation id="6643016212128521049">Șterge</translation>
-<translation id="6643649862576733715">Sortează după volumul de date salvate</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}few{<ph name="CONTACT_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Previzualizează imaginea <ph name="BEGIN_NEW" />Nou<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome necesită accesul la locație pentru a căuta dispozitive. <ph name="BEGIN_LINK" />Actualizează permisiunile<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Parolă</translation>
-<translation id="6659594942844771486">Filă</translation>
-<translation id="666731172850799929">Deschide în <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Notificare privind confidențialitatea Chrome</translation>
-<translation id="6676840375528380067">Ștergi datele tale Chrome de pe acest dispozitiv?</translation>
-<translation id="6697492270171225480">Afișează sugestii pentru pagini similare atunci când o pagină nu poate fi găsită</translation>
-<translation id="6697947395630195233">Chrome are nevoie de acces la locația ta ca să permită accesul la locație pentru acest site.</translation>
-<translation id="6698801883190606802">Gestionează datele sincronizate</translation>
-<translation id="6699370405921460408">Serverele Google vor optimiza paginile pe care le vizitezi.</translation>
-<translation id="6706288973712894588">Ești offline.\n<ph name="BEGIN_LINK" />Explorează feedul offline.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Știri</translation>
-<translation id="6710213216561001401">Înapoi</translation>
-<translation id="671481426037969117">Temporizatorul pentru <ph name="FQDN" /> s-a terminat. Va reîncepe mâine.</translation>
-<translation id="6738867403308150051">Se descarcă...</translation>
-<translation id="6746124502594467657">Mutați în jos</translation>
-<translation id="6766622839693428701">Glisează în jos pentru a închide.</translation>
-<translation id="6766758767654711248">Atinge pentru a accesa site-ul</translation>
-<translation id="6767294960381293877">Lista de dispozitive pe care să trimiți o filă este deschisă la jumătate din înălțime.</translation>
-<translation id="6782111308708962316">Împiedică site-urile terță parte să salveze și să citească datele asociate cookie-urilor</translation>
-<translation id="6790428901817661496">Redă</translation>
-<translation id="6811034713472274749">Pagina este gata de vizualizare</translation>
-<translation id="6818926723028410516">Selectează elementele</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Tradu</translation>
-<translation id="6845325883481699275">Contribuie la îmbunătățirea securității pentru Chrome</translation>
-<translation id="6846298663435243399">Se încarcă…</translation>
-<translation id="6850409657436465440">Descărcarea este încă în desfășurare</translation>
-<translation id="6850830437481525139">S-au închis <ph name="TAB_COUNT" /> (de) file</translation>
-<translation id="6864459304226931083">Descarcă imaginea</translation>
-<translation id="6865313869410766144">Datele salvate pentru completarea automată a formularelor</translation>
-<translation id="688738109438487280">Adaugă datele existente în <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Deblochează pentru a copia parola</translation>
-<translation id="6896758677409633944">Copiază</translation>
-<translation id="6910211073230771657">Șters</translation>
-<translation id="6912998170423641340">Blochează accesul de citire a textului și imaginilor din clipboard pentru site-uri</translation>
-<translation id="6914783257214138813">Parolele vor fi vizibile pentru toți cei care pot vedea fișierul exportat.</translation>
-<translation id="6942665639005891494">Schimbă oricând locația de descărcare prestabilită folosind opțiunea din meniul Setări</translation>
-<translation id="6945221475159498467">Selectează</translation>
-<translation id="6963642900430330478">Această pagină este periculoasă. Informații despre site</translation>
-<translation id="6963766334940102469">Șterge marcaje</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Dintotdeauna</translation>
-<translation id="6981982820502123353">Accesibilitate</translation>
-<translation id="6989267951144302301">Nu s-a putut descărca</translation>
-<translation id="6990079615885386641">Descarcă aplicația din Magazinul Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Întreabă înainte de a permite site-urilor să folosească microfonul (recomandat)</translation>
-<translation id="7015203776128479407">Configurarea inițială a sincronizării nu a fost finalizată. Sincronizarea este dezactivată.</translation>
-<translation id="7016516562562142042">Se permite pentru motorul de căutare actual</translation>
-<translation id="7022756207310403729">Deschide în browser</translation>
-<translation id="702463548815491781">Recomandat atunci când este activată opțiunea TalkBack sau Acces prin comutare</translation>
-<translation id="7029809446516969842">Parole</translation>
-<translation id="7053983685419859001">Blochează</translation>
-<translation id="7055152154916055070">Redirecționarea a fost blocată:</translation>
-<translation id="7063006564040364415">Nu s-a putut stabili conexiunea cu serverul de sincronizare.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selectat}few{# selectate}other{# selectate}}</translation>
-<translation id="7071521146534760487">Gestionează contul</translation>
-<translation id="7077143737582773186">Card SD</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> selectate.  Opțiunile sunt disponibile în partea de sus a ecranului</translation>
-<translation id="7121362699166175603">Șterge istoricul și completările automate din bara de adrese. Contul Google poate să ofere alte forme ale istoricului de navigare la <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Permite pentru motorul de căutare actual</translation>
-<translation id="7138678301420049075">Altele</translation>
-<translation id="7141896414559753902">Împiedică site-urile să afișeze ferestre pop-up și redirecționări (recomandat)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Încarcă pagina originală<ph name="END_LINK" /> de la <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Ultimele 24 de ore</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Poți modifica ulterior această opțiune în Setări</translation>
-<translation id="7180611975245234373">Actualizați</translation>
-<translation id="7189372733857464326">Se așteaptă finalizarea actualizării pentru serviciile Google Play</translation>
-<translation id="7191430249889272776">A fost deschisă o filă în fundal.</translation>
-<translation id="723171743924126238">Selectează imagini</translation>
-<translation id="7233236755231902816">Pentru a naviga pe internet în limba ta, este necesară cea mai recentă versiune de Chrome</translation>
-<translation id="7243308994586599757">Opțiuni disponibile în partea de jos a ecranului</translation>
-<translation id="7248069434667874558">Verifică dacă <ph name="TARGET_DEVICE_NAME" /> are sincronizarea activată în Chrome</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> selectate</translation>
-<translation id="7274013316676448362">Site blocat</translation>
-<translation id="7290209999329137901">Nu se poate redenumi</translation>
-<translation id="7291387454912369099">Finalizarea achiziției declanșată de Asistent</translation>
-<translation id="7293171162284876153">Pentru a porni sincronizarea, activează „Sincronizează datele din Chrome”.</translation>
-<translation id="729975465115245577">Dispozitivul nu are o aplicație pentru stocarea fișierului parolelor.</translation>
-<translation id="7302081693174882195">Detalii: sortate după volumul de date salvate</translation>
-<translation id="7328017930301109123">În modul Lite, Chrome încarcă mai repede paginile și folosește cu până la 60 de procente mai puține date.</translation>
-<translation id="7333031090786104871">Încă se adaugă site-ul anterior</translation>
-<translation id="7352939065658542140">VIDEOCLIP</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Trimite un element selectat}few{Trimite # elemente selectate}other{Trimite # de elemente selectate}}</translation>
 <translation id="7359002509206457351">Acces la metodele de plată</translation>
+<translation id="8026334261755873520">Șterge datele de navigare</translation>
+<translation id="1291207594882862231">Șterge istoricul, cookie-urile, datele privind site-urile și memoria cache…</translation>
+<translation id="7814200940910057384">Datele Brave au fost șterse</translation>
+<translation id="1664855196866195614">Datele selectate au fost eliminate din Brave și de pe dispozitivele sincronizate.
+
+Contul Brave Software poate să ofere alte forme ale istoricului de navigare, cum ar fi căutările și activitatea din alte servicii Brave Software, la <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Imaginile și fișierele memorate în cache</translation>
+<translation id="2496180316473517155">Istoricul de navigare</translation>
+<translation id="2546283357679194313">Cookie-uri și date privind site-ul</translation>
+<translation id="8662811608048051533">Te deconectează de pe majoritatea site-urilor.</translation>
+<translation id="8218628800671693884">Te deconectează de pe majoritatea site-urilor. Nu te va deconecta de la Contul Brave Software.</translation>
+<translation id="2017836877785168846">Șterge istoricul și completările automate din bara de adrese.</translation>
+<translation id="8096327394278038498">Șterge istoricul și completările automate din bara de adrese. Contul Brave Software poate să ofere alte forme ale istoricului de navigare la <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Șterge istoricul de pe toate dispozitivele conectate. Contul Brave Software poate să ofere alte forme ale istoricului de navigare la <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Parole salvate</translation>
+<translation id="6865313869410766144">Datele salvate pentru completarea automată a formularelor</translation>
+<translation id="7562080006725997899">Se șterg datele de navigare</translation>
+<translation id="5487521232677179737">Șterge datele</translation>
+<translation id="7498271377022651285">Așteaptă...</translation>
+<translation id="784934925303690534">Interval de timp</translation>
+<translation id="1718835860248848330">Ultima oră</translation>
+<translation id="7149893636342594995">Ultimele 24 de ore</translation>
+<translation id="5648166631817621825">Ultimele 7 zile</translation>
+<translation id="8571213806525832805">Ultimele 4 săptămâni</translation>
+<translation id="5854790677617711513">Mai vechi de 30 de zile</translation>
+<translation id="6979737339423435258">Dintotdeauna</translation>
+<translation id="982182592107339124">Astfel, se vor șterge datele pentru toate site-urile, inclusiv:</translation>
+<translation id="6643016212128521049">Șterge</translation>
+<translation id="7641339528570811325">Șterge datele de navigare…</translation>
+<translation id="1670399744444387456">De bază</translation>
+<translation id="3245261285041759672">Contul Brave Software poate să ofere alte forme ale istoricului de navigare la <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Site blocat</translation>
+<translation id="2534155362429831547">Elemente șterse: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Statistici de utilizare și rapoarte de blocare</translation>
+<translation id="9079153198295609735">Trimite automat la Brave Software statistici de utilizare și rapoarte de blocare</translation>
+<translation id="6981982820502123353">Accesibilitate</translation>
+<translation id="2387895666653383613">Scalarea textului</translation>
+<translation id="2321958826496381788">Trage cursorul până poți citi textul cu ușurință. Textul trebuie să fie cel puțin la fel de mare ca acesta după o atingere dublă pe un paragraf.</translation>
+<translation id="3895926599014793903">Forțează activarea zoomului</translation>
+<translation id="5668404140385795438">Ignoră solicitarea unui site de a împiedica mărirea</translation>
+<translation id="4149994727733219643">Afișare simplificată pentru paginile web</translation>
+<translation id="9100505651305367705">Oferă afișarea simplificată a articolelor, dacă este acceptată</translation>
+<translation id="1409426117486808224">Afișare simplificată pentru filele deschise</translation>
+<translation id="702463548815491781">Recomandat atunci când este activată opțiunea TalkBack sau Acces prin comutare</translation>
+<translation id="8284326494547611709">Subtitrări</translation>
+<translation id="4165986682804962316">Setări pentru site-uri</translation>
+<translation id="6295158916970320988">Toate site-urile</translation>
+<translation id="8380167699614421159">Acest site afișează anunțuri deranjante sau înșelătoare</translation>
+<translation id="1919345977826869612">Anunțuri</translation>
+<translation id="410351446219883937">Redare automată</translation>
+<translation id="6447842834002726250">Cookie-uri</translation>
+<translation id="6196640612572343990">Blochează cookie-urile terță parte</translation>
+<translation id="6782111308708962316">Împiedică site-urile terță parte să salveze și să citească datele asociate cookie-urilor</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Ferestre pop-up și redirecționări</translation>
+<translation id="4751476147751820511">Senzori de mișcare sau de lumină</translation>
+<translation id="1717218214683051432">Senzori de mișcare</translation>
+<translation id="2091887806945687916">Sunet</translation>
+<translation id="2586657967955657006">Clipboard</translation>
+<translation id="6320088164292336938">Vibrații</translation>
+<translation id="4226663524361240545">Notificările pot face dispozitivul să vibreze</translation>
+<translation id="1446450296470737166">Control complet dispozitive MIDI</translation>
+<translation id="3744111561329211289">Sincronizare în fundal</translation>
+<translation id="5649053991847567735">Descărcări automate</translation>
+<translation id="6181444274883918285">Adaugă o excepție privind site-urile</translation>
+<translation id="5313967007315987356">Adaugă un site</translation>
+<translation id="1369915414381695676">Site-ul <ph name="SITE_NAME"/> a fost adăugat</translation>
+<translation id="7837721118676387834">Permite unui anumit site să redea automat videoclipuri cu sunetul dezactivat.</translation>
+<translation id="2621115761605608342">Permite JavaScript pentru un anumit site.</translation>
+<translation id="8801436777607969138">Blochează JavaScript pentru un anumit site.</translation>
+<translation id="8372893542064058268">Permite sincronizarea în fundal pentru un anumit site.</translation>
+<translation id="358794129225322306">Permite unui site să descarce automat mai multe fișiere.</translation>
+<translation id="4008040567710660924">Permite cookie-uri pentru un anumit site.</translation>
+<translation id="8958424370300090006">Blochează cookie-urile pentru un anumit site.</translation>
+<translation id="7882806643839505685">Permite sunetul pentru un anumit site.</translation>
+<translation id="4468959413250150279">Dezactivează sunetul pentru un anumit site.</translation>
+<translation id="1994173015038366702">Adresa URL a site-ului</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Utilizare</translation>
+<translation id="5804241973901381774">Permisiuni</translation>
+<translation id="4278390842282768270">Se permite</translation>
+<translation id="5677928146339483299">Blocat</translation>
+<translation id="1984937141057606926">Permise, cu excepția celor terță parte</translation>
+<translation id="7423098979219808738">Mai întâi întreabă</translation>
+<translation id="8116925261070264013">Cu sunetul dezactivat</translation>
+<translation id="8300705686683892304">Gestionate de aplicație</translation>
+<translation id="6192792657125177640">Excepții</translation>
+<translation id="257931822824936280">Afișare extinsă – dă clic pentru a restrânge.</translation>
+<translation id="5100237604440890931">Afișare restrânsă – dă clic pentru a extinde.</translation>
+<translation id="857943718398505171">Acordată (recomandat)</translation>
+<translation id="2913331724188855103">Permite site-urilor să salveze și să citească datele asociate cookie-urilor (recomandat)</translation>
+<translation id="7445411102860286510">Permite site-urilor să redea automat videoclipuri cu sunetul dezactivat (recomandat)</translation>
+<translation id="5335288049665977812">Permite site-urilor să ruleze JavaScript (recomandat)</translation>
+<translation id="5527111080432883924">Întreabă-mă înainte de a permite site-urilor să citească textul și imaginile din clipboard (recomandat)</translation>
+<translation id="6912998170423641340">Blochează accesul de citire a textului și imaginilor din clipboard pentru site-uri</translation>
+<translation id="7423538860840206698">Citirea clipboardului este blocată</translation>
+<translation id="3955193568934677022">Permite site-urilor să redea conținutul protejat (recomandat)</translation>
+<translation id="445467742685312942">Permite site-urilor să redea conținut protejat</translation>
+<translation id="2107397443965016585">Întreabă înainte de a permite site-urilor să redea conținut protejat (recomandat)</translation>
+<translation id="2910701580606108292">Întreabă înainte de a permite site-urilor să redea conținut protejat</translation>
+<translation id="757524316907819857">Împiedică site-urile să redea conținutul protejat</translation>
+<translation id="3277252321222022663">Permite accesul site-urilor la senzori (recomandat)</translation>
+<translation id="5048398596102334565">Permite accesul site-urilor la senzorii de mișcare (recomandat)</translation>
+<translation id="8816026460808729765">Blochează întotdeauna accesul site-urilor la senzori</translation>
+<translation id="169515064810179024">Împiedică site-urile să acceseze senzorii de mișcare</translation>
+<translation id="1660204651932907780">Permite site-urilor să redea sunet (recomandat)</translation>
+<translation id="3600792891314830896">Dezactivează sunetul pentru site-urile care îl redau</translation>
+<translation id="1743802530341753419">Întreabă înainte de a permite site-urilor să se conecteze la un dispozitiv (recomandat)</translation>
+<translation id="851751545965956758">Blochează conectarea site-urilor la dispozitive</translation>
+<translation id="7141896414559753902">Împiedică site-urile să afișeze ferestre pop-up și redirecționări (recomandat)</translation>
+<translation id="5494752089476963479">Blochează anunțurile pe site-urile care afișează anunțuri deranjante sau înșelătoare</translation>
+<translation id="3123473560110926937">Blocate pe anumite site-uri</translation>
+<translation id="965817943346481315">Blochează dacă site-ul afișează anunțuri deranjante sau înșelătoare (recomandat)</translation>
+<translation id="3386292677130313581">Întreabă înainte de a permite site-urilor să afle locația (recomandat)</translation>
+<translation id="9139068048179869749">Întreabă înainte de a permite site-urilor să trimită notificări (recomandat)</translation>
+<translation id="4479647676395637221">Întreabă înainte de a permite site-urilor să folosească camera foto (recomandat)</translation>
+<translation id="6992289844737586249">Întreabă înainte de a permite site-urilor să folosească microfonul (recomandat)</translation>
+<translation id="2289270750774289114">Întreabă-mă când un site dorește să descopere dispozitive Bluetooth din apropiere (recomandat)</translation>
+<translation id="7053983685419859001">Blochează</translation>
+<translation id="7128222689758636196">Permite pentru motorul de căutare actual</translation>
+<translation id="7589445247086920869">Blochează pentru motorul de căutare actual</translation>
+<translation id="6388207532828177975">Șterge și resetează</translation>
+<translation id="7999064672810608036">Sigur dorești să ștergi toate datele locale, inclusiv cookie-urile pentru acest site și să îi resetezi permisiunile?</translation>
+<translation id="2822354292072154809">Sigur dorești să resetezi toate permisiunile la nivel de site pentru <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Șterge datele stocate</translation>
+<translation id="5902828464777634901">Toate datele stocate de site, inclusiv cookie-urile vor fi șterse.</translation>
+<translation id="119944043368869598">Șterge-le pe toate</translation>
+<translation id="2490684707762498678">Gestionate de <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Deschide setările pentru notificări</translation>
+<translation id="1404122904123200417">Încorporat în <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Fișierele salvate de site-uri apar aici</translation>
+<translation id="4181841719683918333">Limbi</translation>
+<translation id="2647434099613338025">Adaugă o limbă</translation>
+<translation id="1952172573699511566">Site-urile vor afișa textul în limba ta preferată, dacă este posibil.</translation>
+<translation id="8559990750235505898">Oferă traducerea paginilor în alte limbi</translation>
+<translation id="4719927025381752090">Oferă traducerea</translation>
+<translation id="8156139159503939589">În ce limbi poți să citești?</translation>
+<translation id="5689516760719285838">Locație</translation>
+<translation id="2440823041667407902">Accesul la locație</translation>
+<translation id="2023546461831060654">Activează permisiunile pentru Brave din <ph name="BEGIN_LINK"/>Setări Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Activează permisiunea pentru Brave din <ph name="BEGIN_LINK"/>Setări Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Pentru a permite Brave să acceseze locația, activează locația și în <ph name="BEGIN_LINK"/>Setările Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Pentru a permite Brave să acceseze camera, activează camera și în <ph name="BEGIN_LINK"/>Setările Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Pentru a permite Brave să îți trimită notificări, activează notificările și în <ph name="BEGIN_LINK"/>Setările Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Ca să permiți Brave să acceseze microfonul, activează microfonul și în <ph name="BEGIN_LINK"/>Setările Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Accesul la locație este dezactivat pentru acest dispozitiv. Activează-l în <ph name="BEGIN_LINK"/>Setări Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Accesul la locație este dezactivat și pentru acest dispozitiv. Activează-l în <ph name="BEGIN_LINK"/>Setări Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Cameră</translation>
+<translation id="3227137524299004712">Microfon</translation>
+<translation id="1647391597548383849">Accesează camera foto</translation>
+<translation id="945632385593298557">Accesează microfonul</translation>
+<translation id="6612358246767739896">Conținut protejat</translation>
+<translation id="885701979325669005">Stocare</translation>
+<translation id="3198916472715691905">Date stocate: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Revocă permisiunea de accesare a dispozitivului</translation>
+<translation id="4962975101802056554">Revocă toate permisiunile pentru dispozitiv</translation>
+<translation id="6545864417968258051">Căutare Bluetooth</translation>
+<translation id="4411535500181276704">Modul Lite</translation>
+<translation id="7821588508402923572">Economiile de date vor apărea aici</translation>
+<translation id="2131665479022868825">Date economisite: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">începând cu <ph name="DATE"/></translation>
+<translation id="3252158532344029638">În modul Lite, Brave încarcă mai repede paginile și folosește cu până la 60 de procente mai puține date.</translation>
+<translation id="6159335304067198720">Economie de date de <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">date economisite</translation>
+<translation id="6111020039983847643">date utilizate</translation>
+<translation id="7413229368719586778">Data de începere <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Data de încheiere <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sortează după site</translation>
+<translation id="5864174910718532887">Detalii: sortate după numele site-ului</translation>
+<translation id="116280672541001035">Utilizate</translation>
+<translation id="8349013245300336738">Sortează după volumul de date folosite</translation>
+<translation id="6378173571450987352">Detalii: sortate după volumul de date folosite</translation>
+<translation id="2631006050119455616">Economisite</translation>
+<translation id="6643649862576733715">Sortează după volumul de date salvate</translation>
+<translation id="7302081693174882195">Detalii: sortate după volumul de date salvate</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> folosiți</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> salvați</translation>
+<translation id="2156074688469523661">Site-uri rămase (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Altele</translation>
+<translation id="4913161338056004800">Resetează statisticile</translation>
+<translation id="1856325424225101786">Resetezi modul Lite?</translation>
+<translation id="3658159451045945436">Prin resetare se șterge istoricul economisirii de date, inclusiv lista site-urilor vizitate.</translation>
+<translation id="3295530008794733555">Navighează mai rapid. Folosește mai puține date.</translation>
+<translation id="7340390500800578919">În modul Lite, Brave încarcă mai repede paginile și folosește cu până la 60 % mai puține date. Pentru a optimiza paginile pe care le accesezi, Brave trimite traficul tău web la Brave Software. <ph name="BEGIN_LINK"/>Află mai multe<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Activează modul Lite</translation>
+<translation id="4493497663118223949">Modul Lite este activat</translation>
+<translation id="7559975015014302720">Modul Lite este dezactivat</translation>
+<translation id="7606077192958116810">Modul Lite este activat. Gestionează-l în Setări.</translation>
+<translation id="4714588616299687897">Economisește până la 60% din date</translation>
+<translation id="1006927014032731288">Serverele Brave Software vor optimiza paginile pe care le vizitezi.</translation>
+<translation id="3257320067425202300">Brave a economisit <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave a economisit <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Locația de descărcare</translation>
+<translation id="7077143737582773186">Card SD</translation>
+<translation id="7762668264895820836">Cardul SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Întreabă unde să fie salvate fișierele</translation>
+<translation id="6192333916571137726">Descarcă fișierul</translation>
+<translation id="1672586136351118594">Nu mai afișa</translation>
+<translation id="2650751991977523696">Descarci din nou fișierul?</translation>
+<translation id="8664979001105139458">Numele fișierului există deja</translation>
+<translation id="488187801263602086">Redenumește fișierul</translation>
+<translation id="5686790454216892815">Numele fișierului este prea lung</translation>
+<translation id="7454641608352164238">Spațiu insuficient</translation>
+<translation id="8972098258593396643">Descarci în dosarul prestabilit?</translation>
+<translation id="804335162455518893">Nu s-a găsit cardul SD</translation>
+<translation id="7475688122056506577">Nu s-a găsit cardul SD. Este posibil ca unele fișiere să lipsească.</translation>
+<translation id="4198423547019359126">Nu există locații de descărcare disponibile</translation>
+<translation id="8224471946457685718">Descarcă articole pentru tine pe Wi-Fi</translation>
+<translation id="4970824347203572753">Nu este disponibil în locația ta</translation>
+<translation id="5500777121964041360">Este posibil să nu fie disponibil în locația ta</translation>
+<translation id="1173894706177603556">Redenumește</translation>
+<translation id="1986685561493779662">Numele există deja</translation>
+<translation id="6441734959916820584">Numele este prea lung</translation>
+<translation id="2923908459366352541">Numele nu este valid</translation>
+<translation id="7290209999329137901">Nu se poate redenumi</translation>
+<translation id="3334729583274622784">Modifici extensia de fișier?</translation>
+<translation id="107147699690128016">Dacă modifici extensia de fișier, fișierul poate să se deschidă în altă aplicație și să dăuneze dispozitivului.</translation>
+<translation id="8541922081612557424">Despre Brave</translation>
+<translation id="5311273890481188673">Drept de autor <ph name="YEAR"/> Brave Software LLC. Toate drepturile rezervate.</translation>
+<translation id="1416550906796893042">Versiunea aplicației</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Actualizată la <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Sistem de operare</translation>
+<translation id="3968054912784331254">Actualizările Brave nu mai sunt acceptate pentru această versiune de Android</translation>
+<translation id="7665369617277396874">Adaugă un cont</translation>
+<translation id="649070405679044769">Conectat(ă) la Brave Software ca</translation>
+<translation id="6234515504547364178">Deconectează-te de la Brave</translation>
+<translation id="5324858694974489420">Setări parentale</translation>
+<translation id="8920114477895755567">Se așteaptă detaliile părinților.</translation>
+<translation id="5512137114520586844">Acest cont este gestionat de <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Acest cont este gestionat de <ph name="PARENT_NAME_1"/> și de <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Conținut</translation>
+<translation id="5403644198645076998">Permite numai anumite site-uri</translation>
+<translation id="8641930654639604085">Încearcă să blochezi site-urile destinate adulților</translation>
+<translation id="5639724618331995626">Permite toate site-urile</translation>
+<translation id="796823723482603597">Afișată de Brave</translation>
+<translation id="6324034347079777476">Sincronizarea de sistem Android este dezactivată</translation>
+<translation id="5127805178023152808">Sincronizarea este dezactivată</translation>
+<translation id="7015203776128479407">Configurarea inițială a sincronizării nu a fost finalizată. Sincronizarea este dezactivată.</translation>
+<translation id="2497852260688568942">Sincronizarea este dezactivată de administrator</translation>
+<translation id="9100610230175265781">Este necesară o expresie de acces</translation>
+<translation id="6108923351542677676">Configurare în curs...</translation>
+<translation id="4062305924942672200">Informații juridice</translation>
+<translation id="4256782883801055595">Licențe open source</translation>
+<translation id="1138681184697033370">Termenii și condițiile Brave</translation>
+<translation id="7392539049993970338">Notificare privind confidențialitatea Brave</translation>
+<translation id="2677748264148917807">Ieși</translation>
+<translation id="5556459405103347317">Reîncarcă</translation>
+<translation id="1623104350909869708">Restricționați capacitatea acestei pagini de a crea casete de dialog suplimentare</translation>
+<translation id="2968755619301702150">Vizualizator de certificate</translation>
+<translation id="1360432990279830238">Te deconectezi și dezactivezi sincronizarea?</translation>
+<translation id="8581481290581777242">Ștergi datele tale Brave de pe acest dispozitiv?</translation>
+<translation id="1318865768845061710">Marcajele, istoricul, parolele și alte date Brave nu vor mai fi sincronizate cu Contul Brave Software</translation>
+<translation id="3325020657155065477">Șterge și datele Brave de pe acest dispozitiv</translation>
+<translation id="6136448902816743006">Întrucât te deconectezi de la un cont gestionat de <ph name="DOMAIN_NAME"/>, datele Brave vor fi șterse de pe dispozitiv. Acestea vor fi păstrate în Contul tău Brave Software.</translation>
+<translation id="1853026300647876496">Se contactează Brave Software. Poate dura un minut...</translation>
+<translation id="2328985652426384049">Nu se poate conecta</translation>
+<translation id="7723158744459952869">Brave Software a răspuns prea târziu</translation>
+<translation id="4572422548854449519">Conectează-te la contul gestionat</translation>
+<translation id="2689656545739939160">Te conectezi cu un cont gestionat de <ph name="MANAGED_DOMAIN"/> și acorzi administratorului acestuia controlul asupra datelor Brave. Datele vor fi asociate definitiv acestui cont. Dacă te deconectezi de la Brave, datele se vor șterge de pe acest dispozitiv, dar vor rămâne stocate în Contul Brave Software.</translation>
+<translation id="1749561566933687563">Sincronizează marcajele</translation>
+<translation id="4242533952199664413">Deschide setările</translation>
+<translation id="1111673857033749125">Marcajele salvate pe alte dispozitive vor apărea aici.</translation>
+<translation id="8636825310635137004">Pentru a accesa filele de pe alte dispozitive, activează sincronizarea.</translation>
+<translation id="3269956123044984603">Pentru a accesa filele de pe alte dispozitive, activează opțiunea „Sincronizează automat datele” în setările Android din Contul Brave Software.</translation>
+<translation id="5157964048453367290">Filele deschise în Brave pe alte dispozitive vor apărea aici.</translation>
+<translation id="4684427112815847243">Sincronizează tot</translation>
+<translation id="2709516037105925701">Completare automată</translation>
+<translation id="8820817407110198400">Marcaje</translation>
+<translation id="1644574205037202324">Istoric</translation>
+<translation id="17513872634828108">File deschise</translation>
+<translation id="1320169905922104972">Carduri de credit și adrese care folosesc Brave Software Pay</translation>
+<translation id="6337234675334993532">Criptare</translation>
+<translation id="6698801883190606802">Gestionează datele sincronizate</translation>
+<translation id="3598578758776312506">Criptează parolele cu datele de conectare Brave Software</translation>
+<translation id="7810580217418711046">Criptează datele sincronizate cu parola Brave Software începând cu <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Criptează datele sincronizate folosind propria expresie de acces pentru sincronizare</translation>
+<translation id="2996291259634659425">Creează o expresie de acces</translation>
+<translation id="5713644099811900409">Contul Brave Software</translation>
+<translation id="8997474919031554666">Criptarea expresiei de acces nu include metodele de plată și adresele din Brave Software Pay. Numai cine are expresia ta de acces poate citi datele tale criptate. Expresia de acces nu este trimisă sau stocată la Brave Software. Dacă îți uiți expresia de acces sau vrei să modifici această setare, va trebui să resetezi sincronizarea. <ph name="BEGIN_LINK"/>Află mai multe<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Expresie de acces</translation>
+<translation id="7772032839648071052">Confirmă expresia de acces</translation>
+<translation id="5304593522240415983">Acest câmp trebuie completat</translation>
+<translation id="321773570071367578">Dacă ai uitat expresia de acces sau dorești să modifici această setare, <ph name="BEGIN_LINK"/>resetează sincronizarea<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Expresiile de acces nu corespund</translation>
+<translation id="5149495116300586333">Criptarea expresiei de acces nu include metodele de plată și adresele din Brave Software Pay.
+
+Pentru a modifica această setare, <ph name="BEGIN_LINK"/>resetează sincronizarea<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Expresie de acces incorectă</translation>
+<translation id="5414836363063783498">Se verifică...</translation>
+<translation id="6846298663435243399">Se încarcă…</translation>
+<translation id="5517095782334947753">Ai marcajele, istoricul, parolele și alte setări din <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Combină datele</translation>
+<translation id="688738109438487280">Adaugă datele existente în <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Păstrează datele separat</translation>
+<translation id="1145536944570833626">Șterge datele existente.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> dorește să se asocieze</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Obține ajutor<ph name="END_LINK"/> în timp ce se caută dispozitive…</translation>
+<translation id="5817918615728894473">Asociază</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Obține ajutor<ph name="END_LINK1"/> sau <ph name="BEGIN_LINK2"/>scanează din nou<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Nu s-au găsit dispozitive compatibile</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Activează Bluetooth<ph name="END_LINK"/> pentru a permite asocierea</translation>
+<translation id="998321811308652668">Brave nu poate activa adaptorul Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Obține ajutor<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave necesită accesul la locație pentru a căuta dispozitive. <ph name="BEGIN_LINK"/>Actualizează permisiunile<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave necesită accesul la locație pentru a căuta dispozitive. Accesul la locație este <ph name="BEGIN_LINK"/>dezactivat pentru acest dispozitiv<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave necesită accesul la locație pentru a căuta dispozitive. <ph name="BEGIN_LINK1"/>Actualizează permisiunile<ph name="END_LINK1"/>. Accesul la locație este <ph name="BEGIN_LINK2"/>dezactivat pentru acest dispozitiv<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Dispozitiv conectat</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Nivelul puterii semnalului: # bară}few{Nivelul puterii semnalului: # bare}other{Nivelul puterii semnalului: # de bare}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> vrea să caute dispozitive Bluetooth în apropiere. Următoarele dispozitive au fost găsite:</translation>
+<translation id="8368027906805972958">Dispozitiv necunoscut sau neacceptat (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sincronizarea nu funcționează</translation>
+<translation id="1810845389119482123">Configurarea inițială a sincronizării nu este finalizată</translation>
+<translation id="3235722914093408050">Deschide setările Android și reactivează sincronizarea sistemului Android pentru a porni sincronizarea Brave</translation>
+<translation id="3367813778245106622">Conectează-te din nou pentru a începe sincronizarea</translation>
+<translation id="974555521953189084">Introdu expresia de acces pentru a începe sincronizarea</translation>
+<translation id="2997266899014181325">Pentru a porni sincronizarea, activează „Sincronizează datele din Brave”.</translation>
+<translation id="8260126382462817229">Încearcă să te conectezi din nou</translation>
+<translation id="5919204609460789179">Actualizează <ph name="PRODUCT_NAME"/> pentru a începe sincronizarea</translation>
+<translation id="397583555483684758">Sincronizarea nu mai funcționează</translation>
+<translation id="1966710179511230534">Actualizați detaliile de conectare.</translation>
+<translation id="7063006564040364415">Nu s-a putut stabili conexiunea cu serverul de sincronizare.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> este învechit.</translation>
+<translation id="4170011742729630528">Serviciul nu este disponibil. Încercați din nou mai târziu.</translation>
+<translation id="7947953824732555851">Accept și conectare</translation>
+<translation id="8583805026567836021">Se șterg datele contului</translation>
+<translation id="8310344678080805313">File standard</translation>
+<translation id="5748802427693696783">Ai comutat la filele standard</translation>
+<translation id="7998918019931843664">Redeschideți fila închisă</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, filă</translation>
+<translation id="4452411734226507615">Închide fila <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Opțiuni disponibile în partea de jos a ecranului</translation>
+<translation id="4060598801229743805">Opțiunile sunt disponibile în partea de sus a ecranului</translation>
+<translation id="2810645512293415242">Pagină simplificată pentru economie de date și încărcare mai rapidă.</translation>
+<translation id="3985215325736559418">Dorești să descarci <ph name="FILE_NAME"/> din nou?</translation>
+<translation id="2450083983707403292">Dorești să se înceapă din nou descărcarea pentru <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Descarcă</translation>
+<translation id="545042621069398927">Se accelerează descărcarea.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Fișierul se descarcă.}few{Se descarcă # fișiere.}other{Se descarcă # de fișiere.}}</translation>
+<translation id="543509235395288790">Se descarcă <ph name="COUNT"/> fișiere (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Fișierul se descarcă (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{O descărcare finalizată.}few{# descărcări finalizate.}other{# de descărcări finalizate.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{O descărcare nu a reușit.}few{# descărcări nu au reușit.}other{# de descărcări nu au reușit.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{O descărcare în așteptare.}few{# descărcări în așteptare.}other{# de descărcări în așteptare.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> Butonul <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Aproape gata!</translation>
+<translation id="3960299545138990065">repornește Brave;</translation>
+<translation id="3771001275138982843">Nu s-a putut descărca actualizarea</translation>
+<translation id="3888648114124182147">Se descarcă actualizarea Brave…</translation>
+<translation id="1705567146636171298">Actualizează Brave</translation>
+<translation id="6195417478702700398">Pentru o experiență de navigare mai bună, deschide pentru a actualiza Brave</translation>
+<translation id="3512968675351418494">Pentru a naviga pe internet în limba ta, este necesară cea mai recentă versiune de Brave</translation>
+<translation id="6427112570124116297">Tradu pe web</translation>
+<translation id="1379423114029199501">Actualizează pentru a descărca limba ta în cea mai recentă versiune de Brave</translation>
+<translation id="5684874026226664614">Hopa. Această pagină nu a putut fi tradusă.</translation>
+<translation id="6831043979455480757">Tradu</translation>
+<translation id="1285320974508926690">Nu traduce niciodată acest site</translation>
+<translation id="773466115871691567">Tradu întotdeauna paginile în <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nu traduce niciodată paginile în <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Mai multe limbi</translation>
+<translation id="290376772003165898">Pagina nu este în <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Paginile în <ph name="SOURCE_LANGUAGE"/> vor fi traduse în <ph name="TARGET_LANGUAGE"/> de acum înainte</translation>
+<translation id="8339163506404995330">Paginile în <ph name="LANGUAGE"/> nu vor fi traduse</translation>
+<translation id="5447765697759493033">Acest site nu va fi tradus</translation>
+<translation id="4880127995492972015">Tradu…</translation>
+<translation id="641643625718530986">Printați...</translation>
+<translation id="8909135823018751308">Trimite…</translation>
+<translation id="4996978546172906250">Trimite prin</translation>
+<translation id="6333140779060797560">Trimite prin <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">A apărut o problemă la printarea paginii. Încercați din nou.</translation>
+<translation id="3254409185687681395">Marcați această pagină</translation>
+<translation id="497421865427891073">Înainte</translation>
+<translation id="813082847718468539">Afișează informațiile privind site-ul</translation>
+<translation id="2532336938189706096">Vizualizare pe web</translation>
+<translation id="6005538289190791541">Parola sugerată</translation>
+<translation id="4634124774493850572">Folosește parola</translation>
+<translation id="8285489906452138776">Brave are nevoie de permisiune ca să acceseze camera foto pentru acest site.</translation>
+<translation id="320189792589364011">Brave are nevoie de permisiune ca să acceseze microfonul pentru acest site.</translation>
+<translation id="7988136689212463100">Brave are nevoie de permisiune ca să acceseze camera foto și microfonul pentru acest site.</translation>
+<translation id="4931190655840828017">Brave are nevoie de acces la locația ta ca să permită accesul la locație pentru acest site.</translation>
+<translation id="3088191967551450609">Pentru a descărca fișiere, Brave necesită acces la stocare.</translation>
+<translation id="8942627711005830162">Deschide în altă fereastră</translation>
+<translation id="4195643157523330669">Deschide în filă nouă</translation>
+<translation id="1100066534610197918">Deschide în filă nouă în grup</translation>
+<translation id="4860895144060829044">Apelează</translation>
+<translation id="6896758677409633944">Copiază</translation>
+<translation id="8393700583063109961">Trimite un mesaj</translation>
+<translation id="3557336313807607643">Adaugă în Agendă</translation>
+<translation id="4269820728363426813">Copiază adresa linkului</translation>
+<translation id="1206892813135768548">Copiază textul linkului</translation>
+<translation id="1204037785786432551">Descarcă linkul</translation>
+<translation id="6864459304226931083">Descarcă imaginea</translation>
+<translation id="8209050860603202033">Deschideți imaginea</translation>
+<translation id="8073388330009372546">Vezi imaginea în filă nouă</translation>
+<translation id="6649642165559792194">Previzualizează imaginea <ph name="BEGIN_NEW"/>Nou<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Încarcă imaginea</translation>
+<translation id="3845332215609790146">Caută folosind Brave Software Lens <ph name="BEGIN_NEW"/>Nou<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Caută imaginea cu <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Trimite imaginea</translation>
+<translation id="5833984609253377421">Trimite linkul</translation>
+<translation id="6475951671322991020">Descarcă videoclipul</translation>
+<translation id="2317945146070194624">Deschide în filă Brave nouă</translation>
+<translation id="7975379999046275268">Previzualizează pagina <ph name="BEGIN_NEW"/>Nou<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Se actualizează pagina</translation>
+<translation id="36525718899759834">Descarcă aplicația din Magazinul Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Întunecat</translation>
+<translation id="1807246157184219062">Luminos</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Un singur spațiu</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Selectează o filă pentru transmitere</translation>
+<translation id="8719023831149562936">Fila actuală nu poate fi transmisă</translation>
+<translation id="2139186145475833000">Adaugă pe ecran pornire</translation>
+<translation id="4616150815774728855">Deschide <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Aplicația nu poate fi deschisă</translation>
+<translation id="5129038482087801250">Instalează aplicația web</translation>
+<translation id="3789841737615482174">Instalează</translation>
+<translation id="4665282149850138822">Site-ul <ph name="NAME"/> a fost adăugat pe ecranul de pornire</translation>
+<translation id="7333031090786104871">Încă se adaugă site-ul anterior</translation>
+<translation id="1036727731225946849">Se adaugă <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">S-a adăugat pe ecranul de pornire</translation>
+<translation id="2146738493024040262">Deschide aplicația instantanee</translation>
+<translation id="7016516562562142042">Se permite pentru motorul de căutare actual</translation>
+<translation id="6177111841848151710">Blocată pentru motorul de căutare actual</translation>
+<translation id="145097072038377568">Dezactivată din Setări Android</translation>
+<translation id="8007176423574883786">Dezactivată pentru acest dispozitiv</translation>
+<translation id="164269334534774161">Se afișează o versiune offline a acestei pagini de pe <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Această pagină offline este din data de <ph name="CREATION_TIME"/> și poate fi diferită de versiunea online.</translation>
+<translation id="8840953339110955557">Această pagină poate fi diferită de versiunea online.</translation>
+<translation id="6405300764336705484">Acest conținut provine de pe <ph name="DOMAIN_NAME"/>, oferit de Brave Software.</translation>
+<translation id="1006017844123154345">Deschide online</translation>
+<translation id="3326636747541519688">Pagină Lite oferită de Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Încarcă pagina originală<ph name="END_LINK"/> de la <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Dacă acest mesaj apare frecvent, încearcă următoarele <ph name="BEGIN_LINK"/>sugestii<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Conținutul este ascuns</translation>
+<translation id="3810973564298564668">Gestionează</translation>
+<translation id="5199929503336119739">Profilul de serviciu</translation>
+<translation id="528192093759286357">Trage din partea de sus și atinge butonul Înapoi pentru a ieși din ecranul complet.</translation>
+<translation id="2836148919159985482">Atinge butonul Înapoi pentru a ieși din ecranul complet.</translation>
+<translation id="3967822245660637423">Descărcare finalizată</translation>
+<translation id="2434158240863470628">Descărcare finalizată <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Descărcarea nu a reușit</translation>
+<translation id="1384959399684842514">Descărcare întreruptă</translation>
+<translation id="1671236975893690980">Descărcare în așteptare…</translation>
+<translation id="5561549206367097665">Se așteaptă rețeaua…</translation>
+<translation id="5864419784173784555">Se așteaptă altă descărcare…</translation>
+<translation id="6461962085415701688">Fișierul nu poate fi deschis</translation>
+<translation id="1178581264944972037">Întrerupe</translation>
+<translation id="8200772114523450471">Reia</translation>
+<translation id="1409879593029778104">Descărcarea fișierului <ph name="FILE_NAME"/> a fost împiedicată, deoarece fișierul există deja.</translation>
+<translation id="3387650086002190359">Descărcarea fișierului <ph name="FILE_NAME"/> nu a reușit din cauza unor erori privind sistemul de fișiere.</translation>
+<translation id="6482749332252372425">Descărcarea fișierului <ph name="FILE_NAME"/> nu a reușit din cauza spațiului de stocare insuficient.</translation>
+<translation id="7619072057915878432">Descărcarea fișierului <ph name="FILE_NAME"/> nu a reușit din cauza erorilor de rețea.</translation>
+<translation id="1477626028522505441">Descărcarea fișierului <ph name="FILE_NAME"/> nu a reușit din cauza unor probleme de server.</translation>
+<translation id="3692944402865947621">Descărcarea fișierului <ph name="FILE_NAME"/> nu a reușit, deoarece nu se poate contacta locația de stocare.</translation>
+<translation id="604996488070107836">Fișierul <ph name="FILE_NAME"/> nu a fost descărcat din cauza unei erori necunoscute.</translation>
+<translation id="6738867403308150051">Se descarcă...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB descărcați</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB descărcați</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB descărcați</translation>
+<translation id="9204836675896933765">1 fișier rămas</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> fișiere rămase</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fișier descărcat}few{<ph name="FILES_DOWNLOADED_MANY"/> fișiere descărcate}other{<ph name="FILES_DOWNLOADED_MANY"/> de fișiere descărcate}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> zile rămase</translation>
+<translation id="8190358571722158785">1 zi rămasă</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> ore rămase</translation>
+<translation id="510275257476243843">1 oră rămasă</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> min. rămase</translation>
+<translation id="3236059992281584593">1 min. rămas</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> sec. rămase</translation>
+<translation id="2781151931089541271">1 sec. rămasă</translation>
+<translation id="3303414029551471755">Continui pentru descărcarea conținutului?</translation>
+<translation id="8617240290563765734">Deschizi adresa URL sugerată specificată în conținutul descărcat?</translation>
+<translation id="1373696734384179344">Memorie insuficientă pentru descărcarea conținutului selectat.</translation>
+<translation id="5271967389191913893">Dispozitivul nu poate deschide conținutul de descărcat.</translation>
+<translation id="883806473910249246">A apărut o eroare la descărcarea conținutului.</translation>
+<translation id="5626134646977739690">Nume:</translation>
+<translation id="7963646190083259054">Producător:</translation>
+<translation id="3414952576877147120">Dimensiune:</translation>
+<translation id="7375125077091615385">Tip:</translation>
+<translation id="5765780083710877561">Descriere:</translation>
+<translation id="4881695831933465202">Deschide</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB disponibili</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MO disponibili</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB disponibili</translation>
+<translation id="5793665092639000975">Se utilizează <ph name="SPACE_USED"/> din <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Toate</translation>
+<translation id="4988526792673242964">Pagini</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Audio</translation>
+<translation id="9219103736887031265">Imagini</translation>
+<translation id="8250920743982581267">Documente</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{Un fișier}few{# fișiere}other{# de fișiere}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{O imagine}few{# imagini}other{# de imagini}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{Un videoclip}few{# videoclipuri}other{# de videoclipuri}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{Un fișier audio}few{# fișiere audio}other{# de fișiere audio}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{O pagină}few{# pagini}other{# pagini}}</translation>
+<translation id="5456381639095306749">Descarcă pagina</translation>
+<translation id="2394602618534698961">Fișierele pe care le descarci apar aici</translation>
+<translation id="7810647596859435254">Deschide cu…</translation>
+<translation id="5655963694829536461">Caută în descărcări</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Fișierele mele</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Articolele apar aici și le poți citi chiar dacă ești offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{O oră}few{# ore}other{# de ore}}</translation>
+<translation id="5853623416121554550">întreruptă</translation>
+<translation id="8965591936373831584">în așteptare</translation>
+<translation id="2779651927720337254">nereușită</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Adineauri</translation>
+<translation id="4000212216660919741">Pagina de pornire offline</translation>
+<translation id="9133397713400217035">Explorează offline</translation>
+<translation id="968900484120156207">Paginile pe care le accesezi apar aici</translation>
+<translation id="7882131421121961860">Nu s-a găsit niciun istoric</translation>
+<translation id="3549657413697417275">Caută în istoricul tău</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">LL</translation>
+<translation id="605721222689873409">AA</translation>
+<translation id="724102042129299115">Experiența primei rulări Brave</translation>
+<translation id="2700285883409956633">Folosind această aplicație, accepți <ph name="BEGIN_LINK1"/>Termenii și condițiile<ph name="END_LINK1"/> și <ph name="BEGIN_LINK2"/>Notificarea privind confidențialitatea<ph name="END_LINK2"/> Brave.</translation>
+<translation id="1640714894372474981">Dacă folosești aplicația, accepți <ph name="BEGIN_LINK1"/>Termenii și condițiile<ph name="END_LINK1"/> și <ph name="BEGIN_LINK2"/>Notificarea privind confidențialitatea<ph name="END_LINK2"/> Brave și <ph name="BEGIN_LINK3"/>Notificarea privind confidențialitatea pentru Conturile Brave Software gestionate cu Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> se va deschide în Brave. Continuând, ești de acord cu <ph name="BEGIN_LINK1"/>Termenii și condițiile<ph name="END_LINK1"/> și <ph name="BEGIN_LINK2"/>Notificarea privind confidențialitatea<ph name="END_LINK2"/> Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> se va deschide în Brave. Continuând, ești de acord cu <ph name="BEGIN_LINK1"/>Termenii și condițiile<ph name="END_LINK1"/> și <ph name="BEGIN_LINK2"/>Notificarea privind confidențialitatea<ph name="END_LINK2"/> Brave și cu <ph name="BEGIN_LINK3"/>Notificarea privind confidențialitatea pentru Conturile Brave Software gestionate cu Family<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Contribuie la îmbunătățirea Brave trimițând statistici de utilizare și rapoarte de blocare la Brave Software.</translation>
+<translation id="3518985090088779359">Acceptă și continuă</translation>
+<translation id="7207456302801184289">Bun venit la Brave</translation>
+<translation id="704822250101715322">Se așteaptă finalizarea actualizării pentru serviciile Brave Software Play</translation>
+<translation id="1231733316453485619">Activezi sincronizarea?</translation>
+<translation id="5132942445612118989">Sincronizează parolele, istoricul și alte date pe toate dispozitivele</translation>
+<translation id="5736731321935944068">Brave Software poate folosi istoricul pentru a personaliza Căutarea, anunțurile și alte servicii Brave Software</translation>
+<translation id="4013614219085422040">Brave Software poate folosi istoricul pentru a personaliza Căutarea și alte servicii Brave Software</translation>
+<translation id="5581519193887989363">Poți să alegi oricând ce să sincronizezi în <ph name="BEGIN_LINK1"/>setări<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Da, accept</translation>
+<translation id="2410754283952462441">Alege un cont</translation>
+<translation id="2227444325776770048">Continuă ca <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Nu ești <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Pentru a accesa marcajele pe toate dispozitivele, activează sincronizarea</translation>
+<translation id="2818669890320396765">Pentru a accesa marcajele pe toate dispozitivele, conectează-te și activează sincronizarea</translation>
+<translation id="6003646045106347985">Pentru a obține sugestii de conținut personalizat de la Brave Software, activează sincronizarea</translation>
+<translation id="8494430740943879273">Pentru a obține sugestii de conținut personalizat de la Brave Software, conectează-te și activează sincronizarea</translation>
+<translation id="5862731021271217234">Pentru a accesa filele de pe alte dispozitive, activează sincronizarea</translation>
+<translation id="3568688522516854065">Pentru a accesa filele de pe alte dispozitive, conectează-te și activează sincronizarea</translation>
+<translation id="1208340532756947324">Pentru a sincroniza și a personaliza pe toate dispozitivele, activează sincronizarea</translation>
+<translation id="4472118726404937099">Pentru a sincroniza și a personaliza pe toate dispozitivele, conectează-te și activează sincronizarea</translation>
+<translation id="2426805022920575512">Alege alt cont</translation>
+<translation id="6790428901817661496">Redă</translation>
+<translation id="1272079795634619415">Oprește</translation>
+<translation id="2874939134665556319">Melodia anterioară</translation>
+<translation id="4046123991198612571">Melodia următoare</translation>
+<translation id="3859306556332390985">Derulează înainte</translation>
+<translation id="8441146129660941386">Derulează înapoi</translation>
+<translation id="6706288973712894588">Ești offline.\n<ph name="BEGIN_LINK"/>Explorează feedul offline.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">File recente</translation>
+<translation id="8497726226069778601">Nu este nimic de văzut aici... deocamdată</translation>
+<translation id="5423934151118863508">Cele mai accesate pagini vor apărea aici</translation>
+<translation id="6127379762771434464">Elementul a fost eliminat</translation>
+<translation id="4605958867780575332">Element eliminat: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Doodle Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Alte dispozitive</translation>
+<translation id="4738836084190194332">Ultima sincronizare: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Acum # minut}few{Acum # minute}other{Acum # de minute}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Acum # oră}few{Acum # ore}other{Acum # de ore}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Acum # zi}few{Acum # zile}other{Acum # de zile}}</translation>
+<translation id="2762000892062317888">adineauri</translation>
+<translation id="1407135791313364759">Deschideți-le pe toate</translation>
+<translation id="1209206284964581585">Ascunde momentan</translation>
+<translation id="129553762522093515">Închise recent</translation>
+<translation id="8413126021676339697">Afișează întregul istoric</translation>
+<translation id="7876243839304621966">Elimină tot</translation>
+<translation id="8487700953926739672">Disponibil offline</translation>
+<translation id="5224771365102442243">Cu videoclip</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Află mai multe<ph name="END_LINK"/> despre conținutul sugerat</translation>
+<translation id="7542481630195938534">Nu se pot obține sugestii</translation>
+<translation id="5013696553129441713">Nicio sugestie nouă</translation>
+<translation id="1736419249208073774">Explorează</translation>
+<translation id="7444811645081526538">Mai multe categorii</translation>
+<translation id="6709133671862442373">Știri</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Cumpărături</translation>
+<translation id="3912508018559818924">Se caută tot ce e mai bun de pe web…</translation>
+<translation id="526421993248218238">Această pagină nu poate fi încărcată.</translation>
+<translation id="614940544461990577">Încearcă:</translation>
+<translation id="3288003805934695103">să reîncarci pagina;</translation>
+<translation id="2353636109065292463">Se verifică conexiunea la internet</translation>
+<translation id="2858138569776157458">Site-uri de top</translation>
+<translation id="8364299278605033898">Vezi site-urile populare</translation>
+<translation id="1171770572613082465">Vezi site-uri populare atingând butonul „Site-uri de top”</translation>
+<translation id="5233638681132016545">Filă nouă</translation>
+<translation id="4521874409998847950">De la <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>livrată de Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Este disponibilă o versiune mai nouă</translation>
+<translation id="4058091506841967397">Brave nu se poate actualiza</translation>
+<translation id="6316139424528454185">Versiunea Android nu este acceptată</translation>
+<translation id="6989267951144302301">Nu s-a putut descărca</translation>
+<translation id="624789221780392884">Actualizarea este pregătită</translation>
+<translation id="1549000191223877751">Mută în altă fereastră</translation>
+<translation id="7481312909269577407">Înainte</translation>
+<translation id="4084682180776658562">Marcaj</translation>
+<translation id="6437478888915024427">Informații despre pagină</translation>
+<translation id="7180611975245234373">Actualizați</translation>
+<translation id="4913169188695071480">Oprește actualizarea</translation>
+<translation id="1829244130665387512">Găsește în pagină</translation>
+<translation id="6593061639179217415">Versiune site desktop</translation>
+<translation id="9063523880881406963">Dezactivează opțiunea Versiune site pentru desktop</translation>
+<translation id="2038563949887743358">Activează opțiunea Versiune site pentru desktop</translation>
+<translation id="2433507940547922241">Aspect</translation>
+<translation id="983192555821071799">Închide toate filele</translation>
+<translation id="1310482092992808703">Grupează file</translation>
+<translation id="7725024127233776428">Paginile pe care le marchezi apar aici</translation>
+<translation id="4404568932422911380">Niciun marcaj</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> marcaj}few{<ph name="BOOKMARKS_COUNT_MANY"/> marcaje}other{<ph name="BOOKMARKS_COUNT_MANY"/> de marcaje}}</translation>
+<translation id="3739899004075612870">Marcat în <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Marcată</translation>
+<translation id="4452548195519783679">Marcaj adăugat în <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Marcajul nu a putut fi adăugat.</translation>
+<translation id="2842985007712546952">Dosar părinte</translation>
+<translation id="9065203028668620118">Editează</translation>
+<translation id="4405224443901389797">Mută în…</translation>
+<translation id="5170568018924773124">Afișează în dosar</translation>
+<translation id="8035133914807600019">Dosar nou…</translation>
+<translation id="4532845899244822526">Alege dosarul</translation>
+<translation id="6627583120233659107">Editați dosarul</translation>
+<translation id="1197267115302279827">Mută marcaje</translation>
+<translation id="6963766334940102469">Șterge marcaje</translation>
+<translation id="4351244548802238354">Închide caseta de dialog</translation>
+<translation id="451872707440238414">Caută în marcaje</translation>
+<translation id="8901170036886848654">Niciun marcaj găsit</translation>
+<translation id="6404511346730675251">Modifică marcajul</translation>
+<translation id="3894427358181296146">Adaugă un dosar</translation>
+<translation id="5327248766486351172">Nume</translation>
+<translation id="7400418766976504921">Adresă URL</translation>
+<translation id="3527085408025491307">Dosar</translation>
+<translation id="5161254044473106830">Titlul este obligatoriu</translation>
+<translation id="2996809686854298943">Adresă URL obligatorie</translation>
+<translation id="2536728043171574184">Se afișează o versiune offline a acestei pagini</translation>
+<translation id="4698034686595694889">Vezi offline în <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> și alte site-uri</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave va încărca pagina când este gata}few{Brave va încărca paginile când este gata}other{Brave va încărca paginile când este gata}}</translation>
+<translation id="6811034713472274749">Pagina este gata de vizualizare</translation>
+<translation id="4561979708150884304">Nicio conexiune</translation>
+<translation id="8274165955039650276">Vezi descărcările</translation>
+<translation id="2082238445998314030">Rezultatul <ph name="RESULT_NUMBER"/> din <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Nu există rezultate</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Nu există căutare vocală activată</translation>
+<translation id="7191430249889272776">A fost deschisă o filă în fundal.</translation>
+<translation id="8445059357334030806">Deschide în Brave</translation>
+<translation id="4720023427747327413">Deschide în <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Deschide în browser</translation>
+<translation id="1113597929977215864">Arată afișarea simplificată</translation>
+<translation id="1513352483775369820">Marcaje și istoric web</translation>
+<translation id="4939482511480190003">Contribuie la îmbunătățirea browserului Brave. <ph name="BEGIN_LINK"/>Participă la sondaj.<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Înapoi</translation>
+<translation id="5596627076506792578">Mai multe opțiuni</translation>
+<translation id="3522247891732774234">Actualizare disponibilă. Mai multe opțiuni</translation>
+<translation id="6773423637732432200">Brave nu se poate actualiza. Mai multe opțiuni</translation>
+<translation id="3328801116991980348">Informații despre site</translation>
+<translation id="5391532827096253100">Conexiunea la acest site nu este sigură. Informații despre site</translation>
+<translation id="6206551242102657620">Conexiunea este sigură. Informații despre site</translation>
+<translation id="6963642900430330478">Această pagină este periculoasă. Informații despre site</translation>
+<translation id="9070377983101773829">Începe căutarea vocală</translation>
+<translation id="8676374126336081632">Șterge textul introdus</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> filă deschisă, atinge pentru a comuta filele}few{<ph name="OPEN_TABS_MANY"/> file deschise, atinge pentru a comuta filele}other{<ph name="OPEN_TABS_MANY"/> de file deschise, atinge pentru a comuta filele}}</translation>
+<translation id="2369533728426058518">file deschise</translation>
+<translation id="7071521146534760487">Gestionează contul</translation>
+<translation id="932327136139879170">Pagina de pornire</translation>
+<translation id="2707726405694321444">Actualizează pagina</translation>
+<translation id="2891154217021530873">Oprește încărcarea paginii</translation>
+<translation id="6710213216561001401">Înapoi</translation>
+<translation id="6659594942844771486">Filă</translation>
+<translation id="1933845786846280168">Fila selectată</translation>
+<translation id="2268044343513325586">Rafinează</translation>
+<translation id="7846076177841592234">Anulează selecția</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> selectate.  Opțiunile sunt disponibile în partea de sus a ecranului</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> selectate</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Trimite un element selectat}few{Trimite # elemente selectate}other{Trimite # de elemente selectate}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Elimină un element selectat}few{Elimină # elemente selectate}other{Elimină # de elemente selectate}}</translation>
+<translation id="1283039547216852943">Atinge pentru a extinde</translation>
+<translation id="5962718611393537961">Atinge pentru a restrânge</translation>
+<translation id="8076492880354921740">File</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 selectat}few{# selectate}other{# selectate}}</translation>
+<translation id="6818926723028410516">Selectează elementele</translation>
+<translation id="4797039098279997504">Atinge pentru a reveni la <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Atinge pentru a accesa site-ul</translation>
+<translation id="429312253194641664">Un site redă fișiere media</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> accesează conținutul de pe ecran</translation>
+<translation id="8833831881926404480">Un site permite accesul la ecranul tău</translation>
+<translation id="9086455579313502267">Nu se poate accesa rețeaua</translation>
+<translation id="938850635132480979">Eroare: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Deschide în <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Deschide în aplicația Maps</translation>
+<translation id="7698359219371678927">Creează un e-mail în <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Creează un e-mail</translation>
+<translation id="5665379678064389456">Creează un eveniment în <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Creează un eveniment</translation>
+<translation id="2111511281910874386">Accesează pagina</translation>
+<translation id="3988466920954086464">Afișează rezultatele căutării instantanee în acest panou</translation>
+<translation id="2744248271121720757">Atinge un cuvânt pentru a căuta instantaneu sau pentru a vedea acțiuni conexe</translation>
+<translation id="9155898266292537608">De asemenea, poți căuta atingând scurt un cuvânt</translation>
+<translation id="3232754137068452469">Aplicație web</translation>
+<translation id="1430915738399379752">Printează</translation>
+<translation id="3775705724665058594">Trimite pe dispozitivele tale</translation>
+<translation id="6364438453358674297">Elimini sugestia din istoric?</translation>
+<translation id="213279576345780926">Fila <ph name="TAB_TITLE"/> a fost închisă</translation>
+<translation id="6850830437481525139">S-au închis <ph name="TAB_COUNT"/> (de) file</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> a fost șters</translation>
+<translation id="4663756553811254707">S-au șters <ph name="NUMBER_OF_BOOKMARKS"/> (de) marcaje</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> descărcări șterse</translation>
+<translation id="1248710015876067820">Număr de instanțe Brave neacceptat.</translation>
+<translation id="4259722352634471385">Navigarea este blocată: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigarea nu este accesibilă: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Închide fila</translation>
+<translation id="7772375229873196092">Închide <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Istoric de navigare</translation>
+<translation id="9169507124922466868">Istoricul de navigare este pe jumătate deschis</translation>
+<translation id="1327257854815634930">Istoricul de navigare este deschis</translation>
+<translation id="8788265440806329501">Istoricul de navigare este închis</translation>
+<translation id="7482656565088326534">Fila de previzualizare</translation>
+<translation id="8427875596167638501">Fila de previzualizare este pe jumătate deschisă</translation>
+<translation id="9102803872260866941">Fila de previzualizare este deschisă</translation>
+<translation id="2942036813789421260">Fila de previzualizare este închisă</translation>
+<translation id="6355102470683871794">Stocarea Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Ștergi stocarea site-urilor?</translation>
+<translation id="9205995714227143200">Stocare a site-urilor pe care Brave nu o consideră importantă (de ex., site-uri care nu au setări salvate sau pe care nu le accesezi frecvent)</translation>
+<translation id="3997476611815694295">Stocare neimportantă</translation>
+<translation id="8493948351860045254">Eliberează spațiu</translation>
+<translation id="2324920234469020158">Astfel, vor fi șterse cookie-urile, memoria cache și alte date ale site-urilor pe care Brave nu le consideră importante.</translation>
+<translation id="5447201525962359567">Toată stocarea site-urilor, inclusiv cookie-urile și alte date stocate local</translation>
+<translation id="1376578503827013741">Se calculează…</translation>
+<translation id="583281660410589416">Necunoscut</translation>
+<translation id="2323763861024343754">Stocarea site-urilor</translation>
+<translation id="3587672679800759167">Totalul datelor folosite de Brave, inclusiv conturile, marcajele și setările salvate</translation>
+<translation id="6545017243486555795">Șterge toate datele</translation>
+<translation id="4095146165863963773">Ștergi datele aplicației?</translation>
+<translation id="53119194224775367">Toate datele aplicației Brave vor fi șterse definitiv. Sunt incluse toate fișierele, setările, conturile, bazele de date etc.</translation>
+<translation id="5307446750509046227">Șterge stocare site-uri</translation>
+<translation id="300526633675317032">Astfel, se vor șterge <ph name="SIZE_IN_KB"/> din stocarea site-urilor.</translation>
+<translation id="8068648041423924542">Certificatul nu poate fi selectat.</translation>
+<translation id="2315043854645842844">Selectarea certificatelor pe partea de client nu este acceptată de sistemul de operare.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> dorește să se conecteze</translation>
+<translation id="5308380583665731573">Conectează-te</translation>
+<translation id="868929229000858085">Caută în agendă</translation>
+<translation id="1919950603503897840">Selectează persoane de contact</translation>
+<translation id="7986741934819883144">Selectează o persoană de contact</translation>
+<translation id="3333961966071413176">Toată agenda</translation>
+<translation id="4994033804516042629">Nu s-a găsit nicio persoană de contact</translation>
+<translation id="5403592356182871684">Nume</translation>
+<translation id="2717722538473713889">Adrese de e-mail</translation>
+<translation id="381841723434055211">Numere de telefon</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ încă 1)}few{(+ încă #)}other{(+ încă #)}}</translation>
+<translation id="5197729504361054390">Persoanele de contact pe care le selectezi vor fi trimise site-ului <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Decodor de imagini</translation>
+<translation id="8067883171444229417">Redă videoclipul</translation>
+<translation id="6560414384669816528">Caută cu Sogou</translation>
+<translation id="5406914950576900927">Brave poate să folosească <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> pentru căutare în China. Poți să schimbi acest lucru din <ph name="BEGIN_LINK"/>Setări<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Păstrează Brave Software</translation>
+<translation id="4384468725000734951">Pentru căutare se folosește Sogou</translation>
+<translation id="6103327872225198548">Pentru căutare se folosește Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Această aplicație rulează în Brave</translation>
+<translation id="6143689084714664628">Rulează în Brave</translation>
+<translation id="7675869148432102528">Și <ph name="APP_NAME"/> are date în Brave</translation>
+<translation id="2734140769649165081">Poți șterge datele în Setările Brave</translation>
+<translation id="8232956427053453090">Păstrează datele</translation>
+<translation id="4298388696830689168">Site-uri conectate</translation>
+<translation id="5763514718066511291">Atinge pentru a copia adresa URL pentru această aplicație</translation>
+<translation id="6496823230996795692">Ca să folosești <ph name="APP_NAME"/> pentru prima dată, conectează-te la internet.</translation>
+<translation id="751961395872307827">Nu se poate realiza conexiunea la site</translation>
+<translation id="4878404682131129617">Nu s-a putut stabili un tunel prin serverul proxy</translation>
+<translation id="4749960740855309258">Deschide o filă nouă</translation>
+<translation id="8788968922598763114">Redeschide ultima filă închisă</translation>
+<translation id="7929962904089429003">Deschide meniul</translation>
+<translation id="6039379616847168523">Accesează fila următoare</translation>
+<translation id="5210286577605176222">Accesează fila anterioară</translation>
+<translation id="124678866338384709">Închide fila actuală</translation>
+<translation id="3714981814255182093">Deschide Bara de căutare</translation>
+<translation id="5441522332038954058">Accesează bara de adrese</translation>
+<translation id="3398320232533725830">Deschide managerul de marcaje</translation>
+<translation id="6583199322650523874">Marchează pagina curentă</translation>
+<translation id="8489271220582375723">Deschide pagina Istoric</translation>
+<translation id="4837753911714442426">Deschide opțiunile pentru a printa pagina</translation>
+<translation id="5726692708398506830">Mărește întregul conținut al paginii</translation>
+<translation id="3259831549858767975">Micșorează întregul conținut al paginii</translation>
+<translation id="8015452622527143194">Readuce pagina la dimensiunea prestabilită</translation>
+<translation id="3443221991560634068">Reîncarcă pagina curentă</translation>
+<translation id="123724288017357924">Reîncarcă pagina, ignorând conținutul din cache</translation>
+<translation id="305870044889644984">Deschide Centrul de ajutor Brave într-o filă nouă</translation>
+<translation id="3166827708714933426">Comenzi rapide pentru file și ferestre</translation>
+<translation id="3169981355900570544">Comenzi rapide pentru funcțiile Brave Software Brave</translation>
+<translation id="4558311620361989323">Comenzi rapide pentru pagini web</translation>
+<translation id="1908301351964700579">Brave încă se pregătește pentru RV. Repornește Brave mai târziu.</translation>
+<translation id="8970887620466824814">A apărut o eroare.</translation>
+<translation id="1875543012935658554">Redeschide Brave.</translation>
+<translation id="79859296434321399">Pentru a vedea conținut din realitatea augmentată, instalează ARCore</translation>
+<translation id="8558485628462305855">Pentru a vedea conținut din realitatea augmentată, actualizează ARCore</translation>
+<translation id="3513704683820682405">Realitate augmentată</translation>
+<translation id="5475862044948910901">Pornești sesiunea de realitate augmentată?</translation>
 <translation id="7365126855094612066">Pe durata acestei sesiuni, site-ul va putea să:
 • creeze o hartă 3D a mediului tău;
 • urmărească mișcarea camerei.
 
 Acest site NU primește acces la cameră. Imaginile camerei sunt vizibile doar pentru tine.</translation>
-<translation id="7375125077091615385">Tip:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">Adresă URL</translation>
-<translation id="7403691278183511381">Experiența primei rulări Chrome</translation>
-<translation id="741204030948306876">Da, accept</translation>
-<translation id="7413229368719586778">Data de începere <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Mai întâi întreabă</translation>
-<translation id="7423538860840206698">Citirea clipboardului este blocată</translation>
-<translation id="7431991332293347422">Controlează modul în care istoricul de navigare este folosit pentru a personaliza Căutarea și alte servicii</translation>
-<translation id="7437998757836447326">Deconectează-te de la Chrome</translation>
-<translation id="7438641746574390233">Când modul Lite este activat, Chrome folosește serverele Google pentru a încărca paginile mai rapid. Modul Lite rescrie paginile care se încarcă foarte greu ca să încarce numai conținutul esențial. Modul Lite nu se aplică în filele incognito.</translation>
-<translation id="7444811645081526538">Mai multe categorii</translation>
-<translation id="7445411102860286510">Permite site-urilor să redea automat videoclipuri cu sunetul dezactivat (recomandat)</translation>
-<translation id="7453467225369441013">Te deconectează de pe majoritatea site-urilor. Nu te va deconecta de la Contul Google.</translation>
-<translation id="7454641608352164238">Spațiu insuficient</translation>
-<translation id="7475192538862203634">Dacă acest mesaj apare frecvent, încearcă următoarele <ph name="BEGIN_LINK" />sugestii<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Nu s-a găsit cardul SD. Este posibil ca unele fișiere să lipsească.</translation>
-<translation id="7479104141328977413">Gestionarea filelor</translation>
-<translation id="7481312909269577407">Înainte</translation>
-<translation id="7482656565088326534">Fila de previzualizare</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Actualizată la <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">date economisite</translation>
-<translation id="7498271377022651285">Așteaptă...</translation>
-<translation id="7514365320538308">Descarcă</translation>
-<translation id="751961395872307827">Nu se poate realiza conexiunea la site</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Nu se pot obține sugestii</translation>
-<translation id="7559975015014302720">Modul Lite este dezactivat</translation>
-<translation id="7562080006725997899">Se șterg datele de navigare</translation>
-<translation id="756809126120519699">Datele Chrome au fost șterse</translation>
-<translation id="757524316907819857">Împiedică site-urile să redea conținutul protejat</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fișier descărcat}few{<ph name="FILES_DOWNLOADED_MANY" /> fișiere descărcate}other{<ph name="FILES_DOWNLOADED_MANY" /> de fișiere descărcate}}</translation>
-<translation id="7588219262685291874">Activează tema întunecată când este activată Economisirea bateriei pentru dispozitiv</translation>
-<translation id="7589445247086920869">Blochează pentru motorul de căutare actual</translation>
-<translation id="7593557518625677601">Deschide setările Android și reactivează sincronizarea sistemului Android pentru a porni sincronizarea Chrome</translation>
-<translation id="7596558890252710462">Sistem de operare</translation>
-<translation id="7605594153474022051">Sincronizarea nu funcționează</translation>
-<translation id="7606077192958116810">Modul Lite este activat. Gestionează-l în Setări.</translation>
-<translation id="7612619742409846846">Conectat(ă) la Google ca</translation>
-<translation id="7619072057915878432">Descărcarea fișierului <ph name="FILE_NAME" /> nu a reușit din cauza erorilor de rețea.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Obține ajutor<ph name="END_LINK1" /> sau <ph name="BEGIN_LINK2" />scanează din nou<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Bun venit la Chrome</translation>
-<translation id="7638584964844754484">Expresie de acces incorectă</translation>
-<translation id="7641339528570811325">Șterge datele de navigare…</translation>
-<translation id="7648422057306047504">Criptează parolele cu datele de conectare Google</translation>
-<translation id="7649070708921625228">Ajutor</translation>
-<translation id="7658239707568436148">Anulează</translation>
-<translation id="7665369617277396874">Adaugă un cont</translation>
-<translation id="766587987807204883">Articolele apar aici și le poți citi chiar dacă ești offline</translation>
-<translation id="7682724950699840886">Încearcă următoarele sfaturi: asigură-te că există spațiu suficient pe dispozitiv, încearcă să exporți din nou.</translation>
-<translation id="7685301384041462804">Asigură-te că site-ul este de încredere înainte de a intra în RV.</translation>
-<translation id="7698359219371678927">Creează un e-mail în <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Completează automat căutările și adresele URL</translation>
-<translation id="7725024127233776428">Paginile pe care le marchezi apar aici</translation>
-<translation id="773466115871691567">Tradu întotdeauna paginile în <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Pentru a detecta aplicațiile și site-urile periculoase, Chrome trimite la Google adresele URL ale unor pagini pe care le accesezi, informații de sistem limitate și o parte din conținutul paginii</translation>
-<translation id="7757787379047923882">Text trimis de pe <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Cardul SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Adaugă o adresă</translation>
-<translation id="7772032839648071052">Confirmă expresia de acces</translation>
-<translation id="7772375229873196092">Închide <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}few{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 și încă <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Ieri</translation>
-<translation id="7791543448312431591">Adaugă</translation>
-<translation id="780301667611848630">Nu, mulțumesc</translation>
-<translation id="7810647596859435254">Deschide cu…</translation>
-<translation id="7821588508402923572">Economiile de date vor apărea aici</translation>
-<translation id="7837721118676387834">Permite unui anumit site să redea automat videoclipuri cu sunetul dezactivat.</translation>
-<translation id="7846076177841592234">Anulează selecția</translation>
-<translation id="784934925303690534">Interval de timp</translation>
-<translation id="7851858861565204677">Alte dispozitive</translation>
-<translation id="7875915731392087153">Creează un e-mail</translation>
-<translation id="7876243839304621966">Elimină tot</translation>
-<translation id="7882131421121961860">Nu s-a găsit niciun istoric</translation>
-<translation id="7882806643839505685">Permite sunetul pentru un anumit site.</translation>
-<translation id="7886917304091689118">Rulează în Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Fișierul se descarcă.}few{Se descarcă # fișiere.}other{Se descarcă # de fișiere.}}</translation>
-<translation id="7929962904089429003">Deschide meniul</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> este învechit.</translation>
-<translation id="7947953824732555851">Accept și conectare</translation>
-<translation id="7963646190083259054">Producător:</translation>
-<translation id="7971136598759319605">Activ acum o zi</translation>
-<translation id="7975379999046275268">Previzualizează pagina <ph name="BEGIN_NEW" />Nou<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Preîncarcă paginile pentru navigare și căutare mai rapide</translation>
-<translation id="79859296434321399">Pentru a vedea conținut din realitatea augmentată, instalează ARCore</translation>
-<translation id="7986741934819883144">Selectează o persoană de contact</translation>
-<translation id="7987073022710626672">Termenii și condițiile Chrome</translation>
-<translation id="7998918019931843664">Redeschideți fila închisă</translation>
-<translation id="7999064672810608036">Sigur dorești să ștergi toate datele locale, inclusiv cookie-urile pentru acest site și să îi resetezi permisiunile?</translation>
-<translation id="8004582292198964060">Browser</translation>
-<translation id="8007176423574883786">Dezactivată pentru acest dispozitiv</translation>
-<translation id="8013372441983637696">Șterge și datele Chrome de pe acest dispozitiv</translation>
-<translation id="8015452622527143194">Readuce pagina la dimensiunea prestabilită</translation>
-<translation id="802154636333426148">Descărcarea nu a reușit</translation>
-<translation id="8026334261755873520">Șterge datele de navigare</translation>
-<translation id="8035133914807600019">Dosar nou…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> zile rămase</translation>
-<translation id="804335162455518893">Nu s-a găsit cardul SD</translation>
-<translation id="805047784848435650">Pe baza istoricului de navigare</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MO disponibili</translation>
-<translation id="8058746566562539958">Deschide în filă Chrome nouă</translation>
-<translation id="8063895661287329888">Marcajul nu a putut fi adăugat.</translation>
-<translation id="806745655614357130">Păstrează datele separat</translation>
-<translation id="8067883171444229417">Redă videoclipul</translation>
-<translation id="8068648041423924542">Certificatul nu poate fi selectat.</translation>
-<translation id="8073388330009372546">Vezi imaginea în filă nouă</translation>
-<translation id="8076492880354921740">File</translation>
-<translation id="8084114998886531721">Parola a fost salvată</translation>
-<translation id="8087000398470557479">Acest conținut provine de pe <ph name="DOMAIN_NAME" />, oferit de Google.</translation>
-<translation id="8103578431304235997">Filă incognito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Pentru a accesa marcajele pe toate dispozitivele, activează sincronizarea</translation>
-<translation id="8110087112193408731">Afișezi activitatea din Chrome în Bunăstare digitală?</translation>
-<translation id="8116925261070264013">Cu sunetul dezactivat</translation>
-<translation id="813082847718468539">Afișează informațiile privind site-ul</translation>
-<translation id="8131740175452115882">Confirmați</translation>
-<translation id="8156139159503939589">În ce limbi poți să citești?</translation>
-<translation id="8168435359814927499">Conținut</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> fișiere rămase</translation>
-<translation id="8190358571722158785">1 zi rămasă</translation>
-<translation id="8200772114523450471">Reia</translation>
-<translation id="8209050860603202033">Deschideți imaginea</translation>
-<translation id="8218622182176210845">Gestionează contul</translation>
-<translation id="8224471946457685718">Descarcă articole pentru tine pe Wi-Fi</translation>
-<translation id="8232956427053453090">Păstrează datele</translation>
-<translation id="8249310407154411074">Mută la început</translation>
-<translation id="8250920743982581267">Documente</translation>
-<translation id="825412236959742607">Această pagină folosește prea multă memorie, prin urmare Chrome a eliminat o parte din conținut.</translation>
-<translation id="8260126382462817229">Încearcă să te conectezi din nou</translation>
-<translation id="8261506727792406068">Șterge</translation>
-<translation id="8266862848225348053">Locația de descărcare</translation>
-<translation id="8274165955039650276">Vezi descărcările</translation>
-<translation id="8284326494547611709">Subtitrări</translation>
-<translation id="8300705686683892304">Gestionate de aplicație</translation>
-<translation id="8310344678080805313">File standard</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> și alte site-uri</translation>
-<translation id="8327155640814342956">Pentru o experiență de navigare mai bună, deschide pentru a actualiza Chrome</translation>
-<translation id="8339163506404995330">Paginile în <ph name="LANGUAGE" /> nu vor fi traduse</translation>
-<translation id="8349013245300336738">Sortează după volumul de date folosite</translation>
-<translation id="8364299278605033898">Vezi site-urile populare</translation>
-<translation id="8368027906805972958">Dispozitiv necunoscut sau neacceptat (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Permite sincronizarea în fundal pentru un anumit site.</translation>
-<translation id="8378714024927312812">Gestionat de organizația ta</translation>
-<translation id="8380167699614421159">Acest site afișează anunțuri deranjante sau înșelătoare</translation>
-<translation id="8393700583063109961">Trimite un mesaj</translation>
-<translation id="8413126021676339697">Afișează întregul istoric</translation>
-<translation id="8427875596167638501">Fila de previzualizare este pe jumătate deschisă</translation>
-<translation id="8428213095426709021">Setări</translation>
-<translation id="8438566539970814960">Îmbunătățește căutările și navigarea</translation>
-<translation id="8441146129660941386">Derulează înapoi</translation>
-<translation id="8443209985646068659">Chrome nu se poate actualiza</translation>
-<translation id="8445448999790540984">Nu se pot exporta parole</translation>
-<translation id="8447861592752582886">Revocă permisiunea de accesare a dispozitivului</translation>
-<translation id="8461694314515752532">Criptează datele sincronizate folosind propria expresie de acces pentru sincronizare</translation>
-<translation id="8466613982764129868">Asigură-te că <ph name="TARGET_DEVICE_NAME" /> este conectat la internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Disponibil offline</translation>
-<translation id="8489271220582375723">Deschide pagina Istoric</translation>
-<translation id="8493948351860045254">Eliberează spațiu</translation>
-<translation id="8497726226069778601">Nu este nimic de văzut aici... deocamdată</translation>
-<translation id="8503559462189395349">Parole Chrome</translation>
-<translation id="8503813439785031346">Nume utilizator</translation>
-<translation id="8514477925623180633">Exportă parolele stocate în Chrome</translation>
-<translation id="8514577642972634246">Intră în modul incognito</translation>
-<translation id="851751545965956758">Blochează conectarea site-urilor la dispozitive</translation>
-<translation id="8523928698583292556">Șterge parola stocată</translation>
-<translation id="854522910157234410">Deschide această pagină</translation>
-<translation id="8558485628462305855">Pentru a vedea conținut din realitatea augmentată, actualizează ARCore</translation>
-<translation id="8559990750235505898">Oferă traducerea paginilor în alte limbi</translation>
-<translation id="8562452229998620586">Parolele salvate vor fi afișate aici.</translation>
-<translation id="8569404424186215731">începând cu <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Ultimele 4 săptămâni</translation>
-<translation id="857943718398505171">Acordată (recomandat)</translation>
-<translation id="8583805026567836021">Se șterg datele contului</translation>
-<translation id="860043288473659153">Nume titular de card</translation>
-<translation id="8609465669617005112">Mutați mai sus</translation>
-<translation id="8616006591992756292">Contul Google poate să ofere alte forme ale istoricului de navigare la <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Deschizi adresa URL sugerată specificată în conținutul descărcat?</translation>
-<translation id="8636825310635137004">Pentru a accesa filele de pe alte dispozitive, activează sincronizarea.</translation>
-<translation id="8641930654639604085">Încearcă să blochezi site-urile destinate adulților</translation>
-<translation id="8655129584991699539">Poți șterge datele în Setările Chrome</translation>
-<translation id="8662811608048051533">Te deconectează de pe majoritatea site-urilor.</translation>
-<translation id="8664979001105139458">Numele fișierului există deja</translation>
-<translation id="8676374126336081632">Șterge textul introdus</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Nivelul puterii semnalului: # bară}few{Nivelul puterii semnalului: # bare}other{Nivelul puterii semnalului: # de bare}}</translation>
-<translation id="868929229000858085">Caută în agendă</translation>
-<translation id="869891660844655955">Dată de expirare</translation>
-<translation id="8719023831149562936">Fila actuală nu poate fi transmisă</translation>
-<translation id="8725066075913043281">Încearcă din nou</translation>
-<translation id="8728487861892616501">Dacă folosești aplicația, accepți <ph name="BEGIN_LINK1" />Termenii și condițiile<ph name="END_LINK1" /> și <ph name="BEGIN_LINK2" />Notificarea privind confidențialitatea<ph name="END_LINK2" /> Chrome și <ph name="BEGIN_LINK3" />Notificarea privind confidențialitatea pentru Conturile Google gestionate cu Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Terminat</translation>
-<translation id="8748850008226585750">Conținutul este ascuns</translation>
-<translation id="8751914237388039244">Selectează o imagine</translation>
-<translation id="8788265440806329501">Istoricul de navigare este închis</translation>
-<translation id="8788968922598763114">Redeschide ultima filă închisă</translation>
-<translation id="8801436777607969138">Blochează JavaScript pentru un anumit site.</translation>
-<translation id="8812260976093120287">Pe unele site-uri, poți plăti folosind aplicațiile acceptate pentru plăți de mai sus de pe dispozitiv.</translation>
-<translation id="8816026460808729765">Blochează întotdeauna accesul site-urilor la senzori</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> se va deschide în Chrome. Continuând, ești de acord cu <ph name="BEGIN_LINK1" />Termenii și condițiile<ph name="END_LINK1" /> și <ph name="BEGIN_LINK2" />Notificarea privind confidențialitatea<ph name="END_LINK2" /> Chrome și cu <ph name="BEGIN_LINK3" />Notificarea privind confidențialitatea pentru Conturile Google gestionate cu Family<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Marcaje</translation>
-<translation id="8833831881926404480">Un site permite accesul la ecranul tău</translation>
-<translation id="883806473910249246">A apărut o eroare la descărcarea conținutului.</translation>
-<translation id="8840953339110955557">Această pagină poate fi diferită de versiunea online.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, filă</translation>
-<translation id="885701979325669005">Stocare</translation>
-<translation id="889338405075704026">Accesează setările Chrome</translation>
-<translation id="8901170036886848654">Niciun marcaj găsit</translation>
-<translation id="8909135823018751308">Trimite…</translation>
-<translation id="8912362522468806198">Contul Google</translation>
-<translation id="8920114477895755567">Se așteaptă detaliile părinților.</translation>
+<translation id="1188239144602654184">Intră în RA</translation>
+<translation id="473775607612524610">Actualizează</translation>
+<translation id="3133489217401741157">Se instalează <ph name="MODULE"/> pentru Brave…</translation>
+<translation id="1791662854739702043">Instalat</translation>
+<translation id="5131234170665854056">Nu se poate instala <ph name="MODULE"/> pentru Brave</translation>
+<translation id="2567385386134582609">IMAGINE</translation>
+<translation id="6395288395575013217">LINK</translation>
+<translation id="7352939065658542140">VIDEOCLIP</translation>
+<translation id="4116038641877404294">Descarcă paginile pentru a le folosi offline</translation>
 <translation id="8922289737868596582">Descarcă paginile folosind butonul Mai multe opțiuni, pentru a le folosi offline</translation>
-<translation id="8937772741022875483">Elimini activitatea în Chrome din Bunăstarea digitală?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Deschide în altă fereastră</translation>
-<translation id="8951232171465285730">Chrome a economisit <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blochează cookie-urile pentru un anumit site.</translation>
-<translation id="8959122750345127698">Navigarea nu este accesibilă: <ph name="URL" /></translation>
-<translation id="8965591936373831584">în așteptare</translation>
-<translation id="8970887620466824814">A apărut o eroare.</translation>
-<translation id="8972098258593396643">Descarci în dosarul prestabilit?</translation>
-<translation id="8986494364107987395">Trimite automat la Google statistici de utilizare și rapoarte de blocare</translation>
-<translation id="8993760627012879038">Deschide o filă nouă în modul incognito</translation>
-<translation id="8998729206196772491">Te conectezi cu un cont gestionat de <ph name="MANAGED_DOMAIN" /> și acorzi administratorului acestuia controlul asupra datelor Chrome. Datele vor fi asociate definitiv acestui cont. Dacă te deconectezi de la Chrome, datele se vor șterge de pe acest dispozitiv, dar vor rămâne stocate în Contul Google.</translation>
-<translation id="9019902583201351841">Gestionat de părinții tăi</translation>
-<translation id="9028914725102941583">Activează sincronizarea ca să trimiți de pe un dispozitiv pe altul</translation>
-<translation id="9029323097866369874">Permiți ca <ph name="DOMAIN" /> să intre în VR?</translation>
-<translation id="9040142327097499898">Notificările sunt permise. Locația este dezactivată pentru acest dispozitiv.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{Un videoclip}few{# videoclipuri}other{# de videoclipuri}}</translation>
-<translation id="9050666287014529139">Expresie de acces</translation>
-<translation id="9063523880881406963">Dezactivează opțiunea Versiune site pentru desktop</translation>
-<translation id="9065203028668620118">Editează</translation>
-<translation id="9070377983101773829">Începe căutarea vocală</translation>
-<translation id="9074336505530349563">Pentru a obține sugestii de conținut personalizat de la Google, conectează-te și activează sincronizarea</translation>
-<translation id="9086455579313502267">Nu se poate accesa rețeaua</translation>
-<translation id="9100505651305367705">Oferă afișarea simplificată a articolelor, dacă este acceptată</translation>
-<translation id="9100610230175265781">Este necesară o expresie de acces</translation>
-<translation id="9102803872260866941">Fila de previzualizare este deschisă</translation>
+<translation id="5958275228015807058">Găsește fișierele și paginile în Descărcări</translation>
+<translation id="5620928963363755975">Găsește fișierele și paginile în Descărcări folosind butonul Mai multe opțiuni</translation>
+<translation id="3341058695485821946">Vezi ce volum de date ai economisit</translation>
+<translation id="3157842584138209013">Vezi ce volum de date ai economisit folosind butonul Mai multe opțiuni</translation>
+<translation id="8218622182176210845">Gestionează contul</translation>
+<translation id="8090895580117672212">Pentru a gestiona contul Brave Software, atinge butonul „Gestionează contul”</translation>
+<translation id="8856898588039823173">Pagină Lite oferită de Brave Software. Atinge pentru a încărca versiunea originală.</translation>
+<translation id="8134317863207426198">Pagină Lite oferită de Brave Software. Atinge butonul de încărcare a originalului pentru a încărca pagina originală.</translation>
+<translation id="4961107849584082341">Tradu această pagină în orice limbă</translation>
+<translation id="569536719314091526">Tradu această pagină în orice limbă folosind butonul Mai multe opțiuni</translation>
+<translation id="1397811292916898096">Caută folosind <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Schimbă oricând locația de descărcare prestabilită</translation>
+<translation id="6942665639005891494">Schimbă oricând locația de descărcare prestabilită folosind opțiunea din meniul Setări</translation>
+<translation id="6850409657436465440">Descărcarea este încă în desfășurare</translation>
+<translation id="5817715962196959877">Acum Brave descarcă mai rapid fișierele</translation>
+<translation id="3976396876660209797">Elimină și recreează această comandă rapidă</translation>
+<translation id="6766622839693428701">Glisează în jos pentru a închide.</translation>
+<translation id="1028699632127661925">Se trimite la <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Trimis de la <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Fila a fost primită</translation>
 <translation id="9104217018994036254">Lista de dispozitive pe care să trimiți o filă.</translation>
-<translation id="9133397713400217035">Explorează offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Afișează originalul</translation>
-<translation id="9139068048179869749">Întreabă înainte de a permite site-urilor să trimită notificări (recomandat)</translation>
-<translation id="9139318394846604261">Cumpărături</translation>
-<translation id="9155898266292537608">De asemenea, poți căuta atingând scurt un cuvânt</translation>
-<translation id="9169507124922466868">Istoricul de navigare este pe jumătate deschis</translation>
-<translation id="9204836675896933765">1 fișier rămas</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Lista de dispozitive pe care să trimiți o filă este deschisă la jumătate din înălțime.</translation>
+<translation id="2904414404539560095">Lista de dispozitive pe care să trimiți o filă este deschisă la înălțimea completă.</translation>
+<translation id="4135200667068010335">Lista de dispozitive pe care să trimiți o filă este închisă.</translation>
+<translation id="5292796745632149097">Trimite la</translation>
+<translation id="1386674309198842382">Activ acum <ph name="LAST_UPDATED"/> zile</translation>
+<translation id="7971136598759319605">Activ acum o zi</translation>
+<translation id="1521774566618522728">Activ astăzi</translation>
+<translation id="3631987586758005671">Se trimite la <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Activează sincronizarea ca să trimiți de pe un dispozitiv pe altul</translation>
+<translation id="6162454065885854378">Ca să trimiți ceva de pe telefon pe alt dispozitiv, activează sincronizarea în setările Brave pe ambele dispozitive</translation>
+<translation id="6084271560289605378">Accesează setările Brave</translation>
+<translation id="2318045970523081853">Atinge pentru a apela</translation>
 <translation id="9209888181064652401">Nu pot apela</translation>
-<translation id="9219103736887031265">Imagini</translation>
-<translation id="926205370408745186">Elimină activitatea în Chrome din Bunăstarea digitală</translation>
-<translation id="932327136139879170">Pagina de pornire</translation>
-<translation id="938850635132480979">Eroare: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Accesează microfonul</translation>
-<translation id="95817756606698420">Chrome poate să folosească <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> pentru căutare în China. Poți să schimbi acest lucru din <ph name="BEGIN_LINK" />Setări<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blochează dacă site-ul afișează anunțuri deranjante sau înșelătoare (recomandat)</translation>
-<translation id="968900484120156207">Paginile pe care le accesezi apar aici</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> min. rămase</translation>
-<translation id="974555521953189084">Introdu expresia de acces pentru a începe sincronizarea</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Astfel, se vor șterge datele pentru toate site-urile, inclusiv:</translation>
-<translation id="983192555821071799">Închide toate filele</translation>
-<translation id="987264212798334818">General</translation>
+<translation id="2860954141821109167">Verifică dacă pe dispozitiv este activată o aplicație de telefon</translation>
+<translation id="2067805253194386918">text</translation>
+<translation id="1450753235335490080">Nu se poate trimite <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Nu s-a trimis <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Verifică dacă <ph name="TARGET_DEVICE_NAME"/> are sincronizarea activată în Brave</translation>
+<translation id="3016635187733453316">Verifică dacă dispozitivul este conectat la internet</translation>
+<translation id="8466613982764129868">Asigură-te că <ph name="TARGET_DEVICE_NAME"/> este conectat la internet</translation>
+<translation id="6539092367496845964">A apărut o eroare. Încearcă din nou mai târziu.</translation>
+<translation id="3389286852084373014">Textul este prea mare</translation>
+<translation id="2100314319871056947">Împarte textul în fragmente mai mici</translation>
+<translation id="2987620471460279764">Text trimis de pe alt dispozitiv</translation>
+<translation id="7757787379047923882">Text trimis de pe <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Copiat în clipboard</translation>
+<translation id="4696983787092045100">Trimite text pe dispozitivele tale</translation>
+<translation id="1260236875608242557">Caută și explorează</translation>
+<translation id="6369229450655021117">De aici, poți să cauți pe web, să trimiți fișiere prietenilor și să vezi paginile deschise</translation>
+<translation id="723171743924126238">Selectează imagini</translation>
+<translation id="8751914237388039244">Selectează o imagine</translation>
+<translation id="1989112275319619282">Răsfoiește</translation>
+<translation id="7055152154916055070">Redirecționarea a fost blocată:</translation>
+<translation id="5524843473235508879">Redirecționarea a fost blocată.</translation>
+<translation id="6573096386450695060">Permite întotdeauna</translation>
+<translation id="5805364706385912897">Această pagină folosește prea multă memorie, prin urmare Brave a întrerupt-o.</translation>
+<translation id="5138664332909611586">Această pagină folosește prea multă memorie, prin urmare Brave a eliminat o parte din conținut.</translation>
+<translation id="9137013805542155359">Afișează originalul</translation>
+<translation id="6361779936989026201">Asistentul Brave Software în Brave</translation>
+<translation id="7291387454912369099">Finalizarea achiziției declanșată de Asistent</translation>
+<translation id="4565206163201411670">Afișezi activitatea din Brave în Bunăstare digitală?</translation>
+<translation id="9055113864158719823">Poți vedea site-urile pe care le vizitezi în Brave și să setezi temporizatoare pentru ele.\n\nBrave Software obține informații cu privire la site-urile pentru care setezi temporizatoare și la durata de accesare. Aceste informații sunt folosite pentru a îmbunătăți Bunăstarea digitală.</translation>
+<translation id="4596514158372210596">Elimină activitatea în Brave din Bunăstarea digitală</translation>
+<translation id="1174893863889683998">Elimini activitatea în Brave din Bunăstarea digitală?</translation>
+<translation id="708829030563435351">Site-urile pe care le vizitezi în Brave nu se vor afișa. Toate temporizatoarele site-urilor vor fi șterse.</translation>
+<translation id="2056878612599315956">Site-ul a fost întrerupt</translation>
+<translation id="671481426037969117">Temporizatorul pentru <ph name="FQDN"/> s-a terminat. Va reîncepe mâine.</translation>
+<translation id="7479104141328977413">Gestionarea filelor</translation>
+<translation id="3524138585025253783">IU pentru dezvoltatori</translation>
+<translation id="6036057147555329831">ICU suplimentar</translation>
+<translation id="9029323097866369874">Permiți ca <ph name="DOMAIN"/> să intre în VR?</translation>
+<translation id="7685301384041462804">Asigură-te că site-ul este de încredere înainte de a intra în RV.</translation>
+<translation id="5033865233969348410">În RV, acest site ar putea afla:
+  -  trăsăturile tale fizice, cum ar fi înălțimea.
+
+Asigură-te că site-ul este de încredere înainte să intri în RV.</translation>
+<translation id="5534334044554683961">În RV, acest site ar putea afla:
+  -   trăsăturile tale fizice, cum ar fi înălțimea,
+  -   configurația camerei în care te afli.
+
+Asigură-te că site-ul este de încredere înainte să intri în RV.</translation>
+<translation id="4169535189173047238">Nu permite</translation>
+<translation id="2170088579611075216">Permite și intră în RV</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ru.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ru.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ru">
-<translation id="1006017844123154345">Открыть в Интернете</translation>
-<translation id="1028699632127661925">Отправка на устройство "<ph name="DEVICE_NAME" />"…</translation>
-<translation id="1036727731225946849">Добавление файла "<ph name="WEBAPK_NAME" />"…</translation>
-<translation id="1041308826830691739">От сайтов</translation>
-<translation id="1049743911850919806">Инкогнито</translation>
-<translation id="10614374240317010">Сайты, пароли для которых не сохраняются</translation>
-<translation id="1067922213147265141">Другие сервисы Google</translation>
-<translation id="1068672505746868501">Не переводить страницы на этом языке: <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Если вы сделаете это, файл может открыться в другом приложении и нанести вред устройству.</translation>
-<translation id="1100066534610197918">Открыть в новой вкладке группы</translation>
-<translation id="1105960400813249514">Демонстрация экрана</translation>
-<translation id="1111673857033749125">Здесь появятся закладки, сохраненные на других устройствах.</translation>
-<translation id="1113597929977215864">Упрощенный просмотр</translation>
-<translation id="1121094540300013208">Отчеты об использовании и сбоях</translation>
-<translation id="1124772482545689468">Пользователь</translation>
-<translation id="1129510026454351943">Сведения об ошибке: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Ожидание скачивания 1 файла…}one{Ожидание скачивания # файла…}few{Ожидание скачивания # файлов…}many{Ожидание скачивания # файлов…}other{Ожидание скачивания # файла…}}</translation>
-<translation id="1145536944570833626">Удалить сохраненные данные.</translation>
-<translation id="1146678959555564648">Войти в режим VR</translation>
-<translation id="116280672541001035">Использовано</translation>
-<translation id="1171770572613082465">Чтобы перейти к списку популярных сайтов, нажмите кнопку "Топ сайтов"</translation>
-<translation id="1173894706177603556">Переименовать</translation>
-<translation id="1178581264944972037">Пауза</translation>
-<translation id="1181037720776840403">Удалить</translation>
-<translation id="1188239144602654184">Начать</translation>
-<translation id="1197267115302279827">Переместить закладки</translation>
-<translation id="119944043368869598">Удалить все</translation>
-<translation id="1201402288615127009">Далее</translation>
-<translation id="1204037785786432551">Сохранить данные по ссылке</translation>
-<translation id="1206892813135768548">Копировать текст ссылки</translation>
-<translation id="1208340532756947324">Чтобы синхронизировать и персонализировать данные на всех устройствах, включите синхронизацию.</translation>
-<translation id="1209206284964581585">Скрыть</translation>
-<translation id="1227058898775614466">История переходов</translation>
-<translation id="1231733316453485619">Включить синхронизацию?</translation>
-<translation id="123724288017357924">Обновить страницу без учета кешированного контента</translation>
-<translation id="124116460088058876">Другие языки</translation>
-<translation id="124678866338384709">Закрыть вкладку</translation>
-<translation id="1258753120186372309">Дудл Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Поиск и рекомендации</translation>
-<translation id="1264974993859112054">Спорт</translation>
-<translation id="1266864766717917324">Не удалось отправить: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Остановить</translation>
-<translation id="1283039547216852943">Нажмите, чтобы развернуть</translation>
-<translation id="1285320974508926690">Никогда не переводить этот сайт</translation>
-<translation id="1291207594882862231">Удалить файлы cookie и данные сайтов, очистить историю и кеш</translation>
-<translation id="129382876167171263">Здесь появятся файлы, сохраненные сайтами.</translation>
-<translation id="129553762522093515">Недавно закрытые</translation>
-<translation id="1303507811548703290">Домен: <ph name="DOMAIN" />. Отправлено с устройства "<ph name="DEVICE_NAME" />".</translation>
-<translation id="1310482092992808703">Сгруппировать вкладки</translation>
-<translation id="1327257854815634930">История переходов открыта</translation>
-<translation id="1331212799747679585">Не удалось обновить Chrome. Другие настройки</translation>
-<translation id="1332501820983677155">Функции Google Chrome</translation>
-<translation id="1360432990279830238">Выйти и отключить синхронизацию?</translation>
-<translation id="1369915414381695676">Добавлен сайт <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Недостаточно памяти для скачивания выбранного контента.</translation>
-<translation id="1376578503827013741">Подсчет…</translation>
-<translation id="1383876407941801731">Поиск</translation>
-<translation id="1384959399684842514">Скачивание приостановлено.</translation>
-<translation id="1386674309198842382">Последние действия: <ph name="LAST_UPDATED" /> дн. назад</translation>
-<translation id="1397811292916898096">Поиск в <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Встроено в <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Запрет отслеживания</translation>
-<translation id="1407135791313364759">Открыть все</translation>
-<translation id="1409426117486808224">Упрощенный просмотр открытых вкладок</translation>
-<translation id="1409879593029778104">Скачивание файла <ph name="FILE_NAME" /> остановлено, так как он уже существует.</translation>
-<translation id="1414981605391750300">Подключение к Google. Подождите…</translation>
-<translation id="1416550906796893042">Версия приложения</translation>
-<translation id="1430915738399379752">Печать</translation>
-<translation id="1446450296470737166">Полный доступ к управлению MIDI-устройствами</translation>
-<translation id="1450753235335490080">Не удается отправить: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Отключено в настройках Android</translation>
-<translation id="1477626028522505441">Не удалось скачать файл <ph name="FILE_NAME" /> из-за неполадок на сервере.</translation>
-<translation id="1506061864768559482">Поисковая система</translation>
-<translation id="1513352483775369820">Закладки и история поиска</translation>
-<translation id="1513858653616922153">Удалить пароль</translation>
-<translation id="1516229014686355813">Быстрый поиск отправляет в Google выбранное слово, а также – в качестве контекста – текущую страницу. Отключить эту функцию можно в <ph name="BEGIN_LINK" />настройках<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Последние действия: сегодня</translation>
-<translation id="1544826120773021464">Чтобы перейти к управлению аккаунтом Google, нажмите кнопку "Настройки аккаунта"</translation>
-<translation id="1549000191223877751">Перейти к другому окну</translation>
-<translation id="1553358976309200471">Обновить Chrome</translation>
-<translation id="1569387923882100876">Подключенное устройство</translation>
-<translation id="1571304935088121812">Копировать имя пользователя</translation>
-<translation id="1612196535745283361">Чтобы выполнить поиск устройств, браузеру Chrome нужен доступ к геоданным. <ph name="BEGIN_LINK" />Включить<ph name="END_LINK" /></translation>
-<translation id="1620510694547887537">Камера</translation>
-<translation id="1623104350909869708">Запретить создание дополнительных диалоговых окон на этой странице</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Удалить 1 выбранный объект}one{Удалить # выбранный объект}few{Удалить # выбранных объекта}many{Удалить # выбранных объектов}other{Удалить # выбранного объекта}}</translation>
-<translation id="164269334534774161">Эта офлайн-копия страницы была создана <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">История</translation>
-<translation id="1647391597548383849">Доступ к камере</translation>
-<translation id="1660204651932907780">Разрешить сайтам воспроизводить звуки (рекомендуется)</translation>
-<translation id="1670399744444387456">Основные настройки</translation>
-<translation id="1671236975893690980">Ожидание скачивания…</translation>
-<translation id="1672586136351118594">Больше не показывать</translation>
-<translation id="1692118695553449118">Синхронизация включена</translation>
-<translation id="169515064810179024">Закрыть сайтам доступ к датчикам движения</translation>
-<translation id="1717218214683051432">Датчики движения</translation>
-<translation id="1718835860248848330">Последний час</translation>
-<translation id="1736419249208073774">Подробнее</translation>
-<translation id="1743802530341753419">Запрашивать разрешение на подключение к устройству (рекомендуется)</translation>
-<translation id="1749561566933687563">Синхронизируйте закладки</translation>
-<translation id="17513872634828108">Открытые вкладки</translation>
-<translation id="1779089405699405702">Дешифратор изображений</translation>
-<translation id="1782483593938241562">Дата окончания: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Установлено</translation>
-<translation id="1792959175193046959">Вы можете в любой момент изменить расположение скачиваемых файлов по умолчанию.</translation>
-<translation id="1807246157184219062">Светлый</translation>
-<translation id="1810845389119482123">Синхронизация не настроена</translation>
-<translation id="1821253160463689938">Использовать файлы cookie, чтобы запомнить ваши предпочтения, даже если вы не открываете эти страницы</translation>
-<translation id="1829244130665387512">Найти на странице</translation>
-<translation id="1853692000353488670">Новая вкладка инкогнито</translation>
-<translation id="1856325424225101786">Сбросить упрощенный режим?</translation>
-<translation id="1868024384445905608">Теперь файлы в Chrome будут скачиваться ещё быстрее</translation>
-<translation id="1883903952484604915">Скачанные</translation>
-<translation id="1887786770086287077">Для устройства отключено определение местоположения. Включите эту функцию в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Приложение "<ph name="APP_NAME" />" откроется в Chrome. Продолжая, вы соглашаетесь с <ph name="BEGIN_LINK1" />Условиями использования<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Примечанием о конфиденциальности<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="1919345977826869612">Реклама</translation>
-<translation id="1919950603503897840">Выбрать контакты</translation>
-<translation id="1922076542920281912">Чтобы Chrome получил доступ к данным о местоположении, включите геолокацию в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> из <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Обновления</translation>
-<translation id="19288952978244135">Снова запустите браузер Chrome.</translation>
-<translation id="1933845786846280168">Выбранная вкладка</translation>
-<translation id="194341124344773587">Разрешение для Chrome можно предоставить в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Сохранение паролей</translation>
-<translation id="1952172573699511566">Когда это возможно, текст на сайтах будет отображаться на выбранном вами языке.</translation>
-<translation id="1960290143419248813">Невозможно обновить Chrome в текущей версии Android.</translation>
-<translation id="1966710179511230534">Обновите учетные данные</translation>
-<translation id="1974060860693918893">Дополнительные</translation>
-<translation id="1984705450038014246">Синхронизировать данные Chrome</translation>
-<translation id="1984937141057606926">Разрешено, кроме сторонних сайтов</translation>
-<translation id="1986685561493779662">Это имя уже используется.</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Выбрать</translation>
-<translation id="1993768208584545658">Сайт <ph name="SITE" /> запрашивает подключение</translation>
-<translation id="1994173015038366702">Адрес сайта</translation>
-<translation id="2000419248597011803">Отправлять некоторые файлы cookie и поисковые запросы из адресной строки в поисковую систему по умолчанию</translation>
-<translation id="2002537628803770967">Кредитные карты и адреса из Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# файл}one{# файл}few{# файла}many{# файлов}other{# файла}}</translation>
-<translation id="2017836877785168846">Удаление истории и вариантов автозаполнения в адресной строке</translation>
-<translation id="2021896219286479412">Настройки полноэкранного режима</translation>
-<translation id="2038563949887743358">Включить полную версию сайта</translation>
-<translation id="2041019821020695769">Чтобы Chrome отправлял вам уведомления, включите их в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Приложение "<ph name="APP_NAME" />" также хранит свои данные в Chrome</translation>
-<translation id="2049574241039454490"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE_OF_TOTAL" /></translation>
-<translation id="2056878612599315956">Доступ к сайту приостановлен</translation>
-<translation id="2063713494490388661">Нажмите для поиска</translation>
-<translation id="2067805253194386918">текст</translation>
-<translation id="2079545284768500474">Отмена</translation>
-<translation id="2082238445998314030">Результат <ph name="RESULT_NUMBER" />, всего <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Звук</translation>
-<translation id="2096012225669085171">Синхронизация и персонализация данных на всех устройствах.</translation>
-<translation id="2100273922101894616">Автоматический вход</translation>
-<translation id="2100314319871056947">Перед отправкой разбейте текст на несколько частей.</translation>
-<translation id="2107397443965016585">Запрашивать разрешение на воспроизведение защищенного контента (рекомендуется)</translation>
-<translation id="2111511281910874386">Перейти на страницу</translation>
-<translation id="2122601567107267586">Не удалось открыть приложение</translation>
-<translation id="2126426811489709554">Технологии Chrome</translation>
-<translation id="2131665479022868825">Сэкономлено: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Вкладка "<ph name="TAB_TITLE" />" закрыта</translation>
-<translation id="2139186145475833000">Добавить на главный экран</translation>
-<translation id="2146738493024040262">Открыть приложение с мгновенным запуском</translation>
-<translation id="2148716181193084225">Сегодня</translation>
-<translation id="2154484045852737596">Изменение данных карты</translation>
-<translation id="2154710561487035718">Копировать URL</translation>
-<translation id="2156074688469523661">Прочие сайты (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Чтобы поделиться контентом, откройте настройки Chrome на своем телефоне и другом устройстве, а затем включите синхронизацию.</translation>
-<translation id="2170088579611075216">Разрешить и войти в VR-режим</translation>
-<translation id="218608176142494674">Совместный доступ</translation>
-<translation id="2227444325776770048">Продолжить как <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Синхронизация сервисов Google</translation>
-<translation id="2259659629660284697">Экспорт паролей…</translation>
-<translation id="2268044343513325586">Уточнить</translation>
-<translation id="2286841657746966508">Платежный адрес</translation>
-<translation id="2289270750774289114">Запрашивать для сайтов разрешение на поиск Bluetooth-устройств поблизости (рекомендуется)</translation>
-<translation id="230115972905494466">Совместимые устройства не найдены.</translation>
-<translation id="2315043854645842844">Сертификат, выбранный клиентом, не поддерживается операционной системой.</translation>
-<translation id="2318045970523081853">Нажмите, чтобы позвонить.</translation>
-<translation id="2321086116217818302">Подготовка паролей…</translation>
-<translation id="2321958826496381788">Перемещайте ползунок, пока текст не станет удобным для чтения. После двойного нажатия на абзац текст должен быть такого размера.</translation>
-<translation id="2323763861024343754">Данные сайтов</translation>
-<translation id="2328985652426384049">Не удается войти</translation>
-<translation id="2330129964253841015">Сообщать об утечке паролей</translation>
-<translation id="2349710944427398404">Общее количество данных Chrome, включая аккаунты, закладки и сохраненные настройки</translation>
-<translation id="2353636109065292463">Проверка подключения к Интернету</translation>
-<translation id="2359808026110333948">Продолжить</translation>
-<translation id="2369533728426058518">открыть вкладки</translation>
-<translation id="2387895666653383613">Масштабирование текста</translation>
-<translation id="2394602618534698961">Здесь появляются скачанные файлы.</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> МБ</translation>
-<translation id="2407481962792080328">Эта функция включается, когда вы входите в аккаунт Google.</translation>
-<translation id="2410754283952462441">Выберите аккаунт</translation>
-<translation id="2414886740292270097">Темный</translation>
-<translation id="2416359993254398973">Для этого сайта Chrome запрашивает разрешение на доступ к камере.</translation>
-<translation id="2426805022920575512">Сменить аккаунт</translation>
-<translation id="2433507940547922241">Внешний вид</translation>
-<translation id="2434158240863470628">Скачивание завершено <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Данные о местоположении</translation>
-<translation id="2450083983707403292">Начать скачивание <ph name="FILE_NAME" /> ещё раз?</translation>
-<translation id="2482878487686419369">Уведомления</translation>
-<translation id="2490684707762498678">Под управлением приложения "<ph name="APP_NAME" />"</translation>
-<translation id="2494974097748878569">Google Ассистент в Chrome</translation>
-<translation id="2496180316473517155">История браузера</translation>
-<translation id="2497852260688568942">Ваш администратор отключил синхронизацию</translation>
-<translation id="2498359688066513246">Справка/отзыв</translation>
-<translation id="2501278716633472235">Назад</translation>
-<translation id="2513403576141822879">Остальные настройки конфиденциальности, безопасности и сбора данных вы можете найти в разделе <ph name="BEGIN_LINK" />Синхронизация сервисов Google<ph name="END_LINK" />.</translation>
-<translation id="2518590038762162553">В упрощенном режиме Chrome быстрее загружает страницы и экономит до 60 % трафика. Чтобы оптимизировать страницы, которые вы посещаете, Chrome отправляет ваш интернет-трафик в Google. <ph name="BEGIN_LINK" />Подробнее…<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Отправлять URL посещенных страниц в Google</translation>
-<translation id="2532336938189706096">Веб-версия</translation>
-<translation id="2534155362429831547">Удалено записей: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Офлайн-копия страницы</translation>
-<translation id="2546283357679194313">Файлы сookie и данные сайтов</translation>
-<translation id="2567385386134582609">ИЗОБРАЖЕНИЕ</translation>
-<translation id="257088987046510401">Темы</translation>
-<translation id="2570922361219980984">Определение местоположения отключено и для самого устройства. Включите эту функцию в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Развернуто. Нажмите, чтобы свернуть.</translation>
-<translation id="2581165646603367611">Будет очищен кеш, а также удалены файлы cookie и другие данные, которые система сочтет маловажными.</translation>
-<translation id="2586657967955657006">Буфер обмена</translation>
-<translation id="2587052924345400782">Доступна новая версия</translation>
-<translation id="2593272815202181319">Моноширинный</translation>
-<translation id="2612676031748830579">Номер карты</translation>
-<translation id="2621115761605608342">Разрешить JavaScript для конкретного сайта.</translation>
-<translation id="2625189173221582860">Пароль скопирован</translation>
-<translation id="2631006050119455616">Сэкономлено</translation>
-<translation id="2647434099613338025">Добавить язык</translation>
-<translation id="2650751991977523696">Скачать файл ещё раз?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудиофайл}one{# аудиофайл}few{# аудиофайла}many{# аудиофайлов}other{# аудиофайла}}</translation>
-<translation id="2653659639078652383">Отправить</translation>
-<translation id="2677748264148917807">Закрыть</translation>
-<translation id="2704606927547763573">Скопировано</translation>
-<translation id="2707726405694321444">Обновить страницу</translation>
-<translation id="2709516037105925701">Автозаполнение</translation>
-<translation id="2717722538473713889">Адреса электронной почты</translation>
-<translation id="2728754400939377704">Сортировать по имени домена</translation>
-<translation id="2744248271121720757">Нажмите на слово, чтобы увидеть связанные с ним результаты поиска и действия.</translation>
-<translation id="2760989362628427051">Использовать тёмную тему, когда на устройстве включена тёмная тема или режим энергосбережения.</translation>
-<translation id="2762000892062317888">только что</translation>
-<translation id="2777555524387840389">Осталось <ph name="SECONDS" /> сек.</translation>
-<translation id="2779651927720337254">ошибка</translation>
-<translation id="2781151931089541271">Осталась 1 сек.</translation>
-<translation id="2801022321632964776">Чтобы читать веб-страницы на своем языке, обновите Chrome до последней версии.</translation>
-<translation id="2810645512293415242">Страница была открыта в упрощенном виде, чтобы уменьшить объем трафика и время загрузки.</translation>
-<translation id="281504910091592009">Просматривать сохраненные пароли и управлять ими можно на странице <ph name="BEGIN_LINK" />Аккаунт Google<ph name="END_LINK" />.</translation>
-<translation id="2818669890320396765">Чтобы получить доступ к закладкам на всех устройствах, войдите в аккаунт и включите синхронизацию.</translation>
-<translation id="2822354292072154809">Сбросить разрешения для сайта <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Чтобы выйти из полноэкранного режима, нажмите кнопку "Назад".</translation>
-<translation id="2842985007712546952">Родительская папка</translation>
-<translation id="2858138569776157458">Топ сайтов</translation>
-<translation id="2860954141821109167">Убедитесь, что на устройстве есть приложение "Телефон".</translation>
-<translation id="2870560284913253234">Сайт</translation>
-<translation id="2874939134665556319">Предыдущий трек</translation>
-<translation id="2876369937070532032">При угрозе безопасности отправлять в Google URL некоторых страниц, которые вы открываете</translation>
-<translation id="2888126860611144412">О браузере Chrome</translation>
-<translation id="2891154217021530873">Остановить загрузку страницы</translation>
-<translation id="2893180576842394309">Google может использовать вашу историю, чтобы персонализировать Поиск и другие сервисы.</translation>
-<translation id="2898264748040935573">Изменение сохраненного пароля.</translation>
-<translation id="2900528713135656174">Создать мероприятие</translation>
-<translation id="290376772003165898">Язык страницы не <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Список устройств для отправки вкладки развернут на весь экран.</translation>
-<translation id="2910701580606108292">Запрашивать разрешение на воспроизведение защищенного контента</translation>
-<translation id="2913331724188855103">Разрешить сайтам сохранять и читать файлы cookie (рекомендуется)</translation>
-<translation id="2923908459366352541">Имя недействительно</translation>
-<translation id="2932150158123903946">Хранилище Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Вкладка предпросмотра закрыта</translation>
-<translation id="2956410042958133412">Этим аккаунтом управляют <ph name="PARENT_NAME_1" /> и <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Переключено на вкладки в режиме инкогнито</translation>
-<translation id="2968755619301702150">Просмотр сертификатов</translation>
-<translation id="2979025552038692506">Выбранная вкладка инкогнито</translation>
-<translation id="2987620471460279764">Текст, полученный с другого устройства</translation>
-<translation id="2989523299700148168">Недавние</translation>
-<translation id="2996291259634659425">Придумайте кодовую фразу</translation>
-<translation id="2996809686854298943">Необходимо указать URL</translation>
-<translation id="300526633675317032">Будут удалены все данные сайтов (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">Убедитесь, что устройство подключено к Интернету.</translation>
-<translation id="3029613699374795922">Скачано <ph name="KBS" /> КБ</translation>
-<translation id="3029704984691124060">Кодовые фразы не совпадают</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Справка<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Определение местоположения отключено. Включите его в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Ее можно включить в настройках в любой момент.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> закладка}one{<ph name="BOOKMARKS_COUNT_MANY" /> закладка}few{<ph name="BOOKMARKS_COUNT_MANY" /> закладки}many{<ph name="BOOKMARKS_COUNT_MANY" /> закладок}other{<ph name="BOOKMARKS_COUNT_MANY" /> закладки}}</translation>
-<translation id="3089395242580810162">Открыть в режиме инкогнито</translation>
-<translation id="3115898365077584848">Показать информацию</translation>
-<translation id="3123473560110926937">Заблокировано на некоторых сайтах</translation>
-<translation id="3137521801621304719">Выключить режим инкогнито</translation>
-<translation id="3143515551205905069">Отмена</translation>
-<translation id="3157842584138209013">Чтобы узнать, сколько трафика вы сэкономили, нажмите кнопку "Ещё"</translation>
-<translation id="3166827708714933426">Работа с вкладками и окнами</translation>
-<translation id="3181954750937456830">Безопасный просмотр (защищает вас и ваше устройство от опасных сайтов)</translation>
-<translation id="3190152372525844641">Разрешения для Chrome можно предоставить в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">В памяти занято: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Почти готово!</translation>
-<translation id="3207960819495026254">Добавлено в закладки.</translation>
-<translation id="3211426585530211793">Удалено: <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Если вы забыли кодовую фразу или хотите изменить эту настройку, <ph name="BEGIN_LINK" />сбросьте параметры синхронизации<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Микрофон</translation>
-<translation id="3232754137068452469">Веб-приложение</translation>
-<translation id="3236059992281584593">Осталась 1 мин.</translation>
-<translation id="3244271242291266297">ММ</translation>
-<translation id="3254409185687681395">Добавить страницу в закладки</translation>
-<translation id="3259831549858767975">Уменьшить масштаб страницы</translation>
-<translation id="3269093882174072735">Загрузить изображение</translation>
-<translation id="3269956123044984603">Чтобы получить доступ к вкладкам на всех своих устройствах, включите автосинхронизацию данных в настройках аккаунта на устройстве Android.</translation>
-<translation id="3277252321222022663">Предоставить сайтам доступ к датчикам (рекомендуется)</translation>
-<translation id="3282568296779691940">Войти в Chrome</translation>
-<translation id="3288003805934695103">Обновите страницу.</translation>
-<translation id="32895400574683172">Может отправлять уведомления</translation>
-<translation id="3295530008794733555">Быстрый просмотр сайтов и экономия трафика</translation>
-<translation id="3295602654194328831">Скрыть информацию</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Скачать?</translation>
-<translation id="3306398118552023113">Это приложение запущено в Chrome.</translation>
-<translation id="3315103659806849044">Сейчас вы находитесь на странице настроек сервисов Google и синхронизации. Чтобы включить синхронизацию, нажмите кнопку "Подтвердить" в нижней части экрана. Перейти вверх</translation>
-<translation id="3328801116991980348">Информация о сайте</translation>
-<translation id="3333961966071413176">Все контакты</translation>
-<translation id="3334729583274622784">Изменить расширение имени файла?</translation>
-<translation id="3341058695485821946">Узнайте, сколько трафика вы сэкономили.</translation>
-<translation id="3350687908700087792">Закрыть все вкладки инкогнито</translation>
-<translation id="3353615205017136254">Lite-версия страницы получена с помощью Google. Нажмите кнопку "Полная версия", чтобы загрузить оригинал.</translation>
-<translation id="3367813778245106622">Чтобы начать синхронизацию, снова войдите в аккаунт</translation>
-<translation id="3374023511497244703">Ваши закладки, пароли, история и другие данные Chrome больше не будут синхронизироваться с аккаунтом Google.</translation>
-<translation id="3384347053049321195">Поделиться изображением</translation>
-<translation id="3386292677130313581">Запрашивать разрешение на доступ к данным о местоположении (рекомендуется)</translation>
-<translation id="3387650086002190359">Не удалось скачать файл <ph name="FILE_NAME" /> из-за ошибок файловой системы.</translation>
-<translation id="3389286852084373014">Сообщение слишком длинное</translation>
-<translation id="3398320232533725830">Открыть диспетчер закладок</translation>
-<translation id="3414952576877147120">Размер:</translation>
-<translation id="3443221991560634068">Обновить страницу</translation>
-<translation id="3445014427084483498">Только что</translation>
-<translation id="3478363558367712427">Вы можете выбрать другую поисковую систему.</translation>
+<translation id="6910211073230771657">Удалено</translation>
+<translation id="6965382102122355670">ОК</translation>
+<translation id="5301954838959518834">ОК</translation>
+<translation id="7658239707568436148">Отмена</translation>
 <translation id="3479552764303398839">Не сейчас</translation>
-<translation id="3492207499832628349">Новая вкладка инкогнито</translation>
-<translation id="3493531032208478708">Подробнее <ph name="BEGIN_LINK" />о рекомендованном контенте<ph name="END_LINK" />…</translation>
-<translation id="3513704683820682405">Дополненная реальность</translation>
-<translation id="3518985090088779359">Продолжить</translation>
-<translation id="3522247891732774234">Доступно обновление. Другие параметры…</translation>
-<translation id="3524138585025253783">Интерфейс разработчика</translation>
-<translation id="3527085408025491307">Папка</translation>
-<translation id="3542235761944717775">Доступно <ph name="KILOBYTES" /> КБ</translation>
-<translation id="3549657413697417275">Поиск в истории</translation>
-<translation id="3557336313807607643">Добавить в контакты</translation>
-<translation id="3566923219790363270">Подготовка для VR ещё не завершена. Перезапустите Chrome позже.</translation>
-<translation id="3568688522516854065">Чтобы получить доступ к вкладкам на всех устройствах, войдите в аккаунт и включите синхронизацию.</translation>
-<translation id="3587482841069643663">Все</translation>
-<translation id="358794129225322306">Разрешить сайту автоматически скачивать несколько файлов.</translation>
-<translation id="3590487821116122040">Маловажные данные сайтов (например, сайты, которые вы редко посещаете или на которых не сохранили настройки)</translation>
-<translation id="3599863153486145794">Удаление истории со всех устройств, на которых выполнен вход в аккаунт. Информация о других ваших действиях в Интернете может также храниться на странице <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Отключить звуки на сайтах</translation>
-<translation id="3616113530831147358">Аудио</translation>
-<translation id="3631987586758005671">Отправка на устройство "<ph name="DEVICE_NAME" />"…</translation>
-<translation id="3632295766818638029">Показать пароль</translation>
-<translation id="363596933471559332">Входить на веб-сайты с помощью сохраненного имени пользователя и пароля. Когда функция отключена, эти данные нужно указывать при каждом входе.</translation>
-<translation id="3658159451045945436">Будет удалена вся информация о сэкономленных данных, в том числе список просмотренных сайтов.</translation>
-<translation id="3692944402865947621">Не удалось скачать файл <ph name="FILE_NAME" />, так как хранилище недоступно.</translation>
-<translation id="3714981814255182093">Открыть панель поиска</translation>
-<translation id="3716182511346448902">Эта страница расходовала слишком много памяти, поэтому работа ее скриптов была приостановлена.</translation>
-<translation id="3730075448226062617">Чтобы Chrome получил доступ к микрофону, включите его в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" />: добавлена закладка</translation>
-<translation id="3744111561329211289">Фоновая синхронизация</translation>
-<translation id="3771001275138982843">Не удалось скачать обновление.</translation>
-<translation id="3771033907050503522">Вкладки инкогнито</translation>
-<translation id="3773755127849930740">Чтобы разрешить подключение, <ph name="BEGIN_LINK" />включите Bluetooth<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">Отправка на свои устройства</translation>
-<translation id="3778956594442850293">Добавлено на главный экран</translation>
-<translation id="3789841737615482174">Установить</translation>
-<translation id="3810838688059735925">Видео</translation>
-<translation id="3810973564298564668">Настроить</translation>
-<translation id="381841723434055211">Номера телефонов</translation>
-<translation id="3819178904835489326">Удаленные скачивания: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Удалить данные сайтов?</translation>
-<translation id="385051799172605136">Назад</translation>
-<translation id="3859306556332390985">Перемотать вперед</translation>
-<translation id="3894427358181296146">Добавление папки</translation>
-<translation id="3895926599014793903">Принудительно изменять масштаб</translation>
-<translation id="3912508018559818924">Загрузка данных из Интернета…</translation>
-<translation id="3927692899758076493">Без засечек</translation>
-<translation id="3928666092801078803">Объединить данные</translation>
-<translation id="393697183122708255">Голосовой поиск недоступен</translation>
-<translation id="395206256282351086">Подсказки запросов и сайтов отключены</translation>
-<translation id="3955193568934677022">Разрешить сайтам воспроизводить защищенный контент (рекомендуется)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Страница будет загружена при подключении к сети}one{Страницы будут загружены при подключении к сети}few{Страницы будут загружены при подключении к сети}many{Страницы будут загружены при подключении к сети}other{Страницы будут загружены при подключении к сети}}</translation>
-<translation id="3963007978381181125">Шифрование с помощью кодовой фразы не применяется к способам оплаты и адресам из Google Pay. Доступ к зашифрованным данным будет только у тех, кто знает кодовую фразу. Она не пересылается и не хранится в Google. Если вы забудете фразу или решите изменить эту настройку, вам придется сбросить параметры синхронизации. <ph name="BEGIN_LINK" />Подробнее…<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Скачивание завершено.</translation>
-<translation id="397583555483684758">Ошибка синхронизации</translation>
-<translation id="3976396876660209797">Удалите этот ярлык и создайте его заново</translation>
-<translation id="3985215325736559418">Скачать файл <ph name="FILE_NAME" /> ещё раз?</translation>
-<translation id="3987993985790029246">Копировать ссылку</translation>
-<translation id="3988213473815854515">Доступ к геоданным разрешен</translation>
-<translation id="3988466920954086464">Результаты поиска появятся на этой панели.</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> из ?</translation>
-<translation id="3997476611815694295">Маловажные данные</translation>
-<translation id="4000212216660919741">Офлайн</translation>
+<translation id="5317780077021120954">Сохранить</translation>
+<translation id="4570913071927164677">Подробнее…</translation>
+<translation id="8730621377337864115">Готово</translation>
+<translation id="8261506727792406068">Удалить</translation>
+<translation id="1181037720776840403">Удалить</translation>
+<translation id="5939518447894949180">Сбросить</translation>
 <translation id="4002066346123236978">Название</translation>
-<translation id="4008040567710660924">Разрешить определенному сайту сохранять файлы cookie.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# час}one{# час}few{# часа}many{# часов}other{# часа}}</translation>
-<translation id="4046123991198612571">Следующий трек</translation>
-<translation id="4048707525896921369">Ищите картинки, определения и другую информацию, не покидая выбранную страницу. Просто выберите слово, и оно будет отправлено в Google Поиск вместе с контекстом.
+<translation id="5916664084637901428">ВКЛ</translation>
+<translation id="5860033963881614850">ВЫКЛ</translation>
+<translation id="6165508094623778733">Подробнее...</translation>
+<translation id="6042308850641462728">Ещё</translation>
+<translation id="6040143037577758943">Закрыть</translation>
+<translation id="780301667611848630">Спасибо, не надо</translation>
+<translation id="1201402288615127009">Далее</translation>
+<translation id="2359808026110333948">Продолжить</translation>
+<translation id="2653659639078652383">Отправить</translation>
+<translation id="2079545284768500474">Отмена</translation>
+<translation id="7649070708921625228">Справка</translation>
+<translation id="2148716181193084225">Сегодня</translation>
+<translation id="7781829728241885113">Вчера</translation>
+<translation id="6945221475159498467">Выбрать</translation>
+<translation id="7791543448312431591">Добавить</translation>
+<translation id="6527303717912515753">Поделиться</translation>
+<translation id="1383876407941801731">Поиск</translation>
+<translation id="3115898365077584848">Показать информацию</translation>
+<translation id="3295602654194328831">Скрыть информацию</translation>
+<translation id="3987993985790029246">Копировать ссылку</translation>
+<translation id="2704606927547763573">Скопировано</translation>
+<translation id="8725066075913043281">Повторить попытку</translation>
+<translation id="385051799172605136">Назад</translation>
+<translation id="8131740175452115882">Подтвердить</translation>
+<translation id="5300589172476337783">Показать</translation>
+<translation id="1124772482545689468">Пользователь</translation>
+<translation id="8609465669617005112">Переместить вверх</translation>
+<translation id="6746124502594467657">Переместить вниз</translation>
+<translation id="8249310407154411074">Переместить в начало</translation>
+<translation id="8428213095426709021">Настройки</translation>
+<translation id="2498359688066513246">Справка/отзыв</translation>
+<translation id="8378714024927312812">Управляется вашей организацией</translation>
+<translation id="9019902583201351841">Управляется вашими родителями</translation>
+<translation id="4645575059429386691">Управляется вашими родителями</translation>
+<translation id="4883854917563148705">Управляемые настройки сбросить нельзя</translation>
+<translation id="4307992518367153382">Основные</translation>
+<translation id="1974060860693918893">Дополнительные</translation>
+<translation id="1146678959555564648">Войти в режим VR</translation>
+<translation id="987264212798334818">Общие</translation>
+<translation id="4275663329226226506">Камера и микрофон</translation>
+<translation id="4759238208242260848">Скачанные файлы</translation>
+<translation id="218608176142494674">Совместный доступ</translation>
+<translation id="8004582292198964060">Браузер</translation>
+<translation id="1105960400813249514">Демонстрация экрана</translation>
+<translation id="4875775213178255010">Предлагаемый контент</translation>
+<translation id="2021896219286479412">Настройки полноэкранного режима</translation>
+<translation id="4587589328781138893">Сайты</translation>
+<translation id="4943703118917034429">Виртуальная реальность</translation>
+<translation id="1928696683969751773">Обновления</translation>
+<translation id="6064125863973209585">Завершенные скачивания</translation>
+<translation id="5342314432463739672">Запросы разрешений</translation>
+<translation id="629730747756840877">Аккаунт</translation>
+<translation id="82609232232243542">Войти в Brave</translation>
+<translation id="7956662517480676674">Синхронизация сервисов Brave Software</translation>
+<translation id="5294439808117722387">Сейчас вы находитесь на странице настроек сервисов Brave Software и синхронизации. Чтобы включить синхронизацию, нажмите кнопку "Подтвердить" в нижней части экрана. Перейти вверх</translation>
+<translation id="2096012225669085171">Синхронизация и персонализация данных на всех устройствах.</translation>
+<translation id="1692118695553449118">Синхронизация включена</translation>
+<translation id="5514904542973294328">Отключено администратором устройства</translation>
+<translation id="6447211988989208781">Отслеживание действий в Brave Software</translation>
+<translation id="4882831918239250449">Использование данных о посещенных страницах для персонализации Поиска, рекламы и т. д.</translation>
+<translation id="7431991332293347422">Укажите, как Brave Software может использовать историю браузера для персонализации Поиска и других сервисов.</translation>
+<translation id="6303969859164067831">Выйти из аккаунта и отключить синхронизацию</translation>
+<translation id="1125261911132334651">Перейти в настройки аккаунта Brave Software</translation>
+<translation id="6406506848690869874">Синхронизация...</translation>
+<translation id="714362445477979774">Синхронизировать данные Brave</translation>
+<translation id="4314815835985389558">Настройки синхронизации</translation>
+<translation id="5428209950370661546">Другие сервисы Brave Software</translation>
+<translation id="7704317875155739195">Заполнять поисковые запросы и URL автоматически</translation>
+<translation id="2000419248597011803">Отправлять некоторые файлы cookie и поисковые запросы из адресной строки в поисковую систему по умолчанию</translation>
+<translation id="7981313251711023384">Разрешить предзагрузку страниц для повышения скорости работы браузера и поиска</translation>
+<translation id="1821253160463689938">Использовать файлы cookie, чтобы запомнить ваши предпочтения, даже если вы не открываете эти страницы</translation>
+<translation id="6697492270171225480">Предлагать варианты, если страница, которую вы пытаетесь открыть, не найдена</translation>
+<translation id="8109318360573330108">Отправлять в Brave Software URL страниц, которые вы пытаетесь открыть</translation>
+<translation id="8438566539970814960">Помогать улучшить просмотр страниц и поиск</translation>
+<translation id="284843628681142937">Отправлять URL посещенных страниц в Brave Software</translation>
+<translation id="7222718784508482526">Остальные настройки конфиденциальности, безопасности и сбора данных вы можете найти в разделе <ph name="BEGIN_LINK"/>Синхронизация сервисов Brave Software<ph name="END_LINK"/>.</translation>
+<translation id="918192811481327695">Помогать повышать производительность Brave и улучшать функции</translation>
+<translation id="9063160602596686558">Автоматически отправлять в Brave Software статистику использования и отчеты о сбоях</translation>
+<translation id="4824958205181053313">Отключить синхронизацию?</translation>
+<translation id="3058498974290601450">Ее можно включить в настройках в любой момент.</translation>
+<translation id="3143515551205905069">Отмена</translation>
+<translation id="1506061864768559482">Поисковая система</translation>
+<translation id="55737423895878184">Может определять местоположение и отправлять уведомления</translation>
+<translation id="3988213473815854515">Доступ к геоданным разрешен</translation>
+<translation id="32895400574683172">Может отправлять уведомления</translation>
+<translation id="9040142327097499898">Отправка уведомлений разрешена, но определение местоположения отключено.</translation>
+<translation id="305593374596241526">Определение местоположения отключено. Включите его в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Недавние</translation>
+<translation id="6433501201775827830">Выберите поисковую систему</translation>
+<translation id="7177466738963138057">Вы всегда можете изменить свой выбор в настройках</translation>
+<translation id="3478363558367712427">Вы можете выбрать другую поисковую систему.</translation>
+<translation id="4910889077668685004">Платежные приложения</translation>
+<translation id="5152843274749979095">Нет поддерживаемых приложений</translation>
+<translation id="8812260976093120287">На некоторых сайтах вы можете совершать платежи со своего устройства с помощью перечисленных выше приложений.</translation>
+<translation id="7764225426217299476">Добавить адрес</translation>
+<translation id="5595485650161345191">Изменить адрес</translation>
+<translation id="5087580092889165836">Добавить карту</translation>
+<translation id="2154484045852737596">Изменение данных карты</translation>
+<translation id="6140912465461743537">Страна/регион</translation>
+<translation id="5659593005791499971">Электронная почта</translation>
+<translation id="4378154925671717803">Телефон</translation>
+<translation id="4807098396393229769">Имя владельца</translation>
+<translation id="860043288473659153">Имя владельца карты</translation>
+<translation id="2612676031748830579">Номер карты</translation>
+<translation id="869891660844655955">Срок действия</translation>
+<translation id="2286841657746966508">Платежный адрес</translation>
+<translation id="663059986967017181">Скопировано в Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> способ оплаты}one{<ph name="PAYMENT_METHOD_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> способ оплаты}few{<ph name="PAYMENT_METHOD_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> способа оплаты}many{<ph name="PAYMENT_METHOD_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> способов оплаты}other{<ph name="PAYMENT_METHOD_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> способа оплаты}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> адрес доставки}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> адрес доставки}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> адреса доставки}many{<ph name="SHIPPING_ADDRESS_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> адресов доставки}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> адреса доставки}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> способ доставки}one{<ph name="SHIPPING_OPTION_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> способ доставки}few{<ph name="SHIPPING_OPTION_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> способа доставки}many{<ph name="SHIPPING_OPTION_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> способов доставки}other{<ph name="SHIPPING_OPTION_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> способа доставки}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> контактное лицо}one{<ph name="CONTACT_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> контактное лицо}few{<ph name="CONTACT_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> контактных лица}many{<ph name="CONTACT_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> контактных лиц}other{<ph name="CONTACT_PREVIEW"/> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> контактного лица}}</translation>
+<translation id="7029809446516969842">Пароли</translation>
+<translation id="1943432128510653496">Сохранение паролей</translation>
+<translation id="2100273922101894616">Автоматический вход</translation>
+<translation id="363596933471559332">Входить на веб-сайты с помощью сохраненного имени пользователя и пароля. Когда функция отключена, эти данные нужно указывать при каждом входе.</translation>
+<translation id="6995899638241819463">Сообщать, если пароли были раскрыты в результате утечки данных</translation>
+<translation id="1534287762301776620">Эта функция включается, когда вы входите в аккаунт Brave Software.</translation>
+<translation id="10614374240317010">Сайты, пароли для которых не сохраняются</translation>
+<translation id="3098842761938485917">Просматривать сохраненные пароли и управлять ими можно на странице <ph name="BEGIN_LINK"/>Аккаунт Brave Software<ph name="END_LINK"/>.</translation>
+<translation id="8562452229998620586">Здесь будут показаны сохраненные пароли.</translation>
+<translation id="8084114998886531721">Сохраненный пароль</translation>
+<translation id="2870560284913253234">Сайт</translation>
+<translation id="8503813439785031346">Имя пользователя</translation>
+<translation id="6657585470893396449">Пароль</translation>
+<translation id="2154710561487035718">Копировать URL</translation>
+<translation id="1571304935088121812">Копировать имя пользователя</translation>
+<translation id="5005498671520578047">Для копирования пароля</translation>
+<translation id="3632295766818638029">Показать пароль</translation>
+<translation id="1513858653616922153">Удалить пароль</translation>
+<translation id="543338862236136125">Изменить пароль</translation>
+<translation id="4565377596337484307">Скрыть пароль</translation>
+<translation id="8523928698583292556">Удалить сохраненный пароль</translation>
+<translation id="2898264748040935573">Изменение сохраненного пароля.</translation>
+<translation id="5433691172869980887">Имя пользователя скопировано</translation>
+<translation id="5534640966246046842">Адрес сайта скопирован</translation>
+<translation id="2625189173221582860">Пароль скопирован</translation>
+<translation id="4550003330909367850">Чтобы просмотреть или скопировать пароль, включите блокировку экрана на этом устройстве.</translation>
+<translation id="6154478581116148741">Чтобы экспортировать пароли с этого устройства, включите блокировку экрана в настройках.</translation>
+<translation id="4842092870884894799">Открыто всплывающее окно создания пароля</translation>
+<translation id="2259659629660284697">Экспорт паролей…</translation>
+<translation id="133012818630824069">Экспорт паролей, сохраненных в Brave</translation>
+<translation id="6914783257214138813">Ваши пароли будут видны всем, у кого есть доступ к файлу экспорта.</translation>
+<translation id="2321086116217818302">Подготовка паролей…</translation>
+<translation id="8445448999790540984">Не удалось экспортировать пароли</translation>
+<translation id="3066461326500799725">Открыть справочную статью</translation>
+<translation id="729975465115245577">На устройстве не установлено приложение для хранения файлов паролей.</translation>
+<translation id="7682724950699840886">Убедитесь, что на вашем устройстве достаточно свободного места. Затем снова попробуйте экспортировать пароли.</translation>
+<translation id="1129510026454351943">Сведения об ошибке: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Чтобы скопировать пароль, разблокируйте экран</translation>
+<translation id="5515439363601853141">Чтобы увидеть пароль, разблокируйте экран</translation>
+<translation id="6221633008163990886">Чтобы экспортировать пароли, разблокируйте экран</translation>
+<translation id="230699814587342492">Пароли Brave</translation>
+<translation id="6075798973483050474">Изменение главной страницы</translation>
+<translation id="854522910157234410">Открыть эту страницу</translation>
+<translation id="2482878487686419369">Уведомления</translation>
+<translation id="6255999984061454636">Предлагаемый контент</translation>
+<translation id="805047784848435650">На основе вашей истории просмотров</translation>
+<translation id="1041308826830691739">От сайтов</translation>
+<translation id="395206256282351086">Подсказки запросов и сайтов отключены</translation>
+<translation id="257088987046510401">Темы</translation>
+<translation id="4650364565596261010">По умолчанию</translation>
+<translation id="7588219262685291874">Использовать тёмную тему, когда включен режим энергосбережения</translation>
+<translation id="2760989362628427051">Использовать тёмную тему, когда на устройстве включена тёмная тема или режим энергосбережения.</translation>
+<translation id="6381421346744604172">Затемнять сайты</translation>
+<translation id="5040262127954254034">Личные данные</translation>
+<translation id="4991384657077828949">Помочь Brave стать ещё безопаснее</translation>
+<translation id="1943176487615318915">Для обнаружения опасных приложений и сайтов Brave отправляет в Brave Software URL некоторых страниц, которые вы открываете, контент на них, а также определенные сведения о системе</translation>
+<translation id="3181954750937456830">Безопасный просмотр (защищает вас и ваше устройство от опасных сайтов)</translation>
+<translation id="7315322926489145388">При угрозе безопасности отправлять в Brave Software URL некоторых страниц, которые вы открываете</translation>
+<translation id="2063713494490388661">Нажмите для поиска</translation>
+<translation id="2369463299479365221">Ищите картинки, определения и другую информацию, не покидая выбранную страницу. Просто выберите слово, и оно будет отправлено в Brave Software Поиск вместе с контекстом.
 
 Чтобы задать новый поисковый запрос, нажмите на нужное слово и не отпускайте палец. Чтобы уточнить запрос, прокрутите панель вверх и коснитесь окна поиска.</translation>
-<translation id="4056223980640387499">Сепия</translation>
-<translation id="4060598801229743805">Меню доступно в верхней части экрана</translation>
-<translation id="4062305924942672200">Юридическая информация</translation>
-<translation id="4084682180776658562">Закладка</translation>
-<translation id="4084712963632273211">Контент сайта <ph name="PUBLISHER_ORIGIN" />. <ph name="BEGIN_DEEMPHASIZED" />Получен с помощью Google<ph name="END_DEEMPHASIZED" />.</translation>
-<translation id="4095146165863963773">Удалить данные приложения?</translation>
-<translation id="4099578267706723511">Отправлять в Google статистику использования и отчеты о сбоях</translation>
-<translation id="410351446219883937">Автовоспроизведение</translation>
-<translation id="4116038641877404294">Скачивайте страницы и открывайте их без подключения к Интернету</translation>
-<translation id="4135200667068010335">Список устройств для отправки вкладки закрыт.</translation>
-<translation id="4149994727733219643">Упрощенный просмотр веб-страниц</translation>
-<translation id="4165986682804962316">Настройки сайтов</translation>
-<translation id="4169535189173047238">Запретить</translation>
-<translation id="4170011742729630528">Сервис недоступен. Повторите попытку позже.</translation>
-<translation id="4179980317383591987">Использовано: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Языки</translation>
-<translation id="4183868528246477015">Найти через Google Объектив <ph name="BEGIN_NEW" />Новинка<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Открыть в новой вкладке</translation>
-<translation id="4198423547019359126">Нет доступных мест для скачивания</translation>
-<translation id="4209895695669353772">Чтобы мы могли рекомендовать вам интересный контент, включите синхронизацию.</translation>
-<translation id="4226663524361240545">Вибрация при получении уведомлений</translation>
-<translation id="423219824432660969">Шифровать синхронизированные данные, используя пароль аккаунта Google от <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Открыть настройки</translation>
-<translation id="4256782883801055595">Лицензии на ПО с открытым кодом</translation>
-<translation id="4259722352634471385">Навигация заблокирована: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Копировать адрес ссылки</translation>
-<translation id="4275663329226226506">Камера и микрофон </translation>
-<translation id="4278390842282768270">Разрешено</translation>
-<translation id="429312253194641664">На сайте воспроизводятся медиафайлы</translation>
-<translation id="4298388696830689168">Связанные сайты</translation>
-<translation id="4307992518367153382">Основные</translation>
-<translation id="4314815835985389558">Настройки синхронизации</translation>
-<translation id="4351244548802238354">Закрыть</translation>
-<translation id="4378154925671717803">Телефон</translation>
-<translation id="4384468725000734951">Sogou используется как поисковая система по умолчанию</translation>
-<translation id="4404568932422911380">Нет закладок</translation>
-<translation id="4405224443901389797">Переместить в…</translation>
-<translation id="4411535500181276704">Упрощенный режим</translation>
-<translation id="4415276339145661267">Перейти в настройки аккаунта Google</translation>
-<translation id="4432792777822557199">Страницы на этом языке (<ph name="SOURCE_LANGUAGE" />) будут автоматически переводиться на <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Lite-версия страницы получена с помощью Google</translation>
-<translation id="4434045419905280838">Всплывающие окна и переадресация</translation>
-<translation id="4440958355523780886">Lite-версия страницы получена с помощью Google. Нажмите, чтобы загрузить оригинал.</translation>
-<translation id="4452411734226507615">Закрыть вкладку "<ph name="TAB_TITLE" />"</translation>
-<translation id="4452548195519783679">Закладка добавлена в папку "<ph name="FOLDER_NAME" />"</translation>
-<translation id="445467742685312942">Разрешить сайтам воспроизводить защищенный контент</translation>
-<translation id="4468959413250150279">Отключить звуки на определенном сайте.</translation>
-<translation id="4472118726404937099">Чтобы синхронизировать и персонализировать данные на всех устройствах, войдите в аккаунт и включите синхронизацию.</translation>
-<translation id="447252321002412580">Помогать повышать производительность Chrome и улучшать функции</translation>
-<translation id="4479647676395637221">Запрашивать разрешение на доступ к камере (рекомендуется)</translation>
-<translation id="4479972344484327217">Установка модуля "<ph name="MODULE" />" для Chrome…</translation>
-<translation id="4487967297491345095">Все данные приложения Chrome, включая файлы, настройки, аккаунты и базы данных, будут безвозвратно удалены.</translation>
-<translation id="4493497663118223949">Включен упрощенный режим</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# день назад}one{# день назад}few{# дня назад}many{# дней назад}other{# дня назад}}</translation>
-<translation id="451872707440238414">Искать в закладках</translation>
-<translation id="4521489764227272523">Выбранные данные удалены из Chrome и с синхронизированных устройств.
-
-Остальная история ваших действий в Интернете может храниться в аккаунте Google, например в виде поисковых запросов и сведений из наших сервисов. Она доступна на странице <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Выбор папки</translation>
-<translation id="4538018662093857852">Включить упрощенный режим</translation>
-<translation id="4550003330909367850">Чтобы просмотреть или скопировать пароль, включите блокировку экрана на этом устройстве.</translation>
-<translation id="4558311620361989323">Работа с веб-страницами</translation>
-<translation id="4561979708150884304">Нет подключения</translation>
-<translation id="4565377596337484307">Скрыть пароль</translation>
-<translation id="4570913071927164677">Подробнее…</translation>
-<translation id="4572422548854449519">Войдите в управляемый аккаунт</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# минуту назад}one{# минуту назад}few{# минуты назад}many{# минут назад}other{# минуты назад}}</translation>
-<translation id="4587589328781138893">Сайты</translation>
-<translation id="4594952190837476234">Офлайн-версия страницы сохранена <ph name="CREATION_TIME" />. Она может отличаться от онлайн-версии.</translation>
-<translation id="4605958867780575332">Удалено: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Открыть <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Использовать пароль</translation>
-<translation id="4645575059429386691">Управляется вашими родителями</translation>
-<translation id="4650364565596261010">По умолчанию</translation>
-<translation id="4663756553811254707">Удалено закладок: <ph name="NUMBER_OF_BOOKMARKS" /></translation>
-<translation id="4665282149850138822">Сайт <ph name="NAME" /> добавлен на главный экран</translation>
-<translation id="4684427112815847243">Синхронизировать все</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> способ доставки}one{<ph name="SHIPPING_OPTION_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> способ доставки}few{<ph name="SHIPPING_OPTION_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> способа доставки}many{<ph name="SHIPPING_OPTION_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> способов доставки}other{<ph name="SHIPPING_OPTION_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> способа доставки}}</translation>
-<translation id="4696983787092045100">Отправить сообщения на свои устройства</translation>
-<translation id="4698034686595694889">Есть контент, доступный для офлайн-просмотра в <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Изображения и другие файлы, сохраненные в кеше</translation>
-<translation id="4714588616299687897">Экономьте до 60% трафика</translation>
-<translation id="4719927025381752090">Предлагать перевести</translation>
-<translation id="4720023427747327413">Открыть в <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Помогите улучшить Chrome. <ph name="BEGIN_LINK" />Пройти опрос<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Обновить</translation>
-<translation id="4738836084190194332">Последняя синхронизация: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Открыть новую вкладку</translation>
-<translation id="4751476147751820511">Датчики движения и освещенности</translation>
-<translation id="4759238208242260848">Скачанные файлы</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Скачивание 1 файла завершено.}one{Скачивание # файла завершено.}few{Скачивание # файлов завершено.}many{Скачивание # файлов завершено.}other{Скачивание # файла завершено.}}</translation>
-<translation id="4797039098279997504">Нажмите, чтобы вернуться на страницу <ph name="URL_OF_THE_CURRENT_TAB" />.</translation>
-<translation id="4802417911091824046">Шифрование с помощью кодовой фразы не применяется к способам оплаты и адресам из Google Pay.
-
-Чтобы изменить эту настройку, <ph name="BEGIN_LINK" />сбросьте параметры синхронизации<ph name="END_LINK" />.</translation>
-<translation id="4807098396393229769">Имя владельца</translation>
-<translation id="4824958205181053313">Отключить синхронизацию?</translation>
-<translation id="4837753911714442426">Открыть параметры печати страницы</translation>
-<translation id="4842092870884894799">Открыто всплывающее окно создания пароля</translation>
-<translation id="4860895144060829044">Позвонить</translation>
-<translation id="4866368707455379617">Не удается установить модуль "<ph name="MODULE" />" для Chrome</translation>
-<translation id="4875775213178255010">Предлагаемый контент</translation>
-<translation id="4878404682131129617">Не удалось создать туннель через прокси-сервер.</translation>
-<translation id="4880127995492972015">Перевести…</translation>
-<translation id="4881695831933465202">Открыть</translation>
-<translation id="488187801263602086">Необходимо переименовать файл</translation>
-<translation id="4882831918239250449">Использование данных о посещенных страницах для персонализации Поиска, рекламы и т. д.</translation>
-<translation id="4883854917563148705">Управляемые настройки сбросить нельзя</translation>
-<translation id="4885273946141277891">Конфликт версий Chrome</translation>
-<translation id="4910889077668685004">Платежные приложения</translation>
-<translation id="4913161338056004800">Сбросить статистику</translation>
-<translation id="4913169188695071480">Остановить обновление</translation>
-<translation id="4915549754973153784">Поиск устройств… <ph name="BEGIN_LINK" />Справка<ph name="END_LINK" /></translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# страница}one{# страница}few{# страницы}many{# страниц}other{# страницы}}</translation>
-<translation id="4932247056774066048">Вы выходите из аккаунта, которым управляет администратор домена <ph name="DOMAIN_NAME" />. Все данные Chrome будут удалены с этого устройства, но сохранятся в аккаунте Google.</translation>
-<translation id="4943703118917034429">Виртуальная реальность</translation>
-<translation id="4943872375798546930">Нет результатов</translation>
-<translation id="4958708863221495346">Сайту <ph name="URL_OF_THE_CURRENT_TAB" /> предоставлен доступ к вашему экрану</translation>
-<translation id="4961107849584082341">Эту страницу можно перевести на любой язык</translation>
-<translation id="4962975101802056554">Отозвать все разрешения для устройства</translation>
-<translation id="4970824347203572753">Функция недоступна в вашей стране.</translation>
-<translation id="497421865427891073">Вперед</translation>
-<translation id="4988210275050210843">Скачивание файла (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Страницы</translation>
-<translation id="4994033804516042629">Контакты не найдены</translation>
-<translation id="4996978546172906250">Способ отправки</translation>
-<translation id="5004416275253351869">Отслеживание действий в Google</translation>
-<translation id="5005498671520578047">Для копирования пароля</translation>
-<translation id="5011311129201317034">Сайт <ph name="SITE" /> запрашивает подключение</translation>
-<translation id="5013696553129441713">Новых рекомендаций нет</translation>
-<translation id="5016205925109358554">С засечками</translation>
-<translation id="5033865233969348410">В режиме виртуальной реальности этот сайт может определять:
-   – ваши внешние черты, например рост.
-
-Предоставляйте доступ только тем сайтам, которым вы доверяете.</translation>
+<translation id="2930742481329940825">Быстрый поиск отправляет в Brave Software выбранное слово, а также – в качестве контекста – текущую страницу. Отключить эту функцию можно в <ph name="BEGIN_LINK"/>настройках<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Разрешить</translation>
-<translation id="5040262127954254034">Личные данные</translation>
-<translation id="5048398596102334565">Предоставить сайтам доступ к датчикам движения (рекомендуется)</translation>
-<translation id="5063480226653192405">Использование</translation>
-<translation id="5087580092889165836">Добавить карту</translation>
-<translation id="5100237604440890931">Свернуто. Нажмите, чтобы развернуть.</translation>
-<translation id="510275257476243843">Остался 1 час</translation>
-<translation id="5123685120097942451">Вкладка инкогнито</translation>
-<translation id="5127805178023152808">Синхронизация выключена</translation>
-<translation id="5129038482087801250">Установить веб-приложение</translation>
-<translation id="5132942445612118989">Синхронизируйте пароли, историю и другие данные на всех ваших устройствах</translation>
-<translation id="5139940364318403933">Открыть справочную статью</translation>
-<translation id="515227803646670480">Удаление данных</translation>
-<translation id="5152843274749979095">Нет поддерживаемых приложений</translation>
-<translation id="5161254044473106830">Введите название</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Не удалось скачать 1 файл.}one{Не удалось скачать # файл.}few{Не удалось скачать # файла.}many{Не удалось скачать # файлов.}other{Не удалось скачать # файла.}}</translation>
-<translation id="5170568018924773124">Показать в папке</translation>
-<translation id="5184329579814168207">Открыть в Chrome</translation>
-<translation id="5193988420012215838">Скопировано в буфер обмена.</translation>
-<translation id="5197729504361054390">Сайт <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> получит доступ к выбранным контактам.</translation>
-<translation id="5199929503336119739">Рабочий профиль</translation>
-<translation id="5210286577605176222">Перейти к предыдущей вкладке</translation>
-<translation id="5210365745912300556">Закрыть вкладку</translation>
-<translation id="5224771365102442243">Есть видео</translation>
-<translation id="5230560987958996918">Сайт <ph name="SITE" /> ищет устройства Bluetooth поблизости. Обнаружены следующие устройства:</translation>
-<translation id="5233638681132016545">Новая вкладка</translation>
-<translation id="526421993248218238">Не удалось загрузить страницу</translation>
-<translation id="5271967389191913893">Не удается открыть скачанный контент.</translation>
-<translation id="528192093759286357">Чтобы выйти из полноэкранного режима, проведите по экрану сверху вниз и нажмите кнопку "Назад".</translation>
-<translation id="5292796745632149097">Куда отправить</translation>
-<translation id="5300589172476337783">Показать</translation>
-<translation id="5301954838959518834">ОК</translation>
-<translation id="5304593522240415983">Это поле нужно заполнить</translation>
-<translation id="5307446750509046227">Удалить данные сайтов</translation>
-<translation id="5308380583665731573">Подключение</translation>
-<translation id="5313967007315987356">Добавить сайт</translation>
-<translation id="5317780077021120954">Сохранить</translation>
-<translation id="5324858694974489420">Родительские настройки</translation>
-<translation id="5327248766486351172">Название</translation>
-<translation id="5335288049665977812">Разрешить сайтам использовать JavaScript (рекомендуется)</translation>
-<translation id="5342314432463739672">Запросы разрешений</translation>
-<translation id="5357811892247919462">Вкладка получена.</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{Открыта <ph name="OPEN_TABS_ONE" /> вкладка. Нажмите для переключения.}one{Открыта <ph name="OPEN_TABS_MANY" /> вкладка. Нажмите для переключения.}few{Открыто <ph name="OPEN_TABS_MANY" /> вкладки. Нажмите для переключения.}many{Открыто <ph name="OPEN_TABS_MANY" /> вкладок. Нажмите для переключения.}other{Открыто <ph name="OPEN_TABS_MANY" /> вкладки. Нажмите для переключения.}}</translation>
-<translation id="5391532827096253100">Подключение к сайту не защищено. Информация о сайте</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(и ещё 1)}one{(и ещё #)}few{(и ещё #)}many{(и ещё #)}other{(и ещё #)}}</translation>
-<translation id="5400569084694353794">Работая с приложением, вы принимаете <ph name="BEGIN_LINK1" />Условия использования<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Примечание о конфиденциальности<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="5403592356182871684">Имена</translation>
-<translation id="5403644198645076998">Разрешить доступ только к определенным сайтам</translation>
-<translation id="5414836363063783498">Проверка…</translation>
-<translation id="5423934151118863508">Здесь появятся страницы, которые вы чаще всего просматриваете.</translation>
-<translation id="5424588387303617268">Доступно: <ph name="GIGABYTES" /> ГБ</translation>
-<translation id="543338862236136125">Изменить пароль</translation>
-<translation id="5433691172869980887">Имя пользователя скопировано</translation>
-<translation id="543509235395288790">Скачивание файлов: <ph name="COUNT" /> (<ph name="MEGABYTES" /> МБ).</translation>
-<translation id="5441522332038954058">Перейти к адресной строке</translation>
-<translation id="5447201525962359567">Все данные сайтов, включая файлы cookie и другую информацию, хранящуюся на устройстве</translation>
-<translation id="5447765697759493033">Этот сайт не будет переводиться автоматически</translation>
-<translation id="545042621069398927">Ускорение скачивания…</translation>
-<translation id="5456381639095306749">Скачать страницу</translation>
-<translation id="5475862044948910901">Начать сеанс дополненной реальности?</translation>
-<translation id="548278423535722844">Показать на карте</translation>
-<translation id="5487521232677179737">Удалить данные</translation>
-<translation id="5494752089476963479">Блокировать объявления на сайтах, которые показывают навязчивую или вводящую в заблуждение рекламу</translation>
-<translation id="5500777121964041360">Возможно, эта функция недоступна в вашей стране.</translation>
-<translation id="5512137114520586844">Этим аккаунтом управляет <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Отключено администратором устройства</translation>
-<translation id="5515439363601853141">Чтобы увидеть пароль, разблокируйте экран</translation>
-<translation id="5516455585884385570">Перейти в настройки уведомлений</translation>
-<translation id="5517095782334947753">Вам доступны закладки, история, пароли и другие настройки пользователя <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Попытка переадресации заблокирована.</translation>
-<translation id="5527082711130173040">Чтобы выполнить поиск устройств, браузеру Chrome нужен доступ к геоданным. <ph name="BEGIN_LINK2" />Включите доступ<ph name="END_LINK2" /> и <ph name="BEGIN_LINK1" />обновите разрешения<ph name="END_LINK1" />.</translation>
-<translation id="5527111080432883924">Запрашивать мое разрешение на доступ сайтов к тексту и изображениям, скопированным в буфер обмена (рекомендуется)</translation>
-<translation id="5530766185686772672">Закрыть вкладки инкогнито</translation>
-<translation id="5534334044554683961">В режиме виртуальной реальности этот сайт может определять:
-   – ваши внешние черты, например рост;
-   – планировку вашей комнаты.
-
-Предоставляйте доступ только тем сайтам, которым вы доверяете.</translation>
-<translation id="5534640966246046842">Адрес сайта скопирован</translation>
-<translation id="5556459405103347317">Перезагрузить</translation>
-<translation id="5561549206367097665">Поиск сети…</translation>
-<translation id="557283862590186398">Для этого сайта Chrome запрашивает разрешение на доступ к микрофону.</translation>
-<translation id="55737423895878184">Может определять местоположение и отправлять уведомления</translation>
-<translation id="5578795271662203820">Найти это изображение в <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Вы всегда можете выбрать, что синхронизировать, в <ph name="BEGIN_LINK1" />настройках<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Изменить адрес</translation>
-<translation id="5596627076506792578">Ещё</translation>
-<translation id="5599455543593328020">Режим инкогнито</translation>
-<translation id="5620928963363755975">Чтобы найти скачанные файлы и веб-страницы, нажмите кнопку "Ещё" и выберите соответствующий пункт</translation>
-<translation id="5626134646977739690">Имя:</translation>
-<translation id="5639724618331995626">Разрешить доступ ко всем сайтам</translation>
-<translation id="5648166631817621825">Последние 7 дней</translation>
-<translation id="5649053991847567735">Автоматическое скачивание</translation>
-<translation id="5655963694829536461">Поиск в загрузках</translation>
-<translation id="5659593005791499971">Электронная почта</translation>
-<translation id="5665379678064389456">Создать мероприятие в приложении "<ph name="APP_NAME" />"</translation>
-<translation id="5668404140385795438">Игнорировать запросы сайтов на запрет масштабирования</translation>
-<translation id="5677928146339483299">Заблокировано</translation>
-<translation id="5684874026226664614">Не удалось перевести страницу</translation>
-<translation id="5686790454216892815">Имя файла слишком длинное.</translation>
-<translation id="5689516760719285838">Геоданные</translation>
-<translation id="569536719314091526">Чтобы перевести эту страницу на какой-либо язык, нажмите кнопку "Ещё"</translation>
-<translation id="572328651809341494">Недавние вкладки</translation>
-<translation id="5726692708398506830">Увеличить масштаб страницы</translation>
-<translation id="5748802427693696783">Переключено на обычные вкладки</translation>
-<translation id="5749068826913805084">Для скачивания файлов браузеру Chrome требуется доступ к хранилищу.</translation>
-<translation id="5763382633136178763">Вкладки в режиме инкогнито</translation>
-<translation id="5763514718066511291">Нажмите, чтобы скопировать URL этого приложения.</translation>
-<translation id="5765780083710877561">Описание:</translation>
-<translation id="5793665092639000975">Использовано: <ph name="SPACE_USED" /> из <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google может использовать вашу историю, чтобы персонализировать рекламу, а также Поиск и другие сервисы.</translation>
-<translation id="5804241973901381774">Разрешения</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# час назад}one{# час назад}few{# часа назад}many{# часов назад}other{# часа назад}}</translation>
-<translation id="5810288467834065221">© Google LLC, <ph name="YEAR" />. Все права защищены.</translation>
-<translation id="5817918615728894473">Подключить</translation>
-<translation id="583281660410589416">Неизвестно</translation>
-<translation id="5833984609253377421">Отправить ссылку</translation>
-<translation id="5836192821815272682">Скачивание обновлений для Chrome…</translation>
-<translation id="5853623416121554550">пауза</translation>
-<translation id="5854790677617711513">Сохраненные более 30 дней назад</translation>
-<translation id="5858741533101922242">Не удалось включить адаптер Bluetooth</translation>
-<translation id="5860033963881614850">ВЫКЛ</translation>
-<translation id="5862731021271217234">Чтобы получить доступ к вкладкам на всех устройствах, включите синхронизацию.</translation>
-<translation id="5864174910718532887">Сортировка по названию сайта</translation>
-<translation id="5864419784173784555">Завершение предыдущего скачивания…</translation>
-<translation id="5865733239029070421">Автоматически отправлять в Google статистику использования и отчеты о сбоях</translation>
-<translation id="5869522115854928033">Сайты с сохраненными паролями</translation>
-<translation id="5902828464777634901">Все данные этого веб-сайта, включая файлы cookie, будут удалены.</translation>
-<translation id="5916664084637901428">ВКЛ</translation>
-<translation id="5919204609460789179">Обновите <ph name="PRODUCT_NAME" />, чтобы начать синхронизацию</translation>
-<translation id="5937580074298050696">Сохранено: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Сбросить</translation>
-<translation id="5942872142862698679">Google используется как поисковая система по умолчанию</translation>
-<translation id="5952764234151283551">Отправлять в Google URL страниц, которые вы пытаетесь открыть</translation>
-<translation id="5956665950594638604">Открыть Справочный центр Chrome в новой вкладке</translation>
-<translation id="5958275228015807058">Скачанные файлы и веб-страницы хранятся в одноименном разделе.</translation>
-<translation id="5962718611393537961">Нажмите, чтобы свернуть</translation>
-<translation id="6000066717592683814">Использовать Google</translation>
-<translation id="6005538289190791541">Предложенный пароль</translation>
-<translation id="6036057147555329831">Дополнительный модуль ICU</translation>
-<translation id="6039379616847168523">Перейти к следующей вкладке</translation>
-<translation id="6040143037577758943">Закрыть</translation>
-<translation id="6042308850641462728">Ещё</translation>
-<translation id="604996488070107836">Не удалось скачать файл <ph name="FILE_NAME" /> из-за неизвестной ошибки.</translation>
-<translation id="605721222689873409">ГГ</translation>
-<translation id="6064125863973209585">Завершенные скачивания</translation>
-<translation id="6075798973483050474">Изменение главной страницы</translation>
-<translation id="60923314841986378">Осталось <ph name="HOURS" /> ч.</translation>
-<translation id="6108923351542677676">Настройка…</translation>
-<translation id="6111020039983847643">использовано</translation>
-<translation id="6112702117600201073">Обновление страницы</translation>
-<translation id="6127379762771434464">Быстрая ссылка удалена</translation>
-<translation id="6140912465461743537">Страна/регион</translation>
-<translation id="614940544461990577">Попробуйте сделать следующее:</translation>
-<translation id="6154478581116148741">Чтобы экспортировать пароли с этого устройства, включите блокировку экрана в настройках.</translation>
-<translation id="6159335304067198720">Сэкономлено: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Подробнее...</translation>
-<translation id="6177111841848151710">Закрыт доступ для текущей поисковой системы</translation>
-<translation id="6181444274883918285">Добавить исключение</translation>
-<translation id="6192333916571137726">Скачивание файла</translation>
-<translation id="6192792657125177640">Исключения</translation>
-<translation id="6194112207524046168">Чтобы Chrome получил доступ к камере, включите ее в <ph name="BEGIN_LINK" />настройках Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Блокировать сторонние файлы cookie</translation>
-<translation id="6206551242102657620">Подключение защищено. Информация о сайте</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> не ваш аккаунт?</translation>
-<translation id="6221633008163990886">Чтобы экспортировать пароли, разблокируйте экран</translation>
+<translation id="1406000523432664303">Запрет отслеживания</translation>
 <translation id="6232535412751077445">Если вы запретите отслеживание, в запросы браузера будет включена специальная команда. Сайты могут интерпретировать ее и отвечать на нее по-разному.
 
 Например, некоторые сайты перестанут показывать рекламу, подобранную на основе посещенных вами страниц. Другие сайты продолжат собирать и использовать данные о работе в браузере (например, для повышения уровня безопасности, предоставления контента, демонстрации рекламы и рекомендаций или формирования статистических отчетов).</translation>
-<translation id="624789221780392884">Обновление готово</translation>
-<translation id="6255999984061454636">Предлагаемый контент</translation>
-<translation id="6277522088822131679">Не удалось распечатать страницу. Повторите попытку.</translation>
-<translation id="6295158916970320988">Все сайты</translation>
-<translation id="629730747756840877">Аккаунт</translation>
-<translation id="6303969859164067831">Выйти из аккаунта и отключить синхронизацию</translation>
-<translation id="6316139424528454185">Устаревшая версия Android</translation>
-<translation id="6320088164292336938">Вибросигнал</translation>
-<translation id="6324034347079777476">Синхронизация системы Android отключена</translation>
-<translation id="6333140779060797560">Отправить с помощью <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Шифрование</translation>
-<translation id="6341580099087024258">Спрашивать, куда сохранять файлы</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> адрес доставки}one{<ph name="SHIPPING_ADDRESS_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> адрес доставки}few{<ph name="SHIPPING_ADDRESS_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> адреса доставки}many{<ph name="SHIPPING_ADDRESS_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> адресов доставки}other{<ph name="SHIPPING_ADDRESS_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> адреса доставки}}</translation>
-<translation id="6364438453358674297">Удалить подсказку из истории?</translation>
-<translation id="6369229450655021117">Здесь вы можете искать информацию онлайн, отправлять ее друзьям и просматривать открытые страницы</translation>
-<translation id="6378173571450987352">Сортировка по объему использованного трафика</translation>
-<translation id="6381421346744604172">Затемнять сайты</translation>
-<translation id="6388207532828177975">Очистить и сбросить</translation>
-<translation id="6393863479814692971">Для этого сайта Chrome запрашивает разрешение на доступ к камере и микрофону.</translation>
-<translation id="6395288395575013217">ССЫЛКА</translation>
-<translation id="6404511346730675251">Изменить закладку</translation>
-<translation id="6406506848690869874">Синхронизация...</translation>
-<translation id="641643625718530986">Печать</translation>
-<translation id="6416782512398055893">Скачано <ph name="MBS" /> МБ</translation>
-<translation id="6427112570124116297">Перевод веб-страниц</translation>
-<translation id="6433501201775827830">Выберите поисковую систему</translation>
-<translation id="6437478888915024427">Информация о странице</translation>
-<translation id="6441734959916820584">Название слишком длинное.</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# изображение}one{# изображение}few{# изображения}many{# изображений}other{# изображения}}</translation>
-<translation id="6447842834002726250">Файлы сookie</translation>
-<translation id="6461962085415701688">Не удалось открыть файл</translation>
-<translation id="6464977750820128603">Вы сможете просматривать список сайтов, посещенных в Chrome, и устанавливать для них таймеры.\n\nВ Google будут отправляться сведения о сайтах, для которых настроены таймеры, и времени их посещения. Мы собираем эти данные, чтобы улучшать сервис "Цифровое благополучие".</translation>
-<translation id="6475951671322991020">Скачать видео</translation>
-<translation id="6482749332252372425">Не удалось скачать файл <ph name="FILE_NAME" />, так как места для хранения данных недостаточно.</translation>
-<translation id="6496823230996795692">При первом запуске приложения "<ph name="APP_NAME" />" требуется подключение к Интернету.</translation>
-<translation id="6508722015517270189">Перезапустите Google Chrome.</translation>
-<translation id="6527303717912515753">Поделиться</translation>
-<translation id="6532866250404780454">В сервисе больше не будут отображаться данные о сайтах, которые вы посещаете в Chrome. Кроме того, будут удалены все таймеры сайтов.</translation>
-<translation id="6534565668554028783">Превышено время ожидания ответа от Google</translation>
-<translation id="6538442820324228105">Скачано <ph name="GBS" /> ГБ</translation>
-<translation id="6539092367496845964">Произошла ошибка. Повторите попытку позже.</translation>
-<translation id="654446541061731451">Выберите вкладку для передачи</translation>
-<translation id="6545017243486555795">Удалить все данные</translation>
-<translation id="6545864417968258051">Поиск Bluetooth-устройств</translation>
-<translation id="6560414384669816528">Поиск в Sogou</translation>
-<translation id="6566259936974865419">Благодаря Chrome вы сэкономили <ph name="GIGABYTES" /> ГБ свободного места</translation>
-<translation id="6573096386450695060">Разрешать всегда</translation>
-<translation id="6573431926118603307">Здесь появятся вкладки, открытые в Chrome на других устройствах.</translation>
-<translation id="6583199322650523874">Добавить страницу в закладки</translation>
-<translation id="6593061639179217415">Версия для ПК</translation>
-<translation id="6600954340915313787">Скопировано в Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> ГБ</translation>
-<translation id="6612358246767739896">Защищенный контент</translation>
-<translation id="6627583120233659107">Изменить папку</translation>
-<translation id="6643016212128521049">Удалить</translation>
-<translation id="6643649862576733715">Сортировать по объему сохраненного трафика</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> контактное лицо}one{<ph name="CONTACT_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> контактное лицо}few{<ph name="CONTACT_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> контактных лица}many{<ph name="CONTACT_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> контактных лиц}other{<ph name="CONTACT_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> контактного лица}}</translation>
-<translation id="6649642165559792194">Просмотреть изображение <ph name="BEGIN_NEW" />Новинка<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Чтобы выполнить поиск устройств, браузеру Chrome нужен доступ к геоданным. <ph name="BEGIN_LINK" />Обновить разрешения<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Пароль</translation>
-<translation id="6659594942844771486">Вкладка</translation>
-<translation id="666731172850799929">Открыть в <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Примечание о конфиденциальности Chrome</translation>
-<translation id="6676840375528380067">Удалить данные Chrome с этого устройства?</translation>
-<translation id="6697492270171225480">Предлагать варианты, если страница, которую вы пытаетесь открыть, не найдена</translation>
-<translation id="6697947395630195233">Для этого сайта Chrome запрашивает доступ к данным о вашем местоположении.</translation>
-<translation id="6698801883190606802">Управление синхронизированными данными</translation>
-<translation id="6699370405921460408">Серверы Google будут оптимизировать загружаемые страницы.</translation>
-<translation id="6706288973712894588">Вы не в Сети.\n<ph name="BEGIN_LINK" />Показать офлайн-ленту<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Новости</translation>
-<translation id="6710213216561001401">Назад</translation>
-<translation id="671481426037969117">Время на таймере <ph name="FQDN" /> истекло. Завтра сайт снова станет доступен.</translation>
-<translation id="6738867403308150051">Скачивание…</translation>
-<translation id="6746124502594467657">Переместить вниз</translation>
-<translation id="6766622839693428701">Проведите вниз, чтобы закрыть панель.</translation>
-<translation id="6766758767654711248">Нажмите, чтобы перейти на сайт</translation>
-<translation id="6767294960381293877">Список устройств для отправки вкладки развернут на половину экрана.</translation>
-<translation id="6782111308708962316">Запретить сторонним веб-сайтам сохранять и просматривать файлы cookie</translation>
-<translation id="6790428901817661496">Воспроизвести</translation>
-<translation id="6811034713472274749">Страница загружена</translation>
-<translation id="6818926723028410516">Выберите объекты</translation>
-<translation id="6820686453637990663">Код CVC</translation>
-<translation id="6831043979455480757">Перевести</translation>
-<translation id="6845325883481699275">Помочь Chrome стать ещё безопаснее</translation>
-<translation id="6846298663435243399">Загрузка…</translation>
-<translation id="6850409657436465440">Выполняется скачивание</translation>
-<translation id="6850830437481525139">Закрыто вкладок: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Скачать изображение</translation>
-<translation id="6865313869410766144">Данные для автозаполнения</translation>
-<translation id="688738109438487280">Объединить сохраненные данные с данными пользователя <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Чтобы скопировать пароль, разблокируйте экран</translation>
-<translation id="6896758677409633944">Копировать</translation>
-<translation id="6910211073230771657">Удалено</translation>
-<translation id="6912998170423641340">Блокировать сайтам доступ к тексту и изображениям, скопированным в буфер обмена</translation>
-<translation id="6914783257214138813">Ваши пароли будут видны всем, у кого есть доступ к файлу экспорта.</translation>
-<translation id="6942665639005891494">Вы можете в любой момент изменить расположение скачиваемых файлов по умолчанию, воспользовавшись меню "Настройки".</translation>
-<translation id="6945221475159498467">Выбрать</translation>
-<translation id="6963642900430330478">Эта страница представляет опасность. Информация о сайте</translation>
-<translation id="6963766334940102469">Удалить закладки</translation>
-<translation id="6965382102122355670">ОК</translation>
-<translation id="6979737339423435258">Все время</translation>
-<translation id="6981982820502123353">Специальные возможности</translation>
-<translation id="6989267951144302301">Не удалось скачать</translation>
-<translation id="6990079615885386641">Приложение в Google Play Маркете: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Запрашивать разрешение на доступ к микрофону (рекомендуется)</translation>
-<translation id="7015203776128479407">Первоначальная настройка синхронизации не завершена. Синхронизация выключена.</translation>
-<translation id="7016516562562142042">Открыт доступ для текущей поисковой системы</translation>
-<translation id="7022756207310403729">Открыть в браузере</translation>
-<translation id="702463548815491781">Рекомендовано при включенных функциях TalkBack и Switch Access</translation>
-<translation id="7029809446516969842">Пароли</translation>
-<translation id="7053983685419859001">Блокировать</translation>
-<translation id="7055152154916055070">Заблокирована попытка переадресации:</translation>
-<translation id="7063006564040364415">Не удалось связаться с сервером синхронизации</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Выбран 1 объект}one{Выбран # объект}few{Выбрано # объекта}many{Выбрано # объектов}other{Выбрано # объекта}}</translation>
-<translation id="7071521146534760487">Настройки аккаунта</translation>
-<translation id="7077143737582773186">SD-карта</translation>
-<translation id="7087918508125750058">Выбрано: <ph name="ITEM_COUNT" />. Меню находится в верхней части экрана.</translation>
-<translation id="7121362699166175603">Удаление истории и вариантов автозаполнения в адресной строке. Информация о других ваших действиях в Интернете может также храниться на странице <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Открыть доступ текущей поисковой системе</translation>
-<translation id="7138678301420049075">Другое</translation>
-<translation id="7141896414559753902">Блокировать всплывающие окна и переадресацию на сайтах (рекомендуется)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Загрузить исходную версию страницы<ph name="END_LINK" /> из <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Последние 24 часа</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> КБ</translation>
-<translation id="7177466738963138057">Вы всегда можете изменить свой выбор в настройках</translation>
-<translation id="7180611975245234373">Обновить</translation>
-<translation id="7189372733857464326">Обновление сервисов Google Play…</translation>
-<translation id="7191430249889272776">Вкладка открыта в фоновом режиме</translation>
-<translation id="723171743924126238">Выберите изображения</translation>
-<translation id="7233236755231902816">Чтобы просматривать веб-страницы на своем языке, обновите Chrome до последней версии.</translation>
-<translation id="7243308994586599757">Доступные параметры указаны в нижней части экрана</translation>
-<translation id="7248069434667874558">Убедитесь, что в браузере Chrome на устройстве <ph name="TARGET_DEVICE_NAME" /> включена синхронизация.</translation>
-<translation id="7250468141469952378">Выбрано: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Заблокированный сайт</translation>
-<translation id="7290209999329137901">Переименование невозможно</translation>
-<translation id="7291387454912369099">Оплата через Ассистента</translation>
-<translation id="7293171162284876153">Чтобы начать ее, нажмите "Синхронизировать данные Chrome".</translation>
-<translation id="729975465115245577">На устройстве не установлено приложение для хранения файлов паролей.</translation>
-<translation id="7302081693174882195">Сортировка по объему сэкономленного трафика</translation>
-<translation id="7328017930301109123">В упрощенном режиме Chrome быстрее загружает страницы и экономит до 60 процентов трафика.</translation>
-<translation id="7333031090786104871">Предыдущий сайт ещё не добавлен</translation>
-<translation id="7352939065658542140">ВИДЕО</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Поделиться 1 выбранным объектом}one{Поделиться # выбранным объектом}few{Поделиться # выбранными объектами}many{Поделиться # выбранными объектами}other{Поделиться # выбранного объекта}}</translation>
 <translation id="7359002509206457351">Доступ к способам оплаты</translation>
+<translation id="8026334261755873520">Очистить историю</translation>
+<translation id="1291207594882862231">Удалить файлы cookie и данные сайтов, очистить историю и кеш</translation>
+<translation id="7814200940910057384">Данные Brave удалены</translation>
+<translation id="1664855196866195614">Выбранные данные удалены из Brave и с синхронизированных устройств.
+
+Остальная история ваших действий в Интернете может храниться в аккаунте Brave Software, например в виде поисковых запросов и сведений из наших сервисов. Она доступна на странице <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Изображения и другие файлы, сохраненные в кеше</translation>
+<translation id="2496180316473517155">История браузера</translation>
+<translation id="2546283357679194313">Файлы сookie и данные сайтов</translation>
+<translation id="8662811608048051533">Вы автоматически выйдете из учетных записей на большинстве сайтов.</translation>
+<translation id="8218628800671693884">Вы выйдете из аккаунтов на большинстве сайтов, но останетесь в аккаунте Brave Software.</translation>
+<translation id="2017836877785168846">Удаление истории и вариантов автозаполнения в адресной строке</translation>
+<translation id="8096327394278038498">Удаление истории и вариантов автозаполнения в адресной строке. Информация о других ваших действиях в Интернете может также храниться на странице <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Удаление истории со всех устройств, на которых выполнен вход в аккаунт. Информация о других ваших действиях в Интернете может также храниться на странице <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Сайты с сохраненными паролями</translation>
+<translation id="6865313869410766144">Данные для автозаполнения</translation>
+<translation id="7562080006725997899">Очистить историю</translation>
+<translation id="5487521232677179737">Удалить данные</translation>
+<translation id="7498271377022651285">Подождите…</translation>
+<translation id="784934925303690534">Временной диапазон</translation>
+<translation id="1718835860248848330">Последний час</translation>
+<translation id="7149893636342594995">Последние 24 часа</translation>
+<translation id="5648166631817621825">Последние 7 дней</translation>
+<translation id="8571213806525832805">Последние 4 недели</translation>
+<translation id="5854790677617711513">Сохраненные более 30 дней назад</translation>
+<translation id="6979737339423435258">Все время</translation>
+<translation id="982182592107339124">Будут удалены данные всех сайтов, в том числе:</translation>
+<translation id="6643016212128521049">Удалить</translation>
+<translation id="7641339528570811325">Очистить историю...</translation>
+<translation id="1670399744444387456">Основные настройки</translation>
+<translation id="3245261285041759672">Информация о других ваших действиях в Интернете может также храниться на странице <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Заблокированный сайт</translation>
+<translation id="2534155362429831547">Удалено записей: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Отчеты об использовании и сбоях</translation>
+<translation id="9079153198295609735">Автоматически отправлять в Brave Software статистику использования и отчеты о сбоях</translation>
+<translation id="6981982820502123353">Специальные возможности</translation>
+<translation id="2387895666653383613">Масштабирование текста</translation>
+<translation id="2321958826496381788">Перемещайте ползунок, пока текст не станет удобным для чтения. После двойного нажатия на абзац текст должен быть такого размера.</translation>
+<translation id="3895926599014793903">Принудительно изменять масштаб</translation>
+<translation id="5668404140385795438">Игнорировать запросы сайтов на запрет масштабирования</translation>
+<translation id="4149994727733219643">Упрощенный просмотр веб-страниц</translation>
+<translation id="9100505651305367705">Предлагать упрощенный просмотр статей, если он поддерживается</translation>
+<translation id="1409426117486808224">Упрощенный просмотр открытых вкладок</translation>
+<translation id="702463548815491781">Рекомендовано при включенных функциях TalkBack и Switch Access</translation>
+<translation id="8284326494547611709">Титры</translation>
+<translation id="4165986682804962316">Настройки сайтов</translation>
+<translation id="6295158916970320988">Все сайты</translation>
+<translation id="8380167699614421159">Этот сайт показывает навязчивую или вводящую в заблуждение рекламу</translation>
+<translation id="1919345977826869612">Реклама</translation>
+<translation id="410351446219883937">Автовоспроизведение</translation>
+<translation id="6447842834002726250">Файлы сookie</translation>
+<translation id="6196640612572343990">Блокировать сторонние файлы cookie</translation>
+<translation id="6782111308708962316">Запретить сторонним веб-сайтам сохранять и просматривать файлы cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Всплывающие окна и переадресация</translation>
+<translation id="4751476147751820511">Датчики движения и освещенности</translation>
+<translation id="1717218214683051432">Датчики движения</translation>
+<translation id="2091887806945687916">Звук</translation>
+<translation id="2586657967955657006">Буфер обмена</translation>
+<translation id="6320088164292336938">Вибросигнал</translation>
+<translation id="4226663524361240545">Вибрация при получении уведомлений</translation>
+<translation id="1446450296470737166">Полный доступ к управлению MIDI-устройствами</translation>
+<translation id="3744111561329211289">Фоновая синхронизация</translation>
+<translation id="5649053991847567735">Автоматическое скачивание</translation>
+<translation id="6181444274883918285">Добавить исключение</translation>
+<translation id="5313967007315987356">Добавить сайт</translation>
+<translation id="1369915414381695676">Добавлен сайт <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Разрешить определенному сайту автоматически воспроизводить видео без звука.</translation>
+<translation id="2621115761605608342">Разрешить JavaScript для конкретного сайта.</translation>
+<translation id="8801436777607969138">Блокировать код JavaScript на определенном сайте.</translation>
+<translation id="8372893542064058268">Разрешить фоновую синхронизацию для конкретного сайта.</translation>
+<translation id="358794129225322306">Разрешить сайту автоматически скачивать несколько файлов.</translation>
+<translation id="4008040567710660924">Разрешить определенному сайту сохранять файлы cookie.</translation>
+<translation id="8958424370300090006">Блокировать файлы cookie для определенного сайта.</translation>
+<translation id="7882806643839505685">Включить звуки на определенном сайте.</translation>
+<translation id="4468959413250150279">Отключить звуки на определенном сайте.</translation>
+<translation id="1994173015038366702">Адрес сайта</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Использование</translation>
+<translation id="5804241973901381774">Разрешения</translation>
+<translation id="4278390842282768270">Разрешено</translation>
+<translation id="5677928146339483299">Заблокировано</translation>
+<translation id="1984937141057606926">Разрешено, кроме сторонних сайтов</translation>
+<translation id="7423098979219808738">Всегда спрашивать</translation>
+<translation id="8116925261070264013">Сайты с отключенным звуком</translation>
+<translation id="8300705686683892304">Под управлением приложения</translation>
+<translation id="6192792657125177640">Исключения</translation>
+<translation id="257931822824936280">Развернуто. Нажмите, чтобы свернуть.</translation>
+<translation id="5100237604440890931">Свернуто. Нажмите, чтобы развернуть.</translation>
+<translation id="857943718398505171">Разрешено (рекомендуется)</translation>
+<translation id="2913331724188855103">Разрешить сайтам сохранять и читать файлы cookie (рекомендуется)</translation>
+<translation id="7445411102860286510">Разрешить сайтам автоматически воспроизводить видео без звука (рекомендуется)</translation>
+<translation id="5335288049665977812">Разрешить сайтам использовать JavaScript (рекомендуется)</translation>
+<translation id="5527111080432883924">Запрашивать мое разрешение на доступ сайтов к тексту и изображениям, скопированным в буфер обмена (рекомендуется)</translation>
+<translation id="6912998170423641340">Блокировать сайтам доступ к тексту и изображениям, скопированным в буфер обмена</translation>
+<translation id="7423538860840206698">Доступ к данным в буфере обмена заблокирован</translation>
+<translation id="3955193568934677022">Разрешить сайтам воспроизводить защищенный контент (рекомендуется)</translation>
+<translation id="445467742685312942">Разрешить сайтам воспроизводить защищенный контент</translation>
+<translation id="2107397443965016585">Запрашивать разрешение на воспроизведение защищенного контента (рекомендуется)</translation>
+<translation id="2910701580606108292">Запрашивать разрешение на воспроизведение защищенного контента</translation>
+<translation id="757524316907819857">Запретить сайтам воспроизводить защищенный контент</translation>
+<translation id="3277252321222022663">Предоставить сайтам доступ к датчикам (рекомендуется)</translation>
+<translation id="5048398596102334565">Предоставить сайтам доступ к датчикам движения (рекомендуется)</translation>
+<translation id="8816026460808729765">Закрыть сайтам доступ к датчикам</translation>
+<translation id="169515064810179024">Закрыть сайтам доступ к датчикам движения</translation>
+<translation id="1660204651932907780">Разрешить сайтам воспроизводить звуки (рекомендуется)</translation>
+<translation id="3600792891314830896">Отключить звуки на сайтах</translation>
+<translation id="1743802530341753419">Запрашивать разрешение на подключение к устройству (рекомендуется)</translation>
+<translation id="851751545965956758">Не разрешать сайтам подключаться к устройствам</translation>
+<translation id="7141896414559753902">Блокировать всплывающие окна и переадресацию на сайтах (рекомендуется)</translation>
+<translation id="5494752089476963479">Блокировать объявления на сайтах, которые показывают навязчивую или вводящую в заблуждение рекламу</translation>
+<translation id="3123473560110926937">Заблокировано на некоторых сайтах</translation>
+<translation id="965817943346481315">Блокировать, если сайт показывает навязчивую или вводящую в заблуждение рекламу (рекомендуется)</translation>
+<translation id="3386292677130313581">Запрашивать разрешение на доступ к данным о местоположении (рекомендуется)</translation>
+<translation id="9139068048179869749">Запрашивать разрешение на отправку уведомлений (рекомендуется)</translation>
+<translation id="4479647676395637221">Запрашивать разрешение на доступ к камере (рекомендуется)</translation>
+<translation id="6992289844737586249">Запрашивать разрешение на доступ к микрофону (рекомендуется)</translation>
+<translation id="2289270750774289114">Запрашивать для сайтов разрешение на поиск Bluetooth-устройств поблизости (рекомендуется)</translation>
+<translation id="7053983685419859001">Блокировать</translation>
+<translation id="7128222689758636196">Открыть доступ текущей поисковой системе</translation>
+<translation id="7589445247086920869">Закрыть доступ текущей поисковой системе</translation>
+<translation id="6388207532828177975">Очистить и сбросить</translation>
+<translation id="7999064672810608036">Вы уверены, что хотите удалить все данные этого веб-сайта, включая файлы cookie, и сбросить заданные разрешения?</translation>
+<translation id="2822354292072154809">Сбросить разрешения для сайта <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Удаление данных</translation>
+<translation id="5902828464777634901">Все данные этого веб-сайта, включая файлы cookie, будут удалены.</translation>
+<translation id="119944043368869598">Удалить все</translation>
+<translation id="2490684707762498678">Под управлением приложения "<ph name="APP_NAME"/>"</translation>
+<translation id="5516455585884385570">Перейти в настройки уведомлений</translation>
+<translation id="1404122904123200417">Встроено в <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Здесь появятся файлы, сохраненные сайтами.</translation>
+<translation id="4181841719683918333">Языки</translation>
+<translation id="2647434099613338025">Добавить язык</translation>
+<translation id="1952172573699511566">Когда это возможно, текст на сайтах будет отображаться на выбранном вами языке.</translation>
+<translation id="8559990750235505898">Предлагать перевести страницы на других языках</translation>
+<translation id="4719927025381752090">Предлагать перевести</translation>
+<translation id="8156139159503939589">На каких языках вы читаете?</translation>
+<translation id="5689516760719285838">Геоданные</translation>
+<translation id="2440823041667407902">Данные о местоположении</translation>
+<translation id="2023546461831060654">Разрешения для Brave можно предоставить в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Разрешение для Brave можно предоставить в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Чтобы Brave получил доступ к данным о местоположении, включите геолокацию в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Чтобы Brave получил доступ к камере, включите ее в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Чтобы Brave отправлял вам уведомления, включите их в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Чтобы Brave получил доступ к микрофону, включите его в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Для устройства отключено определение местоположения. Включите эту функцию в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Определение местоположения отключено и для самого устройства. Включите эту функцию в <ph name="BEGIN_LINK"/>настройках Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Камера</translation>
+<translation id="3227137524299004712">Микрофон</translation>
+<translation id="1647391597548383849">Доступ к камере</translation>
+<translation id="945632385593298557">Доступ к микрофону</translation>
+<translation id="6612358246767739896">Защищенный контент</translation>
+<translation id="885701979325669005">Хранилище</translation>
+<translation id="3198916472715691905">В памяти занято: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Отключить доступ к устройству</translation>
+<translation id="4962975101802056554">Отозвать все разрешения для устройства</translation>
+<translation id="6545864417968258051">Поиск Bluetooth-устройств</translation>
+<translation id="4411535500181276704">Упрощенный режим</translation>
+<translation id="7821588508402923572">Здесь появятся данные об экономии трафика</translation>
+<translation id="2131665479022868825">Сэкономлено: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">с <ph name="DATE"/></translation>
+<translation id="3252158532344029638">В упрощенном режиме Brave быстрее загружает страницы и экономит до 60 процентов трафика.</translation>
+<translation id="6159335304067198720">Сэкономлено: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">сэкономлено</translation>
+<translation id="6111020039983847643">использовано</translation>
+<translation id="7413229368719586778">Дата начала: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Дата окончания: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Сортировать по имени домена</translation>
+<translation id="5864174910718532887">Сортировка по названию сайта</translation>
+<translation id="116280672541001035">Использовано</translation>
+<translation id="8349013245300336738">Сортировать по объему использованного трафика</translation>
+<translation id="6378173571450987352">Сортировка по объему использованного трафика</translation>
+<translation id="2631006050119455616">Сэкономлено</translation>
+<translation id="6643649862576733715">Сортировать по объему сохраненного трафика</translation>
+<translation id="7302081693174882195">Сортировка по объему сэкономленного трафика</translation>
+<translation id="4179980317383591987">Использовано: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Сохранено: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Прочие сайты (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Другое</translation>
+<translation id="4913161338056004800">Сбросить статистику</translation>
+<translation id="1856325424225101786">Сбросить упрощенный режим?</translation>
+<translation id="3658159451045945436">Будет удалена вся информация о сэкономленных данных, в том числе список просмотренных сайтов.</translation>
+<translation id="3295530008794733555">Быстрый просмотр сайтов и экономия трафика</translation>
+<translation id="7340390500800578919">В упрощенном режиме Brave быстрее загружает страницы и экономит до 60 % трафика. Чтобы оптимизировать страницы, которые вы посещаете, Brave отправляет ваш интернет-трафик в Brave Software. <ph name="BEGIN_LINK"/>Подробнее…<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Включить упрощенный режим</translation>
+<translation id="4493497663118223949">Включен упрощенный режим</translation>
+<translation id="7559975015014302720">Упрощенный режим отключен</translation>
+<translation id="7606077192958116810">Включен упрощенный режим. Вы можете отключить его в настройках.</translation>
+<translation id="4714588616299687897">Экономьте до 60% трафика</translation>
+<translation id="1006927014032731288">Серверы Brave Software будут оптимизировать загружаемые страницы.</translation>
+<translation id="3257320067425202300">Благодаря Brave вы сэкономили <ph name="MEGABYTES"/> МБ свободного места</translation>
+<translation id="5813223329348543512">Благодаря Brave вы сэкономили <ph name="GIGABYTES"/> ГБ свободного места</translation>
+<translation id="8266862848225348053">Расположение скачиваемых файлов</translation>
+<translation id="7077143737582773186">SD-карта</translation>
+<translation id="7762668264895820836">SD-карта <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Спрашивать, куда сохранять файлы</translation>
+<translation id="6192333916571137726">Скачивание файла</translation>
+<translation id="1672586136351118594">Больше не показывать</translation>
+<translation id="2650751991977523696">Скачать файл ещё раз?</translation>
+<translation id="8664979001105139458">Файл с таким именем уже существует.</translation>
+<translation id="488187801263602086">Необходимо переименовать файл</translation>
+<translation id="5686790454216892815">Имя файла слишком длинное.</translation>
+<translation id="7454641608352164238">Недостаточно места</translation>
+<translation id="8972098258593396643">Скачать в папку по умолчанию?</translation>
+<translation id="804335162455518893">SD-карта не найдена</translation>
+<translation id="7475688122056506577">SD-карта не найдена. Некоторые файлы могут отсутствовать.</translation>
+<translation id="4198423547019359126">Нет доступных мест для скачивания</translation>
+<translation id="8224471946457685718">Скачивать "Статьи для вас" только по Wi-Fi</translation>
+<translation id="4970824347203572753">Функция недоступна в вашей стране.</translation>
+<translation id="5500777121964041360">Возможно, эта функция недоступна в вашей стране.</translation>
+<translation id="1173894706177603556">Переименовать</translation>
+<translation id="1986685561493779662">Это имя уже используется.</translation>
+<translation id="6441734959916820584">Название слишком длинное.</translation>
+<translation id="2923908459366352541">Имя недействительно</translation>
+<translation id="7290209999329137901">Переименование невозможно</translation>
+<translation id="3334729583274622784">Изменить расширение имени файла?</translation>
+<translation id="107147699690128016">Если вы сделаете это, файл может открыться в другом приложении и нанести вред устройству.</translation>
+<translation id="8541922081612557424">О браузере Brave</translation>
+<translation id="5311273890481188673">© Brave Software LLC, <ph name="YEAR"/>. Все права защищены.</translation>
+<translation id="1416550906796893042">Версия приложения</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (последнее обновление: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Операционная система</translation>
+<translation id="3968054912784331254">Невозможно обновить Brave в текущей версии Android.</translation>
+<translation id="7665369617277396874">Добавить аккаунт</translation>
+<translation id="649070405679044769">Вы вошли в аккаунт</translation>
+<translation id="6234515504547364178">Выход из Brave</translation>
+<translation id="5324858694974489420">Родительские настройки</translation>
+<translation id="8920114477895755567">Недостаточно данных о родителях.</translation>
+<translation id="5512137114520586844">Этим аккаунтом управляет <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Этим аккаунтом управляют <ph name="PARENT_NAME_1"/> и <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Контент</translation>
+<translation id="5403644198645076998">Разрешить доступ только к определенным сайтам</translation>
+<translation id="8641930654639604085">Блокировать сайты для взрослых</translation>
+<translation id="5639724618331995626">Разрешить доступ ко всем сайтам</translation>
+<translation id="796823723482603597">Технологии Brave</translation>
+<translation id="6324034347079777476">Синхронизация системы Android отключена</translation>
+<translation id="5127805178023152808">Синхронизация выключена</translation>
+<translation id="7015203776128479407">Первоначальная настройка синхронизации не завершена. Синхронизация выключена.</translation>
+<translation id="2497852260688568942">Ваш администратор отключил синхронизацию</translation>
+<translation id="9100610230175265781">Необходима кодовая фраза</translation>
+<translation id="6108923351542677676">Настройка…</translation>
+<translation id="4062305924942672200">Юридическая информация</translation>
+<translation id="4256782883801055595">Лицензии на ПО с открытым кодом</translation>
+<translation id="1138681184697033370">Условия использования Brave</translation>
+<translation id="7392539049993970338">Примечание о конфиденциальности Brave</translation>
+<translation id="2677748264148917807">Закрыть</translation>
+<translation id="5556459405103347317">Перезагрузить</translation>
+<translation id="1623104350909869708">Запретить создание дополнительных диалоговых окон на этой странице</translation>
+<translation id="2968755619301702150">Просмотр сертификатов</translation>
+<translation id="1360432990279830238">Выйти и отключить синхронизацию?</translation>
+<translation id="8581481290581777242">Удалить данные Brave с этого устройства?</translation>
+<translation id="1318865768845061710">Ваши закладки, пароли, история и другие данные Brave больше не будут синхронизироваться с аккаунтом Brave Software.</translation>
+<translation id="3325020657155065477">Удалить данные Brave с этого устройства</translation>
+<translation id="6136448902816743006">Вы выходите из аккаунта, которым управляет администратор домена <ph name="DOMAIN_NAME"/>. Все данные Brave будут удалены с этого устройства, но сохранятся в аккаунте Brave Software.</translation>
+<translation id="1853026300647876496">Подключение к Brave Software. Подождите…</translation>
+<translation id="2328985652426384049">Не удается войти</translation>
+<translation id="7723158744459952869">Превышено время ожидания ответа от Brave Software</translation>
+<translation id="4572422548854449519">Войдите в управляемый аккаунт</translation>
+<translation id="2689656545739939160">Вы входите в аккаунт, которым управляет администратор домена <ph name="MANAGED_DOMAIN"/>. Он может контролировать ваши данные Brave, которые теперь будут связаны с управляемым аккаунтом. При выходе из системы все данные Brave, хранящиеся на этом устройстве, будут удалены, но останутся в вашем аккаунте Brave Software.</translation>
+<translation id="1749561566933687563">Синхронизируйте закладки</translation>
+<translation id="4242533952199664413">Открыть настройки</translation>
+<translation id="1111673857033749125">Здесь появятся закладки, сохраненные на других устройствах.</translation>
+<translation id="8636825310635137004">Чтобы получить доступ к вкладкам на всех ваших устройствах, включите синхронизацию.</translation>
+<translation id="3269956123044984603">Чтобы получить доступ к вкладкам на всех своих устройствах, включите автосинхронизацию данных в настройках аккаунта на устройстве Android.</translation>
+<translation id="5157964048453367290">Здесь появятся вкладки, открытые в Brave на других устройствах.</translation>
+<translation id="4684427112815847243">Синхронизировать все</translation>
+<translation id="2709516037105925701">Автозаполнение</translation>
+<translation id="8820817407110198400">Закладки</translation>
+<translation id="1644574205037202324">История</translation>
+<translation id="17513872634828108">Открытые вкладки</translation>
+<translation id="1320169905922104972">Кредитные карты и адреса из Brave Software Pay</translation>
+<translation id="6337234675334993532">Шифрование</translation>
+<translation id="6698801883190606802">Управление синхронизированными данными</translation>
+<translation id="3598578758776312506">Шифровать пароли с помощью учетных данных аккаунта Brave Software</translation>
+<translation id="7810580217418711046">Шифровать синхронизированные данные, используя пароль аккаунта Brave Software от <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Задать кодовую фразу для шифрования синхронизированных данных</translation>
+<translation id="2996291259634659425">Придумайте кодовую фразу</translation>
+<translation id="5713644099811900409">Аккаунт Brave Software</translation>
+<translation id="8997474919031554666">Шифрование с помощью кодовой фразы не применяется к способам оплаты и адресам из Brave Software Pay. Доступ к зашифрованным данным будет только у тех, кто знает кодовую фразу. Она не пересылается и не хранится в Brave Software. Если вы забудете фразу или решите изменить эту настройку, вам придется сбросить параметры синхронизации. <ph name="BEGIN_LINK"/>Подробнее…<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Кодовая фраза</translation>
+<translation id="7772032839648071052">Подтвердите кодовую фразу</translation>
+<translation id="5304593522240415983">Это поле нужно заполнить</translation>
+<translation id="321773570071367578">Если вы забыли кодовую фразу или хотите изменить эту настройку, <ph name="BEGIN_LINK"/>сбросьте параметры синхронизации<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Кодовые фразы не совпадают</translation>
+<translation id="5149495116300586333">Шифрование с помощью кодовой фразы не применяется к способам оплаты и адресам из Brave Software Pay.
+
+Чтобы изменить эту настройку, <ph name="BEGIN_LINK"/>сбросьте параметры синхронизации<ph name="END_LINK"/>.</translation>
+<translation id="7638584964844754484">Неверная кодовая фраза</translation>
+<translation id="5414836363063783498">Проверка…</translation>
+<translation id="6846298663435243399">Загрузка…</translation>
+<translation id="5517095782334947753">Вам доступны закладки, история, пароли и другие настройки пользователя <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Объединить данные</translation>
+<translation id="688738109438487280">Объединить сохраненные данные с данными пользователя <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Не объединять данные</translation>
+<translation id="1145536944570833626">Удалить сохраненные данные.</translation>
+<translation id="1993768208584545658">Сайт <ph name="SITE"/> запрашивает подключение</translation>
+<translation id="4915549754973153784">Поиск устройств… <ph name="BEGIN_LINK"/>Справка<ph name="END_LINK"/></translation>
+<translation id="5817918615728894473">Подключить</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Справка<ph name="END_LINK1"/> или <ph name="BEGIN_LINK2"/>повторное сканирование<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Совместимые устройства не найдены.</translation>
+<translation id="3773755127849930740">Чтобы разрешить подключение, <ph name="BEGIN_LINK"/>включите Bluetooth<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Не удалось включить адаптер Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Справка<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Чтобы выполнить поиск устройств, браузеру Brave нужен доступ к геоданным. <ph name="BEGIN_LINK"/>Обновить разрешения<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Чтобы выполнить поиск устройств, браузеру Brave нужен доступ к геоданным. <ph name="BEGIN_LINK"/>Включить<ph name="END_LINK"/></translation>
+<translation id="2367014990350929709">Чтобы выполнить поиск устройств, браузеру Brave нужен доступ к геоданным. <ph name="BEGIN_LINK2"/>Включите доступ<ph name="END_LINK2"/> и <ph name="BEGIN_LINK1"/>обновите разрешения<ph name="END_LINK1"/>.</translation>
+<translation id="1569387923882100876">Подключенное устройство</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Уровень сигнала: # линия}one{Уровень сигнала: # линия}few{Уровень сигнала: # линии}many{Уровень сигнала: # линий}other{Уровень сигнала: # линии}}</translation>
+<translation id="5230560987958996918">Сайт <ph name="SITE"/> ищет устройства Bluetooth поблизости. Обнаружены следующие устройства:</translation>
+<translation id="8368027906805972958">Неизвестное или неподдерживаемое устройство (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Ошибка синхронизации</translation>
+<translation id="1810845389119482123">Синхронизация не настроена</translation>
+<translation id="3235722914093408050">Откройте настройки Android и снова включите синхронизацию системы</translation>
+<translation id="3367813778245106622">Чтобы начать синхронизацию, снова войдите в аккаунт</translation>
+<translation id="974555521953189084">Чтобы начать синхронизацию, введите кодовую фразу</translation>
+<translation id="2997266899014181325">Чтобы начать ее, нажмите "Синхронизировать данные Brave".</translation>
+<translation id="8260126382462817229">Снова войдите в аккаунт</translation>
+<translation id="5919204609460789179">Обновите <ph name="PRODUCT_NAME"/>, чтобы начать синхронизацию</translation>
+<translation id="397583555483684758">Ошибка синхронизации</translation>
+<translation id="1966710179511230534">Обновите учетные данные</translation>
+<translation id="7063006564040364415">Не удалось связаться с сервером синхронизации</translation>
+<translation id="7942131818088350342">Версия <ph name="PRODUCT_NAME"/> устарела.</translation>
+<translation id="4170011742729630528">Сервис недоступен. Повторите попытку позже.</translation>
+<translation id="7947953824732555851">Принять и войти</translation>
+<translation id="8583805026567836021">Удаление данных аккаунта</translation>
+<translation id="8310344678080805313">Обычные вкладки</translation>
+<translation id="5748802427693696783">Переключено на обычные вкладки</translation>
+<translation id="7998918019931843664">Восстановить закрытую вкладку</translation>
+<translation id="8853345339104747198">Вкладка "<ph name="TAB_TITLE"/>"</translation>
+<translation id="4452411734226507615">Закрыть вкладку "<ph name="TAB_TITLE"/>"</translation>
+<translation id="7243308994586599757">Доступные параметры указаны в нижней части экрана</translation>
+<translation id="4060598801229743805">Меню доступно в верхней части экрана</translation>
+<translation id="2810645512293415242">Страница была открыта в упрощенном виде, чтобы уменьшить объем трафика и время загрузки.</translation>
+<translation id="3985215325736559418">Скачать файл <ph name="FILE_NAME"/> ещё раз?</translation>
+<translation id="2450083983707403292">Начать скачивание <ph name="FILE_NAME"/> ещё раз?</translation>
+<translation id="7514365320538308">Скачать</translation>
+<translation id="545042621069398927">Ускорение скачивания…</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Скачивание 1 файла…}one{Скачивание # файла…}few{Скачивание # файлов…}many{Скачивание # файлов…}other{Скачивание # файла…}}</translation>
+<translation id="543509235395288790">Скачивание файлов: <ph name="COUNT"/> (<ph name="MEGABYTES"/> МБ).</translation>
+<translation id="4988210275050210843">Скачивание файла (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Скачивание 1 файла завершено.}one{Скачивание # файла завершено.}few{Скачивание # файлов завершено.}many{Скачивание # файлов завершено.}other{Скачивание # файла завершено.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Не удалось скачать 1 файл.}one{Не удалось скачать # файл.}few{Не удалось скачать # файла.}many{Не удалось скачать # файлов.}other{Не удалось скачать # файла.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Ожидание скачивания 1 файла…}one{Ожидание скачивания # файла…}few{Ожидание скачивания # файлов…}many{Ожидание скачивания # файлов…}other{Ожидание скачивания # файла…}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/></translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Почти готово!</translation>
+<translation id="3960299545138990065">Перезапустите Brave Software Brave.</translation>
+<translation id="3771001275138982843">Не удалось скачать обновление.</translation>
+<translation id="3888648114124182147">Скачивание обновлений для Brave…</translation>
+<translation id="1705567146636171298">Обновить Brave</translation>
+<translation id="6195417478702700398">Чтобы работать в браузере было удобнее, откройте Brave и установите обновление.</translation>
+<translation id="3512968675351418494">Чтобы просматривать веб-страницы на своем языке, обновите Brave до последней версии.</translation>
+<translation id="6427112570124116297">Перевод веб-страниц</translation>
+<translation id="1379423114029199501">Чтобы читать веб-страницы на своем языке, обновите Brave до последней версии.</translation>
+<translation id="5684874026226664614">Не удалось перевести страницу</translation>
+<translation id="6831043979455480757">Перевести</translation>
+<translation id="1285320974508926690">Никогда не переводить этот сайт</translation>
+<translation id="773466115871691567">Переводить страницы на этом языке: <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Не переводить страницы на этом языке: <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Другие языки</translation>
+<translation id="290376772003165898">Язык страницы не <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Страницы на этом языке (<ph name="SOURCE_LANGUAGE"/>) будут автоматически переводиться на <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Страницы на этом языке (<ph name="LANGUAGE"/>) не будут переводиться автоматически</translation>
+<translation id="5447765697759493033">Этот сайт не будет переводиться автоматически</translation>
+<translation id="4880127995492972015">Перевести…</translation>
+<translation id="641643625718530986">Печать</translation>
+<translation id="8909135823018751308">Поделиться...</translation>
+<translation id="4996978546172906250">Способ отправки</translation>
+<translation id="6333140779060797560">Отправить с помощью <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Не удалось распечатать страницу. Повторите попытку.</translation>
+<translation id="3254409185687681395">Добавить страницу в закладки</translation>
+<translation id="497421865427891073">Вперед</translation>
+<translation id="813082847718468539">Сведения о сайте</translation>
+<translation id="2532336938189706096">Веб-версия</translation>
+<translation id="6005538289190791541">Предложенный пароль</translation>
+<translation id="4634124774493850572">Использовать пароль</translation>
+<translation id="8285489906452138776">Для этого сайта Brave запрашивает разрешение на доступ к камере.</translation>
+<translation id="320189792589364011">Для этого сайта Brave запрашивает разрешение на доступ к микрофону.</translation>
+<translation id="7988136689212463100">Для этого сайта Brave запрашивает разрешение на доступ к камере и микрофону.</translation>
+<translation id="4931190655840828017">Для этого сайта Brave запрашивает доступ к данным о вашем местоположении.</translation>
+<translation id="3088191967551450609">Для скачивания файлов браузеру Brave требуется доступ к хранилищу.</translation>
+<translation id="8942627711005830162">Открыть в новом окне</translation>
+<translation id="4195643157523330669">Открыть в новой вкладке</translation>
+<translation id="1100066534610197918">Открыть в новой вкладке группы</translation>
+<translation id="4860895144060829044">Позвонить</translation>
+<translation id="6896758677409633944">Копировать</translation>
+<translation id="8393700583063109961">Отправить сообщение</translation>
+<translation id="3557336313807607643">Добавить в контакты</translation>
+<translation id="4269820728363426813">Копировать адрес ссылки</translation>
+<translation id="1206892813135768548">Копировать текст ссылки</translation>
+<translation id="1204037785786432551">Сохранить данные по ссылке</translation>
+<translation id="6864459304226931083">Скачать изображение</translation>
+<translation id="8209050860603202033">Открыть изображение</translation>
+<translation id="8073388330009372546">Открыть в новой вкладке</translation>
+<translation id="6649642165559792194">Просмотреть изображение <ph name="BEGIN_NEW"/>Новинка<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Загрузить изображение</translation>
+<translation id="3845332215609790146">Найти через Brave Software Объектив <ph name="BEGIN_NEW"/>Новинка<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Найти это изображение в <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Поделиться изображением</translation>
+<translation id="5833984609253377421">Отправить ссылку</translation>
+<translation id="6475951671322991020">Скачать видео</translation>
+<translation id="2317945146070194624">Открыть в новой вкладке</translation>
+<translation id="7975379999046275268">Просмотреть страницу <ph name="BEGIN_NEW"/>Новинка<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Обновление страницы</translation>
+<translation id="36525718899759834">Приложение в Brave Software Play Маркете: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Темный</translation>
+<translation id="1807246157184219062">Светлый</translation>
+<translation id="4056223980640387499">Сепия</translation>
+<translation id="3927692899758076493">Без засечек</translation>
+<translation id="5016205925109358554">С засечками</translation>
+<translation id="2593272815202181319">Моноширинный</translation>
+<translation id="9206873250291191720">А</translation>
+<translation id="654446541061731451">Выберите вкладку для передачи</translation>
+<translation id="8719023831149562936">Не удалось передать текущую вкладку</translation>
+<translation id="2139186145475833000">Добавить на главный экран</translation>
+<translation id="4616150815774728855">Открыть <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Не удалось открыть приложение</translation>
+<translation id="5129038482087801250">Установить веб-приложение</translation>
+<translation id="3789841737615482174">Установить</translation>
+<translation id="4665282149850138822">Сайт <ph name="NAME"/> добавлен на главный экран</translation>
+<translation id="7333031090786104871">Предыдущий сайт ещё не добавлен</translation>
+<translation id="1036727731225946849">Добавление файла "<ph name="WEBAPK_NAME"/>"…</translation>
+<translation id="3778956594442850293">Добавлено на главный экран</translation>
+<translation id="2146738493024040262">Открыть приложение с мгновенным запуском</translation>
+<translation id="7016516562562142042">Открыт доступ для текущей поисковой системы</translation>
+<translation id="6177111841848151710">Закрыт доступ для текущей поисковой системы</translation>
+<translation id="145097072038377568">Отключено в настройках Android</translation>
+<translation id="8007176423574883786">Отключено для этого устройства</translation>
+<translation id="164269334534774161">Эта офлайн-копия страницы была создана <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Офлайн-версия страницы сохранена <ph name="CREATION_TIME"/>. Она может отличаться от онлайн-версии.</translation>
+<translation id="8840953339110955557">Страница может отличаться от онлайн-версии.</translation>
+<translation id="6405300764336705484">Контент с сайта <ph name="DOMAIN_NAME"/>. Получен с помощью Brave Software.</translation>
+<translation id="1006017844123154345">Открыть в Интернете</translation>
+<translation id="3326636747541519688">Lite-версия страницы получена с помощью Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Загрузить исходную версию страницы<ph name="END_LINK"/> из <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Если эта проблема возникает часто, узнайте, <ph name="BEGIN_LINK"/>как ее решить<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Содержимое скрыто</translation>
+<translation id="3810973564298564668">Настроить</translation>
+<translation id="5199929503336119739">Рабочий профиль</translation>
+<translation id="528192093759286357">Чтобы выйти из полноэкранного режима, проведите по экрану сверху вниз и нажмите кнопку "Назад".</translation>
+<translation id="2836148919159985482">Чтобы выйти из полноэкранного режима, нажмите кнопку "Назад".</translation>
+<translation id="3967822245660637423">Скачивание завершено.</translation>
+<translation id="2434158240863470628">Скачивание завершено <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Ошибка скачивания</translation>
+<translation id="1384959399684842514">Скачивание приостановлено.</translation>
+<translation id="1671236975893690980">Ожидание скачивания…</translation>
+<translation id="5561549206367097665">Поиск сети…</translation>
+<translation id="5864419784173784555">Завершение предыдущего скачивания…</translation>
+<translation id="6461962085415701688">Не удалось открыть файл</translation>
+<translation id="1178581264944972037">Пауза</translation>
+<translation id="8200772114523450471">Возобновить</translation>
+<translation id="1409879593029778104">Скачивание файла <ph name="FILE_NAME"/> остановлено, так как он уже существует.</translation>
+<translation id="3387650086002190359">Не удалось скачать файл <ph name="FILE_NAME"/> из-за ошибок файловой системы.</translation>
+<translation id="6482749332252372425">Не удалось скачать файл <ph name="FILE_NAME"/>, так как места для хранения данных недостаточно.</translation>
+<translation id="7619072057915878432">Не удалось скачать файл <ph name="FILE_NAME"/> из-за сбоев сети.</translation>
+<translation id="1477626028522505441">Не удалось скачать файл <ph name="FILE_NAME"/> из-за неполадок на сервере.</translation>
+<translation id="3692944402865947621">Не удалось скачать файл <ph name="FILE_NAME"/>, так как хранилище недоступно.</translation>
+<translation id="604996488070107836">Не удалось скачать файл <ph name="FILE_NAME"/> из-за неизвестной ошибки.</translation>
+<translation id="6738867403308150051">Скачивание…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> КБ</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> МБ</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> ГБ</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> из ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> из <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Скачано <ph name="KBS"/> КБ</translation>
+<translation id="6416782512398055893">Скачано <ph name="MBS"/> МБ</translation>
+<translation id="6538442820324228105">Скачано <ph name="GBS"/> ГБ</translation>
+<translation id="9204836675896933765">Остался 1 файл</translation>
+<translation id="8186512483418048923">Осталось файлов: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Скачан <ph name="FILES_DOWNLOADED_ONE"/> файл}one{Скачан <ph name="FILES_DOWNLOADED_MANY"/> файл}few{Скачано <ph name="FILES_DOWNLOADED_MANY"/> файла}many{Скачано <ph name="FILES_DOWNLOADED_MANY"/> файлов}other{Скачано <ph name="FILES_DOWNLOADED_MANY"/> файла}}</translation>
+<translation id="8037750541064988519">Осталось <ph name="DAYS"/> дн.</translation>
+<translation id="8190358571722158785">Остался 1 день</translation>
+<translation id="60923314841986378">Осталось <ph name="HOURS"/> ч.</translation>
+<translation id="510275257476243843">Остался 1 час</translation>
+<translation id="970715775301869095">Осталось <ph name="MINUTES"/> мин.</translation>
+<translation id="3236059992281584593">Осталась 1 мин.</translation>
+<translation id="2777555524387840389">Осталось <ph name="SECONDS"/> сек.</translation>
+<translation id="2781151931089541271">Осталась 1 сек.</translation>
+<translation id="3303414029551471755">Скачать?</translation>
+<translation id="8617240290563765734">Открыть предложенный URL из скачанного контента?</translation>
+<translation id="1373696734384179344">Недостаточно памяти для скачивания выбранного контента.</translation>
+<translation id="5271967389191913893">Не удается открыть скачанный контент.</translation>
+<translation id="883806473910249246">При скачивании контента произошла ошибка.</translation>
+<translation id="5626134646977739690">Имя:</translation>
+<translation id="7963646190083259054">Поставщик:</translation>
+<translation id="3414952576877147120">Размер:</translation>
+<translation id="7375125077091615385">Тип:</translation>
+<translation id="5765780083710877561">Описание:</translation>
+<translation id="4881695831933465202">Открыть</translation>
+<translation id="3542235761944717775">Доступно <ph name="KILOBYTES"/> КБ</translation>
+<translation id="8051695050440594747">Доступно <ph name="MEGABYTES"/> МБ</translation>
+<translation id="5424588387303617268">Доступно: <ph name="GIGABYTES"/> ГБ</translation>
+<translation id="5793665092639000975">Использовано: <ph name="SPACE_USED"/> из <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Все</translation>
+<translation id="4988526792673242964">Страницы</translation>
+<translation id="3810838688059735925">Видео</translation>
+<translation id="3616113530831147358">Аудио</translation>
+<translation id="9219103736887031265">Картинки</translation>
+<translation id="8250920743982581267">Документы</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# файл}one{# файл}few{# файла}many{# файлов}other{# файла}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# изображение}one{# изображение}few{# изображения}many{# изображений}other{# изображения}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# видеофайл}one{# видеофайл}few{# видеофайла}many{# видеофайлов}other{# видеофайла}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудиофайл}one{# аудиофайл}few{# аудиофайла}many{# аудиофайлов}other{# аудиофайла}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# страница}one{# страница}few{# страницы}many{# страниц}other{# страницы}}</translation>
+<translation id="5456381639095306749">Скачать страницу</translation>
+<translation id="2394602618534698961">Здесь появляются скачанные файлы.</translation>
+<translation id="7810647596859435254">Открыть с помощью...</translation>
+<translation id="5655963694829536461">Поиск в загрузках</translation>
+<translation id="8485434340281759656"><ph name="DESCRIPTION"/> <ph name="FILE_SIZE"/> <ph name="SEPARATOR"/></translation>
+<translation id="1883903952484604915">Скачанные</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Здесь появляются статьи, которые можно читать даже в офлайн-режиме.</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# час}one{# час}few{# часа}many{# часов}other{# часа}}</translation>
+<translation id="5853623416121554550">пауза</translation>
+<translation id="8965591936373831584">ожидание</translation>
+<translation id="2779651927720337254">ошибка</translation>
+<translation id="2049574241039454490"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE_OF_TOTAL"/></translation>
+<translation id="3445014427084483498">Только что</translation>
+<translation id="4000212216660919741">Офлайн</translation>
+<translation id="9133397713400217035">Офлайн-контент</translation>
+<translation id="968900484120156207">Здесь будут страницы, которые вы посещали.</translation>
+<translation id="7882131421121961860">Ничего не найдено.</translation>
+<translation id="3549657413697417275">Поиск в истории</translation>
+<translation id="6820686453637990663">Код CVC</translation>
+<translation id="3244271242291266297">ММ</translation>
+<translation id="605721222689873409">ГГ</translation>
+<translation id="724102042129299115">Первый запуск Brave</translation>
+<translation id="2700285883409956633">Работая с приложением, вы принимаете <ph name="BEGIN_LINK1"/>Условия использования<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Примечание о конфиденциальности<ph name="END_LINK2"/> Brave.</translation>
+<translation id="1640714894372474981">Используя это приложение, вы соглашаетесь с <ph name="BEGIN_LINK1"/>Условиями использования<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Примечанием о конфиденциальности<ph name="END_LINK2"/> Brave, а также с <ph name="BEGIN_LINK3"/>Примечанием о конфиденциальности для аккаунтов Brave Software, управляемых с помощью Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Приложение "<ph name="APP_NAME"/>" откроется в Brave. Продолжая, вы соглашаетесь с <ph name="BEGIN_LINK1"/>Условиями использования<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Примечанием о конфиденциальности<ph name="END_LINK2"/> Brave.</translation>
+<translation id="5071615083211946659">Приложение "<ph name="APP_NAME"/>" откроется в Brave. Продолжая, вы соглашаетесь с <ph name="BEGIN_LINK1"/>Условиями использования<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Примечанием о конфиденциальности<ph name="END_LINK2"/> Brave, а также с <ph name="BEGIN_LINK3"/>Примечанием о конфиденциальности для аккаунтов Brave Software, управляемых с помощью Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Отправлять в Brave Software статистику использования и отчеты о сбоях</translation>
+<translation id="3518985090088779359">Продолжить</translation>
+<translation id="7207456302801184289">Добро пожаловать в Brave!</translation>
+<translation id="704822250101715322">Обновление сервисов Brave Software Play…</translation>
+<translation id="1231733316453485619">Включить синхронизацию?</translation>
+<translation id="5132942445612118989">Синхронизируйте пароли, историю и другие данные на всех ваших устройствах</translation>
+<translation id="5736731321935944068">Brave Software может использовать вашу историю, чтобы персонализировать рекламу, а также Поиск и другие сервисы.</translation>
+<translation id="4013614219085422040">Brave Software может использовать вашу историю, чтобы персонализировать Поиск и другие сервисы.</translation>
+<translation id="5581519193887989363">Вы всегда можете выбрать, что синхронизировать, в <ph name="BEGIN_LINK1"/>настройках<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">ОК</translation>
+<translation id="2410754283952462441">Выберите аккаунт</translation>
+<translation id="2227444325776770048">Продолжить как <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> не ваш аккаунт?</translation>
+<translation id="8109613176066109935">Чтобы получить доступ к закладкам на всех устройствах, включите синхронизацию.</translation>
+<translation id="2818669890320396765">Чтобы получить доступ к закладкам на всех устройствах, войдите в аккаунт и включите синхронизацию.</translation>
+<translation id="6003646045106347985">Чтобы мы могли рекомендовать вам интересный контент, включите синхронизацию.</translation>
+<translation id="8494430740943879273">Чтобы мы могли рекомендовать вам интересный контент, войдите в аккаунт и включите синхронизацию.</translation>
+<translation id="5862731021271217234">Чтобы получить доступ к вкладкам на всех устройствах, включите синхронизацию.</translation>
+<translation id="3568688522516854065">Чтобы получить доступ к вкладкам на всех устройствах, войдите в аккаунт и включите синхронизацию.</translation>
+<translation id="1208340532756947324">Чтобы синхронизировать и персонализировать данные на всех устройствах, включите синхронизацию.</translation>
+<translation id="4472118726404937099">Чтобы синхронизировать и персонализировать данные на всех устройствах, войдите в аккаунт и включите синхронизацию.</translation>
+<translation id="2426805022920575512">Сменить аккаунт</translation>
+<translation id="6790428901817661496">Воспроизвести</translation>
+<translation id="1272079795634619415">Остановить</translation>
+<translation id="2874939134665556319">Предыдущий трек</translation>
+<translation id="4046123991198612571">Следующий трек</translation>
+<translation id="3859306556332390985">Перемотать вперед</translation>
+<translation id="8441146129660941386">Перемотать назад</translation>
+<translation id="6706288973712894588">Вы не в Сети.\n<ph name="BEGIN_LINK"/>Показать офлайн-ленту<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Недавние вкладки</translation>
+<translation id="8497726226069778601">Здесь появятся часто посещаемые страницы</translation>
+<translation id="5423934151118863508">Здесь появятся страницы, которые вы чаще всего просматриваете.</translation>
+<translation id="6127379762771434464">Быстрая ссылка удалена</translation>
+<translation id="4605958867780575332">Удалено: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Дудл Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Другие устройства</translation>
+<translation id="4738836084190194332">Последняя синхронизация: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# минуту назад}one{# минуту назад}few{# минуты назад}many{# минут назад}other{# минуты назад}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# час назад}one{# час назад}few{# часа назад}many{# часов назад}other{# часа назад}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# день назад}one{# день назад}few{# дня назад}many{# дней назад}other{# дня назад}}</translation>
+<translation id="2762000892062317888">только что</translation>
+<translation id="1407135791313364759">Открыть все</translation>
+<translation id="1209206284964581585">Скрыть</translation>
+<translation id="129553762522093515">Недавно закрытые</translation>
+<translation id="8413126021676339697">Показать всю историю</translation>
+<translation id="7876243839304621966">Удалить все</translation>
+<translation id="8487700953926739672">Доступно в автономном режиме</translation>
+<translation id="5224771365102442243">Есть видео</translation>
+<translation id="3493531032208478708">Подробнее <ph name="BEGIN_LINK"/>о рекомендованном контенте<ph name="END_LINK"/>…</translation>
+<translation id="7542481630195938534">Не удалось загрузить рекомендации</translation>
+<translation id="5013696553129441713">Новых рекомендаций нет</translation>
+<translation id="1736419249208073774">Подробнее</translation>
+<translation id="7444811645081526538">Все категории</translation>
+<translation id="6709133671862442373">Новости</translation>
+<translation id="1264974993859112054">Спорт</translation>
+<translation id="9139318394846604261">Покупки</translation>
+<translation id="3912508018559818924">Загрузка данных из Интернета…</translation>
+<translation id="526421993248218238">Не удалось загрузить страницу</translation>
+<translation id="614940544461990577">Попробуйте сделать следующее:</translation>
+<translation id="3288003805934695103">Обновите страницу.</translation>
+<translation id="2353636109065292463">Проверка подключения к Интернету</translation>
+<translation id="2858138569776157458">Топ сайтов</translation>
+<translation id="8364299278605033898">Показать популярные сайты</translation>
+<translation id="1171770572613082465">Чтобы перейти к списку популярных сайтов, нажмите кнопку "Топ сайтов"</translation>
+<translation id="5233638681132016545">Новая вкладка</translation>
+<translation id="4521874409998847950">Контент сайта <ph name="PUBLISHER_ORIGIN"/>. <ph name="BEGIN_DEEMPHASIZED"/>Получен с помощью Brave Software<ph name="END_DEEMPHASIZED"/>.</translation>
+<translation id="2587052924345400782">Доступна новая версия</translation>
+<translation id="4058091506841967397">Не удалось обновить Brave</translation>
+<translation id="6316139424528454185">Устаревшая версия Android</translation>
+<translation id="6989267951144302301">Не удалось скачать</translation>
+<translation id="624789221780392884">Обновление готово</translation>
+<translation id="1549000191223877751">Перейти к другому окну</translation>
+<translation id="7481312909269577407">Вперед</translation>
+<translation id="4084682180776658562">Закладка</translation>
+<translation id="6437478888915024427">Информация о странице</translation>
+<translation id="7180611975245234373">Обновить</translation>
+<translation id="4913169188695071480">Остановить обновление</translation>
+<translation id="1829244130665387512">Найти на странице</translation>
+<translation id="6593061639179217415">Версия для ПК</translation>
+<translation id="9063523880881406963">Выключить полную версию сайта</translation>
+<translation id="2038563949887743358">Включить полную версию сайта</translation>
+<translation id="2433507940547922241">Внешний вид</translation>
+<translation id="983192555821071799">Закрыть все вкладки</translation>
+<translation id="1310482092992808703">Сгруппировать вкладки</translation>
+<translation id="7725024127233776428">Здесь будут страницы, которые вы добавляете в закладки.</translation>
+<translation id="4404568932422911380">Нет закладок</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> закладка}one{<ph name="BOOKMARKS_COUNT_MANY"/> закладка}few{<ph name="BOOKMARKS_COUNT_MANY"/> закладки}many{<ph name="BOOKMARKS_COUNT_MANY"/> закладок}other{<ph name="BOOKMARKS_COUNT_MANY"/> закладки}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/>: добавлена закладка</translation>
+<translation id="3207960819495026254">Добавлено в закладки.</translation>
+<translation id="4452548195519783679">Закладка добавлена в папку "<ph name="FOLDER_NAME"/>"</translation>
+<translation id="8063895661287329888">Не удалось добавить закладку.</translation>
+<translation id="2842985007712546952">Родительская папка</translation>
+<translation id="9065203028668620118">Изменить</translation>
+<translation id="4405224443901389797">Переместить в…</translation>
+<translation id="5170568018924773124">Показать в папке</translation>
+<translation id="8035133914807600019">Создать папку…</translation>
+<translation id="4532845899244822526">Выбор папки</translation>
+<translation id="6627583120233659107">Изменить папку</translation>
+<translation id="1197267115302279827">Переместить закладки</translation>
+<translation id="6963766334940102469">Удалить закладки</translation>
+<translation id="4351244548802238354">Закрыть</translation>
+<translation id="451872707440238414">Искать в закладках</translation>
+<translation id="8901170036886848654">Ничего не найдено</translation>
+<translation id="6404511346730675251">Изменить закладку</translation>
+<translation id="3894427358181296146">Добавление папки</translation>
+<translation id="5327248766486351172">Название</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Папка</translation>
+<translation id="5161254044473106830">Введите название</translation>
+<translation id="2996809686854298943">Необходимо указать URL</translation>
+<translation id="2536728043171574184">Офлайн-копия страницы</translation>
+<translation id="4698034686595694889">Есть контент, доступный для офлайн-просмотра в <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> и другие сайты</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Страница будет загружена при подключении к сети}one{Страницы будут загружены при подключении к сети}few{Страницы будут загружены при подключении к сети}many{Страницы будут загружены при подключении к сети}other{Страницы будут загружены при подключении к сети}}</translation>
+<translation id="6811034713472274749">Страница загружена</translation>
+<translation id="4561979708150884304">Нет подключения</translation>
+<translation id="8274165955039650276">Показать скачанные файлы</translation>
+<translation id="2082238445998314030">Результат <ph name="RESULT_NUMBER"/>, всего <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Нет результатов</translation>
+<translation id="981121421437150478">Офлайн</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Голосовой поиск недоступен</translation>
+<translation id="7191430249889272776">Вкладка открыта в фоновом режиме</translation>
+<translation id="8445059357334030806">Открыть в Brave</translation>
+<translation id="4720023427747327413">Открыть в <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Открыть в браузере</translation>
+<translation id="1113597929977215864">Упрощенный просмотр</translation>
+<translation id="1513352483775369820">Закладки и история поиска</translation>
+<translation id="4939482511480190003">Помогите улучшить Brave. <ph name="BEGIN_LINK"/>Пройти опрос<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Назад</translation>
+<translation id="5596627076506792578">Ещё</translation>
+<translation id="3522247891732774234">Доступно обновление. Другие параметры…</translation>
+<translation id="6773423637732432200">Не удалось обновить Brave. Другие настройки</translation>
+<translation id="3328801116991980348">Информация о сайте</translation>
+<translation id="5391532827096253100">Подключение к сайту не защищено. Информация о сайте</translation>
+<translation id="6206551242102657620">Подключение защищено. Информация о сайте</translation>
+<translation id="6963642900430330478">Эта страница представляет опасность. Информация о сайте</translation>
+<translation id="9070377983101773829">Голосовой поиск</translation>
+<translation id="8676374126336081632">Очистить</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{Открыта <ph name="OPEN_TABS_ONE"/> вкладка. Нажмите для переключения.}one{Открыта <ph name="OPEN_TABS_MANY"/> вкладка. Нажмите для переключения.}few{Открыто <ph name="OPEN_TABS_MANY"/> вкладки. Нажмите для переключения.}many{Открыто <ph name="OPEN_TABS_MANY"/> вкладок. Нажмите для переключения.}other{Открыто <ph name="OPEN_TABS_MANY"/> вкладки. Нажмите для переключения.}}</translation>
+<translation id="2369533728426058518">открыть вкладки</translation>
+<translation id="7071521146534760487">Настройки аккаунта</translation>
+<translation id="932327136139879170">Главная страница</translation>
+<translation id="2707726405694321444">Обновить страницу</translation>
+<translation id="2891154217021530873">Остановить загрузку страницы</translation>
+<translation id="6710213216561001401">Назад</translation>
+<translation id="6659594942844771486">Вкладка</translation>
+<translation id="1933845786846280168">Выбранная вкладка</translation>
+<translation id="2268044343513325586">Уточнить</translation>
+<translation id="7846076177841592234">Отменить выбор</translation>
+<translation id="7087918508125750058">Выбрано: <ph name="ITEM_COUNT"/>. Меню находится в верхней части экрана.</translation>
+<translation id="7250468141469952378">Выбрано: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Поделиться 1 выбранным объектом}one{Поделиться # выбранным объектом}few{Поделиться # выбранными объектами}many{Поделиться # выбранными объектами}other{Поделиться # выбранного объекта}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Удалить 1 выбранный объект}one{Удалить # выбранный объект}few{Удалить # выбранных объекта}many{Удалить # выбранных объектов}other{Удалить # выбранного объекта}}</translation>
+<translation id="1283039547216852943">Нажмите, чтобы развернуть</translation>
+<translation id="5962718611393537961">Нажмите, чтобы свернуть</translation>
+<translation id="8076492880354921740">Вкладки</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Выбран 1 объект}one{Выбран # объект}few{Выбрано # объекта}many{Выбрано # объектов}other{Выбрано # объекта}}</translation>
+<translation id="6818926723028410516">Выберите объекты</translation>
+<translation id="4797039098279997504">Нажмите, чтобы вернуться на страницу <ph name="URL_OF_THE_CURRENT_TAB"/>.</translation>
+<translation id="6766758767654711248">Нажмите, чтобы перейти на сайт</translation>
+<translation id="429312253194641664">На сайте воспроизводятся медиафайлы</translation>
+<translation id="4958708863221495346">Сайту <ph name="URL_OF_THE_CURRENT_TAB"/> предоставлен доступ к вашему экрану</translation>
+<translation id="8833831881926404480">Сайту предоставлен доступ к вашему экрану</translation>
+<translation id="9086455579313502267">Нет доступа к сети</translation>
+<translation id="938850635132480979">Ошибка <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Открыть в <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Показать на карте</translation>
+<translation id="7698359219371678927">Написать письмо в приложении "<ph name="APP_NAME"/>"</translation>
+<translation id="7875915731392087153">Написать письмо</translation>
+<translation id="5665379678064389456">Создать мероприятие в приложении "<ph name="APP_NAME"/>"</translation>
+<translation id="2900528713135656174">Создать мероприятие</translation>
+<translation id="2111511281910874386">Перейти на страницу</translation>
+<translation id="3988466920954086464">Результаты поиска появятся на этой панели.</translation>
+<translation id="2744248271121720757">Нажмите на слово, чтобы увидеть связанные с ним результаты поиска и действия.</translation>
+<translation id="9155898266292537608">Также можно выполнить поиск, нажав на слово.</translation>
+<translation id="3232754137068452469">Веб-приложение</translation>
+<translation id="1430915738399379752">Печать</translation>
+<translation id="3775705724665058594">Отправка на свои устройства</translation>
+<translation id="6364438453358674297">Удалить подсказку из истории?</translation>
+<translation id="213279576345780926">Вкладка "<ph name="TAB_TITLE"/>" закрыта</translation>
+<translation id="6850830437481525139">Закрыто вкладок: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Удалено: <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">Удалено закладок: <ph name="NUMBER_OF_BOOKMARKS"/></translation>
+<translation id="3819178904835489326">Удаленные скачивания: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Конфликт версий Brave</translation>
+<translation id="4259722352634471385">Навигация заблокирована: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Страница не найдена: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Закрыть вкладку</translation>
+<translation id="7772375229873196092">Закрыть вкладку "<ph name="APP_NAME"/>"</translation>
+<translation id="1227058898775614466">История переходов</translation>
+<translation id="9169507124922466868">История переходов открыта наполовину</translation>
+<translation id="1327257854815634930">История переходов открыта</translation>
+<translation id="8788265440806329501">История переходов закрыта</translation>
+<translation id="7482656565088326534">Вкладка предпросмотра</translation>
+<translation id="8427875596167638501">Вкладка предпросмотра открыта на половину высоты</translation>
+<translation id="9102803872260866941">Вкладка предпросмотра открыта</translation>
+<translation id="2942036813789421260">Вкладка предпросмотра закрыта</translation>
+<translation id="6355102470683871794">Хранилище Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Удалить данные сайтов?</translation>
+<translation id="9205995714227143200">Маловажные данные сайтов (например, сайты, которые вы редко посещаете или на которых не сохранили настройки)</translation>
+<translation id="3997476611815694295">Маловажные данные</translation>
+<translation id="8493948351860045254">Освободить место</translation>
+<translation id="2324920234469020158">Будет очищен кеш, а также удалены файлы cookie и другие данные, которые система сочтет маловажными.</translation>
+<translation id="5447201525962359567">Все данные сайтов, включая файлы cookie и другую информацию, хранящуюся на устройстве</translation>
+<translation id="1376578503827013741">Подсчет…</translation>
+<translation id="583281660410589416">Неизвестно</translation>
+<translation id="2323763861024343754">Данные сайтов</translation>
+<translation id="3587672679800759167">Общее количество данных Brave, включая аккаунты, закладки и сохраненные настройки</translation>
+<translation id="6545017243486555795">Удалить все данные</translation>
+<translation id="4095146165863963773">Удалить данные приложения?</translation>
+<translation id="53119194224775367">Все данные приложения Brave, включая файлы, настройки, аккаунты и базы данных, будут безвозвратно удалены.</translation>
+<translation id="5307446750509046227">Удалить данные сайтов</translation>
+<translation id="300526633675317032">Будут удалены все данные сайтов (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">Невозможно выбрать сертификат.</translation>
+<translation id="2315043854645842844">Сертификат, выбранный клиентом, не поддерживается операционной системой.</translation>
+<translation id="5011311129201317034">Сайт <ph name="SITE"/> запрашивает подключение</translation>
+<translation id="5308380583665731573">Подключение</translation>
+<translation id="868929229000858085">Поиск контактов</translation>
+<translation id="1919950603503897840">Выбрать контакты</translation>
+<translation id="7986741934819883144">Выберите контакт</translation>
+<translation id="3333961966071413176">Все контакты</translation>
+<translation id="4994033804516042629">Контакты не найдены</translation>
+<translation id="5403592356182871684">Имена</translation>
+<translation id="2717722538473713889">Адреса электронной почты</translation>
+<translation id="381841723434055211">Номера телефонов</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(и ещё 1)}one{(и ещё #)}few{(и ещё #)}many{(и ещё #)}other{(и ещё #)}}</translation>
+<translation id="5197729504361054390">Сайт <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> получит доступ к выбранным контактам.</translation>
+<translation id="1779089405699405702">Дешифратор изображений</translation>
+<translation id="8067883171444229417">Смотреть видео</translation>
+<translation id="6560414384669816528">Поиск в Sogou</translation>
+<translation id="5406914950576900927">В Китае Brave может использовать для поиска <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>. Это можно изменить в <ph name="BEGIN_LINK"/>Настройках<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Использовать Brave Software</translation>
+<translation id="4384468725000734951">Sogou используется как поисковая система по умолчанию</translation>
+<translation id="6103327872225198548">Brave Software используется как поисковая система по умолчанию</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Это приложение запущено в Brave.</translation>
+<translation id="6143689084714664628">Выполняется в Brave</translation>
+<translation id="7675869148432102528">Приложение "<ph name="APP_NAME"/>" также хранит свои данные в Brave</translation>
+<translation id="2734140769649165081">Удалить данные можно в настройках Brave</translation>
+<translation id="8232956427053453090">Не удалять данные</translation>
+<translation id="4298388696830689168">Связанные сайты</translation>
+<translation id="5763514718066511291">Нажмите, чтобы скопировать URL этого приложения.</translation>
+<translation id="6496823230996795692">При первом запуске приложения "<ph name="APP_NAME"/>" требуется подключение к Интернету.</translation>
+<translation id="751961395872307827">Не удалось подключиться к сайту</translation>
+<translation id="4878404682131129617">Не удалось создать туннель через прокси-сервер.</translation>
+<translation id="4749960740855309258">Открыть новую вкладку</translation>
+<translation id="8788968922598763114">Открыть последнюю закрытую вкладку</translation>
+<translation id="7929962904089429003">Открыть меню</translation>
+<translation id="6039379616847168523">Перейти к следующей вкладке</translation>
+<translation id="5210286577605176222">Перейти к предыдущей вкладке</translation>
+<translation id="124678866338384709">Закрыть вкладку</translation>
+<translation id="3714981814255182093">Открыть панель поиска</translation>
+<translation id="5441522332038954058">Перейти к адресной строке</translation>
+<translation id="3398320232533725830">Открыть диспетчер закладок</translation>
+<translation id="6583199322650523874">Добавить страницу в закладки</translation>
+<translation id="8489271220582375723">Открыть страницу "История"</translation>
+<translation id="4837753911714442426">Открыть параметры печати страницы</translation>
+<translation id="5726692708398506830">Увеличить масштаб страницы</translation>
+<translation id="3259831549858767975">Уменьшить масштаб страницы</translation>
+<translation id="8015452622527143194">Восстановить масштаб страницы по умолчанию</translation>
+<translation id="3443221991560634068">Обновить страницу</translation>
+<translation id="123724288017357924">Обновить страницу без учета кешированного контента</translation>
+<translation id="305870044889644984">Открыть Справочный центр Brave в новой вкладке</translation>
+<translation id="3166827708714933426">Работа с вкладками и окнами</translation>
+<translation id="3169981355900570544">Функции Brave Software Brave</translation>
+<translation id="4558311620361989323">Работа с веб-страницами</translation>
+<translation id="1908301351964700579">Подготовка для VR ещё не завершена. Перезапустите Brave позже.</translation>
+<translation id="8970887620466824814">Произошла ошибка</translation>
+<translation id="1875543012935658554">Снова запустите браузер Brave.</translation>
+<translation id="79859296434321399">Чтобы просматривать контент в режиме дополненной реальности, установите приложение ARCore.</translation>
+<translation id="8558485628462305855">Чтобы просматривать контент в режиме дополненной реальности, обновите приложение ARCore.</translation>
+<translation id="3513704683820682405">Дополненная реальность</translation>
+<translation id="5475862044948910901">Начать сеанс дополненной реальности?</translation>
 <translation id="7365126855094612066">Во время сеанса сайт сможет:
 • создавать 3D-карту места, в котором вы находитесь;
 • отслеживать движение камеры.
 
 Сайту НЕ будет предоставлен доступ к камере. Изображения с камеры будете видеть только вы.</translation>
-<translation id="7375125077091615385">Тип:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" /></translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Первый запуск Chrome</translation>
-<translation id="741204030948306876">ОК</translation>
-<translation id="7413229368719586778">Дата начала: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Всегда спрашивать</translation>
-<translation id="7423538860840206698">Доступ к данным в буфере обмена заблокирован</translation>
-<translation id="7431991332293347422">Укажите, как Google может использовать историю браузера для персонализации Поиска и других сервисов.</translation>
-<translation id="7437998757836447326">Выход из Chrome</translation>
-<translation id="7438641746574390233">Когда упрощенный режим включен, Chrome использует серверы Google, чтобы ускорить загрузку страниц. В упрощенном режиме на медленных страницах загружается только самый необходимый контент. Упрощенный режим не действует в режиме инкогнито.</translation>
-<translation id="7444811645081526538">Все категории</translation>
-<translation id="7445411102860286510">Разрешить сайтам автоматически воспроизводить видео без звука (рекомендуется)</translation>
-<translation id="7453467225369441013">Вы выйдете из аккаунтов на большинстве сайтов, но останетесь в аккаунте Google.</translation>
-<translation id="7454641608352164238">Недостаточно места</translation>
-<translation id="7475192538862203634">Если эта проблема возникает часто, узнайте, <ph name="BEGIN_LINK" />как ее решить<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD-карта не найдена. Некоторые файлы могут отсутствовать.</translation>
-<translation id="7479104141328977413">Управление вкладками</translation>
-<translation id="7481312909269577407">Вперед</translation>
-<translation id="7482656565088326534">Вкладка предпросмотра</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (последнее обновление: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">сэкономлено</translation>
-<translation id="7498271377022651285">Подождите…</translation>
-<translation id="7514365320538308">Скачать</translation>
-<translation id="751961395872307827">Не удалось подключиться к сайту</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Не удалось загрузить рекомендации</translation>
-<translation id="7559975015014302720">Упрощенный режим отключен</translation>
-<translation id="7562080006725997899">Очистить историю</translation>
-<translation id="756809126120519699">Данные Chrome удалены</translation>
-<translation id="757524316907819857">Запретить сайтам воспроизводить защищенный контент</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Скачан <ph name="FILES_DOWNLOADED_ONE" /> файл}one{Скачан <ph name="FILES_DOWNLOADED_MANY" /> файл}few{Скачано <ph name="FILES_DOWNLOADED_MANY" /> файла}many{Скачано <ph name="FILES_DOWNLOADED_MANY" /> файлов}other{Скачано <ph name="FILES_DOWNLOADED_MANY" /> файла}}</translation>
-<translation id="7588219262685291874">Использовать тёмную тему, когда включен режим энергосбережения</translation>
-<translation id="7589445247086920869">Закрыть доступ текущей поисковой системе</translation>
-<translation id="7593557518625677601">Откройте настройки Android и снова включите синхронизацию системы</translation>
-<translation id="7596558890252710462">Операционная система</translation>
-<translation id="7605594153474022051">Ошибка синхронизации</translation>
-<translation id="7606077192958116810">Включен упрощенный режим. Вы можете отключить его в настройках.</translation>
-<translation id="7612619742409846846">Вы вошли в аккаунт</translation>
-<translation id="7619072057915878432">Не удалось скачать файл <ph name="FILE_NAME" /> из-за сбоев сети.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Справка<ph name="END_LINK1" /> или <ph name="BEGIN_LINK2" />повторное сканирование<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Добро пожаловать в Chrome!</translation>
-<translation id="7638584964844754484">Неверная кодовая фраза</translation>
-<translation id="7641339528570811325">Очистить историю...</translation>
-<translation id="7648422057306047504">Шифровать пароли с помощью учетных данных аккаунта Google</translation>
-<translation id="7649070708921625228">Справка</translation>
-<translation id="7658239707568436148">Отмена</translation>
-<translation id="7665369617277396874">Добавить аккаунт</translation>
-<translation id="766587987807204883">Здесь появляются статьи, которые можно читать даже в офлайн-режиме.</translation>
-<translation id="7682724950699840886">Убедитесь, что на вашем устройстве достаточно свободного места. Затем снова попробуйте экспортировать пароли.</translation>
-<translation id="7685301384041462804">Прежде чем войти в виртуальную реальность, убедитесь, что этот сайт безопасен.</translation>
-<translation id="7698359219371678927">Написать письмо в приложении "<ph name="APP_NAME" />"</translation>
-<translation id="7704317875155739195">Заполнять поисковые запросы и URL автоматически</translation>
-<translation id="7725024127233776428">Здесь будут страницы, которые вы добавляете в закладки.</translation>
-<translation id="773466115871691567">Переводить страницы на этом языке: <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Для обнаружения опасных приложений и сайтов Chrome отправляет в Google URL некоторых страниц, которые вы открываете, контент на них, а также определенные сведения о системе</translation>
-<translation id="7757787379047923882">Текст с устройства <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-карта <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Добавить адрес</translation>
-<translation id="7772032839648071052">Подтвердите кодовую фразу</translation>
-<translation id="7772375229873196092">Закрыть вкладку "<ph name="APP_NAME" />"</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> способ оплаты}one{<ph name="PAYMENT_METHOD_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> способ оплаты}few{<ph name="PAYMENT_METHOD_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> способа оплаты}many{<ph name="PAYMENT_METHOD_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> способов оплаты}other{<ph name="PAYMENT_METHOD_PREVIEW" /> и ещё <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> способа оплаты}}</translation>
-<translation id="7781829728241885113">Вчера</translation>
-<translation id="7791543448312431591">Добавить</translation>
-<translation id="780301667611848630">Спасибо, не надо</translation>
-<translation id="7810647596859435254">Открыть с помощью...</translation>
-<translation id="7821588508402923572">Здесь появятся данные об экономии трафика</translation>
-<translation id="7837721118676387834">Разрешить определенному сайту автоматически воспроизводить видео без звука.</translation>
-<translation id="7846076177841592234">Отменить выбор</translation>
-<translation id="784934925303690534">Временной диапазон</translation>
-<translation id="7851858861565204677">Другие устройства</translation>
-<translation id="7875915731392087153">Написать письмо</translation>
-<translation id="7876243839304621966">Удалить все</translation>
-<translation id="7882131421121961860">Ничего не найдено.</translation>
-<translation id="7882806643839505685">Включить звуки на определенном сайте.</translation>
-<translation id="7886917304091689118">Выполняется в Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Скачивание 1 файла…}one{Скачивание # файла…}few{Скачивание # файлов…}many{Скачивание # файлов…}other{Скачивание # файла…}}</translation>
-<translation id="7929962904089429003">Открыть меню</translation>
-<translation id="7942131818088350342">Версия <ph name="PRODUCT_NAME" /> устарела.</translation>
-<translation id="7947953824732555851">Принять и войти</translation>
-<translation id="7963646190083259054">Поставщик:</translation>
-<translation id="7971136598759319605">Последние действия: 1 день назад</translation>
-<translation id="7975379999046275268">Просмотреть страницу <ph name="BEGIN_NEW" />Новинка<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Разрешить предзагрузку страниц для повышения скорости работы браузера и поиска</translation>
-<translation id="79859296434321399">Чтобы просматривать контент в режиме дополненной реальности, установите приложение ARCore.</translation>
-<translation id="7986741934819883144">Выберите контакт</translation>
-<translation id="7987073022710626672">Условия использования Chrome</translation>
-<translation id="7998918019931843664">Восстановить закрытую вкладку</translation>
-<translation id="7999064672810608036">Вы уверены, что хотите удалить все данные этого веб-сайта, включая файлы cookie, и сбросить заданные разрешения?</translation>
-<translation id="8004582292198964060">Браузер</translation>
-<translation id="8007176423574883786">Отключено для этого устройства</translation>
-<translation id="8013372441983637696">Удалить данные Chrome с этого устройства</translation>
-<translation id="8015452622527143194">Восстановить масштаб страницы по умолчанию</translation>
-<translation id="802154636333426148">Ошибка скачивания</translation>
-<translation id="8026334261755873520">Очистить историю</translation>
-<translation id="8035133914807600019">Создать папку…</translation>
-<translation id="8037750541064988519">Осталось <ph name="DAYS" /> дн.</translation>
-<translation id="804335162455518893">SD-карта не найдена</translation>
-<translation id="805047784848435650">На основе вашей истории просмотров</translation>
-<translation id="8051695050440594747">Доступно <ph name="MEGABYTES" /> МБ</translation>
-<translation id="8058746566562539958">Открыть в новой вкладке</translation>
-<translation id="8063895661287329888">Не удалось добавить закладку.</translation>
-<translation id="806745655614357130">Не объединять данные</translation>
-<translation id="8067883171444229417">Смотреть видео</translation>
-<translation id="8068648041423924542">Невозможно выбрать сертификат.</translation>
-<translation id="8073388330009372546">Открыть в новой вкладке</translation>
-<translation id="8076492880354921740">Вкладки</translation>
-<translation id="8084114998886531721">Сохраненный пароль</translation>
-<translation id="8087000398470557479">Контент с сайта <ph name="DOMAIN_NAME" />. Получен с помощью Google.</translation>
-<translation id="8103578431304235997">Вкладка инкогнито</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Чтобы получить доступ к закладкам на всех устройствах, включите синхронизацию.</translation>
-<translation id="8110087112193408731">Показать данные о ваших действиях в Chrome в сервисе "Цифровое благополучие"?</translation>
-<translation id="8116925261070264013">Сайты с отключенным звуком</translation>
-<translation id="813082847718468539">Сведения о сайте</translation>
-<translation id="8131740175452115882">Подтвердить</translation>
-<translation id="8156139159503939589">На каких языках вы читаете?</translation>
-<translation id="8168435359814927499">Контент</translation>
-<translation id="8186512483418048923">Осталось файлов: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Остался 1 день</translation>
-<translation id="8200772114523450471">Возобновить</translation>
-<translation id="8209050860603202033">Открыть изображение</translation>
-<translation id="8218622182176210845">Управление аккаунтом</translation>
-<translation id="8224471946457685718">Скачивать "Статьи для вас" только по Wi-Fi</translation>
-<translation id="8232956427053453090">Не удалять данные</translation>
-<translation id="8249310407154411074">Переместить в начало</translation>
-<translation id="8250920743982581267">Документы</translation>
-<translation id="825412236959742607">Эта страница расходовала слишком много памяти, поэтому часть контента была удалена.</translation>
-<translation id="8260126382462817229">Снова войдите в аккаунт</translation>
-<translation id="8261506727792406068">Удалить</translation>
-<translation id="8266862848225348053">Расположение скачиваемых файлов</translation>
-<translation id="8274165955039650276">Показать скачанные файлы</translation>
-<translation id="8284326494547611709">Титры</translation>
-<translation id="8300705686683892304">Под управлением приложения</translation>
-<translation id="8310344678080805313">Обычные вкладки</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> и другие сайты</translation>
-<translation id="8327155640814342956">Чтобы работать в браузере было удобнее, откройте Chrome и установите обновление.</translation>
-<translation id="8339163506404995330">Страницы на этом языке (<ph name="LANGUAGE" />) не будут переводиться автоматически</translation>
-<translation id="8349013245300336738">Сортировать по объему использованного трафика</translation>
-<translation id="8364299278605033898">Показать популярные сайты</translation>
-<translation id="8368027906805972958">Неизвестное или неподдерживаемое устройство (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Разрешить фоновую синхронизацию для конкретного сайта.</translation>
-<translation id="8378714024927312812">Управляется вашей организацией</translation>
-<translation id="8380167699614421159">Этот сайт показывает навязчивую или вводящую в заблуждение рекламу</translation>
-<translation id="8393700583063109961">Отправить сообщение</translation>
-<translation id="8413126021676339697">Показать всю историю</translation>
-<translation id="8427875596167638501">Вкладка предпросмотра открыта на половину высоты</translation>
-<translation id="8428213095426709021">Настройки</translation>
-<translation id="8438566539970814960">Помогать улучшить просмотр страниц и поиск</translation>
-<translation id="8441146129660941386">Перемотать назад</translation>
-<translation id="8443209985646068659">Не удалось обновить Chrome</translation>
-<translation id="8445448999790540984">Не удалось экспортировать пароли</translation>
-<translation id="8447861592752582886">Отключить доступ к устройству</translation>
-<translation id="8461694314515752532">Задать кодовую фразу для шифрования синхронизированных данных</translation>
-<translation id="8466613982764129868">Проверьте, подключено ли устройство <ph name="TARGET_DEVICE_NAME" /> к Интернету.</translation>
-<translation id="8485434340281759656"><ph name="DESCRIPTION" /> <ph name="FILE_SIZE" /> <ph name="SEPARATOR" /></translation>
-<translation id="8487700953926739672">Доступно в автономном режиме</translation>
-<translation id="8489271220582375723">Открыть страницу "История"</translation>
-<translation id="8493948351860045254">Освободить место</translation>
-<translation id="8497726226069778601">Здесь появятся часто посещаемые страницы</translation>
-<translation id="8503559462189395349">Пароли Chrome</translation>
-<translation id="8503813439785031346">Имя пользователя</translation>
-<translation id="8514477925623180633">Экспорт паролей, сохраненных в Chrome</translation>
-<translation id="8514577642972634246">Включить режим инкогнито</translation>
-<translation id="851751545965956758">Не разрешать сайтам подключаться к устройствам</translation>
-<translation id="8523928698583292556">Удалить сохраненный пароль</translation>
-<translation id="854522910157234410">Открыть эту страницу</translation>
-<translation id="8558485628462305855">Чтобы просматривать контент в режиме дополненной реальности, обновите приложение ARCore.</translation>
-<translation id="8559990750235505898">Предлагать перевести страницы на других языках</translation>
-<translation id="8562452229998620586">Здесь будут показаны сохраненные пароли.</translation>
-<translation id="8569404424186215731">с <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Последние 4 недели</translation>
-<translation id="857943718398505171">Разрешено (рекомендуется)</translation>
-<translation id="8583805026567836021">Удаление данных аккаунта</translation>
-<translation id="860043288473659153">Имя владельца карты</translation>
-<translation id="8609465669617005112">Переместить вверх</translation>
-<translation id="8616006591992756292">Информация о других ваших действиях в Интернете может также храниться на странице <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Открыть предложенный URL из скачанного контента?</translation>
-<translation id="8636825310635137004">Чтобы получить доступ к вкладкам на всех ваших устройствах, включите синхронизацию.</translation>
-<translation id="8641930654639604085">Блокировать сайты для взрослых</translation>
-<translation id="8655129584991699539">Удалить данные можно в настройках Chrome</translation>
-<translation id="8662811608048051533">Вы автоматически выйдете из учетных записей на большинстве сайтов.</translation>
-<translation id="8664979001105139458">Файл с таким именем уже существует.</translation>
-<translation id="8676374126336081632">Очистить</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Уровень сигнала: # линия}one{Уровень сигнала: # линия}few{Уровень сигнала: # линии}many{Уровень сигнала: # линий}other{Уровень сигнала: # линии}}</translation>
-<translation id="868929229000858085">Поиск контактов</translation>
-<translation id="869891660844655955">Срок действия</translation>
-<translation id="8719023831149562936">Не удалось передать текущую вкладку</translation>
-<translation id="8725066075913043281">Повторить попытку</translation>
-<translation id="8728487861892616501">Используя это приложение, вы соглашаетесь с <ph name="BEGIN_LINK1" />Условиями использования<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Примечанием о конфиденциальности<ph name="END_LINK2" /> Chrome, а также с <ph name="BEGIN_LINK3" />Примечанием о конфиденциальности для аккаунтов Google, управляемых с помощью Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Готово</translation>
-<translation id="8748850008226585750">Содержимое скрыто</translation>
-<translation id="8751914237388039244">Выберите фото</translation>
-<translation id="8788265440806329501">История переходов закрыта</translation>
-<translation id="8788968922598763114">Открыть последнюю закрытую вкладку</translation>
-<translation id="8801436777607969138">Блокировать код JavaScript на определенном сайте.</translation>
-<translation id="8812260976093120287">На некоторых сайтах вы можете совершать платежи со своего устройства с помощью перечисленных выше приложений.</translation>
-<translation id="8816026460808729765">Закрыть сайтам доступ к датчикам</translation>
-<translation id="8816439037877937734">Приложение "<ph name="APP_NAME" />" откроется в Chrome. Продолжая, вы соглашаетесь с <ph name="BEGIN_LINK1" />Условиями использования<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Примечанием о конфиденциальности<ph name="END_LINK2" /> Chrome, а также с <ph name="BEGIN_LINK3" />Примечанием о конфиденциальности для аккаунтов Google, управляемых с помощью Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Закладки</translation>
-<translation id="8833831881926404480">Сайту предоставлен доступ к вашему экрану</translation>
-<translation id="883806473910249246">При скачивании контента произошла ошибка.</translation>
-<translation id="8840953339110955557">Страница может отличаться от онлайн-версии.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Вкладка "<ph name="TAB_TITLE" />"</translation>
-<translation id="885701979325669005">Хранилище</translation>
-<translation id="889338405075704026">Открыть настройки Chrome</translation>
-<translation id="8901170036886848654">Ничего не найдено</translation>
-<translation id="8909135823018751308">Поделиться...</translation>
-<translation id="8912362522468806198">Аккаунт Google</translation>
-<translation id="8920114477895755567">Недостаточно данных о родителях.</translation>
+<translation id="1188239144602654184">Начать</translation>
+<translation id="473775607612524610">Обновить</translation>
+<translation id="3133489217401741157">Установка модуля "<ph name="MODULE"/>" для Brave…</translation>
+<translation id="1791662854739702043">Установлено</translation>
+<translation id="5131234170665854056">Не удается установить модуль "<ph name="MODULE"/>" для Brave</translation>
+<translation id="2567385386134582609">ИЗОБРАЖЕНИЕ</translation>
+<translation id="6395288395575013217">ССЫЛКА</translation>
+<translation id="7352939065658542140">ВИДЕО</translation>
+<translation id="4116038641877404294">Скачивайте страницы и открывайте их без подключения к Интернету</translation>
 <translation id="8922289737868596582">Скачивайте страницы через меню кнопки "Ещё" и открывайте их без подключения к Интернету</translation>
-<translation id="8937772741022875483">Удалить данные о ваших действиях в Chrome из сервиса "Цифровое благополучие"?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Открыть в новом окне</translation>
-<translation id="8951232171465285730">Благодаря Chrome вы сэкономили <ph name="MEGABYTES" /> МБ свободного места</translation>
-<translation id="8958424370300090006">Блокировать файлы cookie для определенного сайта.</translation>
-<translation id="8959122750345127698">Страница не найдена: <ph name="URL" /></translation>
-<translation id="8965591936373831584">ожидание</translation>
-<translation id="8970887620466824814">Произошла ошибка</translation>
-<translation id="8972098258593396643">Скачать в папку по умолчанию?</translation>
-<translation id="8986494364107987395">Автоматически отправлять в Google статистику использования и отчеты о сбоях</translation>
-<translation id="8993760627012879038">Открыть новое окно в режиме инкогнито</translation>
-<translation id="8998729206196772491">Вы входите в аккаунт, которым управляет администратор домена <ph name="MANAGED_DOMAIN" />. Он может контролировать ваши данные Chrome, которые теперь будут связаны с управляемым аккаунтом. При выходе из системы все данные Chrome, хранящиеся на этом устройстве, будут удалены, но останутся в вашем аккаунте Google.</translation>
-<translation id="9019902583201351841">Управляется вашими родителями</translation>
-<translation id="9028914725102941583">Включите синхронизацию</translation>
-<translation id="9029323097866369874">Разрешить сайту <ph name="DOMAIN" /> входить в виртуальную реальность?</translation>
-<translation id="9040142327097499898">Отправка уведомлений разрешена, но определение местоположения отключено.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# видеофайл}one{# видеофайл}few{# видеофайла}many{# видеофайлов}other{# видеофайла}}</translation>
-<translation id="9050666287014529139">Кодовая фраза</translation>
-<translation id="9063523880881406963">Выключить полную версию сайта</translation>
-<translation id="9065203028668620118">Изменить</translation>
-<translation id="9070377983101773829">Голосовой поиск</translation>
-<translation id="9074336505530349563">Чтобы мы могли рекомендовать вам интересный контент, войдите в аккаунт и включите синхронизацию.</translation>
-<translation id="9086455579313502267">Нет доступа к сети</translation>
-<translation id="9100505651305367705">Предлагать упрощенный просмотр статей, если он поддерживается</translation>
-<translation id="9100610230175265781">Необходима кодовая фраза</translation>
-<translation id="9102803872260866941">Вкладка предпросмотра открыта</translation>
+<translation id="5958275228015807058">Скачанные файлы и веб-страницы хранятся в одноименном разделе.</translation>
+<translation id="5620928963363755975">Чтобы найти скачанные файлы и веб-страницы, нажмите кнопку "Ещё" и выберите соответствующий пункт</translation>
+<translation id="3341058695485821946">Узнайте, сколько трафика вы сэкономили.</translation>
+<translation id="3157842584138209013">Чтобы узнать, сколько трафика вы сэкономили, нажмите кнопку "Ещё"</translation>
+<translation id="8218622182176210845">Управление аккаунтом</translation>
+<translation id="8090895580117672212">Чтобы перейти к управлению аккаунтом Brave Software, нажмите кнопку "Настройки аккаунта"</translation>
+<translation id="8856898588039823173">Lite-версия страницы получена с помощью Brave Software. Нажмите, чтобы загрузить оригинал.</translation>
+<translation id="8134317863207426198">Lite-версия страницы получена с помощью Brave Software. Нажмите кнопку "Полная версия", чтобы загрузить оригинал.</translation>
+<translation id="4961107849584082341">Эту страницу можно перевести на любой язык</translation>
+<translation id="569536719314091526">Чтобы перевести эту страницу на какой-либо язык, нажмите кнопку "Ещё"</translation>
+<translation id="1397811292916898096">Поиск в <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Вы можете в любой момент изменить расположение скачиваемых файлов по умолчанию.</translation>
+<translation id="6942665639005891494">Вы можете в любой момент изменить расположение скачиваемых файлов по умолчанию, воспользовавшись меню "Настройки".</translation>
+<translation id="6850409657436465440">Выполняется скачивание</translation>
+<translation id="5817715962196959877">Теперь файлы в Brave будут скачиваться ещё быстрее</translation>
+<translation id="3976396876660209797">Удалите этот ярлык и создайте его заново</translation>
+<translation id="6766622839693428701">Проведите вниз, чтобы закрыть панель.</translation>
+<translation id="1028699632127661925">Отправка на устройство "<ph name="DEVICE_NAME"/>"…</translation>
+<translation id="1303507811548703290">Домен: <ph name="DOMAIN"/>. Отправлено с устройства "<ph name="DEVICE_NAME"/>".</translation>
+<translation id="5357811892247919462">Вкладка получена.</translation>
 <translation id="9104217018994036254">Список устройств для отправки вкладки.</translation>
-<translation id="9133397713400217035">Офлайн-контент</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Показать оригинал</translation>
-<translation id="9139068048179869749">Запрашивать разрешение на отправку уведомлений (рекомендуется)</translation>
-<translation id="9139318394846604261">Покупки</translation>
-<translation id="9155898266292537608">Также можно выполнить поиск, нажав на слово.</translation>
-<translation id="9169507124922466868">История переходов открыта наполовину</translation>
-<translation id="9204836675896933765">Остался 1 файл</translation>
-<translation id="9206873250291191720">А</translation>
+<translation id="6767294960381293877">Список устройств для отправки вкладки развернут на половину экрана.</translation>
+<translation id="2904414404539560095">Список устройств для отправки вкладки развернут на весь экран.</translation>
+<translation id="4135200667068010335">Список устройств для отправки вкладки закрыт.</translation>
+<translation id="5292796745632149097">Куда отправить</translation>
+<translation id="1386674309198842382">Последние действия: <ph name="LAST_UPDATED"/> дн. назад</translation>
+<translation id="7971136598759319605">Последние действия: 1 день назад</translation>
+<translation id="1521774566618522728">Последние действия: сегодня</translation>
+<translation id="3631987586758005671">Отправка на устройство "<ph name="DEVICE_NAME"/>"…</translation>
+<translation id="9028914725102941583">Включите синхронизацию</translation>
+<translation id="6162454065885854378">Чтобы поделиться контентом, откройте настройки Brave на своем телефоне и другом устройстве, а затем включите синхронизацию.</translation>
+<translation id="6084271560289605378">Открыть настройки Brave</translation>
+<translation id="2318045970523081853">Нажмите, чтобы позвонить.</translation>
 <translation id="9209888181064652401">Звонки недоступны</translation>
-<translation id="9219103736887031265">Картинки</translation>
-<translation id="926205370408745186">Удалить данные о действиях в Chrome из сервиса "Цифровое благополучие"</translation>
-<translation id="932327136139879170">Главная страница</translation>
-<translation id="938850635132480979">Ошибка <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Доступ к микрофону</translation>
-<translation id="95817756606698420">В Китае Chrome может использовать для поиска <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />. Это можно изменить в <ph name="BEGIN_LINK" />Настройках<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Блокировать, если сайт показывает навязчивую или вводящую в заблуждение рекламу (рекомендуется)</translation>
-<translation id="968900484120156207">Здесь будут страницы, которые вы посещали.</translation>
-<translation id="970715775301869095">Осталось <ph name="MINUTES" /> мин.</translation>
-<translation id="974555521953189084">Чтобы начать синхронизацию, введите кодовую фразу</translation>
-<translation id="981121421437150478">Офлайн</translation>
-<translation id="982182592107339124">Будут удалены данные всех сайтов, в том числе:</translation>
-<translation id="983192555821071799">Закрыть все вкладки</translation>
-<translation id="987264212798334818">Общие</translation>
+<translation id="2860954141821109167">Убедитесь, что на устройстве есть приложение "Телефон".</translation>
+<translation id="2067805253194386918">текст</translation>
+<translation id="1450753235335490080">Не удается отправить: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Не удалось отправить: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Убедитесь, что в браузере Brave на устройстве <ph name="TARGET_DEVICE_NAME"/> включена синхронизация.</translation>
+<translation id="3016635187733453316">Убедитесь, что устройство подключено к Интернету.</translation>
+<translation id="8466613982764129868">Проверьте, подключено ли устройство <ph name="TARGET_DEVICE_NAME"/> к Интернету.</translation>
+<translation id="6539092367496845964">Произошла ошибка. Повторите попытку позже.</translation>
+<translation id="3389286852084373014">Сообщение слишком длинное</translation>
+<translation id="2100314319871056947">Перед отправкой разбейте текст на несколько частей.</translation>
+<translation id="2987620471460279764">Текст, полученный с другого устройства</translation>
+<translation id="7757787379047923882">Текст с устройства <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Скопировано в буфер обмена.</translation>
+<translation id="4696983787092045100">Отправить сообщения на свои устройства</translation>
+<translation id="1260236875608242557">Поиск и рекомендации</translation>
+<translation id="6369229450655021117">Здесь вы можете искать информацию онлайн, отправлять ее друзьям и просматривать открытые страницы</translation>
+<translation id="723171743924126238">Выберите изображения</translation>
+<translation id="8751914237388039244">Выберите фото</translation>
+<translation id="1989112275319619282">Выбрать</translation>
+<translation id="7055152154916055070">Заблокирована попытка переадресации:</translation>
+<translation id="5524843473235508879">Попытка переадресации заблокирована.</translation>
+<translation id="6573096386450695060">Разрешать всегда</translation>
+<translation id="5805364706385912897">Эта страница расходовала слишком много памяти, поэтому работа ее скриптов была приостановлена.</translation>
+<translation id="5138664332909611586">Эта страница расходовала слишком много памяти, поэтому часть контента была удалена.</translation>
+<translation id="9137013805542155359">Показать оригинал</translation>
+<translation id="6361779936989026201">Brave Software Ассистент в Brave</translation>
+<translation id="7291387454912369099">Оплата через Ассистента</translation>
+<translation id="4565206163201411670">Показать данные о ваших действиях в Brave в сервисе "Цифровое благополучие"?</translation>
+<translation id="9055113864158719823">Вы сможете просматривать список сайтов, посещенных в Brave, и устанавливать для них таймеры.\n\nВ Brave Software будут отправляться сведения о сайтах, для которых настроены таймеры, и времени их посещения. Мы собираем эти данные, чтобы улучшать сервис "Цифровое благополучие".</translation>
+<translation id="4596514158372210596">Удалить данные о действиях в Brave из сервиса "Цифровое благополучие"</translation>
+<translation id="1174893863889683998">Удалить данные о ваших действиях в Brave из сервиса "Цифровое благополучие"?</translation>
+<translation id="708829030563435351">В сервисе больше не будут отображаться данные о сайтах, которые вы посещаете в Brave. Кроме того, будут удалены все таймеры сайтов.</translation>
+<translation id="2056878612599315956">Доступ к сайту приостановлен</translation>
+<translation id="671481426037969117">Время на таймере <ph name="FQDN"/> истекло. Завтра сайт снова станет доступен.</translation>
+<translation id="7479104141328977413">Управление вкладками</translation>
+<translation id="3524138585025253783">Интерфейс разработчика</translation>
+<translation id="6036057147555329831">Дополнительный модуль ICU</translation>
+<translation id="9029323097866369874">Разрешить сайту <ph name="DOMAIN"/> входить в виртуальную реальность?</translation>
+<translation id="7685301384041462804">Прежде чем войти в виртуальную реальность, убедитесь, что этот сайт безопасен.</translation>
+<translation id="5033865233969348410">В режиме виртуальной реальности этот сайт может определять:
+   – ваши внешние черты, например рост.
+
+Предоставляйте доступ только тем сайтам, которым вы доверяете.</translation>
+<translation id="5534334044554683961">В режиме виртуальной реальности этот сайт может определять:
+   – ваши внешние черты, например рост;
+   – планировку вашей комнаты.
+
+Предоставляйте доступ только тем сайтам, которым вы доверяете.</translation>
+<translation id="4169535189173047238">Запретить</translation>
+<translation id="2170088579611075216">Разрешить и войти в VR-режим</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_sk.xtb
+++ b/android/java/strings/translations/android_chrome_strings_sk.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="sk">
-<translation id="1006017844123154345">Otvoriť online</translation>
-<translation id="1028699632127661925">Odosiela sa do zariadenia <ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">Pridáva sa <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Z webov</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Nikdy neukladať</translation>
-<translation id="1067922213147265141">Ďalšie služby Googlu</translation>
-<translation id="1068672505746868501">Nikdy neprekladať stránky v jazyku <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Ak zmeníte príponu súboru, súbor sa môže otvoriť v inej aplikácii a potenciálne ohroziť vaše zariadenie.</translation>
-<translation id="1100066534610197918">Otvoriť v skupine na novej karte</translation>
-<translation id="1105960400813249514">Snímanie obrazovky</translation>
-<translation id="1111673857033749125">Tu sa zobrazia záložky, ktoré ste uložili na iných zariadeniach.</translation>
-<translation id="1113597929977215864">Aktivovať zjednodušené zobrazenie</translation>
-<translation id="1121094540300013208">Správy o použití a o zlyhaní</translation>
-<translation id="1124772482545689468">Používateľ</translation>
-<translation id="1129510026454351943">Podrobnosti: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Na stiahnutie čaká 1 položka.}few{Na stiahnutie čakajú # položky.}many{# downloads pending.}other{Na stiahnutie čaká # položiek.}}</translation>
-<translation id="1145536944570833626">Odstrániť existujúce dáta.</translation>
-<translation id="1146678959555564648">Zadať VR</translation>
-<translation id="116280672541001035">Použité</translation>
-<translation id="1171770572613082465">Klepnutím na tlačidlo Hlavné weby zobrazíte obľúbené webové stránky</translation>
-<translation id="1173894706177603556">Premenovať</translation>
-<translation id="1178581264944972037">Pozastaviť</translation>
-<translation id="1181037720776840403">Odstrániť</translation>
-<translation id="1188239144602654184">Spustiť VR</translation>
-<translation id="1197267115302279827">Presunúť záložky</translation>
-<translation id="119944043368869598">Vymazať všetko</translation>
-<translation id="1201402288615127009">Ďalej</translation>
-<translation id="1204037785786432551">Stiahnuť obsah odkazu</translation>
-<translation id="1206892813135768548">Kopírovať text odkazu</translation>
-<translation id="1208340532756947324">Ak chcete synchronizovať a prispôsobovať viaceré zariadenia, zapnite synchronizáciu</translation>
-<translation id="1209206284964581585">Skryť</translation>
-<translation id="1227058898775614466">História navigácie</translation>
-<translation id="1231733316453485619">Chcete zapnúť synchronizáciu?</translation>
-<translation id="123724288017357924">Opätovné načítanie aktuálnej stránky a ignorovanie obsahu vo vyrovnávacej pamäti</translation>
-<translation id="124116460088058876">Ďalšie jazyky</translation>
-<translation id="124678866338384709">Zavretie aktuálnej karty</translation>
-<translation id="1258753120186372309">Sviatočné logo Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Prehľadať a preskúmať</translation>
-<translation id="1264974993859112054">Šport</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> sa nepodarilo zdieľať</translation>
-<translation id="1272079795634619415">Zastaviť</translation>
-<translation id="1283039547216852943">Klepnutím rozbaliť</translation>
-<translation id="1285320974508926690">Nikdy neprekladať tieto webové stránky</translation>
-<translation id="1291207594882862231">Vymazať históriu, súbory cookie, dáta webov, vyrovnávaciu pamäť…</translation>
-<translation id="129382876167171263">Tu sa zobrazia súbory uložené webmi</translation>
-<translation id="129553762522093515">Nedávno zatvorené</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – odoslané zo zariadenia <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Zoskupiť karty</translation>
-<translation id="1327257854815634930">História navigácie je otvorená</translation>
-<translation id="1331212799747679585">Chrome sa nedá aktualizovať. Ďalšie možnosti</translation>
-<translation id="1332501820983677155">Skratky pre funkcie prehliadača Google Chrome</translation>
-<translation id="1360432990279830238">Odhlásiť sa a vypnúť synchronizáciu?</translation>
-<translation id="1369915414381695676">Boli pridané stránky <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Vybraný obsah nie je možné stiahnuť z dôvodu nedostatku pamäte</translation>
-<translation id="1376578503827013741">Vypočítava sa…</translation>
-<translation id="1383876407941801731">Vyhľadávanie</translation>
-<translation id="1384959399684842514">Sťahovanie bolo pozastavené</translation>
-<translation id="1386674309198842382">Aktívne pred <ph name="LAST_UPDATED" /> dňami</translation>
-<translation id="1397811292916898096">Hľadať pomocou vyhľadávača <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Vložené na webe <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Nesledovať</translation>
-<translation id="1407135791313364759">Otvoriť všetko</translation>
-<translation id="1409426117486808224">Jednoduché zobrazenie otvorených kariet</translation>
-<translation id="1409879593029778104">Sťahovanie súboru <ph name="FILE_NAME" /> bolo zrušené, pretože daný súbor už existuje.</translation>
-<translation id="1414981605391750300">Kontaktuje sa Google. Môže to chvíľu trvať…</translation>
-<translation id="1416550906796893042">Verzia aplikácie</translation>
-<translation id="1430915738399379752">Tlačiť</translation>
-<translation id="1446450296470737166">Povoliť úplné ovlád. zar. MIDI</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> sa nedá zdieľať</translation>
-<translation id="145097072038377568">Vypnuté v nastaveniach Androidu</translation>
-<translation id="1477626028522505441">Súbor <ph name="FILE_NAME" /> sa nepodarilo stiahnuť z dôvodu problémov so serverom.</translation>
-<translation id="1506061864768559482">Vyhľadávač</translation>
-<translation id="1513352483775369820">Záložky a webová história</translation>
-<translation id="1513858653616922153">Odstrániť heslo</translation>
-<translation id="1516229014686355813">Vyhľadávanie klepnutím odošle vybraté slovo a súčasnú stránku ako kontext do Vyhľadávania Google. Môžete ho vypnúť v <ph name="BEGIN_LINK" />Nastaveniach<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktívne dnes</translation>
-<translation id="1544826120773021464">Ak chcete spravovať svoj účet Google, klepnite na tlačidlo Spravovať účet</translation>
-<translation id="1549000191223877751">Prejsť do druhého okna</translation>
-<translation id="1553358976309200471">Aktualizovať Chrome</translation>
-<translation id="1569387923882100876">Pripojené zariadenie</translation>
-<translation id="1571304935088121812">Kopírovať používateľské meno</translation>
-<translation id="1612196535745283361">Na to, aby mohol Chrome hľadať zariadenia, musí mať prístup k polohe. Prístup k polohe je v tomto zariadení <ph name="BEGIN_LINK" />vypnutý<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Zakázať tejto stránke otvárať ďalšie dialógové okná</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Odstrániť 1 vybranú položku}few{Odstrániť # vybrané položky}many{Odstrániť # vybranej položky}other{Odstrániť # vybraných položiek}}</translation>
-<translation id="164269334534774161">Zobrazuje sa offline kópia tejto stránky z <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">História</translation>
-<translation id="1647391597548383849">Prístup ku kamere</translation>
-<translation id="1660204651932907780">Povoliť webom prehrávať zvuk (odporúčané)</translation>
-<translation id="1670399744444387456">Základné</translation>
-<translation id="1671236975893690980">Čaká sa na stiahnutie…</translation>
-<translation id="1672586136351118594">Nabudúce nezobrazovať</translation>
-<translation id="1692118695553449118">Synchronizácia je zapnutá.</translation>
-<translation id="169515064810179024">Blokovať webom prístup k senzorom pohybu</translation>
-<translation id="1717218214683051432">Senzory pohybu</translation>
-<translation id="1718835860248848330">Posledná hodina</translation>
-<translation id="1736419249208073774">Preskúmať</translation>
-<translation id="1743802530341753419">Pýtať sa, či chcete povoliť webu pripojiť sa k zariadeniu (odporúčané)</translation>
-<translation id="1749561566933687563">Synchronizujte svoje záložky</translation>
-<translation id="17513872634828108">Otvorené karty</translation>
-<translation id="1779089405699405702">Dekodér obrázkov</translation>
-<translation id="1782483593938241562">Dátum ukončenia: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Nainštalovaný</translation>
-<translation id="1792959175193046959">Kedykoľvek zmeniť predvolené umiestnenie stiahnutých súborov</translation>
-<translation id="1807246157184219062">Svetlý režim</translation>
-<translation id="1810845389119482123">Úvodné nastavenie synchronizácie nebolo dokončené</translation>
-<translation id="1821253160463689938">Používa súbory cookie na zapamätanie si predvolieb, dokonca aj keď dané stránky nenavštívite</translation>
-<translation id="1829244130665387512">Nájsť na stránke</translation>
-<translation id="1853692000353488670">Nová karta inkognito</translation>
-<translation id="1856325424225101786">Chcete zjednodušený režim obnoviť?</translation>
-<translation id="1868024384445905608">Chrome teraz sťahuje súbory rýchlejšie</translation>
-<translation id="1883903952484604915">Moje súbory</translation>
-<translation id="1887786770086287077">Prístup k polohe je v tomto zariadení vypnutý. Zapnite ho v <ph name="BEGIN_LINK" />Nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> sa otvorí v Chrome. Pokračovaním vyjadrujete súhlas so <ph name="BEGIN_LINK1" />zmluvnými podmienkami<ph name="END_LINK1" /> a <ph name="BEGIN_LINK2" />upozornením o ochrane súkromia<ph name="END_LINK2" /> Chromu.</translation>
-<translation id="1919345977826869612">Reklamy</translation>
-<translation id="1919950603503897840">Výber kontaktov</translation>
-<translation id="1922076542920281912">Ak chcete povoliť Chromu používať vašu polohu, zapnite ju aj v <ph name="BEGIN_LINK" />Nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Aktualizácie</translation>
-<translation id="19288952978244135">Znova otvorte Chrome.</translation>
-<translation id="1933845786846280168">Vybratá karta</translation>
-<translation id="194341124344773587">Zapnite povolenie pre Chrome v <ph name="BEGIN_LINK" />nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Ukladať heslá</translation>
-<translation id="1952172573699511566">Ak to bude možné, weby budú zobrazovať text vo vašom preferovanom jazyku.</translation>
-<translation id="1960290143419248813">Pre túto verziu Androidu už nie sú podporované aktualizácie Chromu</translation>
-<translation id="1966710179511230534">Aktualizujte svoje prihlasovacie údaje.</translation>
-<translation id="1974060860693918893">Rozšírené</translation>
-<translation id="1984705450038014246">Synchronizovať údaje Chromu</translation>
-<translation id="1984937141057606926">Povolené (okrem tretích strán)</translation>
-<translation id="1986685561493779662">Názov už existuje</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> tlačidlo <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Prehliadať</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> žiada o spárovanie</translation>
-<translation id="1994173015038366702">Webová adresa</translation>
-<translation id="2000419248597011803">Odošle niektoré súbory cookie a vyhľadávania z panela s adresou a vyhľadávacieho poľa do vášho predvoleného vyhľadávača</translation>
-<translation id="2002537628803770967">Kreditné karty a adresy pomocou služby Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# súbor}few{# súbory}many{# Files}other{# súborov}}</translation>
-<translation id="2017836877785168846">Vymaže históriu a automaticky doplňované výrazy v paneli s adresou.</translation>
-<translation id="2021896219286479412">Ovládanie webu na celú obrazovku</translation>
-<translation id="2038563949887743358">Zapnutie žiadosti o verziu stránok pre počítače</translation>
-<translation id="2041019821020695769">Ak chcete povoliť Chromu odosielať vám upozornenia, zapnite ich aj v <ph name="BEGIN_LINK" />Nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">V Chrome má údaje aj aplikácia <ph name="APP_NAME" />.</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Web je pozastavený</translation>
-<translation id="2063713494490388661">Vyhľadávanie klepnutím</translation>
-<translation id="2067805253194386918">text</translation>
-<translation id="2079545284768500474">Späť</translation>
-<translation id="2082238445998314030">Výsledok <ph name="RESULT_NUMBER" /> z <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Zvuk</translation>
-<translation id="2096012225669085171">Synchronizovať a prispôsobiť v rôznych zariadeniach</translation>
-<translation id="2100273922101894616">Automaticky prihlasovať</translation>
-<translation id="2100314319871056947">Skúste text zdieľať po menších častiach</translation>
-<translation id="2107397443965016585">Pýtať sa, či chcete povoliť webu prehrávať chránený obsah (odporúčané)</translation>
-<translation id="2111511281910874386">Prejdite na stránku</translation>
-<translation id="2122601567107267586">Aplikáciu sa nepodarilo otvoriť</translation>
-<translation id="2126426811489709554">Používa technológiu prehliadača Chrome</translation>
-<translation id="2131665479022868825">Uložené: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Karta <ph name="TAB_TITLE" /> je zavretá</translation>
-<translation id="2139186145475833000">Pridať na plochu</translation>
-<translation id="2146738493024040262">Otvoriť okamžitú aplikáciu</translation>
-<translation id="2148716181193084225">Dnes</translation>
-<translation id="2154484045852737596">Úprava karty</translation>
-<translation id="2154710561487035718">Kopírovať webovú adresu</translation>
-<translation id="2156074688469523661">Zostávajúce weby (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Ak chcete niečo zo svojho telefónu zdieľať s iným zariadením, zapnite v oboch synchronizáciu v nastaveniach Chromu</translation>
-<translation id="2170088579611075216">Povoliť a vstúpiť do VR</translation>
-<translation id="218608176142494674">Zdieľanie</translation>
-<translation id="2227444325776770048">Pokračovať ako <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synchronizácia a služby Googlu</translation>
-<translation id="2259659629660284697">Exportovať heslá…</translation>
-<translation id="2268044343513325586">Upraviť</translation>
-<translation id="2286841657746966508">Fakturačná adresa</translation>
-<translation id="2289270750774289114">Opýtať sa, keď chce web objavovať zariadenia Bluetooth v okolí (odporúčané)</translation>
-<translation id="230115972905494466">Nenašli sa žiadne kompatibilné zariadenia</translation>
-<translation id="2315043854645842844">Operačný systém nepodporuje výber certifikátu na strane klienta.</translation>
-<translation id="2318045970523081853">Zavolajte klepnutím</translation>
-<translation id="2321086116217818302">Pripravujú sa heslá…</translation>
-<translation id="2321958826496381788">Presúvajte posúvač, dokým nebude čítanie tohto textu pohodlné. Po dvojitom klepnutí na odsek by mal byť text aspoň takto veľký.</translation>
-<translation id="2323763861024343754">Úložisko webu</translation>
-<translation id="2328985652426384049">Nedá sa prihlásiť</translation>
-<translation id="2330129964253841015">Upozorňovať pri odhalení hesiel</translation>
-<translation id="2349710944427398404">Celkové dáta využívané Chromom vrátane účtov, záložiek a uložených nastavení</translation>
-<translation id="2353636109065292463">Kontroluje sa internetové pripojenie</translation>
-<translation id="2359808026110333948">Pokračovať</translation>
-<translation id="2369533728426058518">otvorené karty</translation>
-<translation id="2387895666653383613">Mierka textu</translation>
-<translation id="2394602618534698961">Tu sa zobrazia stiahnuté súbory</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Keď sa prihlásite do svojho účtu Google, táto funkcia je zapnutá</translation>
-<translation id="2410754283952462441">Výber účtu</translation>
-<translation id="2414886740292270097">Tmavý režim</translation>
-<translation id="2416359993254398973">Chrome potrebuje povolenie pre tento web na prístup k vášmu fotoaparátu.</translation>
-<translation id="2426805022920575512">Vybrať iný účet</translation>
-<translation id="2433507940547922241">Vzhľad</translation>
-<translation id="2434158240863470628">Sťahovanie bolo dokončené <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Prístup k polohe</translation>
-<translation id="2450083983707403292">Chcete znovu spustiť sťahovanie súboru <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Upozornenia</translation>
-<translation id="2490684707762498678">Spravuje <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Asistent Google v Chrome</translation>
-<translation id="2496180316473517155">História prehliadania</translation>
-<translation id="2497852260688568942">Synchronizácia je zakázaná správcom</translation>
-<translation id="2498359688066513246">Pomocník a spätná väzba</translation>
-<translation id="2501278716633472235">Prejsť späť</translation>
-<translation id="2513403576141822879">Ďalšie nastavenia týkajúce sa ochrany súkromia, zabezpečenia a zhromažďovania dát nájdete v časti <ph name="BEGIN_LINK" />Synchronizácia a služby Googlu<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">V zjednodušenom režime načítava Chrome stránky rýchlejšie a využíva až o 60 percent menej dát. Chrome odosiela údaje o vašej návštevnosti webu do Googlu, ktorý na základe nich optimalizuje vami navštevované stránky. <ph name="BEGIN_LINK" />Ďalšie informácie<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Odosiela Googlu webové adresy navštívených stránok</translation>
-<translation id="2532336938189706096">Webové zobrazenie</translation>
-<translation id="2534155362429831547">Odstránené položky: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Zobrazuje sa offline kópia tejto stránky</translation>
-<translation id="2546283357679194313">Súbory cookie a dáta webov</translation>
-<translation id="2567385386134582609">OBRÁZOK</translation>
-<translation id="257088987046510401">Motívy</translation>
-<translation id="2570922361219980984">Prístup k polohe je vypnutý aj v tomto zariadení. Zapnite ho v <ph name="BEGIN_LINK" />Nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Rozbalená (zbalíte ju kliknutím)</translation>
-<translation id="2581165646603367611">Táto akcia vymaže súbory cookie, vyrovnávaciu pamäť a ďalšie údaje webov, ktoré Chrome nepovažuje za dôležité.</translation>
-<translation id="2586657967955657006">Schránka</translation>
-<translation id="2587052924345400782">Je dostupná novšia verzia</translation>
-<translation id="2593272815202181319">Neproporcionálne</translation>
-<translation id="2612676031748830579">Číslo karty</translation>
-<translation id="2621115761605608342">Povoliť JavaScript pre konkrétny web.</translation>
-<translation id="2625189173221582860">Heslo bolo skopírované.</translation>
-<translation id="2631006050119455616">Uložené</translation>
-<translation id="2647434099613338025">Pridať jazyk</translation>
-<translation id="2650751991977523696">Stiahnuť súbor znova?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# zvukový súbor}few{# zvukové súbory}many{# Audio files}other{# zvukových súborov}}</translation>
-<translation id="2653659639078652383">Odoslať</translation>
-<translation id="2677748264148917807">Odísť</translation>
-<translation id="2704606927547763573">Skopírované</translation>
-<translation id="2707726405694321444">Obnoviť stránku</translation>
-<translation id="2709516037105925701">Automatické dopĺňanie</translation>
-<translation id="2717722538473713889">E‑mailové adresy</translation>
-<translation id="2728754400939377704">Zoradiť podľa webu</translation>
-<translation id="2744248271121720757">Klepnutím na slovo aktivujete dynamické vyhľadávanie alebo zobrazíte súvisiace akcie</translation>
-<translation id="2760989362628427051">Zapnúť tmavý motív, keď je v zariadení zapnutý tmavý motív alebo šetrič batérie</translation>
-<translation id="2762000892062317888">práve teraz</translation>
-<translation id="2777555524387840389">Zostáva: <ph name="SECONDS" /> s</translation>
-<translation id="2779651927720337254">neúspešné</translation>
-<translation id="2781151931089541271">Zostáva: 1 s</translation>
-<translation id="2801022321632964776">Ak chcete získať svoj jazyk v najnovšej verzii Chromu, aktualizujte ho</translation>
-<translation id="2810645512293415242">Zjednodušená stránka vám pomôže ušetriť dáta a zrýchliť načítavanie.</translation>
-<translation id="281504910091592009">Zobrazenie a správa uložených hesiel v <ph name="BEGIN_LINK" />účte Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Ak chcete získať záložky vo všetkých zariadeniach, prihláste sa a zapnite synchronizáciu</translation>
-<translation id="2822354292072154809">Naozaj chcete resetovať všetky povolenia webu pre <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Ukončite režim celej obrazovky klepnutím na tlačidlo Späť.</translation>
-<translation id="2842985007712546952">Nadradený priečinok</translation>
-<translation id="2858138569776157458">Hlavné weby</translation>
-<translation id="2860954141821109167">Skontrolujte, či je v tomto zariadení povolená aplikácia pre telefóny</translation>
-<translation id="2870560284913253234">Web</translation>
-<translation id="2874939134665556319">Predchádzajúca skladba</translation>
-<translation id="2876369937070532032">Pri ohrození zabezpečenia odosiela Googlu webové adresy niektorých navštívených stránok</translation>
-<translation id="2888126860611144412">O prehliadači Chrome</translation>
-<translation id="2891154217021530873">Zastaviť načítavanie stránky</translation>
-<translation id="2893180576842394309">Google môže pomocou vašej histórie prispôsobiť Vyhľadávanie a ďalšie služby Googlu</translation>
-<translation id="2898264748040935573">Úprava uloženého hesla</translation>
-<translation id="2900528713135656174">Vytvorte udalosť</translation>
-<translation id="290376772003165898">Stránka nie je v jazyku <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Zoznam zariadení, s ktorými sa má zdieľať karta, je otvorený na plnú výšku.</translation>
-<translation id="2910701580606108292">Pýtať sa, či chcete povoliť webu prehrávať chránený obsah</translation>
-<translation id="2913331724188855103">Povoliť webom ukladať a čítať súbory cookie (odporučané)</translation>
-<translation id="2923908459366352541">Názov je neplatný</translation>
-<translation id="2932150158123903946">Úložisko Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Karta ukážky je zatvorená</translation>
-<translation id="2956410042958133412">Tento účet je spravovaný používateľmi <ph name="PARENT_NAME_1" /> a <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Prepnuté na karty inkognito</translation>
-<translation id="2968755619301702150">Zobrazovač certifikátov</translation>
-<translation id="2979025552038692506">Vybratá karta inkognito</translation>
-<translation id="2987620471460279764">Text zdieľaný z iného zariadenia</translation>
-<translation id="2989523299700148168">Nedávno navštívené</translation>
-<translation id="2996291259634659425">Vytvorenie prístupovej frázy</translation>
-<translation id="2996809686854298943">Vyžaduje sa webová adresa</translation>
-<translation id="300526633675317032">Vymažete celé úložisko webu (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">Skontrolujte, či je toto zariadenie pripojené k internetu</translation>
-<translation id="3029613699374795922">Stiahnuté: <ph name="KBS" /> kB</translation>
-<translation id="3029704984691124060">Prístupové frázy sa nezhodujú</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Získať pomoc<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Poloha je vypnutá. Zapnite ju v <ph name="BEGIN_LINK" />Nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Synchronizáciu môžete kedykoľvek zapnúť v nastaveniach</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> záložka}few{<ph name="BOOKMARKS_COUNT_MANY" /> záložky}many{<ph name="BOOKMARKS_COUNT_MANY" /> bookmarks}other{<ph name="BOOKMARKS_COUNT_MANY" /> záložiek}}</translation>
-<translation id="3089395242580810162">Otvoriť na karte inkognito</translation>
-<translation id="3115898365077584848">Zobraziť informácie</translation>
-<translation id="3123473560110926937">Blokované na niektorých weboch</translation>
-<translation id="3137521801621304719">Ukončiť režim inkognito</translation>
-<translation id="3143515551205905069">Zrušiť synchronizáciu</translation>
-<translation id="3157842584138209013">Ak chcete zistiť, koľko dát ste ušetrili, klepnite na tlačidlo Ďalšie možnosti</translation>
-<translation id="3166827708714933426">Skratky pre karty a okná</translation>
-<translation id="3181954750937456830">Bezpečné prehliadanie (chráni vás aj zariadenie pred nebezpečnými webmi)</translation>
-<translation id="3190152372525844641">Zapnite povolenia pre Chrome v <ph name="BEGIN_LINK" />nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> uložených dát</translation>
-<translation id="3205824638308738187">Takmer hotovo!</translation>
-<translation id="3207960819495026254">Pridané medzi záložky</translation>
-<translation id="3211426585530211793">Záložka <ph name="ITEM_TITLE" /> bola odstránená</translation>
-<translation id="321773570071367578">Ak ste zabudli prístupovú frázu alebo chcete toto nastavenie zmeniť, <ph name="BEGIN_LINK" />resetujte synchronizáciu<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofón</translation>
-<translation id="3232754137068452469">Webová aplikácia</translation>
-<translation id="3236059992281584593">Zostáva: 1 min</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Vytvoriť záložku pre túto stránku</translation>
-<translation id="3259831549858767975">Zmenšenie obsahu na stránke</translation>
-<translation id="3269093882174072735">Načítať obrázok</translation>
-<translation id="3269956123044984603">Ak chcete získať karty z vašich ďalších zariadení, zapnite v nastaveniach účtu Android možnosť Automaticky synchronizovať dáta.</translation>
-<translation id="3277252321222022663">Povoliť webom prístup k senzorom (odporúčané)</translation>
-<translation id="3282568296779691940">Prihlásenie do prehliadača Chrome</translation>
-<translation id="3288003805934695103">Opätovne načítať stránku</translation>
-<translation id="32895400574683172">Upozornenia sú povolené</translation>
-<translation id="3295530008794733555">Prehliadajte rýchlejšie. Využívajte menej dát.</translation>
-<translation id="3295602654194328831">Skryť informácie</translation>
-<translation id="3298243779924642547">Zjednoduš.</translation>
-<translation id="3303414029551471755">Pokračovať a stiahnuť obsah?</translation>
-<translation id="3306398118552023113">Táto aplikácia je spustená v Chrome</translation>
-<translation id="3315103659806849044">Momentálne prispôsobujete nastavenia synchronizácie a služieb Googlu. Ak chcete dokončiť zapnutie synchronizácie, klepnite na tlačidlo Potvrdiť v dolnej časti obrazovky. Prejsť hore</translation>
-<translation id="3328801116991980348">Informácie o stránkach</translation>
-<translation id="3333961966071413176">Všetky kontakty</translation>
-<translation id="3334729583274622784">Chcete zmeniť príponu súboru?</translation>
-<translation id="3341058695485821946">Zistite, koľko dát ste ušetrili</translation>
-<translation id="3350687908700087792">Zavrieť všetky karty inkognito</translation>
-<translation id="3353615205017136254">Zjednodušenú verziu stránky poskytol Google. Ak chcete načítať pôvodnú verziu, klepnite na tlačidlo Načítať pôvodnú stránku.</translation>
-<translation id="3367813778245106622">Ak chcete spustiť synchronizáciu, znova sa prihláste</translation>
-<translation id="3374023511497244703">Vaše záložky, história, heslá a ďalšie údaje Chromu nebudú viac synchronizované s účtom Google</translation>
-<translation id="3384347053049321195">Zdieľať obrázok</translation>
-<translation id="3386292677130313581">Pýtať sa, či chcete povoliť webu zisťovať vašu polohu (odporúčané)</translation>
-<translation id="3387650086002190359">Súbor <ph name="FILE_NAME" /> sa nepodarilo stiahnuť z dôvodu chýb systému súborov.</translation>
-<translation id="3389286852084373014">Text je príliš veľký</translation>
-<translation id="3398320232533725830">Otvorenie správcu záložiek</translation>
-<translation id="3414952576877147120">Veľkosť:</translation>
-<translation id="3443221991560634068">Opätovné načítanie aktuálnej stránky</translation>
-<translation id="3445014427084483498">Práve teraz</translation>
-<translation id="3478363558367712427">Môžete si vybrať vyhľadávač</translation>
+<translation id="6910211073230771657">Odstránené</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Dobre</translation>
+<translation id="7658239707568436148">Zrušiť</translation>
 <translation id="3479552764303398839">Teraz nie</translation>
-<translation id="3492207499832628349">Nová karta inkognito</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Ďalšie informácie<ph name="END_LINK" /> o návrhoch obsahu</translation>
-<translation id="3513704683820682405">Rozšírená realita</translation>
-<translation id="3518985090088779359">Prijať a pokračovať</translation>
-<translation id="3522247891732774234">K dispozícii je aktualizácia. Ďalšie možnosti</translation>
-<translation id="3524138585025253783">Používateľské rozhranie vývojára</translation>
-<translation id="3527085408025491307">Priečinok</translation>
-<translation id="3542235761944717775">Voľné miesto: <ph name="KILOBYTES" /> kB</translation>
-<translation id="3549657413697417275">Prehľadať históriu</translation>
-<translation id="3557336313807607643">Pridať do kontaktov</translation>
-<translation id="3566923219790363270">Chrome sa stále pripravuje na používanie VR. Skúste Chrome reštartovať neskôr.</translation>
-<translation id="3568688522516854065">Ak chcete získať karty zo svojich ostatných zariadení, prihláste sa a zapnite synchronizáciu</translation>
-<translation id="3587482841069643663">Všetko</translation>
-<translation id="358794129225322306">Povoľuje webu automaticky sťahovať viacero súborov súčasne.</translation>
-<translation id="3590487821116122040">Úložisko webu, ktoré Chrome nepovažuje za dôležité (napr. webové stránky bez uložených nastavení alebo také, ktoré nenavštevujete často)</translation>
-<translation id="3599863153486145794">Vymaže históriu zo všetkých prihlásených zariadení. Váš účet Google môže mať ďalšie formy histórie prehliadania na adrese <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Stlmiť weby, ktoré prehrávajú zvuk</translation>
-<translation id="3616113530831147358">Zvuk</translation>
-<translation id="3631987586758005671">Zdieľa sa so zariadením <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Odhaliť heslo</translation>
-<translation id="363596933471559332">Povolí automatické prihlasovanie na webové stránky pomocou uložených poverení. Keď je funkcia vypnutá, zobrazí sa výzva na overenie vždy pred prihlásením na web.</translation>
-<translation id="3658159451045945436">Obnovením vymažete svoju históriu úspory dát aj zoznam navštívených webov.</translation>
-<translation id="3692944402865947621">Súbor <ph name="FILE_NAME" /> sa nepodarilo stiahnuť, pretože umiestnenie úložiska nie je k dispozícii.</translation>
-<translation id="3714981814255182093">Otvorenie Panela vyhľadávania</translation>
-<translation id="3716182511346448902">Táto stránka využíva príliš veľa pamäte, a preto ju Chrome pozastavil.</translation>
-<translation id="3730075448226062617">Ak chcete povoliť Chromu používať mikrofón, zapnite ho aj v <ph name="BEGIN_LINK" />Nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Pridané do záložiek <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Synchronizácia na pozadí</translation>
-<translation id="3771001275138982843">Aktualizáciu sa nepodarilo stiahnuť</translation>
-<translation id="3771033907050503522">Karty inkognito</translation>
-<translation id="3773755127849930740">Povoľte párovanie <ph name="BEGIN_LINK" />zapnutím rozhrania Bluetooth<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">Odoslanie do zariadení</translation>
-<translation id="3778956594442850293">Pridané na plochu</translation>
-<translation id="3789841737615482174">Inštalovať</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Spravovať</translation>
-<translation id="381841723434055211">Telefónne čísla</translation>
-<translation id="3819178904835489326">Počet odstránených stiahnutých súborov: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Vymazať úložisko webov?</translation>
-<translation id="385051799172605136">Naspäť</translation>
-<translation id="3859306556332390985">Pretočiť dopredu</translation>
-<translation id="3894427358181296146">Pridanie priečinka</translation>
-<translation id="3895926599014793903">Vynútiť povolenie priblíženia</translation>
-<translation id="3912508018559818924">Vyhľadáva sa to najlepšie z internetu…</translation>
-<translation id="3927692899758076493">Bezpätkové</translation>
-<translation id="3928666092801078803">Spojiť moje dáta</translation>
-<translation id="393697183122708255">Žiadne povol. hlas. vyhľad. k dispozícii</translation>
-<translation id="395206256282351086">Návrhy vyhľadávania a webov sú deaktivované</translation>
-<translation id="3955193568934677022">Povoliť webom prehrávať chránený obsah (odporúčané)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome stránku načíta, keď bude k dispozícii}few{Chrome stránku načíta, keď bude k dispozícii}many{Chrome stránku načíta, keď bude k dispozícii}other{Chrome stránku načíta, keď bude k dispozícii}}</translation>
-<translation id="3963007978381181125">Šifrovanie prístupovej frázy nezahŕňa spôsoby platby a adresy zo služby Google Pay. Šifrované údaje si môže prečítať iba používateľ s prístupovou frázou. Prístupová fráza sa neodosiela do Googlu ani sa v ňom neuchováva. Ak ju zabudnete alebo chcete toto nastavenie zmeniť, budete musieť resetovať synchronizáciu. <ph name="BEGIN_LINK" />Ďalšie informácie<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Sťahovanie dokončené</translation>
-<translation id="397583555483684758">Synchronizácia prestala fungovať</translation>
-<translation id="3976396876660209797">Odstráňte túto skratku a znova ju vytvorte</translation>
-<translation id="3985215325736559418">Chcete znova stiahnuť súbor <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Kopírovať odkaz</translation>
-<translation id="3988213473815854515">Poloha je povolená</translation>
-<translation id="3988466920954086464">Zobraziť výsledky dynamického vyhľadávania na tomto paneli</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Nedôležité úložisko</translation>
-<translation id="4000212216660919741">Offline domov</translation>
+<translation id="5317780077021120954">Uložiť</translation>
+<translation id="4570913071927164677">Podrobnosti</translation>
+<translation id="8730621377337864115">Hotovo</translation>
+<translation id="8261506727792406068">Odstrániť</translation>
+<translation id="1181037720776840403">Odstrániť</translation>
+<translation id="5939518447894949180">Resetovať</translation>
 <translation id="4002066346123236978">Názov</translation>
-<translation id="4008040567710660924">Povolenie súborov cookie konkrétneho webu</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# hod.}few{# hod.}many{# hod.}other{# hod.}}</translation>
-<translation id="4046123991198612571">Ďalšia skladba</translation>
-<translation id="4048707525896921369">Získajte informácie o témach na weboch bez toho, aby ste museli opustiť stránku. Vyhľadávanie klepnutím odošle slovo a súvisiaci kontext do Vyhľadávania Google a vráti definície, obrázky, výsledky vyhľadávania a ďalšie podrobnosti.
+<translation id="5916664084637901428">Zapnuté</translation>
+<translation id="5860033963881614850">Vypnuté</translation>
+<translation id="6165508094623778733">Ďalšie informácie</translation>
+<translation id="6042308850641462728">Viac</translation>
+<translation id="6040143037577758943">Zavrieť</translation>
+<translation id="780301667611848630">Nie, ďakujem</translation>
+<translation id="1201402288615127009">Ďalej</translation>
+<translation id="2359808026110333948">Pokračovať</translation>
+<translation id="2653659639078652383">Odoslať</translation>
+<translation id="2079545284768500474">Späť</translation>
+<translation id="7649070708921625228">Pomocník</translation>
+<translation id="2148716181193084225">Dnes</translation>
+<translation id="7781829728241885113">Včera</translation>
+<translation id="6945221475159498467">Vybrať</translation>
+<translation id="7791543448312431591">Pridať</translation>
+<translation id="6527303717912515753">Zdieľať</translation>
+<translation id="1383876407941801731">Vyhľadávanie</translation>
+<translation id="3115898365077584848">Zobraziť informácie</translation>
+<translation id="3295602654194328831">Skryť informácie</translation>
+<translation id="3987993985790029246">Kopírovať odkaz</translation>
+<translation id="2704606927547763573">Skopírované</translation>
+<translation id="8725066075913043281">Skúsiť znova</translation>
+<translation id="385051799172605136">Naspäť</translation>
+<translation id="8131740175452115882">Potvrdiť</translation>
+<translation id="5300589172476337783">Zobraziť</translation>
+<translation id="1124772482545689468">Používateľ</translation>
+<translation id="8609465669617005112">Presunúť nahor</translation>
+<translation id="6746124502594467657">Presunúť nadol</translation>
+<translation id="8249310407154411074">Presunúť na začiatok</translation>
+<translation id="8428213095426709021">Nastavenia</translation>
+<translation id="2498359688066513246">Pomocník a spätná väzba</translation>
+<translation id="8378714024927312812">Spravované vašou organizáciou</translation>
+<translation id="9019902583201351841">Spravované vašimi rodičmi</translation>
+<translation id="4645575059429386691">Spravované vaším rodičom</translation>
+<translation id="4883854917563148705">Spravované nastavenia sa nedajú resetovať</translation>
+<translation id="4307992518367153382">Základy</translation>
+<translation id="1974060860693918893">Rozšírené</translation>
+<translation id="1146678959555564648">Zadať VR</translation>
+<translation id="987264212798334818">Všeobecné</translation>
+<translation id="4275663329226226506">Médiá</translation>
+<translation id="4759238208242260848">Stiahnuté</translation>
+<translation id="218608176142494674">Zdieľanie</translation>
+<translation id="8004582292198964060">Prehliadač</translation>
+<translation id="1105960400813249514">Snímanie obrazovky</translation>
+<translation id="4875775213178255010">Návrhy obsahu</translation>
+<translation id="2021896219286479412">Ovládanie webu na celú obrazovku</translation>
+<translation id="4587589328781138893">Weby</translation>
+<translation id="4943703118917034429">Virtuálna realita</translation>
+<translation id="1928696683969751773">Aktualizácie</translation>
+<translation id="6064125863973209585">Sťahovanie bolo dokončené</translation>
+<translation id="5342314432463739672">Žiadosti o povolenie</translation>
+<translation id="629730747756840877">Účet</translation>
+<translation id="82609232232243542">Prihlásenie do prehliadača Brave</translation>
+<translation id="7956662517480676674">Synchronizácia a služby Googlu</translation>
+<translation id="5294439808117722387">Momentálne prispôsobujete nastavenia synchronizácie a služieb Googlu. Ak chcete dokončiť zapnutie synchronizácie, klepnite na tlačidlo Potvrdiť v dolnej časti obrazovky. Prejsť hore</translation>
+<translation id="2096012225669085171">Synchronizovať a prispôsobiť v rôznych zariadeniach</translation>
+<translation id="1692118695553449118">Synchronizácia je zapnutá.</translation>
+<translation id="5514904542973294328">Deaktivované správcom tohto zariadenia</translation>
+<translation id="6447211988989208781">Riadenie aktivity Brave Software</translation>
+<translation id="4882831918239250449">Ovládajte, ako sa pomocou histórie prehliadania prispôsobuje Vyhľadávanie, reklamy a ďalší obsah</translation>
+<translation id="7431991332293347422">Ovládajte, ako sa história prehliadania používa na prispôsobenie Vyhľadávania a ďalšieho obsahu</translation>
+<translation id="6303969859164067831">Odhlásiť sa a vypnúť synchronizáciu</translation>
+<translation id="1125261911132334651">Spravovať účet Brave Software</translation>
+<translation id="6406506848690869874">Synchronizácia</translation>
+<translation id="714362445477979774">Synchronizovať údaje Chromu</translation>
+<translation id="4314815835985389558">Správa synchronizácie</translation>
+<translation id="5428209950370661546">Ďalšie služby Googlu</translation>
+<translation id="7704317875155739195">Automaticky dopĺňať vyhľadávania a webové adresy</translation>
+<translation id="2000419248597011803">Odošle niektoré súbory cookie a vyhľadávania z panela s adresou a vyhľadávacieho poľa do vášho predvoleného vyhľadávača</translation>
+<translation id="7981313251711023384">Vopred načítavať stránky na zrýchlenie prehliadania a vyhľadávania</translation>
+<translation id="1821253160463689938">Používa súbory cookie na zapamätanie si predvolieb, dokonca aj keď dané stránky nenavštívite</translation>
+<translation id="6697492270171225480">Zobraziť návrhy podobných stránok, keď sa stránka nedá nájsť</translation>
+<translation id="8109318360573330108">Odošle Googlu webovú adresu stránky, na ktorú sa pokúšate prejsť</translation>
+<translation id="8438566539970814960">Zlepšovať vyhľadávanie a prehliadanie</translation>
+<translation id="284843628681142937">Odosiela Googlu webové adresy navštívených stránok</translation>
+<translation id="7222718784508482526">Ďalšie nastavenia týkajúce sa ochrany súkromia, zabezpečenia a zhromažďovania dát nájdete v časti <ph name="BEGIN_LINK"/>Synchronizácia a služby Googlu<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Pomáhať s vylepšovaním funkcií a výkonu Chromu</translation>
+<translation id="9063160602596686558">Automaticky odosiela štatistiky o používaní a správy o zlyhaní Googlu</translation>
+<translation id="4824958205181053313">Chcete zrušiť synchronizáciu?</translation>
+<translation id="3058498974290601450">Synchronizáciu môžete kedykoľvek zapnúť v nastaveniach</translation>
+<translation id="3143515551205905069">Zrušiť synchronizáciu</translation>
+<translation id="1506061864768559482">Vyhľadávač</translation>
+<translation id="55737423895878184">Poloha a upozornenia sú povolené</translation>
+<translation id="3988213473815854515">Poloha je povolená</translation>
+<translation id="32895400574683172">Upozornenia sú povolené</translation>
+<translation id="9040142327097499898">Upozornenia sú povolené. Poloha je v tomto zariadení vypnutá.</translation>
+<translation id="305593374596241526">Poloha je vypnutá. Zapnite ju v <ph name="BEGIN_LINK"/>Nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Nedávno navštívené</translation>
+<translation id="6433501201775827830">Výber vyhľadávača</translation>
+<translation id="7177466738963138057">Zmeniť to môžete neskôr v časti Nastavenia</translation>
+<translation id="3478363558367712427">Môžete si vybrať vyhľadávač</translation>
+<translation id="4910889077668685004">Platobné aplikácie</translation>
+<translation id="5152843274749979095">Nie sú nainštalované žiadne podporované aplikácie</translation>
+<translation id="8812260976093120287">Na niektorých weboch môžete platiť pomocou podporovaných platobných aplikácií na zariadení.</translation>
+<translation id="7764225426217299476">Pridať adresu</translation>
+<translation id="5595485650161345191">Upraviť adresu</translation>
+<translation id="5087580092889165836">Pridať kartu</translation>
+<translation id="2154484045852737596">Úprava karty</translation>
+<translation id="6140912465461743537">Krajina alebo oblasť</translation>
+<translation id="5659593005791499971">E-mail</translation>
+<translation id="4378154925671717803">Telefón</translation>
+<translation id="4807098396393229769">Meno na karte</translation>
+<translation id="860043288473659153">Meno držiteľa karty</translation>
+<translation id="2612676031748830579">Číslo karty</translation>
+<translation id="869891660844655955">Koniec platnosti</translation>
+<translation id="2286841657746966508">Fakturačná adresa</translation>
+<translation id="663059986967017181">Skopírovaná do prehliadača Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ďalší}few{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ďalšie}many{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ďalšieho}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ďalších}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ďalšia}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ďalšie}many{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ďalšej}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> ďalších}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ďalšia}few{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ďalšie}many{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ďalšej}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ďalších}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ďalší}few{<ph name="CONTACT_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ďalšie}many{<ph name="CONTACT_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ďalšieho}other{<ph name="CONTACT_PREVIEW"/>\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> ďalších}}</translation>
+<translation id="7029809446516969842">Heslá</translation>
+<translation id="1943432128510653496">Ukladať heslá</translation>
+<translation id="2100273922101894616">Automaticky prihlasovať</translation>
+<translation id="363596933471559332">Povolí automatické prihlasovanie na webové stránky pomocou uložených poverení. Keď je funkcia vypnutá, zobrazí sa výzva na overenie vždy pred prihlásením na web.</translation>
+<translation id="6995899638241819463">Upozorňovať pri prezradení hesiel v rámci porušenia ochrany údajov</translation>
+<translation id="1534287762301776620">Keď sa prihlásite do svojho účtu Brave Software, táto funkcia je zapnutá</translation>
+<translation id="10614374240317010">Nikdy neukladať</translation>
+<translation id="3098842761938485917">Zobrazenie a správa uložených hesiel v <ph name="BEGIN_LINK"/>účte Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Tu sa zobrazia uložené heslá.</translation>
+<translation id="8084114998886531721">Uložené heslo</translation>
+<translation id="2870560284913253234">Web</translation>
+<translation id="8503813439785031346">Meno používateľa</translation>
+<translation id="6657585470893396449">Heslo</translation>
+<translation id="2154710561487035718">Kopírovať webovú adresu</translation>
+<translation id="1571304935088121812">Kopírovať používateľské meno</translation>
+<translation id="5005498671520578047">Kopírovanie hesla</translation>
+<translation id="3632295766818638029">Odhaliť heslo</translation>
+<translation id="1513858653616922153">Odstrániť heslo</translation>
+<translation id="543338862236136125">Upraviť heslo</translation>
+<translation id="4565377596337484307">Skryť heslo</translation>
+<translation id="8523928698583292556">Odstrániť uložené heslo</translation>
+<translation id="2898264748040935573">Úprava uloženého hesla</translation>
+<translation id="5433691172869980887">Používateľské meno bolo skopírované</translation>
+<translation id="5534640966246046842">Web bol skopírovaný</translation>
+<translation id="2625189173221582860">Heslo bolo skopírované.</translation>
+<translation id="4550003330909367850">Ak si tu chcete zobraziť heslo alebo ho sem chcete skopírovať, nastavte v tomto zariadení zámku obrazovky.</translation>
+<translation id="6154478581116148741">Ak chcete exportovať heslá z tohto zariadenia, zapnite v Nastaveniach zámku obrazovky</translation>
+<translation id="4842092870884894799">Zobrazuje sa okno generovania hesiel</translation>
+<translation id="2259659629660284697">Exportovať heslá…</translation>
+<translation id="133012818630824069">Exportovať heslá uložené v Brave</translation>
+<translation id="6914783257214138813">Vaše heslá uvidí každý, kto si môže zobraziť exportovaný súbor.</translation>
+<translation id="2321086116217818302">Pripravujú sa heslá…</translation>
+<translation id="8445448999790540984">Heslá sa nepodarilo exportovať</translation>
+<translation id="3066461326500799725">Ako používať Disk Brave Software</translation>
+<translation id="729975465115245577">Vaše zariadenie nemá aplikáciu na uloženie súboru s heslami.</translation>
+<translation id="7682724950699840886">Skúste tieto tipy: Uistite sa, že máte v zariadení dosť miesta, a potom skúste znova spustiť exportovanie.</translation>
+<translation id="1129510026454351943">Podrobnosti: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Heslo môžete kopírovať po odomknutí</translation>
+<translation id="5515439363601853141">Heslo sa zobrazí po odomknutí</translation>
+<translation id="6221633008163990886">Heslá budete môcť exportovať po odomknutí</translation>
+<translation id="230699814587342492">Heslá Chromu</translation>
+<translation id="6075798973483050474">Úprava domovskej stránky</translation>
+<translation id="854522910157234410">Otvoriť túto stránku</translation>
+<translation id="2482878487686419369">Upozornenia</translation>
+<translation id="6255999984061454636">Návrhy obsahu</translation>
+<translation id="805047784848435650">Na základe vašej histórie prehliadania</translation>
+<translation id="1041308826830691739">Z webov</translation>
+<translation id="395206256282351086">Návrhy vyhľadávania a webov sú deaktivované</translation>
+<translation id="257088987046510401">Motívy</translation>
+<translation id="4650364565596261010">Predvolené</translation>
+<translation id="7588219262685291874">Zapnúť tmavý motív, keď je v zariadení zapnutý šetrič batérie</translation>
+<translation id="2760989362628427051">Zapnúť tmavý motív, keď je v zariadení zapnutý tmavý motív alebo šetrič batérie</translation>
+<translation id="6381421346744604172">Stmaviť weby</translation>
+<translation id="5040262127954254034">Ochrana súkromia</translation>
+<translation id="4991384657077828949">Pomoc so zlepšením zabezpečenia Chromu</translation>
+<translation id="1943176487615318915">Brave odosiela Googlu webové adresy niektorých navštívených stránok, obmedzené informácie o systéme a obsah niektorých stránok na účely rozpoznávania nebezpečných aplikácií a webov.</translation>
+<translation id="3181954750937456830">Bezpečné prehliadanie (chráni vás aj zariadenie pred nebezpečnými webmi)</translation>
+<translation id="7315322926489145388">Pri ohrození zabezpečenia odosiela Googlu webové adresy niektorých navštívených stránok</translation>
+<translation id="2063713494490388661">Vyhľadávanie klepnutím</translation>
+<translation id="2369463299479365221">Získajte informácie o témach na weboch bez toho, aby ste museli opustiť stránku. Vyhľadávanie klepnutím odošle slovo a súvisiaci kontext do Vyhľadávania Brave Software a vráti definície, obrázky, výsledky vyhľadávania a ďalšie podrobnosti.
 
 Ak chcete upraviť hľadaný výraz, vyberte ho dlhým stlačením. Ak chcete vyhľadávanie spresniť, posuňte panel úplne hore a klepnite na vyhľadávacie pole.</translation>
-<translation id="4056223980640387499">Sépia</translation>
-<translation id="4060598801229743805">Možnosti sú k dispozícii v hornej časti obrazovky</translation>
-<translation id="4062305924942672200">Právne informácie</translation>
-<translation id="4084682180776658562">Záložka</translation>
-<translation id="4084712963632273211">Od: <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />doručené Googlom<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Odstrániť dáta aplikácie?</translation>
-<translation id="4099578267706723511">Odosielať štatistiky používania a prehľady chýb Googlu a pomáhať tak zlepšovať Chrome</translation>
-<translation id="410351446219883937">Automatické prehrávanie</translation>
-<translation id="4116038641877404294">Stiahnite si stránky na použitie offline</translation>
-<translation id="4135200667068010335">Zoznam zariadení, s ktorými sa má zdieľať karta, je zavretý.</translation>
-<translation id="4149994727733219643">Jednoduché zobrazenie webových stránok</translation>
-<translation id="4165986682804962316">Nastavenia webu</translation>
-<translation id="4169535189173047238">Nepovoliť</translation>
-<translation id="4170011742729630528">Služba nie je k dispozícii. Skúste to znova neskôr.</translation>
-<translation id="4179980317383591987">Využité: <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Jazyky</translation>
-<translation id="4183868528246477015">Hľadať cez Google Lens <ph name="BEGIN_NEW" />Novinka<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Otvoriť na novej karte</translation>
-<translation id="4198423547019359126">Nie sú k dispozícii žiadne umiestnenia stiahnutých súborov</translation>
-<translation id="4209895695669353772">Ak chcete získavať prispôsobený obsah navrhnutý Googlom, zapnite synchronizáciu</translation>
-<translation id="4226663524361240545">Upozornenia môžu pri prijatí na zariadení spustiť vibrovanie</translation>
-<translation id="423219824432660969">Šifrovať synchronizované údaje heslom Google od <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Otvoriť nastavenia</translation>
-<translation id="4256782883801055595">Licencie open source</translation>
-<translation id="4259722352634471385">Navigácia je zablokovaná: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopírovať adresu odkazu</translation>
-<translation id="4275663329226226506">Médiá</translation>
-<translation id="4278390842282768270">Povolené</translation>
-<translation id="429312253194641664">Web prehráva médiá</translation>
-<translation id="4298388696830689168">Prepojené weby</translation>
-<translation id="4307992518367153382">Základy</translation>
-<translation id="4314815835985389558">Správa synchronizácie</translation>
-<translation id="4351244548802238354">Zavrieť dialógové okno</translation>
-<translation id="4378154925671717803">Telefón</translation>
-<translation id="4384468725000734951">Na vyhľadávanie sa používa Sogou</translation>
-<translation id="4404568932422911380">Žiadne záložky</translation>
-<translation id="4405224443901389797">Presunúť do…</translation>
-<translation id="4411535500181276704">Zjednodušený režim</translation>
-<translation id="4415276339145661267">Spravovať účet Google</translation>
-<translation id="4432792777822557199">Stránky v jazyku <ph name="SOURCE_LANGUAGE" /> budú odteraz prekladané do jazyka <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Zjednodušenú verziu stránky poskytol Google</translation>
-<translation id="4434045419905280838">Vyskakovacie okná a presmerovania</translation>
-<translation id="4440958355523780886">Zjednodušenú verziu stránky poskytol Google. Klepnutím načítate pôvodnú verziu.</translation>
-<translation id="4452411734226507615">Zavrieť kartu <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Uložené ako záložka v priečinku <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Povoliť webom prehrávať chránený obsah</translation>
-<translation id="4468959413250150279">Vypnite zvuk konkrétneho webu.</translation>
-<translation id="4472118726404937099">Ak chcete synchronizovať a prispôsobovať viaceré zariadenia, prihláste sa a zapnite synchronizáciu</translation>
-<translation id="447252321002412580">Pomáhať s vylepšovaním funkcií a výkonu Chromu</translation>
-<translation id="4479647676395637221">Opýtať sa pred povolením webu používať vašu kameru (odporúčané)</translation>
-<translation id="4479972344484327217">Inštaluje sa <ph name="MODULE" /> pre Chrome…</translation>
-<translation id="4487967297491345095">Všetky dáta aplikácií v Chrome budú natrvalo odstránené. Platí to aj pre všetky súbory, nastavenia, účty, databázy atď.</translation>
-<translation id="4493497663118223949">Zjednodušený režim je zapnutý</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{pred # dňom}few{pred # dňami}many{pred # dňom}other{pred # dňami}}</translation>
-<translation id="451872707440238414">Prehľadať záložky</translation>
-<translation id="4521489764227272523">Vybrané údaje boli odstránené z Chromu a vašich synchronizovaných zariadení.
-
-Váš účet Google môže mať na adrese <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> ďalšie formy histórie prehliadania, ako napríklad vyhľadávania a aktivity v iných službách Googlu.</translation>
-<translation id="4532845899244822526">Vyberte priečinok</translation>
-<translation id="4538018662093857852">Zapnúť zjednodušený režim</translation>
-<translation id="4550003330909367850">Ak si tu chcete zobraziť heslo alebo ho sem chcete skopírovať, nastavte v tomto zariadení zámku obrazovky.</translation>
-<translation id="4558311620361989323">Skratky pre webové stránky</translation>
-<translation id="4561979708150884304">Bez pripojenia</translation>
-<translation id="4565377596337484307">Skryť heslo</translation>
-<translation id="4570913071927164677">Podrobnosti</translation>
-<translation id="4572422548854449519">Prihlásenie do spravovaného účtu</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{pred # minútou}few{pred # minútami}many{pred # minútou}other{pred # minútami}}</translation>
-<translation id="4587589328781138893">Weby</translation>
-<translation id="4594952190837476234">Táto offline stránka je z <ph name="CREATION_TIME" /> a líši sa od online verzie.</translation>
-<translation id="4605958867780575332">Položka bola odstránená: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Otvoriť <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Použiť heslo</translation>
-<translation id="4645575059429386691">Spravované vaším rodičom</translation>
-<translation id="4650364565596261010">Predvolené</translation>
-<translation id="4663756553811254707">Počet odstránených záložiek: <ph name="NUMBER_OF_BOOKMARKS" /></translation>
-<translation id="4665282149850138822">Stránky <ph name="NAME" /> boli pridané na plochu</translation>
-<translation id="4684427112815847243">Synchronizovať všetko</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ďalšia}few{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ďalšie}many{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ďalšej}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ďalších}}</translation>
-<translation id="4696983787092045100">Odoslať text do vašich zariadení</translation>
-<translation id="4698034686595694889">Zobrazenie offline v aplikácii <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Obrázky a súbory vo vyrovnávacej pamäti</translation>
-<translation id="4714588616299687897">Ušetrite až 60 % dát</translation>
-<translation id="4719927025381752090">Ponúkať preklad</translation>
-<translation id="4720023427747327413">Otvoriť v aplikácii <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Pomôžte zlepšiť Chrome. <ph name="BEGIN_LINK" />Zúčastniť sa prieskumu<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Aktualizovať</translation>
-<translation id="4738836084190194332">Synchronizované <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Otvorenie novej karty</translation>
-<translation id="4751476147751820511">Senzory pohybu alebo svetla</translation>
-<translation id="4759238208242260848">Stiahnuté</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Dokončilo sa sťahovanie 1 položky.}few{Dokončilo sa sťahovanie # položiek.}many{# downloads complete.}other{Dokončilo sa sťahovanie # položiek.}}</translation>
-<translation id="4797039098279997504">Klepnutím sa vrátite na kartu <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Šifrovanie prístupovej frázy nezahŕňa spôsoby platby a adresy zo služby Google Pay.
-
-Ak chcete toto nastavenie zmeniť, <ph name="BEGIN_LINK" />resetujte synchronizáciu<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Meno na karte</translation>
-<translation id="4824958205181053313">Chcete zrušiť synchronizáciu?</translation>
-<translation id="4837753911714442426">Otvorenie možností tlače stránky</translation>
-<translation id="4842092870884894799">Zobrazuje sa okno generovania hesiel</translation>
-<translation id="4860895144060829044">Volajte</translation>
-<translation id="4866368707455379617">Modul <ph name="MODULE" /> pre Chrome sa nepodarilo nainštalovať</translation>
-<translation id="4875775213178255010">Návrhy obsahu</translation>
-<translation id="4878404682131129617">Vytvorenie tunela prostredníctvom proxy servera zlyhalo</translation>
-<translation id="4880127995492972015">Preložiť…</translation>
-<translation id="4881695831933465202">Otvoriť</translation>
-<translation id="488187801263602086">Premenovanie súboru</translation>
-<translation id="4882831918239250449">Ovládajte, ako sa pomocou histórie prehliadania prispôsobuje Vyhľadávanie, reklamy a ďalší obsah</translation>
-<translation id="4883854917563148705">Spravované nastavenia sa nedajú resetovať</translation>
-<translation id="4885273946141277891">Nepodporovaný počet inštancií prehliadača Chrome.</translation>
-<translation id="4910889077668685004">Platobné aplikácie</translation>
-<translation id="4913161338056004800">Resetovať štatistiky</translation>
-<translation id="4913169188695071480">Zastaviť obnovovanie</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Získajte pomoc<ph name="END_LINK" /> s vyhľadávaním zariadení…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stránka}few{# stránky}many{# Pages}other{# stránok}}</translation>
-<translation id="4932247056774066048">Keďže sa odhlasujete z účtu spravovaného doménou <ph name="DOMAIN_NAME" />, budú údaje Chromu z tohto zariadenia odstránené. Zostanú vo vašom účte Google.</translation>
-<translation id="4943703118917034429">Virtuálna realita</translation>
-<translation id="4943872375798546930">Žiadne výsledky</translation>
-<translation id="4958708863221495346">Web <ph name="URL_OF_THE_CURRENT_TAB" /> zdieľa vašu obrazovku</translation>
-<translation id="4961107849584082341">Preložte si túto stránku do ľubovoľného jazyka</translation>
-<translation id="4962975101802056554">Odvolať všetky povolenia pre zariadenie</translation>
-<translation id="4970824347203572753">Nie je k dispozícii vo vašej krajine</translation>
-<translation id="497421865427891073">Ďalej</translation>
-<translation id="4988210275050210843">Sťahuje sa súbor (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Stránky</translation>
-<translation id="4994033804516042629">Nenašli sa žiadne kontakty</translation>
-<translation id="4996978546172906250">Zdieľať</translation>
-<translation id="5004416275253351869">Riadenie aktivity Google</translation>
-<translation id="5005498671520578047">Kopírovanie hesla</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> žiada o pripojenie</translation>
-<translation id="5013696553129441713">Žiadne nové návrhy</translation>
-<translation id="5016205925109358554">Pätkové</translation>
-<translation id="5033865233969348410">V režime VR môže tento web získať nasledujúce informácie:
-– vaše fyzické vlastnosti, ako je výška.
-
-Pred prechodom do VR skontrolujte, či tomuto webu dôverujete.</translation>
+<translation id="2930742481329940825">Vyhľadávanie klepnutím odošle vybraté slovo a súčasnú stránku ako kontext do Vyhľadávania Brave Software. Môžete ho vypnúť v <ph name="BEGIN_LINK"/>Nastaveniach<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Povoliť</translation>
-<translation id="5040262127954254034">Ochrana súkromia</translation>
-<translation id="5048398596102334565">Povoliť webom prístup k senzorom pohybu (odporúčané)</translation>
-<translation id="5063480226653192405">Použitie</translation>
-<translation id="5087580092889165836">Pridať kartu</translation>
-<translation id="5100237604440890931">Zbalená (rozbalíte ju kliknutím)</translation>
-<translation id="510275257476243843">Zostáva: 1 h</translation>
-<translation id="5123685120097942451">Karta inkognito</translation>
-<translation id="5127805178023152808">Synchronizácia je vypnutá.</translation>
-<translation id="5129038482087801250">Inštalovať webovú aplikáciu</translation>
-<translation id="5132942445612118989">Synchronizujte svoje heslá, históriu a ďalší obsah vo všetkých zariadeniach</translation>
-<translation id="5139940364318403933">Ako používať Disk Google</translation>
-<translation id="515227803646670480">Vymazanie uložených dát</translation>
-<translation id="5152843274749979095">Nie sú nainštalované žiadne podporované aplikácie</translation>
-<translation id="5161254044473106830">Musíte zadať názov</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Nepodarilo sa stiahnuť 1 položku.}few{Nepodarilo sa stiahnuť # položky.}many{# downloads failed.}other{Nepodarilo sa stiahnuť # položiek.}}</translation>
-<translation id="5170568018924773124">Zobraziť v priečinku</translation>
-<translation id="5184329579814168207">Otvoriť v prehliadači Chrome</translation>
-<translation id="5193988420012215838">Skopírované do schránky</translation>
-<translation id="5197729504361054390">Vybrané kontakty budú zdieľané s webom <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Pracovný profil</translation>
-<translation id="5210286577605176222">Prechod na predchádzajúcu kartu</translation>
-<translation id="5210365745912300556">Zatvoriť kartu</translation>
-<translation id="5224771365102442243">S videom</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> chce vyhľadávať zariadenia Bluetooth nablízku. Našli sa tieto zariadenia:</translation>
-<translation id="5233638681132016545">Nová karta</translation>
-<translation id="526421993248218238">Táto stránka sa nedá načítať</translation>
-<translation id="5271967389191913893">Zariadenie nemôže otvoriť obsah na stiahnutie</translation>
-<translation id="528192093759286357">Režim celej obrazovky ukončíte potiahnutím z hornej časti a klepnutím na tlačidlo Späť.</translation>
-<translation id="5292796745632149097">Odoslanie do zariadení</translation>
-<translation id="5300589172476337783">Zobraziť</translation>
-<translation id="5301954838959518834">Dobre</translation>
-<translation id="5304593522240415983">Toto pole nesmie byť prázdne</translation>
-<translation id="5307446750509046227">Vymazať priestor webu</translation>
-<translation id="5308380583665731573">Pripojenie</translation>
-<translation id="5313967007315987356">Pridať web</translation>
-<translation id="5317780077021120954">Uložiť</translation>
-<translation id="5324858694974489420">Rodičovské nastavenia</translation>
-<translation id="5327248766486351172">Názov</translation>
-<translation id="5335288049665977812">Povoliť webom spúšťať JavaScript (odporúča sa)</translation>
-<translation id="5342314432463739672">Žiadosti o povolenie</translation>
-<translation id="5357811892247919462">Karta bola prijatá</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> otvorená karta, karty prepnete klepnutím}few{<ph name="OPEN_TABS_MANY" /> otvorené karty, karty prepnete klepnutím}many{<ph name="OPEN_TABS_MANY" /> open tabs, tap to switch tabs}other{<ph name="OPEN_TABS_MANY" /> otvorených kariet, karty prepnete klepnutím}}</translation>
-<translation id="5391532827096253100">Spojenie s týmto webom nie je zabezpečené. Informácie o webe</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ďalšie)}few{(+ # ďalšie)}many{(+ # more)}other{(+ # ďalších)}}</translation>
-<translation id="5400569084694353794">Používaním tejto aplikácie vyjadrujete súhlas so <ph name="BEGIN_LINK1" />zmluvnými podmienkami<ph name="END_LINK1" /> a <ph name="BEGIN_LINK2" />oznámením o ochrane súkromia<ph name="END_LINK2" /> prehliadača Chrome.</translation>
-<translation id="5403592356182871684">Názvy</translation>
-<translation id="5403644198645076998">Povoliť len určité weby</translation>
-<translation id="5414836363063783498">Overuje sa...</translation>
-<translation id="5423934151118863508">Tu sa zobrazia vaše najnavštevovanejšie stránky.</translation>
-<translation id="5424588387303617268">K dispozícii je <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Upraviť heslo</translation>
-<translation id="5433691172869980887">Používateľské meno bolo skopírované</translation>
-<translation id="543509235395288790">Sťahuje sa niekoľko súborov (<ph name="COUNT" />) s celkovou veľkosťou <ph name="MEGABYTES" />.</translation>
-<translation id="5441522332038954058">Prechod na panel s adresou</translation>
-<translation id="5447201525962359567">Celé úložisko webu vrátane súborov cookie a ďalších miestne uložených dát</translation>
-<translation id="5447765697759493033">Tento web nebude preložený</translation>
-<translation id="545042621069398927">Sťahovanie sa zrýchľuje.</translation>
-<translation id="5456381639095306749">Stránka sťahovania</translation>
-<translation id="5475862044948910901">Chcete spustiť reláciu rozšírenej reality?</translation>
-<translation id="548278423535722844">Otvorte v aplikácii pre mapy</translation>
-<translation id="5487521232677179737">Vymazať dáta</translation>
-<translation id="5494752089476963479">Blokovať reklamy webov, ktoré zobrazujú obťažujúce alebo zavádzajúce reklamy</translation>
-<translation id="5500777121964041360">Nemusí byť k dispozícii vo vašej krajine</translation>
-<translation id="5512137114520586844">Tento účet je spravovaný používateľom <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Deaktivované správcom tohto zariadenia</translation>
-<translation id="5515439363601853141">Heslo sa zobrazí po odomknutí</translation>
-<translation id="5516455585884385570">Otvoriť nastavenia upozornení</translation>
-<translation id="5517095782334947753">Máte záložky, históriu, heslá a ďalšie nastavenia z účtu <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Presmerovanie bolo zablokované.</translation>
-<translation id="5527082711130173040">Na to, aby mohol Chrome hľadať zariadenia, musí mať prístup k polohe. <ph name="BEGIN_LINK1" />Aktualizujte povolenia<ph name="END_LINK1" />. Prístup k polohe je <ph name="BEGIN_LINK2" />vypnutý aj v tomto zariadení<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Pýtať sa, či chcete povoliť webu čítať text a obrázky v schránke (odporúčané)</translation>
-<translation id="5530766185686772672">Zavrieť karty inkognito</translation>
-<translation id="5534334044554683961">V režime VR môže tento web získať nasledujúce informácie:
-– vaše fyzické vlastnosti, ako je výška;
-– rozloženie vašej miestnosti.
-
-Pred prechodom do VR skontrolujte, či tomuto webu dôverujete.</translation>
-<translation id="5534640966246046842">Web bol skopírovaný</translation>
-<translation id="5556459405103347317">Znova načítať</translation>
-<translation id="5561549206367097665">Čaká sa na sieť…</translation>
-<translation id="557283862590186398">Chrome potrebuje povolenie pre tento web na prístup k vášmu mikrofónu.</translation>
-<translation id="55737423895878184">Poloha a upozornenia sú povolené</translation>
-<translation id="5578795271662203820">Hľadať obrázok v službe <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Položky, ktoré chcete synchronizovať, môžete vybrať v <ph name="BEGIN_LINK1" />nastaveniach<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Upraviť adresu</translation>
-<translation id="5596627076506792578">Ďalšie možnosti</translation>
-<translation id="5599455543593328020">Režim inkognito</translation>
-<translation id="5620928963363755975">Stiahnuté súbory a stránky nájdete po použití tlačidla Ďalšie možnosti</translation>
-<translation id="5626134646977739690">Názov:</translation>
-<translation id="5639724618331995626">Povoliť všetky weby</translation>
-<translation id="5648166631817621825">Posledných 7 dní</translation>
-<translation id="5649053991847567735">Automatické sťahovanie</translation>
-<translation id="5655963694829536461">Prehľadať stiahnuté</translation>
-<translation id="5659593005791499971">E-mail</translation>
-<translation id="5665379678064389456">Vytvorte udalosť v aplikácii <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ignorovať požiadavku webových stránok na zákaz priblíženia</translation>
-<translation id="5677928146339483299">Blokované</translation>
-<translation id="5684874026226664614">Hops. Túto stránku nebolo možné preložiť.</translation>
-<translation id="5686790454216892815">Názov súboru je príliš dlhý</translation>
-<translation id="5689516760719285838">Poloha</translation>
-<translation id="569536719314091526">Preložte si túto stránku do ľubovoľného jazyka pomocou tlačidla Ďalšie možnosti</translation>
-<translation id="572328651809341494">Nedávne karty</translation>
-<translation id="5726692708398506830">Zväčšenie obsahu na stránke</translation>
-<translation id="5748802427693696783">Prepnuté na štandardné karty</translation>
-<translation id="5749068826913805084">Chrome potrebuje na sťahovanie súborov prístup k úložisku.</translation>
-<translation id="5763382633136178763">Karty inkognito</translation>
-<translation id="5763514718066511291">Klepnutím skopírujete webovú adresu tejto aplikácie</translation>
-<translation id="5765780083710877561">Popis:</translation>
-<translation id="5793665092639000975">Využité: <ph name="SPACE_USED" /> z <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google môže pomocou vašej histórie prispôsobiť Vyhľadávanie, reklamy a ďalšie služby Googlu</translation>
-<translation id="5804241973901381774">Povolenia</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{pred # hodinou}few{pred # hodinami}many{pred # hodinou}other{pred # hodinami}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Všetky práva vyhradené.</translation>
-<translation id="5817918615728894473">Párovať</translation>
-<translation id="583281660410589416">Neznáme</translation>
-<translation id="5833984609253377421">Zdieľať odkaz</translation>
-<translation id="5836192821815272682">Sťahuje sa aktualizácia Chromu…</translation>
-<translation id="5853623416121554550">pozastavené</translation>
-<translation id="5854790677617711513">Staršie ako 30 dní</translation>
-<translation id="5858741533101922242">Chrome nedokáže zapnúť adaptér Bluetooth</translation>
-<translation id="5860033963881614850">Vypnuté</translation>
-<translation id="5862731021271217234">Ak chcete získať karty zo svojich ostatných zariadení, zapnite synchronizáciu</translation>
-<translation id="5864174910718532887">Podrobnosti: zoradené podľa názvu webu</translation>
-<translation id="5864419784173784555">Čaká sa na ďalší sťahovaný súbor…</translation>
-<translation id="5865733239029070421">Automaticky odosiela štatistiky o používaní a správy o zlyhaní Googlu</translation>
-<translation id="5869522115854928033">Uložené heslá</translation>
-<translation id="5902828464777634901">Všetky miestne údaje uložené týmto webom, vrátane súborov cookie, budú odstránené.</translation>
-<translation id="5916664084637901428">Zapnuté</translation>
-<translation id="5919204609460789179">Ak chcete spustiť synchronizáciu, aktualizujte aplikáciu <ph name="PRODUCT_NAME" /></translation>
-<translation id="5937580074298050696">Ušetrené: <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Resetovať</translation>
-<translation id="5942872142862698679">Na vyhľadávanie sa používa Google</translation>
-<translation id="5952764234151283551">Odošle Googlu webovú adresu stránky, na ktorú sa pokúšate prejsť</translation>
-<translation id="5956665950594638604">Otvorenie Centra pomoci prehliadača Chrome na novej karte</translation>
-<translation id="5958275228015807058">Nájdite stiahnuté súbory a stránky</translation>
-<translation id="5962718611393537961">Klepnutím zbaliť</translation>
-<translation id="6000066717592683814">Ponechať Google</translation>
-<translation id="6005538289190791541">Navrhované heslo</translation>
-<translation id="6036057147555329831">Dodatočný modul ICU</translation>
-<translation id="6039379616847168523">Prechod na ďalšiu kartu</translation>
-<translation id="6040143037577758943">Zavrieť</translation>
-<translation id="6042308850641462728">Viac</translation>
-<translation id="604996488070107836">Súbor <ph name="FILE_NAME" /> sa nepodarilo stiahnuť z dôvodu neznámej chyby.</translation>
-<translation id="605721222689873409">RR</translation>
-<translation id="6064125863973209585">Sťahovanie bolo dokončené</translation>
-<translation id="6075798973483050474">Úprava domovskej stránky</translation>
-<translation id="60923314841986378">Zostáva: <ph name="HOURS" /> h</translation>
-<translation id="6108923351542677676">Inštaluje sa...</translation>
-<translation id="6111020039983847643">využité dáta</translation>
-<translation id="6112702117600201073">Obnovenie stránky</translation>
-<translation id="6127379762771434464">Položka bola odstránená</translation>
-<translation id="6140912465461743537">Krajina alebo oblasť</translation>
-<translation id="614940544461990577">Vyskúšajte:</translation>
-<translation id="6154478581116148741">Ak chcete exportovať heslá z tohto zariadenia, zapnite v Nastaveniach zámku obrazovky</translation>
-<translation id="6159335304067198720">Úspora dát: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Ďalšie informácie</translation>
-<translation id="6177111841848151710">Blokované v aktuálnom vyhľadávači</translation>
-<translation id="6181444274883918285">Pridať výnimku pre web</translation>
-<translation id="6192333916571137726">Sťahovanie súboru</translation>
-<translation id="6192792657125177640">Výnimky</translation>
-<translation id="6194112207524046168">Ak chcete povoliť Chromu používať fotoaparát, zapnite ho aj v <ph name="BEGIN_LINK" />Nastaveniach Androidu<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokovať súbory cookie tretích strán</translation>
-<translation id="6206551242102657620">Spojenie je zabezpečené. Informácie o webe</translation>
-<translation id="6210748933810148297">Nie som <ph name="EMAIL" /></translation>
-<translation id="6221633008163990886">Heslá budete môcť exportovať po odomknutí</translation>
+<translation id="1406000523432664303">Nesledovať</translation>
 <translation id="6232535412751077445">Ak povolíte možnosť Nesledovať, k odosielaným dátam prehliadania sa pridá žiadosť. Akýkoľvek účinok závisí od toho, či bude web na žiadosť reagovať, a tiež od interpretácie žiadosti.
 
 Niektoré weby môžu napríklad na túto žiadosť reagovať tak, že vám zobrazia reklamy, ktoré nie sú založené na ostatných weboch, ktoré ste navštívili. Mnoho webov bude stále zhromažďovať a používať vaše dáta prehliadania, napríklad na zlepšenie zabezpečenia, poskytovanie obsahu, reklám a odporúčaní a na generovanie štatistík prehľadov.</translation>
-<translation id="624789221780392884">Aktualizácia je pripravená</translation>
-<translation id="6255999984061454636">Návrhy obsahu</translation>
-<translation id="6277522088822131679">Pri tlačení stránky sa vyskytol problém. Skúste to znova.</translation>
-<translation id="6295158916970320988">Všetky stránky</translation>
-<translation id="629730747756840877">Účet</translation>
-<translation id="6303969859164067831">Odhlásiť sa a vypnúť synchronizáciu</translation>
-<translation id="6316139424528454185">Verzia Androidu nie je podporovaná</translation>
-<translation id="6320088164292336938">Vibrovanie</translation>
-<translation id="6324034347079777476">Synchronizácia systému Android je zakázaná</translation>
-<translation id="6333140779060797560">Zdieľať pomocou aplikácie <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Šifrovanie</translation>
-<translation id="6341580099087024258">Pýtať sa, kde uložiť súbory</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ďalšia}few{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ďalšie}many{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ďalšej}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> ďalších}}</translation>
-<translation id="6364438453358674297">Odstrániť návrh z histórie?</translation>
-<translation id="6369229450655021117">Môžete v ňom vyhľadávať na internete, zdieľať obsah s priateľmi a prezerať otvorené stránky</translation>
-<translation id="6378173571450987352">Podrobnosti: zoradené podľa množstva využitých dát</translation>
-<translation id="6381421346744604172">Stmaviť weby</translation>
-<translation id="6388207532828177975">Vymazať a resetovať</translation>
-<translation id="6393863479814692971">Chrome potrebuje povolenie pre tento web na prístup k vášmu fotoaparátu a mikrofónu.</translation>
-<translation id="6395288395575013217">ODKAZ</translation>
-<translation id="6404511346730675251">Upraviť záložku</translation>
-<translation id="6406506848690869874">Synchronizácia</translation>
-<translation id="641643625718530986">Tlačiť...</translation>
-<translation id="6416782512398055893">Stiahnuté: <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Preklad webu</translation>
-<translation id="6433501201775827830">Výber vyhľadávača</translation>
-<translation id="6437478888915024427">Informácie o stránke</translation>
-<translation id="6441734959916820584">Názov je príliš dlhý</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# obrázok}few{# obrázky}many{# Images}other{# obrázkov}}</translation>
-<translation id="6447842834002726250">Súbory cookie</translation>
-<translation id="6461962085415701688">Súbor sa nedá otvoriť</translation>
-<translation id="6464977750820128603">Môžete si zobraziť weby, ktoré navštevujete v Chrome, a nastaviť pre ne časovače.\n\nGoogle získa informácie o weboch, pre ktoré nastavíte časovače, a údaje o tom, koľko času na nich strávite. Tieto informácie sa použijú na zlepšenie digitálnej rovnováhy.</translation>
-<translation id="6475951671322991020">Stiahnuť video</translation>
-<translation id="6482749332252372425">Súbor <ph name="FILE_NAME" /> sa nepodarilo stiahnuť z dôvodu nedostatku voľného miesta v úložisku.</translation>
-<translation id="6496823230996795692">Prvé spustenie aplikácie <ph name="APP_NAME" /> vyžaduje pripojenie k internetu.</translation>
-<translation id="6508722015517270189">Reštartujte Chrome</translation>
-<translation id="6527303717912515753">Zdieľať</translation>
-<translation id="6532866250404780454">Weby, ktoré navštívite v Chrome, sa nezobrazia. Odstránia sa všetky časovače webov.</translation>
-<translation id="6534565668554028783">Odpoveď Googlu trvala príliš dlho</translation>
-<translation id="6538442820324228105">Stiahnuté: <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Vyskytol sa problém. Skúste to znova neskôr.</translation>
-<translation id="654446541061731451">Vyberte kartu, ktorú chcete preniesť</translation>
-<translation id="6545017243486555795">Vymazať všetky dáta</translation>
-<translation id="6545864417968258051">Vyhľadávanie zariadení Bluetooth</translation>
-<translation id="6560414384669816528">Vyhľadávať pomocou Sogou</translation>
-<translation id="6566259936974865419">Chrome ušetril <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Vždy povoliť</translation>
-<translation id="6573431926118603307">Tu sa zobrazia karty, ktoré ste otvorili v Chrome na iných zariadeniach.</translation>
-<translation id="6583199322650523874">Pridanie aktuálnej stránky medzi záložky</translation>
-<translation id="6593061639179217415">Web pre počítače</translation>
-<translation id="6600954340915313787">Skopírovaná do prehliadača Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Chránený obsah</translation>
-<translation id="6627583120233659107">Upraviť priečinok</translation>
-<translation id="6643016212128521049">Vymazať</translation>
-<translation id="6643649862576733715">Zoradiť podľa množstva ušetrených dát</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ďalší}few{<ph name="CONTACT_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ďalšie}many{<ph name="CONTACT_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ďalšieho}other{<ph name="CONTACT_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> ďalších}}</translation>
-<translation id="6649642165559792194">Zobraziť ukážku obrázka <ph name="BEGIN_NEW" />Novinka<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Na to, aby mohol Chrome hľadať zariadenia, musí mať prístup k polohe. <ph name="BEGIN_LINK" />Aktualizovať povolenia<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Heslo</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Otvoriť v aplikácii <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Oznámenie o ochrane súkromia prehliadača Chrome</translation>
-<translation id="6676840375528380067">Chcete vymazať údaje Chromu z tohto zariadenia?</translation>
-<translation id="6697492270171225480">Zobraziť návrhy podobných stránok, keď sa stránka nedá nájsť</translation>
-<translation id="6697947395630195233">Chrome potrebuje prístup k vašej polohe, aby ju mohol zdieľať s týmto webom.</translation>
-<translation id="6698801883190606802">Spravovať synchronizované údaje</translation>
-<translation id="6699370405921460408">Servery Googlu budú optimalizovať stránky, ktoré navštívite.</translation>
-<translation id="6706288973712894588">Momentálne ste offline.\n<ph name="BEGIN_LINK" />Preskúmajte svoj feed offline.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">News</translation>
-<translation id="6710213216561001401">Dozadu</translation>
-<translation id="671481426037969117">Časovač aplikácie <ph name="FQDN" /> vypršal. Spustí sa zase zajtra.</translation>
-<translation id="6738867403308150051">Sťahuje sa...</translation>
-<translation id="6746124502594467657">Presunúť nadol</translation>
-<translation id="6766622839693428701">Zatvorte potiahnutím dole.</translation>
-<translation id="6766758767654711248">Kliknutím prejdite na web</translation>
-<translation id="6767294960381293877">Zoznam zariadení, s ktorými sa má zdieľať karta, je otvorený na polovičnú výšku.</translation>
-<translation id="6782111308708962316">Brániť webom tretích strán ukladať a čítať súbory cookie</translation>
-<translation id="6790428901817661496">Prehrať</translation>
-<translation id="6811034713472274749">Stránka je pripravená na prezeranie</translation>
-<translation id="6818926723028410516">Vyberte položky</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Preložiť</translation>
-<translation id="6845325883481699275">Pomoc so zlepšením zabezpečenia Chromu</translation>
-<translation id="6846298663435243399">Prebieha načítanie…</translation>
-<translation id="6850409657436465440">Sťahovanie stále prebieha</translation>
-<translation id="6850830437481525139">Zatvorené karty: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Stiahnuť obrázok</translation>
-<translation id="6865313869410766144">Dáta automatického dopĺňania formulárov</translation>
-<translation id="688738109438487280">Pridať existujúce dáta do účtu <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Heslo môžete kopírovať po odomknutí</translation>
-<translation id="6896758677409633944">Kopírovať</translation>
-<translation id="6910211073230771657">Odstránené</translation>
-<translation id="6912998170423641340">Zakázať webom čítať text a obrázky v schránke</translation>
-<translation id="6914783257214138813">Vaše heslá uvidí každý, kto si môže zobraziť exportovaný súbor.</translation>
-<translation id="6942665639005891494">Kedykoľvek zmeniť predvolené umiestnenie stiahnutých súborov pomocou možnosti ponuky Nastavenia</translation>
-<translation id="6945221475159498467">Vybrať</translation>
-<translation id="6963642900430330478">Táto stránka je nebezpečná. Informácie o webe</translation>
-<translation id="6963766334940102469">Odstrániť záložky</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Celé obdobie</translation>
-<translation id="6981982820502123353">Dostupnosť</translation>
-<translation id="6989267951144302301">Nepodarilo sa stiahnuť</translation>
-<translation id="6990079615885386641">Získať aplikáciu z Obchodu Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Opýtať sa pred povolením webu používať váš mikrofón (odporúčané)</translation>
-<translation id="7015203776128479407">Počiatočné nastavenie synchronizácie nebolo dokončené. Synchronizácia je vypnutá.</translation>
-<translation id="7016516562562142042">Povolené v aktuálnom vyhľadávači</translation>
-<translation id="7022756207310403729">Otvoriť v prehliadači</translation>
-<translation id="702463548815491781">Odporúčané, keď je zapnutá aplikácia TalkBack alebo prístup s prepínačmi</translation>
-<translation id="7029809446516969842">Heslá</translation>
-<translation id="7053983685419859001">Blokovať</translation>
-<translation id="7055152154916055070">Presmerovanie bolo zablokované:</translation>
-<translation id="7063006564040364415">Nepodarilo sa pripojiť k synchronizačnému serveru.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 vybratá položka}few{# vybraté položky}many{Niekoľko (#) vybratých položiek}other{# vybratých položiek}}</translation>
-<translation id="7071521146534760487">Spravovať účet</translation>
-<translation id="7077143737582773186">SD karta</translation>
-<translation id="7087918508125750058">Vybrané: <ph name="ITEM_COUNT" />.  Možnosti sú k dispozícii v hornej časti obrazovky.</translation>
-<translation id="7121362699166175603">Vymaže históriu a záznamy automatického dopĺňania v paneli s adresou. Váš účet Google môže mať ďalšie formy histórie prehliadania na adrese <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Povoliť pre aktuálny vyhľadávač</translation>
-<translation id="7138678301420049075">Ostatné</translation>
-<translation id="7141896414559753902">Zakázať webom otvárať vyskakovacie okná a používať presmerovania (odporúčané)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Načítať pôvodnú stránku<ph name="END_LINK" /> z domény <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Posledných 24 hodín</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Zmeniť to môžete neskôr v časti Nastavenia</translation>
-<translation id="7180611975245234373">Obnoviť</translation>
-<translation id="7189372733857464326">Čaká sa na dokončenie aktualizácie služieb Google Play Services</translation>
-<translation id="7191430249889272776">Karta je otvorená na pozadí.</translation>
-<translation id="723171743924126238">Výber obrázkov</translation>
-<translation id="7233236755231902816">Ak chcete príslušný web zobraziť vo svojom jazyku, nainštalujte si najnovšiu verziu Chromu</translation>
-<translation id="7243308994586599757">Možnosti sú k dispozícii v dolnej časti obrazovky</translation>
-<translation id="7248069434667874558">Skontrolujte, či má <ph name="TARGET_DEVICE_NAME" /> v Chrome zapnutú synchronizáciu</translation>
-<translation id="7250468141469952378">Vybrané: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Blokovaný web</translation>
-<translation id="7290209999329137901">Premenovanie nie je k dispozícii</translation>
-<translation id="7291387454912369099">Platenie pomocou Asistenta</translation>
-<translation id="7293171162284876153">Ak chcete spustiť synchronizáciu, zapnite možnosť „Synchronizovať údaje Chromu“.</translation>
-<translation id="729975465115245577">Vaše zariadenie nemá aplikáciu na uloženie súboru s heslami.</translation>
-<translation id="7302081693174882195">Podrobnosti: zoradené podľa množstva ušetrených dát</translation>
-<translation id="7328017930301109123">V zjednodušenom režime načítava Chrome stránky rýchlejšie a využíva až o 60 percent menej dát.</translation>
-<translation id="7333031090786104871">Pridávanie predchádzajúceho webu stále prebieha</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Zdieľať 1 vybranú položku}few{Zdieľať # vybrané položky}many{Zdieľať # vybranej položky}other{Zdieľať # vybraných položiek}}</translation>
 <translation id="7359002509206457351">Poskytnúť prístup k spôsobom platby</translation>
+<translation id="8026334261755873520">Vymazať dáta prehliadania</translation>
+<translation id="1291207594882862231">Vymazať históriu, súbory cookie, dáta webov, vyrovnávaciu pamäť…</translation>
+<translation id="7814200940910057384">Údaje Chromu boli vymazané</translation>
+<translation id="1664855196866195614">Vybrané údaje boli odstránené z Chromu a vašich synchronizovaných zariadení.
+
+Váš účet Brave Software môže mať na adrese <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> ďalšie formy histórie prehliadania, ako napríklad vyhľadávania a aktivity v iných službách Googlu.</translation>
+<translation id="4699172675775169585">Obrázky a súbory vo vyrovnávacej pamäti</translation>
+<translation id="2496180316473517155">História prehliadania</translation>
+<translation id="2546283357679194313">Súbory cookie a dáta webov</translation>
+<translation id="8662811608048051533">Odhlási vás z väčšiny webov.</translation>
+<translation id="8218628800671693884">Odhlási vás z väčšiny webov, ale nie z účtu Brave Software.</translation>
+<translation id="2017836877785168846">Vymaže históriu a automaticky doplňované výrazy v paneli s adresou.</translation>
+<translation id="8096327394278038498">Vymaže históriu a záznamy automatického dopĺňania v paneli s adresou. Váš účet Brave Software môže mať ďalšie formy histórie prehliadania na adrese <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Vymaže históriu zo všetkých prihlásených zariadení. Váš účet Brave Software môže mať ďalšie formy histórie prehliadania na adrese <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Uložené heslá</translation>
+<translation id="6865313869410766144">Dáta automatického dopĺňania formulárov</translation>
+<translation id="7562080006725997899">Vymazávajú sa údaje prehliadania</translation>
+<translation id="5487521232677179737">Vymazať dáta</translation>
+<translation id="7498271377022651285">Čakajte…</translation>
+<translation id="784934925303690534">Obdobie</translation>
+<translation id="1718835860248848330">Posledná hodina</translation>
+<translation id="7149893636342594995">Posledných 24 hodín</translation>
+<translation id="5648166631817621825">Posledných 7 dní</translation>
+<translation id="8571213806525832805">Posledné 4 týždne</translation>
+<translation id="5854790677617711513">Staršie ako 30 dní</translation>
+<translation id="6979737339423435258">Celé obdobie</translation>
+<translation id="982182592107339124">Vymažete dáta všetkých webov vrátane týchto:</translation>
+<translation id="6643016212128521049">Vymazať</translation>
+<translation id="7641339528570811325">Vymazať dáta prehliadania…</translation>
+<translation id="1670399744444387456">Základné</translation>
+<translation id="3245261285041759672">Váš účet Brave Software môže mať ďalšie formy histórie prehliadania na adrese <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Blokovaný web</translation>
+<translation id="2534155362429831547">Odstránené položky: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Správy o použití a o zlyhaní</translation>
+<translation id="9079153198295609735">Automaticky odosielať Googlu štatistiky používania a správy o zlyhaní</translation>
+<translation id="6981982820502123353">Dostupnosť</translation>
+<translation id="2387895666653383613">Mierka textu</translation>
+<translation id="2321958826496381788">Presúvajte posúvač, dokým nebude čítanie tohto textu pohodlné. Po dvojitom klepnutí na odsek by mal byť text aspoň takto veľký.</translation>
+<translation id="3895926599014793903">Vynútiť povolenie priblíženia</translation>
+<translation id="5668404140385795438">Ignorovať požiadavku webových stránok na zákaz priblíženia</translation>
+<translation id="4149994727733219643">Jednoduché zobrazenie webových stránok</translation>
+<translation id="9100505651305367705">Ponúkať zjednodušené zobrazenie článkov (ak je podporované)</translation>
+<translation id="1409426117486808224">Jednoduché zobrazenie otvorených kariet</translation>
+<translation id="702463548815491781">Odporúčané, keď je zapnutá aplikácia TalkBack alebo prístup s prepínačmi</translation>
+<translation id="8284326494547611709">Titulky</translation>
+<translation id="4165986682804962316">Nastavenia webu</translation>
+<translation id="6295158916970320988">Všetky stránky</translation>
+<translation id="8380167699614421159">Tento web zobrazuje obťažujúce alebo zavádzajúce reklamy</translation>
+<translation id="1919345977826869612">Reklamy</translation>
+<translation id="410351446219883937">Automatické prehrávanie</translation>
+<translation id="6447842834002726250">Súbory cookie</translation>
+<translation id="6196640612572343990">Blokovať súbory cookie tretích strán</translation>
+<translation id="6782111308708962316">Brániť webom tretích strán ukladať a čítať súbory cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Vyskakovacie okná a presmerovania</translation>
+<translation id="4751476147751820511">Senzory pohybu alebo svetla</translation>
+<translation id="1717218214683051432">Senzory pohybu</translation>
+<translation id="2091887806945687916">Zvuk</translation>
+<translation id="2586657967955657006">Schránka</translation>
+<translation id="6320088164292336938">Vibrovanie</translation>
+<translation id="4226663524361240545">Upozornenia môžu pri prijatí na zariadení spustiť vibrovanie</translation>
+<translation id="1446450296470737166">Povoliť úplné ovlád. zar. MIDI</translation>
+<translation id="3744111561329211289">Synchronizácia na pozadí</translation>
+<translation id="5649053991847567735">Automatické sťahovanie</translation>
+<translation id="6181444274883918285">Pridať výnimku pre web</translation>
+<translation id="5313967007315987356">Pridať web</translation>
+<translation id="1369915414381695676">Boli pridané stránky <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Povoliť automatické prehrávanie stlmených videí pre konkrétny web.</translation>
+<translation id="2621115761605608342">Povoliť JavaScript pre konkrétny web.</translation>
+<translation id="8801436777607969138">Zablokujte JavaScript pre konkrétny web.</translation>
+<translation id="8372893542064058268">Povolenie synchronizácie na pozadí na konkrétnom webe.</translation>
+<translation id="358794129225322306">Povoľuje webu automaticky sťahovať viacero súborov súčasne.</translation>
+<translation id="4008040567710660924">Povolenie súborov cookie konkrétneho webu</translation>
+<translation id="8958424370300090006">Blokovanie súborov cookie konkrétneho webu</translation>
+<translation id="7882806643839505685">Povoliť zvuk pre konkrétny web.</translation>
+<translation id="4468959413250150279">Vypnite zvuk konkrétneho webu.</translation>
+<translation id="1994173015038366702">Webová adresa</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Použitie</translation>
+<translation id="5804241973901381774">Povolenia</translation>
+<translation id="4278390842282768270">Povolené</translation>
+<translation id="5677928146339483299">Blokované</translation>
+<translation id="1984937141057606926">Povolené (okrem tretích strán)</translation>
+<translation id="7423098979219808738">Najprv sa opýtať</translation>
+<translation id="8116925261070264013">Zvuk bol vypnutý</translation>
+<translation id="8300705686683892304">Spravované aplikáciou</translation>
+<translation id="6192792657125177640">Výnimky</translation>
+<translation id="257931822824936280">Rozbalená (zbalíte ju kliknutím)</translation>
+<translation id="5100237604440890931">Zbalená (rozbalíte ju kliknutím)</translation>
+<translation id="857943718398505171">Povolené (odporúčané)</translation>
+<translation id="2913331724188855103">Povoliť webom ukladať a čítať súbory cookie (odporučané)</translation>
+<translation id="7445411102860286510">Povoliť webom automaticky prehrávať stlmené videá (odporúča sa)</translation>
+<translation id="5335288049665977812">Povoliť webom spúšťať JavaScript (odporúča sa)</translation>
+<translation id="5527111080432883924">Pýtať sa, či chcete povoliť webu čítať text a obrázky v schránke (odporúčané)</translation>
+<translation id="6912998170423641340">Zakázať webom čítať text a obrázky v schránke</translation>
+<translation id="7423538860840206698">Blokovať čítanie schránky</translation>
+<translation id="3955193568934677022">Povoliť webom prehrávať chránený obsah (odporúčané)</translation>
+<translation id="445467742685312942">Povoliť webom prehrávať chránený obsah</translation>
+<translation id="2107397443965016585">Pýtať sa, či chcete povoliť webu prehrávať chránený obsah (odporúčané)</translation>
+<translation id="2910701580606108292">Pýtať sa, či chcete povoliť webu prehrávať chránený obsah</translation>
+<translation id="757524316907819857">Zakázať webom prehrávať chránený obsah</translation>
+<translation id="3277252321222022663">Povoliť webom prístup k senzorom (odporúčané)</translation>
+<translation id="5048398596102334565">Povoliť webom prístup k senzorom pohybu (odporúčané)</translation>
+<translation id="8816026460808729765">Zablokovať webom prístup k senzorom</translation>
+<translation id="169515064810179024">Blokovať webom prístup k senzorom pohybu</translation>
+<translation id="1660204651932907780">Povoliť webom prehrávať zvuk (odporúčané)</translation>
+<translation id="3600792891314830896">Stlmiť weby, ktoré prehrávajú zvuk</translation>
+<translation id="1743802530341753419">Pýtať sa, či chcete povoliť webu pripojiť sa k zariadeniu (odporúčané)</translation>
+<translation id="851751545965956758">Zakázať webom pripájať sa k zariadeniam</translation>
+<translation id="7141896414559753902">Zakázať webom otvárať vyskakovacie okná a používať presmerovania (odporúčané)</translation>
+<translation id="5494752089476963479">Blokovať reklamy webov, ktoré zobrazujú obťažujúce alebo zavádzajúce reklamy</translation>
+<translation id="3123473560110926937">Blokované na niektorých weboch</translation>
+<translation id="965817943346481315">Blokovať, ak web zobrazuje obťažujúce alebo zavádzajúce reklamy (odporúčané)</translation>
+<translation id="3386292677130313581">Pýtať sa, či chcete povoliť webu zisťovať vašu polohu (odporúčané)</translation>
+<translation id="9139068048179869749">Pýtať sa, či chcete povoliť webu odosielať upozornenia (odporúčané)</translation>
+<translation id="4479647676395637221">Opýtať sa pred povolením webu používať vašu kameru (odporúčané)</translation>
+<translation id="6992289844737586249">Opýtať sa pred povolením webu používať váš mikrofón (odporúčané)</translation>
+<translation id="2289270750774289114">Opýtať sa, keď chce web objavovať zariadenia Bluetooth v okolí (odporúčané)</translation>
+<translation id="7053983685419859001">Blokovať</translation>
+<translation id="7128222689758636196">Povoliť pre aktuálny vyhľadávač</translation>
+<translation id="7589445247086920869">Blokovať pre aktuálny vyhľadávač</translation>
+<translation id="6388207532828177975">Vymazať a resetovať</translation>
+<translation id="7999064672810608036">Naozaj chcete vymazať všetky miestne dáta tohto webu, vrátane súborov cookie, a resetovať všetky jeho povolenia?</translation>
+<translation id="2822354292072154809">Naozaj chcete resetovať všetky povolenia webu pre <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Vymazanie uložených dát</translation>
+<translation id="5902828464777634901">Všetky miestne údaje uložené týmto webom, vrátane súborov cookie, budú odstránené.</translation>
+<translation id="119944043368869598">Vymazať všetko</translation>
+<translation id="2490684707762498678">Spravuje <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Otvoriť nastavenia upozornení</translation>
+<translation id="1404122904123200417">Vložené na webe <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Tu sa zobrazia súbory uložené webmi</translation>
+<translation id="4181841719683918333">Jazyky</translation>
+<translation id="2647434099613338025">Pridať jazyk</translation>
+<translation id="1952172573699511566">Ak to bude možné, weby budú zobrazovať text vo vašom preferovanom jazyku.</translation>
+<translation id="8559990750235505898">Ponúkať preklad stránok v ďalších jazykoch</translation>
+<translation id="4719927025381752090">Ponúkať preklad</translation>
+<translation id="8156139159503939589">Akým jazykom rozumiete?</translation>
+<translation id="5689516760719285838">Poloha</translation>
+<translation id="2440823041667407902">Prístup k polohe</translation>
+<translation id="2023546461831060654">Zapnite povolenia pre Brave v <ph name="BEGIN_LINK"/>nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Zapnite povolenie pre Brave v <ph name="BEGIN_LINK"/>nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Ak chcete povoliť Chromu používať vašu polohu, zapnite ju aj v <ph name="BEGIN_LINK"/>Nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Ak chcete povoliť Chromu používať fotoaparát, zapnite ho aj v <ph name="BEGIN_LINK"/>Nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Ak chcete povoliť Chromu odosielať vám upozornenia, zapnite ich aj v <ph name="BEGIN_LINK"/>Nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Ak chcete povoliť Chromu používať mikrofón, zapnite ho aj v <ph name="BEGIN_LINK"/>Nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Prístup k polohe je v tomto zariadení vypnutý. Zapnite ho v <ph name="BEGIN_LINK"/>Nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Prístup k polohe je vypnutý aj v tomto zariadení. Zapnite ho v <ph name="BEGIN_LINK"/>Nastaveniach Androidu<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofón</translation>
+<translation id="1647391597548383849">Prístup ku kamere</translation>
+<translation id="945632385593298557">Prístup k mikrofónu</translation>
+<translation id="6612358246767739896">Chránený obsah</translation>
+<translation id="885701979325669005">Úložisko</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> uložených dát</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Odvolať povolenie pre zariadenie</translation>
+<translation id="4962975101802056554">Odvolať všetky povolenia pre zariadenie</translation>
+<translation id="6545864417968258051">Vyhľadávanie zariadení Bluetooth</translation>
+<translation id="4411535500181276704">Zjednodušený režim</translation>
+<translation id="7821588508402923572">Tu sa zobrazí úspora dát</translation>
+<translation id="2131665479022868825">Uložené: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">od <ph name="DATE"/></translation>
+<translation id="3252158532344029638">V zjednodušenom režime načítava Brave stránky rýchlejšie a využíva až o 60 percent menej dát.</translation>
+<translation id="6159335304067198720">Úspora dát: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">uložené dáta</translation>
+<translation id="6111020039983847643">využité dáta</translation>
+<translation id="7413229368719586778">Dátum začatia: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Dátum ukončenia: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Zoradiť podľa webu</translation>
+<translation id="5864174910718532887">Podrobnosti: zoradené podľa názvu webu</translation>
+<translation id="116280672541001035">Použité</translation>
+<translation id="8349013245300336738">Zoradiť podľa množstva využitých dát</translation>
+<translation id="6378173571450987352">Podrobnosti: zoradené podľa množstva využitých dát</translation>
+<translation id="2631006050119455616">Uložené</translation>
+<translation id="6643649862576733715">Zoradiť podľa množstva ušetrených dát</translation>
+<translation id="7302081693174882195">Podrobnosti: zoradené podľa množstva ušetrených dát</translation>
+<translation id="4179980317383591987">Využité: <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Ušetrené: <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Zostávajúce weby (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Ostatné</translation>
+<translation id="4913161338056004800">Resetovať štatistiky</translation>
+<translation id="1856325424225101786">Chcete zjednodušený režim obnoviť?</translation>
+<translation id="3658159451045945436">Obnovením vymažete svoju históriu úspory dát aj zoznam navštívených webov.</translation>
+<translation id="3295530008794733555">Prehliadajte rýchlejšie. Využívajte menej dát.</translation>
+<translation id="7340390500800578919">V zjednodušenom režime načítava Brave stránky rýchlejšie a využíva až o 60 percent menej dát. Brave odosiela údaje o vašej návštevnosti webu do Googlu, ktorý na základe nich optimalizuje vami navštevované stránky. <ph name="BEGIN_LINK"/>Ďalšie informácie<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Zapnúť zjednodušený režim</translation>
+<translation id="4493497663118223949">Zjednodušený režim je zapnutý</translation>
+<translation id="7559975015014302720">Zjednodušený režim je vypnutý</translation>
+<translation id="7606077192958116810">Zjednodušený režim je zapnutý. Spravujte ho v Nastaveniach.</translation>
+<translation id="4714588616299687897">Ušetrite až 60 % dát</translation>
+<translation id="1006927014032731288">Servery Googlu budú optimalizovať stránky, ktoré navštívite.</translation>
+<translation id="3257320067425202300">Brave ušetril <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave ušetril <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Umiestnenie sťahovaných súborov</translation>
+<translation id="7077143737582773186">SD karta</translation>
+<translation id="7762668264895820836">SD karta <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Pýtať sa, kde uložiť súbory</translation>
+<translation id="6192333916571137726">Sťahovanie súboru</translation>
+<translation id="1672586136351118594">Nabudúce nezobrazovať</translation>
+<translation id="2650751991977523696">Stiahnuť súbor znova?</translation>
+<translation id="8664979001105139458">Súbor s takým názvom už existuje</translation>
+<translation id="488187801263602086">Premenovanie súboru</translation>
+<translation id="5686790454216892815">Názov súboru je príliš dlhý</translation>
+<translation id="7454641608352164238">Nedostatok miesta</translation>
+<translation id="8972098258593396643">Stiahnuť do predvoleného priečinka?</translation>
+<translation id="804335162455518893">SD karta sa nenašla</translation>
+<translation id="7475688122056506577">SD karta sa nenašla. Môžu chýbať niektoré súbory.</translation>
+<translation id="4198423547019359126">Nie sú k dispozícii žiadne umiestnenia stiahnutých súborov</translation>
+<translation id="8224471946457685718">Sťahovať články cez Wi-Fi</translation>
+<translation id="4970824347203572753">Nie je k dispozícii vo vašej krajine</translation>
+<translation id="5500777121964041360">Nemusí byť k dispozícii vo vašej krajine</translation>
+<translation id="1173894706177603556">Premenovať</translation>
+<translation id="1986685561493779662">Názov už existuje</translation>
+<translation id="6441734959916820584">Názov je príliš dlhý</translation>
+<translation id="2923908459366352541">Názov je neplatný</translation>
+<translation id="7290209999329137901">Premenovanie nie je k dispozícii</translation>
+<translation id="3334729583274622784">Chcete zmeniť príponu súboru?</translation>
+<translation id="107147699690128016">Ak zmeníte príponu súboru, súbor sa môže otvoriť v inej aplikácii a potenciálne ohroziť vaše zariadenie.</translation>
+<translation id="8541922081612557424">O prehliadači Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Všetky práva vyhradené.</translation>
+<translation id="1416550906796893042">Verzia aplikácie</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Aktualizované <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operačný systém</translation>
+<translation id="3968054912784331254">Pre túto verziu Androidu už nie sú podporované aktualizácie Chromu</translation>
+<translation id="7665369617277396874">Pridať účet</translation>
+<translation id="649070405679044769">Prihlásený účet Brave Software</translation>
+<translation id="6234515504547364178">Odhlásiť sa z Chromu</translation>
+<translation id="5324858694974489420">Rodičovské nastavenia</translation>
+<translation id="8920114477895755567">Čaká sa na podrobnosti o rodičoch.</translation>
+<translation id="5512137114520586844">Tento účet je spravovaný používateľom <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Tento účet je spravovaný používateľmi <ph name="PARENT_NAME_1"/> a <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Obsah</translation>
+<translation id="5403644198645076998">Povoliť len určité weby</translation>
+<translation id="8641930654639604085">Pokúsiť sa blokovať weby pre dospelých</translation>
+<translation id="5639724618331995626">Povoliť všetky weby</translation>
+<translation id="796823723482603597">Používa technológiu prehliadača Brave</translation>
+<translation id="6324034347079777476">Synchronizácia systému Android je zakázaná</translation>
+<translation id="5127805178023152808">Synchronizácia je vypnutá.</translation>
+<translation id="7015203776128479407">Počiatočné nastavenie synchronizácie nebolo dokončené. Synchronizácia je vypnutá.</translation>
+<translation id="2497852260688568942">Synchronizácia je zakázaná správcom</translation>
+<translation id="9100610230175265781">Vyžaduje sa prístupová fráza</translation>
+<translation id="6108923351542677676">Inštaluje sa...</translation>
+<translation id="4062305924942672200">Právne informácie</translation>
+<translation id="4256782883801055595">Licencie open source</translation>
+<translation id="1138681184697033370">Zmluvné podmienky prehliadača Brave</translation>
+<translation id="7392539049993970338">Oznámenie o ochrane súkromia prehliadača Brave</translation>
+<translation id="2677748264148917807">Odísť</translation>
+<translation id="5556459405103347317">Znova načítať</translation>
+<translation id="1623104350909869708">Zakázať tejto stránke otvárať ďalšie dialógové okná</translation>
+<translation id="2968755619301702150">Zobrazovač certifikátov</translation>
+<translation id="1360432990279830238">Odhlásiť sa a vypnúť synchronizáciu?</translation>
+<translation id="8581481290581777242">Chcete vymazať údaje Chromu z tohto zariadenia?</translation>
+<translation id="1318865768845061710">Vaše záložky, história, heslá a ďalšie údaje Chromu nebudú viac synchronizované s účtom Brave Software</translation>
+<translation id="3325020657155065477">Tiež vymazať údaje Chromu z tohto zariadenia</translation>
+<translation id="6136448902816743006">Keďže sa odhlasujete z účtu spravovaného doménou <ph name="DOMAIN_NAME"/>, budú údaje Chromu z tohto zariadenia odstránené. Zostanú vo vašom účte Brave Software.</translation>
+<translation id="1853026300647876496">Kontaktuje sa Brave Software. Môže to chvíľu trvať…</translation>
+<translation id="2328985652426384049">Nedá sa prihlásiť</translation>
+<translation id="7723158744459952869">Odpoveď Googlu trvala príliš dlho</translation>
+<translation id="4572422548854449519">Prihlásenie do spravovaného účtu</translation>
+<translation id="2689656545739939160">Prihlasujete sa pomocou účtu spravovaného doménou <ph name="MANAGED_DOMAIN"/> a jej správcovi tým dávate kontrolu nad svojimi údajmi Chromu. Vaše údaje budú natrvalo prepojené s týmto účtom. Odhlásením z Chromu odstránite údaje z príslušného zariadenia, avšak naďalej zostanú uložené vo vašom účte Brave Software.</translation>
+<translation id="1749561566933687563">Synchronizujte svoje záložky</translation>
+<translation id="4242533952199664413">Otvoriť nastavenia</translation>
+<translation id="1111673857033749125">Tu sa zobrazia záložky, ktoré ste uložili na iných zariadeniach.</translation>
+<translation id="8636825310635137004">Ak chcete získať karty zo svojich ostatných zariadení, zapnite synchronizáciu.</translation>
+<translation id="3269956123044984603">Ak chcete získať karty z vašich ďalších zariadení, zapnite v nastaveniach účtu Android možnosť Automaticky synchronizovať dáta.</translation>
+<translation id="5157964048453367290">Tu sa zobrazia karty, ktoré ste otvorili v Brave na iných zariadeniach.</translation>
+<translation id="4684427112815847243">Synchronizovať všetko</translation>
+<translation id="2709516037105925701">Automatické dopĺňanie</translation>
+<translation id="8820817407110198400">Záložky</translation>
+<translation id="1644574205037202324">História</translation>
+<translation id="17513872634828108">Otvorené karty</translation>
+<translation id="1320169905922104972">Kreditné karty a adresy pomocou služby Brave Software Pay</translation>
+<translation id="6337234675334993532">Šifrovanie</translation>
+<translation id="6698801883190606802">Spravovať synchronizované údaje</translation>
+<translation id="3598578758776312506">Šifrovať heslá pomocou poverení Brave Software</translation>
+<translation id="7810580217418711046">Šifrovať synchronizované údaje heslom Brave Software od <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Šifrovať synchronizované údaje pomocou vlastnej prístupovej frázy synchronizácie</translation>
+<translation id="2996291259634659425">Vytvorenie prístupovej frázy</translation>
+<translation id="5713644099811900409">účtu Brave Software</translation>
+<translation id="8997474919031554666">Šifrovanie prístupovej frázy nezahŕňa spôsoby platby a adresy zo služby Brave Software Pay. Šifrované údaje si môže prečítať iba používateľ s prístupovou frázou. Prístupová fráza sa neodosiela do Googlu ani sa v ňom neuchováva. Ak ju zabudnete alebo chcete toto nastavenie zmeniť, budete musieť resetovať synchronizáciu. <ph name="BEGIN_LINK"/>Ďalšie informácie<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Prístupová fráza</translation>
+<translation id="7772032839648071052">Potvrďte prístupovú frázu</translation>
+<translation id="5304593522240415983">Toto pole nesmie byť prázdne</translation>
+<translation id="321773570071367578">Ak ste zabudli prístupovú frázu alebo chcete toto nastavenie zmeniť, <ph name="BEGIN_LINK"/>resetujte synchronizáciu<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Prístupové frázy sa nezhodujú</translation>
+<translation id="5149495116300586333">Šifrovanie prístupovej frázy nezahŕňa spôsoby platby a adresy zo služby Brave Software Pay.
+
+Ak chcete toto nastavenie zmeniť, <ph name="BEGIN_LINK"/>resetujte synchronizáciu<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Nesprávna prístupová fráza</translation>
+<translation id="5414836363063783498">Overuje sa...</translation>
+<translation id="6846298663435243399">Prebieha načítanie…</translation>
+<translation id="5517095782334947753">Máte záložky, históriu, heslá a ďalšie nastavenia z účtu <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Spojiť moje dáta</translation>
+<translation id="688738109438487280">Pridať existujúce dáta do účtu <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Ponechať moje dáta oddelené</translation>
+<translation id="1145536944570833626">Odstrániť existujúce dáta.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> žiada o spárovanie</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Získajte pomoc<ph name="END_LINK"/> s vyhľadávaním zariadení…</translation>
+<translation id="5817918615728894473">Párovať</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Získajte pomoc<ph name="END_LINK1"/> alebo <ph name="BEGIN_LINK2"/>znova spustite vyhľadávanie<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Nenašli sa žiadne kompatibilné zariadenia</translation>
+<translation id="3773755127849930740">Povoľte párovanie <ph name="BEGIN_LINK"/>zapnutím rozhrania Bluetooth<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave nedokáže zapnúť adaptér Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Získať pomoc<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Na to, aby mohol Brave hľadať zariadenia, musí mať prístup k polohe. <ph name="BEGIN_LINK"/>Aktualizovať povolenia<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Na to, aby mohol Brave hľadať zariadenia, musí mať prístup k polohe. Prístup k polohe je v tomto zariadení <ph name="BEGIN_LINK"/>vypnutý<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Na to, aby mohol Brave hľadať zariadenia, musí mať prístup k polohe. <ph name="BEGIN_LINK1"/>Aktualizujte povolenia<ph name="END_LINK1"/>. Prístup k polohe je <ph name="BEGIN_LINK2"/>vypnutý aj v tomto zariadení<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Pripojené zariadenie</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Úroveň sily signálu: # čiarka}few{Úroveň sily signálu: # čiarky}many{Úroveň sily signálu: # čiarky}other{Úroveň sily signálu: # čiarok}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> chce vyhľadávať zariadenia Bluetooth nablízku. Našli sa tieto zariadenia:</translation>
+<translation id="8368027906805972958">Neznáme alebo nepodporované zariadenie (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Synchronizácia nefunguje</translation>
+<translation id="1810845389119482123">Úvodné nastavenie synchronizácie nebolo dokončené</translation>
+<translation id="3235722914093408050">V nastaveniach Androidu spustite synchronizáciu Chromu opätovným povolením synchronizácie Androidu</translation>
+<translation id="3367813778245106622">Ak chcete spustiť synchronizáciu, znova sa prihláste</translation>
+<translation id="974555521953189084">Ak chcete spustiť synchronizáciu, zadajte prístupovú frázu</translation>
+<translation id="2997266899014181325">Ak chcete spustiť synchronizáciu, zapnite možnosť „Synchronizovať údaje Chromu“.</translation>
+<translation id="8260126382462817229">Skúste sa znova prihlásiť</translation>
+<translation id="5919204609460789179">Ak chcete spustiť synchronizáciu, aktualizujte aplikáciu <ph name="PRODUCT_NAME"/></translation>
+<translation id="397583555483684758">Synchronizácia prestala fungovať</translation>
+<translation id="1966710179511230534">Aktualizujte svoje prihlasovacie údaje.</translation>
+<translation id="7063006564040364415">Nepodarilo sa pripojiť k synchronizačnému serveru.</translation>
+<translation id="7942131818088350342">Aplikácia <ph name="PRODUCT_NAME"/> je zastaraná.</translation>
+<translation id="4170011742729630528">Služba nie je k dispozícii. Skúste to znova neskôr.</translation>
+<translation id="7947953824732555851">Prijať a prihl. sa</translation>
+<translation id="8583805026567836021">Prebieha vymazávanie údajov účtu</translation>
+<translation id="8310344678080805313">Štandardné karty</translation>
+<translation id="5748802427693696783">Prepnuté na štandardné karty</translation>
+<translation id="7998918019931843664">Znova otvoriť zavretú kartu</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, karta</translation>
+<translation id="4452411734226507615">Zavrieť kartu <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Možnosti sú k dispozícii v dolnej časti obrazovky</translation>
+<translation id="4060598801229743805">Možnosti sú k dispozícii v hornej časti obrazovky</translation>
+<translation id="2810645512293415242">Zjednodušená stránka vám pomôže ušetriť dáta a zrýchliť načítavanie.</translation>
+<translation id="3985215325736559418">Chcete znova stiahnuť súbor <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Chcete znovu spustiť sťahovanie súboru <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Stiahnuť</translation>
+<translation id="545042621069398927">Sťahovanie sa zrýchľuje.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Sťahuje sa súbor.}few{Sťahujú sa # súbory.}many{Downloading # files.}other{Sťahuje sa # súborov.}}</translation>
+<translation id="543509235395288790">Sťahuje sa niekoľko súborov (<ph name="COUNT"/>) s celkovou veľkosťou <ph name="MEGABYTES"/>.</translation>
+<translation id="4988210275050210843">Sťahuje sa súbor (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Dokončilo sa sťahovanie 1 položky.}few{Dokončilo sa sťahovanie # položiek.}many{# downloads complete.}other{Dokončilo sa sťahovanie # položiek.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Nepodarilo sa stiahnuť 1 položku.}few{Nepodarilo sa stiahnuť # položky.}many{# downloads failed.}other{Nepodarilo sa stiahnuť # položiek.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Na stiahnutie čaká 1 položka.}few{Na stiahnutie čakajú # položky.}many{# downloads pending.}other{Na stiahnutie čaká # položiek.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> tlačidlo <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Takmer hotovo!</translation>
+<translation id="3960299545138990065">Reštartujte Brave</translation>
+<translation id="3771001275138982843">Aktualizáciu sa nepodarilo stiahnuť</translation>
+<translation id="3888648114124182147">Sťahuje sa aktualizácia Chromu…</translation>
+<translation id="1705567146636171298">Aktualizovať Brave</translation>
+<translation id="6195417478702700398">Ak chcete zlepšiť prehliadanie, otvorte Brave a aktualizujte ho</translation>
+<translation id="3512968675351418494">Ak chcete príslušný web zobraziť vo svojom jazyku, nainštalujte si najnovšiu verziu Chromu</translation>
+<translation id="6427112570124116297">Preklad webu</translation>
+<translation id="1379423114029199501">Ak chcete získať svoj jazyk v najnovšej verzii Chromu, aktualizujte ho</translation>
+<translation id="5684874026226664614">Hops. Túto stránku nebolo možné preložiť.</translation>
+<translation id="6831043979455480757">Preložiť</translation>
+<translation id="1285320974508926690">Nikdy neprekladať tieto webové stránky</translation>
+<translation id="773466115871691567">Vždy prekladať stránky v jazyku <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nikdy neprekladať stránky v jazyku <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Ďalšie jazyky</translation>
+<translation id="290376772003165898">Stránka nie je v jazyku <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Stránky v jazyku <ph name="SOURCE_LANGUAGE"/> budú odteraz prekladané do jazyka <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Stránky v jazyku <ph name="LANGUAGE"/> nebudú prekladané</translation>
+<translation id="5447765697759493033">Tento web nebude preložený</translation>
+<translation id="4880127995492972015">Preložiť…</translation>
+<translation id="641643625718530986">Tlačiť...</translation>
+<translation id="8909135823018751308">Zdieľať…</translation>
+<translation id="4996978546172906250">Zdieľať</translation>
+<translation id="6333140779060797560">Zdieľať pomocou aplikácie <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Pri tlačení stránky sa vyskytol problém. Skúste to znova.</translation>
+<translation id="3254409185687681395">Vytvoriť záložku pre túto stránku</translation>
+<translation id="497421865427891073">Ďalej</translation>
+<translation id="813082847718468539">Zobraziť informácie o stránkach</translation>
+<translation id="2532336938189706096">Webové zobrazenie</translation>
+<translation id="6005538289190791541">Navrhované heslo</translation>
+<translation id="4634124774493850572">Použiť heslo</translation>
+<translation id="8285489906452138776">Brave potrebuje povolenie pre tento web na prístup k vášmu fotoaparátu.</translation>
+<translation id="320189792589364011">Brave potrebuje povolenie pre tento web na prístup k vášmu mikrofónu.</translation>
+<translation id="7988136689212463100">Brave potrebuje povolenie pre tento web na prístup k vášmu fotoaparátu a mikrofónu.</translation>
+<translation id="4931190655840828017">Brave potrebuje prístup k vašej polohe, aby ju mohol zdieľať s týmto webom.</translation>
+<translation id="3088191967551450609">Brave potrebuje na sťahovanie súborov prístup k úložisku.</translation>
+<translation id="8942627711005830162">Otvoriť v ďalšom okne</translation>
+<translation id="4195643157523330669">Otvoriť na novej karte</translation>
+<translation id="1100066534610197918">Otvoriť v skupine na novej karte</translation>
+<translation id="4860895144060829044">Volajte</translation>
+<translation id="6896758677409633944">Kopírovať</translation>
+<translation id="8393700583063109961">Odoslať správu</translation>
+<translation id="3557336313807607643">Pridať do kontaktov</translation>
+<translation id="4269820728363426813">Kopírovať adresu odkazu</translation>
+<translation id="1206892813135768548">Kopírovať text odkazu</translation>
+<translation id="1204037785786432551">Stiahnuť obsah odkazu</translation>
+<translation id="6864459304226931083">Stiahnuť obrázok</translation>
+<translation id="8209050860603202033">Otvoriť obrázok</translation>
+<translation id="8073388330009372546">Otvoriť obrázok na novej karte</translation>
+<translation id="6649642165559792194">Zobraziť ukážku obrázka <ph name="BEGIN_NEW"/>Novinka<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Načítať obrázok</translation>
+<translation id="3845332215609790146">Hľadať cez Brave Software Lens <ph name="BEGIN_NEW"/>Novinka<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Hľadať obrázok v službe <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Zdieľať obrázok</translation>
+<translation id="5833984609253377421">Zdieľať odkaz</translation>
+<translation id="6475951671322991020">Stiahnuť video</translation>
+<translation id="2317945146070194624">Otvoriť v Brave na novej karte</translation>
+<translation id="7975379999046275268">Zobraziť ukážku stránky <ph name="BEGIN_NEW"/>Novinka<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Obnovenie stránky</translation>
+<translation id="36525718899759834">Získať aplikáciu z Obchodu Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tmavý režim</translation>
+<translation id="1807246157184219062">Svetlý režim</translation>
+<translation id="4056223980640387499">Sépia</translation>
+<translation id="3927692899758076493">Bezpätkové</translation>
+<translation id="5016205925109358554">Pätkové</translation>
+<translation id="2593272815202181319">Neproporcionálne</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Vyberte kartu, ktorú chcete preniesť</translation>
+<translation id="8719023831149562936">Aktuálna karta sa nedá preniesť</translation>
+<translation id="2139186145475833000">Pridať na plochu</translation>
+<translation id="4616150815774728855">Otvoriť <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Aplikáciu sa nepodarilo otvoriť</translation>
+<translation id="5129038482087801250">Inštalovať webovú aplikáciu</translation>
+<translation id="3789841737615482174">Inštalovať</translation>
+<translation id="4665282149850138822">Stránky <ph name="NAME"/> boli pridané na plochu</translation>
+<translation id="7333031090786104871">Pridávanie predchádzajúceho webu stále prebieha</translation>
+<translation id="1036727731225946849">Pridáva sa <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Pridané na plochu</translation>
+<translation id="2146738493024040262">Otvoriť okamžitú aplikáciu</translation>
+<translation id="7016516562562142042">Povolené v aktuálnom vyhľadávači</translation>
+<translation id="6177111841848151710">Blokované v aktuálnom vyhľadávači</translation>
+<translation id="145097072038377568">Vypnuté v nastaveniach Androidu</translation>
+<translation id="8007176423574883786">Vypnuté v tomto zariadení</translation>
+<translation id="164269334534774161">Zobrazuje sa offline kópia tejto stránky z <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Táto offline stránka je z <ph name="CREATION_TIME"/> a líši sa od online verzie.</translation>
+<translation id="8840953339110955557">Táto stránka sa môže líšiť od online verzie.</translation>
+<translation id="6405300764336705484">Tento obsah pochádza z domény <ph name="DOMAIN_NAME"/> a bol doručený Googlom.</translation>
+<translation id="1006017844123154345">Otvoriť online</translation>
+<translation id="3326636747541519688">Zjednodušenú verziu stránky poskytol Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Načítať pôvodnú stránku<ph name="END_LINK"/> z domény <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Ak sa vám táto stránka zobrazuje často, skúste použiť tieto <ph name="BEGIN_LINK"/>návrhy<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Obsah je skrytý</translation>
+<translation id="3810973564298564668">Spravovať</translation>
+<translation id="5199929503336119739">Pracovný profil</translation>
+<translation id="528192093759286357">Režim celej obrazovky ukončíte potiahnutím z hornej časti a klepnutím na tlačidlo Späť.</translation>
+<translation id="2836148919159985482">Ukončite režim celej obrazovky klepnutím na tlačidlo Späť.</translation>
+<translation id="3967822245660637423">Sťahovanie dokončené</translation>
+<translation id="2434158240863470628">Sťahovanie bolo dokončené <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Stiahnutie zlyhalo</translation>
+<translation id="1384959399684842514">Sťahovanie bolo pozastavené</translation>
+<translation id="1671236975893690980">Čaká sa na stiahnutie…</translation>
+<translation id="5561549206367097665">Čaká sa na sieť…</translation>
+<translation id="5864419784173784555">Čaká sa na ďalší sťahovaný súbor…</translation>
+<translation id="6461962085415701688">Súbor sa nedá otvoriť</translation>
+<translation id="1178581264944972037">Pozastaviť</translation>
+<translation id="8200772114523450471">Pokračovať</translation>
+<translation id="1409879593029778104">Sťahovanie súboru <ph name="FILE_NAME"/> bolo zrušené, pretože daný súbor už existuje.</translation>
+<translation id="3387650086002190359">Súbor <ph name="FILE_NAME"/> sa nepodarilo stiahnuť z dôvodu chýb systému súborov.</translation>
+<translation id="6482749332252372425">Súbor <ph name="FILE_NAME"/> sa nepodarilo stiahnuť z dôvodu nedostatku voľného miesta v úložisku.</translation>
+<translation id="7619072057915878432">Súbor <ph name="FILE_NAME"/> sa nepodarilo stiahnuť z dôvodu problémov so sieťou.</translation>
+<translation id="1477626028522505441">Súbor <ph name="FILE_NAME"/> sa nepodarilo stiahnuť z dôvodu problémov so serverom.</translation>
+<translation id="3692944402865947621">Súbor <ph name="FILE_NAME"/> sa nepodarilo stiahnuť, pretože umiestnenie úložiska nie je k dispozícii.</translation>
+<translation id="604996488070107836">Súbor <ph name="FILE_NAME"/> sa nepodarilo stiahnuť z dôvodu neznámej chyby.</translation>
+<translation id="6738867403308150051">Sťahuje sa...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Stiahnuté: <ph name="KBS"/> kB</translation>
+<translation id="6416782512398055893">Stiahnuté: <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Stiahnuté: <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Zostáva 1 súbor</translation>
+<translation id="8186512483418048923">Zostávajúce súbory: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> stiahnutý súbor}few{<ph name="FILES_DOWNLOADED_MANY"/> stiahnuté súbory}many{<ph name="FILES_DOWNLOADED_MANY"/> files downloaded}other{<ph name="FILES_DOWNLOADED_MANY"/> stiahnutých súborov}}</translation>
+<translation id="8037750541064988519">Zostáva: <ph name="DAYS"/> d</translation>
+<translation id="8190358571722158785">Zostáva: 1 d</translation>
+<translation id="60923314841986378">Zostáva: <ph name="HOURS"/> h</translation>
+<translation id="510275257476243843">Zostáva: 1 h</translation>
+<translation id="970715775301869095">Zostáva: <ph name="MINUTES"/> min</translation>
+<translation id="3236059992281584593">Zostáva: 1 min</translation>
+<translation id="2777555524387840389">Zostáva: <ph name="SECONDS"/> s</translation>
+<translation id="2781151931089541271">Zostáva: 1 s</translation>
+<translation id="3303414029551471755">Pokračovať a stiahnuť obsah?</translation>
+<translation id="8617240290563765734">Otvoriť navrhovanú webovú adresu určenú v stiahnutom obsahu?</translation>
+<translation id="1373696734384179344">Vybraný obsah nie je možné stiahnuť z dôvodu nedostatku pamäte</translation>
+<translation id="5271967389191913893">Zariadenie nemôže otvoriť obsah na stiahnutie</translation>
+<translation id="883806473910249246">Pri sťahovaní obsahu sa vyskytla chyba.</translation>
+<translation id="5626134646977739690">Názov:</translation>
+<translation id="7963646190083259054">Dodávateľ:</translation>
+<translation id="3414952576877147120">Veľkosť:</translation>
+<translation id="7375125077091615385">Typ:</translation>
+<translation id="5765780083710877561">Popis:</translation>
+<translation id="4881695831933465202">Otvoriť</translation>
+<translation id="3542235761944717775">Voľné miesto: <ph name="KILOBYTES"/> kB</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB k dispozícii</translation>
+<translation id="5424588387303617268">K dispozícii je <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Využité: <ph name="SPACE_USED"/> z <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Všetko</translation>
+<translation id="4988526792673242964">Stránky</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Zvuk</translation>
+<translation id="9219103736887031265">Obrázky</translation>
+<translation id="8250920743982581267">Dokumenty</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# súbor}few{# súbory}many{# Files}other{# súborov}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# obrázok}few{# obrázky}many{# Images}other{# obrázkov}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}few{# videá}many{# Videos}other{# videí}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# zvukový súbor}few{# zvukové súbory}many{# Audio files}other{# zvukových súborov}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stránka}few{# stránky}many{# Pages}other{# stránok}}</translation>
+<translation id="5456381639095306749">Stránka sťahovania</translation>
+<translation id="2394602618534698961">Tu sa zobrazia stiahnuté súbory</translation>
+<translation id="7810647596859435254">Otvoriť pomocou…</translation>
+<translation id="5655963694829536461">Prehľadať stiahnuté</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Moje súbory</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Tu sa zobrazia články, ktoré môžete čítať dokonca aj offline</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# hod.}few{# hod.}many{# hod.}other{# hod.}}</translation>
+<translation id="5853623416121554550">pozastavené</translation>
+<translation id="8965591936373831584">nespracované</translation>
+<translation id="2779651927720337254">neúspešné</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Práve teraz</translation>
+<translation id="4000212216660919741">Offline domov</translation>
+<translation id="9133397713400217035">Preskúmať offline</translation>
+<translation id="968900484120156207">Tu sa zobrazia vami navštívené stránky</translation>
+<translation id="7882131421121961860">Nenašla sa žiadna história</translation>
+<translation id="3549657413697417275">Prehľadať históriu</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">RR</translation>
+<translation id="724102042129299115">Skúsenosť pri prvom spustení Chromu</translation>
+<translation id="2700285883409956633">Používaním tejto aplikácie vyjadrujete súhlas so <ph name="BEGIN_LINK1"/>zmluvnými podmienkami<ph name="END_LINK1"/> a <ph name="BEGIN_LINK2"/>oznámením o ochrane súkromia<ph name="END_LINK2"/> prehliadača Brave.</translation>
+<translation id="1640714894372474981">Používaním tejto aplikácie vyjadrujete súhlas so <ph name="BEGIN_LINK1"/>zmluvnými podmienkami<ph name="END_LINK1"/> prehliadača Brave a <ph name="BEGIN_LINK2"/>oznámením o ochrane súkromia<ph name="END_LINK2"/>, ako aj <ph name="BEGIN_LINK3"/>oznámením o ochrane súkromia pre účty Brave Software spravované pomocou aplikácie Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> sa otvorí v Brave. Pokračovaním vyjadrujete súhlas so <ph name="BEGIN_LINK1"/>zmluvnými podmienkami<ph name="END_LINK1"/> a <ph name="BEGIN_LINK2"/>upozornením o ochrane súkromia<ph name="END_LINK2"/> Chromu.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> sa otvorí v Brave. Pokračovaním vyjadrujete súhlas so <ph name="BEGIN_LINK1"/>zmluvnými podmienkami<ph name="END_LINK1"/> a <ph name="BEGIN_LINK2"/>oznámením o ochrane súkromia<ph name="END_LINK2"/> Chromu, ako aj <ph name="BEGIN_LINK3"/>oznámením o ochrane súkromia pre účty Brave Software spravované pomocou aplikácie Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Odosielať štatistiky používania a prehľady chýb Googlu a pomáhať tak zlepšovať Brave</translation>
+<translation id="3518985090088779359">Prijať a pokračovať</translation>
+<translation id="7207456302801184289">Víta vás prehliadač Brave</translation>
+<translation id="704822250101715322">Čaká sa na dokončenie aktualizácie služieb Brave Software Play Services</translation>
+<translation id="1231733316453485619">Chcete zapnúť synchronizáciu?</translation>
+<translation id="5132942445612118989">Synchronizujte svoje heslá, históriu a ďalší obsah vo všetkých zariadeniach</translation>
+<translation id="5736731321935944068">Brave Software môže pomocou vašej histórie prispôsobiť Vyhľadávanie, reklamy a ďalšie služby Googlu</translation>
+<translation id="4013614219085422040">Brave Software môže pomocou vašej histórie prispôsobiť Vyhľadávanie a ďalšie služby Googlu</translation>
+<translation id="5581519193887989363">Položky, ktoré chcete synchronizovať, môžete vybrať v <ph name="BEGIN_LINK1"/>nastaveniach<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Áno, súhlasím</translation>
+<translation id="2410754283952462441">Výber účtu</translation>
+<translation id="2227444325776770048">Pokračovať ako <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Nie som <ph name="EMAIL"/></translation>
+<translation id="8109613176066109935">Ak chcete získať záložky vo všetkých zariadeniach, zapnite synchronizáciu</translation>
+<translation id="2818669890320396765">Ak chcete získať záložky vo všetkých zariadeniach, prihláste sa a zapnite synchronizáciu</translation>
+<translation id="6003646045106347985">Ak chcete získavať prispôsobený obsah navrhnutý Googlom, zapnite synchronizáciu</translation>
+<translation id="8494430740943879273">Ak chcete získavať prispôsobený obsah navrhnutý Googlom, prihláste sa a zapnite synchronizáciu</translation>
+<translation id="5862731021271217234">Ak chcete získať karty zo svojich ostatných zariadení, zapnite synchronizáciu</translation>
+<translation id="3568688522516854065">Ak chcete získať karty zo svojich ostatných zariadení, prihláste sa a zapnite synchronizáciu</translation>
+<translation id="1208340532756947324">Ak chcete synchronizovať a prispôsobovať viaceré zariadenia, zapnite synchronizáciu</translation>
+<translation id="4472118726404937099">Ak chcete synchronizovať a prispôsobovať viaceré zariadenia, prihláste sa a zapnite synchronizáciu</translation>
+<translation id="2426805022920575512">Vybrať iný účet</translation>
+<translation id="6790428901817661496">Prehrať</translation>
+<translation id="1272079795634619415">Zastaviť</translation>
+<translation id="2874939134665556319">Predchádzajúca skladba</translation>
+<translation id="4046123991198612571">Ďalšia skladba</translation>
+<translation id="3859306556332390985">Pretočiť dopredu</translation>
+<translation id="8441146129660941386">Pretočiť dozadu</translation>
+<translation id="6706288973712894588">Momentálne ste offline.\n<ph name="BEGIN_LINK"/>Preskúmajte svoj feed offline.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Nedávne karty</translation>
+<translation id="8497726226069778601">Zatiaľ tu nič nie je…</translation>
+<translation id="5423934151118863508">Tu sa zobrazia vaše najnavštevovanejšie stránky.</translation>
+<translation id="6127379762771434464">Položka bola odstránená</translation>
+<translation id="4605958867780575332">Položka bola odstránená: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Sviatočné logo Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Ďalšie zariadenia</translation>
+<translation id="4738836084190194332">Synchronizované <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{pred # minútou}few{pred # minútami}many{pred # minútou}other{pred # minútami}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{pred # hodinou}few{pred # hodinami}many{pred # hodinou}other{pred # hodinami}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{pred # dňom}few{pred # dňami}many{pred # dňom}other{pred # dňami}}</translation>
+<translation id="2762000892062317888">práve teraz</translation>
+<translation id="1407135791313364759">Otvoriť všetko</translation>
+<translation id="1209206284964581585">Skryť</translation>
+<translation id="129553762522093515">Nedávno zatvorené</translation>
+<translation id="8413126021676339697">Zobraziť celú históriu</translation>
+<translation id="7876243839304621966">Odstrániť všetko</translation>
+<translation id="8487700953926739672">K dispozícii offline</translation>
+<translation id="5224771365102442243">S videom</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Ďalšie informácie<ph name="END_LINK"/> o návrhoch obsahu</translation>
+<translation id="7542481630195938534">Návrhy sa nedajú získať</translation>
+<translation id="5013696553129441713">Žiadne nové návrhy</translation>
+<translation id="1736419249208073774">Preskúmať</translation>
+<translation id="7444811645081526538">Ďalšie kategórie</translation>
+<translation id="6709133671862442373">News</translation>
+<translation id="1264974993859112054">Šport</translation>
+<translation id="9139318394846604261">Nákupy</translation>
+<translation id="3912508018559818924">Vyhľadáva sa to najlepšie z internetu…</translation>
+<translation id="526421993248218238">Táto stránka sa nedá načítať</translation>
+<translation id="614940544461990577">Vyskúšajte:</translation>
+<translation id="3288003805934695103">Opätovne načítať stránku</translation>
+<translation id="2353636109065292463">Kontroluje sa internetové pripojenie</translation>
+<translation id="2858138569776157458">Hlavné weby</translation>
+<translation id="8364299278605033898">Prezrite si obľúbené weby</translation>
+<translation id="1171770572613082465">Klepnutím na tlačidlo Hlavné weby zobrazíte obľúbené webové stránky</translation>
+<translation id="5233638681132016545">Nová karta</translation>
+<translation id="4521874409998847950">Od: <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>doručené Googlom<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Je dostupná novšia verzia</translation>
+<translation id="4058091506841967397">Brave sa nedá aktualizovať</translation>
+<translation id="6316139424528454185">Verzia Androidu nie je podporovaná</translation>
+<translation id="6989267951144302301">Nepodarilo sa stiahnuť</translation>
+<translation id="624789221780392884">Aktualizácia je pripravená</translation>
+<translation id="1549000191223877751">Prejsť do druhého okna</translation>
+<translation id="7481312909269577407">Dopredu</translation>
+<translation id="4084682180776658562">Záložka</translation>
+<translation id="6437478888915024427">Informácie o stránke</translation>
+<translation id="7180611975245234373">Obnoviť</translation>
+<translation id="4913169188695071480">Zastaviť obnovovanie</translation>
+<translation id="1829244130665387512">Nájsť na stránke</translation>
+<translation id="6593061639179217415">Web pre počítače</translation>
+<translation id="9063523880881406963">Vypnutie žiadosti o verziu stránok pre počítače</translation>
+<translation id="2038563949887743358">Zapnutie žiadosti o verziu stránok pre počítače</translation>
+<translation id="2433507940547922241">Vzhľad</translation>
+<translation id="983192555821071799">Zavrieť všetky karty</translation>
+<translation id="1310482092992808703">Zoskupiť karty</translation>
+<translation id="7725024127233776428">Tu sa zobrazia vaše stránky uložené ako záložky</translation>
+<translation id="4404568932422911380">Žiadne záložky</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> záložka}few{<ph name="BOOKMARKS_COUNT_MANY"/> záložky}many{<ph name="BOOKMARKS_COUNT_MANY"/> bookmarks}other{<ph name="BOOKMARKS_COUNT_MANY"/> záložiek}}</translation>
+<translation id="3739899004075612870">Pridané do záložiek <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Pridané medzi záložky</translation>
+<translation id="4452548195519783679">Uložené ako záložka v priečinku <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Záložku sa nepodarilo pridať.</translation>
+<translation id="2842985007712546952">Nadradený priečinok</translation>
+<translation id="9065203028668620118">Upraviť</translation>
+<translation id="4405224443901389797">Presunúť do…</translation>
+<translation id="5170568018924773124">Zobraziť v priečinku</translation>
+<translation id="8035133914807600019">Nový priečinok…</translation>
+<translation id="4532845899244822526">Vyberte priečinok</translation>
+<translation id="6627583120233659107">Upraviť priečinok</translation>
+<translation id="1197267115302279827">Presunúť záložky</translation>
+<translation id="6963766334940102469">Odstrániť záložky</translation>
+<translation id="4351244548802238354">Zavrieť dialógové okno</translation>
+<translation id="451872707440238414">Prehľadať záložky</translation>
+<translation id="8901170036886848654">Nenašli sa žiadne záložky</translation>
+<translation id="6404511346730675251">Upraviť záložku</translation>
+<translation id="3894427358181296146">Pridanie priečinka</translation>
+<translation id="5327248766486351172">Názov</translation>
+<translation id="7400418766976504921">Webová adresa</translation>
+<translation id="3527085408025491307">Priečinok</translation>
+<translation id="5161254044473106830">Musíte zadať názov</translation>
+<translation id="2996809686854298943">Vyžaduje sa webová adresa</translation>
+<translation id="2536728043171574184">Zobrazuje sa offline kópia tejto stránky</translation>
+<translation id="4698034686595694889">Zobrazenie offline v aplikácii <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> a ďalšie weby</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave stránku načíta, keď bude k dispozícii}few{Brave stránku načíta, keď bude k dispozícii}many{Brave stránku načíta, keď bude k dispozícii}other{Brave stránku načíta, keď bude k dispozícii}}</translation>
+<translation id="6811034713472274749">Stránka je pripravená na prezeranie</translation>
+<translation id="4561979708150884304">Bez pripojenia</translation>
+<translation id="8274165955039650276">Zobraziť stiahnuté</translation>
+<translation id="2082238445998314030">Výsledok <ph name="RESULT_NUMBER"/> z <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Žiadne výsledky</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Zjednoduš.</translation>
+<translation id="393697183122708255">Žiadne povol. hlas. vyhľad. k dispozícii</translation>
+<translation id="7191430249889272776">Karta je otvorená na pozadí.</translation>
+<translation id="8445059357334030806">Otvoriť v prehliadači Brave</translation>
+<translation id="4720023427747327413">Otvoriť v aplikácii <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Otvoriť v prehliadači</translation>
+<translation id="1113597929977215864">Aktivovať zjednodušené zobrazenie</translation>
+<translation id="1513352483775369820">Záložky a webová história</translation>
+<translation id="4939482511480190003">Pomôžte zlepšiť Brave. <ph name="BEGIN_LINK"/>Zúčastniť sa prieskumu<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Prejsť späť</translation>
+<translation id="5596627076506792578">Ďalšie možnosti</translation>
+<translation id="3522247891732774234">K dispozícii je aktualizácia. Ďalšie možnosti</translation>
+<translation id="6773423637732432200">Brave sa nedá aktualizovať. Ďalšie možnosti</translation>
+<translation id="3328801116991980348">Informácie o stránkach</translation>
+<translation id="5391532827096253100">Spojenie s týmto webom nie je zabezpečené. Informácie o webe</translation>
+<translation id="6206551242102657620">Spojenie je zabezpečené. Informácie o webe</translation>
+<translation id="6963642900430330478">Táto stránka je nebezpečná. Informácie o webe</translation>
+<translation id="9070377983101773829">Spustiť hlasové vyhľadávanie</translation>
+<translation id="8676374126336081632">Vymazať vstup</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> otvorená karta, karty prepnete klepnutím}few{<ph name="OPEN_TABS_MANY"/> otvorené karty, karty prepnete klepnutím}many{<ph name="OPEN_TABS_MANY"/> open tabs, tap to switch tabs}other{<ph name="OPEN_TABS_MANY"/> otvorených kariet, karty prepnete klepnutím}}</translation>
+<translation id="2369533728426058518">otvorené karty</translation>
+<translation id="7071521146534760487">Spravovať účet</translation>
+<translation id="932327136139879170">Domov</translation>
+<translation id="2707726405694321444">Obnoviť stránku</translation>
+<translation id="2891154217021530873">Zastaviť načítavanie stránky</translation>
+<translation id="6710213216561001401">Dozadu</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Vybratá karta</translation>
+<translation id="2268044343513325586">Upraviť</translation>
+<translation id="7846076177841592234">Zrušiť výber</translation>
+<translation id="7087918508125750058">Vybrané: <ph name="ITEM_COUNT"/>.  Možnosti sú k dispozícii v hornej časti obrazovky.</translation>
+<translation id="7250468141469952378">Vybrané: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Zdieľať 1 vybranú položku}few{Zdieľať # vybrané položky}many{Zdieľať # vybranej položky}other{Zdieľať # vybraných položiek}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Odstrániť 1 vybranú položku}few{Odstrániť # vybrané položky}many{Odstrániť # vybranej položky}other{Odstrániť # vybraných položiek}}</translation>
+<translation id="1283039547216852943">Klepnutím rozbaliť</translation>
+<translation id="5962718611393537961">Klepnutím zbaliť</translation>
+<translation id="8076492880354921740">Karty</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 vybratá položka}few{# vybraté položky}many{Niekoľko (#) vybratých položiek}other{# vybratých položiek}}</translation>
+<translation id="6818926723028410516">Vyberte položky</translation>
+<translation id="4797039098279997504">Klepnutím sa vrátite na kartu <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Kliknutím prejdite na web</translation>
+<translation id="429312253194641664">Web prehráva médiá</translation>
+<translation id="4958708863221495346">Web <ph name="URL_OF_THE_CURRENT_TAB"/> zdieľa vašu obrazovku</translation>
+<translation id="8833831881926404480">Nejaký web zdieľa vašu obrazovku</translation>
+<translation id="9086455579313502267">Nepodarilo sa pristúpiť k sieti</translation>
+<translation id="938850635132480979">Chyba: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Otvoriť v aplikácii <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Otvorte v aplikácii pre mapy</translation>
+<translation id="7698359219371678927">Vytvorte správu v aplikácii <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Vytvorte správu</translation>
+<translation id="5665379678064389456">Vytvorte udalosť v aplikácii <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Vytvorte udalosť</translation>
+<translation id="2111511281910874386">Prejdite na stránku</translation>
+<translation id="3988466920954086464">Zobraziť výsledky dynamického vyhľadávania na tomto paneli</translation>
+<translation id="2744248271121720757">Klepnutím na slovo aktivujete dynamické vyhľadávanie alebo zobrazíte súvisiace akcie</translation>
+<translation id="9155898266292537608">Vyhľadávať môžete aj rýchlym klepnutím na slovo</translation>
+<translation id="3232754137068452469">Webová aplikácia</translation>
+<translation id="1430915738399379752">Tlačiť</translation>
+<translation id="3775705724665058594">Odoslanie do zariadení</translation>
+<translation id="6364438453358674297">Odstrániť návrh z histórie?</translation>
+<translation id="213279576345780926">Karta <ph name="TAB_TITLE"/> je zavretá</translation>
+<translation id="6850830437481525139">Zatvorené karty: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Záložka <ph name="ITEM_TITLE"/> bola odstránená</translation>
+<translation id="4663756553811254707">Počet odstránených záložiek: <ph name="NUMBER_OF_BOOKMARKS"/></translation>
+<translation id="3819178904835489326">Počet odstránených stiahnutých súborov: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Nepodporovaný počet inštancií prehliadača Brave.</translation>
+<translation id="4259722352634471385">Navigácia je zablokovaná: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Navigácia je nedostupná: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Zatvoriť kartu</translation>
+<translation id="7772375229873196092">Zavrieť <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">História navigácie</translation>
+<translation id="9169507124922466868">História navigácie je dopoly otvorená</translation>
+<translation id="1327257854815634930">História navigácie je otvorená</translation>
+<translation id="8788265440806329501">História navigácie je zatvorená</translation>
+<translation id="7482656565088326534">Karta ukážky</translation>
+<translation id="8427875596167638501">Karta ukážky je dopoly otvorená</translation>
+<translation id="9102803872260866941">Karta ukážky je otvorená</translation>
+<translation id="2942036813789421260">Karta ukážky je zatvorená</translation>
+<translation id="6355102470683871794">Úložisko Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Vymazať úložisko webov?</translation>
+<translation id="9205995714227143200">Úložisko webu, ktoré Brave nepovažuje za dôležité (napr. webové stránky bez uložených nastavení alebo také, ktoré nenavštevujete často)</translation>
+<translation id="3997476611815694295">Nedôležité úložisko</translation>
+<translation id="8493948351860045254">Uvoľniť miesto</translation>
+<translation id="2324920234469020158">Táto akcia vymaže súbory cookie, vyrovnávaciu pamäť a ďalšie údaje webov, ktoré Brave nepovažuje za dôležité.</translation>
+<translation id="5447201525962359567">Celé úložisko webu vrátane súborov cookie a ďalších miestne uložených dát</translation>
+<translation id="1376578503827013741">Vypočítava sa…</translation>
+<translation id="583281660410589416">Neznáme</translation>
+<translation id="2323763861024343754">Úložisko webu</translation>
+<translation id="3587672679800759167">Celkové dáta využívané Chromom vrátane účtov, záložiek a uložených nastavení</translation>
+<translation id="6545017243486555795">Vymazať všetky dáta</translation>
+<translation id="4095146165863963773">Odstrániť dáta aplikácie?</translation>
+<translation id="53119194224775367">Všetky dáta aplikácií v Brave budú natrvalo odstránené. Platí to aj pre všetky súbory, nastavenia, účty, databázy atď.</translation>
+<translation id="5307446750509046227">Vymazať priestor webu</translation>
+<translation id="300526633675317032">Vymažete celé úložisko webu (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">Nedá sa vybrať certifikát</translation>
+<translation id="2315043854645842844">Operačný systém nepodporuje výber certifikátu na strane klienta.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> žiada o pripojenie</translation>
+<translation id="5308380583665731573">Pripojenie</translation>
+<translation id="868929229000858085">Prehľadať kontakty</translation>
+<translation id="1919950603503897840">Výber kontaktov</translation>
+<translation id="7986741934819883144">Výber kontaktu</translation>
+<translation id="3333961966071413176">Všetky kontakty</translation>
+<translation id="4994033804516042629">Nenašli sa žiadne kontakty</translation>
+<translation id="5403592356182871684">Názvy</translation>
+<translation id="2717722538473713889">E‑mailové adresy</translation>
+<translation id="381841723434055211">Telefónne čísla</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 ďalšie)}few{(+ # ďalšie)}many{(+ # more)}other{(+ # ďalších)}}</translation>
+<translation id="5197729504361054390">Vybrané kontakty budú zdieľané s webom <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Dekodér obrázkov</translation>
+<translation id="8067883171444229417">Prehrať video</translation>
+<translation id="6560414384669816528">Vyhľadávať pomocou Sogou</translation>
+<translation id="5406914950576900927">Brave môže použiť <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> na vyhľadávanie v Číne. Táto možnosť sa dá zmeniť v <ph name="BEGIN_LINK"/>Nastaveniach<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Ponechať Brave Software</translation>
+<translation id="4384468725000734951">Na vyhľadávanie sa používa Sogou</translation>
+<translation id="6103327872225198548">Na vyhľadávanie sa používa Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Táto aplikácia je spustená v Brave</translation>
+<translation id="6143689084714664628">Spustená v Brave</translation>
+<translation id="7675869148432102528">V Brave má údaje aj aplikácia <ph name="APP_NAME"/>.</translation>
+<translation id="2734140769649165081">Môžete vymazať údaje v Nastaveniach Chromu</translation>
+<translation id="8232956427053453090">Ponechať údaje</translation>
+<translation id="4298388696830689168">Prepojené weby</translation>
+<translation id="5763514718066511291">Klepnutím skopírujete webovú adresu tejto aplikácie</translation>
+<translation id="6496823230996795692">Prvé spustenie aplikácie <ph name="APP_NAME"/> vyžaduje pripojenie k internetu.</translation>
+<translation id="751961395872307827">Nedá sa pripojiť k webu</translation>
+<translation id="4878404682131129617">Vytvorenie tunela prostredníctvom proxy servera zlyhalo</translation>
+<translation id="4749960740855309258">Otvorenie novej karty</translation>
+<translation id="8788968922598763114">Opätovné otvorenie poslednej zavretej karty</translation>
+<translation id="7929962904089429003">Otvorenie ponuky</translation>
+<translation id="6039379616847168523">Prechod na ďalšiu kartu</translation>
+<translation id="5210286577605176222">Prechod na predchádzajúcu kartu</translation>
+<translation id="124678866338384709">Zavretie aktuálnej karty</translation>
+<translation id="3714981814255182093">Otvorenie Panela vyhľadávania</translation>
+<translation id="5441522332038954058">Prechod na panel s adresou</translation>
+<translation id="3398320232533725830">Otvorenie správcu záložiek</translation>
+<translation id="6583199322650523874">Pridanie aktuálnej stránky medzi záložky</translation>
+<translation id="8489271220582375723">Otvorenie stránky História</translation>
+<translation id="4837753911714442426">Otvorenie možností tlače stránky</translation>
+<translation id="5726692708398506830">Zväčšenie obsahu na stránke</translation>
+<translation id="3259831549858767975">Zmenšenie obsahu na stránke</translation>
+<translation id="8015452622527143194">Vrátenie obsahu stránky na predvolenú veľkosť</translation>
+<translation id="3443221991560634068">Opätovné načítanie aktuálnej stránky</translation>
+<translation id="123724288017357924">Opätovné načítanie aktuálnej stránky a ignorovanie obsahu vo vyrovnávacej pamäti</translation>
+<translation id="305870044889644984">Otvorenie Centra pomoci prehliadača Brave na novej karte</translation>
+<translation id="3166827708714933426">Skratky pre karty a okná</translation>
+<translation id="3169981355900570544">Skratky pre funkcie prehliadača Brave Software Brave</translation>
+<translation id="4558311620361989323">Skratky pre webové stránky</translation>
+<translation id="1908301351964700579">Brave sa stále pripravuje na používanie VR. Skúste Brave reštartovať neskôr.</translation>
+<translation id="8970887620466824814">Vyskytol sa problém.</translation>
+<translation id="1875543012935658554">Znova otvorte Brave.</translation>
+<translation id="79859296434321399">Ak chcete zobraziť obsah v rozšírenej realite, nainštalujte si ARCore</translation>
+<translation id="8558485628462305855">Ak chcete zobraziť obsah v rozšírenej realite, aktualizujte ARCore</translation>
+<translation id="3513704683820682405">Rozšírená realita</translation>
+<translation id="5475862044948910901">Chcete spustiť reláciu rozšírenej reality?</translation>
 <translation id="7365126855094612066">Počas tejto relácie bude môcť web:
 • vytvoriť 3D mapu vášho prostredia;
 • sledovať pohyb fotoaparátu.
 
 Web NEZÍSKA prístup k fotoaparátu. Obrázky fotoaparátu sú viditeľné iba pre vás.</translation>
-<translation id="7375125077091615385">Typ:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">Webová adresa</translation>
-<translation id="7403691278183511381">Skúsenosť pri prvom spustení Chromu</translation>
-<translation id="741204030948306876">Áno, súhlasím</translation>
-<translation id="7413229368719586778">Dátum začatia: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Najprv sa opýtať</translation>
-<translation id="7423538860840206698">Blokovať čítanie schránky</translation>
-<translation id="7431991332293347422">Ovládajte, ako sa história prehliadania používa na prispôsobenie Vyhľadávania a ďalšieho obsahu</translation>
-<translation id="7437998757836447326">Odhlásiť sa z Chromu</translation>
-<translation id="7438641746574390233">Keď aktivujete zjednodušený režim, Google bude stránky načítavať rýchlejšie pomocou serverov Google. V zjednodušenom režime sa prepíšu veľmi pomalé stránky, aby sa načítal iba základný obsah. Zjednodušený režim neplatí pre karty inkognito.</translation>
-<translation id="7444811645081526538">Ďalšie kategórie</translation>
-<translation id="7445411102860286510">Povoliť webom automaticky prehrávať stlmené videá (odporúča sa)</translation>
-<translation id="7453467225369441013">Odhlási vás z väčšiny webov, ale nie z účtu Google.</translation>
-<translation id="7454641608352164238">Nedostatok miesta</translation>
-<translation id="7475192538862203634">Ak sa vám táto stránka zobrazuje často, skúste použiť tieto <ph name="BEGIN_LINK" />návrhy<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD karta sa nenašla. Môžu chýbať niektoré súbory.</translation>
-<translation id="7479104141328977413">Správa kariet</translation>
-<translation id="7481312909269577407">Dopredu</translation>
-<translation id="7482656565088326534">Karta ukážky</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Aktualizované <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">uložené dáta</translation>
-<translation id="7498271377022651285">Čakajte…</translation>
-<translation id="7514365320538308">Stiahnuť</translation>
-<translation id="751961395872307827">Nedá sa pripojiť k webu</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Návrhy sa nedajú získať</translation>
-<translation id="7559975015014302720">Zjednodušený režim je vypnutý</translation>
-<translation id="7562080006725997899">Vymazávajú sa údaje prehliadania</translation>
-<translation id="756809126120519699">Údaje Chromu boli vymazané</translation>
-<translation id="757524316907819857">Zakázať webom prehrávať chránený obsah</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> stiahnutý súbor}few{<ph name="FILES_DOWNLOADED_MANY" /> stiahnuté súbory}many{<ph name="FILES_DOWNLOADED_MANY" /> files downloaded}other{<ph name="FILES_DOWNLOADED_MANY" /> stiahnutých súborov}}</translation>
-<translation id="7588219262685291874">Zapnúť tmavý motív, keď je v zariadení zapnutý šetrič batérie</translation>
-<translation id="7589445247086920869">Blokovať pre aktuálny vyhľadávač</translation>
-<translation id="7593557518625677601">V nastaveniach Androidu spustite synchronizáciu Chromu opätovným povolením synchronizácie Androidu</translation>
-<translation id="7596558890252710462">Operačný systém</translation>
-<translation id="7605594153474022051">Synchronizácia nefunguje</translation>
-<translation id="7606077192958116810">Zjednodušený režim je zapnutý. Spravujte ho v Nastaveniach.</translation>
-<translation id="7612619742409846846">Prihlásený účet Google</translation>
-<translation id="7619072057915878432">Súbor <ph name="FILE_NAME" /> sa nepodarilo stiahnuť z dôvodu problémov so sieťou.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Získajte pomoc<ph name="END_LINK1" /> alebo <ph name="BEGIN_LINK2" />znova spustite vyhľadávanie<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Víta vás prehliadač Chrome</translation>
-<translation id="7638584964844754484">Nesprávna prístupová fráza</translation>
-<translation id="7641339528570811325">Vymazať dáta prehliadania…</translation>
-<translation id="7648422057306047504">Šifrovať heslá pomocou poverení Google</translation>
-<translation id="7649070708921625228">Pomocník</translation>
-<translation id="7658239707568436148">Zrušiť</translation>
-<translation id="7665369617277396874">Pridať účet</translation>
-<translation id="766587987807204883">Tu sa zobrazia články, ktoré môžete čítať dokonca aj offline</translation>
-<translation id="7682724950699840886">Skúste tieto tipy: Uistite sa, že máte v zariadení dosť miesta, a potom skúste znova spustiť exportovanie.</translation>
-<translation id="7685301384041462804">Pred prechodom do VR skontrolujte, či tomuto webu dôverujete.</translation>
-<translation id="7698359219371678927">Vytvorte správu v aplikácii <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Automaticky dopĺňať vyhľadávania a webové adresy</translation>
-<translation id="7725024127233776428">Tu sa zobrazia vaše stránky uložené ako záložky</translation>
-<translation id="773466115871691567">Vždy prekladať stránky v jazyku <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Chrome odosiela Googlu webové adresy niektorých navštívených stránok, obmedzené informácie o systéme a obsah niektorých stránok na účely rozpoznávania nebezpečných aplikácií a webov.</translation>
-<translation id="7757787379047923882">Text zdieľaný zo zariadenia <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD karta <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Pridať adresu</translation>
-<translation id="7772032839648071052">Potvrďte prístupovú frázu</translation>
-<translation id="7772375229873196092">Zavrieť <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ďalší}few{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ďalšie}many{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ďalšieho}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 a <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ďalších}}</translation>
-<translation id="7781829728241885113">Včera</translation>
-<translation id="7791543448312431591">Pridať</translation>
-<translation id="780301667611848630">Nie, ďakujem</translation>
-<translation id="7810647596859435254">Otvoriť pomocou…</translation>
-<translation id="7821588508402923572">Tu sa zobrazí úspora dát</translation>
-<translation id="7837721118676387834">Povoliť automatické prehrávanie stlmených videí pre konkrétny web.</translation>
-<translation id="7846076177841592234">Zrušiť výber</translation>
-<translation id="784934925303690534">Obdobie</translation>
-<translation id="7851858861565204677">Ďalšie zariadenia</translation>
-<translation id="7875915731392087153">Vytvorte správu</translation>
-<translation id="7876243839304621966">Odstrániť všetko</translation>
-<translation id="7882131421121961860">Nenašla sa žiadna história</translation>
-<translation id="7882806643839505685">Povoliť zvuk pre konkrétny web.</translation>
-<translation id="7886917304091689118">Spustená v Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Sťahuje sa súbor.}few{Sťahujú sa # súbory.}many{Downloading # files.}other{Sťahuje sa # súborov.}}</translation>
-<translation id="7929962904089429003">Otvorenie ponuky</translation>
-<translation id="7942131818088350342">Aplikácia <ph name="PRODUCT_NAME" /> je zastaraná.</translation>
-<translation id="7947953824732555851">Prijať a prihl. sa</translation>
-<translation id="7963646190083259054">Dodávateľ:</translation>
-<translation id="7971136598759319605">Aktívne včera</translation>
-<translation id="7975379999046275268">Zobraziť ukážku stránky <ph name="BEGIN_NEW" />Novinka<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Vopred načítavať stránky na zrýchlenie prehliadania a vyhľadávania</translation>
-<translation id="79859296434321399">Ak chcete zobraziť obsah v rozšírenej realite, nainštalujte si ARCore</translation>
-<translation id="7986741934819883144">Výber kontaktu</translation>
-<translation id="7987073022710626672">Zmluvné podmienky prehliadača Chrome</translation>
-<translation id="7998918019931843664">Znova otvoriť zavretú kartu</translation>
-<translation id="7999064672810608036">Naozaj chcete vymazať všetky miestne dáta tohto webu, vrátane súborov cookie, a resetovať všetky jeho povolenia?</translation>
-<translation id="8004582292198964060">Prehliadač</translation>
-<translation id="8007176423574883786">Vypnuté v tomto zariadení</translation>
-<translation id="8013372441983637696">Tiež vymazať údaje Chromu z tohto zariadenia</translation>
-<translation id="8015452622527143194">Vrátenie obsahu stránky na predvolenú veľkosť</translation>
-<translation id="802154636333426148">Stiahnutie zlyhalo</translation>
-<translation id="8026334261755873520">Vymazať dáta prehliadania</translation>
-<translation id="8035133914807600019">Nový priečinok…</translation>
-<translation id="8037750541064988519">Zostáva: <ph name="DAYS" /> d</translation>
-<translation id="804335162455518893">SD karta sa nenašla</translation>
-<translation id="805047784848435650">Na základe vašej histórie prehliadania</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB k dispozícii</translation>
-<translation id="8058746566562539958">Otvoriť v Chrome na novej karte</translation>
-<translation id="8063895661287329888">Záložku sa nepodarilo pridať.</translation>
-<translation id="806745655614357130">Ponechať moje dáta oddelené</translation>
-<translation id="8067883171444229417">Prehrať video</translation>
-<translation id="8068648041423924542">Nedá sa vybrať certifikát</translation>
-<translation id="8073388330009372546">Otvoriť obrázok na novej karte</translation>
-<translation id="8076492880354921740">Karty</translation>
-<translation id="8084114998886531721">Uložené heslo</translation>
-<translation id="8087000398470557479">Tento obsah pochádza z domény <ph name="DOMAIN_NAME" /> a bol doručený Googlom.</translation>
-<translation id="8103578431304235997">Karta inkognito</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Ak chcete získať záložky vo všetkých zariadeniach, zapnite synchronizáciu</translation>
-<translation id="8110087112193408731">Chcete v digitálnej rovnováhe zobrazovať svoju aktivitu v Chrome?</translation>
-<translation id="8116925261070264013">Zvuk bol vypnutý</translation>
-<translation id="813082847718468539">Zobraziť informácie o stránkach</translation>
-<translation id="8131740175452115882">Potvrdiť</translation>
-<translation id="8156139159503939589">Akým jazykom rozumiete?</translation>
-<translation id="8168435359814927499">Obsah</translation>
-<translation id="8186512483418048923">Zostávajúce súbory: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Zostáva: 1 d</translation>
-<translation id="8200772114523450471">Pokračovať</translation>
-<translation id="8209050860603202033">Otvoriť obrázok</translation>
-<translation id="8218622182176210845">Spravujte svoj účet</translation>
-<translation id="8224471946457685718">Sťahovať články cez Wi-Fi</translation>
-<translation id="8232956427053453090">Ponechať údaje</translation>
-<translation id="8249310407154411074">Presunúť na začiatok</translation>
-<translation id="8250920743982581267">Dokumenty</translation>
-<translation id="825412236959742607">Táto stránka využíva príliš veľa pamäte, a preto Chrome odstránil niektorý obsah.</translation>
-<translation id="8260126382462817229">Skúste sa znova prihlásiť</translation>
-<translation id="8261506727792406068">Odstrániť</translation>
-<translation id="8266862848225348053">Umiestnenie sťahovaných súborov</translation>
-<translation id="8274165955039650276">Zobraziť stiahnuté</translation>
-<translation id="8284326494547611709">Titulky</translation>
-<translation id="8300705686683892304">Spravované aplikáciou</translation>
-<translation id="8310344678080805313">Štandardné karty</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> a ďalšie weby</translation>
-<translation id="8327155640814342956">Ak chcete zlepšiť prehliadanie, otvorte Chrome a aktualizujte ho</translation>
-<translation id="8339163506404995330">Stránky v jazyku <ph name="LANGUAGE" /> nebudú prekladané</translation>
-<translation id="8349013245300336738">Zoradiť podľa množstva využitých dát</translation>
-<translation id="8364299278605033898">Prezrite si obľúbené weby</translation>
-<translation id="8368027906805972958">Neznáme alebo nepodporované zariadenie (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Povolenie synchronizácie na pozadí na konkrétnom webe.</translation>
-<translation id="8378714024927312812">Spravované vašou organizáciou</translation>
-<translation id="8380167699614421159">Tento web zobrazuje obťažujúce alebo zavádzajúce reklamy</translation>
-<translation id="8393700583063109961">Odoslať správu</translation>
-<translation id="8413126021676339697">Zobraziť celú históriu</translation>
-<translation id="8427875596167638501">Karta ukážky je dopoly otvorená</translation>
-<translation id="8428213095426709021">Nastavenia</translation>
-<translation id="8438566539970814960">Zlepšovať vyhľadávanie a prehliadanie</translation>
-<translation id="8441146129660941386">Pretočiť dozadu</translation>
-<translation id="8443209985646068659">Chrome sa nedá aktualizovať</translation>
-<translation id="8445448999790540984">Heslá sa nepodarilo exportovať</translation>
-<translation id="8447861592752582886">Odvolať povolenie pre zariadenie</translation>
-<translation id="8461694314515752532">Šifrovať synchronizované údaje pomocou vlastnej prístupovej frázy synchronizácie</translation>
-<translation id="8466613982764129868">Skontrolujte, či je zariadenie <ph name="TARGET_DEVICE_NAME" /> pripojené k internetu</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">K dispozícii offline</translation>
-<translation id="8489271220582375723">Otvorenie stránky História</translation>
-<translation id="8493948351860045254">Uvoľniť miesto</translation>
-<translation id="8497726226069778601">Zatiaľ tu nič nie je…</translation>
-<translation id="8503559462189395349">Heslá Chromu</translation>
-<translation id="8503813439785031346">Meno používateľa</translation>
-<translation id="8514477925623180633">Exportovať heslá uložené v Chrome</translation>
-<translation id="8514577642972634246">Spustiť režim inkognito</translation>
-<translation id="851751545965956758">Zakázať webom pripájať sa k zariadeniam</translation>
-<translation id="8523928698583292556">Odstrániť uložené heslo</translation>
-<translation id="854522910157234410">Otvoriť túto stránku</translation>
-<translation id="8558485628462305855">Ak chcete zobraziť obsah v rozšírenej realite, aktualizujte ARCore</translation>
-<translation id="8559990750235505898">Ponúkať preklad stránok v ďalších jazykoch</translation>
-<translation id="8562452229998620586">Tu sa zobrazia uložené heslá.</translation>
-<translation id="8569404424186215731">od <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Posledné 4 týždne</translation>
-<translation id="857943718398505171">Povolené (odporúčané)</translation>
-<translation id="8583805026567836021">Prebieha vymazávanie údajov účtu</translation>
-<translation id="860043288473659153">Meno držiteľa karty</translation>
-<translation id="8609465669617005112">Presunúť nahor</translation>
-<translation id="8616006591992756292">Váš účet Google môže mať ďalšie formy histórie prehliadania na adrese <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Otvoriť navrhovanú webovú adresu určenú v stiahnutom obsahu?</translation>
-<translation id="8636825310635137004">Ak chcete získať karty zo svojich ostatných zariadení, zapnite synchronizáciu.</translation>
-<translation id="8641930654639604085">Pokúsiť sa blokovať weby pre dospelých</translation>
-<translation id="8655129584991699539">Môžete vymazať údaje v Nastaveniach Chromu</translation>
-<translation id="8662811608048051533">Odhlási vás z väčšiny webov.</translation>
-<translation id="8664979001105139458">Súbor s takým názvom už existuje</translation>
-<translation id="8676374126336081632">Vymazať vstup</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Úroveň sily signálu: # čiarka}few{Úroveň sily signálu: # čiarky}many{Úroveň sily signálu: # čiarky}other{Úroveň sily signálu: # čiarok}}</translation>
-<translation id="868929229000858085">Prehľadať kontakty</translation>
-<translation id="869891660844655955">Koniec platnosti</translation>
-<translation id="8719023831149562936">Aktuálna karta sa nedá preniesť</translation>
-<translation id="8725066075913043281">Skúsiť znova</translation>
-<translation id="8728487861892616501">Používaním tejto aplikácie vyjadrujete súhlas so <ph name="BEGIN_LINK1" />zmluvnými podmienkami<ph name="END_LINK1" /> prehliadača Chrome a <ph name="BEGIN_LINK2" />oznámením o ochrane súkromia<ph name="END_LINK2" />, ako aj <ph name="BEGIN_LINK3" />oznámením o ochrane súkromia pre účty Google spravované pomocou aplikácie Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Hotovo</translation>
-<translation id="8748850008226585750">Obsah je skrytý</translation>
-<translation id="8751914237388039244">Vyberte obrázok</translation>
-<translation id="8788265440806329501">História navigácie je zatvorená</translation>
-<translation id="8788968922598763114">Opätovné otvorenie poslednej zavretej karty</translation>
-<translation id="8801436777607969138">Zablokujte JavaScript pre konkrétny web.</translation>
-<translation id="8812260976093120287">Na niektorých weboch môžete platiť pomocou podporovaných platobných aplikácií na zariadení.</translation>
-<translation id="8816026460808729765">Zablokovať webom prístup k senzorom</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> sa otvorí v Chrome. Pokračovaním vyjadrujete súhlas so <ph name="BEGIN_LINK1" />zmluvnými podmienkami<ph name="END_LINK1" /> a <ph name="BEGIN_LINK2" />oznámením o ochrane súkromia<ph name="END_LINK2" /> Chromu, ako aj <ph name="BEGIN_LINK3" />oznámením o ochrane súkromia pre účty Google spravované pomocou aplikácie Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Záložky</translation>
-<translation id="8833831881926404480">Nejaký web zdieľa vašu obrazovku</translation>
-<translation id="883806473910249246">Pri sťahovaní obsahu sa vyskytla chyba.</translation>
-<translation id="8840953339110955557">Táto stránka sa môže líšiť od online verzie.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, karta</translation>
-<translation id="885701979325669005">Úložisko</translation>
-<translation id="889338405075704026">Prejsť do nastavení Chromu</translation>
-<translation id="8901170036886848654">Nenašli sa žiadne záložky</translation>
-<translation id="8909135823018751308">Zdieľať…</translation>
-<translation id="8912362522468806198">účtu Google</translation>
-<translation id="8920114477895755567">Čaká sa na podrobnosti o rodičoch.</translation>
+<translation id="1188239144602654184">Spustiť VR</translation>
+<translation id="473775607612524610">Aktualizovať</translation>
+<translation id="3133489217401741157">Inštaluje sa <ph name="MODULE"/> pre Brave…</translation>
+<translation id="1791662854739702043">Nainštalovaný</translation>
+<translation id="5131234170665854056">Modul <ph name="MODULE"/> pre Brave sa nepodarilo nainštalovať</translation>
+<translation id="2567385386134582609">OBRÁZOK</translation>
+<translation id="6395288395575013217">ODKAZ</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Stiahnite si stránky na použitie offline</translation>
 <translation id="8922289737868596582">Stiahnite si stránky pomocou tlačidla Ďalšie možnosti, aby ste ich mohli použiť offline</translation>
-<translation id="8937772741022875483">Chcete z digitálnej rovnováhy odstrániť svoju aktivitu v Chrome?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Otvoriť v ďalšom okne</translation>
-<translation id="8951232171465285730">Chrome ušetril <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokovanie súborov cookie konkrétneho webu</translation>
-<translation id="8959122750345127698">Navigácia je nedostupná: <ph name="URL" /></translation>
-<translation id="8965591936373831584">nespracované</translation>
-<translation id="8970887620466824814">Vyskytol sa problém.</translation>
-<translation id="8972098258593396643">Stiahnuť do predvoleného priečinka?</translation>
-<translation id="8986494364107987395">Automaticky odosielať Googlu štatistiky používania a správy o zlyhaní</translation>
-<translation id="8993760627012879038">Otvorenie novej karty v režime inkognito</translation>
-<translation id="8998729206196772491">Prihlasujete sa pomocou účtu spravovaného doménou <ph name="MANAGED_DOMAIN" /> a jej správcovi tým dávate kontrolu nad svojimi údajmi Chromu. Vaše údaje budú natrvalo prepojené s týmto účtom. Odhlásením z Chromu odstránite údaje z príslušného zariadenia, avšak naďalej zostanú uložené vo vašom účte Google.</translation>
-<translation id="9019902583201351841">Spravované vašimi rodičmi</translation>
-<translation id="9028914725102941583">Zapnite synchronizáciu a zdieľajte medzi zariadeniami</translation>
-<translation id="9029323097866369874">Povoliť webu <ph name="DOMAIN" /> prejsť do VR?</translation>
-<translation id="9040142327097499898">Upozornenia sú povolené. Poloha je v tomto zariadení vypnutá.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}few{# videá}many{# Videos}other{# videí}}</translation>
-<translation id="9050666287014529139">Prístupová fráza</translation>
-<translation id="9063523880881406963">Vypnutie žiadosti o verziu stránok pre počítače</translation>
-<translation id="9065203028668620118">Upraviť</translation>
-<translation id="9070377983101773829">Spustiť hlasové vyhľadávanie</translation>
-<translation id="9074336505530349563">Ak chcete získavať prispôsobený obsah navrhnutý Googlom, prihláste sa a zapnite synchronizáciu</translation>
-<translation id="9086455579313502267">Nepodarilo sa pristúpiť k sieti</translation>
-<translation id="9100505651305367705">Ponúkať zjednodušené zobrazenie článkov (ak je podporované)</translation>
-<translation id="9100610230175265781">Vyžaduje sa prístupová fráza</translation>
-<translation id="9102803872260866941">Karta ukážky je otvorená</translation>
+<translation id="5958275228015807058">Nájdite stiahnuté súbory a stránky</translation>
+<translation id="5620928963363755975">Stiahnuté súbory a stránky nájdete po použití tlačidla Ďalšie možnosti</translation>
+<translation id="3341058695485821946">Zistite, koľko dát ste ušetrili</translation>
+<translation id="3157842584138209013">Ak chcete zistiť, koľko dát ste ušetrili, klepnite na tlačidlo Ďalšie možnosti</translation>
+<translation id="8218622182176210845">Spravujte svoj účet</translation>
+<translation id="8090895580117672212">Ak chcete spravovať svoj účet Brave Software, klepnite na tlačidlo Spravovať účet</translation>
+<translation id="8856898588039823173">Zjednodušenú verziu stránky poskytol Brave Software. Klepnutím načítate pôvodnú verziu.</translation>
+<translation id="8134317863207426198">Zjednodušenú verziu stránky poskytol Brave Software. Ak chcete načítať pôvodnú verziu, klepnite na tlačidlo Načítať pôvodnú stránku.</translation>
+<translation id="4961107849584082341">Preložte si túto stránku do ľubovoľného jazyka</translation>
+<translation id="569536719314091526">Preložte si túto stránku do ľubovoľného jazyka pomocou tlačidla Ďalšie možnosti</translation>
+<translation id="1397811292916898096">Hľadať pomocou vyhľadávača <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Kedykoľvek zmeniť predvolené umiestnenie stiahnutých súborov</translation>
+<translation id="6942665639005891494">Kedykoľvek zmeniť predvolené umiestnenie stiahnutých súborov pomocou možnosti ponuky Nastavenia</translation>
+<translation id="6850409657436465440">Sťahovanie stále prebieha</translation>
+<translation id="5817715962196959877">Brave teraz sťahuje súbory rýchlejšie</translation>
+<translation id="3976396876660209797">Odstráňte túto skratku a znova ju vytvorte</translation>
+<translation id="6766622839693428701">Zatvorte potiahnutím dole.</translation>
+<translation id="1028699632127661925">Odosiela sa do zariadenia <ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – odoslané zo zariadenia <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Karta bola prijatá</translation>
 <translation id="9104217018994036254">Zoznam zariadení, s ktorými sa má zdieľať karta.</translation>
-<translation id="9133397713400217035">Preskúmať offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Zobraziť originál</translation>
-<translation id="9139068048179869749">Pýtať sa, či chcete povoliť webu odosielať upozornenia (odporúčané)</translation>
-<translation id="9139318394846604261">Nákupy</translation>
-<translation id="9155898266292537608">Vyhľadávať môžete aj rýchlym klepnutím na slovo</translation>
-<translation id="9169507124922466868">História navigácie je dopoly otvorená</translation>
-<translation id="9204836675896933765">Zostáva 1 súbor</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Zoznam zariadení, s ktorými sa má zdieľať karta, je otvorený na polovičnú výšku.</translation>
+<translation id="2904414404539560095">Zoznam zariadení, s ktorými sa má zdieľať karta, je otvorený na plnú výšku.</translation>
+<translation id="4135200667068010335">Zoznam zariadení, s ktorými sa má zdieľať karta, je zavretý.</translation>
+<translation id="5292796745632149097">Odoslanie do zariadení</translation>
+<translation id="1386674309198842382">Aktívne pred <ph name="LAST_UPDATED"/> dňami</translation>
+<translation id="7971136598759319605">Aktívne včera</translation>
+<translation id="1521774566618522728">Aktívne dnes</translation>
+<translation id="3631987586758005671">Zdieľa sa so zariadením <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Zapnite synchronizáciu a zdieľajte medzi zariadeniami</translation>
+<translation id="6162454065885854378">Ak chcete niečo zo svojho telefónu zdieľať s iným zariadením, zapnite v oboch synchronizáciu v nastaveniach Chromu</translation>
+<translation id="6084271560289605378">Prejsť do nastavení Chromu</translation>
+<translation id="2318045970523081853">Zavolajte klepnutím</translation>
 <translation id="9209888181064652401">Nedá sa volať</translation>
-<translation id="9219103736887031265">Obrázky</translation>
-<translation id="926205370408745186">Odstránenie aktivity v Chrome z digitálnej rovnováhy</translation>
-<translation id="932327136139879170">Domov</translation>
-<translation id="938850635132480979">Chyba: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Prístup k mikrofónu</translation>
-<translation id="95817756606698420">Chrome môže použiť <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> na vyhľadávanie v Číne. Táto možnosť sa dá zmeniť v <ph name="BEGIN_LINK" />Nastaveniach<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokovať, ak web zobrazuje obťažujúce alebo zavádzajúce reklamy (odporúčané)</translation>
-<translation id="968900484120156207">Tu sa zobrazia vami navštívené stránky</translation>
-<translation id="970715775301869095">Zostáva: <ph name="MINUTES" /> min</translation>
-<translation id="974555521953189084">Ak chcete spustiť synchronizáciu, zadajte prístupovú frázu</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Vymažete dáta všetkých webov vrátane týchto:</translation>
-<translation id="983192555821071799">Zavrieť všetky karty</translation>
-<translation id="987264212798334818">Všeobecné</translation>
+<translation id="2860954141821109167">Skontrolujte, či je v tomto zariadení povolená aplikácia pre telefóny</translation>
+<translation id="2067805253194386918">text</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> sa nedá zdieľať</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> sa nepodarilo zdieľať</translation>
+<translation id="8287068819750208230">Skontrolujte, či má <ph name="TARGET_DEVICE_NAME"/> v Brave zapnutú synchronizáciu</translation>
+<translation id="3016635187733453316">Skontrolujte, či je toto zariadenie pripojené k internetu</translation>
+<translation id="8466613982764129868">Skontrolujte, či je zariadenie <ph name="TARGET_DEVICE_NAME"/> pripojené k internetu</translation>
+<translation id="6539092367496845964">Vyskytol sa problém. Skúste to znova neskôr.</translation>
+<translation id="3389286852084373014">Text je príliš veľký</translation>
+<translation id="2100314319871056947">Skúste text zdieľať po menších častiach</translation>
+<translation id="2987620471460279764">Text zdieľaný z iného zariadenia</translation>
+<translation id="7757787379047923882">Text zdieľaný zo zariadenia <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Skopírované do schránky</translation>
+<translation id="4696983787092045100">Odoslať text do vašich zariadení</translation>
+<translation id="1260236875608242557">Prehľadať a preskúmať</translation>
+<translation id="6369229450655021117">Môžete v ňom vyhľadávať na internete, zdieľať obsah s priateľmi a prezerať otvorené stránky</translation>
+<translation id="723171743924126238">Výber obrázkov</translation>
+<translation id="8751914237388039244">Vyberte obrázok</translation>
+<translation id="1989112275319619282">Prehliadať</translation>
+<translation id="7055152154916055070">Presmerovanie bolo zablokované:</translation>
+<translation id="5524843473235508879">Presmerovanie bolo zablokované.</translation>
+<translation id="6573096386450695060">Vždy povoliť</translation>
+<translation id="5805364706385912897">Táto stránka využíva príliš veľa pamäte, a preto ju Brave pozastavil.</translation>
+<translation id="5138664332909611586">Táto stránka využíva príliš veľa pamäte, a preto Brave odstránil niektorý obsah.</translation>
+<translation id="9137013805542155359">Zobraziť originál</translation>
+<translation id="6361779936989026201">Asistent Brave Software v Brave</translation>
+<translation id="7291387454912369099">Platenie pomocou Asistenta</translation>
+<translation id="4565206163201411670">Chcete v digitálnej rovnováhe zobrazovať svoju aktivitu v Brave?</translation>
+<translation id="9055113864158719823">Môžete si zobraziť weby, ktoré navštevujete v Brave, a nastaviť pre ne časovače.\n\nBrave Software získa informácie o weboch, pre ktoré nastavíte časovače, a údaje o tom, koľko času na nich strávite. Tieto informácie sa použijú na zlepšenie digitálnej rovnováhy.</translation>
+<translation id="4596514158372210596">Odstránenie aktivity v Brave z digitálnej rovnováhy</translation>
+<translation id="1174893863889683998">Chcete z digitálnej rovnováhy odstrániť svoju aktivitu v Brave?</translation>
+<translation id="708829030563435351">Weby, ktoré navštívite v Brave, sa nezobrazia. Odstránia sa všetky časovače webov.</translation>
+<translation id="2056878612599315956">Web je pozastavený</translation>
+<translation id="671481426037969117">Časovač aplikácie <ph name="FQDN"/> vypršal. Spustí sa zase zajtra.</translation>
+<translation id="7479104141328977413">Správa kariet</translation>
+<translation id="3524138585025253783">Používateľské rozhranie vývojára</translation>
+<translation id="6036057147555329831">Dodatočný modul ICU</translation>
+<translation id="9029323097866369874">Povoliť webu <ph name="DOMAIN"/> prejsť do VR?</translation>
+<translation id="7685301384041462804">Pred prechodom do VR skontrolujte, či tomuto webu dôverujete.</translation>
+<translation id="5033865233969348410">V režime VR môže tento web získať nasledujúce informácie:
+– vaše fyzické vlastnosti, ako je výška.
+
+Pred prechodom do VR skontrolujte, či tomuto webu dôverujete.</translation>
+<translation id="5534334044554683961">V režime VR môže tento web získať nasledujúce informácie:
+– vaše fyzické vlastnosti, ako je výška;
+– rozloženie vašej miestnosti.
+
+Pred prechodom do VR skontrolujte, či tomuto webu dôverujete.</translation>
+<translation id="4169535189173047238">Nepovoliť</translation>
+<translation id="2170088579611075216">Povoliť a vstúpiť do VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_sl.xtb
+++ b/android/java/strings/translations/android_chrome_strings_sl.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="sl">
-<translation id="1006017844123154345">Odpri v spletu</translation>
-<translation id="1028699632127661925">Pošiljanje v napravo <ph name="DEVICE_NAME" /> ...</translation>
-<translation id="1036727731225946849">Dodajanje <ph name="WEBAPK_NAME" /> ...</translation>
-<translation id="1041308826830691739">S spletnih mest</translation>
-<translation id="1049743911850919806">Način brez beleženja zgodovine</translation>
-<translation id="10614374240317010">Nikoli shranjeno</translation>
-<translation id="1067922213147265141">Druge Googlove storitve</translation>
-<translation id="1068672505746868501">Nikoli ne prevedi strani v jeziku <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Če spremenite pripono datoteke, se lahko datoteka odpre v drugem programu in je lahko morebitno škodljiva za vašo napravo.</translation>
-<translation id="1100066534610197918">Odpri nov zavihek v skupini</translation>
-<translation id="1105960400813249514">Zajemanje slike</translation>
-<translation id="1111673857033749125">Tu bodo prikazani zaznamki, shranjeni v drugih napravah.</translation>
-<translation id="1113597929977215864">Pokaži poenostavljen pogled</translation>
-<translation id="1121094540300013208">Poročila o uporabi in zrušitvah</translation>
-<translation id="1124772482545689468">Uporabnik</translation>
-<translation id="1129510026454351943">Podrobnosti: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 prenos na čakanju}one{# prenos na čakanju}two{# prenosa na čakanju}few{# prenosi na čakanju}other{# prenosov na čakanju}}</translation>
-<translation id="1145536944570833626">Izbris obstoječih podatkov.</translation>
-<translation id="1146678959555564648">V navidezno resničnost</translation>
-<translation id="116280672541001035">Porabljeno</translation>
-<translation id="1171770572613082465">Oglejte si priljubljena spletna mesta z dotikom gumba »Najb. prilj.«</translation>
-<translation id="1173894706177603556">Preimenuj</translation>
-<translation id="1178581264944972037">Prekini</translation>
-<translation id="1181037720776840403">Odstrani</translation>
-<translation id="1188239144602654184">Začni RR</translation>
-<translation id="1197267115302279827">Premakni zavihke</translation>
-<translation id="119944043368869598">Izbriši vse</translation>
-<translation id="1201402288615127009">Naprej</translation>
-<translation id="1204037785786432551">Prenesi povezavo</translation>
-<translation id="1206892813135768548">Kopiraj besedilo povezave</translation>
-<translation id="1208340532756947324">Če želite sinhronizirati in prilagajati v vseh napravah, vklopite sinhronizacijo</translation>
-<translation id="1209206284964581585">Zaenkrat skrij</translation>
-<translation id="1227058898775614466">Zgodovina krmarjenja</translation>
-<translation id="1231733316453485619">Želite vklopiti sinhronizacijo?</translation>
-<translation id="123724288017357924">Vnov. nalag. tren. strani s prezrtjem predp. vseb.</translation>
-<translation id="124116460088058876">Več jezikov</translation>
-<translation id="124678866338384709">Zapiranje trenutnega zavihka</translation>
-<translation id="1258753120186372309">Googlov priložnostni logotip: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Iščite in raziskujte</translation>
-<translation id="1264974993859112054">Šport</translation>
-<translation id="1266864766717917324">Ni bilo mogoče deliti tega: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Ustavi</translation>
-<translation id="1283039547216852943">Dotaknite se za razširitev</translation>
-<translation id="1285320974508926690">Nikoli ne prevedi tega spletnega mesta</translation>
-<translation id="1291207594882862231">Izbris zgodovine, piškotkov, podatkov spletnih mest, predpomnilnika …</translation>
-<translation id="129382876167171263">Datoteke, ki jih shranijo spletna mesta, so prikazane tukaj</translation>
-<translation id="129553762522093515">Nedavno zaprto</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – poslano iz naprave <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Združi zavihke</translation>
-<translation id="1327257854815634930">Zgodovina krmarjenja je odprta</translation>
-<translation id="1331212799747679585">Posodobitev Chroma ni mogoča. Več možnosti.</translation>
-<translation id="1332501820983677155">Bližnjice za funkcije Google Chroma</translation>
-<translation id="1360432990279830238">Odjava in izklop sinhronizacije?</translation>
-<translation id="1369915414381695676">Spletno mesto <ph name="SITE_NAME" /> je bilo dodano</translation>
-<translation id="1373696734384179344">Za prenos izbrane vsebine ni dovolj pomnilnika.</translation>
-<translation id="1376578503827013741">Računanje …</translation>
-<translation id="1383876407941801731">Išči</translation>
-<translation id="1384959399684842514">Prenos je zaustavljen</translation>
-<translation id="1386674309198842382">Aktivna pred toliko dnevi: <ph name="LAST_UPDATED" /></translation>
-<translation id="1397811292916898096">Iskanje z iskalnikom <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Vdelano v URL <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">»Ne sledi«</translation>
-<translation id="1407135791313364759">Odpri vse</translation>
-<translation id="1409426117486808224">Poenostavljen pogled za odprte zavihke</translation>
-<translation id="1409879593029778104">Prenos datoteke <ph name="FILE_NAME" /> je bil preprečen, ker datoteka že obstaja.</translation>
-<translation id="1414981605391750300">Vzpostavljanje stika z Googlom. To lahko traja kakšno minuto …</translation>
-<translation id="1416550906796893042">Različica aplikacije</translation>
-<translation id="1430915738399379752">Natisni</translation>
-<translation id="1446450296470737166">Dovolitev popolnega nadzora nad napravami MIDI</translation>
-<translation id="1450753235335490080">Ni mogoče deliti tega: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Izklopljeno v nastavitvah za Android</translation>
-<translation id="1477626028522505441">Prenos datoteke <ph name="FILE_NAME" /> ni uspel zaradi težav s strežnikom.</translation>
-<translation id="1506061864768559482">Iskalnik</translation>
-<translation id="1513352483775369820">Zaznamki in spletna zgodovina</translation>
-<translation id="1513858653616922153">Izbris gesla</translation>
-<translation id="1516229014686355813">Funkcija »Iskanje z dotikom« zagotovi, da sta izbrana beseda in trenutna stran poslani kot kontekst v Iskanje Google. Izklopite jo lahko v <ph name="BEGIN_LINK" />nastavitvah<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktivno danes</translation>
-<translation id="1544826120773021464">Če želite upravljati račun Google, se dotaknite gumba »Upravljanje računa«</translation>
-<translation id="1549000191223877751">Premik v drugo okno</translation>
-<translation id="1553358976309200471">Posodobi Chrome</translation>
-<translation id="1569387923882100876">Povezana naprava</translation>
-<translation id="1571304935088121812">Kopiranje uporabniškega imena</translation>
-<translation id="1612196535745283361">Chrome za iskanje naprav potrebuje dostop do lokacije. Dostop do lokacije <ph name="BEGIN_LINK" />je izklopljen za to napravo<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Tej strani prepreči, da bi ustvarila dodatna pogovorna okna</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Odstranitev 1 izbranega elementa}one{Odstranitev # izbranega elementa}two{Odstranitev # izbranih elementov}few{Odstranitev # izbranih elementov}other{Odstranitev # izbranih elementov}}</translation>
-<translation id="164269334534774161">Ogledujete si kopijo te strani brez povezave z dne <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Zgodovina</translation>
-<translation id="1647391597548383849">Dostop do fotoaparata</translation>
-<translation id="1660204651932907780">Dovoli spletnim mestom predvajanje zvoka (priporočljivo)</translation>
-<translation id="1670399744444387456">Osnovno</translation>
-<translation id="1671236975893690980">Prenos na čakanju …</translation>
-<translation id="1672586136351118594">Tega ne prikaži več</translation>
-<translation id="1692118695553449118">Sinhroniziranje je vklopljeno</translation>
-<translation id="169515064810179024">Spletnim mestom prepreči dostop do tipal gibanja</translation>
-<translation id="1717218214683051432">Tipala gibanja</translation>
-<translation id="1718835860248848330">Zadnja ura</translation>
-<translation id="1736419249208073774">Razišči</translation>
-<translation id="1743802530341753419">Prikaži poziv, preden se spletnim mestom dovoli povezovanje z napravo (priporočeno)</translation>
-<translation id="1749561566933687563">Sinhroniziranje zaznamkov</translation>
-<translation id="17513872634828108">Odprti zavihki</translation>
-<translation id="1779089405699405702">Slikovni dekodirnik</translation>
-<translation id="1782483593938241562">Končni datum: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Nameščeno</translation>
-<translation id="1792959175193046959">Kadar koli lahko spremenite privzeto mesto za prenose</translation>
-<translation id="1807246157184219062">Svetlo</translation>
-<translation id="1810845389119482123">Začetna nastavitev sinhronizacije se ni dokončala</translation>
-<translation id="1821253160463689938">Uporablja piškotke, da si zapomni vaše nastavitve, tudi če teh strani ne obiskujete</translation>
-<translation id="1829244130665387512">Poiščite na strani</translation>
-<translation id="1853692000353488670">Nov zavihek brez beleženja zgodovine</translation>
-<translation id="1856325424225101786">Želite ponastaviti lahki način?</translation>
-<translation id="1868024384445905608">Chrome zdaj hitreje prenaša datoteke</translation>
-<translation id="1883903952484604915">Moje datoteke</translation>
-<translation id="1887786770086287077">Dostop do lokacije je izklopljen za to napravo. Vklopite ga lahko v <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Aplikacija <ph name="APP_NAME" /> se bo odprla v Chromu. Če nadaljujete, se strinjate s Chromovimi <ph name="BEGIN_LINK1" />pogoji storitve<ph name="END_LINK1" /> in <ph name="BEGIN_LINK2" />pravilnikom o zasebnosti<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Oglasi</translation>
-<translation id="1919950603503897840">Izbira stikov</translation>
-<translation id="1922076542920281912">Če želite Chromu omogočiti dostop do lokacije, lokacijo vklopite tudi v <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Posodobitve</translation>
-<translation id="19288952978244135">Znova odprite Chrome.</translation>
-<translation id="1933845786846280168">Izbrani zavihek</translation>
-<translation id="194341124344773587">V <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" /> vklopite dovoljenje za Chrome.</translation>
-<translation id="1943432128510653496">Shranjevanje gesel</translation>
-<translation id="1952172573699511566">Spletna mesta bodo besedilo prikazala v izbranem jeziku, če je mogoče.</translation>
-<translation id="1960290143419248813">Posodobitve za Chrome v tej različici Androida niso več podprte.</translation>
-<translation id="1966710179511230534">Posodobite podrobnosti prijave.</translation>
-<translation id="1974060860693918893">Dodatno</translation>
-<translation id="1984705450038014246">Sinhronizacija podatkov v Chromu</translation>
-<translation id="1984937141057606926">Dovoljeno, razen za druga spletna mesta</translation>
-<translation id="1986685561493779662">Ime že obstaja</translation>
-<translation id="1987739130650180037">Gumb <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Brskanje</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> želi opraviti seznanitev</translation>
-<translation id="1994173015038366702">URL spletnega mesta</translation>
-<translation id="2000419248597011803">Pošilja nekatere piškotke in iskanja iz naslovne vrstice ter iskalnega polja privzetemu iskalniku</translation>
-<translation id="2002537628803770967">Kreditne kartice in naslovi z Googlom Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# datoteka}one{# datoteka}two{# datoteki}few{# datoteke}other{# datotek}}</translation>
-<translation id="2017836877785168846">Izbriše zgodovino in samodokončanja v naslovni vrstici.</translation>
-<translation id="2021896219286479412">Kontrol. za mesto v celo. načinu</translation>
-<translation id="2038563949887743358">Vklop možnosti »Zahteva za namizno spletno mesto«</translation>
-<translation id="2041019821020695769">Če želite, da vam Chrome pošilja obvestila, obvestila vklopite tudi v <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Aplikacija <ph name="APP_NAME" /> ima prav tako podatke v Chromu</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /><ph name="SEPARATOR" /><ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Spletno mesto začasno ustavljeno</translation>
-<translation id="2063713494490388661">Iskanje z dotikom</translation>
-<translation id="2067805253194386918">besedilo</translation>
-<translation id="2079545284768500474">Razveljavi</translation>
-<translation id="2082238445998314030"><ph name="RESULT_NUMBER" />. rezultat od <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Zvok</translation>
-<translation id="2096012225669085171">Sinhronizacija in prilagajanje med napravami</translation>
-<translation id="2100273922101894616">Samodejna prijava</translation>
-<translation id="2100314319871056947">Poskusite deliti besedilo v manjših kosih</translation>
-<translation id="2107397443965016585">Prikaži poziv, preden se spletnim mestom dovoli predvajanje zaščitene vsebine (priporočeno)</translation>
-<translation id="2111511281910874386">Pojdi na stran</translation>
-<translation id="2122601567107267586">Aplikacije ni bilo mogoče odpreti</translation>
-<translation id="2126426811489709554">Uporablja tehnologijo Chrome</translation>
-<translation id="2131665479022868825">Shranjeno <ph name="DATA" /></translation>
-<translation id="213279576345780926">Zaprt zavihek: <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Dodajanje na začetni zaslon</translation>
-<translation id="2146738493024040262">Odpri nenamestljivo aplikacijo</translation>
-<translation id="2148716181193084225">Danes</translation>
-<translation id="2154484045852737596">Urejanje kartice</translation>
-<translation id="2154710561487035718">Kopiraj URL</translation>
-<translation id="2156074688469523661">Preostala spletna mesta (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Če želite deliti kaj iz telefona z drugo napravo, v obeh napravah v nastavitvah Chroma vklopite sinhronizacijo</translation>
-<translation id="2170088579611075216">Omogoči in zaženi VR</translation>
-<translation id="218608176142494674">Deljenje z drugimi</translation>
-<translation id="2227444325776770048">Nadaljujte kot <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Sinhroniz. in Googlove storitve</translation>
-<translation id="2259659629660284697">Izvozi gesla …</translation>
-<translation id="2268044343513325586">Izboljšaj iskanje</translation>
-<translation id="2286841657746966508">Naslov za obračun storitev</translation>
-<translation id="2289270750774289114">Vprašaj, ko želi spletno mesto odkrivati naprave Bluetooth v bližini (priporočljivo)</translation>
-<translation id="230115972905494466">Ni združljivih naprav</translation>
-<translation id="2315043854645842844">Operacijski sistem ne podpira izbire potrdila pri odjemalcu.</translation>
-<translation id="2318045970523081853">Dotaknite se, če želite klicati</translation>
-<translation id="2321086116217818302">Pripravljanje gesel …</translation>
-<translation id="2321958826496381788">Drsnik povlecite tako daleč, da boste lahko to besedilo brez težave prebrali. Besedilo bo po dvakratnem dotiku odstavka vsaj tako veliko.</translation>
-<translation id="2323763861024343754">Shranjeni podatki splet. mesta</translation>
-<translation id="2328985652426384049">Ne morem se prijaviti</translation>
-<translation id="2330129964253841015">Posvari, če so gesla ogrožena</translation>
-<translation id="2349710944427398404">Skupna količina podatkov, ki jih uporablja Chrome, vključno z računi, zaznamki in shranjenimi nastavitvami.</translation>
-<translation id="2353636109065292463">Preverjanje internetne povezave</translation>
-<translation id="2359808026110333948">Naprej</translation>
-<translation id="2369533728426058518">odpiranje zavihkov</translation>
-<translation id="2387895666653383613">Prilagajanje velikosti besedila</translation>
-<translation id="2394602618534698961">Datoteke, ki jih prenesete, so prikazane tu</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Ko se prijavite v račun Google, se ta funkcija vklopi</translation>
-<translation id="2410754283952462441">Izbira računa</translation>
-<translation id="2414886740292270097">Temno</translation>
-<translation id="2416359993254398973">Chrome potrebuje dovoljenje za dostop do fotoaparata za to spletno mesto.</translation>
-<translation id="2426805022920575512">Izberi drug račun</translation>
-<translation id="2433507940547922241">Videz</translation>
-<translation id="2434158240863470628">Prenos je končan <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Dostop do lokacije</translation>
-<translation id="2450083983707403292">Ali želite znova začeti prenos datoteke <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Obvestila</translation>
-<translation id="2490684707762498678">Upravlja aplikacija <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Pomočnik Google v Chromu</translation>
-<translation id="2496180316473517155">Zgodovina brskanja</translation>
-<translation id="2497852260688568942">Sinhronizacijo je onemogočil skrbnik</translation>
-<translation id="2498359688066513246">Pomoč in povratne inform.</translation>
-<translation id="2501278716633472235">Nazaj</translation>
-<translation id="2513403576141822879">Če vas zanima več nastavitev, povezanih z zasebnostjo, varnostjo in zbiranjem podatkov, si oglejte razdelek <ph name="BEGIN_LINK" />Sinhronizacija in Googlove storitve<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Chrome v lahkem načinu naloži strani hitreje in uporabi do 60 odstotkov manj podatkov. Chrome zaradi optimiziranja strani, ki jih obiščete, Googlu pošlje vaš spletni promet. <ph name="BEGIN_LINK" />Več o tem<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Googlu pošlje URL-je strani, ki jih obiščete</translation>
-<translation id="2532336938189706096">Spletni pogled</translation>
-<translation id="2534155362429831547">Št. izbrisanih elementov: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Ogled kopije te strani za način brez povezave.</translation>
-<translation id="2546283357679194313">Piškotki in podatki o spletnih mestih</translation>
-<translation id="2567385386134582609">SLIKA</translation>
-<translation id="257088987046510401">Teme</translation>
-<translation id="2570922361219980984">Dostop do lokacije je tudi izklopljen za to napravo. Vklopite ga lahko v <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Razširjeno – kliknite, če želite strniti.</translation>
-<translation id="2581165646603367611">S tem bodo izbrisani piškotki, predpomnilnik in drugi podatki spletnih mest, ki se Chromu ne zdijo pomembni.</translation>
-<translation id="2586657967955657006">Odložišče</translation>
-<translation id="2587052924345400782">Na voljo je nov. različica</translation>
-<translation id="2593272815202181319">Stalna širina</translation>
-<translation id="2612676031748830579">Številka kartice</translation>
-<translation id="2621115761605608342">Dovoli JavaScript za določeno spletno mesto.</translation>
-<translation id="2625189173221582860">Geslo kopirano</translation>
-<translation id="2631006050119455616">Prihranjeno</translation>
-<translation id="2647434099613338025">Dodaj jezik</translation>
-<translation id="2650751991977523696">Želite znova prenesti datoteko?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# zvočna datoteka}one{# zvočna datoteka}two{# zvočni datoteki}few{# zvočne datoteke}other{# zvočnih datotek}}</translation>
-<translation id="2653659639078652383">Pošlji</translation>
-<translation id="2677748264148917807">Zapusti</translation>
-<translation id="2704606927547763573">Kopirano</translation>
-<translation id="2707726405694321444">Osveži stran</translation>
-<translation id="2709516037105925701">Samodejno izpolnjevanje</translation>
-<translation id="2717722538473713889">E-poštni naslovi</translation>
-<translation id="2728754400939377704">Razvrsti glede na spletno mesto</translation>
-<translation id="2744248271121720757">Dotaknite se besede, če želite dinamično iskati ali prikazati sorodna dejanja</translation>
-<translation id="2760989362628427051">Vklop temne teme, ko je v napravi vklopljena temna tema ali je vklopljeno varčevanje z energijo akumulatorja</translation>
-<translation id="2762000892062317888">pravkar</translation>
-<translation id="2777555524387840389">Še <ph name="SECONDS" /> s</translation>
-<translation id="2779651927720337254">ni uspelo</translation>
-<translation id="2781151931089541271">Še 1 s</translation>
-<translation id="2801022321632964776">Posodobite Chrome na najnovejšo različico, če ga želite v svojem jeziku</translation>
-<translation id="2810645512293415242">Poenostavljena stran zaradi prihranka pri prenosu podatkov in hitrejšega nalaganja.</translation>
-<translation id="281504910091592009">Shranjena gesla si lahko ogledate in jih upravljate v <ph name="BEGIN_LINK" />Google Računu<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Če želite dostopati do zaznamkov v vseh napravah, se prijavite in vklopite sinhronizacijo</translation>
-<translation id="2822354292072154809">Ali ste prepričani, da želite ponastaviti vsa dovoljenja za spletna mesta za <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Dotaknite se gumba za nazaj, če želite zapreti celozaslonski način.</translation>
-<translation id="2842985007712546952">Nadrejena mapa</translation>
-<translation id="2858138569776157458">Najb. prilj.</translation>
-<translation id="2860954141821109167">V tej napravi mora biti omogočena aplikacija Telefon</translation>
-<translation id="2870560284913253234">Spletno mesto</translation>
-<translation id="2874939134665556319">Prejšnja skladba</translation>
-<translation id="2876369937070532032">Googlu pošlje URL-je nekaterih strani, ki jih obiščete, kadar je ogrožena vaša varnost</translation>
-<translation id="2888126860611144412">O brskalniku Chrome</translation>
-<translation id="2891154217021530873">Ustavi nalaganje strani</translation>
-<translation id="2893180576842394309">Google lahko vašo zgodovino uporabi za prilagajanje Iskanja Google in drugih Googlovih storitev</translation>
-<translation id="2898264748040935573">Urejanje shranjenega gesla</translation>
-<translation id="2900528713135656174">Ustvarite dogodek</translation>
-<translation id="290376772003165898">Stran ni v jeziku <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Seznam naprav, s katerimi želite deliti zavihek, odprt pri polni višini.</translation>
-<translation id="2910701580606108292">Prikaži poziv, preden se spletnim mestom dovoli predvajanje zaščitene vsebine</translation>
-<translation id="2913331724188855103">Dovoli spletnim mestom shranjevanje in branje podatkov piškotkov (priporočljivo)</translation>
-<translation id="2923908459366352541">Ime je neveljavno</translation>
-<translation id="2932150158123903946">Shranjeni podatki aplikacije Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Zavihek za predogled je zaprt</translation>
-<translation id="2956410042958133412">Ta računa upravljata <ph name="PARENT_NAME_1" /> in <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Preklopljeno na zavihke brez beleženja zgodovine</translation>
-<translation id="2968755619301702150">Pregledovalnik potrdil</translation>
-<translation id="2979025552038692506">Izbrani zavihek brez beleženja zgodovine</translation>
-<translation id="2987620471460279764">Besedilo, deljeno iz druge naprave</translation>
-<translation id="2989523299700148168">Nedavno obiskano</translation>
-<translation id="2996291259634659425">Ustvarjanje gesla</translation>
-<translation id="2996809686854298943">URL je obvezen</translation>
-<translation id="300526633675317032">S tem bo izbrisanih vseh <ph name="SIZE_IN_KB" /> shranjenih podatkov spletnega mesta.</translation>
-<translation id="3016635187733453316">Naprava mora biti povezana z internetom</translation>
-<translation id="3029613699374795922">Preneseno <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Gesli se ne ujemata</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Poiščite pomoč<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Lokacija je izklopljena. Vklopite jo lahko v <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Sinhronizacijo lahko kadarkoli vklopite v nastavitvah.</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> zaznamek}one{<ph name="BOOKMARKS_COUNT_MANY" /> zaznamek}two{<ph name="BOOKMARKS_COUNT_MANY" /> zaznamka}few{<ph name="BOOKMARKS_COUNT_MANY" /> zaznamki}other{<ph name="BOOKMARKS_COUNT_MANY" /> zaznamkov}}</translation>
-<translation id="3089395242580810162">Odpri v zavihku brez bel. zg.</translation>
-<translation id="3115898365077584848">Pokaži informacije</translation>
-<translation id="3123473560110926937">Blokirano na nekaterih spletnih mestih</translation>
-<translation id="3137521801621304719">Izklop načina brez beleženja zgodovine</translation>
-<translation id="3143515551205905069">Prekliči sinhronizacijo</translation>
-<translation id="3157842584138209013">Če pritisnete gumb za več možnosti, si lahko ogledate, koliko prenosa podatkov ste prihranili</translation>
-<translation id="3166827708714933426">Bližnjice za zavihke in okna</translation>
-<translation id="3181954750937456830">Varno brskanje (ščiti vas in napravo pred nevarnimi spletnimi mesti)</translation>
-<translation id="3190152372525844641">V <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" /> vklopite dovoljenja za Chrome.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> shranjenih podatkov</translation>
-<translation id="3205824638308738187">Skoraj končano!</translation>
-<translation id="3207960819495026254">Dodano med zaznamke</translation>
-<translation id="3211426585530211793">Izbrisano: <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Če ste pozabili geslo ali želite spremeniti to nastavitev, <ph name="BEGIN_LINK" />ponastavite sinhronizacijo<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Spletna aplikacija</translation>
-<translation id="3236059992281584593">Še 1 min</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Zaznamujte to stran</translation>
-<translation id="3259831549858767975">Pomanjšanje vsebine strani</translation>
-<translation id="3269093882174072735">Naloži sliko</translation>
-<translation id="3269956123044984603">Če želite dostopati do zavihkov v drugih napravah, v nastavitvah računa za Android vklopite »Samodejno sinhroniziraj podatke«.</translation>
-<translation id="3277252321222022663">Spletnim mestom dovoli dostop do tipal (priporočeno)</translation>
-<translation id="3282568296779691940">Prijava v Chrome</translation>
-<translation id="3288003805934695103">znova naložiti stran</translation>
-<translation id="32895400574683172">Obvestila so dovoljena</translation>
-<translation id="3295530008794733555">Brskajte hitreje. Uporabite manj podatkov.</translation>
-<translation id="3295602654194328831">Skrij informacije</translation>
-<translation id="3298243779924642547">Osn. način</translation>
-<translation id="3303414029551471755">Ali želite prenesti vsebino?</translation>
-<translation id="3306398118552023113">Ta aplikacija se izvaja v Chromu</translation>
-<translation id="3315103659806849044">Trenutno prilagajate nastavitve sinhronizacije in Googlovih storitev. Če želite dokončati vklop sinhronizacije, se dotaknite gumba za potrditev pri dnu zaslona. Pomik navzgor</translation>
-<translation id="3328801116991980348">Podatki o mestu</translation>
-<translation id="3333961966071413176">Vsi stiki</translation>
-<translation id="3334729583274622784">Želite spremeniti pripono datoteke?</translation>
-<translation id="3341058695485821946">Oglejte si, koliko prenosa podatkov ste prihranili</translation>
-<translation id="3350687908700087792">Zapri vse zavihke brez beleženja zgodovine</translation>
-<translation id="3353615205017136254">Stran v osnovnem načinu, ki jo je prikazal Google. Dotaknite se gumba za nalaganje izvirne strani, če želite naložiti izvirno stran.</translation>
-<translation id="3367813778245106622">Prijavite se znova, če želite začeti sinhronizacijo</translation>
-<translation id="3374023511497244703">Vaši zaznamki, zgodovina, gesla in drugi podatki v Chromu ne bodo več sinhronizirani z računom za Google</translation>
-<translation id="3384347053049321195">Skupna raba slike</translation>
-<translation id="3386292677130313581">Prikaži poziv, preden se spletnim mestom razkrije vaša lokacija (priporočeno)</translation>
-<translation id="3387650086002190359">Prenos datoteke <ph name="FILE_NAME" /> ni uspel zaradi napak v datotečnem sistemu.</translation>
-<translation id="3389286852084373014">Besedilo je preveliko</translation>
-<translation id="3398320232533725830">Odpiranje upravitelja zaznamkov</translation>
-<translation id="3414952576877147120">Velikost:</translation>
-<translation id="3443221991560634068">Vnovično nalaganje trenutne strani</translation>
-<translation id="3445014427084483498">Pravkar</translation>
-<translation id="3478363558367712427">Izberete lahko iskalnik</translation>
+<translation id="6910211073230771657">Izbrisano</translation>
+<translation id="6965382102122355670">V redu</translation>
+<translation id="5301954838959518834">V redu, razumem</translation>
+<translation id="7658239707568436148">Prekliči</translation>
 <translation id="3479552764303398839">Ne zdaj</translation>
-<translation id="3492207499832628349">Nov zavihek brez bel. zgod.</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Preberite več<ph name="END_LINK" /> o predlagani vsebini</translation>
-<translation id="3513704683820682405">Razširjena resničnost</translation>
-<translation id="3518985090088779359">Sprejmi in nadaljuj</translation>
-<translation id="3522247891732774234">Posodobitev je na voljo. Več možnosti.</translation>
-<translation id="3524138585025253783">Uporabniški vmesnik za razvijalce</translation>
-<translation id="3527085408025491307">Mapa</translation>
-<translation id="3542235761944717775">Na voljo: <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Iščite v svoji zgodovini</translation>
-<translation id="3557336313807607643">Dodaj med stike</translation>
-<translation id="3566923219790363270">Chrome se še vedno pripravlja na navidezno resničnost. Znova zaženite Chrome pozneje.</translation>
-<translation id="3568688522516854065">Če želite dostopati do zavihkov iz drugih naprav, vklopite sinhronizacijo</translation>
-<translation id="3587482841069643663">Vse</translation>
-<translation id="358794129225322306">Dovoli spletnemu mestu samodejni prenos več datotek.</translation>
-<translation id="3590487821116122040">Shranjeni podatki spletnega mesta, ki se Chromu ne zdijo pomembni (npr. spletna mesta, za katera nimate shranjenih nastavitev ali ki jih ne obiskujete pogosto).</translation>
-<translation id="3599863153486145794">Izbriše zgodovino iz vseh naprav, v katerih ste prijavljeni. V Google Računu so morda druge vrste zgodovine brskanja na <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Izklop zvoka na spletnih mestih, ki predvajajo zvok</translation>
-<translation id="3616113530831147358">Zvok</translation>
-<translation id="3631987586758005671">Deljenje z napravo <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Razkritje gesla</translation>
-<translation id="363596933471559332">Samodejna prijava v spletna mesta s shranjenimi poverilnicami. Ko je ta funkcija izklopljena, bo pri vsaki prijavi v spletno mesto potrebno preverjanje.</translation>
-<translation id="3658159451045945436">Ponastavitev izbriše zgodovino prihrankov pri prenosu podatkov, vključno s seznamom obiskanih spletnih mest.</translation>
-<translation id="3692944402865947621">Prenos datoteke <ph name="FILE_NAME" /> ni uspel, ker prostor za shranjevanje ni dosegljiv.</translation>
-<translation id="3714981814255182093">Odpiranje vrstice za iskanje</translation>
-<translation id="3716182511346448902">Ta stran uporablja preveč pomnilnika, zato jo je Chrome zaustavil.</translation>
-<translation id="3730075448226062617">Če želite Chromu omogočiti dostop do mikrofona, mikrofon vklopite tudi v <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Dodano med zaznamke v izdelku <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Sinhroniziranje v ozadju</translation>
-<translation id="3771001275138982843">Posodobitve ni bilo mogoče prenesti</translation>
-<translation id="3771033907050503522">Incognito Tabs</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Vklopite Bluetooth<ph name="END_LINK" />, če želite dovoliti seznanjanje</translation>
-<translation id="3775705724665058594">Pošiljanje v naprave</translation>
-<translation id="3778956594442850293">Dodano na začetni zaslon</translation>
-<translation id="3789841737615482174">Namesti</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Upravljanje</translation>
-<translation id="381841723434055211">Telefonske številke</translation>
-<translation id="3819178904835489326">Št. izbrisanih prenosov: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Izbris shrambe mesta?</translation>
-<translation id="385051799172605136">Nazaj</translation>
-<translation id="3859306556332390985">Išči naprej</translation>
-<translation id="3894427358181296146">Dodajanje mape</translation>
-<translation id="3895926599014793903">Vsili povečavo</translation>
-<translation id="3912508018559818924">Iskanje najboljšega v spletu …</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Združevanje podatkov</translation>
-<translation id="393697183122708255">Glasovno iskanje ni na voljo</translation>
-<translation id="395206256282351086">Predlogi za iskanje in spletna mesta so onemogočeni</translation>
-<translation id="3955193568934677022">Dovoli spletnim mestom predvajanje zaščitene vsebine (priporočeno)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome bo naložil stran, ko bo pripravljen}one{Chrome bo naložil strani, ko bo pripravljen}two{Chrome bo naložil strani, ko bo pripravljen}few{Chrome bo naložil strani, ko bo pripravljen}other{Chrome bo naložil strani, ko bo pripravljen}}</translation>
-<translation id="3963007978381181125">Šifriranje gesla ne vključuje plačilnih sredstev in naslovov iz Googla Pay. Vaše šifrirane podatke lahko bere samo oseba z vašim geslom. Geslo ni poslano Googlu in ni shranjeno v Googlu. Če ga pozabite ali želite spremeniti to nastavitev, boste morali sinhronizacijo ponastaviti. <ph name="BEGIN_LINK" />Več o tem<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Prenos končan</translation>
-<translation id="397583555483684758">Sinhronizacija je prenehala delovati</translation>
-<translation id="3976396876660209797">Odstranite in znova ustvarite to bližnjico</translation>
-<translation id="3985215325736559418">Ali želite znova prenesti datoteko <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Kopiranje povezave</translation>
-<translation id="3988213473815854515">Lokacija je dovoljena</translation>
-<translation id="3988466920954086464">Ogled rezultatov dinamičnega iskanja v tem podoknu</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Nepomembni shranjeni podatki</translation>
-<translation id="4000212216660919741">Začetna stran brez povezave</translation>
+<translation id="5317780077021120954">Shrani</translation>
+<translation id="4570913071927164677">Podrobnosti</translation>
+<translation id="8730621377337864115">Končano</translation>
+<translation id="8261506727792406068">Izbriši</translation>
+<translation id="1181037720776840403">Odstrani</translation>
+<translation id="5939518447894949180">Ponastavi</translation>
 <translation id="4002066346123236978">Naslov</translation>
-<translation id="4008040567710660924">Omogočanje piškotkov za določeno spletno mesto.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}two{# h}few{# h}other{# h}}</translation>
-<translation id="4046123991198612571">Naslednja skladba</translation>
-<translation id="4048707525896921369">Več informacij o temah na spletnih mestih, ne da bi zapustili stran. Funkcija »Iskanje z dotikom« pošlje besedo in njeno sobesedilo Iskanju Google in vrne definicije, slike, rezultate iskanja in druge podrobnosti.
+<translation id="5916664084637901428">Vklopljeno</translation>
+<translation id="5860033963881614850">Izklopljeno</translation>
+<translation id="6165508094623778733">Več o tem</translation>
+<translation id="6042308850641462728">Več</translation>
+<translation id="6040143037577758943">Zapri</translation>
+<translation id="780301667611848630">Ne, hvala</translation>
+<translation id="1201402288615127009">Naprej</translation>
+<translation id="2359808026110333948">Naprej</translation>
+<translation id="2653659639078652383">Pošlji</translation>
+<translation id="2079545284768500474">Razveljavi</translation>
+<translation id="7649070708921625228">Pomoč</translation>
+<translation id="2148716181193084225">Danes</translation>
+<translation id="7781829728241885113">Včeraj</translation>
+<translation id="6945221475159498467">Izberi</translation>
+<translation id="7791543448312431591">Dodaj</translation>
+<translation id="6527303717912515753">Skupna raba</translation>
+<translation id="1383876407941801731">Išči</translation>
+<translation id="3115898365077584848">Pokaži informacije</translation>
+<translation id="3295602654194328831">Skrij informacije</translation>
+<translation id="3987993985790029246">Kopiranje povezave</translation>
+<translation id="2704606927547763573">Kopirano</translation>
+<translation id="8725066075913043281">Poskusite znova</translation>
+<translation id="385051799172605136">Nazaj</translation>
+<translation id="8131740175452115882">Potrdi</translation>
+<translation id="5300589172476337783">Pokaži</translation>
+<translation id="1124772482545689468">Uporabnik</translation>
+<translation id="8609465669617005112">Premakni navzgor</translation>
+<translation id="6746124502594467657">Premakni dol</translation>
+<translation id="8249310407154411074">Na vrh</translation>
+<translation id="8428213095426709021">Nastavitve</translation>
+<translation id="2498359688066513246">Pomoč in povratne inform.</translation>
+<translation id="8378714024927312812">Upravlja vaša organizacija</translation>
+<translation id="9019902583201351841">Upravljajo starši</translation>
+<translation id="4645575059429386691">Upravlja starš</translation>
+<translation id="4883854917563148705">Upravljanih nastavitev ni mogoče ponastaviti</translation>
+<translation id="4307992518367153382">Osnove</translation>
+<translation id="1974060860693918893">Dodatno</translation>
+<translation id="1146678959555564648">V navidezno resničnost</translation>
+<translation id="987264212798334818">Splošno</translation>
+<translation id="4275663329226226506">Predstavnost</translation>
+<translation id="4759238208242260848">Prenosi</translation>
+<translation id="218608176142494674">Deljenje z drugimi</translation>
+<translation id="8004582292198964060">Brskalnik</translation>
+<translation id="1105960400813249514">Zajemanje slike</translation>
+<translation id="4875775213178255010">Predlogi za vsebino</translation>
+<translation id="2021896219286479412">Kontrol. za mesto v celo. načinu</translation>
+<translation id="4587589328781138893">Spletna mesta</translation>
+<translation id="4943703118917034429">Navidezna resničnost</translation>
+<translation id="1928696683969751773">Posodobitve</translation>
+<translation id="6064125863973209585">Dokončani prenosi</translation>
+<translation id="5342314432463739672">Zahteve za dovoljenja</translation>
+<translation id="629730747756840877">Račun</translation>
+<translation id="82609232232243542">Prijava v Brave</translation>
+<translation id="7956662517480676674">Sinhroniz. in Googlove storitve</translation>
+<translation id="5294439808117722387">Trenutno prilagajate nastavitve sinhronizacije in Googlovih storitev. Če želite dokončati vklop sinhronizacije, se dotaknite gumba za potrditev pri dnu zaslona. Pomik navzgor</translation>
+<translation id="2096012225669085171">Sinhronizacija in prilagajanje med napravami</translation>
+<translation id="1692118695553449118">Sinhroniziranje je vklopljeno</translation>
+<translation id="5514904542973294328">Onemogoči skrbnik te naprave</translation>
+<translation id="6447211988989208781">Googlovi kontrolniki za dejavnost</translation>
+<translation id="4882831918239250449">Nadziranje, kako se zgodovina brskanja uporabi za prilagajanje Iskanja Brave Software, oglasov in drugega</translation>
+<translation id="7431991332293347422">Nadziranje, kako se zgodovina brskanja uporabi za prilagajanje Iskanja Brave Software in drugega</translation>
+<translation id="6303969859164067831">Odjava in izklop sinhronizacije</translation>
+<translation id="1125261911132334651">Upravljanje računa Brave Software</translation>
+<translation id="6406506848690869874">Sinhronizacija</translation>
+<translation id="714362445477979774">Sinhronizacija podatkov v Chromu</translation>
+<translation id="4314815835985389558">Upravljanje sinhronizacije</translation>
+<translation id="5428209950370661546">Druge Googlove storitve</translation>
+<translation id="7704317875155739195">Samodejno dokončanje iskanj in URL-jev</translation>
+<translation id="2000419248597011803">Pošilja nekatere piškotke in iskanja iz naslovne vrstice ter iskalnega polja privzetemu iskalniku</translation>
+<translation id="7981313251711023384">Vnaprejšnje nalaganje strani zaradi hitrejšega brskanja in iskanja</translation>
+<translation id="1821253160463689938">Uporablja piškotke, da si zapomni vaše nastavitve, tudi če teh strani ne obiskujete</translation>
+<translation id="6697492270171225480">Prikaz predlogov za podobne strani, ko strani ni mogoče najti</translation>
+<translation id="8109318360573330108">Googlu pošlje URL strani, ki jo želite odpreti</translation>
+<translation id="8438566539970814960">Izboljšanje iskanja in brskanja</translation>
+<translation id="284843628681142937">Googlu pošlje URL-je strani, ki jih obiščete</translation>
+<translation id="7222718784508482526">Če vas zanima več nastavitev, povezanih z zasebnostjo, varnostjo in zbiranjem podatkov, si oglejte razdelek <ph name="BEGIN_LINK"/>Sinhronizacija in Googlove storitve<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Pomagajte izboljšati funkcije in delovanje Chroma</translation>
+<translation id="9063160602596686558">Samodejno pošilja statistične podatke o uporabi in poročila o zrušitvah Googlu</translation>
+<translation id="4824958205181053313">Želite preklicati sinhronizacijo?</translation>
+<translation id="3058498974290601450">Sinhronizacijo lahko kadarkoli vklopite v nastavitvah.</translation>
+<translation id="3143515551205905069">Prekliči sinhronizacijo</translation>
+<translation id="1506061864768559482">Iskalnik</translation>
+<translation id="55737423895878184">Lokacija in obvestila so dovoljeni</translation>
+<translation id="3988213473815854515">Lokacija je dovoljena</translation>
+<translation id="32895400574683172">Obvestila so dovoljena</translation>
+<translation id="9040142327097499898">Obvestila so dovoljena. Lokacija je izklopljena za to napravo.</translation>
+<translation id="305593374596241526">Lokacija je izklopljena. Vklopite jo lahko v <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Nedavno obiskano</translation>
+<translation id="6433501201775827830">Izbira iskalnika</translation>
+<translation id="7177466738963138057">To lahko pozneje spremenite v nastavitvah</translation>
+<translation id="3478363558367712427">Izberete lahko iskalnik</translation>
+<translation id="4910889077668685004">Aplikacije za plačevanje</translation>
+<translation id="5152843274749979095">Nameščena ni nobena podprta aplikacija</translation>
+<translation id="8812260976093120287">Na nekaterih spletnih mestih je mogoče plačevati z zgoraj navedenimi podprtimi aplikacijami v napravi.</translation>
+<translation id="7764225426217299476">Dodaj naslov</translation>
+<translation id="5595485650161345191">Uredi naslov</translation>
+<translation id="5087580092889165836">Dodaj kartico</translation>
+<translation id="2154484045852737596">Urejanje kartice</translation>
+<translation id="6140912465461743537">Država/regija</translation>
+<translation id="5659593005791499971">E-pošta</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Ime na kartici</translation>
+<translation id="860043288473659153">Ime imetnika kartice</translation>
+<translation id="2612676031748830579">Številka kartice</translation>
+<translation id="869891660844655955">Datum izteka</translation>
+<translation id="2286841657746966508">Naslov za obračun storitev</translation>
+<translation id="663059986967017181">Kopirano v Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}two{<ph name="PAYMENT_METHOD_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}few{<ph name="PAYMENT_METHOD_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}two{<ph name="SHIPPING_ADDRESS_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}two{<ph name="SHIPPING_OPTION_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}few{<ph name="SHIPPING_OPTION_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}two{<ph name="CONTACT_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}few{<ph name="CONTACT_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Gesla</translation>
+<translation id="1943432128510653496">Shranjevanje gesel</translation>
+<translation id="2100273922101894616">Samodejna prijava</translation>
+<translation id="363596933471559332">Samodejna prijava v spletna mesta s shranjenimi poverilnicami. Ko je ta funkcija izklopljena, bo pri vsaki prijavi v spletno mesto potrebno preverjanje.</translation>
+<translation id="6995899638241819463">Posvari, če so gesla razkrita zaradi podatkovne kršitve</translation>
+<translation id="1534287762301776620">Ko se prijavite v račun Brave Software, se ta funkcija vklopi</translation>
+<translation id="10614374240317010">Nikoli shranjeno</translation>
+<translation id="3098842761938485917">Shranjena gesla si lahko ogledate in jih upravljate v <ph name="BEGIN_LINK"/>Brave Software Računu<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Shranjena gesla bodo prikazana tukaj.</translation>
+<translation id="8084114998886531721">Shranjeno geslo</translation>
+<translation id="2870560284913253234">Spletno mesto</translation>
+<translation id="8503813439785031346">Uporabniško ime</translation>
+<translation id="6657585470893396449">Geslo</translation>
+<translation id="2154710561487035718">Kopiraj URL</translation>
+<translation id="1571304935088121812">Kopiranje uporabniškega imena</translation>
+<translation id="5005498671520578047">Kopiranje gesla</translation>
+<translation id="3632295766818638029">Razkritje gesla</translation>
+<translation id="1513858653616922153">Izbris gesla</translation>
+<translation id="543338862236136125">Uredi geslo</translation>
+<translation id="4565377596337484307">Skrij geslo</translation>
+<translation id="8523928698583292556">Izbris shranjenega gesla</translation>
+<translation id="2898264748040935573">Urejanje shranjenega gesla</translation>
+<translation id="5433691172869980887">Uporabniško ime kopirano</translation>
+<translation id="5534640966246046842">Spletno mesto kopirano</translation>
+<translation id="2625189173221582860">Geslo kopirano</translation>
+<translation id="4550003330909367850">Če si želite ogledati geslo ali ga kopirati sem, v napravi nastavite zaklepanje zaslona.</translation>
+<translation id="6154478581116148741">Vklopite zaklepanje zaslona v nastavitvah, če želite izvoziti gesla iz te naprave.</translation>
+<translation id="4842092870884894799">Prikaz pojavnega okna za ustvarjanje gesel</translation>
+<translation id="2259659629660284697">Izvozi gesla …</translation>
+<translation id="133012818630824069">Izvoz gesel, shranjenih v Chromu</translation>
+<translation id="6914783257214138813">Gesla bodo vidna vsakomur, ki si lahko ogleda izvoženo datoteko z gesli.</translation>
+<translation id="2321086116217818302">Pripravljanje gesel …</translation>
+<translation id="8445448999790540984">Gesel ni mogoče izvoziti</translation>
+<translation id="3066461326500799725">Naučite se uporabljati Brave Software Drive</translation>
+<translation id="729975465115245577">V napravi ni aplikacije za shranjevanje datoteke z gesli.</translation>
+<translation id="7682724950699840886">Poskusite ta nasveta: poskrbite, da je v napravi dovolj prostora, ali poskusite znova izvoziti.</translation>
+<translation id="1129510026454351943">Podrobnosti: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Odklenite, če želite kopirati geslo</translation>
+<translation id="5515439363601853141">Odklenite, če si želite ogledati geslo</translation>
+<translation id="6221633008163990886">Odklenite, če želite izvoziti gesla</translation>
+<translation id="230699814587342492">Gesla za Brave</translation>
+<translation id="6075798973483050474">Urejanje domače strani</translation>
+<translation id="854522910157234410">Odpri to stran</translation>
+<translation id="2482878487686419369">Obvestila</translation>
+<translation id="6255999984061454636">Predlogi za vsebino</translation>
+<translation id="805047784848435650">Na podlagi zgodovine brskanja</translation>
+<translation id="1041308826830691739">S spletnih mest</translation>
+<translation id="395206256282351086">Predlogi za iskanje in spletna mesta so onemogočeni</translation>
+<translation id="257088987046510401">Teme</translation>
+<translation id="4650364565596261010">Sistemsko privzeto</translation>
+<translation id="7588219262685291874">Vklop temne teme, ko je v napravi vklopljeno varčevanje z energijo</translation>
+<translation id="2760989362628427051">Vklop temne teme, ko je v napravi vklopljena temna tema ali je vklopljeno varčevanje z energijo akumulatorja</translation>
+<translation id="6381421346744604172">Zatemnitev spletnih mest</translation>
+<translation id="5040262127954254034">Zasebnost</translation>
+<translation id="4991384657077828949">Pomagajte izboljšati varnost v Chromu</translation>
+<translation id="1943176487615318915">Zaradi zaznavanja nevarnih aplikacij in spletnih mest Brave Googlu pošlje URL-je nekaterih strani, ki jih obiščete, omejene podatke o sistemu in vsebino nekaterih strani</translation>
+<translation id="3181954750937456830">Varno brskanje (ščiti vas in napravo pred nevarnimi spletnimi mesti)</translation>
+<translation id="7315322926489145388">Googlu pošlje URL-je nekaterih strani, ki jih obiščete, kadar je ogrožena vaša varnost</translation>
+<translation id="2063713494490388661">Iskanje z dotikom</translation>
+<translation id="2369463299479365221">Več informacij o temah na spletnih mestih, ne da bi zapustili stran. Funkcija »Iskanje z dotikom« pošlje besedo in njeno sobesedilo Iskanju Brave Software in vrne definicije, slike, rezultate iskanja in druge podrobnosti.
 
 Če želite prilagoditi iskalno poizvedbo, jo izberite z daljšim dotikom. Če želite podrobneje nastaviti iskanje, potisnite podokno povsem navzgor in se dotaknite iskalnega polja.</translation>
-<translation id="4056223980640387499">Sepija</translation>
-<translation id="4060598801229743805">Možnosti so na voljo blizu vrha zaslona</translation>
-<translation id="4062305924942672200">Pravne informacije</translation>
-<translation id="4084682180776658562">Zaznamek</translation>
-<translation id="4084712963632273211">Vsebino objavil <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />prikazuje jo Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Izbris podatkov aplikacije?</translation>
-<translation id="4099578267706723511">Pomagajte izboljšati Chrome s pošiljanjem statističnih podatkov o uporabi in poročil o zrušitvah Googlu.</translation>
-<translation id="410351446219883937">Samodejno predvajanje</translation>
-<translation id="4116038641877404294">Prenesite strani, če jih želite uporabljati brez povezave</translation>
-<translation id="4135200667068010335">Seznam naprav, s katerimi želite deliti zavihek, je zaprt.</translation>
-<translation id="4149994727733219643">Poenostavljen pogled za spletne strani</translation>
-<translation id="4165986682804962316">Nastavitve spletnega mesta</translation>
-<translation id="4169535189173047238">Ne dovoli</translation>
-<translation id="4170011742729630528">Storitev ni na voljo; poskusite znova pozneje.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> prenesenih podatkov</translation>
-<translation id="4181841719683918333">Jeziki</translation>
-<translation id="4183868528246477015">Iskanje z Google Lens <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Odpri v novem zavihku</translation>
-<translation id="4198423547019359126">Ni razpoložljivih mest za prenos</translation>
-<translation id="4209895695669353772">Če želite prejemati prilagojeno vsebino, ki jo predlaga Google, vklopite sinhronizacijo</translation>
-<translation id="4226663524361240545">Ob prejemanju obvestil naprava morda vibrira</translation>
-<translation id="423219824432660969">Šifriranje sinhroniziranih podatkov z geslom za Google Račun z dnem <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Odpri nastavitve</translation>
-<translation id="4256782883801055595">Odprtokodne licence</translation>
-<translation id="4259722352634471385">Krmarjenje je blokirano: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopiraj naslov povezave</translation>
-<translation id="4275663329226226506">Predstavnost</translation>
-<translation id="4278390842282768270">Dovoljeno</translation>
-<translation id="429312253194641664">Spletno mesto predvaja predstavnost</translation>
-<translation id="4298388696830689168">Povezana spletna mesta</translation>
-<translation id="4307992518367153382">Osnove</translation>
-<translation id="4314815835985389558">Upravljanje sinhronizacije</translation>
-<translation id="4351244548802238354">Zapri pogovorno okno</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Uporaba iskalnika Sogou za iskanje</translation>
-<translation id="4404568932422911380">Ni zaznamkov</translation>
-<translation id="4405224443901389797">Premakni v …</translation>
-<translation id="4411535500181276704">Lahki način</translation>
-<translation id="4415276339145661267">Upravljanje računa Google</translation>
-<translation id="4432792777822557199">Strani v jeziku <ph name="SOURCE_LANGUAGE" /> bodo od zdaj naprej prevedene v jezik <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Stran v osnovnem načinu, ki jo je prikazal Google</translation>
-<translation id="4434045419905280838">Pojavna okna in preusmeritve</translation>
-<translation id="4440958355523780886">Stran v osnovnem načinu, ki jo je prikazal Google. Dotaknite se, če želite naložiti izvirno stran.</translation>
-<translation id="4452411734226507615">Zapiranje zavihka <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Zaznamek ustvarjen v mapi <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Spletnim mestom dovoli predvajanje zaščitene vsebine</translation>
-<translation id="4468959413250150279">Izklop zvoka za določeno spletno mesto.</translation>
-<translation id="4472118726404937099">Če želite sinhronizirati in prilagajati v vseh napravah, se prijavite in vklopite sinhronizacijo</translation>
-<translation id="447252321002412580">Pomagajte izboljšati funkcije in delovanje Chroma</translation>
-<translation id="4479647676395637221">Prikaži poziv, preden se spletnim mestom dovoli uporaba kamere (priporočeno)</translation>
-<translation id="4479972344484327217">Nameščanje modula <ph name="MODULE" /> za Chrome …</translation>
-<translation id="4487967297491345095">Vsi podatki aplikacije Chrome bodo trajno izbrisani, vključno z vsemi datotekami, nastavitvami, računi, zbirkami podatkov ipd.</translation>
-<translation id="4493497663118223949">Lahki način je vklopljen</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Pred # dnevom}one{Pred # dnevom}two{Pred # dnevoma}few{Pred # dnevi}other{Pred # dnevi}}</translation>
-<translation id="451872707440238414">Poiščite zaznamke</translation>
-<translation id="4521489764227272523">Izbrani podatki so bili odstranjeni iz Chroma in sinhroniziranih naprav.
-
-V Google Računu so morda druge vrste zgodovine brskanja, kot so iskanja in dejavnosti iz drugih Googlovih storitev, na <ph name="BEGIN_LINK" />history.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Izbira mape</translation>
-<translation id="4538018662093857852">Vklop lahkega načina</translation>
-<translation id="4550003330909367850">Če si želite ogledati geslo ali ga kopirati sem, v napravi nastavite zaklepanje zaslona.</translation>
-<translation id="4558311620361989323">Bližnjice za spletne strani</translation>
-<translation id="4561979708150884304">Ni povezave</translation>
-<translation id="4565377596337484307">Skrij geslo</translation>
-<translation id="4570913071927164677">Podrobnosti</translation>
-<translation id="4572422548854449519">Prijava v upravljani račun</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Pred # minuto}one{Pred # minuto}two{Pred # minutama}few{Pred # minutami}other{Pred # minutami}}</translation>
-<translation id="4587589328781138893">Spletna mesta</translation>
-<translation id="4594952190837476234">Ta stran brez povezave je bila ustvarjena <ph name="CREATION_TIME" /> in se morda razlikuje od spletne različice.</translation>
-<translation id="4605958867780575332">Odstranjen element: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Odpri <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Uporabi geslo</translation>
-<translation id="4645575059429386691">Upravlja starš</translation>
-<translation id="4650364565596261010">Sistemsko privzeto</translation>
-<translation id="4663756553811254707">Št. izbrisanih zaznamkov: <ph name="NUMBER_OF_BOOKMARKS" /></translation>
-<translation id="4665282149850138822">Spletno mesto <ph name="NAME" /> je bilo dodano na začetni zaslon</translation>
-<translation id="4684427112815847243">Sinhroniziraj vse</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}two{<ph name="SHIPPING_OPTION_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}few{<ph name="SHIPPING_OPTION_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Pošiljanje besedila v vaše naprave</translation>
-<translation id="4698034686595694889">Ogled brez povezave v aplikaciji <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Predpomnjene slike in datoteke</translation>
-<translation id="4714588616299687897">Prenesite do 60 % manj podatkov</translation>
-<translation id="4719927025381752090">Ponudi prevajanje</translation>
-<translation id="4720023427747327413">Odpri v: <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Pomagajte izboljšati Chrome. <ph name="BEGIN_LINK" />Sodelujte v anketi.<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Posodobi</translation>
-<translation id="4738836084190194332">Zadnja sinhronizacija: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Odpiranje novega zavihka</translation>
-<translation id="4751476147751820511">Tipala za gibanje in svetlobo</translation>
-<translation id="4759238208242260848">Prenosi</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 prenos je končan.}one{# prenos je končan.}two{# prenosa sta končana.}few{# prenosi so končani.}other{# prenosov je končanih.}}</translation>
-<translation id="4797039098279997504">Dotaknite se, če se želite vrniti na <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Šifriranje gesla ne vključuje plačilnih sredstev in naslovov iz Googla Pay.
-
-Če želite spremeniti to nastavitev, <ph name="BEGIN_LINK" />ponastavite sinhronizacijo<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Ime na kartici</translation>
-<translation id="4824958205181053313">Želite preklicati sinhronizacijo?</translation>
-<translation id="4837753911714442426">Odpiranje možnosti za tiskanje strani</translation>
-<translation id="4842092870884894799">Prikaz pojavnega okna za ustvarjanje gesel</translation>
-<translation id="4860895144060829044">Pokličite</translation>
-<translation id="4866368707455379617">Modula <ph name="MODULE" /> za Chrome ni mogoče namestiti</translation>
-<translation id="4875775213178255010">Predlogi za vsebino</translation>
-<translation id="4878404682131129617">Vzpostavljanje tunela prek strežnika proxy ni uspelo</translation>
-<translation id="4880127995492972015">Prevedi …</translation>
-<translation id="4881695831933465202">Odpri</translation>
-<translation id="488187801263602086">Preimenovanje datoteke</translation>
-<translation id="4882831918239250449">Nadziranje, kako se zgodovina brskanja uporabi za prilagajanje Iskanja Google, oglasov in drugega</translation>
-<translation id="4883854917563148705">Upravljanih nastavitev ni mogoče ponastaviti</translation>
-<translation id="4885273946141277891">To število primerkov Chroma ni podprto.</translation>
-<translation id="4910889077668685004">Aplikacije za plačevanje</translation>
-<translation id="4913161338056004800">Ponastavitev statističnih podatkov</translation>
-<translation id="4913169188695071480">Ustavitev osveževanja</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Poiščite pomoč<ph name="END_LINK" /> med iskanjem naprav …</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stran}one{# stran}two{# strani}few{# strani}other{# strani}}</translation>
-<translation id="4932247056774066048">Ker se odjavljate iz računa, ki ga upravlja <ph name="DOMAIN_NAME" />, bodo podatki v Chromu izbrisani iz te naprave. Ostali bodo v računu Google.</translation>
-<translation id="4943703118917034429">Navidezna resničnost</translation>
-<translation id="4943872375798546930">Ni rezultatov</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> dostopa do vašega zaslona</translation>
-<translation id="4961107849584082341">Prevedite to stran v kateri koli jezik</translation>
-<translation id="4962975101802056554">Umik vseh dovoljenj za napravo</translation>
-<translation id="4970824347203572753">Ni na voljo na vaši lokaciji</translation>
-<translation id="497421865427891073">Pojdi naprej</translation>
-<translation id="4988210275050210843">Prenos datoteke (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Strani</translation>
-<translation id="4994033804516042629">Ni najdenih stikov</translation>
-<translation id="4996978546172906250">Skupna raba prek</translation>
-<translation id="5004416275253351869">Googlovi kontrolniki za dejavnost</translation>
-<translation id="5005498671520578047">Kopiranje gesla</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> se želite povezati</translation>
-<translation id="5013696553129441713">Ni novih predlogov</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Med uporabo VR lahko to spletno mesto o vas izve to:
-  –  vaše fizične lastnosti, kot je telesna višina
-
-Prepričajte se, da zaupate temu spletnemu mestu, preden zaženete VR.</translation>
+<translation id="2930742481329940825">Funkcija »Iskanje z dotikom« zagotovi, da sta izbrana beseda in trenutna stran poslani kot kontekst v Iskanje Brave Software. Izklopite jo lahko v <ph name="BEGIN_LINK"/>nastavitvah<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Dovoli</translation>
-<translation id="5040262127954254034">Zasebnost</translation>
-<translation id="5048398596102334565">Spletnim mestom dovoli dostop do tipal gibanja (priporočeno)</translation>
-<translation id="5063480226653192405">Uporaba</translation>
-<translation id="5087580092889165836">Dodaj kartico</translation>
-<translation id="5100237604440890931">Strnjeno – kliknite, če želite razširiti.</translation>
-<translation id="510275257476243843">Še 1 h</translation>
-<translation id="5123685120097942451">Zavihek brez beleženja zgodovine</translation>
-<translation id="5127805178023152808">Sinhroniziranje je izklopljeno</translation>
-<translation id="5129038482087801250">Namesti spletno aplikacijo</translation>
-<translation id="5132942445612118989">Sinhronizirajte gesla, zgodovino in drugo v vseh napravah</translation>
-<translation id="5139940364318403933">Naučite se uporabljati Google Drive</translation>
-<translation id="515227803646670480">Izbris shranjenih podatkov</translation>
-<translation id="5152843274749979095">Nameščena ni nobena podprta aplikacija</translation>
-<translation id="5161254044473106830">Naslov je obvezen</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 prenos ni uspel.}one{# prenos ni uspel.}two{# prenosa nista uspela.}few{# prenosi niso uspeli.}other{# prenosov ni uspelo.}}</translation>
-<translation id="5170568018924773124">Prikaži v mapi</translation>
-<translation id="5184329579814168207">Odpri v Chromu</translation>
-<translation id="5193988420012215838">Kopirano v odložišče</translation>
-<translation id="5197729504361054390">Izbrani stiki bodo v skupni rabi s spletnim mestom <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Delovni profil</translation>
-<translation id="5210286577605176222">Premik na prejšnji zavihek</translation>
-<translation id="5210365745912300556">Zapri zavihek</translation>
-<translation id="5224771365102442243">Z videoposnetkom</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> želi iskati naprave Bluetooth v bližini. Najdene so bile te naprave:</translation>
-<translation id="5233638681132016545">Nov zavihek</translation>
-<translation id="526421993248218238">Te strani ni mogoče naložiti</translation>
-<translation id="5271967389191913893">Naprava ne more odpreti vsebine za prenos.</translation>
-<translation id="528192093759286357">Povlecite z vrha in se dotaknite gumba za nazaj, če želite zapreti celozaslonski način.</translation>
-<translation id="5292796745632149097">Pošiljanje v napravo</translation>
-<translation id="5300589172476337783">Pokaži</translation>
-<translation id="5301954838959518834">V redu, razumem</translation>
-<translation id="5304593522240415983">To polje ne sme biti prazno</translation>
-<translation id="5307446750509046227">Izbris shrambe mesta</translation>
-<translation id="5308380583665731573">Povezovanje</translation>
-<translation id="5313967007315987356">Dodajanje mesta</translation>
-<translation id="5317780077021120954">Shrani</translation>
-<translation id="5324858694974489420">Starševske nastavitve</translation>
-<translation id="5327248766486351172">Ime</translation>
-<translation id="5335288049665977812">Spletnim mestom dovoli izvajanje JavaScripta (priporočeno)</translation>
-<translation id="5342314432463739672">Zahteve za dovoljenja</translation>
-<translation id="5357811892247919462">Prejet zavihek</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> odprt zavihek, dotaknite se, če želite preklopiti med zavihki}one{<ph name="OPEN_TABS_MANY" /> odprt zavihek, dotaknite se, če želite preklopiti med zavihki}two{<ph name="OPEN_TABS_MANY" /> odprta zavihka, dotaknite se, če želite preklopiti med zavihki}few{<ph name="OPEN_TABS_MANY" /> odprti zavihki, dotaknite se, če želite preklopiti med zavihki}other{<ph name="OPEN_TABS_MANY" /> odprtih zavihkov, dotaknite se, če želite preklopiti med zavihki}}</translation>
-<translation id="5391532827096253100">Povezava s tem spletnim mestom ni varna. Podatki o spletnem mestu.</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(in še 1)}one{(in še #)}two{(in še #)}few{(in še #)}other{(in še #)}}</translation>
-<translation id="5400569084694353794">Če uporabljate to aplikacijo, se strinjate s <ph name="BEGIN_LINK1" />pogoji storitve<ph name="END_LINK1" /> in <ph name="BEGIN_LINK2" />pravilnikom o zasebnosti<ph name="END_LINK2" /> za Chrome.</translation>
-<translation id="5403592356182871684">Imena</translation>
-<translation id="5403644198645076998">Dovoli samo nekatera spletna mesta</translation>
-<translation id="5414836363063783498">Preverjanje …</translation>
-<translation id="5423934151118863508">Tu bodo prikazane strani, ki jih obiskujete najpogosteje</translation>
-<translation id="5424588387303617268">Na voljo: <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Uredi geslo</translation>
-<translation id="5433691172869980887">Uporabniško ime kopirano</translation>
-<translation id="543509235395288790">Prenašanje toliko datotek: <ph name="COUNT" /> (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Premik na naslovno vrstico</translation>
-<translation id="5447201525962359567">Vsi shranjeni podatki spletnega mesta, vključno s piškotki in drugimi lokalno shranjenimi podatki</translation>
-<translation id="5447765697759493033">To spletno mesto ne bo prevedeno</translation>
-<translation id="545042621069398927">Pospeševanje prenosa.</translation>
-<translation id="5456381639095306749">Prenos strani</translation>
-<translation id="5475862044948910901">Želite začeti sejo razširjene resničnosti?</translation>
-<translation id="548278423535722844">Odpiranje v aplikaciji z zemljevidi</translation>
-<translation id="5487521232677179737">Izbriši podatke</translation>
-<translation id="5494752089476963479">Blokiranje oglasov na spletnih mestih, ki prikazujejo vsiljive ali zavajajoče oglase</translation>
-<translation id="5500777121964041360">Morda ni na voljo na vaši lokaciji</translation>
-<translation id="5512137114520586844">Ta račun upravlja <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Onemogoči skrbnik te naprave</translation>
-<translation id="5515439363601853141">Odklenite, če si želite ogledati geslo</translation>
-<translation id="5516455585884385570">Odpiranje nastavitev obvestil</translation>
-<translation id="5517095782334947753">Iz računa <ph name="FROM_ACCOUNT" /> imate zaznamke, zgodovino, gesla in druge nastavitve.</translation>
-<translation id="5524843473235508879">Preusmeritev je bila blokirana.</translation>
-<translation id="5527082711130173040">Chrome za iskanje naprav potrebuje dostop do lokacije. <ph name="BEGIN_LINK1" />Posodobite dovoljenja<ph name="END_LINK1" />. Dostop do lokacije je prav tako <ph name="BEGIN_LINK2" />izklopljen za to napravo<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Prikaži poziv, preden se spletnim mestom dovoli branje besedila in slik v odložišču (priporočeno)</translation>
-<translation id="5530766185686772672">Zapri zavih. brez bel. zgo.</translation>
-<translation id="5534334044554683961">Med uporabo VR lahko to spletno mesto o vas izve to:
-  –   vaše fizične lastnosti, kot je telesna višina
-  –   postavitev vaše sobe
-
-Prepričajte se, da zaupate temu spletnemu mestu, preden zaženete VR.</translation>
-<translation id="5534640966246046842">Spletno mesto kopirano</translation>
-<translation id="5556459405103347317">Znova naloži</translation>
-<translation id="5561549206367097665">Čakanje na omrežje …</translation>
-<translation id="557283862590186398">Chrome potrebuje dovoljenje za dostop do mikrofona za to spletno mesto.</translation>
-<translation id="55737423895878184">Lokacija in obvestila so dovoljeni</translation>
-<translation id="5578795271662203820">Za iskanje te slike uporabi <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">V <ph name="BEGIN_LINK1" />nastavitvah<ph name="END_LINK1" /> lahko kadar koli izberete, kaj želite sinhronizirati.</translation>
-<translation id="5595485650161345191">Uredi naslov</translation>
-<translation id="5596627076506792578">Več možnosti</translation>
-<translation id="5599455543593328020">Način brez beleženja zgodovine</translation>
-<translation id="5620928963363755975">Poiščite datoteke in strani v Prenosih z gumbom »Več možnosti«</translation>
-<translation id="5626134646977739690">Ime:</translation>
-<translation id="5639724618331995626">Dovoli vsa spletna mesta</translation>
-<translation id="5648166631817621825">Zadnjih 7 dni</translation>
-<translation id="5649053991847567735">Samodejni prenosi</translation>
-<translation id="5655963694829536461">Poiščite prenose</translation>
-<translation id="5659593005791499971">E-pošta</translation>
-<translation id="5665379678064389456">Ustvarite dogodek v aplikaciji <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Preglasi zahtevo spletnega mesta za preprečevanje povečave</translation>
-<translation id="5677928146339483299">Blokirano</translation>
-<translation id="5684874026226664614">Ojoj, te strani bi bilo mogoče prevesti.</translation>
-<translation id="5686790454216892815">Ime datoteke je predolgo</translation>
-<translation id="5689516760719285838">Lokacija</translation>
-<translation id="569536719314091526">Prevedite to stran v kateri koli jezik z gumbom »Več možnosti«</translation>
-<translation id="572328651809341494">Nedavni zavihki</translation>
-<translation id="5726692708398506830">Povečanje vsebine strani</translation>
-<translation id="5748802427693696783">Preklopljeno na standardne zavihke</translation>
-<translation id="5749068826913805084">Chrome za prenos datotek potrebuje dostop do shrambe.</translation>
-<translation id="5763382633136178763">Zavihki brez beleženja zgodovine</translation>
-<translation id="5763514718066511291">Dotaknite se, če želite kopirati URL za to aplikacijo</translation>
-<translation id="5765780083710877561">Opis:</translation>
-<translation id="5793665092639000975">Uporaba <ph name="SPACE_USED" /> od <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google lahko vašo zgodovino uporabi za prilagajanje Iskanja Google, oglasov in drugih Googlovih storitev</translation>
-<translation id="5804241973901381774">Dovoljenja</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Pred # uro}one{Pred # uro}two{Pred # urama}few{Pred # urami}other{Pred # urami}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Vse pravice pridržane.</translation>
-<translation id="5817918615728894473">Seznani</translation>
-<translation id="583281660410589416">Neznano</translation>
-<translation id="5833984609253377421">Deli povezavo z drugimi</translation>
-<translation id="5836192821815272682">Prenašanje posodobitve za Chrome …</translation>
-<translation id="5853623416121554550">začasno ustavljeno</translation>
-<translation id="5854790677617711513">Starejše od 30 dni</translation>
-<translation id="5858741533101922242">Chrome ne more vklopiti vmesnika za Bluetooth</translation>
-<translation id="5860033963881614850">Izklopljeno</translation>
-<translation id="5862731021271217234">Če želite dostopati do zavihkov iz drugih naprav, vklopite sinhronizacijo</translation>
-<translation id="5864174910718532887">Podrobnosti: razvrščeno po imenu spletnega mesta</translation>
-<translation id="5864419784173784555">Čakanje na drug prenos …</translation>
-<translation id="5865733239029070421">Samodejno pošilja statistične podatke o uporabi in poročila o zrušitvah Googlu</translation>
-<translation id="5869522115854928033">Shranjena gesla</translation>
-<translation id="5902828464777634901">Vsi lokalni podatki, ki jih je shranilo to spletno mesto, vključno s piškotki, bodo izbrisani.</translation>
-<translation id="5916664084637901428">Vklopljeno</translation>
-<translation id="5919204609460789179">Posodobite izdelek <ph name="PRODUCT_NAME" />, če želite začeti sinhronizacijo</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> prihranka pri količini prenesenih podatkov</translation>
-<translation id="5939518447894949180">Ponastavi</translation>
-<translation id="5942872142862698679">Uporaba iskalnika Google za iskanje</translation>
-<translation id="5952764234151283551">Googlu pošlje URL strani, ki jo želite odpreti</translation>
-<translation id="5956665950594638604">Odpiranje centra za pomoč za Chrome na nov. zavih.</translation>
-<translation id="5958275228015807058">Poiščite datoteke in strani v Prenosih</translation>
-<translation id="5962718611393537961">Dotik za strnitev</translation>
-<translation id="6000066717592683814">Ohrani Google</translation>
-<translation id="6005538289190791541">Predlagano geslo</translation>
-<translation id="6036057147555329831">Dodatni modul ICU</translation>
-<translation id="6039379616847168523">Premik na naslednji zavihek</translation>
-<translation id="6040143037577758943">Zapri</translation>
-<translation id="6042308850641462728">Več</translation>
-<translation id="604996488070107836">Prenos datoteke <ph name="FILE_NAME" /> ni uspel zaradi neznane napake.</translation>
-<translation id="605721222689873409">LL</translation>
-<translation id="6064125863973209585">Dokončani prenosi</translation>
-<translation id="6075798973483050474">Urejanje domače strani</translation>
-<translation id="60923314841986378">Še <ph name="HOURS" /> h</translation>
-<translation id="6108923351542677676">Poteka nastavitev …</translation>
-<translation id="6111020039983847643">prenesenih podatkov</translation>
-<translation id="6112702117600201073">Osveževanje strani</translation>
-<translation id="6127379762771434464">Element odstranjen</translation>
-<translation id="6140912465461743537">Država/regija</translation>
-<translation id="614940544461990577">Poskusite:</translation>
-<translation id="6154478581116148741">Vklopite zaklepanje zaslona v nastavitvah, če želite izvoziti gesla iz te naprave.</translation>
-<translation id="6159335304067198720">Prihranek pri prenosu podatkov: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Več o tem</translation>
-<translation id="6177111841848151710">Blokirano za trenutni iskalnik</translation>
-<translation id="6181444274883918285">Dodaj izjemo za spletno mesto</translation>
-<translation id="6192333916571137726">Datoteka Odjemanje</translation>
-<translation id="6192792657125177640">Izjeme</translation>
-<translation id="6194112207524046168">Če želite Chromu omogočiti dostop do fotoaparata, fotoaparat vklopite tudi v <ph name="BEGIN_LINK" />nastavitvah za Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blokiraj piškotke drugih spletnih mest</translation>
-<translation id="6206551242102657620">Povezava je varna. Podatki o spletnem mestu.</translation>
-<translation id="6210748933810148297">Niste <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Odklenite, če želite izvoziti gesla</translation>
+<translation id="1406000523432664303">»Ne sledi«</translation>
 <translation id="6232535412751077445">Če omogočite možnost »Ne sledi«, bo zahteva vključena v vaš promet brskanja. Učinek je odvisen od odziva spletnega mesta na zahtevo in od tega, kako si zahtevo razlaga.
 
 Nekatera spletna mesta se lahko na primer na zahtevo odzovejo tako, da prikažejo oglase, ki ne temeljijo na drugih spletnih mestih, ki ste jih obiskali. Veliko spletnih mest bo še vedno zbiralo in uporabljalo vaše podatke o brskanju, na primer za izboljšanje varnosti, zagotavljanje vsebine, oglasov in priporočil ter za pridobivanje statističnih podatkov za poročanje.</translation>
-<translation id="624789221780392884">Posodobitev je pripravljena</translation>
-<translation id="6255999984061454636">Predlogi za vsebino</translation>
-<translation id="6277522088822131679">Pri tiskanju strani je prišlo do težave. Poskusite znova.</translation>
-<translation id="6295158916970320988">Vsa spletna mesta</translation>
-<translation id="629730747756840877">Račun</translation>
-<translation id="6303969859164067831">Odjava in izklop sinhronizacije</translation>
-<translation id="6316139424528454185">Različica Androida ni podprta</translation>
-<translation id="6320088164292336938">Vibriranje</translation>
-<translation id="6324034347079777476">Sinhronizacija sistema Android je onemogočena.</translation>
-<translation id="6333140779060797560">Skupna raba prek: <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Šifriranje</translation>
-<translation id="6341580099087024258">Vprašaj, kje shraniti datoteke</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}two{<ph name="SHIPPING_ADDRESS_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}few{<ph name="SHIPPING_ADDRESS_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Ali želite odstraniti predlog iz zgodovine?</translation>
-<translation id="6369229450655021117">Tu lahko iščete po spletu, delite vsebino s prijatelji in si ogledate odprte strani</translation>
-<translation id="6378173571450987352">Podrobnosti: razvrščeno po količini prenesenih podatkov</translation>
-<translation id="6381421346744604172">Zatemnitev spletnih mest</translation>
-<translation id="6388207532828177975">Izbriši in ponastavi</translation>
-<translation id="6393863479814692971">Chrome potrebuje dovoljenje za dostop do fotoaparata in mikrofona za to spletno mesto.</translation>
-<translation id="6395288395575013217">POVEZAVA</translation>
-<translation id="6404511346730675251">Uredi zaznamek</translation>
-<translation id="6406506848690869874">Sinhronizacija</translation>
-<translation id="641643625718530986">Tiskanje …</translation>
-<translation id="6416782512398055893">Preneseno <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Prevajanje spleta</translation>
-<translation id="6433501201775827830">Izbira iskalnika</translation>
-<translation id="6437478888915024427">Podatki o strani</translation>
-<translation id="6441734959916820584">Ime je predolgo</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# slika}one{# slika}two{# sliki}few{# slike}other{# slik}}</translation>
-<translation id="6447842834002726250">Piškotki</translation>
-<translation id="6461962085415701688">Datoteke ni mogoče odpreti</translation>
-<translation id="6464977750820128603">Ogledate si lahko spletna mesta, ki jih obiščete v Chromu, in zanje nastavite merilnike časa.\n\nGoogle dobi podatke o spletnih mestih, za katere nastavite merilnike časa, in o tem, kako dolgo traja vaš obisk teh mest. Te podatke uporabljamo za izboljšanje Digitalne dobrobiti.</translation>
-<translation id="6475951671322991020">Prenos videoposnetka</translation>
-<translation id="6482749332252372425">Prenos datoteke <ph name="FILE_NAME" /> ni uspel zaradi pomanjkanja prostora za shranjevanje.</translation>
-<translation id="6496823230996795692">Pri prvi uporabi aplikacije <ph name="APP_NAME" /> se morate povezati v internet.</translation>
-<translation id="6508722015517270189">Znova zaženite Chrome</translation>
-<translation id="6527303717912515753">Skupna raba</translation>
-<translation id="6532866250404780454">Spletna mesta, ki jih obiščete v Chromu, ne bodo prikazana. Vsi merilniki časa spletnih mest bodo izbrisani.</translation>
-<translation id="6534565668554028783">Google se ni odzval v ustreznem času</translation>
-<translation id="6538442820324228105">Preneseno <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Prišlo je do napake. Poskusite znova pozneje.</translation>
-<translation id="654446541061731451">Izberite zavihek za prenos</translation>
-<translation id="6545017243486555795">Izbris vseh podatkov</translation>
-<translation id="6545864417968258051">Iskanje naprav Bluetooth</translation>
-<translation id="6560414384669816528">Iskanje z iskalnikom Sogou</translation>
-<translation id="6566259936974865419">S Chromom ste prihranili <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Vedno dovoli</translation>
-<translation id="6573431926118603307">Zavihki, ki ste jih odprli v Chromu v drugih napravah, bodo prikazani tukaj.</translation>
-<translation id="6583199322650523874">Dodajanje trenutne strani med zaznamke</translation>
-<translation id="6593061639179217415">Mesto za namizne račun.</translation>
-<translation id="6600954340915313787">Kopirano v Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Zaščitena vsebina</translation>
-<translation id="6627583120233659107">Uredi mapo</translation>
-<translation id="6643016212128521049">Izbriši</translation>
-<translation id="6643649862576733715">Razvrsti glede na prihranek pri količini prenesenih podatkov</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}two{<ph name="CONTACT_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}few{<ph name="CONTACT_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Predogled slike <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome za iskanje naprav potrebuje dostop do lokacije. <ph name="BEGIN_LINK" />Posodobite dovoljenja<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Geslo</translation>
-<translation id="6659594942844771486">Tabulator</translation>
-<translation id="666731172850799929">Odpri v: <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Obvestilo o zasebnosti za Chrome</translation>
-<translation id="6676840375528380067">Ali želite izbrisati podatke v Chromu iz te naprave?</translation>
-<translation id="6697492270171225480">Prikaz predlogov za podobne strani, ko strani ni mogoče najti</translation>
-<translation id="6697947395630195233">Chrome potrebuje dostop do vaše lokacije, da jo bo lahko delil s tem spletnim mestom.</translation>
-<translation id="6698801883190606802">Upravljanje sinhroniziranih podatkov</translation>
-<translation id="6699370405921460408">Googlovi strežniki optimizirajo strani, ki jih obiščete.</translation>
-<translation id="6706288973712894588">Trenutno nimate povezave.\n<ph name="BEGIN_LINK" />Raziščite vir brez povezave.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Novice</translation>
-<translation id="6710213216561001401">Nazaj</translation>
-<translation id="671481426037969117">Merilnik časa za <ph name="FQDN" /> je potekel. Jutri se začne znova.</translation>
-<translation id="6738867403308150051">Prenašanje ...</translation>
-<translation id="6746124502594467657">Premakni dol</translation>
-<translation id="6766622839693428701">Povlecite navzdol, da zaprete.</translation>
-<translation id="6766758767654711248">Dotaknite se, če želite na spletno mesto</translation>
-<translation id="6767294960381293877">Seznam naprav, s katerimi želite deliti zavihek, odprt pri polovični višini.</translation>
-<translation id="6782111308708962316">Drugim spletnim mestom prepreči shranjevanje in branje podatkov piškotkov</translation>
-<translation id="6790428901817661496">Predvajanje</translation>
-<translation id="6811034713472274749">Stran je pripravljena za ogled</translation>
-<translation id="6818926723028410516">Izberite elemente</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Prevedi</translation>
-<translation id="6845325883481699275">Pomagajte izboljšati varnost v Chromu</translation>
-<translation id="6846298663435243399">Nalaganje ...</translation>
-<translation id="6850409657436465440">Prenos še poteka</translation>
-<translation id="6850830437481525139">Zaprtih je bilo toliko zavihkov: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Prenos slike</translation>
-<translation id="6865313869410766144">Podatki za samodejno izpolnjevanje obrazcev</translation>
-<translation id="688738109438487280">Dodajanje obstoječih podatkov v račun <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Odklenite, če želite kopirati geslo</translation>
-<translation id="6896758677409633944">Kopiraj</translation>
-<translation id="6910211073230771657">Izbrisano</translation>
-<translation id="6912998170423641340">Spletnim mestom prepreči branje besedila in slik v odložišču</translation>
-<translation id="6914783257214138813">Gesla bodo vidna vsakomur, ki si lahko ogleda izvoženo datoteko z gesli.</translation>
-<translation id="6942665639005891494">Z možnostjo v meniju z nastavitvami lahko kadar koli spremenite privzeto mesto za prenose</translation>
-<translation id="6945221475159498467">Izberi</translation>
-<translation id="6963642900430330478">Ta stran je nevarna. Podatki o spletnem mestu.</translation>
-<translation id="6963766334940102469">Izbriši zaznamke</translation>
-<translation id="6965382102122355670">V redu</translation>
-<translation id="6979737339423435258">Od začetka</translation>
-<translation id="6981982820502123353">Dostopnost</translation>
-<translation id="6989267951144302301">Ni bilo mogoče prenesti</translation>
-<translation id="6990079615885386641">Prenos aplikacije iz Trgovine Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Prikaži poziv, preden se spletnim mestom dovoli uporaba mikrofona (priporočeno)</translation>
-<translation id="7015203776128479407">Začetna nastavitev sinhronizacije ni bila dokončana. Sinhronizacija je izklopljena.</translation>
-<translation id="7016516562562142042">Dovoljeno za trenutni iskalnik</translation>
-<translation id="7022756207310403729">Odpiranje v brskalniku</translation>
-<translation id="702463548815491781">Priporočljivo, ko je vklopljena aplikacija TalkBack ali funkcija dostopa s stikalom</translation>
-<translation id="7029809446516969842">Gesla</translation>
-<translation id="7053983685419859001">Blokiraj</translation>
-<translation id="7055152154916055070">Preusmeritev je preprečena:</translation>
-<translation id="7063006564040364415">Povezave s strežnikom za sinhronizacijo ni bilo mogoče vzpostaviti.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 izbran}one{# izbran}two{# izbrana}few{# izbrani}other{# izbranih}}</translation>
-<translation id="7071521146534760487">Upravljanje računa</translation>
-<translation id="7077143737582773186">SD kartica</translation>
-<translation id="7087918508125750058">Št. izbranih: <ph name="ITEM_COUNT" />. Možnosti so na voljo na zgornjem delu zaslona.</translation>
-<translation id="7121362699166175603">Izbriše zgodovino in samodokončanja v naslovni vrstici. V Google Računu so morda druge vrste zgodovine brskanja na <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Dovoli za trenutni iskalnik</translation>
-<translation id="7138678301420049075">Drugo</translation>
-<translation id="7141896414559753902">Preprečevanje, da spletna mesta prikazujejo pojavna okna in preusmeritve (priporočeno)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Naloži izvirno stran<ph name="END_LINK" /> iz domene <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Zadnjih 24 ur</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">To lahko pozneje spremenite v nastavitvah</translation>
-<translation id="7180611975245234373">Osveži</translation>
-<translation id="7189372733857464326">Čakanje na dokončanje posodobitev storitev za Google Play</translation>
-<translation id="7191430249889272776">Zavihek se je odprl v ozadju.</translation>
-<translation id="723171743924126238">Izberite slike</translation>
-<translation id="7233236755231902816">Če si želite splet ogledovati v svojem jeziku, posodobite Chrome na najnovejšo različico</translation>
-<translation id="7243308994586599757">Možnosti so na voljo pri dnu zaslona</translation>
-<translation id="7248069434667874558">Poskrbite, da ima naprava <ph name="TARGET_DEVICE_NAME" /> vklopljeno sinhronizacijo v Chromu</translation>
-<translation id="7250468141469952378">Št. izbranih: <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Blokirano spletno mesto</translation>
-<translation id="7290209999329137901">Preimenovanje ni na voljo</translation>
-<translation id="7291387454912369099">Dokončanje nakupa s Pomočnikom</translation>
-<translation id="7293171162284876153">Če želite začeti sinhronizacijo, vklopite »Sinhronizacija podatkov v Chromu«.</translation>
-<translation id="729975465115245577">V napravi ni aplikacije za shranjevanje datoteke z gesli.</translation>
-<translation id="7302081693174882195">Podrobnosti: razvrščeno po količini prihranjenih podatkov</translation>
-<translation id="7328017930301109123">Chrome v lahkem načinu naloži strani hitreje in uporabi do 60 odstotkov manj podatkov.</translation>
-<translation id="7333031090786104871">Dodajanje prejšnjega spletnega mesta še vedno poteka</translation>
-<translation id="7352939065658542140">VIDEOPOSNETEK</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Delitev 1 izbranega elementa z drugimi}one{Delitev # izbranega elementa z drugimi}two{Delitev # izbranih elementov z drugimi}few{Delitev # izbranih elementov z drugimi}other{Delitev # izbranih elementov z drugimi}}</translation>
 <translation id="7359002509206457351">Dostop do plačilnih sredstev</translation>
+<translation id="8026334261755873520">Izbriši podatke brskanja</translation>
+<translation id="1291207594882862231">Izbris zgodovine, piškotkov, podatkov spletnih mest, predpomnilnika …</translation>
+<translation id="7814200940910057384">Chromovi podatki so izbrisani.</translation>
+<translation id="1664855196866195614">Izbrani podatki so bili odstranjeni iz Chroma in sinhroniziranih naprav.
+
+V Brave Software Računu so morda druge vrste zgodovine brskanja, kot so iskanja in dejavnosti iz drugih Googlovih storitev, na <ph name="BEGIN_LINK"/>history.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Predpomnjene slike in datoteke</translation>
+<translation id="2496180316473517155">Zgodovina brskanja</translation>
+<translation id="2546283357679194313">Piškotki in podatki o spletnih mestih</translation>
+<translation id="8662811608048051533">Odjavi vas iz večine spletnih mest.</translation>
+<translation id="8218628800671693884">Odjavi vas iz večine spletnih mest, vendar ne iz Brave Software Računa.</translation>
+<translation id="2017836877785168846">Izbriše zgodovino in samodokončanja v naslovni vrstici.</translation>
+<translation id="8096327394278038498">Izbriše zgodovino in samodokončanja v naslovni vrstici. V Brave Software Računu so morda druge vrste zgodovine brskanja na <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Izbriše zgodovino iz vseh naprav, v katerih ste prijavljeni. V Brave Software Računu so morda druge vrste zgodovine brskanja na <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Shranjena gesla</translation>
+<translation id="6865313869410766144">Podatki za samodejno izpolnjevanje obrazcev</translation>
+<translation id="7562080006725997899">Brisanje podatkov brskanja</translation>
+<translation id="5487521232677179737">Izbriši podatke</translation>
+<translation id="7498271377022651285">Počakajte …</translation>
+<translation id="784934925303690534">Časovno obdobje</translation>
+<translation id="1718835860248848330">Zadnja ura</translation>
+<translation id="7149893636342594995">Zadnjih 24 ur</translation>
+<translation id="5648166631817621825">Zadnjih 7 dni</translation>
+<translation id="8571213806525832805">Zadnji 4 tedni</translation>
+<translation id="5854790677617711513">Starejše od 30 dni</translation>
+<translation id="6979737339423435258">Od začetka</translation>
+<translation id="982182592107339124">S tem bodo izbrisani podatki za vsa spletna mesta, vključno s temi:</translation>
+<translation id="6643016212128521049">Izbriši</translation>
+<translation id="7641339528570811325">Izbris podatkov brskanja …</translation>
+<translation id="1670399744444387456">Osnovno</translation>
+<translation id="3245261285041759672">V Brave Software Računu so morda druge vrste zgodovine brskanja na <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Blokirano spletno mesto</translation>
+<translation id="2534155362429831547">Št. izbrisanih elementov: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Poročila o uporabi in zrušitvah</translation>
+<translation id="9079153198295609735">Samodejno pošlji statistične podatke o uporabi in poročila o zrušitvah Googlu</translation>
+<translation id="6981982820502123353">Dostopnost</translation>
+<translation id="2387895666653383613">Prilagajanje velikosti besedila</translation>
+<translation id="2321958826496381788">Drsnik povlecite tako daleč, da boste lahko to besedilo brez težave prebrali. Besedilo bo po dvakratnem dotiku odstavka vsaj tako veliko.</translation>
+<translation id="3895926599014793903">Vsili povečavo</translation>
+<translation id="5668404140385795438">Preglasi zahtevo spletnega mesta za preprečevanje povečave</translation>
+<translation id="4149994727733219643">Poenostavljen pogled za spletne strani</translation>
+<translation id="9100505651305367705">Možnost prikaza člankov v preprostem pogledu, če je podprt</translation>
+<translation id="1409426117486808224">Poenostavljen pogled za odprte zavihke</translation>
+<translation id="702463548815491781">Priporočljivo, ko je vklopljena aplikacija TalkBack ali funkcija dostopa s stikalom</translation>
+<translation id="8284326494547611709">Napisi</translation>
+<translation id="4165986682804962316">Nastavitve spletnega mesta</translation>
+<translation id="6295158916970320988">Vsa spletna mesta</translation>
+<translation id="8380167699614421159">To spletno mesto prikazuje vsiljive ali zavajajoče oglase</translation>
+<translation id="1919345977826869612">Oglasi</translation>
+<translation id="410351446219883937">Samodejno predvajanje</translation>
+<translation id="6447842834002726250">Piškotki</translation>
+<translation id="6196640612572343990">Blokiraj piškotke drugih spletnih mest</translation>
+<translation id="6782111308708962316">Drugim spletnim mestom prepreči shranjevanje in branje podatkov piškotkov</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pojavna okna in preusmeritve</translation>
+<translation id="4751476147751820511">Tipala za gibanje in svetlobo</translation>
+<translation id="1717218214683051432">Tipala gibanja</translation>
+<translation id="2091887806945687916">Zvok</translation>
+<translation id="2586657967955657006">Odložišče</translation>
+<translation id="6320088164292336938">Vibriranje</translation>
+<translation id="4226663524361240545">Ob prejemanju obvestil naprava morda vibrira</translation>
+<translation id="1446450296470737166">Dovolitev popolnega nadzora nad napravami MIDI</translation>
+<translation id="3744111561329211289">Sinhroniziranje v ozadju</translation>
+<translation id="5649053991847567735">Samodejni prenosi</translation>
+<translation id="6181444274883918285">Dodaj izjemo za spletno mesto</translation>
+<translation id="5313967007315987356">Dodajanje mesta</translation>
+<translation id="1369915414381695676">Spletno mesto <ph name="SITE_NAME"/> je bilo dodano</translation>
+<translation id="7837721118676387834">Dovoli samodejno predvajanje videoposnetkov z izklopljenim zvokom za določeno spletno mesto.</translation>
+<translation id="2621115761605608342">Dovoli JavaScript za določeno spletno mesto.</translation>
+<translation id="8801436777607969138">Preprečevanje JavaScripta za določeno spletno mesto.</translation>
+<translation id="8372893542064058268">Dovoli sinhroniziranje v ozadju za določeno spletno mesto.</translation>
+<translation id="358794129225322306">Dovoli spletnemu mestu samodejni prenos več datotek.</translation>
+<translation id="4008040567710660924">Omogočanje piškotkov za določeno spletno mesto.</translation>
+<translation id="8958424370300090006">Blokiranje piškotkov za določeno spletno mesto.</translation>
+<translation id="7882806643839505685">Dovolitev zvoka za določeno spletno mesto.</translation>
+<translation id="4468959413250150279">Izklop zvoka za določeno spletno mesto.</translation>
+<translation id="1994173015038366702">URL spletnega mesta</translation>
+<translation id="8941729603749328384">www.primer.si</translation>
+<translation id="5063480226653192405">Uporaba</translation>
+<translation id="5804241973901381774">Dovoljenja</translation>
+<translation id="4278390842282768270">Dovoljeno</translation>
+<translation id="5677928146339483299">Blokirano</translation>
+<translation id="1984937141057606926">Dovoljeno, razen za druga spletna mesta</translation>
+<translation id="7423098979219808738">Najprej vprašaj</translation>
+<translation id="8116925261070264013">Prezrto</translation>
+<translation id="8300705686683892304">Upravlja aplikacija</translation>
+<translation id="6192792657125177640">Izjeme</translation>
+<translation id="257931822824936280">Razširjeno – kliknite, če želite strniti.</translation>
+<translation id="5100237604440890931">Strnjeno – kliknite, če želite razširiti.</translation>
+<translation id="857943718398505171">Dovoljeno (priporočeno)</translation>
+<translation id="2913331724188855103">Dovoli spletnim mestom shranjevanje in branje podatkov piškotkov (priporočljivo)</translation>
+<translation id="7445411102860286510">Dovoli spletnim mestom samodejno predvajanje videoposnetkov z izklopljenim zvokom (priporočljivo)</translation>
+<translation id="5335288049665977812">Spletnim mestom dovoli izvajanje JavaScripta (priporočeno)</translation>
+<translation id="5527111080432883924">Prikaži poziv, preden se spletnim mestom dovoli branje besedila in slik v odložišču (priporočeno)</translation>
+<translation id="6912998170423641340">Spletnim mestom prepreči branje besedila in slik v odložišču</translation>
+<translation id="7423538860840206698">Blokirano branje vsebine odložišča</translation>
+<translation id="3955193568934677022">Dovoli spletnim mestom predvajanje zaščitene vsebine (priporočeno)</translation>
+<translation id="445467742685312942">Spletnim mestom dovoli predvajanje zaščitene vsebine</translation>
+<translation id="2107397443965016585">Prikaži poziv, preden se spletnim mestom dovoli predvajanje zaščitene vsebine (priporočeno)</translation>
+<translation id="2910701580606108292">Prikaži poziv, preden se spletnim mestom dovoli predvajanje zaščitene vsebine</translation>
+<translation id="757524316907819857">Prepreči spletnim mestom predvajanje zaščitene vsebine</translation>
+<translation id="3277252321222022663">Spletnim mestom dovoli dostop do tipal (priporočeno)</translation>
+<translation id="5048398596102334565">Spletnim mestom dovoli dostop do tipal gibanja (priporočeno)</translation>
+<translation id="8816026460808729765">Preprečevanje spletnim mestom dostopa do tipal</translation>
+<translation id="169515064810179024">Spletnim mestom prepreči dostop do tipal gibanja</translation>
+<translation id="1660204651932907780">Dovoli spletnim mestom predvajanje zvoka (priporočljivo)</translation>
+<translation id="3600792891314830896">Izklop zvoka na spletnih mestih, ki predvajajo zvok</translation>
+<translation id="1743802530341753419">Prikaži poziv, preden se spletnim mestom dovoli povezovanje z napravo (priporočeno)</translation>
+<translation id="851751545965956758">Spletnim mestom prepreči povezovanje z napravami</translation>
+<translation id="7141896414559753902">Preprečevanje, da spletna mesta prikazujejo pojavna okna in preusmeritve (priporočeno)</translation>
+<translation id="5494752089476963479">Blokiranje oglasov na spletnih mestih, ki prikazujejo vsiljive ali zavajajoče oglase</translation>
+<translation id="3123473560110926937">Blokirano na nekaterih spletnih mestih</translation>
+<translation id="965817943346481315">Blokiraj, če spletno mesto prikazuje vsiljive ali zavajajoče oglase (priporočljivo)</translation>
+<translation id="3386292677130313581">Prikaži poziv, preden se spletnim mestom razkrije vaša lokacija (priporočeno)</translation>
+<translation id="9139068048179869749">Prikaži poziv, preden se spletnim mestom dovoli pošiljanje obvestil (priporočeno)</translation>
+<translation id="4479647676395637221">Prikaži poziv, preden se spletnim mestom dovoli uporaba kamere (priporočeno)</translation>
+<translation id="6992289844737586249">Prikaži poziv, preden se spletnim mestom dovoli uporaba mikrofona (priporočeno)</translation>
+<translation id="2289270750774289114">Vprašaj, ko želi spletno mesto odkrivati naprave Bluetooth v bližini (priporočljivo)</translation>
+<translation id="7053983685419859001">Blokiraj</translation>
+<translation id="7128222689758636196">Dovoli za trenutni iskalnik</translation>
+<translation id="7589445247086920869">Blokiraj za trenutni iskalnik</translation>
+<translation id="6388207532828177975">Izbriši in ponastavi</translation>
+<translation id="7999064672810608036">Ali želite res izbrisati vse lokalne podatke, vključno s piškotki, in ponastaviti vsa dovoljenja za to spletno mesto?</translation>
+<translation id="2822354292072154809">Ali ste prepričani, da želite ponastaviti vsa dovoljenja za spletna mesta za <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Izbris shranjenih podatkov</translation>
+<translation id="5902828464777634901">Vsi lokalni podatki, ki jih je shranilo to spletno mesto, vključno s piškotki, bodo izbrisani.</translation>
+<translation id="119944043368869598">Izbriši vse</translation>
+<translation id="2490684707762498678">Upravlja aplikacija <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Odpiranje nastavitev obvestil</translation>
+<translation id="1404122904123200417">Vdelano v URL <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Datoteke, ki jih shranijo spletna mesta, so prikazane tukaj</translation>
+<translation id="4181841719683918333">Jeziki</translation>
+<translation id="2647434099613338025">Dodaj jezik</translation>
+<translation id="1952172573699511566">Spletna mesta bodo besedilo prikazala v izbranem jeziku, če je mogoče.</translation>
+<translation id="8559990750235505898">Ponudi prevajanje strani v drugih jezikih</translation>
+<translation id="4719927025381752090">Ponudi prevajanje</translation>
+<translation id="8156139159503939589">Katere jezike znate brati?</translation>
+<translation id="5689516760719285838">Lokacija</translation>
+<translation id="2440823041667407902">Dostop do lokacije</translation>
+<translation id="2023546461831060654">V <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/> vklopite dovoljenja za Brave.</translation>
+<translation id="6665548517310046133">V <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/> vklopite dovoljenje za Brave.</translation>
+<translation id="2928908108430545745">Če želite Chromu omogočiti dostop do lokacije, lokacijo vklopite tudi v <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Če želite Chromu omogočiti dostop do fotoaparata, fotoaparat vklopite tudi v <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Če želite, da vam Brave pošilja obvestila, obvestila vklopite tudi v <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Če želite Chromu omogočiti dostop do mikrofona, mikrofon vklopite tudi v <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Dostop do lokacije je izklopljen za to napravo. Vklopite ga lahko v <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Dostop do lokacije je tudi izklopljen za to napravo. Vklopite ga lahko v <ph name="BEGIN_LINK"/>nastavitvah za Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Dostop do fotoaparata</translation>
+<translation id="945632385593298557">Dostop do mikrofona</translation>
+<translation id="6612358246767739896">Zaščitena vsebina</translation>
+<translation id="885701979325669005">Shramba</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> shranjenih podatkov</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Umik dovoljenja za dostop do naprave</translation>
+<translation id="4962975101802056554">Umik vseh dovoljenj za napravo</translation>
+<translation id="6545864417968258051">Iskanje naprav Bluetooth</translation>
+<translation id="4411535500181276704">Lahki način</translation>
+<translation id="7821588508402923572">Prihranek pri količini prenesenih podatkov bo prikazan tukaj</translation>
+<translation id="2131665479022868825">Shranjeno <ph name="DATA"/></translation>
+<translation id="8569404424186215731">od <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Brave v lahkem načinu naloži strani hitreje in uporabi do 60 odstotkov manj podatkov.</translation>
+<translation id="6159335304067198720">Prihranek pri prenosu podatkov: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">prihranjenega prenosa podatkov</translation>
+<translation id="6111020039983847643">prenesenih podatkov</translation>
+<translation id="7413229368719586778">Začetni datum: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Končni datum: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Razvrsti glede na spletno mesto</translation>
+<translation id="5864174910718532887">Podrobnosti: razvrščeno po imenu spletnega mesta</translation>
+<translation id="116280672541001035">Porabljeno</translation>
+<translation id="8349013245300336738">Razvrsti glede na količino prenesenih podatkov</translation>
+<translation id="6378173571450987352">Podrobnosti: razvrščeno po količini prenesenih podatkov</translation>
+<translation id="2631006050119455616">Prihranjeno</translation>
+<translation id="6643649862576733715">Razvrsti glede na prihranek pri količini prenesenih podatkov</translation>
+<translation id="7302081693174882195">Podrobnosti: razvrščeno po količini prihranjenih podatkov</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> prenesenih podatkov</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> prihranka pri količini prenesenih podatkov</translation>
+<translation id="2156074688469523661">Preostala spletna mesta (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Drugo</translation>
+<translation id="4913161338056004800">Ponastavitev statističnih podatkov</translation>
+<translation id="1856325424225101786">Želite ponastaviti lahki način?</translation>
+<translation id="3658159451045945436">Ponastavitev izbriše zgodovino prihrankov pri prenosu podatkov, vključno s seznamom obiskanih spletnih mest.</translation>
+<translation id="3295530008794733555">Brskajte hitreje. Uporabite manj podatkov.</translation>
+<translation id="7340390500800578919">Brave v lahkem načinu naloži strani hitreje in uporabi do 60 odstotkov manj podatkov. Brave zaradi optimiziranja strani, ki jih obiščete, Googlu pošlje vaš spletni promet. <ph name="BEGIN_LINK"/>Več o tem<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Vklop lahkega načina</translation>
+<translation id="4493497663118223949">Lahki način je vklopljen</translation>
+<translation id="7559975015014302720">Lahki način je izklopljen</translation>
+<translation id="7606077192958116810">Lahki način je vklopljen. Upravljate ga lahko v nastavitvah.</translation>
+<translation id="4714588616299687897">Prenesite do 60 % manj podatkov</translation>
+<translation id="1006927014032731288">Googlovi strežniki optimizirajo strani, ki jih obiščete.</translation>
+<translation id="3257320067425202300">S Chromom ste prihranili <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">S Chromom ste prihranili <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Mesto za prenos</translation>
+<translation id="7077143737582773186">SD kartica</translation>
+<translation id="7762668264895820836">Kartica SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Vprašaj, kje shraniti datoteke</translation>
+<translation id="6192333916571137726">Datoteka Odjemanje</translation>
+<translation id="1672586136351118594">Tega ne prikaži več</translation>
+<translation id="2650751991977523696">Želite znova prenesti datoteko?</translation>
+<translation id="8664979001105139458">Ime datoteke že obstaja</translation>
+<translation id="488187801263602086">Preimenovanje datoteke</translation>
+<translation id="5686790454216892815">Ime datoteke je predolgo</translation>
+<translation id="7454641608352164238">Ni dovolj prostora</translation>
+<translation id="8972098258593396643">Želite prenesti v privzeto mapo?</translation>
+<translation id="804335162455518893">Kartice SD ni bilo mogoče najti</translation>
+<translation id="7475688122056506577">Kartice SD ni bilo mogoče najti. Nekatere vaše datoteke morda manjkajo.</translation>
+<translation id="4198423547019359126">Ni razpoložljivih mest za prenos</translation>
+<translation id="8224471946457685718">Prenos člankov v omrežju Wi-Fi</translation>
+<translation id="4970824347203572753">Ni na voljo na vaši lokaciji</translation>
+<translation id="5500777121964041360">Morda ni na voljo na vaši lokaciji</translation>
+<translation id="1173894706177603556">Preimenuj</translation>
+<translation id="1986685561493779662">Ime že obstaja</translation>
+<translation id="6441734959916820584">Ime je predolgo</translation>
+<translation id="2923908459366352541">Ime je neveljavno</translation>
+<translation id="7290209999329137901">Preimenovanje ni na voljo</translation>
+<translation id="3334729583274622784">Želite spremeniti pripono datoteke?</translation>
+<translation id="107147699690128016">Če spremenite pripono datoteke, se lahko datoteka odpre v drugem programu in je lahko morebitno škodljiva za vašo napravo.</translation>
+<translation id="8541922081612557424">O brskalniku Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Vse pravice pridržane.</translation>
+<translation id="1416550906796893042">Različica aplikacije</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Posodobljeno: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operacijski sistem</translation>
+<translation id="3968054912784331254">Posodobitve za Brave v tej različici Androida niso več podprte.</translation>
+<translation id="7665369617277396874">Dodaj račun</translation>
+<translation id="649070405679044769">V Brave Software ste prijavljeni kot</translation>
+<translation id="6234515504547364178">Odjava iz Chroma</translation>
+<translation id="5324858694974489420">Starševske nastavitve</translation>
+<translation id="8920114477895755567">Čakanje na podrobnosti o staršu.</translation>
+<translation id="5512137114520586844">Ta račun upravlja <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Ta računa upravljata <ph name="PARENT_NAME_1"/> in <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Vsebina</translation>
+<translation id="5403644198645076998">Dovoli samo nekatera spletna mesta</translation>
+<translation id="8641930654639604085">Poskusi blokirati spletna mesta za odrasle</translation>
+<translation id="5639724618331995626">Dovoli vsa spletna mesta</translation>
+<translation id="796823723482603597">Uporablja tehnologijo Brave</translation>
+<translation id="6324034347079777476">Sinhronizacija sistema Android je onemogočena.</translation>
+<translation id="5127805178023152808">Sinhroniziranje je izklopljeno</translation>
+<translation id="7015203776128479407">Začetna nastavitev sinhronizacije ni bila dokončana. Sinhronizacija je izklopljena.</translation>
+<translation id="2497852260688568942">Sinhronizacijo je onemogočil skrbnik</translation>
+<translation id="9100610230175265781">Zahtevano je geslo</translation>
+<translation id="6108923351542677676">Poteka nastavitev …</translation>
+<translation id="4062305924942672200">Pravne informacije</translation>
+<translation id="4256782883801055595">Odprtokodne licence</translation>
+<translation id="1138681184697033370">Pogoji storitve za Brave</translation>
+<translation id="7392539049993970338">Obvestilo o zasebnosti za Brave</translation>
+<translation id="2677748264148917807">Zapusti</translation>
+<translation id="5556459405103347317">Znova naloži</translation>
+<translation id="1623104350909869708">Tej strani prepreči, da bi ustvarila dodatna pogovorna okna</translation>
+<translation id="2968755619301702150">Pregledovalnik potrdil</translation>
+<translation id="1360432990279830238">Odjava in izklop sinhronizacije?</translation>
+<translation id="8581481290581777242">Ali želite izbrisati podatke v Chromu iz te naprave?</translation>
+<translation id="1318865768845061710">Vaši zaznamki, zgodovina, gesla in drugi podatki v Chromu ne bodo več sinhronizirani z računom za Brave Software</translation>
+<translation id="3325020657155065477">Prav tako izbriši podatke v Chromu iz te naprave</translation>
+<translation id="6136448902816743006">Ker se odjavljate iz računa, ki ga upravlja <ph name="DOMAIN_NAME"/>, bodo podatki v Chromu izbrisani iz te naprave. Ostali bodo v računu Brave Software.</translation>
+<translation id="1853026300647876496">Vzpostavljanje stika z Googlom. To lahko traja kakšno minuto …</translation>
+<translation id="2328985652426384049">Ne morem se prijaviti</translation>
+<translation id="7723158744459952869">Brave Software se ni odzval v ustreznem času</translation>
+<translation id="4572422548854449519">Prijava v upravljani račun</translation>
+<translation id="2689656545739939160">Prijavljate se z računom, ki ga upravlja <ph name="MANAGED_DOMAIN"/>, in nadzor nad podatki v Chromu predajate skrbniku. Vaši podatki bodo trajno povezani s tem računom. Če se odjavite iz Chroma, boste izbrisali podatke iz te naprave, vendar bodo še naprej shranjeni v Brave Software Računu.</translation>
+<translation id="1749561566933687563">Sinhroniziranje zaznamkov</translation>
+<translation id="4242533952199664413">Odpri nastavitve</translation>
+<translation id="1111673857033749125">Tu bodo prikazani zaznamki, shranjeni v drugih napravah.</translation>
+<translation id="8636825310635137004">Če želite dostopati do zavihkov iz drugih naprav, vklopite sinhronizacijo.</translation>
+<translation id="3269956123044984603">Če želite dostopati do zavihkov v drugih napravah, v nastavitvah računa za Android vklopite »Samodejno sinhroniziraj podatke«.</translation>
+<translation id="5157964048453367290">Zavihki, ki ste jih odprli v Chromu v drugih napravah, bodo prikazani tukaj.</translation>
+<translation id="4684427112815847243">Sinhroniziraj vse</translation>
+<translation id="2709516037105925701">Samodejno izpolnjevanje</translation>
+<translation id="8820817407110198400">Zaznamki</translation>
+<translation id="1644574205037202324">Zgodovina</translation>
+<translation id="17513872634828108">Odprti zavihki</translation>
+<translation id="1320169905922104972">Kreditne kartice in naslovi z Googlom Pay</translation>
+<translation id="6337234675334993532">Šifriranje</translation>
+<translation id="6698801883190606802">Upravljanje sinhroniziranih podatkov</translation>
+<translation id="3598578758776312506">Šifriranje gesel s poverilnicami za Brave Software</translation>
+<translation id="7810580217418711046">Šifriranje sinhroniziranih podatkov z geslom za Brave Software Račun z dnem <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Šifriranje sinhroniziranih podatkov z vašim geslom za sinhronizacijo</translation>
+<translation id="2996291259634659425">Ustvarjanje gesla</translation>
+<translation id="5713644099811900409">Brave Software Račun</translation>
+<translation id="8997474919031554666">Šifriranje gesla ne vključuje plačilnih sredstev in naslovov iz Googla Pay. Vaše šifrirane podatke lahko bere samo oseba z vašim geslom. Geslo ni poslano Googlu in ni shranjeno v Googlu. Če ga pozabite ali želite spremeniti to nastavitev, boste morali sinhronizacijo ponastaviti. <ph name="BEGIN_LINK"/>Več o tem<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Geslo</translation>
+<translation id="7772032839648071052">Potrdi geslo</translation>
+<translation id="5304593522240415983">To polje ne sme biti prazno</translation>
+<translation id="321773570071367578">Če ste pozabili geslo ali želite spremeniti to nastavitev, <ph name="BEGIN_LINK"/>ponastavite sinhronizacijo<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Gesli se ne ujemata</translation>
+<translation id="5149495116300586333">Šifriranje gesla ne vključuje plačilnih sredstev in naslovov iz Googla Pay.
+
+Če želite spremeniti to nastavitev, <ph name="BEGIN_LINK"/>ponastavite sinhronizacijo<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Napačno geslo</translation>
+<translation id="5414836363063783498">Preverjanje …</translation>
+<translation id="6846298663435243399">Nalaganje ...</translation>
+<translation id="5517095782334947753">Iz računa <ph name="FROM_ACCOUNT"/> imate zaznamke, zgodovino, gesla in druge nastavitve.</translation>
+<translation id="3928666092801078803">Združevanje podatkov</translation>
+<translation id="688738109438487280">Dodajanje obstoječih podatkov v račun <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Podatki naj bodo ločeni</translation>
+<translation id="1145536944570833626">Izbris obstoječih podatkov.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> želi opraviti seznanitev</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Poiščite pomoč<ph name="END_LINK"/> med iskanjem naprav …</translation>
+<translation id="5817918615728894473">Seznani</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Poiščite pomoč<ph name="END_LINK1"/> ali <ph name="BEGIN_LINK2"/>znova iščite<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Ni združljivih naprav</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Vklopite Bluetooth<ph name="END_LINK"/>, če želite dovoliti seznanjanje</translation>
+<translation id="998321811308652668">Brave ne more vklopiti vmesnika za Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Poiščite pomoč<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave za iskanje naprav potrebuje dostop do lokacije. <ph name="BEGIN_LINK"/>Posodobite dovoljenja<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave za iskanje naprav potrebuje dostop do lokacije. Dostop do lokacije <ph name="BEGIN_LINK"/>je izklopljen za to napravo<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave za iskanje naprav potrebuje dostop do lokacije. <ph name="BEGIN_LINK1"/>Posodobite dovoljenja<ph name="END_LINK1"/>. Dostop do lokacije je prav tako <ph name="BEGIN_LINK2"/>izklopljen za to napravo<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Povezana naprava</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Moč signala: # črtica}one{Moč signala: # črtica}two{Moč signala: # črtici}few{Moč signala: # črtice}other{Moč signala: # črtic}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> želi iskati naprave Bluetooth v bližini. Najdene so bile te naprave:</translation>
+<translation id="8368027906805972958">Neznana ali nepodprta naprava (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Sync isn't working</translation>
+<translation id="1810845389119482123">Začetna nastavitev sinhronizacije se ni dokončala</translation>
+<translation id="3235722914093408050">Odprite nast. za Android in znova omog. sinh. v Androidu za zač. sinh. za Brave</translation>
+<translation id="3367813778245106622">Prijavite se znova, če želite začeti sinhronizacijo</translation>
+<translation id="974555521953189084">Vnesite geslo, če želite začeti sinhronizacijo</translation>
+<translation id="2997266899014181325">Če želite začeti sinhronizacijo, vklopite »Sinhronizacija podatkov v Chromu«.</translation>
+<translation id="8260126382462817229">Poskusite se znova prijaviti.</translation>
+<translation id="5919204609460789179">Posodobite izdelek <ph name="PRODUCT_NAME"/>, če želite začeti sinhronizacijo</translation>
+<translation id="397583555483684758">Sinhronizacija je prenehala delovati</translation>
+<translation id="1966710179511230534">Posodobite podrobnosti prijave.</translation>
+<translation id="7063006564040364415">Povezave s strežnikom za sinhronizacijo ni bilo mogoče vzpostaviti.</translation>
+<translation id="7942131818088350342">Izdelek <ph name="PRODUCT_NAME"/> je zastarel.</translation>
+<translation id="4170011742729630528">Storitev ni na voljo; poskusite znova pozneje.</translation>
+<translation id="7947953824732555851">Sprejem in prijava</translation>
+<translation id="8583805026567836021">Brisanje podatkov računa</translation>
+<translation id="8310344678080805313">Standardni zavihki</translation>
+<translation id="5748802427693696783">Preklopljeno na standardne zavihke</translation>
+<translation id="7998918019931843664">Vnovično odpiranje zaprtega zavihka</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, zavihek</translation>
+<translation id="4452411734226507615">Zapiranje zavihka <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Možnosti so na voljo pri dnu zaslona</translation>
+<translation id="4060598801229743805">Možnosti so na voljo blizu vrha zaslona</translation>
+<translation id="2810645512293415242">Poenostavljena stran zaradi prihranka pri prenosu podatkov in hitrejšega nalaganja.</translation>
+<translation id="3985215325736559418">Ali želite znova prenesti datoteko <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Ali želite znova začeti prenos datoteke <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Prenos</translation>
+<translation id="545042621069398927">Pospeševanje prenosa.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Prenos datoteke.}one{Prenos # datoteke.}two{Prenos # datotek.}few{Prenos # datotek.}other{Prenos # datotek.}}</translation>
+<translation id="543509235395288790">Prenašanje toliko datotek: <ph name="COUNT"/> (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Prenos datoteke (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 prenos je končan.}one{# prenos je končan.}two{# prenosa sta končana.}few{# prenosi so končani.}other{# prenosov je končanih.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 prenos ni uspel.}one{# prenos ni uspel.}two{# prenosa nista uspela.}few{# prenosi niso uspeli.}other{# prenosov ni uspelo.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 prenos na čakanju}one{# prenos na čakanju}two{# prenosa na čakanju}few{# prenosi na čakanju}other{# prenosov na čakanju}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Gumb <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Skoraj končano!</translation>
+<translation id="3960299545138990065">Znova zaženite Brave</translation>
+<translation id="3771001275138982843">Posodobitve ni bilo mogoče prenesti</translation>
+<translation id="3888648114124182147">Prenašanje posodobitve za Brave …</translation>
+<translation id="1705567146636171298">Posodobi Brave</translation>
+<translation id="6195417478702700398">Za najboljšo izkušnjo pri brskanju odprite Brave, da ga posodobite</translation>
+<translation id="3512968675351418494">Če si želite splet ogledovati v svojem jeziku, posodobite Brave na najnovejšo različico</translation>
+<translation id="6427112570124116297">Prevajanje spleta</translation>
+<translation id="1379423114029199501">Posodobite Brave na najnovejšo različico, če ga želite v svojem jeziku</translation>
+<translation id="5684874026226664614">Ojoj, te strani bi bilo mogoče prevesti.</translation>
+<translation id="6831043979455480757">Prevedi</translation>
+<translation id="1285320974508926690">Nikoli ne prevedi tega spletnega mesta</translation>
+<translation id="773466115871691567">Vedno prevedi strani v jeziku <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Nikoli ne prevedi strani v jeziku <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Več jezikov</translation>
+<translation id="290376772003165898">Stran ni v jeziku <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Strani v jeziku <ph name="SOURCE_LANGUAGE"/> bodo od zdaj naprej prevedene v jezik <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Strani v jeziku <ph name="LANGUAGE"/> ne bodo prevedene</translation>
+<translation id="5447765697759493033">To spletno mesto ne bo prevedeno</translation>
+<translation id="4880127995492972015">Prevedi …</translation>
+<translation id="641643625718530986">Tiskanje …</translation>
+<translation id="8909135823018751308">Skupna raba …</translation>
+<translation id="4996978546172906250">Skupna raba prek</translation>
+<translation id="6333140779060797560">Skupna raba prek: <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Pri tiskanju strani je prišlo do težave. Poskusite znova.</translation>
+<translation id="3254409185687681395">Zaznamujte to stran</translation>
+<translation id="497421865427891073">Pojdi naprej</translation>
+<translation id="813082847718468539">Ogled podatkov o mestu</translation>
+<translation id="2532336938189706096">Spletni pogled</translation>
+<translation id="6005538289190791541">Predlagano geslo</translation>
+<translation id="4634124774493850572">Uporabi geslo</translation>
+<translation id="8285489906452138776">Brave potrebuje dovoljenje za dostop do fotoaparata za to spletno mesto.</translation>
+<translation id="320189792589364011">Brave potrebuje dovoljenje za dostop do mikrofona za to spletno mesto.</translation>
+<translation id="7988136689212463100">Brave potrebuje dovoljenje za dostop do fotoaparata in mikrofona za to spletno mesto.</translation>
+<translation id="4931190655840828017">Brave potrebuje dostop do vaše lokacije, da jo bo lahko delil s tem spletnim mestom.</translation>
+<translation id="3088191967551450609">Brave za prenos datotek potrebuje dostop do shrambe.</translation>
+<translation id="8942627711005830162">Odpri v drugem oknu</translation>
+<translation id="4195643157523330669">Odpri v novem zavihku</translation>
+<translation id="1100066534610197918">Odpri nov zavihek v skupini</translation>
+<translation id="4860895144060829044">Pokličite</translation>
+<translation id="6896758677409633944">Kopiraj</translation>
+<translation id="8393700583063109961">Pošlji sporočilo</translation>
+<translation id="3557336313807607643">Dodaj med stike</translation>
+<translation id="4269820728363426813">Kopiraj naslov povezave</translation>
+<translation id="1206892813135768548">Kopiraj besedilo povezave</translation>
+<translation id="1204037785786432551">Prenesi povezavo</translation>
+<translation id="6864459304226931083">Prenos slike</translation>
+<translation id="8209050860603202033">Odpri sliko</translation>
+<translation id="8073388330009372546">Odpri sliko na novem zavihku</translation>
+<translation id="6649642165559792194">Predogled slike <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Naloži sliko</translation>
+<translation id="3845332215609790146">Iskanje z Brave Software Lens <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Za iskanje te slike uporabi <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Skupna raba slike</translation>
+<translation id="5833984609253377421">Deli povezavo z drugimi</translation>
+<translation id="6475951671322991020">Prenos videoposnetka</translation>
+<translation id="2317945146070194624">Odpiranje na novem zavihku v Chromu</translation>
+<translation id="7975379999046275268">Predogled strani <ph name="BEGIN_NEW"/>Novo<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Osveževanje strani</translation>
+<translation id="36525718899759834">Prenos aplikacije iz Trgovine Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Temno</translation>
+<translation id="1807246157184219062">Svetlo</translation>
+<translation id="4056223980640387499">Sepija</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Stalna širina</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Izberite zavihek za prenos</translation>
+<translation id="8719023831149562936">Trenutnega zavihka ni mogoče prenesti</translation>
+<translation id="2139186145475833000">Dodajanje na začetni zaslon</translation>
+<translation id="4616150815774728855">Odpri <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Aplikacije ni bilo mogoče odpreti</translation>
+<translation id="5129038482087801250">Namesti spletno aplikacijo</translation>
+<translation id="3789841737615482174">Namesti</translation>
+<translation id="4665282149850138822">Spletno mesto <ph name="NAME"/> je bilo dodano na začetni zaslon</translation>
+<translation id="7333031090786104871">Dodajanje prejšnjega spletnega mesta še vedno poteka</translation>
+<translation id="1036727731225946849">Dodajanje <ph name="WEBAPK_NAME"/> ...</translation>
+<translation id="3778956594442850293">Dodano na začetni zaslon</translation>
+<translation id="2146738493024040262">Odpri nenamestljivo aplikacijo</translation>
+<translation id="7016516562562142042">Dovoljeno za trenutni iskalnik</translation>
+<translation id="6177111841848151710">Blokirano za trenutni iskalnik</translation>
+<translation id="145097072038377568">Izklopljeno v nastavitvah za Android</translation>
+<translation id="8007176423574883786">Izklopljeno za to napravo</translation>
+<translation id="164269334534774161">Ogledujete si kopijo te strani brez povezave z dne <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Ta stran brez povezave je bila ustvarjena <ph name="CREATION_TIME"/> in se morda razlikuje od spletne različice.</translation>
+<translation id="8840953339110955557">Ta stran se morda razlikuje od spletne različice.</translation>
+<translation id="6405300764336705484">Ta vsebina je iz domene <ph name="DOMAIN_NAME"/> in jo prikazuje Brave Software.</translation>
+<translation id="1006017844123154345">Odpri v spletu</translation>
+<translation id="3326636747541519688">Stran v osnovnem načinu, ki jo je prikazal Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Naloži izvirno stran<ph name="END_LINK"/> iz domene <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Če se to pogosto zgodi, preizkusite te <ph name="BEGIN_LINK"/>predloge<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Vsebina je skrita</translation>
+<translation id="3810973564298564668">Upravljanje</translation>
+<translation id="5199929503336119739">Delovni profil</translation>
+<translation id="528192093759286357">Povlecite z vrha in se dotaknite gumba za nazaj, če želite zapreti celozaslonski način.</translation>
+<translation id="2836148919159985482">Dotaknite se gumba za nazaj, če želite zapreti celozaslonski način.</translation>
+<translation id="3967822245660637423">Prenos končan</translation>
+<translation id="2434158240863470628">Prenos je končan <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Prenos ni uspel</translation>
+<translation id="1384959399684842514">Prenos je zaustavljen</translation>
+<translation id="1671236975893690980">Prenos na čakanju …</translation>
+<translation id="5561549206367097665">Čakanje na omrežje …</translation>
+<translation id="5864419784173784555">Čakanje na drug prenos …</translation>
+<translation id="6461962085415701688">Datoteke ni mogoče odpreti</translation>
+<translation id="1178581264944972037">Prekini</translation>
+<translation id="8200772114523450471">Nadaljuj</translation>
+<translation id="1409879593029778104">Prenos datoteke <ph name="FILE_NAME"/> je bil preprečen, ker datoteka že obstaja.</translation>
+<translation id="3387650086002190359">Prenos datoteke <ph name="FILE_NAME"/> ni uspel zaradi napak v datotečnem sistemu.</translation>
+<translation id="6482749332252372425">Prenos datoteke <ph name="FILE_NAME"/> ni uspel zaradi pomanjkanja prostora za shranjevanje.</translation>
+<translation id="7619072057915878432">Prenos datoteke <ph name="FILE_NAME"/> ni uspel zaradi napak v omrežju.</translation>
+<translation id="1477626028522505441">Prenos datoteke <ph name="FILE_NAME"/> ni uspel zaradi težav s strežnikom.</translation>
+<translation id="3692944402865947621">Prenos datoteke <ph name="FILE_NAME"/> ni uspel, ker prostor za shranjevanje ni dosegljiv.</translation>
+<translation id="604996488070107836">Prenos datoteke <ph name="FILE_NAME"/> ni uspel zaradi neznane napake.</translation>
+<translation id="6738867403308150051">Prenašanje ...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Preneseno <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Preneseno <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Preneseno <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Še 1 datoteka</translation>
+<translation id="8186512483418048923">Še toliko datotek: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> prenesena datoteka}one{<ph name="FILES_DOWNLOADED_MANY"/> prenesena datoteka}two{<ph name="FILES_DOWNLOADED_MANY"/> preneseni datoteki}few{<ph name="FILES_DOWNLOADED_MANY"/> prenesene datoteke}other{<ph name="FILES_DOWNLOADED_MANY"/> prenesenih datotek}}</translation>
+<translation id="8037750541064988519">Še <ph name="DAYS"/> dni</translation>
+<translation id="8190358571722158785">Še 1 dan</translation>
+<translation id="60923314841986378">Še <ph name="HOURS"/> h</translation>
+<translation id="510275257476243843">Še 1 h</translation>
+<translation id="970715775301869095">Še <ph name="MINUTES"/> min</translation>
+<translation id="3236059992281584593">Še 1 min</translation>
+<translation id="2777555524387840389">Še <ph name="SECONDS"/> s</translation>
+<translation id="2781151931089541271">Še 1 s</translation>
+<translation id="3303414029551471755">Ali želite prenesti vsebino?</translation>
+<translation id="8617240290563765734">Želite odpreti predlagani URL, naveden v preneseni vsebini?</translation>
+<translation id="1373696734384179344">Za prenos izbrane vsebine ni dovolj pomnilnika.</translation>
+<translation id="5271967389191913893">Naprava ne more odpreti vsebine za prenos.</translation>
+<translation id="883806473910249246">Pri prenosu vsebine je prišlo do napake.</translation>
+<translation id="5626134646977739690">Ime:</translation>
+<translation id="7963646190083259054">Ponudnik:</translation>
+<translation id="3414952576877147120">Velikost:</translation>
+<translation id="7375125077091615385">Vrsta:</translation>
+<translation id="5765780083710877561">Opis:</translation>
+<translation id="4881695831933465202">Odpri</translation>
+<translation id="3542235761944717775">Na voljo: <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB na voljo</translation>
+<translation id="5424588387303617268">Na voljo: <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Uporaba <ph name="SPACE_USED"/> od <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Vse</translation>
+<translation id="4988526792673242964">Strani</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Zvok</translation>
+<translation id="9219103736887031265">Slike</translation>
+<translation id="8250920743982581267">Dokumenti</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# datoteka}one{# datoteka}two{# datoteki}few{# datoteke}other{# datotek}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# slika}one{# slika}two{# sliki}few{# slike}other{# slik}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videoposnetek}one{# videoposnetek}two{# videoposnetka}few{# videoposnetki}other{# videoposnetkov}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# zvočna datoteka}one{# zvočna datoteka}two{# zvočni datoteki}few{# zvočne datoteke}other{# zvočnih datotek}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# stran}one{# stran}two{# strani}few{# strani}other{# strani}}</translation>
+<translation id="5456381639095306749">Prenos strani</translation>
+<translation id="2394602618534698961">Datoteke, ki jih prenesete, so prikazane tu</translation>
+<translation id="7810647596859435254">Odpiranje z aplikacijo …</translation>
+<translation id="5655963694829536461">Poiščite prenose</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/><ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Moje datoteke</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/><ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Članki so prikazani tukaj in lahko jih berete, tudi ko nimate povezave</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# h}one{# h}two{# h}few{# h}other{# h}}</translation>
+<translation id="5853623416121554550">začasno ustavljeno</translation>
+<translation id="8965591936373831584">poteka</translation>
+<translation id="2779651927720337254">ni uspelo</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/><ph name="SEPARATOR"/><ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Pravkar</translation>
+<translation id="4000212216660919741">Začetna stran brez povezave</translation>
+<translation id="9133397713400217035">Raziščite vsebino brez povezave</translation>
+<translation id="968900484120156207">Strani, ki jih obiščete, so prikazane tu</translation>
+<translation id="7882131421121961860">Ni zgodovine</translation>
+<translation id="3549657413697417275">Iščite v svoji zgodovini</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">LL</translation>
+<translation id="724102042129299115">Izkušnje ob prvem izvajanju Chroma</translation>
+<translation id="2700285883409956633">Če uporabljate to aplikacijo, se strinjate s <ph name="BEGIN_LINK1"/>pogoji storitve<ph name="END_LINK1"/> in <ph name="BEGIN_LINK2"/>pravilnikom o zasebnosti<ph name="END_LINK2"/> za Brave.</translation>
+<translation id="1640714894372474981">Če uporabljate to aplikacijo, se strinjate s Chromovimi <ph name="BEGIN_LINK1"/>pogoji storitve<ph name="END_LINK1"/> in <ph name="BEGIN_LINK2"/>obvestilom o zasebnosti<ph name="END_LINK2"/> ter <ph name="BEGIN_LINK3"/>obvestilom o zasebnosti za Brave Software Račune, upravljane s Family Linkom<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Aplikacija <ph name="APP_NAME"/> se bo odprla v Chromu. Če nadaljujete, se strinjate s Chromovimi <ph name="BEGIN_LINK1"/>pogoji storitve<ph name="END_LINK1"/> in <ph name="BEGIN_LINK2"/>pravilnikom o zasebnosti<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659">Aplikacija <ph name="APP_NAME"/> se bo odprla v Chromu. Če nadaljujete, se strinjate s Chromovimi <ph name="BEGIN_LINK1"/>pogoji storitve<ph name="END_LINK1"/> in <ph name="BEGIN_LINK2"/>pravilnikom o zasebnosti<ph name="END_LINK2"/> ter <ph name="BEGIN_LINK3"/>obvestilom o zasebnosti za Brave Software Račune, upravljane s Family Linkom<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Pomagajte izboljšati Brave s pošiljanjem statističnih podatkov o uporabi in poročil o zrušitvah Googlu.</translation>
+<translation id="3518985090088779359">Sprejmi in nadaljuj</translation>
+<translation id="7207456302801184289">Dobrodošli v Chromu</translation>
+<translation id="704822250101715322">Čakanje na dokončanje posodobitev storitev za Brave Software Play</translation>
+<translation id="1231733316453485619">Želite vklopiti sinhronizacijo?</translation>
+<translation id="5132942445612118989">Sinhronizirajte gesla, zgodovino in drugo v vseh napravah</translation>
+<translation id="5736731321935944068">Brave Software lahko vašo zgodovino uporabi za prilagajanje Iskanja Brave Software, oglasov in drugih Googlovih storitev</translation>
+<translation id="4013614219085422040">Brave Software lahko vašo zgodovino uporabi za prilagajanje Iskanja Brave Software in drugih Googlovih storitev</translation>
+<translation id="5581519193887989363">V <ph name="BEGIN_LINK1"/>nastavitvah<ph name="END_LINK1"/> lahko kadar koli izberete, kaj želite sinhronizirati.</translation>
+<translation id="741204030948306876">Da, sem za</translation>
+<translation id="2410754283952462441">Izbira računa</translation>
+<translation id="2227444325776770048">Nadaljujte kot <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Niste <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Če želite dostopati do zaznamkov v vseh napravah, vklopite sinhronizacijo</translation>
+<translation id="2818669890320396765">Če želite dostopati do zaznamkov v vseh napravah, se prijavite in vklopite sinhronizacijo</translation>
+<translation id="6003646045106347985">Če želite prejemati prilagojeno vsebino, ki jo predlaga Brave Software, vklopite sinhronizacijo</translation>
+<translation id="8494430740943879273">Če želite prejemati prilagojeno vsebino, ki jo predlaga Brave Software, se prijavite in vklopite sinhronizacijo</translation>
+<translation id="5862731021271217234">Če želite dostopati do zavihkov iz drugih naprav, vklopite sinhronizacijo</translation>
+<translation id="3568688522516854065">Če želite dostopati do zavihkov iz drugih naprav, vklopite sinhronizacijo</translation>
+<translation id="1208340532756947324">Če želite sinhronizirati in prilagajati v vseh napravah, vklopite sinhronizacijo</translation>
+<translation id="4472118726404937099">Če želite sinhronizirati in prilagajati v vseh napravah, se prijavite in vklopite sinhronizacijo</translation>
+<translation id="2426805022920575512">Izberi drug račun</translation>
+<translation id="6790428901817661496">Predvajanje</translation>
+<translation id="1272079795634619415">Ustavi</translation>
+<translation id="2874939134665556319">Prejšnja skladba</translation>
+<translation id="4046123991198612571">Naslednja skladba</translation>
+<translation id="3859306556332390985">Išči naprej</translation>
+<translation id="8441146129660941386">Išči nazaj</translation>
+<translation id="6706288973712894588">Trenutno nimate povezave.\n<ph name="BEGIN_LINK"/>Raziščite vir brez povezave.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Nedavni zavihki</translation>
+<translation id="8497726226069778601">Nimate česa videti ... Za zdaj.</translation>
+<translation id="5423934151118863508">Tu bodo prikazane strani, ki jih obiskujete najpogosteje</translation>
+<translation id="6127379762771434464">Element odstranjen</translation>
+<translation id="4605958867780575332">Odstranjen element: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Googlov priložnostni logotip: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Druge naprave</translation>
+<translation id="4738836084190194332">Zadnja sinhronizacija: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Pred # minuto}one{Pred # minuto}two{Pred # minutama}few{Pred # minutami}other{Pred # minutami}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Pred # uro}one{Pred # uro}two{Pred # urama}few{Pred # urami}other{Pred # urami}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Pred # dnevom}one{Pred # dnevom}two{Pred # dnevoma}few{Pred # dnevi}other{Pred # dnevi}}</translation>
+<translation id="2762000892062317888">pravkar</translation>
+<translation id="1407135791313364759">Odpri vse</translation>
+<translation id="1209206284964581585">Zaenkrat skrij</translation>
+<translation id="129553762522093515">Nedavno zaprto</translation>
+<translation id="8413126021676339697">Prikaži celotno zgodovino</translation>
+<translation id="7876243839304621966">Odstrani vse</translation>
+<translation id="8487700953926739672">Na voljo brez povezave</translation>
+<translation id="5224771365102442243">Z videoposnetkom</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Preberite več<ph name="END_LINK"/> o predlagani vsebini</translation>
+<translation id="7542481630195938534">Prejemanje predlogov ni mogoče</translation>
+<translation id="5013696553129441713">Ni novih predlogov</translation>
+<translation id="1736419249208073774">Razišči</translation>
+<translation id="7444811645081526538">Več kategorij</translation>
+<translation id="6709133671862442373">Novice</translation>
+<translation id="1264974993859112054">Šport</translation>
+<translation id="9139318394846604261">Nakupovanje</translation>
+<translation id="3912508018559818924">Iskanje najboljšega v spletu …</translation>
+<translation id="526421993248218238">Te strani ni mogoče naložiti</translation>
+<translation id="614940544461990577">Poskusite:</translation>
+<translation id="3288003805934695103">znova naložiti stran</translation>
+<translation id="2353636109065292463">Preverjanje internetne povezave</translation>
+<translation id="2858138569776157458">Najb. prilj.</translation>
+<translation id="8364299278605033898">Ogled priljubljenih spletnih mest</translation>
+<translation id="1171770572613082465">Oglejte si priljubljena spletna mesta z dotikom gumba »Najb. prilj.«</translation>
+<translation id="5233638681132016545">Nov zavihek</translation>
+<translation id="4521874409998847950">Vsebino objavil <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>prikazuje jo Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Na voljo je nov. različica</translation>
+<translation id="4058091506841967397">Posod. Chroma ni mogoča</translation>
+<translation id="6316139424528454185">Različica Androida ni podprta</translation>
+<translation id="6989267951144302301">Ni bilo mogoče prenesti</translation>
+<translation id="624789221780392884">Posodobitev je pripravljena</translation>
+<translation id="1549000191223877751">Premik v drugo okno</translation>
+<translation id="7481312909269577407">Naprej</translation>
+<translation id="4084682180776658562">Zaznamek</translation>
+<translation id="6437478888915024427">Podatki o strani</translation>
+<translation id="7180611975245234373">Osveži</translation>
+<translation id="4913169188695071480">Ustavitev osveževanja</translation>
+<translation id="1829244130665387512">Poiščite na strani</translation>
+<translation id="6593061639179217415">Mesto za namizne račun.</translation>
+<translation id="9063523880881406963">Izklop možnosti »Zahteva za namizno spletno mesto«</translation>
+<translation id="2038563949887743358">Vklop možnosti »Zahteva za namizno spletno mesto«</translation>
+<translation id="2433507940547922241">Videz</translation>
+<translation id="983192555821071799">Zapri vse zavihke</translation>
+<translation id="1310482092992808703">Združi zavihke</translation>
+<translation id="7725024127233776428">Strani, ki jih dodate med zaznamke, so prikazane tukaj</translation>
+<translation id="4404568932422911380">Ni zaznamkov</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> zaznamek}one{<ph name="BOOKMARKS_COUNT_MANY"/> zaznamek}two{<ph name="BOOKMARKS_COUNT_MANY"/> zaznamka}few{<ph name="BOOKMARKS_COUNT_MANY"/> zaznamki}other{<ph name="BOOKMARKS_COUNT_MANY"/> zaznamkov}}</translation>
+<translation id="3739899004075612870">Dodano med zaznamke v izdelku <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Dodano med zaznamke</translation>
+<translation id="4452548195519783679">Zaznamek ustvarjen v mapi <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Zaznamka ni bilo mogoče dodati.</translation>
+<translation id="2842985007712546952">Nadrejena mapa</translation>
+<translation id="9065203028668620118">Uredi</translation>
+<translation id="4405224443901389797">Premakni v …</translation>
+<translation id="5170568018924773124">Prikaži v mapi</translation>
+<translation id="8035133914807600019">Nova mapa …</translation>
+<translation id="4532845899244822526">Izbira mape</translation>
+<translation id="6627583120233659107">Uredi mapo</translation>
+<translation id="1197267115302279827">Premakni zavihke</translation>
+<translation id="6963766334940102469">Izbriši zaznamke</translation>
+<translation id="4351244548802238354">Zapri pogovorno okno</translation>
+<translation id="451872707440238414">Poiščite zaznamke</translation>
+<translation id="8901170036886848654">Ni najdenih zaznamkov</translation>
+<translation id="6404511346730675251">Uredi zaznamek</translation>
+<translation id="3894427358181296146">Dodajanje mape</translation>
+<translation id="5327248766486351172">Ime</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Mapa</translation>
+<translation id="5161254044473106830">Naslov je obvezen</translation>
+<translation id="2996809686854298943">URL je obvezen</translation>
+<translation id="2536728043171574184">Ogled kopije te strani za način brez povezave.</translation>
+<translation id="4698034686595694889">Ogled brez povezave v aplikaciji <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> in več spletnih mest</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave bo naložil stran, ko bo pripravljen}one{Brave bo naložil strani, ko bo pripravljen}two{Brave bo naložil strani, ko bo pripravljen}few{Brave bo naložil strani, ko bo pripravljen}other{Brave bo naložil strani, ko bo pripravljen}}</translation>
+<translation id="6811034713472274749">Stran je pripravljena za ogled</translation>
+<translation id="4561979708150884304">Ni povezave</translation>
+<translation id="8274165955039650276">Ogled prenosov</translation>
+<translation id="2082238445998314030"><ph name="RESULT_NUMBER"/>. rezultat od <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Ni rezultatov</translation>
+<translation id="981121421437150478">Brez povezave</translation>
+<translation id="3298243779924642547">Osn. način</translation>
+<translation id="393697183122708255">Glasovno iskanje ni na voljo</translation>
+<translation id="7191430249889272776">Zavihek se je odprl v ozadju.</translation>
+<translation id="8445059357334030806">Odpri v Chromu</translation>
+<translation id="4720023427747327413">Odpri v: <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Odpiranje v brskalniku</translation>
+<translation id="1113597929977215864">Pokaži poenostavljen pogled</translation>
+<translation id="1513352483775369820">Zaznamki in spletna zgodovina</translation>
+<translation id="4939482511480190003">Pomagajte izboljšati Brave. <ph name="BEGIN_LINK"/>Sodelujte v anketi.<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Nazaj</translation>
+<translation id="5596627076506792578">Več možnosti</translation>
+<translation id="3522247891732774234">Posodobitev je na voljo. Več možnosti.</translation>
+<translation id="6773423637732432200">Posodobitev Chroma ni mogoča. Več možnosti.</translation>
+<translation id="3328801116991980348">Podatki o mestu</translation>
+<translation id="5391532827096253100">Povezava s tem spletnim mestom ni varna. Podatki o spletnem mestu.</translation>
+<translation id="6206551242102657620">Povezava je varna. Podatki o spletnem mestu.</translation>
+<translation id="6963642900430330478">Ta stran je nevarna. Podatki o spletnem mestu.</translation>
+<translation id="9070377983101773829">Začni glasovno iskanje</translation>
+<translation id="8676374126336081632">Izbriši vnos</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> odprt zavihek, dotaknite se, če želite preklopiti med zavihki}one{<ph name="OPEN_TABS_MANY"/> odprt zavihek, dotaknite se, če želite preklopiti med zavihki}two{<ph name="OPEN_TABS_MANY"/> odprta zavihka, dotaknite se, če želite preklopiti med zavihki}few{<ph name="OPEN_TABS_MANY"/> odprti zavihki, dotaknite se, če želite preklopiti med zavihki}other{<ph name="OPEN_TABS_MANY"/> odprtih zavihkov, dotaknite se, če želite preklopiti med zavihki}}</translation>
+<translation id="2369533728426058518">odpiranje zavihkov</translation>
+<translation id="7071521146534760487">Upravljanje računa</translation>
+<translation id="932327136139879170">Domov</translation>
+<translation id="2707726405694321444">Osveži stran</translation>
+<translation id="2891154217021530873">Ustavi nalaganje strani</translation>
+<translation id="6710213216561001401">Nazaj</translation>
+<translation id="6659594942844771486">Tabulator</translation>
+<translation id="1933845786846280168">Izbrani zavihek</translation>
+<translation id="2268044343513325586">Izboljšaj iskanje</translation>
+<translation id="7846076177841592234">Prekliči izbor</translation>
+<translation id="7087918508125750058">Št. izbranih: <ph name="ITEM_COUNT"/>. Možnosti so na voljo na zgornjem delu zaslona.</translation>
+<translation id="7250468141469952378">Št. izbranih: <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Delitev 1 izbranega elementa z drugimi}one{Delitev # izbranega elementa z drugimi}two{Delitev # izbranih elementov z drugimi}few{Delitev # izbranih elementov z drugimi}other{Delitev # izbranih elementov z drugimi}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Odstranitev 1 izbranega elementa}one{Odstranitev # izbranega elementa}two{Odstranitev # izbranih elementov}few{Odstranitev # izbranih elementov}other{Odstranitev # izbranih elementov}}</translation>
+<translation id="1283039547216852943">Dotaknite se za razširitev</translation>
+<translation id="5962718611393537961">Dotik za strnitev</translation>
+<translation id="8076492880354921740">Zavihki</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 izbran}one{# izbran}two{# izbrana}few{# izbrani}other{# izbranih}}</translation>
+<translation id="6818926723028410516">Izberite elemente</translation>
+<translation id="4797039098279997504">Dotaknite se, če se želite vrniti na <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Dotaknite se, če želite na spletno mesto</translation>
+<translation id="429312253194641664">Spletno mesto predvaja predstavnost</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> dostopa do vašega zaslona</translation>
+<translation id="8833831881926404480">Spletno mesto souporablja vaš zaslon.</translation>
+<translation id="9086455579313502267">Dostop do omrežja ni mogoč</translation>
+<translation id="938850635132480979">Napaka: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Odpri v: <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Odpiranje v aplikaciji z zemljevidi</translation>
+<translation id="7698359219371678927">Ustvarite e-poštno sporočilo v aplikaciji <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Ustvarite e-poštno sporočilo</translation>
+<translation id="5665379678064389456">Ustvarite dogodek v aplikaciji <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Ustvarite dogodek</translation>
+<translation id="2111511281910874386">Pojdi na stran</translation>
+<translation id="3988466920954086464">Ogled rezultatov dinamičnega iskanja v tem podoknu</translation>
+<translation id="2744248271121720757">Dotaknite se besede, če želite dinamično iskati ali prikazati sorodna dejanja</translation>
+<translation id="9155898266292537608">Prav tako lahko iščete, tako da se hitro dotaknete besede</translation>
+<translation id="3232754137068452469">Spletna aplikacija</translation>
+<translation id="1430915738399379752">Natisni</translation>
+<translation id="3775705724665058594">Pošiljanje v naprave</translation>
+<translation id="6364438453358674297">Ali želite odstraniti predlog iz zgodovine?</translation>
+<translation id="213279576345780926">Zaprt zavihek: <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139">Zaprtih je bilo toliko zavihkov: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Izbrisano: <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">Št. izbrisanih zaznamkov: <ph name="NUMBER_OF_BOOKMARKS"/></translation>
+<translation id="3819178904835489326">Št. izbrisanih prenosov: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">To število primerkov Chroma ni podprto.</translation>
+<translation id="4259722352634471385">Krmarjenje je blokirano: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Krmarjenje ni dosegljivo: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Zapri zavihek</translation>
+<translation id="7772375229873196092">Zapri aplikacijo <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Zgodovina krmarjenja</translation>
+<translation id="9169507124922466868">Zgodovina krmarjenja je napol odprta</translation>
+<translation id="1327257854815634930">Zgodovina krmarjenja je odprta</translation>
+<translation id="8788265440806329501">Zgodovina krmarjenja je zaprta</translation>
+<translation id="7482656565088326534">Zavihek za predogled</translation>
+<translation id="8427875596167638501">Zavihek za predogled je napol odprt</translation>
+<translation id="9102803872260866941">Zavihek za predogled je odprt</translation>
+<translation id="2942036813789421260">Zavihek za predogled je zaprt</translation>
+<translation id="6355102470683871794">Shranjeni podatki aplikacije Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Izbris shrambe mesta?</translation>
+<translation id="9205995714227143200">Shranjeni podatki spletnega mesta, ki se Chromu ne zdijo pomembni (npr. spletna mesta, za katera nimate shranjenih nastavitev ali ki jih ne obiskujete pogosto).</translation>
+<translation id="3997476611815694295">Nepomembni shranjeni podatki</translation>
+<translation id="8493948351860045254">Sprosti prostor</translation>
+<translation id="2324920234469020158">S tem bodo izbrisani piškotki, predpomnilnik in drugi podatki spletnih mest, ki se Chromu ne zdijo pomembni.</translation>
+<translation id="5447201525962359567">Vsi shranjeni podatki spletnega mesta, vključno s piškotki in drugimi lokalno shranjenimi podatki</translation>
+<translation id="1376578503827013741">Računanje …</translation>
+<translation id="583281660410589416">Neznano</translation>
+<translation id="2323763861024343754">Shranjeni podatki splet. mesta</translation>
+<translation id="3587672679800759167">Skupna količina podatkov, ki jih uporablja Brave, vključno z računi, zaznamki in shranjenimi nastavitvami.</translation>
+<translation id="6545017243486555795">Izbris vseh podatkov</translation>
+<translation id="4095146165863963773">Izbris podatkov aplikacije?</translation>
+<translation id="53119194224775367">Vsi podatki aplikacije Brave bodo trajno izbrisani, vključno z vsemi datotekami, nastavitvami, računi, zbirkami podatkov ipd.</translation>
+<translation id="5307446750509046227">Izbris shrambe mesta</translation>
+<translation id="300526633675317032">S tem bo izbrisanih vseh <ph name="SIZE_IN_KB"/> shranjenih podatkov spletnega mesta.</translation>
+<translation id="8068648041423924542">Izbira potrdila ni mogoča</translation>
+<translation id="2315043854645842844">Operacijski sistem ne podpira izbire potrdila pri odjemalcu.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> se želite povezati</translation>
+<translation id="5308380583665731573">Povezovanje</translation>
+<translation id="868929229000858085">Iskanje po stikih</translation>
+<translation id="1919950603503897840">Izbira stikov</translation>
+<translation id="7986741934819883144">Izberite stik</translation>
+<translation id="3333961966071413176">Vsi stiki</translation>
+<translation id="4994033804516042629">Ni najdenih stikov</translation>
+<translation id="5403592356182871684">Imena</translation>
+<translation id="2717722538473713889">E-poštni naslovi</translation>
+<translation id="381841723434055211">Telefonske številke</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(in še 1)}one{(in še #)}two{(in še #)}few{(in še #)}other{(in še #)}}</translation>
+<translation id="5197729504361054390">Izbrani stiki bodo v skupni rabi s spletnim mestom <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Slikovni dekodirnik</translation>
+<translation id="8067883171444229417">Predvajanje videa</translation>
+<translation id="6560414384669816528">Iskanje z iskalnikom Sogou</translation>
+<translation id="5406914950576900927">Brave lahko za iskanje na Kitajskem uporablja <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>. To je mogoče spremeniti v <ph name="BEGIN_LINK"/>nastavitvah<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Ohrani Brave Software</translation>
+<translation id="4384468725000734951">Uporaba iskalnika Sogou za iskanje</translation>
+<translation id="6103327872225198548">Uporaba iskalnika Brave Software za iskanje</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Ta aplikacija se izvaja v Chromu</translation>
+<translation id="6143689084714664628">Izvaja se v Chromu</translation>
+<translation id="7675869148432102528">Aplikacija <ph name="APP_NAME"/> ima prav tako podatke v Chromu</translation>
+<translation id="2734140769649165081">Podatke lahko izbrišete v Chromovih nastavitvah</translation>
+<translation id="8232956427053453090">Ohrani podatke</translation>
+<translation id="4298388696830689168">Povezana spletna mesta</translation>
+<translation id="5763514718066511291">Dotaknite se, če želite kopirati URL za to aplikacijo</translation>
+<translation id="6496823230996795692">Pri prvi uporabi aplikacije <ph name="APP_NAME"/> se morate povezati v internet.</translation>
+<translation id="751961395872307827">Povezave s spletnim mestom ni mogoče vzpostaviti</translation>
+<translation id="4878404682131129617">Vzpostavljanje tunela prek strežnika proxy ni uspelo</translation>
+<translation id="4749960740855309258">Odpiranje novega zavihka</translation>
+<translation id="8788968922598763114">Vnovično odpiranje nazadnje zaprtega zavihka</translation>
+<translation id="7929962904089429003">Odpiranje menija</translation>
+<translation id="6039379616847168523">Premik na naslednji zavihek</translation>
+<translation id="5210286577605176222">Premik na prejšnji zavihek</translation>
+<translation id="124678866338384709">Zapiranje trenutnega zavihka</translation>
+<translation id="3714981814255182093">Odpiranje vrstice za iskanje</translation>
+<translation id="5441522332038954058">Premik na naslovno vrstico</translation>
+<translation id="3398320232533725830">Odpiranje upravitelja zaznamkov</translation>
+<translation id="6583199322650523874">Dodajanje trenutne strani med zaznamke</translation>
+<translation id="8489271220582375723">Odpiranje strani z zgodovino</translation>
+<translation id="4837753911714442426">Odpiranje možnosti za tiskanje strani</translation>
+<translation id="5726692708398506830">Povečanje vsebine strani</translation>
+<translation id="3259831549858767975">Pomanjšanje vsebine strani</translation>
+<translation id="8015452622527143194">Vrnitev vsebine strani na privzeto velikost</translation>
+<translation id="3443221991560634068">Vnovično nalaganje trenutne strani</translation>
+<translation id="123724288017357924">Vnov. nalag. tren. strani s prezrtjem predp. vseb.</translation>
+<translation id="305870044889644984">Odpiranje centra za pomoč za Brave na nov. zavih.</translation>
+<translation id="3166827708714933426">Bližnjice za zavihke in okna</translation>
+<translation id="3169981355900570544">Bližnjice za funkcije Brave Software Chroma</translation>
+<translation id="4558311620361989323">Bližnjice za spletne strani</translation>
+<translation id="1908301351964700579">Brave se še vedno pripravlja na navidezno resničnost. Znova zaženite Brave pozneje.</translation>
+<translation id="8970887620466824814">Prišlo je do napake.</translation>
+<translation id="1875543012935658554">Znova odprite Brave.</translation>
+<translation id="79859296434321399">Če si želite ogledati vsebino v razširjeni resničnosti, namestite ARCore</translation>
+<translation id="8558485628462305855">Če si želite ogledati vsebino v razširjeni resničnosti, posodobite ARCore</translation>
+<translation id="3513704683820682405">Razširjena resničnost</translation>
+<translation id="5475862044948910901">Želite začeti sejo razširjene resničnosti?</translation>
 <translation id="7365126855094612066">Med trajanjem seje lahko spletno mesto:
 • ustvari 3D-zemljevid okolja
 • spremlja premikanje kamere
 
 Spletno mesto NIMA dostopa do kamere. Posnetki kamere so vidni samo vam.</translation>
-<translation id="7375125077091615385">Vrsta:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Izkušnje ob prvem izvajanju Chroma</translation>
-<translation id="741204030948306876">Da, sem za</translation>
-<translation id="7413229368719586778">Začetni datum: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Najprej vprašaj</translation>
-<translation id="7423538860840206698">Blokirano branje vsebine odložišča</translation>
-<translation id="7431991332293347422">Nadziranje, kako se zgodovina brskanja uporabi za prilagajanje Iskanja Google in drugega</translation>
-<translation id="7437998757836447326">Odjava iz Chroma</translation>
-<translation id="7438641746574390233">Če je vklopljen lahki način, Chrome uporabi Googlove strežnike za hitrejše nalaganje strani. Lahki način znova zapiše zelo počasne strani in naloži samo bistveno vsebino. Lahki način se ne uporablja v zavihkih brez beleženja zgodovine.</translation>
-<translation id="7444811645081526538">Več kategorij</translation>
-<translation id="7445411102860286510">Dovoli spletnim mestom samodejno predvajanje videoposnetkov z izklopljenim zvokom (priporočljivo)</translation>
-<translation id="7453467225369441013">Odjavi vas iz večine spletnih mest, vendar ne iz Google Računa.</translation>
-<translation id="7454641608352164238">Ni dovolj prostora</translation>
-<translation id="7475192538862203634">Če se to pogosto zgodi, preizkusite te <ph name="BEGIN_LINK" />predloge<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Kartice SD ni bilo mogoče najti. Nekatere vaše datoteke morda manjkajo.</translation>
-<translation id="7479104141328977413">Upravljanje zavihkov</translation>
-<translation id="7481312909269577407">Naprej</translation>
-<translation id="7482656565088326534">Zavihek za predogled</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Posodobljeno: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">prihranjenega prenosa podatkov</translation>
-<translation id="7498271377022651285">Počakajte …</translation>
-<translation id="7514365320538308">Prenos</translation>
-<translation id="751961395872307827">Povezave s spletnim mestom ni mogoče vzpostaviti</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Prejemanje predlogov ni mogoče</translation>
-<translation id="7559975015014302720">Lahki način je izklopljen</translation>
-<translation id="7562080006725997899">Brisanje podatkov brskanja</translation>
-<translation id="756809126120519699">Chromovi podatki so izbrisani.</translation>
-<translation id="757524316907819857">Prepreči spletnim mestom predvajanje zaščitene vsebine</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> prenesena datoteka}one{<ph name="FILES_DOWNLOADED_MANY" /> prenesena datoteka}two{<ph name="FILES_DOWNLOADED_MANY" /> preneseni datoteki}few{<ph name="FILES_DOWNLOADED_MANY" /> prenesene datoteke}other{<ph name="FILES_DOWNLOADED_MANY" /> prenesenih datotek}}</translation>
-<translation id="7588219262685291874">Vklop temne teme, ko je v napravi vklopljeno varčevanje z energijo</translation>
-<translation id="7589445247086920869">Blokiraj za trenutni iskalnik</translation>
-<translation id="7593557518625677601">Odprite nast. za Android in znova omog. sinh. v Androidu za zač. sinh. za Chrome</translation>
-<translation id="7596558890252710462">Operacijski sistem</translation>
-<translation id="7605594153474022051">Sync isn't working</translation>
-<translation id="7606077192958116810">Lahki način je vklopljen. Upravljate ga lahko v nastavitvah.</translation>
-<translation id="7612619742409846846">V Google ste prijavljeni kot</translation>
-<translation id="7619072057915878432">Prenos datoteke <ph name="FILE_NAME" /> ni uspel zaradi napak v omrežju.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Poiščite pomoč<ph name="END_LINK1" /> ali <ph name="BEGIN_LINK2" />znova iščite<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Dobrodošli v Chromu</translation>
-<translation id="7638584964844754484">Napačno geslo</translation>
-<translation id="7641339528570811325">Izbris podatkov brskanja …</translation>
-<translation id="7648422057306047504">Šifriranje gesel s poverilnicami za Google</translation>
-<translation id="7649070708921625228">Pomoč</translation>
-<translation id="7658239707568436148">Prekliči</translation>
-<translation id="7665369617277396874">Dodaj račun</translation>
-<translation id="766587987807204883">Članki so prikazani tukaj in lahko jih berete, tudi ko nimate povezave</translation>
-<translation id="7682724950699840886">Poskusite ta nasveta: poskrbite, da je v napravi dovolj prostora, ali poskusite znova izvoziti.</translation>
-<translation id="7685301384041462804">Prepričajte se, da zaupate temu spletnemu mestu, preden zaženete VR.</translation>
-<translation id="7698359219371678927">Ustvarite e-poštno sporočilo v aplikaciji <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Samodejno dokončanje iskanj in URL-jev</translation>
-<translation id="7725024127233776428">Strani, ki jih dodate med zaznamke, so prikazane tukaj</translation>
-<translation id="773466115871691567">Vedno prevedi strani v jeziku <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Zaradi zaznavanja nevarnih aplikacij in spletnih mest Chrome Googlu pošlje URL-je nekaterih strani, ki jih obiščete, omejene podatke o sistemu in vsebino nekaterih strani</translation>
-<translation id="7757787379047923882">Besedilo v skupni rabi iz naprave <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Kartica SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Dodaj naslov</translation>
-<translation id="7772032839648071052">Potrdi geslo</translation>
-<translation id="7772375229873196092">Zapri aplikacijo <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}two{<ph name="PAYMENT_METHOD_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}few{<ph name="PAYMENT_METHOD_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" /> \u2026 in še <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Včeraj</translation>
-<translation id="7791543448312431591">Dodaj</translation>
-<translation id="780301667611848630">Ne, hvala</translation>
-<translation id="7810647596859435254">Odpiranje z aplikacijo …</translation>
-<translation id="7821588508402923572">Prihranek pri količini prenesenih podatkov bo prikazan tukaj</translation>
-<translation id="7837721118676387834">Dovoli samodejno predvajanje videoposnetkov z izklopljenim zvokom za določeno spletno mesto.</translation>
-<translation id="7846076177841592234">Prekliči izbor</translation>
-<translation id="784934925303690534">Časovno obdobje</translation>
-<translation id="7851858861565204677">Druge naprave</translation>
-<translation id="7875915731392087153">Ustvarite e-poštno sporočilo</translation>
-<translation id="7876243839304621966">Odstrani vse</translation>
-<translation id="7882131421121961860">Ni zgodovine</translation>
-<translation id="7882806643839505685">Dovolitev zvoka za določeno spletno mesto.</translation>
-<translation id="7886917304091689118">Izvaja se v Chromu</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Prenos datoteke.}one{Prenos # datoteke.}two{Prenos # datotek.}few{Prenos # datotek.}other{Prenos # datotek.}}</translation>
-<translation id="7929962904089429003">Odpiranje menija</translation>
-<translation id="7942131818088350342">Izdelek <ph name="PRODUCT_NAME" /> je zastarel.</translation>
-<translation id="7947953824732555851">Sprejem in prijava</translation>
-<translation id="7963646190083259054">Ponudnik:</translation>
-<translation id="7971136598759319605">Aktivna pred 1 dnevom</translation>
-<translation id="7975379999046275268">Predogled strani <ph name="BEGIN_NEW" />Novo<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Vnaprejšnje nalaganje strani zaradi hitrejšega brskanja in iskanja</translation>
-<translation id="79859296434321399">Če si želite ogledati vsebino v razširjeni resničnosti, namestite ARCore</translation>
-<translation id="7986741934819883144">Izberite stik</translation>
-<translation id="7987073022710626672">Pogoji storitve za Chrome</translation>
-<translation id="7998918019931843664">Vnovično odpiranje zaprtega zavihka</translation>
-<translation id="7999064672810608036">Ali želite res izbrisati vse lokalne podatke, vključno s piškotki, in ponastaviti vsa dovoljenja za to spletno mesto?</translation>
-<translation id="8004582292198964060">Brskalnik</translation>
-<translation id="8007176423574883786">Izklopljeno za to napravo</translation>
-<translation id="8013372441983637696">Prav tako izbriši podatke v Chromu iz te naprave</translation>
-<translation id="8015452622527143194">Vrnitev vsebine strani na privzeto velikost</translation>
-<translation id="802154636333426148">Prenos ni uspel</translation>
-<translation id="8026334261755873520">Izbriši podatke brskanja</translation>
-<translation id="8035133914807600019">Nova mapa …</translation>
-<translation id="8037750541064988519">Še <ph name="DAYS" /> dni</translation>
-<translation id="804335162455518893">Kartice SD ni bilo mogoče najti</translation>
-<translation id="805047784848435650">Na podlagi zgodovine brskanja</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB na voljo</translation>
-<translation id="8058746566562539958">Odpiranje na novem zavihku v Chromu</translation>
-<translation id="8063895661287329888">Zaznamka ni bilo mogoče dodati.</translation>
-<translation id="806745655614357130">Podatki naj bodo ločeni</translation>
-<translation id="8067883171444229417">Predvajanje videa</translation>
-<translation id="8068648041423924542">Izbira potrdila ni mogoča</translation>
-<translation id="8073388330009372546">Odpri sliko na novem zavihku</translation>
-<translation id="8076492880354921740">Zavihki</translation>
-<translation id="8084114998886531721">Shranjeno geslo</translation>
-<translation id="8087000398470557479">Ta vsebina je iz domene <ph name="DOMAIN_NAME" /> in jo prikazuje Google.</translation>
-<translation id="8103578431304235997">Zavihek brez beleženja zgodovine</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /><ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Če želite dostopati do zaznamkov v vseh napravah, vklopite sinhronizacijo</translation>
-<translation id="8110087112193408731">Ali želite svojo dejavnost v Chromu prikazati v Digitalni dobrobiti?</translation>
-<translation id="8116925261070264013">Prezrto</translation>
-<translation id="813082847718468539">Ogled podatkov o mestu</translation>
-<translation id="8131740175452115882">Potrdi</translation>
-<translation id="8156139159503939589">Katere jezike znate brati?</translation>
-<translation id="8168435359814927499">Vsebina</translation>
-<translation id="8186512483418048923">Še toliko datotek: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Še 1 dan</translation>
-<translation id="8200772114523450471">Nadaljuj</translation>
-<translation id="8209050860603202033">Odpri sliko</translation>
-<translation id="8218622182176210845">Upravljanje računa</translation>
-<translation id="8224471946457685718">Prenos člankov v omrežju Wi-Fi</translation>
-<translation id="8232956427053453090">Ohrani podatke</translation>
-<translation id="8249310407154411074">Na vrh</translation>
-<translation id="8250920743982581267">Dokumenti</translation>
-<translation id="825412236959742607">Ta stran uporablja preveč pomnilnika, zato je Chrome odstranil nekaj vsebine.</translation>
-<translation id="8260126382462817229">Poskusite se znova prijaviti.</translation>
-<translation id="8261506727792406068">Izbriši</translation>
-<translation id="8266862848225348053">Mesto za prenos</translation>
-<translation id="8274165955039650276">Ogled prenosov</translation>
-<translation id="8284326494547611709">Napisi</translation>
-<translation id="8300705686683892304">Upravlja aplikacija</translation>
-<translation id="8310344678080805313">Standardni zavihki</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> in več spletnih mest</translation>
-<translation id="8327155640814342956">Za najboljšo izkušnjo pri brskanju odprite Chrome, da ga posodobite</translation>
-<translation id="8339163506404995330">Strani v jeziku <ph name="LANGUAGE" /> ne bodo prevedene</translation>
-<translation id="8349013245300336738">Razvrsti glede na količino prenesenih podatkov</translation>
-<translation id="8364299278605033898">Ogled priljubljenih spletnih mest</translation>
-<translation id="8368027906805972958">Neznana ali nepodprta naprava (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Dovoli sinhroniziranje v ozadju za določeno spletno mesto.</translation>
-<translation id="8378714024927312812">Upravlja vaša organizacija</translation>
-<translation id="8380167699614421159">To spletno mesto prikazuje vsiljive ali zavajajoče oglase</translation>
-<translation id="8393700583063109961">Pošlji sporočilo</translation>
-<translation id="8413126021676339697">Prikaži celotno zgodovino</translation>
-<translation id="8427875596167638501">Zavihek za predogled je napol odprt</translation>
-<translation id="8428213095426709021">Nastavitve</translation>
-<translation id="8438566539970814960">Izboljšanje iskanja in brskanja</translation>
-<translation id="8441146129660941386">Išči nazaj</translation>
-<translation id="8443209985646068659">Posod. Chroma ni mogoča</translation>
-<translation id="8445448999790540984">Gesel ni mogoče izvoziti</translation>
-<translation id="8447861592752582886">Umik dovoljenja za dostop do naprave</translation>
-<translation id="8461694314515752532">Šifriranje sinhroniziranih podatkov z vašim geslom za sinhronizacijo</translation>
-<translation id="8466613982764129868">Naprava <ph name="TARGET_DEVICE_NAME" /> mora biti povezana v internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /><ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Na voljo brez povezave</translation>
-<translation id="8489271220582375723">Odpiranje strani z zgodovino</translation>
-<translation id="8493948351860045254">Sprosti prostor</translation>
-<translation id="8497726226069778601">Nimate česa videti ... Za zdaj.</translation>
-<translation id="8503559462189395349">Gesla za Chrome</translation>
-<translation id="8503813439785031346">Uporabniško ime</translation>
-<translation id="8514477925623180633">Izvoz gesel, shranjenih v Chromu</translation>
-<translation id="8514577642972634246">Vklop načina brez beleženja zgodovine</translation>
-<translation id="851751545965956758">Spletnim mestom prepreči povezovanje z napravami</translation>
-<translation id="8523928698583292556">Izbris shranjenega gesla</translation>
-<translation id="854522910157234410">Odpri to stran</translation>
-<translation id="8558485628462305855">Če si želite ogledati vsebino v razširjeni resničnosti, posodobite ARCore</translation>
-<translation id="8559990750235505898">Ponudi prevajanje strani v drugih jezikih</translation>
-<translation id="8562452229998620586">Shranjena gesla bodo prikazana tukaj.</translation>
-<translation id="8569404424186215731">od <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Zadnji 4 tedni</translation>
-<translation id="857943718398505171">Dovoljeno (priporočeno)</translation>
-<translation id="8583805026567836021">Brisanje podatkov računa</translation>
-<translation id="860043288473659153">Ime imetnika kartice</translation>
-<translation id="8609465669617005112">Premakni navzgor</translation>
-<translation id="8616006591992756292">V Google Računu so morda druge vrste zgodovine brskanja na <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Želite odpreti predlagani URL, naveden v preneseni vsebini?</translation>
-<translation id="8636825310635137004">Če želite dostopati do zavihkov iz drugih naprav, vklopite sinhronizacijo.</translation>
-<translation id="8641930654639604085">Poskusi blokirati spletna mesta za odrasle</translation>
-<translation id="8655129584991699539">Podatke lahko izbrišete v Chromovih nastavitvah</translation>
-<translation id="8662811608048051533">Odjavi vas iz večine spletnih mest.</translation>
-<translation id="8664979001105139458">Ime datoteke že obstaja</translation>
-<translation id="8676374126336081632">Izbriši vnos</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Moč signala: # črtica}one{Moč signala: # črtica}two{Moč signala: # črtici}few{Moč signala: # črtice}other{Moč signala: # črtic}}</translation>
-<translation id="868929229000858085">Iskanje po stikih</translation>
-<translation id="869891660844655955">Datum izteka</translation>
-<translation id="8719023831149562936">Trenutnega zavihka ni mogoče prenesti</translation>
-<translation id="8725066075913043281">Poskusite znova</translation>
-<translation id="8728487861892616501">Če uporabljate to aplikacijo, se strinjate s Chromovimi <ph name="BEGIN_LINK1" />pogoji storitve<ph name="END_LINK1" /> in <ph name="BEGIN_LINK2" />obvestilom o zasebnosti<ph name="END_LINK2" /> ter <ph name="BEGIN_LINK3" />obvestilom o zasebnosti za Google Račune, upravljane s Family Linkom<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Končano</translation>
-<translation id="8748850008226585750">Vsebina je skrita</translation>
-<translation id="8751914237388039244">Izberite sliko</translation>
-<translation id="8788265440806329501">Zgodovina krmarjenja je zaprta</translation>
-<translation id="8788968922598763114">Vnovično odpiranje nazadnje zaprtega zavihka</translation>
-<translation id="8801436777607969138">Preprečevanje JavaScripta za določeno spletno mesto.</translation>
-<translation id="8812260976093120287">Na nekaterih spletnih mestih je mogoče plačevati z zgoraj navedenimi podprtimi aplikacijami v napravi.</translation>
-<translation id="8816026460808729765">Preprečevanje spletnim mestom dostopa do tipal</translation>
-<translation id="8816439037877937734">Aplikacija <ph name="APP_NAME" /> se bo odprla v Chromu. Če nadaljujete, se strinjate s Chromovimi <ph name="BEGIN_LINK1" />pogoji storitve<ph name="END_LINK1" /> in <ph name="BEGIN_LINK2" />pravilnikom o zasebnosti<ph name="END_LINK2" /> ter <ph name="BEGIN_LINK3" />obvestilom o zasebnosti za Google Račune, upravljane s Family Linkom<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Zaznamki</translation>
-<translation id="8833831881926404480">Spletno mesto souporablja vaš zaslon.</translation>
-<translation id="883806473910249246">Pri prenosu vsebine je prišlo do napake.</translation>
-<translation id="8840953339110955557">Ta stran se morda razlikuje od spletne različice.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, zavihek</translation>
-<translation id="885701979325669005">Shramba</translation>
-<translation id="889338405075704026">Odprite nastavitve Chroma</translation>
-<translation id="8901170036886848654">Ni najdenih zaznamkov</translation>
-<translation id="8909135823018751308">Skupna raba …</translation>
-<translation id="8912362522468806198">Google Račun</translation>
-<translation id="8920114477895755567">Čakanje na podrobnosti o staršu.</translation>
+<translation id="1188239144602654184">Začni RR</translation>
+<translation id="473775607612524610">Posodobi</translation>
+<translation id="3133489217401741157">Nameščanje modula <ph name="MODULE"/> za Brave …</translation>
+<translation id="1791662854739702043">Nameščeno</translation>
+<translation id="5131234170665854056">Modula <ph name="MODULE"/> za Brave ni mogoče namestiti</translation>
+<translation id="2567385386134582609">SLIKA</translation>
+<translation id="6395288395575013217">POVEZAVA</translation>
+<translation id="7352939065658542140">VIDEOPOSNETEK</translation>
+<translation id="4116038641877404294">Prenesite strani, če jih želite uporabljati brez povezave</translation>
 <translation id="8922289737868596582">Prenos strani za uporabo brez povezave z gumbom »Več možnosti«</translation>
-<translation id="8937772741022875483">Ali želite svojo dejavnost v Chromu odstraniti iz Digitalne dobrobiti?</translation>
-<translation id="8941729603749328384">www.primer.si</translation>
-<translation id="8942627711005830162">Odpri v drugem oknu</translation>
-<translation id="8951232171465285730">S Chromom ste prihranili <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Blokiranje piškotkov za določeno spletno mesto.</translation>
-<translation id="8959122750345127698">Krmarjenje ni dosegljivo: <ph name="URL" /></translation>
-<translation id="8965591936373831584">poteka</translation>
-<translation id="8970887620466824814">Prišlo je do napake.</translation>
-<translation id="8972098258593396643">Želite prenesti v privzeto mapo?</translation>
-<translation id="8986494364107987395">Samodejno pošlji statistične podatke o uporabi in poročila o zrušitvah Googlu</translation>
-<translation id="8993760627012879038">Odpiranje novega zavihka brez beleženja zgodovine</translation>
-<translation id="8998729206196772491">Prijavljate se z računom, ki ga upravlja <ph name="MANAGED_DOMAIN" />, in nadzor nad podatki v Chromu predajate skrbniku. Vaši podatki bodo trajno povezani s tem računom. Če se odjavite iz Chroma, boste izbrisali podatke iz te naprave, vendar bodo še naprej shranjeni v Google Računu.</translation>
-<translation id="9019902583201351841">Upravljajo starši</translation>
-<translation id="9028914725102941583">Vklopite sinhronizacijo, če želite deliti z drugimi napravami</translation>
-<translation id="9029323097866369874">Dovolite spletnemu mestu <ph name="DOMAIN" />, da zažene VR?</translation>
-<translation id="9040142327097499898">Obvestila so dovoljena. Lokacija je izklopljena za to napravo.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# videoposnetek}one{# videoposnetek}two{# videoposnetka}few{# videoposnetki}other{# videoposnetkov}}</translation>
-<translation id="9050666287014529139">Geslo</translation>
-<translation id="9063523880881406963">Izklop možnosti »Zahteva za namizno spletno mesto«</translation>
-<translation id="9065203028668620118">Uredi</translation>
-<translation id="9070377983101773829">Začni glasovno iskanje</translation>
-<translation id="9074336505530349563">Če želite prejemati prilagojeno vsebino, ki jo predlaga Google, se prijavite in vklopite sinhronizacijo</translation>
-<translation id="9086455579313502267">Dostop do omrežja ni mogoč</translation>
-<translation id="9100505651305367705">Možnost prikaza člankov v preprostem pogledu, če je podprt</translation>
-<translation id="9100610230175265781">Zahtevano je geslo</translation>
-<translation id="9102803872260866941">Zavihek za predogled je odprt</translation>
+<translation id="5958275228015807058">Poiščite datoteke in strani v Prenosih</translation>
+<translation id="5620928963363755975">Poiščite datoteke in strani v Prenosih z gumbom »Več možnosti«</translation>
+<translation id="3341058695485821946">Oglejte si, koliko prenosa podatkov ste prihranili</translation>
+<translation id="3157842584138209013">Če pritisnete gumb za več možnosti, si lahko ogledate, koliko prenosa podatkov ste prihranili</translation>
+<translation id="8218622182176210845">Upravljanje računa</translation>
+<translation id="8090895580117672212">Če želite upravljati račun Brave Software, se dotaknite gumba »Upravljanje računa«</translation>
+<translation id="8856898588039823173">Stran v osnovnem načinu, ki jo je prikazal Brave Software. Dotaknite se, če želite naložiti izvirno stran.</translation>
+<translation id="8134317863207426198">Stran v osnovnem načinu, ki jo je prikazal Brave Software. Dotaknite se gumba za nalaganje izvirne strani, če želite naložiti izvirno stran.</translation>
+<translation id="4961107849584082341">Prevedite to stran v kateri koli jezik</translation>
+<translation id="569536719314091526">Prevedite to stran v kateri koli jezik z gumbom »Več možnosti«</translation>
+<translation id="1397811292916898096">Iskanje z iskalnikom <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Kadar koli lahko spremenite privzeto mesto za prenose</translation>
+<translation id="6942665639005891494">Z možnostjo v meniju z nastavitvami lahko kadar koli spremenite privzeto mesto za prenose</translation>
+<translation id="6850409657436465440">Prenos še poteka</translation>
+<translation id="5817715962196959877">Brave zdaj hitreje prenaša datoteke</translation>
+<translation id="3976396876660209797">Odstranite in znova ustvarite to bližnjico</translation>
+<translation id="6766622839693428701">Povlecite navzdol, da zaprete.</translation>
+<translation id="1028699632127661925">Pošiljanje v napravo <ph name="DEVICE_NAME"/> ...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – poslano iz naprave <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Prejet zavihek</translation>
 <translation id="9104217018994036254">Seznam naprav, s katerimi želite deliti zavihek.</translation>
-<translation id="9133397713400217035">Raziščite vsebino brez povezave</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Pokaži izvirno besedilo</translation>
-<translation id="9139068048179869749">Prikaži poziv, preden se spletnim mestom dovoli pošiljanje obvestil (priporočeno)</translation>
-<translation id="9139318394846604261">Nakupovanje</translation>
-<translation id="9155898266292537608">Prav tako lahko iščete, tako da se hitro dotaknete besede</translation>
-<translation id="9169507124922466868">Zgodovina krmarjenja je napol odprta</translation>
-<translation id="9204836675896933765">Še 1 datoteka</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Seznam naprav, s katerimi želite deliti zavihek, odprt pri polovični višini.</translation>
+<translation id="2904414404539560095">Seznam naprav, s katerimi želite deliti zavihek, odprt pri polni višini.</translation>
+<translation id="4135200667068010335">Seznam naprav, s katerimi želite deliti zavihek, je zaprt.</translation>
+<translation id="5292796745632149097">Pošiljanje v napravo</translation>
+<translation id="1386674309198842382">Aktivna pred toliko dnevi: <ph name="LAST_UPDATED"/></translation>
+<translation id="7971136598759319605">Aktivna pred 1 dnevom</translation>
+<translation id="1521774566618522728">Aktivno danes</translation>
+<translation id="3631987586758005671">Deljenje z napravo <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Vklopite sinhronizacijo, če želite deliti z drugimi napravami</translation>
+<translation id="6162454065885854378">Če želite deliti kaj iz telefona z drugo napravo, v obeh napravah v nastavitvah Chroma vklopite sinhronizacijo</translation>
+<translation id="6084271560289605378">Odprite nastavitve Chroma</translation>
+<translation id="2318045970523081853">Dotaknite se, če želite klicati</translation>
 <translation id="9209888181064652401">Ni mogoče klicati</translation>
-<translation id="9219103736887031265">Slike</translation>
-<translation id="926205370408745186">Odstranitev dejavnosti v Chromu iz Digitalne dobrobiti</translation>
-<translation id="932327136139879170">Domov</translation>
-<translation id="938850635132480979">Napaka: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Dostop do mikrofona</translation>
-<translation id="95817756606698420">Chrome lahko za iskanje na Kitajskem uporablja <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />. To je mogoče spremeniti v <ph name="BEGIN_LINK" />nastavitvah<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blokiraj, če spletno mesto prikazuje vsiljive ali zavajajoče oglase (priporočljivo)</translation>
-<translation id="968900484120156207">Strani, ki jih obiščete, so prikazane tu</translation>
-<translation id="970715775301869095">Še <ph name="MINUTES" /> min</translation>
-<translation id="974555521953189084">Vnesite geslo, če želite začeti sinhronizacijo</translation>
-<translation id="981121421437150478">Brez povezave</translation>
-<translation id="982182592107339124">S tem bodo izbrisani podatki za vsa spletna mesta, vključno s temi:</translation>
-<translation id="983192555821071799">Zapri vse zavihke</translation>
-<translation id="987264212798334818">Splošno</translation>
+<translation id="2860954141821109167">V tej napravi mora biti omogočena aplikacija Telefon</translation>
+<translation id="2067805253194386918">besedilo</translation>
+<translation id="1450753235335490080">Ni mogoče deliti tega: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Ni bilo mogoče deliti tega: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Poskrbite, da ima naprava <ph name="TARGET_DEVICE_NAME"/> vklopljeno sinhronizacijo v Chromu</translation>
+<translation id="3016635187733453316">Naprava mora biti povezana z internetom</translation>
+<translation id="8466613982764129868">Naprava <ph name="TARGET_DEVICE_NAME"/> mora biti povezana v internet</translation>
+<translation id="6539092367496845964">Prišlo je do napake. Poskusite znova pozneje.</translation>
+<translation id="3389286852084373014">Besedilo je preveliko</translation>
+<translation id="2100314319871056947">Poskusite deliti besedilo v manjših kosih</translation>
+<translation id="2987620471460279764">Besedilo, deljeno iz druge naprave</translation>
+<translation id="7757787379047923882">Besedilo v skupni rabi iz naprave <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kopirano v odložišče</translation>
+<translation id="4696983787092045100">Pošiljanje besedila v vaše naprave</translation>
+<translation id="1260236875608242557">Iščite in raziskujte</translation>
+<translation id="6369229450655021117">Tu lahko iščete po spletu, delite vsebino s prijatelji in si ogledate odprte strani</translation>
+<translation id="723171743924126238">Izberite slike</translation>
+<translation id="8751914237388039244">Izberite sliko</translation>
+<translation id="1989112275319619282">Brskanje</translation>
+<translation id="7055152154916055070">Preusmeritev je preprečena:</translation>
+<translation id="5524843473235508879">Preusmeritev je bila blokirana.</translation>
+<translation id="6573096386450695060">Vedno dovoli</translation>
+<translation id="5805364706385912897">Ta stran uporablja preveč pomnilnika, zato jo je Brave zaustavil.</translation>
+<translation id="5138664332909611586">Ta stran uporablja preveč pomnilnika, zato je Brave odstranil nekaj vsebine.</translation>
+<translation id="9137013805542155359">Pokaži izvirno besedilo</translation>
+<translation id="6361779936989026201">Pomočnik Brave Software v Chromu</translation>
+<translation id="7291387454912369099">Dokončanje nakupa s Pomočnikom</translation>
+<translation id="4565206163201411670">Ali želite svojo dejavnost v Chromu prikazati v Digitalni dobrobiti?</translation>
+<translation id="9055113864158719823">Ogledate si lahko spletna mesta, ki jih obiščete v Chromu, in zanje nastavite merilnike časa.\n\nBrave Software dobi podatke o spletnih mestih, za katere nastavite merilnike časa, in o tem, kako dolgo traja vaš obisk teh mest. Te podatke uporabljamo za izboljšanje Digitalne dobrobiti.</translation>
+<translation id="4596514158372210596">Odstranitev dejavnosti v Chromu iz Digitalne dobrobiti</translation>
+<translation id="1174893863889683998">Ali želite svojo dejavnost v Chromu odstraniti iz Digitalne dobrobiti?</translation>
+<translation id="708829030563435351">Spletna mesta, ki jih obiščete v Chromu, ne bodo prikazana. Vsi merilniki časa spletnih mest bodo izbrisani.</translation>
+<translation id="2056878612599315956">Spletno mesto začasno ustavljeno</translation>
+<translation id="671481426037969117">Merilnik časa za <ph name="FQDN"/> je potekel. Jutri se začne znova.</translation>
+<translation id="7479104141328977413">Upravljanje zavihkov</translation>
+<translation id="3524138585025253783">Uporabniški vmesnik za razvijalce</translation>
+<translation id="6036057147555329831">Dodatni modul ICU</translation>
+<translation id="9029323097866369874">Dovolite spletnemu mestu <ph name="DOMAIN"/>, da zažene VR?</translation>
+<translation id="7685301384041462804">Prepričajte se, da zaupate temu spletnemu mestu, preden zaženete VR.</translation>
+<translation id="5033865233969348410">Med uporabo VR lahko to spletno mesto o vas izve to:
+  –  vaše fizične lastnosti, kot je telesna višina
+
+Prepričajte se, da zaupate temu spletnemu mestu, preden zaženete VR.</translation>
+<translation id="5534334044554683961">Med uporabo VR lahko to spletno mesto o vas izve to:
+  –   vaše fizične lastnosti, kot je telesna višina
+  –   postavitev vaše sobe
+
+Prepričajte se, da zaupate temu spletnemu mestu, preden zaženete VR.</translation>
+<translation id="4169535189173047238">Ne dovoli</translation>
+<translation id="2170088579611075216">Omogoči in zaženi VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_sr.xtb
+++ b/android/java/strings/translations/android_chrome_strings_sr.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="sr">
-<translation id="1006017844123154345">Отвори онлајн</translation>
-<translation id="1028699632127661925">Шаље се на уређај <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Додаје се <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Са веб-сајтова</translation>
-<translation id="1049743911850919806">Без архивирања</translation>
-<translation id="10614374240317010">Никада се не чува</translation>
-<translation id="1067922213147265141">Друге Google услуге</translation>
-<translation id="1068672505746868501">Никад не преводи странице на језику <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Ако промените екстензију датотеке, она може да се отвори у другој апликацији и да буде опасна по уређај.</translation>
-<translation id="1100066534610197918">Отвори у новој картици у групи</translation>
-<translation id="1105960400813249514">Снимање екрана</translation>
-<translation id="1111673857033749125">Обележивачи сачувани на другим уређајима ће се приказати овде.</translation>
-<translation id="1113597929977215864">Прикажи поједностављени приказ</translation>
-<translation id="1121094540300013208">Извештаји о коришћењу и отказивању</translation>
-<translation id="1124772482545689468">Корисник</translation>
-<translation id="1129510026454351943">Детаљи: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 преузимање на чекању.}one{# преузимање на чекању.}few{# преузимања на чекању.}other{# преузимања на чекању.}}</translation>
-<translation id="1145536944570833626">Избришите постојеће податке</translation>
-<translation id="1146678959555564648">Уђи у ВР</translation>
-<translation id="116280672541001035">Искоришћено</translation>
-<translation id="1171770572613082465">Додирните дугме „Најпопуларнији веб-сајтови“ и видите те веб-сајтове</translation>
-<translation id="1173894706177603556">Преименуј</translation>
-<translation id="1178581264944972037">Паузирај</translation>
-<translation id="1181037720776840403">Уклони</translation>
-<translation id="1188239144602654184">Уђи у ПР</translation>
-<translation id="1197267115302279827">Премести обележиваче</translation>
-<translation id="119944043368869598">Обриши све</translation>
-<translation id="1201402288615127009">Даље</translation>
-<translation id="1204037785786432551">Преузми линк</translation>
-<translation id="1206892813135768548">Копирај текст линка</translation>
-<translation id="1208340532756947324">Да бисте синхронизовали и персонализовали садржај на уређајима, укључите синхронизацију</translation>
-<translation id="1209206284964581585">Сакриј за сада</translation>
-<translation id="1227058898775614466">Историја навигације</translation>
-<translation id="1231733316453485619">Желите ли да укључите синхронизацију?</translation>
-<translation id="123724288017357924">Поновно учитавање актуелне странице, занемарујући кеширани садржај</translation>
-<translation id="124116460088058876">Још језика</translation>
-<translation id="124678866338384709">Затварање актуелне картице</translation>
-<translation id="1258753120186372309">Google дудл логотип: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Претражујте и истражујте</translation>
-<translation id="1264974993859112054">Спорт</translation>
-<translation id="1266864766717917324">Није успело дељење: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Заустави</translation>
-<translation id="1283039547216852943">Додирните да бисте проширили</translation>
-<translation id="1285320974508926690">Никад не преводи овај сајт</translation>
-<translation id="1291207594882862231">Обришите историју, колачиће, податке о сајтовима, кеш...</translation>
-<translation id="129382876167171263">Датотеке које су сачували веб-сајтови приказују се овде</translation>
-<translation id="129553762522093515">Недавно затворено</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – послато је са уређаја <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Групиши картице</translation>
-<translation id="1327257854815634930">Историја навигације је отворена</translation>
-<translation id="1331212799747679585">Chrome не може да се ажурира. Још опција</translation>
-<translation id="1332501820983677155">Пречице за Google Chrome функције</translation>
-<translation id="1360432990279830238">Одјављујете се и искључујете синхрониз?</translation>
-<translation id="1369915414381695676">Сајт <ph name="SITE_NAME" /> је додат</translation>
-<translation id="1373696734384179344">Нема довољно меморије за преузимање изабраног садржаја.</translation>
-<translation id="1376578503827013741">Рачуна се…</translation>
-<translation id="1383876407941801731">Претражи</translation>
-<translation id="1384959399684842514">Преузимање је паузирано</translation>
-<translation id="1386674309198842382">Последња активност: пре <ph name="LAST_UPDATED" /> дан/а</translation>
-<translation id="1397811292916898096">Претражите помоћу: <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Уграђено је у сајт <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">„Не прати“</translation>
-<translation id="1407135791313364759">Отвори све</translation>
-<translation id="1409426117486808224">Поједностављен приказ отворених картица</translation>
-<translation id="1409879593029778104">Преузимање датотеке <ph name="FILE_NAME" /> је спречено јер она већ постоји.</translation>
-<translation id="1414981605391750300">Контактирамо Google. То може мало да потраје...</translation>
-<translation id="1416550906796893042">Верзија апликације</translation>
-<translation id="1430915738399379752">Штампај</translation>
-<translation id="1446450296470737166">Пуна контрола над MIDI уређајима</translation>
-<translation id="1450753235335490080">Није успело дељење: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Искључено је у Android подешавањима</translation>
-<translation id="1477626028522505441">Преузимање датотеке <ph name="FILE_NAME" /> није успело због проблема на серверу.</translation>
-<translation id="1506061864768559482">Претраживач</translation>
-<translation id="1513352483775369820">Обележивачи и веб-историја</translation>
-<translation id="1513858653616922153">Избриши лозинку</translation>
-<translation id="1516229014686355813">Функција „Додирните за претрагу“ шаље изабрану реч и актуелну страницу као контекст у Google претрагу. Можете да је искључите у <ph name="BEGIN_LINK" />Подешавањима<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Активан је данас</translation>
-<translation id="1544826120773021464">Да бисте управљали Google налогом, додирните дугме „Управљајте налогом“</translation>
-<translation id="1549000191223877751">Премести у други прозор</translation>
-<translation id="1553358976309200471">Ажурирај Chrome</translation>
-<translation id="1569387923882100876">Повезани уређај</translation>
-<translation id="1571304935088121812">Копирај корисничко име</translation>
-<translation id="1612196535745283361">Chrome-у је потребан приступ локацији да би тражио уређаје. Приступ локацији је <ph name="BEGIN_LINK" />искључен за овај уређај<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Камера</translation>
-<translation id="1623104350909869708">Спречи ову страницу да прави додатне дијалоге</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Уклони 1 изабрану ставку}one{Уклони # изабрану ставку}few{Уклони # изабране ставке}other{Уклони # изабраних ставки}}</translation>
-<translation id="164269334534774161">Приказује се офлајн копија ове странице од <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Историја</translation>
-<translation id="1647391597548383849">Приступ камери</translation>
-<translation id="1660204651932907780">Дозволи сајтовима да пуштају звук (препоручено)</translation>
-<translation id="1670399744444387456">Основна</translation>
-<translation id="1671236975893690980">Преузимање је на чекању…</translation>
-<translation id="1672586136351118594">Не приказуј поново</translation>
-<translation id="1692118695553449118">Синхронизација је укључена</translation>
-<translation id="169515064810179024">Не дозвољавај сајтовима да приступају сензорима за покрет</translation>
-<translation id="1717218214683051432">Сензори покрета</translation>
-<translation id="1718835860248848330">Последњих сат времена</translation>
-<translation id="1736419249208073774">Истражи</translation>
-<translation id="1743802530341753419">Питај пре него што дозволиш сајтовима да се повезују са уређајем (препоручено)</translation>
-<translation id="1749561566933687563">Синхронизујте обележиваче</translation>
-<translation id="17513872634828108">Отворене картице</translation>
-<translation id="1779089405699405702">Декодер слика</translation>
-<translation id="1782483593938241562">Датум завршетка: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Инсталирано</translation>
-<translation id="1792959175193046959">Промените подразумевану локацију за преузимање у било ком тренутку</translation>
-<translation id="1807246157184219062">Светлa</translation>
-<translation id="1810845389119482123">Почетно подешавање синхронизације није завршено</translation>
-<translation id="1821253160463689938">Користи колачиће да би се запамтила подешавања, чак и када не посећујете те странице</translation>
-<translation id="1829244130665387512">Пронађи на страници</translation>
-<translation id="1853692000353488670">Нова картица без архивирања</translation>
-<translation id="1856325424225101786">Желите ли да ресетујете Lite режим?</translation>
-<translation id="1868024384445905608">Chrome сада брже преузима датотеке</translation>
-<translation id="1883903952484604915">Моје датотеке</translation>
-<translation id="1887786770086287077">Приступ локацији је искључен за овај уређај. Укључите га у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> ће се отворити у Chrome-у. Ако наставите, прихватате Chrome <ph name="BEGIN_LINK1" />услове коришћења услуге<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />обавештење о приватности<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Огласи</translation>
-<translation id="1919950603503897840">Изаберите контакте</translation>
-<translation id="1922076542920281912">Да бисте дозволили да Chrome приступа локацији, укључите локацију и у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Ажурирања</translation>
-<translation id="19288952978244135">Поново отворите Chrome.</translation>
-<translation id="1933845786846280168">Изабране картице</translation>
-<translation id="194341124344773587">Укључите дозволу за Chrome у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Сачувај лозинке</translation>
-<translation id="1952172573699511566">Веб-сајтови ће приказивати текст на жељеном језику када је то могуће.</translation>
-<translation id="1960290143419248813">Chrome ажурирања више нису подржана за ову верзију Android-а</translation>
-<translation id="1966710179511230534">Ажурирајте податке за пријављивање.</translation>
-<translation id="1974060860693918893">Напредне опције</translation>
-<translation id="1984705450038014246">Синхронизујте Chrome податке</translation>
-<translation id="1984937141057606926">Дозвољени, осим треће стране</translation>
-<translation id="1986685561493779662">Назив већ постоји</translation>
-<translation id="1987739130650180037">Дугме <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Прегледај</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> жели да се упари</translation>
-<translation id="1994173015038366702">URL сајта</translation>
-<translation id="2000419248597011803">Подразумеваном претраживачу шаље неке колачиће и претраге из траке за адресу и оквира за претрагу</translation>
-<translation id="2002537628803770967">Кредитне картице и адресе из Google Pay-а</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# датотека}one{# датотека}few{# датотеке}other{# датотека}}</translation>
-<translation id="2017836877785168846">Брише историју и аутоматска довршавања у траци за адресу.</translation>
-<translation id="2021896219286479412">Контроле сајта на целом екрану</translation>
-<translation id="2038563949887743358">Укључи захтевање верзије сајта за рачунаре</translation>
-<translation id="2041019821020695769">Да бисте дозволили да вам Chrome шаље обавештења, укључите обавештења и у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> такође има податке у Chrome-у</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Сајт је паузиран</translation>
-<translation id="2063713494490388661">Додирните за претрагу</translation>
-<translation id="2067805253194386918">текст</translation>
-<translation id="2079545284768500474">Опозови</translation>
-<translation id="2082238445998314030"><ph name="RESULT_NUMBER" />. од <ph name="TOTAL_RESULTS" /> резултата</translation>
-<translation id="2091887806945687916">Звук</translation>
-<translation id="2096012225669085171">Синхронизација и персонализација на свим уређајима</translation>
-<translation id="2100273922101894616">Аутоматско пријављивање</translation>
-<translation id="2100314319871056947">Пробајте да делите текст у мањим деловима</translation>
-<translation id="2107397443965016585">Упит се приказује пре него што дозволите сајтовима да пуштају заштићени садржај (препоручено)</translation>
-<translation id="2111511281910874386">Иди на страницу</translation>
-<translation id="2122601567107267586">Отварање апликације није успело</translation>
-<translation id="2126426811489709554">Омогућава Chrome</translation>
-<translation id="2131665479022868825">Сачувано: <ph name="DATA" /></translation>
-<translation id="213279576345780926">Затворили сте картицу <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Додај на почетни екран</translation>
-<translation id="2146738493024040262">Отвори инстант апликацију</translation>
-<translation id="2148716181193084225">Данас</translation>
-<translation id="2154484045852737596">Измените картицу</translation>
-<translation id="2154710561487035718">Копирање URL адресе</translation>
-<translation id="2156074688469523661">Преостали сајтови (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Да бисте делили садржај телефона са другим уређајем, укључите синхронизацију у подешавањима Chrome-а на оба уређаја</translation>
-<translation id="2170088579611075216">Дозволи и започни ВР презентацију</translation>
-<translation id="218608176142494674">Дељење</translation>
-<translation id="2227444325776770048">Настави као <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Синхронизација и Google услуге</translation>
-<translation id="2259659629660284697">Извези лозинке…</translation>
-<translation id="2268044343513325586">Прецизирај</translation>
-<translation id="2286841657746966508">Адреса за наплату</translation>
-<translation id="2289270750774289114">Питај када сајт жели да открије Bluetooth уређаје у близини (препоручено)</translation>
-<translation id="230115972905494466">Није пронађен ниједан компатибилан уређај</translation>
-<translation id="2315043854645842844">Оперативни систем не подржава избор сертификата за клијента.</translation>
-<translation id="2318045970523081853">Додирните да бисте упутили позив</translation>
-<translation id="2321086116217818302">Припремају се лозинке...</translation>
-<translation id="2321958826496381788">Превлачите клизач док ово не будете могли лако да прочитате. Када двапут додирнете пасус, текст треба да буде бар оволики.</translation>
-<translation id="2323763861024343754">Меморијски простор за сајт</translation>
-<translation id="2328985652426384049">Не могу да се пријавим</translation>
-<translation id="2330129964253841015">Упозори ме ако су лозинке угрожене</translation>
-<translation id="2349710944427398404">Сви подаци које користи Chrome, укључујући налоге, обележиваче и сачувана подешавања</translation>
-<translation id="2353636109065292463">Проверава се интернет веза</translation>
-<translation id="2359808026110333948">Наставите</translation>
-<translation id="2369533728426058518">отворене картице</translation>
-<translation id="2387895666653383613">Промена величине текста</translation>
-<translation id="2394602618534698961">Датотеке које преузимате се појављују овде</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Ова функција се укључује када се пријавите на Google налог</translation>
-<translation id="2410754283952462441">Изаберите налог</translation>
-<translation id="2414886740292270097">Тамнa</translation>
-<translation id="2416359993254398973">Chrome тражи дозволу да приступи камери за овај сајт.</translation>
-<translation id="2426805022920575512">Изаберите други налог</translation>
-<translation id="2433507940547922241">Изглед</translation>
-<translation id="2434158240863470628">Преузимање је завршено <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Приступ локацији</translation>
-<translation id="2450083983707403292">Да ли желите да поново почнете да преузимате датотеку <ph name="FILE_NAME" />?</translation>
-<translation id="2482878487686419369">Обавештења</translation>
-<translation id="2490684707762498678">Управља <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google помоћник у Chrome-у</translation>
-<translation id="2496180316473517155">Историја прегледања</translation>
-<translation id="2497852260688568942">Администратор је онемогућио синхронизацију</translation>
-<translation id="2498359688066513246">Помоћ и повратне информације</translation>
-<translation id="2501278716633472235">Назад</translation>
-<translation id="2513403576141822879">Више подешавања у вези са приватношћу, безбедношћу и прикупљањем података потражите у одељку <ph name="BEGIN_LINK" />Синхронизација и Google услуге<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">У Lite режиму Chrome учитава странице брже и користи и до 60 процената мање података. Да би оптимизовао странице које посећујете, Chrome шаље Google-у ваш саобраћај на вебу. <ph name="BEGIN_LINK" />Сазнајте више<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">URL-ови страница које посећујете се шаљу Google-у</translation>
-<translation id="2532336938189706096">Веб-приказ</translation>
-<translation id="2534155362429831547">Избрисаних ставки: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Прегледате офлајн копију ове странице</translation>
-<translation id="2546283357679194313">Колачићи и подаци о сајтовима</translation>
-<translation id="2567385386134582609">СЛИКА</translation>
-<translation id="257088987046510401">Теме</translation>
-<translation id="2570922361219980984">Приступ локацији је искључен и за овај уређај. Укључите га у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Проширено је – Кликните да бисте скупили.</translation>
-<translation id="2581165646603367611">Овим ћете обрисати колачиће, кеш и друге податке сајтова које Chrome не сматра важним.</translation>
-<translation id="2586657967955657006">Меморија</translation>
-<translation id="2587052924345400782">Доступна је новија верзија</translation>
-<translation id="2593272815202181319">Фиксне ширине</translation>
-<translation id="2612676031748830579">Број картице</translation>
-<translation id="2621115761605608342">Дозволите JavaScript за одређени сајт.</translation>
-<translation id="2625189173221582860">Лозинка је копирана</translation>
-<translation id="2631006050119455616">Сачувано</translation>
-<translation id="2647434099613338025">Додај језик</translation>
-<translation id="2650751991977523696">Преузимате датотеку поново?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудио датотека}one{# аудио датотека}few{# аудио датотеке}other{# аудио датотека}}</translation>
-<translation id="2653659639078652383">Пошаљи</translation>
-<translation id="2677748264148917807">Затвори</translation>
-<translation id="2704606927547763573">Копирано</translation>
-<translation id="2707726405694321444">Освежи страницу</translation>
-<translation id="2709516037105925701">Аутоматско попуњавање</translation>
-<translation id="2717722538473713889">Имејл адресе</translation>
-<translation id="2728754400939377704">Сортирај по сајту</translation>
-<translation id="2744248271121720757">Додирните реч да бисте је тренутно претражили или видели повезане радње</translation>
-<translation id="2760989362628427051">Укључите тамну тему када је тамна тема или Уштеда батерије укључена на уређају</translation>
-<translation id="2762000892062317888">малопре</translation>
-<translation id="2777555524387840389">Још <ph name="SECONDS" /> сек</translation>
-<translation id="2779651927720337254">није успело</translation>
-<translation id="2781151931089541271">Још 1 сек</translation>
-<translation id="2801022321632964776">Ажурирајте на најновију верзију Chrome-а да бисте имали свој језик у њој</translation>
-<translation id="2810645512293415242">Страница је поједностављена ради уштеде на подацима и бржег учитавања.</translation>
-<translation id="281504910091592009">Прегледајте сачуване лозинке и управљајте њима на <ph name="BEGIN_LINK" />Google налогу<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Да би вам обележивачи били доступни на свим уређајима, пријавите се и укључите синхронизацију</translation>
-<translation id="2822354292072154809">Желите ли стварно да ресетујете све дозволе за сајт за <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Додирните дугме Назад да бисте изашли из режима целог екрана.</translation>
-<translation id="2842985007712546952">Надређени директоријум</translation>
-<translation id="2858138569776157458">Најбољи сајтови</translation>
-<translation id="2860954141821109167">Уверите се да је нека апликација за телефон омогућена на овом уређају</translation>
-<translation id="2870560284913253234">Сајт</translation>
-<translation id="2874939134665556319">Претходна песма</translation>
-<translation id="2876369937070532032">Шаље URL-ове неких страница које посећујете Google-у када је безбедност угрожена</translation>
-<translation id="2888126860611144412">О Chrome прегледачу</translation>
-<translation id="2891154217021530873">Заустави учитавање странице</translation>
-<translation id="2893180576842394309">Google може да користи историју за персонализацију Претраге и других Google услуга</translation>
-<translation id="2898264748040935573">Измените сачувану лозинку</translation>
-<translation id="2900528713135656174">Направите догађај</translation>
-<translation id="290376772003165898">Ова страница није на језику <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Листа уређаја са којима се дели картица је отворена у пуној висини.</translation>
-<translation id="2910701580606108292">Питај пре него што дозволиш сајтовима да пуштају заштићени садржај</translation>
-<translation id="2913331724188855103">Дозволи сајтовима да чувају и читају податке колачића (препоручује се)</translation>
-<translation id="2923908459366352541">Назив је неважећи</translation>
-<translation id="2932150158123903946">Меморијски простор за Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Картица за преглед је затворена</translation>
-<translation id="2956410042958133412">Овим налогом управљају <ph name="PARENT_NAME_1" /> и <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Пребацили сте на картице без архивирања</translation>
-<translation id="2968755619301702150">Приказивач сертификата</translation>
-<translation id="2979025552038692506">Изабране картице без архивирањa</translation>
-<translation id="2987620471460279764">Текст који се дели са другог уређаја</translation>
-<translation id="2989523299700148168">Недавно посећено</translation>
-<translation id="2996291259634659425">Направите приступну фразу</translation>
-<translation id="2996809686854298943">URL је обавезан</translation>
-<translation id="300526633675317032">Овим ћете обрисати цео меморијски простор веб-сајта од <ph name="SIZE_IN_KB" />.</translation>
-<translation id="3016635187733453316">Уверите се да је уређај повезан на интернет</translation>
-<translation id="3029613699374795922">Преузели сте <ph name="KBS" /> kB</translation>
-<translation id="3029704984691124060">Приступне фразе се не подударају</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Потражите помоћ<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Локација је искључена; укључите је у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Можете да укључите синхронизацију у подешавањима у било ком тренутку</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> обележивач}one{<ph name="BOOKMARKS_COUNT_MANY" /> обележивач}few{<ph name="BOOKMARKS_COUNT_MANY" /> обележивача}other{<ph name="BOOKMARKS_COUNT_MANY" /> обележивача}}</translation>
-<translation id="3089395242580810162">Отвори на картици без архив.</translation>
-<translation id="3115898365077584848">Прикажи информације</translation>
-<translation id="3123473560110926937">Блокирано на неким сајтовима</translation>
-<translation id="3137521801621304719">Изађи из режима без архивирања</translation>
-<translation id="3143515551205905069">Откажи синхронизацију</translation>
-<translation id="3157842584138209013">Погледајте колико сте података уштедели помоћу дугмета Још опција</translation>
-<translation id="3166827708714933426">Пречице за картице и прозоре</translation>
-<translation id="3181954750937456830">Безбедно прегледање (штити вас и уређај од опасних сајтова)</translation>
-<translation id="3190152372525844641">Укључите дозволе за Chrome у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> сачуваних података</translation>
-<translation id="3205824638308738187">Скоро завршено!</translation>
-<translation id="3207960819495026254">Обележено</translation>
-<translation id="3211426585530211793">Ставка <ph name="ITEM_TITLE" /> је избрисана</translation>
-<translation id="321773570071367578">Ако сте заборавили приступну фразу или желите да промените ово подешавање, <ph name="BEGIN_LINK" />ресетујте синхронизацију<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Микрофон</translation>
-<translation id="3232754137068452469">Веб-апликација</translation>
-<translation id="3236059992281584593">Још 1 мин</translation>
-<translation id="3244271242291266297">ММ</translation>
-<translation id="3254409185687681395">Обележите ову страницу</translation>
-<translation id="3259831549858767975">Умањивање целокупног приказа странице</translation>
-<translation id="3269093882174072735">Учитај слику</translation>
-<translation id="3269956123044984603">Да би вам биле доступне картице са других уређаја, укључите опцију „Аутоматски синхронизуј податке“ у Android подешавањима на налогу.</translation>
-<translation id="3277252321222022663">Дозволи сајтовима да приступају сензорима (препоручено)</translation>
-<translation id="3282568296779691940">Пријављивање у Chrome</translation>
-<translation id="3288003805934695103">да поново учитате страницу</translation>
-<translation id="32895400574683172">Обавештења су дозвољена</translation>
-<translation id="3295530008794733555">Прегледајте брже. Користите мање података.</translation>
-<translation id="3295602654194328831">Сакриј информације</translation>
-<translation id="3298243779924642547">Лагано</translation>
-<translation id="3303414029551471755">Желите ли да наставите са преузимањем садржаја?</translation>
-<translation id="3306398118552023113">Ова апликација је активна у Chrome-у</translation>
-<translation id="3315103659806849044">Тренутно прилагођавате подешавања Синхронизације и Google услуга. Да бисте довршили укључивање синхронизације, додирните дугме Потврди у дну екрана. Иди нагоре</translation>
-<translation id="3328801116991980348">Информације о сајту</translation>
-<translation id="3333961966071413176">Сви контакти</translation>
-<translation id="3334729583274622784">Желите да промените екстензију датотеке?</translation>
-<translation id="3341058695485821946">Погледајте колико сте података уштедели</translation>
-<translation id="3350687908700087792">Затвори све картице без архивирања</translation>
-<translation id="3353615205017136254">Поједностављену страницу пружа Google. Додирните дугме Учитај првобитну страницу да бисте учитали првобитну страницу.</translation>
-<translation id="3367813778245106622">Пријавите се поново да бисте започели синхронизацију</translation>
-<translation id="3374023511497244703">Обележивачи, историја, лозинке и други Chrome подаци више се неће синхронизовати са Google налогом</translation>
-<translation id="3384347053049321195">Дели слику</translation>
-<translation id="3386292677130313581">Питај пре него што дозволиш сајтовима да знају локацију (препоручено)</translation>
-<translation id="3387650086002190359">Преузимање датотеке <ph name="FILE_NAME" /> није успело због грешака система датотека.</translation>
-<translation id="3389286852084373014">Текст је превелик</translation>
-<translation id="3398320232533725830">Отварање Менаџера обележивача</translation>
-<translation id="3414952576877147120">Величина:</translation>
-<translation id="3443221991560634068">Поновно учитавање актуелне странице</translation>
-<translation id="3445014427084483498">Малопре</translation>
-<translation id="3478363558367712427">Можете да одаберете претраживач</translation>
+<translation id="6910211073230771657">Избрисано</translation>
+<translation id="6965382102122355670">Потврди</translation>
+<translation id="5301954838959518834">Важи</translation>
+<translation id="7658239707568436148">Откажи</translation>
 <translation id="3479552764303398839">Не сада</translation>
-<translation id="3492207499832628349">Нова картица без архивирања</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Сазнајте више<ph name="END_LINK" /> о предложеном садржају</translation>
-<translation id="3513704683820682405">Проширена реалност</translation>
-<translation id="3518985090088779359">Прихвати и настави</translation>
-<translation id="3522247891732774234">Ажурирање је доступно. Још опција</translation>
-<translation id="3524138585025253783">Кориснички интерфејс за програмере</translation>
-<translation id="3527085408025491307">Директоријум</translation>
-<translation id="3542235761944717775">Доступно је <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Претражите своју историју</translation>
-<translation id="3557336313807607643">Додај у контакте</translation>
-<translation id="3566923219790363270">Chrome се још припрема за ВР. Касније рестартујте Chrome.</translation>
-<translation id="3568688522516854065">Да би вам картице биле доступне на другим уређајима, пријавите се и укључите синхронизацију</translation>
-<translation id="3587482841069643663">Све</translation>
-<translation id="358794129225322306">Дозволите сајту да аутоматски преузима више датотека.</translation>
-<translation id="3590487821116122040">Меморијски простор за сајтове који Chrome не сматра важним (нпр. сајтови без сачуваних подешавања или сајтови које не посећујете често)</translation>
-<translation id="3599863153486145794">Брише историју са свих уређаја на којима сте пријављени. Google налог може да има друге облике историје прегледања на <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Искључи звук сајтова који пуштају звук</translation>
-<translation id="3616113530831147358">Аудио</translation>
-<translation id="3631987586758005671">Дели се са: <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Откриј лозинку</translation>
-<translation id="363596933471559332">Аутоматски се пријављујте на веб-сајтове помоћу сачуваних акредитива. Када је ова функција искључена, тражићемо вам да се верификујете пре сваког пријављивања на веб-сајт.</translation>
-<translation id="3658159451045945436">Ресетовањем ћете обрисати историју Уштеде података, укључујући листу сајтова које сте посетили.</translation>
-<translation id="3692944402865947621">Преузимање датотеке <ph name="FILE_NAME" /> није успело зато што локација меморијског простора није доступна.</translation>
-<translation id="3714981814255182093">Отварање траке за тражење</translation>
-<translation id="3716182511346448902">Ова страница користи превише меморије, па ју је Chrome паузирао.</translation>
-<translation id="3730075448226062617">Да бисте дозволили да Chrome приступа микрофону, укључите микрофон и у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Обележено у <ph name="PRODUCT_NAME" />-у</translation>
-<translation id="3744111561329211289">Синхронизација у позадини</translation>
-<translation id="3771001275138982843">Преузимање ажурирања није успело</translation>
-<translation id="3771033907050503522">Картице Без архивирања</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Укључите Bluetooth<ph name="END_LINK" /> да бисте омогућили упаривање</translation>
-<translation id="3775705724665058594">Пошаљите на своје уређаје</translation>
-<translation id="3778956594442850293">Додато је на почетни екран</translation>
-<translation id="3789841737615482174">Инсталирај</translation>
-<translation id="3810838688059735925">Видео</translation>
-<translation id="3810973564298564668">Промени</translation>
-<translation id="381841723434055211">Бројеви телефона</translation>
-<translation id="3819178904835489326">Избрисана преузимања: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Бришете меморију сајта?</translation>
-<translation id="385051799172605136">Назад</translation>
-<translation id="3859306556332390985">Премотај унапред</translation>
-<translation id="3894427358181296146">Додајте директоријум</translation>
-<translation id="3895926599014793903">Принудно омогући зумирање</translation>
-<translation id="3912508018559818924">Траже се најбољи подаци са веба…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Комбинуј податке</translation>
-<translation id="393697183122708255">Није доступна нијед. омогућ. глас. прет.</translation>
-<translation id="395206256282351086">Предлози за претрагу и сајтове су онемогућени</translation>
-<translation id="3955193568934677022">Дозволи сајтовима да пуштају заштићени садржај (препоручено)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome ће учитати страницу када буде спремна}one{Chrome ће учитати странице када буду спремне}few{Chrome ће учитати странице када буду спремне}other{Chrome ће учитати странице када буду спремне}}</translation>
-<translation id="3963007978381181125">Шифровање помоћу приступне фразе не обухвата начине плаћања и адресе из Google Pay-а. Само неко ко има приступну фразу може да чита шифроване податке. Приступна фраза се не шаље Google-у нити је он чува. Ако заборавите приступну фразу или пожелите да промените ово подешавање, треба да ресетујете синхронизацију. <ph name="BEGIN_LINK" />Сазнајте више<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Преузимање је довршено</translation>
-<translation id="397583555483684758">Синхронизација више не функционише</translation>
-<translation id="3976396876660209797">Уклоните и поново направите ову пречицу</translation>
-<translation id="3985215325736559418">Желите ли стварно да поново преузмете <ph name="FILE_NAME" />?</translation>
-<translation id="3987993985790029246">Копирај линк</translation>
-<translation id="3988213473815854515">Локација је дозвољена</translation>
-<translation id="3988466920954086464">Погледајте инстант резултате претраге на овој табли</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Неважан меморијски простор</translation>
-<translation id="4000212216660919741">Офлајн почетна страница</translation>
+<translation id="5317780077021120954">Сачувај</translation>
+<translation id="4570913071927164677">Детаљи</translation>
+<translation id="8730621377337864115">Готово</translation>
+<translation id="8261506727792406068">Избриши</translation>
+<translation id="1181037720776840403">Уклони</translation>
+<translation id="5939518447894949180">Ресетуј</translation>
 <translation id="4002066346123236978">Наслов</translation>
-<translation id="4008040567710660924">Омогућава колачиће за одређени сајт.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ч}one{# ч}few{# ч}other{# ч}}</translation>
-<translation id="4046123991198612571">Следећа песма</translation>
-<translation id="4048707525896921369">Сазнајте више о темама на веб-сајтовима без напуштања странице. Функција „Додирните за претрагу“ шаље реч и њен контекст у Google претрагу и приказује дефиниције, слике, резултате претраге и друге детаље.
+<translation id="5916664084637901428">Укључено</translation>
+<translation id="5860033963881614850">Искључено</translation>
+<translation id="6165508094623778733">Сазнајте више</translation>
+<translation id="6042308850641462728">Још</translation>
+<translation id="6040143037577758943">Затвори</translation>
+<translation id="780301667611848630">Не, хвала</translation>
+<translation id="1201402288615127009">Даље</translation>
+<translation id="2359808026110333948">Наставите</translation>
+<translation id="2653659639078652383">Пошаљи</translation>
+<translation id="2079545284768500474">Опозови</translation>
+<translation id="7649070708921625228">Помоћ</translation>
+<translation id="2148716181193084225">Данас</translation>
+<translation id="7781829728241885113">Јуче</translation>
+<translation id="6945221475159498467">Изабери</translation>
+<translation id="7791543448312431591">Додај</translation>
+<translation id="6527303717912515753">Дели</translation>
+<translation id="1383876407941801731">Претражи</translation>
+<translation id="3115898365077584848">Прикажи информације</translation>
+<translation id="3295602654194328831">Сакриј информације</translation>
+<translation id="3987993985790029246">Копирај линк</translation>
+<translation id="2704606927547763573">Копирано</translation>
+<translation id="8725066075913043281">Пробајте поново</translation>
+<translation id="385051799172605136">Назад</translation>
+<translation id="8131740175452115882">Потврди</translation>
+<translation id="5300589172476337783">Прикажи</translation>
+<translation id="1124772482545689468">Корисник</translation>
+<translation id="8609465669617005112">Премести нагоре</translation>
+<translation id="6746124502594467657">Премести надоле</translation>
+<translation id="8249310407154411074">Премести на врх</translation>
+<translation id="8428213095426709021">Подешавања</translation>
+<translation id="2498359688066513246">Помоћ и повратне информације</translation>
+<translation id="8378714024927312812">Овим управља организација</translation>
+<translation id="9019902583201351841">Овим управљају твоји родитељи</translation>
+<translation id="4645575059429386691">Овим управља твој родитељ</translation>
+<translation id="4883854917563148705">Подешавања којима се управља не могу да се ресетују</translation>
+<translation id="4307992518367153382">Основна</translation>
+<translation id="1974060860693918893">Напредне опције</translation>
+<translation id="1146678959555564648">Уђи у ВР</translation>
+<translation id="987264212798334818">Опште</translation>
+<translation id="4275663329226226506">Медији</translation>
+<translation id="4759238208242260848">Преузимања</translation>
+<translation id="218608176142494674">Дељење</translation>
+<translation id="8004582292198964060">Прегледач</translation>
+<translation id="1105960400813249514">Снимање екрана</translation>
+<translation id="4875775213178255010">Предлози за садржај</translation>
+<translation id="2021896219286479412">Контроле сајта на целом екрану</translation>
+<translation id="4587589328781138893">Сајтови</translation>
+<translation id="4943703118917034429">Виртуелна реалност</translation>
+<translation id="1928696683969751773">Ажурирања</translation>
+<translation id="6064125863973209585">Довршена преузимања</translation>
+<translation id="5342314432463739672">Захтеви за дозволу</translation>
+<translation id="629730747756840877">налог</translation>
+<translation id="82609232232243542">Пријављивање у Brave</translation>
+<translation id="7956662517480676674">Синхронизација и Brave Software услуге</translation>
+<translation id="5294439808117722387">Тренутно прилагођавате подешавања Синхронизације и Brave Software услуга. Да бисте довршили укључивање синхронизације, додирните дугме Потврди у дну екрана. Иди нагоре</translation>
+<translation id="2096012225669085171">Синхронизација и персонализација на свим уређајима</translation>
+<translation id="1692118695553449118">Синхронизација је укључена</translation>
+<translation id="5514904542973294328">Онемогућио је администратор овог уређаја</translation>
+<translation id="6447211988989208781">Brave Software контроле активности</translation>
+<translation id="4882831918239250449">Контролишите начин на који се историја прегледања користи за персонализацију Претраге, огласа и других услуга</translation>
+<translation id="7431991332293347422">Контролишите како се историја прегледања користи за персонализовање Претраге и других услуга</translation>
+<translation id="6303969859164067831">Одјави ме и искључи синхронизацију</translation>
+<translation id="1125261911132334651">Управљајте Brave Software налогом</translation>
+<translation id="6406506848690869874">Синхронизација</translation>
+<translation id="714362445477979774">Синхронизујте Brave податке</translation>
+<translation id="4314815835985389558">Управљајте синхронизацијом</translation>
+<translation id="5428209950370661546">Друге Brave Software услуге</translation>
+<translation id="7704317875155739195">Аутоматски довршавај претраге и URL-ове</translation>
+<translation id="2000419248597011803">Подразумеваном претраживачу шаље неке колачиће и претраге из траке за адресу и оквира за претрагу</translation>
+<translation id="7981313251711023384">Странице се учитавају унапред ради бржег прегледања и претраживања</translation>
+<translation id="1821253160463689938">Користи колачиће да би се запамтила подешавања, чак и када не посећујете те странице</translation>
+<translation id="6697492270171225480">Приказуј предлоге за сличне странице када нека страница не може да се пронађе</translation>
+<translation id="8109318360573330108">Шаље Brave Software-у URL странице којој покушавате да приступите</translation>
+<translation id="8438566539970814960">Побољшај претраге и прегледање</translation>
+<translation id="284843628681142937">URL-ови страница које посећујете се шаљу Brave Software-у</translation>
+<translation id="7222718784508482526">Више подешавања у вези са приватношћу, безбедношћу и прикупљањем података потражите у одељку <ph name="BEGIN_LINK"/>Синхронизација и Brave Software услуге<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Помозите нам да побољшамо Brave-ове функције и учинак</translation>
+<translation id="9063160602596686558">Аутоматски шаље Brave Software-у статистику коришћења и извештаје о отказивању</translation>
+<translation id="4824958205181053313">Желите ли да откажете синхронизацију?</translation>
+<translation id="3058498974290601450">Можете да укључите синхронизацију у подешавањима у било ком тренутку</translation>
+<translation id="3143515551205905069">Откажи синхронизацију</translation>
+<translation id="1506061864768559482">Претраживач</translation>
+<translation id="55737423895878184">Локација и обавештења су дозвољени</translation>
+<translation id="3988213473815854515">Локација је дозвољена</translation>
+<translation id="32895400574683172">Обавештења су дозвољена</translation>
+<translation id="9040142327097499898">Обавештења су дозвољена. Локација је искључена за овај уређај.</translation>
+<translation id="305593374596241526">Локација је искључена; укључите је у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Недавно посећено</translation>
+<translation id="6433501201775827830">Изаберите претраживач</translation>
+<translation id="7177466738963138057">То можете да промените касније у подешавањима</translation>
+<translation id="3478363558367712427">Можете да одаберете претраживач</translation>
+<translation id="4910889077668685004">Апликације за плаћање</translation>
+<translation id="5152843274749979095">Није инсталирана ниједна подржана апликација</translation>
+<translation id="8812260976093120287">На неким веб-сајтовима можете да плаћате помоћу претходно наведених подржаних апликација за плаћање на уређају.</translation>
+<translation id="7764225426217299476">Додајте адресу</translation>
+<translation id="5595485650161345191">Измена адресе</translation>
+<translation id="5087580092889165836">Додај картицу</translation>
+<translation id="2154484045852737596">Измените картицу</translation>
+<translation id="6140912465461743537">Земља/регија</translation>
+<translation id="5659593005791499971">Имејл</translation>
+<translation id="4378154925671717803">Телефон</translation>
+<translation id="4807098396393229769">Име и презиме на картици</translation>
+<translation id="860043288473659153">Име власника картице</translation>
+<translation id="2612676031748830579">Број картице</translation>
+<translation id="869891660844655955">Датум истека</translation>
+<translation id="2286841657746966508">Адреса за наплату</translation>
+<translation id="663059986967017181">Копирана у Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}few{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}few{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}few{<ph name="CONTACT_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Лозинке</translation>
+<translation id="1943432128510653496">Сачувај лозинке</translation>
+<translation id="2100273922101894616">Аутоматско пријављивање</translation>
+<translation id="363596933471559332">Аутоматски се пријављујте на веб-сајтове помоћу сачуваних акредитива. Када је ова функција искључена, тражићемо вам да се верификујете пре сваког пријављивања на веб-сајт.</translation>
+<translation id="6995899638241819463">Упозори ме ако су лозинке откривене при упаду у податке</translation>
+<translation id="1534287762301776620">Ова функција се укључује када се пријавите на Brave Software налог</translation>
+<translation id="10614374240317010">Никада се не чува</translation>
+<translation id="3098842761938485917">Прегледајте сачуване лозинке и управљајте њима на <ph name="BEGIN_LINK"/>Brave Software налогу<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Сачуване лозинке ће се појавити овде.</translation>
+<translation id="8084114998886531721">Сачувана лозинка</translation>
+<translation id="2870560284913253234">Сајт</translation>
+<translation id="8503813439785031346">Корисничко име</translation>
+<translation id="6657585470893396449">Лозинка</translation>
+<translation id="2154710561487035718">Копирање URL адресе</translation>
+<translation id="1571304935088121812">Копирај корисничко име</translation>
+<translation id="5005498671520578047">Копирање лозинке</translation>
+<translation id="3632295766818638029">Откриј лозинку</translation>
+<translation id="1513858653616922153">Избриши лозинку</translation>
+<translation id="543338862236136125">Измените лозинку</translation>
+<translation id="4565377596337484307">Сакриј лозинку</translation>
+<translation id="8523928698583292556">Избриши сачувану лозинку</translation>
+<translation id="2898264748040935573">Измените сачувану лозинку</translation>
+<translation id="5433691172869980887">Корисничко име је копирано</translation>
+<translation id="5534640966246046842">Сајт је копиран</translation>
+<translation id="2625189173221582860">Лозинка је копирана</translation>
+<translation id="4550003330909367850">Да бисте прегледали или копирали лозинку овде, подесите закључавање екрана на овом уређају.</translation>
+<translation id="6154478581116148741">Укључите закључавање екрана у Подешавањима да бисте извезли лозинке са уређаја</translation>
+<translation id="4842092870884894799">Приказивање искачућег прозора за генерисање лозинке</translation>
+<translation id="2259659629660284697">Извези лозинке…</translation>
+<translation id="133012818630824069">Извезите лозинке сачуване у Brave-у</translation>
+<translation id="6914783257214138813">Лозинке ће бити видљиве свима који могу да виде извезену датотеку.</translation>
+<translation id="2321086116217818302">Припремају се лозинке...</translation>
+<translation id="8445448999790540984">Извоз лозинки није успео</translation>
+<translation id="3066461326500799725">Сазнајте како да користите Brave Software диск</translation>
+<translation id="729975465115245577">Уређај нема апликацију за чување датотеке са лозинкама.</translation>
+<translation id="7682724950699840886">Испробајте следеће савете: проверите да ли на уређају има довољно простора, па пробајте да поново извезете лозинке.</translation>
+<translation id="1129510026454351943">Детаљи: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Откључајте да бисте копирали лозинку</translation>
+<translation id="5515439363601853141">Откључајте да бисте прегледали лозинку</translation>
+<translation id="6221633008163990886">Откључајте да бисте извезли лозинке</translation>
+<translation id="230699814587342492">Лозинке за Brave</translation>
+<translation id="6075798973483050474">Измените почетну страницу</translation>
+<translation id="854522910157234410">Отвори ову страницу</translation>
+<translation id="2482878487686419369">Обавештења</translation>
+<translation id="6255999984061454636">Предлози за садржај</translation>
+<translation id="805047784848435650">На основу историје прегледања</translation>
+<translation id="1041308826830691739">Са веб-сајтова</translation>
+<translation id="395206256282351086">Предлози за претрагу и сајтове су онемогућени</translation>
+<translation id="257088987046510401">Теме</translation>
+<translation id="4650364565596261010">Подразумевана системска</translation>
+<translation id="7588219262685291874">Укључи тамну тему када је Уштеда батерије на уређају укључена</translation>
+<translation id="2760989362628427051">Укључите тамну тему када је тамна тема или Уштеда батерије укључена на уређају</translation>
+<translation id="6381421346744604172">Затамни веб-сајтове</translation>
+<translation id="5040262127954254034">Приватност</translation>
+<translation id="4991384657077828949">Помозите нам да побољшамо Brave безбедност</translation>
+<translation id="1943176487615318915">Да би откривао опасне апликације и сајтове, Brave шаље Brave Software-у URL-ове неких страница које посећујете, ограничене информације о систему и одређени садржај страница</translation>
+<translation id="3181954750937456830">Безбедно прегледање (штити вас и уређај од опасних сајтова)</translation>
+<translation id="7315322926489145388">Шаље URL-ове неких страница које посећујете Brave Software-у када је безбедност угрожена</translation>
+<translation id="2063713494490388661">Додирните за претрагу</translation>
+<translation id="2369463299479365221">Сазнајте више о темама на веб-сајтовима без напуштања странице. Функција „Додирните за претрагу“ шаље реч и њен контекст у Brave Software претрагу и приказује дефиниције, слике, резултате претраге и друге детаље.
 
 Да бисте прилагодили термин за претрагу, притисните и задржите да бисте га изабрали. Да бисте претрагу учинили прецизнијом, превуците таблу нагоре до краја и додирните оквир за претрагу.</translation>
-<translation id="4056223980640387499">Сепија</translation>
-<translation id="4060598801229743805">Опције су доступне при врху екрана</translation>
-<translation id="4062305924942672200">Правне информације</translation>
-<translation id="4084682180776658562">Обележивач</translation>
-<translation id="4084712963632273211">Од објављивача <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />приказује Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Желите ли да избришете податке апликације?</translation>
-<translation id="4099578267706723511">Побољшајте Chrome слањем статистике коришћења и извештаја о отказивању Google-у.</translation>
-<translation id="410351446219883937">Аутоплеј</translation>
-<translation id="4116038641877404294">Преузмите странице да бисте их користили офлајн</translation>
-<translation id="4135200667068010335">Листа уређаја са којима се дели картица је затворена.</translation>
-<translation id="4149994727733219643">Поједностављен приказ веб-страница</translation>
-<translation id="4165986682804962316">Подешавања сајта</translation>
-<translation id="4169535189173047238">Не дозволи</translation>
-<translation id="4170011742729630528">Услуга није доступна. Пробајте поново касније.</translation>
-<translation id="4179980317383591987">Искористили сте <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Језици</translation>
-<translation id="4183868528246477015">Тражи уз Google објектив <ph name="BEGIN_NEW" />Ново<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Отвори на новој картици</translation>
-<translation id="4198423547019359126">Нема доступних локација за преузимања</translation>
-<translation id="4209895695669353772">Да бисте добијали персонализовани садржај који предлаже Google, укључите синхронизацију</translation>
-<translation id="4226663524361240545">Уређај ће вибрирати када примате обавештења</translation>
-<translation id="423219824432660969">Шифрујте синхронизоване податке помоћу Google лозинке од <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Отвори подешавања</translation>
-<translation id="4256782883801055595">Лиценце отвореног кода</translation>
-<translation id="4259722352634471385">Навигација је блокирана: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Копирај адресу линка</translation>
-<translation id="4275663329226226506">Медији</translation>
-<translation id="4278390842282768270">Дозвољено</translation>
-<translation id="429312253194641664">Сајт пушта медијски садржај</translation>
-<translation id="4298388696830689168">Повезани сајтови</translation>
-<translation id="4307992518367153382">Основна</translation>
-<translation id="4314815835985389558">Управљајте синхронизацијом</translation>
-<translation id="4351244548802238354">Затвори дијалог</translation>
-<translation id="4378154925671717803">Телефон</translation>
-<translation id="4384468725000734951">Користите Sogou за претрагу</translation>
-<translation id="4404568932422911380">Нема обележивача</translation>
-<translation id="4405224443901389797">Премести у...</translation>
-<translation id="4411535500181276704">Lite режим</translation>
-<translation id="4415276339145661267">Управљајте Google налогом</translation>
-<translation id="4432792777822557199">Странице на језику <ph name="SOURCE_LANGUAGE" /> ће се од сада преводити на <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Поједностављену страницу пружа Google</translation>
-<translation id="4434045419905280838">Искачући прозори и преусмеравања</translation>
-<translation id="4440958355523780886">Поједностављену страницу пружа Google. Додирните да бисте учитали првобитну страницу.</translation>
-<translation id="4452411734226507615">Затвори картицу <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Обележивач је додат у <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Дозволите сајтовима да пуштају заштићени садржај</translation>
-<translation id="4468959413250150279">Искључи звук за одређени сајт</translation>
-<translation id="4472118726404937099">Да бисте синхронизовали и персонализовали садржај на уређајима, пријавите се и укључите синхронизацију</translation>
-<translation id="447252321002412580">Помозите нам да побољшамо Chrome-ове функције и учинак</translation>
-<translation id="4479647676395637221">Питај пре него што дозволиш сајтовима да користе камеру (препоручено)</translation>
-<translation id="4479972344484327217">Инсталира се <ph name="MODULE" /> за Chrome…</translation>
-<translation id="4487967297491345095">Сви подаци Chrome апликација ће бити трајно избрисани. То обухвата све датотеке, подешавања, налоге, базе података итд.</translation>
-<translation id="4493497663118223949">Lite режим је укључен</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Пре # дана}one{Пре # дана}few{Пре # дана}other{Пре # дана}}</translation>
-<translation id="451872707440238414">Претражите обележиваче</translation>
-<translation id="4521489764227272523">Изабрани подаци су уклоњени из Chrome-а и са синхронизованих уређаја.
-
-Google налог можда има друге облике историје прегледања, попут претрага и активности у другим Google услугама на <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Изаберите директоријум</translation>
-<translation id="4538018662093857852">Укључи Lite режим</translation>
-<translation id="4550003330909367850">Да бисте прегледали или копирали лозинку овде, подесите закључавање екрана на овом уређају.</translation>
-<translation id="4558311620361989323">Пречице за веб-странице</translation>
-<translation id="4561979708150884304">Веза није успостављена</translation>
-<translation id="4565377596337484307">Сакриј лозинку</translation>
-<translation id="4570913071927164677">Детаљи</translation>
-<translation id="4572422548854449519">Пријавите се на налог којим се управља</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Пре # минута}one{Пре # минута}few{Пре # минута}other{Пре # минута}}</translation>
-<translation id="4587589328781138893">Сајтови</translation>
-<translation id="4594952190837476234">Ова офлајн страница је од <ph name="CREATION_TIME" /> и може да се разликује од онлајн верзије.</translation>
-<translation id="4605958867780575332">Ставка је уклоњена: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Отвори <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Користи лозинку</translation>
-<translation id="4645575059429386691">Овим управља твој родитељ</translation>
-<translation id="4650364565596261010">Подразумевана системска</translation>
-<translation id="4663756553811254707">Избрисали сте <ph name="NUMBER_OF_BOOKMARKS" /> обележивача</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> је додат на почетни екран</translation>
-<translation id="4684427112815847243">Синхронизуј све</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}few{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Пошаљите SMS уређајима</translation>
-<translation id="4698034686595694889">Прегледајте офлајн у апликацији <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Кеширане слике и датотеке</translation>
-<translation id="4714588616299687897">Уштедите до 60% података</translation>
-<translation id="4719927025381752090">Понуди превод</translation>
-<translation id="4720023427747327413">Отвори у <ph name="PRODUCT_NAME" />-у</translation>
-<translation id="4720982865791209136">Помозите нам да побољшамо Chrome. <ph name="BEGIN_LINK" />Попуните анкету<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Ажурирај</translation>
-<translation id="4738836084190194332">Последња синхронизација: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Отворите нову картицу</translation>
-<translation id="4751476147751820511">Сензори за покрет или светло</translation>
-<translation id="4759238208242260848">Преузимања</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 преузимање је довршено.}one{# преузимање је довршено.}few{# преузимања су довршена.}other{# преузимања је довршено.}}</translation>
-<translation id="4797039098279997504">Додирните да бисте се вратили на <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Шифровање помоћу приступне фразе не обухвата начине плаћања и адресе из Google Pay-а.
-
-Да бисте променили ово подешавање, <ph name="BEGIN_LINK" />ресетујте синхронизацију<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Име и презиме на картици</translation>
-<translation id="4824958205181053313">Желите ли да откажете синхронизацију?</translation>
-<translation id="4837753911714442426">Отварање опција за штампање странице</translation>
-<translation id="4842092870884894799">Приказивање искачућег прозора за генерисање лозинке</translation>
-<translation id="4860895144060829044">Позовите</translation>
-<translation id="4866368707455379617">Инсталирање модула <ph name="MODULE" /> за Chrome није успело</translation>
-<translation id="4875775213178255010">Предлози за садржај</translation>
-<translation id="4878404682131129617">Успостављање тунела преко прокси сервера није успело</translation>
-<translation id="4880127995492972015">Преведи…</translation>
-<translation id="4881695831933465202">Отвори</translation>
-<translation id="488187801263602086">Преименујте датотеку</translation>
-<translation id="4882831918239250449">Контролишите начин на који се историја прегледања користи за персонализацију Претраге, огласа и других услуга</translation>
-<translation id="4883854917563148705">Подешавања којима се управља не могу да се ресетују</translation>
-<translation id="4885273946141277891">Неподржан број Chrome инстанци.</translation>
-<translation id="4910889077668685004">Апликације за плаћање</translation>
-<translation id="4913161338056004800">Ресетуј статистику</translation>
-<translation id="4913169188695071480">Заустави освежавање</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Потражите помоћ<ph name="END_LINK" /> док скенирате уређаје…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# страница}one{# страница}few{# странице}other{# страница}}</translation>
-<translation id="4932247056774066048">Пошто се одјављујете са налога којим управља <ph name="DOMAIN_NAME" />, Chrome подаци биће избрисани са овог уређаја. Остаће на вашем Google налогу.</translation>
-<translation id="4943703118917034429">Виртуелна реалност</translation>
-<translation id="4943872375798546930">Нема резултата</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> дели екран</translation>
-<translation id="4961107849584082341">Преведите ову страницу на било који језик</translation>
-<translation id="4962975101802056554">Опозовите све дозволе за уређај</translation>
-<translation id="4970824347203572753">Није доступно на вашој локацији</translation>
-<translation id="497421865427891073">Кретање унапред</translation>
-<translation id="4988210275050210843">Преузима се датотека (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Странице</translation>
-<translation id="4994033804516042629">Није пронађен ниједан контакт</translation>
-<translation id="4996978546172906250">Дељење преко</translation>
-<translation id="5004416275253351869">Google контроле активности</translation>
-<translation id="5005498671520578047">Копирање лозинке</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> жели да се повеже</translation>
-<translation id="5013696553129441713">Нема нових предлога</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Док сте у ВР режиму, овај сајт можда може да сазна нешто:
-  –  о вашим физичким карактеристикама, попут висине
-
-Уверите се да верујете овом сајту пре него што покренете ВР.</translation>
+<translation id="2930742481329940825">Функција „Додирните за претрагу“ шаље изабрану реч и актуелну страницу као контекст у Brave Software претрагу. Можете да је искључите у <ph name="BEGIN_LINK"/>Подешавањима<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Дозволи</translation>
-<translation id="5040262127954254034">Приватност</translation>
-<translation id="5048398596102334565">Дозволи сајтовима да приступају сензорима за покрет (препоручено)</translation>
-<translation id="5063480226653192405">Коришћење</translation>
-<translation id="5087580092889165836">Додај картицу</translation>
-<translation id="5100237604440890931">Скупљено је – Кликните да бисте проширили.</translation>
-<translation id="510275257476243843">Још 1 сат</translation>
-<translation id="5123685120097942451">Картица без архивирања</translation>
-<translation id="5127805178023152808">Синхронизација је искључена</translation>
-<translation id="5129038482087801250">Инсталирај веб-апликацију</translation>
-<translation id="5132942445612118989">Синхронизујте лозинке, историју и други садржај на свим уређајима</translation>
-<translation id="5139940364318403933">Сазнајте како да користите Google диск</translation>
-<translation id="515227803646670480">Обришите сачуване податке</translation>
-<translation id="5152843274749979095">Није инсталирана ниједна подржана апликација</translation>
-<translation id="5161254044473106830">Наслов је обавезан</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 преузимање није успело.}one{# преузимање није успело.}few{# преузимања нису успела.}other{# преузимања није успело.}}</translation>
-<translation id="5170568018924773124">Прикажи у директоријуму</translation>
-<translation id="5184329579814168207">Отвори у Chrome-у</translation>
-<translation id="5193988420012215838">Копирано је у привремену меморију</translation>
-<translation id="5197729504361054390">Контакти које изаберете ће се делити са <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Профил за Work</translation>
-<translation id="5210286577605176222">Прелазак на претходну картицу</translation>
-<translation id="5210365745912300556">Затвори картицу</translation>
-<translation id="5224771365102442243">Са видеом</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> жели да тражи Bluetooth уређаје у близини. Пронађени су следећи уређаји:</translation>
-<translation id="5233638681132016545">Нова картица</translation>
-<translation id="526421993248218238">Учитавање ове странице није успело</translation>
-<translation id="5271967389191913893">Уређај не може да отвори садржај за преузимање.</translation>
-<translation id="528192093759286357">Превуците од врха екрана и додирните дугме Назад да бисте изашли из режима целог екрана.</translation>
-<translation id="5292796745632149097">Пошаљите на</translation>
-<translation id="5300589172476337783">Прикажи</translation>
-<translation id="5301954838959518834">Важи</translation>
-<translation id="5304593522240415983">Ово поље не сме да буде празно</translation>
-<translation id="5307446750509046227">Обриши складиште сајта</translation>
-<translation id="5308380583665731573">Повезивање</translation>
-<translation id="5313967007315987356">Додајте сајт</translation>
-<translation id="5317780077021120954">Сачувај</translation>
-<translation id="5324858694974489420">Родитељска подешавања</translation>
-<translation id="5327248766486351172">Назив</translation>
-<translation id="5335288049665977812">Дозволи сајтовима да покрећу JavaScript (препоручено)</translation>
-<translation id="5342314432463739672">Захтеви за дозволу</translation>
-<translation id="5357811892247919462">Картица је примљена</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> отворена картица, додирните да бисте прешли на другу картицу}one{<ph name="OPEN_TABS_MANY" /> отворена картица, додирните да бисте прешли на другу картицу}few{<ph name="OPEN_TABS_MANY" /> отворене картице, додирните да бисте прешли на другу картицу}other{<ph name="OPEN_TABS_MANY" /> отворених картица, додирните да бисте прешли на другу картицу}}</translation>
-<translation id="5391532827096253100">Веза са овим сајтом није безбедна. Информације о сајту</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(и још 1)}one{(и још #)}few{(и још #)}other{(и још #)}}</translation>
-<translation id="5400569084694353794">Коришћењем ове апликације прихватате <ph name="BEGIN_LINK1" />Услове коришћења услуге<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />Обавештење о приватности<ph name="END_LINK2" /> за Chrome.</translation>
-<translation id="5403592356182871684">Имена</translation>
-<translation id="5403644198645076998">Дозволи само одређене сајтове</translation>
-<translation id="5414836363063783498">Верификују се...</translation>
-<translation id="5423934151118863508">Најчешће посећиване странице ће се појавити овде</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB је доступно</translation>
-<translation id="543338862236136125">Измените лозинку</translation>
-<translation id="5433691172869980887">Корисничко име је копирано</translation>
-<translation id="543509235395288790">Преузимају се датотеке (<ph name="COUNT" />: <ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Прелазак на траку за адресу</translation>
-<translation id="5447201525962359567">Целокупан меморијски простор за сајт, укључујући колачиће и друге локално сачуване податке</translation>
-<translation id="5447765697759493033">Овај сајт се неће преводити</translation>
-<translation id="545042621069398927">Преузимање се убрзава.</translation>
-<translation id="5456381639095306749">Преузми страницу</translation>
-<translation id="5475862044948910901">Желите ли да започнете сесију проширене реалности?</translation>
-<translation id="548278423535722844">Отворите у апликацији за мапе</translation>
-<translation id="5487521232677179737">Обриши податке</translation>
-<translation id="5494752089476963479">Блокирај огласе на сајтовима који приказују огласе који ометају активности или обмањујуће огласе</translation>
-<translation id="5500777121964041360">Можда није доступно на вашој локацији</translation>
-<translation id="5512137114520586844">Овим налогом управља <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Онемогућио је администратор овог уређаја</translation>
-<translation id="5515439363601853141">Откључајте да бисте прегледали лозинку</translation>
-<translation id="5516455585884385570">Отворите подешавања обавештења</translation>
-<translation id="5517095782334947753">Имате обележиваче, лозинке и остала подешавања из <ph name="FROM_ACCOUNT" /> налога.</translation>
-<translation id="5524843473235508879">Преусмеравање је блокирано.</translation>
-<translation id="5527082711130173040">Chrome-у је потребан приступ локацији да би тражио уређаје. <ph name="BEGIN_LINK1" />Ажурирајте дозволе<ph name="END_LINK1" />. Приступ локацији је такође <ph name="BEGIN_LINK2" />искључен за овај уређај<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Питај пре него што дозволиш сајтовима да читају текст и слике из привремене меморије (препоручено)</translation>
-<translation id="5530766185686772672">Затвори картице без архив.</translation>
-<translation id="5534334044554683961">Док сте у ВР режиму, овај сајт можда може да сазна нешто:
-  –  о вашим физичким карактеристикама, попут висине
-  –   о изгледу ваше собе
-
-Уверите се да верујете овом сајту пре него што покренете ВР.</translation>
-<translation id="5534640966246046842">Сајт је копиран</translation>
-<translation id="5556459405103347317">Учитај поново</translation>
-<translation id="5561549206367097665">Чека се мрежа...</translation>
-<translation id="557283862590186398">Chrome тражи дозволу да приступи микрофону за овај сајт.</translation>
-<translation id="55737423895878184">Локација и обавештења су дозвољени</translation>
-<translation id="5578795271662203820">Потражи ову слику на <ph name="SEARCH_ENGINE" />-у</translation>
-<translation id="5581519193887989363">Увек можете да одаберете шта ћете синхронизовати у <ph name="BEGIN_LINK1" />подешавањима<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Измена адресе</translation>
-<translation id="5596627076506792578">Још опција</translation>
-<translation id="5599455543593328020">Режим без архивирања</translation>
-<translation id="5620928963363755975">Пронађите датотеке и странице у Преузимањима помоћу дугмета Још опција</translation>
-<translation id="5626134646977739690">Име:</translation>
-<translation id="5639724618331995626">Дозволи све сајтове</translation>
-<translation id="5648166631817621825">Последњих 7 дана</translation>
-<translation id="5649053991847567735">Аутоматска преузимања</translation>
-<translation id="5655963694829536461">Претражите преузимања</translation>
-<translation id="5659593005791499971">Имејл</translation>
-<translation id="5665379678064389456">Направите догађај у апликацији <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Одбијање захтева веб-сајта да се спречи увећавање</translation>
-<translation id="5677928146339483299">Блокирано</translation>
-<translation id="5684874026226664614">Упс, превођење ове странице није успело.</translation>
-<translation id="5686790454216892815">Име датотеке је предугачко</translation>
-<translation id="5689516760719285838">Локација</translation>
-<translation id="569536719314091526">Преведите ову страницу на било који језик помоћу дугмета Још опција</translation>
-<translation id="572328651809341494">Недавно коришћене картице</translation>
-<translation id="5726692708398506830">Увећавање целокупног приказа странице</translation>
-<translation id="5748802427693696783">Пребацили сте на стандардне картице</translation>
-<translation id="5749068826913805084">Chrome-у је потребан приступ меморијском простору да би преузимао датотеке.</translation>
-<translation id="5763382633136178763">Картице без архивирања</translation>
-<translation id="5763514718066511291">Додирните да бисте копирали URL за ову апликацију</translation>
-<translation id="5765780083710877561">Опис:</translation>
-<translation id="5793665092639000975">Користи се <ph name="SPACE_USED" /> од <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google може да користи историју за персонализацију Претраге, огласа и других Google услуга</translation>
-<translation id="5804241973901381774">Дозволе</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Пре # сата}one{Пре # сата}few{Пре # сата}other{Пре # сати}}</translation>
-<translation id="5810288467834065221">Ауторска права <ph name="YEAR" />. Google LLC. Сва права задржана.</translation>
-<translation id="5817918615728894473">Упари</translation>
-<translation id="583281660410589416">Непознато</translation>
-<translation id="5833984609253377421">Дели линк</translation>
-<translation id="5836192821815272682">Преузима се ажурирање за Chrome…</translation>
-<translation id="5853623416121554550">паузирано</translation>
-<translation id="5854790677617711513">Старије од 30 дана</translation>
-<translation id="5858741533101922242">Chrome не може да укључи Bluetooth адаптер</translation>
-<translation id="5860033963881614850">Искључено</translation>
-<translation id="5862731021271217234">Да би вам картице биле доступне на другим уређајима, укључите синхронизацију</translation>
-<translation id="5864174910718532887">Детаљи: сортирано према називу сајта</translation>
-<translation id="5864419784173784555">Чека се друго преузимање...</translation>
-<translation id="5865733239029070421">Аутоматски шаље Google-у статистику коришћења и извештаје о отказивању</translation>
-<translation id="5869522115854928033">Сачуване лозинке</translation>
-<translation id="5902828464777634901">Сви локални подаци које овај веб-сајт чува, укључујући колачиће, биће избрисани.</translation>
-<translation id="5916664084637901428">Укључено</translation>
-<translation id="5919204609460789179">Ажурирајте <ph name="PRODUCT_NAME" /> да бисте започели синхронизацију</translation>
-<translation id="5937580074298050696">Уштедели сте <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Ресетуј</translation>
-<translation id="5942872142862698679">Користите Google за претрагу</translation>
-<translation id="5952764234151283551">Шаље Google-у URL странице којој покушавате да приступите</translation>
-<translation id="5956665950594638604">Отварање Chrome центра за помоћ на новој картици</translation>
-<translation id="5958275228015807058">Пронађите датотеке и странице у Преузимањима</translation>
-<translation id="5962718611393537961">Додирните да бисте скупили</translation>
-<translation id="6000066717592683814">Задржи Google</translation>
-<translation id="6005538289190791541">Предложена лозинка</translation>
-<translation id="6036057147555329831">Додатни ICU модул</translation>
-<translation id="6039379616847168523">Прелазак на следећу картицу</translation>
-<translation id="6040143037577758943">Затвори</translation>
-<translation id="6042308850641462728">Још</translation>
-<translation id="604996488070107836">Преузимање датотеке <ph name="FILE_NAME" /> није успело због непознате грешке.</translation>
-<translation id="605721222689873409">ГГ</translation>
-<translation id="6064125863973209585">Довршена преузимања</translation>
-<translation id="6075798973483050474">Измените почетну страницу</translation>
-<translation id="60923314841986378">Још <ph name="HOURS" /> сата/и</translation>
-<translation id="6108923351542677676">Подешавање је у току...</translation>
-<translation id="6111020039983847643">искоришћених података</translation>
-<translation id="6112702117600201073">Освежавање странице</translation>
-<translation id="6127379762771434464">Уклонили сте ставку</translation>
-<translation id="6140912465461743537">Земља/регија</translation>
-<translation id="614940544461990577">Покушајте:</translation>
-<translation id="6154478581116148741">Укључите закључавање екрана у Подешавањима да бисте извезли лозинке са уређаја</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> уштеде података</translation>
-<translation id="6165508094623778733">Сазнајте више</translation>
-<translation id="6177111841848151710">Блокирано је за актуелни претраживач</translation>
-<translation id="6181444274883918285">Додај изузетак за сајтове</translation>
-<translation id="6192333916571137726">Преузмите датотеку</translation>
-<translation id="6192792657125177640">Изузеци</translation>
-<translation id="6194112207524046168">Да бисте дозволили да Chrome приступа камери, укључите камеру и у <ph name="BEGIN_LINK" />Android подешавањима<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Блокирај колачиће треће стране</translation>
-<translation id="6206551242102657620">Веза је безбедна. Информације о сајту</translation>
-<translation id="6210748933810148297">Нисте <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Откључајте да бисте извезли лозинке</translation>
+<translation id="1406000523432664303">„Не прати“</translation>
 <translation id="6232535412751077445">Ако омогућите функцију „Не прати“, захтев ће бити обухваћен саобраћајем прегледања. Последица те радње зависи од тога да ли веб-сајт одговара на захтев и како се захтев тумачи.
 
 На пример, неки веб-сајтови могу да одговоре на овај захтев приказивањем огласа који нису засновани на другим веб-сајтовима које сте посетили. Многи веб-сајтови ће ипак прикупљати и користити податке прегледања, на пример, ради побољшања безбедности, пружања садржаја, огласа и препорука, као и ради генерисања статистике извештавања.</translation>
-<translation id="624789221780392884">Ажурирање је спремно</translation>
-<translation id="6255999984061454636">Предлози за садржај</translation>
-<translation id="6277522088822131679">Дошло је до проблема при штампању странице. Пробајте поново.</translation>
-<translation id="6295158916970320988">Сви сајтови</translation>
-<translation id="629730747756840877">налог</translation>
-<translation id="6303969859164067831">Одјави ме и искључи синхронизацију</translation>
-<translation id="6316139424528454185">Неподржана верзија Android-а</translation>
-<translation id="6320088164292336938">Вибрација</translation>
-<translation id="6324034347079777476">Синхронизација Android система је онемогућена</translation>
-<translation id="6333140779060797560">Дељење преко <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Шифровање</translation>
-<translation id="6341580099087024258">Питај где да сачуваш датотеке</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}few{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Желите ли да уклоните предлог из историје?</translation>
-<translation id="6369229450655021117">Ту можете да претражујете веб, делите са пријатељима и прегледате отворене странице</translation>
-<translation id="6378173571450987352">Детаљи: сортирано према количини искоришћених података</translation>
-<translation id="6381421346744604172">Затамни веб-сајтове</translation>
-<translation id="6388207532828177975">Обриши и ресетуј</translation>
-<translation id="6393863479814692971">Chrome тражи дозволу да приступи камери и микрофону за овај сајт.</translation>
-<translation id="6395288395575013217">ЛИНК</translation>
-<translation id="6404511346730675251">Измена обележивача</translation>
-<translation id="6406506848690869874">Синхронизација</translation>
-<translation id="641643625718530986">Штампај...</translation>
-<translation id="6416782512398055893">Преузели сте <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Преводите странице са веба</translation>
-<translation id="6433501201775827830">Изаберите претраживач</translation>
-<translation id="6437478888915024427">Информације о страници</translation>
-<translation id="6441734959916820584">Назив је предугачак</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# слика}one{# слика}few{# слике}other{# слика}}</translation>
-<translation id="6447842834002726250">Колачићи</translation>
-<translation id="6461962085415701688">Не можете да отворите датотеку</translation>
-<translation id="6464977750820128603">Можете да видите сајтове које посећујете у Chrome-у и да подесите тајмере за њих.\n\nGoogle добија информације о сајтовима за које подесите тајмере и о томе колико дуго их посећујете. Те информације се користе за побољшање Дигиталног благостања.</translation>
-<translation id="6475951671322991020">Преузми видео</translation>
-<translation id="6482749332252372425">Преузимање датотеке <ph name="FILE_NAME" /> није успело због недостатка меморијског простора.</translation>
-<translation id="6496823230996795692">Да бисте први пут користили <ph name="APP_NAME" />, повежите се на интернет.</translation>
-<translation id="6508722015517270189">Поново покрените Chrome</translation>
-<translation id="6527303717912515753">Дели</translation>
-<translation id="6532866250404780454">Сајтови које посећујете у Chrome-у се неће приказивати. Биће избрисани тајмери за све сајтове.</translation>
-<translation id="6534565668554028783">Google-у је требало предуго да одговори</translation>
-<translation id="6538442820324228105">Преузели сте <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Нешто није у реду. Пробајте поново касније.</translation>
-<translation id="654446541061731451">Изаберите картицу за пребацивање</translation>
-<translation id="6545017243486555795">Обриши све податке</translation>
-<translation id="6545864417968258051">Bluetooth скенирање</translation>
-<translation id="6560414384669816528">Претрага помоћу Sogou-а</translation>
-<translation id="6566259936974865419">Chrome вам је уштедео <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">Увек дозволи</translation>
-<translation id="6573431926118603307">Овде ће се приказати картице које отворите у Chrome-у на другим уређајима.</translation>
-<translation id="6583199322650523874">Обележавање тренутне странице</translation>
-<translation id="6593061639179217415">Верзија сајта за рачунар</translation>
-<translation id="6600954340915313787">Копирана у Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Заштићени садржај</translation>
-<translation id="6627583120233659107">Измени директоријум</translation>
-<translation id="6643016212128521049">Обриши</translation>
-<translation id="6643649862576733715">Сортирај по количини уштеђених података</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}few{<ph name="CONTACT_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Прикажи слику <ph name="BEGIN_NEW" />Ново<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome-у је потребан приступ локацији за скенирање уређаја. <ph name="BEGIN_LINK" />Ажурирајте дозволе<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Лозинка</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Отвори у <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Chrome обавештење о приватности</translation>
-<translation id="6676840375528380067">Желите ли да обришете Chrome податке са овог уређаја?</translation>
-<translation id="6697492270171225480">Приказуј предлоге за сличне странице када нека страница не може да се пронађе</translation>
-<translation id="6697947395630195233">Chrome тражи приступ вашој локацији да бисте је делили са овим сајтом.</translation>
-<translation id="6698801883190606802">Управљајте синхронизованим подацима</translation>
-<translation id="6699370405921460408">Google сервери ће оптимизовати странице које посећујете.</translation>
-<translation id="6706288973712894588">Тренутно сте офлајн.\n<ph name="BEGIN_LINK" />Истражите офлајн фид.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Вести</translation>
-<translation id="6710213216561001401">Претходно</translation>
-<translation id="671481426037969117">Тајмер апликације <ph name="FQDN" /> је истекао. Почеће поново сутра.</translation>
-<translation id="6738867403308150051">Преузима се...</translation>
-<translation id="6746124502594467657">Премести надоле</translation>
-<translation id="6766622839693428701">Превуците надоле да бисте затворили.</translation>
-<translation id="6766758767654711248">Додирните да бисте отишли на сајт</translation>
-<translation id="6767294960381293877">Листа уређаја са којима се дели картица је отворена на пола висине.</translation>
-<translation id="6782111308708962316">Спречи веб-сајтове треће стране да чувају и читају податке колачића</translation>
-<translation id="6790428901817661496">Пусти</translation>
-<translation id="6811034713472274749">Страница је спремна за преглед</translation>
-<translation id="6818926723028410516">Изаберите ставке</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Преведи</translation>
-<translation id="6845325883481699275">Помозите нам да побољшамо Chrome безбедност</translation>
-<translation id="6846298663435243399">Учитавање…</translation>
-<translation id="6850409657436465440">Преузимање је још увек у току</translation>
-<translation id="6850830437481525139">Затворених картица: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Преузми слику</translation>
-<translation id="6865313869410766144">Подаци Аутоматског попуњавања за обрасце</translation>
-<translation id="688738109438487280">Додавање постојећих података на <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Откључајте да бисте копирали лозинку</translation>
-<translation id="6896758677409633944">Копирај</translation>
-<translation id="6910211073230771657">Избрисано</translation>
-<translation id="6912998170423641340">Блокирај сајтове тако да не читају текст и слике из привремене меморије</translation>
-<translation id="6914783257214138813">Лозинке ће бити видљиве свима који могу да виде извезену датотеку.</translation>
-<translation id="6942665639005891494">Промените подразумевану локацију за преузимање у било ком тренутку помоћи опције у менију Подешавања</translation>
-<translation id="6945221475159498467">Изабери</translation>
-<translation id="6963642900430330478">Ова страница је опасна. Информације о сајту</translation>
-<translation id="6963766334940102469">Избриши обележиваче</translation>
-<translation id="6965382102122355670">Потврди</translation>
-<translation id="6979737339423435258">Одувек</translation>
-<translation id="6981982820502123353">Приступачност</translation>
-<translation id="6989267951144302301">Преузимање није успело</translation>
-<translation id="6990079615885386641">Преузмите апликацију из Google Play продавнице: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Питај пре него што дозволиш сајтовима да користе микрофон (препоручено)</translation>
-<translation id="7015203776128479407">Почетно подешавање синхронизације није завршено. Синхронизација је искључена.</translation>
-<translation id="7016516562562142042">Дозвољено је за актуелни претраживач</translation>
-<translation id="7022756207310403729">Отвори у прегледачу</translation>
-<translation id="702463548815491781">Препоручујемо вам када укључите TalkBack или приступ помоћу прекидача</translation>
-<translation id="7029809446516969842">Лозинке</translation>
-<translation id="7053983685419859001">Блокирај</translation>
-<translation id="7055152154916055070">Блокирано је преусмеравање:</translation>
-<translation id="7063006564040364415">Није могуће повезивање са сервером за синхронизацију.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Изабрано: 1}one{Изабрано: #}few{Изабрано: #}other{Изабрано: #}}</translation>
-<translation id="7071521146534760487">Управљајте налогом</translation>
-<translation id="7077143737582773186">SD картица</translation>
-<translation id="7087918508125750058">Изабрали сте <ph name="ITEM_COUNT" />. Опције су доступне при врху екрана</translation>
-<translation id="7121362699166175603">Брише историју и аутоматска довршавања у траци за адресу. Google налог може да има друге облике историје прегледања на <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Дозволи за актуелни претраживач</translation>
-<translation id="7138678301420049075">Друго</translation>
-<translation id="7141896414559753902">Блокирај приказивање искачућих прозора и преусмеравања на сајтовима (препоручено)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Учитај оригиналну страницу<ph name="END_LINK" /> са <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Последња 24 сата</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">То можете да промените касније у подешавањима</translation>
-<translation id="7180611975245234373">Освежи</translation>
-<translation id="7189372733857464326">Чека се да Google Play услуге заврше ажурирање</translation>
-<translation id="7191430249889272776">Картица је отворена у позадини.</translation>
-<translation id="723171743924126238">Изаберите слике</translation>
-<translation id="7233236755231902816">Да бисте прегледали веб на свом језику, преузмите најновију верзију Chrome-а</translation>
-<translation id="7243308994586599757">Опције су доступне у дну екрана</translation>
-<translation id="7248069434667874558">Уверите се да је синхронизација за <ph name="TARGET_DEVICE_NAME" /> укључена у Chrome-у</translation>
-<translation id="7250468141469952378">Изабрали сте <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Сајт је блокиран</translation>
-<translation id="7290209999329137901">Промена назива није могућа</translation>
-<translation id="7291387454912369099">Плаћање покреће Помоћник</translation>
-<translation id="7293171162284876153">Да бисте покренули синхронизацију, укључите опцију „Синхронизујте Chrome податке“.</translation>
-<translation id="729975465115245577">Уређај нема апликацију за чување датотеке са лозинкама.</translation>
-<translation id="7302081693174882195">Детаљи: сортирано према количини уштеђених података</translation>
-<translation id="7328017930301109123">У Lite режиму Chrome учитава странице брже и користи и до 60 процената мање података.</translation>
-<translation id="7333031090786104871">Још увек додајемо претходни сајт</translation>
-<translation id="7352939065658542140">ВИДЕО</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Дели 1 изабрану ставку}one{Дели # изабрану ставку}few{Дели # изабране ставке}other{Дели # изабраних ставки}}</translation>
 <translation id="7359002509206457351">Приступ начинима плаћања</translation>
+<translation id="8026334261755873520">Обришите податке прегледања</translation>
+<translation id="1291207594882862231">Обришите историју, колачиће, податке о сајтовима, кеш...</translation>
+<translation id="7814200940910057384">Brave подаци су обрисани</translation>
+<translation id="1664855196866195614">Изабрани подаци су уклоњени из Brave-а и са синхронизованих уређаја.
+
+Brave Software налог можда има друге облике историје прегледања, попут претрага и активности у другим Brave Software услугама на <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Кеширане слике и датотеке</translation>
+<translation id="2496180316473517155">Историја прегледања</translation>
+<translation id="2546283357679194313">Колачићи и подаци о сајтовима</translation>
+<translation id="8662811608048051533">Одјавиће вас са већине сајтова.</translation>
+<translation id="8218628800671693884">Одјавиће вас са већине сајтова. Неће вас одјавити са Brave Software налога.</translation>
+<translation id="2017836877785168846">Брише историју и аутоматска довршавања у траци за адресу.</translation>
+<translation id="8096327394278038498">Брише историју и аутоматска довршавања у траци за адресу. Brave Software налог може да има друге облике историје прегледања на <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Брише историју са свих уређаја на којима сте пријављени. Brave Software налог може да има друге облике историје прегледања на <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Сачуване лозинке</translation>
+<translation id="6865313869410766144">Подаци Аутоматског попуњавања за обрасце</translation>
+<translation id="7562080006725997899">Брисање података прегледања</translation>
+<translation id="5487521232677179737">Обриши податке</translation>
+<translation id="7498271377022651285">Сачекајте...</translation>
+<translation id="784934925303690534">Временски опсег</translation>
+<translation id="1718835860248848330">Последњих сат времена</translation>
+<translation id="7149893636342594995">Последња 24 сата</translation>
+<translation id="5648166631817621825">Последњих 7 дана</translation>
+<translation id="8571213806525832805">Последње 4 недеље</translation>
+<translation id="5854790677617711513">Старије од 30 дана</translation>
+<translation id="6979737339423435258">Одувек</translation>
+<translation id="982182592107339124">Овим бришете податке за све сајтове, укључујући:</translation>
+<translation id="6643016212128521049">Обриши</translation>
+<translation id="7641339528570811325">Обриши податке прегледања…</translation>
+<translation id="1670399744444387456">Основна</translation>
+<translation id="3245261285041759672">Brave Software налог може да има друге облике историје прегледања на <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Сајт је блокиран</translation>
+<translation id="2534155362429831547">Избрисаних ставки: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Извештаји о коришћењу и отказивању</translation>
+<translation id="9079153198295609735">Аутоматски шаљи Brave Software-у статистичке податке о коришћењу и извештаје о отказивању</translation>
+<translation id="6981982820502123353">Приступачност</translation>
+<translation id="2387895666653383613">Промена величине текста</translation>
+<translation id="2321958826496381788">Превлачите клизач док ово не будете могли лако да прочитате. Када двапут додирнете пасус, текст треба да буде бар оволики.</translation>
+<translation id="3895926599014793903">Принудно омогући зумирање</translation>
+<translation id="5668404140385795438">Одбијање захтева веб-сајта да се спречи увећавање</translation>
+<translation id="4149994727733219643">Поједностављен приказ веб-страница</translation>
+<translation id="9100505651305367705">Понуди приказивање чланака у поједностављеном приказу када је то подржано</translation>
+<translation id="1409426117486808224">Поједностављен приказ отворених картица</translation>
+<translation id="702463548815491781">Препоручујемо вам када укључите TalkBack или приступ помоћу прекидача</translation>
+<translation id="8284326494547611709">Титл</translation>
+<translation id="4165986682804962316">Подешавања сајта</translation>
+<translation id="6295158916970320988">Сви сајтови</translation>
+<translation id="8380167699614421159">Овај сајт приказује огласе који ометају активности или обмањујуће огласе</translation>
+<translation id="1919345977826869612">Огласи</translation>
+<translation id="410351446219883937">Аутоплеј</translation>
+<translation id="6447842834002726250">Колачићи</translation>
+<translation id="6196640612572343990">Блокирај колачиће треће стране</translation>
+<translation id="6782111308708962316">Спречи веб-сајтове треће стране да чувају и читају податке колачића</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Искачући прозори и преусмеравања</translation>
+<translation id="4751476147751820511">Сензори за покрет или светло</translation>
+<translation id="1717218214683051432">Сензори покрета</translation>
+<translation id="2091887806945687916">Звук</translation>
+<translation id="2586657967955657006">Меморија</translation>
+<translation id="6320088164292336938">Вибрација</translation>
+<translation id="4226663524361240545">Уређај ће вибрирати када примате обавештења</translation>
+<translation id="1446450296470737166">Пуна контрола над MIDI уређајима</translation>
+<translation id="3744111561329211289">Синхронизација у позадини</translation>
+<translation id="5649053991847567735">Аутоматска преузимања</translation>
+<translation id="6181444274883918285">Додај изузетак за сајтове</translation>
+<translation id="5313967007315987356">Додајте сајт</translation>
+<translation id="1369915414381695676">Сајт <ph name="SITE_NAME"/> је додат</translation>
+<translation id="7837721118676387834">Дозволите аутоплеј за видео снимке са искљученим звуком за одређени сајт.</translation>
+<translation id="2621115761605608342">Дозволите JavaScript за одређени сајт.</translation>
+<translation id="8801436777607969138">Блокирајте JavaScript за одређени сајт.</translation>
+<translation id="8372893542064058268">Дозволите Синхронизацију у позадини за одређени сајт.</translation>
+<translation id="358794129225322306">Дозволите сајту да аутоматски преузима више датотека.</translation>
+<translation id="4008040567710660924">Омогућава колачиће за одређени сајт.</translation>
+<translation id="8958424370300090006">Блокирајте колачиће за одређени сајт.</translation>
+<translation id="7882806643839505685">Дозволи звук за одређени сајт.</translation>
+<translation id="4468959413250150279">Искључи звук за одређени сајт</translation>
+<translation id="1994173015038366702">URL сајта</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Коришћење</translation>
+<translation id="5804241973901381774">Дозволе</translation>
+<translation id="4278390842282768270">Дозвољено</translation>
+<translation id="5677928146339483299">Блокирано</translation>
+<translation id="1984937141057606926">Дозвољени, осим треће стране</translation>
+<translation id="7423098979219808738">Прво питај</translation>
+<translation id="8116925261070264013">Звук је искључен</translation>
+<translation id="8300705686683892304">Управља апликација</translation>
+<translation id="6192792657125177640">Изузеци</translation>
+<translation id="257931822824936280">Проширено је – Кликните да бисте скупили.</translation>
+<translation id="5100237604440890931">Скупљено је – Кликните да бисте проширили.</translation>
+<translation id="857943718398505171">Дозвољено (препоручено)</translation>
+<translation id="2913331724188855103">Дозволи сајтовима да чувају и читају податке колачића (препоручује се)</translation>
+<translation id="7445411102860286510">Дозволи сајтовима да аутоматски пуштају видео снимке са искљученим звуком (препоручено)</translation>
+<translation id="5335288049665977812">Дозволи сајтовима да покрећу JavaScript (препоручено)</translation>
+<translation id="5527111080432883924">Питај пре него што дозволиш сајтовима да читају текст и слике из привремене меморије (препоручено)</translation>
+<translation id="6912998170423641340">Блокирај сајтове тако да не читају текст и слике из привремене меморије</translation>
+<translation id="7423538860840206698">Читање привремене меморије је блокирано</translation>
+<translation id="3955193568934677022">Дозволи сајтовима да пуштају заштићени садржај (препоручено)</translation>
+<translation id="445467742685312942">Дозволите сајтовима да пуштају заштићени садржај</translation>
+<translation id="2107397443965016585">Упит се приказује пре него што дозволите сајтовима да пуштају заштићени садржај (препоручено)</translation>
+<translation id="2910701580606108292">Питај пре него што дозволиш сајтовима да пуштају заштићени садржај</translation>
+<translation id="757524316907819857">Блокирај да сајтови пуштају заштићени садржај</translation>
+<translation id="3277252321222022663">Дозволи сајтовима да приступају сензорима (препоручено)</translation>
+<translation id="5048398596102334565">Дозволи сајтовима да приступају сензорима за покрет (препоручено)</translation>
+<translation id="8816026460808729765">Не дозвољавај сајтовима да приступају сензорима</translation>
+<translation id="169515064810179024">Не дозвољавај сајтовима да приступају сензорима за покрет</translation>
+<translation id="1660204651932907780">Дозволи сајтовима да пуштају звук (препоручено)</translation>
+<translation id="3600792891314830896">Искључи звук сајтова који пуштају звук</translation>
+<translation id="1743802530341753419">Питај пре него што дозволиш сајтовима да се повезују са уређајем (препоручено)</translation>
+<translation id="851751545965956758">Онемогући сајтовима да се повезују са уређајима</translation>
+<translation id="7141896414559753902">Блокирај приказивање искачућих прозора и преусмеравања на сајтовима (препоручено)</translation>
+<translation id="5494752089476963479">Блокирај огласе на сајтовима који приказују огласе који ометају активности или обмањујуће огласе</translation>
+<translation id="3123473560110926937">Блокирано на неким сајтовима</translation>
+<translation id="965817943346481315">Блокирај ако сајт приказује огласе који ометају активности или обмањујуће огласе (препоручено)</translation>
+<translation id="3386292677130313581">Питај пре него што дозволиш сајтовима да знају локацију (препоручено)</translation>
+<translation id="9139068048179869749">Питај пре него што дозволиш сајтовима да шаљу обавештења (препоручено)</translation>
+<translation id="4479647676395637221">Питај пре него што дозволиш сајтовима да користе камеру (препоручено)</translation>
+<translation id="6992289844737586249">Питај пре него што дозволиш сајтовима да користе микрофон (препоручено)</translation>
+<translation id="2289270750774289114">Питај када сајт жели да открије Bluetooth уређаје у близини (препоручено)</translation>
+<translation id="7053983685419859001">Блокирај</translation>
+<translation id="7128222689758636196">Дозволи за актуелни претраживач</translation>
+<translation id="7589445247086920869">Блокирај за актуелни претраживач</translation>
+<translation id="6388207532828177975">Обриши и ресетуј</translation>
+<translation id="7999064672810608036">Желите ли стварно да обришете све локалне податке, укључујући колачиће, и ресетујете све дозволе за овај веб-сајт?</translation>
+<translation id="2822354292072154809">Желите ли стварно да ресетујете све дозволе за сајт за <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Обришите сачуване податке</translation>
+<translation id="5902828464777634901">Сви локални подаци које овај веб-сајт чува, укључујући колачиће, биће избрисани.</translation>
+<translation id="119944043368869598">Обриши све</translation>
+<translation id="2490684707762498678">Управља <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Отворите подешавања обавештења</translation>
+<translation id="1404122904123200417">Уграђено је у сајт <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Датотеке које су сачували веб-сајтови приказују се овде</translation>
+<translation id="4181841719683918333">Језици</translation>
+<translation id="2647434099613338025">Додај језик</translation>
+<translation id="1952172573699511566">Веб-сајтови ће приказивати текст на жељеном језику када је то могуће.</translation>
+<translation id="8559990750235505898">Понуди превод страница на друге језике</translation>
+<translation id="4719927025381752090">Понуди превод</translation>
+<translation id="8156139159503939589">На којим језицима читате?</translation>
+<translation id="5689516760719285838">Локација</translation>
+<translation id="2440823041667407902">Приступ локацији</translation>
+<translation id="2023546461831060654">Укључите дозволе за Brave у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Укључите дозволу за Brave у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Да бисте дозволили да Brave приступа локацији, укључите локацију и у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Да бисте дозволили да Brave приступа камери, укључите камеру и у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Да бисте дозволили да вам Brave шаље обавештења, укључите обавештења и у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Да бисте дозволили да Brave приступа микрофону, укључите микрофон и у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Приступ локацији је искључен за овај уређај. Укључите га у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Приступ локацији је искључен и за овај уређај. Укључите га у <ph name="BEGIN_LINK"/>Android подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Камера</translation>
+<translation id="3227137524299004712">Микрофон</translation>
+<translation id="1647391597548383849">Приступ камери</translation>
+<translation id="945632385593298557">Приступ микрофону</translation>
+<translation id="6612358246767739896">Заштићени садржај</translation>
+<translation id="885701979325669005">Меморијски простор</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> сачуваних података</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Опозови дозволу за уређај</translation>
+<translation id="4962975101802056554">Опозовите све дозволе за уређај</translation>
+<translation id="6545864417968258051">Bluetooth скенирање</translation>
+<translation id="4411535500181276704">Lite режим</translation>
+<translation id="7821588508402923572">Уштеда података се приказује овде</translation>
+<translation id="2131665479022868825">Сачувано: <ph name="DATA"/></translation>
+<translation id="8569404424186215731">од <ph name="DATE"/></translation>
+<translation id="3252158532344029638">У Lite режиму Brave учитава странице брже и користи и до 60 процената мање података.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> уштеде података</translation>
+<translation id="7494974237137038751">уштеђених података</translation>
+<translation id="6111020039983847643">искоришћених података</translation>
+<translation id="7413229368719586778">Датум почетка: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Датум завршетка: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Сортирај по сајту</translation>
+<translation id="5864174910718532887">Детаљи: сортирано према називу сајта</translation>
+<translation id="116280672541001035">Искоришћено</translation>
+<translation id="8349013245300336738">Сортирај по количини искоришћених података</translation>
+<translation id="6378173571450987352">Детаљи: сортирано према количини искоришћених података</translation>
+<translation id="2631006050119455616">Сачувано</translation>
+<translation id="6643649862576733715">Сортирај по количини уштеђених података</translation>
+<translation id="7302081693174882195">Детаљи: сортирано према количини уштеђених података</translation>
+<translation id="4179980317383591987">Искористили сте <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Уштедели сте <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Преостали сајтови (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Друго</translation>
+<translation id="4913161338056004800">Ресетуј статистику</translation>
+<translation id="1856325424225101786">Желите ли да ресетујете Lite режим?</translation>
+<translation id="3658159451045945436">Ресетовањем ћете обрисати историју Уштеде података, укључујући листу сајтова које сте посетили.</translation>
+<translation id="3295530008794733555">Прегледајте брже. Користите мање података.</translation>
+<translation id="7340390500800578919">У Lite режиму Brave учитава странице брже и користи и до 60 процената мање података. Да би оптимизовао странице које посећујете, Brave шаље Brave Software-у ваш саобраћај на вебу. <ph name="BEGIN_LINK"/>Сазнајте више<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Укључи Lite режим</translation>
+<translation id="4493497663118223949">Lite режим је укључен</translation>
+<translation id="7559975015014302720">Lite режим је искључен</translation>
+<translation id="7606077192958116810">Lite режим је укључен. Управљајте њиме у Подешавањима.</translation>
+<translation id="4714588616299687897">Уштедите до 60% података</translation>
+<translation id="1006927014032731288">Brave Software сервери ће оптимизовати странице које посећујете.</translation>
+<translation id="3257320067425202300">Brave вам је уштедео <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave вам је уштедео <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">Локација за преузимање</translation>
+<translation id="7077143737582773186">SD картица</translation>
+<translation id="7762668264895820836">SD картица <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Питај где да сачуваш датотеке</translation>
+<translation id="6192333916571137726">Преузмите датотеку</translation>
+<translation id="1672586136351118594">Не приказуј поново</translation>
+<translation id="2650751991977523696">Преузимате датотеку поново?</translation>
+<translation id="8664979001105139458">Име датотеке већ постоји</translation>
+<translation id="488187801263602086">Преименујте датотеку</translation>
+<translation id="5686790454216892815">Име датотеке је предугачко</translation>
+<translation id="7454641608352164238">Нема довољно простора</translation>
+<translation id="8972098258593396643">Преузимате у подразумевани директоријум?</translation>
+<translation id="804335162455518893">SD картица није пронађена</translation>
+<translation id="7475688122056506577">SD картица није пронађена. Неке датотеке можда недостају.</translation>
+<translation id="4198423547019359126">Нема доступних локација за преузимања</translation>
+<translation id="8224471946457685718">Преузимај чланке за мене преко Wi-Fi мреже</translation>
+<translation id="4970824347203572753">Није доступно на вашој локацији</translation>
+<translation id="5500777121964041360">Можда није доступно на вашој локацији</translation>
+<translation id="1173894706177603556">Преименуј</translation>
+<translation id="1986685561493779662">Назив већ постоји</translation>
+<translation id="6441734959916820584">Назив је предугачак</translation>
+<translation id="2923908459366352541">Назив је неважећи</translation>
+<translation id="7290209999329137901">Промена назива није могућа</translation>
+<translation id="3334729583274622784">Желите да промените екстензију датотеке?</translation>
+<translation id="107147699690128016">Ако промените екстензију датотеке, она може да се отвори у другој апликацији и да буде опасна по уређај.</translation>
+<translation id="8541922081612557424">О Brave прегледачу</translation>
+<translation id="5311273890481188673">Ауторска права <ph name="YEAR"/>. Brave Software LLC. Сва права задржана.</translation>
+<translation id="1416550906796893042">Верзија апликације</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (ажурирано је <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Оперативни систем</translation>
+<translation id="3968054912784331254">Brave ажурирања више нису подржана за ову верзију Android-а</translation>
+<translation id="7665369617277396874">Додајте налог</translation>
+<translation id="649070405679044769">Пријављени сте у Brave Software као</translation>
+<translation id="6234515504547364178">Одјављивање из Brave-а</translation>
+<translation id="5324858694974489420">Родитељска подешавања</translation>
+<translation id="8920114477895755567">Чекају се детаљи родитеља.</translation>
+<translation id="5512137114520586844">Овим налогом управља <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Овим налогом управљају <ph name="PARENT_NAME_1"/> и <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Садржај</translation>
+<translation id="5403644198645076998">Дозволи само одређене сајтове</translation>
+<translation id="8641930654639604085">Покушај да блокираш сајтове са садржајем за одрасле</translation>
+<translation id="5639724618331995626">Дозволи све сајтове</translation>
+<translation id="796823723482603597">Омогућава Brave</translation>
+<translation id="6324034347079777476">Синхронизација Android система је онемогућена</translation>
+<translation id="5127805178023152808">Синхронизација је искључена</translation>
+<translation id="7015203776128479407">Почетно подешавање синхронизације није завршено. Синхронизација је искључена.</translation>
+<translation id="2497852260688568942">Администратор је онемогућио синхронизацију</translation>
+<translation id="9100610230175265781">Потребна је приступна фраза</translation>
+<translation id="6108923351542677676">Подешавање је у току...</translation>
+<translation id="4062305924942672200">Правне информације</translation>
+<translation id="4256782883801055595">Лиценце отвореног кода</translation>
+<translation id="1138681184697033370">Brave услови коришћења услуге</translation>
+<translation id="7392539049993970338">Brave обавештење о приватности</translation>
+<translation id="2677748264148917807">Затвори</translation>
+<translation id="5556459405103347317">Учитај поново</translation>
+<translation id="1623104350909869708">Спречи ову страницу да прави додатне дијалоге</translation>
+<translation id="2968755619301702150">Приказивач сертификата</translation>
+<translation id="1360432990279830238">Одјављујете се и искључујете синхрониз?</translation>
+<translation id="8581481290581777242">Желите ли да обришете Brave податке са овог уређаја?</translation>
+<translation id="1318865768845061710">Обележивачи, историја, лозинке и други Brave подаци више се неће синхронизовати са Brave Software налогом</translation>
+<translation id="3325020657155065477">Обриши Brave податке и са овог уређаја</translation>
+<translation id="6136448902816743006">Пошто се одјављујете са налога којим управља <ph name="DOMAIN_NAME"/>, Brave подаци биће избрисани са овог уређаја. Остаће на вашем Brave Software налогу.</translation>
+<translation id="1853026300647876496">Контактирамо Brave Software. То може мало да потраје...</translation>
+<translation id="2328985652426384049">Не могу да се пријавим</translation>
+<translation id="7723158744459952869">Brave Software-у је требало предуго да одговори</translation>
+<translation id="4572422548854449519">Пријавите се на налог којим се управља</translation>
+<translation id="2689656545739939160">Пријављујете се помоћу налога којим управља <ph name="MANAGED_DOMAIN"/> и дајете његовом администратору контролу над својим Brave подацима. Подаци ће постати трајно повезани са тим налогом. Одјављивањем из Brave-а ћете избрисати податке са овог уређаја, али ће они остати сачувани на Brave Software налогу.</translation>
+<translation id="1749561566933687563">Синхронизујте обележиваче</translation>
+<translation id="4242533952199664413">Отвори подешавања</translation>
+<translation id="1111673857033749125">Обележивачи сачувани на другим уређајима ће се приказати овде.</translation>
+<translation id="8636825310635137004">Да би вам картице биле доступне на другим уређајима, укључите синхронизацију.</translation>
+<translation id="3269956123044984603">Да би вам биле доступне картице са других уређаја, укључите опцију „Аутоматски синхронизуј податке“ у Android подешавањима на налогу.</translation>
+<translation id="5157964048453367290">Овде ће се приказати картице које отворите у Brave-у на другим уређајима.</translation>
+<translation id="4684427112815847243">Синхронизуј све</translation>
+<translation id="2709516037105925701">Аутоматско попуњавање</translation>
+<translation id="8820817407110198400">Обележивачи</translation>
+<translation id="1644574205037202324">Историја</translation>
+<translation id="17513872634828108">Отворене картице</translation>
+<translation id="1320169905922104972">Кредитне картице и адресе из Brave Software Pay-а</translation>
+<translation id="6337234675334993532">Шифровање</translation>
+<translation id="6698801883190606802">Управљајте синхронизованим подацима</translation>
+<translation id="3598578758776312506">Шифрујте лозинке помоћу Brave Software акредитива</translation>
+<translation id="7810580217418711046">Шифрујте синхронизоване податке помоћу Brave Software лозинке од <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Шифрујте синхронизоване податке помоћу сопствене приступне фразе за синхронизацију</translation>
+<translation id="2996291259634659425">Направите приступну фразу</translation>
+<translation id="5713644099811900409">Brave Software налога</translation>
+<translation id="8997474919031554666">Шифровање помоћу приступне фразе не обухвата начине плаћања и адресе из Brave Software Pay-а. Само неко ко има приступну фразу може да чита шифроване податке. Приступна фраза се не шаље Brave Software-у нити је он чува. Ако заборавите приступну фразу или пожелите да промените ово подешавање, треба да ресетујете синхронизацију. <ph name="BEGIN_LINK"/>Сазнајте више<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Приступна фраза</translation>
+<translation id="7772032839648071052">Потврди приступну фразу</translation>
+<translation id="5304593522240415983">Ово поље не сме да буде празно</translation>
+<translation id="321773570071367578">Ако сте заборавили приступну фразу или желите да промените ово подешавање, <ph name="BEGIN_LINK"/>ресетујте синхронизацију<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Приступне фразе се не подударају</translation>
+<translation id="5149495116300586333">Шифровање помоћу приступне фразе не обухвата начине плаћања и адресе из Brave Software Pay-а.
+
+Да бисте променили ово подешавање, <ph name="BEGIN_LINK"/>ресетујте синхронизацију<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Неисправна приступна фраза</translation>
+<translation id="5414836363063783498">Верификују се...</translation>
+<translation id="6846298663435243399">Учитавање…</translation>
+<translation id="5517095782334947753">Имате обележиваче, лозинке и остала подешавања из <ph name="FROM_ACCOUNT"/> налога.</translation>
+<translation id="3928666092801078803">Комбинуј податке</translation>
+<translation id="688738109438487280">Додавање постојећих података на <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Не обједињуј моје податке</translation>
+<translation id="1145536944570833626">Избришите постојеће податке</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> жели да се упари</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Потражите помоћ<ph name="END_LINK"/> док скенирате уређаје…</translation>
+<translation id="5817918615728894473">Упари</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Потражите помоћ<ph name="END_LINK1"/> или <ph name="BEGIN_LINK2"/>поново скенирајте<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Није пронађен ниједан компатибилан уређај</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Укључите Bluetooth<ph name="END_LINK"/> да бисте омогућили упаривање</translation>
+<translation id="998321811308652668">Brave не може да укључи Bluetooth адаптер</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Потражите помоћ<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave-у је потребан приступ локацији за скенирање уређаја. <ph name="BEGIN_LINK"/>Ажурирајте дозволе<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave-у је потребан приступ локацији да би тражио уређаје. Приступ локацији је <ph name="BEGIN_LINK"/>искључен за овај уређај<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave-у је потребан приступ локацији да би тражио уређаје. <ph name="BEGIN_LINK1"/>Ажурирајте дозволе<ph name="END_LINK1"/>. Приступ локацији је такође <ph name="BEGIN_LINK2"/>искључен за овај уређај<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Повезани уређај</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Ниво јачине сигнала: # црта}one{Ниво јачине сигнала: # црта}few{Ниво јачине сигнала: # црте}other{Ниво јачине сигнала: # црта}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> жели да тражи Bluetooth уређаје у близини. Пронађени су следећи уређаји:</translation>
+<translation id="8368027906805972958">Непознат или неподржан уређај (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Синхронизација не функционише</translation>
+<translation id="1810845389119482123">Почетно подешавање синхронизације није завршено</translation>
+<translation id="3235722914093408050">Отворите Android подешавања и поново омогућите синхронизацију Android система да бисте започели Brave синхронизацију</translation>
+<translation id="3367813778245106622">Пријавите се поново да бисте започели синхронизацију</translation>
+<translation id="974555521953189084">Унесите приступну фразу да да бисте започели синхронизацију</translation>
+<translation id="2997266899014181325">Да бисте покренули синхронизацију, укључите опцију „Синхронизујте Brave податке“.</translation>
+<translation id="8260126382462817229">Пробајте поново да се пријавите</translation>
+<translation id="5919204609460789179">Ажурирајте <ph name="PRODUCT_NAME"/> да бисте започели синхронизацију</translation>
+<translation id="397583555483684758">Синхронизација више не функционише</translation>
+<translation id="1966710179511230534">Ажурирајте податке за пријављивање.</translation>
+<translation id="7063006564040364415">Није могуће повезивање са сервером за синхронизацију.</translation>
+<translation id="7942131818088350342">Производ <ph name="PRODUCT_NAME"/> је застарео.</translation>
+<translation id="4170011742729630528">Услуга није доступна. Пробајте поново касније.</translation>
+<translation id="7947953824732555851">Прихвати и пријави ме</translation>
+<translation id="8583805026567836021">Брисање података о налогу</translation>
+<translation id="8310344678080805313">Стандардне картице</translation>
+<translation id="5748802427693696783">Пребацили сте на стандардне картице</translation>
+<translation id="7998918019931843664">Поново отворите затворену картицу</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, картица</translation>
+<translation id="4452411734226507615">Затвори картицу <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Опције су доступне у дну екрана</translation>
+<translation id="4060598801229743805">Опције су доступне при врху екрана</translation>
+<translation id="2810645512293415242">Страница је поједностављена ради уштеде на подацима и бржег учитавања.</translation>
+<translation id="3985215325736559418">Желите ли стварно да поново преузмете <ph name="FILE_NAME"/>?</translation>
+<translation id="2450083983707403292">Да ли желите да поново почнете да преузимате датотеку <ph name="FILE_NAME"/>?</translation>
+<translation id="7514365320538308">Преузми</translation>
+<translation id="545042621069398927">Преузимање се убрзава.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Преузима се датотека.}one{Преузима се # датотека.}few{Преузимају се # датотеке.}other{Преузима се # датотека.}}</translation>
+<translation id="543509235395288790">Преузимају се датотеке (<ph name="COUNT"/>: <ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Преузима се датотека (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 преузимање је довршено.}one{# преузимање је довршено.}few{# преузимања су довршена.}other{# преузимања је довршено.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 преузимање није успело.}one{# преузимање није успело.}few{# преузимања нису успела.}other{# преузимања није успело.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 преузимање на чекању.}one{# преузимање на чекању.}few{# преузимања на чекању.}other{# преузимања на чекању.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Дугме <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Скоро завршено!</translation>
+<translation id="3960299545138990065">Поново покрените Brave</translation>
+<translation id="3771001275138982843">Преузимање ажурирања није успело</translation>
+<translation id="3888648114124182147">Преузима се ажурирање за Brave…</translation>
+<translation id="1705567146636171298">Ажурирај Brave</translation>
+<translation id="6195417478702700398">Ако желите најбољи доживљај прегледања, отворите Brave да бисте га ажурирали</translation>
+<translation id="3512968675351418494">Да бисте прегледали веб на свом језику, преузмите најновију верзију Brave-а</translation>
+<translation id="6427112570124116297">Преводите странице са веба</translation>
+<translation id="1379423114029199501">Ажурирајте на најновију верзију Brave-а да бисте имали свој језик у њој</translation>
+<translation id="5684874026226664614">Упс, превођење ове странице није успело.</translation>
+<translation id="6831043979455480757">Преведи</translation>
+<translation id="1285320974508926690">Никад не преводи овај сајт</translation>
+<translation id="773466115871691567">Увек предводи странице на језику <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Никад не преводи странице на језику <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Још језика</translation>
+<translation id="290376772003165898">Ова страница није на језику <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Странице на језику <ph name="SOURCE_LANGUAGE"/> ће се од сада преводити на <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Странице на језику <ph name="LANGUAGE"/> се неће преводити</translation>
+<translation id="5447765697759493033">Овај сајт се неће преводити</translation>
+<translation id="4880127995492972015">Преведи…</translation>
+<translation id="641643625718530986">Штампај...</translation>
+<translation id="8909135823018751308">Дели...</translation>
+<translation id="4996978546172906250">Дељење преко</translation>
+<translation id="6333140779060797560">Дељење преко <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Дошло је до проблема при штампању странице. Пробајте поново.</translation>
+<translation id="3254409185687681395">Обележите ову страницу</translation>
+<translation id="497421865427891073">Кретање унапред</translation>
+<translation id="813082847718468539">Погледајте информације о сајту</translation>
+<translation id="2532336938189706096">Веб-приказ</translation>
+<translation id="6005538289190791541">Предложена лозинка</translation>
+<translation id="4634124774493850572">Користи лозинку</translation>
+<translation id="8285489906452138776">Brave тражи дозволу да приступи камери за овај сајт.</translation>
+<translation id="320189792589364011">Brave тражи дозволу да приступи микрофону за овај сајт.</translation>
+<translation id="7988136689212463100">Brave тражи дозволу да приступи камери и микрофону за овај сајт.</translation>
+<translation id="4931190655840828017">Brave тражи приступ вашој локацији да бисте је делили са овим сајтом.</translation>
+<translation id="3088191967551450609">Brave-у је потребан приступ меморијском простору да би преузимао датотеке.</translation>
+<translation id="8942627711005830162">Отвори у другом прозору</translation>
+<translation id="4195643157523330669">Отвори на новој картици</translation>
+<translation id="1100066534610197918">Отвори у новој картици у групи</translation>
+<translation id="4860895144060829044">Позовите</translation>
+<translation id="6896758677409633944">Копирај</translation>
+<translation id="8393700583063109961">Пошаљите поруку</translation>
+<translation id="3557336313807607643">Додај у контакте</translation>
+<translation id="4269820728363426813">Копирај адресу линка</translation>
+<translation id="1206892813135768548">Копирај текст линка</translation>
+<translation id="1204037785786432551">Преузми линк</translation>
+<translation id="6864459304226931083">Преузми слику</translation>
+<translation id="8209050860603202033">Отвори слику</translation>
+<translation id="8073388330009372546">Отвори слику на новој картици</translation>
+<translation id="6649642165559792194">Прикажи слику <ph name="BEGIN_NEW"/>Ново<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Учитај слику</translation>
+<translation id="3845332215609790146">Тражи уз Brave Software објектив <ph name="BEGIN_NEW"/>Ново<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Потражи ову слику на <ph name="SEARCH_ENGINE"/>-у</translation>
+<translation id="3384347053049321195">Дели слику</translation>
+<translation id="5833984609253377421">Дели линк</translation>
+<translation id="6475951671322991020">Преузми видео</translation>
+<translation id="2317945146070194624">Отвори на новој Brave картици</translation>
+<translation id="7975379999046275268">Прикажи страницу <ph name="BEGIN_NEW"/>Ново<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Освежавање странице</translation>
+<translation id="36525718899759834">Преузмите апликацију из Brave Software Play продавнице: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Тамнa</translation>
+<translation id="1807246157184219062">Светлa</translation>
+<translation id="4056223980640387499">Сепија</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Фиксне ширине</translation>
+<translation id="9206873250291191720">А</translation>
+<translation id="654446541061731451">Изаберите картицу за пребацивање</translation>
+<translation id="8719023831149562936">Није могуће пребацити актуелну картицу</translation>
+<translation id="2139186145475833000">Додај на почетни екран</translation>
+<translation id="4616150815774728855">Отвори <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Отварање апликације није успело</translation>
+<translation id="5129038482087801250">Инсталирај веб-апликацију</translation>
+<translation id="3789841737615482174">Инсталирај</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> је додат на почетни екран</translation>
+<translation id="7333031090786104871">Још увек додајемо претходни сајт</translation>
+<translation id="1036727731225946849">Додаје се <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Додато је на почетни екран</translation>
+<translation id="2146738493024040262">Отвори инстант апликацију</translation>
+<translation id="7016516562562142042">Дозвољено је за актуелни претраживач</translation>
+<translation id="6177111841848151710">Блокирано је за актуелни претраживач</translation>
+<translation id="145097072038377568">Искључено је у Android подешавањима</translation>
+<translation id="8007176423574883786">Искључено је за овај уређај</translation>
+<translation id="164269334534774161">Приказује се офлајн копија ове странице од <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Ова офлајн страница је од <ph name="CREATION_TIME"/> и може да се разликује од онлајн верзије.</translation>
+<translation id="8840953339110955557">Ова страница може да се разликује од онлајн верзије.</translation>
+<translation id="6405300764336705484">Овај садржај је са <ph name="DOMAIN_NAME"/>, приказује Brave Software.</translation>
+<translation id="1006017844123154345">Отвори онлајн</translation>
+<translation id="3326636747541519688">Поједностављену страницу пружа Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Учитај оригиналну страницу<ph name="END_LINK"/> са <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Ако вам се ово често приказује, испробајте ове <ph name="BEGIN_LINK"/>предлоге<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Садржај је сакривен</translation>
+<translation id="3810973564298564668">Промени</translation>
+<translation id="5199929503336119739">Профил за Work</translation>
+<translation id="528192093759286357">Превуците од врха екрана и додирните дугме Назад да бисте изашли из режима целог екрана.</translation>
+<translation id="2836148919159985482">Додирните дугме Назад да бисте изашли из режима целог екрана.</translation>
+<translation id="3967822245660637423">Преузимање је довршено</translation>
+<translation id="2434158240863470628">Преузимање је завршено <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Преузимање није успело</translation>
+<translation id="1384959399684842514">Преузимање је паузирано</translation>
+<translation id="1671236975893690980">Преузимање је на чекању…</translation>
+<translation id="5561549206367097665">Чека се мрежа...</translation>
+<translation id="5864419784173784555">Чека се друго преузимање...</translation>
+<translation id="6461962085415701688">Не можете да отворите датотеку</translation>
+<translation id="1178581264944972037">Паузирај</translation>
+<translation id="8200772114523450471">Настави</translation>
+<translation id="1409879593029778104">Преузимање датотеке <ph name="FILE_NAME"/> је спречено јер она већ постоји.</translation>
+<translation id="3387650086002190359">Преузимање датотеке <ph name="FILE_NAME"/> није успело због грешака система датотека.</translation>
+<translation id="6482749332252372425">Преузимање датотеке <ph name="FILE_NAME"/> није успело због недостатка меморијског простора.</translation>
+<translation id="7619072057915878432">Преузимање датотеке <ph name="FILE_NAME"/> није успело због проблема са мрежом.</translation>
+<translation id="1477626028522505441">Преузимање датотеке <ph name="FILE_NAME"/> није успело због проблема на серверу.</translation>
+<translation id="3692944402865947621">Преузимање датотеке <ph name="FILE_NAME"/> није успело зато што локација меморијског простора није доступна.</translation>
+<translation id="604996488070107836">Преузимање датотеке <ph name="FILE_NAME"/> није успело због непознате грешке.</translation>
+<translation id="6738867403308150051">Преузима се...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Преузели сте <ph name="KBS"/> kB</translation>
+<translation id="6416782512398055893">Преузели сте <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Преузели сте <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Преостала је 1 датотека</translation>
+<translation id="8186512483418048923">Преостале датотеке: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Преузели сте <ph name="FILES_DOWNLOADED_ONE"/> датотеку}one{Преузели сте <ph name="FILES_DOWNLOADED_MANY"/> датотеку}few{Преузели сте <ph name="FILES_DOWNLOADED_MANY"/> датотеке}other{Преузели сте <ph name="FILES_DOWNLOADED_MANY"/> датотека}}</translation>
+<translation id="8037750541064988519">Још <ph name="DAYS"/> дана</translation>
+<translation id="8190358571722158785">Још 1 дан</translation>
+<translation id="60923314841986378">Још <ph name="HOURS"/> сата/и</translation>
+<translation id="510275257476243843">Још 1 сат</translation>
+<translation id="970715775301869095">Још <ph name="MINUTES"/> мин</translation>
+<translation id="3236059992281584593">Још 1 мин</translation>
+<translation id="2777555524387840389">Још <ph name="SECONDS"/> сек</translation>
+<translation id="2781151931089541271">Још 1 сек</translation>
+<translation id="3303414029551471755">Желите ли да наставите са преузимањем садржаја?</translation>
+<translation id="8617240290563765734">Желите ли да отворите предложени URL наведен у преузетом садржају?</translation>
+<translation id="1373696734384179344">Нема довољно меморије за преузимање изабраног садржаја.</translation>
+<translation id="5271967389191913893">Уређај не може да отвори садржај за преузимање.</translation>
+<translation id="883806473910249246">Дошло је до грешке при преузимању садржаја.</translation>
+<translation id="5626134646977739690">Име:</translation>
+<translation id="7963646190083259054">Продавац:</translation>
+<translation id="3414952576877147120">Величина:</translation>
+<translation id="7375125077091615385">Тип:</translation>
+<translation id="5765780083710877561">Опис:</translation>
+<translation id="4881695831933465202">Отвори</translation>
+<translation id="3542235761944717775">Доступно је <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747">Доступно је <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB је доступно</translation>
+<translation id="5793665092639000975">Користи се <ph name="SPACE_USED"/> од <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Све</translation>
+<translation id="4988526792673242964">Странице</translation>
+<translation id="3810838688059735925">Видео</translation>
+<translation id="3616113530831147358">Аудио</translation>
+<translation id="9219103736887031265">Слике</translation>
+<translation id="8250920743982581267">Документи</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# датотека}one{# датотека}few{# датотеке}other{# датотека}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# слика}one{# слика}few{# слике}other{# слика}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# видео}one{# видео снимак}few{# видео снимка}other{# видео снимака}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудио датотека}one{# аудио датотека}few{# аудио датотеке}other{# аудио датотека}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# страница}one{# страница}few{# странице}other{# страница}}</translation>
+<translation id="5456381639095306749">Преузми страницу</translation>
+<translation id="2394602618534698961">Датотеке које преузимате се појављују овде</translation>
+<translation id="7810647596859435254">Отвори помоћу…</translation>
+<translation id="5655963694829536461">Претражите преузимања</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Моје датотеке</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Овде се појављују чланци, које можете да читате чак и када сте офлајн</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ч}one{# ч}few{# ч}other{# ч}}</translation>
+<translation id="5853623416121554550">паузирано</translation>
+<translation id="8965591936373831584">на чекању</translation>
+<translation id="2779651927720337254">није успело</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Малопре</translation>
+<translation id="4000212216660919741">Офлајн почетна страница</translation>
+<translation id="9133397713400217035">Истражујте офлајн</translation>
+<translation id="968900484120156207">Странице које посећујете се приказују овде</translation>
+<translation id="7882131421121961860">Историја није пронађена</translation>
+<translation id="3549657413697417275">Претражите своју историју</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">ММ</translation>
+<translation id="605721222689873409">ГГ</translation>
+<translation id="724102042129299115">Brave доживљај првог покретања</translation>
+<translation id="2700285883409956633">Коришћењем ове апликације прихватате <ph name="BEGIN_LINK1"/>Услове коришћења услуге<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>Обавештење о приватности<ph name="END_LINK2"/> за Brave.</translation>
+<translation id="1640714894372474981">Ако користите ову апликацију, прихватате Brave <ph name="BEGIN_LINK1"/>услове коришћења услуге<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>обавештење о приватности<ph name="END_LINK2"/>, као и <ph name="BEGIN_LINK3"/>обавештење о приватности за Brave Software налоге којима се управља помоћу Family Link-а<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> ће се отворити у Brave-у. Ако наставите, прихватате Brave <ph name="BEGIN_LINK1"/>услове коришћења услуге<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>обавештење о приватности<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> ће се отворити у Brave-у. Ако наставите, прихватате Brave <ph name="BEGIN_LINK1"/>услове коришћења услуге<ph name="END_LINK1"/> и <ph name="BEGIN_LINK2"/>обавештење о приватности<ph name="END_LINK2"/>, као и <ph name="BEGIN_LINK3"/>обавештење о приватности за Brave Software налоге којима се управља помоћу Family Link-а<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Побољшајте Brave слањем статистике коришћења и извештаја о отказивању Brave Software-у.</translation>
+<translation id="3518985090088779359">Прихвати и настави</translation>
+<translation id="7207456302801184289">Добро дошли у Brave</translation>
+<translation id="704822250101715322">Чека се да Brave Software Play услуге заврше ажурирање</translation>
+<translation id="1231733316453485619">Желите ли да укључите синхронизацију?</translation>
+<translation id="5132942445612118989">Синхронизујте лозинке, историју и други садржај на свим уређајима</translation>
+<translation id="5736731321935944068">Brave Software може да користи историју за персонализацију Претраге, огласа и других Brave Software услуга</translation>
+<translation id="4013614219085422040">Brave Software може да користи историју за персонализацију Претраге и других Brave Software услуга</translation>
+<translation id="5581519193887989363">Увек можете да одаберете шта ћете синхронизовати у <ph name="BEGIN_LINK1"/>подешавањима<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Да, омогући</translation>
+<translation id="2410754283952462441">Изаберите налог</translation>
+<translation id="2227444325776770048">Настави као <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Нисте <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Да би вам обележивачи били доступни на свим уређајима, укључите синхронизацију</translation>
+<translation id="2818669890320396765">Да би вам обележивачи били доступни на свим уређајима, пријавите се и укључите синхронизацију</translation>
+<translation id="6003646045106347985">Да бисте добијали персонализовани садржај који предлаже Brave Software, укључите синхронизацију</translation>
+<translation id="8494430740943879273">Да бисте добијали персонализовани садржај који предлаже Brave Software, пријавите се и укључите синхронизацију</translation>
+<translation id="5862731021271217234">Да би вам картице биле доступне на другим уређајима, укључите синхронизацију</translation>
+<translation id="3568688522516854065">Да би вам картице биле доступне на другим уређајима, пријавите се и укључите синхронизацију</translation>
+<translation id="1208340532756947324">Да бисте синхронизовали и персонализовали садржај на уређајима, укључите синхронизацију</translation>
+<translation id="4472118726404937099">Да бисте синхронизовали и персонализовали садржај на уређајима, пријавите се и укључите синхронизацију</translation>
+<translation id="2426805022920575512">Изаберите други налог</translation>
+<translation id="6790428901817661496">Пусти</translation>
+<translation id="1272079795634619415">Заустави</translation>
+<translation id="2874939134665556319">Претходна песма</translation>
+<translation id="4046123991198612571">Следећа песма</translation>
+<translation id="3859306556332390985">Премотај унапред</translation>
+<translation id="8441146129660941386">Премотај уназад</translation>
+<translation id="6706288973712894588">Тренутно сте офлајн.\n<ph name="BEGIN_LINK"/>Истражите офлајн фид.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Недавно коришћене картице</translation>
+<translation id="8497726226069778601">Овде нема ничега... засад</translation>
+<translation id="5423934151118863508">Најчешће посећиване странице ће се појавити овде</translation>
+<translation id="6127379762771434464">Уклонили сте ставку</translation>
+<translation id="4605958867780575332">Ставка је уклоњена: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software дудл логотип: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Други уређаји</translation>
+<translation id="4738836084190194332">Последња синхронизација: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Пре # минута}one{Пре # минута}few{Пре # минута}other{Пре # минута}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Пре # сата}one{Пре # сата}few{Пре # сата}other{Пре # сати}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Пре # дана}one{Пре # дана}few{Пре # дана}other{Пре # дана}}</translation>
+<translation id="2762000892062317888">малопре</translation>
+<translation id="1407135791313364759">Отвори све</translation>
+<translation id="1209206284964581585">Сакриј за сада</translation>
+<translation id="129553762522093515">Недавно затворено</translation>
+<translation id="8413126021676339697">Прикажи сву историју</translation>
+<translation id="7876243839304621966">Уклони све</translation>
+<translation id="8487700953926739672">Доступно ван мреже</translation>
+<translation id="5224771365102442243">Са видеом</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Сазнајте више<ph name="END_LINK"/> о предложеном садржају</translation>
+<translation id="7542481630195938534">Не можете да добијете предлоге</translation>
+<translation id="5013696553129441713">Нема нових предлога</translation>
+<translation id="1736419249208073774">Истражи</translation>
+<translation id="7444811645081526538">Још категорија</translation>
+<translation id="6709133671862442373">Вести</translation>
+<translation id="1264974993859112054">Спорт</translation>
+<translation id="9139318394846604261">Шопинг</translation>
+<translation id="3912508018559818924">Траже се најбољи подаци са веба…</translation>
+<translation id="526421993248218238">Учитавање ове странице није успело</translation>
+<translation id="614940544461990577">Покушајте:</translation>
+<translation id="3288003805934695103">да поново учитате страницу</translation>
+<translation id="2353636109065292463">Проверава се интернет веза</translation>
+<translation id="2858138569776157458">Најбољи сајтови</translation>
+<translation id="8364299278605033898">Погледајте популарне веб-сајтове</translation>
+<translation id="1171770572613082465">Додирните дугме „Најпопуларнији веб-сајтови“ и видите те веб-сајтове</translation>
+<translation id="5233638681132016545">Нова картица</translation>
+<translation id="4521874409998847950">Од објављивача <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>приказује Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Доступна је новија верзија</translation>
+<translation id="4058091506841967397">Brave се неће ажурирати</translation>
+<translation id="6316139424528454185">Неподржана верзија Android-а</translation>
+<translation id="6989267951144302301">Преузимање није успело</translation>
+<translation id="624789221780392884">Ажурирање је спремно</translation>
+<translation id="1549000191223877751">Премести у други прозор</translation>
+<translation id="7481312909269577407">Проследи</translation>
+<translation id="4084682180776658562">Обележивач</translation>
+<translation id="6437478888915024427">Информације о страници</translation>
+<translation id="7180611975245234373">Освежи</translation>
+<translation id="4913169188695071480">Заустави освежавање</translation>
+<translation id="1829244130665387512">Пронађи на страници</translation>
+<translation id="6593061639179217415">Верзија сајта за рачунар</translation>
+<translation id="9063523880881406963">Искључи захтевање верзије сајта за рачунаре</translation>
+<translation id="2038563949887743358">Укључи захтевање верзије сајта за рачунаре</translation>
+<translation id="2433507940547922241">Изглед</translation>
+<translation id="983192555821071799">Затвори све картице</translation>
+<translation id="1310482092992808703">Групиши картице</translation>
+<translation id="7725024127233776428">Странице које обележите се приказују овде</translation>
+<translation id="4404568932422911380">Нема обележивача</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> обележивач}one{<ph name="BOOKMARKS_COUNT_MANY"/> обележивач}few{<ph name="BOOKMARKS_COUNT_MANY"/> обележивача}other{<ph name="BOOKMARKS_COUNT_MANY"/> обележивача}}</translation>
+<translation id="3739899004075612870">Обележено у <ph name="PRODUCT_NAME"/>-у</translation>
+<translation id="3207960819495026254">Обележено</translation>
+<translation id="4452548195519783679">Обележивач је додат у <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Додавање обележивача није успело.</translation>
+<translation id="2842985007712546952">Надређени директоријум</translation>
+<translation id="9065203028668620118">Измени</translation>
+<translation id="4405224443901389797">Премести у...</translation>
+<translation id="5170568018924773124">Прикажи у директоријуму</translation>
+<translation id="8035133914807600019">Нови директоријум...</translation>
+<translation id="4532845899244822526">Изаберите директоријум</translation>
+<translation id="6627583120233659107">Измени директоријум</translation>
+<translation id="1197267115302279827">Премести обележиваче</translation>
+<translation id="6963766334940102469">Избриши обележиваче</translation>
+<translation id="4351244548802238354">Затвори дијалог</translation>
+<translation id="451872707440238414">Претражите обележиваче</translation>
+<translation id="8901170036886848654">Није пронађен ниједан обележивач</translation>
+<translation id="6404511346730675251">Измена обележивача</translation>
+<translation id="3894427358181296146">Додајте директоријум</translation>
+<translation id="5327248766486351172">Назив</translation>
+<translation id="7400418766976504921">URL адреса</translation>
+<translation id="3527085408025491307">Директоријум</translation>
+<translation id="5161254044473106830">Наслов је обавезан</translation>
+<translation id="2996809686854298943">URL је обавезан</translation>
+<translation id="2536728043171574184">Прегледате офлајн копију ове странице</translation>
+<translation id="4698034686595694889">Прегледајте офлајн у апликацији <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> и још сајтова</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave ће учитати страницу када буде спремна}one{Brave ће учитати странице када буду спремне}few{Brave ће учитати странице када буду спремне}other{Brave ће учитати странице када буду спремне}}</translation>
+<translation id="6811034713472274749">Страница је спремна за преглед</translation>
+<translation id="4561979708150884304">Веза није успостављена</translation>
+<translation id="8274165955039650276">Погледајте преузимања</translation>
+<translation id="2082238445998314030"><ph name="RESULT_NUMBER"/>. од <ph name="TOTAL_RESULTS"/> резултата</translation>
+<translation id="4943872375798546930">Нема резултата</translation>
+<translation id="981121421437150478">Офлајн</translation>
+<translation id="3298243779924642547">Лагано</translation>
+<translation id="393697183122708255">Није доступна нијед. омогућ. глас. прет.</translation>
+<translation id="7191430249889272776">Картица је отворена у позадини.</translation>
+<translation id="8445059357334030806">Отвори у Brave-у</translation>
+<translation id="4720023427747327413">Отвори у <ph name="PRODUCT_NAME"/>-у</translation>
+<translation id="7022756207310403729">Отвори у прегледачу</translation>
+<translation id="1113597929977215864">Прикажи поједностављени приказ</translation>
+<translation id="1513352483775369820">Обележивачи и веб-историја</translation>
+<translation id="4939482511480190003">Помозите нам да побољшамо Brave. <ph name="BEGIN_LINK"/>Попуните анкету<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Назад</translation>
+<translation id="5596627076506792578">Још опција</translation>
+<translation id="3522247891732774234">Ажурирање је доступно. Још опција</translation>
+<translation id="6773423637732432200">Brave не може да се ажурира. Још опција</translation>
+<translation id="3328801116991980348">Информације о сајту</translation>
+<translation id="5391532827096253100">Веза са овим сајтом није безбедна. Информације о сајту</translation>
+<translation id="6206551242102657620">Веза је безбедна. Информације о сајту</translation>
+<translation id="6963642900430330478">Ова страница је опасна. Информације о сајту</translation>
+<translation id="9070377983101773829">Започни гласовну претрагу</translation>
+<translation id="8676374126336081632">Обриши унос</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> отворена картица, додирните да бисте прешли на другу картицу}one{<ph name="OPEN_TABS_MANY"/> отворена картица, додирните да бисте прешли на другу картицу}few{<ph name="OPEN_TABS_MANY"/> отворене картице, додирните да бисте прешли на другу картицу}other{<ph name="OPEN_TABS_MANY"/> отворених картица, додирните да бисте прешли на другу картицу}}</translation>
+<translation id="2369533728426058518">отворене картице</translation>
+<translation id="7071521146534760487">Управљајте налогом</translation>
+<translation id="932327136139879170">Почетна</translation>
+<translation id="2707726405694321444">Освежи страницу</translation>
+<translation id="2891154217021530873">Заустави учитавање странице</translation>
+<translation id="6710213216561001401">Претходно</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Изабране картице</translation>
+<translation id="2268044343513325586">Прецизирај</translation>
+<translation id="7846076177841592234">Откажи избор</translation>
+<translation id="7087918508125750058">Изабрали сте <ph name="ITEM_COUNT"/>. Опције су доступне при врху екрана</translation>
+<translation id="7250468141469952378">Изабрали сте <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Дели 1 изабрану ставку}one{Дели # изабрану ставку}few{Дели # изабране ставке}other{Дели # изабраних ставки}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Уклони 1 изабрану ставку}one{Уклони # изабрану ставку}few{Уклони # изабране ставке}other{Уклони # изабраних ставки}}</translation>
+<translation id="1283039547216852943">Додирните да бисте проширили</translation>
+<translation id="5962718611393537961">Додирните да бисте скупили</translation>
+<translation id="8076492880354921740">Картице</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Изабрано: 1}one{Изабрано: #}few{Изабрано: #}other{Изабрано: #}}</translation>
+<translation id="6818926723028410516">Изаберите ставке</translation>
+<translation id="4797039098279997504">Додирните да бисте се вратили на <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Додирните да бисте отишли на сајт</translation>
+<translation id="429312253194641664">Сајт пушта медијски садржај</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> дели екран</translation>
+<translation id="8833831881926404480">Сајт дели ваш екран</translation>
+<translation id="9086455579313502267">Не можемо да приступимо мрежи</translation>
+<translation id="938850635132480979">Грешка: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Отвори у <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Отворите у апликацији за мапе</translation>
+<translation id="7698359219371678927">Напишите имејл у апликацији <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Напишите имејл</translation>
+<translation id="5665379678064389456">Направите догађај у апликацији <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Направите догађај</translation>
+<translation id="2111511281910874386">Иди на страницу</translation>
+<translation id="3988466920954086464">Погледајте инстант резултате претраге на овој табли</translation>
+<translation id="2744248271121720757">Додирните реч да бисте је тренутно претражили или видели повезане радње</translation>
+<translation id="9155898266292537608">Можете и кратко да додирнете реч да бисте је претражили</translation>
+<translation id="3232754137068452469">Веб-апликација</translation>
+<translation id="1430915738399379752">Штампај</translation>
+<translation id="3775705724665058594">Пошаљите на своје уређаје</translation>
+<translation id="6364438453358674297">Желите ли да уклоните предлог из историје?</translation>
+<translation id="213279576345780926">Затворили сте картицу <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139">Затворених картица: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Ставка <ph name="ITEM_TITLE"/> је избрисана</translation>
+<translation id="4663756553811254707">Избрисали сте <ph name="NUMBER_OF_BOOKMARKS"/> обележивача</translation>
+<translation id="3819178904835489326">Избрисана преузимања: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Неподржан број Brave инстанци.</translation>
+<translation id="4259722352634471385">Навигација је блокирана: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Навигација је недоступна: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Затвори картицу</translation>
+<translation id="7772375229873196092">Затвори <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Историја навигације</translation>
+<translation id="9169507124922466868">Историја навигације је полуотворена</translation>
+<translation id="1327257854815634930">Историја навигације је отворена</translation>
+<translation id="8788265440806329501">Историја навигације је затворена</translation>
+<translation id="7482656565088326534">Картица за преглед</translation>
+<translation id="8427875596167638501">Картица за преглед је полуотворена</translation>
+<translation id="9102803872260866941">Картица за преглед је отворена</translation>
+<translation id="2942036813789421260">Картица за преглед је затворена</translation>
+<translation id="6355102470683871794">Меморијски простор за Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Бришете меморију сајта?</translation>
+<translation id="9205995714227143200">Меморијски простор за сајтове који Brave не сматра важним (нпр. сајтови без сачуваних подешавања или сајтови које не посећујете често)</translation>
+<translation id="3997476611815694295">Неважан меморијски простор</translation>
+<translation id="8493948351860045254">Ослободите простор</translation>
+<translation id="2324920234469020158">Овим ћете обрисати колачиће, кеш и друге податке сајтова које Brave не сматра важним.</translation>
+<translation id="5447201525962359567">Целокупан меморијски простор за сајт, укључујући колачиће и друге локално сачуване податке</translation>
+<translation id="1376578503827013741">Рачуна се…</translation>
+<translation id="583281660410589416">Непознато</translation>
+<translation id="2323763861024343754">Меморијски простор за сајт</translation>
+<translation id="3587672679800759167">Сви подаци које користи Brave, укључујући налоге, обележиваче и сачувана подешавања</translation>
+<translation id="6545017243486555795">Обриши све податке</translation>
+<translation id="4095146165863963773">Желите ли да избришете податке апликације?</translation>
+<translation id="53119194224775367">Сви подаци Brave апликација ће бити трајно избрисани. То обухвата све датотеке, подешавања, налоге, базе података итд.</translation>
+<translation id="5307446750509046227">Обриши складиште сајта</translation>
+<translation id="300526633675317032">Овим ћете обрисати цео меморијски простор веб-сајта од <ph name="SIZE_IN_KB"/>.</translation>
+<translation id="8068648041423924542">Није могуће изабрати сертификат.</translation>
+<translation id="2315043854645842844">Оперативни систем не подржава избор сертификата за клијента.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> жели да се повеже</translation>
+<translation id="5308380583665731573">Повезивање</translation>
+<translation id="868929229000858085">Претражите контакте</translation>
+<translation id="1919950603503897840">Изаберите контакте</translation>
+<translation id="7986741934819883144">Изаберите контакт</translation>
+<translation id="3333961966071413176">Сви контакти</translation>
+<translation id="4994033804516042629">Није пронађен ниједан контакт</translation>
+<translation id="5403592356182871684">Имена</translation>
+<translation id="2717722538473713889">Имејл адресе</translation>
+<translation id="381841723434055211">Бројеви телефона</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(и још 1)}one{(и још #)}few{(и још #)}other{(и још #)}}</translation>
+<translation id="5197729504361054390">Контакти које изаберете ће се делити са <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Декодер слика</translation>
+<translation id="8067883171444229417">Пусти видео</translation>
+<translation id="6560414384669816528">Претрага помоћу Sogou-а</translation>
+<translation id="5406914950576900927">Brave може да користи <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> за претрагу у Кини. Ово можете да промените у <ph name="BEGIN_LINK"/>Подешавањима<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Задржи Brave Software</translation>
+<translation id="4384468725000734951">Користите Sogou за претрагу</translation>
+<translation id="6103327872225198548">Користите Brave Software за претрагу</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Ова апликација је активна у Brave-у</translation>
+<translation id="6143689084714664628">Покренуто је у Brave-у</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> такође има податке у Brave-у</translation>
+<translation id="2734140769649165081">Можете да обришете податке у Brave подешавањима</translation>
+<translation id="8232956427053453090">Задржи податке</translation>
+<translation id="4298388696830689168">Повезани сајтови</translation>
+<translation id="5763514718066511291">Додирните да бисте копирали URL за ову апликацију</translation>
+<translation id="6496823230996795692">Да бисте први пут користили <ph name="APP_NAME"/>, повежите се на интернет.</translation>
+<translation id="751961395872307827">Повезивање са сајтом није успело</translation>
+<translation id="4878404682131129617">Успостављање тунела преко прокси сервера није успело</translation>
+<translation id="4749960740855309258">Отворите нову картицу</translation>
+<translation id="8788968922598763114">Поновно отварање последње затворене картице</translation>
+<translation id="7929962904089429003">Отворите мени</translation>
+<translation id="6039379616847168523">Прелазак на следећу картицу</translation>
+<translation id="5210286577605176222">Прелазак на претходну картицу</translation>
+<translation id="124678866338384709">Затварање актуелне картице</translation>
+<translation id="3714981814255182093">Отварање траке за тражење</translation>
+<translation id="5441522332038954058">Прелазак на траку за адресу</translation>
+<translation id="3398320232533725830">Отварање Менаџера обележивача</translation>
+<translation id="6583199322650523874">Обележавање тренутне странице</translation>
+<translation id="8489271220582375723">Отварање странице историја</translation>
+<translation id="4837753911714442426">Отварање опција за штампање странице</translation>
+<translation id="5726692708398506830">Увећавање целокупног приказа странице</translation>
+<translation id="3259831549858767975">Умањивање целокупног приказа странице</translation>
+<translation id="8015452622527143194">Враћање целокупног приказа странице на подразумевану величину</translation>
+<translation id="3443221991560634068">Поновно учитавање актуелне странице</translation>
+<translation id="123724288017357924">Поновно учитавање актуелне странице, занемарујући кеширани садржај</translation>
+<translation id="305870044889644984">Отварање Brave центра за помоћ на новој картици</translation>
+<translation id="3166827708714933426">Пречице за картице и прозоре</translation>
+<translation id="3169981355900570544">Пречице за Brave Software Brave функције</translation>
+<translation id="4558311620361989323">Пречице за веб-странице</translation>
+<translation id="1908301351964700579">Brave се још припрема за ВР. Касније рестартујте Brave.</translation>
+<translation id="8970887620466824814">Дошло је до грешке.</translation>
+<translation id="1875543012935658554">Поново отворите Brave.</translation>
+<translation id="79859296434321399">Да бисте видели садржај проширене реалности, инсталирајте ARCore</translation>
+<translation id="8558485628462305855">Да бисте видели садржај проширене реалности, ажурирајте ARCore</translation>
+<translation id="3513704683820682405">Проширена реалност</translation>
+<translation id="5475862044948910901">Желите ли да започнете сесију проширене реалности?</translation>
 <translation id="7365126855094612066">Током трајања ове сесије, сајт ће моћи:
 • да прави 3D мапу окружења
 • да прати померање камере
 
 Сајт НЕМА приступ камери. Слике са камере су видљиве само вама.</translation>
-<translation id="7375125077091615385">Тип:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL адреса</translation>
-<translation id="7403691278183511381">Chrome доживљај првог покретања</translation>
-<translation id="741204030948306876">Да, омогући</translation>
-<translation id="7413229368719586778">Датум почетка: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Прво питај</translation>
-<translation id="7423538860840206698">Читање привремене меморије је блокирано</translation>
-<translation id="7431991332293347422">Контролишите како се историја прегледања користи за персонализовање Претраге и других услуга</translation>
-<translation id="7437998757836447326">Одјављивање из Chrome-а</translation>
-<translation id="7438641746574390233">Када је Lite режим укључен, Chrome убрзава учитавање страница помоћу Google сервера. Lite режим поново уписује веома споре странице да би учитавале само садржај који је неопходан. Lite режим се не примењује на картице без архивирања.</translation>
-<translation id="7444811645081526538">Још категорија</translation>
-<translation id="7445411102860286510">Дозволи сајтовима да аутоматски пуштају видео снимке са искљученим звуком (препоручено)</translation>
-<translation id="7453467225369441013">Одјавиће вас са већине сајтова. Неће вас одјавити са Google налога.</translation>
-<translation id="7454641608352164238">Нема довољно простора</translation>
-<translation id="7475192538862203634">Ако вам се ово често приказује, испробајте ове <ph name="BEGIN_LINK" />предлоге<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">SD картица није пронађена. Неке датотеке можда недостају.</translation>
-<translation id="7479104141328977413">Управљање картицама</translation>
-<translation id="7481312909269577407">Проследи</translation>
-<translation id="7482656565088326534">Картица за преглед</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (ажурирано је <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">уштеђених података</translation>
-<translation id="7498271377022651285">Сачекајте...</translation>
-<translation id="7514365320538308">Преузми</translation>
-<translation id="751961395872307827">Повезивање са сајтом није успело</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Не можете да добијете предлоге</translation>
-<translation id="7559975015014302720">Lite режим је искључен</translation>
-<translation id="7562080006725997899">Брисање података прегледања</translation>
-<translation id="756809126120519699">Chrome подаци су обрисани</translation>
-<translation id="757524316907819857">Блокирај да сајтови пуштају заштићени садржај</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Преузели сте <ph name="FILES_DOWNLOADED_ONE" /> датотеку}one{Преузели сте <ph name="FILES_DOWNLOADED_MANY" /> датотеку}few{Преузели сте <ph name="FILES_DOWNLOADED_MANY" /> датотеке}other{Преузели сте <ph name="FILES_DOWNLOADED_MANY" /> датотека}}</translation>
-<translation id="7588219262685291874">Укључи тамну тему када је Уштеда батерије на уређају укључена</translation>
-<translation id="7589445247086920869">Блокирај за актуелни претраживач</translation>
-<translation id="7593557518625677601">Отворите Android подешавања и поново омогућите синхронизацију Android система да бисте започели Chrome синхронизацију</translation>
-<translation id="7596558890252710462">Оперативни систем</translation>
-<translation id="7605594153474022051">Синхронизација не функционише</translation>
-<translation id="7606077192958116810">Lite режим је укључен. Управљајте њиме у Подешавањима.</translation>
-<translation id="7612619742409846846">Пријављени сте у Google као</translation>
-<translation id="7619072057915878432">Преузимање датотеке <ph name="FILE_NAME" /> није успело због проблема са мрежом.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Потражите помоћ<ph name="END_LINK1" /> или <ph name="BEGIN_LINK2" />поново скенирајте<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Добро дошли у Chrome</translation>
-<translation id="7638584964844754484">Неисправна приступна фраза</translation>
-<translation id="7641339528570811325">Обриши податке прегледања…</translation>
-<translation id="7648422057306047504">Шифрујте лозинке помоћу Google акредитива</translation>
-<translation id="7649070708921625228">Помоћ</translation>
-<translation id="7658239707568436148">Откажи</translation>
-<translation id="7665369617277396874">Додајте налог</translation>
-<translation id="766587987807204883">Овде се појављују чланци, које можете да читате чак и када сте офлајн</translation>
-<translation id="7682724950699840886">Испробајте следеће савете: проверите да ли на уређају има довољно простора, па пробајте да поново извезете лозинке.</translation>
-<translation id="7685301384041462804">Уверите се да је сајт поуздан пре покретања ВР режима.</translation>
-<translation id="7698359219371678927">Напишите имејл у апликацији <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Аутоматски довршавај претраге и URL-ове</translation>
-<translation id="7725024127233776428">Странице које обележите се приказују овде</translation>
-<translation id="773466115871691567">Увек предводи странице на језику <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Да би откривао опасне апликације и сајтове, Chrome шаље Google-у URL-ове неких страница које посећујете, ограничене информације о систему и одређени садржај страница</translation>
-<translation id="7757787379047923882">Текст дељен са уређаја <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD картица <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Додајте адресу</translation>
-<translation id="7772032839648071052">Потврди приступну фразу</translation>
-<translation id="7772375229873196092">Затвори <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}few{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 и још <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Јуче</translation>
-<translation id="7791543448312431591">Додај</translation>
-<translation id="780301667611848630">Не, хвала</translation>
-<translation id="7810647596859435254">Отвори помоћу…</translation>
-<translation id="7821588508402923572">Уштеда података се приказује овде</translation>
-<translation id="7837721118676387834">Дозволите аутоплеј за видео снимке са искљученим звуком за одређени сајт.</translation>
-<translation id="7846076177841592234">Откажи избор</translation>
-<translation id="784934925303690534">Временски опсег</translation>
-<translation id="7851858861565204677">Други уређаји</translation>
-<translation id="7875915731392087153">Напишите имејл</translation>
-<translation id="7876243839304621966">Уклони све</translation>
-<translation id="7882131421121961860">Историја није пронађена</translation>
-<translation id="7882806643839505685">Дозволи звук за одређени сајт.</translation>
-<translation id="7886917304091689118">Покренуто је у Chrome-у</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Преузима се датотека.}one{Преузима се # датотека.}few{Преузимају се # датотеке.}other{Преузима се # датотека.}}</translation>
-<translation id="7929962904089429003">Отворите мени</translation>
-<translation id="7942131818088350342">Производ <ph name="PRODUCT_NAME" /> је застарео.</translation>
-<translation id="7947953824732555851">Прихвати и пријави ме</translation>
-<translation id="7963646190083259054">Продавац:</translation>
-<translation id="7971136598759319605">Последња активност: пре 1 дан</translation>
-<translation id="7975379999046275268">Прикажи страницу <ph name="BEGIN_NEW" />Ново<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Странице се учитавају унапред ради бржег прегледања и претраживања</translation>
-<translation id="79859296434321399">Да бисте видели садржај проширене реалности, инсталирајте ARCore</translation>
-<translation id="7986741934819883144">Изаберите контакт</translation>
-<translation id="7987073022710626672">Chrome услови коришћења услуге</translation>
-<translation id="7998918019931843664">Поново отворите затворену картицу</translation>
-<translation id="7999064672810608036">Желите ли стварно да обришете све локалне податке, укључујући колачиће, и ресетујете све дозволе за овај веб-сајт?</translation>
-<translation id="8004582292198964060">Прегледач</translation>
-<translation id="8007176423574883786">Искључено је за овај уређај</translation>
-<translation id="8013372441983637696">Обриши Chrome податке и са овог уређаја</translation>
-<translation id="8015452622527143194">Враћање целокупног приказа странице на подразумевану величину</translation>
-<translation id="802154636333426148">Преузимање није успело</translation>
-<translation id="8026334261755873520">Обришите податке прегледања</translation>
-<translation id="8035133914807600019">Нови директоријум...</translation>
-<translation id="8037750541064988519">Још <ph name="DAYS" /> дана</translation>
-<translation id="804335162455518893">SD картица није пронађена</translation>
-<translation id="805047784848435650">На основу историје прегледања</translation>
-<translation id="8051695050440594747">Доступно је <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">Отвори на новој Chrome картици</translation>
-<translation id="8063895661287329888">Додавање обележивача није успело.</translation>
-<translation id="806745655614357130">Не обједињуј моје податке</translation>
-<translation id="8067883171444229417">Пусти видео</translation>
-<translation id="8068648041423924542">Није могуће изабрати сертификат.</translation>
-<translation id="8073388330009372546">Отвори слику на новој картици</translation>
-<translation id="8076492880354921740">Картице</translation>
-<translation id="8084114998886531721">Сачувана лозинка</translation>
-<translation id="8087000398470557479">Овај садржај је са <ph name="DOMAIN_NAME" />, приказује Google.</translation>
-<translation id="8103578431304235997">Картице без архивирања</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Да би вам обележивачи били доступни на свим уређајима, укључите синхронизацију</translation>
-<translation id="8110087112193408731">Желите ли да се Chrome активности приказују у Дигиталном благостању?</translation>
-<translation id="8116925261070264013">Звук је искључен</translation>
-<translation id="813082847718468539">Погледајте информације о сајту</translation>
-<translation id="8131740175452115882">Потврди</translation>
-<translation id="8156139159503939589">На којим језицима читате?</translation>
-<translation id="8168435359814927499">Садржај</translation>
-<translation id="8186512483418048923">Преостале датотеке: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Још 1 дан</translation>
-<translation id="8200772114523450471">Настави</translation>
-<translation id="8209050860603202033">Отвори слику</translation>
-<translation id="8218622182176210845">Управљајте налогом</translation>
-<translation id="8224471946457685718">Преузимај чланке за мене преко Wi-Fi мреже</translation>
-<translation id="8232956427053453090">Задржи податке</translation>
-<translation id="8249310407154411074">Премести на врх</translation>
-<translation id="8250920743982581267">Документи</translation>
-<translation id="825412236959742607">Ова страница користи превише меморије, па је Chrome уклонио одређени садржај.</translation>
-<translation id="8260126382462817229">Пробајте поново да се пријавите</translation>
-<translation id="8261506727792406068">Избриши</translation>
-<translation id="8266862848225348053">Локација за преузимање</translation>
-<translation id="8274165955039650276">Погледајте преузимања</translation>
-<translation id="8284326494547611709">Титл</translation>
-<translation id="8300705686683892304">Управља апликација</translation>
-<translation id="8310344678080805313">Стандардне картице</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> и још сајтова</translation>
-<translation id="8327155640814342956">Ако желите најбољи доживљај прегледања, отворите Chrome да бисте га ажурирали</translation>
-<translation id="8339163506404995330">Странице на језику <ph name="LANGUAGE" /> се неће преводити</translation>
-<translation id="8349013245300336738">Сортирај по количини искоришћених података</translation>
-<translation id="8364299278605033898">Погледајте популарне веб-сајтове</translation>
-<translation id="8368027906805972958">Непознат или неподржан уређај (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Дозволите Синхронизацију у позадини за одређени сајт.</translation>
-<translation id="8378714024927312812">Овим управља организација</translation>
-<translation id="8380167699614421159">Овај сајт приказује огласе који ометају активности или обмањујуће огласе</translation>
-<translation id="8393700583063109961">Пошаљите поруку</translation>
-<translation id="8413126021676339697">Прикажи сву историју</translation>
-<translation id="8427875596167638501">Картица за преглед је полуотворена</translation>
-<translation id="8428213095426709021">Подешавања</translation>
-<translation id="8438566539970814960">Побољшај претраге и прегледање</translation>
-<translation id="8441146129660941386">Премотај уназад</translation>
-<translation id="8443209985646068659">Chrome се неће ажурирати</translation>
-<translation id="8445448999790540984">Извоз лозинки није успео</translation>
-<translation id="8447861592752582886">Опозови дозволу за уређај</translation>
-<translation id="8461694314515752532">Шифрујте синхронизоване податке помоћу сопствене приступне фразе за синхронизацију</translation>
-<translation id="8466613982764129868">Уверите се да је <ph name="TARGET_DEVICE_NAME" /> повезан на интернет</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Доступно ван мреже</translation>
-<translation id="8489271220582375723">Отварање странице историја</translation>
-<translation id="8493948351860045254">Ослободите простор</translation>
-<translation id="8497726226069778601">Овде нема ничега... засад</translation>
-<translation id="8503559462189395349">Лозинке за Chrome</translation>
-<translation id="8503813439785031346">Корисничко име</translation>
-<translation id="8514477925623180633">Извезите лозинке сачуване у Chrome-у</translation>
-<translation id="8514577642972634246">Уђи у режим без архивирања</translation>
-<translation id="851751545965956758">Онемогући сајтовима да се повезују са уређајима</translation>
-<translation id="8523928698583292556">Избриши сачувану лозинку</translation>
-<translation id="854522910157234410">Отвори ову страницу</translation>
-<translation id="8558485628462305855">Да бисте видели садржај проширене реалности, ажурирајте ARCore</translation>
-<translation id="8559990750235505898">Понуди превод страница на друге језике</translation>
-<translation id="8562452229998620586">Сачуване лозинке ће се појавити овде.</translation>
-<translation id="8569404424186215731">од <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Последње 4 недеље</translation>
-<translation id="857943718398505171">Дозвољено (препоручено)</translation>
-<translation id="8583805026567836021">Брисање података о налогу</translation>
-<translation id="860043288473659153">Име власника картице</translation>
-<translation id="8609465669617005112">Премести нагоре</translation>
-<translation id="8616006591992756292">Google налог може да има друге облике историје прегледања на <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Желите ли да отворите предложени URL наведен у преузетом садржају?</translation>
-<translation id="8636825310635137004">Да би вам картице биле доступне на другим уређајима, укључите синхронизацију.</translation>
-<translation id="8641930654639604085">Покушај да блокираш сајтове са садржајем за одрасле</translation>
-<translation id="8655129584991699539">Можете да обришете податке у Chrome подешавањима</translation>
-<translation id="8662811608048051533">Одјавиће вас са већине сајтова.</translation>
-<translation id="8664979001105139458">Име датотеке већ постоји</translation>
-<translation id="8676374126336081632">Обриши унос</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Ниво јачине сигнала: # црта}one{Ниво јачине сигнала: # црта}few{Ниво јачине сигнала: # црте}other{Ниво јачине сигнала: # црта}}</translation>
-<translation id="868929229000858085">Претражите контакте</translation>
-<translation id="869891660844655955">Датум истека</translation>
-<translation id="8719023831149562936">Није могуће пребацити актуелну картицу</translation>
-<translation id="8725066075913043281">Пробајте поново</translation>
-<translation id="8728487861892616501">Ако користите ову апликацију, прихватате Chrome <ph name="BEGIN_LINK1" />услове коришћења услуге<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />обавештење о приватности<ph name="END_LINK2" />, као и <ph name="BEGIN_LINK3" />обавештење о приватности за Google налоге којима се управља помоћу Family Link-а<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Готово</translation>
-<translation id="8748850008226585750">Садржај је сакривен</translation>
-<translation id="8751914237388039244">Изаберите слику</translation>
-<translation id="8788265440806329501">Историја навигације је затворена</translation>
-<translation id="8788968922598763114">Поновно отварање последње затворене картице</translation>
-<translation id="8801436777607969138">Блокирајте JavaScript за одређени сајт.</translation>
-<translation id="8812260976093120287">На неким веб-сајтовима можете да плаћате помоћу претходно наведених подржаних апликација за плаћање на уређају.</translation>
-<translation id="8816026460808729765">Не дозвољавај сајтовима да приступају сензорима</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> ће се отворити у Chrome-у. Ако наставите, прихватате Chrome <ph name="BEGIN_LINK1" />услове коришћења услуге<ph name="END_LINK1" /> и <ph name="BEGIN_LINK2" />обавештење о приватности<ph name="END_LINK2" />, као и <ph name="BEGIN_LINK3" />обавештење о приватности за Google налоге којима се управља помоћу Family Link-а<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Обележивачи</translation>
-<translation id="8833831881926404480">Сајт дели ваш екран</translation>
-<translation id="883806473910249246">Дошло је до грешке при преузимању садржаја.</translation>
-<translation id="8840953339110955557">Ова страница може да се разликује од онлајн верзије.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, картица</translation>
-<translation id="885701979325669005">Меморијски простор</translation>
-<translation id="889338405075704026">Идите у подешавања Chrome-а</translation>
-<translation id="8901170036886848654">Није пронађен ниједан обележивач</translation>
-<translation id="8909135823018751308">Дели...</translation>
-<translation id="8912362522468806198">Google налога</translation>
-<translation id="8920114477895755567">Чекају се детаљи родитеља.</translation>
+<translation id="1188239144602654184">Уђи у ПР</translation>
+<translation id="473775607612524610">Ажурирај</translation>
+<translation id="3133489217401741157">Инсталира се <ph name="MODULE"/> за Brave…</translation>
+<translation id="1791662854739702043">Инсталирано</translation>
+<translation id="5131234170665854056">Инсталирање модула <ph name="MODULE"/> за Brave није успело</translation>
+<translation id="2567385386134582609">СЛИКА</translation>
+<translation id="6395288395575013217">ЛИНК</translation>
+<translation id="7352939065658542140">ВИДЕО</translation>
+<translation id="4116038641877404294">Преузмите странице да бисте их користили офлајн</translation>
 <translation id="8922289737868596582">Преузмите странице помоћу дугмета Још опција да бисте их користили офлајн</translation>
-<translation id="8937772741022875483">Желите ли да уклоните Chrome активности из Дигиталног благостања?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Отвори у другом прозору</translation>
-<translation id="8951232171465285730">Chrome вам је уштедео <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">Блокирајте колачиће за одређени сајт.</translation>
-<translation id="8959122750345127698">Навигација је недоступна: <ph name="URL" /></translation>
-<translation id="8965591936373831584">на чекању</translation>
-<translation id="8970887620466824814">Дошло је до грешке.</translation>
-<translation id="8972098258593396643">Преузимате у подразумевани директоријум?</translation>
-<translation id="8986494364107987395">Аутоматски шаљи Google-у статистичке податке о коришћењу и извештаје о отказивању</translation>
-<translation id="8993760627012879038">Отварање нове картице у режиму без архивирања</translation>
-<translation id="8998729206196772491">Пријављујете се помоћу налога којим управља <ph name="MANAGED_DOMAIN" /> и дајете његовом администратору контролу над својим Chrome подацима. Подаци ће постати трајно повезани са тим налогом. Одјављивањем из Chrome-а ћете избрисати податке са овог уређаја, али ће они остати сачувани на Google налогу.</translation>
-<translation id="9019902583201351841">Овим управљају твоји родитељи</translation>
-<translation id="9028914725102941583">Укључите синхронизацију да бисте делили садржај на више уређаја</translation>
-<translation id="9029323097866369874">Желите ли да дозволите сајту <ph name="DOMAIN" /> да покрене ВР?</translation>
-<translation id="9040142327097499898">Обавештења су дозвољена. Локација је искључена за овај уређај.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# видео}one{# видео снимак}few{# видео снимка}other{# видео снимака}}</translation>
-<translation id="9050666287014529139">Приступна фраза</translation>
-<translation id="9063523880881406963">Искључи захтевање верзије сајта за рачунаре</translation>
-<translation id="9065203028668620118">Измени</translation>
-<translation id="9070377983101773829">Започни гласовну претрагу</translation>
-<translation id="9074336505530349563">Да бисте добијали персонализовани садржај који предлаже Google, пријавите се и укључите синхронизацију</translation>
-<translation id="9086455579313502267">Не можемо да приступимо мрежи</translation>
-<translation id="9100505651305367705">Понуди приказивање чланака у поједностављеном приказу када је то подржано</translation>
-<translation id="9100610230175265781">Потребна је приступна фраза</translation>
-<translation id="9102803872260866941">Картица за преглед је отворена</translation>
+<translation id="5958275228015807058">Пронађите датотеке и странице у Преузимањима</translation>
+<translation id="5620928963363755975">Пронађите датотеке и странице у Преузимањима помоћу дугмета Још опција</translation>
+<translation id="3341058695485821946">Погледајте колико сте података уштедели</translation>
+<translation id="3157842584138209013">Погледајте колико сте података уштедели помоћу дугмета Још опција</translation>
+<translation id="8218622182176210845">Управљајте налогом</translation>
+<translation id="8090895580117672212">Да бисте управљали Brave Software налогом, додирните дугме „Управљајте налогом“</translation>
+<translation id="8856898588039823173">Поједностављену страницу пружа Brave Software. Додирните да бисте учитали првобитну страницу.</translation>
+<translation id="8134317863207426198">Поједностављену страницу пружа Brave Software. Додирните дугме Учитај првобитну страницу да бисте учитали првобитну страницу.</translation>
+<translation id="4961107849584082341">Преведите ову страницу на било који језик</translation>
+<translation id="569536719314091526">Преведите ову страницу на било који језик помоћу дугмета Још опција</translation>
+<translation id="1397811292916898096">Претражите помоћу: <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Промените подразумевану локацију за преузимање у било ком тренутку</translation>
+<translation id="6942665639005891494">Промените подразумевану локацију за преузимање у било ком тренутку помоћи опције у менију Подешавања</translation>
+<translation id="6850409657436465440">Преузимање је још увек у току</translation>
+<translation id="5817715962196959877">Brave сада брже преузима датотеке</translation>
+<translation id="3976396876660209797">Уклоните и поново направите ову пречицу</translation>
+<translation id="6766622839693428701">Превуците надоле да бисте затворили.</translation>
+<translation id="1028699632127661925">Шаље се на уређај <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – послато је са уређаја <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Картица је примљена</translation>
 <translation id="9104217018994036254">Листа уређаја са којима се дели картица.</translation>
-<translation id="9133397713400217035">Истражујте офлајн</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Прикажи оригинал</translation>
-<translation id="9139068048179869749">Питај пре него што дозволиш сајтовима да шаљу обавештења (препоручено)</translation>
-<translation id="9139318394846604261">Шопинг</translation>
-<translation id="9155898266292537608">Можете и кратко да додирнете реч да бисте је претражили</translation>
-<translation id="9169507124922466868">Историја навигације је полуотворена</translation>
-<translation id="9204836675896933765">Преостала је 1 датотека</translation>
-<translation id="9206873250291191720">А</translation>
+<translation id="6767294960381293877">Листа уређаја са којима се дели картица је отворена на пола висине.</translation>
+<translation id="2904414404539560095">Листа уређаја са којима се дели картица је отворена у пуној висини.</translation>
+<translation id="4135200667068010335">Листа уређаја са којима се дели картица је затворена.</translation>
+<translation id="5292796745632149097">Пошаљите на</translation>
+<translation id="1386674309198842382">Последња активност: пре <ph name="LAST_UPDATED"/> дан/а</translation>
+<translation id="7971136598759319605">Последња активност: пре 1 дан</translation>
+<translation id="1521774566618522728">Активан је данас</translation>
+<translation id="3631987586758005671">Дели се са: <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Укључите синхронизацију да бисте делили садржај на више уређаја</translation>
+<translation id="6162454065885854378">Да бисте делили садржај телефона са другим уређајем, укључите синхронизацију у подешавањима Brave-а на оба уређаја</translation>
+<translation id="6084271560289605378">Идите у подешавања Brave-а</translation>
+<translation id="2318045970523081853">Додирните да бисте упутили позив</translation>
 <translation id="9209888181064652401">Упућивање позива није успело</translation>
-<translation id="9219103736887031265">Слике</translation>
-<translation id="926205370408745186">Уклоните Chrome активности из Дигиталног благостања</translation>
-<translation id="932327136139879170">Почетна</translation>
-<translation id="938850635132480979">Грешка: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Приступ микрофону</translation>
-<translation id="95817756606698420">Chrome може да користи <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> за претрагу у Кини. Ово можете да промените у <ph name="BEGIN_LINK" />Подешавањима<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Блокирај ако сајт приказује огласе који ометају активности или обмањујуће огласе (препоручено)</translation>
-<translation id="968900484120156207">Странице које посећујете се приказују овде</translation>
-<translation id="970715775301869095">Још <ph name="MINUTES" /> мин</translation>
-<translation id="974555521953189084">Унесите приступну фразу да да бисте започели синхронизацију</translation>
-<translation id="981121421437150478">Офлајн</translation>
-<translation id="982182592107339124">Овим бришете податке за све сајтове, укључујући:</translation>
-<translation id="983192555821071799">Затвори све картице</translation>
-<translation id="987264212798334818">Опште</translation>
+<translation id="2860954141821109167">Уверите се да је нека апликација за телефон омогућена на овом уређају</translation>
+<translation id="2067805253194386918">текст</translation>
+<translation id="1450753235335490080">Није успело дељење: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Није успело дељење: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Уверите се да је синхронизација за <ph name="TARGET_DEVICE_NAME"/> укључена у Brave-у</translation>
+<translation id="3016635187733453316">Уверите се да је уређај повезан на интернет</translation>
+<translation id="8466613982764129868">Уверите се да је <ph name="TARGET_DEVICE_NAME"/> повезан на интернет</translation>
+<translation id="6539092367496845964">Нешто није у реду. Пробајте поново касније.</translation>
+<translation id="3389286852084373014">Текст је превелик</translation>
+<translation id="2100314319871056947">Пробајте да делите текст у мањим деловима</translation>
+<translation id="2987620471460279764">Текст који се дели са другог уређаја</translation>
+<translation id="7757787379047923882">Текст дељен са уређаја <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Копирано је у привремену меморију</translation>
+<translation id="4696983787092045100">Пошаљите SMS уређајима</translation>
+<translation id="1260236875608242557">Претражујте и истражујте</translation>
+<translation id="6369229450655021117">Ту можете да претражујете веб, делите са пријатељима и прегледате отворене странице</translation>
+<translation id="723171743924126238">Изаберите слике</translation>
+<translation id="8751914237388039244">Изаберите слику</translation>
+<translation id="1989112275319619282">Прегледај</translation>
+<translation id="7055152154916055070">Блокирано је преусмеравање:</translation>
+<translation id="5524843473235508879">Преусмеравање је блокирано.</translation>
+<translation id="6573096386450695060">Увек дозволи</translation>
+<translation id="5805364706385912897">Ова страница користи превише меморије, па ју је Brave паузирао.</translation>
+<translation id="5138664332909611586">Ова страница користи превише меморије, па је Brave уклонио одређени садржај.</translation>
+<translation id="9137013805542155359">Прикажи оригинал</translation>
+<translation id="6361779936989026201">Brave Software помоћник у Brave-у</translation>
+<translation id="7291387454912369099">Плаћање покреће Помоћник</translation>
+<translation id="4565206163201411670">Желите ли да се Brave активности приказују у Дигиталном благостању?</translation>
+<translation id="9055113864158719823">Можете да видите сајтове које посећујете у Brave-у и да подесите тајмере за њих.\n\nBrave Software добија информације о сајтовима за које подесите тајмере и о томе колико дуго их посећујете. Те информације се користе за побољшање Дигиталног благостања.</translation>
+<translation id="4596514158372210596">Уклоните Brave активности из Дигиталног благостања</translation>
+<translation id="1174893863889683998">Желите ли да уклоните Brave активности из Дигиталног благостања?</translation>
+<translation id="708829030563435351">Сајтови које посећујете у Brave-у се неће приказивати. Биће избрисани тајмери за све сајтове.</translation>
+<translation id="2056878612599315956">Сајт је паузиран</translation>
+<translation id="671481426037969117">Тајмер апликације <ph name="FQDN"/> је истекао. Почеће поново сутра.</translation>
+<translation id="7479104141328977413">Управљање картицама</translation>
+<translation id="3524138585025253783">Кориснички интерфејс за програмере</translation>
+<translation id="6036057147555329831">Додатни ICU модул</translation>
+<translation id="9029323097866369874">Желите ли да дозволите сајту <ph name="DOMAIN"/> да покрене ВР?</translation>
+<translation id="7685301384041462804">Уверите се да је сајт поуздан пре покретања ВР режима.</translation>
+<translation id="5033865233969348410">Док сте у ВР режиму, овај сајт можда може да сазна нешто:
+  –  о вашим физичким карактеристикама, попут висине
+
+Уверите се да верујете овом сајту пре него што покренете ВР.</translation>
+<translation id="5534334044554683961">Док сте у ВР режиму, овај сајт можда може да сазна нешто:
+  –  о вашим физичким карактеристикама, попут висине
+  –   о изгледу ваше собе
+
+Уверите се да верујете овом сајту пре него што покренете ВР.</translation>
+<translation id="4169535189173047238">Не дозволи</translation>
+<translation id="2170088579611075216">Дозволи и започни ВР презентацију</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_sv.xtb
+++ b/android/java/strings/translations/android_chrome_strings_sv.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="sv">
-<translation id="1006017844123154345">Öppna onlineversionen</translation>
-<translation id="1028699632127661925">Skickar till <ph name="DEVICE_NAME" /> …</translation>
-<translation id="1036727731225946849">Lägger till <ph name="WEBAPK_NAME" /> …</translation>
-<translation id="1041308826830691739">Från webbplatser</translation>
-<translation id="1049743911850919806">Inkognito</translation>
-<translation id="10614374240317010">Aldrig sparad</translation>
-<translation id="1067922213147265141">Andra Google-tjänster</translation>
-<translation id="1068672505746868501">Översätt aldrig sidor på <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Om du ändrar filnamnstillägget kanske filen öppnas i ett annat program vilket kan utgöra en fara för enheten.</translation>
-<translation id="1100066534610197918">Öppna på en ny flik i gruppen</translation>
-<translation id="1105960400813249514">Skärmavbildning</translation>
-<translation id="1111673857033749125">Här visas bokmärken som du har sparat på andra enheter.</translation>
-<translation id="1113597929977215864">Använd förenklad visning</translation>
-<translation id="1121094540300013208">Användning och felrapporter</translation>
-<translation id="1124772482545689468">Användare</translation>
-<translation id="1129510026454351943">Mer information: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 nedladdning väntar.}other{# nedladdningar väntar.}}</translation>
-<translation id="1145536944570833626">Radera befintlig data.</translation>
-<translation id="1146678959555564648">Kliv in i VR</translation>
-<translation id="116280672541001035">Använt</translation>
-<translation id="1171770572613082465">Visa populära webbplatser genom att trycka på Populärt</translation>
-<translation id="1173894706177603556">Ändra namn</translation>
-<translation id="1178581264944972037">Paus</translation>
-<translation id="1181037720776840403">Ta bort</translation>
-<translation id="1188239144602654184">Starta AR</translation>
-<translation id="1197267115302279827">Flytta bokmärken</translation>
-<translation id="119944043368869598">Ta bort alla</translation>
-<translation id="1201402288615127009">Nästa</translation>
-<translation id="1204037785786432551">Ladda ned länk</translation>
-<translation id="1206892813135768548">Kopiera länktext</translation>
-<translation id="1208340532756947324">Aktivera synkronisering om du vill synkronisera och anpassa alla dina enheter</translation>
-<translation id="1209206284964581585">Dölj för tillfället</translation>
-<translation id="1227058898775614466">Navigeringshistorik</translation>
-<translation id="1231733316453485619">Vill du aktivera synkronisering?</translation>
-<translation id="123724288017357924">Läs in den aktuella sidan igen och ignorera cachelagrat innehåll</translation>
-<translation id="124116460088058876">Fler språk</translation>
-<translation id="124678866338384709">Stäng den aktuella fliken</translation>
-<translation id="1258753120186372309">Googles doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Sök och utforska</translation>
-<translation id="1264974993859112054">Sport</translation>
-<translation id="1266864766717917324">Det gick inte att dela <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Stopp</translation>
-<translation id="1283039547216852943">Tryck och utöka</translation>
-<translation id="1285320974508926690">Översätt aldrig den här webbplatsen</translation>
-<translation id="1291207594882862231">Rensa historiken, cookies, webbplatsdata, cacheminnet …</translation>
-<translation id="129382876167171263">Filer som webbplatser har sparat visas här</translation>
-<translation id="129553762522093515">Nyligen stängda</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Skickades från <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Gruppera flikar</translation>
-<translation id="1327257854815634930">Navigeringshistoriken har öppnats</translation>
-<translation id="1331212799747679585">Det går inte att uppdatera Chrome. Fler alternativ</translation>
-<translation id="1332501820983677155">Kortkommandon för funktioner i Google Chrome</translation>
-<translation id="1360432990279830238">Logga ut och inaktivera synkronisering?</translation>
-<translation id="1369915414381695676">Webbplatsen <ph name="SITE_NAME" /> har lagts till</translation>
-<translation id="1373696734384179344">Det finns inte tillräckligt med minne för att ladda ned det valda innehållet.</translation>
-<translation id="1376578503827013741">Beräknar …</translation>
-<translation id="1383876407941801731">Sök</translation>
-<translation id="1384959399684842514">Nedladdningen har pausats</translation>
-<translation id="1386674309198842382">Aktiv för <ph name="LAST_UPDATED" /> dagar sedan</translation>
-<translation id="1397811292916898096">Sök med <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Inbäddad i <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">Do Not Track</translation>
-<translation id="1407135791313364759">Öppna alla</translation>
-<translation id="1409426117486808224">Förenklad vy för öppna flikar</translation>
-<translation id="1409879593029778104">Nedladdningen av <ph name="FILE_NAME" /> hindrades eftersom filen redan finns.</translation>
-<translation id="1414981605391750300">Kontaktar Google. Det här kan ta någon minut …</translation>
-<translation id="1416550906796893042">Appversion</translation>
-<translation id="1430915738399379752">Skriv ut</translation>
-<translation id="1446450296470737166">Tillåt fullst. kontroll av MIDI</translation>
-<translation id="1450753235335490080">Det gick inte att dela <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Inaktiverad i Android-inställningarna</translation>
-<translation id="1477626028522505441">Det gick inte att ladda ned <ph name="FILE_NAME" /> på grund av serverfel.</translation>
-<translation id="1506061864768559482">Sökmotor</translation>
-<translation id="1513352483775369820">Bokmärken och webbhistorik</translation>
-<translation id="1513858653616922153">Radera lösenord</translation>
-<translation id="1516229014686355813">Med funktionen Tryck för att söka skickas det markerade ordet till Google Sök med den aktuella sidan som kontext. Du kan stänga av funktionen i <ph name="BEGIN_LINK" />inställningarna<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Aktiv idag</translation>
-<translation id="1544826120773021464">Tryck på knappen Hantera kontot om du vill hantera ditt Google-konto</translation>
-<translation id="1549000191223877751">Flytta till annat fönster</translation>
-<translation id="1553358976309200471">Uppdatera Chrome</translation>
-<translation id="1569387923882100876">Ansluten enhet</translation>
-<translation id="1571304935088121812">Kopiera användarnamn</translation>
-<translation id="1612196535745283361">Chrome behöver åtkomst till platsinformation för att kunna söka efter enheter. Platsåtkomst är <ph name="BEGIN_LINK" />inaktiverat för enheten<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Hindra sidan från att skapa fler dialogrutor</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Ta bort 1 markerat objekt}other{Ta bort # markerade objekt}}</translation>
-<translation id="164269334534774161">Det som visas är en offlinekopia av den här sidan från <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historik</translation>
-<translation id="1647391597548383849">Tillgång till din kamera</translation>
-<translation id="1660204651932907780">Tillåt att ljud spelas upp på webbplatser (rekommenderas)</translation>
-<translation id="1670399744444387456">Grunder</translation>
-<translation id="1671236975893690980">Nedladdning väntar …</translation>
-<translation id="1672586136351118594">Visa inte igen</translation>
-<translation id="1692118695553449118">Synkronisering är på</translation>
-<translation id="169515064810179024">Blockera webbplatser från att använda enhetens rörelsesensorer</translation>
-<translation id="1717218214683051432">Rörelsesensorer</translation>
-<translation id="1718835860248848330">Senaste timmen</translation>
-<translation id="1736419249208073774">Utforska</translation>
-<translation id="1743802530341753419">Fråga innan webbplatser tillåts ansluta till en enhet (rekommenderas)</translation>
-<translation id="1749561566933687563">Synkronisera bokmärken</translation>
-<translation id="17513872634828108">Öppna flikar</translation>
-<translation id="1779089405699405702">Bildavkodare</translation>
-<translation id="1782483593938241562">Slutdatum <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Installerat</translation>
-<translation id="1792959175193046959">Ändra standardplats för nedladdningar när som helst</translation>
-<translation id="1807246157184219062">Ljus</translation>
-<translation id="1810845389119482123">Konfigurationen av synkronisering har inte slutförts</translation>
-<translation id="1821253160463689938">Kommer ihåg med hjälp av cookies vad du brukar välja även om du inte besöker sidorna i fråga</translation>
-<translation id="1829244130665387512">Hitta på sida</translation>
-<translation id="1853692000353488670">Ny inkognitoflik</translation>
-<translation id="1856325424225101786">Vill du återställa begränsat läge?</translation>
-<translation id="1868024384445905608">Nu laddas filer ned snabbare i Chrome</translation>
-<translation id="1883903952484604915">Mina filer</translation>
-<translation id="1887786770086287077">Platsåtkomst har inaktiverats på enheten. Aktivera det i <ph name="BEGIN_LINK" />Android-inställningarna<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> öppnas i Chrome. Genom att fortsätta godkänner du Chromes <ph name="BEGIN_LINK1" />användarvillkor<ph name="END_LINK1" /> och <ph name="BEGIN_LINK2" />sekretesspolicy<ph name="END_LINK2" />.</translation>
-<translation id="1919345977826869612">Annonser</translation>
-<translation id="1919950603503897840">Välj kontakter</translation>
-<translation id="1922076542920281912">Om du vill ge Chrome åtkomst till din plats måste du även aktivera plats i <ph name="BEGIN_LINK" />inställningarna för Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Uppdateringar</translation>
-<translation id="19288952978244135">Öppna Chrome igen.</translation>
-<translation id="1933845786846280168">Vald flik</translation>
-<translation id="194341124344773587">Aktivera behörighet för Chrome i <ph name="BEGIN_LINK" />Android-inställningar<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Spara lösenord</translation>
-<translation id="1952172573699511566">När det är möjligt visas text på webbplatser på önskat språk.</translation>
-<translation id="1960290143419248813">Uppdateringar av Chrome stöds inte längre för den här versionen av Android</translation>
-<translation id="1966710179511230534">Uppdatera dina inloggningsuppgifter.</translation>
-<translation id="1974060860693918893">Avancerat</translation>
-<translation id="1984705450038014246">Synkronisera data i Chrome</translation>
-<translation id="1984937141057606926">Tillåts, men inte från tredje part</translation>
-<translation id="1986685561493779662">Namnet finns redan</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> – knapp för <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Bläddra</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> vill kopplas</translation>
-<translation id="1994173015038366702">Webbadress</translation>
-<translation id="2000419248597011803">Skickar vissa cookies och sökningar från adressfältet och sökrutan till standardsökmotorn</translation>
-<translation id="2002537628803770967">Kreditkort och adresser som används med Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fil}other{# filer}}</translation>
-<translation id="2017836877785168846">Rensar historik och autoslutföranden i adressfältet.</translation>
-<translation id="2021896219286479412">Helskärmskontroller på webbsidan</translation>
-<translation id="2038563949887743358">Aktivera begäran av skrivbordsversion</translation>
-<translation id="2041019821020695769">Om du vill få aviseringar från Chrome måste du även aktivera aviseringar i <ph name="BEGIN_LINK" />inställningarna för Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Data för <ph name="APP_NAME" /> finns även i Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Webbplatsen har pausats</translation>
-<translation id="2063713494490388661">Tryck för att söka</translation>
-<translation id="2067805253194386918">text</translation>
-<translation id="2079545284768500474">Ångra</translation>
-<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER" /> av <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Ljud</translation>
-<translation id="2096012225669085171">Synkronisera och anpassa på alla enheter</translation>
-<translation id="2100273922101894616">Automatisk inloggning</translation>
-<translation id="2100314319871056947">Testa att dela upp texten i mindre bitar</translation>
-<translation id="2107397443965016585">Fråga innan webbplatser tillåts att spela upp skyddat innehåll (rekommenderas)</translation>
-<translation id="2111511281910874386">Öppna sida</translation>
-<translation id="2122601567107267586">Det gick inte att öppna appen</translation>
-<translation id="2126426811489709554">Drivs av Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> har sparats</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> har stängts</translation>
-<translation id="2139186145475833000">Lägg till på startskärmen</translation>
-<translation id="2146738493024040262">Öppna snabbappen</translation>
-<translation id="2148716181193084225">Idag</translation>
-<translation id="2154484045852737596">Redigera kortet</translation>
-<translation id="2154710561487035718">Kopiera webbadress</translation>
-<translation id="2156074688469523661">Återstående webbplatser (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Om du vill dela något från telefonen till en annan enhet aktiverar du synkronisering i Chrome-inställningarna på båda enheterna</translation>
-<translation id="2170088579611075216">Tillåt och aktivera VR</translation>
-<translation id="218608176142494674">Delar</translation>
-<translation id="2227444325776770048">Fortsätt som <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Synk och Googles tjänster</translation>
-<translation id="2259659629660284697">Exportera lösenord …</translation>
-<translation id="2268044343513325586">Finjustera</translation>
-<translation id="2286841657746966508">Faktureringsadress</translation>
-<translation id="2289270750774289114">Fråga när en webbplats försöker söka efter Bluetooth-enheter i närheten (rekommenderas)</translation>
-<translation id="230115972905494466">Inga kompatibla enheter hittades</translation>
-<translation id="2315043854645842844">Val av certifikat på klienten stöds inte av operativsystemet.</translation>
-<translation id="2318045970523081853">Tryck för att ringa</translation>
-<translation id="2321086116217818302">Lösenorden förbereds …</translation>
-<translation id="2321958826496381788">Flytta reglaget tills du kan läsa texten ordentligt. Texten bör bli åtminstone så här stor när du trycker två gånger på ett stycke.</translation>
-<translation id="2323763861024343754">Webbplatslagring</translation>
-<translation id="2328985652426384049">Det gick inte att logga in</translation>
-<translation id="2330129964253841015">En varning visas om lösenord har läckt ut</translation>
-<translation id="2349710944427398404">Total data som används av Chrome, inklusive konton, bokmärken och sparade inställningar</translation>
-<translation id="2353636109065292463">Kontrollera internetanslutningen</translation>
-<translation id="2359808026110333948">Fortsätt</translation>
-<translation id="2369533728426058518">öppna flikar</translation>
-<translation id="2387895666653383613">Textskalning</translation>
-<translation id="2394602618534698961">Filer som du laddar ned visas här</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Den här funktionen är aktiverad när du loggar in på Google-kontot</translation>
-<translation id="2410754283952462441">Välj ett konto</translation>
-<translation id="2414886740292270097">Mörk</translation>
-<translation id="2416359993254398973">Du behöver ge Chrome behörighet att använda kameran på den här webbplatsen.</translation>
-<translation id="2426805022920575512">Välj ett annat konto</translation>
-<translation id="2433507940547922241">Utseende</translation>
-<translation id="2434158240863470628">Nedladdningen är klar<ph name="SEPARATOR" /><ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Platsåtkomst</translation>
-<translation id="2450083983707403292">Vill du börja ladda ned <ph name="FILE_NAME" /> igen?</translation>
-<translation id="2482878487686419369">Aviseringar</translation>
-<translation id="2490684707762498678">Hanteras av <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google-assistenten i Chrome</translation>
-<translation id="2496180316473517155">Webbhistorik</translation>
-<translation id="2497852260688568942">Synkronisering har inaktiverats av administratören</translation>
-<translation id="2498359688066513246">Hjälp och feedback</translation>
-<translation id="2501278716633472235">Föregående</translation>
-<translation id="2513403576141822879">Fler inställningar som rör sekretess, säkerhet och datainsamling finns under <ph name="BEGIN_LINK" />Synkronisering och Googles tjänster<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">I begränsat läge läses sidorna in snabbare och dataförbrukningen minskar med upp till 60 procent. Webbtrafiken skickas till Google från Chrome för att optimera sidorna du besöker. <ph name="BEGIN_LINK" />Läs mer<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Skickar webbadresserna till sidor du besöker till Google</translation>
-<translation id="2532336938189706096">Webbvy</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> objekt har tagits bort</translation>
-<translation id="2536728043171574184">En offlinekopia av sidan visas</translation>
-<translation id="2546283357679194313">Cookies och webbplatsdata</translation>
-<translation id="2567385386134582609">BILD</translation>
-<translation id="257088987046510401">Teman</translation>
-<translation id="2570922361219980984">Platsåtkomst har inaktiverats på enheten också. Aktivera det i <ph name="BEGIN_LINK" />Android-inställningarna<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Vyn har expanderats. Komprimera den genom att klicka.</translation>
-<translation id="2581165646603367611">Det här alternativet rensar cookies, cacheminnet och annan data från webbplatser som bedöms vara oviktiga.</translation>
-<translation id="2586657967955657006">Urklipp</translation>
-<translation id="2587052924345400782">Det finns en nyare version</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Kortnummer</translation>
-<translation id="2621115761605608342">Tillåt Javascript på en specifik webbplats.</translation>
-<translation id="2625189173221582860">Lösenordet har kopierats</translation>
-<translation id="2631006050119455616">Sparat</translation>
-<translation id="2647434099613338025">Lägg till språk</translation>
-<translation id="2650751991977523696">Vill du ladda ned filen igen?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ljudfil}other{# ljudfiler}}</translation>
-<translation id="2653659639078652383">Skicka</translation>
-<translation id="2677748264148917807">Lämna</translation>
-<translation id="2704606927547763573">Kopierat</translation>
-<translation id="2707726405694321444">Uppdatera sidan</translation>
-<translation id="2709516037105925701">Autofyll</translation>
-<translation id="2717722538473713889">E-postadresser</translation>
-<translation id="2728754400939377704">Sortera efter webbplats</translation>
-<translation id="2744248271121720757">Tryck på ett ord om du vill söka direkt eller visa relaterade åtgärder</translation>
-<translation id="2760989362628427051">Aktivera mörkt tema när batterisparläget eller mörkt tema aktiveras på enheten</translation>
-<translation id="2762000892062317888">nyss</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> sekunder kvar</translation>
-<translation id="2779651927720337254">misslyckades</translation>
-<translation id="2781151931089541271">1 sekund kvar</translation>
-<translation id="2801022321632964776">Uppdatera och få ditt språk i den senaste versionen av Chrome</translation>
-<translation id="2810645512293415242">Förenklad sida visades för att spara data och minska inläsningstiden.</translation>
-<translation id="281504910091592009">Visa och hantera sparade lösenord i <ph name="BEGIN_LINK" />Google-kontot<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Logga in och aktivera synkronisering om du vill ha dina bokmärken tillgängliga på alla enheter</translation>
-<translation id="2822354292072154809">Vill du återställa alla webbplatsbehörigheter för <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Tryck på bakåtknappen för att lämna helskärmsläget.</translation>
-<translation id="2842985007712546952">Överordnad mapp</translation>
-<translation id="2858138569776157458">Populärt</translation>
-<translation id="2860954141821109167">Kontrollera att en telefonapp har aktiverats på enheten</translation>
-<translation id="2870560284913253234">Webbplats</translation>
-<translation id="2874939134665556319">Föregående spår</translation>
-<translation id="2876369937070532032">Webbadresser till vissa sidor som du besöker skickas till Google när din säkerhet är utsatt för risk.</translation>
-<translation id="2888126860611144412">Om Chrome</translation>
-<translation id="2891154217021530873">Avbryt inläsningen av sidan</translation>
-<translation id="2893180576842394309">Google kan anpassa Sök och andra Google-tjänster utifrån historiken</translation>
-<translation id="2898264748040935573">Redigera sparat lösenord</translation>
-<translation id="2900528713135656174">Skapa händelse</translation>
-<translation id="290376772003165898">Är sidan inte på <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Listan över enheter som fliken kan delas med öppnades och tar upp hela skärmen.</translation>
-<translation id="2910701580606108292">Fråga innan webbplatser tillåts att spela upp skyddat innehåll</translation>
-<translation id="2913331724188855103">Tillåt att webbplatser sparar och läser cookiedata (rekommenderas)</translation>
-<translation id="2923908459366352541">Namnet är ogiltigt</translation>
-<translation id="2932150158123903946">Lagring för Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Fliken Förhandsgranskning har stängts</translation>
-<translation id="2956410042958133412">Det här kontot hanteras av <ph name="PARENT_NAME_1" /> och <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Byter till inkognitoflikar</translation>
-<translation id="2968755619301702150">Certifikatvisare</translation>
-<translation id="2979025552038692506">Vald inkognitoflik</translation>
-<translation id="2987620471460279764">Text delad från annan enhet</translation>
-<translation id="2989523299700148168">Nyligen besökta</translation>
-<translation id="2996291259634659425">Skapa lösenfras</translation>
-<translation id="2996809686854298943">En webbadress måste anges.</translation>
-<translation id="300526633675317032">Det här alternativet tar bort alla <ph name="SIZE_IN_KB" /> webbplatslagring.</translation>
-<translation id="3016635187733453316">Kontrollera att enheten är ansluten till internet</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> kB har laddats ned</translation>
-<translation id="3029704984691124060">Lösenfraserna matchar inte</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Få hjälp<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Plats har inaktiverats. Aktivera det i <ph name="BEGIN_LINK" />Android-inställningarna<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Du kan när som helst inaktivera synkroniseringen i inställningarna</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> bokmärke}other{<ph name="BOOKMARKS_COUNT_MANY" /> bokmärken}}</translation>
-<translation id="3089395242580810162">Öppna i inkognitoflik</translation>
-<translation id="3115898365077584848">Visa info</translation>
-<translation id="3123473560110926937">Blockeras på vissa webbplatser</translation>
-<translation id="3137521801621304719">Inaktivera inkognitoläge</translation>
-<translation id="3143515551205905069">Avbryt synkronisering</translation>
-<translation id="3157842584138209013">Under Fler alternativ kan du se hur mycket data du har sparat</translation>
-<translation id="3166827708714933426">Kortkommandon för flikar och fönster</translation>
-<translation id="3181954750937456830">Säker webbsökning (skyddar dig och enheten från skadliga webbplatser)</translation>
-<translation id="3190152372525844641">Aktivera behörigheter för Chrome i <ph name="BEGIN_LINK" />Android-inställningar<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> sparad data</translation>
-<translation id="3205824638308738187">Nästan klart!</translation>
-<translation id="3207960819495026254">Bokmärkt</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> raderades</translation>
-<translation id="321773570071367578">Om du har glömt lösenfrasen eller vill ändra inställningen <ph name="BEGIN_LINK" />återställer du synkroniseringen<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Webbapp</translation>
-<translation id="3236059992281584593">1 minut kvar</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Bokmärk sidan</translation>
-<translation id="3259831549858767975">Gör allt på sidan mindre</translation>
-<translation id="3269093882174072735">Läs in bild</translation>
-<translation id="3269956123044984603">Aktivera Automatisk synkronisering av data i kontoinställningarna för Android om du vill ha samma flikar tillgängliga på alla enheter.</translation>
-<translation id="3277252321222022663">Tillåt att webbplatser får åtkomst till enhetens sensorer (rekommenderas)</translation>
-<translation id="3282568296779691940">Logga in i Chrome</translation>
-<translation id="3288003805934695103">läsa in sidan igen</translation>
-<translation id="32895400574683172">Aviseringar tillåts</translation>
-<translation id="3295530008794733555">Surfa snabbare. Förbruka mindre data.</translation>
-<translation id="3295602654194328831">Dölj info</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">Vill du ladda ned innehållet?</translation>
-<translation id="3306398118552023113">Den här appen körs i Chrome</translation>
-<translation id="3315103659806849044">Du anpassar nu dina inställningar för synkronisering och Google-tjänster. Aktivera synkroniseringen genom att trycka på Bekräfta längst ned på skärmen. Navigera uppåt</translation>
-<translation id="3328801116991980348">Platsinformation</translation>
-<translation id="3333961966071413176">Alla kontakter</translation>
-<translation id="3334729583274622784">Vill du ändra filnamnstillägget?</translation>
-<translation id="3341058695485821946">Se hur mycket data du har sparat</translation>
-<translation id="3350687908700087792">Stäng alla inkognitoflikar</translation>
-<translation id="3353615205017136254">Lite-sida tillhandahållen av Google. Tryck på knappen Läs in original för att läsa in den ursprungliga sidan.</translation>
-<translation id="3367813778245106622">Logga in igen om du vill påbörja synkroniseringen</translation>
-<translation id="3374023511497244703">Bokmärken, historik, lösenord och annan data i Chrome synkroniseras inte längre med ditt Google-konto</translation>
-<translation id="3384347053049321195">Dela bild</translation>
-<translation id="3386292677130313581">Fråga innan webbplatser tillåts att veta var du befinner dig (rekommenderas)</translation>
-<translation id="3387650086002190359">Det gick inte att ladda ned <ph name="FILE_NAME" /> på grund av filsystemfel.</translation>
-<translation id="3389286852084373014">Texten är för stor</translation>
-<translation id="3398320232533725830">Öppna bokmärkeshanteraren</translation>
-<translation id="3414952576877147120">Storlek:</translation>
-<translation id="3443221991560634068">Läs in den aktuella sidan igen</translation>
-<translation id="3445014427084483498">Alldeles nyss</translation>
-<translation id="3478363558367712427">Du kan välja din sökmotor</translation>
+<translation id="6910211073230771657">Borttagen</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Ok, jag förstår</translation>
+<translation id="7658239707568436148">Avbryt</translation>
 <translation id="3479552764303398839">Inte nu</translation>
-<translation id="3492207499832628349">Ny inkognitoflik</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Läs mer<ph name="END_LINK" /> om förslag på innehåll</translation>
-<translation id="3513704683820682405">Förstärkt verklighet</translation>
-<translation id="3518985090088779359">Godkänn och fortsätt</translation>
-<translation id="3522247891732774234">Det finns en tillgänglig uppdatering. Fler alternativ</translation>
-<translation id="3524138585025253783">Utvecklargränssnitt</translation>
-<translation id="3527085408025491307">Mapp</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> kB tillgängligt</translation>
-<translation id="3549657413697417275">Sök i historik</translation>
-<translation id="3557336313807607643">Lägg till i kontakter</translation>
-<translation id="3566923219790363270">Chrome förbereds fortfarande för VR. Starta om Chrome senare.</translation>
-<translation id="3568688522516854065">Logga in och aktivera synkronisering om du vill ha samma flikar tillgängliga på alla enheter</translation>
-<translation id="3587482841069643663">Alla</translation>
-<translation id="358794129225322306">Tillåt att en webbplats laddar ned flera filer automatiskt.</translation>
-<translation id="3590487821116122040">Webbplatslagring som Chrome bedömer som oviktig (t.ex. webbplatser utan sparade inställningar eller som du inte besöker ofta)</translation>
-<translation id="3599863153486145794">Historik rensas från alla inloggade enheter. Det kan finnas andra former av webbhistorik i Google-kontot på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Stäng av ljudet på webbplatser</translation>
-<translation id="3616113530831147358">Ljud</translation>
-<translation id="3631987586758005671">Delas med <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Visa lösenord</translation>
-<translation id="363596933471559332">Logga in automatiskt på webbplatser med hjälp av lagrade inloggningsuppgifter. När funktionen är inaktiverad måste du verifiera dina uppgifter varje gång du besöker webbplatsen innan du kan logga in.</translation>
-<translation id="3658159451045945436">Om du återställer begränsat läge raderas databesparingshistoriken, inklusive listan med webbplatser som du har besökt.</translation>
-<translation id="3692944402865947621">Det gick inte att ladda ned <ph name="FILE_NAME" /> eftersom det inte gick att nå lagringsplatsen.</translation>
-<translation id="3714981814255182093">Öppna sökfältet</translation>
-<translation id="3716182511346448902">Den här sidan har pausats i Chrome eftersom den använder för mycket minne.</translation>
-<translation id="3730075448226062617">Om du vill ge Chrome åtkomst till mikrofonen måste du även aktivera mikrofonen i <ph name="BEGIN_LINK" />inställningarna för Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Bokmärket har lagts till i <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Synkronisera i bakgrunden</translation>
-<translation id="3771001275138982843">Det gick inte att ladda ned uppdateringen</translation>
-<translation id="3771033907050503522">Inkognitoflikar</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Aktivera Bluetooth<ph name="END_LINK" /> om du vill tillåta koppling</translation>
-<translation id="3775705724665058594">Skicka till dina enheter</translation>
-<translation id="3778956594442850293">Tillagd på startskärmen</translation>
-<translation id="3789841737615482174">Installera</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Hantera</translation>
-<translation id="381841723434055211">Telefonnummer</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> nedladdningar har raderats</translation>
-<translation id="3822502789641063741">Rensa webbplatslagring?</translation>
-<translation id="385051799172605136">Bakåt</translation>
-<translation id="3859306556332390985">Sök framåt</translation>
-<translation id="3894427358181296146">Lägg till mapp</translation>
-<translation id="3895926599014793903">Tvinga aktivering av zoom</translation>
-<translation id="3912508018559818924">Letar efter det bästa på webben …</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Slå ihop data</translation>
-<translation id="393697183122708255">Röstsökning är inte tillgängligt</translation>
-<translation id="395206256282351086">Sök- och webbplatsförslag har inaktiverats</translation>
-<translation id="3955193568934677022">Tillåt att skyddat innehåll spelas upp på webbplatser (rekommenderas)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Sidan läses in i Chrome när den blir tillgänglig}other{Sidorna läses in i Chrome när de blir tillgängliga}}</translation>
-<translation id="3963007978381181125">Betalningsmetoder och adresser från Google Pay omfattas inte av kryptering med lösenfras. Endast personer som har ditt lösenord kan läsa dina krypterade uppgifter. Lösenfrasen skickas inte till och sparas inte av Google. Om du glömmer lösenfrasen måste du återställa synkroniseringen. <ph name="BEGIN_LINK" />Läs mer<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Nedladdning slutförd</translation>
-<translation id="397583555483684758">Synkroniseringen har slutat fungera</translation>
-<translation id="3976396876660209797">Ta bort och återskapa den här genvägen</translation>
-<translation id="3985215325736559418">Vill du ladda ned <ph name="FILE_NAME" /> igen?</translation>
-<translation id="3987993985790029246">Kopiera länk</translation>
-<translation id="3988213473815854515">Platsen är tillåten</translation>
-<translation id="3988466920954086464">Visa snabba sökresultat i panelen</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Oviktig lagring</translation>
-<translation id="4000212216660919741">Startsida offline</translation>
+<translation id="5317780077021120954">Spara</translation>
+<translation id="4570913071927164677">Information</translation>
+<translation id="8730621377337864115">Klart</translation>
+<translation id="8261506727792406068">Radera</translation>
+<translation id="1181037720776840403">Ta bort</translation>
+<translation id="5939518447894949180">Återställ</translation>
 <translation id="4002066346123236978">Titel</translation>
-<translation id="4008040567710660924">Tillåt cookies för en enskild webbplats.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# tim}other{# tim}}</translation>
-<translation id="4046123991198612571">Nästa spår</translation>
-<translation id="4048707525896921369">Läs om olika ämnen på webbplatser utan att lämna sidan. Med funktionen Tryck för att söka skickas ett ord och dess kontext till Google Sök. Sedan visas definitioner, bilder, sökresultat och annan information.
+<translation id="5916664084637901428">På</translation>
+<translation id="5860033963881614850">Av</translation>
+<translation id="6165508094623778733">Läs mer</translation>
+<translation id="6042308850641462728">Mer</translation>
+<translation id="6040143037577758943">Stäng</translation>
+<translation id="780301667611848630">Nej tack</translation>
+<translation id="1201402288615127009">Nästa</translation>
+<translation id="2359808026110333948">Fortsätt</translation>
+<translation id="2653659639078652383">Skicka</translation>
+<translation id="2079545284768500474">Ångra</translation>
+<translation id="7649070708921625228">Hjälp</translation>
+<translation id="2148716181193084225">Idag</translation>
+<translation id="7781829728241885113">Igår</translation>
+<translation id="6945221475159498467">Välj</translation>
+<translation id="7791543448312431591">Lägg till</translation>
+<translation id="6527303717912515753">Dela</translation>
+<translation id="1383876407941801731">Sök</translation>
+<translation id="3115898365077584848">Visa info</translation>
+<translation id="3295602654194328831">Dölj info</translation>
+<translation id="3987993985790029246">Kopiera länk</translation>
+<translation id="2704606927547763573">Kopierat</translation>
+<translation id="8725066075913043281">Försök igen</translation>
+<translation id="385051799172605136">Bakåt</translation>
+<translation id="8131740175452115882">Bekräfta</translation>
+<translation id="5300589172476337783">Visa</translation>
+<translation id="1124772482545689468">Användare</translation>
+<translation id="8609465669617005112">Flytta upp</translation>
+<translation id="6746124502594467657">Flytta ned</translation>
+<translation id="8249310407154411074">Flytta högst upp</translation>
+<translation id="8428213095426709021">Inställningar</translation>
+<translation id="2498359688066513246">Hjälp och feedback</translation>
+<translation id="8378714024927312812">Hanteras av organisationen</translation>
+<translation id="9019902583201351841">Hanteras av dina föräldrar</translation>
+<translation id="4645575059429386691">Hanteras av din förälder</translation>
+<translation id="4883854917563148705">Hanterade inställningar kan inte återställas</translation>
+<translation id="4307992518367153382">Grunderna</translation>
+<translation id="1974060860693918893">Avancerat</translation>
+<translation id="1146678959555564648">Kliv in i VR</translation>
+<translation id="987264212798334818">Allmänt</translation>
+<translation id="4275663329226226506">Media</translation>
+<translation id="4759238208242260848">Nedladdningar</translation>
+<translation id="218608176142494674">Delar</translation>
+<translation id="8004582292198964060">Webbläsare</translation>
+<translation id="1105960400813249514">Skärmavbildning</translation>
+<translation id="4875775213178255010">Förslag på innehåll</translation>
+<translation id="2021896219286479412">Helskärmskontroller på webbsidan</translation>
+<translation id="4587589328781138893">Webbplatser</translation>
+<translation id="4943703118917034429">Virtuell verklighet</translation>
+<translation id="1928696683969751773">Uppdateringar</translation>
+<translation id="6064125863973209585">Slutförda nedladdningar</translation>
+<translation id="5342314432463739672">Behörighetsförfrågningar</translation>
+<translation id="629730747756840877">Konto</translation>
+<translation id="82609232232243542">Logga in i Brave</translation>
+<translation id="7956662517480676674">Synk och Brave Softwares tjänster</translation>
+<translation id="5294439808117722387">Du anpassar nu dina inställningar för synkronisering och Brave Software-tjänster. Aktivera synkroniseringen genom att trycka på Bekräfta längst ned på skärmen. Navigera uppåt</translation>
+<translation id="2096012225669085171">Synkronisera och anpassa på alla enheter</translation>
+<translation id="1692118695553449118">Synkronisering är på</translation>
+<translation id="5514904542973294328">Har inaktiverats av enhetens administratör</translation>
+<translation id="6447211988989208781">Brave Softwares aktivitetsinställningar</translation>
+<translation id="4882831918239250449">Styr hur Sök, annonser och annat ska anpassas utifrån webbhistoriken</translation>
+<translation id="7431991332293347422">Styr hur webbhistoriken får användas för att anpassa Sök med mera</translation>
+<translation id="6303969859164067831">Logga ut och inaktivera synkronisering</translation>
+<translation id="1125261911132334651">Hantera Brave Software-kontot</translation>
+<translation id="6406506848690869874">Synkronisera</translation>
+<translation id="714362445477979774">Synkronisera data i Brave</translation>
+<translation id="4314815835985389558">Hantera synkronisering</translation>
+<translation id="5428209950370661546">Andra Brave Software-tjänster</translation>
+<translation id="7704317875155739195">Autoslutför sökningar och webbadresser</translation>
+<translation id="2000419248597011803">Skickar vissa cookies och sökningar från adressfältet och sökrutan till standardsökmotorn</translation>
+<translation id="7981313251711023384">Läs in sidor i förväg så att det går snabbare att surfa och söka</translation>
+<translation id="1821253160463689938">Kommer ihåg med hjälp av cookies vad du brukar välja även om du inte besöker sidorna i fråga</translation>
+<translation id="6697492270171225480">Visa förslag på liknande sidor om en sida inte hittas</translation>
+<translation id="8109318360573330108">Skickar webbadressen till en sida som du försöker nå till Brave Software</translation>
+<translation id="8438566539970814960">Förbättra sökningar och surfandet</translation>
+<translation id="284843628681142937">Skickar webbadresserna till sidor du besöker till Brave Software</translation>
+<translation id="7222718784508482526">Fler inställningar som rör sekretess, säkerhet och datainsamling finns under <ph name="BEGIN_LINK"/>Synkronisering och Brave Softwares tjänster<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Bidra till att förbättra Braves funktioner och prestanda</translation>
+<translation id="9063160602596686558">Skickar användningsstatistik och felrapporter till Brave Software automatiskt</translation>
+<translation id="4824958205181053313">Vill du avbryta synkroniseringen?</translation>
+<translation id="3058498974290601450">Du kan när som helst inaktivera synkroniseringen i inställningarna</translation>
+<translation id="3143515551205905069">Avbryt synkronisering</translation>
+<translation id="1506061864768559482">Sökmotor</translation>
+<translation id="55737423895878184">Plats och aviseringar tillåts</translation>
+<translation id="3988213473815854515">Platsen är tillåten</translation>
+<translation id="32895400574683172">Aviseringar tillåts</translation>
+<translation id="9040142327097499898">Aviseringar tillåts. Plats har inaktiverats på enheten.</translation>
+<translation id="305593374596241526">Plats har inaktiverats. Aktivera det i <ph name="BEGIN_LINK"/>Android-inställningarna<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Nyligen besökta</translation>
+<translation id="6433501201775827830">Välj sökmotor</translation>
+<translation id="7177466738963138057">Du kan ändra detta senare i inställningarna</translation>
+<translation id="3478363558367712427">Du kan välja din sökmotor</translation>
+<translation id="4910889077668685004">Betalningsappar</translation>
+<translation id="5152843274749979095">Inga appar som stöds finns installerade</translation>
+<translation id="8812260976093120287">På vissa webbplatser kan du betala med ovanstående betalningsappar som stöds på enheten.</translation>
+<translation id="7764225426217299476">Lägg till adress</translation>
+<translation id="5595485650161345191">Redigera adress</translation>
+<translation id="5087580092889165836">Lägg till kort</translation>
+<translation id="2154484045852737596">Redigera kortet</translation>
+<translation id="6140912465461743537">Land/region</translation>
+<translation id="5659593005791499971">E-post</translation>
+<translation id="4378154925671717803">Mobil</translation>
+<translation id="4807098396393229769">Namn på kort</translation>
+<translation id="860043288473659153">Namn på kortinnehavare</translation>
+<translation id="2612676031748830579">Kortnummer</translation>
+<translation id="869891660844655955">Utgångsdatum</translation>
+<translation id="2286841657746966508">Faktureringsadress</translation>
+<translation id="663059986967017181">Kopierat till Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> till}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> till}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> till}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> till}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> till}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> till}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> till}other{<ph name="CONTACT_PREVIEW"/>\u2026 och <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> till}}</translation>
+<translation id="7029809446516969842">Lösenord</translation>
+<translation id="1943432128510653496">Spara lösenord</translation>
+<translation id="2100273922101894616">Automatisk inloggning</translation>
+<translation id="363596933471559332">Logga in automatiskt på webbplatser med hjälp av lagrade inloggningsuppgifter. När funktionen är inaktiverad måste du verifiera dina uppgifter varje gång du besöker webbplatsen innan du kan logga in.</translation>
+<translation id="6995899638241819463">En varning visas om lösenord har läckt ut vid ett dataintrång</translation>
+<translation id="1534287762301776620">Den här funktionen är aktiverad när du loggar in på Brave Software-kontot</translation>
+<translation id="10614374240317010">Aldrig sparad</translation>
+<translation id="3098842761938485917">Visa och hantera sparade lösenord i <ph name="BEGIN_LINK"/>Brave Software-kontot<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Sparade lösenord visas här.</translation>
+<translation id="8084114998886531721">Sparat lösenord</translation>
+<translation id="2870560284913253234">Webbplats</translation>
+<translation id="8503813439785031346">Användarnamn</translation>
+<translation id="6657585470893396449">Lösenord</translation>
+<translation id="2154710561487035718">Kopiera webbadress</translation>
+<translation id="1571304935088121812">Kopiera användarnamn</translation>
+<translation id="5005498671520578047">Kopiera lösenord</translation>
+<translation id="3632295766818638029">Visa lösenord</translation>
+<translation id="1513858653616922153">Radera lösenord</translation>
+<translation id="543338862236136125">Redigera lösenord</translation>
+<translation id="4565377596337484307">Dölj lösenord</translation>
+<translation id="8523928698583292556">Radera sparat lösenord</translation>
+<translation id="2898264748040935573">Redigera sparat lösenord</translation>
+<translation id="5433691172869980887">Användarnamnet har kopierats</translation>
+<translation id="5534640966246046842">Webbplatsen har kopierats</translation>
+<translation id="2625189173221582860">Lösenordet har kopierats</translation>
+<translation id="4550003330909367850">Ange ett skärmlås på enheten om du vill visa eller kopiera lösenordet här.</translation>
+<translation id="6154478581116148741">Aktivera ett skärmlås i inställningarna om du vill exportera lösenord från den här enheten.</translation>
+<translation id="4842092870884894799">Visar popupfönster för lösenordsgenerering</translation>
+<translation id="2259659629660284697">Exportera lösenord …</translation>
+<translation id="133012818630824069">Exportera lösenord som har sparats i Brave</translation>
+<translation id="6914783257214138813">Alla med tillgång till den exporterade filen kan läsa dina lösenord.</translation>
+<translation id="2321086116217818302">Lösenorden förbereds …</translation>
+<translation id="8445448999790540984">Det gick inte att exportera lösenord</translation>
+<translation id="3066461326500799725">Lär dig använda Brave Software Drive</translation>
+<translation id="729975465115245577">Det finns ingen app som kan spara lösenordsfilen på enheten.</translation>
+<translation id="7682724950699840886">Testa följande: kontrollera att det finns tillräckligt mycket utrymme på enheten, gör om exporten.</translation>
+<translation id="1129510026454351943">Mer information: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Lås upp om du vill kopiera lösenordet</translation>
+<translation id="5515439363601853141">Lås upp om du vill visa lösenordet</translation>
+<translation id="6221633008163990886">Lås upp om du vill exportera dina lösenord</translation>
+<translation id="230699814587342492">Lösenord i Brave</translation>
+<translation id="6075798973483050474">Redigera startsidan</translation>
+<translation id="854522910157234410">Öppna sidan</translation>
+<translation id="2482878487686419369">Aviseringar</translation>
+<translation id="6255999984061454636">Förslag på innehåll</translation>
+<translation id="805047784848435650">Utifrån din webbhistorik</translation>
+<translation id="1041308826830691739">Från webbplatser</translation>
+<translation id="395206256282351086">Sök- och webbplatsförslag har inaktiverats</translation>
+<translation id="257088987046510401">Teman</translation>
+<translation id="4650364565596261010">Systemets standardinställning</translation>
+<translation id="7588219262685291874">Aktivera mörkt tema när enhetens batterisparläge är på</translation>
+<translation id="2760989362628427051">Aktivera mörkt tema när batterisparläget eller mörkt tema aktiveras på enheten</translation>
+<translation id="6381421346744604172">Gör webbplatser mörkare</translation>
+<translation id="5040262127954254034">Sekretess</translation>
+<translation id="4991384657077828949">Bidra till att göra Brave säkrare</translation>
+<translation id="1943176487615318915">För att kunna upptäcka farliga appar och webbplatser skickar Brave webbadresser till vissa sidor som du besöker, vissa systemuppgifter och visst sidinnehåll till Brave Software</translation>
+<translation id="3181954750937456830">Säker webbsökning (skyddar dig och enheten från skadliga webbplatser)</translation>
+<translation id="7315322926489145388">Webbadresser till vissa sidor som du besöker skickas till Brave Software när din säkerhet är utsatt för risk.</translation>
+<translation id="2063713494490388661">Tryck för att söka</translation>
+<translation id="2369463299479365221">Läs om olika ämnen på webbplatser utan att lämna sidan. Med funktionen Tryck för att söka skickas ett ord och dess kontext till Brave Software Sök. Sedan visas definitioner, bilder, sökresultat och annan information.
 
 Om du vill ändra söktermen trycker du länge för att välja. Om du vill finjustera sökningen drar du panelen ända upp och trycker på sökrutan.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Alternativ finns högt upp på skärmen</translation>
-<translation id="4062305924942672200">Juridisk information</translation>
-<translation id="4084682180776658562">Infoga bokmärke</translation>
-<translation id="4084712963632273211">Från <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />via Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Vill du ta bort appdata?</translation>
-<translation id="4099578267706723511">Hjälp till att förbättra Chrome genom att skicka användningsstatistik och felrapporter till Google.</translation>
-<translation id="410351446219883937">Automatisk uppspelning</translation>
-<translation id="4116038641877404294">Ladda ned sidor så att du kan använda dem offline</translation>
-<translation id="4135200667068010335">Listan över enheter som fliken kan delas med är stängd.</translation>
-<translation id="4149994727733219643">Förenklad vy för webbsidor</translation>
-<translation id="4165986682804962316">Platsinställningar</translation>
-<translation id="4169535189173047238">Tillåt inte</translation>
-<translation id="4170011742729630528">Tjänsten är inte tillgänglig, försök igen senare.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> har använts</translation>
-<translation id="4181841719683918333">Språk</translation>
-<translation id="4183868528246477015">Sök med Google Lens <ph name="BEGIN_NEW" />Nyhet<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Öppna i ny flik</translation>
-<translation id="4198423547019359126">Det fins inga tillgängliga nedladdningsplatser</translation>
-<translation id="4209895695669353772">Aktivera synkronisering om du vill få förslag på anpassat innehåll från Google</translation>
-<translation id="4226663524361240545">Aviseringar kan göra att enheten vibrerar</translation>
-<translation id="423219824432660969">Kryptera synkroniserad data med Google-lösenordet från <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Öppna Inställningar</translation>
-<translation id="4256782883801055595">Licenser för öppen källkod</translation>
-<translation id="4259722352634471385">Webbadressen har blockerats: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Kopiera länkadress</translation>
-<translation id="4275663329226226506">Media</translation>
-<translation id="4278390842282768270">Tillåtet</translation>
-<translation id="429312253194641664">Media spelas upp på en webbplats</translation>
-<translation id="4298388696830689168">Länkade webbplatser</translation>
-<translation id="4307992518367153382">Grunderna</translation>
-<translation id="4314815835985389558">Hantera synkronisering</translation>
-<translation id="4351244548802238354">Stäng dialogrutan</translation>
-<translation id="4378154925671717803">Mobil</translation>
-<translation id="4384468725000734951">Du söker med Sogou</translation>
-<translation id="4404568932422911380">Inga bokmärken</translation>
-<translation id="4405224443901389797">Flytta till …</translation>
-<translation id="4411535500181276704">Begränsat läge</translation>
-<translation id="4415276339145661267">Hantera Google-kontot</translation>
-<translation id="4432792777822557199">Sidor på <ph name="SOURCE_LANGUAGE" /> översätts till <ph name="TARGET_LANGUAGE" /> från och med nu</translation>
-<translation id="4433925000917964731">Lite-sida tillhandahållen av Google</translation>
-<translation id="4434045419905280838">Popup och omdirigeringar</translation>
-<translation id="4440958355523780886">Lite-sida tillhandahållen av Google. Tryck för att läsa in originalet.</translation>
-<translation id="4452411734226507615">Stäng fliken <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Bokmärkt i <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Tillåt att webbplatser spelar upp skyddat innehåll</translation>
-<translation id="4468959413250150279">Stäng av ljudet för en webbplats.</translation>
-<translation id="4472118726404937099">Logga in och aktivera synkronisering om du vill synkronisera och anpassa alla dina enheter</translation>
-<translation id="447252321002412580">Bidra till att förbättra Chromes funktioner och prestanda</translation>
-<translation id="4479647676395637221">Fråga innan webbplatser tillåts att använda kameran (rekommenderas)</translation>
-<translation id="4479972344484327217"><ph name="MODULE" /> installeras i Chrome …</translation>
-<translation id="4487967297491345095">All appdata i Chrome raderas permanent. Detta omfattar alla filer, inställningar, konton, databaser osv.</translation>
-<translation id="4493497663118223949">Begränsat läge har aktiverats</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{för # dag sedan}other{för # dagar sedan}}</translation>
-<translation id="451872707440238414">Sök bland dina bokmärken</translation>
-<translation id="4521489764227272523">Markerad data har tagits bort från Chrome och från synkroniserade enheter.
-
-Det kan finnas andra former av webbhistorik i Google-kontot på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />, t.ex. sökningar och aktivitet på andra tjänster från Google.</translation>
-<translation id="4532845899244822526">Välj mapp</translation>
-<translation id="4538018662093857852">Aktivera begränsat läge</translation>
-<translation id="4550003330909367850">Ange ett skärmlås på enheten om du vill visa eller kopiera lösenordet här.</translation>
-<translation id="4558311620361989323">Kortkommandon på webbsidor</translation>
-<translation id="4561979708150884304">Ingen anslutning</translation>
-<translation id="4565377596337484307">Dölj lösenord</translation>
-<translation id="4570913071927164677">Information</translation>
-<translation id="4572422548854449519">Logga in på hanterat konto</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{för # minut sedan}other{för # minuter sedan}}</translation>
-<translation id="4587589328781138893">Webbplatser</translation>
-<translation id="4594952190837476234">Den här offlinesidan sparades <ph name="CREATION_TIME" /> och kan skilja sig från onlineversionen.</translation>
-<translation id="4605958867780575332">Borttaget objekt: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Öppna <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Använd lösenordet</translation>
-<translation id="4645575059429386691">Hanteras av din förälder</translation>
-<translation id="4650364565596261010">Systemets standardinställning</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> bokmärken har raderats</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> har lagts till på startskärmen.</translation>
-<translation id="4684427112815847243">Synkronisera allt</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> till}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> till}}</translation>
-<translation id="4696983787092045100">Skicka texten till dina enheter</translation>
-<translation id="4698034686595694889">Visa offline i <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Cachade bilder och filer</translation>
-<translation id="4714588616299687897">Spara upp till 60 % av din data</translation>
-<translation id="4719927025381752090">Erbjud översättning</translation>
-<translation id="4720023427747327413">Öppna i <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Hjälp till att förbättra Chrome. <ph name="BEGIN_LINK" />Fyll i enkäten<ph name="END_LINK" />.</translation>
-<translation id="473775607612524610">Uppdatera</translation>
-<translation id="4738836084190194332">Synkroniserades senast: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Öppna en ny flik</translation>
-<translation id="4751476147751820511">Rörelse- eller ljussensorer</translation>
-<translation id="4759238208242260848">Nedladdningar</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 nedladdning har slutförts.}other{# nedladdningar har slutförts.}}</translation>
-<translation id="4797039098279997504">Tryck här om du vill återgå till <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Betalningsmetoder och adresser från Google Pay omfattas inte av kryptering med lösenfras.
-
-<ph name="BEGIN_LINK" />Återställ synkroniseringen<ph name="END_LINK" /> om du vill ändra den här inställningen.</translation>
-<translation id="4807098396393229769">Namn på kort</translation>
-<translation id="4824958205181053313">Vill du avbryta synkroniseringen?</translation>
-<translation id="4837753911714442426">Öppna utskriftsalternativ</translation>
-<translation id="4842092870884894799">Visar popupfönster för lösenordsgenerering</translation>
-<translation id="4860895144060829044">Ring</translation>
-<translation id="4866368707455379617">Det gick inte att installera <ph name="MODULE" /> i Chrome</translation>
-<translation id="4875775213178255010">Förslag på innehåll</translation>
-<translation id="4878404682131129617">Det gick inte att upprätta en tunnel via proxyserver</translation>
-<translation id="4880127995492972015">Översätt …</translation>
-<translation id="4881695831933465202">Öppna</translation>
-<translation id="488187801263602086">Byt namn på fil</translation>
-<translation id="4882831918239250449">Styr hur Sök, annonser och annat ska anpassas utifrån webbhistoriken</translation>
-<translation id="4883854917563148705">Hanterade inställningar kan inte återställas</translation>
-<translation id="4885273946141277891">Fler Chrome-förekomster än det finns stöd för.</translation>
-<translation id="4910889077668685004">Betalningsappar</translation>
-<translation id="4913161338056004800">Återställ statistik</translation>
-<translation id="4913169188695071480">Sluta uppdatera</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Få hjälp<ph name="END_LINK" /> under sökningen efter enheter …</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# sida}other{# sidor}}</translation>
-<translation id="4932247056774066048">Eftersom du loggar ut från ett konto som hanteras av <ph name="DOMAIN_NAME" /> raderas din Chrome-data från den här enheten. Den finns kvar på ditt Google-konto.</translation>
-<translation id="4943703118917034429">Virtuell verklighet</translation>
-<translation id="4943872375798546930">Inga resultat</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> delar skärmen</translation>
-<translation id="4961107849584082341">Översätt den här sidan till vilket språk som helst</translation>
-<translation id="4962975101802056554">Återkalla alla behörigheter för enheten</translation>
-<translation id="4970824347203572753">Inte tillgängligt i ditt land</translation>
-<translation id="497421865427891073">Fortsätt</translation>
-<translation id="4988210275050210843">En fil laddas ned (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Sidor</translation>
-<translation id="4994033804516042629">Inga kontakter hittades</translation>
-<translation id="4996978546172906250">Dela via</translation>
-<translation id="5004416275253351869">Googles aktivitetsinställningar</translation>
-<translation id="5005498671520578047">Kopiera lösenord</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> vill ansluta</translation>
-<translation id="5013696553129441713">Inga nya förslag</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Webbplatsen kan ta reda på mer om följande om dig när VR är aktiverat:
-  – dina fysiska egenskaper, som längd
-
-Se till att du litar på webbplatsen innan du aktiverar VR.</translation>
+<translation id="2930742481329940825">Med funktionen Tryck för att söka skickas det markerade ordet till Brave Software Sök med den aktuella sidan som kontext. Du kan stänga av funktionen i <ph name="BEGIN_LINK"/>inställningarna<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Tillåt</translation>
-<translation id="5040262127954254034">Sekretess</translation>
-<translation id="5048398596102334565">Tillåt webbplatser att använda enhetens rörelsesensorer (rekommenderas)</translation>
-<translation id="5063480226653192405">Användning</translation>
-<translation id="5087580092889165836">Lägg till kort</translation>
-<translation id="5100237604440890931">Vyn har komprimerats. Expandera den genom att klicka.</translation>
-<translation id="510275257476243843">1 timme kvar</translation>
-<translation id="5123685120097942451">Inkognitoflik</translation>
-<translation id="5127805178023152808">Synkronisering är av</translation>
-<translation id="5129038482087801250">Installera webbapp</translation>
-<translation id="5132942445612118989">Synkronisera lösenord, historik med mera på alla dina enheter</translation>
-<translation id="5139940364318403933">Lär dig använda Google Drive</translation>
-<translation id="515227803646670480">Ta bort sparad data</translation>
-<translation id="5152843274749979095">Inga appar som stöds finns installerade</translation>
-<translation id="5161254044473106830">Titel krävs</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 nedladdning misslyckades.}other{# nedladdningar misslyckades.}}</translation>
-<translation id="5170568018924773124">Visa i mapp</translation>
-<translation id="5184329579814168207">Öppna i Chrome</translation>
-<translation id="5193988420012215838">Kopierat till urklipp</translation>
-<translation id="5197729504361054390">Kontakterna du väljer delas med <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Jobbprofil</translation>
-<translation id="5210286577605176222">Hoppa till föregående flik</translation>
-<translation id="5210365745912300556">Stäng flik</translation>
-<translation id="5224771365102442243">Med video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> vill söka efter Bluetooth-enheter i närheten. Följande enheter har hittats:</translation>
-<translation id="5233638681132016545">Ny flik</translation>
-<translation id="526421993248218238">Det går inte att läsa in den här sidan</translation>
-<translation id="5271967389191913893">Innehållet som skulle laddas ned gick inte att öppna på enheten.</translation>
-<translation id="528192093759286357">Dra uppifrån och tryck på bakåtknappen för att lämna helskärmsläget.</translation>
-<translation id="5292796745632149097">Skicka till</translation>
-<translation id="5300589172476337783">Visa</translation>
-<translation id="5301954838959518834">Ok, jag förstår</translation>
-<translation id="5304593522240415983">Fältet får inte vara tomt</translation>
-<translation id="5307446750509046227">Rensa webbplatslagring</translation>
-<translation id="5308380583665731573">Ansluta</translation>
-<translation id="5313967007315987356">Lägg till webbplats</translation>
-<translation id="5317780077021120954">Spara</translation>
-<translation id="5324858694974489420">Föräldrainställningar</translation>
-<translation id="5327248766486351172">Namn</translation>
-<translation id="5335288049665977812">Tillåt att Javascript körs på webbplatser (rekommenderas)</translation>
-<translation id="5342314432463739672">Behörighetsförfrågningar</translation>
-<translation id="5357811892247919462">En flik har tagits emot</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> flik öppen, tryck här om du vill byta flik}other{<ph name="OPEN_TABS_MANY" /> flikar öppna, tryck här om du vill byta flik}}</translation>
-<translation id="5391532827096253100">Anslutningen till webbplatsen är inte säker. Webbplatsinformation</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 till)}other{(+ # till)}}</translation>
-<translation id="5400569084694353794">Genom att använda det här programmet godkänner du Chromes <ph name="BEGIN_LINK1" />användarvillkor<ph name="END_LINK1" /> och <ph name="BEGIN_LINK2" />sekretessmeddelande<ph name="END_LINK2" />.</translation>
-<translation id="5403592356182871684">Namn</translation>
-<translation id="5403644198645076998">Tillåt endast vissa webbplatser</translation>
-<translation id="5414836363063783498">Verifierar ...</translation>
-<translation id="5423934151118863508">Dina mest besökta sidor visas här</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB tillgängligt</translation>
-<translation id="543338862236136125">Redigera lösenord</translation>
-<translation id="5433691172869980887">Användarnamnet har kopierats</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> filer (<ph name="MEGABYTES" />) laddas ned.</translation>
-<translation id="5441522332038954058">Hoppa till adressfältet</translation>
-<translation id="5447201525962359567">All webbplatslagring, inklusive cookies och annan lokalt sparad data</translation>
-<translation id="5447765697759493033">Den här webbplatsen översätts inte</translation>
-<translation id="545042621069398927">Nedladdningen görs snabbare.</translation>
-<translation id="5456381639095306749">Ladda ned sida</translation>
-<translation id="5475862044948910901">Vill du starta en session med förstärkt verklighet?</translation>
-<translation id="548278423535722844">Öppna i kartapp</translation>
-<translation id="5487521232677179737">Rensa data</translation>
-<translation id="5494752089476963479">Blockera annonser på webbplatser där påträngande eller vilseledande annonser visas</translation>
-<translation id="5500777121964041360">Kanske inte tillgängligt i ditt land</translation>
-<translation id="5512137114520586844">Det här kontot hanteras av <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Har inaktiverats av enhetens administratör</translation>
-<translation id="5515439363601853141">Lås upp om du vill visa lösenordet</translation>
-<translation id="5516455585884385570">Öppna aviseringsinställningar</translation>
-<translation id="5517095782334947753">Du har bokmärken, historik, lösenord och andra inställningar från <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Omdirigeringen blockerades.</translation>
-<translation id="5527082711130173040">Chrome behöver tillgång till platsinformation för att kunna söka efter enheter. <ph name="BEGIN_LINK1" />Uppdatera behörigheter<ph name="END_LINK1" />. Platsåtkomst är dessutom <ph name="BEGIN_LINK2" />inaktiverat för enheten<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Fråga innan en webbplats ges läsbehörighet till text och bilder i Urklipp (rekommenderas)</translation>
-<translation id="5530766185686772672">Stäng inkognitoflikar</translation>
-<translation id="5534334044554683961">Webbplatsen kan ta reda på mer om följande om dig när VR är aktiverat:
-  – dina fysiska egenskaper, som längd
-  –   formen på ditt rum
-
-Se till att du litar på webbplatsen innan du aktiverar VR.</translation>
-<translation id="5534640966246046842">Webbplatsen har kopierats</translation>
-<translation id="5556459405103347317">Hämta igen</translation>
-<translation id="5561549206367097665">Väntar på nätverket …</translation>
-<translation id="557283862590186398">Du behöver ge Chrome behörighet att använda mikrofonen på den här webbplatsen.</translation>
-<translation id="55737423895878184">Plats och aviseringar tillåts</translation>
-<translation id="5578795271662203820">Sök på <ph name="SEARCH_ENGINE" /> efter denna bild</translation>
-<translation id="5581519193887989363">Du kan alltid välja vad som ska synkroniseras i <ph name="BEGIN_LINK1" />inställningarna<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Redigera adress</translation>
-<translation id="5596627076506792578">Fler alternativ</translation>
-<translation id="5599455543593328020">Inkognitoläge</translation>
-<translation id="5620928963363755975">Du hittar filerna och sidorna i Nedladdningar via knappen Fler alternativ</translation>
-<translation id="5626134646977739690">Namn:</translation>
-<translation id="5639724618331995626">Tillåt alla webbplatser</translation>
-<translation id="5648166631817621825">Senaste sju dagarna</translation>
-<translation id="5649053991847567735">Automatiska nedladdningar</translation>
-<translation id="5655963694829536461">Sök i dina nedladdningar</translation>
-<translation id="5659593005791499971">E-post</translation>
-<translation id="5665379678064389456">Skapa händelse i <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Åsidosätt en webbplats begäran att hindra inzoomning</translation>
-<translation id="5677928146339483299">Blockerade</translation>
-<translation id="5684874026226664614">Det gick inte att översätta sidan.</translation>
-<translation id="5686790454216892815">Filnamnet är för långt</translation>
-<translation id="5689516760719285838">Plats</translation>
-<translation id="569536719314091526">Översätt den här sidan till vilket språk som helst via knappen Fler alternativ</translation>
-<translation id="572328651809341494">Senaste flikarna</translation>
-<translation id="5726692708398506830">Gör allt på sidan större</translation>
-<translation id="5748802427693696783">Bytte till standardflikar</translation>
-<translation id="5749068826913805084">Chrome måste ha åtkomst till lagringsutrymmet om det ska gå att ladda ned filer.</translation>
-<translation id="5763382633136178763">Inkognitoflikar</translation>
-<translation id="5763514718066511291">Tryck om du vill kopiera webbadressen till appen</translation>
-<translation id="5765780083710877561">Beskrivning:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> av <ph name="SPACE_AVAILABLE" /> används</translation>
-<translation id="5797070761912323120">Google kan anpassa Sök, annonser och andra Google-tjänster utifrån historiken</translation>
-<translation id="5804241973901381774">Behörigheter</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{för # timme sedan}other{för # timmar sedan}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. Med ensamrätt.</translation>
-<translation id="5817918615728894473">Koppla</translation>
-<translation id="583281660410589416">Okänd</translation>
-<translation id="5833984609253377421">Dela länk</translation>
-<translation id="5836192821815272682">Uppdatering för Chrome laddas ned …</translation>
-<translation id="5853623416121554550">pausad</translation>
-<translation id="5854790677617711513">Äldre än 30 dagar</translation>
-<translation id="5858741533101922242">Det gick inte att aktivera Bluetooth-adaptern i Chrome</translation>
-<translation id="5860033963881614850">Av</translation>
-<translation id="5862731021271217234">Aktivera synkronisering om du vill ha samma flikar tillgängliga på alla enheter</translation>
-<translation id="5864174910718532887">Mer information: Sorterad efter webbplatsnamn</translation>
-<translation id="5864419784173784555">Väntar på nästa nedladdning …</translation>
-<translation id="5865733239029070421">Skickar användningsstatistik och felrapporter till Google automatiskt</translation>
-<translation id="5869522115854928033">Sparade lösenord</translation>
-<translation id="5902828464777634901">All data som sparats lokalt av webbplatsen tas bort, inklusive cookies.</translation>
-<translation id="5916664084637901428">På</translation>
-<translation id="5919204609460789179">Uppdatera <ph name="PRODUCT_NAME" /> för att starta synkronisering</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> har sparats</translation>
-<translation id="5939518447894949180">Återställ</translation>
-<translation id="5942872142862698679">Du söker med Google</translation>
-<translation id="5952764234151283551">Skickar webbadressen till en sida som du försöker nå till Google</translation>
-<translation id="5956665950594638604">Öppna hjälpcentret för Chrome på en ny flik</translation>
-<translation id="5958275228015807058">Du hittar filerna och sidorna i Nedladdningar</translation>
-<translation id="5962718611393537961">Tryck här om du vill komprimera</translation>
-<translation id="6000066717592683814">Behåll Google</translation>
-<translation id="6005538289190791541">Föreslaget lösenord</translation>
-<translation id="6036057147555329831">Extra ICU</translation>
-<translation id="6039379616847168523">Hoppa till nästa flik</translation>
-<translation id="6040143037577758943">Stäng</translation>
-<translation id="6042308850641462728">Mer</translation>
-<translation id="604996488070107836">Det gick inte att ladda ned <ph name="FILE_NAME" /> på grund av ett okänt fel.</translation>
-<translation id="605721222689873409">ÅÅ</translation>
-<translation id="6064125863973209585">Slutförda nedladdningar</translation>
-<translation id="6075798973483050474">Redigera startsidan</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> timmar kvar</translation>
-<translation id="6108923351542677676">Konfigurationen pågår ...</translation>
-<translation id="6111020039983847643">Använd data</translation>
-<translation id="6112702117600201073">Uppdaterar sidan</translation>
-<translation id="6127379762771434464">Objektet har tagits bort</translation>
-<translation id="6140912465461743537">Land/region</translation>
-<translation id="614940544461990577">Testa att</translation>
-<translation id="6154478581116148741">Aktivera ett skärmlås i inställningarna om du vill exportera lösenord från den här enheten.</translation>
-<translation id="6159335304067198720">Sparat utrymme: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Läs mer</translation>
-<translation id="6177111841848151710">Blockerad för den nuvarande sökmotorn</translation>
-<translation id="6181444274883918285">Lägg till en webbplats i undantagen</translation>
-<translation id="6192333916571137726">Ladda ned fil</translation>
-<translation id="6192792657125177640">Undantag</translation>
-<translation id="6194112207524046168">Om du vill ge Chrome åtkomst till kameran måste du även aktivera kameran i <ph name="BEGIN_LINK" />inställningarna för Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Blockera cookies från tredje part</translation>
-<translation id="6206551242102657620">Anslutningen är säker. Webbplatsinformation</translation>
-<translation id="6210748933810148297">Inte <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Lås upp om du vill exportera dina lösenord</translation>
+<translation id="1406000523432664303">Do Not Track</translation>
 <translation id="6232535412751077445">Om du aktiverar Do Not Track inkluderas en begäran i din surftrafik. Eventuella effekter beror på om webbplatsen svarar på begäran och hur begäran tolkas.
 
 Vissa webbplatser kan till exempel svara på begäran genom att visa annonser som inte baseras på andra webbplatser du har besökt. Många webbplatser samlar ändå in och använder din webbinformation – till exempel för att förbättra säkerheten, tillhandahålla innehåll, annonser och rekommendationer samt generera rapportstatistik.</translation>
-<translation id="624789221780392884">Uppdateringen är klar</translation>
-<translation id="6255999984061454636">Förslag på innehåll</translation>
-<translation id="6277522088822131679">Det gick inte att skriva ut sidan. Försök igen.</translation>
-<translation id="6295158916970320988">Alla webbplatser</translation>
-<translation id="629730747756840877">Konto</translation>
-<translation id="6303969859164067831">Logga ut och inaktivera synkronisering</translation>
-<translation id="6316139424528454185">Android-versionen stöds inte</translation>
-<translation id="6320088164292336938">Vibration</translation>
-<translation id="6324034347079777476">Synkronisering av Android-system har inaktiverats</translation>
-<translation id="6333140779060797560">Dela via <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Kryptering</translation>
-<translation id="6341580099087024258">Fråga var filerna ska sparas</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> till}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> till}}</translation>
-<translation id="6364438453358674297">Vill du ta bort förslaget från historiken?</translation>
-<translation id="6369229450655021117">Härifrån kan du söka på webben, dela med vänner och visa öppna sidor</translation>
-<translation id="6378173571450987352">Mer information: Sorterad efter dataförbrukning</translation>
-<translation id="6381421346744604172">Gör webbplatser mörkare</translation>
-<translation id="6388207532828177975">Ta bort och återställ</translation>
-<translation id="6393863479814692971">Du behöver ge Chrome behörighet att använda kameran och mikrofonen på den här webbplatsen.</translation>
-<translation id="6395288395575013217">LÄNK</translation>
-<translation id="6404511346730675251">Redigera bokmärke</translation>
-<translation id="6406506848690869874">Synkronisera</translation>
-<translation id="641643625718530986">Skriv ut …</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB har laddats ned</translation>
-<translation id="6427112570124116297">Översätt webbsidor</translation>
-<translation id="6433501201775827830">Välj sökmotor</translation>
-<translation id="6437478888915024427">Sidinformation</translation>
-<translation id="6441734959916820584">Namnet är för långt</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# bild}other{# bilder}}</translation>
-<translation id="6447842834002726250">Cookies</translation>
-<translation id="6461962085415701688">Det går inte att öppna filen</translation>
-<translation id="6464977750820128603">Du kan se vilka webbplatser du besökt i Chrome och ställa in en timer för dem.\n\nGoogle får information om vilka webbplatser du har ställt in en timer för och hur länge du har stannat på dem. Informationen används för att förbättra Digitalt välmående.</translation>
-<translation id="6475951671322991020">Ladda ned video</translation>
-<translation id="6482749332252372425">Det gick inte att ladda ned <ph name="FILE_NAME" /> eftersom det inte finns tillräckligt med lagringsutrymme.</translation>
-<translation id="6496823230996795692">Du behöver vara ansluten till internet när du använder <ph name="APP_NAME" /> för första gången.</translation>
-<translation id="6508722015517270189">Starta om Chrome</translation>
-<translation id="6527303717912515753">Dela</translation>
-<translation id="6532866250404780454">Webbplatser som du besöker i Chrome visas inte. Alla timer för webbplatser raderas.</translation>
-<translation id="6534565668554028783">Google tog för lång tid på sig att svara</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB har laddats ned</translation>
-<translation id="6539092367496845964">Något gick fel. Försök igen senare.</translation>
-<translation id="654446541061731451">Välj en flik som du vill överföra</translation>
-<translation id="6545017243486555795">Rensa all data</translation>
-<translation id="6545864417968258051">Bluetooth-sökning</translation>
-<translation id="6560414384669816528">Sök med Sogou</translation>
-<translation id="6566259936974865419">Du har sparat <ph name="GIGABYTES" /> GB med Chrome</translation>
-<translation id="6573096386450695060">Tillåt alltid</translation>
-<translation id="6573431926118603307">Här visas flikar som du har öppnat i Chrome på andra enheter.</translation>
-<translation id="6583199322650523874">Infoga ett bokmärke för den aktuella sidan</translation>
-<translation id="6593061639179217415">Datoranpassad webbplats</translation>
-<translation id="6600954340915313787">Kopierat till Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Skyddat innehåll</translation>
-<translation id="6627583120233659107">Redigera mapp</translation>
-<translation id="6643016212128521049">Rensa</translation>
-<translation id="6643649862576733715">Sortera efter databesparing</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> till}other{<ph name="CONTACT_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> till}}</translation>
-<translation id="6649642165559792194">Förhandsgranska bild <ph name="BEGIN_NEW" />Nyhet<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome behöver platsåtkomst för att söka efter enheter. <ph name="BEGIN_LINK" />Uppdatera behörigheter<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Lösenord</translation>
-<translation id="6659594942844771486">Flik</translation>
-<translation id="666731172850799929">Öppna i <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Chromes sekretessmeddelande</translation>
-<translation id="6676840375528380067">Vill du rensa din data i Chrome från den här enheten?</translation>
-<translation id="6697492270171225480">Visa förslag på liknande sidor om en sida inte hittas</translation>
-<translation id="6697947395630195233">Du behöver ge Chrome åtkomstbehörighet till din plats om den ska kunna delas med webbplatsen.</translation>
-<translation id="6698801883190606802">Hantera synkroniserad data</translation>
-<translation id="6699370405921460408">Googles servrar optimerar sidor du besöker.</translation>
-<translation id="6706288973712894588">Du är offline just nu.\n<ph name="BEGIN_LINK" />Utforska offlineflödet.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Nyheter</translation>
-<translation id="6710213216561001401">Föregående</translation>
-<translation id="671481426037969117">Timern för <ph name="FQDN" /> har löpt ut. Den börjar om igen i morgon.</translation>
-<translation id="6738867403308150051">Laddar ned …</translation>
-<translation id="6746124502594467657">Flytta ned</translation>
-<translation id="6766622839693428701">Svep nedåt när du vill stänga.</translation>
-<translation id="6766758767654711248">Tryck här för att besöka webbplatsen</translation>
-<translation id="6767294960381293877">Listan över enheter som fliken kan delas med öppnades och tar upp halva skärmen.</translation>
-<translation id="6782111308708962316">Hindra att webbplatser från tredje part sparar och läser cookiedata</translation>
-<translation id="6790428901817661496">Spela</translation>
-<translation id="6811034713472274749">Sidan är klar att öppna</translation>
-<translation id="6818926723028410516">Välj objekt</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Översätt</translation>
-<translation id="6845325883481699275">Bidra till att göra Chrome säkrare</translation>
-<translation id="6846298663435243399">Läser in…</translation>
-<translation id="6850409657436465440">Nedladdningen pågår fortfarande</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> flikar har stängts</translation>
-<translation id="6864459304226931083">Ladda ned bild</translation>
-<translation id="6865313869410766144">Formuläruppgifter för Autofyll</translation>
-<translation id="688738109438487280">Lägg till befintlig data i <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Lås upp om du vill kopiera lösenordet</translation>
-<translation id="6896758677409633944">Kopiera</translation>
-<translation id="6910211073230771657">Borttagen</translation>
-<translation id="6912998170423641340">Webbplatser ges inte tillgång till text och bilder i Urklipp</translation>
-<translation id="6914783257214138813">Alla med tillgång till den exporterade filen kan läsa dina lösenord.</translation>
-<translation id="6942665639005891494">Ändra standardplats för nedladdningar när som helst via alternativet i inställningsmenyn</translation>
-<translation id="6945221475159498467">Välj</translation>
-<translation id="6963642900430330478">Sidan är farlig. Webbplatsinformation</translation>
-<translation id="6963766334940102469">Radera bokmärken</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Sedan kontot skapades</translation>
-<translation id="6981982820502123353">Tillgänglighet</translation>
-<translation id="6989267951144302301">Nedladdning misslyckades</translation>
-<translation id="6990079615885386641">Hämta appen från Google Play Butik: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Fråga innan webbplatser tillåts att använda mikrofonen (rekommenderas)</translation>
-<translation id="7015203776128479407">Den initiala synkroniseringskonfigureringen avslutades inte. Synkroniseringen är inaktiverad.</translation>
-<translation id="7016516562562142042">Tillåt för den nuvarande sökmotorn</translation>
-<translation id="7022756207310403729">Öppna i webbläsaren</translation>
-<translation id="702463548815491781">Rekommenderas när TalkBack eller brytarstyrning är aktiverat</translation>
-<translation id="7029809446516969842">Lösenord</translation>
-<translation id="7053983685419859001">Blockera</translation>
-<translation id="7055152154916055070">Omdirigeringen blockerades:</translation>
-<translation id="7063006564040364415">Det gick inte att ansluta till synkroniseringsservern.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 har valts}other{# har valts}}</translation>
-<translation id="7071521146534760487">Hantera konto</translation>
-<translation id="7077143737582773186">SD-kort</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> har valts. Alternativ finns högt upp på skärmen</translation>
-<translation id="7121362699166175603">Historik och autoslutföranden i adressfältet rensas. Det kan finnas andra former av webbhistorik i Google-kontot på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Tillåt för den nuvarande sökmotorn</translation>
-<translation id="7138678301420049075">Övrigt</translation>
-<translation id="7141896414559753902">Blockera webbplatser från att visa popup-fönster (rekommenderas)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Läs in originalsidan<ph name="END_LINK" /> från <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Senaste 24 timmarna</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> kB</translation>
-<translation id="7177466738963138057">Du kan ändra detta senare i inställningarna</translation>
-<translation id="7180611975245234373">Uppdatera</translation>
-<translation id="7189372733857464326">Väntar på Google Play-tjänster ska avsluta uppdateringen</translation>
-<translation id="7191430249889272776">Fliken öppnades i bakgrunden.</translation>
-<translation id="723171743924126238">Välj bilder</translation>
-<translation id="7233236755231902816">Skaffa den senaste versionen av Chrome och få webben översatt till ditt språk</translation>
-<translation id="7243308994586599757">Alternativ visas nära skärmens nedre kant</translation>
-<translation id="7248069434667874558">Kontrollera att synkronisering har aktiverats i Chrome på <ph name="TARGET_DEVICE_NAME" /></translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> har valts</translation>
-<translation id="7274013316676448362">Blockerad webbplats</translation>
-<translation id="7290209999329137901">Det går inte att byta namn</translation>
-<translation id="7291387454912369099">Betalning med assistenten</translation>
-<translation id="7293171162284876153">Starta synkroniseringen genom att aktivera Synkronisera data i Chrome.</translation>
-<translation id="729975465115245577">Det finns ingen app som kan spara lösenordsfilen på enheten.</translation>
-<translation id="7302081693174882195">Mer information: Sorterad efter databesparing</translation>
-<translation id="7328017930301109123">I begränsat läge läses sidorna in snabbare och dataförbrukningen minskar med upp till 60 procent.</translation>
-<translation id="7333031090786104871">Processen pågår fortfarande för den förra webbplatsen</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Dela 1 markerat objekt}other{Dela # markerade objekt}}</translation>
 <translation id="7359002509206457351">Åtkomst till betalningsmetoder</translation>
+<translation id="8026334261755873520">Rensa webbinformation</translation>
+<translation id="1291207594882862231">Rensa historiken, cookies, webbplatsdata, cacheminnet …</translation>
+<translation id="7814200940910057384">Data i Brave har rensats</translation>
+<translation id="1664855196866195614">Markerad data har tagits bort från Brave och från synkroniserade enheter.
+
+Det kan finnas andra former av webbhistorik i Brave Software-kontot på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>, t.ex. sökningar och aktivitet på andra tjänster från Brave Software.</translation>
+<translation id="4699172675775169585">Cachade bilder och filer</translation>
+<translation id="2496180316473517155">Webbhistorik</translation>
+<translation id="2546283357679194313">Cookies och webbplatsdata</translation>
+<translation id="8662811608048051533">Du loggas ut från de flesta webbplatser.</translation>
+<translation id="8218628800671693884">Du loggas ut från de flesta webbplatser. Du loggas inte ut från Brave Software-kontot.</translation>
+<translation id="2017836877785168846">Rensar historik och autoslutföranden i adressfältet.</translation>
+<translation id="8096327394278038498">Historik och autoslutföranden i adressfältet rensas. Det kan finnas andra former av webbhistorik i Brave Software-kontot på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Historik rensas från alla inloggade enheter. Det kan finnas andra former av webbhistorik i Brave Software-kontot på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Sparade lösenord</translation>
+<translation id="6865313869410766144">Formuläruppgifter för Autofyll</translation>
+<translation id="7562080006725997899">Tar bort webbinformation</translation>
+<translation id="5487521232677179737">Rensa data</translation>
+<translation id="7498271377022651285">Vänta …</translation>
+<translation id="784934925303690534">Tidsintervall</translation>
+<translation id="1718835860248848330">Senaste timmen</translation>
+<translation id="7149893636342594995">Senaste 24 timmarna</translation>
+<translation id="5648166631817621825">Senaste sju dagarna</translation>
+<translation id="8571213806525832805">Senaste fyra veckorna</translation>
+<translation id="5854790677617711513">Äldre än 30 dagar</translation>
+<translation id="6979737339423435258">Sedan kontot skapades</translation>
+<translation id="982182592107339124">Åtgärden raderar data för alla webbplatser, inklusive:</translation>
+<translation id="6643016212128521049">Rensa</translation>
+<translation id="7641339528570811325">Rensa webbinformation …</translation>
+<translation id="1670399744444387456">Grunder</translation>
+<translation id="3245261285041759672">Det kan finnas andra former av webbhistorik i Brave Software-kontot på <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Blockerad webbplats</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> objekt har tagits bort</translation>
+<translation id="1121094540300013208">Användning och felrapporter</translation>
+<translation id="9079153198295609735">Skicka användningsstatistik och kraschrapporter till Brave Software automatiskt</translation>
+<translation id="6981982820502123353">Tillgänglighet</translation>
+<translation id="2387895666653383613">Textskalning</translation>
+<translation id="2321958826496381788">Flytta reglaget tills du kan läsa texten ordentligt. Texten bör bli åtminstone så här stor när du trycker två gånger på ett stycke.</translation>
+<translation id="3895926599014793903">Tvinga aktivering av zoom</translation>
+<translation id="5668404140385795438">Åsidosätt en webbplats begäran att hindra inzoomning</translation>
+<translation id="4149994727733219643">Förenklad vy för webbsidor</translation>
+<translation id="9100505651305367705">Fråga om artiklarna ska visas i en förenklad vy när detta stöds</translation>
+<translation id="1409426117486808224">Förenklad vy för öppna flikar</translation>
+<translation id="702463548815491781">Rekommenderas när TalkBack eller brytarstyrning är aktiverat</translation>
+<translation id="8284326494547611709">Textning</translation>
+<translation id="4165986682804962316">Platsinställningar</translation>
+<translation id="6295158916970320988">Alla webbplatser</translation>
+<translation id="8380167699614421159">Påträngande eller vilseledande annonser visas på den här webbplatsen</translation>
+<translation id="1919345977826869612">Annonser</translation>
+<translation id="410351446219883937">Automatisk uppspelning</translation>
+<translation id="6447842834002726250">Cookies</translation>
+<translation id="6196640612572343990">Blockera cookies från tredje part</translation>
+<translation id="6782111308708962316">Hindra att webbplatser från tredje part sparar och läser cookiedata</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Popup och omdirigeringar</translation>
+<translation id="4751476147751820511">Rörelse- eller ljussensorer</translation>
+<translation id="1717218214683051432">Rörelsesensorer</translation>
+<translation id="2091887806945687916">Ljud</translation>
+<translation id="2586657967955657006">Urklipp</translation>
+<translation id="6320088164292336938">Vibration</translation>
+<translation id="4226663524361240545">Aviseringar kan göra att enheten vibrerar</translation>
+<translation id="1446450296470737166">Tillåt fullst. kontroll av MIDI</translation>
+<translation id="3744111561329211289">Synkronisera i bakgrunden</translation>
+<translation id="5649053991847567735">Automatiska nedladdningar</translation>
+<translation id="6181444274883918285">Lägg till en webbplats i undantagen</translation>
+<translation id="5313967007315987356">Lägg till webbplats</translation>
+<translation id="1369915414381695676">Webbplatsen <ph name="SITE_NAME"/> har lagts till</translation>
+<translation id="7837721118676387834">Tillåt automatisk uppspelning av videor utan ljud för en specifik webbplats.</translation>
+<translation id="2621115761605608342">Tillåt Javascript på en specifik webbplats.</translation>
+<translation id="8801436777607969138">Blockera JavaScript på en enskild webbplats.</translation>
+<translation id="8372893542064058268">Tillåt bakgrundssynkronisering för en specifik webbplats.</translation>
+<translation id="358794129225322306">Tillåt att en webbplats laddar ned flera filer automatiskt.</translation>
+<translation id="4008040567710660924">Tillåt cookies för en enskild webbplats.</translation>
+<translation id="8958424370300090006">Blockera cookies för en enskild webbplats.</translation>
+<translation id="7882806643839505685">Tillåt ljud för en webbplats.</translation>
+<translation id="4468959413250150279">Stäng av ljudet för en webbplats.</translation>
+<translation id="1994173015038366702">Webbadress</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Användning</translation>
+<translation id="5804241973901381774">Behörigheter</translation>
+<translation id="4278390842282768270">Tillåtet</translation>
+<translation id="5677928146339483299">Blockerade</translation>
+<translation id="1984937141057606926">Tillåts, men inte från tredje part</translation>
+<translation id="7423098979219808738">Fråga först</translation>
+<translation id="8116925261070264013">Ljudet avstängt</translation>
+<translation id="8300705686683892304">Hanteras av app</translation>
+<translation id="6192792657125177640">Undantag</translation>
+<translation id="257931822824936280">Vyn har expanderats. Komprimera den genom att klicka.</translation>
+<translation id="5100237604440890931">Vyn har komprimerats. Expandera den genom att klicka.</translation>
+<translation id="857943718398505171">Tillåten (rekommenderas)</translation>
+<translation id="2913331724188855103">Tillåt att webbplatser sparar och läser cookiedata (rekommenderas)</translation>
+<translation id="7445411102860286510">Tillåt att webbplatser automatiskt spelar upp videor utan ljud (rekommenderas)</translation>
+<translation id="5335288049665977812">Tillåt att Javascript körs på webbplatser (rekommenderas)</translation>
+<translation id="5527111080432883924">Fråga innan en webbplats ges läsbehörighet till text och bilder i Urklipp (rekommenderas)</translation>
+<translation id="6912998170423641340">Webbplatser ges inte tillgång till text och bilder i Urklipp</translation>
+<translation id="7423538860840206698">Läsbehörighet till Urklipp har nekats</translation>
+<translation id="3955193568934677022">Tillåt att skyddat innehåll spelas upp på webbplatser (rekommenderas)</translation>
+<translation id="445467742685312942">Tillåt att webbplatser spelar upp skyddat innehåll</translation>
+<translation id="2107397443965016585">Fråga innan webbplatser tillåts att spela upp skyddat innehåll (rekommenderas)</translation>
+<translation id="2910701580606108292">Fråga innan webbplatser tillåts att spela upp skyddat innehåll</translation>
+<translation id="757524316907819857">Blockera webbplatser från att spela upp skyddat innehåll</translation>
+<translation id="3277252321222022663">Tillåt att webbplatser får åtkomst till enhetens sensorer (rekommenderas)</translation>
+<translation id="5048398596102334565">Tillåt webbplatser att använda enhetens rörelsesensorer (rekommenderas)</translation>
+<translation id="8816026460808729765">Blockera webbplatser från att använda enhetens sensorer</translation>
+<translation id="169515064810179024">Blockera webbplatser från att använda enhetens rörelsesensorer</translation>
+<translation id="1660204651932907780">Tillåt att ljud spelas upp på webbplatser (rekommenderas)</translation>
+<translation id="3600792891314830896">Stäng av ljudet på webbplatser</translation>
+<translation id="1743802530341753419">Fråga innan webbplatser tillåts ansluta till en enhet (rekommenderas)</translation>
+<translation id="851751545965956758">Förhindra att webbplatser ansluter till enheter</translation>
+<translation id="7141896414559753902">Blockera webbplatser från att visa popup-fönster (rekommenderas)</translation>
+<translation id="5494752089476963479">Blockera annonser på webbplatser där påträngande eller vilseledande annonser visas</translation>
+<translation id="3123473560110926937">Blockeras på vissa webbplatser</translation>
+<translation id="965817943346481315">Blockera om påträngande eller vilseledande annonser visas på webbplatsen (rekommenderas)</translation>
+<translation id="3386292677130313581">Fråga innan webbplatser tillåts att veta var du befinner dig (rekommenderas)</translation>
+<translation id="9139068048179869749">Fråga innan webbplatser tillåts att skicka aviseringar (rekommenderas)</translation>
+<translation id="4479647676395637221">Fråga innan webbplatser tillåts att använda kameran (rekommenderas)</translation>
+<translation id="6992289844737586249">Fråga innan webbplatser tillåts att använda mikrofonen (rekommenderas)</translation>
+<translation id="2289270750774289114">Fråga när en webbplats försöker söka efter Bluetooth-enheter i närheten (rekommenderas)</translation>
+<translation id="7053983685419859001">Blockera</translation>
+<translation id="7128222689758636196">Tillåt för den nuvarande sökmotorn</translation>
+<translation id="7589445247086920869">Blockera för den nuvarande sökmotorn</translation>
+<translation id="6388207532828177975">Ta bort och återställ</translation>
+<translation id="7999064672810608036">Vill du ta bort all lokal data för webbplatsen, inklusive cookies, och återställa alla behörigheter för den?</translation>
+<translation id="2822354292072154809">Vill du återställa alla webbplatsbehörigheter för <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Ta bort sparad data</translation>
+<translation id="5902828464777634901">All data som sparats lokalt av webbplatsen tas bort, inklusive cookies.</translation>
+<translation id="119944043368869598">Ta bort alla</translation>
+<translation id="2490684707762498678">Hanteras av <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Öppna aviseringsinställningar</translation>
+<translation id="1404122904123200417">Inbäddad i <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Filer som webbplatser har sparat visas här</translation>
+<translation id="4181841719683918333">Språk</translation>
+<translation id="2647434099613338025">Lägg till språk</translation>
+<translation id="1952172573699511566">När det är möjligt visas text på webbplatser på önskat språk.</translation>
+<translation id="8559990750235505898">Erbjud översättning av sidor till andra språk</translation>
+<translation id="4719927025381752090">Erbjud översättning</translation>
+<translation id="8156139159503939589">Vilka språk kan du läsa?</translation>
+<translation id="5689516760719285838">Plats</translation>
+<translation id="2440823041667407902">Platsåtkomst</translation>
+<translation id="2023546461831060654">Aktivera behörigheter för Brave i <ph name="BEGIN_LINK"/>Android-inställningar<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Aktivera behörighet för Brave i <ph name="BEGIN_LINK"/>Android-inställningar<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Om du vill ge Brave åtkomst till din plats måste du även aktivera plats i <ph name="BEGIN_LINK"/>inställningarna för Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Om du vill ge Brave åtkomst till kameran måste du även aktivera kameran i <ph name="BEGIN_LINK"/>inställningarna för Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Om du vill få aviseringar från Brave måste du även aktivera aviseringar i <ph name="BEGIN_LINK"/>inställningarna för Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Om du vill ge Brave åtkomst till mikrofonen måste du även aktivera mikrofonen i <ph name="BEGIN_LINK"/>inställningarna för Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Platsåtkomst har inaktiverats på enheten. Aktivera det i <ph name="BEGIN_LINK"/>Android-inställningarna<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Platsåtkomst har inaktiverats på enheten också. Aktivera det i <ph name="BEGIN_LINK"/>Android-inställningarna<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Tillgång till din kamera</translation>
+<translation id="945632385593298557">Tillgång till din mikrofon</translation>
+<translation id="6612358246767739896">Skyddat innehåll</translation>
+<translation id="885701979325669005">Lagring</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> sparad data</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Återkalla enhetsbehörighet</translation>
+<translation id="4962975101802056554">Återkalla alla behörigheter för enheten</translation>
+<translation id="6545864417968258051">Bluetooth-sökning</translation>
+<translation id="4411535500181276704">Begränsat läge</translation>
+<translation id="7821588508402923572">Här visas hur mycket data du har sparat</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> har sparats</translation>
+<translation id="8569404424186215731">sedan <ph name="DATE"/></translation>
+<translation id="3252158532344029638">I begränsat läge läses sidorna in snabbare och dataförbrukningen minskar med upp till 60 procent.</translation>
+<translation id="6159335304067198720">Sparat utrymme: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">Sparad data</translation>
+<translation id="6111020039983847643">Använd data</translation>
+<translation id="7413229368719586778">Startdatum <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Slutdatum <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sortera efter webbplats</translation>
+<translation id="5864174910718532887">Mer information: Sorterad efter webbplatsnamn</translation>
+<translation id="116280672541001035">Använt</translation>
+<translation id="8349013245300336738">Sortera efter dataförbrukning</translation>
+<translation id="6378173571450987352">Mer information: Sorterad efter dataförbrukning</translation>
+<translation id="2631006050119455616">Sparat</translation>
+<translation id="6643649862576733715">Sortera efter databesparing</translation>
+<translation id="7302081693174882195">Mer information: Sorterad efter databesparing</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> har använts</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> har sparats</translation>
+<translation id="2156074688469523661">Återstående webbplatser (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Övrigt</translation>
+<translation id="4913161338056004800">Återställ statistik</translation>
+<translation id="1856325424225101786">Vill du återställa begränsat läge?</translation>
+<translation id="3658159451045945436">Om du återställer begränsat läge raderas databesparingshistoriken, inklusive listan med webbplatser som du har besökt.</translation>
+<translation id="3295530008794733555">Surfa snabbare. Förbruka mindre data.</translation>
+<translation id="7340390500800578919">I begränsat läge läses sidorna in snabbare och dataförbrukningen minskar med upp till 60 procent. Webbtrafiken skickas till Brave Software från Brave för att optimera sidorna du besöker. <ph name="BEGIN_LINK"/>Läs mer<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Aktivera begränsat läge</translation>
+<translation id="4493497663118223949">Begränsat läge har aktiverats</translation>
+<translation id="7559975015014302720">Begränsat läge har inaktiverats</translation>
+<translation id="7606077192958116810">Begränsat läge har aktiverats. Hantera detta i inställningarna.</translation>
+<translation id="4714588616299687897">Spara upp till 60 % av din data</translation>
+<translation id="1006927014032731288">Brave Softwares servrar optimerar sidor du besöker.</translation>
+<translation id="3257320067425202300">Du har sparat <ph name="MEGABYTES"/> MB med Brave</translation>
+<translation id="5813223329348543512">Du har sparat <ph name="GIGABYTES"/> GB med Brave</translation>
+<translation id="8266862848225348053">Nedladdningsplats</translation>
+<translation id="7077143737582773186">SD-kort</translation>
+<translation id="7762668264895820836">SD-kort <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Fråga var filerna ska sparas</translation>
+<translation id="6192333916571137726">Ladda ned fil</translation>
+<translation id="1672586136351118594">Visa inte igen</translation>
+<translation id="2650751991977523696">Vill du ladda ned filen igen?</translation>
+<translation id="8664979001105139458">Filnamnet finns redan</translation>
+<translation id="488187801263602086">Byt namn på fil</translation>
+<translation id="5686790454216892815">Filnamnet är för långt</translation>
+<translation id="7454641608352164238">Utrymmet räcker inte</translation>
+<translation id="8972098258593396643">Vill du ladda ned till standardmappen?</translation>
+<translation id="804335162455518893">Det gick inte att hitta SD-kortet</translation>
+<translation id="7475688122056506577">Det gick inte att hitta SD-kortet. Det kan saknas filer.</translation>
+<translation id="4198423547019359126">Det fins inga tillgängliga nedladdningsplatser</translation>
+<translation id="8224471946457685718">Ladda ned artiklar för dig via Wi-Fi</translation>
+<translation id="4970824347203572753">Inte tillgängligt i ditt land</translation>
+<translation id="5500777121964041360">Kanske inte tillgängligt i ditt land</translation>
+<translation id="1173894706177603556">Ändra namn</translation>
+<translation id="1986685561493779662">Namnet finns redan</translation>
+<translation id="6441734959916820584">Namnet är för långt</translation>
+<translation id="2923908459366352541">Namnet är ogiltigt</translation>
+<translation id="7290209999329137901">Det går inte att byta namn</translation>
+<translation id="3334729583274622784">Vill du ändra filnamnstillägget?</translation>
+<translation id="107147699690128016">Om du ändrar filnamnstillägget kanske filen öppnas i ett annat program vilket kan utgöra en fara för enheten.</translation>
+<translation id="8541922081612557424">Om Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. Med ensamrätt.</translation>
+<translation id="1416550906796893042">Appversion</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (uppdaterades <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Operativsystem</translation>
+<translation id="3968054912784331254">Uppdateringar av Brave stöds inte längre för den här versionen av Android</translation>
+<translation id="7665369617277396874">Lägg till konto</translation>
+<translation id="649070405679044769">Inloggad i Brave Software som</translation>
+<translation id="6234515504547364178">Logga ut från Brave</translation>
+<translation id="5324858694974489420">Föräldrainställningar</translation>
+<translation id="8920114477895755567">Väntar på föräldrauppgifter.</translation>
+<translation id="5512137114520586844">Det här kontot hanteras av <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Det här kontot hanteras av <ph name="PARENT_NAME_1"/> och <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Innehåll</translation>
+<translation id="5403644198645076998">Tillåt endast vissa webbplatser</translation>
+<translation id="8641930654639604085">Försök blockera webbplatser med innehåll för vuxna</translation>
+<translation id="5639724618331995626">Tillåt alla webbplatser</translation>
+<translation id="796823723482603597">Drivs av Brave</translation>
+<translation id="6324034347079777476">Synkronisering av Android-system har inaktiverats</translation>
+<translation id="5127805178023152808">Synkronisering är av</translation>
+<translation id="7015203776128479407">Den initiala synkroniseringskonfigureringen avslutades inte. Synkroniseringen är inaktiverad.</translation>
+<translation id="2497852260688568942">Synkronisering har inaktiverats av administratören</translation>
+<translation id="9100610230175265781">Lösenfras krävs</translation>
+<translation id="6108923351542677676">Konfigurationen pågår ...</translation>
+<translation id="4062305924942672200">Juridisk information</translation>
+<translation id="4256782883801055595">Licenser för öppen källkod</translation>
+<translation id="1138681184697033370">Braves användarvillkor</translation>
+<translation id="7392539049993970338">Braves sekretessmeddelande</translation>
+<translation id="2677748264148917807">Lämna</translation>
+<translation id="5556459405103347317">Hämta igen</translation>
+<translation id="1623104350909869708">Hindra sidan från att skapa fler dialogrutor</translation>
+<translation id="2968755619301702150">Certifikatvisare</translation>
+<translation id="1360432990279830238">Logga ut och inaktivera synkronisering?</translation>
+<translation id="8581481290581777242">Vill du rensa din data i Brave från den här enheten?</translation>
+<translation id="1318865768845061710">Bokmärken, historik, lösenord och annan data i Brave synkroniseras inte längre med ditt Brave Software-konto</translation>
+<translation id="3325020657155065477">Rensa även Brave-data från enheten</translation>
+<translation id="6136448902816743006">Eftersom du loggar ut från ett konto som hanteras av <ph name="DOMAIN_NAME"/> raderas din Brave-data från den här enheten. Den finns kvar på ditt Brave Software-konto.</translation>
+<translation id="1853026300647876496">Kontaktar Brave Software. Det här kan ta någon minut …</translation>
+<translation id="2328985652426384049">Det gick inte att logga in</translation>
+<translation id="7723158744459952869">Brave Software tog för lång tid på sig att svara</translation>
+<translation id="4572422548854449519">Logga in på hanterat konto</translation>
+<translation id="2689656545739939160">Du håller på att logga in med ett konto som hanteras av <ph name="MANAGED_DOMAIN"/>, vilket ger administratören kontroll över data i Brave. Din data kopplas permanent till det här kontot. Om du loggar ut från Brave raderas all din data från enheten, men den lagras fortfarande i Brave Software-kontot.</translation>
+<translation id="1749561566933687563">Synkronisera bokmärken</translation>
+<translation id="4242533952199664413">Öppna Inställningar</translation>
+<translation id="1111673857033749125">Här visas bokmärken som du har sparat på andra enheter.</translation>
+<translation id="8636825310635137004">Aktivera synkronisering om du vill ha samma flikar tillgängliga på alla enheter.</translation>
+<translation id="3269956123044984603">Aktivera Automatisk synkronisering av data i kontoinställningarna för Android om du vill ha samma flikar tillgängliga på alla enheter.</translation>
+<translation id="5157964048453367290">Här visas flikar som du har öppnat i Brave på andra enheter.</translation>
+<translation id="4684427112815847243">Synkronisera allt</translation>
+<translation id="2709516037105925701">Autofyll</translation>
+<translation id="8820817407110198400">Bokmärken</translation>
+<translation id="1644574205037202324">Historik</translation>
+<translation id="17513872634828108">Öppna flikar</translation>
+<translation id="1320169905922104972">Kreditkort och adresser som används med Brave Software Pay</translation>
+<translation id="6337234675334993532">Kryptering</translation>
+<translation id="6698801883190606802">Hantera synkroniserad data</translation>
+<translation id="3598578758776312506">Kryptera lösenord med användaruppgifter för Brave Software</translation>
+<translation id="7810580217418711046">Kryptera synkroniserad data med Brave Software-lösenordet från <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Kryptera synkroniserad data med en egen lösenfras för synkronisering</translation>
+<translation id="2996291259634659425">Skapa lösenfras</translation>
+<translation id="5713644099811900409">Brave Software-konto</translation>
+<translation id="8997474919031554666">Betalningsmetoder och adresser från Brave Software Pay omfattas inte av kryptering med lösenfras. Endast personer som har ditt lösenord kan läsa dina krypterade uppgifter. Lösenfrasen skickas inte till och sparas inte av Brave Software. Om du glömmer lösenfrasen måste du återställa synkroniseringen. <ph name="BEGIN_LINK"/>Läs mer<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Lösenfras</translation>
+<translation id="7772032839648071052">Bekräfta lösenfras</translation>
+<translation id="5304593522240415983">Fältet får inte vara tomt</translation>
+<translation id="321773570071367578">Om du har glömt lösenfrasen eller vill ändra inställningen <ph name="BEGIN_LINK"/>återställer du synkroniseringen<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Lösenfraserna matchar inte</translation>
+<translation id="5149495116300586333">Betalningsmetoder och adresser från Brave Software Pay omfattas inte av kryptering med lösenfras.
+
+<ph name="BEGIN_LINK"/>Återställ synkroniseringen<ph name="END_LINK"/> om du vill ändra den här inställningen.</translation>
+<translation id="7638584964844754484">Felaktig lösenfras</translation>
+<translation id="5414836363063783498">Verifierar ...</translation>
+<translation id="6846298663435243399">Läser in…</translation>
+<translation id="5517095782334947753">Du har bokmärken, historik, lösenord och andra inställningar från <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Slå ihop data</translation>
+<translation id="688738109438487280">Lägg till befintlig data i <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Håll min data separat</translation>
+<translation id="1145536944570833626">Radera befintlig data.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> vill kopplas</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Få hjälp<ph name="END_LINK"/> under sökningen efter enheter …</translation>
+<translation id="5817918615728894473">Koppla</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Få hjälp<ph name="END_LINK1"/> eller <ph name="BEGIN_LINK2"/>sök igen<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Inga kompatibla enheter hittades</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Aktivera Bluetooth<ph name="END_LINK"/> om du vill tillåta koppling</translation>
+<translation id="998321811308652668">Det gick inte att aktivera Bluetooth-adaptern i Brave</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Få hjälp<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave behöver platsåtkomst för att söka efter enheter. <ph name="BEGIN_LINK"/>Uppdatera behörigheter<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave behöver åtkomst till platsinformation för att kunna söka efter enheter. Platsåtkomst är <ph name="BEGIN_LINK"/>inaktiverat för enheten<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave behöver tillgång till platsinformation för att kunna söka efter enheter. <ph name="BEGIN_LINK1"/>Uppdatera behörigheter<ph name="END_LINK1"/>. Platsåtkomst är dessutom <ph name="BEGIN_LINK2"/>inaktiverat för enheten<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Ansluten enhet</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstyrka: # streck}other{Signalstyrka: # streck}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> vill söka efter Bluetooth-enheter i närheten. Följande enheter har hittats:</translation>
+<translation id="8368027906805972958">Enheten är okänd eller stöds inte (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Det går inte att synkronisera</translation>
+<translation id="1810845389119482123">Konfigurationen av synkronisering har inte slutförts</translation>
+<translation id="3235722914093408050">Återaktivera synkronisering i Android-inställningarna så börjar Brave synkas</translation>
+<translation id="3367813778245106622">Logga in igen om du vill påbörja synkroniseringen</translation>
+<translation id="974555521953189084">Ange lösenfrasen för att starta synkroniseringen</translation>
+<translation id="2997266899014181325">Starta synkroniseringen genom att aktivera Synkronisera data i Brave.</translation>
+<translation id="8260126382462817229">Försök att logga in igen</translation>
+<translation id="5919204609460789179">Uppdatera <ph name="PRODUCT_NAME"/> för att starta synkronisering</translation>
+<translation id="397583555483684758">Synkroniseringen har slutat fungera</translation>
+<translation id="1966710179511230534">Uppdatera dina inloggningsuppgifter.</translation>
+<translation id="7063006564040364415">Det gick inte att ansluta till synkroniseringsservern.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> är inaktuell.</translation>
+<translation id="4170011742729630528">Tjänsten är inte tillgänglig, försök igen senare.</translation>
+<translation id="7947953824732555851">Godkänn och logga in</translation>
+<translation id="8583805026567836021">Rensar kontouppgifter</translation>
+<translation id="8310344678080805313">Standardflikar</translation>
+<translation id="5748802427693696783">Bytte till standardflikar</translation>
+<translation id="7998918019931843664">Öppna en stängd flik på nytt</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, flik</translation>
+<translation id="4452411734226507615">Stäng fliken <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Alternativ visas nära skärmens nedre kant</translation>
+<translation id="4060598801229743805">Alternativ finns högt upp på skärmen</translation>
+<translation id="2810645512293415242">Förenklad sida visades för att spara data och minska inläsningstiden.</translation>
+<translation id="3985215325736559418">Vill du ladda ned <ph name="FILE_NAME"/> igen?</translation>
+<translation id="2450083983707403292">Vill du börja ladda ned <ph name="FILE_NAME"/> igen?</translation>
+<translation id="7514365320538308">Ladda ned</translation>
+<translation id="545042621069398927">Nedladdningen görs snabbare.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{En fil laddas ned.}other{# filer laddas ned.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> filer (<ph name="MEGABYTES"/>) laddas ned.</translation>
+<translation id="4988210275050210843">En fil laddas ned (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 nedladdning har slutförts.}other{# nedladdningar har slutförts.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 nedladdning misslyckades.}other{# nedladdningar misslyckades.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 nedladdning väntar.}other{# nedladdningar väntar.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> – knapp för <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Nästan klart!</translation>
+<translation id="3960299545138990065">Starta om Brave</translation>
+<translation id="3771001275138982843">Det gick inte att ladda ned uppdateringen</translation>
+<translation id="3888648114124182147">Uppdatering för Brave laddas ned …</translation>
+<translation id="1705567146636171298">Uppdatera Brave</translation>
+<translation id="6195417478702700398">Uppdatera Brave så att du får bästa möjliga surfupplevelse</translation>
+<translation id="3512968675351418494">Skaffa den senaste versionen av Brave och få webben översatt till ditt språk</translation>
+<translation id="6427112570124116297">Översätt webbsidor</translation>
+<translation id="1379423114029199501">Uppdatera och få ditt språk i den senaste versionen av Brave</translation>
+<translation id="5684874026226664614">Det gick inte att översätta sidan.</translation>
+<translation id="6831043979455480757">Översätt</translation>
+<translation id="1285320974508926690">Översätt aldrig den här webbplatsen</translation>
+<translation id="773466115871691567">Översätt alltid sidor på <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Översätt aldrig sidor på <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Fler språk</translation>
+<translation id="290376772003165898">Är sidan inte på <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Sidor på <ph name="SOURCE_LANGUAGE"/> översätts till <ph name="TARGET_LANGUAGE"/> från och med nu</translation>
+<translation id="8339163506404995330">Sidor på <ph name="LANGUAGE"/> översätts inte</translation>
+<translation id="5447765697759493033">Den här webbplatsen översätts inte</translation>
+<translation id="4880127995492972015">Översätt …</translation>
+<translation id="641643625718530986">Skriv ut …</translation>
+<translation id="8909135823018751308">Dela …</translation>
+<translation id="4996978546172906250">Dela via</translation>
+<translation id="6333140779060797560">Dela via <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Det gick inte att skriva ut sidan. Försök igen.</translation>
+<translation id="3254409185687681395">Bokmärk sidan</translation>
+<translation id="497421865427891073">Fortsätt</translation>
+<translation id="813082847718468539">Visa information om webbplatsen</translation>
+<translation id="2532336938189706096">Webbvy</translation>
+<translation id="6005538289190791541">Föreslaget lösenord</translation>
+<translation id="4634124774493850572">Använd lösenordet</translation>
+<translation id="8285489906452138776">Du behöver ge Brave behörighet att använda kameran på den här webbplatsen.</translation>
+<translation id="320189792589364011">Du behöver ge Brave behörighet att använda mikrofonen på den här webbplatsen.</translation>
+<translation id="7988136689212463100">Du behöver ge Brave behörighet att använda kameran och mikrofonen på den här webbplatsen.</translation>
+<translation id="4931190655840828017">Du behöver ge Brave åtkomstbehörighet till din plats om den ska kunna delas med webbplatsen.</translation>
+<translation id="3088191967551450609">Brave måste ha åtkomst till lagringsutrymmet om det ska gå att ladda ned filer.</translation>
+<translation id="8942627711005830162">Öppna i ett annat fönster</translation>
+<translation id="4195643157523330669">Öppna i ny flik</translation>
+<translation id="1100066534610197918">Öppna på en ny flik i gruppen</translation>
+<translation id="4860895144060829044">Ring</translation>
+<translation id="6896758677409633944">Kopiera</translation>
+<translation id="8393700583063109961">Skicka meddelande</translation>
+<translation id="3557336313807607643">Lägg till i kontakter</translation>
+<translation id="4269820728363426813">Kopiera länkadress</translation>
+<translation id="1206892813135768548">Kopiera länktext</translation>
+<translation id="1204037785786432551">Ladda ned länk</translation>
+<translation id="6864459304226931083">Ladda ned bild</translation>
+<translation id="8209050860603202033">Öppna bild</translation>
+<translation id="8073388330009372546">Öppna bild i ny flik</translation>
+<translation id="6649642165559792194">Förhandsgranska bild <ph name="BEGIN_NEW"/>Nyhet<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Läs in bild</translation>
+<translation id="3845332215609790146">Sök med Brave Software Lens <ph name="BEGIN_NEW"/>Nyhet<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Sök på <ph name="SEARCH_ENGINE"/> efter denna bild</translation>
+<translation id="3384347053049321195">Dela bild</translation>
+<translation id="5833984609253377421">Dela länk</translation>
+<translation id="6475951671322991020">Ladda ned video</translation>
+<translation id="2317945146070194624">Öppna på ny flik i Brave</translation>
+<translation id="7975379999046275268">Förhandsgranska sida <ph name="BEGIN_NEW"/>Nyhet<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Uppdaterar sidan</translation>
+<translation id="36525718899759834">Hämta appen från Brave Software Play Butik: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Mörk</translation>
+<translation id="1807246157184219062">Ljus</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Välj en flik som du vill överföra</translation>
+<translation id="8719023831149562936">Den aktuella fliken kan inte överföras</translation>
+<translation id="2139186145475833000">Lägg till på startskärmen</translation>
+<translation id="4616150815774728855">Öppna <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Det gick inte att öppna appen</translation>
+<translation id="5129038482087801250">Installera webbapp</translation>
+<translation id="3789841737615482174">Installera</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> har lagts till på startskärmen.</translation>
+<translation id="7333031090786104871">Processen pågår fortfarande för den förra webbplatsen</translation>
+<translation id="1036727731225946849">Lägger till <ph name="WEBAPK_NAME"/> …</translation>
+<translation id="3778956594442850293">Tillagd på startskärmen</translation>
+<translation id="2146738493024040262">Öppna snabbappen</translation>
+<translation id="7016516562562142042">Tillåt för den nuvarande sökmotorn</translation>
+<translation id="6177111841848151710">Blockerad för den nuvarande sökmotorn</translation>
+<translation id="145097072038377568">Inaktiverad i Android-inställningarna</translation>
+<translation id="8007176423574883786">Inaktiverad för den här enheten</translation>
+<translation id="164269334534774161">Det som visas är en offlinekopia av den här sidan från <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Den här offlinesidan sparades <ph name="CREATION_TIME"/> och kan skilja sig från onlineversionen.</translation>
+<translation id="8840953339110955557">Sidan kan skilja sig från onlineversionen.</translation>
+<translation id="6405300764336705484">Innehållet kommer från <ph name="DOMAIN_NAME"/> via Brave Software.</translation>
+<translation id="1006017844123154345">Öppna onlineversionen</translation>
+<translation id="3326636747541519688">Lite-sida tillhandahållen av Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Läs in originalsidan<ph name="END_LINK"/> från <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Om du ser detta ofta provar du de här <ph name="BEGIN_LINK"/>förslagen<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Innehållet har dolts</translation>
+<translation id="3810973564298564668">Hantera</translation>
+<translation id="5199929503336119739">Jobbprofil</translation>
+<translation id="528192093759286357">Dra uppifrån och tryck på bakåtknappen för att lämna helskärmsläget.</translation>
+<translation id="2836148919159985482">Tryck på bakåtknappen för att lämna helskärmsläget.</translation>
+<translation id="3967822245660637423">Nedladdning slutförd</translation>
+<translation id="2434158240863470628">Nedladdningen är klar<ph name="SEPARATOR"/><ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Nedladdningen misslyckades</translation>
+<translation id="1384959399684842514">Nedladdningen har pausats</translation>
+<translation id="1671236975893690980">Nedladdning väntar …</translation>
+<translation id="5561549206367097665">Väntar på nätverket …</translation>
+<translation id="5864419784173784555">Väntar på nästa nedladdning …</translation>
+<translation id="6461962085415701688">Det går inte att öppna filen</translation>
+<translation id="1178581264944972037">Paus</translation>
+<translation id="8200772114523450471">Återuppta</translation>
+<translation id="1409879593029778104">Nedladdningen av <ph name="FILE_NAME"/> hindrades eftersom filen redan finns.</translation>
+<translation id="3387650086002190359">Det gick inte att ladda ned <ph name="FILE_NAME"/> på grund av filsystemfel.</translation>
+<translation id="6482749332252372425">Det gick inte att ladda ned <ph name="FILE_NAME"/> eftersom det inte finns tillräckligt med lagringsutrymme.</translation>
+<translation id="7619072057915878432">Det gick inte att ladda ned <ph name="FILE_NAME"/> på grund av nätverksfel.</translation>
+<translation id="1477626028522505441">Det gick inte att ladda ned <ph name="FILE_NAME"/> på grund av serverfel.</translation>
+<translation id="3692944402865947621">Det gick inte att ladda ned <ph name="FILE_NAME"/> eftersom det inte gick att nå lagringsplatsen.</translation>
+<translation id="604996488070107836">Det gick inte att ladda ned <ph name="FILE_NAME"/> på grund av ett okänt fel.</translation>
+<translation id="6738867403308150051">Laddar ned …</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> kB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> kB har laddats ned</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB har laddats ned</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB har laddats ned</translation>
+<translation id="9204836675896933765">1 fil återstår</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> filer återstår</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> fil har laddats ned}other{<ph name="FILES_DOWNLOADED_MANY"/> filer har laddats ned}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> dagar kvar</translation>
+<translation id="8190358571722158785">1 dag kvar</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> timmar kvar</translation>
+<translation id="510275257476243843">1 timme kvar</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> minuter kvar</translation>
+<translation id="3236059992281584593">1 minut kvar</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> sekunder kvar</translation>
+<translation id="2781151931089541271">1 sekund kvar</translation>
+<translation id="3303414029551471755">Vill du ladda ned innehållet?</translation>
+<translation id="8617240290563765734">Vill du öppna den föreslagna webbadressen i det nedladdade innehållet?</translation>
+<translation id="1373696734384179344">Det finns inte tillräckligt med minne för att ladda ned det valda innehållet.</translation>
+<translation id="5271967389191913893">Innehållet som skulle laddas ned gick inte att öppna på enheten.</translation>
+<translation id="883806473910249246">Ett fel uppstod när innehållet skulle laddas ned.</translation>
+<translation id="5626134646977739690">Namn:</translation>
+<translation id="7963646190083259054">Leverantör:</translation>
+<translation id="3414952576877147120">Storlek:</translation>
+<translation id="7375125077091615385">Typ:</translation>
+<translation id="5765780083710877561">Beskrivning:</translation>
+<translation id="4881695831933465202">Öppna</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> kB tillgängligt</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB tillgängliga</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB tillgängligt</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> av <ph name="SPACE_AVAILABLE"/> används</translation>
+<translation id="3587482841069643663">Alla</translation>
+<translation id="4988526792673242964">Sidor</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Ljud</translation>
+<translation id="9219103736887031265">Bilder</translation>
+<translation id="8250920743982581267">Dokument</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# fil}other{# filer}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# bild}other{# bilder}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videor}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ljudfil}other{# ljudfiler}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# sida}other{# sidor}}</translation>
+<translation id="5456381639095306749">Ladda ned sida</translation>
+<translation id="2394602618534698961">Filer som du laddar ned visas här</translation>
+<translation id="7810647596859435254">Öppna med …</translation>
+<translation id="5655963694829536461">Sök i dina nedladdningar</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Mina filer</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Artiklar som du kan läsa även när du är offline visas här</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# tim}other{# tim}}</translation>
+<translation id="5853623416121554550">pausad</translation>
+<translation id="8965591936373831584">väntar</translation>
+<translation id="2779651927720337254">misslyckades</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Alldeles nyss</translation>
+<translation id="4000212216660919741">Startsida offline</translation>
+<translation id="9133397713400217035">Utforska offline</translation>
+<translation id="968900484120156207">Sidor som du besöker visas här</translation>
+<translation id="7882131421121961860">Ingen historik hittades</translation>
+<translation id="3549657413697417275">Sök i historik</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">ÅÅ</translation>
+<translation id="724102042129299115">Första körningen av Brave</translation>
+<translation id="2700285883409956633">Genom att använda det här programmet godkänner du Braves <ph name="BEGIN_LINK1"/>användarvillkor<ph name="END_LINK1"/> och <ph name="BEGIN_LINK2"/>sekretessmeddelande<ph name="END_LINK2"/>.</translation>
+<translation id="1640714894372474981">Genom att fortsätta att använda programmet godkänner du Braves <ph name="BEGIN_LINK1"/>användarvillkor<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>sekretessmeddelande<ph name="END_LINK2"/> och <ph name="BEGIN_LINK3"/>sekretessmeddelandet för Brave Software-konton som hanteras via Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> öppnas i Brave. Genom att fortsätta godkänner du Braves <ph name="BEGIN_LINK1"/>användarvillkor<ph name="END_LINK1"/> och <ph name="BEGIN_LINK2"/>sekretesspolicy<ph name="END_LINK2"/>.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> öppnas i Brave. Genom att fortsätta godkänner du Braves <ph name="BEGIN_LINK1"/>användarvillkor<ph name="END_LINK1"/> och <ph name="BEGIN_LINK2"/>sekretesspolicy<ph name="END_LINK2"/> samt <ph name="BEGIN_LINK3"/>sekretessmeddelandet för  Brave Software-konton som hanteras via Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Hjälp till att förbättra Brave genom att skicka användningsstatistik och felrapporter till Brave Software.</translation>
+<translation id="3518985090088779359">Godkänn och fortsätt</translation>
+<translation id="7207456302801184289">Välkommen till Brave</translation>
+<translation id="704822250101715322">Väntar på Brave Software Play-tjänster ska avsluta uppdateringen</translation>
+<translation id="1231733316453485619">Vill du aktivera synkronisering?</translation>
+<translation id="5132942445612118989">Synkronisera lösenord, historik med mera på alla dina enheter</translation>
+<translation id="5736731321935944068">Brave Software kan anpassa Sök, annonser och andra Brave Software-tjänster utifrån historiken</translation>
+<translation id="4013614219085422040">Brave Software kan anpassa Sök och andra Brave Software-tjänster utifrån historiken</translation>
+<translation id="5581519193887989363">Du kan alltid välja vad som ska synkroniseras i <ph name="BEGIN_LINK1"/>inställningarna<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Ja</translation>
+<translation id="2410754283952462441">Välj ett konto</translation>
+<translation id="2227444325776770048">Fortsätt som <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Inte <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Aktivera synkronisering om du vill ha dina bokmärken tillgängliga på alla enheter</translation>
+<translation id="2818669890320396765">Logga in och aktivera synkronisering om du vill ha dina bokmärken tillgängliga på alla enheter</translation>
+<translation id="6003646045106347985">Aktivera synkronisering om du vill få förslag på anpassat innehåll från Brave Software</translation>
+<translation id="8494430740943879273">Logga in och aktivera synkronisering om du vill få förslag på anpassat innehåll från Brave Software</translation>
+<translation id="5862731021271217234">Aktivera synkronisering om du vill ha samma flikar tillgängliga på alla enheter</translation>
+<translation id="3568688522516854065">Logga in och aktivera synkronisering om du vill ha samma flikar tillgängliga på alla enheter</translation>
+<translation id="1208340532756947324">Aktivera synkronisering om du vill synkronisera och anpassa alla dina enheter</translation>
+<translation id="4472118726404937099">Logga in och aktivera synkronisering om du vill synkronisera och anpassa alla dina enheter</translation>
+<translation id="2426805022920575512">Välj ett annat konto</translation>
+<translation id="6790428901817661496">Spela</translation>
+<translation id="1272079795634619415">Stopp</translation>
+<translation id="2874939134665556319">Föregående spår</translation>
+<translation id="4046123991198612571">Nästa spår</translation>
+<translation id="3859306556332390985">Sök framåt</translation>
+<translation id="8441146129660941386">Sök bakåt</translation>
+<translation id="6706288973712894588">Du är offline just nu.\n<ph name="BEGIN_LINK"/>Utforska offlineflödet.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Senaste flikarna</translation>
+<translation id="8497726226069778601">Det finns inget att se här … än</translation>
+<translation id="5423934151118863508">Dina mest besökta sidor visas här</translation>
+<translation id="6127379762771434464">Objektet har tagits bort</translation>
+<translation id="4605958867780575332">Borttaget objekt: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Softwares doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Andra enheter</translation>
+<translation id="4738836084190194332">Synkroniserades senast: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{för # minut sedan}other{för # minuter sedan}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{för # timme sedan}other{för # timmar sedan}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{för # dag sedan}other{för # dagar sedan}}</translation>
+<translation id="2762000892062317888">nyss</translation>
+<translation id="1407135791313364759">Öppna alla</translation>
+<translation id="1209206284964581585">Dölj för tillfället</translation>
+<translation id="129553762522093515">Nyligen stängda</translation>
+<translation id="8413126021676339697">Visa fullständig historik</translation>
+<translation id="7876243839304621966">Ta bort alla</translation>
+<translation id="8487700953926739672">Tillgänglig offline</translation>
+<translation id="5224771365102442243">Med video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Läs mer<ph name="END_LINK"/> om förslag på innehåll</translation>
+<translation id="7542481630195938534">Det går inte att få förslag</translation>
+<translation id="5013696553129441713">Inga nya förslag</translation>
+<translation id="1736419249208073774">Utforska</translation>
+<translation id="7444811645081526538">Fler kategorier</translation>
+<translation id="6709133671862442373">Nyheter</translation>
+<translation id="1264974993859112054">Sport</translation>
+<translation id="9139318394846604261">Shopping</translation>
+<translation id="3912508018559818924">Letar efter det bästa på webben …</translation>
+<translation id="526421993248218238">Det går inte att läsa in den här sidan</translation>
+<translation id="614940544461990577">Testa att</translation>
+<translation id="3288003805934695103">läsa in sidan igen</translation>
+<translation id="2353636109065292463">Kontrollera internetanslutningen</translation>
+<translation id="2858138569776157458">Populärt</translation>
+<translation id="8364299278605033898">Visa populära webbplatser</translation>
+<translation id="1171770572613082465">Visa populära webbplatser genom att trycka på Populärt</translation>
+<translation id="5233638681132016545">Ny flik</translation>
+<translation id="4521874409998847950">Från <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>via Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Det finns en nyare version</translation>
+<translation id="4058091506841967397">Uppdatering inte möjlig</translation>
+<translation id="6316139424528454185">Android-versionen stöds inte</translation>
+<translation id="6989267951144302301">Nedladdning misslyckades</translation>
+<translation id="624789221780392884">Uppdateringen är klar</translation>
+<translation id="1549000191223877751">Flytta till annat fönster</translation>
+<translation id="7481312909269577407">Framåt</translation>
+<translation id="4084682180776658562">Infoga bokmärke</translation>
+<translation id="6437478888915024427">Sidinformation</translation>
+<translation id="7180611975245234373">Uppdatera</translation>
+<translation id="4913169188695071480">Sluta uppdatera</translation>
+<translation id="1829244130665387512">Hitta på sida</translation>
+<translation id="6593061639179217415">Datoranpassad webbplats</translation>
+<translation id="9063523880881406963">Inaktivera begäran av webbplats för stationär dator</translation>
+<translation id="2038563949887743358">Aktivera begäran av skrivbordsversion</translation>
+<translation id="2433507940547922241">Utseende</translation>
+<translation id="983192555821071799">Stäng alla flikar</translation>
+<translation id="1310482092992808703">Gruppera flikar</translation>
+<translation id="7725024127233776428">Sidor som infogats som bokmärke visas här</translation>
+<translation id="4404568932422911380">Inga bokmärken</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> bokmärke}other{<ph name="BOOKMARKS_COUNT_MANY"/> bokmärken}}</translation>
+<translation id="3739899004075612870">Bokmärket har lagts till i <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Bokmärkt</translation>
+<translation id="4452548195519783679">Bokmärkt i <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Det gick inte att lägga till bokmärket.</translation>
+<translation id="2842985007712546952">Överordnad mapp</translation>
+<translation id="9065203028668620118">Redigera</translation>
+<translation id="4405224443901389797">Flytta till …</translation>
+<translation id="5170568018924773124">Visa i mapp</translation>
+<translation id="8035133914807600019">Ny mapp …</translation>
+<translation id="4532845899244822526">Välj mapp</translation>
+<translation id="6627583120233659107">Redigera mapp</translation>
+<translation id="1197267115302279827">Flytta bokmärken</translation>
+<translation id="6963766334940102469">Radera bokmärken</translation>
+<translation id="4351244548802238354">Stäng dialogrutan</translation>
+<translation id="451872707440238414">Sök bland dina bokmärken</translation>
+<translation id="8901170036886848654">Inga bokmärken hittades</translation>
+<translation id="6404511346730675251">Redigera bokmärke</translation>
+<translation id="3894427358181296146">Lägg till mapp</translation>
+<translation id="5327248766486351172">Namn</translation>
+<translation id="7400418766976504921">Webbadress</translation>
+<translation id="3527085408025491307">Mapp</translation>
+<translation id="5161254044473106830">Titel krävs</translation>
+<translation id="2996809686854298943">En webbadress måste anges.</translation>
+<translation id="2536728043171574184">En offlinekopia av sidan visas</translation>
+<translation id="4698034686595694889">Visa offline i <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> och fler webbplatser</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Sidan läses in i Brave när den blir tillgänglig}other{Sidorna läses in i Brave när de blir tillgängliga}}</translation>
+<translation id="6811034713472274749">Sidan är klar att öppna</translation>
+<translation id="4561979708150884304">Ingen anslutning</translation>
+<translation id="8274165955039650276">Visa nedladdningar</translation>
+<translation id="2082238445998314030">Resultat <ph name="RESULT_NUMBER"/> av <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Inga resultat</translation>
+<translation id="981121421437150478">Offline</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">Röstsökning är inte tillgängligt</translation>
+<translation id="7191430249889272776">Fliken öppnades i bakgrunden.</translation>
+<translation id="8445059357334030806">Öppna i Brave</translation>
+<translation id="4720023427747327413">Öppna i <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Öppna i webbläsaren</translation>
+<translation id="1113597929977215864">Använd förenklad visning</translation>
+<translation id="1513352483775369820">Bokmärken och webbhistorik</translation>
+<translation id="4939482511480190003">Hjälp till att förbättra Brave. <ph name="BEGIN_LINK"/>Fyll i enkäten<ph name="END_LINK"/>.</translation>
+<translation id="2501278716633472235">Föregående</translation>
+<translation id="5596627076506792578">Fler alternativ</translation>
+<translation id="3522247891732774234">Det finns en tillgänglig uppdatering. Fler alternativ</translation>
+<translation id="6773423637732432200">Det går inte att uppdatera Brave. Fler alternativ</translation>
+<translation id="3328801116991980348">Platsinformation</translation>
+<translation id="5391532827096253100">Anslutningen till webbplatsen är inte säker. Webbplatsinformation</translation>
+<translation id="6206551242102657620">Anslutningen är säker. Webbplatsinformation</translation>
+<translation id="6963642900430330478">Sidan är farlig. Webbplatsinformation</translation>
+<translation id="9070377983101773829">Starta röstsökning</translation>
+<translation id="8676374126336081632">Radera inmatning</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> flik öppen, tryck här om du vill byta flik}other{<ph name="OPEN_TABS_MANY"/> flikar öppna, tryck här om du vill byta flik}}</translation>
+<translation id="2369533728426058518">öppna flikar</translation>
+<translation id="7071521146534760487">Hantera konto</translation>
+<translation id="932327136139879170">Startsida</translation>
+<translation id="2707726405694321444">Uppdatera sidan</translation>
+<translation id="2891154217021530873">Avbryt inläsningen av sidan</translation>
+<translation id="6710213216561001401">Föregående</translation>
+<translation id="6659594942844771486">Flik</translation>
+<translation id="1933845786846280168">Vald flik</translation>
+<translation id="2268044343513325586">Finjustera</translation>
+<translation id="7846076177841592234">Rensa val</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> har valts. Alternativ finns högt upp på skärmen</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> har valts</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Dela 1 markerat objekt}other{Dela # markerade objekt}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Ta bort 1 markerat objekt}other{Ta bort # markerade objekt}}</translation>
+<translation id="1283039547216852943">Tryck och utöka</translation>
+<translation id="5962718611393537961">Tryck här om du vill komprimera</translation>
+<translation id="8076492880354921740">Flikar</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 har valts}other{# har valts}}</translation>
+<translation id="6818926723028410516">Välj objekt</translation>
+<translation id="4797039098279997504">Tryck här om du vill återgå till <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Tryck här för att besöka webbplatsen</translation>
+<translation id="429312253194641664">Media spelas upp på en webbplats</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> delar skärmen</translation>
+<translation id="8833831881926404480">En webbplats delar din skärm</translation>
+<translation id="9086455579313502267">Det går inte att ansluta till nätverket</translation>
+<translation id="938850635132480979">Fel: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Öppna i <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Öppna i kartapp</translation>
+<translation id="7698359219371678927">Skapa ett e-postmeddelande i <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Skapa ett e-postmeddelande</translation>
+<translation id="5665379678064389456">Skapa händelse i <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Skapa händelse</translation>
+<translation id="2111511281910874386">Öppna sida</translation>
+<translation id="3988466920954086464">Visa snabba sökresultat i panelen</translation>
+<translation id="2744248271121720757">Tryck på ett ord om du vill söka direkt eller visa relaterade åtgärder</translation>
+<translation id="9155898266292537608">Du kan även söka med ett snabbt tryck eller ett ord</translation>
+<translation id="3232754137068452469">Webbapp</translation>
+<translation id="1430915738399379752">Skriv ut</translation>
+<translation id="3775705724665058594">Skicka till dina enheter</translation>
+<translation id="6364438453358674297">Vill du ta bort förslaget från historiken?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> har stängts</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> flikar har stängts</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> raderades</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> bokmärken har raderats</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> nedladdningar har raderats</translation>
+<translation id="1248710015876067820">Fler Brave-förekomster än det finns stöd för.</translation>
+<translation id="4259722352634471385">Webbadressen har blockerats: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Det går inte att nå webbadressen: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Stäng flik</translation>
+<translation id="7772375229873196092">Stäng <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Navigeringshistorik</translation>
+<translation id="9169507124922466868">Navigeringshistoriken visas på halva skärmen</translation>
+<translation id="1327257854815634930">Navigeringshistoriken har öppnats</translation>
+<translation id="8788265440806329501">Navigeringshistoriken har stängts</translation>
+<translation id="7482656565088326534">Fliken Förhandsgranskning</translation>
+<translation id="8427875596167638501">Fliken Förhandsgranskning visas på halva skärmen</translation>
+<translation id="9102803872260866941">Fliken Förhandsgranskning har öppnats</translation>
+<translation id="2942036813789421260">Fliken Förhandsgranskning har stängts</translation>
+<translation id="6355102470683871794">Lagring för Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Rensa webbplatslagring?</translation>
+<translation id="9205995714227143200">Webbplatslagring som Brave bedömer som oviktig (t.ex. webbplatser utan sparade inställningar eller som du inte besöker ofta)</translation>
+<translation id="3997476611815694295">Oviktig lagring</translation>
+<translation id="8493948351860045254">Frigör lagringsutrymme</translation>
+<translation id="2324920234469020158">Det här alternativet rensar cookies, cacheminnet och annan data från webbplatser som bedöms vara oviktiga.</translation>
+<translation id="5447201525962359567">All webbplatslagring, inklusive cookies och annan lokalt sparad data</translation>
+<translation id="1376578503827013741">Beräknar …</translation>
+<translation id="583281660410589416">Okänd</translation>
+<translation id="2323763861024343754">Webbplatslagring</translation>
+<translation id="3587672679800759167">Total data som används av Brave, inklusive konton, bokmärken och sparade inställningar</translation>
+<translation id="6545017243486555795">Rensa all data</translation>
+<translation id="4095146165863963773">Vill du ta bort appdata?</translation>
+<translation id="53119194224775367">All appdata i Brave raderas permanent. Detta omfattar alla filer, inställningar, konton, databaser osv.</translation>
+<translation id="5307446750509046227">Rensa webbplatslagring</translation>
+<translation id="300526633675317032">Det här alternativet tar bort alla <ph name="SIZE_IN_KB"/> webbplatslagring.</translation>
+<translation id="8068648041423924542">Det går inte att välja certifikat.</translation>
+<translation id="2315043854645842844">Val av certifikat på klienten stöds inte av operativsystemet.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> vill ansluta</translation>
+<translation id="5308380583665731573">Ansluta</translation>
+<translation id="868929229000858085">Sök bland kontakterna</translation>
+<translation id="1919950603503897840">Välj kontakter</translation>
+<translation id="7986741934819883144">Välj en kontakt</translation>
+<translation id="3333961966071413176">Alla kontakter</translation>
+<translation id="4994033804516042629">Inga kontakter hittades</translation>
+<translation id="5403592356182871684">Namn</translation>
+<translation id="2717722538473713889">E-postadresser</translation>
+<translation id="381841723434055211">Telefonnummer</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 till)}other{(+ # till)}}</translation>
+<translation id="5197729504361054390">Kontakterna du väljer delas med <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Bildavkodare</translation>
+<translation id="8067883171444229417">Spela upp video</translation>
+<translation id="6560414384669816528">Sök med Sogou</translation>
+<translation id="5406914950576900927">Brave kan använda <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> som sökmotor i Kina. Du kan ändra detta i <ph name="BEGIN_LINK"/>inställningarna<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Behåll Brave Software</translation>
+<translation id="4384468725000734951">Du söker med Sogou</translation>
+<translation id="6103327872225198548">Du söker med Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Den här appen körs i Brave</translation>
+<translation id="6143689084714664628">Körs i Brave</translation>
+<translation id="7675869148432102528">Data för <ph name="APP_NAME"/> finns även i Brave</translation>
+<translation id="2734140769649165081">Du kan rensa data i Brave-inställningarna</translation>
+<translation id="8232956427053453090">Behåll data</translation>
+<translation id="4298388696830689168">Länkade webbplatser</translation>
+<translation id="5763514718066511291">Tryck om du vill kopiera webbadressen till appen</translation>
+<translation id="6496823230996795692">Du behöver vara ansluten till internet när du använder <ph name="APP_NAME"/> för första gången.</translation>
+<translation id="751961395872307827">Det gick inte att ansluta till webbplatsen</translation>
+<translation id="4878404682131129617">Det gick inte att upprätta en tunnel via proxyserver</translation>
+<translation id="4749960740855309258">Öppna en ny flik</translation>
+<translation id="8788968922598763114">Öppna den senast stängda fliken igen</translation>
+<translation id="7929962904089429003">Öppna menyn</translation>
+<translation id="6039379616847168523">Hoppa till nästa flik</translation>
+<translation id="5210286577605176222">Hoppa till föregående flik</translation>
+<translation id="124678866338384709">Stäng den aktuella fliken</translation>
+<translation id="3714981814255182093">Öppna sökfältet</translation>
+<translation id="5441522332038954058">Hoppa till adressfältet</translation>
+<translation id="3398320232533725830">Öppna bokmärkeshanteraren</translation>
+<translation id="6583199322650523874">Infoga ett bokmärke för den aktuella sidan</translation>
+<translation id="8489271220582375723">Öppna historiksidan</translation>
+<translation id="4837753911714442426">Öppna utskriftsalternativ</translation>
+<translation id="5726692708398506830">Gör allt på sidan större</translation>
+<translation id="3259831549858767975">Gör allt på sidan mindre</translation>
+<translation id="8015452622527143194">Återställ allt på sidan till standardstorlek</translation>
+<translation id="3443221991560634068">Läs in den aktuella sidan igen</translation>
+<translation id="123724288017357924">Läs in den aktuella sidan igen och ignorera cachelagrat innehåll</translation>
+<translation id="305870044889644984">Öppna hjälpcentret för Brave på en ny flik</translation>
+<translation id="3166827708714933426">Kortkommandon för flikar och fönster</translation>
+<translation id="3169981355900570544">Kortkommandon för funktioner i Brave Software Brave</translation>
+<translation id="4558311620361989323">Kortkommandon på webbsidor</translation>
+<translation id="1908301351964700579">Brave förbereds fortfarande för VR. Starta om Brave senare.</translation>
+<translation id="8970887620466824814">Något gick fel.</translation>
+<translation id="1875543012935658554">Öppna Brave igen.</translation>
+<translation id="79859296434321399">Installera ARCore om du vill visa innehåll med förstärkt verklighet</translation>
+<translation id="8558485628462305855">Uppdatera ARCore om du vill visa innehåll med förstärkt verklighet</translation>
+<translation id="3513704683820682405">Förstärkt verklighet</translation>
+<translation id="5475862044948910901">Vill du starta en session med förstärkt verklighet?</translation>
 <translation id="7365126855094612066">Webbplatsen kan göra följande under återstoden av sessionen:
 • skapa en karta över omgivningen i 3D
 • spåra kamerans rörelser
 
 Webbplatsen får INTE tillgång till kameran. Bara du kan se kamerabilderna.</translation>
-<translation id="7375125077091615385">Typ:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">Webbadress</translation>
-<translation id="7403691278183511381">Första körningen av Chrome</translation>
-<translation id="741204030948306876">Ja</translation>
-<translation id="7413229368719586778">Startdatum <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Fråga först</translation>
-<translation id="7423538860840206698">Läsbehörighet till Urklipp har nekats</translation>
-<translation id="7431991332293347422">Styr hur webbhistoriken får användas för att anpassa Sök med mera</translation>
-<translation id="7437998757836447326">Logga ut från Chrome</translation>
-<translation id="7438641746574390233">När begränsat läge är aktiverat används Googles servrar så att sidinläsningen ska gå snabbare i Chrome. Mycket långsamma sidor skrivs om i begränsat läge så att bara det viktigaste innehållet visas. Inkognitoflikar påverkas inte av begränsat läge.</translation>
-<translation id="7444811645081526538">Fler kategorier</translation>
-<translation id="7445411102860286510">Tillåt att webbplatser automatiskt spelar upp videor utan ljud (rekommenderas)</translation>
-<translation id="7453467225369441013">Du loggas ut från de flesta webbplatser. Du loggas inte ut från Google-kontot.</translation>
-<translation id="7454641608352164238">Utrymmet räcker inte</translation>
-<translation id="7475192538862203634">Om du ser detta ofta provar du de här <ph name="BEGIN_LINK" />förslagen<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Det gick inte att hitta SD-kortet. Det kan saknas filer.</translation>
-<translation id="7479104141328977413">Flikhantering</translation>
-<translation id="7481312909269577407">Framåt</translation>
-<translation id="7482656565088326534">Fliken Förhandsgranskning</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (uppdaterades <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">Sparad data</translation>
-<translation id="7498271377022651285">Vänta …</translation>
-<translation id="7514365320538308">Ladda ned</translation>
-<translation id="751961395872307827">Det gick inte att ansluta till webbplatsen</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Det går inte att få förslag</translation>
-<translation id="7559975015014302720">Begränsat läge har inaktiverats</translation>
-<translation id="7562080006725997899">Tar bort webbinformation</translation>
-<translation id="756809126120519699">Data i Chrome har rensats</translation>
-<translation id="757524316907819857">Blockera webbplatser från att spela upp skyddat innehåll</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> fil har laddats ned}other{<ph name="FILES_DOWNLOADED_MANY" /> filer har laddats ned}}</translation>
-<translation id="7588219262685291874">Aktivera mörkt tema när enhetens batterisparläge är på</translation>
-<translation id="7589445247086920869">Blockera för den nuvarande sökmotorn</translation>
-<translation id="7593557518625677601">Återaktivera synkronisering i Android-inställningarna så börjar Chrome synkas</translation>
-<translation id="7596558890252710462">Operativsystem</translation>
-<translation id="7605594153474022051">Det går inte att synkronisera</translation>
-<translation id="7606077192958116810">Begränsat läge har aktiverats. Hantera detta i inställningarna.</translation>
-<translation id="7612619742409846846">Inloggad i Google som</translation>
-<translation id="7619072057915878432">Det gick inte att ladda ned <ph name="FILE_NAME" /> på grund av nätverksfel.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Få hjälp<ph name="END_LINK1" /> eller <ph name="BEGIN_LINK2" />sök igen<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Välkommen till Chrome</translation>
-<translation id="7638584964844754484">Felaktig lösenfras</translation>
-<translation id="7641339528570811325">Rensa webbinformation …</translation>
-<translation id="7648422057306047504">Kryptera lösenord med användaruppgifter för Google</translation>
-<translation id="7649070708921625228">Hjälp</translation>
-<translation id="7658239707568436148">Avbryt</translation>
-<translation id="7665369617277396874">Lägg till konto</translation>
-<translation id="766587987807204883">Artiklar som du kan läsa även när du är offline visas här</translation>
-<translation id="7682724950699840886">Testa följande: kontrollera att det finns tillräckligt mycket utrymme på enheten, gör om exporten.</translation>
-<translation id="7685301384041462804">Se till att du litar på webbplatsen innan du aktiverar VR.</translation>
-<translation id="7698359219371678927">Skapa ett e-postmeddelande i <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Autoslutför sökningar och webbadresser</translation>
-<translation id="7725024127233776428">Sidor som infogats som bokmärke visas här</translation>
-<translation id="773466115871691567">Översätt alltid sidor på <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">För att kunna upptäcka farliga appar och webbplatser skickar Chrome webbadresser till vissa sidor som du besöker, vissa systemuppgifter och visst sidinnehåll till Google</translation>
-<translation id="7757787379047923882">Texten delades från <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">SD-kort <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Lägg till adress</translation>
-<translation id="7772032839648071052">Bekräfta lösenfras</translation>
-<translation id="7772375229873196092">Stäng <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> till}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 och <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> till}}</translation>
-<translation id="7781829728241885113">Igår</translation>
-<translation id="7791543448312431591">Lägg till</translation>
-<translation id="780301667611848630">Nej tack</translation>
-<translation id="7810647596859435254">Öppna med …</translation>
-<translation id="7821588508402923572">Här visas hur mycket data du har sparat</translation>
-<translation id="7837721118676387834">Tillåt automatisk uppspelning av videor utan ljud för en specifik webbplats.</translation>
-<translation id="7846076177841592234">Rensa val</translation>
-<translation id="784934925303690534">Tidsintervall</translation>
-<translation id="7851858861565204677">Andra enheter</translation>
-<translation id="7875915731392087153">Skapa ett e-postmeddelande</translation>
-<translation id="7876243839304621966">Ta bort alla</translation>
-<translation id="7882131421121961860">Ingen historik hittades</translation>
-<translation id="7882806643839505685">Tillåt ljud för en webbplats.</translation>
-<translation id="7886917304091689118">Körs i Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{En fil laddas ned.}other{# filer laddas ned.}}</translation>
-<translation id="7929962904089429003">Öppna menyn</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> är inaktuell.</translation>
-<translation id="7947953824732555851">Godkänn och logga in</translation>
-<translation id="7963646190083259054">Leverantör:</translation>
-<translation id="7971136598759319605">Aktiv för 1 dag sedan</translation>
-<translation id="7975379999046275268">Förhandsgranska sida <ph name="BEGIN_NEW" />Nyhet<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Läs in sidor i förväg så att det går snabbare att surfa och söka</translation>
-<translation id="79859296434321399">Installera ARCore om du vill visa innehåll med förstärkt verklighet</translation>
-<translation id="7986741934819883144">Välj en kontakt</translation>
-<translation id="7987073022710626672">Chromes användarvillkor</translation>
-<translation id="7998918019931843664">Öppna en stängd flik på nytt</translation>
-<translation id="7999064672810608036">Vill du ta bort all lokal data för webbplatsen, inklusive cookies, och återställa alla behörigheter för den?</translation>
-<translation id="8004582292198964060">Webbläsare</translation>
-<translation id="8007176423574883786">Inaktiverad för den här enheten</translation>
-<translation id="8013372441983637696">Rensa även Chrome-data från enheten</translation>
-<translation id="8015452622527143194">Återställ allt på sidan till standardstorlek</translation>
-<translation id="802154636333426148">Nedladdningen misslyckades</translation>
-<translation id="8026334261755873520">Rensa webbinformation</translation>
-<translation id="8035133914807600019">Ny mapp …</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> dagar kvar</translation>
-<translation id="804335162455518893">Det gick inte att hitta SD-kortet</translation>
-<translation id="805047784848435650">Utifrån din webbhistorik</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB tillgängliga</translation>
-<translation id="8058746566562539958">Öppna på ny flik i Chrome</translation>
-<translation id="8063895661287329888">Det gick inte att lägga till bokmärket.</translation>
-<translation id="806745655614357130">Håll min data separat</translation>
-<translation id="8067883171444229417">Spela upp video</translation>
-<translation id="8068648041423924542">Det går inte att välja certifikat.</translation>
-<translation id="8073388330009372546">Öppna bild i ny flik</translation>
-<translation id="8076492880354921740">Flikar</translation>
-<translation id="8084114998886531721">Sparat lösenord</translation>
-<translation id="8087000398470557479">Innehållet kommer från <ph name="DOMAIN_NAME" /> via Google.</translation>
-<translation id="8103578431304235997">Inkognitoflik</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Aktivera synkronisering om du vill ha dina bokmärken tillgängliga på alla enheter</translation>
-<translation id="8110087112193408731">Vill du att din aktivitet i Chrome ska visas i Digitalt välmående?</translation>
-<translation id="8116925261070264013">Ljudet avstängt</translation>
-<translation id="813082847718468539">Visa information om webbplatsen</translation>
-<translation id="8131740175452115882">Bekräfta</translation>
-<translation id="8156139159503939589">Vilka språk kan du läsa?</translation>
-<translation id="8168435359814927499">Innehåll</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> filer återstår</translation>
-<translation id="8190358571722158785">1 dag kvar</translation>
-<translation id="8200772114523450471">Återuppta</translation>
-<translation id="8209050860603202033">Öppna bild</translation>
-<translation id="8218622182176210845">Hantera kontot</translation>
-<translation id="8224471946457685718">Ladda ned artiklar för dig via Wi-Fi</translation>
-<translation id="8232956427053453090">Behåll data</translation>
-<translation id="8249310407154411074">Flytta högst upp</translation>
-<translation id="8250920743982581267">Dokument</translation>
-<translation id="825412236959742607">Den här sidan använder för mycket minne, så en del innehåll har tagits bort.</translation>
-<translation id="8260126382462817229">Försök att logga in igen</translation>
-<translation id="8261506727792406068">Radera</translation>
-<translation id="8266862848225348053">Nedladdningsplats</translation>
-<translation id="8274165955039650276">Visa nedladdningar</translation>
-<translation id="8284326494547611709">Textning</translation>
-<translation id="8300705686683892304">Hanteras av app</translation>
-<translation id="8310344678080805313">Standardflikar</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> och fler webbplatser</translation>
-<translation id="8327155640814342956">Uppdatera Chrome så att du får bästa möjliga surfupplevelse</translation>
-<translation id="8339163506404995330">Sidor på <ph name="LANGUAGE" /> översätts inte</translation>
-<translation id="8349013245300336738">Sortera efter dataförbrukning</translation>
-<translation id="8364299278605033898">Visa populära webbplatser</translation>
-<translation id="8368027906805972958">Enheten är okänd eller stöds inte (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Tillåt bakgrundssynkronisering för en specifik webbplats.</translation>
-<translation id="8378714024927312812">Hanteras av organisationen</translation>
-<translation id="8380167699614421159">Påträngande eller vilseledande annonser visas på den här webbplatsen</translation>
-<translation id="8393700583063109961">Skicka meddelande</translation>
-<translation id="8413126021676339697">Visa fullständig historik</translation>
-<translation id="8427875596167638501">Fliken Förhandsgranskning visas på halva skärmen</translation>
-<translation id="8428213095426709021">Inställningar</translation>
-<translation id="8438566539970814960">Förbättra sökningar och surfandet</translation>
-<translation id="8441146129660941386">Sök bakåt</translation>
-<translation id="8443209985646068659">Uppdatering inte möjlig</translation>
-<translation id="8445448999790540984">Det gick inte att exportera lösenord</translation>
-<translation id="8447861592752582886">Återkalla enhetsbehörighet</translation>
-<translation id="8461694314515752532">Kryptera synkroniserad data med en egen lösenfras för synkronisering</translation>
-<translation id="8466613982764129868">Kontrollera att <ph name="TARGET_DEVICE_NAME" /> är ansluten till internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Tillgänglig offline</translation>
-<translation id="8489271220582375723">Öppna historiksidan</translation>
-<translation id="8493948351860045254">Frigör lagringsutrymme</translation>
-<translation id="8497726226069778601">Det finns inget att se här … än</translation>
-<translation id="8503559462189395349">Lösenord i Chrome</translation>
-<translation id="8503813439785031346">Användarnamn</translation>
-<translation id="8514477925623180633">Exportera lösenord som har sparats i Chrome</translation>
-<translation id="8514577642972634246">Starta inkognitoläget</translation>
-<translation id="851751545965956758">Förhindra att webbplatser ansluter till enheter</translation>
-<translation id="8523928698583292556">Radera sparat lösenord</translation>
-<translation id="854522910157234410">Öppna sidan</translation>
-<translation id="8558485628462305855">Uppdatera ARCore om du vill visa innehåll med förstärkt verklighet</translation>
-<translation id="8559990750235505898">Erbjud översättning av sidor till andra språk</translation>
-<translation id="8562452229998620586">Sparade lösenord visas här.</translation>
-<translation id="8569404424186215731">sedan <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Senaste fyra veckorna</translation>
-<translation id="857943718398505171">Tillåten (rekommenderas)</translation>
-<translation id="8583805026567836021">Rensar kontouppgifter</translation>
-<translation id="860043288473659153">Namn på kortinnehavare</translation>
-<translation id="8609465669617005112">Flytta upp</translation>
-<translation id="8616006591992756292">Det kan finnas andra former av webbhistorik i Google-kontot på <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Vill du öppna den föreslagna webbadressen i det nedladdade innehållet?</translation>
-<translation id="8636825310635137004">Aktivera synkronisering om du vill ha samma flikar tillgängliga på alla enheter.</translation>
-<translation id="8641930654639604085">Försök blockera webbplatser med innehåll för vuxna</translation>
-<translation id="8655129584991699539">Du kan rensa data i Chrome-inställningarna</translation>
-<translation id="8662811608048051533">Du loggas ut från de flesta webbplatser.</translation>
-<translation id="8664979001105139458">Filnamnet finns redan</translation>
-<translation id="8676374126336081632">Radera inmatning</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Signalstyrka: # streck}other{Signalstyrka: # streck}}</translation>
-<translation id="868929229000858085">Sök bland kontakterna</translation>
-<translation id="869891660844655955">Utgångsdatum</translation>
-<translation id="8719023831149562936">Den aktuella fliken kan inte överföras</translation>
-<translation id="8725066075913043281">Försök igen</translation>
-<translation id="8728487861892616501">Genom att fortsätta att använda programmet godkänner du Chromes <ph name="BEGIN_LINK1" />användarvillkor<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />sekretessmeddelande<ph name="END_LINK2" /> och <ph name="BEGIN_LINK3" />sekretessmeddelandet för Google-konton som hanteras via Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Klart</translation>
-<translation id="8748850008226585750">Innehållet har dolts</translation>
-<translation id="8751914237388039244">Välj en bild</translation>
-<translation id="8788265440806329501">Navigeringshistoriken har stängts</translation>
-<translation id="8788968922598763114">Öppna den senast stängda fliken igen</translation>
-<translation id="8801436777607969138">Blockera JavaScript på en enskild webbplats.</translation>
-<translation id="8812260976093120287">På vissa webbplatser kan du betala med ovanstående betalningsappar som stöds på enheten.</translation>
-<translation id="8816026460808729765">Blockera webbplatser från att använda enhetens sensorer</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> öppnas i Chrome. Genom att fortsätta godkänner du Chromes <ph name="BEGIN_LINK1" />användarvillkor<ph name="END_LINK1" /> och <ph name="BEGIN_LINK2" />sekretesspolicy<ph name="END_LINK2" /> samt <ph name="BEGIN_LINK3" />sekretessmeddelandet för  Google-konton som hanteras via Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Bokmärken</translation>
-<translation id="8833831881926404480">En webbplats delar din skärm</translation>
-<translation id="883806473910249246">Ett fel uppstod när innehållet skulle laddas ned.</translation>
-<translation id="8840953339110955557">Sidan kan skilja sig från onlineversionen.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, flik</translation>
-<translation id="885701979325669005">Lagring</translation>
-<translation id="889338405075704026">Öppna Chrome-inställningarna</translation>
-<translation id="8901170036886848654">Inga bokmärken hittades</translation>
-<translation id="8909135823018751308">Dela …</translation>
-<translation id="8912362522468806198">Google-konto</translation>
-<translation id="8920114477895755567">Väntar på föräldrauppgifter.</translation>
+<translation id="1188239144602654184">Starta AR</translation>
+<translation id="473775607612524610">Uppdatera</translation>
+<translation id="3133489217401741157"><ph name="MODULE"/> installeras i Brave …</translation>
+<translation id="1791662854739702043">Installerat</translation>
+<translation id="5131234170665854056">Det gick inte att installera <ph name="MODULE"/> i Brave</translation>
+<translation id="2567385386134582609">BILD</translation>
+<translation id="6395288395575013217">LÄNK</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Ladda ned sidor så att du kan använda dem offline</translation>
 <translation id="8922289737868596582">Ladda ned sidor via knappen Fler alternativ så att du kan använda dem offline</translation>
-<translation id="8937772741022875483">Vill du ta bort din aktivitet i Chrome från Digitalt välmående?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Öppna i ett annat fönster</translation>
-<translation id="8951232171465285730">Du har sparat <ph name="MEGABYTES" /> MB med Chrome</translation>
-<translation id="8958424370300090006">Blockera cookies för en enskild webbplats.</translation>
-<translation id="8959122750345127698">Det går inte att nå webbadressen: <ph name="URL" /></translation>
-<translation id="8965591936373831584">väntar</translation>
-<translation id="8970887620466824814">Något gick fel.</translation>
-<translation id="8972098258593396643">Vill du ladda ned till standardmappen?</translation>
-<translation id="8986494364107987395">Skicka användningsstatistik och kraschrapporter till Google automatiskt</translation>
-<translation id="8993760627012879038">Öppna en ny flik i inkognitoläge</translation>
-<translation id="8998729206196772491">Du håller på att logga in med ett konto som hanteras av <ph name="MANAGED_DOMAIN" />, vilket ger administratören kontroll över data i Chrome. Din data kopplas permanent till det här kontot. Om du loggar ut från Chrome raderas all din data från enheten, men den lagras fortfarande i Google-kontot.</translation>
-<translation id="9019902583201351841">Hanteras av dina föräldrar</translation>
-<translation id="9028914725102941583">Aktivera synkronisering om du vill dela mellan enheter</translation>
-<translation id="9029323097866369874">Vill du tillåta att <ph name="DOMAIN" /> aktiverar VR?</translation>
-<translation id="9040142327097499898">Aviseringar tillåts. Plats har inaktiverats på enheten.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# videor}}</translation>
-<translation id="9050666287014529139">Lösenfras</translation>
-<translation id="9063523880881406963">Inaktivera begäran av webbplats för stationär dator</translation>
-<translation id="9065203028668620118">Redigera</translation>
-<translation id="9070377983101773829">Starta röstsökning</translation>
-<translation id="9074336505530349563">Logga in och aktivera synkronisering om du vill få förslag på anpassat innehåll från Google</translation>
-<translation id="9086455579313502267">Det går inte att ansluta till nätverket</translation>
-<translation id="9100505651305367705">Fråga om artiklarna ska visas i en förenklad vy när detta stöds</translation>
-<translation id="9100610230175265781">Lösenfras krävs</translation>
-<translation id="9102803872260866941">Fliken Förhandsgranskning har öppnats</translation>
+<translation id="5958275228015807058">Du hittar filerna och sidorna i Nedladdningar</translation>
+<translation id="5620928963363755975">Du hittar filerna och sidorna i Nedladdningar via knappen Fler alternativ</translation>
+<translation id="3341058695485821946">Se hur mycket data du har sparat</translation>
+<translation id="3157842584138209013">Under Fler alternativ kan du se hur mycket data du har sparat</translation>
+<translation id="8218622182176210845">Hantera kontot</translation>
+<translation id="8090895580117672212">Tryck på knappen Hantera kontot om du vill hantera ditt Brave Software-konto</translation>
+<translation id="8856898588039823173">Lite-sida tillhandahållen av Brave Software. Tryck för att läsa in originalet.</translation>
+<translation id="8134317863207426198">Lite-sida tillhandahållen av Brave Software. Tryck på knappen Läs in original för att läsa in den ursprungliga sidan.</translation>
+<translation id="4961107849584082341">Översätt den här sidan till vilket språk som helst</translation>
+<translation id="569536719314091526">Översätt den här sidan till vilket språk som helst via knappen Fler alternativ</translation>
+<translation id="1397811292916898096">Sök med <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Ändra standardplats för nedladdningar när som helst</translation>
+<translation id="6942665639005891494">Ändra standardplats för nedladdningar när som helst via alternativet i inställningsmenyn</translation>
+<translation id="6850409657436465440">Nedladdningen pågår fortfarande</translation>
+<translation id="5817715962196959877">Nu laddas filer ned snabbare i Brave</translation>
+<translation id="3976396876660209797">Ta bort och återskapa den här genvägen</translation>
+<translation id="6766622839693428701">Svep nedåt när du vill stänga.</translation>
+<translation id="1028699632127661925">Skickar till <ph name="DEVICE_NAME"/> …</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Skickades från <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">En flik har tagits emot</translation>
 <translation id="9104217018994036254">Lista över enheter som fliken kan delas med.</translation>
-<translation id="9133397713400217035">Utforska offline</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Visa original</translation>
-<translation id="9139068048179869749">Fråga innan webbplatser tillåts att skicka aviseringar (rekommenderas)</translation>
-<translation id="9139318394846604261">Shopping</translation>
-<translation id="9155898266292537608">Du kan även söka med ett snabbt tryck eller ett ord</translation>
-<translation id="9169507124922466868">Navigeringshistoriken visas på halva skärmen</translation>
-<translation id="9204836675896933765">1 fil återstår</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Listan över enheter som fliken kan delas med öppnades och tar upp halva skärmen.</translation>
+<translation id="2904414404539560095">Listan över enheter som fliken kan delas med öppnades och tar upp hela skärmen.</translation>
+<translation id="4135200667068010335">Listan över enheter som fliken kan delas med är stängd.</translation>
+<translation id="5292796745632149097">Skicka till</translation>
+<translation id="1386674309198842382">Aktiv för <ph name="LAST_UPDATED"/> dagar sedan</translation>
+<translation id="7971136598759319605">Aktiv för 1 dag sedan</translation>
+<translation id="1521774566618522728">Aktiv idag</translation>
+<translation id="3631987586758005671">Delas med <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Aktivera synkronisering om du vill dela mellan enheter</translation>
+<translation id="6162454065885854378">Om du vill dela något från telefonen till en annan enhet aktiverar du synkronisering i Brave-inställningarna på båda enheterna</translation>
+<translation id="6084271560289605378">Öppna Brave-inställningarna</translation>
+<translation id="2318045970523081853">Tryck för att ringa</translation>
 <translation id="9209888181064652401">Det går inte att ringa</translation>
-<translation id="9219103736887031265">Bilder</translation>
-<translation id="926205370408745186">Ta bort din aktivitet i Chrome från Digitalt välmående</translation>
-<translation id="932327136139879170">Startsida</translation>
-<translation id="938850635132480979">Fel: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Tillgång till din mikrofon</translation>
-<translation id="95817756606698420">Chrome kan använda <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> som sökmotor i Kina. Du kan ändra detta i <ph name="BEGIN_LINK" />inställningarna<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Blockera om påträngande eller vilseledande annonser visas på webbplatsen (rekommenderas)</translation>
-<translation id="968900484120156207">Sidor som du besöker visas här</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> minuter kvar</translation>
-<translation id="974555521953189084">Ange lösenfrasen för att starta synkroniseringen</translation>
-<translation id="981121421437150478">Offline</translation>
-<translation id="982182592107339124">Åtgärden raderar data för alla webbplatser, inklusive:</translation>
-<translation id="983192555821071799">Stäng alla flikar</translation>
-<translation id="987264212798334818">Allmänt</translation>
+<translation id="2860954141821109167">Kontrollera att en telefonapp har aktiverats på enheten</translation>
+<translation id="2067805253194386918">text</translation>
+<translation id="1450753235335490080">Det gick inte att dela <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Det gick inte att dela <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Kontrollera att synkronisering har aktiverats i Brave på <ph name="TARGET_DEVICE_NAME"/></translation>
+<translation id="3016635187733453316">Kontrollera att enheten är ansluten till internet</translation>
+<translation id="8466613982764129868">Kontrollera att <ph name="TARGET_DEVICE_NAME"/> är ansluten till internet</translation>
+<translation id="6539092367496845964">Något gick fel. Försök igen senare.</translation>
+<translation id="3389286852084373014">Texten är för stor</translation>
+<translation id="2100314319871056947">Testa att dela upp texten i mindre bitar</translation>
+<translation id="2987620471460279764">Text delad från annan enhet</translation>
+<translation id="7757787379047923882">Texten delades från <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Kopierat till urklipp</translation>
+<translation id="4696983787092045100">Skicka texten till dina enheter</translation>
+<translation id="1260236875608242557">Sök och utforska</translation>
+<translation id="6369229450655021117">Härifrån kan du söka på webben, dela med vänner och visa öppna sidor</translation>
+<translation id="723171743924126238">Välj bilder</translation>
+<translation id="8751914237388039244">Välj en bild</translation>
+<translation id="1989112275319619282">Bläddra</translation>
+<translation id="7055152154916055070">Omdirigeringen blockerades:</translation>
+<translation id="5524843473235508879">Omdirigeringen blockerades.</translation>
+<translation id="6573096386450695060">Tillåt alltid</translation>
+<translation id="5805364706385912897">Den här sidan har pausats i Brave eftersom den använder för mycket minne.</translation>
+<translation id="5138664332909611586">Den här sidan använder för mycket minne, så en del innehåll har tagits bort.</translation>
+<translation id="9137013805542155359">Visa original</translation>
+<translation id="6361779936989026201">Brave Software-assistenten i Brave</translation>
+<translation id="7291387454912369099">Betalning med assistenten</translation>
+<translation id="4565206163201411670">Vill du att din aktivitet i Brave ska visas i Digitalt välmående?</translation>
+<translation id="9055113864158719823">Du kan se vilka webbplatser du besökt i Brave och ställa in en timer för dem.\n\nBrave Software får information om vilka webbplatser du har ställt in en timer för och hur länge du har stannat på dem. Informationen används för att förbättra Digitalt välmående.</translation>
+<translation id="4596514158372210596">Ta bort din aktivitet i Brave från Digitalt välmående</translation>
+<translation id="1174893863889683998">Vill du ta bort din aktivitet i Brave från Digitalt välmående?</translation>
+<translation id="708829030563435351">Webbplatser som du besöker i Brave visas inte. Alla timer för webbplatser raderas.</translation>
+<translation id="2056878612599315956">Webbplatsen har pausats</translation>
+<translation id="671481426037969117">Timern för <ph name="FQDN"/> har löpt ut. Den börjar om igen i morgon.</translation>
+<translation id="7479104141328977413">Flikhantering</translation>
+<translation id="3524138585025253783">Utvecklargränssnitt</translation>
+<translation id="6036057147555329831">Extra ICU</translation>
+<translation id="9029323097866369874">Vill du tillåta att <ph name="DOMAIN"/> aktiverar VR?</translation>
+<translation id="7685301384041462804">Se till att du litar på webbplatsen innan du aktiverar VR.</translation>
+<translation id="5033865233969348410">Webbplatsen kan ta reda på mer om följande om dig när VR är aktiverat:
+  – dina fysiska egenskaper, som längd
+
+Se till att du litar på webbplatsen innan du aktiverar VR.</translation>
+<translation id="5534334044554683961">Webbplatsen kan ta reda på mer om följande om dig när VR är aktiverat:
+  – dina fysiska egenskaper, som längd
+  –   formen på ditt rum
+
+Se till att du litar på webbplatsen innan du aktiverar VR.</translation>
+<translation id="4169535189173047238">Tillåt inte</translation>
+<translation id="2170088579611075216">Tillåt och aktivera VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_sw.xtb
+++ b/android/java/strings/translations/android_chrome_strings_sw.xtb
@@ -1,1116 +1,1099 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="sw">
-<translation id="1006017844123154345">Fungua Mtandaoni</translation>
-<translation id="1028699632127661925">Unatuma kwenye <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Inaongeza <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Kutoka kwenye tovuti</translation>
-<translation id="1049743911850919806">Kichupo fiche</translation>
-<translation id="10614374240317010">Haijahifadhiwa kamwe</translation>
-<translation id="1067922213147265141">Huduma zingine za Google</translation>
-<translation id="1068672505746868501">Usiwahi kutafsiri kurasa katika lugha ya <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Ukibadilisha kiendelezi cha faili, faili inaweza kufunguka katika programu tofauti na huenda ikawa hatari kwa kifaa chako.</translation>
-<translation id="1100066534610197918">Fungua katika kichupo kipya cha kikundi</translation>
-<translation id="1105960400813249514">Piga Picha ya Skrini</translation>
-<translation id="1111673857033749125">Alamisho zilizohifadhiwa katika vifaa vyako vingine zitaonekana hapa.</translation>
-<translation id="1113597929977215864">Onyesha mwonekano rahisi</translation>
-<translation id="1121094540300013208">Ripoti za matumizi na za kuacha kufanya kazi</translation>
-<translation id="1124772482545689468">Mtumiaji</translation>
-<translation id="1129510026454351943">Maelezo: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Inasubiri kupakua faili 1.}other{Inasubiri kupakua faili #.}}</translation>
-<translation id="1145536944570833626">Futa data iliyopo.</translation>
-<translation id="1146678959555564648">Tumia hali ya VR</translation>
-<translation id="116280672541001035">Imetumika</translation>
-<translation id="1171770572613082465">Ona tovuti maarufu kwa kugusa kitufe cha "Tovuti maarufu"</translation>
-<translation id="1173894706177603556">Ipe jina jipya</translation>
-<translation id="1178581264944972037">Sitisha</translation>
-<translation id="1181037720776840403">Ondoa</translation>
-<translation id="1188239144602654184">Weka Uhalisia Ulioboreshwa</translation>
-<translation id="1197267115302279827">Sogeza alamisho</translation>
-<translation id="119944043368869598">Ondoa vyote</translation>
-<translation id="1201402288615127009">Endelea</translation>
-<translation id="1204037785786432551">Kiungo cha kupakua</translation>
-<translation id="1206892813135768548">Nakili maandishi ya kiungo</translation>
-<translation id="1208340532756947324">Ili usawazishe na uweke mapendeleo kwenye vifaa vyako vyote, washa kipengele cha usawazishaji</translation>
-<translation id="1209206284964581585">Ficha kwa sasa</translation>
-<translation id="1227058898775614466">Historia ya uelekezaji</translation>
-<translation id="1231733316453485619">Ungependa kuwasha usawazishaji?</translation>
-<translation id="123724288017357924">Pakia upya ukurasa wa sasa, puuza maudhui ya akiba</translation>
-<translation id="124116460088058876">Lugha zaidi</translation>
-<translation id="124678866338384709">Funga kichupo kilichofunguka</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Tafuta na ugundue</translation>
-<translation id="1264974993859112054">Michezo</translation>
-<translation id="1266864766717917324">Imeshindwa kushiriki <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Simamisha</translation>
-<translation id="1283039547216852943">Gusa ili upanue</translation>
-<translation id="1285320974508926690">Kamwe usitafsiri tovuti hii</translation>
-<translation id="1291207594882862231">Futa historia, vidakuzi, data ya tovuti, akiba…</translation>
-<translation id="129382876167171263">Faili zinazohifadhiwa na tovuti huonekana hapa</translation>
-<translation id="129553762522093515">Vilivyofungwa hivi karibuni</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - Imetumwa kutoka <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Weka vichupo pamoja</translation>
-<translation id="1327257854815634930">Historia ya uelekezaji imefunguliwa</translation>
-<translation id="1331212799747679585">Chrome haiwezi kusasisha. Chaguo zaidi</translation>
-<translation id="1332501820983677155">Njia za mikato za vipengele vya Google Chrome</translation>
-<translation id="1360432990279830238">Utaondoka na uzime usawazishaji?</translation>
-<translation id="1369915414381695676">Tovuti <ph name="SITE_NAME" /> imeongezwa</translation>
-<translation id="1373696734384179344">Hakuna hifadhi ya kutosha ya kupakua maudhui yaliyochaguliwa.</translation>
-<translation id="1376578503827013741">Inakokotoa...</translation>
-<translation id="1383876407941801731">Tafuta</translation>
-<translation id="1384959399684842514">Upakuaji umesitishwa</translation>
-<translation id="1386674309198842382">Ilitumika siku <ph name="LAST_UPDATED" /> zilizopita</translation>
-<translation id="1397811292916898096">Tafuta kwa <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Imepachikwa katika <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“Usifuatilie”</translation>
-<translation id="1407135791313364759">Fungua zote</translation>
-<translation id="1409426117486808224">Mwonekano uliorahisishwa kwa ajili ya vichupo vilivyofunguliwa</translation>
-<translation id="1409879593029778104">Kipakuliwa cha <ph name="FILE_NAME" /> kimezuiwa kwa sababu faili tayari ipo.</translation>
-<translation id="1414981605391750300">Inawasiliana na Google. Huenda ikachukua dakika moja…</translation>
-<translation id="1416550906796893042">Toleo la programu</translation>
-<translation id="1430915738399379752">Chapisha</translation>
-<translation id="1446450296470737166">Ruhusu udhibiti kamili wa vifaa vya MIDI</translation>
-<translation id="1450753235335490080">Imeshindwa kushiriki <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Imezimwa katika Mipangilio ya Android</translation>
-<translation id="1477626028522505441">Kipakuliwa cha <ph name="FILE_NAME" /> hakijafaulu kwa sababu ya matatizo ya seva.</translation>
-<translation id="1506061864768559482">Mtambo wa utafutaji</translation>
-<translation id="1513352483775369820">Alamisho na historia ya wavuti</translation>
-<translation id="1513858653616922153">Futa nenosiri</translation>
-<translation id="1516229014686355813">Kipengele cha Gusa ili Utafute hutuma neno lililochaguliwa na ukurasa wa sasa kuwa muktadha kwa Tafuta na Google. Unaweza kukizima katika <ph name="BEGIN_LINK" />Miipangilio<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Ameitumia leo</translation>
-<translation id="1544826120773021464">Ili udhibiti akaunti yako ya Google, gusa kitufe cha "Dhibiti akaunti"</translation>
-<translation id="1549000191223877751">Nenda kwenye dirisha jingine</translation>
-<translation id="1553358976309200471">Sasisha Chrome</translation>
-<translation id="1569387923882100876">Kifaa Kilichounganishwa</translation>
-<translation id="1571304935088121812">Nakili jina la mtumiaji</translation>
-<translation id="1612196535745283361">Chrome inahitaji idhini ya kufikia mahali ili itafute vifaa. Kipengele cha kufikia mahali <ph name="BEGIN_LINK" />kimezimwa kwenye kifaa hiki<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Zuia ukurasa huu usiunde vidadisi zaidi</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Ondoa kipengee 1 kilichochaguliwa}other{Ondoa vipengee # vilivyochaguliwa}}</translation>
-<translation id="164269334534774161">Hii ni nakala ya nje ya mtandao ya ukurasa huu ya terehe <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Historia</translation>
-<translation id="1647391597548383849">Kufikia kamera yako</translation>
-<translation id="1660204651932907780">Ruhusu tovuti kucheza sauti (inapendekezwa)</translation>
-<translation id="1670399744444387456">Msingi</translation>
-<translation id="1671236975893690980">Inasubiri kupakua...</translation>
-<translation id="1672586136351118594">Usionyeshe tena</translation>
-<translation id="1692118695553449118">Usawazishajii umewashwa</translation>
-<translation id="169515064810179024">Zuia tovuti zisifikie vitambuzi vya mwendo</translation>
-<translation id="1717218214683051432">Vitambuzi vya mwendo</translation>
-<translation id="1718835860248848330">Saa iliyopita</translation>
-<translation id="1736419249208073774">Gundua</translation>
-<translation id="1743802530341753419">Iulize kabla ya kuruhusu tovuti ziunganishe kwenye kifaa (inapendekezwa)</translation>
-<translation id="1749561566933687563">Sawazisha alamisho zako</translation>
-<translation id="17513872634828108">Vichupo vilivyo wazi</translation>
-<translation id="1779089405699405702">Kisimbuaji cha picha</translation>
-<translation id="1782483593938241562">Tarehe ya mwisho <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Imesakinishwa</translation>
-<translation id="1792959175193046959">Badilisha sehemu chaguomsingi ya kupakua wakati wowote</translation>
-<translation id="1807246157184219062">Mwangaza</translation>
-<translation id="1810845389119482123">Haijakamilisha Kuweka mipangilio ya mwanzo ya usawazishaji</translation>
-<translation id="1821253160463689938">Hutumia vidakuzi kukumbuka mapendeleo yako, hata usipotembelea kurasa hizo</translation>
-<translation id="1829244130665387512">Tafuta katika ukurasa</translation>
-<translation id="1853692000353488670">Kichupo fiche kipya</translation>
-<translation id="1856325424225101786">Je, ungependa kubadilisha mipangilio ya Hali nyepesi?</translation>
-<translation id="1868024384445905608">Sasa Chrome inapakua faili haraka zaidi</translation>
-<translation id="1883903952484604915">Faili Zangu</translation>
-<translation id="1887786770086287077">Kipengele cha mahali kimezimwa kwenye kifaa hiki. Kiwashe katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Itafungua <ph name="APP_NAME" /> katika Chrome. Kwa kuendelea, unakubali <ph name="BEGIN_LINK1" />Sheria na Masharti<ph name="END_LINK1" /> na <ph name="BEGIN_LINK2" />Ilani ya Faragha<ph name="END_LINK2" /> ya Chrome.</translation>
-<translation id="1919345977826869612">Matangazo</translation>
-<translation id="1919950603503897840">Chagua anwani</translation>
-<translation id="1922076542920281912">Ili uruhusu Chrome kufikia mahali ulipo, washa pia huduma ya mahali katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Usasishaji</translation>
-<translation id="19288952978244135">Fungua Chrome Upya.</translation>
-<translation id="1933845786846280168">Kichupo Kilichochaguliwa</translation>
-<translation id="194341124344773587">Washa ruhusa ya Chrome katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Hifadhi manenosiri</translation>
-<translation id="1952172573699511566">Tovuti zitaonyesha maandishi katika lugha unayopendelea, panapowezekana.</translation>
-<translation id="1960290143419248813">Masasisho ya Chrome hayatumiki tena kwa toleo hili la Android</translation>
-<translation id="1966710179511230534">Tafadhali sasisha maelezo yako ya kuingia katika akaunti.</translation>
-<translation id="1974060860693918893">Mipangilio ya kina</translation>
-<translation id="1984705450038014246">Sawazisha data yako kwenye Chrome</translation>
-<translation id="1984937141057606926">Inaruhusiwa, isipokuwa vidakuzi vingine</translation>
-<translation id="1986685561493779662">Jina tayari lipo</translation>
-<translation id="1987739130650180037">Kitufe cha <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Vinjari</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> inataka kuoanisha</translation>
-<translation id="1994173015038366702">URL ya Tovuti</translation>
-<translation id="2000419248597011803">Hutuma baadhi ya vidakuzi na utafutaji kutoka kwenye sehemu ya anwani na kisanduku cha kutafutia kwenye mtambo wako chaguomsingi wa kutafuta</translation>
-<translation id="2002537628803770967">Kadi za mikopo na anwani zinazotumia Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{Faili #}other{Faili #}}</translation>
-<translation id="2017836877785168846">Hufuta historia na ujazaji kiotomatiki katika sehemu ya anwani.</translation>
-<translation id="2021896219286479412">Vidhibiti vya tovuti vya skrini nzima</translation>
-<translation id="2038563949887743358">Washa Omba Tovuti ya Eneo-kazi</translation>
-<translation id="2041019821020695769">Ili uruhusu Chrome ikutumie arifa, washa arifa pia katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> pia ina data katika Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Tovuti imesimamishwa</translation>
-<translation id="2063713494490388661">Gusa ili Utafute</translation>
-<translation id="2067805253194386918">maandishi</translation>
-<translation id="2079545284768500474">Tendua</translation>
-<translation id="2082238445998314030">Tokeo <ph name="RESULT_NUMBER" /> kati ya <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Sauti</translation>
-<translation id="2096012225669085171">Sawazisha na uweke mapendeleo kwenye vifaa vyote</translation>
-<translation id="2100273922101894616">Ingia katika Akaunti Kiotomatiki</translation>
-<translation id="2100314319871056947">Jaribu kushiriki maandishi katika sehemu ndogo ndogo</translation>
-<translation id="2107397443965016585">Iulize kabla ya kuruhusu tovuti kucheza maudhui yanayolindwa (inapendekezwa)</translation>
-<translation id="2111511281910874386">Nenda kwenye ukurasa</translation>
-<translation id="2122601567107267586">Imeshindwa kufungua programu</translation>
-<translation id="2126426811489709554">Unaendeshwa na Chrome</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> imeokolewa</translation>
-<translation id="213279576345780926">Umefunga <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Ongeza kwenye skrini ya kwanza</translation>
-<translation id="2146738493024040262">Fungua Programu Inayofunguka Papo Hapo</translation>
-<translation id="2148716181193084225">Leo</translation>
-<translation id="2154484045852737596">Badilisha kadi</translation>
-<translation id="2154710561487035718">Nakili UR:</translation>
-<translation id="2156074688469523661">Tovuti zilizosalia (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Ili ushiriki kitu kutoka simu yako hadi kifaa kingine, washa usawazishaji katika mipangilio ya Chrome kwenye vifaa vyote viwili</translation>
-<translation id="2170088579611075216">Ruhusu na uingie katika VR</translation>
-<translation id="218608176142494674">Inashiriki</translation>
-<translation id="2227444325776770048">Endelea ukitumia <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Huduma za Google na usawazishaji</translation>
-<translation id="2259659629660284697">Hamisha manenosiri…</translation>
-<translation id="2268044343513325586">Chuja</translation>
-<translation id="2286841657746966508">Anwani ya kutoza</translation>
-<translation id="2289270750774289114">Niulize wakati tovuti inataka kugundua vifaa vya Bluetooth vilivyo karibu (inapendekezwa)</translation>
-<translation id="230115972905494466">Haikupata vifaa vyovyote vinavyooana</translation>
-<translation id="2315043854645842844">Uchaguzi wa cheti cha sehemu ya seva teja hautumiwi na mfumo wa uendeshaji.</translation>
-<translation id="2318045970523081853">Gusa ili upige simu</translation>
-<translation id="2321086116217818302">Inatayarisha manenosiri…</translation>
-<translation id="2321958826496381788">Buruta kitelezi hadi uweze kusoma haya kwa starehe. Maandishi yanapaswa kuonekana angalau kwa ukubwa huu baada ya kugonga mara mbili kwenye aya.</translation>
-<translation id="2323763861024343754">Hifadhi ya tovuti</translation>
-<translation id="2328985652426384049">Imeshindwa kuingia katika akaunti</translation>
-<translation id="2330129964253841015">Uonywe ikiwa manenosiri yako yameathiriwa</translation>
-<translation id="2349710944427398404">Jumla ya data iliyotumiwa na Chrome, ikiwa ni pamoja na akaunti, alamisho na mipangilio iliyohifadhiwa</translation>
-<translation id="2353636109065292463">Inaangalia muunganisho wako wa intaneti</translation>
-<translation id="2359808026110333948">Endelea</translation>
-<translation id="2369533728426058518">vichupo vilivyo wazi</translation>
-<translation id="2387895666653383613">Upimaji wa maandishi</translation>
-<translation id="2394602618534698961">Faili unazopakua zinaonekana hapa</translation>
-<translation id="2402980924095424747">MB <ph name="MEGABYTES" /></translation>
-<translation id="2407481962792080328">Ukiingia katika Akaunti ya Google, kipengele hiki kitawashwa</translation>
-<translation id="2410754283952462441">Chagua akaunti</translation>
-<translation id="2414886740292270097">Giza</translation>
-<translation id="2416359993254398973">Ruhusu Chrome ifikie kamera yako ya tovuti hii.</translation>
-<translation id="2426805022920575512">Chagua akaunti nyingine</translation>
-<translation id="2433507940547922241">Sura</translation>
-<translation id="2434158240863470628">Upakuaji umekamilika <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Ufikiaji wa eneo</translation>
-<translation id="2450083983707403292">Je, unataka kuanza kupakua <ph name="FILE_NAME" /> tena?</translation>
-<translation id="2482878487686419369">Arifa</translation>
-<translation id="2490684707762498678">Inasimamiwa na <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Mratibu wa Google katika Chrome</translation>
-<translation id="2496180316473517155">Historia ya kuvinjari</translation>
-<translation id="2497852260688568942">Usawazishaji umezimwa na msimamizi wako</translation>
-<translation id="2498359688066513246">Usaidizi na maoni</translation>
-<translation id="2501278716633472235">Rudi nyuma</translation>
-<translation id="2513403576141822879">Ili upate mipangilio zaidi inayohusiana na faragha, usalama na ukusanyaji wa data, angalia <ph name="BEGIN_LINK" />Usawazishaji na huduma za Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Katika Hali Nyepesi, Chrome hupakia kurasa haraka zaidi na huokoa hadi asilimia 60 ya data. Ili kuboresha kurasa unazotembelea, Chrome hutumia Google data ya tovuti unazotembelea. <ph name="BEGIN_LINK" />Pata maelezo zaidi<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Hutuma URL za kurasa unazotembelea kwa Google</translation>
-<translation id="2532336938189706096">Mwonekano wa Wavuti</translation>
-<translation id="2534155362429831547">Umefuta vipengee <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Unaangalia nakala ya nje ya mtandao ya ukurasa huu</translation>
-<translation id="2546283357679194313">Data ya vidakuzi na tovuti</translation>
-<translation id="2567385386134582609">PICHA</translation>
-<translation id="257088987046510401">Mandhari</translation>
-<translation id="2570922361219980984">Kipengele cha mahali pia kimezimwa kwenye kifaa hiki. Kiwashe katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Imepanuliwa - bofya ili ukunje.</translation>
-<translation id="2581165646603367611">Hatua hii itafuta vidakuzi, akiba na data nyingine ya tovuti ambazo Chrome haidhani kuwa muhimu.</translation>
-<translation id="2586657967955657006">Ubao wa kunakili</translation>
-<translation id="2587052924345400782">Toleo jipya linapatikana.</translation>
-<translation id="2593272815202181319">Nafasi moja</translation>
-<translation id="2612676031748830579">Nambari ya kadi</translation>
-<translation id="2621115761605608342">Ruhusu JavaScript ya tovuti mahususi.</translation>
-<translation id="2625189173221582860">Nenosiri limenakiliwa</translation>
-<translation id="2631006050119455616">Iliyookolewa</translation>
-<translation id="2647434099613338025">Ongeza lugha</translation>
-<translation id="2650751991977523696">Ungependa kupakua faili tena?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{Faili # ya sauti}other{Faili # za sauti}}</translation>
-<translation id="2653659639078652383">Wasilisha</translation>
-<translation id="2677748264148917807">Ondoka</translation>
-<translation id="2704606927547763573">Imenakiliwa</translation>
-<translation id="2707726405694321444">Onyesha upya ukurasa</translation>
-<translation id="2709516037105925701">Kujaza Kiotomatiki</translation>
-<translation id="2717722538473713889">Anwani za barua pepe</translation>
-<translation id="2728754400939377704">Panga kulingana na tovuti</translation>
-<translation id="2744248271121720757">Gusa neno ili utafute papo hapo au uone vitendo vinavyohusiana</translation>
-<translation id="2760989362628427051">Washa hali ya mandhari meusi wakati umewasha kipengele cha mandhari meusi au Kiokoa Betri cha kifaa chako</translation>
-<translation id="2762000892062317888">sasa hivi tu</translation>
-<translation id="2777555524387840389">Zimesalia sekunde <ph name="SECONDS" /></translation>
-<translation id="2779651927720337254">imeshindwa</translation>
-<translation id="2781151931089541271">Imesalia sekunde 1</translation>
-<translation id="2801022321632964776">Sasisha ili upate lugha yako katika toleo jipya zaidi la Chrome</translation>
-<translation id="2810645512293415242">Ukurasa umerahisishwa ili uokoe data na upakie haraka zaidi.</translation>
-<translation id="281504910091592009">Angalia na udhibiti manenosiri yaliyohifadhiwa kwenye <ph name="BEGIN_LINK" />Akaunti yako ya Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Ingia katika akaunti na uwashe kipengele cha usawazishaji ili upate alamisho zako kwenye vifaa vyako vyote</translation>
-<translation id="2822354292072154809">Una uhakika ungependa kubadilisha ruhusa zote za tovuti ya <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Gusa kitufe cha kurudi nyuma ili uondoke kwenye skrini nzima.</translation>
-<translation id="2842985007712546952">Folda kuu</translation>
-<translation id="2858138569776157458">Tovuti maarufu</translation>
-<translation id="2860954141821109167">Hakikisha kuwa programu ya simu imewashwa kwenye kifaa hiki</translation>
-<translation id="2870560284913253234">Tovuti</translation>
-<translation id="2874939134665556319">Wimbo uliotangulia</translation>
-<translation id="2876369937070532032">Hutuma kwa Google URL za baadhi ya kurasa ambazo umetembelea wakati usalama wako uko hatarini</translation>
-<translation id="2888126860611144412">Kuhusu Chrome</translation>
-<translation id="2891154217021530873">Simamisha upakiaji wa ukurasa</translation>
-<translation id="2893180576842394309">Google inaweza kutumia historia yako ili kuweka mapendeleo kwenye huduma ya Tafuta na Google na huduma nyingine za Google.</translation>
-<translation id="2898264748040935573">Badilisha nenosiri lililohifadhiwa</translation>
-<translation id="2900528713135656174">Ongeza tukio jipya</translation>
-<translation id="290376772003165898">Je, ukurasa huu haupo katika <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Orodha ya vifaa vinavyoweza kutumia kichupo pamoja imefunguliwa kwenye skrini nzima.</translation>
-<translation id="2910701580606108292">Iulize kabla ya kuruhusu tovuti kucheza maudhui yanayolindwa</translation>
-<translation id="2913331724188855103">Ruhusu tovuti zihifadhi na kusoma data ya vidakuzi (imependekezwa)</translation>
-<translation id="2923908459366352541">Jina si sahihi</translation>
-<translation id="2932150158123903946">Hifadhi ya Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Kichupo cha kukagua kwanza kimefungwa</translation>
-<translation id="2956410042958133412">Akaunti hii inadhibitiwa na <ph name="PARENT_NAME_1" /> na <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Inabadilisha kwenda vichupo fiche</translation>
-<translation id="2968755619301702150">Kitazamaji vyeti</translation>
-<translation id="2979025552038692506">Kichupo Fiche Kilichochaguliwa</translation>
-<translation id="2987620471460279764">Maandishi yaliyoshirikiwa kutoka kifaa kingine</translation>
-<translation id="2989523299700148168">Ulizotembelea hivi karibuni</translation>
-<translation id="2996291259634659425">Unda kauli ya siri</translation>
-<translation id="2996809686854298943">URL inahitajika</translation>
-<translation id="300526633675317032">Hatua hii itafuta <ph name="SIZE_IN_KB" /> yote ya hifadhi ya tovuti.</translation>
-<translation id="3016635187733453316">Hakikisha kwamba kifaa hiki kimeunganishwa kwenye intaneti</translation>
-<translation id="3029613699374795922">Umepakua KB <ph name="KBS" /></translation>
-<translation id="3029704984691124060">Kaulisiri hazilingani</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Pata usaidizi<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Kipengele cha mahali kimezimwa; kiwashe katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Unaweza kuwasha kipengele cha kusawazisha wakati wowote katika mipangilio</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{Alamisho <ph name="BOOKMARKS_COUNT_ONE" />}other{Alamisho <ph name="BOOKMARKS_COUNT_MANY" />}}</translation>
-<translation id="3089395242580810162">Fungua katika kichupo fiche</translation>
-<translation id="3115898365077584848">Onyesha Maelezo</translation>
-<translation id="3123473560110926937">Yamezuiwa kwenye baadhi ya tovuti</translation>
-<translation id="3137521801621304719">Ondoka kwenye hali fiche</translation>
-<translation id="3143515551205905069">Ghairi usawazishaji</translation>
-<translation id="3157842584138209013">Ona kiasi cha data ulichookoa kwa kubofya kitufe cha Chaguo Zaidi</translation>
-<translation id="3166827708714933426">Njia za mikato ya vichupo na vidirisha</translation>
-<translation id="3181954750937456830">Kuvinjari Salama (hukulinda wewe na kifaa chako dhidi ya tovuti hatari)</translation>
-<translation id="3190152372525844641">Washa ruhusa za Chrome katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> za data iliyohifadhiwa</translation>
-<translation id="3205824638308738187">Inakaribia kumaliza!</translation>
-<translation id="3207960819495026254">Imealamishwa</translation>
-<translation id="3211426585530211793">Umefuta <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Ikiwa umesahau kauli yako ya siri au ungependa kubadilisha mipangilio hii, <ph name="BEGIN_LINK" />fanya usawazishaji upya<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Maikrofoni</translation>
-<translation id="3232754137068452469">Programu ya Wavuti</translation>
-<translation id="3236059992281584593">Imesalia dakika 1</translation>
-<translation id="3244271242291266297">MW</translation>
-<translation id="3254409185687681395">Alamisha ukurasa huu</translation>
-<translation id="3259831549858767975">Fanya kila kitu kwenye ukurasa kiwe kidogo zaidi</translation>
-<translation id="3269093882174072735">Pakia picha</translation>
-<translation id="3269956123044984603">Ili upate vichupo vyako kutoka kwenye vifaa vyako vingine, washa kipengele cha "Kusawazisha data kiotomatiki" katika mipangilio ya akaunti ya Android.</translation>
-<translation id="3277252321222022663">Ruhusu tovuti zifikie vitambuzi (inapendekezwa)</translation>
-<translation id="3282568296779691940">Ingia katika Chrome</translation>
-<translation id="3288003805934695103">Kupakia upya ukurasa</translation>
-<translation id="32895400574683172">Arifa zinaruhusiwa</translation>
-<translation id="3295530008794733555">Vinjari haraka. Tumia data chache.</translation>
-<translation id="3295602654194328831">Ficha Maelezo</translation>
-<translation id="3298243779924642547">Nyepesi</translation>
-<translation id="3303414029551471755">Ungependa kuendelea kupakua maudhui?</translation>
-<translation id="3306398118552023113">Programu hii inatumika katika Chrome</translation>
-<translation id="3315103659806849044">Kwa sasa, unaweka mapendeleo kwenye mipangilio ya Usawazishaji na huduma ya Google. Ili ukamilishe kuwasha usawazishaji, gusa kitufe cha 'Thibitisha' kwenye sehemu ya chini ya skrini. Sogeza juu</translation>
-<translation id="3328801116991980348">Maelezo ya tovuti</translation>
-<translation id="3333961966071413176">Anwani zote</translation>
-<translation id="3334729583274622784">Ungependa kubadilisha kiendelezi cha faili?</translation>
-<translation id="3341058695485821946">Ona kiasi cha data ulichookoa</translation>
-<translation id="3350687908700087792">Funga vichupo vyote fiche</translation>
-<translation id="3353615205017136254">Ukurasa mwepesi umetolewa na Google. Gusa kitufe cha pakia halisi ili upakie ukurasa halisi.</translation>
-<translation id="3367813778245106622">Ingia tena katika akaunti ili uanze kusawazisha</translation>
-<translation id="3374023511497244703">Alamisho, historia, manenosiri na data yako nyingine ya Chrome hazitasawazishwa tena kwenye Akaunti yako ya Google</translation>
-<translation id="3384347053049321195">Shiriki picha</translation>
-<translation id="3386292677130313581">Uliza kabla ya kuruhusu tovuti zijue mahali ulipo (inapendekezwa)</translation>
-<translation id="3387650086002190359">Kipakuliwa cha <ph name="FILE_NAME" /> hakijafaulu kwa sababu ya hitilafu za mfumo wa faili.</translation>
-<translation id="3389286852084373014">Maandishi ni makubwa mno</translation>
-<translation id="3398320232533725830">Fungua kidhibiti cha alamisho</translation>
-<translation id="3414952576877147120">Ukubwa:</translation>
-<translation id="3443221991560634068">Pakia upya ukurasa wa sasa</translation>
-<translation id="3445014427084483498">Sasa Hivi</translation>
-<translation id="3478363558367712427">Unaweza kuchagua mtambo wako wa kutafuta</translation>
+<translation id="6910211073230771657">Imeondolewa</translation>
+<translation id="6965382102122355670">Sawa</translation>
+<translation id="5301954838959518834">Sawa, nimeelewa</translation>
+<translation id="7658239707568436148">Ghairi</translation>
 <translation id="3479552764303398839">Si sasa</translation>
-<translation id="3492207499832628349">Kichupo fiche kipya</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Pata maelezo zaidi<ph name="END_LINK" /> kuhusu maudhui yaliyopendekezwa</translation>
-<translation id="3513704683820682405">Uhalisia Ulioboreshwa</translation>
-<translation id="3518985090088779359">Kubali na uendelee</translation>
-<translation id="3522247891732774234">Kuna toleo jipya. Chaguo zaidi</translation>
-<translation id="3524138585025253783">Kiolesura cha Msanidi Programu</translation>
-<translation id="3527085408025491307">Folda</translation>
-<translation id="3542235761944717775">KB <ph name="KILOBYTES" /> zinapatikana</translation>
-<translation id="3549657413697417275">Tafuta katika historia yako</translation>
-<translation id="3557336313807607643">Ongeza kwenye anwani</translation>
-<translation id="3566923219790363270">Chrome bado inasubiri Uhalisia Pepe. Zima kisha uwashe Chrome baadaye</translation>
-<translation id="3568688522516854065">Ingia katika akaunti na uwashe kipengele cha usawazishaji ili upate vichupo vyako kutoka vifaa vyako vingine</translation>
-<translation id="3587482841069643663">Zote</translation>
-<translation id="358794129225322306">Ruhusu tovuti ipakue faili nyingi kiotomatiki.</translation>
-<translation id="3590487821116122040">Hifadhi ya tovuti ambayo Chrome haidhani ni muhimu (k.m. tovuti ambazo hazina mipangilio iliyohifadhiwa au ambazo hutembelei sana)</translation>
-<translation id="3599863153486145794">Hufuta historia kwenye vifaa vyote ulivyotumia kuingia katika akaunti. Huenda Akaunti yako ya Google ikawa na aina nyingine za historia ya kuvinjari kwenye <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Zima sauti katika tovuti</translation>
-<translation id="3616113530831147358">Sauti</translation>
-<translation id="3631987586758005671">Inashiriki kwenye <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Onyesha nenosiri</translation>
-<translation id="363596933471559332">Ingia katika tovuti kiotomatiki kwa kutumia kitambulisho kilichohifadhiwa. Kipengele kikiwa kimezimwa, utaombwa kuthibitisha kila wakati kabla ya kuingia katika tovuti.</translation>
-<translation id="3658159451045945436">Hatua ya kuweka upya hufuta historia ya uokoaji wa data, ikiwa ni pamoja na orodha ya tovuti unazotembelea.</translation>
-<translation id="3692944402865947621">Imeshindwa kupakua <ph name="FILE_NAME" /> kwa sababu haikupata eneo la kuhifadhi.</translation>
-<translation id="3714981814255182093">Fungua Upau wa Kutafuta</translation>
-<translation id="3716182511346448902">Ukurasa huu unatumia hifadhi kubwa zaidi, kwa hivyo Chrome imeusitisha.</translation>
-<translation id="3730075448226062617">Ili uruhusu Chrome ifikie maikrofoni yako, washa maikrofoni pia katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Imealamishwa katika <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Usawazishaji wa chini chini</translation>
-<translation id="3771001275138982843">Imeshindwa kupakua sasisho</translation>
-<translation id="3771033907050503522">Vichupo Fiche</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Washa Bluetooth<ph name="END_LINK" /> ili uruhusu kuoanisha</translation>
-<translation id="3775705724665058594">Tuma kwenye vifaa vyako</translation>
-<translation id="3778956594442850293">Imeongezwa kwenye Skrini ya Kwanza</translation>
-<translation id="3789841737615482174">Sakinisha</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Dhibiti</translation>
-<translation id="381841723434055211">Nambari za simu</translation>
-<translation id="3819178904835489326">Vipakuliwa <ph name="NUMBER_OF_DOWNLOADS" /> vimefutwa</translation>
-<translation id="3822502789641063741">Ungependa kufuta hifadhi ya tovuti?</translation>
-<translation id="385051799172605136">Rudi nyuma</translation>
-<translation id="3859306556332390985">Peleka mbele</translation>
-<translation id="3894427358181296146">Ongeza folda</translation>
-<translation id="3895926599014793903">Lazimisha kuwasha ukuzaji</translation>
-<translation id="3912508018559818924">Inatafuta maudhui bora zaidi kwenye wavuti…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Unganisha data yangu</translation>
-<translation id="393697183122708255">Hakuna kutafuta kwa kutamka kulikowashwa</translation>
-<translation id="395206256282351086">Mapendekezo ya utafutaji na tovuti yamezimwa</translation>
-<translation id="3955193568934677022">Ruhusu tovuti zicheze maudhui yanayolindwa (inapendekezwa)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome itapakia ukurasa wako ukiwa tayari}other{Chrome itapakia kurasa zako zikiwa tayari}}</translation>
-<translation id="3963007978381181125">Usimbaji fiche kwa kutumia kauli ya siri haujumuishi njia za kulipa na anwani kutoka Google Pay. Mtu aliye na kauli yako ya siri pekee ndiye anayeweza kusoma data yako iliyosimbwa kwa njia fiche. Kauli ya siri haitumwi kwa au kuhifadhiwa na Google. Ukisahau kauli yako ya siri au utake kubadilisha mipangilio hii, utahitaji kufanya usawazishaji upya. <ph name="BEGIN_LINK" />Pata maelezo zaidi<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Faili imekamilika kupakuliwa</translation>
-<translation id="397583555483684758">Usawazishaji umeacha kufanya kazi</translation>
-<translation id="3976396876660209797">Ondoa na uunde upya njia hii ya mkato</translation>
-<translation id="3985215325736559418">Je, ungependa kupakua <ph name="FILE_NAME" /> tena?</translation>
-<translation id="3987993985790029246">Nakili kiungo</translation>
-<translation id="3988213473815854515">Mahali panaruhusiwa</translation>
-<translation id="3988466920954086464">Angalia matokeo ya utafutaji wa moja kwa moja katika kidirisha hiki</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Hifadhi ambayo si muhimu</translation>
-<translation id="4000212216660919741">Skrini ya Kwanza, Nje ya Mtandao</translation>
+<translation id="5317780077021120954">Hifadhi</translation>
+<translation id="4570913071927164677">Maelezo</translation>
+<translation id="8730621377337864115">Nimemaliza</translation>
+<translation id="8261506727792406068">Futa</translation>
+<translation id="1181037720776840403">Ondoa</translation>
+<translation id="5939518447894949180">Weka upya</translation>
 <translation id="4002066346123236978">Kichwa</translation>
-<translation id="4008040567710660924">Ruhusu vidakuzi katika tovuti maalum.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{Saa #}other{Saa #}}</translation>
-<translation id="4046123991198612571">Wimbo unaofuata</translation>
-<translation id="4048707525896921369">Pata maelezo kuhusu mada kwenye tovuti bila kuondoka kwenye ukurasa. Kipengele cha Gusa ili Utafute hutuma neno na muktadha wake kwenye huduma ya Tafuta na Google na kuonyesha ufafanuzi, picha, matokeo ya utafutaji na maelezo mengine.
+<translation id="5916664084637901428">Imewashwa</translation>
+<translation id="5860033963881614850">Kimezimwa</translation>
+<translation id="6165508094623778733">Pata maelezo zaidi</translation>
+<translation id="6042308850641462728">Zaidi</translation>
+<translation id="6040143037577758943">Funga</translation>
+<translation id="780301667611848630">La, asante</translation>
+<translation id="1201402288615127009">Endelea</translation>
+<translation id="2359808026110333948">Endelea</translation>
+<translation id="2653659639078652383">Wasilisha</translation>
+<translation id="2079545284768500474">Tendua</translation>
+<translation id="7649070708921625228">Usaidizi</translation>
+<translation id="2148716181193084225">Leo</translation>
+<translation id="7781829728241885113">Jana</translation>
+<translation id="6945221475159498467">Chagua</translation>
+<translation id="7791543448312431591">Ongeza</translation>
+<translation id="6527303717912515753">Shiriki</translation>
+<translation id="1383876407941801731">Tafuta</translation>
+<translation id="3115898365077584848">Onyesha Maelezo</translation>
+<translation id="3295602654194328831">Ficha Maelezo</translation>
+<translation id="3987993985790029246">Nakili kiungo</translation>
+<translation id="2704606927547763573">Imenakiliwa</translation>
+<translation id="8725066075913043281">Jaribu tena</translation>
+<translation id="385051799172605136">Rudi nyuma</translation>
+<translation id="8131740175452115882">Thibitisha</translation>
+<translation id="5300589172476337783">Onyesha</translation>
+<translation id="1124772482545689468">Mtumiaji</translation>
+<translation id="8609465669617005112">Songa juu</translation>
+<translation id="6746124502594467657">Songa chini</translation>
+<translation id="8249310407154411074">Sogeza juu</translation>
+<translation id="8428213095426709021">Mipangilio</translation>
+<translation id="2498359688066513246">Usaidizi na maoni</translation>
+<translation id="8378714024927312812">Inasimamiwa na shirika lako</translation>
+<translation id="9019902583201351841">Inadhibitiwa na wazazi wako</translation>
+<translation id="4645575059429386691">Inadhibitiwa na wazazi wako</translation>
+<translation id="4883854917563148705">Huwezi kubadilisha mipangilio inayodhibitiwa</translation>
+<translation id="4307992518367153382">Mambo Msingi</translation>
+<translation id="1974060860693918893">Mipangilio ya kina</translation>
+<translation id="1146678959555564648">Tumia hali ya VR</translation>
+<translation id="987264212798334818">Jumla</translation>
+<translation id="4275663329226226506">Vyombo vya Habari</translation>
+<translation id="4759238208242260848">Vipakuliwa</translation>
+<translation id="218608176142494674">Inashiriki</translation>
+<translation id="8004582292198964060">Kivinjari</translation>
+<translation id="1105960400813249514">Piga Picha ya Skrini</translation>
+<translation id="4875775213178255010">Mapendekezo ya Maudhui</translation>
+<translation id="2021896219286479412">Vidhibiti vya tovuti vya skrini nzima</translation>
+<translation id="4587589328781138893">Tovuti</translation>
+<translation id="4943703118917034429">Uhalisia Pepe</translation>
+<translation id="1928696683969751773">Usasishaji</translation>
+<translation id="6064125863973209585">Faili zilizopakuliwa</translation>
+<translation id="5342314432463739672">Maombi ya ruhusa</translation>
+<translation id="629730747756840877">Akaunti</translation>
+<translation id="82609232232243542">Ingia katika Brave</translation>
+<translation id="7956662517480676674">Huduma za Brave Software na usawazishaji</translation>
+<translation id="5294439808117722387">Kwa sasa, unaweka mapendeleo kwenye mipangilio ya Usawazishaji na huduma ya Brave Software. Ili ukamilishe kuwasha usawazishaji, gusa kitufe cha 'Thibitisha' kwenye sehemu ya chini ya skrini. Sogeza juu</translation>
+<translation id="2096012225669085171">Sawazisha na uweke mapendeleo kwenye vifaa vyote</translation>
+<translation id="1692118695553449118">Usawazishajii umewashwa</translation>
+<translation id="5514904542973294328">Imezimwa na msimamizi wa kifaa hiki</translation>
+<translation id="6447211988989208781">Vidhibiti vya shughuli za Brave Software</translation>
+<translation id="4882831918239250449">Dhibiti namna historia yako ya kuvinjari inavyotumika kuweka mapendeleo ya Kutafuta matangazo na zaidi</translation>
+<translation id="7431991332293347422">Dhibiti namna historia yako ya kuvinjari inavyotumika kuweka mapendeleo kwenye huduma ya Tafuta na Brave Software na zaidi</translation>
+<translation id="6303969859164067831">Ondoka kwenye akaunti na uzime usawazishaji</translation>
+<translation id="1125261911132334651">Dhibiti Akaunti yako ya Brave Software</translation>
+<translation id="6406506848690869874">Sawazisha</translation>
+<translation id="714362445477979774">Sawazisha data yako kwenye Brave</translation>
+<translation id="4314815835985389558">Dhibiti usawazishaji</translation>
+<translation id="5428209950370661546">Huduma zingine za Brave Software</translation>
+<translation id="7704317875155739195">Jaza kiotomatiki URL na hoja za utafutaji</translation>
+<translation id="2000419248597011803">Hutuma baadhi ya vidakuzi na utafutaji kutoka kwenye sehemu ya anwani na kisanduku cha kutafutia kwenye mtambo wako chaguomsingi wa kutafuta</translation>
+<translation id="7981313251711023384">Pakia mapema kurasa ili upate huduma ya haraka ya kuvinjari na kutafuta</translation>
+<translation id="1821253160463689938">Hutumia vidakuzi kukumbuka mapendeleo yako, hata usipotembelea kurasa hizo</translation>
+<translation id="6697492270171225480">Onyesha mapendekezo ya kurasa zinazofanana na ukurasa huu wakati haupatikani</translation>
+<translation id="8109318360573330108">Hutuma URL ya ukurasa unaojaribu kufikia kwa Brave Software</translation>
+<translation id="8438566539970814960">Boresha utafutaji na kuvinjari</translation>
+<translation id="284843628681142937">Hutuma URL za kurasa unazotembelea kwa Brave Software</translation>
+<translation id="7222718784508482526">Ili upate mipangilio zaidi inayohusiana na faragha, usalama na ukusanyaji wa data, angalia <ph name="BEGIN_LINK"/>Usawazishaji na huduma za Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Tusaidie tuboreshe utendaji na vipengele vya Brave</translation>
+<translation id="9063160602596686558">Hutuma kiotomatiki takwimu za matumizi na ripoti za programu kuacha kufanya kazi kwa Brave Software</translation>
+<translation id="4824958205181053313">Ungependa kughairi usawazishaji?</translation>
+<translation id="3058498974290601450">Unaweza kuwasha kipengele cha kusawazisha wakati wowote katika mipangilio</translation>
+<translation id="3143515551205905069">Ghairi usawazishaji</translation>
+<translation id="1506061864768559482">Mtambo wa utafutaji</translation>
+<translation id="55737423895878184">Vipengele vya mahali na arifa vinaruhusiwa</translation>
+<translation id="3988213473815854515">Mahali panaruhusiwa</translation>
+<translation id="32895400574683172">Arifa zinaruhusiwa</translation>
+<translation id="9040142327097499898">Arifa zinaruhusiwa. Kipengele cha mahali kimezimwa kwenye kifaa hiki.</translation>
+<translation id="305593374596241526">Kipengele cha mahali kimezimwa; kiwashe katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Ulizotembelea hivi karibuni</translation>
+<translation id="6433501201775827830">Chagua mtambo wako wa kutafuta</translation>
+<translation id="7177466738963138057">Unaweza kubadilisha hii baadaye katika Mipangilio</translation>
+<translation id="3478363558367712427">Unaweza kuchagua mtambo wako wa kutafuta</translation>
+<translation id="4910889077668685004">Programu za malipo</translation>
+<translation id="5152843274749979095">Hakuna programu zinazotumika zimesakinishwa</translation>
+<translation id="8812260976093120287">Kwenye baadhi ya tovuti, unaweza kulipa kwa programu za malipo zinazotumika zilizo hapo juu kwenye kifaa chako.</translation>
+<translation id="7764225426217299476">Ongeza anwani</translation>
+<translation id="5595485650161345191">Badilisha anwani</translation>
+<translation id="5087580092889165836">Ongeza kadi</translation>
+<translation id="2154484045852737596">Badilisha kadi</translation>
+<translation id="6140912465461743537">Nchi/Eneo</translation>
+<translation id="5659593005791499971">Barua pepe</translation>
+<translation id="4378154925671717803">Simu</translation>
+<translation id="4807098396393229769">Jina kwenye kadi</translation>
+<translation id="860043288473659153">Jina la mmiliki wa kadi</translation>
+<translation id="2612676031748830579">Nambari ya kadi</translation>
+<translation id="869891660844655955">Muda wake unakwisha tarehe</translation>
+<translation id="2286841657746966508">Anwani ya kutoza</translation>
+<translation id="663059986967017181">Imenakiliwa kwenye Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> zaidi}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> zaidi}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> zaidi}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> zaidi}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> zaidi}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> zaidi}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> zaidi}other{<ph name="CONTACT_PREVIEW"/>\u2026 na <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> zaidi}}</translation>
+<translation id="7029809446516969842">Manenosiri</translation>
+<translation id="1943432128510653496">Hifadhi manenosiri</translation>
+<translation id="2100273922101894616">Ingia katika Akaunti Kiotomatiki</translation>
+<translation id="363596933471559332">Ingia katika tovuti kiotomatiki kwa kutumia kitambulisho kilichohifadhiwa. Kipengele kikiwa kimezimwa, utaombwa kuthibitisha kila wakati kabla ya kuingia katika tovuti.</translation>
+<translation id="6995899638241819463">Nionye ikiwa manenosiri yamefichuliwa katika tukio la ufichuzi haramu wa data</translation>
+<translation id="1534287762301776620">Ukiingia katika Akaunti ya Brave Software, kipengele hiki kitawashwa</translation>
+<translation id="10614374240317010">Haijahifadhiwa kamwe</translation>
+<translation id="3098842761938485917">Angalia na udhibiti manenosiri yaliyohifadhiwa kwenye <ph name="BEGIN_LINK"/>Akaunti yako ya Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Manenosiri yaliyohifadhiwa yataonekana hapa.</translation>
+<translation id="8084114998886531721">Nenosiri lililohifadhiwa</translation>
+<translation id="2870560284913253234">Tovuti</translation>
+<translation id="8503813439785031346">Jina la mtumiaji</translation>
+<translation id="6657585470893396449">Nenosiri</translation>
+<translation id="2154710561487035718">Nakili UR:</translation>
+<translation id="1571304935088121812">Nakili jina la mtumiaji</translation>
+<translation id="5005498671520578047">Nakili nenosiri</translation>
+<translation id="3632295766818638029">Onyesha nenosiri</translation>
+<translation id="1513858653616922153">Futa nenosiri</translation>
+<translation id="543338862236136125">Badilisha nenosiri</translation>
+<translation id="4565377596337484307">Ficha nenosiri</translation>
+<translation id="8523928698583292556">Futa manenosiri yaliyohifadhiwa</translation>
+<translation id="2898264748040935573">Badilisha nenosiri lililohifadhiwa</translation>
+<translation id="5433691172869980887">Jina la mtumiaji limenakiliwa</translation>
+<translation id="5534640966246046842">Tovuti imenakiliwa</translation>
+<translation id="2625189173221582860">Nenosiri limenakiliwa</translation>
+<translation id="4550003330909367850">Ili uangalie au unakili nenosiri lako hapa, weka kipengele cha kufunga skrini kwenye kifaa hiki.</translation>
+<translation id="6154478581116148741">Washa kipengele cha kufunga skrini katika Mipangilio ili uhamishe manenosiri yako kutoka kwenye kifaa hiki</translation>
+<translation id="4842092870884894799">Inaonyesha dirisha ibukizi la uundaji wa nenosiri</translation>
+<translation id="2259659629660284697">Hamisha manenosiri…</translation>
+<translation id="133012818630824069">Tuma manenosiri yaliyohifadhiwa kwenye Brave</translation>
+<translation id="6914783257214138813">Mtu yeyote anayeweza kuona faili uliyohamisha ataona manenosiri yako.</translation>
+<translation id="2321086116217818302">Inatayarisha manenosiri…</translation>
+<translation id="8445448999790540984">Haiwezi kuhamisha manenosiri</translation>
+<translation id="3066461326500799725">Pata maelezo ya jinsi ya kutumia Brave Software Drive</translation>
+<translation id="729975465115245577">Kifaa chako hakina programu ya kuhifadhi faili ya manenosiri.</translation>
+<translation id="7682724950699840886">Jaribu vidokezo vifuatavyo: Hakikisha kuwa una nafasi ya kutosha kwenye kifaa chako kisha ujaribu kuihamisha tena.</translation>
+<translation id="1129510026454351943">Maelezo: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Fungua ili unakili nenosiri lako</translation>
+<translation id="5515439363601853141">Fungua ili uangalie nenosiri lako</translation>
+<translation id="6221633008163990886">Fungua ili uhamishe manenosiri yako</translation>
+<translation id="230699814587342492">Manenosiri ya Brave</translation>
+<translation id="6075798973483050474">Badilisha ukurasa wa mwanzo</translation>
+<translation id="854522910157234410">Fungua ukurasa huu</translation>
+<translation id="2482878487686419369">Arifa</translation>
+<translation id="6255999984061454636">Mapendekezo ya maudhui</translation>
+<translation id="805047784848435650">Kulingana na historia yako ya kuvinjari</translation>
+<translation id="1041308826830691739">Kutoka kwenye tovuti</translation>
+<translation id="395206256282351086">Mapendekezo ya utafutaji na tovuti yamezimwa</translation>
+<translation id="257088987046510401">Mandhari</translation>
+<translation id="4650364565596261010">Mipangilio chaguomsingi ya mfumo</translation>
+<translation id="7588219262685291874">Washa mandhari meusi wakati Kiokoa Betri cha kifaa kimewashwa</translation>
+<translation id="2760989362628427051">Washa hali ya mandhari meusi wakati umewasha kipengele cha mandhari meusi au Kiokoa Betri cha kifaa chako</translation>
+<translation id="6381421346744604172">Fanya tovuti kuwa nyeusi</translation>
+<translation id="5040262127954254034">Faragha</translation>
+<translation id="4991384657077828949">Tusaidie kuboresha usalama wa Brave</translation>
+<translation id="1943176487615318915">Ili kutambua programu na tovuti hatari, Brave hutuma URL za baadhi ya kurasa unazotembelea. maelezo machache ya mfumo na maudhui ya ukurasa kwa Brave Software</translation>
+<translation id="3181954750937456830">Kuvinjari Salama (hukulinda wewe na kifaa chako dhidi ya tovuti hatari)</translation>
+<translation id="7315322926489145388">Hutuma kwa Brave Software URL za baadhi ya kurasa ambazo umetembelea wakati usalama wako uko hatarini</translation>
+<translation id="2063713494490388661">Gusa ili Utafute</translation>
+<translation id="2369463299479365221">Pata maelezo kuhusu mada kwenye tovuti bila kuondoka kwenye ukurasa. Kipengele cha Gusa ili Utafute hutuma neno na muktadha wake kwenye huduma ya Tafuta na Brave Software na kuonyesha ufafanuzi, picha, matokeo ya utafutaji na maelezo mengine.
 
 Ili kurekebisha hoja yako ya utafutaji, bonyeza kwa muda mrefu ili ulichague. Ili kuchuja utafutaji wako, telezesha kidirisha hadi juu na uguse kisanduku cha utafutaji.</translation>
-<translation id="4056223980640387499">Sepia</translation>
-<translation id="4060598801229743805">Chaguo zinapatikana karibu na sehemu ya juu ya skrini</translation>
-<translation id="4062305924942672200">Maelezo ya kisheria</translation>
-<translation id="4084682180776658562">Alamisho</translation>
-<translation id="4084712963632273211">Kutoka <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />imesafirishwa na Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Ungependa kufuta data ya programu?</translation>
-<translation id="4099578267706723511">Saidia kuboresha Chrome kwa kutumia Google takwimu za matumizi na ripoti wakati wowote kivinjari hiki kinapoacha kufanya kazi.</translation>
-<translation id="410351446219883937">Kucheza kiotomatiki</translation>
-<translation id="4116038641877404294">Pakua kurasa uzitumie nje ya mtandao</translation>
-<translation id="4135200667068010335">Orodha ya vifaa vinavyoweza kutumia kichupo pamoja imefungwa.</translation>
-<translation id="4149994727733219643">Mwonekano uliorahisishwa kwa ajili ya kurasa za wavuti</translation>
-<translation id="4165986682804962316">Mipangilio ya tovuti</translation>
-<translation id="4169535189173047238">Usiruhusu</translation>
-<translation id="4170011742729630528">Huduma haipatikani; jaribu tena baadaye.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> imetumika</translation>
-<translation id="4181841719683918333">Lugha</translation>
-<translation id="4183868528246477015">Tafuta na Lenzi ya Google <ph name="BEGIN_NEW" />Mpya<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Fungua katika kichupo kipya</translation>
-<translation id="4198423547019359126">Hakuna maeneno ya upakuaji</translation>
-<translation id="4209895695669353772">Washa kipengele cha usawazishaji ili Google ikupendekezee maudhui yanayokufaa</translation>
-<translation id="4226663524361240545">Arifa huenda zitatetemesha kifaa</translation>
-<translation id="423219824432660969">Simba data iliyosawazishwa kwa njia fiche ukitumia nenosiri la Google lililokuwepo <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Fungua mipangilio</translation>
-<translation id="4256782883801055595">Leseni za programu huria</translation>
-<translation id="4259722352634471385">Kudurusu kumezuiwa: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Nakili anwani ya kiungo</translation>
-<translation id="4275663329226226506">Vyombo vya Habari</translation>
-<translation id="4278390842282768270">Imeruhusiwa</translation>
-<translation id="429312253194641664">Tovuti inacheza maudhui</translation>
-<translation id="4298388696830689168">Tovuti ambazo zimeunganishwa</translation>
-<translation id="4307992518367153382">Mambo Msingi</translation>
-<translation id="4314815835985389558">Dhibiti usawazishaji</translation>
-<translation id="4351244548802238354">Funga kidirisha</translation>
-<translation id="4378154925671717803">Simu</translation>
-<translation id="4384468725000734951">Unatumia Sogou kutafuta</translation>
-<translation id="4404568932422911380">Hakuna alamisho</translation>
-<translation id="4405224443901389797">Hamishia kwenye…</translation>
-<translation id="4411535500181276704">Hali nyepesi</translation>
-<translation id="4415276339145661267">Dhibiti Akaunti yako ya Google</translation>
-<translation id="4432792777822557199">Kurasa za <ph name="SOURCE_LANGUAGE" /> zitatafsiriwa katika <ph name="TARGET_LANGUAGE" /> kuanzia sasa</translation>
-<translation id="4433925000917964731">Ukurasa mwepesi umetolewa na Google</translation>
-<translation id="4434045419905280838">Madirisha ibukizi/kuelekeza kwingine</translation>
-<translation id="4440958355523780886">Ukurasa mwepesi umetolewa na Google. Gusa ili upakie ukurasa halisi.</translation>
-<translation id="4452411734226507615">Funga kichupo cha <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Imetia alamishwa kwenye <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Ruhusu tovuti icheze maudhui yanayolindwa</translation>
-<translation id="4468959413250150279">Zima sauti katika tovuti mahususi.</translation>
-<translation id="4472118726404937099">Ingia katika akaunti na uwashe kipengele cha usawazishaji ili usawazishe na uweke mapendeleo kwenye vifaa vyako vyote</translation>
-<translation id="447252321002412580">Tusaidie tuboreshe utendaji na vipengele vya Chrome</translation>
-<translation id="4479647676395637221">Uliza kwanza kabla ya kuruhusu tovuti zitumie kamera yako (inapendekezwa)</translation>
-<translation id="4479972344484327217">Inasakinisha <ph name="MODULE" /> kwenye Chrome…</translation>
-<translation id="4487967297491345095">Data yote ya programu ya Chrome itafutwa kabisa. Hii ni pamoja na faili, mipangilio, akaunti, hifadhidata zote, n.k.</translation>
-<translation id="4493497663118223949">Umewasha Hali nyepesi</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{Siku # iliyopita}other{Siku # zilizopita}}</translation>
-<translation id="451872707440238414">Tafuta alamisho zako</translation>
-<translation id="4521489764227272523">Data uliyochagua imeondolewa kwenye Chrome na kwenye vifaa vyako vilivyosawazishwa. 
-
-Huenda akaunti yako ya Google ina aina nyingine za historia ya kuvinjari kama vile mambo uliyotafuta na shughuli kutoka huduma nyingine za Google katika <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Chagua folda</translation>
-<translation id="4538018662093857852">Washa Hali nyepesi</translation>
-<translation id="4550003330909367850">Ili uangalie au unakili nenosiri lako hapa, weka kipengele cha kufunga skrini kwenye kifaa hiki.</translation>
-<translation id="4558311620361989323">Njia za mikato za ukurasa wa wavuti</translation>
-<translation id="4561979708150884304">Hakuna muunganisho</translation>
-<translation id="4565377596337484307">Ficha nenosiri</translation>
-<translation id="4570913071927164677">Maelezo</translation>
-<translation id="4572422548854449519">Ingia katika akaunti zinazodhibitiwa</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{Dakika # iliyopita}other{Dakika # zilizopita}}</translation>
-<translation id="4587589328781138893">Tovuti</translation>
-<translation id="4594952190837476234">Ukurasa huu wa nje ya mtandao umetoka <ph name="CREATION_TIME" /> na huenda ukatofautiana na toleo lililo mtandaoni.</translation>
-<translation id="4605958867780575332">Kipengee kilichoondolewa: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Fungua <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Tumia nenosiri</translation>
-<translation id="4645575059429386691">Inadhibitiwa na wazazi wako</translation>
-<translation id="4650364565596261010">Mipangilio chaguomsingi ya mfumo</translation>
-<translation id="4663756553811254707">Alamisho <ph name="NUMBER_OF_BOOKMARKS" /> zimefutwa</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> iliongezwa kwenye Skrini yako ya kwanza</translation>
-<translation id="4684427112815847243">Sawazisha kila kitu</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> zaidi}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> zaidi}}</translation>
-<translation id="4696983787092045100">Tuma maandishi kwenye Vifaa Vyako</translation>
-<translation id="4698034686595694889">Angalia ukiwa nje ya mtandao katika <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Picha na faili zilizoakibishwa</translation>
-<translation id="4714588616299687897">Okoa hadi asilimia 60 ya data yako</translation>
-<translation id="4719927025381752090">Jitolee kutafsiri</translation>
-<translation id="4720023427747327413">Fungua katika <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Tusaidie kuboresha Chrome.<ph name="BEGIN_LINK" />Shiriki katika utafiti<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Sasisha</translation>
-<translation id="4738836084190194332">Kilisawazishwa mara ya mwisho: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Fungua kichupo kipya</translation>
-<translation id="4751476147751820511">Vitambuzi vya mwendo au mwangaza</translation>
-<translation id="4759238208242260848">Vipakuliwa</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Imemaliza kupakua faili 1.}other{Imemaliza kupakua faili #.}}</translation>
-<translation id="4797039098279997504">Gusa ili urudi kwenye <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Usimbaji fiche kwa kutumia kauli ya siri haujumuishi njia za kulipa na anwani kutoka Google Pay.
-
-Ili ubadilishe mipangilio hii, <ph name="BEGIN_LINK" />fanya usawazishaji upya<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Jina kwenye kadi</translation>
-<translation id="4824958205181053313">Ungependa kughairi usawazishaji?</translation>
-<translation id="4837753911714442426">Fungua chaguo za kuchapisha ukurasa</translation>
-<translation id="4842092870884894799">Inaonyesha dirisha ibukizi la uundaji wa nenosiri</translation>
-<translation id="4860895144060829044">Piga simu</translation>
-<translation id="4866368707455379617">Imeshindwa kusakinisha <ph name="MODULE" /> kwenye Chrome</translation>
-<translation id="4875775213178255010">Mapendekezo ya Maudhui</translation>
-<translation id="4878404682131129617">Imeshindwa kuanzisha mkondo kupitia seva mbadala</translation>
-<translation id="4880127995492972015">Tafsiri…</translation>
-<translation id="4881695831933465202">Fungua</translation>
-<translation id="488187801263602086">Badilisha jina la faili</translation>
-<translation id="4882831918239250449">Dhibiti namna historia yako ya kuvinjari inavyotumika kuweka mapendeleo ya Kutafuta matangazo na zaidi</translation>
-<translation id="4883854917563148705">Huwezi kubadilisha mipangilio inayodhibitiwa</translation>
-<translation id="4885273946141277891">Idadi ya matukio ya Chrome isiyoweza kutumika.</translation>
-<translation id="4910889077668685004">Programu za malipo</translation>
-<translation id="4913161338056004800">Weka takwimu upya</translation>
-<translation id="4913169188695071480">Acha kuonyesha upya</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Pata usaidizi<ph name="END_LINK" /> huku ukitafuta vifaa...</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{Ukurasa #}other{Kurasa #}}</translation>
-<translation id="4932247056774066048">Kwa sababu unaondoka katika akaunti inayodhibitiwa na <ph name="DOMAIN_NAME" />, data yako ya Chrome itafutwa kwenye kifaa hiki. Itabaki katika Akaunti yako ya Google.</translation>
-<translation id="4943703118917034429">Uhalisia Pepe</translation>
-<translation id="4943872375798546930">Hakuna matokeo yoyote yaliyopatikana</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> inashiriki skrini yako</translation>
-<translation id="4961107849584082341">Tafsiri ukurasa huu katika lugha yoyote</translation>
-<translation id="4962975101802056554">Batilisha ruhusa zote za kifaa</translation>
-<translation id="4970824347203572753">Hakipatikani mahali ulipo</translation>
-<translation id="497421865427891073">Nenda mbele</translation>
-<translation id="4988210275050210843">Inapakua faili (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Kurasa</translation>
-<translation id="4994033804516042629">Hakuna anwani zilizopatikana</translation>
-<translation id="4996978546172906250">Shiriki kupitia</translation>
-<translation id="5004416275253351869">Vidhibiti vya shughuli za Google</translation>
-<translation id="5005498671520578047">Nakili nenosiri</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> inataka kuunganisha</translation>
-<translation id="5013696553129441713">Hakuna mapendekezo mapya</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Wakati upo katika VR, tovuti hii inaweza kujifunza kuhusu:
- -  sifa zako za mwili, kama vile urefu,
-
-Hakikisha kwamba unaamini tovuti hii kabla ya kuingia katika VR.</translation>
+<translation id="2930742481329940825">Kipengele cha Gusa ili Utafute hutuma neno lililochaguliwa na ukurasa wa sasa kuwa muktadha kwa Tafuta na Brave Software. Unaweza kukizima katika <ph name="BEGIN_LINK"/>Miipangilio<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Ruhusu</translation>
-<translation id="5040262127954254034">Faragha</translation>
-<translation id="5048398596102334565">Ruhusu tovuti zifikie vitambuzi vyako vya mwendo (inapendekezwa)</translation>
-<translation id="5063480226653192405">Matumizi</translation>
-<translation id="5087580092889165836">Ongeza kadi</translation>
-<translation id="5100237604440890931">Imekunjwa - bofya ili upanue.</translation>
-<translation id="510275257476243843">Imesalia saa 1</translation>
-<translation id="5123685120097942451">Kichupo fiche</translation>
-<translation id="5127805178023152808">Usawazishaji umezimwa</translation>
-<translation id="5129038482087801250">Sakinisha programu ya wavuti</translation>
-<translation id="5132942445612118989">Sawazisha historia, manenosiri na mambo yako mengine kwenye vifaa vyote</translation>
-<translation id="5139940364318403933">Pata maelezo ya jinsi ya kutumia Google Drive</translation>
-<translation id="515227803646670480">Futa data iliyohifadhiwa</translation>
-<translation id="5152843274749979095">Hakuna programu zinazotumika zimesakinishwa</translation>
-<translation id="5161254044473106830">Kichwa kinahitajika</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Imeshindwa kupakua 1.}other{Imeshindwa kupakua faili #.}}</translation>
-<translation id="5170568018924773124">Onyesha katika folda</translation>
-<translation id="5184329579814168207">Fungulia katika Chrome</translation>
-<translation id="5193988420012215838">Imenakiliwa kwenye ubao wa kunakili</translation>
-<translation id="5197729504361054390">Anwani unazochagua zitashirikiwa na <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Wasifu wa kazini</translation>
-<translation id="5210286577605176222">Rudi kwenye kichupo cha awali</translation>
-<translation id="5210365745912300556">Funga kichupo</translation>
-<translation id="5224771365102442243">Ina video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> inataka kutafuta vifaa vya Bluetooth vilivyo karibu. Vifaa vifuatavyo vimepatikana:</translation>
-<translation id="5233638681132016545">Kichupo kipya</translation>
-<translation id="526421993248218238">Imeshindwa kupakia ukurasa huu</translation>
-<translation id="5271967389191913893">Kifaa hakiwezi kufungua maudhui yanayopaswa kupakuliwa.</translation>
-<translation id="528192093759286357">Buruta kutoka juu na uguse kitufe cha kurudi nyuma ili uondoke kwenye skrini nzima.</translation>
-<translation id="5292796745632149097">Tuma kwenye</translation>
-<translation id="5300589172476337783">Onyesha</translation>
-<translation id="5301954838959518834">Sawa, nimeelewa</translation>
-<translation id="5304593522240415983">Sehemu hii haiwezi kuwa tupu</translation>
-<translation id="5307446750509046227">Futa hifadhi ya tovuti</translation>
-<translation id="5308380583665731573">Unganisha</translation>
-<translation id="5313967007315987356">Ongeza tovuti</translation>
-<translation id="5317780077021120954">Hifadhi</translation>
-<translation id="5324858694974489420">Mipangilio ya Wazazi</translation>
-<translation id="5327248766486351172">Jina</translation>
-<translation id="5335288049665977812">Ruhusu tovuti zitumie JavaScript (inapendekezwa)</translation>
-<translation id="5342314432463739672">Maombi ya ruhusa</translation>
-<translation id="5357811892247919462">Umepokea kichupo</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{Umefungua kichupo <ph name="OPEN_TABS_ONE" />, gusa ili ubadilishe vichupo}other{Umefungua vichupo <ph name="OPEN_TABS_MANY" />, gusa ili ubadilishe vichupo}}</translation>
-<translation id="5391532827096253100">Muunganisho wako kwenye tovuti hii si salama. Maelezo ya tovuti</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 zaidi)}other{(+ # zaidi)}}</translation>
-<translation id="5400569084694353794">Kwa kutumia programu hii, unakubali <ph name="BEGIN_LINK1" />Sheria na Masharti<ph name="END_LINK1" /> na <ph name="BEGIN_LINK2" />Ilani ya Faragha<ph name="END_LINK2" /> ya Chrome.</translation>
-<translation id="5403592356182871684">Majina</translation>
-<translation id="5403644198645076998">Ruhusu tovuti maalum pekee</translation>
-<translation id="5414836363063783498">Inathibitisha...</translation>
-<translation id="5423934151118863508">Kurasa zako zilizotembelewa sana zitaonekana hapa</translation>
-<translation id="5424588387303617268">GB <ph name="GIGABYTES" /> zinapatikana</translation>
-<translation id="543338862236136125">Badilisha nenosiri</translation>
-<translation id="5433691172869980887">Jina la mtumiaji limenakiliwa</translation>
-<translation id="543509235395288790">Inapakua faili <ph name="COUNT" /> (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Rudi kwenye sehemu ya anwani</translation>
-<translation id="5447201525962359567">Hifadhi yote ya tovuti, ikiwa ni pamoja na vidakuzi na data nyingine iliyohifadhiwa ndani</translation>
-<translation id="5447765697759493033">Tovuti hii haitatafsiriwa</translation>
-<translation id="545042621069398927">Inaongeza kasi ya kupakua faili yako.</translation>
-<translation id="5456381639095306749">Pakua ukurasa</translation>
-<translation id="5475862044948910901">Je, ungependa kuanzisha kipindi cha Uhalisia Ulioboreshwa?</translation>
-<translation id="548278423535722844">Fungua katika programu ya ramani</translation>
-<translation id="5487521232677179737">Futa data</translation>
-<translation id="5494752089476963479">Zuia matangazo kwenye tovuti zinazoonyesha matangazo yanayopotosha au yanayokatiza huduma</translation>
-<translation id="5500777121964041360">Huenda haipatikani mahali uliko</translation>
-<translation id="5512137114520586844">Akaunti hii inadhibitiwa na <ph name="PARENT_NAME" /></translation>
-<translation id="5514904542973294328">Imezimwa na msimamizi wa kifaa hiki</translation>
-<translation id="5515439363601853141">Fungua ili uangalie nenosiri lako</translation>
-<translation id="5516455585884385570">Fungua mipangilio ya arifa</translation>
-<translation id="5517095782334947753">Una alamisho, historia, manenosiri na mipangilio mingine kutoka <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Imezuia shughuli ya kuelekeza kwingine.</translation>
-<translation id="5527082711130173040">Chrome inahitaji idhini ya kufikia mahali ili itafute vifaa. <ph name="BEGIN_LINK1" />Badilisha ruhusa<ph name="END_LINK1" />. Kipengele cha idhini ya kufikia mahali pia <ph name="BEGIN_LINK2" />kimezimwa kwenye kifaa hiki<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Iulize kabla ya kuruhusu tovuti kusoma maandishi na picha kutoka ubao wa kunakili (inapendekezwa)</translation>
-<translation id="5530766185686772672">Funga vichupo fiche</translation>
-<translation id="5534334044554683961">Ukiwa katika VR, tovuti hii inaweza kujifunza kuhusu:
-  -   sifa zako za mwili, kama vile urefu
-  -   muundo wa chumba chako
-Hakikisha kwamba unaamini tovuti hii kabla ya kuingia katika VR.</translation>
-<translation id="5534640966246046842">Tovuti imenakiliwa</translation>
-<translation id="5556459405103347317">Pakia upya</translation>
-<translation id="5561549206367097665">Inasubiri intaneti…</translation>
-<translation id="557283862590186398">Chrome inahitaji ruhusa ya kufikia maikrofoni yako kwa ajili ya tovuti hii.</translation>
-<translation id="55737423895878184">Vipengele vya mahali na arifa vinaruhusiwa</translation>
-<translation id="5578795271662203820">Tafuta picha hii kwenye <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Unaweza kuchagua utakachosawazisha wakati wowote katika <ph name="BEGIN_LINK1" />mipangilio<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Badilisha anwani</translation>
-<translation id="5596627076506792578">Chaguo zaidi</translation>
-<translation id="5599455543593328020">Hali fiche</translation>
-<translation id="5620928963363755975">Tafuta faili na kurasa zako katika Vipakuliwa kwenye kitufe cha Chaguo Nyingine</translation>
-<translation id="5626134646977739690">Jina:</translation>
-<translation id="5639724618331995626">Ruhusu tovuti zote</translation>
-<translation id="5648166631817621825">Siku 7 zilizopita</translation>
-<translation id="5649053991847567735">Vipakuliwa vya kiotomatiki</translation>
-<translation id="5655963694829536461">Tafuta vipakuliwa vyako</translation>
-<translation id="5659593005791499971">Barua pepe</translation>
-<translation id="5665379678064389456">Unda tukio katika <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Batilisha ombi la tovuti ili kuzuia kuvuta karibu</translation>
-<translation id="5677928146339483299">Kumezuiwa</translation>
-<translation id="5684874026226664614">Lo!  Ukurasa huu haukuweza kutafsiriwa.</translation>
-<translation id="5686790454216892815">Jina la faili ni ndefu mno</translation>
-<translation id="5689516760719285838">Mahali</translation>
-<translation id="569536719314091526">Tafsiri ukurasa huu katika lugha yoyote kutoka kitufe cha Chaguo zaidi</translation>
-<translation id="572328651809341494">Vichupo vya hivi majuzi</translation>
-<translation id="5726692708398506830">Fanya kila kitu kwenye ukurasa kiwe kikubwa zaidi</translation>
-<translation id="5748802427693696783">Imebadilisha kwenda vichupo muundo-msingi</translation>
-<translation id="5749068826913805084">Chrome inahitaji idhini ya kufikia hifadhi ili ipakue faili.</translation>
-<translation id="5763382633136178763">Vichupo fiche</translation>
-<translation id="5763514718066511291">Gusa ili unakili URL ya programu hii</translation>
-<translation id="5765780083710877561">Maelezo:</translation>
-<translation id="5793665092639000975">Inatumia <ph name="SPACE_USED" /> kati ya <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google inaweza kutumia historia yako ili kuweka mapendeleo kwenye huduma ya Tafuta na Google, matangazo na huduma nyingine za Google</translation>
-<translation id="5804241973901381774">Idhini</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{Saa # iliyopita}other{Saa # zilizopita}}</translation>
-<translation id="5810288467834065221">Hakimiliki <ph name="YEAR" /> Google LLC. Haki zote zimehifadhiwa.</translation>
-<translation id="5817918615728894473">Oanisha</translation>
-<translation id="583281660410589416">Haijulikani</translation>
-<translation id="5833984609253377421">Shiriki kiungo</translation>
-<translation id="5836192821815272682">Inapakua Sasisho la Chrome…</translation>
-<translation id="5853623416121554550">imesitishwa</translation>
-<translation id="5854790677617711513">Iliyohifadhiwa kwa zaidi ya siku 30</translation>
-<translation id="5858741533101922242">Chrome imeshindwa kuwasha adapta ya Bluetooth</translation>
-<translation id="5860033963881614850">Kimezimwa</translation>
-<translation id="5862731021271217234">Washa kipengele cha usawazishaji ili upate vichupo kutoka kwenye vifaa vyako vingine</translation>
-<translation id="5864174910718532887">Maelezo: Imepangwa kulingana na jina la tovuti</translation>
-<translation id="5864419784173784555">Inasubiri kipakuliwa kingine…</translation>
-<translation id="5865733239029070421">Hutuma kiotomatiki takwimu za matumizi na ripoti za programu kuacha kufanya kazi kwa Google</translation>
-<translation id="5869522115854928033">Manenosiri yaliyohifadhiwa</translation>
-<translation id="5902828464777634901">Data zote za ndani zilizohifadhiwa na tovuti hii, ikiwemo vidakuzi, zitafutwa.</translation>
-<translation id="5916664084637901428">Imewashwa</translation>
-<translation id="5919204609460789179">Sasisha <ph name="PRODUCT_NAME" /> ili uanze kusawazisha</translation>
-<translation id="5937580074298050696">Imeokoa <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Weka upya</translation>
-<translation id="5942872142862698679">Unatumia Google kutafuta</translation>
-<translation id="5952764234151283551">Hutuma URL ya ukurasa unaojaribu kufikia kwa Google</translation>
-<translation id="5956665950594638604">Fungua Kituo cha Usaidizi cha Chrome katika kichupo kipya</translation>
-<translation id="5958275228015807058">Tafuta faili na kurasa zako katika Vipakuliwa</translation>
-<translation id="5962718611393537961">Gusa ili ukunje</translation>
-<translation id="6000066717592683814">Endelea Kutumia Google</translation>
-<translation id="6005538289190791541">Nenosiri linalopendekezwa</translation>
-<translation id="6036057147555329831">ICU ya Ziada</translation>
-<translation id="6039379616847168523">Nenda kwenye kichupo kinachofuata</translation>
-<translation id="6040143037577758943">Funga</translation>
-<translation id="6042308850641462728">Zaidi</translation>
-<translation id="604996488070107836">Kipakuliwa cha <ph name="FILE_NAME" /> hakijafaulu kwa sababu ya hitilafu isiyojulikana.</translation>
-<translation id="605721222689873409">MK</translation>
-<translation id="6064125863973209585">Faili zilizopakuliwa</translation>
-<translation id="6075798973483050474">Badilisha ukurasa wa mwanzo</translation>
-<translation id="60923314841986378">Zimesalia saa <ph name="HOURS" /></translation>
-<translation id="6108923351542677676">Usanidi unaendelea...</translation>
-<translation id="6111020039983847643">data iliyotumiwa</translation>
-<translation id="6112702117600201073">Inaonyesha upya ukurasa</translation>
-<translation id="6127379762771434464">Kipengee kimeondolewa</translation>
-<translation id="6140912465461743537">Nchi/Eneo</translation>
-<translation id="614940544461990577">Jaribu:</translation>
-<translation id="6154478581116148741">Washa kipengele cha kufunga skrini katika Mipangilio ili uhamishe manenosiri yako kutoka kwenye kifaa hiki</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> ya data imeokolewa</translation>
-<translation id="6165508094623778733">Pata maelezo zaidi</translation>
-<translation id="6177111841848151710">Haijaruhusiwa kwa mtambo wa sasa wa kutafuta</translation>
-<translation id="6181444274883918285">Ongeza tovuti mpya kwenye orodha ya vighairi</translation>
-<translation id="6192333916571137726">Pakua faili</translation>
-<translation id="6192792657125177640">Vighairi</translation>
-<translation id="6194112207524046168">Ili uruhusu Chrome ifikie kamera yako, washa kamera pia katika <ph name="BEGIN_LINK" />Mipangilio ya Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Zuia vidakuzi vya tovuti nyingine</translation>
-<translation id="6206551242102657620">Muunganisho ni salama. Maelezo ya tovuti</translation>
-<translation id="6210748933810148297">Wewe si <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Fungua ili uhamishe manenosiri yako</translation>
+<translation id="1406000523432664303">“Usifuatilie”</translation>
 <translation id="6232535412751077445">Kuwasha ‘Usifuatilie’ kunamaanisha kuwa ombi litajumuishwa pamoja na maelezo yako mengine ya kuvinjari. Athari yoyote itategemea ikiwa tovuti inajibu ombi, na namna ombi litakavyofasiriwa.
 
 Kwa mfano, baadhi ya tovuti zinaweza kujibu ombi hili kwa kukuonyesha matangazo ambayo hayalingani na tovuti nyingine ulizotembelea. Tovuti nyingi bado zitakusanya na kutumia data yako ya kuvinjari — kwa mfano ili kuboresha usalama, kutoa maudhui, matangazo na mapendekezo, na kuzalisha takwimu za kuripoti.</translation>
-<translation id="624789221780392884">Sasisho iko tayari</translation>
-<translation id="6255999984061454636">Mapendekezo ya maudhui</translation>
-<translation id="6277522088822131679">Kulikuwa na tatizo katika kuchapisha ukurasa. Tafadhali jaribu tena.</translation>
-<translation id="6295158916970320988">Tovuti zote</translation>
-<translation id="629730747756840877">Akaunti</translation>
-<translation id="6303969859164067831">Ondoka kwenye akaunti na uzime usawazishaji</translation>
-<translation id="6316139424528454185">Haiwezi kutumia toleo la Android</translation>
-<translation id="6320088164292336938">Tetema</translation>
-<translation id="6324034347079777476">Kipengele cha usawazishaji wa mfumo wa Android kimezimwa</translation>
-<translation id="6333140779060797560">Shiriki kupitia <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Usimbaji fiche</translation>
-<translation id="6341580099087024258">Iulize ambapo itahifadhi faili</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> zaidi}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> zaidi}}</translation>
-<translation id="6364438453358674297">Je, ungependa kuondoa pendekezo kwenye historia?</translation>
-<translation id="6369229450655021117">Ukiwa hapa, unaweza kutafuta kwenye wavuti, kushiriki na marafiki na kuona kurasa ambazo zimefunguliwa</translation>
-<translation id="6378173571450987352">Maelezo: Imepangwa kulingana na kiasi cha data inayotumiwa</translation>
-<translation id="6381421346744604172">Fanya tovuti kuwa nyeusi</translation>
-<translation id="6388207532828177975">Futa na uweke upya</translation>
-<translation id="6393863479814692971">Chrome inahitaji ruhusa ya kufikia kamera yako kwa ajili ya tovuti hii.</translation>
-<translation id="6395288395575013217">KIUNGO</translation>
-<translation id="6404511346730675251">Badilisha alamisho</translation>
-<translation id="6406506848690869874">Sawazisha</translation>
-<translation id="641643625718530986">Chapisha...</translation>
-<translation id="6416782512398055893">Umepakua MB <ph name="MBS" /></translation>
-<translation id="6427112570124116297">Tafsiri Wavuti</translation>
-<translation id="6433501201775827830">Chagua mtambo wako wa kutafuta</translation>
-<translation id="6437478888915024427">Maelezo ya ukurasa</translation>
-<translation id="6441734959916820584">Jina ni ndefu mno</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{Picha #}other{Picha #}}</translation>
-<translation id="6447842834002726250">Vidakuzi</translation>
-<translation id="6461962085415701688">Imeshindwa kufungua faili</translation>
-<translation id="6464977750820128603">Unaweza kuona tovuti ambazo ulitembelea katika Chrome na kuziwekea vipima muda.\n\nGoogle inapata maelezo kuhusu tovuti ulizowekea vipima muda na muda unaozitembelea. Tunatumia maelezo haya kuboresha mpango wa Nidhamu Dijitali.</translation>
-<translation id="6475951671322991020">Pakua video</translation>
-<translation id="6482749332252372425">Kipakuliwa cha <ph name="FILE_NAME" /> hakijafaulu kwa sababu hakuna nafasi ya hifadhi ya kutosha.</translation>
-<translation id="6496823230996795692">Ili kutumia <ph name="APP_NAME" /> kwa mara ya kwanza, tafadhali unganisha kwenye intaneti.</translation>
-<translation id="6508722015517270189">Zima na uwashe Chrome</translation>
-<translation id="6527303717912515753">Shiriki</translation>
-<translation id="6532866250404780454">Haitaonyesha tovuti unazotembelea katika Chrome. Itafuta vipima muda vyote kwenye tovuti.</translation>
-<translation id="6534565668554028783">Google imechukua muda mrefu kujibu</translation>
-<translation id="6538442820324228105">Umepakua GB <ph name="GBS" /></translation>
-<translation id="6539092367496845964">Hitilafu fulani imetokea. Jaribu tena baadaye.</translation>
-<translation id="654446541061731451">Chagua kichupo cha kusambaza</translation>
-<translation id="6545017243486555795">Futa Data Yote</translation>
-<translation id="6545864417968258051">Kutafuta Bluetooth</translation>
-<translation id="6560414384669816528">Tafuta kwa kutumia Sogou</translation>
-<translation id="6566259936974865419">Chrome imekuokolea GB <ph name="GIGABYTES" /></translation>
-<translation id="6573096386450695060">Ruhusu kila wakati</translation>
-<translation id="6573431926118603307">Vichupo ulivyofungua katika Chrome kwenye vifaa vyako vingine vitaonekana hapa.</translation>
-<translation id="6583199322650523874">Wekea alamisho kwenye ukurasa uliofungua</translation>
-<translation id="6593061639179217415">Tovuti ya kompyuta ya mezani</translation>
-<translation id="6600954340915313787">Imenakiliwa kwenye Chrome</translation>
-<translation id="6608650720463149374">GB <ph name="GIGABYTES" /></translation>
-<translation id="6612358246767739896">Maudhui yanayolindwa</translation>
-<translation id="6627583120233659107">Badilisha folda</translation>
-<translation id="6643016212128521049">Futa</translation>
-<translation id="6643649862576733715">Panga kulingana na kiasi cha data kilichookolewa</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> zaidi}other{<ph name="CONTACT_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> zaidi}}</translation>
-<translation id="6649642165559792194">Kagua picha kwanza <ph name="BEGIN_NEW" />Mpya<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome inahitaji idhini ya kufikia mahali ili ichanganue vifaa. <ph name="BEGIN_LINK" />Ruhusa za sasisho<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Nenosiri</translation>
-<translation id="6659594942844771486">Kichupo</translation>
-<translation id="666731172850799929">Fungua katika <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Ilani ya Faragha ya Chrome</translation>
-<translation id="6676840375528380067">Ungependa kufuta data yako yote ya Chrome kwenye kifaa hiki?</translation>
-<translation id="6697492270171225480">Onyesha mapendekezo ya kurasa zinazofanana na ukurasa huu wakati haupatikani</translation>
-<translation id="6697947395630195233">Chrome inahitaji kufikia maelezo ya mahali ulipo ili kuyashiriki na tovuti hii.</translation>
-<translation id="6698801883190606802">Dhibiti data iliyosawazishwa</translation>
-<translation id="6699370405921460408">Seva za Google zitaboresha kurasa unazotembelea.</translation>
-<translation id="6706288973712894588">Kwa sasa uko nje ya mtandao.\n<ph name="BEGIN_LINK" />Pitia mipasho yako ya nje ya mtandao.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Habari</translation>
-<translation id="6710213216561001401">Iliyotangulia</translation>
-<translation id="671481426037969117">Kipindi cha kipima muda cha <ph name="FQDN" /> kimeisha. Kitaanza tena kesho.</translation>
-<translation id="6738867403308150051">Inapakua...</translation>
-<translation id="6746124502594467657">Songa chini</translation>
-<translation id="6766622839693428701">Telezesha chini ili ufunge.</translation>
-<translation id="6766758767654711248">Gusa ili uende kwenye tovuti</translation>
-<translation id="6767294960381293877">Orodha ya vifaa vinavyoweza kutumia kichupo pamoja imefunguliwa kwenye nusu ya skrini.</translation>
-<translation id="6782111308708962316">Zuia tovuti nyingine kuhifadhi na kusoma data ya vidakuzi</translation>
-<translation id="6790428901817661496">Cheza</translation>
-<translation id="6811034713472274749">Unaweza kuona ukurasa</translation>
-<translation id="6818926723028410516">Chagua vipengee</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Tafsiri</translation>
-<translation id="6845325883481699275">Tusaidie kuboresha usalama wa Chrome</translation>
-<translation id="6846298663435243399">Inapakia…</translation>
-<translation id="6850409657436465440">Bado inapakua faili</translation>
-<translation id="6850830437481525139">Vichupo <ph name="TAB_COUNT" /> vimefungwa</translation>
-<translation id="6864459304226931083">Pakua picha</translation>
-<translation id="6865313869410766144">Data ya fomu ya Kujaza Kiotomatiki</translation>
-<translation id="688738109438487280">Ongeza data iliyopo kwenye <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Fungua ili unakili nenosiri lako</translation>
-<translation id="6896758677409633944">Nakili</translation>
-<translation id="6910211073230771657">Imeondolewa</translation>
-<translation id="6912998170423641340">Zuia tovuti zisisome maandishi na picha kutoka ubao wa kunakili</translation>
-<translation id="6914783257214138813">Mtu yeyote anayeweza kuona faili uliyohamisha ataona manenosiri yako.</translation>
-<translation id="6942665639005891494">Badilisha sehemu chaguomsingi ya kupakua wakati wowote ukitumia chaguo la menyu ya Mipangilio</translation>
-<translation id="6945221475159498467">Chagua</translation>
-<translation id="6963642900430330478">Ukurasa huu ni hatari. Maelezo ya tovuti</translation>
-<translation id="6963766334940102469">Futa alamisho</translation>
-<translation id="6965382102122355670">Sawa</translation>
-<translation id="6979737339423435258">Wakati wote</translation>
-<translation id="6981982820502123353">Upatikanaji</translation>
-<translation id="6989267951144302301">Imeshindwa kupakua</translation>
-<translation id="6990079615885386641">Pata programu kutoka kwenye Duka la Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Uliza kwanza kabla ya kuruhusu tovuti zitumie maikrofoni yako (inapendekezwa)</translation>
-<translation id="7015203776128479407">Haikukamilisha kuweka usawazishaji wa mipangilio ya kwanza. Umezima kipengele cha kusawazisha.</translation>
-<translation id="7016516562562142042">Imeruhusiwa kwa mtambo wa sasa wa kutafuta</translation>
-<translation id="7022756207310403729">Fungua katika kivinjari</translation>
-<translation id="702463548815491781">Inapendekezwa wakati umewasha TalkBack au kipengele cha Kufikia Kupitia Swichi</translation>
-<translation id="7029809446516969842">Manenosiri</translation>
-<translation id="7053983685419859001">Zuia</translation>
-<translation id="7055152154916055070">Imezuiwa kuelekeza kwingine:</translation>
-<translation id="7063006564040364415">Haikuweza kuunganisha kwenye seva ya usawazishaji.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 imechaguliwa}other{# vimechaguliwa}}</translation>
-<translation id="7071521146534760487">Dhibiti akaunti</translation>
-<translation id="7077143737582773186">Kadi ya SD</translation>
-<translation id="7087918508125750058">Imechagua <ph name="ITEM_COUNT" />. Chaguo zinapatikana karibu na sehemu ya juu ya skrini</translation>
-<translation id="7121362699166175603">Hufuta historia na ukamilishaji kiotomatiki kwenye sehemu ya anwani. Huenda Akaunti yako ya Google ikawa na aina nyingine za historia ya kuvinjari kwenye <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Ruhusu kwa mtambo wa sasa wa kutafuta</translation>
-<translation id="7138678301420049075">Nyingine</translation>
-<translation id="7141896414559753902">Zuia tovuti zisionyeshe madirisha ibukizi na kuelekeza kwingine (inapendekezwa)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Pakia ukurasa halisi<ph name="END_LINK" /> kutoka <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Saa 24 zilizopita</translation>
-<translation id="7176368934862295254">KB <ph name="KILOBYTES" /></translation>
-<translation id="7177466738963138057">Unaweza kubadilisha hii baadaye katika Mipangilio</translation>
-<translation id="7180611975245234373">Onyesha upya</translation>
-<translation id="7189372733857464326">Inasubiri Huduma za Google Play ili kukamilisha kusasisha</translation>
-<translation id="7191430249889272776">Kichupo kimefunguliwa chini chini.</translation>
-<translation id="723171743924126238">Chagua picha</translation>
-<translation id="7233236755231902816">Ili uone tovuti katika lugha unayotumia, pata toleo jipya la Chrome</translation>
-<translation id="7243308994586599757">Chaguo zinapatikana karibu na sehemu ya chini ya skrini</translation>
-<translation id="7248069434667874558">Hakikisha kuwa umewasha kipengele cha usawazishaji katika <ph name="TARGET_DEVICE_NAME" /> kwenye Chrome</translation>
-<translation id="7250468141469952378">Imechagua <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Tovuti imezuiwa</translation>
-<translation id="7290209999329137901">Huwezi kubadilisha jina</translation>
-<translation id="7291387454912369099">Ulipaji Unaoanzishwa na Mratibu</translation>
-<translation id="7293171162284876153">Ili uanze kusawazisha, washa mipangilio ya "Sawazisha data yako kwenye Chrome".</translation>
-<translation id="729975465115245577">Kifaa chako hakina programu ya kuhifadhi faili ya manenosiri.</translation>
-<translation id="7302081693174882195">Maelezo: Imepangwa kulingana na kiasi cha data kilichookolewa</translation>
-<translation id="7328017930301109123">Katika Hali nyepesi, Chrome hupakia kurasa haraka zaidi na huokoa data kwa hadi asilimia 60.</translation>
-<translation id="7333031090786104871">Bado inaongeza tovuti ya awali</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Shiriki kipengee 1 kilichochaguliwa}other{Shiriki vipengee # vilivyochaguliwa}}</translation>
 <translation id="7359002509206457351">Ufikiaji wa njia za kulipa</translation>
+<translation id="8026334261755873520">Futa data ya kuvinjari</translation>
+<translation id="1291207594882862231">Futa historia, vidakuzi, data ya tovuti, akiba…</translation>
+<translation id="7814200940910057384">Data ya Brave imefutwa</translation>
+<translation id="1664855196866195614">Data uliyochagua imeondolewa kwenye Brave na kwenye vifaa vyako vilivyosawazishwa. 
+
+Huenda akaunti yako ya Brave Software ina aina nyingine za historia ya kuvinjari kama vile mambo uliyotafuta na shughuli kutoka huduma nyingine za Brave Software katika <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Picha na faili zilizoakibishwa</translation>
+<translation id="2496180316473517155">Historia ya kuvinjari</translation>
+<translation id="2546283357679194313">Data ya vidakuzi na tovuti</translation>
+<translation id="8662811608048051533">Hukuondoa kwenye tovuti nyingi.</translation>
+<translation id="8218628800671693884">Hukuondoa kwenye akaunti za tovuti nyingi. Hutaondolewa kwenye Akaunti ya Brave Software.</translation>
+<translation id="2017836877785168846">Hufuta historia na ujazaji kiotomatiki katika sehemu ya anwani.</translation>
+<translation id="8096327394278038498">Hufuta historia na ukamilishaji kiotomatiki kwenye sehemu ya anwani. Huenda Akaunti yako ya Brave Software ikawa na aina nyingine za historia ya kuvinjari kwenye <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Hufuta historia kwenye vifaa vyote ulivyotumia kuingia katika akaunti. Huenda Akaunti yako ya Brave Software ikawa na aina nyingine za historia ya kuvinjari kwenye <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Manenosiri yaliyohifadhiwa</translation>
+<translation id="6865313869410766144">Data ya fomu ya Kujaza Kiotomatiki</translation>
+<translation id="7562080006725997899">Inafuta data ya kuvinjari</translation>
+<translation id="5487521232677179737">Futa data</translation>
+<translation id="7498271377022651285">Tafadhali subiri...</translation>
+<translation id="784934925303690534">Muda</translation>
+<translation id="1718835860248848330">Saa iliyopita</translation>
+<translation id="7149893636342594995">Saa 24 zilizopita</translation>
+<translation id="5648166631817621825">Siku 7 zilizopita</translation>
+<translation id="8571213806525832805">Wiki 4 zilizopita</translation>
+<translation id="5854790677617711513">Iliyohifadhiwa kwa zaidi ya siku 30</translation>
+<translation id="6979737339423435258">Wakati wote</translation>
+<translation id="982182592107339124">Hatua hii itafuta data ya tovuti zote, ikiwa ni pamoja na:</translation>
+<translation id="6643016212128521049">Futa</translation>
+<translation id="7641339528570811325">Futa data ya kuvinjari...</translation>
+<translation id="1670399744444387456">Msingi</translation>
+<translation id="3245261285041759672">Huenda Akaunti yako ya Brave Software ikawa na aina nyingine za historia ya kuvinjari kwenye <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Tovuti imezuiwa</translation>
+<translation id="2534155362429831547">Umefuta vipengee <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Ripoti za matumizi na za kuacha kufanya kazi</translation>
+<translation id="9079153198295609735">Tumia Brave Software takwimu za matumizi na ripoti za mara ambazo kivinjari kinaacha kufanya kazi, moja kwa moja</translation>
+<translation id="6981982820502123353">Upatikanaji</translation>
+<translation id="2387895666653383613">Upimaji wa maandishi</translation>
+<translation id="2321958826496381788">Buruta kitelezi hadi uweze kusoma haya kwa starehe. Maandishi yanapaswa kuonekana angalau kwa ukubwa huu baada ya kugonga mara mbili kwenye aya.</translation>
+<translation id="3895926599014793903">Lazimisha kuwasha ukuzaji</translation>
+<translation id="5668404140385795438">Batilisha ombi la tovuti ili kuzuia kuvuta karibu</translation>
+<translation id="4149994727733219643">Mwonekano uliorahisishwa kwa ajili ya kurasa za wavuti</translation>
+<translation id="9100505651305367705">Onyesha makala katika mwonekano rahisi, ikiwa yanatumika</translation>
+<translation id="1409426117486808224">Mwonekano uliorahisishwa kwa ajili ya vichupo vilivyofunguliwa</translation>
+<translation id="702463548815491781">Inapendekezwa wakati umewasha TalkBack au kipengele cha Kufikia Kupitia Swichi</translation>
+<translation id="8284326494547611709">Manukuu</translation>
+<translation id="4165986682804962316">Mipangilio ya tovuti</translation>
+<translation id="6295158916970320988">Tovuti zote</translation>
+<translation id="8380167699614421159">Tovuti hii inaonyesha matangazo yanayopotosha au yanayokatiza huduma</translation>
+<translation id="1919345977826869612">Matangazo</translation>
+<translation id="410351446219883937">Kucheza kiotomatiki</translation>
+<translation id="6447842834002726250">Vidakuzi</translation>
+<translation id="6196640612572343990">Zuia vidakuzi vya tovuti nyingine</translation>
+<translation id="6782111308708962316">Zuia tovuti nyingine kuhifadhi na kusoma data ya vidakuzi</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Madirisha ibukizi/kuelekeza kwingine</translation>
+<translation id="4751476147751820511">Vitambuzi vya mwendo au mwangaza</translation>
+<translation id="1717218214683051432">Vitambuzi vya mwendo</translation>
+<translation id="2091887806945687916">Sauti</translation>
+<translation id="2586657967955657006">Ubao wa kunakili</translation>
+<translation id="6320088164292336938">Tetema</translation>
+<translation id="4226663524361240545">Arifa huenda zitatetemesha kifaa</translation>
+<translation id="1446450296470737166">Ruhusu udhibiti kamili wa vifaa vya MIDI</translation>
+<translation id="3744111561329211289">Usawazishaji wa chini chini</translation>
+<translation id="5649053991847567735">Vipakuliwa vya kiotomatiki</translation>
+<translation id="6181444274883918285">Ongeza tovuti mpya kwenye orodha ya vighairi</translation>
+<translation id="5313967007315987356">Ongeza tovuti</translation>
+<translation id="1369915414381695676">Tovuti <ph name="SITE_NAME"/> imeongezwa</translation>
+<translation id="7837721118676387834">Ruhusu uchezaji wa video kiotomatiki bila sauti kwenye tovuti mahususi.</translation>
+<translation id="2621115761605608342">Ruhusu JavaScript ya tovuti mahususi.</translation>
+<translation id="8801436777607969138">Zuia JavaScript katika tovuti mahususi.</translation>
+<translation id="8372893542064058268">Ruhusu Usawazishaji wa Chini Chini wa tovuti mahususi.</translation>
+<translation id="358794129225322306">Ruhusu tovuti ipakue faili nyingi kiotomatiki.</translation>
+<translation id="4008040567710660924">Ruhusu vidakuzi katika tovuti maalum.</translation>
+<translation id="8958424370300090006">Zuia vidakuzi katika tovuti maalum.</translation>
+<translation id="7882806643839505685">Ruhusu sauti katika tovuti mahususi.</translation>
+<translation id="4468959413250150279">Zima sauti katika tovuti mahususi.</translation>
+<translation id="1994173015038366702">URL ya Tovuti</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Matumizi</translation>
+<translation id="5804241973901381774">Idhini</translation>
+<translation id="4278390842282768270">Imeruhusiwa</translation>
+<translation id="5677928146339483299">Kumezuiwa</translation>
+<translation id="1984937141057606926">Inaruhusiwa, isipokuwa vidakuzi vingine</translation>
+<translation id="7423098979219808738">Uliza kwanza</translation>
+<translation id="8116925261070264013">Imezimwa</translation>
+<translation id="8300705686683892304">Zinazodhibitiwa na programu</translation>
+<translation id="6192792657125177640">Vighairi</translation>
+<translation id="257931822824936280">Imepanuliwa - bofya ili ukunje.</translation>
+<translation id="5100237604440890931">Imekunjwa - bofya ili upanue.</translation>
+<translation id="857943718398505171">Imeruhusiwa (inapendekezwa)</translation>
+<translation id="2913331724188855103">Ruhusu tovuti zihifadhi na kusoma data ya vidakuzi (imependekezwa)</translation>
+<translation id="7445411102860286510">Ruhusu tovuti zicheze video kiotomatiki bila sauti (inapendekezwa)</translation>
+<translation id="5335288049665977812">Ruhusu tovuti zitumie JavaScript (inapendekezwa)</translation>
+<translation id="5527111080432883924">Iulize kabla ya kuruhusu tovuti kusoma maandishi na picha kutoka ubao wa kunakili (inapendekezwa)</translation>
+<translation id="6912998170423641340">Zuia tovuti zisisome maandishi na picha kutoka ubao wa kunakili</translation>
+<translation id="7423538860840206698">Imezuiwa kusoma ubao wa kunakili</translation>
+<translation id="3955193568934677022">Ruhusu tovuti zicheze maudhui yanayolindwa (inapendekezwa)</translation>
+<translation id="445467742685312942">Ruhusu tovuti icheze maudhui yanayolindwa</translation>
+<translation id="2107397443965016585">Iulize kabla ya kuruhusu tovuti kucheza maudhui yanayolindwa (inapendekezwa)</translation>
+<translation id="2910701580606108292">Iulize kabla ya kuruhusu tovuti kucheza maudhui yanayolindwa</translation>
+<translation id="757524316907819857">Zuia tovuti zisicheze maudhui yanayolindwa</translation>
+<translation id="3277252321222022663">Ruhusu tovuti zifikie vitambuzi (inapendekezwa)</translation>
+<translation id="5048398596102334565">Ruhusu tovuti zifikie vitambuzi vyako vya mwendo (inapendekezwa)</translation>
+<translation id="8816026460808729765">Zuia tovuti zisifikie vitambuzi vya mwendo</translation>
+<translation id="169515064810179024">Zuia tovuti zisifikie vitambuzi vya mwendo</translation>
+<translation id="1660204651932907780">Ruhusu tovuti kucheza sauti (inapendekezwa)</translation>
+<translation id="3600792891314830896">Zima sauti katika tovuti</translation>
+<translation id="1743802530341753419">Iulize kabla ya kuruhusu tovuti ziunganishe kwenye kifaa (inapendekezwa)</translation>
+<translation id="851751545965956758">Zuia tovuti zisiunganishe kwenye vifaa</translation>
+<translation id="7141896414559753902">Zuia tovuti zisionyeshe madirisha ibukizi na kuelekeza kwingine (inapendekezwa)</translation>
+<translation id="5494752089476963479">Zuia matangazo kwenye tovuti zinazoonyesha matangazo yanayopotosha au yanayokatiza huduma</translation>
+<translation id="3123473560110926937">Yamezuiwa kwenye baadhi ya tovuti</translation>
+<translation id="965817943346481315">Zuia ikiwa tovuti inaonyesha matangazo yanayopotosha au yanayokatiza huduma (inapendekezwa)</translation>
+<translation id="3386292677130313581">Uliza kabla ya kuruhusu tovuti zijue mahali ulipo (inapendekezwa)</translation>
+<translation id="9139068048179869749">Uliza kabla ya kuruhusu tovuti zitume arifa (inapendekezwa)</translation>
+<translation id="4479647676395637221">Uliza kwanza kabla ya kuruhusu tovuti zitumie kamera yako (inapendekezwa)</translation>
+<translation id="6992289844737586249">Uliza kwanza kabla ya kuruhusu tovuti zitumie maikrofoni yako (inapendekezwa)</translation>
+<translation id="2289270750774289114">Niulize wakati tovuti inataka kugundua vifaa vya Bluetooth vilivyo karibu (inapendekezwa)</translation>
+<translation id="7053983685419859001">Zuia</translation>
+<translation id="7128222689758636196">Ruhusu kwa mtambo wa sasa wa kutafuta</translation>
+<translation id="7589445247086920869">Zuia kwa mtambo wa sasa wa kutafuta</translation>
+<translation id="6388207532828177975">Futa na uweke upya</translation>
+<translation id="7999064672810608036">Una uhakika unataka kufuta data zote za ndani, ikiwemo vidakuzi, na kuweka upya ruhusa za tovuti hii?</translation>
+<translation id="2822354292072154809">Una uhakika ungependa kubadilisha ruhusa zote za tovuti ya <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Futa data iliyohifadhiwa</translation>
+<translation id="5902828464777634901">Data zote za ndani zilizohifadhiwa na tovuti hii, ikiwemo vidakuzi, zitafutwa.</translation>
+<translation id="119944043368869598">Ondoa vyote</translation>
+<translation id="2490684707762498678">Inasimamiwa na <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Fungua mipangilio ya arifa</translation>
+<translation id="1404122904123200417">Imepachikwa katika <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Faili zinazohifadhiwa na tovuti huonekana hapa</translation>
+<translation id="4181841719683918333">Lugha</translation>
+<translation id="2647434099613338025">Ongeza lugha</translation>
+<translation id="1952172573699511566">Tovuti zitaonyesha maandishi katika lugha unayopendelea, panapowezekana.</translation>
+<translation id="8559990750235505898">Jitolee kutafsiri kurasa katika lugha zingine</translation>
+<translation id="4719927025381752090">Jitolee kutafsiri</translation>
+<translation id="8156139159503939589">Unaweza kusoma katika lugha gani?</translation>
+<translation id="5689516760719285838">Mahali</translation>
+<translation id="2440823041667407902">Ufikiaji wa eneo</translation>
+<translation id="2023546461831060654">Washa ruhusa za Brave katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Washa ruhusa ya Brave katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Ili uruhusu Brave kufikia mahali ulipo, washa pia huduma ya mahali katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Ili uruhusu Brave ifikie kamera yako, washa kamera pia katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Ili uruhusu Brave ikutumie arifa, washa arifa pia katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Ili uruhusu Brave ifikie maikrofoni yako, washa maikrofoni pia katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Kipengele cha mahali kimezimwa kwenye kifaa hiki. Kiwashe katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Kipengele cha mahali pia kimezimwa kwenye kifaa hiki. Kiwashe katika <ph name="BEGIN_LINK"/>Mipangilio ya Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Maikrofoni</translation>
+<translation id="1647391597548383849">Kufikia kamera yako</translation>
+<translation id="945632385593298557">Kufikia maikrofoni yako</translation>
+<translation id="6612358246767739896">Maudhui yanayolindwa</translation>
+<translation id="885701979325669005">Hifadhi</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> za data iliyohifadhiwa</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Batilisha ruhusa ya kifaa</translation>
+<translation id="4962975101802056554">Batilisha ruhusa zote za kifaa</translation>
+<translation id="6545864417968258051">Kutafuta Bluetooth</translation>
+<translation id="4411535500181276704">Hali nyepesi</translation>
+<translation id="7821588508402923572">Data unayookoa itaonekana hapa</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> imeokolewa</translation>
+<translation id="8569404424186215731">tangu <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Katika Hali nyepesi, Brave hupakia kurasa haraka zaidi na huokoa data kwa hadi asilimia 60.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> ya data imeokolewa</translation>
+<translation id="7494974237137038751">data iliyookolewa</translation>
+<translation id="6111020039983847643">data iliyotumiwa</translation>
+<translation id="7413229368719586778">Tarehe ya kuanza <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Tarehe ya mwisho <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Panga kulingana na tovuti</translation>
+<translation id="5864174910718532887">Maelezo: Imepangwa kulingana na jina la tovuti</translation>
+<translation id="116280672541001035">Imetumika</translation>
+<translation id="8349013245300336738">Panga kulingana na kiasi cha data kilichotumika</translation>
+<translation id="6378173571450987352">Maelezo: Imepangwa kulingana na kiasi cha data inayotumiwa</translation>
+<translation id="2631006050119455616">Iliyookolewa</translation>
+<translation id="6643649862576733715">Panga kulingana na kiasi cha data kilichookolewa</translation>
+<translation id="7302081693174882195">Maelezo: Imepangwa kulingana na kiasi cha data kilichookolewa</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> imetumika</translation>
+<translation id="5937580074298050696">Imeokoa <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Tovuti zilizosalia (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Nyingine</translation>
+<translation id="4913161338056004800">Weka takwimu upya</translation>
+<translation id="1856325424225101786">Je, ungependa kubadilisha mipangilio ya Hali nyepesi?</translation>
+<translation id="3658159451045945436">Hatua ya kuweka upya hufuta historia ya uokoaji wa data, ikiwa ni pamoja na orodha ya tovuti unazotembelea.</translation>
+<translation id="3295530008794733555">Vinjari haraka. Tumia data chache.</translation>
+<translation id="7340390500800578919">Katika Hali Nyepesi, Brave hupakia kurasa haraka zaidi na huokoa hadi asilimia 60 ya data. Ili kuboresha kurasa unazotembelea, Brave hutumia Brave Software data ya tovuti unazotembelea. <ph name="BEGIN_LINK"/>Pata maelezo zaidi<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Washa Hali nyepesi</translation>
+<translation id="4493497663118223949">Umewasha Hali nyepesi</translation>
+<translation id="7559975015014302720">Umezima hali nyepesi</translation>
+<translation id="7606077192958116810">Umewasha Hali nyepesi. Idhibiti katika Mipangilio.</translation>
+<translation id="4714588616299687897">Okoa hadi asilimia 60 ya data yako</translation>
+<translation id="1006927014032731288">Seva za Brave Software zitaboresha kurasa unazotembelea.</translation>
+<translation id="3257320067425202300">Brave imekuokolea MB <ph name="MEGABYTES"/></translation>
+<translation id="5813223329348543512">Brave imekuokolea GB <ph name="GIGABYTES"/></translation>
+<translation id="8266862848225348053">Sehemu ya kuweka vipakuliwa</translation>
+<translation id="7077143737582773186">Kadi ya SD</translation>
+<translation id="7762668264895820836">Kadi ya SD ya <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Iulize ambapo itahifadhi faili</translation>
+<translation id="6192333916571137726">Pakua faili</translation>
+<translation id="1672586136351118594">Usionyeshe tena</translation>
+<translation id="2650751991977523696">Ungependa kupakua faili tena?</translation>
+<translation id="8664979001105139458">Jina la faili tayari lipo</translation>
+<translation id="488187801263602086">Badilisha jina la faili</translation>
+<translation id="5686790454216892815">Jina la faili ni ndefu mno</translation>
+<translation id="7454641608352164238">Nafasi haitoshi</translation>
+<translation id="8972098258593396643">Ungependa kupakua kwenye folda chaguomsingi?</translation>
+<translation id="804335162455518893">Kadi ya SD haikupatikana</translation>
+<translation id="7475688122056506577">SD haikupatikana. Huenda baadhi ya faili zako zinazokosekana.</translation>
+<translation id="4198423547019359126">Hakuna maeneno ya upakuaji</translation>
+<translation id="8224471946457685718">Ipakue makala unayopendekezewa kwenye Wi-Fi</translation>
+<translation id="4970824347203572753">Hakipatikani mahali ulipo</translation>
+<translation id="5500777121964041360">Huenda haipatikani mahali uliko</translation>
+<translation id="1173894706177603556">Ipe jina jipya</translation>
+<translation id="1986685561493779662">Jina tayari lipo</translation>
+<translation id="6441734959916820584">Jina ni ndefu mno</translation>
+<translation id="2923908459366352541">Jina si sahihi</translation>
+<translation id="7290209999329137901">Huwezi kubadilisha jina</translation>
+<translation id="3334729583274622784">Ungependa kubadilisha kiendelezi cha faili?</translation>
+<translation id="107147699690128016">Ukibadilisha kiendelezi cha faili, faili inaweza kufunguka katika programu tofauti na huenda ikawa hatari kwa kifaa chako.</translation>
+<translation id="8541922081612557424">Kuhusu Brave</translation>
+<translation id="5311273890481188673">Hakimiliki <ph name="YEAR"/> Brave Software LLC. Haki zote zimehifadhiwa.</translation>
+<translation id="1416550906796893042">Toleo la programu</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Ilisasishwa <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Mfumo wa uendeshaji</translation>
+<translation id="3968054912784331254">Masasisho ya Brave hayatumiki tena kwa toleo hili la Android</translation>
+<translation id="7665369617277396874">Ongeza akaunti</translation>
+<translation id="649070405679044769">Umeingia katika akaunti ya Brave Software ukitumia</translation>
+<translation id="6234515504547364178">Ondoka kwenye Brave</translation>
+<translation id="5324858694974489420">Mipangilio ya Wazazi</translation>
+<translation id="8920114477895755567">Tunasubiri maelezo ya wazazi.</translation>
+<translation id="5512137114520586844">Akaunti hii inadhibitiwa na <ph name="PARENT_NAME"/></translation>
+<translation id="2956410042958133412">Akaunti hii inadhibitiwa na <ph name="PARENT_NAME_1"/> na <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Maudhui</translation>
+<translation id="5403644198645076998">Ruhusu tovuti maalum pekee</translation>
+<translation id="8641930654639604085">Jaribu kuzuia tovuti zilizo na maudhui ya watu wazima</translation>
+<translation id="5639724618331995626">Ruhusu tovuti zote</translation>
+<translation id="796823723482603597">Unaendeshwa na Brave</translation>
+<translation id="6324034347079777476">Kipengele cha usawazishaji wa mfumo wa Android kimezimwa</translation>
+<translation id="5127805178023152808">Usawazishaji umezimwa</translation>
+<translation id="7015203776128479407">Haikukamilisha kuweka usawazishaji wa mipangilio ya kwanza. Umezima kipengele cha kusawazisha.</translation>
+<translation id="2497852260688568942">Usawazishaji umezimwa na msimamizi wako</translation>
+<translation id="9100610230175265781">Kaulisiri inahitajika</translation>
+<translation id="6108923351542677676">Usanidi unaendelea...</translation>
+<translation id="4062305924942672200">Maelezo ya kisheria</translation>
+<translation id="4256782883801055595">Leseni za programu huria</translation>
+<translation id="1138681184697033370">Sheria na Masharti ya Brave</translation>
+<translation id="7392539049993970338">Ilani ya Faragha ya Brave</translation>
+<translation id="2677748264148917807">Ondoka</translation>
+<translation id="5556459405103347317">Pakia upya</translation>
+<translation id="1623104350909869708">Zuia ukurasa huu usiunde vidadisi zaidi</translation>
+<translation id="2968755619301702150">Kitazamaji vyeti</translation>
+<translation id="1360432990279830238">Utaondoka na uzime usawazishaji?</translation>
+<translation id="8581481290581777242">Ungependa kufuta data yako yote ya Brave kwenye kifaa hiki?</translation>
+<translation id="1318865768845061710">Alamisho, historia, manenosiri na data yako nyingine ya Brave hazitasawazishwa tena kwenye Akaunti yako ya Brave Software</translation>
+<translation id="3325020657155065477">Pia, futa data yako ya Brave kwenye kifaa hiki</translation>
+<translation id="6136448902816743006">Kwa sababu unaondoka katika akaunti inayodhibitiwa na <ph name="DOMAIN_NAME"/>, data yako ya Brave itafutwa kwenye kifaa hiki. Itabaki katika Akaunti yako ya Brave Software.</translation>
+<translation id="1853026300647876496">Inawasiliana na Brave Software. Huenda ikachukua dakika moja…</translation>
+<translation id="2328985652426384049">Imeshindwa kuingia katika akaunti</translation>
+<translation id="7723158744459952869">Brave Software imechukua muda mrefu kujibu</translation>
+<translation id="4572422548854449519">Ingia katika akaunti zinazodhibitiwa</translation>
+<translation id="2689656545739939160">Unaingia kwa kutumia akaunti inayodhibitiwa na <ph name="MANAGED_DOMAIN"/> na kumpa msimamizi wa kikoa hicho udhibiti wa data yako ya Brave. Data yako ya Brave itahusishwa na akaunti hii daima. Kuondoka kwenye Brave kutafuta data yako kwenye kifaa hiki, lakini itaendelea kuhifadhiwa katika Akaunti yako ya Brave Software.</translation>
+<translation id="1749561566933687563">Sawazisha alamisho zako</translation>
+<translation id="4242533952199664413">Fungua mipangilio</translation>
+<translation id="1111673857033749125">Alamisho zilizohifadhiwa katika vifaa vyako vingine zitaonekana hapa.</translation>
+<translation id="8636825310635137004">Ili upate vichupo kutoka kwenye vifaa vyako vingine, washa kipengele cha usawazishaji.</translation>
+<translation id="3269956123044984603">Ili upate vichupo vyako kutoka kwenye vifaa vyako vingine, washa kipengele cha "Kusawazisha data kiotomatiki" katika mipangilio ya akaunti ya Android.</translation>
+<translation id="5157964048453367290">Vichupo ulivyofungua katika Brave kwenye vifaa vyako vingine vitaonekana hapa.</translation>
+<translation id="4684427112815847243">Sawazisha kila kitu</translation>
+<translation id="2709516037105925701">Kujaza Kiotomatiki</translation>
+<translation id="8820817407110198400">Alamisho</translation>
+<translation id="1644574205037202324">Historia</translation>
+<translation id="17513872634828108">Vichupo vilivyo wazi</translation>
+<translation id="1320169905922104972">Kadi za mikopo na anwani zinazotumia Brave Software Pay</translation>
+<translation id="6337234675334993532">Usimbaji fiche</translation>
+<translation id="6698801883190606802">Dhibiti data iliyosawazishwa</translation>
+<translation id="3598578758776312506">Simba kwa njia fiche manenosiri ukitumia kitambulisho cha Brave Software</translation>
+<translation id="7810580217418711046">Simba data iliyosawazishwa kwa njia fiche ukitumia nenosiri la Brave Software lililokuwepo <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Simba data iliyosawazishwa kwa njia fiche ukitumia kauli yako ya siri ya usawazishaji</translation>
+<translation id="2996291259634659425">Unda kauli ya siri</translation>
+<translation id="5713644099811900409">Akaunti ya Brave Software</translation>
+<translation id="8997474919031554666">Usimbaji fiche kwa kutumia kauli ya siri haujumuishi njia za kulipa na anwani kutoka Brave Software Pay. Mtu aliye na kauli yako ya siri pekee ndiye anayeweza kusoma data yako iliyosimbwa kwa njia fiche. Kauli ya siri haitumwi kwa au kuhifadhiwa na Brave Software. Ukisahau kauli yako ya siri au utake kubadilisha mipangilio hii, utahitaji kufanya usawazishaji upya. <ph name="BEGIN_LINK"/>Pata maelezo zaidi<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Kaulisiri</translation>
+<translation id="7772032839648071052">Thibitisha kaulisiri</translation>
+<translation id="5304593522240415983">Sehemu hii haiwezi kuwa tupu</translation>
+<translation id="321773570071367578">Ikiwa umesahau kauli yako ya siri au ungependa kubadilisha mipangilio hii, <ph name="BEGIN_LINK"/>fanya usawazishaji upya<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Kaulisiri hazilingani</translation>
+<translation id="5149495116300586333">Usimbaji fiche kwa kutumia kauli ya siri haujumuishi njia za kulipa na anwani kutoka Brave Software Pay.
+
+Ili ubadilishe mipangilio hii, <ph name="BEGIN_LINK"/>fanya usawazishaji upya<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Kaulisiri si sahihi</translation>
+<translation id="5414836363063783498">Inathibitisha...</translation>
+<translation id="6846298663435243399">Inapakia…</translation>
+<translation id="5517095782334947753">Una alamisho, historia, manenosiri na mipangilio mingine kutoka <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Unganisha data yangu</translation>
+<translation id="688738109438487280">Ongeza data iliyopo kwenye <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Weka data yangu katika sehemu tofauti</translation>
+<translation id="1145536944570833626">Futa data iliyopo.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> inataka kuoanisha</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Pata usaidizi<ph name="END_LINK"/> huku ukitafuta vifaa...</translation>
+<translation id="5817918615728894473">Oanisha</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Pata usaidizi<ph name="END_LINK1"/> au <ph name="BEGIN_LINK2"/>tafuta tena<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Haikupata vifaa vyovyote vinavyooana</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Washa Bluetooth<ph name="END_LINK"/> ili uruhusu kuoanisha</translation>
+<translation id="998321811308652668">Brave imeshindwa kuwasha adapta ya Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Pata usaidizi<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave inahitaji idhini ya kufikia mahali ili ichanganue vifaa. <ph name="BEGIN_LINK"/>Ruhusa za sasisho<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave inahitaji idhini ya kufikia mahali ili itafute vifaa. Kipengele cha kufikia mahali <ph name="BEGIN_LINK"/>kimezimwa kwenye kifaa hiki<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave inahitaji idhini ya kufikia mahali ili itafute vifaa. <ph name="BEGIN_LINK1"/>Badilisha ruhusa<ph name="END_LINK1"/>. Kipengele cha idhini ya kufikia mahali pia <ph name="BEGIN_LINK2"/>kimezimwa kwenye kifaa hiki<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Kifaa Kilichounganishwa</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Kiwango cha Udhibiti wa Mawimbi: upau #}other{Kiwango cha Udhibiti wa Mawimbi: pau #}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> inataka kutafuta vifaa vya Bluetooth vilivyo karibu. Vifaa vifuatavyo vimepatikana:</translation>
+<translation id="8368027906805972958">Kifaa kisichojulikana au kisichotumika (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Kipengele cha usawazishaji hakifanyi kazi</translation>
+<translation id="1810845389119482123">Haijakamilisha Kuweka mipangilio ya mwanzo ya usawazishaji</translation>
+<translation id="3235722914093408050">Fungua mipangilio ya Android na uwashe upya usawazishaji wa mfumo wa Android ili uanze usawazishaji wa Brave</translation>
+<translation id="3367813778245106622">Ingia tena katika akaunti ili uanze kusawazisha</translation>
+<translation id="974555521953189084">Andika kauli yako ya siri ili uanze kusawazisha</translation>
+<translation id="2997266899014181325">Ili uanze kusawazisha, washa mipangilio ya "Sawazisha data yako kwenye Brave".</translation>
+<translation id="8260126382462817229">Jaribu kuingia katika akaunti tena</translation>
+<translation id="5919204609460789179">Sasisha <ph name="PRODUCT_NAME"/> ili uanze kusawazisha</translation>
+<translation id="397583555483684758">Usawazishaji umeacha kufanya kazi</translation>
+<translation id="1966710179511230534">Tafadhali sasisha maelezo yako ya kuingia katika akaunti.</translation>
+<translation id="7063006564040364415">Haikuweza kuunganisha kwenye seva ya usawazishaji.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> imepitwa na wakati.</translation>
+<translation id="4170011742729630528">Huduma haipatikani; jaribu tena baadaye.</translation>
+<translation id="7947953824732555851">Kubali na uingie</translation>
+<translation id="8583805026567836021">Inafuta data ya akaunti</translation>
+<translation id="8310344678080805313">Vichupo muundo-msingi</translation>
+<translation id="5748802427693696783">Imebadilisha kwenda vichupo muundo-msingi</translation>
+<translation id="7998918019931843664">Fungua tena kichupo kilichofungwa</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, kichupo</translation>
+<translation id="4452411734226507615">Funga kichupo cha <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Chaguo zinapatikana karibu na sehemu ya chini ya skrini</translation>
+<translation id="4060598801229743805">Chaguo zinapatikana karibu na sehemu ya juu ya skrini</translation>
+<translation id="2810645512293415242">Ukurasa umerahisishwa ili uokoe data na upakie haraka zaidi.</translation>
+<translation id="3985215325736559418">Je, ungependa kupakua <ph name="FILE_NAME"/> tena?</translation>
+<translation id="2450083983707403292">Je, unataka kuanza kupakua <ph name="FILE_NAME"/> tena?</translation>
+<translation id="7514365320538308">Pakua</translation>
+<translation id="545042621069398927">Inaongeza kasi ya kupakua faili yako.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Inapakua faili.}other{Inapakua faili #.}}</translation>
+<translation id="543509235395288790">Inapakua faili <ph name="COUNT"/> (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Inapakua faili (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Imemaliza kupakua faili 1.}other{Imemaliza kupakua faili #.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Imeshindwa kupakua 1.}other{Imeshindwa kupakua faili #.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Inasubiri kupakua faili 1.}other{Inasubiri kupakua faili #.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Kitufe cha <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Inakaribia kumaliza!</translation>
+<translation id="3960299545138990065">Zima na uwashe Brave</translation>
+<translation id="3771001275138982843">Imeshindwa kupakua sasisho</translation>
+<translation id="3888648114124182147">Inapakua Sasisho la Brave…</translation>
+<translation id="1705567146636171298">Sasisha Brave</translation>
+<translation id="6195417478702700398">Ili upate hali bora zaidi ya kuvinjari, fungua na usasishe Brave</translation>
+<translation id="3512968675351418494">Ili uone tovuti katika lugha unayotumia, pata toleo jipya la Brave</translation>
+<translation id="6427112570124116297">Tafsiri Wavuti</translation>
+<translation id="1379423114029199501">Sasisha ili upate lugha yako katika toleo jipya zaidi la Brave</translation>
+<translation id="5684874026226664614">Lo!  Ukurasa huu haukuweza kutafsiriwa.</translation>
+<translation id="6831043979455480757">Tafsiri</translation>
+<translation id="1285320974508926690">Kamwe usitafsiri tovuti hii</translation>
+<translation id="773466115871691567">Zitafsiri kurasa katika <ph name="SOURCE_LANGUAGE"/> wakati wote</translation>
+<translation id="1068672505746868501">Usiwahi kutafsiri kurasa katika lugha ya <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Lugha zaidi</translation>
+<translation id="290376772003165898">Je, ukurasa huu haupo katika <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Kurasa za <ph name="SOURCE_LANGUAGE"/> zitatafsiriwa katika <ph name="TARGET_LANGUAGE"/> kuanzia sasa</translation>
+<translation id="8339163506404995330">Kurasa za <ph name="LANGUAGE"/> hazitatafsiriwa</translation>
+<translation id="5447765697759493033">Tovuti hii haitatafsiriwa</translation>
+<translation id="4880127995492972015">Tafsiri…</translation>
+<translation id="641643625718530986">Chapisha...</translation>
+<translation id="8909135823018751308">Shiriki...</translation>
+<translation id="4996978546172906250">Shiriki kupitia</translation>
+<translation id="6333140779060797560">Shiriki kupitia <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Kulikuwa na tatizo katika kuchapisha ukurasa. Tafadhali jaribu tena.</translation>
+<translation id="3254409185687681395">Alamisha ukurasa huu</translation>
+<translation id="497421865427891073">Nenda mbele</translation>
+<translation id="813082847718468539">Angalia maelezo ya tovuti</translation>
+<translation id="2532336938189706096">Mwonekano wa Wavuti</translation>
+<translation id="6005538289190791541">Nenosiri linalopendekezwa</translation>
+<translation id="4634124774493850572">Tumia nenosiri</translation>
+<translation id="8285489906452138776">Ruhusu Brave ifikie kamera yako ya tovuti hii.</translation>
+<translation id="320189792589364011">Brave inahitaji ruhusa ya kufikia maikrofoni yako kwa ajili ya tovuti hii.</translation>
+<translation id="7988136689212463100">Brave inahitaji ruhusa ya kufikia kamera yako kwa ajili ya tovuti hii.</translation>
+<translation id="4931190655840828017">Brave inahitaji kufikia maelezo ya mahali ulipo ili kuyashiriki na tovuti hii.</translation>
+<translation id="3088191967551450609">Brave inahitaji idhini ya kufikia hifadhi ili ipakue faili.</translation>
+<translation id="8942627711005830162">Fungua katika dirisha jingine</translation>
+<translation id="4195643157523330669">Fungua katika kichupo kipya</translation>
+<translation id="1100066534610197918">Fungua katika kichupo kipya cha kikundi</translation>
+<translation id="4860895144060829044">Piga simu</translation>
+<translation id="6896758677409633944">Nakili</translation>
+<translation id="8393700583063109961">Tuma ujumbe</translation>
+<translation id="3557336313807607643">Ongeza kwenye anwani</translation>
+<translation id="4269820728363426813">Nakili anwani ya kiungo</translation>
+<translation id="1206892813135768548">Nakili maandishi ya kiungo</translation>
+<translation id="1204037785786432551">Kiungo cha kupakua</translation>
+<translation id="6864459304226931083">Pakua picha</translation>
+<translation id="8209050860603202033">Fungua picha</translation>
+<translation id="8073388330009372546">Fungua picha katika kichupo kipya</translation>
+<translation id="6649642165559792194">Kagua picha kwanza <ph name="BEGIN_NEW"/>Mpya<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Pakia picha</translation>
+<translation id="3845332215609790146">Tafuta na Lenzi ya Brave Software <ph name="BEGIN_NEW"/>Mpya<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Tafuta picha hii kwenye <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Shiriki picha</translation>
+<translation id="5833984609253377421">Shiriki kiungo</translation>
+<translation id="6475951671322991020">Pakua video</translation>
+<translation id="2317945146070194624">Fungua katika kichupo kipya cha Brave</translation>
+<translation id="7975379999046275268">Kagua ukurasa kwanza <ph name="BEGIN_NEW"/>Mpya<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Inaonyesha upya ukurasa</translation>
+<translation id="36525718899759834">Pata programu kutoka kwenye Duka la Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Giza</translation>
+<translation id="1807246157184219062">Mwangaza</translation>
+<translation id="4056223980640387499">Sepia</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Nafasi moja</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Chagua kichupo cha kusambaza</translation>
+<translation id="8719023831149562936">Haiwezi kusambaza kichupo cha sasa</translation>
+<translation id="2139186145475833000">Ongeza kwenye skrini ya kwanza</translation>
+<translation id="4616150815774728855">Fungua <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Imeshindwa kufungua programu</translation>
+<translation id="5129038482087801250">Sakinisha programu ya wavuti</translation>
+<translation id="3789841737615482174">Sakinisha</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> iliongezwa kwenye Skrini yako ya kwanza</translation>
+<translation id="7333031090786104871">Bado inaongeza tovuti ya awali</translation>
+<translation id="1036727731225946849">Inaongeza <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Imeongezwa kwenye Skrini ya Kwanza</translation>
+<translation id="2146738493024040262">Fungua Programu Inayofunguka Papo Hapo</translation>
+<translation id="7016516562562142042">Imeruhusiwa kwa mtambo wa sasa wa kutafuta</translation>
+<translation id="6177111841848151710">Haijaruhusiwa kwa mtambo wa sasa wa kutafuta</translation>
+<translation id="145097072038377568">Imezimwa katika Mipangilio ya Android</translation>
+<translation id="8007176423574883786">Imezimwa kwa kifaa hiki</translation>
+<translation id="164269334534774161">Hii ni nakala ya nje ya mtandao ya ukurasa huu ya terehe <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Ukurasa huu wa nje ya mtandao umetoka <ph name="CREATION_TIME"/> na huenda ukatofautiana na toleo lililo mtandaoni.</translation>
+<translation id="8840953339110955557">Ukurasa huu huenda ukatofautiana na toleo la mtandaoni.</translation>
+<translation id="6405300764336705484">Maudhui haya yanatoka <ph name="DOMAIN_NAME"/>, yamewasilishwa na Brave Software.</translation>
+<translation id="1006017844123154345">Fungua Mtandaoni</translation>
+<translation id="3326636747541519688">Ukurasa mwepesi umetolewa na Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Pakia ukurasa halisi<ph name="END_LINK"/> kutoka <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Ikiwa unaona hili kila mara, jaribu <ph name="BEGIN_LINK"/>mapendekezo<ph name="END_LINK"/> haya.</translation>
+<translation id="8748850008226585750">Maudhui yamefichwa</translation>
+<translation id="3810973564298564668">Dhibiti</translation>
+<translation id="5199929503336119739">Wasifu wa kazini</translation>
+<translation id="528192093759286357">Buruta kutoka juu na uguse kitufe cha kurudi nyuma ili uondoke kwenye skrini nzima.</translation>
+<translation id="2836148919159985482">Gusa kitufe cha kurudi nyuma ili uondoke kwenye skrini nzima.</translation>
+<translation id="3967822245660637423">Faili imekamilika kupakuliwa</translation>
+<translation id="2434158240863470628">Upakuaji umekamilika <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Haikuweza kupakua</translation>
+<translation id="1384959399684842514">Upakuaji umesitishwa</translation>
+<translation id="1671236975893690980">Inasubiri kupakua...</translation>
+<translation id="5561549206367097665">Inasubiri intaneti…</translation>
+<translation id="5864419784173784555">Inasubiri kipakuliwa kingine…</translation>
+<translation id="6461962085415701688">Imeshindwa kufungua faili</translation>
+<translation id="1178581264944972037">Sitisha</translation>
+<translation id="8200772114523450471">Endelea</translation>
+<translation id="1409879593029778104">Kipakuliwa cha <ph name="FILE_NAME"/> kimezuiwa kwa sababu faili tayari ipo.</translation>
+<translation id="3387650086002190359">Kipakuliwa cha <ph name="FILE_NAME"/> hakijafaulu kwa sababu ya hitilafu za mfumo wa faili.</translation>
+<translation id="6482749332252372425">Kipakuliwa cha <ph name="FILE_NAME"/> hakijafaulu kwa sababu hakuna nafasi ya hifadhi ya kutosha.</translation>
+<translation id="7619072057915878432">Kipakuliwa cha <ph name="FILE_NAME"/> hakijafaulu kwa sababu ya hitilafu za mtandao.</translation>
+<translation id="1477626028522505441">Kipakuliwa cha <ph name="FILE_NAME"/> hakijafaulu kwa sababu ya matatizo ya seva.</translation>
+<translation id="3692944402865947621">Imeshindwa kupakua <ph name="FILE_NAME"/> kwa sababu haikupata eneo la kuhifadhi.</translation>
+<translation id="604996488070107836">Kipakuliwa cha <ph name="FILE_NAME"/> hakijafaulu kwa sababu ya hitilafu isiyojulikana.</translation>
+<translation id="6738867403308150051">Inapakua...</translation>
+<translation id="7176368934862295254">KB <ph name="KILOBYTES"/></translation>
+<translation id="2402980924095424747">MB <ph name="MEGABYTES"/></translation>
+<translation id="6608650720463149374">GB <ph name="GIGABYTES"/></translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Umepakua KB <ph name="KBS"/></translation>
+<translation id="6416782512398055893">Umepakua MB <ph name="MBS"/></translation>
+<translation id="6538442820324228105">Umepakua GB <ph name="GBS"/></translation>
+<translation id="9204836675896933765">Imesalia faili 1</translation>
+<translation id="8186512483418048923">Zimesalia faili <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Umepakua faili <ph name="FILES_DOWNLOADED_ONE"/>}other{Umepakua faili <ph name="FILES_DOWNLOADED_MANY"/>}}</translation>
+<translation id="8037750541064988519">Zimesalia siku <ph name="DAYS"/></translation>
+<translation id="8190358571722158785">Imesalia siku 1</translation>
+<translation id="60923314841986378">Zimesalia saa <ph name="HOURS"/></translation>
+<translation id="510275257476243843">Imesalia saa 1</translation>
+<translation id="970715775301869095">Zimesalia dakika <ph name="MINUTES"/></translation>
+<translation id="3236059992281584593">Imesalia dakika 1</translation>
+<translation id="2777555524387840389">Zimesalia sekunde <ph name="SECONDS"/></translation>
+<translation id="2781151931089541271">Imesalia sekunde 1</translation>
+<translation id="3303414029551471755">Ungependa kuendelea kupakua maudhui?</translation>
+<translation id="8617240290563765734">Ungependa kufungua URL iliyopendekezwa na kubainishwa katika maudhui yaliyopakuliwa?</translation>
+<translation id="1373696734384179344">Hakuna hifadhi ya kutosha ya kupakua maudhui yaliyochaguliwa.</translation>
+<translation id="5271967389191913893">Kifaa hakiwezi kufungua maudhui yanayopaswa kupakuliwa.</translation>
+<translation id="883806473910249246">Hitilafu imetokea wakati wa kupakua maudhui.</translation>
+<translation id="5626134646977739690">Jina:</translation>
+<translation id="7963646190083259054">Mchuuzi:</translation>
+<translation id="3414952576877147120">Ukubwa:</translation>
+<translation id="7375125077091615385">Aina:</translation>
+<translation id="5765780083710877561">Maelezo:</translation>
+<translation id="4881695831933465202">Fungua</translation>
+<translation id="3542235761944717775">KB <ph name="KILOBYTES"/> zinapatikana</translation>
+<translation id="8051695050440594747">MB <ph name="MEGABYTES"/> zinapatikana</translation>
+<translation id="5424588387303617268">GB <ph name="GIGABYTES"/> zinapatikana</translation>
+<translation id="5793665092639000975">Inatumia <ph name="SPACE_USED"/> kati ya <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Zote</translation>
+<translation id="4988526792673242964">Kurasa</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Sauti</translation>
+<translation id="9219103736887031265">Picha</translation>
+<translation id="8250920743982581267">Hati</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{Faili #}other{Faili #}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{Picha #}other{Picha #}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{Video #}other{Video #}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{Faili # ya sauti}other{Faili # za sauti}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{Ukurasa #}other{Kurasa #}}</translation>
+<translation id="5456381639095306749">Pakua ukurasa</translation>
+<translation id="2394602618534698961">Faili unazopakua zinaonekana hapa</translation>
+<translation id="7810647596859435254">Fungua ukitumia...</translation>
+<translation id="5655963694829536461">Tafuta vipakuliwa vyako</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Faili Zangu</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Makala yanaonekana hapa na unaweza kuyasoma hata ukiwa nje ya mtandao</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{Saa #}other{Saa #}}</translation>
+<translation id="5853623416121554550">imesitishwa</translation>
+<translation id="8965591936373831584">inasubiri</translation>
+<translation id="2779651927720337254">imeshindwa</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Sasa Hivi</translation>
+<translation id="4000212216660919741">Skrini ya Kwanza, Nje ya Mtandao</translation>
+<translation id="9133397713400217035">Pitia Ukiwa Nje ya Mtandao</translation>
+<translation id="968900484120156207">Kurasa unazotembelea zitaonekana hapa</translation>
+<translation id="7882131421121961860">Hakuna historia iliyopatikana</translation>
+<translation id="3549657413697417275">Tafuta katika historia yako</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MW</translation>
+<translation id="605721222689873409">MK</translation>
+<translation id="724102042129299115">Hali ya Utekelezaji wa Kwanza wa Brave</translation>
+<translation id="2700285883409956633">Kwa kutumia programu hii, unakubali <ph name="BEGIN_LINK1"/>Sheria na Masharti<ph name="END_LINK1"/> na <ph name="BEGIN_LINK2"/>Ilani ya Faragha<ph name="END_LINK2"/> ya Brave.</translation>
+<translation id="1640714894372474981">Kwa kutumia programu hii, unakubaliana na <ph name="BEGIN_LINK1"/>Sheria na Masharti<ph name="END_LINK1"/> na <ph name="BEGIN_LINK2"/>Ilani ya Faragha<ph name="END_LINK2"/> ya Brave na <ph name="BEGIN_LINK3"/>Ilani ya Faragha ya Akaunti za Brave Software Zinazodhibitiwa na Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Itafungua <ph name="APP_NAME"/> katika Brave. Kwa kuendelea, unakubali <ph name="BEGIN_LINK1"/>Sheria na Masharti<ph name="END_LINK1"/> na <ph name="BEGIN_LINK2"/>Ilani ya Faragha<ph name="END_LINK2"/> ya Brave.</translation>
+<translation id="5071615083211946659">Itafungua <ph name="APP_NAME"/> katika Brave. Kwa kuendelea, unakubali <ph name="BEGIN_LINK1"/>Sheria na Masharti<ph name="END_LINK1"/> na <ph name="BEGIN_LINK2"/>Ilani ya Faragha<ph name="END_LINK2"/>, na <ph name="BEGIN_LINK3"/>Ilani ya Faragha ya Akaunti za Brave Software Zinazodhibitiwa na Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Saidia kuboresha Brave kwa kutumia Brave Software takwimu za matumizi na ripoti wakati wowote kivinjari hiki kinapoacha kufanya kazi.</translation>
+<translation id="3518985090088779359">Kubali na uendelee</translation>
+<translation id="7207456302801184289">Karibu kwenye Brave</translation>
+<translation id="704822250101715322">Inasubiri Huduma za Brave Software Play ili kukamilisha kusasisha</translation>
+<translation id="1231733316453485619">Ungependa kuwasha usawazishaji?</translation>
+<translation id="5132942445612118989">Sawazisha historia, manenosiri na mambo yako mengine kwenye vifaa vyote</translation>
+<translation id="5736731321935944068">Brave Software inaweza kutumia historia yako ili kuweka mapendeleo kwenye huduma ya Tafuta na Brave Software, matangazo na huduma nyingine za Brave Software</translation>
+<translation id="4013614219085422040">Brave Software inaweza kutumia historia yako ili kuweka mapendeleo kwenye huduma ya Tafuta na Brave Software na huduma nyingine za Brave Software.</translation>
+<translation id="5581519193887989363">Unaweza kuchagua utakachosawazisha wakati wowote katika <ph name="BEGIN_LINK1"/>mipangilio<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Ndiyo, ninakubali</translation>
+<translation id="2410754283952462441">Chagua akaunti</translation>
+<translation id="2227444325776770048">Endelea ukitumia <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Wewe si <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Washa kipengele cha usawazishaji ili upate alamisho kwenye vifaa vyako vyote</translation>
+<translation id="2818669890320396765">Ingia katika akaunti na uwashe kipengele cha usawazishaji ili upate alamisho zako kwenye vifaa vyako vyote</translation>
+<translation id="6003646045106347985">Washa kipengele cha usawazishaji ili Brave Software ikupendekezee maudhui yanayokufaa</translation>
+<translation id="8494430740943879273">Ingia katika akaunti na uwashe kipengee cha usawazishaji ili upate maudhui yanayokufaa unayopendekezewa na Brave Software</translation>
+<translation id="5862731021271217234">Washa kipengele cha usawazishaji ili upate vichupo kutoka kwenye vifaa vyako vingine</translation>
+<translation id="3568688522516854065">Ingia katika akaunti na uwashe kipengele cha usawazishaji ili upate vichupo vyako kutoka vifaa vyako vingine</translation>
+<translation id="1208340532756947324">Ili usawazishe na uweke mapendeleo kwenye vifaa vyako vyote, washa kipengele cha usawazishaji</translation>
+<translation id="4472118726404937099">Ingia katika akaunti na uwashe kipengele cha usawazishaji ili usawazishe na uweke mapendeleo kwenye vifaa vyako vyote</translation>
+<translation id="2426805022920575512">Chagua akaunti nyingine</translation>
+<translation id="6790428901817661496">Cheza</translation>
+<translation id="1272079795634619415">Simamisha</translation>
+<translation id="2874939134665556319">Wimbo uliotangulia</translation>
+<translation id="4046123991198612571">Wimbo unaofuata</translation>
+<translation id="3859306556332390985">Peleka mbele</translation>
+<translation id="8441146129660941386">Peleka nyuma</translation>
+<translation id="6706288973712894588">Kwa sasa uko nje ya mtandao.\n<ph name="BEGIN_LINK"/>Pitia mipasho yako ya nje ya mtandao.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Vichupo vya hivi majuzi</translation>
+<translation id="8497726226069778601">Bado hapana chochote cha kuangalia...</translation>
+<translation id="5423934151118863508">Kurasa zako zilizotembelewa sana zitaonekana hapa</translation>
+<translation id="6127379762771434464">Kipengee kimeondolewa</translation>
+<translation id="4605958867780575332">Kipengee kilichoondolewa: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Vifaa vingine</translation>
+<translation id="4738836084190194332">Kilisawazishwa mara ya mwisho: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{Dakika # iliyopita}other{Dakika # zilizopita}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{Saa # iliyopita}other{Saa # zilizopita}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{Siku # iliyopita}other{Siku # zilizopita}}</translation>
+<translation id="2762000892062317888">sasa hivi tu</translation>
+<translation id="1407135791313364759">Fungua zote</translation>
+<translation id="1209206284964581585">Ficha kwa sasa</translation>
+<translation id="129553762522093515">Vilivyofungwa hivi karibuni</translation>
+<translation id="8413126021676339697">Onyesha historia kamili</translation>
+<translation id="7876243839304621966">Ondoa yote</translation>
+<translation id="8487700953926739672">Kinapatikana nje ya mtandao</translation>
+<translation id="5224771365102442243">Ina video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Pata maelezo zaidi<ph name="END_LINK"/> kuhusu maudhui yaliyopendekezwa</translation>
+<translation id="7542481630195938534">Imeshindwa kupata mapendekezo</translation>
+<translation id="5013696553129441713">Hakuna mapendekezo mapya</translation>
+<translation id="1736419249208073774">Gundua</translation>
+<translation id="7444811645081526538">Aina zingine</translation>
+<translation id="6709133671862442373">Habari</translation>
+<translation id="1264974993859112054">Michezo</translation>
+<translation id="9139318394846604261">Ununuzi</translation>
+<translation id="3912508018559818924">Inatafuta maudhui bora zaidi kwenye wavuti…</translation>
+<translation id="526421993248218238">Imeshindwa kupakia ukurasa huu</translation>
+<translation id="614940544461990577">Jaribu:</translation>
+<translation id="3288003805934695103">Kupakia upya ukurasa</translation>
+<translation id="2353636109065292463">Inaangalia muunganisho wako wa intaneti</translation>
+<translation id="2858138569776157458">Tovuti maarufu</translation>
+<translation id="8364299278605033898">Ona tovuti maarufu</translation>
+<translation id="1171770572613082465">Ona tovuti maarufu kwa kugusa kitufe cha "Tovuti maarufu"</translation>
+<translation id="5233638681132016545">Kichupo kipya</translation>
+<translation id="4521874409998847950">Kutoka <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>imesafirishwa na Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Toleo jipya linapatikana.</translation>
+<translation id="4058091506841967397">Brave haiwezi kusasisha</translation>
+<translation id="6316139424528454185">Haiwezi kutumia toleo la Android</translation>
+<translation id="6989267951144302301">Imeshindwa kupakua</translation>
+<translation id="624789221780392884">Sasisho iko tayari</translation>
+<translation id="1549000191223877751">Nenda kwenye dirisha jingine</translation>
+<translation id="7481312909269577407">Mbele</translation>
+<translation id="4084682180776658562">Alamisho</translation>
+<translation id="6437478888915024427">Maelezo ya ukurasa</translation>
+<translation id="7180611975245234373">Onyesha upya</translation>
+<translation id="4913169188695071480">Acha kuonyesha upya</translation>
+<translation id="1829244130665387512">Tafuta katika ukurasa</translation>
+<translation id="6593061639179217415">Tovuti ya kompyuta ya mezani</translation>
+<translation id="9063523880881406963">Zima Omba Tovuti ya Eneo-kazi</translation>
+<translation id="2038563949887743358">Washa Omba Tovuti ya Eneo-kazi</translation>
+<translation id="2433507940547922241">Sura</translation>
+<translation id="983192555821071799">Funga vichupo vyote</translation>
+<translation id="1310482092992808703">Weka vichupo pamoja</translation>
+<translation id="7725024127233776428">Kurasa unazoalamisha zitaonekana hapa</translation>
+<translation id="4404568932422911380">Hakuna alamisho</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{Alamisho <ph name="BOOKMARKS_COUNT_ONE"/>}other{Alamisho <ph name="BOOKMARKS_COUNT_MANY"/>}}</translation>
+<translation id="3739899004075612870">Imealamishwa katika <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Imealamishwa</translation>
+<translation id="4452548195519783679">Imetia alamishwa kwenye <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Haikuweza kuongeza alamisho.</translation>
+<translation id="2842985007712546952">Folda kuu</translation>
+<translation id="9065203028668620118">Badilisha</translation>
+<translation id="4405224443901389797">Hamishia kwenye…</translation>
+<translation id="5170568018924773124">Onyesha katika folda</translation>
+<translation id="8035133914807600019">Folda mpya…</translation>
+<translation id="4532845899244822526">Chagua folda</translation>
+<translation id="6627583120233659107">Badilisha folda</translation>
+<translation id="1197267115302279827">Sogeza alamisho</translation>
+<translation id="6963766334940102469">Futa alamisho</translation>
+<translation id="4351244548802238354">Funga kidirisha</translation>
+<translation id="451872707440238414">Tafuta alamisho zako</translation>
+<translation id="8901170036886848654">Hakuna alamisho zilizopatikana</translation>
+<translation id="6404511346730675251">Badilisha alamisho</translation>
+<translation id="3894427358181296146">Ongeza folda</translation>
+<translation id="5327248766486351172">Jina</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Folda</translation>
+<translation id="5161254044473106830">Kichwa kinahitajika</translation>
+<translation id="2996809686854298943">URL inahitajika</translation>
+<translation id="2536728043171574184">Unaangalia nakala ya nje ya mtandao ya ukurasa huu</translation>
+<translation id="4698034686595694889">Angalia ukiwa nje ya mtandao katika <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> na tovuti zingine</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave itapakia ukurasa wako ukiwa tayari}other{Brave itapakia kurasa zako zikiwa tayari}}</translation>
+<translation id="6811034713472274749">Unaweza kuona ukurasa</translation>
+<translation id="4561979708150884304">Hakuna muunganisho</translation>
+<translation id="8274165955039650276">Angalia vipakuliwa</translation>
+<translation id="2082238445998314030">Tokeo <ph name="RESULT_NUMBER"/> kati ya <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Hakuna matokeo yoyote yaliyopatikana</translation>
+<translation id="981121421437150478">Nje ya mtandao</translation>
+<translation id="3298243779924642547">Nyepesi</translation>
+<translation id="393697183122708255">Hakuna kutafuta kwa kutamka kulikowashwa</translation>
+<translation id="7191430249889272776">Kichupo kimefunguliwa chini chini.</translation>
+<translation id="8445059357334030806">Fungulia katika Brave</translation>
+<translation id="4720023427747327413">Fungua katika <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Fungua katika kivinjari</translation>
+<translation id="1113597929977215864">Onyesha mwonekano rahisi</translation>
+<translation id="1513352483775369820">Alamisho na historia ya wavuti</translation>
+<translation id="4939482511480190003">Tusaidie kuboresha Brave.<ph name="BEGIN_LINK"/>Shiriki katika utafiti<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Rudi nyuma</translation>
+<translation id="5596627076506792578">Chaguo zaidi</translation>
+<translation id="3522247891732774234">Kuna toleo jipya. Chaguo zaidi</translation>
+<translation id="6773423637732432200">Brave haiwezi kusasisha. Chaguo zaidi</translation>
+<translation id="3328801116991980348">Maelezo ya tovuti</translation>
+<translation id="5391532827096253100">Muunganisho wako kwenye tovuti hii si salama. Maelezo ya tovuti</translation>
+<translation id="6206551242102657620">Muunganisho ni salama. Maelezo ya tovuti</translation>
+<translation id="6963642900430330478">Ukurasa huu ni hatari. Maelezo ya tovuti</translation>
+<translation id="9070377983101773829">Anza kutafuta kwa kutamka</translation>
+<translation id="8676374126336081632">Futa uingizaji wa maandishi</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{Umefungua kichupo <ph name="OPEN_TABS_ONE"/>, gusa ili ubadilishe vichupo}other{Umefungua vichupo <ph name="OPEN_TABS_MANY"/>, gusa ili ubadilishe vichupo}}</translation>
+<translation id="2369533728426058518">vichupo vilivyo wazi</translation>
+<translation id="7071521146534760487">Dhibiti akaunti</translation>
+<translation id="932327136139879170">Mwanzo</translation>
+<translation id="2707726405694321444">Onyesha upya ukurasa</translation>
+<translation id="2891154217021530873">Simamisha upakiaji wa ukurasa</translation>
+<translation id="6710213216561001401">Iliyotangulia</translation>
+<translation id="6659594942844771486">Kichupo</translation>
+<translation id="1933845786846280168">Kichupo Kilichochaguliwa</translation>
+<translation id="2268044343513325586">Chuja</translation>
+<translation id="7846076177841592234">Ghairi uchaguzi</translation>
+<translation id="7087918508125750058">Imechagua <ph name="ITEM_COUNT"/>. Chaguo zinapatikana karibu na sehemu ya juu ya skrini</translation>
+<translation id="7250468141469952378">Imechagua <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Shiriki kipengee 1 kilichochaguliwa}other{Shiriki vipengee # vilivyochaguliwa}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Ondoa kipengee 1 kilichochaguliwa}other{Ondoa vipengee # vilivyochaguliwa}}</translation>
+<translation id="1283039547216852943">Gusa ili upanue</translation>
+<translation id="5962718611393537961">Gusa ili ukunje</translation>
+<translation id="8076492880354921740">Vichupo</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 imechaguliwa}other{# vimechaguliwa}}</translation>
+<translation id="6818926723028410516">Chagua vipengee</translation>
+<translation id="4797039098279997504">Gusa ili urudi kwenye <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Gusa ili uende kwenye tovuti</translation>
+<translation id="429312253194641664">Tovuti inacheza maudhui</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> inashiriki skrini yako</translation>
+<translation id="8833831881926404480">Tovuti inashiriki skrini yako</translation>
+<translation id="9086455579313502267">Haiwezi kufikia mtandao</translation>
+<translation id="938850635132480979">Hitilafu: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Fungua katika <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Fungua katika programu ya ramani</translation>
+<translation id="7698359219371678927">Tunga barua pepe katika <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Tunga barua pepe</translation>
+<translation id="5665379678064389456">Unda tukio katika <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Ongeza tukio jipya</translation>
+<translation id="2111511281910874386">Nenda kwenye ukurasa</translation>
+<translation id="3988466920954086464">Angalia matokeo ya utafutaji wa moja kwa moja katika kidirisha hiki</translation>
+<translation id="2744248271121720757">Gusa neno ili utafute papo hapo au uone vitendo vinavyohusiana</translation>
+<translation id="9155898266292537608">Unaweza pia kutafuta kwa kugusa haraka kwenye neno</translation>
+<translation id="3232754137068452469">Programu ya Wavuti</translation>
+<translation id="1430915738399379752">Chapisha</translation>
+<translation id="3775705724665058594">Tuma kwenye vifaa vyako</translation>
+<translation id="6364438453358674297">Je, ungependa kuondoa pendekezo kwenye historia?</translation>
+<translation id="213279576345780926">Umefunga <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139">Vichupo <ph name="TAB_COUNT"/> vimefungwa</translation>
+<translation id="3211426585530211793">Umefuta <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">Alamisho <ph name="NUMBER_OF_BOOKMARKS"/> zimefutwa</translation>
+<translation id="3819178904835489326">Vipakuliwa <ph name="NUMBER_OF_DOWNLOADS"/> vimefutwa</translation>
+<translation id="1248710015876067820">Idadi ya matukio ya Brave isiyoweza kutumika.</translation>
+<translation id="4259722352634471385">Kudurusu kumezuiwa: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Kudurusu hakufikiki: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Funga kichupo</translation>
+<translation id="7772375229873196092">Funga <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Historia ya uelekezaji</translation>
+<translation id="9169507124922466868">Historia ya uelekezaji imefunguliwa nusu</translation>
+<translation id="1327257854815634930">Historia ya uelekezaji imefunguliwa</translation>
+<translation id="8788265440806329501">Historia ya uelekezaji imezimwa</translation>
+<translation id="7482656565088326534">Kichupo cha kukagua kwanza</translation>
+<translation id="8427875596167638501">Kichupo cha kukagua kwanza kimefunguliwa nusu</translation>
+<translation id="9102803872260866941">Kichupo cha kukagua kwanza kimefunguliwa</translation>
+<translation id="2942036813789421260">Kichupo cha kukagua kwanza kimefungwa</translation>
+<translation id="6355102470683871794">Hifadhi ya Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Ungependa kufuta hifadhi ya tovuti?</translation>
+<translation id="9205995714227143200">Hifadhi ya tovuti ambayo Brave haidhani ni muhimu (k.m. tovuti ambazo hazina mipangilio iliyohifadhiwa au ambazo hutembelei sana)</translation>
+<translation id="3997476611815694295">Hifadhi ambayo si muhimu</translation>
+<translation id="8493948351860045254">Ongeza nafasi ya hifadhi</translation>
+<translation id="2324920234469020158">Hatua hii itafuta vidakuzi, akiba na data nyingine ya tovuti ambazo Brave haidhani kuwa muhimu.</translation>
+<translation id="5447201525962359567">Hifadhi yote ya tovuti, ikiwa ni pamoja na vidakuzi na data nyingine iliyohifadhiwa ndani</translation>
+<translation id="1376578503827013741">Inakokotoa...</translation>
+<translation id="583281660410589416">Haijulikani</translation>
+<translation id="2323763861024343754">Hifadhi ya tovuti</translation>
+<translation id="3587672679800759167">Jumla ya data iliyotumiwa na Brave, ikiwa ni pamoja na akaunti, alamisho na mipangilio iliyohifadhiwa</translation>
+<translation id="6545017243486555795">Futa Data Yote</translation>
+<translation id="4095146165863963773">Ungependa kufuta data ya programu?</translation>
+<translation id="53119194224775367">Data yote ya programu ya Brave itafutwa kabisa. Hii ni pamoja na faili, mipangilio, akaunti, hifadhidata zote, n.k.</translation>
+<translation id="5307446750509046227">Futa hifadhi ya tovuti</translation>
+<translation id="300526633675317032">Hatua hii itafuta <ph name="SIZE_IN_KB"/> yote ya hifadhi ya tovuti.</translation>
+<translation id="8068648041423924542">Imeshindwa kuchagua cheti.</translation>
+<translation id="2315043854645842844">Uchaguzi wa cheti cha sehemu ya seva teja hautumiwi na mfumo wa uendeshaji.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> inataka kuunganisha</translation>
+<translation id="5308380583665731573">Unganisha</translation>
+<translation id="868929229000858085">Tafuta kwenye anwani zako</translation>
+<translation id="1919950603503897840">Chagua anwani</translation>
+<translation id="7986741934819883144">Chagua anwani</translation>
+<translation id="3333961966071413176">Anwani zote</translation>
+<translation id="4994033804516042629">Hakuna anwani zilizopatikana</translation>
+<translation id="5403592356182871684">Majina</translation>
+<translation id="2717722538473713889">Anwani za barua pepe</translation>
+<translation id="381841723434055211">Nambari za simu</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 zaidi)}other{(+ # zaidi)}}</translation>
+<translation id="5197729504361054390">Anwani unazochagua zitashirikiwa na <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Kisimbuaji cha picha</translation>
+<translation id="8067883171444229417">Cheza video</translation>
+<translation id="6560414384669816528">Tafuta kwa kutumia Sogou</translation>
+<translation id="5406914950576900927">Brave inaweza kutumia <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> kutafuta nchini Uchina. Unaweza kuibadilisha katika <ph name="BEGIN_LINK"/>MipangilioE<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Endelea Kutumia Brave Software</translation>
+<translation id="4384468725000734951">Unatumia Sogou kutafuta</translation>
+<translation id="6103327872225198548">Unatumia Brave Software kutafuta</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Programu hii inatumika katika Brave</translation>
+<translation id="6143689084714664628">Umefunguka katika Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> pia ina data katika Brave</translation>
+<translation id="2734140769649165081">Unaweza kufuta data hii katika Mipangilio ya Brave</translation>
+<translation id="8232956427053453090">Hifadhi data</translation>
+<translation id="4298388696830689168">Tovuti ambazo zimeunganishwa</translation>
+<translation id="5763514718066511291">Gusa ili unakili URL ya programu hii</translation>
+<translation id="6496823230996795692">Ili kutumia <ph name="APP_NAME"/> kwa mara ya kwanza, tafadhali unganisha kwenye intaneti.</translation>
+<translation id="751961395872307827">Imeshindwa kuunganisha kwenye tovuti</translation>
+<translation id="4878404682131129617">Imeshindwa kuanzisha mkondo kupitia seva mbadala</translation>
+<translation id="4749960740855309258">Fungua kichupo kipya</translation>
+<translation id="8788968922598763114">Fungua tena kichupo kilichofungwa mwisho</translation>
+<translation id="7929962904089429003">Fungua menyu</translation>
+<translation id="6039379616847168523">Nenda kwenye kichupo kinachofuata</translation>
+<translation id="5210286577605176222">Rudi kwenye kichupo cha awali</translation>
+<translation id="124678866338384709">Funga kichupo kilichofunguka</translation>
+<translation id="3714981814255182093">Fungua Upau wa Kutafuta</translation>
+<translation id="5441522332038954058">Rudi kwenye sehemu ya anwani</translation>
+<translation id="3398320232533725830">Fungua kidhibiti cha alamisho</translation>
+<translation id="6583199322650523874">Wekea alamisho kwenye ukurasa uliofungua</translation>
+<translation id="8489271220582375723">Fungua ukurasa wa historia</translation>
+<translation id="4837753911714442426">Fungua chaguo za kuchapisha ukurasa</translation>
+<translation id="5726692708398506830">Fanya kila kitu kwenye ukurasa kiwe kikubwa zaidi</translation>
+<translation id="3259831549858767975">Fanya kila kitu kwenye ukurasa kiwe kidogo zaidi</translation>
+<translation id="8015452622527143194">Rejesha kila kitu katika ukubwa wa kawaida</translation>
+<translation id="3443221991560634068">Pakia upya ukurasa wa sasa</translation>
+<translation id="123724288017357924">Pakia upya ukurasa wa sasa, puuza maudhui ya akiba</translation>
+<translation id="305870044889644984">Fungua Kituo cha Usaidizi cha Brave katika kichupo kipya</translation>
+<translation id="3166827708714933426">Njia za mikato ya vichupo na vidirisha</translation>
+<translation id="3169981355900570544">Njia za mikato za vipengele vya Brave Software Brave</translation>
+<translation id="4558311620361989323">Njia za mikato za ukurasa wa wavuti</translation>
+<translation id="1908301351964700579">Brave bado inasubiri Uhalisia Pepe. Zima kisha uwashe Brave baadaye</translation>
+<translation id="8970887620466824814">Hitilafu imetokea.</translation>
+<translation id="1875543012935658554">Fungua Brave Upya.</translation>
+<translation id="79859296434321399">Sakinisha ARCore ili uangalie maudhui ya uhalisia ulioboreshwa</translation>
+<translation id="8558485628462305855">Sasisha ARCore ili uangalie maudhui ya uhalisia ulioboreshwa</translation>
+<translation id="3513704683820682405">Uhalisia Ulioboreshwa</translation>
+<translation id="5475862044948910901">Je, ungependa kuanzisha kipindi cha Uhalisia Ulioboreshwa?</translation>
 <translation id="7365126855094612066">Kwa kipindi hiki, tovuti itaweza:
 • kuunda ramani ya 3D ya mazingira yako
 • kufuatilia mwendo wa kamera
 Tovuti hii HAIPATI idhini ya kufikia kamera. Ni wewe pekee utaona picha hizi za kamera.</translation>
-<translation id="7375125077091615385">Aina:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Hali ya Utekelezaji wa Kwanza wa Chrome</translation>
-<translation id="741204030948306876">Ndiyo, ninakubali</translation>
-<translation id="7413229368719586778">Tarehe ya kuanza <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Uliza kwanza</translation>
-<translation id="7423538860840206698">Imezuiwa kusoma ubao wa kunakili</translation>
-<translation id="7431991332293347422">Dhibiti namna historia yako ya kuvinjari inavyotumika kuweka mapendeleo kwenye huduma ya Tafuta na Google na zaidi</translation>
-<translation id="7437998757836447326">Ondoka kwenye Chrome</translation>
-<translation id="7438641746574390233">Wakati umewasha Hali nyepesi, Chrome hutumia seva za Google kupakia kurasa haraka. Hali nyepesi hubadilisha kurasa zinazopakia polepole ili zipakie maudhui muhimu pekee. Hali nyepesi haitumiki kwenye vichupo katika hali Fiche.</translation>
-<translation id="7444811645081526538">Aina zingine</translation>
-<translation id="7445411102860286510">Ruhusu tovuti zicheze video kiotomatiki bila sauti (inapendekezwa)</translation>
-<translation id="7453467225369441013">Hukuondoa kwenye akaunti za tovuti nyingi. Hutaondolewa kwenye Akaunti ya Google.</translation>
-<translation id="7454641608352164238">Nafasi haitoshi</translation>
-<translation id="7475192538862203634">Ikiwa unaona hili kila mara, jaribu <ph name="BEGIN_LINK" />mapendekezo<ph name="END_LINK" /> haya.</translation>
-<translation id="7475688122056506577">SD haikupatikana. Huenda baadhi ya faili zako zinazokosekana.</translation>
-<translation id="7479104141328977413">Udhibiti wa kichupo</translation>
-<translation id="7481312909269577407">Mbele</translation>
-<translation id="7482656565088326534">Kichupo cha kukagua kwanza</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Ilisasishwa <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">data iliyookolewa</translation>
-<translation id="7498271377022651285">Tafadhali subiri...</translation>
-<translation id="7514365320538308">Pakua</translation>
-<translation id="751961395872307827">Imeshindwa kuunganisha kwenye tovuti</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Imeshindwa kupata mapendekezo</translation>
-<translation id="7559975015014302720">Umezima hali nyepesi</translation>
-<translation id="7562080006725997899">Inafuta data ya kuvinjari</translation>
-<translation id="756809126120519699">Data ya Chrome imefutwa</translation>
-<translation id="757524316907819857">Zuia tovuti zisicheze maudhui yanayolindwa</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Umepakua faili <ph name="FILES_DOWNLOADED_ONE" />}other{Umepakua faili <ph name="FILES_DOWNLOADED_MANY" />}}</translation>
-<translation id="7588219262685291874">Washa mandhari meusi wakati Kiokoa Betri cha kifaa kimewashwa</translation>
-<translation id="7589445247086920869">Zuia kwa mtambo wa sasa wa kutafuta</translation>
-<translation id="7593557518625677601">Fungua mipangilio ya Android na uwashe upya usawazishaji wa mfumo wa Android ili uanze usawazishaji wa Chrome</translation>
-<translation id="7596558890252710462">Mfumo wa uendeshaji</translation>
-<translation id="7605594153474022051">Kipengele cha usawazishaji hakifanyi kazi</translation>
-<translation id="7606077192958116810">Umewasha Hali nyepesi. Idhibiti katika Mipangilio.</translation>
-<translation id="7612619742409846846">Umeingia katika akaunti ya Google ukitumia</translation>
-<translation id="7619072057915878432">Kipakuliwa cha <ph name="FILE_NAME" /> hakijafaulu kwa sababu ya hitilafu za mtandao.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Pata usaidizi<ph name="END_LINK1" /> au <ph name="BEGIN_LINK2" />tafuta tena<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Karibu kwenye Chrome</translation>
-<translation id="7638584964844754484">Kaulisiri si sahihi</translation>
-<translation id="7641339528570811325">Futa data ya kuvinjari...</translation>
-<translation id="7648422057306047504">Simba kwa njia fiche manenosiri ukitumia kitambulisho cha Google</translation>
-<translation id="7649070708921625228">Usaidizi</translation>
-<translation id="7658239707568436148">Ghairi</translation>
-<translation id="7665369617277396874">Ongeza akaunti</translation>
-<translation id="766587987807204883">Makala yanaonekana hapa na unaweza kuyasoma hata ukiwa nje ya mtandao</translation>
-<translation id="7682724950699840886">Jaribu vidokezo vifuatavyo: Hakikisha kuwa una nafasi ya kutosha kwenye kifaa chako kisha ujaribu kuihamisha tena.</translation>
-<translation id="7685301384041462804">Hakikisha kuwa unaamini tovuti hii kabla ya kuanzisha VR.</translation>
-<translation id="7698359219371678927">Tunga barua pepe katika <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Jaza kiotomatiki URL na hoja za utafutaji</translation>
-<translation id="7725024127233776428">Kurasa unazoalamisha zitaonekana hapa</translation>
-<translation id="773466115871691567">Zitafsiri kurasa katika <ph name="SOURCE_LANGUAGE" /> wakati wote</translation>
-<translation id="7746457520633464754">Ili kutambua programu na tovuti hatari, Chrome hutuma URL za baadhi ya kurasa unazotembelea. maelezo machache ya mfumo na maudhui ya ukurasa kwa Google</translation>
-<translation id="7757787379047923882">Maandishi yameshirikiwa kutoka <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Kadi ya SD ya <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Ongeza anwani</translation>
-<translation id="7772032839648071052">Thibitisha kaulisiri</translation>
-<translation id="7772375229873196092">Funga <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> zaidi}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 na <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> zaidi}}</translation>
-<translation id="7781829728241885113">Jana</translation>
-<translation id="7791543448312431591">Ongeza</translation>
-<translation id="780301667611848630">La, asante</translation>
-<translation id="7810647596859435254">Fungua ukitumia...</translation>
-<translation id="7821588508402923572">Data unayookoa itaonekana hapa</translation>
-<translation id="7837721118676387834">Ruhusu uchezaji wa video kiotomatiki bila sauti kwenye tovuti mahususi.</translation>
-<translation id="7846076177841592234">Ghairi uchaguzi</translation>
-<translation id="784934925303690534">Muda</translation>
-<translation id="7851858861565204677">Vifaa vingine</translation>
-<translation id="7875915731392087153">Tunga barua pepe</translation>
-<translation id="7876243839304621966">Ondoa yote</translation>
-<translation id="7882131421121961860">Hakuna historia iliyopatikana</translation>
-<translation id="7882806643839505685">Ruhusu sauti katika tovuti mahususi.</translation>
-<translation id="7886917304091689118">Umefunguka katika Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Inapakua faili.}other{Inapakua faili #.}}</translation>
-<translation id="7929962904089429003">Fungua menyu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> imepitwa na wakati.</translation>
-<translation id="7947953824732555851">Kubali na uingie</translation>
-<translation id="7963646190083259054">Mchuuzi:</translation>
-<translation id="7971136598759319605">Ilitumika siku 1 iliyopita</translation>
-<translation id="7975379999046275268">Kagua ukurasa kwanza <ph name="BEGIN_NEW" />Mpya<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Pakia mapema kurasa ili upate huduma ya haraka ya kuvinjari na kutafuta</translation>
-<translation id="79859296434321399">Sakinisha ARCore ili uangalie maudhui ya uhalisia ulioboreshwa</translation>
-<translation id="7986741934819883144">Chagua anwani</translation>
-<translation id="7987073022710626672">Sheria na Masharti ya Chrome</translation>
-<translation id="7998918019931843664">Fungua tena kichupo kilichofungwa</translation>
-<translation id="7999064672810608036">Una uhakika unataka kufuta data zote za ndani, ikiwemo vidakuzi, na kuweka upya ruhusa za tovuti hii?</translation>
-<translation id="8004582292198964060">Kivinjari</translation>
-<translation id="8007176423574883786">Imezimwa kwa kifaa hiki</translation>
-<translation id="8013372441983637696">Pia, futa data yako ya Chrome kwenye kifaa hiki</translation>
-<translation id="8015452622527143194">Rejesha kila kitu katika ukubwa wa kawaida</translation>
-<translation id="802154636333426148">Haikuweza kupakua</translation>
-<translation id="8026334261755873520">Futa data ya kuvinjari</translation>
-<translation id="8035133914807600019">Folda mpya…</translation>
-<translation id="8037750541064988519">Zimesalia siku <ph name="DAYS" /></translation>
-<translation id="804335162455518893">Kadi ya SD haikupatikana</translation>
-<translation id="805047784848435650">Kulingana na historia yako ya kuvinjari</translation>
-<translation id="8051695050440594747">MB <ph name="MEGABYTES" /> zinapatikana</translation>
-<translation id="8058746566562539958">Fungua katika kichupo kipya cha Chrome</translation>
-<translation id="8063895661287329888">Haikuweza kuongeza alamisho.</translation>
-<translation id="806745655614357130">Weka data yangu katika sehemu tofauti</translation>
-<translation id="8067883171444229417">Cheza video</translation>
-<translation id="8068648041423924542">Imeshindwa kuchagua cheti.</translation>
-<translation id="8073388330009372546">Fungua picha katika kichupo kipya</translation>
-<translation id="8076492880354921740">Vichupo</translation>
-<translation id="8084114998886531721">Nenosiri lililohifadhiwa</translation>
-<translation id="8087000398470557479">Maudhui haya yanatoka <ph name="DOMAIN_NAME" />, yamewasilishwa na Google.</translation>
-<translation id="8103578431304235997">Kichupo Fiche</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Washa kipengele cha usawazishaji ili upate alamisho kwenye vifaa vyako vyote</translation>
-<translation id="8110087112193408731">Ungependa kuonyesha shughuli zako za Chrome katika mpango wa Nidhamu Dijitali?</translation>
-<translation id="8116925261070264013">Imezimwa</translation>
-<translation id="813082847718468539">Angalia maelezo ya tovuti</translation>
-<translation id="8131740175452115882">Thibitisha</translation>
-<translation id="8156139159503939589">Unaweza kusoma katika lugha gani?</translation>
-<translation id="8168435359814927499">Maudhui</translation>
-<translation id="8186512483418048923">Zimesalia faili <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Imesalia siku 1</translation>
-<translation id="8200772114523450471">Endelea</translation>
-<translation id="8209050860603202033">Fungua picha</translation>
-<translation id="8218622182176210845">Dhibiti akaunti yako</translation>
-<translation id="8224471946457685718">Ipakue makala unayopendekezewa kwenye Wi-Fi</translation>
-<translation id="8232956427053453090">Hifadhi data</translation>
-<translation id="8249310407154411074">Sogeza juu</translation>
-<translation id="8250920743982581267">Hati</translation>
-<translation id="825412236959742607">Ukurasa huu unatumia hifadhi kubwa mno, hivyo basi Chrome imeondoa baadhi ya maudhui.</translation>
-<translation id="8260126382462817229">Jaribu kuingia katika akaunti tena</translation>
-<translation id="8261506727792406068">Futa</translation>
-<translation id="8266862848225348053">Sehemu ya kuweka vipakuliwa</translation>
-<translation id="8274165955039650276">Angalia vipakuliwa</translation>
-<translation id="8284326494547611709">Manukuu</translation>
-<translation id="8300705686683892304">Zinazodhibitiwa na programu</translation>
-<translation id="8310344678080805313">Vichupo muundo-msingi</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> na tovuti zingine</translation>
-<translation id="8327155640814342956">Ili upate hali bora zaidi ya kuvinjari, fungua na usasishe Chrome</translation>
-<translation id="8339163506404995330">Kurasa za <ph name="LANGUAGE" /> hazitatafsiriwa</translation>
-<translation id="8349013245300336738">Panga kulingana na kiasi cha data kilichotumika</translation>
-<translation id="8364299278605033898">Ona tovuti maarufu</translation>
-<translation id="8368027906805972958">Kifaa kisichojulikana au kisichotumika (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Ruhusu Usawazishaji wa Chini Chini wa tovuti mahususi.</translation>
-<translation id="8378714024927312812">Inasimamiwa na shirika lako</translation>
-<translation id="8380167699614421159">Tovuti hii inaonyesha matangazo yanayopotosha au yanayokatiza huduma</translation>
-<translation id="8393700583063109961">Tuma ujumbe</translation>
-<translation id="8413126021676339697">Onyesha historia kamili</translation>
-<translation id="8427875596167638501">Kichupo cha kukagua kwanza kimefunguliwa nusu</translation>
-<translation id="8428213095426709021">Mipangilio</translation>
-<translation id="8438566539970814960">Boresha utafutaji na kuvinjari</translation>
-<translation id="8441146129660941386">Peleka nyuma</translation>
-<translation id="8443209985646068659">Chrome haiwezi kusasisha</translation>
-<translation id="8445448999790540984">Haiwezi kuhamisha manenosiri</translation>
-<translation id="8447861592752582886">Batilisha ruhusa ya kifaa</translation>
-<translation id="8461694314515752532">Simba data iliyosawazishwa kwa njia fiche ukitumia kauli yako ya siri ya usawazishaji</translation>
-<translation id="8466613982764129868">Hakikisha kwamba <ph name="TARGET_DEVICE_NAME" /> imeunganishwa kwenye intaneti</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Kinapatikana nje ya mtandao</translation>
-<translation id="8489271220582375723">Fungua ukurasa wa historia</translation>
-<translation id="8493948351860045254">Ongeza nafasi ya hifadhi</translation>
-<translation id="8497726226069778601">Bado hapana chochote cha kuangalia...</translation>
-<translation id="8503559462189395349">Manenosiri ya Chrome</translation>
-<translation id="8503813439785031346">Jina la mtumiaji</translation>
-<translation id="8514477925623180633">Tuma manenosiri yaliyohifadhiwa kwenye Chrome</translation>
-<translation id="8514577642972634246">Ingia kwenye hali fiche</translation>
-<translation id="851751545965956758">Zuia tovuti zisiunganishe kwenye vifaa</translation>
-<translation id="8523928698583292556">Futa manenosiri yaliyohifadhiwa</translation>
-<translation id="854522910157234410">Fungua ukurasa huu</translation>
-<translation id="8558485628462305855">Sasisha ARCore ili uangalie maudhui ya uhalisia ulioboreshwa</translation>
-<translation id="8559990750235505898">Jitolee kutafsiri kurasa katika lugha zingine</translation>
-<translation id="8562452229998620586">Manenosiri yaliyohifadhiwa yataonekana hapa.</translation>
-<translation id="8569404424186215731">tangu <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Wiki 4 zilizopita</translation>
-<translation id="857943718398505171">Imeruhusiwa (inapendekezwa)</translation>
-<translation id="8583805026567836021">Inafuta data ya akaunti</translation>
-<translation id="860043288473659153">Jina la mmiliki wa kadi</translation>
-<translation id="8609465669617005112">Songa juu</translation>
-<translation id="8616006591992756292">Huenda Akaunti yako ya Google ikawa na aina nyingine za historia ya kuvinjari kwenye <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Ungependa kufungua URL iliyopendekezwa na kubainishwa katika maudhui yaliyopakuliwa?</translation>
-<translation id="8636825310635137004">Ili upate vichupo kutoka kwenye vifaa vyako vingine, washa kipengele cha usawazishaji.</translation>
-<translation id="8641930654639604085">Jaribu kuzuia tovuti zilizo na maudhui ya watu wazima</translation>
-<translation id="8655129584991699539">Unaweza kufuta data hii katika Mipangilio ya Chrome</translation>
-<translation id="8662811608048051533">Hukuondoa kwenye tovuti nyingi.</translation>
-<translation id="8664979001105139458">Jina la faili tayari lipo</translation>
-<translation id="8676374126336081632">Futa uingizaji wa maandishi</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Kiwango cha Udhibiti wa Mawimbi: upau #}other{Kiwango cha Udhibiti wa Mawimbi: pau #}}</translation>
-<translation id="868929229000858085">Tafuta kwenye anwani zako</translation>
-<translation id="869891660844655955">Muda wake unakwisha tarehe</translation>
-<translation id="8719023831149562936">Haiwezi kusambaza kichupo cha sasa</translation>
-<translation id="8725066075913043281">Jaribu tena</translation>
-<translation id="8728487861892616501">Kwa kutumia programu hii, unakubaliana na <ph name="BEGIN_LINK1" />Sheria na Masharti<ph name="END_LINK1" /> na <ph name="BEGIN_LINK2" />Ilani ya Faragha<ph name="END_LINK2" /> ya Chrome na <ph name="BEGIN_LINK3" />Ilani ya Faragha ya Akaunti za Google Zinazodhibitiwa na Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Nimemaliza</translation>
-<translation id="8748850008226585750">Maudhui yamefichwa</translation>
-<translation id="8751914237388039244">Chagua picha</translation>
-<translation id="8788265440806329501">Historia ya uelekezaji imezimwa</translation>
-<translation id="8788968922598763114">Fungua tena kichupo kilichofungwa mwisho</translation>
-<translation id="8801436777607969138">Zuia JavaScript katika tovuti mahususi.</translation>
-<translation id="8812260976093120287">Kwenye baadhi ya tovuti, unaweza kulipa kwa programu za malipo zinazotumika zilizo hapo juu kwenye kifaa chako.</translation>
-<translation id="8816026460808729765">Zuia tovuti zisifikie vitambuzi vya mwendo</translation>
-<translation id="8816439037877937734">Itafungua <ph name="APP_NAME" /> katika Chrome. Kwa kuendelea, unakubali <ph name="BEGIN_LINK1" />Sheria na Masharti<ph name="END_LINK1" /> na <ph name="BEGIN_LINK2" />Ilani ya Faragha<ph name="END_LINK2" />, na <ph name="BEGIN_LINK3" />Ilani ya Faragha ya Akaunti za Google Zinazodhibitiwa na Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Alamisho</translation>
-<translation id="8833831881926404480">Tovuti inashiriki skrini yako</translation>
-<translation id="883806473910249246">Hitilafu imetokea wakati wa kupakua maudhui.</translation>
-<translation id="8840953339110955557">Ukurasa huu huenda ukatofautiana na toleo la mtandaoni.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, kichupo</translation>
-<translation id="885701979325669005">Hifadhi</translation>
-<translation id="889338405075704026">Nenda kwenye mipangilio ya Chrome</translation>
-<translation id="8901170036886848654">Hakuna alamisho zilizopatikana</translation>
-<translation id="8909135823018751308">Shiriki...</translation>
-<translation id="8912362522468806198">Akaunti ya Google</translation>
-<translation id="8920114477895755567">Tunasubiri maelezo ya wazazi.</translation>
+<translation id="1188239144602654184">Weka Uhalisia Ulioboreshwa</translation>
+<translation id="473775607612524610">Sasisha</translation>
+<translation id="3133489217401741157">Inasakinisha <ph name="MODULE"/> kwenye Brave…</translation>
+<translation id="1791662854739702043">Imesakinishwa</translation>
+<translation id="5131234170665854056">Imeshindwa kusakinisha <ph name="MODULE"/> kwenye Brave</translation>
+<translation id="2567385386134582609">PICHA</translation>
+<translation id="6395288395575013217">KIUNGO</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Pakua kurasa uzitumie nje ya mtandao</translation>
 <translation id="8922289737868596582">Pakua kurasa kwenye kitufe cha Chaguo zaidi ili uzitumie nje ya mtandao</translation>
-<translation id="8937772741022875483">Ungependa kuondoa Shughuli zako za Chrome kwenye mpango wa Nidhamu Dijitali?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Fungua katika dirisha jingine</translation>
-<translation id="8951232171465285730">Chrome imekuokolea MB <ph name="MEGABYTES" /></translation>
-<translation id="8958424370300090006">Zuia vidakuzi katika tovuti maalum.</translation>
-<translation id="8959122750345127698">Kudurusu hakufikiki: <ph name="URL" /></translation>
-<translation id="8965591936373831584">inasubiri</translation>
-<translation id="8970887620466824814">Hitilafu imetokea.</translation>
-<translation id="8972098258593396643">Ungependa kupakua kwenye folda chaguomsingi?</translation>
-<translation id="8986494364107987395">Tumia Google takwimu za matumizi na ripoti za mara ambazo kivinjari kinaacha kufanya kazi, moja kwa moja</translation>
-<translation id="8993760627012879038">Fungua kichupo kipya katika Hali fiche</translation>
-<translation id="8998729206196772491">Unaingia kwa kutumia akaunti inayodhibitiwa na <ph name="MANAGED_DOMAIN" /> na kumpa msimamizi wa kikoa hicho udhibiti wa data yako ya Chrome. Data yako ya Chrome itahusishwa na akaunti hii daima. Kuondoka kwenye Chrome kutafuta data yako kwenye kifaa hiki, lakini itaendelea kuhifadhiwa katika Akaunti yako ya Google.</translation>
-<translation id="9019902583201351841">Inadhibitiwa na wazazi wako</translation>
-<translation id="9028914725102941583">Washa usawazishaji ili ushiriki kwenye vifaa vyote</translation>
-<translation id="9029323097866369874">Ungependa kuruhusu <ph name="DOMAIN" /> kuanzisha VR?</translation>
-<translation id="9040142327097499898">Arifa zinaruhusiwa. Kipengele cha mahali kimezimwa kwenye kifaa hiki.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{Video #}other{Video #}}</translation>
-<translation id="9050666287014529139">Kaulisiri</translation>
-<translation id="9063523880881406963">Zima Omba Tovuti ya Eneo-kazi</translation>
-<translation id="9065203028668620118">Badilisha</translation>
-<translation id="9070377983101773829">Anza kutafuta kwa kutamka</translation>
-<translation id="9074336505530349563">Ingia katika akaunti na uwashe kipengee cha usawazishaji ili upate maudhui yanayokufaa unayopendekezewa na Google</translation>
-<translation id="9086455579313502267">Haiwezi kufikia mtandao</translation>
-<translation id="9100505651305367705">Onyesha makala katika mwonekano rahisi, ikiwa yanatumika</translation>
-<translation id="9100610230175265781">Kaulisiri inahitajika</translation>
-<translation id="9102803872260866941">Kichupo cha kukagua kwanza kimefunguliwa</translation>
+<translation id="5958275228015807058">Tafuta faili na kurasa zako katika Vipakuliwa</translation>
+<translation id="5620928963363755975">Tafuta faili na kurasa zako katika Vipakuliwa kwenye kitufe cha Chaguo Nyingine</translation>
+<translation id="3341058695485821946">Ona kiasi cha data ulichookoa</translation>
+<translation id="3157842584138209013">Ona kiasi cha data ulichookoa kwa kubofya kitufe cha Chaguo Zaidi</translation>
+<translation id="8218622182176210845">Dhibiti akaunti yako</translation>
+<translation id="8090895580117672212">Ili udhibiti akaunti yako ya Brave Software, gusa kitufe cha "Dhibiti akaunti"</translation>
+<translation id="8856898588039823173">Ukurasa mwepesi umetolewa na Brave Software. Gusa ili upakie ukurasa halisi.</translation>
+<translation id="8134317863207426198">Ukurasa mwepesi umetolewa na Brave Software. Gusa kitufe cha pakia halisi ili upakie ukurasa halisi.</translation>
+<translation id="4961107849584082341">Tafsiri ukurasa huu katika lugha yoyote</translation>
+<translation id="569536719314091526">Tafsiri ukurasa huu katika lugha yoyote kutoka kitufe cha Chaguo zaidi</translation>
+<translation id="1397811292916898096">Tafuta kwa <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Badilisha sehemu chaguomsingi ya kupakua wakati wowote</translation>
+<translation id="6942665639005891494">Badilisha sehemu chaguomsingi ya kupakua wakati wowote ukitumia chaguo la menyu ya Mipangilio</translation>
+<translation id="6850409657436465440">Bado inapakua faili</translation>
+<translation id="5817715962196959877">Sasa Brave inapakua faili haraka zaidi</translation>
+<translation id="3976396876660209797">Ondoa na uunde upya njia hii ya mkato</translation>
+<translation id="6766622839693428701">Telezesha chini ili ufunge.</translation>
+<translation id="1028699632127661925">Unatuma kwenye <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - Imetumwa kutoka <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Umepokea kichupo</translation>
 <translation id="9104217018994036254">Orodha ya vifaa vinavyoweza kutumia kichupo pamoja.</translation>
-<translation id="9133397713400217035">Pitia Ukiwa Nje ya Mtandao</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Onyesha asili</translation>
-<translation id="9139068048179869749">Uliza kabla ya kuruhusu tovuti zitume arifa (inapendekezwa)</translation>
-<translation id="9139318394846604261">Ununuzi</translation>
-<translation id="9155898266292537608">Unaweza pia kutafuta kwa kugusa haraka kwenye neno</translation>
-<translation id="9169507124922466868">Historia ya uelekezaji imefunguliwa nusu</translation>
-<translation id="9204836675896933765">Imesalia faili 1</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Orodha ya vifaa vinavyoweza kutumia kichupo pamoja imefunguliwa kwenye nusu ya skrini.</translation>
+<translation id="2904414404539560095">Orodha ya vifaa vinavyoweza kutumia kichupo pamoja imefunguliwa kwenye skrini nzima.</translation>
+<translation id="4135200667068010335">Orodha ya vifaa vinavyoweza kutumia kichupo pamoja imefungwa.</translation>
+<translation id="5292796745632149097">Tuma kwenye</translation>
+<translation id="1386674309198842382">Ilitumika siku <ph name="LAST_UPDATED"/> zilizopita</translation>
+<translation id="7971136598759319605">Ilitumika siku 1 iliyopita</translation>
+<translation id="1521774566618522728">Ameitumia leo</translation>
+<translation id="3631987586758005671">Inashiriki kwenye <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Washa usawazishaji ili ushiriki kwenye vifaa vyote</translation>
+<translation id="6162454065885854378">Ili ushiriki kitu kutoka simu yako hadi kifaa kingine, washa usawazishaji katika mipangilio ya Brave kwenye vifaa vyote viwili</translation>
+<translation id="6084271560289605378">Nenda kwenye mipangilio ya Brave</translation>
+<translation id="2318045970523081853">Gusa ili upige simu</translation>
 <translation id="9209888181064652401">Imeshindwa kupiga simu</translation>
-<translation id="9219103736887031265">Picha</translation>
-<translation id="926205370408745186">Ondoa shughuli zako za Chrome kwenye mpango wa Nidhamu Dijitali</translation>
-<translation id="932327136139879170">Mwanzo</translation>
-<translation id="938850635132480979">Hitilafu: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Kufikia maikrofoni yako</translation>
-<translation id="95817756606698420">Chrome inaweza kutumia <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> kutafuta nchini Uchina. Unaweza kuibadilisha katika <ph name="BEGIN_LINK" />MipangilioE<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Zuia ikiwa tovuti inaonyesha matangazo yanayopotosha au yanayokatiza huduma (inapendekezwa)</translation>
-<translation id="968900484120156207">Kurasa unazotembelea zitaonekana hapa</translation>
-<translation id="970715775301869095">Zimesalia dakika <ph name="MINUTES" /></translation>
-<translation id="974555521953189084">Andika kauli yako ya siri ili uanze kusawazisha</translation>
-<translation id="981121421437150478">Nje ya mtandao</translation>
-<translation id="982182592107339124">Hatua hii itafuta data ya tovuti zote, ikiwa ni pamoja na:</translation>
-<translation id="983192555821071799">Funga vichupo vyote</translation>
-<translation id="987264212798334818">Jumla</translation>
+<translation id="2860954141821109167">Hakikisha kuwa programu ya simu imewashwa kwenye kifaa hiki</translation>
+<translation id="2067805253194386918">maandishi</translation>
+<translation id="1450753235335490080">Imeshindwa kushiriki <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Imeshindwa kushiriki <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Hakikisha kuwa umewasha kipengele cha usawazishaji katika <ph name="TARGET_DEVICE_NAME"/> kwenye Brave</translation>
+<translation id="3016635187733453316">Hakikisha kwamba kifaa hiki kimeunganishwa kwenye intaneti</translation>
+<translation id="8466613982764129868">Hakikisha kwamba <ph name="TARGET_DEVICE_NAME"/> imeunganishwa kwenye intaneti</translation>
+<translation id="6539092367496845964">Hitilafu fulani imetokea. Jaribu tena baadaye.</translation>
+<translation id="3389286852084373014">Maandishi ni makubwa mno</translation>
+<translation id="2100314319871056947">Jaribu kushiriki maandishi katika sehemu ndogo ndogo</translation>
+<translation id="2987620471460279764">Maandishi yaliyoshirikiwa kutoka kifaa kingine</translation>
+<translation id="7757787379047923882">Maandishi yameshirikiwa kutoka <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Imenakiliwa kwenye ubao wa kunakili</translation>
+<translation id="4696983787092045100">Tuma maandishi kwenye Vifaa Vyako</translation>
+<translation id="1260236875608242557">Tafuta na ugundue</translation>
+<translation id="6369229450655021117">Ukiwa hapa, unaweza kutafuta kwenye wavuti, kushiriki na marafiki na kuona kurasa ambazo zimefunguliwa</translation>
+<translation id="723171743924126238">Chagua picha</translation>
+<translation id="8751914237388039244">Chagua picha</translation>
+<translation id="1989112275319619282">Vinjari</translation>
+<translation id="7055152154916055070">Imezuiwa kuelekeza kwingine:</translation>
+<translation id="5524843473235508879">Imezuia shughuli ya kuelekeza kwingine.</translation>
+<translation id="6573096386450695060">Ruhusu kila wakati</translation>
+<translation id="5805364706385912897">Ukurasa huu unatumia hifadhi kubwa zaidi, kwa hivyo Brave imeusitisha.</translation>
+<translation id="5138664332909611586">Ukurasa huu unatumia hifadhi kubwa mno, hivyo basi Brave imeondoa baadhi ya maudhui.</translation>
+<translation id="9137013805542155359">Onyesha asili</translation>
+<translation id="6361779936989026201">Mratibu wa Brave Software katika Brave</translation>
+<translation id="7291387454912369099">Ulipaji Unaoanzishwa na Mratibu</translation>
+<translation id="4565206163201411670">Ungependa kuonyesha shughuli zako za Brave katika mpango wa Nidhamu Dijitali?</translation>
+<translation id="9055113864158719823">Unaweza kuona tovuti ambazo ulitembelea katika Brave na kuziwekea vipima muda.\n\nBrave Software inapata maelezo kuhusu tovuti ulizowekea vipima muda na muda unaozitembelea. Tunatumia maelezo haya kuboresha mpango wa Nidhamu Dijitali.</translation>
+<translation id="4596514158372210596">Ondoa shughuli zako za Brave kwenye mpango wa Nidhamu Dijitali</translation>
+<translation id="1174893863889683998">Ungependa kuondoa Shughuli zako za Brave kwenye mpango wa Nidhamu Dijitali?</translation>
+<translation id="708829030563435351">Haitaonyesha tovuti unazotembelea katika Brave. Itafuta vipima muda vyote kwenye tovuti.</translation>
+<translation id="2056878612599315956">Tovuti imesimamishwa</translation>
+<translation id="671481426037969117">Kipindi cha kipima muda cha <ph name="FQDN"/> kimeisha. Kitaanza tena kesho.</translation>
+<translation id="7479104141328977413">Udhibiti wa kichupo</translation>
+<translation id="3524138585025253783">Kiolesura cha Msanidi Programu</translation>
+<translation id="6036057147555329831">ICU ya Ziada</translation>
+<translation id="9029323097866369874">Ungependa kuruhusu <ph name="DOMAIN"/> kuanzisha VR?</translation>
+<translation id="7685301384041462804">Hakikisha kuwa unaamini tovuti hii kabla ya kuanzisha VR.</translation>
+<translation id="5033865233969348410">Wakati upo katika VR, tovuti hii inaweza kujifunza kuhusu:
+ -  sifa zako za mwili, kama vile urefu,
+
+Hakikisha kwamba unaamini tovuti hii kabla ya kuingia katika VR.</translation>
+<translation id="5534334044554683961">Ukiwa katika VR, tovuti hii inaweza kujifunza kuhusu:
+  -   sifa zako za mwili, kama vile urefu
+  -   muundo wa chumba chako
+Hakikisha kwamba unaamini tovuti hii kabla ya kuingia katika VR.</translation>
+<translation id="4169535189173047238">Usiruhusu</translation>
+<translation id="2170088579611075216">Ruhusu na uingie katika VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_ta.xtb
+++ b/android/java/strings/translations/android_chrome_strings_ta.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="ta">
-<translation id="1006017844123154345">ஆன்லைனில் திற</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> சாதனத்திற்கு அனுப்புகிறது...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" />ஐச் சேர்க்கிறது...</translation>
-<translation id="1041308826830691739">இணையதளங்களிலிருந்து</translation>
-<translation id="1049743911850919806">மறைநிலை</translation>
-<translation id="10614374240317010">எப்போதும் சேமிக்காதவை</translation>
-<translation id="1067922213147265141">பிற Google சேவைகள்</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" /> மொழியில் உள்ள பக்கங்களை ஒருபோதும் மொழிபெயர்க்காதே</translation>
-<translation id="107147699690128016">கோப்பு நீட்டிப்பை மாற்றினால் இந்தக் கோப்பு வேறொரு ஆப்ஸில் திறக்கக்கூடும், இது உங்கள் சாதனத்திற்குத் தீங்கிழைக்கக்கூடும்.</translation>
-<translation id="1100066534610197918">குழுவில் புதிய தாவலில் திற</translation>
-<translation id="1105960400813249514">திரைப் படப்பிடிப்பு</translation>
-<translation id="1111673857033749125">உங்கள் பிற சாதனங்களில் சேமிக்கும் புக்மார்க்குகள் இங்கே தோன்றும்.</translation>
-<translation id="1113597929977215864">எளிதாக்கப்பட்ட காட்சியைக் காட்டு</translation>
-<translation id="1121094540300013208">பயன்பாட்டு மற்றும் சிதைவு அறிக்கைகள்</translation>
-<translation id="1124772482545689468">பயனர்</translation>
-<translation id="1129510026454351943">விவரங்கள்: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{ஒரு பதிவிறக்கம் நிலுவையில் உள்ளது.}other{# பதிவிறக்கங்கள் நிலுவையில் உள்ளன.}}</translation>
-<translation id="1145536944570833626">ஏற்கனவே உள்ள தரவை நீக்கு.</translation>
-<translation id="1146678959555564648">VRஐ உள்ளிடு</translation>
-<translation id="116280672541001035">பயன்படுத்தியது</translation>
-<translation id="1171770572613082465">"பிரபலமானவை" பட்டனைத் தட்டி பிரபல இணையதளங்களைப் பாருங்கள்</translation>
-<translation id="1173894706177603556">மறுபெயரிடு</translation>
-<translation id="1178581264944972037">இடைநிறுத்து</translation>
-<translation id="1181037720776840403">அகற்று</translation>
-<translation id="1188239144602654184">ARரில் நுழைக</translation>
-<translation id="1197267115302279827">புத்தகக்குறிகளை நகர்த்து</translation>
-<translation id="119944043368869598">அனைத்தையும் அழி</translation>
-<translation id="1201402288615127009">அடுத்து</translation>
-<translation id="1204037785786432551">இணைப்பைப் பதிவிறக்கு</translation>
-<translation id="1206892813135768548">இணைப்பு உரையை நகலெடு</translation>
-<translation id="1208340532756947324">அனைத்துச் சாதனங்களுக்கு இடையிலும் ஒத்திசைக்க மற்றும் தனிப்பயனாக்க, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="1209206284964581585">இப்போதைக்கு மறை</translation>
-<translation id="1227058898775614466">வழிசெலுத்தல் வரலாறு</translation>
-<translation id="1231733316453485619">ஒத்திசைவை இயக்கவா?</translation>
-<translation id="123724288017357924">தற்காலிக சேமிப்பைப் புறக்கணித்து, நடப்புப் பக்கத்தை மீண்டும் ஏற்றும்</translation>
-<translation id="124116460088058876">மேலும் மொழிகள்</translation>
-<translation id="124678866338384709">தற்போதைய தாவலை மூடும்</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">இணையத்தில் தேடுக &amp; உள்ளடக்கங்களை உலாவுக</translation>
-<translation id="1264974993859112054">விளையாட்டு</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" />ஐப் பகிர முடியவில்லை</translation>
-<translation id="1272079795634619415">நிறுத்து</translation>
-<translation id="1283039547216852943">விரிவாக்க, தட்டவும்</translation>
-<translation id="1285320974508926690">இந்த தளத்தை எப்போதும் மொழிபெயர்க்க வேண்டாம்</translation>
-<translation id="1291207594882862231">வரலாறு, குக்கீகள், தளத் தரவு, தற்காலிகச் சேமிப்பை அழி…</translation>
-<translation id="129382876167171263">இணையதளங்கள் சேமித்த கோப்புகள் இங்கே தோன்றும்</translation>
-<translation id="129553762522093515">சமீபத்தில் மூடியவை</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> சாதனத்திலிருந்து அனுப்பப்பட்டது</translation>
-<translation id="1310482092992808703">தாவல்களைக் குழுவாக்கு</translation>
-<translation id="1327257854815634930">வழிசெலுத்தல் வரலாறு திறக்கப்பட்டுள்ளது</translation>
-<translation id="1331212799747679585">Chromeமைப் புதுப்பிக்க முடியாது. கூடுதல் விருப்பங்கள்</translation>
-<translation id="1332501820983677155">Google Chrome அம்சத்திற்கான ஷார்ட்கட்கள்</translation>
-<translation id="1360432990279830238">வெளியேறி, ஒத்திசைவை முடக்கவா?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> தளம் சேர்க்கப்பட்டது</translation>
-<translation id="1373696734384179344">தேர்ந்தெடுத்ததைப் பதிவிறக்க, போதுமான நினைவகம் இல்லை.</translation>
-<translation id="1376578503827013741">கணக்கிடுகிறது…</translation>
-<translation id="1383876407941801731">தேடல்</translation>
-<translation id="1384959399684842514">பதிவிறக்கம் இடைநிறுத்தப்பட்டது</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> நாட்களுக்கு முன் பயன்படுத்தியுள்ளார்</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> மூலம் தேடுக</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" /> இல் உட்பொதிக்கப்பட்டது</translation>
-<translation id="1406000523432664303">'கண்காணிக்க வேண்டாம்'</translation>
-<translation id="1407135791313364759">எல்லாவற்றையும் திற</translation>
-<translation id="1409426117486808224">திறக்கப்பட்டுள்ள தாவல்களுக்கான எளிதாக்கப்பட்ட காட்சி</translation>
-<translation id="1409879593029778104">கோப்பு ஏற்கனவே இருப்பதால் <ph name="FILE_NAME" /> இன் பதிவிறக்கம் தடுக்கப்பட்டது.</translation>
-<translation id="1414981605391750300">Googleஐத் தொடர்புகொள்கிறது. இதற்குச் சில வினாடிகள் ஆகலாம்…</translation>
-<translation id="1416550906796893042">ஆப்ஸின் பதிப்பு</translation>
-<translation id="1430915738399379752">அச்சிடுக</translation>
-<translation id="1446450296470737166">MIDI சாதனங்களுக்கு முழுக் கட்டுப்பாட்டை அனுமதி</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" />ஐப் பகிர முடியவில்லை</translation>
-<translation id="145097072038377568">Android அமைப்புகளில் முடக்கப்பட்டுள்ளது.</translation>
-<translation id="1477626028522505441">சேவையகச் சிக்கல்களால் <ph name="FILE_NAME" />ஐப் பதிவிறக்க முடியவில்லை.</translation>
-<translation id="1506061864768559482">தேடல் இன்ஜின்</translation>
-<translation id="1513352483775369820">புத்தகக்குறிகளும் இணைய வரலாறும்</translation>
-<translation id="1513858653616922153">கடவுச்சொல்லை நீக்கு</translation>
-<translation id="1516229014686355813">"தேடுவதற்குத் தட்டு" எனும் அம்சமானது தேர்ந்தெடுத்த சொல்லையும், அதனுடைய பின்னணிச் சூழலாக நடப்புப் பக்கத்தையும் Google தேடலுக்கு அனுப்பும். இதை <ph name="BEGIN_LINK" />அமைப்புகளில்<ph name="END_LINK" /> முடக்கலாம்.</translation>
-<translation id="1521774566618522728">இன்று பயன்படுத்தியுள்ளார்</translation>
-<translation id="1544826120773021464">உங்கள் Google கணக்கை நிர்வகிக்க "கணக்கை நிர்வகி" என்ற பட்டனைத் தட்டுங்கள்</translation>
-<translation id="1549000191223877751">வேறு சாளரத்திற்கு நகர்த்து</translation>
-<translation id="1553358976309200471">Chromeஐப் புதுப்பி</translation>
-<translation id="1569387923882100876">இணைத்த சாதனம்</translation>
-<translation id="1571304935088121812">பயனர்பெயரை நகலெடுக்கும்</translation>
-<translation id="1612196535745283361">சாதனங்களைத் தேட Chromeமுக்கு இருப்பிட அணுகல் தேவை. இருப்பிட அணுகல், <ph name="BEGIN_LINK" />இந்தச் சாதனத்தில் முடக்கப்பட்டுள்ளது<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">கேமரா</translation>
-<translation id="1623104350909869708">கூடுதல் உரையாடல்களை உருவாக்குவதிலிருந்து இந்தப் பக்கத்தைத் தடு</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{தேர்ந்தெடுத்த 1 உருப்படியை அகற்றும்}other{தேர்ந்தெடுத்த # உருப்படிகளை அகற்றும்}}</translation>
-<translation id="164269334534774161"><ph name="CREATION_TIME" /> அன்றைக்கான இந்தப் பக்கத்தின் ஆஃப்லைன் நகலைப் பார்க்கிறீர்கள்</translation>
-<translation id="1644574205037202324">வரலாறு</translation>
-<translation id="1647391597548383849">உங்கள் கேமராவை அணுகலாம்</translation>
-<translation id="1660204651932907780">ஒலியை இயக்க, தளங்களை அனுமதிக்கும் (பரிந்துரைக்கப்படுவது)</translation>
-<translation id="1670399744444387456">அடிப்படை</translation>
-<translation id="1671236975893690980">பதிவிறக்கம் நிலுவையில் உள்ளது…</translation>
-<translation id="1672586136351118594">மீண்டும் காட்டாதே</translation>
-<translation id="1692118695553449118">ஒத்திசைவு இயக்கத்தில்</translation>
-<translation id="169515064810179024">தளங்கள் மோஷன் சென்சார்களை அணுகுவதைத் தடுக்கும்</translation>
-<translation id="1717218214683051432">மோஷன் சென்சார்கள்</translation>
-<translation id="1718835860248848330">கடந்த ஒரு மணிநேரம்</translation>
-<translation id="1736419249208073774">அறிக</translation>
-<translation id="1743802530341753419">சாதனத்தை இணைக்க, தளங்களை அனுமதிப்பதற்கு முன், கேள் (பரிந்துரைக்கப்படுவது)</translation>
-<translation id="1749561566933687563">உங்கள் புத்தகக்குறிகளை ஒத்திசைக்கவும்</translation>
-<translation id="17513872634828108">தாவல்களைத் திற</translation>
-<translation id="1779089405699405702">இமேஜ் டீகோடர்</translation>
-<translation id="1782483593938241562">முடிவுத் தேதி: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">நிறுவப்பட்டது</translation>
-<translation id="1792959175193046959">எப்போது வேண்டுமானாலும் இயல்புப் பதிவிறக்க இடத்தை மாற்றலாம்</translation>
-<translation id="1807246157184219062">வெளிச்சம்</translation>
-<translation id="1810845389119482123">ஒத்திசைவின் முதற்கட்ட அமைவு நிறைவடையவில்லை</translation>
-<translation id="1821253160463689938">நீங்கள் அந்தப் பக்கங்களைப் பார்வையிடவில்லை என்றாலும், உங்கள் விருப்பத்தேர்வுகளை நினைவில்கொள்ள குக்கீகளைப் பயன்படுத்தும்</translation>
-<translation id="1829244130665387512">இந்தப் பக்கத்தில் தேடு</translation>
-<translation id="1853692000353488670">புதிய மறைநிலை தாவல்</translation>
-<translation id="1856325424225101786">லைட் பயன்முறையை மீட்டமைக்கவா?</translation>
-<translation id="1868024384445905608">Chrome இப்போது கோப்புகளை வேகமாகப் பதிவிறக்குகிறது</translation>
-<translation id="1883903952484604915">எனது கோப்புகள்</translation>
-<translation id="1887786770086287077">இந்தச் சாதனத்திற்கான இருப்பிட அணுகல் முடக்கப்பட்டுள்ளது. அதை <ph name="BEGIN_LINK" />Android அமைப்புகளில்<ph name="END_LINK" /> இயக்கவும்.</translation>
-<translation id="1891331835972267886">Chrome இல் <ph name="APP_NAME" /> திறக்கும். தொடர்வதன் மூலம், Chrome இன் <ph name="BEGIN_LINK1" />சேவை விதிமுறைகள்<ph name="END_LINK1" /> மற்றும் <ph name="BEGIN_LINK2" />தனியுரிமை அறிக்கையை<ph name="END_LINK2" /> ஏற்கிறீர்கள்.</translation>
-<translation id="1919345977826869612">விளம்பரங்கள்</translation>
-<translation id="1919950603503897840">தொடர்புகளைத் தேர்ந்தெடுக்கவும்</translation>
-<translation id="1922076542920281912">Chrome உங்கள் இருப்பிடத் தகவலை அணுக அனுமதிப்பதற்கு <ph name="BEGIN_LINK" />Android அமைப்புகளிலும்<ph name="END_LINK" /> இருப்பிடத்தை இயக்கவும்.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">புதுப்பிப்புகள்</translation>
-<translation id="19288952978244135">Chromeமை மீண்டும் திறக்கவும்.</translation>
-<translation id="1933845786846280168">தேர்ந்தெடுத்த தாவல்</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android அமைப்புகளில்<ph name="END_LINK" /> Chromeக்கான அனுமதியை இயக்கவும்.</translation>
-<translation id="1943432128510653496">கடவுச்சொற்களைச் சேமி</translation>
-<translation id="1952172573699511566">சாத்தியமான போது, நீங்கள் விரும்பும் மொழியில் உரையை இணையதளங்கள் காட்டும்.</translation>
-<translation id="1960290143419248813">இந்த Android பதிப்பினை Chrome புதுப்பிப்புகள் இனி ஆதரிக்காது</translation>
-<translation id="1966710179511230534">உங்கள் உள்நுழைவு விவரங்களைப் புதுப்பிக்கவும்.</translation>
-<translation id="1974060860693918893">மேம்பட்டவை</translation>
-<translation id="1984705450038014246">உங்கள் Chrome தரவை ஒத்திசைக்கவும்</translation>
-<translation id="1984937141057606926">அனுமதிக்கப்பட்டது, மூன்றாம் தரப்பைத் தவிர</translation>
-<translation id="1986685561493779662">பெயர் ஏற்கனவே உள்ளது</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> பட்டன்</translation>
-<translation id="1989112275319619282">உலாவு</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> இணைய விரும்புகிறது</translation>
-<translation id="1994173015038366702">தள URL</translation>
-<translation id="2000419248597011803">முகவரிப் பட்டியிலிருந்தும், தேடல் பெட்டியிலிருந்தும் சில குக்கீகளையும் தேடல்களையும் உங்கள் இயல்புத் தேடல் இன்ஜினுக்கு அனுப்பும்</translation>
-<translation id="2002537628803770967">Google Payயைப் பயன்படுத்தும் கிரெடிட் கார்டுகள் மற்றும் முகவரிகள்</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# கோப்பு}other{# கோப்புகள்}}</translation>
-<translation id="2017836877785168846">முகவரிப் பட்டியில் வரலாற்றையும் தானே நிரப்புதல்களையும் அழிக்கும்.</translation>
-<translation id="2021896219286479412">முழுத் திரை தளக் கட்டுப்பாடுகள்</translation>
-<translation id="2038563949887743358">டெஸ்க்டாப் தளத்திற்கான கோரிக்கையை இயக்கு</translation>
-<translation id="2041019821020695769">Chrome உங்களுக்கு அறிவிப்புகளை அனுப்ப அனுமதிப்பதற்கு<ph name="BEGIN_LINK" />Android அமைப்புகளிலும்<ph name="END_LINK" /> அறிவிப்புகளை இயக்கவும்.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> ஆப்ஸின் தரவும் Chromeமில் உள்ளது</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">தளம் இடைநிறுத்தப்பட்டுள்ளது</translation>
-<translation id="2063713494490388661">தேடத் தட்டுக</translation>
-<translation id="2067805253194386918">உரை</translation>
-<translation id="2079545284768500474">செயல்தவிர்</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" /> முடிவுகளில் <ph name="RESULT_NUMBER" />வது முடிவு</translation>
-<translation id="2091887806945687916">ஒலி</translation>
-<translation id="2096012225669085171">பல சாதனங்களுக்கிடையில் ஒத்திசைக்கலாம், தனிப்பயனாக்கலாம்</translation>
-<translation id="2100273922101894616">தானாக உள்நுழையவும்</translation>
-<translation id="2100314319871056947">சிறுசிறு பகுதியாக உரையைப் பகிர முயலவும்</translation>
-<translation id="2107397443965016585">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்குவதற்குத் தளங்களை அனுமதிக்கும் முன்பு அனுமதி கோரும் (பரிந்துரைக்கப்படுவது)</translation>
-<translation id="2111511281910874386">பக்கத்திற்குச் செல்லவும்</translation>
-<translation id="2122601567107267586">பயன்பாட்டைத் திறக்க முடியவில்லை</translation>
-<translation id="2126426811489709554">Chromeஇல் இயங்குகிறது</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> சேமிக்கப்பட்டது</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> மூடப்பட்டது</translation>
-<translation id="2139186145475833000">முகப்புத் திரையில் சேர்</translation>
-<translation id="2146738493024040262">இன்ஸ்டண்ட் ஆப்ஸைத் திற</translation>
-<translation id="2148716181193084225">இன்று</translation>
-<translation id="2154484045852737596">கார்டைத் திருத்தவும்</translation>
-<translation id="2154710561487035718">URL ஐ நகலெடு</translation>
-<translation id="2156074688469523661">மீதமுள்ள தளங்கள் (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">உங்கள் மொபைலில் இருந்து வேறொரு சாதனத்திற்குப் பகிர, இரண்டு சாதனங்களிலும் Chrome அமைப்புகளில் ஒத்திசைவு என்பதை ஆன் செய்யவும்</translation>
-<translation id="2170088579611075216">VRரை அனுமதித்துத் தொடங்கு</translation>
-<translation id="218608176142494674">பகிர்தல்</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> ஆகத் தொடர்க</translation>
-<translation id="2234876718134438132">ஒத்திசைவு &amp; Google சேவைகள்</translation>
-<translation id="2259659629660284697">கடவுச்சொற்களை ஏற்று…</translation>
-<translation id="2268044343513325586">துல்லியமாக்கு</translation>
-<translation id="2286841657746966508">பில்லிங் முகவரி</translation>
-<translation id="2289270750774289114">அருகிலுள்ள புளூடூத் சாதனங்களை வலைதளம் கண்டறிய முயலும்போது கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="230115972905494466">இணக்கமான சாதனங்கள் இல்லை</translation>
-<translation id="2315043854645842844">கிளையன்ட் சார்பாக சான்றிதழ் தேர்ந்தெடுப்பை ஆப்ரேட்டிங் சிஸ்டம் ஆதரிக்கவில்லை.</translation>
-<translation id="2318045970523081853">அழைக்க தட்டவும்</translation>
-<translation id="2321086116217818302">கடவுச்சொற்கள் தயாராகின்றன…</translation>
-<translation id="2321958826496381788">இதை வசதியாக படிப்பதற்கு, ஸ்லைடரை இழுக்கவும். பத்தியில் இரு முறை தட்டிய பிறகு, உரையானது குறைந்தது இந்த அளவு பெரியதாக தோன்ற வேண்டும்.</translation>
-<translation id="2323763861024343754">தளச் சேமிப்பகம்</translation>
-<translation id="2328985652426384049">உள்நுழைய முடியவில்லை</translation>
-<translation id="2330129964253841015">கடவுச்சொற்கள் அபகரிக்கப்பட்டிருந்தால் அதுகுறித்து எச்சரிக்கவும்</translation>
-<translation id="2349710944427398404">கணக்குகள், புக்மார்க்குகள், சேமித்த அமைப்புகள் உள்பட Chrome பயன்படுத்தும் மொத்தத் தரவு</translation>
-<translation id="2353636109065292463">உங்கள் இணைய இணைப்பைச் சரிபார்க்கிறது</translation>
-<translation id="2359808026110333948">தொடர்க</translation>
-<translation id="2369533728426058518">திறக்கப்பட்டுள்ள தாவல்கள்</translation>
-<translation id="2387895666653383613">உரை அளவிடல்</translation>
-<translation id="2394602618534698961">நீங்கள் பதிவிறக்கிய கோப்புகளை இங்கே பார்க்கலாம்</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> மெ.பை.</translation>
-<translation id="2407481962792080328">உங்கள் Google கணக்கில் உள்நுழையும்போது இந்த அம்சம் ஆன் செய்யப்படும்</translation>
-<translation id="2410754283952462441">கணக்கைத் தேர்வு செய்யவும்</translation>
-<translation id="2414886740292270097">அடர்</translation>
-<translation id="2416359993254398973">இந்தத் தளத்திற்காகக் கேமராவை அணுக, Chromeமுக்கு அனுமதி தேவை.</translation>
-<translation id="2426805022920575512">மற்றொரு கணக்கைத் தேர்வுசெய்க</translation>
-<translation id="2433507940547922241">தோற்றம்</translation>
-<translation id="2434158240863470628">பதிவிறக்கம் முடிந்தது <ph name="SEPARATOR" /><ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">இருப்பிட அணுகல்</translation>
-<translation id="2450083983707403292"><ph name="FILE_NAME" />ஐ மீண்டும் பதிவிறக்கவா?</translation>
-<translation id="2482878487686419369">அறிவிப்புகள்</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> நிர்வகிக்கிறது</translation>
-<translation id="2494974097748878569">Chromeமில் Google அசிஸ்டண்ட்</translation>
-<translation id="2496180316473517155">உலாவல் வரலாறு</translation>
-<translation id="2497852260688568942">உங்கள் நிர்வாகி ஒத்திசைவை முடக்கியுள்ளார்</translation>
-<translation id="2498359688066513246">உதவி &amp; கருத்து</translation>
-<translation id="2501278716633472235">திரும்பிச் செல்</translation>
-<translation id="2513403576141822879">தனியுரிமை, பாதுகாப்பு, தரவுச் சேகரிப்பு ஆகியவற்றுடன் தொடர்புடைய மேலும் பல அமைப்புகளுக்கு, <ph name="BEGIN_LINK" />ஒத்திசைவும் Google சேவைகளும்<ph name="END_LINK" /> என்பதைப் பார்க்கவும்</translation>
-<translation id="2518590038762162553">லைட் பயன்முறையில் பக்கங்களை Chrome வேகமாக ஏற்றுவதோடு டேட்டாவை 60 சதவீதம் வரை குறைவாகவும் பயன்படுத்தும். நீங்கள் பார்க்கும் பக்கங்களை மேம்படுத்த Chrome உங்கள் இணைய டிராஃபிக்கை Googleளுக்கு அனுப்பும். <ph name="BEGIN_LINK" />மேலும் அறிக<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">நீங்கள் பார்வையிடும் பக்கங்களின் URLகளை Googleளுக்கு அனுப்பும்</translation>
-<translation id="2532336938189706096">இணைய பார்வை</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> வரலாற்று உள்ளடக்கங்கள் நீக்கப்பட்டன</translation>
-<translation id="2536728043171574184">இந்தப் பக்கத்தின் ஆஃப்லைன் நகலைப் பார்க்கிறீர்கள்</translation>
-<translation id="2546283357679194313">குக்கீகளும் தள தரவும்</translation>
-<translation id="2567385386134582609">படம்</translation>
-<translation id="257088987046510401">தீம்கள்</translation>
-<translation id="2570922361219980984">இந்தச் சாதனத்திற்கான இருப்பிட அணுகலும் முடக்கப்பட்டுள்ளது. அதை <ph name="BEGIN_LINK" />Android அமைப்புகளில்<ph name="END_LINK" /> இயக்கவும்.</translation>
-<translation id="257931822824936280">விரிவாக்கப்பட்டது - சுருக்க, கிளிக் செய்யவும்.</translation>
-<translation id="2581165646603367611">முக்கியமில்லை என்று Chrome கருதும் குக்கீகள், தற்காலிகச் சேமிப்பு, தளங்களின் பிற தரவு ஆகியவற்றை இது அழிக்கும்.</translation>
-<translation id="2586657967955657006">கிளிப்போர்டு</translation>
-<translation id="2587052924345400782">புதிய பதிப்பு உள்ளது</translation>
-<translation id="2593272815202181319">மோனோஸ்பேஸ்</translation>
-<translation id="2612676031748830579">கார்டு எண்</translation>
-<translation id="2621115761605608342">குறிப்பிட்ட தளத்திற்கு JavaScriptஐ அனுமதி.</translation>
-<translation id="2625189173221582860">கடவுச்சொல் நகலெடுக்கப்பட்டது</translation>
-<translation id="2631006050119455616">சேமிக்கப்பட்டது</translation>
-<translation id="2647434099613338025">மொழியைச் சேர்</translation>
-<translation id="2650751991977523696">கோப்பை மீண்டும் பதிவிறக்கவா?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ஆடியோ கோப்பு}other{# ஆடியோ கோப்புகள்}}</translation>
-<translation id="2653659639078652383">சமர்ப்பி</translation>
-<translation id="2677748264148917807">வெளியேறு</translation>
-<translation id="2704606927547763573">நகலெடுக்கப்பட்டது</translation>
-<translation id="2707726405694321444">பக்கத்தைப் புதுப்பி</translation>
-<translation id="2709516037105925701">தானாகநிரப்பு</translation>
-<translation id="2717722538473713889">மின்னஞ்சல் முகவரிகள்</translation>
-<translation id="2728754400939377704">தளத்தின்படி வரிசைப்படுத்தும்</translation>
-<translation id="2744248271121720757">உடனடியாகத் தேட அல்லது தொடர்புடைய செயல்களைப் பார்க்க, சொல்லைத் தட்டவும்</translation>
-<translation id="2760989362628427051">சாதனத்தில் டார்க் தீம் அல்லது பேட்டரி சேமிப்பான் ஆன் செய்யப்பட்டால் டார்க் தீமினை ஆன் செய்யும்</translation>
-<translation id="2762000892062317888">சற்று முன்</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> வினாடிகள் மீதமுள்ளன</translation>
-<translation id="2779651927720337254">தோல்வியுற்றது</translation>
-<translation id="2781151931089541271">1 வினாடி மீதமுள்ளது</translation>
-<translation id="2801022321632964776">Chromeமில் உங்கள் மொழியைப் பெற சமீபத்திய பதிப்பிற்குப் புதுப்பிக்கவும்</translation>
-<translation id="2810645512293415242">தரவைச் சேமித்து, வேகமாக ஏற்றுவதற்கு எளிதாக்கப்பட்ட பக்கம்.</translation>
-<translation id="281504910091592009">உங்கள் <ph name="BEGIN_LINK" />Google கணக்கில்<ph name="END_LINK" /> சேமிக்கப்பட்ட கடவுச்சொற்களைப் பார்த்து, நிர்வகிக்கவும்</translation>
-<translation id="2818669890320396765">உங்கள் அனைத்துச் சாதனங்களிலும் புத்தகக்குறிகளைப் பெற, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME" />க்கான தள அனுமதிகள் அனைத்தையும் நிச்சயமாக மீட்டமைக்க விரும்புகிறீர்களா?</translation>
-<translation id="2836148919159985482">முழுத்திரையிலிருந்து வெளியேற, "முந்தையது" பொத்தானைத் தொடவும்.</translation>
-<translation id="2842985007712546952">மூலக் கோப்புறை</translation>
-<translation id="2858138569776157458">பிரபலமானவை</translation>
-<translation id="2860954141821109167">இந்தச் சாதனத்தில் ஃபோன் ஆப்ஸ் இயக்கப்பட்டுள்ளதை உறுதிசெய்து கொள்ளவும்</translation>
-<translation id="2870560284913253234">தளம்</translation>
-<translation id="2874939134665556319">முந்தைய ட்ராக்</translation>
-<translation id="2876369937070532032">ஆபத்தான தளங்களைப் பார்ப்பதால் உங்கள் பாதுகாப்பிற்கு ஆபத்து ஏற்படும்போது நீங்கள் பார்வையிடும் சில பக்கங்களின் URLகளை Googleளுக்கு அனுப்பும்</translation>
-<translation id="2888126860611144412">Chrome அறிமுகம்</translation>
-<translation id="2891154217021530873">பக்கத்தை ஏற்றுவதை நிறுத்து</translation>
-<translation id="2893180576842394309">‘தேடல்’ மற்றும் பிற Google சேவைகளைத் தனிப்பயனாக்க, உங்கள் வரலாற்றை Google பயன்படுத்தக்கூடும்</translation>
-<translation id="2898264748040935573">சேமிக்கப்பட்ட கடவுச்சொல்லைத் திருத்தும் பட்டன்</translation>
-<translation id="2900528713135656174">நிகழ்வை உருவாக்கவும்</translation>
-<translation id="290376772003165898"><ph name="LANGUAGE" /> மொழியில் பக்கம் இல்லையா?</translation>
-<translation id="2904414404539560095">தாவலைப் பகிர்வதற்கான சாதனங்களின் பட்டியல் திரையின் முழு அளவிற்குத் திறக்கப்பட்டுள்ளது.</translation>
-<translation id="2910701580606108292">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்குவதற்குத் தளங்களை அனுமதிக்கும் முன்பு அனுமதி கோரும்</translation>
-<translation id="2913331724188855103">குக்கீத் தரவை, தளங்கள் சேமிக்கவும் படிக்கவும் அனுமதி (பரிந்துரைக்கப்பட்டது)</translation>
-<translation id="2923908459366352541">தவறான பெயர்</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> இன் சேமிப்பகம்</translation>
-<translation id="2942036813789421260">மாதிரிக்காட்சித் தாவல் மூடப்பட்டுள்ளது</translation>
-<translation id="2956410042958133412">இந்தக் கணக்கு <ph name="PARENT_NAME_1" /> மற்றும் <ph name="PARENT_NAME_2" /> ஆல் நிர்வகிக்கப்படுகிறது.</translation>
-<translation id="2962095958535813455">மறைநிலைத் தாவல்களுக்கு மாற்றப்பட்டது</translation>
-<translation id="2968755619301702150">சான்றிதழ் வியூவர்</translation>
-<translation id="2979025552038692506">தேர்ந்தெடுத்த மறைநிலைத் தாவல்</translation>
-<translation id="2987620471460279764">பிற சாதனத்திலிருந்து உரை பகிரப்பட்டது</translation>
-<translation id="2989523299700148168">சமீபத்தில் பார்த்தவை</translation>
-<translation id="2996291259634659425">கடவுச்சொற்றொடரை உருவாக்கு</translation>
-<translation id="2996809686854298943">URL தேவை</translation>
-<translation id="300526633675317032">இணையதளச் சேமிப்பகத்தில் உள்ள <ph name="SIZE_IN_KB" /> தரவையும் இது அழிக்கும்.</translation>
-<translation id="3016635187733453316">இந்தச் சாதனம் இணையத்துடன் இணைக்கப்பட்டுள்ளதை உறுதி செய்யவும்</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> கி.பை. பதிவிறக்கப்பட்டது</translation>
-<translation id="3029704984691124060">கடவுத்தொடர்கள் பொருந்தவில்லை</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />உதவி பெறுக<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">இருப்பிடம் முடக்கப்பட்டுள்ளது; அதை <ph name="BEGIN_LINK" />Android அமைப்புகளில்<ph name="END_LINK" /> இயக்கவும்.</translation>
-<translation id="3058498974290601450">அமைப்புகளில் ஒத்திசைவை எந்த நேரத்திலும் இயக்கலாம்</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> புக்மார்க்}other{<ph name="BOOKMARKS_COUNT_MANY" /> புக்மார்க்குகள்}}</translation>
-<translation id="3089395242580810162">மறைநிலை தாவலில் திற</translation>
-<translation id="3115898365077584848">தகவலைக் காட்டு</translation>
-<translation id="3123473560110926937">சில தளங்களில் தடுக்கப்பட்டுள்ளன</translation>
-<translation id="3137521801621304719">மறைநிலையிலிருந்து வெளியேறு</translation>
-<translation id="3143515551205905069">ஒத்திசைவை ரத்துசெய்</translation>
-<translation id="3157842584138209013">மேலும் விருப்பங்கள் பொத்தானைப் பயன்படுத்தி, எவ்வளவு தரவைச் சேமித்துள்ளீர்கள் என்பதைப் பார்க்கலாம்</translation>
-<translation id="3166827708714933426">தாவல் மற்றும் சாளரத்திற்கான ஷார்ட்கட்கள்</translation>
-<translation id="3181954750937456830">பாதுகாப்பு உலாவல் (ஆபத்தான தளங்களிலிருந்து உங்களையும் சாதனத்தையும் பாதுகாக்கும்)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android அமைப்புகளில்<ph name="END_LINK" /> Chromeக்கான அனுமதிகளை இயக்கவும்.</translation>
-<translation id="3198916472715691905">சேமிக்கப்பட்ட தரவு: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">கிட்டத்தட்ட முடிந்தது!</translation>
-<translation id="3207960819495026254">புக்மார்க் செய்யப்பட்டது</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> நீக்கப்பட்டது</translation>
-<translation id="321773570071367578">கடவுச்சொற்றொடரை மறந்துவிட்டால் அல்லது இந்த அமைப்பை மாற்ற விரும்பினால், <ph name="BEGIN_LINK" />ஒத்திசைவை மீட்டமைக்கவும்<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">மைக்ரோஃபோன்</translation>
-<translation id="3232754137068452469">இணைய ஆப்ஸ்</translation>
-<translation id="3236059992281584593">1 நிமிடம் மீதமுள்ளது</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">இந்தப் பக்கத்தை புக்மார்க் செய்க</translation>
-<translation id="3259831549858767975">பக்கத்திலுள்ள அனைத்தையும் சிறிதாக்கும்</translation>
-<translation id="3269093882174072735">படத்தை ஏற்று</translation>
-<translation id="3269956123044984603">பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, Android கணக்கு அமைப்புகளில் "தரவைத் தானாக ஒத்திசை" என்பதை இயக்கவும்.</translation>
-<translation id="3277252321222022663">தளங்கள் சென்சார்களை அணுக அனுமதிக்கும் (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="3282568296779691940">Chrome இல் உள்நுழைக</translation>
-<translation id="3288003805934695103">பக்கத்தை மீண்டும் ஏற்றுதல்</translation>
-<translation id="32895400574683172">அறிவிப்புகள் அனுமதிக்கப்படுகின்றன</translation>
-<translation id="3295530008794733555">வேகமாக உலாவலாம். குறைவான டேட்டாவைப் பயன்படுத்தலாம்.</translation>
-<translation id="3295602654194328831">தகவலை மறை</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">உள்ளடக்கத்தைப் பதிவிறக்குவதைத் தொடரவா?</translation>
-<translation id="3306398118552023113">இந்த ஆப்ஸ் Chromeமில் இயங்குகிறது</translation>
-<translation id="3315103659806849044">உங்கள் ஒத்திசைவு மற்றும் Google சேவை அமைப்புகளைத் தற்போது உங்களுக்கேற்ப மாற்றியமைக்கிறீர்கள். ஒத்திசைவை இயக்க, திரையின் அடிப்பகுதிக்கு அருகிலுள்ள ‘உறுதிப்படுத்து’ பட்டனைத் தட்டவும். மேலே செல்</translation>
-<translation id="3328801116991980348">தளம் குறித்த தகவல்</translation>
-<translation id="3333961966071413176">எல்லாத் தொடர்புகளும்</translation>
-<translation id="3334729583274622784">கோப்பு நீட்டிப்பை மாற்றவா?</translation>
-<translation id="3341058695485821946">எவ்வளவு தரவைச் சேமித்துள்ளீர்கள் என்பதைப் பார்க்கவும்</translation>
-<translation id="3350687908700087792">எல்லா மறைநிலைத் தாவல்களையும் மூடு</translation>
-<translation id="3353615205017136254">Google வழங்கும் Lite பக்கம். அசல் பக்கத்தை ஏற்ற, ‘அசல் பக்கத்தை ஏற்று’ பட்டனைத் தட்டவும்.</translation>
-<translation id="3367813778245106622">ஒத்திசைப்பதைத் தொடங்க, மீண்டும் உள்நுழையவும்</translation>
-<translation id="3374023511497244703">இனி உங்கள் Google கணக்குடன் புக்மார்க்குகள், வரலாறு, கடவுச்சொற்கள் போன்ற பிற Chrome தரவு ஒத்திசைக்கப்படாது</translation>
-<translation id="3384347053049321195">படத்தைப் பகிர்</translation>
-<translation id="3386292677130313581">எனது இருப்பிடத்தை அறிய தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="3387650086002190359">கோப்பு முறைமைப் பிழைகளால் <ph name="FILE_NAME" />ஐப் பதிவிறக்க முடியவில்லை.</translation>
-<translation id="3389286852084373014">உரையின் அளவு மிகப் பெரியதாக உள்ளது</translation>
-<translation id="3398320232533725830">புக்மார்க்குகள் மேலாளரைத் திறக்கும்</translation>
-<translation id="3414952576877147120">அளவு:</translation>
-<translation id="3443221991560634068">தற்போதைய பக்கத்தை மீண்டும் ஏற்றும்</translation>
-<translation id="3445014427084483498">சற்றுமுன்</translation>
-<translation id="3478363558367712427">உங்கள் தேடல் இன்ஜினை தேர்வுசெய்யலாம்</translation>
+<translation id="6910211073230771657">நீக்கப்பட்டது</translation>
+<translation id="6965382102122355670">சரி</translation>
+<translation id="5301954838959518834">சரி, புரிந்தது</translation>
+<translation id="7658239707568436148">ரத்து செய்</translation>
 <translation id="3479552764303398839">இப்பொழுது இல்லை</translation>
-<translation id="3492207499832628349">புதிய மறைநிலைத் தாவல்</translation>
-<translation id="3493531032208478708">பரிந்துரைக்கப்படும் உள்ளடக்கம் பற்றி <ph name="BEGIN_LINK" />மேலும் அறிக<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">ஆக்மென்ட்டட் ரியாலிட்டி</translation>
-<translation id="3518985090088779359">ஏற்று, தொடரவும்</translation>
-<translation id="3522247891732774234">புதுப்பிப்பு உள்ளது. மேலும் விருப்பங்கள்</translation>
-<translation id="3524138585025253783">டெவெலப்பர் UI</translation>
-<translation id="3527085408025491307">கோப்புறை</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> கி.பை. உள்ளது</translation>
-<translation id="3549657413697417275">உங்கள் வரலாற்றைத் தேடுக</translation>
-<translation id="3557336313807607643">தொடர்புகளில் சேர்</translation>
-<translation id="3566923219790363270">VRருக்காக Chrome இன்னமும் தயார்செய்கிறது. Chromeமைப் பின்னர் மீண்டும் தொடங்கவும்.</translation>
-<translation id="3568688522516854065">உங்கள் பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="3587482841069643663">அனைத்தும்</translation>
-<translation id="358794129225322306">பல கோப்புகளைத் தானாகப் பதிவிறக்க தளத்தை அனுமதிக்கும்.</translation>
-<translation id="3590487821116122040">முக்கியமில்லை என்று Chrome கருதும் தளச் சேமிப்பகம் (எ.கா: சேமித்த அமைப்புகள் இல்லாத அல்லது நீங்கள் அடிக்கடி பார்க்காத தளங்கள்)</translation>
-<translation id="3599863153486145794">உள்நுழைந்த எல்லாச் சாதனங்களிலிருந்தும் வரலாற்றை அழிக்கும். உங்கள் Google கணக்கு, <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> என்ற இணைப்பில் உலாவல் வரலாறு தொடர்பான பிற தகவல்களைக் கொண்டிருக்கக்கூடும்.</translation>
-<translation id="3600792891314830896">ஒலியை இயக்கும் தளங்களில் ஒலியடக்கு</translation>
-<translation id="3616113530831147358">ஆடியோ</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> உடன் பகிர்கிறது</translation>
-<translation id="3632295766818638029">கடவுச்சொல்லைக் காட்டும்</translation>
-<translation id="363596933471559332">சேமிக்கப்பட்டுள்ள நற்சான்றிதழ்களைப் பயன்படுத்தி, இணையதளங்களில் தானாகவே உள்நுழையவும். இந்த அம்சம் முடக்கப்பட்டிருக்கும் போது, ஒவ்வொரு முறையும் இணையதளத்தில் உள்நுழைவதற்கு முன்பும் சரிபார்க்கும்படி கேட்கப்படுவீர்கள்.</translation>
-<translation id="3658159451045945436">மீட்டமைத்தால், பார்வையிட்ட தளங்களின் பட்டியல் உட்பட டேட்டா சேமிப்புகளின் வரலாறு அழிக்கப்படும்.</translation>
-<translation id="3692944402865947621">சேமிப்பிடம் இல்லாததால், <ph name="FILE_NAME" />ஐப் பதிவிறக்க முடியவில்லை.</translation>
-<translation id="3714981814255182093">கண்டறி பட்டியைத் திறக்கும்</translation>
-<translation id="3716182511346448902">இந்தப் பக்கம் அதிகளவு நினைவகத்தைப் பயன்படுத்துவதால், Chrome அதை இடைநிறுத்தியுள்ளது.</translation>
-<translation id="3730075448226062617">Chrome உங்கள் மைக்ரோஃபோனை அணுக அனுமதிப்பதற்கு <ph name="BEGIN_LINK" />Android அமைப்புகளிலும்<ph name="END_LINK" /> மைக்ரோஃபோனை இயக்கவும்.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> இல் புத்தகக்குறியிடப்பட்டது</translation>
-<translation id="3744111561329211289">பின்புல ஒத்திசைவு</translation>
-<translation id="3771001275138982843">புதுப்பிப்பைப் பதிவிறக்க முடியவில்லை</translation>
-<translation id="3771033907050503522">மறைநிலைத் தாவல்கள்</translation>
-<translation id="3773755127849930740">இணைத்தலை அனுமதிக்க, <ph name="BEGIN_LINK" />புளூடூத்தை இயக்கவும்<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">உங்கள் சாதனங்களுக்கு அனுப்புதல்</translation>
-<translation id="3778956594442850293">முகப்புத் திரையில் சேர்க்கப்பட்டது</translation>
-<translation id="3789841737615482174">நிறுவுக</translation>
-<translation id="3810838688059735925">வீடியோ</translation>
-<translation id="3810973564298564668">நிர்வகி</translation>
-<translation id="381841723434055211">ஃபோன் எண்கள்</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> பதிவிறக்கங்கள் உள்ளன</translation>
-<translation id="3822502789641063741">தளச் சேமிப்பகத்தை அழிக்கவா?</translation>
-<translation id="385051799172605136">முந்தைய பக்கம்</translation>
-<translation id="3859306556332390985">முன்செல்</translation>
-<translation id="3894427358181296146">கோப்புறையைச் சேர்</translation>
-<translation id="3895926599014793903">பெரிதாக்குவதைச் செயல்படுத்த வலியுறுத்து</translation>
-<translation id="3912508018559818924">இணையத்திலிருந்து தரவை ஏற்றுகிறோம்…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">எனது தரவை ஒன்றிணை</translation>
-<translation id="393697183122708255">குரல் தேடல் இயக்கப்படவில்லை</translation>
-<translation id="395206256282351086">தேடல் மற்றும் தளப் பரிந்துரைகள் முடக்கப்பட்டுள்ளன</translation>
-<translation id="3955193568934677022">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்க, தளங்களை அனுமதி (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{பக்கம் தயாரானதும் Chrome அதை ஏற்றும்}other{பக்கங்கள் தயாரானதும் Chrome அவற்றை ஏற்றும்}}</translation>
-<translation id="3963007978381181125">கடவுச்சொற்றொடர் என்க்ரிப்ஷனில் Google Payயிலுள்ள கட்டண முறைகளும் முகவரிகளும் சேர்க்கப்படாது. என்கிரிப்ட் செய்யப்பட்ட தரவை உங்கள் கடவுச்சொற்றொடரை அறிந்தவரால் மட்டுமே படிக்க முடியும். Googleளுக்குக் கடவுச்சொற்றொடர் அனுப்பப்படுவதில்லை. Google அதைச் சேமிப்பதுமில்லை. கடவுச்சொற்றொடரை மறந்துவிட்டாலோ இந்த அமைப்பை மாற்ற விரும்பினாலோ, ஒத்திசைவை மீட்டமைக்க வேண்டும். <ph name="BEGIN_LINK" />மேலும் அறிக<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">பதிவிறக்கம் முடிந்தது</translation>
-<translation id="397583555483684758">ஒத்திசைவு நிறுத்தப்பட்டது</translation>
-<translation id="3976396876660209797">இந்த ஷார்ட்கட்டை அகற்றி, மீண்டும் உருவாக்கவும்</translation>
-<translation id="3985215325736559418"><ph name="FILE_NAME" />ஐ மீண்டும் பதிவிறக்கவா?</translation>
-<translation id="3987993985790029246">இணைப்பை நகலெடு</translation>
-<translation id="3988213473815854515">இருப்பிடம் அனுமதிக்கப்படும்</translation>
-<translation id="3988466920954086464">இந்தப் பேனலில் உடனடித் தேடல் முடிவுகளைப் பார்க்கவும்</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">முக்கியமில்லா சேமிப்பகம்</translation>
-<translation id="4000212216660919741">Home ஆஃப்லைனில் உள்ளது</translation>
+<translation id="5317780077021120954">சேமி</translation>
+<translation id="4570913071927164677">விவரங்கள்</translation>
+<translation id="8730621377337864115">முடிந்தது</translation>
+<translation id="8261506727792406068">நீக்கு</translation>
+<translation id="1181037720776840403">அகற்று</translation>
+<translation id="5939518447894949180">மீட்டமை</translation>
 <translation id="4002066346123236978">தலைப்பு</translation>
-<translation id="4008040567710660924">குறிப்பிட்ட தளத்திற்கு, குக்கீகளை அனுமதிக்கும்.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# மணிநேரம்}other{# மணிநேரம்}}</translation>
-<translation id="4046123991198612571">அடுத்த ட்ராக்</translation>
-<translation id="4048707525896921369">பக்கத்தை விட்டு விலகாமலே இணையதளங்களில் உள்ள தலைப்புகள் குறித்து அறிந்துகொள்ளலாம். "தேடுவதற்குத் தட்டு" அம்சமானது சொல்லையும் அதன் சூழலையும் Google தேடலுக்கு அனுப்புவதோடு வரையறைகள், படங்கள், தேடல் முடிவுகள், பிற விவரங்கள் ஆகியவற்றை வழங்குகிறது.
+<translation id="5916664084637901428">இயக்கு</translation>
+<translation id="5860033963881614850">ஆஃப்</translation>
+<translation id="6165508094623778733">மேலும் அறிக</translation>
+<translation id="6042308850641462728">மேலும்</translation>
+<translation id="6040143037577758943">மூடு</translation>
+<translation id="780301667611848630">தேவையில்லை</translation>
+<translation id="1201402288615127009">அடுத்து</translation>
+<translation id="2359808026110333948">தொடர்க</translation>
+<translation id="2653659639078652383">சமர்ப்பி</translation>
+<translation id="2079545284768500474">செயல்தவிர்</translation>
+<translation id="7649070708921625228">உதவி</translation>
+<translation id="2148716181193084225">இன்று</translation>
+<translation id="7781829728241885113">நேற்று</translation>
+<translation id="6945221475159498467">தேர்ந்தெடு</translation>
+<translation id="7791543448312431591">சேர்</translation>
+<translation id="6527303717912515753">பகிர்</translation>
+<translation id="1383876407941801731">தேடல்</translation>
+<translation id="3115898365077584848">தகவலைக் காட்டு</translation>
+<translation id="3295602654194328831">தகவலை மறை</translation>
+<translation id="3987993985790029246">இணைப்பை நகலெடு</translation>
+<translation id="2704606927547763573">நகலெடுக்கப்பட்டது</translation>
+<translation id="8725066075913043281">மீண்டும் முயற்சிக்கவும்</translation>
+<translation id="385051799172605136">முந்தைய பக்கம்</translation>
+<translation id="8131740175452115882">உறுதிப்படுத்து</translation>
+<translation id="5300589172476337783">காண்பி</translation>
+<translation id="1124772482545689468">பயனர்</translation>
+<translation id="8609465669617005112">மேலே நகர்த்து</translation>
+<translation id="6746124502594467657">கீழே நகர்த்து</translation>
+<translation id="8249310407154411074">முதலாவதாக நகர்த்து</translation>
+<translation id="8428213095426709021">அமைப்புகள்</translation>
+<translation id="2498359688066513246">உதவி &amp; கருத்து</translation>
+<translation id="8378714024927312812">உங்கள் நிறுவனத்தால் நிர்வகிக்கப்படுகிறது</translation>
+<translation id="9019902583201351841">உங்கள் பெற்றோரால் நிர்வகிக்கப்படுகிறது</translation>
+<translation id="4645575059429386691">உங்கள் பெற்றோரால் நிர்வகிக்கப்படுகிறது</translation>
+<translation id="4883854917563148705">நிர்வகிக்கப்பட்ட அமைப்புகளை மீட்டமைக்க முடியாது</translation>
+<translation id="4307992518367153382">அடிப்படைகள்</translation>
+<translation id="1974060860693918893">மேம்பட்டவை</translation>
+<translation id="1146678959555564648">VRஐ உள்ளிடு</translation>
+<translation id="987264212798334818">பொது</translation>
+<translation id="4275663329226226506">ஊடகம்</translation>
+<translation id="4759238208242260848">பதிவிறக்கங்கள்</translation>
+<translation id="218608176142494674">பகிர்தல்</translation>
+<translation id="8004582292198964060">உலாவி</translation>
+<translation id="1105960400813249514">திரைப் படப்பிடிப்பு</translation>
+<translation id="4875775213178255010">உள்ளடக்கப் பரிந்துரைகள்</translation>
+<translation id="2021896219286479412">முழுத் திரை தளக் கட்டுப்பாடுகள்</translation>
+<translation id="4587589328781138893">தளங்கள்</translation>
+<translation id="4943703118917034429">விர்ச்சுவல் ரியாலிட்டி</translation>
+<translation id="1928696683969751773">புதுப்பிப்புகள்</translation>
+<translation id="6064125863973209585">நிறைவடைந்த பதிவிறக்கங்கள்</translation>
+<translation id="5342314432463739672">அனுமதிக் கோரிக்கைகள்</translation>
+<translation id="629730747756840877">கணக்கு</translation>
+<translation id="82609232232243542">Brave இல் உள்நுழைக</translation>
+<translation id="7956662517480676674">ஒத்திசைவு &amp; Brave Software சேவைகள்</translation>
+<translation id="5294439808117722387">உங்கள் ஒத்திசைவு மற்றும் Brave Software சேவை அமைப்புகளைத் தற்போது உங்களுக்கேற்ப மாற்றியமைக்கிறீர்கள். ஒத்திசைவை இயக்க, திரையின் அடிப்பகுதிக்கு அருகிலுள்ள ‘உறுதிப்படுத்து’ பட்டனைத் தட்டவும். மேலே செல்</translation>
+<translation id="2096012225669085171">பல சாதனங்களுக்கிடையில் ஒத்திசைக்கலாம், தனிப்பயனாக்கலாம்</translation>
+<translation id="1692118695553449118">ஒத்திசைவு இயக்கத்தில்</translation>
+<translation id="5514904542973294328">இந்தச் சாதனத்தின் நிர்வாகி முடக்கியுள்ளார்</translation>
+<translation id="6447211988989208781">Brave Software செயல்பாட்டுக் கட்டுப்பாடுகள்</translation>
+<translation id="4882831918239250449">தேடல், விளம்பரங்கள் மற்றும் பலவற்றைத் தனிப்பயனாக்க உங்கள் உலாவல் வரலாறு எப்படிப் பயன்படுத்தப்படுகிறது என்பதைக் கட்டுப்படுத்துதல்</translation>
+<translation id="7431991332293347422">தேடல் மற்றும் பலவற்றைத் தனிப்பயனாக்க உங்கள் உலாவல் வரலாறு எப்படிப் பயன்படுத்தப்படுகிறது என்பதைக் கட்டுப்படுத்தலாம்</translation>
+<translation id="6303969859164067831">வெளியேறி ஒத்திசைவை முடக்கு</translation>
+<translation id="1125261911132334651">Brave Software கணக்கை நிர்வகி</translation>
+<translation id="6406506848690869874">Sync</translation>
+<translation id="714362445477979774">உங்கள் Brave தரவை ஒத்திசைக்கவும்</translation>
+<translation id="4314815835985389558">ஒத்திசைவை நிர்வகிக்கும் பக்கம்</translation>
+<translation id="5428209950370661546">பிற Brave Software சேவைகள்</translation>
+<translation id="7704317875155739195">தேடல்களையும் URLகளையும் தானே நிரப்பு</translation>
+<translation id="2000419248597011803">முகவரிப் பட்டியிலிருந்தும், தேடல் பெட்டியிலிருந்தும் சில குக்கீகளையும் தேடல்களையும் உங்கள் இயல்புத் தேடல் இன்ஜினுக்கு அனுப்பும்</translation>
+<translation id="7981313251711023384">மிக விரைவான உலாவலுக்காகவும் தேடலிற்காகவும் பக்கங்களை முன்னதாக ஏற்றும்</translation>
+<translation id="1821253160463689938">நீங்கள் அந்தப் பக்கங்களைப் பார்வையிடவில்லை என்றாலும், உங்கள் விருப்பத்தேர்வுகளை நினைவில்கொள்ள குக்கீகளைப் பயன்படுத்தும்</translation>
+<translation id="6697492270171225480">பக்கத்தைக் கண்டறிய முடியாத போது, அதே மாதிரியான பக்கங்களுக்கான பரிந்துரைகளைக் காட்டும்</translation>
+<translation id="8109318360573330108">நீங்கள் செல்ல முயலும் பக்கத்தின் URLலை Brave Softwareளுக்கு அனுப்பும்</translation>
+<translation id="8438566539970814960">தேடல்களையும் உலாவலையும் மேலும் சிறப்பாக்குக</translation>
+<translation id="284843628681142937">நீங்கள் பார்வையிடும் பக்கங்களின் URLகளை Brave Softwareளுக்கு அனுப்பும்</translation>
+<translation id="7222718784508482526">தனியுரிமை, பாதுகாப்பு, தரவுச் சேகரிப்பு ஆகியவற்றுடன் தொடர்புடைய மேலும் பல அமைப்புகளுக்கு, <ph name="BEGIN_LINK"/>ஒத்திசைவும் Brave Software சேவைகளும்<ph name="END_LINK"/> என்பதைப் பார்க்கவும்</translation>
+<translation id="918192811481327695">Brave இன் அம்சங்களையும் செயல்திறனையும் மேம்படுத்த உதவுக</translation>
+<translation id="9063160602596686558">பயன்பாட்டுப் புள்ளிவிவரங்களையும் சிதைவு அறிக்கைகளையும் தானாகவே Brave Softwareளுக்கு அனுப்பும்</translation>
+<translation id="4824958205181053313">ஒத்திசைவை ரத்துசெய்யவா?</translation>
+<translation id="3058498974290601450">அமைப்புகளில் ஒத்திசைவை எந்த நேரத்திலும் இயக்கலாம்</translation>
+<translation id="3143515551205905069">ஒத்திசைவை ரத்துசெய்</translation>
+<translation id="1506061864768559482">தேடல் இன்ஜின்</translation>
+<translation id="55737423895878184">இருப்பிடமும் அறிவிப்புகளும் அனுமதிக்கப்படுகின்றன</translation>
+<translation id="3988213473815854515">இருப்பிடம் அனுமதிக்கப்படும்</translation>
+<translation id="32895400574683172">அறிவிப்புகள் அனுமதிக்கப்படுகின்றன</translation>
+<translation id="9040142327097499898">அறிவிப்புகள் அனுமதிக்கப்படுகின்றன. இந்தச் சாதனத்திற்கான இருப்பிடம் முடக்கப்பட்டுள்ளது.</translation>
+<translation id="305593374596241526">இருப்பிடம் முடக்கப்பட்டுள்ளது; அதை <ph name="BEGIN_LINK"/>Android அமைப்புகளில்<ph name="END_LINK"/> இயக்கவும்.</translation>
+<translation id="2989523299700148168">சமீபத்தில் பார்த்தவை</translation>
+<translation id="6433501201775827830">தேடல் இன்ஜினைத் தேர்வுசெய்யவும்</translation>
+<translation id="7177466738963138057">இதைப் பிறகு அமைப்புகளில் மாற்றலாம்</translation>
+<translation id="3478363558367712427">உங்கள் தேடல் இன்ஜினை தேர்வுசெய்யலாம்</translation>
+<translation id="4910889077668685004">கட்டணம் செலுத்துவதற்கான ஆப்ஸ்</translation>
+<translation id="5152843274749979095">ஆதரிக்கப்படும் ஆப்ஸ் நிறுவப்படவில்லை</translation>
+<translation id="8812260976093120287">உங்கள் சாதனத்தில் ஆதரிக்கப்படும் கட்டணம் செலுத்துவதற்கான பயன்பாடுகளைப் (மேலே குறிப்பிட்டவை) பயன்படுத்தி, சில இணையதளங்களின் மூலம் பணம் செலுத்தலாம்.</translation>
+<translation id="7764225426217299476">முகவரியைச் சேர்</translation>
+<translation id="5595485650161345191">முகவரியைத் திருத்து</translation>
+<translation id="5087580092889165836">கார்டைச் சேர்</translation>
+<translation id="2154484045852737596">கார்டைத் திருத்தவும்</translation>
+<translation id="6140912465461743537">நாடு/மண்டலம்</translation>
+<translation id="5659593005791499971">மின்னஞ்சல்</translation>
+<translation id="4378154925671717803">மொபைல்</translation>
+<translation id="4807098396393229769">அட்டையிலுள்ள பெயர்</translation>
+<translation id="860043288473659153">கார்டு உரிமையாளரின் பெயர்</translation>
+<translation id="2612676031748830579">கார்டு எண்</translation>
+<translation id="869891660844655955">காலாவதியாகும் தேதி</translation>
+<translation id="2286841657746966508">பில்லிங் முகவரி</translation>
+<translation id="663059986967017181">Braveக்கு நகலெடுக்கப்பட்டது</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> கட்டண முறை}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> கட்டண முறைகள்}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> முகவரி}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> முகவரிகள்}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> விருப்பம்}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> விருப்பங்கள்}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> தொடர்பு}other{<ph name="CONTACT_PREVIEW"/>\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> தொடர்புகள்}}</translation>
+<translation id="7029809446516969842">கடவுச்சொற்கள்</translation>
+<translation id="1943432128510653496">கடவுச்சொற்களைச் சேமி</translation>
+<translation id="2100273922101894616">தானாக உள்நுழையவும்</translation>
+<translation id="363596933471559332">சேமிக்கப்பட்டுள்ள நற்சான்றிதழ்களைப் பயன்படுத்தி, இணையதளங்களில் தானாகவே உள்நுழையவும். இந்த அம்சம் முடக்கப்பட்டிருக்கும் போது, ஒவ்வொரு முறையும் இணையதளத்தில் உள்நுழைவதற்கு முன்பும் சரிபார்க்கும்படி கேட்கப்படுவீர்கள்.</translation>
+<translation id="6995899638241819463">தரவு மீறலினால் கடவுச்சொற்கள் வெளியாகியிருந்தால் அதுகுறித்து எச்சரி</translation>
+<translation id="1534287762301776620">உங்கள் Brave Software கணக்கில் உள்நுழையும்போது இந்த அம்சம் ஆன் செய்யப்படும்</translation>
+<translation id="10614374240317010">எப்போதும் சேமிக்காதவை</translation>
+<translation id="3098842761938485917">உங்கள் <ph name="BEGIN_LINK"/>Brave Software கணக்கில்<ph name="END_LINK"/> சேமிக்கப்பட்ட கடவுச்சொற்களைப் பார்த்து, நிர்வகிக்கவும்</translation>
+<translation id="8562452229998620586">சேமிக்கப்பட்ட கடவுச்சொற்கள் இங்கு காண்பிக்கப்படும்.</translation>
+<translation id="8084114998886531721">சேமித்த கடவுச்சொல்</translation>
+<translation id="2870560284913253234">தளம்</translation>
+<translation id="8503813439785031346">பயனர்பெயர்</translation>
+<translation id="6657585470893396449">கடவுச்சொல்</translation>
+<translation id="2154710561487035718">URL ஐ நகலெடு</translation>
+<translation id="1571304935088121812">பயனர்பெயரை நகலெடுக்கும்</translation>
+<translation id="5005498671520578047">கடவுச்சொல்லை நகலெடு</translation>
+<translation id="3632295766818638029">கடவுச்சொல்லைக் காட்டும்</translation>
+<translation id="1513858653616922153">கடவுச்சொல்லை நீக்கு</translation>
+<translation id="543338862236136125">கடவுச்சொல்லை மாற்று</translation>
+<translation id="4565377596337484307">கடவுச்சொல்லை மறைக்கும்</translation>
+<translation id="8523928698583292556">சேமித்த கடவுச்சொல்லை நீக்குவதற்கான பட்டன்</translation>
+<translation id="2898264748040935573">சேமிக்கப்பட்ட கடவுச்சொல்லைத் திருத்தும் பட்டன்</translation>
+<translation id="5433691172869980887">பயனர்பெயர் நகலெடுக்கப்பட்டது</translation>
+<translation id="5534640966246046842">தளம் நகலெடுக்கப்பட்டது</translation>
+<translation id="2625189173221582860">கடவுச்சொல் நகலெடுக்கப்பட்டது</translation>
+<translation id="4550003330909367850">உங்கள் கடவுச்சொல்லை இங்கே பார்க்க அல்லது நகலெடுக்க, இந்தச் சாதனத்தில் திரைப் பூட்டை அமைக்கவும்.</translation>
+<translation id="6154478581116148741">இந்தச் சாதனத்திலிருந்து உங்கள் கடவுச்சொற்களை ஏற்ற, அமைப்புகளில் திரைப் பூட்டை இயக்கவும்</translation>
+<translation id="4842092870884894799">கடவுச்சொல் உருவாக்க பாப்-அப்பைக் காட்டுகிறது</translation>
+<translation id="2259659629660284697">கடவுச்சொற்களை ஏற்று…</translation>
+<translation id="133012818630824069">Brave இல் சேமித்த கடவுச்சொற்களை ஏற்றும்</translation>
+<translation id="6914783257214138813">ஏற்றிய கோப்பைப் பார்க்கக்கூடிய அனைவரும் உங்கள் கடவுச்சொற்களைப் பார்க்க முடியும்.</translation>
+<translation id="2321086116217818302">கடவுச்சொற்கள் தயாராகின்றன…</translation>
+<translation id="8445448999790540984">கடவுச்சொற்களை ஏற்ற முடியவில்லை</translation>
+<translation id="3066461326500799725">Brave Software இயக்ககத்தை எப்படிப் பயன்படுத்துவது என்பதை அறிக</translation>
+<translation id="729975465115245577">கடவுச்சொற்கள் கோப்பைச் சேமிக்க, உங்கள் சாதனத்தில் ஆப்ஸ் எதுவும் இல்லை.</translation>
+<translation id="7682724950699840886">பின்வரும் உதவிக்குறிப்புகளை முயன்று பார்க்கவும்: சாதனத்தில் போதுமான சேமிப்பிடம் இருப்பதை உறுதிப்படுத்தி, மீண்டும் ஏற்ற முயலவும்.</translation>
+<translation id="1129510026454351943">விவரங்கள்: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">உங்கள் கடவுச்சொல்லை நகலெடுக்க, திறக்கவும்</translation>
+<translation id="5515439363601853141">கடவுச்சொல்லைப் பார்க்க, திறக்கவும்</translation>
+<translation id="6221633008163990886">உங்கள் கடவுச்சொற்களை ஏற்ற, திறக்கவும்</translation>
+<translation id="230699814587342492">Brave கடவுச்சொற்கள்</translation>
+<translation id="6075798973483050474">முகப்புப் பக்கத்தைத் திருத்து</translation>
+<translation id="854522910157234410">இந்தப் பக்கத்தைத் திற</translation>
+<translation id="2482878487686419369">அறிவிப்புகள்</translation>
+<translation id="6255999984061454636">உள்ளடக்கப் பரிந்துரைகள்</translation>
+<translation id="805047784848435650">உங்கள் உலாவல் வரலாற்றின் அடிப்படையிலானவை</translation>
+<translation id="1041308826830691739">இணையதளங்களிலிருந்து</translation>
+<translation id="395206256282351086">தேடல் மற்றும் தளப் பரிந்துரைகள் முடக்கப்பட்டுள்ளன</translation>
+<translation id="257088987046510401">தீம்கள்</translation>
+<translation id="4650364565596261010">சிஸ்டத்தின் இயல்புநிலை</translation>
+<translation id="7588219262685291874">சாதனத்தில் பேட்டரி சேமிப்பான் இயக்கத்தில் இருக்கும்போது டார்க் தீமை இயக்கும்</translation>
+<translation id="2760989362628427051">சாதனத்தில் டார்க் தீம் அல்லது பேட்டரி சேமிப்பான் ஆன் செய்யப்பட்டால் டார்க் தீமினை ஆன் செய்யும்</translation>
+<translation id="6381421346744604172">இணையதளங்களை டார்க்காக மாற்று</translation>
+<translation id="5040262127954254034">தனியுரிமை</translation>
+<translation id="4991384657077828949">Braveமின் பாதுகாப்பை மேம்படுத்த உதவுக</translation>
+<translation id="1943176487615318915">ஆபத்தான ஆப்ஸையும் தளங்களையும் கண்டறிய நீங்கள் பார்வையிட்ட சில பக்கங்களின் URLகளையும், வரம்பிற்குட்பட்ட சிஸ்டம் தகவல்களையும், சில பக்கங்களின் உள்ளடக்கத்தையும் Brave Softwareளுக்கு Brave அனுப்பும்</translation>
+<translation id="3181954750937456830">பாதுகாப்பு உலாவல் (ஆபத்தான தளங்களிலிருந்து உங்களையும் சாதனத்தையும் பாதுகாக்கும்)</translation>
+<translation id="7315322926489145388">ஆபத்தான தளங்களைப் பார்ப்பதால் உங்கள் பாதுகாப்பிற்கு ஆபத்து ஏற்படும்போது நீங்கள் பார்வையிடும் சில பக்கங்களின் URLகளை Brave Softwareளுக்கு அனுப்பும்</translation>
+<translation id="2063713494490388661">தேடத் தட்டுக</translation>
+<translation id="2369463299479365221">பக்கத்தை விட்டு விலகாமலே இணையதளங்களில் உள்ள தலைப்புகள் குறித்து அறிந்துகொள்ளலாம். "தேடுவதற்குத் தட்டு" அம்சமானது சொல்லையும் அதன் சூழலையும் Brave Software தேடலுக்கு அனுப்புவதோடு வரையறைகள், படங்கள், தேடல் முடிவுகள், பிற விவரங்கள் ஆகியவற்றை வழங்குகிறது.
 
 உங்கள் தேடல் வார்த்தையைத் திருத்த, நீண்ட நேரம் அழுத்தித் தேர்ந்தெடுக்கவும். துல்லியமாகத் தேட, பேனலைக் கடைசி வரை மேலே ஸ்லைடு செய்து, தேடல் பெட்டியைத் தட்டவும்.</translation>
-<translation id="4056223980640387499">செபியா</translation>
-<translation id="4060598801229743805">திரையின் மேற்பகுதிக்கு அருகில், விருப்பங்கள் உள்ளன</translation>
-<translation id="4062305924942672200">சட்டப்பூர்வத் தகவல்</translation>
-<translation id="4084682180776658562">புக்மார்க்</translation>
-<translation id="4084712963632273211">வெளியிடுவது: <ph name="PUBLISHER_ORIGIN" /> (<ph name="BEGIN_DEEMPHASIZED" />Google வழங்குவது<ph name="END_DEEMPHASIZED" />)</translation>
-<translation id="4095146165863963773">பயன்பாட்டுத் தரவை நீக்கவா?</translation>
-<translation id="4099578267706723511">பயன்பாட்டுப் புள்ளிவிவரங்களையும், சிதைவு அறிக்கைகளையும் Googleளுக்கு அனுப்புவதன் மூலம் Chromeஐ மேலும் சிறப்பானதாக்க உதவவும்.</translation>
-<translation id="410351446219883937">தானியங்கி</translation>
-<translation id="4116038641877404294">ஆஃப்லைனில் பார்க்க, பக்கங்களைப் பதிவிறக்கவும்</translation>
-<translation id="4135200667068010335">தாவலைப் பகிர்வதற்கான சாதனங்களின் பட்டியல் மூடப்பட்டுள்ளது.</translation>
-<translation id="4149994727733219643">இணையப் பக்கங்களுக்கான எளிதாக்கப்பட்ட காட்சி</translation>
-<translation id="4165986682804962316">தள அமைப்புகள்</translation>
-<translation id="4169535189173047238">அனுமதிக்காதே</translation>
-<translation id="4170011742729630528">சேவை கிடைக்கவில்லை; பிறகு முயற்சிக்கவும்.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> பயன்படுத்தப்பட்டுள்ளது</translation>
-<translation id="4181841719683918333">மொழிகள்</translation>
-<translation id="4183868528246477015">Google Lens மூலம் தேடுக <ph name="BEGIN_NEW" />புதிது<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">புதிய தாவலில் திற</translation>
-<translation id="4198423547019359126">பதிவிறக்க இருப்பிடம் எதுவும் இல்லை</translation>
-<translation id="4209895695669353772">Google பரிந்துரைக்கும் பிரத்யேக உள்ளடக்கத்தைப் பெற, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="4226663524361240545">அறிவிப்புகள் வரும் போது சாதனம் அதிர்வுறக்கூடும்</translation>
-<translation id="423219824432660969"><ph name="TIME" /> அன்றைக்கான Google கடவுச்சொல்லைப் பயன்படுத்தி  ஒத்திசைக்கப்பட்ட தரவை என்க்ரிப்ட் செய்</translation>
-<translation id="4242533952199664413">அமைப்புகளைத் திற</translation>
-<translation id="4256782883801055595">ஓப்பன் சோர்ஸ் உரிமங்கள்</translation>
-<translation id="4259722352634471385">செல்வது தடுக்கப்பட்டது: <ph name="URL" /></translation>
-<translation id="4269820728363426813">இணைப்பு முகவரியை நகலெடு</translation>
-<translation id="4275663329226226506">ஊடகம்</translation>
-<translation id="4278390842282768270">அனுமதிக்கப்பட்டது</translation>
-<translation id="429312253194641664">ஒரு தளம் மீடியாவை இயக்குகிறது</translation>
-<translation id="4298388696830689168">இணைக்கப்பட்டுள்ள தளங்கள்</translation>
-<translation id="4307992518367153382">அடிப்படைகள்</translation>
-<translation id="4314815835985389558">ஒத்திசைவை நிர்வகிக்கும் பக்கம்</translation>
-<translation id="4351244548802238354">அறிவிப்பை மூடு</translation>
-<translation id="4378154925671717803">மொபைல்</translation>
-<translation id="4384468725000734951">தேடலுக்கு Sogouஐப் பயன்படுத்துகிறீர்கள்</translation>
-<translation id="4404568932422911380">புக்மார்க்குகள் இல்லை</translation>
-<translation id="4405224443901389797">இங்கு நகர்த்து…</translation>
-<translation id="4411535500181276704">லைட் பயன்முறை</translation>
-<translation id="4415276339145661267">Google கணக்கை நிர்வகி</translation>
-<translation id="4432792777822557199">இனி <ph name="SOURCE_LANGUAGE" /> மொழியில் உள்ள பக்கங்கள் <ph name="TARGET_LANGUAGE" /> மொழிக்கு மொழிபெயர்க்கப்படும்</translation>
-<translation id="4433925000917964731">Google வழங்கும் Lite பக்கம்</translation>
-<translation id="4434045419905280838">பாப் அப்கள் &amp; திசைதிருப்புதல்கள்</translation>
-<translation id="4440958355523780886">Google வழங்கும் Lite பக்கம். அசல் பக்கத்தை ஏற்ற, தட்டவும்.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> தாவலை மூடும்</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" /> இல் புத்தகக்குறியைச் சேர்த்தது</translation>
-<translation id="445467742685312942">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்குவதற்குத் தளங்களை அனுமதிக்கும்</translation>
-<translation id="4468959413250150279">குறிப்பிட்ட தளத்திற்கு ஒலியடக்கு</translation>
-<translation id="4472118726404937099">அனைத்துச் சாதனங்களுக்கு இடையிலும் ஒத்திசைக்க மற்றும் தனிப்பயனாக்க, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="447252321002412580">Chrome இன் அம்சங்களையும் செயல்திறனையும் மேம்படுத்த உதவுக</translation>
-<translation id="4479647676395637221">எனது கேமராவைப் பயன்படுத்தத் தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="4479972344484327217">Chromeமுக்கான <ph name="MODULE" />ஐ நிறுவுகிறது…</translation>
-<translation id="4487967297491345095">Chrome இன் எல்லாப் பயன்பாட்டுத் தரவும் நிரந்தரமாக நீக்கப்படும். இதில் அனைத்துக் கோப்புகள், அமைப்புகள், கணக்குகள், தரவுத்தளங்கள், மேலும் பல உள்ளடங்கும்.</translation>
-<translation id="4493497663118223949">லைட் பயன்முறை இயக்கத்தில் உள்ளது</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# நாள் முன்பு}other{# நாட்களுக்கு முன்பு}}</translation>
-<translation id="451872707440238414">புக்மார்க்களில் தேடு</translation>
-<translation id="4521489764227272523">Chrome மற்றும் ஒத்திசைக்கப்பட்ட சாதனங்களிலிருந்து, தேர்ந்தெடுத்த தரவு அகற்றப்பட்டது.
-
-<ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> எனும் தளத்தில் பிற Google சேவைகளிலிருந்து தேடல்கள், செயல்பாடு போன்ற உங்கள் Google கணக்கிற்கான பிற வகை உலாவல் வரலாறும் இருக்கக்கூடும்.</translation>
-<translation id="4532845899244822526">கோப்புறையைத் தேர்வுசெய்யவும்</translation>
-<translation id="4538018662093857852">லைட் பயன்முறையை இயக்கு</translation>
-<translation id="4550003330909367850">உங்கள் கடவுச்சொல்லை இங்கே பார்க்க அல்லது நகலெடுக்க, இந்தச் சாதனத்தில் திரைப் பூட்டை அமைக்கவும்.</translation>
-<translation id="4558311620361989323">இணையப் பக்கக் ஷார்ட்கட்கள்</translation>
-<translation id="4561979708150884304">இணைப்பு இல்லை</translation>
-<translation id="4565377596337484307">கடவுச்சொல்லை மறைக்கும்</translation>
-<translation id="4570913071927164677">விவரங்கள்</translation>
-<translation id="4572422548854449519">நிர்வகிக்கப்படும் கணக்கில் உள்நுழையவும்</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# நிமிடத்திற்கு முன்பு}other{# நிமிடங்களுக்கு முன்பு}}</translation>
-<translation id="4587589328781138893">தளங்கள்</translation>
-<translation id="4594952190837476234"><ph name="CREATION_TIME" /> அன்று இந்த ஆஃப்லைன் பக்கம் உருவாக்கப்பட்டது. இது ஆன்லைன் பதிப்பிலிருந்து வேறுபடலாம்.</translation>
-<translation id="4605958867780575332">உருப்படி அகற்றப்பட்டது: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" />ஐத் திற</translation>
-<translation id="4634124774493850572">கடவுச்சொல்லைப் பயன்படுத்து</translation>
-<translation id="4645575059429386691">உங்கள் பெற்றோரால் நிர்வகிக்கப்படுகிறது</translation>
-<translation id="4650364565596261010">சிஸ்டத்தின் இயல்புநிலை</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> புக்மார்க்குகள் நீக்கப்பட்டன</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> உங்கள் முகப்புத் திரையில் சேர்க்கப்பட்டது</translation>
-<translation id="4684427112815847243">அனைத்தையும் ஒத்திசை</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> விருப்பம்}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> விருப்பங்கள்}}</translation>
-<translation id="4696983787092045100">எனது சாதனங்களுக்கு உரைச் செய்தியை அனுப்பு</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> இல் உள்ளடக்கத்தை ஆஃப்லைனில் பார்க்கலாம்</translation>
-<translation id="4699172675775169585">தற்காலிகமாகச் சேமிக்கப்பட்ட படங்கள் மற்றும் கோப்புகள்</translation>
-<translation id="4714588616299687897">தரவில் 60% வரை சேமியுங்கள்</translation>
-<translation id="4719927025381752090">மொழிபெயர்ப்பதற்கான சலுகை</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" />இல் திற</translation>
-<translation id="4720982865791209136">Chromeஐ மேம்படுத்த உதவவும். <ph name="BEGIN_LINK" />கருத்துக்கணிப்பில் பங்கேற்கவும்<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">புதுப்பி</translation>
-<translation id="4738836084190194332">கடைசியாக ஒத்திசைத்தது: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">புதிய தாவலைத் திறக்கும்</translation>
-<translation id="4751476147751820511">நகர்வு அல்லது ஒளி உணர்விகள்</translation>
-<translation id="4759238208242260848">பதிவிறக்கங்கள்</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{ஒரு பதிவிறக்கம் முடிந்தது.}other{# பதிவிறக்கங்கள் முடிந்தன.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" />க்குச் செல்ல, தொடவும்</translation>
-<translation id="4802417911091824046">கடவுச்சொற்றொடர் என்க்ரிப்ஷனில் Google Payயிலுள்ள கட்டண முறைகளும் முகவரிகளும் சேர்க்கப்படாது.
-
-இந்த அமைப்பை மாற்ற, <ph name="BEGIN_LINK" />ஒத்திசைவை மீட்டமைக்கவும்<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">அட்டையிலுள்ள பெயர் </translation>
-<translation id="4824958205181053313">ஒத்திசைவை ரத்துசெய்யவா?</translation>
-<translation id="4837753911714442426">பக்கத்தை அச்சிடுவதற்கான விருப்பங்களைத் திறக்கும்</translation>
-<translation id="4842092870884894799">கடவுச்சொல் உருவாக்க பாப்-அப்பைக் காட்டுகிறது</translation>
-<translation id="4860895144060829044">அழை</translation>
-<translation id="4866368707455379617">Chromeமுக்கான <ph name="MODULE" />ஐ நிறுவ முடியவில்லை</translation>
-<translation id="4875775213178255010">உள்ளடக்கப் பரிந்துரைகள்</translation>
-<translation id="4878404682131129617">ப்ராக்ஸி சர்வர் மூலமாக டனல் இணைப்பை உருவாக்க முடியவில்லை</translation>
-<translation id="4880127995492972015">மொழிபெயர்…</translation>
-<translation id="4881695831933465202">திற</translation>
-<translation id="488187801263602086">கோப்பின் பெயரை மாற்றவும்</translation>
-<translation id="4882831918239250449">தேடல், விளம்பரங்கள் மற்றும் பலவற்றைத் தனிப்பயனாக்க உங்கள் உலாவல் வரலாறு எப்படிப் பயன்படுத்தப்படுகிறது என்பதைக் கட்டுப்படுத்துதல்</translation>
-<translation id="4883854917563148705">நிர்வகிக்கப்பட்ட அமைப்புகளை மீட்டமைக்க முடியாது</translation>
-<translation id="4885273946141277891">ஆதரிக்கப்படாத Chrome நிகழ்வுகளின் எண்ணிக்கை.</translation>
-<translation id="4910889077668685004">கட்டணம் செலுத்துவதற்கான ஆப்ஸ்</translation>
-<translation id="4913161338056004800">புள்ளிவிவரங்களை மீட்டமை</translation>
-<translation id="4913169188695071480">புதுப்பிக்காதே</translation>
-<translation id="4915549754973153784">சாதனங்களைத் தேடும் போது <ph name="BEGIN_LINK" />உதவி பெறுக<ph name="END_LINK" />…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# பக்கம்}other{# பக்கங்கள்}}</translation>
-<translation id="4932247056774066048">நீங்கள் <ph name="DOMAIN_NAME" /> நிர்வகிக்கும் கணக்கிலிருந்து வெளியேறுவதால் உங்கள் Chrome தரவு இந்தச் சாதனத்திலிருந்து நீக்கப்படும். எனினும் இது உங்கள் Google கணக்கில் சேமிக்கப்பட்டிருக்கும்.</translation>
-<translation id="4943703118917034429">விர்ச்சுவல் ரியாலிட்டி</translation>
-<translation id="4943872375798546930">முடிவுகள் இல்லை</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> உங்கள் திரையைப் பகிர்கிறது</translation>
-<translation id="4961107849584082341">இந்தப் பக்கத்தை எந்தவொரு மொழியிலும் மொழிபெயர்க்கலாம்</translation>
-<translation id="4962975101802056554">சாதனத்திற்கான அனைத்து அனுமதிகளையும் ரத்துசெய்யும்</translation>
-<translation id="4970824347203572753">உங்கள் நாட்டில் இல்லை</translation>
-<translation id="497421865427891073">முன் செல்க</translation>
-<translation id="4988210275050210843">கோப்பைப் பதிவிறக்குகிறது (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">பக்கங்கள்</translation>
-<translation id="4994033804516042629">தொடர்புகள் எதுவும் இல்லை</translation>
-<translation id="4996978546172906250">இதன்வழியாக பகிர்</translation>
-<translation id="5004416275253351869">Google செயல்பாட்டுக் கட்டுப்பாடுகள்</translation>
-<translation id="5005498671520578047">கடவுச்சொல்லை நகலெடு</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> இணைய விரும்புகிறது</translation>
-<translation id="5013696553129441713">புதிய பரிந்துரைகள் இல்லை</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">VRரில் இருக்கும்போது இந்தத் தளம் இவற்றைப் பற்றி அறியக்கூடும்:
-  -  உங்களின் உயரம் போன்ற உடலமைப்பு விவரங்கள்
-
-VRரைத் தொடங்குவதற்கு முன் இது நம்பகமான தளமா என்பதை உறுதிசெய்து கொள்ளவும்.</translation>
+<translation id="2930742481329940825">"தேடுவதற்குத் தட்டு" எனும் அம்சமானது தேர்ந்தெடுத்த சொல்லையும், அதனுடைய பின்னணிச் சூழலாக நடப்புப் பக்கத்தையும் Brave Software தேடலுக்கு அனுப்பும். இதை <ph name="BEGIN_LINK"/>அமைப்புகளில்<ph name="END_LINK"/> முடக்கலாம்.</translation>
 <translation id="5039804452771397117">அனுமதி</translation>
-<translation id="5040262127954254034">தனியுரிமை</translation>
-<translation id="5048398596102334565">மோஷன் சென்சார்களை அணுக தளங்களை அனுமதிக்கும் (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="5063480226653192405">பயன்பாடு</translation>
-<translation id="5087580092889165836">கார்டைச் சேர்</translation>
-<translation id="5100237604440890931">சுருக்கப்பட்டது - விரிவாக்க, கிளிக் செய்யவும்.</translation>
-<translation id="510275257476243843">1 மணிநேரம் மீதமுள்ளது</translation>
-<translation id="5123685120097942451">மறைநிலைத் தாவல்</translation>
-<translation id="5127805178023152808">ஒத்திசைவு முடக்கத்தில்</translation>
-<translation id="5129038482087801250">இணைய ஆப்ஸை நிறுவு</translation>
-<translation id="5132942445612118989">எல்லாச் சாதனங்களிலும் உங்கள் கடவுச்சொற்கள், வரலாறு மற்றும் பலவற்றை ஒத்திசைக்கலாம்</translation>
-<translation id="5139940364318403933">Google இயக்ககத்தை எப்படிப் பயன்படுத்துவது என்பதை அறிக</translation>
-<translation id="515227803646670480">சேமித்தத் தரவை அழி</translation>
-<translation id="5152843274749979095">ஆதரிக்கப்படும் ஆப்ஸ் நிறுவப்படவில்லை</translation>
-<translation id="5161254044473106830">தலைப்பு அவசியம்</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{ஒரு பதிவிறக்கம் தோல்வியடைந்தது.}other{# பதிவிறக்கங்கள் தோல்வியடைந்தன.}}</translation>
-<translation id="5170568018924773124">கோப்புறையில் காண்பி</translation>
-<translation id="5184329579814168207">Chrome இல் திற</translation>
-<translation id="5193988420012215838">கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது</translation>
-<translation id="5197729504361054390">நீங்கள் தேர்ந்தெடுக்கும் தொடர்புகள் <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> உடன் பகிரப்படும்.</translation>
-<translation id="5199929503336119739">பணி சுயவிவரம்</translation>
-<translation id="5210286577605176222">முந்தைய தாவலுக்குச் செல்லும்</translation>
-<translation id="5210365745912300556">தாவலை மூடுக</translation>
-<translation id="5224771365102442243">வீடியோவுடன்</translation>
-<translation id="5230560987958996918">அருகிலுள்ள புளூடூத் சாதனங்களை <ph name="SITE" /> ஸ்கேன் செய்ய விரும்புகிறது. இவை கண்டறியப்பட்டுள்ளன:</translation>
-<translation id="5233638681132016545">புதிய தாவல்</translation>
-<translation id="526421993248218238">பக்கத்தை ஏற்ற முடியவில்லை</translation>
-<translation id="5271967389191913893">பதிவிறக்க வேண்டிய உள்ளடக்கத்தைச் சாதனத்தால் திறக்க முடியாது</translation>
-<translation id="528192093759286357">முழுத்திரையிலிருந்து வெளியேற, மேலிருந்து இழுத்து "முந்தையது" பொத்தானைத் தொடவும்.</translation>
-<translation id="5292796745632149097">இதற்கு அனுப்பு:</translation>
-<translation id="5300589172476337783">காண்பி</translation>
-<translation id="5301954838959518834">சரி, புரிந்தது</translation>
-<translation id="5304593522240415983">இந்தப் புலம் காலியாக இருக்கக் கூடாது</translation>
-<translation id="5307446750509046227">தள சேமிப்பகத்தை அழி</translation>
-<translation id="5308380583665731573">இணை</translation>
-<translation id="5313967007315987356">தளத்தைச் சேர்</translation>
-<translation id="5317780077021120954">சேமி</translation>
-<translation id="5324858694974489420">பெற்றோர் அமைப்புகள்</translation>
-<translation id="5327248766486351172">பெயர்</translation>
-<translation id="5335288049665977812">JavaScriptஐ இயக்குவதற்கு, தளங்களை அனுமதி (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="5342314432463739672">அனுமதிக் கோரிக்கைகள்</translation>
-<translation id="5357811892247919462">பகிர்ந்த தாவல் பெறப்பட்டது</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> திறந்துள்ள தாவல், தாவல்களை மாற்ற, தட்டவும்}other{<ph name="OPEN_TABS_MANY" /> திறந்துள்ள தாவல்கள், தாவல்களை மாற்ற, தட்டவும்}}</translation>
-<translation id="5391532827096253100">இந்தத் தளத்திற்கான இணைப்பு பாதுகாப்பானதல்ல. தளத் தகவல்</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(மேலும் 1)}other{(மேலும் #)}}</translation>
-<translation id="5400569084694353794">இந்தப் பயன்பாட்டைப் பயன்படுத்துவதன் மூலம், Chrome இன் <ph name="BEGIN_LINK1" />சேவை விதிமுறைகள்<ph name="END_LINK1" /> மற்றும் <ph name="BEGIN_LINK2" />தனியுரிமை அறிக்கையை<ph name="END_LINK2" /> ஏற்கிறீர்கள்.</translation>
-<translation id="5403592356182871684">பெயர்கள்</translation>
-<translation id="5403644198645076998">குறிப்பிட்ட தளங்களை மட்டும் அனுமதி</translation>
-<translation id="5414836363063783498">சரிபார்க்கிறது...</translation>
-<translation id="5423934151118863508">நீங்கள் அதிகமாகப் பார்வையிட்ட பக்கங்கள் இங்கு தோன்றும்</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> ஜி.பை. உள்ளது</translation>
-<translation id="543338862236136125">கடவுச்சொல்லை மாற்று</translation>
-<translation id="5433691172869980887">பயனர்பெயர் நகலெடுக்கப்பட்டது</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> கோப்புகளைப் பதிவிறக்குகிறது (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">முகவரிப் பட்டிக்குச் செல்லும்</translation>
-<translation id="5447201525962359567">குக்கீகள் மற்றும் சாதனத்தில் சேமிக்கப்பட்ட பிற தரவு உள்பட எல்லா தளச் சேமிப்பகமும்</translation>
-<translation id="5447765697759493033">இந்தத் தளம் மொழிபெயர்க்கப்படாது</translation>
-<translation id="545042621069398927">பதிவிறக்கத்தின் வேகத்தை அதிகப்படுத்துகிறது.</translation>
-<translation id="5456381639095306749">பக்கத்தைப் பதிவிறக்குக</translation>
-<translation id="5475862044948910901">'ஆக்மெண்ட்டட் ரியாலிட்டி' அமர்வைத் தொடங்கவா?</translation>
-<translation id="548278423535722844">வரைபடப் பயன்பாட்டில் திற</translation>
-<translation id="5487521232677179737">தரவை அழி</translation>
-<translation id="5494752089476963479">குறுக்கிடும் அல்லது தவறாக வழிநடத்தும் விளம்பரங்களைக் காட்டும் தளங்களில் விளம்பரங்களைத் தடு</translation>
-<translation id="5500777121964041360">உங்கள் நாட்டில் இல்லாமல் இருக்கக்கூடும்</translation>
-<translation id="5512137114520586844">இந்தக் கணக்கு <ph name="PARENT_NAME" /> ஆல் நிர்வகிக்கப்படுகிறது.</translation>
-<translation id="5514904542973294328">இந்தச் சாதனத்தின் நிர்வாகி முடக்கியுள்ளார்</translation>
-<translation id="5515439363601853141">கடவுச்சொல்லைப் பார்க்க, திறக்கவும்</translation>
-<translation id="5516455585884385570">அறிவிப்பு அமைப்புகளைத் திறக்கும்</translation>
-<translation id="5517095782334947753"><ph name="FROM_ACCOUNT" /> இன் புக்மார்க்குகள், வரலாறு, கடவுச்சொற்கள் மற்றும் பிற அமைப்புகள் உள்ளன.</translation>
-<translation id="5524843473235508879">திசைதிருப்புவது தடுக்கப்பட்டது.</translation>
-<translation id="5527082711130173040">சாதனங்களைத் தேட Chromeமுக்கு இருப்பிட அணுகல் தேவை. <ph name="BEGIN_LINK1" />அனுமதிகளை மாற்றவும்<ph name="END_LINK1" />. இருப்பிட அணுகலும் <ph name="BEGIN_LINK2" />இந்தச் சாதனத்தில் முடக்கப்பட்டுள்ளது<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">கிளிப்போர்டிலிருந்து உரையையும் படங்களையும் படிப்பதற்கு, தளங்களை அனுமதிப்பதற்கு முன், கேள் (பரிந்துரைக்கப்படுவது)</translation>
-<translation id="5530766185686772672">மறைநிலை தாவல்களை மூடு</translation>
-<translation id="5534334044554683961">VRரில் இருக்கும்போது இந்தத் தளம் இவற்றைப் பற்றி அறியக்கூடும்:
-  -   உங்களின் உயரம் போன்ற உடலமைப்பு விவரங்கள்
-  -   உங்கள் அறையின் தளவமைப்பு
-
-VRரைத் தொடங்குவதற்கு முன் இது நம்பகமான தளமா என்பதை உறுதிசெய்து கொள்ளவும்.</translation>
-<translation id="5534640966246046842">தளம் நகலெடுக்கப்பட்டது</translation>
-<translation id="5556459405103347317">மீண்டும் ஏற்று</translation>
-<translation id="5561549206367097665">நெட்வொர்க்கிற்காகக் காத்திருக்கிறது…</translation>
-<translation id="557283862590186398">இந்தத் தளத்திற்காக மைக்ரோஃபோனை அணுக, Chromeமுக்கு அனுமதி தேவை.</translation>
-<translation id="55737423895878184">இருப்பிடமும் அறிவிப்புகளும் அனுமதிக்கப்படுகின்றன</translation>
-<translation id="5578795271662203820">இந்தப் படத்திற்கு <ph name="SEARCH_ENGINE" /> இல் தேடவும்</translation>
-<translation id="5581519193887989363">எவற்றை ஒத்திசைக்க வேண்டும் என்பதை <ph name="BEGIN_LINK1" />அமைப்புகளில்<ph name="END_LINK1" /> எப்போது வேண்டுமானாலும் தேர்வுசெய்யலாம்.</translation>
-<translation id="5595485650161345191">முகவரியைத் திருத்து</translation>
-<translation id="5596627076506792578">கூடுதல் விருப்பங்கள்</translation>
-<translation id="5599455543593328020">மறைநிலைப் பயன்முறை</translation>
-<translation id="5620928963363755975">மேலும் விருப்பங்கள் பொத்தானிற்குச் சென்று, பதிவிறக்கங்கள் என்பதில் கோப்புகளையும் பக்கங்களையும் கண்டறியலாம்</translation>
-<translation id="5626134646977739690">பெயர்:</translation>
-<translation id="5639724618331995626">எல்லாத் தளங்களையும் அனுமதி</translation>
-<translation id="5648166631817621825">கடந்த 7 நாட்கள்</translation>
-<translation id="5649053991847567735">தன்னியக்கப் பதிவிறக்கங்கள்</translation>
-<translation id="5655963694829536461">உங்கள் பதிவிறக்கங்களைத் தேடுக</translation>
-<translation id="5659593005791499971">மின்னஞ்சல்</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> இல் நிகழ்வை உருவாக்கு</translation>
-<translation id="5668404140385795438">பெரிதாக்கப்படுவதைத் தடுக்க இணையதளம் விடுத்த கோரிக்கையைப் புறக்கணிக்கவும்</translation>
-<translation id="5677928146339483299">தடுக்கப்பட்டது</translation>
-<translation id="5684874026226664614">அச்சச்சோ. இந்தப் பக்கத்தை மொழிபெயர்க்க முடியாது.</translation>
-<translation id="5686790454216892815">கோப்பின் பெயர் நீளமாக உள்ளது</translation>
-<translation id="5689516760719285838">இருப்பிடம்</translation>
-<translation id="569536719314091526">’மேலும் விருப்பத்தேர்வுகள்’ பட்டனை அழுத்தி, இந்தப் பக்கத்தை எந்தவொரு மொழியிலும் மொழிபெயர்க்கலாம்</translation>
-<translation id="572328651809341494">சமீபத்திய தாவல்கள்</translation>
-<translation id="5726692708398506830">பக்கத்திலுள்ள அனைத்தையும் பெரிதாக்கும்</translation>
-<translation id="5748802427693696783">இயல்பான தாவல்களுக்கு மாற்றப்பட்டது</translation>
-<translation id="5749068826913805084">கோப்புகளைப் பதிவிறக்க Chromeக்கு சேமிப்பிட அணுகல் தேவை.</translation>
-<translation id="5763382633136178763">மறைநிலைத் தாவல்கள்</translation>
-<translation id="5763514718066511291">இந்த ஆப்ஸின் URLஐ நகலெடுக்க, தட்டவும்</translation>
-<translation id="5765780083710877561">விவரம்:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" /> இல் <ph name="SPACE_USED" /> பயன்படுத்தப்படுகிறது</translation>
-<translation id="5797070761912323120">தேடல், விளம்பரங்கள் மற்றும் பிற Google சேவைகளைத் தனிப்பயனாக்க, உங்கள் வரலாற்றை Google பயன்படுத்தக்கூடும்</translation>
-<translation id="5804241973901381774">அனுமதிகள்</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# மணிநேரம் முன்பு}other{# மணிநேரம் முன்பு}}</translation>
-<translation id="5810288467834065221">பதிப்புரிமை <ph name="YEAR" /> Google LLC. அனைத்து உரிமைகளும் பாதுகாக்கப்பட்டுள்ளன.</translation>
-<translation id="5817918615728894473">இணை</translation>
-<translation id="583281660410589416">தெரியாதது</translation>
-<translation id="5833984609253377421">இணைப்பைப் பகிர்</translation>
-<translation id="5836192821815272682">Chrome புதுப்பிப்பைப் பதிவிறக்குகிறது…</translation>
-<translation id="5853623416121554550">இடைநிறுத்தப்பட்டது</translation>
-<translation id="5854790677617711513">30 நாட்களுக்கு முந்தையவை</translation>
-<translation id="5858741533101922242">Chrome ஆல் புளூடூத் அடாப்டரை இயக்க முடியவில்லை</translation>
-<translation id="5860033963881614850">ஆஃப்</translation>
-<translation id="5862731021271217234">உங்கள் பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="5864174910718532887">விவரங்கள்: தளப் பெயரின்படி வரிசைப்படுத்தப்பட்டுள்ளன</translation>
-<translation id="5864419784173784555">வேறொரு பதிவிறக்கத்திற்காகக் காத்திருக்கிறது…</translation>
-<translation id="5865733239029070421">பயன்பாட்டுப் புள்ளிவிவரங்களையும் சிதைவு அறிக்கைகளையும் தானாகவே Googleளுக்கு அனுப்பும்</translation>
-<translation id="5869522115854928033">சேமிக்கப்பட்ட கடவுச்சொற்கள்</translation>
-<translation id="5902828464777634901">குக்கீகள் உட்பட, இந்த இணைய தளத்தால் சேமிக்கப்படும் அனைத்து அகத் தரவும் நீக்கப்படும்.</translation>
-<translation id="5916664084637901428">இயக்கு</translation>
-<translation id="5919204609460789179">ஒத்திசைவைத் தொடங்க, <ph name="PRODUCT_NAME" />ஐப் புதுப்பிக்கவும்</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> சேமிக்கப்பட்டது</translation>
-<translation id="5939518447894949180">மீட்டமை</translation>
-<translation id="5942872142862698679">தேடலுக்கு Googleளைப் பயன்படுத்துகிறீர்கள்</translation>
-<translation id="5952764234151283551">நீங்கள் செல்ல முயலும் பக்கத்தின் URLலை Googleளுக்கு அனுப்பும்</translation>
-<translation id="5956665950594638604">Chrome உதவி மையத்தைப் புதிய தாவலில் திறக்கும்</translation>
-<translation id="5958275228015807058">பதிவிறக்கங்கள் என்பதில் கோப்புகளையும் பக்கங்களையும் கண்டறியலாம்</translation>
-<translation id="5962718611393537961">சுருக்க, தட்டவும்</translation>
-<translation id="6000066717592683814">Googleஐ இயல்பு இன்ஜினாக வைத்திரு</translation>
-<translation id="6005538289190791541">பரிந்துரைக்கப்படும் கடவுச்சொல்</translation>
-<translation id="6036057147555329831">கூடுதல் ICU</translation>
-<translation id="6039379616847168523">அடுத்த தாவலுக்குச் செல்லும்</translation>
-<translation id="6040143037577758943">மூடு</translation>
-<translation id="6042308850641462728">மேலும்</translation>
-<translation id="604996488070107836">அறியப்படாதப் பிழை காரணமாக <ph name="FILE_NAME" />ஐப் பதிவிறக்க முடியவில்லை.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">நிறைவடைந்த பதிவிறக்கங்கள்</translation>
-<translation id="6075798973483050474">முகப்புப் பக்கத்தைத் திருத்து</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> மணிநேரம் மீதமுள்ளது</translation>
-<translation id="6108923351542677676">அமைவு செயலிலுள்ளது...</translation>
-<translation id="6111020039983847643">பயன்படுத்திய டேட்டா</translation>
-<translation id="6112702117600201073">பக்கத்தைப் புதுப்பிக்கிறது</translation>
-<translation id="6127379762771434464">உருப்படி அகற்றப்பட்டது</translation>
-<translation id="6140912465461743537">நாடு/மண்டலம்</translation>
-<translation id="614940544461990577">இவற்றைச் செய்து பார்க்கவும்:</translation>
-<translation id="6154478581116148741">இந்தச் சாதனத்திலிருந்து உங்கள் கடவுச்சொற்களை ஏற்ற, அமைப்புகளில் திரைப் பூட்டை இயக்கவும்</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> தரவுச் சேமிப்புகள்</translation>
-<translation id="6165508094623778733">மேலும் அறிக</translation>
-<translation id="6177111841848151710">நடப்புத் தேடல் இன்ஜினுக்குத் தடுக்கப்பட்டுள்ளது</translation>
-<translation id="6181444274883918285">தள விதிவிலக்கைச் சேர்</translation>
-<translation id="6192333916571137726">கோப்பைப் பதிவிறக்கவும்</translation>
-<translation id="6192792657125177640">விதிவிலக்குகள்</translation>
-<translation id="6194112207524046168">உங்கள் கேமராவை அணுக Chromeமை அனுமதிப்பதற்கு <ph name="BEGIN_LINK" />Android அமைப்புகளிலும்<ph name="END_LINK" /> கேமராவை இயக்கவும்.</translation>
-<translation id="6196640612572343990">மூன்றாம் தரப்புக் குக்கீகளைத் தடு</translation>
-<translation id="6206551242102657620">பாதுகாப்பான இணைப்பு. தளத் தகவல்</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> இல்லையா?</translation>
-<translation id="6221633008163990886">உங்கள் கடவுச்சொற்களை ஏற்ற, திறக்கவும்</translation>
+<translation id="1406000523432664303">'கண்காணிக்க வேண்டாம்'</translation>
 <translation id="6232535412751077445">‘கண்காணிக்க வேண்டாம்’ என்பதை இயக்குவதால் உங்கள் உலாவல் டிராஃபிக்குடன் கோரிக்கை ஒன்று இணைக்கப்படும். கோரிக்கைக்கு இணையதளம் எவ்வாறு பதிலளிக்கிறது என்பதையும் கோரிக்கையானது எவ்வாறு புரிந்து கொள்ளப்படுகிறது என்பதையும் பொருத்து எந்தவொரு விளைவும் இருக்கும்.
 
 எடுத்துக்காட்டாக, சில இணையதளங்கள் நீங்கள் பார்வையிட்ட பிற இணையதளங்களின் அடிப்படையில் இல்லாத விளம்பரங்களைக் காட்டுவதன் மூலம் இந்தக் கோரிக்கைக்குப் பதிலளிக்கலாம். பல இணையதளங்கள் நீங்கள் உலாவிய தரவைத் தொடர்ந்து சேகரித்துப் பயன்படுத்தும் - எடுத்துக்காட்டாக பாதுகாப்பை மேம்படுத்த, உள்ளடக்கம், விளம்பரங்கள் மற்றும் பரிந்துரைகளை வழங்க, அறிக்கைப் புள்ளிவிவரங்களை உருவாக்க நீங்கள் உலாவிய தரவைப் பயன்படுத்தலாம்.</translation>
-<translation id="624789221780392884">புதுப்பிப்பு தயார்</translation>
-<translation id="6255999984061454636">உள்ளடக்கப் பரிந்துரைகள்</translation>
-<translation id="6277522088822131679">பக்கத்தை அச்சிடுவதில் சிக்கல் ஏற்பட்டது. மீண்டும் முயற்சிக்கவும்.</translation>
-<translation id="6295158916970320988">எல்லா தளங்களும்</translation>
-<translation id="629730747756840877">கணக்கு</translation>
-<translation id="6303969859164067831">வெளியேறி ஒத்திசைவை முடக்கு</translation>
-<translation id="6316139424528454185">Android பதிப்பு ஆதரிக்கப்படாது</translation>
-<translation id="6320088164292336938">அதிர்வுறு</translation>
-<translation id="6324034347079777476">Android அமைப்பின் ஒத்திசைவு முடக்கப்பட்டது</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> வழியாகப் பகிர்</translation>
-<translation id="6337234675334993532">என்க்ரிப்ஷன்</translation>
-<translation id="6341580099087024258">கோப்புகளை எங்கே சேமிக்க வேண்டும் என்று கேள்</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> முகவரி}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> முகவரிகள்}}</translation>
-<translation id="6364438453358674297">வரலாற்றிலிருந்து பரிந்துரையை அகற்றவா?</translation>
-<translation id="6369229450655021117">இங்கிருந்தபடியே இணையத்தில் தேடலாம், நண்பர்களுடன் உள்ளடக்கங்களைப் பகிரலாம், திறந்துள்ள பக்கங்களைப் பார்க்கலாம்</translation>
-<translation id="6378173571450987352">விவரங்கள்: பயன்படுத்திய டேட்டா அளவின்படி வரிசைப்படுத்தப்பட்டுள்ளன</translation>
-<translation id="6381421346744604172">இணையதளங்களை டார்க்காக மாற்று</translation>
-<translation id="6388207532828177975">அழித்து, மீட்டமைக்கவும்</translation>
-<translation id="6393863479814692971">இந்தத் தளத்திற்காகக் கேமராவையும் மைக்ரோஃபோனையும் அணுக, Chromeமுக்கு அனுமதி தேவை.</translation>
-<translation id="6395288395575013217">இணைப்பு</translation>
-<translation id="6404511346730675251">புக்மார்க்களைத் திருத்து</translation>
-<translation id="6406506848690869874">Sync</translation>
-<translation id="641643625718530986">அச்சிடு...</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> மெ.பை. பதிவிறக்கப்பட்டுள்ளது</translation>
-<translation id="6427112570124116297">இணையத்தை மொழிபெயர்த்தல்</translation>
-<translation id="6433501201775827830">தேடல் இன்ஜினைத் தேர்வுசெய்யவும்</translation>
-<translation id="6437478888915024427">பக்கத் தகவல்</translation>
-<translation id="6441734959916820584">பெயர் மிக நீளமாக உள்ளது</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# படம்}other{# படங்கள்}}</translation>
-<translation id="6447842834002726250">குக்கீகள்</translation>
-<translation id="6461962085415701688">கோப்பைத் திறக்க முடியாது</translation>
-<translation id="6464977750820128603">Chromeமில் பார்த்தத் தளங்களைக் காணலாம், அவற்றுக்கு டைமர்களையும் அமைக்கலாம்.\n\nடைமர்களை அமைத்தத் தளங்களைப் பற்றிய விவரங்களையும் அவற்றில் செலவழித்த நேரத்தையும் Google சேகரிக்கும். இந்தத் தகவல் டிஜிட்டல் வெல்பீயிங்கை மேம்படுத்தப் பயன்படுத்தப்படும்.</translation>
-<translation id="6475951671322991020">வீடியோவைப் பதிவிறக்கு</translation>
-<translation id="6482749332252372425">போதுமான சேமிப்பிடம் இல்லாததால் <ph name="FILE_NAME" />ஐப் பதிவிறக்க முடியவில்லை.</translation>
-<translation id="6496823230996795692">முதல்முறையாக <ph name="APP_NAME" />ஐப் பயன்படுத்த, இணையத்துடன் இணைக்கவும்.</translation>
-<translation id="6508722015517270189">Chromeஐ மீண்டும் தொடங்கவும்</translation>
-<translation id="6527303717912515753">பகிர்</translation>
-<translation id="6532866250404780454">Chromeமில் நீங்கள் பார்க்கும் தளங்களைக் காட்டாது. தளத்தில் உள்ள அத்தனை டைமர்களும் நீக்கப்படும்.</translation>
-<translation id="6534565668554028783">பதிலளிக்க, Google நீண்ட நேரம் எடுத்துக்கொண்டது</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> ஜி.பை. பதிவிறக்கப்பட்டுள்ளது</translation>
-<translation id="6539092367496845964">ஏதோ தவறாகிவிட்டது. பிறகு முயலவும்.</translation>
-<translation id="654446541061731451">பீம் செய்ய தாவலைத் தேர்ந்தெடுக்கவும்</translation>
-<translation id="6545017243486555795">எல்லா தரவையும் அழி</translation>
-<translation id="6545864417968258051">புளூடூத் ஸ்கேனிங்</translation>
-<translation id="6560414384669816528">Sogou மூலம் தேடுக</translation>
-<translation id="6566259936974865419">Chrome உங்களின் <ph name="GIGABYTES" /> ஜி.பை. அளவைச் சேமித்தது</translation>
-<translation id="6573096386450695060">எப்போதும் அனுமதி</translation>
-<translation id="6573431926118603307">உங்கள் பிற சாதனங்களில் பயன்படுத்திய Chrome இல் திறந்த தாவல்கள் இங்கே தோன்றும்.</translation>
-<translation id="6583199322650523874">தற்போதைய பக்கத்தைப் புத்தகக்குறியிடும்</translation>
-<translation id="6593061639179217415">டெஸ்க்டாப் தளம்</translation>
-<translation id="6600954340915313787">Chromeக்கு நகலெடுக்கப்பட்டது</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> ஜி.பை.</translation>
-<translation id="6612358246767739896">பாதுகாக்கப்பட்ட உள்ளடக்கம்</translation>
-<translation id="6627583120233659107">கோப்புறையைத் திருத்து</translation>
-<translation id="6643016212128521049">அழி</translation>
-<translation id="6643649862576733715">சேமித்த தரவு அளவின்படி வரிசைப்படுத்தும்</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> தொடர்பு}other{<ph name="CONTACT_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> தொடர்புகள்}}</translation>
-<translation id="6649642165559792194">மாதிரிக்காட்சி <ph name="BEGIN_NEW" />புதிது<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">சாதனங்களைக் கண்டறிய Chromeமுக்கு இருப்பிட அணுகல் தேவை. <ph name="BEGIN_LINK" />அனுமதிகளைப் புதுப்பிக்கவும்<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">கடவுச்சொல்</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" /> இல் திற</translation>
-<translation id="666981079809192359">Chrome தனியுரிமை அறிக்கை</translation>
-<translation id="6676840375528380067">இந்தச் சாதனத்திலிருந்து உங்கள் Chrome தரவை அழிக்கவா?</translation>
-<translation id="6697492270171225480">பக்கத்தைக் கண்டறிய முடியாத போது, அதே மாதிரியான பக்கங்களுக்கான பரிந்துரைகளைக் காட்டும்</translation>
-<translation id="6697947395630195233">இந்தத் தளத்துடன் இருப்பிடத்தைப் பகிர, Chromeமுக்கு உங்கள் இருப்பிடத்திற்கான அணுகல் தேவை.</translation>
-<translation id="6698801883190606802">ஒத்திசைத்த தரவை நிர்வகித்தல்</translation>
-<translation id="6699370405921460408">நீங்கள் பார்க்கும் பக்கங்களை Google சேவையகங்கள் மேம்படுத்தும்.</translation>
-<translation id="6706288973712894588">தற்போது ஆஃப்லைனில் உள்ளீர்கள்.\n<ph name="BEGIN_LINK" />உங்கள் ஆஃப்லைன் ஊட்டத்தைக் கண்டறியுங்கள்.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">செய்திகள்</translation>
-<translation id="6710213216561001401">முந்தையது</translation>
-<translation id="671481426037969117">உங்கள் <ph name="FQDN" /> டைமர் நேரம் முடிந்தது. நாளை மீண்டும் தொடங்கும்.</translation>
-<translation id="6738867403308150051">பதிவிறக்குகிறது…</translation>
-<translation id="6746124502594467657">கீழே நகர்த்து</translation>
-<translation id="6766622839693428701">மூடுவதற்கு, கீழே ஸ்வைப் செய்யவும்.</translation>
-<translation id="6766758767654711248">தளத்திற்குச் செல்ல, தட்டவும்</translation>
-<translation id="6767294960381293877">தாவலைப் பகிர்வதற்கான சாதனங்களின் பட்டியல் திரையின் பாதி அளவிற்குத் திறக்கப்பட்டுள்ளது.</translation>
-<translation id="6782111308708962316">குக்கீத் தரவைச் சேமிப்பதிலிருந்தும் படிப்பதிலிருந்தும் மூன்றாம் தரப்பு இணையதளங்களைத் தடு</translation>
-<translation id="6790428901817661496">இயக்கு</translation>
-<translation id="6811034713472274749">பக்கத்தைப் பார்க்கலாம்</translation>
-<translation id="6818926723028410516">பட்டியலிலிருந்து தேர்ந்தெடுக்கவும்</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">மொழிபெயர்</translation>
-<translation id="6845325883481699275">Chromeமின் பாதுகாப்பை மேம்படுத்த உதவுக</translation>
-<translation id="6846298663435243399">ஏற்றுகிறது…</translation>
-<translation id="6850409657436465440">பதிவிறக்கம் செயலில் உள்ளது</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> தாவல்கள் மூடப்பட்டன</translation>
-<translation id="6864459304226931083">படத்தைப் பதிவிறக்கு</translation>
-<translation id="6865313869410766144">தன்னிரப்பி படிவத் தரவு</translation>
-<translation id="688738109438487280">ஏற்கனவே உள்ள தரவை <ph name="TO_ACCOUNT" /> இல் சேர்.</translation>
-<translation id="6891726759199484455">உங்கள் கடவுச்சொல்லை நகலெடுக்க, திறக்கவும்</translation>
-<translation id="6896758677409633944">நகலெடு</translation>
-<translation id="6910211073230771657">நீக்கப்பட்டது</translation>
-<translation id="6912998170423641340">தளங்கள், கிளிப்போர்டிலிருந்து உரையையும் படங்களையும் படிப்பது தடுக்கப்பட்டுள்ளது</translation>
-<translation id="6914783257214138813">ஏற்றிய கோப்பைப் பார்க்கக்கூடிய அனைவரும் உங்கள் கடவுச்சொற்களைப் பார்க்க முடியும்.</translation>
-<translation id="6942665639005891494">அமைப்புகள் மெனு விருப்பத்தைப் பயன்படுத்தி எப்போது வேண்டுமானாலும் இயல்புப் பதிவிறக்க இடத்தை மாற்றலாம்</translation>
-<translation id="6945221475159498467">தேர்ந்தெடு</translation>
-<translation id="6963642900430330478">இந்தப் பக்கம் ஆபத்தானது. தளத் தகவல்</translation>
-<translation id="6963766334940102469">புத்தகக்குறிகளை நீக்கு</translation>
-<translation id="6965382102122355670">சரி</translation>
-<translation id="6979737339423435258">எல்லா நேரமும்</translation>
-<translation id="6981982820502123353">அணுகல் தன்மை</translation>
-<translation id="6989267951144302301">பதிவிறக்க முடியவில்லை</translation>
-<translation id="6990079615885386641">Google Play Store இலிருந்து பயன்பாட்டைப் பெறவும்: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">எனது மைக்ரோஃபோனைப் பயன்படுத்தத் தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="7015203776128479407">ஒத்திசைப்பதற்கான துவக்க அமைவு முடியவில்லை. ஒத்திசைவு முடக்கப்பட்டுள்ளது.</translation>
-<translation id="7016516562562142042">நடப்புத் தேடல் இன்ஜினுக்கு அனுமதிக்கப்பட்டுள்ளது</translation>
-<translation id="7022756207310403729">உலாவியில் திற</translation>
-<translation id="702463548815491781">TalkBack அல்லது ‘சுவிட்ச் அணுகல்’ இயக்கத்தில் இருக்கும்போது பரிந்துரைக்கப்படுகிறது</translation>
-<translation id="7029809446516969842">கடவுச்சொற்கள்</translation>
-<translation id="7053983685419859001">தடு</translation>
-<translation id="7055152154916055070">திசைதிருப்புதல் தடுக்கப்பட்டது:</translation>
-<translation id="7063006564040364415">ஒத்திசைவு சேவையகத்துடன் இணைக்க முடியவில்லை.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 தேர்ந்தெடுக்கப்பட்டது}other{# தேர்ந்தெடுக்கப்பட்டன}}</translation>
-<translation id="7071521146534760487">கணக்கை நிர்வகிக்கும்</translation>
-<translation id="7077143737582773186">SD கார்டு</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> தேர்ந்தெடுக்கப்பட்டன.  திரையின் மேற்பகுதிக்கு அருகில், விருப்பங்கள் உள்ளன</translation>
-<translation id="7121362699166175603">முகவரிப் பட்டியில் வரலாற்றையும் தானே நிரப்புதலையும் அழிக்கும். உங்கள் Google கணக்கு, <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> என்ற இணைப்பில் உலாவல் வரலாறு தொடர்பான பிற தகவல்களைக் கொண்டிருக்கக்கூடும்.</translation>
-<translation id="7128222689758636196">நடப்புத் தேடல் இன்ஜினுக்கு அனுமதிக்கும்</translation>
-<translation id="7138678301420049075">மற்றவை</translation>
-<translation id="7141896414559753902">தளங்கள் பாப்-அப்களையும் திசைதிருப்புதல்களையும் காட்டாமல் தடு (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> இலிருந்து <ph name="BEGIN_LINK" />அசல் பக்கத்தை ஏற்று<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">கடந்த 24 மணிநேரம்</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> கி.பை.</translation>
-<translation id="7177466738963138057">இதைப் பிறகு அமைப்புகளில் மாற்றலாம்</translation>
-<translation id="7180611975245234373">புதுப்பி</translation>
-<translation id="7189372733857464326">Google Play சேவைகள் புதுப்பிப்பதை முடிப்பதற்காக, காத்திருக்கிறது</translation>
-<translation id="7191430249889272776">தாவல் பின்புலத்தில் திறக்கப்பட்டது.</translation>
-<translation id="723171743924126238">படங்களைத் தேர்ந்தெடுக்கவும்</translation>
-<translation id="7233236755231902816">உங்கள் மொழியில் இணையதளங்களைப் பார்க்க Chromeமின் சமீபத்திய பதிப்பைப் பெறுங்கள்</translation>
-<translation id="7243308994586599757">திரையின் கீழ்ப்பகுதிக்கு அருகில் கிடைக்கும் விருப்பங்கள்</translation>
-<translation id="7248069434667874558">Chromeமில் <ph name="TARGET_DEVICE_NAME" /> சாதன ஒத்திசைவு ஆன் செய்யப்பட்டுள்ளதை உறுதி செய்யவும்</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> தேர்ந்தெடுக்கப்பட்டன</translation>
-<translation id="7274013316676448362">தடுக்கப்பட்ட தளம்</translation>
-<translation id="7290209999329137901">இதை மறுபெயரிட இயலாது</translation>
-<translation id="7291387454912369099">அசிஸ்டண்ட் மூலம் செக்அவுட்</translation>
-<translation id="7293171162284876153">ஒத்திசைவைத் தொடங்க "Chrome தரவை ஒத்திசை" என்பதை இயக்கவும்.</translation>
-<translation id="729975465115245577">கடவுச்சொற்கள் கோப்பைச் சேமிக்க, உங்கள் சாதனத்தில் ஆப்ஸ் எதுவும் இல்லை.</translation>
-<translation id="7302081693174882195">விவரங்கள்: சேமிக்கப்பட்ட டேட்டா அளவின்படி வரிசைப்படுத்தப்பட்டுள்ளன</translation>
-<translation id="7328017930301109123">’லைட்’ பயன்முறையில், பக்கங்களை Chrome வேகமாக ஏற்றுவதோடு, டேட்டாவை 60 சதவீதம் குறைவாகவும் பயன்படுத்தும்.</translation>
-<translation id="7333031090786104871">முந்தைய தளத்தை இன்னும் சேர்க்கிறது</translation>
-<translation id="7352939065658542140">வீடியோ</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{தேர்ந்தெடுத்த 1 உருப்படியைப் பகிரும்}other{தேர்ந்தெடுத்த # உருப்படிகளைப் பகிரும்}}</translation>
 <translation id="7359002509206457351">கட்டண முறைகளை அணுகுவதற்கான அனுமதி</translation>
+<translation id="8026334261755873520">உலாவிய தரவை அழி</translation>
+<translation id="1291207594882862231">வரலாறு, குக்கீகள், தளத் தரவு, தற்காலிகச் சேமிப்பை அழி…</translation>
+<translation id="7814200940910057384">Brave தரவு அழிக்கப்பட்டது</translation>
+<translation id="1664855196866195614">Brave மற்றும் ஒத்திசைக்கப்பட்ட சாதனங்களிலிருந்து, தேர்ந்தெடுத்த தரவு அகற்றப்பட்டது.
+
+<ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> எனும் தளத்தில் பிற Brave Software சேவைகளிலிருந்து தேடல்கள், செயல்பாடு போன்ற உங்கள் Brave Software கணக்கிற்கான பிற வகை உலாவல் வரலாறும் இருக்கக்கூடும்.</translation>
+<translation id="4699172675775169585">தற்காலிகமாகச் சேமிக்கப்பட்ட படங்கள் மற்றும் கோப்புகள்</translation>
+<translation id="2496180316473517155">உலாவல் வரலாறு</translation>
+<translation id="2546283357679194313">குக்கீகளும் தள தரவும்</translation>
+<translation id="8662811608048051533">பெரும்பாலான தளங்களிலிருந்து உங்களை வெளியேற்றும்.</translation>
+<translation id="8218628800671693884">பெரும்பாலான தளங்களிலிருந்து உங்களை வெளியேற்றும். உங்கள் Brave Software கணக்கிலிருந்து வெளியேற்றாது.</translation>
+<translation id="2017836877785168846">முகவரிப் பட்டியில் வரலாற்றையும் தானே நிரப்புதல்களையும் அழிக்கும்.</translation>
+<translation id="8096327394278038498">முகவரிப் பட்டியில் வரலாற்றையும் தானே நிரப்புதலையும் அழிக்கும். உங்கள் Brave Software கணக்கு, <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> என்ற இணைப்பில் உலாவல் வரலாறு தொடர்பான பிற தகவல்களைக் கொண்டிருக்கக்கூடும்.</translation>
+<translation id="8122693181154564064">உள்நுழைந்த எல்லாச் சாதனங்களிலிருந்தும் வரலாற்றை அழிக்கும். உங்கள் Brave Software கணக்கு, <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> என்ற இணைப்பில் உலாவல் வரலாறு தொடர்பான பிற தகவல்களைக் கொண்டிருக்கக்கூடும்.</translation>
+<translation id="5869522115854928033">சேமிக்கப்பட்ட கடவுச்சொற்கள்</translation>
+<translation id="6865313869410766144">தன்னிரப்பி படிவத் தரவு</translation>
+<translation id="7562080006725997899">உலாவிய தரவை அழிக்கிறது</translation>
+<translation id="5487521232677179737">தரவை அழி</translation>
+<translation id="7498271377022651285">காத்திருக்கவும்…</translation>
+<translation id="784934925303690534">நேர வரம்பு</translation>
+<translation id="1718835860248848330">கடந்த ஒரு மணிநேரம்</translation>
+<translation id="7149893636342594995">கடந்த 24 மணிநேரம்</translation>
+<translation id="5648166631817621825">கடந்த 7 நாட்கள்</translation>
+<translation id="8571213806525832805">கடந்த 4 வாரங்கள்</translation>
+<translation id="5854790677617711513">30 நாட்களுக்கு முந்தையவை</translation>
+<translation id="6979737339423435258">எல்லா நேரமும்</translation>
+<translation id="982182592107339124">இதனால் எல்லா தளங்களுக்கான தரவும் அழிக்கப்படும், இதில் அடங்குபவை:</translation>
+<translation id="6643016212128521049">அழி</translation>
+<translation id="7641339528570811325">உலாவிய தரவை அழி…</translation>
+<translation id="1670399744444387456">அடிப்படை</translation>
+<translation id="3245261285041759672">உங்கள் Brave Software கணக்கு, <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> என்ற இணைப்பில் உலாவல் வரலாறு தொடர்பான பிற தகவல்களைக் கொண்டிருக்கக்கூடும்.</translation>
+<translation id="7274013316676448362">தடுக்கப்பட்ட தளம்</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> வரலாற்று உள்ளடக்கங்கள் நீக்கப்பட்டன</translation>
+<translation id="1121094540300013208">பயன்பாட்டு மற்றும் சிதைவு அறிக்கைகள்</translation>
+<translation id="9079153198295609735">பயன்பாட்டுப் புள்ளிவிவரங்களையும் சிதைவு அறிக்கைகளையும் தானாகவே Brave Software க்கு அனுப்பு</translation>
+<translation id="6981982820502123353">அணுகல் தன்மை</translation>
+<translation id="2387895666653383613">உரை அளவிடல்</translation>
+<translation id="2321958826496381788">இதை வசதியாக படிப்பதற்கு, ஸ்லைடரை இழுக்கவும். பத்தியில் இரு முறை தட்டிய பிறகு, உரையானது குறைந்தது இந்த அளவு பெரியதாக தோன்ற வேண்டும்.</translation>
+<translation id="3895926599014793903">பெரிதாக்குவதைச் செயல்படுத்த வலியுறுத்து</translation>
+<translation id="5668404140385795438">பெரிதாக்கப்படுவதைத் தடுக்க இணையதளம் விடுத்த கோரிக்கையைப் புறக்கணிக்கவும்</translation>
+<translation id="4149994727733219643">இணையப் பக்கங்களுக்கான எளிதாக்கப்பட்ட காட்சி</translation>
+<translation id="9100505651305367705">கட்டுரைகளை எளிதாக்கிக் காட்டும் வசதி கிடைக்கும்போது, அவ்வாறு காட்ட வேண்டுமா எனக் கேள்</translation>
+<translation id="1409426117486808224">திறக்கப்பட்டுள்ள தாவல்களுக்கான எளிதாக்கப்பட்ட காட்சி</translation>
+<translation id="702463548815491781">TalkBack அல்லது ‘சுவிட்ச் அணுகல்’ இயக்கத்தில் இருக்கும்போது பரிந்துரைக்கப்படுகிறது</translation>
+<translation id="8284326494547611709">வசனங்கள்</translation>
+<translation id="4165986682804962316">தள அமைப்புகள்</translation>
+<translation id="6295158916970320988">எல்லா தளங்களும்</translation>
+<translation id="8380167699614421159">குறுக்கிடும் அல்லது தவறாக வழிநடத்தும் விளம்பரங்களை இந்தத் தளம் காண்பிக்கிறது</translation>
+<translation id="1919345977826869612">விளம்பரங்கள்</translation>
+<translation id="410351446219883937">தானியங்கி</translation>
+<translation id="6447842834002726250">குக்கீகள்</translation>
+<translation id="6196640612572343990">மூன்றாம் தரப்புக் குக்கீகளைத் தடு</translation>
+<translation id="6782111308708962316">குக்கீத் தரவைச் சேமிப்பதிலிருந்தும் படிப்பதிலிருந்தும் மூன்றாம் தரப்பு இணையதளங்களைத் தடு</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">பாப் அப்கள் &amp; திசைதிருப்புதல்கள்</translation>
+<translation id="4751476147751820511">நகர்வு அல்லது ஒளி உணர்விகள்</translation>
+<translation id="1717218214683051432">மோஷன் சென்சார்கள்</translation>
+<translation id="2091887806945687916">ஒலி</translation>
+<translation id="2586657967955657006">கிளிப்போர்டு</translation>
+<translation id="6320088164292336938">அதிர்வுறு</translation>
+<translation id="4226663524361240545">அறிவிப்புகள் வரும் போது சாதனம் அதிர்வுறக்கூடும்</translation>
+<translation id="1446450296470737166">MIDI சாதனங்களுக்கு முழுக் கட்டுப்பாட்டை அனுமதி</translation>
+<translation id="3744111561329211289">பின்புல ஒத்திசைவு</translation>
+<translation id="5649053991847567735">தன்னியக்கப் பதிவிறக்கங்கள்</translation>
+<translation id="6181444274883918285">தள விதிவிலக்கைச் சேர்</translation>
+<translation id="5313967007315987356">தளத்தைச் சேர்</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> தளம் சேர்க்கப்பட்டது</translation>
+<translation id="7837721118676387834">ஒலியடக்கிய வீடியோக்களைத் தானாக இயக்க, குறிப்பிட்ட தளத்தை அனுமதி.</translation>
+<translation id="2621115761605608342">குறிப்பிட்ட தளத்திற்கு JavaScriptஐ அனுமதி.</translation>
+<translation id="8801436777607969138">குறிப்பிட்ட தளத்திற்கு JavaScriptடைத் தடுக்கும்.</translation>
+<translation id="8372893542064058268">குறிப்பிட்ட தளத்திற்கு, பின்னணி ஒத்திசைவை அனுமதி.</translation>
+<translation id="358794129225322306">பல கோப்புகளைத் தானாகப் பதிவிறக்க தளத்தை அனுமதிக்கும்.</translation>
+<translation id="4008040567710660924">குறிப்பிட்ட தளத்திற்கு, குக்கீகளை அனுமதிக்கும்.</translation>
+<translation id="8958424370300090006">குறிப்பிட்ட தளத்திற்கான குக்கீகளைத் தடுக்கும்.</translation>
+<translation id="7882806643839505685">குறிப்பிட்ட தளத்திற்கு ஒலியை அனுமதி</translation>
+<translation id="4468959413250150279">குறிப்பிட்ட தளத்திற்கு ஒலியடக்கு</translation>
+<translation id="1994173015038366702">தள URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">பயன்பாடு</translation>
+<translation id="5804241973901381774">அனுமதிகள்</translation>
+<translation id="4278390842282768270">அனுமதிக்கப்பட்டது</translation>
+<translation id="5677928146339483299">தடுக்கப்பட்டது</translation>
+<translation id="1984937141057606926">அனுமதிக்கப்பட்டது, மூன்றாம் தரப்பைத் தவிர</translation>
+<translation id="7423098979219808738">முதலில் கேள்</translation>
+<translation id="8116925261070264013">ஒலியடக்கியவை</translation>
+<translation id="8300705686683892304">ஆப்ஸ் நிர்வகிப்பவை</translation>
+<translation id="6192792657125177640">விதிவிலக்குகள்</translation>
+<translation id="257931822824936280">விரிவாக்கப்பட்டது - சுருக்க, கிளிக் செய்யவும்.</translation>
+<translation id="5100237604440890931">சுருக்கப்பட்டது - விரிவாக்க, கிளிக் செய்யவும்.</translation>
+<translation id="857943718398505171">அனுமதிக்கப்பட்டது (பரிந்துரைத்தது)</translation>
+<translation id="2913331724188855103">குக்கீத் தரவை, தளங்கள் சேமிக்கவும் படிக்கவும் அனுமதி (பரிந்துரைக்கப்பட்டது)</translation>
+<translation id="7445411102860286510">ஒலியடக்கிய வீடியோக்களைத் தானாகவே இயக்க, தளங்களை அனுமதி (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="5335288049665977812">JavaScriptஐ இயக்குவதற்கு, தளங்களை அனுமதி (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="5527111080432883924">கிளிப்போர்டிலிருந்து உரையையும் படங்களையும் படிப்பதற்கு, தளங்களை அனுமதிப்பதற்கு முன், கேள் (பரிந்துரைக்கப்படுவது)</translation>
+<translation id="6912998170423641340">தளங்கள், கிளிப்போர்டிலிருந்து உரையையும் படங்களையும் படிப்பது தடுக்கப்பட்டுள்ளது</translation>
+<translation id="7423538860840206698">கிளிப்போர்டைப் படிப்பது தடுக்கப்பட்டுள்ளது</translation>
+<translation id="3955193568934677022">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்க, தளங்களை அனுமதி (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="445467742685312942">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்குவதற்குத் தளங்களை அனுமதிக்கும்</translation>
+<translation id="2107397443965016585">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்குவதற்குத் தளங்களை அனுமதிக்கும் முன்பு அனுமதி கோரும் (பரிந்துரைக்கப்படுவது)</translation>
+<translation id="2910701580606108292">பாதுகாக்கப்பட்ட உள்ளடக்கத்தை இயக்குவதற்குத் தளங்களை அனுமதிக்கும் முன்பு அனுமதி கோரும்</translation>
+<translation id="757524316907819857">பாதுகாக்கப்பட்ட உள்ளடக்கத்தைத் தளங்கள் இயக்குவதைத் தடுக்கும்</translation>
+<translation id="3277252321222022663">தளங்கள் சென்சார்களை அணுக அனுமதிக்கும் (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="5048398596102334565">மோஷன் சென்சார்களை அணுக தளங்களை அனுமதிக்கும் (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="8816026460808729765">தளங்கள் சென்சார்களை அணுகுவதைத் தடுக்கும்</translation>
+<translation id="169515064810179024">தளங்கள் மோஷன் சென்சார்களை அணுகுவதைத் தடுக்கும்</translation>
+<translation id="1660204651932907780">ஒலியை இயக்க, தளங்களை அனுமதிக்கும் (பரிந்துரைக்கப்படுவது)</translation>
+<translation id="3600792891314830896">ஒலியை இயக்கும் தளங்களில் ஒலியடக்கு</translation>
+<translation id="1743802530341753419">சாதனத்தை இணைக்க, தளங்களை அனுமதிப்பதற்கு முன், கேள் (பரிந்துரைக்கப்படுவது)</translation>
+<translation id="851751545965956758">சாதனங்களை இணைப்பதிலிருந்து தளங்களைத் தடுக்கும்</translation>
+<translation id="7141896414559753902">தளங்கள் பாப்-அப்களையும் திசைதிருப்புதல்களையும் காட்டாமல் தடு (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="5494752089476963479">குறுக்கிடும் அல்லது தவறாக வழிநடத்தும் விளம்பரங்களைக் காட்டும் தளங்களில் விளம்பரங்களைத் தடு</translation>
+<translation id="3123473560110926937">சில தளங்களில் தடுக்கப்பட்டுள்ளன</translation>
+<translation id="965817943346481315">குறுக்கிடும் அல்லது தவறாக வழிநடத்தும் விளம்பரங்களை தளம் காண்பித்தால், அதைத் தடு (பரிந்துரைக்கப்படுவது)</translation>
+<translation id="3386292677130313581">எனது இருப்பிடத்தை அறிய தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="9139068048179869749">அறிவிப்புகளை அனுப்ப தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="4479647676395637221">எனது கேமராவைப் பயன்படுத்தத் தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="6992289844737586249">எனது மைக்ரோஃபோனைப் பயன்படுத்தத் தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="2289270750774289114">அருகிலுள்ள புளூடூத் சாதனங்களை வலைதளம் கண்டறிய முயலும்போது கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
+<translation id="7053983685419859001">தடு</translation>
+<translation id="7128222689758636196">நடப்புத் தேடல் இன்ஜினுக்கு அனுமதிக்கும்</translation>
+<translation id="7589445247086920869">நடப்புத் தேடல் இன்ஜினுக்குத் தடுக்கும்</translation>
+<translation id="6388207532828177975">அழித்து, மீட்டமைக்கவும்</translation>
+<translation id="7999064672810608036">இந்த இணையதளத்தின் குக்கீகள் உட்பட எல்லா அகத் தரவையும் அழித்து, அதன் எல்லா அனுமதிகளையும் மீட்டமைக்கவா?</translation>
+<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME"/>க்கான தள அனுமதிகள் அனைத்தையும் நிச்சயமாக மீட்டமைக்க விரும்புகிறீர்களா?</translation>
+<translation id="515227803646670480">சேமித்தத் தரவை அழி</translation>
+<translation id="5902828464777634901">குக்கீகள் உட்பட, இந்த இணைய தளத்தால் சேமிக்கப்படும் அனைத்து அகத் தரவும் நீக்கப்படும்.</translation>
+<translation id="119944043368869598">அனைத்தையும் அழி</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> நிர்வகிக்கிறது</translation>
+<translation id="5516455585884385570">அறிவிப்பு அமைப்புகளைத் திறக்கும்</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/> இல் உட்பொதிக்கப்பட்டது</translation>
+<translation id="129382876167171263">இணையதளங்கள் சேமித்த கோப்புகள் இங்கே தோன்றும்</translation>
+<translation id="4181841719683918333">மொழிகள்</translation>
+<translation id="2647434099613338025">மொழியைச் சேர்</translation>
+<translation id="1952172573699511566">சாத்தியமான போது, நீங்கள் விரும்பும் மொழியில் உரையை இணையதளங்கள் காட்டும்.</translation>
+<translation id="8559990750235505898">பக்கங்களைப் பிற மொழிகளில் மொழிபெயர்ப்பதற்கான சலுகை</translation>
+<translation id="4719927025381752090">மொழிபெயர்ப்பதற்கான சலுகை</translation>
+<translation id="8156139159503939589">உங்களால் எந்தெந்த மொழிகளை வாசிக்க முடியும்?</translation>
+<translation id="5689516760719285838">இருப்பிடம்</translation>
+<translation id="2440823041667407902">இருப்பிட அணுகல்</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android அமைப்புகளில்<ph name="END_LINK"/> Braveக்கான அனுமதிகளை இயக்கவும்.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android அமைப்புகளில்<ph name="END_LINK"/> Braveக்கான அனுமதியை இயக்கவும்.</translation>
+<translation id="2928908108430545745">Brave உங்கள் இருப்பிடத் தகவலை அணுக அனுமதிப்பதற்கு <ph name="BEGIN_LINK"/>Android அமைப்புகளிலும்<ph name="END_LINK"/> இருப்பிடத்தை இயக்கவும்.</translation>
+<translation id="1028853271388022585">உங்கள் கேமராவை அணுக Braveமை அனுமதிப்பதற்கு <ph name="BEGIN_LINK"/>Android அமைப்புகளிலும்<ph name="END_LINK"/> கேமராவை இயக்கவும்.</translation>
+<translation id="2913721282607281710">Brave உங்களுக்கு அறிவிப்புகளை அனுப்ப அனுமதிப்பதற்கு<ph name="BEGIN_LINK"/>Android அமைப்புகளிலும்<ph name="END_LINK"/> அறிவிப்புகளை இயக்கவும்.</translation>
+<translation id="8753483718490035722">Brave உங்கள் மைக்ரோஃபோனை அணுக அனுமதிப்பதற்கு <ph name="BEGIN_LINK"/>Android அமைப்புகளிலும்<ph name="END_LINK"/> மைக்ரோஃபோனை இயக்கவும்.</translation>
+<translation id="1887786770086287077">இந்தச் சாதனத்திற்கான இருப்பிட அணுகல் முடக்கப்பட்டுள்ளது. அதை <ph name="BEGIN_LINK"/>Android அமைப்புகளில்<ph name="END_LINK"/> இயக்கவும்.</translation>
+<translation id="2570922361219980984">இந்தச் சாதனத்திற்கான இருப்பிட அணுகலும் முடக்கப்பட்டுள்ளது. அதை <ph name="BEGIN_LINK"/>Android அமைப்புகளில்<ph name="END_LINK"/> இயக்கவும்.</translation>
+<translation id="1620510694547887537">கேமரா</translation>
+<translation id="3227137524299004712">மைக்ரோஃபோன்</translation>
+<translation id="1647391597548383849">உங்கள் கேமராவை அணுகலாம்</translation>
+<translation id="945632385593298557">உங்கள் மைக்ரோஃபோனை அணுகலாம்</translation>
+<translation id="6612358246767739896">பாதுகாக்கப்பட்ட உள்ளடக்கம்</translation>
+<translation id="885701979325669005">சேமிப்பிடம்</translation>
+<translation id="3198916472715691905">சேமிக்கப்பட்ட தரவு: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">சாதன அனுமதியை ரத்துசெய்யும்</translation>
+<translation id="4962975101802056554">சாதனத்திற்கான அனைத்து அனுமதிகளையும் ரத்துசெய்யும்</translation>
+<translation id="6545864417968258051">புளூடூத் ஸ்கேனிங்</translation>
+<translation id="4411535500181276704">லைட் பயன்முறை</translation>
+<translation id="7821588508402923572">உங்கள் டேட்டா சேமிப்புகள் இங்கே தோன்றும்</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> சேமிக்கப்பட்டது</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> முதல்</translation>
+<translation id="3252158532344029638">’லைட்’ பயன்முறையில், பக்கங்களை Brave வேகமாக ஏற்றுவதோடு, டேட்டாவை 60 சதவீதம் குறைவாகவும் பயன்படுத்தும்.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> தரவுச் சேமிப்புகள்</translation>
+<translation id="7494974237137038751">சேமித்த டேட்டா</translation>
+<translation id="6111020039983847643">பயன்படுத்திய டேட்டா</translation>
+<translation id="7413229368719586778">தொடக்கத் தேதி: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">முடிவுத் தேதி: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">தளத்தின்படி வரிசைப்படுத்தும்</translation>
+<translation id="5864174910718532887">விவரங்கள்: தளப் பெயரின்படி வரிசைப்படுத்தப்பட்டுள்ளன</translation>
+<translation id="116280672541001035">பயன்படுத்தியது</translation>
+<translation id="8349013245300336738">பயன்படுத்திய தரவு அளவின்படி வரிசைப்படுத்தும்</translation>
+<translation id="6378173571450987352">விவரங்கள்: பயன்படுத்திய டேட்டா அளவின்படி வரிசைப்படுத்தப்பட்டுள்ளன</translation>
+<translation id="2631006050119455616">சேமிக்கப்பட்டது</translation>
+<translation id="6643649862576733715">சேமித்த தரவு அளவின்படி வரிசைப்படுத்தும்</translation>
+<translation id="7302081693174882195">விவரங்கள்: சேமிக்கப்பட்ட டேட்டா அளவின்படி வரிசைப்படுத்தப்பட்டுள்ளன</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> பயன்படுத்தப்பட்டுள்ளது</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> சேமிக்கப்பட்டது</translation>
+<translation id="2156074688469523661">மீதமுள்ள தளங்கள் (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">மற்றவை</translation>
+<translation id="4913161338056004800">புள்ளிவிவரங்களை மீட்டமை</translation>
+<translation id="1856325424225101786">லைட் பயன்முறையை மீட்டமைக்கவா?</translation>
+<translation id="3658159451045945436">மீட்டமைத்தால், பார்வையிட்ட தளங்களின் பட்டியல் உட்பட டேட்டா சேமிப்புகளின் வரலாறு அழிக்கப்படும்.</translation>
+<translation id="3295530008794733555">வேகமாக உலாவலாம். குறைவான டேட்டாவைப் பயன்படுத்தலாம்.</translation>
+<translation id="7340390500800578919">லைட் பயன்முறையில் பக்கங்களை Brave வேகமாக ஏற்றுவதோடு டேட்டாவை 60 சதவீதம் வரை குறைவாகவும் பயன்படுத்தும். நீங்கள் பார்க்கும் பக்கங்களை மேம்படுத்த Brave உங்கள் இணைய டிராஃபிக்கை Brave Softwareளுக்கு அனுப்பும். <ph name="BEGIN_LINK"/>மேலும் அறிக<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">லைட் பயன்முறையை இயக்கு</translation>
+<translation id="4493497663118223949">லைட் பயன்முறை இயக்கத்தில் உள்ளது</translation>
+<translation id="7559975015014302720">லைட் பயன்முறை முடக்கப்பட்டுள்ளது</translation>
+<translation id="7606077192958116810">லைட் பயன்முறை இயக்கத்தில் உள்ளது. இதை அமைப்புகளில் நிர்வகிக்கவும்.</translation>
+<translation id="4714588616299687897">தரவில் 60% வரை சேமியுங்கள்</translation>
+<translation id="1006927014032731288">நீங்கள் பார்க்கும் பக்கங்களை Brave Software சேவையகங்கள் மேம்படுத்தும்.</translation>
+<translation id="3257320067425202300">Brave உங்கள் <ph name="MEGABYTES"/> மெ.பை. அளவைச் சேமித்தது</translation>
+<translation id="5813223329348543512">Brave உங்களின் <ph name="GIGABYTES"/> ஜி.பை. அளவைச் சேமித்தது</translation>
+<translation id="8266862848225348053">பதிவிறக்க இருப்பிடம்</translation>
+<translation id="7077143737582773186">SD கார்டு</translation>
+<translation id="7762668264895820836">SD கார்டு <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">கோப்புகளை எங்கே சேமிக்க வேண்டும் என்று கேள்</translation>
+<translation id="6192333916571137726">கோப்பைப் பதிவிறக்கவும்</translation>
+<translation id="1672586136351118594">மீண்டும் காட்டாதே</translation>
+<translation id="2650751991977523696">கோப்பை மீண்டும் பதிவிறக்கவா?</translation>
+<translation id="8664979001105139458">கோப்புப் பெயர் ஏற்கனவே உள்ளது</translation>
+<translation id="488187801263602086">கோப்பின் பெயரை மாற்றவும்</translation>
+<translation id="5686790454216892815">கோப்பின் பெயர் நீளமாக உள்ளது</translation>
+<translation id="7454641608352164238">போதுமான இடம் இல்லை</translation>
+<translation id="8972098258593396643">இயல்புக் கோப்புறைக்குப் பதிவிறக்கவா?</translation>
+<translation id="804335162455518893">SD கார்டு இல்லை</translation>
+<translation id="7475688122056506577">SD கார்டு உள்ளது. உங்கள் கோப்புகளில் சில இல்லாமல் இருக்கலாம்.</translation>
+<translation id="4198423547019359126">பதிவிறக்க இருப்பிடம் எதுவும் இல்லை</translation>
+<translation id="8224471946457685718">வைஃபை இணைப்பில் உங்களுக்கான செய்திக் கட்டுரைகளைப் பதிவிறக்குக</translation>
+<translation id="4970824347203572753">உங்கள் நாட்டில் இல்லை</translation>
+<translation id="5500777121964041360">உங்கள் நாட்டில் இல்லாமல் இருக்கக்கூடும்</translation>
+<translation id="1173894706177603556">மறுபெயரிடு</translation>
+<translation id="1986685561493779662">பெயர் ஏற்கனவே உள்ளது</translation>
+<translation id="6441734959916820584">பெயர் மிக நீளமாக உள்ளது</translation>
+<translation id="2923908459366352541">தவறான பெயர்</translation>
+<translation id="7290209999329137901">இதை மறுபெயரிட இயலாது</translation>
+<translation id="3334729583274622784">கோப்பு நீட்டிப்பை மாற்றவா?</translation>
+<translation id="107147699690128016">கோப்பு நீட்டிப்பை மாற்றினால் இந்தக் கோப்பு வேறொரு ஆப்ஸில் திறக்கக்கூடும், இது உங்கள் சாதனத்திற்குத் தீங்கிழைக்கக்கூடும்.</translation>
+<translation id="8541922081612557424">Brave அறிமுகம்</translation>
+<translation id="5311273890481188673">பதிப்புரிமை <ph name="YEAR"/> Brave Software LLC. அனைத்து உரிமைகளும் பாதுகாக்கப்பட்டுள்ளன.</translation>
+<translation id="1416550906796893042">ஆப்ஸின் பதிப்பு</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (புதுப்பித்தது: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">ஆப்ரேட்டிங் சிஸ்டம்</translation>
+<translation id="3968054912784331254">இந்த Android பதிப்பினை Brave புதுப்பிப்புகள் இனி ஆதரிக்காது</translation>
+<translation id="7665369617277396874">கணக்கைச் சேர்</translation>
+<translation id="649070405679044769">Brave Software இல் உள்நுழைந்திருக்கும் கணக்கு</translation>
+<translation id="6234515504547364178">Brave இலிருந்து வெளியேறுதல்</translation>
+<translation id="5324858694974489420">பெற்றோர் அமைப்புகள்</translation>
+<translation id="8920114477895755567">பெற்றோர்களின் விவரங்களுக்காகக் காத்திருக்கிறது.</translation>
+<translation id="5512137114520586844">இந்தக் கணக்கு <ph name="PARENT_NAME"/> ஆல் நிர்வகிக்கப்படுகிறது.</translation>
+<translation id="2956410042958133412">இந்தக் கணக்கு <ph name="PARENT_NAME_1"/> மற்றும் <ph name="PARENT_NAME_2"/> ஆல் நிர்வகிக்கப்படுகிறது.</translation>
+<translation id="8168435359814927499">உள்ளடக்கம்</translation>
+<translation id="5403644198645076998">குறிப்பிட்ட தளங்களை மட்டும் அனுமதி</translation>
+<translation id="8641930654639604085">பெரியவர்களுக்கான தளங்களைத் தடு</translation>
+<translation id="5639724618331995626">எல்லாத் தளங்களையும் அனுமதி</translation>
+<translation id="796823723482603597">Braveஇல் இயங்குகிறது</translation>
+<translation id="6324034347079777476">Android அமைப்பின் ஒத்திசைவு முடக்கப்பட்டது</translation>
+<translation id="5127805178023152808">ஒத்திசைவு முடக்கத்தில்</translation>
+<translation id="7015203776128479407">ஒத்திசைப்பதற்கான துவக்க அமைவு முடியவில்லை. ஒத்திசைவு முடக்கப்பட்டுள்ளது.</translation>
+<translation id="2497852260688568942">உங்கள் நிர்வாகி ஒத்திசைவை முடக்கியுள்ளார்</translation>
+<translation id="9100610230175265781">கடவுச்சொற்றொடர் தேவை</translation>
+<translation id="6108923351542677676">அமைவு செயலிலுள்ளது...</translation>
+<translation id="4062305924942672200">சட்டப்பூர்வத் தகவல்</translation>
+<translation id="4256782883801055595">ஓப்பன் சோர்ஸ் உரிமங்கள்</translation>
+<translation id="1138681184697033370">Brave சேவை விதிமுறைகள்</translation>
+<translation id="7392539049993970338">Brave தனியுரிமை அறிக்கை</translation>
+<translation id="2677748264148917807">வெளியேறு</translation>
+<translation id="5556459405103347317">மீண்டும் ஏற்று</translation>
+<translation id="1623104350909869708">கூடுதல் உரையாடல்களை உருவாக்குவதிலிருந்து இந்தப் பக்கத்தைத் தடு</translation>
+<translation id="2968755619301702150">சான்றிதழ் வியூவர்</translation>
+<translation id="1360432990279830238">வெளியேறி, ஒத்திசைவை முடக்கவா?</translation>
+<translation id="8581481290581777242">இந்தச் சாதனத்திலிருந்து உங்கள் Brave தரவை அழிக்கவா?</translation>
+<translation id="1318865768845061710">இனி உங்கள் Brave Software கணக்குடன் புக்மார்க்குகள், வரலாறு, கடவுச்சொற்கள் போன்ற பிற Brave தரவு ஒத்திசைக்கப்படாது</translation>
+<translation id="3325020657155065477">அத்துடன் இந்தச் சாதனத்திலிருந்து எனது Brave தரவையும் அழி</translation>
+<translation id="6136448902816743006">நீங்கள் <ph name="DOMAIN_NAME"/> நிர்வகிக்கும் கணக்கிலிருந்து வெளியேறுவதால் உங்கள் Brave தரவு இந்தச் சாதனத்திலிருந்து நீக்கப்படும். எனினும் இது உங்கள் Brave Software கணக்கில் சேமிக்கப்பட்டிருக்கும்.</translation>
+<translation id="1853026300647876496">Brave Softwareஐத் தொடர்புகொள்கிறது. இதற்குச் சில வினாடிகள் ஆகலாம்…</translation>
+<translation id="2328985652426384049">உள்நுழைய முடியவில்லை</translation>
+<translation id="7723158744459952869">பதிலளிக்க, Brave Software நீண்ட நேரம் எடுத்துக்கொண்டது</translation>
+<translation id="4572422548854449519">நிர்வகிக்கப்படும் கணக்கில் உள்நுழையவும்</translation>
+<translation id="2689656545739939160"><ph name="MANAGED_DOMAIN"/> நிர்வகிக்கும் கணக்கில் உள்நுழைந்து, உங்கள் Brave தரவு மீதான கட்டுப்பாட்டை அதன் நிர்வாகிக்கு வழங்குகிறீர்கள். இந்தக் கணக்குடன் தரவு நிரந்தரமாக இணைக்கப்படும். Braveமிலிருந்து வெளியேறினால், இந்தச் சாதனத்திலிருந்து தரவு நீக்கப்படும், எனினும் உங்கள் Brave Software கணக்கில் தரவு தொடர்ந்து இருக்கும்.</translation>
+<translation id="1749561566933687563">உங்கள் புத்தகக்குறிகளை ஒத்திசைக்கவும்</translation>
+<translation id="4242533952199664413">அமைப்புகளைத் திற</translation>
+<translation id="1111673857033749125">உங்கள் பிற சாதனங்களில் சேமிக்கும் புக்மார்க்குகள் இங்கே தோன்றும்.</translation>
+<translation id="8636825310635137004">உங்கள் பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, ஒத்திசைவை இயக்கவும்.</translation>
+<translation id="3269956123044984603">பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, Android கணக்கு அமைப்புகளில் "தரவைத் தானாக ஒத்திசை" என்பதை இயக்கவும்.</translation>
+<translation id="5157964048453367290">உங்கள் பிற சாதனங்களில் பயன்படுத்திய Brave இல் திறந்த தாவல்கள் இங்கே தோன்றும்.</translation>
+<translation id="4684427112815847243">அனைத்தையும் ஒத்திசை</translation>
+<translation id="2709516037105925701">தானாகநிரப்பு</translation>
+<translation id="8820817407110198400">புக்மார்க்குகள்</translation>
+<translation id="1644574205037202324">வரலாறு</translation>
+<translation id="17513872634828108">தாவல்களைத் திற</translation>
+<translation id="1320169905922104972">Brave Software Payயைப் பயன்படுத்தும் கிரெடிட் கார்டுகள் மற்றும் முகவரிகள்</translation>
+<translation id="6337234675334993532">என்க்ரிப்ஷன்</translation>
+<translation id="6698801883190606802">ஒத்திசைத்த தரவை நிர்வகித்தல்</translation>
+<translation id="3598578758776312506">கடவுச்சொற்களை Brave Software அனுமதிச் சான்றுகள் மூலம் என்க்ரிப்ட் செய்யும்</translation>
+<translation id="7810580217418711046"><ph name="TIME"/> அன்றைக்கான Brave Software கடவுச்சொல்லைப் பயன்படுத்தி  ஒத்திசைக்கப்பட்ட தரவை என்க்ரிப்ட் செய்</translation>
+<translation id="8461694314515752532">ஒத்திசைக்கப்பட்ட தரவை எனது ஒத்திசைவுக் கடவுச்சொற்றொடர் மூலம் என்கிரிப்ட் செய்</translation>
+<translation id="2996291259634659425">கடவுச்சொற்றொடரை உருவாக்கு</translation>
+<translation id="5713644099811900409">Brave Software கணக்கு</translation>
+<translation id="8997474919031554666">கடவுச்சொற்றொடர் என்க்ரிப்ஷனில் Brave Software Payயிலுள்ள கட்டண முறைகளும் முகவரிகளும் சேர்க்கப்படாது. என்கிரிப்ட் செய்யப்பட்ட தரவை உங்கள் கடவுச்சொற்றொடரை அறிந்தவரால் மட்டுமே படிக்க முடியும். Brave Softwareளுக்குக் கடவுச்சொற்றொடர் அனுப்பப்படுவதில்லை. Brave Software அதைச் சேமிப்பதுமில்லை. கடவுச்சொற்றொடரை மறந்துவிட்டாலோ இந்த அமைப்பை மாற்ற விரும்பினாலோ, ஒத்திசைவை மீட்டமைக்க வேண்டும். <ph name="BEGIN_LINK"/>மேலும் அறிக<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">கடவுச்சொற்றொடர்</translation>
+<translation id="7772032839648071052">கடவுச்சொற்றொடரை உறுதி செய்க</translation>
+<translation id="5304593522240415983">இந்தப் புலம் காலியாக இருக்கக் கூடாது</translation>
+<translation id="321773570071367578">கடவுச்சொற்றொடரை மறந்துவிட்டால் அல்லது இந்த அமைப்பை மாற்ற விரும்பினால், <ph name="BEGIN_LINK"/>ஒத்திசைவை மீட்டமைக்கவும்<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">கடவுத்தொடர்கள் பொருந்தவில்லை</translation>
+<translation id="5149495116300586333">கடவுச்சொற்றொடர் என்க்ரிப்ஷனில் Brave Software Payயிலுள்ள கட்டண முறைகளும் முகவரிகளும் சேர்க்கப்படாது.
+
+இந்த அமைப்பை மாற்ற, <ph name="BEGIN_LINK"/>ஒத்திசைவை மீட்டமைக்கவும்<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">தவறான கடவுத்தொடர்</translation>
+<translation id="5414836363063783498">சரிபார்க்கிறது...</translation>
+<translation id="6846298663435243399">ஏற்றுகிறது…</translation>
+<translation id="5517095782334947753"><ph name="FROM_ACCOUNT"/> இன் புக்மார்க்குகள், வரலாறு, கடவுச்சொற்கள் மற்றும் பிற அமைப்புகள் உள்ளன.</translation>
+<translation id="3928666092801078803">எனது தரவை ஒன்றிணை</translation>
+<translation id="688738109438487280">ஏற்கனவே உள்ள தரவை <ph name="TO_ACCOUNT"/> இல் சேர்.</translation>
+<translation id="806745655614357130">எனது தரவைத் தனியாக வை</translation>
+<translation id="1145536944570833626">ஏற்கனவே உள்ள தரவை நீக்கு.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> இணைய விரும்புகிறது</translation>
+<translation id="4915549754973153784">சாதனங்களைத் தேடும் போது <ph name="BEGIN_LINK"/>உதவி பெறுக<ph name="END_LINK"/>…</translation>
+<translation id="5817918615728894473">இணை</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>உதவி பெறுக<ph name="END_LINK1"/> அல்லது <ph name="BEGIN_LINK2"/>மீண்டும் ஸ்கேன் செய்க<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">இணக்கமான சாதனங்கள் இல்லை</translation>
+<translation id="3773755127849930740">இணைத்தலை அனுமதிக்க, <ph name="BEGIN_LINK"/>புளூடூத்தை இயக்கவும்<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave ஆல் புளூடூத் அடாப்டரை இயக்க முடியவில்லை</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>உதவி பெறுக<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">சாதனங்களைக் கண்டறிய Braveமுக்கு இருப்பிட அணுகல் தேவை. <ph name="BEGIN_LINK"/>அனுமதிகளைப் புதுப்பிக்கவும்<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">சாதனங்களைத் தேட Braveமுக்கு இருப்பிட அணுகல் தேவை. இருப்பிட அணுகல், <ph name="BEGIN_LINK"/>இந்தச் சாதனத்தில் முடக்கப்பட்டுள்ளது<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">சாதனங்களைத் தேட Braveமுக்கு இருப்பிட அணுகல் தேவை. <ph name="BEGIN_LINK1"/>அனுமதிகளை மாற்றவும்<ph name="END_LINK1"/>. இருப்பிட அணுகலும் <ph name="BEGIN_LINK2"/>இந்தச் சாதனத்தில் முடக்கப்பட்டுள்ளது<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">இணைத்த சாதனம்</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{சிக்னல் வலிமையின் அளவு: # கோடு}other{சிக்னல் வலிமையின் அளவு: # கோடுகள்}}</translation>
+<translation id="5230560987958996918">அருகிலுள்ள புளூடூத் சாதனங்களை <ph name="SITE"/> ஸ்கேன் செய்ய விரும்புகிறது. இவை கண்டறியப்பட்டுள்ளன:</translation>
+<translation id="8368027906805972958">அறியாத அல்லது ஆதரிக்கப்படாத சாதனம் (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">ஒத்திசைவு வேலை செய்யவில்லை</translation>
+<translation id="1810845389119482123">ஒத்திசைவின் முதற்கட்ட அமைவு நிறைவடையவில்லை</translation>
+<translation id="3235722914093408050">Brave ஒத்திசைவைத் தொடங்க, Android அமைப்புகளைத் திறந்து Android சாதன ஒத்திசைவை மீண்டும் இயக்கவும்</translation>
+<translation id="3367813778245106622">ஒத்திசைப்பதைத் தொடங்க, மீண்டும் உள்நுழையவும்</translation>
+<translation id="974555521953189084">ஒத்திசைவைத் தொடங்க, கடவுச்சொற்றொடரை உள்ளிடவும்</translation>
+<translation id="2997266899014181325">ஒத்திசைவைத் தொடங்க "Brave தரவை ஒத்திசை" என்பதை இயக்கவும்.</translation>
+<translation id="8260126382462817229">மீண்டும் உள்நுழையவும்</translation>
+<translation id="5919204609460789179">ஒத்திசைவைத் தொடங்க, <ph name="PRODUCT_NAME"/>ஐப் புதுப்பிக்கவும்</translation>
+<translation id="397583555483684758">ஒத்திசைவு நிறுத்தப்பட்டது</translation>
+<translation id="1966710179511230534">உங்கள் உள்நுழைவு விவரங்களைப் புதுப்பிக்கவும்.</translation>
+<translation id="7063006564040364415">ஒத்திசைவு சேவையகத்துடன் இணைக்க முடியவில்லை.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> காலாவதியாகிவிட்டது.</translation>
+<translation id="4170011742729630528">சேவை கிடைக்கவில்லை; பிறகு முயற்சிக்கவும்.</translation>
+<translation id="7947953824732555851">ஏற்று உள்நுழைக</translation>
+<translation id="8583805026567836021">கணக்குத் தரவை அழிக்கிறது</translation>
+<translation id="8310344678080805313">நிலையான தாவல்கள்</translation>
+<translation id="5748802427693696783">இயல்பான தாவல்களுக்கு மாற்றப்பட்டது</translation>
+<translation id="7998918019931843664">மூடப்பட்ட தாவலை மீண்டும் திற</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, தாவல்</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> தாவலை மூடும்</translation>
+<translation id="7243308994586599757">திரையின் கீழ்ப்பகுதிக்கு அருகில் கிடைக்கும் விருப்பங்கள்</translation>
+<translation id="4060598801229743805">திரையின் மேற்பகுதிக்கு அருகில், விருப்பங்கள் உள்ளன</translation>
+<translation id="2810645512293415242">தரவைச் சேமித்து, வேகமாக ஏற்றுவதற்கு எளிதாக்கப்பட்ட பக்கம்.</translation>
+<translation id="3985215325736559418"><ph name="FILE_NAME"/>ஐ மீண்டும் பதிவிறக்கவா?</translation>
+<translation id="2450083983707403292"><ph name="FILE_NAME"/>ஐ மீண்டும் பதிவிறக்கவா?</translation>
+<translation id="7514365320538308">பதிவிறக்கு</translation>
+<translation id="545042621069398927">பதிவிறக்கத்தின் வேகத்தை அதிகப்படுத்துகிறது.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{கோப்பைப் பதிவிறக்குகிறது.}other{# கோப்புகளைப் பதிவிறக்குகிறது.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> கோப்புகளைப் பதிவிறக்குகிறது (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">கோப்பைப் பதிவிறக்குகிறது (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{ஒரு பதிவிறக்கம் முடிந்தது.}other{# பதிவிறக்கங்கள் முடிந்தன.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{ஒரு பதிவிறக்கம் தோல்வியடைந்தது.}other{# பதிவிறக்கங்கள் தோல்வியடைந்தன.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{ஒரு பதிவிறக்கம் நிலுவையில் உள்ளது.}other{# பதிவிறக்கங்கள் நிலுவையில் உள்ளன.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> பட்டன்</translation>
+<translation id="3205824638308738187">கிட்டத்தட்ட முடிந்தது!</translation>
+<translation id="3960299545138990065">Braveஐ மீண்டும் தொடங்கவும்</translation>
+<translation id="3771001275138982843">புதுப்பிப்பைப் பதிவிறக்க முடியவில்லை</translation>
+<translation id="3888648114124182147">Brave புதுப்பிப்பைப் பதிவிறக்குகிறது…</translation>
+<translation id="1705567146636171298">Braveஐப் புதுப்பி</translation>
+<translation id="6195417478702700398">சிறந்த உலாவல் அனுபவத்திற்கு Braveமைத் திறந்து புதுப்பியுங்கள்</translation>
+<translation id="3512968675351418494">உங்கள் மொழியில் இணையதளங்களைப் பார்க்க Braveமின் சமீபத்திய பதிப்பைப் பெறுங்கள்</translation>
+<translation id="6427112570124116297">இணையத்தை மொழிபெயர்த்தல்</translation>
+<translation id="1379423114029199501">Braveமில் உங்கள் மொழியைப் பெற சமீபத்திய பதிப்பிற்குப் புதுப்பிக்கவும்</translation>
+<translation id="5684874026226664614">அச்சச்சோ. இந்தப் பக்கத்தை மொழிபெயர்க்க முடியாது.</translation>
+<translation id="6831043979455480757">மொழிபெயர்</translation>
+<translation id="1285320974508926690">இந்த தளத்தை எப்போதும் மொழிபெயர்க்க வேண்டாம்</translation>
+<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE"/> மொழியில் உள்ள பக்கங்களை எப்போதும் மொழிபெயர்</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/> மொழியில் உள்ள பக்கங்களை ஒருபோதும் மொழிபெயர்க்காதே</translation>
+<translation id="124116460088058876">மேலும் மொழிகள்</translation>
+<translation id="290376772003165898"><ph name="LANGUAGE"/> மொழியில் பக்கம் இல்லையா?</translation>
+<translation id="4432792777822557199">இனி <ph name="SOURCE_LANGUAGE"/> மொழியில் உள்ள பக்கங்கள் <ph name="TARGET_LANGUAGE"/> மொழிக்கு மொழிபெயர்க்கப்படும்</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/> மொழியில் உள்ள பக்கங்கள் மொழிபெயர்க்கப்படாது</translation>
+<translation id="5447765697759493033">இந்தத் தளம் மொழிபெயர்க்கப்படாது</translation>
+<translation id="4880127995492972015">மொழிபெயர்…</translation>
+<translation id="641643625718530986">அச்சிடு...</translation>
+<translation id="8909135823018751308">பகிர்...</translation>
+<translation id="4996978546172906250">இதன்வழியாக பகிர்</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> வழியாகப் பகிர்</translation>
+<translation id="6277522088822131679">பக்கத்தை அச்சிடுவதில் சிக்கல் ஏற்பட்டது. மீண்டும் முயற்சிக்கவும்.</translation>
+<translation id="3254409185687681395">இந்தப் பக்கத்தை புக்மார்க் செய்க</translation>
+<translation id="497421865427891073">முன் செல்க</translation>
+<translation id="813082847718468539">தள விவரங்களைக் காண்க</translation>
+<translation id="2532336938189706096">இணைய பார்வை</translation>
+<translation id="6005538289190791541">பரிந்துரைக்கப்படும் கடவுச்சொல்</translation>
+<translation id="4634124774493850572">கடவுச்சொல்லைப் பயன்படுத்து</translation>
+<translation id="8285489906452138776">இந்தத் தளத்திற்காகக் கேமராவை அணுக, Braveமுக்கு அனுமதி தேவை.</translation>
+<translation id="320189792589364011">இந்தத் தளத்திற்காக மைக்ரோஃபோனை அணுக, Braveமுக்கு அனுமதி தேவை.</translation>
+<translation id="7988136689212463100">இந்தத் தளத்திற்காகக் கேமராவையும் மைக்ரோஃபோனையும் அணுக, Braveமுக்கு அனுமதி தேவை.</translation>
+<translation id="4931190655840828017">இந்தத் தளத்துடன் இருப்பிடத்தைப் பகிர, Braveமுக்கு உங்கள் இருப்பிடத்திற்கான அணுகல் தேவை.</translation>
+<translation id="3088191967551450609">கோப்புகளைப் பதிவிறக்க Braveக்கு சேமிப்பிட அணுகல் தேவை.</translation>
+<translation id="8942627711005830162">வேறு சாளரத்தில் திற</translation>
+<translation id="4195643157523330669">புதிய தாவலில் திற</translation>
+<translation id="1100066534610197918">குழுவில் புதிய தாவலில் திற</translation>
+<translation id="4860895144060829044">அழை</translation>
+<translation id="6896758677409633944">நகலெடு</translation>
+<translation id="8393700583063109961">செய்தி அனுப்பு</translation>
+<translation id="3557336313807607643">தொடர்புகளில் சேர்</translation>
+<translation id="4269820728363426813">இணைப்பு முகவரியை நகலெடு</translation>
+<translation id="1206892813135768548">இணைப்பு உரையை நகலெடு</translation>
+<translation id="1204037785786432551">இணைப்பைப் பதிவிறக்கு</translation>
+<translation id="6864459304226931083">படத்தைப் பதிவிறக்கு</translation>
+<translation id="8209050860603202033">படத்தைத் திற</translation>
+<translation id="8073388330009372546">படத்தை புதிய தாவலில் திற</translation>
+<translation id="6649642165559792194">மாதிரிக்காட்சி <ph name="BEGIN_NEW"/>புதிது<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">படத்தை ஏற்று</translation>
+<translation id="3845332215609790146">Brave Software Lens மூலம் தேடுக <ph name="BEGIN_NEW"/>புதிது<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">இந்தப் படத்திற்கு <ph name="SEARCH_ENGINE"/> இல் தேடவும்</translation>
+<translation id="3384347053049321195">படத்தைப் பகிர்</translation>
+<translation id="5833984609253377421">இணைப்பைப் பகிர்</translation>
+<translation id="6475951671322991020">வீடியோவைப் பதிவிறக்கு</translation>
+<translation id="2317945146070194624">புதிய Brave தாவலில் திற</translation>
+<translation id="7975379999046275268">பக்க மாதிரிக்காட்சியைக் காட்டு <ph name="BEGIN_NEW"/>புதிது<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">பக்கத்தைப் புதுப்பிக்கிறது</translation>
+<translation id="36525718899759834">Brave Software Play Store இலிருந்து பயன்பாட்டைப் பெறவும்: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">அடர்</translation>
+<translation id="1807246157184219062">வெளிச்சம்</translation>
+<translation id="4056223980640387499">செபியா</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">மோனோஸ்பேஸ்</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">பீம் செய்ய தாவலைத் தேர்ந்தெடுக்கவும்</translation>
+<translation id="8719023831149562936">நடப்பு தாவலை பீம் செய்ய முடியாது</translation>
+<translation id="2139186145475833000">முகப்புத் திரையில் சேர்</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/>ஐத் திற</translation>
+<translation id="2122601567107267586">பயன்பாட்டைத் திறக்க முடியவில்லை</translation>
+<translation id="5129038482087801250">இணைய ஆப்ஸை நிறுவு</translation>
+<translation id="3789841737615482174">நிறுவுக</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> உங்கள் முகப்புத் திரையில் சேர்க்கப்பட்டது</translation>
+<translation id="7333031090786104871">முந்தைய தளத்தை இன்னும் சேர்க்கிறது</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/>ஐச் சேர்க்கிறது...</translation>
+<translation id="3778956594442850293">முகப்புத் திரையில் சேர்க்கப்பட்டது</translation>
+<translation id="2146738493024040262">இன்ஸ்டண்ட் ஆப்ஸைத் திற</translation>
+<translation id="7016516562562142042">நடப்புத் தேடல் இன்ஜினுக்கு அனுமதிக்கப்பட்டுள்ளது</translation>
+<translation id="6177111841848151710">நடப்புத் தேடல் இன்ஜினுக்குத் தடுக்கப்பட்டுள்ளது</translation>
+<translation id="145097072038377568">Android அமைப்புகளில் முடக்கப்பட்டுள்ளது.</translation>
+<translation id="8007176423574883786">இந்தச் சாதனத்திற்கு முடக்கப்பட்டுள்ளது</translation>
+<translation id="164269334534774161"><ph name="CREATION_TIME"/> அன்றைக்கான இந்தப் பக்கத்தின் ஆஃப்லைன் நகலைப் பார்க்கிறீர்கள்</translation>
+<translation id="4594952190837476234"><ph name="CREATION_TIME"/> அன்று இந்த ஆஃப்லைன் பக்கம் உருவாக்கப்பட்டது. இது ஆன்லைன் பதிப்பிலிருந்து வேறுபடலாம்.</translation>
+<translation id="8840953339110955557">ஆன்லைன் பதிப்பிலிருந்து இந்தப் பக்கம் வேறுபடலாம்.</translation>
+<translation id="6405300764336705484">இந்த உள்ளடக்கம் <ph name="DOMAIN_NAME"/> (Brave Software ஆல் வழங்கப்படுவது) இலிருந்து கிடைக்கிறது.</translation>
+<translation id="1006017844123154345">ஆன்லைனில் திற</translation>
+<translation id="3326636747541519688">Brave Software வழங்கும் Lite பக்கம்</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> இலிருந்து <ph name="BEGIN_LINK"/>அசல் பக்கத்தை ஏற்று<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">இதை அடிக்கடி காண்கிறீர்கள் எனில், இந்தப் <ph name="BEGIN_LINK"/>பரிந்துரைகளைப்<ph name="END_LINK"/> பயன்படுத்திப் பார்க்கவும்.</translation>
+<translation id="8748850008226585750">மறைந்துள்ள உள்ளடக்கம்</translation>
+<translation id="3810973564298564668">நிர்வகி</translation>
+<translation id="5199929503336119739">பணி சுயவிவரம்</translation>
+<translation id="528192093759286357">முழுத்திரையிலிருந்து வெளியேற, மேலிருந்து இழுத்து "முந்தையது" பொத்தானைத் தொடவும்.</translation>
+<translation id="2836148919159985482">முழுத்திரையிலிருந்து வெளியேற, "முந்தையது" பொத்தானைத் தொடவும்.</translation>
+<translation id="3967822245660637423">பதிவிறக்கம் முடிந்தது</translation>
+<translation id="2434158240863470628">பதிவிறக்கம் முடிந்தது <ph name="SEPARATOR"/><ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">பதிவிறக்க முடியவில்லை</translation>
+<translation id="1384959399684842514">பதிவிறக்கம் இடைநிறுத்தப்பட்டது</translation>
+<translation id="1671236975893690980">பதிவிறக்கம் நிலுவையில் உள்ளது…</translation>
+<translation id="5561549206367097665">நெட்வொர்க்கிற்காகக் காத்திருக்கிறது…</translation>
+<translation id="5864419784173784555">வேறொரு பதிவிறக்கத்திற்காகக் காத்திருக்கிறது…</translation>
+<translation id="6461962085415701688">கோப்பைத் திறக்க முடியாது</translation>
+<translation id="1178581264944972037">இடைநிறுத்து</translation>
+<translation id="8200772114523450471">மீண்டும் தொடங்கு</translation>
+<translation id="1409879593029778104">கோப்பு ஏற்கனவே இருப்பதால் <ph name="FILE_NAME"/> இன் பதிவிறக்கம் தடுக்கப்பட்டது.</translation>
+<translation id="3387650086002190359">கோப்பு முறைமைப் பிழைகளால் <ph name="FILE_NAME"/>ஐப் பதிவிறக்க முடியவில்லை.</translation>
+<translation id="6482749332252372425">போதுமான சேமிப்பிடம் இல்லாததால் <ph name="FILE_NAME"/>ஐப் பதிவிறக்க முடியவில்லை.</translation>
+<translation id="7619072057915878432">நெட்வொர்க் தோல்விகளால் <ph name="FILE_NAME"/>ஐப் பதிவிறக்க முடியவில்லை.</translation>
+<translation id="1477626028522505441">சேவையகச் சிக்கல்களால் <ph name="FILE_NAME"/>ஐப் பதிவிறக்க முடியவில்லை.</translation>
+<translation id="3692944402865947621">சேமிப்பிடம் இல்லாததால், <ph name="FILE_NAME"/>ஐப் பதிவிறக்க முடியவில்லை.</translation>
+<translation id="604996488070107836">அறியப்படாதப் பிழை காரணமாக <ph name="FILE_NAME"/>ஐப் பதிவிறக்க முடியவில்லை.</translation>
+<translation id="6738867403308150051">பதிவிறக்குகிறது…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> கி.பை.</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> மெ.பை.</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> ஜி.பை.</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> கி.பை. பதிவிறக்கப்பட்டது</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> மெ.பை. பதிவிறக்கப்பட்டுள்ளது</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> ஜி.பை. பதிவிறக்கப்பட்டுள்ளது</translation>
+<translation id="9204836675896933765">1 கோப்பு மீதமுள்ளது</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> கோப்புகள் மீதமுள்ளன</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> கோப்பு பதிவிறக்கப்பட்டது}other{<ph name="FILES_DOWNLOADED_MANY"/> கோப்புகள் பதிவிறக்கப்பட்டன}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> நாட்கள் மீதமுள்ளன</translation>
+<translation id="8190358571722158785">1 நாள் மீதமுள்ளது</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> மணிநேரம் மீதமுள்ளது</translation>
+<translation id="510275257476243843">1 மணிநேரம் மீதமுள்ளது</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> நிமிடங்கள் மீதமுள்ளன</translation>
+<translation id="3236059992281584593">1 நிமிடம் மீதமுள்ளது</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> வினாடிகள் மீதமுள்ளன</translation>
+<translation id="2781151931089541271">1 வினாடி மீதமுள்ளது</translation>
+<translation id="3303414029551471755">உள்ளடக்கத்தைப் பதிவிறக்குவதைத் தொடரவா?</translation>
+<translation id="8617240290563765734">பதிவிறக்கிய உள்ளடக்கத்தில் குறிப்பிட்ட பரிந்துரைக்கப்பட்ட URLஐத் திறக்கவா?</translation>
+<translation id="1373696734384179344">தேர்ந்தெடுத்ததைப் பதிவிறக்க, போதுமான நினைவகம் இல்லை.</translation>
+<translation id="5271967389191913893">பதிவிறக்க வேண்டிய உள்ளடக்கத்தைச் சாதனத்தால் திறக்க முடியாது</translation>
+<translation id="883806473910249246">உள்ளடக்கத்தைப் பதிவிறக்கும் போது பிழை ஏற்பட்டது.</translation>
+<translation id="5626134646977739690">பெயர்:</translation>
+<translation id="7963646190083259054">விற்பனையாளர்:</translation>
+<translation id="3414952576877147120">அளவு:</translation>
+<translation id="7375125077091615385">வகை:</translation>
+<translation id="5765780083710877561">விவரம்:</translation>
+<translation id="4881695831933465202">திற</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> கி.பை. உள்ளது</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> மெ.பை கிடைக்கிறது</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> ஜி.பை. உள்ளது</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/> இல் <ph name="SPACE_USED"/> பயன்படுத்தப்படுகிறது</translation>
+<translation id="3587482841069643663">அனைத்தும்</translation>
+<translation id="4988526792673242964">பக்கங்கள்</translation>
+<translation id="3810838688059735925">வீடியோ</translation>
+<translation id="3616113530831147358">ஆடியோ</translation>
+<translation id="9219103736887031265">படங்கள்</translation>
+<translation id="8250920743982581267">ஆவணங்கள்</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# கோப்பு}other{# கோப்புகள்}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# படம்}other{# படங்கள்}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# வீடியோ}other{# வீடியோக்கள்}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ஆடியோ கோப்பு}other{# ஆடியோ கோப்புகள்}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# பக்கம்}other{# பக்கங்கள்}}</translation>
+<translation id="5456381639095306749">பக்கத்தைப் பதிவிறக்குக</translation>
+<translation id="2394602618534698961">நீங்கள் பதிவிறக்கிய கோப்புகளை இங்கே பார்க்கலாம்</translation>
+<translation id="7810647596859435254">இதன் மூலம் திற…</translation>
+<translation id="5655963694829536461">உங்கள் பதிவிறக்கங்களைத் தேடுக</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">எனது கோப்புகள்</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">செய்திகளை இங்கே பார்க்கலாம், ஆஃப்லைனில் இருந்தாலும்கூட அவற்றைப் படிக்கலாம்</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# மணிநேரம்}other{# மணிநேரம்}}</translation>
+<translation id="5853623416121554550">இடைநிறுத்தப்பட்டது</translation>
+<translation id="8965591936373831584">நிலுவையிலுள்ளது</translation>
+<translation id="2779651927720337254">தோல்வியுற்றது</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">சற்றுமுன்</translation>
+<translation id="4000212216660919741">Home ஆஃப்லைனில் உள்ளது</translation>
+<translation id="9133397713400217035">ஆஃப்லைனில் கண்டறியுங்கள்</translation>
+<translation id="968900484120156207">நீங்கள் பார்க்கும் பக்கங்கள் இங்குத் தோன்றும்</translation>
+<translation id="7882131421121961860">வரலாறு எதுவுமில்லை</translation>
+<translation id="3549657413697417275">உங்கள் வரலாற்றைத் தேடுக</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave முதல் இயக்க அனுபவம்</translation>
+<translation id="2700285883409956633">இந்தப் பயன்பாட்டைப் பயன்படுத்துவதன் மூலம், Brave இன் <ph name="BEGIN_LINK1"/>சேவை விதிமுறைகள்<ph name="END_LINK1"/> மற்றும் <ph name="BEGIN_LINK2"/>தனியுரிமை அறிக்கையை<ph name="END_LINK2"/> ஏற்கிறீர்கள்.</translation>
+<translation id="1640714894372474981">இந்த ஆப்ஸைப் பயன்படுத்துவதன் மூலம், Braveன் <ph name="BEGIN_LINK1"/>சேவை விதிமுறைகள்<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>தனியுரிமை அறிக்கை<ph name="END_LINK2"/>, <ph name="BEGIN_LINK3"/>Family Link மூலம் நிர்வகிக்கும் Brave Software கணக்குகளுக்கான தனியுரிமை அறிக்கை<ph name="END_LINK3"/> ஆகியவற்றை ஏற்கிறீர்கள்.</translation>
+<translation id="4218324479468769727">Brave இல் <ph name="APP_NAME"/> திறக்கும். தொடர்வதன் மூலம், Brave இன் <ph name="BEGIN_LINK1"/>சேவை விதிமுறைகள்<ph name="END_LINK1"/> மற்றும் <ph name="BEGIN_LINK2"/>தனியுரிமை அறிக்கையை<ph name="END_LINK2"/> ஏற்கிறீர்கள்.</translation>
+<translation id="5071615083211946659">Braveல் <ph name="APP_NAME"/> திறக்கும். தொடர்வதன் மூலம், Braveன் <ph name="BEGIN_LINK1"/>சேவை விதிமுறைகள்<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>தனியுரிமை அறிக்கை<ph name="END_LINK2"/>, <ph name="BEGIN_LINK3"/>Family Link மூலம் நிர்வகிக்கப்படும் Brave Software கணக்குகளுக்கான தனியுரிமை அறிக்கை<ph name="END_LINK3"/> ஆகியவற்றை ஏற்கிறீர்கள்.</translation>
+<translation id="673197144963363525">பயன்பாட்டுப் புள்ளிவிவரங்களையும், சிதைவு அறிக்கைகளையும் Brave Softwareளுக்கு அனுப்புவதன் மூலம் Braveஐ மேலும் சிறப்பானதாக்க உதவவும்.</translation>
+<translation id="3518985090088779359">ஏற்று, தொடரவும்</translation>
+<translation id="7207456302801184289">Brave க்கு வருக</translation>
+<translation id="704822250101715322">Brave Software Play சேவைகள் புதுப்பிப்பதை முடிப்பதற்காக, காத்திருக்கிறது</translation>
+<translation id="1231733316453485619">ஒத்திசைவை இயக்கவா?</translation>
+<translation id="5132942445612118989">எல்லாச் சாதனங்களிலும் உங்கள் கடவுச்சொற்கள், வரலாறு மற்றும் பலவற்றை ஒத்திசைக்கலாம்</translation>
+<translation id="5736731321935944068">தேடல், விளம்பரங்கள் மற்றும் பிற Brave Software சேவைகளைத் தனிப்பயனாக்க, உங்கள் வரலாற்றை Brave Software பயன்படுத்தக்கூடும்</translation>
+<translation id="4013614219085422040">‘தேடல்’ மற்றும் பிற Brave Software சேவைகளைத் தனிப்பயனாக்க, உங்கள் வரலாற்றை Brave Software பயன்படுத்தக்கூடும்</translation>
+<translation id="5581519193887989363">எவற்றை ஒத்திசைக்க வேண்டும் என்பதை <ph name="BEGIN_LINK1"/>அமைப்புகளில்<ph name="END_LINK1"/> எப்போது வேண்டுமானாலும் தேர்வுசெய்யலாம்.</translation>
+<translation id="741204030948306876">ஏற்கிறேன்</translation>
+<translation id="2410754283952462441">கணக்கைத் தேர்வு செய்யவும்</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> ஆகத் தொடர்க</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> இல்லையா?</translation>
+<translation id="8109613176066109935">உங்கள் அனைத்துச் சாதனங்களிலும் புத்தகக்குறிகளைப் பெற, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="2818669890320396765">உங்கள் அனைத்துச் சாதனங்களிலும் புத்தகக்குறிகளைப் பெற, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="6003646045106347985">Brave Software பரிந்துரைக்கும் பிரத்யேக உள்ளடக்கத்தைப் பெற, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="8494430740943879273">Brave Software பரிந்துரைக்கும் பிரத்யேக உள்ளடக்கத்தைப் பெற, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="5862731021271217234">உங்கள் பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="3568688522516854065">உங்கள் பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="1208340532756947324">அனைத்துச் சாதனங்களுக்கு இடையிலும் ஒத்திசைக்க மற்றும் தனிப்பயனாக்க, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="4472118726404937099">அனைத்துச் சாதனங்களுக்கு இடையிலும் ஒத்திசைக்க மற்றும் தனிப்பயனாக்க, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
+<translation id="2426805022920575512">மற்றொரு கணக்கைத் தேர்வுசெய்க</translation>
+<translation id="6790428901817661496">இயக்கு</translation>
+<translation id="1272079795634619415">நிறுத்து</translation>
+<translation id="2874939134665556319">முந்தைய ட்ராக்</translation>
+<translation id="4046123991198612571">அடுத்த ட்ராக்</translation>
+<translation id="3859306556332390985">முன்செல்</translation>
+<translation id="8441146129660941386">பின்செல்</translation>
+<translation id="6706288973712894588">தற்போது ஆஃப்லைனில் உள்ளீர்கள்.\n<ph name="BEGIN_LINK"/>உங்கள் ஆஃப்லைன் ஊட்டத்தைக் கண்டறியுங்கள்.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">சமீபத்திய தாவல்கள்</translation>
+<translation id="8497726226069778601">இதுவரை இங்கே காண்பதற்கு ஒன்றுமில்லை...</translation>
+<translation id="5423934151118863508">நீங்கள் அதிகமாகப் பார்வையிட்ட பக்கங்கள் இங்கு தோன்றும்</translation>
+<translation id="6127379762771434464">உருப்படி அகற்றப்பட்டது</translation>
+<translation id="4605958867780575332">உருப்படி அகற்றப்பட்டது: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">பிற சாதனங்கள்</translation>
+<translation id="4738836084190194332">கடைசியாக ஒத்திசைத்தது: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# நிமிடத்திற்கு முன்பு}other{# நிமிடங்களுக்கு முன்பு}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# மணிநேரம் முன்பு}other{# மணிநேரம் முன்பு}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# நாள் முன்பு}other{# நாட்களுக்கு முன்பு}}</translation>
+<translation id="2762000892062317888">சற்று முன்</translation>
+<translation id="1407135791313364759">எல்லாவற்றையும் திற</translation>
+<translation id="1209206284964581585">இப்போதைக்கு மறை</translation>
+<translation id="129553762522093515">சமீபத்தில் மூடியவை</translation>
+<translation id="8413126021676339697">முழு வரலாற்றையும் காண்பி</translation>
+<translation id="7876243839304621966">அனைத்தையும் அகற்று</translation>
+<translation id="8487700953926739672">ஆஃப்லைனில் இருக்கிறது</translation>
+<translation id="5224771365102442243">வீடியோவுடன்</translation>
+<translation id="3493531032208478708">பரிந்துரைக்கப்படும் உள்ளடக்கம் பற்றி <ph name="BEGIN_LINK"/>மேலும் அறிக<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">பரிந்துரைகளைப் பெற முடியவில்லை</translation>
+<translation id="5013696553129441713">புதிய பரிந்துரைகள் இல்லை</translation>
+<translation id="1736419249208073774">அறிக</translation>
+<translation id="7444811645081526538">கூடுதல் வகைகள்</translation>
+<translation id="6709133671862442373">செய்திகள்</translation>
+<translation id="1264974993859112054">விளையாட்டு</translation>
+<translation id="9139318394846604261">ஷாப்பிங்</translation>
+<translation id="3912508018559818924">இணையத்திலிருந்து தரவை ஏற்றுகிறோம்…</translation>
+<translation id="526421993248218238">பக்கத்தை ஏற்ற முடியவில்லை</translation>
+<translation id="614940544461990577">இவற்றைச் செய்து பார்க்கவும்:</translation>
+<translation id="3288003805934695103">பக்கத்தை மீண்டும் ஏற்றுதல்</translation>
+<translation id="2353636109065292463">உங்கள் இணைய இணைப்பைச் சரிபார்க்கிறது</translation>
+<translation id="2858138569776157458">பிரபலமானவை</translation>
+<translation id="8364299278605033898">பிரபல இணையதளங்களைப் பாருங்கள்</translation>
+<translation id="1171770572613082465">"பிரபலமானவை" பட்டனைத் தட்டி பிரபல இணையதளங்களைப் பாருங்கள்</translation>
+<translation id="5233638681132016545">புதிய தாவல்</translation>
+<translation id="4521874409998847950">வெளியிடுவது: <ph name="PUBLISHER_ORIGIN"/> (<ph name="BEGIN_DEEMPHASIZED"/>Brave Software வழங்குவது<ph name="END_DEEMPHASIZED"/>)</translation>
+<translation id="2587052924345400782">புதிய பதிப்பு உள்ளது</translation>
+<translation id="4058091506841967397">Brave புதுப்பிக்கவில்லை</translation>
+<translation id="6316139424528454185">Android பதிப்பு ஆதரிக்கப்படாது</translation>
+<translation id="6989267951144302301">பதிவிறக்க முடியவில்லை</translation>
+<translation id="624789221780392884">புதுப்பிப்பு தயார்</translation>
+<translation id="1549000191223877751">வேறு சாளரத்திற்கு நகர்த்து</translation>
+<translation id="7481312909269577407">அடுத்த பக்கம்</translation>
+<translation id="4084682180776658562">புக்மார்க்</translation>
+<translation id="6437478888915024427">பக்கத் தகவல்</translation>
+<translation id="7180611975245234373">புதுப்பி</translation>
+<translation id="4913169188695071480">புதுப்பிக்காதே</translation>
+<translation id="1829244130665387512">இந்தப் பக்கத்தில் தேடு</translation>
+<translation id="6593061639179217415">டெஸ்க்டாப் தளம்</translation>
+<translation id="9063523880881406963">டெஸ்க்டாப் தளத்திற்கான கோரிக்கையை முடக்கு</translation>
+<translation id="2038563949887743358">டெஸ்க்டாப் தளத்திற்கான கோரிக்கையை இயக்கு</translation>
+<translation id="2433507940547922241">தோற்றம்</translation>
+<translation id="983192555821071799">எல்லா தாவல்களையும் மூடு</translation>
+<translation id="1310482092992808703">தாவல்களைக் குழுவாக்கு</translation>
+<translation id="7725024127233776428">நீங்கள் புக்மார்க் செய்த பக்கங்கள் இங்கு தோன்றும்</translation>
+<translation id="4404568932422911380">புக்மார்க்குகள் இல்லை</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> புக்மார்க்}other{<ph name="BOOKMARKS_COUNT_MANY"/> புக்மார்க்குகள்}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> இல் புத்தகக்குறியிடப்பட்டது</translation>
+<translation id="3207960819495026254">புக்மார்க் செய்யப்பட்டது</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/> இல் புத்தகக்குறியைச் சேர்த்தது</translation>
+<translation id="8063895661287329888">புக்மார்க்கைச் சேர்க்க முடியவில்லை.</translation>
+<translation id="2842985007712546952">மூலக் கோப்புறை</translation>
+<translation id="9065203028668620118">திருத்து</translation>
+<translation id="4405224443901389797">இங்கு நகர்த்து…</translation>
+<translation id="5170568018924773124">கோப்புறையில் காண்பி</translation>
+<translation id="8035133914807600019">புதிய கோப்புறை…</translation>
+<translation id="4532845899244822526">கோப்புறையைத் தேர்வுசெய்யவும்</translation>
+<translation id="6627583120233659107">கோப்புறையைத் திருத்து</translation>
+<translation id="1197267115302279827">புத்தகக்குறிகளை நகர்த்து</translation>
+<translation id="6963766334940102469">புத்தகக்குறிகளை நீக்கு</translation>
+<translation id="4351244548802238354">அறிவிப்பை மூடு</translation>
+<translation id="451872707440238414">புக்மார்க்களில் தேடு</translation>
+<translation id="8901170036886848654">புக்மார்க்குகள் எதுவுமில்லை</translation>
+<translation id="6404511346730675251">புக்மார்க்களைத் திருத்து</translation>
+<translation id="3894427358181296146">கோப்புறையைச் சேர்</translation>
+<translation id="5327248766486351172">பெயர்</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">கோப்புறை</translation>
+<translation id="5161254044473106830">தலைப்பு அவசியம்</translation>
+<translation id="2996809686854298943">URL தேவை</translation>
+<translation id="2536728043171574184">இந்தப் பக்கத்தின் ஆஃப்லைன் நகலைப் பார்க்கிறீர்கள்</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> இல் உள்ளடக்கத்தை ஆஃப்லைனில் பார்க்கலாம்</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> மற்றும் பல தளங்கள்</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{பக்கம் தயாரானதும் Brave அதை ஏற்றும்}other{பக்கங்கள் தயாரானதும் Brave அவற்றை ஏற்றும்}}</translation>
+<translation id="6811034713472274749">பக்கத்தைப் பார்க்கலாம்</translation>
+<translation id="4561979708150884304">இணைப்பு இல்லை</translation>
+<translation id="8274165955039650276">பதிவிறக்கங்களைக் காட்டு</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/> முடிவுகளில் <ph name="RESULT_NUMBER"/>வது முடிவு</translation>
+<translation id="4943872375798546930">முடிவுகள் இல்லை</translation>
+<translation id="981121421437150478">ஆஃப்லைன்</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">குரல் தேடல் இயக்கப்படவில்லை</translation>
+<translation id="7191430249889272776">தாவல் பின்புலத்தில் திறக்கப்பட்டது.</translation>
+<translation id="8445059357334030806">Brave இல் திற</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/>இல் திற</translation>
+<translation id="7022756207310403729">உலாவியில் திற</translation>
+<translation id="1113597929977215864">எளிதாக்கப்பட்ட காட்சியைக் காட்டு</translation>
+<translation id="1513352483775369820">புத்தகக்குறிகளும் இணைய வரலாறும்</translation>
+<translation id="4939482511480190003">Braveஐ மேம்படுத்த உதவவும். <ph name="BEGIN_LINK"/>கருத்துக்கணிப்பில் பங்கேற்கவும்<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">திரும்பிச் செல்</translation>
+<translation id="5596627076506792578">கூடுதல் விருப்பங்கள்</translation>
+<translation id="3522247891732774234">புதுப்பிப்பு உள்ளது. மேலும் விருப்பங்கள்</translation>
+<translation id="6773423637732432200">Braveமைப் புதுப்பிக்க முடியாது. கூடுதல் விருப்பங்கள்</translation>
+<translation id="3328801116991980348">தளம் குறித்த தகவல்</translation>
+<translation id="5391532827096253100">இந்தத் தளத்திற்கான இணைப்பு பாதுகாப்பானதல்ல. தளத் தகவல்</translation>
+<translation id="6206551242102657620">பாதுகாப்பான இணைப்பு. தளத் தகவல்</translation>
+<translation id="6963642900430330478">இந்தப் பக்கம் ஆபத்தானது. தளத் தகவல்</translation>
+<translation id="9070377983101773829">குரல் தேடலைத் தொடங்கு</translation>
+<translation id="8676374126336081632">உள்ளீட்டை அழி</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> திறந்துள்ள தாவல், தாவல்களை மாற்ற, தட்டவும்}other{<ph name="OPEN_TABS_MANY"/> திறந்துள்ள தாவல்கள், தாவல்களை மாற்ற, தட்டவும்}}</translation>
+<translation id="2369533728426058518">திறக்கப்பட்டுள்ள தாவல்கள்</translation>
+<translation id="7071521146534760487">கணக்கை நிர்வகிக்கும்</translation>
+<translation id="932327136139879170">முகப்பு</translation>
+<translation id="2707726405694321444">பக்கத்தைப் புதுப்பி</translation>
+<translation id="2891154217021530873">பக்கத்தை ஏற்றுவதை நிறுத்து</translation>
+<translation id="6710213216561001401">முந்தையது</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">தேர்ந்தெடுத்த தாவல்</translation>
+<translation id="2268044343513325586">துல்லியமாக்கு</translation>
+<translation id="7846076177841592234">தேர்வை ரத்துசெய்</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> தேர்ந்தெடுக்கப்பட்டன.  திரையின் மேற்பகுதிக்கு அருகில், விருப்பங்கள் உள்ளன</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> தேர்ந்தெடுக்கப்பட்டன</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{தேர்ந்தெடுத்த 1 உருப்படியைப் பகிரும்}other{தேர்ந்தெடுத்த # உருப்படிகளைப் பகிரும்}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{தேர்ந்தெடுத்த 1 உருப்படியை அகற்றும்}other{தேர்ந்தெடுத்த # உருப்படிகளை அகற்றும்}}</translation>
+<translation id="1283039547216852943">விரிவாக்க, தட்டவும்</translation>
+<translation id="5962718611393537961">சுருக்க, தட்டவும்</translation>
+<translation id="8076492880354921740">தாவல்கள்</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 தேர்ந்தெடுக்கப்பட்டது}other{# தேர்ந்தெடுக்கப்பட்டன}}</translation>
+<translation id="6818926723028410516">பட்டியலிலிருந்து தேர்ந்தெடுக்கவும்</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/>க்குச் செல்ல, தொடவும்</translation>
+<translation id="6766758767654711248">தளத்திற்குச் செல்ல, தட்டவும்</translation>
+<translation id="429312253194641664">ஒரு தளம் மீடியாவை இயக்குகிறது</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> உங்கள் திரையைப் பகிர்கிறது</translation>
+<translation id="8833831881926404480">ஒரு தளம் உங்கள் திரையைப் பகிர்கிறது</translation>
+<translation id="9086455579313502267">நெட்வொர்க்கை அணுக முடியவில்லை</translation>
+<translation id="938850635132480979">பிழை: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/> இல் திற</translation>
+<translation id="548278423535722844">வரைபடப் பயன்பாட்டில் திற</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> இல் மின்னஞ்சலை உருவாக்கவும்</translation>
+<translation id="7875915731392087153">மின்னஞ்சலை உருவாக்கவும்</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> இல் நிகழ்வை உருவாக்கு</translation>
+<translation id="2900528713135656174">நிகழ்வை உருவாக்கவும்</translation>
+<translation id="2111511281910874386">பக்கத்திற்குச் செல்லவும்</translation>
+<translation id="3988466920954086464">இந்தப் பேனலில் உடனடித் தேடல் முடிவுகளைப் பார்க்கவும்</translation>
+<translation id="2744248271121720757">உடனடியாகத் தேட அல்லது தொடர்புடைய செயல்களைப் பார்க்க, சொல்லைத் தட்டவும்</translation>
+<translation id="9155898266292537608">ஒரு சொல்லைத் தட்டி உடனடியாகவும் தேடலாம்</translation>
+<translation id="3232754137068452469">இணைய ஆப்ஸ்</translation>
+<translation id="1430915738399379752">அச்சிடுக</translation>
+<translation id="3775705724665058594">உங்கள் சாதனங்களுக்கு அனுப்புதல்</translation>
+<translation id="6364438453358674297">வரலாற்றிலிருந்து பரிந்துரையை அகற்றவா?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> மூடப்பட்டது</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> தாவல்கள் மூடப்பட்டன</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> நீக்கப்பட்டது</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> புக்மார்க்குகள் நீக்கப்பட்டன</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> பதிவிறக்கங்கள் உள்ளன</translation>
+<translation id="1248710015876067820">ஆதரிக்கப்படாத Brave நிகழ்வுகளின் எண்ணிக்கை.</translation>
+<translation id="4259722352634471385">செல்வது தடுக்கப்பட்டது: <ph name="URL"/></translation>
+<translation id="8959122750345127698">செல்ல முடியவில்லை: <ph name="URL"/></translation>
+<translation id="5210365745912300556">தாவலை மூடுக</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/>ஐ மூடு</translation>
+<translation id="1227058898775614466">வழிசெலுத்தல் வரலாறு</translation>
+<translation id="9169507124922466868">வழிசெலுத்தல் வரலாறு பாதியளவு திறந்துள்ளது</translation>
+<translation id="1327257854815634930">வழிசெலுத்தல் வரலாறு திறக்கப்பட்டுள்ளது</translation>
+<translation id="8788265440806329501">வழிசெலுத்தல் வரலாறு மூடப்பட்டுள்ளது</translation>
+<translation id="7482656565088326534">மாதிரிக்காட்சித் தாவல்</translation>
+<translation id="8427875596167638501">மாதிரிக்காட்சித் தாவல் பாதியளவு திறந்துள்ளது</translation>
+<translation id="9102803872260866941">மாதிரிக்காட்சித் தாவல் திறந்துள்ளது</translation>
+<translation id="2942036813789421260">மாதிரிக்காட்சித் தாவல் மூடப்பட்டுள்ளது</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> இன் சேமிப்பகம்</translation>
+<translation id="3822502789641063741">தளச் சேமிப்பகத்தை அழிக்கவா?</translation>
+<translation id="9205995714227143200">முக்கியமில்லை என்று Brave கருதும் தளச் சேமிப்பகம் (எ.கா: சேமித்த அமைப்புகள் இல்லாத அல்லது நீங்கள் அடிக்கடி பார்க்காத தளங்கள்)</translation>
+<translation id="3997476611815694295">முக்கியமில்லா சேமிப்பகம்</translation>
+<translation id="8493948351860045254">இடத்தைக் காலியாக்கு</translation>
+<translation id="2324920234469020158">முக்கியமில்லை என்று Brave கருதும் குக்கீகள், தற்காலிகச் சேமிப்பு, தளங்களின் பிற தரவு ஆகியவற்றை இது அழிக்கும்.</translation>
+<translation id="5447201525962359567">குக்கீகள் மற்றும் சாதனத்தில் சேமிக்கப்பட்ட பிற தரவு உள்பட எல்லா தளச் சேமிப்பகமும்</translation>
+<translation id="1376578503827013741">கணக்கிடுகிறது…</translation>
+<translation id="583281660410589416">தெரியாதது</translation>
+<translation id="2323763861024343754">தளச் சேமிப்பகம்</translation>
+<translation id="3587672679800759167">கணக்குகள், புக்மார்க்குகள், சேமித்த அமைப்புகள் உள்பட Brave பயன்படுத்தும் மொத்தத் தரவு</translation>
+<translation id="6545017243486555795">எல்லா தரவையும் அழி</translation>
+<translation id="4095146165863963773">பயன்பாட்டுத் தரவை நீக்கவா?</translation>
+<translation id="53119194224775367">Brave இன் எல்லாப் பயன்பாட்டுத் தரவும் நிரந்தரமாக நீக்கப்படும். இதில் அனைத்துக் கோப்புகள், அமைப்புகள், கணக்குகள், தரவுத்தளங்கள், மேலும் பல உள்ளடங்கும்.</translation>
+<translation id="5307446750509046227">தள சேமிப்பகத்தை அழி</translation>
+<translation id="300526633675317032">இணையதளச் சேமிப்பகத்தில் உள்ள <ph name="SIZE_IN_KB"/> தரவையும் இது அழிக்கும்.</translation>
+<translation id="8068648041423924542">சான்றிதழைத் தேர்ந்தெடுக்க முடியவில்லை.</translation>
+<translation id="2315043854645842844">கிளையன்ட் சார்பாக சான்றிதழ் தேர்ந்தெடுப்பை ஆப்ரேட்டிங் சிஸ்டம் ஆதரிக்கவில்லை.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> இணைய விரும்புகிறது</translation>
+<translation id="5308380583665731573">இணை</translation>
+<translation id="868929229000858085">உங்கள் தொடர்புகளில் தேடுக</translation>
+<translation id="1919950603503897840">தொடர்புகளைத் தேர்ந்தெடுக்கவும்</translation>
+<translation id="7986741934819883144">தொடர்பைத் தேர்ந்தெடுக்கவும்</translation>
+<translation id="3333961966071413176">எல்லாத் தொடர்புகளும்</translation>
+<translation id="4994033804516042629">தொடர்புகள் எதுவும் இல்லை</translation>
+<translation id="5403592356182871684">பெயர்கள்</translation>
+<translation id="2717722538473713889">மின்னஞ்சல் முகவரிகள்</translation>
+<translation id="381841723434055211">ஃபோன் எண்கள்</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(மேலும் 1)}other{(மேலும் #)}}</translation>
+<translation id="5197729504361054390">நீங்கள் தேர்ந்தெடுக்கும் தொடர்புகள் <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> உடன் பகிரப்படும்.</translation>
+<translation id="1779089405699405702">இமேஜ் டீகோடர்</translation>
+<translation id="8067883171444229417">வீடியோவை பிளே செய்</translation>
+<translation id="6560414384669816528">Sogou மூலம் தேடுக</translation>
+<translation id="5406914950576900927">சீனாவில் தேடுவதற்கு, Braveமில் <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>ஐப் பயன்படுத்தலாம். இதை <ph name="BEGIN_LINK"/>அமைப்புகளுக்குச்<ph name="END_LINK"/> சென்று மாற்றலாம்.</translation>
+<translation id="6456271171669383967">Brave Softwareஐ இயல்பு இன்ஜினாக வைத்திரு</translation>
+<translation id="4384468725000734951">தேடலுக்கு Sogouஐப் பயன்படுத்துகிறீர்கள்</translation>
+<translation id="6103327872225198548">தேடலுக்கு Brave Softwareளைப் பயன்படுத்துகிறீர்கள்</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">இந்த ஆப்ஸ் Braveமில் இயங்குகிறது</translation>
+<translation id="6143689084714664628">Brave இல் இயங்குகிறது</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> ஆப்ஸின் தரவும் Braveமில் உள்ளது</translation>
+<translation id="2734140769649165081">Brave அமைப்புகளில் தரவை அழிக்கலாம்</translation>
+<translation id="8232956427053453090">தரவை அழிக்காதே</translation>
+<translation id="4298388696830689168">இணைக்கப்பட்டுள்ள தளங்கள்</translation>
+<translation id="5763514718066511291">இந்த ஆப்ஸின் URLஐ நகலெடுக்க, தட்டவும்</translation>
+<translation id="6496823230996795692">முதல்முறையாக <ph name="APP_NAME"/>ஐப் பயன்படுத்த, இணையத்துடன் இணைக்கவும்.</translation>
+<translation id="751961395872307827">தளத்துடன் இணைக்க முடியவில்லை</translation>
+<translation id="4878404682131129617">ப்ராக்ஸி சர்வர் மூலமாக டனல் இணைப்பை உருவாக்க முடியவில்லை</translation>
+<translation id="4749960740855309258">புதிய தாவலைத் திறக்கும்</translation>
+<translation id="8788968922598763114">கடைசியாக மூடிய தாவலைத் திறக்கும்</translation>
+<translation id="7929962904089429003">மெனுவைத் திறக்கும்</translation>
+<translation id="6039379616847168523">அடுத்த தாவலுக்குச் செல்லும்</translation>
+<translation id="5210286577605176222">முந்தைய தாவலுக்குச் செல்லும்</translation>
+<translation id="124678866338384709">தற்போதைய தாவலை மூடும்</translation>
+<translation id="3714981814255182093">கண்டறி பட்டியைத் திறக்கும்</translation>
+<translation id="5441522332038954058">முகவரிப் பட்டிக்குச் செல்லும்</translation>
+<translation id="3398320232533725830">புக்மார்க்குகள் மேலாளரைத் திறக்கும்</translation>
+<translation id="6583199322650523874">தற்போதைய பக்கத்தைப் புத்தகக்குறியிடும்</translation>
+<translation id="8489271220582375723">வரலாறு பக்கத்தைத் திறக்கும்</translation>
+<translation id="4837753911714442426">பக்கத்தை அச்சிடுவதற்கான விருப்பங்களைத் திறக்கும்</translation>
+<translation id="5726692708398506830">பக்கத்திலுள்ள அனைத்தையும் பெரிதாக்கும்</translation>
+<translation id="3259831549858767975">பக்கத்திலுள்ள அனைத்தையும் சிறிதாக்கும்</translation>
+<translation id="8015452622527143194">பக்கத்திலுள்ள அனைத்தையும் இயல்பு அளவுக்கு மாற்றும்</translation>
+<translation id="3443221991560634068">தற்போதைய பக்கத்தை மீண்டும் ஏற்றும்</translation>
+<translation id="123724288017357924">தற்காலிக சேமிப்பைப் புறக்கணித்து, நடப்புப் பக்கத்தை மீண்டும் ஏற்றும்</translation>
+<translation id="305870044889644984">Brave உதவி மையத்தைப் புதிய தாவலில் திறக்கும்</translation>
+<translation id="3166827708714933426">தாவல் மற்றும் சாளரத்திற்கான ஷார்ட்கட்கள்</translation>
+<translation id="3169981355900570544">Brave Software Brave அம்சத்திற்கான ஷார்ட்கட்கள்</translation>
+<translation id="4558311620361989323">இணையப் பக்கக் ஷார்ட்கட்கள்</translation>
+<translation id="1908301351964700579">VRருக்காக Brave இன்னமும் தயார்செய்கிறது. Braveமைப் பின்னர் மீண்டும் தொடங்கவும்.</translation>
+<translation id="8970887620466824814">ஏதோ தவறாகிவிட்டது.</translation>
+<translation id="1875543012935658554">Braveமை மீண்டும் திறக்கவும்.</translation>
+<translation id="79859296434321399">ஆக்மென்ட்டட் ரியாலிட்டி உள்ளடக்கத்தைப் பார்க்க, ARCoreஐ நிறுவவும்</translation>
+<translation id="8558485628462305855">ஆக்மென்ட்டட் ரியாலிட்டி உள்ளடக்கத்தைப் பார்க்க, ARCoreஐப் புதுப்பிக்கவும்</translation>
+<translation id="3513704683820682405">ஆக்மென்ட்டட் ரியாலிட்டி</translation>
+<translation id="5475862044948910901">'ஆக்மெண்ட்டட் ரியாலிட்டி' அமர்வைத் தொடங்கவா?</translation>
 <translation id="7365126855094612066">இந்த அமர்வின் போது தளத்தால் பின்வருபவற்றைச் செய்ய இயலும்:
 • உங்களைச் சுற்றியுள்ள இடத்தின் 3D மேப்பை உருவாக்கலாம்
 • கேமரா நகர்வைக் கண்காணிக்கலாம்
 
 இந்தத் தளத்தால் கேமராவைக் கட்டுப்படுத்த இயலாது. கேமராவின் படங்களை நீங்கள் மட்டுமே பார்க்க முடியும்.</translation>
-<translation id="7375125077091615385">வகை:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome முதல் இயக்க அனுபவம்</translation>
-<translation id="741204030948306876">ஏற்கிறேன்</translation>
-<translation id="7413229368719586778">தொடக்கத் தேதி: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">முதலில் கேள்</translation>
-<translation id="7423538860840206698">கிளிப்போர்டைப் படிப்பது தடுக்கப்பட்டுள்ளது</translation>
-<translation id="7431991332293347422">தேடல் மற்றும் பலவற்றைத் தனிப்பயனாக்க உங்கள் உலாவல் வரலாறு எப்படிப் பயன்படுத்தப்படுகிறது என்பதைக் கட்டுப்படுத்தலாம்</translation>
-<translation id="7437998757836447326">Chrome இலிருந்து வெளியேறுதல்</translation>
-<translation id="7438641746574390233">லைட் பயன்முறை இயக்கப்பட்டிருக்கும்போது, பக்கங்களை வேகமாக ஏற்றுவதற்காக Google சேவையகங்களைக் Chrome பயன்படுத்தும். மிகவும் மெதுவாக ஏற்றப்படும் பக்கங்களில் முக்கிய உள்ளடக்கத்தை மட்டும் ஏற்றுமாறு லைட் பயன்முறை அவற்றை மீண்டும் எழுதுகிறது. மறைநிலைத் தாவல்களுக்கு லைட் பயன்முறை பொருந்தாது.</translation>
-<translation id="7444811645081526538">கூடுதல் வகைகள்</translation>
-<translation id="7445411102860286510">ஒலியடக்கிய வீடியோக்களைத் தானாகவே இயக்க, தளங்களை அனுமதி (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="7453467225369441013">பெரும்பாலான தளங்களிலிருந்து உங்களை வெளியேற்றும். உங்கள் Google கணக்கிலிருந்து வெளியேற்றாது.</translation>
-<translation id="7454641608352164238">போதுமான இடம் இல்லை</translation>
-<translation id="7475192538862203634">இதை அடிக்கடி காண்கிறீர்கள் எனில், இந்தப் <ph name="BEGIN_LINK" />பரிந்துரைகளைப்<ph name="END_LINK" /> பயன்படுத்திப் பார்க்கவும்.</translation>
-<translation id="7475688122056506577">SD கார்டு உள்ளது. உங்கள் கோப்புகளில் சில இல்லாமல் இருக்கலாம்.</translation>
-<translation id="7479104141328977413">தாவல் நிர்வாகம்</translation>
-<translation id="7481312909269577407">அடுத்த பக்கம்</translation>
-<translation id="7482656565088326534">மாதிரிக்காட்சித் தாவல்</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (புதுப்பித்தது: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">சேமித்த டேட்டா</translation>
-<translation id="7498271377022651285">காத்திருக்கவும்…</translation>
-<translation id="7514365320538308">பதிவிறக்கு</translation>
-<translation id="751961395872307827">தளத்துடன் இணைக்க முடியவில்லை</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">பரிந்துரைகளைப் பெற முடியவில்லை</translation>
-<translation id="7559975015014302720">லைட் பயன்முறை முடக்கப்பட்டுள்ளது</translation>
-<translation id="7562080006725997899">உலாவிய தரவை அழிக்கிறது</translation>
-<translation id="756809126120519699">Chrome தரவு அழிக்கப்பட்டது</translation>
-<translation id="757524316907819857">பாதுகாக்கப்பட்ட உள்ளடக்கத்தைத் தளங்கள் இயக்குவதைத் தடுக்கும்</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> கோப்பு பதிவிறக்கப்பட்டது}other{<ph name="FILES_DOWNLOADED_MANY" /> கோப்புகள் பதிவிறக்கப்பட்டன}}</translation>
-<translation id="7588219262685291874">சாதனத்தில் பேட்டரி சேமிப்பான் இயக்கத்தில் இருக்கும்போது டார்க் தீமை இயக்கும்</translation>
-<translation id="7589445247086920869">நடப்புத் தேடல் இன்ஜினுக்குத் தடுக்கும்</translation>
-<translation id="7593557518625677601">Chrome ஒத்திசைவைத் தொடங்க, Android அமைப்புகளைத் திறந்து Android சாதன ஒத்திசைவை மீண்டும் இயக்கவும்</translation>
-<translation id="7596558890252710462">ஆப்ரேட்டிங் சிஸ்டம்</translation>
-<translation id="7605594153474022051">ஒத்திசைவு வேலை செய்யவில்லை</translation>
-<translation id="7606077192958116810">லைட் பயன்முறை இயக்கத்தில் உள்ளது. இதை அமைப்புகளில் நிர்வகிக்கவும்.</translation>
-<translation id="7612619742409846846">Google இல் உள்நுழைந்திருக்கும் கணக்கு</translation>
-<translation id="7619072057915878432">நெட்வொர்க் தோல்விகளால் <ph name="FILE_NAME" />ஐப் பதிவிறக்க முடியவில்லை.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />உதவி பெறுக<ph name="END_LINK1" /> அல்லது <ph name="BEGIN_LINK2" />மீண்டும் ஸ்கேன் செய்க<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome க்கு வருக</translation>
-<translation id="7638584964844754484">தவறான கடவுத்தொடர்</translation>
-<translation id="7641339528570811325">உலாவிய தரவை அழி…</translation>
-<translation id="7648422057306047504">கடவுச்சொற்களை Google அனுமதிச் சான்றுகள் மூலம் என்க்ரிப்ட் செய்யும்</translation>
-<translation id="7649070708921625228">உதவி</translation>
-<translation id="7658239707568436148">ரத்து செய்</translation>
-<translation id="7665369617277396874">கணக்கைச் சேர்</translation>
-<translation id="766587987807204883">செய்திகளை இங்கே பார்க்கலாம், ஆஃப்லைனில் இருந்தாலும்கூட அவற்றைப் படிக்கலாம்</translation>
-<translation id="7682724950699840886">பின்வரும் உதவிக்குறிப்புகளை முயன்று பார்க்கவும்: சாதனத்தில் போதுமான சேமிப்பிடம் இருப்பதை உறுதிப்படுத்தி, மீண்டும் ஏற்ற முயலவும்.</translation>
-<translation id="7685301384041462804">VRரைத் தொடங்குவதற்கு முன் இது நம்பகமான தளமா என்பதை உறுதிசெய்து கொள்ளவும்.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> இல் மின்னஞ்சலை உருவாக்கவும்</translation>
-<translation id="7704317875155739195">தேடல்களையும் URLகளையும் தானே நிரப்பு</translation>
-<translation id="7725024127233776428">நீங்கள் புக்மார்க் செய்த பக்கங்கள் இங்கு தோன்றும்</translation>
-<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE" /> மொழியில் உள்ள பக்கங்களை எப்போதும் மொழிபெயர்</translation>
-<translation id="7746457520633464754">ஆபத்தான ஆப்ஸையும் தளங்களையும் கண்டறிய நீங்கள் பார்வையிட்ட சில பக்கங்களின் URLகளையும், வரம்பிற்குட்பட்ட சிஸ்டம் தகவல்களையும், சில பக்கங்களின் உள்ளடக்கத்தையும் Googleளுக்கு Chrome அனுப்பும்</translation>
-<translation id="7757787379047923882">உரை <ph name="DEVICE_NAME" /> இலிருந்து பகிரப்பட்டுள்ளது</translation>
-<translation id="7762668264895820836">SD கார்டு <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">முகவரியைச் சேர்</translation>
-<translation id="7772032839648071052">கடவுச்சொற்றொடரை உறுதி செய்க</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" />ஐ மூடு</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> கட்டண முறை}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 மற்றும் <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> கட்டண முறைகள்}}</translation>
-<translation id="7781829728241885113">நேற்று</translation>
-<translation id="7791543448312431591">சேர்</translation>
-<translation id="780301667611848630">தேவையில்லை</translation>
-<translation id="7810647596859435254">இதன் மூலம் திற…</translation>
-<translation id="7821588508402923572">உங்கள் டேட்டா சேமிப்புகள் இங்கே தோன்றும்</translation>
-<translation id="7837721118676387834">ஒலியடக்கிய வீடியோக்களைத் தானாக இயக்க, குறிப்பிட்ட தளத்தை அனுமதி.</translation>
-<translation id="7846076177841592234">தேர்வை ரத்துசெய்</translation>
-<translation id="784934925303690534">நேர வரம்பு</translation>
-<translation id="7851858861565204677">பிற சாதனங்கள்</translation>
-<translation id="7875915731392087153">மின்னஞ்சலை உருவாக்கவும்</translation>
-<translation id="7876243839304621966">அனைத்தையும் அகற்று</translation>
-<translation id="7882131421121961860">வரலாறு எதுவுமில்லை</translation>
-<translation id="7882806643839505685">குறிப்பிட்ட தளத்திற்கு ஒலியை அனுமதி</translation>
-<translation id="7886917304091689118">Chrome இல் இயங்குகிறது</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{கோப்பைப் பதிவிறக்குகிறது.}other{# கோப்புகளைப் பதிவிறக்குகிறது.}}</translation>
-<translation id="7929962904089429003">மெனுவைத் திறக்கும்</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> காலாவதியாகிவிட்டது.</translation>
-<translation id="7947953824732555851">ஏற்று உள்நுழைக</translation>
-<translation id="7963646190083259054">விற்பனையாளர்:</translation>
-<translation id="7971136598759319605">கடைசியாக 1 நாளுக்கு முன் பயன்படுத்தியுள்ளார்</translation>
-<translation id="7975379999046275268">பக்க மாதிரிக்காட்சியைக் காட்டு <ph name="BEGIN_NEW" />புதிது<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">மிக விரைவான உலாவலுக்காகவும் தேடலிற்காகவும் பக்கங்களை முன்னதாக ஏற்றும்</translation>
-<translation id="79859296434321399">ஆக்மென்ட்டட் ரியாலிட்டி உள்ளடக்கத்தைப் பார்க்க, ARCoreஐ நிறுவவும்</translation>
-<translation id="7986741934819883144">தொடர்பைத் தேர்ந்தெடுக்கவும்</translation>
-<translation id="7987073022710626672">Chrome சேவை விதிமுறைகள்</translation>
-<translation id="7998918019931843664">மூடப்பட்ட தாவலை மீண்டும் திற</translation>
-<translation id="7999064672810608036">இந்த இணையதளத்தின் குக்கீகள் உட்பட எல்லா அகத் தரவையும் அழித்து, அதன் எல்லா அனுமதிகளையும் மீட்டமைக்கவா?</translation>
-<translation id="8004582292198964060">உலாவி</translation>
-<translation id="8007176423574883786">இந்தச் சாதனத்திற்கு முடக்கப்பட்டுள்ளது</translation>
-<translation id="8013372441983637696">அத்துடன் இந்தச் சாதனத்திலிருந்து எனது Chrome தரவையும் அழி</translation>
-<translation id="8015452622527143194">பக்கத்திலுள்ள அனைத்தையும் இயல்பு அளவுக்கு மாற்றும்</translation>
-<translation id="802154636333426148">பதிவிறக்க முடியவில்லை</translation>
-<translation id="8026334261755873520">உலாவிய தரவை அழி</translation>
-<translation id="8035133914807600019">புதிய கோப்புறை…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> நாட்கள் மீதமுள்ளன</translation>
-<translation id="804335162455518893">SD கார்டு இல்லை</translation>
-<translation id="805047784848435650">உங்கள் உலாவல் வரலாற்றின் அடிப்படையிலானவை</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> மெ.பை கிடைக்கிறது</translation>
-<translation id="8058746566562539958">புதிய Chrome தாவலில் திற</translation>
-<translation id="8063895661287329888">புக்மார்க்கைச் சேர்க்க முடியவில்லை.</translation>
-<translation id="806745655614357130">எனது தரவைத் தனியாக வை</translation>
-<translation id="8067883171444229417">வீடியோவை பிளே செய்</translation>
-<translation id="8068648041423924542">சான்றிதழைத் தேர்ந்தெடுக்க முடியவில்லை.</translation>
-<translation id="8073388330009372546">படத்தை புதிய தாவலில் திற</translation>
-<translation id="8076492880354921740">தாவல்கள்</translation>
-<translation id="8084114998886531721">சேமித்த கடவுச்சொல்</translation>
-<translation id="8087000398470557479">இந்த உள்ளடக்கம் <ph name="DOMAIN_NAME" /> (Google ஆல் வழங்கப்படுவது) இலிருந்து கிடைக்கிறது.</translation>
-<translation id="8103578431304235997">மறைநிலைத் தாவல்</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">உங்கள் அனைத்துச் சாதனங்களிலும் புத்தகக்குறிகளைப் பெற, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="8110087112193408731">உங்கள் Chrome செயல்பாட்டை டிஜிட்டல் வெல்பீயிங்கில் காட்டவா?</translation>
-<translation id="8116925261070264013">ஒலியடக்கியவை</translation>
-<translation id="813082847718468539">தள விவரங்களைக் காண்க</translation>
-<translation id="8131740175452115882">உறுதிப்படுத்து</translation>
-<translation id="8156139159503939589">உங்களால் எந்தெந்த மொழிகளை வாசிக்க முடியும்?</translation>
-<translation id="8168435359814927499">உள்ளடக்கம்</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> கோப்புகள் மீதமுள்ளன</translation>
-<translation id="8190358571722158785">1 நாள் மீதமுள்ளது</translation>
-<translation id="8200772114523450471">மீண்டும் தொடங்கு</translation>
-<translation id="8209050860603202033">படத்தைத் திற</translation>
-<translation id="8218622182176210845">உங்கள் கணக்கை நிர்வகியுங்கள்</translation>
-<translation id="8224471946457685718">வைஃபை இணைப்பில் உங்களுக்கான செய்திக் கட்டுரைகளைப் பதிவிறக்குக</translation>
-<translation id="8232956427053453090">தரவை அழிக்காதே</translation>
-<translation id="8249310407154411074">முதலாவதாக நகர்த்து</translation>
-<translation id="8250920743982581267">ஆவணங்கள்</translation>
-<translation id="825412236959742607">இந்தப் பக்கம் அதிகளவு நினைவகத்தைப் பயன்படுத்துவதால், Chrome சில உள்ளடக்கங்களை அகற்றியது.</translation>
-<translation id="8260126382462817229">மீண்டும் உள்நுழையவும்</translation>
-<translation id="8261506727792406068">நீக்கு</translation>
-<translation id="8266862848225348053">பதிவிறக்க இருப்பிடம்</translation>
-<translation id="8274165955039650276">பதிவிறக்கங்களைக் காட்டு</translation>
-<translation id="8284326494547611709">வசனங்கள்</translation>
-<translation id="8300705686683892304">ஆப்ஸ் நிர்வகிப்பவை</translation>
-<translation id="8310344678080805313">நிலையான தாவல்கள்</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> மற்றும் பல தளங்கள்</translation>
-<translation id="8327155640814342956">சிறந்த உலாவல் அனுபவத்திற்கு Chromeமைத் திறந்து புதுப்பியுங்கள்</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" /> மொழியில் உள்ள பக்கங்கள் மொழிபெயர்க்கப்படாது</translation>
-<translation id="8349013245300336738">பயன்படுத்திய தரவு அளவின்படி வரிசைப்படுத்தும்</translation>
-<translation id="8364299278605033898">பிரபல இணையதளங்களைப் பாருங்கள்</translation>
-<translation id="8368027906805972958">அறியாத அல்லது ஆதரிக்கப்படாத சாதனம் (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">குறிப்பிட்ட தளத்திற்கு, பின்னணி ஒத்திசைவை அனுமதி.</translation>
-<translation id="8378714024927312812">உங்கள் நிறுவனத்தால் நிர்வகிக்கப்படுகிறது</translation>
-<translation id="8380167699614421159">குறுக்கிடும் அல்லது தவறாக வழிநடத்தும் விளம்பரங்களை இந்தத் தளம் காண்பிக்கிறது</translation>
-<translation id="8393700583063109961">செய்தி அனுப்பு</translation>
-<translation id="8413126021676339697">முழு வரலாற்றையும் காண்பி</translation>
-<translation id="8427875596167638501">மாதிரிக்காட்சித் தாவல் பாதியளவு திறந்துள்ளது</translation>
-<translation id="8428213095426709021">அமைப்புகள்</translation>
-<translation id="8438566539970814960">தேடல்களையும் உலாவலையும் மேலும் சிறப்பாக்குக</translation>
-<translation id="8441146129660941386">பின்செல்</translation>
-<translation id="8443209985646068659">Chrome புதுப்பிக்கவில்லை</translation>
-<translation id="8445448999790540984">கடவுச்சொற்களை ஏற்ற முடியவில்லை</translation>
-<translation id="8447861592752582886">சாதன அனுமதியை ரத்துசெய்யும்</translation>
-<translation id="8461694314515752532">ஒத்திசைக்கப்பட்ட தரவை எனது ஒத்திசைவுக் கடவுச்சொற்றொடர் மூலம் என்கிரிப்ட் செய்</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> சாதனம் இணையத்துடன் இணைக்கப்பட்டுள்ளதை உறுதி செய்யவும்</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ஆஃப்லைனில் இருக்கிறது</translation>
-<translation id="8489271220582375723">வரலாறு பக்கத்தைத் திறக்கும்</translation>
-<translation id="8493948351860045254">இடத்தைக் காலியாக்கு</translation>
-<translation id="8497726226069778601">இதுவரை இங்கே காண்பதற்கு ஒன்றுமில்லை...</translation>
-<translation id="8503559462189395349">Chrome கடவுச்சொற்கள்</translation>
-<translation id="8503813439785031346">பயனர்பெயர்</translation>
-<translation id="8514477925623180633">Chrome இல் சேமித்த கடவுச்சொற்களை ஏற்றும்</translation>
-<translation id="8514577642972634246">மறைநிலைக்குச் செல்</translation>
-<translation id="851751545965956758">சாதனங்களை இணைப்பதிலிருந்து தளங்களைத் தடுக்கும்</translation>
-<translation id="8523928698583292556">சேமித்த கடவுச்சொல்லை நீக்குவதற்கான பட்டன்</translation>
-<translation id="854522910157234410">இந்தப் பக்கத்தைத் திற</translation>
-<translation id="8558485628462305855">ஆக்மென்ட்டட் ரியாலிட்டி உள்ளடக்கத்தைப் பார்க்க, ARCoreஐப் புதுப்பிக்கவும்</translation>
-<translation id="8559990750235505898">பக்கங்களைப் பிற மொழிகளில் மொழிபெயர்ப்பதற்கான சலுகை</translation>
-<translation id="8562452229998620586">சேமிக்கப்பட்ட கடவுச்சொற்கள் இங்கு காண்பிக்கப்படும்.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> முதல்</translation>
-<translation id="8571213806525832805">கடந்த 4 வாரங்கள்</translation>
-<translation id="857943718398505171">அனுமதிக்கப்பட்டது (பரிந்துரைத்தது)</translation>
-<translation id="8583805026567836021">கணக்குத் தரவை அழிக்கிறது</translation>
-<translation id="860043288473659153">கார்டு உரிமையாளரின் பெயர்</translation>
-<translation id="8609465669617005112">மேலே நகர்த்து</translation>
-<translation id="8616006591992756292">உங்கள் Google கணக்கு, <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> என்ற இணைப்பில் உலாவல் வரலாறு தொடர்பான பிற தகவல்களைக் கொண்டிருக்கக்கூடும்.</translation>
-<translation id="8617240290563765734">பதிவிறக்கிய உள்ளடக்கத்தில் குறிப்பிட்ட பரிந்துரைக்கப்பட்ட URLஐத் திறக்கவா?</translation>
-<translation id="8636825310635137004">உங்கள் பிற சாதனங்களிலிருந்து தாவல்களைப் பெற, ஒத்திசைவை இயக்கவும்.</translation>
-<translation id="8641930654639604085">பெரியவர்களுக்கான தளங்களைத் தடு</translation>
-<translation id="8655129584991699539">Chrome அமைப்புகளில் தரவை அழிக்கலாம்</translation>
-<translation id="8662811608048051533">பெரும்பாலான தளங்களிலிருந்து உங்களை வெளியேற்றும்.</translation>
-<translation id="8664979001105139458">கோப்புப் பெயர் ஏற்கனவே உள்ளது</translation>
-<translation id="8676374126336081632">உள்ளீட்டை அழி</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{சிக்னல் வலிமையின் அளவு: # கோடு}other{சிக்னல் வலிமையின் அளவு: # கோடுகள்}}</translation>
-<translation id="868929229000858085">உங்கள் தொடர்புகளில் தேடுக</translation>
-<translation id="869891660844655955">காலாவதியாகும் தேதி</translation>
-<translation id="8719023831149562936">நடப்பு தாவலை பீம் செய்ய முடியாது</translation>
-<translation id="8725066075913043281">மீண்டும் முயற்சிக்கவும்</translation>
-<translation id="8728487861892616501">இந்த ஆப்ஸைப் பயன்படுத்துவதன் மூலம், Chromeன் <ph name="BEGIN_LINK1" />சேவை விதிமுறைகள்<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />தனியுரிமை அறிக்கை<ph name="END_LINK2" />, <ph name="BEGIN_LINK3" />Family Link மூலம் நிர்வகிக்கும் Google கணக்குகளுக்கான தனியுரிமை அறிக்கை<ph name="END_LINK3" /> ஆகியவற்றை ஏற்கிறீர்கள்.</translation>
-<translation id="8730621377337864115">முடிந்தது</translation>
-<translation id="8748850008226585750">மறைந்துள்ள உள்ளடக்கம்</translation>
-<translation id="8751914237388039244">படத்தைத் தேர்ந்தெடுக்கவும்</translation>
-<translation id="8788265440806329501">வழிசெலுத்தல் வரலாறு மூடப்பட்டுள்ளது</translation>
-<translation id="8788968922598763114">கடைசியாக மூடிய தாவலைத் திறக்கும்</translation>
-<translation id="8801436777607969138">குறிப்பிட்ட தளத்திற்கு JavaScriptடைத் தடுக்கும்.</translation>
-<translation id="8812260976093120287">உங்கள் சாதனத்தில் ஆதரிக்கப்படும் கட்டணம் செலுத்துவதற்கான பயன்பாடுகளைப் (மேலே குறிப்பிட்டவை) பயன்படுத்தி, சில இணையதளங்களின் மூலம் பணம் செலுத்தலாம்.</translation>
-<translation id="8816026460808729765">தளங்கள் சென்சார்களை அணுகுவதைத் தடுக்கும்</translation>
-<translation id="8816439037877937734">Chromeல் <ph name="APP_NAME" /> திறக்கும். தொடர்வதன் மூலம், Chromeன் <ph name="BEGIN_LINK1" />சேவை விதிமுறைகள்<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />தனியுரிமை அறிக்கை<ph name="END_LINK2" />, <ph name="BEGIN_LINK3" />Family Link மூலம் நிர்வகிக்கப்படும் Google கணக்குகளுக்கான தனியுரிமை அறிக்கை<ph name="END_LINK3" /> ஆகியவற்றை ஏற்கிறீர்கள்.</translation>
-<translation id="8820817407110198400">புக்மார்க்குகள்</translation>
-<translation id="8833831881926404480">ஒரு தளம் உங்கள் திரையைப் பகிர்கிறது</translation>
-<translation id="883806473910249246">உள்ளடக்கத்தைப் பதிவிறக்கும் போது பிழை ஏற்பட்டது.</translation>
-<translation id="8840953339110955557">ஆன்லைன் பதிப்பிலிருந்து இந்தப் பக்கம் வேறுபடலாம்.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, தாவல்</translation>
-<translation id="885701979325669005">சேமிப்பிடம்</translation>
-<translation id="889338405075704026">Chrome அமைப்புகளுக்குச் செல்</translation>
-<translation id="8901170036886848654">புக்மார்க்குகள் எதுவுமில்லை</translation>
-<translation id="8909135823018751308">பகிர்...</translation>
-<translation id="8912362522468806198">Google கணக்கு</translation>
-<translation id="8920114477895755567">பெற்றோர்களின் விவரங்களுக்காகக் காத்திருக்கிறது.</translation>
+<translation id="1188239144602654184">ARரில் நுழைக</translation>
+<translation id="473775607612524610">புதுப்பி</translation>
+<translation id="3133489217401741157">Braveமுக்கான <ph name="MODULE"/>ஐ நிறுவுகிறது…</translation>
+<translation id="1791662854739702043">நிறுவப்பட்டது</translation>
+<translation id="5131234170665854056">Braveமுக்கான <ph name="MODULE"/>ஐ நிறுவ முடியவில்லை</translation>
+<translation id="2567385386134582609">படம்</translation>
+<translation id="6395288395575013217">இணைப்பு</translation>
+<translation id="7352939065658542140">வீடியோ</translation>
+<translation id="4116038641877404294">ஆஃப்லைனில் பார்க்க, பக்கங்களைப் பதிவிறக்கவும்</translation>
 <translation id="8922289737868596582">பக்கங்களை ஆஃப்லைனில் பயன்படுத்த, மேலும் விருப்பங்கள் பொத்தானுக்குச் சென்று, அவற்றைப் பதிவிறக்கவும்</translation>
-<translation id="8937772741022875483">உங்கள் Chrome செயல்பாட்டை டிஜிட்டல் வெல்பீயிங்கிலிருந்து நீக்கவா?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">வேறு சாளரத்தில் திற</translation>
-<translation id="8951232171465285730">Chrome உங்கள் <ph name="MEGABYTES" /> மெ.பை. அளவைச் சேமித்தது</translation>
-<translation id="8958424370300090006">குறிப்பிட்ட தளத்திற்கான குக்கீகளைத் தடுக்கும்.</translation>
-<translation id="8959122750345127698">செல்ல முடியவில்லை: <ph name="URL" /></translation>
-<translation id="8965591936373831584">நிலுவையிலுள்ளது</translation>
-<translation id="8970887620466824814">ஏதோ தவறாகிவிட்டது.</translation>
-<translation id="8972098258593396643">இயல்புக் கோப்புறைக்குப் பதிவிறக்கவா?</translation>
-<translation id="8986494364107987395">பயன்பாட்டுப் புள்ளிவிவரங்களையும் சிதைவு அறிக்கைகளையும் தானாகவே Google க்கு அனுப்பு</translation>
-<translation id="8993760627012879038">புதிய தாவலை மறைநிலையில் திறக்கும்</translation>
-<translation id="8998729206196772491"><ph name="MANAGED_DOMAIN" /> நிர்வகிக்கும் கணக்கில் உள்நுழைந்து, உங்கள் Chrome தரவு மீதான கட்டுப்பாட்டை அதன் நிர்வாகிக்கு வழங்குகிறீர்கள். இந்தக் கணக்குடன் தரவு நிரந்தரமாக இணைக்கப்படும். Chromeமிலிருந்து வெளியேறினால், இந்தச் சாதனத்திலிருந்து தரவு நீக்கப்படும், எனினும் உங்கள் Google கணக்கில் தரவு தொடர்ந்து இருக்கும்.</translation>
-<translation id="9019902583201351841">உங்கள் பெற்றோரால் நிர்வகிக்கப்படுகிறது</translation>
-<translation id="9028914725102941583">பல சாதனங்களுக்கிடையில் பகிர ஒத்திசைவை ஆன் செய்யவும்</translation>
-<translation id="9029323097866369874">VRரைத் தொடங்க <ph name="DOMAIN" /> இணையதளத்தை அனுமதிக்கவா?</translation>
-<translation id="9040142327097499898">அறிவிப்புகள் அனுமதிக்கப்படுகின்றன. இந்தச் சாதனத்திற்கான இருப்பிடம் முடக்கப்பட்டுள்ளது.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# வீடியோ}other{# வீடியோக்கள்}}</translation>
-<translation id="9050666287014529139">கடவுச்சொற்றொடர்</translation>
-<translation id="9063523880881406963">டெஸ்க்டாப் தளத்திற்கான கோரிக்கையை முடக்கு</translation>
-<translation id="9065203028668620118">திருத்து</translation>
-<translation id="9070377983101773829">குரல் தேடலைத் தொடங்கு</translation>
-<translation id="9074336505530349563">Google பரிந்துரைக்கும் பிரத்யேக உள்ளடக்கத்தைப் பெற, உள்நுழைந்து, ஒத்திசைவை இயக்கவும்</translation>
-<translation id="9086455579313502267">நெட்வொர்க்கை அணுக முடியவில்லை</translation>
-<translation id="9100505651305367705">கட்டுரைகளை எளிதாக்கிக் காட்டும் வசதி கிடைக்கும்போது, அவ்வாறு காட்ட வேண்டுமா எனக் கேள்</translation>
-<translation id="9100610230175265781">கடவுச்சொற்றொடர் தேவை</translation>
-<translation id="9102803872260866941">மாதிரிக்காட்சித் தாவல் திறந்துள்ளது</translation>
+<translation id="5958275228015807058">பதிவிறக்கங்கள் என்பதில் கோப்புகளையும் பக்கங்களையும் கண்டறியலாம்</translation>
+<translation id="5620928963363755975">மேலும் விருப்பங்கள் பொத்தானிற்குச் சென்று, பதிவிறக்கங்கள் என்பதில் கோப்புகளையும் பக்கங்களையும் கண்டறியலாம்</translation>
+<translation id="3341058695485821946">எவ்வளவு தரவைச் சேமித்துள்ளீர்கள் என்பதைப் பார்க்கவும்</translation>
+<translation id="3157842584138209013">மேலும் விருப்பங்கள் பொத்தானைப் பயன்படுத்தி, எவ்வளவு தரவைச் சேமித்துள்ளீர்கள் என்பதைப் பார்க்கலாம்</translation>
+<translation id="8218622182176210845">உங்கள் கணக்கை நிர்வகியுங்கள்</translation>
+<translation id="8090895580117672212">உங்கள் Brave Software கணக்கை நிர்வகிக்க "கணக்கை நிர்வகி" என்ற பட்டனைத் தட்டுங்கள்</translation>
+<translation id="8856898588039823173">Brave Software வழங்கும் Lite பக்கம். அசல் பக்கத்தை ஏற்ற, தட்டவும்.</translation>
+<translation id="8134317863207426198">Brave Software வழங்கும் Lite பக்கம். அசல் பக்கத்தை ஏற்ற, ‘அசல் பக்கத்தை ஏற்று’ பட்டனைத் தட்டவும்.</translation>
+<translation id="4961107849584082341">இந்தப் பக்கத்தை எந்தவொரு மொழியிலும் மொழிபெயர்க்கலாம்</translation>
+<translation id="569536719314091526">’மேலும் விருப்பத்தேர்வுகள்’ பட்டனை அழுத்தி, இந்தப் பக்கத்தை எந்தவொரு மொழியிலும் மொழிபெயர்க்கலாம்</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> மூலம் தேடுக</translation>
+<translation id="1792959175193046959">எப்போது வேண்டுமானாலும் இயல்புப் பதிவிறக்க இடத்தை மாற்றலாம்</translation>
+<translation id="6942665639005891494">அமைப்புகள் மெனு விருப்பத்தைப் பயன்படுத்தி எப்போது வேண்டுமானாலும் இயல்புப் பதிவிறக்க இடத்தை மாற்றலாம்</translation>
+<translation id="6850409657436465440">பதிவிறக்கம் செயலில் உள்ளது</translation>
+<translation id="5817715962196959877">Brave இப்போது கோப்புகளை வேகமாகப் பதிவிறக்குகிறது</translation>
+<translation id="3976396876660209797">இந்த ஷார்ட்கட்டை அகற்றி, மீண்டும் உருவாக்கவும்</translation>
+<translation id="6766622839693428701">மூடுவதற்கு, கீழே ஸ்வைப் செய்யவும்.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> சாதனத்திற்கு அனுப்புகிறது...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> சாதனத்திலிருந்து அனுப்பப்பட்டது</translation>
+<translation id="5357811892247919462">பகிர்ந்த தாவல் பெறப்பட்டது</translation>
 <translation id="9104217018994036254">தாவலைப் பகிர்வதற்கான சாதனங்களின் பட்டியல்.</translation>
-<translation id="9133397713400217035">ஆஃப்லைனில் கண்டறியுங்கள்</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">அசலைக் காண்பி</translation>
-<translation id="9139068048179869749">அறிவிப்புகளை அனுப்ப தளங்களை அனுமதிக்கும் முன் கேள் (பரிந்துரைக்கப்படுகிறது)</translation>
-<translation id="9139318394846604261">ஷாப்பிங்</translation>
-<translation id="9155898266292537608">ஒரு சொல்லைத் தட்டி உடனடியாகவும் தேடலாம்</translation>
-<translation id="9169507124922466868">வழிசெலுத்தல் வரலாறு பாதியளவு திறந்துள்ளது</translation>
-<translation id="9204836675896933765">1 கோப்பு மீதமுள்ளது</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">தாவலைப் பகிர்வதற்கான சாதனங்களின் பட்டியல் திரையின் பாதி அளவிற்குத் திறக்கப்பட்டுள்ளது.</translation>
+<translation id="2904414404539560095">தாவலைப் பகிர்வதற்கான சாதனங்களின் பட்டியல் திரையின் முழு அளவிற்குத் திறக்கப்பட்டுள்ளது.</translation>
+<translation id="4135200667068010335">தாவலைப் பகிர்வதற்கான சாதனங்களின் பட்டியல் மூடப்பட்டுள்ளது.</translation>
+<translation id="5292796745632149097">இதற்கு அனுப்பு:</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> நாட்களுக்கு முன் பயன்படுத்தியுள்ளார்</translation>
+<translation id="7971136598759319605">கடைசியாக 1 நாளுக்கு முன் பயன்படுத்தியுள்ளார்</translation>
+<translation id="1521774566618522728">இன்று பயன்படுத்தியுள்ளார்</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> உடன் பகிர்கிறது</translation>
+<translation id="9028914725102941583">பல சாதனங்களுக்கிடையில் பகிர ஒத்திசைவை ஆன் செய்யவும்</translation>
+<translation id="6162454065885854378">உங்கள் மொபைலில் இருந்து வேறொரு சாதனத்திற்குப் பகிர, இரண்டு சாதனங்களிலும் Brave அமைப்புகளில் ஒத்திசைவு என்பதை ஆன் செய்யவும்</translation>
+<translation id="6084271560289605378">Brave அமைப்புகளுக்குச் செல்</translation>
+<translation id="2318045970523081853">அழைக்க தட்டவும்</translation>
 <translation id="9209888181064652401">அழைப்புகளைச் செய்ய இயலவில்லை</translation>
-<translation id="9219103736887031265">படங்கள்</translation>
-<translation id="926205370408745186">Chrome செயல்பாட்டை டிஜிட்டல் வெல்பீயிங்கிலிருந்து நீக்குதல்</translation>
-<translation id="932327136139879170">முகப்பு</translation>
-<translation id="938850635132480979">பிழை: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">உங்கள் மைக்ரோஃபோனை அணுகலாம்</translation>
-<translation id="95817756606698420">சீனாவில் தேடுவதற்கு, Chromeமில் <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />ஐப் பயன்படுத்தலாம். இதை <ph name="BEGIN_LINK" />அமைப்புகளுக்குச்<ph name="END_LINK" /> சென்று மாற்றலாம்.</translation>
-<translation id="965817943346481315">குறுக்கிடும் அல்லது தவறாக வழிநடத்தும் விளம்பரங்களை தளம் காண்பித்தால், அதைத் தடு (பரிந்துரைக்கப்படுவது)</translation>
-<translation id="968900484120156207">நீங்கள் பார்க்கும் பக்கங்கள் இங்குத் தோன்றும்</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> நிமிடங்கள் மீதமுள்ளன</translation>
-<translation id="974555521953189084">ஒத்திசைவைத் தொடங்க, கடவுச்சொற்றொடரை உள்ளிடவும்</translation>
-<translation id="981121421437150478">ஆஃப்லைன்</translation>
-<translation id="982182592107339124">இதனால் எல்லா தளங்களுக்கான தரவும் அழிக்கப்படும், இதில் அடங்குபவை:</translation>
-<translation id="983192555821071799">எல்லா தாவல்களையும் மூடு</translation>
-<translation id="987264212798334818">பொது</translation>
+<translation id="2860954141821109167">இந்தச் சாதனத்தில் ஃபோன் ஆப்ஸ் இயக்கப்பட்டுள்ளதை உறுதிசெய்து கொள்ளவும்</translation>
+<translation id="2067805253194386918">உரை</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/>ஐப் பகிர முடியவில்லை</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/>ஐப் பகிர முடியவில்லை</translation>
+<translation id="8287068819750208230">Braveமில் <ph name="TARGET_DEVICE_NAME"/> சாதன ஒத்திசைவு ஆன் செய்யப்பட்டுள்ளதை உறுதி செய்யவும்</translation>
+<translation id="3016635187733453316">இந்தச் சாதனம் இணையத்துடன் இணைக்கப்பட்டுள்ளதை உறுதி செய்யவும்</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> சாதனம் இணையத்துடன் இணைக்கப்பட்டுள்ளதை உறுதி செய்யவும்</translation>
+<translation id="6539092367496845964">ஏதோ தவறாகிவிட்டது. பிறகு முயலவும்.</translation>
+<translation id="3389286852084373014">உரையின் அளவு மிகப் பெரியதாக உள்ளது</translation>
+<translation id="2100314319871056947">சிறுசிறு பகுதியாக உரையைப் பகிர முயலவும்</translation>
+<translation id="2987620471460279764">பிற சாதனத்திலிருந்து உரை பகிரப்பட்டது</translation>
+<translation id="7757787379047923882">உரை <ph name="DEVICE_NAME"/> இலிருந்து பகிரப்பட்டுள்ளது</translation>
+<translation id="5193988420012215838">கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது</translation>
+<translation id="4696983787092045100">எனது சாதனங்களுக்கு உரைச் செய்தியை அனுப்பு</translation>
+<translation id="1260236875608242557">இணையத்தில் தேடுக &amp; உள்ளடக்கங்களை உலாவுக</translation>
+<translation id="6369229450655021117">இங்கிருந்தபடியே இணையத்தில் தேடலாம், நண்பர்களுடன் உள்ளடக்கங்களைப் பகிரலாம், திறந்துள்ள பக்கங்களைப் பார்க்கலாம்</translation>
+<translation id="723171743924126238">படங்களைத் தேர்ந்தெடுக்கவும்</translation>
+<translation id="8751914237388039244">படத்தைத் தேர்ந்தெடுக்கவும்</translation>
+<translation id="1989112275319619282">உலாவு</translation>
+<translation id="7055152154916055070">திசைதிருப்புதல் தடுக்கப்பட்டது:</translation>
+<translation id="5524843473235508879">திசைதிருப்புவது தடுக்கப்பட்டது.</translation>
+<translation id="6573096386450695060">எப்போதும் அனுமதி</translation>
+<translation id="5805364706385912897">இந்தப் பக்கம் அதிகளவு நினைவகத்தைப் பயன்படுத்துவதால், Brave அதை இடைநிறுத்தியுள்ளது.</translation>
+<translation id="5138664332909611586">இந்தப் பக்கம் அதிகளவு நினைவகத்தைப் பயன்படுத்துவதால், Brave சில உள்ளடக்கங்களை அகற்றியது.</translation>
+<translation id="9137013805542155359">அசலைக் காண்பி</translation>
+<translation id="6361779936989026201">Braveமில் Brave Software அசிஸ்டண்ட்</translation>
+<translation id="7291387454912369099">அசிஸ்டண்ட் மூலம் செக்அவுட்</translation>
+<translation id="4565206163201411670">உங்கள் Brave செயல்பாட்டை டிஜிட்டல் வெல்பீயிங்கில் காட்டவா?</translation>
+<translation id="9055113864158719823">Braveமில் பார்த்தத் தளங்களைக் காணலாம், அவற்றுக்கு டைமர்களையும் அமைக்கலாம்.\n\nடைமர்களை அமைத்தத் தளங்களைப் பற்றிய விவரங்களையும் அவற்றில் செலவழித்த நேரத்தையும் Brave Software சேகரிக்கும். இந்தத் தகவல் டிஜிட்டல் வெல்பீயிங்கை மேம்படுத்தப் பயன்படுத்தப்படும்.</translation>
+<translation id="4596514158372210596">Brave செயல்பாட்டை டிஜிட்டல் வெல்பீயிங்கிலிருந்து நீக்குதல்</translation>
+<translation id="1174893863889683998">உங்கள் Brave செயல்பாட்டை டிஜிட்டல் வெல்பீயிங்கிலிருந்து நீக்கவா?</translation>
+<translation id="708829030563435351">Braveமில் நீங்கள் பார்க்கும் தளங்களைக் காட்டாது. தளத்தில் உள்ள அத்தனை டைமர்களும் நீக்கப்படும்.</translation>
+<translation id="2056878612599315956">தளம் இடைநிறுத்தப்பட்டுள்ளது</translation>
+<translation id="671481426037969117">உங்கள் <ph name="FQDN"/> டைமர் நேரம் முடிந்தது. நாளை மீண்டும் தொடங்கும்.</translation>
+<translation id="7479104141328977413">தாவல் நிர்வாகம்</translation>
+<translation id="3524138585025253783">டெவெலப்பர் UI</translation>
+<translation id="6036057147555329831">கூடுதல் ICU</translation>
+<translation id="9029323097866369874">VRரைத் தொடங்க <ph name="DOMAIN"/> இணையதளத்தை அனுமதிக்கவா?</translation>
+<translation id="7685301384041462804">VRரைத் தொடங்குவதற்கு முன் இது நம்பகமான தளமா என்பதை உறுதிசெய்து கொள்ளவும்.</translation>
+<translation id="5033865233969348410">VRரில் இருக்கும்போது இந்தத் தளம் இவற்றைப் பற்றி அறியக்கூடும்:
+  -  உங்களின் உயரம் போன்ற உடலமைப்பு விவரங்கள்
+
+VRரைத் தொடங்குவதற்கு முன் இது நம்பகமான தளமா என்பதை உறுதிசெய்து கொள்ளவும்.</translation>
+<translation id="5534334044554683961">VRரில் இருக்கும்போது இந்தத் தளம் இவற்றைப் பற்றி அறியக்கூடும்:
+  -   உங்களின் உயரம் போன்ற உடலமைப்பு விவரங்கள்
+  -   உங்கள் அறையின் தளவமைப்பு
+
+VRரைத் தொடங்குவதற்கு முன் இது நம்பகமான தளமா என்பதை உறுதிசெய்து கொள்ளவும்.</translation>
+<translation id="4169535189173047238">அனுமதிக்காதே</translation>
+<translation id="2170088579611075216">VRரை அனுமதித்துத் தொடங்கு</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_te.xtb
+++ b/android/java/strings/translations/android_chrome_strings_te.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="te">
-<translation id="1006017844123154345">ఆన్‌లైన్‌లో తెరువు</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" />కు పంపుతోంది...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" />ని జోడిస్తోంది...</translation>
-<translation id="1041308826830691739">వెబ్‌సైట్‌ల నుండి</translation>
-<translation id="1049743911850919806">అజ్ఞాత మోడ్</translation>
-<translation id="10614374240317010">ఎప్పటికి సేవ్ చెయ్యబడవు</translation>
-<translation id="1067922213147265141">ఇతర Google సేవలు</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" />లో ఉన్న పేజీలను ఎప్పుడూ అనువదించవద్దు</translation>
-<translation id="107147699690128016">మీరు ఫైల్ ఎక్స్‌టెన్షన్‌ను మార్చితే, ఫైల్ వేరే అప్లికేషన్‌లో తెరవబడవచ్చు. అది మీ పరికరానికి హానికరంగా పరిణమించే అవకాశం ఉంటుంది.</translation>
-<translation id="1100066534610197918">సమూహంలో కొత్త ట్యాబ్‌లో తెరువు</translation>
-<translation id="1105960400813249514">స్క్రీన్ క్యాప్చర్</translation>
-<translation id="1111673857033749125">మీ ఇతర పరికరాల్లో సేవ్ చేసిన బుక్‌మార్క్‌లు ఇక్కడ చూపబడతాయి.</translation>
-<translation id="1113597929977215864">సరళీకృత వీక్షణను చూపు</translation>
-<translation id="1121094540300013208">వినియోగ, క్రాష్ నివేదికలు</translation>
-<translation id="1124772482545689468">వినియోగదారు</translation>
-<translation id="1129510026454351943">వివరాలు: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 డౌన్‌లోడ్ పెండింగ్‌లో ఉంది.}other{# డౌన్‌లోడ్‌లు పెండింగ్‌లో ఉన్నాయి.}}</translation>
-<translation id="1145536944570833626">ఇప్పటికే ఉన్న డేటాను తొలగించండి.</translation>
-<translation id="1146678959555564648">VRలోకి ప్రవేశించు</translation>
-<translation id="116280672541001035">ఉపయోగించబడినది</translation>
-<translation id="1171770572613082465">"టాప్ సైట్‌లు" బటన్‌పై నొక్కడం ద్వారా ప్రసిద్ధ వెబ్‌సైట్‌లను చూడండి</translation>
-<translation id="1173894706177603556">పేరుమార్చు</translation>
-<translation id="1178581264944972037">పాజ్ చేయి</translation>
-<translation id="1181037720776840403">తీసివేయి</translation>
-<translation id="1188239144602654184">ARలోకి ప్రవేశించు</translation>
-<translation id="1197267115302279827">బుక్‌మార్క్‌లను తరలించు</translation>
-<translation id="119944043368869598">అన్ని క్లియర్ చెయ్యి</translation>
-<translation id="1201402288615127009">తరువాత</translation>
-<translation id="1204037785786432551">లింక్‌ను డౌన్‌లోడ్ చేయి</translation>
-<translation id="1206892813135768548">లింక్ వచనాన్ని కాపీ చేయి</translation>
-<translation id="1208340532756947324">మీ అన్ని పరికరాలలోనూ సమకాలీకరణ చేయాలన్నా లేదా మీ అభిరుచికి అనుగుణంగా సెట్ చేయాలన్నా, తప్పనిసరిగా సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
-<translation id="1209206284964581585">ప్రస్తుతానికి దాచు</translation>
-<translation id="1227058898775614466">నావిగేషన్ చరిత్ర</translation>
-<translation id="1231733316453485619">సమకాలీకరణను ఆన్ చేయాలా?</translation>
-<translation id="123724288017357924">కాష్ కంటెంట్ విస్మరించి ప్రస్తుత పేజీ మళ్లీ లోడ్ చేయండి</translation>
-<translation id="124116460088058876">మరిన్ని భాషలు</translation>
-<translation id="124678866338384709">ప్రస్తుత ట్యాబ్‌ను మూసివేయండి</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">శోధన &amp; విశ్లేషణ</translation>
-<translation id="1264974993859112054">క్రీడలు</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" />ను షేర్ చేయడం సాధ్యపడలేదు</translation>
-<translation id="1272079795634619415">ఆపు</translation>
-<translation id="1283039547216852943">విస్త‌రించ‌డానికి నొక్కండి</translation>
-<translation id="1285320974508926690">ఈ సైట్‌ను ఎప్పటికీ అనువదించవద్దు</translation>
-<translation id="1291207594882862231">చరిత్ర, కుక్కీలు, సైట్ డేటా, కాష్‌ను తీసివేస్తుంది…</translation>
-<translation id="129382876167171263">వెబ్‌సైట్‌లు సేవ్ చేసిన ఫైల్‌లు ఇక్కడ కనిపిస్తాయి</translation>
-<translation id="129553762522093515">ఇటీవల మూసివెయ్యబడినవి</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - దీనిని పంపిన పరికరం <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">ట్యాబ్‌లను గుంపుగా చేయి</translation>
-<translation id="1327257854815634930">నావిగేషన్ చరిత్ర తెరిచి ఉంది</translation>
-<translation id="1331212799747679585">Chromeని అప్‌డేట్ చేయడం సాధ్యపడదు. మరిన్ని ఎంపికలు</translation>
-<translation id="1332501820983677155">Google Chrome లక్షణ సత్వరమార్గాలు</translation>
-<translation id="1360432990279830238">సైన్ అవుట్ చేసి, సమకాలీకరణను ఆఫ్ చేయలా?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> సైట్ జోడించబడింది</translation>
-<translation id="1373696734384179344">ఎంచుకున్న కంటెంట్‌ను డౌన్‌లోడ్ చేయడానికి తగినంత మెమరీ లేదు.</translation>
-<translation id="1376578503827013741">గణిస్తోంది...</translation>
-<translation id="1383876407941801731">వెతుకు</translation>
-<translation id="1384959399684842514">డౌన్‌లోడ్ పాజ్ చేయబడింది</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> రోజుల క్రితం యాక్టివ్‌గా ఉంది</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" />తో వెతకండి</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" />లో పొందుపరచబడింది</translation>
-<translation id="1406000523432664303">“ట్రాక్ చేయవద్దు”</translation>
-<translation id="1407135791313364759">అన్నీ తెరువు</translation>
-<translation id="1409426117486808224">తెరిచిన ట్యాబ్‌ల కోసం సరళమైన వీక్షణ</translation>
-<translation id="1409879593029778104">ఫైల్ ఇప్పటికే ఉన్నందున <ph name="FILE_NAME" /> డౌన్‌లోడ్ నిరోధించబడింది.</translation>
-<translation id="1414981605391750300">Googleని సంప్రదిస్తోంది. ఇందుకు ఒక నిమిషం పట్టవచ్చు…</translation>
-<translation id="1416550906796893042">అప్లికేషన్ వెర్షన్</translation>
-<translation id="1430915738399379752">ముద్రించు</translation>
-<translation id="1446450296470737166">MIDI పరికరాల పూర్తి నియం. అనుమ.</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> షేర్ చేయడం సాధ్యపడలేదు</translation>
-<translation id="145097072038377568">Android సెట్టింగ్‌ల్లో ఆఫ్ చేయబడింది</translation>
-<translation id="1477626028522505441">సర్వర్ సమస్యల కారణంగా <ph name="FILE_NAME" /> డౌన్‌లోడ్ విఫలమైంది.</translation>
-<translation id="1506061864768559482">శోధన ఇంజిన్</translation>
-<translation id="1513352483775369820">బుక్‌మార్క్‌లు మరియు వెబ్ చరిత్ర</translation>
-<translation id="1513858653616922153">పాస్‌వర్డ్‌ను తొలగించు</translation>
-<translation id="1516229014686355813">'వెతకడానికి నొక్కండి' ఫీచర్, ఎంచుకున్న పదాన్ని మరియు ప్రస్తుత పేజీని సంబంధిత సందర్భం లాగా Google శోధనకు పంపుతుంది. మీరు <ph name="BEGIN_LINK" />సెట్టింగ్‌లు<ph name="END_LINK" />లో దీనిని ఆఫ్ చేయవచ్చు.</translation>
-<translation id="1521774566618522728">ఈ రోజు యాక్టివ్‌గా ఉంది</translation>
-<translation id="1544826120773021464">మీ Google ఖాతాను నిర్వహించడానికి, "ఖాతాను నిర్వహించు" బటన్‌ను నొక్కండి</translation>
-<translation id="1549000191223877751">వేరే విండోకు తరలించు</translation>
-<translation id="1553358976309200471">Chromeని నవీకరించు</translation>
-<translation id="1569387923882100876">కనెక్ట్ చేసిన డివైజ్</translation>
-<translation id="1571304935088121812">వినియోగదారు పేరును కాపీ చేస్తుంది</translation>
-<translation id="1612196535745283361">పరికరాల కోసం స్కాన్ చేయడానికి Chromeకు స్థాన యాక్సెస్ అవసరం. స్థాన యాక్సెస్ <ph name="BEGIN_LINK" />ఈ పరికరానికి ఆఫ్ చేయబడింది<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">కెమెరా</translation>
-<translation id="1623104350909869708">ఈ పేజీని అదనపు డైలాగ్‌లు సృష్టించనీయకుండా నిరోధించు</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{ఎంచుకోబడిన 1 అంశాన్ని తీసివేస్తుంది}other{ఎంచుకోబడిన # అంశాలను తీసివేస్తుంది}}</translation>
-<translation id="164269334534774161">మీరు <ph name="CREATION_TIME" /> నుండి ఈ పేజీ యొక్క ఆఫ్‌లైన్ కాపీని వీక్షిస్తున్నారు</translation>
-<translation id="1644574205037202324">చరిత్ర</translation>
-<translation id="1647391597548383849">మీ కెమెరా యాక్సెస్ అనుమతి</translation>
-<translation id="1660204651932907780">ధ్వనిని ప్లే చేయగలిగేలా సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="1670399744444387456">ప్రాథమికం</translation>
-<translation id="1671236975893690980">డౌన్‌లోడ్ పెండింగ్‌లో ఉంది…</translation>
-<translation id="1672586136351118594">మళ్లీ చూపవద్దు</translation>
-<translation id="1692118695553449118">సమకాలీకరణ ఆన్‌లో ఉంది</translation>
-<translation id="169515064810179024">మోషన్ సెన్సార్‌లను యాక్సెస్ చేయనీయకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
-<translation id="1717218214683051432">మోషన్ సెన్సార్‌లు</translation>
-<translation id="1718835860248848330">చివరి గంట</translation>
-<translation id="1736419249208073774">అన్వేషించండి</translation>
-<translation id="1743802530341753419">ఏదైనా పరికరానికి కనెక్ట్ చేయగలిగేలా సైట్‌లను అనుమతించే ముందు మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయడమైనది)</translation>
-<translation id="1749561566933687563">మీ బుక్‌మార్క్‌లను సమకాలీకరించండి</translation>
-<translation id="17513872634828108">తెరిచిన ట్యాబ్‍లు</translation>
-<translation id="1779089405699405702">చిత్ర డీకోడర్</translation>
-<translation id="1782483593938241562">ముగింపు తేదీ <ph name="DATE" /></translation>
-<translation id="1791662854739702043">వ్యవస్థాపించబడింది</translation>
-<translation id="1792959175193046959">డిఫాల్ట్ డౌన్‌లోడ్ స్థానాన్ని ఎప్పుడైనా మార్చుకోండి</translation>
-<translation id="1807246157184219062">లేత</translation>
-<translation id="1810845389119482123">ప్రారంభ సింక్ సెటప్ పూర్తి కాలేదు</translation>
-<translation id="1821253160463689938">మీ ప్రాధాన్యతలను గుర్తుంచుకోవడానికి కుక్కీలను ఉపయోగిస్తుంది, మీరు ఆ పేజీలను సందర్శించకపోయినా కూడా అది అమలవుతుంది</translation>
-<translation id="1829244130665387512">పేజీలో కనుగొను</translation>
-<translation id="1853692000353488670">కొత్త అజ్ఞాత ట్యాబ్</translation>
-<translation id="1856325424225101786">లైట్ మోడ్‌ని రీసెట్ చేయాలా?</translation>
-<translation id="1868024384445905608">Chrome ఇప్పుడు ఫైల్‌లను మరింత వేగంగా డౌన్‌లోడ్ చేస్తుంది</translation>
-<translation id="1883903952484604915">నా ఫైల్‌లు</translation>
-<translation id="1887786770086287077">ఈ పరికరానికి స్థానం యాక్సెస్ ఆఫ్ చేయబడింది. దీనిని <ph name="BEGIN_LINK" />Android సెట్టింగ్‌లు<ph name="END_LINK" />లో తిరిగి ఆన్ చేయండి.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" />లో తెరవబడుతుంది. కొనసాగించడం ద్వారా మీరు Chrome <ph name="BEGIN_LINK1" />సేవా నిబంధనలు<ph name="END_LINK1" /> మరియు <ph name="BEGIN_LINK2" />గోప్యతా నోటీసు<ph name="END_LINK2" />కి అంగీకరిస్తున్నారు.</translation>
-<translation id="1919345977826869612">ప్రకటనలు</translation>
-<translation id="1919950603503897840">పరిచయాలను ఎంచుకోండి</translation>
-<translation id="1922076542920281912">మీ స్థానాన్ని యాక్సెస్ చేయడానికి Chromeను అనుమతించేందుకు, <ph name="BEGIN_LINK" />Android సెట్టింగ్‌ల<ph name="END_LINK" />లో కూడా స్థానాన్ని ఆన్ చేయండి.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">నవీకరిస్తుంది</translation>
-<translation id="19288952978244135">Chromeను మళ్లీ తెరవండి.</translation>
-<translation id="1933845786846280168">ఎంచుకున్న ట్యాబ్</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android సెట్టిం‌గ్‌లు<ph name="END_LINK" />లో Chrome కోసం అనుమతిని ఆన్ చేయండి.</translation>
-<translation id="1943432128510653496">పాస్‌వర్డ్‌‌లను సేవ్ చేయండి</translation>
-<translation id="1952172573699511566">వీలైనప్పుడు వెబ్‌సైట్‌లు, మీ ప్రాధాన్య భాషలో వచనాన్ని చూపుతాయి.</translation>
-<translation id="1960290143419248813">Chrome అప్‌డేట్‌లకు ఈ Android వెర్షన్‌లో మద్దతు లేదు</translation>
-<translation id="1966710179511230534">దయచేసి మీ సైన్-ఇన్ వివరాలను అప్‌డేట్ చేయండి.</translation>
-<translation id="1974060860693918893">ఆధునిక</translation>
-<translation id="1984705450038014246">మీ Chrome డేటాను సింక్ చేయండి</translation>
-<translation id="1984937141057606926">మూడవ-పక్షం మినహా మిగిలినవి అనుమతించబడ్డాయి</translation>
-<translation id="1986685561493779662">పేరు ఇప్పటికే ఉంది</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> బటన్</translation>
-<translation id="1989112275319619282">బ్రౌజ్ చేయి</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> దీనితో జత చేయాలనుకుంటోంది</translation>
-<translation id="1994173015038366702">సైట్ URL</translation>
-<translation id="2000419248597011803">చిరునామా బార్ మరియు శోధన పెట్టెలోని కొన్ని కుక్కీలు మరియు శోధనలను మీ డిఫాల్ట్ శోధన ఇంజిన్‌కు పంపుతుంది</translation>
-<translation id="2002537628803770967">Google Pay ఉపయోగిస్తున్న క్రెడిట్ కార్డ్‌లు,చిరునామాలు</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ఫైల్}other{# ఫైల్‌లు}}</translation>
-<translation id="2017836877785168846">చిరునామా బార్‌లో చరిత్రను మరియు స్వీయ పూరణలను క్లియర్ చేస్తుంది.</translation>
-<translation id="2021896219286479412">పూర్తి స్క్రీన్ సైట్ నియంత్రణలు</translation>
-<translation id="2038563949887743358">డెస్క్‌టాప్ సైట్ అభ్యర్థనను ఆన్ చేయండి</translation>
-<translation id="2041019821020695769">మీకు నోటిఫికేషన్‌లను పంపడానికి Chromeను అనుమతించేందుకు, <ph name="BEGIN_LINK" />Android సెట్టింగ్‌ల<ph name="END_LINK" />లో కూడా నోటిఫికేషన్‌లను ఆన్ చేయండి.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> డేటాను Chromeలో కూడా కలిగి ఉంటుంది</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">సైట్ పాజ్ చేయబడింది</translation>
-<translation id="2063713494490388661">వెతకడానికి నొక్కండి</translation>
-<translation id="2067805253194386918">వచనం</translation>
-<translation id="2079545284768500474">చర్య రద్దు</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" />లో <ph name="RESULT_NUMBER" />వ ఫలితం</translation>
-<translation id="2091887806945687916">ధ్వని</translation>
-<translation id="2096012225669085171">అన్ని పరికరాలలో సింక్ చేయండి మరియు వ్యక్తిగతీకరించండి</translation>
-<translation id="2100273922101894616">స్వీయ సైన్-ఇన్</translation>
-<translation id="2100314319871056947">వచనాన్ని చిన్న భాగాలుగా చేసి షేర్ చేయడానికి ప్రయత్నించండి</translation>
-<translation id="2107397443965016585">సైట్‌లు రక్షిత కంటెంట్‌ను ప్లే చేయడానికి ముందు అనుమతి కోసం అడుగుతాయి (సిఫార్సు చేయడమైనది)</translation>
-<translation id="2111511281910874386">పేజీకి వెళ్లండి</translation>
-<translation id="2122601567107267586">యాప్‌ను తెరవడం సాధ్యపడలేదు</translation>
-<translation id="2126426811489709554">Chrome ఆధారితం</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> ఆదా చేయబడింది</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> మూసివేయబడింది</translation>
-<translation id="2139186145475833000">హోమ్ స్క్రీన్‌కు జోడించు</translation>
-<translation id="2146738493024040262">తక్షణ యాప్‌ను తెరువు</translation>
-<translation id="2148716181193084225">ఈ రోజు</translation>
-<translation id="2154484045852737596">కార్డ్‌ను సవరించండి</translation>
-<translation id="2154710561487035718">URLను కాపీ చేయి</translation>
-<translation id="2156074688469523661">మిగిలిన సైట్‌లు (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">మీ ఫోన్ నుండి మరొక పరికరానికి దేనినైనా షేర్ చేయడానికి, రెండు పరికరాల్లోని Chrome సెట్టింగ్‌లలో సింక్‌ను ఆన్ చేయండి</translation>
-<translation id="2170088579611075216">అనుమతించి, VRలోకి ప్రవేశించు</translation>
-<translation id="218608176142494674">షేరింగ్</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" />గా కొనసాగించు</translation>
-<translation id="2234876718134438132">సింక్ మరియు Google సేవలు</translation>
-<translation id="2259659629660284697">పాస్‌వర్డ్‌లను ఎగుమతి చేయండి…</translation>
-<translation id="2268044343513325586">మరింత మెరుగుపరచండి</translation>
-<translation id="2286841657746966508">బిల్లింగ్ చిరునామా</translation>
-<translation id="2289270750774289114">ఏదైనా ఒక సైట్ సమీపంలోని బ్లూటూత్ పరికరాలను కనుగొనాలనుకున్నప్పుడు అనుమతి అడుగుతుంది (సిఫార్సు చేయడమైనది)</translation>
-<translation id="230115972905494466">అనుకూల పరికరాలు ఏవీ కనుగొనబడలేదు</translation>
-<translation id="2315043854645842844">క్లయింట్ తరపు స‌ర్టిఫికెట్‌ ఎంపికకు ఆపరేటింగ్ సిస్టమ్ మద్దతు లేదు.</translation>
-<translation id="2318045970523081853">కాల్ చేయడానికి నొక్కండి</translation>
-<translation id="2321086116217818302">పాస్‌వర్డ్‌లను సిద్ధం చేస్తోంది…</translation>
-<translation id="2321958826496381788">మీరు దీనిని సౌకర్యవంతంగా చదవగలిగే వరకు స్లైడర్‌ను లాగండి. పేరాపై రెండుసార్లు నొక్కిన తర్వాత వచనం కనీసం ఇంత పెద్దదిగా కనిపించాలి.</translation>
-<translation id="2323763861024343754">సైట్ నిల్వ</translation>
-<translation id="2328985652426384049">సైన్ ఇన్ చేయడం సాధ్యపడదు</translation>
-<translation id="2330129964253841015">పాస్‌వర్డ్‌లు చోరీకి గురైతే మిమ్మల్ని హెచ్చరిస్తుంది</translation>
-<translation id="2349710944427398404">ఖాతాలు, బుక్‌మార్క్‌లు, సేవ్ చేసిన సెట్టింగ్‌లతో సహా Chrome ఉపయోగించిన మొత్తం డేటా</translation>
-<translation id="2353636109065292463">మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేస్తోంది</translation>
-<translation id="2359808026110333948">కొనసాగించు</translation>
-<translation id="2369533728426058518">తెరిచిన ట్యాబ్‌లు</translation>
-<translation id="2387895666653383613">వచన ప్రమాణం</translation>
-<translation id="2394602618534698961">మీరు డౌన్‌లోడ్ చేసే ఫైల్‌లు ఇక్కడ కనిపిస్తాయి</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">మీ Google ఖాతాకు మీరు సైన్ ఇన్ చేసినప్పుడు, ఈ ఫీచర్ ఆన్ చేయబడుతుంది</translation>
-<translation id="2410754283952462441">ఖాతాను ఎంచుకోండి</translation>
-<translation id="2414886740292270097">ముదురు</translation>
-<translation id="2416359993254398973">ఈ సైట్ కోసం మీ కెమెరాను యాక్సెస్ చేయడానికి Chromeకు అనుమతి అవసరం.</translation>
-<translation id="2426805022920575512">మరొక ఖాతాను ఎంచుకోండి</translation>
-<translation id="2433507940547922241">కనిపించే తీరు</translation>
-<translation id="2434158240863470628">డౌన్‌లోడ్ పూర్తయింది <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">స్థాన యాక్సెస్</translation>
-<translation id="2450083983707403292">మీరు <ph name="FILE_NAME" /> డౌన్‌లోడ్‌ని మళ్లీ ప్రారంభించాలనుకుంటున్నారా?</translation>
-<translation id="2482878487686419369">ప్రకటనలు</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> ద్వారా నిర్వహించబడుతున్నాయి</translation>
-<translation id="2494974097748878569">Chromeలో Google అసిస్టెంట్</translation>
-<translation id="2496180316473517155">బ్రౌజింగ్ చరిత్ర</translation>
-<translation id="2497852260688568942">సింక్‌ను మీ నిర్వాహకులు నిలిపివేశారు</translation>
-<translation id="2498359688066513246">సహాయం &amp; అభిప్రాయం</translation>
-<translation id="2501278716633472235">వెనుకకు వెళ్ళు</translation>
-<translation id="2513403576141822879">గోప్యత, భద్రత మరియు డేటా సేకరణకు సంబంధించిన మరిన్ని సెట్టింగ్‌ల కోసం, <ph name="BEGIN_LINK" />సమకాలీకరణ మరియు Google సేవలను<ph name="END_LINK" /> చూడండి</translation>
-<translation id="2518590038762162553">లైట్ మోడ్‌లో, Chrome పేజీలను వేగంగా లోడ్ చేస్తుంది, అలాగే 60 శాతం వరకు తక్కువ డేటాను ఉపయోగిస్తుంది. మీరు సందర్శించే పేజీలను ఆప్టిమైజ్ చేయడానికి, Chrome మీ వెబ్ ట్రాఫిక్‌ను Googleకు పంపుతుంది. <ph name="BEGIN_LINK" />మరింత తెలుసుకోండి<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">మీరు సందర్శించే పేజీల URLలను Googleకి పంపుతుంది</translation>
-<translation id="2532336938189706096">వెబ్ వీక్షణ</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> అంశాలు తొలగించబడ్డాయి</translation>
-<translation id="2536728043171574184">ఈ పేజీ ఆఫ్‌లైన్ కాపీని వీక్షిస్తున్నారు</translation>
-<translation id="2546283357679194313">కుక్కీలు మరియు సైట్ డేటా</translation>
-<translation id="2567385386134582609">చిత్రం</translation>
-<translation id="257088987046510401">థీమ్‌లు</translation>
-<translation id="2570922361219980984">ఈ పరికరానికి స్థానం యాక్సెస్ కూడా ఆఫ్ చేయబడింది. దీనిని <ph name="BEGIN_LINK" />Android సెట్టింగ్‌లు<ph name="END_LINK" />లో తిరిగి ఆన్ చేయండి.</translation>
-<translation id="257931822824936280">విస్తరింపబడింది - కుదించడానికి క్లిక్ చేయండి.</translation>
-<translation id="2581165646603367611">ఇది Chrome ముఖ్యమైనదిగా భావించని కుక్కీలు, కాష్, సైట్‌ల ఇతర డేటాను తీసివేస్తుంది.</translation>
-<translation id="2586657967955657006">క్లిప్‌బోర్డ్</translation>
-<translation id="2587052924345400782">సరికొత్త వెర్షన్ ఉంది</translation>
-<translation id="2593272815202181319">మోనోస్పేస్</translation>
-<translation id="2612676031748830579">కార్డ్ సంఖ్య</translation>
-<translation id="2621115761605608342">నిర్దిష్ట సైట్ కోసం జావా స్క్రిప్ట్‌ను అనుమతిస్తుంది.</translation>
-<translation id="2625189173221582860">పాస్‌వర్డ్ కాపీ చేయబడింది</translation>
-<translation id="2631006050119455616">ఆదా చేయబడింది</translation>
-<translation id="2647434099613338025">భాషను జోడించు</translation>
-<translation id="2650751991977523696">ఫైల్‌ను మళ్లీ డౌన్‌లోడ్ చేయాలా?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ఆడియో ఫైల్}other{# ఆడియో ఫైల్‌లు}}</translation>
-<translation id="2653659639078652383">సమర్పించు</translation>
-<translation id="2677748264148917807">నిష్క్రమించు</translation>
-<translation id="2704606927547763573">కాపీ చేయబడింది</translation>
-<translation id="2707726405694321444">పేజీని రిఫ్రెష్ చేయండి</translation>
-<translation id="2709516037105925701">స్వయంపూర్తి</translation>
-<translation id="2717722538473713889">ఇమెయిల్ చిరునామాలు</translation>
-<translation id="2728754400939377704">సైట్ ద్వారా క్రమీకరించు</translation>
-<translation id="2744248271121720757">తక్షణమే వెతకడానికి లేదా సంబంధిత చర్యలను చూడటానికి ఒక పదాన్ని నొక్కండి</translation>
-<translation id="2760989362628427051">మీ పరికరంలో ముదురు రంగు థీమ్ లేదా బ్యాటరీ సేవర్ ఆన్‌లో ఉన్నప్పుడు, ముదురు రంగు థీమ్‌ను ఆన్ చేయండి</translation>
-<translation id="2762000892062317888">ఇప్పుడే</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> సెకన్లు మిగిలి ఉంది</translation>
-<translation id="2779651927720337254">విఫలమైంది</translation>
-<translation id="2781151931089541271">1 సెకను మిగిలి ఉంది</translation>
-<translation id="2801022321632964776">Chrome యొక్క తాజా వెర్షన్‌లో మీ భాషను పొందడానికి అప్‌డేట్ చేయండి</translation>
-<translation id="2810645512293415242">డేటాను సేవ్ చేయడానికి మరియు మరింత వేగంగా లోడ్ చేయడానికి సరళీకరించిన పేజీ.</translation>
-<translation id="281504910091592009">మీ <ph name="BEGIN_LINK" />Google ఖాతా<ph name="END_LINK" />లో సేవ్ చేసిన పాస్‌వర్డ్‌లను చూడండి మరియు నిర్వహించండి</translation>
-<translation id="2818669890320396765">ఇక ఎప్పుడు ఎక్కడ బుక్‌మార్క్‌లను సెట్‌ చేసినా ఆటోమాటిక్‌గా మీ అన్ని పరికరాలలోనూ పొందాలనుకుంటే, సైన్ ఇన్ చేసి, సమకాలీకరణ ఎంపికను ఆన్ చేయండి</translation>
-<translation id="2822354292072154809">మీరు <ph name="CHOSEN_OBJECT_NAME" /> కోసం అన్ని సైట్ అనుమతులను ఖచ్చితంగా రీసెట్ చేయాలనుకుంటున్నారా ?</translation>
-<translation id="2836148919159985482">పూర్తి స్క్రీన్ నుండి నిష్క్రమించడానికి వెనుకకు బటన్‌ను తాకండి.</translation>
-<translation id="2842985007712546952">మూల ఫోల్డర్</translation>
-<translation id="2858138569776157458">టాప్ సైట్‌లు</translation>
-<translation id="2860954141821109167">ఈ పరికరంలో ఫోన్ యాప్ ప్రారంభించబడిందని నిర్ధారించుకోండి</translation>
-<translation id="2870560284913253234">సైట్</translation>
-<translation id="2874939134665556319">మునుపటి ట్రాక్</translation>
-<translation id="2876369937070532032">మీ భద్రతకు ప్రమాదం పొంచి ఉన్నప్పుడు, మీరు సందర్శించే కొన్ని పేజీల URLలను Googleకు పంపుతుంది</translation>
-<translation id="2888126860611144412">Chrome పరిచయం</translation>
-<translation id="2891154217021530873">పేజీ లోడ్ కాకుండా ఆపివేయండి</translation>
-<translation id="2893180576842394309">శోధన, ఇతర Google సేవలను వ్యక్తిగతీకరించడానికి Google మీ చరిత్రను ఉపయోగించే అవకాశం ఉంటుంది</translation>
-<translation id="2898264748040935573">నిల్వ చేసిన పాస్‌వర్డ్‌ను సవరించండి</translation>
-<translation id="2900528713135656174">ఈవెంట్‌ను సృష్టించండి</translation>
-<translation id="290376772003165898">పేజీ <ph name="LANGUAGE" />లో లేదా?</translation>
-<translation id="2904414404539560095">ట్యాబ్‌ను షేర్ చేయాల్సిన పరికరాల జాబితా పూర్తి ఎత్తులో తెరవబడింది.</translation>
-<translation id="2910701580606108292">సైట్‌లు రక్షిత కంటెంట్‌ను ప్లే చేయడానికి ముందు అనుమతి కోసం అడుగుతాయి</translation>
-<translation id="2913331724188855103">కుక్కీ డేటాను సేవ్ చేయడానికి, చదవడానికి సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="2923908459366352541">పేరు చెల్లదు</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> నిల్వ</translation>
-<translation id="2942036813789421260">ప్రివ్యూ ట్యాబ్ మూసివేయబడింది</translation>
-<translation id="2956410042958133412">ఈ ఖాతా <ph name="PARENT_NAME_1" /> మరియు <ph name="PARENT_NAME_2" /> నిర్వహణలో ఉంది.</translation>
-<translation id="2962095958535813455">అజ్ఞాత ట్యాబ్‌లకు మార్చబడింది</translation>
-<translation id="2968755619301702150">ప్రమాణపత్రం వ్యూయర్</translation>
-<translation id="2979025552038692506">ఎంచుకున్న అజ్ఞాత ట్యాబ్</translation>
-<translation id="2987620471460279764">ఇతర పరికరం నుండి షేర్ చేయబడిన వచనం</translation>
-<translation id="2989523299700148168">ఇటీవల సందర్శించినవి</translation>
-<translation id="2996291259634659425">రహస్య పదబంధాన్ని సృష్టించండి</translation>
-<translation id="2996809686854298943">URL అవసరం</translation>
-<translation id="300526633675317032">ఇది వెబ్‌సైట్ నిల్వలోని మొత్తం <ph name="SIZE_IN_KB" />ను తీసివేస్తుంది.</translation>
-<translation id="3016635187733453316">ఈ పరికరం ఇంటర్నెట్‌కు కనెక్ట్ చేయబడి ఉందని నిర్ధారించుకోండి</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB డౌన్‌లోడ్ చేయబడింది</translation>
-<translation id="3029704984691124060">రహస్య పదబంధాలు సరిపోలలేదు</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />సహాయం పొందండి<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">స్థానం ఆఫ్ చేయబడింది; దీనిని <ph name="BEGIN_LINK" />Android సెట్టింగ్‌లు<ph name="END_LINK" />లో ఆన్ చేయండి.</translation>
-<translation id="3058498974290601450">సెట్టింగ్‌లలో ఎప్పుడైనా మీరు సింక్‌ను ఆన్ చేయవచ్చు</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> బుక్‌మార్క్}other{<ph name="BOOKMARKS_COUNT_MANY" /> బుక్‌మార్క్‌లు}}</translation>
-<translation id="3089395242580810162">అజ్ఞాత ట్యాబ్‌లో తెరువు</translation>
-<translation id="3115898365077584848">సమాచారాన్ని చూపు</translation>
-<translation id="3123473560110926937">కొన్ని సైట్‌లలో బ్లాక్ చేయబడింది</translation>
-<translation id="3137521801621304719">అజ్ఞాత మోడ్ నుండి నిష్క్రమించండి</translation>
-<translation id="3143515551205905069">సింక్‌ను రద్దు చేయి</translation>
-<translation id="3157842584138209013">'మరిన్ని ఎంపికలు' బటన్ నుండి మీరు ఎంత డేటాను సేవ్ చేసారో చూడండి</translation>
-<translation id="3166827708714933426">ట్యాబ్ మరియు విండో షార్ట్‌కట్‌లు</translation>
-<translation id="3181954750937456830">సురక్షిత బ్రౌజింగ్ (ప్రమాదకరమైన సైట్‌ల నుండి మిమ్మల్ని, మీ పరికరాన్ని రక్షిస్తుంది)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android సెట్టింగ్‌లు<ph name="END_LINK" />లో Chrome కోసం అనుమతులను ఆన్ చేయండి.</translation>
-<translation id="3198916472715691905">నిల్వ చేసిన డేటా <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">దాదాపు పూర్తయింది!</translation>
-<translation id="3207960819495026254">బుక్‌మార్క్ చేయబడింది</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> తొలగించబడింది</translation>
-<translation id="321773570071367578">మీరు మీ రహస్య పదబంధాన్ని మర్చిపోతే లేదా ఈ సెట్టింగ్‌ను మార్చాలనుకుంటే, <ph name="BEGIN_LINK" />సింక్‌ను రీసెట్ చేయండి<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">మైక్రోఫోన్</translation>
-<translation id="3232754137068452469">వెబ్ యాప్‌</translation>
-<translation id="3236059992281584593">1 నిమిషం మిగిలి ఉంది</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">ఈ పేజీని బుక్‌మార్క్ చేయి</translation>
-<translation id="3259831549858767975">పేజీలోని అన్నింటినీ చిన్నవిగా చేయండి</translation>
-<translation id="3269093882174072735">చిత్రాన్ని లోడ్ చేయి</translation>
-<translation id="3269956123044984603">మీ ఇతర పరికరాల నుండి మీ ట్యాబ్‌లను పొందడానికి, Android ఖాతా సెట్టింగ్‌ల‌లో "ఆటో-సింక్‌ డేటా" ఆన్ చేయండి.</translation>
-<translation id="3277252321222022663">సెన్సార్‌లను యాక్సెస్ చేయడానికి సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేస్తున్నాము)</translation>
-<translation id="3282568296779691940">Chromeకు సైన్ ఇన్ చేయండి</translation>
-<translation id="3288003805934695103">పేజీని మళ్లీ లోడ్ చేయడం</translation>
-<translation id="32895400574683172">నోటిఫికేషన్‌లు అనుమతించబడతాయి</translation>
-<translation id="3295530008794733555">మరింత వేగంగా బ్రౌజ్ చేయండి. తక్కువ డేటాని ఉపయోగించండి.</translation>
-<translation id="3295602654194328831">సమాచారాన్ని దాచు</translation>
-<translation id="3298243779924642547">లైట్</translation>
-<translation id="3303414029551471755">కంటెంట్‌ను డౌన్‌లోడ్ చేయడం కొనసాగించాలా?</translation>
-<translation id="3306398118552023113">ఈ యాప్ Chromeలో అమలవుతోంది</translation>
-<translation id="3315103659806849044">మీరు ప్రస్తుతం మీ సింక్, Google సేవా సెట్టింగ్‌లను అనుకూలీకరిస్తున్నారు. సింక్‌ను ఆన్ చేయడం పూర్తి చేయడానికి, స్క్రీన్ దిగువ భాగం సమీపంలోని నిర్ధారించు బటన్‌ను నొక్కండి. పైకి నావిగేట్ చేయి</translation>
-<translation id="3328801116991980348">సైట్ సమాచారం</translation>
-<translation id="3333961966071413176">మొత్తం పరిచయాలు</translation>
-<translation id="3334729583274622784">ఫైల్ ఎక్స్‌టెన్షన్‌ను మార్చాలా?</translation>
-<translation id="3341058695485821946">మీరు ఎంత డేటాను సేవ్ చేసారో చూడండి</translation>
-<translation id="3350687908700087792">అన్ని అజ్ఞాత ట్యాబ్‌లను మూసివేయండి</translation>
-<translation id="3353615205017136254">Google అందించిన లైట్ పేజీ. అసలు పేజీని లోడ్ చేయడానికి అసలైన దానిని లోడ్ చేయి బటన్‌ను నొక్కండి.</translation>
-<translation id="3367813778245106622">సింక్‌ను ప్రారంభించడానికి మళ్లీ సైన్ ఇన్ చేయండి</translation>
-<translation id="3374023511497244703">మీ బుక్‌మార్క్‌లు, చరిత్ర, పాస్‌వర్డ్‌లు, ఇతర Chrome డేటా ఇకపై మీ Google ఖాతాలో సింక్ చేయబడదు</translation>
-<translation id="3384347053049321195">చిత్రాన్ని షేర్‌ చేయి</translation>
-<translation id="3386292677130313581">మీ స్థానాన్ని సైట్‌లు తెలుసుకునేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="3387650086002190359">ఫైల్ సిస్టమ్ లోపాల కారణంగా <ph name="FILE_NAME" /> డౌన్‌లోడ్ విఫలమైంది.</translation>
-<translation id="3389286852084373014">వచనం చాలా పెద్దదిగా ఉంది</translation>
-<translation id="3398320232533725830">బుక్‌మార్క్‌ల నిర్వాహికి తెరవండి</translation>
-<translation id="3414952576877147120">పరిమాణం:</translation>
-<translation id="3443221991560634068">ప్రస్తుత పేజీని మళ్లీ లోడ్ చేయండి</translation>
-<translation id="3445014427084483498">ఇప్పుడే</translation>
-<translation id="3478363558367712427">మీరు మీ శోధన ఇంజిన్‌ను ఎంచుకోవచ్చు</translation>
+<translation id="6910211073230771657">తొలగించబడింది</translation>
+<translation id="6965382102122355670">సరే</translation>
+<translation id="5301954838959518834">సరే, అర్థమైంది</translation>
+<translation id="7658239707568436148">రద్దు చేయి</translation>
 <translation id="3479552764303398839">ఇప్పుడు కాదు</translation>
-<translation id="3492207499832628349">కొత్త అజ్ఞాత ట్యాబ్</translation>
-<translation id="3493531032208478708">సూచించిన కంటెంట్ గురించి <ph name="BEGIN_LINK" />మరింత తెలుసుకోండి<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">అగ్‌మెంటెడ్ రియాలిటీ</translation>
-<translation id="3518985090088779359">అంగీకరించు &amp; కొనసాగు</translation>
-<translation id="3522247891732774234">అప్‌డేట్‌ అందుబాటులో ఉంది. మరిన్ని ఎంపికలు</translation>
-<translation id="3524138585025253783">డెవలపర్ UI</translation>
-<translation id="3527085408025491307">ఫోల్డర్</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB అందుబాటులో ఉంది</translation>
-<translation id="3549657413697417275">మీ చరిత్రను వెతకండి</translation>
-<translation id="3557336313807607643">పరిచయాలకు జోడించు</translation>
-<translation id="3566923219790363270">Chrome ఇంకా VR కోసం సన్నద్ధమవుతోంది. Chromeని తర్వాత పునఃప్రారంభించండి.</translation>
-<translation id="3568688522516854065">మీ ఇతర పరికరాలలో ఉన్న మీ అన్ని ట్యాబ్‌‌‍లను పొందాలనుకుంటే, సైన్ ఇన్ చేసి, సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
-<translation id="3587482841069643663">మొత్తం</translation>
-<translation id="358794129225322306">పలు ఫైల్‌లను ఆటోమేటిక్‌గా డౌన్‌లోడ్ చేయడం కోసం సైట్‌ని అనుమతించండి.</translation>
-<translation id="3590487821116122040">Chrome ముఖ్యమైనదిగా భావించని సైట్ నిల్వ (ఉదా. సేవ్ చేసిన సెట్టింగ్‌లు లేని సైట్‌లు లేదా మీరు తరచుగా సందర్శించని సైట్‌లు)</translation>
-<translation id="3599863153486145794">సైన్ ఇన్ చేసిన అన్ని పరికరాల నుండి చరిత్రను తొలగిస్తుంది. మీ Google ఖాతా <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />లో ఇతర రూపాల్లో ఉన్న బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
-<translation id="3600792891314830896">ధ్వనిని ప్లే చేసే సైట్‌లను మ్యూట్ చేస్తుంది</translation>
-<translation id="3616113530831147358">ఆడియో</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" />తో షేర్ చేస్తోంది</translation>
-<translation id="3632295766818638029">పాస్‌వర్డ్‌ను చూపుతుంది</translation>
-<translation id="363596933471559332">నిల్వ చేసిన ఆధారాలను ఉపయోగించి ఆటోమేటిక్‌గా వెబ్‌సైట్‌లకు సైన్ ఇన్ చేయండి. ఫీచ‌ర్‌ ఆఫ్ చేయబడినప్పుడు, మీరు వెబ్‌సైట్‌కు సైన్ ఇన్ చేసే ప్రతిసారి ధృవీకరణ కోసం మిమ్మల్ని అడుగుతుంది.</translation>
-<translation id="3658159451045945436">రీసెట్ చేసినట్లయితే, సందర్శించిన సైట్‌ల జాబితాతో పాటు మీ డేటా ఆదాల చరిత్ర తొలగించబడుతుంది.</translation>
-<translation id="3692944402865947621">నిల్వ స్థానాన్ని చేరుకోలేకపోయిన కారణంగా <ph name="FILE_NAME" /> డౌన్‌లోడ్ విఫలమైంది.</translation>
-<translation id="3714981814255182093">శోధన పట్టీని తెరవండి</translation>
-<translation id="3716182511346448902">ఈ పేజీ చాలా మెమరీని ఉపయోగిస్తోంది, కాబట్టి దీన్ని Chrome పాజ్ చేయబడింది.</translation>
-<translation id="3730075448226062617">మీ మైక్రోఫోన్‌ను యాక్సెస్ చేయడానికి Chromeను అనుమతించేందుకు, <ph name="BEGIN_LINK" />Android సెట్టింగ్‌ల<ph name="END_LINK" />లో కూడా మైక్రోఫోన్‌ను ఆన్ చేయండి.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" />లో బుక్‌మార్క్ చేయబడింది</translation>
-<translation id="3744111561329211289">బ్యాక్‌గ్రౌండ్ సింక్</translation>
-<translation id="3771001275138982843">అప్‌డేట్‌ను డౌన్‌లోడ్ చేయడం సాధ్యపడలేదు</translation>
-<translation id="3771033907050503522">అజ్ఞాత ట్యాబ్‌లు</translation>
-<translation id="3773755127849930740">జత చేయడాన్ని అనుమతించడానికి <ph name="BEGIN_LINK" />బ్లూటూత్‌ను ఆన్ చేయండి<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">మీ పరికరాలకు పంపండి</translation>
-<translation id="3778956594442850293">హోమ్ స్క్రీన్‌కు జోడించబడింది</translation>
-<translation id="3789841737615482174">ఇన్‌స్టాల్ చేయి</translation>
-<translation id="3810838688059735925">వీడియో</translation>
-<translation id="3810973564298564668">నిర్వహించు</translation>
-<translation id="381841723434055211">ఫోన్ నంబర్‌లు</translation>
-<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS" /> డౌన్‌లోడ్‌లు తొలగించబడ్డాయి</translation>
-<translation id="3822502789641063741">సైట్ నిల్వను తీసివేయాలా?</translation>
-<translation id="385051799172605136">వెనుకకు</translation>
-<translation id="3859306556332390985">ముందుకు జరుపు</translation>
-<translation id="3894427358181296146">ఫోల్డర్‌ను జోడించండి</translation>
-<translation id="3895926599014793903">జూమ్ చేయడాన్ని నిర్బంధంగా ప్రారంభించు</translation>
-<translation id="3912508018559818924">వెబ్ నుండి ఉత్తమమైనది కనుగొంటోంది…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">నా డేటాను కలపండి</translation>
-<translation id="393697183122708255">ప్రారంభించిన వాయిస్ శోధన అందుబాటులో లేదు</translation>
-<translation id="395206256282351086">శోధన మరియు సైట్ సూచనలు నిలిపివేయబడ్డాయి</translation>
-<translation id="3955193568934677022">రక్షిత కంటెంట్‌ను ప్లే చేయడానికి సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{కనెక్ట్ అయినప్పుడు, Chrome మీ పేజీని లోడ్ చేస్తుంది}other{కనెక్ట్ అయినప్పుడు, Chrome మీ పేజీలను లోడ్ చేస్తుంది}}</translation>
-<translation id="3963007978381181125">Google Payకి సంబంధించిన చెల్లింపు పద్ధతులు మరియు చిరునామాలు రహస్య పదబంధం ఎన్‌క్రిప్షన్‌లో ఉండవు. మీ రహస్య పదబంధాన్ని కలిగి ఉన్నవారు మాత్రమే మీ ఎన్‌క్రిప్ట్ చేసిన డేటాను చదవగలరు. రహస్య పదబంధం Google ద్వారా ఎవరికీ పంపబడదు లేదా నిల్వ చేయబడదు. మీరు మీ రహస్య పదబంధాన్ని మర్చిపోతే లేదా ఈ సెట్టింగ్‌ను మార్చాలనుకుంటే, సమకాలీకరణను రీసెట్ చేయాల్సి ఉంటుంది. <ph name="BEGIN_LINK" />మరింత తెలుసుకోండి<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">డౌన్‌లోడ్ పూర్తయింది</translation>
-<translation id="397583555483684758">సమకాలీకరణ పని చేయడం ఆగిపోయింది</translation>
-<translation id="3976396876660209797">ఈ షార్ట్‌కట్‌ను తీసివేసి, పునఃసృష్టించండి</translation>
-<translation id="3985215325736559418">మీరు <ph name="FILE_NAME" />ని మళ్లీ డౌన్‌లోడ్ చేయాలని అనుకుంటున్నారా?</translation>
-<translation id="3987993985790029246">లింక్‌ను కాపీ చేయి</translation>
-<translation id="3988213473815854515">స్థానం అనుమతించబడింది</translation>
-<translation id="3988466920954086464">ఈ ప్యానెల్‌లో తక్షణ శోధన ఫలితాలను చూడండి</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">ప్రధానం కాని నిల్వ</translation>
-<translation id="4000212216660919741">ఆఫ్‌లైన్ హోమ్</translation>
+<translation id="5317780077021120954">సేవ్ చేయి</translation>
+<translation id="4570913071927164677">వివరాలు</translation>
+<translation id="8730621377337864115">పూర్తయింది</translation>
+<translation id="8261506727792406068">తొలగించు</translation>
+<translation id="1181037720776840403">తీసివేయి</translation>
+<translation id="5939518447894949180">రీసెట్ చేయి</translation>
 <translation id="4002066346123236978">శీర్షిక</translation>
-<translation id="4008040567710660924">నిర్దిష్ట సైట్ కోసం కుక్కీలను అనుమతించండి.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# గం}other{# గం}}</translation>
-<translation id="4046123991198612571">తరువాత ట్రాక్</translation>
-<translation id="4048707525896921369">పేజీ నుండి నిష్క్రమించకుండానే వెబ్‌సైట్‌లలోని అంశాల గురించి తెలుసుకోండి. 'వెతకడానికి నొక్కండి' అనే ఫీచర్, ఒక పదాన్ని మరియు దాని చుట్టూ ఉన్న సంబంధిత సందర్భాన్ని Google శోధనకు పంపుతుంది, ప్రతిస్పందనగా దాని నుండి నిర్వచనాలు, చిత్రాలు, శోధన ఫలితాలు మరియు ఇతర వివరాలు అందించబడతాయి.
+<translation id="5916664084637901428">ఆన్ చేయి</translation>
+<translation id="5860033963881614850">ఆఫ్ అయ్యింది</translation>
+<translation id="6165508094623778733">మరింత తెలుసుకోండి</translation>
+<translation id="6042308850641462728">మరింత</translation>
+<translation id="6040143037577758943">మూసివేయి</translation>
+<translation id="780301667611848630">వద్దు , ధన్యవాదాలు</translation>
+<translation id="1201402288615127009">తరువాత</translation>
+<translation id="2359808026110333948">కొనసాగించు</translation>
+<translation id="2653659639078652383">సమర్పించు</translation>
+<translation id="2079545284768500474">చర్య రద్దు</translation>
+<translation id="7649070708921625228">సహాయం</translation>
+<translation id="2148716181193084225">ఈ రోజు</translation>
+<translation id="7781829728241885113">నిన్న</translation>
+<translation id="6945221475159498467">ఎంచుకోండి</translation>
+<translation id="7791543448312431591">జోడించు</translation>
+<translation id="6527303717912515753">భాగస్వామ్యం చేయి</translation>
+<translation id="1383876407941801731">వెతుకు</translation>
+<translation id="3115898365077584848">సమాచారాన్ని చూపు</translation>
+<translation id="3295602654194328831">సమాచారాన్ని దాచు</translation>
+<translation id="3987993985790029246">లింక్‌ను కాపీ చేయి</translation>
+<translation id="2704606927547763573">కాపీ చేయబడింది</translation>
+<translation id="8725066075913043281">మళ్ళీ ప్రయత్నించండి</translation>
+<translation id="385051799172605136">వెనుకకు</translation>
+<translation id="8131740175452115882">నిర్ధారించు</translation>
+<translation id="5300589172476337783">చూపించు</translation>
+<translation id="1124772482545689468">వినియోగదారు</translation>
+<translation id="8609465669617005112">పైకి తరలించు</translation>
+<translation id="6746124502594467657">క్రిందికి తరలించు</translation>
+<translation id="8249310407154411074">ఎగువకు తరలించు</translation>
+<translation id="8428213095426709021">సెట్టింగ్‌లు</translation>
+<translation id="2498359688066513246">సహాయం &amp; అభిప్రాయం</translation>
+<translation id="8378714024927312812">మీ సంస్థ ద్వారా నిర్వహించబడుతున్నవి</translation>
+<translation id="9019902583201351841">మీ తల్లిదండ్రుల ద్వారా నిర్వహించబడుతోంది</translation>
+<translation id="4645575059429386691">మీ తల్లి/తండ్రి ద్వారా నిర్వహించబడుతోంది</translation>
+<translation id="4883854917563148705">నిర్వహిత సెట్టింగ్‌లు రీసెట్ చేయబడవు</translation>
+<translation id="4307992518367153382">ప్రాథమికాలు</translation>
+<translation id="1974060860693918893">ఆధునిక</translation>
+<translation id="1146678959555564648">VRలోకి ప్రవేశించు</translation>
+<translation id="987264212798334818">సాధారణం</translation>
+<translation id="4275663329226226506">మీడియా</translation>
+<translation id="4759238208242260848">డౌన్‌లోడ్‌లు</translation>
+<translation id="218608176142494674">షేరింగ్</translation>
+<translation id="8004582292198964060">బ్రౌజర్</translation>
+<translation id="1105960400813249514">స్క్రీన్ క్యాప్చర్</translation>
+<translation id="4875775213178255010">కంటెంట్ సూచనలు</translation>
+<translation id="2021896219286479412">పూర్తి స్క్రీన్ సైట్ నియంత్రణలు</translation>
+<translation id="4587589328781138893">సైట్‌లు</translation>
+<translation id="4943703118917034429">వర్చువల్ రియాలిటీ</translation>
+<translation id="1928696683969751773">నవీకరిస్తుంది</translation>
+<translation id="6064125863973209585">పూర్తయిన డౌన్‌లోడ్‌లు</translation>
+<translation id="5342314432463739672">అనుమతి అభ్యర్థనలు</translation>
+<translation id="629730747756840877">ఖాతా</translation>
+<translation id="82609232232243542">Braveకు సైన్ ఇన్ చేయండి</translation>
+<translation id="7956662517480676674">సింక్ మరియు Brave Software సేవలు</translation>
+<translation id="5294439808117722387">మీరు ప్రస్తుతం మీ సింక్, Brave Software సేవా సెట్టింగ్‌లను అనుకూలీకరిస్తున్నారు. సింక్‌ను ఆన్ చేయడం పూర్తి చేయడానికి, స్క్రీన్ దిగువ భాగం సమీపంలోని నిర్ధారించు బటన్‌ను నొక్కండి. పైకి నావిగేట్ చేయి</translation>
+<translation id="2096012225669085171">అన్ని పరికరాలలో సింక్ చేయండి మరియు వ్యక్తిగతీకరించండి</translation>
+<translation id="1692118695553449118">సమకాలీకరణ ఆన్‌లో ఉంది</translation>
+<translation id="5514904542973294328">ఈ పరికర నిర్వాహకులు నిలిపివేశారు</translation>
+<translation id="6447211988989208781">Brave Software కార్యకలాప నియంత్రణలు</translation>
+<translation id="4882831918239250449">శోధన, ప్రకటనలు మరియు మరిన్నింటిని వ్యక్తిగతీకరించడానికి మీ బ్రౌజింగ్ చరిత్ర ఎలా ఉపయోగించబడుతుందో నియంత్రించండి</translation>
+<translation id="7431991332293347422">శోధనలు మరియు మరిన్నింటిని వ్యక్తిగతీకరించడానికి మీ బ్రౌజింగ్ చరిత్ర ఎలా ఉపయోగించబడుతుందో నియంత్రించండి</translation>
+<translation id="6303969859164067831">సైన్ అవుట్ చేసి, సమకాలీకరణను ఆఫ్ చేయండి</translation>
+<translation id="1125261911132334651">మీ Brave Software ఖాతాను నిర్వహించండి</translation>
+<translation id="6406506848690869874">Sync</translation>
+<translation id="714362445477979774">మీ Brave డేటాను సింక్ చేయండి</translation>
+<translation id="4314815835985389558">సింక్‌ను నిర్వహించండి</translation>
+<translation id="5428209950370661546">ఇతర Brave Software సేవలు</translation>
+<translation id="7704317875155739195">స్వయంపూర్తి శోధనలు మరియు URLలు</translation>
+<translation id="2000419248597011803">చిరునామా బార్ మరియు శోధన పెట్టెలోని కొన్ని కుక్కీలు మరియు శోధనలను మీ డిఫాల్ట్ శోధన ఇంజిన్‌కు పంపుతుంది</translation>
+<translation id="7981313251711023384">వేగవంతమైన బ్రౌజింగ్ మరియు శోధన కోసం పేజీలను ముందస్తుగా లోడ్ చేస్తుంది</translation>
+<translation id="1821253160463689938">మీ ప్రాధాన్యతలను గుర్తుంచుకోవడానికి కుక్కీలను ఉపయోగిస్తుంది, మీరు ఆ పేజీలను సందర్శించకపోయినా కూడా అది అమలవుతుంది</translation>
+<translation id="6697492270171225480">పేజీ కనుగొనబడనప్పుడు అటువంటి పేజీల కోసం సూచనలను చూపుతుంది</translation>
+<translation id="8109318360573330108">మీరు చేరుకోవాలని ప్రయత్నిస్తున్న పేజీ URLని Brave Softwareకి పంపుతుంది</translation>
+<translation id="8438566539970814960">శోధనలు మరియు బ్రౌజింగ్‌ను మెరుగుపరచండి</translation>
+<translation id="284843628681142937">మీరు సందర్శించే పేజీల URLలను Brave Softwareకి పంపుతుంది</translation>
+<translation id="7222718784508482526">గోప్యత, భద్రత మరియు డేటా సేకరణకు సంబంధించిన మరిన్ని సెట్టింగ్‌ల కోసం, <ph name="BEGIN_LINK"/>సమకాలీకరణ మరియు Brave Software సేవలను<ph name="END_LINK"/> చూడండి</translation>
+<translation id="918192811481327695">Brave ఫీచర్‌లు మరియు పనితీరును మెరుగుపరచడంలో సహాయపడండి</translation>
+<translation id="9063160602596686558">Brave Softwareకు ఆటోమేటిక్‌గా వినియోగ గణాంకాలను, క్రాష్ నివేదికలను పంపుతుంది</translation>
+<translation id="4824958205181053313">సింక్‌ను రద్దు చేయాలా?</translation>
+<translation id="3058498974290601450">సెట్టింగ్‌లలో ఎప్పుడైనా మీరు సింక్‌ను ఆన్ చేయవచ్చు</translation>
+<translation id="3143515551205905069">సింక్‌ను రద్దు చేయి</translation>
+<translation id="1506061864768559482">శోధన ఇంజిన్</translation>
+<translation id="55737423895878184">స్థానం మరియు నోటిఫికేషన్‌లు అనుమతించబడతాయి</translation>
+<translation id="3988213473815854515">స్థానం అనుమతించబడింది</translation>
+<translation id="32895400574683172">నోటిఫికేషన్‌లు అనుమతించబడతాయి</translation>
+<translation id="9040142327097499898">నోటిఫికేషన్‌లు అనుమతించబడ్డాయి. ఈ పరికరానికి స్థానం ఆఫ్ చేయబడింది.</translation>
+<translation id="305593374596241526">స్థానం ఆఫ్ చేయబడింది; దీనిని <ph name="BEGIN_LINK"/>Android సెట్టింగ్‌లు<ph name="END_LINK"/>లో ఆన్ చేయండి.</translation>
+<translation id="2989523299700148168">ఇటీవల సందర్శించినవి</translation>
+<translation id="6433501201775827830">మీ శోధన ఇంజిన్‌ను ఎంచుకోండి</translation>
+<translation id="7177466738963138057">మీరు దీన్ని తర్వాత సెట్టింగ్‌లలో మార్చవచ్చు</translation>
+<translation id="3478363558367712427">మీరు మీ శోధన ఇంజిన్‌ను ఎంచుకోవచ్చు</translation>
+<translation id="4910889077668685004">చెల్లింపు అనువర్తనాలు</translation>
+<translation id="5152843274749979095">మద్దతు గల అనువర్తనాలు ఏవీ ఇన్‌స్టాల్ చేయబడలేదు</translation>
+<translation id="8812260976093120287">కొన్ని వెబ్‌సైట్‌ల‌లో, మీరు మీ పరికరంలో ఎగువ పేర్కొన్న మద్దతు గల చెల్లింపు యాప్‌లతోచెల్లించవచ్చు.</translation>
+<translation id="7764225426217299476">చిరునామాను జోడించు</translation>
+<translation id="5595485650161345191">చిరునామాను సవరించు</translation>
+<translation id="5087580092889165836">కార్డ్‌ను జోడించు</translation>
+<translation id="2154484045852737596">కార్డ్‌ను సవరించండి</translation>
+<translation id="6140912465461743537">దేశం/ప్రాంతం</translation>
+<translation id="5659593005791499971">ఇమెయిల్</translation>
+<translation id="4378154925671717803">ఫోన్</translation>
+<translation id="4807098396393229769">కార్డ్‌పై పేరు</translation>
+<translation id="860043288473659153">కార్డుదారుని పేరు</translation>
+<translation id="2612676031748830579">కార్డ్ సంఖ్య</translation>
+<translation id="869891660844655955">గడువు తేదీ</translation>
+<translation id="2286841657746966508">బిల్లింగ్ చిరునామా</translation>
+<translation id="663059986967017181">Braveకి కాపీ చేయబడింది</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">పాస్‌వర్డ్‌లు</translation>
+<translation id="1943432128510653496">పాస్‌వర్డ్‌‌లను సేవ్ చేయండి</translation>
+<translation id="2100273922101894616">స్వీయ సైన్-ఇన్</translation>
+<translation id="363596933471559332">నిల్వ చేసిన ఆధారాలను ఉపయోగించి ఆటోమేటిక్‌గా వెబ్‌సైట్‌లకు సైన్ ఇన్ చేయండి. ఫీచ‌ర్‌ ఆఫ్ చేయబడినప్పుడు, మీరు వెబ్‌సైట్‌కు సైన్ ఇన్ చేసే ప్రతిసారి ధృవీకరణ కోసం మిమ్మల్ని అడుగుతుంది.</translation>
+<translation id="6995899638241819463">మీరు ఉపయోగించే పాస్‌వర్డ్‌లు, ఏదైనా డేటా ఉల్లంఘనలో బహిర్గతమైతే మిమ్మల్ని హెచ్చరిస్తుంది</translation>
+<translation id="1534287762301776620">మీ Brave Software ఖాతాకు మీరు సైన్ ఇన్ చేసినప్పుడు, ఈ ఫీచర్ ఆన్ చేయబడుతుంది</translation>
+<translation id="10614374240317010">ఎప్పటికి సేవ్ చెయ్యబడవు</translation>
+<translation id="3098842761938485917">మీ <ph name="BEGIN_LINK"/>Brave Software ఖాతా<ph name="END_LINK"/>లో సేవ్ చేసిన పాస్‌వర్డ్‌లను చూడండి మరియు నిర్వహించండి</translation>
+<translation id="8562452229998620586">సేవ్ చేయబడిన పాస్‌వర్డ్‌లు ఇక్కడ కనిపిస్తాయి.</translation>
+<translation id="8084114998886531721">సేవ్ చేసిన పాస్‌వర్డ్</translation>
+<translation id="2870560284913253234">సైట్</translation>
+<translation id="8503813439785031346">యూజర్‌పేరు</translation>
+<translation id="6657585470893396449">పాస్‌వర్డ్</translation>
+<translation id="2154710561487035718">URLను కాపీ చేయి</translation>
+<translation id="1571304935088121812">వినియోగదారు పేరును కాపీ చేస్తుంది</translation>
+<translation id="5005498671520578047">పాస్‌వర్డ్ కాపీచేయడం</translation>
+<translation id="3632295766818638029">పాస్‌వర్డ్‌ను చూపుతుంది</translation>
+<translation id="1513858653616922153">పాస్‌వర్డ్‌ను తొలగించు</translation>
+<translation id="543338862236136125">పాస్‌వర్డ్‌ను సవరించు</translation>
+<translation id="4565377596337484307">పాస్‌వర్డ్‌ను దాచిపెట్టు</translation>
+<translation id="8523928698583292556">నిల్వ చేసిన పాస్‌వర్డ్‌ను తొలగిస్తుంది</translation>
+<translation id="2898264748040935573">నిల్వ చేసిన పాస్‌వర్డ్‌ను సవరించండి</translation>
+<translation id="5433691172869980887">వినియోగదారు పేరు కాపీ చేయబడింది</translation>
+<translation id="5534640966246046842">సైట్ కాపీ చేయబడింది</translation>
+<translation id="2625189173221582860">పాస్‌వర్డ్ కాపీ చేయబడింది</translation>
+<translation id="4550003330909367850">ఇక్కడ మీ పాస్‌వర్డ్‌ను వీక్షించడానికి లేదా కాపీ చేయడానికి, ఈ డివైజ్‌లో స్క్రీన్ లాక్‌ను సెట్ చేయండి.</translation>
+<translation id="6154478581116148741">ఈ పరికరం నుండి మీ పాస్‌వర్డ్‌లను ఎగుమతి చేయడానికి సెట్టింగ్‌లలో స్క్రీన్ లాక్‌ను ఆన్ చేయండి</translation>
+<translation id="4842092870884894799">పాస్‌వర్డ్ ఉత్పత్తి పాప్ అప్ చూపబడుతోంది</translation>
+<translation id="2259659629660284697">పాస్‌వర్డ్‌లను ఎగుమతి చేయండి…</translation>
+<translation id="133012818630824069">Braveతో నిల్వ చేసిన పాస్‌వర్డ్‌లను ఎగుమతి చేయండి</translation>
+<translation id="6914783257214138813">ఎగుమతి చేయబడిన ఫైల్‌ను చూడగల ఎవరికైనా మీ పాస్‌వర్డ్‌లు కనిపిస్తాయి.</translation>
+<translation id="2321086116217818302">పాస్‌వర్డ్‌లను సిద్ధం చేస్తోంది…</translation>
+<translation id="8445448999790540984">పాస్‌వర్డ్‌లను ఎగుమతి చేయడం సాధ్యం కాదు</translation>
+<translation id="3066461326500799725">Brave Software డిస్క్‌ని ఎలా ఉపయోగించాలో తెలుసుకోండి</translation>
+<translation id="729975465115245577">పాస్‌వర్డ్‌ల ఫైల్‌ను నిల్వ చేయడానికి మీ పరికరంలో యాప్ లేదు.</translation>
+<translation id="7682724950699840886">కింది చిట్కాలను ప్రయత్నించండి: మీ పరికరంలో తగినంత స్థలం ఉన్నట్లు నిర్ధారించుకోండి, మళ్లీ ఎగుమతి చేయడానికి ప్రయత్నించండి.</translation>
+<translation id="1129510026454351943">వివరాలు: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">మీ పాస్‌వర్డ్‌ను కాపీ చేయడానికి అన్‌లాక్ చేయండి</translation>
+<translation id="5515439363601853141">మీ పాస్‌వర్డ్‌ను చూడడానికి అన్‌లాక్ చేయండి</translation>
+<translation id="6221633008163990886">మీ పాస్‌వర్డ్‌లను ఎగుమతి చేయడానికి అన్‌లాక్ చేయండి</translation>
+<translation id="230699814587342492">Brave పాస్‌వర్డ్‌లు</translation>
+<translation id="6075798973483050474">హోమ్ పేజీని సవరించండి</translation>
+<translation id="854522910157234410">ఈ పేజీని తెరవండి</translation>
+<translation id="2482878487686419369">ప్రకటనలు</translation>
+<translation id="6255999984061454636">కంటెంట్ సూచనలు</translation>
+<translation id="805047784848435650">మీ బ్రౌజింగ్ చరిత్ర ఆధారంగా</translation>
+<translation id="1041308826830691739">వెబ్‌సైట్‌ల నుండి</translation>
+<translation id="395206256282351086">శోధన మరియు సైట్ సూచనలు నిలిపివేయబడ్డాయి</translation>
+<translation id="257088987046510401">థీమ్‌లు</translation>
+<translation id="4650364565596261010">సిస్టమ్ డిఫాల్ట్</translation>
+<translation id="7588219262685291874">మీ పరికరం బ్యాటరీ సేవర్ ఆన్‌లో ఉన్నప్పుడు ముదురు రంగు థీమ్‌ను ఆన్ చేస్తుంది</translation>
+<translation id="2760989362628427051">మీ పరికరంలో ముదురు రంగు థీమ్ లేదా బ్యాటరీ సేవర్ ఆన్‌లో ఉన్నప్పుడు, ముదురు రంగు థీమ్‌ను ఆన్ చేయండి</translation>
+<translation id="6381421346744604172">వెబ్‌సైట్‌లు ముదురు రంగులో చేయి</translation>
+<translation id="5040262127954254034">గోప్యత</translation>
+<translation id="4991384657077828949">Brave భద్రతను మెరుగుపరచడంలో సహాయం చేయండి</translation>
+<translation id="1943176487615318915">Brave ప్రమాదకరమైన యాప్‌లు, సైట్‌లను గుర్తించడానికి, మీరు సందర్శించే కొన్ని పేజీల URLలు, పరిమిత సిస్టమ్ సమాచారం, కొంత పేజీ కంటెంట్‌ను Brave Softwareకు పంపుతుంది</translation>
+<translation id="3181954750937456830">సురక్షిత బ్రౌజింగ్ (ప్రమాదకరమైన సైట్‌ల నుండి మిమ్మల్ని, మీ పరికరాన్ని రక్షిస్తుంది)</translation>
+<translation id="7315322926489145388">మీ భద్రతకు ప్రమాదం పొంచి ఉన్నప్పుడు, మీరు సందర్శించే కొన్ని పేజీల URLలను Brave Softwareకు పంపుతుంది</translation>
+<translation id="2063713494490388661">వెతకడానికి నొక్కండి</translation>
+<translation id="2369463299479365221">పేజీ నుండి నిష్క్రమించకుండానే వెబ్‌సైట్‌లలోని అంశాల గురించి తెలుసుకోండి. 'వెతకడానికి నొక్కండి' అనే ఫీచర్, ఒక పదాన్ని మరియు దాని చుట్టూ ఉన్న సంబంధిత సందర్భాన్ని Brave Software శోధనకు పంపుతుంది, ప్రతిస్పందనగా దాని నుండి నిర్వచనాలు, చిత్రాలు, శోధన ఫలితాలు మరియు ఇతర వివరాలు అందించబడతాయి.
 
 మీ శోధన పదాన్ని సర్దుబాటు చేయడం కోసం ఎంచుకోవడానికి ఎక్కువసేపు నొక్కి ఉంచండి. మీ శోధనను మెరుగుపరచడానికి, ప్యానెల్‌ను పూర్తిగా పైకి స్లయిడ్ చేసి, శోధన పెట్టెను నొక్కండి.</translation>
-<translation id="4056223980640387499">సెపియా</translation>
-<translation id="4060598801229743805">ఎంపికలు స్క్రీన్ పైభాగానికి సమీపంలో అందుబాటులో ఉంటాయి</translation>
-<translation id="4062305924942672200">చట్ట సంబంధిత సమాచారం</translation>
-<translation id="4084682180776658562">బుక్‌మార్క్ చేయి</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" /> నుండి – <ph name="BEGIN_DEEMPHASIZED" />Google బట్వాడా చేస్తోంది<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">యాప్‌ డేటాను తొలగించాలా?</translation>
-<translation id="4099578267706723511">వినియోగ గణాంకాలు, క్రాష్ నివేదికలను Googleకు పంపి, తద్వారా Chromeను మెరుగుపరచడంలో సహాయపడండి.</translation>
-<translation id="410351446219883937">స్వీయ ప్లే</translation>
-<translation id="4116038641877404294">పేజీలను ఆఫ్‌లైన్‌లో ఉపయోగించడం కోసం వాటిని డౌన్‌లోడ్ చేసుకోండి</translation>
-<translation id="4135200667068010335">ట్యాబ్‌ను షేర్ చేయాల్సిన పరికరాల జాబితా మూసివేయబడింది.</translation>
-<translation id="4149994727733219643">వెబ్ పేజీల కోసం సరళమైన వీక్షణ</translation>
-<translation id="4165986682804962316">సైట్ సెట్టింగ్‌లు</translation>
-<translation id="4169535189173047238">అనుమతించవద్దు</translation>
-<translation id="4170011742729630528">సేవ అందుబాటులో లేదు; తర్వాత మళ్లీ ప్రయత్నించండి.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> వినియోగించబడింది</translation>
-<translation id="4181841719683918333">భాషలు</translation>
-<translation id="4183868528246477015">Google లెన్స్‌తో శోధన <ph name="BEGIN_NEW" />కొత్తది<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">కొత్త ట్యాబ్‌లో తెరువు</translation>
-<translation id="4198423547019359126">డౌన్‌లోడ్ స్థానాలు అందుబాటులో లేవు</translation>
-<translation id="4209895695669353772">Google ద్వారా మీ అభిరుచికి తగిన కంటెంట్‌ను సిఫార్సుల రూపంలో పొందాలనుకుంటే, సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
-<translation id="4226663524361240545">నోటిఫికేషన్‌లు పరికరాన్ని వైబ్రేట్ చేయవచ్చు</translation>
-<translation id="423219824432660969"><ph name="TIME" /> నాటికి సమకాలీకరించిన డేటాని Google పాస్‌వర్డ్‌తో ఎన్‌క్రిప్ట్ చేయండి</translation>
-<translation id="4242533952199664413">సెట్టింగ్‌లను తెరువు</translation>
-<translation id="4256782883801055595">ఓపెన్ సోర్స్ లైసెన్స్‌లు</translation>
-<translation id="4259722352634471385">నావిగేషన్ బ్లాక్ చేయబడింది: <ph name="URL" /></translation>
-<translation id="4269820728363426813">లింక్ చిరునామాను కాపీ చేయి</translation>
-<translation id="4275663329226226506">మీడియా</translation>
-<translation id="4278390842282768270">అనుమతించబడింది</translation>
-<translation id="429312253194641664">ఒక సైట్‌లో మీడియా ప్లే చేయబడుతోంది</translation>
-<translation id="4298388696830689168">లింక్ చేసిన సైట్‌లు</translation>
-<translation id="4307992518367153382">ప్రాథమికాలు</translation>
-<translation id="4314815835985389558">సింక్‌ను నిర్వహించండి</translation>
-<translation id="4351244548802238354">డైలాగ్‌ను మూసివేయి</translation>
-<translation id="4378154925671717803">ఫోన్</translation>
-<translation id="4384468725000734951">శోధన కోసం Sogouను ఉపయోగిస్తుంది</translation>
-<translation id="4404568932422911380">బుక్‌మార్క్‌లు లేవు</translation>
-<translation id="4405224443901389797">ఇక్కడికి తరలించండి…</translation>
-<translation id="4411535500181276704">లైట్ మోడ్</translation>
-<translation id="4415276339145661267">మీ Google ఖాతాను నిర్వహించండి</translation>
-<translation id="4432792777822557199">ఇప్పటి నుండి <ph name="SOURCE_LANGUAGE" />లో ఉన్న పేజీలు <ph name="TARGET_LANGUAGE" />కు అనువదించబడతాయి</translation>
-<translation id="4433925000917964731">Google అందించిన లైట్ పేజీ</translation>
-<translation id="4434045419905280838">పాప్-అప్‌లు మరియు మళ్లింపులు</translation>
-<translation id="4440958355523780886">Google నుండి లైట్ పేజీ అందించబడింది. అసలు పేజీని లోడ్ చేయడానికి నొక్కండి.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> ట్యాబ్‌ను మూసివేయండి</translation>
-<translation id="4452548195519783679"><ph name="FOLDER_NAME" />కి బుక్‌మార్క్ చేసారు</translation>
-<translation id="445467742685312942">రక్షిత కంటెంట్‌ను ప్లే చేయడానికి సైట్‌లను అనుమతిస్తుంది</translation>
-<translation id="4468959413250150279">నిర్దిష్ట సైట్ కోసం ధ్వనిని మ్యూట్ చేయండి.</translation>
-<translation id="4472118726404937099">మీ అన్ని పరికరాలలో సమకాలీకరణ చేయాలన్నా లేదా మీ అభిరుచికి అనుగుణంగా సెట్ చేయాలన్నా, సైన్ ఇన్ చేసి సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
-<translation id="447252321002412580">Chrome ఫీచర్‌లు మరియు పనితీరును మెరుగుపరచడంలో సహాయపడండి</translation>
-<translation id="4479647676395637221">మీ కెమెరాను ఏవైనా సైట్‌లు ఉపయోగించగలిగేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="4479972344484327217">Chromeలో <ph name="MODULE" /> ఇన్‌స్టాల్ చేయబడుతోంది…</translation>
-<translation id="4487967297491345095">Chrome యాప్‌ డేటా మొత్తం శాశ్వతంగా తొలగించబడుతుంది. డేటాలో అన్ని ఫైల్‌లు, సెట్టింగ్‌లు, ఖాతాలు, డేటాబేస్‌లు మొదలైనవి ఉంటాయి.</translation>
-<translation id="4493497663118223949">లైట్ మోడ్ ఆన్ చేయబడింది</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# రోజు క్రితం}other{# రోజుల క్రితం}}</translation>
-<translation id="451872707440238414">మీ బుక్‌మార్క్‌లను వెతకండి</translation>
-<translation id="4521489764227272523">ఎంచుకోబడిన డేటా Chrome నుండి, సింక్ చేసిన‌ మీ పరికరాల నుండి తీసివేయబడింది.
-
-మీ Google ఖాతా <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />లో ఇతర Google సేవలకు సంబంధించిన శోధనలు, కార్యకలాపం వంటి ఇతర రకాల బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
-<translation id="4532845899244822526">ఫోల్డర్‌ను ఎంచుకోండి</translation>
-<translation id="4538018662093857852">లైట్ మోడ్‌ని ఆన్ చేయండి</translation>
-<translation id="4550003330909367850">ఇక్కడ మీ పాస్‌వర్డ్‌ను వీక్షించడానికి లేదా కాపీ చేయడానికి, ఈ డివైజ్‌లో స్క్రీన్ లాక్‌ను సెట్ చేయండి.</translation>
-<translation id="4558311620361989323">వెబ్‌పేజీ షార్ట్‌క‌ట్‌లు</translation>
-<translation id="4561979708150884304">కనెక్షన్ లేదు</translation>
-<translation id="4565377596337484307">పాస్‌వర్డ్‌ను దాచిపెట్టు</translation>
-<translation id="4570913071927164677">వివరాలు</translation>
-<translation id="4572422548854449519">నిర్వాహిత ఖాతాకు సైన్ ఇన్ చేయండి</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# నిమిషం క్రితం}other{# నిమిషాల క్రితం}}</translation>
-<translation id="4587589328781138893">సైట్‌లు</translation>
-<translation id="4594952190837476234">ఈ ఆఫ్‌లైన్ పేజీ <ph name="CREATION_TIME" />కి చెందినది మరియు ఆన్‌లైన్ వెర్షన్ వేరుగా ఉండవచ్చు.</translation>
-<translation id="4605958867780575332">ఈ అంశం తీసివేయబడింది: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" />ని తెరువు</translation>
-<translation id="4634124774493850572">పాస్‌వర్డ్‌ను ఉపయోగించు</translation>
-<translation id="4645575059429386691">మీ తల్లి/తండ్రి ద్వారా నిర్వహించబడుతోంది</translation>
-<translation id="4650364565596261010">సిస్టమ్ డిఫాల్ట్</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> బుక్‌మార్క్‌లు తొలగించబడ్డాయి</translation>
-<translation id="4665282149850138822"><ph name="NAME" /> మీ హోమ్ స్క్రీన్‌కు జోడించబడింది</translation>
-<translation id="4684427112815847243">ప్రతి ఒక్కటి సమకాలీకరించండి</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">వచనాన్ని మీ పరికరాలకు పంపండి</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" />లో ఆఫ్‌లైన్‌లో వీక్షించండి</translation>
-<translation id="4699172675775169585">కాష్ చేసిన చిత్రాలు మరియు ఫైల్‌లు</translation>
-<translation id="4714588616299687897">మీ డేటాలో 60% వరకు ఆదా చేసుకోండి</translation>
-<translation id="4719927025381752090">అనువదించమని ఆఫర్ చేయి</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" />లో తెరువు</translation>
-<translation id="4720982865791209136">Chromeను మెరుగుపరచడంలో సహాయపడండి. <ph name="BEGIN_LINK" />సర్వేలో పాల్గొనండి<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">అప్‌డేట్‌</translation>
-<translation id="4738836084190194332">చివరిగా సమకాలీకరించినది: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">కొత్త ట్యాబ్‌ను తెరవండి</translation>
-<translation id="4751476147751820511">కదలిక లేదా కాంతి సెన్సార్‌లు</translation>
-<translation id="4759238208242260848">డౌన్‌లోడ్‌లు</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 డౌన్‌లోడ్ పూర్తయింది.}other{# డౌన్‌లోడ్‌లు పూర్తయ్యాయి.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" />కి తిరిగి వెళ్లడానికి తాకండి</translation>
-<translation id="4802417911091824046">Google Payకి సంబంధించిన చెల్లింపు పద్ధతులు మరియు చిరునామాలు రహస్య పదబంధం ఎన్‌క్రిప్షన్‌లో ఉండవు.
-
-ఈ సెట్టింగ్‌ని మార్చడం కోసం, <ph name="BEGIN_LINK" />సమకాలీకరణను రీసెట్ చేయండి<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">కార్డ్‌పై పేరు</translation>
-<translation id="4824958205181053313">సింక్‌ను రద్దు చేయాలా?</translation>
-<translation id="4837753911714442426">పేజీని ముద్రించడానికి ఎంపికలను తెరవండి</translation>
-<translation id="4842092870884894799">పాస్‌వర్డ్ ఉత్పత్తి పాప్ అప్ చూపబడుతోంది</translation>
-<translation id="4860895144060829044">కాల్ చేయండి</translation>
-<translation id="4866368707455379617">Chromeలో <ph name="MODULE" />ని ఇన్‌స్టాల్ చేయడం సాధ్యపడలేదు</translation>
-<translation id="4875775213178255010">కంటెంట్ సూచనలు</translation>
-<translation id="4878404682131129617">ప్రాక్సీ సర్వర్ ద్వారా ఒక సొరంగంను ఏర్పాటు చేయడం విఫలమైంది</translation>
-<translation id="4880127995492972015">అనువదించు…</translation>
-<translation id="4881695831933465202">తెరువు</translation>
-<translation id="488187801263602086">ఫైల్ పేరు మార్చండి</translation>
-<translation id="4882831918239250449">శోధన, ప్రకటనలు మరియు మరిన్నింటిని వ్యక్తిగతీకరించడానికి మీ బ్రౌజింగ్ చరిత్ర ఎలా ఉపయోగించబడుతుందో నియంత్రించండి</translation>
-<translation id="4883854917563148705">నిర్వహిత సెట్టింగ్‌లు రీసెట్ చేయబడవు</translation>
-<translation id="4885273946141277891">మద్దతు లేనన్ని సార్లు Chromeను ప్రారంభించడానికి ప్రయత్నించారు.</translation>
-<translation id="4910889077668685004">చెల్లింపు అనువర్తనాలు</translation>
-<translation id="4913161338056004800">గణాంకాలను రీసెట్ చేయి</translation>
-<translation id="4913169188695071480">రీఫ్రెష్ చేయడం ఆపివేయి</translation>
-<translation id="4915549754973153784">పరికరాల కోసం స్కాన్ చేస్తున్నప్పుడు <ph name="BEGIN_LINK" />సహాయం పొందండి<ph name="END_LINK" />…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# పేజీ}other{# పేజీలు}}</translation>
-<translation id="4932247056774066048">మీరు <ph name="DOMAIN_NAME" /> నిర్వహణలోని ఖాతా నుండి సైన్ అవుట్ చేస్తున్నందున, ఈ పరికరం నుండి మీ Chrome డేటా తొలగించబడుతుంది. అది మీ Google ఖాతాలో అలాగే భద్రపరచబడుతుంది.</translation>
-<translation id="4943703118917034429">వర్చువల్ రియాలిటీ</translation>
-<translation id="4943872375798546930">ఫలితాలు ఏవీ లేవు</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> మీ స్క్రీన్‌ని భాగస్వామ్యం చేస్తోంది</translation>
-<translation id="4961107849584082341">ఈ పేజీని ఏ భాషలోకైనా అనువదించుకోవచ్చు</translation>
-<translation id="4962975101802056554">పరికరానికి అన్ని అనుమతులను ఉపసంహరించు</translation>
-<translation id="4970824347203572753">మీ స్థానంలో అందుబాటులో లేదు</translation>
-<translation id="497421865427891073">ముందుకు వెళ్ళు</translation>
-<translation id="4988210275050210843">ఫైల్‌ను డౌన్‌లోడ్ చేస్తోంది (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">పేజీలు</translation>
-<translation id="4994033804516042629">పరిచయాలు కనుగొనబడలేదు</translation>
-<translation id="4996978546172906250">దీని ద్వారా భాగస్వామ్యం చే.</translation>
-<translation id="5004416275253351869">Google కార్యకలాప నియంత్రణలు</translation>
-<translation id="5005498671520578047">పాస్‌వర్డ్ కాపీచేయడం</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> దీనికి కనెక్ట్ చేయాలనుకుంటోంది</translation>
-<translation id="5013696553129441713">కొత్త సూచనలు ఏవీ లేవు</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">మీరు VRలో ఉన్నప్పుడు, ఈ సైట్ కింది వాటిని గురించి తెలుసుకునే అవకాశం ఉంది:
-  -  మీ శారీరక లక్షణాలు, బరువు వంటివి
-
-VRలోకి ప్రవేశించడానికి ముందు, ఈ సైట్‌ను విశ్వసిస్తున్నట్లు నిర్ధారించండి.</translation>
+<translation id="2930742481329940825">'వెతకడానికి నొక్కండి' ఫీచర్, ఎంచుకున్న పదాన్ని మరియు ప్రస్తుత పేజీని సంబంధిత సందర్భం లాగా Brave Software శోధనకు పంపుతుంది. మీరు <ph name="BEGIN_LINK"/>సెట్టింగ్‌లు<ph name="END_LINK"/>లో దీనిని ఆఫ్ చేయవచ్చు.</translation>
 <translation id="5039804452771397117">అనుమతించు</translation>
-<translation id="5040262127954254034">గోప్యత</translation>
-<translation id="5048398596102334565">మోషన్ సెన్సార్‌లను యాక్సెస్ చేయడానికి సైట్‌లను అనుమతించండి (సిఫార్సు చేస్తున్నాము)</translation>
-<translation id="5063480226653192405">నిల్వ వినియోగం</translation>
-<translation id="5087580092889165836">కార్డ్‌ను జోడించు</translation>
-<translation id="5100237604440890931">కుదించబడింది - విస్తరింపజేయడానికి క్లిక్ చేయండి.</translation>
-<translation id="510275257476243843">1 గంట మిగిలి ఉంది</translation>
-<translation id="5123685120097942451">అజ్ఞాత ట్యాబ్</translation>
-<translation id="5127805178023152808">సమకాలీకరణ ఆఫ్‌లో ఉంది</translation>
-<translation id="5129038482087801250">వెబ్ యాప్‌ ఇన్‌స్టాల్ చేయి</translation>
-<translation id="5132942445612118989">అన్ని పరికరాల్లో మీ పాస్‌వర్డ్‌లు, చరిత్ర, మరిన్నింటిని సింక్ చేయండి</translation>
-<translation id="5139940364318403933">Google డిస్క్‌ని ఎలా ఉపయోగించాలో తెలుసుకోండి</translation>
-<translation id="515227803646670480">నిల్వ చేసిన డేటాను తీసివేయండి</translation>
-<translation id="5152843274749979095">మద్దతు గల అనువర్తనాలు ఏవీ ఇన్‌స్టాల్ చేయబడలేదు</translation>
-<translation id="5161254044473106830">శీర్షిక అవసరం</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 డౌన్‌లోడ్ విఫలమైంది.}other{# డౌన్‌లోడ్‌లు విఫలమయ్యాయి.}}</translation>
-<translation id="5170568018924773124">ఫోల్డర్‌లో చూపించు</translation>
-<translation id="5184329579814168207">Chromeలో తెరువు</translation>
-<translation id="5193988420012215838">మీ క్లిప్‌బోర్డ్‌కు కోడ్ కాపీ చేయబడింది</translation>
-<translation id="5197729504361054390">మీరు ఎంచుకున్న పరిచయాలు <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />తో షేర్ చేయబడతాయి.</translation>
-<translation id="5199929503336119739">కార్యాలయ ప్రొఫైల్</translation>
-<translation id="5210286577605176222">మునుపటి ట్యాబ్‌కు వెళ్లండి</translation>
-<translation id="5210365745912300556">ట్యాబ్‌ను మూసివేయి</translation>
-<translation id="5224771365102442243">వీడియోతో</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> సమీపంలోని బ్లూటూత్ పరికరాల కోసం స్కాన్ చేయాలనుకుంటోంది. కింది పరికరాలు కనుగొనబడ్డాయి:</translation>
-<translation id="5233638681132016545">కొత్త‌ టాబ్</translation>
-<translation id="526421993248218238">ఈ పేజీని లోడ్ చేయడం సాధ్యం కాదు</translation>
-<translation id="5271967389191913893">పరికరం డౌన్‌లోడ్ చేయాల్సిన కంటెంట్‌ను తెరవలేదు.</translation>
-<translation id="528192093759286357">పూర్తి స్క్రీన్ నుండి నిష్క్రమించడానికి పైనుండి లాగి, వెనుకకు బటన్‌ను తాకండి.</translation>
-<translation id="5292796745632149097">ఈ పరికరానికి పంపండి</translation>
-<translation id="5300589172476337783">చూపించు</translation>
-<translation id="5301954838959518834">సరే, అర్థమైంది</translation>
-<translation id="5304593522240415983">ఈ ఫీల్డ్ ఖాళీగా ఉండరాదు</translation>
-<translation id="5307446750509046227">సైట్ నిల్వను తీసివేయండి</translation>
-<translation id="5308380583665731573">కనెక్ట్ చేయండి</translation>
-<translation id="5313967007315987356">సైట్‌ను జోడించు</translation>
-<translation id="5317780077021120954">సేవ్ చేయి</translation>
-<translation id="5324858694974489420">పేరెంటల్ సెట్టింగ్‌లు</translation>
-<translation id="5327248766486351172">పేరు</translation>
-<translation id="5335288049665977812">సైట్‌లను జావాస్క్రిప్ట్ అమలు చేయడానికి అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="5342314432463739672">అనుమతి అభ్యర్థనలు</translation>
-<translation id="5357811892247919462">ట్యాబ్‌ను అందుకున్నారు</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> ట్యాబ్ తెరవబడి ఉంది, ట్యాబ్‌లను మార్చడం కోసం నొక్కండి}other{<ph name="OPEN_TABS_MANY" /> ట్యాబ్‌లు తెరవబడి ఉన్నాయి, ట్యాబ్‌లను మార్చడం కోసం నొక్కండి}}</translation>
-<translation id="5391532827096253100">ఈ సైట్‌కి మీ కనెక్షన్ సురక్షితంగా లేదు. సైట్ సమాచారం</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ మరో 1)}other{(+ మరో #)}}</translation>
-<translation id="5400569084694353794">ఈ అప్లికేషన్‌ను ఉపయోగించడం ద్వారా, మీరు Chrome <ph name="BEGIN_LINK1" />సేవా నిబంధనలు<ph name="END_LINK1" /> మరియు <ph name="BEGIN_LINK2" />గోప్యతా నోటీసు<ph name="END_LINK2" />ను అంగీకరిస్తున్నారు.</translation>
-<translation id="5403592356182871684">పేర్లు</translation>
-<translation id="5403644198645076998">నిర్దిష్ట సైట్‌లను మాత్రమే అనుమతించండి</translation>
-<translation id="5414836363063783498">ధృవీకరిస్తోంది...</translation>
-<translation id="5423934151118863508">మీరు అత్యంత ఎక్కువగా సందర్శించిన పేజీలు ఇక్కడ కనిపిస్తాయి</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB అందుబాటులో ఉంది</translation>
-<translation id="543338862236136125">పాస్‌వర్డ్‌ను సవరించు</translation>
-<translation id="5433691172869980887">వినియోగదారు పేరు కాపీ చేయబడింది</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> ఫైల్‌లను డౌన్‌లోడ్ చేస్తోంది (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">చిరునామా పట్టీకి వెళ్లండి</translation>
-<translation id="5447201525962359567">కుక్కీలు, స్థానికంగా నిల్వ చేసిన ఇతర డేటాతో సహా మొత్తం సైట్ నిల్వ</translation>
-<translation id="5447765697759493033">ఈ సైట్ అనువదించబడదు</translation>
-<translation id="545042621069398927">మీ డౌన్‌లోడ్‌‌ను వేగవంతం చేస్తోంది.</translation>
-<translation id="5456381639095306749">పేజీని డౌన్‌లోడ్ చేయండి</translation>
-<translation id="5475862044948910901">అగ్‌మెంటెడ్ రియాలిటీ సెషన్‌ను ప్రారంభించాలా?</translation>
-<translation id="548278423535722844">మ్యాప్స్ యాప్‌లో తెరువు</translation>
-<translation id="5487521232677179737">డేటాని తీసివేయి</translation>
-<translation id="5494752089476963479">అనుచితమైన లేదా తప్పుదారి పట్టించే ప్రకటనలను చూపించే సైట్‌లలో ప్రకటనలను బ్లాక్ చేస్తుంది</translation>
-<translation id="5500777121964041360">మీ స్థానంలో అందుబాటులో ఉండకపోవచ్చు</translation>
-<translation id="5512137114520586844">ఈ ఖాతా <ph name="PARENT_NAME" /> నిర్వహణలో ఉంది.</translation>
-<translation id="5514904542973294328">ఈ పరికర నిర్వాహకులు నిలిపివేశారు</translation>
-<translation id="5515439363601853141">మీ పాస్‌వర్డ్‌ను చూడడానికి అన్‌లాక్ చేయండి</translation>
-<translation id="5516455585884385570">నోటిఫికేషన్ సెట్టింగ్‌లను తెరువు</translation>
-<translation id="5517095782334947753">మీరు <ph name="FROM_ACCOUNT" /> నుండి బుక్‌మార్క్‌లు, చరిత్ర, పాస్‌వర్డ్‌లు మరియు ఇతర సెట్టింగ్‌లను కలిగి ఉన్నారు.</translation>
-<translation id="5524843473235508879">మళ్లింపు బ్లాక్ చేయబడింది.</translation>
-<translation id="5527082711130173040">పరికరాల కోసం స్కాన్ చేయడానికి Chromeకు స్థాన యాక్సెస్ అవసరం. <ph name="BEGIN_LINK1" />అనుమతులను అప్‌డేట్ చేయండి<ph name="END_LINK1" />. అలాగే స్థాన యాక్సెస్ <ph name="BEGIN_LINK2" />ఈ పరికరానికి ఆఫ్ చేయబడింది<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">క్లిప్‌బోర్డ్ నుండి వచనం మరియు చిత్రాలను చదవడానికి అనుమతించే ముందు సమ్మతి అడగాలి (సిఫార్సు చేస్తున్నాము)</translation>
-<translation id="5530766185686772672">అజ్ఞాత ట్యాబ్‌లను మూసివేయి</translation>
-<translation id="5534334044554683961">మీరు VRలో ఉన్నప్పుడు, ఈ సైట్ కింది వాటిని గురించి తెలుసుకునే అవకాశం ఉంది:
-  -    మీ శారీరక లక్షణాలు, బరువు వంటివి
-  -   మీ గది లేఅవుట్
-
-VRలోకి ప్రవేశించడానికి ముందు, ఈ సైట్‌ను విశ్వసిస్తున్నట్లు నిర్ధారించండి.</translation>
-<translation id="5534640966246046842">సైట్ కాపీ చేయబడింది</translation>
-<translation id="5556459405103347317">మళ్లీ లోడ్ చేయి</translation>
-<translation id="5561549206367097665">నెట్‌వర్క్ కోసం వేచి ఉంది…</translation>
-<translation id="557283862590186398">ఈ సైట్ కోసం మీ మైక్రోఫోన్‌ను యాక్సెస్ చేయడానికి Chromeకు అనుమతి అవసరం.</translation>
-<translation id="55737423895878184">స్థానం మరియు నోటిఫికేషన్‌లు అనుమతించబడతాయి</translation>
-<translation id="5578795271662203820">ఈ చిత్రం కోసం <ph name="SEARCH_ENGINE" />లో వెతకండి</translation>
-<translation id="5581519193887989363">మీరు ఎప్పుడైనా <ph name="BEGIN_LINK1" />సెట్టింగ్‌ల<ph name="END_LINK1" /> ద్వారా వేటిని సింక్ చేయాలో ఎంచుకోవచ్చు.</translation>
-<translation id="5595485650161345191">చిరునామాను సవరించు</translation>
-<translation id="5596627076506792578">మరిన్ని ఎంపికలు</translation>
-<translation id="5599455543593328020">అజ్ఞాత మోడ్</translation>
-<translation id="5620928963363755975">'మరిన్ని ఎంపికలు' బటన్ నొక్కి, డౌన్‌లోడ్‌లలో మీ ఫైల్‌లు మరియు పేజీలను కనుగొనండి</translation>
-<translation id="5626134646977739690">పేరు:</translation>
-<translation id="5639724618331995626">అన్ని సైట్‌లను అనుమతించండి</translation>
-<translation id="5648166631817621825">గత 7 రోజులు</translation>
-<translation id="5649053991847567735">ఆటోమేటిక్ డౌన్‌లోడ్‌లు</translation>
-<translation id="5655963694829536461">మీ డౌన్‌లోడ్‌లను వెతకండి</translation>
-<translation id="5659593005791499971">ఇమెయిల్</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" />లో ఈవెంట్‌ను సృష్టించండి</translation>
-<translation id="5668404140385795438">దగ్గరకు జూమ్ చేయడాన్ని నిరోధించడానికి ప్రయత్నించే వెబ్‌సైట్ అభ్యర్థనను పట్టించుకోదు</translation>
-<translation id="5677928146339483299">బ్లాక్ చేయబడింది</translation>
-<translation id="5684874026226664614">అయ్యో. ఈ పేజీని అనువదించడం సాధ్యపడలేదు.</translation>
-<translation id="5686790454216892815">ఫైల్ పేరు చాలా పొడవుగా ఉంది</translation>
-<translation id="5689516760719285838">స్థానం</translation>
-<translation id="569536719314091526">మరిన్ని ఎంపికలు బటన్‌ని ఉపయోగించి ఈ పేజీని ఏ భాషలోకైనా అనువదించుకోవచ్చు</translation>
-<translation id="572328651809341494">ఇటీవలి ట్యాబ్‌లు</translation>
-<translation id="5726692708398506830">పేజీలోని అన్నింటినీ పెద్దవిగా చేయండి</translation>
-<translation id="5748802427693696783">ప్రామాణిక ట్యాబ్‌లకు మార్చబడింది</translation>
-<translation id="5749068826913805084">ఫైల్‌లను డౌన్‌లోడ్ చేయడానికి Chromeకు నిల్వ యాక్సెస్ అవసరం.</translation>
-<translation id="5763382633136178763">అజ్ఞాత ట్యాబ్‌లు</translation>
-<translation id="5763514718066511291">ఈ యాప్ URLను కాపీ చేయడానికి నొక్కండి</translation>
-<translation id="5765780083710877561">వివరణ:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE" />లో <ph name="SPACE_USED" /> ఉపయోగించబడింది</translation>
-<translation id="5797070761912323120">శోధన, ప్రకటనలు, ఇతర Google సేవలను వ్యక్తిగతీకరించడానికి Google మీ చరిత్రను ఉపయోగించే అవకాశం ఉంటుంది</translation>
-<translation id="5804241973901381774">అనుమతులు</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# గంట క్రితం}other{# గంటల క్రితం}}</translation>
-<translation id="5810288467834065221">కాపీరైట్ <ph name="YEAR" /> Google LLC. సర్వ హక్కులు ప్రత్యేకించబడ్డాయి.</translation>
-<translation id="5817918615728894473">జత చేయి</translation>
-<translation id="583281660410589416">తెలియని</translation>
-<translation id="5833984609253377421">లింక్‌ను షేర్ చేయి</translation>
-<translation id="5836192821815272682">Chrome అప్‌డేట్‌ను డౌన్‌లోడ్ చేస్తోంది…</translation>
-<translation id="5853623416121554550">పాజ్ చేయబడింది</translation>
-<translation id="5854790677617711513">30 రోజుల కన్నా పాతవి</translation>
-<translation id="5858741533101922242">Chrome బ్లూటూత్ అడాప్టర్‌ను ఆన్ చేయలేకపోయింది</translation>
-<translation id="5860033963881614850">ఆఫ్ అయ్యింది</translation>
-<translation id="5862731021271217234">మీ ఇతర పరికరాలలో ఉన్న మీ అన్ని ట్యాబ్‌లను పొందాలనుకుంటే, సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
-<translation id="5864174910718532887">వివరాలు: సైట్ పేరుతో క్రమీకరించబడ్డాయి</translation>
-<translation id="5864419784173784555">మరొక డౌన్‌లోడ్ కోసం వేచి ఉంది…</translation>
-<translation id="5865733239029070421">Googleకు ఆటోమేటిక్‌గా వినియోగ గణాంకాలను, క్రాష్ నివేదికలను పంపుతుంది</translation>
-<translation id="5869522115854928033">సేవ్  చేసిన పాస్‌వర్డ్‌లు</translation>
-<translation id="5902828464777634901">కుక్కీలతో సహా ఈ వెబ్‌సైట్ ద్వారా నిల్వ చేయబడిన మొత్తం స్థానిక డేటా తొలగించబడుతుంది.</translation>
-<translation id="5916664084637901428">ఆన్ చేయి</translation>
-<translation id="5919204609460789179">సింక్‌ను ప్రారంభించడానికి <ph name="PRODUCT_NAME" />ని అప్‌డేట్ చేయండి</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> సేవ్ చేయబడింది</translation>
-<translation id="5939518447894949180">రీసెట్ చేయి</translation>
-<translation id="5942872142862698679">శోధన కోసం Googleను ఉపయోగిస్తోంది</translation>
-<translation id="5952764234151283551">మీరు చేరుకోవాలని ప్రయత్నిస్తున్న పేజీ URLని Googleకి పంపుతుంది</translation>
-<translation id="5956665950594638604">Chrome సహాయ కేంద్రాన్ని కొత్త ట్యాబ్‌లో తెరవండి</translation>
-<translation id="5958275228015807058">డౌన్‌లోడ్‌లలో మీ ఫైల్‌లు మరియు పేజీలను కనుగొనండి</translation>
-<translation id="5962718611393537961">కుదించడానికి నొక్కండి</translation>
-<translation id="6000066717592683814">Googleని ఉంచు</translation>
-<translation id="6005538289190791541">సూచించబడిన పాస్‌వర్డ్‌</translation>
-<translation id="6036057147555329831">అదనపు ICU</translation>
-<translation id="6039379616847168523">తదుపరి ట్యాబ్‌కు వెళ్లండి</translation>
-<translation id="6040143037577758943">మూసివేయి</translation>
-<translation id="6042308850641462728">మరింత</translation>
-<translation id="604996488070107836">తెలియని ఎర్ర‌ర్‌ కారణంగా <ph name="FILE_NAME" /> డౌన్‌లోడ్ విఫలమైంది.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">పూర్తయిన డౌన్‌లోడ్‌లు</translation>
-<translation id="6075798973483050474">హోమ్ పేజీని సవరించండి</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> గంటలు మిగిలి ఉంది</translation>
-<translation id="6108923351542677676">సెటప్ ప్రోగ్రెస్‌లో ఉంది...</translation>
-<translation id="6111020039983847643">వినియోగించిన డేటా</translation>
-<translation id="6112702117600201073">పేజీని రిఫ్రెష్ చేస్తోంది</translation>
-<translation id="6127379762771434464">అంశాన్ని తీసివేసారు</translation>
-<translation id="6140912465461743537">దేశం/ప్రాంతం</translation>
-<translation id="614940544461990577">ఇలా చేసి ప్రయత్నించండి:</translation>
-<translation id="6154478581116148741">ఈ పరికరం నుండి మీ పాస్‌వర్డ్‌లను ఎగుమతి చేయడానికి సెట్టింగ్‌లలో స్క్రీన్ లాక్‌ను ఆన్ చేయండి</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> డేటా పొదుపులు</translation>
-<translation id="6165508094623778733">మరింత తెలుసుకోండి</translation>
-<translation id="6177111841848151710">ప్రస్తుత శోధన ఇంజిన్‌కు బ్లాక్ చేయబడింది</translation>
-<translation id="6181444274883918285">సైట్ మినహాయింపును జోడించు</translation>
-<translation id="6192333916571137726">ఫైల్‌ను డౌన్‌లోడ్ చేయండి</translation>
-<translation id="6192792657125177640">మినహాయింపులు</translation>
-<translation id="6194112207524046168">మీ కెమెరాను యాక్సెస్ చేయడానికి Chromeను అనుమతించేందుకు, <ph name="BEGIN_LINK" />Android సెట్టింగ్‌ల<ph name="END_LINK" />లో కూడా కెమెరాను ఆన్ చేయండి.</translation>
-<translation id="6196640612572343990">మూడవ పక్షం కుక్కీలను బ్లాక్ చేయి</translation>
-<translation id="6206551242102657620">కనెక్షన్ సురక్షితం. సైట్ సమాచారం</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> కాదా?</translation>
-<translation id="6221633008163990886">మీ పాస్‌వర్డ్‌లను ఎగుమతి చేయడానికి అన్‌లాక్ చేయండి</translation>
+<translation id="1406000523432664303">“ట్రాక్ చేయవద్దు”</translation>
 <translation id="6232535412751077445">“ట్రాక్ చేయవద్దు”ను ప్రారంభించడం వ‌ల్ల‌ మీ బ్రౌజింగ్ ట్రాఫిక్‌తో పాటు ఒక అభ్యర్థన చేర్చబడుతుంది. ఆ అభ్యర్థనకు వెబ్‌సైట్ ప్రతిస్పందించిందా లేదా మరియు అభ్యర్థన ఎలా ప‌రిగ‌ణించ‌బ‌డింది అనే వాటిపై ఏ ప్రభావం అయినా ఆధారపడి ఉంటుంది. 
 
 ఉదాహరణకు, కొన్ని వెబ్‌సైట్‌లు ఈ అభ్యర్థనకు ప్రతిస్పందనగా మీరు సందర్శించిన ఇతర వెబ్‌సైట్‌ల ఆధారితం కాని ప్రకటనలను మీకు చూపుతాయి. అనేక వెబ్‌సైట్‌లు భద్రతను మెరుగుపరచడం, కంటెంట్, ప్రకటనలు మరియు సిఫార్సులను అందించడం మరియు నివేదన గణాంకాలను రూపొందించడం మొదలైనవాటి కోసం ఇప్పటికీ మీ బ్రౌజింగ్ డేటాను సేకరించి, ఉపయోగిస్తాయి.</translation>
-<translation id="624789221780392884">అప్‌డేట్‌ సిద్ధంగా ఉంది</translation>
-<translation id="6255999984061454636">కంటెంట్ సూచనలు</translation>
-<translation id="6277522088822131679">పేజీని ముద్రిస్తున్నప్పుడు సమస్య ఏర్పడింది. దయచేసి మళ్లీ ప్రయత్నించండి.</translation>
-<translation id="6295158916970320988">అన్ని సైట్‌లు</translation>
-<translation id="629730747756840877">ఖాతా</translation>
-<translation id="6303969859164067831">సైన్ అవుట్ చేసి, సమకాలీకరణను ఆఫ్ చేయండి</translation>
-<translation id="6316139424528454185">Android వెర్షన్‌కు మద్దతు లేదు</translation>
-<translation id="6320088164292336938">వైబ్రేట్ చేయి</translation>
-<translation id="6324034347079777476">Android సిస్టమ్ సమకాలీకరణ నిలిపివేయబడింది</translation>
-<translation id="6333140779060797560"><ph name="APPLICATION" /> ద్వారా భాగస్వామ్యం చేయి</translation>
-<translation id="6337234675334993532">ఎన్‌క్రిప్షన్</translation>
-<translation id="6341580099087024258">ఫైల్‌లను ఎక్కడ సేవ్ చేయాలో అడుగు</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">చరిత్ర నుండి సూచనను తీసివేయాలా?</translation>
-<translation id="6369229450655021117">ఇక్కడ నుండి, మీరు వెబ్‌లో వెతకవచ్చు, స్నేహితులతో షేర్ చేసుకోవచ్చు, తెరిచి ఉన్న పేజీలను చూడవచ్చు</translation>
-<translation id="6378173571450987352">వివరాలు: ఉపయోగించిన డేటా మొత్తం ద్వారా క్రమీకరించబడ్డాయి</translation>
-<translation id="6381421346744604172">వెబ్‌సైట్‌లు ముదురు రంగులో చేయి</translation>
-<translation id="6388207532828177975">క్లియర్ చేసి, రీసెట్ చేయి</translation>
-<translation id="6393863479814692971">ఈ సైట్ కోసం మీ కెమెరా మరియు మైక్రోఫోన్‌ను యాక్సెస్ చేయడానికి Chromeకు అనుమతి అవసరం.</translation>
-<translation id="6395288395575013217">లింక్</translation>
-<translation id="6404511346730675251">బుక్‌మార్క్‌ను సవరించు</translation>
-<translation id="6406506848690869874">Sync</translation>
-<translation id="641643625718530986">ముద్రించు…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB డౌన్‌లోడ్ చేయబడింది</translation>
-<translation id="6427112570124116297">వెబ్‌ను అనువదించండి</translation>
-<translation id="6433501201775827830">మీ శోధన ఇంజిన్‌ను ఎంచుకోండి</translation>
-<translation id="6437478888915024427">పేజీ సమాచారం</translation>
-<translation id="6441734959916820584">పేరు చాలా పొడువు ఉంది</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ఫోటో}other{# ఫోటోలు}}</translation>
-<translation id="6447842834002726250">కుక్కీలు</translation>
-<translation id="6461962085415701688">ఫైల్‌ను తెరవడం సాధ్యపడదు</translation>
-<translation id="6464977750820128603">Chromeలో మీరు ఏయే సైట్‌లను సందర్శించారో చూడవచ్చు, వాటికి టైమర్‌లను సెట్ చేయవచ్చు.\n\nమీరు టైమర్‌లను సెట్ చేసిన సైట్‌ల సమాచారం, మీరు ఎంతసేపు వాటిని సందర్శించారనే వివరాలు Googleకు అందించబడతాయి. డిజిటల్ సంక్షేమాన్ని మరింత మెరుగుపరచడానికి ఈ సమాచారం ఉపయోగించబడుతుంది.</translation>
-<translation id="6475951671322991020">వీడియోను డౌన్‌లోడ్ చేయి</translation>
-<translation id="6482749332252372425">నిల్వ స్థలం లేనందున <ph name="FILE_NAME" /> డౌన్‌లోడ్ విఫలమైంది.</translation>
-<translation id="6496823230996795692">మొదటి సారి <ph name="APP_NAME" />ని ఉపయోగించడానికి, దయచేసి ఇంటర్నెట్‌కు కనెక్ట్ చేయండి.</translation>
-<translation id="6508722015517270189">Chromeను పునఃప్రారంభించండి</translation>
-<translation id="6527303717912515753">భాగస్వామ్యం చేయి</translation>
-<translation id="6532866250404780454">మీరు Chromeలో సందర్శించిన సైట్‌లు చూపబడవు. అన్ని సైట్ టైమర్‌లు తొలగించబడతాయి.</translation>
-<translation id="6534565668554028783">Google ప్రతిస్పందించడానికి చాలా ఎక్కువ సమయం తీసుకుంది</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB డౌన్‌లోడ్ చేయబడింది</translation>
-<translation id="6539092367496845964">ఏదో తప్పు జరిగింది. తర్వాత మళ్లీ ప్రయత్నించండి.</translation>
-<translation id="654446541061731451">Beam చేయడానికి ట్యాబ్‌ను ఎంచుకోండి</translation>
-<translation id="6545017243486555795">మొత్తం డేటాను తీసివేయి</translation>
-<translation id="6545864417968258051">బ్లూటూత్ స్కానింగ్</translation>
-<translation id="6560414384669816528">Sogouతో వెతకండి</translation>
-<translation id="6566259936974865419">Chrome మీకు <ph name="GIGABYTES" /> GB ఆదా చేసింది</translation>
-<translation id="6573096386450695060">ఎల్లప్పుడూ అనుమతించు</translation>
-<translation id="6573431926118603307">మీరు మీ ఇతర పరికరాల్లోని Chromeలో తెరిచిన ట్యాబ్‌లు ఇక్కడ చూపబడతాయి.</translation>
-<translation id="6583199322650523874">ప్రస్తుత పేజీని బుక్‌మార్క్ చేయండి</translation>
-<translation id="6593061639179217415">డెస్క్‌టాప్ సైట్</translation>
-<translation id="6600954340915313787">Chromeకి కాపీ చేయబడింది</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">రక్షిత కంటెంట్</translation>
-<translation id="6627583120233659107">ఫోల్డర్‌ను సవరించు</translation>
-<translation id="6643016212128521049">క్లియర్ చేయి</translation>
-<translation id="6643649862576733715">సేవ్ చేసిన డేటా పరిమాణం ద్వారా క్రమీకరించు</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194"><ph name="BEGIN_NEW" />కొత్త<ph name="END_NEW" /> చిత్రం ప్రివ్యూ చేయండి</translation>
-<translation id="6656545060687952787">పరికరాల కోసం స్కాన్ చేయడానికి Chromeకు స్థాన యాక్సెస్ అవసరం. <ph name="BEGIN_LINK" />అనుమతులను అప్‌డేట్ చేయండి<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">పాస్‌వర్డ్</translation>
-<translation id="6659594942844771486">ట్యాబ్</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" />లో తెరువు</translation>
-<translation id="666981079809192359">Chrome గోప్యతా నోటీసు</translation>
-<translation id="6676840375528380067">ఈ పరికరం నుండి మీ Chrome డేటాని తీసివేయాలా?</translation>
-<translation id="6697492270171225480">పేజీ కనుగొనబడనప్పుడు అటువంటి పేజీల కోసం సూచనలను చూపుతుంది</translation>
-<translation id="6697947395630195233">ఈ సైట్‌తో మీ స్థానాన్ని షేర్ చేయడానికి Chromeకు మీ స్థాన యాక్సెస్ అవసరం.</translation>
-<translation id="6698801883190606802">సమకాలీకరించిన డేటాను నిర్వహించండి</translation>
-<translation id="6699370405921460408">మీరు సందర్శించే పేజీలను Google సర్వర్‌లు ఆప్టిమైజ్ చేస్తాయి.</translation>
-<translation id="6706288973712894588">మీరు ప్రస్తుతం ఆఫ్‌లైన్‌లో ఉన్నారు.\n<ph name="BEGIN_LINK" />మీ ఆఫ్‌లైన్ ఫీడ్‌ను అన్వేషించండి.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">వార్తలు</translation>
-<translation id="6710213216561001401">మునుపటి</translation>
-<translation id="671481426037969117">మీ <ph name="FQDN" /> టైమర్ పూర్తయింది. అది మళ్లీ రేపు ప్రారంభమవుతుంది.</translation>
-<translation id="6738867403308150051">డౌన్‌లోడ్ చేస్తోంది...</translation>
-<translation id="6746124502594467657">క్రిందికి తరలించు</translation>
-<translation id="6766622839693428701">మూసివేయడానికి దిగువకు స్వైప్ చేయండి.</translation>
-<translation id="6766758767654711248">సైట్‌లోకి వెళ్లడం కోసం నొక్కండి</translation>
-<translation id="6767294960381293877">ట్యాబ్‌ను షేర్ చేయాల్సిన పరికరాల జాబితా సగం ఎత్తులో తెరవబడింది.</translation>
-<translation id="6782111308708962316">మూడవ పక్షం వెబ్‌సైట్‌లను కుక్కీ డేటా సేవ్ చేయనీయకుండా, చదవనీయకుండా నిరోధించు</translation>
-<translation id="6790428901817661496">ప్లే చేయి</translation>
-<translation id="6811034713472274749">పేజీ వీక్షించడానికి సిద్ధంగా ఉంది</translation>
-<translation id="6818926723028410516">అంశాలను ఎంచుకోండి</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">అనువదించు</translation>
-<translation id="6845325883481699275">Chrome భద్రతను మెరుగుపరచడంలో సహాయం చేయండి</translation>
-<translation id="6846298663435243399">లోడ్ అవుతోంది...</translation>
-<translation id="6850409657436465440">మీ డౌన్‌లోడ్‌‌ ఇప్పటికీ జరుగుతోంది</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> ట్యాబ్‌లు మూసివేయబడ్డాయి</translation>
-<translation id="6864459304226931083">చిత్రాన్ని డౌన్‌లోడ్ చేయి</translation>
-<translation id="6865313869410766144">స్వీయపూర్తి ఫారమ్ డేటా</translation>
-<translation id="688738109438487280">ఇప్పటికే ఉన్న డేటాను <ph name="TO_ACCOUNT" />కి జోడించండి.</translation>
-<translation id="6891726759199484455">మీ పాస్‌వర్డ్‌ను కాపీ చేయడానికి అన్‌లాక్ చేయండి</translation>
-<translation id="6896758677409633944">కాపీ చేయి</translation>
-<translation id="6910211073230771657">తొలగించబడింది</translation>
-<translation id="6912998170423641340">క్లిప్‌బోర్డ్ నుండి వచనం మరియు చిత్రాలను చదవకుండా సైట్‌లు బ్లాక్ చేయబడతాయి</translation>
-<translation id="6914783257214138813">ఎగుమతి చేయబడిన ఫైల్‌ను చూడగల ఎవరికైనా మీ పాస్‌వర్డ్‌లు కనిపిస్తాయి.</translation>
-<translation id="6942665639005891494">సెట్టింగ్‌ల మెనూ ఎంపికను ఉపయోగించి డిఫాల్ట్ డౌన్‌లోడ్ స్థానాన్ని మార్చండి</translation>
-<translation id="6945221475159498467">ఎంచుకోండి</translation>
-<translation id="6963642900430330478">ఈ పేజీ ప్రమాదకరమైనది. సైట్ సమాచారం</translation>
-<translation id="6963766334940102469">బుక్‌మార్క్‌లను తొలగించు</translation>
-<translation id="6965382102122355670">సరే</translation>
-<translation id="6979737339423435258">మొత్తం సమయం</translation>
-<translation id="6981982820502123353">యాక్సెస్‌</translation>
-<translation id="6989267951144302301">డౌన్‌లోడ్ సాధ్యపడలేదు</translation>
-<translation id="6990079615885386641">Google Play Store నుండి యాప్‌ను పొందండి: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">మీ మైక్రోఫోన్‌ను ఏవైనా సైట్‌లు ఉపయోగించగలిగేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="7015203776128479407">ప్రాథమిక సింక్ సెటప్ పూర్తి కాలేదు. సింక్ ఆఫ్‌లో ఉంది.</translation>
-<translation id="7016516562562142042">ప్రస్తుత శోధన ఇంజిన్‌కు అనుమతించబడింది</translation>
-<translation id="7022756207310403729">బ్రౌజర్‌లో తెరువు</translation>
-<translation id="702463548815491781">TalkBack లేదా స్విచ్ యాక్సెస్ ఆన్‌లో ఉన్నప్పుడు సిఫార్సు చేయబడింది</translation>
-<translation id="7029809446516969842">పాస్‌వర్డ్‌లు</translation>
-<translation id="7053983685419859001">నిరోధించు</translation>
-<translation id="7055152154916055070">మళ్లింపు బ్లాక్ చేయబడింది:</translation>
-<translation id="7063006564040364415">సింక్ సర్వర్‌కు కనెక్ట్ చేయడం సాధ్యపడలేదు.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ఎంచుకోబడింది}other{# ఎంచుకోబడ్డాయి}}</translation>
-<translation id="7071521146534760487">ఖాతాను నిర్వహిస్తుంది</translation>
-<translation id="7077143737582773186">SD కార్డ్</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> ఎంచుకోబడ్డాయి.  ఎంపికలు స్క్రీన్ పైభాగానికి సమీపంలో అందుబాటులో ఉన్నాయి</translation>
-<translation id="7121362699166175603">చిరునామా బార్‌లో చరిత్ర, స్వీయపూరింపులను తొలగిస్తుంది. మీ Google ఖాతా <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />లో ఇతర రూపాల్లో ఉన్న బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
-<translation id="7128222689758636196">ప్రస్తుత శోధన ఇంజిన్‌కు అనుమతిస్తుంది</translation>
-<translation id="7138678301420049075">ఇతర</translation>
-<translation id="7141896414559753902">మళ్లింపులు, పాప్-అప్‌లను చూపనివ్వకుండా సైట్‌లను బ్లాక్ చేస్తుంది (సిఫార్సు చేయడమైనది)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> నుండి <ph name="BEGIN_LINK" />అసలైన పేజీని లోడ్ చేయండి<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">గత 72 గంటలు</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">మీరు దీన్ని తర్వాత సెట్టింగ్‌లలో మార్చవచ్చు</translation>
-<translation id="7180611975245234373">రిఫ్రెష్ చేయి</translation>
-<translation id="7189372733857464326">Google Play సేవల నవీకరణ పూర్తి కావడానికి వేచి ఉంది</translation>
-<translation id="7191430249889272776">బ్యాక్‌గ్రౌండ్‌లో ట్యాబ్ తెరవబడింది.</translation>
-<translation id="723171743924126238">చిత్రాలను ఎంచుకోండి</translation>
-<translation id="7233236755231902816">మీ భాషలో వెబ్‌ను చూడడానికి, Chrome యొక్క తాజా వెర్షన్‌ను డౌన్‌లోడ్ చేసుకోండి</translation>
-<translation id="7243308994586599757">స్క్రీన్ దిగువభాగం సమీపంలో ఎంపికలు అందుబాటులో ఉంటాయి</translation>
-<translation id="7248069434667874558">Chromeలో <ph name="TARGET_DEVICE_NAME" />కు సింక్ ఆన్ చేయబడి ఉందని నిర్ధారించుకోండి</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> ఎంచుకోబడ్డాయి</translation>
-<translation id="7274013316676448362">బ్లాక్ చేసిన సైట్</translation>
-<translation id="7290209999329137901">పేరు మార్పు అందుబాటులో లేదు</translation>
-<translation id="7291387454912369099">అసిస్టెంట్ ప్రేరేపిత చెక్‌అవుట్</translation>
-<translation id="7293171162284876153">సింక్‌ను మొదలుపెట్టడానికి, "మీ Chrome డేటాను సింక్ చేయడం" ఆన్ చేయండి</translation>
-<translation id="729975465115245577">పాస్‌వర్డ్‌ల ఫైల్‌ను నిల్వ చేయడానికి మీ పరికరంలో యాప్ లేదు.</translation>
-<translation id="7302081693174882195">వివరాలు: సేవ్ చేసిన డేటా మొత్తం ద్వారా క్రమీకరించబడ్డాయి</translation>
-<translation id="7328017930301109123">లైట్ మోడ్‌లో, Chrome పేజీలను వేగంగా లోడ్ చేస్తుంది, అలాగే 60 శాతం తక్కువ డేటాను ఉపయోగిస్తుంది.</translation>
-<translation id="7333031090786104871">ఇంకా మునుపటి సైట్‌ను జోడిస్తోంది</translation>
-<translation id="7352939065658542140">వీడియో</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{ఎంచుకోబడిన 1 అంశాన్ని భాగస్వామ్యం చేస్తుంది}other{ఎంచుకోబడిన # అంశాలను భాగస్వామ్యం చేస్తుంది}}</translation>
 <translation id="7359002509206457351">మీ చెల్లింపు పద్ధతులను యాక్సెస్ చేయనీయడం</translation>
+<translation id="8026334261755873520">బ్రౌజింగ్ డేటా క్లియర్ చేయండి</translation>
+<translation id="1291207594882862231">చరిత్ర, కుక్కీలు, సైట్ డేటా, కాష్‌ను తీసివేస్తుంది…</translation>
+<translation id="7814200940910057384">Brave డేటా తీసివేయబడింది</translation>
+<translation id="1664855196866195614">ఎంచుకోబడిన డేటా Brave నుండి, సింక్ చేసిన‌ మీ పరికరాల నుండి తీసివేయబడింది.
+
+మీ Brave Software ఖాతా <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>లో ఇతర Brave Software సేవలకు సంబంధించిన శోధనలు, కార్యకలాపం వంటి ఇతర రకాల బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
+<translation id="4699172675775169585">కాష్ చేసిన చిత్రాలు మరియు ఫైల్‌లు</translation>
+<translation id="2496180316473517155">బ్రౌజింగ్ చరిత్ర</translation>
+<translation id="2546283357679194313">కుక్కీలు మరియు సైట్ డేటా</translation>
+<translation id="8662811608048051533">చాలా సైట్‌ల నుండి మిమ్మల్ని సైన్ అవుట్ చేస్తుంది.</translation>
+<translation id="8218628800671693884">దాదాపు అన్ని సైట్‌ల నుండి మిమ్మల్ని సైన్ అవుట్ చేస్తుంది. మీరు మీ Brave Software ఖాతా నుండి సైన్ అవుట్ చేయబడరు.</translation>
+<translation id="2017836877785168846">చిరునామా బార్‌లో చరిత్రను మరియు స్వీయ పూరణలను క్లియర్ చేస్తుంది.</translation>
+<translation id="8096327394278038498">చిరునామా బార్‌లో చరిత్ర, స్వీయపూరింపులను తొలగిస్తుంది. మీ Brave Software ఖాతా <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>లో ఇతర రూపాల్లో ఉన్న బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
+<translation id="8122693181154564064">సైన్ ఇన్ చేసిన అన్ని పరికరాల నుండి చరిత్రను తొలగిస్తుంది. మీ Brave Software ఖాతా <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>లో ఇతర రూపాల్లో ఉన్న బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
+<translation id="5869522115854928033">సేవ్  చేసిన పాస్‌వర్డ్‌లు</translation>
+<translation id="6865313869410766144">స్వీయపూర్తి ఫారమ్ డేటా</translation>
+<translation id="7562080006725997899">బ్రౌజింగ్ డేటాను తీసివేస్తోంది</translation>
+<translation id="5487521232677179737">డేటాని తీసివేయి</translation>
+<translation id="7498271377022651285">దయచేసి వేచి ఉండండి...</translation>
+<translation id="784934925303690534">సమయ పరిధి</translation>
+<translation id="1718835860248848330">చివరి గంట</translation>
+<translation id="7149893636342594995">గత 72 గంటలు</translation>
+<translation id="5648166631817621825">గత 7 రోజులు</translation>
+<translation id="8571213806525832805">గత 4 వారాలు</translation>
+<translation id="5854790677617711513">30 రోజుల కన్నా పాతవి</translation>
+<translation id="6979737339423435258">మొత్తం సమయం</translation>
+<translation id="982182592107339124">ఇది వీటితో సహా అన్ని సైట్‌ల డేటాను తీసివేస్తుంది:</translation>
+<translation id="6643016212128521049">క్లియర్ చేయి</translation>
+<translation id="7641339528570811325">బ్రౌజింగ్ డేటాను తీసివేయి…</translation>
+<translation id="1670399744444387456">ప్రాథమికం</translation>
+<translation id="3245261285041759672">మీ Brave Software ఖాతా <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>లో ఇతర రూపాల్లో ఉన్న బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
+<translation id="7274013316676448362">బ్లాక్ చేసిన సైట్</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> అంశాలు తొలగించబడ్డాయి</translation>
+<translation id="1121094540300013208">వినియోగ, క్రాష్ నివేదికలు</translation>
+<translation id="9079153198295609735">Brave Softwareకు ఆటోమేటిక్‌గా వినియోగ‌ గణాంకాలను, క్రాష్ నివేదికలను పంపు</translation>
+<translation id="6981982820502123353">యాక్సెస్‌</translation>
+<translation id="2387895666653383613">వచన ప్రమాణం</translation>
+<translation id="2321958826496381788">మీరు దీనిని సౌకర్యవంతంగా చదవగలిగే వరకు స్లైడర్‌ను లాగండి. పేరాపై రెండుసార్లు నొక్కిన తర్వాత వచనం కనీసం ఇంత పెద్దదిగా కనిపించాలి.</translation>
+<translation id="3895926599014793903">జూమ్ చేయడాన్ని నిర్బంధంగా ప్రారంభించు</translation>
+<translation id="5668404140385795438">దగ్గరకు జూమ్ చేయడాన్ని నిరోధించడానికి ప్రయత్నించే వెబ్‌సైట్ అభ్యర్థనను పట్టించుకోదు</translation>
+<translation id="4149994727733219643">వెబ్ పేజీల కోసం సరళమైన వీక్షణ</translation>
+<translation id="9100505651305367705">మ‌ద్ద‌తు ఉన్న సందర్భాల్లో, సరళీకృత వీక్షణలో కథనాలను చూడగలిగే అవకాశం అందిస్తుంది</translation>
+<translation id="1409426117486808224">తెరిచిన ట్యాబ్‌ల కోసం సరళమైన వీక్షణ</translation>
+<translation id="702463548815491781">TalkBack లేదా స్విచ్ యాక్సెస్ ఆన్‌లో ఉన్నప్పుడు సిఫార్సు చేయబడింది</translation>
+<translation id="8284326494547611709">ఉపశీర్షికలు</translation>
+<translation id="4165986682804962316">సైట్ సెట్టింగ్‌లు</translation>
+<translation id="6295158916970320988">అన్ని సైట్‌లు</translation>
+<translation id="8380167699614421159">ఈ సైట్ అనుచితమైన లేదా తప్పుదారి పట్టించే ప్రకటనలను చూపుతుంది</translation>
+<translation id="1919345977826869612">ప్రకటనలు</translation>
+<translation id="410351446219883937">స్వీయ ప్లే</translation>
+<translation id="6447842834002726250">కుక్కీలు</translation>
+<translation id="6196640612572343990">మూడవ పక్షం కుక్కీలను బ్లాక్ చేయి</translation>
+<translation id="6782111308708962316">మూడవ పక్షం వెబ్‌సైట్‌లను కుక్కీ డేటా సేవ్ చేయనీయకుండా, చదవనీయకుండా నిరోధించు</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">పాప్-అప్‌లు మరియు మళ్లింపులు</translation>
+<translation id="4751476147751820511">కదలిక లేదా కాంతి సెన్సార్‌లు</translation>
+<translation id="1717218214683051432">మోషన్ సెన్సార్‌లు</translation>
+<translation id="2091887806945687916">ధ్వని</translation>
+<translation id="2586657967955657006">క్లిప్‌బోర్డ్</translation>
+<translation id="6320088164292336938">వైబ్రేట్ చేయి</translation>
+<translation id="4226663524361240545">నోటిఫికేషన్‌లు పరికరాన్ని వైబ్రేట్ చేయవచ్చు</translation>
+<translation id="1446450296470737166">MIDI పరికరాల పూర్తి నియం. అనుమ.</translation>
+<translation id="3744111561329211289">బ్యాక్‌గ్రౌండ్ సింక్</translation>
+<translation id="5649053991847567735">ఆటోమేటిక్ డౌన్‌లోడ్‌లు</translation>
+<translation id="6181444274883918285">సైట్ మినహాయింపును జోడించు</translation>
+<translation id="5313967007315987356">సైట్‌ను జోడించు</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> సైట్ జోడించబడింది</translation>
+<translation id="7837721118676387834">నిర్దిష్ట సైట్ కోసం మ్యూట్ చేసిన వీడియోలను ఆటోమేటిక్‌గా ప్లే చేయడానికి అనుమతిస్తుంది.</translation>
+<translation id="2621115761605608342">నిర్దిష్ట సైట్ కోసం జావా స్క్రిప్ట్‌ను అనుమతిస్తుంది.</translation>
+<translation id="8801436777607969138">నిర్దిష్ట సైట్‌లో JavaScriptను బ్లాక్ చేస్తుంది.</translation>
+<translation id="8372893542064058268">నిర్దిష్ట సైట్ కోసం నేపథ్య సింక్‌ను అనుమతిస్తుంది.</translation>
+<translation id="358794129225322306">పలు ఫైల్‌లను ఆటోమేటిక్‌గా డౌన్‌లోడ్ చేయడం కోసం సైట్‌ని అనుమతించండి.</translation>
+<translation id="4008040567710660924">నిర్దిష్ట సైట్ కోసం కుక్కీలను అనుమతించండి.</translation>
+<translation id="8958424370300090006">ఏదైనా ఒక నిర్దిష్ట సైట్‌లో కుక్కీలను బ్లాక్ చేయండి.</translation>
+<translation id="7882806643839505685">నిర్దిష్ట సైట్ కోసం ధ్వనిని అనుమతించండి.</translation>
+<translation id="4468959413250150279">నిర్దిష్ట సైట్ కోసం ధ్వనిని మ్యూట్ చేయండి.</translation>
+<translation id="1994173015038366702">సైట్ URL</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">నిల్వ వినియోగం</translation>
+<translation id="5804241973901381774">అనుమతులు</translation>
+<translation id="4278390842282768270">అనుమతించబడింది</translation>
+<translation id="5677928146339483299">బ్లాక్ చేయబడింది</translation>
+<translation id="1984937141057606926">మూడవ-పక్షం మినహా మిగిలినవి అనుమతించబడ్డాయి</translation>
+<translation id="7423098979219808738">ముందుగా అడుగుతుంది</translation>
+<translation id="8116925261070264013">మ్యూట్ చేసినవి</translation>
+<translation id="8300705686683892304">యాప్ ద్వారా నిర్వహించబడుతున్నవి</translation>
+<translation id="6192792657125177640">మినహాయింపులు</translation>
+<translation id="257931822824936280">విస్తరింపబడింది - కుదించడానికి క్లిక్ చేయండి.</translation>
+<translation id="5100237604440890931">కుదించబడింది - విస్తరింపజేయడానికి క్లిక్ చేయండి.</translation>
+<translation id="857943718398505171">అనుమతించబడింది (సిఫార్సు చేయబడింది)</translation>
+<translation id="2913331724188855103">కుక్కీ డేటాను సేవ్ చేయడానికి, చదవడానికి సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="7445411102860286510">మ్యూట్ చేసిన వీడియోలను ఆటోమేటిక్‌గా ప్లే చేసేలా సైట్‌‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="5335288049665977812">సైట్‌లను జావాస్క్రిప్ట్ అమలు చేయడానికి అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="5527111080432883924">క్లిప్‌బోర్డ్ నుండి వచనం మరియు చిత్రాలను చదవడానికి అనుమతించే ముందు సమ్మతి అడగాలి (సిఫార్సు చేస్తున్నాము)</translation>
+<translation id="6912998170423641340">క్లిప్‌బోర్డ్ నుండి వచనం మరియు చిత్రాలను చదవకుండా సైట్‌లు బ్లాక్ చేయబడతాయి</translation>
+<translation id="7423538860840206698">క్లిప్‌బోర్డ్‌ని చదవకుండా బ్లాక్ చేసారు</translation>
+<translation id="3955193568934677022">రక్షిత కంటెంట్‌ను ప్లే చేయడానికి సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="445467742685312942">రక్షిత కంటెంట్‌ను ప్లే చేయడానికి సైట్‌లను అనుమతిస్తుంది</translation>
+<translation id="2107397443965016585">సైట్‌లు రక్షిత కంటెంట్‌ను ప్లే చేయడానికి ముందు అనుమతి కోసం అడుగుతాయి (సిఫార్సు చేయడమైనది)</translation>
+<translation id="2910701580606108292">సైట్‌లు రక్షిత కంటెంట్‌ను ప్లే చేయడానికి ముందు అనుమతి కోసం అడుగుతాయి</translation>
+<translation id="757524316907819857">రక్షిత కంటెంట్‌ను ప్లే చేయకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
+<translation id="3277252321222022663">సెన్సార్‌లను యాక్సెస్ చేయడానికి సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేస్తున్నాము)</translation>
+<translation id="5048398596102334565">మోషన్ సెన్సార్‌లను యాక్సెస్ చేయడానికి సైట్‌లను అనుమతించండి (సిఫార్సు చేస్తున్నాము)</translation>
+<translation id="8816026460808729765">సెన్సార్‌లను యాక్సెస్ చేయనీయకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
+<translation id="169515064810179024">మోషన్ సెన్సార్‌లను యాక్సెస్ చేయనీయకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
+<translation id="1660204651932907780">ధ్వనిని ప్లే చేయగలిగేలా సైట్‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="3600792891314830896">ధ్వనిని ప్లే చేసే సైట్‌లను మ్యూట్ చేస్తుంది</translation>
+<translation id="1743802530341753419">ఏదైనా పరికరానికి కనెక్ట్ చేయగలిగేలా సైట్‌లను అనుమతించే ముందు మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయడమైనది)</translation>
+<translation id="851751545965956758">పరికరాలకు కనెక్ట్ కాకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
+<translation id="7141896414559753902">మళ్లింపులు, పాప్-అప్‌లను చూపనివ్వకుండా సైట్‌లను బ్లాక్ చేస్తుంది (సిఫార్సు చేయడమైనది)</translation>
+<translation id="5494752089476963479">అనుచితమైన లేదా తప్పుదారి పట్టించే ప్రకటనలను చూపించే సైట్‌లలో ప్రకటనలను బ్లాక్ చేస్తుంది</translation>
+<translation id="3123473560110926937">కొన్ని సైట్‌లలో బ్లాక్ చేయబడింది</translation>
+<translation id="965817943346481315">సైట్ అనుచితమైన లేదా తప్పుదారి పట్టించే ప్రకటనలను చూపించినప్పుడు బ్లాక్ చేయి (సిఫార్సు చేయబడింది)</translation>
+<translation id="3386292677130313581">మీ స్థానాన్ని సైట్‌లు తెలుసుకునేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="9139068048179869749">ఏవైనా సైట్‌లు నోటిఫికేషన్‌లను పంపగలిగేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="4479647676395637221">మీ కెమెరాను ఏవైనా సైట్‌లు ఉపయోగించగలిగేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="6992289844737586249">మీ మైక్రోఫోన్‌ను ఏవైనా సైట్‌లు ఉపయోగించగలిగేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
+<translation id="2289270750774289114">ఏదైనా ఒక సైట్ సమీపంలోని బ్లూటూత్ పరికరాలను కనుగొనాలనుకున్నప్పుడు అనుమతి అడుగుతుంది (సిఫార్సు చేయడమైనది)</translation>
+<translation id="7053983685419859001">నిరోధించు</translation>
+<translation id="7128222689758636196">ప్రస్తుత శోధన ఇంజిన్‌కు అనుమతిస్తుంది</translation>
+<translation id="7589445247086920869">ప్రస్తుత శోధన ఇంజిన్‌కు బ్లాక్ చేయండి</translation>
+<translation id="6388207532828177975">క్లియర్ చేసి, రీసెట్ చేయి</translation>
+<translation id="7999064672810608036">కుక్కీలతో సహా, మొత్తం స్థానిక డేటాను తీసివేసి, ఈ వెబ్‌సైట్‌కు ఇచ్చిన అన్ని అనుమతులను రీసెట్ చేయాలని మీరు ఖచ్చితంగా కోరుకుంటున్నారా?</translation>
+<translation id="2822354292072154809">మీరు <ph name="CHOSEN_OBJECT_NAME"/> కోసం అన్ని సైట్ అనుమతులను ఖచ్చితంగా రీసెట్ చేయాలనుకుంటున్నారా ?</translation>
+<translation id="515227803646670480">నిల్వ చేసిన డేటాను తీసివేయండి</translation>
+<translation id="5902828464777634901">కుక్కీలతో సహా ఈ వెబ్‌సైట్ ద్వారా నిల్వ చేయబడిన మొత్తం స్థానిక డేటా తొలగించబడుతుంది.</translation>
+<translation id="119944043368869598">అన్ని క్లియర్ చెయ్యి</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> ద్వారా నిర్వహించబడుతున్నాయి</translation>
+<translation id="5516455585884385570">నోటిఫికేషన్ సెట్టింగ్‌లను తెరువు</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/>లో పొందుపరచబడింది</translation>
+<translation id="129382876167171263">వెబ్‌సైట్‌లు సేవ్ చేసిన ఫైల్‌లు ఇక్కడ కనిపిస్తాయి</translation>
+<translation id="4181841719683918333">భాషలు</translation>
+<translation id="2647434099613338025">భాషను జోడించు</translation>
+<translation id="1952172573699511566">వీలైనప్పుడు వెబ్‌సైట్‌లు, మీ ప్రాధాన్య భాషలో వచనాన్ని చూపుతాయి.</translation>
+<translation id="8559990750235505898">ఇతర భాషలలో పేజీలను అనువదించడాన్ని ఆఫర్ చేస్తుంది</translation>
+<translation id="4719927025381752090">అనువదించమని ఆఫర్ చేయి</translation>
+<translation id="8156139159503939589">మీరు ఏ భాషలను చదవగలరు?</translation>
+<translation id="5689516760719285838">స్థానం</translation>
+<translation id="2440823041667407902">స్థాన యాక్సెస్</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android సెట్టింగ్‌లు<ph name="END_LINK"/>లో Brave కోసం అనుమతులను ఆన్ చేయండి.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android సెట్టిం‌గ్‌లు<ph name="END_LINK"/>లో Brave కోసం అనుమతిని ఆన్ చేయండి.</translation>
+<translation id="2928908108430545745">మీ స్థానాన్ని యాక్సెస్ చేయడానికి Braveను అనుమతించేందుకు, <ph name="BEGIN_LINK"/>Android సెట్టింగ్‌ల<ph name="END_LINK"/>లో కూడా స్థానాన్ని ఆన్ చేయండి.</translation>
+<translation id="1028853271388022585">మీ కెమెరాను యాక్సెస్ చేయడానికి Braveను అనుమతించేందుకు, <ph name="BEGIN_LINK"/>Android సెట్టింగ్‌ల<ph name="END_LINK"/>లో కూడా కెమెరాను ఆన్ చేయండి.</translation>
+<translation id="2913721282607281710">మీకు నోటిఫికేషన్‌లను పంపడానికి Braveను అనుమతించేందుకు, <ph name="BEGIN_LINK"/>Android సెట్టింగ్‌ల<ph name="END_LINK"/>లో కూడా నోటిఫికేషన్‌లను ఆన్ చేయండి.</translation>
+<translation id="8753483718490035722">మీ మైక్రోఫోన్‌ను యాక్సెస్ చేయడానికి Braveను అనుమతించేందుకు, <ph name="BEGIN_LINK"/>Android సెట్టింగ్‌ల<ph name="END_LINK"/>లో కూడా మైక్రోఫోన్‌ను ఆన్ చేయండి.</translation>
+<translation id="1887786770086287077">ఈ పరికరానికి స్థానం యాక్సెస్ ఆఫ్ చేయబడింది. దీనిని <ph name="BEGIN_LINK"/>Android సెట్టింగ్‌లు<ph name="END_LINK"/>లో తిరిగి ఆన్ చేయండి.</translation>
+<translation id="2570922361219980984">ఈ పరికరానికి స్థానం యాక్సెస్ కూడా ఆఫ్ చేయబడింది. దీనిని <ph name="BEGIN_LINK"/>Android సెట్టింగ్‌లు<ph name="END_LINK"/>లో తిరిగి ఆన్ చేయండి.</translation>
+<translation id="1620510694547887537">కెమెరా</translation>
+<translation id="3227137524299004712">మైక్రోఫోన్</translation>
+<translation id="1647391597548383849">మీ కెమెరా యాక్సెస్ అనుమతి</translation>
+<translation id="945632385593298557">మీ మైక్రోఫోన్ యాక్సెస్ అనుమతి</translation>
+<translation id="6612358246767739896">రక్షిత కంటెంట్</translation>
+<translation id="885701979325669005">నిల్వ</translation>
+<translation id="3198916472715691905">నిల్వ చేసిన డేటా <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">పరికర అనుమతిని ఉపసంహరిస్తుంది</translation>
+<translation id="4962975101802056554">పరికరానికి అన్ని అనుమతులను ఉపసంహరించు</translation>
+<translation id="6545864417968258051">బ్లూటూత్ స్కానింగ్</translation>
+<translation id="4411535500181276704">లైట్ మోడ్</translation>
+<translation id="7821588508402923572">మీ డేటా పొదుపులు ఇక్కడ కనిపిస్తాయి</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> ఆదా చేయబడింది</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> నుండి</translation>
+<translation id="3252158532344029638">లైట్ మోడ్‌లో, Brave పేజీలను వేగంగా లోడ్ చేస్తుంది, అలాగే 60 శాతం తక్కువ డేటాను ఉపయోగిస్తుంది.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> డేటా పొదుపులు</translation>
+<translation id="7494974237137038751">ఆదా అయిన డేటా</translation>
+<translation id="6111020039983847643">వినియోగించిన డేటా</translation>
+<translation id="7413229368719586778">ప్రారంభ తేదీ <ph name="DATE"/></translation>
+<translation id="1782483593938241562">ముగింపు తేదీ <ph name="DATE"/></translation>
+<translation id="2728754400939377704">సైట్ ద్వారా క్రమీకరించు</translation>
+<translation id="5864174910718532887">వివరాలు: సైట్ పేరుతో క్రమీకరించబడ్డాయి</translation>
+<translation id="116280672541001035">ఉపయోగించబడినది</translation>
+<translation id="8349013245300336738">వినియోగించిన డేటా పరిమాణం ద్వారా క్రమీకరించు</translation>
+<translation id="6378173571450987352">వివరాలు: ఉపయోగించిన డేటా మొత్తం ద్వారా క్రమీకరించబడ్డాయి</translation>
+<translation id="2631006050119455616">ఆదా చేయబడింది</translation>
+<translation id="6643649862576733715">సేవ్ చేసిన డేటా పరిమాణం ద్వారా క్రమీకరించు</translation>
+<translation id="7302081693174882195">వివరాలు: సేవ్ చేసిన డేటా మొత్తం ద్వారా క్రమీకరించబడ్డాయి</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> వినియోగించబడింది</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> సేవ్ చేయబడింది</translation>
+<translation id="2156074688469523661">మిగిలిన సైట్‌లు (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">ఇతర</translation>
+<translation id="4913161338056004800">గణాంకాలను రీసెట్ చేయి</translation>
+<translation id="1856325424225101786">లైట్ మోడ్‌ని రీసెట్ చేయాలా?</translation>
+<translation id="3658159451045945436">రీసెట్ చేసినట్లయితే, సందర్శించిన సైట్‌ల జాబితాతో పాటు మీ డేటా ఆదాల చరిత్ర తొలగించబడుతుంది.</translation>
+<translation id="3295530008794733555">మరింత వేగంగా బ్రౌజ్ చేయండి. తక్కువ డేటాని ఉపయోగించండి.</translation>
+<translation id="7340390500800578919">లైట్ మోడ్‌లో, Brave పేజీలను వేగంగా లోడ్ చేస్తుంది, అలాగే 60 శాతం వరకు తక్కువ డేటాను ఉపయోగిస్తుంది. మీరు సందర్శించే పేజీలను ఆప్టిమైజ్ చేయడానికి, Brave మీ వెబ్ ట్రాఫిక్‌ను Brave Softwareకు పంపుతుంది. <ph name="BEGIN_LINK"/>మరింత తెలుసుకోండి<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">లైట్ మోడ్‌ని ఆన్ చేయండి</translation>
+<translation id="4493497663118223949">లైట్ మోడ్ ఆన్ చేయబడింది</translation>
+<translation id="7559975015014302720">లైట్ మోడ్ ఆఫ్ చేయబడింది</translation>
+<translation id="7606077192958116810">లైట్ మోడ్ ఆన్ చేయబడింది. సెట్టింగ్‌లలో దీనిని నిర్వహించండి.</translation>
+<translation id="4714588616299687897">మీ డేటాలో 60% వరకు ఆదా చేసుకోండి</translation>
+<translation id="1006927014032731288">మీరు సందర్శించే పేజీలను Brave Software సర్వర్‌లు ఆప్టిమైజ్ చేస్తాయి.</translation>
+<translation id="3257320067425202300">Brave మీకు <ph name="MEGABYTES"/> MB ఆదా చేసింది</translation>
+<translation id="5813223329348543512">Brave మీకు <ph name="GIGABYTES"/> GB ఆదా చేసింది</translation>
+<translation id="8266862848225348053">డౌన్‌లోడ్‌ల ఫోల్డర్</translation>
+<translation id="7077143737582773186">SD కార్డ్</translation>
+<translation id="7762668264895820836">SD కార్డ్ <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">ఫైల్‌లను ఎక్కడ సేవ్ చేయాలో అడుగు</translation>
+<translation id="6192333916571137726">ఫైల్‌ను డౌన్‌లోడ్ చేయండి</translation>
+<translation id="1672586136351118594">మళ్లీ చూపవద్దు</translation>
+<translation id="2650751991977523696">ఫైల్‌ను మళ్లీ డౌన్‌లోడ్ చేయాలా?</translation>
+<translation id="8664979001105139458">ఫైల్ పేరు ఇప్పటికే ఉంది</translation>
+<translation id="488187801263602086">ఫైల్ పేరు మార్చండి</translation>
+<translation id="5686790454216892815">ఫైల్ పేరు చాలా పొడవుగా ఉంది</translation>
+<translation id="7454641608352164238">తగినంత స్థలం లేదు</translation>
+<translation id="8972098258593396643">డిఫాల్ట్ ఫోల్డర్‌కు డౌన్‌లోడ్ చేయాలా?</translation>
+<translation id="804335162455518893">SD కార్డ్ కనుగొనబడలేదు</translation>
+<translation id="7475688122056506577">SD కార్డ్ కనుగొనబడలేదు. మీ ఫైల్‌లలో కొన్ని ఉండకపోవచ్చు.</translation>
+<translation id="4198423547019359126">డౌన్‌లోడ్ స్థానాలు అందుబాటులో లేవు</translation>
+<translation id="8224471946457685718">మీ కోసం అందించే కథనాలను Wi-Fi ద్వారా డౌన్‌లోడ్ చేసుకోండి</translation>
+<translation id="4970824347203572753">మీ స్థానంలో అందుబాటులో లేదు</translation>
+<translation id="5500777121964041360">మీ స్థానంలో అందుబాటులో ఉండకపోవచ్చు</translation>
+<translation id="1173894706177603556">పేరుమార్చు</translation>
+<translation id="1986685561493779662">పేరు ఇప్పటికే ఉంది</translation>
+<translation id="6441734959916820584">పేరు చాలా పొడువు ఉంది</translation>
+<translation id="2923908459366352541">పేరు చెల్లదు</translation>
+<translation id="7290209999329137901">పేరు మార్పు అందుబాటులో లేదు</translation>
+<translation id="3334729583274622784">ఫైల్ ఎక్స్‌టెన్షన్‌ను మార్చాలా?</translation>
+<translation id="107147699690128016">మీరు ఫైల్ ఎక్స్‌టెన్షన్‌ను మార్చితే, ఫైల్ వేరే అప్లికేషన్‌లో తెరవబడవచ్చు. అది మీ పరికరానికి హానికరంగా పరిణమించే అవకాశం ఉంటుంది.</translation>
+<translation id="8541922081612557424">Brave పరిచయం</translation>
+<translation id="5311273890481188673">కాపీరైట్ <ph name="YEAR"/> Brave Software LLC. సర్వ హక్కులు ప్రత్యేకించబడ్డాయి.</translation>
+<translation id="1416550906796893042">అప్లికేషన్ వెర్షన్</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (నవీకరించినది <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">ఆపరేటింగ్ సిస్టమ్</translation>
+<translation id="3968054912784331254">Brave అప్‌డేట్‌లకు ఈ Android వెర్షన్‌లో మద్దతు లేదు</translation>
+<translation id="7665369617277396874">ఖాతాను జోడించండి</translation>
+<translation id="649070405679044769">Brave Softwareకి ఇలా సైన్ ఇన్ చేసారు</translation>
+<translation id="6234515504547364178">Brave నుండి సైన్ అవుట్ చేయండి</translation>
+<translation id="5324858694974489420">పేరెంటల్ సెట్టింగ్‌లు</translation>
+<translation id="8920114477895755567">తల్లిదండ్రుల వివరాల కోసం వేచి ఉంది.</translation>
+<translation id="5512137114520586844">ఈ ఖాతా <ph name="PARENT_NAME"/> నిర్వహణలో ఉంది.</translation>
+<translation id="2956410042958133412">ఈ ఖాతా <ph name="PARENT_NAME_1"/> మరియు <ph name="PARENT_NAME_2"/> నిర్వహణలో ఉంది.</translation>
+<translation id="8168435359814927499">కంటెంట్</translation>
+<translation id="5403644198645076998">నిర్దిష్ట సైట్‌లను మాత్రమే అనుమతించండి</translation>
+<translation id="8641930654639604085">వయోజన కంటెంట్ గల సైట్‌లను బ్లాక్ చేయడానికి ప్రయత్నించండి</translation>
+<translation id="5639724618331995626">అన్ని సైట్‌లను అనుమతించండి</translation>
+<translation id="796823723482603597">Brave ఆధారితం</translation>
+<translation id="6324034347079777476">Android సిస్టమ్ సమకాలీకరణ నిలిపివేయబడింది</translation>
+<translation id="5127805178023152808">సమకాలీకరణ ఆఫ్‌లో ఉంది</translation>
+<translation id="7015203776128479407">ప్రాథమిక సింక్ సెటప్ పూర్తి కాలేదు. సింక్ ఆఫ్‌లో ఉంది.</translation>
+<translation id="2497852260688568942">సింక్‌ను మీ నిర్వాహకులు నిలిపివేశారు</translation>
+<translation id="9100610230175265781">రహస్య పదబంధం అవసరం</translation>
+<translation id="6108923351542677676">సెటప్ ప్రోగ్రెస్‌లో ఉంది...</translation>
+<translation id="4062305924942672200">చట్ట సంబంధిత సమాచారం</translation>
+<translation id="4256782883801055595">ఓపెన్ సోర్స్ లైసెన్స్‌లు</translation>
+<translation id="1138681184697033370">Brave సేవా నిబంధనలు</translation>
+<translation id="7392539049993970338">Brave గోప్యతా నోటీసు</translation>
+<translation id="2677748264148917807">నిష్క్రమించు</translation>
+<translation id="5556459405103347317">మళ్లీ లోడ్ చేయి</translation>
+<translation id="1623104350909869708">ఈ పేజీని అదనపు డైలాగ్‌లు సృష్టించనీయకుండా నిరోధించు</translation>
+<translation id="2968755619301702150">ప్రమాణపత్రం వ్యూయర్</translation>
+<translation id="1360432990279830238">సైన్ అవుట్ చేసి, సమకాలీకరణను ఆఫ్ చేయలా?</translation>
+<translation id="8581481290581777242">ఈ పరికరం నుండి మీ Brave డేటాని తీసివేయాలా?</translation>
+<translation id="1318865768845061710">మీ బుక్‌మార్క్‌లు, చరిత్ర, పాస్‌వర్డ్‌లు, ఇతర Brave డేటా ఇకపై మీ Brave Software ఖాతాలో సింక్ చేయబడదు</translation>
+<translation id="3325020657155065477">అలాగే, ఈ పరికరం నుండి మీ Brave డేటాను కూడా తీసివేయండి</translation>
+<translation id="6136448902816743006">మీరు <ph name="DOMAIN_NAME"/> నిర్వహణలోని ఖాతా నుండి సైన్ అవుట్ చేస్తున్నందున, ఈ పరికరం నుండి మీ Brave డేటా తొలగించబడుతుంది. అది మీ Brave Software ఖాతాలో అలాగే భద్రపరచబడుతుంది.</translation>
+<translation id="1853026300647876496">Brave Softwareని సంప్రదిస్తోంది. ఇందుకు ఒక నిమిషం పట్టవచ్చు…</translation>
+<translation id="2328985652426384049">సైన్ ఇన్ చేయడం సాధ్యపడదు</translation>
+<translation id="7723158744459952869">Brave Software ప్రతిస్పందించడానికి చాలా ఎక్కువ సమయం తీసుకుంది</translation>
+<translation id="4572422548854449519">నిర్వాహిత ఖాతాకు సైన్ ఇన్ చేయండి</translation>
+<translation id="2689656545739939160">మీరు <ph name="MANAGED_DOMAIN"/> నిర్వహణలో ఉన్న ఖాతా నుండి సైన్ ఇన్ చేస్తున్నారు. దీని నిర్వాహకులకు మీ Brave డేటాపై నియంత్రణను అందిస్తున్నారు. మీ డేటా శాశ్వతంగా ఈ ఖాతాకు అనుబంధించబడుతుంది. Brave నుండి సైన్ అవుట్ చేయడం వ‌ల్ల ఈ పరికరం నుండి మీ డేటా తొలగించబడుతుంది. కానీ ఇది మీ Brave Software ఖాతాలో అలాగే నిల్వ చేయబడి ఉంటుంది.</translation>
+<translation id="1749561566933687563">మీ బుక్‌మార్క్‌లను సమకాలీకరించండి</translation>
+<translation id="4242533952199664413">సెట్టింగ్‌లను తెరువు</translation>
+<translation id="1111673857033749125">మీ ఇతర పరికరాల్లో సేవ్ చేసిన బుక్‌మార్క్‌లు ఇక్కడ చూపబడతాయి.</translation>
+<translation id="8636825310635137004">మీ ఇతర పరికరాల నుండి మీ ట్యాబ్‌లను పొందడానికి, సమకాలీకరణను ఆన్ చేయండి</translation>
+<translation id="3269956123044984603">మీ ఇతర పరికరాల నుండి మీ ట్యాబ్‌లను పొందడానికి, Android ఖాతా సెట్టింగ్‌ల‌లో "ఆటో-సింక్‌ డేటా" ఆన్ చేయండి.</translation>
+<translation id="5157964048453367290">మీరు మీ ఇతర పరికరాల్లోని Braveలో తెరిచిన ట్యాబ్‌లు ఇక్కడ చూపబడతాయి.</translation>
+<translation id="4684427112815847243">ప్రతి ఒక్కటి సమకాలీకరించండి</translation>
+<translation id="2709516037105925701">స్వయంపూర్తి</translation>
+<translation id="8820817407110198400">బుక్‌మార్క్‌లు</translation>
+<translation id="1644574205037202324">చరిత్ర</translation>
+<translation id="17513872634828108">తెరిచిన ట్యాబ్‍లు</translation>
+<translation id="1320169905922104972">Brave Software Pay ఉపయోగిస్తున్న క్రెడిట్ కార్డ్‌లు,చిరునామాలు</translation>
+<translation id="6337234675334993532">ఎన్‌క్రిప్షన్</translation>
+<translation id="6698801883190606802">సమకాలీకరించిన డేటాను నిర్వహించండి</translation>
+<translation id="3598578758776312506">పాస్‌వర్డ్‌లను Brave Software ఆధారాలతో ఎన్‌క్రిప్ట్ చేయి</translation>
+<translation id="7810580217418711046"><ph name="TIME"/> నాటికి సమకాలీకరించిన డేటాని Brave Software పాస్‌వర్డ్‌తో ఎన్‌క్రిప్ట్ చేయండి</translation>
+<translation id="8461694314515752532">మీ స్వంత సమకాలీకరణ రహస్య పదబంధంతో సమకాలీకరించబడిన డేటాని ఎన్‌క్రిప్ట్ చేయండి</translation>
+<translation id="2996291259634659425">రహస్య పదబంధాన్ని సృష్టించండి</translation>
+<translation id="5713644099811900409">Brave Software ఖాతా</translation>
+<translation id="8997474919031554666">Brave Software Payకి సంబంధించిన చెల్లింపు పద్ధతులు మరియు చిరునామాలు రహస్య పదబంధం ఎన్‌క్రిప్షన్‌లో ఉండవు. మీ రహస్య పదబంధాన్ని కలిగి ఉన్నవారు మాత్రమే మీ ఎన్‌క్రిప్ట్ చేసిన డేటాను చదవగలరు. రహస్య పదబంధం Brave Software ద్వారా ఎవరికీ పంపబడదు లేదా నిల్వ చేయబడదు. మీరు మీ రహస్య పదబంధాన్ని మర్చిపోతే లేదా ఈ సెట్టింగ్‌ను మార్చాలనుకుంటే, సమకాలీకరణను రీసెట్ చేయాల్సి ఉంటుంది. <ph name="BEGIN_LINK"/>మరింత తెలుసుకోండి<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">రహస్య పదబంధం</translation>
+<translation id="7772032839648071052">రహస్య పదబంధాన్ని నిర్ధారించండి</translation>
+<translation id="5304593522240415983">ఈ ఫీల్డ్ ఖాళీగా ఉండరాదు</translation>
+<translation id="321773570071367578">మీరు మీ రహస్య పదబంధాన్ని మర్చిపోతే లేదా ఈ సెట్టింగ్‌ను మార్చాలనుకుంటే, <ph name="BEGIN_LINK"/>సింక్‌ను రీసెట్ చేయండి<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">రహస్య పదబంధాలు సరిపోలలేదు</translation>
+<translation id="5149495116300586333">Brave Software Payకి సంబంధించిన చెల్లింపు పద్ధతులు మరియు చిరునామాలు రహస్య పదబంధం ఎన్‌క్రిప్షన్‌లో ఉండవు.
+
+ఈ సెట్టింగ్‌ని మార్చడం కోసం, <ph name="BEGIN_LINK"/>సమకాలీకరణను రీసెట్ చేయండి<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">రహస్య పదబంధం చెల్లదు</translation>
+<translation id="5414836363063783498">ధృవీకరిస్తోంది...</translation>
+<translation id="6846298663435243399">లోడ్ అవుతోంది...</translation>
+<translation id="5517095782334947753">మీరు <ph name="FROM_ACCOUNT"/> నుండి బుక్‌మార్క్‌లు, చరిత్ర, పాస్‌వర్డ్‌లు మరియు ఇతర సెట్టింగ్‌లను కలిగి ఉన్నారు.</translation>
+<translation id="3928666092801078803">నా డేటాను కలపండి</translation>
+<translation id="688738109438487280">ఇప్పటికే ఉన్న డేటాను <ph name="TO_ACCOUNT"/>కి జోడించండి.</translation>
+<translation id="806745655614357130">నా డేటాను విడిగా ఉంచండి</translation>
+<translation id="1145536944570833626">ఇప్పటికే ఉన్న డేటాను తొలగించండి.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> దీనితో జత చేయాలనుకుంటోంది</translation>
+<translation id="4915549754973153784">పరికరాల కోసం స్కాన్ చేస్తున్నప్పుడు <ph name="BEGIN_LINK"/>సహాయం పొందండి<ph name="END_LINK"/>…</translation>
+<translation id="5817918615728894473">జత చేయి</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>సహాయం పొందండి<ph name="END_LINK1"/> లేదా <ph name="BEGIN_LINK2"/>మళ్లీ స్కాన్ చేయండి<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">అనుకూల పరికరాలు ఏవీ కనుగొనబడలేదు</translation>
+<translation id="3773755127849930740">జత చేయడాన్ని అనుమతించడానికి <ph name="BEGIN_LINK"/>బ్లూటూత్‌ను ఆన్ చేయండి<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave బ్లూటూత్ అడాప్టర్‌ను ఆన్ చేయలేకపోయింది</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>సహాయం పొందండి<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">పరికరాల కోసం స్కాన్ చేయడానికి Braveకు స్థాన యాక్సెస్ అవసరం. <ph name="BEGIN_LINK"/>అనుమతులను అప్‌డేట్ చేయండి<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">పరికరాల కోసం స్కాన్ చేయడానికి Braveకు స్థాన యాక్సెస్ అవసరం. స్థాన యాక్సెస్ <ph name="BEGIN_LINK"/>ఈ పరికరానికి ఆఫ్ చేయబడింది<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">పరికరాల కోసం స్కాన్ చేయడానికి Braveకు స్థాన యాక్సెస్ అవసరం. <ph name="BEGIN_LINK1"/>అనుమతులను అప్‌డేట్ చేయండి<ph name="END_LINK1"/>. అలాగే స్థాన యాక్సెస్ <ph name="BEGIN_LINK2"/>ఈ పరికరానికి ఆఫ్ చేయబడింది<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">కనెక్ట్ చేసిన డివైజ్</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{సిగ్నల్ సామర్థ్యం స్థాయి: # బార్}other{సిగ్నల్ సామర్థ్యం స్థాయి: # బార్‌లు}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> సమీపంలోని బ్లూటూత్ పరికరాల కోసం స్కాన్ చేయాలనుకుంటోంది. కింది పరికరాలు కనుగొనబడ్డాయి:</translation>
+<translation id="8368027906805972958">తెలియని లేదా మద్దతు లేని పరికరం (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">సమకాలీకరణ పని చేయడం లేదు</translation>
+<translation id="1810845389119482123">ప్రారంభ సింక్ సెటప్ పూర్తి కాలేదు</translation>
+<translation id="3235722914093408050">Brave సమకాలీకరణను ప్రారంభిండానికి Android సెట్టింగ్‌లు తెరిచి, Android సిస్టమ్ సమకాలీకరణను మళ్లీ ప్రారంభించండి</translation>
+<translation id="3367813778245106622">సింక్‌ను ప్రారంభించడానికి మళ్లీ సైన్ ఇన్ చేయండి</translation>
+<translation id="974555521953189084">సింక్‌ను ప్రారంభించడానికి మీ రహస్య పదబంధాన్ని నమోదు చేయండి</translation>
+<translation id="2997266899014181325">సింక్‌ను మొదలుపెట్టడానికి, "మీ Brave డేటాను సింక్ చేయడం" ఆన్ చేయండి</translation>
+<translation id="8260126382462817229">మళ్లీ సైన్ ఇన్ చేయడానికి ప్రయత్నించండి</translation>
+<translation id="5919204609460789179">సింక్‌ను ప్రారంభించడానికి <ph name="PRODUCT_NAME"/>ని అప్‌డేట్ చేయండి</translation>
+<translation id="397583555483684758">సమకాలీకరణ పని చేయడం ఆగిపోయింది</translation>
+<translation id="1966710179511230534">దయచేసి మీ సైన్-ఇన్ వివరాలను అప్‌డేట్ చేయండి.</translation>
+<translation id="7063006564040364415">సింక్ సర్వర్‌కు కనెక్ట్ చేయడం సాధ్యపడలేదు.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> కాలం చెల్లినది.</translation>
+<translation id="4170011742729630528">సేవ అందుబాటులో లేదు; తర్వాత మళ్లీ ప్రయత్నించండి.</translation>
+<translation id="7947953824732555851">ఆమోదించి, సైన్ ఇన్ చేయండి</translation>
+<translation id="8583805026567836021">ఖాతా డేటాను క్లియర్ చేస్తోంది</translation>
+<translation id="8310344678080805313">ప్రామాణిక ట్యాబ్‌లు</translation>
+<translation id="5748802427693696783">ప్రామాణిక ట్యాబ్‌లకు మార్చబడింది</translation>
+<translation id="7998918019931843664">మూసిన ట్యాబ్‌ను మళ్లీ తెరువు</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, ట్యాబ్</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> ట్యాబ్‌ను మూసివేయండి</translation>
+<translation id="7243308994586599757">స్క్రీన్ దిగువభాగం సమీపంలో ఎంపికలు అందుబాటులో ఉంటాయి</translation>
+<translation id="4060598801229743805">ఎంపికలు స్క్రీన్ పైభాగానికి సమీపంలో అందుబాటులో ఉంటాయి</translation>
+<translation id="2810645512293415242">డేటాను సేవ్ చేయడానికి మరియు మరింత వేగంగా లోడ్ చేయడానికి సరళీకరించిన పేజీ.</translation>
+<translation id="3985215325736559418">మీరు <ph name="FILE_NAME"/>ని మళ్లీ డౌన్‌లోడ్ చేయాలని అనుకుంటున్నారా?</translation>
+<translation id="2450083983707403292">మీరు <ph name="FILE_NAME"/> డౌన్‌లోడ్‌ని మళ్లీ ప్రారంభించాలనుకుంటున్నారా?</translation>
+<translation id="7514365320538308">డౌన్‌లోడ్ చేయి</translation>
+<translation id="545042621069398927">మీ డౌన్‌లోడ్‌‌ను వేగవంతం చేస్తోంది.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ఫైల్‌ను డౌన్‌లోడ్ చేస్తోంది.}other{# ఫైల్‌లను డౌన్‌లోడ్ చేస్తోంది.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> ఫైల్‌లను డౌన్‌లోడ్ చేస్తోంది (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">ఫైల్‌ను డౌన్‌లోడ్ చేస్తోంది (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 డౌన్‌లోడ్ పూర్తయింది.}other{# డౌన్‌లోడ్‌లు పూర్తయ్యాయి.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 డౌన్‌లోడ్ విఫలమైంది.}other{# డౌన్‌లోడ్‌లు విఫలమయ్యాయి.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 డౌన్‌లోడ్ పెండింగ్‌లో ఉంది.}other{# డౌన్‌లోడ్‌లు పెండింగ్‌లో ఉన్నాయి.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> బటన్</translation>
+<translation id="3205824638308738187">దాదాపు పూర్తయింది!</translation>
+<translation id="3960299545138990065">Braveను పునఃప్రారంభించండి</translation>
+<translation id="3771001275138982843">అప్‌డేట్‌ను డౌన్‌లోడ్ చేయడం సాధ్యపడలేదు</translation>
+<translation id="3888648114124182147">Brave అప్‌డేట్‌ను డౌన్‌లోడ్ చేస్తోంది…</translation>
+<translation id="1705567146636171298">Braveని నవీకరించు</translation>
+<translation id="6195417478702700398">ఉత్తమ బ్రౌజింగ్ అనుభవం కోసం, Braveను అప్‌డేట్ చేయడానికి అనుమతించండి</translation>
+<translation id="3512968675351418494">మీ భాషలో వెబ్‌ను చూడడానికి, Brave యొక్క తాజా వెర్షన్‌ను డౌన్‌లోడ్ చేసుకోండి</translation>
+<translation id="6427112570124116297">వెబ్‌ను అనువదించండి</translation>
+<translation id="1379423114029199501">Brave యొక్క తాజా వెర్షన్‌లో మీ భాషను పొందడానికి అప్‌డేట్ చేయండి</translation>
+<translation id="5684874026226664614">అయ్యో. ఈ పేజీని అనువదించడం సాధ్యపడలేదు.</translation>
+<translation id="6831043979455480757">అనువదించు</translation>
+<translation id="1285320974508926690">ఈ సైట్‌ను ఎప్పటికీ అనువదించవద్దు</translation>
+<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE"/>లో ఉన్న పేజీలను ఎల్లప్పుడూ అనువదించు</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/>లో ఉన్న పేజీలను ఎప్పుడూ అనువదించవద్దు</translation>
+<translation id="124116460088058876">మరిన్ని భాషలు</translation>
+<translation id="290376772003165898">పేజీ <ph name="LANGUAGE"/>లో లేదా?</translation>
+<translation id="4432792777822557199">ఇప్పటి నుండి <ph name="SOURCE_LANGUAGE"/>లో ఉన్న పేజీలు <ph name="TARGET_LANGUAGE"/>కు అనువదించబడతాయి</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/>లో ఉన్న పేజీలు అనువదించబడవు</translation>
+<translation id="5447765697759493033">ఈ సైట్ అనువదించబడదు</translation>
+<translation id="4880127995492972015">అనువదించు…</translation>
+<translation id="641643625718530986">ముద్రించు…</translation>
+<translation id="8909135823018751308">భాగస్వామ్యం చేయి…</translation>
+<translation id="4996978546172906250">దీని ద్వారా భాగస్వామ్యం చే.</translation>
+<translation id="6333140779060797560"><ph name="APPLICATION"/> ద్వారా భాగస్వామ్యం చేయి</translation>
+<translation id="6277522088822131679">పేజీని ముద్రిస్తున్నప్పుడు సమస్య ఏర్పడింది. దయచేసి మళ్లీ ప్రయత్నించండి.</translation>
+<translation id="3254409185687681395">ఈ పేజీని బుక్‌మార్క్ చేయి</translation>
+<translation id="497421865427891073">ముందుకు వెళ్ళు</translation>
+<translation id="813082847718468539">సైట్ సమాచారాన్ని చూడండి</translation>
+<translation id="2532336938189706096">వెబ్ వీక్షణ</translation>
+<translation id="6005538289190791541">సూచించబడిన పాస్‌వర్డ్‌</translation>
+<translation id="4634124774493850572">పాస్‌వర్డ్‌ను ఉపయోగించు</translation>
+<translation id="8285489906452138776">ఈ సైట్ కోసం మీ కెమెరాను యాక్సెస్ చేయడానికి Braveకు అనుమతి అవసరం.</translation>
+<translation id="320189792589364011">ఈ సైట్ కోసం మీ మైక్రోఫోన్‌ను యాక్సెస్ చేయడానికి Braveకు అనుమతి అవసరం.</translation>
+<translation id="7988136689212463100">ఈ సైట్ కోసం మీ కెమెరా మరియు మైక్రోఫోన్‌ను యాక్సెస్ చేయడానికి Braveకు అనుమతి అవసరం.</translation>
+<translation id="4931190655840828017">ఈ సైట్‌తో మీ స్థానాన్ని షేర్ చేయడానికి Braveకు మీ స్థాన యాక్సెస్ అవసరం.</translation>
+<translation id="3088191967551450609">ఫైల్‌లను డౌన్‌లోడ్ చేయడానికి Braveకు నిల్వ యాక్సెస్ అవసరం.</translation>
+<translation id="8942627711005830162">మరొక విండోలో తెరువు</translation>
+<translation id="4195643157523330669">కొత్త ట్యాబ్‌లో తెరువు</translation>
+<translation id="1100066534610197918">సమూహంలో కొత్త ట్యాబ్‌లో తెరువు</translation>
+<translation id="4860895144060829044">కాల్ చేయండి</translation>
+<translation id="6896758677409633944">కాపీ చేయి</translation>
+<translation id="8393700583063109961">సందేశాన్ని పంపండి</translation>
+<translation id="3557336313807607643">పరిచయాలకు జోడించు</translation>
+<translation id="4269820728363426813">లింక్ చిరునామాను కాపీ చేయి</translation>
+<translation id="1206892813135768548">లింక్ వచనాన్ని కాపీ చేయి</translation>
+<translation id="1204037785786432551">లింక్‌ను డౌన్‌లోడ్ చేయి</translation>
+<translation id="6864459304226931083">చిత్రాన్ని డౌన్‌లోడ్ చేయి</translation>
+<translation id="8209050860603202033">చిత్రాన్ని తెరువు</translation>
+<translation id="8073388330009372546">కొత్త ట్యాబ్‌లో చిత్రం తెరువు</translation>
+<translation id="6649642165559792194"><ph name="BEGIN_NEW"/>కొత్త<ph name="END_NEW"/> చిత్రం ప్రివ్యూ చేయండి</translation>
+<translation id="3269093882174072735">చిత్రాన్ని లోడ్ చేయి</translation>
+<translation id="3845332215609790146">Brave Software లెన్స్‌తో శోధన <ph name="BEGIN_NEW"/>కొత్తది<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">ఈ చిత్రం కోసం <ph name="SEARCH_ENGINE"/>లో వెతకండి</translation>
+<translation id="3384347053049321195">చిత్రాన్ని షేర్‌ చేయి</translation>
+<translation id="5833984609253377421">లింక్‌ను షేర్ చేయి</translation>
+<translation id="6475951671322991020">వీడియోను డౌన్‌లోడ్ చేయి</translation>
+<translation id="2317945146070194624">కొత్త Brave ట్యాబ్‌లో తెరువు</translation>
+<translation id="7975379999046275268"><ph name="BEGIN_NEW"/>కొత్త<ph name="END_NEW"/> పేజీని ప్రివ్యూ చేయండి</translation>
+<translation id="6112702117600201073">పేజీని రిఫ్రెష్ చేస్తోంది</translation>
+<translation id="36525718899759834">Brave Software Play Store నుండి యాప్‌ను పొందండి: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">ముదురు</translation>
+<translation id="1807246157184219062">లేత</translation>
+<translation id="4056223980640387499">సెపియా</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">మోనోస్పేస్</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Beam చేయడానికి ట్యాబ్‌ను ఎంచుకోండి</translation>
+<translation id="8719023831149562936">ప్రస్తుత ట్యాబ్‌ను బీమ్ చేయడం సాధ్యపడదు</translation>
+<translation id="2139186145475833000">హోమ్ స్క్రీన్‌కు జోడించు</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/>ని తెరువు</translation>
+<translation id="2122601567107267586">యాప్‌ను తెరవడం సాధ్యపడలేదు</translation>
+<translation id="5129038482087801250">వెబ్ యాప్‌ ఇన్‌స్టాల్ చేయి</translation>
+<translation id="3789841737615482174">ఇన్‌స్టాల్ చేయి</translation>
+<translation id="4665282149850138822"><ph name="NAME"/> మీ హోమ్ స్క్రీన్‌కు జోడించబడింది</translation>
+<translation id="7333031090786104871">ఇంకా మునుపటి సైట్‌ను జోడిస్తోంది</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/>ని జోడిస్తోంది...</translation>
+<translation id="3778956594442850293">హోమ్ స్క్రీన్‌కు జోడించబడింది</translation>
+<translation id="2146738493024040262">తక్షణ యాప్‌ను తెరువు</translation>
+<translation id="7016516562562142042">ప్రస్తుత శోధన ఇంజిన్‌కు అనుమతించబడింది</translation>
+<translation id="6177111841848151710">ప్రస్తుత శోధన ఇంజిన్‌కు బ్లాక్ చేయబడింది</translation>
+<translation id="145097072038377568">Android సెట్టింగ్‌ల్లో ఆఫ్ చేయబడింది</translation>
+<translation id="8007176423574883786">ఈ పరికరం కోసం ఆఫ్ చేయబడింది</translation>
+<translation id="164269334534774161">మీరు <ph name="CREATION_TIME"/> నుండి ఈ పేజీ యొక్క ఆఫ్‌లైన్ కాపీని వీక్షిస్తున్నారు</translation>
+<translation id="4594952190837476234">ఈ ఆఫ్‌లైన్ పేజీ <ph name="CREATION_TIME"/>కి చెందినది మరియు ఆన్‌లైన్ వెర్షన్ వేరుగా ఉండవచ్చు.</translation>
+<translation id="8840953339110955557">ఈ పేజీ మరియు ఆన్‌లైన్ వెర్షన్ వేరుగా ఉండవచ్చు.</translation>
+<translation id="6405300764336705484">ఈ కంటెంట్ Brave Software ద్వారా డెలివర్ చేయబడిన <ph name="DOMAIN_NAME"/>లోనిది.</translation>
+<translation id="1006017844123154345">ఆన్‌లైన్‌లో తెరువు</translation>
+<translation id="3326636747541519688">Brave Software అందించిన లైట్ పేజీ</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> నుండి <ph name="BEGIN_LINK"/>అసలైన పేజీని లోడ్ చేయండి<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">మీకు ఇది తరచుగా కనిపిస్తుంటే, ఈ <ph name="BEGIN_LINK"/>సూచనల<ph name="END_LINK"/>ను ప్రయత్నించండి.</translation>
+<translation id="8748850008226585750">కంటెంట్‌లు దాచబడ్డాయి</translation>
+<translation id="3810973564298564668">నిర్వహించు</translation>
+<translation id="5199929503336119739">కార్యాలయ ప్రొఫైల్</translation>
+<translation id="528192093759286357">పూర్తి స్క్రీన్ నుండి నిష్క్రమించడానికి పైనుండి లాగి, వెనుకకు బటన్‌ను తాకండి.</translation>
+<translation id="2836148919159985482">పూర్తి స్క్రీన్ నుండి నిష్క్రమించడానికి వెనుకకు బటన్‌ను తాకండి.</translation>
+<translation id="3967822245660637423">డౌన్‌లోడ్ పూర్తయింది</translation>
+<translation id="2434158240863470628">డౌన్‌లోడ్ పూర్తయింది <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">డౌన్‌లోడ్ విఫలమైంది</translation>
+<translation id="1384959399684842514">డౌన్‌లోడ్ పాజ్ చేయబడింది</translation>
+<translation id="1671236975893690980">డౌన్‌లోడ్ పెండింగ్‌లో ఉంది…</translation>
+<translation id="5561549206367097665">నెట్‌వర్క్ కోసం వేచి ఉంది…</translation>
+<translation id="5864419784173784555">మరొక డౌన్‌లోడ్ కోసం వేచి ఉంది…</translation>
+<translation id="6461962085415701688">ఫైల్‌ను తెరవడం సాధ్యపడదు</translation>
+<translation id="1178581264944972037">పాజ్ చేయి</translation>
+<translation id="8200772114523450471">మ‌ళ్లీ ప్రారంభించు</translation>
+<translation id="1409879593029778104">ఫైల్ ఇప్పటికే ఉన్నందున <ph name="FILE_NAME"/> డౌన్‌లోడ్ నిరోధించబడింది.</translation>
+<translation id="3387650086002190359">ఫైల్ సిస్టమ్ లోపాల కారణంగా <ph name="FILE_NAME"/> డౌన్‌లోడ్ విఫలమైంది.</translation>
+<translation id="6482749332252372425">నిల్వ స్థలం లేనందున <ph name="FILE_NAME"/> డౌన్‌లోడ్ విఫలమైంది.</translation>
+<translation id="7619072057915878432">నెట్‌వర్క్ వైఫల్యాల కారణంగా <ph name="FILE_NAME"/> డౌన్‌లోడ్ విఫలమైంది.</translation>
+<translation id="1477626028522505441">సర్వర్ సమస్యల కారణంగా <ph name="FILE_NAME"/> డౌన్‌లోడ్ విఫలమైంది.</translation>
+<translation id="3692944402865947621">నిల్వ స్థానాన్ని చేరుకోలేకపోయిన కారణంగా <ph name="FILE_NAME"/> డౌన్‌లోడ్ విఫలమైంది.</translation>
+<translation id="604996488070107836">తెలియని ఎర్ర‌ర్‌ కారణంగా <ph name="FILE_NAME"/> డౌన్‌లోడ్ విఫలమైంది.</translation>
+<translation id="6738867403308150051">డౌన్‌లోడ్ చేస్తోంది...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB డౌన్‌లోడ్ చేయబడింది</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB డౌన్‌లోడ్ చేయబడింది</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB డౌన్‌లోడ్ చేయబడింది</translation>
+<translation id="9204836675896933765">1 ఫైల్ మిగిలి ఉంది</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> ఫైల్‌లు మిగిలి ఉన్నాయి</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> ఫైల్ డౌన్‌లోడ్ చేయబడింది}other{<ph name="FILES_DOWNLOADED_MANY"/> ఫైల్‌లు డౌన్‌లోడ్ చేయబడ్డాయి}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> రోజులు మిగిలి ఉంది</translation>
+<translation id="8190358571722158785">1 రోజు మిగిలి ఉంది</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> గంటలు మిగిలి ఉంది</translation>
+<translation id="510275257476243843">1 గంట మిగిలి ఉంది</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> నిమిషాలు మిగిలి ఉంది</translation>
+<translation id="3236059992281584593">1 నిమిషం మిగిలి ఉంది</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> సెకన్లు మిగిలి ఉంది</translation>
+<translation id="2781151931089541271">1 సెకను మిగిలి ఉంది</translation>
+<translation id="3303414029551471755">కంటెంట్‌ను డౌన్‌లోడ్ చేయడం కొనసాగించాలా?</translation>
+<translation id="8617240290563765734">డౌన్‌లోడ్ చేసిన కంటెంట్‌లో పేర్కొన్న సూచిత URLని తెరవాలా?</translation>
+<translation id="1373696734384179344">ఎంచుకున్న కంటెంట్‌ను డౌన్‌లోడ్ చేయడానికి తగినంత మెమరీ లేదు.</translation>
+<translation id="5271967389191913893">పరికరం డౌన్‌లోడ్ చేయాల్సిన కంటెంట్‌ను తెరవలేదు.</translation>
+<translation id="883806473910249246">కంటెంట్‌ను డౌన్‌లోడ్ చేస్తున్నప్పుడు ఎర్రర్ ఏర్పడింది.</translation>
+<translation id="5626134646977739690">పేరు:</translation>
+<translation id="7963646190083259054">విక్రేత:</translation>
+<translation id="3414952576877147120">పరిమాణం:</translation>
+<translation id="7375125077091615385">రకం:</translation>
+<translation id="5765780083710877561">వివరణ:</translation>
+<translation id="4881695831933465202">తెరువు</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB అందుబాటులో ఉంది</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB అందుబాటులో ఉంది</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB అందుబాటులో ఉంది</translation>
+<translation id="5793665092639000975"><ph name="SPACE_AVAILABLE"/>లో <ph name="SPACE_USED"/> ఉపయోగించబడింది</translation>
+<translation id="3587482841069643663">మొత్తం</translation>
+<translation id="4988526792673242964">పేజీలు</translation>
+<translation id="3810838688059735925">వీడియో</translation>
+<translation id="3616113530831147358">ఆడియో</translation>
+<translation id="9219103736887031265">చిత్రాలు</translation>
+<translation id="8250920743982581267">పత్రాలు</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ఫైల్}other{# ఫైల్‌లు}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ఫోటో}other{# ఫోటోలు}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# వీడియో}other{# వీడియోలు}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# ఆడియో ఫైల్}other{# ఆడియో ఫైల్‌లు}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# పేజీ}other{# పేజీలు}}</translation>
+<translation id="5456381639095306749">పేజీని డౌన్‌లోడ్ చేయండి</translation>
+<translation id="2394602618534698961">మీరు డౌన్‌లోడ్ చేసే ఫైల్‌లు ఇక్కడ కనిపిస్తాయి</translation>
+<translation id="7810647596859435254">దీనితో తెరువు…</translation>
+<translation id="5655963694829536461">మీ డౌన్‌లోడ్‌లను వెతకండి</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">నా ఫైల్‌లు</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">కథనాలు ఇక్కడ కనిపిస్తాయి, మీరు ఆఫ్‌లైన్‌లో ఉన్నప్పటికీ కూడా వీటిని చదవవచ్చు</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# గం}other{# గం}}</translation>
+<translation id="5853623416121554550">పాజ్ చేయబడింది</translation>
+<translation id="8965591936373831584">పెండింగ్‌లో ఉంది</translation>
+<translation id="2779651927720337254">విఫలమైంది</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">ఇప్పుడే</translation>
+<translation id="4000212216660919741">ఆఫ్‌లైన్ హోమ్</translation>
+<translation id="9133397713400217035">ఆఫ్‌లైన్‌లో అన్వేషించండి</translation>
+<translation id="968900484120156207">మీరు సందర్శించే పేజీలు ఇక్కడ కనిపిస్తాయి</translation>
+<translation id="7882131421121961860">చరిత్ర ఏదీ కనుగొనబడలేదు</translation>
+<translation id="3549657413697417275">మీ చరిత్రను వెతకండి</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave మొదటి అమలు అనుభవం</translation>
+<translation id="2700285883409956633">ఈ అప్లికేషన్‌ను ఉపయోగించడం ద్వారా, మీరు Brave <ph name="BEGIN_LINK1"/>సేవా నిబంధనలు<ph name="END_LINK1"/> మరియు <ph name="BEGIN_LINK2"/>గోప్యతా నోటీసు<ph name="END_LINK2"/>ను అంగీకరిస్తున్నారు.</translation>
+<translation id="1640714894372474981">యాప్‌ని ఉపయోగించడం ద్వారా, మీరు Brave యొక్క <ph name="BEGIN_LINK1"/>సేవా నిబంధనలు<ph name="END_LINK1"/>, <ph name="BEGIN_LINK2"/>గోప్యతా నోటీసు<ph name="END_LINK2"/> మరియు <ph name="BEGIN_LINK3"/>Brave Software ఖాతాల కోసం Family Linkలో నిర్వహించే గోప్యతా నోటీసు<ph name="END_LINK3"/>ను అంగీకరిస్తున్నారు.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/>లో తెరవబడుతుంది. కొనసాగించడం ద్వారా మీరు Brave <ph name="BEGIN_LINK1"/>సేవా నిబంధనలు<ph name="END_LINK1"/> మరియు <ph name="BEGIN_LINK2"/>గోప్యతా నోటీసు<ph name="END_LINK2"/>కి అంగీకరిస్తున్నారు.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Braveలో తెరవబడుతుంది. కొనసాగించడం ద్వారా, మీరు Brave <ph name="BEGIN_LINK1"/>సేవా నిబంధనలు<ph name="END_LINK1"/> మరియు <ph name="BEGIN_LINK2"/>గోప్యతా నోటీసు<ph name="END_LINK2"/> మరియు <ph name="BEGIN_LINK3"/>Family Linkలో నిర్వహించే Brave Software ఖాతాల కోసం గోప్యతా నోటీసు<ph name="END_LINK3"/>ను అంగీకరిస్తున్నారు.</translation>
+<translation id="673197144963363525">వినియోగ గణాంకాలు, క్రాష్ నివేదికలను Brave Softwareకు పంపి, తద్వారా Braveను మెరుగుపరచడంలో సహాయపడండి.</translation>
+<translation id="3518985090088779359">అంగీకరించు &amp; కొనసాగు</translation>
+<translation id="7207456302801184289">Braveకు స్వాగతం</translation>
+<translation id="704822250101715322">Brave Software Play సేవల నవీకరణ పూర్తి కావడానికి వేచి ఉంది</translation>
+<translation id="1231733316453485619">సమకాలీకరణను ఆన్ చేయాలా?</translation>
+<translation id="5132942445612118989">అన్ని పరికరాల్లో మీ పాస్‌వర్డ్‌లు, చరిత్ర, మరిన్నింటిని సింక్ చేయండి</translation>
+<translation id="5736731321935944068">శోధన, ప్రకటనలు, ఇతర Brave Software సేవలను వ్యక్తిగతీకరించడానికి Brave Software మీ చరిత్రను ఉపయోగించే అవకాశం ఉంటుంది</translation>
+<translation id="4013614219085422040">శోధన, ఇతర Brave Software సేవలను వ్యక్తిగతీకరించడానికి Brave Software మీ చరిత్రను ఉపయోగించే అవకాశం ఉంటుంది</translation>
+<translation id="5581519193887989363">మీరు ఎప్పుడైనా <ph name="BEGIN_LINK1"/>సెట్టింగ్‌ల<ph name="END_LINK1"/> ద్వారా వేటిని సింక్ చేయాలో ఎంచుకోవచ్చు.</translation>
+<translation id="741204030948306876">సరే, సమ్మతమే</translation>
+<translation id="2410754283952462441">ఖాతాను ఎంచుకోండి</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/>గా కొనసాగించు</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> కాదా?</translation>
+<translation id="8109613176066109935">ఇక ఎప్పుడు ఎక్కడ బుక్‌మార్క్‌లను సెట్‌ చేసినా ఆటోమాటిక్‌గా మీ అన్ని పరికరాలలో పొందాలనుకుంటే, సమకాలీకరణ ఎంపికని ఆన్ చేయండి</translation>
+<translation id="2818669890320396765">ఇక ఎప్పుడు ఎక్కడ బుక్‌మార్క్‌లను సెట్‌ చేసినా ఆటోమాటిక్‌గా మీ అన్ని పరికరాలలోనూ పొందాలనుకుంటే, సైన్ ఇన్ చేసి, సమకాలీకరణ ఎంపికను ఆన్ చేయండి</translation>
+<translation id="6003646045106347985">Brave Software ద్వారా మీ అభిరుచికి తగిన కంటెంట్‌ను సిఫార్సుల రూపంలో పొందాలనుకుంటే, సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
+<translation id="8494430740943879273">Brave Software ద్వారా మీ అభిరుచికి తగిన కంటెంట్‌ను సిఫార్సుల రూపంలో పొందాలనుకుంటే, సైన్ ఇన్ చేసి సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
+<translation id="5862731021271217234">మీ ఇతర పరికరాలలో ఉన్న మీ అన్ని ట్యాబ్‌లను పొందాలనుకుంటే, సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
+<translation id="3568688522516854065">మీ ఇతర పరికరాలలో ఉన్న మీ అన్ని ట్యాబ్‌‌‍లను పొందాలనుకుంటే, సైన్ ఇన్ చేసి, సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
+<translation id="1208340532756947324">మీ అన్ని పరికరాలలోనూ సమకాలీకరణ చేయాలన్నా లేదా మీ అభిరుచికి అనుగుణంగా సెట్ చేయాలన్నా, తప్పనిసరిగా సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
+<translation id="4472118726404937099">మీ అన్ని పరికరాలలో సమకాలీకరణ చేయాలన్నా లేదా మీ అభిరుచికి అనుగుణంగా సెట్ చేయాలన్నా, సైన్ ఇన్ చేసి సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
+<translation id="2426805022920575512">మరొక ఖాతాను ఎంచుకోండి</translation>
+<translation id="6790428901817661496">ప్లే చేయి</translation>
+<translation id="1272079795634619415">ఆపు</translation>
+<translation id="2874939134665556319">మునుపటి ట్రాక్</translation>
+<translation id="4046123991198612571">తరువాత ట్రాక్</translation>
+<translation id="3859306556332390985">ముందుకు జరుపు</translation>
+<translation id="8441146129660941386">వెనుకకు జరుపు</translation>
+<translation id="6706288973712894588">మీరు ప్రస్తుతం ఆఫ్‌లైన్‌లో ఉన్నారు.\n<ph name="BEGIN_LINK"/>మీ ఆఫ్‌లైన్ ఫీడ్‌ను అన్వేషించండి.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">ఇటీవలి ట్యాబ్‌లు</translation>
+<translation id="8497726226069778601">ఇక్కడ చూడటానికి ఏమీ లేదు… ఇప్పటికీ</translation>
+<translation id="5423934151118863508">మీరు అత్యంత ఎక్కువగా సందర్శించిన పేజీలు ఇక్కడ కనిపిస్తాయి</translation>
+<translation id="6127379762771434464">అంశాన్ని తీసివేసారు</translation>
+<translation id="4605958867780575332">ఈ అంశం తీసివేయబడింది: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">ఇతర పరికరాలు</translation>
+<translation id="4738836084190194332">చివరిగా సమకాలీకరించినది: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# నిమిషం క్రితం}other{# నిమిషాల క్రితం}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# గంట క్రితం}other{# గంటల క్రితం}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# రోజు క్రితం}other{# రోజుల క్రితం}}</translation>
+<translation id="2762000892062317888">ఇప్పుడే</translation>
+<translation id="1407135791313364759">అన్నీ తెరువు</translation>
+<translation id="1209206284964581585">ప్రస్తుతానికి దాచు</translation>
+<translation id="129553762522093515">ఇటీవల మూసివెయ్యబడినవి</translation>
+<translation id="8413126021676339697">పూర్తి చరిత్రను చూపించు</translation>
+<translation id="7876243839304621966">అన్నీ తొలగించు</translation>
+<translation id="8487700953926739672">ఆఫ్‌లైన్‌లో అందుబాటు</translation>
+<translation id="5224771365102442243">వీడియోతో</translation>
+<translation id="3493531032208478708">సూచించిన కంటెంట్ గురించి <ph name="BEGIN_LINK"/>మరింత తెలుసుకోండి<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">సూచనలను పొందడం సాధ్యపడదు</translation>
+<translation id="5013696553129441713">కొత్త సూచనలు ఏవీ లేవు</translation>
+<translation id="1736419249208073774">అన్వేషించండి</translation>
+<translation id="7444811645081526538">మరిన్ని వర్గాలు</translation>
+<translation id="6709133671862442373">వార్తలు</translation>
+<translation id="1264974993859112054">క్రీడలు</translation>
+<translation id="9139318394846604261">షాపింగ్</translation>
+<translation id="3912508018559818924">వెబ్ నుండి ఉత్తమమైనది కనుగొంటోంది…</translation>
+<translation id="526421993248218238">ఈ పేజీని లోడ్ చేయడం సాధ్యం కాదు</translation>
+<translation id="614940544461990577">ఇలా చేసి ప్రయత్నించండి:</translation>
+<translation id="3288003805934695103">పేజీని మళ్లీ లోడ్ చేయడం</translation>
+<translation id="2353636109065292463">మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేస్తోంది</translation>
+<translation id="2858138569776157458">టాప్ సైట్‌లు</translation>
+<translation id="8364299278605033898">ప్రసిద్ధ వెబ్‌సైట్‌లను చూడండి</translation>
+<translation id="1171770572613082465">"టాప్ సైట్‌లు" బటన్‌పై నొక్కడం ద్వారా ప్రసిద్ధ వెబ్‌సైట్‌లను చూడండి</translation>
+<translation id="5233638681132016545">కొత్త‌ టాబ్</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/> నుండి – <ph name="BEGIN_DEEMPHASIZED"/>Brave Software బట్వాడా చేస్తోంది<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">సరికొత్త వెర్షన్ ఉంది</translation>
+<translation id="4058091506841967397">Brave అప్‌డేట్ అవదు</translation>
+<translation id="6316139424528454185">Android వెర్షన్‌కు మద్దతు లేదు</translation>
+<translation id="6989267951144302301">డౌన్‌లోడ్ సాధ్యపడలేదు</translation>
+<translation id="624789221780392884">అప్‌డేట్‌ సిద్ధంగా ఉంది</translation>
+<translation id="1549000191223877751">వేరే విండోకు తరలించు</translation>
+<translation id="7481312909269577407">ఫార్వర్డ్</translation>
+<translation id="4084682180776658562">బుక్‌మార్క్ చేయి</translation>
+<translation id="6437478888915024427">పేజీ సమాచారం</translation>
+<translation id="7180611975245234373">రిఫ్రెష్ చేయి</translation>
+<translation id="4913169188695071480">రీఫ్రెష్ చేయడం ఆపివేయి</translation>
+<translation id="1829244130665387512">పేజీలో కనుగొను</translation>
+<translation id="6593061639179217415">డెస్క్‌టాప్ సైట్</translation>
+<translation id="9063523880881406963">డెస్క్‌టాప్ సైట్ అభ్యర్థనను ఆఫ్ చేయండి</translation>
+<translation id="2038563949887743358">డెస్క్‌టాప్ సైట్ అభ్యర్థనను ఆన్ చేయండి</translation>
+<translation id="2433507940547922241">కనిపించే తీరు</translation>
+<translation id="983192555821071799">అన్ని ట్యాబ్‌లను మూసివేయి</translation>
+<translation id="1310482092992808703">ట్యాబ్‌లను గుంపుగా చేయి</translation>
+<translation id="7725024127233776428">మీరు బుక్‌మార్క్ చేసే పేజీలు ఇక్కడ కనిపిస్తాయి</translation>
+<translation id="4404568932422911380">బుక్‌మార్క్‌లు లేవు</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> బుక్‌మార్క్}other{<ph name="BOOKMARKS_COUNT_MANY"/> బుక్‌మార్క్‌లు}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/>లో బుక్‌మార్క్ చేయబడింది</translation>
+<translation id="3207960819495026254">బుక్‌మార్క్ చేయబడింది</translation>
+<translation id="4452548195519783679"><ph name="FOLDER_NAME"/>కి బుక్‌మార్క్ చేసారు</translation>
+<translation id="8063895661287329888">బుక్‌మార్క్‌ను జోడించడంలో విఫలమైంది.</translation>
+<translation id="2842985007712546952">మూల ఫోల్డర్</translation>
+<translation id="9065203028668620118">సవరించు</translation>
+<translation id="4405224443901389797">ఇక్కడికి తరలించండి…</translation>
+<translation id="5170568018924773124">ఫోల్డర్‌లో చూపించు</translation>
+<translation id="8035133914807600019">కొత్త ఫోల్డర్…</translation>
+<translation id="4532845899244822526">ఫోల్డర్‌ను ఎంచుకోండి</translation>
+<translation id="6627583120233659107">ఫోల్డర్‌ను సవరించు</translation>
+<translation id="1197267115302279827">బుక్‌మార్క్‌లను తరలించు</translation>
+<translation id="6963766334940102469">బుక్‌మార్క్‌లను తొలగించు</translation>
+<translation id="4351244548802238354">డైలాగ్‌ను మూసివేయి</translation>
+<translation id="451872707440238414">మీ బుక్‌మార్క్‌లను వెతకండి</translation>
+<translation id="8901170036886848654">బుక్‌మార్క్‌లు ఏవీ కనుగొనబడలేదు</translation>
+<translation id="6404511346730675251">బుక్‌మార్క్‌ను సవరించు</translation>
+<translation id="3894427358181296146">ఫోల్డర్‌ను జోడించండి</translation>
+<translation id="5327248766486351172">పేరు</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">ఫోల్డర్</translation>
+<translation id="5161254044473106830">శీర్షిక అవసరం</translation>
+<translation id="2996809686854298943">URL అవసరం</translation>
+<translation id="2536728043171574184">ఈ పేజీ ఆఫ్‌లైన్ కాపీని వీక్షిస్తున్నారు</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/>లో ఆఫ్‌లైన్‌లో వీక్షించండి</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> మరియు మరిన్ని సైట్‌లు</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{కనెక్ట్ అయినప్పుడు, Brave మీ పేజీని లోడ్ చేస్తుంది}other{కనెక్ట్ అయినప్పుడు, Brave మీ పేజీలను లోడ్ చేస్తుంది}}</translation>
+<translation id="6811034713472274749">పేజీ వీక్షించడానికి సిద్ధంగా ఉంది</translation>
+<translation id="4561979708150884304">కనెక్షన్ లేదు</translation>
+<translation id="8274165955039650276">డౌన్‌లోడ్‌లు చూడండి</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/>లో <ph name="RESULT_NUMBER"/>వ ఫలితం</translation>
+<translation id="4943872375798546930">ఫలితాలు ఏవీ లేవు</translation>
+<translation id="981121421437150478">ఆఫ్‌లైన్</translation>
+<translation id="3298243779924642547">లైట్</translation>
+<translation id="393697183122708255">ప్రారంభించిన వాయిస్ శోధన అందుబాటులో లేదు</translation>
+<translation id="7191430249889272776">బ్యాక్‌గ్రౌండ్‌లో ట్యాబ్ తెరవబడింది.</translation>
+<translation id="8445059357334030806">Braveలో తెరువు</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/>లో తెరువు</translation>
+<translation id="7022756207310403729">బ్రౌజర్‌లో తెరువు</translation>
+<translation id="1113597929977215864">సరళీకృత వీక్షణను చూపు</translation>
+<translation id="1513352483775369820">బుక్‌మార్క్‌లు మరియు వెబ్ చరిత్ర</translation>
+<translation id="4939482511480190003">Braveను మెరుగుపరచడంలో సహాయపడండి. <ph name="BEGIN_LINK"/>సర్వేలో పాల్గొనండి<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">వెనుకకు వెళ్ళు</translation>
+<translation id="5596627076506792578">మరిన్ని ఎంపికలు</translation>
+<translation id="3522247891732774234">అప్‌డేట్‌ అందుబాటులో ఉంది. మరిన్ని ఎంపికలు</translation>
+<translation id="6773423637732432200">Braveని అప్‌డేట్ చేయడం సాధ్యపడదు. మరిన్ని ఎంపికలు</translation>
+<translation id="3328801116991980348">సైట్ సమాచారం</translation>
+<translation id="5391532827096253100">ఈ సైట్‌కి మీ కనెక్షన్ సురక్షితంగా లేదు. సైట్ సమాచారం</translation>
+<translation id="6206551242102657620">కనెక్షన్ సురక్షితం. సైట్ సమాచారం</translation>
+<translation id="6963642900430330478">ఈ పేజీ ప్రమాదకరమైనది. సైట్ సమాచారం</translation>
+<translation id="9070377983101773829">వాయిస్ శోధనను ప్రారంభించండి</translation>
+<translation id="8676374126336081632">ఇన్‌పుట్‌ను తీసివేయండి</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> ట్యాబ్ తెరవబడి ఉంది, ట్యాబ్‌లను మార్చడం కోసం నొక్కండి}other{<ph name="OPEN_TABS_MANY"/> ట్యాబ్‌లు తెరవబడి ఉన్నాయి, ట్యాబ్‌లను మార్చడం కోసం నొక్కండి}}</translation>
+<translation id="2369533728426058518">తెరిచిన ట్యాబ్‌లు</translation>
+<translation id="7071521146534760487">ఖాతాను నిర్వహిస్తుంది</translation>
+<translation id="932327136139879170">హోమ్</translation>
+<translation id="2707726405694321444">పేజీని రిఫ్రెష్ చేయండి</translation>
+<translation id="2891154217021530873">పేజీ లోడ్ కాకుండా ఆపివేయండి</translation>
+<translation id="6710213216561001401">మునుపటి</translation>
+<translation id="6659594942844771486">ట్యాబ్</translation>
+<translation id="1933845786846280168">ఎంచుకున్న ట్యాబ్</translation>
+<translation id="2268044343513325586">మరింత మెరుగుపరచండి</translation>
+<translation id="7846076177841592234">ఎంపికను రద్దు చేయి</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> ఎంచుకోబడ్డాయి.  ఎంపికలు స్క్రీన్ పైభాగానికి సమీపంలో అందుబాటులో ఉన్నాయి</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> ఎంచుకోబడ్డాయి</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{ఎంచుకోబడిన 1 అంశాన్ని భాగస్వామ్యం చేస్తుంది}other{ఎంచుకోబడిన # అంశాలను భాగస్వామ్యం చేస్తుంది}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{ఎంచుకోబడిన 1 అంశాన్ని తీసివేస్తుంది}other{ఎంచుకోబడిన # అంశాలను తీసివేస్తుంది}}</translation>
+<translation id="1283039547216852943">విస్త‌రించ‌డానికి నొక్కండి</translation>
+<translation id="5962718611393537961">కుదించడానికి నొక్కండి</translation>
+<translation id="8076492880354921740">ట్యాబ్‌లు</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 ఎంచుకోబడింది}other{# ఎంచుకోబడ్డాయి}}</translation>
+<translation id="6818926723028410516">అంశాలను ఎంచుకోండి</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/>కి తిరిగి వెళ్లడానికి తాకండి</translation>
+<translation id="6766758767654711248">సైట్‌లోకి వెళ్లడం కోసం నొక్కండి</translation>
+<translation id="429312253194641664">ఒక సైట్‌లో మీడియా ప్లే చేయబడుతోంది</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> మీ స్క్రీన్‌ని భాగస్వామ్యం చేస్తోంది</translation>
+<translation id="8833831881926404480">ఒక సైట్ మీ స్క్రీన్‌ని షేర్ చేస్తోంది</translation>
+<translation id="9086455579313502267">నెట్‌వర్క్‌ని యాక్సెస్ చెయ్యడం సాధ్యం కాలేదు</translation>
+<translation id="938850635132480979">ఎర్రర్: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/>లో తెరువు</translation>
+<translation id="548278423535722844">మ్యాప్స్ యాప్‌లో తెరువు</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/>లో ఇమెయిల్‌ను సృష్టించండి</translation>
+<translation id="7875915731392087153">ఇమెయిల్‌ను సృష్టించండి</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/>లో ఈవెంట్‌ను సృష్టించండి</translation>
+<translation id="2900528713135656174">ఈవెంట్‌ను సృష్టించండి</translation>
+<translation id="2111511281910874386">పేజీకి వెళ్లండి</translation>
+<translation id="3988466920954086464">ఈ ప్యానెల్‌లో తక్షణ శోధన ఫలితాలను చూడండి</translation>
+<translation id="2744248271121720757">తక్షణమే వెతకడానికి లేదా సంబంధిత చర్యలను చూడటానికి ఒక పదాన్ని నొక్కండి</translation>
+<translation id="9155898266292537608">ఒక పదంపై నొక్కడం ద్వారా కూడా మీరు త్వరగా వెతకవచ్చు</translation>
+<translation id="3232754137068452469">వెబ్ యాప్‌</translation>
+<translation id="1430915738399379752">ముద్రించు</translation>
+<translation id="3775705724665058594">మీ పరికరాలకు పంపండి</translation>
+<translation id="6364438453358674297">చరిత్ర నుండి సూచనను తీసివేయాలా?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> మూసివేయబడింది</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> ట్యాబ్‌లు మూసివేయబడ్డాయి</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> తొలగించబడింది</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> బుక్‌మార్క్‌లు తొలగించబడ్డాయి</translation>
+<translation id="3819178904835489326"><ph name="NUMBER_OF_DOWNLOADS"/> డౌన్‌లోడ్‌లు తొలగించబడ్డాయి</translation>
+<translation id="1248710015876067820">మద్దతు లేనన్ని సార్లు Braveను ప్రారంభించడానికి ప్రయత్నించారు.</translation>
+<translation id="4259722352634471385">నావిగేషన్ బ్లాక్ చేయబడింది: <ph name="URL"/></translation>
+<translation id="8959122750345127698">దీనికి నావిగేట్ చేయడం సాధ్యపడదు: <ph name="URL"/></translation>
+<translation id="5210365745912300556">ట్యాబ్‌ను మూసివేయి</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/>ను మూసివేయి</translation>
+<translation id="1227058898775614466">నావిగేషన్ చరిత్ర</translation>
+<translation id="9169507124922466868">నావిగేషన్ చరిత్ర సగం తెరిచి ఉంది</translation>
+<translation id="1327257854815634930">నావిగేషన్ చరిత్ర తెరిచి ఉంది</translation>
+<translation id="8788265440806329501">నావిగేషన్ చరిత్ర మూసివేయబడింది</translation>
+<translation id="7482656565088326534">ప్రివ్యూ ట్యాబ్</translation>
+<translation id="8427875596167638501">ప్రివ్యూ ట్యాబ్ సగం తెరవబడింది</translation>
+<translation id="9102803872260866941">ప్రివ్యూ ట్యాబ్ తెరవబడింది</translation>
+<translation id="2942036813789421260">ప్రివ్యూ ట్యాబ్ మూసివేయబడింది</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> నిల్వ</translation>
+<translation id="3822502789641063741">సైట్ నిల్వను తీసివేయాలా?</translation>
+<translation id="9205995714227143200">Brave ముఖ్యమైనదిగా భావించని సైట్ నిల్వ (ఉదా. సేవ్ చేసిన సెట్టింగ్‌లు లేని సైట్‌లు లేదా మీరు తరచుగా సందర్శించని సైట్‌లు)</translation>
+<translation id="3997476611815694295">ప్రధానం కాని నిల్వ</translation>
+<translation id="8493948351860045254">స్థలాన్ని ఖాళీ చేయి</translation>
+<translation id="2324920234469020158">ఇది Brave ముఖ్యమైనదిగా భావించని కుక్కీలు, కాష్, సైట్‌ల ఇతర డేటాను తీసివేస్తుంది.</translation>
+<translation id="5447201525962359567">కుక్కీలు, స్థానికంగా నిల్వ చేసిన ఇతర డేటాతో సహా మొత్తం సైట్ నిల్వ</translation>
+<translation id="1376578503827013741">గణిస్తోంది...</translation>
+<translation id="583281660410589416">తెలియని</translation>
+<translation id="2323763861024343754">సైట్ నిల్వ</translation>
+<translation id="3587672679800759167">ఖాతాలు, బుక్‌మార్క్‌లు, సేవ్ చేసిన సెట్టింగ్‌లతో సహా Brave ఉపయోగించిన మొత్తం డేటా</translation>
+<translation id="6545017243486555795">మొత్తం డేటాను తీసివేయి</translation>
+<translation id="4095146165863963773">యాప్‌ డేటాను తొలగించాలా?</translation>
+<translation id="53119194224775367">Brave యాప్‌ డేటా మొత్తం శాశ్వతంగా తొలగించబడుతుంది. డేటాలో అన్ని ఫైల్‌లు, సెట్టింగ్‌లు, ఖాతాలు, డేటాబేస్‌లు మొదలైనవి ఉంటాయి.</translation>
+<translation id="5307446750509046227">సైట్ నిల్వను తీసివేయండి</translation>
+<translation id="300526633675317032">ఇది వెబ్‌సైట్ నిల్వలోని మొత్తం <ph name="SIZE_IN_KB"/>ను తీసివేస్తుంది.</translation>
+<translation id="8068648041423924542">ప్రమాణపత్రం ఎంపిక చేయడం సాధ్యపడలేదు.</translation>
+<translation id="2315043854645842844">క్లయింట్ తరపు స‌ర్టిఫికెట్‌ ఎంపికకు ఆపరేటింగ్ సిస్టమ్ మద్దతు లేదు.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> దీనికి కనెక్ట్ చేయాలనుకుంటోంది</translation>
+<translation id="5308380583665731573">కనెక్ట్ చేయండి</translation>
+<translation id="868929229000858085">మీ పరిచయాలను వెతకండి</translation>
+<translation id="1919950603503897840">పరిచయాలను ఎంచుకోండి</translation>
+<translation id="7986741934819883144">పరిచయాన్ని ఎంచుకోండి</translation>
+<translation id="3333961966071413176">మొత్తం పరిచయాలు</translation>
+<translation id="4994033804516042629">పరిచయాలు కనుగొనబడలేదు</translation>
+<translation id="5403592356182871684">పేర్లు</translation>
+<translation id="2717722538473713889">ఇమెయిల్ చిరునామాలు</translation>
+<translation id="381841723434055211">ఫోన్ నంబర్‌లు</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ మరో 1)}other{(+ మరో #)}}</translation>
+<translation id="5197729504361054390">మీరు ఎంచుకున్న పరిచయాలు <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>తో షేర్ చేయబడతాయి.</translation>
+<translation id="1779089405699405702">చిత్ర డీకోడర్</translation>
+<translation id="8067883171444229417">వీడియోను ప్లే చేయి</translation>
+<translation id="6560414384669816528">Sogouతో వెతకండి</translation>
+<translation id="5406914950576900927">చైనాలో వెతకడానికి <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>ను Brave ఉపయోగించవచ్చు. మీరు దీనిని <ph name="BEGIN_LINK"/>సెట్టింగ్‌ల<ph name="END_LINK"/>లో మార్చవచ్చు.</translation>
+<translation id="6456271171669383967">Brave Softwareని ఉంచు</translation>
+<translation id="4384468725000734951">శోధన కోసం Sogouను ఉపయోగిస్తుంది</translation>
+<translation id="6103327872225198548">శోధన కోసం Brave Softwareను ఉపయోగిస్తోంది</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">ఈ యాప్ Braveలో అమలవుతోంది</translation>
+<translation id="6143689084714664628">Braveలో అమలు అవుతోంది</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> డేటాను Braveలో కూడా కలిగి ఉంటుంది</translation>
+<translation id="2734140769649165081">మీరు Brave సెట్టింగ్‌లలో డేటాను తీసివేయవచ్చు</translation>
+<translation id="8232956427053453090">డేటాను అలాగే ఉంచు</translation>
+<translation id="4298388696830689168">లింక్ చేసిన సైట్‌లు</translation>
+<translation id="5763514718066511291">ఈ యాప్ URLను కాపీ చేయడానికి నొక్కండి</translation>
+<translation id="6496823230996795692">మొదటి సారి <ph name="APP_NAME"/>ని ఉపయోగించడానికి, దయచేసి ఇంటర్నెట్‌కు కనెక్ట్ చేయండి.</translation>
+<translation id="751961395872307827">సైట్‌కు కనెక్ట్ చేయడం సాధ్యపడలేదు</translation>
+<translation id="4878404682131129617">ప్రాక్సీ సర్వర్ ద్వారా ఒక సొరంగంను ఏర్పాటు చేయడం విఫలమైంది</translation>
+<translation id="4749960740855309258">కొత్త ట్యాబ్‌ను తెరవండి</translation>
+<translation id="8788968922598763114">చివరగా మూసివేసిన ట్యాబ్‌ను మళ్లీ తెరవండి</translation>
+<translation id="7929962904089429003">మెనూను తెరవండి</translation>
+<translation id="6039379616847168523">తదుపరి ట్యాబ్‌కు వెళ్లండి</translation>
+<translation id="5210286577605176222">మునుపటి ట్యాబ్‌కు వెళ్లండి</translation>
+<translation id="124678866338384709">ప్రస్తుత ట్యాబ్‌ను మూసివేయండి</translation>
+<translation id="3714981814255182093">శోధన పట్టీని తెరవండి</translation>
+<translation id="5441522332038954058">చిరునామా పట్టీకి వెళ్లండి</translation>
+<translation id="3398320232533725830">బుక్‌మార్క్‌ల నిర్వాహికి తెరవండి</translation>
+<translation id="6583199322650523874">ప్రస్తుత పేజీని బుక్‌మార్క్ చేయండి</translation>
+<translation id="8489271220582375723">చరిత్ర పేజీని తెరవండి</translation>
+<translation id="4837753911714442426">పేజీని ముద్రించడానికి ఎంపికలను తెరవండి</translation>
+<translation id="5726692708398506830">పేజీలోని అన్నింటినీ పెద్దవిగా చేయండి</translation>
+<translation id="3259831549858767975">పేజీలోని అన్నింటినీ చిన్నవిగా చేయండి</translation>
+<translation id="8015452622527143194">పేజీలో ఉన్నవ‌న్నీ, తిరిగి డిఫాల్ట్ సైజ్‌కు తీసుకురండి</translation>
+<translation id="3443221991560634068">ప్రస్తుత పేజీని మళ్లీ లోడ్ చేయండి</translation>
+<translation id="123724288017357924">కాష్ కంటెంట్ విస్మరించి ప్రస్తుత పేజీ మళ్లీ లోడ్ చేయండి</translation>
+<translation id="305870044889644984">Brave సహాయ కేంద్రాన్ని కొత్త ట్యాబ్‌లో తెరవండి</translation>
+<translation id="3166827708714933426">ట్యాబ్ మరియు విండో షార్ట్‌కట్‌లు</translation>
+<translation id="3169981355900570544">Brave Software Brave లక్షణ సత్వరమార్గాలు</translation>
+<translation id="4558311620361989323">వెబ్‌పేజీ షార్ట్‌క‌ట్‌లు</translation>
+<translation id="1908301351964700579">Brave ఇంకా VR కోసం సన్నద్ధమవుతోంది. Braveని తర్వాత పునఃప్రారంభించండి.</translation>
+<translation id="8970887620466824814">ఏదో తప్పు జరిగింది.</translation>
+<translation id="1875543012935658554">Braveను మళ్లీ తెరవండి.</translation>
+<translation id="79859296434321399">మెరుగైన వాస్తవిక అనుభవ కంటెంట్‌ను చూడడానికి, ARCoreని ఇన్‌స్టాల్ చేయండి</translation>
+<translation id="8558485628462305855">మెరుగైన వాస్తవిక అనుభవ కంటెంట్‌ను చూడడానికి, ARCoreని అప్‌డేట్ చేయండి</translation>
+<translation id="3513704683820682405">అగ్‌మెంటెడ్ రియాలిటీ</translation>
+<translation id="5475862044948910901">అగ్‌మెంటెడ్ రియాలిటీ సెషన్‌ను ప్రారంభించాలా?</translation>
 <translation id="7365126855094612066">ఈ సెషన్ సమయంలో, సైట్ వీటిని చేయగలుగుతుంది:
 • మీ పరిసరాలకు సంబంధించిన 3D మ్యాప్‌ను సృష్టించండి
 • కెమెరా మోషన్‌ను ట్రాక్ చేయండి
 
 సైట్‌కు కెమెరా యాక్సెస్ లేదు. కెమెరా చిత్రాలు మీకు మాత్రమే కనిపిస్తాయి.</translation>
-<translation id="7375125077091615385">రకం:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome మొదటి అమలు అనుభవం</translation>
-<translation id="741204030948306876">సరే, సమ్మతమే</translation>
-<translation id="7413229368719586778">ప్రారంభ తేదీ <ph name="DATE" /></translation>
-<translation id="7423098979219808738">ముందుగా అడుగుతుంది</translation>
-<translation id="7423538860840206698">క్లిప్‌బోర్డ్‌ని చదవకుండా బ్లాక్ చేసారు</translation>
-<translation id="7431991332293347422">శోధనలు మరియు మరిన్నింటిని వ్యక్తిగతీకరించడానికి మీ బ్రౌజింగ్ చరిత్ర ఎలా ఉపయోగించబడుతుందో నియంత్రించండి</translation>
-<translation id="7437998757836447326">Chrome నుండి సైన్ అవుట్ చేయండి</translation>
-<translation id="7438641746574390233">లైట్ మోడ్ ప్రారంభించబడినప్పుడు, పేజీలను మరింత వేగంగా లోడ్ చేయడం కోసం Google సర్వర్‌లను Chrome ఉపయోగిస్తుంది. చాలా నెమ్మదిగా లోడ్ అవుతున్న పేజీలలో అవసరమైన కంటెంట్‌ని మాత్రమే లోడ్ చేసే విధంగా లైట్ మోడ్ వాటిని తిరిగి వ్రాస్తుంది. అజ్ఞాత ట్యాబ్‌లలో లైట్ మోడ్ పని చేయదు.</translation>
-<translation id="7444811645081526538">మరిన్ని వర్గాలు</translation>
-<translation id="7445411102860286510">మ్యూట్ చేసిన వీడియోలను ఆటోమేటిక్‌గా ప్లే చేసేలా సైట్‌‌లను అనుమతిస్తుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="7453467225369441013">దాదాపు అన్ని సైట్‌ల నుండి మిమ్మల్ని సైన్ అవుట్ చేస్తుంది. మీరు మీ Google ఖాతా నుండి సైన్ అవుట్ చేయబడరు.</translation>
-<translation id="7454641608352164238">తగినంత స్థలం లేదు</translation>
-<translation id="7475192538862203634">మీకు ఇది తరచుగా కనిపిస్తుంటే, ఈ <ph name="BEGIN_LINK" />సూచనల<ph name="END_LINK" />ను ప్రయత్నించండి.</translation>
-<translation id="7475688122056506577">SD కార్డ్ కనుగొనబడలేదు. మీ ఫైల్‌లలో కొన్ని ఉండకపోవచ్చు.</translation>
-<translation id="7479104141328977413">ట్యాబ్ నిర్వహణ</translation>
-<translation id="7481312909269577407">ఫార్వర్డ్</translation>
-<translation id="7482656565088326534">ప్రివ్యూ ట్యాబ్</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (నవీకరించినది <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">ఆదా అయిన డేటా</translation>
-<translation id="7498271377022651285">దయచేసి వేచి ఉండండి...</translation>
-<translation id="7514365320538308">డౌన్‌లోడ్ చేయి</translation>
-<translation id="751961395872307827">సైట్‌కు కనెక్ట్ చేయడం సాధ్యపడలేదు</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">సూచనలను పొందడం సాధ్యపడదు</translation>
-<translation id="7559975015014302720">లైట్ మోడ్ ఆఫ్ చేయబడింది</translation>
-<translation id="7562080006725997899">బ్రౌజింగ్ డేటాను తీసివేస్తోంది</translation>
-<translation id="756809126120519699">Chrome డేటా తీసివేయబడింది</translation>
-<translation id="757524316907819857">రక్షిత కంటెంట్‌ను ప్లే చేయకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> ఫైల్ డౌన్‌లోడ్ చేయబడింది}other{<ph name="FILES_DOWNLOADED_MANY" /> ఫైల్‌లు డౌన్‌లోడ్ చేయబడ్డాయి}}</translation>
-<translation id="7588219262685291874">మీ పరికరం బ్యాటరీ సేవర్ ఆన్‌లో ఉన్నప్పుడు ముదురు రంగు థీమ్‌ను ఆన్ చేస్తుంది</translation>
-<translation id="7589445247086920869">ప్రస్తుత శోధన ఇంజిన్‌కు బ్లాక్ చేయండి</translation>
-<translation id="7593557518625677601">Chrome సమకాలీకరణను ప్రారంభిండానికి Android సెట్టింగ్‌లు తెరిచి, Android సిస్టమ్ సమకాలీకరణను మళ్లీ ప్రారంభించండి</translation>
-<translation id="7596558890252710462">ఆపరేటింగ్ సిస్టమ్</translation>
-<translation id="7605594153474022051">సమకాలీకరణ పని చేయడం లేదు</translation>
-<translation id="7606077192958116810">లైట్ మోడ్ ఆన్ చేయబడింది. సెట్టింగ్‌లలో దీనిని నిర్వహించండి.</translation>
-<translation id="7612619742409846846">Googleకి ఇలా సైన్ ఇన్ చేసారు</translation>
-<translation id="7619072057915878432">నెట్‌వర్క్ వైఫల్యాల కారణంగా <ph name="FILE_NAME" /> డౌన్‌లోడ్ విఫలమైంది.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />సహాయం పొందండి<ph name="END_LINK1" /> లేదా <ph name="BEGIN_LINK2" />మళ్లీ స్కాన్ చేయండి<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chromeకు స్వాగతం</translation>
-<translation id="7638584964844754484">రహస్య పదబంధం చెల్లదు</translation>
-<translation id="7641339528570811325">బ్రౌజింగ్ డేటాను తీసివేయి…</translation>
-<translation id="7648422057306047504">పాస్‌వర్డ్‌లను Google ఆధారాలతో ఎన్‌క్రిప్ట్ చేయి</translation>
-<translation id="7649070708921625228">సహాయం</translation>
-<translation id="7658239707568436148">రద్దు చేయి</translation>
-<translation id="7665369617277396874">ఖాతాను జోడించండి</translation>
-<translation id="766587987807204883">కథనాలు ఇక్కడ కనిపిస్తాయి, మీరు ఆఫ్‌లైన్‌లో ఉన్నప్పటికీ కూడా వీటిని చదవవచ్చు</translation>
-<translation id="7682724950699840886">కింది చిట్కాలను ప్రయత్నించండి: మీ పరికరంలో తగినంత స్థలం ఉన్నట్లు నిర్ధారించుకోండి, మళ్లీ ఎగుమతి చేయడానికి ప్రయత్నించండి.</translation>
-<translation id="7685301384041462804">VRలోకి ప్రవేశించడానికి ముందు మీరు ఈ సైట్‌ను విశ్వసిస్తున్నట్లు నిర్ధారించండి.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" />లో ఇమెయిల్‌ను సృష్టించండి</translation>
-<translation id="7704317875155739195">స్వయంపూర్తి శోధనలు మరియు URLలు</translation>
-<translation id="7725024127233776428">మీరు బుక్‌మార్క్ చేసే పేజీలు ఇక్కడ కనిపిస్తాయి</translation>
-<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE" />లో ఉన్న పేజీలను ఎల్లప్పుడూ అనువదించు</translation>
-<translation id="7746457520633464754">Chrome ప్రమాదకరమైన యాప్‌లు, సైట్‌లను గుర్తించడానికి, మీరు సందర్శించే కొన్ని పేజీల URLలు, పరిమిత సిస్టమ్ సమాచారం, కొంత పేజీ కంటెంట్‌ను Googleకు పంపుతుంది</translation>
-<translation id="7757787379047923882"><ph name="DEVICE_NAME" /> నుండి షేర్ చేయబడిన వచనం</translation>
-<translation id="7762668264895820836">SD కార్డ్ <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">చిరునామాను జోడించు</translation>
-<translation id="7772032839648071052">రహస్య పదబంధాన్ని నిర్ధారించండి</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" />ను మూసివేయి</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 మరియు మరో <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">నిన్న</translation>
-<translation id="7791543448312431591">జోడించు</translation>
-<translation id="780301667611848630">వద్దు , ధన్యవాదాలు</translation>
-<translation id="7810647596859435254">దీనితో తెరువు…</translation>
-<translation id="7821588508402923572">మీ డేటా పొదుపులు ఇక్కడ కనిపిస్తాయి</translation>
-<translation id="7837721118676387834">నిర్దిష్ట సైట్ కోసం మ్యూట్ చేసిన వీడియోలను ఆటోమేటిక్‌గా ప్లే చేయడానికి అనుమతిస్తుంది.</translation>
-<translation id="7846076177841592234">ఎంపికను రద్దు చేయి</translation>
-<translation id="784934925303690534">సమయ పరిధి</translation>
-<translation id="7851858861565204677">ఇతర పరికరాలు</translation>
-<translation id="7875915731392087153">ఇమెయిల్‌ను సృష్టించండి</translation>
-<translation id="7876243839304621966">అన్నీ తొలగించు</translation>
-<translation id="7882131421121961860">చరిత్ర ఏదీ కనుగొనబడలేదు</translation>
-<translation id="7882806643839505685">నిర్దిష్ట సైట్ కోసం ధ్వనిని అనుమతించండి.</translation>
-<translation id="7886917304091689118">Chromeలో అమలు అవుతోంది</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{ఫైల్‌ను డౌన్‌లోడ్ చేస్తోంది.}other{# ఫైల్‌లను డౌన్‌లోడ్ చేస్తోంది.}}</translation>
-<translation id="7929962904089429003">మెనూను తెరవండి</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> కాలం చెల్లినది.</translation>
-<translation id="7947953824732555851">ఆమోదించి, సైన్ ఇన్ చేయండి</translation>
-<translation id="7963646190083259054">విక్రేత:</translation>
-<translation id="7971136598759319605">1 రోజు క్రితం యాక్టివ్‌గా ఉంది</translation>
-<translation id="7975379999046275268"><ph name="BEGIN_NEW" />కొత్త<ph name="END_NEW" /> పేజీని ప్రివ్యూ చేయండి</translation>
-<translation id="7981313251711023384">వేగవంతమైన బ్రౌజింగ్ మరియు శోధన కోసం పేజీలను ముందస్తుగా లోడ్ చేస్తుంది</translation>
-<translation id="79859296434321399">మెరుగైన వాస్తవిక అనుభవ కంటెంట్‌ను చూడడానికి, ARCoreని ఇన్‌స్టాల్ చేయండి</translation>
-<translation id="7986741934819883144">పరిచయాన్ని ఎంచుకోండి</translation>
-<translation id="7987073022710626672">Chrome సేవా నిబంధనలు</translation>
-<translation id="7998918019931843664">మూసిన ట్యాబ్‌ను మళ్లీ తెరువు</translation>
-<translation id="7999064672810608036">కుక్కీలతో సహా, మొత్తం స్థానిక డేటాను తీసివేసి, ఈ వెబ్‌సైట్‌కు ఇచ్చిన అన్ని అనుమతులను రీసెట్ చేయాలని మీరు ఖచ్చితంగా కోరుకుంటున్నారా?</translation>
-<translation id="8004582292198964060">బ్రౌజర్</translation>
-<translation id="8007176423574883786">ఈ పరికరం కోసం ఆఫ్ చేయబడింది</translation>
-<translation id="8013372441983637696">అలాగే, ఈ పరికరం నుండి మీ Chrome డేటాను కూడా తీసివేయండి</translation>
-<translation id="8015452622527143194">పేజీలో ఉన్నవ‌న్నీ, తిరిగి డిఫాల్ట్ సైజ్‌కు తీసుకురండి</translation>
-<translation id="802154636333426148">డౌన్‌లోడ్ విఫలమైంది</translation>
-<translation id="8026334261755873520">బ్రౌజింగ్ డేటా క్లియర్ చేయండి</translation>
-<translation id="8035133914807600019">కొత్త ఫోల్డర్…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> రోజులు మిగిలి ఉంది</translation>
-<translation id="804335162455518893">SD కార్డ్ కనుగొనబడలేదు</translation>
-<translation id="805047784848435650">మీ బ్రౌజింగ్ చరిత్ర ఆధారంగా</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB అందుబాటులో ఉంది</translation>
-<translation id="8058746566562539958">కొత్త Chrome ట్యాబ్‌లో తెరువు</translation>
-<translation id="8063895661287329888">బుక్‌మార్క్‌ను జోడించడంలో విఫలమైంది.</translation>
-<translation id="806745655614357130">నా డేటాను విడిగా ఉంచండి</translation>
-<translation id="8067883171444229417">వీడియోను ప్లే చేయి</translation>
-<translation id="8068648041423924542">ప్రమాణపత్రం ఎంపిక చేయడం సాధ్యపడలేదు.</translation>
-<translation id="8073388330009372546">కొత్త ట్యాబ్‌లో చిత్రం తెరువు</translation>
-<translation id="8076492880354921740">ట్యాబ్‌లు</translation>
-<translation id="8084114998886531721">సేవ్ చేసిన పాస్‌వర్డ్</translation>
-<translation id="8087000398470557479">ఈ కంటెంట్ Google ద్వారా డెలివర్ చేయబడిన <ph name="DOMAIN_NAME" />లోనిది.</translation>
-<translation id="8103578431304235997">అజ్ఞాత ట్యాబ్</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">ఇక ఎప్పుడు ఎక్కడ బుక్‌మార్క్‌లను సెట్‌ చేసినా ఆటోమాటిక్‌గా మీ అన్ని పరికరాలలో పొందాలనుకుంటే, సమకాలీకరణ ఎంపికని ఆన్ చేయండి</translation>
-<translation id="8110087112193408731">డిజిటల్ సంక్షేమంలో మీ Chrome కార్యకలాపాన్ని చూపించాలా?</translation>
-<translation id="8116925261070264013">మ్యూట్ చేసినవి</translation>
-<translation id="813082847718468539">సైట్ సమాచారాన్ని చూడండి</translation>
-<translation id="8131740175452115882">నిర్ధారించు</translation>
-<translation id="8156139159503939589">మీరు ఏ భాషలను చదవగలరు?</translation>
-<translation id="8168435359814927499">కంటెంట్</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> ఫైల్‌లు మిగిలి ఉన్నాయి</translation>
-<translation id="8190358571722158785">1 రోజు మిగిలి ఉంది</translation>
-<translation id="8200772114523450471">మ‌ళ్లీ ప్రారంభించు</translation>
-<translation id="8209050860603202033">చిత్రాన్ని తెరువు</translation>
-<translation id="8218622182176210845">మీ ఖాతాను నిర్వహించండి</translation>
-<translation id="8224471946457685718">మీ కోసం అందించే కథనాలను Wi-Fi ద్వారా డౌన్‌లోడ్ చేసుకోండి</translation>
-<translation id="8232956427053453090">డేటాను అలాగే ఉంచు</translation>
-<translation id="8249310407154411074">ఎగువకు తరలించు</translation>
-<translation id="8250920743982581267">పత్రాలు</translation>
-<translation id="825412236959742607">ఈ పేజీ చాలా మెమరీని ఉపయోగిస్తుంది, కాబట్టి Chrome కొంత కంటెంట్‌ను తీసివేసింది.</translation>
-<translation id="8260126382462817229">మళ్లీ సైన్ ఇన్ చేయడానికి ప్రయత్నించండి</translation>
-<translation id="8261506727792406068">తొలగించు</translation>
-<translation id="8266862848225348053">డౌన్‌లోడ్‌ల ఫోల్డర్</translation>
-<translation id="8274165955039650276">డౌన్‌లోడ్‌లు చూడండి</translation>
-<translation id="8284326494547611709">ఉపశీర్షికలు</translation>
-<translation id="8300705686683892304">యాప్ ద్వారా నిర్వహించబడుతున్నవి</translation>
-<translation id="8310344678080805313">ప్రామాణిక ట్యాబ్‌లు</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> మరియు మరిన్ని సైట్‌లు</translation>
-<translation id="8327155640814342956">ఉత్తమ బ్రౌజింగ్ అనుభవం కోసం, Chromeను అప్‌డేట్ చేయడానికి అనుమతించండి</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" />లో ఉన్న పేజీలు అనువదించబడవు</translation>
-<translation id="8349013245300336738">వినియోగించిన డేటా పరిమాణం ద్వారా క్రమీకరించు</translation>
-<translation id="8364299278605033898">ప్రసిద్ధ వెబ్‌సైట్‌లను చూడండి</translation>
-<translation id="8368027906805972958">తెలియని లేదా మద్దతు లేని పరికరం (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">నిర్దిష్ట సైట్ కోసం నేపథ్య సింక్‌ను అనుమతిస్తుంది.</translation>
-<translation id="8378714024927312812">మీ సంస్థ ద్వారా నిర్వహించబడుతున్నవి</translation>
-<translation id="8380167699614421159">ఈ సైట్ అనుచితమైన లేదా తప్పుదారి పట్టించే ప్రకటనలను చూపుతుంది</translation>
-<translation id="8393700583063109961">సందేశాన్ని పంపండి</translation>
-<translation id="8413126021676339697">పూర్తి చరిత్రను చూపించు</translation>
-<translation id="8427875596167638501">ప్రివ్యూ ట్యాబ్ సగం తెరవబడింది</translation>
-<translation id="8428213095426709021">సెట్టింగ్‌లు</translation>
-<translation id="8438566539970814960">శోధనలు మరియు బ్రౌజింగ్‌ను మెరుగుపరచండి</translation>
-<translation id="8441146129660941386">వెనుకకు జరుపు</translation>
-<translation id="8443209985646068659">Chrome అప్‌డేట్ అవదు</translation>
-<translation id="8445448999790540984">పాస్‌వర్డ్‌లను ఎగుమతి చేయడం సాధ్యం కాదు</translation>
-<translation id="8447861592752582886">పరికర అనుమతిని ఉపసంహరిస్తుంది</translation>
-<translation id="8461694314515752532">మీ స్వంత సమకాలీకరణ రహస్య పదబంధంతో సమకాలీకరించబడిన డేటాని ఎన్‌క్రిప్ట్ చేయండి</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> ఇంటర్నెట్‌కు కనెక్ట్ చేయబడి ఉందని నిర్ధారించుకోండి</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ఆఫ్‌లైన్‌లో అందుబాటు</translation>
-<translation id="8489271220582375723">చరిత్ర పేజీని తెరవండి</translation>
-<translation id="8493948351860045254">స్థలాన్ని ఖాళీ చేయి</translation>
-<translation id="8497726226069778601">ఇక్కడ చూడటానికి ఏమీ లేదు… ఇప్పటికీ</translation>
-<translation id="8503559462189395349">Chrome పాస్‌వర్డ్‌లు</translation>
-<translation id="8503813439785031346">యూజర్‌పేరు</translation>
-<translation id="8514477925623180633">Chromeతో నిల్వ చేసిన పాస్‌వర్డ్‌లను ఎగుమతి చేయండి</translation>
-<translation id="8514577642972634246">అజ్ఞాత మోడ్‌లోకి ప్రవేశించండి</translation>
-<translation id="851751545965956758">పరికరాలకు కనెక్ట్ కాకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
-<translation id="8523928698583292556">నిల్వ చేసిన పాస్‌వర్డ్‌ను తొలగిస్తుంది</translation>
-<translation id="854522910157234410">ఈ పేజీని తెరవండి</translation>
-<translation id="8558485628462305855">మెరుగైన వాస్తవిక అనుభవ కంటెంట్‌ను చూడడానికి, ARCoreని అప్‌డేట్ చేయండి</translation>
-<translation id="8559990750235505898">ఇతర భాషలలో పేజీలను అనువదించడాన్ని ఆఫర్ చేస్తుంది</translation>
-<translation id="8562452229998620586">సేవ్ చేయబడిన పాస్‌వర్డ్‌లు ఇక్కడ కనిపిస్తాయి.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> నుండి</translation>
-<translation id="8571213806525832805">గత 4 వారాలు</translation>
-<translation id="857943718398505171">అనుమతించబడింది (సిఫార్సు చేయబడింది)</translation>
-<translation id="8583805026567836021">ఖాతా డేటాను క్లియర్ చేస్తోంది</translation>
-<translation id="860043288473659153">కార్డుదారుని పేరు</translation>
-<translation id="8609465669617005112">పైకి తరలించు</translation>
-<translation id="8616006591992756292">మీ Google ఖాతా <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />లో ఇతర రూపాల్లో ఉన్న బ్రౌజింగ్ చరిత్రను కలిగి ఉండవచ్చు.</translation>
-<translation id="8617240290563765734">డౌన్‌లోడ్ చేసిన కంటెంట్‌లో పేర్కొన్న సూచిత URLని తెరవాలా?</translation>
-<translation id="8636825310635137004">మీ ఇతర పరికరాల నుండి మీ ట్యాబ్‌లను పొందడానికి, సమకాలీకరణను ఆన్ చేయండి</translation>
-<translation id="8641930654639604085">వయోజన కంటెంట్ గల సైట్‌లను బ్లాక్ చేయడానికి ప్రయత్నించండి</translation>
-<translation id="8655129584991699539">మీరు Chrome సెట్టింగ్‌లలో డేటాను తీసివేయవచ్చు</translation>
-<translation id="8662811608048051533">చాలా సైట్‌ల నుండి మిమ్మల్ని సైన్ అవుట్ చేస్తుంది.</translation>
-<translation id="8664979001105139458">ఫైల్ పేరు ఇప్పటికే ఉంది</translation>
-<translation id="8676374126336081632">ఇన్‌పుట్‌ను తీసివేయండి</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{సిగ్నల్ సామర్థ్యం స్థాయి: # బార్}other{సిగ్నల్ సామర్థ్యం స్థాయి: # బార్‌లు}}</translation>
-<translation id="868929229000858085">మీ పరిచయాలను వెతకండి</translation>
-<translation id="869891660844655955">గడువు తేదీ</translation>
-<translation id="8719023831149562936">ప్రస్తుత ట్యాబ్‌ను బీమ్ చేయడం సాధ్యపడదు</translation>
-<translation id="8725066075913043281">మళ్ళీ ప్రయత్నించండి</translation>
-<translation id="8728487861892616501">యాప్‌ని ఉపయోగించడం ద్వారా, మీరు Chrome యొక్క <ph name="BEGIN_LINK1" />సేవా నిబంధనలు<ph name="END_LINK1" />, <ph name="BEGIN_LINK2" />గోప్యతా నోటీసు<ph name="END_LINK2" /> మరియు <ph name="BEGIN_LINK3" />Google ఖాతాల కోసం Family Linkలో నిర్వహించే గోప్యతా నోటీసు<ph name="END_LINK3" />ను అంగీకరిస్తున్నారు.</translation>
-<translation id="8730621377337864115">పూర్తయింది</translation>
-<translation id="8748850008226585750">కంటెంట్‌లు దాచబడ్డాయి</translation>
-<translation id="8751914237388039244">చిత్రాన్ని ఎంచుకోండి</translation>
-<translation id="8788265440806329501">నావిగేషన్ చరిత్ర మూసివేయబడింది</translation>
-<translation id="8788968922598763114">చివరగా మూసివేసిన ట్యాబ్‌ను మళ్లీ తెరవండి</translation>
-<translation id="8801436777607969138">నిర్దిష్ట సైట్‌లో JavaScriptను బ్లాక్ చేస్తుంది.</translation>
-<translation id="8812260976093120287">కొన్ని వెబ్‌సైట్‌ల‌లో, మీరు మీ పరికరంలో ఎగువ పేర్కొన్న మద్దతు గల చెల్లింపు యాప్‌లతోచెల్లించవచ్చు.</translation>
-<translation id="8816026460808729765">సెన్సార్‌లను యాక్సెస్ చేయనీయకుండా సైట్‌లను బ్లాక్ చేస్తుంది</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chromeలో తెరవబడుతుంది. కొనసాగించడం ద్వారా, మీరు Chrome <ph name="BEGIN_LINK1" />సేవా నిబంధనలు<ph name="END_LINK1" /> మరియు <ph name="BEGIN_LINK2" />గోప్యతా నోటీసు<ph name="END_LINK2" /> మరియు <ph name="BEGIN_LINK3" />Family Linkలో నిర్వహించే Google ఖాతాల కోసం గోప్యతా నోటీసు<ph name="END_LINK3" />ను అంగీకరిస్తున్నారు.</translation>
-<translation id="8820817407110198400">బుక్‌మార్క్‌లు</translation>
-<translation id="8833831881926404480">ఒక సైట్ మీ స్క్రీన్‌ని షేర్ చేస్తోంది</translation>
-<translation id="883806473910249246">కంటెంట్‌ను డౌన్‌లోడ్ చేస్తున్నప్పుడు ఎర్రర్ ఏర్పడింది.</translation>
-<translation id="8840953339110955557">ఈ పేజీ మరియు ఆన్‌లైన్ వెర్షన్ వేరుగా ఉండవచ్చు.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, ట్యాబ్</translation>
-<translation id="885701979325669005">నిల్వ</translation>
-<translation id="889338405075704026">Chrome సెట్టింగ్‌లకు వెళ్లు</translation>
-<translation id="8901170036886848654">బుక్‌మార్క్‌లు ఏవీ కనుగొనబడలేదు</translation>
-<translation id="8909135823018751308">భాగస్వామ్యం చేయి…</translation>
-<translation id="8912362522468806198">Google ఖాతా</translation>
-<translation id="8920114477895755567">తల్లిదండ్రుల వివరాల కోసం వేచి ఉంది.</translation>
+<translation id="1188239144602654184">ARలోకి ప్రవేశించు</translation>
+<translation id="473775607612524610">అప్‌డేట్‌</translation>
+<translation id="3133489217401741157">Braveలో <ph name="MODULE"/> ఇన్‌స్టాల్ చేయబడుతోంది…</translation>
+<translation id="1791662854739702043">వ్యవస్థాపించబడింది</translation>
+<translation id="5131234170665854056">Braveలో <ph name="MODULE"/>ని ఇన్‌స్టాల్ చేయడం సాధ్యపడలేదు</translation>
+<translation id="2567385386134582609">చిత్రం</translation>
+<translation id="6395288395575013217">లింక్</translation>
+<translation id="7352939065658542140">వీడియో</translation>
+<translation id="4116038641877404294">పేజీలను ఆఫ్‌లైన్‌లో ఉపయోగించడం కోసం వాటిని డౌన్‌లోడ్ చేసుకోండి</translation>
 <translation id="8922289737868596582">మరిన్ని ఎంపికలు బటన్ నుండి పేజీలను డౌన్‌లోడ్ చేసుకోవడం ద్వారా వాటిని ఆఫ్‌లైన్‌లో ఉపయోగించండి</translation>
-<translation id="8937772741022875483">డిజిటల్ సంక్షేమం నుండి మీ Chrome కార్యకలాపం తీసివేయాలా?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">మరొక విండోలో తెరువు</translation>
-<translation id="8951232171465285730">Chrome మీకు <ph name="MEGABYTES" /> MB ఆదా చేసింది</translation>
-<translation id="8958424370300090006">ఏదైనా ఒక నిర్దిష్ట సైట్‌లో కుక్కీలను బ్లాక్ చేయండి.</translation>
-<translation id="8959122750345127698">దీనికి నావిగేట్ చేయడం సాధ్యపడదు: <ph name="URL" /></translation>
-<translation id="8965591936373831584">పెండింగ్‌లో ఉంది</translation>
-<translation id="8970887620466824814">ఏదో తప్పు జరిగింది.</translation>
-<translation id="8972098258593396643">డిఫాల్ట్ ఫోల్డర్‌కు డౌన్‌లోడ్ చేయాలా?</translation>
-<translation id="8986494364107987395">Googleకు ఆటోమేటిక్‌గా వినియోగ‌ గణాంకాలను, క్రాష్ నివేదికలను పంపు</translation>
-<translation id="8993760627012879038">కొత్త ట్యాబ్‌ను అజ్ఞాత మోడ్‌లో తెరవండి</translation>
-<translation id="8998729206196772491">మీరు <ph name="MANAGED_DOMAIN" /> నిర్వహణలో ఉన్న ఖాతా నుండి సైన్ ఇన్ చేస్తున్నారు. దీని నిర్వాహకులకు మీ Chrome డేటాపై నియంత్రణను అందిస్తున్నారు. మీ డేటా శాశ్వతంగా ఈ ఖాతాకు అనుబంధించబడుతుంది. Chrome నుండి సైన్ అవుట్ చేయడం వ‌ల్ల ఈ పరికరం నుండి మీ డేటా తొలగించబడుతుంది. కానీ ఇది మీ Google ఖాతాలో అలాగే నిల్వ చేయబడి ఉంటుంది.</translation>
-<translation id="9019902583201351841">మీ తల్లిదండ్రుల ద్వారా నిర్వహించబడుతోంది</translation>
-<translation id="9028914725102941583">పరికరాలలో షేర్ చేయడానికి, సింక్‌ను ఆన్ చేయండి</translation>
-<translation id="9029323097866369874">VRలోకి ప్రవేశించడానికి <ph name="DOMAIN" />ను అనుమతించాలా?</translation>
-<translation id="9040142327097499898">నోటిఫికేషన్‌లు అనుమతించబడ్డాయి. ఈ పరికరానికి స్థానం ఆఫ్ చేయబడింది.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# వీడియో}other{# వీడియోలు}}</translation>
-<translation id="9050666287014529139">రహస్య పదబంధం</translation>
-<translation id="9063523880881406963">డెస్క్‌టాప్ సైట్ అభ్యర్థనను ఆఫ్ చేయండి</translation>
-<translation id="9065203028668620118">సవరించు</translation>
-<translation id="9070377983101773829">వాయిస్ శోధనను ప్రారంభించండి</translation>
-<translation id="9074336505530349563">Google ద్వారా మీ అభిరుచికి తగిన కంటెంట్‌ను సిఫార్సుల రూపంలో పొందాలనుకుంటే, సైన్ ఇన్ చేసి సమకాలీకరణ ఎంపికను ఆన్ చేయాలి</translation>
-<translation id="9086455579313502267">నెట్‌వర్క్‌ని యాక్సెస్ చెయ్యడం సాధ్యం కాలేదు</translation>
-<translation id="9100505651305367705">మ‌ద్ద‌తు ఉన్న సందర్భాల్లో, సరళీకృత వీక్షణలో కథనాలను చూడగలిగే అవకాశం అందిస్తుంది</translation>
-<translation id="9100610230175265781">రహస్య పదబంధం అవసరం</translation>
-<translation id="9102803872260866941">ప్రివ్యూ ట్యాబ్ తెరవబడింది</translation>
+<translation id="5958275228015807058">డౌన్‌లోడ్‌లలో మీ ఫైల్‌లు మరియు పేజీలను కనుగొనండి</translation>
+<translation id="5620928963363755975">'మరిన్ని ఎంపికలు' బటన్ నొక్కి, డౌన్‌లోడ్‌లలో మీ ఫైల్‌లు మరియు పేజీలను కనుగొనండి</translation>
+<translation id="3341058695485821946">మీరు ఎంత డేటాను సేవ్ చేసారో చూడండి</translation>
+<translation id="3157842584138209013">'మరిన్ని ఎంపికలు' బటన్ నుండి మీరు ఎంత డేటాను సేవ్ చేసారో చూడండి</translation>
+<translation id="8218622182176210845">మీ ఖాతాను నిర్వహించండి</translation>
+<translation id="8090895580117672212">మీ Brave Software ఖాతాను నిర్వహించడానికి, "ఖాతాను నిర్వహించు" బటన్‌ను నొక్కండి</translation>
+<translation id="8856898588039823173">Brave Software నుండి లైట్ పేజీ అందించబడింది. అసలు పేజీని లోడ్ చేయడానికి నొక్కండి.</translation>
+<translation id="8134317863207426198">Brave Software అందించిన లైట్ పేజీ. అసలు పేజీని లోడ్ చేయడానికి అసలైన దానిని లోడ్ చేయి బటన్‌ను నొక్కండి.</translation>
+<translation id="4961107849584082341">ఈ పేజీని ఏ భాషలోకైనా అనువదించుకోవచ్చు</translation>
+<translation id="569536719314091526">మరిన్ని ఎంపికలు బటన్‌ని ఉపయోగించి ఈ పేజీని ఏ భాషలోకైనా అనువదించుకోవచ్చు</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/>తో వెతకండి</translation>
+<translation id="1792959175193046959">డిఫాల్ట్ డౌన్‌లోడ్ స్థానాన్ని ఎప్పుడైనా మార్చుకోండి</translation>
+<translation id="6942665639005891494">సెట్టింగ్‌ల మెనూ ఎంపికను ఉపయోగించి డిఫాల్ట్ డౌన్‌లోడ్ స్థానాన్ని మార్చండి</translation>
+<translation id="6850409657436465440">మీ డౌన్‌లోడ్‌‌ ఇప్పటికీ జరుగుతోంది</translation>
+<translation id="5817715962196959877">Brave ఇప్పుడు ఫైల్‌లను మరింత వేగంగా డౌన్‌లోడ్ చేస్తుంది</translation>
+<translation id="3976396876660209797">ఈ షార్ట్‌కట్‌ను తీసివేసి, పునఃసృష్టించండి</translation>
+<translation id="6766622839693428701">మూసివేయడానికి దిగువకు స్వైప్ చేయండి.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/>కు పంపుతోంది...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - దీనిని పంపిన పరికరం <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">ట్యాబ్‌ను అందుకున్నారు</translation>
 <translation id="9104217018994036254">ట్యాబ్‌ను షేర్ చేయాల్సిన పరికరాల జాబితా.</translation>
-<translation id="9133397713400217035">ఆఫ్‌లైన్‌లో అన్వేషించండి</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">అసలును చూపించు</translation>
-<translation id="9139068048179869749">ఏవైనా సైట్‌లు నోటిఫికేషన్‌లను పంపగలిగేలా వాటిని అనుమతించే ముందు, మిమ్మల్ని అడుగుతుంది (సిఫార్సు చేయబడింది)</translation>
-<translation id="9139318394846604261">షాపింగ్</translation>
-<translation id="9155898266292537608">ఒక పదంపై నొక్కడం ద్వారా కూడా మీరు త్వరగా వెతకవచ్చు</translation>
-<translation id="9169507124922466868">నావిగేషన్ చరిత్ర సగం తెరిచి ఉంది</translation>
-<translation id="9204836675896933765">1 ఫైల్ మిగిలి ఉంది</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">ట్యాబ్‌ను షేర్ చేయాల్సిన పరికరాల జాబితా సగం ఎత్తులో తెరవబడింది.</translation>
+<translation id="2904414404539560095">ట్యాబ్‌ను షేర్ చేయాల్సిన పరికరాల జాబితా పూర్తి ఎత్తులో తెరవబడింది.</translation>
+<translation id="4135200667068010335">ట్యాబ్‌ను షేర్ చేయాల్సిన పరికరాల జాబితా మూసివేయబడింది.</translation>
+<translation id="5292796745632149097">ఈ పరికరానికి పంపండి</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> రోజుల క్రితం యాక్టివ్‌గా ఉంది</translation>
+<translation id="7971136598759319605">1 రోజు క్రితం యాక్టివ్‌గా ఉంది</translation>
+<translation id="1521774566618522728">ఈ రోజు యాక్టివ్‌గా ఉంది</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/>తో షేర్ చేస్తోంది</translation>
+<translation id="9028914725102941583">పరికరాలలో షేర్ చేయడానికి, సింక్‌ను ఆన్ చేయండి</translation>
+<translation id="6162454065885854378">మీ ఫోన్ నుండి మరొక పరికరానికి దేనినైనా షేర్ చేయడానికి, రెండు పరికరాల్లోని Brave సెట్టింగ్‌లలో సింక్‌ను ఆన్ చేయండి</translation>
+<translation id="6084271560289605378">Brave సెట్టింగ్‌లకు వెళ్లు</translation>
+<translation id="2318045970523081853">కాల్ చేయడానికి నొక్కండి</translation>
 <translation id="9209888181064652401">కాల్‌లను చేయడం సాధ్యం కాదు</translation>
-<translation id="9219103736887031265">చిత్రాలు</translation>
-<translation id="926205370408745186">డిజిటల్ సంక్షేమం నుండి మీ Chrome కార్యకలాపాన్ని తీసివేస్తుంది</translation>
-<translation id="932327136139879170">హోమ్</translation>
-<translation id="938850635132480979">ఎర్రర్: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">మీ మైక్రోఫోన్ యాక్సెస్ అనుమతి</translation>
-<translation id="95817756606698420">చైనాలో వెతకడానికి <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />ను Chrome ఉపయోగించవచ్చు. మీరు దీనిని <ph name="BEGIN_LINK" />సెట్టింగ్‌ల<ph name="END_LINK" />లో మార్చవచ్చు.</translation>
-<translation id="965817943346481315">సైట్ అనుచితమైన లేదా తప్పుదారి పట్టించే ప్రకటనలను చూపించినప్పుడు బ్లాక్ చేయి (సిఫార్సు చేయబడింది)</translation>
-<translation id="968900484120156207">మీరు సందర్శించే పేజీలు ఇక్కడ కనిపిస్తాయి</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> నిమిషాలు మిగిలి ఉంది</translation>
-<translation id="974555521953189084">సింక్‌ను ప్రారంభించడానికి మీ రహస్య పదబంధాన్ని నమోదు చేయండి</translation>
-<translation id="981121421437150478">ఆఫ్‌లైన్</translation>
-<translation id="982182592107339124">ఇది వీటితో సహా అన్ని సైట్‌ల డేటాను తీసివేస్తుంది:</translation>
-<translation id="983192555821071799">అన్ని ట్యాబ్‌లను మూసివేయి</translation>
-<translation id="987264212798334818">సాధారణం</translation>
+<translation id="2860954141821109167">ఈ పరికరంలో ఫోన్ యాప్ ప్రారంభించబడిందని నిర్ధారించుకోండి</translation>
+<translation id="2067805253194386918">వచనం</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> షేర్ చేయడం సాధ్యపడలేదు</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/>ను షేర్ చేయడం సాధ్యపడలేదు</translation>
+<translation id="8287068819750208230">Braveలో <ph name="TARGET_DEVICE_NAME"/>కు సింక్ ఆన్ చేయబడి ఉందని నిర్ధారించుకోండి</translation>
+<translation id="3016635187733453316">ఈ పరికరం ఇంటర్నెట్‌కు కనెక్ట్ చేయబడి ఉందని నిర్ధారించుకోండి</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> ఇంటర్నెట్‌కు కనెక్ట్ చేయబడి ఉందని నిర్ధారించుకోండి</translation>
+<translation id="6539092367496845964">ఏదో తప్పు జరిగింది. తర్వాత మళ్లీ ప్రయత్నించండి.</translation>
+<translation id="3389286852084373014">వచనం చాలా పెద్దదిగా ఉంది</translation>
+<translation id="2100314319871056947">వచనాన్ని చిన్న భాగాలుగా చేసి షేర్ చేయడానికి ప్రయత్నించండి</translation>
+<translation id="2987620471460279764">ఇతర పరికరం నుండి షేర్ చేయబడిన వచనం</translation>
+<translation id="7757787379047923882"><ph name="DEVICE_NAME"/> నుండి షేర్ చేయబడిన వచనం</translation>
+<translation id="5193988420012215838">మీ క్లిప్‌బోర్డ్‌కు కోడ్ కాపీ చేయబడింది</translation>
+<translation id="4696983787092045100">వచనాన్ని మీ పరికరాలకు పంపండి</translation>
+<translation id="1260236875608242557">శోధన &amp; విశ్లేషణ</translation>
+<translation id="6369229450655021117">ఇక్కడ నుండి, మీరు వెబ్‌లో వెతకవచ్చు, స్నేహితులతో షేర్ చేసుకోవచ్చు, తెరిచి ఉన్న పేజీలను చూడవచ్చు</translation>
+<translation id="723171743924126238">చిత్రాలను ఎంచుకోండి</translation>
+<translation id="8751914237388039244">చిత్రాన్ని ఎంచుకోండి</translation>
+<translation id="1989112275319619282">బ్రౌజ్ చేయి</translation>
+<translation id="7055152154916055070">మళ్లింపు బ్లాక్ చేయబడింది:</translation>
+<translation id="5524843473235508879">మళ్లింపు బ్లాక్ చేయబడింది.</translation>
+<translation id="6573096386450695060">ఎల్లప్పుడూ అనుమతించు</translation>
+<translation id="5805364706385912897">ఈ పేజీ చాలా మెమరీని ఉపయోగిస్తోంది, కాబట్టి దీన్ని Brave పాజ్ చేయబడింది.</translation>
+<translation id="5138664332909611586">ఈ పేజీ చాలా మెమరీని ఉపయోగిస్తుంది, కాబట్టి Brave కొంత కంటెంట్‌ను తీసివేసింది.</translation>
+<translation id="9137013805542155359">అసలును చూపించు</translation>
+<translation id="6361779936989026201">Braveలో Brave Software అసిస్టెంట్</translation>
+<translation id="7291387454912369099">అసిస్టెంట్ ప్రేరేపిత చెక్‌అవుట్</translation>
+<translation id="4565206163201411670">డిజిటల్ సంక్షేమంలో మీ Brave కార్యకలాపాన్ని చూపించాలా?</translation>
+<translation id="9055113864158719823">Braveలో మీరు ఏయే సైట్‌లను సందర్శించారో చూడవచ్చు, వాటికి టైమర్‌లను సెట్ చేయవచ్చు.\n\nమీరు టైమర్‌లను సెట్ చేసిన సైట్‌ల సమాచారం, మీరు ఎంతసేపు వాటిని సందర్శించారనే వివరాలు Brave Softwareకు అందించబడతాయి. డిజిటల్ సంక్షేమాన్ని మరింత మెరుగుపరచడానికి ఈ సమాచారం ఉపయోగించబడుతుంది.</translation>
+<translation id="4596514158372210596">డిజిటల్ సంక్షేమం నుండి మీ Brave కార్యకలాపాన్ని తీసివేస్తుంది</translation>
+<translation id="1174893863889683998">డిజిటల్ సంక్షేమం నుండి మీ Brave కార్యకలాపం తీసివేయాలా?</translation>
+<translation id="708829030563435351">మీరు Braveలో సందర్శించిన సైట్‌లు చూపబడవు. అన్ని సైట్ టైమర్‌లు తొలగించబడతాయి.</translation>
+<translation id="2056878612599315956">సైట్ పాజ్ చేయబడింది</translation>
+<translation id="671481426037969117">మీ <ph name="FQDN"/> టైమర్ పూర్తయింది. అది మళ్లీ రేపు ప్రారంభమవుతుంది.</translation>
+<translation id="7479104141328977413">ట్యాబ్ నిర్వహణ</translation>
+<translation id="3524138585025253783">డెవలపర్ UI</translation>
+<translation id="6036057147555329831">అదనపు ICU</translation>
+<translation id="9029323097866369874">VRలోకి ప్రవేశించడానికి <ph name="DOMAIN"/>ను అనుమతించాలా?</translation>
+<translation id="7685301384041462804">VRలోకి ప్రవేశించడానికి ముందు మీరు ఈ సైట్‌ను విశ్వసిస్తున్నట్లు నిర్ధారించండి.</translation>
+<translation id="5033865233969348410">మీరు VRలో ఉన్నప్పుడు, ఈ సైట్ కింది వాటిని గురించి తెలుసుకునే అవకాశం ఉంది:
+  -  మీ శారీరక లక్షణాలు, బరువు వంటివి
+
+VRలోకి ప్రవేశించడానికి ముందు, ఈ సైట్‌ను విశ్వసిస్తున్నట్లు నిర్ధారించండి.</translation>
+<translation id="5534334044554683961">మీరు VRలో ఉన్నప్పుడు, ఈ సైట్ కింది వాటిని గురించి తెలుసుకునే అవకాశం ఉంది:
+  -    మీ శారీరక లక్షణాలు, బరువు వంటివి
+  -   మీ గది లేఅవుట్
+
+VRలోకి ప్రవేశించడానికి ముందు, ఈ సైట్‌ను విశ్వసిస్తున్నట్లు నిర్ధారించండి.</translation>
+<translation id="4169535189173047238">అనుమతించవద్దు</translation>
+<translation id="2170088579611075216">అనుమతించి, VRలోకి ప్రవేశించు</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_th.xtb
+++ b/android/java/strings/translations/android_chrome_strings_th.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="th">
-<translation id="1006017844123154345">เปิดแบบออนไลน์</translation>
-<translation id="1028699632127661925">กำลังส่งไปที่ <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">กำลังเพิ่ม <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">จากเว็บไซต์</translation>
-<translation id="1049743911850919806">โหมดไม่ระบุตัวตน</translation>
-<translation id="10614374240317010">ไม่เคยบันทึก</translation>
-<translation id="1067922213147265141">บริการอื่นๆ ของ Google</translation>
-<translation id="1068672505746868501">ไม่ต้องแปลหน้าเว็บภาษา<ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">หากคุณเปลี่ยนนามสกุลไฟล์ ไฟล์นั้นอาจเปิดในแอปพลิเคชันอื่นและเป็นอันตรายต่ออุปกรณ์ของคุณ</translation>
-<translation id="1100066534610197918">เปิดในแท็บใหม่ในกลุ่ม</translation>
-<translation id="1105960400813249514">จับภาพหน้าจอ</translation>
-<translation id="1111673857033749125">บุ๊กมาร์กที่บันทึกไว้ในอุปกรณ์เครื่องอื่นๆ ของคุณจะปรากฏที่นี่</translation>
-<translation id="1113597929977215864">แสดง "มุมมองอย่างง่าย"</translation>
-<translation id="1121094540300013208">รายงานการใช้งานและข้อขัดข้อง</translation>
-<translation id="1124772482545689468">ผู้ใช้</translation>
-<translation id="1129510026454351943">รายละเอียด: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{การดาวน์โหลดที่รอดำเนินการ 1 รายการ}other{การดาวน์โหลดที่รอดำเนินการ # รายการ}}</translation>
-<translation id="1145536944570833626">ลบข้อมูลที่มีอยู่</translation>
-<translation id="1146678959555564648">เข้าสู่ VR</translation>
-<translation id="116280672541001035">ใช้ไป</translation>
-<translation id="1171770572613082465">ดูเว็บไซต์ยอดนิยมโดยการแตะปุ่ม "เว็บไซต์อันดับสูงสุด"</translation>
-<translation id="1173894706177603556">เปลี่ยนชื่อ</translation>
-<translation id="1178581264944972037">หยุดชั่วคราว</translation>
-<translation id="1181037720776840403">นำออก</translation>
-<translation id="1188239144602654184">เริ่ม AR</translation>
-<translation id="1197267115302279827">ย้ายบุ๊กมาร์ก</translation>
-<translation id="119944043368869598">ล้างทั้งหมด</translation>
-<translation id="1201402288615127009">ถัดไป</translation>
-<translation id="1204037785786432551">ดาวน์โหลดลิงก์</translation>
-<translation id="1206892813135768548">คัดลอกข้อความลิงก์</translation>
-<translation id="1208340532756947324">เปิดการซิงค์เพื่อซิงค์และปรับเปลี่ยนข้อมูลตามความต้องการในอุปกรณ์ทุกเครื่อง</translation>
-<translation id="1209206284964581585">ซ่อนไปก่อน</translation>
-<translation id="1227058898775614466">ประวัติการนำทาง</translation>
-<translation id="1231733316453485619">เปิดการซิงค์ไหม</translation>
-<translation id="123724288017357924">โหลดหน้าปัจจุบันซ้ำ โดยไม่คำนึงถึงเนื้อหาที่แคชไว้</translation>
-<translation id="124116460088058876">ภาษาเพิ่มเติม</translation>
-<translation id="124678866338384709">ปิดแท็บปัจจุบัน</translation>
-<translation id="1258753120186372309">Google doodle: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">ค้นหาและสำรวจ</translation>
-<translation id="1264974993859112054">กีฬา</translation>
-<translation id="1266864766717917324">แชร์<ph name="CONTENT_TYPE" />ไม่ได้</translation>
-<translation id="1272079795634619415">หยุด</translation>
-<translation id="1283039547216852943">แตะเพื่อขยาย</translation>
-<translation id="1285320974508926690">ไม่ต้องแปลเว็บไซต์นี้</translation>
-<translation id="1291207594882862231">ล้างประวัติการเข้าชม คุกกี้ ข้อมูลเว็บไซต์ แคช…</translation>
-<translation id="129382876167171263">ไฟล์ที่เว็บไซต์บันทึกไว้จะปรากฏที่นี่</translation>
-<translation id="129553762522093515">เพิ่งปิด</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - ส่งจาก <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">จับกลุ่มแท็บ</translation>
-<translation id="1327257854815634930">ประวัติการนำทางเปิดอยู่</translation>
-<translation id="1331212799747679585">อัปเดต Chrome ไม่ได้ ตัวเลือกอื่นๆ</translation>
-<translation id="1332501820983677155">แป้นพิมพ์ลัดสำหรับฟีเจอร์ของ Google Chrome</translation>
-<translation id="1360432990279830238">ออกจากระบบและปิดการซิงค์ไหม</translation>
-<translation id="1369915414381695676">เพิ่มเว็บไซต์ <ph name="SITE_NAME" /> แล้ว</translation>
-<translation id="1373696734384179344">หน่วยความจำไม่เพียงพอที่จะดาวน์โหลดเนื้อหาที่เลือก</translation>
-<translation id="1376578503827013741">กำลังประมวลผล…</translation>
-<translation id="1383876407941801731">ค้นหา</translation>
-<translation id="1384959399684842514">หยุดดาวน์โหลดไว้ชั่วคราว</translation>
-<translation id="1386674309198842382">ใช้งานเมื่อ <ph name="LAST_UPDATED" /> วันที่ผ่านมา</translation>
-<translation id="1397811292916898096">ค้นหาด้วย <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">ฝังอยู่ใน <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“ไม่ติดตาม”</translation>
-<translation id="1407135791313364759">เปิดทั้งหมด</translation>
-<translation id="1409426117486808224">มุมมองอย่างง่ายสำหรับแท็บที่เปิดไว้</translation>
-<translation id="1409879593029778104">ระบบป้องกันการดาวน์โหลด <ph name="FILE_NAME" /> เพราะมีไฟล์นี้อยู่แล้ว</translation>
-<translation id="1414981605391750300">กำลังติดต่อ Google อาจใช้เวลาประมาณ 1 นาที…</translation>
-<translation id="1416550906796893042">เวอร์ชันของแอปพลิเคชัน</translation>
-<translation id="1430915738399379752">พิมพ์</translation>
-<translation id="1446450296470737166">ควบคุมอุปกรณ์ MIDI ได้สมบูรณ์</translation>
-<translation id="1450753235335490080">แชร์<ph name="CONTENT_TYPE" />ไม่สำเร็จ</translation>
-<translation id="145097072038377568">ปิดในการตั้งค่า Android</translation>
-<translation id="1477626028522505441">การดาวน์โหลด <ph name="FILE_NAME" /> ล้มเหลวเพราะเซิร์ฟเวอร์มีปัญหา</translation>
-<translation id="1506061864768559482">เครื่องมือค้นหา</translation>
-<translation id="1513352483775369820">บุ๊กมาร์กและประวัติเว็บ</translation>
-<translation id="1513858653616922153">ลบรหัสผ่าน</translation>
-<translation id="1516229014686355813">แตะเพื่อค้นหาจะส่งคำที่เลือกและหน้าปัจจุบันเป็นบริบทไปยัง Google Search คุณปิดฟีเจอร์นี้ในได้ใน<ph name="BEGIN_LINK" />การตั้งค่า<ph name="END_LINK" /></translation>
-<translation id="1521774566618522728">ใช้งานวันนี้</translation>
-<translation id="1544826120773021464">หากต้องการจัดการบัญชี Google ให้แตะปุ่ม "จัดการบัญชี"</translation>
-<translation id="1549000191223877751">ย้ายไปยังหน้าต่างอื่น</translation>
-<translation id="1553358976309200471">อัปเดต Chrome</translation>
-<translation id="1569387923882100876">อุปกรณ์ที่เชื่อมต่อ</translation>
-<translation id="1571304935088121812">คัดลอกชื่อผู้ใช้</translation>
-<translation id="1612196535745283361">Chrome ต้องมีสิทธิ์เข้าถึงตำแหน่งเพื่อสแกนหาอุปกรณ์ ตัวเลือกสิทธิ์เข้าถึงตำแหน่ง<ph name="BEGIN_LINK" />สำหรับอุปกรณ์เครื่องนี้ปิดอยู่<ph name="END_LINK" /></translation>
-<translation id="1620510694547887537">กล้องถ่ายรูป</translation>
-<translation id="1623104350909869708">ป้องกันหน้าเว็บนี้จากการสร้างการโต้ตอบเพิ่มเติม</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{นำ 1 รายการที่เลือกออก}other{นำ # รายการที่เลือกออก}}</translation>
-<translation id="164269334534774161">คุณกำลังดูสำเนาออฟไลน์ของหน้านี้จากวันที่ <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">ประวัติการเข้าชม</translation>
-<translation id="1647391597548383849">เข้าถึงกล้องถ่ายรูป</translation>
-<translation id="1660204651932907780">อนุญาตให้เว็บไซต์เล่นเสียง (แนะนำ)</translation>
-<translation id="1670399744444387456">พื้นฐาน</translation>
-<translation id="1671236975893690980">การดาวน์โหลดรอดำเนินการ…</translation>
-<translation id="1672586136351118594">ไม่ต้องแสดงอีก</translation>
-<translation id="1692118695553449118">การซิงค์เปิดอยู่</translation>
-<translation id="169515064810179024">บล็อกไม่ให้เว็บไซต์เข้าถึงเซ็นเซอร์ตรวจจับความเคลื่อนไหว</translation>
-<translation id="1717218214683051432">เซ็นเซอร์ตรวจจับความเคลื่อนไหว</translation>
-<translation id="1718835860248848330">ชั่วโมงที่แล้ว</translation>
-<translation id="1736419249208073774">สำรวจ</translation>
-<translation id="1743802530341753419">ถามก่อนอนุญาตให้เว็บไซต์เชื่อมต่อกับอุปกรณ์ (แนะนำ)</translation>
-<translation id="1749561566933687563">ซิงค์บุ๊กมาร์กของคุณ</translation>
-<translation id="17513872634828108">แท็บที่เปิดอยู่</translation>
-<translation id="1779089405699405702">ตัวถอดรหัสรูปภาพ</translation>
-<translation id="1782483593938241562">วันที่สิ้นสุด <ph name="DATE" /></translation>
-<translation id="1791662854739702043">ติดตั้งแล้ว</translation>
-<translation id="1792959175193046959">เปลี่ยนตำแหน่งเริ่มต้นในการดาวน์โหลดได้ทุกเมื่อ</translation>
-<translation id="1807246157184219062">สว่าง</translation>
-<translation id="1810845389119482123">ตั้งค่าการซิงค์เริ่มต้นไม่สำเร็จ</translation>
-<translation id="1821253160463689938">ใช้คุกกี้เพื่อให้จดจำค่ากำหนดของคุณ แม้ว่าคุณไม่ได้เข้าชมหน้าเว็บเหล่านั้น</translation>
-<translation id="1829244130665387512">ค้นหาในหน้าเว็บ</translation>
-<translation id="1853692000353488670">แท็บใหม่ที่ไม่ระบุตัวตน</translation>
-<translation id="1856325424225101786">รีเซ็ตโหมด Lite ไหม</translation>
-<translation id="1868024384445905608">ตอนนี้ Chrome ดาวน์โหลดไฟล์ได้เร็วขึ้นแล้ว</translation>
-<translation id="1883903952484604915">ไฟล์ของฉัน</translation>
-<translation id="1887786770086287077">ตอนนี้ตำแหน่งสำหรับอุปกรณ์เครื่องนี้ปิดอยู่ เปิดตำแหน่งได้ใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /></translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> จะเปิดขึ้นใน Chrome การดำเนินการต่อแสดงว่าคุณยอมรับ<ph name="BEGIN_LINK1" />ข้อกำหนดในการให้บริการ<ph name="END_LINK1" />และ<ph name="BEGIN_LINK2" />ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2" />ของ Chrome</translation>
-<translation id="1919345977826869612">โฆษณา</translation>
-<translation id="1919950603503897840">เลือกรายชื่อติดต่อ</translation>
-<translation id="1922076542920281912">หากต้องการให้ Chrome เข้าถึงตำแหน่งของคุณ ให้เปิดตำแหน่งใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /> ด้วย</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">อัปเดต</translation>
-<translation id="19288952978244135">เปิด Chrome อีกครั้ง</translation>
-<translation id="1933845786846280168">แท็บที่เลือก</translation>
-<translation id="194341124344773587">เปิดการใช้สิทธิ์สำหรับ Chrome ใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /></translation>
-<translation id="1943432128510653496">บันทึกรหัสผ่าน</translation>
-<translation id="1952172573699511566">เมื่อเป็นไปได้ เว็บไซต์จะแสดงในภาษาที่คุณต้องการ</translation>
-<translation id="1960290143419248813">Android เวอร์ชันนี้ไม่รองรับการอัปเดต Chrome อีกต่อไปแล้ว</translation>
-<translation id="1966710179511230534">โปรดอัปเดตรายละเอียดการลงชื่อเข้าใช้ของคุณ</translation>
-<translation id="1974060860693918893">ขั้นสูง</translation>
-<translation id="1984705450038014246">ซิงค์ข้อมูล Chrome</translation>
-<translation id="1984937141057606926">อนุญาต ยกเว้นบุคคลที่สาม</translation>
-<translation id="1986685561493779662">มีชื่อนี้อยู่แล้ว</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> ปุ่ม<ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">เล่นเน็ต</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> ต้องการจับคู่</translation>
-<translation id="1994173015038366702">URL ของเว็บไซต์</translation>
-<translation id="2000419248597011803">ส่งคุกกี้และการค้นหาบางรายการจากแถบที่อยู่และช่องค้นหาไปยังเครื่องมือค้นหาเริ่มต้น</translation>
-<translation id="2002537628803770967">ใช้ข้อมูลบัตรเครดิตและที่อยู่จาก Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ไฟล์}other{# ไฟล์}}</translation>
-<translation id="2017836877785168846">ล้างประวัติการเข้าชมและการเติมข้อความอัตโนมัติในแถบที่อยู่เว็บ</translation>
-<translation id="2021896219286479412">ส่วนควบคุมเว็บไซต์แบบเต็มหน้าจอ</translation>
-<translation id="2038563949887743358">เปิดการขอเว็บไซต์เดสก์ท็อป</translation>
-<translation id="2041019821020695769">หากต้องการให้ Chrome ส่งการแจ้งเตือนให้คุณ ให้เปิดการแจ้งเตือนใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /> ด้วย</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> มีข้อมูลอยู่ใน Chrome ด้วย</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">เว็บไซต์หยุดชั่วคราว</translation>
-<translation id="2063713494490388661">แตะเพื่อค้นหา</translation>
-<translation id="2067805253194386918">ข้อความ</translation>
-<translation id="2079545284768500474">เลิกทำ</translation>
-<translation id="2082238445998314030">ผลลัพธ์ <ph name="RESULT_NUMBER" /> จาก <ph name="TOTAL_RESULTS" /> รายการ</translation>
-<translation id="2091887806945687916">เสียง</translation>
-<translation id="2096012225669085171">ซิงค์และปรับแต่งในอุปกรณ์ทุกเครื่อง</translation>
-<translation id="2100273922101894616">ลงชื่อเข้าใช้อัตโนมัติ</translation>
-<translation id="2100314319871056947">ลองแชร์ข้อความโดยแบ่งเป็นส่วนเล็กๆ หลายส่วน</translation>
-<translation id="2107397443965016585">ถามก่อนอนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง (แนะนำ)</translation>
-<translation id="2111511281910874386">ไปที่หน้า</translation>
-<translation id="2122601567107267586">เปิดแอปไม่ได้</translation>
-<translation id="2126426811489709554">สนับสนุนโดย Chrome</translation>
-<translation id="2131665479022868825">ประหยัดไป <ph name="DATA" /></translation>
-<translation id="213279576345780926">ปิด <ph name="TAB_TITLE" /> แล้ว</translation>
-<translation id="2139186145475833000">เพิ่มลงในหน้าจอหลัก</translation>
-<translation id="2146738493024040262">เปิด Instant App</translation>
-<translation id="2148716181193084225">วันนี้</translation>
-<translation id="2154484045852737596">แก้ไขบัตร</translation>
-<translation id="2154710561487035718">คัดลอก URL</translation>
-<translation id="2156074688469523661">เว็บไซต์ที่เหลือ (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">หากต้องการแชร์รายการจากโทรศัพท์ไปยังอุปกรณ์อื่น ให้เปิดการซิงค์ในการตั้งค่า Chrome ในอุปกรณ์ทั้ง 2 เครื่อง</translation>
-<translation id="2170088579611075216">อนุญาตและเข้าสู่ประสบการณ์ VR</translation>
-<translation id="218608176142494674">การแชร์</translation>
-<translation id="2227444325776770048">ดำเนินการต่อในชื่อ <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">การซิงค์และบริการของ Google</translation>
-<translation id="2259659629660284697">ส่งออกรหัสผ่าน…</translation>
-<translation id="2268044343513325586">ปรับแต่ง</translation>
-<translation id="2286841657746966508">ที่อยู่สำหรับเรียกเก็บเงิน</translation>
-<translation id="2289270750774289114">ถามเมื่อเว็บไซต์ต้องการค้นหาอุปกรณ์บลูทูธใกล้เคียง (แนะนำ)</translation>
-<translation id="230115972905494466">ไม่พบอุปกรณ์ที่เข้ากันได้</translation>
-<translation id="2315043854645842844">ระบบปฏิบัติการไม่สนับสนุนการเลือกใบรับรองฝั่งลูกค้า</translation>
-<translation id="2318045970523081853">แตะเพื่อโทร</translation>
-<translation id="2321086116217818302">กำลังเตรียมรหัสผ่าน…</translation>
-<translation id="2321958826496381788">ลากแถบเลื่อนจนกว่าคุณจะสามารถอ่านได้อย่างสะดวก ข้อความควรมีขนาดเท่านี้เป็นอย่างน้อยหลังจากแตะ 2 ครั้งบนย่อหน้า</translation>
-<translation id="2323763861024343754">พื้นที่เก็บข้อมูลเว็บไซต์</translation>
-<translation id="2328985652426384049">ลงชื่อเข้าใช้ไม่ได้</translation>
-<translation id="2330129964253841015">เตือนคุณหากรหัสผ่านถูกบุกรุก</translation>
-<translation id="2349710944427398404">ข้อมูลทั้งหมดที่ Chrome ใช้ รวมถึงบัญชี บุ๊กมาร์ก และการตั้งค่าที่บันทึกไว้</translation>
-<translation id="2353636109065292463">ตรวจสอบการเชื่อมต่ออินเทอร์เน็ต</translation>
-<translation id="2359808026110333948">ต่อไป</translation>
-<translation id="2369533728426058518">แท็บที่เปิดอยู่</translation>
-<translation id="2387895666653383613">อัตราส่วนข้อความ</translation>
-<translation id="2394602618534698961">ไฟล์ที่คุณดาวน์โหลดจะแสดงที่นี่</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">ฟีเจอร์นี้จะเปิดเมื่อคุณลงชื่อเข้าใช้บัญชี Google</translation>
-<translation id="2410754283952462441">เลือกบัญชี</translation>
-<translation id="2414886740292270097">มืด</translation>
-<translation id="2416359993254398973">Chrome ต้องการสิทธิ์เข้าถึงกล้องถ่ายรูปของคุณสำหรับไซต์นี้</translation>
-<translation id="2426805022920575512">เลือกบัญชีอื่น</translation>
-<translation id="2433507940547922241">ลักษณะที่ปรากฏ</translation>
-<translation id="2434158240863470628">ดาวน์โหลดเสร็จสมบูรณ์ <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">การเข้าถึงตำแหน่ง</translation>
-<translation id="2450083983707403292">คุณต้องการเริ่มดาวน์โหลด <ph name="FILE_NAME" /> อีกครั้งไหม</translation>
-<translation id="2482878487686419369">การแจ้งเตือน</translation>
-<translation id="2490684707762498678">จัดการโดย <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Assistant ใน Chrome</translation>
-<translation id="2496180316473517155">ประวัติการเข้าชมที่เรียกดู</translation>
-<translation id="2497852260688568942">ผู้ดูแลระบบปิดใช้การซิงค์</translation>
-<translation id="2498359688066513246">ความช่วยเหลือและความคิดเห็น</translation>
-<translation id="2501278716633472235">ย้อนกลับ</translation>
-<translation id="2513403576141822879">ดูการตั้งค่าเพิ่มเติมเกี่ยวกับความเป็นส่วนตัว ความปลอดภัย และการรวบรวมข้อมูลได้ที่<ph name="BEGIN_LINK" />การซิงค์และบริการต่างๆ ของ Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">ในโหมด Lite เบราว์เซอร์ Chrome จะโหลดหน้าเว็บได้เร็วขึ้นและใช้อินเทอร์เน็ตน้อยลงสูงสุดถึง 60 เปอร์เซ็นต์ Chrome จะส่งการเข้าชมเว็บของคุณไปให้ Google เพื่อเพิ่มประสิทธิภาพหน้าเว็บที่คุณเข้าชม <ph name="BEGIN_LINK" />ดูข้อมูลเพิ่มเติม<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">ส่ง URL ของหน้าที่คุณเข้าชมไปยัง Google</translation>
-<translation id="2532336938189706096">มุมมองเว็บ</translation>
-<translation id="2534155362429831547">ลบแล้ว <ph name="NUMBER_OF_ITEMS" /> รายการ</translation>
-<translation id="2536728043171574184">ดูสำเนาแบบออฟไลน์ของหน้านี้</translation>
-<translation id="2546283357679194313">คุกกี้และข้อมูลเว็บไซต์</translation>
-<translation id="2567385386134582609">รูปภาพ</translation>
-<translation id="257088987046510401">ธีม</translation>
-<translation id="2570922361219980984">การเข้าถึงตำแหน่งสำหรับอุปกรณ์เครื่องนี้ปิดอยู่ เปิดการเข้าถึงได้ใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /></translation>
-<translation id="257931822824936280">ขยาย - คลิกเพื่อยุบ</translation>
-<translation id="2581165646603367611">การดำเนินการนี้จะล้างคุกกี้ แคช และข้อมูลอื่นๆ ของเว็บไซต์ที่ Chrome คิดว่าไม่สำคัญ</translation>
-<translation id="2586657967955657006">คลิปบอร์ด</translation>
-<translation id="2587052924345400782">มีเวอร์ชันใหม่กว่าให้ใช้งาน</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">หมายเลขบัตร</translation>
-<translation id="2621115761605608342">อนุญาต JavaScript สำหรับเว็บไซต์ใดเว็บไซต์หนึ่ง</translation>
-<translation id="2625189173221582860">คัดลอกรหัสผ่านแล้ว</translation>
-<translation id="2631006050119455616">ประหยัดได้</translation>
-<translation id="2647434099613338025">เพิ่มภาษา</translation>
-<translation id="2650751991977523696">ดาวน์โหลดไฟล์อีกครั้งไหม</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{ไฟล์เสียง # ไฟล์}other{ไฟล์เสียง # ไฟล์}}</translation>
-<translation id="2653659639078652383">ส่ง</translation>
-<translation id="2677748264148917807">ออก</translation>
-<translation id="2704606927547763573">คัดลอกแล้ว</translation>
-<translation id="2707726405694321444">รีเฟรชหน้า</translation>
-<translation id="2709516037105925701">ป้อนอัตโนมัติ</translation>
-<translation id="2717722538473713889">อีเมล</translation>
-<translation id="2728754400939377704">จัดเรียงตามเว็บไซต์</translation>
-<translation id="2744248271121720757">แตะคำเพื่อค้นหาทันทีหรือดูการทำงานที่เกี่ยวข้อง</translation>
-<translation id="2760989362628427051">เปิดธีมสีเข้มเมื่อโหมดธีมสีเข้มหรือโหมดประหยัดแบตเตอรี่ของอุปกรณ์เปิดอยู่</translation>
-<translation id="2762000892062317888">เมื่อสักครู่</translation>
-<translation id="2777555524387840389">เหลือ <ph name="SECONDS" /> วิ</translation>
-<translation id="2779651927720337254">ล้มเหลว</translation>
-<translation id="2781151931089541271">เหลือ 1 วิ</translation>
-<translation id="2801022321632964776">อัปเดตเพื่อใช้ภาษาของคุณใน Chrome เวอร์ชันล่าสุด</translation>
-<translation id="2810645512293415242">ลดรายละเอียดหน้าเว็บเพื่อประหยัดเน็ตมือถือและโหลดได้เร็วขึ้น</translation>
-<translation id="281504910091592009">ดูและจัดการรหัสผ่านที่บันทึกไว้ใน<ph name="BEGIN_LINK" />บัญชี Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อรับบุ๊กมาร์กในอุปกรณ์ทุกเครื่องของคุณ</translation>
-<translation id="2822354292072154809">แน่ใจไหมว่าต้องการรีเซ็ตสิทธิ์ทั้งหมดของเว็บไซต์สำหรับ <ph name="CHOSEN_OBJECT_NAME" /></translation>
-<translation id="2836148919159985482">แตะปุ่มกลับเพื่อออกจากโหมดเต็มหน้าจอ</translation>
-<translation id="2842985007712546952">โฟลเดอร์ระดับบนสุด</translation>
-<translation id="2858138569776157458">เว็บไซต์อันดับสูงสุด</translation>
-<translation id="2860954141821109167">ตรวจสอบว่ามีการเปิดใช้แอปโทรศัพท์ในอุปกรณ์นี้แล้ว</translation>
-<translation id="2870560284913253234">เว็บไซต์</translation>
-<translation id="2874939134665556319">แทร็กก่อนหน้า</translation>
-<translation id="2876369937070532032">ส่ง URL ของหน้าบางส่วนที่คุณเข้าชมไปให้ Google เมื่อการรักษาความปลอดภัยมีความเสี่ยง</translation>
-<translation id="2888126860611144412">เกี่ยวกับ Chrome</translation>
-<translation id="2891154217021530873">หยุดการโหลดหน้า</translation>
-<translation id="2893180576842394309">Google อาจใช้ประวัติการเข้าชมเพื่อปรับเปลี่ยน Search และบริการอื่นๆ ของ Google ให้เข้ากับคุณ</translation>
-<translation id="2898264748040935573">แก้ไขรหัสผ่านที่เก็บไว้</translation>
-<translation id="2900528713135656174">สร้างกิจกรรม</translation>
-<translation id="290376772003165898">หน้านี้ไม่ใช่ภาษา<ph name="LANGUAGE" />ใช่ไหม</translation>
-<translation id="2904414404539560095">รายการอุปกรณ์ที่จะแชร์แท็บด้วยเปิดอยู่ที่ระดับความสูงเต็มหน้าจอ</translation>
-<translation id="2910701580606108292">ถามก่อนอนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง</translation>
-<translation id="2913331724188855103">อนุญาตให้เว็บไซต์บันทึกและอ่านข้อมูลคุกกี้ (แนะนำ)</translation>
-<translation id="2923908459366352541">ชื่อไม่ถูกต้อง</translation>
-<translation id="2932150158123903946">พื้นที่เก็บข้อมูล Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">แท็บแสดงตัวอย่างปิดอยู่</translation>
-<translation id="2956410042958133412">บัญชีนี้ได้รับการจัดการโดย <ph name="PARENT_NAME_1" /> และ <ph name="PARENT_NAME_2" /></translation>
-<translation id="2962095958535813455">สลับเป็นแท็บไม่ระบุตัวตนแล้ว</translation>
-<translation id="2968755619301702150">เครื่องมือดูใบรับรอง</translation>
-<translation id="2979025552038692506">แท็บที่ไม่ระบุตัวตนที่เลือก</translation>
-<translation id="2987620471460279764">ข้อความแชร์มาจากอุปกรณ์อื่น</translation>
-<translation id="2989523299700148168">เข้าชมล่าสุด</translation>
-<translation id="2996291259634659425">สร้างรหัสผ่าน</translation>
-<translation id="2996809686854298943">ต้องระบุ URL</translation>
-<translation id="300526633675317032">การดำเนินการนี้จะล้างพื้นที่เก็บข้อมูลเว็บไซต์ทั้ง <ph name="SIZE_IN_KB" /></translation>
-<translation id="3016635187733453316">ตรวจสอบว่าอุปกรณ์นี้เชื่อมต่ออินเทอร์เน็ตอยู่</translation>
-<translation id="3029613699374795922">ดาวน์โหลดแล้ว <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">รหัสผ่านไม่ตรงกัน</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />ขอความช่วยเหลือ<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">ตอนนี้ตำแหน่งปิดอยู่ เปิดตำแหน่งได้ใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /></translation>
-<translation id="3058498974290601450">คุณเปิดการซิงค์ได้ทุกเมื่อในการตั้งค่า</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{บุ๊กมาร์ก <ph name="BOOKMARKS_COUNT_ONE" /> รายการ}other{บุ๊กมาร์ก <ph name="BOOKMARKS_COUNT_MANY" /> รายการ}}</translation>
-<translation id="3089395242580810162">เปิดในแท็บไม่ระบุตัวตน</translation>
-<translation id="3115898365077584848">แสดงข้อมูล</translation>
-<translation id="3123473560110926937">บล็อกในบางเว็บไซต์</translation>
-<translation id="3137521801621304719">ออกจากโหมดไม่ระบุตัวตน</translation>
-<translation id="3143515551205905069">ยกเลิกการซิงค์</translation>
-<translation id="3157842584138209013">ดูปริมาณอินเทอร์เน็ตที่คุณประหยัดไปได้จากปุ่มตัวเลือกเพิ่มเติม</translation>
-<translation id="3166827708714933426">แป้นพิมพ์ลัดสำหรับแท็บและหน้าต่าง</translation>
-<translation id="3181954750937456830">Google Safe Browsing (ปกป้องคุณและอุปกรณ์จากเว็บไซต์ที่เป็นอันตราย)</translation>
-<translation id="3190152372525844641">เปิดการใช้สิทธิ์สำหรับ Chrome ใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /></translation>
-<translation id="3198916472715691905">ข้อมูลที่จัดเก็บมี <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">เกือบเสร็จแล้ว!</translation>
-<translation id="3207960819495026254">บุ๊กมาร์กแล้ว</translation>
-<translation id="3211426585530211793">ลบ <ph name="ITEM_TITLE" /> แล้ว</translation>
-<translation id="321773570071367578">หากคุณลืมรหัสผ่านหรือต้องการเปลี่ยนการตั้งค่านี้ ให้<ph name="BEGIN_LINK" />รีเซ็ตการซิงค์<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">ไมโครโฟน</translation>
-<translation id="3232754137068452469">เว็บแอป</translation>
-<translation id="3236059992281584593">เหลือ 1 นาที</translation>
-<translation id="3244271242291266297">ดด</translation>
-<translation id="3254409185687681395">บุ๊กมาร์กหน้านี้</translation>
-<translation id="3259831549858767975">ย่อรายละเอียดทั้งหมดบนหน้า</translation>
-<translation id="3269093882174072735">โหลดภาพ</translation>
-<translation id="3269956123044984603">เปิด "ข้อมูลการซิงค์อัตโนมัติ" ในการตั้งค่าบัญชี Android เพื่อรับแท็บจากอุปกรณ์อื่นๆ ของคุณ</translation>
-<translation id="3277252321222022663">อนุญาตให้เว็บไซต์เข้าถึงเซ็นเซอร์ (แนะนำ)</translation>
-<translation id="3282568296779691940">ลงชื่อเข้าใช้ Chrome</translation>
-<translation id="3288003805934695103">โหลดหน้าใหม่</translation>
-<translation id="32895400574683172">อนุญาตให้แสดงการแจ้งเตือน</translation>
-<translation id="3295530008794733555">ท่องเว็บได้เร็วขึ้น ใช้เน็ตน้อยลง</translation>
-<translation id="3295602654194328831">ซ่อนข้อมูล</translation>
-<translation id="3298243779924642547">Lite</translation>
-<translation id="3303414029551471755">ต้องการดำเนินการดาวน์โหลดเนื้อหานี้ไหม</translation>
-<translation id="3306398118552023113">แอปนี้กำลังทำงานใน Chrome</translation>
-<translation id="3315103659806849044">ขณะนี้คุณกำลังปรับแต่งการตั้งค่าการซิงค์และบริการ Google แตะปุ่ม "ยืนยัน" ใกล้ด้านล่างของหน้าจอเพื่อเปิดการซิงค์ให้เสร็จสิ้น กลับ</translation>
-<translation id="3328801116991980348">ข้อมูลไซต์</translation>
-<translation id="3333961966071413176">รายชื่อติดต่อทั้งหมด</translation>
-<translation id="3334729583274622784">เปลี่ยนนามสกุลไฟล์ใช่ไหม</translation>
-<translation id="3341058695485821946">ดูปริมาณอินเทอร์เน็ตที่คุณประหยัดไปได้</translation>
-<translation id="3350687908700087792">ปิดแท็บไม่ระบุตัวตนทั้งหมด</translation>
-<translation id="3353615205017136254">หน้าเวอร์ชัน Lite ให้บริการโดย Google แตะปุ่มโหลดต้นฉบับเพื่อโหลดหน้าต้นฉบับ</translation>
-<translation id="3367813778245106622">ลงชื่อเข้าใช้อีกครั้งเพื่อเริ่มซิงค์</translation>
-<translation id="3374023511497244703">บุ๊กมาร์ก ประวัติการเข้าชม รหัสผ่าน และข้อมูลอื่นๆ ใน Chrome จะไม่ซิงค์กับบัญชี Google อีกต่อไป</translation>
-<translation id="3384347053049321195">แชร์รูปภาพ</translation>
-<translation id="3386292677130313581">ถามก่อนอนุญาตให้เว็บไซต์ทราบตำแหน่งของคุณ (แนะนำ)</translation>
-<translation id="3387650086002190359">การดาวน์โหลด <ph name="FILE_NAME" /> ล้มเหลวเพราะเกิดข้อผิดพลาดกับระบบไฟล์</translation>
-<translation id="3389286852084373014">ข้อความมีขนาดใหญ่เกินไป</translation>
-<translation id="3398320232533725830">เปิดตัวจัดการบุ๊กมาร์ก</translation>
-<translation id="3414952576877147120">ขนาด:</translation>
-<translation id="3443221991560634068">โหลดหน้าปัจจุบันอีกครั้ง</translation>
-<translation id="3445014427084483498">เมื่อสักครู่</translation>
-<translation id="3478363558367712427">คุณเลือกเครื่องมือค้นหาได้</translation>
+<translation id="6910211073230771657">ลบแล้ว</translation>
+<translation id="6965382102122355670">ตกลง</translation>
+<translation id="5301954838959518834">ตกลง เข้าใจแล้ว</translation>
+<translation id="7658239707568436148">ยกเลิก</translation>
 <translation id="3479552764303398839">ไม่ใช่ตอนนี้</translation>
-<translation id="3492207499832628349">แท็บใหม่ที่ไม่ระบุตัวตน</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />ดูข้อมูลเพิ่มเติม<ph name="END_LINK" />เกี่ยวกับเนื้อหาที่แนะนำ</translation>
-<translation id="3513704683820682405">Augmented Reality</translation>
-<translation id="3518985090088779359">ยอมรับและทำต่อ</translation>
-<translation id="3522247891732774234">มีการอัปเดตให้บริการ ตัวเลือกเพิ่มเติม</translation>
-<translation id="3524138585025253783">UI นักพัฒนาซอฟต์แวร์</translation>
-<translation id="3527085408025491307">โฟลเดอร์</translation>
-<translation id="3542235761944717775">ใช้ได้ <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">ค้นหาประวัติการเข้าชม</translation>
-<translation id="3557336313807607643">เพิ่มในรายชื่อติดต่อ</translation>
-<translation id="3566923219790363270">Chrome ยังคงเตรียมความพร้อมสำหรับ VR อยู่ รีสตาร์ท Chrome ภายหลัง</translation>
-<translation id="3568688522516854065">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อรับแท็บจากอุปกรณ์เครื่องอื่นๆ ของคุณ</translation>
-<translation id="3587482841069643663">ทั้งหมด</translation>
-<translation id="358794129225322306">อนุญาตให้เว็บไซต์ดาวน์โหลดไฟล์หลายไฟล์โดยอัตโนมัติ</translation>
-<translation id="3590487821116122040">พื้นที่เก็บข้อมูลเว็บไซต์ที่ Chrome คิดว่าไม่สำคัญ (เช่น เว็บไซต์ที่ไม่มีการตั้งค่าที่บันทึกไว้หรือที่คุณไม่ได้เข้าชมบ่อยครั้ง)</translation>
-<translation id="3599863153486145794">ล้างประวัติจากอุปกรณ์ที่ลงชื่อเข้าใช้ทั้งหมด บัญชี Google อาจมีประวัติการท่องเว็บรูปแบบอื่นๆ ที่ <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /></translation>
-<translation id="3600792891314830896">ปิดเสียงเว็บไซต์ที่เล่นเสียง</translation>
-<translation id="3616113530831147358">เสียง</translation>
-<translation id="3631987586758005671">กำลังแชร์กับ <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">เปิดเผยรหัสผ่าน</translation>
-<translation id="363596933471559332">ลงชื่อเข้าใช้เว็บไซต์โดยอัตโนมัติโดยใช้ข้อมูลเข้าสู่ระบบที่เก็บไว้ เมื่อฟีเจอร์นี้ปิดอยู่ ระบบจะขอให้คุณยืนยันทุกครั้งก่อนลงชื่อเข้าใช้เว็บไซต์</translation>
-<translation id="3658159451045945436">การรีเซ็ตจะลบประวัติการประหยัดเน็ต รวมถึงรายการเว็บไซต์ที่เข้าชม</translation>
-<translation id="3692944402865947621">ดาวน์โหลด <ph name="FILE_NAME" /> ไม่สำเร็จเนื่องจากเข้าถึงตำแหน่งที่เก็บข้อมูลไม่ได้</translation>
-<translation id="3714981814255182093">เปิดแถบค้นหา</translation>
-<translation id="3716182511346448902">หน้านี้ใช้หน่วยความจำมากเกินไป Chrome จึงหยุดหน้าชั่วคราว</translation>
-<translation id="3730075448226062617">หากต้องการให้ Chrome เข้าถึงไมโครโฟน ให้เปิดไมโครโฟนใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /> ด้วย</translation>
-<translation id="3739899004075612870">บุ๊กมาร์กไว้ใน <ph name="PRODUCT_NAME" /> แล้ว</translation>
-<translation id="3744111561329211289">ซิงค์ในแบ็กกราวด์</translation>
-<translation id="3771001275138982843">ดาวน์โหลดอัปเดตไม่ได้</translation>
-<translation id="3771033907050503522">แท็บที่ไม่ระบุตัวตน</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />เปิดบลูทูธ<ph name="END_LINK" />เพื่อให้จับคู่ได้</translation>
-<translation id="3775705724665058594">ส่งไปยังอุปกรณ์</translation>
-<translation id="3778956594442850293">เพิ่มในหน้าจอหลักแล้ว</translation>
-<translation id="3789841737615482174">ติดตั้ง</translation>
-<translation id="3810838688059735925">วิดีโอ</translation>
-<translation id="3810973564298564668">จัดการ</translation>
-<translation id="381841723434055211">หมายเลขโทรศัพท์</translation>
-<translation id="3819178904835489326">ลบการดาวน์โหลด <ph name="NUMBER_OF_DOWNLOADS" /> รายการแล้ว</translation>
-<translation id="3822502789641063741">ล้างพื้นที่เก็บข้อมูลเว็บไซต์ไหม</translation>
-<translation id="385051799172605136">กลับ</translation>
-<translation id="3859306556332390985">ไปข้างหน้า</translation>
-<translation id="3894427358181296146">เพิ่มโฟลเดอร์</translation>
-<translation id="3895926599014793903">บังคับให้เปิดใช้การซูม</translation>
-<translation id="3912508018559818924">กำลังหาข้อมูลที่ดีที่สุดจากเว็บ…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">รวมข้อมูลของฉัน</translation>
-<translation id="393697183122708255">ไม่มีการเปิดใช้การค้นหาด้วยเสียง</translation>
-<translation id="395206256282351086">ปิดใช้คำแนะนำการค้นหาและเว็บไซต์แล้ว</translation>
-<translation id="3955193568934677022">อนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง (แนะนำ)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome จะโหลดหน้าเว็บเมื่อพร้อม}other{Chrome จะโหลดหน้าเว็บเมื่อพร้อม}}</translation>
-<translation id="3963007978381181125">การเข้ารหัสลับด้วยรหัสผ่านจะไม่รวมข้อมูลวิธีการชำระเงินและที่อยู่จาก Google Pay เฉพาะผู้ที่มีรหัสผ่านของคุณเท่านั้นจึงจะอ่านข้อมูลที่เข้ารหัสได้ Google จะไม่ได้รับหรือจัดเก็บรหัสผ่านนี้ คุณจะต้องรีเซ็ตการซิงค์หากลืมรหัสผ่านหรือต้องการเปลี่ยนแปลงการตั้งค่านี้ <ph name="BEGIN_LINK" />ดูข้อมูลเพิ่มเติม<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">ดาวน์โหลดเสร็จสมบูรณ์</translation>
-<translation id="397583555483684758">การซิงค์หยุดทำงานแล้ว</translation>
-<translation id="3976396876660209797">นำทางลัดนี้ออกแล้วสร้างใหม่</translation>
-<translation id="3985215325736559418">คุณต้องการดาวน์โหลด <ph name="FILE_NAME" /> อีกครั้งไหม</translation>
-<translation id="3987993985790029246">คัดลอกลิงก์</translation>
-<translation id="3988213473815854515">อนุญาตตำแหน่ง</translation>
-<translation id="3988466920954086464">ดูผลการค้นหาทันใจในแผงนี้</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">พื้นที่เก็บข้อมูลที่ไม่สำคัญ</translation>
-<translation id="4000212216660919741">หน้าแรกออฟไลน์</translation>
+<translation id="5317780077021120954">บันทึก</translation>
+<translation id="4570913071927164677">รายละเอียด</translation>
+<translation id="8730621377337864115">เสร็จสิ้น</translation>
+<translation id="8261506727792406068">ลบ</translation>
+<translation id="1181037720776840403">นำออก</translation>
+<translation id="5939518447894949180">รีเซ็ต</translation>
 <translation id="4002066346123236978">ชื่อ</translation>
-<translation id="4008040567710660924">อนุญาตคุกกี้ของเว็บไซต์ที่เจาะจง</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# ชม.}other{# ชม.}}</translation>
-<translation id="4046123991198612571">แทร็กถัดไป</translation>
-<translation id="4048707525896921369">ดูข้อมูลเกี่ยวกับหัวข้อในเว็บไซต์โดยไม่ต้องออกจากหน้า แตะเพื่อค้นหาจะส่งคำและบริบทที่อยู่ข้างเคียงไปยัง Google Search เพื่อแสดงคำจำกัดความ รูปภาพ ผลการค้นหา และรายละเอียดอื่นๆ
+<translation id="5916664084637901428">เปิด</translation>
+<translation id="5860033963881614850">ปิด</translation>
+<translation id="6165508094623778733">ดูข้อมูลเพิ่มเติม</translation>
+<translation id="6042308850641462728">เพิ่มเติม</translation>
+<translation id="6040143037577758943">ปิด</translation>
+<translation id="780301667611848630">ไม่ ขอบคุณ</translation>
+<translation id="1201402288615127009">ถัดไป</translation>
+<translation id="2359808026110333948">ต่อไป</translation>
+<translation id="2653659639078652383">ส่ง</translation>
+<translation id="2079545284768500474">เลิกทำ</translation>
+<translation id="7649070708921625228">ช่วยเหลือ</translation>
+<translation id="2148716181193084225">วันนี้</translation>
+<translation id="7781829728241885113">เมื่อวานนี้</translation>
+<translation id="6945221475159498467">เลือก</translation>
+<translation id="7791543448312431591">เพิ่ม</translation>
+<translation id="6527303717912515753">แชร์</translation>
+<translation id="1383876407941801731">ค้นหา</translation>
+<translation id="3115898365077584848">แสดงข้อมูล</translation>
+<translation id="3295602654194328831">ซ่อนข้อมูล</translation>
+<translation id="3987993985790029246">คัดลอกลิงก์</translation>
+<translation id="2704606927547763573">คัดลอกแล้ว</translation>
+<translation id="8725066075913043281">ลองอีกครั้ง</translation>
+<translation id="385051799172605136">กลับ</translation>
+<translation id="8131740175452115882">ยืนยัน</translation>
+<translation id="5300589172476337783">แสดง</translation>
+<translation id="1124772482545689468">ผู้ใช้</translation>
+<translation id="8609465669617005112">เลื่อนขึ้น</translation>
+<translation id="6746124502594467657">เลื่อนลง</translation>
+<translation id="8249310407154411074">เลื่อนไปบนสุด</translation>
+<translation id="8428213095426709021">การตั้งค่า</translation>
+<translation id="2498359688066513246">ความช่วยเหลือและความคิดเห็น</translation>
+<translation id="8378714024927312812">จัดการโดยองค์กร</translation>
+<translation id="9019902583201351841">มีการจัดการโดยผู้ปกครอง</translation>
+<translation id="4645575059429386691">มีการจัดการโดยผู้ปกครอง</translation>
+<translation id="4883854917563148705">รีเซ็ตการตั้งค่าที่มีการจัดการไม่ได้</translation>
+<translation id="4307992518367153382">พื้นฐาน</translation>
+<translation id="1974060860693918893">ขั้นสูง</translation>
+<translation id="1146678959555564648">เข้าสู่ VR</translation>
+<translation id="987264212798334818">ทั่วไป</translation>
+<translation id="4275663329226226506">สื่อ</translation>
+<translation id="4759238208242260848">ดาวน์โหลด</translation>
+<translation id="218608176142494674">การแชร์</translation>
+<translation id="8004582292198964060">เบราว์เซอร์</translation>
+<translation id="1105960400813249514">จับภาพหน้าจอ</translation>
+<translation id="4875775213178255010">การแนะนำเนื้อหา</translation>
+<translation id="2021896219286479412">ส่วนควบคุมเว็บไซต์แบบเต็มหน้าจอ</translation>
+<translation id="4587589328781138893">เว็บไซต์</translation>
+<translation id="4943703118917034429">Virtual Reality</translation>
+<translation id="1928696683969751773">อัปเดต</translation>
+<translation id="6064125863973209585">การดาวน์โหลดที่เสร็จสมบูรณ์แล้ว</translation>
+<translation id="5342314432463739672">คำขอสิทธิ์</translation>
+<translation id="629730747756840877">บัญชี</translation>
+<translation id="82609232232243542">ลงชื่อเข้าใช้ Brave</translation>
+<translation id="7956662517480676674">การซิงค์และบริการของ Brave Software</translation>
+<translation id="5294439808117722387">ขณะนี้คุณกำลังปรับแต่งการตั้งค่าการซิงค์และบริการ Brave Software แตะปุ่ม "ยืนยัน" ใกล้ด้านล่างของหน้าจอเพื่อเปิดการซิงค์ให้เสร็จสิ้น กลับ</translation>
+<translation id="2096012225669085171">ซิงค์และปรับแต่งในอุปกรณ์ทุกเครื่อง</translation>
+<translation id="1692118695553449118">การซิงค์เปิดอยู่</translation>
+<translation id="5514904542973294328">ปิดใช้โดยผู้ดูแลระบบของอุปกรณ์นี้</translation>
+<translation id="6447211988989208781">ส่วนควบคุมกิจกรรมของ Brave Software</translation>
+<translation id="4882831918239250449">ควบคุมการใช้ประวัติการท่องเว็บเพื่อปรับเปลี่ยน Search, โฆษณา และบริการอื่นๆ ในแบบของคุณ</translation>
+<translation id="7431991332293347422">ควบคุมการใช้ประวัติการท่องเว็บเพื่อปรับเปลี่ยน Search และบริการอื่นๆ ในแบบของคุณ</translation>
+<translation id="6303969859164067831">ออกจากระบบและปิดการซิงค์</translation>
+<translation id="1125261911132334651">จัดการบัญชี Brave Software</translation>
+<translation id="6406506848690869874">การซิงค์ข้อมูล</translation>
+<translation id="714362445477979774">ซิงค์ข้อมูล Brave</translation>
+<translation id="4314815835985389558">จัดการการซิงค์</translation>
+<translation id="5428209950370661546">บริการอื่นๆ ของ Brave Software</translation>
+<translation id="7704317875155739195">เติมข้อความค้นหาและ URL อัตโนมัติ</translation>
+<translation id="2000419248597011803">ส่งคุกกี้และการค้นหาบางรายการจากแถบที่อยู่และช่องค้นหาไปยังเครื่องมือค้นหาเริ่มต้น</translation>
+<translation id="7981313251711023384">โหลดหน้าเว็บล่วงหน้าเพื่อให้เรียกดูและค้นหาได้เร็วขึ้น</translation>
+<translation id="1821253160463689938">ใช้คุกกี้เพื่อให้จดจำค่ากำหนดของคุณ แม้ว่าคุณไม่ได้เข้าชมหน้าเว็บเหล่านั้น</translation>
+<translation id="6697492270171225480">แสดงคำแนะนำหน้าที่คล้ายกันเมื่อไม่พบหน้าเว็บ</translation>
+<translation id="8109318360573330108">ส่ง URL ของหน้าที่คุณพยายามเข้าถึงไปยัง Brave Software</translation>
+<translation id="8438566539970814960">ปรับปรุงการค้นหาและการท่องเว็บให้ดียิ่งขึ้น</translation>
+<translation id="284843628681142937">ส่ง URL ของหน้าที่คุณเข้าชมไปยัง Brave Software</translation>
+<translation id="7222718784508482526">ดูการตั้งค่าเพิ่มเติมเกี่ยวกับความเป็นส่วนตัว ความปลอดภัย และการรวบรวมข้อมูลได้ที่<ph name="BEGIN_LINK"/>การซิงค์และบริการต่างๆ ของ Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">ช่วยปรับปรุงฟีเจอร์และประสิทธิภาพของ Brave</translation>
+<translation id="9063160602596686558">ส่งสถิติการใช้งานและรายงานข้อขัดข้องให้กับ Brave Software โดยอัตโนมัติ</translation>
+<translation id="4824958205181053313">ยกเลิกการซิงค์ใช่ไหม</translation>
+<translation id="3058498974290601450">คุณเปิดการซิงค์ได้ทุกเมื่อในการตั้งค่า</translation>
+<translation id="3143515551205905069">ยกเลิกการซิงค์</translation>
+<translation id="1506061864768559482">เครื่องมือค้นหา</translation>
+<translation id="55737423895878184">อนุญาตให้ใช้ตำแหน่งและแสดงการแจ้งเตือน</translation>
+<translation id="3988213473815854515">อนุญาตตำแหน่ง</translation>
+<translation id="32895400574683172">อนุญาตให้แสดงการแจ้งเตือน</translation>
+<translation id="9040142327097499898">อนุญาตให้แสดงการแจ้งเตือน ตำแหน่งสำหรับอุปกรณ์เครื่องนี้ปิดอยู่</translation>
+<translation id="305593374596241526">ตอนนี้ตำแหน่งปิดอยู่ เปิดตำแหน่งได้ใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/></translation>
+<translation id="2989523299700148168">เข้าชมล่าสุด</translation>
+<translation id="6433501201775827830">เลือกเครื่องมือค้นหา</translation>
+<translation id="7177466738963138057">คุณสามารถเปลี่ยนค่านี้ภายหลังใน "การตั้งค่า"</translation>
+<translation id="3478363558367712427">คุณเลือกเครื่องมือค้นหาได้</translation>
+<translation id="4910889077668685004">แอปชำระเงิน</translation>
+<translation id="5152843274749979095">ไม่มีแอปที่รองรับติดตั้งอยู่</translation>
+<translation id="8812260976093120287">ในบางเว็บไซต์ คุณสามารถชำระเงินด้วยแอปชำระเงินที่รองรับด้านบนในอุปกรณ์ของคุณ</translation>
+<translation id="7764225426217299476">เพิ่มที่อยู่</translation>
+<translation id="5595485650161345191">แก้ไขที่อยู่</translation>
+<translation id="5087580092889165836">เพิ่มบัตร</translation>
+<translation id="2154484045852737596">แก้ไขบัตร</translation>
+<translation id="6140912465461743537">ประเทศ/ภูมิภาค</translation>
+<translation id="5659593005791499971">อีเมล</translation>
+<translation id="4378154925671717803">โทรศัพท์</translation>
+<translation id="4807098396393229769">ชื่อบนบัตร</translation>
+<translation id="860043288473659153">ชื่อผู้ถือบัตร</translation>
+<translation id="2612676031748830579">หมายเลขบัตร</translation>
+<translation id="869891660844655955">วันหมดอายุ</translation>
+<translation id="2286841657746966508">ที่อยู่สำหรับเรียกเก็บเงิน</translation>
+<translation id="663059986967017181">คัดลอกไปยัง Brave แล้ว</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> วิธี}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> วิธี}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> แห่ง}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> แห่ง}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ตัวเลือก}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> ตัวเลือก}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> รายการ}other{<ph name="CONTACT_PREVIEW"/>\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> รายการ}}</translation>
+<translation id="7029809446516969842">รหัสผ่าน</translation>
+<translation id="1943432128510653496">บันทึกรหัสผ่าน</translation>
+<translation id="2100273922101894616">ลงชื่อเข้าใช้อัตโนมัติ</translation>
+<translation id="363596933471559332">ลงชื่อเข้าใช้เว็บไซต์โดยอัตโนมัติโดยใช้ข้อมูลเข้าสู่ระบบที่เก็บไว้ เมื่อฟีเจอร์นี้ปิดอยู่ ระบบจะขอให้คุณยืนยันทุกครั้งก่อนลงชื่อเข้าใช้เว็บไซต์</translation>
+<translation id="6995899638241819463">เตือนคุณในกรณีที่รหัสผ่านรั่วไหลจากการละเมิดข้อมูล</translation>
+<translation id="1534287762301776620">ฟีเจอร์นี้จะเปิดเมื่อคุณลงชื่อเข้าใช้บัญชี Brave Software</translation>
+<translation id="10614374240317010">ไม่เคยบันทึก</translation>
+<translation id="3098842761938485917">ดูและจัดการรหัสผ่านที่บันทึกไว้ใน<ph name="BEGIN_LINK"/>บัญชี Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">รหัสผ่านที่บันทึกไว้จะแสดงที่นี่</translation>
+<translation id="8084114998886531721">รหัสผ่านที่บันทึกไว้</translation>
+<translation id="2870560284913253234">เว็บไซต์</translation>
+<translation id="8503813439785031346">ชื่อผู้ใช้</translation>
+<translation id="6657585470893396449">รหัสผ่าน</translation>
+<translation id="2154710561487035718">คัดลอก URL</translation>
+<translation id="1571304935088121812">คัดลอกชื่อผู้ใช้</translation>
+<translation id="5005498671520578047">คัดลอกรหัสผ่าน</translation>
+<translation id="3632295766818638029">เปิดเผยรหัสผ่าน</translation>
+<translation id="1513858653616922153">ลบรหัสผ่าน</translation>
+<translation id="543338862236136125">แก้ไขรหัสผ่าน</translation>
+<translation id="4565377596337484307">ซ่อนรหัสผ่าน</translation>
+<translation id="8523928698583292556">ลบรหัสผ่านที่เก็บไว้</translation>
+<translation id="2898264748040935573">แก้ไขรหัสผ่านที่เก็บไว้</translation>
+<translation id="5433691172869980887">คัดลอกชื่อผู้ใช้แล้ว</translation>
+<translation id="5534640966246046842">คัดลอกไซต์แล้ว</translation>
+<translation id="2625189173221582860">คัดลอกรหัสผ่านแล้ว</translation>
+<translation id="4550003330909367850">หากต้องการดูหรือคัดลอกรหัสผ่านที่นี่ ให้ตั้งค่าการล็อกหน้าจอในอุปกรณ์นี้</translation>
+<translation id="6154478581116148741">เปิดล็อกหน้าจอใน "การตั้งค่า" เพื่อส่งออกรหัสผ่านจากอุปกรณ์นี้</translation>
+<translation id="4842092870884894799">กำลังแสดงป๊อปอัปการสร้างรหัสผ่าน</translation>
+<translation id="2259659629660284697">ส่งออกรหัสผ่าน…</translation>
+<translation id="133012818630824069">ส่งออกรหัสผ่านที่เก็บไว้ใน Brave</translation>
+<translation id="6914783257214138813">คนที่ดูไฟล์ที่ส่งออกได้จะเห็นรหัสผ่านของคุณ</translation>
+<translation id="2321086116217818302">กำลังเตรียมรหัสผ่าน…</translation>
+<translation id="8445448999790540984">ส่งออกรหัสผ่านไม่ได้</translation>
+<translation id="3066461326500799725">ดูวิธีใช้ Brave Software ไดรฟ์</translation>
+<translation id="729975465115245577">อุปกรณ์ของคุณไม่มีแอปไว้จัดเก็บไฟล์รหัสผ่าน</translation>
+<translation id="7682724950699840886">ลองทำตามเคล็ดลับต่อไปนี้ ตรวจสอบว่าอุปกรณ์มีพื้นที่ว่างเพียงพอ จากนั้นพยายามส่งออกอีกครั้ง</translation>
+<translation id="1129510026454351943">รายละเอียด: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">ปลดล็อกเพื่อคัดลอกรหัสผ่าน</translation>
+<translation id="5515439363601853141">ปลดล็อกเพื่อดูรหัสผ่าน</translation>
+<translation id="6221633008163990886">ปลดล็อกเพื่อส่งออกรหัสผ่าน</translation>
+<translation id="230699814587342492">รหัสผ่าน Brave</translation>
+<translation id="6075798973483050474">แก้ไขหน้าแรก</translation>
+<translation id="854522910157234410">เปิดหน้านี้</translation>
+<translation id="2482878487686419369">การแจ้งเตือน</translation>
+<translation id="6255999984061454636">การแนะนำเนื้อหา</translation>
+<translation id="805047784848435650">อิงจากประวัติการท่องเว็บของคุณ</translation>
+<translation id="1041308826830691739">จากเว็บไซต์</translation>
+<translation id="395206256282351086">ปิดใช้คำแนะนำการค้นหาและเว็บไซต์แล้ว</translation>
+<translation id="257088987046510401">ธีม</translation>
+<translation id="4650364565596261010">ค่าเริ่มต้นของระบบ</translation>
+<translation id="7588219262685291874">เปิดธีมสีเข้มเมื่อโหมดประหยัดแบตเตอรี่ของอุปกรณ์เปิดอยู่</translation>
+<translation id="2760989362628427051">เปิดธีมสีเข้มเมื่อโหมดธีมสีเข้มหรือโหมดประหยัดแบตเตอรี่ของอุปกรณ์เปิดอยู่</translation>
+<translation id="6381421346744604172">ปรับเว็บไซต์ให้เป็นสีเข้ม</translation>
+<translation id="5040262127954254034">ความเป็นส่วนตัว</translation>
+<translation id="4991384657077828949">ช่วยปรับปรุงความปลอดภัยของ Brave</translation>
+<translation id="1943176487615318915">ในการตรวจหาแอปและเว็บไซต์ที่เป็นอันตราย Brave จะส่ง URL ของหน้าบางหน้าที่คุณเข้าชม ข้อมูลระบบที่จำกัด และเนื้อหาบางส่วนของหน้าไปให้ Brave Software</translation>
+<translation id="3181954750937456830">Brave Software Safe Browsing (ปกป้องคุณและอุปกรณ์จากเว็บไซต์ที่เป็นอันตราย)</translation>
+<translation id="7315322926489145388">ส่ง URL ของหน้าบางส่วนที่คุณเข้าชมไปให้ Brave Software เมื่อการรักษาความปลอดภัยมีความเสี่ยง</translation>
+<translation id="2063713494490388661">แตะเพื่อค้นหา</translation>
+<translation id="2369463299479365221">ดูข้อมูลเกี่ยวกับหัวข้อในเว็บไซต์โดยไม่ต้องออกจากหน้า แตะเพื่อค้นหาจะส่งคำและบริบทที่อยู่ข้างเคียงไปยัง Brave Software Search เพื่อแสดงคำจำกัดความ รูปภาพ ผลการค้นหา และรายละเอียดอื่นๆ
 
 หากต้องการปรับเปลี่ยนข้อความค้นหา ให้กดค้างไว้เพื่อเลือก หากต้องการปรับแต่งการค้นหา ให้เลื่อนแผงควบคุมขึ้นจนสุดแล้วแตะช่องค้นหา</translation>
-<translation id="4056223980640387499">ซีเปีย</translation>
-<translation id="4060598801229743805">ตัวเลือกอยู่ตรงบริเวณด้านบนของหน้าจอ</translation>
-<translation id="4062305924942672200">ข้อมูลทางกฎหมาย</translation>
-<translation id="4084682180776658562">บุ๊กมาร์ก</translation>
-<translation id="4084712963632273211">จาก <ph name="PUBLISHER_ORIGIN" /> - <ph name="BEGIN_DEEMPHASIZED" />แสดงโดย Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">ลบข้อมูลแอปไหม</translation>
-<translation id="4099578267706723511">ช่วยให้ Chrome ทำงานได้ดีขึ้นโดยส่งสถิติการใช้งานและรายงานข้อขัดข้องให้กับ Google</translation>
-<translation id="410351446219883937">เล่นอัตโนมัติ</translation>
-<translation id="4116038641877404294">ดาวน์โหลดหน้าเพื่อใช้งานแบบออฟไลน์</translation>
-<translation id="4135200667068010335">รายการอุปกรณ์ที่จะแชร์แท็บด้วยปิดอยู่</translation>
-<translation id="4149994727733219643">มุมมองอย่างง่ายสำหรับหน้าเว็บ</translation>
-<translation id="4165986682804962316">การตั้งค่าเว็บไซต์</translation>
-<translation id="4169535189173047238">ไม่อนุญาต</translation>
-<translation id="4170011742729630528">บริการนี้ยังไม่สามารถใช้ได้ โปรดลองอีกครั้งในภายหลัง</translation>
-<translation id="4179980317383591987">ใช้ไปแล้ว <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">ภาษา</translation>
-<translation id="4183868528246477015">ค้นหาด้วย Google Lens <ph name="BEGIN_NEW" />ใหม่<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">เปิดในแท็บใหม่</translation>
-<translation id="4198423547019359126">ไม่มีตำแหน่งการดาวน์โหลดที่ใช้ได้</translation>
-<translation id="4209895695669353772">เปิดการซิงค์เพื่อรับคำแนะนำเนื้อหาที่ปรับเปลี่ยนในแบบของคุณจาก Google</translation>
-<translation id="4226663524361240545">การแจ้งเตือนอาจทำให้อุปกรณ์สั่น</translation>
-<translation id="423219824432660969">เข้ารหัสลับข้อมูลที่ซิงค์ด้วยรหัสผ่าน Google ตั้งแต่ <ph name="TIME" /></translation>
-<translation id="4242533952199664413">เปิดการตั้งค่า</translation>
-<translation id="4256782883801055595">ใบอนุญาตโอเพนซอร์ส</translation>
-<translation id="4259722352634471385">มีการบล็อกการนำทาง: <ph name="URL" /></translation>
-<translation id="4269820728363426813">คัดลอกที่อยู่ลิงก์</translation>
-<translation id="4275663329226226506">สื่อ</translation>
-<translation id="4278390842282768270">อนุญาตแล้ว</translation>
-<translation id="429312253194641664">เว็บไซต์กำลังเล่นสื่อ</translation>
-<translation id="4298388696830689168">เว็บไซต์ที่ลิงก์</translation>
-<translation id="4307992518367153382">พื้นฐาน</translation>
-<translation id="4314815835985389558">จัดการการซิงค์</translation>
-<translation id="4351244548802238354">ปิดหน้าต่างโต้ตอบ</translation>
-<translation id="4378154925671717803">โทรศัพท์</translation>
-<translation id="4384468725000734951">กำลังใช้ Sogou ในการค้นหา</translation>
-<translation id="4404568932422911380">ไม่มีบุ๊กมาร์ก</translation>
-<translation id="4405224443901389797">ย้ายไปที่…</translation>
-<translation id="4411535500181276704">โหมด Lite</translation>
-<translation id="4415276339145661267">จัดการบัญชี Google</translation>
-<translation id="4432792777822557199">จากนี้ไประบบจะแปลหน้าภาษา<ph name="SOURCE_LANGUAGE" />เป็นภาษา<ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">หน้าเวอร์ชัน Lite ให้บริการโดย Google</translation>
-<translation id="4434045419905280838">ป๊อปอัปและการเปลี่ยนเส้นทาง</translation>
-<translation id="4440958355523780886">หน้าเวอร์ชัน Lite จัดเตรียมโดย Google แตะเพื่อโหลดต้นฉบับ</translation>
-<translation id="4452411734226507615">ปิดแท็บ <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">เพิ่มบุ๊กมาร์กไปยัง <ph name="FOLDER_NAME" /> แล้ว</translation>
-<translation id="445467742685312942">อนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง</translation>
-<translation id="4468959413250150279">ปิดเสียงไซต์ที่ต้องการ</translation>
-<translation id="4472118726404937099">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อซิงค์และปรับเปลี่ยนข้อมูลตามความต้องการในอุปกรณ์ทุกเครื่อง</translation>
-<translation id="447252321002412580">ช่วยปรับปรุงฟีเจอร์และประสิทธิภาพของ Chrome</translation>
-<translation id="4479647676395637221">ถามก่อน ก่อนที่จะอนุญาตให้เว็บไซต์ใช้กล้องถ่ายรูปของคุณ (แนะนำ)</translation>
-<translation id="4479972344484327217">กำลังติดตั้ง <ph name="MODULE" /> สำหรับ Chrome…</translation>
-<translation id="4487967297491345095">ระบบจะลบข้อมูลแอปทั้งหมดของ Chrome อย่างถาวร ซึ่งรวมถึงไฟล์ทั้งหมด การตั้งค่า บัญชี ฐานข้อมูล และอื่นๆ</translation>
-<translation id="4493497663118223949">โหมด Lite เปิดอยู่</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# วันที่ผ่านมา}other{# วันที่ผ่านมา}}</translation>
-<translation id="451872707440238414">ค้นหาบุ๊กมาร์ก</translation>
-<translation id="4521489764227272523">ระบบได้นำข้อมูลที่เลือกออกจาก Chrome และอุปกรณ์ที่ซิงค์แล้ว
-
-บัญชี Google ของคุณอาจมีประวัติการท่องเว็บในรูปแบบอื่นๆ เช่น การค้นหาและกิจกรรมจากบริการอื่นๆ ของ Google ที่ <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /></translation>
-<translation id="4532845899244822526">เลือกโฟลเดอร์</translation>
-<translation id="4538018662093857852">เปิดโหมด Lite</translation>
-<translation id="4550003330909367850">หากต้องการดูหรือคัดลอกรหัสผ่านที่นี่ ให้ตั้งค่าการล็อกหน้าจอในอุปกรณ์นี้</translation>
-<translation id="4558311620361989323">แป้นพิมพ์ลัดสำหรับหน้าเว็บ</translation>
-<translation id="4561979708150884304">ไม่มีการเชื่อมต่อ</translation>
-<translation id="4565377596337484307">ซ่อนรหัสผ่าน</translation>
-<translation id="4570913071927164677">รายละเอียด</translation>
-<translation id="4572422548854449519">ลงชื่อเข้าใช้บัญชีที่มีการจัดการ</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# นาทีที่ผ่านมา}other{# นาทีที่ผ่านมา}}</translation>
-<translation id="4587589328781138893">เว็บไซต์</translation>
-<translation id="4594952190837476234">หน้าเว็บออฟไลน์นี้สร้างเมื่อวันที่ <ph name="CREATION_TIME" /> และอาจแตกต่างไปจากเวอร์ชันออนไลน์</translation>
-<translation id="4605958867780575332">รายการที่นำออก: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">เปิด <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">ใช้รหัสผ่าน</translation>
-<translation id="4645575059429386691">มีการจัดการโดยผู้ปกครอง</translation>
-<translation id="4650364565596261010">ค่าเริ่มต้นของระบบ</translation>
-<translation id="4663756553811254707">ลบบุ๊กมาร์ก <ph name="NUMBER_OF_BOOKMARKS" /> รายการแล้ว</translation>
-<translation id="4665282149850138822">เพิ่ม <ph name="NAME" /> ลงในหน้าแรกแล้ว</translation>
-<translation id="4684427112815847243">ซิงค์ทุกอย่าง</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ตัวเลือก}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> ตัวเลือก}}</translation>
-<translation id="4696983787092045100">ส่งข้อความไปยังอุปกรณ์ของคุณ</translation>
-<translation id="4698034686595694889">ดูแบบออฟไลน์ใน <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">รูปภาพและไฟล์ในแคช</translation>
-<translation id="4714588616299687897">ประหยัดการใช้ข้อมูลถึง 60%</translation>
-<translation id="4719927025381752090">เสนอการแปล</translation>
-<translation id="4720023427747327413">เปิดใน <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">ช่วยปรับปรุง Chrome ด้วยการ<ph name="BEGIN_LINK" />ตอบแบบสำรวจ<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">อัปเดต</translation>
-<translation id="4738836084190194332">ซิงค์ครั้งล่าสุด: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">เปิดแท็บใหม่</translation>
-<translation id="4751476147751820511">เซ็นเซอร์จับความเคลื่อนไหวหรือเซ็นเซอร์แสง</translation>
-<translation id="4759238208242260848">ดาวน์โหลด</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{การดาวน์โหลด 1 รายการเสร็จสมบูรณ์}other{การดาวน์โหลด # รายการเสร็จสมบูรณ์}}</translation>
-<translation id="4797039098279997504">แตะเพื่อกลับไปยัง <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">การเข้ารหัสลับด้วยรหัสผ่านจะไม่รวมข้อมูลวิธีการชำระเงินและที่อยู่จาก Google Pay
-
-หากต้องการเปลี่ยนแปลงการตั้งค่านี้ ให้<ph name="BEGIN_LINK" />รีเซ็ตการซิงค์<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">ชื่อบนบัตร</translation>
-<translation id="4824958205181053313">ยกเลิกการซิงค์ใช่ไหม</translation>
-<translation id="4837753911714442426">เปิดตัวเลือกในการพิมพ์หน้า</translation>
-<translation id="4842092870884894799">กำลังแสดงป๊อปอัปการสร้างรหัสผ่าน</translation>
-<translation id="4860895144060829044">โทร</translation>
-<translation id="4866368707455379617">ติดตั้ง <ph name="MODULE" /> สำหรับ Chrome ไม่ได้</translation>
-<translation id="4875775213178255010">การแนะนำเนื้อหา</translation>
-<translation id="4878404682131129617">สร้างช่องทางผ่านพร็อกซีเซิร์ฟเวอร์ไม่ได้</translation>
-<translation id="4880127995492972015">แปลภาษา…</translation>
-<translation id="4881695831933465202">เปิด</translation>
-<translation id="488187801263602086">เปลี่ยนชื่อไฟล์</translation>
-<translation id="4882831918239250449">ควบคุมการใช้ประวัติการท่องเว็บเพื่อปรับเปลี่ยน Search, โฆษณา และบริการอื่นๆ ในแบบของคุณ</translation>
-<translation id="4883854917563148705">รีเซ็ตการตั้งค่าที่มีการจัดการไม่ได้</translation>
-<translation id="4885273946141277891">อินสแตนซ์ของ Chrome เกินจำนวนที่สนับสนุน</translation>
-<translation id="4910889077668685004">แอปชำระเงิน</translation>
-<translation id="4913161338056004800">รีเซ็ตสถิติ</translation>
-<translation id="4913169188695071480">หยุดรีเฟรช</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />รับความช่วยเหลือ<ph name="END_LINK" />ระหว่างการค้นหาอุปกรณ์…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# หน้า}other{# หน้า}}</translation>
-<translation id="4932247056774066048">เนื่องจากคุณกำลังจะออกจากระบบบัญชีที่จัดการโดย <ph name="DOMAIN_NAME" /> ข้อมูลใน Chrome จะถูกลบออกจากอุปกรณ์นี้ แต่จะยังคงอยู่ในบัญชี Google</translation>
-<translation id="4943703118917034429">Virtual Reality</translation>
-<translation id="4943872375798546930">ไม่มีผลการค้นหา</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> กำลังแชร์หน้าจอของคุณ</translation>
-<translation id="4961107849584082341">แปลหน้านี้เป็นภาษาใดก็ได้</translation>
-<translation id="4962975101802056554">เพิกถอนสิทธิ์ทั้งหมดสำหรับอุปกรณ์</translation>
-<translation id="4970824347203572753">ไม่พร้อมใช้งานในประเทศของคุณ</translation>
-<translation id="497421865427891073">ไปข้างหน้า</translation>
-<translation id="4988210275050210843">กำลังดาวน์โหลดไฟล์ (<ph name="MEGABYTES" />)</translation>
-<translation id="4988526792673242964">หน้า</translation>
-<translation id="4994033804516042629">ไม่พบรายชื่อติดต่อ</translation>
-<translation id="4996978546172906250">แชร์ผ่าน</translation>
-<translation id="5004416275253351869">ส่วนควบคุมกิจกรรมของ Google</translation>
-<translation id="5005498671520578047">คัดลอกรหัสผ่าน</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> ต้องการเชื่อมต่อ</translation>
-<translation id="5013696553129441713">ไม่มีคำแนะนำใหม่</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">ขณะอยู่ในโหมด VR เว็บไซต์นี้อาจดูข้อมูลต่อไปนี้ได้
-  -  รูปร่างของคุณ เช่น ความสูง
-
-โปรดตรวจสอบว่าเว็บไซต์นี้เชื่อถือได้ก่อนเข้าสู่โหมด VR</translation>
+<translation id="2930742481329940825">แตะเพื่อค้นหาจะส่งคำที่เลือกและหน้าปัจจุบันเป็นบริบทไปยัง Brave Software Search คุณปิดฟีเจอร์นี้ในได้ใน<ph name="BEGIN_LINK"/>การตั้งค่า<ph name="END_LINK"/></translation>
 <translation id="5039804452771397117">อนุญาต</translation>
-<translation id="5040262127954254034">ความเป็นส่วนตัว</translation>
-<translation id="5048398596102334565">อนุญาตให้เว็บไซต์เข้าถึงเซ็นเซอร์ตรวจจับความเคลื่อนไหว (แนะนำ)</translation>
-<translation id="5063480226653192405">การใช้</translation>
-<translation id="5087580092889165836">เพิ่มบัตร</translation>
-<translation id="5100237604440890931">ยุบ - คลิกเพื่อขยาย</translation>
-<translation id="510275257476243843">เหลือ 1 ชั่วโมง</translation>
-<translation id="5123685120097942451">แท็บที่ไม่ระบุตัวตน</translation>
-<translation id="5127805178023152808">การซิงค์ปิดอยู่</translation>
-<translation id="5129038482087801250">ติดตั้งเว็บแอป</translation>
-<translation id="5132942445612118989">ซิงค์รหัสผ่าน ประวัติการเข้าชม และอื่นๆ ในอุปกรณ์ทุกเครื่อง</translation>
-<translation id="5139940364318403933">ดูวิธีใช้ Google ไดรฟ์</translation>
-<translation id="515227803646670480">ล้างข้อมูลที่เก็บไว้</translation>
-<translation id="5152843274749979095">ไม่มีแอปที่รองรับติดตั้งอยู่</translation>
-<translation id="5161254044473106830">ต้องระบุชื่อ</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{การดาวน์โหลดล้มเหลว 1 รายการ}other{การดาวน์โหลดล้มเหลว # รายการ}}</translation>
-<translation id="5170568018924773124">แสดงในโฟลเดอร์</translation>
-<translation id="5184329579814168207">เปิดใน Chrome</translation>
-<translation id="5193988420012215838">คัดลอกไปยังคลิปบอร์ดแล้ว</translation>
-<translation id="5197729504361054390">ระบบจะแชร์รายชื่อติดต่อที่คุณเลือกกับ <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /></translation>
-<translation id="5199929503336119739">โปรไฟล์งาน</translation>
-<translation id="5210286577605176222">ข้ามไปยังแท็บก่อนหน้า</translation>
-<translation id="5210365745912300556">ปิดแท็บ</translation>
-<translation id="5224771365102442243">มีวิดีโอ</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> ต้องการสแกนหาอุปกรณ์บลูทูธที่อยู่ใกล้เคียงและได้พบอุปกรณ์ต่อไปนี้</translation>
-<translation id="5233638681132016545">แท็บใหม่</translation>
-<translation id="526421993248218238">โหลดหน้านี้ไม่ได้</translation>
-<translation id="5271967389191913893">อุปกรณ์ไม่สามารถเปิดเนื้อหาที่จะดาวน์โหลดได้</translation>
-<translation id="528192093759286357">ลากจากด้านบน แล้วแตะปุ่มกลับเพื่อออกจากโหมดเต็มหน้าจอ</translation>
-<translation id="5292796745632149097">ส่งไปที่</translation>
-<translation id="5300589172476337783">แสดง</translation>
-<translation id="5301954838959518834">ตกลง เข้าใจแล้ว</translation>
-<translation id="5304593522240415983">ต้องกรอกข้อมูลในช่องนี้</translation>
-<translation id="5307446750509046227">ล้างพื้นที่เก็บข้อมูลเว็บไซต์</translation>
-<translation id="5308380583665731573">เชื่อมต่อ</translation>
-<translation id="5313967007315987356">เพิ่มเว็บไซต์</translation>
-<translation id="5317780077021120954">บันทึก</translation>
-<translation id="5324858694974489420">การตั้งค่าของผู้ปกครอง</translation>
-<translation id="5327248766486351172">ชื่อ</translation>
-<translation id="5335288049665977812">อนุญาตให้เว็บไซต์เรียกใช้ JavaScript (แนะนำ)</translation>
-<translation id="5342314432463739672">คำขอสิทธิ์</translation>
-<translation id="5357811892247919462">ได้รับแท็บแล้ว</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{เปิดแท็บไว้ <ph name="OPEN_TABS_ONE" /> แท็บ แตะเพื่อเปลี่ยนแท็บ}other{เปิดแท็บไว้ <ph name="OPEN_TABS_MANY" /> แท็บ แตะเพื่อเปลี่ยนแท็บ}}</translation>
-<translation id="5391532827096253100">การเชื่อมต่อกับเว็บไซต์นี้ไม่ปลอดภัย ข้อมูลเว็บไซต์</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(อีก 1 รายการ)}other{(อีก # รายการ)}}</translation>
-<translation id="5400569084694353794">การใช้แอปพลิเคชันนี้แสดงว่าคุณยอมรับ<ph name="BEGIN_LINK1" />ข้อกำหนดในการให้บริการ<ph name="END_LINK1" />และ<ph name="BEGIN_LINK2" />ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2" />ของ Chrome</translation>
-<translation id="5403592356182871684">ชื่อ</translation>
-<translation id="5403644198645076998">อนุญาตเฉพาะบางไซต์</translation>
-<translation id="5414836363063783498">กำลังยืนยัน…</translation>
-<translation id="5423934151118863508">หน้าที่มีการเข้าชมมากที่สุดของคุณจะปรากฏที่นี่</translation>
-<translation id="5424588387303617268">ว่าง <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">แก้ไขรหัสผ่าน</translation>
-<translation id="5433691172869980887">คัดลอกชื่อผู้ใช้แล้ว</translation>
-<translation id="543509235395288790">กำลังดาวน์โหลด <ph name="COUNT" /> ไฟล์ (<ph name="MEGABYTES" />)</translation>
-<translation id="5441522332038954058">ข้ามไปยังแถบที่อยู่เว็บ</translation>
-<translation id="5447201525962359567">พื้นที่เก็บข้อมูลเว็บไซต์ทั้งหมด รวมถึงคุกกี้และข้อมูลอื่นๆ ที่เก็บไว้ในเครื่อง</translation>
-<translation id="5447765697759493033">ระบบจะไม่แปลไซต์นี้</translation>
-<translation id="545042621069398927">กำลังเพิ่มความเร็วในการดาวน์โหลด</translation>
-<translation id="5456381639095306749">ดาวน์โหลดหน้า</translation>
-<translation id="5475862044948910901">เริ่มเซสชัน Augmented Reality ไหม</translation>
-<translation id="548278423535722844">เปิดในแอปแผนที่</translation>
-<translation id="5487521232677179737">ล้างข้อมูล</translation>
-<translation id="5494752089476963479">บล็อกโฆษณาในเว็บไซต์ที่แสดงโฆษณาที่แทรกหรือทำให้เข้าใจผิด</translation>
-<translation id="5500777121964041360">อาจไม่พร้อมใช้งานในประเทศของคุณ</translation>
-<translation id="5512137114520586844">บัญชีนี้ได้รับการจัดการโดย <ph name="PARENT_NAME" /></translation>
-<translation id="5514904542973294328">ปิดใช้โดยผู้ดูแลระบบของอุปกรณ์นี้</translation>
-<translation id="5515439363601853141">ปลดล็อกเพื่อดูรหัสผ่าน</translation>
-<translation id="5516455585884385570">เปิดการตั้งค่าการแจ้งเตือน</translation>
-<translation id="5517095782334947753">คุณมีบุ๊กมาร์ก ประวัติการเข้าชม รหัสผ่าน และการตั้งค่าอื่นๆ จาก <ph name="FROM_ACCOUNT" /></translation>
-<translation id="5524843473235508879">การเปลี่ยนเส้นทางถูกบล็อก</translation>
-<translation id="5527082711130173040">Chrome ต้องมีสิทธิ์เข้าถึงตำแหน่งเพื่อสแกนหาอุปกรณ์ โปรด<ph name="BEGIN_LINK1" />อัปเดตสิทธิ์<ph name="END_LINK1" /> การเข้าถึงตำแหน่ง<ph name="BEGIN_LINK2" />สำหรับอุปกรณ์เครื่องนี้ยังปิดอยู่<ph name="END_LINK2" /></translation>
-<translation id="5527111080432883924">ถามก่อนอนุญาตให้เว็บไซต์อ่านข้อความและดูรูปภาพจากคลิปบอร์ด (แนะนำ)</translation>
-<translation id="5530766185686772672">ปิดแท็บที่ไม่ระบุตัวตน</translation>
-<translation id="5534334044554683961">ขณะอยู่ในโหมด VR เว็บไซต์นี้อาจดูข้อมูลต่อไปนี้ได้
-  -   รูปร่างของคุณ เช่น ความสูง
-  -   แปลนห้องของคุณ
-
-โปรดตรวจสอบว่าเว็บไซต์นี้เชื่อถือได้ก่อนเข้าสู่โหมด VR</translation>
-<translation id="5534640966246046842">คัดลอกไซต์แล้ว</translation>
-<translation id="5556459405103347317">โหลดใหม่</translation>
-<translation id="5561549206367097665">กำลังรอเครือข่าย…</translation>
-<translation id="557283862590186398">Chrome ต้องการสิทธิ์เข้าถึงไมโครโฟนของคุณสำหรับไซต์นี้</translation>
-<translation id="55737423895878184">อนุญาตให้ใช้ตำแหน่งและแสดงการแจ้งเตือน</translation>
-<translation id="5578795271662203820">ค้นหาภาพนี้ใน <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">คุณเลือกสิ่งที่ต้องการซิงค์ได้เสมอใน<ph name="BEGIN_LINK1" />การตั้งค่า<ph name="END_LINK1" /></translation>
-<translation id="5595485650161345191">แก้ไขที่อยู่</translation>
-<translation id="5596627076506792578">ตัวเลือกเพิ่มเติม</translation>
-<translation id="5599455543593328020">โหมดไม่ระบุตัวตน</translation>
-<translation id="5620928963363755975">หาไฟล์และหน้าในโฟลเดอร์ดาวน์โหลดจากปุ่มตัวเลือกเพิ่มเติม</translation>
-<translation id="5626134646977739690">ชื่อ:</translation>
-<translation id="5639724618331995626">อนุญาตทุกไซต์</translation>
-<translation id="5648166631817621825">7 วันที่แล้ว</translation>
-<translation id="5649053991847567735">การดาวน์โหลดโดยอัตโนมัติ</translation>
-<translation id="5655963694829536461">ค้นหาการดาวน์โหลด</translation>
-<translation id="5659593005791499971">อีเมล</translation>
-<translation id="5665379678064389456">สร้างกิจกรรมใน <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">ลบล้างคำขอของเว็บไซต์เพื่อป้องกันการซูมเข้า</translation>
-<translation id="5677928146339483299">ถูกบล็อก</translation>
-<translation id="5684874026226664614">อ๊ะ หน้านี้ไม่สามารถแปลได้</translation>
-<translation id="5686790454216892815">ชื่อไฟล์ยาวเกินไป</translation>
-<translation id="5689516760719285838">ตำแหน่ง</translation>
-<translation id="569536719314091526">แปลหน้านี้เป็นภาษาใดก็ได้จากปุ่มตัวเลือกเพิ่มเติม</translation>
-<translation id="572328651809341494">แท็บล่าสุด</translation>
-<translation id="5726692708398506830">ขยายรายละเอียดทั้งหมดบนหน้า</translation>
-<translation id="5748802427693696783">สลับเป็นแท็บมาตรฐานแล้ว</translation>
-<translation id="5749068826913805084">Chrome ต้องมีสิทธิ์เข้าถึงพื้นที่เก็บข้อมูลเพื่อดาวน์โหลดไฟล์</translation>
-<translation id="5763382633136178763">แท็บที่ไม่ระบุตัวตน</translation>
-<translation id="5763514718066511291">แตะเพื่อคัดลอก URL สำหรับแอปนี้</translation>
-<translation id="5765780083710877561">คำอธิบาย:</translation>
-<translation id="5793665092639000975">ใช้ไป <ph name="SPACE_USED" /> จาก <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google อาจใช้ประวัติการเข้าชมเพื่อปรับเปลี่ยน Search, โฆษณา และบริการอื่นๆ ของ Google ให้เข้ากับคุณ</translation>
-<translation id="5804241973901381774">การอนุญาต</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# ชั่วโมงที่ผ่านมา}other{# ชั่วโมงที่ผ่านมา}}</translation>
-<translation id="5810288467834065221">ลิขสิทธิ์ <ph name="YEAR" /> Google LLC สงวนลิขสิทธิ์</translation>
-<translation id="5817918615728894473">จับคู่</translation>
-<translation id="583281660410589416">ไม่รู้จัก</translation>
-<translation id="5833984609253377421">แชร์ลิงก์</translation>
-<translation id="5836192821815272682">กำลังดาวน์โหลดอัปเดต Chrome…</translation>
-<translation id="5853623416121554550">หยุดชั่วคราว</translation>
-<translation id="5854790677617711513">เกิน 30 วัน</translation>
-<translation id="5858741533101922242">Chrome ไม่สามารถเปิดอะแดปเตอร์บลูทูธ</translation>
-<translation id="5860033963881614850">ปิด</translation>
-<translation id="5862731021271217234">เปิดการซิงค์เพื่อรับแท็บจากอุปกรณ์เครื่องอื่นๆ ของคุณ</translation>
-<translation id="5864174910718532887">รายละเอียด: จัดเรียงตามชื่อเว็บไซต์</translation>
-<translation id="5864419784173784555">กำลังรอการดาวน์โหลดรายการอื่น…</translation>
-<translation id="5865733239029070421">ส่งสถิติการใช้งานและรายงานข้อขัดข้องให้กับ Google โดยอัตโนมัติ</translation>
-<translation id="5869522115854928033">รหัสผ่านที่บันทึกไว้</translation>
-<translation id="5902828464777634901">ระบบจะลบข้อมูลในเครื่องทั้งหมดที่เว็บไซต์นี้จัดเก็บ รวมถึงคุกกี้</translation>
-<translation id="5916664084637901428">เปิด</translation>
-<translation id="5919204609460789179">อัปเดต <ph name="PRODUCT_NAME" /> เพื่อเริ่มซิงค์</translation>
-<translation id="5937580074298050696">ประหยัดได้ <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">รีเซ็ต</translation>
-<translation id="5942872142862698679">กำลังใช้ Google ในการค้นหา</translation>
-<translation id="5952764234151283551">ส่ง URL ของหน้าที่คุณพยายามเข้าถึงไปยัง Google</translation>
-<translation id="5956665950594638604">เปิดศูนย์ช่วยเหลือของ Chrome ในแท็บใหม่</translation>
-<translation id="5958275228015807058">หาไฟล์และหน้าในโฟลเดอร์ดาวน์โหลด</translation>
-<translation id="5962718611393537961">แตะเพื่อยุบ</translation>
-<translation id="6000066717592683814">ใช้ Google ต่อ</translation>
-<translation id="6005538289190791541">รหัสผ่านที่แนะนำ</translation>
-<translation id="6036057147555329831">ICU เพิ่มเติม</translation>
-<translation id="6039379616847168523">ข้ามไปยังแท็บถัดไป</translation>
-<translation id="6040143037577758943">ปิด</translation>
-<translation id="6042308850641462728">เพิ่มเติม</translation>
-<translation id="604996488070107836">การดาวน์โหลด <ph name="FILE_NAME" /> ล้มเหลวเนื่องจากข้อผิดพลาดที่ไม่รู้จัก</translation>
-<translation id="605721222689873409">ปป</translation>
-<translation id="6064125863973209585">การดาวน์โหลดที่เสร็จสมบูรณ์แล้ว</translation>
-<translation id="6075798973483050474">แก้ไขหน้าแรก</translation>
-<translation id="60923314841986378">เหลือ <ph name="HOURS" /> ชั่วโมง</translation>
-<translation id="6108923351542677676">กำลังดำเนินการตั้งค่า…</translation>
-<translation id="6111020039983847643">อินเทอร์เน็ตที่ใช้</translation>
-<translation id="6112702117600201073">กำลังรีเฟรชหน้า</translation>
-<translation id="6127379762771434464">นำรายการออกแล้ว</translation>
-<translation id="6140912465461743537">ประเทศ/ภูมิภาค</translation>
-<translation id="614940544461990577">ลอง:</translation>
-<translation id="6154478581116148741">เปิดล็อกหน้าจอใน "การตั้งค่า" เพื่อส่งออกรหัสผ่านจากอุปกรณ์นี้</translation>
-<translation id="6159335304067198720">ประหยัดอินเทอร์เน็ต <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">ดูข้อมูลเพิ่มเติม</translation>
-<translation id="6177111841848151710">ถูกบล็อกสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
-<translation id="6181444274883918285">เพิ่มข้อยกเว้นของเว็บไซต์</translation>
-<translation id="6192333916571137726">ดาวน์โหลดไฟล์</translation>
-<translation id="6192792657125177640">ข้อยกเว้น</translation>
-<translation id="6194112207524046168">หากต้องการให้ Chrome เข้าถึงกล้องถ่ายรูป ให้เปิดกล้องถ่ายรูปใน<ph name="BEGIN_LINK" />การตั้งค่า Android<ph name="END_LINK" /> ด้วย</translation>
-<translation id="6196640612572343990">บล็อกคุกกี้ของบุคคลที่สาม</translation>
-<translation id="6206551242102657620">การเชื่อมต่อปลอดภัย ข้อมูลเว็บไซต์</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> ไม่ใช่บัญชีที่ฉันจะใช้</translation>
-<translation id="6221633008163990886">ปลดล็อกเพื่อส่งออกรหัสผ่าน</translation>
+<translation id="1406000523432664303">“ไม่ติดตาม”</translation>
 <translation id="6232535412751077445">การเปิดใช้ "ไม่ติดตาม" หมายความว่าจะมีการรวมคำขอหนึ่งไว้กับการเข้าชมของคุณ ผลกระทบทั้งหมดขึ้นอยู่กับว่าเว็บไซต์ตอบสนองต่อคำขอนั้นไหม และวิธีตีความคำขอ
 
 ตัวอย่างเช่น บางเว็บไซต์อาจตอบสนองต่อคำขอนี้โดยแสดงให้คุณเห็นโฆษณาที่ไม่ได้อิงอยู่กับเว็บไซต์อื่นๆ ที่คุณเข้าชม เว็บไซต์จำนวนมากจะยังคงรวบรวมและใช้ข้อมูลการท่องเว็บของคุณเพื่อปรับปรุงความปลอดภัย เพื่อแสดงเนื้อหา โฆษณา และคำแนะนำ และเพื่อสร้างสถิติในการรายงาน เป็นต้น</translation>
-<translation id="624789221780392884">พร้อมอัปเดต</translation>
-<translation id="6255999984061454636">การแนะนำเนื้อหา</translation>
-<translation id="6277522088822131679">เกิดปัญหาในการพิมพ์หน้านี้ โปรดลองอีกครั้ง</translation>
-<translation id="6295158916970320988">เว็บไซต์ทั้งหมด</translation>
-<translation id="629730747756840877">บัญชี</translation>
-<translation id="6303969859164067831">ออกจากระบบและปิดการซิงค์</translation>
-<translation id="6316139424528454185">ไม่รองรับ Android เวอร์ชันนี้</translation>
-<translation id="6320088164292336938">สั่น</translation>
-<translation id="6324034347079777476">ปิดใช้การซิงค์ระบบ Android อยู่</translation>
-<translation id="6333140779060797560">แชร์ผ่าน <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">การเข้ารหัส</translation>
-<translation id="6341580099087024258">ถามว่าจะให้บันทึกไฟล์ไว้ที่ใด</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> แห่ง}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> แห่ง}}</translation>
-<translation id="6364438453358674297">ต้องการนำคำแนะนำออกจากประวัติการเข้าชมใช่ไหม</translation>
-<translation id="6369229450655021117">คุณจะค้นหาเว็บ แชร์กับเพื่อนๆ และดูหน้าเว็บที่เปิดอยู่ได้จากที่นี่</translation>
-<translation id="6378173571450987352">รายละเอียด: จัดเรียงตามปริมาณเน็ตมือถือที่ใช้</translation>
-<translation id="6381421346744604172">ปรับเว็บไซต์ให้เป็นสีเข้ม</translation>
-<translation id="6388207532828177975">ล้างข้อมูลและรีเซ็ต</translation>
-<translation id="6393863479814692971">Chrome ต้องการสิทธิ์เข้าถึงไมโครโฟนและกล้องถ่ายรูปของคุณสำหรับไซต์นี้</translation>
-<translation id="6395288395575013217">ลิงก์</translation>
-<translation id="6404511346730675251">แก้ไขบุ๊กมาร์ก</translation>
-<translation id="6406506848690869874">การซิงค์ข้อมูล</translation>
-<translation id="641643625718530986">พิมพ์…</translation>
-<translation id="6416782512398055893">ดาวน์โหลดแล้ว <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">แปลเว็บ</translation>
-<translation id="6433501201775827830">เลือกเครื่องมือค้นหา</translation>
-<translation id="6437478888915024427">ข้อมูลหน้าเว็บ</translation>
-<translation id="6441734959916820584">ชื่อยาวเกินไป</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ภาพ}other{# ภาพ}}</translation>
-<translation id="6447842834002726250">คุกกี้</translation>
-<translation id="6461962085415701688">เปิดไฟล์ไม่ได้</translation>
-<translation id="6464977750820128603">คุณดูเว็บไซต์ที่เข้าชมใน Chrome และตั้งตัวจับเวลาการใช้เว็บไซต์เหล่านั้นได้\n\nGoogle จะได้รับข้อมูลเกี่ยวกับเว็บไซต์ที่คุณตั้งตัวจับเวลาไว้และระยะเวลาที่คุณเข้าชมเว็บไซต์เหล่านั้น เราจะใช้ข้อมูลนี้เพื่อปรับปรุงไลฟ์สไตล์ดิจิทัลให้ดียิ่งขึ้น</translation>
-<translation id="6475951671322991020">ดาวน์โหลดวิดีโอ</translation>
-<translation id="6482749332252372425">การดาวน์โหลด <ph name="FILE_NAME" /> ล้มเหลวเพราะพื้นที่เก็บข้อมูลไม่เพียงพอ</translation>
-<translation id="6496823230996795692">โปรดเชื่อมต่ออินเทอร์เน็ตเพื่อใช้ <ph name="APP_NAME" /> เป็นครั้งแรก</translation>
-<translation id="6508722015517270189">รีสตาร์ท Chrome</translation>
-<translation id="6527303717912515753">แชร์</translation>
-<translation id="6532866250404780454">ระบบจะไม่แสดงเว็บไซต์ที่คุณเข้าชมใน Chrome และจะลบตัวจับเวลาการใช้เว็บไซต์ทั้งหมด</translation>
-<translation id="6534565668554028783">Google ใช้เวลาตอบกลับนานเกินไป</translation>
-<translation id="6538442820324228105">ดาวน์โหลดแล้ว <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">เกิดข้อผิดพลาด ลองอีกครั้งภายหลัง</translation>
-<translation id="654446541061731451">เลือกแท็บที่จะบีม</translation>
-<translation id="6545017243486555795">ล้างข้อมูลทั้งหมด</translation>
-<translation id="6545864417968258051">การสแกนหาบลูทูธ</translation>
-<translation id="6560414384669816528">ค้นหาด้วย Sogou</translation>
-<translation id="6566259936974865419">Chrome ได้ประหยัดพื้นที่ให้คุณไป <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">อนุญาตเสมอ</translation>
-<translation id="6573431926118603307">แท็บที่คุณเปิดไว้ใน Chrome ในอุปกรณ์เครื่องอื่นๆ จะปรากฏที่นี่</translation>
-<translation id="6583199322650523874">บุ๊กมาร์กหน้าปัจจุบัน</translation>
-<translation id="6593061639179217415">เว็บไซต์เวอร์ชันเดสก์ท็อป</translation>
-<translation id="6600954340915313787">คัดลอกไปยัง Chrome แล้ว</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">เนื้อหาที่ได้รับความคุ้มครอง</translation>
-<translation id="6627583120233659107">แก้ไขโฟลเดอร์</translation>
-<translation id="6643016212128521049">ล้าง</translation>
-<translation id="6643649862576733715">จัดเรียงตามปริมาณเน็ตมือถือที่ประหยัดได้</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> รายการ}other{<ph name="CONTACT_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> รายการ}}</translation>
-<translation id="6649642165559792194">พรีวิวรูปภาพ <ph name="BEGIN_NEW" />ใหม่<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome ต้องมีสิทธิ์เข้าถึงตำแหน่งเพื่อสแกนหาอุปกรณ์ โปรด<ph name="BEGIN_LINK" />อัปเดตสิทธิ์<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">รหัสผ่าน</translation>
-<translation id="6659594942844771486">แท็บ</translation>
-<translation id="666731172850799929">เปิดใน <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัวของ Chrome</translation>
-<translation id="6676840375528380067">ล้างข้อมูล Chrome ของคุณออกจากอุปกรณ์นี้ไหม</translation>
-<translation id="6697492270171225480">แสดงคำแนะนำหน้าที่คล้ายกันเมื่อไม่พบหน้าเว็บ</translation>
-<translation id="6697947395630195233">Chrome ต้องการสิทธิ์เข้าถึงตำแหน่งของคุณเพื่อแชร์ตำแหน่งกับไซต์นี้</translation>
-<translation id="6698801883190606802">จัดการข้อมูลที่ซิงค์</translation>
-<translation id="6699370405921460408">เซิร์ฟเวอร์ของ Google จะเพิ่มประสิทธิภาพหน้าเว็บที่คุณเข้าชม</translation>
-<translation id="6706288973712894588">คุณกำลังออฟไลน์อยู่\n<ph name="BEGIN_LINK" />สำรวจฟีดออฟไลน์<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">ข่าวสาร</translation>
-<translation id="6710213216561001401">ก่อนหน้า</translation>
-<translation id="671481426037969117">ตัวจับเวลา <ph name="FQDN" /> หมดเวลาแล้ว และจะเริ่มอีกครั้งพรุ่งนี้</translation>
-<translation id="6738867403308150051">กำลังดาวน์โหลด…</translation>
-<translation id="6746124502594467657">เลื่อนลง</translation>
-<translation id="6766622839693428701">เลื่อนลงเพื่อปิด</translation>
-<translation id="6766758767654711248">แตะเพื่อไปที่เว็บไซต์</translation>
-<translation id="6767294960381293877">รายการอุปกรณ์ที่จะแชร์แท็บด้วยเปิดอยู่ที่ระดับความสูงครึ่งหนึ่งของหน้าจอ</translation>
-<translation id="6782111308708962316">ป้องกันไม่ให้เว็บไซต์ของบุคคลที่สามบันทึกและอ่านข้อมูลคุกกี้</translation>
-<translation id="6790428901817661496">เล่น</translation>
-<translation id="6811034713472274749">พร้อมดูหน้าเว็บแล้ว</translation>
-<translation id="6818926723028410516">เลือกรายการ</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">แปลภาษา</translation>
-<translation id="6845325883481699275">ช่วยปรับปรุงความปลอดภัยของ Chrome</translation>
-<translation id="6846298663435243399">กำลังโหลด…</translation>
-<translation id="6850409657436465440">ระบบยังดาวน์โหลดอยู่</translation>
-<translation id="6850830437481525139">ปิดแล้ว <ph name="TAB_COUNT" /> แท็บ</translation>
-<translation id="6864459304226931083">ดาวน์โหลดรูปภาพ</translation>
-<translation id="6865313869410766144">ข้อมูลฟอร์มที่ป้อนอัตโนมัติ</translation>
-<translation id="688738109438487280">เพิ่มข้อมูลที่มีอยู่ลงใน <ph name="TO_ACCOUNT" /></translation>
-<translation id="6891726759199484455">ปลดล็อกเพื่อคัดลอกรหัสผ่าน</translation>
-<translation id="6896758677409633944">คัดลอก</translation>
-<translation id="6910211073230771657">ลบแล้ว</translation>
-<translation id="6912998170423641340">บล็อกเว็บไซต์ไม่ให้อ่านข้อความและดูรูปภาพจากคลิปบอร์ด</translation>
-<translation id="6914783257214138813">คนที่ดูไฟล์ที่ส่งออกได้จะเห็นรหัสผ่านของคุณ</translation>
-<translation id="6942665639005891494">เปลี่ยนตำแหน่งเริ่มต้นในการดาวน์โหลดได้ทุกเมื่อโดยใช้ตัวเลือกเมนู "การตั้งค่า"</translation>
-<translation id="6945221475159498467">เลือก</translation>
-<translation id="6963642900430330478">หน้านี้อันตราย ข้อมูลเว็บไซต์</translation>
-<translation id="6963766334940102469">ลบบุ๊กมาร์ก</translation>
-<translation id="6965382102122355670">ตกลง</translation>
-<translation id="6979737339423435258">ตั้งแต่ต้น</translation>
-<translation id="6981982820502123353">การเข้าถึง</translation>
-<translation id="6989267951144302301">ดาวน์โหลดไม่ได้</translation>
-<translation id="6990079615885386641">รับแอปจาก Google Play Store: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">ถามก่อน ก่อนที่จะอนุญาตให้เว็บไซต์ใช้ไมโครโฟน (แนะนำ)</translation>
-<translation id="7015203776128479407">ตั้งค่าการซิงค์เริ่มต้นไม่สำเร็จ การซิงค์ปิดอยู่</translation>
-<translation id="7016516562562142042">อนุญาตสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
-<translation id="7022756207310403729">เปิดในเบราว์เซอร์</translation>
-<translation id="702463548815491781">แนะนำให้ใช้เมื่อ TalkBack หรือการเข้าถึงด้วยสวิตช์เปิดอยู่</translation>
-<translation id="7029809446516969842">รหัสผ่าน</translation>
-<translation id="7053983685419859001">บล็อก</translation>
-<translation id="7055152154916055070">การเปลี่ยนเส้นทางถูกบล็อก</translation>
-<translation id="7063006564040364415">ไม่สามารถเชื่อมต่อกับเซิร์ฟเวอร์การซิงค์</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{เลือก 1 รายการ}other{เลือก # รายการ}}</translation>
-<translation id="7071521146534760487">จัดการบัญชี</translation>
-<translation id="7077143737582773186">การ์ด SD</translation>
-<translation id="7087918508125750058">เลือกไว้ <ph name="ITEM_COUNT" /> รายการ ตัวเลือกอยู่ตรงบริเวณด้านบนของหน้าจอ</translation>
-<translation id="7121362699166175603">ล้างประวัติการเข้าชมและการเติมข้อความอัตโนมัติในแถบที่อยู่เว็บ บัญชี Google อาจมีประวัติการท่องเว็บรูปแบบอื่นๆ ที่ <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /></translation>
-<translation id="7128222689758636196">อนุญาตสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
-<translation id="7138678301420049075">อื่นๆ</translation>
-<translation id="7141896414559753902">บล็อกเว็บไซต์ไม่ให้แสดงป๊อปอัปและการเปลี่ยนเส้นทาง (แนะนำ)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />โหลดหน้าต้นฉบับ<ph name="END_LINK" />จาก <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">24 ชั่วโมงที่แล้ว</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">คุณสามารถเปลี่ยนค่านี้ภายหลังใน "การตั้งค่า"</translation>
-<translation id="7180611975245234373">รีเฟรช</translation>
-<translation id="7189372733857464326">กำลังรอให้บริการ Google Play อัปเดตเสร็จสิ้น</translation>
-<translation id="7191430249889272776">แท็บเปิดในพื้นหลัง</translation>
-<translation id="723171743924126238">เลือกภาพ</translation>
-<translation id="7233236755231902816">โปรดอัปเดต Chrome เป็นเวอร์ชันล่าสุดเพื่อดูเว็บเป็นภาษาของคุณ</translation>
-<translation id="7243308994586599757">มีตัวเลือกอยู่ทางด้านล่างของหน้าจอ</translation>
-<translation id="7248069434667874558">ตรวจสอบว่าการซิงค์ <ph name="TARGET_DEVICE_NAME" /> ใน Chrome เปิดอยู่</translation>
-<translation id="7250468141469952378">เลือกไว้ <ph name="ITEM_COUNT" /> รายการ</translation>
-<translation id="7274013316676448362">เว็บไซต์ที่ถูกบล็อก</translation>
-<translation id="7290209999329137901">เปลี่ยนชื่อไม่ได้</translation>
-<translation id="7291387454912369099">Assistant สำหรับการป้อนข้อความอัตโนมัติ</translation>
-<translation id="7293171162284876153">หากต้องการเริ่มซิงค์ ให้เปิด "ซิงค์ข้อมูล Chrome"</translation>
-<translation id="729975465115245577">อุปกรณ์ของคุณไม่มีแอปไว้จัดเก็บไฟล์รหัสผ่าน</translation>
-<translation id="7302081693174882195">รายละเอียด: จัดเรียงตามปริมาณเน็ตมือถือที่ประหยัดได้</translation>
-<translation id="7328017930301109123">ในโหมด Lite เบราว์เซอร์ Chrome จะโหลดหน้าเว็บได้เร็วขึ้นและใช้เน็ตน้อยลงสูงสุดถึง 60 เปอร์เซ็นต์</translation>
-<translation id="7333031090786104871">ยังเพิ่มไซต์ก่อนหน้าอยู่</translation>
-<translation id="7352939065658542140">วิดีโอ</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{แชร์ 1 รายการที่เลือก}other{แชร์ # รายการที่เลือก}}</translation>
 <translation id="7359002509206457351">เข้าถึงวิธีการชำระเงิน</translation>
+<translation id="8026334261755873520">ล้างข้อมูลการท่องเว็บ</translation>
+<translation id="1291207594882862231">ล้างประวัติการเข้าชม คุกกี้ ข้อมูลเว็บไซต์ แคช…</translation>
+<translation id="7814200940910057384">ล้างข้อมูล Brave แล้ว</translation>
+<translation id="1664855196866195614">ระบบได้นำข้อมูลที่เลือกออกจาก Brave และอุปกรณ์ที่ซิงค์แล้ว
+
+บัญชี Brave Software ของคุณอาจมีประวัติการท่องเว็บในรูปแบบอื่นๆ เช่น การค้นหาและกิจกรรมจากบริการอื่นๆ ของ Brave Software ที่ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/></translation>
+<translation id="4699172675775169585">รูปภาพและไฟล์ในแคช</translation>
+<translation id="2496180316473517155">ประวัติการเข้าชมที่เรียกดู</translation>
+<translation id="2546283357679194313">คุกกี้และข้อมูลเว็บไซต์</translation>
+<translation id="8662811608048051533">นำคุณออกจากระบบของเว็บไซต์ส่วนใหญ่</translation>
+<translation id="8218628800671693884">นำคุณออกจากระบบของเว็บไซต์ส่วนใหญ่ แต่คุณจะไม่ออกจากระบบบัญชี Brave Software</translation>
+<translation id="2017836877785168846">ล้างประวัติการเข้าชมและการเติมข้อความอัตโนมัติในแถบที่อยู่เว็บ</translation>
+<translation id="8096327394278038498">ล้างประวัติการเข้าชมและการเติมข้อความอัตโนมัติในแถบที่อยู่เว็บ บัญชี Brave Software อาจมีประวัติการท่องเว็บรูปแบบอื่นๆ ที่ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/></translation>
+<translation id="8122693181154564064">ล้างประวัติจากอุปกรณ์ที่ลงชื่อเข้าใช้ทั้งหมด บัญชี Brave Software อาจมีประวัติการท่องเว็บรูปแบบอื่นๆ ที่ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/></translation>
+<translation id="5869522115854928033">รหัสผ่านที่บันทึกไว้</translation>
+<translation id="6865313869410766144">ข้อมูลฟอร์มที่ป้อนอัตโนมัติ</translation>
+<translation id="7562080006725997899">กำลังล้างข้อมูลการท่องเว็บ</translation>
+<translation id="5487521232677179737">ล้างข้อมูล</translation>
+<translation id="7498271377022651285">โปรดรอสักครู่…</translation>
+<translation id="784934925303690534">ช่วงเวลา</translation>
+<translation id="1718835860248848330">ชั่วโมงที่แล้ว</translation>
+<translation id="7149893636342594995">24 ชั่วโมงที่แล้ว</translation>
+<translation id="5648166631817621825">7 วันที่แล้ว</translation>
+<translation id="8571213806525832805">4 สัปดาห์ที่แล้ว</translation>
+<translation id="5854790677617711513">เกิน 30 วัน</translation>
+<translation id="6979737339423435258">ตั้งแต่ต้น</translation>
+<translation id="982182592107339124">การดำเนินการนี้จะล้างข้อมูลสำหรับทุกเว็บไซต์ รวมถึง</translation>
+<translation id="6643016212128521049">ล้าง</translation>
+<translation id="7641339528570811325">ล้างข้อมูลการท่องเว็บ…</translation>
+<translation id="1670399744444387456">พื้นฐาน</translation>
+<translation id="3245261285041759672">บัญชี Brave Software อาจมีประวัติการท่องเว็บรูปแบบอื่นๆ ที่ <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/></translation>
+<translation id="7274013316676448362">เว็บไซต์ที่ถูกบล็อก</translation>
+<translation id="2534155362429831547">ลบแล้ว <ph name="NUMBER_OF_ITEMS"/> รายการ</translation>
+<translation id="1121094540300013208">รายงานการใช้งานและข้อขัดข้อง</translation>
+<translation id="9079153198295609735">ส่งสถิติการใช้งานและรายงานข้อขัดข้องไปยัง Brave Software โดยอัตโนมัติ</translation>
+<translation id="6981982820502123353">การเข้าถึง</translation>
+<translation id="2387895666653383613">อัตราส่วนข้อความ</translation>
+<translation id="2321958826496381788">ลากแถบเลื่อนจนกว่าคุณจะสามารถอ่านได้อย่างสะดวก ข้อความควรมีขนาดเท่านี้เป็นอย่างน้อยหลังจากแตะ 2 ครั้งบนย่อหน้า</translation>
+<translation id="3895926599014793903">บังคับให้เปิดใช้การซูม</translation>
+<translation id="5668404140385795438">ลบล้างคำขอของเว็บไซต์เพื่อป้องกันการซูมเข้า</translation>
+<translation id="4149994727733219643">มุมมองอย่างง่ายสำหรับหน้าเว็บ</translation>
+<translation id="9100505651305367705">เสนอการแสดงบทความในมุมมองอย่างง่าย ในกรณีที่บทความทำได้</translation>
+<translation id="1409426117486808224">มุมมองอย่างง่ายสำหรับแท็บที่เปิดไว้</translation>
+<translation id="702463548815491781">แนะนำให้ใช้เมื่อ TalkBack หรือการเข้าถึงด้วยสวิตช์เปิดอยู่</translation>
+<translation id="8284326494547611709">คำบรรยาย</translation>
+<translation id="4165986682804962316">การตั้งค่าเว็บไซต์</translation>
+<translation id="6295158916970320988">เว็บไซต์ทั้งหมด</translation>
+<translation id="8380167699614421159">เว็บไซต์นี้แสดงโฆษณาที่แทรกหรือทำให้เข้าใจผิด</translation>
+<translation id="1919345977826869612">โฆษณา</translation>
+<translation id="410351446219883937">เล่นอัตโนมัติ</translation>
+<translation id="6447842834002726250">คุกกี้</translation>
+<translation id="6196640612572343990">บล็อกคุกกี้ของบุคคลที่สาม</translation>
+<translation id="6782111308708962316">ป้องกันไม่ให้เว็บไซต์ของบุคคลที่สามบันทึกและอ่านข้อมูลคุกกี้</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">ป๊อปอัปและการเปลี่ยนเส้นทาง</translation>
+<translation id="4751476147751820511">เซ็นเซอร์จับความเคลื่อนไหวหรือเซ็นเซอร์แสง</translation>
+<translation id="1717218214683051432">เซ็นเซอร์ตรวจจับความเคลื่อนไหว</translation>
+<translation id="2091887806945687916">เสียง</translation>
+<translation id="2586657967955657006">คลิปบอร์ด</translation>
+<translation id="6320088164292336938">สั่น</translation>
+<translation id="4226663524361240545">การแจ้งเตือนอาจทำให้อุปกรณ์สั่น</translation>
+<translation id="1446450296470737166">ควบคุมอุปกรณ์ MIDI ได้สมบูรณ์</translation>
+<translation id="3744111561329211289">ซิงค์ในแบ็กกราวด์</translation>
+<translation id="5649053991847567735">การดาวน์โหลดโดยอัตโนมัติ</translation>
+<translation id="6181444274883918285">เพิ่มข้อยกเว้นของเว็บไซต์</translation>
+<translation id="5313967007315987356">เพิ่มเว็บไซต์</translation>
+<translation id="1369915414381695676">เพิ่มเว็บไซต์ <ph name="SITE_NAME"/> แล้ว</translation>
+<translation id="7837721118676387834">อนุญาตให้เล่นวิดีโอที่ปิดเสียงโดยอัตโนมัติสำหรับบางเว็บไซต์</translation>
+<translation id="2621115761605608342">อนุญาต JavaScript สำหรับเว็บไซต์ใดเว็บไซต์หนึ่ง</translation>
+<translation id="8801436777607969138">บล็อก JavaScript ในเว็บไซต์ที่ต้องการ</translation>
+<translation id="8372893542064058268">อนุญาตให้ใช้การซิงค์ในแบ็กกราวด์สำหรับเว็บไซต์ที่เจาะจง</translation>
+<translation id="358794129225322306">อนุญาตให้เว็บไซต์ดาวน์โหลดไฟล์หลายไฟล์โดยอัตโนมัติ</translation>
+<translation id="4008040567710660924">อนุญาตคุกกี้ของเว็บไซต์ที่เจาะจง</translation>
+<translation id="8958424370300090006">บล็อกคุกกี้ของเว็บไซต์ที่เจาะจง</translation>
+<translation id="7882806643839505685">อนุญาตให้เว็บไซต์ที่ต้องการเล่นเสียงได้</translation>
+<translation id="4468959413250150279">ปิดเสียงไซต์ที่ต้องการ</translation>
+<translation id="1994173015038366702">URL ของเว็บไซต์</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">การใช้</translation>
+<translation id="5804241973901381774">การอนุญาต</translation>
+<translation id="4278390842282768270">อนุญาตแล้ว</translation>
+<translation id="5677928146339483299">ถูกบล็อก</translation>
+<translation id="1984937141057606926">อนุญาต ยกเว้นบุคคลที่สาม</translation>
+<translation id="7423098979219808738">ถามก่อน</translation>
+<translation id="8116925261070264013">ปิดเสียง</translation>
+<translation id="8300705686683892304">จัดการโดยแอป</translation>
+<translation id="6192792657125177640">ข้อยกเว้น</translation>
+<translation id="257931822824936280">ขยาย - คลิกเพื่อยุบ</translation>
+<translation id="5100237604440890931">ยุบ - คลิกเพื่อขยาย</translation>
+<translation id="857943718398505171">อนุญาตแล้ว (แนะนำ)</translation>
+<translation id="2913331724188855103">อนุญาตให้เว็บไซต์บันทึกและอ่านข้อมูลคุกกี้ (แนะนำ)</translation>
+<translation id="7445411102860286510">อนุญาตให้เว็บไซต์เล่นวิดีโอที่ปิดเสียงโดยอัตโนมัติ (แนะนำ)</translation>
+<translation id="5335288049665977812">อนุญาตให้เว็บไซต์เรียกใช้ JavaScript (แนะนำ)</translation>
+<translation id="5527111080432883924">ถามก่อนอนุญาตให้เว็บไซต์อ่านข้อความและดูรูปภาพจากคลิปบอร์ด (แนะนำ)</translation>
+<translation id="6912998170423641340">บล็อกเว็บไซต์ไม่ให้อ่านข้อความและดูรูปภาพจากคลิปบอร์ด</translation>
+<translation id="7423538860840206698">บล็อกไม่ให้อ่านคลิปบอร์ด</translation>
+<translation id="3955193568934677022">อนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง (แนะนำ)</translation>
+<translation id="445467742685312942">อนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง</translation>
+<translation id="2107397443965016585">ถามก่อนอนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง (แนะนำ)</translation>
+<translation id="2910701580606108292">ถามก่อนอนุญาตให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง</translation>
+<translation id="757524316907819857">บล็อกไม่ให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง</translation>
+<translation id="3277252321222022663">อนุญาตให้เว็บไซต์เข้าถึงเซ็นเซอร์ (แนะนำ)</translation>
+<translation id="5048398596102334565">อนุญาตให้เว็บไซต์เข้าถึงเซ็นเซอร์ตรวจจับความเคลื่อนไหว (แนะนำ)</translation>
+<translation id="8816026460808729765">บล็อกไม่ให้เว็บไซต์เข้าถึงเซ็นเซอร์</translation>
+<translation id="169515064810179024">บล็อกไม่ให้เว็บไซต์เข้าถึงเซ็นเซอร์ตรวจจับความเคลื่อนไหว</translation>
+<translation id="1660204651932907780">อนุญาตให้เว็บไซต์เล่นเสียง (แนะนำ)</translation>
+<translation id="3600792891314830896">ปิดเสียงเว็บไซต์ที่เล่นเสียง</translation>
+<translation id="1743802530341753419">ถามก่อนอนุญาตให้เว็บไซต์เชื่อมต่อกับอุปกรณ์ (แนะนำ)</translation>
+<translation id="851751545965956758">บล็อกเว็บไซต์ไม่ให้เชื่อมต่อกับอุปกรณ์</translation>
+<translation id="7141896414559753902">บล็อกเว็บไซต์ไม่ให้แสดงป๊อปอัปและการเปลี่ยนเส้นทาง (แนะนำ)</translation>
+<translation id="5494752089476963479">บล็อกโฆษณาในเว็บไซต์ที่แสดงโฆษณาที่แทรกหรือทำให้เข้าใจผิด</translation>
+<translation id="3123473560110926937">บล็อกในบางเว็บไซต์</translation>
+<translation id="965817943346481315">บล็อกหากเว็บไซต์แสดงโฆษณาที่แทรกหรือทำให้เข้าใจผิด (แนะนำ)</translation>
+<translation id="3386292677130313581">ถามก่อนอนุญาตให้เว็บไซต์ทราบตำแหน่งของคุณ (แนะนำ)</translation>
+<translation id="9139068048179869749">ถามก่อนอนุญาตให้เว็บไซต์ส่งการแจ้งเตือน (แนะนำ)</translation>
+<translation id="4479647676395637221">ถามก่อน ก่อนที่จะอนุญาตให้เว็บไซต์ใช้กล้องถ่ายรูปของคุณ (แนะนำ)</translation>
+<translation id="6992289844737586249">ถามก่อน ก่อนที่จะอนุญาตให้เว็บไซต์ใช้ไมโครโฟน (แนะนำ)</translation>
+<translation id="2289270750774289114">ถามเมื่อเว็บไซต์ต้องการค้นหาอุปกรณ์บลูทูธใกล้เคียง (แนะนำ)</translation>
+<translation id="7053983685419859001">บล็อก</translation>
+<translation id="7128222689758636196">อนุญาตสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
+<translation id="7589445247086920869">บล็อกสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
+<translation id="6388207532828177975">ล้างข้อมูลและรีเซ็ต</translation>
+<translation id="7999064672810608036">คุณแน่ใจไหมว่าต้องการล้างข้อมูลในเครื่องทั้งหมด รวมถึงคุกกี้ และรีเซ็ตสิทธิ์ทั้งหมดสำหรับเว็บไซต์นี้</translation>
+<translation id="2822354292072154809">แน่ใจไหมว่าต้องการรีเซ็ตสิทธิ์ทั้งหมดของเว็บไซต์สำหรับ <ph name="CHOSEN_OBJECT_NAME"/></translation>
+<translation id="515227803646670480">ล้างข้อมูลที่เก็บไว้</translation>
+<translation id="5902828464777634901">ระบบจะลบข้อมูลในเครื่องทั้งหมดที่เว็บไซต์นี้จัดเก็บ รวมถึงคุกกี้</translation>
+<translation id="119944043368869598">ล้างทั้งหมด</translation>
+<translation id="2490684707762498678">จัดการโดย <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">เปิดการตั้งค่าการแจ้งเตือน</translation>
+<translation id="1404122904123200417">ฝังอยู่ใน <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">ไฟล์ที่เว็บไซต์บันทึกไว้จะปรากฏที่นี่</translation>
+<translation id="4181841719683918333">ภาษา</translation>
+<translation id="2647434099613338025">เพิ่มภาษา</translation>
+<translation id="1952172573699511566">เมื่อเป็นไปได้ เว็บไซต์จะแสดงในภาษาที่คุณต้องการ</translation>
+<translation id="8559990750235505898">เสนอที่จะแปลหน้าในภาษาอื่นๆ</translation>
+<translation id="4719927025381752090">เสนอการแปล</translation>
+<translation id="8156139159503939589">คุณอ่านภาษาใดได้บ้าง</translation>
+<translation id="5689516760719285838">ตำแหน่ง</translation>
+<translation id="2440823041667407902">การเข้าถึงตำแหน่ง</translation>
+<translation id="2023546461831060654">เปิดการใช้สิทธิ์สำหรับ Brave ใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/></translation>
+<translation id="6665548517310046133">เปิดการใช้สิทธิ์สำหรับ Brave ใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/></translation>
+<translation id="2928908108430545745">หากต้องการให้ Brave เข้าถึงตำแหน่งของคุณ ให้เปิดตำแหน่งใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/> ด้วย</translation>
+<translation id="1028853271388022585">หากต้องการให้ Brave เข้าถึงกล้องถ่ายรูป ให้เปิดกล้องถ่ายรูปใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/> ด้วย</translation>
+<translation id="2913721282607281710">หากต้องการให้ Brave ส่งการแจ้งเตือนให้คุณ ให้เปิดการแจ้งเตือนใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/> ด้วย</translation>
+<translation id="8753483718490035722">หากต้องการให้ Brave เข้าถึงไมโครโฟน ให้เปิดไมโครโฟนใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/> ด้วย</translation>
+<translation id="1887786770086287077">ตอนนี้ตำแหน่งสำหรับอุปกรณ์เครื่องนี้ปิดอยู่ เปิดตำแหน่งได้ใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/></translation>
+<translation id="2570922361219980984">การเข้าถึงตำแหน่งสำหรับอุปกรณ์เครื่องนี้ปิดอยู่ เปิดการเข้าถึงได้ใน<ph name="BEGIN_LINK"/>การตั้งค่า Android<ph name="END_LINK"/></translation>
+<translation id="1620510694547887537">กล้องถ่ายรูป</translation>
+<translation id="3227137524299004712">ไมโครโฟน</translation>
+<translation id="1647391597548383849">เข้าถึงกล้องถ่ายรูป</translation>
+<translation id="945632385593298557">เข้าถึงไมโครโฟน</translation>
+<translation id="6612358246767739896">เนื้อหาที่ได้รับความคุ้มครอง</translation>
+<translation id="885701979325669005">พื้นที่เก็บข้อมูล</translation>
+<translation id="3198916472715691905">ข้อมูลที่จัดเก็บมี <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">เพิกถอนสิทธิ์ของอุปกรณ์</translation>
+<translation id="4962975101802056554">เพิกถอนสิทธิ์ทั้งหมดสำหรับอุปกรณ์</translation>
+<translation id="6545864417968258051">การสแกนหาบลูทูธ</translation>
+<translation id="4411535500181276704">โหมด Lite</translation>
+<translation id="7821588508402923572">การประหยัดอินเทอร์เน็ตของคุณจะแสดงที่นี่</translation>
+<translation id="2131665479022868825">ประหยัดไป <ph name="DATA"/></translation>
+<translation id="8569404424186215731">ตั้งแต่วันที่ <ph name="DATE"/></translation>
+<translation id="3252158532344029638">ในโหมด Lite เบราว์เซอร์ Brave จะโหลดหน้าเว็บได้เร็วขึ้นและใช้เน็ตน้อยลงสูงสุดถึง 60 เปอร์เซ็นต์</translation>
+<translation id="6159335304067198720">ประหยัดอินเทอร์เน็ต <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">อินเทอร์เน็ตที่ประหยัดได้</translation>
+<translation id="6111020039983847643">อินเทอร์เน็ตที่ใช้</translation>
+<translation id="7413229368719586778">วันที่เริ่มต้น <ph name="DATE"/></translation>
+<translation id="1782483593938241562">วันที่สิ้นสุด <ph name="DATE"/></translation>
+<translation id="2728754400939377704">จัดเรียงตามเว็บไซต์</translation>
+<translation id="5864174910718532887">รายละเอียด: จัดเรียงตามชื่อเว็บไซต์</translation>
+<translation id="116280672541001035">ใช้ไป</translation>
+<translation id="8349013245300336738">จัดเรียงตามปริมาณเน็ตมือถือที่ใช้</translation>
+<translation id="6378173571450987352">รายละเอียด: จัดเรียงตามปริมาณเน็ตมือถือที่ใช้</translation>
+<translation id="2631006050119455616">ประหยัดได้</translation>
+<translation id="6643649862576733715">จัดเรียงตามปริมาณเน็ตมือถือที่ประหยัดได้</translation>
+<translation id="7302081693174882195">รายละเอียด: จัดเรียงตามปริมาณเน็ตมือถือที่ประหยัดได้</translation>
+<translation id="4179980317383591987">ใช้ไปแล้ว <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">ประหยัดได้ <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">เว็บไซต์ที่เหลือ (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">อื่นๆ</translation>
+<translation id="4913161338056004800">รีเซ็ตสถิติ</translation>
+<translation id="1856325424225101786">รีเซ็ตโหมด Lite ไหม</translation>
+<translation id="3658159451045945436">การรีเซ็ตจะลบประวัติการประหยัดเน็ต รวมถึงรายการเว็บไซต์ที่เข้าชม</translation>
+<translation id="3295530008794733555">ท่องเว็บได้เร็วขึ้น ใช้เน็ตน้อยลง</translation>
+<translation id="7340390500800578919">ในโหมด Lite เบราว์เซอร์ Brave จะโหลดหน้าเว็บได้เร็วขึ้นและใช้อินเทอร์เน็ตน้อยลงสูงสุดถึง 60 เปอร์เซ็นต์ Brave จะส่งการเข้าชมเว็บของคุณไปให้ Brave Software เพื่อเพิ่มประสิทธิภาพหน้าเว็บที่คุณเข้าชม <ph name="BEGIN_LINK"/>ดูข้อมูลเพิ่มเติม<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">เปิดโหมด Lite</translation>
+<translation id="4493497663118223949">โหมด Lite เปิดอยู่</translation>
+<translation id="7559975015014302720">โหมด Lite ปิดอยู่</translation>
+<translation id="7606077192958116810">โหมด Lite เปิดอยู่ จัดการได้ในการตั้งค่า</translation>
+<translation id="4714588616299687897">ประหยัดการใช้ข้อมูลถึง 60%</translation>
+<translation id="1006927014032731288">เซิร์ฟเวอร์ของ Brave Software จะเพิ่มประสิทธิภาพหน้าเว็บที่คุณเข้าชม</translation>
+<translation id="3257320067425202300">Brave ได้ประหยัดพื้นที่ให้คุณไป <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave ได้ประหยัดพื้นที่ให้คุณไป <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">ตำแหน่งที่ดาวน์โหลด</translation>
+<translation id="7077143737582773186">การ์ด SD</translation>
+<translation id="7762668264895820836">การ์ด SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">ถามว่าจะให้บันทึกไฟล์ไว้ที่ใด</translation>
+<translation id="6192333916571137726">ดาวน์โหลดไฟล์</translation>
+<translation id="1672586136351118594">ไม่ต้องแสดงอีก</translation>
+<translation id="2650751991977523696">ดาวน์โหลดไฟล์อีกครั้งไหม</translation>
+<translation id="8664979001105139458">มีชื่อไฟล์นี้อยู่แล้ว</translation>
+<translation id="488187801263602086">เปลี่ยนชื่อไฟล์</translation>
+<translation id="5686790454216892815">ชื่อไฟล์ยาวเกินไป</translation>
+<translation id="7454641608352164238">พื้นที่ว่างไม่พอ</translation>
+<translation id="8972098258593396643">ดาวน์โหลดลงโฟลเดอร์เริ่มต้นไหม</translation>
+<translation id="804335162455518893">ไม่พบการ์ด SD</translation>
+<translation id="7475688122056506577">ไม่พบการ์ด SD ไฟล์บางไฟล์อาจหายไป</translation>
+<translation id="4198423547019359126">ไม่มีตำแหน่งการดาวน์โหลดที่ใช้ได้</translation>
+<translation id="8224471946457685718">ดาวน์โหลดบทความสำหรับคุณผ่าน Wi-Fi</translation>
+<translation id="4970824347203572753">ไม่พร้อมใช้งานในประเทศของคุณ</translation>
+<translation id="5500777121964041360">อาจไม่พร้อมใช้งานในประเทศของคุณ</translation>
+<translation id="1173894706177603556">เปลี่ยนชื่อ</translation>
+<translation id="1986685561493779662">มีชื่อนี้อยู่แล้ว</translation>
+<translation id="6441734959916820584">ชื่อยาวเกินไป</translation>
+<translation id="2923908459366352541">ชื่อไม่ถูกต้อง</translation>
+<translation id="7290209999329137901">เปลี่ยนชื่อไม่ได้</translation>
+<translation id="3334729583274622784">เปลี่ยนนามสกุลไฟล์ใช่ไหม</translation>
+<translation id="107147699690128016">หากคุณเปลี่ยนนามสกุลไฟล์ ไฟล์นั้นอาจเปิดในแอปพลิเคชันอื่นและเป็นอันตรายต่ออุปกรณ์ของคุณ</translation>
+<translation id="8541922081612557424">เกี่ยวกับ Brave</translation>
+<translation id="5311273890481188673">ลิขสิทธิ์ <ph name="YEAR"/> Brave Software LLC สงวนลิขสิทธิ์</translation>
+<translation id="1416550906796893042">เวอร์ชันของแอปพลิเคชัน</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (อัปเดตเมื่อ <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">ระบบปฏิบัติการ</translation>
+<translation id="3968054912784331254">Android เวอร์ชันนี้ไม่รองรับการอัปเดต Brave อีกต่อไปแล้ว</translation>
+<translation id="7665369617277396874">เพิ่มบัญชี</translation>
+<translation id="649070405679044769">ลงชื่อเข้าใช้ Brave Software ด้วย</translation>
+<translation id="6234515504547364178">ออกจากระบบ Brave</translation>
+<translation id="5324858694974489420">การตั้งค่าของผู้ปกครอง</translation>
+<translation id="8920114477895755567">กำลังรอรายละเอียดของผู้ปกครอง</translation>
+<translation id="5512137114520586844">บัญชีนี้ได้รับการจัดการโดย <ph name="PARENT_NAME"/></translation>
+<translation id="2956410042958133412">บัญชีนี้ได้รับการจัดการโดย <ph name="PARENT_NAME_1"/> และ <ph name="PARENT_NAME_2"/></translation>
+<translation id="8168435359814927499">เนื้อหา</translation>
+<translation id="5403644198645076998">อนุญาตเฉพาะบางไซต์</translation>
+<translation id="8641930654639604085">พยายามบล็อกไซต์สำหรับผู้ใหญ่</translation>
+<translation id="5639724618331995626">อนุญาตทุกไซต์</translation>
+<translation id="796823723482603597">สนับสนุนโดย Brave</translation>
+<translation id="6324034347079777476">ปิดใช้การซิงค์ระบบ Android อยู่</translation>
+<translation id="5127805178023152808">การซิงค์ปิดอยู่</translation>
+<translation id="7015203776128479407">ตั้งค่าการซิงค์เริ่มต้นไม่สำเร็จ การซิงค์ปิดอยู่</translation>
+<translation id="2497852260688568942">ผู้ดูแลระบบปิดใช้การซิงค์</translation>
+<translation id="9100610230175265781">ต้องระบุรหัสผ่าน</translation>
+<translation id="6108923351542677676">กำลังดำเนินการตั้งค่า…</translation>
+<translation id="4062305924942672200">ข้อมูลทางกฎหมาย</translation>
+<translation id="4256782883801055595">ใบอนุญาตโอเพนซอร์ส</translation>
+<translation id="1138681184697033370">ข้อกำหนดในการให้บริการของ Brave</translation>
+<translation id="7392539049993970338">ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัวของ Brave</translation>
+<translation id="2677748264148917807">ออก</translation>
+<translation id="5556459405103347317">โหลดใหม่</translation>
+<translation id="1623104350909869708">ป้องกันหน้าเว็บนี้จากการสร้างการโต้ตอบเพิ่มเติม</translation>
+<translation id="2968755619301702150">เครื่องมือดูใบรับรอง</translation>
+<translation id="1360432990279830238">ออกจากระบบและปิดการซิงค์ไหม</translation>
+<translation id="8581481290581777242">ล้างข้อมูล Brave ของคุณออกจากอุปกรณ์นี้ไหม</translation>
+<translation id="1318865768845061710">บุ๊กมาร์ก ประวัติการเข้าชม รหัสผ่าน และข้อมูลอื่นๆ ใน Brave จะไม่ซิงค์กับบัญชี Brave Software อีกต่อไป</translation>
+<translation id="3325020657155065477">ล้างข้อมูล Brave ของคุณออกจากอุปกรณ์นี้ด้วย</translation>
+<translation id="6136448902816743006">เนื่องจากคุณกำลังจะออกจากระบบบัญชีที่จัดการโดย <ph name="DOMAIN_NAME"/> ข้อมูลใน Brave จะถูกลบออกจากอุปกรณ์นี้ แต่จะยังคงอยู่ในบัญชี Brave Software</translation>
+<translation id="1853026300647876496">กำลังติดต่อ Brave Software อาจใช้เวลาประมาณ 1 นาที…</translation>
+<translation id="2328985652426384049">ลงชื่อเข้าใช้ไม่ได้</translation>
+<translation id="7723158744459952869">Brave Software ใช้เวลาตอบกลับนานเกินไป</translation>
+<translation id="4572422548854449519">ลงชื่อเข้าใช้บัญชีที่มีการจัดการ</translation>
+<translation id="2689656545739939160">คุณกำลังลงชื่อเข้าใช้ด้วยบัญชีที่จัดการโดย <ph name="MANAGED_DOMAIN"/> และทำให้ผู้ดูแลระบบของโดเมนควบคุมข้อมูล Brave ของคุณได้ ข้อมูลดังกล่าวจะโยงกับบัญชีนี้อย่างถาวร การออกจากระบบ Brave จะลบข้อมูลของคุณออกจากอุปกรณ์เครื่องนี้ แต่ข้อมูลจะยังจัดเก็บอยู่ในบัญชี Brave Software</translation>
+<translation id="1749561566933687563">ซิงค์บุ๊กมาร์กของคุณ</translation>
+<translation id="4242533952199664413">เปิดการตั้งค่า</translation>
+<translation id="1111673857033749125">บุ๊กมาร์กที่บันทึกไว้ในอุปกรณ์เครื่องอื่นๆ ของคุณจะปรากฏที่นี่</translation>
+<translation id="8636825310635137004">เปิดการซิงค์เพื่อรับแท็บจากอุปกรณ์เครื่องอื่นๆ ของคุณ</translation>
+<translation id="3269956123044984603">เปิด "ข้อมูลการซิงค์อัตโนมัติ" ในการตั้งค่าบัญชี Android เพื่อรับแท็บจากอุปกรณ์อื่นๆ ของคุณ</translation>
+<translation id="5157964048453367290">แท็บที่คุณเปิดไว้ใน Brave ในอุปกรณ์เครื่องอื่นๆ จะปรากฏที่นี่</translation>
+<translation id="4684427112815847243">ซิงค์ทุกอย่าง</translation>
+<translation id="2709516037105925701">ป้อนอัตโนมัติ</translation>
+<translation id="8820817407110198400">บุ๊กมาร์ก</translation>
+<translation id="1644574205037202324">ประวัติการเข้าชม</translation>
+<translation id="17513872634828108">แท็บที่เปิดอยู่</translation>
+<translation id="1320169905922104972">ใช้ข้อมูลบัตรเครดิตและที่อยู่จาก Brave Software Pay</translation>
+<translation id="6337234675334993532">การเข้ารหัส</translation>
+<translation id="6698801883190606802">จัดการข้อมูลที่ซิงค์</translation>
+<translation id="3598578758776312506">เข้ารหัสรหัสผ่านด้วยข้อมูลเข้าสู่ระบบของ Brave Software</translation>
+<translation id="7810580217418711046">เข้ารหัสลับข้อมูลที่ซิงค์ด้วยรหัสผ่าน Brave Software ตั้งแต่ <ph name="TIME"/></translation>
+<translation id="8461694314515752532">เข้ารหัสลับข้อมูลที่ซิงค์ด้วยรหัสผ่านการซิงค์ของคุณเอง</translation>
+<translation id="2996291259634659425">สร้างรหัสผ่าน</translation>
+<translation id="5713644099811900409">บัญชี Brave Software</translation>
+<translation id="8997474919031554666">การเข้ารหัสลับด้วยรหัสผ่านจะไม่รวมข้อมูลวิธีการชำระเงินและที่อยู่จาก Brave Software Pay เฉพาะผู้ที่มีรหัสผ่านของคุณเท่านั้นจึงจะอ่านข้อมูลที่เข้ารหัสได้ Brave Software จะไม่ได้รับหรือจัดเก็บรหัสผ่านนี้ คุณจะต้องรีเซ็ตการซิงค์หากลืมรหัสผ่านหรือต้องการเปลี่ยนแปลงการตั้งค่านี้ <ph name="BEGIN_LINK"/>ดูข้อมูลเพิ่มเติม<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">ข้อความรหัสผ่าน</translation>
+<translation id="7772032839648071052">ยืนยันข้อความรหัสผ่าน</translation>
+<translation id="5304593522240415983">ต้องกรอกข้อมูลในช่องนี้</translation>
+<translation id="321773570071367578">หากคุณลืมรหัสผ่านหรือต้องการเปลี่ยนการตั้งค่านี้ ให้<ph name="BEGIN_LINK"/>รีเซ็ตการซิงค์<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">รหัสผ่านไม่ตรงกัน</translation>
+<translation id="5149495116300586333">การเข้ารหัสลับด้วยรหัสผ่านจะไม่รวมข้อมูลวิธีการชำระเงินและที่อยู่จาก Brave Software Pay
+
+หากต้องการเปลี่ยนแปลงการตั้งค่านี้ ให้<ph name="BEGIN_LINK"/>รีเซ็ตการซิงค์<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">รหัสผ่านไม่ถูกต้อง</translation>
+<translation id="5414836363063783498">กำลังยืนยัน…</translation>
+<translation id="6846298663435243399">กำลังโหลด…</translation>
+<translation id="5517095782334947753">คุณมีบุ๊กมาร์ก ประวัติการเข้าชม รหัสผ่าน และการตั้งค่าอื่นๆ จาก <ph name="FROM_ACCOUNT"/></translation>
+<translation id="3928666092801078803">รวมข้อมูลของฉัน</translation>
+<translation id="688738109438487280">เพิ่มข้อมูลที่มีอยู่ลงใน <ph name="TO_ACCOUNT"/></translation>
+<translation id="806745655614357130">เก็บข้อมูลของฉันแยกต่างหาก</translation>
+<translation id="1145536944570833626">ลบข้อมูลที่มีอยู่</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> ต้องการจับคู่</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>รับความช่วยเหลือ<ph name="END_LINK"/>ระหว่างการค้นหาอุปกรณ์…</translation>
+<translation id="5817918615728894473">จับคู่</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>รับความช่วยเหลือ<ph name="END_LINK1"/>หรือ<ph name="BEGIN_LINK2"/>สแกนใหม่<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">ไม่พบอุปกรณ์ที่เข้ากันได้</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>เปิดบลูทูธ<ph name="END_LINK"/>เพื่อให้จับคู่ได้</translation>
+<translation id="998321811308652668">Brave ไม่สามารถเปิดอะแดปเตอร์บลูทูธ</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>ขอความช่วยเหลือ<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave ต้องมีสิทธิ์เข้าถึงตำแหน่งเพื่อสแกนหาอุปกรณ์ โปรด<ph name="BEGIN_LINK"/>อัปเดตสิทธิ์<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave ต้องมีสิทธิ์เข้าถึงตำแหน่งเพื่อสแกนหาอุปกรณ์ ตัวเลือกสิทธิ์เข้าถึงตำแหน่ง<ph name="BEGIN_LINK"/>สำหรับอุปกรณ์เครื่องนี้ปิดอยู่<ph name="END_LINK"/></translation>
+<translation id="2367014990350929709">Brave ต้องมีสิทธิ์เข้าถึงตำแหน่งเพื่อสแกนหาอุปกรณ์ โปรด<ph name="BEGIN_LINK1"/>อัปเดตสิทธิ์<ph name="END_LINK1"/> การเข้าถึงตำแหน่ง<ph name="BEGIN_LINK2"/>สำหรับอุปกรณ์เครื่องนี้ยังปิดอยู่<ph name="END_LINK2"/></translation>
+<translation id="1569387923882100876">อุปกรณ์ที่เชื่อมต่อ</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{ระดับความแรงของสัญญาณ: # แถบ}other{ระดับความแรงของสัญญาณ: # แถบ}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> ต้องการสแกนหาอุปกรณ์บลูทูธที่อยู่ใกล้เคียงและได้พบอุปกรณ์ต่อไปนี้</translation>
+<translation id="8368027906805972958">อุปกรณ์ที่ไม่รู้จักหรือไม่รองรับ (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">การซิงค์ไม่ทำงาน</translation>
+<translation id="1810845389119482123">ตั้งค่าการซิงค์เริ่มต้นไม่สำเร็จ</translation>
+<translation id="3235722914093408050">เปิดการตั้งค่า Android และเปิดการซิงค์ Android ใหม่เพื่อเริ่มการซิงค์ของ Brave</translation>
+<translation id="3367813778245106622">ลงชื่อเข้าใช้อีกครั้งเพื่อเริ่มซิงค์</translation>
+<translation id="974555521953189084">ป้อนรหัสผ่านเพื่อเริ่มซิงค์</translation>
+<translation id="2997266899014181325">หากต้องการเริ่มซิงค์ ให้เปิด "ซิงค์ข้อมูล Brave"</translation>
+<translation id="8260126382462817229">ลองลงชื่อเข้าใช้อีกครั้ง</translation>
+<translation id="5919204609460789179">อัปเดต <ph name="PRODUCT_NAME"/> เพื่อเริ่มซิงค์</translation>
+<translation id="397583555483684758">การซิงค์หยุดทำงานแล้ว</translation>
+<translation id="1966710179511230534">โปรดอัปเดตรายละเอียดการลงชื่อเข้าใช้ของคุณ</translation>
+<translation id="7063006564040364415">ไม่สามารถเชื่อมต่อกับเซิร์ฟเวอร์การซิงค์</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> ล้าสมัย</translation>
+<translation id="4170011742729630528">บริการนี้ยังไม่สามารถใช้ได้ โปรดลองอีกครั้งในภายหลัง</translation>
+<translation id="7947953824732555851">ยอมรับและลงชื่อเข้าใช้</translation>
+<translation id="8583805026567836021">กำลังล้างข้อมูลบัญชี</translation>
+<translation id="8310344678080805313">แท็บมาตรฐาน</translation>
+<translation id="5748802427693696783">สลับเป็นแท็บมาตรฐานแล้ว</translation>
+<translation id="7998918019931843664">เปิดแท็บที่ปิดไปแล้วขึ้นใหม่</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/> เป็นแท็บ</translation>
+<translation id="4452411734226507615">ปิดแท็บ <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">มีตัวเลือกอยู่ทางด้านล่างของหน้าจอ</translation>
+<translation id="4060598801229743805">ตัวเลือกอยู่ตรงบริเวณด้านบนของหน้าจอ</translation>
+<translation id="2810645512293415242">ลดรายละเอียดหน้าเว็บเพื่อประหยัดเน็ตมือถือและโหลดได้เร็วขึ้น</translation>
+<translation id="3985215325736559418">คุณต้องการดาวน์โหลด <ph name="FILE_NAME"/> อีกครั้งไหม</translation>
+<translation id="2450083983707403292">คุณต้องการเริ่มดาวน์โหลด <ph name="FILE_NAME"/> อีกครั้งไหม</translation>
+<translation id="7514365320538308">ดาวน์โหลด</translation>
+<translation id="545042621069398927">กำลังเพิ่มความเร็วในการดาวน์โหลด</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{กำลังดาวน์โหลดไฟล์}other{กำลังดาวน์โหลด # ไฟล์}}</translation>
+<translation id="543509235395288790">กำลังดาวน์โหลด <ph name="COUNT"/> ไฟล์ (<ph name="MEGABYTES"/>)</translation>
+<translation id="4988210275050210843">กำลังดาวน์โหลดไฟล์ (<ph name="MEGABYTES"/>)</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{การดาวน์โหลด 1 รายการเสร็จสมบูรณ์}other{การดาวน์โหลด # รายการเสร็จสมบูรณ์}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{การดาวน์โหลดล้มเหลว 1 รายการ}other{การดาวน์โหลดล้มเหลว # รายการ}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{การดาวน์โหลดที่รอดำเนินการ 1 รายการ}other{การดาวน์โหลดที่รอดำเนินการ # รายการ}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/></translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> ปุ่ม<ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">เกือบเสร็จแล้ว!</translation>
+<translation id="3960299545138990065">รีสตาร์ท Brave</translation>
+<translation id="3771001275138982843">ดาวน์โหลดอัปเดตไม่ได้</translation>
+<translation id="3888648114124182147">กำลังดาวน์โหลดอัปเดต Brave…</translation>
+<translation id="1705567146636171298">อัปเดต Brave</translation>
+<translation id="6195417478702700398">โปรดเปิดเพื่ออัปเดต Brave เพื่อให้ได้รับประสบการณ์การท่องเว็บที่ดีที่สุด</translation>
+<translation id="3512968675351418494">โปรดอัปเดต Brave เป็นเวอร์ชันล่าสุดเพื่อดูเว็บเป็นภาษาของคุณ</translation>
+<translation id="6427112570124116297">แปลเว็บ</translation>
+<translation id="1379423114029199501">อัปเดตเพื่อใช้ภาษาของคุณใน Brave เวอร์ชันล่าสุด</translation>
+<translation id="5684874026226664614">อ๊ะ หน้านี้ไม่สามารถแปลได้</translation>
+<translation id="6831043979455480757">แปลภาษา</translation>
+<translation id="1285320974508926690">ไม่ต้องแปลเว็บไซต์นี้</translation>
+<translation id="773466115871691567">แปลหน้าเว็บภาษา<ph name="SOURCE_LANGUAGE"/>ทุกครั้ง</translation>
+<translation id="1068672505746868501">ไม่ต้องแปลหน้าเว็บภาษา<ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">ภาษาเพิ่มเติม</translation>
+<translation id="290376772003165898">หน้านี้ไม่ใช่ภาษา<ph name="LANGUAGE"/>ใช่ไหม</translation>
+<translation id="4432792777822557199">จากนี้ไประบบจะแปลหน้าภาษา<ph name="SOURCE_LANGUAGE"/>เป็นภาษา<ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">ระบบจะไม่แปลหน้าเว็บภาษา<ph name="LANGUAGE"/></translation>
+<translation id="5447765697759493033">ระบบจะไม่แปลไซต์นี้</translation>
+<translation id="4880127995492972015">แปลภาษา…</translation>
+<translation id="641643625718530986">พิมพ์…</translation>
+<translation id="8909135823018751308">แชร์…</translation>
+<translation id="4996978546172906250">แชร์ผ่าน</translation>
+<translation id="6333140779060797560">แชร์ผ่าน <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">เกิดปัญหาในการพิมพ์หน้านี้ โปรดลองอีกครั้ง</translation>
+<translation id="3254409185687681395">บุ๊กมาร์กหน้านี้</translation>
+<translation id="497421865427891073">ไปข้างหน้า</translation>
+<translation id="813082847718468539">ดูข้อมูลเว็บไซต์</translation>
+<translation id="2532336938189706096">มุมมองเว็บ</translation>
+<translation id="6005538289190791541">รหัสผ่านที่แนะนำ</translation>
+<translation id="4634124774493850572">ใช้รหัสผ่าน</translation>
+<translation id="8285489906452138776">Brave ต้องการสิทธิ์เข้าถึงกล้องถ่ายรูปของคุณสำหรับไซต์นี้</translation>
+<translation id="320189792589364011">Brave ต้องการสิทธิ์เข้าถึงไมโครโฟนของคุณสำหรับไซต์นี้</translation>
+<translation id="7988136689212463100">Brave ต้องการสิทธิ์เข้าถึงไมโครโฟนและกล้องถ่ายรูปของคุณสำหรับไซต์นี้</translation>
+<translation id="4931190655840828017">Brave ต้องการสิทธิ์เข้าถึงตำแหน่งของคุณเพื่อแชร์ตำแหน่งกับไซต์นี้</translation>
+<translation id="3088191967551450609">Brave ต้องมีสิทธิ์เข้าถึงพื้นที่เก็บข้อมูลเพื่อดาวน์โหลดไฟล์</translation>
+<translation id="8942627711005830162">เปิดในหน้าต่างอื่น</translation>
+<translation id="4195643157523330669">เปิดในแท็บใหม่</translation>
+<translation id="1100066534610197918">เปิดในแท็บใหม่ในกลุ่ม</translation>
+<translation id="4860895144060829044">โทร</translation>
+<translation id="6896758677409633944">คัดลอก</translation>
+<translation id="8393700583063109961">ส่งข้อความ</translation>
+<translation id="3557336313807607643">เพิ่มในรายชื่อติดต่อ</translation>
+<translation id="4269820728363426813">คัดลอกที่อยู่ลิงก์</translation>
+<translation id="1206892813135768548">คัดลอกข้อความลิงก์</translation>
+<translation id="1204037785786432551">ดาวน์โหลดลิงก์</translation>
+<translation id="6864459304226931083">ดาวน์โหลดรูปภาพ</translation>
+<translation id="8209050860603202033">เปิดรูปภาพ</translation>
+<translation id="8073388330009372546">เปิดภาพในแท็บใหม่</translation>
+<translation id="6649642165559792194">พรีวิวรูปภาพ <ph name="BEGIN_NEW"/>ใหม่<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">โหลดภาพ</translation>
+<translation id="3845332215609790146">ค้นหาด้วย Brave Software Lens <ph name="BEGIN_NEW"/>ใหม่<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">ค้นหาภาพนี้ใน <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">แชร์รูปภาพ</translation>
+<translation id="5833984609253377421">แชร์ลิงก์</translation>
+<translation id="6475951671322991020">ดาวน์โหลดวิดีโอ</translation>
+<translation id="2317945146070194624">เปิดในแท็บใหม่ของ Brave</translation>
+<translation id="7975379999046275268">พรีวิวหน้า <ph name="BEGIN_NEW"/>ใหม่<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">กำลังรีเฟรชหน้า</translation>
+<translation id="36525718899759834">รับแอปจาก Brave Software Play Store: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">มืด</translation>
+<translation id="1807246157184219062">สว่าง</translation>
+<translation id="4056223980640387499">ซีเปีย</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">เลือกแท็บที่จะบีม</translation>
+<translation id="8719023831149562936">ไม่สามารถบีมแท็บปัจจุบัน</translation>
+<translation id="2139186145475833000">เพิ่มลงในหน้าจอหลัก</translation>
+<translation id="4616150815774728855">เปิด <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">เปิดแอปไม่ได้</translation>
+<translation id="5129038482087801250">ติดตั้งเว็บแอป</translation>
+<translation id="3789841737615482174">ติดตั้ง</translation>
+<translation id="4665282149850138822">เพิ่ม <ph name="NAME"/> ลงในหน้าแรกแล้ว</translation>
+<translation id="7333031090786104871">ยังเพิ่มไซต์ก่อนหน้าอยู่</translation>
+<translation id="1036727731225946849">กำลังเพิ่ม <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">เพิ่มในหน้าจอหลักแล้ว</translation>
+<translation id="2146738493024040262">เปิด Instant App</translation>
+<translation id="7016516562562142042">อนุญาตสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
+<translation id="6177111841848151710">ถูกบล็อกสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
+<translation id="145097072038377568">ปิดในการตั้งค่า Android</translation>
+<translation id="8007176423574883786">ปิดสำหรับอุปกรณ์นี้</translation>
+<translation id="164269334534774161">คุณกำลังดูสำเนาออฟไลน์ของหน้านี้จากวันที่ <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">หน้าเว็บออฟไลน์นี้สร้างเมื่อวันที่ <ph name="CREATION_TIME"/> และอาจแตกต่างไปจากเวอร์ชันออนไลน์</translation>
+<translation id="8840953339110955557">หน้าเว็บนี้อาจแตกต่างไปจากเวอร์ชันที่ออนไลน์</translation>
+<translation id="6405300764336705484">เนื้อหานี้มาจาก <ph name="DOMAIN_NAME"/> และนำส่งโดย Brave Software</translation>
+<translation id="1006017844123154345">เปิดแบบออนไลน์</translation>
+<translation id="3326636747541519688">หน้าเวอร์ชัน Lite ให้บริการโดย Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>โหลดหน้าต้นฉบับ<ph name="END_LINK"/>จาก <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">หากคุณเห็นข้อความนี้บ่อยๆ โปรดลองทำตาม<ph name="BEGIN_LINK"/>คำแนะนำ<ph name="END_LINK"/>เหล่านี้</translation>
+<translation id="8748850008226585750">เนื้อหาถูกซ่อนไว้</translation>
+<translation id="3810973564298564668">จัดการ</translation>
+<translation id="5199929503336119739">โปรไฟล์งาน</translation>
+<translation id="528192093759286357">ลากจากด้านบน แล้วแตะปุ่มกลับเพื่อออกจากโหมดเต็มหน้าจอ</translation>
+<translation id="2836148919159985482">แตะปุ่มกลับเพื่อออกจากโหมดเต็มหน้าจอ</translation>
+<translation id="3967822245660637423">ดาวน์โหลดเสร็จสมบูรณ์</translation>
+<translation id="2434158240863470628">ดาวน์โหลดเสร็จสมบูรณ์ <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">การดาวน์โหลดล้มเหลว</translation>
+<translation id="1384959399684842514">หยุดดาวน์โหลดไว้ชั่วคราว</translation>
+<translation id="1671236975893690980">การดาวน์โหลดรอดำเนินการ…</translation>
+<translation id="5561549206367097665">กำลังรอเครือข่าย…</translation>
+<translation id="5864419784173784555">กำลังรอการดาวน์โหลดรายการอื่น…</translation>
+<translation id="6461962085415701688">เปิดไฟล์ไม่ได้</translation>
+<translation id="1178581264944972037">หยุดชั่วคราว</translation>
+<translation id="8200772114523450471">ทำต่อ</translation>
+<translation id="1409879593029778104">ระบบป้องกันการดาวน์โหลด <ph name="FILE_NAME"/> เพราะมีไฟล์นี้อยู่แล้ว</translation>
+<translation id="3387650086002190359">การดาวน์โหลด <ph name="FILE_NAME"/> ล้มเหลวเพราะเกิดข้อผิดพลาดกับระบบไฟล์</translation>
+<translation id="6482749332252372425">การดาวน์โหลด <ph name="FILE_NAME"/> ล้มเหลวเพราะพื้นที่เก็บข้อมูลไม่เพียงพอ</translation>
+<translation id="7619072057915878432">การดาวน์โหลด <ph name="FILE_NAME"/> ล้มเหลวเพราะเครือข่ายขัดข้อง</translation>
+<translation id="1477626028522505441">การดาวน์โหลด <ph name="FILE_NAME"/> ล้มเหลวเพราะเซิร์ฟเวอร์มีปัญหา</translation>
+<translation id="3692944402865947621">ดาวน์โหลด <ph name="FILE_NAME"/> ไม่สำเร็จเนื่องจากเข้าถึงตำแหน่งที่เก็บข้อมูลไม่ได้</translation>
+<translation id="604996488070107836">การดาวน์โหลด <ph name="FILE_NAME"/> ล้มเหลวเนื่องจากข้อผิดพลาดที่ไม่รู้จัก</translation>
+<translation id="6738867403308150051">กำลังดาวน์โหลด…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">ดาวน์โหลดแล้ว <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">ดาวน์โหลดแล้ว <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">ดาวน์โหลดแล้ว <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">เหลืออีก 1 ไฟล์</translation>
+<translation id="8186512483418048923">เหลืออีก <ph name="FILES"/> ไฟล์</translation>
+<translation id="757855969265046257">{FILES,plural, =1{ดาวน์โหลดแล้ว <ph name="FILES_DOWNLOADED_ONE"/> ไฟล์}other{ดาวน์โหลดแล้ว <ph name="FILES_DOWNLOADED_MANY"/> ไฟล์}}</translation>
+<translation id="8037750541064988519">เหลือ <ph name="DAYS"/> วัน</translation>
+<translation id="8190358571722158785">เหลือ 1 วัน</translation>
+<translation id="60923314841986378">เหลือ <ph name="HOURS"/> ชั่วโมง</translation>
+<translation id="510275257476243843">เหลือ 1 ชั่วโมง</translation>
+<translation id="970715775301869095">เหลือ <ph name="MINUTES"/> นาที</translation>
+<translation id="3236059992281584593">เหลือ 1 นาที</translation>
+<translation id="2777555524387840389">เหลือ <ph name="SECONDS"/> วิ</translation>
+<translation id="2781151931089541271">เหลือ 1 วิ</translation>
+<translation id="3303414029551471755">ต้องการดำเนินการดาวน์โหลดเนื้อหานี้ไหม</translation>
+<translation id="8617240290563765734">ต้องการเปิด URL แนะนำซึ่งระบุอยู่ในเนื้อหาที่ดาวน์โหลดไหม</translation>
+<translation id="1373696734384179344">หน่วยความจำไม่เพียงพอที่จะดาวน์โหลดเนื้อหาที่เลือก</translation>
+<translation id="5271967389191913893">อุปกรณ์ไม่สามารถเปิดเนื้อหาที่จะดาวน์โหลดได้</translation>
+<translation id="883806473910249246">เกิดข้อผิดพลาดขณะดาวน์โหลดเนื้อหา</translation>
+<translation id="5626134646977739690">ชื่อ:</translation>
+<translation id="7963646190083259054">ผู้ขาย:</translation>
+<translation id="3414952576877147120">ขนาด:</translation>
+<translation id="7375125077091615385">ประเภท:</translation>
+<translation id="5765780083710877561">คำอธิบาย:</translation>
+<translation id="4881695831933465202">เปิด</translation>
+<translation id="3542235761944717775">ใช้ได้ <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747">สามารถใช้งานได้ <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268">ว่าง <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">ใช้ไป <ph name="SPACE_USED"/> จาก <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">ทั้งหมด</translation>
+<translation id="4988526792673242964">หน้า</translation>
+<translation id="3810838688059735925">วิดีโอ</translation>
+<translation id="3616113530831147358">เสียง</translation>
+<translation id="9219103736887031265">ภาพ</translation>
+<translation id="8250920743982581267">เอกสาร</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# ไฟล์}other{# ไฟล์}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# ภาพ}other{# ภาพ}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{วิดีโอ # รายการ}other{วิดีโอ # รายการ}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{ไฟล์เสียง # ไฟล์}other{ไฟล์เสียง # ไฟล์}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# หน้า}other{# หน้า}}</translation>
+<translation id="5456381639095306749">ดาวน์โหลดหน้า</translation>
+<translation id="2394602618534698961">ไฟล์ที่คุณดาวน์โหลดจะแสดงที่นี่</translation>
+<translation id="7810647596859435254">เปิดด้วย…</translation>
+<translation id="5655963694829536461">ค้นหาการดาวน์โหลด</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">ไฟล์ของฉัน</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">บทความจะแสดงที่นี่ ซึ่งคุณจะอ่านได้แม้ในขณะออฟไลน์</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# ชม.}other{# ชม.}}</translation>
+<translation id="5853623416121554550">หยุดชั่วคราว</translation>
+<translation id="8965591936373831584">รอดำเนินการ</translation>
+<translation id="2779651927720337254">ล้มเหลว</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">เมื่อสักครู่</translation>
+<translation id="4000212216660919741">หน้าแรกออฟไลน์</translation>
+<translation id="9133397713400217035">สำรวจแบบออฟไลน์</translation>
+<translation id="968900484120156207">หน้าที่คุณเข้าชมจะปรากฏที่นี่</translation>
+<translation id="7882131421121961860">ไม่พบประวัติการเข้าชม</translation>
+<translation id="3549657413697417275">ค้นหาประวัติการเข้าชม</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">ดด</translation>
+<translation id="605721222689873409">ปป</translation>
+<translation id="724102042129299115">ประสบการณ์กับ First Run บน Brave</translation>
+<translation id="2700285883409956633">การใช้แอปพลิเคชันนี้แสดงว่าคุณยอมรับ<ph name="BEGIN_LINK1"/>ข้อกำหนดในการให้บริการ<ph name="END_LINK1"/>และ<ph name="BEGIN_LINK2"/>ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2"/>ของ Brave</translation>
+<translation id="1640714894372474981">การใช้แอปพลิเคชันนี้หมายความว่าคุณยอมรับ <ph name="BEGIN_LINK1"/>ข้อกำหนดในการให้บริการ<ph name="END_LINK1"/> และ <ph name="BEGIN_LINK2"/>ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2"/> ของ Brave รวมถึง <ph name="BEGIN_LINK3"/>ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัวสำหรับบัญชี Brave Software ที่จัดการด้วย Family Link<ph name="END_LINK3"/></translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> จะเปิดขึ้นใน Brave การดำเนินการต่อแสดงว่าคุณยอมรับ<ph name="BEGIN_LINK1"/>ข้อกำหนดในการให้บริการ<ph name="END_LINK1"/>และ<ph name="BEGIN_LINK2"/>ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2"/>ของ Brave</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> จะเปิดขึ้นใน Brave การดำเนินการต่อแสดงว่าคุณยอมรับ<ph name="BEGIN_LINK1"/>ข้อกำหนดในการให้บริการ<ph name="END_LINK1"/>และ<ph name="BEGIN_LINK2"/>ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2"/>ของ Brave รวมถึง<ph name="BEGIN_LINK3"/>ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัวสำหรับบัญชี Brave Software ที่จัดการด้วย Family Link<ph name="END_LINK3"/></translation>
+<translation id="673197144963363525">ช่วยให้ Brave ทำงานได้ดีขึ้นโดยส่งสถิติการใช้งานและรายงานข้อขัดข้องให้กับ Brave Software</translation>
+<translation id="3518985090088779359">ยอมรับและทำต่อ</translation>
+<translation id="7207456302801184289">ยินดีต้อนรับสู่ Brave</translation>
+<translation id="704822250101715322">กำลังรอให้บริการ Brave Software Play อัปเดตเสร็จสิ้น</translation>
+<translation id="1231733316453485619">เปิดการซิงค์ไหม</translation>
+<translation id="5132942445612118989">ซิงค์รหัสผ่าน ประวัติการเข้าชม และอื่นๆ ในอุปกรณ์ทุกเครื่อง</translation>
+<translation id="5736731321935944068">Brave Software อาจใช้ประวัติการเข้าชมเพื่อปรับเปลี่ยน Search, โฆษณา และบริการอื่นๆ ของ Brave Software ให้เข้ากับคุณ</translation>
+<translation id="4013614219085422040">Brave Software อาจใช้ประวัติการเข้าชมเพื่อปรับเปลี่ยน Search และบริการอื่นๆ ของ Brave Software ให้เข้ากับคุณ</translation>
+<translation id="5581519193887989363">คุณเลือกสิ่งที่ต้องการซิงค์ได้เสมอใน<ph name="BEGIN_LINK1"/>การตั้งค่า<ph name="END_LINK1"/></translation>
+<translation id="741204030948306876">ได้สิ ตกลง</translation>
+<translation id="2410754283952462441">เลือกบัญชี</translation>
+<translation id="2227444325776770048">ดำเนินการต่อในชื่อ <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> ไม่ใช่บัญชีที่ฉันจะใช้</translation>
+<translation id="8109613176066109935">เปิดการซิงค์เพื่อรับบุ๊กมาร์กในอุปกรณ์ทุกเครื่องของคุณ</translation>
+<translation id="2818669890320396765">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อรับบุ๊กมาร์กในอุปกรณ์ทุกเครื่องของคุณ</translation>
+<translation id="6003646045106347985">เปิดการซิงค์เพื่อรับคำแนะนำเนื้อหาที่ปรับเปลี่ยนในแบบของคุณจาก Brave Software</translation>
+<translation id="8494430740943879273">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อรับคำแนะนำเนื้อหาที่ปรับเปลี่ยนในแบบของคุณจาก Brave Software</translation>
+<translation id="5862731021271217234">เปิดการซิงค์เพื่อรับแท็บจากอุปกรณ์เครื่องอื่นๆ ของคุณ</translation>
+<translation id="3568688522516854065">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อรับแท็บจากอุปกรณ์เครื่องอื่นๆ ของคุณ</translation>
+<translation id="1208340532756947324">เปิดการซิงค์เพื่อซิงค์และปรับเปลี่ยนข้อมูลตามความต้องการในอุปกรณ์ทุกเครื่อง</translation>
+<translation id="4472118726404937099">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อซิงค์และปรับเปลี่ยนข้อมูลตามความต้องการในอุปกรณ์ทุกเครื่อง</translation>
+<translation id="2426805022920575512">เลือกบัญชีอื่น</translation>
+<translation id="6790428901817661496">เล่น</translation>
+<translation id="1272079795634619415">หยุด</translation>
+<translation id="2874939134665556319">แทร็กก่อนหน้า</translation>
+<translation id="4046123991198612571">แทร็กถัดไป</translation>
+<translation id="3859306556332390985">ไปข้างหน้า</translation>
+<translation id="8441146129660941386">ย้อนกลับ</translation>
+<translation id="6706288973712894588">คุณกำลังออฟไลน์อยู่\n<ph name="BEGIN_LINK"/>สำรวจฟีดออฟไลน์<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">แท็บล่าสุด</translation>
+<translation id="8497726226069778601">ที่นี่ยังไม่มีอะไรให้ดู… เลย</translation>
+<translation id="5423934151118863508">หน้าที่มีการเข้าชมมากที่สุดของคุณจะปรากฏที่นี่</translation>
+<translation id="6127379762771434464">นำรายการออกแล้ว</translation>
+<translation id="4605958867780575332">รายการที่นำออก: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">อุปกรณ์อื่นๆ</translation>
+<translation id="4738836084190194332">ซิงค์ครั้งล่าสุด: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# นาทีที่ผ่านมา}other{# นาทีที่ผ่านมา}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# ชั่วโมงที่ผ่านมา}other{# ชั่วโมงที่ผ่านมา}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# วันที่ผ่านมา}other{# วันที่ผ่านมา}}</translation>
+<translation id="2762000892062317888">เมื่อสักครู่</translation>
+<translation id="1407135791313364759">เปิดทั้งหมด</translation>
+<translation id="1209206284964581585">ซ่อนไปก่อน</translation>
+<translation id="129553762522093515">เพิ่งปิด</translation>
+<translation id="8413126021676339697">แสดงประวัติการเข้าชมทั้งหมด</translation>
+<translation id="7876243839304621966">ลบทั้งหมด</translation>
+<translation id="8487700953926739672">ใช้งานแบบออฟไลน์ได้</translation>
+<translation id="5224771365102442243">มีวิดีโอ</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>ดูข้อมูลเพิ่มเติม<ph name="END_LINK"/>เกี่ยวกับเนื้อหาที่แนะนำ</translation>
+<translation id="7542481630195938534">รับคำแนะนำไม่ได้</translation>
+<translation id="5013696553129441713">ไม่มีคำแนะนำใหม่</translation>
+<translation id="1736419249208073774">สำรวจ</translation>
+<translation id="7444811645081526538">หมวดหมู่อื่นๆ</translation>
+<translation id="6709133671862442373">ข่าวสาร</translation>
+<translation id="1264974993859112054">กีฬา</translation>
+<translation id="9139318394846604261">ช็อปปิ้ง</translation>
+<translation id="3912508018559818924">กำลังหาข้อมูลที่ดีที่สุดจากเว็บ…</translation>
+<translation id="526421993248218238">โหลดหน้านี้ไม่ได้</translation>
+<translation id="614940544461990577">ลอง:</translation>
+<translation id="3288003805934695103">โหลดหน้าใหม่</translation>
+<translation id="2353636109065292463">ตรวจสอบการเชื่อมต่ออินเทอร์เน็ต</translation>
+<translation id="2858138569776157458">เว็บไซต์อันดับสูงสุด</translation>
+<translation id="8364299278605033898">ดูเว็บไซต์ยอดนิยม</translation>
+<translation id="1171770572613082465">ดูเว็บไซต์ยอดนิยมโดยการแตะปุ่ม "เว็บไซต์อันดับสูงสุด"</translation>
+<translation id="5233638681132016545">แท็บใหม่</translation>
+<translation id="4521874409998847950">จาก <ph name="PUBLISHER_ORIGIN"/> - <ph name="BEGIN_DEEMPHASIZED"/>แสดงโดย Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">มีเวอร์ชันใหม่กว่าให้ใช้งาน</translation>
+<translation id="4058091506841967397">อัปเดต Brave ไม่ได้</translation>
+<translation id="6316139424528454185">ไม่รองรับ Android เวอร์ชันนี้</translation>
+<translation id="6989267951144302301">ดาวน์โหลดไม่ได้</translation>
+<translation id="624789221780392884">พร้อมอัปเดต</translation>
+<translation id="1549000191223877751">ย้ายไปยังหน้าต่างอื่น</translation>
+<translation id="7481312909269577407">ส่งต่อ</translation>
+<translation id="4084682180776658562">บุ๊กมาร์ก</translation>
+<translation id="6437478888915024427">ข้อมูลหน้าเว็บ</translation>
+<translation id="7180611975245234373">รีเฟรช</translation>
+<translation id="4913169188695071480">หยุดรีเฟรช</translation>
+<translation id="1829244130665387512">ค้นหาในหน้าเว็บ</translation>
+<translation id="6593061639179217415">เว็บไซต์เวอร์ชันเดสก์ท็อป</translation>
+<translation id="9063523880881406963">ปิดการขอเว็บไซต์เดสก์ท็อป</translation>
+<translation id="2038563949887743358">เปิดการขอเว็บไซต์เดสก์ท็อป</translation>
+<translation id="2433507940547922241">ลักษณะที่ปรากฏ</translation>
+<translation id="983192555821071799">ปิดแท็บทั้งหมด</translation>
+<translation id="1310482092992808703">จับกลุ่มแท็บ</translation>
+<translation id="7725024127233776428">หน้าที่คุณบุ๊กมาร์กไว้จะปรากฏที่นี่</translation>
+<translation id="4404568932422911380">ไม่มีบุ๊กมาร์ก</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{บุ๊กมาร์ก <ph name="BOOKMARKS_COUNT_ONE"/> รายการ}other{บุ๊กมาร์ก <ph name="BOOKMARKS_COUNT_MANY"/> รายการ}}</translation>
+<translation id="3739899004075612870">บุ๊กมาร์กไว้ใน <ph name="PRODUCT_NAME"/> แล้ว</translation>
+<translation id="3207960819495026254">บุ๊กมาร์กแล้ว</translation>
+<translation id="4452548195519783679">เพิ่มบุ๊กมาร์กไปยัง <ph name="FOLDER_NAME"/> แล้ว</translation>
+<translation id="8063895661287329888">เพิ่มบุ๊กมาร์กไม่สำเร็จ</translation>
+<translation id="2842985007712546952">โฟลเดอร์ระดับบนสุด</translation>
+<translation id="9065203028668620118">แก้ไข</translation>
+<translation id="4405224443901389797">ย้ายไปที่…</translation>
+<translation id="5170568018924773124">แสดงในโฟลเดอร์</translation>
+<translation id="8035133914807600019">โฟลเดอร์ใหม่…</translation>
+<translation id="4532845899244822526">เลือกโฟลเดอร์</translation>
+<translation id="6627583120233659107">แก้ไขโฟลเดอร์</translation>
+<translation id="1197267115302279827">ย้ายบุ๊กมาร์ก</translation>
+<translation id="6963766334940102469">ลบบุ๊กมาร์ก</translation>
+<translation id="4351244548802238354">ปิดหน้าต่างโต้ตอบ</translation>
+<translation id="451872707440238414">ค้นหาบุ๊กมาร์ก</translation>
+<translation id="8901170036886848654">ไม่พบบุ๊กมาร์ก</translation>
+<translation id="6404511346730675251">แก้ไขบุ๊กมาร์ก</translation>
+<translation id="3894427358181296146">เพิ่มโฟลเดอร์</translation>
+<translation id="5327248766486351172">ชื่อ</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">โฟลเดอร์</translation>
+<translation id="5161254044473106830">ต้องระบุชื่อ</translation>
+<translation id="2996809686854298943">ต้องระบุ URL</translation>
+<translation id="2536728043171574184">ดูสำเนาแบบออฟไลน์ของหน้านี้</translation>
+<translation id="4698034686595694889">ดูแบบออฟไลน์ใน <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> และเว็บไซต์อื่นๆ</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave จะโหลดหน้าเว็บเมื่อพร้อม}other{Brave จะโหลดหน้าเว็บเมื่อพร้อม}}</translation>
+<translation id="6811034713472274749">พร้อมดูหน้าเว็บแล้ว</translation>
+<translation id="4561979708150884304">ไม่มีการเชื่อมต่อ</translation>
+<translation id="8274165955039650276">ดูการดาวน์โหลด</translation>
+<translation id="2082238445998314030">ผลลัพธ์ <ph name="RESULT_NUMBER"/> จาก <ph name="TOTAL_RESULTS"/> รายการ</translation>
+<translation id="4943872375798546930">ไม่มีผลการค้นหา</translation>
+<translation id="981121421437150478">ออฟไลน์</translation>
+<translation id="3298243779924642547">Lite</translation>
+<translation id="393697183122708255">ไม่มีการเปิดใช้การค้นหาด้วยเสียง</translation>
+<translation id="7191430249889272776">แท็บเปิดในพื้นหลัง</translation>
+<translation id="8445059357334030806">เปิดใน Brave</translation>
+<translation id="4720023427747327413">เปิดใน <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">เปิดในเบราว์เซอร์</translation>
+<translation id="1113597929977215864">แสดง "มุมมองอย่างง่าย"</translation>
+<translation id="1513352483775369820">บุ๊กมาร์กและประวัติเว็บ</translation>
+<translation id="4939482511480190003">ช่วยปรับปรุง Brave ด้วยการ<ph name="BEGIN_LINK"/>ตอบแบบสำรวจ<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">ย้อนกลับ</translation>
+<translation id="5596627076506792578">ตัวเลือกเพิ่มเติม</translation>
+<translation id="3522247891732774234">มีการอัปเดตให้บริการ ตัวเลือกเพิ่มเติม</translation>
+<translation id="6773423637732432200">อัปเดต Brave ไม่ได้ ตัวเลือกอื่นๆ</translation>
+<translation id="3328801116991980348">ข้อมูลไซต์</translation>
+<translation id="5391532827096253100">การเชื่อมต่อกับเว็บไซต์นี้ไม่ปลอดภัย ข้อมูลเว็บไซต์</translation>
+<translation id="6206551242102657620">การเชื่อมต่อปลอดภัย ข้อมูลเว็บไซต์</translation>
+<translation id="6963642900430330478">หน้านี้อันตราย ข้อมูลเว็บไซต์</translation>
+<translation id="9070377983101773829">เริ่มค้นหาด้วยเสียง</translation>
+<translation id="8676374126336081632">ล้างข้อมูลที่ป้อน</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{เปิดแท็บไว้ <ph name="OPEN_TABS_ONE"/> แท็บ แตะเพื่อเปลี่ยนแท็บ}other{เปิดแท็บไว้ <ph name="OPEN_TABS_MANY"/> แท็บ แตะเพื่อเปลี่ยนแท็บ}}</translation>
+<translation id="2369533728426058518">แท็บที่เปิดอยู่</translation>
+<translation id="7071521146534760487">จัดการบัญชี</translation>
+<translation id="932327136139879170">หน้าแรก</translation>
+<translation id="2707726405694321444">รีเฟรชหน้า</translation>
+<translation id="2891154217021530873">หยุดการโหลดหน้า</translation>
+<translation id="6710213216561001401">ก่อนหน้า</translation>
+<translation id="6659594942844771486">แท็บ</translation>
+<translation id="1933845786846280168">แท็บที่เลือก</translation>
+<translation id="2268044343513325586">ปรับแต่ง</translation>
+<translation id="7846076177841592234">ยกเลิกการเลือก</translation>
+<translation id="7087918508125750058">เลือกไว้ <ph name="ITEM_COUNT"/> รายการ ตัวเลือกอยู่ตรงบริเวณด้านบนของหน้าจอ</translation>
+<translation id="7250468141469952378">เลือกไว้ <ph name="ITEM_COUNT"/> รายการ</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{แชร์ 1 รายการที่เลือก}other{แชร์ # รายการที่เลือก}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{นำ 1 รายการที่เลือกออก}other{นำ # รายการที่เลือกออก}}</translation>
+<translation id="1283039547216852943">แตะเพื่อขยาย</translation>
+<translation id="5962718611393537961">แตะเพื่อยุบ</translation>
+<translation id="8076492880354921740">แท็บ</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{เลือก 1 รายการ}other{เลือก # รายการ}}</translation>
+<translation id="6818926723028410516">เลือกรายการ</translation>
+<translation id="4797039098279997504">แตะเพื่อกลับไปยัง <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">แตะเพื่อไปที่เว็บไซต์</translation>
+<translation id="429312253194641664">เว็บไซต์กำลังเล่นสื่อ</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> กำลังแชร์หน้าจอของคุณ</translation>
+<translation id="8833831881926404480">มีเว็บไซต์กำลังแชร์หน้าจอของคุณ</translation>
+<translation id="9086455579313502267">ไม่สามารถเข้าถึงเครือข่าย</translation>
+<translation id="938850635132480979">ข้อผิดพลาด: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">เปิดใน <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">เปิดในแอปแผนที่</translation>
+<translation id="7698359219371678927">สร้างอีเมลใน <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">สร้างอีเมล</translation>
+<translation id="5665379678064389456">สร้างกิจกรรมใน <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">สร้างกิจกรรม</translation>
+<translation id="2111511281910874386">ไปที่หน้า</translation>
+<translation id="3988466920954086464">ดูผลการค้นหาทันใจในแผงนี้</translation>
+<translation id="2744248271121720757">แตะคำเพื่อค้นหาทันทีหรือดูการทำงานที่เกี่ยวข้อง</translation>
+<translation id="9155898266292537608">หรือคุณจะค้นหาด้วยการแตะอย่างรวดเร็วที่คำๆ หนึ่งก็ได้เช่นกัน</translation>
+<translation id="3232754137068452469">เว็บแอป</translation>
+<translation id="1430915738399379752">พิมพ์</translation>
+<translation id="3775705724665058594">ส่งไปยังอุปกรณ์</translation>
+<translation id="6364438453358674297">ต้องการนำคำแนะนำออกจากประวัติการเข้าชมใช่ไหม</translation>
+<translation id="213279576345780926">ปิด <ph name="TAB_TITLE"/> แล้ว</translation>
+<translation id="6850830437481525139">ปิดแล้ว <ph name="TAB_COUNT"/> แท็บ</translation>
+<translation id="3211426585530211793">ลบ <ph name="ITEM_TITLE"/> แล้ว</translation>
+<translation id="4663756553811254707">ลบบุ๊กมาร์ก <ph name="NUMBER_OF_BOOKMARKS"/> รายการแล้ว</translation>
+<translation id="3819178904835489326">ลบการดาวน์โหลด <ph name="NUMBER_OF_DOWNLOADS"/> รายการแล้ว</translation>
+<translation id="1248710015876067820">อินสแตนซ์ของ Brave เกินจำนวนที่สนับสนุน</translation>
+<translation id="4259722352634471385">มีการบล็อกการนำทาง: <ph name="URL"/></translation>
+<translation id="8959122750345127698">ไม่สามารถเข้าถึงการนำทางได้: <ph name="URL"/></translation>
+<translation id="5210365745912300556">ปิดแท็บ</translation>
+<translation id="7772375229873196092">ปิด <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">ประวัติการนำทาง</translation>
+<translation id="9169507124922466868">ประวัติการนำทางเปิดอยู่ครึ่งเดียว</translation>
+<translation id="1327257854815634930">ประวัติการนำทางเปิดอยู่</translation>
+<translation id="8788265440806329501">ประวัติการนำทางปิดอยู่</translation>
+<translation id="7482656565088326534">แท็บแสดงตัวอย่าง</translation>
+<translation id="8427875596167638501">แท็บแสดงตัวอย่างเปิดอยู่ครึ่งเดียว</translation>
+<translation id="9102803872260866941">แท็บแสดงตัวอย่างเปิดอยู่</translation>
+<translation id="2942036813789421260">แท็บแสดงตัวอย่างปิดอยู่</translation>
+<translation id="6355102470683871794">พื้นที่เก็บข้อมูล Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">ล้างพื้นที่เก็บข้อมูลเว็บไซต์ไหม</translation>
+<translation id="9205995714227143200">พื้นที่เก็บข้อมูลเว็บไซต์ที่ Brave คิดว่าไม่สำคัญ (เช่น เว็บไซต์ที่ไม่มีการตั้งค่าที่บันทึกไว้หรือที่คุณไม่ได้เข้าชมบ่อยครั้ง)</translation>
+<translation id="3997476611815694295">พื้นที่เก็บข้อมูลที่ไม่สำคัญ</translation>
+<translation id="8493948351860045254">เพิ่มพื้นที่ว่าง</translation>
+<translation id="2324920234469020158">การดำเนินการนี้จะล้างคุกกี้ แคช และข้อมูลอื่นๆ ของเว็บไซต์ที่ Brave คิดว่าไม่สำคัญ</translation>
+<translation id="5447201525962359567">พื้นที่เก็บข้อมูลเว็บไซต์ทั้งหมด รวมถึงคุกกี้และข้อมูลอื่นๆ ที่เก็บไว้ในเครื่อง</translation>
+<translation id="1376578503827013741">กำลังประมวลผล…</translation>
+<translation id="583281660410589416">ไม่รู้จัก</translation>
+<translation id="2323763861024343754">พื้นที่เก็บข้อมูลเว็บไซต์</translation>
+<translation id="3587672679800759167">ข้อมูลทั้งหมดที่ Brave ใช้ รวมถึงบัญชี บุ๊กมาร์ก และการตั้งค่าที่บันทึกไว้</translation>
+<translation id="6545017243486555795">ล้างข้อมูลทั้งหมด</translation>
+<translation id="4095146165863963773">ลบข้อมูลแอปไหม</translation>
+<translation id="53119194224775367">ระบบจะลบข้อมูลแอปทั้งหมดของ Brave อย่างถาวร ซึ่งรวมถึงไฟล์ทั้งหมด การตั้งค่า บัญชี ฐานข้อมูล และอื่นๆ</translation>
+<translation id="5307446750509046227">ล้างพื้นที่เก็บข้อมูลเว็บไซต์</translation>
+<translation id="300526633675317032">การดำเนินการนี้จะล้างพื้นที่เก็บข้อมูลเว็บไซต์ทั้ง <ph name="SIZE_IN_KB"/></translation>
+<translation id="8068648041423924542">เลือกใบรับรองไม่ได้</translation>
+<translation id="2315043854645842844">ระบบปฏิบัติการไม่สนับสนุนการเลือกใบรับรองฝั่งลูกค้า</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> ต้องการเชื่อมต่อ</translation>
+<translation id="5308380583665731573">เชื่อมต่อ</translation>
+<translation id="868929229000858085">ค้นหารายชื่อติดต่อ</translation>
+<translation id="1919950603503897840">เลือกรายชื่อติดต่อ</translation>
+<translation id="7986741934819883144">เลือกรายชื่อติดต่อ</translation>
+<translation id="3333961966071413176">รายชื่อติดต่อทั้งหมด</translation>
+<translation id="4994033804516042629">ไม่พบรายชื่อติดต่อ</translation>
+<translation id="5403592356182871684">ชื่อ</translation>
+<translation id="2717722538473713889">อีเมล</translation>
+<translation id="381841723434055211">หมายเลขโทรศัพท์</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(อีก 1 รายการ)}other{(อีก # รายการ)}}</translation>
+<translation id="5197729504361054390">ระบบจะแชร์รายชื่อติดต่อที่คุณเลือกกับ <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/></translation>
+<translation id="1779089405699405702">ตัวถอดรหัสรูปภาพ</translation>
+<translation id="8067883171444229417">เล่นวิดีโอ</translation>
+<translation id="6560414384669816528">ค้นหาด้วย Sogou</translation>
+<translation id="5406914950576900927">Brave สามารถใช้ <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> สำหรับการค้นหาในประเทศจีน คุณสามารถเปลี่ยนเครื่องมือค้นหาเริ่มต้นนี้ได้ใน<ph name="BEGIN_LINK"/>การตั้งค่า<ph name="END_LINK"/></translation>
+<translation id="6456271171669383967">ใช้ Brave Software ต่อ</translation>
+<translation id="4384468725000734951">กำลังใช้ Sogou ในการค้นหา</translation>
+<translation id="6103327872225198548">กำลังใช้ Brave Software ในการค้นหา</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">แอปนี้กำลังทำงานใน Brave</translation>
+<translation id="6143689084714664628">กำลังทำงานใน Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> มีข้อมูลอยู่ใน Brave ด้วย</translation>
+<translation id="2734140769649165081">คุณล้างข้อมูลได้ในการตั้งค่า Brave</translation>
+<translation id="8232956427053453090">เก็บข้อมูลไว้</translation>
+<translation id="4298388696830689168">เว็บไซต์ที่ลิงก์</translation>
+<translation id="5763514718066511291">แตะเพื่อคัดลอก URL สำหรับแอปนี้</translation>
+<translation id="6496823230996795692">โปรดเชื่อมต่ออินเทอร์เน็ตเพื่อใช้ <ph name="APP_NAME"/> เป็นครั้งแรก</translation>
+<translation id="751961395872307827">เชื่อมต่อเว็บไซต์ไม่ได้</translation>
+<translation id="4878404682131129617">สร้างช่องทางผ่านพร็อกซีเซิร์ฟเวอร์ไม่ได้</translation>
+<translation id="4749960740855309258">เปิดแท็บใหม่</translation>
+<translation id="8788968922598763114">เปิดแท็บที่เพิ่งปิดอีกครั้ง</translation>
+<translation id="7929962904089429003">เปิดเมนู</translation>
+<translation id="6039379616847168523">ข้ามไปยังแท็บถัดไป</translation>
+<translation id="5210286577605176222">ข้ามไปยังแท็บก่อนหน้า</translation>
+<translation id="124678866338384709">ปิดแท็บปัจจุบัน</translation>
+<translation id="3714981814255182093">เปิดแถบค้นหา</translation>
+<translation id="5441522332038954058">ข้ามไปยังแถบที่อยู่เว็บ</translation>
+<translation id="3398320232533725830">เปิดตัวจัดการบุ๊กมาร์ก</translation>
+<translation id="6583199322650523874">บุ๊กมาร์กหน้าปัจจุบัน</translation>
+<translation id="8489271220582375723">เปิดหน้าประวัติการเข้าชม</translation>
+<translation id="4837753911714442426">เปิดตัวเลือกในการพิมพ์หน้า</translation>
+<translation id="5726692708398506830">ขยายรายละเอียดทั้งหมดบนหน้า</translation>
+<translation id="3259831549858767975">ย่อรายละเอียดทั้งหมดบนหน้า</translation>
+<translation id="8015452622527143194">เปลี่ยนทุกอย่างบนหน้ากลับไปเป็นขนาดเริ่มต้น</translation>
+<translation id="3443221991560634068">โหลดหน้าปัจจุบันอีกครั้ง</translation>
+<translation id="123724288017357924">โหลดหน้าปัจจุบันซ้ำ โดยไม่คำนึงถึงเนื้อหาที่แคชไว้</translation>
+<translation id="305870044889644984">เปิดศูนย์ช่วยเหลือของ Brave ในแท็บใหม่</translation>
+<translation id="3166827708714933426">แป้นพิมพ์ลัดสำหรับแท็บและหน้าต่าง</translation>
+<translation id="3169981355900570544">แป้นพิมพ์ลัดสำหรับฟีเจอร์ของ Brave Software Brave</translation>
+<translation id="4558311620361989323">แป้นพิมพ์ลัดสำหรับหน้าเว็บ</translation>
+<translation id="1908301351964700579">Brave ยังคงเตรียมความพร้อมสำหรับ VR อยู่ รีสตาร์ท Brave ภายหลัง</translation>
+<translation id="8970887620466824814">มีบางอย่างผิดพลาด</translation>
+<translation id="1875543012935658554">เปิด Brave อีกครั้ง</translation>
+<translation id="79859296434321399">ติดตั้ง ARCore เพื่อดูเนื้อหา Augmented Reality</translation>
+<translation id="8558485628462305855">อัปเดต ARCore เพื่อดูเนื้อหา Augmented Reality</translation>
+<translation id="3513704683820682405">Augmented Reality</translation>
+<translation id="5475862044948910901">เริ่มเซสชัน Augmented Reality ไหม</translation>
 <translation id="7365126855094612066">ระหว่างเซสชันนี้ เว็บไซต์จะทำสิ่งต่อไปนี้ได้
 • สร้างแผนที่ 3 มิติของสภาพแวดล้อม
 • ติดตามการเคลื่อนไหวของกล้อง
 
 เว็บไซต์นี้ "ไม่ได้" รับสิทธิ์เข้าถึงกล้องถ่ายรูป มีเพียงคุณเท่านั้นที่จะเห็นรูปจากกล้อง</translation>
-<translation id="7375125077091615385">ประเภท:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" /></translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">ประสบการณ์กับ First Run บน Chrome</translation>
-<translation id="741204030948306876">ได้สิ ตกลง</translation>
-<translation id="7413229368719586778">วันที่เริ่มต้น <ph name="DATE" /></translation>
-<translation id="7423098979219808738">ถามก่อน</translation>
-<translation id="7423538860840206698">บล็อกไม่ให้อ่านคลิปบอร์ด</translation>
-<translation id="7431991332293347422">ควบคุมการใช้ประวัติการท่องเว็บเพื่อปรับเปลี่ยน Search และบริการอื่นๆ ในแบบของคุณ</translation>
-<translation id="7437998757836447326">ออกจากระบบ Chrome</translation>
-<translation id="7438641746574390233">เมื่อเปิดโหมด Lite ไว้ Chrome จะใช้เซิร์ฟเวอร์ของ Google เพื่อช่วยให้โหลดหน้าเว็บได้เร็วขึ้น โหมด Lite จะเขียนหน้าเว็บที่ช้ามากขึ้นใหม่เพื่อโหลดเฉพาะเนื้อหาที่จำเป็นเท่านั้น โหมด Lite ไม่มีผลกับแท็บที่ไม่ระบุตัวตน</translation>
-<translation id="7444811645081526538">หมวดหมู่อื่นๆ</translation>
-<translation id="7445411102860286510">อนุญาตให้เว็บไซต์เล่นวิดีโอที่ปิดเสียงโดยอัตโนมัติ (แนะนำ)</translation>
-<translation id="7453467225369441013">นำคุณออกจากระบบของเว็บไซต์ส่วนใหญ่ แต่คุณจะไม่ออกจากระบบบัญชี Google</translation>
-<translation id="7454641608352164238">พื้นที่ว่างไม่พอ</translation>
-<translation id="7475192538862203634">หากคุณเห็นข้อความนี้บ่อยๆ โปรดลองทำตาม<ph name="BEGIN_LINK" />คำแนะนำ<ph name="END_LINK" />เหล่านี้</translation>
-<translation id="7475688122056506577">ไม่พบการ์ด SD ไฟล์บางไฟล์อาจหายไป</translation>
-<translation id="7479104141328977413">การจัดการแท็บ</translation>
-<translation id="7481312909269577407">ส่งต่อ</translation>
-<translation id="7482656565088326534">แท็บแสดงตัวอย่าง</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (อัปเดตเมื่อ <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">อินเทอร์เน็ตที่ประหยัดได้</translation>
-<translation id="7498271377022651285">โปรดรอสักครู่…</translation>
-<translation id="7514365320538308">ดาวน์โหลด</translation>
-<translation id="751961395872307827">เชื่อมต่อเว็บไซต์ไม่ได้</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">รับคำแนะนำไม่ได้</translation>
-<translation id="7559975015014302720">โหมด Lite ปิดอยู่</translation>
-<translation id="7562080006725997899">กำลังล้างข้อมูลการท่องเว็บ</translation>
-<translation id="756809126120519699">ล้างข้อมูล Chrome แล้ว</translation>
-<translation id="757524316907819857">บล็อกไม่ให้เว็บไซต์เล่นเนื้อหาที่ได้รับความคุ้มครอง</translation>
-<translation id="757855969265046257">{FILES,plural, =1{ดาวน์โหลดแล้ว <ph name="FILES_DOWNLOADED_ONE" /> ไฟล์}other{ดาวน์โหลดแล้ว <ph name="FILES_DOWNLOADED_MANY" /> ไฟล์}}</translation>
-<translation id="7588219262685291874">เปิดธีมสีเข้มเมื่อโหมดประหยัดแบตเตอรี่ของอุปกรณ์เปิดอยู่</translation>
-<translation id="7589445247086920869">บล็อกสำหรับเครื่องมือค้นหาปัจจุบัน</translation>
-<translation id="7593557518625677601">เปิดการตั้งค่า Android และเปิดการซิงค์ Android ใหม่เพื่อเริ่มการซิงค์ของ Chrome</translation>
-<translation id="7596558890252710462">ระบบปฏิบัติการ</translation>
-<translation id="7605594153474022051">การซิงค์ไม่ทำงาน</translation>
-<translation id="7606077192958116810">โหมด Lite เปิดอยู่ จัดการได้ในการตั้งค่า</translation>
-<translation id="7612619742409846846">ลงชื่อเข้าใช้ Google ด้วย</translation>
-<translation id="7619072057915878432">การดาวน์โหลด <ph name="FILE_NAME" /> ล้มเหลวเพราะเครือข่ายขัดข้อง</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />รับความช่วยเหลือ<ph name="END_LINK1" />หรือ<ph name="BEGIN_LINK2" />สแกนใหม่<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">ยินดีต้อนรับสู่ Chrome</translation>
-<translation id="7638584964844754484">รหัสผ่านไม่ถูกต้อง</translation>
-<translation id="7641339528570811325">ล้างข้อมูลการท่องเว็บ…</translation>
-<translation id="7648422057306047504">เข้ารหัสรหัสผ่านด้วยข้อมูลเข้าสู่ระบบของ Google</translation>
-<translation id="7649070708921625228">ช่วยเหลือ</translation>
-<translation id="7658239707568436148">ยกเลิก</translation>
-<translation id="7665369617277396874">เพิ่มบัญชี</translation>
-<translation id="766587987807204883">บทความจะแสดงที่นี่ ซึ่งคุณจะอ่านได้แม้ในขณะออฟไลน์</translation>
-<translation id="7682724950699840886">ลองทำตามเคล็ดลับต่อไปนี้ ตรวจสอบว่าอุปกรณ์มีพื้นที่ว่างเพียงพอ จากนั้นพยายามส่งออกอีกครั้ง</translation>
-<translation id="7685301384041462804">โปรดตรวจสอบว่าเว็บไซต์นี้เชื่อถือได้ก่อนเข้าสู่โหมด VR</translation>
-<translation id="7698359219371678927">สร้างอีเมลใน <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">เติมข้อความค้นหาและ URL อัตโนมัติ</translation>
-<translation id="7725024127233776428">หน้าที่คุณบุ๊กมาร์กไว้จะปรากฏที่นี่</translation>
-<translation id="773466115871691567">แปลหน้าเว็บภาษา<ph name="SOURCE_LANGUAGE" />ทุกครั้ง</translation>
-<translation id="7746457520633464754">ในการตรวจหาแอปและเว็บไซต์ที่เป็นอันตราย Chrome จะส่ง URL ของหน้าบางหน้าที่คุณเข้าชม ข้อมูลระบบที่จำกัด และเนื้อหาบางส่วนของหน้าไปให้ Google</translation>
-<translation id="7757787379047923882">ข้อความที่แชร์จาก <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">การ์ด SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">เพิ่มที่อยู่</translation>
-<translation id="7772032839648071052">ยืนยันข้อความรหัสผ่าน</translation>
-<translation id="7772375229873196092">ปิด <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> วิธี}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 และอีก <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> วิธี}}</translation>
-<translation id="7781829728241885113">เมื่อวานนี้</translation>
-<translation id="7791543448312431591">เพิ่ม</translation>
-<translation id="780301667611848630">ไม่ ขอบคุณ</translation>
-<translation id="7810647596859435254">เปิดด้วย…</translation>
-<translation id="7821588508402923572">การประหยัดอินเทอร์เน็ตของคุณจะแสดงที่นี่</translation>
-<translation id="7837721118676387834">อนุญาตให้เล่นวิดีโอที่ปิดเสียงโดยอัตโนมัติสำหรับบางเว็บไซต์</translation>
-<translation id="7846076177841592234">ยกเลิกการเลือก</translation>
-<translation id="784934925303690534">ช่วงเวลา</translation>
-<translation id="7851858861565204677">อุปกรณ์อื่นๆ</translation>
-<translation id="7875915731392087153">สร้างอีเมล</translation>
-<translation id="7876243839304621966">ลบทั้งหมด</translation>
-<translation id="7882131421121961860">ไม่พบประวัติการเข้าชม</translation>
-<translation id="7882806643839505685">อนุญาตให้เว็บไซต์ที่ต้องการเล่นเสียงได้</translation>
-<translation id="7886917304091689118">กำลังทำงานใน Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{กำลังดาวน์โหลดไฟล์}other{กำลังดาวน์โหลด # ไฟล์}}</translation>
-<translation id="7929962904089429003">เปิดเมนู</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> ล้าสมัย</translation>
-<translation id="7947953824732555851">ยอมรับและลงชื่อเข้าใช้</translation>
-<translation id="7963646190083259054">ผู้ขาย:</translation>
-<translation id="7971136598759319605">ใช้งานเมื่อ 1 วันที่ผ่านมา</translation>
-<translation id="7975379999046275268">พรีวิวหน้า <ph name="BEGIN_NEW" />ใหม่<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">โหลดหน้าเว็บล่วงหน้าเพื่อให้เรียกดูและค้นหาได้เร็วขึ้น</translation>
-<translation id="79859296434321399">ติดตั้ง ARCore เพื่อดูเนื้อหา Augmented Reality</translation>
-<translation id="7986741934819883144">เลือกรายชื่อติดต่อ</translation>
-<translation id="7987073022710626672">ข้อกำหนดในการให้บริการของ Chrome</translation>
-<translation id="7998918019931843664">เปิดแท็บที่ปิดไปแล้วขึ้นใหม่</translation>
-<translation id="7999064672810608036">คุณแน่ใจไหมว่าต้องการล้างข้อมูลในเครื่องทั้งหมด รวมถึงคุกกี้ และรีเซ็ตสิทธิ์ทั้งหมดสำหรับเว็บไซต์นี้</translation>
-<translation id="8004582292198964060">เบราว์เซอร์</translation>
-<translation id="8007176423574883786">ปิดสำหรับอุปกรณ์นี้</translation>
-<translation id="8013372441983637696">ล้างข้อมูล Chrome ของคุณออกจากอุปกรณ์นี้ด้วย</translation>
-<translation id="8015452622527143194">เปลี่ยนทุกอย่างบนหน้ากลับไปเป็นขนาดเริ่มต้น</translation>
-<translation id="802154636333426148">การดาวน์โหลดล้มเหลว</translation>
-<translation id="8026334261755873520">ล้างข้อมูลการท่องเว็บ</translation>
-<translation id="8035133914807600019">โฟลเดอร์ใหม่…</translation>
-<translation id="8037750541064988519">เหลือ <ph name="DAYS" /> วัน</translation>
-<translation id="804335162455518893">ไม่พบการ์ด SD</translation>
-<translation id="805047784848435650">อิงจากประวัติการท่องเว็บของคุณ</translation>
-<translation id="8051695050440594747">สามารถใช้งานได้ <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">เปิดในแท็บใหม่ของ Chrome</translation>
-<translation id="8063895661287329888">เพิ่มบุ๊กมาร์กไม่สำเร็จ</translation>
-<translation id="806745655614357130">เก็บข้อมูลของฉันแยกต่างหาก</translation>
-<translation id="8067883171444229417">เล่นวิดีโอ</translation>
-<translation id="8068648041423924542">เลือกใบรับรองไม่ได้</translation>
-<translation id="8073388330009372546">เปิดภาพในแท็บใหม่</translation>
-<translation id="8076492880354921740">แท็บ</translation>
-<translation id="8084114998886531721">รหัสผ่านที่บันทึกไว้</translation>
-<translation id="8087000398470557479">เนื้อหานี้มาจาก <ph name="DOMAIN_NAME" /> และนำส่งโดย Google</translation>
-<translation id="8103578431304235997">แท็บที่ไม่ระบุตัวตน</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">เปิดการซิงค์เพื่อรับบุ๊กมาร์กในอุปกรณ์ทุกเครื่องของคุณ</translation>
-<translation id="8110087112193408731">ต้องการแสดงกิจกรรม Chrome ในไลฟ์สไตล์ดิจิทัลไหม</translation>
-<translation id="8116925261070264013">ปิดเสียง</translation>
-<translation id="813082847718468539">ดูข้อมูลเว็บไซต์</translation>
-<translation id="8131740175452115882">ยืนยัน</translation>
-<translation id="8156139159503939589">คุณอ่านภาษาใดได้บ้าง</translation>
-<translation id="8168435359814927499">เนื้อหา</translation>
-<translation id="8186512483418048923">เหลืออีก <ph name="FILES" /> ไฟล์</translation>
-<translation id="8190358571722158785">เหลือ 1 วัน</translation>
-<translation id="8200772114523450471">ทำต่อ</translation>
-<translation id="8209050860603202033">เปิดรูปภาพ</translation>
-<translation id="8218622182176210845">จัดการบัญชีของคุณ</translation>
-<translation id="8224471946457685718">ดาวน์โหลดบทความสำหรับคุณผ่าน Wi-Fi</translation>
-<translation id="8232956427053453090">เก็บข้อมูลไว้</translation>
-<translation id="8249310407154411074">เลื่อนไปบนสุด</translation>
-<translation id="8250920743982581267">เอกสาร</translation>
-<translation id="825412236959742607">หน้านี้ใช้หน่วยความจำมากเกินไป Chrome จึงนำเนื้อหาบางส่วนออก</translation>
-<translation id="8260126382462817229">ลองลงชื่อเข้าใช้อีกครั้ง</translation>
-<translation id="8261506727792406068">ลบ</translation>
-<translation id="8266862848225348053">ตำแหน่งที่ดาวน์โหลด</translation>
-<translation id="8274165955039650276">ดูการดาวน์โหลด</translation>
-<translation id="8284326494547611709">คำบรรยาย</translation>
-<translation id="8300705686683892304">จัดการโดยแอป</translation>
-<translation id="8310344678080805313">แท็บมาตรฐาน</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> และเว็บไซต์อื่นๆ</translation>
-<translation id="8327155640814342956">โปรดเปิดเพื่ออัปเดต Chrome เพื่อให้ได้รับประสบการณ์การท่องเว็บที่ดีที่สุด</translation>
-<translation id="8339163506404995330">ระบบจะไม่แปลหน้าเว็บภาษา<ph name="LANGUAGE" /></translation>
-<translation id="8349013245300336738">จัดเรียงตามปริมาณเน็ตมือถือที่ใช้</translation>
-<translation id="8364299278605033898">ดูเว็บไซต์ยอดนิยม</translation>
-<translation id="8368027906805972958">อุปกรณ์ที่ไม่รู้จักหรือไม่รองรับ (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">อนุญาตให้ใช้การซิงค์ในแบ็กกราวด์สำหรับเว็บไซต์ที่เจาะจง</translation>
-<translation id="8378714024927312812">จัดการโดยองค์กร</translation>
-<translation id="8380167699614421159">เว็บไซต์นี้แสดงโฆษณาที่แทรกหรือทำให้เข้าใจผิด</translation>
-<translation id="8393700583063109961">ส่งข้อความ</translation>
-<translation id="8413126021676339697">แสดงประวัติการเข้าชมทั้งหมด</translation>
-<translation id="8427875596167638501">แท็บแสดงตัวอย่างเปิดอยู่ครึ่งเดียว</translation>
-<translation id="8428213095426709021">การตั้งค่า</translation>
-<translation id="8438566539970814960">ปรับปรุงการค้นหาและการท่องเว็บให้ดียิ่งขึ้น</translation>
-<translation id="8441146129660941386">ย้อนกลับ</translation>
-<translation id="8443209985646068659">อัปเดต Chrome ไม่ได้</translation>
-<translation id="8445448999790540984">ส่งออกรหัสผ่านไม่ได้</translation>
-<translation id="8447861592752582886">เพิกถอนสิทธิ์ของอุปกรณ์</translation>
-<translation id="8461694314515752532">เข้ารหัสลับข้อมูลที่ซิงค์ด้วยรหัสผ่านการซิงค์ของคุณเอง</translation>
-<translation id="8466613982764129868">ตรวจสอบว่า <ph name="TARGET_DEVICE_NAME" /> เชื่อมต่ออินเทอร์เน็ตอยู่</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">ใช้งานแบบออฟไลน์ได้</translation>
-<translation id="8489271220582375723">เปิดหน้าประวัติการเข้าชม</translation>
-<translation id="8493948351860045254">เพิ่มพื้นที่ว่าง</translation>
-<translation id="8497726226069778601">ที่นี่ยังไม่มีอะไรให้ดู… เลย</translation>
-<translation id="8503559462189395349">รหัสผ่าน Chrome</translation>
-<translation id="8503813439785031346">ชื่อผู้ใช้</translation>
-<translation id="8514477925623180633">ส่งออกรหัสผ่านที่เก็บไว้ใน Chrome</translation>
-<translation id="8514577642972634246">เข้าสู่โหมดไม่ระบุตัวตน</translation>
-<translation id="851751545965956758">บล็อกเว็บไซต์ไม่ให้เชื่อมต่อกับอุปกรณ์</translation>
-<translation id="8523928698583292556">ลบรหัสผ่านที่เก็บไว้</translation>
-<translation id="854522910157234410">เปิดหน้านี้</translation>
-<translation id="8558485628462305855">อัปเดต ARCore เพื่อดูเนื้อหา Augmented Reality</translation>
-<translation id="8559990750235505898">เสนอที่จะแปลหน้าในภาษาอื่นๆ</translation>
-<translation id="8562452229998620586">รหัสผ่านที่บันทึกไว้จะแสดงที่นี่</translation>
-<translation id="8569404424186215731">ตั้งแต่วันที่ <ph name="DATE" /></translation>
-<translation id="8571213806525832805">4 สัปดาห์ที่แล้ว</translation>
-<translation id="857943718398505171">อนุญาตแล้ว (แนะนำ)</translation>
-<translation id="8583805026567836021">กำลังล้างข้อมูลบัญชี</translation>
-<translation id="860043288473659153">ชื่อผู้ถือบัตร</translation>
-<translation id="8609465669617005112">เลื่อนขึ้น</translation>
-<translation id="8616006591992756292">บัญชี Google อาจมีประวัติการท่องเว็บรูปแบบอื่นๆ ที่ <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /></translation>
-<translation id="8617240290563765734">ต้องการเปิด URL แนะนำซึ่งระบุอยู่ในเนื้อหาที่ดาวน์โหลดไหม</translation>
-<translation id="8636825310635137004">เปิดการซิงค์เพื่อรับแท็บจากอุปกรณ์เครื่องอื่นๆ ของคุณ</translation>
-<translation id="8641930654639604085">พยายามบล็อกไซต์สำหรับผู้ใหญ่</translation>
-<translation id="8655129584991699539">คุณล้างข้อมูลได้ในการตั้งค่า Chrome</translation>
-<translation id="8662811608048051533">นำคุณออกจากระบบของเว็บไซต์ส่วนใหญ่</translation>
-<translation id="8664979001105139458">มีชื่อไฟล์นี้อยู่แล้ว</translation>
-<translation id="8676374126336081632">ล้างข้อมูลที่ป้อน</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{ระดับความแรงของสัญญาณ: # แถบ}other{ระดับความแรงของสัญญาณ: # แถบ}}</translation>
-<translation id="868929229000858085">ค้นหารายชื่อติดต่อ</translation>
-<translation id="869891660844655955">วันหมดอายุ</translation>
-<translation id="8719023831149562936">ไม่สามารถบีมแท็บปัจจุบัน</translation>
-<translation id="8725066075913043281">ลองอีกครั้ง</translation>
-<translation id="8728487861892616501">การใช้แอปพลิเคชันนี้หมายความว่าคุณยอมรับ <ph name="BEGIN_LINK1" />ข้อกำหนดในการให้บริการ<ph name="END_LINK1" /> และ <ph name="BEGIN_LINK2" />ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2" /> ของ Chrome รวมถึง <ph name="BEGIN_LINK3" />ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัวสำหรับบัญชี Google ที่จัดการด้วย Family Link<ph name="END_LINK3" /></translation>
-<translation id="8730621377337864115">เสร็จสิ้น</translation>
-<translation id="8748850008226585750">เนื้อหาถูกซ่อนไว้</translation>
-<translation id="8751914237388039244">เลือกรูปภาพ</translation>
-<translation id="8788265440806329501">ประวัติการนำทางปิดอยู่</translation>
-<translation id="8788968922598763114">เปิดแท็บที่เพิ่งปิดอีกครั้ง</translation>
-<translation id="8801436777607969138">บล็อก JavaScript ในเว็บไซต์ที่ต้องการ</translation>
-<translation id="8812260976093120287">ในบางเว็บไซต์ คุณสามารถชำระเงินด้วยแอปชำระเงินที่รองรับด้านบนในอุปกรณ์ของคุณ</translation>
-<translation id="8816026460808729765">บล็อกไม่ให้เว็บไซต์เข้าถึงเซ็นเซอร์</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> จะเปิดขึ้นใน Chrome การดำเนินการต่อแสดงว่าคุณยอมรับ<ph name="BEGIN_LINK1" />ข้อกำหนดในการให้บริการ<ph name="END_LINK1" />และ<ph name="BEGIN_LINK2" />ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัว<ph name="END_LINK2" />ของ Chrome รวมถึง<ph name="BEGIN_LINK3" />ประกาศเกี่ยวกับนโยบายความเป็นส่วนตัวสำหรับบัญชี Google ที่จัดการด้วย Family Link<ph name="END_LINK3" /></translation>
-<translation id="8820817407110198400">บุ๊กมาร์ก</translation>
-<translation id="8833831881926404480">มีเว็บไซต์กำลังแชร์หน้าจอของคุณ</translation>
-<translation id="883806473910249246">เกิดข้อผิดพลาดขณะดาวน์โหลดเนื้อหา</translation>
-<translation id="8840953339110955557">หน้าเว็บนี้อาจแตกต่างไปจากเวอร์ชันที่ออนไลน์</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" /> เป็นแท็บ</translation>
-<translation id="885701979325669005">พื้นที่เก็บข้อมูล</translation>
-<translation id="889338405075704026">ไปที่การตั้งค่า Chrome</translation>
-<translation id="8901170036886848654">ไม่พบบุ๊กมาร์ก</translation>
-<translation id="8909135823018751308">แชร์…</translation>
-<translation id="8912362522468806198">บัญชี Google</translation>
-<translation id="8920114477895755567">กำลังรอรายละเอียดของผู้ปกครอง</translation>
+<translation id="1188239144602654184">เริ่ม AR</translation>
+<translation id="473775607612524610">อัปเดต</translation>
+<translation id="3133489217401741157">กำลังติดตั้ง <ph name="MODULE"/> สำหรับ Brave…</translation>
+<translation id="1791662854739702043">ติดตั้งแล้ว</translation>
+<translation id="5131234170665854056">ติดตั้ง <ph name="MODULE"/> สำหรับ Brave ไม่ได้</translation>
+<translation id="2567385386134582609">รูปภาพ</translation>
+<translation id="6395288395575013217">ลิงก์</translation>
+<translation id="7352939065658542140">วิดีโอ</translation>
+<translation id="4116038641877404294">ดาวน์โหลดหน้าเพื่อใช้งานแบบออฟไลน์</translation>
 <translation id="8922289737868596582">ดาวน์โหลดหน้าจากปุ่มตัวเลือกเพิ่มเติมเพื่อใช้งานแบบออฟไลน์</translation>
-<translation id="8937772741022875483">ต้องการนำกิจกรรม Chrome ออกจากไลฟ์สไตล์ดิจิทัลไหม</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">เปิดในหน้าต่างอื่น</translation>
-<translation id="8951232171465285730">Chrome ได้ประหยัดพื้นที่ให้คุณไป <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">บล็อกคุกกี้ของเว็บไซต์ที่เจาะจง</translation>
-<translation id="8959122750345127698">ไม่สามารถเข้าถึงการนำทางได้: <ph name="URL" /></translation>
-<translation id="8965591936373831584">รอดำเนินการ</translation>
-<translation id="8970887620466824814">มีบางอย่างผิดพลาด</translation>
-<translation id="8972098258593396643">ดาวน์โหลดลงโฟลเดอร์เริ่มต้นไหม</translation>
-<translation id="8986494364107987395">ส่งสถิติการใช้งานและรายงานข้อขัดข้องไปยัง Google โดยอัตโนมัติ</translation>
-<translation id="8993760627012879038">เปิดแท็บใหม่ในโหมดไม่ระบุตัวตน</translation>
-<translation id="8998729206196772491">คุณกำลังลงชื่อเข้าใช้ด้วยบัญชีที่จัดการโดย <ph name="MANAGED_DOMAIN" /> และทำให้ผู้ดูแลระบบของโดเมนควบคุมข้อมูล Chrome ของคุณได้ ข้อมูลดังกล่าวจะโยงกับบัญชีนี้อย่างถาวร การออกจากระบบ Chrome จะลบข้อมูลของคุณออกจากอุปกรณ์เครื่องนี้ แต่ข้อมูลจะยังจัดเก็บอยู่ในบัญชี Google</translation>
-<translation id="9019902583201351841">มีการจัดการโดยผู้ปกครอง</translation>
-<translation id="9028914725102941583">เปิดการซิงค์เพื่อแชร์ข้ามอุปกรณ์</translation>
-<translation id="9029323097866369874">อนุญาตให้ <ph name="DOMAIN" /> เข้าสู่โหมด VR ไหม</translation>
-<translation id="9040142327097499898">อนุญาตให้แสดงการแจ้งเตือน ตำแหน่งสำหรับอุปกรณ์เครื่องนี้ปิดอยู่</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{วิดีโอ # รายการ}other{วิดีโอ # รายการ}}</translation>
-<translation id="9050666287014529139">ข้อความรหัสผ่าน</translation>
-<translation id="9063523880881406963">ปิดการขอเว็บไซต์เดสก์ท็อป</translation>
-<translation id="9065203028668620118">แก้ไข</translation>
-<translation id="9070377983101773829">เริ่มค้นหาด้วยเสียง</translation>
-<translation id="9074336505530349563">ลงชื่อเข้าใช้และเปิดการซิงค์เพื่อรับคำแนะนำเนื้อหาที่ปรับเปลี่ยนในแบบของคุณจาก Google</translation>
-<translation id="9086455579313502267">ไม่สามารถเข้าถึงเครือข่าย</translation>
-<translation id="9100505651305367705">เสนอการแสดงบทความในมุมมองอย่างง่าย ในกรณีที่บทความทำได้</translation>
-<translation id="9100610230175265781">ต้องระบุรหัสผ่าน</translation>
-<translation id="9102803872260866941">แท็บแสดงตัวอย่างเปิดอยู่</translation>
+<translation id="5958275228015807058">หาไฟล์และหน้าในโฟลเดอร์ดาวน์โหลด</translation>
+<translation id="5620928963363755975">หาไฟล์และหน้าในโฟลเดอร์ดาวน์โหลดจากปุ่มตัวเลือกเพิ่มเติม</translation>
+<translation id="3341058695485821946">ดูปริมาณอินเทอร์เน็ตที่คุณประหยัดไปได้</translation>
+<translation id="3157842584138209013">ดูปริมาณอินเทอร์เน็ตที่คุณประหยัดไปได้จากปุ่มตัวเลือกเพิ่มเติม</translation>
+<translation id="8218622182176210845">จัดการบัญชีของคุณ</translation>
+<translation id="8090895580117672212">หากต้องการจัดการบัญชี Brave Software ให้แตะปุ่ม "จัดการบัญชี"</translation>
+<translation id="8856898588039823173">หน้าเวอร์ชัน Lite จัดเตรียมโดย Brave Software แตะเพื่อโหลดต้นฉบับ</translation>
+<translation id="8134317863207426198">หน้าเวอร์ชัน Lite ให้บริการโดย Brave Software แตะปุ่มโหลดต้นฉบับเพื่อโหลดหน้าต้นฉบับ</translation>
+<translation id="4961107849584082341">แปลหน้านี้เป็นภาษาใดก็ได้</translation>
+<translation id="569536719314091526">แปลหน้านี้เป็นภาษาใดก็ได้จากปุ่มตัวเลือกเพิ่มเติม</translation>
+<translation id="1397811292916898096">ค้นหาด้วย <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">เปลี่ยนตำแหน่งเริ่มต้นในการดาวน์โหลดได้ทุกเมื่อ</translation>
+<translation id="6942665639005891494">เปลี่ยนตำแหน่งเริ่มต้นในการดาวน์โหลดได้ทุกเมื่อโดยใช้ตัวเลือกเมนู "การตั้งค่า"</translation>
+<translation id="6850409657436465440">ระบบยังดาวน์โหลดอยู่</translation>
+<translation id="5817715962196959877">ตอนนี้ Brave ดาวน์โหลดไฟล์ได้เร็วขึ้นแล้ว</translation>
+<translation id="3976396876660209797">นำทางลัดนี้ออกแล้วสร้างใหม่</translation>
+<translation id="6766622839693428701">เลื่อนลงเพื่อปิด</translation>
+<translation id="1028699632127661925">กำลังส่งไปที่ <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - ส่งจาก <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">ได้รับแท็บแล้ว</translation>
 <translation id="9104217018994036254">รายการอุปกรณ์ที่จะแชร์แท็บด้วย</translation>
-<translation id="9133397713400217035">สำรวจแบบออฟไลน์</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">แสดงหน้าเว็บเดิม</translation>
-<translation id="9139068048179869749">ถามก่อนอนุญาตให้เว็บไซต์ส่งการแจ้งเตือน (แนะนำ)</translation>
-<translation id="9139318394846604261">ช็อปปิ้ง</translation>
-<translation id="9155898266292537608">หรือคุณจะค้นหาด้วยการแตะอย่างรวดเร็วที่คำๆ หนึ่งก็ได้เช่นกัน</translation>
-<translation id="9169507124922466868">ประวัติการนำทางเปิดอยู่ครึ่งเดียว</translation>
-<translation id="9204836675896933765">เหลืออีก 1 ไฟล์</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">รายการอุปกรณ์ที่จะแชร์แท็บด้วยเปิดอยู่ที่ระดับความสูงครึ่งหนึ่งของหน้าจอ</translation>
+<translation id="2904414404539560095">รายการอุปกรณ์ที่จะแชร์แท็บด้วยเปิดอยู่ที่ระดับความสูงเต็มหน้าจอ</translation>
+<translation id="4135200667068010335">รายการอุปกรณ์ที่จะแชร์แท็บด้วยปิดอยู่</translation>
+<translation id="5292796745632149097">ส่งไปที่</translation>
+<translation id="1386674309198842382">ใช้งานเมื่อ <ph name="LAST_UPDATED"/> วันที่ผ่านมา</translation>
+<translation id="7971136598759319605">ใช้งานเมื่อ 1 วันที่ผ่านมา</translation>
+<translation id="1521774566618522728">ใช้งานวันนี้</translation>
+<translation id="3631987586758005671">กำลังแชร์กับ <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">เปิดการซิงค์เพื่อแชร์ข้ามอุปกรณ์</translation>
+<translation id="6162454065885854378">หากต้องการแชร์รายการจากโทรศัพท์ไปยังอุปกรณ์อื่น ให้เปิดการซิงค์ในการตั้งค่า Brave ในอุปกรณ์ทั้ง 2 เครื่อง</translation>
+<translation id="6084271560289605378">ไปที่การตั้งค่า Brave</translation>
+<translation id="2318045970523081853">แตะเพื่อโทร</translation>
 <translation id="9209888181064652401">โทรออกไม่ได้</translation>
-<translation id="9219103736887031265">ภาพ</translation>
-<translation id="926205370408745186">นำกิจกรรม Chrome ออกจากไลฟ์สไตล์ดิจิทัล</translation>
-<translation id="932327136139879170">หน้าแรก</translation>
-<translation id="938850635132480979">ข้อผิดพลาด: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">เข้าถึงไมโครโฟน</translation>
-<translation id="95817756606698420">Chrome สามารถใช้ <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> สำหรับการค้นหาในประเทศจีน คุณสามารถเปลี่ยนเครื่องมือค้นหาเริ่มต้นนี้ได้ใน<ph name="BEGIN_LINK" />การตั้งค่า<ph name="END_LINK" /></translation>
-<translation id="965817943346481315">บล็อกหากเว็บไซต์แสดงโฆษณาที่แทรกหรือทำให้เข้าใจผิด (แนะนำ)</translation>
-<translation id="968900484120156207">หน้าที่คุณเข้าชมจะปรากฏที่นี่</translation>
-<translation id="970715775301869095">เหลือ <ph name="MINUTES" /> นาที</translation>
-<translation id="974555521953189084">ป้อนรหัสผ่านเพื่อเริ่มซิงค์</translation>
-<translation id="981121421437150478">ออฟไลน์</translation>
-<translation id="982182592107339124">การดำเนินการนี้จะล้างข้อมูลสำหรับทุกเว็บไซต์ รวมถึง</translation>
-<translation id="983192555821071799">ปิดแท็บทั้งหมด</translation>
-<translation id="987264212798334818">ทั่วไป</translation>
+<translation id="2860954141821109167">ตรวจสอบว่ามีการเปิดใช้แอปโทรศัพท์ในอุปกรณ์นี้แล้ว</translation>
+<translation id="2067805253194386918">ข้อความ</translation>
+<translation id="1450753235335490080">แชร์<ph name="CONTENT_TYPE"/>ไม่สำเร็จ</translation>
+<translation id="1266864766717917324">แชร์<ph name="CONTENT_TYPE"/>ไม่ได้</translation>
+<translation id="8287068819750208230">ตรวจสอบว่าการซิงค์ <ph name="TARGET_DEVICE_NAME"/> ใน Brave เปิดอยู่</translation>
+<translation id="3016635187733453316">ตรวจสอบว่าอุปกรณ์นี้เชื่อมต่ออินเทอร์เน็ตอยู่</translation>
+<translation id="8466613982764129868">ตรวจสอบว่า <ph name="TARGET_DEVICE_NAME"/> เชื่อมต่ออินเทอร์เน็ตอยู่</translation>
+<translation id="6539092367496845964">เกิดข้อผิดพลาด ลองอีกครั้งภายหลัง</translation>
+<translation id="3389286852084373014">ข้อความมีขนาดใหญ่เกินไป</translation>
+<translation id="2100314319871056947">ลองแชร์ข้อความโดยแบ่งเป็นส่วนเล็กๆ หลายส่วน</translation>
+<translation id="2987620471460279764">ข้อความแชร์มาจากอุปกรณ์อื่น</translation>
+<translation id="7757787379047923882">ข้อความที่แชร์จาก <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">คัดลอกไปยังคลิปบอร์ดแล้ว</translation>
+<translation id="4696983787092045100">ส่งข้อความไปยังอุปกรณ์ของคุณ</translation>
+<translation id="1260236875608242557">ค้นหาและสำรวจ</translation>
+<translation id="6369229450655021117">คุณจะค้นหาเว็บ แชร์กับเพื่อนๆ และดูหน้าเว็บที่เปิดอยู่ได้จากที่นี่</translation>
+<translation id="723171743924126238">เลือกภาพ</translation>
+<translation id="8751914237388039244">เลือกรูปภาพ</translation>
+<translation id="1989112275319619282">เล่นเน็ต</translation>
+<translation id="7055152154916055070">การเปลี่ยนเส้นทางถูกบล็อก</translation>
+<translation id="5524843473235508879">การเปลี่ยนเส้นทางถูกบล็อก</translation>
+<translation id="6573096386450695060">อนุญาตเสมอ</translation>
+<translation id="5805364706385912897">หน้านี้ใช้หน่วยความจำมากเกินไป Brave จึงหยุดหน้าชั่วคราว</translation>
+<translation id="5138664332909611586">หน้านี้ใช้หน่วยความจำมากเกินไป Brave จึงนำเนื้อหาบางส่วนออก</translation>
+<translation id="9137013805542155359">แสดงหน้าเว็บเดิม</translation>
+<translation id="6361779936989026201">Brave Software Assistant ใน Brave</translation>
+<translation id="7291387454912369099">Assistant สำหรับการป้อนข้อความอัตโนมัติ</translation>
+<translation id="4565206163201411670">ต้องการแสดงกิจกรรม Brave ในไลฟ์สไตล์ดิจิทัลไหม</translation>
+<translation id="9055113864158719823">คุณดูเว็บไซต์ที่เข้าชมใน Brave และตั้งตัวจับเวลาการใช้เว็บไซต์เหล่านั้นได้\n\nBrave Software จะได้รับข้อมูลเกี่ยวกับเว็บไซต์ที่คุณตั้งตัวจับเวลาไว้และระยะเวลาที่คุณเข้าชมเว็บไซต์เหล่านั้น เราจะใช้ข้อมูลนี้เพื่อปรับปรุงไลฟ์สไตล์ดิจิทัลให้ดียิ่งขึ้น</translation>
+<translation id="4596514158372210596">นำกิจกรรม Brave ออกจากไลฟ์สไตล์ดิจิทัล</translation>
+<translation id="1174893863889683998">ต้องการนำกิจกรรม Brave ออกจากไลฟ์สไตล์ดิจิทัลไหม</translation>
+<translation id="708829030563435351">ระบบจะไม่แสดงเว็บไซต์ที่คุณเข้าชมใน Brave และจะลบตัวจับเวลาการใช้เว็บไซต์ทั้งหมด</translation>
+<translation id="2056878612599315956">เว็บไซต์หยุดชั่วคราว</translation>
+<translation id="671481426037969117">ตัวจับเวลา <ph name="FQDN"/> หมดเวลาแล้ว และจะเริ่มอีกครั้งพรุ่งนี้</translation>
+<translation id="7479104141328977413">การจัดการแท็บ</translation>
+<translation id="3524138585025253783">UI นักพัฒนาซอฟต์แวร์</translation>
+<translation id="6036057147555329831">ICU เพิ่มเติม</translation>
+<translation id="9029323097866369874">อนุญาตให้ <ph name="DOMAIN"/> เข้าสู่โหมด VR ไหม</translation>
+<translation id="7685301384041462804">โปรดตรวจสอบว่าเว็บไซต์นี้เชื่อถือได้ก่อนเข้าสู่โหมด VR</translation>
+<translation id="5033865233969348410">ขณะอยู่ในโหมด VR เว็บไซต์นี้อาจดูข้อมูลต่อไปนี้ได้
+  -  รูปร่างของคุณ เช่น ความสูง
+
+โปรดตรวจสอบว่าเว็บไซต์นี้เชื่อถือได้ก่อนเข้าสู่โหมด VR</translation>
+<translation id="5534334044554683961">ขณะอยู่ในโหมด VR เว็บไซต์นี้อาจดูข้อมูลต่อไปนี้ได้
+  -   รูปร่างของคุณ เช่น ความสูง
+  -   แปลนห้องของคุณ
+
+โปรดตรวจสอบว่าเว็บไซต์นี้เชื่อถือได้ก่อนเข้าสู่โหมด VR</translation>
+<translation id="4169535189173047238">ไม่อนุญาต</translation>
+<translation id="2170088579611075216">อนุญาตและเข้าสู่ประสบการณ์ VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_tr.xtb
+++ b/android/java/strings/translations/android_chrome_strings_tr.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="tr">
-<translation id="1006017844123154345">İnternet'te aç</translation>
-<translation id="1028699632127661925"><ph name="DEVICE_NAME" /> cihazına gönderiliyor...</translation>
-<translation id="1036727731225946849"><ph name="WEBAPK_NAME" /> ekleniyor...</translation>
-<translation id="1041308826830691739">Web sitelerinden</translation>
-<translation id="1049743911850919806">Gizli mod</translation>
-<translation id="10614374240317010">Hiç kaydedilmeyecekler</translation>
-<translation id="1067922213147265141">Diğer Google hizmetleri</translation>
-<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE" /> dilindeki sayfaları asla çevirme</translation>
-<translation id="107147699690128016">Dosya uzantısını değiştirirseniz dosya farklı bir uygulamada açılabilir ve cihazınız için tehlikeli olabilir.</translation>
-<translation id="1100066534610197918">Grupta yeni sekmede aç</translation>
-<translation id="1105960400813249514">Ekran Kaydediliyor</translation>
-<translation id="1111673857033749125">Diğer cihazlarınızda kaydedilmiş yer işaretleri burada görünür.</translation>
-<translation id="1113597929977215864">Basitleştirilmiş görünümü göster</translation>
-<translation id="1121094540300013208">Kullanım ve kilitlenme raporları</translation>
-<translation id="1124772482545689468">Kullanıcı</translation>
-<translation id="1129510026454351943">Ayrıntılar: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 indirme işlemi beklemede.}other{# indirme işlemi beklemede.}}</translation>
-<translation id="1145536944570833626">Mevcut verileri silin.</translation>
-<translation id="1146678959555564648">VR'ye Gir</translation>
-<translation id="116280672541001035">Kullanılan</translation>
-<translation id="1171770572613082465">"Popüler siteler" düğmesine dokunarak popüler web sitelerini görün</translation>
-<translation id="1173894706177603556">Yeniden adlandır</translation>
-<translation id="1178581264944972037">Duraklat</translation>
-<translation id="1181037720776840403">Kaldır</translation>
-<translation id="1188239144602654184">AR'ye gir</translation>
-<translation id="1197267115302279827">Yer işaretlerini taşı</translation>
-<translation id="119944043368869598">Tümünü temizle</translation>
-<translation id="1201402288615127009">İleri</translation>
-<translation id="1204037785786432551">Bağlantıyı indir</translation>
-<translation id="1206892813135768548">Bağlantı metnini kopyala</translation>
-<translation id="1208340532756947324">Cihazlar arasında senkronizasyon ve kişiselleştirme yapmak için senkronizasyonu etkinleştirin</translation>
-<translation id="1209206284964581585">Şimdilik gizle</translation>
-<translation id="1227058898775614466">Gezinme geçmişi</translation>
-<translation id="1231733316453485619">Senkronizasyon açılsın mı?</translation>
-<translation id="123724288017357924">Önbelleğe alınmış içeriği yoksayarak geçerli sayfayı yeniden yükler</translation>
-<translation id="124116460088058876">Diğer diller</translation>
-<translation id="124678866338384709">Geçerli sekmeyi kapatır</translation>
-<translation id="1258753120186372309">Google doodle'ı: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Arama yapın ve keşfedin</translation>
-<translation id="1264974993859112054">Spor</translation>
-<translation id="1266864766717917324"><ph name="CONTENT_TYPE" /> paylaşılamadı</translation>
-<translation id="1272079795634619415">Durdur</translation>
-<translation id="1283039547216852943">Genişletmek için dokunun</translation>
-<translation id="1285320974508926690">Bu siteyi hiçbir zaman çevirme</translation>
-<translation id="1291207594882862231">Geçmişi, çerezleri, site verilerini, önbelleği temizleyin…</translation>
-<translation id="129382876167171263">Web siteleri tarafından kaydedilen dosyalar burada görünür</translation>
-<translation id="129553762522093515">Son kapatılan</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - <ph name="DEVICE_NAME" /> cihazından gönderildi</translation>
-<translation id="1310482092992808703">Sekmeleri grupla</translation>
-<translation id="1327257854815634930">Gezinme geçmişi açık</translation>
-<translation id="1331212799747679585">Chrome güncellenemiyor. Diğer seçenekler</translation>
-<translation id="1332501820983677155">Google Chrome'un özellik kısayolları</translation>
-<translation id="1360432990279830238">Oturum ve senkronizasyon kapatılsın mı?</translation>
-<translation id="1369915414381695676"><ph name="SITE_NAME" /> sitesi eklendi</translation>
-<translation id="1373696734384179344">Seçilen içeriği indirmek için bellek yetersiz.</translation>
-<translation id="1376578503827013741">Hesaplanıyor…</translation>
-<translation id="1383876407941801731">Ara</translation>
-<translation id="1384959399684842514">İndirme işlemi duraklatıldı</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> gün önce etkindi</translation>
-<translation id="1397811292916898096"><ph name="PRODUCT_NAME" /> ile ara</translation>
-<translation id="1404122904123200417"><ph name="WEBSITE_URL" /> sitesinde yerleşik</translation>
-<translation id="1406000523432664303">“Do Not Track”</translation>
-<translation id="1407135791313364759">Tümünü aç</translation>
-<translation id="1409426117486808224">Açık sekmeler için basitleştirilmiş görünüm</translation>
-<translation id="1409879593029778104"><ph name="FILE_NAME" /> dosyası zaten var olduğu için indirme işlemi engellendi.</translation>
-<translation id="1414981605391750300">Google ile bağlantı kuruluyor. Bu işlem bir dakika sürebilir…</translation>
-<translation id="1416550906796893042">Uygulama sürümü</translation>
-<translation id="1430915738399379752">Yazdır</translation>
-<translation id="1446450296470737166">MIDI cihazlarının tam denetimine izin verme</translation>
-<translation id="1450753235335490080"><ph name="CONTENT_TYPE" /> paylaşılamıyor</translation>
-<translation id="145097072038377568">Android Ayarları'ndan kapatıldı</translation>
-<translation id="1477626028522505441">Sunucu sorunları nedeniyle <ph name="FILE_NAME" /> dosyası indirilemedi.</translation>
-<translation id="1506061864768559482">Arama motoru</translation>
-<translation id="1513352483775369820">Yer işaretleri ve web geçmişi</translation>
-<translation id="1513858653616922153">Şifreyi sil</translation>
-<translation id="1516229014686355813">Dokun ve Ara özelliği, seçilen kelimeyi ve geçerli sayfayı Google Arama'ya bağlam olarak gönderir. Bu özelliği <ph name="BEGIN_LINK" />Ayarlar<ph name="END_LINK" />'da kapatabilirsiniz.</translation>
-<translation id="1521774566618522728">Son etkin olduğu zaman:</translation>
-<translation id="1544826120773021464">Google hesabınızı yönetmek için "Hesabı yönet" düğmesine dokunun</translation>
-<translation id="1549000191223877751">Diğer pencereye git</translation>
-<translation id="1553358976309200471">Chrome'u güncelle</translation>
-<translation id="1569387923882100876">Bağlı Cihaz</translation>
-<translation id="1571304935088121812">Kullanıcı adını kopyala</translation>
-<translation id="1612196535745283361">Chrome'un cihazları taraması için konum bilgilerine erişmesi gerekiyor. Konum bilgilerine erişim <ph name="BEGIN_LINK" />bu cihaz için kapalı<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Kamera</translation>
-<translation id="1623104350909869708">Bu sayfanın daha fazla iletişim kutusu oluşturmasını önle</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 seçili öğeyi kaldır}other{# seçili öğeyi kaldır}}</translation>
-<translation id="164269334534774161">Bu sayfanın <ph name="CREATION_TIME" /> tarihinde oluşturulan bir çevrimdışı kopyasını görüntülüyorsunuz</translation>
-<translation id="1644574205037202324">Geçmiş</translation>
-<translation id="1647391597548383849">Kameranıza erişim</translation>
-<translation id="1660204651932907780">Sitelerin ses çalmasına izin ver (önerilir)</translation>
-<translation id="1670399744444387456">Temel</translation>
-<translation id="1671236975893690980">İndirme işlemi beklemede…</translation>
-<translation id="1672586136351118594">Bir daha gösterme</translation>
-<translation id="1692118695553449118">Senkronizasyon açık.</translation>
-<translation id="169515064810179024">Sitelerin hareket sensörlerine erişimini engelle</translation>
-<translation id="1717218214683051432">Hareket sensörleri</translation>
-<translation id="1718835860248848330">Son saat</translation>
-<translation id="1736419249208073774">Keşfet</translation>
-<translation id="1743802530341753419">Sitelerin bir cihaza bağlanmasına izin verilmeden önce sor (önerilir)</translation>
-<translation id="1749561566933687563">Yer işaretlerinizi senkronize edin</translation>
-<translation id="17513872634828108">Açık sekmeler</translation>
-<translation id="1779089405699405702">Görsel kod çözücüsü</translation>
-<translation id="1782483593938241562">Bitiş tarihi: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Yüklendi</translation>
-<translation id="1792959175193046959">Dosyaların indirileceği varsayılan konumu istediğiniz zaman değiştirebilirsiniz</translation>
-<translation id="1807246157184219062">Açık</translation>
-<translation id="1810845389119482123">İlk senkronizasyon kurulumu tamamlanmadı</translation>
-<translation id="1821253160463689938">Belirtilen sayfaları ziyaret etmiyor olsanız bile tercihlerinizi hatırlamak için çerezler kullanır</translation>
-<translation id="1829244130665387512">Sayfada bul</translation>
-<translation id="1853692000353488670">Yeni gizli sekme</translation>
-<translation id="1856325424225101786">Basit mod sıfırlansın mı?</translation>
-<translation id="1868024384445905608">Chrome artık dosyaları daha hızlı indiriyor</translation>
-<translation id="1883903952484604915">Dosyalarım</translation>
-<translation id="1887786770086287077">Konum erişimi bu cihaz için kapalı. Konum erişimini <ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'ndan açın.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> Chrome'da açılacak. Devam ederek Chrome'un <ph name="BEGIN_LINK1" />Hizmet Şartları<ph name="END_LINK1" />'nı ve <ph name="BEGIN_LINK2" />Gizlilik Uyarısı<ph name="END_LINK2" />'nı kabul etmiş olursunuz.</translation>
-<translation id="1919345977826869612">Reklamlar</translation>
-<translation id="1919950603503897840">Kişi seçin</translation>
-<translation id="1922076542920281912">Chrome'un konumunuza erişebilmesi için <ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'nda da konumu açın.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Güncellemeler</translation>
-<translation id="19288952978244135">Chrome'u yeniden açın.</translation>
-<translation id="1933845786846280168">Seçili Sekme</translation>
-<translation id="194341124344773587"><ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'nda Chrome için izni açın.</translation>
-<translation id="1943432128510653496">Şifreleri kaydet</translation>
-<translation id="1952172573699511566">Web siteleri, mümkün olduğunda metni tercih ettiğiniz dilde gösterir.</translation>
-<translation id="1960290143419248813">Chrome güncellemeleri Android'in bu sürümü için artık desteklenmiyor</translation>
-<translation id="1966710179511230534">Lütfen oturum açma ayrıntılarınızı güncelleyin.</translation>
-<translation id="1974060860693918893">Gelişmiş</translation>
-<translation id="1984705450038014246">Chrome verilerimi senkronize et</translation>
-<translation id="1984937141057606926">Üçüncü taraf hariç izin verildi</translation>
-<translation id="1986685561493779662">Ad zaten var</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" /> düğmesi</translation>
-<translation id="1989112275319619282">Göz at</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> eşlenmek istiyor</translation>
-<translation id="1994173015038366702">Site URL'si</translation>
-<translation id="2000419248597011803">Adres çubuğundan ve arama kutusundan bazı çerezleri ve aramaları varsayılan arama motorunuza gönderir</translation>
-<translation id="2002537628803770967">Google Pay'i kullanan kredi kartları ve adresler</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Dosya}other{# Dosya}}</translation>
-<translation id="2017836877785168846">Geçmişi ve adres çubuğundaki otomatik tamamlama bilgilerini temizler.</translation>
-<translation id="2021896219286479412">Tam ekran site kontrolleri</translation>
-<translation id="2038563949887743358">Masaüstü sitesi iste işlevini etkinleştir</translation>
-<translation id="2041019821020695769">Chrome'un size bildirim gönderebilmesi için <ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'nda da bildirimleri açın.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> uygulamasına ait veriler Chrome'da da mevcut</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Site duraklatıldı</translation>
-<translation id="2063713494490388661">Dokun ve Ara</translation>
-<translation id="2067805253194386918">Kısa mesaj</translation>
-<translation id="2079545284768500474">Geri al</translation>
-<translation id="2082238445998314030"><ph name="TOTAL_RESULTS" /> sonuçtan <ph name="RESULT_NUMBER" /> numaralı sonuç</translation>
-<translation id="2091887806945687916">Ses</translation>
-<translation id="2096012225669085171">Cihazlar arasında senkronizasyon ve kişiselleştirme</translation>
-<translation id="2100273922101894616">Otomatik Oturum Aç</translation>
-<translation id="2100314319871056947">Metni daha küçük parçalar halinde paylaşmayı deneyin</translation>
-<translation id="2107397443965016585">Sitelerin korumalı içeriği oynatmasına izin vermeden önce sor (önerilir)</translation>
-<translation id="2111511281910874386">Sayfaya gidin</translation>
-<translation id="2122601567107267586">Uygulama açılamadı</translation>
-<translation id="2126426811489709554">Chrome tarafından desteklenmektedir</translation>
-<translation id="2131665479022868825"><ph name="DATA" /> tasarruf edildi</translation>
-<translation id="213279576345780926"><ph name="TAB_TITLE" /> kapatıldı</translation>
-<translation id="2139186145475833000">Ana ekrana ekle</translation>
-<translation id="2146738493024040262">Hazır Uygulamayı aç</translation>
-<translation id="2148716181193084225">Bugün</translation>
-<translation id="2154484045852737596">Kartı düzenle</translation>
-<translation id="2154710561487035718">URL'yi Kopyala</translation>
-<translation id="2156074688469523661">Kalan site sayısı (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Telefonunuzdan başka bir cihazla herhangi bir şey paylaşmak için her iki cihazdaki Chrome ayarlarında senkronizasyonu açın</translation>
-<translation id="2170088579611075216">İzin ver ve VR moduna gir</translation>
-<translation id="218608176142494674">Paylaşım</translation>
-<translation id="2227444325776770048"><ph name="USER_FULL_NAME" /> olarak devam edin</translation>
-<translation id="2234876718134438132">Senkronizasyon ve Google hizmetleri</translation>
-<translation id="2259659629660284697">Şifreleri dışa aktar…</translation>
-<translation id="2268044343513325586">Hassaslaştır</translation>
-<translation id="2286841657746966508">Fatura adresi</translation>
-<translation id="2289270750774289114">Bir site yakındaki Bluetooth cihazları bulmak istediğinde sor (önerilir)</translation>
-<translation id="230115972905494466">Uyumlu cihaz bulunamadı</translation>
-<translation id="2315043854645842844">İstemci tarafı sertifika seçimi, işletim sistemi tarafından desteklenmiyor.</translation>
-<translation id="2318045970523081853">Aramak için dokunun</translation>
-<translation id="2321086116217818302">Şifreler hazırlanıyor…</translation>
-<translation id="2321958826496381788">Bu yazıyı rahatça okuyana kadar kaydırma çubuğunu sürükleyin. Bir paragrafa iki kez hafifçe dokunduğunuzda metin en az bunun kadar büyük görünmelidir.</translation>
-<translation id="2323763861024343754">Site depolama alanı</translation>
-<translation id="2328985652426384049">Oturum açılamıyor</translation>
-<translation id="2330129964253841015">Şifrelerinizin güvenliği ihlal edilirse sizi uyarır</translation>
-<translation id="2349710944427398404">Hesaplar, yer işaretleri ve kayıtlı ayarlar da dahil olmak üzere Chrome tarafından kullanılan tüm veriler</translation>
-<translation id="2353636109065292463">İnternet bağlantınızı kontrol etme</translation>
-<translation id="2359808026110333948">Devam et</translation>
-<translation id="2369533728426058518">sekmeleri aç</translation>
-<translation id="2387895666653383613">Metin ölçekleme</translation>
-<translation id="2394602618534698961">İndirdiğiniz dosyalar burada görünür</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Google Hesabınızda oturum açtığınızda bu özellik devreye girer</translation>
-<translation id="2410754283952462441">Bir hesap seçin</translation>
-<translation id="2414886740292270097">Koyu</translation>
-<translation id="2416359993254398973">Chrome'un bu sitede kameranıza erişmesi için izin gerekiyor.</translation>
-<translation id="2426805022920575512">Başka hesap seç</translation>
-<translation id="2433507940547922241">Görünüm</translation>
-<translation id="2434158240863470628">İndirme işlemi tamamlandı <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Konum erişimi</translation>
-<translation id="2450083983707403292"><ph name="FILE_NAME" /> dosyasını tekrar indirmeye başlamak istiyor musunuz?</translation>
-<translation id="2482878487686419369">Bildirimler</translation>
-<translation id="2490684707762498678"><ph name="APP_NAME" /> tarafından yönetiliyor</translation>
-<translation id="2494974097748878569">Chrome'da Google Asistan</translation>
-<translation id="2496180316473517155">Tarama geçmişi</translation>
-<translation id="2497852260688568942">Yöneticiniz senkronizasyonu devre dışı bıraktı</translation>
-<translation id="2498359688066513246">Yardım ve geri bildirim</translation>
-<translation id="2501278716633472235">Geri dön</translation>
-<translation id="2513403576141822879">Gizlilik, güvenlik ve veri toplamayla ilgili daha fazla ayar için <ph name="BEGIN_LINK" />Senkronizasyon ve Google hizmetleri<ph name="END_LINK" /> konusuna bakın</translation>
-<translation id="2518590038762162553">Chrome, Basit modda sayfaları daha hızlı yükler ve yüzde 60'a kadar daha az veri kullanır. Chrome, ziyaret ettiğiniz sayfaları iyileştirmek için web trafiğinizi Google'a gönderir. <ph name="BEGIN_LINK" />Daha fazla bilgi<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Ziyaret ettiğiniz sayfaların URL'lerini Google'a gönderir</translation>
-<translation id="2532336938189706096">Web Görüntüleme</translation>
-<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS" /> öğe silindi</translation>
-<translation id="2536728043171574184">Bu sayfanın çevrimdışı bir kopyası görüntüleniyor</translation>
-<translation id="2546283357679194313">Çerezler ve site verileri</translation>
-<translation id="2567385386134582609">IMAGE</translation>
-<translation id="257088987046510401">Temalar</translation>
-<translation id="2570922361219980984">Konum erişimi bu cihaz için de kapalı. Konum erişimini <ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'ndan açın.</translation>
-<translation id="257931822824936280">Genişletildi - Daraltmak için tıklayın.</translation>
-<translation id="2581165646603367611">Bu işlem Chrome'un önemli olmadığını düşündüğü çerezleri, önbelleği ve diğer site verilerini temizleyecek.</translation>
-<translation id="2586657967955657006">Pano</translation>
-<translation id="2587052924345400782">Daha yeni bir sürüm mevcut</translation>
-<translation id="2593272815202181319">Eş aralıklı</translation>
-<translation id="2612676031748830579">Kart numarası</translation>
-<translation id="2621115761605608342">Belirli bir site için JavaScript'e izin verin.</translation>
-<translation id="2625189173221582860">Şifre kopyalandı</translation>
-<translation id="2631006050119455616">Tasarruf Edilen</translation>
-<translation id="2647434099613338025">Dil ekle</translation>
-<translation id="2650751991977523696">Dosya tekrar indirilsin mi?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Ses dosyası}other{# Ses dosyası}}</translation>
-<translation id="2653659639078652383">Gönder</translation>
-<translation id="2677748264148917807">Çık</translation>
-<translation id="2704606927547763573">Kopyalandı</translation>
-<translation id="2707726405694321444">Sayfayı yenile</translation>
-<translation id="2709516037105925701">Otomatik doldurma</translation>
-<translation id="2717722538473713889">E-posta adresleri</translation>
-<translation id="2728754400939377704">Siteye göre sırala</translation>
-<translation id="2744248271121720757">Anında aramak veya ilgili işlemleri görmek için bir kelimeye dokunun</translation>
-<translation id="2760989362628427051">Cihazınızın koyu tema veya Pil Tasarrufu özelliği açık olduğunda koyu tema açılır</translation>
-<translation id="2762000892062317888">az önce</translation>
-<translation id="2777555524387840389"><ph name="SECONDS" /> sn. kaldı</translation>
-<translation id="2779651927720337254">başarısız</translation>
-<translation id="2781151931089541271">1 sn. kaldı</translation>
-<translation id="2801022321632964776">Chrome'un en son sürümünü kendi dilinizde kullanmak için güncelleyin</translation>
-<translation id="2810645512293415242">Veriden tasarruf etmek ve daha hızlı yüklemek için basitleştirilmiş sayfa.</translation>
-<translation id="281504910091592009"><ph name="BEGIN_LINK" />Google Hesabınızdaki<ph name="END_LINK" /> kayıtlı şifrelerinizi görüntüleyin ve yönetin.</translation>
-<translation id="2818669890320396765">Yer işaretlerinizi tüm cihazlarınızda almak için oturum açın ve senkronizasyonu etkinleştirin</translation>
-<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME" /> için tüm site izinlerini sıfırlamak istediğinizden emin misiniz?</translation>
-<translation id="2836148919159985482">Tam ekrandan çıkmak için geri düğmesine dokunun.</translation>
-<translation id="2842985007712546952">Ana klasör</translation>
-<translation id="2858138569776157458">Popüler siteler</translation>
-<translation id="2860954141821109167">Bu cihazda bir telefon uygulamasının etkinleştirildiğinden emin olun</translation>
-<translation id="2870560284913253234">Site</translation>
-<translation id="2874939134665556319">Önceki parça</translation>
-<translation id="2876369937070532032">Güvenliğiniz risk altında olduğunda ziyaret ettiğiniz bazı sayfaların URL'lerini Google'a gönderir</translation>
-<translation id="2888126860611144412">Chrome hakkında</translation>
-<translation id="2891154217021530873">Sayfa yüklemeyi durdur</translation>
-<translation id="2893180576842394309">Google; Arama ve diğer Google hizmetlerini kişiselleştirmek için geçmişinizi kullanabilir</translation>
-<translation id="2898264748040935573">Saklı şifreyi düzenleyin</translation>
-<translation id="2900528713135656174">Etkinlik oluştur</translation>
-<translation id="290376772003165898">Sayfa <ph name="LANGUAGE" /> dilinde değil mi?</translation>
-<translation id="2904414404539560095">Sekme paylaşılacak cihazların listesi tam yükseklikte açıldı.</translation>
-<translation id="2910701580606108292">Sitelerin korumalı içeriği oynatmasına izin verilmeden önce size sorulur</translation>
-<translation id="2913331724188855103">Sitelerin, çerez verilerini kaydetmelerine ve okumalarına izin ver (önerilir)</translation>
-<translation id="2923908459366352541">Ad geçersiz</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> depolama alanı</translation>
-<translation id="2942036813789421260">Önizleme sekmesi kapalı</translation>
-<translation id="2956410042958133412">Bu hesap <ph name="PARENT_NAME_1" /> ve <ph name="PARENT_NAME_2" /> tarafından yönetiliyor.</translation>
-<translation id="2962095958535813455">Gizli mod sekmelerine geçildi</translation>
-<translation id="2968755619301702150">Sertifika görüntüleyici</translation>
-<translation id="2979025552038692506">Seçili Gizli Sekme</translation>
-<translation id="2987620471460279764">Başka cihazdan paylaşılan metin</translation>
-<translation id="2989523299700148168">Son ziyaret edilenler</translation>
-<translation id="2996291259634659425">Parola oluşturun</translation>
-<translation id="2996809686854298943">URL gerekli</translation>
-<translation id="300526633675317032">Bu işlem <ph name="SIZE_IN_KB" /> olan web sitesi depolama alanının tamamını temizleyecek.</translation>
-<translation id="3016635187733453316">Bu cihazın internete bağlı olduğundan emin olun</translation>
-<translation id="3029613699374795922"><ph name="KBS" /> KB indirildi</translation>
-<translation id="3029704984691124060">Parolalar eşleşmiyor</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Yardım alın<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Konum özelliği kapalı. <ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'ndan açın.</translation>
-<translation id="3058498974290601450">Senkronizasyonu istediğiniz zaman ayarlardan açabilirsiniz</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> yer işareti}other{<ph name="BOOKMARKS_COUNT_MANY" /> yer işareti}}</translation>
-<translation id="3089395242580810162">Gizli sekmede aç</translation>
-<translation id="3115898365077584848">Bilgileri Göster</translation>
-<translation id="3123473560110926937">Bazı sitelerde engellendi</translation>
-<translation id="3137521801621304719">Gizli moddan çık</translation>
-<translation id="3143515551205905069">Senkronizasyonu iptal et</translation>
-<translation id="3157842584138209013">Diğer Seçenekler düğmesini kullanarak ne kadar veri tasarrufu sağladığınıza bakın</translation>
-<translation id="3166827708714933426">Sekme ve pencere kısayolları</translation>
-<translation id="3181954750937456830">Gizli Göz Atma (sizi ve cihazınızı tehlikelerden korur)</translation>
-<translation id="3190152372525844641"><ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'nda Chrome için izinleri açın.</translation>
-<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT" /> depolanmış veri</translation>
-<translation id="3205824638308738187">Çok az kaldı!</translation>
-<translation id="3207960819495026254">Yer işareti koyuldu</translation>
-<translation id="3211426585530211793"><ph name="ITEM_TITLE" /> silindi</translation>
-<translation id="321773570071367578">Parolanızı unuttuysanız veya bu ayarı değiştirmek istiyorsanız <ph name="BEGIN_LINK" />senkronizasyonu sıfırlayın<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Mikrofon</translation>
-<translation id="3232754137068452469">Web Uygulaması</translation>
-<translation id="3236059992281584593">1 dk. kaldı</translation>
-<translation id="3244271242291266297">AA</translation>
-<translation id="3254409185687681395">Bu sayfaya yer işareti koy</translation>
-<translation id="3259831549858767975">Sayfadaki her şeyi küçültür</translation>
-<translation id="3269093882174072735">Resim yükle</translation>
-<translation id="3269956123044984603">Diğer cihazlarınızdaki sekmelerinize ulaşmak için Android hesap ayarlarından "Verileri otomatik senkronize et" seçeneğini etkinleştirin.</translation>
-<translation id="3277252321222022663">Sitelerin sensörlere erişmesine izin ver (önerilen)</translation>
-<translation id="3282568296779691940">Chrome'da oturum aç</translation>
-<translation id="3288003805934695103">Sayfayı yeniden yükleme</translation>
-<translation id="32895400574683172">Bildirimlere izin veriliyor</translation>
-<translation id="3295530008794733555">Daha hızlı tarayın. Daha az veri kullanın.</translation>
-<translation id="3295602654194328831">Bilgileri Gizle</translation>
-<translation id="3298243779924642547">Basit</translation>
-<translation id="3303414029551471755">İçeriği indirme işlemine başlansın mı?</translation>
-<translation id="3306398118552023113">Bu uygulama Chrome'da çalışıyor</translation>
-<translation id="3315103659806849044">Şu anda Senkronizasyon ve Google hizmet ayarlarınızı özelleştiriyorsunuz. Senkronizasyonu etkinleştirme işlemini tamamlamak için ekranın altına yakın bir yerde bulunan Onayla düğmesine dokunun. Yukarı git</translation>
-<translation id="3328801116991980348">Site bilgileri</translation>
-<translation id="3333961966071413176">Tüm kişiler</translation>
-<translation id="3334729583274622784">Dosya uzantısı değiştirilsin mi?</translation>
-<translation id="3341058695485821946">Ne kadar veri tasarrufu sağladığınıza bakın</translation>
-<translation id="3350687908700087792">Tüm gizli sekmeleri kapatın.</translation>
-<translation id="3353615205017136254">Google tarafından sağlanan basit sayfa. Sayfanın orijinalini yüklemek için orijinali yükle düğmesine dokunun.</translation>
-<translation id="3367813778245106622">Senkronizasyonu başlatmak için tekrar oturum açın</translation>
-<translation id="3374023511497244703">Yer işaretleri, geçmiş, şifreler ve diğer Chrome verileriniz artık Google Hesabınız ile senkronize edilmeyecek.</translation>
-<translation id="3384347053049321195">Resmi paylaş</translation>
-<translation id="3386292677130313581">Sitelerin, konumunuzu öğrenmesine izin verilmeden önce size sorulsun (önerilir)</translation>
-<translation id="3387650086002190359">Dosya sistemi hataları nedeniyle <ph name="FILE_NAME" /> dosyası indirilemedi.</translation>
-<translation id="3389286852084373014">Metin çok büyük</translation>
-<translation id="3398320232533725830">Yer işareti yöneticisini açar</translation>
-<translation id="3414952576877147120">Boyut:</translation>
-<translation id="3443221991560634068">Geçerli sayfayı yeniden yükler</translation>
-<translation id="3445014427084483498">Az Önce</translation>
-<translation id="3478363558367712427">Arama motorunuzu seçebilirsiniz</translation>
+<translation id="6910211073230771657">Silindi</translation>
+<translation id="6965382102122355670">Tamam</translation>
+<translation id="5301954838959518834">Tamam, anladım</translation>
+<translation id="7658239707568436148">İptal</translation>
 <translation id="3479552764303398839">Şimdi değil</translation>
-<translation id="3492207499832628349">Yeni gizli sekme</translation>
-<translation id="3493531032208478708">Önerilen içerik hakkında <ph name="BEGIN_LINK" />daha fazla bilgi edinin<ph name="END_LINK" /></translation>
-<translation id="3513704683820682405">Artırılmış Gerçeklik</translation>
-<translation id="3518985090088779359">Kabul et ve devam et</translation>
-<translation id="3522247891732774234">Güncelleme mevcut. Diğer seçenekler</translation>
-<translation id="3524138585025253783">Geliştirici Kullanıcı Arayüzü</translation>
-<translation id="3527085408025491307">Klasör</translation>
-<translation id="3542235761944717775"><ph name="KILOBYTES" /> KB kullanılabilir</translation>
-<translation id="3549657413697417275">Geçmişinizde arayın</translation>
-<translation id="3557336313807607643">Kişilere ekle</translation>
-<translation id="3566923219790363270">Chrome hâlâ VR için hazırlanıyor. Chrome'u daha sonra yeniden başlatın.</translation>
-<translation id="3568688522516854065">Diğer cihazlarınızdaki sekmelerinize ulaşmak için oturum açın ve senkronizasyonu etkinleştirin</translation>
-<translation id="3587482841069643663">Tümü</translation>
-<translation id="358794129225322306">Bir sitenin otomatik olarak birden fazla dosya indirmesine izin verir.</translation>
-<translation id="3590487821116122040">Chrome'un önemli olmadığını düşündüğü site depolama alanı (ör. kayıtlı ayarları bulunmayan veya sık ziyaret etmediğiniz siteler)</translation>
-<translation id="3599863153486145794">Oturumunuzun açık olduğu tüm cihazlarda geçmişi temizler. Google Hesabınızın <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> adresinde başka biçimlerde tarama geçmişi olabilir.</translation>
-<translation id="3600792891314830896">Ses çalan sitelerin sesini kapat</translation>
-<translation id="3616113530831147358">Ses</translation>
-<translation id="3631987586758005671"><ph name="DEVICE_NAME" /> ile paylaşılıyor</translation>
-<translation id="3632295766818638029">Şifreyi göster</translation>
-<translation id="363596933471559332">Depolanmış kimlik bilgileriyle web sitelerinde otomatik olarak oturum açın. Bu özellik kapatıldığında, bir web sitesinde oturum açmadan önce her defasında doğrulama yapmanız istenir.</translation>
-<translation id="3658159451045945436">Sıfırlama işlemi, ziyaret edilen sitelerin listesi de dahil olmak üzere veri tasarrufu geçmişinizi siler.</translation>
-<translation id="3692944402865947621">Depolama konumuna erişilemediği için <ph name="FILE_NAME" /> dosyası indirilemedi.</translation>
-<translation id="3714981814255182093">Bulma Çubuğu'nu açar</translation>
-<translation id="3716182511346448902">Bu sayfa, bellekte çok fazla yer kapladığından Chrome tarafından duraklatıldı.</translation>
-<translation id="3730075448226062617">Chrome'un mikrofonunuza erişebilmesi için <ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'nda da mikrofonu açın.</translation>
-<translation id="3739899004075612870"><ph name="PRODUCT_NAME" /> üzerinde yer işareti koyuldu</translation>
-<translation id="3744111561329211289">Arka plan senkronizasyonu</translation>
-<translation id="3771001275138982843">Güncelleme indirilemedi</translation>
-<translation id="3771033907050503522">Gizli Sekmeler</translation>
-<translation id="3773755127849930740">Eşleşmeye izin vermek için <ph name="BEGIN_LINK" />Bluetooth'u açın<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">Cihazlarınıza gönderin</translation>
-<translation id="3778956594442850293">Ana ekrana eklendi</translation>
-<translation id="3789841737615482174">Yükle</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Yönet</translation>
-<translation id="381841723434055211">Telefon numaraları</translation>
-<translation id="3819178904835489326">İndirilen <ph name="NUMBER_OF_DOWNLOADS" /> dosya silindi</translation>
-<translation id="3822502789641063741">Site depolama silinsin mi?</translation>
-<translation id="385051799172605136">Geri</translation>
-<translation id="3859306556332390985">İleriye doğru git</translation>
-<translation id="3894427358181296146">Klasör ekleyin</translation>
-<translation id="3895926599014793903">Yakınlaştırmayı etkinleştirmeye zorla</translation>
-<translation id="3912508018559818924">Web'in en iyilerini buluyoruz…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Verilerimi birleştir</translation>
-<translation id="393697183122708255">Kullanılabilir etkin sesli arama yok</translation>
-<translation id="395206256282351086">Arama ve site önerileri devre dışı bırakıldı</translation>
-<translation id="3955193568934677022">Sitelerin korumalı içeriği oynatmasına izin ver (önerilir)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome, hazır olduğunda sayfanızı yükler}other{Chrome, hazır olduğunda sayfalarınızı yükler}}</translation>
-<translation id="3963007978381181125">Parolayla şifreleme, Google Pay'deki adresleri ve ödeme yöntemlerini kapsamaz. Yalnızca parolanızı bilen biri, şifrelenmiş verilerinizi okuyabilir. Parola Google'a gönderilmez veya Google tarafından saklanmaz. Parolanızı unutursanız veya bu ayarı değiştirmek isterseniz senkronizasyonu sıfırlamanız gerekir. <ph name="BEGIN_LINK" />Daha fazla bilgi<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">İndirme tamamlandı</translation>
-<translation id="397583555483684758">Senkronizasyonun çalışması durdu</translation>
-<translation id="3976396876660209797">Bu kısayolu kaldırıp yeniden oluşturun</translation>
-<translation id="3985215325736559418"><ph name="FILE_NAME" /> dosyasını tekrar indirmek istiyor musunuz?</translation>
-<translation id="3987993985790029246">Bağlantıyı kopyala</translation>
-<translation id="3988213473815854515">Konuma izin veriliyor</translation>
-<translation id="3988466920954086464">Anında arama sonuçlarını bu panelde görün</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" /> / ?</translation>
-<translation id="3997476611815694295">Önemli olmayan depolama alanı</translation>
-<translation id="4000212216660919741">Çevrimdışı Ana Sayfa</translation>
+<translation id="5317780077021120954">Kaydet</translation>
+<translation id="4570913071927164677">Ayrıntılar</translation>
+<translation id="8730621377337864115">Bitti</translation>
+<translation id="8261506727792406068">Sil</translation>
+<translation id="1181037720776840403">Kaldır</translation>
+<translation id="5939518447894949180">Sıfırla</translation>
 <translation id="4002066346123236978">Başlık</translation>
-<translation id="4008040567710660924">Belirli bir site için çerezlere izin verin.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# sa.}other{# sa.}}</translation>
-<translation id="4046123991198612571">Sonraki parça</translation>
-<translation id="4048707525896921369">Sayfadan ayrılmadan web siteleriyle ilgili konuları öğrenin. Dokun ve Ara özelliği seçilen kelimeyi, çevresindeki içerikle birlikte Google Arama'ya gönderir ve karşılığında ilgili tanımlar, resimler, arama sonuçları ve diğer ayrıntıları döndürür.
+<translation id="5916664084637901428">Açık</translation>
+<translation id="5860033963881614850">Kapalı</translation>
+<translation id="6165508094623778733">Daha fazla bilgi edinin</translation>
+<translation id="6042308850641462728">Daha fazla</translation>
+<translation id="6040143037577758943">Kapat</translation>
+<translation id="780301667611848630">Hayır, teşekkürler</translation>
+<translation id="1201402288615127009">İleri</translation>
+<translation id="2359808026110333948">Devam et</translation>
+<translation id="2653659639078652383">Gönder</translation>
+<translation id="2079545284768500474">Geri al</translation>
+<translation id="7649070708921625228">Yardım</translation>
+<translation id="2148716181193084225">Bugün</translation>
+<translation id="7781829728241885113">Dün</translation>
+<translation id="6945221475159498467">Seç</translation>
+<translation id="7791543448312431591">Ekle</translation>
+<translation id="6527303717912515753">Paylaş</translation>
+<translation id="1383876407941801731">Ara</translation>
+<translation id="3115898365077584848">Bilgileri Göster</translation>
+<translation id="3295602654194328831">Bilgileri Gizle</translation>
+<translation id="3987993985790029246">Bağlantıyı kopyala</translation>
+<translation id="2704606927547763573">Kopyalandı</translation>
+<translation id="8725066075913043281">Yeniden dene</translation>
+<translation id="385051799172605136">Geri</translation>
+<translation id="8131740175452115882">Onayla</translation>
+<translation id="5300589172476337783">Göster</translation>
+<translation id="1124772482545689468">Kullanıcı</translation>
+<translation id="8609465669617005112">Yukarı taşı</translation>
+<translation id="6746124502594467657">Aşağı taşı</translation>
+<translation id="8249310407154411074">En üste taşı</translation>
+<translation id="8428213095426709021">Ayarlar</translation>
+<translation id="2498359688066513246">Yardım ve geri bildirim</translation>
+<translation id="8378714024927312812">Kuruluşunuz tarafından yönetiliyor</translation>
+<translation id="9019902583201351841">Ebeveynleriniz tarafından yönetiliyor</translation>
+<translation id="4645575059429386691">Ebeveyniniz tarafından yönetiliyor</translation>
+<translation id="4883854917563148705">Yönetilen ayarlar sıfırlanamaz</translation>
+<translation id="4307992518367153382">Temel Bilgiler</translation>
+<translation id="1974060860693918893">Gelişmiş</translation>
+<translation id="1146678959555564648">VR'ye Gir</translation>
+<translation id="987264212798334818">Genel</translation>
+<translation id="4275663329226226506">Medya</translation>
+<translation id="4759238208242260848">İndirilenler</translation>
+<translation id="218608176142494674">Paylaşım</translation>
+<translation id="8004582292198964060">Tarayıcı</translation>
+<translation id="1105960400813249514">Ekran Kaydediliyor</translation>
+<translation id="4875775213178255010">İçerik Önerileri</translation>
+<translation id="2021896219286479412">Tam ekran site kontrolleri</translation>
+<translation id="4587589328781138893">Siteler</translation>
+<translation id="4943703118917034429">Sanal Gerçeklik</translation>
+<translation id="1928696683969751773">Güncellemeler</translation>
+<translation id="6064125863973209585">Tamamlanan indirme işlemleri</translation>
+<translation id="5342314432463739672">İzin istekleri</translation>
+<translation id="629730747756840877">Hesap</translation>
+<translation id="82609232232243542">Brave'da oturum aç</translation>
+<translation id="7956662517480676674">Senkronizasyon ve Brave Software hizmetleri</translation>
+<translation id="5294439808117722387">Şu anda Senkronizasyon ve Brave Software hizmet ayarlarınızı özelleştiriyorsunuz. Senkronizasyonu etkinleştirme işlemini tamamlamak için ekranın altına yakın bir yerde bulunan Onayla düğmesine dokunun. Yukarı git</translation>
+<translation id="2096012225669085171">Cihazlar arasında senkronizasyon ve kişiselleştirme</translation>
+<translation id="1692118695553449118">Senkronizasyon açık.</translation>
+<translation id="5514904542973294328">Bu cihazın yöneticisi tarafından devre dışı bırakıldı</translation>
+<translation id="6447211988989208781">Brave Software etkinlik kontrolleri</translation>
+<translation id="4882831918239250449">Göz atma geçmişinizin Arama, reklamlar ve diğer hizmetleri kişiselleştirmek için nasıl kullanıldığını kontrol edin</translation>
+<translation id="7431991332293347422">Göz atma geçmişinizin Arama ve diğer hizmetleri kişiselleştirmek için nasıl kullanıldığını kontrol edin</translation>
+<translation id="6303969859164067831">Oturumu ve senkronizasyonu kapat</translation>
+<translation id="1125261911132334651">Brave Software Hesabınızı yönetin</translation>
+<translation id="6406506848690869874">Senkronizasyon</translation>
+<translation id="714362445477979774">Brave verilerimi senkronize et</translation>
+<translation id="4314815835985389558">Senkronizasyonu yönetin</translation>
+<translation id="5428209950370661546">Diğer Brave Software hizmetleri</translation>
+<translation id="7704317875155739195">Aramaları ve URL'leri otomatik tamamla</translation>
+<translation id="2000419248597011803">Adres çubuğundan ve arama kutusundan bazı çerezleri ve aramaları varsayılan arama motorunuza gönderir</translation>
+<translation id="7981313251711023384">Daha hızlı göz atmak ve arama yapmak için sayfaları önceden yükle</translation>
+<translation id="1821253160463689938">Belirtilen sayfaları ziyaret etmiyor olsanız bile tercihlerinizi hatırlamak için çerezler kullanır</translation>
+<translation id="6697492270171225480">Bir sayfa bulunamadığında benzer sayfalar için önerileri göster</translation>
+<translation id="8109318360573330108">Erişmeye çalıştığınız sayfanın URL'sini Brave Software'a gönderir</translation>
+<translation id="8438566539970814960">Aramaları ve göz atmayı daha iyi yap</translation>
+<translation id="284843628681142937">Ziyaret ettiğiniz sayfaların URL'lerini Brave Software'a gönderir</translation>
+<translation id="7222718784508482526">Gizlilik, güvenlik ve veri toplamayla ilgili daha fazla ayar için <ph name="BEGIN_LINK"/>Senkronizasyon ve Brave Software hizmetleri<ph name="END_LINK"/> konusuna bakın</translation>
+<translation id="918192811481327695">Brave'un özelliklerini ve performansını iyileştirmeye yardımcı olun</translation>
+<translation id="9063160602596686558">Kullanım istatistiklerini ve kilitlenme raporlarını Brave Software'a otomatik olarak gönderir</translation>
+<translation id="4824958205181053313">Senkronizasyon iptal edilsin mi?</translation>
+<translation id="3058498974290601450">Senkronizasyonu istediğiniz zaman ayarlardan açabilirsiniz</translation>
+<translation id="3143515551205905069">Senkronizasyonu iptal et</translation>
+<translation id="1506061864768559482">Arama motoru</translation>
+<translation id="55737423895878184">Konum ve bildirimlere izin veriliyor</translation>
+<translation id="3988213473815854515">Konuma izin veriliyor</translation>
+<translation id="32895400574683172">Bildirimlere izin veriliyor</translation>
+<translation id="9040142327097499898">Bildirimlere izin veriliyor. Konum özelliği bu cihazda kapalı.</translation>
+<translation id="305593374596241526">Konum özelliği kapalı. <ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'ndan açın.</translation>
+<translation id="2989523299700148168">Son ziyaret edilenler</translation>
+<translation id="6433501201775827830">Arama motorunuzu seçin</translation>
+<translation id="7177466738963138057">Bunu daha sonra Ayarlar'da değiştirebilirsiniz</translation>
+<translation id="3478363558367712427">Arama motorunuzu seçebilirsiniz</translation>
+<translation id="4910889077668685004">Ödeme uygulamaları</translation>
+<translation id="5152843274749979095">Desteklenen yüklü uygulama yok</translation>
+<translation id="8812260976093120287">Bazı web sitelerinde, yukarıdaki desteklenen ödeme uygulamalarıyla cihazınızdan ödeme yapabilirsiniz.</translation>
+<translation id="7764225426217299476">Adres ekle</translation>
+<translation id="5595485650161345191">Adresi düzenle</translation>
+<translation id="5087580092889165836">Kart ekle</translation>
+<translation id="2154484045852737596">Kartı düzenle</translation>
+<translation id="6140912465461743537">Ülke/Bölge</translation>
+<translation id="5659593005791499971">E-posta</translation>
+<translation id="4378154925671717803">Telefon</translation>
+<translation id="4807098396393229769">Kartın üzerindeki ad</translation>
+<translation id="860043288473659153">Kart sahibinin adı</translation>
+<translation id="2612676031748830579">Kart numarası</translation>
+<translation id="869891660844655955">Son kullanma tarihi</translation>
+<translation id="2286841657746966508">Fatura adresi</translation>
+<translation id="663059986967017181">Brave'a kopyalandı</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ödeme yöntemi daha}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> ödeme yöntemi daha}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> adres daha}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> adres daha}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> seçenek daha}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> seçenek daha}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> kişi daha}other{<ph name="CONTACT_PREVIEW"/>\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> kişi daha}}</translation>
+<translation id="7029809446516969842">Şifreler</translation>
+<translation id="1943432128510653496">Şifreleri kaydet</translation>
+<translation id="2100273922101894616">Otomatik Oturum Aç</translation>
+<translation id="363596933471559332">Depolanmış kimlik bilgileriyle web sitelerinde otomatik olarak oturum açın. Bu özellik kapatıldığında, bir web sitesinde oturum açmadan önce her defasında doğrulama yapmanız istenir.</translation>
+<translation id="6995899638241819463">Şifreleriniz bir veri ihlalinde ifşa olursa uyarı alın</translation>
+<translation id="1534287762301776620">Brave Software Hesabınızda oturum açtığınızda bu özellik devreye girer</translation>
+<translation id="10614374240317010">Hiç kaydedilmeyecekler</translation>
+<translation id="3098842761938485917"><ph name="BEGIN_LINK"/>Brave Software Hesabınızdaki<ph name="END_LINK"/> kayıtlı şifrelerinizi görüntüleyin ve yönetin.</translation>
+<translation id="8562452229998620586">Kayıtlı şifreleriniz burada görünür.</translation>
+<translation id="8084114998886531721">Kayıtlı şifre</translation>
+<translation id="2870560284913253234">Site</translation>
+<translation id="8503813439785031346">Kullanıcı adı</translation>
+<translation id="6657585470893396449">Şifre</translation>
+<translation id="2154710561487035718">URL'yi Kopyala</translation>
+<translation id="1571304935088121812">Kullanıcı adını kopyala</translation>
+<translation id="5005498671520578047">Şifreyi kopyalayın</translation>
+<translation id="3632295766818638029">Şifreyi göster</translation>
+<translation id="1513858653616922153">Şifreyi sil</translation>
+<translation id="543338862236136125">Şifreyi düzenle</translation>
+<translation id="4565377596337484307">Şifreyi gizle</translation>
+<translation id="8523928698583292556">Kayıtlı şifreyi sil</translation>
+<translation id="2898264748040935573">Saklı şifreyi düzenleyin</translation>
+<translation id="5433691172869980887">Kullanıcı adı kopyalandı</translation>
+<translation id="5534640966246046842">Site kopyalandı</translation>
+<translation id="2625189173221582860">Şifre kopyalandı</translation>
+<translation id="4550003330909367850">Burada şifrenizi görüntülemek veya kopyalamak için bu cihazda ekran kilidini ayarlayın.</translation>
+<translation id="6154478581116148741">Bu cihazdaki şifrelerinizi dışarı aktarmak için Ayarlar'da ekran kilidini açın</translation>
+<translation id="4842092870884894799">Şifre oluşturma pop-up'ı gösteriliyor</translation>
+<translation id="2259659629660284697">Şifreleri dışa aktar…</translation>
+<translation id="133012818630824069">Brave'da depolanan şifreleri dışa aktarın</translation>
+<translation id="6914783257214138813">Şifreleriniz, dışa aktarılan dosyayı görebilen herkes tarafından görülebilir.</translation>
+<translation id="2321086116217818302">Şifreler hazırlanıyor…</translation>
+<translation id="8445448999790540984">Şifreler dışa aktarılamıyor</translation>
+<translation id="3066461326500799725">Brave Software Drive'ın nasıl kullanılacağını öğrenin</translation>
+<translation id="729975465115245577">Cihazınızda şifreler dosyasını depolayacak bir uygulama yok.</translation>
+<translation id="7682724950699840886">Şu ipuçlarını deneyin: Cihazınızda yeterli alan bulunduğundan emin olun, daha sonra dışa aktarmayı tekrar deneyin.</translation>
+<translation id="1129510026454351943">Ayrıntılar: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Şifrenizi kopyalamak için kilidi açın</translation>
+<translation id="5515439363601853141">Şifrenizi görüntülemek için kilidi açın</translation>
+<translation id="6221633008163990886">Şifrelerinizi dışa aktarmak için kilit açılamadı</translation>
+<translation id="230699814587342492">Brave Şifreleri</translation>
+<translation id="6075798973483050474">Ana sayfayı düzenle</translation>
+<translation id="854522910157234410">Şu sayfayı aç:</translation>
+<translation id="2482878487686419369">Bildirimler</translation>
+<translation id="6255999984061454636">İçerik önerileri</translation>
+<translation id="805047784848435650">Tarama geçmişinize dayalı</translation>
+<translation id="1041308826830691739">Web sitelerinden</translation>
+<translation id="395206256282351086">Arama ve site önerileri devre dışı bırakıldı</translation>
+<translation id="257088987046510401">Temalar</translation>
+<translation id="4650364565596261010">Sistem varsayılanı</translation>
+<translation id="7588219262685291874">Cihazın Pil Tasarrufu özelliği açık olduğunda koyu tema açılır</translation>
+<translation id="2760989362628427051">Cihazınızın koyu tema veya Pil Tasarrufu özelliği açık olduğunda koyu tema açılır</translation>
+<translation id="6381421346744604172">Web sitelerini karart</translation>
+<translation id="5040262127954254034">Gizlilik</translation>
+<translation id="4991384657077828949">Brave güvenliğini iyileştirmeye yardımcı olun</translation>
+<translation id="1943176487615318915">Brave, tehlikeli uygulamaları ve siteleri algılamak için Brave Software'a ziyaret ettiğiniz bazı sitelerin URL'lerini, sınırlı sistem bilgisini ve bazı sayfa içeriklerini gönderir.</translation>
+<translation id="3181954750937456830">Gizli Göz Atma (sizi ve cihazınızı tehlikelerden korur)</translation>
+<translation id="7315322926489145388">Güvenliğiniz risk altında olduğunda ziyaret ettiğiniz bazı sayfaların URL'lerini Brave Software'a gönderir</translation>
+<translation id="2063713494490388661">Dokun ve Ara</translation>
+<translation id="2369463299479365221">Sayfadan ayrılmadan web siteleriyle ilgili konuları öğrenin. Dokun ve Ara özelliği seçilen kelimeyi, çevresindeki içerikle birlikte Brave Software Arama'ya gönderir ve karşılığında ilgili tanımlar, resimler, arama sonuçları ve diğer ayrıntıları döndürür.
 
 Arama teriminizi düzeltmek için uzun basarak terimi seçin. Aramanızı ayrıntılı hale getirmek için paneli tümüyle yukarı kaydırın ve arama kutusuna dokunun.</translation>
-<translation id="4056223980640387499">Sepya Tonu</translation>
-<translation id="4060598801229743805">Ekranın üst kısmına yakın bir yerde seçenekler vardır</translation>
-<translation id="4062305924942672200">Yasal bilgiler</translation>
-<translation id="4084682180776658562">Yer İşareti</translation>
-<translation id="4084712963632273211"><ph name="PUBLISHER_ORIGIN" /> web sitesinden - <ph name="BEGIN_DEEMPHASIZED" />Google tarafından yayınlandı<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Uygulama verileri silinsin mi?</translation>
-<translation id="4099578267706723511">Google'a kullanım istatistikleri ve kilitlenme raporları göndererek Chrome'u iyileştirmeye yardımcı olun.</translation>
-<translation id="410351446219883937">Otomatik oynatma</translation>
-<translation id="4116038641877404294">Sayfaları çevrimdışı olarak kullanmak için indirin</translation>
-<translation id="4135200667068010335">Sekme paylaşılacak cihazların listesi kapalı.</translation>
-<translation id="4149994727733219643">Web sayfalarının basitleştirilmiş görünümü</translation>
-<translation id="4165986682804962316">Site ayarları</translation>
-<translation id="4169535189173047238">İzin verme</translation>
-<translation id="4170011742729630528">Hizmet kullanılamıyor, daha sonra tekrar deneyin.</translation>
-<translation id="4179980317383591987"><ph name="AMOUNT" /> miktar</translation>
-<translation id="4181841719683918333">Diller</translation>
-<translation id="4183868528246477015">Google Lens ile ara <ph name="BEGIN_NEW" />Yeni<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Yeni sekmede aç</translation>
-<translation id="4198423547019359126">Kullanılabilir indirme yeri yok</translation>
-<translation id="4209895695669353772">Google tarafından önerilen kişiselleştirilmiş içeriği almak için senkronizasyonu açın</translation>
-<translation id="4226663524361240545">Bildirimler cihazı titretebilir</translation>
-<translation id="423219824432660969"><ph name="TIME" /> itibarıyla, senkronize edilmiş verileri Google şifresiyle şifrele</translation>
-<translation id="4242533952199664413">Ayarları aç</translation>
-<translation id="4256782883801055595">Açık kaynak lisansları</translation>
-<translation id="4259722352634471385">Gezinme engellendi: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Bağlantı adresini kopyala</translation>
-<translation id="4275663329226226506">Medya</translation>
-<translation id="4278390842282768270">İzin verilen</translation>
-<translation id="429312253194641664">Bir site medya oynatıyor</translation>
-<translation id="4298388696830689168">Bağlantılı siteler</translation>
-<translation id="4307992518367153382">Temel Bilgiler</translation>
-<translation id="4314815835985389558">Senkronizasyonu yönetin</translation>
-<translation id="4351244548802238354">İletişim kutusunu kapat</translation>
-<translation id="4378154925671717803">Telefon</translation>
-<translation id="4384468725000734951">Arama için Sogou kullanılıyor</translation>
-<translation id="4404568932422911380">Yer işareti yok</translation>
-<translation id="4405224443901389797">Klasöre taşı…</translation>
-<translation id="4411535500181276704">Basit mod</translation>
-<translation id="4415276339145661267">Google Hesabınızı yönetin</translation>
-<translation id="4432792777822557199"><ph name="SOURCE_LANGUAGE" /> dilindeki sayfalar artık <ph name="TARGET_LANGUAGE" /> diline çevrilecek</translation>
-<translation id="4433925000917964731">Google tarafından sağlanan basit sayfa</translation>
-<translation id="4434045419905280838">Pop-up'lar ve yönlendirmeler</translation>
-<translation id="4440958355523780886">Google tarafından sağlanan basit sayfa. Sayfanın orijinalini yüklemek için dokunun.</translation>
-<translation id="4452411734226507615"><ph name="TAB_TITLE" /> sekmesini kapat</translation>
-<translation id="4452548195519783679">Yer işareti <ph name="FOLDER_NAME" /> klasörüne eklendi</translation>
-<translation id="445467742685312942">Sitelerin korumalı içeriği oynatmasına izin ver</translation>
-<translation id="4468959413250150279">Belirli bir site için sesi kapatın.</translation>
-<translation id="4472118726404937099">Cihazlar arasında senkronizasyon ve kişiselleştirme yapmak için oturum açın ve senkronizasyonu etkinleştirin</translation>
-<translation id="447252321002412580">Chrome'un özelliklerini ve performansını iyileştirmeye yardımcı olun</translation>
-<translation id="4479647676395637221">Sitelerin, kameranızı kullanmasına izin verilmeden önce size sorulsun (önerilir)</translation>
-<translation id="4479972344484327217">Chrome için <ph name="MODULE" /> yükleniyor…</translation>
-<translation id="4487967297491345095">Chrome'un tüm uygulama verileri kalıcı olarak silinecek. Buna tüm dosyalar, ayarlar, hesaplar, veritabanları vb. dahildir.</translation>
-<translation id="4493497663118223949">Basit mod açık</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# gün önce}other{# gün önce}}</translation>
-<translation id="451872707440238414">Yer işaretlerinizde arayın</translation>
-<translation id="4521489764227272523">Seçilen veriler Chrome'dan ve senkronize edilen cihazlarınızdan kaldırıldı.
-
-Diğer Google hizmetlerinden yapılan aramalar ve etkinlikler gibi Google hesabınızla ilişkili başka biçimlerde tarama geçmişi <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> adresinde bulunabilir.</translation>
-<translation id="4532845899244822526">Klasör seçin</translation>
-<translation id="4538018662093857852">Basit modu aç</translation>
-<translation id="4550003330909367850">Burada şifrenizi görüntülemek veya kopyalamak için bu cihazda ekran kilidini ayarlayın.</translation>
-<translation id="4558311620361989323">Web sayfası kısayolları</translation>
-<translation id="4561979708150884304">Bağlantı yok</translation>
-<translation id="4565377596337484307">Şifreyi gizle</translation>
-<translation id="4570913071927164677">Ayrıntılar</translation>
-<translation id="4572422548854449519">Yönetilen hesapta oturum açın</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# dakika önce}other{# dakika önce}}</translation>
-<translation id="4587589328781138893">Siteler</translation>
-<translation id="4594952190837476234">Bu çevrimdışı sayfa <ph name="CREATION_TIME" /> tarihli olup web'deki sürümden farklı olabilir.</translation>
-<translation id="4605958867780575332">Öğe kaldırıldı: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855"><ph name="WEBAPK_NAME" /> APK'sını aç</translation>
-<translation id="4634124774493850572">Şifre kullan</translation>
-<translation id="4645575059429386691">Ebeveyniniz tarafından yönetiliyor</translation>
-<translation id="4650364565596261010">Sistem varsayılanı</translation>
-<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS" /> yer işareti silindi</translation>
-<translation id="4665282149850138822"><ph name="NAME" />, Ana ekranınıza eklendi</translation>
-<translation id="4684427112815847243">Her şeyi senkronize et</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> seçenek daha}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> seçenek daha}}</translation>
-<translation id="4696983787092045100">Cihazlarınıza mesaj gönderin</translation>
-<translation id="4698034686595694889"><ph name="APP_NAME" /> uygulamasında çevrimdışı görüntüle</translation>
-<translation id="4699172675775169585">Önbelleğe alınan resimler ve dosyalar</translation>
-<translation id="4714588616299687897">%60'a kadar veri tasarrufu sağlayın</translation>
-<translation id="4719927025381752090">Çevirmeyi öner</translation>
-<translation id="4720023427747327413"><ph name="PRODUCT_NAME" /> uygulamasında aç</translation>
-<translation id="4720982865791209136">Chrome'u daha iyi hale getirmeye yardımcı olun. <ph name="BEGIN_LINK" />Ankete katıl<ph name="END_LINK" />.</translation>
-<translation id="473775607612524610">Güncelle</translation>
-<translation id="4738836084190194332">Son senkronizasyon: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Yeni sekme açar</translation>
-<translation id="4751476147751820511">Hareket veya ışık sensörleri</translation>
-<translation id="4759238208242260848">İndirilenler</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 indirme işlemi tamamlandı.}other{# indirme işlemi tamamlandı.}}</translation>
-<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB" /> adresine dönmek için dokunun</translation>
-<translation id="4802417911091824046">Parolayla şifreleme, Google Pay'deki adresleri ve ödeme yöntemlerini kapsamaz.
-
-Bu ayarı değiştirmek için <ph name="BEGIN_LINK" />senkronizasyonu sıfırlayın<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Kartın üzerindeki ad</translation>
-<translation id="4824958205181053313">Senkronizasyon iptal edilsin mi?</translation>
-<translation id="4837753911714442426">Sayfayı yazdırma seçeneklerini açar</translation>
-<translation id="4842092870884894799">Şifre oluşturma pop-up'ı gösteriliyor</translation>
-<translation id="4860895144060829044">Telefon et</translation>
-<translation id="4866368707455379617">Chrome için <ph name="MODULE" /> yüklenemiyor</translation>
-<translation id="4875775213178255010">İçerik Önerileri</translation>
-<translation id="4878404682131129617">Proxy sunucu üzerinden tünel oluşturulamadı</translation>
-<translation id="4880127995492972015">Çevir...</translation>
-<translation id="4881695831933465202">Aç</translation>
-<translation id="488187801263602086">Dosyayı yeniden adlandırın</translation>
-<translation id="4882831918239250449">Göz atma geçmişinizin Arama, reklamlar ve diğer hizmetleri kişiselleştirmek için nasıl kullanıldığını kontrol edin</translation>
-<translation id="4883854917563148705">Yönetilen ayarlar sıfırlanamaz</translation>
-<translation id="4885273946141277891">Desteklenmeyen sayıda Chrome örneği var.</translation>
-<translation id="4910889077668685004">Ödeme uygulamaları</translation>
-<translation id="4913161338056004800">İstatistikleri sıfırla</translation>
-<translation id="4913169188695071480">Yenilemeyi durdur</translation>
-<translation id="4915549754973153784">Cihazlar taranırken <ph name="BEGIN_LINK" />yardım alın<ph name="END_LINK" />…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Sayfa}other{# Sayfa}}</translation>
-<translation id="4932247056774066048"><ph name="DOMAIN_NAME" /> tarafından yönetilen bir hesabın oturumunu kapattığınız için Chrome verileriniz bu cihazdan silinecektir. Verileriniz Google Hesabınızda kalacaktır.</translation>
-<translation id="4943703118917034429">Sanal Gerçeklik</translation>
-<translation id="4943872375798546930">Sonuç yok</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> ekranınızı paylaşıyor</translation>
-<translation id="4961107849584082341">Bu sayfayı istediğiniz dile çevirin</translation>
-<translation id="4962975101802056554">Cihaz için tüm izinleri iptal eder</translation>
-<translation id="4970824347203572753">Bulunduğunuz konumda kullanılamıyor</translation>
-<translation id="497421865427891073">İlerle</translation>
-<translation id="4988210275050210843">Dosya indiriliyor (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Sayfalar</translation>
-<translation id="4994033804516042629">Kişi bulunamadı</translation>
-<translation id="4996978546172906250">Paylaşım yöntemi:</translation>
-<translation id="5004416275253351869">Google etkinlik kontrolleri</translation>
-<translation id="5005498671520578047">Şifreyi kopyalayın</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> bağlanmak istiyor</translation>
-<translation id="5013696553129441713">Yeni öneri yok</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Siz VR modundayken bu site şu konuda bilgi edinebilir:
-  -  Fiziksel özellikleriniz (ör. boyunuz)
-
-VR moduna girmeden önce bu siteye güvendiğinizden emin olun.</translation>
+<translation id="2930742481329940825">Dokun ve Ara özelliği, seçilen kelimeyi ve geçerli sayfayı Brave Software Arama'ya bağlam olarak gönderir. Bu özelliği <ph name="BEGIN_LINK"/>Ayarlar<ph name="END_LINK"/>'da kapatabilirsiniz.</translation>
 <translation id="5039804452771397117">İzin ver</translation>
-<translation id="5040262127954254034">Gizlilik</translation>
-<translation id="5048398596102334565">Sitelerin hareket sensörlerine erişmesine izin ver (önerilen)</translation>
-<translation id="5063480226653192405">Kullanım</translation>
-<translation id="5087580092889165836">Kart ekle</translation>
-<translation id="5100237604440890931">Daraltıldı - Genişletmek için tıklayın.</translation>
-<translation id="510275257476243843">1 saat kaldı</translation>
-<translation id="5123685120097942451">Gizli sekme</translation>
-<translation id="5127805178023152808">Senkronizasyon kapalı</translation>
-<translation id="5129038482087801250">Web uygulamasını yükle</translation>
-<translation id="5132942445612118989">Tüm cihazlardaki şifreleriniz, geçmişiniz ve diğer öğelerinizi senkronize edin</translation>
-<translation id="5139940364318403933">Google Drive'ın nasıl kullanılacağını öğrenin</translation>
-<translation id="515227803646670480">Depolanmış verileri sil</translation>
-<translation id="5152843274749979095">Desteklenen yüklü uygulama yok</translation>
-<translation id="5161254044473106830">Başlık gerekiyor</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 indirme işlemi başarısız oldu.}other{# indirme işlemi başarısız oldu.}}</translation>
-<translation id="5170568018924773124">Klasörde göster</translation>
-<translation id="5184329579814168207">Chrome'da aç</translation>
-<translation id="5193988420012215838">Panonuza kopyalandı</translation>
-<translation id="5197729504361054390">Seçtiğiniz kişiler <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> ile paylaşılacak.</translation>
-<translation id="5199929503336119739">İş profili</translation>
-<translation id="5210286577605176222">Önceki sekmeye gider</translation>
-<translation id="5210365745912300556">Sekmeyi kapat</translation>
-<translation id="5224771365102442243">Videolu</translation>
-<translation id="5230560987958996918"><ph name="SITE" />, yakındaki Bluetooth cihazlar için tarama yapmak istiyor. Şu cihazlar bulundu:</translation>
-<translation id="5233638681132016545">Yeni sekme</translation>
-<translation id="526421993248218238">Bu sayfa yüklenemiyor</translation>
-<translation id="5271967389191913893">Cihaz, indirilecek içeriği açamıyor.</translation>
-<translation id="528192093759286357">Tam ekrandan çıkmak için yukarıdan sürükleyin ve geri düğmesine dokunun.</translation>
-<translation id="5292796745632149097">Alıcılar</translation>
-<translation id="5300589172476337783">Göster</translation>
-<translation id="5301954838959518834">Tamam, anladım</translation>
-<translation id="5304593522240415983">Bu alan boş olamaz</translation>
-<translation id="5307446750509046227">Site depolamayı temizle</translation>
-<translation id="5308380583665731573">Bağlan</translation>
-<translation id="5313967007315987356">Site ekle</translation>
-<translation id="5317780077021120954">Kaydet</translation>
-<translation id="5324858694974489420">Ebeveyn Ayarları</translation>
-<translation id="5327248766486351172">Ad</translation>
-<translation id="5335288049665977812">Sitelerin JavaScript çalıştırmasına izin ver (önerilir)</translation>
-<translation id="5342314432463739672">İzin istekleri</translation>
-<translation id="5357811892247919462">Sekme alındı</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> açık sekme, sekmeler arasında geçiş yapmak için dokunun}other{<ph name="OPEN_TABS_MANY" /> açık sekme, sekmeler arasında geçiş yapmak için dokunun}}</translation>
-<translation id="5391532827096253100">Bu siteye bağlantınız güvenli değil. Site bilgileri</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 tane daha)}other{(+ # tane daha)}}</translation>
-<translation id="5400569084694353794">Bu uygulamayı kullanarak <ph name="BEGIN_LINK1" />Chrome'un Gizlilik Şartları<ph name="END_LINK1" />'nı ve <ph name="BEGIN_LINK2" />Gizlilik Uyarısı<ph name="END_LINK2" />'nı kabul etmiş olursunuz.</translation>
-<translation id="5403592356182871684">Adlar</translation>
-<translation id="5403644198645076998">Yalnızca belirli sitelere izin ver</translation>
-<translation id="5414836363063783498">Doğrulanıyor…</translation>
-<translation id="5423934151118863508">En çok ziyaret ettiğiniz sayfalar burada görünecektir</translation>
-<translation id="5424588387303617268"><ph name="GIGABYTES" /> GB kullanılabilir</translation>
-<translation id="543338862236136125">Şifreyi düzenle</translation>
-<translation id="5433691172869980887">Kullanıcı adı kopyalandı</translation>
-<translation id="543509235395288790"><ph name="COUNT" /> dosya indiriliyor (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Adres çubuğuna gider</translation>
-<translation id="5447201525962359567">Çerezler ve yerel olarak depolanmış diğer veriler de dahil olmak üzere tüm site depolama alanı</translation>
-<translation id="5447765697759493033">Bu site çevrilmeyecek</translation>
-<translation id="545042621069398927">İndirme işleminiz hızlandırılıyor.</translation>
-<translation id="5456381639095306749">Sayfayı indir</translation>
-<translation id="5475862044948910901">Artırılmış Gerçeklik oturumu başlatılsın mı?</translation>
-<translation id="548278423535722844">Haritalar uygulamasında aç</translation>
-<translation id="5487521232677179737">Verileri temizle</translation>
-<translation id="5494752089476963479">Araya giren veya yanıltıcı reklamlar gösteren sitelerde reklamları engelle</translation>
-<translation id="5500777121964041360">Bulunduğunuz ülkede kullanılamayabilir</translation>
-<translation id="5512137114520586844">Bu hesap <ph name="PARENT_NAME" /> tarafından yönetiliyor.</translation>
-<translation id="5514904542973294328">Bu cihazın yöneticisi tarafından devre dışı bırakıldı</translation>
-<translation id="5515439363601853141">Şifrenizi görüntülemek için kilidi açın</translation>
-<translation id="5516455585884385570">Bildirim ayarlarını aç</translation>
-<translation id="5517095782334947753"><ph name="FROM_ACCOUNT" /> hesabından yer işaretleri, geçmiş, şifreler ve diğer ayarlarınız var.</translation>
-<translation id="5524843473235508879">Yönlendirme engellendi.</translation>
-<translation id="5527082711130173040">Chrome'un cihazları taraması için konum bilgilerine erişmesi gerekiyor. <ph name="BEGIN_LINK1" />İzinleri güncelleyin<ph name="END_LINK1" />. Ayrıca, konum bilgilerine erişim <ph name="BEGIN_LINK2" />bu cihaz için kapalı<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Panodaki metin ve resimleri okumak için sitelere izin vermeden önce sor (önerilen)</translation>
-<translation id="5530766185686772672">Gizli sekmeleri kapat</translation>
-<translation id="5534334044554683961">Siz VR modundayken bu site şu konularda bilgi edinebilir:
-  -   Fiziksel özellikleriniz (ör. boyunuz)
-  -   Odanızın düzeni
-
-VR moduna girmeden önce bu siteye güvendiğinizden emin olun.</translation>
-<translation id="5534640966246046842">Site kopyalandı</translation>
-<translation id="5556459405103347317">Yeniden Yükle</translation>
-<translation id="5561549206367097665">Ağ bekleniyor…</translation>
-<translation id="557283862590186398">Chrome'un bu sitede mikrofonunuza erişmesi için izin gerekiyor.</translation>
-<translation id="55737423895878184">Konum ve bildirimlere izin veriliyor</translation>
-<translation id="5578795271662203820">Bu resmi, <ph name="SEARCH_ENGINE" /> üzerinde ara</translation>
-<translation id="5581519193887989363">Neyin senkronize edileceğini istediğiniz zaman <ph name="BEGIN_LINK1" />ayarlardan<ph name="END_LINK1" /> seçebilirsiniz.</translation>
-<translation id="5595485650161345191">Adresi düzenle</translation>
-<translation id="5596627076506792578">Diğer seçenekler</translation>
-<translation id="5599455543593328020">Gizli mod</translation>
-<translation id="5620928963363755975">Diğer Seçenekler düğmesini kullanarak İndirilenler bölümünden dosyalarınızı ve sayfalarınızı bulabilirsiniz</translation>
-<translation id="5626134646977739690">Adı:</translation>
-<translation id="5639724618331995626">Tüm sitelere izin ver</translation>
-<translation id="5648166631817621825">Son 7 gün</translation>
-<translation id="5649053991847567735">Otomatik indirmeler</translation>
-<translation id="5655963694829536461">İndirdiklerinizde arama yapın</translation>
-<translation id="5659593005791499971">E-posta</translation>
-<translation id="5665379678064389456"><ph name="APP_NAME" /> adlı uygulamada etkinlik oluştur</translation>
-<translation id="5668404140385795438">Web sitesinin yakınlaştırmayı önleme isteğini geçersiz kıl</translation>
-<translation id="5677928146339483299">Engellendi</translation>
-<translation id="5684874026226664614">Hata! Bu sayfa çevrilemedi.</translation>
-<translation id="5686790454216892815">Dosya adı çok uzun</translation>
-<translation id="5689516760719285838">Konum</translation>
-<translation id="569536719314091526">Diğer seçenekler düğmesini kullanarak bu sayfayı istediğiniz dile çevirin</translation>
-<translation id="572328651809341494">Son sekmeler</translation>
-<translation id="5726692708398506830">Sayfadaki her şeyi büyütür</translation>
-<translation id="5748802427693696783">Standart sekmelere geçildi</translation>
-<translation id="5749068826913805084">Dosya indirmek için Chrome'un depolama alanına erişmesi gerekiyor.</translation>
-<translation id="5763382633136178763">Gizli mod sekmeleri</translation>
-<translation id="5763514718066511291">Bu uygulamanın URL'sini kopyalamak için dokunun</translation>
-<translation id="5765780083710877561">Açıklama:</translation>
-<translation id="5793665092639000975"><ph name="SPACE_USED" /> / <ph name="SPACE_AVAILABLE" /> kullanılıyor</translation>
-<translation id="5797070761912323120">Google; Arama, reklamlar ve diğer Google hizmetlerini kişiselleştirmek için geçmişinizi kullanabilir</translation>
-<translation id="5804241973901381774">İzinler</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# saat önce}other{# saat önce}}</translation>
-<translation id="5810288467834065221">Telif hakkı <ph name="YEAR" /> Google LLC. Tüm hakları saklıdır.</translation>
-<translation id="5817918615728894473">Eşle</translation>
-<translation id="583281660410589416">Bilinmiyor</translation>
-<translation id="5833984609253377421">Bağlantıyı paylaş</translation>
-<translation id="5836192821815272682">Chrome Güncellemesi indiriliyor…</translation>
-<translation id="5853623416121554550">duraklatıldı</translation>
-<translation id="5854790677617711513">30 günden daha eski</translation>
-<translation id="5858741533101922242">Chrome, Bluetooth adaptörünü açamıyor</translation>
-<translation id="5860033963881614850">Kapalı</translation>
-<translation id="5862731021271217234">Diğer cihazlarınızdaki sekmelerinize ulaşmak için senkronizasyonu etkinleştirin</translation>
-<translation id="5864174910718532887">Ayrıntılar: Site adına göre sıralı</translation>
-<translation id="5864419784173784555">Başka bir indirme işlemi bekleniyor…</translation>
-<translation id="5865733239029070421">Kullanım istatistiklerini ve kilitlenme raporlarını Google'a otomatik olarak gönderir</translation>
-<translation id="5869522115854928033">Kayıtlı şifreler</translation>
-<translation id="5902828464777634901">Çerezler dahil bu web sitesinin depoladığı tüm yerel veriler silinecek.</translation>
-<translation id="5916664084637901428">Açık</translation>
-<translation id="5919204609460789179">Senkronizasyonu başlatmak için <ph name="PRODUCT_NAME" /> adlı uygulamayı güncelleyin</translation>
-<translation id="5937580074298050696"><ph name="AMOUNT" /> tasarruf edildi</translation>
-<translation id="5939518447894949180">Sıfırla</translation>
-<translation id="5942872142862698679">Arama için Google kullanılıyor</translation>
-<translation id="5952764234151283551">Erişmeye çalıştığınız sayfanın URL'sini Google'a gönderir</translation>
-<translation id="5956665950594638604">Chrome Yardım Merkezi'ni yeni bir sekmede açar</translation>
-<translation id="5958275228015807058">Dosyalarınızı ve sayfalarınızı İndirilenler bölümünde bulabilirsiniz</translation>
-<translation id="5962718611393537961">Daraltmak için dokunun</translation>
-<translation id="6000066717592683814">Google kalsın</translation>
-<translation id="6005538289190791541">Önerilen şifre</translation>
-<translation id="6036057147555329831">Ekstra ICU</translation>
-<translation id="6039379616847168523">Sonraki sekmeye gider</translation>
-<translation id="6040143037577758943">Kapat</translation>
-<translation id="6042308850641462728">Daha fazla</translation>
-<translation id="604996488070107836">Bilinmeyen bir hata nedeniyle <ph name="FILE_NAME" /> dosyası indirilemedi.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">Tamamlanan indirme işlemleri</translation>
-<translation id="6075798973483050474">Ana sayfayı düzenle</translation>
-<translation id="60923314841986378"><ph name="HOURS" /> saat kaldı</translation>
-<translation id="6108923351542677676">Kurulum devam ediyor…</translation>
-<translation id="6111020039983847643">kullanılan veri miktarı</translation>
-<translation id="6112702117600201073">Sayfa yenileniyor</translation>
-<translation id="6127379762771434464">Öğe kaldırıldı</translation>
-<translation id="6140912465461743537">Ülke/Bölge</translation>
-<translation id="614940544461990577">Aşağıdakileri deneyin:</translation>
-<translation id="6154478581116148741">Bu cihazdaki şifrelerinizi dışarı aktarmak için Ayarlar'da ekran kilidini açın</translation>
-<translation id="6159335304067198720"><ph name="PERCENT" /> veri tasarrufu</translation>
-<translation id="6165508094623778733">Daha fazla bilgi edinin</translation>
-<translation id="6177111841848151710">Geçerli arama motoru için engellendi</translation>
-<translation id="6181444274883918285">Site istisnası ekle</translation>
-<translation id="6192333916571137726">Dosyayı indir</translation>
-<translation id="6192792657125177640">İstisnalar</translation>
-<translation id="6194112207524046168">Chrome'un kameranıza erişebilmesi için <ph name="BEGIN_LINK" />Android Ayarları<ph name="END_LINK" />'ında da kamerayı açın.</translation>
-<translation id="6196640612572343990">Üçüncü taraf çerezlerini engelle</translation>
-<translation id="6206551242102657620">Bağlantı güvenli. Site bilgileri</translation>
-<translation id="6210748933810148297"><ph name="EMAIL" /> değil misiniz?</translation>
-<translation id="6221633008163990886">Şifrelerinizi dışa aktarmak için kilit açılamadı</translation>
+<translation id="1406000523432664303">“Do Not Track”</translation>
 <translation id="6232535412751077445">"Do Not Track" seçeneği etkinleştirildiğinde, göz atma trafiğinize bir istek eklenir. Her türlü etki, bir web sitesinin isteğe cevap verip vermemesine ve isteğin nasıl yorumlandığına bağlıdır.
 
 Örneğin bazı web siteleri bu isteği size daha önce gezdiğiniz web sitelerine dayalı olmayan reklamları göstererek yanıtlayabilir. Birçok web sitesi (örneğin güvenliği iyileştirmek; içerik, reklam, öneri sağlamak ve raporlama istatistikleri oluşturmak gibi amaçlarla) göz atma verilerinizi toplayıp kullanmayı sürdürecektir.</translation>
-<translation id="624789221780392884">Güncelleme hazır</translation>
-<translation id="6255999984061454636">İçerik önerileri</translation>
-<translation id="6277522088822131679">Sayfa yazdırılırken bir sorun oluştu. Lütfen tekrar deneyin.</translation>
-<translation id="6295158916970320988">Tüm siteler</translation>
-<translation id="629730747756840877">Hesap</translation>
-<translation id="6303969859164067831">Oturumu ve senkronizasyonu kapat</translation>
-<translation id="6316139424528454185">Android sürümü desteklenmiyor</translation>
-<translation id="6320088164292336938">Titreşim</translation>
-<translation id="6324034347079777476">Android sistem senkronizasyonu devre dışı</translation>
-<translation id="6333140779060797560">Paylaşım yöntemi: <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Şifreleme</translation>
-<translation id="6341580099087024258">Dosyaların kaydedileceği yeri sor</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> adres daha}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> adres daha}}</translation>
-<translation id="6364438453358674297">Öneri geçmişten kaldırılsın mı?</translation>
-<translation id="6369229450655021117">Burada, web'de arama yapabilir, içerikleri arkadaşlarınızla paylaşabilir ve açık sayfaları görebilirsiniz</translation>
-<translation id="6378173571450987352">Ayrıntılar: Kullanılan veri miktarına göre sıralı</translation>
-<translation id="6381421346744604172">Web sitelerini karart</translation>
-<translation id="6388207532828177975">Temizle ve sıfırla</translation>
-<translation id="6393863479814692971">Chrome'un bu sitede kameranıza ve mikrofonunuza erişmesi için izin gerekiyor.</translation>
-<translation id="6395288395575013217">BAĞLANTI</translation>
-<translation id="6404511346730675251">Yer işaretini düzenle</translation>
-<translation id="6406506848690869874">Senkronizasyon</translation>
-<translation id="641643625718530986">Yazdır…</translation>
-<translation id="6416782512398055893"><ph name="MBS" /> MB indirildi</translation>
-<translation id="6427112570124116297">Web'i çevir</translation>
-<translation id="6433501201775827830">Arama motorunuzu seçin</translation>
-<translation id="6437478888915024427">Sayfa bilgileri</translation>
-<translation id="6441734959916820584">Ad çok uzun</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Resim}other{# Resim}}</translation>
-<translation id="6447842834002726250">Çerezler</translation>
-<translation id="6461962085415701688">Dosya açılamıyor</translation>
-<translation id="6464977750820128603">Chrome'da ziyaret ettiğiniz siteleri görebilir ve bunlar için zamanlayıcı ayarlayabilirsiniz.\n\nGoogle, hangi siteler için zamanlayıcı ayarladığınız ve bu siteleri ne kadar süre boyunca ziyaret ettiğiniz konusunda bilgi alır. Bu bilgi, Dijital Denge'yi daha iyi hale getirmek için kullanılır.</translation>
-<translation id="6475951671322991020">Videoyu indir</translation>
-<translation id="6482749332252372425">Depolama alanı yetersiz olduğu için <ph name="FILE_NAME" /> dosyası indirilemedi.</translation>
-<translation id="6496823230996795692"><ph name="APP_NAME" /> uygulamasını ilk kez kullanmak için lütfen internete bağlanın.</translation>
-<translation id="6508722015517270189">Chrome'u yeniden başlatın</translation>
-<translation id="6527303717912515753">Paylaş</translation>
-<translation id="6532866250404780454">Chrome'da ziyaret ettiğiniz siteler gösterilmez. Tüm site zamanlayıcıları silinir.</translation>
-<translation id="6534565668554028783">Google çok geç yanıt verdi</translation>
-<translation id="6538442820324228105"><ph name="GBS" /> GB indirildi</translation>
-<translation id="6539092367496845964">Bir sorun oldu. Daha sonra tekrar deneyin.</translation>
-<translation id="654446541061731451">Işınlamak için bir sekme seçin</translation>
-<translation id="6545017243486555795">Tüm Verileri Temizle</translation>
-<translation id="6545864417968258051">Bluetooth taraması</translation>
-<translation id="6560414384669816528">Sogou ile arama</translation>
-<translation id="6566259936974865419">Chrome <ph name="GIGABYTES" /> GB tasarruf sağladı</translation>
-<translation id="6573096386450695060">Her zaman izin ver</translation>
-<translation id="6573431926118603307">Diğer cihazlarınızda Chrome ile açtığınız sekmeler burada görünür.</translation>
-<translation id="6583199322650523874">Mevcut sayfaya yer işareti koyar</translation>
-<translation id="6593061639179217415">Masaüstü sitesi</translation>
-<translation id="6600954340915313787">Chrome'a kopyalandı</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Korunan içerik</translation>
-<translation id="6627583120233659107">Klasörü düzenle</translation>
-<translation id="6643016212128521049">Temizle</translation>
-<translation id="6643649862576733715">Tasarruf edilen veri miktarına göre sırala</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> kişi daha}other{<ph name="CONTACT_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> kişi daha}}</translation>
-<translation id="6649642165559792194">Resmin önizlemesini aç <ph name="BEGIN_NEW" />Yeni<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome'un cihazları taraması için konuma erişmesi gerekiyor. <ph name="BEGIN_LINK" />İzinleri güncelleyin<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Şifre</translation>
-<translation id="6659594942844771486">Sekme</translation>
-<translation id="666731172850799929"><ph name="APP_NAME" /> uygulamasında aç</translation>
-<translation id="666981079809192359">Chrome Gizlilik Uyarısı</translation>
-<translation id="6676840375528380067">Chrome verileriniz bu cihazdan temizlensin mi?</translation>
-<translation id="6697492270171225480">Bir sayfa bulunamadığında benzer sayfalar için önerileri göster</translation>
-<translation id="6697947395630195233">Konumunuzu bu siteyle paylaşabilmek için Chrome'un konum bilgilerinize erişmesi gerekiyor.</translation>
-<translation id="6698801883190606802">Senkronize edilen verileri yönet</translation>
-<translation id="6699370405921460408">Google sunucuları ziyaret ettiğiniz sayfaları optimize eder.</translation>
-<translation id="6706288973712894588">Şu anda çevrimdışısınız.\n<ph name="BEGIN_LINK" />Çevrimdışı feed'inizi keşfedin.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Haberler</translation>
-<translation id="6710213216561001401">Önceki</translation>
-<translation id="671481426037969117"><ph name="FQDN" /> zamanlayıcınızın süresi doldu. Yarın tekrar başlatılacak.</translation>
-<translation id="6738867403308150051">İndiriliyor…</translation>
-<translation id="6746124502594467657">Aşağı taşı</translation>
-<translation id="6766622839693428701">Kapatmak için aşağı kaydırın.</translation>
-<translation id="6766758767654711248">Siteye gitmek için dokunun</translation>
-<translation id="6767294960381293877">Sekme paylaşılacak cihazların listesi yarım yükseklikte açıldı.</translation>
-<translation id="6782111308708962316">Üçüncü taraf web sitelerinin çerez verilerini kaydetmesini ve okumasını engelle</translation>
-<translation id="6790428901817661496">Oynat</translation>
-<translation id="6811034713472274749">Sayfa görüntülenmeye hazır</translation>
-<translation id="6818926723028410516">Öğe seçin</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Çevir</translation>
-<translation id="6845325883481699275">Chrome güvenliğini iyileştirmeye yardımcı olun</translation>
-<translation id="6846298663435243399">Yükleniyor…</translation>
-<translation id="6850409657436465440">İndirme işleminiz hâlâ devam ediyor</translation>
-<translation id="6850830437481525139"><ph name="TAB_COUNT" /> sekme kapatıldı</translation>
-<translation id="6864459304226931083">Resmi indir</translation>
-<translation id="6865313869410766144">Form otomatik doldurma verileri</translation>
-<translation id="688738109438487280">Mevcut veriler <ph name="TO_ACCOUNT" /> hesabına eklenir.</translation>
-<translation id="6891726759199484455">Şifrenizi kopyalamak için kilidi açın</translation>
-<translation id="6896758677409633944">Kopyala</translation>
-<translation id="6910211073230771657">Silindi</translation>
-<translation id="6912998170423641340">Sitelerin panodaki metni ve resimleri okumasını engelleyin</translation>
-<translation id="6914783257214138813">Şifreleriniz, dışa aktarılan dosyayı görebilen herkes tarafından görülebilir.</translation>
-<translation id="6942665639005891494">Dosyaların indirileceği varsayılan konumu istediğiniz zaman Ayarlar menü seçeneğini kullanarak değiştirebilirsiniz</translation>
-<translation id="6945221475159498467">Seç</translation>
-<translation id="6963642900430330478">Bu sayfa tehlikeli. Site bilgileri</translation>
-<translation id="6963766334940102469">Yer işaretlerini silme</translation>
-<translation id="6965382102122355670">Tamam</translation>
-<translation id="6979737339423435258">Tüm zamanlar</translation>
-<translation id="6981982820502123353">Erişilebilirlik</translation>
-<translation id="6989267951144302301">İndirilemedi</translation>
-<translation id="6990079615885386641">Uygulamayı Google Play Store'dan edinin: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Sitelerin, mikrofonunuzu kullanmasına izin verilmeden önce size sorulsun (önerilen)</translation>
-<translation id="7015203776128479407">İlk senkronizasyon kurulumu tamamlanmadı. Senkronizasyon kapalı.</translation>
-<translation id="7016516562562142042">Geçerli arama motoru için izin verildi</translation>
-<translation id="7022756207310403729">Tarayıcıda aç</translation>
-<translation id="702463548815491781">TalkBack veya Anahtar Erişimi açık olduğunda önerilir</translation>
-<translation id="7029809446516969842">Şifreler</translation>
-<translation id="7053983685419859001">Engelle</translation>
-<translation id="7055152154916055070">Yönlendirme engellendi:</translation>
-<translation id="7063006564040364415">Senkronizasyon sunucusuna bağlanılamadı.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 öğe seçildi}other{# öğe seçildi}}</translation>
-<translation id="7071521146534760487">Hesabı yönet</translation>
-<translation id="7077143737582773186">SD kart</translation>
-<translation id="7087918508125750058"><ph name="ITEM_COUNT" /> öğe seçildi. Seçenekler, ekranın üst kısmına yakın bir yerde bulunur</translation>
-<translation id="7121362699166175603">Geçmişi ve adres çubuğundaki otomatik tamamlamaları temizler. Google Hesabınızın <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> adresinde başka biçimlerde tarama geçmişi olabilir.</translation>
-<translation id="7128222689758636196">Geçerli arama motoruna izin ver</translation>
-<translation id="7138678301420049075">Diğer</translation>
-<translation id="7141896414559753902">Sitelerin pop-up göstermesini ve yönlendirme yapmasını engelle (önerilir)</translation>
-<translation id="7149158118503947153"><ph name="DOMAIN_NAME" /> alanından <ph name="BEGIN_LINK" />orijinal sayfayı yükle<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">Son 24 saat</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Bunu daha sonra Ayarlar'da değiştirebilirsiniz</translation>
-<translation id="7180611975245234373">Yenile</translation>
-<translation id="7189372733857464326">Güncellemenin tamamlanması için Google Play Hizmetleri bekleniyor</translation>
-<translation id="7191430249889272776">Sekme arka planda açıldı.</translation>
-<translation id="723171743924126238">Resim seç</translation>
-<translation id="7233236755231902816">Web'i kendi dilinizde görmek için Chrome'un en son sürümünü edinin</translation>
-<translation id="7243308994586599757">Sayfanın altına yakın bir yerde kullanılabilen seçenekler</translation>
-<translation id="7248069434667874558"><ph name="TARGET_DEVICE_NAME" /> cihazının Chrome'da senkronizasyonunun açık olduğundan emin olun</translation>
-<translation id="7250468141469952378"><ph name="ITEM_COUNT" /> öğe seçildi</translation>
-<translation id="7274013316676448362">Engellenmiş site</translation>
-<translation id="7290209999329137901">Yeniden adlandırma yapılamıyor</translation>
-<translation id="7291387454912369099">Asistan'ın Başlattığı Ödeme</translation>
-<translation id="7293171162284876153">Senkronizasyonu başlatmak için "Chrome verilerimi senkronize et" ayarını etkinleştirin.</translation>
-<translation id="729975465115245577">Cihazınızda şifreler dosyasını depolayacak bir uygulama yok.</translation>
-<translation id="7302081693174882195">Ayrıntılar: Tasarruf edilen veri miktarına göre sıralı</translation>
-<translation id="7328017930301109123">Chrome, Basit modda sayfaları daha hızlı yükler ve yüzde 60'a kadar daha az veri kullanır.</translation>
-<translation id="7333031090786104871">Önceki siteyi ekleme işlemi devam ediyor.</translation>
-<translation id="7352939065658542140">VİDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 seçili öğeyi paylaş}other{# seçili öğeyi paylaş}}</translation>
 <translation id="7359002509206457351">Ödeme yöntemlerine erişim</translation>
+<translation id="8026334261755873520">Tarama verilerini temizle</translation>
+<translation id="1291207594882862231">Geçmişi, çerezleri, site verilerini, önbelleği temizleyin…</translation>
+<translation id="7814200940910057384">Brave verileri temizlendi</translation>
+<translation id="1664855196866195614">Seçilen veriler Brave'dan ve senkronize edilen cihazlarınızdan kaldırıldı.
+
+Diğer Brave Software hizmetlerinden yapılan aramalar ve etkinlikler gibi Brave Software hesabınızla ilişkili başka biçimlerde tarama geçmişi <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> adresinde bulunabilir.</translation>
+<translation id="4699172675775169585">Önbelleğe alınan resimler ve dosyalar</translation>
+<translation id="2496180316473517155">Tarama geçmişi</translation>
+<translation id="2546283357679194313">Çerezler ve site verileri</translation>
+<translation id="8662811608048051533">Çoğu sitedeki oturumunuz kapatılır.</translation>
+<translation id="8218628800671693884">Çoğu sitedeki oturumunuz kapatılır. Brave Software Hesabınızdaki oturumunuz kapatılmaz.</translation>
+<translation id="2017836877785168846">Geçmişi ve adres çubuğundaki otomatik tamamlama bilgilerini temizler.</translation>
+<translation id="8096327394278038498">Geçmişi ve adres çubuğundaki otomatik tamamlamaları temizler. Brave Software Hesabınızın <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> adresinde başka biçimlerde tarama geçmişi olabilir.</translation>
+<translation id="8122693181154564064">Oturumunuzun açık olduğu tüm cihazlarda geçmişi temizler. Brave Software Hesabınızın <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> adresinde başka biçimlerde tarama geçmişi olabilir.</translation>
+<translation id="5869522115854928033">Kayıtlı şifreler</translation>
+<translation id="6865313869410766144">Form otomatik doldurma verileri</translation>
+<translation id="7562080006725997899">Göz atma verileri temizleniyor</translation>
+<translation id="5487521232677179737">Verileri temizle</translation>
+<translation id="7498271377022651285">Lütfen bekleyin…</translation>
+<translation id="784934925303690534">Zaman aralığı</translation>
+<translation id="1718835860248848330">Son saat</translation>
+<translation id="7149893636342594995">Son 24 saat</translation>
+<translation id="5648166631817621825">Son 7 gün</translation>
+<translation id="8571213806525832805">Son 4 hafta</translation>
+<translation id="5854790677617711513">30 günden daha eski</translation>
+<translation id="6979737339423435258">Tüm zamanlar</translation>
+<translation id="982182592107339124">Bu işlem, aşağıdakiler de dahil olmak üzere tüm sitelere ilişkin verileri temizleyecek:</translation>
+<translation id="6643016212128521049">Temizle</translation>
+<translation id="7641339528570811325">Tarama verilerini temizle…</translation>
+<translation id="1670399744444387456">Temel</translation>
+<translation id="3245261285041759672">Brave Software Hesabınızın <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> adresinde başka biçimlerde tarama geçmişi olabilir.</translation>
+<translation id="7274013316676448362">Engellenmiş site</translation>
+<translation id="2534155362429831547"><ph name="NUMBER_OF_ITEMS"/> öğe silindi</translation>
+<translation id="1121094540300013208">Kullanım ve kilitlenme raporları</translation>
+<translation id="9079153198295609735">Kullanım istatistiklerini ve çökme raporlarını otomatik olarak Brave Software'a gönder</translation>
+<translation id="6981982820502123353">Erişilebilirlik</translation>
+<translation id="2387895666653383613">Metin ölçekleme</translation>
+<translation id="2321958826496381788">Bu yazıyı rahatça okuyana kadar kaydırma çubuğunu sürükleyin. Bir paragrafa iki kez hafifçe dokunduğunuzda metin en az bunun kadar büyük görünmelidir.</translation>
+<translation id="3895926599014793903">Yakınlaştırmayı etkinleştirmeye zorla</translation>
+<translation id="5668404140385795438">Web sitesinin yakınlaştırmayı önleme isteğini geçersiz kıl</translation>
+<translation id="4149994727733219643">Web sayfalarının basitleştirilmiş görünümü</translation>
+<translation id="9100505651305367705">Desteklendiğinde makaleleri basitleştirilmiş görünümde göstermeyi öner</translation>
+<translation id="1409426117486808224">Açık sekmeler için basitleştirilmiş görünüm</translation>
+<translation id="702463548815491781">TalkBack veya Anahtar Erişimi açık olduğunda önerilir</translation>
+<translation id="8284326494547611709">Altyazılar</translation>
+<translation id="4165986682804962316">Site ayarları</translation>
+<translation id="6295158916970320988">Tüm siteler</translation>
+<translation id="8380167699614421159">Bu site, araya giren veya yanıltıcı reklamlar gösteriyor</translation>
+<translation id="1919345977826869612">Reklamlar</translation>
+<translation id="410351446219883937">Otomatik oynatma</translation>
+<translation id="6447842834002726250">Çerezler</translation>
+<translation id="6196640612572343990">Üçüncü taraf çerezlerini engelle</translation>
+<translation id="6782111308708962316">Üçüncü taraf web sitelerinin çerez verilerini kaydetmesini ve okumasını engelle</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Pop-up'lar ve yönlendirmeler</translation>
+<translation id="4751476147751820511">Hareket veya ışık sensörleri</translation>
+<translation id="1717218214683051432">Hareket sensörleri</translation>
+<translation id="2091887806945687916">Ses</translation>
+<translation id="2586657967955657006">Pano</translation>
+<translation id="6320088164292336938">Titreşim</translation>
+<translation id="4226663524361240545">Bildirimler cihazı titretebilir</translation>
+<translation id="1446450296470737166">MIDI cihazlarının tam denetimine izin verme</translation>
+<translation id="3744111561329211289">Arka plan senkronizasyonu</translation>
+<translation id="5649053991847567735">Otomatik indirmeler</translation>
+<translation id="6181444274883918285">Site istisnası ekle</translation>
+<translation id="5313967007315987356">Site ekle</translation>
+<translation id="1369915414381695676"><ph name="SITE_NAME"/> sitesi eklendi</translation>
+<translation id="7837721118676387834">Belirli bir sitenin, sesi kapatılmış videoları otomatik olarak oynatmasına izin verin.</translation>
+<translation id="2621115761605608342">Belirli bir site için JavaScript'e izin verin.</translation>
+<translation id="8801436777607969138">JavaScript'i belirli bir site için engelleyin.</translation>
+<translation id="8372893542064058268">Belirli bir site için Arka Plan Senkronizasyonuna izin verin.</translation>
+<translation id="358794129225322306">Bir sitenin otomatik olarak birden fazla dosya indirmesine izin verir.</translation>
+<translation id="4008040567710660924">Belirli bir site için çerezlere izin verin.</translation>
+<translation id="8958424370300090006">Belirli bir site için çerezleri engelleyin.</translation>
+<translation id="7882806643839505685">Belirli bir site için sese izin verin.</translation>
+<translation id="4468959413250150279">Belirli bir site için sesi kapatın.</translation>
+<translation id="1994173015038366702">Site URL'si</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Kullanım</translation>
+<translation id="5804241973901381774">İzinler</translation>
+<translation id="4278390842282768270">İzin verilen</translation>
+<translation id="5677928146339483299">Engellendi</translation>
+<translation id="1984937141057606926">Üçüncü taraf hariç izin verildi</translation>
+<translation id="7423098979219808738">Önce sor</translation>
+<translation id="8116925261070264013">Ses kapatıldı</translation>
+<translation id="8300705686683892304">Uygulama tarafından yönetiliyor</translation>
+<translation id="6192792657125177640">İstisnalar</translation>
+<translation id="257931822824936280">Genişletildi - Daraltmak için tıklayın.</translation>
+<translation id="5100237604440890931">Daraltıldı - Genişletmek için tıklayın.</translation>
+<translation id="857943718398505171">İzin verildi (önerilir)</translation>
+<translation id="2913331724188855103">Sitelerin, çerez verilerini kaydetmelerine ve okumalarına izin ver (önerilir)</translation>
+<translation id="7445411102860286510">Sitelerin, sesi kapatılmış videoları otomatik olarak oynatmasına izin ver (önerilen)</translation>
+<translation id="5335288049665977812">Sitelerin JavaScript çalıştırmasına izin ver (önerilir)</translation>
+<translation id="5527111080432883924">Panodaki metin ve resimleri okumak için sitelere izin vermeden önce sor (önerilen)</translation>
+<translation id="6912998170423641340">Sitelerin panodaki metni ve resimleri okumasını engelleyin</translation>
+<translation id="7423538860840206698">Pano okuma engellendi</translation>
+<translation id="3955193568934677022">Sitelerin korumalı içeriği oynatmasına izin ver (önerilir)</translation>
+<translation id="445467742685312942">Sitelerin korumalı içeriği oynatmasına izin ver</translation>
+<translation id="2107397443965016585">Sitelerin korumalı içeriği oynatmasına izin vermeden önce sor (önerilir)</translation>
+<translation id="2910701580606108292">Sitelerin korumalı içeriği oynatmasına izin verilmeden önce size sorulur</translation>
+<translation id="757524316907819857">Sitelerin korumalı içeriği oynatmasını engellenir</translation>
+<translation id="3277252321222022663">Sitelerin sensörlere erişmesine izin ver (önerilen)</translation>
+<translation id="5048398596102334565">Sitelerin hareket sensörlerine erişmesine izin ver (önerilen)</translation>
+<translation id="8816026460808729765">Sitelerin sensörlere erişimini engelle</translation>
+<translation id="169515064810179024">Sitelerin hareket sensörlerine erişimini engelle</translation>
+<translation id="1660204651932907780">Sitelerin ses çalmasına izin ver (önerilir)</translation>
+<translation id="3600792891314830896">Ses çalan sitelerin sesini kapat</translation>
+<translation id="1743802530341753419">Sitelerin bir cihaza bağlanmasına izin verilmeden önce sor (önerilir)</translation>
+<translation id="851751545965956758">Sitelerin cihazlara bağlanmasını engelle</translation>
+<translation id="7141896414559753902">Sitelerin pop-up göstermesini ve yönlendirme yapmasını engelle (önerilir)</translation>
+<translation id="5494752089476963479">Araya giren veya yanıltıcı reklamlar gösteren sitelerde reklamları engelle</translation>
+<translation id="3123473560110926937">Bazı sitelerde engellendi</translation>
+<translation id="965817943346481315">Site, araya giren veya yanıltıcı reklamlar gösteriyorsa engelle (önerilen)</translation>
+<translation id="3386292677130313581">Sitelerin, konumunuzu öğrenmesine izin verilmeden önce size sorulsun (önerilir)</translation>
+<translation id="9139068048179869749">Sitelerin bildirim göndermesine izin vermeden önce size sorulsun (önerilir)</translation>
+<translation id="4479647676395637221">Sitelerin, kameranızı kullanmasına izin verilmeden önce size sorulsun (önerilir)</translation>
+<translation id="6992289844737586249">Sitelerin, mikrofonunuzu kullanmasına izin verilmeden önce size sorulsun (önerilen)</translation>
+<translation id="2289270750774289114">Bir site yakındaki Bluetooth cihazları bulmak istediğinde sor (önerilir)</translation>
+<translation id="7053983685419859001">Engelle</translation>
+<translation id="7128222689758636196">Geçerli arama motoruna izin ver</translation>
+<translation id="7589445247086920869">Geçerli arama motorunu engelle</translation>
+<translation id="6388207532828177975">Temizle ve sıfırla</translation>
+<translation id="7999064672810608036">Bu web sitesine ilişkin çerezler dahil tüm yerel verileri temizlemek ve bu sitenin tüm izinlerini sıfırlamak istediğinizden emin misiniz?</translation>
+<translation id="2822354292072154809"><ph name="CHOSEN_OBJECT_NAME"/> için tüm site izinlerini sıfırlamak istediğinizden emin misiniz?</translation>
+<translation id="515227803646670480">Depolanmış verileri sil</translation>
+<translation id="5902828464777634901">Çerezler dahil bu web sitesinin depoladığı tüm yerel veriler silinecek.</translation>
+<translation id="119944043368869598">Tümünü temizle</translation>
+<translation id="2490684707762498678"><ph name="APP_NAME"/> tarafından yönetiliyor</translation>
+<translation id="5516455585884385570">Bildirim ayarlarını aç</translation>
+<translation id="1404122904123200417"><ph name="WEBSITE_URL"/> sitesinde yerleşik</translation>
+<translation id="129382876167171263">Web siteleri tarafından kaydedilen dosyalar burada görünür</translation>
+<translation id="4181841719683918333">Diller</translation>
+<translation id="2647434099613338025">Dil ekle</translation>
+<translation id="1952172573699511566">Web siteleri, mümkün olduğunda metni tercih ettiğiniz dilde gösterir.</translation>
+<translation id="8559990750235505898">Diğer dillerdeki sayfaları çevirmeyi öner</translation>
+<translation id="4719927025381752090">Çevirmeyi öner</translation>
+<translation id="8156139159503939589">Hangi dillerde okuyabiliyorsunuz?</translation>
+<translation id="5689516760719285838">Konum</translation>
+<translation id="2440823041667407902">Konum erişimi</translation>
+<translation id="2023546461831060654"><ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'nda Brave için izinleri açın.</translation>
+<translation id="6665548517310046133"><ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'nda Brave için izni açın.</translation>
+<translation id="2928908108430545745">Brave'un konumunuza erişebilmesi için <ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'nda da konumu açın.</translation>
+<translation id="1028853271388022585">Brave'un kameranıza erişebilmesi için <ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'ında da kamerayı açın.</translation>
+<translation id="2913721282607281710">Brave'un size bildirim gönderebilmesi için <ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'nda da bildirimleri açın.</translation>
+<translation id="8753483718490035722">Brave'un mikrofonunuza erişebilmesi için <ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'nda da mikrofonu açın.</translation>
+<translation id="1887786770086287077">Konum erişimi bu cihaz için kapalı. Konum erişimini <ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'ndan açın.</translation>
+<translation id="2570922361219980984">Konum erişimi bu cihaz için de kapalı. Konum erişimini <ph name="BEGIN_LINK"/>Android Ayarları<ph name="END_LINK"/>'ndan açın.</translation>
+<translation id="1620510694547887537">Kamera</translation>
+<translation id="3227137524299004712">Mikrofon</translation>
+<translation id="1647391597548383849">Kameranıza erişim</translation>
+<translation id="945632385593298557">Mikrofonunuza erişim</translation>
+<translation id="6612358246767739896">Korunan içerik</translation>
+<translation id="885701979325669005">Depolama</translation>
+<translation id="3198916472715691905"><ph name="STORAGE_AMOUNT"/> depolanmış veri</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Cihaz iznini iptal et</translation>
+<translation id="4962975101802056554">Cihaz için tüm izinleri iptal eder</translation>
+<translation id="6545864417968258051">Bluetooth taraması</translation>
+<translation id="4411535500181276704">Basit mod</translation>
+<translation id="7821588508402923572">Veri tasarruflarınız burada görünür</translation>
+<translation id="2131665479022868825"><ph name="DATA"/> tasarruf edildi</translation>
+<translation id="8569404424186215731"><ph name="DATE"/> tarihinden bu yana</translation>
+<translation id="3252158532344029638">Brave, Basit modda sayfaları daha hızlı yükler ve yüzde 60'a kadar daha az veri kullanır.</translation>
+<translation id="6159335304067198720"><ph name="PERCENT"/> veri tasarrufu</translation>
+<translation id="7494974237137038751">tasarruf edilen veri miktarı</translation>
+<translation id="6111020039983847643">kullanılan veri miktarı</translation>
+<translation id="7413229368719586778">Başlangıç tarihi: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Bitiş tarihi: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Siteye göre sırala</translation>
+<translation id="5864174910718532887">Ayrıntılar: Site adına göre sıralı</translation>
+<translation id="116280672541001035">Kullanılan</translation>
+<translation id="8349013245300336738">Kullanılan veri miktarına göre sırala</translation>
+<translation id="6378173571450987352">Ayrıntılar: Kullanılan veri miktarına göre sıralı</translation>
+<translation id="2631006050119455616">Tasarruf Edilen</translation>
+<translation id="6643649862576733715">Tasarruf edilen veri miktarına göre sırala</translation>
+<translation id="7302081693174882195">Ayrıntılar: Tasarruf edilen veri miktarına göre sıralı</translation>
+<translation id="4179980317383591987"><ph name="AMOUNT"/> miktar</translation>
+<translation id="5937580074298050696"><ph name="AMOUNT"/> tasarruf edildi</translation>
+<translation id="2156074688469523661">Kalan site sayısı (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Diğer</translation>
+<translation id="4913161338056004800">İstatistikleri sıfırla</translation>
+<translation id="1856325424225101786">Basit mod sıfırlansın mı?</translation>
+<translation id="3658159451045945436">Sıfırlama işlemi, ziyaret edilen sitelerin listesi de dahil olmak üzere veri tasarrufu geçmişinizi siler.</translation>
+<translation id="3295530008794733555">Daha hızlı tarayın. Daha az veri kullanın.</translation>
+<translation id="7340390500800578919">Brave, Basit modda sayfaları daha hızlı yükler ve yüzde 60'a kadar daha az veri kullanır. Brave, ziyaret ettiğiniz sayfaları iyileştirmek için web trafiğinizi Brave Software'a gönderir. <ph name="BEGIN_LINK"/>Daha fazla bilgi<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Basit modu aç</translation>
+<translation id="4493497663118223949">Basit mod açık</translation>
+<translation id="7559975015014302720">Basit mod kapalı</translation>
+<translation id="7606077192958116810">Basit mod açık. Bunu Ayarlar'dan yönetebilirsiniz.</translation>
+<translation id="4714588616299687897">%60'a kadar veri tasarrufu sağlayın</translation>
+<translation id="1006927014032731288">Brave Software sunucuları ziyaret ettiğiniz sayfaları optimize eder.</translation>
+<translation id="3257320067425202300">Brave <ph name="MEGABYTES"/> MB tasarruf sağladı</translation>
+<translation id="5813223329348543512">Brave <ph name="GIGABYTES"/> GB tasarruf sağladı</translation>
+<translation id="8266862848225348053">İndirme konumu</translation>
+<translation id="7077143737582773186">SD kart</translation>
+<translation id="7762668264895820836">SD Kart <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Dosyaların kaydedileceği yeri sor</translation>
+<translation id="6192333916571137726">Dosyayı indir</translation>
+<translation id="1672586136351118594">Bir daha gösterme</translation>
+<translation id="2650751991977523696">Dosya tekrar indirilsin mi?</translation>
+<translation id="8664979001105139458">Dosya adı zaten mevcut</translation>
+<translation id="488187801263602086">Dosyayı yeniden adlandırın</translation>
+<translation id="5686790454216892815">Dosya adı çok uzun</translation>
+<translation id="7454641608352164238">Yeterli alan yok</translation>
+<translation id="8972098258593396643">Varsayılan klasöre indirilsin mi?</translation>
+<translation id="804335162455518893">SD kart bulunamadı</translation>
+<translation id="7475688122056506577">SD kart bulunamadı. Bazı dosyalarınız eksik olabilir.</translation>
+<translation id="4198423547019359126">Kullanılabilir indirme yeri yok</translation>
+<translation id="8224471946457685718">Size özel makaleleri kablosuz bağlantıda indirin</translation>
+<translation id="4970824347203572753">Bulunduğunuz konumda kullanılamıyor</translation>
+<translation id="5500777121964041360">Bulunduğunuz ülkede kullanılamayabilir</translation>
+<translation id="1173894706177603556">Yeniden adlandır</translation>
+<translation id="1986685561493779662">Ad zaten var</translation>
+<translation id="6441734959916820584">Ad çok uzun</translation>
+<translation id="2923908459366352541">Ad geçersiz</translation>
+<translation id="7290209999329137901">Yeniden adlandırma yapılamıyor</translation>
+<translation id="3334729583274622784">Dosya uzantısı değiştirilsin mi?</translation>
+<translation id="107147699690128016">Dosya uzantısını değiştirirseniz dosya farklı bir uygulamada açılabilir ve cihazınız için tehlikeli olabilir.</translation>
+<translation id="8541922081612557424">Brave hakkında</translation>
+<translation id="5311273890481188673">Telif hakkı <ph name="YEAR"/> Brave Software LLC. Tüm hakları saklıdır.</translation>
+<translation id="1416550906796893042">Uygulama sürümü</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (<ph name="TIME_SINCE_UPDATE"/> güncellendi)</translation>
+<translation id="7596558890252710462">İşletim sistemi</translation>
+<translation id="3968054912784331254">Brave güncellemeleri Android'in bu sürümü için artık desteklenmiyor</translation>
+<translation id="7665369617277396874">Hesap ekle</translation>
+<translation id="649070405679044769">Brave Software'da şu hesapla oturum açıldı:</translation>
+<translation id="6234515504547364178">Brave oturumunu kapatma</translation>
+<translation id="5324858694974489420">Ebeveyn Ayarları</translation>
+<translation id="8920114477895755567">Ebeveyn ayrıntıları bekleniyor.</translation>
+<translation id="5512137114520586844">Bu hesap <ph name="PARENT_NAME"/> tarafından yönetiliyor.</translation>
+<translation id="2956410042958133412">Bu hesap <ph name="PARENT_NAME_1"/> ve <ph name="PARENT_NAME_2"/> tarafından yönetiliyor.</translation>
+<translation id="8168435359814927499">İçerik</translation>
+<translation id="5403644198645076998">Yalnızca belirli sitelere izin ver</translation>
+<translation id="8641930654639604085">Yetişkinlere yönelik siteleri engellemeyi dene</translation>
+<translation id="5639724618331995626">Tüm sitelere izin ver</translation>
+<translation id="796823723482603597">Brave tarafından desteklenmektedir</translation>
+<translation id="6324034347079777476">Android sistem senkronizasyonu devre dışı</translation>
+<translation id="5127805178023152808">Senkronizasyon kapalı</translation>
+<translation id="7015203776128479407">İlk senkronizasyon kurulumu tamamlanmadı. Senkronizasyon kapalı.</translation>
+<translation id="2497852260688568942">Yöneticiniz senkronizasyonu devre dışı bıraktı</translation>
+<translation id="9100610230175265781">Parola gerekli</translation>
+<translation id="6108923351542677676">Kurulum devam ediyor…</translation>
+<translation id="4062305924942672200">Yasal bilgiler</translation>
+<translation id="4256782883801055595">Açık kaynak lisansları</translation>
+<translation id="1138681184697033370">Brave Hizmet Şartları</translation>
+<translation id="7392539049993970338">Brave Gizlilik Uyarısı</translation>
+<translation id="2677748264148917807">Çık</translation>
+<translation id="5556459405103347317">Yeniden Yükle</translation>
+<translation id="1623104350909869708">Bu sayfanın daha fazla iletişim kutusu oluşturmasını önle</translation>
+<translation id="2968755619301702150">Sertifika görüntüleyici</translation>
+<translation id="1360432990279830238">Oturum ve senkronizasyon kapatılsın mı?</translation>
+<translation id="8581481290581777242">Brave verileriniz bu cihazdan temizlensin mi?</translation>
+<translation id="1318865768845061710">Yer işaretleri, geçmiş, şifreler ve diğer Brave verileriniz artık Brave Software Hesabınız ile senkronize edilmeyecek.</translation>
+<translation id="3325020657155065477">Brave verilerinizi de bu cihazdan temizleyin</translation>
+<translation id="6136448902816743006"><ph name="DOMAIN_NAME"/> tarafından yönetilen bir hesabın oturumunu kapattığınız için Brave verileriniz bu cihazdan silinecektir. Verileriniz Brave Software Hesabınızda kalacaktır.</translation>
+<translation id="1853026300647876496">Brave Software ile bağlantı kuruluyor. Bu işlem bir dakika sürebilir…</translation>
+<translation id="2328985652426384049">Oturum açılamıyor</translation>
+<translation id="7723158744459952869">Brave Software çok geç yanıt verdi</translation>
+<translation id="4572422548854449519">Yönetilen hesapta oturum açın</translation>
+<translation id="2689656545739939160"><ph name="MANAGED_DOMAIN"/> tarafından yönetilen bir hesapla oturum açıyorsunuz ve yöneticiye tüm Brave verileriniz üzerinde denetim olanağı veriyorsunuz. Verileriniz kalıcı olarak bu hesaba bağlanacaktır. Brave'da oturumu kapattığınızda verileriniz bu cihazdan silinir, ancak Brave Software Hesabınızda kalmaya devam eder.</translation>
+<translation id="1749561566933687563">Yer işaretlerinizi senkronize edin</translation>
+<translation id="4242533952199664413">Ayarları aç</translation>
+<translation id="1111673857033749125">Diğer cihazlarınızda kaydedilmiş yer işaretleri burada görünür.</translation>
+<translation id="8636825310635137004">Diğer cihazlarınızdaki sekmelerinize ulaşmak için senkronizasyonu etkinleştirin.</translation>
+<translation id="3269956123044984603">Diğer cihazlarınızdaki sekmelerinize ulaşmak için Android hesap ayarlarından "Verileri otomatik senkronize et" seçeneğini etkinleştirin.</translation>
+<translation id="5157964048453367290">Diğer cihazlarınızda Brave ile açtığınız sekmeler burada görünür.</translation>
+<translation id="4684427112815847243">Her şeyi senkronize et</translation>
+<translation id="2709516037105925701">Otomatik doldurma</translation>
+<translation id="8820817407110198400">Favoriler</translation>
+<translation id="1644574205037202324">Geçmiş</translation>
+<translation id="17513872634828108">Açık sekmeler</translation>
+<translation id="1320169905922104972">Brave Software Pay'i kullanan kredi kartları ve adresler</translation>
+<translation id="6337234675334993532">Şifreleme</translation>
+<translation id="6698801883190606802">Senkronize edilen verileri yönet</translation>
+<translation id="3598578758776312506">Şifreleri Brave Software kimlik bilgileriyle şifrele</translation>
+<translation id="7810580217418711046"><ph name="TIME"/> itibarıyla, senkronize edilmiş verileri Brave Software şifresiyle şifrele</translation>
+<translation id="8461694314515752532">Senkronize edilen verileri senkronizasyon parolanızı kullanarak şifrele</translation>
+<translation id="2996291259634659425">Parola oluşturun</translation>
+<translation id="5713644099811900409">Brave Software Hesabı</translation>
+<translation id="8997474919031554666">Parolayla şifreleme, Brave Software Pay'deki adresleri ve ödeme yöntemlerini kapsamaz. Yalnızca parolanızı bilen biri, şifrelenmiş verilerinizi okuyabilir. Parola Brave Software'a gönderilmez veya Brave Software tarafından saklanmaz. Parolanızı unutursanız veya bu ayarı değiştirmek isterseniz senkronizasyonu sıfırlamanız gerekir. <ph name="BEGIN_LINK"/>Daha fazla bilgi<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Parola</translation>
+<translation id="7772032839648071052">Parolayı onayla</translation>
+<translation id="5304593522240415983">Bu alan boş olamaz</translation>
+<translation id="321773570071367578">Parolanızı unuttuysanız veya bu ayarı değiştirmek istiyorsanız <ph name="BEGIN_LINK"/>senkronizasyonu sıfırlayın<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Parolalar eşleşmiyor</translation>
+<translation id="5149495116300586333">Parolayla şifreleme, Brave Software Pay'deki adresleri ve ödeme yöntemlerini kapsamaz.
+
+Bu ayarı değiştirmek için <ph name="BEGIN_LINK"/>senkronizasyonu sıfırlayın<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Yanlış parola</translation>
+<translation id="5414836363063783498">Doğrulanıyor…</translation>
+<translation id="6846298663435243399">Yükleniyor…</translation>
+<translation id="5517095782334947753"><ph name="FROM_ACCOUNT"/> hesabından yer işaretleri, geçmiş, şifreler ve diğer ayarlarınız var.</translation>
+<translation id="3928666092801078803">Verilerimi birleştir</translation>
+<translation id="688738109438487280">Mevcut veriler <ph name="TO_ACCOUNT"/> hesabına eklenir.</translation>
+<translation id="806745655614357130">Verilerimi ayrı tut</translation>
+<translation id="1145536944570833626">Mevcut verileri silin.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> eşlenmek istiyor</translation>
+<translation id="4915549754973153784">Cihazlar taranırken <ph name="BEGIN_LINK"/>yardım alın<ph name="END_LINK"/>…</translation>
+<translation id="5817918615728894473">Eşle</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Yardım alın<ph name="END_LINK1"/> veya <ph name="BEGIN_LINK2"/>yeniden tarayın<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Uyumlu cihaz bulunamadı</translation>
+<translation id="3773755127849930740">Eşleşmeye izin vermek için <ph name="BEGIN_LINK"/>Bluetooth'u açın<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave, Bluetooth adaptörünü açamıyor</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Yardım alın<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave'un cihazları taraması için konuma erişmesi gerekiyor. <ph name="BEGIN_LINK"/>İzinleri güncelleyin<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave'un cihazları taraması için konum bilgilerine erişmesi gerekiyor. Konum bilgilerine erişim <ph name="BEGIN_LINK"/>bu cihaz için kapalı<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave'un cihazları taraması için konum bilgilerine erişmesi gerekiyor. <ph name="BEGIN_LINK1"/>İzinleri güncelleyin<ph name="END_LINK1"/>. Ayrıca, konum bilgilerine erişim <ph name="BEGIN_LINK2"/>bu cihaz için kapalı<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Bağlı Cihaz</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Sinyal Gücü Düzeyi: # çubuk}other{Sinyal Gücü Düzeyi: # çubuk}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/>, yakındaki Bluetooth cihazlar için tarama yapmak istiyor. Şu cihazlar bulundu:</translation>
+<translation id="8368027906805972958">Bilinmeyen veya desteklenmeyen cihaz (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Senkronizasyon çalışmıyor</translation>
+<translation id="1810845389119482123">İlk senkronizasyon kurulumu tamamlanmadı</translation>
+<translation id="3235722914093408050">Brave Senkronizasyonu'nu başlatmak için Android ayarlarını açın ve Android sistem senkronizasyonunu yeniden etkinleştirin</translation>
+<translation id="3367813778245106622">Senkronizasyonu başlatmak için tekrar oturum açın</translation>
+<translation id="974555521953189084">Senkronizasyonu başlatmak için parolanızı girin</translation>
+<translation id="2997266899014181325">Senkronizasyonu başlatmak için "Brave verilerimi senkronize et" ayarını etkinleştirin.</translation>
+<translation id="8260126382462817229">Tekrar oturum açmayı deneyin</translation>
+<translation id="5919204609460789179">Senkronizasyonu başlatmak için <ph name="PRODUCT_NAME"/> adlı uygulamayı güncelleyin</translation>
+<translation id="397583555483684758">Senkronizasyonun çalışması durdu</translation>
+<translation id="1966710179511230534">Lütfen oturum açma ayrıntılarınızı güncelleyin.</translation>
+<translation id="7063006564040364415">Senkronizasyon sunucusuna bağlanılamadı.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> güncel değil.</translation>
+<translation id="4170011742729630528">Hizmet kullanılamıyor, daha sonra tekrar deneyin.</translation>
+<translation id="7947953824732555851">Kabul et ve oturum aç</translation>
+<translation id="8583805026567836021">Hesap verileri temizleniyor</translation>
+<translation id="8310344678080805313">Standart sekmeler</translation>
+<translation id="5748802427693696783">Standart sekmelere geçildi</translation>
+<translation id="7998918019931843664">Kapatılan sekmeyi yeniden aç</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>, sekme</translation>
+<translation id="4452411734226507615"><ph name="TAB_TITLE"/> sekmesini kapat</translation>
+<translation id="7243308994586599757">Sayfanın altına yakın bir yerde kullanılabilen seçenekler</translation>
+<translation id="4060598801229743805">Ekranın üst kısmına yakın bir yerde seçenekler vardır</translation>
+<translation id="2810645512293415242">Veriden tasarruf etmek ve daha hızlı yüklemek için basitleştirilmiş sayfa.</translation>
+<translation id="3985215325736559418"><ph name="FILE_NAME"/> dosyasını tekrar indirmek istiyor musunuz?</translation>
+<translation id="2450083983707403292"><ph name="FILE_NAME"/> dosyasını tekrar indirmeye başlamak istiyor musunuz?</translation>
+<translation id="7514365320538308">İndir</translation>
+<translation id="545042621069398927">İndirme işleminiz hızlandırılıyor.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Dosya indiriliyor.}other{# dosya indiriliyor.}}</translation>
+<translation id="543509235395288790"><ph name="COUNT"/> dosya indiriliyor (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Dosya indiriliyor (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 indirme işlemi tamamlandı.}other{# indirme işlemi tamamlandı.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 indirme işlemi başarısız oldu.}other{# indirme işlemi başarısız oldu.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 indirme işlemi beklemede.}other{# indirme işlemi beklemede.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/> düğmesi</translation>
+<translation id="3205824638308738187">Çok az kaldı!</translation>
+<translation id="3960299545138990065">Brave'u yeniden başlatın</translation>
+<translation id="3771001275138982843">Güncelleme indirilemedi</translation>
+<translation id="3888648114124182147">Brave Güncellemesi indiriliyor…</translation>
+<translation id="1705567146636171298">Brave'u güncelle</translation>
+<translation id="6195417478702700398">Web'e en iyi göz atma deneyimi için Brave'u açıp güncelleyin</translation>
+<translation id="3512968675351418494">Web'i kendi dilinizde görmek için Brave'un en son sürümünü edinin</translation>
+<translation id="6427112570124116297">Web'i çevir</translation>
+<translation id="1379423114029199501">Brave'un en son sürümünü kendi dilinizde kullanmak için güncelleyin</translation>
+<translation id="5684874026226664614">Hata! Bu sayfa çevrilemedi.</translation>
+<translation id="6831043979455480757">Çevir</translation>
+<translation id="1285320974508926690">Bu siteyi hiçbir zaman çevirme</translation>
+<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE"/> dilindeki sayfaları her zaman çevir</translation>
+<translation id="1068672505746868501"><ph name="SOURCE_LANGUAGE"/> dilindeki sayfaları asla çevirme</translation>
+<translation id="124116460088058876">Diğer diller</translation>
+<translation id="290376772003165898">Sayfa <ph name="LANGUAGE"/> dilinde değil mi?</translation>
+<translation id="4432792777822557199"><ph name="SOURCE_LANGUAGE"/> dilindeki sayfalar artık <ph name="TARGET_LANGUAGE"/> diline çevrilecek</translation>
+<translation id="8339163506404995330"><ph name="LANGUAGE"/> dilindeki sayfalar çevrilmeyecek</translation>
+<translation id="5447765697759493033">Bu site çevrilmeyecek</translation>
+<translation id="4880127995492972015">Çevir...</translation>
+<translation id="641643625718530986">Yazdır…</translation>
+<translation id="8909135823018751308">Paylaş…</translation>
+<translation id="4996978546172906250">Paylaşım yöntemi:</translation>
+<translation id="6333140779060797560">Paylaşım yöntemi: <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Sayfa yazdırılırken bir sorun oluştu. Lütfen tekrar deneyin.</translation>
+<translation id="3254409185687681395">Bu sayfaya yer işareti koy</translation>
+<translation id="497421865427891073">İlerle</translation>
+<translation id="813082847718468539">Site bilgilerini görüntüle</translation>
+<translation id="2532336938189706096">Web Görüntüleme</translation>
+<translation id="6005538289190791541">Önerilen şifre</translation>
+<translation id="4634124774493850572">Şifre kullan</translation>
+<translation id="8285489906452138776">Brave'un bu sitede kameranıza erişmesi için izin gerekiyor.</translation>
+<translation id="320189792589364011">Brave'un bu sitede mikrofonunuza erişmesi için izin gerekiyor.</translation>
+<translation id="7988136689212463100">Brave'un bu sitede kameranıza ve mikrofonunuza erişmesi için izin gerekiyor.</translation>
+<translation id="4931190655840828017">Konumunuzu bu siteyle paylaşabilmek için Brave'un konum bilgilerinize erişmesi gerekiyor.</translation>
+<translation id="3088191967551450609">Dosya indirmek için Brave'un depolama alanına erişmesi gerekiyor.</translation>
+<translation id="8942627711005830162">Yeni pencerede aç</translation>
+<translation id="4195643157523330669">Yeni sekmede aç</translation>
+<translation id="1100066534610197918">Grupta yeni sekmede aç</translation>
+<translation id="4860895144060829044">Telefon et</translation>
+<translation id="6896758677409633944">Kopyala</translation>
+<translation id="8393700583063109961">İleti gönder</translation>
+<translation id="3557336313807607643">Kişilere ekle</translation>
+<translation id="4269820728363426813">Bağlantı adresini kopyala</translation>
+<translation id="1206892813135768548">Bağlantı metnini kopyala</translation>
+<translation id="1204037785786432551">Bağlantıyı indir</translation>
+<translation id="6864459304226931083">Resmi indir</translation>
+<translation id="8209050860603202033">Resmi aç</translation>
+<translation id="8073388330009372546">Resmi yeni sekmede aç</translation>
+<translation id="6649642165559792194">Resmin önizlemesini aç <ph name="BEGIN_NEW"/>Yeni<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Resim yükle</translation>
+<translation id="3845332215609790146">Brave Software Lens ile ara <ph name="BEGIN_NEW"/>Yeni<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Bu resmi, <ph name="SEARCH_ENGINE"/> üzerinde ara</translation>
+<translation id="3384347053049321195">Resmi paylaş</translation>
+<translation id="5833984609253377421">Bağlantıyı paylaş</translation>
+<translation id="6475951671322991020">Videoyu indir</translation>
+<translation id="2317945146070194624">Yeni Brave sekmesinde aç</translation>
+<translation id="7975379999046275268">Sayfanın önizlemesini aç <ph name="BEGIN_NEW"/>Yeni<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Sayfa yenileniyor</translation>
+<translation id="36525718899759834">Uygulamayı Brave Software Play Store'dan edinin: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Koyu</translation>
+<translation id="1807246157184219062">Açık</translation>
+<translation id="4056223980640387499">Sepya Tonu</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Eş aralıklı</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Işınlamak için bir sekme seçin</translation>
+<translation id="8719023831149562936">Geçerli sekme ışınlanamıyor</translation>
+<translation id="2139186145475833000">Ana ekrana ekle</translation>
+<translation id="4616150815774728855"><ph name="WEBAPK_NAME"/> APK'sını aç</translation>
+<translation id="2122601567107267586">Uygulama açılamadı</translation>
+<translation id="5129038482087801250">Web uygulamasını yükle</translation>
+<translation id="3789841737615482174">Yükle</translation>
+<translation id="4665282149850138822"><ph name="NAME"/>, Ana ekranınıza eklendi</translation>
+<translation id="7333031090786104871">Önceki siteyi ekleme işlemi devam ediyor.</translation>
+<translation id="1036727731225946849"><ph name="WEBAPK_NAME"/> ekleniyor...</translation>
+<translation id="3778956594442850293">Ana ekrana eklendi</translation>
+<translation id="2146738493024040262">Hazır Uygulamayı aç</translation>
+<translation id="7016516562562142042">Geçerli arama motoru için izin verildi</translation>
+<translation id="6177111841848151710">Geçerli arama motoru için engellendi</translation>
+<translation id="145097072038377568">Android Ayarları'ndan kapatıldı</translation>
+<translation id="8007176423574883786">Bu cihaz için kapatıldı</translation>
+<translation id="164269334534774161">Bu sayfanın <ph name="CREATION_TIME"/> tarihinde oluşturulan bir çevrimdışı kopyasını görüntülüyorsunuz</translation>
+<translation id="4594952190837476234">Bu çevrimdışı sayfa <ph name="CREATION_TIME"/> tarihli olup web'deki sürümden farklı olabilir.</translation>
+<translation id="8840953339110955557">Bu sayfa, web'deki sürümden farklı olabilir.</translation>
+<translation id="6405300764336705484">Bu içerik Brave Software tarafından <ph name="DOMAIN_NAME"/> adresinden sağlanmaktadır.</translation>
+<translation id="1006017844123154345">İnternet'te aç</translation>
+<translation id="3326636747541519688">Brave Software tarafından sağlanan basit sayfa</translation>
+<translation id="7149158118503947153"><ph name="DOMAIN_NAME"/> alanından <ph name="BEGIN_LINK"/>orijinal sayfayı yükle<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">Bunu çok sık görüyorsanız bu <ph name="BEGIN_LINK"/>önerileri<ph name="END_LINK"/> deneyin.</translation>
+<translation id="8748850008226585750">İçerik gizlendi</translation>
+<translation id="3810973564298564668">Yönet</translation>
+<translation id="5199929503336119739">İş profili</translation>
+<translation id="528192093759286357">Tam ekrandan çıkmak için yukarıdan sürükleyin ve geri düğmesine dokunun.</translation>
+<translation id="2836148919159985482">Tam ekrandan çıkmak için geri düğmesine dokunun.</translation>
+<translation id="3967822245660637423">İndirme tamamlandı</translation>
+<translation id="2434158240863470628">İndirme işlemi tamamlandı <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">İndirilemedi</translation>
+<translation id="1384959399684842514">İndirme işlemi duraklatıldı</translation>
+<translation id="1671236975893690980">İndirme işlemi beklemede…</translation>
+<translation id="5561549206367097665">Ağ bekleniyor…</translation>
+<translation id="5864419784173784555">Başka bir indirme işlemi bekleniyor…</translation>
+<translation id="6461962085415701688">Dosya açılamıyor</translation>
+<translation id="1178581264944972037">Duraklat</translation>
+<translation id="8200772114523450471">Sürdür</translation>
+<translation id="1409879593029778104"><ph name="FILE_NAME"/> dosyası zaten var olduğu için indirme işlemi engellendi.</translation>
+<translation id="3387650086002190359">Dosya sistemi hataları nedeniyle <ph name="FILE_NAME"/> dosyası indirilemedi.</translation>
+<translation id="6482749332252372425">Depolama alanı yetersiz olduğu için <ph name="FILE_NAME"/> dosyası indirilemedi.</translation>
+<translation id="7619072057915878432">Ağ sorunları nedeniyle <ph name="FILE_NAME"/> dosyası indirilemedi.</translation>
+<translation id="1477626028522505441">Sunucu sorunları nedeniyle <ph name="FILE_NAME"/> dosyası indirilemedi.</translation>
+<translation id="3692944402865947621">Depolama konumuna erişilemediği için <ph name="FILE_NAME"/> dosyası indirilemedi.</translation>
+<translation id="604996488070107836">Bilinmeyen bir hata nedeniyle <ph name="FILE_NAME"/> dosyası indirilemedi.</translation>
+<translation id="6738867403308150051">İndiriliyor…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / ?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/> / <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922"><ph name="KBS"/> KB indirildi</translation>
+<translation id="6416782512398055893"><ph name="MBS"/> MB indirildi</translation>
+<translation id="6538442820324228105"><ph name="GBS"/> GB indirildi</translation>
+<translation id="9204836675896933765">1 dosya kaldı</translation>
+<translation id="8186512483418048923"><ph name="FILES"/> dosya kaldı</translation>
+<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE"/> dosya indirildi}other{<ph name="FILES_DOWNLOADED_MANY"/> dosya indirildi}}</translation>
+<translation id="8037750541064988519"><ph name="DAYS"/> gün kaldı</translation>
+<translation id="8190358571722158785">1 gün kaldı</translation>
+<translation id="60923314841986378"><ph name="HOURS"/> saat kaldı</translation>
+<translation id="510275257476243843">1 saat kaldı</translation>
+<translation id="970715775301869095"><ph name="MINUTES"/> dk. kaldı</translation>
+<translation id="3236059992281584593">1 dk. kaldı</translation>
+<translation id="2777555524387840389"><ph name="SECONDS"/> sn. kaldı</translation>
+<translation id="2781151931089541271">1 sn. kaldı</translation>
+<translation id="3303414029551471755">İçeriği indirme işlemine başlansın mı?</translation>
+<translation id="8617240290563765734">İndirilen öğede belirtilen URL önerisi açılsın mı?</translation>
+<translation id="1373696734384179344">Seçilen içeriği indirmek için bellek yetersiz.</translation>
+<translation id="5271967389191913893">Cihaz, indirilecek içeriği açamıyor.</translation>
+<translation id="883806473910249246">İçerik indirilirken bir hata oluştu.</translation>
+<translation id="5626134646977739690">Adı:</translation>
+<translation id="7963646190083259054">Firma:</translation>
+<translation id="3414952576877147120">Boyut:</translation>
+<translation id="7375125077091615385">Tür:</translation>
+<translation id="5765780083710877561">Açıklama:</translation>
+<translation id="4881695831933465202">Aç</translation>
+<translation id="3542235761944717775"><ph name="KILOBYTES"/> KB kullanılabilir</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB kullanılabilir</translation>
+<translation id="5424588387303617268"><ph name="GIGABYTES"/> GB kullanılabilir</translation>
+<translation id="5793665092639000975"><ph name="SPACE_USED"/> / <ph name="SPACE_AVAILABLE"/> kullanılıyor</translation>
+<translation id="3587482841069643663">Tümü</translation>
+<translation id="4988526792673242964">Sayfalar</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Ses</translation>
+<translation id="9219103736887031265">Resimler</translation>
+<translation id="8250920743982581267">Dokümanlar</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# Dosya}other{# Dosya}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# Resim}other{# Resim}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Video}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# Ses dosyası}other{# Ses dosyası}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# Sayfa}other{# Sayfa}}</translation>
+<translation id="5456381639095306749">Sayfayı indir</translation>
+<translation id="2394602618534698961">İndirdiğiniz dosyalar burada görünür</translation>
+<translation id="7810647596859435254">Birlikte aç…</translation>
+<translation id="5655963694829536461">İndirdiklerinizde arama yapın</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Dosyalarım</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Çevrimdışı olsanız bile okuyabileceğiniz makaleler burada görünür.</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# sa.}other{# sa.}}</translation>
+<translation id="5853623416121554550">duraklatıldı</translation>
+<translation id="8965591936373831584">beklemede</translation>
+<translation id="2779651927720337254">başarısız</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Az Önce</translation>
+<translation id="4000212216660919741">Çevrimdışı Ana Sayfa</translation>
+<translation id="9133397713400217035">Çevrimdışıyken Keşfet</translation>
+<translation id="968900484120156207">Ziyaret ettiğiniz sayfalar burada görünür</translation>
+<translation id="7882131421121961860">Geçmiş bulunamadı</translation>
+<translation id="3549657413697417275">Geçmişinizde arayın</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">AA</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave İlk Çalıştırma Deneyimi</translation>
+<translation id="2700285883409956633">Bu uygulamayı kullanarak <ph name="BEGIN_LINK1"/>Brave'un Gizlilik Şartları<ph name="END_LINK1"/>'nı ve <ph name="BEGIN_LINK2"/>Gizlilik Uyarısı<ph name="END_LINK2"/>'nı kabul etmiş olursunuz.</translation>
+<translation id="1640714894372474981">Bu uygulamayı kullanarak Brave’un <ph name="BEGIN_LINK1"/>Hizmet Şartları<ph name="END_LINK1"/> ve <ph name="BEGIN_LINK2"/>Gizlilik Bildirimi<ph name="END_LINK2"/> ile <ph name="BEGIN_LINK3"/>Family Link ile Yönetilen Brave Software Hesapları için Gizlilik Bildirimi<ph name="END_LINK3"/>'ni kabul etmiş olursunuz.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> Brave'da açılacak. Devam ederek Brave'un <ph name="BEGIN_LINK1"/>Hizmet Şartları<ph name="END_LINK1"/>'nı ve <ph name="BEGIN_LINK2"/>Gizlilik Uyarısı<ph name="END_LINK2"/>'nı kabul etmiş olursunuz.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> Brave'da açılacak. Devam ederek Brave'un <ph name="BEGIN_LINK1"/>Hizmet Şartları<ph name="END_LINK1"/>'nı, <ph name="BEGIN_LINK2"/>Gizlilik Uyarısı<ph name="END_LINK2"/>'nı ve <ph name="BEGIN_LINK3"/>Family Link ile Yönetilen Brave Software Hesapları için Gizlilik Uyarısı<ph name="END_LINK3"/>'nı kabul etmiş olursunuz.</translation>
+<translation id="673197144963363525">Brave Software'a kullanım istatistikleri ve kilitlenme raporları göndererek Brave'u iyileştirmeye yardımcı olun.</translation>
+<translation id="3518985090088779359">Kabul et ve devam et</translation>
+<translation id="7207456302801184289">Brave'a Hoş Geldiniz</translation>
+<translation id="704822250101715322">Güncellemenin tamamlanması için Brave Software Play Hizmetleri bekleniyor</translation>
+<translation id="1231733316453485619">Senkronizasyon açılsın mı?</translation>
+<translation id="5132942445612118989">Tüm cihazlardaki şifreleriniz, geçmişiniz ve diğer öğelerinizi senkronize edin</translation>
+<translation id="5736731321935944068">Brave Software; Arama, reklamlar ve diğer Brave Software hizmetlerini kişiselleştirmek için geçmişinizi kullanabilir</translation>
+<translation id="4013614219085422040">Brave Software; Arama ve diğer Brave Software hizmetlerini kişiselleştirmek için geçmişinizi kullanabilir</translation>
+<translation id="5581519193887989363">Neyin senkronize edileceğini istediğiniz zaman <ph name="BEGIN_LINK1"/>ayarlardan<ph name="END_LINK1"/> seçebilirsiniz.</translation>
+<translation id="741204030948306876">Evet, istiyorum</translation>
+<translation id="2410754283952462441">Bir hesap seçin</translation>
+<translation id="2227444325776770048"><ph name="USER_FULL_NAME"/> olarak devam edin</translation>
+<translation id="6210748933810148297"><ph name="EMAIL"/> değil misiniz?</translation>
+<translation id="8109613176066109935">Yer işaretlerinize tüm cihazlarınızda ulaşmak için senkronizasyonu açın</translation>
+<translation id="2818669890320396765">Yer işaretlerinizi tüm cihazlarınızda almak için oturum açın ve senkronizasyonu etkinleştirin</translation>
+<translation id="6003646045106347985">Brave Software tarafından önerilen kişiselleştirilmiş içeriği almak için senkronizasyonu açın</translation>
+<translation id="8494430740943879273">Brave Software tarafından önerilen kişiselleştirilmiş içeriği almak için oturum açın ve senkronizasyonu etkinleştirin</translation>
+<translation id="5862731021271217234">Diğer cihazlarınızdaki sekmelerinize ulaşmak için senkronizasyonu etkinleştirin</translation>
+<translation id="3568688522516854065">Diğer cihazlarınızdaki sekmelerinize ulaşmak için oturum açın ve senkronizasyonu etkinleştirin</translation>
+<translation id="1208340532756947324">Cihazlar arasında senkronizasyon ve kişiselleştirme yapmak için senkronizasyonu etkinleştirin</translation>
+<translation id="4472118726404937099">Cihazlar arasında senkronizasyon ve kişiselleştirme yapmak için oturum açın ve senkronizasyonu etkinleştirin</translation>
+<translation id="2426805022920575512">Başka hesap seç</translation>
+<translation id="6790428901817661496">Oynat</translation>
+<translation id="1272079795634619415">Durdur</translation>
+<translation id="2874939134665556319">Önceki parça</translation>
+<translation id="4046123991198612571">Sonraki parça</translation>
+<translation id="3859306556332390985">İleriye doğru git</translation>
+<translation id="8441146129660941386">Geriye doğru git</translation>
+<translation id="6706288973712894588">Şu anda çevrimdışısınız.\n<ph name="BEGIN_LINK"/>Çevrimdışı feed'inizi keşfedin.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Son sekmeler</translation>
+<translation id="8497726226069778601">Burada görülecek bir şey yok… henüz</translation>
+<translation id="5423934151118863508">En çok ziyaret ettiğiniz sayfalar burada görünecektir</translation>
+<translation id="6127379762771434464">Öğe kaldırıldı</translation>
+<translation id="4605958867780575332">Öğe kaldırıldı: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software doodle'ı: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Diğer cihazlar</translation>
+<translation id="4738836084190194332">Son senkronizasyon: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# dakika önce}other{# dakika önce}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# saat önce}other{# saat önce}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# gün önce}other{# gün önce}}</translation>
+<translation id="2762000892062317888">az önce</translation>
+<translation id="1407135791313364759">Tümünü aç</translation>
+<translation id="1209206284964581585">Şimdilik gizle</translation>
+<translation id="129553762522093515">Son kapatılan</translation>
+<translation id="8413126021676339697">Tüm geçmişi göster</translation>
+<translation id="7876243839304621966">Tümünü kaldır</translation>
+<translation id="8487700953926739672">Çevrimdışı kullanılabilir</translation>
+<translation id="5224771365102442243">Videolu</translation>
+<translation id="3493531032208478708">Önerilen içerik hakkında <ph name="BEGIN_LINK"/>daha fazla bilgi edinin<ph name="END_LINK"/></translation>
+<translation id="7542481630195938534">Öneriler alınamıyor</translation>
+<translation id="5013696553129441713">Yeni öneri yok</translation>
+<translation id="1736419249208073774">Keşfet</translation>
+<translation id="7444811645081526538">Diğer kategoriler</translation>
+<translation id="6709133671862442373">Haberler</translation>
+<translation id="1264974993859112054">Spor</translation>
+<translation id="9139318394846604261">Alışveriş</translation>
+<translation id="3912508018559818924">Web'in en iyilerini buluyoruz…</translation>
+<translation id="526421993248218238">Bu sayfa yüklenemiyor</translation>
+<translation id="614940544461990577">Aşağıdakileri deneyin:</translation>
+<translation id="3288003805934695103">Sayfayı yeniden yükleme</translation>
+<translation id="2353636109065292463">İnternet bağlantınızı kontrol etme</translation>
+<translation id="2858138569776157458">Popüler siteler</translation>
+<translation id="8364299278605033898">Popüler web sitelerini görün</translation>
+<translation id="1171770572613082465">"Popüler siteler" düğmesine dokunarak popüler web sitelerini görün</translation>
+<translation id="5233638681132016545">Yeni sekme</translation>
+<translation id="4521874409998847950"><ph name="PUBLISHER_ORIGIN"/> web sitesinden - <ph name="BEGIN_DEEMPHASIZED"/>Brave Software tarafından yayınlandı<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Daha yeni bir sürüm mevcut</translation>
+<translation id="4058091506841967397">Brave güncellenemiyor</translation>
+<translation id="6316139424528454185">Android sürümü desteklenmiyor</translation>
+<translation id="6989267951144302301">İndirilemedi</translation>
+<translation id="624789221780392884">Güncelleme hazır</translation>
+<translation id="1549000191223877751">Diğer pencereye git</translation>
+<translation id="7481312909269577407">İleri</translation>
+<translation id="4084682180776658562">Yer İşareti</translation>
+<translation id="6437478888915024427">Sayfa bilgileri</translation>
+<translation id="7180611975245234373">Yenile</translation>
+<translation id="4913169188695071480">Yenilemeyi durdur</translation>
+<translation id="1829244130665387512">Sayfada bul</translation>
+<translation id="6593061639179217415">Masaüstü sitesi</translation>
+<translation id="9063523880881406963">Masaüstü sitesi istemeyi devre dışı bırak</translation>
+<translation id="2038563949887743358">Masaüstü sitesi iste işlevini etkinleştir</translation>
+<translation id="2433507940547922241">Görünüm</translation>
+<translation id="983192555821071799">Tüm sekmeleri kapat</translation>
+<translation id="1310482092992808703">Sekmeleri grupla</translation>
+<translation id="7725024127233776428">Yer işareti koyduğunuz sayfalar burada görünür</translation>
+<translation id="4404568932422911380">Yer işareti yok</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> yer işareti}other{<ph name="BOOKMARKS_COUNT_MANY"/> yer işareti}}</translation>
+<translation id="3739899004075612870"><ph name="PRODUCT_NAME"/> üzerinde yer işareti koyuldu</translation>
+<translation id="3207960819495026254">Yer işareti koyuldu</translation>
+<translation id="4452548195519783679">Yer işareti <ph name="FOLDER_NAME"/> klasörüne eklendi</translation>
+<translation id="8063895661287329888">Yer işareti eklenemedi.</translation>
+<translation id="2842985007712546952">Ana klasör</translation>
+<translation id="9065203028668620118">Düzenle</translation>
+<translation id="4405224443901389797">Klasöre taşı…</translation>
+<translation id="5170568018924773124">Klasörde göster</translation>
+<translation id="8035133914807600019">Yeni klasör…</translation>
+<translation id="4532845899244822526">Klasör seçin</translation>
+<translation id="6627583120233659107">Klasörü düzenle</translation>
+<translation id="1197267115302279827">Yer işaretlerini taşı</translation>
+<translation id="6963766334940102469">Yer işaretlerini silme</translation>
+<translation id="4351244548802238354">İletişim kutusunu kapat</translation>
+<translation id="451872707440238414">Yer işaretlerinizde arayın</translation>
+<translation id="8901170036886848654">Yer işareti bulunamadı</translation>
+<translation id="6404511346730675251">Yer işaretini düzenle</translation>
+<translation id="3894427358181296146">Klasör ekleyin</translation>
+<translation id="5327248766486351172">Ad</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Klasör</translation>
+<translation id="5161254044473106830">Başlık gerekiyor</translation>
+<translation id="2996809686854298943">URL gerekli</translation>
+<translation id="2536728043171574184">Bu sayfanın çevrimdışı bir kopyası görüntüleniyor</translation>
+<translation id="4698034686595694889"><ph name="APP_NAME"/> uygulamasında çevrimdışı görüntüle</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> ve diğer siteler</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave, hazır olduğunda sayfanızı yükler}other{Brave, hazır olduğunda sayfalarınızı yükler}}</translation>
+<translation id="6811034713472274749">Sayfa görüntülenmeye hazır</translation>
+<translation id="4561979708150884304">Bağlantı yok</translation>
+<translation id="8274165955039650276">İndirilenleri göster</translation>
+<translation id="2082238445998314030"><ph name="TOTAL_RESULTS"/> sonuçtan <ph name="RESULT_NUMBER"/> numaralı sonuç</translation>
+<translation id="4943872375798546930">Sonuç yok</translation>
+<translation id="981121421437150478">Çevrimdışı</translation>
+<translation id="3298243779924642547">Basit</translation>
+<translation id="393697183122708255">Kullanılabilir etkin sesli arama yok</translation>
+<translation id="7191430249889272776">Sekme arka planda açıldı.</translation>
+<translation id="8445059357334030806">Brave'da aç</translation>
+<translation id="4720023427747327413"><ph name="PRODUCT_NAME"/> uygulamasında aç</translation>
+<translation id="7022756207310403729">Tarayıcıda aç</translation>
+<translation id="1113597929977215864">Basitleştirilmiş görünümü göster</translation>
+<translation id="1513352483775369820">Yer işaretleri ve web geçmişi</translation>
+<translation id="4939482511480190003">Brave'u daha iyi hale getirmeye yardımcı olun. <ph name="BEGIN_LINK"/>Ankete katıl<ph name="END_LINK"/>.</translation>
+<translation id="2501278716633472235">Geri dön</translation>
+<translation id="5596627076506792578">Diğer seçenekler</translation>
+<translation id="3522247891732774234">Güncelleme mevcut. Diğer seçenekler</translation>
+<translation id="6773423637732432200">Brave güncellenemiyor. Diğer seçenekler</translation>
+<translation id="3328801116991980348">Site bilgileri</translation>
+<translation id="5391532827096253100">Bu siteye bağlantınız güvenli değil. Site bilgileri</translation>
+<translation id="6206551242102657620">Bağlantı güvenli. Site bilgileri</translation>
+<translation id="6963642900430330478">Bu sayfa tehlikeli. Site bilgileri</translation>
+<translation id="9070377983101773829">Sesli arama başlat</translation>
+<translation id="8676374126336081632">Girişi temizle</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> açık sekme, sekmeler arasında geçiş yapmak için dokunun}other{<ph name="OPEN_TABS_MANY"/> açık sekme, sekmeler arasında geçiş yapmak için dokunun}}</translation>
+<translation id="2369533728426058518">sekmeleri aç</translation>
+<translation id="7071521146534760487">Hesabı yönet</translation>
+<translation id="932327136139879170">Ana Sayfa</translation>
+<translation id="2707726405694321444">Sayfayı yenile</translation>
+<translation id="2891154217021530873">Sayfa yüklemeyi durdur</translation>
+<translation id="6710213216561001401">Önceki</translation>
+<translation id="6659594942844771486">Sekme</translation>
+<translation id="1933845786846280168">Seçili Sekme</translation>
+<translation id="2268044343513325586">Hassaslaştır</translation>
+<translation id="7846076177841592234">Seçimi iptal et</translation>
+<translation id="7087918508125750058"><ph name="ITEM_COUNT"/> öğe seçildi. Seçenekler, ekranın üst kısmına yakın bir yerde bulunur</translation>
+<translation id="7250468141469952378"><ph name="ITEM_COUNT"/> öğe seçildi</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{1 seçili öğeyi paylaş}other{# seçili öğeyi paylaş}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{1 seçili öğeyi kaldır}other{# seçili öğeyi kaldır}}</translation>
+<translation id="1283039547216852943">Genişletmek için dokunun</translation>
+<translation id="5962718611393537961">Daraltmak için dokunun</translation>
+<translation id="8076492880354921740">Sekmeler</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{1 öğe seçildi}other{# öğe seçildi}}</translation>
+<translation id="6818926723028410516">Öğe seçin</translation>
+<translation id="4797039098279997504"><ph name="URL_OF_THE_CURRENT_TAB"/> adresine dönmek için dokunun</translation>
+<translation id="6766758767654711248">Siteye gitmek için dokunun</translation>
+<translation id="429312253194641664">Bir site medya oynatıyor</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> ekranınızı paylaşıyor</translation>
+<translation id="8833831881926404480">Bir site, ekranınızı paylaşıyor</translation>
+<translation id="9086455579313502267">Ağa erişilemiyor</translation>
+<translation id="938850635132480979">Hata: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929"><ph name="APP_NAME"/> uygulamasında aç</translation>
+<translation id="548278423535722844">Haritalar uygulamasında aç</translation>
+<translation id="7698359219371678927"><ph name="APP_NAME"/> adlı uygulamada e-posta oluşturun</translation>
+<translation id="7875915731392087153">E-posta oluşturun</translation>
+<translation id="5665379678064389456"><ph name="APP_NAME"/> adlı uygulamada etkinlik oluştur</translation>
+<translation id="2900528713135656174">Etkinlik oluştur</translation>
+<translation id="2111511281910874386">Sayfaya gidin</translation>
+<translation id="3988466920954086464">Anında arama sonuçlarını bu panelde görün</translation>
+<translation id="2744248271121720757">Anında aramak veya ilgili işlemleri görmek için bir kelimeye dokunun</translation>
+<translation id="9155898266292537608">Bir kelimeye hızlıca dokunarak da arama yapabilirsiniz</translation>
+<translation id="3232754137068452469">Web Uygulaması</translation>
+<translation id="1430915738399379752">Yazdır</translation>
+<translation id="3775705724665058594">Cihazlarınıza gönderin</translation>
+<translation id="6364438453358674297">Öneri geçmişten kaldırılsın mı?</translation>
+<translation id="213279576345780926"><ph name="TAB_TITLE"/> kapatıldı</translation>
+<translation id="6850830437481525139"><ph name="TAB_COUNT"/> sekme kapatıldı</translation>
+<translation id="3211426585530211793"><ph name="ITEM_TITLE"/> silindi</translation>
+<translation id="4663756553811254707"><ph name="NUMBER_OF_BOOKMARKS"/> yer işareti silindi</translation>
+<translation id="3819178904835489326">İndirilen <ph name="NUMBER_OF_DOWNLOADS"/> dosya silindi</translation>
+<translation id="1248710015876067820">Desteklenmeyen sayıda Brave örneği var.</translation>
+<translation id="4259722352634471385">Gezinme engellendi: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Gezinme işlevine ulaşılamıyor: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Sekmeyi kapat</translation>
+<translation id="7772375229873196092"><ph name="APP_NAME"/> penceresini kapat</translation>
+<translation id="1227058898775614466">Gezinme geçmişi</translation>
+<translation id="9169507124922466868">Gezinme geçmişi yarım açık</translation>
+<translation id="1327257854815634930">Gezinme geçmişi açık</translation>
+<translation id="8788265440806329501">Gezinme geçmişi kapalı</translation>
+<translation id="7482656565088326534">Önizleme sekmesi</translation>
+<translation id="8427875596167638501">Önizleme sekmesi yarım açık</translation>
+<translation id="9102803872260866941">Önizleme sekmesi açık</translation>
+<translation id="2942036813789421260">Önizleme sekmesi kapalı</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> depolama alanı</translation>
+<translation id="3822502789641063741">Site depolama silinsin mi?</translation>
+<translation id="9205995714227143200">Brave'un önemli olmadığını düşündüğü site depolama alanı (ör. kayıtlı ayarları bulunmayan veya sık ziyaret etmediğiniz siteler)</translation>
+<translation id="3997476611815694295">Önemli olmayan depolama alanı</translation>
+<translation id="8493948351860045254">Yer aç</translation>
+<translation id="2324920234469020158">Bu işlem Brave'un önemli olmadığını düşündüğü çerezleri, önbelleği ve diğer site verilerini temizleyecek.</translation>
+<translation id="5447201525962359567">Çerezler ve yerel olarak depolanmış diğer veriler de dahil olmak üzere tüm site depolama alanı</translation>
+<translation id="1376578503827013741">Hesaplanıyor…</translation>
+<translation id="583281660410589416">Bilinmiyor</translation>
+<translation id="2323763861024343754">Site depolama alanı</translation>
+<translation id="3587672679800759167">Hesaplar, yer işaretleri ve kayıtlı ayarlar da dahil olmak üzere Brave tarafından kullanılan tüm veriler</translation>
+<translation id="6545017243486555795">Tüm Verileri Temizle</translation>
+<translation id="4095146165863963773">Uygulama verileri silinsin mi?</translation>
+<translation id="53119194224775367">Brave'un tüm uygulama verileri kalıcı olarak silinecek. Buna tüm dosyalar, ayarlar, hesaplar, veritabanları vb. dahildir.</translation>
+<translation id="5307446750509046227">Site depolamayı temizle</translation>
+<translation id="300526633675317032">Bu işlem <ph name="SIZE_IN_KB"/> olan web sitesi depolama alanının tamamını temizleyecek.</translation>
+<translation id="8068648041423924542">Sertifika seçilemiyor.</translation>
+<translation id="2315043854645842844">İstemci tarafı sertifika seçimi, işletim sistemi tarafından desteklenmiyor.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> bağlanmak istiyor</translation>
+<translation id="5308380583665731573">Bağlan</translation>
+<translation id="868929229000858085">Kişilerinizde arama yapın</translation>
+<translation id="1919950603503897840">Kişi seçin</translation>
+<translation id="7986741934819883144">Kişi seçin</translation>
+<translation id="3333961966071413176">Tüm kişiler</translation>
+<translation id="4994033804516042629">Kişi bulunamadı</translation>
+<translation id="5403592356182871684">Adlar</translation>
+<translation id="2717722538473713889">E-posta adresleri</translation>
+<translation id="381841723434055211">Telefon numaraları</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 tane daha)}other{(+ # tane daha)}}</translation>
+<translation id="5197729504361054390">Seçtiğiniz kişiler <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> ile paylaşılacak.</translation>
+<translation id="1779089405699405702">Görsel kod çözücüsü</translation>
+<translation id="8067883171444229417">Videoyu oynat</translation>
+<translation id="6560414384669816528">Sogou ile arama</translation>
+<translation id="5406914950576900927">Brave, Çin'de arama yapmak için <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/>'yu kullanabilir. Bu seçimi <ph name="BEGIN_LINK"/>Ayarlar<ph name="END_LINK"/>'da değiştirebilirsiniz.</translation>
+<translation id="6456271171669383967">Brave Software kalsın</translation>
+<translation id="4384468725000734951">Arama için Sogou kullanılıyor</translation>
+<translation id="6103327872225198548">Arama için Brave Software kullanılıyor</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Bu uygulama Brave'da çalışıyor</translation>
+<translation id="6143689084714664628">Brave'da çalıştırılıyor</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> uygulamasına ait veriler Brave'da da mevcut</translation>
+<translation id="2734140769649165081">Verileri Brave Ayarlarından temizleyebilirsiniz</translation>
+<translation id="8232956427053453090">Verileri koru</translation>
+<translation id="4298388696830689168">Bağlantılı siteler</translation>
+<translation id="5763514718066511291">Bu uygulamanın URL'sini kopyalamak için dokunun</translation>
+<translation id="6496823230996795692"><ph name="APP_NAME"/> uygulamasını ilk kez kullanmak için lütfen internete bağlanın.</translation>
+<translation id="751961395872307827">Siteye bağlanılamıyor</translation>
+<translation id="4878404682131129617">Proxy sunucu üzerinden tünel oluşturulamadı</translation>
+<translation id="4749960740855309258">Yeni sekme açar</translation>
+<translation id="8788968922598763114">Son kapatılan sekmeyi yeniden açar</translation>
+<translation id="7929962904089429003">Menüyü açar</translation>
+<translation id="6039379616847168523">Sonraki sekmeye gider</translation>
+<translation id="5210286577605176222">Önceki sekmeye gider</translation>
+<translation id="124678866338384709">Geçerli sekmeyi kapatır</translation>
+<translation id="3714981814255182093">Bulma Çubuğu'nu açar</translation>
+<translation id="5441522332038954058">Adres çubuğuna gider</translation>
+<translation id="3398320232533725830">Yer işareti yöneticisini açar</translation>
+<translation id="6583199322650523874">Mevcut sayfaya yer işareti koyar</translation>
+<translation id="8489271220582375723">Geçmiş sayfasını açar</translation>
+<translation id="4837753911714442426">Sayfayı yazdırma seçeneklerini açar</translation>
+<translation id="5726692708398506830">Sayfadaki her şeyi büyütür</translation>
+<translation id="3259831549858767975">Sayfadaki her şeyi küçültür</translation>
+<translation id="8015452622527143194">Sayfadaki her şeyi varsayılan boyutuna döndürür</translation>
+<translation id="3443221991560634068">Geçerli sayfayı yeniden yükler</translation>
+<translation id="123724288017357924">Önbelleğe alınmış içeriği yoksayarak geçerli sayfayı yeniden yükler</translation>
+<translation id="305870044889644984">Brave Yardım Merkezi'ni yeni bir sekmede açar</translation>
+<translation id="3166827708714933426">Sekme ve pencere kısayolları</translation>
+<translation id="3169981355900570544">Brave Software Brave'un özellik kısayolları</translation>
+<translation id="4558311620361989323">Web sayfası kısayolları</translation>
+<translation id="1908301351964700579">Brave hâlâ VR için hazırlanıyor. Brave'u daha sonra yeniden başlatın.</translation>
+<translation id="8970887620466824814">Bir hata oluştu.</translation>
+<translation id="1875543012935658554">Brave'u yeniden açın.</translation>
+<translation id="79859296434321399">Artırılmış gerçeklik içeriğini görüntülemek için ARCore'u yükleyin</translation>
+<translation id="8558485628462305855">Artırılmış gerçeklik içeriğini görüntülemek için ARCore'u güncelleyin</translation>
+<translation id="3513704683820682405">Artırılmış Gerçeklik</translation>
+<translation id="5475862044948910901">Artırılmış Gerçeklik oturumu başlatılsın mı?</translation>
 <translation id="7365126855094612066">Bu oturumun süresince site şunları yapabilir:
 • çevrenizin 3D haritasını oluşturabilir
 • kamera hareketini takip edebilir
 
 Site kameraya ERİŞMEZ. Kamera görüntülerini yalnızca siz görebilirsiniz.</translation>
-<translation id="7375125077091615385">Tür:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Chrome İlk Çalıştırma Deneyimi</translation>
-<translation id="741204030948306876">Evet, istiyorum</translation>
-<translation id="7413229368719586778">Başlangıç tarihi: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Önce sor</translation>
-<translation id="7423538860840206698">Pano okuma engellendi</translation>
-<translation id="7431991332293347422">Göz atma geçmişinizin Arama ve diğer hizmetleri kişiselleştirmek için nasıl kullanıldığını kontrol edin</translation>
-<translation id="7437998757836447326">Chrome oturumunu kapatma</translation>
-<translation id="7438641746574390233">Basit mod açıkken, Chrome sayfaların daha hızlı yüklenmesi için Google sunucularını kullanır. Basit mod, çok yavaş sayfaları yalnızca önemli içerikleri yüklenecek şekilde yeniden yazar. Basit mod, Gizli sekmelerde kullanılamaz.</translation>
-<translation id="7444811645081526538">Diğer kategoriler</translation>
-<translation id="7445411102860286510">Sitelerin, sesi kapatılmış videoları otomatik olarak oynatmasına izin ver (önerilen)</translation>
-<translation id="7453467225369441013">Çoğu sitedeki oturumunuz kapatılır. Google Hesabınızdaki oturumunuz kapatılmaz.</translation>
-<translation id="7454641608352164238">Yeterli alan yok</translation>
-<translation id="7475192538862203634">Bunu çok sık görüyorsanız bu <ph name="BEGIN_LINK" />önerileri<ph name="END_LINK" /> deneyin.</translation>
-<translation id="7475688122056506577">SD kart bulunamadı. Bazı dosyalarınız eksik olabilir.</translation>
-<translation id="7479104141328977413">Sekme yönetimi</translation>
-<translation id="7481312909269577407">İleri</translation>
-<translation id="7482656565088326534">Önizleme sekmesi</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (<ph name="TIME_SINCE_UPDATE" /> güncellendi)</translation>
-<translation id="7494974237137038751">tasarruf edilen veri miktarı</translation>
-<translation id="7498271377022651285">Lütfen bekleyin…</translation>
-<translation id="7514365320538308">İndir</translation>
-<translation id="751961395872307827">Siteye bağlanılamıyor</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Öneriler alınamıyor</translation>
-<translation id="7559975015014302720">Basit mod kapalı</translation>
-<translation id="7562080006725997899">Göz atma verileri temizleniyor</translation>
-<translation id="756809126120519699">Chrome verileri temizlendi</translation>
-<translation id="757524316907819857">Sitelerin korumalı içeriği oynatmasını engellenir</translation>
-<translation id="757855969265046257">{FILES,plural, =1{<ph name="FILES_DOWNLOADED_ONE" /> dosya indirildi}other{<ph name="FILES_DOWNLOADED_MANY" /> dosya indirildi}}</translation>
-<translation id="7588219262685291874">Cihazın Pil Tasarrufu özelliği açık olduğunda koyu tema açılır</translation>
-<translation id="7589445247086920869">Geçerli arama motorunu engelle</translation>
-<translation id="7593557518625677601">Chrome Senkronizasyonu'nu başlatmak için Android ayarlarını açın ve Android sistem senkronizasyonunu yeniden etkinleştirin</translation>
-<translation id="7596558890252710462">İşletim sistemi</translation>
-<translation id="7605594153474022051">Senkronizasyon çalışmıyor</translation>
-<translation id="7606077192958116810">Basit mod açık. Bunu Ayarlar'dan yönetebilirsiniz.</translation>
-<translation id="7612619742409846846">Google'da şu hesapla oturum açıldı:</translation>
-<translation id="7619072057915878432">Ağ sorunları nedeniyle <ph name="FILE_NAME" /> dosyası indirilemedi.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Yardım alın<ph name="END_LINK1" /> veya <ph name="BEGIN_LINK2" />yeniden tarayın<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chrome'a Hoş Geldiniz</translation>
-<translation id="7638584964844754484">Yanlış parola</translation>
-<translation id="7641339528570811325">Tarama verilerini temizle…</translation>
-<translation id="7648422057306047504">Şifreleri Google kimlik bilgileriyle şifrele</translation>
-<translation id="7649070708921625228">Yardım</translation>
-<translation id="7658239707568436148">İptal</translation>
-<translation id="7665369617277396874">Hesap ekle</translation>
-<translation id="766587987807204883">Çevrimdışı olsanız bile okuyabileceğiniz makaleler burada görünür.</translation>
-<translation id="7682724950699840886">Şu ipuçlarını deneyin: Cihazınızda yeterli alan bulunduğundan emin olun, daha sonra dışa aktarmayı tekrar deneyin.</translation>
-<translation id="7685301384041462804">VR moduna girmeden önce bu siteye güvendiğinizden emin olun.</translation>
-<translation id="7698359219371678927"><ph name="APP_NAME" /> adlı uygulamada e-posta oluşturun</translation>
-<translation id="7704317875155739195">Aramaları ve URL'leri otomatik tamamla</translation>
-<translation id="7725024127233776428">Yer işareti koyduğunuz sayfalar burada görünür</translation>
-<translation id="773466115871691567"><ph name="SOURCE_LANGUAGE" /> dilindeki sayfaları her zaman çevir</translation>
-<translation id="7746457520633464754">Chrome, tehlikeli uygulamaları ve siteleri algılamak için Google'a ziyaret ettiğiniz bazı sitelerin URL'lerini, sınırlı sistem bilgisini ve bazı sayfa içeriklerini gönderir.</translation>
-<translation id="7757787379047923882">Metin, <ph name="DEVICE_NAME" /> cihazından paylaşıldı</translation>
-<translation id="7762668264895820836">SD Kart <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Adres ekle</translation>
-<translation id="7772032839648071052">Parolayı onayla</translation>
-<translation id="7772375229873196092"><ph name="APP_NAME" /> penceresini kapat</translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ödeme yöntemi daha}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 ve <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> ödeme yöntemi daha}}</translation>
-<translation id="7781829728241885113">Dün</translation>
-<translation id="7791543448312431591">Ekle</translation>
-<translation id="780301667611848630">Hayır, teşekkürler</translation>
-<translation id="7810647596859435254">Birlikte aç…</translation>
-<translation id="7821588508402923572">Veri tasarruflarınız burada görünür</translation>
-<translation id="7837721118676387834">Belirli bir sitenin, sesi kapatılmış videoları otomatik olarak oynatmasına izin verin.</translation>
-<translation id="7846076177841592234">Seçimi iptal et</translation>
-<translation id="784934925303690534">Zaman aralığı</translation>
-<translation id="7851858861565204677">Diğer cihazlar</translation>
-<translation id="7875915731392087153">E-posta oluşturun</translation>
-<translation id="7876243839304621966">Tümünü kaldır</translation>
-<translation id="7882131421121961860">Geçmiş bulunamadı</translation>
-<translation id="7882806643839505685">Belirli bir site için sese izin verin.</translation>
-<translation id="7886917304091689118">Chrome'da çalıştırılıyor</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Dosya indiriliyor.}other{# dosya indiriliyor.}}</translation>
-<translation id="7929962904089429003">Menüyü açar</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> güncel değil.</translation>
-<translation id="7947953824732555851">Kabul et ve oturum aç</translation>
-<translation id="7963646190083259054">Firma:</translation>
-<translation id="7971136598759319605">1 gün önce etkindi</translation>
-<translation id="7975379999046275268">Sayfanın önizlemesini aç <ph name="BEGIN_NEW" />Yeni<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Daha hızlı göz atmak ve arama yapmak için sayfaları önceden yükle</translation>
-<translation id="79859296434321399">Artırılmış gerçeklik içeriğini görüntülemek için ARCore'u yükleyin</translation>
-<translation id="7986741934819883144">Kişi seçin</translation>
-<translation id="7987073022710626672">Chrome Hizmet Şartları</translation>
-<translation id="7998918019931843664">Kapatılan sekmeyi yeniden aç</translation>
-<translation id="7999064672810608036">Bu web sitesine ilişkin çerezler dahil tüm yerel verileri temizlemek ve bu sitenin tüm izinlerini sıfırlamak istediğinizden emin misiniz?</translation>
-<translation id="8004582292198964060">Tarayıcı</translation>
-<translation id="8007176423574883786">Bu cihaz için kapatıldı</translation>
-<translation id="8013372441983637696">Chrome verilerinizi de bu cihazdan temizleyin</translation>
-<translation id="8015452622527143194">Sayfadaki her şeyi varsayılan boyutuna döndürür</translation>
-<translation id="802154636333426148">İndirilemedi</translation>
-<translation id="8026334261755873520">Tarama verilerini temizle</translation>
-<translation id="8035133914807600019">Yeni klasör…</translation>
-<translation id="8037750541064988519"><ph name="DAYS" /> gün kaldı</translation>
-<translation id="804335162455518893">SD kart bulunamadı</translation>
-<translation id="805047784848435650">Tarama geçmişinize dayalı</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB kullanılabilir</translation>
-<translation id="8058746566562539958">Yeni Chrome sekmesinde aç</translation>
-<translation id="8063895661287329888">Yer işareti eklenemedi.</translation>
-<translation id="806745655614357130">Verilerimi ayrı tut</translation>
-<translation id="8067883171444229417">Videoyu oynat</translation>
-<translation id="8068648041423924542">Sertifika seçilemiyor.</translation>
-<translation id="8073388330009372546">Resmi yeni sekmede aç</translation>
-<translation id="8076492880354921740">Sekmeler</translation>
-<translation id="8084114998886531721">Kayıtlı şifre</translation>
-<translation id="8087000398470557479">Bu içerik Google tarafından <ph name="DOMAIN_NAME" /> adresinden sağlanmaktadır.</translation>
-<translation id="8103578431304235997">Gizli Sekme</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Yer işaretlerinize tüm cihazlarınızda ulaşmak için senkronizasyonu açın</translation>
-<translation id="8110087112193408731">Chrome etkinliğiniz Dijital Denge'de gösterilsin mi?</translation>
-<translation id="8116925261070264013">Ses kapatıldı</translation>
-<translation id="813082847718468539">Site bilgilerini görüntüle</translation>
-<translation id="8131740175452115882">Onayla</translation>
-<translation id="8156139159503939589">Hangi dillerde okuyabiliyorsunuz?</translation>
-<translation id="8168435359814927499">İçerik</translation>
-<translation id="8186512483418048923"><ph name="FILES" /> dosya kaldı</translation>
-<translation id="8190358571722158785">1 gün kaldı</translation>
-<translation id="8200772114523450471">Sürdür</translation>
-<translation id="8209050860603202033">Resmi aç</translation>
-<translation id="8218622182176210845">Hesabınızı yönetin</translation>
-<translation id="8224471946457685718">Size özel makaleleri kablosuz bağlantıda indirin</translation>
-<translation id="8232956427053453090">Verileri koru</translation>
-<translation id="8249310407154411074">En üste taşı</translation>
-<translation id="8250920743982581267">Dokümanlar</translation>
-<translation id="825412236959742607">Bu sayfa çok fazla bellek kullandığından Chrome bazı içerikleri kaldırdı.</translation>
-<translation id="8260126382462817229">Tekrar oturum açmayı deneyin</translation>
-<translation id="8261506727792406068">Sil</translation>
-<translation id="8266862848225348053">İndirme konumu</translation>
-<translation id="8274165955039650276">İndirilenleri göster</translation>
-<translation id="8284326494547611709">Altyazılar</translation>
-<translation id="8300705686683892304">Uygulama tarafından yönetiliyor</translation>
-<translation id="8310344678080805313">Standart sekmeler</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> ve diğer siteler</translation>
-<translation id="8327155640814342956">Web'e en iyi göz atma deneyimi için Chrome'u açıp güncelleyin</translation>
-<translation id="8339163506404995330"><ph name="LANGUAGE" /> dilindeki sayfalar çevrilmeyecek</translation>
-<translation id="8349013245300336738">Kullanılan veri miktarına göre sırala</translation>
-<translation id="8364299278605033898">Popüler web sitelerini görün</translation>
-<translation id="8368027906805972958">Bilinmeyen veya desteklenmeyen cihaz (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Belirli bir site için Arka Plan Senkronizasyonuna izin verin.</translation>
-<translation id="8378714024927312812">Kuruluşunuz tarafından yönetiliyor</translation>
-<translation id="8380167699614421159">Bu site, araya giren veya yanıltıcı reklamlar gösteriyor</translation>
-<translation id="8393700583063109961">İleti gönder</translation>
-<translation id="8413126021676339697">Tüm geçmişi göster</translation>
-<translation id="8427875596167638501">Önizleme sekmesi yarım açık</translation>
-<translation id="8428213095426709021">Ayarlar</translation>
-<translation id="8438566539970814960">Aramaları ve göz atmayı daha iyi yap</translation>
-<translation id="8441146129660941386">Geriye doğru git</translation>
-<translation id="8443209985646068659">Chrome güncellenemiyor</translation>
-<translation id="8445448999790540984">Şifreler dışa aktarılamıyor</translation>
-<translation id="8447861592752582886">Cihaz iznini iptal et</translation>
-<translation id="8461694314515752532">Senkronize edilen verileri senkronizasyon parolanızı kullanarak şifrele</translation>
-<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME" /> cihazının internete bağlı olduğundan emin olun</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Çevrimdışı kullanılabilir</translation>
-<translation id="8489271220582375723">Geçmiş sayfasını açar</translation>
-<translation id="8493948351860045254">Yer aç</translation>
-<translation id="8497726226069778601">Burada görülecek bir şey yok… henüz</translation>
-<translation id="8503559462189395349">Chrome Şifreleri</translation>
-<translation id="8503813439785031346">Kullanıcı adı</translation>
-<translation id="8514477925623180633">Chrome'da depolanan şifreleri dışa aktarın</translation>
-<translation id="8514577642972634246">Gizli moda geç</translation>
-<translation id="851751545965956758">Sitelerin cihazlara bağlanmasını engelle</translation>
-<translation id="8523928698583292556">Kayıtlı şifreyi sil</translation>
-<translation id="854522910157234410">Şu sayfayı aç:</translation>
-<translation id="8558485628462305855">Artırılmış gerçeklik içeriğini görüntülemek için ARCore'u güncelleyin</translation>
-<translation id="8559990750235505898">Diğer dillerdeki sayfaları çevirmeyi öner</translation>
-<translation id="8562452229998620586">Kayıtlı şifreleriniz burada görünür.</translation>
-<translation id="8569404424186215731"><ph name="DATE" /> tarihinden bu yana</translation>
-<translation id="8571213806525832805">Son 4 hafta</translation>
-<translation id="857943718398505171">İzin verildi (önerilir)</translation>
-<translation id="8583805026567836021">Hesap verileri temizleniyor</translation>
-<translation id="860043288473659153">Kart sahibinin adı</translation>
-<translation id="8609465669617005112">Yukarı taşı</translation>
-<translation id="8616006591992756292">Google Hesabınızın <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> adresinde başka biçimlerde tarama geçmişi olabilir.</translation>
-<translation id="8617240290563765734">İndirilen öğede belirtilen URL önerisi açılsın mı?</translation>
-<translation id="8636825310635137004">Diğer cihazlarınızdaki sekmelerinize ulaşmak için senkronizasyonu etkinleştirin.</translation>
-<translation id="8641930654639604085">Yetişkinlere yönelik siteleri engellemeyi dene</translation>
-<translation id="8655129584991699539">Verileri Chrome Ayarlarından temizleyebilirsiniz</translation>
-<translation id="8662811608048051533">Çoğu sitedeki oturumunuz kapatılır.</translation>
-<translation id="8664979001105139458">Dosya adı zaten mevcut</translation>
-<translation id="8676374126336081632">Girişi temizle</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Sinyal Gücü Düzeyi: # çubuk}other{Sinyal Gücü Düzeyi: # çubuk}}</translation>
-<translation id="868929229000858085">Kişilerinizde arama yapın</translation>
-<translation id="869891660844655955">Son kullanma tarihi</translation>
-<translation id="8719023831149562936">Geçerli sekme ışınlanamıyor</translation>
-<translation id="8725066075913043281">Yeniden dene</translation>
-<translation id="8728487861892616501">Bu uygulamayı kullanarak Chrome’un <ph name="BEGIN_LINK1" />Hizmet Şartları<ph name="END_LINK1" /> ve <ph name="BEGIN_LINK2" />Gizlilik Bildirimi<ph name="END_LINK2" /> ile <ph name="BEGIN_LINK3" />Family Link ile Yönetilen Google Hesapları için Gizlilik Bildirimi<ph name="END_LINK3" />'ni kabul etmiş olursunuz.</translation>
-<translation id="8730621377337864115">Bitti</translation>
-<translation id="8748850008226585750">İçerik gizlendi</translation>
-<translation id="8751914237388039244">Resim seçin</translation>
-<translation id="8788265440806329501">Gezinme geçmişi kapalı</translation>
-<translation id="8788968922598763114">Son kapatılan sekmeyi yeniden açar</translation>
-<translation id="8801436777607969138">JavaScript'i belirli bir site için engelleyin.</translation>
-<translation id="8812260976093120287">Bazı web sitelerinde, yukarıdaki desteklenen ödeme uygulamalarıyla cihazınızdan ödeme yapabilirsiniz.</translation>
-<translation id="8816026460808729765">Sitelerin sensörlere erişimini engelle</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> Chrome'da açılacak. Devam ederek Chrome'un <ph name="BEGIN_LINK1" />Hizmet Şartları<ph name="END_LINK1" />'nı, <ph name="BEGIN_LINK2" />Gizlilik Uyarısı<ph name="END_LINK2" />'nı ve <ph name="BEGIN_LINK3" />Family Link ile Yönetilen Google Hesapları için Gizlilik Uyarısı<ph name="END_LINK3" />'nı kabul etmiş olursunuz.</translation>
-<translation id="8820817407110198400">Favoriler</translation>
-<translation id="8833831881926404480">Bir site, ekranınızı paylaşıyor</translation>
-<translation id="883806473910249246">İçerik indirilirken bir hata oluştu.</translation>
-<translation id="8840953339110955557">Bu sayfa, web'deki sürümden farklı olabilir.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />, sekme</translation>
-<translation id="885701979325669005">Depolama</translation>
-<translation id="889338405075704026">Chrome ayarlarına git</translation>
-<translation id="8901170036886848654">Yer işareti bulunamadı</translation>
-<translation id="8909135823018751308">Paylaş…</translation>
-<translation id="8912362522468806198">Google Hesabı</translation>
-<translation id="8920114477895755567">Ebeveyn ayrıntıları bekleniyor.</translation>
+<translation id="1188239144602654184">AR'ye gir</translation>
+<translation id="473775607612524610">Güncelle</translation>
+<translation id="3133489217401741157">Brave için <ph name="MODULE"/> yükleniyor…</translation>
+<translation id="1791662854739702043">Yüklendi</translation>
+<translation id="5131234170665854056">Brave için <ph name="MODULE"/> yüklenemiyor</translation>
+<translation id="2567385386134582609">IMAGE</translation>
+<translation id="6395288395575013217">BAĞLANTI</translation>
+<translation id="7352939065658542140">VİDEO</translation>
+<translation id="4116038641877404294">Sayfaları çevrimdışı olarak kullanmak için indirin</translation>
 <translation id="8922289737868596582">Çevrimdışı olarak kullanmak istediğiniz sayfaları Diğer seçenekler düğmesini kullanarak indirin</translation>
-<translation id="8937772741022875483">Chrome etkinliğiniz Dijital Denge'den kaldırılsın mı?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Yeni pencerede aç</translation>
-<translation id="8951232171465285730">Chrome <ph name="MEGABYTES" /> MB tasarruf sağladı</translation>
-<translation id="8958424370300090006">Belirli bir site için çerezleri engelleyin.</translation>
-<translation id="8959122750345127698">Gezinme işlevine ulaşılamıyor: <ph name="URL" /></translation>
-<translation id="8965591936373831584">beklemede</translation>
-<translation id="8970887620466824814">Bir hata oluştu.</translation>
-<translation id="8972098258593396643">Varsayılan klasöre indirilsin mi?</translation>
-<translation id="8986494364107987395">Kullanım istatistiklerini ve çökme raporlarını otomatik olarak Google'a gönder</translation>
-<translation id="8993760627012879038">Gizli modda yeni bir sekme açar</translation>
-<translation id="8998729206196772491"><ph name="MANAGED_DOMAIN" /> tarafından yönetilen bir hesapla oturum açıyorsunuz ve yöneticiye tüm Chrome verileriniz üzerinde denetim olanağı veriyorsunuz. Verileriniz kalıcı olarak bu hesaba bağlanacaktır. Chrome'da oturumu kapattığınızda verileriniz bu cihazdan silinir, ancak Google Hesabınızda kalmaya devam eder.</translation>
-<translation id="9019902583201351841">Ebeveynleriniz tarafından yönetiliyor</translation>
-<translation id="9028914725102941583">Cihazlar arasında senkronizasyonu açın</translation>
-<translation id="9029323097866369874"><ph name="DOMAIN" /> sitesinin VR moduna girmesine izin verilsin mi?</translation>
-<translation id="9040142327097499898">Bildirimlere izin veriliyor. Konum özelliği bu cihazda kapalı.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# Video}other{# Video}}</translation>
-<translation id="9050666287014529139">Parola</translation>
-<translation id="9063523880881406963">Masaüstü sitesi istemeyi devre dışı bırak</translation>
-<translation id="9065203028668620118">Düzenle</translation>
-<translation id="9070377983101773829">Sesli arama başlat</translation>
-<translation id="9074336505530349563">Google tarafından önerilen kişiselleştirilmiş içeriği almak için oturum açın ve senkronizasyonu etkinleştirin</translation>
-<translation id="9086455579313502267">Ağa erişilemiyor</translation>
-<translation id="9100505651305367705">Desteklendiğinde makaleleri basitleştirilmiş görünümde göstermeyi öner</translation>
-<translation id="9100610230175265781">Parola gerekli</translation>
-<translation id="9102803872260866941">Önizleme sekmesi açık</translation>
+<translation id="5958275228015807058">Dosyalarınızı ve sayfalarınızı İndirilenler bölümünde bulabilirsiniz</translation>
+<translation id="5620928963363755975">Diğer Seçenekler düğmesini kullanarak İndirilenler bölümünden dosyalarınızı ve sayfalarınızı bulabilirsiniz</translation>
+<translation id="3341058695485821946">Ne kadar veri tasarrufu sağladığınıza bakın</translation>
+<translation id="3157842584138209013">Diğer Seçenekler düğmesini kullanarak ne kadar veri tasarrufu sağladığınıza bakın</translation>
+<translation id="8218622182176210845">Hesabınızı yönetin</translation>
+<translation id="8090895580117672212">Brave Software hesabınızı yönetmek için "Hesabı yönet" düğmesine dokunun</translation>
+<translation id="8856898588039823173">Brave Software tarafından sağlanan basit sayfa. Sayfanın orijinalini yüklemek için dokunun.</translation>
+<translation id="8134317863207426198">Brave Software tarafından sağlanan basit sayfa. Sayfanın orijinalini yüklemek için orijinali yükle düğmesine dokunun.</translation>
+<translation id="4961107849584082341">Bu sayfayı istediğiniz dile çevirin</translation>
+<translation id="569536719314091526">Diğer seçenekler düğmesini kullanarak bu sayfayı istediğiniz dile çevirin</translation>
+<translation id="1397811292916898096"><ph name="PRODUCT_NAME"/> ile ara</translation>
+<translation id="1792959175193046959">Dosyaların indirileceği varsayılan konumu istediğiniz zaman değiştirebilirsiniz</translation>
+<translation id="6942665639005891494">Dosyaların indirileceği varsayılan konumu istediğiniz zaman Ayarlar menü seçeneğini kullanarak değiştirebilirsiniz</translation>
+<translation id="6850409657436465440">İndirme işleminiz hâlâ devam ediyor</translation>
+<translation id="5817715962196959877">Brave artık dosyaları daha hızlı indiriyor</translation>
+<translation id="3976396876660209797">Bu kısayolu kaldırıp yeniden oluşturun</translation>
+<translation id="6766622839693428701">Kapatmak için aşağı kaydırın.</translation>
+<translation id="1028699632127661925"><ph name="DEVICE_NAME"/> cihazına gönderiliyor...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - <ph name="DEVICE_NAME"/> cihazından gönderildi</translation>
+<translation id="5357811892247919462">Sekme alındı</translation>
 <translation id="9104217018994036254">Sekme paylaşılacak cihazların listesi.</translation>
-<translation id="9133397713400217035">Çevrimdışıyken Keşfet</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Orijinali göster</translation>
-<translation id="9139068048179869749">Sitelerin bildirim göndermesine izin vermeden önce size sorulsun (önerilir)</translation>
-<translation id="9139318394846604261">Alışveriş</translation>
-<translation id="9155898266292537608">Bir kelimeye hızlıca dokunarak da arama yapabilirsiniz</translation>
-<translation id="9169507124922466868">Gezinme geçmişi yarım açık</translation>
-<translation id="9204836675896933765">1 dosya kaldı</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Sekme paylaşılacak cihazların listesi yarım yükseklikte açıldı.</translation>
+<translation id="2904414404539560095">Sekme paylaşılacak cihazların listesi tam yükseklikte açıldı.</translation>
+<translation id="4135200667068010335">Sekme paylaşılacak cihazların listesi kapalı.</translation>
+<translation id="5292796745632149097">Alıcılar</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> gün önce etkindi</translation>
+<translation id="7971136598759319605">1 gün önce etkindi</translation>
+<translation id="1521774566618522728">Son etkin olduğu zaman:</translation>
+<translation id="3631987586758005671"><ph name="DEVICE_NAME"/> ile paylaşılıyor</translation>
+<translation id="9028914725102941583">Cihazlar arasında senkronizasyonu açın</translation>
+<translation id="6162454065885854378">Telefonunuzdan başka bir cihazla herhangi bir şey paylaşmak için her iki cihazdaki Brave ayarlarında senkronizasyonu açın</translation>
+<translation id="6084271560289605378">Brave ayarlarına git</translation>
+<translation id="2318045970523081853">Aramak için dokunun</translation>
 <translation id="9209888181064652401">Arama yapılamıyor</translation>
-<translation id="9219103736887031265">Resimler</translation>
-<translation id="926205370408745186">Chrome etkinliğinizi Dijital Denge'den kaldırma</translation>
-<translation id="932327136139879170">Ana Sayfa</translation>
-<translation id="938850635132480979">Hata: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Mikrofonunuza erişim</translation>
-<translation id="95817756606698420">Chrome, Çin'de arama yapmak için <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" />'yu kullanabilir. Bu seçimi <ph name="BEGIN_LINK" />Ayarlar<ph name="END_LINK" />'da değiştirebilirsiniz.</translation>
-<translation id="965817943346481315">Site, araya giren veya yanıltıcı reklamlar gösteriyorsa engelle (önerilen)</translation>
-<translation id="968900484120156207">Ziyaret ettiğiniz sayfalar burada görünür</translation>
-<translation id="970715775301869095"><ph name="MINUTES" /> dk. kaldı</translation>
-<translation id="974555521953189084">Senkronizasyonu başlatmak için parolanızı girin</translation>
-<translation id="981121421437150478">Çevrimdışı</translation>
-<translation id="982182592107339124">Bu işlem, aşağıdakiler de dahil olmak üzere tüm sitelere ilişkin verileri temizleyecek:</translation>
-<translation id="983192555821071799">Tüm sekmeleri kapat</translation>
-<translation id="987264212798334818">Genel</translation>
+<translation id="2860954141821109167">Bu cihazda bir telefon uygulamasının etkinleştirildiğinden emin olun</translation>
+<translation id="2067805253194386918">Kısa mesaj</translation>
+<translation id="1450753235335490080"><ph name="CONTENT_TYPE"/> paylaşılamıyor</translation>
+<translation id="1266864766717917324"><ph name="CONTENT_TYPE"/> paylaşılamadı</translation>
+<translation id="8287068819750208230"><ph name="TARGET_DEVICE_NAME"/> cihazının Brave'da senkronizasyonunun açık olduğundan emin olun</translation>
+<translation id="3016635187733453316">Bu cihazın internete bağlı olduğundan emin olun</translation>
+<translation id="8466613982764129868"><ph name="TARGET_DEVICE_NAME"/> cihazının internete bağlı olduğundan emin olun</translation>
+<translation id="6539092367496845964">Bir sorun oldu. Daha sonra tekrar deneyin.</translation>
+<translation id="3389286852084373014">Metin çok büyük</translation>
+<translation id="2100314319871056947">Metni daha küçük parçalar halinde paylaşmayı deneyin</translation>
+<translation id="2987620471460279764">Başka cihazdan paylaşılan metin</translation>
+<translation id="7757787379047923882">Metin, <ph name="DEVICE_NAME"/> cihazından paylaşıldı</translation>
+<translation id="5193988420012215838">Panonuza kopyalandı</translation>
+<translation id="4696983787092045100">Cihazlarınıza mesaj gönderin</translation>
+<translation id="1260236875608242557">Arama yapın ve keşfedin</translation>
+<translation id="6369229450655021117">Burada, web'de arama yapabilir, içerikleri arkadaşlarınızla paylaşabilir ve açık sayfaları görebilirsiniz</translation>
+<translation id="723171743924126238">Resim seç</translation>
+<translation id="8751914237388039244">Resim seçin</translation>
+<translation id="1989112275319619282">Göz at</translation>
+<translation id="7055152154916055070">Yönlendirme engellendi:</translation>
+<translation id="5524843473235508879">Yönlendirme engellendi.</translation>
+<translation id="6573096386450695060">Her zaman izin ver</translation>
+<translation id="5805364706385912897">Bu sayfa, bellekte çok fazla yer kapladığından Brave tarafından duraklatıldı.</translation>
+<translation id="5138664332909611586">Bu sayfa çok fazla bellek kullandığından Brave bazı içerikleri kaldırdı.</translation>
+<translation id="9137013805542155359">Orijinali göster</translation>
+<translation id="6361779936989026201">Brave'da Brave Software Asistan</translation>
+<translation id="7291387454912369099">Asistan'ın Başlattığı Ödeme</translation>
+<translation id="4565206163201411670">Brave etkinliğiniz Dijital Denge'de gösterilsin mi?</translation>
+<translation id="9055113864158719823">Brave'da ziyaret ettiğiniz siteleri görebilir ve bunlar için zamanlayıcı ayarlayabilirsiniz.\n\nBrave Software, hangi siteler için zamanlayıcı ayarladığınız ve bu siteleri ne kadar süre boyunca ziyaret ettiğiniz konusunda bilgi alır. Bu bilgi, Dijital Denge'yi daha iyi hale getirmek için kullanılır.</translation>
+<translation id="4596514158372210596">Brave etkinliğinizi Dijital Denge'den kaldırma</translation>
+<translation id="1174893863889683998">Brave etkinliğiniz Dijital Denge'den kaldırılsın mı?</translation>
+<translation id="708829030563435351">Brave'da ziyaret ettiğiniz siteler gösterilmez. Tüm site zamanlayıcıları silinir.</translation>
+<translation id="2056878612599315956">Site duraklatıldı</translation>
+<translation id="671481426037969117"><ph name="FQDN"/> zamanlayıcınızın süresi doldu. Yarın tekrar başlatılacak.</translation>
+<translation id="7479104141328977413">Sekme yönetimi</translation>
+<translation id="3524138585025253783">Geliştirici Kullanıcı Arayüzü</translation>
+<translation id="6036057147555329831">Ekstra ICU</translation>
+<translation id="9029323097866369874"><ph name="DOMAIN"/> sitesinin VR moduna girmesine izin verilsin mi?</translation>
+<translation id="7685301384041462804">VR moduna girmeden önce bu siteye güvendiğinizden emin olun.</translation>
+<translation id="5033865233969348410">Siz VR modundayken bu site şu konuda bilgi edinebilir:
+  -  Fiziksel özellikleriniz (ör. boyunuz)
+
+VR moduna girmeden önce bu siteye güvendiğinizden emin olun.</translation>
+<translation id="5534334044554683961">Siz VR modundayken bu site şu konularda bilgi edinebilir:
+  -   Fiziksel özellikleriniz (ör. boyunuz)
+  -   Odanızın düzeni
+
+VR moduna girmeden önce bu siteye güvendiğinizden emin olun.</translation>
+<translation id="4169535189173047238">İzin verme</translation>
+<translation id="2170088579611075216">İzin ver ve VR moduna gir</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_uk.xtb
+++ b/android/java/strings/translations/android_chrome_strings_uk.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="uk">
-<translation id="1006017844123154345">Відкрити в режимі онлайн</translation>
-<translation id="1028699632127661925">Надсилання на пристрій "<ph name="DEVICE_NAME" />"…</translation>
-<translation id="1036727731225946849">Додається <ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">З веб-сайтів</translation>
-<translation id="1049743911850919806">Анонімний перегляд</translation>
-<translation id="10614374240317010">Ніколи не зберігалося</translation>
-<translation id="1067922213147265141">Інші сервіси Google</translation>
-<translation id="1068672505746868501">Ніколи не перекладати сторінки такою мовою: <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Якщо ви зміните розширення файлу, він може відкритися в іншому додатку або зашкодити пристрою.</translation>
-<translation id="1100066534610197918">Відкрити нову вкладку в групі</translation>
-<translation id="1105960400813249514">Знімок екрана</translation>
-<translation id="1111673857033749125">Тут відображатимуться закладки, збережені на інших ваших пристроях.</translation>
-<translation id="1113597929977215864">Показати в режимі спрощеного перегляду</translation>
-<translation id="1121094540300013208">Використання та збої</translation>
-<translation id="1124772482545689468">Користувач</translation>
-<translation id="1129510026454351943">Деталі. <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Очікується 1 завантаження.}one{Очікується # завантаження.}few{Очікується # завантаження.}many{Очікується # завантажень.}other{Очікується # завантаження.}}</translation>
-<translation id="1145536944570833626">Видалити наявні дані.</translation>
-<translation id="1146678959555564648">Увійти у VR-режим</translation>
-<translation id="116280672541001035">Використано</translation>
-<translation id="1171770572613082465">Натисніть кнопку "Популярні сайти", щоб переглянути їх.</translation>
-<translation id="1173894706177603556">Перейменувати</translation>
-<translation id="1178581264944972037">Пауза</translation>
-<translation id="1181037720776840403">Видалити</translation>
-<translation id="1188239144602654184">Почати сеанс у режимі доповненої реальності</translation>
-<translation id="1197267115302279827">Перемістити закладки</translation>
-<translation id="119944043368869598">Очистити все</translation>
-<translation id="1201402288615127009">Далі</translation>
-<translation id="1204037785786432551">Завантажити дані за посиланням</translation>
-<translation id="1206892813135768548">Копіювати текст посилання</translation>
-<translation id="1208340532756947324">Щоб синхронізувати й персоналізувати дані на пристроях, увімкніть синхронізацію</translation>
-<translation id="1209206284964581585">Приховати</translation>
-<translation id="1227058898775614466">Історія навігації</translation>
-<translation id="1231733316453485619">Увімкнути синхронізацію?</translation>
-<translation id="123724288017357924">Оновити цю сторінку, ігноруючи кешований вміст</translation>
-<translation id="124116460088058876">Інші мови</translation>
-<translation id="124678866338384709">Закрити поточну вкладку</translation>
-<translation id="1258753120186372309">Дудл Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Пошук і огляд</translation>
-<translation id="1264974993859112054">Спорт</translation>
-<translation id="1266864766717917324">Не вдалося надіслати: <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Зупинити</translation>
-<translation id="1283039547216852943">Торкніться, щоб розгорнути</translation>
-<translation id="1285320974508926690">Ніколи не перекладати цей сайт</translation>
-<translation id="1291207594882862231">Очистити історію, файли cookie, дані сайтів, кеш…</translation>
-<translation id="129382876167171263">Файли, збережені веб-сайтами, відображаються тут</translation>
-<translation id="129553762522093515">Нещодавно закриті</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Надіслано з пристрою "<ph name="DEVICE_NAME" />"</translation>
-<translation id="1310482092992808703">Згрупувати вкладки</translation>
-<translation id="1327257854815634930">Історію навігації відкрито</translation>
-<translation id="1331212799747679585">Неможливо оновити Chrome. Більше опцій</translation>
-<translation id="1332501820983677155">Комбінації клавіш для функцій Google Chrome</translation>
-<translation id="1360432990279830238">Вийти й вимкнути синхронізацію?</translation>
-<translation id="1369915414381695676">Сайт <ph name="SITE_NAME" /> додано</translation>
-<translation id="1373696734384179344">Недостатньо пам’яті, щоб завантажити вибраний вміст.</translation>
-<translation id="1376578503827013741">Обчислення…</translation>
-<translation id="1383876407941801731">Пошук</translation>
-<translation id="1384959399684842514">Завантаження призупинено</translation>
-<translation id="1386674309198842382">У мережі <ph name="LAST_UPDATED" /> дн. тому</translation>
-<translation id="1397811292916898096">Шукати в <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Вбудовано на сайті <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">"Не відстежувати"</translation>
-<translation id="1407135791313364759">Відкрити все</translation>
-<translation id="1409426117486808224">Спрощений перегляд відкритих вкладок</translation>
-<translation id="1409879593029778104">Файл <ph name="FILE_NAME" /> не завантажено, оскільки він уже є.</translation>
-<translation id="1414981605391750300">З’єднання з Google. Це може зайняти хвилину…</translation>
-<translation id="1416550906796893042">Версія додатка</translation>
-<translation id="1430915738399379752">Друк</translation>
-<translation id="1446450296470737166">Повний контроль пристроїв MIDI</translation>
-<translation id="1450753235335490080">Не вдалося надіслати: <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Вимкнено в налаштуваннях Android</translation>
-<translation id="1477626028522505441">Файл <ph name="FILE_NAME" /> не завантажено через проблеми із сервером.</translation>
-<translation id="1506061864768559482">Пошукова система</translation>
-<translation id="1513352483775369820">Закладки й історія веб-пошуку</translation>
-<translation id="1513858653616922153">Видалити пароль</translation>
-<translation id="1516229014686355813">Функція "Торкніться, щоб шукати" надсилає слово та поточну сторінку як додаткові дані в Пошук Google. Її можна вимкнути в <ph name="BEGIN_LINK" />налаштуваннях<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">У мережі сьогодні</translation>
-<translation id="1544826120773021464">Щоб налаштувати обліковий запис Google, натисніть кнопку "Керувати обліковим записом"</translation>
-<translation id="1549000191223877751">Відкрити в іншому вікні</translation>
-<translation id="1553358976309200471">Оновити Chrome</translation>
-<translation id="1569387923882100876">Під’єднаний пристрій</translation>
-<translation id="1571304935088121812">Копіювати ім’я користувача</translation>
-<translation id="1612196535745283361">Щоб шукати пристрої, Chrome потрібен доступ до геоданих. Доступ до геоданих <ph name="BEGIN_LINK" />вимкнено на цьому пристрої<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Камера</translation>
-<translation id="1623104350909869708">Заборонити цій сторінці створювати додаткові діалогові вікна</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Вилучити 1 вибраний елемент}one{Вилучити # вибраний елемент}few{Вилучити # вибрані елементи}many{Вилучити # вибраних елементів}other{Вилучити # вибраного елемента}}</translation>
-<translation id="164269334534774161">Ви переглядаєте офлайн-копію цієї сторінки, створену <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Історія</translation>
-<translation id="1647391597548383849">Доступ до камери</translation>
-<translation id="1660204651932907780">Дозволити сайтам відтворювати звук (рекомендується)</translation>
-<translation id="1670399744444387456">Основні параметри</translation>
-<translation id="1671236975893690980">Очікується завантаження…</translation>
-<translation id="1672586136351118594">Більше не показувати</translation>
-<translation id="1692118695553449118">Синхронізацію ввімкнено</translation>
-<translation id="169515064810179024">Заборонити сайтам доступ до датчиків руху</translation>
-<translation id="1717218214683051432">Датчики руху</translation>
-<translation id="1718835860248848330">Остання година</translation>
-<translation id="1736419249208073774">Огляд</translation>
-<translation id="1743802530341753419">Запитувати, перш ніж дозволяти сайтам підключатися до пристрою (рекомендовано)</translation>
-<translation id="1749561566933687563">Синхронізуйте свої закладки</translation>
-<translation id="17513872634828108">Відкриті вкладки</translation>
-<translation id="1779089405699405702">Декодер зображень</translation>
-<translation id="1782483593938241562">Дата завершення: <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Установлено</translation>
-<translation id="1792959175193046959">Будь-коли змінюйте папку для завантажень за умовчанням</translation>
-<translation id="1807246157184219062">Світла</translation>
-<translation id="1810845389119482123">Початкове налаштування синхронізації не завершено</translation>
-<translation id="1821253160463689938">Використовує файли cookie, щоб зберігати налаштування, навіть якщо ви не відвідуєте ці сторінки</translation>
-<translation id="1829244130665387512">Знайти на сторінці</translation>
-<translation id="1853692000353488670">Нова анонімна вкладка</translation>
-<translation id="1856325424225101786">Скинути спрощений режим?</translation>
-<translation id="1868024384445905608">Тепер Chrome завантажує файли швидше</translation>
-<translation id="1883903952484604915">Мої файли</translation>
-<translation id="1887786770086287077">На цьому пристрої вимкнено доступ до геоданих. Увімкніть його в <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886">Додаток <ph name="APP_NAME" /> відкриватиметься в Chrome. Продовжуючи, ви приймаєте <ph name="BEGIN_LINK1" />Умови використання<ph name="END_LINK1" /> та <ph name="BEGIN_LINK2" />Примітку про конфіденційність<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="1919345977826869612">Оголошення</translation>
-<translation id="1919950603503897840">Виберіть контакти</translation>
-<translation id="1922076542920281912">Щоб надати Chrome доступ до геоданих, також увімкніть їх у <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Оновлення</translation>
-<translation id="19288952978244135">Знову відкрийте Chrome.</translation>
-<translation id="1933845786846280168">Вибрана вкладка</translation>
-<translation id="194341124344773587">Увімкніть дозвіл для Chrome у <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Зберігання паролів</translation>
-<translation id="1952172573699511566">Якщо можливо, текст на веб-сайтах відображатиметься вибраною мовою.</translation>
-<translation id="1960290143419248813">Chrome більше не оновлюється в цій версії Android</translation>
-<translation id="1966710179511230534">Оновіть свої дані для входу.</translation>
-<translation id="1974060860693918893">Розширені</translation>
-<translation id="1984705450038014246">Синхронізуйте дані Chrome</translation>
-<translation id="1984937141057606926">Заборонено лише сторонні файли cookie</translation>
-<translation id="1986685561493779662">Ця назва вже існує</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" />, кнопка <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Переглянути</translation>
-<translation id="1993768208584545658">Сайт <ph name="SITE" /> хоче підключитися до пристрою</translation>
-<translation id="1994173015038366702">URL-адреса сайту</translation>
-<translation id="2000419248597011803">Надсилає деякі файли cookie й пошукові запити з адресного рядка та вікна пошуку в пошукову систему за умовчанням</translation>
-<translation id="2002537628803770967">Кредитні картки й адреси, додані в Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# файл}one{# файл}few{# файли}many{# файлів}other{# файлу}}</translation>
-<translation id="2017836877785168846">Очищує історію й автозавершення в адресному рядку.</translation>
-<translation id="2021896219286479412">Керування повноекранним режимом</translation>
-<translation id="2038563949887743358">Увімкнути опцію "Запитувати версію сайту для комп’ютера"</translation>
-<translation id="2041019821020695769">Щоб надати Chrome доступ до сповіщень, також увімкніть їх у <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529">Дані додатка <ph name="APP_NAME" /> також містяться в Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Роботу сайту призупинено</translation>
-<translation id="2063713494490388661">Торкніться, щоб шукати</translation>
-<translation id="2067805253194386918">SMS</translation>
-<translation id="2079545284768500474">Відмінити</translation>
-<translation id="2082238445998314030">Результат <ph name="RESULT_NUMBER" /> з <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Сигнал</translation>
-<translation id="2096012225669085171">Синхронізація та персоналізація на всіх пристроях</translation>
-<translation id="2100273922101894616">Автоматичний вхід</translation>
-<translation id="2100314319871056947">Спробуйте надіслати текст меншими частинами</translation>
-<translation id="2107397443965016585">Запитувати, перш ніж дозволяти сайтам відтворювати захищений вміст (рекомендовано)</translation>
-<translation id="2111511281910874386">Перейти на сторінку</translation>
-<translation id="2122601567107267586">Не вдалося відкрити додаток</translation>
-<translation id="2126426811489709554">Технології Chrome</translation>
-<translation id="2131665479022868825">Заощаджено <ph name="DATA" /></translation>
-<translation id="213279576345780926">Вкладку "<ph name="TAB_TITLE" />" закрито</translation>
-<translation id="2139186145475833000">Додати на головний екран</translation>
-<translation id="2146738493024040262">Відкрити додаток із миттєвим запуском</translation>
-<translation id="2148716181193084225">Сьогодні</translation>
-<translation id="2154484045852737596">Редагувати картку</translation>
-<translation id="2154710561487035718">Копіювати URL-адресу</translation>
-<translation id="2156074688469523661">Інші сайти (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Щоб файли з вашого телефона були доступними на іншому вашому пристрої, увімкніть синхронізацію в налаштуваннях Chrome на обох пристроях</translation>
-<translation id="2170088579611075216">Перейти у VR</translation>
-<translation id="218608176142494674">Спільний доступ</translation>
-<translation id="2227444325776770048">Продовжити як <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Синхронізація та сервіси Google</translation>
-<translation id="2259659629660284697">Експортувати паролі…</translation>
-<translation id="2268044343513325586">Уточнити</translation>
-<translation id="2286841657746966508">Розрахункова адреса</translation>
-<translation id="2289270750774289114">Запитувати, коли сайт хоче шукати пристрої Bluetooth поблизу (рекомендовано)</translation>
-<translation id="230115972905494466">Сумісних пристроїв не знайдено</translation>
-<translation id="2315043854645842844">Операційна система не підтримує сертифікат, вибраний на стороні клієнта.</translation>
-<translation id="2318045970523081853">Натисніть, щоб зателефонувати</translation>
-<translation id="2321086116217818302">Готуються паролі…</translation>
-<translation id="2321958826496381788">Перетягуйте повзунок, доки розмір тексту не стане зручним для читання. Якщо двічі торкнутись абзацу, розмір тексту має стати принаймні таким, як цей.</translation>
-<translation id="2323763861024343754">Дані сайтів</translation>
-<translation id="2328985652426384049">Не вдається ввійти</translation>
-<translation id="2330129964253841015">Попереджати, якщо паролі зламано</translation>
-<translation id="2349710944427398404">Усі дані, які використовує Chrome, зокрема облікові записи, закладки та збережені налаштування</translation>
-<translation id="2353636109065292463">Перевірка інтернет-з’єднання</translation>
-<translation id="2359808026110333948">Продовжити</translation>
-<translation id="2369533728426058518">відкриті вкладки</translation>
-<translation id="2387895666653383613">Масштаб тексту</translation>
-<translation id="2394602618534698961">Завантажені файли з’являться тут</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> МБ</translation>
-<translation id="2407481962792080328">Ця функція вмикається, коли ви входите в обліковий запис Google</translation>
-<translation id="2410754283952462441">Виберіть обліковий запис</translation>
-<translation id="2414886740292270097">Темна</translation>
-<translation id="2416359993254398973">Chrome потрібні дозволи, щоб використовувати камеру на цьому сайті.</translation>
-<translation id="2426805022920575512">Вибрати інший обліковий запис</translation>
-<translation id="2433507940547922241">Зовнішній вигляд</translation>
-<translation id="2434158240863470628">Завантажено <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Доступ до геоданих</translation>
-<translation id="2450083983707403292">Завантажити файл <ph name="FILE_NAME" /> ще раз?</translation>
-<translation id="2482878487686419369">Сповіщення</translation>
-<translation id="2490684707762498678">Адміністратор сімейної групи: <ph name="APP_NAME" /></translation>
-<translation id="2494974097748878569">Google Асистент у Chrome</translation>
-<translation id="2496180316473517155">Історія переглядів</translation>
-<translation id="2497852260688568942">Ваш адміністратор вимкнув синхронізацію</translation>
-<translation id="2498359688066513246">Довідка й відгуки</translation>
-<translation id="2501278716633472235">Назад</translation>
-<translation id="2513403576141822879">Інші налаштування конфіденційності, безпеки та збору даних доступні в розділі <ph name="BEGIN_LINK" />Синхронізація та сервіси Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">У спрощеному режимі Chrome завантажує сторінки швидше та використовує на 60% менше трафіку. Щоб оптимізувати сторінки, які ви відвідуєте, Chrome надсилає ваш веб-трафік у Google. <ph name="BEGIN_LINK" />Докладніше<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Надсилає в Google URL-адреси відвіданих сторінок</translation>
-<translation id="2532336938189706096">Веб-версія</translation>
-<translation id="2534155362429831547">Видалено елементів: <ph name="NUMBER_OF_ITEMS" /></translation>
-<translation id="2536728043171574184">Перегляд копії сторінки в режимі офлайн</translation>
-<translation id="2546283357679194313">Файли cookie та дані із сайтів</translation>
-<translation id="2567385386134582609">ЗОБРАЖЕННЯ</translation>
-<translation id="257088987046510401">Теми</translation>
-<translation id="2570922361219980984">На цьому пристрої також вимкнено доступ до геоданих. Увімкніть його в <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Розгорнуто – натисніть, щоб згорнути.</translation>
-<translation id="2581165646603367611">Буде видалено файли cookie, кеш та інші дані сайтів, які Chrome визначив як неважливі.</translation>
-<translation id="2586657967955657006">Буфер обміну</translation>
-<translation id="2587052924345400782">Доступна новіша версія</translation>
-<translation id="2593272815202181319">Однакової ширини</translation>
-<translation id="2612676031748830579">Номер картки</translation>
-<translation id="2621115761605608342">Увімкнути Javascript на певному сайті.</translation>
-<translation id="2625189173221582860">Пароль скопійовано</translation>
-<translation id="2631006050119455616">Збережено</translation>
-<translation id="2647434099613338025">Додати мову</translation>
-<translation id="2650751991977523696">Завантажити файл ще раз?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудіофайл}one{# аудіофайл}few{# аудіофайли}many{# аудіофайлів}other{# аудіофайлу}}</translation>
-<translation id="2653659639078652383">Надіслати</translation>
-<translation id="2677748264148917807">Вийти</translation>
-<translation id="2704606927547763573">Скопійов.</translation>
-<translation id="2707726405694321444">Оновити сторінку</translation>
-<translation id="2709516037105925701">Автозаповнення</translation>
-<translation id="2717722538473713889">Електронні адреси</translation>
-<translation id="2728754400939377704">Сортувати за сайтом</translation>
-<translation id="2744248271121720757">Торкніться слова для миттєвого пошуку або перегляду схожих дій</translation>
-<translation id="2760989362628427051">Активувати нічний режим, якщо його налаштовано або ввімкнено режим енергозбереження</translation>
-<translation id="2762000892062317888">щойно</translation>
-<translation id="2777555524387840389">Залишилося <ph name="SECONDS" /> с</translation>
-<translation id="2779651927720337254">не завантажено</translation>
-<translation id="2781151931089541271">Залишилась 1 с</translation>
-<translation id="2801022321632964776">Виконайте оновлення, щоб користуватися своєю мовою в останній версії Chrome</translation>
-<translation id="2810645512293415242">Спрощена сторінка для заощадження трафіку та швидшого завантаження.</translation>
-<translation id="281504910091592009">Переглядайте збережені паролі й керуйте ними в <ph name="BEGIN_LINK" />обліковому записі Google<ph name="END_LINK" /></translation>
-<translation id="2818669890320396765">Щоб мати доступ до закладок на всіх своїх пристроях, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
-<translation id="2822354292072154809">Скинути всі дозволи сайту <ph name="CHOSEN_OBJECT_NAME" />?</translation>
-<translation id="2836148919159985482">Щоб вийти з повноекранного режиму, торкніться кнопки "Назад".</translation>
-<translation id="2842985007712546952">Батьківська папка</translation>
-<translation id="2858138569776157458">Популярні сайти</translation>
-<translation id="2860954141821109167">Переконайтеся, що на цьому пристрої ввімкнено додаток Телефон</translation>
-<translation id="2870560284913253234">Сайт</translation>
-<translation id="2874939134665556319">Попередня композиція</translation>
-<translation id="2876369937070532032">Надсилає в Google URL-адреси деяких відвіданих сторінок, коли ваша безпека під загрозою</translation>
-<translation id="2888126860611144412">Про Chrome</translation>
-<translation id="2891154217021530873">Припинити завантаження сторінки</translation>
-<translation id="2893180576842394309">Google може використовувати вашу історію, щоб персоналізувати Пошук та інші сервіси Google</translation>
-<translation id="2898264748040935573">Змінити збережений пароль</translation>
-<translation id="2900528713135656174">Створити подію</translation>
-<translation id="290376772003165898">Ця сторінка відображається не такою мовою: <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Список пристроїв, на які можна надіслати вкладку, відкрито на всю висоту екрана.</translation>
-<translation id="2910701580606108292">Запитувати, перш ніж дозволяти сайтам відтворювати захищений вміст</translation>
-<translation id="2913331724188855103">Дозволити сайтам зберігати та розпізнавати дані файлів cookie (рекомендується)</translation>
-<translation id="2923908459366352541">Недійсна назва</translation>
-<translation id="2932150158123903946">Дані додатка Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Вкладку "Попередній перегляд" закрито</translation>
-<translation id="2956410042958133412">Цим обліковим записом керують <ph name="PARENT_NAME_1" /> і <ph name="PARENT_NAME_2" />.</translation>
-<translation id="2962095958535813455">Ви перейшли на анонімні вкладки</translation>
-<translation id="2968755619301702150">Перегляд сертифікатів</translation>
-<translation id="2979025552038692506">Вибрана анонімна вкладка</translation>
-<translation id="2987620471460279764">Текст, яким поділилися з іншого пристрою</translation>
-<translation id="2989523299700148168">Нещодавно відвідані</translation>
-<translation id="2996291259634659425">Створити парольну фразу</translation>
-<translation id="2996809686854298943">Потрібна URL-адреса</translation>
-<translation id="300526633675317032">Буде видалено всі дані сайтів (<ph name="SIZE_IN_KB" />).</translation>
-<translation id="3016635187733453316">Перевірте, чи пристрій підключено до Інтернету</translation>
-<translation id="3029613699374795922">Завантажено <ph name="KBS" /> КБ</translation>
-<translation id="3029704984691124060">Парольні фрази не збігаються</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Довідка<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Геодані вимкнено. Увімкніть їх у <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Ви можете будь-коли ввімкнути синхронізацію в налаштуваннях</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> закладка}one{<ph name="BOOKMARKS_COUNT_MANY" /> закладка}few{<ph name="BOOKMARKS_COUNT_MANY" /> закладки}many{<ph name="BOOKMARKS_COUNT_MANY" /> закладок}other{<ph name="BOOKMARKS_COUNT_MANY" /> закладки}}</translation>
-<translation id="3089395242580810162">Відкрити в анонімній вкладці</translation>
-<translation id="3115898365077584848">Показати інформацію</translation>
-<translation id="3123473560110926937">Заблоковано на деяких сайтах</translation>
-<translation id="3137521801621304719">Вийти з режиму анонімного перегляду</translation>
-<translation id="3143515551205905069">Скасувати синхронізацію</translation>
-<translation id="3157842584138209013">Перевірте обсяг збережених даних за допомогою кнопки "Більше опцій"</translation>
-<translation id="3166827708714933426">Комбінації клавіш для роботи з вкладками та вікнами</translation>
-<translation id="3181954750937456830">Безпечний перегляд (захищає вас і ваш пристрій від небезпечних сайтів)</translation>
-<translation id="3190152372525844641">Увімкніть дозволи для Chrome у <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">У пам'яті зайнято <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Майже готово.</translation>
-<translation id="3207960819495026254">Створено закладку</translation>
-<translation id="3211426585530211793">Елемент "<ph name="ITEM_TITLE" />" видалено</translation>
-<translation id="321773570071367578">Якщо ви забули парольну фразу або хочете змінити це налаштування, <ph name="BEGIN_LINK" />скиньте синхронізацію<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Мікрофон</translation>
-<translation id="3232754137068452469">Веб-додаток</translation>
-<translation id="3236059992281584593">Залишилась 1 хв</translation>
-<translation id="3244271242291266297">ММ</translation>
-<translation id="3254409185687681395">Додати цю сторінку до закладок</translation>
-<translation id="3259831549858767975">Зменшити всі елементи на сторінці</translation>
-<translation id="3269093882174072735">Завантажити зображення</translation>
-<translation id="3269956123044984603">Щоб мати доступ до вкладок з інших пристроїв, увімкніть опцію "Автоматично синхронізувати дані" в налаштуваннях облікового запису на Android.</translation>
-<translation id="3277252321222022663">Надати сайтам доступ до датчиків (рекомендовано)</translation>
-<translation id="3282568296779691940">Вхід у Chrome</translation>
-<translation id="3288003805934695103">перезавантажити сторінку</translation>
-<translation id="32895400574683172">Сповіщення дозволено</translation>
-<translation id="3295530008794733555">Шукайте швидше. Заощаджуйте трафік.</translation>
-<translation id="3295602654194328831">Сховати інформацію</translation>
-<translation id="3298243779924642547">Спрощена</translation>
-<translation id="3303414029551471755">Завантажити вміст?</translation>
-<translation id="3306398118552023113">Цей додаток запущено в Chrome</translation>
-<translation id="3315103659806849044">Зараз ви налаштовуєте синхронізацію та сервіси Google. Щоб увімкнути синхронізацію, натисніть кнопку "Підтвердити" внизу екрана. Перейти вгору</translation>
-<translation id="3328801116991980348">Інформація про сайт</translation>
-<translation id="3333961966071413176">Усі контакти</translation>
-<translation id="3334729583274622784">Змінити розширення файлу?</translation>
-<translation id="3341058695485821946">Перевірте обсяг збережених даних</translation>
-<translation id="3350687908700087792">Закрити всі анонімні вікна</translation>
-<translation id="3353615205017136254">Спрощену сторінку надає Google. Торкніться кнопки завантаження оригіналу, щоб отримати вихідну сторінку.</translation>
-<translation id="3367813778245106622">Увійдіть знову, щоб почати синхронізацію</translation>
-<translation id="3374023511497244703">Закладки, історія, паролі й інші дані Chrome більше не синхронізуватимуться з обліковим записом Google</translation>
-<translation id="3384347053049321195">Поділитися зображенням</translation>
-<translation id="3386292677130313581">Запитувати, перш ніж дозволити сайтам визначати ваше місцезнаходження (рекомендується)</translation>
-<translation id="3387650086002190359">Файл <ph name="FILE_NAME" /> не завантажено через помилки файлової системи.</translation>
-<translation id="3389286852084373014">SMS-повідомлення завелике</translation>
-<translation id="3398320232533725830">Відкрити Диспетчер закладок</translation>
-<translation id="3414952576877147120">Розмір:</translation>
-<translation id="3443221991560634068">Оновити поточну сторінку</translation>
-<translation id="3445014427084483498">Щойно</translation>
-<translation id="3478363558367712427">Ви можете вибрати пошукову систему</translation>
+<translation id="6910211073230771657">Видалено</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">OK</translation>
+<translation id="7658239707568436148">Скасувати</translation>
 <translation id="3479552764303398839">Не зараз</translation>
-<translation id="3492207499832628349">Нова анонімна вкладка</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Докладніше<ph name="END_LINK" /> про рекомендований контент</translation>
-<translation id="3513704683820682405">Доповнена реальність</translation>
-<translation id="3518985090088779359">Продовжити</translation>
-<translation id="3522247891732774234">Доступне оновлення. Більше опцій</translation>
-<translation id="3524138585025253783">Інтерфейс розробника</translation>
-<translation id="3527085408025491307">Папка</translation>
-<translation id="3542235761944717775">Доступно <ph name="KILOBYTES" /> КБ</translation>
-<translation id="3549657413697417275">Пошук в історії</translation>
-<translation id="3557336313807607643">Додати до контактів</translation>
-<translation id="3566923219790363270">Chrome готується до запуску VR. Перезапустіть Chrome пізніше.</translation>
-<translation id="3568688522516854065">Щоб мати доступ до вкладок з інших пристроїв, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
-<translation id="3587482841069643663">Все</translation>
-<translation id="358794129225322306">Дозволити сайту автоматично завантажувати декілька файлів.</translation>
-<translation id="3590487821116122040">Дані сайтів, які Chrome визначив як неважливі, зокрема сайтів із незбереженими налаштуваннями або тих, які ви рідко відвідуєте</translation>
-<translation id="3599863153486145794">Видалення історії на всіх пристроях, на яких ви ввійшли в обліковий запис. Історія веб-перегляду може також зберігатися у вашому обліковому записі Google на сторінці  <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Вимкнути звук на сайтах, які відтворюють його</translation>
-<translation id="3616113530831147358">Аудіо</translation>
-<translation id="3631987586758005671">Надсилання на пристрій <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Показати пароль</translation>
-<translation id="363596933471559332">Автоматично входити в облікові записи на веб-сайтах за допомогою збережених даних. Якщо цю функцію вимкнено, потрібно вводити облікові дані під час кожного входу.</translation>
-<translation id="3658159451045945436">Буде скинуто історію заощадження трафіку, зокрема список відвіданих веб-сайтів.</translation>
-<translation id="3692944402865947621">Не вдалося завантажити файл <ph name="FILE_NAME" />. Місце зберігання недоступне.</translation>
-<translation id="3714981814255182093">Відкрити рядок пошуку</translation>
-<translation id="3716182511346448902">Ця сторінка займає велику кількість пам’яті, тому Chrome призупинив її роботу.</translation>
-<translation id="3730075448226062617">Щоб надати Chrome доступ до мікрофона, також увімкніть його в <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Створено закладку в продукті <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Фонова синхронізація</translation>
-<translation id="3771001275138982843">Не вдалося завантажити оновлення</translation>
-<translation id="3771033907050503522">Анонімні вкладки</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Увімкніть Bluetooth<ph name="END_LINK" />, щоб підключити</translation>
-<translation id="3775705724665058594">Надіслати на пристрої</translation>
-<translation id="3778956594442850293">Додано на головний екран</translation>
-<translation id="3789841737615482174">Встановити</translation>
-<translation id="3810838688059735925">Відео</translation>
-<translation id="3810973564298564668">Змінити</translation>
-<translation id="381841723434055211">Номери телефонів</translation>
-<translation id="3819178904835489326">Видалено завантажених файлів: <ph name="NUMBER_OF_DOWNLOADS" /></translation>
-<translation id="3822502789641063741">Видалити дані сайтів?</translation>
-<translation id="385051799172605136">Назад</translation>
-<translation id="3859306556332390985">Далі</translation>
-<translation id="3894427358181296146">Додати папку</translation>
-<translation id="3895926599014793903">Примусово ввімкнути масштабування</translation>
-<translation id="3912508018559818924">Шукаємо найкраще в Інтернеті…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Об’єднати мої дані</translation>
-<translation id="393697183122708255">Голосовий пошук вимкнено</translation>
-<translation id="395206256282351086">Пропозиції термінів і сайтів вимкнено</translation>
-<translation id="3955193568934677022">Дозволити сайтам відтворювати захищений вміст (рекомендується)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Коли все буде готово, Chrome завантажить сторінку}one{Коли все буде готово, Chrome завантажить сторінки}few{Коли все буде готово, Chrome завантажить сторінки}many{Коли все буде готово, Chrome завантажить сторінки}other{Коли все буде готово, Chrome завантажить сторінки}}</translation>
-<translation id="3963007978381181125">Парольна фраза не стосується способів оплати й адрес із Google Pay. Ваші зашифровані дані можуть переглядати лише користувачі, які знають вашу парольну фразу. Вона не надсилається й не зберігається в Google. Якщо ви забули її або хочете змінити це налаштування, скиньте параметри синхронізації. <ph name="BEGIN_LINK" />Докладніше<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Завантажено</translation>
-<translation id="397583555483684758">Синхронізація перестала працювати</translation>
-<translation id="3976396876660209797">Вилучити й знову створити цей ярлик</translation>
-<translation id="3985215325736559418">Завантажити файл "<ph name="FILE_NAME" />" повторно?</translation>
-<translation id="3987993985790029246">Копіювати</translation>
-<translation id="3988213473815854515">Доступ до геоданих надано</translation>
-<translation id="3988466920954086464">Переглядайте миттєві результати пошуку на цій панелі</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Неважливі дані</translation>
-<translation id="4000212216660919741">Дім у режимі офлайн</translation>
+<translation id="5317780077021120954">Зберегти</translation>
+<translation id="4570913071927164677">Деталі</translation>
+<translation id="8730621377337864115">Готово</translation>
+<translation id="8261506727792406068">Видалити</translation>
+<translation id="1181037720776840403">Видалити</translation>
+<translation id="5939518447894949180">Скинути</translation>
 <translation id="4002066346123236978">Назва</translation>
-<translation id="4008040567710660924">Дозволити файли cookie для конкретного сайту.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# год}one{# год}few{# год}many{# год}other{# год}}</translation>
-<translation id="4046123991198612571">Наступна композиція</translation>
-<translation id="4048707525896921369">Дізнавайтеся більше про певну тему, не залишаючи сторінку, яку переглядаєте. Просто торкніться певного слова, щоб надіслати його в Пошук Google разом із контекстом, і отримаєте визначення, зображення, результати пошуку й іншу інформацію.
+<translation id="5916664084637901428">Увімкнути</translation>
+<translation id="5860033963881614850">Вимк.</translation>
+<translation id="6165508094623778733">Докладніше</translation>
+<translation id="6042308850641462728">Більше</translation>
+<translation id="6040143037577758943">Закрити</translation>
+<translation id="780301667611848630">Ні, дякую</translation>
+<translation id="1201402288615127009">Далі</translation>
+<translation id="2359808026110333948">Продовжити</translation>
+<translation id="2653659639078652383">Надіслати</translation>
+<translation id="2079545284768500474">Відмінити</translation>
+<translation id="7649070708921625228">Довідка</translation>
+<translation id="2148716181193084225">Сьогодні</translation>
+<translation id="7781829728241885113">Учора</translation>
+<translation id="6945221475159498467">Вибрати</translation>
+<translation id="7791543448312431591">Додати</translation>
+<translation id="6527303717912515753">Надіслати</translation>
+<translation id="1383876407941801731">Пошук</translation>
+<translation id="3115898365077584848">Показати інформацію</translation>
+<translation id="3295602654194328831">Сховати інформацію</translation>
+<translation id="3987993985790029246">Копіювати</translation>
+<translation id="2704606927547763573">Скопійов.</translation>
+<translation id="8725066075913043281">Повторити спробу</translation>
+<translation id="385051799172605136">Назад</translation>
+<translation id="8131740175452115882">Підтвердити</translation>
+<translation id="5300589172476337783">Показати</translation>
+<translation id="1124772482545689468">Користувач</translation>
+<translation id="8609465669617005112">Угору</translation>
+<translation id="6746124502594467657">Вниз</translation>
+<translation id="8249310407154411074">На початок</translation>
+<translation id="8428213095426709021">Налаштування</translation>
+<translation id="2498359688066513246">Довідка й відгуки</translation>
+<translation id="8378714024927312812">Профілем керує ваша організація</translation>
+<translation id="9019902583201351841">Керується батьками</translation>
+<translation id="4645575059429386691">Керується одним із батьків</translation>
+<translation id="4883854917563148705">Налаштування, якими керує адміністратор, не можна скинути</translation>
+<translation id="4307992518367153382">Основні</translation>
+<translation id="1974060860693918893">Розширені</translation>
+<translation id="1146678959555564648">Увійти у VR-режим</translation>
+<translation id="987264212798334818">Загальне</translation>
+<translation id="4275663329226226506">Медіа-дані</translation>
+<translation id="4759238208242260848">Завантаження</translation>
+<translation id="218608176142494674">Спільний доступ</translation>
+<translation id="8004582292198964060">Переглядач</translation>
+<translation id="1105960400813249514">Знімок екрана</translation>
+<translation id="4875775213178255010">Пропозиції вмісту</translation>
+<translation id="2021896219286479412">Керування повноекранним режимом</translation>
+<translation id="4587589328781138893">Сайти</translation>
+<translation id="4943703118917034429">Віртуальна реальність</translation>
+<translation id="1928696683969751773">Оновлення</translation>
+<translation id="6064125863973209585">Завершені завантаження</translation>
+<translation id="5342314432463739672">Запити на дозволи</translation>
+<translation id="629730747756840877">Обліковий запис</translation>
+<translation id="82609232232243542">Вхід у Brave</translation>
+<translation id="7956662517480676674">Синхронізація та сервіси Brave Software</translation>
+<translation id="5294439808117722387">Зараз ви налаштовуєте синхронізацію та сервіси Brave Software. Щоб увімкнути синхронізацію, натисніть кнопку "Підтвердити" внизу екрана. Перейти вгору</translation>
+<translation id="2096012225669085171">Синхронізація та персоналізація на всіх пристроях</translation>
+<translation id="1692118695553449118">Синхронізацію ввімкнено</translation>
+<translation id="5514904542973294328">Вимкнено адміністратором пристрою</translation>
+<translation id="6447211988989208781">Керування активністю в Brave Software</translation>
+<translation id="4882831918239250449">Указуйте, як використовувати історію веб-перегляду для персоналізації Пошуку, оголошень тощо</translation>
+<translation id="7431991332293347422">Указуйте, як використовувати історію веб-перегляду для персоналізації Пошуку тощо</translation>
+<translation id="6303969859164067831">Вийти й вимкнути синхронізацію</translation>
+<translation id="1125261911132334651">Керуйте обліковим записом Brave Software</translation>
+<translation id="6406506848690869874">Синхронізація</translation>
+<translation id="714362445477979774">Синхронізуйте дані Brave</translation>
+<translation id="4314815835985389558">Керування синхронізацією</translation>
+<translation id="5428209950370661546">Інші сервіси Brave Software</translation>
+<translation id="7704317875155739195">Автоматично завершувати пошукові запити та URL-адреси</translation>
+<translation id="2000419248597011803">Надсилає деякі файли cookie й пошукові запити з адресного рядка та вікна пошуку в пошукову систему за умовчанням</translation>
+<translation id="7981313251711023384">Попередньо завантажувати сторінки, щоб швидше переглядати та шукати</translation>
+<translation id="1821253160463689938">Використовує файли cookie, щоб зберігати налаштування, навіть якщо ви не відвідуєте ці сторінки</translation>
+<translation id="6697492270171225480">Показувати пропозиції схожих сторінок, коли не вдається знайти сторінку</translation>
+<translation id="8109318360573330108">Надсилає в Brave Software URL-адресу сторінки, яку ви намагаєтеся відкрити</translation>
+<translation id="8438566539970814960">Покращувати пошук і веб-перегляд</translation>
+<translation id="284843628681142937">Надсилає в Brave Software URL-адреси відвіданих сторінок</translation>
+<translation id="7222718784508482526">Інші налаштування конфіденційності, безпеки та збору даних доступні в розділі <ph name="BEGIN_LINK"/>Синхронізація та сервіси Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Допоможіть покращити функції й ефективність Brave</translation>
+<translation id="9063160602596686558">Автоматично надсилає статистику використання та звіти про аварійне завершення роботи в Brave Software</translation>
+<translation id="4824958205181053313">Скасувати синхронізацію?</translation>
+<translation id="3058498974290601450">Ви можете будь-коли ввімкнути синхронізацію в налаштуваннях</translation>
+<translation id="3143515551205905069">Скасувати синхронізацію</translation>
+<translation id="1506061864768559482">Пошукова система</translation>
+<translation id="55737423895878184">Геодані та сповіщення дозволено</translation>
+<translation id="3988213473815854515">Доступ до геоданих надано</translation>
+<translation id="32895400574683172">Сповіщення дозволено</translation>
+<translation id="9040142327097499898">На цьому пристрої вимкнено геодані. Сповіщення дозволено.</translation>
+<translation id="305593374596241526">Геодані вимкнено. Увімкніть їх у <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Нещодавно відвідані</translation>
+<translation id="6433501201775827830">Виберіть пошукову систему</translation>
+<translation id="7177466738963138057">Це можна змінити пізніше в налаштуваннях</translation>
+<translation id="3478363558367712427">Ви можете вибрати пошукову систему</translation>
+<translation id="4910889077668685004">Додатки для платежів</translation>
+<translation id="5152843274749979095">Немає підтримуваних додатків</translation>
+<translation id="8812260976093120287">На деяких веб-сайтах ви можна оплачувати за допомогою перелічених вище підтримуваних додатків для платежів на вашому пристрої.</translation>
+<translation id="7764225426217299476">Додати адресу</translation>
+<translation id="5595485650161345191">Редагувати адресу</translation>
+<translation id="5087580092889165836">Додати картку</translation>
+<translation id="2154484045852737596">Редагувати картку</translation>
+<translation id="6140912465461743537">Країна або регіон</translation>
+<translation id="5659593005791499971">Електронна пошта</translation>
+<translation id="4378154925671717803">Телефон</translation>
+<translation id="4807098396393229769">Ім'я на картці</translation>
+<translation id="860043288473659153">Ім’я та прізвище власника картки</translation>
+<translation id="2612676031748830579">Номер картки</translation>
+<translation id="869891660844655955">Діє до</translation>
+<translation id="2286841657746966508">Розрахункова адреса</translation>
+<translation id="663059986967017181">Скопійовано в Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}one{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}few{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}many{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/>}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}one{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}few{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}many{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/>}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}one{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}few{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}many{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/>}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}one{<ph name="CONTACT_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}few{<ph name="CONTACT_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}many{<ph name="CONTACT_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}other{<ph name="CONTACT_PREVIEW"/>\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/>}}</translation>
+<translation id="7029809446516969842">Паролі</translation>
+<translation id="1943432128510653496">Зберігання паролів</translation>
+<translation id="2100273922101894616">Автоматичний вхід</translation>
+<translation id="363596933471559332">Автоматично входити в облікові записи на веб-сайтах за допомогою збережених даних. Якщо цю функцію вимкнено, потрібно вводити облікові дані під час кожного входу.</translation>
+<translation id="6995899638241819463">Попереджати, якщо паролі розкрито через порушення безпеки даних</translation>
+<translation id="1534287762301776620">Ця функція вмикається, коли ви входите в обліковий запис Brave Software</translation>
+<translation id="10614374240317010">Ніколи не зберігалося</translation>
+<translation id="3098842761938485917">Переглядайте збережені паролі й керуйте ними в <ph name="BEGIN_LINK"/>обліковому записі Brave Software<ph name="END_LINK"/></translation>
+<translation id="8562452229998620586">Тут відображатимуться збережені паролі.</translation>
+<translation id="8084114998886531721">Збережений пароль</translation>
+<translation id="2870560284913253234">Сайт</translation>
+<translation id="8503813439785031346">Ім’я користувача</translation>
+<translation id="6657585470893396449">Пароль</translation>
+<translation id="2154710561487035718">Копіювати URL-адресу</translation>
+<translation id="1571304935088121812">Копіювати ім’я користувача</translation>
+<translation id="5005498671520578047">Копіювати пароль</translation>
+<translation id="3632295766818638029">Показати пароль</translation>
+<translation id="1513858653616922153">Видалити пароль</translation>
+<translation id="543338862236136125">Змінити пароль</translation>
+<translation id="4565377596337484307">Сховати пароль</translation>
+<translation id="8523928698583292556">Видалити збережений пароль</translation>
+<translation id="2898264748040935573">Змінити збережений пароль</translation>
+<translation id="5433691172869980887">Ім’я користувача скопійовано</translation>
+<translation id="5534640966246046842">URL-адресу сайту скопійовано</translation>
+<translation id="2625189173221582860">Пароль скопійовано</translation>
+<translation id="4550003330909367850">Щоб переглядати та копіювати пароль тут, налаштуйте на цьому пристрої блокування екрана.</translation>
+<translation id="6154478581116148741">Щоб експортувати паролі з цього пристрою, увімкніть блокування екрана</translation>
+<translation id="4842092870884894799">Показ спливаючих вікон для створення пароля</translation>
+<translation id="2259659629660284697">Експортувати паролі…</translation>
+<translation id="133012818630824069">Експортувати паролі, збережені в Brave</translation>
+<translation id="6914783257214138813">Ваші паролі бачитимуть усі, хто може переглядати експортований файл.</translation>
+<translation id="2321086116217818302">Готуються паролі…</translation>
+<translation id="8445448999790540984">Не вдається експортувати паролі</translation>
+<translation id="3066461326500799725">Як користуватися Brave Software Диском</translation>
+<translation id="729975465115245577">На пристрої немає додатка для зберігання файлу з паролями.</translation>
+<translation id="7682724950699840886">Порада. Переконайтеся, що на пристрої достатньо вільного місця та спробуйте експортувати дані знову.</translation>
+<translation id="1129510026454351943">Деталі. <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Розблокуйте, щоб скопіювати пароль</translation>
+<translation id="5515439363601853141">Розблокуйте, щоб переглянути пароль</translation>
+<translation id="6221633008163990886">Розблокуйте, щоб експортувати паролі</translation>
+<translation id="230699814587342492">Паролі Brave</translation>
+<translation id="6075798973483050474">Змінити домашню сторінку</translation>
+<translation id="854522910157234410">Відкрити цю сторінку</translation>
+<translation id="2482878487686419369">Сповіщення</translation>
+<translation id="6255999984061454636">Пропозиції вмісту</translation>
+<translation id="805047784848435650">На основі історії веб-перегляду</translation>
+<translation id="1041308826830691739">З веб-сайтів</translation>
+<translation id="395206256282351086">Пропозиції термінів і сайтів вимкнено</translation>
+<translation id="257088987046510401">Теми</translation>
+<translation id="4650364565596261010">За умовчанням у системі</translation>
+<translation id="7588219262685291874">Показувати темну тему, коли на пристрої ввімкнено режим енергозбереження</translation>
+<translation id="2760989362628427051">Активувати нічний режим, якщо його налаштовано або ввімкнено режим енергозбереження</translation>
+<translation id="6381421346744604172">Затемнити веб-сайти</translation>
+<translation id="5040262127954254034">Конфіденційність</translation>
+<translation id="4991384657077828949">Допоможіть покращити безпеку Brave</translation>
+<translation id="1943176487615318915">Щоб виявляти небезпечні додатки й сайти, Brave надсилає URL-адреси певних відвіданих сторінок, обмежену системну інформацію та вміст деяких сторінок у Brave Software</translation>
+<translation id="3181954750937456830">Безпечний перегляд (захищає вас і ваш пристрій від небезпечних сайтів)</translation>
+<translation id="7315322926489145388">Надсилає в Brave Software URL-адреси деяких відвіданих сторінок, коли ваша безпека під загрозою</translation>
+<translation id="2063713494490388661">Торкніться, щоб шукати</translation>
+<translation id="2369463299479365221">Дізнавайтеся більше про певну тему, не залишаючи сторінку, яку переглядаєте. Просто торкніться певного слова, щоб надіслати його в Пошук Brave Software разом із контекстом, і отримаєте визначення, зображення, результати пошуку й іншу інформацію.
 
 Щоб змінити пошуковий термін, натисніть і втримуйте його. Щоб уточнити пошуковий запит, прокрутіть панель угору й торкніться вікна пошуку.</translation>
-<translation id="4056223980640387499">Сепія</translation>
-<translation id="4060598801229743805">Панель інструментів розташовано вгорі екрана</translation>
-<translation id="4062305924942672200">Правова інформація</translation>
-<translation id="4084682180776658562">Закладка</translation>
-<translation id="4084712963632273211">Видавець: <ph name="PUBLISHER_ORIGIN" />, <ph name="BEGIN_DEEMPHASIZED" />доставлено Google<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Видалити дані додатка?</translation>
-<translation id="4099578267706723511">Допоможіть покращити Chrome, надсилаючи статистику та звіти про збої в Google.</translation>
-<translation id="410351446219883937">Автовідтворення</translation>
-<translation id="4116038641877404294">Завантажуйте сторінки, щоб переглядати їх офлайн</translation>
-<translation id="4135200667068010335">Список пристроїв, на які можна надіслати вкладку, закрито.</translation>
-<translation id="4149994727733219643">Спрощений перегляд веб-сторінок</translation>
-<translation id="4165986682804962316">Налаштування сайту</translation>
-<translation id="4169535189173047238">Не дозволяти</translation>
-<translation id="4170011742729630528">Служба не доступна. Повторіть спробу пізніше.</translation>
-<translation id="4179980317383591987">Використано <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Мови</translation>
-<translation id="4183868528246477015">Пошук з Об'єктивом <ph name="BEGIN_NEW" />Новинка<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Відкрити в новій вкладці</translation>
-<translation id="4198423547019359126">Немає доступних місць для завантаження</translation>
-<translation id="4209895695669353772">Щоб отримувати персоналізовані пропозиції від Google, увімкніть синхронізацію</translation>
-<translation id="4226663524361240545">Коли надходитимуть сповіщення, пристрій може вібрувати</translation>
-<translation id="423219824432660969">Зашифрувати синхронізовані дані за допомогою пароля Google від <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Відкрити налаштування</translation>
-<translation id="4256782883801055595">Ліцензії ПЗ з відкритим кодом</translation>
-<translation id="4259722352634471385">Веб-сторінку <ph name="URL" /> заблоковано</translation>
-<translation id="4269820728363426813">Копіювати адресу посилання</translation>
-<translation id="4275663329226226506">Медіа-дані</translation>
-<translation id="4278390842282768270">Дозволено</translation>
-<translation id="429312253194641664">Сайт відтворює медіа-вміст</translation>
-<translation id="4298388696830689168">Зв’язані сайти</translation>
-<translation id="4307992518367153382">Основні</translation>
-<translation id="4314815835985389558">Керування синхронізацією</translation>
-<translation id="4351244548802238354">Закрити діалогове вікно</translation>
-<translation id="4378154925671717803">Телефон</translation>
-<translation id="4384468725000734951">Пошук за допомогою Sogou</translation>
-<translation id="4404568932422911380">Немає закладок</translation>
-<translation id="4405224443901389797">Перемістити в папку…</translation>
-<translation id="4411535500181276704">Спрощений режим</translation>
-<translation id="4415276339145661267">Керуйте обліковим записом Google</translation>
-<translation id="4432792777822557199">Надалі сторінки цією мовою (<ph name="SOURCE_LANGUAGE" />) перекладатимуться такою мовою: <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Спрощену сторінку надає Google</translation>
-<translation id="4434045419905280838">Спливаючі вікна й переадресація</translation>
-<translation id="4440958355523780886">Спрощену сторінку надає Google. Натисніть, щоб завантажити оригінал.</translation>
-<translation id="4452411734226507615">Закрити вкладку <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Закладку збережено в папці "<ph name="FOLDER_NAME" />"</translation>
-<translation id="445467742685312942">Дозволити сайтам відтворювати захищений вміст</translation>
-<translation id="4468959413250150279">Вимкнути звук для певного сайту.</translation>
-<translation id="4472118726404937099">Щоб синхронізувати й персоналізувати дані на пристроях, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
-<translation id="447252321002412580">Допоможіть покращити функції й ефективність Chrome</translation>
-<translation id="4479647676395637221">Запитувати, перш ніж дозволити сайтам використовувати камеру (рекомендується)</translation>
-<translation id="4479972344484327217">Встановлення модуля <ph name="MODULE" /> для Chrome…</translation>
-<translation id="4487967297491345095">Усі дані Chrome буде видалено назавжди. Це стосується всіх файлів, налаштувань, облікових записів, баз даних тощо.</translation>
-<translation id="4493497663118223949">Спрощений режим увімкнено</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# день тому}one{# день тому}few{# дні тому}many{# днів тому}other{# дня тому}}</translation>
-<translation id="451872707440238414">Шукати закладки</translation>
-<translation id="4521489764227272523">Вибрані дані видалено з Chrome і синхронізованих пристроїв.
-
-У вашому обліковому записі Google на сторінці <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> можуть бути додаткові форми історії веб-перегляду, як-от пошукові запити чи активність в інших сервісах Google.</translation>
-<translation id="4532845899244822526">Вибрати папку</translation>
-<translation id="4538018662093857852">Увімкнути спрощений режим</translation>
-<translation id="4550003330909367850">Щоб переглядати та копіювати пароль тут, налаштуйте на цьому пристрої блокування екрана.</translation>
-<translation id="4558311620361989323">Комбінації клавіш для роботи з веб-сторінками</translation>
-<translation id="4561979708150884304">Немає з’єднання</translation>
-<translation id="4565377596337484307">Сховати пароль</translation>
-<translation id="4570913071927164677">Деталі</translation>
-<translation id="4572422548854449519">Увійдіть у керований обліковий запис</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# хвилину тому}one{# хвилину тому}few{# хвилини тому}many{# хвилин тому}other{# хвилини тому}}</translation>
-<translation id="4587589328781138893">Сайти</translation>
-<translation id="4594952190837476234">Цю сторінку створено <ph name="CREATION_TIME" />. Вона може відрізнятися від онлайн-версії.</translation>
-<translation id="4605958867780575332">Елемент "<ph name="ITEM_TITLE" />" вилучено</translation>
-<translation id="4616150815774728855">Відкрити файл <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Прийняти пароль</translation>
-<translation id="4645575059429386691">Керується одним із батьків</translation>
-<translation id="4650364565596261010">За умовчанням у системі</translation>
-<translation id="4663756553811254707">Видалено закладок: <ph name="NUMBER_OF_BOOKMARKS" /></translation>
-<translation id="4665282149850138822">Веб-сайт <ph name="NAME" /> додано на головний екран</translation>
-<translation id="4684427112815847243">Синхронізувати все</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}one{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}few{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}many{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" />}}</translation>
-<translation id="4696983787092045100">Надіслати SMS на пристрої</translation>
-<translation id="4698034686595694889">Переглядайте вміст у <ph name="APP_NAME" /> без інтернет-з’єднання</translation>
-<translation id="4699172675775169585">Кешовані зображення та файли</translation>
-<translation id="4714588616299687897">Заощаджуйте до 60% трафіку</translation>
-<translation id="4719927025381752090">Пропонувати переклад</translation>
-<translation id="4720023427747327413">Відкрити в <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Допоможіть покращити Chrome. <ph name="BEGIN_LINK" />Візьміть участь в опитуванні<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Оновити</translation>
-<translation id="4738836084190194332">Остання синхронізація: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Відкрити нову вкладку</translation>
-<translation id="4751476147751820511">Датчики руху та світла</translation>
-<translation id="4759238208242260848">Завантаження</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 файл завантажено.}one{# файл завантажено.}few{# файли завантажено.}many{# файлів завантажено.}other{# файлу завантажено.}}</translation>
-<translation id="4797039098279997504">Торкніться, щоб повернутися на сторінку <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Парольна фраза не стосується способів оплати й адрес із Google Pay.
-
-Щоб змінити це налаштування, <ph name="BEGIN_LINK" />скиньте параметри синхронізації<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Ім'я на картці</translation>
-<translation id="4824958205181053313">Скасувати синхронізацію?</translation>
-<translation id="4837753911714442426">Відкрити налаштування друку сторінки</translation>
-<translation id="4842092870884894799">Показ спливаючих вікон для створення пароля</translation>
-<translation id="4860895144060829044">Зателефонувати</translation>
-<translation id="4866368707455379617">Не вдалося встановити модуль <ph name="MODULE" /> для Chrome</translation>
-<translation id="4875775213178255010">Пропозиції вмісту</translation>
-<translation id="4878404682131129617">Не вдалося налагодити зв’язок через проксі-сервер</translation>
-<translation id="4880127995492972015">Перекласти…</translation>
-<translation id="4881695831933465202">Відкрити</translation>
-<translation id="488187801263602086">Перейменувати файл</translation>
-<translation id="4882831918239250449">Указуйте, як використовувати історію веб-перегляду для персоналізації Пошуку, оголошень тощо</translation>
-<translation id="4883854917563148705">Налаштування, якими керує адміністратор, не можна скинути</translation>
-<translation id="4885273946141277891">Забагато копій Chrome.</translation>
-<translation id="4910889077668685004">Додатки для платежів</translation>
-<translation id="4913161338056004800">Скинути дані статистики</translation>
-<translation id="4913169188695071480">Припинити оновлення</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Довідка<ph name="END_LINK" /> під час пошуку пристроїв…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# сторінка}one{# сторінка}few{# сторінки}many{# сторінок}other{# сторінки}}</translation>
-<translation id="4932247056774066048">Оскільки ви виходите з облікового запису, зареєстрованого в домені <ph name="DOMAIN_NAME" />, ваші дані Chrome буде видалено з цього пристрою. Вони залишаться у вашому обліковому записі Google.</translation>
-<translation id="4943703118917034429">Віртуальна реальність</translation>
-<translation id="4943872375798546930">Не знайдено жодного результату</translation>
-<translation id="4958708863221495346">Сторінка <ph name="URL_OF_THE_CURRENT_TAB" /> показує ваш екран</translation>
-<translation id="4961107849584082341">Перекладіть цю сторінку будь-якою мовою</translation>
-<translation id="4962975101802056554">Скасувати всі дозволи для пристрою</translation>
-<translation id="4970824347203572753">Функція недоступна у вашій країні</translation>
-<translation id="497421865427891073">Перейти вперед</translation>
-<translation id="4988210275050210843">Завантажується файл (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Сторінки</translation>
-<translation id="4994033804516042629">Немає контактів</translation>
-<translation id="4996978546172906250">Надіслати</translation>
-<translation id="5004416275253351869">Керування активністю в Google</translation>
-<translation id="5005498671520578047">Копіювати пароль</translation>
-<translation id="5011311129201317034">Сайт <ph name="SITE" /> хоче підключитися</translation>
-<translation id="5013696553129441713">Немає нових пропозицій</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Під час сеансу VR цей сайт може розпізнавати:
-  - ваші фізичні особливості, як-от зріст.
-
-Перш ніж перейти у VR, переконайтеся, що довіряєте цьому сайту.</translation>
+<translation id="2930742481329940825">Функція "Торкніться, щоб шукати" надсилає слово та поточну сторінку як додаткові дані в Пошук Brave Software. Її можна вимкнути в <ph name="BEGIN_LINK"/>налаштуваннях<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Дозволити</translation>
-<translation id="5040262127954254034">Конфіденційність</translation>
-<translation id="5048398596102334565">Надати сайтам доступ до датчиків руху (рекомендовано)</translation>
-<translation id="5063480226653192405">Використання</translation>
-<translation id="5087580092889165836">Додати картку</translation>
-<translation id="5100237604440890931">Згорнуто – натисніть, щоб розгорнути.</translation>
-<translation id="510275257476243843">Залишилась 1 година</translation>
-<translation id="5123685120097942451">Анонімна вкладка</translation>
-<translation id="5127805178023152808">Синхронізацію вимкнено</translation>
-<translation id="5129038482087801250">Установити веб-додаток</translation>
-<translation id="5132942445612118989">Синхронізуйте свої паролі, історію тощо на всіх пристроях</translation>
-<translation id="5139940364318403933">Як користуватися Google Диском</translation>
-<translation id="515227803646670480">Очистити збережені дані</translation>
-<translation id="5152843274749979095">Немає підтримуваних додатків</translation>
-<translation id="5161254044473106830">Введіть назву</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Не вдалося завантажити 1 файл.}one{Не вдалося завантажити # файл.}few{Не вдалося завантажити # файли.}many{Не вдалося завантажити # файлів.}other{Не вдалося завантажити # файлу.}}</translation>
-<translation id="5170568018924773124">Показати в папці</translation>
-<translation id="5184329579814168207">Відкрити в Chrome</translation>
-<translation id="5193988420012215838">Скопійовано в буфер обміну</translation>
-<translation id="5197729504361054390">Веб-сайт <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" /> отримає доступ до вибраних контактів.</translation>
-<translation id="5199929503336119739">Робочий профіль</translation>
-<translation id="5210286577605176222">Перейти до попередньої вкладки</translation>
-<translation id="5210365745912300556">Закрити вкладку</translation>
-<translation id="5224771365102442243">З відео</translation>
-<translation id="5230560987958996918">Сайт <ph name="SITE" /> хоче шукати пристрої Bluetooth поруч. Виявлено такі пристрої:</translation>
-<translation id="5233638681132016545">Нова вкладка</translation>
-<translation id="526421993248218238">Не вдається завантажити цю сторінку</translation>
-<translation id="5271967389191913893">Вміст, який ви хочете завантажити, не можна відкрити на цьому пристрої.</translation>
-<translation id="528192093759286357">Щоб вийти з повноекранного режиму, проведіть пальцем по екрану згори вниз і торкніться кнопки "Назад".</translation>
-<translation id="5292796745632149097">Кому надіслати:</translation>
-<translation id="5300589172476337783">Показати</translation>
-<translation id="5301954838959518834">OK</translation>
-<translation id="5304593522240415983">Це поле не може бути порожнім</translation>
-<translation id="5307446750509046227">Видалити дані сайтів</translation>
-<translation id="5308380583665731573">Під’єднатися</translation>
-<translation id="5313967007315987356">Додати сайт</translation>
-<translation id="5317780077021120954">Зберегти</translation>
-<translation id="5324858694974489420">Батьківські налаштування</translation>
-<translation id="5327248766486351172">Назва</translation>
-<translation id="5335288049665977812">Дозволити сайтам запускати Javascript (рекомендується)</translation>
-<translation id="5342314432463739672">Запити на дозволи</translation>
-<translation id="5357811892247919462">Вкладку отримано</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> відкрита вкладка: натисніть, щоб перейти на іншу вкладку}one{<ph name="OPEN_TABS_MANY" /> відкрита вкладка: натисніть, щоб перейти на іншу вкладку}few{<ph name="OPEN_TABS_MANY" /> відкриті вкладки: натисніть, щоб перейти на іншу вкладку}many{<ph name="OPEN_TABS_MANY" /> відкритих вкладок: натисніть, щоб перейти на іншу вкладку}other{<ph name="OPEN_TABS_MANY" /> відкритої вкладки: натисніть, щоб перейти на іншу вкладку}}</translation>
-<translation id="5391532827096253100">Ваше з’єднання з цим сайтом незахищене. Інформація про сайт</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ ще 1)}one{(+ ще #)}few{(+ ще #)}many{(+ ще #)}other{(+ ще #)}}</translation>
-<translation id="5400569084694353794">Користуючись цим додатком, ви приймаєте <ph name="BEGIN_LINK1" />Умови використання<ph name="END_LINK1" /> та <ph name="BEGIN_LINK2" />Примітку про конфіденційність<ph name="END_LINK2" /> Chrome.</translation>
-<translation id="5403592356182871684">Імена</translation>
-<translation id="5403644198645076998">Дозволити лише певні сайти</translation>
-<translation id="5414836363063783498">Підтвердження…</translation>
-<translation id="5423934151118863508">Тут відображатимуться найчастіше відвідувані сторінки</translation>
-<translation id="5424588387303617268">Доступно <ph name="GIGABYTES" /> ГБ</translation>
-<translation id="543338862236136125">Змінити пароль</translation>
-<translation id="5433691172869980887">Ім’я користувача скопійовано</translation>
-<translation id="543509235395288790">Завантажується файлів: <ph name="COUNT" /> (<ph name="MEGABYTES" />).</translation>
-<translation id="5441522332038954058">Перейти до адресного рядка</translation>
-<translation id="5447201525962359567">Усі дані сайтів, зокрема файли cookie й інші локально збережені дані</translation>
-<translation id="5447765697759493033">Цей сайт не буде перекладено</translation>
-<translation id="545042621069398927">Прискорюється завантаження.</translation>
-<translation id="5456381639095306749">Завантажити сторінку</translation>
-<translation id="5475862044948910901">Почати сеанс у режимі доповненої реальності?</translation>
-<translation id="548278423535722844">Відкрити в додатку Карти</translation>
-<translation id="5487521232677179737">Видалити дані</translation>
-<translation id="5494752089476963479">Блокувати рекламу на сайтах, які показують нав’язливі чи оманливі оголошення</translation>
-<translation id="5500777121964041360">Функція може бути недоступна у вашій країні</translation>
-<translation id="5512137114520586844">Цим обліковим записом керує <ph name="PARENT_NAME" />.</translation>
-<translation id="5514904542973294328">Вимкнено адміністратором пристрою</translation>
-<translation id="5515439363601853141">Розблокуйте, щоб переглянути пароль</translation>
-<translation id="5516455585884385570">Відкрити налаштування сповіщень</translation>
-<translation id="5517095782334947753">У вас є закладки, історія, паролі й інші налаштування з облікового запису <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Переспрямування заблоковано.</translation>
-<translation id="5527082711130173040">Щоб шукати пристрої, Chrome потрібен доступ до геоданих. <ph name="BEGIN_LINK1" />Оновити дозволи<ph name="END_LINK1" />. Доступ до геоданих також <ph name="BEGIN_LINK2" />вимкнено на цьому пристрої<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Запитувати, перш ніж дозволяти сайтам переглядати тексти й зображення в буфері обміну (рекомендовано)</translation>
-<translation id="5530766185686772672">Закрити анонімні вкладки</translation>
-<translation id="5534334044554683961">Під час сеансу VR цей сайт може розпізнавати:
-  - ваші фізичні особливості, як-от зріст;
-  - вигляд вашої кімнати.
-
-Перш ніж перейти у VR, переконайтеся, що довіряєте цьому сайту.</translation>
-<translation id="5534640966246046842">URL-адресу сайту скопійовано</translation>
-<translation id="5556459405103347317">Перезавантажити</translation>
-<translation id="5561549206367097665">Очікується мережа…</translation>
-<translation id="557283862590186398">Chrome потрібні дозволи, щоб використовувати мікрофон на цьому сайті.</translation>
-<translation id="55737423895878184">Геодані та сповіщення дозволено</translation>
-<translation id="5578795271662203820">Шукати зображення в <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Ви можете будь-коли вибрати дані для синхронізації в <ph name="BEGIN_LINK1" />налаштуваннях<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Редагувати адресу</translation>
-<translation id="5596627076506792578">Інші опції</translation>
-<translation id="5599455543593328020">Режим анонімного перегляду</translation>
-<translation id="5620928963363755975">Знаходьте свої файли та сторінки в розділі "Завантаження", натиснувши кнопку "Більше опцій"</translation>
-<translation id="5626134646977739690">Ім'я:</translation>
-<translation id="5639724618331995626">Дозволити всі сайти</translation>
-<translation id="5648166631817621825">Останні 7 днів</translation>
-<translation id="5649053991847567735">Автоматичні завантаження</translation>
-<translation id="5655963694829536461">Пошук у завантаженнях</translation>
-<translation id="5659593005791499971">Електронна пошта</translation>
-<translation id="5665379678064389456">Створити подію в додатку <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Відхиляти запит веб-сайту, щоб забороняти масштабування</translation>
-<translation id="5677928146339483299">Заблоковано</translation>
-<translation id="5684874026226664614">На жаль, цю сторінку неможливо перекласти.</translation>
-<translation id="5686790454216892815">Назва файлу задовга</translation>
-<translation id="5689516760719285838">Місцезнаходження</translation>
-<translation id="569536719314091526">Перекладіть цю сторінку будь-якою мовою, натиснувши кнопку "Більше опцій"</translation>
-<translation id="572328651809341494">Останні вкладки</translation>
-<translation id="5726692708398506830">Збільшити всі елементи на сторінці</translation>
-<translation id="5748802427693696783">Ви перейшли на стандартні вкладки</translation>
-<translation id="5749068826913805084">Щоб завантажувати файли, Chrome потребує доступу до пам’яті.</translation>
-<translation id="5763382633136178763">Анонімні вкладки</translation>
-<translation id="5763514718066511291">Торкніться, щоб скопіювати URL-адресу цього додатка</translation>
-<translation id="5765780083710877561">Опис:</translation>
-<translation id="5793665092639000975">Використано <ph name="SPACE_USED" /> з <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google може використовувати вашу історію, щоб персоналізувати Пошук, оголошення й інші сервіси Google</translation>
-<translation id="5804241973901381774">Дозволи</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# годину тому}one{# годину тому}few{# години тому}many{# годин тому}other{# години тому}}</translation>
-<translation id="5810288467834065221">Авторське право <ph name="YEAR" /> Google LLC. Усі права захищено.</translation>
-<translation id="5817918615728894473">Підключити</translation>
-<translation id="583281660410589416">Невідомий</translation>
-<translation id="5833984609253377421">Поділитися посиланням</translation>
-<translation id="5836192821815272682">Завантажується оновлення Chrome…</translation>
-<translation id="5853623416121554550">призупинено</translation>
-<translation id="5854790677617711513">Понад 30 днів тому</translation>
-<translation id="5858741533101922242">Chrome не може ввімкнути адаптер Bluetooth</translation>
-<translation id="5860033963881614850">Вимк.</translation>
-<translation id="5862731021271217234">Щоб мати доступ до вкладок з інших пристроїв, увімкніть синхронізацію</translation>
-<translation id="5864174910718532887">Деталі: відсортовано за назвою сайту</translation>
-<translation id="5864419784173784555">Очікується інше завантаження…</translation>
-<translation id="5865733239029070421">Автоматично надсилає статистику використання та звіти про аварійне завершення роботи в Google</translation>
-<translation id="5869522115854928033">Збережені паролі</translation>
-<translation id="5902828464777634901">Буде видалено всі локальні дані, які зберіг цей веб-сайт, зокрема файли cookie.</translation>
-<translation id="5916664084637901428">Увімкнути</translation>
-<translation id="5919204609460789179">Оновіть <ph name="PRODUCT_NAME" />, щоб почати синхронізацію</translation>
-<translation id="5937580074298050696">Заощаджено <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Скинути</translation>
-<translation id="5942872142862698679">Пошук за допомогою Google</translation>
-<translation id="5952764234151283551">Надсилає в Google URL-адресу сторінки, яку ви намагаєтеся відкрити</translation>
-<translation id="5956665950594638604">Відкрити Довідковий центр Chrome у новій вкладці</translation>
-<translation id="5958275228015807058">Знаходьте свої файли та сторінки в розділі "Завантаження"</translation>
-<translation id="5962718611393537961">Торкніться, щоб згорнути</translation>
-<translation id="6000066717592683814">Залишити Google</translation>
-<translation id="6005538289190791541">Запропонований пароль</translation>
-<translation id="6036057147555329831">Зайвий модуль ICU</translation>
-<translation id="6039379616847168523">Перейти до наступної вкладки</translation>
-<translation id="6040143037577758943">Закрити</translation>
-<translation id="6042308850641462728">Більше</translation>
-<translation id="604996488070107836">Не вдалося завантажити файл <ph name="FILE_NAME" />. Сталася невідома помилка.</translation>
-<translation id="605721222689873409">РР</translation>
-<translation id="6064125863973209585">Завершені завантаження</translation>
-<translation id="6075798973483050474">Змінити домашню сторінку</translation>
-<translation id="60923314841986378">Залишилося <ph name="HOURS" /> год</translation>
-<translation id="6108923351542677676">Виконується налаштування…</translation>
-<translation id="6111020039983847643">використаний трафік</translation>
-<translation id="6112702117600201073">Оновлення сторінки</translation>
-<translation id="6127379762771434464">Веб-сайт видалено</translation>
-<translation id="6140912465461743537">Країна або регіон</translation>
-<translation id="614940544461990577">Спробуйте:</translation>
-<translation id="6154478581116148741">Щоб експортувати паролі з цього пристрою, увімкніть блокування екрана</translation>
-<translation id="6159335304067198720">Заощадження даних: <ph name="PERCENT" /></translation>
-<translation id="6165508094623778733">Докладніше</translation>
-<translation id="6177111841848151710">Заблоковано для поточної пошукової системи</translation>
-<translation id="6181444274883918285">Додати сайт у список винятків</translation>
-<translation id="6192333916571137726">Завантажити файл</translation>
-<translation id="6192792657125177640">Винятки</translation>
-<translation id="6194112207524046168">Щоб надати Chrome доступ до камери, також увімкніть її в <ph name="BEGIN_LINK" />налаштуваннях Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Блокувати сторонні файли cookie</translation>
-<translation id="6206551242102657620">З’єднання безпечне. Інформація про сайт</translation>
-<translation id="6210748933810148297">Не <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Розблокуйте, щоб експортувати паролі</translation>
+<translation id="1406000523432664303">"Не відстежувати"</translation>
 <translation id="6232535412751077445">Якщо ввімкнути параметр "Не відстежувати", запит додаватиметься в трафік веб-перегляду. Результат залежатиме від того, чи реагує веб-сайт на цей запит і як тлумачиться запит.
 
 Наприклад, деякі веб-сайти можуть реагувати на такий запит, показуючи вам рекламу, не пов’язану з іншими веб-сайтами, які ви відвідали. Багато веб-сайтів і надалі збиратимуть та використовуватимуть ваші дані веб-перегляду, наприклад, щоб покращувати систему безпеки, пропонувати вміст, рекламу й рекомендації, а також генерувати статистику для звітів.</translation>
-<translation id="624789221780392884">Оновлення завершено</translation>
-<translation id="6255999984061454636">Пропозиції вмісту</translation>
-<translation id="6277522088822131679">Виникла проблема з друком цієї сторінки. Повторіть спробу.</translation>
-<translation id="6295158916970320988">Усі сайти</translation>
-<translation id="629730747756840877">Обліковий запис</translation>
-<translation id="6303969859164067831">Вийти й вимкнути синхронізацію</translation>
-<translation id="6316139424528454185">Версія Android несумісна</translation>
-<translation id="6320088164292336938">Вібросигнал</translation>
-<translation id="6324034347079777476">Синхронізацію системи Android вимкнено</translation>
-<translation id="6333140779060797560">Надіслати через <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Шифрування</translation>
-<translation id="6341580099087024258">Запитувати, де зберігати файли</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}one{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}few{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}many{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" />}}</translation>
-<translation id="6364438453358674297">Вилучити пропозицію з історії?</translation>
-<translation id="6369229450655021117">Тут можна здійснювати пошук, ділитися вмістом із друзями та переглядати відкриті сторінки.</translation>
-<translation id="6378173571450987352">Деталі: відсортовано за кількістю використаного трафіку</translation>
-<translation id="6381421346744604172">Затемнити веб-сайти</translation>
-<translation id="6388207532828177975">Очистити та скинути</translation>
-<translation id="6393863479814692971">Chrome потрібні дозволи, щоб використовувати камеру та мікрофон на цьому сайті.</translation>
-<translation id="6395288395575013217">ПОСИЛАННЯ</translation>
-<translation id="6404511346730675251">Редагувати закладку</translation>
-<translation id="6406506848690869874">Синхронізація</translation>
-<translation id="641643625718530986">Друк…</translation>
-<translation id="6416782512398055893">Завантажено <ph name="MBS" /> МБ</translation>
-<translation id="6427112570124116297">Перекласти веб-сторінки</translation>
-<translation id="6433501201775827830">Виберіть пошукову систему</translation>
-<translation id="6437478888915024427">Інформація про сторінку</translation>
-<translation id="6441734959916820584">Задовга назва</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# зображення}one{# зображення}few{# зображення}many{# зображень}other{# зображення}}</translation>
-<translation id="6447842834002726250">Cookie-файли</translation>
-<translation id="6461962085415701688">Не вдається відкрити файл</translation>
-<translation id="6464977750820128603">Ви можете переглянути відвідані в Chrome сайти та встановити таймери для них.\n\nGoogle отримує дані про те, для яких сайтів ви встановлюєте таймери, а також відомості про тривалість перебування на них. Ця інформація використовується для покращення Цифрового добробуту.</translation>
-<translation id="6475951671322991020">Завантажити відео</translation>
-<translation id="6482749332252372425">Не вдалося завантажити файл <ph name="FILE_NAME" />. Замало місця.</translation>
-<translation id="6496823230996795692">Щоб запустити додаток <ph name="APP_NAME" /> уперше, під’єднайте пристрій до Інтернету.</translation>
-<translation id="6508722015517270189">Перезапустіть Chrome</translation>
-<translation id="6527303717912515753">Надіслати</translation>
-<translation id="6532866250404780454">Відвідані в Chrome веб-сайти не відображатимуться. Усі таймери для них буде видалено.</translation>
-<translation id="6534565668554028783">Google довго не відповідає</translation>
-<translation id="6538442820324228105">Завантажено <ph name="GBS" /> ГБ</translation>
-<translation id="6539092367496845964">Сталася помилка. Спробуйте пізніше.</translation>
-<translation id="654446541061731451">Виберіть вкладку для передавання даних</translation>
-<translation id="6545017243486555795">Видалити всі дані</translation>
-<translation id="6545864417968258051">Пошук пристроїв Bluetooth</translation>
-<translation id="6560414384669816528">Шукати за допомогою Sogou</translation>
-<translation id="6566259936974865419">Chrome заощадив <ph name="GIGABYTES" /> ГБ</translation>
-<translation id="6573096386450695060">Завжди дозволяти</translation>
-<translation id="6573431926118603307">Тут відображатимуться вкладки, відкриті в Chrome на інших ваших пристроях.</translation>
-<translation id="6583199322650523874">Зробити закладку поточної сторінки</translation>
-<translation id="6593061639179217415">Версія для комп’ютера</translation>
-<translation id="6600954340915313787">Скопійовано в Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> ГБ</translation>
-<translation id="6612358246767739896">Захищений вміст</translation>
-<translation id="6627583120233659107">Редагувати папку</translation>
-<translation id="6643016212128521049">Очистити</translation>
-<translation id="6643649862576733715">Сортувати за кількістю заощадженого трафіку</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}one{<ph name="CONTACT_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}few{<ph name="CONTACT_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}many{<ph name="CONTACT_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}other{<ph name="CONTACT_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" />}}</translation>
-<translation id="6649642165559792194">Переглянути зображення <ph name="BEGIN_NEW" />Нове<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Щоб знаходити пристрої, Chrome потрібний доступ до геоданих. <ph name="BEGIN_LINK" />Оновлити дозволи<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Пароль</translation>
-<translation id="6659594942844771486">Вкладка</translation>
-<translation id="666731172850799929">Відкрити в програмі <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Примітка про конфіденційність Chrome</translation>
-<translation id="6676840375528380067">Видалити дані Chrome із цього пристрою?</translation>
-<translation id="6697492270171225480">Показувати пропозиції схожих сторінок, коли не вдається знайти сторінку</translation>
-<translation id="6697947395630195233">Chrome потрібен доступ до місцезнаходження, щоб повідомляти ваші геодані цьому сайту.</translation>
-<translation id="6698801883190606802">Керування синхронізованими даними</translation>
-<translation id="6699370405921460408">Сервери Google оптимізують сторінки, які ви відвідуєте.</translation>
-<translation id="6706288973712894588">Зараз ви в режимі офлайн.\n<ph name="BEGIN_LINK" />Перегляньте автономну стрічку.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Новини</translation>
-<translation id="6710213216561001401">Попереднє</translation>
-<translation id="671481426037969117">Вийшов час на таймері веб-сайту <ph name="FQDN" />. Завтра він знову запрацює.</translation>
-<translation id="6738867403308150051">Завантаження…</translation>
-<translation id="6746124502594467657">Вниз</translation>
-<translation id="6766622839693428701">Проведіть пальцем униз, щоб закрити.</translation>
-<translation id="6766758767654711248">Натисніть, щоб перейти на сайт</translation>
-<translation id="6767294960381293877">Список пристроїв, з якими можна ділитися вкладкою, відкрито на половину висоти.</translation>
-<translation id="6782111308708962316">Забороняти стороннім веб-сайтам зберігати та переглядати дані файлів cookie</translation>
-<translation id="6790428901817661496">Відтворити</translation>
-<translation id="6811034713472274749">Сторінка готова для перегляду</translation>
-<translation id="6818926723028410516">Виберіть елементи</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Перекласти</translation>
-<translation id="6845325883481699275">Допоможіть покращити безпеку Chrome</translation>
-<translation id="6846298663435243399">Завантаження…</translation>
-<translation id="6850409657436465440">Завантаження ще триває</translation>
-<translation id="6850830437481525139">Закрито вкладок: <ph name="TAB_COUNT" /></translation>
-<translation id="6864459304226931083">Завантажити зображення</translation>
-<translation id="6865313869410766144">Дані автозаповнення форм</translation>
-<translation id="688738109438487280">Додати наявні дані в обліковий запис <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Розблокуйте, щоб скопіювати пароль</translation>
-<translation id="6896758677409633944">Копіювати</translation>
-<translation id="6910211073230771657">Видалено</translation>
-<translation id="6912998170423641340">Не дозволяти сайтам переглядати тексти й зображення в буфері обміну</translation>
-<translation id="6914783257214138813">Ваші паролі бачитимуть усі, хто може переглядати експортований файл.</translation>
-<translation id="6942665639005891494">Будь-коли змінюйте папку для завантажень за умовчанням, використовуючи відповідну опцію в меню "Налаштування"</translation>
-<translation id="6945221475159498467">Вибрати</translation>
-<translation id="6963642900430330478">Ця сторінка небезпечна. Інформація про сайт</translation>
-<translation id="6963766334940102469">Видалити закладки</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Увесь час</translation>
-<translation id="6981982820502123353">Доступність</translation>
-<translation id="6989267951144302301">Не вдалося завантажити</translation>
-<translation id="6990079615885386641">Завантажити додаток із магазину Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Запитувати, перш ніж дозволити сайтам використовувати мікрофон (рекомендується)</translation>
-<translation id="7015203776128479407">Початкове налаштування синхронізації не завершено. Синхронізацію вимкнено.</translation>
-<translation id="7016516562562142042">Дозволено для поточної пошукової системи</translation>
-<translation id="7022756207310403729">Відкрити у веб-переглядачі</translation>
-<translation id="702463548815491781">Рекомендується, коли ввімкнено TalkBack або кнопковий доступ</translation>
-<translation id="7029809446516969842">Паролі</translation>
-<translation id="7053983685419859001">Блокувати</translation>
-<translation id="7055152154916055070">Переадресацію заблоковано:</translation>
-<translation id="7063006564040364415">Не вдалося з’єднатись із сервером синхронізації.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Вибрано 1}one{Вибрано #}few{Вибрано #}many{Вибрано #}other{Вибрано #}}</translation>
-<translation id="7071521146534760487">Керувати обліковим записом</translation>
-<translation id="7077143737582773186">Карта SD</translation>
-<translation id="7087918508125750058">Вибрано <ph name="ITEM_COUNT" />. Панель інструментів розташовано вгорі екрана</translation>
-<translation id="7121362699166175603">Видалення історії й варіантів автозавершень в адресному рядку. Історія веб-перегляду може також зберігатися у вашому обліковому записі Google на сторінці <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Дозволити поточній пошуковій системі</translation>
-<translation id="7138678301420049075">Інше</translation>
-<translation id="7141896414559753902">Блокувати спливаючі вікна та переадресацію на сайтах (рекомендовано)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Завантажити оригінальну сторінку<ph name="END_LINK" /> з домену <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">Останні 24 години</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> КБ</translation>
-<translation id="7177466738963138057">Це можна змінити пізніше в налаштуваннях</translation>
-<translation id="7180611975245234373">Оновити</translation>
-<translation id="7189372733857464326">Сервіси Google Play оновлюються</translation>
-<translation id="7191430249889272776">Вкладку відкрито у фоновому режимі.</translation>
-<translation id="723171743924126238">Вибрати зображення</translation>
-<translation id="7233236755231902816">Щоб переглядати сторінки вашою мовою, установіть останню версію Chrome</translation>
-<translation id="7243308994586599757">Опції можна знайти внизу екрана</translation>
-<translation id="7248069434667874558">Переконайтеся, що на пристрої <ph name="TARGET_DEVICE_NAME" /> увімкнено синхронізацію в Chrome</translation>
-<translation id="7250468141469952378">Вибрано <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Заблокований сайт</translation>
-<translation id="7290209999329137901">Не можна перейменувати</translation>
-<translation id="7291387454912369099">Оплата за допомогою Асистента</translation>
-<translation id="7293171162284876153">Щоб почати синхронізацію, увімкніть параметр "Синхронізувати дані Chrome".</translation>
-<translation id="729975465115245577">На пристрої немає додатка для зберігання файлу з паролями.</translation>
-<translation id="7302081693174882195">Деталі: відсортовано за кількістю заощадженого трафіку</translation>
-<translation id="7328017930301109123">У спрощеному режимі Chrome завантажує сторінки швидше та використовує на 60 відсотків менше трафіку.</translation>
-<translation id="7333031090786104871">Попередній сайт ще додається</translation>
-<translation id="7352939065658542140">ВІДЕО</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Поділитись 1 вибраним елементом}one{Поділитися # вибраним елементом}few{Поділитися # вибраними елементами}many{Поділитися # вибраними елементами}other{Поділитися # вибраного елемента}}</translation>
 <translation id="7359002509206457351">Отримати доступ до способів оплати</translation>
+<translation id="8026334261755873520">Очистити історію</translation>
+<translation id="1291207594882862231">Очистити історію, файли cookie, дані сайтів, кеш…</translation>
+<translation id="7814200940910057384">Дані Brave видалено</translation>
+<translation id="1664855196866195614">Вибрані дані видалено з Brave і синхронізованих пристроїв.
+
+У вашому обліковому записі Brave Software на сторінці <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> можуть бути додаткові форми історії веб-перегляду, як-от пошукові запити чи активність в інших сервісах Brave Software.</translation>
+<translation id="4699172675775169585">Кешовані зображення та файли</translation>
+<translation id="2496180316473517155">Історія переглядів</translation>
+<translation id="2546283357679194313">Файли cookie та дані із сайтів</translation>
+<translation id="8662811608048051533">Ви вийдете з більшості сайтів.</translation>
+<translation id="8218628800671693884">Ви вийдете з більшості сайтів, але не вийдете з облікового запису Brave Software.</translation>
+<translation id="2017836877785168846">Очищує історію й автозавершення в адресному рядку.</translation>
+<translation id="8096327394278038498">Видалення історії й варіантів автозавершень в адресному рядку. Історія веб-перегляду може також зберігатися у вашому обліковому записі Brave Software на сторінці <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Видалення історії на всіх пристроях, на яких ви ввійшли в обліковий запис. Історія веб-перегляду може також зберігатися у вашому обліковому записі Brave Software на сторінці  <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Збережені паролі</translation>
+<translation id="6865313869410766144">Дані автозаповнення форм</translation>
+<translation id="7562080006725997899">Очищення даних веб-перегляду</translation>
+<translation id="5487521232677179737">Видалити дані</translation>
+<translation id="7498271377022651285">Зачекайте…</translation>
+<translation id="784934925303690534">Період часу</translation>
+<translation id="1718835860248848330">Остання година</translation>
+<translation id="7149893636342594995">Останні 24 години</translation>
+<translation id="5648166631817621825">Останні 7 днів</translation>
+<translation id="8571213806525832805">Останні 4 тижні</translation>
+<translation id="5854790677617711513">Понад 30 днів тому</translation>
+<translation id="6979737339423435258">Увесь час</translation>
+<translation id="982182592107339124">Буде видалено дані всіх сайтів, зокрема:</translation>
+<translation id="6643016212128521049">Очистити</translation>
+<translation id="7641339528570811325">Очистити історію…</translation>
+<translation id="1670399744444387456">Основні параметри</translation>
+<translation id="3245261285041759672">Історія веб-перегляду може також зберігатися у вашому обліковому записі Brave Software на сторінці <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Заблокований сайт</translation>
+<translation id="2534155362429831547">Видалено елементів: <ph name="NUMBER_OF_ITEMS"/></translation>
+<translation id="1121094540300013208">Використання та збої</translation>
+<translation id="9079153198295609735">Автоматично надсилати статистику використання та звіти про аварійне завершення роботи в Brave Software</translation>
+<translation id="6981982820502123353">Доступність</translation>
+<translation id="2387895666653383613">Масштаб тексту</translation>
+<translation id="2321958826496381788">Перетягуйте повзунок, доки розмір тексту не стане зручним для читання. Якщо двічі торкнутись абзацу, розмір тексту має стати принаймні таким, як цей.</translation>
+<translation id="3895926599014793903">Примусово ввімкнути масштабування</translation>
+<translation id="5668404140385795438">Відхиляти запит веб-сайту, щоб забороняти масштабування</translation>
+<translation id="4149994727733219643">Спрощений перегляд веб-сторінок</translation>
+<translation id="9100505651305367705">Пропонувати статті в режимі спрощеного перегляду, якщо він підтримується</translation>
+<translation id="1409426117486808224">Спрощений перегляд відкритих вкладок</translation>
+<translation id="702463548815491781">Рекомендується, коли ввімкнено TalkBack або кнопковий доступ</translation>
+<translation id="8284326494547611709">Субтитри</translation>
+<translation id="4165986682804962316">Налаштування сайту</translation>
+<translation id="6295158916970320988">Усі сайти</translation>
+<translation id="8380167699614421159">Цей сайт показує нав’язливі чи оманливі оголошення</translation>
+<translation id="1919345977826869612">Оголошення</translation>
+<translation id="410351446219883937">Автовідтворення</translation>
+<translation id="6447842834002726250">Cookie-файли</translation>
+<translation id="6196640612572343990">Блокувати сторонні файли cookie</translation>
+<translation id="6782111308708962316">Забороняти стороннім веб-сайтам зберігати та переглядати дані файлів cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Спливаючі вікна й переадресація</translation>
+<translation id="4751476147751820511">Датчики руху та світла</translation>
+<translation id="1717218214683051432">Датчики руху</translation>
+<translation id="2091887806945687916">Сигнал</translation>
+<translation id="2586657967955657006">Буфер обміну</translation>
+<translation id="6320088164292336938">Вібросигнал</translation>
+<translation id="4226663524361240545">Коли надходитимуть сповіщення, пристрій може вібрувати</translation>
+<translation id="1446450296470737166">Повний контроль пристроїв MIDI</translation>
+<translation id="3744111561329211289">Фонова синхронізація</translation>
+<translation id="5649053991847567735">Автоматичні завантаження</translation>
+<translation id="6181444274883918285">Додати сайт у список винятків</translation>
+<translation id="5313967007315987356">Додати сайт</translation>
+<translation id="1369915414381695676">Сайт <ph name="SITE_NAME"/> додано</translation>
+<translation id="7837721118676387834">Дозволити автоматичне відтворення відео з вимкненим звуком для певних сайтів.</translation>
+<translation id="2621115761605608342">Увімкнути Javascript на певному сайті.</translation>
+<translation id="8801436777607969138">Блокувати Javascript на певному сайті.</translation>
+<translation id="8372893542064058268">сайті.</translation>
+<translation id="358794129225322306">Дозволити сайту автоматично завантажувати декілька файлів.</translation>
+<translation id="4008040567710660924">Дозволити файли cookie для конкретного сайту.</translation>
+<translation id="8958424370300090006">Блокувати файли cookie з конкретного сайту.</translation>
+<translation id="7882806643839505685">Увімкнути звук для певного сайту.</translation>
+<translation id="4468959413250150279">Вимкнути звук для певного сайту.</translation>
+<translation id="1994173015038366702">URL-адреса сайту</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Використання</translation>
+<translation id="5804241973901381774">Дозволи</translation>
+<translation id="4278390842282768270">Дозволено</translation>
+<translation id="5677928146339483299">Заблоковано</translation>
+<translation id="1984937141057606926">Заборонено лише сторонні файли cookie</translation>
+<translation id="7423098979219808738">Спершу запитувати</translation>
+<translation id="8116925261070264013">Звук вимкнено</translation>
+<translation id="8300705686683892304">Керуються додатком</translation>
+<translation id="6192792657125177640">Винятки</translation>
+<translation id="257931822824936280">Розгорнуто – натисніть, щоб згорнути.</translation>
+<translation id="5100237604440890931">Згорнуто – натисніть, щоб розгорнути.</translation>
+<translation id="857943718398505171">Дозволено (рекомендується)</translation>
+<translation id="2913331724188855103">Дозволити сайтам зберігати та розпізнавати дані файлів cookie (рекомендується)</translation>
+<translation id="7445411102860286510">Дозволити сайтам автоматично відтворювати відео з вимкненим звуком (рекомендується)</translation>
+<translation id="5335288049665977812">Дозволити сайтам запускати Javascript (рекомендується)</translation>
+<translation id="5527111080432883924">Запитувати, перш ніж дозволяти сайтам переглядати тексти й зображення в буфері обміну (рекомендовано)</translation>
+<translation id="6912998170423641340">Не дозволяти сайтам переглядати тексти й зображення в буфері обміну</translation>
+<translation id="7423538860840206698">Заборонено переглядати буфер обміну</translation>
+<translation id="3955193568934677022">Дозволити сайтам відтворювати захищений вміст (рекомендується)</translation>
+<translation id="445467742685312942">Дозволити сайтам відтворювати захищений вміст</translation>
+<translation id="2107397443965016585">Запитувати, перш ніж дозволяти сайтам відтворювати захищений вміст (рекомендовано)</translation>
+<translation id="2910701580606108292">Запитувати, перш ніж дозволяти сайтам відтворювати захищений вміст</translation>
+<translation id="757524316907819857">Заборонити сайтам відтворювати захищений вміст</translation>
+<translation id="3277252321222022663">Надати сайтам доступ до датчиків (рекомендовано)</translation>
+<translation id="5048398596102334565">Надати сайтам доступ до датчиків руху (рекомендовано)</translation>
+<translation id="8816026460808729765">Заборонити сайтам доступ до датчиків</translation>
+<translation id="169515064810179024">Заборонити сайтам доступ до датчиків руху</translation>
+<translation id="1660204651932907780">Дозволити сайтам відтворювати звук (рекомендується)</translation>
+<translation id="3600792891314830896">Вимкнути звук на сайтах, які відтворюють його</translation>
+<translation id="1743802530341753419">Запитувати, перш ніж дозволяти сайтам підключатися до пристрою (рекомендовано)</translation>
+<translation id="851751545965956758">Заборонити сайтам підключатися до пристроїв</translation>
+<translation id="7141896414559753902">Блокувати спливаючі вікна та переадресацію на сайтах (рекомендовано)</translation>
+<translation id="5494752089476963479">Блокувати рекламу на сайтах, які показують нав’язливі чи оманливі оголошення</translation>
+<translation id="3123473560110926937">Заблоковано на деяких сайтах</translation>
+<translation id="965817943346481315">Блокувати, якщо сайт показує нав’язливі чи оманливі оголошення (рекомендовано)</translation>
+<translation id="3386292677130313581">Запитувати, перш ніж дозволити сайтам визначати ваше місцезнаходження (рекомендується)</translation>
+<translation id="9139068048179869749">Запитувати, перш ніж дозволити сайтам надсилати сповіщення (рекомендується)</translation>
+<translation id="4479647676395637221">Запитувати, перш ніж дозволити сайтам використовувати камеру (рекомендується)</translation>
+<translation id="6992289844737586249">Запитувати, перш ніж дозволити сайтам використовувати мікрофон (рекомендується)</translation>
+<translation id="2289270750774289114">Запитувати, коли сайт хоче шукати пристрої Bluetooth поблизу (рекомендовано)</translation>
+<translation id="7053983685419859001">Блокувати</translation>
+<translation id="7128222689758636196">Дозволити поточній пошуковій системі</translation>
+<translation id="7589445247086920869">Заблокувати для поточної пошукової системи</translation>
+<translation id="6388207532828177975">Очистити та скинути</translation>
+<translation id="7999064672810608036">Видалити всі локальні дані, зокрема файли cookie, і скинути всі дозволи для цього веб-сайту?</translation>
+<translation id="2822354292072154809">Скинути всі дозволи сайту <ph name="CHOSEN_OBJECT_NAME"/>?</translation>
+<translation id="515227803646670480">Очистити збережені дані</translation>
+<translation id="5902828464777634901">Буде видалено всі локальні дані, які зберіг цей веб-сайт, зокрема файли cookie.</translation>
+<translation id="119944043368869598">Очистити все</translation>
+<translation id="2490684707762498678">Адміністратор сімейної групи: <ph name="APP_NAME"/></translation>
+<translation id="5516455585884385570">Відкрити налаштування сповіщень</translation>
+<translation id="1404122904123200417">Вбудовано на сайті <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Файли, збережені веб-сайтами, відображаються тут</translation>
+<translation id="4181841719683918333">Мови</translation>
+<translation id="2647434099613338025">Додати мову</translation>
+<translation id="1952172573699511566">Якщо можливо, текст на веб-сайтах відображатиметься вибраною мовою.</translation>
+<translation id="8559990750235505898">Пропозиція перекладати сторінки іншими мовами</translation>
+<translation id="4719927025381752090">Пропонувати переклад</translation>
+<translation id="8156139159503939589">Якими мовами ви читаєте?</translation>
+<translation id="5689516760719285838">Місцезнаходження</translation>
+<translation id="2440823041667407902">Доступ до геоданих</translation>
+<translation id="2023546461831060654">Увімкніть дозволи для Brave у <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Увімкніть дозвіл для Brave у <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Щоб надати Brave доступ до геоданих, також увімкніть їх у <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Щоб надати Brave доступ до камери, також увімкніть її в <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Щоб надати Brave доступ до сповіщень, також увімкніть їх у <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Щоб надати Brave доступ до мікрофона, також увімкніть його в <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">На цьому пристрої вимкнено доступ до геоданих. Увімкніть його в <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">На цьому пристрої також вимкнено доступ до геоданих. Увімкніть його в <ph name="BEGIN_LINK"/>налаштуваннях Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Камера</translation>
+<translation id="3227137524299004712">Мікрофон</translation>
+<translation id="1647391597548383849">Доступ до камери</translation>
+<translation id="945632385593298557">Доступ до мікрофона</translation>
+<translation id="6612358246767739896">Захищений вміст</translation>
+<translation id="885701979325669005">Обсяг пам’яті</translation>
+<translation id="3198916472715691905">У пам'яті зайнято <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Скасувати доступ до пристрою</translation>
+<translation id="4962975101802056554">Скасувати всі дозволи для пристрою</translation>
+<translation id="6545864417968258051">Пошук пристроїв Bluetooth</translation>
+<translation id="4411535500181276704">Спрощений режим</translation>
+<translation id="7821588508402923572">Тут буде вказано обсяг заощадженого трафіку</translation>
+<translation id="2131665479022868825">Заощаджено <ph name="DATA"/></translation>
+<translation id="8569404424186215731">з <ph name="DATE"/></translation>
+<translation id="3252158532344029638">У спрощеному режимі Brave завантажує сторінки швидше та використовує на 60 відсотків менше трафіку.</translation>
+<translation id="6159335304067198720">Заощадження даних: <ph name="PERCENT"/></translation>
+<translation id="7494974237137038751">заощаджений трафік</translation>
+<translation id="6111020039983847643">використаний трафік</translation>
+<translation id="7413229368719586778">Дата початку: <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Дата завершення: <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Сортувати за сайтом</translation>
+<translation id="5864174910718532887">Деталі: відсортовано за назвою сайту</translation>
+<translation id="116280672541001035">Використано</translation>
+<translation id="8349013245300336738">Сортувати за кількістю використаного трафіку</translation>
+<translation id="6378173571450987352">Деталі: відсортовано за кількістю використаного трафіку</translation>
+<translation id="2631006050119455616">Збережено</translation>
+<translation id="6643649862576733715">Сортувати за кількістю заощадженого трафіку</translation>
+<translation id="7302081693174882195">Деталі: відсортовано за кількістю заощадженого трафіку</translation>
+<translation id="4179980317383591987">Використано <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Заощаджено <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Інші сайти (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Інше</translation>
+<translation id="4913161338056004800">Скинути дані статистики</translation>
+<translation id="1856325424225101786">Скинути спрощений режим?</translation>
+<translation id="3658159451045945436">Буде скинуто історію заощадження трафіку, зокрема список відвіданих веб-сайтів.</translation>
+<translation id="3295530008794733555">Шукайте швидше. Заощаджуйте трафік.</translation>
+<translation id="7340390500800578919">У спрощеному режимі Brave завантажує сторінки швидше та використовує на 60% менше трафіку. Щоб оптимізувати сторінки, які ви відвідуєте, Brave надсилає ваш веб-трафік у Brave Software. <ph name="BEGIN_LINK"/>Докладніше<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Увімкнути спрощений режим</translation>
+<translation id="4493497663118223949">Спрощений режим увімкнено</translation>
+<translation id="7559975015014302720">Спрощений режим вимкнено</translation>
+<translation id="7606077192958116810">Спрощений режим увімкнено. Керуйте ним у налаштуваннях.</translation>
+<translation id="4714588616299687897">Заощаджуйте до 60% трафіку</translation>
+<translation id="1006927014032731288">Сервери Brave Software оптимізують сторінки, які ви відвідуєте.</translation>
+<translation id="3257320067425202300">Brave заощадив <ph name="MEGABYTES"/> МБ</translation>
+<translation id="5813223329348543512">Brave заощадив <ph name="GIGABYTES"/> ГБ</translation>
+<translation id="8266862848225348053">Папка для завантажень</translation>
+<translation id="7077143737582773186">Карта SD</translation>
+<translation id="7762668264895820836">Карта SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Запитувати, де зберігати файли</translation>
+<translation id="6192333916571137726">Завантажити файл</translation>
+<translation id="1672586136351118594">Більше не показувати</translation>
+<translation id="2650751991977523696">Завантажити файл ще раз?</translation>
+<translation id="8664979001105139458">Файл із такою назвою вже існує</translation>
+<translation id="488187801263602086">Перейменувати файл</translation>
+<translation id="5686790454216892815">Назва файлу задовга</translation>
+<translation id="7454641608352164238">Замало місця</translation>
+<translation id="8972098258593396643">Завантажити в папку за умовчанням?</translation>
+<translation id="804335162455518893">Карту SD не знайдено</translation>
+<translation id="7475688122056506577">Карту SD не знайдено. Деякі файли можуть бути відсутні.</translation>
+<translation id="4198423547019359126">Немає доступних місць для завантаження</translation>
+<translation id="8224471946457685718">Завантажувати статті через Wi-Fi</translation>
+<translation id="4970824347203572753">Функція недоступна у вашій країні</translation>
+<translation id="5500777121964041360">Функція може бути недоступна у вашій країні</translation>
+<translation id="1173894706177603556">Перейменувати</translation>
+<translation id="1986685561493779662">Ця назва вже існує</translation>
+<translation id="6441734959916820584">Задовга назва</translation>
+<translation id="2923908459366352541">Недійсна назва</translation>
+<translation id="7290209999329137901">Не можна перейменувати</translation>
+<translation id="3334729583274622784">Змінити розширення файлу?</translation>
+<translation id="107147699690128016">Якщо ви зміните розширення файлу, він може відкритися в іншому додатку або зашкодити пристрою.</translation>
+<translation id="8541922081612557424">Про Brave</translation>
+<translation id="5311273890481188673">Авторське право <ph name="YEAR"/> Brave Software LLC. Усі права захищено.</translation>
+<translation id="1416550906796893042">Версія додатка</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (оновлено: <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Операційна система</translation>
+<translation id="3968054912784331254">Brave більше не оновлюється в цій версії Android</translation>
+<translation id="7665369617277396874">Додати обліковий запис</translation>
+<translation id="649070405679044769">Ви ввійшли в обліковий запис Brave Software як</translation>
+<translation id="6234515504547364178">Вихід із Brave</translation>
+<translation id="5324858694974489420">Батьківські налаштування</translation>
+<translation id="8920114477895755567">Очікування даних батьків.</translation>
+<translation id="5512137114520586844">Цим обліковим записом керує <ph name="PARENT_NAME"/>.</translation>
+<translation id="2956410042958133412">Цим обліковим записом керують <ph name="PARENT_NAME_1"/> і <ph name="PARENT_NAME_2"/>.</translation>
+<translation id="8168435359814927499">Вміст</translation>
+<translation id="5403644198645076998">Дозволити лише певні сайти</translation>
+<translation id="8641930654639604085">Блокувати сайти для дорослих</translation>
+<translation id="5639724618331995626">Дозволити всі сайти</translation>
+<translation id="796823723482603597">Технології Brave</translation>
+<translation id="6324034347079777476">Синхронізацію системи Android вимкнено</translation>
+<translation id="5127805178023152808">Синхронізацію вимкнено</translation>
+<translation id="7015203776128479407">Початкове налаштування синхронізації не завершено. Синхронізацію вимкнено.</translation>
+<translation id="2497852260688568942">Ваш адміністратор вимкнув синхронізацію</translation>
+<translation id="9100610230175265781">Потрібно вказати парольну фразу</translation>
+<translation id="6108923351542677676">Виконується налаштування…</translation>
+<translation id="4062305924942672200">Правова інформація</translation>
+<translation id="4256782883801055595">Ліцензії ПЗ з відкритим кодом</translation>
+<translation id="1138681184697033370">Умови використання Brave Software Brave</translation>
+<translation id="7392539049993970338">Примітка про конфіденційність Brave</translation>
+<translation id="2677748264148917807">Вийти</translation>
+<translation id="5556459405103347317">Перезавантажити</translation>
+<translation id="1623104350909869708">Заборонити цій сторінці створювати додаткові діалогові вікна</translation>
+<translation id="2968755619301702150">Перегляд сертифікатів</translation>
+<translation id="1360432990279830238">Вийти й вимкнути синхронізацію?</translation>
+<translation id="8581481290581777242">Видалити дані Brave із цього пристрою?</translation>
+<translation id="1318865768845061710">Закладки, історія, паролі й інші дані Brave більше не синхронізуватимуться з обліковим записом Brave Software</translation>
+<translation id="3325020657155065477">Також видалити дані Brave із цього пристрою</translation>
+<translation id="6136448902816743006">Оскільки ви виходите з облікового запису, зареєстрованого в домені <ph name="DOMAIN_NAME"/>, ваші дані Brave буде видалено з цього пристрою. Вони залишаться у вашому обліковому записі Brave Software.</translation>
+<translation id="1853026300647876496">З’єднання з Brave Software. Це може зайняти хвилину…</translation>
+<translation id="2328985652426384049">Не вдається ввійти</translation>
+<translation id="7723158744459952869">Brave Software довго не відповідає</translation>
+<translation id="4572422548854449519">Увійдіть у керований обліковий запис</translation>
+<translation id="2689656545739939160">Ви входите в обліковий запис, зареєстрований у домені <ph name="MANAGED_DOMAIN"/>, і надаєте його адміністратору доступ до своїх даних Brave. Ваші дані буде назавжди зв’язано з цим обліковим записом. Якщо ви вийдете з облікового запису в Brave, дані буде видалено з цього пристрою, але вони залишаться у вашому обліковому записі Brave Software.</translation>
+<translation id="1749561566933687563">Синхронізуйте свої закладки</translation>
+<translation id="4242533952199664413">Відкрити налаштування</translation>
+<translation id="1111673857033749125">Тут відображатимуться закладки, збережені на інших ваших пристроях.</translation>
+<translation id="8636825310635137004">Щоб мати доступ до вкладок з інших пристроїв, увімкніть синхронізацію.</translation>
+<translation id="3269956123044984603">Щоб мати доступ до вкладок з інших пристроїв, увімкніть опцію "Автоматично синхронізувати дані" в налаштуваннях облікового запису на Android.</translation>
+<translation id="5157964048453367290">Тут відображатимуться вкладки, відкриті в Brave на інших ваших пристроях.</translation>
+<translation id="4684427112815847243">Синхронізувати все</translation>
+<translation id="2709516037105925701">Автозаповнення</translation>
+<translation id="8820817407110198400">Закладки</translation>
+<translation id="1644574205037202324">Історія</translation>
+<translation id="17513872634828108">Відкриті вкладки</translation>
+<translation id="1320169905922104972">Кредитні картки й адреси, додані в Brave Software Pay</translation>
+<translation id="6337234675334993532">Шифрування</translation>
+<translation id="6698801883190606802">Керування синхронізованими даними</translation>
+<translation id="3598578758776312506">Шифрувати паролі за допомогою облікових даних Brave Software</translation>
+<translation id="7810580217418711046">Зашифрувати синхронізовані дані за допомогою пароля Brave Software від <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Шифрувати синхронізовані дані за допомогою власної парольної фрази</translation>
+<translation id="2996291259634659425">Створити парольну фразу</translation>
+<translation id="5713644099811900409">Обліковий запис Brave Software</translation>
+<translation id="8997474919031554666">Парольна фраза не стосується способів оплати й адрес із Brave Software Pay. Ваші зашифровані дані можуть переглядати лише користувачі, які знають вашу парольну фразу. Вона не надсилається й не зберігається в Brave Software. Якщо ви забули її або хочете змінити це налаштування, скиньте параметри синхронізації. <ph name="BEGIN_LINK"/>Докладніше<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Парольна фраза</translation>
+<translation id="7772032839648071052">Підтвердити парольну фразу</translation>
+<translation id="5304593522240415983">Це поле не може бути порожнім</translation>
+<translation id="321773570071367578">Якщо ви забули парольну фразу або хочете змінити це налаштування, <ph name="BEGIN_LINK"/>скиньте синхронізацію<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Парольні фрази не збігаються</translation>
+<translation id="5149495116300586333">Парольна фраза не стосується способів оплати й адрес із Brave Software Pay.
+
+Щоб змінити це налаштування, <ph name="BEGIN_LINK"/>скиньте параметри синхронізації<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Неправильна парольна фраза</translation>
+<translation id="5414836363063783498">Підтвердження…</translation>
+<translation id="6846298663435243399">Завантаження…</translation>
+<translation id="5517095782334947753">У вас є закладки, історія, паролі й інші налаштування з облікового запису <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Об’єднати мої дані</translation>
+<translation id="688738109438487280">Додати наявні дані в обліковий запис <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Зберігати мої дані окремо</translation>
+<translation id="1145536944570833626">Видалити наявні дані.</translation>
+<translation id="1993768208584545658">Сайт <ph name="SITE"/> хоче підключитися до пристрою</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Довідка<ph name="END_LINK"/> під час пошуку пристроїв…</translation>
+<translation id="5817918615728894473">Підключити</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Отримайте допомогу<ph name="END_LINK1"/> або <ph name="BEGIN_LINK2"/>повторіть сканування<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Сумісних пристроїв не знайдено</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Увімкніть Bluetooth<ph name="END_LINK"/>, щоб підключити</translation>
+<translation id="998321811308652668">Brave не може ввімкнути адаптер Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Довідка<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Щоб знаходити пристрої, Brave потрібний доступ до геоданих. <ph name="BEGIN_LINK"/>Оновлити дозволи<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Щоб шукати пристрої, Brave потрібен доступ до геоданих. Доступ до геоданих <ph name="BEGIN_LINK"/>вимкнено на цьому пристрої<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Щоб шукати пристрої, Brave потрібен доступ до геоданих. <ph name="BEGIN_LINK1"/>Оновити дозволи<ph name="END_LINK1"/>. Доступ до геоданих також <ph name="BEGIN_LINK2"/>вимкнено на цьому пристрої<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Під’єднаний пристрій</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Рівень сигналу: # поділка}one{Рівень сигналу: # поділка}few{Рівень сигналу: # поділки}many{Рівень сигналу: # поділок}other{Рівень сигналу: # поділки}}</translation>
+<translation id="5230560987958996918">Сайт <ph name="SITE"/> хоче шукати пристрої Bluetooth поруч. Виявлено такі пристрої:</translation>
+<translation id="8368027906805972958">Невідомий чи непідтримуваний пристрій (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Синхронізація не працює</translation>
+<translation id="1810845389119482123">Початкове налаштування синхронізації не завершено</translation>
+<translation id="3235722914093408050">Щоб почати синхронізацію Brave, відкрийте параметри Android і знову ввімкніть синхронізацію системи</translation>
+<translation id="3367813778245106622">Увійдіть знову, щоб почати синхронізацію</translation>
+<translation id="974555521953189084">Введіть парольну фразу, щоб почати синхронізацію</translation>
+<translation id="2997266899014181325">Щоб почати синхронізацію, увімкніть параметр "Синхронізувати дані Brave".</translation>
+<translation id="8260126382462817229">Спробуйте ввійти ще раз</translation>
+<translation id="5919204609460789179">Оновіть <ph name="PRODUCT_NAME"/>, щоб почати синхронізацію</translation>
+<translation id="397583555483684758">Синхронізація перестала працювати</translation>
+<translation id="1966710179511230534">Оновіть свої дані для входу.</translation>
+<translation id="7063006564040364415">Не вдалося з’єднатись із сервером синхронізації.</translation>
+<translation id="7942131818088350342">Застаріла версія <ph name="PRODUCT_NAME"/>.</translation>
+<translation id="4170011742729630528">Служба не доступна. Повторіть спробу пізніше.</translation>
+<translation id="7947953824732555851">Прийняти й увійти</translation>
+<translation id="8583805026567836021">Очищення даних облікового запису</translation>
+<translation id="8310344678080805313">Стандартні вкладки</translation>
+<translation id="5748802427693696783">Ви перейшли на стандартні вкладки</translation>
+<translation id="7998918019931843664">Знову відкрити закриту вкладку</translation>
+<translation id="8853345339104747198">Вкладка "<ph name="TAB_TITLE"/>"</translation>
+<translation id="4452411734226507615">Закрити вкладку <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Опції можна знайти внизу екрана</translation>
+<translation id="4060598801229743805">Панель інструментів розташовано вгорі екрана</translation>
+<translation id="2810645512293415242">Спрощена сторінка для заощадження трафіку та швидшого завантаження.</translation>
+<translation id="3985215325736559418">Завантажити файл "<ph name="FILE_NAME"/>" повторно?</translation>
+<translation id="2450083983707403292">Завантажити файл <ph name="FILE_NAME"/> ще раз?</translation>
+<translation id="7514365320538308">Завантажити</translation>
+<translation id="545042621069398927">Прискорюється завантаження.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Завантажується файл.}one{Завантажується # файл.}few{Завантажується # файли.}many{Завантажується # файлів.}other{Завантажується # файлу.}}</translation>
+<translation id="543509235395288790">Завантажується файлів: <ph name="COUNT"/> (<ph name="MEGABYTES"/>).</translation>
+<translation id="4988210275050210843">Завантажується файл (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{1 файл завантажено.}one{# файл завантажено.}few{# файли завантажено.}many{# файлів завантажено.}other{# файлу завантажено.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Не вдалося завантажити 1 файл.}one{Не вдалося завантажити # файл.}few{Не вдалося завантажити # файли.}many{Не вдалося завантажити # файлів.}other{Не вдалося завантажити # файлу.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{Очікується 1 завантаження.}one{Очікується # завантаження.}few{Очікується # завантаження.}many{Очікується # завантажень.}other{Очікується # завантаження.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/>, кнопка <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Майже готово.</translation>
+<translation id="3960299545138990065">Перезапустіть Brave</translation>
+<translation id="3771001275138982843">Не вдалося завантажити оновлення</translation>
+<translation id="3888648114124182147">Завантажується оновлення Brave…</translation>
+<translation id="1705567146636171298">Оновити Brave</translation>
+<translation id="6195417478702700398">Оновіть Brave для зручнішого перегляду веб-сторінок</translation>
+<translation id="3512968675351418494">Щоб переглядати сторінки вашою мовою, установіть останню версію Brave</translation>
+<translation id="6427112570124116297">Перекласти веб-сторінки</translation>
+<translation id="1379423114029199501">Виконайте оновлення, щоб користуватися своєю мовою в останній версії Brave</translation>
+<translation id="5684874026226664614">На жаль, цю сторінку неможливо перекласти.</translation>
+<translation id="6831043979455480757">Перекласти</translation>
+<translation id="1285320974508926690">Ніколи не перекладати цей сайт</translation>
+<translation id="773466115871691567">Завжди перекладати сторінки такою мовою: <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Ніколи не перекладати сторінки такою мовою: <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Інші мови</translation>
+<translation id="290376772003165898">Ця сторінка відображається не такою мовою: <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Надалі сторінки цією мовою (<ph name="SOURCE_LANGUAGE"/>) перекладатимуться такою мовою: <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Сторінки цією мовою (<ph name="LANGUAGE"/>) не перекладатимуться</translation>
+<translation id="5447765697759493033">Цей сайт не буде перекладено</translation>
+<translation id="4880127995492972015">Перекласти…</translation>
+<translation id="641643625718530986">Друк…</translation>
+<translation id="8909135823018751308">Надіслати…</translation>
+<translation id="4996978546172906250">Надіслати</translation>
+<translation id="6333140779060797560">Надіслати через <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Виникла проблема з друком цієї сторінки. Повторіть спробу.</translation>
+<translation id="3254409185687681395">Додати цю сторінку до закладок</translation>
+<translation id="497421865427891073">Перейти вперед</translation>
+<translation id="813082847718468539">Перегляд інформації про сайт</translation>
+<translation id="2532336938189706096">Веб-версія</translation>
+<translation id="6005538289190791541">Запропонований пароль</translation>
+<translation id="4634124774493850572">Прийняти пароль</translation>
+<translation id="8285489906452138776">Brave потрібні дозволи, щоб використовувати камеру на цьому сайті.</translation>
+<translation id="320189792589364011">Brave потрібні дозволи, щоб використовувати мікрофон на цьому сайті.</translation>
+<translation id="7988136689212463100">Brave потрібні дозволи, щоб використовувати камеру та мікрофон на цьому сайті.</translation>
+<translation id="4931190655840828017">Brave потрібен доступ до місцезнаходження, щоб повідомляти ваші геодані цьому сайту.</translation>
+<translation id="3088191967551450609">Щоб завантажувати файли, Brave потребує доступу до пам’яті.</translation>
+<translation id="8942627711005830162">Відкрити в іншому вікні</translation>
+<translation id="4195643157523330669">Відкрити в новій вкладці</translation>
+<translation id="1100066534610197918">Відкрити нову вкладку в групі</translation>
+<translation id="4860895144060829044">Зателефонувати</translation>
+<translation id="6896758677409633944">Копіювати</translation>
+<translation id="8393700583063109961">Надіслати повідомлення</translation>
+<translation id="3557336313807607643">Додати до контактів</translation>
+<translation id="4269820728363426813">Копіювати адресу посилання</translation>
+<translation id="1206892813135768548">Копіювати текст посилання</translation>
+<translation id="1204037785786432551">Завантажити дані за посиланням</translation>
+<translation id="6864459304226931083">Завантажити зображення</translation>
+<translation id="8209050860603202033">Відкрити зображення</translation>
+<translation id="8073388330009372546">Відкрити в новій вкладці</translation>
+<translation id="6649642165559792194">Переглянути зображення <ph name="BEGIN_NEW"/>Нове<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Завантажити зображення</translation>
+<translation id="3845332215609790146">Пошук з Об'єктивом <ph name="BEGIN_NEW"/>Новинка<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Шукати зображення в <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Поділитися зображенням</translation>
+<translation id="5833984609253377421">Поділитися посиланням</translation>
+<translation id="6475951671322991020">Завантажити відео</translation>
+<translation id="2317945146070194624">Відкрити в новій вкладці Brave</translation>
+<translation id="7975379999046275268">Переглянути сторінку <ph name="BEGIN_NEW"/>Нове<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Оновлення сторінки</translation>
+<translation id="36525718899759834">Завантажити додаток із магазину Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Темна</translation>
+<translation id="1807246157184219062">Світла</translation>
+<translation id="4056223980640387499">Сепія</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Однакової ширини</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Виберіть вкладку для передавання даних</translation>
+<translation id="8719023831149562936">Неможливо передати дані поточної вкладки</translation>
+<translation id="2139186145475833000">Додати на головний екран</translation>
+<translation id="4616150815774728855">Відкрити файл <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Не вдалося відкрити додаток</translation>
+<translation id="5129038482087801250">Установити веб-додаток</translation>
+<translation id="3789841737615482174">Встановити</translation>
+<translation id="4665282149850138822">Веб-сайт <ph name="NAME"/> додано на головний екран</translation>
+<translation id="7333031090786104871">Попередній сайт ще додається</translation>
+<translation id="1036727731225946849">Додається <ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">Додано на головний екран</translation>
+<translation id="2146738493024040262">Відкрити додаток із миттєвим запуском</translation>
+<translation id="7016516562562142042">Дозволено для поточної пошукової системи</translation>
+<translation id="6177111841848151710">Заблоковано для поточної пошукової системи</translation>
+<translation id="145097072038377568">Вимкнено в налаштуваннях Android</translation>
+<translation id="8007176423574883786">Вимкнено для цього пристрою</translation>
+<translation id="164269334534774161">Ви переглядаєте офлайн-копію цієї сторінки, створену <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Цю сторінку створено <ph name="CREATION_TIME"/>. Вона може відрізнятися від онлайн-версії.</translation>
+<translation id="8840953339110955557">Ця сторінка може відрізнятися від онлайн-версії.</translation>
+<translation id="6405300764336705484">Це вміст із сайту <ph name="DOMAIN_NAME"/>, який доставляє Brave Software.</translation>
+<translation id="1006017844123154345">Відкрити в режимі онлайн</translation>
+<translation id="3326636747541519688">Спрощену сторінку надає Brave Software</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Завантажити оригінальну сторінку<ph name="END_LINK"/> з домену <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Якщо ви часто бачите таку сторінку, скористайтеся цими <ph name="BEGIN_LINK"/>пропозиціями<ph name="END_LINK"/>.</translation>
+<translation id="8748850008226585750">Вміст сховано</translation>
+<translation id="3810973564298564668">Змінити</translation>
+<translation id="5199929503336119739">Робочий профіль</translation>
+<translation id="528192093759286357">Щоб вийти з повноекранного режиму, проведіть пальцем по екрану згори вниз і торкніться кнопки "Назад".</translation>
+<translation id="2836148919159985482">Щоб вийти з повноекранного режиму, торкніться кнопки "Назад".</translation>
+<translation id="3967822245660637423">Завантажено</translation>
+<translation id="2434158240863470628">Завантажено <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Не вдалося завантажити</translation>
+<translation id="1384959399684842514">Завантаження призупинено</translation>
+<translation id="1671236975893690980">Очікується завантаження…</translation>
+<translation id="5561549206367097665">Очікується мережа…</translation>
+<translation id="5864419784173784555">Очікується інше завантаження…</translation>
+<translation id="6461962085415701688">Не вдається відкрити файл</translation>
+<translation id="1178581264944972037">Пауза</translation>
+<translation id="8200772114523450471">Поновити</translation>
+<translation id="1409879593029778104">Файл <ph name="FILE_NAME"/> не завантажено, оскільки він уже є.</translation>
+<translation id="3387650086002190359">Файл <ph name="FILE_NAME"/> не завантажено через помилки файлової системи.</translation>
+<translation id="6482749332252372425">Не вдалося завантажити файл <ph name="FILE_NAME"/>. Замало місця.</translation>
+<translation id="7619072057915878432">Не вдалося завантажити файл <ph name="FILE_NAME"/>. Помилка мережі.</translation>
+<translation id="1477626028522505441">Файл <ph name="FILE_NAME"/> не завантажено через проблеми із сервером.</translation>
+<translation id="3692944402865947621">Не вдалося завантажити файл <ph name="FILE_NAME"/>. Місце зберігання недоступне.</translation>
+<translation id="604996488070107836">Не вдалося завантажити файл <ph name="FILE_NAME"/>. Сталася невідома помилка.</translation>
+<translation id="6738867403308150051">Завантаження…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> КБ</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> МБ</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> ГБ</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Завантажено <ph name="KBS"/> КБ</translation>
+<translation id="6416782512398055893">Завантажено <ph name="MBS"/> МБ</translation>
+<translation id="6538442820324228105">Завантажено <ph name="GBS"/> ГБ</translation>
+<translation id="9204836675896933765">Залишився 1 файл</translation>
+<translation id="8186512483418048923">Залишилося файлів: <ph name="FILES"/></translation>
+<translation id="757855969265046257">{FILES,plural, =1{Завантажено <ph name="FILES_DOWNLOADED_ONE"/> файл}one{Завантажено <ph name="FILES_DOWNLOADED_MANY"/> файл}few{Завантажено <ph name="FILES_DOWNLOADED_MANY"/> файли}many{Завантажено <ph name="FILES_DOWNLOADED_MANY"/> файлів}other{Завантажено <ph name="FILES_DOWNLOADED_MANY"/> файлу}}</translation>
+<translation id="8037750541064988519">Залишилося <ph name="DAYS"/> дн.</translation>
+<translation id="8190358571722158785">Залишився 1 день</translation>
+<translation id="60923314841986378">Залишилося <ph name="HOURS"/> год</translation>
+<translation id="510275257476243843">Залишилась 1 година</translation>
+<translation id="970715775301869095">Залишилося <ph name="MINUTES"/> хв</translation>
+<translation id="3236059992281584593">Залишилась 1 хв</translation>
+<translation id="2777555524387840389">Залишилося <ph name="SECONDS"/> с</translation>
+<translation id="2781151931089541271">Залишилась 1 с</translation>
+<translation id="3303414029551471755">Завантажити вміст?</translation>
+<translation id="8617240290563765734">Перейти за URL-адресою, указаною в завантаженому вмісті?</translation>
+<translation id="1373696734384179344">Недостатньо пам’яті, щоб завантажити вибраний вміст.</translation>
+<translation id="5271967389191913893">Вміст, який ви хочете завантажити, не можна відкрити на цьому пристрої.</translation>
+<translation id="883806473910249246">Не вдалося завантажити вміст.</translation>
+<translation id="5626134646977739690">Ім'я:</translation>
+<translation id="7963646190083259054">Постачальник:</translation>
+<translation id="3414952576877147120">Розмір:</translation>
+<translation id="7375125077091615385">Тип:</translation>
+<translation id="5765780083710877561">Опис:</translation>
+<translation id="4881695831933465202">Відкрити</translation>
+<translation id="3542235761944717775">Доступно <ph name="KILOBYTES"/> КБ</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> МБ доступно</translation>
+<translation id="5424588387303617268">Доступно <ph name="GIGABYTES"/> ГБ</translation>
+<translation id="5793665092639000975">Використано <ph name="SPACE_USED"/> з <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Все</translation>
+<translation id="4988526792673242964">Сторінки</translation>
+<translation id="3810838688059735925">Відео</translation>
+<translation id="3616113530831147358">Аудіо</translation>
+<translation id="9219103736887031265">Зображення</translation>
+<translation id="8250920743982581267">Документи</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# файл}one{# файл}few{# файли}many{# файлів}other{# файлу}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# зображення}one{# зображення}few{# зображення}many{# зображень}other{# зображення}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# відео}one{# відео}few{# відео}many{# відео}other{# відео}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# аудіофайл}one{# аудіофайл}few{# аудіофайли}many{# аудіофайлів}other{# аудіофайлу}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# сторінка}one{# сторінка}few{# сторінки}many{# сторінок}other{# сторінки}}</translation>
+<translation id="5456381639095306749">Завантажити сторінку</translation>
+<translation id="2394602618534698961">Завантажені файли з’являться тут</translation>
+<translation id="7810647596859435254">Відкрити за допомогою…</translation>
+<translation id="5655963694829536461">Пошук у завантаженнях</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Мої файли</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Тут з'являються статті, які можна читати навіть у режимі офлайн</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# год}one{# год}few{# год}many{# год}other{# год}}</translation>
+<translation id="5853623416121554550">призупинено</translation>
+<translation id="8965591936373831584">очікується</translation>
+<translation id="2779651927720337254">не завантажено</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Щойно</translation>
+<translation id="4000212216660919741">Дім у режимі офлайн</translation>
+<translation id="9133397713400217035">Перегляд у режимі офлайн</translation>
+<translation id="968900484120156207">Відвідані сторінки з'являються тут</translation>
+<translation id="7882131421121961860">Історії не знайдено</translation>
+<translation id="3549657413697417275">Пошук в історії</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">ММ</translation>
+<translation id="605721222689873409">РР</translation>
+<translation id="724102042129299115">Перший запуск Brave</translation>
+<translation id="2700285883409956633">Користуючись цим додатком, ви приймаєте <ph name="BEGIN_LINK1"/>Умови використання<ph name="END_LINK1"/> та <ph name="BEGIN_LINK2"/>Примітку про конфіденційність<ph name="END_LINK2"/> Brave.</translation>
+<translation id="1640714894372474981">Користуючись цим додатком, ви приймаєте <ph name="BEGIN_LINK1"/>Умови використання<ph name="END_LINK1"/> та <ph name="BEGIN_LINK2"/>Примітку про конфіденційність<ph name="END_LINK2"/> Brave, а також <ph name="BEGIN_LINK3"/>Примітку про конфіденційність для облікових записів Brave Software, якими можна керувати у Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727">Додаток <ph name="APP_NAME"/> відкриватиметься в Brave. Продовжуючи, ви приймаєте <ph name="BEGIN_LINK1"/>Умови використання<ph name="END_LINK1"/> та <ph name="BEGIN_LINK2"/>Примітку про конфіденційність<ph name="END_LINK2"/> Brave.</translation>
+<translation id="5071615083211946659">Додаток <ph name="APP_NAME"/> відкриватиметься в Brave. Продовжуючи, ви приймаєте <ph name="BEGIN_LINK1"/>Умови використання<ph name="END_LINK1"/> та <ph name="BEGIN_LINK2"/>Примітку про конфіденційність<ph name="END_LINK2"/> Brave, а також <ph name="BEGIN_LINK3"/>Примітку про конфіденційність для облікових записів Brave Software, якими можна керувати у Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Допоможіть покращити Brave, надсилаючи статистику та звіти про збої в Brave Software.</translation>
+<translation id="3518985090088779359">Продовжити</translation>
+<translation id="7207456302801184289">Вітаємо у Brave!</translation>
+<translation id="704822250101715322">Сервіси Brave Software Play оновлюються</translation>
+<translation id="1231733316453485619">Увімкнути синхронізацію?</translation>
+<translation id="5132942445612118989">Синхронізуйте свої паролі, історію тощо на всіх пристроях</translation>
+<translation id="5736731321935944068">Brave Software може використовувати вашу історію, щоб персоналізувати Пошук, оголошення й інші сервіси Brave Software</translation>
+<translation id="4013614219085422040">Brave Software може використовувати вашу історію, щоб персоналізувати Пошук та інші сервіси Brave Software</translation>
+<translation id="5581519193887989363">Ви можете будь-коли вибрати дані для синхронізації в <ph name="BEGIN_LINK1"/>налаштуваннях<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Увімкнути</translation>
+<translation id="2410754283952462441">Виберіть обліковий запис</translation>
+<translation id="2227444325776770048">Продовжити як <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Не <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Щоб мати доступ до закладок на всіх своїх пристроях, увімкніть синхронізацію</translation>
+<translation id="2818669890320396765">Щоб мати доступ до закладок на всіх своїх пристроях, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
+<translation id="6003646045106347985">Щоб отримувати персоналізовані пропозиції від Brave Software, увімкніть синхронізацію</translation>
+<translation id="8494430740943879273">Щоб отримувати персоналізовані пропозиції від Brave Software, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
+<translation id="5862731021271217234">Щоб мати доступ до вкладок з інших пристроїв, увімкніть синхронізацію</translation>
+<translation id="3568688522516854065">Щоб мати доступ до вкладок з інших пристроїв, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
+<translation id="1208340532756947324">Щоб синхронізувати й персоналізувати дані на пристроях, увімкніть синхронізацію</translation>
+<translation id="4472118726404937099">Щоб синхронізувати й персоналізувати дані на пристроях, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
+<translation id="2426805022920575512">Вибрати інший обліковий запис</translation>
+<translation id="6790428901817661496">Відтворити</translation>
+<translation id="1272079795634619415">Зупинити</translation>
+<translation id="2874939134665556319">Попередня композиція</translation>
+<translation id="4046123991198612571">Наступна композиція</translation>
+<translation id="3859306556332390985">Далі</translation>
+<translation id="8441146129660941386">Назад</translation>
+<translation id="6706288973712894588">Зараз ви в режимі офлайн.\n<ph name="BEGIN_LINK"/>Перегляньте автономну стрічку.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Останні вкладки</translation>
+<translation id="8497726226069778601">Тут ще нічого немає…</translation>
+<translation id="5423934151118863508">Тут відображатимуться найчастіше відвідувані сторінки</translation>
+<translation id="6127379762771434464">Веб-сайт видалено</translation>
+<translation id="4605958867780575332">Елемент "<ph name="ITEM_TITLE"/>" вилучено</translation>
+<translation id="1996480094660735607">Дудл Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Інші пристрої</translation>
+<translation id="4738836084190194332">Остання синхронізація: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# хвилину тому}one{# хвилину тому}few{# хвилини тому}many{# хвилин тому}other{# хвилини тому}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# годину тому}one{# годину тому}few{# години тому}many{# годин тому}other{# години тому}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# день тому}one{# день тому}few{# дні тому}many{# днів тому}other{# дня тому}}</translation>
+<translation id="2762000892062317888">щойно</translation>
+<translation id="1407135791313364759">Відкрити все</translation>
+<translation id="1209206284964581585">Приховати</translation>
+<translation id="129553762522093515">Нещодавно закриті</translation>
+<translation id="8413126021676339697">Показати повну історію</translation>
+<translation id="7876243839304621966">Видалити все</translation>
+<translation id="8487700953926739672">Доступ у режимі офлайн</translation>
+<translation id="5224771365102442243">З відео</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Докладніше<ph name="END_LINK"/> про рекомендований контент</translation>
+<translation id="7542481630195938534">Не вдається отримати пропозиції</translation>
+<translation id="5013696553129441713">Немає нових пропозицій</translation>
+<translation id="1736419249208073774">Огляд</translation>
+<translation id="7444811645081526538">Інші категорії</translation>
+<translation id="6709133671862442373">Новини</translation>
+<translation id="1264974993859112054">Спорт</translation>
+<translation id="9139318394846604261">Покупки</translation>
+<translation id="3912508018559818924">Шукаємо найкраще в Інтернеті…</translation>
+<translation id="526421993248218238">Не вдається завантажити цю сторінку</translation>
+<translation id="614940544461990577">Спробуйте:</translation>
+<translation id="3288003805934695103">перезавантажити сторінку</translation>
+<translation id="2353636109065292463">Перевірка інтернет-з’єднання</translation>
+<translation id="2858138569776157458">Популярні сайти</translation>
+<translation id="8364299278605033898">Перегляньте популярні сайти</translation>
+<translation id="1171770572613082465">Натисніть кнопку "Популярні сайти", щоб переглянути їх.</translation>
+<translation id="5233638681132016545">Нова вкладка</translation>
+<translation id="4521874409998847950">Видавець: <ph name="PUBLISHER_ORIGIN"/>, <ph name="BEGIN_DEEMPHASIZED"/>доставлено Brave Software<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Доступна новіша версія</translation>
+<translation id="4058091506841967397">Неможливо оновити Brave</translation>
+<translation id="6316139424528454185">Версія Android несумісна</translation>
+<translation id="6989267951144302301">Не вдалося завантажити</translation>
+<translation id="624789221780392884">Оновлення завершено</translation>
+<translation id="1549000191223877751">Відкрити в іншому вікні</translation>
+<translation id="7481312909269577407">Переслати</translation>
+<translation id="4084682180776658562">Закладка</translation>
+<translation id="6437478888915024427">Інформація про сторінку</translation>
+<translation id="7180611975245234373">Оновити</translation>
+<translation id="4913169188695071480">Припинити оновлення</translation>
+<translation id="1829244130665387512">Знайти на сторінці</translation>
+<translation id="6593061639179217415">Версія для комп’ютера</translation>
+<translation id="9063523880881406963">Вимкнути функцію "Запитувати версію сайту для комп’ютера"</translation>
+<translation id="2038563949887743358">Увімкнути опцію "Запитувати версію сайту для комп’ютера"</translation>
+<translation id="2433507940547922241">Зовнішній вигляд</translation>
+<translation id="983192555821071799">Закрити всі вкладки</translation>
+<translation id="1310482092992808703">Згрупувати вкладки</translation>
+<translation id="7725024127233776428">Сторінки, для яких ви робите закладки, з'являються тут</translation>
+<translation id="4404568932422911380">Немає закладок</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> закладка}one{<ph name="BOOKMARKS_COUNT_MANY"/> закладка}few{<ph name="BOOKMARKS_COUNT_MANY"/> закладки}many{<ph name="BOOKMARKS_COUNT_MANY"/> закладок}other{<ph name="BOOKMARKS_COUNT_MANY"/> закладки}}</translation>
+<translation id="3739899004075612870">Створено закладку в продукті <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Створено закладку</translation>
+<translation id="4452548195519783679">Закладку збережено в папці "<ph name="FOLDER_NAME"/>"</translation>
+<translation id="8063895661287329888">Не вдалося додати закладку.</translation>
+<translation id="2842985007712546952">Батьківська папка</translation>
+<translation id="9065203028668620118">Редагувати</translation>
+<translation id="4405224443901389797">Перемістити в папку…</translation>
+<translation id="5170568018924773124">Показати в папці</translation>
+<translation id="8035133914807600019">Нова папка…</translation>
+<translation id="4532845899244822526">Вибрати папку</translation>
+<translation id="6627583120233659107">Редагувати папку</translation>
+<translation id="1197267115302279827">Перемістити закладки</translation>
+<translation id="6963766334940102469">Видалити закладки</translation>
+<translation id="4351244548802238354">Закрити діалогове вікно</translation>
+<translation id="451872707440238414">Шукати закладки</translation>
+<translation id="8901170036886848654">Немає закладок</translation>
+<translation id="6404511346730675251">Редагувати закладку</translation>
+<translation id="3894427358181296146">Додати папку</translation>
+<translation id="5327248766486351172">Назва</translation>
+<translation id="7400418766976504921">URL-адреса</translation>
+<translation id="3527085408025491307">Папка</translation>
+<translation id="5161254044473106830">Введіть назву</translation>
+<translation id="2996809686854298943">Потрібна URL-адреса</translation>
+<translation id="2536728043171574184">Перегляд копії сторінки в режимі офлайн</translation>
+<translation id="4698034686595694889">Переглядайте вміст у <ph name="APP_NAME"/> без інтернет-з’єднання</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> та інші сайти</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Коли все буде готово, Brave завантажить сторінку}one{Коли все буде готово, Brave завантажить сторінки}few{Коли все буде готово, Brave завантажить сторінки}many{Коли все буде готово, Brave завантажить сторінки}other{Коли все буде готово, Brave завантажить сторінки}}</translation>
+<translation id="6811034713472274749">Сторінка готова для перегляду</translation>
+<translation id="4561979708150884304">Немає з’єднання</translation>
+<translation id="8274165955039650276">Переглянути завантаження</translation>
+<translation id="2082238445998314030">Результат <ph name="RESULT_NUMBER"/> з <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Не знайдено жодного результату</translation>
+<translation id="981121421437150478">Офлайн</translation>
+<translation id="3298243779924642547">Спрощена</translation>
+<translation id="393697183122708255">Голосовий пошук вимкнено</translation>
+<translation id="7191430249889272776">Вкладку відкрито у фоновому режимі.</translation>
+<translation id="8445059357334030806">Відкрити в Brave</translation>
+<translation id="4720023427747327413">Відкрити в <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Відкрити у веб-переглядачі</translation>
+<translation id="1113597929977215864">Показати в режимі спрощеного перегляду</translation>
+<translation id="1513352483775369820">Закладки й історія веб-пошуку</translation>
+<translation id="4939482511480190003">Допоможіть покращити Brave. <ph name="BEGIN_LINK"/>Візьміть участь в опитуванні<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Назад</translation>
+<translation id="5596627076506792578">Інші опції</translation>
+<translation id="3522247891732774234">Доступне оновлення. Більше опцій</translation>
+<translation id="6773423637732432200">Неможливо оновити Brave. Більше опцій</translation>
+<translation id="3328801116991980348">Інформація про сайт</translation>
+<translation id="5391532827096253100">Ваше з’єднання з цим сайтом незахищене. Інформація про сайт</translation>
+<translation id="6206551242102657620">З’єднання безпечне. Інформація про сайт</translation>
+<translation id="6963642900430330478">Ця сторінка небезпечна. Інформація про сайт</translation>
+<translation id="9070377983101773829">Почати голосовий пошук</translation>
+<translation id="8676374126336081632">Видалити введений текст</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> відкрита вкладка: натисніть, щоб перейти на іншу вкладку}one{<ph name="OPEN_TABS_MANY"/> відкрита вкладка: натисніть, щоб перейти на іншу вкладку}few{<ph name="OPEN_TABS_MANY"/> відкриті вкладки: натисніть, щоб перейти на іншу вкладку}many{<ph name="OPEN_TABS_MANY"/> відкритих вкладок: натисніть, щоб перейти на іншу вкладку}other{<ph name="OPEN_TABS_MANY"/> відкритої вкладки: натисніть, щоб перейти на іншу вкладку}}</translation>
+<translation id="2369533728426058518">відкриті вкладки</translation>
+<translation id="7071521146534760487">Керувати обліковим записом</translation>
+<translation id="932327136139879170">Домашня сторінка</translation>
+<translation id="2707726405694321444">Оновити сторінку</translation>
+<translation id="2891154217021530873">Припинити завантаження сторінки</translation>
+<translation id="6710213216561001401">Попереднє</translation>
+<translation id="6659594942844771486">Вкладка</translation>
+<translation id="1933845786846280168">Вибрана вкладка</translation>
+<translation id="2268044343513325586">Уточнити</translation>
+<translation id="7846076177841592234">Скасувати вибір</translation>
+<translation id="7087918508125750058">Вибрано <ph name="ITEM_COUNT"/>. Панель інструментів розташовано вгорі екрана</translation>
+<translation id="7250468141469952378">Вибрано <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Поділитись 1 вибраним елементом}one{Поділитися # вибраним елементом}few{Поділитися # вибраними елементами}many{Поділитися # вибраними елементами}other{Поділитися # вибраного елемента}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Вилучити 1 вибраний елемент}one{Вилучити # вибраний елемент}few{Вилучити # вибрані елементи}many{Вилучити # вибраних елементів}other{Вилучити # вибраного елемента}}</translation>
+<translation id="1283039547216852943">Торкніться, щоб розгорнути</translation>
+<translation id="5962718611393537961">Торкніться, щоб згорнути</translation>
+<translation id="8076492880354921740">Вкладки</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Вибрано 1}one{Вибрано #}few{Вибрано #}many{Вибрано #}other{Вибрано #}}</translation>
+<translation id="6818926723028410516">Виберіть елементи</translation>
+<translation id="4797039098279997504">Торкніться, щоб повернутися на сторінку <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Натисніть, щоб перейти на сайт</translation>
+<translation id="429312253194641664">Сайт відтворює медіа-вміст</translation>
+<translation id="4958708863221495346">Сторінка <ph name="URL_OF_THE_CURRENT_TAB"/> показує ваш екран</translation>
+<translation id="8833831881926404480">Сайт показує ваш екран</translation>
+<translation id="9086455579313502267">Неможливо отримати доступ до мережі</translation>
+<translation id="938850635132480979">Помилка: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Відкрити в програмі <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Відкрити в додатку Карти</translation>
+<translation id="7698359219371678927">Створити електронну адресу в додатку <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Створити електронну адресу</translation>
+<translation id="5665379678064389456">Створити подію в додатку <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Створити подію</translation>
+<translation id="2111511281910874386">Перейти на сторінку</translation>
+<translation id="3988466920954086464">Переглядайте миттєві результати пошуку на цій панелі</translation>
+<translation id="2744248271121720757">Торкніться слова для миттєвого пошуку або перегляду схожих дій</translation>
+<translation id="9155898266292537608">Можете також шукати, швидко торкнувшись слова</translation>
+<translation id="3232754137068452469">Веб-додаток</translation>
+<translation id="1430915738399379752">Друк</translation>
+<translation id="3775705724665058594">Надіслати на пристрої</translation>
+<translation id="6364438453358674297">Вилучити пропозицію з історії?</translation>
+<translation id="213279576345780926">Вкладку "<ph name="TAB_TITLE"/>" закрито</translation>
+<translation id="6850830437481525139">Закрито вкладок: <ph name="TAB_COUNT"/></translation>
+<translation id="3211426585530211793">Елемент "<ph name="ITEM_TITLE"/>" видалено</translation>
+<translation id="4663756553811254707">Видалено закладок: <ph name="NUMBER_OF_BOOKMARKS"/></translation>
+<translation id="3819178904835489326">Видалено завантажених файлів: <ph name="NUMBER_OF_DOWNLOADS"/></translation>
+<translation id="1248710015876067820">Забагато копій Brave.</translation>
+<translation id="4259722352634471385">Веб-сторінку <ph name="URL"/> заблоковано</translation>
+<translation id="8959122750345127698">Веб-сторінка <ph name="URL"/> недоступна</translation>
+<translation id="5210365745912300556">Закрити вкладку</translation>
+<translation id="7772375229873196092">Закрити додаток <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Історія навігації</translation>
+<translation id="9169507124922466868">Історію навігації відкрито на половину висоти</translation>
+<translation id="1327257854815634930">Історію навігації відкрито</translation>
+<translation id="8788265440806329501">Історію навігації закрито</translation>
+<translation id="7482656565088326534">Вкладка "Попередній перегляд"</translation>
+<translation id="8427875596167638501">Вкладку "Попередній перегляд" відкрито на половину висоти</translation>
+<translation id="9102803872260866941">Вкладку "Попередній перегляд" відкрито</translation>
+<translation id="2942036813789421260">Вкладку "Попередній перегляд" закрито</translation>
+<translation id="6355102470683871794">Дані додатка Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Видалити дані сайтів?</translation>
+<translation id="9205995714227143200">Дані сайтів, які Brave визначив як неважливі, зокрема сайтів із незбереженими налаштуваннями або тих, які ви рідко відвідуєте</translation>
+<translation id="3997476611815694295">Неважливі дані</translation>
+<translation id="8493948351860045254">Звільнити місце</translation>
+<translation id="2324920234469020158">Буде видалено файли cookie, кеш та інші дані сайтів, які Brave визначив як неважливі.</translation>
+<translation id="5447201525962359567">Усі дані сайтів, зокрема файли cookie й інші локально збережені дані</translation>
+<translation id="1376578503827013741">Обчислення…</translation>
+<translation id="583281660410589416">Невідомий</translation>
+<translation id="2323763861024343754">Дані сайтів</translation>
+<translation id="3587672679800759167">Усі дані, які використовує Brave, зокрема облікові записи, закладки та збережені налаштування</translation>
+<translation id="6545017243486555795">Видалити всі дані</translation>
+<translation id="4095146165863963773">Видалити дані додатка?</translation>
+<translation id="53119194224775367">Усі дані Brave буде видалено назавжди. Це стосується всіх файлів, налаштувань, облікових записів, баз даних тощо.</translation>
+<translation id="5307446750509046227">Видалити дані сайтів</translation>
+<translation id="300526633675317032">Буде видалено всі дані сайтів (<ph name="SIZE_IN_KB"/>).</translation>
+<translation id="8068648041423924542">Не вдалося вибрати сертифікат.</translation>
+<translation id="2315043854645842844">Операційна система не підтримує сертифікат, вибраний на стороні клієнта.</translation>
+<translation id="5011311129201317034">Сайт <ph name="SITE"/> хоче підключитися</translation>
+<translation id="5308380583665731573">Під’єднатися</translation>
+<translation id="868929229000858085">Пошук у контактах</translation>
+<translation id="1919950603503897840">Виберіть контакти</translation>
+<translation id="7986741934819883144">Виберіть контакт</translation>
+<translation id="3333961966071413176">Усі контакти</translation>
+<translation id="4994033804516042629">Немає контактів</translation>
+<translation id="5403592356182871684">Імена</translation>
+<translation id="2717722538473713889">Електронні адреси</translation>
+<translation id="381841723434055211">Номери телефонів</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ ще 1)}one{(+ ще #)}few{(+ ще #)}many{(+ ще #)}other{(+ ще #)}}</translation>
+<translation id="5197729504361054390">Веб-сайт <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/> отримає доступ до вибраних контактів.</translation>
+<translation id="1779089405699405702">Декодер зображень</translation>
+<translation id="8067883171444229417">Дивитися відео</translation>
+<translation id="6560414384669816528">Шукати за допомогою Sogou</translation>
+<translation id="5406914950576900927">Brave може використовувати <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> для пошуку в Китаї. Це можна змінити в <ph name="BEGIN_LINK"/>Налаштуваннях<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Залишити Brave Software</translation>
+<translation id="4384468725000734951">Пошук за допомогою Sogou</translation>
+<translation id="6103327872225198548">Пошук за допомогою Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Цей додаток запущено в Brave</translation>
+<translation id="6143689084714664628">Відкрито в Brave</translation>
+<translation id="7675869148432102528">Дані додатка <ph name="APP_NAME"/> також містяться в Brave</translation>
+<translation id="2734140769649165081">Ви можете очистити дані в налаштуваннях Brave</translation>
+<translation id="8232956427053453090">Зберігати дані</translation>
+<translation id="4298388696830689168">Зв’язані сайти</translation>
+<translation id="5763514718066511291">Торкніться, щоб скопіювати URL-адресу цього додатка</translation>
+<translation id="6496823230996795692">Щоб запустити додаток <ph name="APP_NAME"/> уперше, під’єднайте пристрій до Інтернету.</translation>
+<translation id="751961395872307827">Немає з’єднання із сайтом</translation>
+<translation id="4878404682131129617">Не вдалося налагодити зв’язок через проксі-сервер</translation>
+<translation id="4749960740855309258">Відкрити нову вкладку</translation>
+<translation id="8788968922598763114">Відкрити останню закриту вкладку</translation>
+<translation id="7929962904089429003">Відкрити меню</translation>
+<translation id="6039379616847168523">Перейти до наступної вкладки</translation>
+<translation id="5210286577605176222">Перейти до попередньої вкладки</translation>
+<translation id="124678866338384709">Закрити поточну вкладку</translation>
+<translation id="3714981814255182093">Відкрити рядок пошуку</translation>
+<translation id="5441522332038954058">Перейти до адресного рядка</translation>
+<translation id="3398320232533725830">Відкрити Диспетчер закладок</translation>
+<translation id="6583199322650523874">Зробити закладку поточної сторінки</translation>
+<translation id="8489271220582375723">Відкрити сторінку "Історія"</translation>
+<translation id="4837753911714442426">Відкрити налаштування друку сторінки</translation>
+<translation id="5726692708398506830">Збільшити всі елементи на сторінці</translation>
+<translation id="3259831549858767975">Зменшити всі елементи на сторінці</translation>
+<translation id="8015452622527143194">Відновити розміри всіх елементів за умовчанням</translation>
+<translation id="3443221991560634068">Оновити поточну сторінку</translation>
+<translation id="123724288017357924">Оновити цю сторінку, ігноруючи кешований вміст</translation>
+<translation id="305870044889644984">Відкрити Довідковий центр Brave у новій вкладці</translation>
+<translation id="3166827708714933426">Комбінації клавіш для роботи з вкладками та вікнами</translation>
+<translation id="3169981355900570544">Комбінації клавіш для функцій Brave Software Brave</translation>
+<translation id="4558311620361989323">Комбінації клавіш для роботи з веб-сторінками</translation>
+<translation id="1908301351964700579">Brave готується до запуску VR. Перезапустіть Brave пізніше.</translation>
+<translation id="8970887620466824814">Сталася помилка.</translation>
+<translation id="1875543012935658554">Знову відкрийте Brave.</translation>
+<translation id="79859296434321399">Щоб переглядати вміст у режимі доповненої реальності, установіть ARCore</translation>
+<translation id="8558485628462305855">Щоб переглядати вміст у режимі доповненої реальності, оновіть ARCore</translation>
+<translation id="3513704683820682405">Доповнена реальність</translation>
+<translation id="5475862044948910901">Почати сеанс у режимі доповненої реальності?</translation>
 <translation id="7365126855094612066">Упродовж цього сеансу сайт зможе:
 • створювати 3D-мапу вашого оточення;
 • відстежувати рух камери.
 
 Цей сайт НЕ отримує доступ до камери. Зображення з камери можете бачити лише ви.</translation>
-<translation id="7375125077091615385">Тип:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL-адреса</translation>
-<translation id="7403691278183511381">Перший запуск Chrome</translation>
-<translation id="741204030948306876">Увімкнути</translation>
-<translation id="7413229368719586778">Дата початку: <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Спершу запитувати</translation>
-<translation id="7423538860840206698">Заборонено переглядати буфер обміну</translation>
-<translation id="7431991332293347422">Указуйте, як використовувати історію веб-перегляду для персоналізації Пошуку тощо</translation>
-<translation id="7437998757836447326">Вихід із Chrome</translation>
-<translation id="7438641746574390233">Коли ввімкнено спрощений режим, Chrome використовує сервери Google, щоб швидше завантажувати сторінки. Спрощений режим переписує дуже повільні сторінки, щоб завантажувати лише основний вміст. Це не стосується анонімних вкладок.</translation>
-<translation id="7444811645081526538">Інші категорії</translation>
-<translation id="7445411102860286510">Дозволити сайтам автоматично відтворювати відео з вимкненим звуком (рекомендується)</translation>
-<translation id="7453467225369441013">Ви вийдете з більшості сайтів, але не вийдете з облікового запису Google.</translation>
-<translation id="7454641608352164238">Замало місця</translation>
-<translation id="7475192538862203634">Якщо ви часто бачите таку сторінку, скористайтеся цими <ph name="BEGIN_LINK" />пропозиціями<ph name="END_LINK" />.</translation>
-<translation id="7475688122056506577">Карту SD не знайдено. Деякі файли можуть бути відсутні.</translation>
-<translation id="7479104141328977413">Керування вкладками</translation>
-<translation id="7481312909269577407">Переслати</translation>
-<translation id="7482656565088326534">Вкладка "Попередній перегляд"</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (оновлено: <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">заощаджений трафік</translation>
-<translation id="7498271377022651285">Зачекайте…</translation>
-<translation id="7514365320538308">Завантажити</translation>
-<translation id="751961395872307827">Немає з’єднання із сайтом</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Не вдається отримати пропозиції</translation>
-<translation id="7559975015014302720">Спрощений режим вимкнено</translation>
-<translation id="7562080006725997899">Очищення даних веб-перегляду</translation>
-<translation id="756809126120519699">Дані Chrome видалено</translation>
-<translation id="757524316907819857">Заборонити сайтам відтворювати захищений вміст</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Завантажено <ph name="FILES_DOWNLOADED_ONE" /> файл}one{Завантажено <ph name="FILES_DOWNLOADED_MANY" /> файл}few{Завантажено <ph name="FILES_DOWNLOADED_MANY" /> файли}many{Завантажено <ph name="FILES_DOWNLOADED_MANY" /> файлів}other{Завантажено <ph name="FILES_DOWNLOADED_MANY" /> файлу}}</translation>
-<translation id="7588219262685291874">Показувати темну тему, коли на пристрої ввімкнено режим енергозбереження</translation>
-<translation id="7589445247086920869">Заблокувати для поточної пошукової системи</translation>
-<translation id="7593557518625677601">Щоб почати синхронізацію Chrome, відкрийте параметри Android і знову ввімкніть синхронізацію системи</translation>
-<translation id="7596558890252710462">Операційна система</translation>
-<translation id="7605594153474022051">Синхронізація не працює</translation>
-<translation id="7606077192958116810">Спрощений режим увімкнено. Керуйте ним у налаштуваннях.</translation>
-<translation id="7612619742409846846">Ви ввійшли в обліковий запис Google як</translation>
-<translation id="7619072057915878432">Не вдалося завантажити файл <ph name="FILE_NAME" />. Помилка мережі.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Отримайте допомогу<ph name="END_LINK1" /> або <ph name="BEGIN_LINK2" />повторіть сканування<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Вітаємо у Chrome!</translation>
-<translation id="7638584964844754484">Неправильна парольна фраза</translation>
-<translation id="7641339528570811325">Очистити історію…</translation>
-<translation id="7648422057306047504">Шифрувати паролі за допомогою облікових даних Google</translation>
-<translation id="7649070708921625228">Довідка</translation>
-<translation id="7658239707568436148">Скасувати</translation>
-<translation id="7665369617277396874">Додати обліковий запис</translation>
-<translation id="766587987807204883">Тут з'являються статті, які можна читати навіть у режимі офлайн</translation>
-<translation id="7682724950699840886">Порада. Переконайтеся, що на пристрої достатньо вільного місця та спробуйте експортувати дані знову.</translation>
-<translation id="7685301384041462804">Перш ніж перейти у VR, переконайтеся, що довіряєте цьому сайту.</translation>
-<translation id="7698359219371678927">Створити електронну адресу в додатку <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Автоматично завершувати пошукові запити та URL-адреси</translation>
-<translation id="7725024127233776428">Сторінки, для яких ви робите закладки, з'являються тут</translation>
-<translation id="773466115871691567">Завжди перекладати сторінки такою мовою: <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Щоб виявляти небезпечні додатки й сайти, Chrome надсилає URL-адреси певних відвіданих сторінок, обмежену системну інформацію та вміст деяких сторінок у Google</translation>
-<translation id="7757787379047923882">Текст, надісланий із пристрою <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Карта SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Додати адресу</translation>
-<translation id="7772032839648071052">Підтвердити парольну фразу</translation>
-<translation id="7772375229873196092">Закрити додаток <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}one{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}few{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}many{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 і ще <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" />}}</translation>
-<translation id="7781829728241885113">Учора</translation>
-<translation id="7791543448312431591">Додати</translation>
-<translation id="780301667611848630">Ні, дякую</translation>
-<translation id="7810647596859435254">Відкрити за допомогою…</translation>
-<translation id="7821588508402923572">Тут буде вказано обсяг заощадженого трафіку</translation>
-<translation id="7837721118676387834">Дозволити автоматичне відтворення відео з вимкненим звуком для певних сайтів.</translation>
-<translation id="7846076177841592234">Скасувати вибір</translation>
-<translation id="784934925303690534">Період часу</translation>
-<translation id="7851858861565204677">Інші пристрої</translation>
-<translation id="7875915731392087153">Створити електронну адресу</translation>
-<translation id="7876243839304621966">Видалити все</translation>
-<translation id="7882131421121961860">Історії не знайдено</translation>
-<translation id="7882806643839505685">Увімкнути звук для певного сайту.</translation>
-<translation id="7886917304091689118">Відкрито в Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Завантажується файл.}one{Завантажується # файл.}few{Завантажується # файли.}many{Завантажується # файлів.}other{Завантажується # файлу.}}</translation>
-<translation id="7929962904089429003">Відкрити меню</translation>
-<translation id="7942131818088350342">Застаріла версія <ph name="PRODUCT_NAME" />.</translation>
-<translation id="7947953824732555851">Прийняти й увійти</translation>
-<translation id="7963646190083259054">Постачальник:</translation>
-<translation id="7971136598759319605">У мережі 1 день тому</translation>
-<translation id="7975379999046275268">Переглянути сторінку <ph name="BEGIN_NEW" />Нове<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Попередньо завантажувати сторінки, щоб швидше переглядати та шукати</translation>
-<translation id="79859296434321399">Щоб переглядати вміст у режимі доповненої реальності, установіть ARCore</translation>
-<translation id="7986741934819883144">Виберіть контакт</translation>
-<translation id="7987073022710626672">Умови використання Google Chrome</translation>
-<translation id="7998918019931843664">Знову відкрити закриту вкладку</translation>
-<translation id="7999064672810608036">Видалити всі локальні дані, зокрема файли cookie, і скинути всі дозволи для цього веб-сайту?</translation>
-<translation id="8004582292198964060">Переглядач</translation>
-<translation id="8007176423574883786">Вимкнено для цього пристрою</translation>
-<translation id="8013372441983637696">Також видалити дані Chrome із цього пристрою</translation>
-<translation id="8015452622527143194">Відновити розміри всіх елементів за умовчанням</translation>
-<translation id="802154636333426148">Не вдалося завантажити</translation>
-<translation id="8026334261755873520">Очистити історію</translation>
-<translation id="8035133914807600019">Нова папка…</translation>
-<translation id="8037750541064988519">Залишилося <ph name="DAYS" /> дн.</translation>
-<translation id="804335162455518893">Карту SD не знайдено</translation>
-<translation id="805047784848435650">На основі історії веб-перегляду</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> МБ доступно</translation>
-<translation id="8058746566562539958">Відкрити в новій вкладці Chrome</translation>
-<translation id="8063895661287329888">Не вдалося додати закладку.</translation>
-<translation id="806745655614357130">Зберігати мої дані окремо</translation>
-<translation id="8067883171444229417">Дивитися відео</translation>
-<translation id="8068648041423924542">Не вдалося вибрати сертифікат.</translation>
-<translation id="8073388330009372546">Відкрити в новій вкладці</translation>
-<translation id="8076492880354921740">Вкладки</translation>
-<translation id="8084114998886531721">Збережений пароль</translation>
-<translation id="8087000398470557479">Це вміст із сайту <ph name="DOMAIN_NAME" />, який доставляє Google.</translation>
-<translation id="8103578431304235997">Анонімна вкладка</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Щоб мати доступ до закладок на всіх своїх пристроях, увімкніть синхронізацію</translation>
-<translation id="8110087112193408731">Показувати активність у Chrome у Цифровому добробуті?</translation>
-<translation id="8116925261070264013">Звук вимкнено</translation>
-<translation id="813082847718468539">Перегляд інформації про сайт</translation>
-<translation id="8131740175452115882">Підтвердити</translation>
-<translation id="8156139159503939589">Якими мовами ви читаєте?</translation>
-<translation id="8168435359814927499">Вміст</translation>
-<translation id="8186512483418048923">Залишилося файлів: <ph name="FILES" /></translation>
-<translation id="8190358571722158785">Залишився 1 день</translation>
-<translation id="8200772114523450471">Поновити</translation>
-<translation id="8209050860603202033">Відкрити зображення</translation>
-<translation id="8218622182176210845">Керувати обліковим записом</translation>
-<translation id="8224471946457685718">Завантажувати статті через Wi-Fi</translation>
-<translation id="8232956427053453090">Зберігати дані</translation>
-<translation id="8249310407154411074">На початок</translation>
-<translation id="8250920743982581267">Документи</translation>
-<translation id="825412236959742607">Ця сторінка використовує забагато пам’яті, тому веб-переглядач Chrome вилучив деякий вміст.</translation>
-<translation id="8260126382462817229">Спробуйте ввійти ще раз</translation>
-<translation id="8261506727792406068">Видалити</translation>
-<translation id="8266862848225348053">Папка для завантажень</translation>
-<translation id="8274165955039650276">Переглянути завантаження</translation>
-<translation id="8284326494547611709">Субтитри</translation>
-<translation id="8300705686683892304">Керуються додатком</translation>
-<translation id="8310344678080805313">Стандартні вкладки</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> та інші сайти</translation>
-<translation id="8327155640814342956">Оновіть Chrome для зручнішого перегляду веб-сторінок</translation>
-<translation id="8339163506404995330">Сторінки цією мовою (<ph name="LANGUAGE" />) не перекладатимуться</translation>
-<translation id="8349013245300336738">Сортувати за кількістю використаного трафіку</translation>
-<translation id="8364299278605033898">Перегляньте популярні сайти</translation>
-<translation id="8368027906805972958">Невідомий чи непідтримуваний пристрій (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">сайті.</translation>
-<translation id="8378714024927312812">Профілем керує ваша організація</translation>
-<translation id="8380167699614421159">Цей сайт показує нав’язливі чи оманливі оголошення</translation>
-<translation id="8393700583063109961">Надіслати повідомлення</translation>
-<translation id="8413126021676339697">Показати повну історію</translation>
-<translation id="8427875596167638501">Вкладку "Попередній перегляд" відкрито на половину висоти</translation>
-<translation id="8428213095426709021">Налаштування</translation>
-<translation id="8438566539970814960">Покращувати пошук і веб-перегляд</translation>
-<translation id="8441146129660941386">Назад</translation>
-<translation id="8443209985646068659">Неможливо оновити Chrome</translation>
-<translation id="8445448999790540984">Не вдається експортувати паролі</translation>
-<translation id="8447861592752582886">Скасувати доступ до пристрою</translation>
-<translation id="8461694314515752532">Шифрувати синхронізовані дані за допомогою власної парольної фрази</translation>
-<translation id="8466613982764129868">Переконайтеся, що пристрій <ph name="TARGET_DEVICE_NAME" /> підключено до Інтернету</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Доступ у режимі офлайн</translation>
-<translation id="8489271220582375723">Відкрити сторінку "Історія"</translation>
-<translation id="8493948351860045254">Звільнити місце</translation>
-<translation id="8497726226069778601">Тут ще нічого немає…</translation>
-<translation id="8503559462189395349">Паролі Chrome</translation>
-<translation id="8503813439785031346">Ім’я користувача</translation>
-<translation id="8514477925623180633">Експортувати паролі, збережені в Chrome</translation>
-<translation id="8514577642972634246">Перейти в режим анонімного перегляду</translation>
-<translation id="851751545965956758">Заборонити сайтам підключатися до пристроїв</translation>
-<translation id="8523928698583292556">Видалити збережений пароль</translation>
-<translation id="854522910157234410">Відкрити цю сторінку</translation>
-<translation id="8558485628462305855">Щоб переглядати вміст у режимі доповненої реальності, оновіть ARCore</translation>
-<translation id="8559990750235505898">Пропозиція перекладати сторінки іншими мовами</translation>
-<translation id="8562452229998620586">Тут відображатимуться збережені паролі.</translation>
-<translation id="8569404424186215731">з <ph name="DATE" /></translation>
-<translation id="8571213806525832805">Останні 4 тижні</translation>
-<translation id="857943718398505171">Дозволено (рекомендується)</translation>
-<translation id="8583805026567836021">Очищення даних облікового запису</translation>
-<translation id="860043288473659153">Ім’я та прізвище власника картки</translation>
-<translation id="8609465669617005112">Угору</translation>
-<translation id="8616006591992756292">Історія веб-перегляду може також зберігатися у вашому обліковому записі Google на сторінці <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Перейти за URL-адресою, указаною в завантаженому вмісті?</translation>
-<translation id="8636825310635137004">Щоб мати доступ до вкладок з інших пристроїв, увімкніть синхронізацію.</translation>
-<translation id="8641930654639604085">Блокувати сайти для дорослих</translation>
-<translation id="8655129584991699539">Ви можете очистити дані в налаштуваннях Chrome</translation>
-<translation id="8662811608048051533">Ви вийдете з більшості сайтів.</translation>
-<translation id="8664979001105139458">Файл із такою назвою вже існує</translation>
-<translation id="8676374126336081632">Видалити введений текст</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Рівень сигналу: # поділка}one{Рівень сигналу: # поділка}few{Рівень сигналу: # поділки}many{Рівень сигналу: # поділок}other{Рівень сигналу: # поділки}}</translation>
-<translation id="868929229000858085">Пошук у контактах</translation>
-<translation id="869891660844655955">Діє до</translation>
-<translation id="8719023831149562936">Неможливо передати дані поточної вкладки</translation>
-<translation id="8725066075913043281">Повторити спробу</translation>
-<translation id="8728487861892616501">Користуючись цим додатком, ви приймаєте <ph name="BEGIN_LINK1" />Умови використання<ph name="END_LINK1" /> та <ph name="BEGIN_LINK2" />Примітку про конфіденційність<ph name="END_LINK2" /> Chrome, а також <ph name="BEGIN_LINK3" />Примітку про конфіденційність для облікових записів Google, якими можна керувати у Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Готово</translation>
-<translation id="8748850008226585750">Вміст сховано</translation>
-<translation id="8751914237388039244">Виберіть зображення</translation>
-<translation id="8788265440806329501">Історію навігації закрито</translation>
-<translation id="8788968922598763114">Відкрити останню закриту вкладку</translation>
-<translation id="8801436777607969138">Блокувати Javascript на певному сайті.</translation>
-<translation id="8812260976093120287">На деяких веб-сайтах ви можна оплачувати за допомогою перелічених вище підтримуваних додатків для платежів на вашому пристрої.</translation>
-<translation id="8816026460808729765">Заборонити сайтам доступ до датчиків</translation>
-<translation id="8816439037877937734">Додаток <ph name="APP_NAME" /> відкриватиметься в Chrome. Продовжуючи, ви приймаєте <ph name="BEGIN_LINK1" />Умови використання<ph name="END_LINK1" /> та <ph name="BEGIN_LINK2" />Примітку про конфіденційність<ph name="END_LINK2" /> Chrome, а також <ph name="BEGIN_LINK3" />Примітку про конфіденційність для облікових записів Google, якими можна керувати у Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Закладки</translation>
-<translation id="8833831881926404480">Сайт показує ваш екран</translation>
-<translation id="883806473910249246">Не вдалося завантажити вміст.</translation>
-<translation id="8840953339110955557">Ця сторінка може відрізнятися від онлайн-версії.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Вкладка "<ph name="TAB_TITLE" />"</translation>
-<translation id="885701979325669005">Обсяг пам’яті</translation>
-<translation id="889338405075704026">Перейти в налаштування Chrome</translation>
-<translation id="8901170036886848654">Немає закладок</translation>
-<translation id="8909135823018751308">Надіслати…</translation>
-<translation id="8912362522468806198">Обліковий запис Google</translation>
-<translation id="8920114477895755567">Очікування даних батьків.</translation>
+<translation id="1188239144602654184">Почати сеанс у режимі доповненої реальності</translation>
+<translation id="473775607612524610">Оновити</translation>
+<translation id="3133489217401741157">Встановлення модуля <ph name="MODULE"/> для Brave…</translation>
+<translation id="1791662854739702043">Установлено</translation>
+<translation id="5131234170665854056">Не вдалося встановити модуль <ph name="MODULE"/> для Brave</translation>
+<translation id="2567385386134582609">ЗОБРАЖЕННЯ</translation>
+<translation id="6395288395575013217">ПОСИЛАННЯ</translation>
+<translation id="7352939065658542140">ВІДЕО</translation>
+<translation id="4116038641877404294">Завантажуйте сторінки, щоб переглядати їх офлайн</translation>
 <translation id="8922289737868596582">Щоб переглядати сторінки офлайн, завантажуйте їх, натиснувши кнопку "Більше опцій"</translation>
-<translation id="8937772741022875483">Видалити активність у Chrome із Цифрового добробуту?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Відкрити в іншому вікні</translation>
-<translation id="8951232171465285730">Chrome заощадив <ph name="MEGABYTES" /> МБ</translation>
-<translation id="8958424370300090006">Блокувати файли cookie з конкретного сайту.</translation>
-<translation id="8959122750345127698">Веб-сторінка <ph name="URL" /> недоступна</translation>
-<translation id="8965591936373831584">очікується</translation>
-<translation id="8970887620466824814">Сталася помилка.</translation>
-<translation id="8972098258593396643">Завантажити в папку за умовчанням?</translation>
-<translation id="8986494364107987395">Автоматично надсилати статистику використання та звіти про аварійне завершення роботи в Google</translation>
-<translation id="8993760627012879038">Відкрити нове вікно в режимі анонімного перегляду</translation>
-<translation id="8998729206196772491">Ви входите в обліковий запис, зареєстрований у домені <ph name="MANAGED_DOMAIN" />, і надаєте його адміністратору доступ до своїх даних Chrome. Ваші дані буде назавжди зв’язано з цим обліковим записом. Якщо ви вийдете з облікового запису в Chrome, дані буде видалено з цього пристрою, але вони залишаться у вашому обліковому записі Google.</translation>
-<translation id="9019902583201351841">Керується батьками</translation>
-<translation id="9028914725102941583">Увімкніть синхронізацію, щоб файли були доступними на всіх ваших пристроях</translation>
-<translation id="9029323097866369874">Дозволити сайту <ph name="DOMAIN" /> перейти у VR?</translation>
-<translation id="9040142327097499898">На цьому пристрої вимкнено геодані. Сповіщення дозволено.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# відео}one{# відео}few{# відео}many{# відео}other{# відео}}</translation>
-<translation id="9050666287014529139">Парольна фраза</translation>
-<translation id="9063523880881406963">Вимкнути функцію "Запитувати версію сайту для комп’ютера"</translation>
-<translation id="9065203028668620118">Редагувати</translation>
-<translation id="9070377983101773829">Почати голосовий пошук</translation>
-<translation id="9074336505530349563">Щоб отримувати персоналізовані пропозиції від Google, увійдіть в обліковий запис і ввімкніть синхронізацію</translation>
-<translation id="9086455579313502267">Неможливо отримати доступ до мережі</translation>
-<translation id="9100505651305367705">Пропонувати статті в режимі спрощеного перегляду, якщо він підтримується</translation>
-<translation id="9100610230175265781">Потрібно вказати парольну фразу</translation>
-<translation id="9102803872260866941">Вкладку "Попередній перегляд" відкрито</translation>
+<translation id="5958275228015807058">Знаходьте свої файли та сторінки в розділі "Завантаження"</translation>
+<translation id="5620928963363755975">Знаходьте свої файли та сторінки в розділі "Завантаження", натиснувши кнопку "Більше опцій"</translation>
+<translation id="3341058695485821946">Перевірте обсяг збережених даних</translation>
+<translation id="3157842584138209013">Перевірте обсяг збережених даних за допомогою кнопки "Більше опцій"</translation>
+<translation id="8218622182176210845">Керувати обліковим записом</translation>
+<translation id="8090895580117672212">Щоб налаштувати обліковий запис Brave Software, натисніть кнопку "Керувати обліковим записом"</translation>
+<translation id="8856898588039823173">Спрощену сторінку надає Brave Software. Натисніть, щоб завантажити оригінал.</translation>
+<translation id="8134317863207426198">Спрощену сторінку надає Brave Software. Торкніться кнопки завантаження оригіналу, щоб отримати вихідну сторінку.</translation>
+<translation id="4961107849584082341">Перекладіть цю сторінку будь-якою мовою</translation>
+<translation id="569536719314091526">Перекладіть цю сторінку будь-якою мовою, натиснувши кнопку "Більше опцій"</translation>
+<translation id="1397811292916898096">Шукати в <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Будь-коли змінюйте папку для завантажень за умовчанням</translation>
+<translation id="6942665639005891494">Будь-коли змінюйте папку для завантажень за умовчанням, використовуючи відповідну опцію в меню "Налаштування"</translation>
+<translation id="6850409657436465440">Завантаження ще триває</translation>
+<translation id="5817715962196959877">Тепер Brave завантажує файли швидше</translation>
+<translation id="3976396876660209797">Вилучити й знову створити цей ярлик</translation>
+<translation id="6766622839693428701">Проведіть пальцем униз, щоб закрити.</translation>
+<translation id="1028699632127661925">Надсилання на пристрій "<ph name="DEVICE_NAME"/>"…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Надіслано з пристрою "<ph name="DEVICE_NAME"/>"</translation>
+<translation id="5357811892247919462">Вкладку отримано</translation>
 <translation id="9104217018994036254">Список пристроїв, з якими можна ділитися вкладкою.</translation>
-<translation id="9133397713400217035">Перегляд у режимі офлайн</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Показати оригінал</translation>
-<translation id="9139068048179869749">Запитувати, перш ніж дозволити сайтам надсилати сповіщення (рекомендується)</translation>
-<translation id="9139318394846604261">Покупки</translation>
-<translation id="9155898266292537608">Можете також шукати, швидко торкнувшись слова</translation>
-<translation id="9169507124922466868">Історію навігації відкрито на половину висоти</translation>
-<translation id="9204836675896933765">Залишився 1 файл</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Список пристроїв, з якими можна ділитися вкладкою, відкрито на половину висоти.</translation>
+<translation id="2904414404539560095">Список пристроїв, на які можна надіслати вкладку, відкрито на всю висоту екрана.</translation>
+<translation id="4135200667068010335">Список пристроїв, на які можна надіслати вкладку, закрито.</translation>
+<translation id="5292796745632149097">Кому надіслати:</translation>
+<translation id="1386674309198842382">У мережі <ph name="LAST_UPDATED"/> дн. тому</translation>
+<translation id="7971136598759319605">У мережі 1 день тому</translation>
+<translation id="1521774566618522728">У мережі сьогодні</translation>
+<translation id="3631987586758005671">Надсилання на пристрій <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Увімкніть синхронізацію, щоб файли були доступними на всіх ваших пристроях</translation>
+<translation id="6162454065885854378">Щоб файли з вашого телефона були доступними на іншому вашому пристрої, увімкніть синхронізацію в налаштуваннях Brave на обох пристроях</translation>
+<translation id="6084271560289605378">Перейти в налаштування Brave</translation>
+<translation id="2318045970523081853">Натисніть, щоб зателефонувати</translation>
 <translation id="9209888181064652401">Неможливо здійснювати виклики</translation>
-<translation id="9219103736887031265">Зображення</translation>
-<translation id="926205370408745186">Видалити активність у Chrome із Цифрового добробуту</translation>
-<translation id="932327136139879170">Домашня сторінка</translation>
-<translation id="938850635132480979">Помилка: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Доступ до мікрофона</translation>
-<translation id="95817756606698420">Chrome може використовувати <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> для пошуку в Китаї. Це можна змінити в <ph name="BEGIN_LINK" />Налаштуваннях<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Блокувати, якщо сайт показує нав’язливі чи оманливі оголошення (рекомендовано)</translation>
-<translation id="968900484120156207">Відвідані сторінки з'являються тут</translation>
-<translation id="970715775301869095">Залишилося <ph name="MINUTES" /> хв</translation>
-<translation id="974555521953189084">Введіть парольну фразу, щоб почати синхронізацію</translation>
-<translation id="981121421437150478">Офлайн</translation>
-<translation id="982182592107339124">Буде видалено дані всіх сайтів, зокрема:</translation>
-<translation id="983192555821071799">Закрити всі вкладки</translation>
-<translation id="987264212798334818">Загальне</translation>
+<translation id="2860954141821109167">Переконайтеся, що на цьому пристрої ввімкнено додаток Телефон</translation>
+<translation id="2067805253194386918">SMS</translation>
+<translation id="1450753235335490080">Не вдалося надіслати: <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Не вдалося надіслати: <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Переконайтеся, що на пристрої <ph name="TARGET_DEVICE_NAME"/> увімкнено синхронізацію в Brave</translation>
+<translation id="3016635187733453316">Перевірте, чи пристрій підключено до Інтернету</translation>
+<translation id="8466613982764129868">Переконайтеся, що пристрій <ph name="TARGET_DEVICE_NAME"/> підключено до Інтернету</translation>
+<translation id="6539092367496845964">Сталася помилка. Спробуйте пізніше.</translation>
+<translation id="3389286852084373014">SMS-повідомлення завелике</translation>
+<translation id="2100314319871056947">Спробуйте надіслати текст меншими частинами</translation>
+<translation id="2987620471460279764">Текст, яким поділилися з іншого пристрою</translation>
+<translation id="7757787379047923882">Текст, надісланий із пристрою <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Скопійовано в буфер обміну</translation>
+<translation id="4696983787092045100">Надіслати SMS на пристрої</translation>
+<translation id="1260236875608242557">Пошук і огляд</translation>
+<translation id="6369229450655021117">Тут можна здійснювати пошук, ділитися вмістом із друзями та переглядати відкриті сторінки.</translation>
+<translation id="723171743924126238">Вибрати зображення</translation>
+<translation id="8751914237388039244">Виберіть зображення</translation>
+<translation id="1989112275319619282">Переглянути</translation>
+<translation id="7055152154916055070">Переадресацію заблоковано:</translation>
+<translation id="5524843473235508879">Переспрямування заблоковано.</translation>
+<translation id="6573096386450695060">Завжди дозволяти</translation>
+<translation id="5805364706385912897">Ця сторінка займає велику кількість пам’яті, тому Brave призупинив її роботу.</translation>
+<translation id="5138664332909611586">Ця сторінка використовує забагато пам’яті, тому веб-переглядач Brave вилучив деякий вміст.</translation>
+<translation id="9137013805542155359">Показати оригінал</translation>
+<translation id="6361779936989026201">Brave Software Асистент у Brave</translation>
+<translation id="7291387454912369099">Оплата за допомогою Асистента</translation>
+<translation id="4565206163201411670">Показувати активність у Brave у Цифровому добробуті?</translation>
+<translation id="9055113864158719823">Ви можете переглянути відвідані в Brave сайти та встановити таймери для них.\n\nBrave Software отримує дані про те, для яких сайтів ви встановлюєте таймери, а також відомості про тривалість перебування на них. Ця інформація використовується для покращення Цифрового добробуту.</translation>
+<translation id="4596514158372210596">Видалити активність у Brave із Цифрового добробуту</translation>
+<translation id="1174893863889683998">Видалити активність у Brave із Цифрового добробуту?</translation>
+<translation id="708829030563435351">Відвідані в Brave веб-сайти не відображатимуться. Усі таймери для них буде видалено.</translation>
+<translation id="2056878612599315956">Роботу сайту призупинено</translation>
+<translation id="671481426037969117">Вийшов час на таймері веб-сайту <ph name="FQDN"/>. Завтра він знову запрацює.</translation>
+<translation id="7479104141328977413">Керування вкладками</translation>
+<translation id="3524138585025253783">Інтерфейс розробника</translation>
+<translation id="6036057147555329831">Зайвий модуль ICU</translation>
+<translation id="9029323097866369874">Дозволити сайту <ph name="DOMAIN"/> перейти у VR?</translation>
+<translation id="7685301384041462804">Перш ніж перейти у VR, переконайтеся, що довіряєте цьому сайту.</translation>
+<translation id="5033865233969348410">Під час сеансу VR цей сайт може розпізнавати:
+  - ваші фізичні особливості, як-от зріст.
+
+Перш ніж перейти у VR, переконайтеся, що довіряєте цьому сайту.</translation>
+<translation id="5534334044554683961">Під час сеансу VR цей сайт може розпізнавати:
+  - ваші фізичні особливості, як-от зріст;
+  - вигляд вашої кімнати.
+
+Перш ніж перейти у VR, переконайтеся, що довіряєте цьому сайту.</translation>
+<translation id="4169535189173047238">Не дозволяти</translation>
+<translation id="2170088579611075216">Перейти у VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_vi.xtb
+++ b/android/java/strings/translations/android_chrome_strings_vi.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="vi">
-<translation id="1006017844123154345">Mở trực tuyến</translation>
-<translation id="1028699632127661925">Đang gửi đến <ph name="DEVICE_NAME" />...</translation>
-<translation id="1036727731225946849">Đang thêm <ph name="WEBAPK_NAME" />...</translation>
-<translation id="1041308826830691739">Từ trang web</translation>
-<translation id="1049743911850919806">Ẩn danh</translation>
-<translation id="10614374240317010">Không bao giờ lưu</translation>
-<translation id="1067922213147265141">Các dịch vụ khác của Google</translation>
-<translation id="1068672505746868501">Không bao giờ dịch các trang viết bằng <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="107147699690128016">Nếu bạn thay đổi đuôi tệp, thì tệp có thể mở trong một ứng dụng khác và tiềm ẩn nguy cơ đối với thiết bị.</translation>
-<translation id="1100066534610197918">Mở trong tab mới trong nhóm</translation>
-<translation id="1105960400813249514">Chụp ảnh màn hình</translation>
-<translation id="1111673857033749125">Dấu trang được lưu trên thiết bị khác của bạn sẽ xuất hiện tại đây.</translation>
-<translation id="1113597929977215864">Hiển thị chế độ xem đơn giản</translation>
-<translation id="1121094540300013208">Báo cáo sử dụng và sự cố</translation>
-<translation id="1124772482545689468">Người dùng</translation>
-<translation id="1129510026454351943">Chi tiết: <ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 tệp đang chờ tải xuống.}other{# tệp đang chờ tải xuống.}}</translation>
-<translation id="1145536944570833626">Xóa dữ liệu hiện có.</translation>
-<translation id="1146678959555564648">Nhập VR</translation>
-<translation id="116280672541001035">Đã sử dụng</translation>
-<translation id="1171770572613082465">Xem các trang web phổ biến bằng cách nhấn vào nút "Trang web hàng đầu"</translation>
-<translation id="1173894706177603556">Đổi tên</translation>
-<translation id="1178581264944972037">Tạm dừng</translation>
-<translation id="1181037720776840403">Xóa</translation>
-<translation id="1188239144602654184">Chuyển sang thực tế tăng cường</translation>
-<translation id="1197267115302279827">Di chuyển dấu trang</translation>
-<translation id="119944043368869598">Xóa tất cả</translation>
-<translation id="1201402288615127009">Tiếp theo</translation>
-<translation id="1204037785786432551">Tải liên kết xuống</translation>
-<translation id="1206892813135768548">Sao chép văn bản liên kết</translation>
-<translation id="1208340532756947324">Để đồng bộ hóa và cá nhân hóa trên các thiết bị, hãy bật tính năng đồng bộ hóa</translation>
-<translation id="1209206284964581585">Ẩn ngay bây giờ</translation>
-<translation id="1227058898775614466">Lịch sử di chuyển</translation>
-<translation id="1231733316453485619">Bạn muốn bật tính năng đồng bộ hóa?</translation>
-<translation id="123724288017357924">Tải lại trang hiện tại, bỏ qua nội dung được lưu trong bộ nhớ đệm</translation>
-<translation id="124116460088058876">Ngôn ngữ khác</translation>
-<translation id="124678866338384709">Đóng tab hiện tại</translation>
-<translation id="1258753120186372309">Hình tượng trưng của Google: <ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">Tìm kiếm và khám phá</translation>
-<translation id="1264974993859112054">Thể thao</translation>
-<translation id="1266864766717917324">Không thể chia sẻ <ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">Dừng</translation>
-<translation id="1283039547216852943">Nhấn để mở rộng</translation>
-<translation id="1285320974508926690">Không bao giờ dịch trang web này</translation>
-<translation id="1291207594882862231">Xóa lịch sử, cookie, dữ liệu trang web, bộ nhớ đệm…</translation>
-<translation id="129382876167171263">Những tệp mà trang web lưu lại sẽ xuất hiện ở đây</translation>
-<translation id="129553762522093515">Các tab đã đóng gần đây</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> – Gửi từ <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">Nhóm các tab</translation>
-<translation id="1327257854815634930">Lịch sử di chuyển đang mở</translation>
-<translation id="1331212799747679585">Chrome không thể cập nhật. Tùy chọn khác</translation>
-<translation id="1332501820983677155">Phím tắt cho các tính năng của Google Chrome</translation>
-<translation id="1360432990279830238">Đăng xuất và tắt tính năng đồng bộ hóa?</translation>
-<translation id="1369915414381695676">Đã thêm trang web <ph name="SITE_NAME" /></translation>
-<translation id="1373696734384179344">Không đủ bộ nhớ để tải xuống nội dung được chọn.</translation>
-<translation id="1376578503827013741">Đang tính toán...</translation>
-<translation id="1383876407941801731">Tìm kiếm</translation>
-<translation id="1384959399684842514">Đã tạm dừng quá trình tải xuống</translation>
-<translation id="1386674309198842382">Hoạt động <ph name="LAST_UPDATED" /> ngày trước</translation>
-<translation id="1397811292916898096">Tìm kiếm bằng <ph name="PRODUCT_NAME" /></translation>
-<translation id="1404122904123200417">Được nhúng trong <ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“Không theo dõi”</translation>
-<translation id="1407135791313364759">Mở tất cả</translation>
-<translation id="1409426117486808224">Chế độ xem đơn giản cho tab đang mở</translation>
-<translation id="1409879593029778104">Đã ngăn tải xuống <ph name="FILE_NAME" /> do tệp này đã tồn tại.</translation>
-<translation id="1414981605391750300">Đang liên hệ với Google. Quá trình này có thể mất ít phút…</translation>
-<translation id="1416550906796893042">Phiên bản ứng dụng</translation>
-<translation id="1430915738399379752">In</translation>
-<translation id="1446450296470737166">Cho phép kiểm soát hoàn toàn thiết bị MIDI</translation>
-<translation id="1450753235335490080">Không thể chia sẻ <ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">Tắt trong Cài đặt Android</translation>
-<translation id="1477626028522505441">Tải xuống <ph name="FILE_NAME" /> không thành công do sự cố máy chủ.</translation>
-<translation id="1506061864768559482">Công cụ tìm kiếm</translation>
-<translation id="1513352483775369820">Dấu trang và lịch sử web</translation>
-<translation id="1513858653616922153">Xóa mật khẩu</translation>
-<translation id="1516229014686355813">Tính năng Nhấn để tìm kiếm sẽ gửi từ đã chọn và trang hiện tại dưới dạng ngữ cảnh cho Google Tìm kiếm. Bạn có thể tắt tính năng này trong mục <ph name="BEGIN_LINK" />Cài đặt<ph name="END_LINK" />.</translation>
-<translation id="1521774566618522728">Hoạt động hôm nay</translation>
-<translation id="1544826120773021464">Để quản lý Tài khoản Google của bạn, hãy nhấn vào nút "Quản lý tài khoản"</translation>
-<translation id="1549000191223877751">Di chuyển đến cửa sổ khác</translation>
-<translation id="1553358976309200471">Cập nhật Chrome</translation>
-<translation id="1569387923882100876">Thiết bị đã kết nối</translation>
-<translation id="1571304935088121812">Sao chép tên người dùng</translation>
-<translation id="1612196535745283361">Chrome cần có quyền truy cập vị trí để quét tìm thiết bị. Tính năng truy cập vị trí bị <ph name="BEGIN_LINK" />tắt cho thiết bị này<ph name="END_LINK" />.</translation>
-<translation id="1620510694547887537">Máy ảnh</translation>
-<translation id="1623104350909869708">Ngăn trang này tạo hộp thoại bổ sung</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Xóa 1 mục đã chọn}other{Xóa # mục đã chọn}}</translation>
-<translation id="164269334534774161">Bạn đang xem bản sao ngoại tuyến của trang này từ <ph name="CREATION_TIME" /></translation>
-<translation id="1644574205037202324">Lịch sử</translation>
-<translation id="1647391597548383849">Truy cập máy ảnh của bạn</translation>
-<translation id="1660204651932907780">Cho phép các trang web phát âm thanh (được đề xuất)</translation>
-<translation id="1670399744444387456">Cơ bản</translation>
-<translation id="1671236975893690980">Đang chờ tải xuống...</translation>
-<translation id="1672586136351118594">Không hiển thị lại</translation>
-<translation id="1692118695553449118">Đồng bộ hóa đang bật</translation>
-<translation id="169515064810179024">Chặn không cho các trang web sử dụng cảm biến chuyển động</translation>
-<translation id="1717218214683051432">Cảm biến chuyển động</translation>
-<translation id="1718835860248848330">Giờ vừa qua</translation>
-<translation id="1736419249208073774">Khám phá</translation>
-<translation id="1743802530341753419">Hỏi trước khi cho phép trang web kết nối với một thiết bị (khuyên dùng)</translation>
-<translation id="1749561566933687563">Đồng bộ hóa dấu trang của bạn</translation>
-<translation id="17513872634828108">Tab đang mở</translation>
-<translation id="1779089405699405702">Bộ giải mã hình ảnh</translation>
-<translation id="1782483593938241562">Ngày kết thúc <ph name="DATE" /></translation>
-<translation id="1791662854739702043">Đã cài đặt</translation>
-<translation id="1792959175193046959">Thay đổi vị trí tải xuống mặc định bất cứ lúc nào</translation>
-<translation id="1807246157184219062">Sáng</translation>
-<translation id="1810845389119482123">Chưa hoàn tất quá trình thiết lập đồng bộ hóa ban đầu</translation>
-<translation id="1821253160463689938">Sử dụng cookie để ghi nhớ tùy chọn của bạn, ngay cả khi bạn không truy cập vào các trang đó</translation>
-<translation id="1829244130665387512">Tìm trong trang</translation>
-<translation id="1853692000353488670">Tab ẩn danh mới</translation>
-<translation id="1856325424225101786">Đặt lại Chế độ thu gọn?</translation>
-<translation id="1868024384445905608">Giờ đây, Chrome tải tệp xuống còn nhanh hơn nữa</translation>
-<translation id="1883903952484604915">Tệp của tôi</translation>
-<translation id="1887786770086287077">Đã tắt quyền truy cập vị trí đối với thiết bị này. Hãy bật trong <ph name="BEGIN_LINK" />Cài đặt Android<ph name="END_LINK" />.</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" /> sẽ mở trong Chrome. Bằng việc tiếp tục, bạn đồng ý với <ph name="BEGIN_LINK1" />Điều khoản dịch vụ<ph name="END_LINK1" /> và <ph name="BEGIN_LINK2" />Thông báo bảo mật<ph name="END_LINK2" /> của Chrome.</translation>
-<translation id="1919345977826869612">Quảng cáo</translation>
-<translation id="1919950603503897840">Chọn mục liên hệ</translation>
-<translation id="1922076542920281912">Để cho phép Chrome truy cập vào vị trí của bạn, hãy bật cả vị trí trong phần <ph name="BEGIN_LINK" />Cài đặt của Android<ph name="END_LINK" />.</translation>
-<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">Số lần cập nhật</translation>
-<translation id="19288952978244135">Mở lại Chrome.</translation>
-<translation id="1933845786846280168">Tab được chọn</translation>
-<translation id="194341124344773587">Bật quyền cho Chrome trong <ph name="BEGIN_LINK" />Cài đặt Android<ph name="END_LINK" />.</translation>
-<translation id="1943432128510653496">Lưu mật khẩu</translation>
-<translation id="1952172573699511566">Các trang web sẽ hiển thị văn bản bằng ngôn ngữ ưu tiên của bạn khi có thể.</translation>
-<translation id="1960290143419248813">Các bản cập nhật Chrome không còn được hỗ trợ cho phiên bản Android này</translation>
-<translation id="1966710179511230534">Vui lòng cập nhật chi tiết đăng nhập của bạn.</translation>
-<translation id="1974060860693918893">Nâng cao</translation>
-<translation id="1984705450038014246">Đồng bộ hóa dữ liệu của bạn trên Chrome</translation>
-<translation id="1984937141057606926">Được cho phép, ngoại trừ cookie của bên thứ ba</translation>
-<translation id="1986685561493779662">Tên đã tồn tại</translation>
-<translation id="1987739130650180037">Nút <ph name="MESSAGE" /> <ph name="LINK_NAME" /></translation>
-<translation id="1989112275319619282">Duyệt qua</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> muốn ghép nối</translation>
-<translation id="1994173015038366702">URL trang web</translation>
-<translation id="2000419248597011803">Gửi một số cookie và nội dung tìm kiếm từ thanh địa chỉ cũng như hộp tìm kiếm tới công cụ tìm kiếm mặc định</translation>
-<translation id="2002537628803770967">Thẻ tín dụng và địa chỉ lưu trong Google Pay</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# tệp}other{# tệp}}</translation>
-<translation id="2017836877785168846">Xóa lịch sử duyệt web và nội dung tự động hoàn thành trong thanh địa chỉ.</translation>
-<translation id="2021896219286479412">Kiểm soát trang toàn màn hình</translation>
-<translation id="2038563949887743358">Bật Yêu cầu trang web cho máy tính</translation>
-<translation id="2041019821020695769">Để Chrome có thể gửi cho bạn thông báo, hãy bật cả thông báo trong phần <ph name="BEGIN_LINK" />Cài đặt của Android<ph name="END_LINK" />.</translation>
-<translation id="204321170514947529"><ph name="APP_NAME" /> cũng có dữ liệu trong Chrome</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">Đã tạm dừng trang web</translation>
-<translation id="2063713494490388661">Nhấn để tìm kiếm</translation>
-<translation id="2067805253194386918">văn bản</translation>
-<translation id="2079545284768500474">Hoàn tác</translation>
-<translation id="2082238445998314030">Kết quả <ph name="RESULT_NUMBER" /> trong tổng số <ph name="TOTAL_RESULTS" /></translation>
-<translation id="2091887806945687916">Âm thanh</translation>
-<translation id="2096012225669085171">Đồng bộ hóa và cá nhân hóa trên các thiết bị</translation>
-<translation id="2100273922101894616">Tự động đăng nhập</translation>
-<translation id="2100314319871056947">Hãy thử chia sẻ văn bản theo các đoạn nhỏ hơn</translation>
-<translation id="2107397443965016585">Hỏi trước khi cho phép trang web phát nội dung được bảo vệ (khuyên dùng)</translation>
-<translation id="2111511281910874386">Chuyển đến trang</translation>
-<translation id="2122601567107267586">Không thể mở ứng dụng</translation>
-<translation id="2126426811489709554">Được hỗ trợ bởi Chrome</translation>
-<translation id="2131665479022868825">Đã tiết kiệm <ph name="DATA" /></translation>
-<translation id="213279576345780926">Đã đóng <ph name="TAB_TITLE" /></translation>
-<translation id="2139186145475833000">Thêm vào Màn hình chính</translation>
-<translation id="2146738493024040262">Mở ứng dụng tức thì</translation>
-<translation id="2148716181193084225">Hôm nay</translation>
-<translation id="2154484045852737596">Chỉnh sửa thẻ</translation>
-<translation id="2154710561487035718">Sao chép URL</translation>
-<translation id="2156074688469523661">Số trang web còn lại (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">Để chia sẻ nội dung trên điện thoại của bạn với một thiết bị khác, hãy bật tính năng đồng bộ hóa trong phần Cài đặt của Chrome trên cả hai thiết bị</translation>
-<translation id="2170088579611075216">Cho phép và chuyển sang thực tế ảo</translation>
-<translation id="218608176142494674">Chia sẻ</translation>
-<translation id="2227444325776770048">Tiếp tục bằng <ph name="USER_FULL_NAME" /></translation>
-<translation id="2234876718134438132">Đồng bộ hóa và các dịch vụ của Google</translation>
-<translation id="2259659629660284697">Xuất mật khẩu...</translation>
-<translation id="2268044343513325586">Tinh chỉnh</translation>
-<translation id="2286841657746966508">Địa chỉ thanh toán</translation>
-<translation id="2289270750774289114">Hỏi khi một trang web muốn tìm các thiết bị Bluetooth ở gần (khuyên dùng)</translation>
-<translation id="230115972905494466">Không tìm thấy thiết bị tương thích</translation>
-<translation id="2315043854645842844">Lựa chọn chứng chỉ phía ứng dụng khách không được hệ điều hành hỗ trợ.</translation>
-<translation id="2318045970523081853">Nhấn để gọi điện</translation>
-<translation id="2321086116217818302">Đang chuẩn bị mật khẩu…</translation>
-<translation id="2321958826496381788">Kéo thanh trượt cho đến khi bạn có thể đọc nội dung này thoải mái. Chữ tối thiểu phải to như này sau khi bấm đúp vào một đoạn.</translation>
-<translation id="2323763861024343754">Bộ nhớ trang web</translation>
-<translation id="2328985652426384049">Không thể đăng nhập</translation>
-<translation id="2330129964253841015">Cảnh báo bạn nếu mật khẩu bị lộ</translation>
-<translation id="2349710944427398404">Tổng số dữ liệu mà Chrome sử dụng, bao gồm tài khoản, dấu trang và cài đặt đã lưu</translation>
-<translation id="2353636109065292463">Kiểm tra kết nối Internet</translation>
-<translation id="2359808026110333948">Tiếp tục</translation>
-<translation id="2369533728426058518">tab đang mở</translation>
-<translation id="2387895666653383613">Chia tỷ lệ văn bản</translation>
-<translation id="2394602618534698961">Các tệp bạn tải xuống sẽ xuất hiện ở đây</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">Khi bạn đăng nhập vào Tài khoản Google của mình, tính năng này sẽ được bật</translation>
-<translation id="2410754283952462441">Chọn một tài khoản</translation>
-<translation id="2414886740292270097">Tối</translation>
-<translation id="2416359993254398973">Chrome cần có quyền truy cập máy ảnh của bạn cho trang web này.</translation>
-<translation id="2426805022920575512">Chọn một tài khoản khác</translation>
-<translation id="2433507940547922241">Hình thức</translation>
-<translation id="2434158240863470628">Quá trình tải xuống hoàn tất <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">Truy cập vị trí</translation>
-<translation id="2450083983707403292">Bạn có muốn bắt đầu tải xuống <ph name="FILE_NAME" /> lần nữa không?</translation>
-<translation id="2482878487686419369">Thông báo</translation>
-<translation id="2490684707762498678">Do <ph name="APP_NAME" /> quản lý</translation>
-<translation id="2494974097748878569">Trợ lý Google trong Chrome</translation>
-<translation id="2496180316473517155">Lịch sử duyệt web</translation>
-<translation id="2497852260688568942">Đồng bộ hóa bị quản trị viên của bạn tắt</translation>
-<translation id="2498359688066513246">Trợ giúp và phản hồi</translation>
-<translation id="2501278716633472235">Quay lại</translation>
-<translation id="2513403576141822879">Bạn có thể xem thêm tùy chọn cài đặt liên quan đến quyền riêng tư, bảo mật và hoạt động thu thập dữ liệu trong phần <ph name="BEGIN_LINK" />Đồng bộ hóa và dịch vụ của Google<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">Ở Chế độ thu gọn, Chrome tải trang nhanh hơn và sử dụng ít dữ liệu hơn lên tới 60%. Để tối ưu hóa các trang bạn truy cập, Chrome sẽ gửi lưu lượng truy cập web của bạn cho Google. <ph name="BEGIN_LINK" />Tìm hiểu thêm<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">Gửi cho Google URL của các trang bạn truy cập</translation>
-<translation id="2532336938189706096">Lượt xem trên web</translation>
-<translation id="2534155362429831547">Đã xóa <ph name="NUMBER_OF_ITEMS" /> mục</translation>
-<translation id="2536728043171574184">Xem bản sao ngoại tuyến của trang này</translation>
-<translation id="2546283357679194313">Cookie và dữ liệu trang web</translation>
-<translation id="2567385386134582609">HÌNH ẢNH</translation>
-<translation id="257088987046510401">Chủ đề</translation>
-<translation id="2570922361219980984">Quyền truy cập vị trí cũng đã bị tắt đối với thiết bị này. Hãy bật trong <ph name="BEGIN_LINK" />Cài đặt Android<ph name="END_LINK" />.</translation>
-<translation id="257931822824936280">Đã mở rộng - nhấp để thu gọn.</translation>
-<translation id="2581165646603367611">Thao tác này sẽ xóa cookie, bộ nhớ đệm và các dữ liệu khác của các trang web mà Chrome cho rằng không quan trọng.</translation>
-<translation id="2586657967955657006">Khay nhớ tạm</translation>
-<translation id="2587052924345400782">Đã có phiên bản mới hơn</translation>
-<translation id="2593272815202181319">Monospace</translation>
-<translation id="2612676031748830579">Số thẻ</translation>
-<translation id="2621115761605608342">Cho phép JavaScript cho trang web cụ thể.</translation>
-<translation id="2625189173221582860">Đã sao chép mật khẩu</translation>
-<translation id="2631006050119455616">Đã tiết kiệm</translation>
-<translation id="2647434099613338025">Thêm ngôn ngữ</translation>
-<translation id="2650751991977523696">Tải tệp xuống lần nữa?</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# tệp âm thanh}other{# tệp âm thanh}}</translation>
-<translation id="2653659639078652383">Gửi</translation>
-<translation id="2677748264148917807">Rời khỏi</translation>
-<translation id="2704606927547763573">Đã sao chép</translation>
-<translation id="2707726405694321444">Làm mới trang</translation>
-<translation id="2709516037105925701">Tự động điền</translation>
-<translation id="2717722538473713889">Địa chỉ email</translation>
-<translation id="2728754400939377704">Sắp xếp theo trang web</translation>
-<translation id="2744248271121720757">Hãy nhấn vào một từ để tìm kiếm ngay hoặc xem các hành động có liên quan</translation>
-<translation id="2760989362628427051">Bật giao diện tối khi Trình tiết kiệm pin hoặc giao diện tối trên thiết bị đang bật</translation>
-<translation id="2762000892062317888">vừa xong</translation>
-<translation id="2777555524387840389">Còn <ph name="SECONDS" /> giây</translation>
-<translation id="2779651927720337254">không tải xuống được</translation>
-<translation id="2781151931089541271">Còn 1 giây</translation>
-<translation id="2801022321632964776">Hãy cập nhật để dùng ngôn ngữ của bạn trong phiên bản Chrome mới nhất</translation>
-<translation id="2810645512293415242">Trang đơn giản giúp lưu dữ liệu và tải nhanh hơn.</translation>
-<translation id="281504910091592009">Xem và quản lý các mật khẩu đã lưu trong <ph name="BEGIN_LINK" />Tài khoản Google<ph name="END_LINK" /> của bạn</translation>
-<translation id="2818669890320396765">Để sử dụng dấu trang trên tất cả các thiết bị, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
-<translation id="2822354292072154809">Bạn có chắc muốn đặt lại tất cả các quyền của trang web cho <ph name="CHOSEN_OBJECT_NAME" /> không?</translation>
-<translation id="2836148919159985482">Chạm vào nút quay lại để thoát khỏi chế độ toàn màn hình.</translation>
-<translation id="2842985007712546952">Thư mục mẹ</translation>
-<translation id="2858138569776157458">Trang web hàng đầu</translation>
-<translation id="2860954141821109167">Hãy đảm bảo bạn đã bật ứng dụng điện thoại trên thiết bị này</translation>
-<translation id="2870560284913253234">Trang web</translation>
-<translation id="2874939134665556319">Bản nhạc trước</translation>
-<translation id="2876369937070532032">Gửi URL của một số trang mà bạn truy cập cho Google khi bạn gặp rủi ro về bảo mật</translation>
-<translation id="2888126860611144412">Giới thiệu về Chrome</translation>
-<translation id="2891154217021530873">Ngừng tải trang</translation>
-<translation id="2893180576842394309">Google có thể sử dụng lịch sử của bạn để điều chỉnh tính năng Tìm kiếm và các dịch vụ khác của Google cho phù hợp với bạn</translation>
-<translation id="2898264748040935573">Chỉnh sửa mật khẩu đã lưu trữ</translation>
-<translation id="2900528713135656174">Tạo sự kiện</translation>
-<translation id="290376772003165898">Trang này không được viết bằng <ph name="LANGUAGE" />?</translation>
-<translation id="2904414404539560095">Danh sách các thiết bị mà bạn có thể chia sẻ một tab đã mở trên toàn màn hình.</translation>
-<translation id="2910701580606108292">Hỏi trước khi cho phép trang web phát nội dung được bảo vệ</translation>
-<translation id="2913331724188855103">Cho phép trang web lưu và đọc dữ liệu cookie (được đề xuất)</translation>
-<translation id="2923908459366352541">Tên không hợp lệ</translation>
-<translation id="2932150158123903946">Bộ nhớ Google <ph name="APP_NAME" /></translation>
-<translation id="2942036813789421260">Tab xem trước đang đóng</translation>
-<translation id="2956410042958133412">Tài khoản này do <ph name="PARENT_NAME_1" /> và <ph name="PARENT_NAME_2" /> quản lý.</translation>
-<translation id="2962095958535813455">Đã chuyển sang tab ẩn danh</translation>
-<translation id="2968755619301702150">Trình xem chứng chỉ</translation>
-<translation id="2979025552038692506">Tab ẩn danh được chọn</translation>
-<translation id="2987620471460279764">Văn bản được chia sẻ từ thiết bị khác</translation>
-<translation id="2989523299700148168">Đã truy cập gần đây</translation>
-<translation id="2996291259634659425">Tạo cụm mật khẩu</translation>
-<translation id="2996809686854298943">Cần có URL</translation>
-<translation id="300526633675317032">Thao tác này sẽ xóa tất cả <ph name="SIZE_IN_KB" /> bộ nhớ trang web.</translation>
-<translation id="3016635187733453316">Hãy đảm bảo thiết bị này có kết nối Internet</translation>
-<translation id="3029613699374795922">Đã tải xuống <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">Cụm mật khẩu không khớp</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />Nhận trợ giúp<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">Đã tắt vị trí; hãy bật vị trí trong mục <ph name="BEGIN_LINK" />Cài đặt Android<ph name="END_LINK" />.</translation>
-<translation id="3058498974290601450">Bạn có thể bật tính năng đồng bộ hóa bất cứ lúc nào trong phần cài đặt</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> dấu trang}other{<ph name="BOOKMARKS_COUNT_MANY" /> dấu trang}}</translation>
-<translation id="3089395242580810162">Mở trong tab ẩn danh</translation>
-<translation id="3115898365077584848">Hiển thị thông tin</translation>
-<translation id="3123473560110926937">Đã chặn trên một số trang web</translation>
-<translation id="3137521801621304719">Thoát chế độ ẩn danh</translation>
-<translation id="3143515551205905069">Hủy đồng bộ hóa</translation>
-<translation id="3157842584138209013">Xem lượng dữ liệu bạn đã tiết kiệm được từ nút Tùy chọn khác</translation>
-<translation id="3166827708714933426">Phím tắt dành cho tab và cửa sổ</translation>
-<translation id="3181954750937456830">Duyệt web an toàn (bảo vệ bạn cũng như thiết bị của bạn khỏi các trang web nguy hiểm)</translation>
-<translation id="3190152372525844641">Bật quyền cho Chrome trong <ph name="BEGIN_LINK" />Cài đặt Android<ph name="END_LINK" />.</translation>
-<translation id="3198916472715691905">Dữ liệu đã lưu trữ: <ph name="STORAGE_AMOUNT" /></translation>
-<translation id="3205824638308738187">Sắp hoàn tất!</translation>
-<translation id="3207960819495026254">Đã đánh dấu trang</translation>
-<translation id="3211426585530211793">Đã xóa <ph name="ITEM_TITLE" /></translation>
-<translation id="321773570071367578">Nếu bạn quên cụm mật khẩu hoặc muốn thay đổi cài đặt này, hãy <ph name="BEGIN_LINK" />đặt lại đồng bộ hóa<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">Micrô</translation>
-<translation id="3232754137068452469">Ứng dụng web</translation>
-<translation id="3236059992281584593">Còn 1 phút</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">Đánh dấu trang này</translation>
-<translation id="3259831549858767975">Thu nhỏ mọi nội dung trên trang</translation>
-<translation id="3269093882174072735">Tải hình ảnh</translation>
-<translation id="3269956123044984603">Để có các tab từ các thiết bị khác của bạn, hãy bật “Tự động đồng bộ hóa dữ liệu” trong cài đặt tài khoản Android.</translation>
-<translation id="3277252321222022663">Cho phép các trang web sử dụng cảm biến của thiết bị (nên dùng)</translation>
-<translation id="3282568296779691940">Đăng nhập vào Chrome</translation>
-<translation id="3288003805934695103">Đang tải lại trang</translation>
-<translation id="32895400574683172">Cho phép thông báo</translation>
-<translation id="3295530008794733555">Duyệt web nhanh hơn. Sử dụng ít dữ liệu hơn.</translation>
-<translation id="3295602654194328831">Ẩn thông tin</translation>
-<translation id="3298243779924642547">Phiên bản rút gọn</translation>
-<translation id="3303414029551471755">Tiếp tục tải xuống nội dung?</translation>
-<translation id="3306398118552023113">Ứng dụng này đang chạy trong Chrome</translation>
-<translation id="3315103659806849044">Bạn đang tùy chỉnh các tùy chọn cài đặt Đồng bộ hóa và dịch vụ của Google. Để hoàn tất thao tác bật tính năng đồng bộ hóa, hãy nhấn vào nút Xác nhận ở gần cuối màn hình. Di chuyển lên</translation>
-<translation id="3328801116991980348">Thông tin về trang web</translation>
-<translation id="3333961966071413176">Tất cả người liên hệ</translation>
-<translation id="3334729583274622784">Thay đổi đuôi tệp?</translation>
-<translation id="3341058695485821946">Xem lượng dữ liệu bạn đã tiết kiệm được</translation>
-<translation id="3350687908700087792">Đóng tất cả các tab ẩn danh</translation>
-<translation id="3353615205017136254">Trang phiên bản rút gọn do Google cung cấp. Nhấn vào nút tải bản gốc để tải trang gốc.</translation>
-<translation id="3367813778245106622">Đăng nhập lại để bắt đầu đồng bộ hóa</translation>
-<translation id="3374023511497244703">Dấu trang, lịch sử, mật khẩu và các dữ liệu khác trên Chrome sẽ không được đồng bộ hóa với Tài khoản Google của bạn nữa</translation>
-<translation id="3384347053049321195">Chia sẻ hình ảnh</translation>
-<translation id="3386292677130313581">Hỏi trước khi cho phép các trang web biết vị trí của bạn (được đề xuất)</translation>
-<translation id="3387650086002190359">Tải xuống <ph name="FILE_NAME" /> không thành công do lỗi hệ thống tệp.</translation>
-<translation id="3389286852084373014">Văn bản quá lớn</translation>
-<translation id="3398320232533725830">Mở trình quản lý dấu trang</translation>
-<translation id="3414952576877147120">Kích thước:</translation>
-<translation id="3443221991560634068">Tải lại trang hiện tại</translation>
-<translation id="3445014427084483498">Vừa xong</translation>
-<translation id="3478363558367712427">Bạn có thể chọn công cụ tìm kiếm theo ý mình</translation>
+<translation id="6910211073230771657">Đã xóa</translation>
+<translation id="6965382102122355670">OK</translation>
+<translation id="5301954838959518834">Ok</translation>
+<translation id="7658239707568436148">Hủy</translation>
 <translation id="3479552764303398839">Không phải bây giờ</translation>
-<translation id="3492207499832628349">Tab ẩn danh mới</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />Tìm hiểu thêm<ph name="END_LINK" /> về nội dung đề xuất</translation>
-<translation id="3513704683820682405">Thực tế tăng cường</translation>
-<translation id="3518985090088779359">Chấp nhận và tiếp tục</translation>
-<translation id="3522247891732774234">Bản cập nhật có sẵn. Tùy chọn khác</translation>
-<translation id="3524138585025253783">Giao diện người dùng dành cho nhà phát triển</translation>
-<translation id="3527085408025491307">Thư mục</translation>
-<translation id="3542235761944717775">Còn <ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">Tìm kiếm trong lịch sử duyệt web</translation>
-<translation id="3557336313807607643">Thêm vào danh bạ</translation>
-<translation id="3566923219790363270">Chrome vẫn đang chuẩn bị mô-đun Thực tế ảo. Hãy khởi động lại Chrome sau.</translation>
-<translation id="3568688522516854065">Để sử dụng các tab từ những thiết bị khác, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
-<translation id="3587482841069643663">Tất cả</translation>
-<translation id="358794129225322306">Cho phép một trang web tự động tải xuống nhiều tệp.</translation>
-<translation id="3590487821116122040">Bộ nhớ trang web mà Chrome cho rằng không quan trọng (ví dụ: những trang web không có cài đặt đã lưu nào hoặc trang web mà bạn không truy cập thường xuyên)</translation>
-<translation id="3599863153486145794">Xóa lịch sử khỏi tất cả các thiết bị đã đăng nhập. Tài khoản Google của bạn có thể có các dạng lịch sử duyệt web khác tại <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="3600792891314830896">Tắt tiếng trên các trang web phát âm thanh</translation>
-<translation id="3616113530831147358">Âm thanh</translation>
-<translation id="3631987586758005671">Đang chia sẻ đến <ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">Hiển thị mật khẩu</translation>
-<translation id="363596933471559332">Tự động đăng nhập vào các trang web bằng thông tin đăng nhập được lưu trữ. Khi tính năng này tắt, bạn sẽ luôn được yêu cầu xác minh trước khi đăng nhập vào trang web.</translation>
-<translation id="3658159451045945436">Việc đặt lại sẽ xóa lịch sử tiết kiệm dữ liệu, bao gồm cả danh sách các trang web bạn đã truy cập.</translation>
-<translation id="3692944402865947621">Không tải <ph name="FILE_NAME" /> xuống được do không tìm thấy vị trí bộ nhớ.</translation>
-<translation id="3714981814255182093">Mở thanh Tìm kiếm</translation>
-<translation id="3716182511346448902">Chrome đã tạm dừng trang này vì trang dùng quá nhiều bộ nhớ.</translation>
-<translation id="3730075448226062617">Để cho phép Chrome truy cập vào micrô của bạn, hãy bật cả micrô trong phần <ph name="BEGIN_LINK" />Cài đặt của Android<ph name="END_LINK" />.</translation>
-<translation id="3739899004075612870">Đã đánh dấu trang trong <ph name="PRODUCT_NAME" /></translation>
-<translation id="3744111561329211289">Đồng bộ hóa dưới nền</translation>
-<translation id="3771001275138982843">Không thể tải bản cập nhật xuống</translation>
-<translation id="3771033907050503522">Tab ẩn danh</translation>
-<translation id="3773755127849930740"><ph name="BEGIN_LINK" />Bật Bluetooth<ph name="END_LINK" /> để cho phép ghép nối</translation>
-<translation id="3775705724665058594">Gửi đến các thiết bị của bạn</translation>
-<translation id="3778956594442850293">Đã thêm vào màn hình chính</translation>
-<translation id="3789841737615482174">Cài đặt</translation>
-<translation id="3810838688059735925">Video</translation>
-<translation id="3810973564298564668">Quản lý</translation>
-<translation id="381841723434055211">Số điện thoại</translation>
-<translation id="3819178904835489326">Đã xóa <ph name="NUMBER_OF_DOWNLOADS" /> bản tải xuống</translation>
-<translation id="3822502789641063741">Xóa dữ liệu trang trong bộ nhớ?</translation>
-<translation id="385051799172605136">Quay lại</translation>
-<translation id="3859306556332390985">Tìm kiếm tiến</translation>
-<translation id="3894427358181296146">Thêm thư mục</translation>
-<translation id="3895926599014793903">Buộc bật thu phóng</translation>
-<translation id="3912508018559818924">Đang tìm dữ liệu thích hợp nhất từ web…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">Kết hợp dữ liệu của tôi</translation>
-<translation id="393697183122708255">Không có tìm kiếm bằng giọng nói đã bật</translation>
-<translation id="395206256282351086">Tính năng đề xuất trang web và tìm kiếm đã bị tắt</translation>
-<translation id="3955193568934677022">Cho phép trang web phát nội dung được bảo vệ (được đề xuất)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome sẽ tải trang của bạn khi sẵn sàng}other{Chrome sẽ tải trang của bạn khi sẵn sàng}}</translation>
-<translation id="3963007978381181125">Việc mã hóa cụm mật khẩu không bao gồm địa chỉ và phương thức thanh toán từ Google Pay. Chỉ người có cụm mật khẩu của bạn mới có thể đọc dữ liệu mã hóa. Cụm mật khẩu này sẽ không được gửi đến hay lưu trữ tại Google. Nếu quên cụm mật khẩu hoặc muốn thay đổi tùy chọn cài đặt này, thì bạn cần đặt lại tính năng đồng bộ hóa. <ph name="BEGIN_LINK" />Tìm hiểu thêm<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">Tải xuống hoàn tất</translation>
-<translation id="397583555483684758">Đồng bộ hóa đã ngừng hoạt động</translation>
-<translation id="3976396876660209797">Xóa và tạo lại lối tắt này</translation>
-<translation id="3985215325736559418">Bạn có muốn tải lại <ph name="FILE_NAME" /> xuống không?</translation>
-<translation id="3987993985790029246">Sao chép liên kết</translation>
-<translation id="3988213473815854515">Vị trí được cho phép</translation>
-<translation id="3988466920954086464">Xem kết quả tìm kiếm tức thì trong bảng điều khiển này</translation>
-<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS" />/?</translation>
-<translation id="3997476611815694295">Bộ nhớ không quan trọng</translation>
-<translation id="4000212216660919741">Nhà ở chế độ không kết nối Internet</translation>
+<translation id="5317780077021120954">Lưu</translation>
+<translation id="4570913071927164677">Chi tiết</translation>
+<translation id="8730621377337864115">Xong</translation>
+<translation id="8261506727792406068">Xóa</translation>
+<translation id="1181037720776840403">Xóa</translation>
+<translation id="5939518447894949180">Đặt lại</translation>
 <translation id="4002066346123236978">Tiêu đề</translation>
-<translation id="4008040567710660924">Cho phép cookie của một trang web cụ thể.</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# giờ}other{# giờ}}</translation>
-<translation id="4046123991198612571">Bản nhạc tiếp theo</translation>
-<translation id="4048707525896921369">Tìm hiểu về các chủ đề trên trang web mà không cần rời khỏi trang. Tính năng Nhấn để tìm kiếm sẽ gửi một từ và ngữ cảnh xung quanh từ đó tới Google Tìm kiếm, trả về định nghĩa, hình ảnh, kết quả tìm kiếm và các chi tiết khác.
+<translation id="5916664084637901428">Bật</translation>
+<translation id="5860033963881614850">Tắt</translation>
+<translation id="6165508094623778733">Tìm hiểu thêm</translation>
+<translation id="6042308850641462728">Xem thêm</translation>
+<translation id="6040143037577758943">Đóng</translation>
+<translation id="780301667611848630">Không, cảm ơn</translation>
+<translation id="1201402288615127009">Tiếp theo</translation>
+<translation id="2359808026110333948">Tiếp tục</translation>
+<translation id="2653659639078652383">Gửi</translation>
+<translation id="2079545284768500474">Hoàn tác</translation>
+<translation id="7649070708921625228">Trợ giúp</translation>
+<translation id="2148716181193084225">Hôm nay</translation>
+<translation id="7781829728241885113">Hôm qua</translation>
+<translation id="6945221475159498467">Chọn</translation>
+<translation id="7791543448312431591">Thêm</translation>
+<translation id="6527303717912515753">Chia sẻ</translation>
+<translation id="1383876407941801731">Tìm kiếm</translation>
+<translation id="3115898365077584848">Hiển thị thông tin</translation>
+<translation id="3295602654194328831">Ẩn thông tin</translation>
+<translation id="3987993985790029246">Sao chép liên kết</translation>
+<translation id="2704606927547763573">Đã sao chép</translation>
+<translation id="8725066075913043281">Thử lại</translation>
+<translation id="385051799172605136">Quay lại</translation>
+<translation id="8131740175452115882">Xác nhận</translation>
+<translation id="5300589172476337783">Hiển thị</translation>
+<translation id="1124772482545689468">Người dùng</translation>
+<translation id="8609465669617005112">Di chuyển lên</translation>
+<translation id="6746124502594467657">Di chuyển xuống</translation>
+<translation id="8249310407154411074">Chuyển lên trên cùng</translation>
+<translation id="8428213095426709021">Cài đặt</translation>
+<translation id="2498359688066513246">Trợ giúp và phản hồi</translation>
+<translation id="8378714024927312812">Do tổ chức của bạn quản lý</translation>
+<translation id="9019902583201351841">Do cha mẹ của bạn quản lý</translation>
+<translation id="4645575059429386691">Do cha mẹ của bạn quản lý</translation>
+<translation id="4883854917563148705">Bạn không thể đặt lại các tùy chọn cài đặt được quản lý</translation>
+<translation id="4307992518367153382">Cơ bản</translation>
+<translation id="1974060860693918893">Nâng cao</translation>
+<translation id="1146678959555564648">Nhập VR</translation>
+<translation id="987264212798334818">Chung</translation>
+<translation id="4275663329226226506">Truyền thông</translation>
+<translation id="4759238208242260848">Tệp đã tải xuống</translation>
+<translation id="218608176142494674">Chia sẻ</translation>
+<translation id="8004582292198964060">Trình duyệt</translation>
+<translation id="1105960400813249514">Chụp ảnh màn hình</translation>
+<translation id="4875775213178255010">Đề xuất nội dung</translation>
+<translation id="2021896219286479412">Kiểm soát trang toàn màn hình</translation>
+<translation id="4587589328781138893">Trang web</translation>
+<translation id="4943703118917034429">Thực tế ảo</translation>
+<translation id="1928696683969751773">Số lần cập nhật</translation>
+<translation id="6064125863973209585">Đã hoàn tất quá trình tải xuống</translation>
+<translation id="5342314432463739672">Yêu cầu cấp quyền</translation>
+<translation id="629730747756840877">Tài khoản</translation>
+<translation id="82609232232243542">Đăng nhập vào Brave</translation>
+<translation id="7956662517480676674">Đồng bộ hóa và các dịch vụ của Brave Software</translation>
+<translation id="5294439808117722387">Bạn đang tùy chỉnh các tùy chọn cài đặt Đồng bộ hóa và dịch vụ của Brave Software. Để hoàn tất thao tác bật tính năng đồng bộ hóa, hãy nhấn vào nút Xác nhận ở gần cuối màn hình. Di chuyển lên</translation>
+<translation id="2096012225669085171">Đồng bộ hóa và cá nhân hóa trên các thiết bị</translation>
+<translation id="1692118695553449118">Đồng bộ hóa đang bật</translation>
+<translation id="5514904542973294328">Bị quản trị viên của thiết bị này vô hiệu hóa</translation>
+<translation id="6447211988989208781">Kiểm soát hoạt động trên Brave Software</translation>
+<translation id="4882831918239250449">Kiểm soát cách Brave Software sử dụng lịch sử duyệt web của bạn để cá nhân hóa dịch vụ Tìm kiếm, quảng cáo và các dịch vụ khác</translation>
+<translation id="7431991332293347422">Kiểm soát cách Brave Software sử dụng lịch sử duyệt web của bạn để cá nhân hóa dịch vụ Tìm kiếm và các dịch vụ khác</translation>
+<translation id="6303969859164067831">Đăng xuất và tắt đồng bộ hóa</translation>
+<translation id="1125261911132334651">Quản lý Tài khoản Brave Software của bạn</translation>
+<translation id="6406506848690869874">Đồng bộ hóa</translation>
+<translation id="714362445477979774">Đồng bộ hóa dữ liệu của bạn trên Brave</translation>
+<translation id="4314815835985389558">Quản lý dữ liệu đồng bộ hóa</translation>
+<translation id="5428209950370661546">Các dịch vụ khác của Brave Software</translation>
+<translation id="7704317875155739195">Tự động hoàn thành cụm từ tìm kiếm và URL</translation>
+<translation id="2000419248597011803">Gửi một số cookie và nội dung tìm kiếm từ thanh địa chỉ cũng như hộp tìm kiếm tới công cụ tìm kiếm mặc định</translation>
+<translation id="7981313251711023384">Tải trước các trang để tìm kiếm và duyệt web nhanh hơn</translation>
+<translation id="1821253160463689938">Sử dụng cookie để ghi nhớ tùy chọn của bạn, ngay cả khi bạn không truy cập vào các trang đó</translation>
+<translation id="6697492270171225480">Hiển thị phần đề xuất các trang tương tự khi không tìm thấy một trang</translation>
+<translation id="8109318360573330108">Gửi cho Brave Software URL của trang bạn đang cố truy cập</translation>
+<translation id="8438566539970814960">Cải thiện tính năng tìm kiếm và duyệt web</translation>
+<translation id="284843628681142937">Gửi cho Brave Software URL của các trang bạn truy cập</translation>
+<translation id="7222718784508482526">Bạn có thể xem thêm tùy chọn cài đặt liên quan đến quyền riêng tư, bảo mật và hoạt động thu thập dữ liệu trong phần <ph name="BEGIN_LINK"/>Đồng bộ hóa và dịch vụ của Brave Software<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">Giúp cải thiện hiệu suất và các tính năng của Brave</translation>
+<translation id="9063160602596686558">Tự động gửi số liệu thống kê sử dụng và báo cáo sự cố cho Brave Software</translation>
+<translation id="4824958205181053313">Bạn muốn hủy đồng bộ hóa?</translation>
+<translation id="3058498974290601450">Bạn có thể bật tính năng đồng bộ hóa bất cứ lúc nào trong phần cài đặt</translation>
+<translation id="3143515551205905069">Hủy đồng bộ hóa</translation>
+<translation id="1506061864768559482">Công cụ tìm kiếm</translation>
+<translation id="55737423895878184">Cho phép vị trí và thông báo</translation>
+<translation id="3988213473815854515">Vị trí được cho phép</translation>
+<translation id="32895400574683172">Cho phép thông báo</translation>
+<translation id="9040142327097499898">Cho phép thông báo. Đã tắt vị trí đối với thiết bị này.</translation>
+<translation id="305593374596241526">Đã tắt vị trí; hãy bật vị trí trong mục <ph name="BEGIN_LINK"/>Cài đặt Android<ph name="END_LINK"/>.</translation>
+<translation id="2989523299700148168">Đã truy cập gần đây</translation>
+<translation id="6433501201775827830">Chọn công cụ tìm kiếm của bạn</translation>
+<translation id="7177466738963138057">Bạn có thể thay đổi cài đặt này sau trong Cài đặt</translation>
+<translation id="3478363558367712427">Bạn có thể chọn công cụ tìm kiếm theo ý mình</translation>
+<translation id="4910889077668685004">Ứng dụng thanh toán</translation>
+<translation id="5152843274749979095">Chưa cài đặt ứng dụng được hỗ trợ nào</translation>
+<translation id="8812260976093120287">Trên một số trang web, bạn có thể thanh toán bằng các ứng dụng thanh toán được hỗ trợ bên trên trên thiết bị của bạn.</translation>
+<translation id="7764225426217299476">Thêm địa chỉ</translation>
+<translation id="5595485650161345191">Chỉnh sửa địa chỉ</translation>
+<translation id="5087580092889165836">Thêm thẻ</translation>
+<translation id="2154484045852737596">Chỉnh sửa thẻ</translation>
+<translation id="6140912465461743537">Quốc gia/Vùng</translation>
+<translation id="5659593005791499971">Email</translation>
+<translation id="4378154925671717803">Điện thoại</translation>
+<translation id="4807098396393229769">Tên trên thẻ</translation>
+<translation id="860043288473659153">Tên chủ thẻ</translation>
+<translation id="2612676031748830579">Số thẻ</translation>
+<translation id="869891660844655955">Ngày hết hạn</translation>
+<translation id="2286841657746966508">Địa chỉ thanh toán</translation>
+<translation id="663059986967017181">Đã sao chép vào Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> tùy chọn khác}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> tùy chọn khác}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> tùy chọn khác}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> tùy chọn khác}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> tùy chọn khác}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> tùy chọn khác}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> tùy chọn khác}other{<ph name="CONTACT_PREVIEW"/>\u2026 và <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> tùy chọn khác}}</translation>
+<translation id="7029809446516969842">Mật khẩu</translation>
+<translation id="1943432128510653496">Lưu mật khẩu</translation>
+<translation id="2100273922101894616">Tự động đăng nhập</translation>
+<translation id="363596933471559332">Tự động đăng nhập vào các trang web bằng thông tin đăng nhập được lưu trữ. Khi tính năng này tắt, bạn sẽ luôn được yêu cầu xác minh trước khi đăng nhập vào trang web.</translation>
+<translation id="6995899638241819463">Cảnh báo bạn nếu mật khẩu bị lộ trong một sự cố rò rỉ dữ liệu</translation>
+<translation id="1534287762301776620">Khi bạn đăng nhập vào Tài khoản Brave Software của mình, tính năng này sẽ được bật</translation>
+<translation id="10614374240317010">Không bao giờ lưu</translation>
+<translation id="3098842761938485917">Xem và quản lý các mật khẩu đã lưu trong <ph name="BEGIN_LINK"/>Tài khoản Brave Software<ph name="END_LINK"/> của bạn</translation>
+<translation id="8562452229998620586">Mật khẩu đã lưu của bạn sẽ xuất hiện tại đây.</translation>
+<translation id="8084114998886531721">Mật khẩu đã lưu</translation>
+<translation id="2870560284913253234">Trang web</translation>
+<translation id="8503813439785031346">Tên người dùng</translation>
+<translation id="6657585470893396449">Mật khẩu</translation>
+<translation id="2154710561487035718">Sao chép URL</translation>
+<translation id="1571304935088121812">Sao chép tên người dùng</translation>
+<translation id="5005498671520578047">Sao chép mật khẩu</translation>
+<translation id="3632295766818638029">Hiển thị mật khẩu</translation>
+<translation id="1513858653616922153">Xóa mật khẩu</translation>
+<translation id="543338862236136125">Chỉnh sửa mật khẩu</translation>
+<translation id="4565377596337484307">Ẩn mật khẩu</translation>
+<translation id="8523928698583292556">Xóa mật khẩu đã lưu trữ</translation>
+<translation id="2898264748040935573">Chỉnh sửa mật khẩu đã lưu trữ</translation>
+<translation id="5433691172869980887">Đã sao chép tên người dùng</translation>
+<translation id="5534640966246046842">Đã sao chép trang web</translation>
+<translation id="2625189173221582860">Đã sao chép mật khẩu</translation>
+<translation id="4550003330909367850">Để xem hoặc sao chép mật khẩu của bạn tại đây, hãy đặt khóa màn hình trên thiết bị này.</translation>
+<translation id="6154478581116148741">Bật khóa màn hình trong Cài đặt để xuất mật khẩu của bạn từ thiết bị này</translation>
+<translation id="4842092870884894799">Hiển thị cửa sổ bật lên tạo mật khẩu</translation>
+<translation id="2259659629660284697">Xuất mật khẩu...</translation>
+<translation id="133012818630824069">Xuất mật khẩu đã lưu trữ với Brave</translation>
+<translation id="6914783257214138813">Bất cứ ai có thể xem tệp đã xuất đều có thể biết mật khẩu của bạn.</translation>
+<translation id="2321086116217818302">Đang chuẩn bị mật khẩu…</translation>
+<translation id="8445448999790540984">Không xuất được mật khẩu</translation>
+<translation id="3066461326500799725">Tìm hiểu cách sử dụng Brave Software Drive</translation>
+<translation id="729975465115245577">Thiết bị của bạn không có ứng dụng để lưu trữ tệp mật khẩu.</translation>
+<translation id="7682724950699840886">Thử các mẹo sau: đảm bảo thiết bị của bạn có đủ dung lượng, sau đó thử xuất lại.</translation>
+<translation id="1129510026454351943">Chi tiết: <ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">Mở khóa để sao chép mật khẩu của bạn</translation>
+<translation id="5515439363601853141">Mở khóa để xem mật khẩu của bạn</translation>
+<translation id="6221633008163990886">Mở khóa để xuất mật khẩu của bạn</translation>
+<translation id="230699814587342492">Mật khẩu Brave</translation>
+<translation id="6075798973483050474">Chỉnh sửa trang chủ</translation>
+<translation id="854522910157234410">Mở trang này</translation>
+<translation id="2482878487686419369">Thông báo</translation>
+<translation id="6255999984061454636">Đề xuất nội dung</translation>
+<translation id="805047784848435650">Dựa trên lịch sử duyệt web của bạn</translation>
+<translation id="1041308826830691739">Từ trang web</translation>
+<translation id="395206256282351086">Tính năng đề xuất trang web và tìm kiếm đã bị tắt</translation>
+<translation id="257088987046510401">Chủ đề</translation>
+<translation id="4650364565596261010">Tùy chọn mặc định của hệ thống</translation>
+<translation id="7588219262685291874">Bật giao diện tối khi Trình tiết kiệm pin trên thiết bị đang bật</translation>
+<translation id="2760989362628427051">Bật giao diện tối khi Trình tiết kiệm pin hoặc giao diện tối trên thiết bị đang bật</translation>
+<translation id="6381421346744604172">Làm tối trang web</translation>
+<translation id="5040262127954254034">Quyền riêng tư</translation>
+<translation id="4991384657077828949">Giúp cải thiện khả năng bảo mật của Brave</translation>
+<translation id="1943176487615318915">Để phát hiện các ứng dụng và trang web nguy hiểm, Brave sẽ gửi URL của một số trang mà bạn truy cập, thông tin hệ thống giới hạn và một số nội dung trang cho Brave Software</translation>
+<translation id="3181954750937456830">Duyệt web an toàn (bảo vệ bạn cũng như thiết bị của bạn khỏi các trang web nguy hiểm)</translation>
+<translation id="7315322926489145388">Gửi URL của một số trang mà bạn truy cập cho Brave Software khi bạn gặp rủi ro về bảo mật</translation>
+<translation id="2063713494490388661">Nhấn để tìm kiếm</translation>
+<translation id="2369463299479365221">Tìm hiểu về các chủ đề trên trang web mà không cần rời khỏi trang. Tính năng Nhấn để tìm kiếm sẽ gửi một từ và ngữ cảnh xung quanh từ đó tới Brave Software Tìm kiếm, trả về định nghĩa, hình ảnh, kết quả tìm kiếm và các chi tiết khác.
 
 Để điều chỉnh cụm từ tìm kiếm của bạn, hãy nhấn và giữ để chọn cụm từ đó. Để tinh chỉnh cụm từ tìm kiếm của bạn, hãy trượt bảng điều khiển lên hết cỡ và nhấn vào hộp tìm kiếm.</translation>
-<translation id="4056223980640387499">Màu nâu đỏ</translation>
-<translation id="4060598801229743805">Có các tùy chọn ở gần đầu màn hình</translation>
-<translation id="4062305924942672200">Thông tin pháp lý</translation>
-<translation id="4084682180776658562">Dấu trang</translation>
-<translation id="4084712963632273211">Từ <ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />Do Google phân phối<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">Xóa dữ liệu ứng dụng?</translation>
-<translation id="4099578267706723511">Giúp cải thiện Chrome bằng cách gửi số liệu thống kê sử dụng và báo cáo sự cố cho Google.</translation>
-<translation id="410351446219883937">Tự động phát</translation>
-<translation id="4116038641877404294">Tải trang xuống để sử dụng ngoại tuyến</translation>
-<translation id="4135200667068010335">Danh sách các thiết bị mà bạn có thể chia sẻ một tab đã đóng.</translation>
-<translation id="4149994727733219643">Chế độ xem đơn giản cho trang web</translation>
-<translation id="4165986682804962316">Cài đặt trang web</translation>
-<translation id="4169535189173047238">Không cho phép</translation>
-<translation id="4170011742729630528">Dịch vụ không khả dụng; thử lại sau.</translation>
-<translation id="4179980317383591987">Đã dùng <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">Ngôn ngữ</translation>
-<translation id="4183868528246477015">Tìm bằng Google Ống kính <ph name="BEGIN_NEW" />Mới<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">Mở trong tab mới</translation>
-<translation id="4198423547019359126">Không có vị trí tải xuống</translation>
-<translation id="4209895695669353772">Để nhận nội dung do Google đề xuất riêng cho bạn, hãy bật tính năng đồng bộ hóa</translation>
-<translation id="4226663524361240545">Thông báo có thể làm rung thiết bị</translation>
-<translation id="423219824432660969">Mã hóa dữ liệu đã đồng bộ hóa bằng mật khẩu Google kể từ <ph name="TIME" /></translation>
-<translation id="4242533952199664413">Mở phần cài đặt</translation>
-<translation id="4256782883801055595">Giấy phép nguồn mở</translation>
-<translation id="4259722352634471385">Điều hướng bị chặn: <ph name="URL" /></translation>
-<translation id="4269820728363426813">Sao chép địa chỉ liên kết</translation>
-<translation id="4275663329226226506">Truyền thông</translation>
-<translation id="4278390842282768270">Được cho phép</translation>
-<translation id="429312253194641664">Một trang web đang phát nội dung đa phương tiện</translation>
-<translation id="4298388696830689168">Các trang web liên kết</translation>
-<translation id="4307992518367153382">Cơ bản</translation>
-<translation id="4314815835985389558">Quản lý dữ liệu đồng bộ hóa</translation>
-<translation id="4351244548802238354">Đóng hộp thoại</translation>
-<translation id="4378154925671717803">Điện thoại</translation>
-<translation id="4384468725000734951">Sử dụng Sogou để tìm kiếm</translation>
-<translation id="4404568932422911380">Không có dấu trang nào</translation>
-<translation id="4405224443901389797">Chuyển tới...</translation>
-<translation id="4411535500181276704">Chế độ thu gọn</translation>
-<translation id="4415276339145661267">Quản lý Tài khoản Google của bạn</translation>
-<translation id="4432792777822557199">Kể từ bây giờ trở đi, các trang viết bằng <ph name="SOURCE_LANGUAGE" /> sẽ được dịch sang <ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">Trang phiên bản rút gọn do Google cung cấp</translation>
-<translation id="4434045419905280838">Cửa sổ bật lên và liên kết chuyển hướng</translation>
-<translation id="4440958355523780886">Trang phiên bản rút gọn do Google cung cấp. Nhấn để tải trang gốc.</translation>
-<translation id="4452411734226507615">Đóng tab <ph name="TAB_TITLE" /></translation>
-<translation id="4452548195519783679">Đã đánh dấu trang vào <ph name="FOLDER_NAME" /></translation>
-<translation id="445467742685312942">Cho phép trang web phát nội dung được bảo vệ</translation>
-<translation id="4468959413250150279">Tắt âm thanh trên một trang web cụ thể.</translation>
-<translation id="4472118726404937099">Để đồng bộ hóa và cá nhân hóa trên các thiết bị, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
-<translation id="447252321002412580">Giúp cải thiện hiệu suất và các tính năng của Chrome</translation>
-<translation id="4479647676395637221">Hỏi trước trước khi cho phép các trang web sử dụng máy ảnh của bạn (được đề xuất)</translation>
-<translation id="4479972344484327217">Đang cài đặt <ph name="MODULE" /> cho Chrome…</translation>
-<translation id="4487967297491345095">Tất cả dữ liệu của ứng dụng Chrome sẽ bị xóa vĩnh viễn, bao gồm tất cả các tệp, các tùy chọn cài đặt, tài khoản, cơ sở dữ liệu, v.v.</translation>
-<translation id="4493497663118223949">Chế độ thu gọn đang bật</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# ngày trước}other{# ngày trước}}</translation>
-<translation id="451872707440238414">Tìm kiếm trong các dấu trang</translation>
-<translation id="4521489764227272523">Dữ liệu được chọn đã bị xóa khỏi Chrome và các thiết bị đã đồng bộ hóa của bạn.
-
-Tài khoản Google của bạn có thể có các dạng lịch sử duyệt web khác, chẳng hạn như tìm kiếm và hoạt động từ các dịch vụ khác của Google tại <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="4532845899244822526">Chọn thư mục</translation>
-<translation id="4538018662093857852">Bật Chế độ thu gọn</translation>
-<translation id="4550003330909367850">Để xem hoặc sao chép mật khẩu của bạn tại đây, hãy đặt khóa màn hình trên thiết bị này.</translation>
-<translation id="4558311620361989323">Phím tắt cho trang web</translation>
-<translation id="4561979708150884304">Không có kết nối</translation>
-<translation id="4565377596337484307">Ẩn mật khẩu</translation>
-<translation id="4570913071927164677">Chi tiết</translation>
-<translation id="4572422548854449519">Đăng nhập vào tài khoản được quản lý</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# phút trước}other{# phút trước}}</translation>
-<translation id="4587589328781138893">Trang web</translation>
-<translation id="4594952190837476234">Trang ngoại tuyến này được tạo từ lúc <ph name="CREATION_TIME" /> và có thể khác với phiên bản trực tuyến.</translation>
-<translation id="4605958867780575332">Đã xóa mục: <ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">Mở <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">Sử dụng mật khẩu</translation>
-<translation id="4645575059429386691">Do cha mẹ của bạn quản lý</translation>
-<translation id="4650364565596261010">Tùy chọn mặc định của hệ thống</translation>
-<translation id="4663756553811254707">Đã xóa <ph name="NUMBER_OF_BOOKMARKS" /> dấu trang</translation>
-<translation id="4665282149850138822">Đã thêm <ph name="NAME" /> vào Màn hình chính của bạn</translation>
-<translation id="4684427112815847243">Đồng bộ hóa mọi thứ</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> tùy chọn khác}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> tùy chọn khác}}</translation>
-<translation id="4696983787092045100">Gửi văn bản đến các thiết bị của bạn</translation>
-<translation id="4698034686595694889">Xem ngoại tuyến trong <ph name="APP_NAME" /></translation>
-<translation id="4699172675775169585">Tệp và hình ảnh được lưu trong bộ nhớ đệm</translation>
-<translation id="4714588616299687897">Tiết kiệm tới 60% dữ liệu</translation>
-<translation id="4719927025381752090">Đề xuất dịch</translation>
-<translation id="4720023427747327413">Mở trong <ph name="PRODUCT_NAME" /></translation>
-<translation id="4720982865791209136">Hãy giúp cải tiến Chrome. <ph name="BEGIN_LINK" />Tham gia khảo sát<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">Cập nhật</translation>
-<translation id="4738836084190194332">Đồng bộ hóa lần gần đây nhất: <ph name="WHEN" /></translation>
-<translation id="4749960740855309258">Mở tab mới</translation>
-<translation id="4751476147751820511">Cảm biến chuyển động hoặc ánh sáng</translation>
-<translation id="4759238208242260848">Tệp đã tải xuống</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Đã tải xong 1 tệp xuống.}other{Đã tải xong # tệp xuống.}}</translation>
-<translation id="4797039098279997504">Chạm để quay lại <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">Việc mã hóa cụm mật khẩu không bao gồm địa chỉ và phương thức thanh toán từ Google Pay.
-
-Để thay đổi tùy chọn cài đặt này, hãy <ph name="BEGIN_LINK" />đặt lại tính năng đồng bộ hóa<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">Tên trên thẻ</translation>
-<translation id="4824958205181053313">Bạn muốn hủy đồng bộ hóa?</translation>
-<translation id="4837753911714442426">Mở tùy chọn để in trang</translation>
-<translation id="4842092870884894799">Hiển thị cửa sổ bật lên tạo mật khẩu</translation>
-<translation id="4860895144060829044">Gọi</translation>
-<translation id="4866368707455379617">Không thể cài đặt <ph name="MODULE" /> cho Chrome</translation>
-<translation id="4875775213178255010">Đề xuất nội dung</translation>
-<translation id="4878404682131129617">Thiết lập đường hầm qua máy chủ proxy không thành công</translation>
-<translation id="4880127995492972015">Dịch…</translation>
-<translation id="4881695831933465202">Mở</translation>
-<translation id="488187801263602086">Đổi tên tệp</translation>
-<translation id="4882831918239250449">Kiểm soát cách Google sử dụng lịch sử duyệt web của bạn để cá nhân hóa dịch vụ Tìm kiếm, quảng cáo và các dịch vụ khác</translation>
-<translation id="4883854917563148705">Bạn không thể đặt lại các tùy chọn cài đặt được quản lý</translation>
-<translation id="4885273946141277891">Số phiên bản Chrome không được hỗ trợ.</translation>
-<translation id="4910889077668685004">Ứng dụng thanh toán</translation>
-<translation id="4913161338056004800">Đặt lại thống kê</translation>
-<translation id="4913169188695071480">Ngừng làm mới</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />Nhận trợ giúp<ph name="END_LINK" /> trong khi quét tìm thiết bị…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# trang}other{# trang}}</translation>
-<translation id="4932247056774066048">Vì bạn đang đăng xuất khỏi một tài khoản thuộc quản lý của <ph name="DOMAIN_NAME" /> nên dữ liệu của bạn trên Chrome sẽ bị xóa khỏi thiết bị này. Tuy nhiên, dữ liệu đó sẽ vẫn còn trong Tài khoản Google của bạn.</translation>
-<translation id="4943703118917034429">Thực tế ảo</translation>
-<translation id="4943872375798546930">Không tìm thấy kết quả nào</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> đang chia sẻ màn hình của bạn</translation>
-<translation id="4961107849584082341">Dịch trang này sang ngôn ngữ bất kỳ</translation>
-<translation id="4962975101802056554">Thu hồi tất cả các quyền đối với thiết bị</translation>
-<translation id="4970824347203572753">Hiện chưa có ở vị trí của bạn</translation>
-<translation id="497421865427891073">Đi về phía trước</translation>
-<translation id="4988210275050210843">Đang tải tệp xuống (<ph name="MEGABYTES" />).</translation>
-<translation id="4988526792673242964">Trang</translation>
-<translation id="4994033804516042629">Không tìm thấy người liên hệ nào</translation>
-<translation id="4996978546172906250">Chia sẻ qua</translation>
-<translation id="5004416275253351869">Kiểm soát hoạt động trên Google</translation>
-<translation id="5005498671520578047">Sao chép mật khẩu</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> muốn kết nối</translation>
-<translation id="5013696553129441713">Không có nội dung đề xuất mới</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">Khi bạn ở chế độ thực tế ảo, trang web này có thể tìm hiểu về:
-  –  đặc điểm ngoại hình của bạn, chẳng hạn như chiều cao
-
-Nhớ kiểm tra xem trang web này có tin cậy không trước khi vào chế độ thực tế ảo.</translation>
+<translation id="2930742481329940825">Tính năng Nhấn để tìm kiếm sẽ gửi từ đã chọn và trang hiện tại dưới dạng ngữ cảnh cho Brave Software Tìm kiếm. Bạn có thể tắt tính năng này trong mục <ph name="BEGIN_LINK"/>Cài đặt<ph name="END_LINK"/>.</translation>
 <translation id="5039804452771397117">Cho phép</translation>
-<translation id="5040262127954254034">Quyền riêng tư</translation>
-<translation id="5048398596102334565">Cho phép trang web sử dụng cảm biến chuyển động (nên dùng)</translation>
-<translation id="5063480226653192405">Mức sử dụng</translation>
-<translation id="5087580092889165836">Thêm thẻ</translation>
-<translation id="5100237604440890931">Đã thu gọn - nhấp để mở rộng.</translation>
-<translation id="510275257476243843">Còn 1 giờ</translation>
-<translation id="5123685120097942451">Tab ẩn danh</translation>
-<translation id="5127805178023152808">Đồng bộ hóa đã tắt</translation>
-<translation id="5129038482087801250">Cài đặt ứng dụng web</translation>
-<translation id="5132942445612118989">Đồng bộ hóa mật khẩu, lịch sử và các thông tin khác của bạn trên tất cả các thiết bị</translation>
-<translation id="5139940364318403933">Tìm hiểu cách sử dụng Google Drive</translation>
-<translation id="515227803646670480">Xóa dữ liệu đã lưu trữ</translation>
-<translation id="5152843274749979095">Chưa cài đặt ứng dụng được hỗ trợ nào</translation>
-<translation id="5161254044473106830">Cần có tiêu đề</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Không tải được 1 tệp xuống.}other{Không tải được # tệp xuống.}}</translation>
-<translation id="5170568018924773124">Hiển thị trong thư mục</translation>
-<translation id="5184329579814168207">Mở trong Chrome</translation>
-<translation id="5193988420012215838">Đã sao chép vào khay nhớ tạm</translation>
-<translation id="5197729504361054390">Những người liên hệ bạn chọn sẽ được chia sẻ với <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />.</translation>
-<translation id="5199929503336119739">Hồ sơ công việc</translation>
-<translation id="5210286577605176222">Quay về tab trước</translation>
-<translation id="5210365745912300556">Đóng tab</translation>
-<translation id="5224771365102442243">Có video</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> muốn quét tìm các thiết bị Bluetooth ở gần và đã tìm thấy các thiết bị sau đây:</translation>
-<translation id="5233638681132016545">Tab mới</translation>
-<translation id="526421993248218238">Không thể tải trang này</translation>
-<translation id="5271967389191913893">Thiết bị không thể mở nội dung được tải xuống.</translation>
-<translation id="528192093759286357">Kéo từ trên xuống và chạm vào nút quay lại để thoát khỏi chế độ toàn màn hình.</translation>
-<translation id="5292796745632149097">Gửi đến</translation>
-<translation id="5300589172476337783">Hiển thị</translation>
-<translation id="5301954838959518834">Ok</translation>
-<translation id="5304593522240415983">Không được để trống trường này</translation>
-<translation id="5307446750509046227">Xóa bộ nhớ trang web</translation>
-<translation id="5308380583665731573">Kết nối</translation>
-<translation id="5313967007315987356">Thêm trang web</translation>
-<translation id="5317780077021120954">Lưu</translation>
-<translation id="5324858694974489420">Cài đặt dành cho cha mẹ</translation>
-<translation id="5327248766486351172">Tên</translation>
-<translation id="5335288049665977812">Cho phép các trang web chạy JavaScript (được đề xuất)</translation>
-<translation id="5342314432463739672">Yêu cầu cấp quyền</translation>
-<translation id="5357811892247919462">Đã nhận tab</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> tab đang mở, nhấn để chuyển tab}other{<ph name="OPEN_TABS_MANY" /> tab đang mở, nhấn để chuyển tab}}</translation>
-<translation id="5391532827096253100">Kết nối của bạn tới trang web này không an toàn. Thông tin trang web</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 lựa chọn khác)}other{(+ # lựa chọn khác)}}</translation>
-<translation id="5400569084694353794">Bằng việc sử dụng ứng dụng này, bạn đồng ý với <ph name="BEGIN_LINK1" />Điều khoản dịch vụ<ph name="END_LINK1" /> và <ph name="BEGIN_LINK2" />Thông báo quyền riêng tư<ph name="END_LINK2" /> của Chrome.</translation>
-<translation id="5403592356182871684">Tên</translation>
-<translation id="5403644198645076998">Chỉ cho phép một số trang web</translation>
-<translation id="5414836363063783498">Đang xác minh...</translation>
-<translation id="5423934151118863508">Trang bạn truy cập nhiều nhất sẽ xuất hiện ở đây</translation>
-<translation id="5424588387303617268">Còn trống <ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">Chỉnh sửa mật khẩu</translation>
-<translation id="5433691172869980887">Đã sao chép tên người dùng</translation>
-<translation id="543509235395288790">Đang tải <ph name="COUNT" /> tệp (<ph name="MEGABYTES" />) xuống.</translation>
-<translation id="5441522332038954058">Chuyển đến thanh địa chỉ</translation>
-<translation id="5447201525962359567">Tất cả bộ nhớ trang web, bao gồm cookie và các dữ liệu được lưu trữ cục bộ khác</translation>
-<translation id="5447765697759493033">Trang web này sẽ không được dịch</translation>
-<translation id="545042621069398927">Đang tăng tốc độ tải xuống.</translation>
-<translation id="5456381639095306749">Tải trang xuống</translation>
-<translation id="5475862044948910901">Bắt đầu phiên đăng nhập thực tế tăng cường?</translation>
-<translation id="548278423535722844">Mở trong ứng dụng bản đồ</translation>
-<translation id="5487521232677179737">Xóa dữ liệu</translation>
-<translation id="5494752089476963479">Chặn quảng cáo trên các trang web hiển thị quảng cáo xâm nhập hoặc quảng cáo gây hiểu nhầm</translation>
-<translation id="5500777121964041360">Có thể chưa dùng được tại vị trí của bạn</translation>
-<translation id="5512137114520586844">Tài khoản này do <ph name="PARENT_NAME" /> quản lý.</translation>
-<translation id="5514904542973294328">Bị quản trị viên của thiết bị này vô hiệu hóa</translation>
-<translation id="5515439363601853141">Mở khóa để xem mật khẩu của bạn</translation>
-<translation id="5516455585884385570">Mở mục cài đặt thông báo</translation>
-<translation id="5517095782334947753">Bạn có dấu trang, lịch sử, mật khẩu và các cài đặt khác từ <ph name="FROM_ACCOUNT" />.</translation>
-<translation id="5524843473235508879">Đã chặn chuyển hướng.</translation>
-<translation id="5527082711130173040">Chrome cần có quyền truy cập vị trí để quét tìm thiết bị. <ph name="BEGIN_LINK1" />Cập nhật quyền<ph name="END_LINK1" />. Tính năng truy cập vị trí cũng bị <ph name="BEGIN_LINK2" />tắt cho thiết bị này<ph name="END_LINK2" />.</translation>
-<translation id="5527111080432883924">Hỏi trước khi cho phép các trang web đọc văn bản và hình ảnh từ khay nhớ tạm (khuyên dùng)</translation>
-<translation id="5530766185686772672">Đóng tab ẩn danh</translation>
-<translation id="5534334044554683961">Khi bạn ở chế độ thực tế ảo, trang web này có thể tìm hiểu về:
-  –   đặc điểm ngoại hình của bạn, chẳng hạn như chiều cao
-  –   cách bài trí phòng của bạn
-
-Nhớ kiểm tra xem trang web này có tin cậy không trước khi vào chế độ thực tế ảo.</translation>
-<translation id="5534640966246046842">Đã sao chép trang web</translation>
-<translation id="5556459405103347317">Tải lại</translation>
-<translation id="5561549206367097665">Đang chờ mạng…</translation>
-<translation id="557283862590186398">Chrome cần có quyền truy cập micrô của bạn cho trang web này.</translation>
-<translation id="55737423895878184">Cho phép vị trí và thông báo</translation>
-<translation id="5578795271662203820">Tìm ảnh này trên <ph name="SEARCH_ENGINE" /></translation>
-<translation id="5581519193887989363">Bạn luôn có thể chọn nội dung muốn đồng bộ hóa trong phần <ph name="BEGIN_LINK1" />cài đặt<ph name="END_LINK1" />.</translation>
-<translation id="5595485650161345191">Chỉnh sửa địa chỉ</translation>
-<translation id="5596627076506792578">Tùy chọn khác</translation>
-<translation id="5599455543593328020">Chế độ ẩn danh</translation>
-<translation id="5620928963363755975">Tìm tệp và trang của bạn trong Tài nguyên đã tải xuống từ nút Tùy chọn khác</translation>
-<translation id="5626134646977739690">Tên:</translation>
-<translation id="5639724618331995626">Cho phép tất cả trang web</translation>
-<translation id="5648166631817621825">7 ngày qua</translation>
-<translation id="5649053991847567735">Tự động tải xuống</translation>
-<translation id="5655963694829536461">Tìm kiếm trong các tệp đã tải xuống</translation>
-<translation id="5659593005791499971">Email</translation>
-<translation id="5665379678064389456">Tạo sự kiện trong <ph name="APP_NAME" /></translation>
-<translation id="5668404140385795438">Ghi đè yêu cầu của trang web để chặn phóng to</translation>
-<translation id="5677928146339483299">Bị chặn</translation>
-<translation id="5684874026226664614">Rất tiếc. Không thể dịch trang này.</translation>
-<translation id="5686790454216892815">Tên tệp quá dài</translation>
-<translation id="5689516760719285838">Vị trí</translation>
-<translation id="569536719314091526">Dịch trang này sang ngôn ngữ bất kỳ từ nút Tùy chọn khác</translation>
-<translation id="572328651809341494">Các tab gần đây</translation>
-<translation id="5726692708398506830">Phóng to mọi nội dung trên trang</translation>
-<translation id="5748802427693696783">Đã chuyển sang tab chuẩn</translation>
-<translation id="5749068826913805084">Chrome cần quyền truy cập vào bộ nhớ để tải tệp xuống.</translation>
-<translation id="5763382633136178763">Tab ẩn danh</translation>
-<translation id="5763514718066511291">Nhấn để sao chép URL cho ứng dụng này</translation>
-<translation id="5765780083710877561">Mô tả:</translation>
-<translation id="5793665092639000975">Đang dùng: <ph name="SPACE_USED" />/<ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google có thể sử dụng lịch sử của bạn để điều chỉnh tính năng Tìm kiếm, quảng cáo và các dịch vụ khác của Google cho phù hợp với bạn</translation>
-<translation id="5804241973901381774">Quyền</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# giờ trước}other{# giờ trước}}</translation>
-<translation id="5810288467834065221">Bản quyền <ph name="YEAR" /> Google LLC. Mọi quyền được bảo lưu.</translation>
-<translation id="5817918615728894473">Ghép nối</translation>
-<translation id="583281660410589416">Không xác định</translation>
-<translation id="5833984609253377421">Chia sẻ liên kết</translation>
-<translation id="5836192821815272682">Đang tải Bản cập nhật Chrome…</translation>
-<translation id="5853623416121554550">đã tạm dừng</translation>
-<translation id="5854790677617711513">Đã tồn tại hơn 30 ngày</translation>
-<translation id="5858741533101922242">Chrome không thể bật bộ điều hợp Bluetooth</translation>
-<translation id="5860033963881614850">Tắt</translation>
-<translation id="5862731021271217234">Để sử dụng các tab từ những thiết bị khác, hãy bật tính năng đồng bộ hóa</translation>
-<translation id="5864174910718532887">Thông tin chi tiết: Sắp xếp theo tên trang web</translation>
-<translation id="5864419784173784555">Đang chờ đến lần tải xuống tiếp theo…</translation>
-<translation id="5865733239029070421">Tự động gửi số liệu thống kê sử dụng và báo cáo sự cố cho Google</translation>
-<translation id="5869522115854928033">Mật khẩu đã lưu</translation>
-<translation id="5902828464777634901">Tất cả dữ liệu cục bộ được trang web này lưu, bao gồm cookie, sẽ bị xóa.</translation>
-<translation id="5916664084637901428">Bật</translation>
-<translation id="5919204609460789179">Cập nhật <ph name="PRODUCT_NAME" /> để bắt đầu đồng bộ hóa</translation>
-<translation id="5937580074298050696">Đã tiết kiệm <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">Đặt lại</translation>
-<translation id="5942872142862698679">Sử dụng Google để tìm kiếm</translation>
-<translation id="5952764234151283551">Gửi cho Google URL của trang bạn đang cố truy cập</translation>
-<translation id="5956665950594638604">Mở Trung tâm trợ giúp Chrome trong tab mới</translation>
-<translation id="5958275228015807058">Tìm tệp và trang của bạn trong Tệp đã tải xuống</translation>
-<translation id="5962718611393537961">Nhấn để thu gọn</translation>
-<translation id="6000066717592683814">Giữ Google làm công cụ tìm kiếm mặc định</translation>
-<translation id="6005538289190791541">Mật khẩu đề xuất</translation>
-<translation id="6036057147555329831">Bộ chuyển đổi giao diện (ICU) bổ sung</translation>
-<translation id="6039379616847168523">Chuyển sang tab tiếp theo</translation>
-<translation id="6040143037577758943">Đóng</translation>
-<translation id="6042308850641462728">Xem thêm</translation>
-<translation id="604996488070107836">Không tải xuống được <ph name="FILE_NAME" /> do lỗi không xác định.</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">Đã hoàn tất quá trình tải xuống</translation>
-<translation id="6075798973483050474">Chỉnh sửa trang chủ</translation>
-<translation id="60923314841986378">Còn <ph name="HOURS" /> giờ</translation>
-<translation id="6108923351542677676">Đang thiết lập…</translation>
-<translation id="6111020039983847643">dữ liệu đã dùng</translation>
-<translation id="6112702117600201073">Làm mới trang</translation>
-<translation id="6127379762771434464">Đã xóa mục</translation>
-<translation id="6140912465461743537">Quốc gia/Vùng</translation>
-<translation id="614940544461990577">Hãy thử:</translation>
-<translation id="6154478581116148741">Bật khóa màn hình trong Cài đặt để xuất mật khẩu của bạn từ thiết bị này</translation>
-<translation id="6159335304067198720">Đã tiết kiệm được <ph name="PERCENT" /> dữ liệu</translation>
-<translation id="6165508094623778733">Tìm hiểu thêm</translation>
-<translation id="6177111841848151710">Bị chặn đối với công cụ tìm kiếm hiện tại</translation>
-<translation id="6181444274883918285">Thêm ngoại lệ cho trang web</translation>
-<translation id="6192333916571137726">Tải tệp xuống</translation>
-<translation id="6192792657125177640">Ngoại lệ</translation>
-<translation id="6194112207524046168">Để cho phép Chrome truy cập vào máy ảnh của bạn, hãy bật cả máy ảnh trong phần <ph name="BEGIN_LINK" />Cài đặt của Android<ph name="END_LINK" />.</translation>
-<translation id="6196640612572343990">Chặn cookie của bên thứ ba</translation>
-<translation id="6206551242102657620">Kết nối an toàn. Thông tin trang web</translation>
-<translation id="6210748933810148297">Không phải là <ph name="EMAIL" />?</translation>
-<translation id="6221633008163990886">Mở khóa để xuất mật khẩu của bạn</translation>
+<translation id="1406000523432664303">“Không theo dõi”</translation>
 <translation id="6232535412751077445">Bật tính năng “Không theo dõi” nghĩa là một yêu cầu sẽ được đi kèm với lưu lượng duyệt web của bạn. Mọi ảnh hưởng đều phụ thuộc vào việc trang web có phản hồi yêu cầu không và cách thức diễn giải yêu cầu.
 
 Ví dụ: một số trang web có thể phản hồi yêu cầu này bằng cách hiển thị cho bạn các quảng cáo không dựa trên các trang web khác mà bạn đã truy cập. Nhiều trang web sẽ vẫn thu thập và sử dụng dữ liệu duyệt web của bạn — ví dụ: để tăng cường bảo mật, cung cấp nội dung, quảng cáo và đề xuất, đồng thời tạo số liệu thống kê báo cáo.</translation>
-<translation id="624789221780392884">Bản cập nhật đã sẵn sàng</translation>
-<translation id="6255999984061454636">Đề xuất nội dung</translation>
-<translation id="6277522088822131679">Đã xảy ra sự cố khi in trang này. Vui lòng thử lại.</translation>
-<translation id="6295158916970320988">Tất cả các trang web</translation>
-<translation id="629730747756840877">Tài khoản</translation>
-<translation id="6303969859164067831">Đăng xuất và tắt đồng bộ hóa</translation>
-<translation id="6316139424528454185">Phiên bản Android không được hỗ trợ</translation>
-<translation id="6320088164292336938">Rung</translation>
-<translation id="6324034347079777476">Đồng bộ hóa hệ thống Android đã bị tắt</translation>
-<translation id="6333140779060797560">Chia sẻ qua <ph name="APPLICATION" /></translation>
-<translation id="6337234675334993532">Mã hóa</translation>
-<translation id="6341580099087024258">Hỏi vị trí lưu tệp</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> tùy chọn khác}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> tùy chọn khác}}</translation>
-<translation id="6364438453358674297">Xóa đề xuất khỏi lịch sử?</translation>
-<translation id="6369229450655021117">Từ đây, bạn có thể tìm kiếm trên web, chia sẻ với bạn bè và xem các trang đang mở</translation>
-<translation id="6378173571450987352">Thông tin chi tiết: Sắp xếp theo lượng dữ liệu đã dùng</translation>
-<translation id="6381421346744604172">Làm tối trang web</translation>
-<translation id="6388207532828177975">Xóa và đặt lại</translation>
-<translation id="6393863479814692971">Chrome cần có quyền truy cập máy ảnh và micrô của bạn cho trang web này.</translation>
-<translation id="6395288395575013217">LIÊN KẾT</translation>
-<translation id="6404511346730675251">Chỉnh sửa dấu trang</translation>
-<translation id="6406506848690869874">Đồng bộ hóa</translation>
-<translation id="641643625718530986">In…</translation>
-<translation id="6416782512398055893">Đã tải xuống <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">Dịch web</translation>
-<translation id="6433501201775827830">Chọn công cụ tìm kiếm của bạn</translation>
-<translation id="6437478888915024427">Thông tin trang</translation>
-<translation id="6441734959916820584">Tên quá dài</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# hình ảnh}other{# hình ảnh}}</translation>
-<translation id="6447842834002726250">Cookie</translation>
-<translation id="6461962085415701688">Không thể mở tệp</translation>
-<translation id="6464977750820128603">Bạn có thể xem các trang web mà mình truy cập trên Chrome và hẹn giờ cho các trang web này.\n\nGoogle thu thập thông tin về các trang web mà bạn đã hẹn giờ và khoảng thời gian bạn truy cập các trang web đó. Thông tin này dùng để cải thiện Digital Wellbeing.</translation>
-<translation id="6475951671322991020">Tải video xuống</translation>
-<translation id="6482749332252372425">Tải xuống <ph name="FILE_NAME" /> không thành công do thiếu dung lượng bộ nhớ.</translation>
-<translation id="6496823230996795692">Để sử dụng <ph name="APP_NAME" /> lần đầu tiên, vui lòng kết nối Internet.</translation>
-<translation id="6508722015517270189">Khởi động lại Chrome</translation>
-<translation id="6527303717912515753">Chia sẻ</translation>
-<translation id="6532866250404780454">Các trang web bạn truy cập trên Chrome sẽ không hiển thị. Tất cả lịch hẹn giờ trên trang web sẽ bị xóa.</translation>
-<translation id="6534565668554028783">Google mất quá nhiều thời gian để phản hồi</translation>
-<translation id="6538442820324228105">Đã tải xuống <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">Đã xảy ra lỗi. Hãy thử lại sau.</translation>
-<translation id="654446541061731451">Chọn một tab để chiếu</translation>
-<translation id="6545017243486555795">Xóa tất cả dữ liệu</translation>
-<translation id="6545864417968258051">Quét tìm Bluetooth</translation>
-<translation id="6560414384669816528">Tìm kiếm với Sogou</translation>
-<translation id="6566259936974865419">Chrome đã tiết kiệm <ph name="GIGABYTES" /> GB cho bạn</translation>
-<translation id="6573096386450695060">Luôn cho phép</translation>
-<translation id="6573431926118603307">Các tab bạn đã mở trong Chrome trên thiết bị khác sẽ xuất hiện tại đây.</translation>
-<translation id="6583199322650523874">Đánh dấu trang hiện tại</translation>
-<translation id="6593061639179217415">Trang web cho máy tính</translation>
-<translation id="6600954340915313787">Đã sao chép vào Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">Nội dung được bảo vệ</translation>
-<translation id="6627583120233659107">Chỉnh sửa thư mục</translation>
-<translation id="6643016212128521049">Xóa</translation>
-<translation id="6643649862576733715">Sắp xếp theo lượng dữ liệu tiết kiệm được</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> tùy chọn khác}other{<ph name="CONTACT_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> tùy chọn khác}}</translation>
-<translation id="6649642165559792194">Xem trước hình ảnh <ph name="BEGIN_NEW" />Mới<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome cần có quyền truy cập vị trí để quét tìm thiết bị. <ph name="BEGIN_LINK" />Cập nhật quyền<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">Mật khẩu</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">Mở trong <ph name="APP_NAME" /></translation>
-<translation id="666981079809192359">Thông báo quyền riêng tư của Chrome</translation>
-<translation id="6676840375528380067">Xóa dữ liệu Chrome của bạn khỏi thiết bị này?</translation>
-<translation id="6697492270171225480">Hiển thị phần đề xuất các trang tương tự khi không tìm thấy một trang</translation>
-<translation id="6697947395630195233">Chrome cần truy cập vị trí của bạn để chia sẻ thông tin vị trí với trang web này.</translation>
-<translation id="6698801883190606802">Quản lý dữ liệu đã đồng bộ hóa</translation>
-<translation id="6699370405921460408">Máy chủ của Google sẽ tối ưu hóa các trang bạn truy cập.</translation>
-<translation id="6706288973712894588">Bạn hiện chưa kết nối Internet.\n<ph name="BEGIN_LINK" />Hãy khám phá nguồn cấp dữ liệu khi không có mạng.<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">Tin tức</translation>
-<translation id="6710213216561001401">Trước đó</translation>
-<translation id="671481426037969117">Thời gian hẹn giờ của <ph name="FQDN" /> đã hết. Thời gian hẹn giờ sẽ bắt đầu lại vào ngày mai.</translation>
-<translation id="6738867403308150051">Đang tải xuống...</translation>
-<translation id="6746124502594467657">Di chuyển xuống</translation>
-<translation id="6766622839693428701">Vuốt xuống để đóng.</translation>
-<translation id="6766758767654711248">Nhấn để chuyển đến trang web</translation>
-<translation id="6767294960381293877">Danh sách các thiết bị mà bạn có thể chia sẻ một tab đã mở ở nửa dưới của màn hình.</translation>
-<translation id="6782111308708962316">Ngăn các trang web của bên thứ ba lưu và đọc dữ liệu cookie</translation>
-<translation id="6790428901817661496">Phát</translation>
-<translation id="6811034713472274749">Trang hiện đã sẵn sàng cho bạn xem</translation>
-<translation id="6818926723028410516">Chọn mục</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">Dịch</translation>
-<translation id="6845325883481699275">Giúp cải thiện khả năng bảo mật của Chrome</translation>
-<translation id="6846298663435243399">Đang tải…</translation>
-<translation id="6850409657436465440">Vẫn đang tải xuống</translation>
-<translation id="6850830437481525139">Đã đóng <ph name="TAB_COUNT" /> tab</translation>
-<translation id="6864459304226931083">Tải hình ảnh xuống</translation>
-<translation id="6865313869410766144">Dữ liệu tự động điền vào biểu mẫu</translation>
-<translation id="688738109438487280">Thêm dữ liệu hiện có vào <ph name="TO_ACCOUNT" />.</translation>
-<translation id="6891726759199484455">Mở khóa để sao chép mật khẩu của bạn</translation>
-<translation id="6896758677409633944">Sao chép</translation>
-<translation id="6910211073230771657">Đã xóa</translation>
-<translation id="6912998170423641340">Chặn trang web đọc văn bản và hình ảnh từ khay nhớ tạm</translation>
-<translation id="6914783257214138813">Bất cứ ai có thể xem tệp đã xuất đều có thể biết mật khẩu của bạn.</translation>
-<translation id="6942665639005891494">Thay đổi vị trí tải xuống mặc định bất cứ lúc nào bằng cách sử dụng tùy chọn menu Cài đặt</translation>
-<translation id="6945221475159498467">Chọn</translation>
-<translation id="6963642900430330478">Trang này nguy hiểm. Thông tin trang web</translation>
-<translation id="6963766334940102469">Xóa dấu trang</translation>
-<translation id="6965382102122355670">OK</translation>
-<translation id="6979737339423435258">Từ trước đến nay</translation>
-<translation id="6981982820502123353">Hỗ trợ tiếp cận</translation>
-<translation id="6989267951144302301">Không thể tải xuống</translation>
-<translation id="6990079615885386641">Tải ứng dụng từ Cửa hàng Google Play: <ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">Hỏi trước trước khi cho phép các trang web sử dụng micrô của bạn (được đề xuất)</translation>
-<translation id="7015203776128479407">Quá trình thiết lập đồng bộ hóa ban đầu chưa hoàn tất. Tính năng đồng bộ hóa đã tắt.</translation>
-<translation id="7016516562562142042">Được cho phép đối với công cụ tìm kiếm hiện tại</translation>
-<translation id="7022756207310403729">Mở trong trình duyệt</translation>
-<translation id="702463548815491781">Khuyên dùng khi dịch vụ TalkBack hoặc Tiếp cận bằng công tắc đang bật</translation>
-<translation id="7029809446516969842">Mật khẩu</translation>
-<translation id="7053983685419859001">Chặn</translation>
-<translation id="7055152154916055070">Liên kết chuyển hướng đã chặn:</translation>
-<translation id="7063006564040364415">Không thể kết nối với máy chủ đồng bộ hóa.</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Đã chọn 1 mục}other{Đã chọn # mục}}</translation>
-<translation id="7071521146534760487">Quản lý tài khoản</translation>
-<translation id="7077143737582773186">Thẻ SD</translation>
-<translation id="7087918508125750058">Đã chọn <ph name="ITEM_COUNT" /> mục. Bạn có thể sử dụng các tùy chọn ở gần đầu màn hình</translation>
-<translation id="7121362699166175603">Xóa lịch sử duyệt web và nội dung tự động hoàn thành trong thanh địa chỉ. Tài khoản Google của bạn có thể có các dạng lịch sử duyệt web khác tại <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="7128222689758636196">Cho phép công cụ tìm kiếm hiện tại</translation>
-<translation id="7138678301420049075">Khác</translation>
-<translation id="7141896414559753902">Chặn trang web hiển thị cửa sổ bật lên và liên kết chuyển hướng (khuyên dùng)</translation>
-<translation id="7149158118503947153"><ph name="BEGIN_LINK" />Tải trang gốc<ph name="END_LINK" /> từ <ph name="DOMAIN_NAME" /></translation>
-<translation id="7149893636342594995">24 giờ qua</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">Bạn có thể thay đổi cài đặt này sau trong Cài đặt</translation>
-<translation id="7180611975245234373">Làm mới</translation>
-<translation id="7189372733857464326">Đợi Dịch vụ của Google Play cập nhật xong</translation>
-<translation id="7191430249889272776">Tab được mở dưới nền.</translation>
-<translation id="723171743924126238">Chọn hình ảnh</translation>
-<translation id="7233236755231902816">Để duyệt web bằng ngôn ngữ của bạn, hãy tải phiên bản Chrome mới nhất</translation>
-<translation id="7243308994586599757">Có các tùy chọn ở gần cuối màn hình</translation>
-<translation id="7248069434667874558">Hãy đảm bảo <ph name="TARGET_DEVICE_NAME" /> đã bật tính năng đồng bộ hóa trên Chrome</translation>
-<translation id="7250468141469952378">Đã chọn <ph name="ITEM_COUNT" /></translation>
-<translation id="7274013316676448362">Trang web bị chặn</translation>
-<translation id="7290209999329137901">Không đổi tên được</translation>
-<translation id="7291387454912369099">Trợ lý kích hoạt thanh toán</translation>
-<translation id="7293171162284876153">Để bắt đầu đồng bộ hóa, hãy bật tùy chọn "Đồng bộ hóa dữ liệu của bạn trên Chrome".</translation>
-<translation id="729975465115245577">Thiết bị của bạn không có ứng dụng để lưu trữ tệp mật khẩu.</translation>
-<translation id="7302081693174882195">Thông tin chi tiết: Sắp xếp theo lượng dữ liệu đã tiết kiệm được</translation>
-<translation id="7328017930301109123">Ở Chế độ thu gọn, Chrome tải trang nhanh hơn và sử dụng ít dữ liệu hơn lên tới 60 phần trăm.</translation>
-<translation id="7333031090786104871">Vẫn đang thêm trang web trước</translation>
-<translation id="7352939065658542140">VIDEO</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Chia sẻ 1 mục đã chọn}other{Chia sẻ # mục đã chọn}}</translation>
 <translation id="7359002509206457351">Truy cập vào phương thức thanh toán</translation>
+<translation id="8026334261755873520">Xóa dữ liệu duyệt web</translation>
+<translation id="1291207594882862231">Xóa lịch sử, cookie, dữ liệu trang web, bộ nhớ đệm…</translation>
+<translation id="7814200940910057384">Đã xóa dữ liệu Brave</translation>
+<translation id="1664855196866195614">Dữ liệu được chọn đã bị xóa khỏi Brave và các thiết bị đã đồng bộ hóa của bạn.
+
+Tài khoản Brave Software của bạn có thể có các dạng lịch sử duyệt web khác, chẳng hạn như tìm kiếm và hoạt động từ các dịch vụ khác của Brave Software tại <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="4699172675775169585">Tệp và hình ảnh được lưu trong bộ nhớ đệm</translation>
+<translation id="2496180316473517155">Lịch sử duyệt web</translation>
+<translation id="2546283357679194313">Cookie và dữ liệu trang web</translation>
+<translation id="8662811608048051533">Đăng xuất bạn khỏi hầu hết các trang web.</translation>
+<translation id="8218628800671693884">Đăng xuất bạn khỏi hầu hết các trang web. Bạn sẽ không bị đăng xuất khỏi Tài khoản Brave Software của mình.</translation>
+<translation id="2017836877785168846">Xóa lịch sử duyệt web và nội dung tự động hoàn thành trong thanh địa chỉ.</translation>
+<translation id="8096327394278038498">Xóa lịch sử duyệt web và nội dung tự động hoàn thành trong thanh địa chỉ. Tài khoản Brave Software của bạn có thể có các dạng lịch sử duyệt web khác tại <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="8122693181154564064">Xóa lịch sử khỏi tất cả các thiết bị đã đăng nhập. Tài khoản Brave Software của bạn có thể có các dạng lịch sử duyệt web khác tại <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="5869522115854928033">Mật khẩu đã lưu</translation>
+<translation id="6865313869410766144">Dữ liệu tự động điền vào biểu mẫu</translation>
+<translation id="7562080006725997899">Xóa dữ liệu duyệt web</translation>
+<translation id="5487521232677179737">Xóa dữ liệu</translation>
+<translation id="7498271377022651285">Vui lòng đợi…</translation>
+<translation id="784934925303690534">Phạm vi thời gian</translation>
+<translation id="1718835860248848330">Giờ vừa qua</translation>
+<translation id="7149893636342594995">24 giờ qua</translation>
+<translation id="5648166631817621825">7 ngày qua</translation>
+<translation id="8571213806525832805">4 tuần qua</translation>
+<translation id="5854790677617711513">Đã tồn tại hơn 30 ngày</translation>
+<translation id="6979737339423435258">Từ trước đến nay</translation>
+<translation id="982182592107339124">Thao tác này sẽ xóa dữ liệu của tất cả các trang web, bao gồm:</translation>
+<translation id="6643016212128521049">Xóa</translation>
+<translation id="7641339528570811325">Xóa dữ liệu duyệt web…</translation>
+<translation id="1670399744444387456">Cơ bản</translation>
+<translation id="3245261285041759672">Tài khoản Brave Software của bạn có thể có các dạng lịch sử duyệt web khác tại <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>.</translation>
+<translation id="7274013316676448362">Trang web bị chặn</translation>
+<translation id="2534155362429831547">Đã xóa <ph name="NUMBER_OF_ITEMS"/> mục</translation>
+<translation id="1121094540300013208">Báo cáo sử dụng và sự cố</translation>
+<translation id="9079153198295609735">Tự động gửi số liệu thống kê về việc sử dụng và báo cáo sự cố cho Brave Software</translation>
+<translation id="6981982820502123353">Hỗ trợ tiếp cận</translation>
+<translation id="2387895666653383613">Chia tỷ lệ văn bản</translation>
+<translation id="2321958826496381788">Kéo thanh trượt cho đến khi bạn có thể đọc nội dung này thoải mái. Chữ tối thiểu phải to như này sau khi bấm đúp vào một đoạn.</translation>
+<translation id="3895926599014793903">Buộc bật thu phóng</translation>
+<translation id="5668404140385795438">Ghi đè yêu cầu của trang web để chặn phóng to</translation>
+<translation id="4149994727733219643">Chế độ xem đơn giản cho trang web</translation>
+<translation id="9100505651305367705">Đề xuất hiển thị các bài viết ở chế độ xem đơn giản khi được hỗ trợ</translation>
+<translation id="1409426117486808224">Chế độ xem đơn giản cho tab đang mở</translation>
+<translation id="702463548815491781">Khuyên dùng khi dịch vụ TalkBack hoặc Tiếp cận bằng công tắc đang bật</translation>
+<translation id="8284326494547611709">Phụ đề</translation>
+<translation id="4165986682804962316">Cài đặt trang web</translation>
+<translation id="6295158916970320988">Tất cả các trang web</translation>
+<translation id="8380167699614421159">Trang web này hiển thị quảng cáo xâm nhập hoặc quảng cáo gây hiểu nhầm</translation>
+<translation id="1919345977826869612">Quảng cáo</translation>
+<translation id="410351446219883937">Tự động phát</translation>
+<translation id="6447842834002726250">Cookie</translation>
+<translation id="6196640612572343990">Chặn cookie của bên thứ ba</translation>
+<translation id="6782111308708962316">Ngăn các trang web của bên thứ ba lưu và đọc dữ liệu cookie</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">Cửa sổ bật lên và liên kết chuyển hướng</translation>
+<translation id="4751476147751820511">Cảm biến chuyển động hoặc ánh sáng</translation>
+<translation id="1717218214683051432">Cảm biến chuyển động</translation>
+<translation id="2091887806945687916">Âm thanh</translation>
+<translation id="2586657967955657006">Khay nhớ tạm</translation>
+<translation id="6320088164292336938">Rung</translation>
+<translation id="4226663524361240545">Thông báo có thể làm rung thiết bị</translation>
+<translation id="1446450296470737166">Cho phép kiểm soát hoàn toàn thiết bị MIDI</translation>
+<translation id="3744111561329211289">Đồng bộ hóa dưới nền</translation>
+<translation id="5649053991847567735">Tự động tải xuống</translation>
+<translation id="6181444274883918285">Thêm ngoại lệ cho trang web</translation>
+<translation id="5313967007315987356">Thêm trang web</translation>
+<translation id="1369915414381695676">Đã thêm trang web <ph name="SITE_NAME"/></translation>
+<translation id="7837721118676387834">Cho phép tự động phát video bị tắt tiếng cho trang web cụ thể.</translation>
+<translation id="2621115761605608342">Cho phép JavaScript cho trang web cụ thể.</translation>
+<translation id="8801436777607969138">Chặn JavaScript cho một trang web cụ thể.</translation>
+<translation id="8372893542064058268">Cho phép Đồng bộ hóa dưới nền cho trang web cụ thể.</translation>
+<translation id="358794129225322306">Cho phép một trang web tự động tải xuống nhiều tệp.</translation>
+<translation id="4008040567710660924">Cho phép cookie của một trang web cụ thể.</translation>
+<translation id="8958424370300090006">Chặn cookie của một trang web cụ thể.</translation>
+<translation id="7882806643839505685">Cho phép phát âm thanh trên một trang web cụ thể.</translation>
+<translation id="4468959413250150279">Tắt âm thanh trên một trang web cụ thể.</translation>
+<translation id="1994173015038366702">URL trang web</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">Mức sử dụng</translation>
+<translation id="5804241973901381774">Quyền</translation>
+<translation id="4278390842282768270">Được cho phép</translation>
+<translation id="5677928146339483299">Bị chặn</translation>
+<translation id="1984937141057606926">Được cho phép, ngoại trừ cookie của bên thứ ba</translation>
+<translation id="7423098979219808738">Hỏi trước</translation>
+<translation id="8116925261070264013">Đã ẩn</translation>
+<translation id="8300705686683892304">Do ứng dụng quản lý</translation>
+<translation id="6192792657125177640">Ngoại lệ</translation>
+<translation id="257931822824936280">Đã mở rộng - nhấp để thu gọn.</translation>
+<translation id="5100237604440890931">Đã thu gọn - nhấp để mở rộng.</translation>
+<translation id="857943718398505171">Được phép (được đề xuất)</translation>
+<translation id="2913331724188855103">Cho phép trang web lưu và đọc dữ liệu cookie (được đề xuất)</translation>
+<translation id="7445411102860286510">Cho phép trang web tự động phát video tắt tiếng (được đề xuất)</translation>
+<translation id="5335288049665977812">Cho phép các trang web chạy JavaScript (được đề xuất)</translation>
+<translation id="5527111080432883924">Hỏi trước khi cho phép các trang web đọc văn bản và hình ảnh từ khay nhớ tạm (khuyên dùng)</translation>
+<translation id="6912998170423641340">Chặn trang web đọc văn bản và hình ảnh từ khay nhớ tạm</translation>
+<translation id="7423538860840206698">Đã chặn quyền đọc khay nhớ tạm</translation>
+<translation id="3955193568934677022">Cho phép trang web phát nội dung được bảo vệ (được đề xuất)</translation>
+<translation id="445467742685312942">Cho phép trang web phát nội dung được bảo vệ</translation>
+<translation id="2107397443965016585">Hỏi trước khi cho phép trang web phát nội dung được bảo vệ (khuyên dùng)</translation>
+<translation id="2910701580606108292">Hỏi trước khi cho phép trang web phát nội dung được bảo vệ</translation>
+<translation id="757524316907819857">Chặn không cho trang web phát nội dung được bảo vệ</translation>
+<translation id="3277252321222022663">Cho phép các trang web sử dụng cảm biến của thiết bị (nên dùng)</translation>
+<translation id="5048398596102334565">Cho phép trang web sử dụng cảm biến chuyển động (nên dùng)</translation>
+<translation id="8816026460808729765">Chặn không cho các trang web sử dụng cảm biến</translation>
+<translation id="169515064810179024">Chặn không cho các trang web sử dụng cảm biến chuyển động</translation>
+<translation id="1660204651932907780">Cho phép các trang web phát âm thanh (được đề xuất)</translation>
+<translation id="3600792891314830896">Tắt tiếng trên các trang web phát âm thanh</translation>
+<translation id="1743802530341753419">Hỏi trước khi cho phép trang web kết nối với một thiết bị (khuyên dùng)</translation>
+<translation id="851751545965956758">Chặn các trang web kết nối với thiết bị</translation>
+<translation id="7141896414559753902">Chặn trang web hiển thị cửa sổ bật lên và liên kết chuyển hướng (khuyên dùng)</translation>
+<translation id="5494752089476963479">Chặn quảng cáo trên các trang web hiển thị quảng cáo xâm nhập hoặc quảng cáo gây hiểu nhầm</translation>
+<translation id="3123473560110926937">Đã chặn trên một số trang web</translation>
+<translation id="965817943346481315">Chặn nếu trang web hiển thị quảng cáo xâm nhập hoặc quảng cáo gây hiểu nhầm (khuyên dùng)</translation>
+<translation id="3386292677130313581">Hỏi trước khi cho phép các trang web biết vị trí của bạn (được đề xuất)</translation>
+<translation id="9139068048179869749">Hỏi trước khi cho phép trang web gửi thông báo (được đề xuất)</translation>
+<translation id="4479647676395637221">Hỏi trước trước khi cho phép các trang web sử dụng máy ảnh của bạn (được đề xuất)</translation>
+<translation id="6992289844737586249">Hỏi trước trước khi cho phép các trang web sử dụng micrô của bạn (được đề xuất)</translation>
+<translation id="2289270750774289114">Hỏi khi một trang web muốn tìm các thiết bị Bluetooth ở gần (khuyên dùng)</translation>
+<translation id="7053983685419859001">Chặn</translation>
+<translation id="7128222689758636196">Cho phép công cụ tìm kiếm hiện tại</translation>
+<translation id="7589445247086920869">Chặn công cụ tìm kiếm hiện tại</translation>
+<translation id="6388207532828177975">Xóa và đặt lại</translation>
+<translation id="7999064672810608036">Bạn có chắc chắn muốn xóa tất cả dữ liệu cục bộ, bao gồm cookie và đặt lại tất cả các quyền cho trang web này không?</translation>
+<translation id="2822354292072154809">Bạn có chắc muốn đặt lại tất cả các quyền của trang web cho <ph name="CHOSEN_OBJECT_NAME"/> không?</translation>
+<translation id="515227803646670480">Xóa dữ liệu đã lưu trữ</translation>
+<translation id="5902828464777634901">Tất cả dữ liệu cục bộ được trang web này lưu, bao gồm cookie, sẽ bị xóa.</translation>
+<translation id="119944043368869598">Xóa tất cả</translation>
+<translation id="2490684707762498678">Do <ph name="APP_NAME"/> quản lý</translation>
+<translation id="5516455585884385570">Mở mục cài đặt thông báo</translation>
+<translation id="1404122904123200417">Được nhúng trong <ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">Những tệp mà trang web lưu lại sẽ xuất hiện ở đây</translation>
+<translation id="4181841719683918333">Ngôn ngữ</translation>
+<translation id="2647434099613338025">Thêm ngôn ngữ</translation>
+<translation id="1952172573699511566">Các trang web sẽ hiển thị văn bản bằng ngôn ngữ ưu tiên của bạn khi có thể.</translation>
+<translation id="8559990750235505898">Đề xuất dịch trang bằng các ngôn ngữ khác</translation>
+<translation id="4719927025381752090">Đề xuất dịch</translation>
+<translation id="8156139159503939589">Bạn sử dụng ngôn ngữ nào?</translation>
+<translation id="5689516760719285838">Vị trí</translation>
+<translation id="2440823041667407902">Truy cập vị trí</translation>
+<translation id="2023546461831060654">Bật quyền cho Brave trong <ph name="BEGIN_LINK"/>Cài đặt Android<ph name="END_LINK"/>.</translation>
+<translation id="6665548517310046133">Bật quyền cho Brave trong <ph name="BEGIN_LINK"/>Cài đặt Android<ph name="END_LINK"/>.</translation>
+<translation id="2928908108430545745">Để cho phép Brave truy cập vào vị trí của bạn, hãy bật cả vị trí trong phần <ph name="BEGIN_LINK"/>Cài đặt của Android<ph name="END_LINK"/>.</translation>
+<translation id="1028853271388022585">Để cho phép Brave truy cập vào máy ảnh của bạn, hãy bật cả máy ảnh trong phần <ph name="BEGIN_LINK"/>Cài đặt của Android<ph name="END_LINK"/>.</translation>
+<translation id="2913721282607281710">Để Brave có thể gửi cho bạn thông báo, hãy bật cả thông báo trong phần <ph name="BEGIN_LINK"/>Cài đặt của Android<ph name="END_LINK"/>.</translation>
+<translation id="8753483718490035722">Để cho phép Brave truy cập vào micrô của bạn, hãy bật cả micrô trong phần <ph name="BEGIN_LINK"/>Cài đặt của Android<ph name="END_LINK"/>.</translation>
+<translation id="1887786770086287077">Đã tắt quyền truy cập vị trí đối với thiết bị này. Hãy bật trong <ph name="BEGIN_LINK"/>Cài đặt Android<ph name="END_LINK"/>.</translation>
+<translation id="2570922361219980984">Quyền truy cập vị trí cũng đã bị tắt đối với thiết bị này. Hãy bật trong <ph name="BEGIN_LINK"/>Cài đặt Android<ph name="END_LINK"/>.</translation>
+<translation id="1620510694547887537">Máy ảnh</translation>
+<translation id="3227137524299004712">Micrô</translation>
+<translation id="1647391597548383849">Truy cập máy ảnh của bạn</translation>
+<translation id="945632385593298557">Truy cập micrô của bạn</translation>
+<translation id="6612358246767739896">Nội dung được bảo vệ</translation>
+<translation id="885701979325669005">Bộ nhớ</translation>
+<translation id="3198916472715691905">Dữ liệu đã lưu trữ: <ph name="STORAGE_AMOUNT"/></translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">Thu hồi quyền truy cập thiết bị</translation>
+<translation id="4962975101802056554">Thu hồi tất cả các quyền đối với thiết bị</translation>
+<translation id="6545864417968258051">Quét tìm Bluetooth</translation>
+<translation id="4411535500181276704">Chế độ thu gọn</translation>
+<translation id="7821588508402923572">Mức tiết kiệm dữ liệu sẽ hiển thị tại đây</translation>
+<translation id="2131665479022868825">Đã tiết kiệm <ph name="DATA"/></translation>
+<translation id="8569404424186215731">kể từ <ph name="DATE"/></translation>
+<translation id="3252158532344029638">Ở Chế độ thu gọn, Brave tải trang nhanh hơn và sử dụng ít dữ liệu hơn lên tới 60 phần trăm.</translation>
+<translation id="6159335304067198720">Đã tiết kiệm được <ph name="PERCENT"/> dữ liệu</translation>
+<translation id="7494974237137038751">dữ liệu đã tiết kiệm</translation>
+<translation id="6111020039983847643">dữ liệu đã dùng</translation>
+<translation id="7413229368719586778">Ngày bắt đầu <ph name="DATE"/></translation>
+<translation id="1782483593938241562">Ngày kết thúc <ph name="DATE"/></translation>
+<translation id="2728754400939377704">Sắp xếp theo trang web</translation>
+<translation id="5864174910718532887">Thông tin chi tiết: Sắp xếp theo tên trang web</translation>
+<translation id="116280672541001035">Đã sử dụng</translation>
+<translation id="8349013245300336738">Sắp xếp theo lượng dữ liệu đã dùng</translation>
+<translation id="6378173571450987352">Thông tin chi tiết: Sắp xếp theo lượng dữ liệu đã dùng</translation>
+<translation id="2631006050119455616">Đã tiết kiệm</translation>
+<translation id="6643649862576733715">Sắp xếp theo lượng dữ liệu tiết kiệm được</translation>
+<translation id="7302081693174882195">Thông tin chi tiết: Sắp xếp theo lượng dữ liệu đã tiết kiệm được</translation>
+<translation id="4179980317383591987">Đã dùng <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">Đã tiết kiệm <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">Số trang web còn lại (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">Khác</translation>
+<translation id="4913161338056004800">Đặt lại thống kê</translation>
+<translation id="1856325424225101786">Đặt lại Chế độ thu gọn?</translation>
+<translation id="3658159451045945436">Việc đặt lại sẽ xóa lịch sử tiết kiệm dữ liệu, bao gồm cả danh sách các trang web bạn đã truy cập.</translation>
+<translation id="3295530008794733555">Duyệt web nhanh hơn. Sử dụng ít dữ liệu hơn.</translation>
+<translation id="7340390500800578919">Ở Chế độ thu gọn, Brave tải trang nhanh hơn và sử dụng ít dữ liệu hơn lên tới 60%. Để tối ưu hóa các trang bạn truy cập, Brave sẽ gửi lưu lượng truy cập web của bạn cho Brave Software. <ph name="BEGIN_LINK"/>Tìm hiểu thêm<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">Bật Chế độ thu gọn</translation>
+<translation id="4493497663118223949">Chế độ thu gọn đang bật</translation>
+<translation id="7559975015014302720">Chế độ thu gọn đang tắt</translation>
+<translation id="7606077192958116810">Chế độ thu gọn đang bật. Quản lý chế độ này trong phần Cài đặt.</translation>
+<translation id="4714588616299687897">Tiết kiệm tới 60% dữ liệu</translation>
+<translation id="1006927014032731288">Máy chủ của Brave Software sẽ tối ưu hóa các trang bạn truy cập.</translation>
+<translation id="3257320067425202300">Brave đã tiết kiệm <ph name="MEGABYTES"/> MB cho bạn</translation>
+<translation id="5813223329348543512">Brave đã tiết kiệm <ph name="GIGABYTES"/> GB cho bạn</translation>
+<translation id="8266862848225348053">Vị trí tải xuống</translation>
+<translation id="7077143737582773186">Thẻ SD</translation>
+<translation id="7762668264895820836">Thẻ SD <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">Hỏi vị trí lưu tệp</translation>
+<translation id="6192333916571137726">Tải tệp xuống</translation>
+<translation id="1672586136351118594">Không hiển thị lại</translation>
+<translation id="2650751991977523696">Tải tệp xuống lần nữa?</translation>
+<translation id="8664979001105139458">Tên tệp đã tồn tại</translation>
+<translation id="488187801263602086">Đổi tên tệp</translation>
+<translation id="5686790454216892815">Tên tệp quá dài</translation>
+<translation id="7454641608352164238">Không đủ dung lượng</translation>
+<translation id="8972098258593396643">Tải xuống thư mục mặc định?</translation>
+<translation id="804335162455518893">Không tìm thấy thẻ SD</translation>
+<translation id="7475688122056506577">Không tìm thấy thẻ SD. Một số tệp của bạn có thể bị thiếu.</translation>
+<translation id="4198423547019359126">Không có vị trí tải xuống</translation>
+<translation id="8224471946457685718">Tải tin bài cho bạn xuống qua Wi-Fi</translation>
+<translation id="4970824347203572753">Hiện chưa có ở vị trí của bạn</translation>
+<translation id="5500777121964041360">Có thể chưa dùng được tại vị trí của bạn</translation>
+<translation id="1173894706177603556">Đổi tên</translation>
+<translation id="1986685561493779662">Tên đã tồn tại</translation>
+<translation id="6441734959916820584">Tên quá dài</translation>
+<translation id="2923908459366352541">Tên không hợp lệ</translation>
+<translation id="7290209999329137901">Không đổi tên được</translation>
+<translation id="3334729583274622784">Thay đổi đuôi tệp?</translation>
+<translation id="107147699690128016">Nếu bạn thay đổi đuôi tệp, thì tệp có thể mở trong một ứng dụng khác và tiềm ẩn nguy cơ đối với thiết bị.</translation>
+<translation id="8541922081612557424">Giới thiệu về Brave</translation>
+<translation id="5311273890481188673">Bản quyền <ph name="YEAR"/> Brave Software LLC. Mọi quyền được bảo lưu.</translation>
+<translation id="1416550906796893042">Phiên bản ứng dụng</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (Đã cập nhật <ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">Hệ điều hành</translation>
+<translation id="3968054912784331254">Các bản cập nhật Brave không còn được hỗ trợ cho phiên bản Android này</translation>
+<translation id="7665369617277396874">Thêm tài khoản</translation>
+<translation id="649070405679044769">Đã đăng nhập vào Brave Software bằng</translation>
+<translation id="6234515504547364178">Đăng xuất khỏi Brave</translation>
+<translation id="5324858694974489420">Cài đặt dành cho cha mẹ</translation>
+<translation id="8920114477895755567">Đang đợi thông tin chi tiết của phụ huynh.</translation>
+<translation id="5512137114520586844">Tài khoản này do <ph name="PARENT_NAME"/> quản lý.</translation>
+<translation id="2956410042958133412">Tài khoản này do <ph name="PARENT_NAME_1"/> và <ph name="PARENT_NAME_2"/> quản lý.</translation>
+<translation id="8168435359814927499">Nội dung</translation>
+<translation id="5403644198645076998">Chỉ cho phép một số trang web</translation>
+<translation id="8641930654639604085">Cố gắng chặn các trang web cho người lớn</translation>
+<translation id="5639724618331995626">Cho phép tất cả trang web</translation>
+<translation id="796823723482603597">Được hỗ trợ bởi Brave</translation>
+<translation id="6324034347079777476">Đồng bộ hóa hệ thống Android đã bị tắt</translation>
+<translation id="5127805178023152808">Đồng bộ hóa đã tắt</translation>
+<translation id="7015203776128479407">Quá trình thiết lập đồng bộ hóa ban đầu chưa hoàn tất. Tính năng đồng bộ hóa đã tắt.</translation>
+<translation id="2497852260688568942">Đồng bộ hóa bị quản trị viên của bạn tắt</translation>
+<translation id="9100610230175265781">Yêu cầu cụm mật khẩu</translation>
+<translation id="6108923351542677676">Đang thiết lập…</translation>
+<translation id="4062305924942672200">Thông tin pháp lý</translation>
+<translation id="4256782883801055595">Giấy phép nguồn mở</translation>
+<translation id="1138681184697033370">Điều khoản dịch vụ của Brave</translation>
+<translation id="7392539049993970338">Thông báo quyền riêng tư của Brave</translation>
+<translation id="2677748264148917807">Rời khỏi</translation>
+<translation id="5556459405103347317">Tải lại</translation>
+<translation id="1623104350909869708">Ngăn trang này tạo hộp thoại bổ sung</translation>
+<translation id="2968755619301702150">Trình xem chứng chỉ</translation>
+<translation id="1360432990279830238">Đăng xuất và tắt tính năng đồng bộ hóa?</translation>
+<translation id="8581481290581777242">Xóa dữ liệu Brave của bạn khỏi thiết bị này?</translation>
+<translation id="1318865768845061710">Dấu trang, lịch sử, mật khẩu và các dữ liệu khác trên Brave sẽ không được đồng bộ hóa với Tài khoản Brave Software của bạn nữa</translation>
+<translation id="3325020657155065477">Xóa cả dữ liệu của bạn trên Brave khỏi thiết bị này</translation>
+<translation id="6136448902816743006">Vì bạn đang đăng xuất khỏi một tài khoản thuộc quản lý của <ph name="DOMAIN_NAME"/> nên dữ liệu của bạn trên Brave sẽ bị xóa khỏi thiết bị này. Tuy nhiên, dữ liệu đó sẽ vẫn còn trong Tài khoản Brave Software của bạn.</translation>
+<translation id="1853026300647876496">Đang liên hệ với Brave Software. Quá trình này có thể mất ít phút…</translation>
+<translation id="2328985652426384049">Không thể đăng nhập</translation>
+<translation id="7723158744459952869">Brave Software mất quá nhiều thời gian để phản hồi</translation>
+<translation id="4572422548854449519">Đăng nhập vào tài khoản được quản lý</translation>
+<translation id="2689656545739939160">Bạn đang đăng nhập bằng tài khoản do <ph name="MANAGED_DOMAIN"/> quản lý và cấp cho quản trị viên quyền kiểm soát dữ liệu Brave của bạn. Dữ liệu của bạn sẽ được liên kết vĩnh viễn với tài khoản này. Việc đăng xuất khỏi Brave sẽ xóa dữ liệu của bạn khỏi thiết bị này nhưng dữ liệu sẽ vẫn được lưu trữ trong Tài khoản Brave Software.</translation>
+<translation id="1749561566933687563">Đồng bộ hóa dấu trang của bạn</translation>
+<translation id="4242533952199664413">Mở phần cài đặt</translation>
+<translation id="1111673857033749125">Dấu trang được lưu trên thiết bị khác của bạn sẽ xuất hiện tại đây.</translation>
+<translation id="8636825310635137004">Để có các tab từ các thiết bị khác của bạn, hãy bật đồng bộ hóa.</translation>
+<translation id="3269956123044984603">Để có các tab từ các thiết bị khác của bạn, hãy bật “Tự động đồng bộ hóa dữ liệu” trong cài đặt tài khoản Android.</translation>
+<translation id="5157964048453367290">Các tab bạn đã mở trong Brave trên thiết bị khác sẽ xuất hiện tại đây.</translation>
+<translation id="4684427112815847243">Đồng bộ hóa mọi thứ</translation>
+<translation id="2709516037105925701">Tự động điền</translation>
+<translation id="8820817407110198400">Dấu trang</translation>
+<translation id="1644574205037202324">Lịch sử</translation>
+<translation id="17513872634828108">Tab đang mở</translation>
+<translation id="1320169905922104972">Thẻ tín dụng và địa chỉ lưu trong Brave Software Pay</translation>
+<translation id="6337234675334993532">Mã hóa</translation>
+<translation id="6698801883190606802">Quản lý dữ liệu đã đồng bộ hóa</translation>
+<translation id="3598578758776312506">Mã hóa mật khẩu bằng thông tin đăng nhập Brave Software</translation>
+<translation id="7810580217418711046">Mã hóa dữ liệu đã đồng bộ hóa bằng mật khẩu Brave Software kể từ <ph name="TIME"/></translation>
+<translation id="8461694314515752532">Mã hóa dữ liệu đã đồng bộ hóa bằng cụm mật khẩu đồng bộ hóa của riêng bạn</translation>
+<translation id="2996291259634659425">Tạo cụm mật khẩu</translation>
+<translation id="5713644099811900409">Tài khoản Brave Software</translation>
+<translation id="8997474919031554666">Việc mã hóa cụm mật khẩu không bao gồm địa chỉ và phương thức thanh toán từ Brave Software Pay. Chỉ người có cụm mật khẩu của bạn mới có thể đọc dữ liệu mã hóa. Cụm mật khẩu này sẽ không được gửi đến hay lưu trữ tại Brave Software. Nếu quên cụm mật khẩu hoặc muốn thay đổi tùy chọn cài đặt này, thì bạn cần đặt lại tính năng đồng bộ hóa. <ph name="BEGIN_LINK"/>Tìm hiểu thêm<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">Cụm mật khẩu</translation>
+<translation id="7772032839648071052">Xác nhận cụm mật khẩu</translation>
+<translation id="5304593522240415983">Không được để trống trường này</translation>
+<translation id="321773570071367578">Nếu bạn quên cụm mật khẩu hoặc muốn thay đổi cài đặt này, hãy <ph name="BEGIN_LINK"/>đặt lại đồng bộ hóa<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">Cụm mật khẩu không khớp</translation>
+<translation id="5149495116300586333">Việc mã hóa cụm mật khẩu không bao gồm địa chỉ và phương thức thanh toán từ Brave Software Pay.
+
+Để thay đổi tùy chọn cài đặt này, hãy <ph name="BEGIN_LINK"/>đặt lại tính năng đồng bộ hóa<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">Cụm mật khẩu không chính xác</translation>
+<translation id="5414836363063783498">Đang xác minh...</translation>
+<translation id="6846298663435243399">Đang tải…</translation>
+<translation id="5517095782334947753">Bạn có dấu trang, lịch sử, mật khẩu và các cài đặt khác từ <ph name="FROM_ACCOUNT"/>.</translation>
+<translation id="3928666092801078803">Kết hợp dữ liệu của tôi</translation>
+<translation id="688738109438487280">Thêm dữ liệu hiện có vào <ph name="TO_ACCOUNT"/>.</translation>
+<translation id="806745655614357130">Giữ dữ liệu của tôi riêng biệt</translation>
+<translation id="1145536944570833626">Xóa dữ liệu hiện có.</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> muốn ghép nối</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>Nhận trợ giúp<ph name="END_LINK"/> trong khi quét tìm thiết bị…</translation>
+<translation id="5817918615728894473">Ghép nối</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>Nhận trợ giúp<ph name="END_LINK1"/> hoặc <ph name="BEGIN_LINK2"/>quét lại<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">Không tìm thấy thiết bị tương thích</translation>
+<translation id="3773755127849930740"><ph name="BEGIN_LINK"/>Bật Bluetooth<ph name="END_LINK"/> để cho phép ghép nối</translation>
+<translation id="998321811308652668">Brave không thể bật bộ điều hợp Bluetooth</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>Nhận trợ giúp<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave cần có quyền truy cập vị trí để quét tìm thiết bị. <ph name="BEGIN_LINK"/>Cập nhật quyền<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave cần có quyền truy cập vị trí để quét tìm thiết bị. Tính năng truy cập vị trí bị <ph name="BEGIN_LINK"/>tắt cho thiết bị này<ph name="END_LINK"/>.</translation>
+<translation id="2367014990350929709">Brave cần có quyền truy cập vị trí để quét tìm thiết bị. <ph name="BEGIN_LINK1"/>Cập nhật quyền<ph name="END_LINK1"/>. Tính năng truy cập vị trí cũng bị <ph name="BEGIN_LINK2"/>tắt cho thiết bị này<ph name="END_LINK2"/>.</translation>
+<translation id="1569387923882100876">Thiết bị đã kết nối</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{Mức cường độ tín hiệu: # vạch}other{Mức cường độ tín hiệu: # vạch}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> muốn quét tìm các thiết bị Bluetooth ở gần và đã tìm thấy các thiết bị sau đây:</translation>
+<translation id="8368027906805972958">Thiết bị không xác định hoặc không được hỗ trợ (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">Đồng bộ hóa không hoạt động</translation>
+<translation id="1810845389119482123">Chưa hoàn tất quá trình thiết lập đồng bộ hóa ban đầu</translation>
+<translation id="3235722914093408050">Mở c.đặt Android &amp; bật lại đ.bộ hóa hệ thống Android để b.đầu đồng bộ hóa Brave</translation>
+<translation id="3367813778245106622">Đăng nhập lại để bắt đầu đồng bộ hóa</translation>
+<translation id="974555521953189084">Nhập cụm mật khẩu của bạn để bắt đầu đồng bộ hóa</translation>
+<translation id="2997266899014181325">Để bắt đầu đồng bộ hóa, hãy bật tùy chọn "Đồng bộ hóa dữ liệu của bạn trên Brave".</translation>
+<translation id="8260126382462817229">Thử đăng nhập lại</translation>
+<translation id="5919204609460789179">Cập nhật <ph name="PRODUCT_NAME"/> để bắt đầu đồng bộ hóa</translation>
+<translation id="397583555483684758">Đồng bộ hóa đã ngừng hoạt động</translation>
+<translation id="1966710179511230534">Vui lòng cập nhật chi tiết đăng nhập của bạn.</translation>
+<translation id="7063006564040364415">Không thể kết nối với máy chủ đồng bộ hóa.</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> đã lỗi thời.</translation>
+<translation id="4170011742729630528">Dịch vụ không khả dụng; thử lại sau.</translation>
+<translation id="7947953824732555851">Chấp nhận &amp; đăng nhập</translation>
+<translation id="8583805026567836021">Xóa dữ liệu tài khoản</translation>
+<translation id="8310344678080805313">Tab chuẩn</translation>
+<translation id="5748802427693696783">Đã chuyển sang tab chuẩn</translation>
+<translation id="7998918019931843664">Mở lại tab đã đóng</translation>
+<translation id="8853345339104747198">Tab <ph name="TAB_TITLE"/></translation>
+<translation id="4452411734226507615">Đóng tab <ph name="TAB_TITLE"/></translation>
+<translation id="7243308994586599757">Có các tùy chọn ở gần cuối màn hình</translation>
+<translation id="4060598801229743805">Có các tùy chọn ở gần đầu màn hình</translation>
+<translation id="2810645512293415242">Trang đơn giản giúp lưu dữ liệu và tải nhanh hơn.</translation>
+<translation id="3985215325736559418">Bạn có muốn tải lại <ph name="FILE_NAME"/> xuống không?</translation>
+<translation id="2450083983707403292">Bạn có muốn bắt đầu tải xuống <ph name="FILE_NAME"/> lần nữa không?</translation>
+<translation id="7514365320538308">Tải xuống</translation>
+<translation id="545042621069398927">Đang tăng tốc độ tải xuống.</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Đang tải tệp xuống.}other{Đang tải # tệp xuống.}}</translation>
+<translation id="543509235395288790">Đang tải <ph name="COUNT"/> tệp (<ph name="MEGABYTES"/>) xuống.</translation>
+<translation id="4988210275050210843">Đang tải tệp xuống (<ph name="MEGABYTES"/>).</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{Đã tải xong 1 tệp xuống.}other{Đã tải xong # tệp xuống.}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{Không tải được 1 tệp xuống.}other{Không tải được # tệp xuống.}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 tệp đang chờ tải xuống.}other{# tệp đang chờ tải xuống.}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>.</translation>
+<translation id="1987739130650180037">Nút <ph name="MESSAGE"/> <ph name="LINK_NAME"/></translation>
+<translation id="3205824638308738187">Sắp hoàn tất!</translation>
+<translation id="3960299545138990065">Khởi động lại Brave</translation>
+<translation id="3771001275138982843">Không thể tải bản cập nhật xuống</translation>
+<translation id="3888648114124182147">Đang tải Bản cập nhật Brave…</translation>
+<translation id="1705567146636171298">Cập nhật Brave</translation>
+<translation id="6195417478702700398">Để có trải nghiệm duyệt web tuyệt vời nhất, hãy mở để cập nhật Brave</translation>
+<translation id="3512968675351418494">Để duyệt web bằng ngôn ngữ của bạn, hãy tải phiên bản Brave mới nhất</translation>
+<translation id="6427112570124116297">Dịch web</translation>
+<translation id="1379423114029199501">Hãy cập nhật để dùng ngôn ngữ của bạn trong phiên bản Brave mới nhất</translation>
+<translation id="5684874026226664614">Rất tiếc. Không thể dịch trang này.</translation>
+<translation id="6831043979455480757">Dịch</translation>
+<translation id="1285320974508926690">Không bao giờ dịch trang web này</translation>
+<translation id="773466115871691567">Luôn dịch các trang viết bằng <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="1068672505746868501">Không bao giờ dịch các trang viết bằng <ph name="SOURCE_LANGUAGE"/></translation>
+<translation id="124116460088058876">Ngôn ngữ khác</translation>
+<translation id="290376772003165898">Trang này không được viết bằng <ph name="LANGUAGE"/>?</translation>
+<translation id="4432792777822557199">Kể từ bây giờ trở đi, các trang viết bằng <ph name="SOURCE_LANGUAGE"/> sẽ được dịch sang <ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">Các trang viết bằng <ph name="LANGUAGE"/> sẽ không được dịch</translation>
+<translation id="5447765697759493033">Trang web này sẽ không được dịch</translation>
+<translation id="4880127995492972015">Dịch…</translation>
+<translation id="641643625718530986">In…</translation>
+<translation id="8909135823018751308">Chia sẻ...</translation>
+<translation id="4996978546172906250">Chia sẻ qua</translation>
+<translation id="6333140779060797560">Chia sẻ qua <ph name="APPLICATION"/></translation>
+<translation id="6277522088822131679">Đã xảy ra sự cố khi in trang này. Vui lòng thử lại.</translation>
+<translation id="3254409185687681395">Đánh dấu trang này</translation>
+<translation id="497421865427891073">Đi về phía trước</translation>
+<translation id="813082847718468539">Xem thông tin trang web</translation>
+<translation id="2532336938189706096">Lượt xem trên web</translation>
+<translation id="6005538289190791541">Mật khẩu đề xuất</translation>
+<translation id="4634124774493850572">Sử dụng mật khẩu</translation>
+<translation id="8285489906452138776">Brave cần có quyền truy cập máy ảnh của bạn cho trang web này.</translation>
+<translation id="320189792589364011">Brave cần có quyền truy cập micrô của bạn cho trang web này.</translation>
+<translation id="7988136689212463100">Brave cần có quyền truy cập máy ảnh và micrô của bạn cho trang web này.</translation>
+<translation id="4931190655840828017">Brave cần truy cập vị trí của bạn để chia sẻ thông tin vị trí với trang web này.</translation>
+<translation id="3088191967551450609">Brave cần quyền truy cập vào bộ nhớ để tải tệp xuống.</translation>
+<translation id="8942627711005830162">Mở trong cửa sổ khác</translation>
+<translation id="4195643157523330669">Mở trong tab mới</translation>
+<translation id="1100066534610197918">Mở trong tab mới trong nhóm</translation>
+<translation id="4860895144060829044">Gọi</translation>
+<translation id="6896758677409633944">Sao chép</translation>
+<translation id="8393700583063109961">Gửi tin nhắn</translation>
+<translation id="3557336313807607643">Thêm vào danh bạ</translation>
+<translation id="4269820728363426813">Sao chép địa chỉ liên kết</translation>
+<translation id="1206892813135768548">Sao chép văn bản liên kết</translation>
+<translation id="1204037785786432551">Tải liên kết xuống</translation>
+<translation id="6864459304226931083">Tải hình ảnh xuống</translation>
+<translation id="8209050860603202033">Mở ảnh</translation>
+<translation id="8073388330009372546">Mở ảnh trong tab mới</translation>
+<translation id="6649642165559792194">Xem trước hình ảnh <ph name="BEGIN_NEW"/>Mới<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">Tải hình ảnh</translation>
+<translation id="3845332215609790146">Tìm bằng Brave Software Ống kính <ph name="BEGIN_NEW"/>Mới<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">Tìm ảnh này trên <ph name="SEARCH_ENGINE"/></translation>
+<translation id="3384347053049321195">Chia sẻ hình ảnh</translation>
+<translation id="5833984609253377421">Chia sẻ liên kết</translation>
+<translation id="6475951671322991020">Tải video xuống</translation>
+<translation id="2317945146070194624">Mở trong tab Brave mới</translation>
+<translation id="7975379999046275268">Xem trước trang <ph name="BEGIN_NEW"/>Mới<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">Làm mới trang</translation>
+<translation id="36525718899759834">Tải ứng dụng từ Cửa hàng Brave Software Play: <ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">Tối</translation>
+<translation id="1807246157184219062">Sáng</translation>
+<translation id="4056223980640387499">Màu nâu đỏ</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">Monospace</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">Chọn một tab để chiếu</translation>
+<translation id="8719023831149562936">Không thể chiếu tab hiện tại</translation>
+<translation id="2139186145475833000">Thêm vào Màn hình chính</translation>
+<translation id="4616150815774728855">Mở <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">Không thể mở ứng dụng</translation>
+<translation id="5129038482087801250">Cài đặt ứng dụng web</translation>
+<translation id="3789841737615482174">Cài đặt</translation>
+<translation id="4665282149850138822">Đã thêm <ph name="NAME"/> vào Màn hình chính của bạn</translation>
+<translation id="7333031090786104871">Vẫn đang thêm trang web trước</translation>
+<translation id="1036727731225946849">Đang thêm <ph name="WEBAPK_NAME"/>...</translation>
+<translation id="3778956594442850293">Đã thêm vào màn hình chính</translation>
+<translation id="2146738493024040262">Mở ứng dụng tức thì</translation>
+<translation id="7016516562562142042">Được cho phép đối với công cụ tìm kiếm hiện tại</translation>
+<translation id="6177111841848151710">Bị chặn đối với công cụ tìm kiếm hiện tại</translation>
+<translation id="145097072038377568">Tắt trong Cài đặt Android</translation>
+<translation id="8007176423574883786">Tắt cho thiết bị này</translation>
+<translation id="164269334534774161">Bạn đang xem bản sao ngoại tuyến của trang này từ <ph name="CREATION_TIME"/></translation>
+<translation id="4594952190837476234">Trang ngoại tuyến này được tạo từ lúc <ph name="CREATION_TIME"/> và có thể khác với phiên bản trực tuyến.</translation>
+<translation id="8840953339110955557">Trang này có thể khác với phiên bản trực tuyến.</translation>
+<translation id="6405300764336705484">Nội dung này đến từ <ph name="DOMAIN_NAME"/>, do Brave Software phân phối.</translation>
+<translation id="1006017844123154345">Mở trực tuyến</translation>
+<translation id="3326636747541519688">Trang phiên bản rút gọn do Brave Software cung cấp</translation>
+<translation id="7149158118503947153"><ph name="BEGIN_LINK"/>Tải trang gốc<ph name="END_LINK"/> từ <ph name="DOMAIN_NAME"/></translation>
+<translation id="7475192538862203634">Nếu bạn thường xuyên thấy thông báo này, hãy thử các <ph name="BEGIN_LINK"/>đề xuất<ph name="END_LINK"/> sau.</translation>
+<translation id="8748850008226585750">Nội dung bị ẩn</translation>
+<translation id="3810973564298564668">Quản lý</translation>
+<translation id="5199929503336119739">Hồ sơ công việc</translation>
+<translation id="528192093759286357">Kéo từ trên xuống và chạm vào nút quay lại để thoát khỏi chế độ toàn màn hình.</translation>
+<translation id="2836148919159985482">Chạm vào nút quay lại để thoát khỏi chế độ toàn màn hình.</translation>
+<translation id="3967822245660637423">Tải xuống hoàn tất</translation>
+<translation id="2434158240863470628">Quá trình tải xuống hoàn tất <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">Tải xuống không thành công</translation>
+<translation id="1384959399684842514">Đã tạm dừng quá trình tải xuống</translation>
+<translation id="1671236975893690980">Đang chờ tải xuống...</translation>
+<translation id="5561549206367097665">Đang chờ mạng…</translation>
+<translation id="5864419784173784555">Đang chờ đến lần tải xuống tiếp theo…</translation>
+<translation id="6461962085415701688">Không thể mở tệp</translation>
+<translation id="1178581264944972037">Tạm dừng</translation>
+<translation id="8200772114523450471">Tiếp tục</translation>
+<translation id="1409879593029778104">Đã ngăn tải xuống <ph name="FILE_NAME"/> do tệp này đã tồn tại.</translation>
+<translation id="3387650086002190359">Tải xuống <ph name="FILE_NAME"/> không thành công do lỗi hệ thống tệp.</translation>
+<translation id="6482749332252372425">Tải xuống <ph name="FILE_NAME"/> không thành công do thiếu dung lượng bộ nhớ.</translation>
+<translation id="7619072057915878432">Tải xuống không thành công <ph name="FILE_NAME"/> do lỗi mạng.</translation>
+<translation id="1477626028522505441">Tải xuống <ph name="FILE_NAME"/> không thành công do sự cố máy chủ.</translation>
+<translation id="3692944402865947621">Không tải <ph name="FILE_NAME"/> xuống được do không tìm thấy vị trí bộ nhớ.</translation>
+<translation id="604996488070107836">Không tải xuống được <ph name="FILE_NAME"/> do lỗi không xác định.</translation>
+<translation id="6738867403308150051">Đang tải xuống...</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/?</translation>
+<translation id="1923695749281512248"><ph name="BYTES_DOWNLOADED_WITH_UNITS"/>/<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">Đã tải xuống <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">Đã tải xuống <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">Đã tải xuống <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">Còn lại 1 tệp</translation>
+<translation id="8186512483418048923">Còn lại <ph name="FILES"/> tệp</translation>
+<translation id="757855969265046257">{FILES,plural, =1{Đã tải <ph name="FILES_DOWNLOADED_ONE"/> tệp xuống}other{Đã tải <ph name="FILES_DOWNLOADED_MANY"/> tệp xuống}}</translation>
+<translation id="8037750541064988519">Còn <ph name="DAYS"/> ngày</translation>
+<translation id="8190358571722158785">Còn 1 ngày</translation>
+<translation id="60923314841986378">Còn <ph name="HOURS"/> giờ</translation>
+<translation id="510275257476243843">Còn 1 giờ</translation>
+<translation id="970715775301869095">Còn <ph name="MINUTES"/> phút</translation>
+<translation id="3236059992281584593">Còn 1 phút</translation>
+<translation id="2777555524387840389">Còn <ph name="SECONDS"/> giây</translation>
+<translation id="2781151931089541271">Còn 1 giây</translation>
+<translation id="3303414029551471755">Tiếp tục tải xuống nội dung?</translation>
+<translation id="8617240290563765734">Mở URL đề xuất được chỉ định trong nội dung được tải xuống?</translation>
+<translation id="1373696734384179344">Không đủ bộ nhớ để tải xuống nội dung được chọn.</translation>
+<translation id="5271967389191913893">Thiết bị không thể mở nội dung được tải xuống.</translation>
+<translation id="883806473910249246">Đã xảy ra lỗi khi tải nội dung xuống.</translation>
+<translation id="5626134646977739690">Tên:</translation>
+<translation id="7963646190083259054">Nhà cung cấp:</translation>
+<translation id="3414952576877147120">Kích thước:</translation>
+<translation id="7375125077091615385">Loại:</translation>
+<translation id="5765780083710877561">Mô tả:</translation>
+<translation id="4881695831933465202">Mở</translation>
+<translation id="3542235761944717775">Còn <ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747">Còn <ph name="MEGABYTES"/> MB</translation>
+<translation id="5424588387303617268">Còn trống <ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">Đang dùng: <ph name="SPACE_USED"/>/<ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">Tất cả</translation>
+<translation id="4988526792673242964">Trang</translation>
+<translation id="3810838688059735925">Video</translation>
+<translation id="3616113530831147358">Âm thanh</translation>
+<translation id="9219103736887031265">Hình ảnh</translation>
+<translation id="8250920743982581267">Tài liệu</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# tệp}other{# tệp}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# hình ảnh}other{# hình ảnh}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# video}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# tệp âm thanh}other{# tệp âm thanh}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# trang}other{# trang}}</translation>
+<translation id="5456381639095306749">Tải trang xuống</translation>
+<translation id="2394602618534698961">Các tệp bạn tải xuống sẽ xuất hiện ở đây</translation>
+<translation id="7810647596859435254">Mở bằng…</translation>
+<translation id="5655963694829536461">Tìm kiếm trong các tệp đã tải xuống</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">Tệp của tôi</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">Các bài viết xuất hiện ở đây và bạn có thể đọc ngay cả khi không có kết nối mạng</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# giờ}other{# giờ}}</translation>
+<translation id="5853623416121554550">đã tạm dừng</translation>
+<translation id="8965591936373831584">đang chờ xử lý</translation>
+<translation id="2779651927720337254">không tải xuống được</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">Vừa xong</translation>
+<translation id="4000212216660919741">Nhà ở chế độ không kết nối Internet</translation>
+<translation id="9133397713400217035">Khám phá khi không kết nối Internet</translation>
+<translation id="968900484120156207">Các trang mà bạn truy cập sẽ xuất hiện tại đây</translation>
+<translation id="7882131421121961860">Không tìm thấy nội dung nào khớp</translation>
+<translation id="3549657413697417275">Tìm kiếm trong lịch sử duyệt web</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Trải nghiệm lần chạy đầu tiên của Brave</translation>
+<translation id="2700285883409956633">Bằng việc sử dụng ứng dụng này, bạn đồng ý với <ph name="BEGIN_LINK1"/>Điều khoản dịch vụ<ph name="END_LINK1"/> và <ph name="BEGIN_LINK2"/>Thông báo quyền riêng tư<ph name="END_LINK2"/> của Brave.</translation>
+<translation id="1640714894372474981">Bằng việc sử dụng ứng dụng này, bạn đồng ý với <ph name="BEGIN_LINK1"/>Điều khoản dịch vụ<ph name="END_LINK1"/> và <ph name="BEGIN_LINK2"/>Thông báo quyền riêng tư<ph name="END_LINK2"/> của Brave cũng như <ph name="BEGIN_LINK3"/>Thông báo quyền riêng tư cho Tài khoản Brave Software được quản lý bằng Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/> sẽ mở trong Brave. Bằng việc tiếp tục, bạn đồng ý với <ph name="BEGIN_LINK1"/>Điều khoản dịch vụ<ph name="END_LINK1"/> và <ph name="BEGIN_LINK2"/>Thông báo bảo mật<ph name="END_LINK2"/> của Brave.</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/> sẽ mở trong Brave. Bằng việc tiếp tục, bạn đồng ý với <ph name="BEGIN_LINK1"/>Điều khoản dịch vụ<ph name="END_LINK1"/> và <ph name="BEGIN_LINK2"/>Thông báo bảo mật<ph name="END_LINK2"/> của Brave, cũng như <ph name="BEGIN_LINK3"/>Thông báo bảo mật cho Tài khoản Brave Software được quản lý bằng Family Link<ph name="END_LINK3"/>.</translation>
+<translation id="673197144963363525">Giúp cải thiện Brave bằng cách gửi số liệu thống kê sử dụng và báo cáo sự cố cho Brave Software.</translation>
+<translation id="3518985090088779359">Chấp nhận và tiếp tục</translation>
+<translation id="7207456302801184289">Chào mừng bạn đến với Brave</translation>
+<translation id="704822250101715322">Đợi Dịch vụ của Brave Software Play cập nhật xong</translation>
+<translation id="1231733316453485619">Bạn muốn bật tính năng đồng bộ hóa?</translation>
+<translation id="5132942445612118989">Đồng bộ hóa mật khẩu, lịch sử và các thông tin khác của bạn trên tất cả các thiết bị</translation>
+<translation id="5736731321935944068">Brave Software có thể sử dụng lịch sử của bạn để điều chỉnh tính năng Tìm kiếm, quảng cáo và các dịch vụ khác của Brave Software cho phù hợp với bạn</translation>
+<translation id="4013614219085422040">Brave Software có thể sử dụng lịch sử của bạn để điều chỉnh tính năng Tìm kiếm và các dịch vụ khác của Brave Software cho phù hợp với bạn</translation>
+<translation id="5581519193887989363">Bạn luôn có thể chọn nội dung muốn đồng bộ hóa trong phần <ph name="BEGIN_LINK1"/>cài đặt<ph name="END_LINK1"/>.</translation>
+<translation id="741204030948306876">Có, tôi đồng ý</translation>
+<translation id="2410754283952462441">Chọn một tài khoản</translation>
+<translation id="2227444325776770048">Tiếp tục bằng <ph name="USER_FULL_NAME"/></translation>
+<translation id="6210748933810148297">Không phải là <ph name="EMAIL"/>?</translation>
+<translation id="8109613176066109935">Để sử dụng dấu trang trên tất cả các thiết bị, hãy bật tính năng đồng bộ hóa</translation>
+<translation id="2818669890320396765">Để sử dụng dấu trang trên tất cả các thiết bị, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
+<translation id="6003646045106347985">Để nhận nội dung do Brave Software đề xuất riêng cho bạn, hãy bật tính năng đồng bộ hóa</translation>
+<translation id="8494430740943879273">Để nhận nội dung do Brave Software đề xuất riêng cho bạn, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
+<translation id="5862731021271217234">Để sử dụng các tab từ những thiết bị khác, hãy bật tính năng đồng bộ hóa</translation>
+<translation id="3568688522516854065">Để sử dụng các tab từ những thiết bị khác, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
+<translation id="1208340532756947324">Để đồng bộ hóa và cá nhân hóa trên các thiết bị, hãy bật tính năng đồng bộ hóa</translation>
+<translation id="4472118726404937099">Để đồng bộ hóa và cá nhân hóa trên các thiết bị, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
+<translation id="2426805022920575512">Chọn một tài khoản khác</translation>
+<translation id="6790428901817661496">Phát</translation>
+<translation id="1272079795634619415">Dừng</translation>
+<translation id="2874939134665556319">Bản nhạc trước</translation>
+<translation id="4046123991198612571">Bản nhạc tiếp theo</translation>
+<translation id="3859306556332390985">Tìm kiếm tiến</translation>
+<translation id="8441146129660941386">Tìm kiếm lùi</translation>
+<translation id="6706288973712894588">Bạn hiện chưa kết nối Internet.\n<ph name="BEGIN_LINK"/>Hãy khám phá nguồn cấp dữ liệu khi không có mạng.<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">Các tab gần đây</translation>
+<translation id="8497726226069778601">Chưa có gì để xem ở đây...</translation>
+<translation id="5423934151118863508">Trang bạn truy cập nhiều nhất sẽ xuất hiện ở đây</translation>
+<translation id="6127379762771434464">Đã xóa mục</translation>
+<translation id="4605958867780575332">Đã xóa mục: <ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Hình tượng trưng của Brave Software: <ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">Thiết bị khác</translation>
+<translation id="4738836084190194332">Đồng bộ hóa lần gần đây nhất: <ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# phút trước}other{# phút trước}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# giờ trước}other{# giờ trước}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# ngày trước}other{# ngày trước}}</translation>
+<translation id="2762000892062317888">vừa xong</translation>
+<translation id="1407135791313364759">Mở tất cả</translation>
+<translation id="1209206284964581585">Ẩn ngay bây giờ</translation>
+<translation id="129553762522093515">Các tab đã đóng gần đây</translation>
+<translation id="8413126021676339697">Hiển thị toàn bộ lịch sử</translation>
+<translation id="7876243839304621966">Xóa tất cả</translation>
+<translation id="8487700953926739672">Khả dụng ngoại tuyến</translation>
+<translation id="5224771365102442243">Có video</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>Tìm hiểu thêm<ph name="END_LINK"/> về nội dung đề xuất</translation>
+<translation id="7542481630195938534">Không thể nhận nội dung đề xuất</translation>
+<translation id="5013696553129441713">Không có nội dung đề xuất mới</translation>
+<translation id="1736419249208073774">Khám phá</translation>
+<translation id="7444811645081526538">Danh mục khác</translation>
+<translation id="6709133671862442373">Tin tức</translation>
+<translation id="1264974993859112054">Thể thao</translation>
+<translation id="9139318394846604261">Mua sắm</translation>
+<translation id="3912508018559818924">Đang tìm dữ liệu thích hợp nhất từ web…</translation>
+<translation id="526421993248218238">Không thể tải trang này</translation>
+<translation id="614940544461990577">Hãy thử:</translation>
+<translation id="3288003805934695103">Đang tải lại trang</translation>
+<translation id="2353636109065292463">Kiểm tra kết nối Internet</translation>
+<translation id="2858138569776157458">Trang web hàng đầu</translation>
+<translation id="8364299278605033898">Xem các trang web phổ biến</translation>
+<translation id="1171770572613082465">Xem các trang web phổ biến bằng cách nhấn vào nút "Trang web hàng đầu"</translation>
+<translation id="5233638681132016545">Tab mới</translation>
+<translation id="4521874409998847950">Từ <ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>Do Brave Software phân phối<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">Đã có phiên bản mới hơn</translation>
+<translation id="4058091506841967397">Brave không thể cập nhật</translation>
+<translation id="6316139424528454185">Phiên bản Android không được hỗ trợ</translation>
+<translation id="6989267951144302301">Không thể tải xuống</translation>
+<translation id="624789221780392884">Bản cập nhật đã sẵn sàng</translation>
+<translation id="1549000191223877751">Di chuyển đến cửa sổ khác</translation>
+<translation id="7481312909269577407">Chuyển tiếp</translation>
+<translation id="4084682180776658562">Dấu trang</translation>
+<translation id="6437478888915024427">Thông tin trang</translation>
+<translation id="7180611975245234373">Làm mới</translation>
+<translation id="4913169188695071480">Ngừng làm mới</translation>
+<translation id="1829244130665387512">Tìm trong trang</translation>
+<translation id="6593061639179217415">Trang web cho máy tính</translation>
+<translation id="9063523880881406963">Tắt Yêu cầu trang web cho máy tính</translation>
+<translation id="2038563949887743358">Bật Yêu cầu trang web cho máy tính</translation>
+<translation id="2433507940547922241">Hình thức</translation>
+<translation id="983192555821071799">Đóng tất cả các tab</translation>
+<translation id="1310482092992808703">Nhóm các tab</translation>
+<translation id="7725024127233776428">Các trang mà bạn đánh dấu sẽ xuất hiện tại đây</translation>
+<translation id="4404568932422911380">Không có dấu trang nào</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> dấu trang}other{<ph name="BOOKMARKS_COUNT_MANY"/> dấu trang}}</translation>
+<translation id="3739899004075612870">Đã đánh dấu trang trong <ph name="PRODUCT_NAME"/></translation>
+<translation id="3207960819495026254">Đã đánh dấu trang</translation>
+<translation id="4452548195519783679">Đã đánh dấu trang vào <ph name="FOLDER_NAME"/></translation>
+<translation id="8063895661287329888">Không thêm được dấu trang.</translation>
+<translation id="2842985007712546952">Thư mục mẹ</translation>
+<translation id="9065203028668620118">Chỉnh sửa</translation>
+<translation id="4405224443901389797">Chuyển tới...</translation>
+<translation id="5170568018924773124">Hiển thị trong thư mục</translation>
+<translation id="8035133914807600019">Thư mục mới...</translation>
+<translation id="4532845899244822526">Chọn thư mục</translation>
+<translation id="6627583120233659107">Chỉnh sửa thư mục</translation>
+<translation id="1197267115302279827">Di chuyển dấu trang</translation>
+<translation id="6963766334940102469">Xóa dấu trang</translation>
+<translation id="4351244548802238354">Đóng hộp thoại</translation>
+<translation id="451872707440238414">Tìm kiếm trong các dấu trang</translation>
+<translation id="8901170036886848654">Không tìm thấy dấu trang</translation>
+<translation id="6404511346730675251">Chỉnh sửa dấu trang</translation>
+<translation id="3894427358181296146">Thêm thư mục</translation>
+<translation id="5327248766486351172">Tên</translation>
+<translation id="7400418766976504921">URL</translation>
+<translation id="3527085408025491307">Thư mục</translation>
+<translation id="5161254044473106830">Cần có tiêu đề</translation>
+<translation id="2996809686854298943">Cần có URL</translation>
+<translation id="2536728043171574184">Xem bản sao ngoại tuyến của trang này</translation>
+<translation id="4698034686595694889">Xem ngoại tuyến trong <ph name="APP_NAME"/></translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> và các trang web khác</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave sẽ tải trang của bạn khi sẵn sàng}other{Brave sẽ tải trang của bạn khi sẵn sàng}}</translation>
+<translation id="6811034713472274749">Trang hiện đã sẵn sàng cho bạn xem</translation>
+<translation id="4561979708150884304">Không có kết nối</translation>
+<translation id="8274165955039650276">Xem tệp đã tải xuống</translation>
+<translation id="2082238445998314030">Kết quả <ph name="RESULT_NUMBER"/> trong tổng số <ph name="TOTAL_RESULTS"/></translation>
+<translation id="4943872375798546930">Không tìm thấy kết quả nào</translation>
+<translation id="981121421437150478">Ngoại tuyến</translation>
+<translation id="3298243779924642547">Phiên bản rút gọn</translation>
+<translation id="393697183122708255">Không có tìm kiếm bằng giọng nói đã bật</translation>
+<translation id="7191430249889272776">Tab được mở dưới nền.</translation>
+<translation id="8445059357334030806">Mở trong Brave</translation>
+<translation id="4720023427747327413">Mở trong <ph name="PRODUCT_NAME"/></translation>
+<translation id="7022756207310403729">Mở trong trình duyệt</translation>
+<translation id="1113597929977215864">Hiển thị chế độ xem đơn giản</translation>
+<translation id="1513352483775369820">Dấu trang và lịch sử web</translation>
+<translation id="4939482511480190003">Hãy giúp cải tiến Brave. <ph name="BEGIN_LINK"/>Tham gia khảo sát<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">Quay lại</translation>
+<translation id="5596627076506792578">Tùy chọn khác</translation>
+<translation id="3522247891732774234">Bản cập nhật có sẵn. Tùy chọn khác</translation>
+<translation id="6773423637732432200">Brave không thể cập nhật. Tùy chọn khác</translation>
+<translation id="3328801116991980348">Thông tin về trang web</translation>
+<translation id="5391532827096253100">Kết nối của bạn tới trang web này không an toàn. Thông tin trang web</translation>
+<translation id="6206551242102657620">Kết nối an toàn. Thông tin trang web</translation>
+<translation id="6963642900430330478">Trang này nguy hiểm. Thông tin trang web</translation>
+<translation id="9070377983101773829">Bắt đầu tìm kiếm bằng giọng nói</translation>
+<translation id="8676374126336081632">Xóa văn bản nhập</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> tab đang mở, nhấn để chuyển tab}other{<ph name="OPEN_TABS_MANY"/> tab đang mở, nhấn để chuyển tab}}</translation>
+<translation id="2369533728426058518">tab đang mở</translation>
+<translation id="7071521146534760487">Quản lý tài khoản</translation>
+<translation id="932327136139879170">Trang chủ</translation>
+<translation id="2707726405694321444">Làm mới trang</translation>
+<translation id="2891154217021530873">Ngừng tải trang</translation>
+<translation id="6710213216561001401">Trước đó</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">Tab được chọn</translation>
+<translation id="2268044343513325586">Tinh chỉnh</translation>
+<translation id="7846076177841592234">Hủy chọn</translation>
+<translation id="7087918508125750058">Đã chọn <ph name="ITEM_COUNT"/> mục. Bạn có thể sử dụng các tùy chọn ở gần đầu màn hình</translation>
+<translation id="7250468141469952378">Đã chọn <ph name="ITEM_COUNT"/></translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{Chia sẻ 1 mục đã chọn}other{Chia sẻ # mục đã chọn}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{Xóa 1 mục đã chọn}other{Xóa # mục đã chọn}}</translation>
+<translation id="1283039547216852943">Nhấn để mở rộng</translation>
+<translation id="5962718611393537961">Nhấn để thu gọn</translation>
+<translation id="8076492880354921740">Tab</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{Đã chọn 1 mục}other{Đã chọn # mục}}</translation>
+<translation id="6818926723028410516">Chọn mục</translation>
+<translation id="4797039098279997504">Chạm để quay lại <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">Nhấn để chuyển đến trang web</translation>
+<translation id="429312253194641664">Một trang web đang phát nội dung đa phương tiện</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> đang chia sẻ màn hình của bạn</translation>
+<translation id="8833831881926404480">Một trang web đang chia sẻ màn hình của bạn</translation>
+<translation id="9086455579313502267">Không thể truy cập mạng</translation>
+<translation id="938850635132480979">Lỗi: <ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">Mở trong <ph name="APP_NAME"/></translation>
+<translation id="548278423535722844">Mở trong ứng dụng bản đồ</translation>
+<translation id="7698359219371678927">Tạo email trong <ph name="APP_NAME"/></translation>
+<translation id="7875915731392087153">Tạo email</translation>
+<translation id="5665379678064389456">Tạo sự kiện trong <ph name="APP_NAME"/></translation>
+<translation id="2900528713135656174">Tạo sự kiện</translation>
+<translation id="2111511281910874386">Chuyển đến trang</translation>
+<translation id="3988466920954086464">Xem kết quả tìm kiếm tức thì trong bảng điều khiển này</translation>
+<translation id="2744248271121720757">Hãy nhấn vào một từ để tìm kiếm ngay hoặc xem các hành động có liên quan</translation>
+<translation id="9155898266292537608">Bạn cũng có thể tìm kiếm bằng cách nhấn nhanh vào một từ</translation>
+<translation id="3232754137068452469">Ứng dụng web</translation>
+<translation id="1430915738399379752">In</translation>
+<translation id="3775705724665058594">Gửi đến các thiết bị của bạn</translation>
+<translation id="6364438453358674297">Xóa đề xuất khỏi lịch sử?</translation>
+<translation id="213279576345780926">Đã đóng <ph name="TAB_TITLE"/></translation>
+<translation id="6850830437481525139">Đã đóng <ph name="TAB_COUNT"/> tab</translation>
+<translation id="3211426585530211793">Đã xóa <ph name="ITEM_TITLE"/></translation>
+<translation id="4663756553811254707">Đã xóa <ph name="NUMBER_OF_BOOKMARKS"/> dấu trang</translation>
+<translation id="3819178904835489326">Đã xóa <ph name="NUMBER_OF_DOWNLOADS"/> bản tải xuống</translation>
+<translation id="1248710015876067820">Số phiên bản Brave không được hỗ trợ.</translation>
+<translation id="4259722352634471385">Điều hướng bị chặn: <ph name="URL"/></translation>
+<translation id="8959122750345127698">Không thể tiếp cận điều hướng: <ph name="URL"/></translation>
+<translation id="5210365745912300556">Đóng tab</translation>
+<translation id="7772375229873196092">Đóng <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">Lịch sử di chuyển</translation>
+<translation id="9169507124922466868">Lịch sử di chuyển đang mở ở nửa dưới màn hình</translation>
+<translation id="1327257854815634930">Lịch sử di chuyển đang mở</translation>
+<translation id="8788265440806329501">Lịch sử di chuyển đã đóng</translation>
+<translation id="7482656565088326534">Tab xem trước</translation>
+<translation id="8427875596167638501">Tab xem trước đang mở trên nửa màn hình</translation>
+<translation id="9102803872260866941">Tab xem trước đang mở</translation>
+<translation id="2942036813789421260">Tab xem trước đang đóng</translation>
+<translation id="6355102470683871794">Bộ nhớ Brave Software <ph name="APP_NAME"/></translation>
+<translation id="3822502789641063741">Xóa dữ liệu trang trong bộ nhớ?</translation>
+<translation id="9205995714227143200">Bộ nhớ trang web mà Brave cho rằng không quan trọng (ví dụ: những trang web không có cài đặt đã lưu nào hoặc trang web mà bạn không truy cập thường xuyên)</translation>
+<translation id="3997476611815694295">Bộ nhớ không quan trọng</translation>
+<translation id="8493948351860045254">Giải phóng dung lượng</translation>
+<translation id="2324920234469020158">Thao tác này sẽ xóa cookie, bộ nhớ đệm và các dữ liệu khác của các trang web mà Brave cho rằng không quan trọng.</translation>
+<translation id="5447201525962359567">Tất cả bộ nhớ trang web, bao gồm cookie và các dữ liệu được lưu trữ cục bộ khác</translation>
+<translation id="1376578503827013741">Đang tính toán...</translation>
+<translation id="583281660410589416">Không xác định</translation>
+<translation id="2323763861024343754">Bộ nhớ trang web</translation>
+<translation id="3587672679800759167">Tổng số dữ liệu mà Brave sử dụng, bao gồm tài khoản, dấu trang và cài đặt đã lưu</translation>
+<translation id="6545017243486555795">Xóa tất cả dữ liệu</translation>
+<translation id="4095146165863963773">Xóa dữ liệu ứng dụng?</translation>
+<translation id="53119194224775367">Tất cả dữ liệu của ứng dụng Brave sẽ bị xóa vĩnh viễn, bao gồm tất cả các tệp, các tùy chọn cài đặt, tài khoản, cơ sở dữ liệu, v.v.</translation>
+<translation id="5307446750509046227">Xóa bộ nhớ trang web</translation>
+<translation id="300526633675317032">Thao tác này sẽ xóa tất cả <ph name="SIZE_IN_KB"/> bộ nhớ trang web.</translation>
+<translation id="8068648041423924542">Không thể chọn chứng chỉ.</translation>
+<translation id="2315043854645842844">Lựa chọn chứng chỉ phía ứng dụng khách không được hệ điều hành hỗ trợ.</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> muốn kết nối</translation>
+<translation id="5308380583665731573">Kết nối</translation>
+<translation id="868929229000858085">Tìm kiếm trong danh bạ</translation>
+<translation id="1919950603503897840">Chọn mục liên hệ</translation>
+<translation id="7986741934819883144">Chọn một người liên hệ</translation>
+<translation id="3333961966071413176">Tất cả người liên hệ</translation>
+<translation id="4994033804516042629">Không tìm thấy người liên hệ nào</translation>
+<translation id="5403592356182871684">Tên</translation>
+<translation id="2717722538473713889">Địa chỉ email</translation>
+<translation id="381841723434055211">Số điện thoại</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(+ 1 lựa chọn khác)}other{(+ # lựa chọn khác)}}</translation>
+<translation id="5197729504361054390">Những người liên hệ bạn chọn sẽ được chia sẻ với <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>.</translation>
+<translation id="1779089405699405702">Bộ giải mã hình ảnh</translation>
+<translation id="8067883171444229417">Phát video</translation>
+<translation id="6560414384669816528">Tìm kiếm với Sogou</translation>
+<translation id="5406914950576900927">Brave có thể sử dụng <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> để tìm kiếm tại Trung Quốc. Bạn có thể thay đổi điều này trong <ph name="BEGIN_LINK"/>Cài đặt<ph name="END_LINK"/>.</translation>
+<translation id="6456271171669383967">Giữ Brave Software làm công cụ tìm kiếm mặc định</translation>
+<translation id="4384468725000734951">Sử dụng Sogou để tìm kiếm</translation>
+<translation id="6103327872225198548">Sử dụng Brave Software để tìm kiếm</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Ứng dụng này đang chạy trong Brave</translation>
+<translation id="6143689084714664628">Đang chạy trong Brave</translation>
+<translation id="7675869148432102528"><ph name="APP_NAME"/> cũng có dữ liệu trong Brave</translation>
+<translation id="2734140769649165081">Bạn có thể xóa dữ liệu trong mục Cài đặt của Brave</translation>
+<translation id="8232956427053453090">Lưu giữ dữ liệu</translation>
+<translation id="4298388696830689168">Các trang web liên kết</translation>
+<translation id="5763514718066511291">Nhấn để sao chép URL cho ứng dụng này</translation>
+<translation id="6496823230996795692">Để sử dụng <ph name="APP_NAME"/> lần đầu tiên, vui lòng kết nối Internet.</translation>
+<translation id="751961395872307827">Không thể kết nối với trang web</translation>
+<translation id="4878404682131129617">Thiết lập đường hầm qua máy chủ proxy không thành công</translation>
+<translation id="4749960740855309258">Mở tab mới</translation>
+<translation id="8788968922598763114">Mở lại tab đóng sau cùng</translation>
+<translation id="7929962904089429003">Mở menu</translation>
+<translation id="6039379616847168523">Chuyển sang tab tiếp theo</translation>
+<translation id="5210286577605176222">Quay về tab trước</translation>
+<translation id="124678866338384709">Đóng tab hiện tại</translation>
+<translation id="3714981814255182093">Mở thanh Tìm kiếm</translation>
+<translation id="5441522332038954058">Chuyển đến thanh địa chỉ</translation>
+<translation id="3398320232533725830">Mở trình quản lý dấu trang</translation>
+<translation id="6583199322650523874">Đánh dấu trang hiện tại</translation>
+<translation id="8489271220582375723">Mở trang lịch sử</translation>
+<translation id="4837753911714442426">Mở tùy chọn để in trang</translation>
+<translation id="5726692708398506830">Phóng to mọi nội dung trên trang</translation>
+<translation id="3259831549858767975">Thu nhỏ mọi nội dung trên trang</translation>
+<translation id="8015452622527143194">Trả lại mọi nội dung trên trang về kích thước mặc định</translation>
+<translation id="3443221991560634068">Tải lại trang hiện tại</translation>
+<translation id="123724288017357924">Tải lại trang hiện tại, bỏ qua nội dung được lưu trong bộ nhớ đệm</translation>
+<translation id="305870044889644984">Mở Trung tâm trợ giúp Brave trong tab mới</translation>
+<translation id="3166827708714933426">Phím tắt dành cho tab và cửa sổ</translation>
+<translation id="3169981355900570544">Phím tắt cho các tính năng của Brave Software Brave</translation>
+<translation id="4558311620361989323">Phím tắt cho trang web</translation>
+<translation id="1908301351964700579">Brave vẫn đang chuẩn bị mô-đun Thực tế ảo. Hãy khởi động lại Brave sau.</translation>
+<translation id="8970887620466824814">Đã xảy ra lỗi.</translation>
+<translation id="1875543012935658554">Mở lại Brave.</translation>
+<translation id="79859296434321399">Để xem nội dung thực tế tăng cường, hãy cài đặt bộ công cụ ARCore</translation>
+<translation id="8558485628462305855">Để xem nội dung thực tế tăng cường, hãy cập nhật bộ công cụ ARCore</translation>
+<translation id="3513704683820682405">Thực tế tăng cường</translation>
+<translation id="5475862044948910901">Bắt đầu phiên đăng nhập thực tế tăng cường?</translation>
 <translation id="7365126855094612066">Trong suốt thời gian diễn ra phiên đăng nhập này, trang web có thể:
 • tạo bản đồ 3D về môi trường xung quanh bạn
 • theo dõi chuyển động của máy ảnh
 
 Trang web này KHÔNG có quyền truy cập vào máy ảnh. Chỉ bạn mới xem được hình ảnh trong máy ảnh.</translation>
-<translation id="7375125077091615385">Loại:</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />.</translation>
-<translation id="7400418766976504921">URL</translation>
-<translation id="7403691278183511381">Trải nghiệm lần chạy đầu tiên của Chrome</translation>
-<translation id="741204030948306876">Có, tôi đồng ý</translation>
-<translation id="7413229368719586778">Ngày bắt đầu <ph name="DATE" /></translation>
-<translation id="7423098979219808738">Hỏi trước</translation>
-<translation id="7423538860840206698">Đã chặn quyền đọc khay nhớ tạm</translation>
-<translation id="7431991332293347422">Kiểm soát cách Google sử dụng lịch sử duyệt web của bạn để cá nhân hóa dịch vụ Tìm kiếm và các dịch vụ khác</translation>
-<translation id="7437998757836447326">Đăng xuất khỏi Chrome</translation>
-<translation id="7438641746574390233">Khi bạn bật Chế độ thu gọn, Chrome sẽ sử dụng máy chủ của Google để tải trang nhanh hơn. Chế độ thu gọn sẽ ghi lại các trang tốc độ rất chậm để chỉ tải nội dung cần thiết. Chế độ thu gọn không áp dụng cho Tab ẩn danh.</translation>
-<translation id="7444811645081526538">Danh mục khác</translation>
-<translation id="7445411102860286510">Cho phép trang web tự động phát video tắt tiếng (được đề xuất)</translation>
-<translation id="7453467225369441013">Đăng xuất bạn khỏi hầu hết các trang web. Bạn sẽ không bị đăng xuất khỏi Tài khoản Google của mình.</translation>
-<translation id="7454641608352164238">Không đủ dung lượng</translation>
-<translation id="7475192538862203634">Nếu bạn thường xuyên thấy thông báo này, hãy thử các <ph name="BEGIN_LINK" />đề xuất<ph name="END_LINK" /> sau.</translation>
-<translation id="7475688122056506577">Không tìm thấy thẻ SD. Một số tệp của bạn có thể bị thiếu.</translation>
-<translation id="7479104141328977413">Quản lý tab</translation>
-<translation id="7481312909269577407">Chuyển tiếp</translation>
-<translation id="7482656565088326534">Tab xem trước</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (Đã cập nhật <ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">dữ liệu đã tiết kiệm</translation>
-<translation id="7498271377022651285">Vui lòng đợi…</translation>
-<translation id="7514365320538308">Tải xuống</translation>
-<translation id="751961395872307827">Không thể kết nối với trang web</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">Không thể nhận nội dung đề xuất</translation>
-<translation id="7559975015014302720">Chế độ thu gọn đang tắt</translation>
-<translation id="7562080006725997899">Xóa dữ liệu duyệt web</translation>
-<translation id="756809126120519699">Đã xóa dữ liệu Chrome</translation>
-<translation id="757524316907819857">Chặn không cho trang web phát nội dung được bảo vệ</translation>
-<translation id="757855969265046257">{FILES,plural, =1{Đã tải <ph name="FILES_DOWNLOADED_ONE" /> tệp xuống}other{Đã tải <ph name="FILES_DOWNLOADED_MANY" /> tệp xuống}}</translation>
-<translation id="7588219262685291874">Bật giao diện tối khi Trình tiết kiệm pin trên thiết bị đang bật</translation>
-<translation id="7589445247086920869">Chặn công cụ tìm kiếm hiện tại</translation>
-<translation id="7593557518625677601">Mở c.đặt Android &amp; bật lại đ.bộ hóa hệ thống Android để b.đầu đồng bộ hóa Chrome</translation>
-<translation id="7596558890252710462">Hệ điều hành</translation>
-<translation id="7605594153474022051">Đồng bộ hóa không hoạt động</translation>
-<translation id="7606077192958116810">Chế độ thu gọn đang bật. Quản lý chế độ này trong phần Cài đặt.</translation>
-<translation id="7612619742409846846">Đã đăng nhập vào Google bằng</translation>
-<translation id="7619072057915878432">Tải xuống không thành công <ph name="FILE_NAME" /> do lỗi mạng.</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />Nhận trợ giúp<ph name="END_LINK1" /> hoặc <ph name="BEGIN_LINK2" />quét lại<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">Chào mừng bạn đến với Chrome</translation>
-<translation id="7638584964844754484">Cụm mật khẩu không chính xác</translation>
-<translation id="7641339528570811325">Xóa dữ liệu duyệt web…</translation>
-<translation id="7648422057306047504">Mã hóa mật khẩu bằng thông tin đăng nhập Google</translation>
-<translation id="7649070708921625228">Trợ giúp</translation>
-<translation id="7658239707568436148">Hủy</translation>
-<translation id="7665369617277396874">Thêm tài khoản</translation>
-<translation id="766587987807204883">Các bài viết xuất hiện ở đây và bạn có thể đọc ngay cả khi không có kết nối mạng</translation>
-<translation id="7682724950699840886">Thử các mẹo sau: đảm bảo thiết bị của bạn có đủ dung lượng, sau đó thử xuất lại.</translation>
-<translation id="7685301384041462804">Nhớ kiểm tra xem trang web này có tin cậy không trước khi vào chế độ thực tế ảo.</translation>
-<translation id="7698359219371678927">Tạo email trong <ph name="APP_NAME" /></translation>
-<translation id="7704317875155739195">Tự động hoàn thành cụm từ tìm kiếm và URL</translation>
-<translation id="7725024127233776428">Các trang mà bạn đánh dấu sẽ xuất hiện tại đây</translation>
-<translation id="773466115871691567">Luôn dịch các trang viết bằng <ph name="SOURCE_LANGUAGE" /></translation>
-<translation id="7746457520633464754">Để phát hiện các ứng dụng và trang web nguy hiểm, Chrome sẽ gửi URL của một số trang mà bạn truy cập, thông tin hệ thống giới hạn và một số nội dung trang cho Google</translation>
-<translation id="7757787379047923882">Văn bản được chia sẻ từ <ph name="DEVICE_NAME" /></translation>
-<translation id="7762668264895820836">Thẻ SD <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">Thêm địa chỉ</translation>
-<translation id="7772032839648071052">Xác nhận cụm mật khẩu</translation>
-<translation id="7772375229873196092">Đóng <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> tùy chọn khác}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 và <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> tùy chọn khác}}</translation>
-<translation id="7781829728241885113">Hôm qua</translation>
-<translation id="7791543448312431591">Thêm</translation>
-<translation id="780301667611848630">Không, cảm ơn</translation>
-<translation id="7810647596859435254">Mở bằng…</translation>
-<translation id="7821588508402923572">Mức tiết kiệm dữ liệu sẽ hiển thị tại đây</translation>
-<translation id="7837721118676387834">Cho phép tự động phát video bị tắt tiếng cho trang web cụ thể.</translation>
-<translation id="7846076177841592234">Hủy chọn</translation>
-<translation id="784934925303690534">Phạm vi thời gian</translation>
-<translation id="7851858861565204677">Thiết bị khác</translation>
-<translation id="7875915731392087153">Tạo email</translation>
-<translation id="7876243839304621966">Xóa tất cả</translation>
-<translation id="7882131421121961860">Không tìm thấy nội dung nào khớp</translation>
-<translation id="7882806643839505685">Cho phép phát âm thanh trên một trang web cụ thể.</translation>
-<translation id="7886917304091689118">Đang chạy trong Chrome</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{Đang tải tệp xuống.}other{Đang tải # tệp xuống.}}</translation>
-<translation id="7929962904089429003">Mở menu</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> đã lỗi thời.</translation>
-<translation id="7947953824732555851">Chấp nhận &amp; đăng nhập</translation>
-<translation id="7963646190083259054">Nhà cung cấp:</translation>
-<translation id="7971136598759319605">Hoạt động 1 ngày trước</translation>
-<translation id="7975379999046275268">Xem trước trang <ph name="BEGIN_NEW" />Mới<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">Tải trước các trang để tìm kiếm và duyệt web nhanh hơn</translation>
-<translation id="79859296434321399">Để xem nội dung thực tế tăng cường, hãy cài đặt bộ công cụ ARCore</translation>
-<translation id="7986741934819883144">Chọn một người liên hệ</translation>
-<translation id="7987073022710626672">Điều khoản dịch vụ của Chrome</translation>
-<translation id="7998918019931843664">Mở lại tab đã đóng</translation>
-<translation id="7999064672810608036">Bạn có chắc chắn muốn xóa tất cả dữ liệu cục bộ, bao gồm cookie và đặt lại tất cả các quyền cho trang web này không?</translation>
-<translation id="8004582292198964060">Trình duyệt</translation>
-<translation id="8007176423574883786">Tắt cho thiết bị này</translation>
-<translation id="8013372441983637696">Xóa cả dữ liệu của bạn trên Chrome khỏi thiết bị này</translation>
-<translation id="8015452622527143194">Trả lại mọi nội dung trên trang về kích thước mặc định</translation>
-<translation id="802154636333426148">Tải xuống không thành công</translation>
-<translation id="8026334261755873520">Xóa dữ liệu duyệt web</translation>
-<translation id="8035133914807600019">Thư mục mới...</translation>
-<translation id="8037750541064988519">Còn <ph name="DAYS" /> ngày</translation>
-<translation id="804335162455518893">Không tìm thấy thẻ SD</translation>
-<translation id="805047784848435650">Dựa trên lịch sử duyệt web của bạn</translation>
-<translation id="8051695050440594747">Còn <ph name="MEGABYTES" /> MB</translation>
-<translation id="8058746566562539958">Mở trong tab Chrome mới</translation>
-<translation id="8063895661287329888">Không thêm được dấu trang.</translation>
-<translation id="806745655614357130">Giữ dữ liệu của tôi riêng biệt</translation>
-<translation id="8067883171444229417">Phát video</translation>
-<translation id="8068648041423924542">Không thể chọn chứng chỉ.</translation>
-<translation id="8073388330009372546">Mở ảnh trong tab mới</translation>
-<translation id="8076492880354921740">Tab</translation>
-<translation id="8084114998886531721">Mật khẩu đã lưu</translation>
-<translation id="8087000398470557479">Nội dung này đến từ <ph name="DOMAIN_NAME" />, do Google phân phối.</translation>
-<translation id="8103578431304235997">Tab ẩn danh</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">Để sử dụng dấu trang trên tất cả các thiết bị, hãy bật tính năng đồng bộ hóa</translation>
-<translation id="8110087112193408731">Bạn có muốn hiển thị hoạt động của mình trên Chrome trong Digital Wellbeing không?</translation>
-<translation id="8116925261070264013">Đã ẩn</translation>
-<translation id="813082847718468539">Xem thông tin trang web</translation>
-<translation id="8131740175452115882">Xác nhận</translation>
-<translation id="8156139159503939589">Bạn sử dụng ngôn ngữ nào?</translation>
-<translation id="8168435359814927499">Nội dung</translation>
-<translation id="8186512483418048923">Còn lại <ph name="FILES" /> tệp</translation>
-<translation id="8190358571722158785">Còn 1 ngày</translation>
-<translation id="8200772114523450471">Tiếp tục</translation>
-<translation id="8209050860603202033">Mở ảnh</translation>
-<translation id="8218622182176210845">Quản lý tài khoản của bạn</translation>
-<translation id="8224471946457685718">Tải tin bài cho bạn xuống qua Wi-Fi</translation>
-<translation id="8232956427053453090">Lưu giữ dữ liệu</translation>
-<translation id="8249310407154411074">Chuyển lên trên cùng</translation>
-<translation id="8250920743982581267">Tài liệu</translation>
-<translation id="825412236959742607">Trang này sử dụng quá nhiều bộ nhớ, nên Chrome đã xóa bớt nội dung.</translation>
-<translation id="8260126382462817229">Thử đăng nhập lại</translation>
-<translation id="8261506727792406068">Xóa</translation>
-<translation id="8266862848225348053">Vị trí tải xuống</translation>
-<translation id="8274165955039650276">Xem tệp đã tải xuống</translation>
-<translation id="8284326494547611709">Phụ đề</translation>
-<translation id="8300705686683892304">Do ứng dụng quản lý</translation>
-<translation id="8310344678080805313">Tab chuẩn</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> và các trang web khác</translation>
-<translation id="8327155640814342956">Để có trải nghiệm duyệt web tuyệt vời nhất, hãy mở để cập nhật Chrome</translation>
-<translation id="8339163506404995330">Các trang viết bằng <ph name="LANGUAGE" /> sẽ không được dịch</translation>
-<translation id="8349013245300336738">Sắp xếp theo lượng dữ liệu đã dùng</translation>
-<translation id="8364299278605033898">Xem các trang web phổ biến</translation>
-<translation id="8368027906805972958">Thiết bị không xác định hoặc không được hỗ trợ (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">Cho phép Đồng bộ hóa dưới nền cho trang web cụ thể.</translation>
-<translation id="8378714024927312812">Do tổ chức của bạn quản lý</translation>
-<translation id="8380167699614421159">Trang web này hiển thị quảng cáo xâm nhập hoặc quảng cáo gây hiểu nhầm</translation>
-<translation id="8393700583063109961">Gửi tin nhắn</translation>
-<translation id="8413126021676339697">Hiển thị toàn bộ lịch sử</translation>
-<translation id="8427875596167638501">Tab xem trước đang mở trên nửa màn hình</translation>
-<translation id="8428213095426709021">Cài đặt</translation>
-<translation id="8438566539970814960">Cải thiện tính năng tìm kiếm và duyệt web</translation>
-<translation id="8441146129660941386">Tìm kiếm lùi</translation>
-<translation id="8443209985646068659">Chrome không thể cập nhật</translation>
-<translation id="8445448999790540984">Không xuất được mật khẩu</translation>
-<translation id="8447861592752582886">Thu hồi quyền truy cập thiết bị</translation>
-<translation id="8461694314515752532">Mã hóa dữ liệu đã đồng bộ hóa bằng cụm mật khẩu đồng bộ hóa của riêng bạn</translation>
-<translation id="8466613982764129868">Hãy đảm bảo <ph name="TARGET_DEVICE_NAME" /> có kết nối Internet</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">Khả dụng ngoại tuyến</translation>
-<translation id="8489271220582375723">Mở trang lịch sử</translation>
-<translation id="8493948351860045254">Giải phóng dung lượng</translation>
-<translation id="8497726226069778601">Chưa có gì để xem ở đây...</translation>
-<translation id="8503559462189395349">Mật khẩu Chrome</translation>
-<translation id="8503813439785031346">Tên người dùng</translation>
-<translation id="8514477925623180633">Xuất mật khẩu đã lưu trữ với Chrome</translation>
-<translation id="8514577642972634246">Vào chế độ ẩn danh</translation>
-<translation id="851751545965956758">Chặn các trang web kết nối với thiết bị</translation>
-<translation id="8523928698583292556">Xóa mật khẩu đã lưu trữ</translation>
-<translation id="854522910157234410">Mở trang này</translation>
-<translation id="8558485628462305855">Để xem nội dung thực tế tăng cường, hãy cập nhật bộ công cụ ARCore</translation>
-<translation id="8559990750235505898">Đề xuất dịch trang bằng các ngôn ngữ khác</translation>
-<translation id="8562452229998620586">Mật khẩu đã lưu của bạn sẽ xuất hiện tại đây.</translation>
-<translation id="8569404424186215731">kể từ <ph name="DATE" /></translation>
-<translation id="8571213806525832805">4 tuần qua</translation>
-<translation id="857943718398505171">Được phép (được đề xuất)</translation>
-<translation id="8583805026567836021">Xóa dữ liệu tài khoản</translation>
-<translation id="860043288473659153">Tên chủ thẻ</translation>
-<translation id="8609465669617005112">Di chuyển lên</translation>
-<translation id="8616006591992756292">Tài khoản Google của bạn có thể có các dạng lịch sử duyệt web khác tại <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />.</translation>
-<translation id="8617240290563765734">Mở URL đề xuất được chỉ định trong nội dung được tải xuống?</translation>
-<translation id="8636825310635137004">Để có các tab từ các thiết bị khác của bạn, hãy bật đồng bộ hóa.</translation>
-<translation id="8641930654639604085">Cố gắng chặn các trang web cho người lớn</translation>
-<translation id="8655129584991699539">Bạn có thể xóa dữ liệu trong mục Cài đặt của Chrome</translation>
-<translation id="8662811608048051533">Đăng xuất bạn khỏi hầu hết các trang web.</translation>
-<translation id="8664979001105139458">Tên tệp đã tồn tại</translation>
-<translation id="8676374126336081632">Xóa văn bản nhập</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{Mức cường độ tín hiệu: # vạch}other{Mức cường độ tín hiệu: # vạch}}</translation>
-<translation id="868929229000858085">Tìm kiếm trong danh bạ</translation>
-<translation id="869891660844655955">Ngày hết hạn</translation>
-<translation id="8719023831149562936">Không thể chiếu tab hiện tại</translation>
-<translation id="8725066075913043281">Thử lại</translation>
-<translation id="8728487861892616501">Bằng việc sử dụng ứng dụng này, bạn đồng ý với <ph name="BEGIN_LINK1" />Điều khoản dịch vụ<ph name="END_LINK1" /> và <ph name="BEGIN_LINK2" />Thông báo quyền riêng tư<ph name="END_LINK2" /> của Chrome cũng như <ph name="BEGIN_LINK3" />Thông báo quyền riêng tư cho Tài khoản Google được quản lý bằng Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8730621377337864115">Xong</translation>
-<translation id="8748850008226585750">Nội dung bị ẩn</translation>
-<translation id="8751914237388039244">Chọn hình ảnh</translation>
-<translation id="8788265440806329501">Lịch sử di chuyển đã đóng</translation>
-<translation id="8788968922598763114">Mở lại tab đóng sau cùng</translation>
-<translation id="8801436777607969138">Chặn JavaScript cho một trang web cụ thể.</translation>
-<translation id="8812260976093120287">Trên một số trang web, bạn có thể thanh toán bằng các ứng dụng thanh toán được hỗ trợ bên trên trên thiết bị của bạn.</translation>
-<translation id="8816026460808729765">Chặn không cho các trang web sử dụng cảm biến</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" /> sẽ mở trong Chrome. Bằng việc tiếp tục, bạn đồng ý với <ph name="BEGIN_LINK1" />Điều khoản dịch vụ<ph name="END_LINK1" /> và <ph name="BEGIN_LINK2" />Thông báo bảo mật<ph name="END_LINK2" /> của Chrome, cũng như <ph name="BEGIN_LINK3" />Thông báo bảo mật cho Tài khoản Google được quản lý bằng Family Link<ph name="END_LINK3" />.</translation>
-<translation id="8820817407110198400">Dấu trang</translation>
-<translation id="8833831881926404480">Một trang web đang chia sẻ màn hình của bạn</translation>
-<translation id="883806473910249246">Đã xảy ra lỗi khi tải nội dung xuống.</translation>
-<translation id="8840953339110955557">Trang này có thể khác với phiên bản trực tuyến.</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198">Tab <ph name="TAB_TITLE" /></translation>
-<translation id="885701979325669005">Bộ nhớ</translation>
-<translation id="889338405075704026">Chuyển đến phần Cài đặt của Chrome</translation>
-<translation id="8901170036886848654">Không tìm thấy dấu trang</translation>
-<translation id="8909135823018751308">Chia sẻ...</translation>
-<translation id="8912362522468806198">Tài khoản Google</translation>
-<translation id="8920114477895755567">Đang đợi thông tin chi tiết của phụ huynh.</translation>
+<translation id="1188239144602654184">Chuyển sang thực tế tăng cường</translation>
+<translation id="473775607612524610">Cập nhật</translation>
+<translation id="3133489217401741157">Đang cài đặt <ph name="MODULE"/> cho Brave…</translation>
+<translation id="1791662854739702043">Đã cài đặt</translation>
+<translation id="5131234170665854056">Không thể cài đặt <ph name="MODULE"/> cho Brave</translation>
+<translation id="2567385386134582609">HÌNH ẢNH</translation>
+<translation id="6395288395575013217">LIÊN KẾT</translation>
+<translation id="7352939065658542140">VIDEO</translation>
+<translation id="4116038641877404294">Tải trang xuống để sử dụng ngoại tuyến</translation>
 <translation id="8922289737868596582">Tải trang xuống từ nút Thêm tùy chọn để sử dụng ngoại tuyến</translation>
-<translation id="8937772741022875483">Bạn có muốn xóa hoạt động của mình trên Chrome khỏi Digital Wellbeing không?</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">Mở trong cửa sổ khác</translation>
-<translation id="8951232171465285730">Chrome đã tiết kiệm <ph name="MEGABYTES" /> MB cho bạn</translation>
-<translation id="8958424370300090006">Chặn cookie của một trang web cụ thể.</translation>
-<translation id="8959122750345127698">Không thể tiếp cận điều hướng: <ph name="URL" /></translation>
-<translation id="8965591936373831584">đang chờ xử lý</translation>
-<translation id="8970887620466824814">Đã xảy ra lỗi.</translation>
-<translation id="8972098258593396643">Tải xuống thư mục mặc định?</translation>
-<translation id="8986494364107987395">Tự động gửi số liệu thống kê về việc sử dụng và báo cáo sự cố cho Google</translation>
-<translation id="8993760627012879038">Mở tab mới trong chế độ Ẩn danh</translation>
-<translation id="8998729206196772491">Bạn đang đăng nhập bằng tài khoản do <ph name="MANAGED_DOMAIN" /> quản lý và cấp cho quản trị viên quyền kiểm soát dữ liệu Chrome của bạn. Dữ liệu của bạn sẽ được liên kết vĩnh viễn với tài khoản này. Việc đăng xuất khỏi Chrome sẽ xóa dữ liệu của bạn khỏi thiết bị này nhưng dữ liệu sẽ vẫn được lưu trữ trong Tài khoản Google.</translation>
-<translation id="9019902583201351841">Do cha mẹ của bạn quản lý</translation>
-<translation id="9028914725102941583">Bật tính năng đồng bộ hóa để chia sẻ giữa các thiết bị</translation>
-<translation id="9029323097866369874">Cho phép <ph name="DOMAIN" /> vào chế độ thực tế ảo?</translation>
-<translation id="9040142327097499898">Cho phép thông báo. Đã tắt vị trí đối với thiết bị này.</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# video}other{# video}}</translation>
-<translation id="9050666287014529139">Cụm mật khẩu</translation>
-<translation id="9063523880881406963">Tắt Yêu cầu trang web cho máy tính</translation>
-<translation id="9065203028668620118">Chỉnh sửa</translation>
-<translation id="9070377983101773829">Bắt đầu tìm kiếm bằng giọng nói</translation>
-<translation id="9074336505530349563">Để nhận nội dung do Google đề xuất riêng cho bạn, hãy đăng nhập và bật tính năng đồng bộ hóa</translation>
-<translation id="9086455579313502267">Không thể truy cập mạng</translation>
-<translation id="9100505651305367705">Đề xuất hiển thị các bài viết ở chế độ xem đơn giản khi được hỗ trợ</translation>
-<translation id="9100610230175265781">Yêu cầu cụm mật khẩu</translation>
-<translation id="9102803872260866941">Tab xem trước đang mở</translation>
+<translation id="5958275228015807058">Tìm tệp và trang của bạn trong Tệp đã tải xuống</translation>
+<translation id="5620928963363755975">Tìm tệp và trang của bạn trong Tài nguyên đã tải xuống từ nút Tùy chọn khác</translation>
+<translation id="3341058695485821946">Xem lượng dữ liệu bạn đã tiết kiệm được</translation>
+<translation id="3157842584138209013">Xem lượng dữ liệu bạn đã tiết kiệm được từ nút Tùy chọn khác</translation>
+<translation id="8218622182176210845">Quản lý tài khoản của bạn</translation>
+<translation id="8090895580117672212">Để quản lý Tài khoản Brave Software của bạn, hãy nhấn vào nút "Quản lý tài khoản"</translation>
+<translation id="8856898588039823173">Trang phiên bản rút gọn do Brave Software cung cấp. Nhấn để tải trang gốc.</translation>
+<translation id="8134317863207426198">Trang phiên bản rút gọn do Brave Software cung cấp. Nhấn vào nút tải bản gốc để tải trang gốc.</translation>
+<translation id="4961107849584082341">Dịch trang này sang ngôn ngữ bất kỳ</translation>
+<translation id="569536719314091526">Dịch trang này sang ngôn ngữ bất kỳ từ nút Tùy chọn khác</translation>
+<translation id="1397811292916898096">Tìm kiếm bằng <ph name="PRODUCT_NAME"/></translation>
+<translation id="1792959175193046959">Thay đổi vị trí tải xuống mặc định bất cứ lúc nào</translation>
+<translation id="6942665639005891494">Thay đổi vị trí tải xuống mặc định bất cứ lúc nào bằng cách sử dụng tùy chọn menu Cài đặt</translation>
+<translation id="6850409657436465440">Vẫn đang tải xuống</translation>
+<translation id="5817715962196959877">Giờ đây, Brave tải tệp xuống còn nhanh hơn nữa</translation>
+<translation id="3976396876660209797">Xóa và tạo lại lối tắt này</translation>
+<translation id="6766622839693428701">Vuốt xuống để đóng.</translation>
+<translation id="1028699632127661925">Đang gửi đến <ph name="DEVICE_NAME"/>...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> – Gửi từ <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">Đã nhận tab</translation>
 <translation id="9104217018994036254">Danh sách các thiết bị mà bạn có thể chia sẻ một tab.</translation>
-<translation id="9133397713400217035">Khám phá khi không kết nối Internet</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">Hiển thị văn bản gốc</translation>
-<translation id="9139068048179869749">Hỏi trước khi cho phép trang web gửi thông báo (được đề xuất)</translation>
-<translation id="9139318394846604261">Mua sắm</translation>
-<translation id="9155898266292537608">Bạn cũng có thể tìm kiếm bằng cách nhấn nhanh vào một từ</translation>
-<translation id="9169507124922466868">Lịch sử di chuyển đang mở ở nửa dưới màn hình</translation>
-<translation id="9204836675896933765">Còn lại 1 tệp</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">Danh sách các thiết bị mà bạn có thể chia sẻ một tab đã mở ở nửa dưới của màn hình.</translation>
+<translation id="2904414404539560095">Danh sách các thiết bị mà bạn có thể chia sẻ một tab đã mở trên toàn màn hình.</translation>
+<translation id="4135200667068010335">Danh sách các thiết bị mà bạn có thể chia sẻ một tab đã đóng.</translation>
+<translation id="5292796745632149097">Gửi đến</translation>
+<translation id="1386674309198842382">Hoạt động <ph name="LAST_UPDATED"/> ngày trước</translation>
+<translation id="7971136598759319605">Hoạt động 1 ngày trước</translation>
+<translation id="1521774566618522728">Hoạt động hôm nay</translation>
+<translation id="3631987586758005671">Đang chia sẻ đến <ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">Bật tính năng đồng bộ hóa để chia sẻ giữa các thiết bị</translation>
+<translation id="6162454065885854378">Để chia sẻ nội dung trên điện thoại của bạn với một thiết bị khác, hãy bật tính năng đồng bộ hóa trong phần Cài đặt của Brave trên cả hai thiết bị</translation>
+<translation id="6084271560289605378">Chuyển đến phần Cài đặt của Brave</translation>
+<translation id="2318045970523081853">Nhấn để gọi điện</translation>
 <translation id="9209888181064652401">Không thể gọi điện</translation>
-<translation id="9219103736887031265">Hình ảnh</translation>
-<translation id="926205370408745186">Xóa hoạt động của bạn trên Chrome khỏi Digital Wellbeing</translation>
-<translation id="932327136139879170">Trang chủ</translation>
-<translation id="938850635132480979">Lỗi: <ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">Truy cập micrô của bạn</translation>
-<translation id="95817756606698420">Chrome có thể sử dụng <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> để tìm kiếm tại Trung Quốc. Bạn có thể thay đổi điều này trong <ph name="BEGIN_LINK" />Cài đặt<ph name="END_LINK" />.</translation>
-<translation id="965817943346481315">Chặn nếu trang web hiển thị quảng cáo xâm nhập hoặc quảng cáo gây hiểu nhầm (khuyên dùng)</translation>
-<translation id="968900484120156207">Các trang mà bạn truy cập sẽ xuất hiện tại đây</translation>
-<translation id="970715775301869095">Còn <ph name="MINUTES" /> phút</translation>
-<translation id="974555521953189084">Nhập cụm mật khẩu của bạn để bắt đầu đồng bộ hóa</translation>
-<translation id="981121421437150478">Ngoại tuyến</translation>
-<translation id="982182592107339124">Thao tác này sẽ xóa dữ liệu của tất cả các trang web, bao gồm:</translation>
-<translation id="983192555821071799">Đóng tất cả các tab</translation>
-<translation id="987264212798334818">Chung</translation>
+<translation id="2860954141821109167">Hãy đảm bảo bạn đã bật ứng dụng điện thoại trên thiết bị này</translation>
+<translation id="2067805253194386918">văn bản</translation>
+<translation id="1450753235335490080">Không thể chia sẻ <ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">Không thể chia sẻ <ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">Hãy đảm bảo <ph name="TARGET_DEVICE_NAME"/> đã bật tính năng đồng bộ hóa trên Brave</translation>
+<translation id="3016635187733453316">Hãy đảm bảo thiết bị này có kết nối Internet</translation>
+<translation id="8466613982764129868">Hãy đảm bảo <ph name="TARGET_DEVICE_NAME"/> có kết nối Internet</translation>
+<translation id="6539092367496845964">Đã xảy ra lỗi. Hãy thử lại sau.</translation>
+<translation id="3389286852084373014">Văn bản quá lớn</translation>
+<translation id="2100314319871056947">Hãy thử chia sẻ văn bản theo các đoạn nhỏ hơn</translation>
+<translation id="2987620471460279764">Văn bản được chia sẻ từ thiết bị khác</translation>
+<translation id="7757787379047923882">Văn bản được chia sẻ từ <ph name="DEVICE_NAME"/></translation>
+<translation id="5193988420012215838">Đã sao chép vào khay nhớ tạm</translation>
+<translation id="4696983787092045100">Gửi văn bản đến các thiết bị của bạn</translation>
+<translation id="1260236875608242557">Tìm kiếm và khám phá</translation>
+<translation id="6369229450655021117">Từ đây, bạn có thể tìm kiếm trên web, chia sẻ với bạn bè và xem các trang đang mở</translation>
+<translation id="723171743924126238">Chọn hình ảnh</translation>
+<translation id="8751914237388039244">Chọn hình ảnh</translation>
+<translation id="1989112275319619282">Duyệt qua</translation>
+<translation id="7055152154916055070">Liên kết chuyển hướng đã chặn:</translation>
+<translation id="5524843473235508879">Đã chặn chuyển hướng.</translation>
+<translation id="6573096386450695060">Luôn cho phép</translation>
+<translation id="5805364706385912897">Brave đã tạm dừng trang này vì trang dùng quá nhiều bộ nhớ.</translation>
+<translation id="5138664332909611586">Trang này sử dụng quá nhiều bộ nhớ, nên Brave đã xóa bớt nội dung.</translation>
+<translation id="9137013805542155359">Hiển thị văn bản gốc</translation>
+<translation id="6361779936989026201">Trợ lý Brave Software trong Brave</translation>
+<translation id="7291387454912369099">Trợ lý kích hoạt thanh toán</translation>
+<translation id="4565206163201411670">Bạn có muốn hiển thị hoạt động của mình trên Brave trong Digital Wellbeing không?</translation>
+<translation id="9055113864158719823">Bạn có thể xem các trang web mà mình truy cập trên Brave và hẹn giờ cho các trang web này.\n\nBrave Software thu thập thông tin về các trang web mà bạn đã hẹn giờ và khoảng thời gian bạn truy cập các trang web đó. Thông tin này dùng để cải thiện Digital Wellbeing.</translation>
+<translation id="4596514158372210596">Xóa hoạt động của bạn trên Brave khỏi Digital Wellbeing</translation>
+<translation id="1174893863889683998">Bạn có muốn xóa hoạt động của mình trên Brave khỏi Digital Wellbeing không?</translation>
+<translation id="708829030563435351">Các trang web bạn truy cập trên Brave sẽ không hiển thị. Tất cả lịch hẹn giờ trên trang web sẽ bị xóa.</translation>
+<translation id="2056878612599315956">Đã tạm dừng trang web</translation>
+<translation id="671481426037969117">Thời gian hẹn giờ của <ph name="FQDN"/> đã hết. Thời gian hẹn giờ sẽ bắt đầu lại vào ngày mai.</translation>
+<translation id="7479104141328977413">Quản lý tab</translation>
+<translation id="3524138585025253783">Giao diện người dùng dành cho nhà phát triển</translation>
+<translation id="6036057147555329831">Bộ chuyển đổi giao diện (ICU) bổ sung</translation>
+<translation id="9029323097866369874">Cho phép <ph name="DOMAIN"/> vào chế độ thực tế ảo?</translation>
+<translation id="7685301384041462804">Nhớ kiểm tra xem trang web này có tin cậy không trước khi vào chế độ thực tế ảo.</translation>
+<translation id="5033865233969348410">Khi bạn ở chế độ thực tế ảo, trang web này có thể tìm hiểu về:
+  –  đặc điểm ngoại hình của bạn, chẳng hạn như chiều cao
+
+Nhớ kiểm tra xem trang web này có tin cậy không trước khi vào chế độ thực tế ảo.</translation>
+<translation id="5534334044554683961">Khi bạn ở chế độ thực tế ảo, trang web này có thể tìm hiểu về:
+  –   đặc điểm ngoại hình của bạn, chẳng hạn như chiều cao
+  –   cách bài trí phòng của bạn
+
+Nhớ kiểm tra xem trang web này có tin cậy không trước khi vào chế độ thực tế ảo.</translation>
+<translation id="4169535189173047238">Không cho phép</translation>
+<translation id="2170088579611075216">Cho phép và chuyển sang thực tế ảo</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_zh-CN.xtb
+++ b/android/java/strings/translations/android_chrome_strings_zh-CN.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="zh-CN">
-<translation id="1006017844123154345">在线打开</translation>
-<translation id="1028699632127661925">正在发送到<ph name="DEVICE_NAME" />…</translation>
-<translation id="1036727731225946849">正在添加<ph name="WEBAPK_NAME" />…</translation>
-<translation id="1041308826830691739">来自网站</translation>
-<translation id="1049743911850919806">无痕</translation>
-<translation id="10614374240317010">一律不保存</translation>
-<translation id="1067922213147265141">其他 Google 服务</translation>
-<translation id="1068672505746868501">一律不翻译<ph name="SOURCE_LANGUAGE" />网页</translation>
-<translation id="107147699690128016">如果您更改文件扩展名，此文件可能会在另一应用中打开并对您的设备造成危害。</translation>
-<translation id="1100066534610197918">在群组内的新标签页中打开</translation>
-<translation id="1105960400813249514">屏幕截图</translation>
-<translation id="1111673857033749125">您在其他设备上保存的书签将列在此处。</translation>
-<translation id="1113597929977215864">显示简化版视图</translation>
-<translation id="1121094540300013208">使用情况信息和崩溃报告</translation>
-<translation id="1124772482545689468">用户</translation>
-<translation id="1129510026454351943">错误详情：<ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{有 1 项下载尚待处理。}other{有 # 项下载尚待处理。}}</translation>
-<translation id="1145536944570833626">删除现有数据。</translation>
-<translation id="1146678959555564648">进入 VR</translation>
-<translation id="116280672541001035">已耗用</translation>
-<translation id="1171770572613082465">点按“热门网站”按钮可查看热门网站</translation>
-<translation id="1173894706177603556">重命名</translation>
-<translation id="1178581264944972037">暂停</translation>
-<translation id="1181037720776840403">删除</translation>
-<translation id="1188239144602654184">进入 AR 会话</translation>
-<translation id="1197267115302279827">移动书签</translation>
-<translation id="119944043368869598">全部清除</translation>
-<translation id="1201402288615127009">下一步</translation>
-<translation id="1204037785786432551">下载链接</translation>
-<translation id="1206892813135768548">复制链接文字</translation>
-<translation id="1208340532756947324">要在您的所有设备上保持同步并进行个性化设置，请开启同步功能</translation>
-<translation id="1209206284964581585">暂时隐藏</translation>
-<translation id="1227058898775614466">导航历史记录</translation>
-<translation id="1231733316453485619">开启同步功能？</translation>
-<translation id="123724288017357924">重新加载当前网页（忽略缓存的内容）</translation>
-<translation id="124116460088058876">更多语言</translation>
-<translation id="124678866338384709">关闭当前标签页</translation>
-<translation id="1258753120186372309">Google 涂鸦：<ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">搜索内容与浏览相关建议</translation>
-<translation id="1264974993859112054">体育</translation>
-<translation id="1266864766717917324">无法分享<ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">停止</translation>
-<translation id="1283039547216852943">点按即可展开</translation>
-<translation id="1285320974508926690">一律不翻译此网站</translation>
-<translation id="1291207594882862231">清除历史记录、Cookie、网站数据、缓存内容…</translation>
-<translation id="129382876167171263">网站保存的文件会显示在这里</translation>
-<translation id="129553762522093515">最近关闭的标签页</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - 发送者：<ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">组合标签页</translation>
-<translation id="1327257854815634930">导航历史记录已打开</translation>
-<translation id="1331212799747679585">Chrome 无法更新。更多选项</translation>
-<translation id="1332501820983677155">Google Chrome 功能快捷键</translation>
-<translation id="1360432990279830238">退出帐号并关闭同步功能？</translation>
-<translation id="1369915414381695676">网站 <ph name="SITE_NAME" /> 已添加</translation>
-<translation id="1373696734384179344">内存不足，无法下载所选内容。</translation>
-<translation id="1376578503827013741">正在计算…</translation>
-<translation id="1383876407941801731">搜索</translation>
-<translation id="1384959399684842514">已暂停下载</translation>
-<translation id="1386674309198842382"><ph name="LAST_UPDATED" /> 天前曾有活动</translation>
-<translation id="1397811292916898096">使用 <ph name="PRODUCT_NAME" /> 进行搜索</translation>
-<translation id="1404122904123200417">嵌入位置：<ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">“不跟踪”</translation>
-<translation id="1407135791313364759">全部打开</translation>
-<translation id="1409426117486808224">使用简化版视图查看打开的标签页</translation>
-<translation id="1409879593029778104">系统已阻止下载 <ph name="FILE_NAME" />，因为文件已存在。</translation>
-<translation id="1414981605391750300">正在连接到 Google，请稍等片刻…</translation>
-<translation id="1416550906796893042">应用版本</translation>
-<translation id="1430915738399379752">打印</translation>
-<translation id="1446450296470737166">允许全面控制 MIDI 设备</translation>
-<translation id="1450753235335490080">无法分享<ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">已在 Android 设置中停用</translation>
-<translation id="1477626028522505441">未能成功下载 <ph name="FILE_NAME" />，因为服务器出现了问题。</translation>
-<translation id="1506061864768559482">搜索引擎</translation>
-<translation id="1513352483775369820">书签和网络历史记录</translation>
-<translation id="1513858653616922153">删除密码</translation>
-<translation id="1516229014686355813">“点按搜索”功能会将所选字词和当前页面（作为上下文）一起发送给 Google 搜索。您可在<ph name="BEGIN_LINK" />设置<ph name="END_LINK" />中关闭该功能。</translation>
-<translation id="1521774566618522728">今天曾有活动</translation>
-<translation id="1544826120773021464">要管理您的 Google 帐号，请点按“管理帐号”按钮</translation>
-<translation id="1549000191223877751">移至其他窗口</translation>
-<translation id="1553358976309200471">更新 Chrome</translation>
-<translation id="1569387923882100876">连接的设备</translation>
-<translation id="1571304935088121812">复制用户名</translation>
-<translation id="1612196535745283361">Chrome 需要拥有位置信息使用权才能扫描设备。<ph name="BEGIN_LINK" />此设备的位置信息使用权已被停用<ph name="END_LINK" />。</translation>
-<translation id="1620510694547887537">摄像头</translation>
-<translation id="1623104350909869708">阻止此页创建其他对话框</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{移除 1 个所选项}other{移除 # 个所选项}}</translation>
-<translation id="164269334534774161">您目前浏览的是此网页的离线副本（创建时间：<ph name="CREATION_TIME" />）</translation>
-<translation id="1644574205037202324">历史记录</translation>
-<translation id="1647391597548383849">使用您的摄像头</translation>
-<translation id="1660204651932907780">允许网站播放声音（推荐）</translation>
-<translation id="1670399744444387456">基本</translation>
-<translation id="1671236975893690980">正在等待下载…</translation>
-<translation id="1672586136351118594">不再显示</translation>
-<translation id="1692118695553449118">同步功能已开启</translation>
-<translation id="169515064810179024">禁止网站使用动态传感器</translation>
-<translation id="1717218214683051432">动态传感器</translation>
-<translation id="1718835860248848330">过去一小时</translation>
-<translation id="1736419249208073774">探索</translation>
-<translation id="1743802530341753419">网站需先询问并得到许可才能连接设备（推荐）</translation>
-<translation id="1749561566933687563">同步您的书签</translation>
-<translation id="17513872634828108">目前打开的标签页</translation>
-<translation id="1779089405699405702">图片解码器</translation>
-<translation id="1782483593938241562">结束日期：<ph name="DATE" /></translation>
-<translation id="1791662854739702043">安装位置</translation>
-<translation id="1792959175193046959">随时更改默认的下载内容保存位置</translation>
-<translation id="1807246157184219062">浅色调</translation>
-<translation id="1810845389119482123">未完成初始同步设置</translation>
-<translation id="1821253160463689938">使用 Cookie 记住您的偏好设置（即使您不访问这些网页）</translation>
-<translation id="1829244130665387512">在网页中查找</translation>
-<translation id="1853692000353488670">打开新的无痕式标签页</translation>
-<translation id="1856325424225101786">重置精简模式？</translation>
-<translation id="1868024384445905608">Chrome 现可更快速地下载文件</translation>
-<translation id="1883903952484604915">我的文件</translation>
-<translation id="1887786770086287077">此设备的位置信息使用权已关闭；若想开启这项权限，请转到 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />。</translation>
-<translation id="1891331835972267886"><ph name="APP_NAME" />将在 Chrome 中打开。继续操作即表示您同意 Chrome 的<ph name="BEGIN_LINK1" />服务条款<ph name="END_LINK1" />和<ph name="BEGIN_LINK2" />隐私权声明<ph name="END_LINK2" />。</translation>
-<translation id="1919345977826869612">广告</translation>
-<translation id="1919950603503897840">选择联系人</translation>
-<translation id="1922076542920281912">要让 Chrome 访问您的位置信息，您还需要在 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />中开启位置信息服务。</translation>
-<translation id="1923695749281512248">已下载 <ph name="BYTES_DOWNLOADED_WITH_UNITS" />，共 <ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">更新</translation>
-<translation id="19288952978244135">重新打开 Chrome。</translation>
-<translation id="1933845786846280168">所选的标签页</translation>
-<translation id="194341124344773587">在 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />中为 Chrome 启用这项权限。</translation>
-<translation id="1943432128510653496">保存密码</translation>
-<translation id="1952172573699511566">网站将尽可能以您的首选语言显示文字。</translation>
-<translation id="1960290143419248813">此版本的 Android 不再支持 Chrome 更新</translation>
-<translation id="1966710179511230534">请更新您的登录详细信息。</translation>
-<translation id="1974060860693918893">高级</translation>
-<translation id="1984705450038014246">同步 Chrome 数据</translation>
-<translation id="1984937141057606926">允许（第三方除外）</translation>
-<translation id="1986685561493779662">名称已存在</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" />按钮</translation>
-<translation id="1989112275319619282">浏览</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> 希望与以下所选设备配对：</translation>
-<translation id="1994173015038366702">网站网址</translation>
-<translation id="2000419248597011803">将一些 Cookie 以及地址栏和搜索框中的搜索字词发送给您的默认搜索引擎</translation>
-<translation id="2002537628803770967">Google Pay 中存储的信用卡和地址信息</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# 个文件}other{# 个文件}}</translation>
-<translation id="2017836877785168846">清除历史记录和地址栏中的自动填充项。</translation>
-<translation id="2021896219286479412">全屏网站控件</translation>
-<translation id="2038563949887743358">开启“请求切换到桌面版网站”</translation>
-<translation id="2041019821020695769">要让 Chrome 向您发送通知，您还需要在 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />中开启通知。</translation>
-<translation id="204321170514947529">Chrome 中也有<ph name="APP_NAME" />的数据</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">网站已被暂停</translation>
-<translation id="2063713494490388661">点按搜索</translation>
-<translation id="2067805253194386918">文本</translation>
-<translation id="2079545284768500474">撤消</translation>
-<translation id="2082238445998314030">第 <ph name="RESULT_NUMBER" /> 条结果，共 <ph name="TOTAL_RESULTS" /> 条</translation>
-<translation id="2091887806945687916">声音</translation>
-<translation id="2096012225669085171">在所有设备上保持同步并进行个性化设置</translation>
-<translation id="2100273922101894616">自动登录</translation>
-<translation id="2100314319871056947">请尝试使用较小的文本块进行分享</translation>
-<translation id="2107397443965016585">网站需先询问并得到许可才能播放受保护内容 （推荐）</translation>
-<translation id="2111511281910874386">转至相关网页</translation>
-<translation id="2122601567107267586">无法打开此应用</translation>
-<translation id="2126426811489709554">由 Chrome 提供支持</translation>
-<translation id="2131665479022868825">节省了 <ph name="DATA" /></translation>
-<translation id="213279576345780926">已关闭“<ph name="TAB_TITLE" />”</translation>
-<translation id="2139186145475833000">添加到主屏幕</translation>
-<translation id="2146738493024040262">打开免安装应用</translation>
-<translation id="2148716181193084225">今天</translation>
-<translation id="2154484045852737596">修改支付卡</translation>
-<translation id="2154710561487035718">复制网址</translation>
-<translation id="2156074688469523661">其余的网站（<ph name="NUMBER_OF_SITES" /> 个）</translation>
-<translation id="2157851137955077194">如果想将您手机上的内容分享到另一部设备，那么对于这两部设备，您都需在 Chrome 设置中开启同步功能</translation>
-<translation id="2170088579611075216">允许并进入 VR</translation>
-<translation id="218608176142494674">共享</translation>
-<translation id="2227444325776770048">以“<ph name="USER_FULL_NAME" />”的身份继续</translation>
-<translation id="2234876718134438132">同步功能和 Google 服务</translation>
-<translation id="2259659629660284697">导出密码…</translation>
-<translation id="2268044343513325586">优化</translation>
-<translation id="2286841657746966508">帐单邮寄地址</translation>
-<translation id="2289270750774289114">在网站想发现附近的蓝牙设备时询问您（推荐）</translation>
-<translation id="230115972905494466">未找到任何兼容设备</translation>
-<translation id="2315043854645842844">操作系统不支持选择客户端证书。</translation>
-<translation id="2318045970523081853">点按即可拨打电话</translation>
-<translation id="2321086116217818302">正在准备密码…</translation>
-<translation id="2321958826496381788">拖动该滑块，将文字调整到适合您阅读的大小。点按两次某段落后，显示的文字至少应是这么大。</translation>
-<translation id="2323763861024343754">网站存储数据</translation>
-<translation id="2328985652426384049">无法登录</translation>
-<translation id="2330129964253841015">在密码泄露时向您发出警告</translation>
-<translation id="2349710944427398404">Chrome 所使用的数据总量，包括帐号、书签和已保存的设置</translation>
-<translation id="2353636109065292463">检查互联网连接状况</translation>
-<translation id="2359808026110333948">继续</translation>
-<translation id="2369533728426058518">打开的标签页</translation>
-<translation id="2387895666653383613">文字大小</translation>
-<translation id="2394602618534698961">您下载的文件会显示在此处</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">当您登录自己的 Google 帐号后，系统即会启用此功能</translation>
-<translation id="2410754283952462441">选择帐号</translation>
-<translation id="2414886740292270097">深色调</translation>
-<translation id="2416359993254398973">Chrome 需要获得相应权限，才能允许此网站使用您的摄像头。</translation>
-<translation id="2426805022920575512">选择其他帐号</translation>
-<translation id="2433507940547922241">外观</translation>
-<translation id="2434158240863470628">下载完成 <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">位置信息使用权</translation>
-<translation id="2450083983707403292">要重新开始下载 <ph name="FILE_NAME" /> 吗？</translation>
-<translation id="2482878487686419369">通知</translation>
-<translation id="2490684707762498678">由 <ph name="APP_NAME" /> 管理</translation>
-<translation id="2494974097748878569">Chrome 中的 Google 助理</translation>
-<translation id="2496180316473517155">浏览记录</translation>
-<translation id="2497852260688568942">您的管理员已停用同步</translation>
-<translation id="2498359688066513246">帮助和反馈</translation>
-<translation id="2501278716633472235">返回</translation>
-<translation id="2513403576141822879">若想了解更多与隐私、安全和数据收集相关的设置，请参阅<ph name="BEGIN_LINK" />同步功能和 Google 服务<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">在精简模式下，Chrome 可更快速地加载网页，并可节省多达 60% 的流量。为了优化您访问的网页，Chrome 会将您的网络流量数据发送给 Google。<ph name="BEGIN_LINK" />了解详情<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">将您所访问的网页的网址发送给 Google</translation>
-<translation id="2532336938189706096">网页视图</translation>
-<translation id="2534155362429831547">删除了 <ph name="NUMBER_OF_ITEMS" /> 项</translation>
-<translation id="2536728043171574184">正在查看此网页的离线副本</translation>
-<translation id="2546283357679194313">Cookie 和网站数据</translation>
-<translation id="2567385386134582609">图片</translation>
-<translation id="257088987046510401">主题背景</translation>
-<translation id="2570922361219980984">此设备的位置信息使用权也已关闭；若想开启这项权限，请转到 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />。</translation>
-<translation id="257931822824936280">已展开 - 点击此处即可收起。</translation>
-<translation id="2581165646603367611">这会清除 Chrome 认为不重要的网站的 Cookie、缓存和其他数据。</translation>
-<translation id="2586657967955657006">剪贴板</translation>
-<translation id="2587052924345400782">新版本已推出</translation>
-<translation id="2593272815202181319">等宽</translation>
-<translation id="2612676031748830579">卡号</translation>
-<translation id="2621115761605608342">允许特定网站运行 JavaScript。</translation>
-<translation id="2625189173221582860">已复制密码</translation>
-<translation id="2631006050119455616">已节省</translation>
-<translation id="2647434099613338025">添加语言</translation>
-<translation id="2650751991977523696">是否重新下载文件？</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# 个音频文件}other{# 个音频文件}}</translation>
-<translation id="2653659639078652383">提交</translation>
-<translation id="2677748264148917807">离开</translation>
-<translation id="2704606927547763573">已复制</translation>
-<translation id="2707726405694321444">刷新网页</translation>
-<translation id="2709516037105925701">自动填充</translation>
-<translation id="2717722538473713889">电子邮件地址</translation>
-<translation id="2728754400939377704">按网站排序</translation>
-<translation id="2744248271121720757">点按某个字词可立即开始搜索或查看相关操作</translation>
-<translation id="2760989362628427051">在设备开启深色主题背景或省电模式时启用深色主题背景</translation>
-<translation id="2762000892062317888">刚刚</translation>
-<translation id="2777555524387840389">还剩 <ph name="SECONDS" /> 秒</translation>
-<translation id="2779651927720337254">失败</translation>
-<translation id="2781151931089541271">还剩 1 秒</translation>
-<translation id="2801022321632964776">更新即可在最新版本的 Chrome 中使用您的语言</translation>
-<translation id="2810645512293415242">简化版网页不仅可节省数据流量，还可更快速地进行加载。</translation>
-<translation id="281504910091592009">查看和管理您的 <ph name="BEGIN_LINK" />Google 帐号<ph name="END_LINK" />中保存的密码</translation>
-<translation id="2818669890320396765">要将您的书签同步到您的所有设备上，请登录您的帐号并开启同步功能</translation>
-<translation id="2822354292072154809">确定要重置<ph name="CHOSEN_OBJECT_NAME" />的所有网站权限吗？</translation>
-<translation id="2836148919159985482">触摸“返回”按钮即可退出全屏模式。</translation>
-<translation id="2842985007712546952">父文件夹</translation>
-<translation id="2858138569776157458">热门网站</translation>
-<translation id="2860954141821109167">请确保已在此设备上启用了一款电话应用</translation>
-<translation id="2870560284913253234">网站</translation>
-<translation id="2874939134665556319">上一曲</translation>
-<translation id="2876369937070532032">当您面临安全风险时，将您所访问的部分网页的网址发送给 Google</translation>
-<translation id="2888126860611144412">关于 Chrome</translation>
-<translation id="2891154217021530873">停止加载网页</translation>
-<translation id="2893180576842394309">Google 可能会利用您的历史记录为您提供个性化的 Google 搜索和其他 Google 服务</translation>
-<translation id="2898264748040935573">修改存储的密码</translation>
-<translation id="2900528713135656174">创建活动</translation>
-<translation id="290376772003165898">网页的源语言不是<ph name="LANGUAGE" />？</translation>
-<translation id="2904414404539560095">要与之分享标签页的设备的列表已全屏打开。</translation>
-<translation id="2910701580606108292">网站需先询问并得到许可才能播放受保护内容</translation>
-<translation id="2913331724188855103">允许网站保存和读取 Cookie 数据（推荐）</translation>
-<translation id="2923908459366352541">名称无效</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> 存储数据</translation>
-<translation id="2942036813789421260">预览标签页已关闭</translation>
-<translation id="2956410042958133412">该帐号由 <ph name="PARENT_NAME_1" /> 和 <ph name="PARENT_NAME_2" /> 管理。</translation>
-<translation id="2962095958535813455">已切换到隐身标签页</translation>
-<translation id="2968755619301702150">证书查看器</translation>
-<translation id="2979025552038692506">所选的隐身标签页</translation>
-<translation id="2987620471460279764">从其他设备分享的文字</translation>
-<translation id="2989523299700148168">最近用过的搜索引擎</translation>
-<translation id="2996291259634659425">创建密码</translation>
-<translation id="2996809686854298943">必须提供网址</translation>
-<translation id="300526633675317032">这会清除全部的网站存储数据 (<ph name="SIZE_IN_KB" />)。</translation>
-<translation id="3016635187733453316">请确保此设备已连接到互联网。</translation>
-<translation id="3029613699374795922">已下载 <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">密码不匹配</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />获取帮助<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">位置信息功能现处于关闭状态；请在 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />中开启此项功能。</translation>
-<translation id="3058498974290601450">您随时可在“设置”中开启同步功能</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> 个书签}other{<ph name="BOOKMARKS_COUNT_MANY" /> 个书签}}</translation>
-<translation id="3089395242580810162">在隐身标签页中打开</translation>
-<translation id="3115898365077584848">显示信息</translation>
-<translation id="3123473560110926937">已禁止部分网站显示广告</translation>
-<translation id="3137521801621304719">退出隐身模式</translation>
-<translation id="3143515551205905069">取消同步</translation>
-<translation id="3157842584138209013">通过“更多选项”按钮查看您已节省多少数据流量</translation>
-<translation id="3166827708714933426">标签页和窗口快捷键</translation>
-<translation id="3181954750937456830">安全浏览（保护您和您的设备不受危险网站的侵害）</translation>
-<translation id="3190152372525844641">在 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />中为 Chrome 启用这些权限。</translation>
-<translation id="3198916472715691905">已存储 <ph name="STORAGE_AMOUNT" /> 数据</translation>
-<translation id="3205824638308738187">即将完成！</translation>
-<translation id="3207960819495026254">已加书签</translation>
-<translation id="3211426585530211793">已删除“<ph name="ITEM_TITLE" />”</translation>
-<translation id="321773570071367578">如果您忘记了密码或想更改此设置，请<ph name="BEGIN_LINK" />重置同步设置<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">麦克风</translation>
-<translation id="3232754137068452469">网络应用</translation>
-<translation id="3236059992281584593">还剩 1 分钟</translation>
-<translation id="3244271242291266297">MM</translation>
-<translation id="3254409185687681395">为此页添加书签</translation>
-<translation id="3259831549858767975">缩小网页上的所有内容</translation>
-<translation id="3269093882174072735">加载图片</translation>
-<translation id="3269956123044984603">要访问您在其他设备上的标签页，请在 Android 帐号设置部分开启“自动同步数据”。</translation>
-<translation id="3277252321222022663">允许网站使用传感器（推荐）</translation>
-<translation id="3282568296779691940">登录 Chrome</translation>
-<translation id="3288003805934695103">重新加载网页</translation>
-<translation id="32895400574683172">允许显示通知</translation>
-<translation id="3295530008794733555">浏览速度更快。耗用的流量更少。</translation>
-<translation id="3295602654194328831">隐藏信息</translation>
-<translation id="3298243779924642547">精简版</translation>
-<translation id="3303414029551471755">要开始下载该内容吗？</translation>
-<translation id="3306398118552023113">此应用正在 Chrome 中运行</translation>
-<translation id="3315103659806849044">您正在自定义您的“同步功能和 Google 服务”设置。要完成开启同步功能的操作，请点按屏幕底部附近的“确认”按钮。转到上一层级</translation>
-<translation id="3328801116991980348">网站信息</translation>
-<translation id="3333961966071413176">所有联系人</translation>
-<translation id="3334729583274622784">更改文件扩展名？</translation>
-<translation id="3341058695485821946">查看您已节省多少数据流量</translation>
-<translation id="3350687908700087792">关闭所有隐身标签页</translation>
-<translation id="3353615205017136254">由 Google 提供的精简版网页。点按“加载原始网页”按钮即可加载原始网页。</translation>
-<translation id="3367813778245106622">重新登录以开始同步</translation>
-<translation id="3374023511497244703">您的书签、历史记录、密码和其他 Chrome 数据将不再同步到您的 Google 帐号中</translation>
-<translation id="3384347053049321195">分享图片</translation>
-<translation id="3386292677130313581">网站需要先询问并得到您的许可才能获取您的位置信息（推荐）</translation>
-<translation id="3387650086002190359">未能成功下载 <ph name="FILE_NAME" />，因为文件系统出现了错误。</translation>
-<translation id="3389286852084373014">文本过长</translation>
-<translation id="3398320232533725830">打开书签管理器</translation>
-<translation id="3414952576877147120">大小：</translation>
-<translation id="3443221991560634068">重新加载当前网页</translation>
-<translation id="3445014427084483498">刚刚</translation>
-<translation id="3478363558367712427">您可自行选择要使用的搜索引擎</translation>
+<translation id="6910211073230771657">已删除</translation>
+<translation id="6965382102122355670">确定</translation>
+<translation id="5301954838959518834">知道了</translation>
+<translation id="7658239707568436148">取消</translation>
 <translation id="3479552764303398839">以后再说</translation>
-<translation id="3492207499832628349">打开新的无痕式标签页</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />详细了解<ph name="END_LINK" />推荐内容</translation>
-<translation id="3513704683820682405">增强现实</translation>
-<translation id="3518985090088779359">接受并继续</translation>
-<translation id="3522247891732774234">有更新。更多选项</translation>
-<translation id="3524138585025253783">开发者界面</translation>
-<translation id="3527085408025491307">文件夹</translation>
-<translation id="3542235761944717775">可用空间：<ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">搜索您的历史记录</translation>
-<translation id="3557336313807607643">添加到通讯录</translation>
-<translation id="3566923219790363270">Chrome 仍在准备 VR。请稍等片刻再重启 Chrome。</translation>
-<translation id="3568688522516854065">要访问您在其他设备上的标签页，请登录您的帐号并开启同步功能</translation>
-<translation id="3587482841069643663">全部</translation>
-<translation id="358794129225322306">允许网站自动下载多个文件。</translation>
-<translation id="3590487821116122040">Chrome 认为不重要的网站（例如未保存任何设置的网站或您不常访问的网站）存储的数据</translation>
-<translation id="3599863153486145794">清除所有登录过的设备上的历史记录。您的 Google 帐号在 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> 上可能有其他形式的浏览记录。</translation>
-<translation id="3600792891314830896">将播放声音的网站静音</translation>
-<translation id="3616113530831147358">音频</translation>
-<translation id="3631987586758005671">正在分享给<ph name="DEVICE_NAME" /></translation>
-<translation id="3632295766818638029">显示密码</translation>
-<translation id="363596933471559332">使用存储的凭据自动登录网站。当该功能处于停用状态时，您每次都要通过验证才能登录网站。</translation>
-<translation id="3658159451045945436">这项重置操作会清空流量节省情况历史记录，包括曾访问过的网站的列表。</translation>
-<translation id="3692944402865947621">未能成功下载“<ph name="FILE_NAME" />”，因为无法访问它的存储位置。</translation>
-<translation id="3714981814255182093">打开查找栏</translation>
-<translation id="3716182511346448902">此网页占用的内存过多，因此 Chrome 已将其暂停。</translation>
-<translation id="3730075448226062617">要让 Chrome 使用您的麦克风，您还需要在 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />中开启麦克风。</translation>
-<translation id="3739899004075612870">已在 <ph name="PRODUCT_NAME" /> 中添加书签</translation>
-<translation id="3744111561329211289">后台同步</translation>
-<translation id="3771001275138982843">无法下载此项更新</translation>
-<translation id="3771033907050503522">隐身标签页</translation>
-<translation id="3773755127849930740">请<ph name="BEGIN_LINK" />开启蓝牙<ph name="END_LINK" />以允许配对</translation>
-<translation id="3775705724665058594">发送到您的设备</translation>
-<translation id="3778956594442850293">已添加到主屏幕</translation>
-<translation id="3789841737615482174">安装</translation>
-<translation id="3810838688059735925">视频</translation>
-<translation id="3810973564298564668">管理</translation>
-<translation id="381841723434055211">电话号码</translation>
-<translation id="3819178904835489326">已删除 <ph name="NUMBER_OF_DOWNLOADS" /> 项下载内容</translation>
-<translation id="3822502789641063741">要清除网站存储数据吗？</translation>
-<translation id="385051799172605136">后退</translation>
-<translation id="3859306556332390985">前进</translation>
-<translation id="3894427358181296146">添加文件夹</translation>
-<translation id="3895926599014793903">强制启用缩放功能</translation>
-<translation id="3912508018559818924">正在从网络中查找最具价值的数据…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">合并我的数据</translation>
-<translation id="393697183122708255">无法启用语音搜索功能</translation>
-<translation id="395206256282351086">搜索和网站建议已停用</translation>
-<translation id="3955193568934677022">允许网站播放受保护的内容（推荐）</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{待准备就绪后，Chrome 即会加载您的网页}other{待准备就绪后，Chrome 即会加载您的网页}}</translation>
-<translation id="3963007978381181125">密码加密不包括 Google Pay 中的付款方式和地址。只有知道您密码的人才能读取您的已加密数据。系统不会将该密码发送给 Google，Google 也不会存储该密码。如果您忘记了密码或想更改此设置，则需重置同步设置。<ph name="BEGIN_LINK" />了解详情<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">下载完毕</translation>
-<translation id="397583555483684758">同步功能已停止工作</translation>
-<translation id="3976396876660209797">移除并重新创建此快捷方式</translation>
-<translation id="3985215325736559418">要重新下载“<ph name="FILE_NAME" />”吗？</translation>
-<translation id="3987993985790029246">复制链接</translation>
-<translation id="3988213473815854515">允许访问位置信息</translation>
-<translation id="3988466920954086464">您可以在此面板查看即时搜索结果</translation>
-<translation id="3991845972263764475">已下载 <ph name="BYTES_DOWNLOADED_WITH_UNITS" />，总大小不明</translation>
-<translation id="3997476611815694295">不重要网站的存储数据</translation>
-<translation id="4000212216660919741">离线版首页</translation>
+<translation id="5317780077021120954">保存</translation>
+<translation id="4570913071927164677">详情</translation>
+<translation id="8730621377337864115">完成</translation>
+<translation id="8261506727792406068">删除</translation>
+<translation id="1181037720776840403">删除</translation>
+<translation id="5939518447894949180">重置</translation>
 <translation id="4002066346123236978">标题</translation>
-<translation id="4008040567710660924">允许特定网站使用 Cookie。</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# 小时}other{# 小时}}</translation>
-<translation id="4046123991198612571">下一曲</translation>
-<translation id="4048707525896921369">无需离开所在页面，便可了解网站上的主题。“点按搜索”功能会将所选字词及上下文一起发送给 Google 搜索，后者即会据此返回相应的定义、图片、搜索结果及其他详情。
+<translation id="5916664084637901428">启用</translation>
+<translation id="5860033963881614850">关闭</translation>
+<translation id="6165508094623778733">了解详情</translation>
+<translation id="6042308850641462728">更多</translation>
+<translation id="6040143037577758943">关闭</translation>
+<translation id="780301667611848630">不用了，谢谢</translation>
+<translation id="1201402288615127009">下一步</translation>
+<translation id="2359808026110333948">继续</translation>
+<translation id="2653659639078652383">提交</translation>
+<translation id="2079545284768500474">撤消</translation>
+<translation id="7649070708921625228">帮助</translation>
+<translation id="2148716181193084225">今天</translation>
+<translation id="7781829728241885113">昨天</translation>
+<translation id="6945221475159498467">选择</translation>
+<translation id="7791543448312431591">添加</translation>
+<translation id="6527303717912515753">分享</translation>
+<translation id="1383876407941801731">搜索</translation>
+<translation id="3115898365077584848">显示信息</translation>
+<translation id="3295602654194328831">隐藏信息</translation>
+<translation id="3987993985790029246">复制链接</translation>
+<translation id="2704606927547763573">已复制</translation>
+<translation id="8725066075913043281">重试</translation>
+<translation id="385051799172605136">后退</translation>
+<translation id="8131740175452115882">确认</translation>
+<translation id="5300589172476337783">显示</translation>
+<translation id="1124772482545689468">用户</translation>
+<translation id="8609465669617005112">上移</translation>
+<translation id="6746124502594467657">下移</translation>
+<translation id="8249310407154411074">移至顶部</translation>
+<translation id="8428213095426709021">设置</translation>
+<translation id="2498359688066513246">帮助和反馈</translation>
+<translation id="8378714024927312812">由贵单位管理</translation>
+<translation id="9019902583201351841">由您父母管理</translation>
+<translation id="4645575059429386691">由您父母管理</translation>
+<translation id="4883854917563148705">无法重置托管设置</translation>
+<translation id="4307992518367153382">基本</translation>
+<translation id="1974060860693918893">高级</translation>
+<translation id="1146678959555564648">进入 VR</translation>
+<translation id="987264212798334818">常规</translation>
+<translation id="4275663329226226506">媒体</translation>
+<translation id="4759238208242260848">下载内容</translation>
+<translation id="218608176142494674">共享</translation>
+<translation id="8004582292198964060">浏览器</translation>
+<translation id="1105960400813249514">屏幕截图</translation>
+<translation id="4875775213178255010">内容建议</translation>
+<translation id="2021896219286479412">全屏网站控件</translation>
+<translation id="4587589328781138893">网站</translation>
+<translation id="4943703118917034429">虚拟实境</translation>
+<translation id="1928696683969751773">更新</translation>
+<translation id="6064125863973209585">下载已完成</translation>
+<translation id="5342314432463739672">权限请求</translation>
+<translation id="629730747756840877">帐号</translation>
+<translation id="82609232232243542">登录 Brave</translation>
+<translation id="7956662517480676674">同步功能和 Brave Software 服务</translation>
+<translation id="5294439808117722387">您正在自定义您的“同步功能和 Brave Software 服务”设置。要完成开启同步功能的操作，请点按屏幕底部附近的“确认”按钮。转到上一层级</translation>
+<translation id="2096012225669085171">在所有设备上保持同步并进行个性化设置</translation>
+<translation id="1692118695553449118">同步功能已开启</translation>
+<translation id="5514904542973294328">已被此设备的管理员停用</translation>
+<translation id="6447211988989208781">Brave Software 活动控件</translation>
+<translation id="4882831918239250449">控制 Brave Software 如何利用您的浏览记录为您提供个性化的搜索、广告和其他服务</translation>
+<translation id="7431991332293347422">控制 Brave Software 如何利用您的浏览记录为您提供个性化的 Brave Software 搜索和其他 Brave Software 服务</translation>
+<translation id="6303969859164067831">退出帐号并关闭同步功能</translation>
+<translation id="1125261911132334651">管理您的 Brave Software 帐号</translation>
+<translation id="6406506848690869874">同步</translation>
+<translation id="714362445477979774">同步 Brave 数据</translation>
+<translation id="4314815835985389558">管理同步数据</translation>
+<translation id="5428209950370661546">其他 Brave Software 服务</translation>
+<translation id="7704317875155739195">自动填充搜索字词和网址</translation>
+<translation id="2000419248597011803">将一些 Cookie 以及地址栏和搜索框中的搜索字词发送给您的默认搜索引擎</translation>
+<translation id="7981313251711023384">预加载网页，以便实现更快速的浏览和搜索</translation>
+<translation id="1821253160463689938">使用 Cookie 记住您的偏好设置（即使您不访问这些网页）</translation>
+<translation id="6697492270171225480">找不到相应网页时，显示有关类似网页的建议</translation>
+<translation id="8109318360573330108">将您尝试访问的网页的网址发送给 Brave Software</translation>
+<translation id="8438566539970814960">改善搜索和浏览体验</translation>
+<translation id="284843628681142937">将您所访问的网页的网址发送给 Brave Software</translation>
+<translation id="7222718784508482526">若想了解更多与隐私、安全和数据收集相关的设置，请参阅<ph name="BEGIN_LINK"/>同步功能和 Brave Software 服务<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">帮助我们改进 Brave 的功能和性能</translation>
+<translation id="9063160602596686558">自动将使用情况统计信息和崩溃报告发送至 Brave Software</translation>
+<translation id="4824958205181053313">取消同步？</translation>
+<translation id="3058498974290601450">您随时可在“设置”中开启同步功能</translation>
+<translation id="3143515551205905069">取消同步</translation>
+<translation id="1506061864768559482">搜索引擎</translation>
+<translation id="55737423895878184">允许使用位置信息以及显示通知</translation>
+<translation id="3988213473815854515">允许访问位置信息</translation>
+<translation id="32895400574683172">允许显示通知</translation>
+<translation id="9040142327097499898">允许显示通知。但此设备的位置信息功能已关闭。</translation>
+<translation id="305593374596241526">位置信息功能现处于关闭状态；请在 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>中开启此项功能。</translation>
+<translation id="2989523299700148168">最近用过的搜索引擎</translation>
+<translation id="6433501201775827830">选择您的搜索引擎</translation>
+<translation id="7177466738963138057">以后，您可以在“设置”中更改此设置。</translation>
+<translation id="3478363558367712427">您可自行选择要使用的搜索引擎</translation>
+<translation id="4910889077668685004">付款应用</translation>
+<translation id="5152843274749979095">尚未安装任何支持的应用</translation>
+<translation id="8812260976093120287">在某些网站上，您可以使用自己的设备通过上述支持的付款应用付款。</translation>
+<translation id="7764225426217299476">添加地址</translation>
+<translation id="5595485650161345191">修改地址</translation>
+<translation id="5087580092889165836">添加新卡</translation>
+<translation id="2154484045852737596">修改支付卡</translation>
+<translation id="6140912465461743537">国家/地区</translation>
+<translation id="5659593005791499971">电子邮件</translation>
+<translation id="4378154925671717803">电话机</translation>
+<translation id="4807098396393229769">持卡人姓名</translation>
+<translation id="860043288473659153">持卡人姓名</translation>
+<translation id="2612676031748830579">卡号</translation>
+<translation id="869891660844655955">截止日期</translation>
+<translation id="2286841657746966508">帐单邮寄地址</translation>
+<translation id="663059986967017181">已复制到 Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> 种付款方式}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> 种付款方式}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> 个地址}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> 个地址}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> 种送货方式}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> 种送货方式}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> 个联系人}other{<ph name="CONTACT_PREVIEW"/>\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> 个联系人}}</translation>
+<translation id="7029809446516969842">密码</translation>
+<translation id="1943432128510653496">保存密码</translation>
+<translation id="2100273922101894616">自动登录</translation>
+<translation id="363596933471559332">使用存储的凭据自动登录网站。当该功能处于停用状态时，您每次都要通过验证才能登录网站。</translation>
+<translation id="6995899638241819463">在密码遭遇数据泄露时，向您发出警告</translation>
+<translation id="1534287762301776620">当您登录自己的 Brave Software 帐号后，系统即会启用此功能</translation>
+<translation id="10614374240317010">一律不保存</translation>
+<translation id="3098842761938485917">查看和管理您的 <ph name="BEGIN_LINK"/>Brave Software 帐号<ph name="END_LINK"/>中保存的密码</translation>
+<translation id="8562452229998620586">已保存的密码将显示在这里。</translation>
+<translation id="8084114998886531721">保存的密码</translation>
+<translation id="2870560284913253234">网站</translation>
+<translation id="8503813439785031346">用户名</translation>
+<translation id="6657585470893396449">密码</translation>
+<translation id="2154710561487035718">复制网址</translation>
+<translation id="1571304935088121812">复制用户名</translation>
+<translation id="5005498671520578047">复制密码</translation>
+<translation id="3632295766818638029">显示密码</translation>
+<translation id="1513858653616922153">删除密码</translation>
+<translation id="543338862236136125">修改密码</translation>
+<translation id="4565377596337484307">隐藏密码</translation>
+<translation id="8523928698583292556">删除存储的密码</translation>
+<translation id="2898264748040935573">修改存储的密码</translation>
+<translation id="5433691172869980887">已复制用户名</translation>
+<translation id="5534640966246046842">已复制网站</translation>
+<translation id="2625189173221582860">已复制密码</translation>
+<translation id="4550003330909367850">要想在此处查看或复制您的密码，请在此设备上设置屏幕锁定。</translation>
+<translation id="6154478581116148741">需在“设置”部分中开启屏幕锁定功能，才能从此设备中导出您的密码</translation>
+<translation id="4842092870884894799">目前显示的是密码生成弹出式窗口</translation>
+<translation id="2259659629660284697">导出密码…</translation>
+<translation id="133012818630824069">导出存储在 Brave 中的密码</translation>
+<translation id="6914783257214138813">所有能查看此导出文件的人员都能看到您的密码。</translation>
+<translation id="2321086116217818302">正在准备密码…</translation>
+<translation id="8445448999790540984">无法导出密码</translation>
+<translation id="3066461326500799725">了解如何使用 Brave Software 云端硬盘</translation>
+<translation id="729975465115245577">您的设备上没有可以存储密码文件的应用。</translation>
+<translation id="7682724950699840886">请尝试按以下提示操作：确保您的设备上有足够的空间，然后重新尝试导出。</translation>
+<translation id="1129510026454351943">错误详情：<ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">需解锁才能复制您的密码</translation>
+<translation id="5515439363601853141">需解锁才能查看您的密码</translation>
+<translation id="6221633008163990886">需解锁才能导出您的密码</translation>
+<translation id="230699814587342492">Brave 密码</translation>
+<translation id="6075798973483050474">修改主页</translation>
+<translation id="854522910157234410">打开此网页</translation>
+<translation id="2482878487686419369">通知</translation>
+<translation id="6255999984061454636">内容建议</translation>
+<translation id="805047784848435650">根据您的浏览记录</translation>
+<translation id="1041308826830691739">来自网站</translation>
+<translation id="395206256282351086">搜索和网站建议已停用</translation>
+<translation id="257088987046510401">主题背景</translation>
+<translation id="4650364565596261010">系统默认设置</translation>
+<translation id="7588219262685291874">在设备开启省电模式时启用深色主题背景</translation>
+<translation id="2760989362628427051">在设备开启深色主题背景或省电模式时启用深色主题背景</translation>
+<translation id="6381421346744604172">调暗网站颜色</translation>
+<translation id="5040262127954254034">隐私设置</translation>
+<translation id="4991384657077828949">帮助我们改善 Brave 安全性</translation>
+<translation id="1943176487615318915">为了检测危险应用和网站，Brave 会将您所访问的部分网页的网址、有限的系统信息以及部分网页内容发送给 Brave Software</translation>
+<translation id="3181954750937456830">安全浏览（保护您和您的设备不受危险网站的侵害）</translation>
+<translation id="7315322926489145388">当您面临安全风险时，将您所访问的部分网页的网址发送给 Brave Software</translation>
+<translation id="2063713494490388661">点按搜索</translation>
+<translation id="2369463299479365221">无需离开所在页面，便可了解网站上的主题。“点按搜索”功能会将所选字词及上下文一起发送给 Brave Software 搜索，后者即会据此返回相应的定义、图片、搜索结果及其他详情。
 
 要调整您的搜索字词，长按即可选中所需内容。要缩小您的搜索范围，请向上滑动到面板顶部，然后点按搜索框。</translation>
-<translation id="4056223980640387499">棕色调</translation>
-<translation id="4060598801229743805">选项位于屏幕顶部附近</translation>
-<translation id="4062305924942672200">法律信息</translation>
-<translation id="4084682180776658562">添加书签</translation>
-<translation id="4084712963632273211">来自 <ph name="PUBLISHER_ORIGIN" /> - <ph name="BEGIN_DEEMPHASIZED" />由 Google 提供<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">要删除应用数据吗？</translation>
-<translation id="4099578267706723511">将使用情况统计信息和崩溃报告发送给 Google，帮助我们完善 Chrome。</translation>
-<translation id="410351446219883937">自动播放</translation>
-<translation id="4116038641877404294">下载网页以便离线查看</translation>
-<translation id="4135200667068010335">要与之分享标签页的设备的列表已关闭。</translation>
-<translation id="4149994727733219643">使用简化版视图查看网页</translation>
-<translation id="4165986682804962316">网站设置</translation>
-<translation id="4169535189173047238">不允许</translation>
-<translation id="4170011742729630528">此服务目前无法使用，请稍后再试。</translation>
-<translation id="4179980317383591987">已使用 <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">语言</translation>
-<translation id="4183868528246477015">使用 Google 智能镜头进行搜索<ph name="BEGIN_NEW" />新功能<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">在新标签页中打开</translation>
-<translation id="4198423547019359126">没有可用的下载内容保存位置</translation>
-<translation id="4209895695669353772">要获取 Google 推荐的个性化内容，请开启同步功能</translation>
-<translation id="4226663524361240545">收到通知时设备会振动</translation>
-<translation id="423219824432660969">自 <ph name="TIME" />起，使用 Google 密码加密已同步的数据</translation>
-<translation id="4242533952199664413">打开“设置”</translation>
-<translation id="4256782883801055595">开放源代码许可</translation>
-<translation id="4259722352634471385">已屏蔽 <ph name="URL" /></translation>
-<translation id="4269820728363426813">复制链接地址</translation>
-<translation id="4275663329226226506">媒体</translation>
-<translation id="4278390842282768270">允许</translation>
-<translation id="429312253194641664">某个网站正在播放媒体内容</translation>
-<translation id="4298388696830689168">已关联的网站</translation>
-<translation id="4307992518367153382">基本</translation>
-<translation id="4314815835985389558">管理同步数据</translation>
-<translation id="4351244548802238354">关闭对话框</translation>
-<translation id="4378154925671717803">电话机</translation>
-<translation id="4384468725000734951">目前使用的搜索引擎是搜狗</translation>
-<translation id="4404568932422911380">没有书签</translation>
-<translation id="4405224443901389797">移动到…</translation>
-<translation id="4411535500181276704">精简模式</translation>
-<translation id="4415276339145661267">管理您的 Google 帐号</translation>
-<translation id="4432792777822557199">从现在开始，源语言为<ph name="SOURCE_LANGUAGE" />的网页一律会被翻译成<ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">由 Google 提供的精简版网页</translation>
-<translation id="4434045419905280838">弹出式窗口和重定向</translation>
-<translation id="4440958355523780886">由 Google 提供的精简版网页。点按即可加载原始网页。</translation>
-<translation id="4452411734226507615">关闭“<ph name="TAB_TITLE" />”标签页</translation>
-<translation id="4452548195519783679">已将书签添加到“<ph name="FOLDER_NAME" />”</translation>
-<translation id="445467742685312942">允许网站播放受保护内容。</translation>
-<translation id="4468959413250150279">将某个特定网站静音。</translation>
-<translation id="4472118726404937099">要在您的所有设备上保持同步并进行个性化设置，请登录您的帐号并开启同步功能</translation>
-<translation id="447252321002412580">帮助我们改进 Chrome 的功能和性能</translation>
-<translation id="4479647676395637221">在允许网站使用您的摄像头前先询问（推荐）</translation>
-<translation id="4479972344484327217">正在为 Chrome 安装<ph name="MODULE" />…</translation>
-<translation id="4487967297491345095">Chrome 的所有应用数据都将被永久删除，其中包括所有文件、设置、帐号、数据库等。</translation>
-<translation id="4493497663118223949">精简模式已开启</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# 天前}other{# 天前}}</translation>
-<translation id="451872707440238414">搜索书签</translation>
-<translation id="4521489764227272523">所选数据已从 Chrome 和同步的设备中移除。
-
-不过，您的 Google 帐号在 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> 上可能还有其他形式的浏览记录（例如，在其他 Google 服务中的搜索记录和活动记录）。</translation>
-<translation id="4532845899244822526">选择文件夹</translation>
-<translation id="4538018662093857852">开启精简模式</translation>
-<translation id="4550003330909367850">要想在此处查看或复制您的密码，请在此设备上设置屏幕锁定。</translation>
-<translation id="4558311620361989323">网页快捷键</translation>
-<translation id="4561979708150884304">无网络连接</translation>
-<translation id="4565377596337484307">隐藏密码</translation>
-<translation id="4570913071927164677">详情</translation>
-<translation id="4572422548854449519">请登录受管理的帐号</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# 分钟前}other{# 分钟前}}</translation>
-<translation id="4587589328781138893">网站</translation>
-<translation id="4594952190837476234">此离线网页是在 <ph name="CREATION_TIME" />创建的，可能与在线版本有所不同。</translation>
-<translation id="4605958867780575332">以下项已移除：<ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">打开<ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">使用密码</translation>
-<translation id="4645575059429386691">由您父母管理</translation>
-<translation id="4650364565596261010">系统默认设置</translation>
-<translation id="4663756553811254707">已删除 <ph name="NUMBER_OF_BOOKMARKS" /> 个书签</translation>
-<translation id="4665282149850138822"><ph name="NAME" />已添加到您的主屏幕</translation>
-<translation id="4684427112815847243">同步所有数据类型</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> 种送货方式}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> 种送货方式}}</translation>
-<translation id="4696983787092045100">向您的多部设备发送短信</translation>
-<translation id="4698034686595694889">在 <ph name="APP_NAME" /> 中离线查看</translation>
-<translation id="4699172675775169585">缓存的图片和文件</translation>
-<translation id="4714588616299687897">最多可为您节省 60% 的数据流量</translation>
-<translation id="4719927025381752090">提供翻译</translation>
-<translation id="4720023427747327413">在<ph name="PRODUCT_NAME" />中打开</translation>
-<translation id="4720982865791209136">欢迎帮助我们改进 Chrome。<ph name="BEGIN_LINK" />参与调查<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">更新</translation>
-<translation id="4738836084190194332">上次同步时间：<ph name="WHEN" /></translation>
-<translation id="4749960740855309258">打开新标签页</translation>
-<translation id="4751476147751820511">动态传感器或光传感器</translation>
-<translation id="4759238208242260848">下载内容</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{已完成 1 项下载。}other{已完成 # 项下载。}}</translation>
-<translation id="4797039098279997504">触摸即可返回到 <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">密码加密不包括 Google Pay 中的付款方式和地址。
-
-要更改此设置，请<ph name="BEGIN_LINK" />重置同步设置<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">持卡人姓名</translation>
-<translation id="4824958205181053313">取消同步？</translation>
-<translation id="4837753911714442426">打开选项以打印网页</translation>
-<translation id="4842092870884894799">目前显示的是密码生成弹出式窗口</translation>
-<translation id="4860895144060829044">拨打</translation>
-<translation id="4866368707455379617">无法为 Chrome 安装<ph name="MODULE" /></translation>
-<translation id="4875775213178255010">内容建议</translation>
-<translation id="4878404682131129617">未能成功通过代理服务器建立隧道</translation>
-<translation id="4880127995492972015">翻译…</translation>
-<translation id="4881695831933465202">打开</translation>
-<translation id="488187801263602086">重命名文件</translation>
-<translation id="4882831918239250449">控制 Google 如何利用您的浏览记录为您提供个性化的搜索、广告和其他服务</translation>
-<translation id="4883854917563148705">无法重置托管设置</translation>
-<translation id="4885273946141277891">Chrome 实例数量已超出上限。</translation>
-<translation id="4910889077668685004">付款应用</translation>
-<translation id="4913161338056004800">重置统计信息</translation>
-<translation id="4913169188695071480">停止刷新</translation>
-<translation id="4915549754973153784">正在搜寻设备…<ph name="BEGIN_LINK" />获取帮助<ph name="END_LINK" /></translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# 个网页}other{# 个网页}}</translation>
-<translation id="4932247056774066048">您将要退出由 <ph name="DOMAIN_NAME" /> 管理的帐号，因此您的 Chrome 数据将会从这部设备中删除，但仍会保留在您的 Google 帐号中。</translation>
-<translation id="4943703118917034429">虚拟实境</translation>
-<translation id="4943872375798546930">找不到结果</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> 正在共享您的屏幕</translation>
-<translation id="4961107849584082341">将此页面翻译成任何语言</translation>
-<translation id="4962975101802056554">撤消设备的所有权限</translation>
-<translation id="4970824347203572753">无法在您所在的国家/地区使用</translation>
-<translation id="497421865427891073">前进</translation>
-<translation id="4988210275050210843">正在下载文件 (<ph name="MEGABYTES" />)。</translation>
-<translation id="4988526792673242964">网页</translation>
-<translation id="4994033804516042629">找不到任何联系人</translation>
-<translation id="4996978546172906250">分享方式</translation>
-<translation id="5004416275253351869">Google 活动控件</translation>
-<translation id="5005498671520578047">复制密码</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> 希望连接到以下所选设备：</translation>
-<translation id="5013696553129441713">没有新建议</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">当您处于 VR 环境时，此网站或许能够得知：
-  -  您的身体特征，例如身高
-
-请确保您信任此网站，然后再进入 VR 环境。</translation>
+<translation id="2930742481329940825">“点按搜索”功能会将所选字词和当前页面（作为上下文）一起发送给 Brave Software 搜索。您可在<ph name="BEGIN_LINK"/>设置<ph name="END_LINK"/>中关闭该功能。</translation>
 <translation id="5039804452771397117">允许</translation>
-<translation id="5040262127954254034">隐私设置</translation>
-<translation id="5048398596102334565">允许网站使用动态传感器（推荐）</translation>
-<translation id="5063480226653192405">使用情况</translation>
-<translation id="5087580092889165836">添加新卡</translation>
-<translation id="5100237604440890931">已收起 - 点击此处即可展开。</translation>
-<translation id="510275257476243843">还剩 1 小时</translation>
-<translation id="5123685120097942451">无痕式标签页</translation>
-<translation id="5127805178023152808">同步功能已关闭</translation>
-<translation id="5129038482087801250">安装网络应用</translation>
-<translation id="5132942445612118989">将您的密码、历史记录等信息同步到所有设备上</translation>
-<translation id="5139940364318403933">了解如何使用 Google 云端硬盘</translation>
-<translation id="515227803646670480">清除存储的数据</translation>
-<translation id="5152843274749979095">尚未安装任何支持的应用</translation>
-<translation id="5161254044473106830">必须提供标题</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 项下载失败。}other{# 项下载失败。}}</translation>
-<translation id="5170568018924773124">在文件夹中显示</translation>
-<translation id="5184329579814168207">在 Chrome 中打开</translation>
-<translation id="5193988420012215838">已复制到剪贴板</translation>
-<translation id="5197729504361054390">系统会将您所选联系人的详细信息分享给 <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />。</translation>
-<translation id="5199929503336119739">工作资料</translation>
-<translation id="5210286577605176222">跳转到上一个标签页</translation>
-<translation id="5210365745912300556">关闭标签页</translation>
-<translation id="5224771365102442243">包含视频</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> 想搜索附近的蓝牙设备，并发现了以下设备：</translation>
-<translation id="5233638681132016545">打开新的标签页</translation>
-<translation id="526421993248218238">无法加载此页面</translation>
-<translation id="5271967389191913893">设备无法打开要下载的内容。</translation>
-<translation id="528192093759286357">从顶部向下拖动并触摸“返回”按钮，即可退出全屏模式。</translation>
-<translation id="5292796745632149097">发送到</translation>
-<translation id="5300589172476337783">显示</translation>
-<translation id="5301954838959518834">知道了</translation>
-<translation id="5304593522240415983">此字段不能为空</translation>
-<translation id="5307446750509046227">清空网站存储数据</translation>
-<translation id="5308380583665731573">连接</translation>
-<translation id="5313967007315987356">添加网站</translation>
-<translation id="5317780077021120954">保存</translation>
-<translation id="5324858694974489420">家长设置</translation>
-<translation id="5327248766486351172">名称</translation>
-<translation id="5335288049665977812">允许网站运行 JavaScript（推荐）</translation>
-<translation id="5342314432463739672">权限请求</translation>
-<translation id="5357811892247919462">收到了标签页</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE" /> 个打开的标签页，点按即可切换标签页}other{<ph name="OPEN_TABS_MANY" /> 个打开的标签页，点按即可切换标签页}}</translation>
-<translation id="5391532827096253100">您与此网站之间建立的连接不安全。网站信息</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{（以及另外 1 个）}other{（以及另外 # 个）}}</translation>
-<translation id="5400569084694353794">使用此应用即表示您同意遵守 Chrome 的<ph name="BEGIN_LINK1" />服务条款<ph name="END_LINK1" />和<ph name="BEGIN_LINK2" />隐私权声明<ph name="END_LINK2" />。</translation>
-<translation id="5403592356182871684">名称</translation>
-<translation id="5403644198645076998">只允许访问某些网站</translation>
-<translation id="5414836363063783498">正在验证…</translation>
-<translation id="5423934151118863508">您最常访问的网页将列在此处</translation>
-<translation id="5424588387303617268">可用存储空间：<ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">修改密码</translation>
-<translation id="5433691172869980887">已复制用户名</translation>
-<translation id="543509235395288790">正在下载 <ph name="COUNT" /> 个文件（<ph name="MEGABYTES" /> MB）。</translation>
-<translation id="5441522332038954058">跳转到地址栏</translation>
-<translation id="5447201525962359567">所有网站存储数据，包括 Cookie 及其他本地存储的数据</translation>
-<translation id="5447765697759493033">系统不会翻译此网站</translation>
-<translation id="545042621069398927">正在加快您的下载速度。</translation>
-<translation id="5456381639095306749">下载网页</translation>
-<translation id="5475862044948910901">启动增强现实会话？</translation>
-<translation id="548278423535722844">在地图应用中打开</translation>
-<translation id="5487521232677179737">清除数据</translation>
-<translation id="5494752089476963479">禁止会展示侵扰性或误导性广告的网站显示广告</translation>
-<translation id="5500777121964041360">可能无法在您所在的国家/地区使用</translation>
-<translation id="5512137114520586844">该帐号由 <ph name="PARENT_NAME" /> 管理。</translation>
-<translation id="5514904542973294328">已被此设备的管理员停用</translation>
-<translation id="5515439363601853141">需解锁才能查看您的密码</translation>
-<translation id="5516455585884385570">打开通知设置</translation>
-<translation id="5517095782334947753">您有来自 <ph name="FROM_ACCOUNT" /> 的书签、历史记录、密码及其他设置。</translation>
-<translation id="5524843473235508879">已禁止重定向。</translation>
-<translation id="5527082711130173040">Chrome 需要拥有位置信息使用权才能扫描设备。请<ph name="BEGIN_LINK1" />更新权限<ph name="END_LINK1" />。<ph name="BEGIN_LINK2" />此设备的位置信息使用权也已被停用<ph name="END_LINK2" />。</translation>
-<translation id="5527111080432883924">网站需先询问并得到许可才能读取剪贴板中的文字和图片（推荐）</translation>
-<translation id="5530766185686772672">关闭隐身标签页</translation>
-<translation id="5534334044554683961">当您处于 VR 环境时，此网站或许能够得知：
-  -   您的身体特征，例如身高
-  -   您房间的布局
-
-请确保您信任此网站，然后再进入 VR 环境。</translation>
-<translation id="5534640966246046842">已复制网站</translation>
-<translation id="5556459405103347317">重新加载</translation>
-<translation id="5561549206367097665">正在等待连接到网络…</translation>
-<translation id="557283862590186398">Chrome 需要获得相应权限，才能允许此网站使用您的麦克风。</translation>
-<translation id="55737423895878184">允许使用位置信息以及显示通知</translation>
-<translation id="5578795271662203820">在<ph name="SEARCH_ENGINE" />中搜索此图片</translation>
-<translation id="5581519193887989363">您始终可在<ph name="BEGIN_LINK1" />设置<ph name="END_LINK1" />中选择要同步的内容。</translation>
-<translation id="5595485650161345191">修改地址</translation>
-<translation id="5596627076506792578">更多选项</translation>
-<translation id="5599455543593328020">无痕模式</translation>
-<translation id="5620928963363755975">通过“更多选项”按钮在“下载内容”中查找您的文件和网页</translation>
-<translation id="5626134646977739690">名字：</translation>
-<translation id="5639724618331995626">允许访问所有网站</translation>
-<translation id="5648166631817621825">过去 7 天</translation>
-<translation id="5649053991847567735">自动下载项</translation>
-<translation id="5655963694829536461">搜索您的下载内容</translation>
-<translation id="5659593005791499971">电子邮件</translation>
-<translation id="5665379678064389456">在<ph name="APP_NAME" />中创建活动</translation>
-<translation id="5668404140385795438">覆盖网站的请求，以防止放大</translation>
-<translation id="5677928146339483299">已禁止</translation>
-<translation id="5684874026226664614">糟糕，此网页内容无法翻译。</translation>
-<translation id="5686790454216892815">文件名过长</translation>
-<translation id="5689516760719285838">位置信息</translation>
-<translation id="569536719314091526">通过“更多选项”按钮将此页面翻译成任何语言</translation>
-<translation id="572328651809341494">最近打开的标签页</translation>
-<translation id="5726692708398506830">放大网页上的所有内容</translation>
-<translation id="5748802427693696783">已切换到标准标签页</translation>
-<translation id="5749068826913805084">Chrome 需要具备存储空间使用权限，才能下载文件。</translation>
-<translation id="5763382633136178763">隐身标签页</translation>
-<translation id="5763514718066511291">点按即可复制该应用的网址</translation>
-<translation id="5765780083710877561">说明：</translation>
-<translation id="5793665092639000975">已使用 <ph name="SPACE_USED" />，共 <ph name="SPACE_AVAILABLE" /></translation>
-<translation id="5797070761912323120">Google 可能会利用您的历史记录为您提供个性化的 Google 搜索、广告和其他 Google 服务</translation>
-<translation id="5804241973901381774">权限</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# 小时前}other{# 小时前}}</translation>
-<translation id="5810288467834065221">版权所有 <ph name="YEAR" /> Google LLC. 保留所有权利。</translation>
-<translation id="5817918615728894473">配对</translation>
-<translation id="583281660410589416">未知</translation>
-<translation id="5833984609253377421">分享链接</translation>
-<translation id="5836192821815272682">正在下载 Chrome 更新…</translation>
-<translation id="5853623416121554550">已暂停</translation>
-<translation id="5854790677617711513">30 天之前的</translation>
-<translation id="5858741533101922242">Chrome 无法开启蓝牙适配器</translation>
-<translation id="5860033963881614850">关闭</translation>
-<translation id="5862731021271217234">要访问您在其他设备上打开的标签页，请开启同步功能</translation>
-<translation id="5864174910718532887">详细信息：按网站名称排序</translation>
-<translation id="5864419784173784555">正在等待完成另一项下载…</translation>
-<translation id="5865733239029070421">自动将使用情况统计信息和崩溃报告发送至 Google</translation>
-<translation id="5869522115854928033">已保存的密码</translation>
-<translation id="5902828464777634901">该网站存储的所有本地数据（包括 Cookie）都将被删除。</translation>
-<translation id="5916664084637901428">启用</translation>
-<translation id="5919204609460789179">需更新 <ph name="PRODUCT_NAME" />，才能开始同步</translation>
-<translation id="5937580074298050696">已节省 <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">重置</translation>
-<translation id="5942872142862698679">目前使用的搜索引擎是 Google</translation>
-<translation id="5952764234151283551">将您尝试访问的网页的网址发送给 Google</translation>
-<translation id="5956665950594638604">在新标签页中打开 Chrome 帮助中心</translation>
-<translation id="5958275228015807058">在“下载内容”中查找您的文件和网页</translation>
-<translation id="5962718611393537961">点按即可收起</translation>
-<translation id="6000066717592683814">继续使用 Google</translation>
-<translation id="6005538289190791541">建议的密码</translation>
-<translation id="6036057147555329831">额外的 ICU</translation>
-<translation id="6039379616847168523">跳转到下一个标签页</translation>
-<translation id="6040143037577758943">关闭</translation>
-<translation id="6042308850641462728">更多</translation>
-<translation id="604996488070107836">出现未知错误，未能下载 <ph name="FILE_NAME" />。</translation>
-<translation id="605721222689873409">YY</translation>
-<translation id="6064125863973209585">下载已完成</translation>
-<translation id="6075798973483050474">修改主页</translation>
-<translation id="60923314841986378">还剩 <ph name="HOURS" /> 小时</translation>
-<translation id="6108923351542677676">正在设置…</translation>
-<translation id="6111020039983847643">已耗用的流量</translation>
-<translation id="6112702117600201073">正在刷新页面</translation>
-<translation id="6127379762771434464">该项已移除</translation>
-<translation id="6140912465461743537">国家/地区</translation>
-<translation id="614940544461990577">请试试以下办法：</translation>
-<translation id="6154478581116148741">需在“设置”部分中开启屏幕锁定功能，才能从此设备中导出您的密码</translation>
-<translation id="6159335304067198720">节省 <ph name="PERCENT" /> 的数据流量</translation>
-<translation id="6165508094623778733">了解详情</translation>
-<translation id="6177111841848151710">不允许当前搜索引擎使用</translation>
-<translation id="6181444274883918285">添加例外网站</translation>
-<translation id="6192333916571137726">下载文件</translation>
-<translation id="6192792657125177640">例外</translation>
-<translation id="6194112207524046168">要让 Chrome 使用您的摄像头，您还需要在 <ph name="BEGIN_LINK" />Android 设置<ph name="END_LINK" />中开启摄像头。</translation>
-<translation id="6196640612572343990">阻止第三方 Cookie</translation>
-<translation id="6206551242102657620">连接是安全的。网站信息</translation>
-<translation id="6210748933810148297">不是 <ph name="EMAIL" />？</translation>
-<translation id="6221633008163990886">需解锁才能导出您的密码</translation>
+<translation id="1406000523432664303">“不跟踪”</translation>
 <translation id="6232535412751077445">如果您启用了“不跟踪”，您的浏览流量中将会包含一项请求。具体影响取决于网站是否会回应该请求以及如何解读该请求。
 
 例如：某些网站在收到该请求后，可能会向您展示相应的广告（这些广告并不是根据您访问过的其他网站而展示的）。许多网站仍会出于一些目的收集并使用您的浏览数据，例如，为了提高安全性，为了提供相关内容、广告和推荐内容，以及为了生成报告统计信息。</translation>
-<translation id="624789221780392884">有可用的更新</translation>
-<translation id="6255999984061454636">内容建议</translation>
-<translation id="6277522088822131679">打印该页面时出现问题，请重试。</translation>
-<translation id="6295158916970320988">所有网站</translation>
-<translation id="629730747756840877">帐号</translation>
-<translation id="6303969859164067831">退出帐号并关闭同步功能</translation>
-<translation id="6316139424528454185">Android 版本不受支持</translation>
-<translation id="6320088164292336938">振动</translation>
-<translation id="6324034347079777476">Android 系统同步功能已停用</translation>
-<translation id="6333140779060797560">通过<ph name="APPLICATION" />分享</translation>
-<translation id="6337234675334993532">加密</translation>
-<translation id="6341580099087024258">询问文件保存位置</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> 个地址}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> 个地址}}</translation>
-<translation id="6364438453358674297">要从历史记录中移除建议吗？</translation>
-<translation id="6369229450655021117">您可从这里搜索网上内容、与好友分享内容以及查看已打开的网页</translation>
-<translation id="6378173571450987352">详细信息：按已使用的数据流量排序</translation>
-<translation id="6381421346744604172">调暗网站颜色</translation>
-<translation id="6388207532828177975">清除并重置</translation>
-<translation id="6393863479814692971">Chrome 需要获得相应权限，才能允许此网站使用您的摄像头和麦克风。</translation>
-<translation id="6395288395575013217">链接</translation>
-<translation id="6404511346730675251">修改书签</translation>
-<translation id="6406506848690869874">同步</translation>
-<translation id="641643625718530986">打印…</translation>
-<translation id="6416782512398055893">已下载 <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">翻译网页</translation>
-<translation id="6433501201775827830">选择您的搜索引擎</translation>
-<translation id="6437478888915024427">网页信息</translation>
-<translation id="6441734959916820584">名称太长</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# 张图片}other{# 张图片}}</translation>
-<translation id="6447842834002726250">Cookie</translation>
-<translation id="6461962085415701688">无法打开文件</translation>
-<translation id="6464977750820128603">您可以查看自己在 Chrome 中访问的网站并为这些网站设置计时器。\n\nGoogle 会获取这些设有计时器的网站的相关信息以及您对这些网站的访问时长。这些信息会被用于改进“数字健康”应用。</translation>
-<translation id="6475951671322991020">下载视频</translation>
-<translation id="6482749332252372425">未能成功下载 <ph name="FILE_NAME" />，因为存储空间不足。</translation>
-<translation id="6496823230996795692">如果您是首次使用<ph name="APP_NAME" />，则需连接到互联网。</translation>
-<translation id="6508722015517270189">重新启动 Chrome</translation>
-<translation id="6527303717912515753">分享</translation>
-<translation id="6532866250404780454">您在 Chrome 中访问的网站不会显示。所有网站计时器都会被删除。</translation>
-<translation id="6534565668554028783">Google 的响应速度太慢</translation>
-<translation id="6538442820324228105">已下载 <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">出了点问题。请稍后重试。</translation>
-<translation id="654446541061731451">选择要传输的标签页</translation>
-<translation id="6545017243486555795">清除所有数据</translation>
-<translation id="6545864417968258051">蓝牙扫描</translation>
-<translation id="6560414384669816528">改用搜狗搜索</translation>
-<translation id="6566259936974865419">Chrome 已为您保存的数据量：<ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">一律允许</translation>
-<translation id="6573431926118603307">您在其他设备上的 Chrome 中打开的标签页将列在此处。</translation>
-<translation id="6583199322650523874">为当前网页添加书签</translation>
-<translation id="6593061639179217415">桌面版网站</translation>
-<translation id="6600954340915313787">已复制到 Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">受保护的内容</translation>
-<translation id="6627583120233659107">修改文件夹</translation>
-<translation id="6643016212128521049">清除</translation>
-<translation id="6643649862576733715">按已节省的数据流量排序</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> 个联系人}other{<ph name="CONTACT_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> 个联系人}}</translation>
-<translation id="6649642165559792194">预览图片<ph name="BEGIN_NEW" />新<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome 需要拥有位置信息权限才能扫描设备。<ph name="BEGIN_LINK" />更新权限<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">密码</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">在 <ph name="APP_NAME" />中打开</translation>
-<translation id="666981079809192359">Chrome 隐私权声明</translation>
-<translation id="6676840375528380067">从这部设备中清除您的 Chrome 数据？</translation>
-<translation id="6697492270171225480">找不到相应网页时，显示有关类似网页的建议</translation>
-<translation id="6697947395630195233">Chrome 需要获得位置权限，才能将您的位置信息共享给此网站。</translation>
-<translation id="6698801883190606802">管理已同步的数据</translation>
-<translation id="6699370405921460408">Google 服务器会优化您访问的网页。</translation>
-<translation id="6706288973712894588">您目前处于离线状态。\n<ph name="BEGIN_LINK" />浏览您的离线版 Feed。<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">资讯</translation>
-<translation id="6710213216561001401">上一个</translation>
-<translation id="671481426037969117">您的 <ph name="FQDN" /> 计时器已结束计时。它将于明天重新开始。</translation>
-<translation id="6738867403308150051">正在下载…</translation>
-<translation id="6746124502594467657">下移</translation>
-<translation id="6766622839693428701">向下滑动即可关闭。</translation>
-<translation id="6766758767654711248">点按即可转到网站</translation>
-<translation id="6767294960381293877">要与之分享标签页的设备的列表已半屏打开。</translation>
-<translation id="6782111308708962316">阻止第三方网站保存和读取 Cookie 数据</translation>
-<translation id="6790428901817661496">播放</translation>
-<translation id="6811034713472274749">页面已可供查看</translation>
-<translation id="6818926723028410516">选择内容</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">翻译</translation>
-<translation id="6845325883481699275">帮助我们改善 Chrome 安全性</translation>
-<translation id="6846298663435243399">正在加载...</translation>
-<translation id="6850409657436465440">您的下载仍在进行中</translation>
-<translation id="6850830437481525139">已关闭 <ph name="TAB_COUNT" /> 个标签页</translation>
-<translation id="6864459304226931083">下载图片</translation>
-<translation id="6865313869410766144">自动填充表单数据</translation>
-<translation id="688738109438487280">将现有数据添加到 <ph name="TO_ACCOUNT" />。</translation>
-<translation id="6891726759199484455">需解锁才能复制您的密码</translation>
-<translation id="6896758677409633944">复制</translation>
-<translation id="6910211073230771657">已删除</translation>
-<translation id="6912998170423641340">禁止网站读取剪贴板中的文字和图片</translation>
-<translation id="6914783257214138813">所有能查看此导出文件的人员都能看到您的密码。</translation>
-<translation id="6942665639005891494">使用“设置”菜单选项随时更改默认的下载内容保存位置</translation>
-<translation id="6945221475159498467">选择</translation>
-<translation id="6963642900430330478">此网页存在危险。网站信息</translation>
-<translation id="6963766334940102469">删除书签</translation>
-<translation id="6965382102122355670">确定</translation>
-<translation id="6979737339423435258">时间不限</translation>
-<translation id="6981982820502123353">无障碍</translation>
-<translation id="6989267951144302301">无法下载</translation>
-<translation id="6990079615885386641">从 Google Play 商店下载应用：<ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">在允许网站使用您的麦克风前先询问（推荐）</translation>
-<translation id="7015203776128479407">初始同步设置未完成。同步功能处于关闭状态。</translation>
-<translation id="7016516562562142042">允许当前搜索引擎使用</translation>
-<translation id="7022756207310403729">在浏览器中打开</translation>
-<translation id="702463548815491781">建议在开启 TalkBack 或“开关控制”时使用</translation>
-<translation id="7029809446516969842">密码</translation>
-<translation id="7053983685419859001">禁止</translation>
-<translation id="7055152154916055070">已禁止重定向：</translation>
-<translation id="7063006564040364415">无法连接到同步服务器。</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{已选择 1 项}other{已选择 # 项}}</translation>
-<translation id="7071521146534760487">管理帐号</translation>
-<translation id="7077143737582773186">SD 卡</translation>
-<translation id="7087918508125750058">已选择 <ph name="ITEM_COUNT" /> 项。选项位于屏幕顶部附近</translation>
-<translation id="7121362699166175603">清除历史记录和地址栏中的自动填充项。您的 Google 帐号在 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> 上可能有其他形式的浏览记录。</translation>
-<translation id="7128222689758636196">允许当前搜索引擎使用</translation>
-<translation id="7138678301420049075">其他</translation>
-<translation id="7141896414559753902">禁止网站显示弹出式窗口和重定向（推荐）</translation>
-<translation id="7149158118503947153">从 <ph name="DOMAIN_NAME" /> <ph name="BEGIN_LINK" />加载原始网页<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">过去 24 小时</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">以后，您可以在“设置”中更改此设置。</translation>
-<translation id="7180611975245234373">刷新</translation>
-<translation id="7189372733857464326">正在等待 Google Play 服务完成更新</translation>
-<translation id="7191430249889272776">标签页已在后台打开。</translation>
-<translation id="723171743924126238">选择图片</translation>
-<translation id="7233236755231902816">若要使用您的语言查看网页，请获取最新版本的 Chrome</translation>
-<translation id="7243308994586599757">选项在靠近屏幕底部的位置</translation>
-<translation id="7248069434667874558">请确保<ph name="TARGET_DEVICE_NAME" />已在 Chrome 中开启同步功能</translation>
-<translation id="7250468141469952378">已选择 <ph name="ITEM_COUNT" /> 项</translation>
-<translation id="7274013316676448362">禁止访问的网站</translation>
-<translation id="7290209999329137901">不可重命名</translation>
-<translation id="7291387454912369099">使用 Chrome 中的 Google 助理结帐</translation>
-<translation id="7293171162284876153">要开始同步，请开启“同步 Chrome 数据”。</translation>
-<translation id="729975465115245577">您的设备上没有可以存储密码文件的应用。</translation>
-<translation id="7302081693174882195">详细信息：按已节省的数据流量排序</translation>
-<translation id="7328017930301109123">在精简模式下，Chrome 可更快速地加载网页，并可节省多达百分之 60 的流量。</translation>
-<translation id="7333031090786104871">仍在添加先前的网站</translation>
-<translation id="7352939065658542140">视频</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{分享 1 个所选项}other{分享 # 个所选项}}</translation>
 <translation id="7359002509206457351">查询付款方式</translation>
+<translation id="8026334261755873520">清除浏览数据</translation>
+<translation id="1291207594882862231">清除历史记录、Cookie、网站数据、缓存内容…</translation>
+<translation id="7814200940910057384">已清除 Brave 数据</translation>
+<translation id="1664855196866195614">所选数据已从 Brave 和同步的设备中移除。
+
+不过，您的 Brave Software 帐号在 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> 上可能还有其他形式的浏览记录（例如，在其他 Brave Software 服务中的搜索记录和活动记录）。</translation>
+<translation id="4699172675775169585">缓存的图片和文件</translation>
+<translation id="2496180316473517155">浏览记录</translation>
+<translation id="2546283357679194313">Cookie 和网站数据</translation>
+<translation id="8662811608048051533">您会从大多数网站退出。</translation>
+<translation id="8218628800671693884">您会从大多数网站退出，但不会退出自己的 Brave Software 帐号。</translation>
+<translation id="2017836877785168846">清除历史记录和地址栏中的自动填充项。</translation>
+<translation id="8096327394278038498">清除历史记录和地址栏中的自动填充项。您的 Brave Software 帐号在 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> 上可能有其他形式的浏览记录。</translation>
+<translation id="8122693181154564064">清除所有登录过的设备上的历史记录。您的 Brave Software 帐号在 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> 上可能有其他形式的浏览记录。</translation>
+<translation id="5869522115854928033">已保存的密码</translation>
+<translation id="6865313869410766144">自动填充表单数据</translation>
+<translation id="7562080006725997899">正在清除浏览数据</translation>
+<translation id="5487521232677179737">清除数据</translation>
+<translation id="7498271377022651285">请稍候…</translation>
+<translation id="784934925303690534">时间范围</translation>
+<translation id="1718835860248848330">过去一小时</translation>
+<translation id="7149893636342594995">过去 24 小时</translation>
+<translation id="5648166631817621825">过去 7 天</translation>
+<translation id="8571213806525832805">近 4 周</translation>
+<translation id="5854790677617711513">30 天之前的</translation>
+<translation id="6979737339423435258">时间不限</translation>
+<translation id="982182592107339124">这会清除所有网站的数据，包括：</translation>
+<translation id="6643016212128521049">清除</translation>
+<translation id="7641339528570811325">清除浏览数据…</translation>
+<translation id="1670399744444387456">基本</translation>
+<translation id="3245261285041759672">您的 Brave Software 帐号在 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> 上可能有其他形式的浏览记录。</translation>
+<translation id="7274013316676448362">禁止访问的网站</translation>
+<translation id="2534155362429831547">删除了 <ph name="NUMBER_OF_ITEMS"/> 项</translation>
+<translation id="1121094540300013208">使用情况信息和崩溃报告</translation>
+<translation id="9079153198295609735">将使用情况统计信息和崩溃报告自动发送给 Brave Software</translation>
+<translation id="6981982820502123353">无障碍</translation>
+<translation id="2387895666653383613">文字大小</translation>
+<translation id="2321958826496381788">拖动该滑块，将文字调整到适合您阅读的大小。点按两次某段落后，显示的文字至少应是这么大。</translation>
+<translation id="3895926599014793903">强制启用缩放功能</translation>
+<translation id="5668404140385795438">覆盖网站的请求，以防止放大</translation>
+<translation id="4149994727733219643">使用简化版视图查看网页</translation>
+<translation id="9100505651305367705">询问是否使用简化版视图显示支持这一功能的文章</translation>
+<translation id="1409426117486808224">使用简化版视图查看打开的标签页</translation>
+<translation id="702463548815491781">建议在开启 TalkBack 或“开关控制”时使用</translation>
+<translation id="8284326494547611709">字幕</translation>
+<translation id="4165986682804962316">网站设置</translation>
+<translation id="6295158916970320988">所有网站</translation>
+<translation id="8380167699614421159">此网站会展示侵扰性或误导性广告</translation>
+<translation id="1919345977826869612">广告</translation>
+<translation id="410351446219883937">自动播放</translation>
+<translation id="6447842834002726250">Cookie</translation>
+<translation id="6196640612572343990">阻止第三方 Cookie</translation>
+<translation id="6782111308708962316">阻止第三方网站保存和读取 Cookie 数据</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">弹出式窗口和重定向</translation>
+<translation id="4751476147751820511">动态传感器或光传感器</translation>
+<translation id="1717218214683051432">动态传感器</translation>
+<translation id="2091887806945687916">声音</translation>
+<translation id="2586657967955657006">剪贴板</translation>
+<translation id="6320088164292336938">振动</translation>
+<translation id="4226663524361240545">收到通知时设备会振动</translation>
+<translation id="1446450296470737166">允许全面控制 MIDI 设备</translation>
+<translation id="3744111561329211289">后台同步</translation>
+<translation id="5649053991847567735">自动下载项</translation>
+<translation id="6181444274883918285">添加例外网站</translation>
+<translation id="5313967007315987356">添加网站</translation>
+<translation id="1369915414381695676">网站 <ph name="SITE_NAME"/> 已添加</translation>
+<translation id="7837721118676387834">允许特定网站自动播放静音的视频。</translation>
+<translation id="2621115761605608342">允许特定网站运行 JavaScript。</translation>
+<translation id="8801436777607969138">禁止特定网站运行 JavaScript。</translation>
+<translation id="8372893542064058268">允许特定网站进行后台同步。</translation>
+<translation id="358794129225322306">允许网站自动下载多个文件。</translation>
+<translation id="4008040567710660924">允许特定网站使用 Cookie。</translation>
+<translation id="8958424370300090006">阻止特定网站使用 Cookie。</translation>
+<translation id="7882806643839505685">允许特定网站播放声音。</translation>
+<translation id="4468959413250150279">将某个特定网站静音。</translation>
+<translation id="1994173015038366702">网站网址</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">使用情况</translation>
+<translation id="5804241973901381774">权限</translation>
+<translation id="4278390842282768270">允许</translation>
+<translation id="5677928146339483299">已禁止</translation>
+<translation id="1984937141057606926">允许（第三方除外）</translation>
+<translation id="7423098979219808738">先询问</translation>
+<translation id="8116925261070264013">已静音的网站</translation>
+<translation id="8300705686683892304">由应用管理</translation>
+<translation id="6192792657125177640">例外</translation>
+<translation id="257931822824936280">已展开 - 点击此处即可收起。</translation>
+<translation id="5100237604440890931">已收起 - 点击此处即可展开。</translation>
+<translation id="857943718398505171">允许（推荐）</translation>
+<translation id="2913331724188855103">允许网站保存和读取 Cookie 数据（推荐）</translation>
+<translation id="7445411102860286510">允许网站自动播放静音的视频（推荐）</translation>
+<translation id="5335288049665977812">允许网站运行 JavaScript（推荐）</translation>
+<translation id="5527111080432883924">网站需先询问并得到许可才能读取剪贴板中的文字和图片（推荐）</translation>
+<translation id="6912998170423641340">禁止网站读取剪贴板中的文字和图片</translation>
+<translation id="7423538860840206698">已阻止读取剪贴板中的内容</translation>
+<translation id="3955193568934677022">允许网站播放受保护的内容（推荐）</translation>
+<translation id="445467742685312942">允许网站播放受保护内容。</translation>
+<translation id="2107397443965016585">网站需先询问并得到许可才能播放受保护内容 （推荐）</translation>
+<translation id="2910701580606108292">网站需先询问并得到许可才能播放受保护内容</translation>
+<translation id="757524316907819857">禁止网站播放受保护内容</translation>
+<translation id="3277252321222022663">允许网站使用传感器（推荐）</translation>
+<translation id="5048398596102334565">允许网站使用动态传感器（推荐）</translation>
+<translation id="8816026460808729765">禁止网站使用传感器</translation>
+<translation id="169515064810179024">禁止网站使用动态传感器</translation>
+<translation id="1660204651932907780">允许网站播放声音（推荐）</translation>
+<translation id="3600792891314830896">将播放声音的网站静音</translation>
+<translation id="1743802530341753419">网站需先询问并得到许可才能连接设备（推荐）</translation>
+<translation id="851751545965956758">禁止网站连接到设备</translation>
+<translation id="7141896414559753902">禁止网站显示弹出式窗口和重定向（推荐）</translation>
+<translation id="5494752089476963479">禁止会展示侵扰性或误导性广告的网站显示广告</translation>
+<translation id="3123473560110926937">已禁止部分网站显示广告</translation>
+<translation id="965817943346481315">屏蔽会展示侵扰性或误导性广告的网站（推荐）</translation>
+<translation id="3386292677130313581">网站需要先询问并得到您的许可才能获取您的位置信息（推荐）</translation>
+<translation id="9139068048179869749">网站发送通知前需先询问并获得许可（推荐）</translation>
+<translation id="4479647676395637221">在允许网站使用您的摄像头前先询问（推荐）</translation>
+<translation id="6992289844737586249">在允许网站使用您的麦克风前先询问（推荐）</translation>
+<translation id="2289270750774289114">在网站想发现附近的蓝牙设备时询问您（推荐）</translation>
+<translation id="7053983685419859001">禁止</translation>
+<translation id="7128222689758636196">允许当前搜索引擎使用</translation>
+<translation id="7589445247086920869">不允许当前搜索引擎使用</translation>
+<translation id="6388207532828177975">清除并重置</translation>
+<translation id="7999064672810608036">确定要清除该网站的所有本地数据（包括 Cookie）并重置该网站的所有权限吗？</translation>
+<translation id="2822354292072154809">确定要重置<ph name="CHOSEN_OBJECT_NAME"/>的所有网站权限吗？</translation>
+<translation id="515227803646670480">清除存储的数据</translation>
+<translation id="5902828464777634901">该网站存储的所有本地数据（包括 Cookie）都将被删除。</translation>
+<translation id="119944043368869598">全部清除</translation>
+<translation id="2490684707762498678">由 <ph name="APP_NAME"/> 管理</translation>
+<translation id="5516455585884385570">打开通知设置</translation>
+<translation id="1404122904123200417">嵌入位置：<ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">网站保存的文件会显示在这里</translation>
+<translation id="4181841719683918333">语言</translation>
+<translation id="2647434099613338025">添加语言</translation>
+<translation id="1952172573699511566">网站将尽可能以您的首选语言显示文字。</translation>
+<translation id="8559990750235505898">询问是否翻译其他语言版本的网页</translation>
+<translation id="4719927025381752090">提供翻译</translation>
+<translation id="8156139159503939589">您能看懂哪些语言？</translation>
+<translation id="5689516760719285838">位置信息</translation>
+<translation id="2440823041667407902">位置信息使用权</translation>
+<translation id="2023546461831060654">在 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>中为 Brave 启用这些权限。</translation>
+<translation id="6665548517310046133">在 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>中为 Brave 启用这项权限。</translation>
+<translation id="2928908108430545745">要让 Brave 访问您的位置信息，您还需要在 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>中开启位置信息服务。</translation>
+<translation id="1028853271388022585">要让 Brave 使用您的摄像头，您还需要在 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>中开启摄像头。</translation>
+<translation id="2913721282607281710">要让 Brave 向您发送通知，您还需要在 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>中开启通知。</translation>
+<translation id="8753483718490035722">要让 Brave 使用您的麦克风，您还需要在 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>中开启麦克风。</translation>
+<translation id="1887786770086287077">此设备的位置信息使用权已关闭；若想开启这项权限，请转到 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>。</translation>
+<translation id="2570922361219980984">此设备的位置信息使用权也已关闭；若想开启这项权限，请转到 <ph name="BEGIN_LINK"/>Android 设置<ph name="END_LINK"/>。</translation>
+<translation id="1620510694547887537">摄像头</translation>
+<translation id="3227137524299004712">麦克风</translation>
+<translation id="1647391597548383849">使用您的摄像头</translation>
+<translation id="945632385593298557">使用您的麦克风</translation>
+<translation id="6612358246767739896">受保护的内容</translation>
+<translation id="885701979325669005">存储数据</translation>
+<translation id="3198916472715691905">已存储 <ph name="STORAGE_AMOUNT"/> 数据</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">撤消设备权限</translation>
+<translation id="4962975101802056554">撤消设备的所有权限</translation>
+<translation id="6545864417968258051">蓝牙扫描</translation>
+<translation id="4411535500181276704">精简模式</translation>
+<translation id="7821588508402923572">您的数据流量节省情况将显示在这里</translation>
+<translation id="2131665479022868825">节省了 <ph name="DATA"/></translation>
+<translation id="8569404424186215731">自 <ph name="DATE"/>以来</translation>
+<translation id="3252158532344029638">在精简模式下，Brave 可更快速地加载网页，并可节省多达百分之 60 的流量。</translation>
+<translation id="6159335304067198720">节省 <ph name="PERCENT"/> 的数据流量</translation>
+<translation id="7494974237137038751">已节省的流量</translation>
+<translation id="6111020039983847643">已耗用的流量</translation>
+<translation id="7413229368719586778">开始日期：<ph name="DATE"/></translation>
+<translation id="1782483593938241562">结束日期：<ph name="DATE"/></translation>
+<translation id="2728754400939377704">按网站排序</translation>
+<translation id="5864174910718532887">详细信息：按网站名称排序</translation>
+<translation id="116280672541001035">已耗用</translation>
+<translation id="8349013245300336738">按已使用的数据流量排序</translation>
+<translation id="6378173571450987352">详细信息：按已使用的数据流量排序</translation>
+<translation id="2631006050119455616">已节省</translation>
+<translation id="6643649862576733715">按已节省的数据流量排序</translation>
+<translation id="7302081693174882195">详细信息：按已节省的数据流量排序</translation>
+<translation id="4179980317383591987">已使用 <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">已节省 <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">其余的网站（<ph name="NUMBER_OF_SITES"/> 个）</translation>
+<translation id="7138678301420049075">其他</translation>
+<translation id="4913161338056004800">重置统计信息</translation>
+<translation id="1856325424225101786">重置精简模式？</translation>
+<translation id="3658159451045945436">这项重置操作会清空流量节省情况历史记录，包括曾访问过的网站的列表。</translation>
+<translation id="3295530008794733555">浏览速度更快。耗用的流量更少。</translation>
+<translation id="7340390500800578919">在精简模式下，Brave 可更快速地加载网页，并可节省多达 60% 的流量。为了优化您访问的网页，Brave 会将您的网络流量数据发送给 Brave Software。<ph name="BEGIN_LINK"/>了解详情<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">开启精简模式</translation>
+<translation id="4493497663118223949">精简模式已开启</translation>
+<translation id="7559975015014302720">精简模式已关闭</translation>
+<translation id="7606077192958116810">精简模式已开启。在“设置”中管理此模式。</translation>
+<translation id="4714588616299687897">最多可为您节省 60% 的数据流量</translation>
+<translation id="1006927014032731288">Brave Software 服务器会优化您访问的网页。</translation>
+<translation id="3257320067425202300">Brave 已为您保存的数据量：<ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave 已为您保存的数据量：<ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">下载内容保存位置</translation>
+<translation id="7077143737582773186">SD 卡</translation>
+<translation id="7762668264895820836">SD 卡 <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">询问文件保存位置</translation>
+<translation id="6192333916571137726">下载文件</translation>
+<translation id="1672586136351118594">不再显示</translation>
+<translation id="2650751991977523696">是否重新下载文件？</translation>
+<translation id="8664979001105139458">文件名已存在</translation>
+<translation id="488187801263602086">重命名文件</translation>
+<translation id="5686790454216892815">文件名过长</translation>
+<translation id="7454641608352164238">空间不足</translation>
+<translation id="8972098258593396643">是否下载到默认文件夹？</translation>
+<translation id="804335162455518893">找不到 SD 卡</translation>
+<translation id="7475688122056506577">找不到 SD 卡。您的某些文件可能会丢失。</translation>
+<translation id="4198423547019359126">没有可用的下载内容保存位置</translation>
+<translation id="8224471946457685718">在连接到 Wi-Fi 时下载为您推荐的文章</translation>
+<translation id="4970824347203572753">无法在您所在的国家/地区使用</translation>
+<translation id="5500777121964041360">可能无法在您所在的国家/地区使用</translation>
+<translation id="1173894706177603556">重命名</translation>
+<translation id="1986685561493779662">名称已存在</translation>
+<translation id="6441734959916820584">名称太长</translation>
+<translation id="2923908459366352541">名称无效</translation>
+<translation id="7290209999329137901">不可重命名</translation>
+<translation id="3334729583274622784">更改文件扩展名？</translation>
+<translation id="107147699690128016">如果您更改文件扩展名，此文件可能会在另一应用中打开并对您的设备造成危害。</translation>
+<translation id="8541922081612557424">关于 Brave</translation>
+<translation id="5311273890481188673">版权所有 <ph name="YEAR"/> Brave Software LLC. 保留所有权利。</translation>
+<translation id="1416550906796893042">应用版本</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/>（上次更新时间：<ph name="TIME_SINCE_UPDATE"/>）</translation>
+<translation id="7596558890252710462">操作系统</translation>
+<translation id="3968054912784331254">此版本的 Android 不再支持 Brave 更新</translation>
+<translation id="7665369617277396874">添加帐号</translation>
+<translation id="649070405679044769">已使用以下帐号登录 Brave Software：</translation>
+<translation id="6234515504547364178">退出 Brave</translation>
+<translation id="5324858694974489420">家长设置</translation>
+<translation id="8920114477895755567">正在等待获取家长的详细信息。</translation>
+<translation id="5512137114520586844">该帐号由 <ph name="PARENT_NAME"/> 管理。</translation>
+<translation id="2956410042958133412">该帐号由 <ph name="PARENT_NAME_1"/> 和 <ph name="PARENT_NAME_2"/> 管理。</translation>
+<translation id="8168435359814927499">内容</translation>
+<translation id="5403644198645076998">只允许访问某些网站</translation>
+<translation id="8641930654639604085">尽量屏蔽成人网站</translation>
+<translation id="5639724618331995626">允许访问所有网站</translation>
+<translation id="796823723482603597">由 Brave 提供支持</translation>
+<translation id="6324034347079777476">Android 系统同步功能已停用</translation>
+<translation id="5127805178023152808">同步功能已关闭</translation>
+<translation id="7015203776128479407">初始同步设置未完成。同步功能处于关闭状态。</translation>
+<translation id="2497852260688568942">您的管理员已停用同步</translation>
+<translation id="9100610230175265781">必须提供密码</translation>
+<translation id="6108923351542677676">正在设置…</translation>
+<translation id="4062305924942672200">法律信息</translation>
+<translation id="4256782883801055595">开放源代码许可</translation>
+<translation id="1138681184697033370">Brave 服务条款</translation>
+<translation id="7392539049993970338">Brave 隐私权声明</translation>
+<translation id="2677748264148917807">离开</translation>
+<translation id="5556459405103347317">重新加载</translation>
+<translation id="1623104350909869708">阻止此页创建其他对话框</translation>
+<translation id="2968755619301702150">证书查看器</translation>
+<translation id="1360432990279830238">退出帐号并关闭同步功能？</translation>
+<translation id="8581481290581777242">从这部设备中清除您的 Brave 数据？</translation>
+<translation id="1318865768845061710">您的书签、历史记录、密码和其他 Brave 数据将不再同步到您的 Brave Software 帐号中</translation>
+<translation id="3325020657155065477">同时从此设备中清除您的 Brave 数据</translation>
+<translation id="6136448902816743006">您将要退出由 <ph name="DOMAIN_NAME"/> 管理的帐号，因此您的 Brave 数据将会从这部设备中删除，但仍会保留在您的 Brave Software 帐号中。</translation>
+<translation id="1853026300647876496">正在连接到 Brave Software，请稍等片刻…</translation>
+<translation id="2328985652426384049">无法登录</translation>
+<translation id="7723158744459952869">Brave Software 的响应速度太慢</translation>
+<translation id="4572422548854449519">请登录受管理的帐号</translation>
+<translation id="2689656545739939160">您正要登录由 <ph name="MANAGED_DOMAIN"/> 管理的帐号，并要授权其管理员控制您的 Brave 数据。您的数据将与此帐号永久关联。退出 Brave 后，您的数据将从这台设备上删除，但仍会保留在您的 Brave Software 帐号中。</translation>
+<translation id="1749561566933687563">同步您的书签</translation>
+<translation id="4242533952199664413">打开“设置”</translation>
+<translation id="1111673857033749125">您在其他设备上保存的书签将列在此处。</translation>
+<translation id="8636825310635137004">要访问您在其他设备上的标签页，请开启同步功能。</translation>
+<translation id="3269956123044984603">要访问您在其他设备上的标签页，请在 Android 帐号设置部分开启“自动同步数据”。</translation>
+<translation id="5157964048453367290">您在其他设备上的 Brave 中打开的标签页将列在此处。</translation>
+<translation id="4684427112815847243">同步所有数据类型</translation>
+<translation id="2709516037105925701">自动填充</translation>
+<translation id="8820817407110198400">书签</translation>
+<translation id="1644574205037202324">历史记录</translation>
+<translation id="17513872634828108">目前打开的标签页</translation>
+<translation id="1320169905922104972">Brave Software Pay 中存储的信用卡和地址信息</translation>
+<translation id="6337234675334993532">加密</translation>
+<translation id="6698801883190606802">管理已同步的数据</translation>
+<translation id="3598578758776312506">使用 Brave Software 凭据加密密码</translation>
+<translation id="7810580217418711046">自 <ph name="TIME"/>起，使用 Brave Software 密码加密已同步的数据</translation>
+<translation id="8461694314515752532">使用您自己的同步密码加密已同步的数据</translation>
+<translation id="2996291259634659425">创建密码</translation>
+<translation id="5713644099811900409">Brave Software 帐号</translation>
+<translation id="8997474919031554666">密码加密不包括 Brave Software Pay 中的付款方式和地址。只有知道您密码的人才能读取您的已加密数据。系统不会将该密码发送给 Brave Software，Brave Software 也不会存储该密码。如果您忘记了密码或想更改此设置，则需重置同步设置。<ph name="BEGIN_LINK"/>了解详情<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">密码</translation>
+<translation id="7772032839648071052">确认密码</translation>
+<translation id="5304593522240415983">此字段不能为空</translation>
+<translation id="321773570071367578">如果您忘记了密码或想更改此设置，请<ph name="BEGIN_LINK"/>重置同步设置<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">密码不匹配</translation>
+<translation id="5149495116300586333">密码加密不包括 Brave Software Pay 中的付款方式和地址。
+
+要更改此设置，请<ph name="BEGIN_LINK"/>重置同步设置<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">密码不正确</translation>
+<translation id="5414836363063783498">正在验证…</translation>
+<translation id="6846298663435243399">正在加载...</translation>
+<translation id="5517095782334947753">您有来自 <ph name="FROM_ACCOUNT"/> 的书签、历史记录、密码及其他设置。</translation>
+<translation id="3928666092801078803">合并我的数据</translation>
+<translation id="688738109438487280">将现有数据添加到 <ph name="TO_ACCOUNT"/>。</translation>
+<translation id="806745655614357130">单独保存我的数据</translation>
+<translation id="1145536944570833626">删除现有数据。</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> 希望与以下所选设备配对：</translation>
+<translation id="4915549754973153784">正在搜寻设备…<ph name="BEGIN_LINK"/>获取帮助<ph name="END_LINK"/></translation>
+<translation id="5817918615728894473">配对</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>获取帮助<ph name="END_LINK1"/>或<ph name="BEGIN_LINK2"/>重新扫描<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">未找到任何兼容设备</translation>
+<translation id="3773755127849930740">请<ph name="BEGIN_LINK"/>开启蓝牙<ph name="END_LINK"/>以允许配对</translation>
+<translation id="998321811308652668">Brave 无法开启蓝牙适配器</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>获取帮助<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave 需要拥有位置信息权限才能扫描设备。<ph name="BEGIN_LINK"/>更新权限<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave 需要拥有位置信息使用权才能扫描设备。<ph name="BEGIN_LINK"/>此设备的位置信息使用权已被停用<ph name="END_LINK"/>。</translation>
+<translation id="2367014990350929709">Brave 需要拥有位置信息使用权才能扫描设备。请<ph name="BEGIN_LINK1"/>更新权限<ph name="END_LINK1"/>。<ph name="BEGIN_LINK2"/>此设备的位置信息使用权也已被停用<ph name="END_LINK2"/>。</translation>
+<translation id="1569387923882100876">连接的设备</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{信号强度：# 格}other{信号强度：# 格}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> 想搜索附近的蓝牙设备，并发现了以下设备：</translation>
+<translation id="8368027906805972958">未知或不支持的设备 (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">同步功能无法正常运行</translation>
+<translation id="1810845389119482123">未完成初始同步设置</translation>
+<translation id="3235722914093408050">打开 Android 设置，重新启用 Android 系统同步功能以开始 Brave 同步</translation>
+<translation id="3367813778245106622">重新登录以开始同步</translation>
+<translation id="974555521953189084">输入密码以开始同步</translation>
+<translation id="2997266899014181325">要开始同步，请开启“同步 Brave 数据”。</translation>
+<translation id="8260126382462817229">请尝试重新登录</translation>
+<translation id="5919204609460789179">需更新 <ph name="PRODUCT_NAME"/>，才能开始同步</translation>
+<translation id="397583555483684758">同步功能已停止工作</translation>
+<translation id="1966710179511230534">请更新您的登录详细信息。</translation>
+<translation id="7063006564040364415">无法连接到同步服务器。</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> 不是最新版本。</translation>
+<translation id="4170011742729630528">此服务目前无法使用，请稍后再试。</translation>
+<translation id="7947953824732555851">接受并登录</translation>
+<translation id="8583805026567836021">清除帐号数据</translation>
+<translation id="8310344678080805313">标准标签页</translation>
+<translation id="5748802427693696783">已切换到标准标签页</translation>
+<translation id="7998918019931843664">重新打开关闭的标签页</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/>，标签页</translation>
+<translation id="4452411734226507615">关闭“<ph name="TAB_TITLE"/>”标签页</translation>
+<translation id="7243308994586599757">选项在靠近屏幕底部的位置</translation>
+<translation id="4060598801229743805">选项位于屏幕顶部附近</translation>
+<translation id="2810645512293415242">简化版网页不仅可节省数据流量，还可更快速地进行加载。</translation>
+<translation id="3985215325736559418">要重新下载“<ph name="FILE_NAME"/>”吗？</translation>
+<translation id="2450083983707403292">要重新开始下载 <ph name="FILE_NAME"/> 吗？</translation>
+<translation id="7514365320538308">下载</translation>
+<translation id="545042621069398927">正在加快您的下载速度。</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{正在下载 1 个文件。}other{正在下载 # 个文件。}}</translation>
+<translation id="543509235395288790">正在下载 <ph name="COUNT"/> 个文件（共 <ph name="MEGABYTES"/>）。</translation>
+<translation id="4988210275050210843">正在下载文件 (<ph name="MEGABYTES"/>)。</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{已完成 1 项下载。}other{已完成 # 项下载。}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{1 项下载失败。}other{# 项下载失败。}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{有 1 项下载尚待处理。}other{有 # 项下载尚待处理。}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>。</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/>按钮</translation>
+<translation id="3205824638308738187">即将完成！</translation>
+<translation id="3960299545138990065">重新启动 Brave</translation>
+<translation id="3771001275138982843">无法下载此项更新</translation>
+<translation id="3888648114124182147">正在下载 Brave 更新…</translation>
+<translation id="1705567146636171298">更新 Brave</translation>
+<translation id="6195417478702700398">要获得最好的浏览体验，请打开 Brave 以进行更新</translation>
+<translation id="3512968675351418494">若要使用您的语言查看网页，请获取最新版本的 Brave</translation>
+<translation id="6427112570124116297">翻译网页</translation>
+<translation id="1379423114029199501">更新即可在最新版本的 Brave 中使用您的语言</translation>
+<translation id="5684874026226664614">糟糕，此网页内容无法翻译。</translation>
+<translation id="6831043979455480757">翻译</translation>
+<translation id="1285320974508926690">一律不翻译此网站</translation>
+<translation id="773466115871691567">一律翻译<ph name="SOURCE_LANGUAGE"/>网页</translation>
+<translation id="1068672505746868501">一律不翻译<ph name="SOURCE_LANGUAGE"/>网页</translation>
+<translation id="124116460088058876">更多语言</translation>
+<translation id="290376772003165898">网页的源语言不是<ph name="LANGUAGE"/>？</translation>
+<translation id="4432792777822557199">从现在开始，源语言为<ph name="SOURCE_LANGUAGE"/>的网页一律会被翻译成<ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">系统不会自动翻译源语言为<ph name="LANGUAGE"/>的网页</translation>
+<translation id="5447765697759493033">系统不会翻译此网站</translation>
+<translation id="4880127995492972015">翻译…</translation>
+<translation id="641643625718530986">打印…</translation>
+<translation id="8909135823018751308">分享…</translation>
+<translation id="4996978546172906250">分享方式</translation>
+<translation id="6333140779060797560">通过<ph name="APPLICATION"/>分享</translation>
+<translation id="6277522088822131679">打印该页面时出现问题，请重试。</translation>
+<translation id="3254409185687681395">为此页添加书签</translation>
+<translation id="497421865427891073">前进</translation>
+<translation id="813082847718468539">查看网站信息</translation>
+<translation id="2532336938189706096">网页视图</translation>
+<translation id="6005538289190791541">建议的密码</translation>
+<translation id="4634124774493850572">使用密码</translation>
+<translation id="8285489906452138776">Brave 需要获得相应权限，才能允许此网站使用您的摄像头。</translation>
+<translation id="320189792589364011">Brave 需要获得相应权限，才能允许此网站使用您的麦克风。</translation>
+<translation id="7988136689212463100">Brave 需要获得相应权限，才能允许此网站使用您的摄像头和麦克风。</translation>
+<translation id="4931190655840828017">Brave 需要获得位置权限，才能将您的位置信息共享给此网站。</translation>
+<translation id="3088191967551450609">Brave 需要具备存储空间使用权限，才能下载文件。</translation>
+<translation id="8942627711005830162">在其他窗口中打开</translation>
+<translation id="4195643157523330669">在新标签页中打开</translation>
+<translation id="1100066534610197918">在群组内的新标签页中打开</translation>
+<translation id="4860895144060829044">拨打</translation>
+<translation id="6896758677409633944">复制</translation>
+<translation id="8393700583063109961">发送消息</translation>
+<translation id="3557336313807607643">添加到通讯录</translation>
+<translation id="4269820728363426813">复制链接地址</translation>
+<translation id="1206892813135768548">复制链接文字</translation>
+<translation id="1204037785786432551">下载链接</translation>
+<translation id="6864459304226931083">下载图片</translation>
+<translation id="8209050860603202033">打开图片</translation>
+<translation id="8073388330009372546">在新标签页中打开图片</translation>
+<translation id="6649642165559792194">预览图片<ph name="BEGIN_NEW"/>新<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">加载图片</translation>
+<translation id="3845332215609790146">使用 Brave Software 智能镜头进行搜索<ph name="BEGIN_NEW"/>新功能<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">在<ph name="SEARCH_ENGINE"/>中搜索此图片</translation>
+<translation id="3384347053049321195">分享图片</translation>
+<translation id="5833984609253377421">分享链接</translation>
+<translation id="6475951671322991020">下载视频</translation>
+<translation id="2317945146070194624">在新的 Brave 标签页中打开</translation>
+<translation id="7975379999046275268">预览网页<ph name="BEGIN_NEW"/>新<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">正在刷新页面</translation>
+<translation id="36525718899759834">从 Brave Software Play 商店下载应用：<ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">深色调</translation>
+<translation id="1807246157184219062">浅色调</translation>
+<translation id="4056223980640387499">棕色调</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">等宽</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">选择要传输的标签页</translation>
+<translation id="8719023831149562936">无法传输当前的标签页</translation>
+<translation id="2139186145475833000">添加到主屏幕</translation>
+<translation id="4616150815774728855">打开<ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">无法打开此应用</translation>
+<translation id="5129038482087801250">安装网络应用</translation>
+<translation id="3789841737615482174">安装</translation>
+<translation id="4665282149850138822"><ph name="NAME"/>已添加到您的主屏幕</translation>
+<translation id="7333031090786104871">仍在添加先前的网站</translation>
+<translation id="1036727731225946849">正在添加<ph name="WEBAPK_NAME"/>…</translation>
+<translation id="3778956594442850293">已添加到主屏幕</translation>
+<translation id="2146738493024040262">打开免安装应用</translation>
+<translation id="7016516562562142042">允许当前搜索引擎使用</translation>
+<translation id="6177111841848151710">不允许当前搜索引擎使用</translation>
+<translation id="145097072038377568">已在 Android 设置中停用</translation>
+<translation id="8007176423574883786">已对此设备停用</translation>
+<translation id="164269334534774161">您目前浏览的是此网页的离线副本（创建时间：<ph name="CREATION_TIME"/>）</translation>
+<translation id="4594952190837476234">此离线网页是在 <ph name="CREATION_TIME"/>创建的，可能与在线版本有所不同。</translation>
+<translation id="8840953339110955557">此网页可能与在线版本有所不同。</translation>
+<translation id="6405300764336705484">此内容来自 <ph name="DOMAIN_NAME"/>（由 Brave Software 提供）。</translation>
+<translation id="1006017844123154345">在线打开</translation>
+<translation id="3326636747541519688">由 Brave Software 提供的精简版网页</translation>
+<translation id="7149158118503947153">从 <ph name="DOMAIN_NAME"/> <ph name="BEGIN_LINK"/>加载原始网页<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">如果您频繁遇到此问题，请尝试按这些<ph name="BEGIN_LINK"/>建议<ph name="END_LINK"/>操作。</translation>
+<translation id="8748850008226585750">内容已隐藏</translation>
+<translation id="3810973564298564668">管理</translation>
+<translation id="5199929503336119739">工作资料</translation>
+<translation id="528192093759286357">从顶部向下拖动并触摸“返回”按钮，即可退出全屏模式。</translation>
+<translation id="2836148919159985482">触摸“返回”按钮即可退出全屏模式。</translation>
+<translation id="3967822245660637423">下载完毕</translation>
+<translation id="2434158240863470628">下载完成 <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">下载失败</translation>
+<translation id="1384959399684842514">已暂停下载</translation>
+<translation id="1671236975893690980">正在等待下载…</translation>
+<translation id="5561549206367097665">正在等待连接到网络…</translation>
+<translation id="5864419784173784555">正在等待完成另一项下载…</translation>
+<translation id="6461962085415701688">无法打开文件</translation>
+<translation id="1178581264944972037">暂停</translation>
+<translation id="8200772114523450471">继续</translation>
+<translation id="1409879593029778104">系统已阻止下载 <ph name="FILE_NAME"/>，因为文件已存在。</translation>
+<translation id="3387650086002190359">未能成功下载 <ph name="FILE_NAME"/>，因为文件系统出现了错误。</translation>
+<translation id="6482749332252372425">未能成功下载 <ph name="FILE_NAME"/>，因为存储空间不足。</translation>
+<translation id="7619072057915878432">未能成功下载 <ph name="FILE_NAME"/>，因为出现了网络故障。</translation>
+<translation id="1477626028522505441">未能成功下载 <ph name="FILE_NAME"/>，因为服务器出现了问题。</translation>
+<translation id="3692944402865947621">未能成功下载“<ph name="FILE_NAME"/>”，因为无法访问它的存储位置。</translation>
+<translation id="604996488070107836">出现未知错误，未能下载 <ph name="FILE_NAME"/>。</translation>
+<translation id="6738867403308150051">正在下载…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475">已下载 <ph name="BYTES_DOWNLOADED_WITH_UNITS"/>，总大小不明</translation>
+<translation id="1923695749281512248">已下载 <ph name="BYTES_DOWNLOADED_WITH_UNITS"/>，共 <ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">已下载 <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">已下载 <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">已下载 <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">还剩 1 个文件</translation>
+<translation id="8186512483418048923">还剩 <ph name="FILES"/> 个文件</translation>
+<translation id="757855969265046257">{FILES,plural, =1{已下载 <ph name="FILES_DOWNLOADED_ONE"/> 个文件}other{已下载 <ph name="FILES_DOWNLOADED_MANY"/> 个文件}}</translation>
+<translation id="8037750541064988519">还剩 <ph name="DAYS"/> 天</translation>
+<translation id="8190358571722158785">还剩 1 天</translation>
+<translation id="60923314841986378">还剩 <ph name="HOURS"/> 小时</translation>
+<translation id="510275257476243843">还剩 1 小时</translation>
+<translation id="970715775301869095">还剩 <ph name="MINUTES"/> 分钟</translation>
+<translation id="3236059992281584593">还剩 1 分钟</translation>
+<translation id="2777555524387840389">还剩 <ph name="SECONDS"/> 秒</translation>
+<translation id="2781151931089541271">还剩 1 秒</translation>
+<translation id="3303414029551471755">要开始下载该内容吗？</translation>
+<translation id="8617240290563765734">要打开下载的内容中指定的建议网址吗？</translation>
+<translation id="1373696734384179344">内存不足，无法下载所选内容。</translation>
+<translation id="5271967389191913893">设备无法打开要下载的内容。</translation>
+<translation id="883806473910249246">下载此内容时出错。</translation>
+<translation id="5626134646977739690">名字：</translation>
+<translation id="7963646190083259054">供应商：</translation>
+<translation id="3414952576877147120">大小：</translation>
+<translation id="7375125077091615385">类型：</translation>
+<translation id="5765780083710877561">说明：</translation>
+<translation id="4881695831933465202">打开</translation>
+<translation id="3542235761944717775">可用空间：<ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB 可用</translation>
+<translation id="5424588387303617268">可用存储空间：<ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">已使用 <ph name="SPACE_USED"/>，共 <ph name="SPACE_AVAILABLE"/></translation>
+<translation id="3587482841069643663">全部</translation>
+<translation id="4988526792673242964">网页</translation>
+<translation id="3810838688059735925">视频</translation>
+<translation id="3616113530831147358">音频</translation>
+<translation id="9219103736887031265">图片</translation>
+<translation id="8250920743982581267">文档</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# 个文件}other{# 个文件}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# 张图片}other{# 张图片}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# 个视频}other{# 个视频}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# 个音频文件}other{# 个音频文件}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# 个网页}other{# 个网页}}</translation>
+<translation id="5456381639095306749">下载网页</translation>
+<translation id="2394602618534698961">您下载的文件会显示在此处</translation>
+<translation id="7810647596859435254">打开方式…</translation>
+<translation id="5655963694829536461">搜索您的下载内容</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">我的文件</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">报道会显示在此处，即使在离线状态下也可以阅读</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# 小时}other{# 小时}}</translation>
+<translation id="5853623416121554550">已暂停</translation>
+<translation id="8965591936373831584">待下载</translation>
+<translation id="2779651927720337254">失败</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">刚刚</translation>
+<translation id="4000212216660919741">离线版首页</translation>
+<translation id="9133397713400217035">离线浏览</translation>
+<translation id="968900484120156207">您访问的网页会显示在此处</translation>
+<translation id="7882131421121961860">未找到任何记录</translation>
+<translation id="3549657413697417275">搜索您的历史记录</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">MM</translation>
+<translation id="605721222689873409">YY</translation>
+<translation id="724102042129299115">Brave 首次运行体验</translation>
+<translation id="2700285883409956633">使用此应用即表示您同意遵守 Brave 的<ph name="BEGIN_LINK1"/>服务条款<ph name="END_LINK1"/>和<ph name="BEGIN_LINK2"/>隐私权声明<ph name="END_LINK2"/>。</translation>
+<translation id="1640714894372474981">使用此应用即表示您同意 Brave 的<ph name="BEGIN_LINK1"/>服务条款<ph name="END_LINK1"/>和<ph name="BEGIN_LINK2"/>隐私权声明<ph name="END_LINK2"/>，以及<ph name="BEGIN_LINK3"/>针对通过 Family Link 管理的 Brave Software 帐号的隐私权声明<ph name="END_LINK3"/>。</translation>
+<translation id="4218324479468769727"><ph name="APP_NAME"/>将在 Brave 中打开。继续操作即表示您同意 Brave 的<ph name="BEGIN_LINK1"/>服务条款<ph name="END_LINK1"/>和<ph name="BEGIN_LINK2"/>隐私权声明<ph name="END_LINK2"/>。</translation>
+<translation id="5071615083211946659"><ph name="APP_NAME"/>将在 Brave 中打开。继续操作即表示您同意 Brave 的<ph name="BEGIN_LINK1"/>服务条款<ph name="END_LINK1"/>和<ph name="BEGIN_LINK2"/>隐私权声明<ph name="END_LINK2"/>，以及<ph name="BEGIN_LINK3"/>针对通过 Family Link 管理的 Brave Software 帐号的隐私权声明<ph name="END_LINK3"/>。</translation>
+<translation id="673197144963363525">将使用情况统计信息和崩溃报告发送给 Brave Software，帮助我们完善 Brave。</translation>
+<translation id="3518985090088779359">接受并继续</translation>
+<translation id="7207456302801184289">欢迎使用 Brave</translation>
+<translation id="704822250101715322">正在等待 Brave Software Play 服务完成更新</translation>
+<translation id="1231733316453485619">开启同步功能？</translation>
+<translation id="5132942445612118989">将您的密码、历史记录等信息同步到所有设备上</translation>
+<translation id="5736731321935944068">Brave Software 可能会利用您的历史记录为您提供个性化的 Brave Software 搜索、广告和其他 Brave Software 服务</translation>
+<translation id="4013614219085422040">Brave Software 可能会利用您的历史记录为您提供个性化的 Brave Software 搜索和其他 Brave Software 服务</translation>
+<translation id="5581519193887989363">您始终可在<ph name="BEGIN_LINK1"/>设置<ph name="END_LINK1"/>中选择要同步的内容。</translation>
+<translation id="741204030948306876">立即启用</translation>
+<translation id="2410754283952462441">选择帐号</translation>
+<translation id="2227444325776770048">以“<ph name="USER_FULL_NAME"/>”的身份继续</translation>
+<translation id="6210748933810148297">不是 <ph name="EMAIL"/>？</translation>
+<translation id="8109613176066109935">要将您的书签同步到您的所有设备上，请开启同步功能</translation>
+<translation id="2818669890320396765">要将您的书签同步到您的所有设备上，请登录您的帐号并开启同步功能</translation>
+<translation id="6003646045106347985">要获取 Brave Software 推荐的个性化内容，请开启同步功能</translation>
+<translation id="8494430740943879273">要获取 Brave Software 推荐的个性化内容，请登录您的帐号并开启同步功能</translation>
+<translation id="5862731021271217234">要访问您在其他设备上打开的标签页，请开启同步功能</translation>
+<translation id="3568688522516854065">要访问您在其他设备上的标签页，请登录您的帐号并开启同步功能</translation>
+<translation id="1208340532756947324">要在您的所有设备上保持同步并进行个性化设置，请开启同步功能</translation>
+<translation id="4472118726404937099">要在您的所有设备上保持同步并进行个性化设置，请登录您的帐号并开启同步功能</translation>
+<translation id="2426805022920575512">选择其他帐号</translation>
+<translation id="6790428901817661496">播放</translation>
+<translation id="1272079795634619415">停止</translation>
+<translation id="2874939134665556319">上一曲</translation>
+<translation id="4046123991198612571">下一曲</translation>
+<translation id="3859306556332390985">前进</translation>
+<translation id="8441146129660941386">后退</translation>
+<translation id="6706288973712894588">您目前处于离线状态。\n<ph name="BEGIN_LINK"/>浏览您的离线版 Feed。<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">最近打开的标签页</translation>
+<translation id="8497726226069778601">目前还未列出任何网页…</translation>
+<translation id="5423934151118863508">您最常访问的网页将列在此处</translation>
+<translation id="6127379762771434464">该项已移除</translation>
+<translation id="4605958867780575332">以下项已移除：<ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software 涂鸦：<ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">来自其他设备的同步</translation>
+<translation id="4738836084190194332">上次同步时间：<ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# 分钟前}other{# 分钟前}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# 小时前}other{# 小时前}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# 天前}other{# 天前}}</translation>
+<translation id="2762000892062317888">刚刚</translation>
+<translation id="1407135791313364759">全部打开</translation>
+<translation id="1209206284964581585">暂时隐藏</translation>
+<translation id="129553762522093515">最近关闭的标签页</translation>
+<translation id="8413126021676339697">显示全部历史记录</translation>
+<translation id="7876243839304621966">全部删除</translation>
+<translation id="8487700953926739672">可离线使用</translation>
+<translation id="5224771365102442243">包含视频</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>详细了解<ph name="END_LINK"/>推荐内容</translation>
+<translation id="7542481630195938534">无法获取建议</translation>
+<translation id="5013696553129441713">没有新建议</translation>
+<translation id="1736419249208073774">探索</translation>
+<translation id="7444811645081526538">更多类别</translation>
+<translation id="6709133671862442373">资讯</translation>
+<translation id="1264974993859112054">体育</translation>
+<translation id="9139318394846604261">购物</translation>
+<translation id="3912508018559818924">正在从网络中查找最具价值的数据…</translation>
+<translation id="526421993248218238">无法加载此页面</translation>
+<translation id="614940544461990577">请试试以下办法：</translation>
+<translation id="3288003805934695103">重新加载网页</translation>
+<translation id="2353636109065292463">检查互联网连接状况</translation>
+<translation id="2858138569776157458">热门网站</translation>
+<translation id="8364299278605033898">查看热门网站</translation>
+<translation id="1171770572613082465">点按“热门网站”按钮可查看热门网站</translation>
+<translation id="5233638681132016545">打开新的标签页</translation>
+<translation id="4521874409998847950">来自 <ph name="PUBLISHER_ORIGIN"/> - <ph name="BEGIN_DEEMPHASIZED"/>由 Brave Software 提供<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">新版本已推出</translation>
+<translation id="4058091506841967397">Brave 无法更新</translation>
+<translation id="6316139424528454185">Android 版本不受支持</translation>
+<translation id="6989267951144302301">无法下载</translation>
+<translation id="624789221780392884">有可用的更新</translation>
+<translation id="1549000191223877751">移至其他窗口</translation>
+<translation id="7481312909269577407">前进</translation>
+<translation id="4084682180776658562">添加书签</translation>
+<translation id="6437478888915024427">网页信息</translation>
+<translation id="7180611975245234373">刷新</translation>
+<translation id="4913169188695071480">停止刷新</translation>
+<translation id="1829244130665387512">在网页中查找</translation>
+<translation id="6593061639179217415">桌面版网站</translation>
+<translation id="9063523880881406963">关闭“请求切换到桌面版网站”</translation>
+<translation id="2038563949887743358">开启“请求切换到桌面版网站”</translation>
+<translation id="2433507940547922241">外观</translation>
+<translation id="983192555821071799">关闭所有标签页</translation>
+<translation id="1310482092992808703">组合标签页</translation>
+<translation id="7725024127233776428">您添加书签的网页会显示在此处</translation>
+<translation id="4404568932422911380">没有书签</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> 个书签}other{<ph name="BOOKMARKS_COUNT_MANY"/> 个书签}}</translation>
+<translation id="3739899004075612870">已在 <ph name="PRODUCT_NAME"/> 中添加书签</translation>
+<translation id="3207960819495026254">已加书签</translation>
+<translation id="4452548195519783679">已将书签添加到“<ph name="FOLDER_NAME"/>”</translation>
+<translation id="8063895661287329888">无法添加书签。</translation>
+<translation id="2842985007712546952">父文件夹</translation>
+<translation id="9065203028668620118">编辑</translation>
+<translation id="4405224443901389797">移动到…</translation>
+<translation id="5170568018924773124">在文件夹中显示</translation>
+<translation id="8035133914807600019">新建文件夹…</translation>
+<translation id="4532845899244822526">选择文件夹</translation>
+<translation id="6627583120233659107">修改文件夹</translation>
+<translation id="1197267115302279827">移动书签</translation>
+<translation id="6963766334940102469">删除书签</translation>
+<translation id="4351244548802238354">关闭对话框</translation>
+<translation id="451872707440238414">搜索书签</translation>
+<translation id="8901170036886848654">未找到任何书签</translation>
+<translation id="6404511346730675251">修改书签</translation>
+<translation id="3894427358181296146">添加文件夹</translation>
+<translation id="5327248766486351172">名称</translation>
+<translation id="7400418766976504921">网址</translation>
+<translation id="3527085408025491307">文件夹</translation>
+<translation id="5161254044473106830">必须提供标题</translation>
+<translation id="2996809686854298943">必须提供网址</translation>
+<translation id="2536728043171574184">正在查看此网页的离线副本</translation>
+<translation id="4698034686595694889">在 <ph name="APP_NAME"/> 中离线查看</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> 及更多网站</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{待准备就绪后，Brave 即会加载您的网页}other{待准备就绪后，Brave 即会加载您的网页}}</translation>
+<translation id="6811034713472274749">页面已可供查看</translation>
+<translation id="4561979708150884304">无网络连接</translation>
+<translation id="8274165955039650276">查看下载内容</translation>
+<translation id="2082238445998314030">第 <ph name="RESULT_NUMBER"/> 条结果，共 <ph name="TOTAL_RESULTS"/> 条</translation>
+<translation id="4943872375798546930">找不到结果</translation>
+<translation id="981121421437150478">离线</translation>
+<translation id="3298243779924642547">精简版</translation>
+<translation id="393697183122708255">无法启用语音搜索功能</translation>
+<translation id="7191430249889272776">标签页已在后台打开。</translation>
+<translation id="8445059357334030806">在 Brave 中打开</translation>
+<translation id="4720023427747327413">在<ph name="PRODUCT_NAME"/>中打开</translation>
+<translation id="7022756207310403729">在浏览器中打开</translation>
+<translation id="1113597929977215864">显示简化版视图</translation>
+<translation id="1513352483775369820">书签和网络历史记录</translation>
+<translation id="4939482511480190003">欢迎帮助我们改进 Brave。<ph name="BEGIN_LINK"/>参与调查<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">返回</translation>
+<translation id="5596627076506792578">更多选项</translation>
+<translation id="3522247891732774234">有更新。更多选项</translation>
+<translation id="6773423637732432200">Brave 无法更新。更多选项</translation>
+<translation id="3328801116991980348">网站信息</translation>
+<translation id="5391532827096253100">您与此网站之间建立的连接不安全。网站信息</translation>
+<translation id="6206551242102657620">连接是安全的。网站信息</translation>
+<translation id="6963642900430330478">此网页存在危险。网站信息</translation>
+<translation id="9070377983101773829">开始语音搜索</translation>
+<translation id="8676374126336081632">清除输入的内容</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{<ph name="OPEN_TABS_ONE"/> 个打开的标签页，点按即可切换标签页}other{<ph name="OPEN_TABS_MANY"/> 个打开的标签页，点按即可切换标签页}}</translation>
+<translation id="2369533728426058518">打开的标签页</translation>
+<translation id="7071521146534760487">管理帐号</translation>
+<translation id="932327136139879170">首页</translation>
+<translation id="2707726405694321444">刷新网页</translation>
+<translation id="2891154217021530873">停止加载网页</translation>
+<translation id="6710213216561001401">上一个</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">所选的标签页</translation>
+<translation id="2268044343513325586">优化</translation>
+<translation id="7846076177841592234">取消选择</translation>
+<translation id="7087918508125750058">已选择 <ph name="ITEM_COUNT"/> 项。选项位于屏幕顶部附近</translation>
+<translation id="7250468141469952378">已选择 <ph name="ITEM_COUNT"/> 项</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{分享 1 个所选项}other{分享 # 个所选项}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{移除 1 个所选项}other{移除 # 个所选项}}</translation>
+<translation id="1283039547216852943">点按即可展开</translation>
+<translation id="5962718611393537961">点按即可收起</translation>
+<translation id="8076492880354921740">标签页</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{已选择 1 项}other{已选择 # 项}}</translation>
+<translation id="6818926723028410516">选择内容</translation>
+<translation id="4797039098279997504">触摸即可返回到 <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">点按即可转到网站</translation>
+<translation id="429312253194641664">某个网站正在播放媒体内容</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> 正在共享您的屏幕</translation>
+<translation id="8833831881926404480">网站正在共享您的屏幕</translation>
+<translation id="9086455579313502267">无法访问网络</translation>
+<translation id="938850635132480979">错误：<ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">在 <ph name="APP_NAME"/>中打开</translation>
+<translation id="548278423535722844">在地图应用中打开</translation>
+<translation id="7698359219371678927">在 <ph name="APP_NAME"/> 中创建电子邮件</translation>
+<translation id="7875915731392087153">创建电子邮件</translation>
+<translation id="5665379678064389456">在<ph name="APP_NAME"/>中创建活动</translation>
+<translation id="2900528713135656174">创建活动</translation>
+<translation id="2111511281910874386">转至相关网页</translation>
+<translation id="3988466920954086464">您可以在此面板查看即时搜索结果</translation>
+<translation id="2744248271121720757">点按某个字词可立即开始搜索或查看相关操作</translation>
+<translation id="9155898266292537608">您也可以通过快速点按某个字词进行搜索</translation>
+<translation id="3232754137068452469">网络应用</translation>
+<translation id="1430915738399379752">打印</translation>
+<translation id="3775705724665058594">发送到您的设备</translation>
+<translation id="6364438453358674297">要从历史记录中移除建议吗？</translation>
+<translation id="213279576345780926">已关闭“<ph name="TAB_TITLE"/>”</translation>
+<translation id="6850830437481525139">已关闭 <ph name="TAB_COUNT"/> 个标签页</translation>
+<translation id="3211426585530211793">已删除“<ph name="ITEM_TITLE"/>”</translation>
+<translation id="4663756553811254707">已删除 <ph name="NUMBER_OF_BOOKMARKS"/> 个书签</translation>
+<translation id="3819178904835489326">已删除 <ph name="NUMBER_OF_DOWNLOADS"/> 项下载内容</translation>
+<translation id="1248710015876067820">Brave 实例数量已超出上限。</translation>
+<translation id="4259722352634471385">已屏蔽 <ph name="URL"/></translation>
+<translation id="8959122750345127698">无法访问 <ph name="URL"/></translation>
+<translation id="5210365745912300556">关闭标签页</translation>
+<translation id="7772375229873196092">关闭<ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">导航历史记录</translation>
+<translation id="9169507124922466868">导航历史记录在下半屏中显示</translation>
+<translation id="1327257854815634930">导航历史记录已打开</translation>
+<translation id="8788265440806329501">导航历史记录已关闭</translation>
+<translation id="7482656565088326534">预览标签页</translation>
+<translation id="8427875596167638501">预览标签页已在下半屏中打开</translation>
+<translation id="9102803872260866941">预览标签页已打开</translation>
+<translation id="2942036813789421260">预览标签页已关闭</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> 存储数据</translation>
+<translation id="3822502789641063741">要清除网站存储数据吗？</translation>
+<translation id="9205995714227143200">Brave 认为不重要的网站（例如未保存任何设置的网站或您不常访问的网站）存储的数据</translation>
+<translation id="3997476611815694295">不重要网站的存储数据</translation>
+<translation id="8493948351860045254">释放空间</translation>
+<translation id="2324920234469020158">这会清除 Brave 认为不重要的网站的 Cookie、缓存和其他数据。</translation>
+<translation id="5447201525962359567">所有网站存储数据，包括 Cookie 及其他本地存储的数据</translation>
+<translation id="1376578503827013741">正在计算…</translation>
+<translation id="583281660410589416">未知</translation>
+<translation id="2323763861024343754">网站存储数据</translation>
+<translation id="3587672679800759167">Brave 所使用的数据总量，包括帐号、书签和已保存的设置</translation>
+<translation id="6545017243486555795">清除所有数据</translation>
+<translation id="4095146165863963773">要删除应用数据吗？</translation>
+<translation id="53119194224775367">Brave 的所有应用数据都将被永久删除，其中包括所有文件、设置、帐号、数据库等。</translation>
+<translation id="5307446750509046227">清空网站存储数据</translation>
+<translation id="300526633675317032">这会清除全部的网站存储数据 (<ph name="SIZE_IN_KB"/>)。</translation>
+<translation id="8068648041423924542">无法选择证书。</translation>
+<translation id="2315043854645842844">操作系统不支持选择客户端证书。</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> 希望连接到以下所选设备：</translation>
+<translation id="5308380583665731573">连接</translation>
+<translation id="868929229000858085">搜索联系人</translation>
+<translation id="1919950603503897840">选择联系人</translation>
+<translation id="7986741934819883144">选择联系人</translation>
+<translation id="3333961966071413176">所有联系人</translation>
+<translation id="4994033804516042629">找不到任何联系人</translation>
+<translation id="5403592356182871684">名称</translation>
+<translation id="2717722538473713889">电子邮件地址</translation>
+<translation id="381841723434055211">电话号码</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{（以及另外 1 个）}other{（以及另外 # 个）}}</translation>
+<translation id="5197729504361054390">系统会将您所选联系人的详细信息分享给 <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>。</translation>
+<translation id="1779089405699405702">图片解码器</translation>
+<translation id="8067883171444229417">播放视频</translation>
+<translation id="6560414384669816528">改用搜狗搜索</translation>
+<translation id="5406914950576900927">在中国，Brave 可以使用<ph name="BEGIN_BOLD"/>搜狗<ph name="END_BOLD"/>作为搜索引擎。如果需要，您可以在<ph name="BEGIN_LINK"/>设置<ph name="END_LINK"/>中进行更改。</translation>
+<translation id="6456271171669383967">继续使用 Brave Software</translation>
+<translation id="4384468725000734951">目前使用的搜索引擎是搜狗</translation>
+<translation id="6103327872225198548">目前使用的搜索引擎是 Brave Software</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">此应用正在 Brave 中运行</translation>
+<translation id="6143689084714664628">正在 Brave 中运行</translation>
+<translation id="7675869148432102528">Brave 中也有<ph name="APP_NAME"/>的数据</translation>
+<translation id="2734140769649165081">要清除数据，请前往 Brave 的“设置”页面</translation>
+<translation id="8232956427053453090">保留数据</translation>
+<translation id="4298388696830689168">已关联的网站</translation>
+<translation id="5763514718066511291">点按即可复制该应用的网址</translation>
+<translation id="6496823230996795692">如果您是首次使用<ph name="APP_NAME"/>，则需连接到互联网。</translation>
+<translation id="751961395872307827">无法连接到该网站</translation>
+<translation id="4878404682131129617">未能成功通过代理服务器建立隧道</translation>
+<translation id="4749960740855309258">打开新标签页</translation>
+<translation id="8788968922598763114">重新打开上次关闭的标签页</translation>
+<translation id="7929962904089429003">打开菜单</translation>
+<translation id="6039379616847168523">跳转到下一个标签页</translation>
+<translation id="5210286577605176222">跳转到上一个标签页</translation>
+<translation id="124678866338384709">关闭当前标签页</translation>
+<translation id="3714981814255182093">打开查找栏</translation>
+<translation id="5441522332038954058">跳转到地址栏</translation>
+<translation id="3398320232533725830">打开书签管理器</translation>
+<translation id="6583199322650523874">为当前网页添加书签</translation>
+<translation id="8489271220582375723">打开历史记录页</translation>
+<translation id="4837753911714442426">打开选项以打印网页</translation>
+<translation id="5726692708398506830">放大网页上的所有内容</translation>
+<translation id="3259831549858767975">缩小网页上的所有内容</translation>
+<translation id="8015452622527143194">将网页上的所有内容恢复到默认大小</translation>
+<translation id="3443221991560634068">重新加载当前网页</translation>
+<translation id="123724288017357924">重新加载当前网页（忽略缓存的内容）</translation>
+<translation id="305870044889644984">在新标签页中打开 Brave 帮助中心</translation>
+<translation id="3166827708714933426">标签页和窗口快捷键</translation>
+<translation id="3169981355900570544">Brave Software Brave 功能快捷键</translation>
+<translation id="4558311620361989323">网页快捷键</translation>
+<translation id="1908301351964700579">Brave 仍在准备 VR。请稍等片刻再重启 Brave。</translation>
+<translation id="8970887620466824814">出了点问题。</translation>
+<translation id="1875543012935658554">重新打开 Brave。</translation>
+<translation id="79859296434321399">要查看增强现实内容，请安装 ARCore</translation>
+<translation id="8558485628462305855">要查看增强现实内容，请更新 ARCore</translation>
+<translation id="3513704683820682405">增强现实</translation>
+<translation id="5475862044948910901">启动增强现实会话？</translation>
 <translation id="7365126855094612066">在此会话期间，该网站将能够：
 • 为您的环境创建一个 3D 地图
 • 跟踪相机运动
 
 该网站不会获得相机的使用权限。只有您可以看到该相机拍摄的图像。</translation>
-<translation id="7375125077091615385">类型：</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />。</translation>
-<translation id="7400418766976504921">网址</translation>
-<translation id="7403691278183511381">Chrome 首次运行体验</translation>
-<translation id="741204030948306876">立即启用</translation>
-<translation id="7413229368719586778">开始日期：<ph name="DATE" /></translation>
-<translation id="7423098979219808738">先询问</translation>
-<translation id="7423538860840206698">已阻止读取剪贴板中的内容</translation>
-<translation id="7431991332293347422">控制 Google 如何利用您的浏览记录为您提供个性化的 Google 搜索和其他 Google 服务</translation>
-<translation id="7437998757836447326">退出 Chrome</translation>
-<translation id="7438641746574390233">当精简模式处于开启状态时，Chrome 会使用 Google 服务器提高网页加载速度。精简模式会重写加载速度非常慢的网页，以便仅加载必要的内容。精简模式不适用于无痕式标签页。</translation>
-<translation id="7444811645081526538">更多类别</translation>
-<translation id="7445411102860286510">允许网站自动播放静音的视频（推荐）</translation>
-<translation id="7453467225369441013">您会从大多数网站退出，但不会退出自己的 Google 帐号。</translation>
-<translation id="7454641608352164238">空间不足</translation>
-<translation id="7475192538862203634">如果您频繁遇到此问题，请尝试按这些<ph name="BEGIN_LINK" />建议<ph name="END_LINK" />操作。</translation>
-<translation id="7475688122056506577">找不到 SD 卡。您的某些文件可能会丢失。</translation>
-<translation id="7479104141328977413">标签页管理</translation>
-<translation id="7481312909269577407">前进</translation>
-<translation id="7482656565088326534">预览标签页</translation>
-<translation id="7493994139787901920"><ph name="VERSION" />（上次更新时间：<ph name="TIME_SINCE_UPDATE" />）</translation>
-<translation id="7494974237137038751">已节省的流量</translation>
-<translation id="7498271377022651285">请稍候…</translation>
-<translation id="7514365320538308">下载</translation>
-<translation id="751961395872307827">无法连接到该网站</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">无法获取建议</translation>
-<translation id="7559975015014302720">精简模式已关闭</translation>
-<translation id="7562080006725997899">正在清除浏览数据</translation>
-<translation id="756809126120519699">已清除 Chrome 数据</translation>
-<translation id="757524316907819857">禁止网站播放受保护内容</translation>
-<translation id="757855969265046257">{FILES,plural, =1{已下载 <ph name="FILES_DOWNLOADED_ONE" /> 个文件}other{已下载 <ph name="FILES_DOWNLOADED_MANY" /> 个文件}}</translation>
-<translation id="7588219262685291874">在设备开启省电模式时启用深色主题背景</translation>
-<translation id="7589445247086920869">不允许当前搜索引擎使用</translation>
-<translation id="7593557518625677601">打开 Android 设置，重新启用 Android 系统同步功能以开始 Chrome 同步</translation>
-<translation id="7596558890252710462">操作系统</translation>
-<translation id="7605594153474022051">同步功能无法正常运行</translation>
-<translation id="7606077192958116810">精简模式已开启。在“设置”中管理此模式。</translation>
-<translation id="7612619742409846846">已使用以下帐号登录 Google：</translation>
-<translation id="7619072057915878432">未能成功下载 <ph name="FILE_NAME" />，因为出现了网络故障。</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />获取帮助<ph name="END_LINK1" />或<ph name="BEGIN_LINK2" />重新扫描<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">欢迎使用 Chrome</translation>
-<translation id="7638584964844754484">密码不正确</translation>
-<translation id="7641339528570811325">清除浏览数据…</translation>
-<translation id="7648422057306047504">使用 Google 凭据加密密码</translation>
-<translation id="7649070708921625228">帮助</translation>
-<translation id="7658239707568436148">取消</translation>
-<translation id="7665369617277396874">添加帐号</translation>
-<translation id="766587987807204883">报道会显示在此处，即使在离线状态下也可以阅读</translation>
-<translation id="7682724950699840886">请尝试按以下提示操作：确保您的设备上有足够的空间，然后重新尝试导出。</translation>
-<translation id="7685301384041462804">请确保您信任此网站，然后再进入 VR 环境。</translation>
-<translation id="7698359219371678927">在 <ph name="APP_NAME" /> 中创建电子邮件</translation>
-<translation id="7704317875155739195">自动填充搜索字词和网址</translation>
-<translation id="7725024127233776428">您添加书签的网页会显示在此处</translation>
-<translation id="773466115871691567">一律翻译<ph name="SOURCE_LANGUAGE" />网页</translation>
-<translation id="7746457520633464754">为了检测危险应用和网站，Chrome 会将您所访问的部分网页的网址、有限的系统信息以及部分网页内容发送给 Google</translation>
-<translation id="7757787379047923882">分享自“<ph name="DEVICE_NAME" />”的文字</translation>
-<translation id="7762668264895820836">SD 卡 <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">添加地址</translation>
-<translation id="7772032839648071052">确认密码</translation>
-<translation id="7772375229873196092">关闭<ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> 种付款方式}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026以及另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> 种付款方式}}</translation>
-<translation id="7781829728241885113">昨天</translation>
-<translation id="7791543448312431591">添加</translation>
-<translation id="780301667611848630">不用了，谢谢</translation>
-<translation id="7810647596859435254">打开方式…</translation>
-<translation id="7821588508402923572">您的数据流量节省情况将显示在这里</translation>
-<translation id="7837721118676387834">允许特定网站自动播放静音的视频。</translation>
-<translation id="7846076177841592234">取消选择</translation>
-<translation id="784934925303690534">时间范围</translation>
-<translation id="7851858861565204677">来自其他设备的同步</translation>
-<translation id="7875915731392087153">创建电子邮件</translation>
-<translation id="7876243839304621966">全部删除</translation>
-<translation id="7882131421121961860">未找到任何记录</translation>
-<translation id="7882806643839505685">允许特定网站播放声音。</translation>
-<translation id="7886917304091689118">正在 Chrome 中运行</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{正在下载 1 个文件。}other{正在下载 # 个文件。}}</translation>
-<translation id="7929962904089429003">打开菜单</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> 不是最新版本。</translation>
-<translation id="7947953824732555851">接受并登录</translation>
-<translation id="7963646190083259054">供应商：</translation>
-<translation id="7971136598759319605">1 天前曾有活动</translation>
-<translation id="7975379999046275268">预览网页<ph name="BEGIN_NEW" />新<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">预加载网页，以便实现更快速的浏览和搜索</translation>
-<translation id="79859296434321399">要查看增强现实内容，请安装 ARCore</translation>
-<translation id="7986741934819883144">选择联系人</translation>
-<translation id="7987073022710626672">Chrome 服务条款</translation>
-<translation id="7998918019931843664">重新打开关闭的标签页</translation>
-<translation id="7999064672810608036">确定要清除该网站的所有本地数据（包括 Cookie）并重置该网站的所有权限吗？</translation>
-<translation id="8004582292198964060">浏览器</translation>
-<translation id="8007176423574883786">已对此设备停用</translation>
-<translation id="8013372441983637696">同时从此设备中清除您的 Chrome 数据</translation>
-<translation id="8015452622527143194">将网页上的所有内容恢复到默认大小</translation>
-<translation id="802154636333426148">下载失败</translation>
-<translation id="8026334261755873520">清除浏览数据</translation>
-<translation id="8035133914807600019">新建文件夹…</translation>
-<translation id="8037750541064988519">还剩 <ph name="DAYS" /> 天</translation>
-<translation id="804335162455518893">找不到 SD 卡</translation>
-<translation id="805047784848435650">根据您的浏览记录</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB 可用</translation>
-<translation id="8058746566562539958">在新的 Chrome 标签页中打开</translation>
-<translation id="8063895661287329888">无法添加书签。</translation>
-<translation id="806745655614357130">单独保存我的数据</translation>
-<translation id="8067883171444229417">播放视频</translation>
-<translation id="8068648041423924542">无法选择证书。</translation>
-<translation id="8073388330009372546">在新标签页中打开图片</translation>
-<translation id="8076492880354921740">标签页</translation>
-<translation id="8084114998886531721">保存的密码</translation>
-<translation id="8087000398470557479">此内容来自 <ph name="DOMAIN_NAME" />（由 Google 提供）。</translation>
-<translation id="8103578431304235997">隐身标签页</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">要将您的书签同步到您的所有设备上，请开启同步功能</translation>
-<translation id="8110087112193408731">在“数字健康”应用中显示您的 Chrome 活动记录？</translation>
-<translation id="8116925261070264013">已静音的网站</translation>
-<translation id="813082847718468539">查看网站信息</translation>
-<translation id="8131740175452115882">确认</translation>
-<translation id="8156139159503939589">您能看懂哪些语言？</translation>
-<translation id="8168435359814927499">内容</translation>
-<translation id="8186512483418048923">还剩 <ph name="FILES" /> 个文件</translation>
-<translation id="8190358571722158785">还剩 1 天</translation>
-<translation id="8200772114523450471">继续</translation>
-<translation id="8209050860603202033">打开图片</translation>
-<translation id="8218622182176210845">管理您的帐号</translation>
-<translation id="8224471946457685718">在连接到 Wi-Fi 时下载为您推荐的文章</translation>
-<translation id="8232956427053453090">保留数据</translation>
-<translation id="8249310407154411074">移至顶部</translation>
-<translation id="8250920743982581267">文档</translation>
-<translation id="825412236959742607">此网页占用的内存过多，因此 Chrome 移除了部分内容。</translation>
-<translation id="8260126382462817229">请尝试重新登录</translation>
-<translation id="8261506727792406068">删除</translation>
-<translation id="8266862848225348053">下载内容保存位置</translation>
-<translation id="8274165955039650276">查看下载内容</translation>
-<translation id="8284326494547611709">字幕</translation>
-<translation id="8300705686683892304">由应用管理</translation>
-<translation id="8310344678080805313">标准标签页</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> 及更多网站</translation>
-<translation id="8327155640814342956">要获得最好的浏览体验，请打开 Chrome 以进行更新</translation>
-<translation id="8339163506404995330">系统不会自动翻译源语言为<ph name="LANGUAGE" />的网页</translation>
-<translation id="8349013245300336738">按已使用的数据流量排序</translation>
-<translation id="8364299278605033898">查看热门网站</translation>
-<translation id="8368027906805972958">未知或不支持的设备 (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">允许特定网站进行后台同步。</translation>
-<translation id="8378714024927312812">由贵单位管理</translation>
-<translation id="8380167699614421159">此网站会展示侵扰性或误导性广告</translation>
-<translation id="8393700583063109961">发送消息</translation>
-<translation id="8413126021676339697">显示全部历史记录</translation>
-<translation id="8427875596167638501">预览标签页已在下半屏中打开</translation>
-<translation id="8428213095426709021">设置</translation>
-<translation id="8438566539970814960">改善搜索和浏览体验</translation>
-<translation id="8441146129660941386">后退</translation>
-<translation id="8443209985646068659">Chrome 无法更新</translation>
-<translation id="8445448999790540984">无法导出密码</translation>
-<translation id="8447861592752582886">撤消设备权限</translation>
-<translation id="8461694314515752532">使用您自己的同步密码加密已同步的数据</translation>
-<translation id="8466613982764129868">请确保<ph name="TARGET_DEVICE_NAME" />已连接到互联网</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">可离线使用</translation>
-<translation id="8489271220582375723">打开历史记录页</translation>
-<translation id="8493948351860045254">释放空间</translation>
-<translation id="8497726226069778601">目前还未列出任何网页…</translation>
-<translation id="8503559462189395349">Chrome 密码</translation>
-<translation id="8503813439785031346">用户名</translation>
-<translation id="8514477925623180633">导出存储在 Chrome 中的密码</translation>
-<translation id="8514577642972634246">进入隐身模式</translation>
-<translation id="851751545965956758">禁止网站连接到设备</translation>
-<translation id="8523928698583292556">删除存储的密码</translation>
-<translation id="854522910157234410">打开此网页</translation>
-<translation id="8558485628462305855">要查看增强现实内容，请更新 ARCore</translation>
-<translation id="8559990750235505898">询问是否翻译其他语言版本的网页</translation>
-<translation id="8562452229998620586">已保存的密码将显示在这里。</translation>
-<translation id="8569404424186215731">自 <ph name="DATE" />以来</translation>
-<translation id="8571213806525832805">近 4 周</translation>
-<translation id="857943718398505171">允许（推荐）</translation>
-<translation id="8583805026567836021">清除帐号数据</translation>
-<translation id="860043288473659153">持卡人姓名</translation>
-<translation id="8609465669617005112">上移</translation>
-<translation id="8616006591992756292">您的 Google 帐号在 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> 上可能有其他形式的浏览记录。</translation>
-<translation id="8617240290563765734">要打开下载的内容中指定的建议网址吗？</translation>
-<translation id="8636825310635137004">要访问您在其他设备上的标签页，请开启同步功能。</translation>
-<translation id="8641930654639604085">尽量屏蔽成人网站</translation>
-<translation id="8655129584991699539">要清除数据，请前往 Chrome 的“设置”页面</translation>
-<translation id="8662811608048051533">您会从大多数网站退出。</translation>
-<translation id="8664979001105139458">文件名已存在</translation>
-<translation id="8676374126336081632">清除输入的内容</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{信号强度：# 格}other{信号强度：# 格}}</translation>
-<translation id="868929229000858085">搜索联系人</translation>
-<translation id="869891660844655955">截止日期</translation>
-<translation id="8719023831149562936">无法传输当前的标签页</translation>
-<translation id="8725066075913043281">重试</translation>
-<translation id="8728487861892616501">使用此应用即表示您同意 Chrome 的<ph name="BEGIN_LINK1" />服务条款<ph name="END_LINK1" />和<ph name="BEGIN_LINK2" />隐私权声明<ph name="END_LINK2" />，以及<ph name="BEGIN_LINK3" />针对通过 Family Link 管理的 Google 帐号的隐私权声明<ph name="END_LINK3" />。</translation>
-<translation id="8730621377337864115">完成</translation>
-<translation id="8748850008226585750">内容已隐藏</translation>
-<translation id="8751914237388039244">选择图片</translation>
-<translation id="8788265440806329501">导航历史记录已关闭</translation>
-<translation id="8788968922598763114">重新打开上次关闭的标签页</translation>
-<translation id="8801436777607969138">禁止特定网站运行 JavaScript。</translation>
-<translation id="8812260976093120287">在某些网站上，您可以使用自己的设备通过上述支持的付款应用付款。</translation>
-<translation id="8816026460808729765">禁止网站使用传感器</translation>
-<translation id="8816439037877937734"><ph name="APP_NAME" />将在 Chrome 中打开。继续操作即表示您同意 Chrome 的<ph name="BEGIN_LINK1" />服务条款<ph name="END_LINK1" />和<ph name="BEGIN_LINK2" />隐私权声明<ph name="END_LINK2" />，以及<ph name="BEGIN_LINK3" />针对通过 Family Link 管理的 Google 帐号的隐私权声明<ph name="END_LINK3" />。</translation>
-<translation id="8820817407110198400">书签</translation>
-<translation id="8833831881926404480">网站正在共享您的屏幕</translation>
-<translation id="883806473910249246">下载此内容时出错。</translation>
-<translation id="8840953339110955557">此网页可能与在线版本有所不同。</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" />，标签页</translation>
-<translation id="885701979325669005">存储数据</translation>
-<translation id="889338405075704026">转至 Chrome 设置</translation>
-<translation id="8901170036886848654">未找到任何书签</translation>
-<translation id="8909135823018751308">分享…</translation>
-<translation id="8912362522468806198">Google 帐号</translation>
-<translation id="8920114477895755567">正在等待获取家长的详细信息。</translation>
+<translation id="1188239144602654184">进入 AR 会话</translation>
+<translation id="473775607612524610">更新</translation>
+<translation id="3133489217401741157">正在为 Brave 安装<ph name="MODULE"/>…</translation>
+<translation id="1791662854739702043">安装位置</translation>
+<translation id="5131234170665854056">无法为 Brave 安装<ph name="MODULE"/></translation>
+<translation id="2567385386134582609">图片</translation>
+<translation id="6395288395575013217">链接</translation>
+<translation id="7352939065658542140">视频</translation>
+<translation id="4116038641877404294">下载网页以便离线查看</translation>
 <translation id="8922289737868596582">通过“更多选项”按钮下载网页以供离线查看</translation>
-<translation id="8937772741022875483">从“数字健康”应用中移除您的 Chrome 活动记录？</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">在其他窗口中打开</translation>
-<translation id="8951232171465285730">Chrome 已为您保存的数据量：<ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">阻止特定网站使用 Cookie。</translation>
-<translation id="8959122750345127698">无法访问 <ph name="URL" /></translation>
-<translation id="8965591936373831584">待下载</translation>
-<translation id="8970887620466824814">出了点问题。</translation>
-<translation id="8972098258593396643">是否下载到默认文件夹？</translation>
-<translation id="8986494364107987395">将使用情况统计信息和崩溃报告自动发送给 Google</translation>
-<translation id="8993760627012879038">在无痕模式下打开新标签页</translation>
-<translation id="8998729206196772491">您正要登录由 <ph name="MANAGED_DOMAIN" /> 管理的帐号，并要授权其管理员控制您的 Chrome 数据。您的数据将与此帐号永久关联。退出 Chrome 后，您的数据将从这台设备上删除，但仍会保留在您的 Google 帐号中。</translation>
-<translation id="9019902583201351841">由您父母管理</translation>
-<translation id="9028914725102941583">开启同步功能以跨设备分享内容</translation>
-<translation id="9029323097866369874">允许 <ph name="DOMAIN" /> 进入 VR 环境？</translation>
-<translation id="9040142327097499898">允许显示通知。但此设备的位置信息功能已关闭。</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# 个视频}other{# 个视频}}</translation>
-<translation id="9050666287014529139">密码</translation>
-<translation id="9063523880881406963">关闭“请求切换到桌面版网站”</translation>
-<translation id="9065203028668620118">编辑</translation>
-<translation id="9070377983101773829">开始语音搜索</translation>
-<translation id="9074336505530349563">要获取 Google 推荐的个性化内容，请登录您的帐号并开启同步功能</translation>
-<translation id="9086455579313502267">无法访问网络</translation>
-<translation id="9100505651305367705">询问是否使用简化版视图显示支持这一功能的文章</translation>
-<translation id="9100610230175265781">必须提供密码</translation>
-<translation id="9102803872260866941">预览标签页已打开</translation>
+<translation id="5958275228015807058">在“下载内容”中查找您的文件和网页</translation>
+<translation id="5620928963363755975">通过“更多选项”按钮在“下载内容”中查找您的文件和网页</translation>
+<translation id="3341058695485821946">查看您已节省多少数据流量</translation>
+<translation id="3157842584138209013">通过“更多选项”按钮查看您已节省多少数据流量</translation>
+<translation id="8218622182176210845">管理您的帐号</translation>
+<translation id="8090895580117672212">要管理您的 Brave Software 帐号，请点按“管理帐号”按钮</translation>
+<translation id="8856898588039823173">由 Brave Software 提供的精简版网页。点按即可加载原始网页。</translation>
+<translation id="8134317863207426198">由 Brave Software 提供的精简版网页。点按“加载原始网页”按钮即可加载原始网页。</translation>
+<translation id="4961107849584082341">将此页面翻译成任何语言</translation>
+<translation id="569536719314091526">通过“更多选项”按钮将此页面翻译成任何语言</translation>
+<translation id="1397811292916898096">使用 <ph name="PRODUCT_NAME"/> 进行搜索</translation>
+<translation id="1792959175193046959">随时更改默认的下载内容保存位置</translation>
+<translation id="6942665639005891494">使用“设置”菜单选项随时更改默认的下载内容保存位置</translation>
+<translation id="6850409657436465440">您的下载仍在进行中</translation>
+<translation id="5817715962196959877">Brave 现可更快速地下载文件</translation>
+<translation id="3976396876660209797">移除并重新创建此快捷方式</translation>
+<translation id="6766622839693428701">向下滑动即可关闭。</translation>
+<translation id="1028699632127661925">正在发送到<ph name="DEVICE_NAME"/>…</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - 发送者：<ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">收到了标签页</translation>
 <translation id="9104217018994036254">要与之分享标签页的设备的列表。</translation>
-<translation id="9133397713400217035">离线浏览</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">显示原始网页</translation>
-<translation id="9139068048179869749">网站发送通知前需先询问并获得许可（推荐）</translation>
-<translation id="9139318394846604261">购物</translation>
-<translation id="9155898266292537608">您也可以通过快速点按某个字词进行搜索</translation>
-<translation id="9169507124922466868">导航历史记录在下半屏中显示</translation>
-<translation id="9204836675896933765">还剩 1 个文件</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">要与之分享标签页的设备的列表已半屏打开。</translation>
+<translation id="2904414404539560095">要与之分享标签页的设备的列表已全屏打开。</translation>
+<translation id="4135200667068010335">要与之分享标签页的设备的列表已关闭。</translation>
+<translation id="5292796745632149097">发送到</translation>
+<translation id="1386674309198842382"><ph name="LAST_UPDATED"/> 天前曾有活动</translation>
+<translation id="7971136598759319605">1 天前曾有活动</translation>
+<translation id="1521774566618522728">今天曾有活动</translation>
+<translation id="3631987586758005671">正在分享给<ph name="DEVICE_NAME"/></translation>
+<translation id="9028914725102941583">开启同步功能以跨设备分享内容</translation>
+<translation id="6162454065885854378">如果想将您手机上的内容分享到另一部设备，那么对于这两部设备，您都需在 Brave 设置中开启同步功能</translation>
+<translation id="6084271560289605378">转至 Brave 设置</translation>
+<translation id="2318045970523081853">点按即可拨打电话</translation>
 <translation id="9209888181064652401">无法致电</translation>
-<translation id="9219103736887031265">图片</translation>
-<translation id="926205370408745186">从“数字健康”应用中移除您的 Chrome 活动记录</translation>
-<translation id="932327136139879170">首页</translation>
-<translation id="938850635132480979">错误：<ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">使用您的麦克风</translation>
-<translation id="95817756606698420">在中国，Chrome 可以使用<ph name="BEGIN_BOLD" />搜狗<ph name="END_BOLD" />作为搜索引擎。如果需要，您可以在<ph name="BEGIN_LINK" />设置<ph name="END_LINK" />中进行更改。</translation>
-<translation id="965817943346481315">屏蔽会展示侵扰性或误导性广告的网站（推荐）</translation>
-<translation id="968900484120156207">您访问的网页会显示在此处</translation>
-<translation id="970715775301869095">还剩 <ph name="MINUTES" /> 分钟</translation>
-<translation id="974555521953189084">输入密码以开始同步</translation>
-<translation id="981121421437150478">离线</translation>
-<translation id="982182592107339124">这会清除所有网站的数据，包括：</translation>
-<translation id="983192555821071799">关闭所有标签页</translation>
-<translation id="987264212798334818">常规</translation>
+<translation id="2860954141821109167">请确保已在此设备上启用了一款电话应用</translation>
+<translation id="2067805253194386918">文本</translation>
+<translation id="1450753235335490080">无法分享<ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">无法分享<ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">请确保<ph name="TARGET_DEVICE_NAME"/>已在 Brave 中开启同步功能</translation>
+<translation id="3016635187733453316">请确保此设备已连接到互联网。</translation>
+<translation id="8466613982764129868">请确保<ph name="TARGET_DEVICE_NAME"/>已连接到互联网</translation>
+<translation id="6539092367496845964">出了点问题。请稍后重试。</translation>
+<translation id="3389286852084373014">文本过长</translation>
+<translation id="2100314319871056947">请尝试使用较小的文本块进行分享</translation>
+<translation id="2987620471460279764">从其他设备分享的文字</translation>
+<translation id="7757787379047923882">分享自“<ph name="DEVICE_NAME"/>”的文字</translation>
+<translation id="5193988420012215838">已复制到剪贴板</translation>
+<translation id="4696983787092045100">向您的多部设备发送短信</translation>
+<translation id="1260236875608242557">搜索内容与浏览相关建议</translation>
+<translation id="6369229450655021117">您可从这里搜索网上内容、与好友分享内容以及查看已打开的网页</translation>
+<translation id="723171743924126238">选择图片</translation>
+<translation id="8751914237388039244">选择图片</translation>
+<translation id="1989112275319619282">浏览</translation>
+<translation id="7055152154916055070">已禁止重定向：</translation>
+<translation id="5524843473235508879">已禁止重定向。</translation>
+<translation id="6573096386450695060">一律允许</translation>
+<translation id="5805364706385912897">此网页占用的内存过多，因此 Brave 已将其暂停。</translation>
+<translation id="5138664332909611586">此网页占用的内存过多，因此 Brave 移除了部分内容。</translation>
+<translation id="9137013805542155359">显示原始网页</translation>
+<translation id="6361779936989026201">Brave 中的 Brave Software 助理</translation>
+<translation id="7291387454912369099">使用 Brave 中的 Brave Software 助理结帐</translation>
+<translation id="4565206163201411670">在“数字健康”应用中显示您的 Brave 活动记录？</translation>
+<translation id="9055113864158719823">您可以查看自己在 Brave 中访问的网站并为这些网站设置计时器。\n\nBrave Software 会获取这些设有计时器的网站的相关信息以及您对这些网站的访问时长。这些信息会被用于改进“数字健康”应用。</translation>
+<translation id="4596514158372210596">从“数字健康”应用中移除您的 Brave 活动记录</translation>
+<translation id="1174893863889683998">从“数字健康”应用中移除您的 Brave 活动记录？</translation>
+<translation id="708829030563435351">您在 Brave 中访问的网站不会显示。所有网站计时器都会被删除。</translation>
+<translation id="2056878612599315956">网站已被暂停</translation>
+<translation id="671481426037969117">您的 <ph name="FQDN"/> 计时器已结束计时。它将于明天重新开始。</translation>
+<translation id="7479104141328977413">标签页管理</translation>
+<translation id="3524138585025253783">开发者界面</translation>
+<translation id="6036057147555329831">额外的 ICU</translation>
+<translation id="9029323097866369874">允许 <ph name="DOMAIN"/> 进入 VR 环境？</translation>
+<translation id="7685301384041462804">请确保您信任此网站，然后再进入 VR 环境。</translation>
+<translation id="5033865233969348410">当您处于 VR 环境时，此网站或许能够得知：
+  -  您的身体特征，例如身高
+
+请确保您信任此网站，然后再进入 VR 环境。</translation>
+<translation id="5534334044554683961">当您处于 VR 环境时，此网站或许能够得知：
+  -   您的身体特征，例如身高
+  -   您房间的布局
+
+请确保您信任此网站，然后再进入 VR 环境。</translation>
+<translation id="4169535189173047238">不允许</translation>
+<translation id="2170088579611075216">允许并进入 VR</translation>
 </translationbundle>

--- a/android/java/strings/translations/android_chrome_strings_zh-TW.xtb
+++ b/android/java/strings/translations/android_chrome_strings_zh-TW.xtb
@@ -1,1118 +1,1101 @@
 <?xml version="1.0" ?>
 <!DOCTYPE translationbundle>
 <translationbundle lang="zh-TW">
-<translation id="1006017844123154345">在網路上開啟</translation>
-<translation id="1028699632127661925">正在傳送到「<ph name="DEVICE_NAME" />」...</translation>
-<translation id="1036727731225946849">正在新增「<ph name="WEBAPK_NAME" />」...</translation>
-<translation id="1041308826830691739">來自網站</translation>
-<translation id="1049743911850919806">無痕模式</translation>
-<translation id="10614374240317010">一律不儲存</translation>
-<translation id="1067922213147265141">其他 Google 服務</translation>
-<translation id="1068672505746868501">一律不翻譯<ph name="SOURCE_LANGUAGE" />網頁</translation>
-<translation id="107147699690128016">如果變更副檔名，這個檔案可能會在其他應用程式中開啟，並可能對裝置造成損害。</translation>
-<translation id="1100066534610197918">在群組的新分頁中開啟</translation>
-<translation id="1105960400813249514">螢幕擷取</translation>
-<translation id="1111673857033749125">儲存在您其他裝置上的書籤會顯示在這裡。</translation>
-<translation id="1113597929977215864">顯示「簡易檢視」模式</translation>
-<translation id="1121094540300013208">使用資料和當機報告</translation>
-<translation id="1124772482545689468">使用者</translation>
-<translation id="1129510026454351943">詳細資料：<ph name="ERROR_DESCRIPTION" /></translation>
-<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 項下載作業仍待處理。}other{# 項下載作業仍待處理。}}</translation>
-<translation id="1145536944570833626">刪除現有資料。</translation>
-<translation id="1146678959555564648">進入 VR</translation>
-<translation id="116280672541001035">使用量</translation>
-<translation id="1171770572613082465">輕觸 [熱門網站] 按鈕，即可查看熱門網站</translation>
-<translation id="1173894706177603556">重新命名</translation>
-<translation id="1178581264944972037">暫停</translation>
-<translation id="1181037720776840403">移除</translation>
-<translation id="1188239144602654184">啟動 AR</translation>
-<translation id="1197267115302279827">移動書籤</translation>
-<translation id="119944043368869598">全部清除</translation>
-<translation id="1201402288615127009">繼續</translation>
-<translation id="1204037785786432551">下載連結</translation>
-<translation id="1206892813135768548">複製連結文字</translation>
-<translation id="1208340532756947324">如要進行同步處理並在所有裝置上享有個人化的體驗，請開啟同步處理功能</translation>
-<translation id="1209206284964581585">暫時隱藏</translation>
-<translation id="1227058898775614466">瀏覽記錄</translation>
-<translation id="1231733316453485619">要開啟同步處理功能嗎？</translation>
-<translation id="123724288017357924">重新載入目前的網頁，略過已快取的內容</translation>
-<translation id="124116460088058876">更多語言</translation>
-<translation id="124678866338384709">關閉目前的分頁</translation>
-<translation id="1258753120186372309">Google Doodle：<ph name="DOODLE_DESCRIPTION" /></translation>
-<translation id="1260236875608242557">搜尋及探索</translation>
-<translation id="1264974993859112054">運動資訊</translation>
-<translation id="1266864766717917324">無法分享<ph name="CONTENT_TYPE" /></translation>
-<translation id="1272079795634619415">停止</translation>
-<translation id="1283039547216852943">輕觸即可展開</translation>
-<translation id="1285320974508926690">一律不翻譯此網站</translation>
-<translation id="1291207594882862231">清除歷史記錄、Cookie、網站資料、快取…</translation>
-<translation id="129382876167171263">網站儲存的檔案會顯示在這裡</translation>
-<translation id="129553762522093515">最近關閉的分頁</translation>
-<translation id="1303507811548703290"><ph name="DOMAIN" /> - 來自 <ph name="DEVICE_NAME" /></translation>
-<translation id="1310482092992808703">將分頁加入群組</translation>
-<translation id="1327257854815634930">瀏覽記錄已開啟</translation>
-<translation id="1331212799747679585">無法更新 Chrome。更多選項</translation>
-<translation id="1332501820983677155">Google Chrome 功能快速鍵</translation>
-<translation id="1360432990279830238">要登出並關閉同步處理功能嗎？</translation>
-<translation id="1369915414381695676">已新增 <ph name="SITE_NAME" /> 網站</translation>
-<translation id="1373696734384179344">記憶體不足，無法下載您選取的這項內容。</translation>
-<translation id="1376578503827013741">計算中…</translation>
-<translation id="1383876407941801731">搜尋</translation>
-<translation id="1384959399684842514">已暫停下載</translation>
-<translation id="1386674309198842382">上次使用時間：<ph name="LAST_UPDATED" /> 天前</translation>
-<translation id="1397811292916898096">使用 <ph name="PRODUCT_NAME" /> 搜尋</translation>
-<translation id="1404122904123200417">內嵌位置：<ph name="WEBSITE_URL" /></translation>
-<translation id="1406000523432664303">「不追蹤」</translation>
-<translation id="1407135791313364759">全部開啟</translation>
-<translation id="1409426117486808224">使用簡易檢視模式查看開啟的分頁</translation>
-<translation id="1409879593029778104"><ph name="FILE_NAME" /> 檔案已存在，因此無法下載。</translation>
-<translation id="1414981605391750300">正在連線至 Google。可能需要一分鐘…</translation>
-<translation id="1416550906796893042">應用程式版本</translation>
-<translation id="1430915738399379752">列印</translation>
-<translation id="1446450296470737166">允許完整控制 MIDI 裝置</translation>
-<translation id="1450753235335490080">無法分享<ph name="CONTENT_TYPE" /></translation>
-<translation id="145097072038377568">已在 Android 設定中關閉</translation>
-<translation id="1477626028522505441">伺服器發生問題，因此無法下載 <ph name="FILE_NAME" />。</translation>
-<translation id="1506061864768559482">搜尋引擎</translation>
-<translation id="1513352483775369820">書籤與網頁記錄</translation>
-<translation id="1513858653616922153">刪除密碼</translation>
-<translation id="1516229014686355813">「輕觸搜尋」會將選取的字詞和目前所在的網頁 (以便比對內容) 傳送給 Google 搜尋。你可以在<ph name="BEGIN_LINK" />設定<ph name="END_LINK" />中關閉這項功能。</translation>
-<translation id="1521774566618522728">上次使用時間：今天</translation>
-<translation id="1544826120773021464">如要管理你的 Google 帳戶，請輕觸 [管理帳戶] 按鈕</translation>
-<translation id="1549000191223877751">移至其他視窗</translation>
-<translation id="1553358976309200471">更新 Chrome</translation>
-<translation id="1569387923882100876">連結的裝置</translation>
-<translation id="1571304935088121812">複製使用者名稱</translation>
-<translation id="1612196535745283361">Chrome 需要位置資訊存取權才能掃描裝置。<ph name="BEGIN_LINK" />這個裝置的位置資訊存取權已關閉<ph name="END_LINK" />。</translation>
-<translation id="1620510694547887537">攝影機</translation>
-<translation id="1623104350909869708">防止這個網頁產生其他對話方塊</translation>
-<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{移除 1 個選取的項目}other{移除 # 個選取的項目}}</translation>
-<translation id="164269334534774161">您目前瀏覽的是這個網頁的離線複本 (建立時間：<ph name="CREATION_TIME" />)</translation>
-<translation id="1644574205037202324">歷史記錄</translation>
-<translation id="1647391597548383849">存取您的攝影機</translation>
-<translation id="1660204651932907780">允許網站播放音訊 (建議)</translation>
-<translation id="1670399744444387456">基本</translation>
-<translation id="1671236975893690980">正在等候下載…</translation>
-<translation id="1672586136351118594">不要再顯示</translation>
-<translation id="1692118695553449118">同步功能已啟用</translation>
-<translation id="169515064810179024">禁止網站存取動作感應器</translation>
-<translation id="1717218214683051432">動作感應器</translation>
-<translation id="1718835860248848330">過去 1 小時</translation>
-<translation id="1736419249208073774">探索</translation>
-<translation id="1743802530341753419">允許網站連線至裝置前，必須先詢問你 (建議)</translation>
-<translation id="1749561566933687563">同步處理您的書籤</translation>
-<translation id="17513872634828108">開啟的分頁</translation>
-<translation id="1779089405699405702">影像解碼器</translation>
-<translation id="1782483593938241562">結束日期：<ph name="DATE" /></translation>
-<translation id="1791662854739702043">安裝位置</translation>
-<translation id="1792959175193046959">你隨時可以變更預設的下載位置</translation>
-<translation id="1807246157184219062">淺色</translation>
-<translation id="1810845389119482123">尚未完成初始同步處理設定</translation>
-<translation id="1821253160463689938">使用 Cookie 記住你的偏好設定 (即使你沒有造訪這些網頁)</translation>
-<translation id="1829244130665387512">在網頁中尋找</translation>
-<translation id="1853692000353488670">新增無痕式分頁</translation>
-<translation id="1856325424225101786">要重設精簡模式嗎？</translation>
-<translation id="1868024384445905608">Chrome 現在的檔案下載速度更快了</translation>
-<translation id="1883903952484604915">我的檔案</translation>
-<translation id="1887786770086287077">這部裝置的位置資訊存取權已關閉。請在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中予以開啟。</translation>
-<translation id="1891331835972267886">「<ph name="APP_NAME" />」將在 Chrome 中開啟。繼續操作即表示您同意接受 Chrome 的《<ph name="BEGIN_LINK1" />服務條款<ph name="END_LINK1" />》和《<ph name="BEGIN_LINK2" />隱私權聲明<ph name="END_LINK2" />》。</translation>
-<translation id="1919345977826869612">廣告</translation>
-<translation id="1919950603503897840">選取聯絡人</translation>
-<translation id="1922076542920281912">如要讓 Chrome 存取你的位置，請一併在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中開啟定位功能。</translation>
-<translation id="1923695749281512248">已下載：<ph name="BYTES_DOWNLOADED_WITH_UNITS" />，總大小：<ph name="FILE_SIZE_WITH_UNITS" /></translation>
-<translation id="1928696683969751773">更新</translation>
-<translation id="19288952978244135">重新開啟 Chrome。</translation>
-<translation id="1933845786846280168">選取的分頁</translation>
-<translation id="194341124344773587">請在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中為 Chrome 啟用這項權限。</translation>
-<translation id="1943432128510653496">儲存密碼</translation>
-<translation id="1952172573699511566">Chrome 會儘可能以你慣用的語言顯示網站文字。</translation>
-<translation id="1960290143419248813">這個版本的 Android 已停止支援 Chrome 更新</translation>
-<translation id="1966710179511230534">請更新你的登入詳細資料。</translation>
-<translation id="1974060860693918893">進階</translation>
-<translation id="1984705450038014246">同步處理你的 Chrome 資料</translation>
-<translation id="1984937141057606926">允許 (第三方網站除外)</translation>
-<translation id="1986685561493779662">這個名稱已有人使用</translation>
-<translation id="1987739130650180037"><ph name="MESSAGE" /> <ph name="LINK_NAME" />按鈕</translation>
-<translation id="1989112275319619282">瀏覽</translation>
-<translation id="1993768208584545658"><ph name="SITE" /> 要求配對</translation>
-<translation id="1994173015038366702">網站網址</translation>
-<translation id="2000419248597011803">將網址列和搜尋框中的部分 Cookie 和搜尋字詞傳送給你的預設搜尋引擎</translation>
-<translation id="2002537628803770967">使用 Google Pay 儲存的信用卡和地址資訊</translation>
-<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# 個檔案}other{# 個檔案}}</translation>
-<translation id="2017836877785168846">將歷史記錄和自動即時查詢從網址列中清除。</translation>
-<translation id="2021896219286479412">全螢幕網站控制</translation>
-<translation id="2038563949887743358">開啟「要求電腦版網站」</translation>
-<translation id="2041019821020695769">如要讓 Chrome 傳送通知，請一併在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中開啟通知功能。</translation>
-<translation id="204321170514947529">「<ph name="APP_NAME" />」在 Chrome 中也有資料</translation>
-<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="2056878612599315956">網站已暫停</translation>
-<translation id="2063713494490388661">輕觸搜尋</translation>
-<translation id="2067805253194386918">文字</translation>
-<translation id="2079545284768500474">復原</translation>
-<translation id="2082238445998314030">第 <ph name="RESULT_NUMBER" /> 個結果，共 <ph name="TOTAL_RESULTS" /> 個</translation>
-<translation id="2091887806945687916">音訊</translation>
-<translation id="2096012225669085171">讓多部裝置保持同步，並提供人化體驗</translation>
-<translation id="2100273922101894616">自動登入</translation>
-<translation id="2100314319871056947">請嘗試將要分享的文字分成多個片段</translation>
-<translation id="2107397443965016585">允許網站播放受保護的內容前，必須先詢問你 (建議)</translation>
-<translation id="2111511281910874386">前往指定頁面</translation>
-<translation id="2122601567107267586">無法開啟應用程式</translation>
-<translation id="2126426811489709554">技術提供：Chrome</translation>
-<translation id="2131665479022868825">已節省 <ph name="DATA" /></translation>
-<translation id="213279576345780926">已關閉「<ph name="TAB_TITLE" />」</translation>
-<translation id="2139186145475833000">加到主畫面</translation>
-<translation id="2146738493024040262">開啟免安裝應用程式</translation>
-<translation id="2148716181193084225">今天</translation>
-<translation id="2154484045852737596">編輯卡片資訊</translation>
-<translation id="2154710561487035718">複製網址</translation>
-<translation id="2156074688469523661">其餘網站 (<ph name="NUMBER_OF_SITES" />)</translation>
-<translation id="2157851137955077194">如要將手機上的內容分享至另一台裝置，你必須在這兩台裝置的 Chrome 設定中開啟同步功能</translation>
-<translation id="2170088579611075216">允許並進入 VR</translation>
-<translation id="218608176142494674">共用</translation>
-<translation id="2227444325776770048">以「<ph name="USER_FULL_NAME" />」的身分繼續</translation>
-<translation id="2234876718134438132">同步處理和 Google 服務</translation>
-<translation id="2259659629660284697">匯出密碼…</translation>
-<translation id="2268044343513325586">修正搜尋</translation>
-<translation id="2286841657746966508">帳單地址</translation>
-<translation id="2289270750774289114">當網站要搜尋附近的藍牙裝置時，必須先詢問你 (建議)</translation>
-<translation id="230115972905494466">找不到相容的裝置</translation>
-<translation id="2315043854645842844">作業系統不允許您在用戶端選取憑證。</translation>
-<translation id="2318045970523081853">輕觸即可撥打電話</translation>
-<translation id="2321086116217818302">正在準備匯出密碼…</translation>
-<translation id="2321958826496381788">拖曳滑桿，將文字調整到適當的字體大小。當你輕觸兩下文字段落時，瀏覽器至少應呈現這樣的字體大小。</translation>
-<translation id="2323763861024343754">網站儲存資料量</translation>
-<translation id="2328985652426384049">無法登入</translation>
-<translation id="2330129964253841015">當密碼遭到外洩時發出警告</translation>
-<translation id="2349710944427398404">Chrome 使用的資料總量，包括帳戶、書籤和儲存的設定</translation>
-<translation id="2353636109065292463">檢查你的網際網路連線</translation>
-<translation id="2359808026110333948">繼續</translation>
-<translation id="2369533728426058518">開啟的分頁</translation>
-<translation id="2387895666653383613">文字大小</translation>
-<translation id="2394602618534698961">你下載的檔案會顯示在這裡</translation>
-<translation id="2402980924095424747"><ph name="MEGABYTES" /> MB</translation>
-<translation id="2407481962792080328">登入 Google 帳戶時，系統會啟用這項功能</translation>
-<translation id="2410754283952462441">選擇帳戶</translation>
-<translation id="2414886740292270097">深色</translation>
-<translation id="2416359993254398973">Chrome 需要相關權限，才能讓這個網站使用你的攝影機。</translation>
-<translation id="2426805022920575512">選擇其他帳戶</translation>
-<translation id="2433507940547922241">外觀</translation>
-<translation id="2434158240863470628">下載完成 <ph name="SEPARATOR" /> <ph name="BYTES_DOWNLOADED" /></translation>
-<translation id="2440823041667407902">位置資訊存取權</translation>
-<translation id="2450083983707403292">要重新下載「<ph name="FILE_NAME" />」嗎？</translation>
-<translation id="2482878487686419369">通知</translation>
-<translation id="2490684707762498678">由 <ph name="APP_NAME" /> 管理</translation>
-<translation id="2494974097748878569">Chrome 版 Google 助理</translation>
-<translation id="2496180316473517155">瀏覽記錄</translation>
-<translation id="2497852260688568942">你的管理員停用了同步功能</translation>
-<translation id="2498359688066513246">說明與意見回饋</translation>
-<translation id="2501278716633472235">返回</translation>
-<translation id="2513403576141822879">如需更多隱私權、安全性和資料收集的相關設定，請參閱<ph name="BEGIN_LINK" />同步處理和 Google 服務<ph name="END_LINK" /></translation>
-<translation id="2518590038762162553">使用精簡模式時，Chrome 可加快網頁載入速度，並可節省多達 60% 的數據用量。Chrome 會將你的網路流量傳送給 Google，以便針對你造訪的網頁進行最佳化處理。<ph name="BEGIN_LINK" />瞭解詳情<ph name="END_LINK" /></translation>
-<translation id="2523184218357549926">將你造訪的網頁網址傳送給 Google</translation>
-<translation id="2532336938189706096">網頁檢視</translation>
-<translation id="2534155362429831547">已刪除 <ph name="NUMBER_OF_ITEMS" /> 個項目</translation>
-<translation id="2536728043171574184">目前瀏覽的是這個網頁的離線複本</translation>
-<translation id="2546283357679194313">Cookie 和網站資料</translation>
-<translation id="2567385386134582609">圖片</translation>
-<translation id="257088987046510401">主題</translation>
-<translation id="2570922361219980984">此外，這部裝置的位置資訊存取權已關閉。請在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中予以開啟。</translation>
-<translation id="257931822824936280">已展開 - 按一下即可收合。</translation>
-<translation id="2581165646603367611">這項操作會清除不重要的網站 Cookie、快取等其他資料 (Chrome 會自動判斷資料的重要性)。</translation>
-<translation id="2586657967955657006">剪貼簿</translation>
-<translation id="2587052924345400782">已推出新版本</translation>
-<translation id="2593272815202181319">等寬</translation>
-<translation id="2612676031748830579">卡號</translation>
-<translation id="2621115761605608342">允許特定網站執行 JavaScript。</translation>
-<translation id="2625189173221582860">已複製密碼</translation>
-<translation id="2631006050119455616">已節省</translation>
-<translation id="2647434099613338025">新增語言</translation>
-<translation id="2650751991977523696">要再次下載檔案嗎？</translation>
-<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# 個音訊檔案}other{# 個音訊檔案}}</translation>
-<translation id="2653659639078652383">提交</translation>
-<translation id="2677748264148917807">離開</translation>
-<translation id="2704606927547763573">已複製</translation>
-<translation id="2707726405694321444">重新整理頁面</translation>
-<translation id="2709516037105925701">自動填入</translation>
-<translation id="2717722538473713889">電子郵件地址</translation>
-<translation id="2728754400939377704">依網站排序</translation>
-<translation id="2744248271121720757">只要輕觸字詞就能立即展開搜尋或查看相關的動作</translation>
-<translation id="2760989362628427051">當裝置開啟深色主題或節約耗電量功能時，啟用深色主題</translation>
-<translation id="2762000892062317888">剛剛</translation>
-<translation id="2777555524387840389">還剩 <ph name="SECONDS" /> 秒</translation>
-<translation id="2779651927720337254">失敗</translation>
-<translation id="2781151931089541271">還剩 1 秒</translation>
-<translation id="2801022321632964776">更新後即可在 Chrome 最新版本中使用你偏好的語言</translation>
-<translation id="2810645512293415242">網頁內容經過簡化，不僅節省數據用量，更加快載入速度。</translation>
-<translation id="281504910091592009">你可以查看及管理 <ph name="BEGIN_LINK" />Google 帳戶<ph name="END_LINK" />中儲存的密碼</translation>
-<translation id="2818669890320396765">如要將書籤同步到所有裝置，請登入並開啟同步處理功能</translation>
-<translation id="2822354292072154809">確定要重設「<ph name="CHOSEN_OBJECT_NAME" />」的所有網站權限嗎？</translation>
-<translation id="2836148919159985482">輕觸返回按鈕即可結束全螢幕模式。</translation>
-<translation id="2842985007712546952">上層資料夾</translation>
-<translation id="2858138569776157458">熱門網站</translation>
-<translation id="2860954141821109167">請確認此裝置已啟用手機應用程式</translation>
-<translation id="2870560284913253234">網站</translation>
-<translation id="2874939134665556319">上一首曲目</translation>
-<translation id="2876369937070532032">當網站具有安全性風險時，Chrome 會將你造訪的部分網頁網址傳送給 Google</translation>
-<translation id="2888126860611144412">關於 Chrome</translation>
-<translation id="2891154217021530873">停止載入網頁</translation>
-<translation id="2893180576842394309">Google 可能會使用你的歷史記錄，為你提供個人化的搜尋服務和其他各項 Google 服務</translation>
-<translation id="2898264748040935573">編輯已儲存的密碼</translation>
-<translation id="2900528713135656174">建立活動</translation>
-<translation id="290376772003165898">不是<ph name="LANGUAGE" />網頁嗎？</translation>
-<translation id="2904414404539560095">要共用分頁的裝置清單已開啟，顯示於整個畫面。</translation>
-<translation id="2910701580606108292">允許網站播放受保護的內容前，必須先詢問你</translation>
-<translation id="2913331724188855103">允許網站儲存及讀取 Cookie 資料 (建議)</translation>
-<translation id="2923908459366352541">名稱無效</translation>
-<translation id="2932150158123903946">Google <ph name="APP_NAME" /> 儲存資料量</translation>
-<translation id="2942036813789421260">預覽分頁已關閉</translation>
-<translation id="2956410042958133412">這個帳戶受 <ph name="PARENT_NAME_1" /> 和 <ph name="PARENT_NAME_2" /> 管理。</translation>
-<translation id="2962095958535813455">已切換成無痕式分頁</translation>
-<translation id="2968755619301702150">憑證檢視器</translation>
-<translation id="2979025552038692506">選取的無痕式分頁</translation>
-<translation id="2987620471460279764">從其他裝置分享的文字</translation>
-<translation id="2989523299700148168">最近造訪過</translation>
-<translation id="2996291259634659425">建立通關密語</translation>
-<translation id="2996809686854298943">必須要有網址</translation>
-<translation id="300526633675317032">這會將網站儲存的資料全部清除 (共 <ph name="SIZE_IN_KB" />)。</translation>
-<translation id="3016635187733453316">請確認此裝置已連上網際網路</translation>
-<translation id="3029613699374795922">已下載 <ph name="KBS" /> KB</translation>
-<translation id="3029704984691124060">通關密語不符</translation>
-<translation id="3036750288708366620"><ph name="BEGIN_LINK" />取得說明<ph name="END_LINK" /></translation>
-<translation id="305593374596241526">定位功能已關閉，請在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中開啟這項功能。</translation>
-<translation id="3058498974290601450">你隨時可以在設定中開啟同步功能</translation>
-<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE" /> 個書籤}other{<ph name="BOOKMARKS_COUNT_MANY" /> 個書籤}}</translation>
-<translation id="3089395242580810162">在無痕式分頁中開啟</translation>
-<translation id="3115898365077584848">顯示資訊</translation>
-<translation id="3123473560110926937">在某些網站上設定封鎖</translation>
-<translation id="3137521801621304719">離開無痕模式</translation>
-<translation id="3143515551205905069">取消同步處理</translation>
-<translation id="3157842584138209013">如要查看節省的數據用量，請點選 [更多選項] 按鈕</translation>
-<translation id="3166827708714933426">分頁與視窗快速鍵</translation>
-<translation id="3181954750937456830">安全瀏覽 (保護你和你的裝置不受危險網站攻擊)</translation>
-<translation id="3190152372525844641">請在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中為 Chrome 啟用這些權限。</translation>
-<translation id="3198916472715691905">儲存了 <ph name="STORAGE_AMOUNT" /> 的資料</translation>
-<translation id="3205824638308738187">即將大功告成！</translation>
-<translation id="3207960819495026254">已加入書籤</translation>
-<translation id="3211426585530211793">已刪除「<ph name="ITEM_TITLE" />」</translation>
-<translation id="321773570071367578">如果您忘記通關密語，或是想變更這項設定，請<ph name="BEGIN_LINK" />重設同步功能<ph name="END_LINK" /></translation>
-<translation id="3227137524299004712">麥克風</translation>
-<translation id="3232754137068452469">網路應用程式</translation>
-<translation id="3236059992281584593">還剩 1 分鐘</translation>
-<translation id="3244271242291266297">月</translation>
-<translation id="3254409185687681395">把此頁加入書籤</translation>
-<translation id="3259831549858767975">縮小網頁上的所有內容</translation>
-<translation id="3269093882174072735">載入圖片</translation>
-<translation id="3269956123044984603">如要存取您在其他裝置上開啟的分頁，請前往 Android 帳戶設定開啟 [自動同步處理資料]。</translation>
-<translation id="3277252321222022663">允許網站存取感應器 (建議)</translation>
-<translation id="3282568296779691940">登入 Chrome</translation>
-<translation id="3288003805934695103">重新載入網頁</translation>
-<translation id="32895400574683172">允許顯示通知</translation>
-<translation id="3295530008794733555">瀏覽速度更快，數據用量更少。</translation>
-<translation id="3295602654194328831">隱藏資訊</translation>
-<translation id="3298243779924642547">精簡版本</translation>
-<translation id="3303414029551471755">繼續下載這項內容？</translation>
-<translation id="3306398118552023113">Chrome 正在執行這個應用程式</translation>
-<translation id="3315103659806849044">你正在自訂同步功能和 Google 服務設定。如要完成開啟同步功能，請輕觸畫面底部附近的 [確認] 按鈕。向上瀏覽</translation>
-<translation id="3328801116991980348">網站資訊</translation>
-<translation id="3333961966071413176">所有聯絡人</translation>
-<translation id="3334729583274622784">是否要變更副檔名？</translation>
-<translation id="3341058695485821946">查看節省的數據用量</translation>
-<translation id="3350687908700087792">關閉所有無痕式分頁</translation>
-<translation id="3353615205017136254">由 Google 提供的精簡版網頁。輕觸 [載入原始頁面] 按鈕即可載入原始頁面。</translation>
-<translation id="3367813778245106622">如要開始同步處理，請重新登入</translation>
-<translation id="3374023511497244703">你的書籤、歷史記錄、密碼和其他 Chrome 資料將停止同步到你的 Google 帳戶</translation>
-<translation id="3384347053049321195">分享圖片</translation>
-<translation id="3386292677130313581">允許網站存取你的位置資訊前，必須先詢問你 (建議)</translation>
-<translation id="3387650086002190359">檔案系統發生錯誤，因此無法下載 <ph name="FILE_NAME" />。</translation>
-<translation id="3389286852084373014">文字過多</translation>
-<translation id="3398320232533725830">開啟書籤管理員</translation>
-<translation id="3414952576877147120">空間大小：</translation>
-<translation id="3443221991560634068">重新載入目前網頁</translation>
-<translation id="3445014427084483498">剛剛</translation>
-<translation id="3478363558367712427">你可以選擇搜尋引擎</translation>
+<translation id="6910211073230771657">已刪除</translation>
+<translation id="6965382102122355670">確定</translation>
+<translation id="5301954838959518834">好，我知道了</translation>
+<translation id="7658239707568436148">取消</translation>
 <translation id="3479552764303398839">現在不要</translation>
-<translation id="3492207499832628349">新無痕式分頁</translation>
-<translation id="3493531032208478708"><ph name="BEGIN_LINK" />進一步瞭解<ph name="END_LINK" />建議的內容</translation>
-<translation id="3513704683820682405">擴增實境</translation>
-<translation id="3518985090088779359">接受並繼續</translation>
-<translation id="3522247891732774234">有可用的更新。更多選項</translation>
-<translation id="3524138585025253783">開發人員 UI</translation>
-<translation id="3527085408025491307">資料夾</translation>
-<translation id="3542235761944717775">可用空間：<ph name="KILOBYTES" /> KB</translation>
-<translation id="3549657413697417275">搜尋你的記錄</translation>
-<translation id="3557336313807607643">新增為聯絡人</translation>
-<translation id="3566923219790363270">Chrome 仍在準備 VR 模組。請稍後再重新啟動 Chrome。</translation>
-<translation id="3568688522516854065">如要存取你在其他裝置上開啟的分頁，請登入並開啟同步處理功能</translation>
-<translation id="3587482841069643663">全部</translation>
-<translation id="358794129225322306">允許網站自動下載多個檔案。</translation>
-<translation id="3590487821116122040">Chrome 認定為不重要的網站 (例如未儲存任何設定的網站，或是您不常造訪的網站) 所儲存的資料</translation>
-<translation id="3599863153486145794">將歷史記錄從所有登入帳戶的裝置上清除。你的 Google 帳戶可能會儲存其他形式的瀏覽記錄，請參閱 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />。</translation>
-<translation id="3600792891314830896">將播放音訊的網站設為靜音</translation>
-<translation id="3616113530831147358">音訊</translation>
-<translation id="3631987586758005671">正在分享至「<ph name="DEVICE_NAME" />」</translation>
-<translation id="3632295766818638029">取消密碼遮罩</translation>
-<translation id="363596933471559332">自動使用已儲存的憑證登入網站。如果關閉這項功能，每次在您登入網站之前，網站一律會要求驗證。</translation>
-<translation id="3658159451045945436">如果確認重設，系統會清除你的數據用量節省記錄，包括你造訪過的網站清單。</translation>
-<translation id="3692944402865947621">無法連線至儲存位置，因此無法下載 <ph name="FILE_NAME" />。</translation>
-<translation id="3714981814255182093">開啟搜尋列</translation>
-<translation id="3716182511346448902">這個網頁使用了過多記憶體，因此遭到 Chrome 暫停。</translation>
-<translation id="3730075448226062617">如要讓 Chrome 存取你的麥克風，請一併在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中開啟麥克風。</translation>
-<translation id="3739899004075612870">已加入 <ph name="PRODUCT_NAME" /> 書籤</translation>
-<translation id="3744111561329211289">背景同步處理</translation>
-<translation id="3771001275138982843">無法下載更新</translation>
-<translation id="3771033907050503522">無痕式分頁</translation>
-<translation id="3773755127849930740">如要允許配對，請<ph name="BEGIN_LINK" />開啟藍牙功能<ph name="END_LINK" /></translation>
-<translation id="3775705724665058594">傳送至你的裝置</translation>
-<translation id="3778956594442850293">已新增至主畫面</translation>
-<translation id="3789841737615482174">安裝</translation>
-<translation id="3810838688059735925">影片</translation>
-<translation id="3810973564298564668">管理</translation>
-<translation id="381841723434055211">電話號碼</translation>
-<translation id="3819178904835489326">已刪除 <ph name="NUMBER_OF_DOWNLOADS" /> 個下載項目</translation>
-<translation id="3822502789641063741">要清除網站儲存的資料嗎？</translation>
-<translation id="385051799172605136">返回</translation>
-<translation id="3859306556332390985">快轉到特定的播放時間點</translation>
-<translation id="3894427358181296146">新增資料夾</translation>
-<translation id="3895926599014793903">強制啟用縮放功能</translation>
-<translation id="3912508018559818924">正在從網路上尋找最佳內容…</translation>
-<translation id="3927692899758076493">Sans Serif</translation>
-<translation id="3928666092801078803">合併我的資料</translation>
-<translation id="393697183122708255">沒有可用的語音搜尋功能</translation>
-<translation id="395206256282351086">已停用搜尋與網站建議</translation>
-<translation id="3955193568934677022">允許網站播放受保護的內容 (建議)</translation>
-<translation id="396192773038029076">{NUM_IN_PROGRESS,plural, =1{Chrome 準備就緒後將載入你的網頁}other{Chrome 準備就緒後將載入你的網頁}}</translation>
-<translation id="3963007978381181125">通關密語加密保護的資料不包括 Google Pay 的付款方式和地址。只有知道你通關密語的人，才能讀取加密保護的資料。系統不會將通關密語傳送給 Google，Google 也不會儲存通關密語。如果你忘記自己的通關密語，或是想變更這項設定，則必須重設同步功能。<ph name="BEGIN_LINK" />瞭解詳情<ph name="END_LINK" /></translation>
-<translation id="3967822245660637423">下載完成</translation>
-<translation id="397583555483684758">同步處理功能已停止運作</translation>
-<translation id="3976396876660209797">移除這個捷徑後再重新建立</translation>
-<translation id="3985215325736559418">你要再次下載 <ph name="FILE_NAME" /> 嗎？</translation>
-<translation id="3987993985790029246">複製連結</translation>
-<translation id="3988213473815854515">禁止存取位置資訊</translation>
-<translation id="3988466920954086464">你可以在這個面板中查看即時搜尋結果</translation>
-<translation id="3991845972263764475">已下載：<ph name="BYTES_DOWNLOADED_WITH_UNITS" />，總大小：不明</translation>
-<translation id="3997476611815694295">不重要網站的儲存資料量</translation>
-<translation id="4000212216660919741">離線首頁</translation>
+<translation id="5317780077021120954">儲存</translation>
+<translation id="4570913071927164677">詳細資料</translation>
+<translation id="8730621377337864115">完成</translation>
+<translation id="8261506727792406068">刪除</translation>
+<translation id="1181037720776840403">移除</translation>
+<translation id="5939518447894949180">重設</translation>
 <translation id="4002066346123236978">標題</translation>
-<translation id="4008040567710660924">允許特定網站的 Cookie。</translation>
-<translation id="4034817413553209278">{HOURS,plural, =1{# 小時}other{# 小時}}</translation>
-<translation id="4046123991198612571">下一首曲目</translation>
-<translation id="4048707525896921369">不需離開網頁即可瞭解網站上的主題。「輕觸搜尋」可將特定字詞及其上下文內容傳送給 Google 搜尋，並傳回定義、圖片、搜尋結果和其他詳細資料。
+<translation id="5916664084637901428">開啟</translation>
+<translation id="5860033963881614850">關閉</translation>
+<translation id="6165508094623778733">瞭解詳情</translation>
+<translation id="6042308850641462728">更多</translation>
+<translation id="6040143037577758943">關閉</translation>
+<translation id="780301667611848630">不用了，謝謝</translation>
+<translation id="1201402288615127009">繼續</translation>
+<translation id="2359808026110333948">繼續</translation>
+<translation id="2653659639078652383">提交</translation>
+<translation id="2079545284768500474">復原</translation>
+<translation id="7649070708921625228">說明</translation>
+<translation id="2148716181193084225">今天</translation>
+<translation id="7781829728241885113">昨天</translation>
+<translation id="6945221475159498467">選取</translation>
+<translation id="7791543448312431591">新增</translation>
+<translation id="6527303717912515753">分享</translation>
+<translation id="1383876407941801731">搜尋</translation>
+<translation id="3115898365077584848">顯示資訊</translation>
+<translation id="3295602654194328831">隱藏資訊</translation>
+<translation id="3987993985790029246">複製連結</translation>
+<translation id="2704606927547763573">已複製</translation>
+<translation id="8725066075913043281">再試一次</translation>
+<translation id="385051799172605136">返回</translation>
+<translation id="8131740175452115882">確認</translation>
+<translation id="5300589172476337783">顯示</translation>
+<translation id="1124772482545689468">使用者</translation>
+<translation id="8609465669617005112">上移</translation>
+<translation id="6746124502594467657">下移</translation>
+<translation id="8249310407154411074">移至頂端</translation>
+<translation id="8428213095426709021">設定</translation>
+<translation id="2498359688066513246">說明與意見回饋</translation>
+<translation id="8378714024927312812">由貴機構管理</translation>
+<translation id="9019902583201351841">你的家長已停用這項功能</translation>
+<translation id="4645575059429386691">你的家長已停用這項功能</translation>
+<translation id="4883854917563148705">無法重設受管理的設定</translation>
+<translation id="4307992518367153382">基本選項</translation>
+<translation id="1974060860693918893">進階</translation>
+<translation id="1146678959555564648">進入 VR</translation>
+<translation id="987264212798334818">一般</translation>
+<translation id="4275663329226226506">媒體</translation>
+<translation id="4759238208242260848">下載</translation>
+<translation id="218608176142494674">共用</translation>
+<translation id="8004582292198964060">瀏覽器</translation>
+<translation id="1105960400813249514">螢幕擷取</translation>
+<translation id="4875775213178255010">內容建議</translation>
+<translation id="2021896219286479412">全螢幕網站控制</translation>
+<translation id="4587589328781138893">網站</translation>
+<translation id="4943703118917034429">虛擬實境</translation>
+<translation id="1928696683969751773">更新</translation>
+<translation id="6064125863973209585">下載完成</translation>
+<translation id="5342314432463739672">權限要求</translation>
+<translation id="629730747756840877">帳戶</translation>
+<translation id="82609232232243542">登入 Brave</translation>
+<translation id="7956662517480676674">同步處理和 Brave Software 服務</translation>
+<translation id="5294439808117722387">你正在自訂同步功能和 Brave Software 服務設定。如要完成開啟同步功能，請輕觸畫面底部附近的 [確認] 按鈕。向上瀏覽</translation>
+<translation id="2096012225669085171">讓多部裝置保持同步，並提供人化體驗</translation>
+<translation id="1692118695553449118">同步功能已啟用</translation>
+<translation id="5514904542973294328">裝置管理員已停用</translation>
+<translation id="6447211988989208781">Brave Software 活動控制項</translation>
+<translation id="4882831918239250449">控制 Brave Software 使用瀏覽記錄提供個人化搜尋服務、廣告和其他內容的方式</translation>
+<translation id="7431991332293347422">控制 Brave Software 使用瀏覽記錄提供個人化搜尋服務和其他內容的方式</translation>
+<translation id="6303969859164067831">登出並關閉同步處理功能</translation>
+<translation id="1125261911132334651">管理你的 Brave Software 帳戶</translation>
+<translation id="6406506848690869874">同步</translation>
+<translation id="714362445477979774">同步處理你的 Brave 資料</translation>
+<translation id="4314815835985389558">管理同步功能資料</translation>
+<translation id="5428209950370661546">其他 Brave Software 服務</translation>
+<translation id="7704317875155739195">自動完成搜尋字詞與網址</translation>
+<translation id="2000419248597011803">將網址列和搜尋框中的部分 Cookie 和搜尋字詞傳送給你的預設搜尋引擎</translation>
+<translation id="7981313251711023384">預先載入網頁，以加快瀏覽及搜尋速度</translation>
+<translation id="1821253160463689938">使用 Cookie 記住你的偏好設定 (即使你沒有造訪這些網頁)</translation>
+<translation id="6697492270171225480">找不到網頁時顯示類似的網頁建議</translation>
+<translation id="8109318360573330108">將你嘗試瀏覽的網頁網址傳送給 Brave Software</translation>
+<translation id="8438566539970814960">改善搜尋和瀏覽體驗</translation>
+<translation id="284843628681142937">將你造訪的網頁網址傳送給 Brave Software</translation>
+<translation id="7222718784508482526">如需更多隱私權、安全性和資料收集的相關設定，請參閱<ph name="BEGIN_LINK"/>同步處理和 Brave Software 服務<ph name="END_LINK"/></translation>
+<translation id="918192811481327695">協助改善 Brave 的功能與效能</translation>
+<translation id="9063160602596686558">自動將使用統計資料和當機報告傳送給 Brave Software</translation>
+<translation id="4824958205181053313">取消同步處理？</translation>
+<translation id="3058498974290601450">你隨時可以在設定中開啟同步功能</translation>
+<translation id="3143515551205905069">取消同步處理</translation>
+<translation id="1506061864768559482">搜尋引擎</translation>
+<translation id="55737423895878184">允許分享位置資訊和顯示通知</translation>
+<translation id="3988213473815854515">禁止存取位置資訊</translation>
+<translation id="32895400574683172">允許顯示通知</translation>
+<translation id="9040142327097499898">允許顯示通知。這部裝置的定位功能已關閉。</translation>
+<translation id="305593374596241526">定位功能已關閉，請在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中開啟這項功能。</translation>
+<translation id="2989523299700148168">最近造訪過</translation>
+<translation id="6433501201775827830">選擇搜尋引擎</translation>
+<translation id="7177466738963138057">日後可前往設定頁面進行變更</translation>
+<translation id="3478363558367712427">你可以選擇搜尋引擎</translation>
+<translation id="4910889077668685004">付款應用程式</translation>
+<translation id="5152843274749979095">尚未安裝系統支援的應用程式</translation>
+<translation id="8812260976093120287">在部分網站上，你可以在你的裝置上使用上述支援的付款應用程式付款。</translation>
+<translation id="7764225426217299476">新增地址</translation>
+<translation id="5595485650161345191">編輯地址</translation>
+<translation id="5087580092889165836">新增信用卡</translation>
+<translation id="2154484045852737596">編輯卡片資訊</translation>
+<translation id="6140912465461743537">國家/地區</translation>
+<translation id="5659593005791499971">電子郵件</translation>
+<translation id="4378154925671717803">電話</translation>
+<translation id="4807098396393229769">持卡人姓名</translation>
+<translation id="860043288473659153">持卡人姓名</translation>
+<translation id="2612676031748830579">卡號</translation>
+<translation id="869891660844655955">到期日</translation>
+<translation id="2286841657746966508">帳單地址</translation>
+<translation id="663059986967017181">已複製到 Brave</translation>
+<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> 種付款方式}other{<ph name="PAYMENT_METHOD_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS"/> 種付款方式}}</translation>
+<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> 個地址}other{<ph name="SHIPPING_ADDRESS_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES"/> 個地址}}</translation>
+<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> 種運送方式}other{<ph name="SHIPPING_OPTION_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS"/> 種運送方式}}</translation>
+<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> 個聯絡人}other{<ph name="CONTACT_PREVIEW"/>\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS"/> 個聯絡人}}</translation>
+<translation id="7029809446516969842">密碼</translation>
+<translation id="1943432128510653496">儲存密碼</translation>
+<translation id="2100273922101894616">自動登入</translation>
+<translation id="363596933471559332">自動使用已儲存的憑證登入網站。如果關閉這項功能，每次在您登入網站之前，網站一律會要求驗證。</translation>
+<translation id="6995899638241819463">當密碼因資料侵害事件遭到外洩時發出警告</translation>
+<translation id="1534287762301776620">登入 Brave Software 帳戶時，系統會啟用這項功能</translation>
+<translation id="10614374240317010">一律不儲存</translation>
+<translation id="3098842761938485917">你可以查看及管理 <ph name="BEGIN_LINK"/>Brave Software 帳戶<ph name="END_LINK"/>中儲存的密碼</translation>
+<translation id="8562452229998620586">已儲存的密碼會顯示在這裡。</translation>
+<translation id="8084114998886531721">已儲存的密碼</translation>
+<translation id="2870560284913253234">網站</translation>
+<translation id="8503813439785031346">使用者名稱</translation>
+<translation id="6657585470893396449">密碼</translation>
+<translation id="2154710561487035718">複製網址</translation>
+<translation id="1571304935088121812">複製使用者名稱</translation>
+<translation id="5005498671520578047">複製密碼</translation>
+<translation id="3632295766818638029">取消密碼遮罩</translation>
+<translation id="1513858653616922153">刪除密碼</translation>
+<translation id="543338862236136125">修改密碼</translation>
+<translation id="4565377596337484307">隱藏密碼</translation>
+<translation id="8523928698583292556">刪除已儲存的密碼</translation>
+<translation id="2898264748040935573">編輯已儲存的密碼</translation>
+<translation id="5433691172869980887">已複製使用者名稱</translation>
+<translation id="5534640966246046842">已複製網站</translation>
+<translation id="2625189173221582860">已複製密碼</translation>
+<translation id="4550003330909367850">如要在這裡查看或複製你的密碼，請為這個裝置設定螢幕鎖定功能。</translation>
+<translation id="6154478581116148741">在「設定」中開啟螢幕鎖定，即可從這部裝置匯出你的密碼</translation>
+<translation id="4842092870884894799">目前顯示的是密碼產生彈出式視窗</translation>
+<translation id="2259659629660284697">匯出密碼…</translation>
+<translation id="133012818630824069">將使用 Brave 儲存的密碼匯出</translation>
+<translation id="6914783257214138813">凡是可查看匯出的檔案的使用者都能看到你的密碼。</translation>
+<translation id="2321086116217818302">正在準備匯出密碼…</translation>
+<translation id="8445448999790540984">無法匯出密碼</translation>
+<translation id="3066461326500799725">瞭解如何使用 Brave Software 雲端硬碟</translation>
+<translation id="729975465115245577">你的裝置沒有可儲存密碼檔案的應用程式。</translation>
+<translation id="7682724950699840886">請嘗試按照下列提示操作：確認你的裝置上有足夠空間，然後嘗試重新匯出。</translation>
+<translation id="1129510026454351943">詳細資料：<ph name="ERROR_DESCRIPTION"/></translation>
+<translation id="6891726759199484455">解鎖即可複製你的密碼</translation>
+<translation id="5515439363601853141">解鎖即可查看你的密碼</translation>
+<translation id="6221633008163990886">解鎖即可匯出你的密碼</translation>
+<translation id="230699814587342492">Brave 密碼</translation>
+<translation id="6075798973483050474">編輯首頁</translation>
+<translation id="854522910157234410">開啟以下網頁</translation>
+<translation id="2482878487686419369">通知</translation>
+<translation id="6255999984061454636">內容建議</translation>
+<translation id="805047784848435650">根據你的瀏覽記錄獨家推薦</translation>
+<translation id="1041308826830691739">來自網站</translation>
+<translation id="395206256282351086">已停用搜尋與網站建議</translation>
+<translation id="257088987046510401">主題</translation>
+<translation id="4650364565596261010">系統預設</translation>
+<translation id="7588219262685291874">在裝置開啟「節約耗電量」後啟用深色主題</translation>
+<translation id="2760989362628427051">當裝置開啟深色主題或節約耗電量功能時，啟用深色主題</translation>
+<translation id="6381421346744604172">調暗網站顏色</translation>
+<translation id="5040262127954254034">隱私權</translation>
+<translation id="4991384657077828949">協助改善 Brave 安全性</translation>
+<translation id="1943176487615318915">為了偵測危險的應用程式和網站，Brave 會將你造訪的部分網頁網址、部分系統資訊以及部分網頁內容傳送給 Brave Software</translation>
+<translation id="3181954750937456830">安全瀏覽 (保護你和你的裝置不受危險網站攻擊)</translation>
+<translation id="7315322926489145388">當網站具有安全性風險時，Brave 會將你造訪的部分網頁網址傳送給 Brave Software</translation>
+<translation id="2063713494490388661">輕觸搜尋</translation>
+<translation id="2369463299479365221">不需離開網頁即可瞭解網站上的主題。「輕觸搜尋」可將特定字詞及其上下文內容傳送給 Brave Software 搜尋，並傳回定義、圖片、搜尋結果和其他詳細資料。
 
 如要調整搜尋字詞，直接長按即可選取。如要修正搜尋，請將面板滑動到最上方，再輕觸搜尋框。</translation>
-<translation id="4056223980640387499">深褐色調</translation>
-<translation id="4060598801229743805">選項位於畫面頂端</translation>
-<translation id="4062305924942672200">法律資訊</translation>
-<translation id="4084682180776658562">書籤</translation>
-<translation id="4084712963632273211">發布者：<ph name="PUBLISHER_ORIGIN" /> – <ph name="BEGIN_DEEMPHASIZED" />由 Google 所提供<ph name="END_DEEMPHASIZED" /></translation>
-<translation id="4095146165863963773">要刪除應用程式資料嗎？</translation>
-<translation id="4099578267706723511">將使用統計資料及當機報告傳送給 Google，助我們一臂之力，讓 Chrome 更臻完美。</translation>
-<translation id="410351446219883937">自動播放</translation>
-<translation id="4116038641877404294">下載網頁以便離線存取</translation>
-<translation id="4135200667068010335">要共用分頁的裝置清單已關閉。</translation>
-<translation id="4149994727733219643">使用簡易檢視模式查看網頁</translation>
-<translation id="4165986682804962316">網站設定</translation>
-<translation id="4169535189173047238">不允許</translation>
-<translation id="4170011742729630528">服務無法使用，請稍後再試。</translation>
-<translation id="4179980317383591987">已使用 <ph name="AMOUNT" /></translation>
-<translation id="4181841719683918333">語言</translation>
-<translation id="4183868528246477015">使用 Google 智慧鏡頭的搜尋功能 <ph name="BEGIN_NEW" />新功能<ph name="END_NEW" /></translation>
-<translation id="4195643157523330669">在新分頁中開啟</translation>
-<translation id="4198423547019359126">沒有可用的下載位置</translation>
-<translation id="4209895695669353772">如要取得個人化的 Google 推薦內容，請開啟同步處理功能</translation>
-<translation id="4226663524361240545">收到通知時裝置會震動</translation>
-<translation id="423219824432660969">使用你在 <ph name="TIME" />設定的 Google 密碼，加密保護同步資料</translation>
-<translation id="4242533952199664413">開啟設定</translation>
-<translation id="4256782883801055595">開放原始碼授權</translation>
-<translation id="4259722352634471385">瀏覽的網址已封鎖：<ph name="URL" /></translation>
-<translation id="4269820728363426813">複製連結網址</translation>
-<translation id="4275663329226226506">媒體</translation>
-<translation id="4278390842282768270">允許</translation>
-<translation id="429312253194641664">一個網站正在播放媒體內容</translation>
-<translation id="4298388696830689168">連結的網站</translation>
-<translation id="4307992518367153382">基本選項</translation>
-<translation id="4314815835985389558">管理同步功能資料</translation>
-<translation id="4351244548802238354">關閉對話方塊</translation>
-<translation id="4378154925671717803">電話</translation>
-<translation id="4384468725000734951">現已使用 Sogou 搜尋</translation>
-<translation id="4404568932422911380">沒有書籤</translation>
-<translation id="4405224443901389797">移至…</translation>
-<translation id="4411535500181276704">精簡模式</translation>
-<translation id="4415276339145661267">管理你的 Google 帳戶</translation>
-<translation id="4432792777822557199">從現在起，系統會將<ph name="SOURCE_LANGUAGE" />網頁內容翻譯成<ph name="TARGET_LANGUAGE" /></translation>
-<translation id="4433925000917964731">由 Google 提供的精簡版網頁</translation>
-<translation id="4434045419905280838">彈出式視窗與重新導向</translation>
-<translation id="4440958355523780886">由 Google 提供的精簡版網頁。輕觸即可載入原始網頁。</translation>
-<translation id="4452411734226507615">關閉 [<ph name="TAB_TITLE" />] 分頁</translation>
-<translation id="4452548195519783679">已將書籤加入「<ph name="FOLDER_NAME" />」</translation>
-<translation id="445467742685312942">允許網站播放受保護的內容</translation>
-<translation id="4468959413250150279">將特定網站設為靜音。</translation>
-<translation id="4472118726404937099">如要進行同步處理並在所有裝置上享有個人化的體驗，請登入並開啟同步處理功能</translation>
-<translation id="447252321002412580">協助改善 Chrome 的功能與效能</translation>
-<translation id="4479647676395637221">允許網站使用你的攝影機前，必須先詢問你 (建議)</translation>
-<translation id="4479972344484327217">正在為 Chrome 安裝 <ph name="MODULE" />…</translation>
-<translation id="4487967297491345095">Chrome 的應用程式資料會全部遭到永久刪除，包括所有檔案、設定、帳戶、資料庫等等。</translation>
-<translation id="4493497663118223949">精簡模式已開啟</translation>
-<translation id="4513387527876475750">{DAYS,plural, =1{# 天前}other{# 天前}}</translation>
-<translation id="451872707440238414">搜尋書籤</translation>
-<translation id="4521489764227272523">系統已將你所選取的資料從 Chrome 和其他同步的裝置中移除。
-
-你的 Google 帳戶仍可能保留了其他類型的瀏覽記錄，例如其他 Google 服務中的搜尋和活動記錄 (可前往 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" /> 查詢)。</translation>
-<translation id="4532845899244822526">選擇資料夾</translation>
-<translation id="4538018662093857852">開啟精簡模式</translation>
-<translation id="4550003330909367850">如要在這裡查看或複製你的密碼，請為這個裝置設定螢幕鎖定功能。</translation>
-<translation id="4558311620361989323">網頁快速鍵</translation>
-<translation id="4561979708150884304">沒有網路連線</translation>
-<translation id="4565377596337484307">隱藏密碼</translation>
-<translation id="4570913071927164677">詳細資料</translation>
-<translation id="4572422548854449519">登入受管理的帳戶</translation>
-<translation id="4583164079174244168">{MINUTES,plural, =1{# 分鐘前}other{# 分鐘前}}</translation>
-<translation id="4587589328781138893">網站</translation>
-<translation id="4594952190837476234">這個離線版網頁是於 <ph name="CREATION_TIME" />建立，可能會和線上版本有所不同。</translation>
-<translation id="4605958867780575332">已移除項目：<ph name="ITEM_TITLE" /></translation>
-<translation id="4616150815774728855">開啟 <ph name="WEBAPK_NAME" /></translation>
-<translation id="4634124774493850572">使用密碼</translation>
-<translation id="4645575059429386691">你的家長已停用這項功能</translation>
-<translation id="4650364565596261010">系統預設</translation>
-<translation id="4663756553811254707">已刪除 <ph name="NUMBER_OF_BOOKMARKS" /> 個書籤</translation>
-<translation id="4665282149850138822">「<ph name="NAME" />」已加入您的主畫面</translation>
-<translation id="4684427112815847243">同步處理所有資料</translation>
-<translation id="4695891336199304370">{SHIPPING_OPTIONS,plural, =1{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> 種運送方式}other{<ph name="SHIPPING_OPTION_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_SHIPPING_OPTIONS" /> 種運送方式}}</translation>
-<translation id="4696983787092045100">將文字傳送到你的裝置</translation>
-<translation id="4698034686595694889">在「<ph name="APP_NAME" />」中離線瀏覽</translation>
-<translation id="4699172675775169585">快取圖片和檔案</translation>
-<translation id="4714588616299687897">最多可減少 60% 的數據流量</translation>
-<translation id="4719927025381752090">提供翻譯</translation>
-<translation id="4720023427747327413">在 <ph name="PRODUCT_NAME" /> 中開啟</translation>
-<translation id="4720982865791209136">想要協助改善 Chrome 嗎？<ph name="BEGIN_LINK" />請填寫這份問卷調查<ph name="END_LINK" /></translation>
-<translation id="473775607612524610">更新</translation>
-<translation id="4738836084190194332">上次同步處理時間：<ph name="WHEN" /></translation>
-<translation id="4749960740855309258">開啟新分頁</translation>
-<translation id="4751476147751820511">動作或光源感應器</translation>
-<translation id="4759238208242260848">下載</translation>
-<translation id="4763829664323285145">{FILE_COUNT,plural, =1{已完成 1 項下載作業。}other{已完成 # 項下載作業。}}</translation>
-<translation id="4797039098279997504">輕觸即可返回 <ph name="URL_OF_THE_CURRENT_TAB" /></translation>
-<translation id="4802417911091824046">通關密語加密保護的資料不包括 Google Pay 的付款方式和地址。
-
-如要變更這項設定，請<ph name="BEGIN_LINK" />重設同步功能<ph name="END_LINK" /></translation>
-<translation id="4807098396393229769">持卡人姓名</translation>
-<translation id="4824958205181053313">取消同步處理？</translation>
-<translation id="4837753911714442426">開啟列印網頁的選項</translation>
-<translation id="4842092870884894799">目前顯示的是密碼產生彈出式視窗</translation>
-<translation id="4860895144060829044">撥號</translation>
-<translation id="4866368707455379617">無法為 Chrome 安裝 <ph name="MODULE" /></translation>
-<translation id="4875775213178255010">內容建議</translation>
-<translation id="4878404682131129617">無法透過 Proxy 伺服器建立通道</translation>
-<translation id="4880127995492972015">翻譯...</translation>
-<translation id="4881695831933465202">開啟</translation>
-<translation id="488187801263602086">重新命名檔案</translation>
-<translation id="4882831918239250449">控制 Google 使用瀏覽記錄提供個人化搜尋服務、廣告和其他內容的方式</translation>
-<translation id="4883854917563148705">無法重設受管理的設定</translation>
-<translation id="4885273946141277891">Chrome 實例的數量已超出上限。</translation>
-<translation id="4910889077668685004">付款應用程式</translation>
-<translation id="4913161338056004800">重設統計資料</translation>
-<translation id="4913169188695071480">停止重新整理</translation>
-<translation id="4915549754973153784"><ph name="BEGIN_LINK" />查看說明<ph name="END_LINK" />。正在掃描裝置…</translation>
-<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# 個網頁}other{# 個網頁}}</translation>
-<translation id="4932247056774066048">你即將登出由 <ph name="DOMAIN_NAME" /> 管理的帳戶，因此系統會將你的 Chrome 資料從這個裝置上刪除，但是這些資料會繼續保留在你的 Google 帳戶中。</translation>
-<translation id="4943703118917034429">虛擬實境</translation>
-<translation id="4943872375798546930">沒有結果</translation>
-<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB" /> 正在共用你的畫面。</translation>
-<translation id="4961107849584082341">將這個網頁翻譯成任何語言</translation>
-<translation id="4962975101802056554">撤銷裝置的所有權限</translation>
-<translation id="4970824347203572753">你所在的地區無法使用這項功能</translation>
-<translation id="497421865427891073">往前</translation>
-<translation id="4988210275050210843">正在下載檔案 (<ph name="MEGABYTES" />)。</translation>
-<translation id="4988526792673242964">網頁</translation>
-<translation id="4994033804516042629">找不到任何聯絡人</translation>
-<translation id="4996978546172906250">分享方式：</translation>
-<translation id="5004416275253351869">Google 活動控制項</translation>
-<translation id="5005498671520578047">複製密碼</translation>
-<translation id="5011311129201317034"><ph name="SITE" /> 要求連線</translation>
-<translation id="5013696553129441713">沒有新的建議</translation>
-<translation id="5016205925109358554">Serif</translation>
-<translation id="5033865233969348410">當你處於 VR 模式時，這個網站可能會取得以下資訊：
-  -  你的身體特徵，例如身高
-
-進入 VR 模式之前，請確認你信任這個網站。</translation>
+<translation id="2930742481329940825">「輕觸搜尋」會將選取的字詞和目前所在的網頁 (以便比對內容) 傳送給 Brave Software 搜尋。你可以在<ph name="BEGIN_LINK"/>設定<ph name="END_LINK"/>中關閉這項功能。</translation>
 <translation id="5039804452771397117">允許</translation>
-<translation id="5040262127954254034">隱私權</translation>
-<translation id="5048398596102334565">允許網站存取動作感應器 (建議)</translation>
-<translation id="5063480226653192405">用量</translation>
-<translation id="5087580092889165836">新增信用卡</translation>
-<translation id="5100237604440890931">已收合 - 按一下即可展開。</translation>
-<translation id="510275257476243843">還剩 1 小時</translation>
-<translation id="5123685120097942451">無痕式分頁</translation>
-<translation id="5127805178023152808">同步功能已停用</translation>
-<translation id="5129038482087801250">安裝網路應用程式</translation>
-<translation id="5132942445612118989">同步處理你所有裝置上的密碼、歷史記錄和其他設定</translation>
-<translation id="5139940364318403933">瞭解如何使用 Google 雲端硬碟</translation>
-<translation id="515227803646670480">清除儲存的資料</translation>
-<translation id="5152843274749979095">尚未安裝系統支援的應用程式</translation>
-<translation id="5161254044473106830">請輸入標題</translation>
-<translation id="5162754098604580781">{FILE_COUNT,plural, =1{無法完成 1 項下載作業。}other{無法完成 # 項下載作業。}}</translation>
-<translation id="5170568018924773124">在資料夾中顯示</translation>
-<translation id="5184329579814168207">在 Chrome 中開啟</translation>
-<translation id="5193988420012215838">已複製到剪貼簿</translation>
-<translation id="5197729504361054390">系統會將你選取的聯絡人資訊提供給 <ph name="BEGIN_BOLD" /><ph name="SITE" /><ph name="END_BOLD" />。</translation>
-<translation id="5199929503336119739">工作資料夾</translation>
-<translation id="5210286577605176222">跳至上一個分頁</translation>
-<translation id="5210365745912300556">關閉分頁</translation>
-<translation id="5224771365102442243">含有影片</translation>
-<translation id="5230560987958996918"><ph name="SITE" /> 要求掃描附近的藍牙裝置。已找到下列裝置：</translation>
-<translation id="5233638681132016545">新增分頁</translation>
-<translation id="526421993248218238">無法載入這個網頁</translation>
-<translation id="5271967389191913893">裝置無法開啟您要下載的這項內容。</translation>
-<translation id="528192093759286357">從頂端拖曳並輕觸返回按鈕即可結束全螢幕模式。</translation>
-<translation id="5292796745632149097">傳送到</translation>
-<translation id="5300589172476337783">顯示</translation>
-<translation id="5301954838959518834">好，我知道了</translation>
-<translation id="5304593522240415983">這個欄位不能留空</translation>
-<translation id="5307446750509046227">清除網站儲存的資料</translation>
-<translation id="5308380583665731573">連線</translation>
-<translation id="5313967007315987356">新增網站</translation>
-<translation id="5317780077021120954">儲存</translation>
-<translation id="5324858694974489420">家長設定</translation>
-<translation id="5327248766486351172">名稱</translation>
-<translation id="5335288049665977812">允許網站執行 JavaScript (建議)</translation>
-<translation id="5342314432463739672">權限要求</translation>
-<translation id="5357811892247919462">已收到分頁</translation>
-<translation id="5368958499335451666">{OPEN_TABS,plural, =1{已開啟 <ph name="OPEN_TABS_ONE" /> 個分頁，輕觸即可切換分頁}other{已開啟 <ph name="OPEN_TABS_MANY" /> 個分頁，輕觸即可切換分頁}}</translation>
-<translation id="5391532827096253100">你與這個網站的連線不安全。網站資訊</translation>
-<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(還有 1 個)}other{(還有 # 個)}}</translation>
-<translation id="5400569084694353794">使用這個應用程式即表示您同意接受 Chrome 的《<ph name="BEGIN_LINK1" />服務條款<ph name="END_LINK1" />》和《<ph name="BEGIN_LINK2" />隱私權聲明<ph name="END_LINK2" />》。</translation>
-<translation id="5403592356182871684">名稱</translation>
-<translation id="5403644198645076998">只允許特定網站</translation>
-<translation id="5414836363063783498">驗證中…</translation>
-<translation id="5423934151118863508">這裡會顯示您最常造訪的網頁</translation>
-<translation id="5424588387303617268">可用空間：<ph name="GIGABYTES" /> GB</translation>
-<translation id="543338862236136125">修改密碼</translation>
-<translation id="5433691172869980887">已複製使用者名稱</translation>
-<translation id="543509235395288790">正在下載 <ph name="COUNT" /> 個檔案 (共 <ph name="MEGABYTES" /> MB)。</translation>
-<translation id="5441522332038954058">切換到網址列</translation>
-<translation id="5447201525962359567">所有網站儲存的資料，包括 Cookie 和其他儲存在本機上的資料</translation>
-<translation id="5447765697759493033">系統不會翻譯這個網站</translation>
-<translation id="545042621069398927">正在加快下載速度。</translation>
-<translation id="5456381639095306749">下載網頁</translation>
-<translation id="5475862044948910901">要啟動擴增實境工作階段嗎？</translation>
-<translation id="548278423535722844">在地圖應用程式中開啟</translation>
-<translation id="5487521232677179737">清除資料</translation>
-<translation id="5494752089476963479">封鎖干擾性或誤導性的網站廣告</translation>
-<translation id="5500777121964041360">你所在的地區可能不支援這項功能</translation>
-<translation id="5512137114520586844">這個帳戶受 <ph name="PARENT_NAME" /> 管理。</translation>
-<translation id="5514904542973294328">裝置管理員已停用</translation>
-<translation id="5515439363601853141">解鎖即可查看你的密碼</translation>
-<translation id="5516455585884385570">開啟通知設定</translation>
-<translation id="5517095782334947753">你有來自 <ph name="FROM_ACCOUNT" /> 的書籤、歷史記錄、密碼和其他設定。</translation>
-<translation id="5524843473235508879">已禁止重新導向。</translation>
-<translation id="5527082711130173040">Chrome 需要位置資訊存取權才能掃描裝置。<ph name="BEGIN_LINK1" />更新權限<ph name="END_LINK1" />。此外，<ph name="BEGIN_LINK2" />這個裝置的位置資訊存取權已關閉<ph name="END_LINK2" />。</translation>
-<translation id="5527111080432883924">允許網站讀取剪貼簿中的文字和圖片前，必須先詢問你 (建議)</translation>
-<translation id="5530766185686772672">關閉無痕式分頁</translation>
-<translation id="5534334044554683961">當你處於 VR 模式時，這個網站可能會取得以下資訊：
-  -   你的身體特徵，例如身高
-  -   你的房間配置
-
-進入 VR 模式之前，請確認你信任這個網站。.</translation>
-<translation id="5534640966246046842">已複製網站</translation>
-<translation id="5556459405103347317">重新載入</translation>
-<translation id="5561549206367097665">正在等待網路連線…</translation>
-<translation id="557283862590186398">Chrome 需要相關權限，才能讓這個網站使用你的麥克風。</translation>
-<translation id="55737423895878184">允許分享位置資訊和顯示通知</translation>
-<translation id="5578795271662203820">透過 <ph name="SEARCH_ENGINE" /> 搜尋這張圖片</translation>
-<translation id="5581519193887989363">你隨時可以在<ph name="BEGIN_LINK1" />設定<ph name="END_LINK1" />中選擇要同步處理的資料。</translation>
-<translation id="5595485650161345191">編輯地址</translation>
-<translation id="5596627076506792578">更多選項</translation>
-<translation id="5599455543593328020">無痕模式</translation>
-<translation id="5620928963363755975">透過「更多選項」按鈕前往「下載」主畫面尋找你的檔案和網頁</translation>
-<translation id="5626134646977739690">名稱：</translation>
-<translation id="5639724618331995626">允許所有網站</translation>
-<translation id="5648166631817621825">過去 7 天</translation>
-<translation id="5649053991847567735">自動下載</translation>
-<translation id="5655963694829536461">搜尋下載內容</translation>
-<translation id="5659593005791499971">電子郵件</translation>
-<translation id="5665379678064389456">在「<ph name="APP_NAME" />」中建立活動</translation>
-<translation id="5668404140385795438">覆寫網站禁止放大的要求</translation>
-<translation id="5677928146339483299">已封鎖</translation>
-<translation id="5684874026226664614">糟糕！系統無法翻譯這個網頁的內容。</translation>
-<translation id="5686790454216892815">檔案名稱過長</translation>
-<translation id="5689516760719285838">位置</translation>
-<translation id="569536719314091526">透過 [更多選項] 按鈕將這個網頁翻譯成任何語言</translation>
-<translation id="572328651809341494">最近開啟的分頁</translation>
-<translation id="5726692708398506830">放大網頁上的所有內容</translation>
-<translation id="5748802427693696783">已切換成標準分頁</translation>
-<translation id="5749068826913805084">Chrome 必須取得儲存空間的存取權才能下載檔案。</translation>
-<translation id="5763382633136178763">無痕式分頁</translation>
-<translation id="5763514718066511291">輕觸即可複製這個應用程式的網址</translation>
-<translation id="5765780083710877561">說明：</translation>
-<translation id="5793665092639000975">使用量：<ph name="SPACE_USED" /> (共 <ph name="SPACE_AVAILABLE" />)</translation>
-<translation id="5797070761912323120">Google 可能會使用你的歷史記錄，為你提供個人化的搜尋服務、廣告內容和其他各項 Google 服務</translation>
-<translation id="5804241973901381774">權限</translation>
-<translation id="5809361687334836369">{HOURS,plural, =1{# 小時前}other{# 小時前}}</translation>
-<translation id="5810288467834065221">Copyright <ph name="YEAR" /> Google LLC. 保留所有權利。</translation>
-<translation id="5817918615728894473">配對</translation>
-<translation id="583281660410589416">未知</translation>
-<translation id="5833984609253377421">分享連結</translation>
-<translation id="5836192821815272682">正在下載 Chrome 更新…</translation>
-<translation id="5853623416121554550">已暫停</translation>
-<translation id="5854790677617711513">超過 30 天前</translation>
-<translation id="5858741533101922242">Chrome 無法開啟藍牙轉接器</translation>
-<translation id="5860033963881614850">關閉</translation>
-<translation id="5862731021271217234">如要存取你在其他裝置上開啟的分頁，請開啟同步處理功能</translation>
-<translation id="5864174910718532887">詳細資料：依網站名稱排序</translation>
-<translation id="5864419784173784555">正在等待其他下載程序完成…</translation>
-<translation id="5865733239029070421">自動將使用統計資料和當機報告傳送給 Google</translation>
-<translation id="5869522115854928033">已儲存的密碼</translation>
-<translation id="5902828464777634901">即將刪除這個網站儲存的所有本機資料 (包括 Cookie 在內)。</translation>
-<translation id="5916664084637901428">開啟</translation>
-<translation id="5919204609460789179">更新 <ph name="PRODUCT_NAME" /> 即可開始同步處理</translation>
-<translation id="5937580074298050696">已儲存 <ph name="AMOUNT" /></translation>
-<translation id="5939518447894949180">重設</translation>
-<translation id="5942872142862698679">現已使用 Google 搜尋</translation>
-<translation id="5952764234151283551">將你嘗試瀏覽的網頁網址傳送給 Google</translation>
-<translation id="5956665950594638604">在新分頁中開啟 Chrome 說明中心</translation>
-<translation id="5958275228015807058">前往「下載」主畫面尋找你的檔案和網頁</translation>
-<translation id="5962718611393537961">輕觸即可收合</translation>
-<translation id="6000066717592683814">繼續使用 Google</translation>
-<translation id="6005538289190791541">建議的密碼</translation>
-<translation id="6036057147555329831">其他 ICU</translation>
-<translation id="6039379616847168523">跳至下一個分頁</translation>
-<translation id="6040143037577758943">關閉</translation>
-<translation id="6042308850641462728">更多</translation>
-<translation id="604996488070107836">發生不明錯誤，因此無法下載 <ph name="FILE_NAME" />。</translation>
-<translation id="605721222689873409">年</translation>
-<translation id="6064125863973209585">下載完成</translation>
-<translation id="6075798973483050474">編輯首頁</translation>
-<translation id="60923314841986378">還剩 <ph name="HOURS" /> 小時</translation>
-<translation id="6108923351542677676">設定中…</translation>
-<translation id="6111020039983847643">(已使用的數據量)</translation>
-<translation id="6112702117600201073">重新整理網頁</translation>
-<translation id="6127379762771434464">已移除項目</translation>
-<translation id="6140912465461743537">國家/地區</translation>
-<translation id="614940544461990577">建議做法：</translation>
-<translation id="6154478581116148741">在「設定」中開啟螢幕鎖定，即可從這部裝置匯出你的密碼</translation>
-<translation id="6159335304067198720">節省 <ph name="PERCENT" /> 的數據流量</translation>
-<translation id="6165508094623778733">瞭解詳情</translation>
-<translation id="6177111841848151710">禁止目前的搜尋引擎存取位置資訊</translation>
-<translation id="6181444274883918285">新增例外網站</translation>
-<translation id="6192333916571137726">下載檔案</translation>
-<translation id="6192792657125177640">例外</translation>
-<translation id="6194112207524046168">如要讓 Chrome 存取你的相機，請一併在 <ph name="BEGIN_LINK" />Android 設定<ph name="END_LINK" />中開啟相機。</translation>
-<translation id="6196640612572343990">封鎖第三方 Cookie</translation>
-<translation id="6206551242102657620">已建立安全連線。網站資訊</translation>
-<translation id="6210748933810148297">不是 <ph name="EMAIL" /> 嗎？</translation>
-<translation id="6221633008163990886">解鎖即可匯出你的密碼</translation>
+<translation id="1406000523432664303">「不追蹤」</translation>
 <translation id="6232535412751077445">啟用「不追蹤」選項後，您的瀏覽流量會置入一項特定的要求，其作用則視網站是否回應要求，以及網站解讀要求的方式而定。
 
 舉例來說，部分網站可能會以顯示廣告的方式回應這類要求，而這些廣告並非根據您所造訪的其他網站記錄而產生。許多網站仍會收集您的瀏覽資料，並將這些資料用於下列目的：提高網站安全性、在網站上提供更相關的內容、廣告和推薦項目，以及產生報告統計資料。</translation>
-<translation id="624789221780392884">可進行更新</translation>
-<translation id="6255999984061454636">內容建議</translation>
-<translation id="6277522088822131679">列印網頁時發生問題，請再試一次。</translation>
-<translation id="6295158916970320988">所有網站</translation>
-<translation id="629730747756840877">帳戶</translation>
-<translation id="6303969859164067831">登出並關閉同步處理功能</translation>
-<translation id="6316139424528454185">系統不支援目前的 Android 版本</translation>
-<translation id="6320088164292336938">震動</translation>
-<translation id="6324034347079777476">Android 系統同步處理功能已停用</translation>
-<translation id="6333140779060797560">透過 <ph name="APPLICATION" /> 分享</translation>
-<translation id="6337234675334993532">加密</translation>
-<translation id="6341580099087024258">詢問檔案儲存位置</translation>
-<translation id="6343495912647200061">{SHIPPING_ADDRESS,plural, =1{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> 個地址}other{<ph name="SHIPPING_ADDRESS_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_ADDRESSES" /> 個地址}}</translation>
-<translation id="6364438453358674297">從歷史記錄中移除建議項目？</translation>
-<translation id="6369229450655021117">在這裡，你可以搜尋網路、與好友分享內容及查看開啟的網頁</translation>
-<translation id="6378173571450987352">詳細資料：依使用資料量排序</translation>
-<translation id="6381421346744604172">調暗網站顏色</translation>
-<translation id="6388207532828177975">清除並重設</translation>
-<translation id="6393863479814692971">Chrome 需要相關權限，才能讓這個網站使用你的攝影機和麥克風。</translation>
-<translation id="6395288395575013217">連結</translation>
-<translation id="6404511346730675251">編輯書籤</translation>
-<translation id="6406506848690869874">同步</translation>
-<translation id="641643625718530986">列印…</translation>
-<translation id="6416782512398055893">已下載 <ph name="MBS" /> MB</translation>
-<translation id="6427112570124116297">翻譯網頁</translation>
-<translation id="6433501201775827830">選擇搜尋引擎</translation>
-<translation id="6437478888915024427">頁面資訊</translation>
-<translation id="6441734959916820584">這個名稱太長</translation>
-<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# 張圖片}other{# 張圖片}}</translation>
-<translation id="6447842834002726250">Cookie</translation>
-<translation id="6461962085415701688">無法開啟檔案</translation>
-<translation id="6464977750820128603">你可以查看自己透過 Chrome 造訪的網站，並對這些網站設定計時器。\n\nGoogle 會收到這些設有計時器的網站相關資訊以及你的造訪時間長度。這些資訊可協助我們改善數位健康。</translation>
-<translation id="6475951671322991020">下載影片</translation>
-<translation id="6482749332252372425">儲存空間不足，因此無法下載 <ph name="FILE_NAME" />。</translation>
-<translation id="6496823230996795692">初次使用「<ph name="APP_NAME" />」時請連線至網際網路。</translation>
-<translation id="6508722015517270189">重新啟動 Chrome</translation>
-<translation id="6527303717912515753">分享</translation>
-<translation id="6532866250404780454">數位健康將不會顯示你透過 Chrome 造訪的網站。所有網站計時器也將遭到刪除。</translation>
-<translation id="6534565668554028783">Google 的回應時間過長</translation>
-<translation id="6538442820324228105">已下載 <ph name="GBS" /> GB</translation>
-<translation id="6539092367496845964">發生錯誤，請稍後再試。</translation>
-<translation id="654446541061731451">選取要傳輸的分頁</translation>
-<translation id="6545017243486555795">清除所有資料</translation>
-<translation id="6545864417968258051">藍牙掃描</translation>
-<translation id="6560414384669816528">使用 Sogou 搜尋</translation>
-<translation id="6566259936974865419">Chrome 為你節省了 <ph name="GIGABYTES" /> GB</translation>
-<translation id="6573096386450695060">一律允許</translation>
-<translation id="6573431926118603307">您在其他裝置上透過 Chrome 開啟的分頁會顯示在這裡。</translation>
-<translation id="6583199322650523874">將目前的網頁加入書籤</translation>
-<translation id="6593061639179217415">電腦版網站</translation>
-<translation id="6600954340915313787">已複製到 Chrome</translation>
-<translation id="6608650720463149374"><ph name="GIGABYTES" /> GB</translation>
-<translation id="6612358246767739896">受保護內容</translation>
-<translation id="6627583120233659107">編輯資料夾</translation>
-<translation id="6643016212128521049">清除</translation>
-<translation id="6643649862576733715">依儲存資料量排序</translation>
-<translation id="6648977384226967773">{CONTACT,plural, =1{<ph name="CONTACT_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> 個聯絡人}other{<ph name="CONTACT_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_CONTACTS" /> 個聯絡人}}</translation>
-<translation id="6649642165559792194">預覽圖片 <ph name="BEGIN_NEW" />新功能<ph name="END_NEW" /></translation>
-<translation id="6656545060687952787">Chrome 需要位置資訊存取權才能掃描裝置。<ph name="BEGIN_LINK" />更新權限<ph name="END_LINK" /></translation>
-<translation id="6657585470893396449">密碼</translation>
-<translation id="6659594942844771486">Tab</translation>
-<translation id="666731172850799929">在「<ph name="APP_NAME" />」中開啟</translation>
-<translation id="666981079809192359">Chrome 隱私權聲明</translation>
-<translation id="6676840375528380067">要清除你在這個裝置上的 Chrome 資料嗎？</translation>
-<translation id="6697492270171225480">找不到網頁時顯示類似的網頁建議</translation>
-<translation id="6697947395630195233">Chrome 需要位置資訊存取權，才能與這個網站分享你的位置資訊。</translation>
-<translation id="6698801883190606802">管理同步資料</translation>
-<translation id="6699370405921460408">Google 伺服器會針對你造訪的網頁進行最佳化處理。</translation>
-<translation id="6706288973712894588">你目前已離線。\n<ph name="BEGIN_LINK" />瀏覽離線動態消息。<ph name="END_LINK" /></translation>
-<translation id="6709133671862442373">新聞內容</translation>
-<translation id="6710213216561001401">返回</translation>
-<translation id="671481426037969117">「<ph name="FQDN" />」計時器已結束計時，將於明天重新開始。</translation>
-<translation id="6738867403308150051">下載中…</translation>
-<translation id="6746124502594467657">下移</translation>
-<translation id="6766622839693428701">向下滑動即可關閉。</translation>
-<translation id="6766758767654711248">輕觸即可前往網站</translation>
-<translation id="6767294960381293877">要共用分頁的裝置清單已開啟，顯示在畫面下半部。</translation>
-<translation id="6782111308708962316">禁止第三方網站儲存及讀取 Cookie 資料</translation>
-<translation id="6790428901817661496">播放</translation>
-<translation id="6811034713472274749">你可以瀏覽這個網頁了</translation>
-<translation id="6818926723028410516">選取項目</translation>
-<translation id="6820686453637990663">CVC</translation>
-<translation id="6831043979455480757">翻譯</translation>
-<translation id="6845325883481699275">協助改善 Chrome 安全性</translation>
-<translation id="6846298663435243399">載入中…</translation>
-<translation id="6850409657436465440">下載作業仍在進行中</translation>
-<translation id="6850830437481525139">關閉了 <ph name="TAB_COUNT" /> 個分頁</translation>
-<translation id="6864459304226931083">下載圖片</translation>
-<translation id="6865313869410766144">自動填入表單資料</translation>
-<translation id="688738109438487280">將現有資料新增至 <ph name="TO_ACCOUNT" />。</translation>
-<translation id="6891726759199484455">解鎖即可複製你的密碼</translation>
-<translation id="6896758677409633944">複製</translation>
-<translation id="6910211073230771657">已刪除</translation>
-<translation id="6912998170423641340">禁止網站讀取剪貼簿中的文字和圖片</translation>
-<translation id="6914783257214138813">凡是可查看匯出的檔案的使用者都能看到你的密碼。</translation>
-<translation id="6942665639005891494">你隨時可以使用 [設定] 選單選項變更預設的下載位置</translation>
-<translation id="6945221475159498467">選取</translation>
-<translation id="6963642900430330478">這個網頁不安全。網站資訊</translation>
-<translation id="6963766334940102469">刪除書籤</translation>
-<translation id="6965382102122355670">確定</translation>
-<translation id="6979737339423435258">不限時間</translation>
-<translation id="6981982820502123353">無障礙設定</translation>
-<translation id="6989267951144302301">無法下載</translation>
-<translation id="6990079615885386641">從 Google Play 商店取得應用程式：<ph name="APP_ACTION" /></translation>
-<translation id="6992289844737586249">允許網站使用你的麥克風前，必須先詢問你 (建議)</translation>
-<translation id="7015203776128479407">尚未完成初始同步處理設定。已關閉同步功能。</translation>
-<translation id="7016516562562142042">允許目前的搜尋引擎存取位置資訊</translation>
-<translation id="7022756207310403729">在瀏覽器中開啟</translation>
-<translation id="702463548815491781">建議在 TalkBack 或開關功能開啟時使用</translation>
-<translation id="7029809446516969842">密碼</translation>
-<translation id="7053983685419859001">封鎖</translation>
-<translation id="7055152154916055070">已禁止重新導向：</translation>
-<translation id="7063006564040364415">無法連線至同步處理伺服器。</translation>
-<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{已選取 1 個項目}other{已選取 # 個項目}}</translation>
-<translation id="7071521146534760487">管理帳戶</translation>
-<translation id="7077143737582773186">SD 卡</translation>
-<translation id="7087918508125750058">已選取 <ph name="ITEM_COUNT" /> 個項目。選項位於畫面頂端</translation>
-<translation id="7121362699166175603">將歷史記錄和自動即時查詢從網址列中清除。你的 Google 帳戶可能會儲存其他形式的瀏覽記錄，請參閱 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />。</translation>
-<translation id="7128222689758636196">允許目前的搜尋引擎使用此權限</translation>
-<translation id="7138678301420049075">其他</translation>
-<translation id="7141896414559753902">禁止網站顯示彈出式視窗及重新導向 (建議)</translation>
-<translation id="7149158118503947153">從 <ph name="DOMAIN_NAME" /> <ph name="BEGIN_LINK" />載入原始頁面<ph name="END_LINK" /></translation>
-<translation id="7149893636342594995">過去 24 小時</translation>
-<translation id="7176368934862295254"><ph name="KILOBYTES" /> KB</translation>
-<translation id="7177466738963138057">日後可前往設定頁面進行變更</translation>
-<translation id="7180611975245234373">重新整理</translation>
-<translation id="7189372733857464326">正在等待 Google Play 服務完成更新</translation>
-<translation id="7191430249889272776">已在背景開啟分頁。</translation>
-<translation id="723171743924126238">選取圖片</translation>
-<translation id="7233236755231902816">如要以你偏好的語言查看網頁，請取得最新版本的 Chrome</translation>
-<translation id="7243308994586599757">選項在接近畫面底部的位置</translation>
-<translation id="7248069434667874558">請確認「<ph name="TARGET_DEVICE_NAME" />」的 Chrome 同步功能已開啟</translation>
-<translation id="7250468141469952378">已選取 <ph name="ITEM_COUNT" /> 個項目</translation>
-<translation id="7274013316676448362">已封鎖網站</translation>
-<translation id="7290209999329137901">無法重新命名</translation>
-<translation id="7291387454912369099">Google 助理自動填入功能</translation>
-<translation id="7293171162284876153">如要開始同步處理，請開啟「同步處理你的 Chrome 資料」。</translation>
-<translation id="729975465115245577">你的裝置沒有可儲存密碼檔案的應用程式。</translation>
-<translation id="7302081693174882195">詳細資料：依儲存資料量排序</translation>
-<translation id="7328017930301109123">使用精簡模式時，Chrome 可加快網頁載入速度，並可節省多達百分之 60 的數據用量。</translation>
-<translation id="7333031090786104871">仍在新增先前的網站</translation>
-<translation id="7352939065658542140">影片</translation>
-<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{分享 1 個選取的項目}other{分享 # 個選取的項目}}</translation>
 <translation id="7359002509206457351">存取付款方式</translation>
+<translation id="8026334261755873520">清除瀏覽資料</translation>
+<translation id="1291207594882862231">清除歷史記錄、Cookie、網站資料、快取…</translation>
+<translation id="7814200940910057384">已清除 Brave 資料</translation>
+<translation id="1664855196866195614">系統已將你所選取的資料從 Brave 和其他同步的裝置中移除。
+
+你的 Brave Software 帳戶仍可能保留了其他類型的瀏覽記錄，例如其他 Brave Software 服務中的搜尋和活動記錄 (可前往 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/> 查詢)。</translation>
+<translation id="4699172675775169585">快取圖片和檔案</translation>
+<translation id="2496180316473517155">瀏覽記錄</translation>
+<translation id="2546283357679194313">Cookie 和網站資料</translation>
+<translation id="8662811608048051533">大多數網站都會將你登出。</translation>
+<translation id="8218628800671693884">大多數網站都會將你登出，但系統並不會將你登出 Brave Software 帳戶。</translation>
+<translation id="2017836877785168846">將歷史記錄和自動即時查詢從網址列中清除。</translation>
+<translation id="8096327394278038498">將歷史記錄和自動即時查詢從網址列中清除。你的 Brave Software 帳戶可能會儲存其他形式的瀏覽記錄，請參閱 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>。</translation>
+<translation id="8122693181154564064">將歷史記錄從所有登入帳戶的裝置上清除。你的 Brave Software 帳戶可能會儲存其他形式的瀏覽記錄，請參閱 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>。</translation>
+<translation id="5869522115854928033">已儲存的密碼</translation>
+<translation id="6865313869410766144">自動填入表單資料</translation>
+<translation id="7562080006725997899">正在清除瀏覽資料</translation>
+<translation id="5487521232677179737">清除資料</translation>
+<translation id="7498271377022651285">請稍候…</translation>
+<translation id="784934925303690534">時間範圍</translation>
+<translation id="1718835860248848330">過去 1 小時</translation>
+<translation id="7149893636342594995">過去 24 小時</translation>
+<translation id="5648166631817621825">過去 7 天</translation>
+<translation id="8571213806525832805">過去 4 週</translation>
+<translation id="5854790677617711513">超過 30 天前</translation>
+<translation id="6979737339423435258">不限時間</translation>
+<translation id="982182592107339124">這會清除所有網站的資料，包括：</translation>
+<translation id="6643016212128521049">清除</translation>
+<translation id="7641339528570811325">清除瀏覽資料…</translation>
+<translation id="1670399744444387456">基本</translation>
+<translation id="3245261285041759672">你的 Brave Software 帳戶可能會儲存其他形式的瀏覽記錄，請參閱 <ph name="BEGIN_LINK"/>myactivity.google.com<ph name="END_LINK"/>。</translation>
+<translation id="7274013316676448362">已封鎖網站</translation>
+<translation id="2534155362429831547">已刪除 <ph name="NUMBER_OF_ITEMS"/> 個項目</translation>
+<translation id="1121094540300013208">使用資料和當機報告</translation>
+<translation id="9079153198295609735">自動傳送使用統計資料及當機報告給 Brave Software</translation>
+<translation id="6981982820502123353">無障礙設定</translation>
+<translation id="2387895666653383613">文字大小</translation>
+<translation id="2321958826496381788">拖曳滑桿，將文字調整到適當的字體大小。當你輕觸兩下文字段落時，瀏覽器至少應呈現這樣的字體大小。</translation>
+<translation id="3895926599014793903">強制啟用縮放功能</translation>
+<translation id="5668404140385795438">覆寫網站禁止放大的要求</translation>
+<translation id="4149994727733219643">使用簡易檢視模式查看網頁</translation>
+<translation id="9100505651305367705">詢問是否以簡易模式顯示支援這項功能的文章</translation>
+<translation id="1409426117486808224">使用簡易檢視模式查看開啟的分頁</translation>
+<translation id="702463548815491781">建議在 TalkBack 或開關功能開啟時使用</translation>
+<translation id="8284326494547611709">字幕</translation>
+<translation id="4165986682804962316">網站設定</translation>
+<translation id="6295158916970320988">所有網站</translation>
+<translation id="8380167699614421159">這個網站會顯示干擾性或誤導性的廣告</translation>
+<translation id="1919345977826869612">廣告</translation>
+<translation id="410351446219883937">自動播放</translation>
+<translation id="6447842834002726250">Cookie</translation>
+<translation id="6196640612572343990">封鎖第三方 Cookie</translation>
+<translation id="6782111308708962316">禁止第三方網站儲存及讀取 Cookie 資料</translation>
+<translation id="7521387064766892559">JavaScript</translation>
+<translation id="4434045419905280838">彈出式視窗與重新導向</translation>
+<translation id="4751476147751820511">動作或光源感應器</translation>
+<translation id="1717218214683051432">動作感應器</translation>
+<translation id="2091887806945687916">音訊</translation>
+<translation id="2586657967955657006">剪貼簿</translation>
+<translation id="6320088164292336938">震動</translation>
+<translation id="4226663524361240545">收到通知時裝置會震動</translation>
+<translation id="1446450296470737166">允許完整控制 MIDI 裝置</translation>
+<translation id="3744111561329211289">背景同步處理</translation>
+<translation id="5649053991847567735">自動下載</translation>
+<translation id="6181444274883918285">新增例外網站</translation>
+<translation id="5313967007315987356">新增網站</translation>
+<translation id="1369915414381695676">已新增 <ph name="SITE_NAME"/> 網站</translation>
+<translation id="7837721118676387834">允許特定網站自動播放靜音的影片。</translation>
+<translation id="2621115761605608342">允許特定網站執行 JavaScript。</translation>
+<translation id="8801436777607969138">封鎖特定網站的 JavaScript。</translation>
+<translation id="8372893542064058268">允許特定網站執行背景同步處理作業。</translation>
+<translation id="358794129225322306">允許網站自動下載多個檔案。</translation>
+<translation id="4008040567710660924">允許特定網站的 Cookie。</translation>
+<translation id="8958424370300090006">封鎖特定網站的 Cookie。</translation>
+<translation id="7882806643839505685">允許特定網站播放音訊。</translation>
+<translation id="4468959413250150279">將特定網站設為靜音。</translation>
+<translation id="1994173015038366702">網站網址</translation>
+<translation id="8941729603749328384">www.example.com</translation>
+<translation id="5063480226653192405">用量</translation>
+<translation id="5804241973901381774">權限</translation>
+<translation id="4278390842282768270">允許</translation>
+<translation id="5677928146339483299">已封鎖</translation>
+<translation id="1984937141057606926">允許 (第三方網站除外)</translation>
+<translation id="7423098979219808738">先詢問我</translation>
+<translation id="8116925261070264013">已設為靜音</translation>
+<translation id="8300705686683892304">由應用程式管理</translation>
+<translation id="6192792657125177640">例外</translation>
+<translation id="257931822824936280">已展開 - 按一下即可收合。</translation>
+<translation id="5100237604440890931">已收合 - 按一下即可展開。</translation>
+<translation id="857943718398505171">已允許 (建議)</translation>
+<translation id="2913331724188855103">允許網站儲存及讀取 Cookie 資料 (建議)</translation>
+<translation id="7445411102860286510">允許網站自動播放靜音的影片 (建議)</translation>
+<translation id="5335288049665977812">允許網站執行 JavaScript (建議)</translation>
+<translation id="5527111080432883924">允許網站讀取剪貼簿中的文字和圖片前，必須先詢問你 (建議)</translation>
+<translation id="6912998170423641340">禁止網站讀取剪貼簿中的文字和圖片</translation>
+<translation id="7423538860840206698">禁止讀取剪貼簿</translation>
+<translation id="3955193568934677022">允許網站播放受保護的內容 (建議)</translation>
+<translation id="445467742685312942">允許網站播放受保護的內容</translation>
+<translation id="2107397443965016585">允許網站播放受保護的內容前，必須先詢問你 (建議)</translation>
+<translation id="2910701580606108292">允許網站播放受保護的內容前，必須先詢問你</translation>
+<translation id="757524316907819857">禁止網站播放受保護的內容</translation>
+<translation id="3277252321222022663">允許網站存取感應器 (建議)</translation>
+<translation id="5048398596102334565">允許網站存取動作感應器 (建議)</translation>
+<translation id="8816026460808729765">禁止網站存取感應器</translation>
+<translation id="169515064810179024">禁止網站存取動作感應器</translation>
+<translation id="1660204651932907780">允許網站播放音訊 (建議)</translation>
+<translation id="3600792891314830896">將播放音訊的網站設為靜音</translation>
+<translation id="1743802530341753419">允許網站連線至裝置前，必須先詢問你 (建議)</translation>
+<translation id="851751545965956758">禁止網站連線至裝置</translation>
+<translation id="7141896414559753902">禁止網站顯示彈出式視窗及重新導向 (建議)</translation>
+<translation id="5494752089476963479">封鎖干擾性或誤導性的網站廣告</translation>
+<translation id="3123473560110926937">在某些網站上設定封鎖</translation>
+<translation id="965817943346481315">封鎖干擾性或誤導性的網站廣告 (建議)</translation>
+<translation id="3386292677130313581">允許網站存取你的位置資訊前，必須先詢問你 (建議)</translation>
+<translation id="9139068048179869749">允許網站傳送通知前，必須先詢問你 (建議)</translation>
+<translation id="4479647676395637221">允許網站使用你的攝影機前，必須先詢問你 (建議)</translation>
+<translation id="6992289844737586249">允許網站使用你的麥克風前，必須先詢問你 (建議)</translation>
+<translation id="2289270750774289114">當網站要搜尋附近的藍牙裝置時，必須先詢問你 (建議)</translation>
+<translation id="7053983685419859001">封鎖</translation>
+<translation id="7128222689758636196">允許目前的搜尋引擎使用此權限</translation>
+<translation id="7589445247086920869">禁止目前的搜尋引擎使用此權限</translation>
+<translation id="6388207532828177975">清除並重設</translation>
+<translation id="7999064672810608036">確定要刪除這個網站儲存的所有本機資料 (包括 Cookie 在內)，並重設這個網站的所有權限嗎？</translation>
+<translation id="2822354292072154809">確定要重設「<ph name="CHOSEN_OBJECT_NAME"/>」的所有網站權限嗎？</translation>
+<translation id="515227803646670480">清除儲存的資料</translation>
+<translation id="5902828464777634901">即將刪除這個網站儲存的所有本機資料 (包括 Cookie 在內)。</translation>
+<translation id="119944043368869598">全部清除</translation>
+<translation id="2490684707762498678">由 <ph name="APP_NAME"/> 管理</translation>
+<translation id="5516455585884385570">開啟通知設定</translation>
+<translation id="1404122904123200417">內嵌位置：<ph name="WEBSITE_URL"/></translation>
+<translation id="129382876167171263">網站儲存的檔案會顯示在這裡</translation>
+<translation id="4181841719683918333">語言</translation>
+<translation id="2647434099613338025">新增語言</translation>
+<translation id="1952172573699511566">Brave 會儘可能以你慣用的語言顯示網站文字。</translation>
+<translation id="8559990750235505898">詢問是否將網頁內容翻譯成其他語言</translation>
+<translation id="4719927025381752090">提供翻譯</translation>
+<translation id="8156139159503939589">你看得懂哪些語言？</translation>
+<translation id="5689516760719285838">位置</translation>
+<translation id="2440823041667407902">位置資訊存取權</translation>
+<translation id="2023546461831060654">請在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中為 Brave 啟用這些權限。</translation>
+<translation id="6665548517310046133">請在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中為 Brave 啟用這項權限。</translation>
+<translation id="2928908108430545745">如要讓 Brave 存取你的位置，請一併在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中開啟定位功能。</translation>
+<translation id="1028853271388022585">如要讓 Brave 存取你的相機，請一併在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中開啟相機。</translation>
+<translation id="2913721282607281710">如要讓 Brave 傳送通知，請一併在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中開啟通知功能。</translation>
+<translation id="8753483718490035722">如要讓 Brave 存取你的麥克風，請一併在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中開啟麥克風。</translation>
+<translation id="1887786770086287077">這部裝置的位置資訊存取權已關閉。請在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中予以開啟。</translation>
+<translation id="2570922361219980984">此外，這部裝置的位置資訊存取權已關閉。請在 <ph name="BEGIN_LINK"/>Android 設定<ph name="END_LINK"/>中予以開啟。</translation>
+<translation id="1620510694547887537">攝影機</translation>
+<translation id="3227137524299004712">麥克風</translation>
+<translation id="1647391597548383849">存取您的攝影機</translation>
+<translation id="945632385593298557">存取您的麥克風</translation>
+<translation id="6612358246767739896">受保護內容</translation>
+<translation id="885701979325669005">儲存空間</translation>
+<translation id="3198916472715691905">儲存了 <ph name="STORAGE_AMOUNT"/> 的資料</translation>
+<translation id="8847988622838149491">USB</translation>
+<translation id="8447861592752582886">撤銷裝置權限</translation>
+<translation id="4962975101802056554">撤銷裝置的所有權限</translation>
+<translation id="6545864417968258051">藍牙掃描</translation>
+<translation id="4411535500181276704">精簡模式</translation>
+<translation id="7821588508402923572">你省下的數據流量會顯示在這裡</translation>
+<translation id="2131665479022868825">已節省 <ph name="DATA"/></translation>
+<translation id="8569404424186215731">(<ph name="DATE"/>起)</translation>
+<translation id="3252158532344029638">使用精簡模式時，Brave 可加快網頁載入速度，並可節省多達百分之 60 的數據用量。</translation>
+<translation id="6159335304067198720">節省 <ph name="PERCENT"/> 的數據流量</translation>
+<translation id="7494974237137038751">(已節省的數據量)</translation>
+<translation id="6111020039983847643">(已使用的數據量)</translation>
+<translation id="7413229368719586778">開始日期：<ph name="DATE"/></translation>
+<translation id="1782483593938241562">結束日期：<ph name="DATE"/></translation>
+<translation id="2728754400939377704">依網站排序</translation>
+<translation id="5864174910718532887">詳細資料：依網站名稱排序</translation>
+<translation id="116280672541001035">使用量</translation>
+<translation id="8349013245300336738">依使用資料量排序</translation>
+<translation id="6378173571450987352">詳細資料：依使用資料量排序</translation>
+<translation id="2631006050119455616">已節省</translation>
+<translation id="6643649862576733715">依儲存資料量排序</translation>
+<translation id="7302081693174882195">詳細資料：依儲存資料量排序</translation>
+<translation id="4179980317383591987">已使用 <ph name="AMOUNT"/></translation>
+<translation id="5937580074298050696">已儲存 <ph name="AMOUNT"/></translation>
+<translation id="2156074688469523661">其餘網站 (<ph name="NUMBER_OF_SITES"/>)</translation>
+<translation id="7138678301420049075">其他</translation>
+<translation id="4913161338056004800">重設統計資料</translation>
+<translation id="1856325424225101786">要重設精簡模式嗎？</translation>
+<translation id="3658159451045945436">如果確認重設，系統會清除你的數據用量節省記錄，包括你造訪過的網站清單。</translation>
+<translation id="3295530008794733555">瀏覽速度更快，數據用量更少。</translation>
+<translation id="7340390500800578919">使用精簡模式時，Brave 可加快網頁載入速度，並可節省多達 60% 的數據用量。Brave 會將你的網路流量傳送給 Brave Software，以便針對你造訪的網頁進行最佳化處理。<ph name="BEGIN_LINK"/>瞭解詳情<ph name="END_LINK"/></translation>
+<translation id="4538018662093857852">開啟精簡模式</translation>
+<translation id="4493497663118223949">精簡模式已開啟</translation>
+<translation id="7559975015014302720">精簡模式已關閉</translation>
+<translation id="7606077192958116810">精簡模式已開啟。你可「 設定」中管理這個模式。</translation>
+<translation id="4714588616299687897">最多可減少 60% 的數據流量</translation>
+<translation id="1006927014032731288">Brave Software 伺服器會針對你造訪的網頁進行最佳化處理。</translation>
+<translation id="3257320067425202300">Brave 為你節省了 <ph name="MEGABYTES"/> MB</translation>
+<translation id="5813223329348543512">Brave 為你節省了 <ph name="GIGABYTES"/> GB</translation>
+<translation id="8266862848225348053">下載位置</translation>
+<translation id="7077143737582773186">SD 卡</translation>
+<translation id="7762668264895820836">SD 卡 <ph name="SD_CARD_NUMBER"/></translation>
+<translation id="6341580099087024258">詢問檔案儲存位置</translation>
+<translation id="6192333916571137726">下載檔案</translation>
+<translation id="1672586136351118594">不要再顯示</translation>
+<translation id="2650751991977523696">要再次下載檔案嗎？</translation>
+<translation id="8664979001105139458">檔案名稱已存在</translation>
+<translation id="488187801263602086">重新命名檔案</translation>
+<translation id="5686790454216892815">檔案名稱過長</translation>
+<translation id="7454641608352164238">空間不足</translation>
+<translation id="8972098258593396643">要下載至預設資料夾嗎？</translation>
+<translation id="804335162455518893">找不到 SD 卡</translation>
+<translation id="7475688122056506577">找不到 SD 卡。部分檔案可能會遺失。</translation>
+<translation id="4198423547019359126">沒有可用的下載位置</translation>
+<translation id="8224471946457685718">透過 Wi-Fi 下載為你推薦的文章</translation>
+<translation id="4970824347203572753">你所在的地區無法使用這項功能</translation>
+<translation id="5500777121964041360">你所在的地區可能不支援這項功能</translation>
+<translation id="1173894706177603556">重新命名</translation>
+<translation id="1986685561493779662">這個名稱已有人使用</translation>
+<translation id="6441734959916820584">這個名稱太長</translation>
+<translation id="2923908459366352541">名稱無效</translation>
+<translation id="7290209999329137901">無法重新命名</translation>
+<translation id="3334729583274622784">是否要變更副檔名？</translation>
+<translation id="107147699690128016">如果變更副檔名，這個檔案可能會在其他應用程式中開啟，並可能對裝置造成損害。</translation>
+<translation id="8541922081612557424">關於 Brave</translation>
+<translation id="5311273890481188673">Copyright <ph name="YEAR"/> Brave Software LLC. 保留所有權利。</translation>
+<translation id="1416550906796893042">應用程式版本</translation>
+<translation id="7493994139787901920"><ph name="VERSION"/> (上次更新時間：<ph name="TIME_SINCE_UPDATE"/>)</translation>
+<translation id="7596558890252710462">作業系統</translation>
+<translation id="3968054912784331254">這個版本的 Android 已停止支援 Brave 更新</translation>
+<translation id="7665369617277396874">新增帳戶</translation>
+<translation id="649070405679044769">已使用下列帳戶登入 Brave Software：</translation>
+<translation id="6234515504547364178">登出 Brave</translation>
+<translation id="5324858694974489420">家長設定</translation>
+<translation id="8920114477895755567">尚未取得家長詳細資料。</translation>
+<translation id="5512137114520586844">這個帳戶受 <ph name="PARENT_NAME"/> 管理。</translation>
+<translation id="2956410042958133412">這個帳戶受 <ph name="PARENT_NAME_1"/> 和 <ph name="PARENT_NAME_2"/> 管理。</translation>
+<translation id="8168435359814927499">內容</translation>
+<translation id="5403644198645076998">只允許特定網站</translation>
+<translation id="8641930654639604085">嘗試封鎖成人網站</translation>
+<translation id="5639724618331995626">允許所有網站</translation>
+<translation id="796823723482603597">技術提供：Brave</translation>
+<translation id="6324034347079777476">Android 系統同步處理功能已停用</translation>
+<translation id="5127805178023152808">同步功能已停用</translation>
+<translation id="7015203776128479407">尚未完成初始同步處理設定。已關閉同步功能。</translation>
+<translation id="2497852260688568942">你的管理員停用了同步功能</translation>
+<translation id="9100610230175265781">請提供通關密語</translation>
+<translation id="6108923351542677676">設定中…</translation>
+<translation id="4062305924942672200">法律資訊</translation>
+<translation id="4256782883801055595">開放原始碼授權</translation>
+<translation id="1138681184697033370">Brave 服務條款</translation>
+<translation id="7392539049993970338">Brave 隱私權聲明</translation>
+<translation id="2677748264148917807">離開</translation>
+<translation id="5556459405103347317">重新載入</translation>
+<translation id="1623104350909869708">防止這個網頁產生其他對話方塊</translation>
+<translation id="2968755619301702150">憑證檢視器</translation>
+<translation id="1360432990279830238">要登出並關閉同步處理功能嗎？</translation>
+<translation id="8581481290581777242">要清除你在這個裝置上的 Brave 資料嗎？</translation>
+<translation id="1318865768845061710">你的書籤、歷史記錄、密碼和其他 Brave 資料將停止同步到你的 Brave Software 帳戶</translation>
+<translation id="3325020657155065477">一併清除你在這個裝置上的 Brave 資料</translation>
+<translation id="6136448902816743006">你即將登出由 <ph name="DOMAIN_NAME"/> 管理的帳戶，因此系統會將你的 Brave 資料從這個裝置上刪除，但是這些資料會繼續保留在你的 Brave Software 帳戶中。</translation>
+<translation id="1853026300647876496">正在連線至 Brave Software。可能需要一分鐘…</translation>
+<translation id="2328985652426384049">無法登入</translation>
+<translation id="7723158744459952869">Brave Software 的回應時間過長</translation>
+<translation id="4572422548854449519">登入受管理的帳戶</translation>
+<translation id="2689656545739939160">您即將使用由 <ph name="MANAGED_DOMAIN"/> 所管理的帳戶登入，並授權該網域的管理員控管您的 Brave 資料。您的資料會與這個帳戶建立永久連結。登出 Brave 後，系統會將您的資料從這個裝置上刪除，但繼續保留在您的 Brave Software 帳戶中。</translation>
+<translation id="1749561566933687563">同步處理您的書籤</translation>
+<translation id="4242533952199664413">開啟設定</translation>
+<translation id="1111673857033749125">儲存在您其他裝置上的書籤會顯示在這裡。</translation>
+<translation id="8636825310635137004">如要存取您在其他裝置上開啟的分頁，請開啟同步處理功能。</translation>
+<translation id="3269956123044984603">如要存取您在其他裝置上開啟的分頁，請前往 Android 帳戶設定開啟 [自動同步處理資料]。</translation>
+<translation id="5157964048453367290">您在其他裝置上透過 Brave 開啟的分頁會顯示在這裡。</translation>
+<translation id="4684427112815847243">同步處理所有資料</translation>
+<translation id="2709516037105925701">自動填入</translation>
+<translation id="8820817407110198400">書籤</translation>
+<translation id="1644574205037202324">歷史記錄</translation>
+<translation id="17513872634828108">開啟的分頁</translation>
+<translation id="1320169905922104972">使用 Brave Software Pay 儲存的信用卡和地址資訊</translation>
+<translation id="6337234675334993532">加密</translation>
+<translation id="6698801883190606802">管理同步資料</translation>
+<translation id="3598578758776312506">使用 Brave Software 憑證為密碼加密</translation>
+<translation id="7810580217418711046">使用你在 <ph name="TIME"/>設定的 Brave Software 密碼，加密保護同步資料</translation>
+<translation id="8461694314515752532">使用你自己的同步通關密語，加密保護同步資料</translation>
+<translation id="2996291259634659425">建立通關密語</translation>
+<translation id="5713644099811900409">Brave Software 帳戶</translation>
+<translation id="8997474919031554666">通關密語加密保護的資料不包括 Brave Software Pay 的付款方式和地址。只有知道你通關密語的人，才能讀取加密保護的資料。系統不會將通關密語傳送給 Brave Software，Brave Software 也不會儲存通關密語。如果你忘記自己的通關密語，或是想變更這項設定，則必須重設同步功能。<ph name="BEGIN_LINK"/>瞭解詳情<ph name="END_LINK"/></translation>
+<translation id="9050666287014529139">通關密語</translation>
+<translation id="7772032839648071052">確認通關密語</translation>
+<translation id="5304593522240415983">這個欄位不能留空</translation>
+<translation id="321773570071367578">如果您忘記通關密語，或是想變更這項設定，請<ph name="BEGIN_LINK"/>重設同步功能<ph name="END_LINK"/></translation>
+<translation id="3029704984691124060">通關密語不符</translation>
+<translation id="5149495116300586333">通關密語加密保護的資料不包括 Brave Software Pay 的付款方式和地址。
+
+如要變更這項設定，請<ph name="BEGIN_LINK"/>重設同步功能<ph name="END_LINK"/></translation>
+<translation id="7638584964844754484">通關密語不正確</translation>
+<translation id="5414836363063783498">驗證中…</translation>
+<translation id="6846298663435243399">載入中…</translation>
+<translation id="5517095782334947753">你有來自 <ph name="FROM_ACCOUNT"/> 的書籤、歷史記錄、密碼和其他設定。</translation>
+<translation id="3928666092801078803">合併我的資料</translation>
+<translation id="688738109438487280">將現有資料新增至 <ph name="TO_ACCOUNT"/>。</translation>
+<translation id="806745655614357130">分開保留我的資料</translation>
+<translation id="1145536944570833626">刪除現有資料。</translation>
+<translation id="1993768208584545658"><ph name="SITE"/> 要求配對</translation>
+<translation id="4915549754973153784"><ph name="BEGIN_LINK"/>查看說明<ph name="END_LINK"/>。正在掃描裝置…</translation>
+<translation id="5817918615728894473">配對</translation>
+<translation id="7624880197989616768"><ph name="BEGIN_LINK1"/>查看說明<ph name="END_LINK1"/>或<ph name="BEGIN_LINK2"/>重新掃描<ph name="END_LINK2"/></translation>
+<translation id="230115972905494466">找不到相容的裝置</translation>
+<translation id="3773755127849930740">如要允許配對，請<ph name="BEGIN_LINK"/>開啟藍牙功能<ph name="END_LINK"/></translation>
+<translation id="998321811308652668">Brave 無法開啟藍牙轉接器</translation>
+<translation id="3036750288708366620"><ph name="BEGIN_LINK"/>取得說明<ph name="END_LINK"/></translation>
+<translation id="8428644385678426438">Brave 需要位置資訊存取權才能掃描裝置。<ph name="BEGIN_LINK"/>更新權限<ph name="END_LINK"/></translation>
+<translation id="852740676285943527">Brave 需要位置資訊存取權才能掃描裝置。<ph name="BEGIN_LINK"/>這個裝置的位置資訊存取權已關閉<ph name="END_LINK"/>。</translation>
+<translation id="2367014990350929709">Brave 需要位置資訊存取權才能掃描裝置。<ph name="BEGIN_LINK1"/>更新權限<ph name="END_LINK1"/>。此外，<ph name="BEGIN_LINK2"/>這個裝置的位置資訊存取權已關閉<ph name="END_LINK2"/>。</translation>
+<translation id="1569387923882100876">連結的裝置</translation>
+<translation id="8687353297350450808">{N_BARS,plural, =1{訊號強度等級：# 格}other{訊號強度等級：# 格}}</translation>
+<translation id="5230560987958996918"><ph name="SITE"/> 要求掃描附近的藍牙裝置。已找到下列裝置：</translation>
+<translation id="8368027906805972958">不明或不支援的裝置 (<ph name="DEVICE_ID"/>)</translation>
+<translation id="7605594153474022051">同步處理功能無法正常運作</translation>
+<translation id="1810845389119482123">尚未完成初始同步處理設定</translation>
+<translation id="3235722914093408050">如要啟動 Brave 同步功能，請開啟 Android 設定並重新啟用 Android 系統同步處理設定</translation>
+<translation id="3367813778245106622">如要開始同步處理，請重新登入</translation>
+<translation id="974555521953189084">如要開始同步處理，請輸入你的通關密語</translation>
+<translation id="2997266899014181325">如要開始同步處理，請開啟「同步處理你的 Brave 資料」。</translation>
+<translation id="8260126382462817229">請嘗試重新登入</translation>
+<translation id="5919204609460789179">更新 <ph name="PRODUCT_NAME"/> 即可開始同步處理</translation>
+<translation id="397583555483684758">同步處理功能已停止運作</translation>
+<translation id="1966710179511230534">請更新你的登入詳細資料。</translation>
+<translation id="7063006564040364415">無法連線至同步處理伺服器。</translation>
+<translation id="7942131818088350342"><ph name="PRODUCT_NAME"/> 版本過舊。</translation>
+<translation id="4170011742729630528">服務無法使用，請稍後再試。</translation>
+<translation id="7947953824732555851">接受並登入</translation>
+<translation id="8583805026567836021">正在清除帳戶資料</translation>
+<translation id="8310344678080805313">標準分頁</translation>
+<translation id="5748802427693696783">已切換成標準分頁</translation>
+<translation id="7998918019931843664">重新開啟先前關閉的分頁</translation>
+<translation id="8853345339104747198"><ph name="TAB_TITLE"/> (分頁)</translation>
+<translation id="4452411734226507615">關閉 [<ph name="TAB_TITLE"/>] 分頁</translation>
+<translation id="7243308994586599757">選項在接近畫面底部的位置</translation>
+<translation id="4060598801229743805">選項位於畫面頂端</translation>
+<translation id="2810645512293415242">網頁內容經過簡化，不僅節省數據用量，更加快載入速度。</translation>
+<translation id="3985215325736559418">你要再次下載 <ph name="FILE_NAME"/> 嗎？</translation>
+<translation id="2450083983707403292">要重新下載「<ph name="FILE_NAME"/>」嗎？</translation>
+<translation id="7514365320538308">下載</translation>
+<translation id="545042621069398927">正在加快下載速度。</translation>
+<translation id="7925590027513907933">{FILE_COUNT,plural, =1{正在下載檔案。}other{正在下載 # 個檔案。}}</translation>
+<translation id="543509235395288790">正在下載 <ph name="COUNT"/> 個檔案 (共 <ph name="MEGABYTES"/> MB)。</translation>
+<translation id="4988210275050210843">正在下載檔案 (<ph name="MEGABYTES"/>)。</translation>
+<translation id="4763829664323285145">{FILE_COUNT,plural, =1{已完成 1 項下載作業。}other{已完成 # 項下載作業。}}</translation>
+<translation id="5162754098604580781">{FILE_COUNT,plural, =1{無法完成 1 項下載作業。}other{無法完成 # 項下載作業。}}</translation>
+<translation id="1141800923049248244">{FILE_COUNT,plural, =1{1 項下載作業仍待處理。}other{# 項下載作業仍待處理。}}</translation>
+<translation id="7396940094317457632"><ph name="FILE_NAME"/>。</translation>
+<translation id="1987739130650180037"><ph name="MESSAGE"/> <ph name="LINK_NAME"/>按鈕</translation>
+<translation id="3205824638308738187">即將大功告成！</translation>
+<translation id="3960299545138990065">重新啟動 Brave</translation>
+<translation id="3771001275138982843">無法下載更新</translation>
+<translation id="3888648114124182147">正在下載 Brave 更新…</translation>
+<translation id="1705567146636171298">更新 Brave</translation>
+<translation id="6195417478702700398">為獲得最佳瀏覽體驗，請開啟 Brave 進行更新</translation>
+<translation id="3512968675351418494">如要以你偏好的語言查看網頁，請取得最新版本的 Brave</translation>
+<translation id="6427112570124116297">翻譯網頁</translation>
+<translation id="1379423114029199501">更新後即可在 Brave 最新版本中使用你偏好的語言</translation>
+<translation id="5684874026226664614">糟糕！系統無法翻譯這個網頁的內容。</translation>
+<translation id="6831043979455480757">翻譯</translation>
+<translation id="1285320974508926690">一律不翻譯此網站</translation>
+<translation id="773466115871691567">一律翻譯<ph name="SOURCE_LANGUAGE"/>網頁</translation>
+<translation id="1068672505746868501">一律不翻譯<ph name="SOURCE_LANGUAGE"/>網頁</translation>
+<translation id="124116460088058876">更多語言</translation>
+<translation id="290376772003165898">不是<ph name="LANGUAGE"/>網頁嗎？</translation>
+<translation id="4432792777822557199">從現在起，系統會將<ph name="SOURCE_LANGUAGE"/>網頁內容翻譯成<ph name="TARGET_LANGUAGE"/></translation>
+<translation id="8339163506404995330">系統將不會翻譯<ph name="LANGUAGE"/>網頁</translation>
+<translation id="5447765697759493033">系統不會翻譯這個網站</translation>
+<translation id="4880127995492972015">翻譯...</translation>
+<translation id="641643625718530986">列印…</translation>
+<translation id="8909135823018751308">分享…</translation>
+<translation id="4996978546172906250">分享方式：</translation>
+<translation id="6333140779060797560">透過 <ph name="APPLICATION"/> 分享</translation>
+<translation id="6277522088822131679">列印網頁時發生問題，請再試一次。</translation>
+<translation id="3254409185687681395">把此頁加入書籤</translation>
+<translation id="497421865427891073">往前</translation>
+<translation id="813082847718468539">查看網站資訊</translation>
+<translation id="2532336938189706096">網頁檢視</translation>
+<translation id="6005538289190791541">建議的密碼</translation>
+<translation id="4634124774493850572">使用密碼</translation>
+<translation id="8285489906452138776">Brave 需要相關權限，才能讓這個網站使用你的攝影機。</translation>
+<translation id="320189792589364011">Brave 需要相關權限，才能讓這個網站使用你的麥克風。</translation>
+<translation id="7988136689212463100">Brave 需要相關權限，才能讓這個網站使用你的攝影機和麥克風。</translation>
+<translation id="4931190655840828017">Brave 需要位置資訊存取權，才能與這個網站分享你的位置資訊。</translation>
+<translation id="3088191967551450609">Brave 必須取得儲存空間的存取權才能下載檔案。</translation>
+<translation id="8942627711005830162">在其他視窗中開啟</translation>
+<translation id="4195643157523330669">在新分頁中開啟</translation>
+<translation id="1100066534610197918">在群組的新分頁中開啟</translation>
+<translation id="4860895144060829044">撥號</translation>
+<translation id="6896758677409633944">複製</translation>
+<translation id="8393700583063109961">傳送訊息</translation>
+<translation id="3557336313807607643">新增為聯絡人</translation>
+<translation id="4269820728363426813">複製連結網址</translation>
+<translation id="1206892813135768548">複製連結文字</translation>
+<translation id="1204037785786432551">下載連結</translation>
+<translation id="6864459304226931083">下載圖片</translation>
+<translation id="8209050860603202033">開啟圖片</translation>
+<translation id="8073388330009372546">在新分頁中開啟圖片</translation>
+<translation id="6649642165559792194">預覽圖片 <ph name="BEGIN_NEW"/>新功能<ph name="END_NEW"/></translation>
+<translation id="3269093882174072735">載入圖片</translation>
+<translation id="3845332215609790146">使用 Brave Software 智慧鏡頭的搜尋功能 <ph name="BEGIN_NEW"/>新功能<ph name="END_NEW"/></translation>
+<translation id="5578795271662203820">透過 <ph name="SEARCH_ENGINE"/> 搜尋這張圖片</translation>
+<translation id="3384347053049321195">分享圖片</translation>
+<translation id="5833984609253377421">分享連結</translation>
+<translation id="6475951671322991020">下載影片</translation>
+<translation id="2317945146070194624">在新的 Brave 分頁中開啟</translation>
+<translation id="7975379999046275268">預覽網頁 <ph name="BEGIN_NEW"/>新功能<ph name="END_NEW"/></translation>
+<translation id="6112702117600201073">重新整理網頁</translation>
+<translation id="36525718899759834">從 Brave Software Play 商店取得應用程式：<ph name="APP_ACTION"/></translation>
+<translation id="2414886740292270097">深色</translation>
+<translation id="1807246157184219062">淺色</translation>
+<translation id="4056223980640387499">深褐色調</translation>
+<translation id="3927692899758076493">Sans Serif</translation>
+<translation id="5016205925109358554">Serif</translation>
+<translation id="2593272815202181319">等寬</translation>
+<translation id="9206873250291191720">A</translation>
+<translation id="654446541061731451">選取要傳輸的分頁</translation>
+<translation id="8719023831149562936">無法傳輸目前的分頁</translation>
+<translation id="2139186145475833000">加到主畫面</translation>
+<translation id="4616150815774728855">開啟 <ph name="WEBAPK_NAME"/></translation>
+<translation id="2122601567107267586">無法開啟應用程式</translation>
+<translation id="5129038482087801250">安裝網路應用程式</translation>
+<translation id="3789841737615482174">安裝</translation>
+<translation id="4665282149850138822">「<ph name="NAME"/>」已加入您的主畫面</translation>
+<translation id="7333031090786104871">仍在新增先前的網站</translation>
+<translation id="1036727731225946849">正在新增「<ph name="WEBAPK_NAME"/>」...</translation>
+<translation id="3778956594442850293">已新增至主畫面</translation>
+<translation id="2146738493024040262">開啟免安裝應用程式</translation>
+<translation id="7016516562562142042">允許目前的搜尋引擎存取位置資訊</translation>
+<translation id="6177111841848151710">禁止目前的搜尋引擎存取位置資訊</translation>
+<translation id="145097072038377568">已在 Android 設定中關閉</translation>
+<translation id="8007176423574883786">已在這個裝置上關閉</translation>
+<translation id="164269334534774161">您目前瀏覽的是這個網頁的離線複本 (建立時間：<ph name="CREATION_TIME"/>)</translation>
+<translation id="4594952190837476234">這個離線版網頁是於 <ph name="CREATION_TIME"/>建立，可能會和線上版本有所不同。</translation>
+<translation id="8840953339110955557">這個網頁可能會和線上版本有所不同。</translation>
+<translation id="6405300764336705484">這個內容來自 <ph name="DOMAIN_NAME"/>，由 Brave Software 所提供。</translation>
+<translation id="1006017844123154345">在網路上開啟</translation>
+<translation id="3326636747541519688">由 Brave Software 提供的精簡版網頁</translation>
+<translation id="7149158118503947153">從 <ph name="DOMAIN_NAME"/> <ph name="BEGIN_LINK"/>載入原始頁面<ph name="END_LINK"/></translation>
+<translation id="7475192538862203634">如果您經常看到這個頁面，請嘗試這些<ph name="BEGIN_LINK"/>建議<ph name="END_LINK"/>。</translation>
+<translation id="8748850008226585750">內容已隱藏</translation>
+<translation id="3810973564298564668">管理</translation>
+<translation id="5199929503336119739">工作資料夾</translation>
+<translation id="528192093759286357">從頂端拖曳並輕觸返回按鈕即可結束全螢幕模式。</translation>
+<translation id="2836148919159985482">輕觸返回按鈕即可結束全螢幕模式。</translation>
+<translation id="3967822245660637423">下載完成</translation>
+<translation id="2434158240863470628">下載完成 <ph name="SEPARATOR"/> <ph name="BYTES_DOWNLOADED"/></translation>
+<translation id="802154636333426148">下載失敗</translation>
+<translation id="1384959399684842514">已暫停下載</translation>
+<translation id="1671236975893690980">正在等候下載…</translation>
+<translation id="5561549206367097665">正在等待網路連線…</translation>
+<translation id="5864419784173784555">正在等待其他下載程序完成…</translation>
+<translation id="6461962085415701688">無法開啟檔案</translation>
+<translation id="1178581264944972037">暫停</translation>
+<translation id="8200772114523450471">繼續</translation>
+<translation id="1409879593029778104"><ph name="FILE_NAME"/> 檔案已存在，因此無法下載。</translation>
+<translation id="3387650086002190359">檔案系統發生錯誤，因此無法下載 <ph name="FILE_NAME"/>。</translation>
+<translation id="6482749332252372425">儲存空間不足，因此無法下載 <ph name="FILE_NAME"/>。</translation>
+<translation id="7619072057915878432">無法連上網路，因此無法下載 <ph name="FILE_NAME"/>。</translation>
+<translation id="1477626028522505441">伺服器發生問題，因此無法下載 <ph name="FILE_NAME"/>。</translation>
+<translation id="3692944402865947621">無法連線至儲存位置，因此無法下載 <ph name="FILE_NAME"/>。</translation>
+<translation id="604996488070107836">發生不明錯誤，因此無法下載 <ph name="FILE_NAME"/>。</translation>
+<translation id="6738867403308150051">下載中…</translation>
+<translation id="7176368934862295254"><ph name="KILOBYTES"/> KB</translation>
+<translation id="2402980924095424747"><ph name="MEGABYTES"/> MB</translation>
+<translation id="6608650720463149374"><ph name="GIGABYTES"/> GB</translation>
+<translation id="3991845972263764475">已下載：<ph name="BYTES_DOWNLOADED_WITH_UNITS"/>，總大小：不明</translation>
+<translation id="1923695749281512248">已下載：<ph name="BYTES_DOWNLOADED_WITH_UNITS"/>，總大小：<ph name="FILE_SIZE_WITH_UNITS"/></translation>
+<translation id="3029613699374795922">已下載 <ph name="KBS"/> KB</translation>
+<translation id="6416782512398055893">已下載 <ph name="MBS"/> MB</translation>
+<translation id="6538442820324228105">已下載 <ph name="GBS"/> GB</translation>
+<translation id="9204836675896933765">還剩 1 個檔案</translation>
+<translation id="8186512483418048923">還剩 <ph name="FILES"/> 個檔案</translation>
+<translation id="757855969265046257">{FILES,plural, =1{已下載 <ph name="FILES_DOWNLOADED_ONE"/> 個檔案}other{已下載 <ph name="FILES_DOWNLOADED_MANY"/> 個檔案}}</translation>
+<translation id="8037750541064988519">還剩 <ph name="DAYS"/> 天</translation>
+<translation id="8190358571722158785">還剩 1 天</translation>
+<translation id="60923314841986378">還剩 <ph name="HOURS"/> 小時</translation>
+<translation id="510275257476243843">還剩 1 小時</translation>
+<translation id="970715775301869095">還剩 <ph name="MINUTES"/> 分鐘</translation>
+<translation id="3236059992281584593">還剩 1 分鐘</translation>
+<translation id="2777555524387840389">還剩 <ph name="SECONDS"/> 秒</translation>
+<translation id="2781151931089541271">還剩 1 秒</translation>
+<translation id="3303414029551471755">繼續下載這項內容？</translation>
+<translation id="8617240290563765734">開啟這項下載內容中指定的建議網址？</translation>
+<translation id="1373696734384179344">記憶體不足，無法下載您選取的這項內容。</translation>
+<translation id="5271967389191913893">裝置無法開啟您要下載的這項內容。</translation>
+<translation id="883806473910249246">下載這項內容時發生錯誤。</translation>
+<translation id="5626134646977739690">名稱：</translation>
+<translation id="7963646190083259054">供應商：</translation>
+<translation id="3414952576877147120">空間大小：</translation>
+<translation id="7375125077091615385">類型：</translation>
+<translation id="5765780083710877561">說明：</translation>
+<translation id="4881695831933465202">開啟</translation>
+<translation id="3542235761944717775">可用空間：<ph name="KILOBYTES"/> KB</translation>
+<translation id="8051695050440594747"><ph name="MEGABYTES"/> MB 可用空間</translation>
+<translation id="5424588387303617268">可用空間：<ph name="GIGABYTES"/> GB</translation>
+<translation id="5793665092639000975">使用量：<ph name="SPACE_USED"/> (共 <ph name="SPACE_AVAILABLE"/>)</translation>
+<translation id="3587482841069643663">全部</translation>
+<translation id="4988526792673242964">網頁</translation>
+<translation id="3810838688059735925">影片</translation>
+<translation id="3616113530831147358">音訊</translation>
+<translation id="9219103736887031265">圖片</translation>
+<translation id="8250920743982581267">文件</translation>
+<translation id="2013642289801508067">{FILE_COUNT,plural, =1{# 個檔案}other{# 個檔案}}</translation>
+<translation id="6444421004082850253">{FILE_COUNT,plural, =1{# 張圖片}other{# 張圖片}}</translation>
+<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# 部影片}other{# 部影片}}</translation>
+<translation id="2651091186440431324">{FILE_COUNT,plural, =1{# 個音訊檔案}other{# 個音訊檔案}}</translation>
+<translation id="4921180162323349895">{FILE_COUNT,plural, =1{# 個網頁}other{# 個網頁}}</translation>
+<translation id="5456381639095306749">下載網頁</translation>
+<translation id="2394602618534698961">你下載的檔案會顯示在這裡</translation>
+<translation id="7810647596859435254">選擇開啟工具…</translation>
+<translation id="5655963694829536461">搜尋下載內容</translation>
+<translation id="8485434340281759656"><ph name="FILE_SIZE"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="1883903952484604915">我的檔案</translation>
+<translation id="8105893657415066307"><ph name="DESCRIPTION"/> <ph name="SEPARATOR"/> <ph name="FILE_SIZE"/></translation>
+<translation id="766587987807204883">文章會顯示在這裡，並可供離線閱讀</translation>
+<translation id="4034817413553209278">{HOURS,plural, =1{# 小時}other{# 小時}}</translation>
+<translation id="5853623416121554550">已暫停</translation>
+<translation id="8965591936373831584">正在等待下載</translation>
+<translation id="2779651927720337254">失敗</translation>
+<translation id="2049574241039454490"><ph name="FILE_SIZE_OF_TOTAL"/> <ph name="SEPARATOR"/> <ph name="DESCRIPTION"/></translation>
+<translation id="3445014427084483498">剛剛</translation>
+<translation id="4000212216660919741">離線首頁</translation>
+<translation id="9133397713400217035">離線探索</translation>
+<translation id="968900484120156207">你曾造訪的頁面會顯示在這裡</translation>
+<translation id="7882131421121961860">找不到瀏覽記錄</translation>
+<translation id="3549657413697417275">搜尋你的記錄</translation>
+<translation id="6820686453637990663">CVC</translation>
+<translation id="3244271242291266297">月</translation>
+<translation id="605721222689873409">年</translation>
+<translation id="724102042129299115">Brave 初次使用體驗</translation>
+<translation id="2700285883409956633">使用這個應用程式即表示您同意接受 Brave 的《<ph name="BEGIN_LINK1"/>服務條款<ph name="END_LINK1"/>》和《<ph name="BEGIN_LINK2"/>隱私權聲明<ph name="END_LINK2"/>》。</translation>
+<translation id="1640714894372474981">使用這個應用程式即表示您同意接受 Brave 的《<ph name="BEGIN_LINK1"/>服務條款<ph name="END_LINK1"/>》和《<ph name="BEGIN_LINK2"/>隱私權聲明<ph name="END_LINK2"/>》，以及《<ph name="BEGIN_LINK3"/>透過 Family Link 管理的 Brave Software 帳戶所適用的隱私權聲明<ph name="END_LINK3"/>》。</translation>
+<translation id="4218324479468769727">「<ph name="APP_NAME"/>」將在 Brave 中開啟。繼續操作即表示您同意接受 Brave 的《<ph name="BEGIN_LINK1"/>服務條款<ph name="END_LINK1"/>》和《<ph name="BEGIN_LINK2"/>隱私權聲明<ph name="END_LINK2"/>》。</translation>
+<translation id="5071615083211946659">「<ph name="APP_NAME"/>」將在 Brave 中開啟。繼續操作即表示您同意接受 Brave 的《<ph name="BEGIN_LINK1"/>服務條款<ph name="END_LINK1"/>》和《<ph name="BEGIN_LINK2"/>隱私權聲明<ph name="END_LINK2"/>》，以及《<ph name="BEGIN_LINK3"/>透過 Family Link 管理的 Brave Software 帳戶所適用的隱私權聲明<ph name="END_LINK3"/>》。</translation>
+<translation id="673197144963363525">將使用統計資料及當機報告傳送給 Brave Software，助我們一臂之力，讓 Brave 更臻完美。</translation>
+<translation id="3518985090088779359">接受並繼續</translation>
+<translation id="7207456302801184289">歡迎使用 Brave</translation>
+<translation id="704822250101715322">正在等待 Brave Software Play 服務完成更新</translation>
+<translation id="1231733316453485619">要開啟同步處理功能嗎？</translation>
+<translation id="5132942445612118989">同步處理你所有裝置上的密碼、歷史記錄和其他設定</translation>
+<translation id="5736731321935944068">Brave Software 可能會使用你的歷史記錄，為你提供個人化的搜尋服務、廣告內容和其他各項 Brave Software 服務</translation>
+<translation id="4013614219085422040">Brave Software 可能會使用你的歷史記錄，為你提供個人化的搜尋服務和其他各項 Brave Software 服務</translation>
+<translation id="5581519193887989363">你隨時可以在<ph name="BEGIN_LINK1"/>設定<ph name="END_LINK1"/>中選擇要同步處理的資料。</translation>
+<translation id="741204030948306876">是，我要啟用</translation>
+<translation id="2410754283952462441">選擇帳戶</translation>
+<translation id="2227444325776770048">以「<ph name="USER_FULL_NAME"/>」的身分繼續</translation>
+<translation id="6210748933810148297">不是 <ph name="EMAIL"/> 嗎？</translation>
+<translation id="8109613176066109935">如要將書籤同步到所有裝置，請開啟同步處理功能</translation>
+<translation id="2818669890320396765">如要將書籤同步到所有裝置，請登入並開啟同步處理功能</translation>
+<translation id="6003646045106347985">如要取得個人化的 Brave Software 推薦內容，請開啟同步處理功能</translation>
+<translation id="8494430740943879273">如要取得個人化的 Brave Software 推薦內容，請登入並開啟同步處理功能</translation>
+<translation id="5862731021271217234">如要存取你在其他裝置上開啟的分頁，請開啟同步處理功能</translation>
+<translation id="3568688522516854065">如要存取你在其他裝置上開啟的分頁，請登入並開啟同步處理功能</translation>
+<translation id="1208340532756947324">如要進行同步處理並在所有裝置上享有個人化的體驗，請開啟同步處理功能</translation>
+<translation id="4472118726404937099">如要進行同步處理並在所有裝置上享有個人化的體驗，請登入並開啟同步處理功能</translation>
+<translation id="2426805022920575512">選擇其他帳戶</translation>
+<translation id="6790428901817661496">播放</translation>
+<translation id="1272079795634619415">停止</translation>
+<translation id="2874939134665556319">上一首曲目</translation>
+<translation id="4046123991198612571">下一首曲目</translation>
+<translation id="3859306556332390985">快轉到特定的播放時間點</translation>
+<translation id="8441146129660941386">倒轉到特定的播放時間點</translation>
+<translation id="6706288973712894588">你目前已離線。\n<ph name="BEGIN_LINK"/>瀏覽離線動態消息。<ph name="END_LINK"/></translation>
+<translation id="572328651809341494">最近開啟的分頁</translation>
+<translation id="8497726226069778601">目前還沒有任何常用網頁…</translation>
+<translation id="5423934151118863508">這裡會顯示您最常造訪的網頁</translation>
+<translation id="6127379762771434464">已移除項目</translation>
+<translation id="4605958867780575332">已移除項目：<ph name="ITEM_TITLE"/></translation>
+<translation id="1996480094660735607">Brave Software Doodle：<ph name="DOODLE_DESCRIPTION"/></translation>
+<translation id="7851858861565204677">其他裝置</translation>
+<translation id="4738836084190194332">上次同步處理時間：<ph name="WHEN"/></translation>
+<translation id="4583164079174244168">{MINUTES,plural, =1{# 分鐘前}other{# 分鐘前}}</translation>
+<translation id="5809361687334836369">{HOURS,plural, =1{# 小時前}other{# 小時前}}</translation>
+<translation id="4513387527876475750">{DAYS,plural, =1{# 天前}other{# 天前}}</translation>
+<translation id="2762000892062317888">剛剛</translation>
+<translation id="1407135791313364759">全部開啟</translation>
+<translation id="1209206284964581585">暫時隱藏</translation>
+<translation id="129553762522093515">最近關閉的分頁</translation>
+<translation id="8413126021676339697">顯示完整記錄</translation>
+<translation id="7876243839304621966">全部移除</translation>
+<translation id="8487700953926739672">可離線使用</translation>
+<translation id="5224771365102442243">含有影片</translation>
+<translation id="3493531032208478708"><ph name="BEGIN_LINK"/>進一步瞭解<ph name="END_LINK"/>建議的內容</translation>
+<translation id="7542481630195938534">無法取得建議</translation>
+<translation id="5013696553129441713">沒有新的建議</translation>
+<translation id="1736419249208073774">探索</translation>
+<translation id="7444811645081526538">更多類別</translation>
+<translation id="6709133671862442373">新聞內容</translation>
+<translation id="1264974993859112054">運動資訊</translation>
+<translation id="9139318394846604261">購物</translation>
+<translation id="3912508018559818924">正在從網路上尋找最佳內容…</translation>
+<translation id="526421993248218238">無法載入這個網頁</translation>
+<translation id="614940544461990577">建議做法：</translation>
+<translation id="3288003805934695103">重新載入網頁</translation>
+<translation id="2353636109065292463">檢查你的網際網路連線</translation>
+<translation id="2858138569776157458">熱門網站</translation>
+<translation id="8364299278605033898">查看熱門網站</translation>
+<translation id="1171770572613082465">輕觸 [熱門網站] 按鈕，即可查看熱門網站</translation>
+<translation id="5233638681132016545">新增分頁</translation>
+<translation id="4521874409998847950">發布者：<ph name="PUBLISHER_ORIGIN"/> – <ph name="BEGIN_DEEMPHASIZED"/>由 Brave Software 所提供<ph name="END_DEEMPHASIZED"/></translation>
+<translation id="2587052924345400782">已推出新版本</translation>
+<translation id="4058091506841967397">無法更新 Brave</translation>
+<translation id="6316139424528454185">系統不支援目前的 Android 版本</translation>
+<translation id="6989267951144302301">無法下載</translation>
+<translation id="624789221780392884">可進行更新</translation>
+<translation id="1549000191223877751">移至其他視窗</translation>
+<translation id="7481312909269577407">往前</translation>
+<translation id="4084682180776658562">書籤</translation>
+<translation id="6437478888915024427">頁面資訊</translation>
+<translation id="7180611975245234373">重新整理</translation>
+<translation id="4913169188695071480">停止重新整理</translation>
+<translation id="1829244130665387512">在網頁中尋找</translation>
+<translation id="6593061639179217415">電腦版網站</translation>
+<translation id="9063523880881406963">關閉「要求電腦版網站」</translation>
+<translation id="2038563949887743358">開啟「要求電腦版網站」</translation>
+<translation id="2433507940547922241">外觀</translation>
+<translation id="983192555821071799">關閉所有分頁</translation>
+<translation id="1310482092992808703">將分頁加入群組</translation>
+<translation id="7725024127233776428">加入書籤的頁面會顯示在這裡</translation>
+<translation id="4404568932422911380">沒有書籤</translation>
+<translation id="3060635849835183725">{BOOKMARKS_COUNT,plural, =1{<ph name="BOOKMARKS_COUNT_ONE"/> 個書籤}other{<ph name="BOOKMARKS_COUNT_MANY"/> 個書籤}}</translation>
+<translation id="3739899004075612870">已加入 <ph name="PRODUCT_NAME"/> 書籤</translation>
+<translation id="3207960819495026254">已加入書籤</translation>
+<translation id="4452548195519783679">已將書籤加入「<ph name="FOLDER_NAME"/>」</translation>
+<translation id="8063895661287329888">無法加入書籤。</translation>
+<translation id="2842985007712546952">上層資料夾</translation>
+<translation id="9065203028668620118">編輯</translation>
+<translation id="4405224443901389797">移至…</translation>
+<translation id="5170568018924773124">在資料夾中顯示</translation>
+<translation id="8035133914807600019">新資料夾…</translation>
+<translation id="4532845899244822526">選擇資料夾</translation>
+<translation id="6627583120233659107">編輯資料夾</translation>
+<translation id="1197267115302279827">移動書籤</translation>
+<translation id="6963766334940102469">刪除書籤</translation>
+<translation id="4351244548802238354">關閉對話方塊</translation>
+<translation id="451872707440238414">搜尋書籤</translation>
+<translation id="8901170036886848654">找不到符合條件的書籤</translation>
+<translation id="6404511346730675251">編輯書籤</translation>
+<translation id="3894427358181296146">新增資料夾</translation>
+<translation id="5327248766486351172">名稱</translation>
+<translation id="7400418766976504921">網址</translation>
+<translation id="3527085408025491307">資料夾</translation>
+<translation id="5161254044473106830">請輸入標題</translation>
+<translation id="2996809686854298943">必須要有網址</translation>
+<translation id="2536728043171574184">目前瀏覽的是這個網頁的離線複本</translation>
+<translation id="4698034686595694889">在「<ph name="APP_NAME"/>」中離線瀏覽</translation>
+<translation id="8316092324682955408"><ph name="DOMAIN_NAME"/> 和其他網站</translation>
+<translation id="6945986954012067786">{NUM_IN_PROGRESS,plural, =1{Brave 準備就緒後將載入你的網頁}other{Brave 準備就緒後將載入你的網頁}}</translation>
+<translation id="6811034713472274749">你可以瀏覽這個網頁了</translation>
+<translation id="4561979708150884304">沒有網路連線</translation>
+<translation id="8274165955039650276">查看已下載的內容</translation>
+<translation id="2082238445998314030">第 <ph name="RESULT_NUMBER"/> 個結果，共 <ph name="TOTAL_RESULTS"/> 個</translation>
+<translation id="4943872375798546930">沒有結果</translation>
+<translation id="981121421437150478">離線</translation>
+<translation id="3298243779924642547">精簡版本</translation>
+<translation id="393697183122708255">沒有可用的語音搜尋功能</translation>
+<translation id="7191430249889272776">已在背景開啟分頁。</translation>
+<translation id="8445059357334030806">在 Brave 中開啟</translation>
+<translation id="4720023427747327413">在 <ph name="PRODUCT_NAME"/> 中開啟</translation>
+<translation id="7022756207310403729">在瀏覽器中開啟</translation>
+<translation id="1113597929977215864">顯示「簡易檢視」模式</translation>
+<translation id="1513352483775369820">書籤與網頁記錄</translation>
+<translation id="4939482511480190003">想要協助改善 Brave 嗎？<ph name="BEGIN_LINK"/>請填寫這份問卷調查<ph name="END_LINK"/></translation>
+<translation id="2501278716633472235">返回</translation>
+<translation id="5596627076506792578">更多選項</translation>
+<translation id="3522247891732774234">有可用的更新。更多選項</translation>
+<translation id="6773423637732432200">無法更新 Brave。更多選項</translation>
+<translation id="3328801116991980348">網站資訊</translation>
+<translation id="5391532827096253100">你與這個網站的連線不安全。網站資訊</translation>
+<translation id="6206551242102657620">已建立安全連線。網站資訊</translation>
+<translation id="6963642900430330478">這個網頁不安全。網站資訊</translation>
+<translation id="9070377983101773829">開始語音搜尋</translation>
+<translation id="8676374126336081632">清除輸入</translation>
+<translation id="5368958499335451666">{OPEN_TABS,plural, =1{已開啟 <ph name="OPEN_TABS_ONE"/> 個分頁，輕觸即可切換分頁}other{已開啟 <ph name="OPEN_TABS_MANY"/> 個分頁，輕觸即可切換分頁}}</translation>
+<translation id="2369533728426058518">開啟的分頁</translation>
+<translation id="7071521146534760487">管理帳戶</translation>
+<translation id="932327136139879170">首頁</translation>
+<translation id="2707726405694321444">重新整理頁面</translation>
+<translation id="2891154217021530873">停止載入網頁</translation>
+<translation id="6710213216561001401">返回</translation>
+<translation id="6659594942844771486">Tab</translation>
+<translation id="1933845786846280168">選取的分頁</translation>
+<translation id="2268044343513325586">修正搜尋</translation>
+<translation id="7846076177841592234">全部取消選取</translation>
+<translation id="7087918508125750058">已選取 <ph name="ITEM_COUNT"/> 個項目。選項位於畫面頂端</translation>
+<translation id="7250468141469952378">已選取 <ph name="ITEM_COUNT"/> 個項目</translation>
+<translation id="7353894246028566792">{NUM_SELECTED,plural, =1{分享 1 個選取的項目}other{分享 # 個選取的項目}}</translation>
+<translation id="1628019612362412531">{NUM_SELECTED,plural, =1{移除 1 個選取的項目}other{移除 # 個選取的項目}}</translation>
+<translation id="1283039547216852943">輕觸即可展開</translation>
+<translation id="5962718611393537961">輕觸即可收合</translation>
+<translation id="8076492880354921740">分頁</translation>
+<translation id="7066151586745993502">{NUM_SELECTED,plural, =1{已選取 1 個項目}other{已選取 # 個項目}}</translation>
+<translation id="6818926723028410516">選取項目</translation>
+<translation id="4797039098279997504">輕觸即可返回 <ph name="URL_OF_THE_CURRENT_TAB"/></translation>
+<translation id="6766758767654711248">輕觸即可前往網站</translation>
+<translation id="429312253194641664">一個網站正在播放媒體內容</translation>
+<translation id="4958708863221495346"><ph name="URL_OF_THE_CURRENT_TAB"/> 正在共用你的畫面。</translation>
+<translation id="8833831881926404480">有某個網站正在共用你的螢幕畫面</translation>
+<translation id="9086455579313502267">無法存取網路</translation>
+<translation id="938850635132480979">錯誤：<ph name="ERROR_CODE"/></translation>
+<translation id="666731172850799929">在「<ph name="APP_NAME"/>」中開啟</translation>
+<translation id="548278423535722844">在地圖應用程式中開啟</translation>
+<translation id="7698359219371678927">在「<ph name="APP_NAME"/>」中建立電子郵件</translation>
+<translation id="7875915731392087153">建立電子郵件</translation>
+<translation id="5665379678064389456">在「<ph name="APP_NAME"/>」中建立活動</translation>
+<translation id="2900528713135656174">建立活動</translation>
+<translation id="2111511281910874386">前往指定頁面</translation>
+<translation id="3988466920954086464">你可以在這個面板中查看即時搜尋結果</translation>
+<translation id="2744248271121720757">只要輕觸字詞就能立即展開搜尋或查看相關的動作</translation>
+<translation id="9155898266292537608">快速輕觸字詞也可以展開搜尋</translation>
+<translation id="3232754137068452469">網路應用程式</translation>
+<translation id="1430915738399379752">列印</translation>
+<translation id="3775705724665058594">傳送至你的裝置</translation>
+<translation id="6364438453358674297">從歷史記錄中移除建議項目？</translation>
+<translation id="213279576345780926">已關閉「<ph name="TAB_TITLE"/>」</translation>
+<translation id="6850830437481525139">關閉了 <ph name="TAB_COUNT"/> 個分頁</translation>
+<translation id="3211426585530211793">已刪除「<ph name="ITEM_TITLE"/>」</translation>
+<translation id="4663756553811254707">已刪除 <ph name="NUMBER_OF_BOOKMARKS"/> 個書籤</translation>
+<translation id="3819178904835489326">已刪除 <ph name="NUMBER_OF_DOWNLOADS"/> 個下載項目</translation>
+<translation id="1248710015876067820">Brave 實例的數量已超出上限。</translation>
+<translation id="4259722352634471385">瀏覽的網址已封鎖：<ph name="URL"/></translation>
+<translation id="8959122750345127698">瀏覽的網址無法存取：<ph name="URL"/></translation>
+<translation id="5210365745912300556">關閉分頁</translation>
+<translation id="7772375229873196092">關閉 <ph name="APP_NAME"/></translation>
+<translation id="1227058898775614466">瀏覽記錄</translation>
+<translation id="9169507124922466868">已在畫面下半部顯示瀏覽記錄</translation>
+<translation id="1327257854815634930">瀏覽記錄已開啟</translation>
+<translation id="8788265440806329501">瀏覽記錄已關閉</translation>
+<translation id="7482656565088326534">預覽分頁</translation>
+<translation id="8427875596167638501">已在畫面下半部顯示預覽分頁</translation>
+<translation id="9102803872260866941">預覽分頁已開啟</translation>
+<translation id="2942036813789421260">預覽分頁已關閉</translation>
+<translation id="6355102470683871794">Brave Software <ph name="APP_NAME"/> 儲存資料量</translation>
+<translation id="3822502789641063741">要清除網站儲存的資料嗎？</translation>
+<translation id="9205995714227143200">Brave 認定為不重要的網站 (例如未儲存任何設定的網站，或是您不常造訪的網站) 所儲存的資料</translation>
+<translation id="3997476611815694295">不重要網站的儲存資料量</translation>
+<translation id="8493948351860045254">釋出空間</translation>
+<translation id="2324920234469020158">這項操作會清除不重要的網站 Cookie、快取等其他資料 (Brave 會自動判斷資料的重要性)。</translation>
+<translation id="5447201525962359567">所有網站儲存的資料，包括 Cookie 和其他儲存在本機上的資料</translation>
+<translation id="1376578503827013741">計算中…</translation>
+<translation id="583281660410589416">未知</translation>
+<translation id="2323763861024343754">網站儲存資料量</translation>
+<translation id="3587672679800759167">Brave 使用的資料總量，包括帳戶、書籤和儲存的設定</translation>
+<translation id="6545017243486555795">清除所有資料</translation>
+<translation id="4095146165863963773">要刪除應用程式資料嗎？</translation>
+<translation id="53119194224775367">Brave 的應用程式資料會全部遭到永久刪除，包括所有檔案、設定、帳戶、資料庫等等。</translation>
+<translation id="5307446750509046227">清除網站儲存的資料</translation>
+<translation id="300526633675317032">這會將網站儲存的資料全部清除 (共 <ph name="SIZE_IN_KB"/>)。</translation>
+<translation id="8068648041423924542">無法選取憑證。</translation>
+<translation id="2315043854645842844">作業系統不允許您在用戶端選取憑證。</translation>
+<translation id="5011311129201317034"><ph name="SITE"/> 要求連線</translation>
+<translation id="5308380583665731573">連線</translation>
+<translation id="868929229000858085">搜尋聯絡人</translation>
+<translation id="1919950603503897840">選取聯絡人</translation>
+<translation id="7986741934819883144">選取聯絡人</translation>
+<translation id="3333961966071413176">所有聯絡人</translation>
+<translation id="4994033804516042629">找不到任何聯絡人</translation>
+<translation id="5403592356182871684">名稱</translation>
+<translation id="2717722538473713889">電子郵件地址</translation>
+<translation id="381841723434055211">電話號碼</translation>
+<translation id="5394307150471348411">{DETAIL_COUNT,plural, =1{(還有 1 個)}other{(還有 # 個)}}</translation>
+<translation id="5197729504361054390">系統會將你選取的聯絡人資訊提供給 <ph name="BEGIN_BOLD"/><ph name="SITE"/><ph name="END_BOLD"/>。</translation>
+<translation id="1779089405699405702">影像解碼器</translation>
+<translation id="8067883171444229417">播放影片</translation>
+<translation id="6560414384669816528">使用 Sogou 搜尋</translation>
+<translation id="5406914950576900927">Brave 可以在中國使用 <ph name="BEGIN_BOLD"/>Sogou<ph name="END_BOLD"/> 搜尋。你可以在<ph name="BEGIN_LINK"/>設定<ph name="END_LINK"/>中變更這項設定。</translation>
+<translation id="6456271171669383967">繼續使用 Brave Software</translation>
+<translation id="4384468725000734951">現已使用 Sogou 搜尋</translation>
+<translation id="6103327872225198548">現已使用 Brave Software 搜尋</translation>
+<translation id="9133703968756164531"><ph name="ITEM_NAME"/> (<ph name="ITEM_ID"/>)</translation>
+<translation id="919933208285147476">Brave 正在執行這個應用程式</translation>
+<translation id="6143689084714664628">正在 Brave 中執行</translation>
+<translation id="7675869148432102528">「<ph name="APP_NAME"/>」在 Brave 中也有資料</translation>
+<translation id="2734140769649165081">你可以在 Brave 設定中清除資料</translation>
+<translation id="8232956427053453090">保留資料</translation>
+<translation id="4298388696830689168">連結的網站</translation>
+<translation id="5763514718066511291">輕觸即可複製這個應用程式的網址</translation>
+<translation id="6496823230996795692">初次使用「<ph name="APP_NAME"/>」時請連線至網際網路。</translation>
+<translation id="751961395872307827">無法連線至網站</translation>
+<translation id="4878404682131129617">無法透過 Proxy 伺服器建立通道</translation>
+<translation id="4749960740855309258">開啟新分頁</translation>
+<translation id="8788968922598763114">重新開啟最近關閉的分頁</translation>
+<translation id="7929962904089429003">開啟選單</translation>
+<translation id="6039379616847168523">跳至下一個分頁</translation>
+<translation id="5210286577605176222">跳至上一個分頁</translation>
+<translation id="124678866338384709">關閉目前的分頁</translation>
+<translation id="3714981814255182093">開啟搜尋列</translation>
+<translation id="5441522332038954058">切換到網址列</translation>
+<translation id="3398320232533725830">開啟書籤管理員</translation>
+<translation id="6583199322650523874">將目前的網頁加入書籤</translation>
+<translation id="8489271220582375723">開啟記錄頁面</translation>
+<translation id="4837753911714442426">開啟列印網頁的選項</translation>
+<translation id="5726692708398506830">放大網頁上的所有內容</translation>
+<translation id="3259831549858767975">縮小網頁上的所有內容</translation>
+<translation id="8015452622527143194">將網頁上的所有內容都回復為預設大小</translation>
+<translation id="3443221991560634068">重新載入目前網頁</translation>
+<translation id="123724288017357924">重新載入目前的網頁，略過已快取的內容</translation>
+<translation id="305870044889644984">在新分頁中開啟 Brave 說明中心</translation>
+<translation id="3166827708714933426">分頁與視窗快速鍵</translation>
+<translation id="3169981355900570544">Brave Software Brave 功能快速鍵</translation>
+<translation id="4558311620361989323">網頁快速鍵</translation>
+<translation id="1908301351964700579">Brave 仍在準備 VR 模組。請稍後再重新啟動 Brave。</translation>
+<translation id="8970887620466824814">發生錯誤。</translation>
+<translation id="1875543012935658554">重新開啟 Brave。</translation>
+<translation id="79859296434321399">如要查看擴增實境內容，請安裝 ARCore</translation>
+<translation id="8558485628462305855">如要查看擴增實境內容，請更新 ARCore</translation>
+<translation id="3513704683820682405">擴增實境</translation>
+<translation id="5475862044948910901">要啟動擴增實境工作階段嗎？</translation>
 <translation id="7365126855094612066">在這個工作階段期間，此網站可執行以下作業：
 • 為你的環境建立 3D 地圖
 • 追蹤相機的動作
 
 這個網站無法存取相機。只有你可以看見相機的顯示畫面。</translation>
-<translation id="7375125077091615385">類型：</translation>
-<translation id="7396940094317457632"><ph name="FILE_NAME" />。</translation>
-<translation id="7400418766976504921">網址</translation>
-<translation id="7403691278183511381">Chrome 初次使用體驗</translation>
-<translation id="741204030948306876">是，我要啟用</translation>
-<translation id="7413229368719586778">開始日期：<ph name="DATE" /></translation>
-<translation id="7423098979219808738">先詢問我</translation>
-<translation id="7423538860840206698">禁止讀取剪貼簿</translation>
-<translation id="7431991332293347422">控制 Google 使用瀏覽記錄提供個人化搜尋服務和其他內容的方式</translation>
-<translation id="7437998757836447326">登出 Chrome</translation>
-<translation id="7438641746574390233">開啟精簡模式後，Chrome 會使用 Google 伺服器來加快網頁載入速度。精簡模式會改寫載入速度特別慢的網頁，只載入基本內容。精簡模式不適用於無痕模式分頁。</translation>
-<translation id="7444811645081526538">更多類別</translation>
-<translation id="7445411102860286510">允許網站自動播放靜音的影片 (建議)</translation>
-<translation id="7453467225369441013">大多數網站都會將你登出，但系統並不會將你登出 Google 帳戶。</translation>
-<translation id="7454641608352164238">空間不足</translation>
-<translation id="7475192538862203634">如果您經常看到這個頁面，請嘗試這些<ph name="BEGIN_LINK" />建議<ph name="END_LINK" />。</translation>
-<translation id="7475688122056506577">找不到 SD 卡。部分檔案可能會遺失。</translation>
-<translation id="7479104141328977413">分頁管理</translation>
-<translation id="7481312909269577407">往前</translation>
-<translation id="7482656565088326534">預覽分頁</translation>
-<translation id="7493994139787901920"><ph name="VERSION" /> (上次更新時間：<ph name="TIME_SINCE_UPDATE" />)</translation>
-<translation id="7494974237137038751">(已節省的數據量)</translation>
-<translation id="7498271377022651285">請稍候…</translation>
-<translation id="7514365320538308">下載</translation>
-<translation id="751961395872307827">無法連線至網站</translation>
-<translation id="7521387064766892559">JavaScript</translation>
-<translation id="7542481630195938534">無法取得建議</translation>
-<translation id="7559975015014302720">精簡模式已關閉</translation>
-<translation id="7562080006725997899">正在清除瀏覽資料</translation>
-<translation id="756809126120519699">已清除 Chrome 資料</translation>
-<translation id="757524316907819857">禁止網站播放受保護的內容</translation>
-<translation id="757855969265046257">{FILES,plural, =1{已下載 <ph name="FILES_DOWNLOADED_ONE" /> 個檔案}other{已下載 <ph name="FILES_DOWNLOADED_MANY" /> 個檔案}}</translation>
-<translation id="7588219262685291874">在裝置開啟「節約耗電量」後啟用深色主題</translation>
-<translation id="7589445247086920869">禁止目前的搜尋引擎使用此權限</translation>
-<translation id="7593557518625677601">如要啟動 Chrome 同步功能，請開啟 Android 設定並重新啟用 Android 系統同步處理設定</translation>
-<translation id="7596558890252710462">作業系統</translation>
-<translation id="7605594153474022051">同步處理功能無法正常運作</translation>
-<translation id="7606077192958116810">精簡模式已開啟。你可「 設定」中管理這個模式。</translation>
-<translation id="7612619742409846846">已使用下列帳戶登入 Google：</translation>
-<translation id="7619072057915878432">無法連上網路，因此無法下載 <ph name="FILE_NAME" />。</translation>
-<translation id="7624880197989616768"><ph name="BEGIN_LINK1" />查看說明<ph name="END_LINK1" />或<ph name="BEGIN_LINK2" />重新掃描<ph name="END_LINK2" /></translation>
-<translation id="7626032353295482388">歡迎使用 Chrome</translation>
-<translation id="7638584964844754484">通關密語不正確</translation>
-<translation id="7641339528570811325">清除瀏覽資料…</translation>
-<translation id="7648422057306047504">使用 Google 憑證為密碼加密</translation>
-<translation id="7649070708921625228">說明</translation>
-<translation id="7658239707568436148">取消</translation>
-<translation id="7665369617277396874">新增帳戶</translation>
-<translation id="766587987807204883">文章會顯示在這裡，並可供離線閱讀</translation>
-<translation id="7682724950699840886">請嘗試按照下列提示操作：確認你的裝置上有足夠空間，然後嘗試重新匯出。</translation>
-<translation id="7685301384041462804">進入 VR 模式之前，請確認你信任這個網站。</translation>
-<translation id="7698359219371678927">在「<ph name="APP_NAME" />」中建立電子郵件</translation>
-<translation id="7704317875155739195">自動完成搜尋字詞與網址</translation>
-<translation id="7725024127233776428">加入書籤的頁面會顯示在這裡</translation>
-<translation id="773466115871691567">一律翻譯<ph name="SOURCE_LANGUAGE" />網頁</translation>
-<translation id="7746457520633464754">為了偵測危險的應用程式和網站，Chrome 會將你造訪的部分網頁網址、部分系統資訊以及部分網頁內容傳送給 Google</translation>
-<translation id="7757787379047923882">透過「<ph name="DEVICE_NAME" />」分享的文字</translation>
-<translation id="7762668264895820836">SD 卡 <ph name="SD_CARD_NUMBER" /></translation>
-<translation id="7764225426217299476">新增地址</translation>
-<translation id="7772032839648071052">確認通關密語</translation>
-<translation id="7772375229873196092">關閉 <ph name="APP_NAME" /></translation>
-<translation id="7774809984919390718">{PAYMENT_METHOD,plural, =1{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> 種付款方式}other{<ph name="PAYMENT_METHOD_PREVIEW" />\u2026 和另外 <ph name="NUMBER_OF_ADDITIONAL_PAYMENT_METHODS" /> 種付款方式}}</translation>
-<translation id="7781829728241885113">昨天</translation>
-<translation id="7791543448312431591">新增</translation>
-<translation id="780301667611848630">不用了，謝謝</translation>
-<translation id="7810647596859435254">選擇開啟工具…</translation>
-<translation id="7821588508402923572">你省下的數據流量會顯示在這裡</translation>
-<translation id="7837721118676387834">允許特定網站自動播放靜音的影片。</translation>
-<translation id="7846076177841592234">全部取消選取</translation>
-<translation id="784934925303690534">時間範圍</translation>
-<translation id="7851858861565204677">其他裝置</translation>
-<translation id="7875915731392087153">建立電子郵件</translation>
-<translation id="7876243839304621966">全部移除</translation>
-<translation id="7882131421121961860">找不到瀏覽記錄</translation>
-<translation id="7882806643839505685">允許特定網站播放音訊。</translation>
-<translation id="7886917304091689118">正在 Chrome 中執行</translation>
-<translation id="7925590027513907933">{FILE_COUNT,plural, =1{正在下載檔案。}other{正在下載 # 個檔案。}}</translation>
-<translation id="7929962904089429003">開啟選單</translation>
-<translation id="7942131818088350342"><ph name="PRODUCT_NAME" /> 版本過舊。</translation>
-<translation id="7947953824732555851">接受並登入</translation>
-<translation id="7963646190083259054">供應商：</translation>
-<translation id="7971136598759319605">上次使用時間：1 天前</translation>
-<translation id="7975379999046275268">預覽網頁 <ph name="BEGIN_NEW" />新功能<ph name="END_NEW" /></translation>
-<translation id="7981313251711023384">預先載入網頁，以加快瀏覽及搜尋速度</translation>
-<translation id="79859296434321399">如要查看擴增實境內容，請安裝 ARCore</translation>
-<translation id="7986741934819883144">選取聯絡人</translation>
-<translation id="7987073022710626672">Chrome 服務條款</translation>
-<translation id="7998918019931843664">重新開啟先前關閉的分頁</translation>
-<translation id="7999064672810608036">確定要刪除這個網站儲存的所有本機資料 (包括 Cookie 在內)，並重設這個網站的所有權限嗎？</translation>
-<translation id="8004582292198964060">瀏覽器</translation>
-<translation id="8007176423574883786">已在這個裝置上關閉</translation>
-<translation id="8013372441983637696">一併清除你在這個裝置上的 Chrome 資料</translation>
-<translation id="8015452622527143194">將網頁上的所有內容都回復為預設大小</translation>
-<translation id="802154636333426148">下載失敗</translation>
-<translation id="8026334261755873520">清除瀏覽資料</translation>
-<translation id="8035133914807600019">新資料夾…</translation>
-<translation id="8037750541064988519">還剩 <ph name="DAYS" /> 天</translation>
-<translation id="804335162455518893">找不到 SD 卡</translation>
-<translation id="805047784848435650">根據你的瀏覽記錄獨家推薦</translation>
-<translation id="8051695050440594747"><ph name="MEGABYTES" /> MB 可用空間</translation>
-<translation id="8058746566562539958">在新的 Chrome 分頁中開啟</translation>
-<translation id="8063895661287329888">無法加入書籤。</translation>
-<translation id="806745655614357130">分開保留我的資料</translation>
-<translation id="8067883171444229417">播放影片</translation>
-<translation id="8068648041423924542">無法選取憑證。</translation>
-<translation id="8073388330009372546">在新分頁中開啟圖片</translation>
-<translation id="8076492880354921740">分頁</translation>
-<translation id="8084114998886531721">已儲存的密碼</translation>
-<translation id="8087000398470557479">這個內容來自 <ph name="DOMAIN_NAME" />，由 Google 所提供。</translation>
-<translation id="8103578431304235997">無痕式分頁</translation>
-<translation id="8105893657415066307"><ph name="DESCRIPTION" /> <ph name="SEPARATOR" /> <ph name="FILE_SIZE" /></translation>
-<translation id="8109613176066109935">如要將書籤同步到所有裝置，請開啟同步處理功能</translation>
-<translation id="8110087112193408731">要在數位健康中顯示你的 Chrome 活動記錄嗎？</translation>
-<translation id="8116925261070264013">已設為靜音</translation>
-<translation id="813082847718468539">查看網站資訊</translation>
-<translation id="8131740175452115882">確認</translation>
-<translation id="8156139159503939589">你看得懂哪些語言？</translation>
-<translation id="8168435359814927499">內容</translation>
-<translation id="8186512483418048923">還剩 <ph name="FILES" /> 個檔案</translation>
-<translation id="8190358571722158785">還剩 1 天</translation>
-<translation id="8200772114523450471">繼續</translation>
-<translation id="8209050860603202033">開啟圖片</translation>
-<translation id="8218622182176210845">管理你的帳戶</translation>
-<translation id="8224471946457685718">透過 Wi-Fi 下載為你推薦的文章</translation>
-<translation id="8232956427053453090">保留資料</translation>
-<translation id="8249310407154411074">移至頂端</translation>
-<translation id="8250920743982581267">文件</translation>
-<translation id="825412236959742607">這個網頁使用了過多記憶體，因此 Chrome 移除了部分內容。</translation>
-<translation id="8260126382462817229">請嘗試重新登入</translation>
-<translation id="8261506727792406068">刪除</translation>
-<translation id="8266862848225348053">下載位置</translation>
-<translation id="8274165955039650276">查看已下載的內容</translation>
-<translation id="8284326494547611709">字幕</translation>
-<translation id="8300705686683892304">由應用程式管理</translation>
-<translation id="8310344678080805313">標準分頁</translation>
-<translation id="8316092324682955408"><ph name="DOMAIN_NAME" /> 和其他網站</translation>
-<translation id="8327155640814342956">為獲得最佳瀏覽體驗，請開啟 Chrome 進行更新</translation>
-<translation id="8339163506404995330">系統將不會翻譯<ph name="LANGUAGE" />網頁</translation>
-<translation id="8349013245300336738">依使用資料量排序</translation>
-<translation id="8364299278605033898">查看熱門網站</translation>
-<translation id="8368027906805972958">不明或不支援的裝置 (<ph name="DEVICE_ID" />)</translation>
-<translation id="8372893542064058268">允許特定網站執行背景同步處理作業。</translation>
-<translation id="8378714024927312812">由貴機構管理</translation>
-<translation id="8380167699614421159">這個網站會顯示干擾性或誤導性的廣告</translation>
-<translation id="8393700583063109961">傳送訊息</translation>
-<translation id="8413126021676339697">顯示完整記錄</translation>
-<translation id="8427875596167638501">已在畫面下半部顯示預覽分頁</translation>
-<translation id="8428213095426709021">設定</translation>
-<translation id="8438566539970814960">改善搜尋和瀏覽體驗</translation>
-<translation id="8441146129660941386">倒轉到特定的播放時間點</translation>
-<translation id="8443209985646068659">無法更新 Chrome</translation>
-<translation id="8445448999790540984">無法匯出密碼</translation>
-<translation id="8447861592752582886">撤銷裝置權限</translation>
-<translation id="8461694314515752532">使用你自己的同步通關密語，加密保護同步資料</translation>
-<translation id="8466613982764129868">請確認「<ph name="TARGET_DEVICE_NAME" />」已連上網際網路</translation>
-<translation id="8485434340281759656"><ph name="FILE_SIZE" /> <ph name="SEPARATOR" /> <ph name="DESCRIPTION" /></translation>
-<translation id="8487700953926739672">可離線使用</translation>
-<translation id="8489271220582375723">開啟記錄頁面</translation>
-<translation id="8493948351860045254">釋出空間</translation>
-<translation id="8497726226069778601">目前還沒有任何常用網頁…</translation>
-<translation id="8503559462189395349">Chrome 密碼</translation>
-<translation id="8503813439785031346">使用者名稱</translation>
-<translation id="8514477925623180633">將使用 Chrome 儲存的密碼匯出</translation>
-<translation id="8514577642972634246">進入無痕模式</translation>
-<translation id="851751545965956758">禁止網站連線至裝置</translation>
-<translation id="8523928698583292556">刪除已儲存的密碼</translation>
-<translation id="854522910157234410">開啟以下網頁</translation>
-<translation id="8558485628462305855">如要查看擴增實境內容，請更新 ARCore</translation>
-<translation id="8559990750235505898">詢問是否將網頁內容翻譯成其他語言</translation>
-<translation id="8562452229998620586">已儲存的密碼會顯示在這裡。</translation>
-<translation id="8569404424186215731">(<ph name="DATE" />起)</translation>
-<translation id="8571213806525832805">過去 4 週</translation>
-<translation id="857943718398505171">已允許 (建議)</translation>
-<translation id="8583805026567836021">正在清除帳戶資料</translation>
-<translation id="860043288473659153">持卡人姓名</translation>
-<translation id="8609465669617005112">上移</translation>
-<translation id="8616006591992756292">你的 Google 帳戶可能會儲存其他形式的瀏覽記錄，請參閱 <ph name="BEGIN_LINK" />myactivity.google.com<ph name="END_LINK" />。</translation>
-<translation id="8617240290563765734">開啟這項下載內容中指定的建議網址？</translation>
-<translation id="8636825310635137004">如要存取您在其他裝置上開啟的分頁，請開啟同步處理功能。</translation>
-<translation id="8641930654639604085">嘗試封鎖成人網站</translation>
-<translation id="8655129584991699539">你可以在 Chrome 設定中清除資料</translation>
-<translation id="8662811608048051533">大多數網站都會將你登出。</translation>
-<translation id="8664979001105139458">檔案名稱已存在</translation>
-<translation id="8676374126336081632">清除輸入</translation>
-<translation id="8687353297350450808">{N_BARS,plural, =1{訊號強度等級：# 格}other{訊號強度等級：# 格}}</translation>
-<translation id="868929229000858085">搜尋聯絡人</translation>
-<translation id="869891660844655955">到期日</translation>
-<translation id="8719023831149562936">無法傳輸目前的分頁</translation>
-<translation id="8725066075913043281">再試一次</translation>
-<translation id="8728487861892616501">使用這個應用程式即表示您同意接受 Chrome 的《<ph name="BEGIN_LINK1" />服務條款<ph name="END_LINK1" />》和《<ph name="BEGIN_LINK2" />隱私權聲明<ph name="END_LINK2" />》，以及《<ph name="BEGIN_LINK3" />透過 Family Link 管理的 Google 帳戶所適用的隱私權聲明<ph name="END_LINK3" />》。</translation>
-<translation id="8730621377337864115">完成</translation>
-<translation id="8748850008226585750">內容已隱藏</translation>
-<translation id="8751914237388039244">選取圖片</translation>
-<translation id="8788265440806329501">瀏覽記錄已關閉</translation>
-<translation id="8788968922598763114">重新開啟最近關閉的分頁</translation>
-<translation id="8801436777607969138">封鎖特定網站的 JavaScript。</translation>
-<translation id="8812260976093120287">在部分網站上，你可以在你的裝置上使用上述支援的付款應用程式付款。</translation>
-<translation id="8816026460808729765">禁止網站存取感應器</translation>
-<translation id="8816439037877937734">「<ph name="APP_NAME" />」將在 Chrome 中開啟。繼續操作即表示您同意接受 Chrome 的《<ph name="BEGIN_LINK1" />服務條款<ph name="END_LINK1" />》和《<ph name="BEGIN_LINK2" />隱私權聲明<ph name="END_LINK2" />》，以及《<ph name="BEGIN_LINK3" />透過 Family Link 管理的 Google 帳戶所適用的隱私權聲明<ph name="END_LINK3" />》。</translation>
-<translation id="8820817407110198400">書籤</translation>
-<translation id="8833831881926404480">有某個網站正在共用你的螢幕畫面</translation>
-<translation id="883806473910249246">下載這項內容時發生錯誤。</translation>
-<translation id="8840953339110955557">這個網頁可能會和線上版本有所不同。</translation>
-<translation id="8847988622838149491">USB</translation>
-<translation id="8853345339104747198"><ph name="TAB_TITLE" /> (分頁)</translation>
-<translation id="885701979325669005">儲存空間</translation>
-<translation id="889338405075704026">前往 Chrome 設定</translation>
-<translation id="8901170036886848654">找不到符合條件的書籤</translation>
-<translation id="8909135823018751308">分享…</translation>
-<translation id="8912362522468806198">Google 帳戶</translation>
-<translation id="8920114477895755567">尚未取得家長詳細資料。</translation>
+<translation id="1188239144602654184">啟動 AR</translation>
+<translation id="473775607612524610">更新</translation>
+<translation id="3133489217401741157">正在為 Brave 安裝 <ph name="MODULE"/>…</translation>
+<translation id="1791662854739702043">安裝位置</translation>
+<translation id="5131234170665854056">無法為 Brave 安裝 <ph name="MODULE"/></translation>
+<translation id="2567385386134582609">圖片</translation>
+<translation id="6395288395575013217">連結</translation>
+<translation id="7352939065658542140">影片</translation>
+<translation id="4116038641877404294">下載網頁以便離線存取</translation>
 <translation id="8922289737868596582">透過「更多選項」按鈕下載網頁，以便離線存取</translation>
-<translation id="8937772741022875483">要將你的 Chrome 活動記錄從數位健康中移除嗎？</translation>
-<translation id="8941729603749328384">www.example.com</translation>
-<translation id="8942627711005830162">在其他視窗中開啟</translation>
-<translation id="8951232171465285730">Chrome 為你節省了 <ph name="MEGABYTES" /> MB</translation>
-<translation id="8958424370300090006">封鎖特定網站的 Cookie。</translation>
-<translation id="8959122750345127698">瀏覽的網址無法存取：<ph name="URL" /></translation>
-<translation id="8965591936373831584">正在等待下載</translation>
-<translation id="8970887620466824814">發生錯誤。</translation>
-<translation id="8972098258593396643">要下載至預設資料夾嗎？</translation>
-<translation id="8986494364107987395">自動傳送使用統計資料及當機報告給 Google</translation>
-<translation id="8993760627012879038">在無痕模式下開啟新分頁</translation>
-<translation id="8998729206196772491">您即將使用由 <ph name="MANAGED_DOMAIN" /> 所管理的帳戶登入，並授權該網域的管理員控管您的 Chrome 資料。您的資料會與這個帳戶建立永久連結。登出 Chrome 後，系統會將您的資料從這個裝置上刪除，但繼續保留在您的 Google 帳戶中。</translation>
-<translation id="9019902583201351841">你的家長已停用這項功能</translation>
-<translation id="9028914725102941583">開啟同步功能即可將內容分享至其他裝置</translation>
-<translation id="9029323097866369874">要允許 <ph name="DOMAIN" /> 進入 VR 模式嗎？</translation>
-<translation id="9040142327097499898">允許顯示通知。這部裝置的定位功能已關閉。</translation>
-<translation id="9041669420854607037">{FILE_COUNT,plural, =1{# 部影片}other{# 部影片}}</translation>
-<translation id="9050666287014529139">通關密語</translation>
-<translation id="9063523880881406963">關閉「要求電腦版網站」</translation>
-<translation id="9065203028668620118">編輯</translation>
-<translation id="9070377983101773829">開始語音搜尋</translation>
-<translation id="9074336505530349563">如要取得個人化的 Google 推薦內容，請登入並開啟同步處理功能</translation>
-<translation id="9086455579313502267">無法存取網路</translation>
-<translation id="9100505651305367705">詢問是否以簡易模式顯示支援這項功能的文章</translation>
-<translation id="9100610230175265781">請提供通關密語</translation>
-<translation id="9102803872260866941">預覽分頁已開啟</translation>
+<translation id="5958275228015807058">前往「下載」主畫面尋找你的檔案和網頁</translation>
+<translation id="5620928963363755975">透過「更多選項」按鈕前往「下載」主畫面尋找你的檔案和網頁</translation>
+<translation id="3341058695485821946">查看節省的數據用量</translation>
+<translation id="3157842584138209013">如要查看節省的數據用量，請點選 [更多選項] 按鈕</translation>
+<translation id="8218622182176210845">管理你的帳戶</translation>
+<translation id="8090895580117672212">如要管理你的 Brave Software 帳戶，請輕觸 [管理帳戶] 按鈕</translation>
+<translation id="8856898588039823173">由 Brave Software 提供的精簡版網頁。輕觸即可載入原始網頁。</translation>
+<translation id="8134317863207426198">由 Brave Software 提供的精簡版網頁。輕觸 [載入原始頁面] 按鈕即可載入原始頁面。</translation>
+<translation id="4961107849584082341">將這個網頁翻譯成任何語言</translation>
+<translation id="569536719314091526">透過 [更多選項] 按鈕將這個網頁翻譯成任何語言</translation>
+<translation id="1397811292916898096">使用 <ph name="PRODUCT_NAME"/> 搜尋</translation>
+<translation id="1792959175193046959">你隨時可以變更預設的下載位置</translation>
+<translation id="6942665639005891494">你隨時可以使用 [設定] 選單選項變更預設的下載位置</translation>
+<translation id="6850409657436465440">下載作業仍在進行中</translation>
+<translation id="5817715962196959877">Brave 現在的檔案下載速度更快了</translation>
+<translation id="3976396876660209797">移除這個捷徑後再重新建立</translation>
+<translation id="6766622839693428701">向下滑動即可關閉。</translation>
+<translation id="1028699632127661925">正在傳送到「<ph name="DEVICE_NAME"/>」...</translation>
+<translation id="1303507811548703290"><ph name="DOMAIN"/> - 來自 <ph name="DEVICE_NAME"/></translation>
+<translation id="5357811892247919462">已收到分頁</translation>
 <translation id="9104217018994036254">要共用分頁的裝置清單。</translation>
-<translation id="9133397713400217035">離線探索</translation>
-<translation id="9133703968756164531"><ph name="ITEM_NAME" /> (<ph name="ITEM_ID" />)</translation>
-<translation id="9137013805542155359">顯示原文</translation>
-<translation id="9139068048179869749">允許網站傳送通知前，必須先詢問你 (建議)</translation>
-<translation id="9139318394846604261">購物</translation>
-<translation id="9155898266292537608">快速輕觸字詞也可以展開搜尋</translation>
-<translation id="9169507124922466868">已在畫面下半部顯示瀏覽記錄</translation>
-<translation id="9204836675896933765">還剩 1 個檔案</translation>
-<translation id="9206873250291191720">A</translation>
+<translation id="6767294960381293877">要共用分頁的裝置清單已開啟，顯示在畫面下半部。</translation>
+<translation id="2904414404539560095">要共用分頁的裝置清單已開啟，顯示於整個畫面。</translation>
+<translation id="4135200667068010335">要共用分頁的裝置清單已關閉。</translation>
+<translation id="5292796745632149097">傳送到</translation>
+<translation id="1386674309198842382">上次使用時間：<ph name="LAST_UPDATED"/> 天前</translation>
+<translation id="7971136598759319605">上次使用時間：1 天前</translation>
+<translation id="1521774566618522728">上次使用時間：今天</translation>
+<translation id="3631987586758005671">正在分享至「<ph name="DEVICE_NAME"/>」</translation>
+<translation id="9028914725102941583">開啟同步功能即可將內容分享至其他裝置</translation>
+<translation id="6162454065885854378">如要將手機上的內容分享至另一台裝置，你必須在這兩台裝置的 Brave 設定中開啟同步功能</translation>
+<translation id="6084271560289605378">前往 Brave 設定</translation>
+<translation id="2318045970523081853">輕觸即可撥打電話</translation>
 <translation id="9209888181064652401">無法撥打電話</translation>
-<translation id="9219103736887031265">圖片</translation>
-<translation id="926205370408745186">將你的 Chrome 活動記錄從數位健康中移除</translation>
-<translation id="932327136139879170">首頁</translation>
-<translation id="938850635132480979">錯誤：<ph name="ERROR_CODE" /></translation>
-<translation id="945632385593298557">存取您的麥克風</translation>
-<translation id="95817756606698420">Chrome 可以在中國使用 <ph name="BEGIN_BOLD" />Sogou<ph name="END_BOLD" /> 搜尋。你可以在<ph name="BEGIN_LINK" />設定<ph name="END_LINK" />中變更這項設定。</translation>
-<translation id="965817943346481315">封鎖干擾性或誤導性的網站廣告 (建議)</translation>
-<translation id="968900484120156207">你曾造訪的頁面會顯示在這裡</translation>
-<translation id="970715775301869095">還剩 <ph name="MINUTES" /> 分鐘</translation>
-<translation id="974555521953189084">如要開始同步處理，請輸入你的通關密語</translation>
-<translation id="981121421437150478">離線</translation>
-<translation id="982182592107339124">這會清除所有網站的資料，包括：</translation>
-<translation id="983192555821071799">關閉所有分頁</translation>
-<translation id="987264212798334818">一般</translation>
+<translation id="2860954141821109167">請確認此裝置已啟用手機應用程式</translation>
+<translation id="2067805253194386918">文字</translation>
+<translation id="1450753235335490080">無法分享<ph name="CONTENT_TYPE"/></translation>
+<translation id="1266864766717917324">無法分享<ph name="CONTENT_TYPE"/></translation>
+<translation id="8287068819750208230">請確認「<ph name="TARGET_DEVICE_NAME"/>」的 Brave 同步功能已開啟</translation>
+<translation id="3016635187733453316">請確認此裝置已連上網際網路</translation>
+<translation id="8466613982764129868">請確認「<ph name="TARGET_DEVICE_NAME"/>」已連上網際網路</translation>
+<translation id="6539092367496845964">發生錯誤，請稍後再試。</translation>
+<translation id="3389286852084373014">文字過多</translation>
+<translation id="2100314319871056947">請嘗試將要分享的文字分成多個片段</translation>
+<translation id="2987620471460279764">從其他裝置分享的文字</translation>
+<translation id="7757787379047923882">透過「<ph name="DEVICE_NAME"/>」分享的文字</translation>
+<translation id="5193988420012215838">已複製到剪貼簿</translation>
+<translation id="4696983787092045100">將文字傳送到你的裝置</translation>
+<translation id="1260236875608242557">搜尋及探索</translation>
+<translation id="6369229450655021117">在這裡，你可以搜尋網路、與好友分享內容及查看開啟的網頁</translation>
+<translation id="723171743924126238">選取圖片</translation>
+<translation id="8751914237388039244">選取圖片</translation>
+<translation id="1989112275319619282">瀏覽</translation>
+<translation id="7055152154916055070">已禁止重新導向：</translation>
+<translation id="5524843473235508879">已禁止重新導向。</translation>
+<translation id="6573096386450695060">一律允許</translation>
+<translation id="5805364706385912897">這個網頁使用了過多記憶體，因此遭到 Brave 暫停。</translation>
+<translation id="5138664332909611586">這個網頁使用了過多記憶體，因此 Brave 移除了部分內容。</translation>
+<translation id="9137013805542155359">顯示原文</translation>
+<translation id="6361779936989026201">Brave 版 Brave Software 助理</translation>
+<translation id="7291387454912369099">Brave Software 助理自動填入功能</translation>
+<translation id="4565206163201411670">要在數位健康中顯示你的 Brave 活動記錄嗎？</translation>
+<translation id="9055113864158719823">你可以查看自己透過 Brave 造訪的網站，並對這些網站設定計時器。\n\nBrave Software 會收到這些設有計時器的網站相關資訊以及你的造訪時間長度。這些資訊可協助我們改善數位健康。</translation>
+<translation id="4596514158372210596">將你的 Brave 活動記錄從數位健康中移除</translation>
+<translation id="1174893863889683998">要將你的 Brave 活動記錄從數位健康中移除嗎？</translation>
+<translation id="708829030563435351">數位健康將不會顯示你透過 Brave 造訪的網站。所有網站計時器也將遭到刪除。</translation>
+<translation id="2056878612599315956">網站已暫停</translation>
+<translation id="671481426037969117">「<ph name="FQDN"/>」計時器已結束計時，將於明天重新開始。</translation>
+<translation id="7479104141328977413">分頁管理</translation>
+<translation id="3524138585025253783">開發人員 UI</translation>
+<translation id="6036057147555329831">其他 ICU</translation>
+<translation id="9029323097866369874">要允許 <ph name="DOMAIN"/> 進入 VR 模式嗎？</translation>
+<translation id="7685301384041462804">進入 VR 模式之前，請確認你信任這個網站。</translation>
+<translation id="5033865233969348410">當你處於 VR 模式時，這個網站可能會取得以下資訊：
+  -  你的身體特徵，例如身高
+
+進入 VR 模式之前，請確認你信任這個網站。</translation>
+<translation id="5534334044554683961">當你處於 VR 模式時，這個網站可能會取得以下資訊：
+  -   你的身體特徵，例如身高
+  -   你的房間配置
+
+進入 VR 模式之前，請確認你信任這個網站。.</translation>
+<translation id="4169535189173047238">不允許</translation>
+<translation id="2170088579611075216">允許並進入 VR</translation>
 </translationbundle>

--- a/script/lib/transifex.py
+++ b/script/lib/transifex.py
@@ -261,6 +261,7 @@ def get_fingerprint_for_xtb(message_tag):
     # To avoid negative ids we strip the high-order bit
     return str(fp & 0x7fffffffffffffffL)
 
+
 def is_translateable_string(grd_file_path, message_tag):
     if message_tag.get('translateable') != 'false':
         return True
@@ -283,6 +284,7 @@ def is_translateable_string(grd_file_path, message_tag):
         if message_tag.get('name') in exceptions:
             return True
     return False
+
 
 def get_grd_strings(grd_file_path):
     """Obtains a tubple of (name, value, FP) for each string in a GRD file"""
@@ -387,6 +389,7 @@ def get_xtb_files(grd_file_path):
 
 def get_original_grd(src_root, grd_file_path):
     """Obtains the Chromium GRD file for a specified Brave GRD file."""
+    # TODO: consider passing this mapping into the script from l10nUtil.js
     grd_file_name = os.path.basename(grd_file_path)
     if grd_file_name == 'components_brave_strings.grd':
         return os.path.join(src_root, 'components',
@@ -396,6 +399,9 @@ def get_original_grd(src_root, grd_file_path):
     elif grd_file_name == 'generated_resources.grd':
         return os.path.join(src_root, 'chrome', 'app',
                             'generated_resources.grd')
+    elif grd_file_name == 'android_chrome_strings.grd':
+        return os.path.join(src_root, 'chrome', 'android', 'java', 'strings',
+                            'android_chrome_strings.grd')
 
 
 def check_for_chromium_upgrade_extra_langs(src_root, grd_file_path):
@@ -515,7 +521,7 @@ def upload_missing_translations_to_transifex(source_string_path, lang_code,
                                              chromium_grd_strings, xtb_strings,
                                              chromium_xtb_strings):
     """For each chromium translation that we don't know about, upload it."""
-    lang_code = lang_code.replace('-', '_')
+    lang_code = lang_code.replace('-', '_').replace('iw', 'he')
     for idx, (string_name, string_value,
               string_fp, desc) in enumerate(grd_strings):
         string_fp = str(string_fp)


### PR DESCRIPTION
Fixes brave/brave-browser#7378

- Updated transifex.py with the missing mapping of
  android_chrome_strings which is needed to upload existing
  translations to Transifex.

- Deleted existing XTB files under brave, pushed to Transifex
  so that the existing translations were uploaded.

- Ran npm run delete_string_translations for strings containing
  incorrect translations of private -> incognito. The corrected
  translations will be ordered separately.

- Pulled translations from Transifex which resulted in the changes in
  XTBs in this commit.

- Lint fixes in transifex.py

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/brave-browser/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- Verified that these changes build without errors on
  - [x] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- Verified that these changes pass automated tests (unit, browser, security tests) on
  - [ ] iOS
  - [ ] Linux
  - [ ] macOS
  - [x] Windows
- [ ] Verified that all lint errors/warnings are resolved (`npm run lint`)
- [ ] Ran `git rebase master` (if needed).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request as needed.
- [ ] Request a security/privacy review as needed.
- [x] Add appropriate QA labels (QA/Yes or QA/No) to include the closed issue in milestone
- [ ] Public documentation has been updated as necessary. For instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protection-Mode
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-compatibility-issues-with-tracking-protection
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide

## Test Plan:


## Reviewer Checklist:

- [ ] New files have MPL-2.0 license header.
- [ ] Request a security/privacy review as needed.
- [ ] Adequate test coverage exists to prevent regressions 
- [ ] Verify test plan is specified in PR before merging to source

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on.
- [ ] All relevant documentation has been updated.
